### PR TITLE
Audit: fix theorem count in ramseys-theorem-oq-04

### DIFF
--- a/src/data/proofs/ramseys-theorem-oq-04/meta.json
+++ b/src/data/proofs/ramseys-theorem-oq-04/meta.json
@@ -81,7 +81,7 @@
     "namespace": "HypergraphRamsey",
     "lineCount": 115,
     "axiomCount": 1,
-    "theoremCount": 7,
+    "theoremCount": 5,
     "definitionCount": 5
   }
 }


### PR DESCRIPTION
## Summary

- **ramseys-theorem-oq-04**: theoremCount 7→5 (actual theorems: k1_is_pigeonhole, classical_ramsey_is_k2, tower_2_1, tower_2_2, tower_strictMono)

All other checks passed (0 sorries, 1 axiom, correct line count 115, correct status/badge axiomatized/axiom).

## Test plan

- [ ] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)