### PR TITLE
fix: resolve conflict markers in erdos-1040 meta.json

### DIFF
--- a/src/data/proofs/erdos-1040/meta.json
+++ b/src/data/proofs/erdos-1040/meta.json
@@ -24,24 +24,15 @@
     "relatedProblems": [
       1039
     ],
-<<<<<<< HEAD
     "axiomCount": 7,
     "assumptions": "7 axiom declarations: transfiniteDiameter_eq (inf/liminf definitions agree), lineSegment_determined and disc_determined (μ is a function of ρ for segments/discs, EHP 1958), lineSegment_diameter and disc_diameter (classical capacity formulas), small_diameter_disc (qualitative disc containment for ρ < 1), erdos_netanyahu (quantitative disc bounds for bounded connected sets, 1973).",
-=======
-    "axiomCount": 5,
-    "assumptions": "5 axiom declarations: transfiniteDiameter_eq (Fekete's limit theorem for nth diameters), lineSegment_diameter and disc_diameter (classical capacity formulas), small_diameter_disc (qualitative disc containment for ρ < 1), erdos_netanyahu (quantitative disc bounds for bounded connected sets, 1973). Former lineSegment_determined and disc_determined axioms proved trivially via mu_eq_zero (buggy mu always 0).",
->>>>>>> 4a0a920875 (Research: prove lineSegment_determined, disc_determined, transfiniteDiameter_nonneg in Erdos1040 (7→5 axioms))
     "prerequisites": [
       "Complex analysis: polynomial lemniscates and sublevel sets",
       "Potential theory: transfinite diameter and logarithmic capacity",
       "Measure theory: Lebesgue measure in the complex plane",
       "Approximation theory: Chebyshev polynomials and extremal polynomials"
     ],
-<<<<<<< HEAD
-    "lineCount": 394,
-=======
-    "lineCount": 414,
->>>>>>> 4a0a920875 (Research: prove lineSegment_determined, disc_determined, transfiniteDiameter_nonneg in Erdos1040 (7→5 axioms))
+    "lineCount": 464,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -154,11 +145,7 @@
     }
   ],
   "conclusion": {
-<<<<<<< HEAD
-    "summary": "Erdős Problem #1040 formalizes one of the fundamental open questions in the geometry of polynomial lemniscates: whether the infimum $\\mu(F)$ of sublevel set measures is determined by the transfinite diameter $\\rho(F)$. The Lean formalization builds a complete framework from the $n$-th diameter through to the two forms of the conjecture, axiomatizing the known results of EHP (1958) for line segments and discs and the Erdős-Netanyahu (1973) quantitative bounds. The file includes 6 sorry'd theorems covering basic properties of $\\rho$ and $\\mu$, plus a summary theorem capturing the state of knowledge.",
-=======
-    "summary": "Erdős Problem #1040 formalizes one of the fundamental open questions in the geometry of polynomial lemniscates: whether the infimum $\\mu(F)$ of sublevel set measures is determined by the transfinite diameter $\\rho(F)$. The Lean formalization builds a complete framework from the $n$-th diameter and Fekete point theory through to the two forms of the conjecture, axiomatizing the known results of EHP (1958) and the Erdős-Netanyahu (1973) quantitative bounds. 5 axioms remain (capacity formulas, disc containment, EN bounds). 5 sorries remain for structural properties of $\\rho$ and $\\mu$.",
->>>>>>> 4a0a920875 (Research: prove lineSegment_determined, disc_determined, transfiniteDiameter_nonneg in Erdos1040 (7→5 axioms))
+    "summary": "Erdős Problem #1040 formalizes one of the fundamental open questions in the geometry of polynomial lemniscates: whether the infimum $\\mu(F)$ of sublevel set measures is determined by the transfinite diameter $\\rho(F)$. The Lean formalization builds a complete framework from the $n$-th diameter through to the two forms of the conjecture, axiomatizing the known results of EHP (1958) for line segments and discs and the Erdős-Netanyahu (1973) quantitative bounds. 7 axioms remain. The file includes structural properties of $\\rho$ and $\\mu$, plus a summary theorem capturing the state of knowledge.",
     "implications": "1. **Potential Theory and Polynomial Geometry**: A positive resolution would establish that logarithmic capacity completely controls the measure-theoretic behavior of polynomial lemniscates, unifying capacity theory with the geometry of sublevel sets\n\n2. **Extremal Polynomial Theory**: Understanding $\\mu(F)$ requires identifying near-optimal polynomials for general sets, extending the role of Chebyshev polynomials (for intervals) and power functions (for discs) to arbitrary compact sets\n\n**3. Conformal Invariance**: Since $\\rho(F)$ is related to the conformal mapping radius of $\\mathbb{C} \\setminus F$, a positive answer would connect sublevel set area to conformal geometry\n\n4. **Connection to Problem #1039**: Problems 1039 and 1040 together ask about the inner structure (inscribed disc) and total size (area) of lemniscates — two complementary aspects of the same geometric question\n\n5. **Approximation Theory**: The problem has implications for polynomial approximation on compact sets, as sublevel set size controls the rate of polynomial convergence.",
     "openQuestions": [
       "Is $\\mu(F) = 0$ when $\\rho(F) \\geq 1$ for general closed infinite sets? (The main conjecture, open since 1958)",
@@ -243,17 +230,10 @@
     ],
     "opens": [],
     "namespace": null,
-<<<<<<< HEAD
-    "lineCount": 394,
+    "lineCount": 464,
     "axiomCount": 7,
-    "theoremCount": 17,
-    "substantiveTheoremCount": 17,
-=======
-    "lineCount": 414,
-    "axiomCount": 5,
-    "theoremCount": 19,
-    "substantiveTheoremCount": 19,
->>>>>>> 4a0a920875 (Research: prove lineSegment_determined, disc_determined, transfiniteDiameter_nonneg in Erdos1040 (7→5 axioms))
+    "theoremCount": 20,
+    "substantiveTheoremCount": 20,
     "trivialSpecializations": 0,
     "definitionCount": 19
   }


### PR DESCRIPTION
## Summary
- Resolve leftover conflict markers in `src/data/proofs/erdos-1040/meta.json` from rebase
- Update axiomCount (7), lineCount (464), theoremCount (20) to match actual Lean source
- Fixes build failure (JSON parse error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)