### PR TITLE
Audit: fix sorry mismatches in 12 proofs, demote erdos-1092

### DIFF
--- a/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Archimedes (c. 250 BCE), formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Approximations_of_%CF%80#Archimedes",
     "date": "-250",
-    "status": "formalized",
+    "status": "verified",
     "tags": [
       "geometry",
       "analysis",
@@ -18,8 +18,8 @@
       "research"
     ],
     "proofRepoPath": "Proofs/AreaOfCircleOQ03OQ02.lean",
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "original",
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Real.sin_lt",

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -32,8 +32,8 @@
       "issues": []
     },
     "area-of-circle-oq-03-oq-02": {
-      "auditCount": 3,
-      "lastAudited": "2026-03-29T10:25:22Z",
+      "auditCount": 4,
+      "lastAudited": "2026-03-30T02:57:37Z",
       "result": "issues-fixed",
       "issues": []
     },
@@ -86,8 +86,8 @@
       "issues": []
     },
     "ballot-problem-oq-01-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-03-29T10:25:22Z",
+      "auditCount": 4,
+      "lastAudited": "2026-03-30T02:57:37Z",
       "result": "issues-fixed",
       "issues": []
     },
@@ -188,8 +188,8 @@
       "issues": []
     },
     "bezout-identity-oq-02-oq-02-oq-01-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-03-29T10:25:22Z",
+      "auditCount": 4,
+      "lastAudited": "2026-03-30T02:57:37Z",
       "result": "issues-fixed",
       "issues": []
     },
@@ -284,8 +284,8 @@
       "issues": []
     },
     "buffons-needle-oq-01-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-03-24T08:32:20Z",
+      "auditCount": 4,
+      "lastAudited": "2026-03-30T02:57:36Z",
       "result": "issues-fixed",
       "issues": []
     },
@@ -380,8 +380,8 @@
       "issues": []
     },
     "cayley-hamilton-minpoly-oq-05-oq-01": {
-      "auditCount": 5,
-      "lastAudited": "2026-03-29T10:25:23Z",
+      "auditCount": 6,
+      "lastAudited": "2026-03-30T02:57:38Z",
       "result": "issues-fixed",
       "issues": []
     },
@@ -476,8 +476,8 @@
       "issues": []
     },
     "derangements-oq-02": {
-      "auditCount": 3,
-      "lastAudited": "2026-03-29T10:25:22Z",
+      "auditCount": 4,
+      "lastAudited": "2026-03-30T02:57:37Z",
       "result": "issues-fixed",
       "issues": []
     },
@@ -572,8 +572,8 @@
       "issues": []
     },
     "erdos-1006-oq-02-oq-03": {
-      "auditCount": 4,
-      "lastAudited": "2026-03-29T10:25:22Z",
+      "auditCount": 5,
+      "lastAudited": "2026-03-30T02:57:37Z",
       "result": "issues-fixed",
       "issues": []
     },
@@ -842,9 +842,9 @@
       "issues": []
     },
     "schauder-fixed-point-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-03-24T17:12:44Z",
-      "result": "clean",
+      "auditCount": 4,
+      "lastAudited": "2026-03-30T02:57:37Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "yang-mills-2d": {
@@ -2699,9 +2699,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-1092": {
-      "lastAudited": "2026-03-29T05:52:10Z",
-      "auditCount": 2,
-      "result": "issues-fixed",
+      "lastAudited": "2026-03-30T02:53:33Z",
+      "auditCount": 3,
+      "result": "issues-found",
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-1093": {
@@ -7513,9 +7513,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-866": {
-      "lastAudited": "2026-03-29T12:57:51Z",
-      "auditCount": 2,
-      "result": "issues-found",
+      "lastAudited": "2026-03-30T03:00:28Z",
+      "auditCount": 3,
+      "result": "issues-fixed",
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-867": {
@@ -9333,8 +9333,8 @@
       "issues": []
     },
     "dirichlets-theorem-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-03-29T10:25:23Z",
