### PR TITLE
fix: remove conflict markers from pythagorean-triples-oq-02

### DIFF
--- a/src/data/proofs/pythagorean-triples-oq-02/index.ts
+++ b/src/data/proofs/pythagorean-triples-oq-02/index.ts
@@ -3,11 +3,7 @@ import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/PythagoreanTriplesOQ02.lean?raw'
 
-<<<<<<< HEAD
 const meta = metaJson as unknown as {
-=======
-const meta = metaJson as {
->>>>>>> bd7bc4fac8 (Research: pythagorean-triples-oq-02 - Gaussian integer connection)
   id: string
   title: string
   slug: string


### PR DESCRIPTION
Fixes build failure from unresolved merge conflict markers.