### PR TITLE
Research: erdos-949 axiom fix + erdos-411 prove Cambie ratio-3 (4→3 axioms)

### DIFF
--- a/proofs/Proofs/Erdos411Problem.lean
+++ b/proofs/Proofs/Erdos411Problem.lean
@@ -70,6 +70,13 @@ theorem totientStep_double_even {m : ℕ} (hm : 2 ∣ m) (hm_pos : 0 < m) :
   rw [totient_double_even hm hm_pos]
   ring
 
+/-- g(3m) = 3·g(m) for m divisible by 3 with m > 0. From Mathlib's totient identity. -/
+theorem totientStep_triple {m : ℕ} (hm : 3 ∣ m) (hm_pos : 0 < m) :
+    totientStep (3 * m) = 3 * totientStep m := by
+  unfold totientStep
+  rw [Nat.totient_mul_of_prime_of_dvd (by decide : Nat.Prime 3) hm]
+  ring
+
 /-- The iterates are always ≥ the starting value. -/
 theorem iteratedTotientStep_ge_start (n k : ℕ) :
     iteratedTotientStep k n ≥ n := by
@@ -130,7 +137,51 @@ def GeneralRatioRelation (n r c : ℕ) : Prop :=
   ∃ K : ℕ, ∀ k : ℕ, k ≥ K →
     iteratedTotientStep (k + r) n = c * iteratedTotientStep k n
 
-axiom cambie_ratio3 : GeneralRatioRelation 738 4 3
+/-- All iterates of 738 are divisible by 3 and satisfy g_{k+4}(738) = 3·g_k(738).
+    Proved by strong induction: base cases (k < 4) verified computationally,
+    inductive step uses g(3m) = 3·g(m) (when 3|m) and the ratio. -/
+private theorem ratio3_738_aux :
+    ∀ k, 3 ∣ iteratedTotientStep k 738 ∧
+      iteratedTotientStep (k + 4) 738 = 3 * iteratedTotientStep k 738 := by
+  intro k
+  induction k using Nat.strongRecOn with
+  | _ k ih =>
+    constructor
+    · -- 3 | a_k: base cases by computation, k ≥ 4 from ratio at k-4
+      by_cases hk : k < 4
+      · interval_cases k <;> native_decide
+      · -- k ≥ 4: a_k = 3·a_{k-4} (from ih at k-4), so 3 | a_k
+        have h := (ih (k - 4) (by omega)).2
+        have : k - 4 + 4 = k := by omega
+        rw [this] at h; rw [h]
+        exact dvd_mul_right 3 _
+    · -- a_{k+4} = 3·a_k: base cases by computation, k ≥ 4 by propagation
+      by_cases hk : k < 4
+      · interval_cases k <;> native_decide
+      · -- k ≥ 4: a_{k+4} = g(a_{k+3}) = g(3·a_{k-1}) = 3·g(a_{k-1}) = 3·a_k
+        have ih_prev := ih (k - 1) (by omega)
+        -- a_{k+3} = 3·a_{k-1}
+        have h_ratio : iteratedTotientStep (k + 3) 738 =
+            3 * iteratedTotientStep (k - 1) 738 := by
+          have h := ih_prev.2; rwa [show k - 1 + 4 = k + 3 from by omega] at h
+        -- a_k = g(a_{k-1})
+        have h_ak : iteratedTotientStep k 738 =
+            totientStep (iteratedTotientStep (k - 1) 738) := by
+          conv_lhs => rw [show k = (k - 1) + 1 from by omega]
+        -- Chain: a_{k+4} = g(a_{k+3}) = g(3·a_{k-1}) = 3·g(a_{k-1}) = 3·a_k
+        calc iteratedTotientStep (k + 4) 738
+            = totientStep (iteratedTotientStep (k + 3) 738) := rfl
+          _ = totientStep (3 * iteratedTotientStep (k - 1) 738) := by rw [h_ratio]
+          _ = 3 * totientStep (iteratedTotientStep (k - 1) 738) :=
+              totientStep_triple ih_prev.1
+                (by have := iteratedTotientStep_ge_start 738 (k - 1); omega)
+          _ = 3 * iteratedTotientStep k 738 := by rw [← h_ak]
+
+/-- PROVED: g_{k+4}(738) = 3·g_k(738) for all k ≥ 0.
+    Cambie's ratio-3 solution, proved via structural induction using
+    g(3m) = 3·g(m) for 3|m and 3-divisibility of all iterates. -/
+theorem cambie_ratio3 : GeneralRatioRelation 738 4 3 :=
+  ⟨0, fun k _ => (ratio3_738_aux k).2⟩
 
 /-- Cambie found ratio-4 solutions as well. -/
 axiom cambie_ratio4_148646 : GeneralRatioRelation 148646 4 4

