### PR TITLE
Research: factor-remainder-theorem-oq-03 - multivariate V-I Galois connection

### DIFF
--- a/proofs/Proofs/FactorRemainderTheoremOQ03.lean
+++ b/proofs/Proofs/FactorRemainderTheoremOQ03.lean
@@ -2,6 +2,7 @@ import Mathlib.Algebra.Polynomial.Div
 import Mathlib.Algebra.Polynomial.FieldDivision
 import Mathlib.FieldTheory.IsAlgClosed.Basic
 import Mathlib.Algebra.MvPolynomial.Basic
+import Mathlib.RingTheory.Ideal.Basic
 import Mathlib.Tactic
 
 /-
@@ -23,12 +24,18 @@ The univariate Factor Theorem says: `f(a) = 0 ↔ (X - C a) ∣ f`.
 The Nullstellensatz generalizes this to systems of multivariate polynomials:
 a system `f₁ = ⋯ = fₘ = 0` has no solution iff 1 is in the ideal `(f₁,...,fₘ)`.
 
+4. Defines **multivariate zero loci and vanishing ideals** for `MvPolynomial`
+   and proves the V-I Galois connection and idempotence properties.
+
 ## Status
 - [x] Univariate weak Nullstellensatz (from IsAlgClosed)
 - [x] Factor Theorem as ideal membership
 - [x] Root count upper bound (from degree)
 - [x] Nonconstant polynomials are not units
-- [ ] Multivariate Nullstellensatz (formalization target for future work)
+- [x] Multivariate zeroLocus and vanishingIdeal definitions
+- [x] Galois connection: S ⊆ V(I(S)), S ⊆ I(V(S))
+- [x] Idempotence: V(I(V(S))) = V(S) and I(V(I(W))) = I(W)
+- [ ] Multivariate weak Nullstellensatz proof (requires Jacobson ring theory)
 
 ## Mathlib Dependencies
 - `IsAlgClosed.exists_root` : nonconstant polynomials have roots
@@ -144,7 +151,113 @@ Formalizing Levels 2-4 in Lean would require:
 -/
 
 -- ============================================================
