### PR TITLE
Fix: correct axiomCount and lineCount for yang-mills-2d-oq-01

### DIFF
--- a/src/data/proofs/yang-mills-2d-oq-01/meta.json
+++ b/src/data/proofs/yang-mills-2d-oq-01/meta.json
@@ -12,7 +12,7 @@
     "badge": "verified",
     "sorries": 0,
     "dateAdded": "2026-03-30",
-    "axiomCount": 10,
-    "lineCount": 147
+    "axiomCount": 0,
+    "lineCount": 308
   }
 }


### PR DESCRIPTION
## Fix

Correct stale `axiomCount` (10 → 0) and `lineCount` (147 → 308) in yang-mills-2d-oq-01 meta.json.

## Evidence

**Before**: `axiomCount: 10`, `lineCount: 147`
**After**: `axiomCount: 0`, `lineCount: 308`

Verified: `grep -cE "^axiom " → 0`, no structure-encoded assumptions, `wc -l → 308`.

Closes #8249

---
Automated fix by lean-mechanic agent.