### PR TITLE
fix: restore as unknown as cast in pythagorean-triples-oq-02

### DIFF
--- a/src/data/proofs/pythagorean-triples-oq-02/index.ts
+++ b/src/data/proofs/pythagorean-triples-oq-02/index.ts
@@ -3,7 +3,7 @@ import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/PythagoreanTriplesOQ02.lean?raw'
 
-const meta = metaJson as {
+const meta = metaJson as unknown as {
   id: string
   title: string
   slug: string


### PR DESCRIPTION
Fixes build failure from reverted type cast.