### PR TITLE
Research: axiom elimination batch 2 — erdos-307, roth-k3-oq-03, metadata fixes

### DIFF
--- a/src/data/research/problems/gcd-algorithm-oq-02.json
+++ b/src/data/research/problems/gcd-algorithm-oq-02.json
@@ -65,7 +65,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GcdAlgorithmOQ02.lean"
     }

--- a/src/data/research/problems/pythagorean-triples-oq-02.json
+++ b/src/data/research/problems/pythagorean-triples-oq-02.json
@@ -29,9 +29,19 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETED: Fully verified (0 sorries, 0 axioms). Gaussian integer framework for Pythagorean triples including norm multiplicativity, Brahmagupta-Fibonacci identity, and product rule.",
+    "builtItems": [
+      "gaussMul, gaussNorm, gaussConj, gaussSq definitions",
+      "norm_multiplicative, gaussSq_formula, mul_conj_eq_norm core theorems",
+      "pythagorean_from_gaussian, gaussian_gives_pythagorean_triple main results",
+      "brahmagupta_fibonacci identity and pythagorean_triple_product"
+    ],
+    "insights": [
+      "The parametric formula (m²-n², 2mn, m²+n²) is the squaring map in ℤ[i]",
+      "Norm multiplicativity N(z₁z₂) = N(z₁)N(z₂) proved by ring tactic",
+      "Brahmagupta-Fibonacci identity follows from Gaussian norm multiplicativity",
+      "Product rule for Pythagorean triples proved via nlinarith + Brahmagupta-Fibonacci"
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Knowledge Base: pythagorean-triples-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"


### PR DESCRIPTION
## Summary
Continuation of axiom elimination work (PR #8201 was partially merged):

**Erdos307Problem.lean**: Remove 4 unused axioms (4→0), status axiomatized→formalized
**RothTheoremOQ03.lean**: Remove 3 unused axioms (7→4) including placeholder inverse theorem
**Metadata fixes**: Stale sorry counts for gcd-algorithm-oq-02, pythagorean-triples-oq-02

## Status
**Outcome**: completed (axiom elimination + metadata cleanup)

🤖 Generated by researcher-8