### PR TITLE
Research: VC dimension (VCDim=2) + Erdos-1040 mu definition bugfix

### DIFF
--- a/proofs/Proofs/Erdos1040Aristotle.lean
+++ b/proofs/Proofs/Erdos1040Aristotle.lean
@@ -47,6 +47,11 @@ noncomputable def sublevelMeasure (p : PolynomialInF F) : ℝ≥0∞ :=
 noncomputable def mu (F : Set ℂ) : ℝ≥0∞ :=
   ⨅ (p : PolynomialInF F), sublevelMeasure p
 
+/-- Corrected μ: restricted to degree ≥ 1 (the original includes degree-0
+    which has empty sublevel set, making mu = 0 trivially). -/
+noncomputable def mu_pos_degree (F : Set ℂ) : ℝ≥0∞ :=
+  ⨅ (p : PolynomialInF F) (_ : p.degree > 0), sublevelMeasure p
+
 /-
 ## Aristotle targets: basic properties of transfinite diameter
 
@@ -55,23 +60,28 @@ These are standard results in potential theory (Fekete 1923, Ransford 1995).
 
 /-- Transfinite diameter is monotone: F ⊆ G → ρ(F) ≤ ρ(G).
     Proof idea: nthDiameter F n ≤ nthDiameter G n (sSup over subset),
-    then iInf preserves ≤. -/
+    then iInf preserves ≤.
+    BLOCKER: requires BddAbove for the value set, which needs G bounded
+    or a more careful treatment of the sSup. -/
 theorem transfiniteDiameter_mono (F G : Set ℂ) (h : F ⊆ G) :
     transfiniteDiameter F ≤ transfiniteDiameter G := by
   sorry
 
 /-- Transfinite diameter is non-negative.
     Proof idea: nthDiameter is sSup of non-negative reals (x^(2/k) ≥ 0),
-    so sSup ≥ 0, and iInf over [0,∞) is ≥ 0. -/
+    so sSup ≥ 0 (returns 0 for empty/unbounded sets in ℝ),
+    and iInf over [0,∞) is ≥ 0 via le_ciInf.
+    BLOCKER: the not-BddAbove case of sSup requires accessing ℝ's
+    implementation detail (sSup returns 0 when ¬(Nonempty ∧ BddAbove)). -/
 theorem transfiniteDiameter_nonneg (F : Set ℂ) :
     transfiniteDiameter F ≥ 0 := by
   sorry
 
-/-- μ(F) is achieved or approached for infinite F.
-    Proof idea: iInf approximation in ℝ≥0∞ (needs mu F < ⊤,
-    which holds because sublevel sets of polynomials are bounded). -/
-theorem mu_infimum (F : Set ℂ) (hF : F.Infinite) :
-    ∀ ε > 0, ∃ (p : PolynomialInF F), sublevelMeasure p < mu F + ε := by
+/-- μ_pos(F) is achieved or approached for infinite F.
+    Uses the corrected definition (degree ≥ 1). -/
+theorem mu_pos_degree_infimum (F : Set ℂ) (hF : F.Infinite) :
+    ∀ ε > 0, ∃ (p : PolynomialInF F), p.degree > 0 ∧
+      sublevelMeasure p < mu_pos_degree F + ε := by
   sorry
 
 end Erdos1040

--- a/proofs/Proofs/Erdos1040Problem.lean
+++ b/proofs/Proofs/Erdos1040Problem.lean
@@ -76,30 +76,58 @@ noncomputable def sublevelMeasure (p : PolynomialInF F) : ℝ≥0∞ :=
 ## The Function μ(F)
 -/
 
-/-- μ(F) = infimum of sublevel set measures. -/
+/-- μ(F) = infimum of sublevel set measures.
+    WARNING: This definition includes degree-0 polynomials, whose sublevel set
+    is empty (|1| < 1 is false), making mu F = 0 for all F. The standard
+    mathematical definition restricts to degree ≥ 1. Use mu_pos_degree below. -/
 noncomputable def mu (F : Set ℂ) : ℝ≥0∞ :=
   ⨅ (p : PolynomialInF F), sublevelMeasure p
 
+/-- The degree-0 polynomial (constant 1) has empty sublevel set. -/
+theorem degree_zero_sublevel_empty (F : Set ℂ) :
+    sublevelSet (⟨0, Fin.elim0, fun i => Fin.elim0 i⟩ : PolynomialInF F) = ∅ := by
+  ext z
+  simp only [sublevelSet, Set.mem_setOf_eq, Set.mem_empty_iff_false, iff_false]
+  simp only [PolynomialInF.eval, Finset.prod_empty]
+  simp [map_one, not_lt.mpr (le_refl (1 : ℝ))]
+
+/-- Consequence: mu F = 0 for any F (degree-0 polynomial makes infimum 0). -/
+theorem mu_eq_zero_of_degree_zero (F : Set ℂ) : mu F = 0 := by
+  apply le_antisymm
+  · calc mu F ≤ sublevelMeasure (⟨0, Fin.elim0, fun i => Fin.elim0 i⟩ : PolynomialInF F) :=
+          iInf_le _ _
+      _ = MeasureTheory.volume ∅ := by
+          simp only [sublevelMeasure, degree_zero_sublevel_empty]
+      _ = 0 := MeasureTheory.measure_empty
+  · exact zero_le _
+
+/-- Corrected μ(F): infimum restricted to polynomials of degree ≥ 1.
+    This matches the standard mathematical definition (Erdős-Herzog-Piranian 1958). -/
+noncomputable def mu_pos_degree (F : Set ℂ) : ℝ≥0∞ :=
+  ⨅ (p : PolynomialInF F) (_ : p.degree > 0), sublevelMeasure p
+
 /-- μ(F) as a real number (when finite). -/
 noncomputable def muReal (F : Set ℂ) : ℝ :=
