### PR TITLE
fix: add missing summary fields to pythagorean-triples-oq-02 sections

### DIFF
--- a/src/data/proofs/pythagorean-triples-oq-02/index.ts
+++ b/src/data/proofs/pythagorean-triples-oq-02/index.ts
@@ -3,7 +3,7 @@ import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/PythagoreanTriplesOQ02.lean?raw'
 
-const meta = metaJson as {
+const meta = metaJson as unknown as {
   id: string
   title: string
   slug: string

--- a/src/data/proofs/pythagorean-triples-oq-02/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-02/meta.json
@@ -36,12 +36,12 @@
     ]
   },
   "sections": [
-    {"id": "gaussian-arithmetic", "title": "Gaussian Integer Arithmetic", "startLine": 24, "endLine": 46},
-    {"id": "core-properties", "title": "Core Properties", "startLine": 51, "endLine": 68},
-    {"id": "pythagorean-triples", "title": "Pythagorean Triples from Squaring", "startLine": 73, "endLine": 95},
-    {"id": "brahmagupta-fibonacci", "title": "Brahmagupta-Fibonacci Identity", "startLine": 100, "endLine": 120},
-    {"id": "factoring", "title": "The Factoring Perspective", "startLine": 125, "endLine": 140},
-    {"id": "examples", "title": "Concrete Examples", "startLine": 145, "endLine": 170}
+    {"id": "gaussian-arithmetic", "title": "Gaussian Integer Arithmetic", "startLine": 24, "endLine": 46, "summary": "Defines Gaussian integers and their operations: multiplication, conjugation, norm, and squaring."},
+    {"id": "core-properties", "title": "Core Properties", "startLine": 51, "endLine": 68, "summary": "Proves norm multiplicativity and conjugation properties of Gaussian integers."},
+    {"id": "pythagorean-triples", "title": "Pythagorean Triples from Squaring", "startLine": 73, "endLine": 95, "summary": "Shows the parametric formula (m²-n², 2mn, m²+n²) is squaring z = m + ni in ℤ[i]."},
+    {"id": "brahmagupta-fibonacci", "title": "Brahmagupta-Fibonacci Identity", "startLine": 100, "endLine": 120, "summary": "Derives the Brahmagupta-Fibonacci identity from Gaussian norm multiplicativity."},
+    {"id": "factoring", "title": "The Factoring Perspective", "startLine": 125, "endLine": 140, "summary": "Establishes the product rule for Pythagorean triples via Gaussian multiplication."},
+    {"id": "examples", "title": "Concrete Examples", "startLine": 145, "endLine": 170, "summary": "Verifies concrete Pythagorean triples (3,4,5), (5,12,13) using the Gaussian framework."}
   ],
   "conclusion": {
     "summary": "The Gaussian integer connection reveals the algebraic structure behind Pythagorean triples: the parametric formula is squaring, and norm multiplicativity gives the Brahmagupta-Fibonacci identity.",


### PR DESCRIPTION
## Summary
- Add missing `summary` fields to ProofSection entries in `pythagorean-triples-oq-02/meta.json`
- Fix TypeScript cast in `index.ts` to handle extra JSON fields
- Fixes build failure introduced by #8171

🤖 Generated with [Claude Code](https://claude.com/claude-code)