### PR TITLE
Research: prove sorries in Erdos1040, filter theory and analysis

### DIFF
--- a/proofs/Proofs/Erdos1087Problem.lean
+++ b/proofs/Proofs/Erdos1087Problem.lean
@@ -262,7 +262,8 @@ f(n) ≤ C(n,4) ≤ n⁴/24, since at most all quadruples could be degenerate.
 -/
 theorem trivial_upper_bound (n : ℕ) (hn : n ≥ 4) :
     (f n : ℝ) ≤ (n : ℝ)^4 / 24 := by
-  sorry -- follows from definition
+  simp only [f, maxDegenerateQuadruples, Nat.cast_zero]
+  positivity
 
 /--
 **Non-trivial Lower Bound Exists:**

--- a/proofs/Proofs/Erdos117OQ01.lean
+++ b/proofs/Proofs/Erdos117OQ01.lean
@@ -119,7 +119,16 @@ theorem limInf_ge_log_c1 :
 
 /-- liminf ≤ limsup (always true for bounded sequences) -/
 theorem limInf_le_limSup : growthRateLimInf ≤ growthRateLimSup := by
-  sorry -- standard analysis result
+  unfold growthRateLimInf growthRateLimSup
+  apply Filter.liminf_le_limsup
+  · -- IsBoundedUnder: growthRate is eventually bounded above
+    obtain ⟨U, hU⟩ := growthRate_upper_bound
+    exact ⟨U, Filter.eventually_atTop.mpr ⟨1, fun n hn => hU n hn⟩⟩
+  · -- IsCoboundedUnder: every eventual upper bound is ≥ L
+    obtain ⟨L, _, hL⟩ := growthRate_lower_bound
+    exact ⟨L, fun a ha => by
+      obtain ⟨N, hN⟩ := Filter.eventually_atTop.mp ha
+      linarith [hL (max N 1) (le_max_right _ _), hN (max N 1) (le_max_left _ _)]⟩
 
 /-
 ## Part IV: The Open Question

--- a/proofs/Proofs/Erdos39Problem.lean
+++ b/proofs/Proofs/Erdos39Problem.lean
@@ -69,7 +69,21 @@ axiom erdos_sidon_upper_bound :
     There exist arbitrarily large N where A(N) < ε√N. -/
 theorem no_sqrt_growth (A : Set ℕ) (hInf : A.Infinite) (hSidon : IsSidonSet A) :
     ∀ c : ℝ, c > 0 → ∃ᶠ N in atTop, (countingFunction A N : ℝ) < c * Real.sqrt N := by
-  sorry  -- Follows from liminf = 0
+  intro c hc
+  have hlim := erdos_sidon_upper_bound A hInf hSidon
+  -- liminf = 0 < c, so A(N)/√N < c frequently
+  have hlt : Filter.liminf (fun N => (countingFunction A N : ℝ) / Real.sqrt N) atTop < c := by
+    rw [hlim]; exact hc
+  have hbdd : atTop.IsBoundedUnder (· ≥ ·)
+      (fun N => (countingFunction A N : ℝ) / Real.sqrt N) :=
+    ⟨0, Filter.eventually_atTop.mpr ⟨0, fun N _ =>
+      div_nonneg (Nat.cast_nonneg _) (Real.sqrt_nonneg _)⟩⟩
+  have hfreq := Filter.frequently_lt_of_liminf_lt hlt hbdd
+  -- Convert A(N)/√N < c to A(N) < c * √N (for N ≥ 1)
+  exact (hfreq.and_eventually (Filter.eventually_atTop.mpr ⟨1, fun _ h => h⟩)).mono
+    fun N ⟨hN, hN1⟩ => by
+      have hNpos : (N : ℝ) > 0 := Nat.cast_pos.mpr (by omega)
+      rwa [div_lt_iff (Real.sqrt_pos_of_pos hNpos)] at hN
 
 /- ## Known Lower Bounds (Constructions) -/
 

--- a/proofs/Proofs/Erdos454Aristotle.lean
+++ b/proofs/Proofs/Erdos454Aristotle.lean
@@ -101,7 +101,16 @@ theorem conjecture_iff_not_negation :
 theorem infinitely_many_deviation_ge_2
     (h : 2 ≤ limsup deviationENat atTop) :
     {n : ℕ | deviationENat n ≥ 2}.Infinite := by
-  sorry -- Needs limsup ≥ c → frequently ≥ c argument in ℕ∞
+  by_contra hfin
+  rw [Set.not_infinite] at hfin
+  obtain ⟨N, hN⟩ := hfin.bddAbove
+  have hev : ∀ᶠ n in atTop, deviationENat n ≤ 1 := by
+    simp only [Filter.eventually_atTop]
+    refine ⟨N + 1, fun n hn => ?_⟩
+    by_contra h'
+    push_neg at h'
+    exact absurd (hN (Order.succ_le_of_lt h')) (by omega)
+  exact absurd (h.trans (Filter.limsup_le_of_le ⟨⊥, fun _ _ => bot_le⟩ hev)) (by norm_num)
 
 -- Prime gap existence (known result, not open)
 /-- There exist arbitrarily large prime gaps: for any G,

--- a/proofs/Proofs/Erdos673Aristotle.lean
+++ b/proofs/Proofs/Erdos673Aristotle.lean
@@ -47,7 +47,7 @@ theorem last_divisor_eq_n (n : ℕ) (hn : n ≥ 1) :
 
 -- Routine lemma: G(1) = 0 (sum over empty range since tau(1)=1)
 theorem G_one : G 1 = 0 := by
-  simp [G, tau_one]
+  simp [G, tau, Nat.divisors_one]
 
 -- Routine lemma: G(p) = 1/p for prime p
 theorem G_prime (p : ℕ) (hp : p.Prime) : G p = 1 / p := by


### PR DESCRIPTION
## Summary
### Erdos1040 (new in this update)
- **muPosDeg_pos_of_small_diameter**: Proves corrected μ(F) > 0 when transfinite diameter ρ(F) < 1. Uses small_diameter_disc axiom + translation invariance of Lebesgue measure (addHaar_ball_center) for uniform lower bound.
- **erdos_1040_current_state**: Second conjunct (μ > 0 for ρ < 1) now fully proved; first conjunct (μ = 0 for segments/discs with ρ ≥ 1) still sorry.
- **Erdos1040Aristotle**: Deduplicated 3x mu_eq_zero, documented transfiniteDiameter_mono BddAbove limitation.
- **Erdos673Aristotle**: Fixed G_one forward-reference to tau_one.

### Previous commits
- **Erdos454Aristotle**: `infinitely_many_deviation_ge_2` — limsup ≥ 2 → set {n | deviation ≥ 2} is infinite
- **Erdos117OQ01**: `limInf_le_limSup` — liminf ≤ limsup for growth rate sequence
- **Erdos1087**: `trivial_upper_bound` — f(n) ≤ n⁴/24 from placeholder definition
- **Erdos39**: `no_sqrt_growth` — liminf A(N)/√N = 0 consequence

## Test plan
- [ ] CI build passes (proofs need Lean verification)
- [ ] No new sorries introduced
- [ ] addHaar_ball_center lemma name verified in Mathlib 4.26.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)