--- PART 5: Numerical Examples
+-- PART 5: Multivariate Zero Loci and Vanishing Ideals
+-- ============================================================
+-- The Nullstellensatz connects two operations that form a Galois connection:
+--   V : Ideals → Sets (zero locus: points where all polynomials in I vanish)
+--   I : Sets → Ideals (vanishing ideal: polynomials vanishing on all points in S)
+
+namespace Nullstellensatz
+
+open MvPolynomial
+
+variable {σ : Type*} {k : Type*} [CommRing k]
+
+/-- The **zero locus** of a set of multivariate polynomials: the set of points
+where every polynomial in the set evaluates to zero.
+
+V(S) = { v : σ → k | ∀ f ∈ S, eval v f = 0 }
+
+This is the fundamental geometric object in algebraic geometry. -/
+def zeroLocus (S : Set (MvPolynomial σ k)) : Set (σ → k) :=
+  { v | ∀ f ∈ S, MvPolynomial.eval v f = 0 }
+
+/-- The **vanishing ideal** of a set of points: the set of polynomials
+that evaluate to zero at every point in the set.
+
+I(W) = { f : MvPolynomial σ k | ∀ v ∈ W, eval v f = 0 }
+
+This is an ideal of the polynomial ring (closure under +, ·, and 0 follows
+from eval being a ring homomorphism). -/
+def vanishingIdeal (W : Set (σ → k)) : Ideal (MvPolynomial σ k) where
+  carrier := { f | ∀ v ∈ W, MvPolynomial.eval v f = 0 }
+  add_mem' {a b} ha hb := fun v hv => by
+    rw [map_add, ha v hv, hb v hv, add_zero]
+  zero_mem' := fun v _ => map_zero (MvPolynomial.eval v)
+  smul_mem' c {f} hf := fun v hv => by
+    change MvPolynomial.eval v (c * f) = 0
+    rw [map_mul, hf v hv, mul_zero]
+
+/-- Zero locus is antimonotone: more polynomials means fewer common zeros. -/
+theorem zeroLocus_antimono {S T : Set (MvPolynomial σ k)} (h : S ⊆ T) :
+    zeroLocus T ⊆ zeroLocus S :=
+  fun _ hv f hf => hv f (h hf)
+
+/-- Vanishing ideal is antimonotone: more points means fewer common vanishing polynomials. -/
+theorem vanishingIdeal_antimono {W₁ W₂ : Set (σ → k)} (h : W₁ ⊆ W₂) :
+    vanishingIdeal W₂ ≤ vanishingIdeal W₁ :=
+  fun _ hf v hv => hf v (h hv)
+
+/-- **Galois connection (V ∘ I direction)**: Every point set is contained in the
+zero locus of its vanishing ideal. S ⊆ V(I(S)). -/
+theorem subset_zeroLocus_vanishingIdeal (W : Set (σ → k)) :
+    W ⊆ zeroLocus (vanishingIdeal W : Ideal (MvPolynomial σ k)) :=
+  fun v hv f hf => hf v hv
+
+/-- **Galois connection (I ∘ V direction)**: Every polynomial set is contained in the
+vanishing ideal of its zero locus. S ⊆ I(V(S)). -/
+theorem subset_vanishingIdeal_zeroLocus (S : Set (MvPolynomial σ k)) :
+    S ⊆ (vanishingIdeal (zeroLocus S) : Ideal (MvPolynomial σ k)) :=
+  fun f hf v hv => hv f hf
+
+/-- The vanishing ideal of the empty set is the whole ring: every polynomial
+vacuously vanishes on the empty set. I(∅) = k[x₁,...,xₙ]. -/
+theorem vanishingIdeal_empty :
+    vanishingIdeal (∅ : Set (σ → k)) = ⊤ := by
+  ext f
+  constructor
+  · intro _; exact Submodule.mem_top
+  · intro _ v hv; exact absurd hv (Set.not_mem_empty v)
+
+/-- The zero locus of a single polynomial is its vanishing set. -/
+theorem zeroLocus_singleton (f : MvPolynomial σ k) :
+    zeroLocus {f} = { v | MvPolynomial.eval v f = 0 } := by
+  ext v; simp [zeroLocus]
+
+/-- The zero locus distributes over unions: V(S ∪ T) = V(S) ∩ V(T).
+More equations means more constraints, so the solution set shrinks. -/
+theorem zeroLocus_union (S T : Set (MvPolynomial σ k)) :
+    zeroLocus (S ∪ T) = zeroLocus S ∩ zeroLocus T := by
+  ext v
+  simp only [zeroLocus, Set.mem_setOf_eq, Set.mem_inter_iff, Set.mem_union]
+  exact ⟨fun h => ⟨fun f hf => h f (Or.inl hf), fun f hf => h f (Or.inr hf)⟩,
+         fun ⟨hs, ht⟩ f hf => hf.elim (hs f) (ht f)⟩
+
+/-- Idempotence: V(I(V(S))) = V(S). Applying the Galois connection twice
+on the geometric side returns to the original zero locus. -/
+theorem zeroLocus_vanishingIdeal_zeroLocus (S : Set (MvPolynomial σ k)) :
+    zeroLocus (vanishingIdeal (zeroLocus S) : Ideal (MvPolynomial σ k)) = zeroLocus S := by
+  apply Set.eq_of_subset_of_subset
+  · intro v hv f hf
+    exact hv f (subset_vanishingIdeal_zeroLocus S hf)
+  · exact subset_zeroLocus_vanishingIdeal (zeroLocus S)
+
+/-- Idempotence: I(V(I(W))) = I(W). Applying the Galois connection twice
+on the algebraic side returns to the original vanishing ideal.
+
+Note: the strong Nullstellensatz says I(V(J)) = √J in general, but
+I(V(I(W))) = I(W) always holds without the radical. -/
+theorem vanishingIdeal_zeroLocus_vanishingIdeal (W : Set (σ → k)) :
+    vanishingIdeal (zeroLocus (vanishingIdeal W : Ideal (MvPolynomial σ k))) =
+      vanishingIdeal W := by
+  apply le_antisymm
+  · exact vanishingIdeal_antimono (subset_zeroLocus_vanishingIdeal W)
+  · exact subset_vanishingIdeal_zeroLocus (vanishingIdeal W : Ideal (MvPolynomial σ k))
+
+end Nullstellensatz
+
+-- ============================================================
+-- PART 6: Numerical Examples
 -- ============================================================
 
 /-- Example: x² - 1 has roots ±1 in any field (char ≠ 2).
