### PR TITLE
fix(gallery): taylor-sincos-convergence-oq-03 — sorry count 6→4

### DIFF
--- a/src/data/proofs/taylor-sincos-convergence-oq-03/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-03/meta.json
@@ -14,9 +14,9 @@
     ],
     "proofRepoPath": "Proofs/TaylorSinCosConvergenceOQ03.lean",
     "badge": "formalized",
-    "sorries": 6,
+    "sorries": 4,
     "axiomCount": 0,
-    "assumptions": "0 axioms. 6 sorries: alternating series estimation (2), sin/cos term monotonicity/limits (2), alternating remainder for sin/cos (2). All have clear proof strategies.",
+    "assumptions": "0 axioms. 4 sorries: alternating series estimation (2: partial sum bounds, tail bound), alternating remainder for sin/cos (2). Sin/cos term monotonicity and limit-to-zero are fully proved.",
     "originalContributions": [
       "Alternating series estimation theorem (abstract, with proof strategy)",
       "Tighter sin/cos remainder bounds: |x|^{2n+1}/(2n+1)! instead of |x|^{2n+1}/(2n)!",
@@ -24,7 +24,7 @@
       "Concrete example: at x=1, n=3, alternating is 7x tighter"
     ],
     "dateAdded": "2026-03-30",
-    "lineCount": 188,
+    "lineCount": 207,
     "theoremCount": 12,
     "definitionCount": 2,
     "mathlib_version": "4.26.0"
@@ -44,7 +44,7 @@
   "leanFile": {
     "imports": ["Mathlib"],
     "namespace": "AlternatingSeriesEstimation",
-    "lineCount": 188,
+    "lineCount": 207,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 2


### PR DESCRIPTION
## Summary

- **taylor-sincos-convergence-oq-03** meta.json stale: 2 sorries resolved
- `sinTermAbs_antitone` and `sinTermAbs_tendsto` are now fully proved
- Fix sorry count (6→4), line count (188→207), assumptions text

## Evidence

| Field | Before | After | Lean source |
|-------|--------|-------|-------------|
| sorries | 6 | 4 | Lines 60, 74, 151, 160 |
| lineCount | 188 | 207 | `wc -l` = 207 |

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)