### PR TITLE
fix: correct sorry/axiom counts in 7 gallery proofs

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2669,9 +2669,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-1087": {
-      "lastAudited": "2026-03-24T13:12:17Z",
-      "auditCount": 1,
-      "result": "clean",
+      "lastAudited": "2026-03-30T07:33:49Z",
+      "auditCount": 2,
+      "result": "issues-fixed",
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-1088": {
@@ -4457,9 +4457,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-39": {
-      "lastAudited": "2026-03-24T13:12:27Z",
-      "auditCount": 1,
-      "result": "clean",
+      "lastAudited": "2026-03-30T07:32:31Z",
+      "auditCount": 2,
+      "result": "issues-fixed",
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-390": {
@@ -4715,9 +4715,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-434": {
-      "lastAudited": "2026-03-24T13:12:27Z",
-      "auditCount": 1,
-      "result": "clean",
+      "lastAudited": "2026-03-30T07:29:36Z",
+      "auditCount": 2,
+      "result": "issues-fixed",
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-435": {
@@ -4841,9 +4841,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-453": {
-      "lastAudited": "2026-03-24T13:12:27Z",
-      "auditCount": 1,
-      "result": "clean",
+      "lastAudited": "2026-03-30T07:32:31Z",
+      "auditCount": 2,
+      "result": "issues-fixed",
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-454": {
@@ -5717,9 +5717,9 @@
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-59": {
-      "lastAudited": "2026-03-24T13:12:27Z",
-      "auditCount": 1,
-      "result": "clean",
+      "lastAudited": "2026-03-30T07:31:01Z",
+      "auditCount": 2,
+      "result": "issues-fixed",
       "agentId": "auditor-cycle-20-batch"
     },
     "erdos-590": {
@@ -9867,9 +9867,9 @@
       "issues": []
     },
     "erdos-117-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-29T14:57:10Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-03-30T07:33:49Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "lagrange-theorem-oq-02": {
@@ -10067,6 +10067,12 @@
     "triangular-reciprocals-oq-01": {
       "auditCount": 1,
       "lastAudited": "2026-03-30T05:08:28Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "hilbert-13-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T07:33:49Z",
       "result": "issues-fixed",
       "issues": []
     }

--- a/src/data/proofs/erdos-1087/meta.json
+++ b/src/data/proofs/erdos-1087/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 1087,
     "erdosUrl": "https://erdosproblems.com/1087",
     "erdosProblemStatus": "open",
@@ -66,7 +66,7 @@
     ],
     "axiomCount": 6,
     "lineCount": 335,
-    "assumptions": "6 axiom(s) and 3 sorry(s). See the Lean source for details."
+    "assumptions": "6 axioms and 1 sorry (erdos_1087_answer_c_exists)."
   },
   "overview": {
     "historicalContext": "**Erdos Problem #1087**\n\nThis problem was posed by Paul Erdos and George Purdy in their 1971 paper \"Some extremal problems in geometry\" (J. Combinatorial Theory Ser. A, 246-252). It belongs to the rich tradition of combinatorial geometry problems that Erdos pioneered.\n\n**The Setting:**\nGiven n points in the plane, consider all C(n,4) = n(n-1)(n-2)(n-3)/24 subsets of 4 points (quadruples). A quadruple is called \"degenerate\" if at least two of its 6 pairwise distances are equal. Let f(n) be the maximum number of degenerate quadruples over all n-point configurations.\n\n**Historical Progress:**\nErdos and Purdy proved bounds n^3 log n << f(n) << n^{7/2} in 1971. The problem asks whether the upper bound can be improved to n^{3+o(1)}, which would nearly match the lower bound. This remains open as of 2025, representing a gap in our understanding of distance geometry.",

--- a/src/data/proofs/erdos-117-oq-01/meta.json
+++ b/src/data/proofs/erdos-117-oq-01/meta.json
@@ -19,9 +19,9 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 3,
     "axiomCount": 3,
-    "assumptions": "3 axiom declarations: h (abelian covering number function), h_pos (h(n) ≥ 1), pyber_bounds (exponential bounds). 4 sorries in analysis lemmas (liminf/limsup properties, Fekete's lemma, limit characterizations).",
+    "assumptions": "3 axiom declarations: h (abelian covering number function), h_pos (h(n) ≥ 1), pyber_bounds (exponential bounds). 3 sorries in analysis lemmas.",
     "erdosNumber": 117,
     "erdosUrl": "https://erdosproblems.com/117",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-39/meta.json
+++ b/src/data/proofs/erdos-39/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 39,
     "erdosUrl": "https://erdosproblems.com/39",
     "erdosProblemStatus": "open",
@@ -55,7 +55,7 @@
       "Probabilistic method in combinatorics",
       "Basic analytic number theory (square root barriers)"
     ],
