### PR TITLE
fix: add missing required fields to proof meta.json files

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-03/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-03/meta.json
@@ -1,50 +1,51 @@
 {
-    "id": "abel-ruffini-oq-04-oq-03",
-    "title": "Galois's Solvability Criterion",
-    "slug": "abel-ruffini-oq-04-oq-03",
-    "description": "A root of an irreducible polynomial is solvable by radicals iff its Galois group is solvable. Forward direction proved (Mathlib), reverse axiomatized (needs Kummer theory).",
-    "meta": {
-        "author": "Galois",
-        "status": "axiomatized",
-        "proofRepoPath": "Proofs/AbelRuffiniOQ04OQ03.lean",
-        "tags": [
-            "algebra",
-            "galois theory",
-            "solvability",
-            "radicals"
-        ],
-        "badge": "axiom",
-        "sorries": 0,
-        "axiomCount": 1,
-        "lineCount": 165,
-        "assumptions": "1 axiom: solvableGal_implies_solvableByRad (reverse direction, requires Kummer theory for cyclic extensions not yet in Mathlib).",
-        "mathlib_version": "4.26.0"
+  "id": "abel-ruffini-oq-04-oq-03",
+  "title": "Galois's Solvability Criterion",
+  "slug": "abel-ruffini-oq-04-oq-03",
+  "description": "A root of an irreducible polynomial is solvable by radicals iff its Galois group is solvable. Forward direction proved (Mathlib), reverse axiomatized (needs Kummer theory).",
+  "meta": {
+    "author": "Galois",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/AbelRuffiniOQ04OQ03.lean",
+    "tags": [
+      "algebra",
+      "galois theory",
+      "solvability",
+      "radicals"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 1,
+    "lineCount": 165,
+    "assumptions": "1 axiom: solvableGal_implies_solvableByRad (reverse direction, requires Kummer theory for cyclic extensions not yet in Mathlib).",
+    "mathlib_version": "4.26.0"
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.FieldTheory.AbelRuffini",
+      "Mathlib.GroupTheory.Solvable",
+      "Mathlib.FieldTheory.Galois.Basic"
+    ],
+    "opens": [
+      "Polynomial"
+    ],
+    "namespace": "GaloisCriterion",
+    "lineCount": 165,
+    "axiomCount": 1,
+    "theoremCount": 7,
+    "definitionCount": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "extends",
+      "description": "States the full iff version of the Galois-radical bridge"
     },
-    "leanFile": {
-        "imports": [
-            "Mathlib.FieldTheory.AbelRuffini",
-            "Mathlib.GroupTheory.Solvable",
-            "Mathlib.FieldTheory.Galois.Basic"
-        ],
-        "opens": [
-            "Polynomial"
-        ],
-        "namespace": "GaloisCriterion",
-        "lineCount": 165,
-        "axiomCount": 1,
-        "theoremCount": 7,
-        "definitionCount": 0
-    },
-    "crossReferences": [
-        {
-            "targetId": "abel-ruffini",
-            "relationship": "extends",
-            "description": "States the full iff version of the Galois-radical bridge"
-        },
-        {
-            "targetId": "abel-ruffini-oq-04",
-            "relationship": "extends",
-            "description": "Extends the A5 simplicity chain with the converse direction"
-        }
-    ]
+    {
+      "targetId": "abel-ruffini-oq-04",
+      "relationship": "extends",
+      "description": "Extends the A5 simplicity chain with the converse direction"
+    }
+  ],
+  "sections": []
 }

--- a/src/data/proofs/amgm-inequality-oq-03-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-03/meta.json
@@ -1,18 +1,24 @@
 {
   "id": "amgm-inequality-oq-03-oq-03",
-  "title": "Power Mean Extreme Cases: Limits as r → ±∞",
+  "title": "Power Mean Extreme Cases: Limits as r \u2192 \u00b1\u221e",
   "slug": "amgm-inequality-oq-03-oq-03",
-  "description": "Formalizes the extreme cases of power means: M_r → max as r → +∞ and M_r → min as r → -∞. Also axiomatizes monotonicity of power means in r.",
+  "description": "Formalizes the extreme cases of power means: M_r \u2192 max as r \u2192 +\u221e and M_r \u2192 min as r \u2192 -\u221e. Also axiomatizes monotonicity of power means in r.",
   "meta": {
-    "author": "Hardy-Littlewood-Pólya (1934)",
+    "author": "Hardy-Littlewood-P\u00f3lya (1934)",
     "date": "1934",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/AmgmInequalityOQ03OQ03.lean",
-    "tags": ["inequalities", "power-means", "analysis", "limits"],
+    "tags": [
+      "inequalities",
+      "power-means",
+      "analysis",
+      "limits"
+    ],
     "badge": "axiom",
     "sorries": 2,
     "dateAdded": "2026-03-30",
     "axiomCount": 3,
     "lineCount": 90
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/angle-trisection-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-03/meta.json
@@ -101,27 +101,32 @@
     {
       "title": "Power-of-2 Characterization",
       "description": "A positive number divides some power of 2 iff it is a power of 2",
-      "summary": "Power-of-2 Characterization"
+      "summary": "Power-of-2 Characterization",
+      "id": "power-of-2-characterization"
     },
     {
       "title": "Prime Factor Characterization",
       "description": "A number is a power of 2 iff all its prime factors equal 2",
-      "summary": "Prime Factor Characterization"
+      "summary": "Prime Factor Characterization",
+      "id": "prime-factor-characterization"
     },
     {
       "title": "Decidability of Constructibility",
       "description": "Decidable instances for IsConstructible and related predicates",
-      "summary": "Decidability of Constructibility"
+      "summary": "Decidability of Constructibility",
+      "id": "decidability-of-constructibili"
     },
     {
       "title": "N-gon Constructibility",
       "description": "Decidability of regular polygon constructibility via Gauss-Wantzel",
-      "summary": "N-gon Constructibility"
+      "summary": "N-gon Constructibility",
+      "id": "n-gon-constructibility"
     },
     {
       "title": "Examples and Summary",
       "description": "Concrete examples and complexity analysis",
-      "summary": "Examples and Summary"
+      "summary": "Examples and Summary",
+      "id": "examples-and-summary"
     }
   ],
   "references": [

--- a/src/data/proofs/area-of-circle-oq-03-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-03/meta.json
@@ -23,14 +23,14 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Archimedes used the method of exhaustion to compute the area of a circle (πr²) and a parabolic segment (4/3 of the inscribed triangle). The method was later generalized by Cavalieri and others, eventually leading to integral calculus. The question of whether the same technique applies to other curves is fundamental to the history of analysis.",
+    "historicalContext": "Archimedes used the method of exhaustion to compute the area of a circle (\u03c0r\u00b2) and a parabolic segment (4/3 of the inscribed triangle). The method was later generalized by Cavalieri and others, eventually leading to integral calculus. The question of whether the same technique applies to other curves is fundamental to the history of analysis.",
     "problemStatement": "Can the method of exhaustion be generalized to other curves (ellipses, parabolas)?",
     "text": "Proves that the method of exhaustion generalizes to ellipses via affine scaling and to parabolic segments via Archimedes' geometric series.",
-    "proofStrategy": "For ellipses: the affine scaling (x,y) → (ax,by) transforms the unit circle to an ellipse, multiplying area by ab. For parabolas: Archimedes' key insight that each exhaustion step fills 1/4 of the remaining area, giving a geometric series summing to 4/3.",
+    "proofStrategy": "For ellipses: the affine scaling (x,y) \u2192 (ax,by) transforms the unit circle to an ellipse, multiplying area by ab. For parabolas: Archimedes' key insight that each exhaustion step fills 1/4 of the remaining area, giving a geometric series summing to 4/3.",
     "keyInsights": [
-      "Ellipse area = ab · circle area via Jacobian of affine scaling",
+      "Ellipse area = ab \u00b7 circle area via Jacobian of affine scaling",
       "Parabolic area follows from geometric series 1 + 1/4 + 1/16 + ... = 4/3",
-      "The general exhaustion principle: geometric convergence C·r^n → 0 for 0 < r < 1",
+      "The general exhaustion principle: geometric convergence C\u00b7r^n \u2192 0 for 0 < r < 1",
       "Archimedes' parabolic result predates integral calculus by ~2000 years"
     ],
     "prerequisites": [
@@ -81,5 +81,6 @@
       "relationship": "related",
       "description": "The original circle area proof that this generalizes"
     }
-  ]
+  ],
+  "sections": []
 }

--- a/src/data/proofs/bezout-identity-oq-03-oq-04/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-04/meta.json
@@ -1,38 +1,39 @@
 {
-    "id": "bezout-identity-oq-03-oq-04",
-    "title": "Efficient Verified CRT via Direct Bézout",
-    "slug": "bezout-identity-oq-03-oq-04",
-    "description": "Efficient CRT computation using direct Bézout coefficients without modular reduction. Proves correctness and uniqueness. 8 theorems, 0 axioms.",
-    "meta": {
-        "author": "Lean Genius",
-        "status": "verified",
-        "proofRepoPath": "Proofs/BezoutIdentityOQ03OQ04.lean",
-        "tags": [
-            "number theory",
-            "CRT",
-            "Bézout",
-            "algorithms"
-        ],
-        "badge": "verified",
-        "sorries": 0,
-        "axiomCount": 0,
-        "lineCount": 142,
-        "assumptions": "None.",
-        "theoremCount": 8,
-        "mathlib_version": "4.26.0"
-    },
-    "leanFile": {
-        "namespace": "BezoutIdentityOQ03OQ04",
-        "lineCount": 142,
-        "axiomCount": 0,
-        "theoremCount": 8,
-        "definitionCount": 1
-    },
-    "crossReferences": [
-        {
-            "targetId": "bezout-identity-oq-03",
-            "relationship": "extends",
-            "description": "Efficient CRT implementation"
-        }
-    ]
+  "id": "bezout-identity-oq-03-oq-04",
+  "title": "Efficient Verified CRT via Direct B\u00e9zout",
+  "slug": "bezout-identity-oq-03-oq-04",
+  "description": "Efficient CRT computation using direct B\u00e9zout coefficients without modular reduction. Proves correctness and uniqueness. 8 theorems, 0 axioms.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BezoutIdentityOQ03OQ04.lean",
+    "tags": [
+      "number theory",
+      "CRT",
+      "B\u00e9zout",
+      "algorithms"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 142,
+    "assumptions": "None.",
+    "theoremCount": 8,
+    "mathlib_version": "4.26.0"
+  },
+  "leanFile": {
+    "namespace": "BezoutIdentityOQ03OQ04",
+    "lineCount": 142,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 1
+  },
+  "crossReferences": [
+    {
+      "targetId": "bezout-identity-oq-03",
+      "relationship": "extends",
+      "description": "Efficient CRT implementation"
+    }
+  ],
+  "sections": []
 }

--- a/src/data/proofs/binary-gcd/meta.json
+++ b/src/data/proofs/binary-gcd/meta.json
@@ -7,15 +7,20 @@
     "author": "Josef Stein (1967), formalized in Lean 4",
     "date": "1967",
     "status": "verified",
-    "tags": ["algorithms", "number-theory", "gcd", "bit-manipulation"],
+    "tags": [
+      "algorithms",
+      "number-theory",
+      "gcd",
+      "bit-manipulation"
+    ],
     "proofRepoPath": "Proofs/GcdAlgorithmOQ02.lean",
     "badge": "original",
     "sorries": 0,
     "originalContributions": [
       "binaryGcd: recursive implementation of Stein's algorithm in Lean 4",
-      "gcd_sub_right: gcd(a-b, b) = gcd(a, b) for b ≤ a",
+      "gcd_sub_right: gcd(a-b, b) = gcd(a, b) for b \u2264 a",
       "gcd_mul_two_left: gcd(2a, b) = gcd(a, b) when b is odd",
-      "gcd_two_mul: gcd(2a, 2b) = 2·gcd(a, b)",
+      "gcd_two_mul: gcd(2a, 2b) = 2\u00b7gcd(a, b)",
       "gcd_odd_sub_half: gcd((a-b)/2, b) = gcd(a, b) for both odd, a > b"
     ],
     "dateAdded": "2026-03-30",
@@ -29,11 +34,14 @@
     "text": "Binary GCD (Stein's algorithm) uses subtraction and division by 2 instead of Euclidean division.",
     "proofStrategy": "Define the algorithm by well-founded recursion on a+b. Prove three key lemmas (even factor extraction, coprime reduction, odd subtraction) and combine for correctness.",
     "keyInsights": [
-      "Three key lemmas: gcd(2a,2b)=2·gcd(a,b), gcd(2a,b)=gcd(a,b) for odd b, gcd(a-b,b)=gcd(a,b)",
+      "Three key lemmas: gcd(2a,2b)=2\u00b7gcd(a,b), gcd(2a,b)=gcd(a,b) for odd b, gcd(a-b,b)=gcd(a,b)",
       "When both arguments are odd, their difference is even, enabling the halving step",
       "Termination: a+b strictly decreases in every recursive call"
     ],
-    "prerequisites": ["GCD properties", "Basic number theory"]
+    "prerequisites": [
+      "GCD properties",
+      "Basic number theory"
+    ]
   },
   "crossReferences": [
     {
@@ -50,7 +58,10 @@
     ]
   },
   "leanFile": {
-    "imports": ["Mathlib.Data.Nat.GCD.Basic", "Mathlib.Tactic"],
+    "imports": [
+      "Mathlib.Data.Nat.GCD.Basic",
+      "Mathlib.Tactic"
+    ],
     "namespace": "BinaryGcd",
     "lineCount": 177,
     "axiomCount": 0,
@@ -68,5 +79,6 @@
       "type": "core",
       "description": "Correctness: binaryGcd a b = Nat.gcd a b"
     }
-  ]
+  ],
+  "sections": []
 }

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-02/meta.json
@@ -67,5 +67,6 @@
       "relationship": "related",
       "description": "The classical Z/2 Borsuk-Ulam that this generalizes"
     }
-  ]
+  ],
+  "sections": []
 }

--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-03/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-03/meta.json
@@ -8,11 +8,17 @@
     "date": "1941",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/BrouwerFixedPointOQ04OQ03.lean",
-    "tags": ["topology", "fixed-point-theory", "game-theory", "functional-analysis"],
+    "tags": [
+      "topology",
+      "fixed-point-theory",
+      "game-theory",
+      "functional-analysis"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 3,
     "lineCount": 165
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/cantors-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-01-oq-01/meta.json
@@ -1,70 +1,71 @@
 {
-    "id": "cantors-theorem-oq-01-oq-01",
-    "title": "Is |P(R)| = aleph_2? Complete Characterization",
-    "slug": "cantors-theorem-oq-01-oq-01",
-    "description": "Shows |P(R)| = aleph_2 is equivalent to CH + GCH at the continuum level. Proves the implication in both directions and establishes unconditional bounds.",
-    "meta": {
-        "author": "Cantor / Gödel / Cohen / Easton",
-        "status": "verified",
-        "proofRepoPath": "Proofs/CantorsTheoremOQ01OQ01.lean",
-        "tags": [
-            "set theory",
-            "cardinal arithmetic",
-            "continuum hypothesis",
-            "independence"
-        ],
-        "badge": "mathlib",
-        "sorries": 0,
-        "axiomCount": 0,
-        "lineCount": 171,
-        "assumptions": "0 axioms, 0 sorries. Core cardinal facts via Mathlib (Cardinal.cantor, mk_set, aleph_one_le_continuum) and parent file CantorsTheoremOQ01.lean (CH/GCH definitions, conditional results).",
-        "mathlib_version": "4.26.0"
-    },
-    "overview": {
-        "historicalContext": "The question whether |P(R)| = aleph_2 packages two independent set-theoretic axioms (CH and GCH at the continuum level) into a single cardinality equation. Gödel (1938) showed CH is consistent with ZFC; Cohen (1963) showed its negation is also consistent. Easton (1970) showed that for regular cardinals, the power function can take almost any value.",
-        "problemStatement": "Is |P(R)| = aleph_2? This is independent of ZFC: it holds iff both CH (continuum = aleph_1) and GCH at continuum (2^continuum = successor of continuum) hold simultaneously.",
-        "text": "Complete characterization of |P(R)| = aleph_2 as equivalent to CH + GCH at the continuum level.",
-        "proofStrategy": "Forward direction: if |P(R)| = aleph_2, then since continuum < aleph_2 = succ(aleph_1) (Cantor), we get continuum <= aleph_1, combined with aleph_1 <= continuum gives CH. GCH follows similarly. Reverse uses the parent file's conditional theorem.",
-        "keyInsights": [
-            "|P(R)| = aleph_2 implies CH (not just consistent with it)",
-            "The proposition packages exactly two independent axioms",
-            "The unconditional lower bound aleph_1 < |P(R)| holds in ZFC"
-        ],
-        "prerequisites": [
-            "Cardinal arithmetic",
-            "Beth and aleph hierarchies",
-            "Successor cardinals"
-        ]
-    },
-    "leanFile": {
-        "imports": [
-            "Proofs.CantorsTheoremOQ01",
-            "Mathlib.SetTheory.Cardinal.Basic",
-            "Mathlib.SetTheory.Cardinal.Ordinal",
-            "Mathlib.SetTheory.Cardinal.Continuum",
-            "Mathlib.SetTheory.Cardinal.Cofinality",
-            "Mathlib.Order.SuccPred.Basic",
-            "Mathlib.Tactic"
-        ],
-        "opens": [
-            "Cardinal"
-        ],
-        "namespace": "CantorsTheoremOQ01OQ01",
-        "lineCount": 171,
-        "axiomCount": 0,
-        "theoremCount": 11,
-        "definitionCount": 2
-    },
-    "crossReferences": [
-        {
-            "targetId": "cantors-theorem-oq-01",
-            "relationship": "extends",
-            "description": "Extends the parent formalization with equivalence characterization"
-        },
-        {
-            "targetId": "cantors-theorem",
-            "relationship": "related",
-            "description": "Based on Cantor's theorem |X| < |P(X)|"
-        }
+  "id": "cantors-theorem-oq-01-oq-01",
+  "title": "Is |P(R)| = aleph_2? Complete Characterization",
+  "slug": "cantors-theorem-oq-01-oq-01",
+  "description": "Shows |P(R)| = aleph_2 is equivalent to CH + GCH at the continuum level. Proves the implication in both directions and establishes unconditional bounds.",
+  "meta": {
+    "author": "Cantor / G\u00f6del / Cohen / Easton",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CantorsTheoremOQ01OQ01.lean",
+    "tags": [
+      "set theory",
+      "cardinal arithmetic",
+      "continuum hypothesis",
+      "independence"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 171,
+    "assumptions": "0 axioms, 0 sorries. Core cardinal facts via Mathlib (Cardinal.cantor, mk_set, aleph_one_le_continuum) and parent file CantorsTheoremOQ01.lean (CH/GCH definitions, conditional results).",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The question whether |P(R)| = aleph_2 packages two independent set-theoretic axioms (CH and GCH at the continuum level) into a single cardinality equation. G\u00f6del (1938) showed CH is consistent with ZFC; Cohen (1963) showed its negation is also consistent. Easton (1970) showed that for regular cardinals, the power function can take almost any value.",
+    "problemStatement": "Is |P(R)| = aleph_2? This is independent of ZFC: it holds iff both CH (continuum = aleph_1) and GCH at continuum (2^continuum = successor of continuum) hold simultaneously.",
+    "text": "Complete characterization of |P(R)| = aleph_2 as equivalent to CH + GCH at the continuum level.",
+    "proofStrategy": "Forward direction: if |P(R)| = aleph_2, then since continuum < aleph_2 = succ(aleph_1) (Cantor), we get continuum <= aleph_1, combined with aleph_1 <= continuum gives CH. GCH follows similarly. Reverse uses the parent file's conditional theorem.",
+    "keyInsights": [
+      "|P(R)| = aleph_2 implies CH (not just consistent with it)",
+      "The proposition packages exactly two independent axioms",
+      "The unconditional lower bound aleph_1 < |P(R)| holds in ZFC"
+    ],
+    "prerequisites": [
+      "Cardinal arithmetic",
+      "Beth and aleph hierarchies",
+      "Successor cardinals"
     ]
+  },
+  "leanFile": {
+    "imports": [
+      "Proofs.CantorsTheoremOQ01",
+      "Mathlib.SetTheory.Cardinal.Basic",
+      "Mathlib.SetTheory.Cardinal.Ordinal",
+      "Mathlib.SetTheory.Cardinal.Continuum",
+      "Mathlib.SetTheory.Cardinal.Cofinality",
+      "Mathlib.Order.SuccPred.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Cardinal"
+    ],
+    "namespace": "CantorsTheoremOQ01OQ01",
+    "lineCount": 171,
+    "axiomCount": 0,
+    "theoremCount": 11,
+    "definitionCount": 2
+  },
+  "crossReferences": [
+    {
+      "targetId": "cantors-theorem-oq-01",
+      "relationship": "extends",
+      "description": "Extends the parent formalization with equivalence characterization"
+    },
+    {
+      "targetId": "cantors-theorem",
+      "relationship": "related",
+      "description": "Based on Cantor's theorem |X| < |P(X)|"
+    }
+  ],
+  "sections": []
 }

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "cauchy-schwarz-oq-01-oq-03",
   "title": "Heisenberg Uncertainty from Complex Cauchy-Schwarz",
   "slug": "cauchy-schwarz-oq-01-oq-03",
-  "description": "Derives the Heisenberg uncertainty principle σ_x·σ_p ≥ ℏ/2 from the complex Cauchy-Schwarz inequality. Pure algebraic derivation in abstract inner product spaces.",
+  "description": "Derives the Heisenberg uncertainty principle \u03c3_x\u00b7\u03c3_p \u2265 \u210f/2 from the complex Cauchy-Schwarz inequality. Pure algebraic derivation in abstract inner product spaces.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -25,11 +25,12 @@
   "overview": {
     "problemStatement": "Can the Heisenberg uncertainty principle be derived from the complex Cauchy-Schwarz inequality?",
     "keyInsights": [
-      "Cauchy-Schwarz: |⟨f,g⟩|² ≤ ‖f‖²·‖g‖²",
-      "Im bound: (Im⟨f,g⟩)² ≤ |⟨f,g⟩|²",
-      "Commutator substitution: Im⟨Δx·ψ, Δp·ψ⟩ = ℏ/2",
-      "Pure algebraic derivation — works in any complex inner product space"
-    ]
+      "Cauchy-Schwarz: |\u27e8f,g\u27e9|\u00b2 \u2264 \u2016f\u2016\u00b2\u00b7\u2016g\u2016\u00b2",
+      "Im bound: (Im\u27e8f,g\u27e9)\u00b2 \u2264 |\u27e8f,g\u27e9|\u00b2",
+      "Commutator substitution: Im\u27e8\u0394x\u00b7\u03c8, \u0394p\u00b7\u03c8\u27e9 = \u210f/2",
+      "Pure algebraic derivation \u2014 works in any complex inner product space"
+    ],
+    "proofStrategy": ""
   },
   "conclusion": {
     "summary": "YES. The uncertainty principle is a direct consequence of Cauchy-Schwarz applied to centered observables, plus the imaginary part bound.",
@@ -48,5 +49,6 @@
       "relationship": "extends",
       "description": "Derives uncertainty principle from complex Cauchy-Schwarz"
     }
-  ]
+  ],
+  "sections": []
 }

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-03/meta.json
@@ -33,5 +33,6 @@
       "targetId": "cayley-hamilton-minpoly-oq-02",
       "relationship": "extends"
     }
-  ]
+  ],
+  "sections": []
 }

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "cayley-hamilton-minpoly-oq-05-oq-01-oq-04",
-  "title": "Nonderogatory → Cyclic Vector: The General Case (All Fields)",
+  "title": "Nonderogatory \u2192 Cyclic Vector: The General Case (All Fields)",
   "slug": "cayley-hamilton-minpoly-oq-05-oq-01-oq-04",
-  "description": "The nonderogatory → cyclic vector theorem holds for ALL fields, including finite fields F_q with q ≤ n where union avoidance fails. Demonstrates F_2 counterexample and module-theoretic approach.",
+  "description": "The nonderogatory \u2192 cyclic vector theorem holds for ALL fields, including finite fields F_q with q \u2264 n where union avoidance fails. Demonstrates F_2 counterexample and module-theoretic approach.",
   "meta": {
     "author": "Classical linear algebra (invariant factor decomposition)",
     "sourceUrl": "",
@@ -25,14 +25,15 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "text": "The nonderogatory → cyclic vector theorem holds for ALL fields, including finite fields where union avoidance fails.",
-    "proofStrategy": "Module-theoretic: K^n as K[X]-module, invariant factor decomposition, nonderogatory forces single factor."
+    "text": "The nonderogatory \u2192 cyclic vector theorem holds for ALL fields, including finite fields where union avoidance fails.",
+    "proofStrategy": "Module-theoretic: K^n as K[X]-module, invariant factor decomposition, nonderogatory forces single factor.",
+    "keyInsights": []
   },
   "sections": [
     {
       "id": "f2-counterexample",
       "title": "F_2 Counterexample to Union Avoidance",
-      "summary": "Shows F_2^2 is covered by 3 proper subspaces, demonstrating that the union avoidance approach fails when |K| ≤ n.",
+      "summary": "Shows F_2^2 is covered by 3 proper subspaces, demonstrating that the union avoidance approach fails when |K| \u2264 n.",
       "startLine": 56,
       "endLine": 77,
       "mathContext": "Union avoidance failure over small finite fields."
@@ -40,7 +41,7 @@
     {
       "id": "annihilator",
       "title": "Annihilator Theory",
-      "summary": "Defines annihilator polynomial and states cyclic ↔ ann = minpoly equivalence.",
+      "summary": "Defines annihilator polynomial and states cyclic \u2194 ann = minpoly equivalence.",
       "startLine": 79,
       "endLine": 107,
       "mathContext": "Annihilator polynomials and cyclic vector characterization."
@@ -63,12 +64,12 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization demonstrates that the nonderogatory → cyclic vector theorem holds for all fields, not just infinite or large finite fields. While union avoidance fails over small fields (F_2 counterexample), the algebraic structure (invariant factor decomposition) forces the result. The GCD annihilation lemma is proved sorry-free. The main theorem requires the structure theorem for f.g. modules over PIDs, which is not yet in Mathlib.",
+    "summary": "This formalization demonstrates that the nonderogatory \u2192 cyclic vector theorem holds for all fields, not just infinite or large finite fields. While union avoidance fails over small fields (F_2 counterexample), the algebraic structure (invariant factor decomposition) forces the result. The GCD annihilation lemma is proved sorry-free. The main theorem requires the structure theorem for f.g. modules over PIDs, which is not yet in Mathlib.",
     "openQuestions": [
       "When will the structure theorem for f.g. modules over PIDs be available in Mathlib?",
       "Can the theorem be proved without the full structure theorem, using only rational canonical form?"
     ],
-    "implications": "This formalization demonstrates that the nonderogatory → cyclic vector theorem holds for all fields, not just infinite or large finite fields. While union avoidance fails over small fields (F_2 counterexample), the algebraic structure (invariant factor decomposition) forces the result. The GCD annihilation lemma is proved sorry-free. The main theorem requires the structure theorem for f.g. modules over PIDs, which is not yet in Mathlib."
+    "implications": "This formalization demonstrates that the nonderogatory \u2192 cyclic vector theorem holds for all fields, not just infinite or large finite fields. While union avoidance fails over small fields (F_2 counterexample), the algebraic structure (invariant factor decomposition) forces the result. The GCD annihilation lemma is proved sorry-free. The main theorem requires the structure theorem for f.g. modules over PIDs, which is not yet in Mathlib."
   },
   "leanFile": {
     "imports": [

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-03/meta.json
@@ -1,42 +1,43 @@
 {
-    "id": "central-limit-theorem-oq-01-oq-03",
-    "title": "Free Probability and Stable Distributions",
-    "slug": "central-limit-theorem-oq-01-oq-03",
-    "description": "Survey of stable distributions in free probability theory. Defines NCP spaces, free independence, stability indices. Assesses ~3900 lines needed for full formalization.",
-    "meta": {
-        "author": "Lean Genius",
-        "status": "verified",
-        "proofRepoPath": "Proofs/CentralLimitTheoremOQ01OQ03.lean",
-        "tags": [
-            "probability",
-            "free probability",
-            "stable distributions",
-            "non-commutative"
-        ],
-        "badge": "verified",
-        "sorries": 0,
-        "axiomCount": 0,
-        "lineCount": 146,
-        "assumptions": "None.",
-        "theoremCount": 7,
-        "mathlib_version": "4.26.0"
-    },
-    "leanFile": {
-        "imports": [
-            "Mathlib.Probability.Variance",
-            "Mathlib.Tactic"
-        ],
-        "namespace": "CentralLimitTheoremOQ01OQ03",
-        "lineCount": 146,
-        "axiomCount": 0,
-        "theoremCount": 7,
-        "definitionCount": 4
-    },
-    "crossReferences": [
-        {
-            "targetId": "central-limit-theorem-oq-01",
-            "relationship": "extends",
-            "description": "Free probability analog of CLT"
-        }
-    ]
+  "id": "central-limit-theorem-oq-01-oq-03",
+  "title": "Free Probability and Stable Distributions",
+  "slug": "central-limit-theorem-oq-01-oq-03",
+  "description": "Survey of stable distributions in free probability theory. Defines NCP spaces, free independence, stability indices. Assesses ~3900 lines needed for full formalization.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/CentralLimitTheoremOQ01OQ03.lean",
+    "tags": [
+      "probability",
+      "free probability",
+      "stable distributions",
+      "non-commutative"
+    ],
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 146,
+    "assumptions": "None.",
+    "theoremCount": 7,
+    "mathlib_version": "4.26.0"
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Probability.Variance",
+      "Mathlib.Tactic"
+    ],
+    "namespace": "CentralLimitTheoremOQ01OQ03",
+    "lineCount": 146,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 4
+  },
+  "crossReferences": [
+    {
+      "targetId": "central-limit-theorem-oq-01",
+      "relationship": "extends",
+      "description": "Free probability analog of CLT"
+    }
+  ],
+  "sections": []
 }

--- a/src/data/proofs/chinese-remainder-constructive-oq-03/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-03/meta.json
@@ -4,7 +4,7 @@
   "slug": "chinese-remainder-constructive-oq-03",
   "description": "Formalizes Residue Number Systems (RNS) for parallel arithmetic: definitions, concrete bases (primes, Mersenne numbers), dynamic range bounds, and correctness of RNS addition/multiplication.",
   "meta": {
-    "author": "Garner (1959), Szabó-Tanaka (1967)",
+    "author": "Garner (1959), Szab\u00f3-Tanaka (1967)",
     "sourceUrl": "",
     "date": "2026",
     "status": "verified",
@@ -19,12 +19,13 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 318,
-    "assumptions": "None. All theorems fully proved. mersenne_coprime_of_coprime proved via Euclidean algorithm on exponents (strong induction). primorial_growth_lower proved for k ≤ 6 (lookup table range). dynamicRange_le_pow, RNS encode/add/mul correctness all verified.",
+    "assumptions": "None. All theorems fully proved. mersenne_coprime_of_coprime proved via Euclidean algorithm on exponents (strong induction). primorial_growth_lower proved for k \u2264 6 (lookup table range). dynamicRange_le_pow, RNS encode/add/mul correctness all verified.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
     "text": "Formalizes Residue Number Systems using the Chinese Remainder Theorem for parallel computer arithmetic.",
-    "proofStrategy": "Define RNS bases, prove concrete examples, formalize encode/add/mul operations and their correctness via Nat.add_mod and Nat.mul_mod."
+    "proofStrategy": "Define RNS bases, prove concrete examples, formalize encode/add/mul operations and their correctness via Nat.add_mod and Nat.mul_mod.",
+    "keyInsights": []
   },
   "sections": [],
   "conclusion": {

--- a/src/data/proofs/collatz-structured-oq-03/meta.json
+++ b/src/data/proofs/collatz-structured-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "collatz-structured-oq-03",
   "title": "Growth Rate of Average Collatz Stopping Time",
   "slug": "collatz-structured-oq-03",
-  "description": "Formalizes the average Collatz stopping time S(N) and asks whether S(N) ~ c·log N. Defines stopping time via Nat.find, heuristic constant 1/log₂(4/3), and states the asymptotic growth question. Axiomatizes Terras density result.",
+  "description": "Formalizes the average Collatz stopping time S(N) and asks whether S(N) ~ c\u00b7log N. Defines stopping time via Nat.find, heuristic constant 1/log\u2082(4/3), and states the asymptotic growth question. Axiomatizes Terras density result.",
   "meta": {
     "status": "axiomatized",
     "proofRepoPath": "Proofs/CollatzStructuredOQ03.lean",
@@ -16,5 +16,6 @@
     "sorries": 0,
     "axiomCount": 1,
     "lineCount": 149
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/de-moivre-oq-03-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-03-oq-01/meta.json
@@ -8,11 +8,17 @@
     "date": "1707",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/DeMoivreOQ03OQ01.lean",
-    "tags": ["complex-analysis", "de-moivre", "roots-of-unity", "equidistribution"],
+    "tags": [
+      "complex-analysis",
+      "de-moivre",
+      "roots-of-unity",
+      "equidistribution"
+    ],
     "badge": "axiom",
     "sorries": 1,
     "dateAdded": "2026-03-30",
     "axiomCount": 1,
     "lineCount": 80
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/denumerability-rationals-oq-04/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-04/meta.json
@@ -1,1 +1,53 @@
-{"id":"denumerability-rationals-oq-04","title":"Constructive Denumerability of Algebraic Numbers","slug":"denumerability-rationals-oq-04","description":"Constructive proof that the algebraic numbers are countable, avoiding the full axiom of choice. Uses polynomial countability and FTA for finite roots.","meta":{"author":"Classical (Cantor-style)","date":"2026","status":"verified","proofRepoPath":"Proofs/DenumerabilityRationalsOQ04.lean","tags":["set-theory","countability","algebraic-numbers","constructive","research"],"badge":"original","sorries":0,"axiomCount":0,"lineCount":141,"assumptions":"No axioms or sorries. Fully constructive.","dateAdded":"2026-03-30","mathlib_version":"4.26.0","originalContributions":["Constructive proof of algebraic numbers countability","Finite roots per polynomial via FTA","Choiceless argument documentation"]},"conclusion":{"summary":"Algebraic numbers proved countable without full AC. 0 axioms, 0 sorries.","openQuestions":[]},"crossReferences":[{"targetId":"denumerability-rationals","relationship":"parent-problem"}],"leanFile":{"imports":["Mathlib"],"namespace":"DenumerabilityOQ04","lineCount":141,"axiomCount":0,"theoremCount":7,"definitionCount":1}}
+{
+  "id": "denumerability-rationals-oq-04",
+  "title": "Constructive Denumerability of Algebraic Numbers",
+  "slug": "denumerability-rationals-oq-04",
+  "description": "Constructive proof that the algebraic numbers are countable, avoiding the full axiom of choice. Uses polynomial countability and FTA for finite roots.",
+  "meta": {
+    "author": "Classical (Cantor-style)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DenumerabilityRationalsOQ04.lean",
+    "tags": [
+      "set-theory",
+      "countability",
+      "algebraic-numbers",
+      "constructive",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 141,
+    "assumptions": "No axioms or sorries. Fully constructive.",
+    "dateAdded": "2026-03-30",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "Constructive proof of algebraic numbers countability",
+      "Finite roots per polynomial via FTA",
+      "Choiceless argument documentation"
+    ]
+  },
+  "conclusion": {
+    "summary": "Algebraic numbers proved countable without full AC. 0 axioms, 0 sorries.",
+    "openQuestions": [],
+    "implications": ""
+  },
+  "crossReferences": [
+    {
+      "targetId": "denumerability-rationals",
+      "relationship": "parent-problem"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "DenumerabilityOQ04",
+    "lineCount": 141,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1
+  },
+  "sections": []
+}

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-01/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-01/meta.json
@@ -25,11 +25,12 @@
     "problemStatement": "Can the Descartes parity result be proved using Mathlib's existing complex root theory?",
     "text": "Proves conjugate root theorem, non-real root pairing, and parity connection. Assesses that the factoring approach is more direct.",
     "keyInsights": [
-      "Conjugate root theorem: z root → z̄ root for real polynomials",
-      "Non-real roots come in pairs → count is always even",
+      "Conjugate root theorem: z root \u2192 z\u0304 root for real polynomials",
+      "Non-real roots come in pairs \u2192 count is always even",
       "Real root count has same parity as degree",
       "Factoring approach (existing proof) is more direct for Lean than complex root theory"
-    ]
+    ],
+    "proofStrategy": "Proves conjugate root theorem, non-real root pairing, and parity connection. Assesses that the factoring approach is more direct."
   },
   "conclusion": {
     "summary": "YES, the complex root theory approach can prove parity, but the factoring approach in OQ01 is more direct. The complex approach has pedagogical value: it explains WHY (non-real roots pair up).",
@@ -53,5 +54,6 @@
       "relationship": "extends",
       "description": "Alternative proof approach for the parity result"
     }
-  ]
+  ],
+  "sections": []
 }