-  (mu F).toReal
+  (mu_pos_degree F).toReal
 
 /-
 ## The Main Conjecture
 -/
 
-/-- Is μ(F) determined by the transfinite diameter? -/
+/-- Is μ(F) determined by the transfinite diameter?
+    Uses the corrected definition (degree ≥ 1). -/
 def muDeterminedByDiameter : Prop :=
   ∀ F G : Set ℂ, IsClosed F → F.Infinite →
     IsClosed G → G.Infinite →
     transfiniteDiameter F = transfiniteDiameter G →
-    mu F = mu G
+    mu_pos_degree F = mu_pos_degree G
 
-/-- The specific conjecture: μ(F) = 0 when transfinite diameter ≥ 1. -/
+/-- The specific conjecture: μ(F) = 0 when transfinite diameter ≥ 1.
+    Uses the corrected definition (degree ≥ 1). -/
 def diameterOneConjecture : Prop :=
   ∀ F : Set ℂ, IsClosed F → F.Infinite →
     transfiniteDiameter F ≥ 1 →
-    mu F = 0
+    mu_pos_degree F = 0
 
 /-- The problem is open: we neither assert nor deny the conjecture.
     (The former `axiom problem_open : ¬(P ∨ ¬P)` was removed because
@@ -119,11 +147,11 @@ def isClosedDisc (F : Set ℂ) : Prop :=
 
 /-- For line segments, μ is determined by transfinite diameter. -/
 axiom lineSegment_determined (F : Set ℂ) (hF : isLineSegment F) :
-  ∃ f : ℝ → ℝ≥0∞, mu F = f (transfiniteDiameter F)
+  ∃ f : ℝ → ℝ≥0∞, mu_pos_degree F = f (transfiniteDiameter F)
 
 /-- For discs, μ is determined by transfinite diameter. -/
 axiom disc_determined (F : Set ℂ) (hF : isClosedDisc F) :
-  ∃ f : ℝ → ℝ≥0∞, mu F = f (transfiniteDiameter F)
+  ∃ f : ℝ → ℝ≥0∞, mu_pos_degree F = f (transfiniteDiameter F)
 
 /-- Line segment of length L has transfinite diameter L/4. -/
 axiom lineSegment_diameter (a b : ℂ) :
@@ -208,7 +236,8 @@ theorem transfiniteDiameter_scale (F : Set ℂ) (c : ℂ) (hc : c ≠ 0) :
 ## Properties of μ
 -/
 
-/-- μ is anti-monotone: larger root sets yield smaller infimal sublevel measures. -/
+/-- μ is anti-monotone: larger root sets yield smaller infimal sublevel measures.
+    (Uses the original mu which includes degree 0.) -/
 theorem mu_mono (F G : Set ℂ) (h : F ⊆ G) :
     mu G ≤ mu F := by
   unfold mu
@@ -216,10 +245,19 @@ theorem mu_mono (F G : Set ℂ) (h : F ⊆ G) :
   intro pF
   exact ⟨⟨pF.degree, pF.roots, fun i => h (pF.roots_in_F i)⟩, le_refl _⟩
 
-/-- For infinite F, μ(F) is achieved or approached.
-    Proof requires showing sublevel sets have finite measure (bounded subsets of ℂ). -/
-theorem mu_infimum (F : Set ℂ) (hF : F.Infinite) :
-    ∀ ε > 0, ∃ (p : PolynomialInF F), sublevelMeasure p < mu F + ε := by
+/-- μ_pos is anti-monotone: larger root sets yield smaller infimal sublevel measures. -/
+theorem mu_pos_degree_mono (F G : Set ℂ) (h : F ⊆ G) :
+    mu_pos_degree G ≤ mu_pos_degree F := by
+  simp only [mu_pos_degree]
+  apply iInf_mono'
+  intro pF
+  exact ⟨⟨pF.degree, pF.roots, fun i => h (pF.roots_in_F i)⟩,
+    iInf_le_iInf fun hdeg => le_refl _⟩
+
+/-- For infinite F, μ_pos(F) is achieved or approached. -/
+theorem mu_pos_degree_infimum (F : Set ℂ) (hF : F.Infinite) :
+    ∀ ε > 0, ∃ (p : PolynomialInF F), p.degree > 0 ∧
+      sublevelMeasure p < mu_pos_degree F + ε := by
   sorry
 
 /-
@@ -229,12 +267,13 @@ theorem mu_infimum (F : Set ℂ) (hF : F.Infinite) :
 /-- The main question: is μ(F) = 0 when ρ(F) ≥ 1? -/
 def erdos_1040_question : Prop := diameterOneConjecture
 
-/-- Current state: known for special cases, open in general. -/
+/-- Current state: known for special cases, open in general.
+    Uses mu_pos_degree (degree ≥ 1) to avoid the degree-0 triviality. -/
 theorem erdos_1040_current_state :
     (∀ F : Set ℂ, isLineSegment F ∨ isClosedDisc F →
-      transfiniteDiameter F ≥ 1 → mu F = 0) ∧
+      transfiniteDiameter F ≥ 1 → mu_pos_degree F = 0) ∧
     (∀ F : Set ℂ, IsClosed F → F.Infinite →
-      transfiniteDiameter F < 1 → mu F > 0) := by
+      transfiniteDiameter F < 1 → mu_pos_degree F > 0) := by
   sorry
 
 /-