-    "assumptions": "5 axiom(s) and 1 sorry(s). See the Lean source for details."
+    "assumptions": "5 axioms (erdos_sidon_upper_bound, greedy_sidon_exists, aks_sidon_construction, ruzsa_sidon_construction, erdos_renyi_construction). 0 sorries."
   },
   "overview": {
     "historicalContext": "Erdős Problem #39 asks one of the central questions in additive combinatorics: how dense can an infinite Sidon set be? A Sidon set (also called a B₂ sequence) is a set where all pairwise sums are distinct. For finite Sidon sets in {1,...,N}, the maximum size is approximately √N (see Problem #30). But for infinite Sidon sets, the situation is more subtle.\n\nErdős proved a fundamental upper bound: for any infinite Sidon set A, the limit inferior of A(N)/√N equals zero. This means no infinite Sidon set can have counting function consistently above c√N. The natural question is whether we can achieve A(N) >> N^{1/2-ε} for all ε > 0.\n\nProgress has been slow but steady. The trivial greedy algorithm gives N^{1/3}. Ajtai, Komlós, and Szemerédi (1981) achieved (N log N)^{1/3}, earning $25 from Erdős. Ruzsa (1998) broke the 1/3 barrier with N^{√2-1} ≈ N^{0.414}, earning $100. The gap to N^{1/2-ε} remains open, with a $500 prize.",

--- a/src/data/proofs/erdos-434/meta.json
+++ b/src/data/proofs/erdos-434/meta.json
@@ -19,7 +19,7 @@
       "coin-problem"
     ],
     "badge": "axiom",
-    "sorries": 8,
+    "sorries": 5,
     "erdosNumber": 434,
     "erdosUrl": "https://erdosproblems.com/434",
     "erdosProblemStatus": "solved",
@@ -70,7 +70,7 @@
     ],
     "axiomCount": 4,
     "lineCount": 310,
