### PR TITLE
Fix: correct axiomCount, sorries, lineCount for motivic-flag-maps-oq-02

### DIFF
--- a/src/data/proofs/motivic-flag-maps-oq-02/meta.json
+++ b/src/data/proofs/motivic-flag-maps-oq-02/meta.json
@@ -21,7 +21,7 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "mathlibDependencies": [
       {
         "theorem": "mul_geom_sum",
@@ -52,9 +52,9 @@
       "Gaussian binomial identity statement: [Gr(d,n)] · [d]! · [n-d]! = [n]!"
     ],
     "dateAdded": "2026-03-30",
-    "axiomCount": 3,
-    "lineCount": 340,
-    "assumptions": "3 axiom(s): motivicClassPartialFlagMaps, partial_flag_extension (conjectured), grassmannian_maps_degree_1 (known but deep). 3 sorry(s): grassmannianClass_duality, grassmannianClass_lines, gaussian_binomial_identity (algebraic identities needing induction).",
+    "axiomCount": 2,
+    "lineCount": 465,
+    "assumptions": "2 axiom(s): motivicClassPartialFlagMaps, partial_flag_extension (conjectured). 2 sorry(s): grassmannianClass_duality, gaussian_binomial_identity (algebraic identities needing induction).",
     "mathlib_version": "4.26.0"
   },
   "sections": [


### PR DESCRIPTION
## Fix

Correct stale metadata in motivic-flag-maps-oq-02 meta.json to match current Lean source.

## Evidence

**Before**: `axiomCount: 3`, `sorries: 3`, `lineCount: 340`, assumptions text lists non-existent `grassmannian_maps_degree_1`
**After**: `axiomCount: 2`, `sorries: 2`, `lineCount: 465`, assumptions text matches actual axioms and sorries

Verified:
- `grep -cE "^axiom " → 2` (motivicClassPartialFlagMaps, partial_flag_extension)
- `grep -c "sorry" → 2` (grassmannianClass_duality, gaussian_binomial_identity)
- `wc -l → 465`
- No structure-encoded assumptions (K0Var/PartialFlag have only data fields)

Closes #8248

---
Automated fix by lean-mechanic agent.