### PR TITLE
fix: add missing overview fields in sqrt2-examples-oq-01

### DIFF
--- a/src/data/proofs/sqrt2-examples-oq-01/meta.json
+++ b/src/data/proofs/sqrt2-examples-oq-01/meta.json
@@ -41,7 +41,10 @@
     ]
   },
   "overview": {
+    "historicalContext": "The non-negativity of squares is a foundational property in ordered algebra, formalized in Mathlib via mul_self_nonneg for LinearOrderedSemiring.",
+    "problemStatement": "Generalize square_nonneg from integers to any LinearOrderedSemiring and derive consequences.",
     "text": "Answers whether square_nonneg generalizes to arbitrary linearly ordered rings. Yes: Mathlib's mul_self_nonneg works for LinearOrderedSemiring.",
+    "proofStrategy": "Uses Mathlib's mul_self_nonneg as the core lemma, derives concrete instances, and gives an independent proof by cases.",
     "keyInsights": [
       "Mathlib's mul_self_nonneg already provides the maximum generalization",
       "The case-analysis proof technique from the parent also generalizes",


### PR DESCRIPTION
Fix build failure from incomplete overview in sqrt2-examples-oq-01/meta.json.