### PR TITLE
chore: update audit tracker for 9 audited proofs

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9981,9 +9981,9 @@
       "issues": []
     },
     "taylor-sincos-convergence-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-30T03:28:55Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-03-30T05:10:47Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "three-place-identity-oq-02": {
@@ -10013,6 +10013,60 @@
     "lagrange-theorem-oq-05": {
       "auditCount": 1,
       "lastAudited": "2026-03-30T03:51:01Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "ballot-problem-oq-01-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T05:08:27Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "factor-remainder-nullstellensatz": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T05:08:28Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "greens-theorem-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T05:08:28Z",
+      "result": "clean",
+      "issues": []
+    },
+    "infinitude-primes-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T05:08:28Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "partition-theorem-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T05:08:28Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "ptolemys-complex-proof": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T05:08:28Z",
+      "result": "clean",
+      "issues": []
+    },
+    "quadratic-reciprocity-algorithm": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T05:08:28Z",
+      "result": "issues-found",
+      "issues": []
+    },
+    "ramseys-theorem-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T05:08:28Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "triangular-reciprocals-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T05:08:28Z",
       "result": "issues-fixed",
       "issues": []
     }


### PR DESCRIPTION
## Summary

Updates audit-tracker.json with results from batch audit of 9 proofs:
- 2 clean (greens-theorem-oq-04, ptolemys-complex-proof)
- 6 issues-fixed (metadata corrections in PR #8148)
- 1 issues-found (quadratic-reciprocity-algorithm badge issue #8149)

🤖 Generated with [Claude Code](https://claude.com/claude-code)