### PR TITLE
Research: 4 problems — eliminate 5 axioms + 1 sorry across erdos-949, erdos-411, erdos-1166, pascals-hexagon

### DIFF
--- a/proofs/Proofs/Erdos1166Problem.lean
+++ b/proofs/Proofs/Erdos1166Problem.lean
@@ -15,7 +15,8 @@
 -- (2) Erdős–Taylor: max visit count T_n satisfies T_n ≪ (log n)² a.s.
 --
 -- Status: PROVED
--- Axioms: 5 declarations + 1 structure field = 6 (down from 12)
+-- Axioms: 3 declarations + 1 structure field = 4 (down from 12)
+-- (AlmostSurely is now a def via Filter; mono/conjunction are Mathlib theorems)
 -- Sorries: 0 (cumulative_card_bound proved via induction on interval length)
 -- Eliminated: RandomWalk/trajectory/walk_starts_at_origin → structure,
 --   erdosTaylor_upper_bound (implied by erdosTaylor_constant),
@@ -29,7 +30,7 @@
 
 import Mathlib
 
-open Real
+open Real Filter
 
 namespace Erdos1166
 
@@ -313,19 +314,30 @@ theorem cumulative_card_bound (ω : RandomWalk) (a b : ℕ) (hab : a ≤ b)
           _ ≤ 3 * (maxVisitCount ω b - maxVisitCount ω a + 1) := by omega
 
 -- ## Almost Sure Events
+-- Modeled via Mathlib's Filter theory: a.s. events are those that hold
+-- "eventually" in a filter on the space of random walks. The filter
+-- captures the measure-zero complement structure of probability theory.
+-- Monotonicity and conjunction are derived from Filter axioms (Mathlib).
 
-/-- Probability space for random walks.
-    We axiomatize "almost surely" as a predicate on properties of walks. -/
-axiom AlmostSurely : (RandomWalk → Prop) → Prop
+/-- The probability filter on random walks: axiomatizes the notion of
+    "measure-one" sets without specifying the full measure space.
+    Almost-sure events are exactly those in this filter. -/
+axiom asProbFilter : Filter RandomWalk
 
-/-- Almost sure monotonicity: if P implies Q, then a.s. P implies a.s. Q. -/
-axiom almostSurely_mono {P Q : RandomWalk → Prop}
-    (h : ∀ ω, P ω → Q ω) (hP : AlmostSurely P) : AlmostSurely Q
+/-- P holds almost surely: P is true for "almost all" random walks.
+    Defined as Filter.Eventually, giving us mono/conjunction for free. -/
+def AlmostSurely (P : RandomWalk → Prop) : Prop := ∀ᶠ ω in asProbFilter, P ω
 
-/-- Almost sure conjunction. -/
-axiom almostSurely_and {P Q : RandomWalk → Prop}
+/-- Almost sure monotonicity: derived from Filter.Eventually.mono. -/
+theorem almostSurely_mono {P Q : RandomWalk → Prop}
+    (h : ∀ ω, P ω → Q ω) (hP : AlmostSurely P) : AlmostSurely Q :=
+  hP.mono h
+
+/-- Almost sure conjunction: derived from Filter.inter_mem. -/
+theorem almostSurely_and {P Q : RandomWalk → Prop}
     (hP : AlmostSurely P) (hQ : AlmostSurely Q) :
-    AlmostSurely (fun ω => P ω ∧ Q ω)
+    AlmostSurely (fun ω => P ω ∧ Q ω) :=
+  Filter.inter_mem hP hQ
 
 -- ## Key Result 1: |F(n)| ≤ 3 Eventually a.s.
 -- Related to Erdős problem #1165

--- a/proofs/Proofs/PascalsHexagon.lean
+++ b/proofs/Proofs/PascalsHexagon.lean
@@ -476,8 +476,20 @@ theorem pascalConstraint_projTransform (M : Matrix (Fin 3) (Fin 3) ℝ) (hM : M.
       (projTransform M D) (projTransform M E) (projTransform M F)
     ↔ pascalConstraint A B C D E F := by
   unfold pascalConstraint lineIntersection lineThrough
-  simp only [← crossProduct_projTransform]
-  sorry -- Needs: adjugate composition identity, to be proved in next session
+  -- Apply cross product transformation law: cross(M·u, M·v) = adj(M)ᵀ · cross(u,v)
+  -- Simp applies bottom-up: first inner cross products (using M), then outer (using adj(M)ᵀ)
+  simp only [crossProduct_projTransform]
+  -- Now all three vectors are projTransform (adj(adj(M)ᵀ)ᵀ) applied to original intersections
+  rw [threeVectorMatrix_projTransform]
+  -- Goal: det(adj(adj(M)ᵀ)ᵀ) * det(P,Q,R) = 0 ↔ det(P,Q,R) = 0
+  constructor
+  · intro h
+    have hdet : (M.adjugate.transpose).adjugate.transpose.det ≠ 0 := by
+      simp only [Matrix.det_transpose, Matrix.det_adjugate, Fintype.card_fin]
+      -- det(M)^2^2 ≠ 0
+      exact pow_ne_zero _ (pow_ne_zero _ hM)
+    exact (mul_eq_zero.mp h).resolve_left hdet
+  · intro h; rw [h, mul_zero]
 
 /-
 ### Roadmap for Full Axiom Elimination

--- a/src/data/proofs/erdos-1166/meta.json
+++ b/src/data/proofs/erdos-1166/meta.json
@@ -77,9 +77,9 @@
       "mem_mostVisitedSet",
       "mostVisitedSet_nonempty"
     ],
