### PR TITLE
Research: erdos-884 - sum-level bound S_all ≤ (τ-1)·S_consec

### DIFF
--- a/proofs/Proofs/Erdos884Problem.lean
+++ b/proofs/Proofs/Erdos884Problem.lean
@@ -396,4 +396,87 @@ theorem erdos_884_statement : ErdosConjecture884 ↔
     ∃ C : ℝ, C > 0 ∧ ∀ n > 1, allPairsSum n ≤ C * (1 + consecutivePairsSum n) := by
   rfl
 
+/- ## Sum-Level Bound -/
+
+/-- For n > 1, n has at least 2 divisors (1 and n). -/
+private theorem numDivisors_ge_two (n : ℕ) (hn : n > 1) : numDivisors n ≥ 2 := by
+  unfold numDivisors
+  have h1 : (1 : ℕ) ∈ n.divisors := Nat.mem_divisors.mpr ⟨one_dvd n, by omega⟩
+  have hn' : n ∈ n.divisors := Nat.mem_divisors.mpr ⟨dvd_refl n, by omega⟩
+  exact Finset.one_lt_card.mpr ⟨1, h1, n, hn', by omega⟩
+
+/-- getD past the end of a ℕ list returns 0 (the default). -/
+private theorem list_getD_zero_of_ge (l : List ℕ) (k : ℕ) (h : l.length ≤ k) :
+    l.getD k 0 = 0 := by
+  induction l generalizing k with
+  | nil => simp [List.getD]
+  | cons a t ih =>
+    cases k with
+    | zero => simp at h
+    | succ k' =>
+      simp only [List.getD, List.get?]
+      exact ih (by simpa using h)
+
+/-- Out-of-bounds divisor access returns 0. -/
+private theorem divisor_eq_zero_of_ge (n k : ℕ) (hk : numDivisors n ≤ k) :
+    divisor n k = 0 := by
+  unfold divisor
+  exact list_getD_zero_of_ge _ _ (by rw [divisorList_length]; exact hk)
+
+/-- Consecutive gap at position τ(n)−1 is 0 (next divisor is out of bounds). -/
+private theorem consecutiveGap_last_eq_zero (n : ℕ) (hn : n > 1) :
+    consecutiveGap n (numDivisors n - 1) = 0 := by
+  have hτ := numDivisors_ge_two n hn
+  unfold consecutiveGap
+  rw [show numDivisors n - 1 + 1 = numDivisors n by omega]
+  rw [divisor_eq_zero_of_ge n (numDivisors n) le_rfl]
+  exact Nat.zero_sub _
+
+/-- Sum-level bound: the all-pairs sum is at most (τ(n)−1) times the consecutive-pairs sum.
+    Each 1/(dⱼ−dᵢ) ≤ 1/(d_{i+1}−dᵢ), and for each i there are at most τ−1 values of j > i.
+    This is a partial result toward Erdős 884 (which asks for an absolute constant). -/
+theorem allPairsSum_le_tau_mul_consecutive (n : ℕ) (hn : n > 1) :
+    allPairsSum n ≤ ((numDivisors n - 1 : ℕ) : ℝ) * consecutivePairsSum n := by
+  have hτ := numDivisors_ge_two n hn
+  set τ := numDivisors n with hτ_def
+  -- Step 1: Bound each pair term and convert inner sum to nsmul
+  have bound_step : allPairsSum n ≤
+      ∑ i ∈ Finset.range τ,
+        (Finset.Ioo i τ).card • ((1 : ℝ) / ↑(consecutiveGap n i)) := by
+    unfold allPairsSum
+    apply Finset.sum_le_sum; intro i _
+    rw [← Finset.sum_const]
+    apply Finset.sum_le_sum; intro j hj
+    have ⟨hij, hjτ⟩ := Finset.mem_Ioo.mp hj
+    exact reciprocal_gap_consecutive_bound n hn hij hjτ
+  -- Step 2: card(Ioo i τ) ≤ τ - 1
+  have card_bound : ∀ i, (Finset.Ioo i τ).card ≤ τ - 1 := by
+    intro i
+    have hsub : Finset.Ioo i τ ⊆ Finset.Ico 1 τ := by
+      intro j; simp only [Finset.mem_Ioo, Finset.mem_Ico]; omega
+    have hcard : (Finset.Ico 1 τ).card = τ - 1 := by
+      have := Finset.card_Ico (α := ℕ) 1 τ; omega
+    exact (Finset.card_le_card hsub).trans (le_of_eq hcard)
+  -- Step 3: Last term vanishes
+  have last_zero : (1 : ℝ) / ↑(consecutiveGap n (τ - 1)) = 0 := by
+    rw [consecutiveGap_last_eq_zero n hn, Nat.cast_zero, div_zero]
+  -- Combine via calc
+  calc allPairsSum n
+      ≤ ∑ i ∈ Finset.range τ,
+          (Finset.Ioo i τ).card • ((1 : ℝ) / ↑(consecutiveGap n i)) := bound_step
+    _ ≤ ∑ i ∈ Finset.range τ,
+          (τ - 1) • ((1 : ℝ) / ↑(consecutiveGap n i)) := by
+        apply Finset.sum_le_sum; intro i _
+        exact nsmul_le_nsmul_left (div_nonneg one_pos.le (Nat.cast_nonneg _)) (card_bound i)
+    _ = (τ - 1) • ∑ i ∈ Finset.range τ, (1 : ℝ) / ↑(consecutiveGap n i) := by
+        rw [Finset.smul_sum]
+    _ = (τ - 1) • (∑ i ∈ Finset.range (τ - 1), (1 : ℝ) / ↑(consecutiveGap n i) +
+          (1 : ℝ) / ↑(consecutiveGap n (τ - 1))) := by
+        congr 1; conv_lhs => rw [show τ = (τ - 1) + 1 by omega]
+        exact Finset.sum_range_succ _ _
+    _ = (τ - 1) • (consecutivePairsSum n + 0) := by
+        unfold consecutivePairsSum; rw [last_zero]
+    _ = (τ - 1) • consecutivePairsSum n := by rw [add_zero]
+    _ = ↑(τ - 1 : ℕ) * consecutivePairsSum n := nsmul_eq_mul _ _
+
 end Erdos884

