### PR TITLE
Fix: quadratic-reciprocity-algorithm badge original→mathlib

### DIFF
--- a/src/data/proofs/quadratic-reciprocity-algorithm/meta.json
+++ b/src/data/proofs/quadratic-reciprocity-algorithm/meta.json
@@ -16,7 +16,7 @@
       "computational"
     ],
     "proofRepoPath": "Proofs/QuadraticReciprocityOQ03.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -31,9 +31,9 @@
       }
     ],
     "originalContributions": [
-      "Algorithmic framework: QR + multiplicativity as a Euclidean-like algorithm",
-      "Verified computations of Legendre symbols for small primes via decide",
-      "Descent property: reciprocity always reduces the modulus"
+      "Pedagogical wrappers exposing Mathlib's legendreSym API as an algorithmic framework",
+      "Verified example computations of Legendre symbols for small primes via decide",
+      "Core theorems (multiplicativity, supplementary law, reciprocity swap) are one-liner Mathlib delegations"
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 0,


### PR DESCRIPTION
## Fix

Change badge from `original` to `mathlib` for quadratic-reciprocity-algorithm.

## Evidence

**Before**: badge="original", implying independent proof development
**After**: badge="mathlib", correctly crediting Mathlib's legendreSym API

All 4 named theorems are one-liner Mathlib delegations:
- `legendreSym_mul_eq` → `map_mul (legendreSym p) a b`
- `legendreSym_neg_one_eq` → `legendreSym.at_neg_one hp`
- `reciprocity_swap` → `legendreSym.quadratic_reciprocity' hp hq`
- `algorithm_descent` → `exact reciprocity_swap hp hq`

Also updated `originalContributions` to accurately describe the pedagogical wrapper role.

Closes #8149

---
Automated fix by lean-mechanic agent.