### PR TITLE
Audit: fix line counts in 4 proofs

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-04/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-04/meta.json
@@ -61,7 +61,7 @@
       }
     ],
     "axiomCount": 1,
-    "lineCount": 160,
+    "lineCount": 169,
     "assumptions": "1 axiom: chung_feller_uniform (the uniform distribution of path types, requiring an explicit bijection between rotation indices and upstep-above-axis counts). All structural infrastructure is proved.",
     "mathlib_version": "4.26.0"
   },
@@ -160,7 +160,7 @@
       "LatticePathLGV"
     ],
     "namespace": "ChungFeller",
-    "lineCount": 160,
+    "lineCount": 169,
     "axiomCount": 1,
     "theoremCount": 8,
     "substantiveTheoremCount": 7,

--- a/src/data/proofs/greens-theorem-oq-04/meta.json
+++ b/src/data/proofs/greens-theorem-oq-04/meta.json
@@ -74,7 +74,7 @@
       "de-rham",
       "research"
     ],
-    "lineCount": 552,
+    "lineCount": 584,
     "prerequisites": [
       "Green's theorem for simply-connected regions (OQ-01, OQ-03)",
       "TypeI regions and iterated integrals",

--- a/src/data/proofs/ptolemys-complex-proof/meta.json
+++ b/src/data/proofs/ptolemys-complex-proof/meta.json
@@ -38,7 +38,7 @@
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 113,
+    "lineCount": 154,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
   },
   "overview": {

--- a/src/data/proofs/triangular-reciprocals-oq-01/meta.json
+++ b/src/data/proofs/triangular-reciprocals-oq-01/meta.json
@@ -7,7 +7,13 @@
     "author": "Classical",
     "status": "verified",
     "proofRepoPath": "Proofs/TriangularReciprocalsFigurate.lean",
-    "tags": ["analysis", "series", "combinatorics", "figurate-numbers", "classic"],
+    "tags": [
+      "analysis",
+      "series",
+      "combinatorics",
+      "figurate-numbers",
+      "classic"
+    ],
     "badge": "verified",
     "sorries": 0,
     "dateAdded": "2026-03-29",
@@ -20,7 +26,7 @@
     ],
     "axiomCount": 0,
     "assumptions": "None. Fully verified.",
-    "lineCount": 110
+    "lineCount": 111
   },
   "overview": {
     "historicalContext": "Figurate (polygonal) numbers date to the Pythagoreans. The sum of reciprocals of triangular numbers telescopes to 2 via partial fractions. Higher figurate reciprocal sums converge by comparison with 1/n².",
@@ -29,7 +35,24 @@
   },
   "sections": [],
   "references": [],
-  "crossReferences": [{"targetId": "triangular-reciprocals", "relationship": "extends", "description": "Extends to general k-gonal numbers"}],
-  "conclusion": {"summary": "Figurate number reciprocal sums formalized with telescoping and convergence."},
-  "leanFile": {"imports": ["Mathlib"], "namespace": "FigurateReciprocals", "lineCount": 110, "axiomCount": 0, "theoremCount": 11, "definitionCount": 3}
+  "crossReferences": [
+    {
+      "targetId": "triangular-reciprocals",
+      "relationship": "extends",
+      "description": "Extends to general k-gonal numbers"
+    }
+  ],
+  "conclusion": {
+    "summary": "Figurate number reciprocal sums formalized with telescoping and convergence."
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "FigurateReciprocals",
+    "lineCount": 111,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 3
+  }
 }


### PR DESCRIPTION
## Summary

- **ballot-problem-oq-01-oq-04**: lineCount 160→169
- **greens-theorem-oq-04**: meta.lineCount 552→584
- **ptolemys-complex-proof**: meta.lineCount 113→154
- **triangular-reciprocals-oq-01**: lineCount 110→111

All proofs are otherwise clean (correct sorries, axioms, status, badge).

## Test plan

- [ ] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)