--- a/proofs/Proofs/Erdos949Problem.lean
+++ b/proofs/Proofs/Erdos949Problem.lean
@@ -153,10 +153,6 @@ axiom sidon_variant_solved :
         realSumset A ⊆ Sᶜ
 
 -- ## The general sum-free problem remains open
-
-/-- The general problem is still open. The key difficulty is that
-sum-free sets can be much denser than Sidon sets, and the
-Sidon proof technique (exploiting injectivity of the sum map)
-does not generalize. -/
-axiom erdos_949_open :
-  ErdosProblem949
+-- The key difficulty is that sum-free sets can be much denser than
+-- Sidon sets, and the Sidon proof technique (exploiting injectivity
+-- of the sum map) does not generalize. The general problem is OPEN.

--- a/src/data/proofs/erdos-411/meta.json
+++ b/src/data/proofs/erdos-411/meta.json
@@ -48,9 +48,9 @@
             "Proved even preservation under g using Mathlib's Nat.totient_even",
             "Formalized Cambie's structural conjecture on the form of r = 2 solutions"
         ],
-        "axiomCount": 4,
-        "lineCount": 173,
-        "assumptions": "4 axioms: cambie_ratio3 (ratio-3 solution n=738), cambie_ratio4_148646 (ratio-4 solution), cambie_ratio4_4325798 (ratio-4 solution), steinerberger_r2_equiv (r=2 reduction to finite equation). The r=2 solutions n=10 and n=94 are fully proved via native_decide."
+        "axiomCount": 3,
+        "lineCount": 223,
+        "assumptions": "3 axioms: cambie_ratio4_148646 (ratio-4 solution), cambie_ratio4_4325798 (ratio-4 solution), steinerberger_r2_equiv (r=2 reduction to finite equation). cambie_ratio3 PROVED via strong induction using g(3m)=3g(m) and 3-divisibility of iterates. The r=2 solutions n=10, n=94 are proved via native_decide."
     },
     "leanFile": {
         "path": "Proofs/Erdos411Problem.lean",
@@ -74,7 +74,7 @@
             "GeneralRatioRelation",
             "CambieConjecture"
         ],
-        "axiomCount": 4,
+        "axiomCount": 3,
         "theoremCount": 9,
         "sorryCount": 0
     },

--- a/src/data/proofs/erdos-949/meta.json
+++ b/src/data/proofs/erdos-949/meta.json
@@ -21,16 +21,16 @@
     "erdosNumber": 949,
     "erdosUrl": "https://erdosproblems.com/949",
     "erdosProblemStatus": "open",
