### PR TITLE
fix: correct stale axiomCount in 4 proofs

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Barbier (1860); Lean formalization 2026",
     "sourceUrl": "https://en.wikipedia.org/wiki/Buffon%27s_noodle",
     "date": "1860",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/BuffonsNeedleOQ01OQ01.lean",
     "tags": [
       "probability",
@@ -20,7 +20,7 @@
       "cauchy-crofton",
       "open-question-resolved"
     ],
-    "badge": "axiom",
+    "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -70,7 +70,7 @@
       "buffon_smooth_full: the complete Buffon-Barbier theorem with all hypotheses explicit"
     ],
     "dateAdded": "2026-02-25",
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 390,
     "mathlib_version": "4.26.0"
   },
@@ -196,7 +196,7 @@
     ],
     "namespace": "BuffonsNeedleOQ01OQ01",
     "lineCount": 390,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 2
   }

--- a/src/data/proofs/erdos-1145/meta.json
+++ b/src/data/proofs/erdos-1145/meta.json
@@ -18,8 +18,8 @@
         "sourceUrl": "https://erdosproblems.com/1145",
         "erdosUrl": "https://erdosproblems.com/1145",
         "proofRepoPath": "Proofs/Erdos1145Problem.lean",
-        "axiomCount": 5,
-        "assumptions": "5 axioms: erdos_sarkozy_conjecture (main open conjecture), ruzsa_unique_rep, ruzsa_ratio_not_one, average_rep_grows, grekos_two_set. Eliminated 3 axioms: ruzsaA_infinite (proved via powers of 4), ruzsaB_infinite (proved via 2·4^k), sum_of_reps_bound (was vacuously true: RHS = 0).",
+        "axiomCount": 4,
+        "assumptions": "4 axioms: erdos_sarkozy_conjecture (main open conjecture), ruzsa_ratio_not_one, average_rep_grows, grekos_two_set. Eliminated 4 axioms: ruzsaA_infinite (proved via powers of 4), ruzsaB_infinite (proved via 2·4^k), sum_of_reps_bound (was vacuously true: RHS = 0), ruzsa_unique_rep (proved).",
         "badge": "axiom",
         "prerequisites": [
             "Additive number theory (sumsets, representation functions)",
@@ -188,7 +188,7 @@
         ],
         "namespace": "Erdos1145",
         "lineCount": 552,
-        "axiomCount": 5,
+        "axiomCount": 4,
         "theoremCount": 10,
         "definitionCount": 10
     }

--- a/src/data/proofs/erdos-408/meta.json
+++ b/src/data/proofs/erdos-408/meta.json
@@ -51,9 +51,9 @@
       "Verified totient computations for small n"
     ],
     "dateAdded": "2026-01-22",
-    "axiomCount": 6,
+    "axiomCount": 5,
     "lineCount": 396,
-    "assumptions": "14 axiom(s) and 1 sorry(s). See the Lean source for details."
+    "assumptions": "5 axioms: pillai_lower_bound, pillai_upper_bound, shapiro_multiplicativity, ElliottHalberstam, egps_conditional. 0 sorries."
   },
   "overview": {
     "historicalContext": "The iterated totient function was first studied by S. S. Pillai in 1929, who established that $f(n)$ — the number of times Euler's totient $\\phi$ must be applied to $n$ before reaching 1 — satisfies $\\log_3 n < f(n) < \\log_2 n$ for large $n$. This showed that $f(n)$ grows logarithmically, but left open the precise constant.\n\nIn 1950, Harold Shapiro proved a deeper structural result: $f$ is essentially multiplicative, meaning $f(mn) = f(m) + f(n) + O(1)$ for coprime $m, n$. This additive-like behavior suggested that $f(n)/\\log n$ should have well-defined statistical properties, analogous to the Erdős-Kac theorem for the number of prime factors.\n\nErdős posed Problem #408 asking three specific questions about this behavior. The breakthrough came in 1990 when Erdős, Granville, Pomerance, and Spiro (EGPS) proved that, conditional on the Elliott-Halberstam conjecture (a strengthening of the Bombieri-Vinogradov theorem asserting level of distribution $\\theta$ for all $\\theta < 1$), the ratio $f(n)/\\log n$ converges to $1/\\log 2 \\approx 1.4427$ for almost all $n$.\n\nThe limiting constant $1/\\log 2$ coincides with the upper endpoint of Pillai's interval, meaning that $f(n)$ is 'almost as large as possible' for typical $n$. Intuitively, this reflects the dominance of the factor of 2 in each totient iteration: since $\\phi(n)$ is always even for $n \\ge 3$, the iteration behaves like repeated halving for generic inputs. The problem remains open unconditionally — even the weaker Bombieri-Vinogradov theorem ($\\theta = 1/2$) is insufficient for the EGPS argument.",
@@ -183,7 +183,7 @@
     ],
     "namespace": "Erdos408",
     "lineCount": 396,
-    "axiomCount": 6,
+    "axiomCount": 5,
     "theoremCount": 14,
     "definitionCount": 9
   },

--- a/src/data/proofs/erdos-831/meta.json
+++ b/src/data/proofs/erdos-831/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/831",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos831Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "extremal-geometry",
       "open-problem"
     ],
-    "badge": "axiom",
+    "badge": "original",
     "sorries": 0,
     "erdosNumber": 831,
     "erdosUrl": "https://erdosproblems.com/831",
@@ -53,9 +53,9 @@
       "areCollinear_perm12, areConcyclic_perm: symmetry lemmas (proved)",
       "erdos_831_summary, erdos_831_open_question: summary theorems"
     ],
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 704,
-    "assumptions": "1 axiom: h_four_lower (h(4)≥2). 0 sorries — h_upper_bound and h_three now fully proved."
+    "assumptions": "Fully verified: 0 axioms, 0 sorries. h_four_lower (h(4)≥2), h_upper_bound, and h_three all proved."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #831**\n\nThis geometric extremal problem was posed by Erdős in the 1970s and revisited in the 1990s, documented in [Er75h] and [Er92e].\n\n**Key History:**\n- Erdős asked about the minimum number of distinct circumradii from point configurations\n- Related to classical problems about point-line and point-circle incidences\n- Connects to the unit distance problem and orchard problem\n\n**Mathematical Setting:**\nGiven n points in general position (no three collinear, no four concyclic), each triple determines a unique circumcircle. The question is: over all such configurations, what is the minimum number of distinct radii among these circles?",
@@ -185,7 +185,7 @@
     ],
     "namespace": "Erdos831",
     "lineCount": 704,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 23,
     "definitionCount": 17
   },


### PR DESCRIPTION
## Fix

Corrects stale axiomCount in 4 meta.json files where axioms were proved/removed but the count wasn't updated.

## Evidence

**buffons-needle-oq-01-oq-01**:
- Before: axiomCount=1, status=axiomatized, badge=axiom
- After: axiomCount=0, status=verified, badge=original
- Reason: File has 0 axiom declarations, 0 sorries — fully verified

**erdos-831**:
- Before: axiomCount=1, status=axiomatized
- After: axiomCount=0, status=verified
- Reason: h_four_lower axiom was proved, file now has 0 axioms, 0 sorries

**erdos-1145**:
- Before: axiomCount=5
- After: axiomCount=4
- Reason: ruzsa_unique_rep axiom was proved/removed

**erdos-408**:
- Before: axiomCount=6, assumptions="14 axiom(s) and 1 sorry(s)"
- After: axiomCount=5, assumptions lists actual 5 axioms, 0 sorries
- Reason: One axiom removed, assumptions text was severely stale

---
Automated fix by lean-mechanic agent.