--- a/src/data/proofs/erdos-884/meta.json
+++ b/src/data/proofs/erdos-884/meta.json
@@ -63,11 +63,12 @@
       "generalGap_telescope: telescoping d_j - d_i = Σ consecutive gaps (by induction)",
       "consecutiveGap_le_generalGap: interior consecutive gap ≤ general gap",
       "reciprocal_gap_index_bound: 1/(d_j-d_i) ≤ 1/(j-i) from gap growth",
-      "reciprocal_gap_consecutive_bound: 1/(d_j-d_i) ≤ 1/g_i from gap domination"
+      "reciprocal_gap_consecutive_bound: 1/(d_j-d_i) ≤ 1/g_i from gap domination",
+      "allPairsSum_le_tau_mul_consecutive: sum-level bound S_all ≤ (τ-1)·S_consec"
     ],
     "axiomCount": 1,
-    "assumptions": "1 axiom: erdos_884 (the OPEN main conjecture). All 8 supporting axioms eliminated: divisorList_pairwise_lt, mem_divisorList_iff, consecutiveGap_pos, generalGap_pos, divisors_6, divisors_prime, prime_case_equality, gap_lower_bound — all proved. numDivisors_mul_coprime sorry also proved via σ₀ multiplicativity.",
-    "lineCount": 399
+    "assumptions": "1 axiom: erdos_884 (the OPEN main conjecture). All 8 supporting axioms eliminated: divisorList_pairwise_lt, mem_divisorList_iff, consecutiveGap_pos, generalGap_pos, divisors_6, divisors_prime, prime_case_equality, gap_lower_bound — all proved. numDivisors_mul_coprime sorry also proved via σ��� multiplicativity.",
+    "lineCount": 482
   },
   "overview": {
     "historicalContext": "Erdős Problem #884 appears in [Er98] and asks about the relationship between two sums over divisor gaps. Given the divisors d₁ < d₂ < ··· < d_t of a positive integer n, one can form either the all-pairs sum (summing 1/(d_j - d_i) over all i < j) or the consecutive-pairs sum (summing only over adjacent divisors). The question is whether the all-pairs sum is controlled by the consecutive-pairs sum up to an absolute constant.\n\nThe problem is related to Erdős Problem #144 on divisor arithmetic. Terence Tao has indicated that this problem appears tractable, suggesting it may be amenable to combinatorial or analytic arguments about divisor distributions.\n\nThe trivial observation is that for primes p, both sums equal 1/(p-1) since there is only one pair of divisors {1, p}. For composite numbers with many divisors, the all-pairs sum has O(τ²) terms while the consecutive-pairs sum has only O(τ) terms, making the conjectured bound non-trivial.",
@@ -174,6 +175,14 @@
       "endLine": 399,
       "summary": "Defines `divisorHarmonicSum n` ($\\sigma_{-1}(n) = \\sum_{d|n} 1/d$) and proves `erdos_884_statement` (the conjecture definition matches the informal statement, by `rfl`).",
       "mathContext": "The divisor harmonic sum $\\sigma_{-1}(n) = \\sum_{d \\mid n} 1/d$ is related but distinct — it sums reciprocals of divisors, not reciprocals of gaps. The `erdos_884_statement` confirms definitional correctness."
+    },
+    {
+      "id": "sum-level-bound",
+      "title": "Sum-Level Bound",
+      "startLine": 399,
+      "endLine": 482,
+      "summary": "Proves `allPairsSum_le_tau_mul_consecutive`: for n > 1, allPairsSum(n) ≤ (τ(n)-1) · consecutivePairsSum(n). Uses per-pair bound 1/(d_j-d_i) ≤ 1/g_i, card(Ioo i τ) ≤ τ-1, and that the last consecutive gap vanishes (out-of-bounds). Helper lemmas: `numDivisors_ge_two`, `list_getD_zero_of_ge`, `divisor_eq_zero_of_ge`, `consecutiveGap_last_eq_zero`.",
+      "mathContext": "$S_{\\text{all}}(n) \\leq (\\tau(n) - 1) \\cdot S_{\\text{consec}}(n)$. For each pair $(i,j)$ with $i < j$, we have $\\frac{1}{d_j - d_i} \\leq \\frac{1}{g_i}$. Summing over $j > i$ gives at most $\\tau - 1$ copies of $\\frac{1}{g_i}$. Summing over $i$ yields $(\\tau-1) \\cdot S_{\\text{consec}}$. This is weaker than Erdős 884 (which asks for an absolute constant), but is an unconditional bound."
     }
   ],
   "references": [
@@ -229,9 +238,9 @@
       "BigOperators"
     ],
     "namespace": "Erdos884",
