### PR TITLE
fix: add missing implications to 6 ProofConclusion entries

### DIFF
--- a/src/data/proofs/angle-trisection-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-03/meta.json
@@ -142,5 +142,8 @@
       "description": "Gauss-Wantzel theorem for n-gon constructibility (used for decidable_ngon_constructibility)"
     }
   ],
-  "conclusion": "Compass-and-straightedge constructibility, given the minimal polynomial degree, is decidable and efficiently computable. The complete characterization reduces a 2000-year-old geometric question to a simple arithmetic check: is the degree a power of 2?"
+  "conclusion": {
+    "summary": "Compass-and-straightedge constructibility, given the minimal polynomial degree, is decidable and efficiently computable. The complete characterization reduces a 2000-year-old geometric question to a simple arithmetic check: is the degree a power of 2?",
+    "implications": "Provides a constructive O(log d) algorithm for deciding constructibility, enabling automated verification of geometric construction problems."
+  }
 }

--- a/src/data/proofs/erdos-1-oq-03/meta.json
+++ b/src/data/proofs/erdos-1-oq-03/meta.json
@@ -124,6 +124,7 @@
   ],
   "conclusion": {
     "summary": "The Conway-Guy sequence is formalized with all key structural properties verified for small cases. The optimality conjecture is stated as an axiom since it remains open for general n.",
+    "implications": "Establishes a formal foundation for studying the Conway-Guy optimality conjecture and provides verified structural properties that could support future progress on Erdos Problem #1.",
     "openQuestions": [
       "Can the Conway-Guy optimality be proved for all n, or just verified computationally?",
       "Can the asymptotic constant sqrt(2/pi)/2 be derived from the recurrence?"

--- a/src/data/proofs/herons-formula-oq-01/meta.json
+++ b/src/data/proofs/herons-formula-oq-01/meta.json
@@ -131,6 +131,7 @@
   ],
   "conclusion": {
     "summary": "Brahmagupta's formula is formalized with full algebraic infrastructure. The reduction to Heron's formula and the rectangle/square special cases are proved cleanly. The main formula is axiomatized (needs cyclic geometry), and the isoperimetric inequality needs AM-GM for 4 variables.",
+    "implications": "Provides a verified algebraic framework for cyclic quadrilateral area computation, bridging Heron's formula to its natural four-sided generalization.",
     "openQuestions": [
       "Can the axiom be eliminated by formalizing cyclic quadrilateral geometry and the law of cosines for supplementary angles?",
       "Can the isoperimetric inequality be proved from a formalized AM-GM inequality for n variables?"

--- a/src/data/proofs/pythagorean-triples-oq-02/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-02/meta.json
@@ -45,6 +45,7 @@
   ],
   "conclusion": {
     "summary": "The Gaussian integer connection reveals the algebraic structure behind Pythagorean triples: the parametric formula is squaring, and norm multiplicativity gives the Brahmagupta-Fibonacci identity.",
+    "implications": "Demonstrates that Gaussian integer arithmetic unifies the parametric formula and the sum-of-two-squares closure property into a single algebraic framework.",
     "openQuestions": []
   },
   "crossReferences": [

--- a/src/data/proofs/subset-count-oq-02/meta.json
+++ b/src/data/proofs/subset-count-oq-02/meta.json
@@ -102,6 +102,7 @@
   ],
   "conclusion": {
     "summary": "The multiset powerset cardinality formula |P(s)| = 2^n is a clean generalization of the set case.",
+    "implications": "Extends the fundamental 2^n counting result from sets to multisets, providing a verified foundation for enumerative combinatorics with repeated elements.",
     "openQuestions": [
       "What about the number of DISTINCT submultisets (without multiplicity)? This is product(m_i + 1) for multiplicities m_i.",
       "How does this connect to generating functions?"

--- a/src/data/proofs/sum-of-kth-powers-oq-04/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-04/meta.json
@@ -104,6 +104,7 @@
   ],
   "conclusion": {
     "summary": "The asymptotic formula sum i^k / n^{k+1} -> 1/(k+1) is stated and the k=0 and k=1 cases are proved. The general case remains as a sorry requiring filter limit manipulation with Faulhaber's formula.",
+    "implications": "Connects discrete power sums to continuous integration via the Riemann sum interpretation, laying groundwork for a full Euler-Maclaurin formalization in Lean 4.",
     "openQuestions": [
       "Can the full Euler-Maclaurin formula with Bernoulli correction terms be formalized?",
       "Can the error term in the Euler-Maclaurin approximation be bounded?"


### PR DESCRIPTION
## Summary
- Add missing `implications` field to 6 gallery proof conclusion entries
- Fix `angle-trisection-oq-03` conclusion from bare string to proper object
- Resolves build failure from type mismatch

Affected: angle-trisection-oq-03, erdos-1-oq-03, herons-formula-oq-01, pythagorean-triples-oq-02, subset-count-oq-02, sum-of-kth-powers-oq-04