-    "axiomCount": 2,
-    "lineCount": 162,
-    "assumptions": "2 axioms: sidon_variant_solved, erdos_949_open. See Lean source for complete statements.",
+    "axiomCount": 1,
+    "lineCount": 158,
+    "assumptions": "1 axiom: sidon_variant_solved (Sidon variant proved by Dillies/AlphaProof, deep result not yet in Mathlib). Removed unsound erdos_949_open which falsely asserted the open conjecture as true.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "Erdős posed this problem asking whether the complement of a sum-free set in $\\mathbb{R}$ always contains a continuum-sized subset whose sumset avoids the original set. The problem lies at the intersection of additive combinatorics and set-theoretic cardinal arithmetic. Sum-free sets have been studied since Schur (1916), who proved that for any $r$-coloring of $\\{1, \\ldots, n\\}$, some color class contains a monochromatic solution to $a + b = c$ when $n$ is large enough. The complement question reverses this perspective: given a set avoiding such solutions, how much additive structure remains outside? The Sidon variant was proved by Yael Dillies using a technique discovered by AlphaProof. The proof splits into two cases based on whether $|S| < \\mathfrak{c}$ or $|S| = \\mathfrak{c}$. In the small case, Zorn's lemma produces a maximal sumset-avoiding subset of $S^c$, and maximality forces continuum cardinality. In the continuum case, the shift construction $A = ((S \\setminus \\{a\\}) - a/2) \\setminus S$ exploits the Sidon property to ensure $|A \\cap S| \\leq 1$. The general sum-free case remains open because sum-free sets can be much denser than Sidon sets ($n/2$ vs. $\\sqrt{n}$ in $[n]$), and the injectivity of the sum map—crucial to the Sidon proof—fails for general sum-free sets. The file also corrects a previous unsound axiom by proving that Sidon sets are NOT necessarily sum-free, with $\\{1, 2, 4\\}$ as counterexample.",
     "problemStatement": "Let $S \\subseteq \\mathbb{R}$ be sum-free ($\\forall a, b \\in S,\\; a + b \\notin S$). Must there exist $A \\subseteq \\mathbb{R} \\setminus S$ with $|A| = \\mathfrak{c}$ (the cardinality of the continuum) such that $A + A \\subseteq \\mathbb{R} \\setminus S$?",
     "text": "If S ⊆ ℝ is sum-free (no a + b = c with a,b,c ∈ S), must there exist A ⊆ ℝ\\S with |A| = 𝔠 and A+A ⊆ ℝ\\S? SOLVED for Sidon sets (Dillies-AlphaProof). General case OPEN.",
