### PR TITLE
Audit: fix stale metadata in erdos-1040 and erdos-453

### DIFF
--- a/src/data/proofs/erdos-1040/meta.json
+++ b/src/data/proofs/erdos-1040/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 4,
     "erdosNumber": 1040,
     "erdosUrl": "https://erdosproblems.com/1040",
     "erdosProblemStatus": "open",
@@ -32,7 +32,7 @@
       "Measure theory: Lebesgue measure in the complex plane",
       "Approximation theory: Chebyshev polynomials and extremal polynomials"
     ],
-    "lineCount": 464,
+    "lineCount": 488,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -230,11 +230,11 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 464,
+    "lineCount": 488,
     "axiomCount": 7,
     "theoremCount": 20,
     "substantiveTheoremCount": 20,
     "trivialSpecializations": 0,
-    "definitionCount": 19
+    "definitionCount": 20
   }
 }

--- a/src/data/proofs/erdos-453/meta.json
+++ b/src/data/proofs/erdos-453/meta.json
@@ -17,7 +17,7 @@
       "prime-number-graph"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 453,
     "erdosUrl": "https://erdosproblems.com/453",
     "erdosProblemStatus": "solved",
@@ -54,9 +54,9 @@
       "counterexample_set_infinite theorem (fully proved from axioms)",
       "log_convexity_iff_vertex identity (proved by rfl)"
     ],
-    "axiomCount": 6,
-    "lineCount": 304,
-    "assumptions": "6 axiom(s) and 2 sorry(s). See the Lean source for details."
+    "axiomCount": 4,
+    "lineCount": 339,
+    "assumptions": "4 axioms: nthPrime_is_prime, nthPrime_strictMono, logPrime_ratio_tendsto_zero, pomerance_convex_hull_lemma. 1 sorry remaining."
   },
   "leanFile": {
     "imports": [
@@ -70,9 +70,9 @@
       "Real"
     ],
     "namespace": "Erdos453",
-    "lineCount": 304,
-    "axiomCount": 6,
-    "theoremCount": 12,
+    "lineCount": 339,
+    "axiomCount": 4,
+    "theoremCount": 14,
     "definitionCount": 7
   },
   "crossReferences": [


### PR DESCRIPTION
## Summary

- **erdos-1040**: sorries 5→4, lineCount 464→488, definitionCount 19→20 (file grew since last audit)
- **erdos-453**: sorries 2→1, axiomCount 6→4, lineCount 304→339, theoremCount 12→14, assumptions text updated to list actual 4 axioms

Also audited (clean, no changes needed):
- arithmetic-series-oq-02-oq-02-oq-03
- erdos-110-oq-03

## Test plan

- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)