### PR TITLE
fix: erdos-1040 sorry count 5→4

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1649,9 +1649,9 @@
       "issues": []
     },
     "erdos-1040": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T12:43:48Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-03-30T07:03:38Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "erdos-1041": {

--- a/src/data/proofs/erdos-1040/meta.json
+++ b/src/data/proofs/erdos-1040/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 4,
     "erdosNumber": 1040,
     "erdosUrl": "https://erdosproblems.com/1040",
     "erdosProblemStatus": "open",
@@ -25,7 +25,7 @@
       1039
     ],
     "axiomCount": 7,
-    "assumptions": "7 axiom declarations: transfiniteDiameter_eq (Fekete's limit theorem), lineSegment_determined (line segment mu determined by diameter), disc_determined (disc mu determined by radius), lineSegment_diameter (line segment capacity = length/4), disc_diameter (disc capacity = radius), small_diameter_disc (qualitative disc containment for ρ < 1), erdos_netanyahu (quantitative disc bounds, 1973). 4 sorries in theorems.",
+    "assumptions": "7 axiom declarations: transfiniteDiameter_eq (Fekete's limit theorem), lineSegment_determined (line segment mu determined by diameter), disc_determined (disc mu determined by radius), lineSegment_diameter (line segment capacity = length/4), disc_diameter (disc capacity = radius), small_diameter_disc (qualitative disc containment for ρ < 1), erdos_netanyahu (quantitative disc bounds, 1973). 4 sorry-carrying theorems: transfiniteDiameter_mono, nthDiameter_eq_zero_of_finite, transfiniteDiameter_scale, erdos_1040_current_state.",
     "prerequisites": [
       "Complex analysis: polynomial lemniscates and sublevel sets",
       "Potential theory: transfinite diameter and logarithmic capacity",
@@ -145,7 +145,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #1040 formalizes one of the fundamental open questions in the geometry of polynomial lemniscates: whether the infimum $\\mu(F)$ of sublevel set measures is determined by the transfinite diameter $\\rho(F)$. The Lean formalization builds a complete framework from the $n$-th diameter and Fekete point theory through to the two forms of the conjecture, axiomatizing the known results of EHP (1958) and the Erdős-Netanyahu (1973) quantitative bounds. 5 axioms remain (capacity formulas, disc containment, EN bounds). 5 sorries remain for structural properties of $\\rho$ and $\\mu$.",
+    "summary": "Erdős Problem #1040 formalizes one of the fundamental open questions in the geometry of polynomial lemniscates: whether the infimum $\\mu(F)$ of sublevel set measures is determined by the transfinite diameter $\\rho(F)$. The Lean formalization builds a complete framework from the $n$-th diameter and Fekete point theory through to the two forms of the conjecture, axiomatizing the known results of EHP (1958) and the Erdős-Netanyahu (1973) quantitative bounds. 7 axioms remain (Fekete's limit, segment/disc determination, capacity formulas, disc containment, EN bounds). 4 sorries remain for structural properties of $\\rho$ and $\\mu$, plus the combined known-results theorem.",
     "implications": "1. **Potential Theory and Polynomial Geometry**: A positive resolution would establish that logarithmic capacity completely controls the measure-theoretic behavior of polynomial lemniscates, unifying capacity theory with the geometry of sublevel sets\n\n2. **Extremal Polynomial Theory**: Understanding $\\mu(F)$ requires identifying near-optimal polynomials for general sets, extending the role of Chebyshev polynomials (for intervals) and power functions (for discs) to arbitrary compact sets\n\n**3. Conformal Invariance**: Since $\\rho(F)$ is related to the conformal mapping radius of $\\mathbb{C} \\setminus F$, a positive answer would connect sublevel set area to conformal geometry\n\n4. **Connection to Problem #1039**: Problems 1039 and 1040 together ask about the inner structure (inscribed disc) and total size (area) of lemniscates — two complementary aspects of the same geometric question\n\n5. **Approximation Theory**: The problem has implications for polynomial approximation on compact sets, as sublevel set size controls the rate of polynomial convergence.",
     "openQuestions": [
       "Is $\\mu(F) = 0$ when $\\rho(F) \\geq 1$ for general closed infinite sets? (The main conjecture, open since 1958)",


### PR DESCRIPTION
## Summary
- Fixed sorry count mismatch in `erdos-1040/meta.json`: claimed 5, actual 4
- Corrected conclusion text: "5 axioms remain" → "7 axioms remain", "5 sorries" → "4 sorries"
- Updated assumptions field to name the 4 sorry-carrying theorems explicitly

## Evidence
Lean source `Proofs/Erdos1040Problem.lean` has exactly 4 sorries (lines 255, 296, 318, 376) and 7 axiom declarations (lines 45, 187, 191, 195, 199, 207, 223).

## Test plan
- [ ] `pnpm build` passes
- [ ] Sorry count in meta.json matches Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)