### PR TITLE
fix(gallery): yang-mills-2d-oq-01 — axiom count 9→10

### DIFF
--- a/src/data/proofs/yang-mills-2d-oq-01/meta.json
+++ b/src/data/proofs/yang-mills-2d-oq-01/meta.json
@@ -12,7 +12,7 @@
     "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-03-30",
-    "axiomCount": 9,
-    "lineCount": 145
+    "axiomCount": 10,
+    "lineCount": 147
   }
 }


### PR DESCRIPTION
## Summary

- **yang-mills-2d-oq-01** axiom count was undercounted by 1
- `gross_taylor_expansion` axiom (line 144) was not included in the count
- Fix axiomCount (9→10), lineCount (145→147)

## Evidence

| Field | Before | After | Lean source |
|-------|--------|-------|-------------|
| axiomCount | 9 | 10 | `grep -c "^axiom "` = 10 |
| lineCount | 145 | 147 | `wc -l` = 147 |

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)