-    "assumptions": "4 axiom(s) and 8 sorry(s). See the Lean source for details."
+    "assumptions": "4 axioms (kiss_2002, sylvester_frobenius, sylvester_count, frobenius_consecutive) and 5 sorries in theorems."
   },
   "overview": {
     "historicalContext": "Erdős Problem #434 is closely related to the classical Frobenius problem (also called the coin problem or money changing problem). Given a set of positive integers with gcd = 1, only finitely many integers are non-representable as sums of elements from the set.\n\nThe Frobenius number is the largest such non-representable integer. For two coprime integers a and b, Sylvester proved in 1884 that this equals ab - a - b, and the count of non-representables is (a-1)(b-1)/2.\n\nProblem #434 asks a different question: not what is the largest non-representable integer, but which k-element subset of {1, ..., n} maximizes the COUNT of non-representable integers. Kiss (2002) proved that the answer is the 'top k' set: {n-k+1, ..., n}. Intuitively, using larger numbers creates more gaps in what's representable.\n\nThe problem connects to numerical semigroup theory, where the 'genus' of a semigroup (number of gaps) is a central invariant. Problem #434 asks which generators maximize the genus. The result is also remarkable from an optimization perspective: the greedy algorithm (always pick the largest available number) produces the provably optimal solution — a rare case in combinatorial optimization where greedy is exactly optimal.\n\nRamírez-Alfonsín (2005) showed that computing the Frobenius number for sets of 3 or more elements is NP-hard, making the clean explicit solution to the extremal problem all the more surprising.",
@@ -217,7 +217,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #434 on the extremal Frobenius problem. Kiss (2002) proved that the 'top k' set {n-k+1, ..., n} maximizes the count of non-representable integers among all k-element subsets of {1, ..., n}. The 311-line proof has 8 sorries (examples, cardinality, finiteness, comparison) and 4 axioms (Kiss's theorem, Sylvester-Frobenius formula and count, consecutive Frobenius). Core representability theory (3 closure lemmas) and topK_5_2 are fully proved.",
+    "summary": "This formalization captures Erdős Problem #434 on the extremal Frobenius problem. Kiss (2002) proved that the 'top k' set {n-k+1, ..., n} maximizes the count of non-representable integers among all k-element subsets of {1, ..., n}. The proof has 5 sorries and 4 axioms (Kiss's theorem, Sylvester-Frobenius formula and count, consecutive Frobenius). Core representability theory (3 closure lemmas) and topK_5_2 are fully proved.",
     "implications": "**Theoretical Significance**: The problem connects the classical Frobenius (coin) problem with extremal combinatorics and numerical semigroup theory.\n\nThe greedy approach of selecting largest elements is optimal, contrasting with many optimization problems where greedy fails. The result also connects to computational complexity: while the Frobenius problem for ≥ 3 elements is NP-hard, the extremal problem has a clean, explicit optimal solution.",
     "openQuestions": [
       "Exact formula for the maximum count of non-representables as a function of n and k?",

--- a/src/data/proofs/erdos-453/meta.json
+++ b/src/data/proofs/erdos-453/meta.json
@@ -17,7 +17,7 @@
       "prime-number-graph"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 453,
     "erdosUrl": "https://erdosproblems.com/453",
     "erdosProblemStatus": "solved",
@@ -54,9 +54,9 @@
       "counterexample_set_infinite theorem (fully proved from axioms)",
       "log_convexity_iff_vertex identity (proved by rfl)"
     ],
-    "axiomCount": 4,
+    "axiomCount": 2,
     "lineCount": 339,
-    "assumptions": "4 axioms: nthPrime_is_prime, nthPrime_strictMono, logPrime_ratio_tendsto_zero, pomerance_convex_hull_lemma. 1 sorry remaining."
+    "assumptions": "2 axioms: logPrime_ratio_tendsto_zero, pomerance_convex_hull_lemma. 0 sorries. nthPrime_is_prime and nthPrime_strictMono are now proved theorems."
   },
   "leanFile": {
     "imports": [
@@ -71,7 +71,7 @@
     ],
     "namespace": "Erdos453",
     "lineCount": 339,
-    "axiomCount": 4,
+    "axiomCount": 2,
     "theoremCount": 14,
     "definitionCount": 7
   },
@@ -126,8 +126,8 @@
       "title": "The Prime Sequence",
       "startLine": 42,
       "endLine": 69,