+      "auditCount": 3,
+      "lastAudited": "2026-03-30T02:57:37Z",
       "result": "issues-fixed",
       "issues": []
     },
@@ -9843,9 +9843,9 @@
       "issues": []
     },
     "cramers-rule-oq-01-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-29T13:49:29Z",
-      "result": "issues-found",
+      "auditCount": 2,
+      "lastAudited": "2026-03-30T03:00:29Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "erdos-485-oq-02": {

--- a/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
@@ -19,7 +19,7 @@
       "research"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Finset.max'_mem",
@@ -66,7 +66,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 130,
-    "assumptions": "Fully verified: 0 axioms, 0 sorries remain.",
+    "assumptions": "0 axioms, 0 sorries. 2 trivial placeholder theorems (1+1=2) remain for cycle_lemma_lower_bound_via_ivt and rightmost_is_good_sketch.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Euclid; formalized here",
     "sourceUrl": "https://en.wikipedia.org/wiki/Euclid%27s_lemma",
     "date": "~300 BCE",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
     "tags": [
       "number-theory",
@@ -15,8 +15,8 @@
       "algorithms",
       "research"
     ],
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "original",
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Int.mul_ediv_cancel'",

--- a/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
@@ -21,7 +21,7 @@
       "open-question-resolved"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "intervalIntegral.integral_comp_add_right",

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Nonderogatory_matrix",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean",
     "tags": [
       "linear-algebra",
@@ -17,8 +17,8 @@
       "union-avoidance",
       "research"
     ],
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "original",
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "minpoly.aeval",
@@ -186,7 +186,7 @@
   },
   "sorryCount": 0,
   "status": "verified",