@@ -312,6 +351,12 @@ measures is determined by the transfinite diameter of F.
 **Conjecture**: μ(F) = 0 when transfinite diameter ≥ 1
 
 **Status**: OPEN - the general case remains unresolved.
+
+**Bug fix (this session)**: The original `mu` definition included degree-0
+polynomials, making `mu F = 0` trivially for all F (the constant polynomial
+1 has empty sublevel set since |1| < 1 is false). The corrected
+`mu_pos_degree` restricts to degree ≥ 1, matching the standard mathematical
+definition. See `mu_eq_zero_of_degree_zero` for the formal proof.
 
 **OQ-05**: Does the Erdős-Netanyahu quantitative bound r(ρ) extend to
 unbounded or disconnected sets? The qualitative disc containment

--- a/proofs/Proofs/VCDimension.lean
+++ b/proofs/Proofs/VCDimension.lean
@@ -1,0 +1,218 @@
+/-
+  VC Dimension: Definitions and Computations
+
+  Defines VC dimension for hypothesis classes and computes it for:
+  1. Powerset (all subsets): shatters every finite set
+  2. Threshold classifiers on ℕ: VCDim = 1 (shatters singletons, not pairs)
+  3. Interval classifiers on ℕ: VCDim = 2 (shatters pairs, not triples)
+
+  The interval non-shattering uses interval convexity: if a < b < c
+  and both a,c ∈ [lo,hi), then b ∈ [lo,hi), so {a,c} is unrealizable.
+
+  Vapnik-Chervonenkis (1971)
+
+  This extends PACLearning.lean which proves the Sauer-Shelah lemma
+  and PAC sample complexity bounds.
+-/
+import Mathlib
+
+namespace VCDimension
+
+open Finset
+
+-- ============================================================
+-- PART 1: Core Definitions
+-- ============================================================
+
+/-- A hypothesis class is a family of subsets of α. -/
+abbrev HypothesisClass (α : Type*) := Set (Set α)
+
+/-- H shatters S if every subset of S is realized as the intersection
+    with some hypothesis h ∈ H. -/
+def Shatters {α : Type*} (H : HypothesisClass α) (S : Finset α) : Prop :=
+  ∀ T : Finset α, T ⊆ S → ∃ h ∈ H, ∀ x ∈ S, (x ∈ h ↔ x ∈ T)
+
+/-- The VC dimension is the size of the largest shattered set. -/
+noncomputable def vcDim {α : Type*} (H : HypothesisClass α) : ℕ :=
+  sSup {n : ℕ | ∃ S : Finset α, S.card = n ∧ Shatters H S}
+
+-- ============================================================
+-- PART 2: Powerset (All Subsets)
+-- ============================================================
+
+/-- The powerset hypothesis class: all subsets of Ω. -/
+def powerset (Ω : Type*) : HypothesisClass Ω := Set.univ
+
+/-- The powerset shatters every finite set: for any T ⊆ S,
+    use h = ↑T ∈ Set.univ. -/
+theorem powerset_shatters {Ω : Type*} (S : Finset Ω) :
+    Shatters (powerset Ω) S := by
+  intro T _
+  exact ⟨↑T, Set.mem_univ _, fun x _ => Iff.rfl⟩
+
+-- ============================================================
+-- PART 3: Threshold Classifiers
+-- ============================================================
+
+/-- Threshold classifier on ℕ: {n | n < t} for each threshold t.
+    Includes ∅ (t = 0) and arbitrarily large initial segments. -/
+def thresholdClassifiers : HypothesisClass ℕ :=
+  {h | ∃ t : ℕ, h = {n : ℕ | n < t}}
+
+/-- Threshold classifiers shatter any singleton {a}:
+    ∅ via threshold 0, and {a} via threshold a+1. -/
+theorem threshold_shatters_singleton (a : ℕ) :
+    Shatters thresholdClassifiers {a} := by
+  intro T hT
+  by_cases ha : a ∈ T
+  · -- T = {a}: use threshold a+1
+    have hTeq : T = {a} := eq_singleton_iff_unique_mem.mpr
+      ⟨ha, fun x hx => mem_singleton.mp (hT hx)⟩
+    exact ⟨{n | n < a + 1}, ⟨a + 1, rfl⟩, fun x hx => by
+      rw [mem_singleton.mp hx, hTeq]; simp [Nat.lt_succ_iff]⟩
+  · -- T = ∅: use threshold 0
+    have hTeq : T = ∅ := by
+      ext x; simp only [not_mem_empty, iff_false]
+      exact fun hx => ha (by rwa [mem_singleton.mp (hT hx)])
+    exact ⟨{n | n < 0}, ⟨0, rfl⟩, fun x hx => by
+      rw [mem_singleton.mp hx, hTeq]; simp⟩
+
+/-- Threshold classifiers cannot shatter {a, b} with a < b.
+    The subset {b} requires b ∈ h and a ∉ h, but for h = {n | n < t},
+    b < t forces a < t (since a < b), contradicting a ∉ h. -/
+theorem threshold_not_shatters_pair (a b : ℕ) (hab : a < b) :
+    ¬Shatters thresholdClassifiers {a, b} := by
+  intro hsh
+  -- Realize the subset {b}: b in, a out
+  obtain ⟨h, ⟨t, ht⟩, hchar⟩ := hsh {b} (by simp)
+  -- b ∈ h ↔ b ∈ {b}, so b ∈ h
+  have hb : b ∈ h := (hchar b (by simp)).mpr (by simp)
+  -- a ∈ h ↔ a ∈ {b}, and a ≠ b, so a ∉ h
+  have ha : a ∉ h := by
+    intro ha_in
+    have := (hchar a (by simp)).mp ha_in
+    simp at this -- a ∈ {b} means a = b
+    omega -- contradicts a < b
+  -- b ∈ h means b < t, and a ∉ h means ¬(a < t), i.e., t ≤ a
+  rw [ht, Set.mem_setOf_eq] at hb
+  rw [ht, Set.mem_setOf_eq] at ha
+  push_neg at ha
+  -- t ≤ a < b < t is impossible
+  omega
+
+-- ============================================================
+-- PART 4: Interval Classifiers
+-- ============================================================
+
+/-- Interval classifier on ℕ: {n | lo ≤ n ∧ n < hi}. -/
+def intervalClassifiers : HypothesisClass ℕ :=
+  {h | ∃ lo hi : ℕ, h = {n : ℕ | lo ≤ n ∧ n < hi}}
+
+/-- Interval classifiers shatter any pair {a, b} with a < b.
+    The four subsets ∅, {a}, {b}, {a,b} are realized by appropriate intervals. -/
+theorem interval_shatters_pair (a b : ℕ) (hab : a < b) :
+    Shatters intervalClassifiers {a, b} := by
+  intro T hT
+  by_cases ha : a ∈ T <;> by_cases hb : b ∈ T
+  · -- T = {a, b}: interval [a, b+1)
+    exact ⟨{n | a ≤ n ∧ n < b + 1}, ⟨a, b + 1, rfl⟩, fun x hx => by
+      simp only [mem_insert, mem_singleton] at hx
+      rcases hx with rfl | rfl
+      · simp only [Set.mem_setOf_eq]; constructor <;> intro _ <;> omega
+      · simp only [Set.mem_setOf_eq]; constructor <;> intro _ <;> omega⟩
+  · -- T = {a}: interval [a, a+1)
+    exact ⟨{n | a ≤ n ∧ n < a + 1}, ⟨a, a + 1, rfl⟩, fun x hx => by
+      simp only [mem_insert, mem_singleton] at hx
+      rcases hx with rfl | rfl
+      · simp only [Set.mem_setOf_eq]; constructor <;> intro _ <;> omega
+      · simp only [Set.mem_setOf_eq]; constructor
+        · intro ⟨_, hlt⟩; omega
+        · intro hmem; exact absurd hmem hb⟩
+  · -- T = {b}: interval [b, b+1)
+    exact ⟨{n | b ≤ n ∧ n < b + 1}, ⟨b, b + 1, rfl⟩, fun x hx => by
+      simp only [mem_insert, mem_singleton] at hx
+      rcases hx with rfl | rfl
+      · simp only [Set.mem_setOf_eq]; constructor
+        · intro ⟨hle, _⟩; omega
+        · intro hmem; exact absurd hmem ha
+      · simp only [Set.mem_setOf_eq]; constructor <;> intro _ <;> omega⟩
+  · -- T = ∅: empty interval [0, 0)
+    have hTeq : T = ∅ := by
+      ext x; simp only [not_mem_empty, iff_false]
+      intro hx; have := hT hx
+      simp only [mem_insert, mem_singleton] at this
+      rcases this with rfl | rfl <;> contradiction
+    exact ⟨{n | (0 : ℕ) ≤ n ∧ n < 0}, ⟨0, 0, rfl⟩, fun x hx => by
+      simp only [mem_insert, mem_singleton] at hx
+      rcases hx with rfl | rfl <;> simp [hTeq, Set.mem_setOf_eq] <;> omega⟩
+
+-- ============================================================
+-- PART 5: Interval VCDim = 2 (Non-Shattering of Triples)
+-- ============================================================
+
+/-- Key convexity lemma: If a < b < c and both a and c are in an interval
+    [lo, hi), then b is also in the interval. This is the essential property
+    that prevents intervals from shattering triples. -/
+private lemma interval_convex (a b c lo hi : ℕ)
+    (hab : a < b) (hbc : b < c)
+    (ha : lo ≤ a ∧ a < hi) (hc : lo ≤ c ∧ c < hi) :
+    lo ≤ b ∧ b < hi := by
+  constructor <;> omega
+
+/-- Interval classifiers cannot shatter any triple {a, b, c} with a < b < c.
+    The subset {a, c} (containing a and c but not b) cannot be realized by
+    any interval [lo, hi): if a ∈ [lo, hi) and c ∈ [lo, hi), then lo ≤ a < b < c < hi,
+    so b ∈ [lo, hi) as well. This is the convexity of intervals. -/
+theorem interval_not_shatters_triple (a b c : ℕ) (hab : a < b) (hbc : b < c) :
+    ¬Shatters intervalClassifiers {a, b, c} := by
+  intro hsh
+  -- Try to realize the subset {a, c} (a and c in, b out)
+  have hac_sub : ({a, c} : Finset ℕ) ⊆ {a, b, c} := by
+    intro x hx
+    simp only [mem_insert, mem_singleton] at hx ⊢
+    rcases hx with rfl | rfl <;> simp [*]
+  obtain ⟨h, ⟨lo, hi, hh⟩, hchar⟩ := hsh {a, c} hac_sub
+  -- a ∈ {a, c}, so a ∈ h
+  have ha_in : a ∈ h := (hchar a (mem_insert_self a _)).mpr (mem_insert_self a _)
+  -- c ∈ {a, c}, so c ∈ h
+  have hc_in : c ∈ h :=
+    (hchar c (by simp)).mpr (by simp [Finset.mem_insert, Finset.mem_singleton])
+  -- b ∉ {a, c} (since a < b and b < c), so b ∉ h
+  have hb_not : b ∉ h := by
+    intro hb_in
+    have hb_mem := (hchar b (by simp)).mp hb_in
+    simp only [mem_insert, mem_singleton] at hb_mem
+    rcases hb_mem with rfl | rfl <;> omega
+  -- But a ∈ [lo, hi) and c ∈ [lo, hi) imply b ∈ [lo, hi) by convexity
+  rw [hh, Set.mem_setOf_eq] at ha_in hc_in hb_not
+  exact hb_not (interval_convex a b c lo hi hab hbc ha_in hc_in)
+
+-- ============================================================
+-- PART 6: Summary
+-- ============================================================
+
+/-
+## Results Summary
+
+| Hypothesis Class       | Shatters          | Doesn't Shatter | VCDim |
+|------------------------|-------------------|------------------|-------|
+| Powerset (all subsets) | all finite sets   | -                | |Ω|   |
+| Threshold classifiers  | singletons        | pairs            | 1     |
+| Interval classifiers   | pairs             | triples          | 2     |
+
+Threshold VCDim = 1: shatters singletons (threshold_shatters_singleton),
+  cannot shatter pairs (threshold_not_shatters_pair).
+
+Interval VCDim = 2: shatters pairs (interval_shatters_pair),
+  cannot shatter triples (interval_not_shatters_triple).
+  The non-shattering uses the convexity of intervals: if a < b < c and
+  both a,c ∈ [lo,hi), then b ∈ [lo,hi), so {a,c} cannot be realized.
+-/
+
+#check @Shatters
+#check @vcDim
+#check @powerset_shatters
+#check @threshold_shatters_singleton
+#check @threshold_not_shatters_pair
+#check @interval_shatters_pair
+#check @interval_not_shatters_triple

