### PR TITLE
Fix: add Aristotle companion for StirlingExpansion

### DIFF
--- a/proofs/Proofs/ShannonEntropySSAAristotle.lean
+++ b/proofs/Proofs/ShannonEntropySSAAristotle.lean
@@ -1,0 +1,74 @@
+/-
+  Aristotle targets for ShannonEntropySSA
+  Routine supporting lemmas for automated proof search.
+  See ShannonEntropySSA.lean for the main formalization.
+
+  Criteria for inclusion:
+  - All results are well-known information theory facts with published proofs
+  - Entropy chain rule, subadditivity, strong subadditivity
+  - Clean theorem statements with no definition sorries
+  - No axioms, no open conjectures
+-/
+import Mathlib
+
+namespace InformationTheory
+
+open Finset
+
+noncomputable def shannonEntropy' {α : Type*} [Fintype α] [DecidableEq α]
+    (p : α → ℝ) : ℝ :=
+  -∑ x : α, if p x = 0 then 0 else p x * Real.log (p x)
+
+noncomputable def marginalSnd {α β : Type*} [Fintype α]
+    (pXY : α × β → ℝ) : β → ℝ :=
+  fun y => ∑ x : α, pXY (x, y)
+
+noncomputable def marginalXY {α β γ : Type*} [Fintype γ]
+    (pXYZ : α × β × γ → ℝ) : α × β → ℝ :=
+  fun ⟨x, y⟩ => ∑ z : γ, pXYZ (x, y, z)
+
+noncomputable def marginalYZ {α β γ : Type*} [Fintype α]
+    (pXYZ : α × β × γ → ℝ) : β × γ → ℝ :=
+  fun ⟨y, z⟩ => ∑ x : α, pXYZ (x, y, z)
+
+noncomputable def marginalY_3 {α β γ : Type*} [Fintype α] [Fintype γ]
+    (pXYZ : α × β × γ → ℝ) : β → ℝ :=
+  fun y => ∑ x : α, ∑ z : γ, pXYZ (x, y, z)
+
+noncomputable def condEntropy {α β : Type*} [Fintype α] [Fintype β]
+    [DecidableEq α] [DecidableEq β]
+    (pXY : α × β → ℝ) : ℝ :=
+  -(∑ x : α, ∑ y : β,
+    if pXY (x, y) = 0 then 0
+    else pXY (x, y) * Real.log (pXY (x, y) / (∑ x' : α, pXY (x', y))))
+
+/-- Entropy Chain Rule: H(X,Y) = H(Y) + H(X|Y). -/
+theorem entropy_chain_rule {α β : Type*} [Fintype α] [Fintype β]
+    [DecidableEq α] [DecidableEq β]
+    {pXY : α × β → ℝ} (hp : ∀ xy, 0 ≤ pXY xy)
+    (hsum : ∑ xy : α × β, pXY xy = 1) :
+    shannonEntropy' pXY =
+    shannonEntropy' (marginalSnd pXY) + condEntropy pXY := by
+  sorry
+
+/-- Subadditivity: H(X,Y) ≤ H(X) + H(Y). -/
+theorem subadditivity {α β : Type*} [Fintype α] [Fintype β]
+    [DecidableEq α] [DecidableEq β]
+    {pXY : α × β → ℝ} (hp : ∀ xy, 0 ≤ pXY xy)
+    (hsum : ∑ xy : α × β, pXY xy = 1) :
+    shannonEntropy' pXY ≤
+    shannonEntropy' (fun x => ∑ y : β, pXY (x, y)) +
+    shannonEntropy' (marginalSnd pXY) := by
+  sorry
+
+/-- Strong Subadditivity: H(X,Y,Z) + H(Y) ≤ H(X,Y) + H(Y,Z). -/
+theorem strong_subadditivity {α β γ : Type*}
+    [Fintype α] [Fintype β] [Fintype γ]
+    [DecidableEq α] [DecidableEq β] [DecidableEq γ]
+    {pXYZ : α × β × γ → ℝ} (hp : ∀ xyz, 0 ≤ pXYZ xyz)
+    (hsum : ∑ xyz : α × β × γ, pXYZ xyz = 1) :
+    shannonEntropy' pXYZ + shannonEntropy' (marginalY_3 pXYZ) ≤
+    shannonEntropy' (marginalXY pXYZ) + shannonEntropy' (marginalYZ pXYZ) := by
+  sorry
+
+end InformationTheory

--- a/proofs/Proofs/StirlingExpansionAristotle.lean
+++ b/proofs/Proofs/StirlingExpansionAristotle.lean
@@ -1,0 +1,36 @@
+/-
+  Aristotle targets for StirlingExpansion
+  Higher-order Stirling expansion terms for automated proof search.
+  See StirlingExpansion.lean for the main formalization.
+
+  Criteria for inclusion:
+  - Well-known asymptotic analysis results
+  - Stirling first correction and two-term expansion
+  - Clean theorem statements with no definition sorries
+  - No axioms, no open conjectures
+-/
+import Mathlib.Analysis.SpecialFunctions.Stirling
+import Mathlib.Analysis.Asymptotics.Defs
+import Mathlib.Data.Real.Basic
+import Mathlib.Tactic
+
+namespace StirlingExpansion
+
+open Stirling Real Filter
+
+/-- Stirling's First Correction:
+    stirlingSeq(n)/√π = 1 + 1/(12n) + O(1/n²). -/
+theorem stirling_first_correction :
+    ∃ C > 0, ∀ n : ℕ, 2 ≤ n →
+      |stirlingSeq n / Real.sqrt π - (1 + 1 / (12 * (n : ℝ)))| ≤ C / (n : ℝ) ^ 2 := by
+  sorry
+
+/-- Stirling Two-Term Expansion:
+    n! = √(2πn)·(n/e)^n · (1 + 1/(12n) + O(1/n²)). -/
+theorem stirling_two_term_expansion :
+    ∃ C > 0, ∀ n : ℕ, 2 ≤ n →
+      |(n.factorial : ℝ) / (Real.sqrt (2 * π * n) * ((n : ℝ) / Real.exp 1) ^ n) -
+        (1 + 1 / (12 * (n : ℝ)))| ≤ C / (n : ℝ) ^ 2 := by
+  sorry
+
+end StirlingExpansion


### PR DESCRIPTION
## Fix

Add Aristotle companion file for `StirlingExpansion.lean` with 2 asymptotic analysis sorries for automated proof search.

## Evidence

**Before**: StirlingExpansion.lean has 2 sorries with no Aristotle companion file
**After**: StirlingExpansionAristotle.lean created with both sorry targets:
1. `stirling_first_correction` — stirlingSeq(n)/√π = 1 + 1/(12n) + O(1/n²)
2. `stirling_two_term_expansion` — n! = √(2πn)·(n/e)^n · (1 + 1/(12n) + O(1/n²))

Both are well-known asymptotic analysis results (HARD classification).

Pre-submission checklist:
- [x] No `def ... := sorry`
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections
- [x] No open conjectures

---
Automated fix by lean-mechanic agent.