### PR TITLE
fix: add missing overview/conclusion fields in sqrt2-examples-oq-01

### DIFF
--- a/src/data/proofs/sqrt2-examples-oq-01/meta.json
+++ b/src/data/proofs/sqrt2-examples-oq-01/meta.json
@@ -41,7 +41,10 @@
     ]
   },
   "overview": {
+    "historicalContext": "The non-negativity of squares is a foundational property in ordered algebra, formalized in Mathlib via mul_self_nonneg for LinearOrderedSemiring.",
+    "problemStatement": "Generalize square_nonneg from integers to any LinearOrderedSemiring and derive consequences.",
     "text": "Answers whether square_nonneg generalizes to arbitrary linearly ordered rings. Yes: Mathlib's mul_self_nonneg works for LinearOrderedSemiring.",
+    "proofStrategy": "Uses Mathlib's mul_self_nonneg as the core lemma, derives concrete instances, and gives an independent proof by cases.",
     "keyInsights": [
       "Mathlib's mul_self_nonneg already provides the maximum generalization",
       "The case-analysis proof technique from the parent also generalizes",

--- a/src/data/proofs/sqrt2-examples-oq-01/meta.json
+++ b/src/data/proofs/sqrt2-examples-oq-01/meta.json
@@ -83,6 +83,7 @@
   ],
   "conclusion": {
     "summary": "The answer is YES: Mathlib's LinearOrderedSemiring provides the maximum generalization with no additional axioms needed.",
+    "implications": "This demonstrates that the non-negativity of squares is a structural property of any linearly ordered semiring, not specific to integers or reals.",
     "openQuestions": []
   },
   "crossReferences": [


### PR DESCRIPTION
Fix TypeScript build failure from incomplete meta.json.