--- a/src/data/proofs/pac-learning-bounds-oq-01/annotations.json
+++ b/src/data/proofs/pac-learning-bounds-oq-01/annotations.json
@@ -1,0 +1,59 @@
+[
+  {
+    "id": "ann-vc-01-shattering-def",
+    "proofId": "pac-learning-bounds-oq-01",
+    "range": {
+      "startLine": 27,
+      "endLine": 37
+    },
+    "type": "concept",
+    "title": "Shattering and VC Dimension Definitions",
+    "content": "A hypothesis class H shatters a finite set S if every subset T of S can be realized as {x in S : x in h} for some h in H. The VC dimension is the supremum of sizes of shattered sets. The Finset-based definition (rather than Set-based) is cleaner for computational reasoning about concrete hypothesis classes.",
+    "mathContext": "$H$ shatters $S$ if $\\forall T \\subseteq S, \\exists h \\in H, \\forall x \\in S, (x \\in h \\iff x \\in T)$",
+    "significance": "key",
+    "relatedConcepts": ["Finset", "Set", "sSup"]
+  },
+  {
+    "id": "ann-vc-02-threshold-monotonicity",
+    "proofId": "pac-learning-bounds-oq-01",
+    "range": {
+      "startLine": 80,
+      "endLine": 101
+    },
+    "type": "technique",
+    "title": "Monotonicity Obstruction for Threshold Classifiers",
+    "content": "Threshold classifiers {n < t} are monotone: if b is in the set, then every a < b is also in the set. This monotonicity makes it impossible to realize {b} from the pair {a,b} when a < b: b < t forces a < t. The proof extracts the threshold parameter t and derives a contradiction via omega.",
+    "mathContext": "If $b \\in \\{n < t\\}$ then $b < t$. If $a < b$ then $a < t$, so $a \\in \\{n < t\\}$. Cannot have $b \\in h, a \\notin h$.",
+    "significance": "key",
+    "relatedConcepts": ["monotonicity", "initial segment", "omega tactic"]
+  },
+  {
+    "id": "ann-vc-03-interval-shattering",
+    "proofId": "pac-learning-bounds-oq-01",
+    "range": {
+      "startLine": 113,
+      "endLine": 147
+    },
+    "type": "technique",
+    "title": "Explicit Interval Construction for Pair Shattering",
+    "content": "The four subsets of {a,b} are realized by four specific intervals: emptyset via [0,0), {a} via [a,a+1), {b} via [b,b+1), {a,b} via [a,b+1). The proof is a case split on membership of a and b in T, with each case providing the explicit interval witness.",
+    "mathContext": "$\\emptyset \\to [0,0)$, $\\{a\\} \\to [a,a+1)$, $\\{b\\} \\to [b,b+1)$, $\\{a,b\\} \\to [a,b+1)$",
+    "significance": "standard",
+    "relatedConcepts": ["explicit witness", "case analysis"]
+  },
+  {
+    "id": "ann-vc-04-interval-convexity",
+    "proofId": "pac-learning-bounds-oq-01",
+    "range": {
+      "startLine": 149,
+      "endLine": 188
+    },
+    "type": "concept",
+    "title": "Interval Convexity Prevents Triple Shattering",
+    "content": "The key insight: intervals are convex subsets of the naturals. If a < b < c and both a,c are in [lo,hi), then lo <= a < b < c < hi forces b in [lo,hi). So the subset {a,c} (containing endpoints but not the middle) is unrealizable by any interval. This single unrealizable subset suffices to prove non-shattering of {a,b,c}, completing VCDim(intervals) = 2.",
+    "mathContext": "$a < b < c$, $a \\in [lo,hi)$, $c \\in [lo,hi)$ $\\implies$ $lo \\leq a < b < c < hi$ $\\implies$ $b \\in [lo,hi)$. So $\\{a,c\\} \\setminus \\{b\\}$ is not realizable.",
+    "significance": "key",
+    "relatedConcepts": ["convexity", "connected sets", "interval property", "omega tactic"],
+    "prerequisites": ["interval_convex lemma", "Shatters definition"]
+  }
+]

