### PR TITLE
Audit: fix sorry/line count mismatches in 4 proofs

### DIFF
--- a/src/data/proofs/erdos-75/meta.json
+++ b/src/data/proofs/erdos-75/meta.json
@@ -17,12 +17,12 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 75,
     "erdosUrl": "https://erdosproblems.com/75",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "lineCount": 160,
+    "lineCount": 187,
     "assumptions": "3 axioms: finite_chromatic_independence (pigeonhole on color classes), ErdosProblem75 (basic conjecture), ErdosProblem75_strong (strong conjecture). Graph infrastructure now uses concrete structures and proved theorems.",
     "mathlib_version": "4.26.0"
   },
@@ -110,7 +110,7 @@
       "Classical"
     ],
     "namespace": "Erdos75",
-    "lineCount": 160,
+    "lineCount": 187,
     "axiomCount": 3,
     "theoremCount": 6,
     "definitionCount": 10

--- a/src/data/proofs/fourier-series-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-03-oq-02/meta.json
@@ -17,9 +17,9 @@
       "sharp-constants"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 3,
     "axiomCount": 3,
-    "lineCount": 365,
+    "lineCount": 387,
     "mathlibDependencies": [
       {
         "theorem": "fourierCoeff",
@@ -195,7 +195,7 @@
       "Filter"
     ],
     "namespace": "FourierAnalyticDecay",
-    "lineCount": 365,
+    "lineCount": 387,
     "structureCount": 0,
     "axiomCount": 3,
     "theoremCount": 10,

--- a/src/data/proofs/prob-method-second-moment/meta.json
+++ b/src/data/proofs/prob-method-second-moment/meta.json
@@ -7,7 +7,7 @@
     "author": "Chebyshev, Paley-Zygmund, formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Second_moment_method",
     "date": "1867",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/ProbMethodSecondMoment.lean",
     "tags": [
       "probabilistic-method",
@@ -16,8 +16,8 @@
       "probability",
       "intermediate"
     ],
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "MeasureTheory.Integral.Lebesgue",
@@ -43,7 +43,7 @@
     ],
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
-    "lineCount": 161,
+    "lineCount": 186,
     "prerequisites": [
       "Variance and second moments of random variables",
       "Chebyshev's inequality and concentration",
@@ -51,7 +51,7 @@
       "Random graphs G(n,p) and threshold functions",
       "Indicator random variables and covariance"
     ],
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "1 sorry: paley_zygmund_quantitative. 0 axioms.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -163,7 +163,7 @@
     ],
     "opens": [],
     "namespace": "ProbMethod.SecondMoment",
-    "lineCount": 161,
+    "lineCount": 186,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0

--- a/src/data/proofs/shannon-entropy/meta.json
+++ b/src/data/proofs/shannon-entropy/meta.json
@@ -7,7 +7,7 @@
     "author": "Claude Shannon (1948), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Entropy_(information_theory)",
     "date": "1948",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/ShannonEntropy.lean",
     "tags": [
       "information-theory",
@@ -15,8 +15,8 @@
       "probability",
       "advanced"
     ],
-    "badge": "verified",
-    "sorries": 0,
+    "badge": "wip",
+    "sorries": 2,
     "mathlibDependencies": [
       {
         "theorem": "Analysis.SpecialFunctions.Log.Basic",
@@ -44,7 +44,7 @@
     ],
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
-    "lineCount": 566,
+    "lineCount": 643,
     "prerequisites": [
       "Probability distributions and discrete random variables",
       "Logarithm and convexity (Jensen's inequality)",
@@ -52,7 +52,7 @@
       "Conditional entropy and mutual information",
       "Data processing inequality and sufficient statistics"
     ],
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "2 sorries: strong_subadditivity and entropy_chain_rule. 0 axioms.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -174,7 +174,7 @@
     ],
     "opens": [],
     "namespace": "InformationTheory",
-    "lineCount": 566,
+    "lineCount": 643,
     "axiomCount": 0,
     "theoremCount": 16,
     "definitionCount": 4


### PR DESCRIPTION
## Summary

**CRITICAL** fixes (status overclaim):
- **shannon-entropy**: status verified→formalized, badge verified→wip, sorries 0→2 (strong_subadditivity, entropy_chain_rule), lineCount 566→643
- **prob-method-second-moment**: status verified→formalized, badge verified→wip, sorries 0→1 (paley_zygmund_quantitative), lineCount 161→186

Other fixes:
- **erdos-75**: sorries 0→1, lineCount 160→187
- **fourier-series-oq-02-oq-03-oq-02**: sorries 4→3, lineCount 365→387

## Test plan

- [ ] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)