### PR TITLE
Audit: fix line counts in 2 proofs

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10003,6 +10003,18 @@
       "lastAudited": "2026-03-30T03:28:56Z",
       "result": "issues-fixed",
       "issues": []
+    },
+    "harmonic-divergence-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T03:51:01Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "lagrange-theorem-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T03:51:01Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "descartes-rule-of-signs-oq-02": {

--- a/src/data/proofs/harmonic-divergence-oq-04/meta.json
+++ b/src/data/proofs/harmonic-divergence-oq-04/meta.json
@@ -46,7 +46,7 @@
     ],
     "axiomCount": 0,
     "assumptions": "None. Fully verified, 0 axioms, 0 sorries.",
-    "lineCount": 113
+    "lineCount": 106
   },
   "overview": {
     "historicalContext": "Nicole Oresme (~1350) proved the harmonic series diverges by grouping terms: each group of 2^k terms sums to at least 1/2, giving infinitely many groups each contributing at least 1/2. Augustin-Louis Cauchy (1821) generalized this to the condensation test: for any nonneg antitone sequence f, Σ f(n) converges iff Σ 2^k·f(2^k) converges. This completely characterizes convergence for monotone decreasing sequences.",
@@ -137,7 +137,7 @@
       "Real"
     ],
     "namespace": "HarmonicDivergenceOQ04",
-    "lineCount": 113,
+    "lineCount": 106,
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 0

--- a/src/data/proofs/lagrange-theorem-oq-05/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-05/meta.json
@@ -47,7 +47,7 @@
     ],
     "axiomCount": 0,
     "assumptions": "None. Fully verified, 0 axioms, 0 sorries.",
-    "lineCount": 118
+    "lineCount": 113
   },
   "overview": {
     "historicalContext": "Lagrange's theorem (1771) that subgroup orders divide group orders is foundational. The orbit-stabilizer theorem generalizes it to group actions. Burnside's lemma (actually due to Cauchy and Frobenius) uses orbit-stabilizer to count orbits via fixed points.",
@@ -139,7 +139,7 @@
       "BigOperators"
     ],
     "namespace": "BurnsideLemma",
-    "lineCount": 118,
+    "lineCount": 113,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 1


### PR DESCRIPTION
## Summary

- **harmonic-divergence-oq-04**: lineCount 113→106
- **lagrange-theorem-oq-05**: lineCount 118→113

Both proofs are otherwise clean (0 sorries, 0 axioms, no True stubs, correct status/badge).

## Test plan

- [ ] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)