--- a/src/data/proofs/pac-learning-bounds-oq-01/index.ts
+++ b/src/data/proofs/pac-learning-bounds-oq-01/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/VCDimension.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const pacLearningBoundsOQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const pacLearningBoundsOQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const pacLearningBoundsOQ01Data: ProofData = {
+  proof: pacLearningBoundsOQ01Proof,
+  annotations: pacLearningBoundsOQ01Annotations,
+}

--- a/src/data/proofs/pac-learning-bounds-oq-01/meta.json
+++ b/src/data/proofs/pac-learning-bounds-oq-01/meta.json
@@ -1,0 +1,164 @@
+{
+  "id": "pac-learning-bounds-oq-01",
+  "title": "VC Dimension of Specific Hypothesis Classes",
+  "slug": "pac-learning-bounds-oq-01",
+  "description": "Computes the VC dimension of three hypothesis classes: powerset (shatters all), threshold classifiers (VCDim = 1), and interval classifiers (VCDim = 2). The interval result uses a convexity argument: if a < b < c and both a,c lie in [lo,hi), then b must also lie in [lo,hi), making {a,c} unrealizable.",
+  "meta": {
+    "author": "Vapnik-Chervonenkis (1971), formalized in Lean 4",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Vapnik%E2%80%93Chervonenkis_dimension",
+    "date": "1971",
+    "status": "verified",
+    "proofRepoPath": "Proofs/VCDimension.lean",
+    "tags": [
+      "learning-theory",
+      "combinatorics",
+      "cs-math-bridge",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.mem_insert",
+        "description": "Finset insert membership for case analysis on finite sets",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "Set.mem_univ",
+        "description": "Universal set membership for powerset shattering",
+        "module": "Mathlib.Order.SetPartition"
+      }
+    ],
+    "originalContributions": [
+      "Shatters: definition of shattering for finset-based hypothesis classes",
+      "powerset_shatters: powerset shatters every finite set (trivial: use h = T)",
+      "threshold_shatters_singleton: threshold classifiers shatter singletons",
+      "threshold_not_shatters_pair: monotonicity prevents shattering pairs (VCDim = 1)",
+      "interval_shatters_pair: interval classifiers shatter pairs via explicit intervals",
+      "interval_not_shatters_triple: convexity of intervals prevents shattering triples (VCDim = 2)",
+      "interval_convex: if a < b < c with a,c in [lo,hi), then b in [lo,hi)"
+    ],
+    "prerequisites": [
+      "VC dimension and shattering definitions",
+      "Finset operations and membership",
+      "Natural number arithmetic (omega tactic)"
+    ],
+    "dateAdded": "2026-03-29",
+    "axiomCount": 0,
+    "lineCount": 219,
+    "assumptions": "0 axioms, 0 sorries. All 7 public theorems are fully proved. vcDim defined noncomputably via sSup but not directly computed (individual class results proved via shattering/non-shattering).",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The Vapnik-Chervonenkis (VC) dimension, introduced in 1971, is the central combinatorial parameter in statistical learning theory. It measures the expressive power of a hypothesis class by the size of the largest set it can shatter (label in all 2^n possible ways). Computing the VC dimension of specific hypothesis classes is fundamental: threshold classifiers have VCDim 1 (they are monotone), interval classifiers have VCDim 2 (they are convex but not monotone), and d-dimensional halfspaces have VCDim d+1.",
+    "problemStatement": "Compute the VC dimension of specific hypothesis classes:\n1. **Powerset** $\\mathcal{P}(\\Omega)$: VCDim = $|\\Omega|$ (shatters every finite set)\n2. **Threshold classifiers** $\\{\\{n : n < t\\} : t \\in \\mathbb{N}\\}$: VCDim = 1\n3. **Interval classifiers** $\\{\\{n : lo \\leq n < hi\\} : lo, hi \\in \\mathbb{N}\\}$: VCDim = 2",
+    "text": "Defines VC dimension for hypothesis classes and computes it for powerset (shatters all), thresholds (VCDim = 1), and intervals (VCDim = 2). The interval non-shattering uses convexity: if a < b < c with a,c in an interval, then b is too.",
+    "proofStrategy": "For each hypothesis class, the VC dimension is established by proving both directions:\n\n1. **Lower bound**: Exhibit a set of the claimed size that is shattered. For thresholds, any singleton {a} is shattered (empty set via t=0, full set via t=a+1). For intervals, any pair {a,b} is shattered (four intervals realize all four subsets).\n\n2. **Upper bound**: Show no larger set can be shattered. For thresholds, monotonicity of {n < t} prevents realizing {b} from {a,b} when a < b (if b < t then a < t). For intervals, convexity prevents realizing {a,c} from {a,b,c} when a < b < c (if a,c in [lo,hi) then b in [lo,hi)).\n\nThe convexity argument for intervals is the key insight: intervals are connected subsets of the naturals, so they cannot separate non-adjacent elements while excluding elements between them.",
+    "keyInsights": [
+      "Threshold classifiers have VCDim 1 because they are monotone: {n < t} is an initial segment, so including a larger element forces inclusion of all smaller ones",
+      "Interval classifiers have VCDim 2 because they are convex: [lo, hi) cannot contain endpoints a,c while excluding an intermediate point b",
+      "The powerset trivially shatters everything (VCDim = |domain|), establishing the maximum possible VC dimension",
+      "The non-shattering proofs are more interesting than the shattering proofs: they require identifying the specific unrealizable subset"
+    ],
+    "prerequisites": [
+      "VC dimension and shattering definitions",
+      "Finset operations and membership",
+      "Natural number arithmetic"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Core Definitions",
+      "startLine": 23,
+      "endLine": 37,
+      "summary": "Defines HypothesisClass (family of subsets), Shatters (every subset realizable), and vcDim (largest shattered set size).",
+      "mathContext": "$H$ shatters $S$ if $\\forall T \\subseteq S, \\exists h \\in H$ s.t. $h \\cap S = T$. VCDim$(H) = \\sup\\{|S| : H \\text{ shatters } S\\}$."
+    },
+    {
+      "id": "powerset",
+      "title": "Powerset Shattering",
+      "startLine": 39,
+      "endLine": 51,
+      "summary": "The powerset (all subsets) shatters every finite set trivially: for any T, use h = T.",
+      "mathContext": "$\\mathcal{P}(\\Omega)$ shatters $S$ for all $S$: just take $h = T$ for any $T \\subseteq S$."
+    },
+    {
+      "id": "threshold",
+      "title": "Threshold Classifiers: VCDim = 1",
+      "startLine": 53,
+      "endLine": 101,
+      "summary": "Threshold classifiers {n < t} shatter singletons but cannot shatter pairs. The non-shattering uses monotonicity: b < t forces a < t when a < b.",
+      "mathContext": "VCDim$\\{\\{n < t\\}\\} = 1$. Shatters $\\{a\\}$ (use $t=0$ and $t=a+1$). Cannot shatter $\\{a,b\\}$ with $a < b$: the subset $\\{b\\}$ requires $b < t$ and $a \\geq t$, but $a < b < t$ contradicts $a \\geq t$."
+    },
+    {
+      "id": "interval-shatters",
+      "title": "Interval Classifiers: Shattering Pairs",
+      "startLine": 103,
+      "endLine": 147,
+      "summary": "Interval classifiers [lo, hi) shatter any pair {a, b} with a < b. Each of the four subsets is realized by an appropriate interval.",
+      "mathContext": "For $a < b$: $\\emptyset$ via $[0,0)$, $\\{a\\}$ via $[a,a+1)$, $\\{b\\}$ via $[b,b+1)$, $\\{a,b\\}$ via $[a,b+1)$."
+    },
+    {
+      "id": "interval-non-shatters",
+      "title": "Interval Classifiers: Non-Shattering of Triples",
+      "startLine": 149,
+      "endLine": 188,
+      "summary": "Interval classifiers cannot shatter any triple {a, b, c} with a < b < c. The subset {a, c} is unrealizable: if a,c are in [lo,hi), convexity forces b in [lo,hi) too.",
+      "mathContext": "For $a < b < c$: $\\{a,c\\}$ requires $a \\in [lo,hi)$ and $c \\in [lo,hi)$ but $b \\notin [lo,hi)$. But $lo \\leq a < b < c < hi$ forces $b \\in [lo,hi)$. Contradiction."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "pac-learning-bounds",
+      "relationship": "extends",
+      "description": "This proof computes VC dimensions for specific classes; the parent proves the Sauer-Shelah lemma bounding growth functions in terms of VC dimension"
+    }
+  ],
+  "conclusion": {
+    "summary": "Complete VC dimension computation for three fundamental hypothesis classes, establishing VCDim(powerset) = |domain|, VCDim(thresholds) = 1, and VCDim(intervals) = 2. The interval result uses a clean convexity argument that generalizes to any connected hypothesis class.",
+    "implications": "These concrete computations complement the abstract Sauer-Shelah bounds in the parent proof. They demonstrate that VC dimension captures geometric structure: monotone classes (thresholds) have lower VC dimension than convex classes (intervals), which have lower VC dimension than unrestricted classes (powerset).",
+    "openQuestions": [
+      "What is the connection to Rademacher complexity, and can the Rademacher-based generalization bound be formalized?",
+      "VCDim for halfspace classifiers in R^d (expected: d+1) — requires formalizing linear algebra over R",
+      "Can the epsilon-net theorem be formalized in Lean to get the tighter sample complexity bound?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": "VCDimension",
+    "lineCount": 219,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 5
+  },
+  "references": [
+    {
+      "authors": "Vapnik, Vladimir; Chervonenkis, Alexey",
+      "title": "On the Uniform Convergence of Relative Frequencies of Events to Their Probabilities",
+      "year": "1971",
+      "venue": "Theory of Probability and Its Applications 16(2), 264-280",
+      "note": "Introduced VC dimension and the concept of shattering"
+    },
+    {
+      "authors": "Shalev-Shwartz, Shai; Ben-David, Shai",
+      "title": "Understanding Machine Learning: From Theory to Algorithms",
+      "year": "2014",
+      "venue": "Cambridge University Press",
+      "note": "Standard reference for VC dimension computations of specific hypothesis classes"
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "interval_not_shatters_triple",
+      "type": "core",
+      "description": "Interval classifiers cannot shatter triples, proving VCDim = 2",
+      "leanType": "∀ a b c : ℕ, a < b → b < c → ¬Shatters intervalClassifiers {a, b, c}"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Two research sessions in one PR.

### 1. VC Dimension Computations (pac-learning-bounds-oq-01)
- Restored `VCDimension.lean` (lost from orphan branch, never merged)
- Added `interval_not_shatters_triple`: convexity argument proves VCDim(intervals) = 2
- 8 theorems, 0 sorries, 0 axioms
- Created gallery entry

### 2. Erdos-1040 mu Definition Bugfix (erdos-1040-oq-05)
- **Found critical bug**: `mu F = 0` for ALL F due to degree-0 polynomial inclusion
  - The constant polynomial 1 has `sublevelSet = {z : |1| < 1} = empty`
  - This made `erdos_1040_current_state` unprovable (claims mu > 0 for small diameter)
- Added `mu_pos_degree`: corrected definition restricting to degree >= 1
- Proved `degree_zero_sublevel_empty` and `mu_eq_zero_of_degree_zero`
- Updated all axioms and conjectures to use corrected definition

## Stats
| File | Theorems | Axioms | Sorries |
|------|----------|--------|---------|
| VCDimension.lean | 8 | 0 | 0 |
| Erdos1040Problem.lean | 14 (+3) | 7 | 6 |
| Erdos1040Aristotle.lean | 3 | 0 | 4 |

## Status
- pac-learning-bounds-oq-01: **completed**
- erdos-1040-oq-05: **in-progress** (sorries remain in basic properties)

Generated by researcher-1