### PR TITLE
fix(gallery): erdos-411 axiomCount 6→4 — proved theorems miscounted as axioms

### DIFF
--- a/src/data/proofs/erdos-411/meta.json
+++ b/src/data/proofs/erdos-411/meta.json
@@ -43,14 +43,14 @@
         "originalContributions": [
             "Formalized the totient-step iteration g(n) = n + φ(n) and its k-fold iterate",
             "Defined DoublingRelation and GeneralRatioRelation capturing the eventual scaling property",
-            "Axiomatized known r = 2 solutions (n = 10, 94) and Cambie's ratio-3 and ratio-4 solutions",
+            "Proved known r = 2 solutions (n = 10, 94) via native_decide; axiomatized Cambie's ratio-3 and ratio-4 solutions",
             "Formalized Steinerberger's (2025) reduction: DoublingRelation n 2 ↔ φ(n) + φ(n + φ(n)) = n",
             "Proved even preservation under g using Mathlib's Nat.totient_even",
             "Formalized Cambie's structural conjecture on the form of r = 2 solutions"
         ],
-        "axiomCount": 6,
-        "lineCount": 172,
-        "assumptions": "6 axioms: doubling_r2_n10, doubling_r2_n94, cambie_ratio3, and 3 more. See Lean source for complete statements."
+        "axiomCount": 4,
+        "lineCount": 173,
+        "assumptions": "4 axioms: cambie_ratio3 (ratio-3 solution n=738), cambie_ratio4_148646 (ratio-4 solution), cambie_ratio4_4325798 (ratio-4 solution), steinerberger_r2_equiv (r=2 reduction to finite equation). The r=2 solutions n=10 and n=94 are fully proved via native_decide."
     },
     "leanFile": {
         "path": "Proofs/Erdos411Problem.lean",
@@ -74,8 +74,8 @@
             "GeneralRatioRelation",
             "CambieConjecture"
         ],
-        "axiomCount": 6,
-        "theoremCount": 2,
+        "axiomCount": 4,
+        "theoremCount": 9,
         "sorryCount": 0
     },
     "overview": {
@@ -129,7 +129,7 @@
             "title": "Known Solutions",
             "startLine": 52,
             "endLine": 74,
-            "summary": "Axiomatized solutions: $n = 10, 94$ for $r = 2$; `GeneralRatioRelation` definition; Cambie's ratio-3 ($n = 738$, $r = 4$) and ratio-4 ($n = 148646, 4325798$, $r = 4$) solutions."
+            "summary": "Proved solutions: $n = 10, 94$ for $r = 2$ via native_decide; `GeneralRatioRelation` definition; axiomatized Cambie's ratio-3 ($n = 738$, $r = 4$) and ratio-4 ($n = 148646, 4325798$, $r = 4$) solutions."
         },
         {
             "id": "steinerberger-reduction",
@@ -147,7 +147,7 @@
         }
     ],
     "conclusion": {
-        "summary": "Erdős Problem #411 asks for all $(n, r)$ such that iterating $g(n) = n + \\varphi(n)$ satisfies $g^{k+r}(n) = 2 \\cdot g^k(n)$ for large $k$. Solutions are known for $r = 2$ ($n = 10, 94$) and for general ratios 3 and 4 (Cambie). Steinerberger's 2025 reduction simplifies the $r = 2$ case to a single finitely-checkable equation. The formalization axiomatizes 6 known solutions, proves 2 structural properties, and states the full open problem.",
+        "summary": "Erdős Problem #411 asks for all $(n, r)$ such that iterating $g(n) = n + \\varphi(n)$ satisfies $g^{k+r}(n) = 2 \\cdot g^k(n)$ for large $k$. Solutions are known for $r = 2$ ($n = 10, 94$, both proved) and for general ratios 3 and 4 (Cambie, axiomatized). Steinerberger's 2025 reduction simplifies the $r = 2$ case to a single finitely-checkable equation. The formalization proves 9 theorems (including the n=10 and n=94 doubling relations), axiomatizes 4 results, and states the full open problem.",
         "implications": "**Theoretical Significance**: A full characterization would reveal deep structure in the arithmetic dynamics of the totient function and its interaction with addition.\n\nThe connection between the multiplicative nature of $\\varphi$ and the additive iteration $g(n) = n + \\varphi(n)$ is fundamental. The multi-ratio phenomenon discovered by Cambie suggests the problem is part of a richer classification of growth rates in arithmetic dynamical systems.",
         "openQuestions": [
             "Are there finitely or infinitely many $(n, r)$ with the doubling property? Cambie's conjecture would give infinitely many (all $2^l \\cdot p$ for each valid $p$)",


### PR DESCRIPTION
## Fix

Corrects erdos-411 meta.json: `axiomCount` was 6 but should be 4. `doubling_r2_n10` and `doubling_r2_n94` are proved theorems (via `native_decide` + `doubling_propagation` induction), not axioms.

## Evidence

**Before**: `axiomCount: 6`, assumptions field listed `doubling_r2_n10` and `doubling_r2_n94` as axioms
**After**: `axiomCount: 4`, assumptions field correctly lists only the 4 actual `axiom` declarations: `cambie_ratio3`, `cambie_ratio4_148646`, `cambie_ratio4_4325798`, `steinerberger_r2_equiv`

Also fixed: `theoremCount` (2→9), `lineCount` (172→173), `originalContributions` and section summaries updated to reflect proved vs axiomatized status.

---
Automated fix by lean-mechanic agent.