### PR TITLE
Fix: correct status overclaims for angle-trisection and dissection-of-cubes-oq-01

### DIFF
--- a/src/data/proofs/angle-trisection/meta.json
+++ b/src/data/proofs/angle-trisection/meta.json
@@ -7,7 +7,7 @@
         "author": "Pierre Wantzel (1837)",
         "sourceUrl": "https://en.wikipedia.org/wiki/Angle_trisection",
         "date": "1837",
-        "status": "verified",
+        "status": "axiomatized",
         "tags": [
             "geometry",
             "galois-theory",
@@ -18,7 +18,7 @@
             "wiedijk-100"
         ],
         "proofRepoPath": "Proofs/AngleTrisection.lean",
-        "badge": "verified",
+        "badge": "axiom",
         "sorries": 0,
         "mathlibDependencies": [
             {
@@ -60,7 +60,7 @@
         ],
         "dateAdded": "2025-12-26",
         "wiedijkNumber": 8,
-        "axiomCount": 0,
+        "axiomCount": 2,
         "prerequisites": [
             "Field extensions and algebraic degree",
             "Polynomial rings and irreducibility over Q",

--- a/src/data/proofs/dissection-of-cubes-oq-01/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01/meta.json
@@ -7,7 +7,7 @@
         "author": "Littlewood / formalized here",
         "sourceUrl": "https://en.wikipedia.org/wiki/Squaring_the_square",
         "date": "1953",
-        "status": "verified",
+        "status": "axiomatized",
         "proofRepoPath": "Proofs/DissectionOfCubesOQ01.lean",
         "tags": [
             "geometry",
@@ -17,7 +17,7 @@
             "open-problem",
             "wiedijk-100"
         ],
-        "badge": "verified",
+        "badge": "axiom",
         "sorries": 0,
         "mathlibDependencies": [
             {
@@ -52,7 +52,7 @@
             "Floor argument commentary: why Littlewood's cascade forces many collisions in practice"
         ],
         "dateAdded": "2026-02-23",
-        "axiomCount": 0,
+        "axiomCount": 2,
         "lineCount": 274
     },
     "overview": {


### PR DESCRIPTION
## Fix

Correct status/badge/axiomCount for 2 proofs that depend on axiomatized companion files.

## Evidence

**angle-trisection**:
- Before: status=verified, badge=verified, meta.axiomCount=0
- After: status=axiomatized, badge=axiom, meta.axiomCount=2
- Reason: imports PiTranscendental.lean which has 2 axiom declarations (lindemann_theorem, pi_transcendental)

**dissection-of-cubes-oq-01**:
- Before: status=verified, badge=verified, meta.axiomCount=0
- After: status=axiomatized, badge=axiom, meta.axiomCount=2
- Reason: imports DissectionOfCubes.lean which has 2 axiom declarations (smaller_cube_above_axiom, all_different_implies_long_chains_axiom)

Per axiom integrity policy: proofs depending on axioms (even transitively) must be axiomatized, not verified.

---
Automated fix by lean-mechanic agent.