@@ -167,3 +280,7 @@ example : ¬(X ^ 2 + 1 : ℚ[X]).IsRoot (-1) := by decide
 #check @exists_linear_factor
 #check @root_count_le_degree
 #check @nonconstant_not_unit
+#check @Nullstellensatz.zeroLocus
+#check @Nullstellensatz.vanishingIdeal
+#check @Nullstellensatz.zeroLocus_vanishingIdeal_zeroLocus
+#check @Nullstellensatz.vanishingIdeal_zeroLocus_vanishingIdeal

--- a/src/data/proofs/factor-remainder-nullstellensatz/meta.json
+++ b/src/data/proofs/factor-remainder-nullstellensatz/meta.json
@@ -2,7 +2,7 @@
   "id": "factor-remainder-nullstellensatz",
   "title": "Factor Theorem to Nullstellensatz Bridge",
   "slug": "factor-remainder-nullstellensatz",
-  "description": "The univariate Factor Theorem as the base case of the Nullstellensatz hierarchy: over algebraically closed fields, nonconstant polynomials have roots and factor into linear terms",
+  "description": "The univariate Factor Theorem as the base case of the Nullstellensatz hierarchy: over algebraically closed fields, nonconstant polynomials have roots. Includes multivariate zero loci and vanishing ideals with Galois connection.",
   "meta": {
     "author": "Formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Hilbert%27s_Nullstellensatz",
@@ -38,12 +38,13 @@
     "originalContributions": [
       "Bridge between the Factor Theorem and the Nullstellensatz framework",
       "Univariate weak Nullstellensatz from IsAlgClosed",
-      "Nullstellensatz hierarchy documentation (4 levels)",
-      "Roadmap for multivariate formalization"
+      "Multivariate zeroLocus and vanishingIdeal definitions for MvPolynomial",
+      "V-I Galois connection with idempotence (V∘I∘V = V, I∘V∘I = I)",
+      "Nullstellensatz hierarchy documentation (4 levels)"
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 169,
+    "lineCount": 284,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
   },
   "overview": {
@@ -90,10 +91,18 @@
     {
       "id": "hierarchy",
       "title": "The Nullstellensatz Hierarchy",
-      "startLine": 108,
-      "endLine": 147,
+      "startLine": 113,
+      "endLine": 148,
       "summary": "Documents the four levels of Nullstellensatz results: Factor Theorem → weak → strong → combinatorial.",
       "mathContext": "Each level generalizes the previous. The documentation outlines what Mathlib infrastructure would be needed for a full formalization of the multivariate Nullstellensatz."
+    },
+    {
+      "id": "multivariate",
+      "title": "Multivariate Zero Loci and Vanishing Ideals",
+      "startLine": 150,
+      "endLine": 254,
+      "summary": "Defines the zero locus V(S) and vanishing ideal I(W) for multivariate polynomials over any commutative ring. Proves the fundamental Galois connection: S ⊆ V(I(S)), S ⊆ I(V(S)), and the idempotence properties V(I(V(S))) = V(S) and I(V(I(W))) = I(W). Also proves union distribution V(S ∪ T) = V(S) ∩ V(T) and basic structural results.",
+      "mathContext": "The V-I correspondence is the foundation of algebraic geometry: zero loci (geometry) and vanishing ideals (algebra) form a Galois connection between the lattice of subsets of affine space and the lattice of ideals. The strong Nullstellensatz would say I(V(J)) = √J, strengthening the idempotence to a precise characterization. The definitions here work over any commutative ring, not just algebraically closed fields."
     }
   ],
   "crossReferences": [
@@ -104,8 +113,8 @@
     }
   ],
   "conclusion": {
-    "summary": "A bridge formalization connecting the univariate Factor Theorem to the Nullstellensatz framework. Six theorems, 0 sorries, 0 axioms. Documents the full Nullstellensatz hierarchy and what would be needed for multivariate formalization.",
-    "implications": "The univariate weak Nullstellensatz is a direct consequence of algebraic closure and the Factor Theorem. Formalizing the multivariate case would require Jacobson ring theory or Zariski's lemma, which are partially available in Mathlib.",
+    "summary": "A bridge formalization connecting the univariate Factor Theorem to the Nullstellensatz framework. 15 theorems + 2 definitions, 0 sorries, 0 axioms. Includes multivariate zero loci and vanishing ideals with the full V-I Galois connection.",
+    "implications": "The multivariate definitions (zeroLocus, vanishingIdeal) and their Galois connection properties provide the algebraic geometry infrastructure needed to state and eventually prove the Nullstellensatz. The idempotence V(I(V(S))) = V(S) holds unconditionally; the strong Nullstellensatz would strengthen I(V(J)) to equal √J.",
     "openQuestions": [
       "Can the strong Nullstellensatz I(V(J)) = rad(J) be formalized using Mathlib's Jacobson ring infrastructure?",
       "Can Alon's combinatorial Nullstellensatz be formalized in Lean, connecting algebraic geometry to combinatorics?"
@@ -125,10 +134,10 @@
     "namespace": null,
     "lineCount": 169,
     "axiomCount": 0,
-    "theoremCount": 6,
-    "substantiveTheoremCount": 3,
+    "theoremCount": 15,
+    "substantiveTheoremCount": 7,
     "duplicateTheorems": 0,
-    "definitionCount": 0
+    "definitionCount": 2
   },
   "mainTheorems": [
     {
@@ -142,6 +151,18 @@
       "type": "core",
       "description": "Over an algebraically closed field, every nonconstant polynomial has a linear factor",
       "leanType": "[IsAlgClosed k] → (f : k[X]) → f ≠ 0 → 0 < f.natDegree → ∃ a, (X - C a) ∣ f"
+    },
+    {
+      "name": "Nullstellensatz.zeroLocus_vanishingIdeal_zeroLocus",
+      "type": "key",
+      "description": "Idempotence: V(I(V(S))) = V(S) for zero loci and vanishing ideals of MvPolynomial",
+      "leanType": "(S : Set (MvPolynomial σ k)) → zeroLocus ↑(vanishingIdeal (zeroLocus S)) = zeroLocus S"
+    },
+    {
+      "name": "Nullstellensatz.vanishingIdeal_zeroLocus_vanishingIdeal",
+      "type": "key",
+      "description": "Idempotence: I(V(I(W))) = I(W) for vanishing ideals and zero loci of MvPolynomial",
+      "leanType": "(W : Set (σ → k)) → vanishingIdeal (zeroLocus ↑(vanishingIdeal W)) = vanishingIdeal W"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Extends the Factor Theorem → Nullstellensatz bridge with multivariate algebraic geometry infrastructure
- Defines `zeroLocus` V(S) and `vanishingIdeal` I(W) for `MvPolynomial` over any commutative ring
- Proves the V-I Galois connection and idempotence properties (V∘I∘V = V, I∘V∘I = I)
- 15 theorems + 2 definitions, **0 sorries, 0 axioms**

## Progress
- Added 9 new theorems and 2 definitions in `Nullstellensatz` namespace
- Updated gallery meta.json with new content description and theorem counts
- Updated problem knowledge with insights about the Galois connection

## Findings
- The V-I Galois connection holds over any `CommRing`, not just algebraically closed fields
- `vanishingIdeal` is constructible as an `Ideal` using `MvPolynomial.eval` being a ring homomorphism
- The strong Nullstellensatz (I(V(J)) = √J) would require Jacobson ring theory or Zariski's lemma

## Status
**Outcome**: progress
**Next Steps**: Prove multivariate weak Nullstellensatz (requires Jacobson ring theory in Mathlib)

🤖 Generated by researcher-4