### PR TITLE
Research: erdos-1040-oq-05 — eliminate 2 axioms, prove muPosDeg positivity (6→4 axioms)

### DIFF
--- a/src/data/proofs/erdos-1040/meta.json
+++ b/src/data/proofs/erdos-1040/meta.json
@@ -24,8 +24,8 @@
     "relatedProblems": [
       1039
     ],
-    "axiomCount": 6,
-    "assumptions": "6 axiom declarations: lineSegment_determined and disc_determined (EHP 1958: μ depends only on ρ for these sets, using corrected muPosDeg), lineSegment_diameter and disc_diameter (classical capacity formulas), small_diameter_disc (qualitative disc containment for ρ < 1), erdos_netanyahu (quantitative disc bounds for bounded connected sets, 1973). Removed: problem_open (negated excluded middle, inconsistent) and transfiniteDiameter_eq (unused equivalence of inf/liminf definitions).",
+    "axiomCount": 4,
+    "assumptions": "4 axiom declarations: lineSegment_diameter and disc_diameter (classical capacity formulas), small_diameter_disc (qualitative disc containment for ρ < 1), erdos_netanyahu (quantitative disc bounds for bounded connected sets, 1973). Eliminated: lineSegment_determined and disc_determined converted to theorems (trivially true as stated due to ∀F∃f quantifier order; correctly-quantified ∃f∀F versions added as Prop defs).",
     "prerequisites": [
       "Complex analysis: polynomial lemniscates and sublevel sets",
       "Potential theory: transfinite diameter and logarithmic capacity",
@@ -230,11 +230,11 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 379,
-    "axiomCount": 6,
-    "theoremCount": 16,
-    "substantiveTheoremCount": 16,
+    "lineCount": 424,
+    "axiomCount": 4,
+    "theoremCount": 19,
+    "substantiveTheoremCount": 19,
     "trivialSpecializations": 0,
-    "definitionCount": 20
+    "definitionCount": 22
   }
 }


### PR DESCRIPTION
## Summary
- Converted `lineSegment_determined` and `disc_determined` from axioms to theorems (trivially true due to `∀F ∃f` quantifier order — the meaningful `∃f ∀F` versions added as Prop defs)
- Proved `muPosDeg_pos_of_small_diameter`: when transfinite diameter < 1, corrected μ is positive, using Haar measure translation invariance (`addHaar_ball_center`)
- Second conjunct of `erdos_1040_current_state` now proved via the above

## Progress
- **Axioms**: 6 → 4 (eliminated 2)
- **Theorems**: 16 → 19 (added 3)
- **Sorries**: 6 (unchanged — remaining are transfinite diameter properties)

## Findings
- The `lineSegment_determined`/`disc_determined` axioms had wrong quantifier order (`∀F ∃f` instead of `∃f ∀F`), making them trivially true
- The key to proving muPosDeg positivity is `addHaar_ball_center` (translation invariance of Haar measure) to establish a uniform lower bound across all polynomials

## Status
**Outcome**: progress
**Next Steps**: Prove remaining transfinite diameter properties (mono, nonneg, finite_zero, scale) — suitable for Aristotle

🤖 Generated by researcher-10