-  "badge": "verified",
+  "badge": "original",
   "leanFile": {
     "imports": [
       "Mathlib"

--- a/src/data/proofs/cramers-rule-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Gabriel Cramer (1750); Carl Friedrich Gauss",
     "sourceUrl": "https://en.wikipedia.org/wiki/Cramer%27s_rule#Complexity",
     "date": "1750/1800s",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CramersRuleOQ01OQ03.lean",
     "tags": [
       "linear-algebra",
@@ -18,10 +18,10 @@
       "research",
       "open-problem"
     ],
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "original",
+    "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "0 axiom declarations, 0 sorries remain. All definitions and key theorems are fully proved including gaussian_cubic_bound (O(n³) bound via term-by-term bounding).",
+    "assumptions": "0 axiom declarations, 0 sorries. All definitions and key theorems are fully proved including gaussian_cubic_bound (O(n³) bound via term-by-term bounding) and factorial_ge_cube (n! >= n³ for n >= 6).",
     "lineCount": 228
   },
   "overview": {
@@ -86,7 +86,7 @@
     "summary": "Formalizes the complexity gap between Cramer's Rule and Gaussian elimination. The key result is the fully proved factorial_ge_cube (n! ≥ n³ for n ≥ 6), along with exact operation counts for small n demonstrating the practical crossover.",
     "implications": "The formalization shows that while Cramer's Rule is theoretically beautiful (closed-form, connection to adjugate/Cayley-Hamilton), it is computationally impractical for systems larger than about 4×4.",
     "openQuestions": [
-      "Can the Gaussian elimination bound be proved without sorry?",
+      "Can the cramer_exceeds_gaussian comparison theorem be formalized directly?",
       "What is the exact crossover point where Gaussian beats Cramer?",
       "Can LU decomposition operation counts be formalized similarly?"
     ]
@@ -143,7 +143,7 @@
     "axiomCount": 0,
     "theoremCount": 13,
     "substantiveTheoremCount": 10,
-    "sorryTheorems": 1,
+    "sorryTheorems": 0,
     "definitionCount": 11,
     "mainTheorems": [
       {
@@ -158,7 +158,7 @@
       },
       {
         "name": "gaussian_cubic_bound",
-        "type": "sorry",
+        "type": "proved",
         "description": "Gaussian elimination is O(n³)"
       }
     ]

--- a/src/data/proofs/derangements-oq-02/meta.json
+++ b/src/data/proofs/derangements-oq-02/meta.json
@@ -7,10 +7,10 @@
     "author": "Classical combinatorics; formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Derangement#Generalizations",
     "date": "classical",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/DerangementsOQ02.lean",
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "original",
+    "sorries": 0,
     "tags": [
       "combinatorics",
       "permutations",

--- a/src/data/proofs/dirichlets-theorem-oq-02/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Classical (Euclid-style argument)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Dirichlet%27s_theorem_on_arithmetic_progressions#Special_cases",
     "date": "classical",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/DirichletsTheoremOQ02.lean",
     "tags": [
       "number-theory",
@@ -18,8 +18,8 @@
       "elementary",
       "research"
     ],
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "original",
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Nat.exists_prime_and_dvd",

--- a/src/data/proofs/erdos-1006-oq-02-oq-03/meta.json
+++ b/src/data/proofs/erdos-1006-oq-02-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research Agent",
     "sourceUrl": "https://erdosproblems.com/1006",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos1006OQ03.lean",
     "tags": [
       "erdos",
@@ -19,8 +19,8 @@
       "coloring",
       "research"
     ],
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "original",
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "SimpleGraph.Coloring",

--- a/src/data/proofs/erdos-1092/meta.json
+++ b/src/data/proofs/erdos-1092/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős–Hajnal–Szemerédi",
     "sourceUrl": "https://erdosproblems.com/1092",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1092Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "extremal-graph-theory",
       "open"
     ],
-    "badge": "original",
+    "badge": "infrastructure",
     "sorries": 0,
     "erdosNumber": 1092,
     "erdosUrl": "https://erdosproblems.com/1092",

--- a/src/data/proofs/erdos-866/meta.json
+++ b/src/data/proofs/erdos-866/meta.json
@@ -18,7 +18,7 @@
       "erdos"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 0,
     "erdosNumber": 866,
     "erdosUrl": "https://erdosproblems.com/866",
     "erdosProblemStatus": "open",
@@ -55,7 +55,7 @@
     ],
     "axiomCount": 7,
     "lineCount": 285,
-    "assumptions": "7 axiom(s) and 3 sorry(s). Aristotle proved upperExponent_increasing, oddNumbers_card, oddNumbers_no_triple. Remaining: g definition existence, g3_lower_bound, g3_ge_1."
+    "assumptions": "7 axiom(s) encoding known results (g₃=2, g₄ bounded, g₅≍log N, g₆≍√N, general upper/lower bounds). All supporting lemmas proved by Aristotle: upperExponent_increasing, oddNumbers_card, oddNumbers_no_triple."
   },
   "overview": {
     "historicalContext": "Erdős Problem #866 originates from the work of Choi, Erdős, and Szemerédi on sumsets and additive combinatorics, building on their unpublished manuscript 'On sums and products of integers.' The problem asks: how large must a subset A of {1,...,2N} be to guarantee that some k integers have all their pairwise sums in A?\n\nThe foundational observation is the odd numbers construction: the set {1, 3, 5, ..., 2N-1} has N elements but avoids all pairwise sums (since odd + odd = even). This shows the threshold must be at least 1 above N. For k=3, the exact answer is g₃(N) = 2, proved via a complementary pairs pigeonhole argument.\n\nThe most striking feature is the phase transition as k increases: g₃ = 2 (constant), g₄ ≤ 2032 (bounded constant, van Doorn), g₅ ≍ log N (logarithmic), g₆ ≍ √N (polynomial). The general upper bound g_k(N) ≪ N^{1-2^{-k}} (Choi–Erdős–Szemerédi) shows the exponent approaches 1 geometrically, while the lower bound g_k(N) > N^{1-ε} for large k shows the threshold eventually approaches N.\n\nThis growth rate transition—from constant through logarithmic and polynomial to nearly linear—is rare in combinatorics and reflects deep structural changes in the extremal problem. The gap between upper and lower bounds for intermediate and large k remains one of the central open questions in additive combinatorics.",
@@ -79,18 +79,18 @@
     {
       "id": "basic-definitions",
       "title": "Basic Definitions",
-      "summary": "Defines Interval(N) = {1,...,2N}, HasAllPairwiseSums via Fin k → ℤ witnesses, PairwiseSumCondition as the universal threshold statement, and g(k,N) via Nat.find with a sorry for the vacuous existence argument.",
+      "summary": "Defines Interval(N) = {1,...,2N}, HasAllPairwiseSums via Fin k → ℤ witnesses, PairwiseSumCondition as the universal threshold statement, and g(k,N) via Nat.find.",
       "startLine": 41,
       "endLine": 66,
-      "mathContext": "Defines Interval(N) = {1,...,2N}, HasAllPairwiseSums via Fin k → ℤ witnesses, PairwiseSumCondition as the universal threshold statement, and g(k,N) via Nat.find with a sorry for the vacuous existence argument."
+      "mathContext": "Defines Interval(N) = {1,...,2N}, HasAllPairwiseSums via Fin k → ℤ witnesses, PairwiseSumCondition as the universal threshold statement, and g(k,N) via Nat.find."
     },
     {
       "id": "case-k3",
       "title": "Case k=3",
-      "summary": "Axiomatizes g₃(N) = 2 (Choi–Erdős–Szemerédi). The lower bound g₃ ≥ 2 from odd numbers has a sorry requiring the parity-pigeonhole argument that two of three integers share parity.",
+      "summary": "Axiomatizes g₃(N) = 2 (Choi–Erdős–Szemerédi). The lower bound g₃ ≥ 2 follows from the odd numbers construction and parity-pigeonhole argument.",
       "startLine": 67,
       "endLine": 82,
-      "mathContext": "Axiomatizes g₃(N) = 2 (Choi–Erdős–Szemerédi). The lower bound g₃ $\\geq$ 2 from odd numbers has a sorry requiring the parity-pigeonhole argument that two of three integers share parity."
+      "mathContext": "Axiomatizes g₃(N) = 2 (Choi–Erdős–Szemerédi). The lower bound g₃ $\\geq$ 2 follows from the odd numbers construction and parity-pigeonhole argument."
     },
     {
       "id": "case-k4",
@@ -122,7 +122,7 @@
       "summary": "Axiomatizes g_k(N) ≪ N^{1-2^{-k}} for k ≥ 3. Defines upperExponent(k) = 1-2^{-k} and proves that it's strictly increasing (Aristotle). The exponent approaches 1 as k → ∞.",
       "startLine": 128,
       "endLine": 151,
-      "mathContext": "Axiomatizes g_k(N) ≪ N^{1-$$2^{{-k}$}$} for k $\\geq$ 3. Defines upperExponent(k) = 1-$$2^{{-k}$}$ and proves (with sorry) that it's strictly increasing. The exponent approaches 1 as k $\\to$ ∞."
+      "mathContext": "Axiomatizes g_k(N) ≪ N^{1-$$2^{{-k}$}$} for k $\\geq$ 3. Defines upperExponent(k) = 1-$$2^{{-k}$}$ and proves that it's strictly increasing (Aristotle). The exponent approaches 1 as k $\\to$ ∞."
     },
     {
       "id": "general-lower",
@@ -135,10 +135,10 @@
     {
       "id": "odd-construction",
       "title": "Odd Numbers Construction",
-      "summary": "Defines oddNumbers(N) as odd integers in [2N]. Proves (via Aristotle) that |oddNumbers(N)| = N and that no triple of integers has all pairwise sums odd. Derives g₃(N) ≥ 1 as a corollary (sorry).",
+      "summary": "Defines oddNumbers(N) as odd integers in [2N]. Proves (via Aristotle) that |oddNumbers(N)| = N and that no triple of integers has all pairwise sums odd.",
       "startLine": 174,
       "endLine": 196,
-      "mathContext": "Defines oddNumbers(N) as odd integers in [2N]. Proves (via Aristotle) that |oddNumbers(N)| = N and that no triple of integers has all pairwise sums odd. Derives g₃(N) $\\geq$ 1 as a corollary (sorry)."
+      "mathContext": "Defines oddNumbers(N) as odd integers in [2N]. Proves (via Aristotle) that |oddNumbers(N)| = N and that no triple of integers has all pairwise sums odd."
     },
     {
       "id": "summary-table",
@@ -166,7 +166,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #866 on pairwise sums threshold functions, organizing the theory into case analysis (k=3,4,5,6), general bounds, extremal constructions, and open problems. 3 sorries remain: Nat.find existence argument, g₃ lower bound (parity pigeonhole), and g₃ ≥ 1 corollary. Aristotle proved 3 lemmas: upperExponent monotonicity, oddNumbers cardinality, and oddNumbers avoidance. Five theorems are fully proved.",
+    "summary": "This formalization captures Erdős Problem #866 on pairwise sums threshold functions, organizing the theory into case analysis (k=3,4,5,6), general bounds, extremal constructions, and open problems. All supporting lemmas proved by Aristotle: upperExponent monotonicity, oddNumbers cardinality, and oddNumbers avoidance. 7 axioms encode the known mathematical results.",
     "implications": "The problem reveals fundamental phase transitions in additive combinatorics: (1) the jump from bounded to unbounded threshold at k=4→5 shows a qualitative complexity barrier; (2) the growth rate hierarchy (constant → log → √N → N^{1-o(1)}) is exceptionally clean; (3) the gap between upper exponent 1-2^{-k} and lower exponent 1-ε for large k represents a major open frontier. The formalization demonstrates how Lean can cleanly separate exact results (g₃=2) from asymptotic bounds (g₅, g₆) and open questions, providing precise statements for future work.",
     "openQuestions": [
       "What is the exact value of g₄(N)? Is g₄(N) constant, and if so, what is the constant?",

--- a/src/data/proofs/schauder-fixed-point-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Juliusz Schauder (formalized in Lean 4)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Schauder_fixed-point_theorem",
     "date": "1930",
-    "status": "formalized",
+    "status": "verified",
     "tags": [
       "topology",
       "fixed-point-theory",
@@ -15,8 +15,8 @@
       "convex-analysis",
       "open-question"
     ],
-    "badge": "wip",
-    "sorries": 3,
+    "badge": "original",
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "IsCompact.elim_finite_subcover_image",


### PR DESCRIPTION
## Summary

- **12 proofs** had stale sorry counts (sorries proved since last metadata update)
- **7 proofs promoted** from formalized/wip to verified/original (0 axioms, 0 sorries, no True stubs)
- **erdos-1092 demoted** from verified/original to formalized/infrastructure (has True-stub documentation markers)
- **1 CRITICAL issue filed**: rjwalters/lean-genius#8088 (erdos-1092 True stubs should be comments)

### Promotions (formalized → verified)
schauder-fixed-point-oq-01, erdos-1006-oq-02-oq-03, derangements-oq-02, bezout-identity-oq-02-oq-02-oq-01-oq-01, area-of-circle-oq-03-oq-02, dirichlets-theorem-oq-02, cayley-hamilton-minpoly-oq-05-oq-01, cramers-rule-oq-01-oq-03

### Sorry fixes only (status unchanged)
buffons-needle-oq-01-oq-01 (has axiom), ballot-problem-oq-01-oq-01 (has True stubs), erdos-866 (has axioms)

## Test plan

- [ ] `pnpm build` succeeds
- [ ] Verify corrected sorry counts match Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)