### PR TITLE
Audit: fix metadata in erdos-780 (0 sorries!) and erdos-307

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -161,7 +161,7 @@
     "namespace": "PowerMeanChain",
     "lineCount": 217,
     "axiomCount": 0,
-    "theoremCount": 14,
+    "theoremCount": 11,
     "definitionCount": 4
   }
 }

--- a/src/data/proofs/erdos-780/meta.json
+++ b/src/data/proofs/erdos-780/meta.json
@@ -19,7 +19,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 0,
     "erdosNumber": 780,
     "erdosUrl": "https://erdosproblems.com/780",
     "erdosProblemStatus": "solved",
@@ -57,14 +57,14 @@
       "alon_frankl_lovasz_1986 main theorem (axiom) with kneser_hypergraph_chromatic_number equivalent",
       "tightness_construction showing the bound is optimal",
       "kneser_conjecture axiom (k=2 special case, Lovász 1978)",
-      "Four small cases as sorry'd theorems: Petersen graph KG(5,2), KG(7,3), KG(2r,r), KG(2r+1,r)",
+      "Four small cases proved: Petersen graph KG(5,2), KG(7,3), KG(2r,r), KG(2r+1,r)",
       "erdos_ko_rado proved from ErdosKoRado.Star construction (was axiom)",
       "Two proved theorems (erdos_780_main, erdos_780_summary) wrapping axioms",
       "Companion file Erdos780Aristotle.lean with 10 routine lemmas for automated proof"
     ],
     "axiomCount": 4,
-    "assumptions": "4 axiom declarations: alon_frankl_lovasz_1986 (n >= threshold implies monochromatic k-matching, deep topological proof), kneser_hypergraph_chromatic_number (chromatic number formula for Kneser hypergraph), tightness_construction (partition coloring avoids k disjoint monochromatic edges), kneser_conjecture (chi(KG(n,r)) = n-2r+2, Lovász 1978). Previously 10 axioms; eliminated chromaticNumber (→ definition), erdos_ko_rado (→ proved from EKR Star), 4 small cases (→ sorry'd theorems). Fixed: kg_7_3_chromatic value corrected from 2 to 3.",
-    "lineCount": 229
+    "assumptions": "4 axiom declarations: alon_frankl_lovasz_1986 (n >= threshold implies monochromatic k-matching, deep topological proof), kneser_hypergraph_chromatic_number (chromatic number formula for Kneser hypergraph), tightness_construction (partition coloring avoids k disjoint monochromatic edges), kneser_conjecture (chi(KG(n,r)) = n-2r+2, Lovász 1978). 0 sorries remaining.",
+    "lineCount": 233
   },
   "overview": {
     "historicalContext": "Erdős Problem #780 generalizes the famous Kneser conjecture to hypergraphs. **Kneser (1955)** conjectured that $\\chi(KG(n,r)) = n - 2r + 2$, i.e., any $(n - 2r + 1)$-coloring of the $r$-subsets of $[n]$ must contain two disjoint sets of the same color. This remained open until **Lovász's landmark 1978 proof** (*J. Comb. Theory A* 25, 319-324), which was the **first major application of algebraic topology to combinatorics**, using the Borsuk-Ulam theorem via the neighborhood complex $\\mathcal{N}(KG(n,r))$. Schrijver simultaneously found a vertex-critical subgraph (the stable Kneser graph) with the same chromatic number.\n\n**Alon, Frankl, and Lovász (1986)** extended this to $r$-uniform hypergraphs (*Trans. AMS* 298, 359-370): if $n \\geq kr + (t-1)(k-1)$, any $t$-coloring of $\\binom{[n]}{r}$ contains $k$ pairwise disjoint monochromatic edges. Their proof generalizes the topological approach using the independence complex and a Borsuk-Ulam-type argument via the Lusternik-Schnirelmann category. **Matoušek (2004)** later gave a purely combinatorial proof using Tucker's lemma. The problem connects to the Erdős-Ko-Rado theorem (1961): the maximum intersecting family gives $\\alpha(KG(n,r)) = \\binom{n-1}{r-1}$, and the fractional chromatic number is $\\chi_f(KG(n,r)) = n/r$.",
@@ -208,10 +208,10 @@
       "Finset"
     ],
     "namespace": "Erdos780",
-    "lineCount": 200,
-    "axiomCount": 10,
-    "theoremCount": 2,
-    "definitionCount": 11
+    "lineCount": 233,
+    "axiomCount": 4,
+    "theoremCount": 7,
+    "definitionCount": 12
   },
   "references": [
     {

--- a/src/data/proofs/pythagorean-triples-oq-02/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-02/meta.json
@@ -109,6 +109,7 @@
     "namespace": "PythagoreanTriplesOQ02",
     "lineCount": 173,
     "axiomCount": 0,
-    "theoremCount": 14
+    "theoremCount": 14,
+    "definitionCount": 4
   }
 }

--- a/src/data/proofs/sqrt2-examples-oq-01/meta.json
+++ b/src/data/proofs/sqrt2-examples-oq-01/meta.json
@@ -18,7 +18,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 100,
+    "lineCount": 102,
     "assumptions": "No axioms. All results follow from Mathlib's LinearOrderedSemiring and LinearOrderedRing instances.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
@@ -98,9 +98,9 @@
   "leanFile": {
     "imports": ["Mathlib"],
     "namespace": "Sqrt2OQ01",
-    "lineCount": 100,
+    "lineCount": 102,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 10,
     "definitionCount": 0
   }
 }


### PR DESCRIPTION
## Summary

- **erdos-780**: All 4 sorries resolved! sorries 4→0, lineCount 229/200→233, leanFile axiomCount 10→4, theoremCount 2→7, definitionCount 11→12. Status remains "axiomatized" (4 axioms for deep topological results).
- **erdos-307**: sorries 6→5, lineCount 375→435

## Test plan

- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)