-    "lineCount": 399,
+    "lineCount": 482,
     "axiomCount": 1,
-    "theoremCount": 28,
+    "theoremCount": 33,
     "definitionCount": 9
   }
 }


### PR DESCRIPTION
## Summary
- Prove `allPairsSum_le_tau_mul_consecutive`: for n > 1, the all-pairs sum is at most (τ(n)-1) times the consecutive-pairs sum
- Add 4 helper lemmas: `numDivisors_ge_two`, `list_getD_zero_of_ge`, `divisor_eq_zero_of_ge`, `consecutiveGap_last_eq_zero`
- This is an unconditional partial result toward Erdős 884 (which asks for an absolute constant)

## Progress
- **Files modified**: `proofs/Proofs/Erdos884Problem.lean` (+83 lines), `src/data/proofs/erdos-884/meta.json`
- **Theorem count**: 28 → 33 (5 new theorems)
- **Axiom count**: unchanged (1 — the open conjecture)
- **Sorry count**: unchanged (0)

## Mathematical Content
The key insight: for each pair (i,j) with i < j, the per-pair bound gives 1/(d_j - d_i) ≤ 1/(d_{i+1} - d_i). For fixed i, there are at most τ-1 values of j > i. Summing yields:

S_all(n) ≤ (τ(n) - 1) · S_consec(n)

This is weaker than the full conjecture (which asks for an absolute constant C), but is unconditional.

## Status
**Outcome**: progress
**Next Steps**: AM-HM inequality for tighter O(log τ) bound; prime power case proof

🤖 Generated by researcher-7