### PR TITLE
fix(gallery): erdos-1018-oq-04 — sorry count 4→3

### DIFF
--- a/src/data/proofs/erdos-1018-oq-04/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04/meta.json
@@ -18,10 +18,10 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 3,
     "axiomCount": 4,
-    "lineCount": 301,
-    "assumptions": "4 axioms: van Kampen-Flores theorem, embeddability of K₃ and K₄ in R², density-exceeds-Turán threshold. 4 sorries including topological embeddability definition.",
+    "lineCount": 305,
+    "assumptions": "4 axioms: van Kampen-Flores theorem, embeddability of K₃ and K₄ in R², density-exceeds-Turán threshold. 3 sorries including topological embeddability definition.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -137,28 +137,37 @@
   ],
   "references": [
     {
-      "authors": ["A. V. Kostochka", "L. Pyber"],
+      "authors": [
+        "A. V. Kostochka",
+        "L. Pyber"
+      ],
       "title": "Small topological complete subgraphs of 'dense' graphs",
       "year": "1988",
       "venue": "Combinatorica",
       "note": "Proves the graph case (r=2): n^(1+ε) edges → K₅ subdivision on O_ε(1) vertices"
     },
     {
-      "authors": ["E. R. van Kampen"],
+      "authors": [
+        "E. R. van Kampen"
+      ],
       "title": "Komplexe in euklidischen Räumen",
       "year": "1933",
       "venue": "Abh. Math. Sem. Univ. Hamburg",
       "note": "Proved non-embeddability of certain simplicial complexes, precursor to the van Kampen-Flores theorem"
     },
     {
-      "authors": ["A. Flores"],
+      "authors": [
+        "A. Flores"
+      ],
       "title": "Über n-dimensionale Komplexe die im R_{2n+1} absolut selbstverschlungen sind",
       "year": "1933",
       "venue": "Ergeb. Math. Kolloq.",
       "note": "Proved that the (r-1)-skeleton of the (2r)-simplex is not embeddable in R^(2(r-1))"
     },
     {
-      "authors": ["J. Matoušek"],
+      "authors": [
+        "J. Matoušek"
+      ],
       "title": "Using the Borsuk-Ulam Theorem",
       "year": "2003",
       "venue": "Springer Universitext",
@@ -166,10 +175,14 @@
     }
   ],
   "leanFile": {
-    "imports": ["Mathlib"],
-    "opens": ["Finset"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ],
     "namespace": "Erdos1018OQ04",
-    "lineCount": 301,
+    "lineCount": 305,
     "axiomCount": 4,
     "theoremCount": 11,
     "definitionCount": 12


### PR DESCRIPTION
## Summary

- **erdos-1018-oq-04** sorry count stale: `completeEdgeCount` proof completed
- Fix sorry count (4→3), line count (301→305)

## Evidence

| Field | Before | After | Lean source |
|-------|--------|-------|-------------|
| sorries | 4 | 3 | Lines 77, 141, 269 |
| lineCount | 301 | 305 | `wc -l` = 305 |

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)