-    "proofStrategy": "The formalization defines `IsSumFreeSet` (no $a + b \\in S$ for $a, b \\in S$), `IsSidonReal` (distinct ordered sums), and `realSumset` (pairwise sums). The main conjecture `ErdosProblem949` uses `Cardinal.mk` and `Cardinal.continuum`. The Sidon variant is axiomatized as `sidon_variant_solved`. Concrete examples include: odd numbers are sum-free (proved by parity), $\\{1, 2, 4\\}$ is Sidon but not sum-free (proved by case analysis correcting an unsound axiom), and basic Sidon properties (empty set, singletons). The general case is recorded as an axiom. The file uses 0 sorry statements.",
+    "proofStrategy": "The formalization defines `IsSumFreeSet` (no $a + b \\in S$ for $a, b \\in S$), `IsSidonReal` (distinct ordered sums), and `realSumset` (pairwise sums). The main conjecture `ErdosProblem949` uses `Cardinal.mk` and `Cardinal.continuum`. The Sidon variant is axiomatized as `sidon_variant_solved` (deep result by Dillies/AlphaProof). Concrete examples include: odd numbers are sum-free (proved by parity), $\\{1, 2, 4\\}$ is Sidon but not sum-free (proved by case analysis correcting an unsound axiom), and basic Sidon properties (empty set, singletons). The general case is documented as open (no axiom asserting it). The file uses 0 sorry statements.",
     "keyInsights": [
       "Sum-free means $(S+S) \\cap S = \\emptyset$; the question asks whether the complement $S^c$ inherits enough additive structure for a continuum-sized sumset-avoiding subset",
       "For Sidon sets, the sum function's injectivity ($a+b = c+d \\implies (a,b) = (c,d)$) is the key property enabling the proof; this fails for general sum-free sets",
@@ -91,13 +91,13 @@
     {
       "id": "sec-949-general",
       "title": "General Sum-Free Case (Open)",
-      "startLine": 113,
-      "endLine": 120,
-      "summary": "Axiom recording the full conjecture for arbitrary sum-free sets. Notes that the Sidon technique (injectivity) does not generalize to the denser sum-free setting."
+      "startLine": 155,
+      "endLine": 158,
+      "summary": "Documents that the general sum-free case remains open. The Sidon technique (injectivity of the sum map) does not generalize to the denser sum-free setting."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #949 asks whether sum-free subsets of $\\mathbb{R}$ always leave a continuum-sized sumset-avoiding subset in their complement. The Sidon variant is solved (Dillies-AlphaProof) via a cardinality dichotomy: Zorn's lemma for $|S| < \\mathfrak{c}$ and a shift construction for $|S| = \\mathfrak{c}$. The general sum-free case remains open. The formalization includes proved examples (odd numbers, Sidon properties), a corrected axiom (Sidon $\\not\\Rightarrow$ sum-free), and 0 sorry statements.",
+    "summary": "Erdős Problem #949 asks whether sum-free subsets of $\\mathbb{R}$ always leave a continuum-sized sumset-avoiding subset in their complement. The Sidon variant is solved (Dillies-AlphaProof) via a cardinality dichotomy: Zorn's lemma for $|S| < \\mathfrak{c}$ and a shift construction for $|S| = \\mathfrak{c}$. The general sum-free case remains open and is not asserted as an axiom. The formalization includes proved examples (odd numbers, Sidon properties), a corrected axiom (Sidon $\\not\\Rightarrow$ sum-free), and 0 sorry statements.",
     "implications": "Resolution would connect the additive structure of sum-free sets to set-theoretic cardinal arithmetic, bridging finite additive combinatorics (Schur, Ramsey) with infinite set theory (Zorn, continuum). The gap between the Sidon and sum-free cases highlights a fundamental question: does the injectivity of the sum map (Sidon property) capture all the additive structure needed, or do denser sum-free sets require entirely different techniques? Progress could come from understanding the additive energy of sum-free sets or from descriptive set-theoretic methods.",
     "openQuestions": [
       "Does the result hold for all sum-free $S \\subseteq \\mathbb{R}$, not just Sidon sets? The density gap ($\\sqrt{n}$ vs. $n/2$ in $[n]$) is the main obstacle.",
@@ -120,8 +120,8 @@
       "Set"
     ],
     "namespace": null,
-    "lineCount": 162,
-    "axiomCount": 2,
+    "lineCount": 158,
+    "axiomCount": 1,
     "theoremCount": 14,
     "definitionCount": 4
   },


### PR DESCRIPTION
## Summary
Two research results on this branch:

### erdos-949: Remove unsound axiom (2→1 axioms)
- Removed `erdos_949_open` axiom which falsely asserted the open conjecture as true
- Remaining `sidon_variant_solved` is a legitimate deep result

### erdos-411: Prove Cambie ratio-3 (4→3 axioms)
- Proved `cambie_ratio3`: g_{k+4}(738) = 3·g_k(738) for all k ≥ 0
- New `totientStep_triple` lemma: g(3m) = 3·g(m) when 3|m (from Mathlib)
- Strong induction combining 3-divisibility + ratio simultaneously
- Base cases by `native_decide`, inductive step by structural propagation

## Files Modified
- `proofs/Proofs/Erdos949Problem.lean` — removed unsound axiom
- `src/data/proofs/erdos-949/meta.json` — axiomCount 2→1
- `proofs/Proofs/Erdos411Problem.lean` — proved cambie_ratio3
- `src/data/proofs/erdos-411/meta.json` — axiomCount 4→3

## Status
**Axiom delta**: erdos-949: 2→1, erdos-411: 4→3

Generated by researcher-5