### PR TITLE
Fix: correct stale leanFile.axiomCount in 4 axiom-free proofs

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-02/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-02/meta.json
@@ -175,7 +175,7 @@
     ],
     "namespace": "BuffonHigherDim",
     "lineCount": 274,
-    "axiomCount": 3,
+    "axiomCount": 0,
     "theoremCount": 19,
     "definitionCount": 3
   },

--- a/src/data/proofs/erdos-278/meta.json
+++ b/src/data/proofs/erdos-278/meta.json
@@ -172,7 +172,7 @@
     "opens": [],
     "namespace": "",
     "lineCount": 644,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 31,
     "definitionCount": 7,
     "mainTheorems": [

--- a/src/data/proofs/erdos-374/meta.json
+++ b/src/data/proofs/erdos-374/meta.json
@@ -142,7 +142,7 @@
     ],
     "namespace": "",
     "lineCount": 195,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 5
   },

--- a/src/data/proofs/triangle-inequality-oq-03/meta.json
+++ b/src/data/proofs/triangle-inequality-oq-03/meta.json
@@ -188,7 +188,7 @@
     "leanFile": {
         "lineCount": 255,
         "structureCount": 0,
-        "axiomCount": 1,
+        "axiomCount": 0,
         "theoremCount": 15,
         "lemmaCount": 0,
         "defCount": 0,


### PR DESCRIPTION
## Fix

Correct stale `leanFile.axiomCount` values in 4 proofs that have 0 actual axioms.

## Evidence

| Proof | Before | After | Verification |
|-------|--------|-------|-------------|
| buffons-needle-oq-01-oq-02 | axiomCount=3 | axiomCount=0 | 0 `axiom` decls, imports only Mathlib |
| erdos-278 | axiomCount=1 | axiomCount=0 | 0 `axiom` decls, no `import Proofs.*` |
| erdos-374 | axiomCount=1 | axiomCount=0 | 0 `axiom` decls, no `import Proofs.*` |
| triangle-inequality-oq-03 | axiomCount=1 | axiomCount=0 | 0 `axiom` decls, no structures with assumptions |

All 4 Lean files have zero axiom declarations and no structure-encoded assumptions. The stale counts were from previous file versions that have since been cleaned up.

---
Automated fix by lean-mechanic agent.