-      "summary": "Defines `nthPrime` (1-indexed wrapper for Mathlib's `Nat.Prime.nthPrime`), verifies $p_1=2, p_2=3, p_3=5, p_4=7$ (sorry), and axiomatizes primality of all terms ($n \\geq 1$) and strict monotonicity of $n \\mapsto p_{n+1}$.",
-      "mathContext": "Defines `nthPrime` (1-indexed wrapper for Mathlib's `Nat.Prime.nthPrime`), verifies $p_1=2, p_2=3, p_3=5, p_4=7$ (sorry), and axiomatizes primality of all terms ($n \\geq 1$) and strict monotonicity of $n \\mapsto p_{n+1}$."
+      "summary": "Defines `nthPrime` (1-indexed wrapper for Mathlib's `Nat.Prime.nthPrime`), verifies $p_1=2, p_2=3, p_3=5, p_4=7$ (proved), and proves primality of all terms ($n \\geq 1$) and strict monotonicity of $n \\mapsto p_{n+1}$.",
+      "mathContext": "Defines `nthPrime` (1-indexed wrapper for Mathlib's `Nat.Prime.nthPrime`), verifies $p_1=2, p_2=3, p_3=5, p_4=7$ (proved), and proves primality of all terms ($n \\geq 1$) and strict monotonicity of $n \\mapsto p_{n+1}$."
     },
     {
       "id": "conjectures",

--- a/src/data/proofs/erdos-59/meta.json
+++ b/src/data/proofs/erdos-59/meta.json
@@ -18,26 +18,26 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 59,
     "erdosUrl": "https://erdosproblems.com/59",
     "erdosProblemStatus": "solved",
-    "axiomCount": 9,
+    "axiomCount": 10,
     "lineCount": 222,
-    "assumptions": "9 axiom(s) and 1 sorry(s). See the Lean source for details.",
+    "assumptions": "10 axioms (cycleGraph, odd_cycle_not_bipartite, even_cycle_bipartite, turanNumber, countFreeGraphs, turanNumber_pos, erdos_frankl_rodl_nonbipartite, morris_saxton_c6_counterexample, turan_theorem, kovari_sos_turan). 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "Erdős conjectured that the number of labeled H-free graphs on n vertices is at most 2^{(1+o(1))ex(n;H)}, where ex(n;H) is the Turán number. This connects extremal graph theory (how dense can an H-free graph be?) with graph enumeration (how many H-free graphs exist?). Erdős, Frankl, and Rödl proved in 1986 that the bound holds for all non-bipartite H, using the Szemerédi regularity lemma to show that most H-free graphs resemble the Turán graph. The bipartite case remained open until Morris and Saxton (2016) found a striking counterexample: the 6-cycle C_6. Using algebraic constructions related to projective planes, they showed there are superpolynomially more C_6-free graphs than the conjecture predicts. Specifically, for C_6 with ex(n;C_6) = Θ(n^{4/3}), the count exceeds 2^{(1+c)n^{4/3}}. This disproved the conjecture but left open the weaker question (Morris-Saxton conjecture): does 2^{O(ex(n;H))} hold for all H? The dichotomy between bipartite and non-bipartite forbidden subgraphs is fundamental and persists across extremal combinatorics.",
     "problemStatement": "Is it true that the number of graphs on $n$ vertices which do not contain $G$ is at most $2^{(1+o(1))\\text{ex}(n;G)}$?",
     "text": "Is the number of G-free graphs on n vertices at most 2^{(1+o(1))ex(n;G)}? Disproved by Morris-Saxton (2016) for C_6.",
-    "proofStrategy": "The formalization defines subgraph containment, H-free property, and bipartiteness. Cycle graphs are axiomatized with bipartiteness properties. Turán numbers and free graph counts are axiomatized since they involve extremal combinatorial computation. Three asymptotic bound predicates (HasOptimalBound, ExceedsOptimalBound, HasPolynomialBound) capture the conjectured bound, counterexample, and open conjecture. The Erdős-Frankl-Rödl theorem and Morris-Saxton counterexample are axioms. The main theorem `erdos_59_disproved` has 1 sorry (extracting a large element from Set.Infinite). Classical Turán bounds and two corollaries are also included.",
+    "proofStrategy": "The formalization defines subgraph containment, H-free property, and bipartiteness. Cycle graphs are axiomatized with bipartiteness properties. Turán numbers and free graph counts are axiomatized since they involve extremal combinatorial computation. Three asymptotic bound predicates (HasOptimalBound, ExceedsOptimalBound, HasPolynomialBound) capture the conjectured bound, counterexample, and open conjecture. The Erdős-Frankl-Rödl theorem and Morris-Saxton counterexample are axioms. The main theorem `erdos_59_disproved` is fully proved. Classical Turán bounds and two corollaries are also included.",
     "keyInsights": [
       "The bipartite/non-bipartite dichotomy is fundamental: for non-bipartite H, the regularity lemma forces most H-free graphs to look like the Turán graph, giving 2^{(1+o(1))ex}. Bipartite H allows more diverse structures",
       "C_6 is the simplest counterexample because ex(n;C_6) = Θ(n^{4/3}) comes from projective plane constructions, and these algebraic structures generate many distinct C_6-free graphs beyond what the Turán number alone predicts",
       "The gap between 2^{(1+o(1))ex} and 2^{O(ex)} is the key open question: the Morris-Saxton conjecture posits 2^{O(ex)} always holds, but 2^{(1+o(1))ex} fails for bipartite H",
       "Turán's theorem gives ex(n;K_{r+1}) exactly, while Kővári-Sós-Turán gives ex(n;C_{2k}) = O(n^{1+1/k}) — the subquadratic growth for bipartite graphs is what makes their counting behavior different",
-      "The sorry in erdos_59_disproved is a technical gap (extracting n ≥ N₀ from Set.Infinite), not a mathematical one — the argument is complete modulo this Lean extraction step"
+      "The 10 axioms encode graph theory infrastructure (cycle graphs, Turán numbers, bipartiteness) and the key results (EFR 1986, Morris-Saxton 2016, Turán and Kővári-Sós-Turán theorems)"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -97,7 +97,7 @@
     {
       "id": "resolution",
       "title": "Problem Resolution: DISPROVED + Bipartiteness Results",
-      "summary": "erdos_59_disproved (1 sorry): negation of universal optimal bound via k=6. c6_is_bipartite and k3_not_bipartite proved from cycle axioms",
+      "summary": "erdos_59_disproved: negation of universal optimal bound via k=6. c6_is_bipartite and k3_not_bipartite proved from cycle axioms",
       "startLine": 132,
       "endLine": 173,
       "mathContext": "SOLVED: EKR (1976) for triangles, Erdos-Frankl-Rodl (1986) for general non-bipartite $G$. Bipartite case still has open questions."
@@ -120,13 +120,13 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #59 is DISPROVED. The 223-line formalization captures the complete resolution: the Erdős-Frankl-Rödl theorem (1986) proves the bound for non-bipartite H, while the Morris-Saxton counterexample (2016) disproves it for C_6. The main theorem has 1 sorry (a technical extraction from Set.Infinite). Classical Turán bounds, the Morris-Saxton weaker conjecture, and bipartiteness results are also formalized.",
+    "summary": "Erdős Problem #59 is DISPROVED. The formalization captures the complete resolution: the Erdős-Frankl-Rödl theorem (1986) proves the bound for non-bipartite H, while the Morris-Saxton counterexample (2016) disproves it for C_6. 0 sorries, 10 axioms encoding graph infrastructure and the key results.",
     "implications": "**Theoretical Significance**: The resolution reveals a fundamental structural dichotomy in extremal graph theory: for non-bipartite forbidden subgraphs, the Turán number essentially determines the count of free graphs (via the regularity lemma).\n\nFor bipartite forbidden subgraphs, algebraic structures (projective planes) create additional diversity that the Turán number alone cannot capture. This parallels the KST/Turán divide throughout extremal combinatorics.",
     "openQuestions": [
       "Does the weaker bound 2^{O(ex(n;G))} hold for all G? (Morris-Saxton Conjecture, OPEN)",
       "For which bipartite graphs H does the original 2^{(1+o(1))ex} bound hold?",
       "What is the exact counting exponent for C_{2k}-free graphs for k > 3?",
-      "Can the sorry in erdos_59_disproved be resolved via Set.Infinite.exists_gt or similar Mathlib lemma?"
+      "Can any of the 10 axioms be proved from Mathlib's combinatorics library?"
     ]
   },
   "crossReferences": [
@@ -171,7 +171,7 @@
     ],
     "namespace": "Erdos59",
     "lineCount": 222,
-    "axiomCount": 9,
+    "axiomCount": 10,
     "theoremCount": 5,
     "definitionCount": 9
   },

--- a/src/data/proofs/hilbert-13-oq-04/meta.json
+++ b/src/data/proofs/hilbert-13-oq-04/meta.json
@@ -20,9 +20,9 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 6,
-    "assumptions": "6 axioms: unitCube_covDimLE, unitCube_covDim_lower_bound (dimension of [0,1]^n), ostrand_separating_maps (Ostrand 1965), generalized_kolmogorov_arnold (generalized KA theorem), sternfeld_characterization (Sternfeld 1985), superposition_2n_plus_1_sharp (optimality of 2n+1). 1 sorry: covDimLE_of_embedding (dimension monotonicity under continuous injection).",
+    "assumptions": "6 axioms: unitCube_covDimLE, unitCube_covDim_lower_bound (dimension of [0,1]^n), ostrand_separating_maps (Ostrand 1965), generalized_kolmogorov_arnold (generalized KA theorem), sternfeld_characterization (Sternfeld 1985), superposition_2n_plus_1_sharp (optimality of 2n+1). 0 sorries.",
     "dateAdded": "2026-03-30",
     "hilbertNumber": 13,
     "mathlibDependencies": [


### PR DESCRIPTION
## Summary
- Fixed stale sorry/axiom counts in 7 meta.json files where Lean source had been updated but gallery metadata lagged behind
- erdos-434: sorries 8→5, erdos-59: sorries 1→0 + axioms 9→10, erdos-453: sorries 1→0 + axioms 4→2, erdos-39: sorries 1→0, hilbert-13-oq-04: sorries 1→0, erdos-1087: sorries 2→1, erdos-117-oq-01: sorries 4→3
- Also updated stale assumptions/conclusion text referencing old counts

## Test plan
- [ ] `pnpm build` passes
- [ ] Sorry counts in meta.json match `grep -c '\bsorry\b'` in corresponding Lean files

🤖 Generated with [Claude Code](https://claude.com/claude-code)