--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01/meta.json
@@ -8,7 +8,12 @@
     "date": "1807",
     "status": "verified",
     "proofRepoPath": "Proofs/DescartesRuleOfSignsOQ02OQ01.lean",
-    "tags": ["algebra", "polynomials", "real-algebraic-geometry", "root-isolation"],
+    "tags": [
+      "algebra",
+      "polynomials",
+      "real-algebraic-geometry",
+      "root-isolation"
+    ],
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
@@ -16,13 +21,17 @@
     "dateAdded": "2026-03-28",
     "assumptions": "0 axioms, 0 sorries. All theorems fully proved including linear_at_most_one_root, rolle_polynomial, and root_of_sign_change.",
     "relatedProblems": [
-      {"id": "descartes-rule-of-signs-oq-02", "relationship": "Proves the budan_upper_bound_axiom from OQ-02"}
+      {
+        "id": "descartes-rule-of-signs-oq-02",
+        "relationship": "Proves the budan_upper_bound_axiom from OQ-02"
+      }
     ]
   },
   "overview": {
     "problemStatement": "Prove the Budan upper bound: #roots(p, (a,b]) <= V_p(a) - V_p(b).",
     "text": "Proof scaffold for Budan's upper bound via strong induction on polynomial degree. Building blocks: constant_no_roots, linear bound, Rolle for polynomials, IVT sign change. The full proof requires sign-change accounting across derivative levels.",
-    "proofStrategy": "Strong induction on deg(p). Base: deg 0/1 trivial. Step: Rolle gives derivative roots between polynomial roots, IH on p' for sub-intervals."
+    "proofStrategy": "Strong induction on deg(p). Base: deg 0/1 trivial. Step: Rolle gives derivative roots between polynomial roots, IH on p' for sub-intervals.",
+    "keyInsights": []
   },
   "leanFile": {
     "namespace": "BudanUpperBound",
@@ -32,10 +41,27 @@
     "defCount": 1,
     "sorries": 0,
     "mainTheorems": [
-      {"name": "constant_no_roots", "type": "proved", "description": "Constant nonzero polynomials have no roots"},
-      {"name": "rolle_polynomial", "type": "proved", "description": "Rolle's theorem for polynomials"},
-      {"name": "root_of_sign_change", "type": "proved", "description": "IVT: sign change implies root"},
-      {"name": "linear_at_most_one_root", "type": "sorry", "description": "Linear polynomial has at most one root in interval"}
+      {
+        "name": "constant_no_roots",
+        "type": "proved",
+        "description": "Constant nonzero polynomials have no roots"
+      },
+      {
+        "name": "rolle_polynomial",
+        "type": "proved",
+        "description": "Rolle's theorem for polynomials"
+      },
+      {
+        "name": "root_of_sign_change",
+        "type": "proved",
+        "description": "IVT: sign change implies root"
+      },
+      {
+        "name": "linear_at_most_one_root",
+        "type": "sorry",
+        "description": "Linear polynomial has at most one root in interval"
+      }
     ]
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/dirichlets-theorem-oq-03/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "dirichlets-theorem-oq-03",
   "title": "Best Constant in Linnik's Theorem for Primes in Arithmetic Progressions",
   "slug": "dirichlets-theorem-oq-03",
-  "description": "Formalizes the Linnik constant L: the best exponent such that the least prime p ≡ a (mod q) satisfies p ≤ c·q^L. Current best: L ≤ 5 (Xylouris 2011). Conjectured: L = 1.",
+  "description": "Formalizes the Linnik constant L: the best exponent such that the least prime p \u2261 a (mod q) satisfies p \u2264 c\u00b7q^L. Current best: L \u2264 5 (Xylouris 2011). Conjectured: L = 1.",
   "meta": {
     "author": "Linnik (1944); Xylouris (2011)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Linnik%27s_theorem",
@@ -31,5 +31,6 @@
     "axiomCount": 2,
     "theoremCount": 8,
     "sorryTheorems": 3
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/divisibility-by-3-oq-03/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-03/meta.json
@@ -9,7 +9,14 @@
     "date": "Classical",
     "status": "verified",
     "proofRepoPath": "Proofs/DivisibilityBy3OQ03.lean",
-    "tags": ["number-theory", "divisibility", "digital-root", "modular-arithmetic", "algorithms", "research"],
+    "tags": [
+      "number-theory",
+      "divisibility",
+      "digital-root",
+      "modular-arithmetic",
+      "algorithms",
+      "research"
+    ],
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
@@ -21,28 +28,79 @@
     "problemStatement": "Formalize the efficient O(1) digital root computation and its properties.",
     "text": "Formalizes the digital root via modular arithmetic.",
     "keyInsights": [
-      "The key identity: 10 ≡ 1 (mod 9), so n ≡ digitSum(n) (mod 9)",
+      "The key identity: 10 \u2261 1 (mod 9), so n \u2261 digitSum(n) (mod 9)",
       "Iterating digit summation converges to n mod 9 (adjusted for 0/9)",
       "The digital root is idempotent and respects addition/multiplication mod 9"
-    ]
+    ],
+    "proofStrategy": "Formalizes the digital root via modular arithmetic."
   },
   "sections": [
-    {"id": "digit-sum", "title": "Digit Sum and Digital Root", "startLine": 1, "endLine": 40, "summary": "Defines digitSum and digitalRoot (iterative), digitalRootFormula (closed-form).", "mathContext": "digitSum: sum of base-10 digits. digitalRoot: iterate until single digit."},
-    {"id": "formula", "title": "Closed-Form Formula", "startLine": 41, "endLine": 80, "summary": "Proves formula properties: range, zero, single digits, mod 9 equivalence.", "mathContext": "$dr(n) = 1 + ((n-1) \\bmod 9)$ for $n > 0$."},
-    {"id": "properties", "title": "Algebraic Properties", "startLine": 81, "endLine": 160, "summary": "Proves idempotency, div by 3 and 9 characterizations, add/mul (sorry).", "mathContext": "$dr(dr(n)) = dr(n)$. $3|n \\iff 3|dr(n)$."},
-    {"id": "examples", "title": "Computational Examples", "startLine": 161, "endLine": 200, "summary": "Examples: dr(123)=6, dr(9999)=9, dr(10)=1, dr(18)=9.", "mathContext": "Concrete computations verify the formula."}
+    {
+      "id": "digit-sum",
+      "title": "Digit Sum and Digital Root",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "Defines digitSum and digitalRoot (iterative), digitalRootFormula (closed-form).",
+      "mathContext": "digitSum: sum of base-10 digits. digitalRoot: iterate until single digit."
+    },
+    {
+      "id": "formula",
+      "title": "Closed-Form Formula",
+      "startLine": 41,
+      "endLine": 80,
+      "summary": "Proves formula properties: range, zero, single digits, mod 9 equivalence.",
+      "mathContext": "$dr(n) = 1 + ((n-1) \\bmod 9)$ for $n > 0$."
+    },
+    {
+      "id": "properties",
+      "title": "Algebraic Properties",
+      "startLine": 81,
+      "endLine": 160,
+      "summary": "Proves idempotency, div by 3 and 9 characterizations, add/mul (sorry).",
+      "mathContext": "$dr(dr(n)) = dr(n)$. $3|n \\iff 3|dr(n)$."
+    },
+    {
+      "id": "examples",
+      "title": "Computational Examples",
+      "startLine": 161,
+      "endLine": 200,
+      "summary": "Examples: dr(123)=6, dr(9999)=9, dr(10)=1, dr(18)=9.",
+      "mathContext": "Concrete computations verify the formula."
+    }
   ],
   "mainTheorems": [
-    {"name": "digitalRoot_idempotent", "type": "core", "description": "dr(dr(n)) = dr(n)"},
-    {"name": "digitalRoot_div9", "type": "core", "description": "9 | n iff dr(n) = 9 (for n > 0)"},
-    {"name": "digitalRoot_div3", "type": "core", "description": "3 | n iff 3 | dr(n)"},
-    {"name": "congruence", "type": "supporting", "description": "n ≡ dr(n) (mod 9)"}
+    {
+      "name": "digitalRoot_idempotent",
+      "type": "core",
+      "description": "dr(dr(n)) = dr(n)"
+    },
+    {
+      "name": "digitalRoot_div9",
+      "type": "core",
+      "description": "9 | n iff dr(n) = 9 (for n > 0)"
+    },
+    {
+      "name": "digitalRoot_div3",
+      "type": "core",
+      "description": "3 | n iff 3 | dr(n)"
+    },
+    {
+      "name": "congruence",
+      "type": "supporting",
+      "description": "n \u2261 dr(n) (mod 9)"
+    }
   ],
   "crossReferences": [
-    {"targetId": "divisibility-by-3", "relationship": "extends", "description": "Extends the divisibility by 3 rule with efficient digital root computation"}
+    {
+      "targetId": "divisibility-by-3",
+      "relationship": "extends",
+      "description": "Extends the divisibility by 3 rule with efficient digital root computation"
+    }
   ],
   "leanFile": {
-    "imports": ["Mathlib"],
+    "imports": [
+      "Mathlib"
+    ],
     "namespace": "DigitalRoot",
     "lineCount": 270,
     "axiomCount": 0,

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-01-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "elementary-quadratic-reciprocity-oq-03-oq-01-oq-01",
   "title": "The Kronecker Symbol: Extending Jacobi to All Integer Moduli",
   "slug": "elementary-quadratic-reciprocity-oq-03-oq-01-oq-01",
-  "description": "Formalizes the Kronecker symbol χ(a,n) extending the Jacobi symbol to all integer moduli, including n=0, n=-1, n=2, and composite even n.",
+  "description": "Formalizes the Kronecker symbol \u03c7(a,n) extending the Jacobi symbol to all integer moduli, including n=0, n=-1, n=2, and composite even n.",
   "meta": {
     "author": "Kronecker (definition), formalized in Lean 4",
     "date": "2026",
@@ -32,12 +32,13 @@
       "Definition of Kronecker symbol for all integer moduli",
       "Two-adic factoring utility (factorTwos)",
       "Proof that Kronecker extends Jacobi for odd positive n",
-      "Proof that χ(1,n) = 1 for all n",
-      "Value characterizations at n = 0, ±1, 2"
+      "Proof that \u03c7(1,n) = 1 for all n",
+      "Value characterizations at n = 0, \u00b11, 2"
     ],
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
   },
   "leanFile": {
     "lineCount": 164
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-01-oq-02/meta.json
@@ -34,8 +34,9 @@
   "overview": {
     "historicalContext": "The Jacobi symbol extends the Legendre symbol to composite moduli and can be computed efficiently via a generalized Euclidean algorithm using quadratic reciprocity, the supplements, and modular reduction.",
     "problemStatement": "Can the verified Euclidean reduction steps from the parent proof be assembled into a certified computation function in Lean 4?",
-    "text": "We show that YES: the reduction, extraction, reciprocity, and supplement steps compose into a certified O(log² n) computation algorithm for the Jacobi symbol.",
-    "proofStrategy": "Define reusable reduction lemmas, then compose them into certified computation chains that prove specific Jacobi symbol values step by step. Define helper functions (extractTwos, recipSign) and prove the one-step reduction theorem that enables recursive certified computation."
+    "text": "We show that YES: the reduction, extraction, reciprocity, and supplement steps compose into a certified O(log\u00b2 n) computation algorithm for the Jacobi symbol.",
+    "proofStrategy": "Define reusable reduction lemmas, then compose them into certified computation chains that prove specific Jacobi symbol values step by step. Define helper functions (extractTwos, recipSign) and prove the one-step reduction theorem that enables recursive certified computation.",
+    "keyInsights": []
   },
   "leanFile": {
     "imports": [
@@ -60,5 +61,6 @@
       "relationship": "extends",
       "description": "Answers the original question about Jacobi symbol reciprocity proof completion"
     }
-  ]
+  ],
+  "sections": []
 }

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-oq-01/meta.json
@@ -74,7 +74,8 @@
   ],
   "overview": {
     "text": "Proves the Kronecker symbol is completely multiplicative in the first argument, handling the Kronecker extension to moduli 0, -1, 1, and general n separately.",
-    "proofStrategy": "Case analysis on n. For n=0: unit character multiplicativity. For n=-1: sign character multiplicativity (sgn(ab) = sgn(a)sgn(b)). For n=1: trivial. For general n: combine sign character multiplicativity with Jacobi symbol mul_left from Mathlib."
+    "proofStrategy": "Case analysis on n. For n=0: unit character multiplicativity. For n=-1: sign character multiplicativity (sgn(ab) = sgn(a)sgn(b)). For n=1: trivial. For general n: combine sign character multiplicativity with Jacobi symbol mul_left from Mathlib.",
+    "keyInsights": []
   },
   "references": [
     {

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
@@ -28,7 +28,9 @@
   "overview": {
     "historicalContext": "Leopold Kronecker extended the Jacobi symbol in 1885 to handle all integer arguments, creating a symbol fundamental to algebraic number theory, Dirichlet L-functions, and modular forms.",
     "problemStatement": "Define the Kronecker symbol (a/n) for all integers a,n and prove its basic properties.",
-    "text": "Formalizes the Kronecker symbol extension of the Jacobi symbol."
+    "text": "Formalizes the Kronecker symbol extension of the Jacobi symbol.",
+    "proofStrategy": "Formalizes the Kronecker symbol extension of the Jacobi symbol.",
+    "keyInsights": []
   },
   "sections": [],
   "conclusion": {

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-03/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-03/meta.json
@@ -1,30 +1,31 @@
 {
-    "id": "elementary-quadratic-reciprocity-oq-03-oq-03",
-    "title": "Jacobi Symbol and Hilbert Symbols: The Local-Global Connection",
-    "slug": "elementary-quadratic-reciprocity-oq-03-oq-03",
-    "description": "Survey of how the Jacobi symbol connects to Hilbert symbols and the local-global principle. Proves Legendre-QR connections from Mathlib, axiomatizes Hilbert symbol and product formula pending p-adic infrastructure.",
-    "meta": {
-        "author": "Formalized in Lean 4 (Mathlib)",
-        "date": "2026",
-        "status": "axiomatized",
-        "proofRepoPath": "Proofs/ElementaryQuadraticReciprocityOQ03OQ03.lean",
-        "tags": [
-            "number-theory",
-            "quadratic-reciprocity",
-            "hilbert-symbol",
-            "class-field-theory",
-            "research"
-        ],
-        "badge": "axiom",
-        "sorries": 0,
-        "axiomCount": 3,
-        "dateAdded": "2026-03-28",
-        "lineCount": 113
-    },
-    "sorryCount": 0,
+  "id": "elementary-quadratic-reciprocity-oq-03-oq-03",
+  "title": "Jacobi Symbol and Hilbert Symbols: The Local-Global Connection",
+  "slug": "elementary-quadratic-reciprocity-oq-03-oq-03",
+  "description": "Survey of how the Jacobi symbol connects to Hilbert symbols and the local-global principle. Proves Legendre-QR connections from Mathlib, axiomatizes Hilbert symbol and product formula pending p-adic infrastructure.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "date": "2026",
     "status": "axiomatized",
+    "proofRepoPath": "Proofs/ElementaryQuadraticReciprocityOQ03OQ03.lean",
+    "tags": [
+      "number-theory",
+      "quadratic-reciprocity",
+      "hilbert-symbol",
+      "class-field-theory",
+      "research"
+    ],
     "badge": "axiom",
-    "leanFile": {
-        "lineCount": 113
-    }
+    "sorries": 0,
+    "axiomCount": 3,
+    "dateAdded": "2026-03-28",
+    "lineCount": 113
+  },
+  "sorryCount": 0,
+  "status": "axiomatized",
+  "badge": "axiom",
+  "leanFile": {
+    "lineCount": 113
+  },
+  "sections": []
 }

--- a/src/data/proofs/erdos-1015-oq-05/meta.json
+++ b/src/data/proofs/erdos-1015-oq-05/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-1015-oq-05",
-  "title": "Erdős #1015 OQ5: Axiom Elimination via Erdős-Szekeres Bound",
+  "title": "Erd\u0151s #1015 OQ5: Axiom Elimination via Erd\u0151s-Szekeres Bound",
   "slug": "erdos-1015-oq-05",
-  "description": "Investigates which of the 8 axioms in the Erdős #1015 formalization can be proved from Mathlib. Eliminates 2: replaces the axiomatized ramseyNumber with a proper definition via Nat.find, and proves R(t,t) ≤ 4^t via the Erdős-Szekeres bound R(r,s) ≤ C(r+s-2, r-1).",
+  "description": "Investigates which of the 8 axioms in the Erd\u0151s #1015 formalization can be proved from Mathlib. Eliminates 2: replaces the axiomatized ramseyNumber with a proper definition via Nat.find, and proves R(t,t) \u2264 4^t via the Erd\u0151s-Szekeres bound R(r,s) \u2264 C(r+s-2, r-1).",
   "meta": {
-    "author": "Erdős-Szekeres (1935)",
+    "author": "Erd\u0151s-Szekeres (1935)",
     "erdosNumber": 1015,
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1015OQ05.lean",
@@ -30,23 +30,23 @@
     {
       "targetId": "erdos-1015",
       "relationship": "extends",
-      "description": "This file eliminates 2 of the 8 axioms from the parent Erdős #1015 formalization by proving them from the Ramsey theorem formalized in RamseysTheorem.lean."
+      "description": "This file eliminates 2 of the 8 axioms from the parent Erd\u0151s #1015 formalization by proving them from the Ramsey theorem formalized in RamseysTheorem.lean."
     },
     {
       "targetId": "ramseys-theorem",
       "relationship": "depends",
-      "description": "Imports the Ramsey theorem (Wiedijk #31) to define ramseyNumber via Nat.find and prove the Erdős-Szekeres bound R(r,s) ≤ C(r+s-2, r-1) by induction."
+      "description": "Imports the Ramsey theorem (Wiedijk #31) to define ramseyNumber via Nat.find and prove the Erd\u0151s-Szekeres bound R(r,s) \u2264 C(r+s-2, r-1) by induction."
     }
   ],
   "overview": {
     "problemStatement": "Can any of the 8 axioms in Erdos1015Problem.lean (Moon's theorem, Ramsey bounds, BES formula, asymptotics) be proved from Mathlib?",
-    "text": "We eliminate 2 of the 8 axioms: (1) ramseyNumber is replaced with a proper definition via Nat.find, and (2) ramsey_upper_bound (R(t,t) ≤ 4^t) is proved via the Erdős-Szekeres bound. The remaining 6 axioms are deep results requiring substantial Ramsey-theoretic machinery beyond Mathlib.",
-    "proofStrategy": "The proof proceeds in four stages: (1) Define ramseyNumber as the minimum n with the Ramsey property via Nat.find. (2) Prove HasRamseyProperty monotonicity for embedding arguments. (3) Prove HasRamseyProperty at the binomial coefficient bound C(r+s-2, r-1) by strong induction on r+s, using Pascal's rule for the bound recurrence and the pigeonhole argument from RamseysTheorem.lean. (4) Chain R(t,t) ≤ C(2t-2, t-1) ≤ 2^(2t-2) = 4^(t-1) ≤ 4^t.",
+    "text": "We eliminate 2 of the 8 axioms: (1) ramseyNumber is replaced with a proper definition via Nat.find, and (2) ramsey_upper_bound (R(t,t) \u2264 4^t) is proved via the Erd\u0151s-Szekeres bound. The remaining 6 axioms are deep results requiring substantial Ramsey-theoretic machinery beyond Mathlib.",
+    "proofStrategy": "The proof proceeds in four stages: (1) Define ramseyNumber as the minimum n with the Ramsey property via Nat.find. (2) Prove HasRamseyProperty monotonicity for embedding arguments. (3) Prove HasRamseyProperty at the binomial coefficient bound C(r+s-2, r-1) by strong induction on r+s, using Pascal's rule for the bound recurrence and the pigeonhole argument from RamseysTheorem.lean. (4) Chain R(t,t) \u2264 C(2t-2, t-1) \u2264 2^(2t-2) = 4^(t-1) \u2264 4^t.",
     "keyInsights": [
-      "The ramseyNumber axiom is really a definition placeholder — replacing it with Nat.find on the Ramsey existence theorem gives a proper constructive definition.",
-      "The Erdős-Szekeres bound R(r,s) ≤ C(r+s-2, r-1) follows from the same pigeonhole induction as Ramsey's theorem, but with explicit tracking of the binomial coefficient via Pascal's rule.",
-      "The key inequality C(n,k) ≤ 2^n (each binomial coefficient is at most the row sum) gives the bridge from combinatorial to exponential bounds.",
-      "The remaining 6 axioms (Moon's theorem, Erdős's f(t) < R(t,t), BES formula, root limit, superlinear growth) all require either specific graph constructions or deep analytic arguments not in Mathlib."
+      "The ramseyNumber axiom is really a definition placeholder \u2014 replacing it with Nat.find on the Ramsey existence theorem gives a proper constructive definition.",
+      "The Erd\u0151s-Szekeres bound R(r,s) \u2264 C(r+s-2, r-1) follows from the same pigeonhole induction as Ramsey's theorem, but with explicit tracking of the binomial coefficient via Pascal's rule.",
+      "The key inequality C(n,k) \u2264 2^n (each binomial coefficient is at most the row sum) gives the bridge from combinatorial to exponential bounds.",
+      "The remaining 6 axioms (Moon's theorem, Erd\u0151s's f(t) < R(t,t), BES formula, root limit, superlinear growth) all require either specific graph constructions or deep analytic arguments not in Mathlib."
     ]
   },
   "leanFile": {
@@ -63,5 +63,6 @@
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 1
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/erdos-1066-oq-04/meta.json
+++ b/src/data/proofs/erdos-1066-oq-04/meta.json
@@ -1,1 +1,89 @@
-{"id":"erdos-1066-oq-04","title":"Higher-Dimensional Unit Distance Independence","slug":"erdos-1066-oq-04","description":"Explores g_d(n) — the independence number of unit distance graphs in ℝ^d. Kissing number τ(d) bounds degrees, giving g_d(n) ≥ n/(τ(d)+1) by greedy coloring.","meta":{"author":"Erdős, Swanepoel, et al.","sourceUrl":"https://erdosproblems.com/1066","date":"2026","status":"axiomatized","proofRepoPath":"Proofs/Erdos1066OQ04.lean","tags":["combinatorial-geometry","unit-distance","independence-number","erdos","research"],"badge":"axiom","sorries":1,"axiomCount":2,"lineCount":156,"assumptions":"2 axioms (degree_le_kissing, greedy_independence). 1 sorry.","dateAdded":"2026-03-30","mathlib_version":"4.26.0","originalContributions":["SepConfig structure for d-dimensional separated points","Kissing number lookup with known values","Greedy bound g_d(n) ≥ n/(τ(d)+1) for specific dimensions","Scaling analysis: greedy weakens as d grows"]},"sections":[{"id":"config","title":"Separated Configurations","startLine":20,"endLine":40},{"id":"kissing","title":"Kissing Number Bound","startLine":42,"endLine":70},{"id":"greedy","title":"Greedy Independence","startLine":72,"endLine":92},{"id":"dimensions","title":"Specific Dimensions","startLine":94,"endLine":128}],"conclusion":{"summary":"Higher-dimensional g_d(n) bounded below by n/(τ(d)+1) via greedy coloring. Structural improvements needed for tighter bounds.","openQuestions":[]},"crossReferences":[{"targetId":"erdos-1066","relationship":"parent-problem"},{"targetId":"erdos-1084-oq-01","relationship":"related-problem","description":"Also uses kissing number bounds"}],"leanFile":{"imports":["Mathlib"],"namespace":"Erdos1066OQ04","lineCount":156,"axiomCount":2,"theoremCount":5,"definitionCount":6}}
+{
+  "id": "erdos-1066-oq-04",
+  "title": "Higher-Dimensional Unit Distance Independence",
+  "slug": "erdos-1066-oq-04",
+  "description": "Explores g_d(n) \u2014 the independence number of unit distance graphs in \u211d^d. Kissing number \u03c4(d) bounds degrees, giving g_d(n) \u2265 n/(\u03c4(d)+1) by greedy coloring.",
+  "meta": {
+    "author": "Erd\u0151s, Swanepoel, et al.",
+    "sourceUrl": "https://erdosproblems.com/1066",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos1066OQ04.lean",
+    "tags": [
+      "combinatorial-geometry",
+      "unit-distance",
+      "independence-number",
+      "erdos",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 1,
+    "axiomCount": 2,
+    "lineCount": 156,
+    "assumptions": "2 axioms (degree_le_kissing, greedy_independence). 1 sorry.",
+    "dateAdded": "2026-03-30",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "SepConfig structure for d-dimensional separated points",
+      "Kissing number lookup with known values",
+      "Greedy bound g_d(n) \u2265 n/(\u03c4(d)+1) for specific dimensions",
+      "Scaling analysis: greedy weakens as d grows"
+    ]
+  },
+  "sections": [
+    {
+      "id": "config",
+      "title": "Separated Configurations",
+      "startLine": 20,
+      "endLine": 40,
+      "summary": "Separated Configurations"
+    },
+    {
+      "id": "kissing",
+      "title": "Kissing Number Bound",
+      "startLine": 42,
+      "endLine": 70,
+      "summary": "Kissing Number Bound"
+    },
+    {
+      "id": "greedy",
+      "title": "Greedy Independence",
+      "startLine": 72,
+      "endLine": 92,
+      "summary": "Greedy Independence"
+    },
+    {
+      "id": "dimensions",
+      "title": "Specific Dimensions",
+      "startLine": 94,
+      "endLine": 128,
+      "summary": "Specific Dimensions"
+    }
+  ],
+  "conclusion": {
+    "summary": "Higher-dimensional g_d(n) bounded below by n/(\u03c4(d)+1) via greedy coloring. Structural improvements needed for tighter bounds.",
+    "openQuestions": [],
+    "implications": ""
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1066",
+      "relationship": "parent-problem"
+    },
+    {
+      "targetId": "erdos-1084-oq-01",
+      "relationship": "related-problem",
+      "description": "Also uses kissing number bounds"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "Erdos1066OQ04",
+    "lineCount": 156,
+    "axiomCount": 2,
+    "theoremCount": 5,
+    "definitionCount": 6
+  }
+}

--- a/src/data/proofs/erdos-1118-oq-02/meta.json
+++ b/src/data/proofs/erdos-1118-oq-02/meta.json
@@ -1,1 +1,49 @@
-{"id":"erdos-1118-oq-02","title":"Superlevel Sets in Several Complex Variables","slug":"erdos-1118-oq-02","description":"Higher-dimensional analogue of Erdős 1118: superlevel sets of holomorphic maps ℂⁿ → ℂ. Plurisubharmonicity, Oka theory, Hartogs extension.","meta":{"author":"Camera, Gol'dberg, Oka","sourceUrl":"https://erdosproblems.com/1118","date":"2026","status":"axiomatized","proofRepoPath":"Proofs/Erdos1118OQ02.lean","tags":["complex-analysis","several-variables","superlevel-sets","erdos","research"],"badge":"axiom","sorries":0,"axiomCount":3,"lineCount":120,"assumptions":"3 axioms. 0 sorries.","dateAdded":"2026-03-30","mathlib_version":"4.26.0"},"conclusion":{"summary":"Several-complex-variables analogue explored. Key differences from 1D: plurisubharmonicity, pseudoconvexity, Hartogs extension.","openQuestions":[]},"crossReferences":[{"targetId":"erdos-1118","relationship":"parent-problem"}],"leanFile":{"imports":["Mathlib"],"namespace":"Erdos1118OQ02","lineCount":120,"axiomCount":3,"theoremCount":4,"definitionCount":1}}
+{
+  "id": "erdos-1118-oq-02",
+  "title": "Superlevel Sets in Several Complex Variables",
+  "slug": "erdos-1118-oq-02",
+  "description": "Higher-dimensional analogue of Erd\u0151s 1118: superlevel sets of holomorphic maps \u2102\u207f \u2192 \u2102. Plurisubharmonicity, Oka theory, Hartogs extension.",
+  "meta": {
+    "author": "Camera, Gol'dberg, Oka",
+    "sourceUrl": "https://erdosproblems.com/1118",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos1118OQ02.lean",
+    "tags": [
+      "complex-analysis",
+      "several-variables",
+      "superlevel-sets",
+      "erdos",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 3,
+    "lineCount": 120,
+    "assumptions": "3 axioms. 0 sorries.",
+    "dateAdded": "2026-03-30",
+    "mathlib_version": "4.26.0"
+  },
+  "conclusion": {
+    "summary": "Several-complex-variables analogue explored. Key differences from 1D: plurisubharmonicity, pseudoconvexity, Hartogs extension.",
+    "openQuestions": [],
+    "implications": ""
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1118",
+      "relationship": "parent-problem"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "Erdos1118OQ02",
+    "lineCount": 120,
+    "axiomCount": 3,
+    "theoremCount": 4,
+    "definitionCount": 1
+  },
+  "sections": []
+}

--- a/src/data/proofs/erdos-115-oq-01/meta.json
+++ b/src/data/proofs/erdos-115-oq-01/meta.json
@@ -1,42 +1,43 @@
 {
-    "id": "erdos-115-oq-01",
-    "title": "Rate of o(1) Correction in Lemniscate Derivatives",
-    "slug": "erdos-115-oq-01",
-    "description": "What is the exact rate of the o(1) correction in max|p'| ≤ (1/2 + o(1))n² on connected lemniscates? Formalizes the correction term, defines possible rates (O(1/n), O(1/log n), O(1/√n), O(n^{-α})), and states the open question about which rate is correct.",
-    "meta": {
-        "author": "Eremenko, Lempert; Pommerenke",
-        "sourceUrl": "https://erdosproblems.com/115",
-        "date": "2000",
-        "status": "axiomatized",
-        "proofRepoPath": "Proofs/Erdos115OQ01Problem.lean",
-        "tags": [
-            "erdos",
-            "complex-analysis",
-            "polynomials",
-            "lemniscates",
-            "asymptotics",
-            "research",
-            "open-problem"
-        ],
-        "badge": "axiom",
-        "sorries": 0,
-        "axiomCount": 11,
-        "assumptions": [
-            "ComplexPoly, IsLemniscateConnected, maxDerivOnLemniscate: definitional",
-            "maxDeriv_nonneg: non-negativity",
-            "eremenko_lempert: main (1/2+o(1))n² bound",
-            "chebyshev_poly, chebyshev_connected, chebyshev_asymptotic: Chebyshev extremals",
-            "supCorrection, supCorrection_upper, correction_tends_to_zero: correction framework"
-        ],
-        "erdosNumber": 115,
-        "erdosUrl": "https://erdosproblems.com/115",
-        "erdosProblemStatus": "open",
-        "dateAdded": "2026-03-29",
-        "mathlib_version": "4.26.0",
-        "mathlibDependencies": [],
-        "parentProof": "erdos-115",
-        "openQuestionType": "extension",
-        "openQuestionOf": "erdos-115",
-        "lineCount": 176
-    }
+  "id": "erdos-115-oq-01",
+  "title": "Rate of o(1) Correction in Lemniscate Derivatives",
+  "slug": "erdos-115-oq-01",
+  "description": "What is the exact rate of the o(1) correction in max|p'| \u2264 (1/2 + o(1))n\u00b2 on connected lemniscates? Formalizes the correction term, defines possible rates (O(1/n), O(1/log n), O(1/\u221an), O(n^{-\u03b1})), and states the open question about which rate is correct.",
+  "meta": {
+    "author": "Eremenko, Lempert; Pommerenke",
+    "sourceUrl": "https://erdosproblems.com/115",
+    "date": "2000",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos115OQ01Problem.lean",
+    "tags": [
+      "erdos",
+      "complex-analysis",
+      "polynomials",
+      "lemniscates",
+      "asymptotics",
+      "research",
+      "open-problem"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 11,
+    "assumptions": [
+      "ComplexPoly, IsLemniscateConnected, maxDerivOnLemniscate: definitional",
+      "maxDeriv_nonneg: non-negativity",
+      "eremenko_lempert: main (1/2+o(1))n\u00b2 bound",
+      "chebyshev_poly, chebyshev_connected, chebyshev_asymptotic: Chebyshev extremals",
+      "supCorrection, supCorrection_upper, correction_tends_to_zero: correction framework"
+    ],
+    "erdosNumber": 115,
+    "erdosUrl": "https://erdosproblems.com/115",
+    "erdosProblemStatus": "open",
+    "dateAdded": "2026-03-29",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [],
+    "parentProof": "erdos-115",
+    "openQuestionType": "extension",
+    "openQuestionOf": "erdos-115",
+    "lineCount": 176
+  },
+  "sections": []
 }

--- a/src/data/proofs/erdos-1151/meta.json
+++ b/src/data/proofs/erdos-1151/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-1151",
-  "title": "Erdős Problem #1151: Limit Points of Lagrange Interpolation at Chebyshev Nodes",
+  "title": "Erd\u0151s Problem #1151: Limit Points of Lagrange Interpolation at Chebyshev Nodes",
   "slug": "erdos-1151",
   "description": "For Lagrange interpolation at Chebyshev nodes, prove that for any closed set A in [-1,1], there exists a continuous function f such that A is the set of limit points of the interpolation values.",
   "meta": {
-    "author": "Erdős (1941), Vértesi (1999)",
+    "author": "Erd\u0151s (1941), V\u00e9rtesi (1999)",
     "sourceUrl": "https://erdosproblems.com/1151",
     "date": "1941",
     "status": "axiomatized",
@@ -35,14 +35,14 @@
       }
     ],
     "originalContributions": [
-      "Formalization of Chebyshev nodes as cos((2k+1)π/(2n))",
+      "Formalization of Chebyshev nodes as cos((2k+1)\u03c0/(2n))",
       "Proof that Chebyshev nodes lie in [-1,1]",
       "Lagrange interpolation operator using basis polynomials",
       "Definition of limit point sets for sequences",
       "Formal statement of the full conjecture with special cases derived"
     ],
     "axiomCount": 2,
-    "assumptions": "2 axioms: erdos_1941_divergence (Erdős 1941 result on divergence at rational cosines), erdos_1151_conjecture (the open problem).",
+    "assumptions": "2 axioms: erdos_1941_divergence (Erd\u0151s 1941 result on divergence at rational cosines), erdos_1151_conjecture (the open problem).",
     "lineCount": 184,
     "prerequisites": [
       "Polynomial interpolation (Lagrange basis)",
@@ -51,12 +51,12 @@
     ]
   },
   "overview": {
-    "historicalContext": "Erdős studied Lagrange interpolation at Chebyshev nodes starting in 1941, showing divergence is possible for continuous functions.",
-    "problemStatement": "Prove that for any closed A ⊆ [-1,1] and suitable x, there exists continuous f such that A is the set of limit points of 𝓛ⁿf(x).",
+    "historicalContext": "Erd\u0151s studied Lagrange interpolation at Chebyshev nodes starting in 1941, showing divergence is possible for continuous functions.",
+    "problemStatement": "Prove that for any closed A \u2286 [-1,1] and suitable x, there exists continuous f such that A is the set of limit points of \ud835\udcdb\u207ff(x).",
     "text": "We formalize the problem, defining Chebyshev nodes, Lagrange interpolation, and limit point sets.",
     "proofStrategy": "Define the mathematical objects and state the conjecture. Derive special cases from it.",
     "keyInsights": [
-      "Chebyshev nodes are cos((2k+1)π/(2n)), roots of Tₙ",
+      "Chebyshev nodes are cos((2k+1)\u03c0/(2n)), roots of T\u2099",
       "Lagrange interpolation can fail to converge for continuous functions",
       "The conjecture would show ALL closed subsets are realizable as limit point sets"
     ],
@@ -75,7 +75,8 @@
       "theorems": [
         "chebyshevNode_mem_Icc"
       ],
-      "summary": "Chebyshev Nodes"
+      "summary": "Chebyshev Nodes",
+      "id": "chebyshev-nodes"
     },
     {
       "title": "Lagrange Interpolation",
@@ -83,7 +84,8 @@
       "lineStart": 57,
       "lineEnd": 80,
       "theorems": [],
-      "summary": "Lagrange Interpolation"
+      "summary": "Lagrange Interpolation",
+      "id": "lagrange-interpolation"
     },
     {
       "title": "Main Conjecture and Special Cases",
@@ -94,11 +96,12 @@
         "erdos_1151_convergent_case",
         "erdos_1151_dense_case"
       ],
-      "summary": "Main Conjecture and Special Cases"
+      "summary": "Main Conjecture and Special Cases",
+      "id": "main-conjecture-and-special-ca"
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erdős Problem #1151 on limit-point behavior of Lagrange interpolation at Chebyshev nodes.",
+    "summary": "We formalize Erd\u0151s Problem #1151 on limit-point behavior of Lagrange interpolation at Chebyshev nodes.",
     "implications": [
       "Complete classification of convergence/divergence behaviors"
     ],
@@ -116,12 +119,12 @@
   "references": [
     {
       "key": "Er41",
-      "citation": "P. Erdős, On divergence properties of the Lagrange interpolation parabolas, Ann. of Math. 42 (1941), 309-315.",
+      "citation": "P. Erd\u0151s, On divergence properties of the Lagrange interpolation parabolas, Ann. of Math. 42 (1941), 309-315.",
       "url": ""
     },
     {
       "key": "Va99",
-      "citation": "P. Vértesi, Problems on interpolation, Problem 2.41, 1999.",
+      "citation": "P. V\u00e9rtesi, Problems on interpolation, Problem 2.41, 1999.",
       "url": ""
     }
   ],

--- a/src/data/proofs/erdos-1168/meta.json
+++ b/src/data/proofs/erdos-1168/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-1168",
-  "title": "Erdős Problem #1168: Negative Partition Relation for ℵ_{ω+1}",
+  "title": "Erd\u0151s Problem #1168: Negative Partition Relation for \u2135_{\u03c9+1}",
   "slug": "erdos-1168",
-  "description": "Prove ℵ_{ω+1} ↛ (ℵ_{ω+1}, 3, …, 3)_{ℵ₀}² without GCH. Open problem in set-theoretic combinatorics at the intersection of partition calculus and pcf theory.",
+  "description": "Prove \u2135_{\u03c9+1} \u219b (\u2135_{\u03c9+1}, 3, \u2026, 3)_{\u2135\u2080}\u00b2 without GCH. Open problem in set-theoretic combinatorics at the intersection of partition calculus and pcf theory.",
   "meta": {
     "erdosNumber": 1168,
     "status": "axiomatized",
@@ -30,5 +30,6 @@
   },
   "leanFile": {
     "lineCount": 153
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/erdos-1183/meta.json
+++ b/src/data/proofs/erdos-1183/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-1183",
-  "title": "Erdős Problem #1183: Monochromatic Lattice Families",
+  "title": "Erd\u0151s Problem #1183: Monochromatic Lattice Families",
   "slug": "erdos-1183",
-  "description": "In any 2-coloring of the subsets of {1,...,n}, there exists a monochromatic family closed under unions and intersections. How large must it be? The trivial chain bound gives ⌈(n+1)/2⌉. Erdős and Ulam had 'no plausible conjecture' for the true order of magnitude.",
+  "description": "In any 2-coloring of the subsets of {1,...,n}, there exists a monochromatic family closed under unions and intersections. How large must it be? The trivial chain bound gives \u2308(n+1)/2\u2309. Erd\u0151s and Ulam had 'no plausible conjecture' for the true order of magnitude.",
   "meta": {
-    "author": "Erdős–Ulam (1978)",
+    "author": "Erd\u0151s\u2013Ulam (1978)",
     "sourceUrl": "https://erdosproblems.com/1183",
     "date": "1978",
     "status": "axiomatized",
@@ -42,12 +42,12 @@
     "originalContributions": [
       "Formalization of union-closed and intersection-closed families on powerset",
       "Proof that every chain is a sublattice (closed under union and intersection)",
-      "Construction of the standard chain ∅ ⊂ {0} ⊂ ... ⊂ Fin n",
+      "Construction of the standard chain \u2205 \u2282 {0} \u2282 ... \u2282 Fin n",
       "Proof of injectivity of initial segments",
-      "Pigeonhole argument yielding f(n) ≥ ⌈(n+1)/2⌉",
+      "Pigeonhole argument yielding f(n) \u2265 \u2308(n+1)/2\u2309",
       "Corrected abstract definitions of f(n) and F(n) using sSup (was sInf, evaluating to 0)",
-      "Formal proof erdos1183_f_lower_bound: f(n) ≥ ⌈(n+1)/2⌉ via le_csSup",
-      "Proof erdos1183_F_ge_f: F(n) ≥ f(n) since sublattices are union-closed",
+      "Formal proof erdos1183_f_lower_bound: f(n) \u2265 \u2308(n+1)/2\u2309 via le_csSup",
+      "Proof erdos1183_F_ge_f: F(n) \u2265 f(n) since sublattices are union-closed",
       "BddAbove proofs bounding achievable sets by 2^n"
     ],
     "axiomCount": 0,
@@ -61,15 +61,15 @@
     ]
   },
   "overview": {
-    "historicalContext": "Erdős and Ulam posed this problem in 1978 [Er78, p.39] as a Ramsey-type question about the powerset lattice. Given a 2-coloring of all subsets of {1,...,n}, how large a monochromatic sublattice (closed under unions and intersections) must exist? They defined two variants: f(n) for full sublattices and F(n) for union-closed families only.",
+    "historicalContext": "Erd\u0151s and Ulam posed this problem in 1978 [Er78, p.39] as a Ramsey-type question about the powerset lattice. Given a 2-coloring of all subsets of {1,...,n}, how large a monochromatic sublattice (closed under unions and intersections) must exist? They defined two variants: f(n) for full sublattices and F(n) for union-closed families only.",
     "problemStatement": "Let f(n) be maximal such that in any 2-coloring of the subsets of {1,...,n} there is always a monochromatic family of at least f(n) sets which is closed under taking unions and intersections. Estimate f(n). Similarly define F(n) requiring only union-closure.",
-    "text": "We formalize the Erdős-Ulam problem on monochromatic sublattice families and prove the trivial lower bound f(n) ≥ ⌈(n+1)/2⌉ via the standard chain argument.",
-    "proofStrategy": "Construct the standard chain ∅ ⊂ {0} ⊂ {0,1} ⊂ ... ⊂ {0,...,n-1} (n+1 elements). Show any chain is a sublattice. Apply pigeonhole to get a monochromatic subchain of size ≥ ⌈(n+1)/2⌉.",
+    "text": "We formalize the Erd\u0151s-Ulam problem on monochromatic sublattice families and prove the trivial lower bound f(n) \u2265 \u2308(n+1)/2\u2309 via the standard chain argument.",
+    "proofStrategy": "Construct the standard chain \u2205 \u2282 {0} \u2282 {0,1} \u2282 ... \u2282 {0,...,n-1} (n+1 elements). Show any chain is a sublattice. Apply pigeonhole to get a monochromatic subchain of size \u2265 \u2308(n+1)/2\u2309.",
     "keyInsights": [
       "In a chain, the union of two comparable sets equals the larger one, so chains are automatically union-closed",
       "Similarly, the intersection equals the smaller one, so chains are intersection-closed",
       "The standard chain has exactly n+1 elements (proved via injectivity of initial segments)",
-      "Pigeonhole on 2-colorings guarantees a color class of size ≥ ⌈(n+1)/2⌉"
+      "Pigeonhole on 2-colorings guarantees a color class of size \u2265 \u2308(n+1)/2\u2309"
     ],
     "prerequisites": [
       "Finite set theory",
@@ -84,11 +84,12 @@
       "lineStart": 35,
       "lineEnd": 62,
       "theorems": [],
-      "summary": "Basic Definitions"
+      "summary": "Basic Definitions",
+      "id": "basic-definitions"
     },
     {
       "title": "Chains Are Sublattices",
-      "content": "We prove that in any chain (totally ordered by ⊆), the union and intersection of any two elements remain in the chain. Hence every chain is a sublattice.",
+      "content": "We prove that in any chain (totally ordered by \u2286), the union and intersection of any two elements remain in the chain. Hence every chain is a sublattice.",
       "lineStart": 64,
       "lineEnd": 85,
       "theorems": [
@@ -96,11 +97,12 @@
         "chain_inter_mem",
         "chain_isSublattice"
       ],
-      "summary": "Chains Are Sublattices"
+      "summary": "Chains Are Sublattices",
+      "id": "chains-are-sublattices"
     },
     {
       "title": "The Standard Chain",
-      "content": "We construct the standard chain ∅ ⊂ {0} ⊂ {0,1} ⊂ ... ⊂ Fin n using initial segments, prove it is a chain, that initial segments are injective, and that the chain has exactly n+1 elements.",
+      "content": "We construct the standard chain \u2205 \u2282 {0} \u2282 {0,1} \u2282 ... \u2282 Fin n using initial segments, prove it is a chain, that initial segments are injective, and that the chain has exactly n+1 elements.",
       "lineStart": 87,
       "lineEnd": 132,
       "theorems": [
@@ -109,32 +111,35 @@
         "initialSeg_injective",
         "stdChain_card"
       ],
-      "summary": "The Standard Chain"
+      "summary": "The Standard Chain",
+      "id": "the-standard-chain"
     },
     {
       "title": "Pigeonhole",
-      "content": "A pigeonhole lemma: in any 2-coloring of a finite set S, some color class has at least ⌈|S|/2⌉ elements.",
+      "content": "A pigeonhole lemma: in any 2-coloring of a finite set S, some color class has at least \u2308|S|/2\u2309 elements.",
       "lineStart": 134,
       "lineEnd": 164,
       "theorems": [
         "exists_mono_color_class"
       ],
-      "summary": "Pigeonhole"
+      "summary": "Pigeonhole",
+      "id": "pigeonhole"
     },
     {
       "title": "Main Results",
-      "content": "The chain bound: for any 2-coloring of subsets of Fin n, there exists a monochromatic sublattice of size ≥ ⌈(n+1)/2⌉. The F(n) bound follows since every sublattice is union-closed.",
+      "content": "The chain bound: for any 2-coloring of subsets of Fin n, there exists a monochromatic sublattice of size \u2265 \u2308(n+1)/2\u2309. The F(n) bound follows since every sublattice is union-closed.",
       "lineStart": 166,
       "lineEnd": 200,
       "theorems": [
         "erdos1183_chain_bound",
         "erdos1183_F_chain_bound"
       ],
-      "summary": "Main Results"
+      "summary": "Main Results",
+      "id": "main-results"
     },
     {
       "title": "Abstract Definitions and Bounds",
-      "content": "Corrected definitions of f(n) and F(n) using sSup (previously sInf, which gave 0). Proves the chain bound connects to the abstract definition: f(n) ≥ ⌈(n+1)/2⌉. Proves F(n) ≥ f(n) since sublattices are union-closed.",
+      "content": "Corrected definitions of f(n) and F(n) using sSup (previously sInf, which gave 0). Proves the chain bound connects to the abstract definition: f(n) \u2265 \u2308(n+1)/2\u2309. Proves F(n) \u2265 f(n) since sublattices are union-closed.",
       "lineStart": 201,
       "lineEnd": 276,
       "theorems": [
@@ -144,15 +149,16 @@
         "achievableSublattice_subset_unionClosed",
         "erdos1183_F_ge_f"
       ],
-      "summary": "Abstract Definitions and Bounds"
+      "summary": "Abstract Definitions and Bounds",
+      "id": "abstract-definitions-and-bound"
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erdős Problem #1183 (Erdős-Ulam) and prove the trivial lower bound f(n) ≥ ⌈(n+1)/2⌉ using the standard chain in the powerset lattice. The true growth rate of both f(n) and F(n) remain open.",
+    "summary": "We formalize Erd\u0151s Problem #1183 (Erd\u0151s-Ulam) and prove the trivial lower bound f(n) \u2265 \u2308(n+1)/2\u2309 using the standard chain in the powerset lattice. The true growth rate of both f(n) and F(n) remain open.",
     "implications": [
       "Provides a baseline Lean formalization for powerset Ramsey problems",
       "The chain argument generalizes to any lattice with long chains",
-      "Improving the bound beyond ⌈(n+1)/2⌉ likely requires non-chain families"
+      "Improving the bound beyond \u2308(n+1)/2\u2309 likely requires non-chain families"
     ],
     "openQuestions": [
       "What is the true order of magnitude of f(n)?",
@@ -169,7 +175,7 @@
   "references": [
     {
       "key": "Er78",
-      "citation": "P. Erdős, Problems and results in combinatorial analysis and combinatorial number theory, Proc. Ninth Southeastern Conf. on Combinatorics, Graph Theory, and Computing, 1978, pp. 39.",
+      "citation": "P. Erd\u0151s, Problems and results in combinatorial analysis and combinatorial number theory, Proc. Ninth Southeastern Conf. on Combinatorics, Graph Theory, and Computing, 1978, pp. 39.",
       "url": "https://erdosproblems.com/1183"
     }
   ],

--- a/src/data/proofs/erdos-183/meta.json
+++ b/src/data/proofs/erdos-183/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-183",
-  "title": "Erdős Problem #183: Multicolor Triangle Ramsey Numbers",
+  "title": "Erd\u0151s Problem #183: Multicolor Triangle Ramsey Numbers",
   "slug": "erdos-183",
   "description": "Determine the limit of R(3;k)^{1/k} as k approaches infinity, where R(3;k) is the minimum n such that any k-coloring of the edges of K_n contains a monochromatic triangle.",
   "meta": {
-    "author": "Erdős",
+    "author": "Erd\u0151s",
     "sourceUrl": "https://erdosproblems.com/183",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos183Problem.lean",
@@ -55,7 +55,7 @@
     "references": [
       {
         "title": "Some remarks on the theory of graphs",
-        "authors": "P. Erdős",
+        "authors": "P. Erd\u0151s",
         "year": 1947,
         "venue": "Bulletin of the American Mathematical Society",
         "url": "https://doi.org/10.1090/S0002-9904-1947-08785-1",
@@ -63,31 +63,31 @@
       },
       {
         "title": "Combinatorial problems and exercises",
-        "authors": "L. Lovász",
+        "authors": "L. Lov\u00e1sz",
         "year": 1993,
         "venue": "North-Holland (2nd edition)",
-        "description": "Contains the pigeonhole upper bound R(3;k) ≤ ⌈e·k!⌉ and connections to Schur numbers"
+        "description": "Contains the pigeonhole upper bound R(3;k) \u2264 \u2308e\u00b7k!\u2309 and connections to Schur numbers"
       },
       {
         "title": "An exponential lower bound for the multicolor Ramsey number of triangles",
         "authors": "J. Ageron, J.-F. Casteras, J. Pellerin, A. Portella, A. Rimmel, R. Tomasik",
         "year": 2021,
         "venue": "Preprint",
-        "description": "Establishes the lower bound R(3;k) ≥ 380^{k/5} − O(1), a major improvement over previous bounds"
+        "description": "Establishes the lower bound R(3;k) \u2265 380^{k/5} \u2212 O(1), a major improvement over previous bounds"
       }
     ],
-    "assumptions": "6 axioms: R3k_three (=17), R3k_factorial_upper, SchurNumber (definition), R3k_schur_lower, R3k_exponential_lower, R3k_precise_lower. R3k_inductive_upper PROVED from extracted pigeonhole step (forcing_step). forcing_set_nonempty PROVED via pigeonhole induction. R3k_two PROVED via pigeonhole + C₅ construction."
+    "assumptions": "6 axioms: R3k_three (=17), R3k_factorial_upper, SchurNumber (definition), R3k_schur_lower, R3k_exponential_lower, R3k_precise_lower. R3k_inductive_upper PROVED from extracted pigeonhole step (forcing_step). forcing_set_nonempty PROVED via pigeonhole induction. R3k_two PROVED via pigeonhole + C\u2085 construction."
   },
   "overview": {
-    "historicalContext": "This problem was posed by Paul Erdős in 1961 [Er61] and remains one of the fundamental open questions in Ramsey theory. The multicolor Ramsey number R(3;k) generalizes the classical two-color Ramsey number R(3,3) = 6, which asks for the minimum n such that any 2-coloring of K_n's edges contains a monochromatic triangle.\n\nThe problem connects to several areas of combinatorics. The upper bound R(3;k) ≤ ⌈e·k!⌉ follows from a clever pigeonhole argument, while lower bounds come from connections to Schur numbers. A major breakthrough came in 2021 when Ageron, Casteras, Pellerin, Portella, Rimmel, and Tomasik [ACPPRT21] improved the lower bound to R(3;k) ≥ 380^{k/5} - O(1).\n\nErdős offered $250 for solving this problem, with an additional $100 specifically for proving that the limit is finite. The gap between known bounds is enormous: R(3;k) lies between roughly 3.28^k and k!, making this one of the most intriguing open problems in Ramsey theory.",
+    "historicalContext": "This problem was posed by Paul Erd\u0151s in 1961 [Er61] and remains one of the fundamental open questions in Ramsey theory. The multicolor Ramsey number R(3;k) generalizes the classical two-color Ramsey number R(3,3) = 6, which asks for the minimum n such that any 2-coloring of K_n's edges contains a monochromatic triangle.\n\nThe problem connects to several areas of combinatorics. The upper bound R(3;k) \u2264 \u2308e\u00b7k!\u2309 follows from a clever pigeonhole argument, while lower bounds come from connections to Schur numbers. A major breakthrough came in 2021 when Ageron, Casteras, Pellerin, Portella, Rimmel, and Tomasik [ACPPRT21] improved the lower bound to R(3;k) \u2265 380^{k/5} - O(1).\n\nErd\u0151s offered $250 for solving this problem, with an additional $100 specifically for proving that the limit is finite. The gap between known bounds is enormous: R(3;k) lies between roughly 3.28^k and k!, making this one of the most intriguing open problems in Ramsey theory.",
     "problemStatement": "Let $R(3;k)$ denote the minimum $n$ such that any $k$-coloring of the edges of the complete graph $K_n$ must contain a monochromatic triangle. Determine:\n\n$$\\lim_{k \\to \\infty} R(3;k)^{1/k}$$\n\n**Known bounds:**\n- Upper: $R(3;k) \\leq \\lceil e \\cdot k! \\rceil$\n- Lower: $R(3;k) \\geq 380^{k/5} - O(1)$\n\n**Reward:** $250 (plus $100 for proving the limit is finite)",
     "text": "Determine the limit of R(3;k)^{1/k} as k approaches infinity, where R(3;k) is the minimum n such that any k-coloring of the edges of K_n contains a monochromatic triangle.",
-    "proofStrategy": "The formalization defines R(3;k) as the minimum n forcing a monochromatic triangle in any k-coloring of K_n. We establish the existence of R(3;k) through an axiom (finiteness follows from the pigeonhole upper bound). The known small values R(3;1)=3, R(3;2)=6, R(3;3)=17 are axiomatized.\n\nThe upper bound uses the inductive relation R(3;k) ≤ 2 + k(R(3;k-1)-1), which unfolds to the factorial bound. The lower bound leverages connections to Schur numbers and the 2021 construction achieving 380^{k/5}.\n\nThe main question is formulated as Filter.Tendsto (fun k => R(3;k)^{1/k}) atTop (nhds L) for some limit L, or alternatively whether this tends to infinity.",
+    "proofStrategy": "The formalization defines R(3;k) as the minimum n forcing a monochromatic triangle in any k-coloring of K_n. We establish the existence of R(3;k) through an axiom (finiteness follows from the pigeonhole upper bound). The known small values R(3;1)=3, R(3;2)=6, R(3;3)=17 are axiomatized.\n\nThe upper bound uses the inductive relation R(3;k) \u2264 2 + k(R(3;k-1)-1), which unfolds to the factorial bound. The lower bound leverages connections to Schur numbers and the 2021 construction achieving 380^{k/5}.\n\nThe main question is formulated as Filter.Tendsto (fun k => R(3;k)^{1/k}) atTop (nhds L) for some limit L, or alternatively whether this tends to infinity.",
     "keyInsights": [
       "**Multicolor Generalization**: R(3;k) extends the classical R(3,3)=6 to k colors, asking when monochromatic triangles are unavoidable",
       "**Enormous Gap**: Known bounds span from exponential (3.28^k) to factorial (k!), leaving vast uncertainty about the true growth rate",
-      "**Schur Connection**: Lower bounds come from Schur numbers S(k), where R(3;k) ≥ S(k) + 2, linking sum-free colorings to triangle-free colorings",
-      "**Pigeonhole Upper Bound**: The relation R(3;k) ≤ 2 + k(R(3;k-1)-1) follows from considering color classes at a vertex",
+      "**Schur Connection**: Lower bounds come from Schur numbers S(k), where R(3;k) \u2265 S(k) + 2, linking sum-free colorings to triangle-free colorings",
+      "**Pigeonhole Upper Bound**: The relation R(3;k) \u2264 2 + k(R(3;k-1)-1) follows from considering color classes at a vertex",
       "**Open Questions**: Both whether the limit exists and whether it is finite remain unknown, each worth separate rewards"
     ],
     "prerequisites": [
@@ -103,63 +103,71 @@
       "startLine": 29,
       "endLine": 55,
       "summary": "Defines edge colorings, symmetry conditions, and monochromatic triangle predicates",
-      "mathContext": "Formal definition: Defines edge colorings, symmetry conditions, and monochromatic triangle predicates"
+      "mathContext": "Formal definition: Defines edge colorings, symmetry conditions, and monochromatic triangle predicates",
+      "id": "basic-definitions"
     },
     {
       "title": "Ramsey Number Definition",
       "startLine": 56,
       "endLine": 75,
       "summary": "Defines R(3;k) as the minimum n forcing monochromatic triangles",
-      "mathContext": "Formal definition: Defines R(3;k) as the minimum n forcing monochromatic triangles"
+      "mathContext": "Formal definition: Defines R(3;k) as the minimum n forcing monochromatic triangles",
+      "id": "ramsey-number-definition"
     },
     {
       "title": "Known Small Values",
       "startLine": 76,
       "endLine": 90,
       "summary": "States R(3;1)=3, R(3;2)=6, R(3;3)=17",
-      "mathContext": "Mathematical content: States R(3;1)=3, R(3;2)=6, R(3;3)=17"
+      "mathContext": "Mathematical content: States R(3;1)=3, R(3;2)=6, R(3;3)=17",
+      "id": "known-small-values"
     },
     {
       "title": "Upper Bound",
       "startLine": 91,
       "endLine": 112,
-      "summary": "The pigeonhole bound R(3;k) ≤ ⌈e·k!⌉",
-      "mathContext": "The pigeonhole bound R(3;k) $\\leq$ ⌈e·k!⌉"
+      "summary": "The pigeonhole bound R(3;k) \u2264 \u2308e\u00b7k!\u2309",
+      "mathContext": "The pigeonhole bound R(3;k) $\\leq$ \u2308e\u00b7k!\u2309",
+      "id": "upper-bound"
     },
     {
       "title": "Lower Bound",
       "startLine": 113,
       "endLine": 136,
       "summary": "Schur number connection and the 380^{k/5} lower bound",
-      "mathContext": "Schur number connection and the $$380^{{k/5}$}$ lower bound"
+      "mathContext": "Schur number connection and the $$380^{{k/5}$}$ lower bound",
+      "id": "lower-bound"
     },
     {
       "title": "Main Question",
       "startLine": 137,
       "endLine": 172,
       "summary": "The limit lim R(3;k)^{1/k} and its possible values",
-      "mathContext": "Mathematical content: The limit lim R(3;k)^{1/k} and its possible values"
+      "mathContext": "Mathematical content: The limit lim R(3;k)^{1/k} and its possible values",
+      "id": "main-question"
     },
     {
       "title": "Growth Rate Analysis",
       "startLine": 173,
       "endLine": 207,
       "summary": "Summary of bounds and the enormous gap",
-      "mathContext": "Bound: Summary of bounds and the enormous gap"
+      "mathContext": "Bound: Summary of bounds and the enormous gap",
+      "id": "growth-rate-analysis"
     },
     {
       "title": "Formal Statement",
       "startLine": 222,
       "endLine": 241,
       "summary": "Main theorem combining existence and bounds",
-      "mathContext": "Verified: Main theorem combining existence and bounds"
+      "mathContext": "Verified: Main theorem combining existence and bounds",
+      "id": "formal-statement"
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #183 on multicolor triangle Ramsey numbers. We define R(3;k), establish its basic properties, and formalize the known upper and lower bounds. The main open question asks for the limit of R(3;k)^{1/k}.",
+    "summary": "This formalization captures Erd\u0151s Problem #183 on multicolor triangle Ramsey numbers. We define R(3;k), establish its basic properties, and formalize the known upper and lower bounds. The main open question asks for the limit of R(3;k)^{1/k}.",
     "implications": "**Theoretical Significance**: The growth rate of R(3;k) is fundamental to understanding how combinatorial structures resist partitioning.\n\nA resolution would illuminate deep connections between Ramsey theory, Schur numbers, and extremal combinatorics. The $350 reward reflects the problem's difficulty and importance.",
     "openQuestions": [
-      "Does lim_{k→∞} R(3;k)^{1/k} exist?",
+      "Does lim_{k\u2192\u221e} R(3;k)^{1/k} exist?",
       "If the limit exists, is it finite?",
       "What is the exact value of R(3;4)?",
       "Can the lower bound 380^{k/5} be improved?",
@@ -183,12 +191,12 @@
   },
   "crossReferences": [
     {
-      "title": "Erdős Problem #165: Asymptotic Formula for R(3,k)",
-      "relationship": "Both concern triangle Ramsey numbers — #165 studies the two-color R(3,k), while #183 generalizes to the k-color R(3;k)",
+      "title": "Erd\u0151s Problem #165: Asymptotic Formula for R(3,k)",
+      "relationship": "Both concern triangle Ramsey numbers \u2014 #165 studies the two-color R(3,k), while #183 generalizes to the k-color R(3;k)",
       "targetId": "erdos-165"
     },
     {
-      "title": "Erdős Problem #166: Ramsey Number R(4,k) Lower Bound",
+      "title": "Erd\u0151s Problem #166: Ramsey Number R(4,k) Lower Bound",
       "relationship": "Both study growth rates of Ramsey numbers; #166 concerns R(4,k) lower bounds while #183 concerns the multicolor triangle Ramsey number R(3;k)",
       "targetId": "erdos-166"
     },

--- a/src/data/proofs/erdos-19-oq-01/meta.json
+++ b/src/data/proofs/erdos-19-oq-01/meta.json
@@ -1,67 +1,68 @@
 {
-    "id": "erdos-19-oq-01",
-    "title": "Explicit Bounds on the EFL Threshold",
-    "slug": "erdos-19-oq-01",
-    "description": "What is the explicit threshold N₀ such that the Kang-Kelly-Kühn-Methuku-Osthus asymptotic proof of the Erdős-Faber-Lovász conjecture takes over? This formalization defines the threshold, proves the finite reduction theorem (EFL reduces to checking finitely many cases in [10, N₀)), and establishes structural bounds.",
-    "meta": {
-        "author": "Kang, Kelly, Kühn, Methuku, Osthus (2021); Hindman (1981)",
-        "sourceUrl": "https://erdosproblems.com/19",
-        "date": "2021",
-        "status": "axiomatized",
-        "proofRepoPath": "Proofs/Erdos19OQ01Problem.lean",
-        "tags": [
-            "erdos",
-            "graph-theory",
-            "ramsey-theory",
-            "chromatic-number",
-            "combinatorics",
-            "research",
-            "open-problem"
-        ],
-        "badge": "axiom",
-        "sorries": 0,
-        "axiomCount": 3,
-        "assumptions": [
-            "kang_kelly_kuhn_methuku_osthus_asymptotic: EFL conjecture holds for all sufficiently large n (2021 result)",
-            "hindman_small_cases: EFL holds for n = 1 through 9 (case analysis, 1981)",
-            "kahn_asymptotic_bound: chi(G) <= (1+o(1))n for EFL graphs (1992 result)"
-        ],
-        "erdosNumber": 19,
-        "erdosUrl": "https://erdosproblems.com/19",
-        "erdosProblemStatus": "solved",
-        "erdosPrizeValue": "$500",
-        "dateAdded": "2026-03-29",
-        "mathlib_version": "4.26.0",
-        "mathlibDependencies": [
-            {
-                "theorem": "Nat.find",
-                "description": "Computes the minimum natural number satisfying a decidable predicate",
-                "module": "Mathlib.Order.WellFounded"
-            },
-            {
-                "theorem": "Nat.find_spec",
-                "description": "The value returned by Nat.find satisfies the predicate",
-                "module": "Mathlib.Order.WellFounded"
-            },
-            {
-                "theorem": "Nat.find_min",
-                "description": "Values below Nat.find do not satisfy the predicate",
-                "module": "Mathlib.Order.WellFounded"
-            },
-            {
-                "theorem": "Nat.find_le",
-                "description": "Nat.find returns at most any witness",
-                "module": "Mathlib.Order.WellFounded"
-            },
-            {
-                "theorem": "Finset",
-                "description": "Finite sets, used for clique representation",
-                "module": "Mathlib.Data.Finset.Basic"
-            }
-        ],
-        "parentProof": "erdos-19",
-        "openQuestionType": "extension",
-        "openQuestionOf": "erdos-19",
-        "lineCount": 394
-    }
+  "id": "erdos-19-oq-01",
+  "title": "Explicit Bounds on the EFL Threshold",
+  "slug": "erdos-19-oq-01",
+  "description": "What is the explicit threshold N\u2080 such that the Kang-Kelly-K\u00fchn-Methuku-Osthus asymptotic proof of the Erd\u0151s-Faber-Lov\u00e1sz conjecture takes over? This formalization defines the threshold, proves the finite reduction theorem (EFL reduces to checking finitely many cases in [10, N\u2080)), and establishes structural bounds.",
+  "meta": {
+    "author": "Kang, Kelly, K\u00fchn, Methuku, Osthus (2021); Hindman (1981)",
+    "sourceUrl": "https://erdosproblems.com/19",
+    "date": "2021",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos19OQ01Problem.lean",
+    "tags": [
+      "erdos",
+      "graph-theory",
+      "ramsey-theory",
+      "chromatic-number",
+      "combinatorics",
+      "research",
+      "open-problem"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 3,
+    "assumptions": [
+      "kang_kelly_kuhn_methuku_osthus_asymptotic: EFL conjecture holds for all sufficiently large n (2021 result)",
+      "hindman_small_cases: EFL holds for n = 1 through 9 (case analysis, 1981)",
+      "kahn_asymptotic_bound: chi(G) <= (1+o(1))n for EFL graphs (1992 result)"
+    ],
+    "erdosNumber": 19,
+    "erdosUrl": "https://erdosproblems.com/19",
+    "erdosProblemStatus": "solved",
+    "erdosPrizeValue": "$500",
+    "dateAdded": "2026-03-29",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.find",
+        "description": "Computes the minimum natural number satisfying a decidable predicate",
+        "module": "Mathlib.Order.WellFounded"
+      },
+      {
+        "theorem": "Nat.find_spec",
+        "description": "The value returned by Nat.find satisfies the predicate",
+        "module": "Mathlib.Order.WellFounded"
+      },
+      {
+        "theorem": "Nat.find_min",
+        "description": "Values below Nat.find do not satisfy the predicate",
+        "module": "Mathlib.Order.WellFounded"
+      },
+      {
+        "theorem": "Nat.find_le",
+        "description": "Nat.find returns at most any witness",
+        "module": "Mathlib.Order.WellFounded"
+      },
+      {
+        "theorem": "Finset",
+        "description": "Finite sets, used for clique representation",
+        "module": "Mathlib.Data.Finset.Basic"
+      }
+    ],
+    "parentProof": "erdos-19",
+    "openQuestionType": "extension",
+    "openQuestionOf": "erdos-19",
+    "lineCount": 394
+  },
+  "sections": []
 }

--- a/src/data/proofs/erdos-307-oq-02/meta.json
+++ b/src/data/proofs/erdos-307-oq-02/meta.json
@@ -2,14 +2,20 @@
   "id": "erdos-307-oq-02",
   "title": "Prime Reciprocal Products: Sorry Elimination",
   "slug": "erdos-307-oq-02",
-  "description": "Eliminates sorries and axioms from Erdős 307 formalization: proves product_rigidity (was axiom), one_helps_balance, and no_two_three_solution. Documents remaining work: p-adic disjointness and computational size bound.",
+  "description": "Eliminates sorries and axioms from Erd\u0151s 307 formalization: proves product_rigidity (was axiom), one_helps_balance, and no_two_three_solution. Documents remaining work: p-adic disjointness and computational size bound.",
   "meta": {
-    "author": "Research (sorry elimination for Erdős 307)",
+    "author": "Research (sorry elimination for Erd\u0151s 307)",
     "sourceUrl": "https://erdosproblems.com/307",
     "date": "2026",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos307OQ02.lean",
-    "tags": ["number-theory", "primes", "egyptian-fractions", "erdos", "research"],
+    "tags": [
+      "number-theory",
+      "primes",
+      "egyptian-fractions",
+      "erdos",
+      "research"
+    ],
     "badge": "axiom",
     "sorries": 1,
     "axiomCount": 0,
@@ -19,41 +25,78 @@
     "mathlib_version": "4.26.0",
     "originalContributions": [
       "product_rigidity proved (was axiom in parent)",
-      "one_helps_balance: reciprocalSum P > 1 when 1 ∈ P",
+      "one_helps_balance: reciprocalSum P > 1 when 1 \u2208 P",
       "no_two_three_solution: no |P|=2, |Q|=3 prime solution",
       "Documentation of remaining work (p-adic, computational)"
     ]
   },
   "overview": {
-    "historicalContext": "Erdős Problem #307 asks whether two finite sets of primes P, Q can satisfy (Σ 1/p)(Σ 1/q) = 1. The parent formalization has several sorry theorems and axioms. This file eliminates three of them.",
-    "problemStatement": "Can the sorry theorems in the Erdős 307 formalization be proved from Mathlib?",
+    "historicalContext": "Erd\u0151s Problem #307 asks whether two finite sets of primes P, Q can satisfy (\u03a3 1/p)(\u03a3 1/q) = 1. The parent formalization has several sorry theorems and axioms. This file eliminates three of them.",
+    "problemStatement": "Can the sorry theorems in the Erd\u0151s 307 formalization be proved from Mathlib?",
     "text": "Proves 3 of 5 sorry/axiom targets. The remaining two (p-adic disjointness, computational size bound) require infrastructure not yet available.",
     "proofStrategy": "product_rigidity is a trivial iff. one_helps_balance splits the sum at 1. no_two_three_solution uses the tight bound on 3 primes.",
     "keyInsights": [
       "product_rigidity was a trivial iff, not a deep result",
-      "3 distinct primes have reciprocal sum ≤ 31/30 (= 1/2 + 1/3 + 1/5)",
-      "Product of (≤ 5/6)(≤ 31/30) = 31/36 < 1 rules out small cases"
+      "3 distinct primes have reciprocal sum \u2264 31/30 (= 1/2 + 1/3 + 1/5)",
+      "Product of (\u2264 5/6)(\u2264 31/30) = 31/36 < 1 rules out small cases"
     ]
   },
   "sections": [
-    {"id": "setup", "title": "Setup", "summary": "Definitions from parent", "startLine": 22, "endLine": 40},
-    {"id": "three-primes", "title": "Bound for 3 Primes", "summary": "reciprocal sum ≤ 31/30 (1 sorry)", "startLine": 42, "endLine": 113},
-    {"id": "no-2-3", "title": "No |P|=2, |Q|=3 Solution", "summary": "Product ≤ 31/36 < 1", "startLine": 115, "endLine": 138},
-    {"id": "one-helps", "title": "1 Helps Balance", "summary": "Σ 1/p > 1 when 1 ∈ P", "startLine": 140, "endLine": 185},
-    {"id": "rigidity", "title": "Product Rigidity", "summary": "Trivial iff (axiom eliminated)", "startLine": 187, "endLine": 220}
+    {
+      "id": "setup",
+      "title": "Setup",
+      "summary": "Definitions from parent",
+      "startLine": 22,
+      "endLine": 40
+    },
+    {
+      "id": "three-primes",
+      "title": "Bound for 3 Primes",
+      "summary": "reciprocal sum \u2264 31/30 (1 sorry)",
+      "startLine": 42,
+      "endLine": 113
+    },
+    {
+      "id": "no-2-3",
+      "title": "No |P|=2, |Q|=3 Solution",
+      "summary": "Product \u2264 31/36 < 1",
+      "startLine": 115,
+      "endLine": 138
+    },
+    {
+      "id": "one-helps",
+      "title": "1 Helps Balance",
+      "summary": "\u03a3 1/p > 1 when 1 \u2208 P",
+      "startLine": 140,
+      "endLine": 185
+    },
+    {
+      "id": "rigidity",
+      "title": "Product Rigidity",
+      "summary": "Trivial iff (axiom eliminated)",
+      "startLine": 187,
+      "endLine": 220
+    }
   ],
   "conclusion": {
     "summary": "3 of 5 sorry/axiom targets eliminated. Remaining: prime_sets_disjoint (p-adic theory) and prime_set_size_lower_bound (computation).",
     "openQuestions": [
       "Prove prime_sets_disjoint via Mathlib's p-adic valuation",
-      "Compute Σ_{p≤281} 1/p ≥ 2 for the size bound"
-    ]
+      "Compute \u03a3_{p\u2264281} 1/p \u2265 2 for the size bound"
+    ],
+    "implications": ""
   },
   "crossReferences": [
-    {"targetId": "erdos-307", "relationship": "parent-problem", "description": "Parent: Erdős 307 formalization"}
+    {
+      "targetId": "erdos-307",
+      "relationship": "parent-problem",
+      "description": "Parent: Erd\u0151s 307 formalization"
+    }
   ],
   "leanFile": {
-    "imports": ["Mathlib"],
+    "imports": [
+      "Mathlib"
+    ],
     "namespace": "Erdos307OQ02",
     "lineCount": 261,
     "axiomCount": 0,

--- a/src/data/proofs/erdos-395-oq-01/meta.json
+++ b/src/data/proofs/erdos-395-oq-01/meta.json
@@ -1,43 +1,44 @@
 {
-    "id": "erdos-395-oq-01",
-    "title": "Optimal Constant in Reverse Littlewood-Offord",
-    "slug": "erdos-395-oq-01",
-    "description": "Structural theorems about the optimal constant c in the reverse Littlewood-Offord problem P(|sum| ≤ √2) ≥ c/n. Formalizes the critical role of the √2 threshold, monotonicity in threshold, tightness of the 1/n rate, and the counterexample exceeding threshold 1.",
-    "meta": {
-        "author": "He-Juškevičius-Narayanan-Spiro (2024), Carnielli-Carolino (2011)",
-        "sourceUrl": "https://erdosproblems.com/395",
-        "date": "2024",
-        "status": "axiomatized",
-        "proofRepoPath": "Proofs/Erdos395OQ01.lean",
-        "tags": [
-            "erdos",
-            "probability",
-            "complex-analysis",
-            "littlewood-offord",
-            "extension"
-        ],
-        "badge": "axiom",
-        "sorries": 2,
-        "erdosNumber": 395,
-        "erdosUrl": "https://erdosproblems.com/395",
-        "erdosProblemStatus": "open-question",
-        "dateAdded": "2026-03-29",
-        "axiomCount": 0,
-        "lineCount": 161,
-        "prerequisites": [
-            "Erdős Problem #395 parent formalization",
-            "Complex analysis and norms",
-            "Probability on finite sets"
-        ],
-        "assumptions": "4 axioms inherited from parent. 2 sorries: optimal_constant_pos (sSup bound), erdos_original_is_false_proved (Set.toFinset computation).",
-        "mathlib_version": "4.29.0",
-        "originalContributions": [
-            "Optimal constant c* defined via sSup",
-            "Counterexample exceeds threshold 1 (derived from parent axiom)",
-            "Monotonicity of counts in threshold parameter",
-            "√2 is critical: result holds at √2, fails at 1",
-            "Rate tightness summary from extremal example",
-            "Extremal example has unit vectors (proved)"
-        ]
-    }
+  "id": "erdos-395-oq-01",
+  "title": "Optimal Constant in Reverse Littlewood-Offord",
+  "slug": "erdos-395-oq-01",
+  "description": "Structural theorems about the optimal constant c in the reverse Littlewood-Offord problem P(|sum| \u2264 \u221a2) \u2265 c/n. Formalizes the critical role of the \u221a2 threshold, monotonicity in threshold, tightness of the 1/n rate, and the counterexample exceeding threshold 1.",
+  "meta": {
+    "author": "He-Ju\u0161kevi\u010dius-Narayanan-Spiro (2024), Carnielli-Carolino (2011)",
+    "sourceUrl": "https://erdosproblems.com/395",
+    "date": "2024",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos395OQ01.lean",
+    "tags": [
+      "erdos",
+      "probability",
+      "complex-analysis",
+      "littlewood-offord",
+      "extension"
+    ],
+    "badge": "axiom",
+    "sorries": 2,
+    "erdosNumber": 395,
+    "erdosUrl": "https://erdosproblems.com/395",
+    "erdosProblemStatus": "open-question",
+    "dateAdded": "2026-03-29",
+    "axiomCount": 0,
+    "lineCount": 161,
+    "prerequisites": [
+      "Erd\u0151s Problem #395 parent formalization",
+      "Complex analysis and norms",
+      "Probability on finite sets"
+    ],
+    "assumptions": "4 axioms inherited from parent. 2 sorries: optimal_constant_pos (sSup bound), erdos_original_is_false_proved (Set.toFinset computation).",
+    "mathlib_version": "4.29.0",
+    "originalContributions": [
+      "Optimal constant c* defined via sSup",
+      "Counterexample exceeds threshold 1 (derived from parent axiom)",
+      "Monotonicity of counts in threshold parameter",
+      "\u221a2 is critical: result holds at \u221a2, fails at 1",
+      "Rate tightness summary from extremal example",
+      "Extremal example has unit vectors (proved)"
+    ]
+  },
+  "sections": []
 }

--- a/src/data/proofs/erdos-525-oq-02/meta.json
+++ b/src/data/proofs/erdos-525-oq-02/meta.json
@@ -1,1 +1,56 @@
-{"id":"erdos-525-oq-02","title":"Multivariate Littlewood Polynomials","slug":"erdos-525-oq-02","description":"Explores higher-dimensional Littlewood polynomials on the d-torus T^d. The square-root cancellation heuristic predicts m(f) ≈ n^(-d/2). Open for d ≥ 2.","meta":{"author":"Konyagin (1994), Cook-Nguyen (2021)","sourceUrl":"https://erdosproblems.com/525","date":"2026","status":"axiomatized","proofRepoPath":"Proofs/Erdos525OQ02.lean","tags":["polynomials","random","littlewood","multivariate","erdos","research"],"badge":"axiom","sorries":1,"axiomCount":1,"lineCount":140,"assumptions":"1 axiom (1D bound), 1 sorry.","dateAdded":"2026-03-30","mathlib_version":"4.26.0","originalContributions":["Multivariate Littlewood polynomial framework","d-torus definition and minimum modulus","Dimension effect: n^d₁ < n^d₂ for d₁ < d₂","Square-root cancellation analysis"]},"conclusion":{"summary":"Multivariate Littlewood polynomials formalized. 1D solved; d≥2 open.","openQuestions":[]},"crossReferences":[{"targetId":"erdos-525","relationship":"parent-problem"}],"leanFile":{"imports":["Mathlib"],"namespace":"Erdos525OQ02","lineCount":140,"axiomCount":1,"theoremCount":4,"definitionCount":4}}
+{
+  "id": "erdos-525-oq-02",
+  "title": "Multivariate Littlewood Polynomials",
+  "slug": "erdos-525-oq-02",
+  "description": "Explores higher-dimensional Littlewood polynomials on the d-torus T^d. The square-root cancellation heuristic predicts m(f) \u2248 n^(-d/2). Open for d \u2265 2.",
+  "meta": {
+    "author": "Konyagin (1994), Cook-Nguyen (2021)",
+    "sourceUrl": "https://erdosproblems.com/525",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos525OQ02.lean",
+    "tags": [
+      "polynomials",
+      "random",
+      "littlewood",
+      "multivariate",
+      "erdos",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 1,
+    "axiomCount": 1,
+    "lineCount": 140,
+    "assumptions": "1 axiom (1D bound), 1 sorry.",
+    "dateAdded": "2026-03-30",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "Multivariate Littlewood polynomial framework",
+      "d-torus definition and minimum modulus",
+      "Dimension effect: n^d\u2081 < n^d\u2082 for d\u2081 < d\u2082",
+      "Square-root cancellation analysis"
+    ]
+  },
+  "conclusion": {
+    "summary": "Multivariate Littlewood polynomials formalized. 1D solved; d\u22652 open.",
+    "openQuestions": [],
+    "implications": ""
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-525",
+      "relationship": "parent-problem"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "Erdos525OQ02",
+    "lineCount": 140,
+    "axiomCount": 1,
+    "theoremCount": 4,
+    "definitionCount": 4
+  },
+  "sections": []
+}

--- a/src/data/proofs/erdos-606-oq-03/meta.json
+++ b/src/data/proofs/erdos-606-oq-03/meta.json
@@ -1,1 +1,54 @@
-{"id":"erdos-606-oq-03","title":"Hyperplane Determination in Higher Dimensions","slug":"erdos-606-oq-03","description":"Explores which hyperplane counts are achievable for n points in ℝ^d. Sylvester-Gallai, Green-Tao, and the gap problem.","meta":{"author":"Sylvester, Green-Tao, Motzkin","sourceUrl":"https://erdosproblems.com/606","date":"2026","status":"axiomatized","proofRepoPath":"Proofs/Erdos606OQ03.lean","tags":["combinatorial-geometry","hyperplanes","sylvester-gallai","erdos","research"],"badge":"axiom","sorries":0,"axiomCount":3,"lineCount":122,"assumptions":"3 axioms. 0 sorries.","dateAdded":"2026-03-30","mathlib_version":"4.26.0","originalContributions":["Max hyperplanes C(n,d), extremal bound n < C(n,d)","Sylvester-Gallai higher-dim framework","Achievable set analysis"]},"conclusion":{"summary":"Achievable hyperplane counts for n points in ℝ^d: between ~n and C(n,d). Full characterization open.","openQuestions":[]},"crossReferences":[{"targetId":"erdos-606","relationship":"parent-problem"}],"leanFile":{"imports":["Mathlib"],"namespace":"Erdos606OQ03","lineCount":122,"axiomCount":3,"theoremCount":4,"definitionCount":0}}
+{
+  "id": "erdos-606-oq-03",
+  "title": "Hyperplane Determination in Higher Dimensions",
+  "slug": "erdos-606-oq-03",
+  "description": "Explores which hyperplane counts are achievable for n points in \u211d^d. Sylvester-Gallai, Green-Tao, and the gap problem.",
+  "meta": {
+    "author": "Sylvester, Green-Tao, Motzkin",
+    "sourceUrl": "https://erdosproblems.com/606",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos606OQ03.lean",
+    "tags": [
+      "combinatorial-geometry",
+      "hyperplanes",
+      "sylvester-gallai",
+      "erdos",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 3,
+    "lineCount": 122,
+    "assumptions": "3 axioms. 0 sorries.",
+    "dateAdded": "2026-03-30",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "Max hyperplanes C(n,d), extremal bound n < C(n,d)",
+      "Sylvester-Gallai higher-dim framework",
+      "Achievable set analysis"
+    ]
+  },
+  "conclusion": {
+    "summary": "Achievable hyperplane counts for n points in \u211d^d: between ~n and C(n,d). Full characterization open.",
+    "openQuestions": [],
+    "implications": ""
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-606",
+      "relationship": "parent-problem"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "Erdos606OQ03",
+    "lineCount": 122,
+    "axiomCount": 3,
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "sections": []
+}

--- a/src/data/proofs/erdos-70-oq-01/meta.json
+++ b/src/data/proofs/erdos-70-oq-01/meta.json
@@ -58,5 +58,6 @@
     "parentProof": "erdos-70",
     "openQuestionType": "extension",
     "openQuestionOf": "erdos-70"
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/erdos-871/meta.json
+++ b/src/data/proofs/erdos-871/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-871",
-  "title": "Erdős Problem #871: Partitioning Additive Bases of Order 2",
+  "title": "Erd\u0151s Problem #871: Partitioning Additive Bases of Order 2",
   "slug": "erdos-871",
-  "description": "Can an additive basis A of order 2 with r_A(n) → ∞ be partitioned into two disjoint additive bases of order 2? DISPROVED by Daniel Larsen (2026).",
+  "description": "Can an additive basis A of order 2 with r_A(n) \u2192 \u221e be partitioned into two disjoint additive bases of order 2? DISPROVED by Daniel Larsen (2026).",
   "meta": {
     "author": "Daniel Larsen (2026)",
     "sourceUrl": "https://erdosproblems.com/871",
@@ -60,16 +60,16 @@
     "assumptions": "3 axiom(s): erdos_nathanson_1989, erdos_nathanson_positive, larsen_construction_blocking. See Lean source for complete statements."
   },
   "overview": {
-    "historicalContext": "This problem was posed by Erdős and Nathanson in 1988 and concerns partitioning additive bases. An additive basis of order 2 is a set A such that A + A covers all sufficiently large integers. The representation function r_A(n) counts how many ways n can be written as a + b with a, b ∈ A.\n\nErdős and Nathanson (1989) showed that for any fixed threshold t, there exists a basis A with r_A(n) ≥ t for all large n that cannot be partitioned into two disjoint bases. They also proved that partition IS possible when r_A(n) > c log n for c > (log 4/3)^{-1} ≈ 3.48.\n\nThe problem asked about the intermediate case: if r_A(n) → ∞ (growing without bound, but possibly slower than log n), can A always be partitioned? Daniel Larsen (2026) showed the answer is NO, disproving the conjecture using an AI-assisted proof with Claude Opus 4.5.",
+    "historicalContext": "This problem was posed by Erd\u0151s and Nathanson in 1988 and concerns partitioning additive bases. An additive basis of order 2 is a set A such that A + A covers all sufficiently large integers. The representation function r_A(n) counts how many ways n can be written as a + b with a, b \u2208 A.\n\nErd\u0151s and Nathanson (1989) showed that for any fixed threshold t, there exists a basis A with r_A(n) \u2265 t for all large n that cannot be partitioned into two disjoint bases. They also proved that partition IS possible when r_A(n) > c log n for c > (log 4/3)^{-1} \u2248 3.48.\n\nThe problem asked about the intermediate case: if r_A(n) \u2192 \u221e (growing without bound, but possibly slower than log n), can A always be partitioned? Daniel Larsen (2026) showed the answer is NO, disproving the conjecture using an AI-assisted proof with Claude Opus 4.5.",
     "problemStatement": "Let $A$ be an additive basis of order 2, meaning $A + A$ covers all sufficiently large integers. Let $r_A(n) = |\\{(a,b) \\in A \\times A : a + b = n\\}|$ be the representation function.\n\n**Question:** If $\\lim_{n \\to \\infty} r_A(n) = \\infty$, can $A$ always be partitioned into two disjoint additive bases of order 2?\n\n**Answer:** NO (Larsen 2026)",
-    "text": "Can an additive basis A of order 2 with r_A(n) → ∞ be partitioned into two disjoint additive bases of order 2? DISPROVED by Daniel Larsen (2026).",
-    "proofStrategy": "The formalization establishes the key definitions: additive basis, representation function, and partition into bases. The disproof uses a 'blocking property' construction: for any partition B ∪ C = A, infinitely many integers n fail to be covered by both B + B and C + C simultaneously.\n\nThe Larsen construction modifies the Erdős-Nathanson approach to ensure r_A(n) → ∞ while maintaining this blocking property. The formal proof shows that any set with the blocking property cannot be partitioned into two bases.",
+    "text": "Can an additive basis A of order 2 with r_A(n) \u2192 \u221e be partitioned into two disjoint additive bases of order 2? DISPROVED by Daniel Larsen (2026).",
+    "proofStrategy": "The formalization establishes the key definitions: additive basis, representation function, and partition into bases. The disproof uses a 'blocking property' construction: for any partition B \u222a C = A, infinitely many integers n fail to be covered by both B + B and C + C simultaneously.\n\nThe Larsen construction modifies the Erd\u0151s-Nathanson approach to ensure r_A(n) \u2192 \u221e while maintaining this blocking property. The formal proof shows that any set with the blocking property cannot be partitioned into two bases.",
     "keyInsights": [
-      "**Representation Function**: r_A(n) counts how many ways n = a + b with a, b ∈ A; it measures 'redundancy' of coverage",
-      "**Threshold vs Growth**: Having r_A(n) ≥ t (fixed) is too weak, while r_A(n) > c log n is strong enough for partition",
+      "**Representation Function**: r_A(n) counts how many ways n = a + b with a, b \u2208 A; it measures 'redundancy' of coverage",
+      "**Threshold vs Growth**: Having r_A(n) \u2265 t (fixed) is too weak, while r_A(n) > c log n is strong enough for partition",
       "**Blocking Property**: A construction prevents partition by ensuring for any split, some integers are missed by at least one part",
       "**AI-Assisted Discovery**: The counterexample was found using Claude Opus 4.5, demonstrating AI utility in mathematical research",
-      "**Gap Closure**: The result shows r_A(n) → ∞ behaves like the fixed-threshold case, not like the logarithmic case"
+      "**Gap Closure**: The result shows r_A(n) \u2192 \u221e behaves like the fixed-threshold case, not like the logarithmic case"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -83,64 +83,72 @@
       "startLine": 38,
       "endLine": 87,
       "summary": "Defines representation function, sumset, and additive basis of order 2",
-      "mathContext": "Formal definition: Defines representation function, sumset, and additive basis of order 2"
+      "mathContext": "Formal definition: Defines representation function, sumset, and additive basis of order 2",
+      "id": "core-definitions"
     },
     {
       "title": "Growth Conditions",
       "startLine": 88,
       "endLine": 116,
       "summary": "RepTendsToInfty and RepEventuallyGe conditions on r_A(n)",
-      "mathContext": "Mathematical content: RepTendsToInfty and RepEventuallyGe conditions on r_A(n)"
+      "mathContext": "Mathematical content: RepTendsToInfty and RepEventuallyGe conditions on r_A(n)",
+      "id": "growth-conditions"
     },
     {
       "title": "Partition Predicate",
       "startLine": 117,
       "endLine": 122,
       "summary": "Definition of CanPartitionIntoBases",
-      "mathContext": "Formal definition: Definition of CanPartitionIntoBases"
+      "mathContext": "Formal definition: Definition of CanPartitionIntoBases",
+      "id": "partition-predicate"
     },
     {
       "title": "The Conjecture",
       "startLine": 123,
       "endLine": 130,
-      "summary": "Formal statement of Erdős Problem #871",
-      "mathContext": "Mathematical content: Formal statement of Erdős Problem #871"
+      "summary": "Formal statement of Erd\u0151s Problem #871",
+      "mathContext": "Mathematical content: Formal statement of Erd\u0151s Problem #871",
+      "id": "the-conjecture"
     },
     {
-      "title": "Erdős-Nathanson Results",
+      "title": "Erd\u0151s-Nathanson Results",
       "startLine": 131,
       "endLine": 147,
       "summary": "1989 negative and positive results on partitioning",
-      "mathContext": "Mathematical content: 1989 negative and positive results on partitioning"
+      "mathContext": "Mathematical content: 1989 negative and positive results on partitioning",
+      "id": "erd\u0151s-nathanson-results"
     },
     {
       "title": "Larsen Counterexample",
       "startLine": 148,
       "endLine": 159,
       "summary": "The disproof axiom and main theorem",
-      "mathContext": "Verified: The disproof axiom and main theorem"
+      "mathContext": "Verified: The disproof axiom and main theorem",
+      "id": "larsen-counterexample"
     },
     {
       "title": "Blocking Property",
       "startLine": 182,
       "endLine": 226,
       "summary": "Technical blocking condition preventing partition",
-      "mathContext": "Mathematical content: Technical blocking condition preventing partition"
+      "mathContext": "Mathematical content: Technical blocking condition preventing partition",
+      "id": "blocking-property"
     },
     {
       "title": "Summary",
       "startLine": 227,
       "endLine": 425,
       "summary": "Overview of results and references",
-      "mathContext": "Mathematical content: Overview of results and references"
+      "mathContext": "Mathematical content: Overview of results and references",
+      "id": "summary"
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #871 has been DISPROVED. The conjecture that additive bases with r_A(n) → ∞ can always be partitioned into two disjoint bases is FALSE. Daniel Larsen (2026) constructed a counterexample using a modification of the Erdős-Nathanson blocking technique.",
-    "implications": "**Theoretical Significance**: The result clarifies the boundary between partitionable and non-partitionable bases.\n\nThe growth condition r_A(n) → ∞ is insufficient for partition; one needs faster growth like r_A(n) > c log n. This advances understanding of the structure of additive bases.",
+    "summary": "Erd\u0151s Problem #871 has been DISPROVED. The conjecture that additive bases with r_A(n) \u2192 \u221e can always be partitioned into two disjoint bases is FALSE. Daniel Larsen (2026) constructed a counterexample using a modification of the Erd\u0151s-Nathanson blocking technique.",
+    "implications": "**Theoretical Significance**: The result clarifies the boundary between partitionable and non-partitionable bases.\n\nThe growth condition r_A(n) \u2192 \u221e is insufficient for partition; one needs faster growth like r_A(n) > c log n. This advances understanding of the structure of additive bases.",
     "openQuestions": [
       "What is the minimal growth rate of r_A(n) that guarantees partition?",
-      "Is r_A(n) = ω(1) but r_A(n) = o(log n) the critical regime?",
+      "Is r_A(n) = \u03c9(1) but r_A(n) = o(log n) the critical regime?",
       "Can the blocking construction be made explicit?",
       "Are there other structural conditions that guarantee partition?",
       "What about partition into more than two bases?"
@@ -166,17 +174,17 @@
     {
       "targetId": "erdos-38",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: additive-basis, additive-combinatorics, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: additive-basis, additive-combinatorics, number-theory"
     },
     {
       "targetId": "erdos-40",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: additive-basis, additive-combinatorics, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: additive-basis, additive-combinatorics, number-theory"
     },
     {
       "targetId": "erdos-881",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: additive-basis, additive-combinatorics, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: additive-basis, additive-combinatorics, number-theory"
     }
   ]
 }

--- a/src/data/proofs/erdos-909-oq-01/meta.json
+++ b/src/data/proofs/erdos-909-oq-01/meta.json
@@ -1,38 +1,39 @@
 {
-    "id": "erdos-909-oq-01",
-    "title": "Characterize Dimension-Stable Spaces",
-    "slug": "erdos-909-oq-01",
-    "description": "Characterize all topological spaces S with dim(S × S) = dim(S). Anderson-Keisler showed such spaces exist for all n ≥ 1, but the structural criterion is unknown. This formalization defines dimension-stability, proves necessary conditions from the product inequality, handles the 0-dimensional case, and shows that dimension mismatch precludes stability.",
-    "meta": {
-        "author": "Anderson, Keisler (1967); Engelking (1978)",
-        "sourceUrl": "https://erdosproblems.com/909",
-        "date": "1967",
-        "status": "axiomatized",
-        "proofRepoPath": "Proofs/Erdos909OQ01Problem.lean",
-        "tags": [
-            "erdos",
-            "topology",
-            "dimension-theory",
-            "product-spaces",
-            "research",
-            "open-problem"
-        ],
-        "badge": "axiom",
-        "sorries": 0,
-        "axiomCount": 2,
-        "assumptions": [
-            "dimension_product_ineq: dim(X x Y) <= dim(X) + dim(Y)",
-            "anderson_keisler_existence: dimension-stable spaces exist for all n >= 1"
-        ],
-        "erdosNumber": 909,
-        "erdosUrl": "https://erdosproblems.com/909",
-        "erdosProblemStatus": "solved",
-        "dateAdded": "2026-03-29",
-        "mathlib_version": "4.26.0",
-        "mathlibDependencies": [],
-        "parentProof": "erdos-909",
-        "openQuestionType": "extension",
-        "openQuestionOf": "erdos-909",
-        "lineCount": 255
-    }
+  "id": "erdos-909-oq-01",
+  "title": "Characterize Dimension-Stable Spaces",
+  "slug": "erdos-909-oq-01",
+  "description": "Characterize all topological spaces S with dim(S \u00d7 S) = dim(S). Anderson-Keisler showed such spaces exist for all n \u2265 1, but the structural criterion is unknown. This formalization defines dimension-stability, proves necessary conditions from the product inequality, handles the 0-dimensional case, and shows that dimension mismatch precludes stability.",
+  "meta": {
+    "author": "Anderson, Keisler (1967); Engelking (1978)",
+    "sourceUrl": "https://erdosproblems.com/909",
+    "date": "1967",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos909OQ01Problem.lean",
+    "tags": [
+      "erdos",
+      "topology",
+      "dimension-theory",
+      "product-spaces",
+      "research",
+      "open-problem"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 2,
+    "assumptions": [
+      "dimension_product_ineq: dim(X x Y) <= dim(X) + dim(Y)",
+      "anderson_keisler_existence: dimension-stable spaces exist for all n >= 1"
+    ],
+    "erdosNumber": 909,
+    "erdosUrl": "https://erdosproblems.com/909",
+    "erdosProblemStatus": "solved",
+    "dateAdded": "2026-03-29",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [],
+    "parentProof": "erdos-909",
+    "openQuestionType": "extension",
+    "openQuestionOf": "erdos-909",
+    "lineCount": 255
+  },
+  "sections": []
 }

--- a/src/data/proofs/erdos-919/meta.json
+++ b/src/data/proofs/erdos-919/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-919",
-  "title": "Erdős Problem #919: Chromatic Numbers on Ordinal Products",
+  "title": "Erd\u0151s Problem #919: Chromatic Numbers on Ordinal Products",
   "slug": "erdos-919",
-  "description": "Is there a graph G on vertex set ω₂² with chromatic number ℵ₂ such that every subgraph of smaller order type has chromatic number at most ℵ₀?",
+  "description": "Is there a graph G on vertex set \u03c9\u2082\u00b2 with chromatic number \u2135\u2082 such that every subgraph of smaller order type has chromatic number at most \u2135\u2080?",
   "meta": {
-    "author": "Erdős",
+    "author": "Erd\u0151s",
     "sourceUrl": "https://erdosproblems.com/919",
     "status": "verified",
     "proofRepoPath": "Proofs/Erdos919Problem.lean",
@@ -48,25 +48,25 @@
       "Formal definitions for graphs on ordinal products",
       "Chromatic number formalization for infinite graphs",
       "Order type conditions for subgraphs",
-      "Erdős-Hajnal construction on ω₁²",
+      "Erd\u0151s-Hajnal construction on \u03c9\u2081\u00b2",
       "Generalization framework for cardinal parameters"
     ],
     "axiomCount": 0,
     "lineCount": 690,
-    "assumptions": "None. All results are fully machine-checked. The Erdős-Hajnal graphs on ω₁² and ω₂² are proved to have chromatic numbers ℵ₁ and ℵ₂ respectively via double pigeonhole arguments. The open questions (Questions 1 and 2) are stated but not assumed.",
+    "assumptions": "None. All results are fully machine-checked. The Erd\u0151s-Hajnal graphs on \u03c9\u2081\u00b2 and \u03c9\u2082\u00b2 are proved to have chromatic numbers \u2135\u2081 and \u2135\u2082 respectively via double pigeonhole arguments. The open questions (Questions 1 and 2) are stated but not assumed.",
     "theoremCount": 42
   },
   "overview": {
-    "historicalContext": "This problem was posed by Erdős in 1969 [Er69b] and sits at the intersection of graph theory, set theory, and infinite combinatorics. It was inspired by Babai's theorem about chromatic properties of graphs on well-ordered vertex sets.\n\nErdős and Hajnal made crucial progress by constructing a counterexample at the ℵ₁ level. They built a graph on ω₁² (the ordinal product of two copies of the first uncountable ordinal) with chromatic number ℵ₁, but where every strictly smaller subgraph (by order type) has countable chromatic number ≤ ℵ₀. This showed that Babai's theorem does not generalize to higher cardinals.\n\nThe natural question then arises: can we do the same construction at the next level? This is Problem #919: does there exist a graph on ω₂² with chromatic number ℵ₂ where smaller subgraphs have chromatic number at most ℵ₀ (not just ℵ₁)?",
-    "problemStatement": "Two questions about graphs on ordinal products:\n\n1. Is there a graph $G$ on vertex set $\\omega_2^2$ with $\\chi(G) = \\aleph_2$ such that every subgraph whose vertices have lesser order type has $\\chi \\leq \\aleph_0$?\n\n2. What if we instead ask for $\\chi(G) = \\aleph_1$?\n\n**Known:** Erdős-Hajnal constructed $G$ on $\\omega_1^2$ with $\\chi(G) = \\aleph_1$ and smaller subgraphs having $\\chi \\leq \\aleph_0$.",
-    "text": "Is there a graph G on vertex set ω₂² with chromatic number ℵ₂ such that every subgraph of smaller order type has chromatic number at most ℵ₀?",
-    "proofStrategy": "The formalization defines graphs on ordinal products ω₁² and ω₂² and proves both Erdős-Hajnal constructions have chromatic numbers exactly ℵ₁ and ℵ₂ respectively. Each proof uses second-coordinate coloring for the upper bound and a double pigeonhole argument for the lower bound:\n1. For each row α, some color has a large fiber (pigeonhole on row)\n2. Some color is dominant for many rows (pigeonhole on colors)\n3. Two such rows yield a monochromatic adjacent pair via cofinality\n\nThe ω₂² proof lifts the ω₁² argument one cardinal level: ℵ₁ plays the role of ℵ₀ throughout, using that initial segments of ω₂ have cardinality ≤ ℵ₁ and that sets of size > ℵ₁ are cofinal in ω₂.",
+    "historicalContext": "This problem was posed by Erd\u0151s in 1969 [Er69b] and sits at the intersection of graph theory, set theory, and infinite combinatorics. It was inspired by Babai's theorem about chromatic properties of graphs on well-ordered vertex sets.\n\nErd\u0151s and Hajnal made crucial progress by constructing a counterexample at the \u2135\u2081 level. They built a graph on \u03c9\u2081\u00b2 (the ordinal product of two copies of the first uncountable ordinal) with chromatic number \u2135\u2081, but where every strictly smaller subgraph (by order type) has countable chromatic number \u2264 \u2135\u2080. This showed that Babai's theorem does not generalize to higher cardinals.\n\nThe natural question then arises: can we do the same construction at the next level? This is Problem #919: does there exist a graph on \u03c9\u2082\u00b2 with chromatic number \u2135\u2082 where smaller subgraphs have chromatic number at most \u2135\u2080 (not just \u2135\u2081)?",
+    "problemStatement": "Two questions about graphs on ordinal products:\n\n1. Is there a graph $G$ on vertex set $\\omega_2^2$ with $\\chi(G) = \\aleph_2$ such that every subgraph whose vertices have lesser order type has $\\chi \\leq \\aleph_0$?\n\n2. What if we instead ask for $\\chi(G) = \\aleph_1$?\n\n**Known:** Erd\u0151s-Hajnal constructed $G$ on $\\omega_1^2$ with $\\chi(G) = \\aleph_1$ and smaller subgraphs having $\\chi \\leq \\aleph_0$.",
+    "text": "Is there a graph G on vertex set \u03c9\u2082\u00b2 with chromatic number \u2135\u2082 such that every subgraph of smaller order type has chromatic number at most \u2135\u2080?",
+    "proofStrategy": "The formalization defines graphs on ordinal products \u03c9\u2081\u00b2 and \u03c9\u2082\u00b2 and proves both Erd\u0151s-Hajnal constructions have chromatic numbers exactly \u2135\u2081 and \u2135\u2082 respectively. Each proof uses second-coordinate coloring for the upper bound and a double pigeonhole argument for the lower bound:\n1. For each row \u03b1, some color has a large fiber (pigeonhole on row)\n2. Some color is dominant for many rows (pigeonhole on colors)\n3. Two such rows yield a monochromatic adjacent pair via cofinality\n\nThe \u03c9\u2082\u00b2 proof lifts the \u03c9\u2081\u00b2 argument one cardinal level: \u2135\u2081 plays the role of \u2135\u2080 throughout, using that initial segments of \u03c9\u2082 have cardinality \u2264 \u2135\u2081 and that sets of size > \u2135\u2081 are cofinal in \u03c9\u2082.",
     "keyInsights": [
-      "**Ordinal Products**: ω₁² = ω₁ × ω₁ has rich structure; vertices can be compared by lexicographic order, enabling order-type constraints",
-      "**Babai's Failure**: The Erdős-Hajnal graph shows that chromatic constraints don't propagate from smaller to larger subgraphs at uncountable cardinals",
-      "**The Gap**: A graph on ω₂² with χ = ℵ₂ and smaller subgraphs having χ ≤ ℵ₁ exists, but achieving ≤ ℵ₀ remains open",
-      "**Two Questions**: Both χ = ℵ₂ and χ = ℵ₁ variants on ω₂² are interesting; they may have different answers",
-      "**General Framework**: The problem generalizes to arbitrary cardinals κ, λ, μ with the question of existence of such graphs"
+      "**Ordinal Products**: \u03c9\u2081\u00b2 = \u03c9\u2081 \u00d7 \u03c9\u2081 has rich structure; vertices can be compared by lexicographic order, enabling order-type constraints",
+      "**Babai's Failure**: The Erd\u0151s-Hajnal graph shows that chromatic constraints don't propagate from smaller to larger subgraphs at uncountable cardinals",
+      "**The Gap**: A graph on \u03c9\u2082\u00b2 with \u03c7 = \u2135\u2082 and smaller subgraphs having \u03c7 \u2264 \u2135\u2081 exists, but achieving \u2264 \u2135\u2080 remains open",
+      "**Two Questions**: Both \u03c7 = \u2135\u2082 and \u03c7 = \u2135\u2081 variants on \u03c9\u2082\u00b2 are interesting; they may have different answers",
+      "**General Framework**: The problem generalizes to arbitrary cardinals \u03ba, \u03bb, \u03bc with the question of existence of such graphs"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -79,72 +79,81 @@
       "title": "Basic Definitions",
       "startLine": 31,
       "endLine": 54,
-      "summary": "Defines ordinal products ω₁², ω₂² and graphs on vertex sets",
-      "mathContext": "Formal definition: Defines ordinal products ω₁², ω₂² and graphs on vertex sets"
+      "summary": "Defines ordinal products \u03c9\u2081\u00b2, \u03c9\u2082\u00b2 and graphs on vertex sets",
+      "mathContext": "Formal definition: Defines ordinal products \u03c9\u2081\u00b2, \u03c9\u2082\u00b2 and graphs on vertex sets",
+      "id": "basic-definitions"
     },
     {
       "title": "Chromatic Number",
       "startLine": 55,
       "endLine": 73,
       "summary": "Proper colorings and chromatic number for infinite graphs",
-      "mathContext": "Mathematical content: Proper colorings and chromatic number for infinite graphs"
+      "mathContext": "Mathematical content: Proper colorings and chromatic number for infinite graphs",
+      "id": "chromatic-number"
     },
     {
       "title": "Order Type and Subgraphs",
       "startLine": 74,
       "endLine": 89,
       "summary": "Order type of subsets and induced subgraphs",
-      "mathContext": "Mathematical content: Order type of subsets and induced subgraphs"
+      "mathContext": "Mathematical content: Order type of subsets and induced subgraphs",
+      "id": "order-type-and-subgraphs"
     },
     {
-      "title": "Erdős-Hajnal Construction",
+      "title": "Erd\u0151s-Hajnal Construction",
       "startLine": 90,
       "endLine": 108,
-      "summary": "The counterexample graph on ω₁² with χ = ℵ₁",
-      "mathContext": "Mathematical content: The counterexample graph on ω₁² with χ = ℵ₁"
+      "summary": "The counterexample graph on \u03c9\u2081\u00b2 with \u03c7 = \u2135\u2081",
+      "mathContext": "Mathematical content: The counterexample graph on \u03c9\u2081\u00b2 with \u03c7 = \u2135\u2081",
+      "id": "erd\u0151s-hajnal-construction"
     },
     {
       "title": "Main Questions",
       "startLine": 109,
       "endLine": 130,
-      "summary": "Question1 (χ = ℵ₂) and Question2 (χ = ℵ₁) for ω₂²",
-      "mathContext": "Mathematical content: Question1 (χ = ℵ₂) and Question2 (χ = ℵ₁) for ω₂²"
+      "summary": "Question1 (\u03c7 = \u2135\u2082) and Question2 (\u03c7 = \u2135\u2081) for \u03c9\u2082\u00b2",
+      "mathContext": "Mathematical content: Question1 (\u03c7 = \u2135\u2082) and Question2 (\u03c7 = \u2135\u2081) for \u03c9\u2082\u00b2",
+      "id": "main-questions"
     },
     {
       "title": "Partial Results",
       "startLine": 131,
       "endLine": 148,
-      "summary": "Construction with ℵ₁ bound (not ℵ₀)",
-      "mathContext": "Bound: Construction with ℵ₁ bound (not ℵ₀)"
+      "summary": "Construction with \u2135\u2081 bound (not \u2135\u2080)",
+      "mathContext": "Bound: Construction with \u2135\u2081 bound (not \u2135\u2080)",
+      "id": "partial-results"
     },
     {
       "title": "Generalization",
       "startLine": 149,
       "endLine": 171,
-      "summary": "General question for cardinals κ, λ, μ",
-      "mathContext": "Mathematical content: General question for cardinals κ, λ, μ"
+      "summary": "General question for cardinals \u03ba, \u03bb, \u03bc",
+      "mathContext": "Mathematical content: General question for cardinals \u03ba, \u03bb, \u03bc",
+      "id": "generalization"
     },
     {
       "title": "Babai Connection",
       "startLine": 172,
       "endLine": 193,
-      "summary": "Babai's theorem and why it fails at ω₁",
-      "mathContext": "Verified: Babai's theorem and why it fails at ω₁"
+      "summary": "Babai's theorem and why it fails at \u03c9\u2081",
+      "mathContext": "Verified: Babai's theorem and why it fails at \u03c9\u2081",
+      "id": "babai-connection"
     },
     {
       "title": "Formal Statement",
       "startLine": 224,
       "endLine": 241,
       "summary": "Main theorem combining both questions",
-      "mathContext": "Verified: Main theorem combining both questions"
+      "mathContext": "Verified: Main theorem combining both questions",
+      "id": "formal-statement"
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #919 on chromatic numbers of graphs on ordinal products. We define the framework for infinite graphs on ω₁² and ω₂², establish the Erdős-Hajnal construction as a key precedent, and pose both questions about ω₂².",
+    "summary": "This formalization captures Erd\u0151s Problem #919 on chromatic numbers of graphs on ordinal products. We define the framework for infinite graphs on \u03c9\u2081\u00b2 and \u03c9\u2082\u00b2, establish the Erd\u0151s-Hajnal construction as a key precedent, and pose both questions about \u03c9\u2082\u00b2.",
     "implications": "The problem illuminates deep connections between graph theory and set theory. A resolution would advance our understanding of how chromatic properties behave under set-theoretic constructions, potentially requiring sophisticated forcing or inner model techniques.",
     "openQuestions": [
-      "Does a graph on ω₂² with χ = ℵ₂ and smaller subgraphs having χ ≤ ℵ₀ exist?",
-      "Does a graph on ω₂² with χ = ℵ₁ and smaller subgraphs having χ ≤ ℵ₀ exist?",
+      "Does a graph on \u03c9\u2082\u00b2 with \u03c7 = \u2135\u2082 and smaller subgraphs having \u03c7 \u2264 \u2135\u2080 exist?",
+      "Does a graph on \u03c9\u2082\u00b2 with \u03c7 = \u2135\u2081 and smaller subgraphs having \u03c7 \u2264 \u2135\u2080 exist?",
       "Is the answer set-theoretically independent?",
       "What is the minimal cardinal gap achievable?",
       "How does the answer depend on large cardinal assumptions?"
@@ -174,17 +183,17 @@
     {
       "targetId": "erdos-111",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: chromatic-number, graph-theory, infinite-combinatorics, set-theory"
+      "description": "Related Erd\u0151s problem sharing themes: chromatic-number, graph-theory, infinite-combinatorics, set-theory"
     },
     {
       "targetId": "erdos-1067",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: chromatic-number, graph-theory, set-theory"
+      "description": "Related Erd\u0151s problem sharing themes: chromatic-number, graph-theory, set-theory"
     },
     {
       "targetId": "erdos-1068",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: chromatic-number, graph-theory, set-theory"
+      "description": "Related Erd\u0151s problem sharing themes: chromatic-number, graph-theory, set-theory"
     }
   ]
 }

--- a/src/data/proofs/euler-polyhedral-formula-oq-01-oq-02/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-01-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "euler-polyhedral-formula-oq-01-oq-02",
   "title": "Four Color Theorem: Survey for Lean 4 Formalization",
   "slug": "euler-polyhedral-formula-oq-01-oq-02",
-  "description": "Survey of re-formalizing Gonthier's Coq proof of the Four Color Theorem in Lean 4. Proves small cases (≤4 vertices, bipartite), assesses feasibility (~43K lines needed), and identifies starting points.",
+  "description": "Survey of re-formalizing Gonthier's Coq proof of the Four Color Theorem in Lean 4. Proves small cases (\u22644 vertices, bipartite), assesses feasibility (~43K lines needed), and identifies starting points.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -29,11 +29,12 @@
       "Planar graph formalization is the key missing infrastructure in Mathlib",
       "Five Color Theorem (~2000 lines) is a feasible intermediate target",
       "native_decide could replace much of the computational kernel"
-    ]
+    ],
+    "proofStrategy": "Survey: 4CT formalization requires ~43K lines. Proves small cases. Identifies starting points."
   },
   "conclusion": {
-    "summary": "A full 4CT in Lean 4 is a multi-year project. The recommended path: planar graphs → Five Color Theorem → reducibility framework → computational verification via native_decide.",
-    "implications": "A full 4CT in Lean 4 is a multi-year project. The recommended path: planar graphs → Five Color Theorem → reducibility framework → computational verification via native_decide."
+    "summary": "A full 4CT in Lean 4 is a multi-year project. The recommended path: planar graphs \u2192 Five Color Theorem \u2192 reducibility framework \u2192 computational verification via native_decide.",
+    "implications": "A full 4CT in Lean 4 is a multi-year project. The recommended path: planar graphs \u2192 Five Color Theorem \u2192 reducibility framework \u2192 computational verification via native_decide."
   },
   "leanFile": {
     "imports": [
@@ -53,5 +54,6 @@
       "relationship": "extends",
       "description": "Addresses 4CT question from Euler formula context"
     }
-  ]
+  ],
+  "sections": []
 }

--- a/src/data/proofs/factor-remainder-nullstellensatz-oq-01/meta.json
+++ b/src/data/proofs/factor-remainder-nullstellensatz-oq-01/meta.json
@@ -1,6 +1,6 @@
 {
   "id": "factor-remainder-nullstellensatz-oq-01",
-  "title": "Strong Nullstellensatz I(V(J)) = √J via Mathlib",
+  "title": "Strong Nullstellensatz I(V(J)) = \u221aJ via Mathlib",
   "slug": "factor-remainder-nullstellensatz-oq-01",
   "description": "Bridges the gallery's Factor-Remainder infrastructure to Mathlib's Nullstellensatz (MvPolynomial.vanishingIdeal_zeroLocus_eq_radical). Derives weak Nullstellensatz, membership criterion, and radical ideal correspondence as corollaries.",
   "meta": {
@@ -8,11 +8,17 @@
     "date": "1893",
     "status": "verified",
     "proofRepoPath": "Proofs/FactorRemainderNullstellensatzOQ01.lean",
-    "tags": ["algebra", "algebraic-geometry", "nullstellensatz", "polynomial-rings"],
+    "tags": [
+      "algebra",
+      "algebraic-geometry",
+      "nullstellensatz",
+      "polynomial-rings"
+    ],
     "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
     "lineCount": 85
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/fair-games-theorem-oq-02/meta.json
+++ b/src/data/proofs/fair-games-theorem-oq-02/meta.json
@@ -4,11 +4,18 @@
   "slug": "fair-games-theorem-oq-02",
   "description": "Concrete applications of the Optional Stopping Theorem: Gambler's Ruin with specific parameters and the doubling (martingale betting) strategy showing E[gain] = 0.",
   "meta": {
-    "author": "Paul Erdős et al.",
+    "author": "Paul Erd\u0151s et al.",
     "date": "1947",
     "status": "verified",
     "proofRepoPath": "Proofs/FairGamesTheoremOQ02.lean",
-    "tags": ["probability", "random-walk", "martingale", "gambling", "wiedijk-100", "classic"],
+    "tags": [
+      "probability",
+      "random-walk",
+      "martingale",
+      "gambling",
+      "wiedijk-100",
+      "classic"
+    ],
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
@@ -17,12 +24,17 @@
     "mathlib_version": "4.26.0"
   },
   "leanFile": {
-    "imports": ["Mathlib"],
-    "opens": ["FairGamesOQ01"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "FairGamesOQ01"
+    ],
     "namespace": "FairGamesOQ02",
     "lineCount": 159,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 5
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/fermats-last-theorem-oq-03/meta.json
+++ b/src/data/proofs/fermats-last-theorem-oq-03/meta.json
@@ -1,1 +1,53 @@
-{"id":"fermats-last-theorem-oq-03","title":"Fermat's Equation over Number Fields","slug":"fermats-last-theorem-oq-03","description":"Explores x^n + y^n = z^n over number fields. Wiles (ℚ), Freitas-Hung-Siksek (real quadratic), and the modularity obstruction.","meta":{"author":"Wiles, Freitas-Hung-Siksek","date":"2026","status":"axiomatized","proofRepoPath":"Proofs/FermatsLastTheoremOQ03.lean","tags":["number-theory","fermat","number-fields","research"],"badge":"axiom","sorries":0,"axiomCount":4,"lineCount":162,"assumptions":"4 axioms (FLT/ℚ, Freitas-Hung-Siksek, modularity obstruction, trivially true). 0 sorries.","dateAdded":"2026-03-30","mathlib_version":"4.26.0","originalContributions":["FermatEquation definition over arbitrary CommRing","Small exponent solutions (n=1,2)","Asymptotic FLT framework","Modularity obstruction analysis"]},"conclusion":{"summary":"FLT over number fields remains largely open. The modularity obstruction is the key difficulty.","openQuestions":[]},"crossReferences":[{"targetId":"fermats-last-theorem","relationship":"parent-problem"}],"leanFile":{"imports":["Mathlib"],"namespace":"FermatsLastTheoremOQ03","lineCount":162,"axiomCount":4,"theoremCount":4,"definitionCount":3}}
+{
+  "id": "fermats-last-theorem-oq-03",
+  "title": "Fermat's Equation over Number Fields",
+  "slug": "fermats-last-theorem-oq-03",
+  "description": "Explores x^n + y^n = z^n over number fields. Wiles (\u211a), Freitas-Hung-Siksek (real quadratic), and the modularity obstruction.",
+  "meta": {
+    "author": "Wiles, Freitas-Hung-Siksek",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/FermatsLastTheoremOQ03.lean",
+    "tags": [
+      "number-theory",
+      "fermat",
+      "number-fields",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 4,
+    "lineCount": 162,
+    "assumptions": "4 axioms (FLT/\u211a, Freitas-Hung-Siksek, modularity obstruction, trivially true). 0 sorries.",
+    "dateAdded": "2026-03-30",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "FermatEquation definition over arbitrary CommRing",
+      "Small exponent solutions (n=1,2)",
+      "Asymptotic FLT framework",
+      "Modularity obstruction analysis"
+    ]
+  },
+  "conclusion": {
+    "summary": "FLT over number fields remains largely open. The modularity obstruction is the key difficulty.",
+    "openQuestions": [],
+    "implications": ""
+  },
+  "crossReferences": [
+    {
+      "targetId": "fermats-last-theorem",
+      "relationship": "parent-problem"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "FermatsLastTheoremOQ03",
+    "lineCount": 162,
+    "axiomCount": 4,
+    "theoremCount": 4,
+    "definitionCount": 3
+  },
+  "sections": []
+}

--- a/src/data/proofs/four-color-theorem-oq-02/meta.json
+++ b/src/data/proofs/four-color-theorem-oq-02/meta.json
@@ -2,17 +2,23 @@
   "id": "four-color-theorem-oq-02",
   "title": "Minimal Unavoidable Reducible Configurations",
   "slug": "four-color-theorem-oq-02",
-  "description": "Formalizes the theory of unavoidable reducible configuration sets for the Four Color Theorem. Historical progression: Appel-Haken 1476 → RSST 633. Open: minimum size unknown.",
+  "description": "Formalizes the theory of unavoidable reducible configuration sets for the Four Color Theorem. Historical progression: Appel-Haken 1476 \u2192 RSST 633. Open: minimum size unknown.",
   "meta": {
     "author": "Robertson-Sanders-Seymour-Thomas (1997)",
     "date": "1997",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/FourColorTheoremOQ02.lean",
-    "tags": ["graph-theory", "four-color-theorem", "configurations", "computer-assisted-proof"],
+    "tags": [
+      "graph-theory",
+      "four-color-theorem",
+      "configurations",
+      "computer-assisted-proof"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 3,
     "lineCount": 110
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/fourier-series-oq-04/meta.json
+++ b/src/data/proofs/fourier-series-oq-04/meta.json
@@ -8,11 +8,17 @@
     "date": "1971",
     "status": "verified",
     "proofRepoPath": "Proofs/FourierSeriesOQ04.lean",
-    "tags": ["harmonic-analysis", "fourier-series", "convergence", "multi-dimensional"],
+    "tags": [
+      "harmonic-analysis",
+      "fourier-series",
+      "convergence",
+      "multi-dimensional"
+    ],
     "badge": "verified",
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
     "lineCount": 176
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/furstenberg-correspondence-oq-02/meta.json
+++ b/src/data/proofs/furstenberg-correspondence-oq-02/meta.json
@@ -15,7 +15,7 @@
       "decomposition",
       "feasibility-survey",
       "furstenberg",
-      "szemerédi"
+      "szemer\u00e9di"
     ],
     "badge": "axiom",
     "sorries": 0,
@@ -27,7 +27,7 @@
       },
       {
         "theorem": "MeasurePreserving.conservative",
-        "description": "Finite measure-preserving maps are conservative (Poincaré recurrence)",
+        "description": "Finite measure-preserving maps are conservative (Poincar\u00e9 recurrence)",
         "module": "Mathlib.Dynamics.Ergodic.Conservative"
       },
       {
@@ -48,9 +48,9 @@
     ],
     "originalContributions": [
       "Comprehensive survey of Mathlib v4.26.0 ergodic theory infrastructure",
-      "Definition of invariant σ-algebra with proof of σ-algebra properties",
+      "Definition of invariant \u03c3-algebra with proof of \u03c3-algebra properties",
       "Three-approach roadmap for ergodic decomposition (conditional expectation, Choquet, disintegration)",
-      "Feasibility assessment: ~1200–2500 lines depending on approach",
+      "Feasibility assessment: ~1200\u20132500 lines depending on approach",
       "Identification of key gap: Birkhoff ergodic theorem convergence",
       "Recommendation: Approach C (via Mathlib disintegration) minimizes effort"
     ],
@@ -70,47 +70,57 @@
   },
   "sections": [
     {
-      "title": "Mathlib's Ergodic Theory — What Exists",
+      "title": "Mathlib's Ergodic Theory \u2014 What Exists",
       "startLine": 70,
       "endLine": 145,
-      "description": "Demonstrates 7 key building blocks already in Mathlib: ergodic maps, extreme point characterization, Poincaré recurrence, RN derivative invariance, invariant function constancy, disintegration, Krein-Milman."
+      "description": "Demonstrates 7 key building blocks already in Mathlib: ergodic maps, extreme point characterization, Poincar\u00e9 recurrence, RN derivative invariance, invariant function constancy, disintegration, Krein-Milman.",
+      "summary": "Mathlib's Ergodic Theory \u2014 What Exists",
+      "id": "mathlib's-ergodic-theory-\u2014-wha"
     },
     {
-      "title": "The Gap — What's Needed",
+      "title": "The Gap \u2014 What's Needed",
       "startLine": 150,
       "endLine": 210,
-      "description": "Identifies three missing components: Birkhoff ergodic theorem, Choquet representation, and the connection between disintegration and invariant σ-algebra."
+      "description": "Identifies three missing components: Birkhoff ergodic theorem, Choquet representation, and the connection between disintegration and invariant \u03c3-algebra.",
+      "summary": "The Gap \u2014 What's Needed",
+      "id": "the-gap-\u2014-what's-needed"
     },
     {
-      "title": "Roadmap — Three Approaches",
+      "title": "Roadmap \u2014 Three Approaches",
       "startLine": 215,
       "endLine": 260,
-      "description": "Three paths to ergodic decomposition with line estimates: (A) conditional expectation ~1700 lines, (B) Choquet theory ~1700 lines, (C) existing disintegration ~1200 lines."
+      "description": "Three paths to ergodic decomposition with line estimates: (A) conditional expectation ~1700 lines, (B) Choquet theory ~1700 lines, (C) existing disintegration ~1200 lines.",
+      "summary": "Roadmap \u2014 Three Approaches",
+      "id": "roadmap-\u2014-three-approaches"
     },
     {
       "title": "Infrastructure Demonstration",
       "startLine": 265,
       "endLine": 310,
-      "description": "Defines the invariant σ-algebra in Lean 4 and proves basic properties (preimage stability, intersection closure)."
+      "description": "Defines the invariant \u03c3-algebra in Lean 4 and proves basic properties (preimage stability, intersection closure).",
+      "summary": "Infrastructure Demonstration",
+      "id": "infrastructure-demonstration"
     },
     {
       "title": "Feasibility Assessment",
       "startLine": 315,
       "endLine": 380,
-      "description": "Final assessment: YES, feasible. Recommends Approach C via Mathlib disintegration as the lowest-effort path (~1200 lines)."
+      "description": "Final assessment: YES, feasible. Recommends Approach C via Mathlib disintegration as the lowest-effort path (~1200 lines).",
+      "summary": "Feasibility Assessment",
+      "id": "feasibility-assessment"
     }
   ],
   "overview": {
-    "historicalContext": "The ergodic decomposition theorem is a fundamental result in ergodic theory, established in the mid-20th century. It states that every invariant measure can be uniquely decomposed into ergodic components. This is analogous to the spectral decomposition in linear algebra: just as every matrix can be decomposed into eigenspaces, every invariant measure decomposes into ergodic measures.\n\nThe theorem is a key stepping stone in Furstenberg's ergodic proof of Szemerédi's theorem (1977). The decomposition reduces the multiple recurrence theorem from general measure-preserving systems to the ergodic case, where structural analysis (compact extensions, weak mixing) can be applied.",
-    "problemStatement": "**Question**: Is it feasible to formalize the ergodic decomposition theorem using Lean 4 and Mathlib?\n\n**Ergodic Decomposition Theorem**: For a measure-preserving system (X, μ, T) on a standard Borel space, there exists a measurable family {μ_x} of probability measures such that:\n(a) μ_x is ergodic for T, for μ-a.e. x\n(b) μ = ∫ μ_x dμ(x)\n(c) μ_x-a.e. y: μ_y = μ_x (consistency)",
+    "historicalContext": "The ergodic decomposition theorem is a fundamental result in ergodic theory, established in the mid-20th century. It states that every invariant measure can be uniquely decomposed into ergodic components. This is analogous to the spectral decomposition in linear algebra: just as every matrix can be decomposed into eigenspaces, every invariant measure decomposes into ergodic measures.\n\nThe theorem is a key stepping stone in Furstenberg's ergodic proof of Szemer\u00e9di's theorem (1977). The decomposition reduces the multiple recurrence theorem from general measure-preserving systems to the ergodic case, where structural analysis (compact extensions, weak mixing) can be applied.",
+    "problemStatement": "**Question**: Is it feasible to formalize the ergodic decomposition theorem using Lean 4 and Mathlib?\n\n**Ergodic Decomposition Theorem**: For a measure-preserving system (X, \u03bc, T) on a standard Borel space, there exists a measurable family {\u03bc_x} of probability measures such that:\n(a) \u03bc_x is ergodic for T, for \u03bc-a.e. x\n(b) \u03bc = \u222b \u03bc_x d\u03bc(x)\n(c) \u03bc_x-a.e. y: \u03bc_y = \u03bc_x (consistency)",
     "text": "Survey of Mathlib's ergodic theory infrastructure for formalizing the ergodic decomposition theorem.",
-    "proofStrategy": "This is a **feasibility survey**, not a proof. We:\n\n1. **Audit Mathlib**: identify all relevant existing infrastructure (7 building blocks found)\n2. **Identify gaps**: Birkhoff ergodic theorem, Choquet representation, conditional measures\n3. **Propose roadmap**: three approaches with line estimates\n4. **Demonstrate**: define the invariant σ-algebra in Lean 4\n5. **Assess**: conclude feasibility is HIGH, recommend disintegration approach (~1200 lines)",
+    "proofStrategy": "This is a **feasibility survey**, not a proof. We:\n\n1. **Audit Mathlib**: identify all relevant existing infrastructure (7 building blocks found)\n2. **Identify gaps**: Birkhoff ergodic theorem, Choquet representation, conditional measures\n3. **Propose roadmap**: three approaches with line estimates\n4. **Demonstrate**: define the invariant \u03c3-algebra in Lean 4\n5. **Assess**: conclude feasibility is HIGH, recommend disintegration approach (~1200 lines)",
     "keyInsights": [
       "**Mathlib has the mathematical backbone**: Ergodic = extreme point of invariant measures (Extreme.lean) + Krein-Milman = the convex geometry of ergodic decomposition is already formalized",
-      "**Disintegration approach is most efficient**: Mathlib's Kernel.Disintegration provides the measure-theoretic machinery, needing only the connection to the invariant σ-algebra",
+      "**Disintegration approach is most efficient**: Mathlib's Kernel.Disintegration provides the measure-theoretic machinery, needing only the connection to the invariant \u03c3-algebra",
       "**Birkhoff ergodic theorem is the main blocker**: Needed for all approaches and independently valuable for Mathlib",
-      "**Impact**: completing ergodic decomposition would reduce Szemerédi's theorem to just the correspondence axiom (~500 lines)",
-      "**Invariant σ-algebra is clean in Lean 4**: the definition and basic properties work naturally"
+      "**Impact**: completing ergodic decomposition would reduce Szemer\u00e9di's theorem to just the correspondence axiom (~500 lines)",
+      "**Invariant \u03c3-algebra is clean in Lean 4**: the definition and basic properties work naturally"
     ],
     "prerequisites": [
       "Measure theory (Mathlib.MeasureTheory)",
@@ -125,7 +135,7 @@
   },
   "conclusion": {
     "summary": "The ergodic decomposition theorem IS feasible to formalize in Lean 4 with Mathlib v4.26.0. Mathlib provides 7 key building blocks including the critical characterization of ergodic measures as extreme points. Three approaches are viable, with the disintegration approach estimated at ~1200 lines. The main technical gap is the Birkhoff ergodic theorem.",
-    "implications": "Completing the ergodic decomposition would unlock the full Furstenberg program: multiple recurrence for all k, reducing Szemerédi's theorem to just the correspondence principle.",
+    "implications": "Completing the ergodic decomposition would unlock the full Furstenberg program: multiple recurrence for all k, reducing Szemer\u00e9di's theorem to just the correspondence principle.",
     "openQuestions": [
       "Can the Birkhoff ergodic theorem be contributed to Mathlib as a standalone result?",
       "Is the disintegration in Mathlib sufficient for the ergodic decomposition, or does it need extension?"
@@ -133,12 +143,12 @@
   },
   "crossReferences": [
     {
-      "relationship": "The ergodic decomposition is needed to eliminate Axiom 2 (multiple recurrence for k≥3) from the Furstenberg correspondence formalization",
+      "relationship": "The ergodic decomposition is needed to eliminate Axiom 2 (multiple recurrence for k\u22653) from the Furstenberg correspondence formalization",
       "sharedConcepts": [
         "ergodic-theory",
         "measure-preserving",
         "multiple-recurrence",
-        "szemerédi"
+        "szemer\u00e9di"
       ],
       "targetId": "furstenberg-correspondence"
     },

--- a/src/data/proofs/geometric-series-oq-02-oq-03/meta.json
+++ b/src/data/proofs/geometric-series-oq-02-oq-03/meta.json
@@ -41,15 +41,16 @@
     ]
   },
   "overview": {
-    "historicalContext": "The openness of the unit group in a Banach algebra is a fundamental result in functional analysis, first established rigorously by Gel'fand (1941). The proof relies on the Neumann series — the operator-theoretic generalization of the geometric series. Kato's perturbation theory (1966) systematically develops the consequences: if A is invertible and B is close enough to A, the Neumann series for A⁻¹(A-B) converges, giving an explicit inverse for B. This result underpins spectral theory, resolvent calculus, and numerical stability analysis.",
+    "historicalContext": "The openness of the unit group in a Banach algebra is a fundamental result in functional analysis, first established rigorously by Gel'fand (1941). The proof relies on the Neumann series \u2014 the operator-theoretic generalization of the geometric series. Kato's perturbation theory (1966) systematically develops the consequences: if A is invertible and B is close enough to A, the Neumann series for A\u207b\u00b9(A-B) converges, giving an explicit inverse for B. This result underpins spectral theory, resolvent calculus, and numerical stability analysis.",
     "problemStatement": "Prove that the unit group of a complete normed ring is open and the inversion map is locally bounded, as corollaries of the Neumann series perturbation theorem.",
     "text": "Unit group topology: openness of invertible elements and local boundedness of inversion in complete normed rings.",
-    "proofStrategy": "All results follow from the perturbation theorem `invertible_near_one` (from OQ-02): if ‖1 - B‖ < 1 then B is a unit. For a general unit A, write B = A(1 - A⁻¹(A-B)) and bound ‖A⁻¹(A-B)‖ ≤ ‖A⁻¹‖‖A-B‖ < 1. Norm bounds come from the Neumann series: ‖B⁻¹‖ ≤ (1 - ‖1-B‖)⁻¹.",
+    "proofStrategy": "All results follow from the perturbation theorem `invertible_near_one` (from OQ-02): if \u20161 - B\u2016 < 1 then B is a unit. For a general unit A, write B = A(1 - A\u207b\u00b9(A-B)) and bound \u2016A\u207b\u00b9(A-B)\u2016 \u2264 \u2016A\u207b\u00b9\u2016\u2016A-B\u2016 < 1. Norm bounds come from the Neumann series: \u2016B\u207b\u00b9\u2016 \u2264 (1 - \u20161-B\u2016)\u207b\u00b9.",
     "keyInsights": [
-      "The unit group is open with explicit radius: B(A, ‖A⁻¹‖⁻¹) consists of units",
-      "Perturbed inverses have Neumann series representations: B⁻¹ = ∑(1-B)^n near 1",
-      "Norm bound: ‖B⁻¹‖ ≤ (1 - ‖1-B‖)⁻¹ gives quantitative control",
-      "The proof is purely algebraic + metric — works in any complete normed ring"
+      "The unit group is open with explicit radius: B(A, \u2016A\u207b\u00b9\u2016\u207b\u00b9) consists of units",
+      "Perturbed inverses have Neumann series representations: B\u207b\u00b9 = \u2211(1-B)^n near 1",
+      "Norm bound: \u2016B\u207b\u00b9\u2016 \u2264 (1 - \u20161-B\u2016)\u207b\u00b9 gives quantitative control",
+      "The proof is purely algebraic + metric \u2014 works in any complete normed ring"
     ]
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/hilbert-20-oq-01/meta.json
+++ b/src/data/proofs/hilbert-20-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "hilbert-20-oq-01",
   "title": "Hilbert's 20th Problem OQ-01: Characterization of Locally Solvable Operators",
   "slug": "hilbert-20-oq-01",
-  "description": "What is the precise characterization of locally solvable operators? Answered by the Nirenberg-Treves conjecture, proved by Dencker (2006): condition (Ψ) on the principal symbol is necessary and sufficient for local solvability of principal-type operators.",
+  "description": "What is the precise characterization of locally solvable operators? Answered by the Nirenberg-Treves conjecture, proved by Dencker (2006): condition (\u03a8) on the principal symbol is necessary and sufficient for local solvability of principal-type operators.",
   "meta": {
     "author": "Nirenberg-Treves (1963), Dencker (2006)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Nirenberg%E2%80%93Treves_conjecture",
@@ -28,19 +28,19 @@
       },
       {
         "theorem": "fderiv",
-        "description": "Fréchet derivatives",
+        "description": "Fr\u00e9chet derivatives",
         "module": "Mathlib.Analysis.Calculus.FDeriv.Basic"
       }
     ],
     "originalContributions": [
       "Formalization of linear partial differential operators via multi-index coefficients",
       "Definition of principal symbol as a function on the cotangent bundle",
-      "Formalization of condition (Ψ) on bicharacteristic curves",
+      "Formalization of condition (\u03a8) on bicharacteristic curves",
       "Statement of the Nirenberg-Treves characterization theorem",
       "Proof that elliptic operators of principal type are locally solvable"
     ],
     "axiomCount": 7,
-    "assumptions": "7 axioms: IsLocallySolvable, BicharacteristicCurve, imSymbolAlongCurve, imSymbolAlongCurve_eq (bridge: curve evaluation = principal symbol Im), hormander_necessity (Hörmander 1960), dencker_sufficiency (Dencker 2006), elliptic_satisfies_psi. These encode deep results from microlocal analysis.",
+    "assumptions": "7 axioms: IsLocallySolvable, BicharacteristicCurve, imSymbolAlongCurve, imSymbolAlongCurve_eq (bridge: curve evaluation = principal symbol Im), hormander_necessity (H\u00f6rmander 1960), dencker_sufficiency (Dencker 2006), elliptic_satisfies_psi. These encode deep results from microlocal analysis.",
     "lineCount": 189,
     "prerequisites": [
       "Partial differential equations",
@@ -50,14 +50,14 @@
     ]
   },
   "overview": {
-    "historicalContext": "The question of which PDEs have local solutions was dramatically transformed by Lewy's 1957 example of a smooth linear PDE with no local solutions. Hörmander (1960) found a necessary condition via the principal symbol. Nirenberg and Treves (1963) conjectured that condition (Ψ) — a sign condition on the imaginary part of the principal symbol along bicharacteristic curves — gives the full characterization. This was proved by Dencker in 2006.",
-    "problemStatement": "What is the precise characterization of locally solvable operators? That is, given a linear partial differential operator P, when does the equation Pu = f have a distribution solution u near a point x₀ for every smooth f?",
-    "text": "We formalize the answer: for operators of principal type, local solvability is equivalent to condition (Ψ) on the principal symbol.",
-    "proofStrategy": "Define linear PDOs, principal symbols, local solvability, principal type, and condition (Ψ). State the Hörmander necessity and Dencker sufficiency as axioms, then derive the characterization. Show elliptic operators as a key special case.",
+    "historicalContext": "The question of which PDEs have local solutions was dramatically transformed by Lewy's 1957 example of a smooth linear PDE with no local solutions. H\u00f6rmander (1960) found a necessary condition via the principal symbol. Nirenberg and Treves (1963) conjectured that condition (\u03a8) \u2014 a sign condition on the imaginary part of the principal symbol along bicharacteristic curves \u2014 gives the full characterization. This was proved by Dencker in 2006.",
+    "problemStatement": "What is the precise characterization of locally solvable operators? That is, given a linear partial differential operator P, when does the equation Pu = f have a distribution solution u near a point x\u2080 for every smooth f?",
+    "text": "We formalize the answer: for operators of principal type, local solvability is equivalent to condition (\u03a8) on the principal symbol.",
+    "proofStrategy": "Define linear PDOs, principal symbols, local solvability, principal type, and condition (\u03a8). State the H\u00f6rmander necessity and Dencker sufficiency as axioms, then derive the characterization. Show elliptic operators as a key special case.",
     "keyInsights": [
-      "The principal symbol p_m(x, ξ) encodes the leading-order behavior of the operator",
-      "Condition (Ψ): Im(p_m) cannot change sign from − to + along bicharacteristics of Re(p_m)",
-      "Elliptic operators satisfy (Ψ) vacuously since p_m never vanishes for nonzero ξ",
+      "The principal symbol p_m(x, \u03be) encodes the leading-order behavior of the operator",
+      "Condition (\u03a8): Im(p_m) cannot change sign from \u2212 to + along bicharacteristics of Re(p_m)",
+      "Elliptic operators satisfy (\u03a8) vacuously since p_m never vanishes for nonzero \u03be",
       "The Nirenberg-Treves conjecture took 43 years to prove (1963-2006)"
     ],
     "prerequisites": [
@@ -73,7 +73,8 @@
       "lineStart": 46,
       "lineEnd": 76,
       "theorems": [],
-      "summary": "Linear Differential Operators"
+      "summary": "Linear Differential Operators",
+      "id": "linear-differential-operators"
     },
     {
       "title": "Local Solvability",
@@ -81,39 +82,43 @@
       "lineStart": 78,
       "lineEnd": 98,
       "theorems": [],
-      "summary": "Local Solvability"
+      "summary": "Local Solvability",
+      "id": "local-solvability"
     },
     {
-      "title": "Condition (Ψ)",
-      "content": "Define bicharacteristic curves, the imaginary part of the symbol along them, and condition (Ψ).",
+      "title": "Condition (\u03a8)",
+      "content": "Define bicharacteristic curves, the imaginary part of the symbol along them, and condition (\u03a8).",
       "lineStart": 100,
       "lineEnd": 122,
       "theorems": [],
-      "summary": "Condition (Ψ)"
+      "summary": "Condition (\u03a8)",
+      "id": "condition-\u03c8"
     },
     {
       "title": "The Nirenberg-Treves Theorem",
-      "content": "State the Hörmander necessity and Dencker sufficiency, then derive the full characterization.",
+      "content": "State the H\u00f6rmander necessity and Dencker sufficiency, then derive the full characterization.",
       "lineStart": 124,
       "lineEnd": 152,
       "theorems": [
         "nirenberg_treves_characterization"
       ],
-      "summary": "The Nirenberg-Treves Theorem"
+      "summary": "The Nirenberg-Treves Theorem",
+      "id": "the-nirenberg-treves-theorem"
     },
     {
       "title": "Special Cases",
-      "content": "Show that elliptic operators and operators with real principal symbols satisfy condition (Ψ), hence are locally solvable.",
+      "content": "Show that elliptic operators and operators with real principal symbols satisfy condition (\u03a8), hence are locally solvable.",
       "lineStart": 154,
       "lineEnd": 181,
       "theorems": [
         "elliptic_locally_solvable"
       ],
-      "summary": "Special Cases"
+      "summary": "Special Cases",
+      "id": "special-cases"
     }
   ],
   "conclusion": {
-    "summary": "We formalize the answer to Hilbert's 20th problem OQ-01: the Nirenberg-Treves conjecture (proved by Dencker, 2006) gives the precise characterization of locally solvable operators. For principal-type operators, local solvability is equivalent to condition (Ψ) on the principal symbol.",
+    "summary": "We formalize the answer to Hilbert's 20th problem OQ-01: the Nirenberg-Treves conjecture (proved by Dencker, 2006) gives the precise characterization of locally solvable operators. For principal-type operators, local solvability is equivalent to condition (\u03a8) on the principal symbol.",
     "implications": [
       "Provides a formal framework for local solvability of PDEs in Lean 4",
       "Demonstrates the principal symbol as the key invariant for solvability",
@@ -121,25 +126,25 @@
     ],
     "openQuestions": [
       "Can the microlocal analysis infrastructure be built to remove the axioms?",
-      "What is the analogue of condition (Ψ) for systems of PDEs?",
+      "What is the analogue of condition (\u03a8) for systems of PDEs?",
       "Can Dencker's proof be formalized using Lean 4 and Mathlib?"
     ]
   },
   "crossReferences": [
     {
       "id": "hilbert-20",
-      "relationship": "Parent problem — Hilbert's 20th problem on boundary value problems"
+      "relationship": "Parent problem \u2014 Hilbert's 20th problem on boundary value problems"
     }
   ],
   "references": [
     {
       "key": "Hormander1960",
-      "citation": "L. Hörmander, Differential operators of principal type, Math. Ann. 140 (1960), 124-146.",
+      "citation": "L. H\u00f6rmander, Differential operators of principal type, Math. Ann. 140 (1960), 124-146.",
       "url": ""
     },
     {
       "key": "NT1963",
-      "citation": "L. Nirenberg and F. Trèves, On local solvability of linear partial differential equations, Comm. Pure Appl. Math. 16 (1963), 331-351.",
+      "citation": "L. Nirenberg and F. Tr\u00e8ves, On local solvability of linear partial differential equations, Comm. Pure Appl. Math. 16 (1963), 331-351.",
       "url": ""
     },
     {

--- a/src/data/proofs/hilbert-22-oq-01/meta.json
+++ b/src/data/proofs/hilbert-22-oq-01/meta.json
@@ -1,1 +1,81 @@
-{"id":"hilbert-22-oq-01","title":"Higher-Dimensional Uniformization","slug":"hilbert-22-oq-01","description":"Explores how the uniformization theorem generalizes to higher dimensions via Kodaira dimension, Yau's theorem, and Kobayashi hyperbolicity.","meta":{"author":"Kodaira, Yau, Kobayashi","date":"2026","status":"axiomatized","proofRepoPath":"Proofs/Hilbert22OQ01.lean","tags":["complex-geometry","uniformization","classification","research"],"badge":"axiom","sorries":1,"axiomCount":3,"lineCount":175,"assumptions":"3 axioms (Yau, Kobayashi), 1 sorry.","dateAdded":"2026-03-30","mathlib_version":"4.26.0","originalContributions":["Kodaira dimension as classification invariant","Enriques-Kodaira surface classification","Analogy table: 1D uniformization → higher-dim Kodaira"]},"sections":[{"id":"kodaira","title":"Kodaira Dimension","startLine":28,"endLine":55},{"id":"surfaces","title":"Surface Classification","startLine":57,"endLine":90},{"id":"yau","title":"Yau's Theorem","startLine":92,"endLine":110},{"id":"kobayashi","title":"Kobayashi Hyperbolicity","startLine":112,"endLine":140}],"conclusion":{"summary":"Higher-dimensional uniformization explored via Kodaira dimension and Yau's theorem.","openQuestions":[]},"crossReferences":[{"targetId":"hilbert-22","relationship":"parent-problem"}],"leanFile":{"imports":["Mathlib"],"namespace":"Hilbert22OQ01","lineCount":175,"axiomCount":3,"theoremCount":1,"definitionCount":6}}
+{
+  "id": "hilbert-22-oq-01",
+  "title": "Higher-Dimensional Uniformization",
+  "slug": "hilbert-22-oq-01",
+  "description": "Explores how the uniformization theorem generalizes to higher dimensions via Kodaira dimension, Yau's theorem, and Kobayashi hyperbolicity.",
+  "meta": {
+    "author": "Kodaira, Yau, Kobayashi",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Hilbert22OQ01.lean",
+    "tags": [
+      "complex-geometry",
+      "uniformization",
+      "classification",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 1,
+    "axiomCount": 3,
+    "lineCount": 175,
+    "assumptions": "3 axioms (Yau, Kobayashi), 1 sorry.",
+    "dateAdded": "2026-03-30",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "Kodaira dimension as classification invariant",
+      "Enriques-Kodaira surface classification",
+      "Analogy table: 1D uniformization \u2192 higher-dim Kodaira"
+    ]
+  },
+  "sections": [
+    {
+      "id": "kodaira",
+      "title": "Kodaira Dimension",
+      "startLine": 28,
+      "endLine": 55,
+      "summary": "Kodaira Dimension"
+    },
+    {
+      "id": "surfaces",
+      "title": "Surface Classification",
+      "startLine": 57,
+      "endLine": 90,
+      "summary": "Surface Classification"
+    },
+    {
+      "id": "yau",
+      "title": "Yau's Theorem",
+      "startLine": 92,
+      "endLine": 110,
+      "summary": "Yau's Theorem"
+    },
+    {
+      "id": "kobayashi",
+      "title": "Kobayashi Hyperbolicity",
+      "startLine": 112,
+      "endLine": 140,
+      "summary": "Kobayashi Hyperbolicity"
+    }
+  ],
+  "conclusion": {
+    "summary": "Higher-dimensional uniformization explored via Kodaira dimension and Yau's theorem.",
+    "openQuestions": [],
+    "implications": ""
+  },
+  "crossReferences": [
+    {
+      "targetId": "hilbert-22",
+      "relationship": "parent-problem"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "Hilbert22OQ01",
+    "lineCount": 175,
+    "axiomCount": 3,
+    "theoremCount": 1,
+    "definitionCount": 6
+  }
+}

--- a/src/data/proofs/intermediate-value-theorem-oq-03/meta.json
+++ b/src/data/proofs/intermediate-value-theorem-oq-03/meta.json
@@ -1,1 +1,73 @@
-{"id":"intermediate-value-theorem-oq-03","title":"IVT and Brouwer Fixed Point Connection","slug":"intermediate-value-theorem-oq-03","description":"Explores the equivalence of IVT and Brouwer in 1D, and why Brouwer is strictly stronger in higher dimensions. Proves the 1D case via g(x) = f(x) - x.","meta":{"author":"Classical topology","date":"2026","status":"axiomatized","proofRepoPath":"Proofs/IntermediateValueTheoremOQ03.lean","tags":["topology","fixed-point","ivt","brouwer","research"],"badge":"axiom","sorries":0,"axiomCount":1,"lineCount":155,"assumptions":"1 axiom (brouwer_2d). 0 sorries.","dateAdded":"2026-03-30","mathlib_version":"4.26.0","originalContributions":["1D Brouwer from IVT via g(x) = f(x) - x","IVT fails in 2D: S¹ example","Dimensional hierarchy: IVT ⊂ Brouwer ⊂ Schauder"]},"sections":[{"id":"1d-brouwer","title":"1D Brouwer from IVT","startLine":23,"endLine":45},{"id":"ivt-fails","title":"Why IVT Fails in 2D","startLine":62,"endLine":82}],"conclusion":{"summary":"IVT and Brouwer are equivalent in 1D but Brouwer is strictly stronger in higher dimensions.","openQuestions":[]},"crossReferences":[{"targetId":"intermediate-value-theorem","relationship":"parent-problem"},{"targetId":"schauder-fixed-point-oq-03","relationship":"related-problem","description":"Kakutani framework for infinite-dimensional extensions"}],"leanFile":{"imports":["Mathlib"],"namespace":"IVTBrouwer","lineCount":155,"axiomCount":1,"theoremCount":4,"definitionCount":0}}
+{
+  "id": "intermediate-value-theorem-oq-03",
+  "title": "IVT and Brouwer Fixed Point Connection",
+  "slug": "intermediate-value-theorem-oq-03",
+  "description": "Explores the equivalence of IVT and Brouwer in 1D, and why Brouwer is strictly stronger in higher dimensions. Proves the 1D case via g(x) = f(x) - x.",
+  "meta": {
+    "author": "Classical topology",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/IntermediateValueTheoremOQ03.lean",
+    "tags": [
+      "topology",
+      "fixed-point",
+      "ivt",
+      "brouwer",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 1,
+    "lineCount": 155,
+    "assumptions": "1 axiom (brouwer_2d). 0 sorries.",
+    "dateAdded": "2026-03-30",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "1D Brouwer from IVT via g(x) = f(x) - x",
+      "IVT fails in 2D: S\u00b9 example",
+      "Dimensional hierarchy: IVT \u2282 Brouwer \u2282 Schauder"
+    ]
+  },
+  "sections": [
+    {
+      "id": "1d-brouwer",
+      "title": "1D Brouwer from IVT",
+      "startLine": 23,
+      "endLine": 45,
+      "summary": "1D Brouwer from IVT"
+    },
+    {
+      "id": "ivt-fails",
+      "title": "Why IVT Fails in 2D",
+      "startLine": 62,
+      "endLine": 82,
+      "summary": "Why IVT Fails in 2D"
+    }
+  ],
+  "conclusion": {
+    "summary": "IVT and Brouwer are equivalent in 1D but Brouwer is strictly stronger in higher dimensions.",
+    "openQuestions": [],
+    "implications": ""
+  },
+  "crossReferences": [
+    {
+      "targetId": "intermediate-value-theorem",
+      "relationship": "parent-problem"
+    },
+    {
+      "targetId": "schauder-fixed-point-oq-03",
+      "relationship": "related-problem",
+      "description": "Kakutani framework for infinite-dimensional extensions"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "IVTBrouwer",
+    "lineCount": 155,
+    "axiomCount": 1,
+    "theoremCount": 4,
+    "definitionCount": 0
+  }
+}

--- a/src/data/proofs/konigsberg-oq-03/meta.json
+++ b/src/data/proofs/konigsberg-oq-03/meta.json
@@ -2,17 +2,23 @@
   "id": "konigsberg-oq-03",
   "title": "Eulerian Paths in Hypergraphs and Infinite Graphs",
   "slug": "konigsberg-oq-03",
-  "description": "Generalizes Euler's theorem to r-uniform hypergraphs (NP-complete for r≥3) and infinite graphs (Erdős-Grünwald-Weiszfeld characterization).",
+  "description": "Generalizes Euler's theorem to r-uniform hypergraphs (NP-complete for r\u22653) and infinite graphs (Erd\u0151s-Gr\u00fcnwald-Weiszfeld characterization).",
   "meta": {
-    "author": "Erdős-Grünwald-Weiszfeld (1936), Lonc-Naroski (2010)",
+    "author": "Erd\u0151s-Gr\u00fcnwald-Weiszfeld (1936), Lonc-Naroski (2010)",
     "date": "1936",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/KonigsbergOQ03.lean",
-    "tags": ["graph-theory", "euler-paths", "hypergraphs", "infinite-graphs"],
+    "tags": [
+      "graph-theory",
+      "euler-paths",
+      "hypergraphs",
+      "infinite-graphs"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 4,
     "lineCount": 110
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/law-of-cosines-oq-04/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-04/meta.json
@@ -1,1 +1,82 @@
-{"id":"law-of-cosines-oq-04","title":"Stewart's Theorem from Law of Cosines","slug":"law-of-cosines-oq-04","description":"Derives Stewart's theorem b²m + c²n = a(d² + mn) from the law of cosines applied to sub-triangles with supplementary angles. Includes median length formula as special case.","meta":{"author":"Matthew Stewart (1746)","date":"2026","status":"verified","proofRepoPath":"Proofs/LawOfCosinesOQ04.lean","tags":["geometry","stewarts-theorem","cevian","law-of-cosines","research"],"badge":"original","sorries":0,"axiomCount":0,"lineCount":160,"assumptions":"No axioms or sorries. All results proved from law of cosines.","dateAdded":"2026-03-30","mathlib_version":"4.26.0","originalContributions":["Stewart's theorem derived from supplementary angle law of cosines","Median length formula d² = (2b²+2c²-a²)/4 as special case","Pure algebraic proof via ring and nlinarith"]},"overview":{"historicalContext":"Stewart's theorem (Matthew Stewart, 1746) relates the length of a cevian to the sides of a triangle. It generalizes the law of cosines.","problemStatement":"Derive Stewart's theorem from the law of cosines / inner product form.","text":"Applies law of cosines to both sub-triangles using supplementary angles, then eliminates cosines by adding."},"sections":[{"id":"algebraic","title":"Algebraic Identity","startLine":30,"endLine":42},{"id":"derivation","title":"Stewart's from Cosines","startLine":44,"endLine":100},{"id":"median","title":"Median Length Formula","startLine":102,"endLine":121}],"conclusion":{"summary":"Stewart's theorem fully derived from law of cosines. 0 axioms, 0 sorries.","openQuestions":[]},"crossReferences":[{"targetId":"law-of-cosines","relationship":"parent-problem"}],"leanFile":{"imports":["Mathlib"],"namespace":"StewartsTheorem","lineCount":160,"axiomCount":0,"theoremCount":6,"definitionCount":3}}
+{
+  "id": "law-of-cosines-oq-04",
+  "title": "Stewart's Theorem from Law of Cosines",
+  "slug": "law-of-cosines-oq-04",
+  "description": "Derives Stewart's theorem b\u00b2m + c\u00b2n = a(d\u00b2 + mn) from the law of cosines applied to sub-triangles with supplementary angles. Includes median length formula as special case.",
+  "meta": {
+    "author": "Matthew Stewart (1746)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LawOfCosinesOQ04.lean",
+    "tags": [
+      "geometry",
+      "stewarts-theorem",
+      "cevian",
+      "law-of-cosines",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 160,
+    "assumptions": "No axioms or sorries. All results proved from law of cosines.",
+    "dateAdded": "2026-03-30",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "Stewart's theorem derived from supplementary angle law of cosines",
+      "Median length formula d\u00b2 = (2b\u00b2+2c\u00b2-a\u00b2)/4 as special case",
+      "Pure algebraic proof via ring and nlinarith"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Stewart's theorem (Matthew Stewart, 1746) relates the length of a cevian to the sides of a triangle. It generalizes the law of cosines.",
+    "problemStatement": "Derive Stewart's theorem from the law of cosines / inner product form.",
+    "text": "Applies law of cosines to both sub-triangles using supplementary angles, then eliminates cosines by adding.",
+    "proofStrategy": "Applies law of cosines to both sub-triangles using supplementary angles, then eliminates cosines by adding.",
+    "keyInsights": []
+  },
+  "sections": [
+    {
+      "id": "algebraic",
+      "title": "Algebraic Identity",
+      "startLine": 30,
+      "endLine": 42,
+      "summary": "Algebraic Identity"
+    },
+    {
+      "id": "derivation",
+      "title": "Stewart's from Cosines",
+      "startLine": 44,
+      "endLine": 100,
+      "summary": "Stewart's from Cosines"
+    },
+    {
+      "id": "median",
+      "title": "Median Length Formula",
+      "startLine": 102,
+      "endLine": 121,
+      "summary": "Median Length Formula"
+    }
+  ],
+  "conclusion": {
+    "summary": "Stewart's theorem fully derived from law of cosines. 0 axioms, 0 sorries.",
+    "openQuestions": [],
+    "implications": ""
+  },
+  "crossReferences": [
+    {
+      "targetId": "law-of-cosines",
+      "relationship": "parent-problem"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "StewartsTheorem",
+    "lineCount": 160,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 3
+  }
+}

--- a/src/data/proofs/lebesgue-measure-oq-03/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-03/meta.json
@@ -1,1 +1,81 @@
-{"id":"lebesgue-measure-oq-03","title":"Infinite-Dimensional Measure Theory","slug":"lebesgue-measure-oq-03","description":"Explores why Lebesgue measure fails in infinite dimensions (no translation-invariant σ-finite measure) and what replaces it (Gaussian/Wiener measures). Proves the orthonormal separation argument.","meta":{"author":"Gross (1967), Wiener","date":"2026","status":"axiomatized","proofRepoPath":"Proofs/LebesgueMeasureOQ03.lean","tags":["measure-theory","infinite-dimensional","gaussian-measure","research"],"badge":"axiom","sorries":0,"axiomCount":3,"lineCount":170,"assumptions":"3 axioms. 0 sorries.","dateAdded":"2026-03-30","mathlib_version":"4.26.0","originalContributions":["Orthonormal vectors have distance √2 (proved)","√2 > 2/3 separation for disjoint balls (proved)","Framework: impossibility → Gaussian → Wiener"]},"sections":[{"id":"impossibility","title":"The Impossibility Result","startLine":20,"endLine":50},{"id":"separation","title":"Orthogonal Separation","startLine":52,"endLine":82},{"id":"gaussian","title":"Gaussian Measures","startLine":84,"endLine":108},{"id":"wiener","title":"Wiener Measure","startLine":110,"endLine":130}],"conclusion":{"summary":"No Lebesgue measure in ∞-dim. Gaussian and Wiener measures are the replacements.","openQuestions":[]},"crossReferences":[{"targetId":"lebesgue-measure","relationship":"parent-problem"}],"leanFile":{"imports":["Mathlib"],"namespace":"LebesgueMeasureOQ03","lineCount":170,"axiomCount":3,"theoremCount":4,"definitionCount":0}}
+{
+  "id": "lebesgue-measure-oq-03",
+  "title": "Infinite-Dimensional Measure Theory",
+  "slug": "lebesgue-measure-oq-03",
+  "description": "Explores why Lebesgue measure fails in infinite dimensions (no translation-invariant \u03c3-finite measure) and what replaces it (Gaussian/Wiener measures). Proves the orthonormal separation argument.",
+  "meta": {
+    "author": "Gross (1967), Wiener",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/LebesgueMeasureOQ03.lean",
+    "tags": [
+      "measure-theory",
+      "infinite-dimensional",
+      "gaussian-measure",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 3,
+    "lineCount": 170,
+    "assumptions": "3 axioms. 0 sorries.",
+    "dateAdded": "2026-03-30",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "Orthonormal vectors have distance \u221a2 (proved)",
+      "\u221a2 > 2/3 separation for disjoint balls (proved)",
+      "Framework: impossibility \u2192 Gaussian \u2192 Wiener"
+    ]
+  },
+  "sections": [
+    {
+      "id": "impossibility",
+      "title": "The Impossibility Result",
+      "startLine": 20,
+      "endLine": 50,
+      "summary": "The Impossibility Result"
+    },
+    {
+      "id": "separation",
+      "title": "Orthogonal Separation",
+      "startLine": 52,
+      "endLine": 82,
+      "summary": "Orthogonal Separation"
+    },
+    {
+      "id": "gaussian",
+      "title": "Gaussian Measures",
+      "startLine": 84,
+      "endLine": 108,
+      "summary": "Gaussian Measures"
+    },
+    {
+      "id": "wiener",
+      "title": "Wiener Measure",
+      "startLine": 110,
+      "endLine": 130,
+      "summary": "Wiener Measure"
+    }
+  ],
+  "conclusion": {
+    "summary": "No Lebesgue measure in \u221e-dim. Gaussian and Wiener measures are the replacements.",
+    "openQuestions": [],
+    "implications": ""
+  },
+  "crossReferences": [
+    {
+      "targetId": "lebesgue-measure",
+      "relationship": "parent-problem"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "LebesgueMeasureOQ03",
+    "lineCount": 170,
+    "axiomCount": 3,
+    "theoremCount": 4,
+    "definitionCount": 0
+  }
+}

--- a/src/data/proofs/mathematical-induction-oq-01/meta.json
+++ b/src/data/proofs/mathematical-induction-oq-01/meta.json
@@ -5,7 +5,12 @@
   "description": "Connects Lean's WellFounded recursion to transfinite induction over ordinals. Proves transfinite induction via Ordinal.induction, the zero/successor/limit trichotomy, course-of-values induction, and the equivalence with the well-ordering principle.",
   "meta": {
     "status": "verified",
-    "tags": ["foundations", "set-theory", "ordinals", "open-question"],
+    "tags": [
+      "foundations",
+      "set-theory",
+      "ordinals",
+      "open-question"
+    ],
     "proofRepoPath": "Proofs/MathematicalInductionOQ01.lean",
     "badge": "verified",
     "sorries": 0,
@@ -16,7 +21,16 @@
     "dateAdded": "2026-03-30"
   },
   "crossReferences": [
-    {"targetId": "mathematical-induction", "relationship": "extends"}
+    {
+      "targetId": "mathematical-induction",
+      "relationship": "extends"
+    }
   ],
-  "leanFile": {"namespace": "TransfiniteInduction", "lineCount": 155, "axiomCount": 0, "theoremCount": 10}
+  "leanFile": {
+    "namespace": "TransfiniteInduction",
+    "lineCount": 155,
+    "axiomCount": 0,
+    "theoremCount": 10
+  },
+  "sections": []
 }

--- a/src/data/proofs/mean-value-theorem-oq-02/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-02/meta.json
@@ -41,7 +41,7 @@
     ]
   },
   "overview": {
-    "historicalContext": "Taylor's theorem (Brook Taylor, 1715) with the Lagrange form of the remainder (Joseph-Louis Lagrange, 1797) is one of the most important results in calculus. It generalizes the Mean Value Theorem to higher order: f(b) = T_n(b) + f^(n+1)(c)/(n+1)! · (b-a)^(n+1).",
+    "historicalContext": "Taylor's theorem (Brook Taylor, 1715) with the Lagrange form of the remainder (Joseph-Louis Lagrange, 1797) is one of the most important results in calculus. It generalizes the Mean Value Theorem to higher order: f(b) = T_n(b) + f^(n+1)(c)/(n+1)! \u00b7 (b-a)^(n+1).",
     "problemStatement": "Is there a Mathlib-compatible formalization of the higher-order MVT (Taylor's theorem with Lagrange remainder)?",
     "text": "Defines the Taylor polynomial, axiomatizes the Lagrange remainder form, and derives the MVT as a special case. Mathlib has the integral remainder form but converting to Lagrange requires the generalized MVT for integrals.",
     "proofStrategy": "Define Taylor polynomials using iteratedDeriv and Finset.sum. Axiomatize the Lagrange form. Derive special cases (n=0 gives MVT, n=1 gives second-order expansion) by specializing and simplifying.",
@@ -59,14 +59,14 @@
     {
       "id": "taylor-polynomial",
       "title": "The Taylor Polynomial",
-      "summary": "Defines T_n(x) = Σ f^(k)(a)/k! · (x-a)^k and proves n=0,1 cases",
+      "summary": "Defines T_n(x) = \u03a3 f^(k)(a)/k! \u00b7 (x-a)^k and proves n=0,1 cases",
       "startLine": 39,
       "endLine": 69
     },
     {
       "id": "lagrange-remainder",
       "title": "Taylor's Theorem with Lagrange Remainder",
-      "summary": "Axiomatizes: f(b) - T_n(b) = f^(n+1)(c)/(n+1)! · (b-a)^(n+1)",
+      "summary": "Axiomatizes: f(b) - T_n(b) = f^(n+1)(c)/(n+1)! \u00b7 (b-a)^(n+1)",
       "startLine": 71,
       "endLine": 99
     },
@@ -80,14 +80,15 @@
     {
       "id": "second-order",
       "title": "Second-Order Taylor",
-      "summary": "f(b) = f(a) + f'(a)(b-a) + f''(c)/2·(b-a)²",
+      "summary": "f(b) = f(a) + f'(a)(b-a) + f''(c)/2\u00b7(b-a)\u00b2",
       "startLine": 129,
       "endLine": 155
     }
   ],
   "conclusion": {
     "summary": "Taylor's theorem with Lagrange remainder is formalized using Mathlib's iteratedDeriv. The Lagrange form is axiomatized (1 axiom) because converting from Mathlib's integral remainder requires substantial infrastructure. The MVT and second-order expansion are derived as special cases.",
-    "openQuestions": []
+    "openQuestions": [],
+    "implications": ""
   },
   "crossReferences": [
     {
@@ -98,7 +99,9 @@
   ],
   "references": [
     {
-      "authors": ["W. Rudin"],
+      "authors": [
+        "W. Rudin"
+      ],
       "title": "Principles of Mathematical Analysis",
       "year": "1976",
       "venue": "McGraw-Hill",
@@ -113,7 +116,11 @@
       "Mathlib.Analysis.SpecialFunctions.Pow.Deriv",
       "Mathlib.Tactic"
     ],
-    "opens": ["Real", "MeasureTheory", "Set"],
+    "opens": [
+      "Real",
+      "MeasureTheory",
+      "Set"
+    ],
     "namespace": "MeanValueTheoremOQ02",
     "lineCount": 155,
     "axiomCount": 1,

--- a/src/data/proofs/morleys-theorem-oq-01/meta.json
+++ b/src/data/proofs/morleys-theorem-oq-01/meta.json
@@ -26,7 +26,7 @@
     "mathlibDependencies": [
       {
         "theorem": "Real.sin_pos_of_pos_of_lt_pi",
-        "description": "sin is positive on (0, π)",
+        "description": "sin is positive on (0, \u03c0)",
         "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
       },
       {
@@ -47,11 +47,11 @@
     "historicalContext": "John Conway devised an elegant 'backward' proof of Morley's theorem: instead of starting with a triangle and finding the equilateral Morley triangle (hard), start with an equilateral triangle and reconstruct the original around it (easier). This file formalizes the construction and supporting angle computations.",
     "problemStatement": "Can morleys_theorem_axiom be proved via Conway's backward construction?",
     "text": "Formalizes the ear construction, proves all angle identities and the Morley side length formula, and reduces the full theorem to a coordinate verification.",
-    "proofStrategy": "Build three isoceles 'ear' triangles on the equilateral Morley triangle, one per side, with apex angles π/3 + α₃, π/3 + β₃, π/3 + γ₃. The Conway angle identities show the correct angles at each vertex. The symmetric side length formula 8R·sin(α/3)·sin(β/3)·sin(γ/3) gives the equilateral property.",
+    "proofStrategy": "Build three isoceles 'ear' triangles on the equilateral Morley triangle, one per side, with apex angles \u03c0/3 + \u03b1\u2083, \u03c0/3 + \u03b2\u2083, \u03c0/3 + \u03b3\u2083. The Conway angle identities show the correct angles at each vertex. The symmetric side length formula 8R\u00b7sin(\u03b1/3)\u00b7sin(\u03b2/3)\u00b7sin(\u03b3/3) gives the equilateral property.",
     "keyInsights": [
       "Conway's backward construction avoids the hard direction of the proof",
-      "The key identity α₃ + β₃ + γ₃ = π/3 drives all angle computations",
-      "The Morley side formula 8R·sin(α/3)·sin(β/3)·sin(γ/3) is symmetric, immediately giving the equilateral property",
+      "The key identity \u03b1\u2083 + \u03b2\u2083 + \u03b3\u2083 = \u03c0/3 drives all angle computations",
+      "The Morley side formula 8R\u00b7sin(\u03b1/3)\u00b7sin(\u03b2/3)\u00b7sin(\u03b3/3) is symmetric, immediately giving the equilateral property",
       "The remaining coordinate verification is finite and mechanical"
     ]
   },
@@ -66,14 +66,14 @@
     {
       "id": "angle-identities",
       "title": "Key Angle Identities",
-      "summary": "Trisected sum = π/3, positivity, bound < π/3",
+      "summary": "Trisected sum = \u03c0/3, positivity, bound < \u03c0/3",
       "startLine": 56,
       "endLine": 79
     },
     {
       "id": "ear-construction",
       "title": "Conway's Ear Construction",
-      "summary": "Ear apex angles, their sum (4π/3), base angles",
+      "summary": "Ear apex angles, their sum (4\u03c0/3), base angles",
       "startLine": 81,
       "endLine": 133
     },
@@ -87,7 +87,7 @@
     {
       "id": "side-formula",
       "title": "The Side Length Formula",
-      "summary": "Morley side length = 8R·sin(α/3)·sin(β/3)·sin(γ/3), symmetry, positivity",
+      "summary": "Morley side length = 8R\u00b7sin(\u03b1/3)\u00b7sin(\u03b2/3)\u00b7sin(\u03b3/3), symmetry, positivity",
       "startLine": 177,
       "endLine": 210
     },
@@ -101,7 +101,7 @@
     {
       "id": "trig-identities",
       "title": "Trig Identities for Computation",
-      "summary": "Product-to-sum, cos(α₃+β₃) = cos(π/3-γ₃)",
+      "summary": "Product-to-sum, cos(\u03b1\u2083+\u03b2\u2083) = cos(\u03c0/3-\u03b3\u2083)",
       "startLine": 232,
       "endLine": 260
     }
@@ -109,8 +109,9 @@
   "conclusion": {
     "summary": "All supporting lemmas for Conway's backward proof are verified (0 axioms, 0 sorries). The remaining step is the coordinate computation showing each Morley side equals the symmetric formula.",
     "openQuestions": [
-      "Complete the coordinate verification: place equilateral triangle in complex plane, compute ear vertices, verify side lengths match 8R·sin(α/3)·sin(β/3)·sin(γ/3)"
-    ]
+      "Complete the coordinate verification: place equilateral triangle in complex plane, compute ear vertices, verify side lengths match 8R\u00b7sin(\u03b1/3)\u00b7sin(\u03b2/3)\u00b7sin(\u03b3/3)"
+    ],
+    "implications": ""
   },
   "crossReferences": [
     {
@@ -121,7 +122,9 @@
   ],
   "references": [
     {
-      "authors": ["J. H. Conway"],
+      "authors": [
+        "J. H. Conway"
+      ],
       "title": "The power of mathematics (Morley's miracle)",
       "year": "1995",
       "venue": "In: Power (ed. A. Blackwell and D. MacKay)",
@@ -129,8 +132,12 @@
     }
   ],
   "leanFile": {
-    "imports": ["Mathlib"],
-    "opens": ["Real"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
     "namespace": "MorleysTheoremOQ01",
     "lineCount": 297,
     "axiomCount": 0,

--- a/src/data/proofs/motivic-flag-maps-oq-02/meta.json
+++ b/src/data/proofs/motivic-flag-maps-oq-02/meta.json
@@ -25,12 +25,12 @@
     "mathlibDependencies": [
       {
         "theorem": "mul_geom_sum",
-        "description": "Geometric series formula: (x-1) * ∑ x^i = x^n - 1",
+        "description": "Geometric series formula: (x-1) * \u2211 x^i = x^n - 1",
         "module": "Mathlib.Algebra.Ring.GeomSum"
       },
       {
         "theorem": "Finset.sum_range_id",
-        "description": "Gauss sum formula: ∑_{i<n} i = n(n-1)/2",
+        "description": "Gauss sum formula: \u2211_{i<n} i = n(n-1)/2",
         "module": "Mathlib.Algebra.BigOperators.Ring"
       },
       {
@@ -44,12 +44,12 @@
       "Recursive Grassmannian motivic class via q-Pascal identity",
       "Explicit Grassmannian computations: Gr(1,2), Gr(1,3), Gr(2,3), Gr(2,4)",
       "q-factorial = complete flag class identity (proved)",
-      "Geometric series factorization: L^n - 1 = (L-1)·[n]_L (proved via mul_geom_sum)",
-      "GL_n decomposition: [GL_n] = (L-1)^n · [n]_L! · L^{T(n)} (proved)",
+      "Geometric series factorization: L^n - 1 = (L-1)\u00b7[n]_L (proved via mul_geom_sum)",
+      "GL_n decomposition: [GL_n] = (L-1)^n \u00b7 [n]_L! \u00b7 L^{T(n)} (proved)",
       "GL_n-flag variety structural relation (proved)",
       "Partial flag variety definition and motivic class factorization",
-      "Extension conjecture: maps to partial flags give parabolic × affine classes",
-      "Gaussian binomial identity statement: [Gr(d,n)] · [d]! · [n-d]! = [n]!"
+      "Extension conjecture: maps to partial flags give parabolic \u00d7 affine classes",
+      "Gaussian binomial identity statement: [Gr(d,n)] \u00b7 [d]! \u00b7 [n-d]! = [n]!"
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 3,
@@ -61,50 +61,55 @@
     {
       "id": "q-analogs",
       "title": "q-Analog Infrastructure",
-      "description": "q-numbers [n]_L = 1 + L + ... + L^{n-1} and q-factorials [n]_L! = ∏ [i]_L, connecting motivic algebra to combinatorics. Key result: [n]_L! = [Fl_n].",
+      "description": "q-numbers [n]_L = 1 + L + ... + L^{n-1} and q-factorials [n]_L! = \u220f [i]_L, connecting motivic algebra to combinatorics. Key result: [n]_L! = [Fl_n].",
       "startLine": 63,
-      "endLine": 140
+      "endLine": 140,
+      "summary": "q-Analog Infrastructure"
     },
     {
       "id": "grassmannians",
       "title": "Grassmannian Motivic Classes",
-      "description": "Recursive definition of [Gr(d,n)] via the q-Pascal identity. Verified for Gr(1,2), Gr(1,3), Gr(2,3), Gr(2,4). The coefficient 2 on L² in [Gr(2,4)] reflects two Schubert cells.",
+      "description": "Recursive definition of [Gr(d,n)] via the q-Pascal identity. Verified for Gr(1,2), Gr(1,3), Gr(2,3), Gr(2,4). The coefficient 2 on L\u00b2 in [Gr(2,4)] reflects two Schubert cells.",
       "startLine": 142,
-      "endLine": 231
+      "endLine": 231,
+      "summary": "Grassmannian Motivic Classes"
     },
     {
       "id": "partial-flags",
       "title": "Partial Flag Varieties",
-      "description": "Definition of partial flags Fl(d₁,...,dₖ; n) as nested subspaces. Motivic class factorization via iterated Grassmannian fibrations.",
+      "description": "Definition of partial flags Fl(d\u2081,...,d\u2096; n) as nested subspaces. Motivic class factorization via iterated Grassmannian fibrations.",
       "startLine": 233,
-      "endLine": 274
+      "endLine": 274,
+      "summary": "Partial Flag Varieties"
     },
     {
       "id": "extension-conjecture",
       "title": "Extension Conjecture",
-      "description": "States the conjectured extension of Bryan et al. to partial flags: [Ω²_β(Fl(d₁,...,dₖ; n+1))] = [Levi × U × A^{a'}]. The complete flag case recovers the original theorem.",
+      "description": "States the conjectured extension of Bryan et al. to partial flags: [\u03a9\u00b2_\u03b2(Fl(d\u2081,...,d\u2096; n+1))] = [Levi \u00d7 U \u00d7 A^{a'}]. The complete flag case recovers the original theorem.",
       "startLine": 276,
-      "endLine": 310
+      "endLine": 310,
+      "summary": "Extension Conjecture"
     },
     {
       "id": "gln-structure",
       "title": "GL_n Structure via q-Analogs",
-      "description": "Proved: [GL_n] = (L-1)^n · [n]_L! · L^{T(n)}, explaining why flag varieties appear in the GL_n formula. Uses mul_geom_sum from Mathlib.",
+      "description": "Proved: [GL_n] = (L-1)^n \u00b7 [n]_L! \u00b7 L^{T(n)}, explaining why flag varieties appear in the GL_n formula. Uses mul_geom_sum from Mathlib.",
       "startLine": 312,
-      "endLine": 345
+      "endLine": 345,
+      "summary": "GL_n Structure via q-Analogs"
     }
   ],
   "overview": {
-    "historicalContext": "Bryan et al. (arXiv:2601.07222) proved that motivic classes of based maps to complete flag varieties have a remarkably simple form: [GL_n × A^a]. A natural question is whether this extends to partial flag varieties — varieties parameterizing incomplete chains of subspaces. Partial flags include Grassmannians (single subspace) and other important moduli spaces in algebraic geometry.",
-    "problemStatement": "**Open Question**: Does the motivic class formula [Ω²_β(Fl_{n+1})] = [GL_n × A^a] extend to partial flag varieties?\n\nFor a partial flag Fl(d₁,...,dₖ; n+1), the conjectured extension involves the parabolic subgroup P = Levi ⋊ U corresponding to the flag type:\n$$[\\Omega^2_\\beta(\\text{Fl}(d_1,\\ldots,d_k; n+1))] = [\\text{Levi} \\times U \\times \\mathbb{A}^{a'}]$$\n\nwhere Levi = GL_{n₁} × ... × GL_{n_{k+1}} for block sizes nᵢ.",
+    "historicalContext": "Bryan et al. (arXiv:2601.07222) proved that motivic classes of based maps to complete flag varieties have a remarkably simple form: [GL_n \u00d7 A^a]. A natural question is whether this extends to partial flag varieties \u2014 varieties parameterizing incomplete chains of subspaces. Partial flags include Grassmannians (single subspace) and other important moduli spaces in algebraic geometry.",
+    "problemStatement": "**Open Question**: Does the motivic class formula [\u03a9\u00b2_\u03b2(Fl_{n+1})] = [GL_n \u00d7 A^a] extend to partial flag varieties?\n\nFor a partial flag Fl(d\u2081,...,d\u2096; n+1), the conjectured extension involves the parabolic subgroup P = Levi \u22ca U corresponding to the flag type:\n$$[\\Omega^2_\\beta(\\text{Fl}(d_1,\\ldots,d_k; n+1))] = [\\text{Levi} \\times U \\times \\mathbb{A}^{a'}]$$\n\nwhere Levi = GL_{n\u2081} \u00d7 ... \u00d7 GL_{n_{k+1}} for block sizes n\u1d62.",
     "text": "Extension of the Bryan et al. motivic class theorem from complete to partial flag varieties, with q-analog infrastructure and Grassmannian motivic classes.",
-    "proofStrategy": "We formalize the necessary infrastructure:\n1. **q-Analogs**: q-numbers [n]_L and q-factorials [n]_L! are defined and proved equal to flag variety classes\n2. **Grassmannians**: Motivic classes via recursive q-Pascal identity, with explicit small cases verified\n3. **Partial Flags**: Defined with motivic class factorization through Grassmannian fibers\n4. **Extension**: The conjecture is stated formally with parabolic subgroup structure\n5. **Structural Identity**: We prove [GL_n] = (L-1)^n · [Fl_n] · L^{T(n)}, revealing why flag varieties appear in GL_n",
+    "proofStrategy": "We formalize the necessary infrastructure:\n1. **q-Analogs**: q-numbers [n]_L and q-factorials [n]_L! are defined and proved equal to flag variety classes\n2. **Grassmannians**: Motivic classes via recursive q-Pascal identity, with explicit small cases verified\n3. **Partial Flags**: Defined with motivic class factorization through Grassmannian fibers\n4. **Extension**: The conjecture is stated formally with parabolic subgroup structure\n5. **Structural Identity**: We prove [GL_n] = (L-1)^n \u00b7 [Fl_n] \u00b7 L^{T(n)}, revealing why flag varieties appear in GL_n",
     "keyInsights": [
-      "The q-factorial [n]_L! equals the complete flag class [Fl_n] — this is the bridge between q-combinatorics and algebraic geometry",
+      "The q-factorial [n]_L! equals the complete flag class [Fl_n] \u2014 this is the bridge between q-combinatorics and algebraic geometry",
       "Grassmannian classes follow a recursive q-Pascal identity, paralleling classical binomial coefficients",
-      "The GL_n class decomposes as (L-1)^n times the flag class times a power of L — this explains the structural connection",
-      "For partial flags, the parabolic subgroup (Levi × unipotent radical) replaces GL_n in the extension conjecture",
-      "The first non-trivial Grassmannian [Gr(2,4)] = 1+L+2L²+L³+L⁴ shows Schubert cell multiplicity"
+      "The GL_n class decomposes as (L-1)^n times the flag class times a power of L \u2014 this explains the structural connection",
+      "For partial flags, the parabolic subgroup (Levi \u00d7 unipotent radical) replaces GL_n in the extension conjecture",
+      "The first non-trivial Grassmannian [Gr(2,4)] = 1+L+2L\u00b2+L\u00b3+L\u2074 shows Schubert cell multiplicity"
     ]
   },
   "conclusion": {
@@ -112,7 +117,7 @@
     "implications": "The extension conjecture for partial flags with parabolic subgroups is stated formally. Three sorries remain for algebraic identities that require careful induction.",
     "openQuestions": [
       "Prove Grassmannian duality [Gr(d,n)] = [Gr(n-d,n)] by induction on the q-Pascal identity",
-      "Prove the Gaussian binomial identity [Gr(d,n)] · [d]! · [n-d]! = [n]!",
+      "Prove the Gaussian binomial identity [Gr(d,n)] \u00b7 [d]! \u00b7 [n-d]! = [n]!",
       "Verify the extension conjecture for Grassmannians (d=1 case: maps to projective space)",
       "Connect to positroid varieties and the work of Galashin-Karp-Lam on amplituhedra"
     ]

--- a/src/data/proofs/napoleons-theorem/meta.json
+++ b/src/data/proofs/napoleons-theorem/meta.json
@@ -21,7 +21,7 @@
     "mathlibDependencies": [
       {
         "theorem": "Complex",
-        "description": "Complex number field ℂ and basic arithmetic",
+        "description": "Complex number field \u2102 and basic arithmetic",
         "module": "Mathlib.Data.Complex.Basic"
       },
       {
@@ -31,13 +31,13 @@
       },
       {
         "theorem": "Real.sqrt",
-        "description": "Square root function for √3 in centroid formulas",
+        "description": "Square root function for \u221a3 in centroid formulas",
         "module": "Mathlib.Data.Real.Sqrt"
       }
     ],
     "originalContributions": [
-      "Napoleon centroid formula: G = (b+c)/2 + i√3(c-b)/6 for outer equilateral on side bc",
-      "Rotation identity: G₃ - G₁ = (G₂ - G₁) · e^{-iπ/3}, the algebraic core of Napoleon's theorem",
+      "Napoleon centroid formula: G = (b+c)/2 + i\u221a3(c-b)/6 for outer equilateral on side bc",
+      "Rotation identity: G\u2083 - G\u2081 = (G\u2082 - G\u2081) \u00b7 e^{-i\u03c0/3}, the algebraic core of Napoleon's theorem",
       "Complete proof of outer and inner Napoleon triangle equilaterality via rotation",
       "Centroid preservation: Napoleon triangle centroid equals original triangle centroid",
       "Inner Napoleon triangle variant with conjugate rotation factor"
@@ -61,62 +61,76 @@
       "title": "Napoleon Centroid Construction",
       "startLine": 60,
       "endLine": 85,
-      "description": "Define the centroid of the outer equilateral triangle on each side using the displacement formula G = midpoint + i√3(c-b)/6."
+      "description": "Define the centroid of the outer equilateral triangle on each side using the displacement formula G = midpoint + i\u221a3(c-b)/6.",
+      "summary": "Napoleon Centroid Construction",
+      "id": "napoleon-centroid-construction"
     },
     {
-      "title": "Algebraic Lemma: √3² = 3",
+      "title": "Algebraic Lemma: \u221a3\u00b2 = 3",
       "startLine": 90,
       "endLine": 105,
-      "description": "The key algebraic fact √3² = 3 lifted to ℂ, used in the rotation identity proof."
+      "description": "The key algebraic fact \u221a3\u00b2 = 3 lifted to \u2102, used in the rotation identity proof.",
+      "summary": "Algebraic Lemma: \u221a3\u00b2 = 3",
+      "id": "algebraic-lemma-\u221a3\u00b2-=-3"
     },
     {
       "title": "Rotation Identity",
       "startLine": 110,
       "endLine": 175,
-      "description": "The algebraic heart: G₃ - G₁ = (G₂ - G₁) · e^{-iπ/3}. Both sides expand to (z₁-z₃)/2 + i√3(2z₂-z₁-z₃)/6."
+      "description": "The algebraic heart: G\u2083 - G\u2081 = (G\u2082 - G\u2081) \u00b7 e^{-i\u03c0/3}. Both sides expand to (z\u2081-z\u2083)/2 + i\u221a3(2z\u2082-z\u2081-z\u2083)/6.",
+      "summary": "Rotation Identity",
+      "id": "rotation-identity"
     },
     {
-      "title": "Napoleon's Theorem — Equilateral Property",
+      "title": "Napoleon's Theorem \u2014 Equilateral Property",
       "startLine": 180,
       "endLine": 230,
-      "description": "All three sides of the outer Napoleon triangle are equal, derived from the rotation identity and |e^{-iπ/3}| = 1."
+      "description": "All three sides of the outer Napoleon triangle are equal, derived from the rotation identity and |e^{-i\u03c0/3}| = 1.",
+      "summary": "Napoleon's Theorem \u2014 Equilateral Property",
+      "id": "napoleon's-theorem-\u2014-equilater"
     },
     {
       "title": "Side Length Formula",
       "startLine": 235,
       "endLine": 265,
-      "description": "The squared side length expressed in terms of the original triangle's vertex coordinates."
+      "description": "The squared side length expressed in terms of the original triangle's vertex coordinates.",
+      "summary": "Side Length Formula",
+      "id": "side-length-formula"
     },
     {
       "title": "Inner Napoleon Triangle",
       "startLine": 270,
       "endLine": 340,
-      "description": "The inner Napoleon triangle (equilateral triangles constructed inward) is also equilateral, with conjugate rotation."
+      "description": "The inner Napoleon triangle (equilateral triangles constructed inward) is also equilateral, with conjugate rotation.",
+      "summary": "Inner Napoleon Triangle",
+      "id": "inner-napoleon-triangle"
     },
     {
       "title": "Centroid Preservation",
       "startLine": 345,
       "endLine": 380,
-      "description": "Both inner and outer Napoleon triangle centroids coincide with the original triangle's centroid."
+      "description": "Both inner and outer Napoleon triangle centroids coincide with the original triangle's centroid.",
+      "summary": "Centroid Preservation",
+      "id": "centroid-preservation"
     }
   ],
   "overview": {
-    "historicalContext": "Napoleon's theorem is traditionally attributed to Napoleon Bonaparte (1769–1821), who was known to be interested in mathematics and geometry. However, the attribution is likely apocryphal — the theorem was known in various forms in the 18th and 19th centuries, and its earliest published proof is from the 1820s.\n\nThe theorem belongs to the family of 'hidden equilateral triangle' results in elementary geometry, alongside Morley's theorem. While Morley's theorem involves angle trisectors, Napoleon's theorem uses the more accessible construction of equilateral triangles on the sides.\n\nThe result has a beautiful dual: both the outer Napoleon triangle (equilateral triangles constructed outward) and the inner Napoleon triangle (constructed inward) are equilateral, and both share the same centroid as the original triangle.",
+    "historicalContext": "Napoleon's theorem is traditionally attributed to Napoleon Bonaparte (1769\u20131821), who was known to be interested in mathematics and geometry. However, the attribution is likely apocryphal \u2014 the theorem was known in various forms in the 18th and 19th centuries, and its earliest published proof is from the 1820s.\n\nThe theorem belongs to the family of 'hidden equilateral triangle' results in elementary geometry, alongside Morley's theorem. While Morley's theorem involves angle trisectors, Napoleon's theorem uses the more accessible construction of equilateral triangles on the sides.\n\nThe result has a beautiful dual: both the outer Napoleon triangle (equilateral triangles constructed outward) and the inner Napoleon triangle (constructed inward) are equilateral, and both share the same centroid as the original triangle.",
     "problemStatement": "**Napoleon's Theorem**: Given any triangle ABC, construct equilateral triangles externally on each side. Then the centroids of these three equilateral triangles form an equilateral triangle (the **outer Napoleon triangle**).\n\nSimilarly, if equilateral triangles are constructed internally, their centroids also form an equilateral triangle (the **inner Napoleon triangle**).\n\nBoth Napoleon triangles share the same centroid as the original triangle.",
     "text": "If equilateral triangles are constructed externally on the sides of any triangle, their centroids form an equilateral triangle.",
-    "proofStrategy": "The proof uses **complex coordinates** and a **rotation identity**.\n\n1. **Construction**: The centroid of the outer equilateral triangle on side bc is G = (b+c)/2 + i√3(c-b)/6, where b, c ∈ ℂ are the vertices.\n\n2. **Rotation identity**: The key insight is that consecutive difference vectors of Napoleon centroids are related by rotation by -60°:\n   G₃ - G₁ = (G₂ - G₁) · e^{-iπ/3}\n   This is verified by expanding both sides: both reduce to (z₁-z₃)/2 + i√3(2z₂-z₁-z₃)/6, using only √3² = 3 and i² = -1.\n\n3. **Equilaterality**: Since |e^{-iπ/3}| = 1, the rotation identity immediately gives |G₃ - G₁| = |G₂ - G₁|. For the third side, G₃ - G₂ = (G₂ - G₁)(e^{-iπ/3} - 1), and |e^{-iπ/3} - 1| = 1 as well.\n\n4. **Inner variant**: Replacing i with -i in the centroid formula gives the inner Napoleon triangle, with rotation by +60° instead of -60°.",
+    "proofStrategy": "The proof uses **complex coordinates** and a **rotation identity**.\n\n1. **Construction**: The centroid of the outer equilateral triangle on side bc is G = (b+c)/2 + i\u221a3(c-b)/6, where b, c \u2208 \u2102 are the vertices.\n\n2. **Rotation identity**: The key insight is that consecutive difference vectors of Napoleon centroids are related by rotation by -60\u00b0:\n   G\u2083 - G\u2081 = (G\u2082 - G\u2081) \u00b7 e^{-i\u03c0/3}\n   This is verified by expanding both sides: both reduce to (z\u2081-z\u2083)/2 + i\u221a3(2z\u2082-z\u2081-z\u2083)/6, using only \u221a3\u00b2 = 3 and i\u00b2 = -1.\n\n3. **Equilaterality**: Since |e^{-i\u03c0/3}| = 1, the rotation identity immediately gives |G\u2083 - G\u2081| = |G\u2082 - G\u2081|. For the third side, G\u2083 - G\u2082 = (G\u2082 - G\u2081)(e^{-i\u03c0/3} - 1), and |e^{-i\u03c0/3} - 1| = 1 as well.\n\n4. **Inner variant**: Replacing i with -i in the centroid formula gives the inner Napoleon triangle, with rotation by +60\u00b0 instead of -60\u00b0.",
     "keyInsights": [
-      "**Rotation identity**: G₃ - G₁ = (G₂ - G₁) · e^{-iπ/3} — consecutive Napoleon sides differ by a 60° rotation, the defining property of equilateral triangles",
-      "**Complex coordinate elegance**: The centroid formula G = (b+c)/2 + i√3(c-b)/6 makes the proof purely algebraic",
-      "**Dual theorem**: Both outer (rotation -60°) and inner (rotation +60°) Napoleon triangles are equilateral",
+      "**Rotation identity**: G\u2083 - G\u2081 = (G\u2082 - G\u2081) \u00b7 e^{-i\u03c0/3} \u2014 consecutive Napoleon sides differ by a 60\u00b0 rotation, the defining property of equilateral triangles",
+      "**Complex coordinate elegance**: The centroid formula G = (b+c)/2 + i\u221a3(c-b)/6 makes the proof purely algebraic",
+      "**Dual theorem**: Both outer (rotation -60\u00b0) and inner (rotation +60\u00b0) Napoleon triangles are equilateral",
       "**Centroid preservation**: The average of Napoleon centroids equals the average of the original vertices, so all three triangles share the same centroid",
-      "**|e^{±iπ/3}| = |e^{±iπ/3} - 1| = 1**: This coincidence (both the rotation and rotation-minus-1 have unit modulus) is why all three sides are equal, not just two"
+      "**|e^{\u00b1i\u03c0/3}| = |e^{\u00b1i\u03c0/3} - 1| = 1**: This coincidence (both the rotation and rotation-minus-1 have unit modulus) is why all three sides are equal, not just two"
     ],
     "prerequisites": [
-      "Complex numbers and arithmetic in ℂ",
+      "Complex numbers and arithmetic in \u2102",
       "Absolute value of complex numbers",
-      "Real square root (√3)",
-      "Basic trigonometry (cos(π/3) = 1/2, sin(π/3) = √3/2)"
+      "Real square root (\u221a3)",
+      "Basic trigonometry (cos(\u03c0/3) = 1/2, sin(\u03c0/3) = \u221a3/2)"
     ],
     "openQuestions": [
       "Can the Napoleon-Douglas-Neumann theorem (generalization to n-gons) be formalized?",
@@ -124,8 +138,8 @@
     ]
   },
   "conclusion": {
-    "summary": "Napoleon's theorem is formalized using complex coordinates. The centroid displacement formula G = (b+c)/2 + i√3(c-b)/6 encodes the construction, and the rotation identity G₃ - G₁ = (G₂ - G₁)·e^{-iπ/3} provides an elegant algebraic proof. Both outer and inner Napoleon triangles are proved equilateral, and centroid preservation is established.",
-    "implications": "**Theoretical Significance**: The proof demonstrates the power of complex coordinates in plane geometry — what appears to be a non-trivial geometric theorem reduces to a polynomial identity over ℂ.\n\nThe rotation identity approach generalizes: any construction where consecutive sides differ by a fixed rotation produces a regular polygon. This connects to the discrete Fourier transform view of polygon geometry.",
+    "summary": "Napoleon's theorem is formalized using complex coordinates. The centroid displacement formula G = (b+c)/2 + i\u221a3(c-b)/6 encodes the construction, and the rotation identity G\u2083 - G\u2081 = (G\u2082 - G\u2081)\u00b7e^{-i\u03c0/3} provides an elegant algebraic proof. Both outer and inner Napoleon triangles are proved equilateral, and centroid preservation is established.",
+    "implications": "**Theoretical Significance**: The proof demonstrates the power of complex coordinates in plane geometry \u2014 what appears to be a non-trivial geometric theorem reduces to a polynomial identity over \u2102.\n\nThe rotation identity approach generalizes: any construction where consecutive sides differ by a fixed rotation produces a regular polygon. This connects to the discrete Fourier transform view of polygon geometry.",
     "openQuestions": [
       "Can the Napoleon-Douglas-Neumann theorem (generalization to n-gons) be formalized?",
       "Can the connection between Napoleon's theorem and the discrete Fourier transform be made explicit?"

--- a/src/data/proofs/partition-theorem-oq-03/meta.json
+++ b/src/data/proofs/partition-theorem-oq-03/meta.json
@@ -31,7 +31,9 @@
   "overview": {
     "historicalContext": "Overpartitions were systematically studied by Corteel and Lovejoy (2004), building on Euler's 1748 partition identity. An overpartition allows the first occurrence of each part size to be optionally marked, doubling the combinatorial choices.",
     "problemStatement": "How do Euler's partition identities generalize to overpartitions?",
-    "text": "Overpartitions extend Euler's partition framework by allowing optional marking of first occurrences."
+    "text": "Overpartitions extend Euler's partition framework by allowing optional marking of first occurrences.",
+    "proofStrategy": "Overpartitions extend Euler's partition framework by allowing optional marking of first occurrences.",
+    "keyInsights": []
   },
   "sections": [],
   "references": [

--- a/src/data/proofs/picks-theorem-oq-01/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01/meta.json
@@ -33,7 +33,8 @@
   "overview": {
     "problemStatement": "Can the Pick's theorem axiom be proved constructively via triangulation into unit lattice triangles?",
     "text": "A 206-line formalization answering YES in principle: the algebraic core of the triangulation proof is complete (0 sorries, 0 axioms). Proves Pick's formula for primitive triangles (base case), the shoelace area formula, Pick's formula for rectangles, and the key additivity lemma showing that merging polygons along shared edges preserves Pick's formula. The remaining gap is formalizing polygon triangulation into primitive lattice triangles, which requires computational geometry infrastructure not yet in Mathlib.",
-    "proofStrategy": "1. Base case: primitive (unimodular) lattice triangles have area 1/2, i=0, b=3, so 0+3/2-1=1/2 ✓\n2. Additivity: when P₁ and P₂ share an edge with k interior lattice points, the union satisfies Pick's formula if both pieces do\n3. Triangulation: every simple lattice polygon can be decomposed into primitive triangles (ear-clipping + subdivision)\n4. Induction: apply additivity from step 2 repeatedly\n\nSteps 1-2 are fully proved; step 3 needs computational geometry infrastructure."
+    "proofStrategy": "1. Base case: primitive (unimodular) lattice triangles have area 1/2, i=0, b=3, so 0+3/2-1=1/2 \u2713\n2. Additivity: when P\u2081 and P\u2082 share an edge with k interior lattice points, the union satisfies Pick's formula if both pieces do\n3. Triangulation: every simple lattice polygon can be decomposed into primitive triangles (ear-clipping + subdivision)\n4. Induction: apply additivity from step 2 repeatedly\n\nSteps 1-2 are fully proved; step 3 needs computational geometry infrastructure.",
+    "keyInsights": []
   },
   "crossReferences": [
     {
@@ -43,11 +44,14 @@
     }
   ],
   "leanFile": {
-    "imports": ["Mathlib"],
+    "imports": [
+      "Mathlib"
+    ],
     "namespace": "PicksTheoremOQ01",
     "lineCount": 206,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 3
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/prob-method-expectation-oq-01/meta.json
+++ b/src/data/proofs/prob-method-expectation-oq-01/meta.json
@@ -4,15 +4,21 @@
   "slug": "prob-method-expectation-oq-01",
   "description": "Bridges the gallery's Finset-based probabilistic method to Mathlib's MeasureTheory. Shows finite probability is a special case of measure-theoretic probability, with linearity of expectation proved from integral_add.",
   "meta": {
-    "author": "Erdős-Spencer, formalized via Mathlib MeasureTheory",
+    "author": "Erd\u0151s-Spencer, formalized via Mathlib MeasureTheory",
     "date": "1974",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/ProbMethodExpectationOQ01.lean",
-    "tags": ["probability", "probabilistic-method", "measure-theory", "combinatorics"],
+    "tags": [
+      "probability",
+      "probabilistic-method",
+      "measure-theory",
+      "combinatorics"
+    ],
     "badge": "axiom",
     "sorries": 2,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
     "lineCount": 100
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/pythagorean-triples-oq-02/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-02/meta.json
@@ -2,13 +2,19 @@
   "id": "pythagorean-triples-oq-02",
   "title": "Pythagorean Triples via Gaussian Integers",
   "slug": "pythagorean-triples-oq-02",
-  "description": "Shows that the parametric formula for Pythagorean triples (m²-n², 2mn, m²+n²) is the squaring map in ℤ[i]. Norm multiplicativity gives the Brahmagupta-Fibonacci identity and a product rule for triples. Fully verified, 0 axioms.",
+  "description": "Shows that the parametric formula for Pythagorean triples (m\u00b2-n\u00b2, 2mn, m\u00b2+n\u00b2) is the squaring map in \u2124[i]. Norm multiplicativity gives the Brahmagupta-Fibonacci identity and a product rule for triples. Fully verified, 0 axioms.",
   "meta": {
     "author": "Brahmagupta (628), Fibonacci (1225), Gauss (1801)",
     "date": "1801",
     "status": "verified",
     "proofRepoPath": "Proofs/PythagoreanTriplesOQ02.lean",
-    "tags": ["number-theory", "gaussian-integers", "pythagorean-triples", "algebraic", "research"],
+    "tags": [
+      "number-theory",
+      "gaussian-integers",
+      "pythagorean-triples",
+      "algebraic",
+      "research"
+    ],
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
@@ -17,31 +23,72 @@
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
-      {"theorem": "PythagoreanTriple", "description": "Predicate a² + b² = c²", "module": "Mathlib.NumberTheory.PythagoreanTriples"}
+      {
+        "theorem": "PythagoreanTriple",
+        "description": "Predicate a\u00b2 + b\u00b2 = c\u00b2",
+        "module": "Mathlib.NumberTheory.PythagoreanTriples"
+      }
     ],
     "originalContributions": [
       "Gaussian integer arithmetic framework (gaussMul, gaussNorm, gaussConj, gaussSq)",
-      "Norm multiplicativity: N(z₁z₂) = N(z₁)N(z₂)",
+      "Norm multiplicativity: N(z\u2081z\u2082) = N(z\u2081)N(z\u2082)",
       "Pythagorean triple from Gaussian squaring: gaussSq_pythagorean",
       "Brahmagupta-Fibonacci identity from norm multiplicativity",
       "Product rule for Pythagorean triples via Gaussian multiplication"
     ]
   },
   "overview": {
-    "text": "Connects Pythagorean triples to Gaussian integers: the parametric formula is squaring in ℤ[i], and norm multiplicativity gives the Brahmagupta-Fibonacci identity.",
+    "text": "Connects Pythagorean triples to Gaussian integers: the parametric formula is squaring in \u2124[i], and norm multiplicativity gives the Brahmagupta-Fibonacci identity.",
     "keyInsights": [
-      "The parametric formula (m²-n², 2mn, m²+n²) IS z² where z = m + ni",
+      "The parametric formula (m\u00b2-n\u00b2, 2mn, m\u00b2+n\u00b2) IS z\u00b2 where z = m + ni",
       "Norm multiplicativity explains why sums of squares are closed under multiplication",
       "Product of Pythagorean triples corresponds to Gaussian multiplication"
-    ]
+    ],
+    "proofStrategy": "Connects Pythagorean triples to Gaussian integers: the parametric formula is squaring in \u2124[i], and norm multiplicativity gives the Brahmagupta-Fibonacci identity."
   },
   "sections": [
-    {"id": "gaussian-arithmetic", "title": "Gaussian Integer Arithmetic", "startLine": 24, "endLine": 46},
-    {"id": "core-properties", "title": "Core Properties", "startLine": 51, "endLine": 68},
-    {"id": "pythagorean-triples", "title": "Pythagorean Triples from Squaring", "startLine": 73, "endLine": 95},
-    {"id": "brahmagupta-fibonacci", "title": "Brahmagupta-Fibonacci Identity", "startLine": 100, "endLine": 120},
-    {"id": "factoring", "title": "The Factoring Perspective", "startLine": 125, "endLine": 140},
-    {"id": "examples", "title": "Concrete Examples", "startLine": 145, "endLine": 170}
+    {
+      "id": "gaussian-arithmetic",
+      "title": "Gaussian Integer Arithmetic",
+      "startLine": 24,
+      "endLine": 46,
+      "summary": "Gaussian Integer Arithmetic"
+    },
+    {
+      "id": "core-properties",
+      "title": "Core Properties",
+      "startLine": 51,
+      "endLine": 68,
+      "summary": "Core Properties"
+    },
+    {
+      "id": "pythagorean-triples",
+      "title": "Pythagorean Triples from Squaring",
+      "startLine": 73,
+      "endLine": 95,
+      "summary": "Pythagorean Triples from Squaring"
+    },
+    {
+      "id": "brahmagupta-fibonacci",
+      "title": "Brahmagupta-Fibonacci Identity",
+      "startLine": 100,
+      "endLine": 120,
+      "summary": "Brahmagupta-Fibonacci Identity"
+    },
+    {
+      "id": "factoring",
+      "title": "The Factoring Perspective",
+      "startLine": 125,
+      "endLine": 140,
+      "summary": "The Factoring Perspective"
+    },
+    {
+      "id": "examples",
+      "title": "Concrete Examples",
+      "startLine": 145,
+      "endLine": 170,
+      "summary": "Concrete Examples"
+    }
   ],
   "conclusion": {
     "summary": "The Gaussian integer connection reveals the algebraic structure behind Pythagorean triples: the parametric formula is squaring, and norm multiplicativity gives the Brahmagupta-Fibonacci identity.",
@@ -49,7 +96,20 @@
     "openQuestions": []
   },
   "crossReferences": [
-    {"slug": "pythagorean-triples", "title": "Formula for Pythagorean Triples", "relation": "parent-problem", "relationship": "extends"}
+    {
+      "slug": "pythagorean-triples",
+      "title": "Formula for Pythagorean Triples",
+      "relation": "parent-problem",
+      "relationship": "extends"
+    }
   ],
-  "leanFile": {"imports": ["Mathlib"], "namespace": "PythagoreanTriplesOQ02", "lineCount": 173, "axiomCount": 0, "theoremCount": 14}
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "PythagoreanTriplesOQ02",
+    "lineCount": 173,
+    "axiomCount": 0,
+    "theoremCount": 14
+  }
 }

--- a/src/data/proofs/randomized-maxcut-oq-02/meta.json
+++ b/src/data/proofs/randomized-maxcut-oq-02/meta.json
@@ -1,1 +1,48 @@
-{"id":"randomized-maxcut-oq-02","title":"Weighted MaxCut Approximation","slug":"randomized-maxcut-oq-02","description":"Extends randomized MaxCut to weighted graphs: random partition achieves W/2 cut weight. Goemans-Williamson 0.878 approximation.","meta":{"author":"Goemans-Williamson (1995)","date":"2026","status":"axiomatized","proofRepoPath":"Proofs/RandomizedMaxcutOQ02.lean","tags":["algorithms","approximation","maxcut","randomized","research"],"badge":"axiom","sorries":0,"axiomCount":1,"lineCount":135,"assumptions":"1 axiom (exists good partition). 0 sorries.","dateAdded":"2026-03-30","mathlib_version":"4.26.0"},"conclusion":{"summary":"Weighted MaxCut: random partition gives 1/2 approximation. GW gives 0.878.","openQuestions":[]},"crossReferences":[{"targetId":"randomized-maxcut","relationship":"parent-problem"}],"leanFile":{"imports":["Mathlib"],"namespace":"WeightedMaxCut","lineCount":135,"axiomCount":1,"theoremCount":5,"definitionCount":5}}
+{
+  "id": "randomized-maxcut-oq-02",
+  "title": "Weighted MaxCut Approximation",
+  "slug": "randomized-maxcut-oq-02",
+  "description": "Extends randomized MaxCut to weighted graphs: random partition achieves W/2 cut weight. Goemans-Williamson 0.878 approximation.",
+  "meta": {
+    "author": "Goemans-Williamson (1995)",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/RandomizedMaxcutOQ02.lean",
+    "tags": [
+      "algorithms",
+      "approximation",
+      "maxcut",
+      "randomized",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 1,
+    "lineCount": 135,
+    "assumptions": "1 axiom (exists good partition). 0 sorries.",
+    "dateAdded": "2026-03-30",
+    "mathlib_version": "4.26.0"
+  },
+  "conclusion": {
+    "summary": "Weighted MaxCut: random partition gives 1/2 approximation. GW gives 0.878.",
+    "openQuestions": [],
+    "implications": ""
+  },
+  "crossReferences": [
+    {
+      "targetId": "randomized-maxcut",
+      "relationship": "parent-problem"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "WeightedMaxCut",
+    "lineCount": 135,
+    "axiomCount": 1,
+    "theoremCount": 5,
+    "definitionCount": 5
+  },
+  "sections": []
+}

--- a/src/data/proofs/roth-theorem-k3-oq-03/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03/meta.json
@@ -2,18 +2,24 @@
   "id": "roth-theorem-k3-oq-03",
   "title": "Density Increment Generalization to k-APs via Gowers Norms",
   "slug": "roth-theorem-k3-oq-03",
-  "description": "Formalizes the generalization of Roth's density increment to k-term arithmetic progressions using Gowers uniformity norms. For k=3, Fourier analysis suffices (U² norm). For k≥4, the U^{k-1} norm controls k-AP counts via the generalized von Neumann theorem.",
+  "description": "Formalizes the generalization of Roth's density increment to k-term arithmetic progressions using Gowers uniformity norms. For k=3, Fourier analysis suffices (U\u00b2 norm). For k\u22654, the U^{k-1} norm controls k-AP counts via the generalized von Neumann theorem.",
   "meta": {
     "author": "Gowers (2001), Green-Tao-Ziegler (2012)",
     "date": "2001",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/RothTheoremOQ03.lean",
-    "tags": ["additive-combinatorics", "gowers-norms", "arithmetic-progressions", "density-increment"],
+    "tags": [
+      "additive-combinatorics",
+      "gowers-norms",
+      "arithmetic-progressions",
+      "density-increment"
+    ],
     "badge": "axiom",
     "sorries": 2,
     "dateAdded": "2026-03-30",
     "axiomCount": 4,
     "assumptions": "4 axioms: gowersNorm (U^s norm function), kAPCount (k-AP counting operator), generalized_von_neumann (k-AP count controlled by U^{k-1} norm), density_increment_kAP (density increases on subprogression for k-AP-free sets). Removed: gowersNorm_nonneg, gowersNorm_mono (unused), inverse_theorem (had placeholder True conclusion).",
     "lineCount": 197
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/schauder-fixed-point-oq-03/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-03/meta.json
@@ -32,7 +32,9 @@
   "overview": {
     "historicalContext": "Kakutani (1941) generalized Brouwer's theorem to set-valued maps. Nash (1950) used it to prove existence of Nash equilibria.",
     "problemStatement": "Formalize the Kakutani fixed point theorem for set-valued maps.",
-    "text": "Defines set-valued maps, upper hemicontinuity, and axiomatizes Kakutani's theorem. Recovers Brouwer as a corollary."
+    "text": "Defines set-valued maps, upper hemicontinuity, and axiomatizes Kakutani's theorem. Recovers Brouwer as a corollary.",
+    "proofStrategy": "Defines set-valued maps, upper hemicontinuity, and axiomatizes Kakutani's theorem. Recovers Brouwer as a corollary.",
+    "keyInsights": []
   },
   "sections": [
     {
@@ -75,7 +77,8 @@
     "summary": "Kakutani framework formalized with 1 axiom (the main theorem). Brouwer recovered as corollary. Nash equilibrium connection sketched.",
     "openQuestions": [
       "Prove kakutani_finite_dim from Brouwer via simplicial approximation"
-    ]
+    ],
+    "implications": ""
   },
   "crossReferences": [
     {

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-01/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-01/meta.json
@@ -1,28 +1,29 @@
 {
-    "id": "solution-of-cubic-oq-03-oq-01",
-    "title": "Discriminant of the Depressed Cubic",
-    "slug": "solution-of-cubic-oq-03-oq-01",
-    "description": "Δ = -4p³ - 27q² = (x₁-x₂)²(x₁-x₃)²(x₂-x₃)² for the depressed cubic x³+px+q=0. Includes root nature from discriminant sign.",
-    "meta": {
-        "status": "verified",
-        "proofRepoPath": "Proofs/SolutionOfCubicOQ03OQ01.lean",
-        "tags": [
-            "algebra",
-            "polynomials",
-            "cubic-equations",
-            "discriminant",
-            "research"
-        ],
-        "badge": "verified",
-        "sorries": 0,
-        "axiomCount": 0,
-        "dateAdded": "2026-03-28",
-        "lineCount": 89
-    },
-    "sorryCount": 0,
+  "id": "solution-of-cubic-oq-03-oq-01",
+  "title": "Discriminant of the Depressed Cubic",
+  "slug": "solution-of-cubic-oq-03-oq-01",
+  "description": "\u0394 = -4p\u00b3 - 27q\u00b2 = (x\u2081-x\u2082)\u00b2(x\u2081-x\u2083)\u00b2(x\u2082-x\u2083)\u00b2 for the depressed cubic x\u00b3+px+q=0. Includes root nature from discriminant sign.",
+  "meta": {
     "status": "verified",
+    "proofRepoPath": "Proofs/SolutionOfCubicOQ03OQ01.lean",
+    "tags": [
+      "algebra",
+      "polynomials",
+      "cubic-equations",
+      "discriminant",
+      "research"
+    ],
     "badge": "verified",
-    "leanFile": {
-        "lineCount": 89
-    }
+    "sorries": 0,
+    "axiomCount": 0,
+    "dateAdded": "2026-03-28",
+    "lineCount": 89
+  },
+  "sorryCount": 0,
+  "status": "verified",
+  "badge": "verified",
+  "leanFile": {
+    "lineCount": 89
+  },
+  "sections": []
 }

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-05/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-05/meta.json
@@ -2,38 +2,55 @@
   "id": "solution-of-cubic-oq-03-oq-05",
   "title": "Vieta's Formulas for the General Cubic",
   "slug": "solution-of-cubic-oq-03-oq-05",
-  "description": "For the general cubic x³ + ax² + bx + c = (x-r₁)(x-r₂)(x-r₃), Vieta's formulas give a = -(r₁+r₂+r₃), b = r₁r₂+r₁r₃+r₂r₃, c = -r₁r₂r₃. Proved over any commutative ring by polynomial coefficient comparison.",
+  "description": "For the general cubic x\u00b3 + ax\u00b2 + bx + c = (x-r\u2081)(x-r\u2082)(x-r\u2083), Vieta's formulas give a = -(r\u2081+r\u2082+r\u2083), b = r\u2081r\u2082+r\u2081r\u2083+r\u2082r\u2083, c = -r\u2081r\u2082r\u2083. Proved over any commutative ring by polynomial coefficient comparison.",
   "meta": {
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Vieta%27s_formulas",
     "date": "2026",
     "status": "verified",
     "proofRepoPath": "Proofs/SolutionOfCubicOQ03OQ05.lean",
-    "tags": ["algebra", "polynomials", "cubic-equations", "vieta-formulas", "symmetric-polynomials", "research"],
+    "tags": [
+      "algebra",
+      "polynomials",
+      "cubic-equations",
+      "vieta-formulas",
+      "symmetric-polynomials",
+      "research"
+    ],
     "badge": "original",
     "sorries": 0,
     "dateAdded": "2026-03-28",
     "axiomCount": 0,
     "lineCount": 112,
     "relatedProblems": [
-      {"id": "solution-of-cubic-oq-03", "relationship": "Parent: Vieta's for depressed cubic"},
-      {"id": "solution-of-cubic", "relationship": "Root: solution of the cubic equation"}
+      {
+        "id": "solution-of-cubic-oq-03",
+        "relationship": "Parent: Vieta's for depressed cubic"
+      },
+      {
+        "id": "solution-of-cubic",
+        "relationship": "Root: solution of the cubic equation"
+      }
     ]
   },
   "overview": {
     "problemStatement": "Verify Vieta's formulas for the general (non-depressed) cubic over a commutative ring.",
-    "proofStrategy": "Expand (x-r₁)(x-r₂)(x-r₃) via ring, then extract coefficients at each degree to obtain the three Vieta relations."
+    "proofStrategy": "Expand (x-r\u2081)(x-r\u2082)(x-r\u2083) via ring, then extract coefficients at each degree to obtain the three Vieta relations.",
+    "keyInsights": []
   },
   "sorryCount": 0,
   "status": "verified",
   "badge": "original",
   "leanFile": {
-    "imports": ["Mathlib"],
+    "imports": [
+      "Mathlib"
+    ],
     "opens": [],
     "namespace": "VietaCubic",
     "lineCount": 112,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/sylow-theorems-oq-01/meta.json
+++ b/src/data/proofs/sylow-theorems-oq-01/meta.json
@@ -2,14 +2,20 @@
   "id": "sylow-theorems-oq-01",
   "title": "Classification of Groups of Order pq via Sylow Theorems",
   "slug": "sylow-theorems-oq-01",
-  "description": "For distinct primes p < q: if p ∤ (q-1), the only group of order pq is cyclic. If p | (q-1), there are exactly two groups (cyclic + non-abelian semidirect product). Proves the Sylow counting arguments (n_q = 1, n_p ∈ {1,q}), normality of unique Sylow subgroups, and states the classification theorem with concrete examples (orders 6, 15, 21, 35).",
+  "description": "For distinct primes p < q: if p \u2224 (q-1), the only group of order pq is cyclic. If p | (q-1), there are exactly two groups (cyclic + non-abelian semidirect product). Proves the Sylow counting arguments (n_q = 1, n_p \u2208 {1,q}), normality of unique Sylow subgroups, and states the classification theorem with concrete examples (orders 6, 15, 21, 35).",
   "meta": {
     "author": "Burnside (1911); Sylow (1872)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Sylow_theorems#Examples",
     "date": "1872/1911",
     "status": "verified",
     "proofRepoPath": "Proofs/SylowTheoremOQ01.lean",
-    "tags": ["group-theory", "finite-groups", "sylow", "classification", "research"],
+    "tags": [
+      "group-theory",
+      "finite-groups",
+      "sylow",
+      "classification",
+      "research"
+    ],
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
@@ -21,33 +27,77 @@
     "problemStatement": "Classify all groups of order pq for distinct primes p < q.",
     "text": "Formalizes the pq-group classification using Sylow counting arguments. Proves uniqueness of Sylow q-subgroups, normality results, and the key divisibility/congruence constraints.",
     "keyInsights": [
-      "The Sylow q-subgroup is always unique (n_q | p and n_q ≡ 1 mod q, with p < q)",
+      "The Sylow q-subgroup is always unique (n_q | p and n_q \u2261 1 mod q, with p < q)",
       "The classification depends solely on whether p | (q-1)",
-      "Concrete examples verify the theory: order 15 cyclic, order 6 has S₃",
+      "Concrete examples verify the theory: order 15 cyclic, order 6 has S\u2083",
       "Helper lemmas compute Sylow subgroup orders via prime factorization of pq"
-    ]
+    ],
+    "proofStrategy": "Formalizes the pq-group classification using Sylow counting arguments. Proves uniqueness of Sylow q-subgroups, normality results, and the key divisibility/congruence constraints."
   },
   "mainTheorems": [
-    {"name": "unique_sylow_q", "type": "core", "description": "The Sylow q-subgroup is always unique (n_q = 1)"},
-    {"name": "sylow_q_normal", "type": "core", "description": "The unique Sylow q-subgroup is normal"},
-    {"name": "unique_sylow_p_when_coprime", "type": "core", "description": "If p ∤ (q-1), the Sylow p-subgroup is also unique"},
-    {"name": "both_normal_when_coprime", "type": "core", "description": "If p ∤ (q-1), both Sylow subgroups are normal"},
-    {"name": "sylow_p_count", "type": "supporting", "description": "n_p ∈ {1, q} for groups of order pq"},
-    {"name": "cyclic_when_coprime", "type": "core", "description": "p ∤ (q-1) → G is cyclic (proved via commutator + order argument)"},
-    {"name": "nonabelian_sylow_p_count", "type": "core", "description": "p | (q-1) and ¬cyclic → n_p = q (proved by contradiction)"},
-    {"name": "pq_cyclic_classification", "type": "core", "description": "p ∤ (q-1) → every group of order pq is cyclic (proved)"},
-    {"name": "order_15_cyclic", "type": "supporting", "description": "Groups of order 15 are cyclic (3 ∤ 4)"}
+    {
+      "name": "unique_sylow_q",
+      "type": "core",
+      "description": "The Sylow q-subgroup is always unique (n_q = 1)"
+    },
+    {
+      "name": "sylow_q_normal",
+      "type": "core",
+      "description": "The unique Sylow q-subgroup is normal"
+    },
+    {
+      "name": "unique_sylow_p_when_coprime",
+      "type": "core",
+      "description": "If p \u2224 (q-1), the Sylow p-subgroup is also unique"
+    },
+    {
+      "name": "both_normal_when_coprime",
+      "type": "core",
+      "description": "If p \u2224 (q-1), both Sylow subgroups are normal"
+    },
+    {
+      "name": "sylow_p_count",
+      "type": "supporting",
+      "description": "n_p \u2208 {1, q} for groups of order pq"
+    },
+    {
+      "name": "cyclic_when_coprime",
+      "type": "core",
+      "description": "p \u2224 (q-1) \u2192 G is cyclic (proved via commutator + order argument)"
+    },
+    {
+      "name": "nonabelian_sylow_p_count",
+      "type": "core",
+      "description": "p | (q-1) and \u00accyclic \u2192 n_p = q (proved by contradiction)"
+    },
+    {
+      "name": "pq_cyclic_classification",
+      "type": "core",
+      "description": "p \u2224 (q-1) \u2192 every group of order pq is cyclic (proved)"
+    },
+    {
+      "name": "order_15_cyclic",
+      "type": "supporting",
+      "description": "Groups of order 15 are cyclic (3 \u2224 4)"
+    }
   ],
   "crossReferences": [
-    {"targetId": "sylow-theorem", "relationship": "extends", "description": "Applies Sylow theorems to classify groups of order pq"}
+    {
+      "targetId": "sylow-theorem",
+      "relationship": "extends",
+      "description": "Applies Sylow theorems to classify groups of order pq"
+    }
   ],
   "leanFile": {
-    "imports": ["Mathlib"],
+    "imports": [
+      "Mathlib"
+    ],
     "namespace": "SylowPQ",
     "lineCount": 387,
     "axiomCount": 0,
     "theoremCount": 20,
     "sorryTheorems": 0,
     "definitionCount": 3
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/taylor-sincos-convergence-oq-03/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-03/meta.json
@@ -32,7 +32,8 @@
   "overview": {
     "problemStatement": "Can the Taylor remainder bounds for sin/cos be sharpened using the alternating series estimation theorem?",
     "text": "A 188-line formalization that answers YES: the alternating series structure of sin(x) = x - x^3/3! + x^5/5! - ... and cos(x) = 1 - x^2/2! + x^4/4! - ... gives error bounds |x|^{2n+1}/(2n+1)! for sin and |x|^{2n}/(2n)! for cos, which are (2n+1) and (2n) times tighter than the Lagrange bounds respectively.",
-    "proofStrategy": "1. Prove the alternating series estimation theorem: for a_0 >= a_1 >= ... >= 0, the alternating partial sums lie between 0 and a_0\n2. Show sin/cos series terms are decreasing for |x| <= 1 and tend to 0\n3. Apply ASE to get tighter remainder bounds\n4. Show these dominate the Lagrange bounds by factor (2n+1) or (2n)"
+    "proofStrategy": "1. Prove the alternating series estimation theorem: for a_0 >= a_1 >= ... >= 0, the alternating partial sums lie between 0 and a_0\n2. Show sin/cos series terms are decreasing for |x| <= 1 and tend to 0\n3. Apply ASE to get tighter remainder bounds\n4. Show these dominate the Lagrange bounds by factor (2n+1) or (2n)",
+    "keyInsights": []
   },
   "crossReferences": [
     {
@@ -50,5 +51,6 @@
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 2
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/three-place-identity-oq-02/meta.json
+++ b/src/data/proofs/three-place-identity-oq-02/meta.json
@@ -5,18 +5,24 @@
   "description": "Formalizes Etter's Stereo Equality Theorem: two equivalence relations suffice to encode three-place relative identity. Proves the forward and reverse constructions, round-trip properties, and shows why a single equivalence relation is insufficient. 0 sorries, 0 axioms.",
   "meta": {
     "status": "verified",
-    "tags": ["foundations", "set-theory", "logic", "identity", "open-question"],
+    "tags": [
+      "foundations",
+      "set-theory",
+      "logic",
+      "identity",
+      "open-question"
+    ],
     "proofRepoPath": "Proofs/ThreePlaceIdentityOQ02.lean",
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. All theorems fully proved.",
     "originalContributions": [
-      "stereoToRelative: Two equivalence relations → relative identity (consensus construction)",
-      "relativeToStereo: Relative identity → two equivalence relations (viewpoint extraction)",
+      "stereoToRelative: Two equivalence relations \u2192 relative identity (consensus construction)",
+      "relativeToStereo: Relative identity \u2192 two equivalence relations (viewpoint extraction)",
       "Stereo equality theorem: two equalities always give valid relative identity",
       "Flat identity is trivial: single equivalence makes all viewpoints agree",
-      "Stereo nontrivial: disagreeing viewpoints → distinct equivalence relations"
+      "Stereo nontrivial: disagreeing viewpoints \u2192 distinct equivalence relations"
     ],
     "dateAdded": "2026-03-30",
     "lineCount": 175,
@@ -24,7 +30,22 @@
     "definitionCount": 5
   },
   "crossReferences": [
-    {"targetId": "three-place-identity", "relationship": "extends", "description": "Extends the base three-place identity formalization with the stereo equality theorem"}
+    {
+      "targetId": "three-place-identity",
+      "relationship": "extends",
+      "description": "Extends the base three-place identity formalization with the stereo equality theorem"
+    }
   ],
-  "leanFile": {"imports": ["Mathlib.Tactic.Tauto", "Mathlib.Logic.Basic"], "namespace": "StereoEquality", "lineCount": 175, "axiomCount": 0, "theoremCount": 8, "definitionCount": 5}
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic.Tauto",
+      "Mathlib.Logic.Basic"
+    ],
+    "namespace": "StereoEquality",
+    "lineCount": 175,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 5
+  },
+  "sections": []
 }

--- a/src/data/proofs/triangular-reciprocals-oq-01/meta.json
+++ b/src/data/proofs/triangular-reciprocals-oq-01/meta.json
@@ -22,16 +22,18 @@
       "partial_fraction: 2/(n(n+1)) = 2/n - 2/(n+1)",
       "triangular, pentagonal, hexagonal definitions with examples",
       "hexagonal_eq_triangular: hexagonal n = triangular (2n-1)",
-      "square_reciprocals_summable: Σ 1/n² converges (p-series)"
+      "square_reciprocals_summable: \u03a3 1/n\u00b2 converges (p-series)"
     ],
     "axiomCount": 0,
     "assumptions": "None. Fully verified.",
     "lineCount": 111
   },
   "overview": {
-    "historicalContext": "Figurate (polygonal) numbers date to the Pythagoreans. The sum of reciprocals of triangular numbers telescopes to 2 via partial fractions. Higher figurate reciprocal sums converge by comparison with 1/n².",
-    "problemStatement": "Generalize Σ 1/T_n to higher figurate numbers Σ 1/P(k,n).",
-    "text": "k-gonal number reciprocals converge for all k >= 3 by comparison with 1/n²."
+    "historicalContext": "Figurate (polygonal) numbers date to the Pythagoreans. The sum of reciprocals of triangular numbers telescopes to 2 via partial fractions. Higher figurate reciprocal sums converge by comparison with 1/n\u00b2.",
+    "problemStatement": "Generalize \u03a3 1/T_n to higher figurate numbers \u03a3 1/P(k,n).",
+    "text": "k-gonal number reciprocals converge for all k >= 3 by comparison with 1/n\u00b2.",
+    "proofStrategy": "k-gonal number reciprocals converge for all k >= 3 by comparison with 1/n\u00b2.",
+    "keyInsights": []
   },
   "sections": [],
   "references": [],

--- a/src/data/proofs/yang-mills-2d-oq-01/meta.json
+++ b/src/data/proofs/yang-mills-2d-oq-01/meta.json
@@ -8,11 +8,19 @@
     "date": "1991",
     "status": "verified",
     "proofRepoPath": "Proofs/YangMills2DOQ01.lean",
-    "tags": ["mathematical-physics", "yang-mills", "gauge-theory", "heat-kernel", "area-law", "casimir-scaling"],
+    "tags": [
+      "mathematical-physics",
+      "yang-mills",
+      "gauge-theory",
+      "heat-kernel",
+      "area-law",
+      "casimir-scaling"
+    ],
     "badge": "verified",
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
     "lineCount": 308
-  }
+  },
+  "sections": []
 }


### PR DESCRIPTION
## Summary
- Fixes TypeScript build errors across 76 proof meta.json files
- Adds missing required fields: sections, section id/summary, overview.proofStrategy/keyInsights, conclusion.implications
- Build now passes successfully

## Test plan
- [x] `pnpm build` passes