### PR TITLE
Audit: fix metadata mismatches in 6 proofs

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-04/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-04/meta.json
@@ -165,7 +165,7 @@
     "theoremCount": 8,
     "substantiveTheoremCount": 7,
     "trivialPlaceholders": 0,
-    "definitionCount": 5
+    "definitionCount": 4
   },
   "references": [
     {

--- a/src/data/proofs/factor-remainder-nullstellensatz/meta.json
+++ b/src/data/proofs/factor-remainder-nullstellensatz/meta.json
@@ -44,7 +44,7 @@
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 284,
+    "lineCount": 286,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
   },
   "overview": {
@@ -132,7 +132,7 @@
       "Polynomial"
     ],
     "namespace": null,
-    "lineCount": 169,
+    "lineCount": 286,
     "axiomCount": 0,
     "theoremCount": 15,
     "substantiveTheoremCount": 7,

--- a/src/data/proofs/infinitude-primes-oq-03/meta.json
+++ b/src/data/proofs/infinitude-primes-oq-03/meta.json
@@ -146,7 +146,7 @@
     "namespace": "InfinitudePrimes3k2",
     "lineCount": 196,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 3,
     "definitionCount": 0
   }
 }

--- a/src/data/proofs/partition-theorem-oq-03/meta.json
+++ b/src/data/proofs/partition-theorem-oq-03/meta.json
@@ -20,7 +20,7 @@
     ],
     "axiomCount": 4,
     "assumptions": "4 axioms: numOverpartitions (function), numOverpartitions_zero/one/two (small values). The function requires enumerating partitions which needs Mathlib Fintype infrastructure.",
-    "lineCount": 70
+    "lineCount": 68
   },
   "overview": {
     "historicalContext": "Overpartitions were systematically studied by Corteel and Lovejoy (2004), building on Euler's 1748 partition identity. An overpartition allows the first occurrence of each part size to be optionally marked, doubling the combinatorial choices.",
@@ -33,5 +33,5 @@
   ],
   "crossReferences": [{"targetId": "partition-theorem", "relationship": "extends", "description": "Extends Euler's partition identity to overpartitions"}],
   "conclusion": {"summary": "Overpartition structure defined with connection to Euler's identity. Small values axiomatized."},
-  "leanFile": {"imports": ["Mathlib"], "namespace": "OverpartitionTheory", "lineCount": 70, "axiomCount": 4, "theoremCount": 4, "definitionCount": 2}
+  "leanFile": {"imports": ["Mathlib"], "namespace": "OverpartitionTheory", "lineCount": 68, "axiomCount": 4, "theoremCount": 2, "definitionCount": 2}
 }

--- a/src/data/proofs/ramseys-theorem-oq-04/meta.json
+++ b/src/data/proofs/ramseys-theorem-oq-04/meta.json
@@ -33,7 +33,7 @@
     ],
     "axiomCount": 1,
     "assumptions": "1 axiom: hypergraph_ramsey_exists (the deep existence result requiring stepping-up lemma). All infrastructure, special cases, both base cases (n ≤ k and k = 1 pigeonhole), and monotonicity are proved.",
-    "lineCount": 296
+    "lineCount": 259
   },
   "overview": {
     "historicalContext": "Ramsey (1930) proved the theorem in full generality for k-element subsets, not just edges. The k=2 (graph) case became most famous. Erdős and Rado (1952) showed hypergraph Ramsey numbers grow as towers of exponentials with height proportional to k.",
@@ -84,9 +84,9 @@
     "imports": ["Mathlib"],
     "opens": ["Finset"],
     "namespace": "HypergraphRamsey",
-    "lineCount": 194,
+    "lineCount": 259,
     "axiomCount": 1,
-    "theoremCount": 12,
+    "theoremCount": 15,
     "definitionCount": 5
   }
 }

--- a/src/data/proofs/triangular-reciprocals-oq-01/meta.json
+++ b/src/data/proofs/triangular-reciprocals-oq-01/meta.json
@@ -52,7 +52,7 @@
     "namespace": "FigurateReciprocals",
     "lineCount": 111,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 10,
     "definitionCount": 3
   }
 }


### PR DESCRIPTION
## Summary

Batch fix for stale metadata counts found during gallery integrity audit of 9 proofs.

- **ballot-problem-oq-01-oq-04**: definitionCount 5→4
- **triangular-reciprocals-oq-01**: theoremCount 11→10
- **infinitude-primes-oq-03**: theoremCount 7→3 (was counting lemmas as theorems)
- **partition-theorem-oq-03**: lineCount 70→68, theoremCount 4→2
- **ramseys-theorem-oq-04**: lineCount 296/194→259, theoremCount 12→15
- **factor-remainder-nullstellensatz**: lineCount 284/169→286

3 proofs passed clean: greens-theorem-oq-04, ptolemys-complex-proof, quadratic-reciprocity-algorithm (counts OK, but badge issue filed separately).

## Test plan

- [ ] `pnpm build` passes
- [ ] Verify counts match `wc -l` and `grep -c` on corresponding Lean files

🤖 Generated with [Claude Code](https://claude.com/claude-code)