### PR TITLE
Fix: add Aristotle companion for TaylorSinCosConvergenceOQ03

### DIFF
--- a/proofs/Proofs/TaylorSinCosConvergenceOQ03Aristotle.lean
+++ b/proofs/Proofs/TaylorSinCosConvergenceOQ03Aristotle.lean
@@ -1,0 +1,70 @@
+/-
+  Aristotle targets for TaylorSinCosConvergenceOQ03
+  Routine supporting lemmas for automated proof search.
+  See TaylorSinCosConvergenceOQ03.lean for the main formalization.
+
+  Criteria for inclusion:
+  - All results are well-known analysis facts
+  - Alternating series estimation, monotonicity, convergence
+  - Clean theorem statements with no definition sorries
+  - No axioms, no open conjectures
+-/
+import Mathlib
+
+open Finset Real Set
+open scoped Nat
+
+namespace AlternatingSeriesEstimation
+
+/-- The absolute value of the k-th term of the sin Taylor series. -/
+noncomputable def sinTermAbs (x : ℝ) (k : ℕ) : ℝ :=
+  |x| ^ (2 * k + 1) / (Nat.factorial (2 * k + 1) : ℝ)
+
+/-- The absolute value of the k-th term of the cos Taylor series. -/
+noncomputable def cosTermAbs (x : ℝ) (k : ℕ) : ℝ :=
+  |x| ^ (2 * k) / (Nat.factorial (2 * k) : ℝ)
+
+/-- Alternating Series Estimation (partial sum form):
+    For a decreasing non-negative sequence, the alternating partial sum
+    through an even index lies between 0 and a₀. -/
+theorem alternating_partial_sum_even_bounds {a : ℕ → ℝ}
+    (ha_pos : ∀ k, 0 ≤ a k) (ha_dec : Antitone a) (m : ℕ) :
+    0 ≤ ∑ k ∈ range (2 * m + 1), (-1 : ℝ) ^ k * a k ∧
+    ∑ k ∈ range (2 * m + 1), (-1 : ℝ) ^ k * a k ≤ a 0 := by
+  sorry
+
+/-- Alternating Series Estimation (tail bound):
+    For a decreasing non-negative sequence converging to 0,
+    the tail after n terms is bounded by aₙ. -/
+theorem alternating_tail_bound {a : ℕ → ℝ}
+    (ha_pos : ∀ k, 0 ≤ a k) (ha_dec : Antitone a)
+    (ha_lim : Filter.Tendsto a Filter.atTop (nhds 0))
+    (ha_sum : Summable (fun k => (-1 : ℝ) ^ k * a k)) (n : ℕ) :
+    ‖∑' k, (-1 : ℝ) ^ (k + n) * a (k + n)‖ ≤ a n := by
+  sorry
+
+/-- Sin series terms are eventually decreasing for |x| ≤ 1. -/
+theorem sinTermAbs_antitone (x : ℝ) (hx : |x| ≤ 1) :
+    Antitone (sinTermAbs x) := by
+  sorry
+
+/-- Sin series terms tend to 0 for any fixed x. -/
+theorem sinTermAbs_tendsto (x : ℝ) :
+    Filter.Tendsto (sinTermAbs x) Filter.atTop (nhds 0) := by
+  sorry
+
+/-- Alternating series remainder bound for sin Taylor series. -/
+theorem sin_alternating_remainder (n : ℕ) (x : ℝ) :
+    ‖Real.sin x - ∑ k ∈ range n,
+      (-1 : ℝ) ^ k * x ^ (2 * k + 1) / (Nat.factorial (2 * k + 1) : ℝ)‖ ≤
+    sinTermAbs x n := by
+  sorry
+
+/-- Alternating series remainder bound for cos Taylor series. -/
+theorem cos_alternating_remainder (n : ℕ) (x : ℝ) :
+    ‖Real.cos x - ∑ k ∈ range n,
+      (-1 : ℝ) ^ k * x ^ (2 * k) / (Nat.factorial (2 * k) : ℝ)‖ ≤
+    cosTermAbs x n := by
+  sorry
+
+end AlternatingSeriesEstimation


### PR DESCRIPTION
## Fix

Add Aristotle companion file for `TaylorSinCosConvergenceOQ03.lean` with 6 routine analysis sorries for automated proof search.

## Evidence

**Before**: TaylorSinCosConvergenceOQ03.lean has 6 sorries with no Aristotle companion file
**After**: TaylorSinCosConvergenceOQ03Aristotle.lean created with all 6 sorry targets:
1. `alternating_partial_sum_even_bounds` — partial sum bounds for alternating series
2. `alternating_tail_bound` — tail bound for alternating series
3. `sinTermAbs_antitone` — sin terms decreasing for |x| ≤ 1
4. `sinTermAbs_tendsto` — sin terms converge to 0
5. `sin_alternating_remainder` — sin Taylor remainder bound
6. `cos_alternating_remainder` — cos Taylor remainder bound

All sorries are routine analysis results (TRIVIAL/HARD classification).

Pre-submission checklist:
- [x] No `def ... := sorry`
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections
- [x] No open conjectures

---
Automated fix by lean-mechanic agent.