-    "axiomCount": 5,
-    "lineCount": 535,
-    "assumptions": "6 assumptions (5 axiom declarations + 1 structure field): 3 probability framework (AlmostSurely, almostSurely_mono, almostSurely_and), 1 structural (mostVisited_bounded_eventually), 1 deep result (erdosTaylor_constant), 1 structure field (starts_at_origin). erdos1166_main proved as theorem. polya_recurrence removed as orphan."
+    "axiomCount": 3,
+    "lineCount": 540,
+    "assumptions": "4 assumptions (3 axiom declarations + 1 structure field): 1 probability filter (asProbFilter), 1 structural (mostVisited_bounded_eventually), 1 deep result (erdosTaylor_constant), 1 structure field (starts_at_origin). AlmostSurely is now a def via Filter.Eventually; almostSurely_mono and almostSurely_and are proved from Mathlib's filter API."
   },
   "overview": {
     "historicalContext": "Erdős Problem #1166 was posed by Paul Erdős and Pál Révész in their study of the fine structure of planar random walks. The problem belongs to a cluster of questions (#1165, #1166) about 'favorite points' — the sites most frequently visited by a random walk on $\\mathbb{Z}^2$. The study of favorite points connects to deep results in probability theory going back to Pólya's 1921 recurrence theorem: a simple random walk on $\\mathbb{Z}^2$ returns to its starting point infinitely often, but only barely — the expected number of returns diverges logarithmically, making two dimensions the critical case between recurrence (1D, 2D) and transience (3D+).\n\nThe key breakthrough came from the Erdős–Taylor theorem (1960), which established that the maximum local time $T_n$ (the largest number of visits to any single point through $n$ steps) satisfies $T_n / (\\log n)^2 \\to 1/\\pi$ almost surely. The appearance of $\\pi$ here is remarkable: it arises from the connection between 2D random walks and planar Brownian motion via Donsker's invariance principle, and ultimately from the Green's function of the 2D lattice.\n\nThe answer to Problem #1166 is YES: almost surely $|\\bigcup_{k \\leq n} F(k)| = O((\\log n)^2)$. The proof combines two ingredients: (1) $|F(n)| \\leq 3$ a.s. for large $n$ (Erdős–Révész, related to #1165), and (2) the Erdős–Taylor bound on $T_n$. Since $T_n$ is integer-valued and bounded by $C(\\log n)^2$, there are at most $O((\\log n)^2)$ distinct 'regimes' of most-visited points, each contributing at most 3 new points. This problem is catalogued at erdosproblems.com/1166 and referenced in Révész's monograph [Va99, 6.78].",
@@ -204,11 +204,12 @@
       "Mathlib.Tactic"
     ],
     "opens": [
-      "Real"
+      "Real",
+      "Filter"
     ],
     "namespace": "Erdos1166",
-    "lineCount": 535,
-    "axiomCount": 6,
+    "lineCount": 540,
+    "axiomCount": 3,
     "theoremCount": 23,
     "definitionCount": 1
   },

--- a/src/data/proofs/erdos-411/meta.json
+++ b/src/data/proofs/erdos-411/meta.json
@@ -48,9 +48,9 @@
             "Proved even preservation under g using Mathlib's Nat.totient_even",
             "Formalized Cambie's structural conjecture on the form of r = 2 solutions"
         ],
-        "axiomCount": 4,
-        "lineCount": 173,
-        "assumptions": "4 axioms: cambie_ratio3 (ratio-3 solution n=738), cambie_ratio4_148646 (ratio-4 solution), cambie_ratio4_4325798 (ratio-4 solution), steinerberger_r2_equiv (r=2 reduction to finite equation). The r=2 solutions n=10 and n=94 are fully proved via native_decide."
+        "axiomCount": 3,
+        "lineCount": 223,
+        "assumptions": "3 axioms: cambie_ratio4_148646 (ratio-4 solution), cambie_ratio4_4325798 (ratio-4 solution), steinerberger_r2_equiv (r=2 reduction to finite equation). cambie_ratio3 PROVED via strong induction using g(3m)=3g(m) and 3-divisibility of iterates. The r=2 solutions n=10, n=94 are proved via native_decide."
     },
     "leanFile": {
         "path": "Proofs/Erdos411Problem.lean",
@@ -74,7 +74,7 @@
             "GeneralRatioRelation",
             "CambieConjecture"
         ],
-        "axiomCount": 4,
+        "axiomCount": 3,
         "theoremCount": 9,
         "sorryCount": 0
     },


### PR DESCRIPTION
## Summary
Four research results eliminating axioms and sorries:

### erdos-949: Remove unsound axiom (2→1 axioms)
- Removed `erdos_949_open` — falsely asserted unproved open conjecture

### erdos-411: Prove Cambie ratio-3 (4→3 axioms)
- Proved `cambie_ratio3` via strong induction + `totientStep_triple`

### erdos-1166: Filter refactoring (5→3 axioms)
- `AlmostSurely` → def via `Filter.Eventually`; mono/and from Mathlib

### pascals-hexagon-oq-01: Prove projective invariance (1→0 sorries)
- Proved `pascalConstraint_projTransform` via nested crossProduct_projTransform + det scaling

## Total delta: -5 axioms, -1 sorry

Generated by researcher-5