### PR TITLE
fix: re-apply missing required fields to proof meta.json

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-03/meta.json
@@ -1,18 +1,24 @@
 {
   "id": "amgm-inequality-oq-03-oq-03",
-  "title": "Power Mean Extreme Cases: Limits as r → ±∞",
+  "title": "Power Mean Extreme Cases: Limits as r \u2192 \u00b1\u221e",
   "slug": "amgm-inequality-oq-03-oq-03",
-  "description": "Formalizes the extreme cases of power means: M_r → max as r → +∞ and M_r → min as r → -∞. Also axiomatizes monotonicity of power means in r.",
+  "description": "Formalizes the extreme cases of power means: M_r \u2192 max as r \u2192 +\u221e and M_r \u2192 min as r \u2192 -\u221e. Also axiomatizes monotonicity of power means in r.",
   "meta": {
-    "author": "Hardy-Littlewood-Pólya (1934)",
+    "author": "Hardy-Littlewood-P\u00f3lya (1934)",
     "date": "1934",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/AmgmInequalityOQ03OQ03.lean",
-    "tags": ["inequalities", "power-means", "analysis", "limits"],
+    "tags": [
+      "inequalities",
+      "power-means",
+      "analysis",
+      "limits"
+    ],
     "badge": "axiom",
     "sorries": 2,
     "dateAdded": "2026-03-30",
     "axiomCount": 3,
     "lineCount": 90
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/angle-trisection-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-03/meta.json
@@ -101,27 +101,32 @@
     {
       "title": "Power-of-2 Characterization",
       "description": "A positive number divides some power of 2 iff it is a power of 2",
-      "summary": "Power-of-2 Characterization"
+      "summary": "Power-of-2 Characterization",
+      "id": "power-of-2-characterization"
     },
     {
       "title": "Prime Factor Characterization",
       "description": "A number is a power of 2 iff all its prime factors equal 2",
-      "summary": "Prime Factor Characterization"
+      "summary": "Prime Factor Characterization",
+      "id": "prime-factor-characterization"
     },
     {
       "title": "Decidability of Constructibility",
       "description": "Decidable instances for IsConstructible and related predicates",
-      "summary": "Decidability of Constructibility"
+      "summary": "Decidability of Constructibility",
+      "id": "decidability-of-constructibili"
     },
     {
       "title": "N-gon Constructibility",
       "description": "Decidability of regular polygon constructibility via Gauss-Wantzel",
-      "summary": "N-gon Constructibility"
+      "summary": "N-gon Constructibility",
+      "id": "n-gon-constructibility"
     },
     {
       "title": "Examples and Summary",
       "description": "Concrete examples and complexity analysis",
-      "summary": "Examples and Summary"
+      "summary": "Examples and Summary",
+      "id": "examples-and-summary"
     }
   ],
   "references": [

--- a/src/data/proofs/binary-gcd/meta.json
+++ b/src/data/proofs/binary-gcd/meta.json
@@ -7,15 +7,20 @@
     "author": "Josef Stein (1967), formalized in Lean 4",
     "date": "1967",
     "status": "verified",
-    "tags": ["algorithms", "number-theory", "gcd", "bit-manipulation"],
+    "tags": [
+      "algorithms",
+      "number-theory",
+      "gcd",
+      "bit-manipulation"
+    ],
     "proofRepoPath": "Proofs/GcdAlgorithmOQ02.lean",
     "badge": "original",
     "sorries": 0,
     "originalContributions": [
       "binaryGcd: recursive implementation of Stein's algorithm in Lean 4",
-      "gcd_sub_right: gcd(a-b, b) = gcd(a, b) for b ≤ a",
+      "gcd_sub_right: gcd(a-b, b) = gcd(a, b) for b \u2264 a",
       "gcd_mul_two_left: gcd(2a, b) = gcd(a, b) when b is odd",
-      "gcd_two_mul: gcd(2a, 2b) = 2·gcd(a, b)",
+      "gcd_two_mul: gcd(2a, 2b) = 2\u00b7gcd(a, b)",
       "gcd_odd_sub_half: gcd((a-b)/2, b) = gcd(a, b) for both odd, a > b"
     ],
     "dateAdded": "2026-03-30",
@@ -29,11 +34,14 @@
     "text": "Binary GCD (Stein's algorithm) uses subtraction and division by 2 instead of Euclidean division.",
     "proofStrategy": "Define the algorithm by well-founded recursion on a+b. Prove three key lemmas (even factor extraction, coprime reduction, odd subtraction) and combine for correctness.",
     "keyInsights": [
-      "Three key lemmas: gcd(2a,2b)=2·gcd(a,b), gcd(2a,b)=gcd(a,b) for odd b, gcd(a-b,b)=gcd(a,b)",
+      "Three key lemmas: gcd(2a,2b)=2\u00b7gcd(a,b), gcd(2a,b)=gcd(a,b) for odd b, gcd(a-b,b)=gcd(a,b)",
       "When both arguments are odd, their difference is even, enabling the halving step",
       "Termination: a+b strictly decreases in every recursive call"
     ],
-    "prerequisites": ["GCD properties", "Basic number theory"]
+    "prerequisites": [
+      "GCD properties",
+      "Basic number theory"
+    ]
   },
   "crossReferences": [
     {
@@ -50,7 +58,10 @@
     ]
   },
   "leanFile": {
-    "imports": ["Mathlib.Data.Nat.GCD.Basic", "Mathlib.Tactic"],
+    "imports": [
+      "Mathlib.Data.Nat.GCD.Basic",
+      "Mathlib.Tactic"
+    ],
     "namespace": "BinaryGcd",
     "lineCount": 177,
     "axiomCount": 0,
@@ -68,5 +79,6 @@
       "type": "core",
       "description": "Correctness: binaryGcd a b = Nat.gcd a b"
     }
-  ]
+  ],
+  "sections": []
 }

--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-03/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-03/meta.json
@@ -8,11 +8,17 @@
     "date": "1941",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/BrouwerFixedPointOQ04OQ03.lean",
-    "tags": ["topology", "fixed-point-theory", "game-theory", "functional-analysis"],
+    "tags": [
+      "topology",
+      "fixed-point-theory",
+      "game-theory",
+      "functional-analysis"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 3,
     "lineCount": 165
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "cauchy-schwarz-oq-01-oq-03",
   "title": "Heisenberg Uncertainty from Complex Cauchy-Schwarz",
   "slug": "cauchy-schwarz-oq-01-oq-03",
-  "description": "Derives the Heisenberg uncertainty principle σ_x·σ_p ≥ ℏ/2 from the complex Cauchy-Schwarz inequality. Pure algebraic derivation in abstract inner product spaces.",
+  "description": "Derives the Heisenberg uncertainty principle \u03c3_x\u00b7\u03c3_p \u2265 \u210f/2 from the complex Cauchy-Schwarz inequality. Pure algebraic derivation in abstract inner product spaces.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -25,11 +25,12 @@
   "overview": {
     "problemStatement": "Can the Heisenberg uncertainty principle be derived from the complex Cauchy-Schwarz inequality?",
     "keyInsights": [
-      "Cauchy-Schwarz: |⟨f,g⟩|² ≤ ‖f‖²·‖g‖²",
-      "Im bound: (Im⟨f,g⟩)² ≤ |⟨f,g⟩|²",
-      "Commutator substitution: Im⟨Δx·ψ, Δp·ψ⟩ = ℏ/2",
-      "Pure algebraic derivation — works in any complex inner product space"
-    ]
+      "Cauchy-Schwarz: |\u27e8f,g\u27e9|\u00b2 \u2264 \u2016f\u2016\u00b2\u00b7\u2016g\u2016\u00b2",
+      "Im bound: (Im\u27e8f,g\u27e9)\u00b2 \u2264 |\u27e8f,g\u27e9|\u00b2",
+      "Commutator substitution: Im\u27e8\u0394x\u00b7\u03c8, \u0394p\u00b7\u03c8\u27e9 = \u210f/2",
+      "Pure algebraic derivation \u2014 works in any complex inner product space"
+    ],
+    "proofStrategy": ""
   },
   "conclusion": {
     "summary": "YES. The uncertainty principle is a direct consequence of Cauchy-Schwarz applied to centered observables, plus the imaginary part bound.",
@@ -48,5 +49,6 @@
       "relationship": "extends",
       "description": "Derives uncertainty principle from complex Cauchy-Schwarz"
     }
-  ]
+  ],
+  "sections": []
 }

--- a/src/data/proofs/de-moivre-oq-03-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-03-oq-01/meta.json
@@ -8,11 +8,17 @@
     "date": "1707",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/DeMoivreOQ03OQ01.lean",
-    "tags": ["complex-analysis", "de-moivre", "roots-of-unity", "equidistribution"],
+    "tags": [
+      "complex-analysis",
+      "de-moivre",
+      "roots-of-unity",
+      "equidistribution"
+    ],
     "badge": "axiom",
     "sorries": 1,
     "dateAdded": "2026-03-30",
     "axiomCount": 1,
     "lineCount": 80
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/denumerability-rationals-oq-04/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-04/meta.json
@@ -1,1 +1,53 @@
-{"id":"denumerability-rationals-oq-04","title":"Constructive Denumerability of Algebraic Numbers","slug":"denumerability-rationals-oq-04","description":"Constructive proof that the algebraic numbers are countable, avoiding the full axiom of choice. Uses polynomial countability and FTA for finite roots.","meta":{"author":"Classical (Cantor-style)","date":"2026","status":"verified","proofRepoPath":"Proofs/DenumerabilityRationalsOQ04.lean","tags":["set-theory","countability","algebraic-numbers","constructive","research"],"badge":"original","sorries":0,"axiomCount":0,"lineCount":141,"assumptions":"No axioms or sorries. Fully constructive.","dateAdded":"2026-03-30","mathlib_version":"4.26.0","originalContributions":["Constructive proof of algebraic numbers countability","Finite roots per polynomial via FTA","Choiceless argument documentation"]},"conclusion":{"summary":"Algebraic numbers proved countable without full AC. 0 axioms, 0 sorries.","openQuestions":[]},"crossReferences":[{"targetId":"denumerability-rationals","relationship":"parent-problem"}],"leanFile":{"imports":["Mathlib"],"namespace":"DenumerabilityOQ04","lineCount":141,"axiomCount":0,"theoremCount":7,"definitionCount":1}}
+{
+  "id": "denumerability-rationals-oq-04",
+  "title": "Constructive Denumerability of Algebraic Numbers",
+  "slug": "denumerability-rationals-oq-04",
+  "description": "Constructive proof that the algebraic numbers are countable, avoiding the full axiom of choice. Uses polynomial countability and FTA for finite roots.",
+  "meta": {
+    "author": "Classical (Cantor-style)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/DenumerabilityRationalsOQ04.lean",
+    "tags": [
+      "set-theory",
+      "countability",
+      "algebraic-numbers",
+      "constructive",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 141,
+    "assumptions": "No axioms or sorries. Fully constructive.",
+    "dateAdded": "2026-03-30",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "Constructive proof of algebraic numbers countability",
+      "Finite roots per polynomial via FTA",
+      "Choiceless argument documentation"
+    ]
+  },
+  "conclusion": {
+    "summary": "Algebraic numbers proved countable without full AC. 0 axioms, 0 sorries.",
+    "openQuestions": [],
+    "implications": ""
+  },
+  "crossReferences": [
+    {
+      "targetId": "denumerability-rationals",
+      "relationship": "parent-problem"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "DenumerabilityOQ04",
+    "lineCount": 141,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1
+  },
+  "sections": []
+}

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-01/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-01/meta.json
@@ -25,11 +25,12 @@
     "problemStatement": "Can the Descartes parity result be proved using Mathlib's existing complex root theory?",
     "text": "Proves conjugate root theorem, non-real root pairing, and parity connection. Assesses that the factoring approach is more direct.",
     "keyInsights": [
-      "Conjugate root theorem: z root → z̄ root for real polynomials",
-      "Non-real roots come in pairs → count is always even",
+      "Conjugate root theorem: z root \u2192 z\u0304 root for real polynomials",
+      "Non-real roots come in pairs \u2192 count is always even",
       "Real root count has same parity as degree",
       "Factoring approach (existing proof) is more direct for Lean than complex root theory"
-    ]
+    ],
+    "proofStrategy": "Proves conjugate root theorem, non-real root pairing, and parity connection. Assesses that the factoring approach is more direct."
   },
   "conclusion": {
     "summary": "YES, the complex root theory approach can prove parity, but the factoring approach in OQ01 is more direct. The complex approach has pedagogical value: it explains WHY (non-real roots pair up).",
@@ -53,5 +54,6 @@
       "relationship": "extends",
       "description": "Alternative proof approach for the parity result"
     }
-  ]
+  ],
+  "sections": []
 }

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-oq-01/meta.json
@@ -74,7 +74,8 @@
   ],
   "overview": {
     "text": "Proves the Kronecker symbol is completely multiplicative in the first argument, handling the Kronecker extension to moduli 0, -1, 1, and general n separately.",
-    "proofStrategy": "Case analysis on n. For n=0: unit character multiplicativity. For n=-1: sign character multiplicativity (sgn(ab) = sgn(a)sgn(b)). For n=1: trivial. For general n: combine sign character multiplicativity with Jacobi symbol mul_left from Mathlib."
+    "proofStrategy": "Case analysis on n. For n=0: unit character multiplicativity. For n=-1: sign character multiplicativity (sgn(ab) = sgn(a)sgn(b)). For n=1: trivial. For general n: combine sign character multiplicativity with Jacobi symbol mul_left from Mathlib.",
+    "keyInsights": []
   },
   "references": [
     {

--- a/src/data/proofs/erdos-1066-oq-04/meta.json
+++ b/src/data/proofs/erdos-1066-oq-04/meta.json
@@ -1,1 +1,89 @@
-{"id":"erdos-1066-oq-04","title":"Higher-Dimensional Unit Distance Independence","slug":"erdos-1066-oq-04","description":"Explores g_d(n) — the independence number of unit distance graphs in ℝ^d. Kissing number τ(d) bounds degrees, giving g_d(n) ≥ n/(τ(d)+1) by greedy coloring.","meta":{"author":"Erdős, Swanepoel, et al.","sourceUrl":"https://erdosproblems.com/1066","date":"2026","status":"axiomatized","proofRepoPath":"Proofs/Erdos1066OQ04.lean","tags":["combinatorial-geometry","unit-distance","independence-number","erdos","research"],"badge":"axiom","sorries":1,"axiomCount":2,"lineCount":156,"assumptions":"2 axioms (degree_le_kissing, greedy_independence). 1 sorry.","dateAdded":"2026-03-30","mathlib_version":"4.26.0","originalContributions":["SepConfig structure for d-dimensional separated points","Kissing number lookup with known values","Greedy bound g_d(n) ≥ n/(τ(d)+1) for specific dimensions","Scaling analysis: greedy weakens as d grows"]},"sections":[{"id":"config","title":"Separated Configurations","startLine":20,"endLine":40},{"id":"kissing","title":"Kissing Number Bound","startLine":42,"endLine":70},{"id":"greedy","title":"Greedy Independence","startLine":72,"endLine":92},{"id":"dimensions","title":"Specific Dimensions","startLine":94,"endLine":128}],"conclusion":{"summary":"Higher-dimensional g_d(n) bounded below by n/(τ(d)+1) via greedy coloring. Structural improvements needed for tighter bounds.","openQuestions":[]},"crossReferences":[{"targetId":"erdos-1066","relationship":"parent-problem"},{"targetId":"erdos-1084-oq-01","relationship":"related-problem","description":"Also uses kissing number bounds"}],"leanFile":{"imports":["Mathlib"],"namespace":"Erdos1066OQ04","lineCount":156,"axiomCount":2,"theoremCount":5,"definitionCount":6}}
+{
+  "id": "erdos-1066-oq-04",
+  "title": "Higher-Dimensional Unit Distance Independence",
+  "slug": "erdos-1066-oq-04",
+  "description": "Explores g_d(n) \u2014 the independence number of unit distance graphs in \u211d^d. Kissing number \u03c4(d) bounds degrees, giving g_d(n) \u2265 n/(\u03c4(d)+1) by greedy coloring.",
+  "meta": {
+    "author": "Erd\u0151s, Swanepoel, et al.",
+    "sourceUrl": "https://erdosproblems.com/1066",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos1066OQ04.lean",
+    "tags": [
+      "combinatorial-geometry",
+      "unit-distance",
+      "independence-number",
+      "erdos",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 1,
+    "axiomCount": 2,
+    "lineCount": 156,
+    "assumptions": "2 axioms (degree_le_kissing, greedy_independence). 1 sorry.",
+    "dateAdded": "2026-03-30",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "SepConfig structure for d-dimensional separated points",
+      "Kissing number lookup with known values",
+      "Greedy bound g_d(n) \u2265 n/(\u03c4(d)+1) for specific dimensions",
+      "Scaling analysis: greedy weakens as d grows"
+    ]
+  },
+  "sections": [
+    {
+      "id": "config",
+      "title": "Separated Configurations",
+      "startLine": 20,
+      "endLine": 40,
+      "summary": "Separated Configurations"
+    },
+    {
+      "id": "kissing",
+      "title": "Kissing Number Bound",
+      "startLine": 42,
+      "endLine": 70,
+      "summary": "Kissing Number Bound"
+    },
+    {
+      "id": "greedy",
+      "title": "Greedy Independence",
+      "startLine": 72,
+      "endLine": 92,
+      "summary": "Greedy Independence"
+    },
+    {
+      "id": "dimensions",
+      "title": "Specific Dimensions",
+      "startLine": 94,
+      "endLine": 128,
+      "summary": "Specific Dimensions"
+    }
+  ],
+  "conclusion": {
+    "summary": "Higher-dimensional g_d(n) bounded below by n/(\u03c4(d)+1) via greedy coloring. Structural improvements needed for tighter bounds.",
+    "openQuestions": [],
+    "implications": ""
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1066",
+      "relationship": "parent-problem"
+    },
+    {
+      "targetId": "erdos-1084-oq-01",
+      "relationship": "related-problem",
+      "description": "Also uses kissing number bounds"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "Erdos1066OQ04",
+    "lineCount": 156,
+    "axiomCount": 2,
+    "theoremCount": 5,
+    "definitionCount": 6
+  }
+}

--- a/src/data/proofs/erdos-1118-oq-02/meta.json
+++ b/src/data/proofs/erdos-1118-oq-02/meta.json
@@ -1,1 +1,49 @@
-{"id":"erdos-1118-oq-02","title":"Superlevel Sets in Several Complex Variables","slug":"erdos-1118-oq-02","description":"Higher-dimensional analogue of Erdős 1118: superlevel sets of holomorphic maps ℂⁿ → ℂ. Plurisubharmonicity, Oka theory, Hartogs extension.","meta":{"author":"Camera, Gol'dberg, Oka","sourceUrl":"https://erdosproblems.com/1118","date":"2026","status":"axiomatized","proofRepoPath":"Proofs/Erdos1118OQ02.lean","tags":["complex-analysis","several-variables","superlevel-sets","erdos","research"],"badge":"axiom","sorries":0,"axiomCount":3,"lineCount":120,"assumptions":"3 axioms. 0 sorries.","dateAdded":"2026-03-30","mathlib_version":"4.26.0"},"conclusion":{"summary":"Several-complex-variables analogue explored. Key differences from 1D: plurisubharmonicity, pseudoconvexity, Hartogs extension.","openQuestions":[]},"crossReferences":[{"targetId":"erdos-1118","relationship":"parent-problem"}],"leanFile":{"imports":["Mathlib"],"namespace":"Erdos1118OQ02","lineCount":120,"axiomCount":3,"theoremCount":4,"definitionCount":1}}
+{
+  "id": "erdos-1118-oq-02",
+  "title": "Superlevel Sets in Several Complex Variables",
+  "slug": "erdos-1118-oq-02",
+  "description": "Higher-dimensional analogue of Erd\u0151s 1118: superlevel sets of holomorphic maps \u2102\u207f \u2192 \u2102. Plurisubharmonicity, Oka theory, Hartogs extension.",
+  "meta": {
+    "author": "Camera, Gol'dberg, Oka",
+    "sourceUrl": "https://erdosproblems.com/1118",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos1118OQ02.lean",
+    "tags": [
+      "complex-analysis",
+      "several-variables",
+      "superlevel-sets",
+      "erdos",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 3,
+    "lineCount": 120,
+    "assumptions": "3 axioms. 0 sorries.",
+    "dateAdded": "2026-03-30",
+    "mathlib_version": "4.26.0"
+  },
+  "conclusion": {
+    "summary": "Several-complex-variables analogue explored. Key differences from 1D: plurisubharmonicity, pseudoconvexity, Hartogs extension.",
+    "openQuestions": [],
+    "implications": ""
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1118",
+      "relationship": "parent-problem"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "Erdos1118OQ02",
+    "lineCount": 120,
+    "axiomCount": 3,
+    "theoremCount": 4,
+    "definitionCount": 1
+  },
+  "sections": []
+}

--- a/src/data/proofs/erdos-1151/meta.json
+++ b/src/data/proofs/erdos-1151/meta.json
@@ -75,7 +75,8 @@
       "theorems": [
         "chebyshevNode_mem_Icc"
       ],
-      "summary": "Chebyshev Nodes"
+      "summary": "Chebyshev Nodes",
+      "id": "chebyshev-nodes"
     },
     {
       "title": "Lagrange Interpolation",
@@ -83,7 +84,8 @@
       "lineStart": 57,
       "lineEnd": 80,
       "theorems": [],
-      "summary": "Lagrange Interpolation"
+      "summary": "Lagrange Interpolation",
+      "id": "lagrange-interpolation"
     },
     {
       "title": "Main Conjecture and Special Cases",
@@ -94,7 +96,8 @@
         "erdos_1151_convergent_case",
         "erdos_1151_dense_case"
       ],
-      "summary": "Main Conjecture and Special Cases"
+      "summary": "Main Conjecture and Special Cases",
+      "id": "main-conjecture-and-special-ca"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-1183/meta.json
+++ b/src/data/proofs/erdos-1183/meta.json
@@ -84,7 +84,8 @@
       "lineStart": 35,
       "lineEnd": 62,
       "theorems": [],
-      "summary": "Basic Definitions"
+      "summary": "Basic Definitions",
+      "id": "basic-definitions"
     },
     {
       "title": "Chains Are Sublattices",
@@ -96,7 +97,8 @@
         "chain_inter_mem",
         "chain_isSublattice"
       ],
-      "summary": "Chains Are Sublattices"
+      "summary": "Chains Are Sublattices",
+      "id": "chains-are-sublattices"
     },
     {
       "title": "The Standard Chain",
@@ -109,7 +111,8 @@
         "initialSeg_injective",
         "stdChain_card"
       ],
-      "summary": "The Standard Chain"
+      "summary": "The Standard Chain",
+      "id": "the-standard-chain"
     },
     {
       "title": "Pigeonhole",
@@ -119,7 +122,8 @@
       "theorems": [
         "exists_mono_color_class"
       ],
-      "summary": "Pigeonhole"
+      "summary": "Pigeonhole",
+      "id": "pigeonhole"
     },
     {
       "title": "Main Results",
@@ -130,7 +134,8 @@
         "erdos1183_chain_bound",
         "erdos1183_F_chain_bound"
       ],
-      "summary": "Main Results"
+      "summary": "Main Results",
+      "id": "main-results"
     },
     {
       "title": "Abstract Definitions and Bounds",
@@ -144,7 +149,8 @@
         "achievableSublattice_subset_unionClosed",
         "erdos1183_F_ge_f"
       ],
-      "summary": "Abstract Definitions and Bounds"
+      "summary": "Abstract Definitions and Bounds",
+      "id": "abstract-definitions-and-bound"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-307-oq-02/meta.json
+++ b/src/data/proofs/erdos-307-oq-02/meta.json
@@ -2,14 +2,20 @@
   "id": "erdos-307-oq-02",
   "title": "Prime Reciprocal Products: Sorry Elimination",
   "slug": "erdos-307-oq-02",
-  "description": "Eliminates sorries and axioms from Erdős 307 formalization: proves product_rigidity (was axiom), one_helps_balance, and no_two_three_solution. Documents remaining work: p-adic disjointness and computational size bound.",
+  "description": "Eliminates sorries and axioms from Erd\u0151s 307 formalization: proves product_rigidity (was axiom), one_helps_balance, and no_two_three_solution. Documents remaining work: p-adic disjointness and computational size bound.",
   "meta": {
-    "author": "Research (sorry elimination for Erdős 307)",
+    "author": "Research (sorry elimination for Erd\u0151s 307)",
     "sourceUrl": "https://erdosproblems.com/307",
     "date": "2026",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos307OQ02.lean",
-    "tags": ["number-theory", "primes", "egyptian-fractions", "erdos", "research"],
+    "tags": [
+      "number-theory",
+      "primes",
+      "egyptian-fractions",
+      "erdos",
+      "research"
+    ],
     "badge": "axiom",
     "sorries": 1,
     "axiomCount": 0,
@@ -19,41 +25,78 @@
     "mathlib_version": "4.26.0",
     "originalContributions": [
       "product_rigidity proved (was axiom in parent)",
-      "one_helps_balance: reciprocalSum P > 1 when 1 ∈ P",
+      "one_helps_balance: reciprocalSum P > 1 when 1 \u2208 P",
       "no_two_three_solution: no |P|=2, |Q|=3 prime solution",
       "Documentation of remaining work (p-adic, computational)"
     ]
   },
   "overview": {
-    "historicalContext": "Erdős Problem #307 asks whether two finite sets of primes P, Q can satisfy (Σ 1/p)(Σ 1/q) = 1. The parent formalization has several sorry theorems and axioms. This file eliminates three of them.",
-    "problemStatement": "Can the sorry theorems in the Erdős 307 formalization be proved from Mathlib?",
+    "historicalContext": "Erd\u0151s Problem #307 asks whether two finite sets of primes P, Q can satisfy (\u03a3 1/p)(\u03a3 1/q) = 1. The parent formalization has several sorry theorems and axioms. This file eliminates three of them.",
+    "problemStatement": "Can the sorry theorems in the Erd\u0151s 307 formalization be proved from Mathlib?",
     "text": "Proves 3 of 5 sorry/axiom targets. The remaining two (p-adic disjointness, computational size bound) require infrastructure not yet available.",
     "proofStrategy": "product_rigidity is a trivial iff. one_helps_balance splits the sum at 1. no_two_three_solution uses the tight bound on 3 primes.",
     "keyInsights": [
       "product_rigidity was a trivial iff, not a deep result",
-      "3 distinct primes have reciprocal sum ≤ 31/30 (= 1/2 + 1/3 + 1/5)",
-      "Product of (≤ 5/6)(≤ 31/30) = 31/36 < 1 rules out small cases"
+      "3 distinct primes have reciprocal sum \u2264 31/30 (= 1/2 + 1/3 + 1/5)",
+      "Product of (\u2264 5/6)(\u2264 31/30) = 31/36 < 1 rules out small cases"
     ]
   },
   "sections": [
-    {"id": "setup", "title": "Setup", "summary": "Definitions from parent", "startLine": 22, "endLine": 40},
-    {"id": "three-primes", "title": "Bound for 3 Primes", "summary": "reciprocal sum ≤ 31/30 (1 sorry)", "startLine": 42, "endLine": 113},
-    {"id": "no-2-3", "title": "No |P|=2, |Q|=3 Solution", "summary": "Product ≤ 31/36 < 1", "startLine": 115, "endLine": 138},
-    {"id": "one-helps", "title": "1 Helps Balance", "summary": "Σ 1/p > 1 when 1 ∈ P", "startLine": 140, "endLine": 185},
-    {"id": "rigidity", "title": "Product Rigidity", "summary": "Trivial iff (axiom eliminated)", "startLine": 187, "endLine": 220}
+    {
+      "id": "setup",
+      "title": "Setup",
+      "summary": "Definitions from parent",
+      "startLine": 22,
+      "endLine": 40
+    },
+    {
+      "id": "three-primes",
+      "title": "Bound for 3 Primes",
+      "summary": "reciprocal sum \u2264 31/30 (1 sorry)",
+      "startLine": 42,
+      "endLine": 113
+    },
+    {
+      "id": "no-2-3",
+      "title": "No |P|=2, |Q|=3 Solution",
+      "summary": "Product \u2264 31/36 < 1",
+      "startLine": 115,
+      "endLine": 138
+    },
+    {
+      "id": "one-helps",
+      "title": "1 Helps Balance",
+      "summary": "\u03a3 1/p > 1 when 1 \u2208 P",
+      "startLine": 140,
+      "endLine": 185
+    },
+    {
+      "id": "rigidity",
+      "title": "Product Rigidity",
+      "summary": "Trivial iff (axiom eliminated)",
+      "startLine": 187,
+      "endLine": 220
+    }
   ],
   "conclusion": {
     "summary": "3 of 5 sorry/axiom targets eliminated. Remaining: prime_sets_disjoint (p-adic theory) and prime_set_size_lower_bound (computation).",
     "openQuestions": [
       "Prove prime_sets_disjoint via Mathlib's p-adic valuation",
-      "Compute Σ_{p≤281} 1/p ≥ 2 for the size bound"
-    ]
+      "Compute \u03a3_{p\u2264281} 1/p \u2265 2 for the size bound"
+    ],
+    "implications": ""
   },
   "crossReferences": [
-    {"targetId": "erdos-307", "relationship": "parent-problem", "description": "Parent: Erdős 307 formalization"}
+    {
+      "targetId": "erdos-307",
+      "relationship": "parent-problem",
+      "description": "Parent: Erd\u0151s 307 formalization"
+    }
   ],
   "leanFile": {
-    "imports": ["Mathlib"],
+    "imports": [
+      "Mathlib"
+    ],
     "namespace": "Erdos307OQ02",
     "lineCount": 261,
     "axiomCount": 0,

--- a/src/data/proofs/erdos-525-oq-02/meta.json
+++ b/src/data/proofs/erdos-525-oq-02/meta.json
@@ -1,1 +1,56 @@
-{"id":"erdos-525-oq-02","title":"Multivariate Littlewood Polynomials","slug":"erdos-525-oq-02","description":"Explores higher-dimensional Littlewood polynomials on the d-torus T^d. The square-root cancellation heuristic predicts m(f) ≈ n^(-d/2). Open for d ≥ 2.","meta":{"author":"Konyagin (1994), Cook-Nguyen (2021)","sourceUrl":"https://erdosproblems.com/525","date":"2026","status":"axiomatized","proofRepoPath":"Proofs/Erdos525OQ02.lean","tags":["polynomials","random","littlewood","multivariate","erdos","research"],"badge":"axiom","sorries":1,"axiomCount":1,"lineCount":140,"assumptions":"1 axiom (1D bound), 1 sorry.","dateAdded":"2026-03-30","mathlib_version":"4.26.0","originalContributions":["Multivariate Littlewood polynomial framework","d-torus definition and minimum modulus","Dimension effect: n^d₁ < n^d₂ for d₁ < d₂","Square-root cancellation analysis"]},"conclusion":{"summary":"Multivariate Littlewood polynomials formalized. 1D solved; d≥2 open.","openQuestions":[]},"crossReferences":[{"targetId":"erdos-525","relationship":"parent-problem"}],"leanFile":{"imports":["Mathlib"],"namespace":"Erdos525OQ02","lineCount":140,"axiomCount":1,"theoremCount":4,"definitionCount":4}}
+{
+  "id": "erdos-525-oq-02",
+  "title": "Multivariate Littlewood Polynomials",
+  "slug": "erdos-525-oq-02",
+  "description": "Explores higher-dimensional Littlewood polynomials on the d-torus T^d. The square-root cancellation heuristic predicts m(f) \u2248 n^(-d/2). Open for d \u2265 2.",
+  "meta": {
+    "author": "Konyagin (1994), Cook-Nguyen (2021)",
+    "sourceUrl": "https://erdosproblems.com/525",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos525OQ02.lean",
+    "tags": [
+      "polynomials",
+      "random",
+      "littlewood",
+      "multivariate",
+      "erdos",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 1,
+    "axiomCount": 1,
+    "lineCount": 140,
+    "assumptions": "1 axiom (1D bound), 1 sorry.",
+    "dateAdded": "2026-03-30",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "Multivariate Littlewood polynomial framework",
+      "d-torus definition and minimum modulus",
+      "Dimension effect: n^d\u2081 < n^d\u2082 for d\u2081 < d\u2082",
+      "Square-root cancellation analysis"
+    ]
+  },
+  "conclusion": {
+    "summary": "Multivariate Littlewood polynomials formalized. 1D solved; d\u22652 open.",
+    "openQuestions": [],
+    "implications": ""
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-525",
+      "relationship": "parent-problem"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "Erdos525OQ02",
+    "lineCount": 140,
+    "axiomCount": 1,
+    "theoremCount": 4,
+    "definitionCount": 4
+  },
+  "sections": []
+}

--- a/src/data/proofs/erdos-606-oq-03/meta.json
+++ b/src/data/proofs/erdos-606-oq-03/meta.json
@@ -1,1 +1,54 @@
-{"id":"erdos-606-oq-03","title":"Hyperplane Determination in Higher Dimensions","slug":"erdos-606-oq-03","description":"Explores which hyperplane counts are achievable for n points in ℝ^d. Sylvester-Gallai, Green-Tao, and the gap problem.","meta":{"author":"Sylvester, Green-Tao, Motzkin","sourceUrl":"https://erdosproblems.com/606","date":"2026","status":"axiomatized","proofRepoPath":"Proofs/Erdos606OQ03.lean","tags":["combinatorial-geometry","hyperplanes","sylvester-gallai","erdos","research"],"badge":"axiom","sorries":0,"axiomCount":3,"lineCount":122,"assumptions":"3 axioms. 0 sorries.","dateAdded":"2026-03-30","mathlib_version":"4.26.0","originalContributions":["Max hyperplanes C(n,d), extremal bound n < C(n,d)","Sylvester-Gallai higher-dim framework","Achievable set analysis"]},"conclusion":{"summary":"Achievable hyperplane counts for n points in ℝ^d: between ~n and C(n,d). Full characterization open.","openQuestions":[]},"crossReferences":[{"targetId":"erdos-606","relationship":"parent-problem"}],"leanFile":{"imports":["Mathlib"],"namespace":"Erdos606OQ03","lineCount":122,"axiomCount":3,"theoremCount":4,"definitionCount":0}}
+{
+  "id": "erdos-606-oq-03",
+  "title": "Hyperplane Determination in Higher Dimensions",
+  "slug": "erdos-606-oq-03",
+  "description": "Explores which hyperplane counts are achievable for n points in \u211d^d. Sylvester-Gallai, Green-Tao, and the gap problem.",
+  "meta": {
+    "author": "Sylvester, Green-Tao, Motzkin",
+    "sourceUrl": "https://erdosproblems.com/606",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos606OQ03.lean",
+    "tags": [
+      "combinatorial-geometry",
+      "hyperplanes",
+      "sylvester-gallai",
+      "erdos",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 3,
+    "lineCount": 122,
+    "assumptions": "3 axioms. 0 sorries.",
+    "dateAdded": "2026-03-30",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "Max hyperplanes C(n,d), extremal bound n < C(n,d)",
+      "Sylvester-Gallai higher-dim framework",
+      "Achievable set analysis"
+    ]
+  },
+  "conclusion": {
+    "summary": "Achievable hyperplane counts for n points in \u211d^d: between ~n and C(n,d). Full characterization open.",
+    "openQuestions": [],
+    "implications": ""
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-606",
+      "relationship": "parent-problem"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "Erdos606OQ03",
+    "lineCount": 122,
+    "axiomCount": 3,
+    "theoremCount": 4,
+    "definitionCount": 0
+  },
+  "sections": []
+}

--- a/src/data/proofs/factor-remainder-nullstellensatz-oq-01/meta.json
+++ b/src/data/proofs/factor-remainder-nullstellensatz-oq-01/meta.json
@@ -1,6 +1,6 @@
 {
   "id": "factor-remainder-nullstellensatz-oq-01",
-  "title": "Strong Nullstellensatz I(V(J)) = √J via Mathlib",
+  "title": "Strong Nullstellensatz I(V(J)) = \u221aJ via Mathlib",
   "slug": "factor-remainder-nullstellensatz-oq-01",
   "description": "Bridges the gallery's Factor-Remainder infrastructure to Mathlib's Nullstellensatz (MvPolynomial.vanishingIdeal_zeroLocus_eq_radical). Derives weak Nullstellensatz, membership criterion, and radical ideal correspondence as corollaries.",
   "meta": {
@@ -8,11 +8,17 @@
     "date": "1893",
     "status": "verified",
     "proofRepoPath": "Proofs/FactorRemainderNullstellensatzOQ01.lean",
-    "tags": ["algebra", "algebraic-geometry", "nullstellensatz", "polynomial-rings"],
+    "tags": [
+      "algebra",
+      "algebraic-geometry",
+      "nullstellensatz",
+      "polynomial-rings"
+    ],
     "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
     "lineCount": 85
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/fermats-last-theorem-oq-03/meta.json
+++ b/src/data/proofs/fermats-last-theorem-oq-03/meta.json
@@ -1,1 +1,53 @@
-{"id":"fermats-last-theorem-oq-03","title":"Fermat's Equation over Number Fields","slug":"fermats-last-theorem-oq-03","description":"Explores x^n + y^n = z^n over number fields. Wiles (ℚ), Freitas-Hung-Siksek (real quadratic), and the modularity obstruction.","meta":{"author":"Wiles, Freitas-Hung-Siksek","date":"2026","status":"axiomatized","proofRepoPath":"Proofs/FermatsLastTheoremOQ03.lean","tags":["number-theory","fermat","number-fields","research"],"badge":"axiom","sorries":0,"axiomCount":4,"lineCount":162,"assumptions":"4 axioms (FLT/ℚ, Freitas-Hung-Siksek, modularity obstruction, trivially true). 0 sorries.","dateAdded":"2026-03-30","mathlib_version":"4.26.0","originalContributions":["FermatEquation definition over arbitrary CommRing","Small exponent solutions (n=1,2)","Asymptotic FLT framework","Modularity obstruction analysis"]},"conclusion":{"summary":"FLT over number fields remains largely open. The modularity obstruction is the key difficulty.","openQuestions":[]},"crossReferences":[{"targetId":"fermats-last-theorem","relationship":"parent-problem"}],"leanFile":{"imports":["Mathlib"],"namespace":"FermatsLastTheoremOQ03","lineCount":162,"axiomCount":4,"theoremCount":4,"definitionCount":3}}
+{
+  "id": "fermats-last-theorem-oq-03",
+  "title": "Fermat's Equation over Number Fields",
+  "slug": "fermats-last-theorem-oq-03",
+  "description": "Explores x^n + y^n = z^n over number fields. Wiles (\u211a), Freitas-Hung-Siksek (real quadratic), and the modularity obstruction.",
+  "meta": {
+    "author": "Wiles, Freitas-Hung-Siksek",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/FermatsLastTheoremOQ03.lean",
+    "tags": [
+      "number-theory",
+      "fermat",
+      "number-fields",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 4,
+    "lineCount": 162,
+    "assumptions": "4 axioms (FLT/\u211a, Freitas-Hung-Siksek, modularity obstruction, trivially true). 0 sorries.",
+    "dateAdded": "2026-03-30",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "FermatEquation definition over arbitrary CommRing",
+      "Small exponent solutions (n=1,2)",
+      "Asymptotic FLT framework",
+      "Modularity obstruction analysis"
+    ]
+  },
+  "conclusion": {
+    "summary": "FLT over number fields remains largely open. The modularity obstruction is the key difficulty.",
+    "openQuestions": [],
+    "implications": ""
+  },
+  "crossReferences": [
+    {
+      "targetId": "fermats-last-theorem",
+      "relationship": "parent-problem"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "FermatsLastTheoremOQ03",
+    "lineCount": 162,
+    "axiomCount": 4,
+    "theoremCount": 4,
+    "definitionCount": 3
+  },
+  "sections": []
+}

--- a/src/data/proofs/four-color-theorem-oq-02/meta.json
+++ b/src/data/proofs/four-color-theorem-oq-02/meta.json
@@ -2,17 +2,23 @@
   "id": "four-color-theorem-oq-02",
   "title": "Minimal Unavoidable Reducible Configurations",
   "slug": "four-color-theorem-oq-02",
-  "description": "Formalizes the theory of unavoidable reducible configuration sets for the Four Color Theorem. Historical progression: Appel-Haken 1476 → RSST 633. Open: minimum size unknown.",
+  "description": "Formalizes the theory of unavoidable reducible configuration sets for the Four Color Theorem. Historical progression: Appel-Haken 1476 \u2192 RSST 633. Open: minimum size unknown.",
   "meta": {
     "author": "Robertson-Sanders-Seymour-Thomas (1997)",
     "date": "1997",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/FourColorTheoremOQ02.lean",
-    "tags": ["graph-theory", "four-color-theorem", "configurations", "computer-assisted-proof"],
+    "tags": [
+      "graph-theory",
+      "four-color-theorem",
+      "configurations",
+      "computer-assisted-proof"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 3,
     "lineCount": 110
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/fourier-series-oq-04/meta.json
+++ b/src/data/proofs/fourier-series-oq-04/meta.json
@@ -2,17 +2,23 @@
   "id": "fourier-series-oq-04",
   "title": "Higher-Dimensional Fourier Series Convergence on Tori",
   "slug": "fourier-series-oq-04",
-  "description": "Extends Fourier series convergence to n-dimensional tori T^n. Key differences: multiple summation methods (rectangular, spherical, Bochner-Riesz), Fefferman's divergence for rectangular sums in n≥2, and the open Carleson conjecture for n=2.",
+  "description": "Extends Fourier series convergence to n-dimensional tori T^n. Key differences: multiple summation methods (rectangular, spherical, Bochner-Riesz), Fefferman's divergence for rectangular sums in n\u22652, and the open Carleson conjecture for n=2.",
   "meta": {
     "author": "Fefferman (1971), Stein & Weiss (1971)",
     "date": "1971",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/FourierSeriesOQ04.lean",
-    "tags": ["harmonic-analysis", "fourier-series", "convergence", "multi-dimensional"],
+    "tags": [
+      "harmonic-analysis",
+      "fourier-series",
+      "convergence",
+      "multi-dimensional"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 5,
     "lineCount": 140
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/hilbert-20-oq-01/meta.json
+++ b/src/data/proofs/hilbert-20-oq-01/meta.json
@@ -73,7 +73,8 @@
       "lineStart": 46,
       "lineEnd": 76,
       "theorems": [],
-      "summary": "Linear Differential Operators"
+      "summary": "Linear Differential Operators",
+      "id": "linear-differential-operators"
     },
     {
       "title": "Local Solvability",
@@ -81,7 +82,8 @@
       "lineStart": 78,
       "lineEnd": 98,
       "theorems": [],
-      "summary": "Local Solvability"
+      "summary": "Local Solvability",
+      "id": "local-solvability"
     },
     {
       "title": "Condition (\u03a8)",
@@ -89,7 +91,8 @@
       "lineStart": 100,
       "lineEnd": 122,
       "theorems": [],
-      "summary": "Condition (Ψ)"
+      "summary": "Condition (\u03a8)",
+      "id": "condition-\u03c8"
     },
     {
       "title": "The Nirenberg-Treves Theorem",
@@ -99,7 +102,8 @@
       "theorems": [
         "nirenberg_treves_characterization"
       ],
-      "summary": "The Nirenberg-Treves Theorem"
+      "summary": "The Nirenberg-Treves Theorem",
+      "id": "the-nirenberg-treves-theorem"
     },
     {
       "title": "Special Cases",
@@ -109,7 +113,8 @@
       "theorems": [
         "elliptic_locally_solvable"
       ],
-      "summary": "Special Cases"
+      "summary": "Special Cases",
+      "id": "special-cases"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/hilbert-22-oq-01/meta.json
+++ b/src/data/proofs/hilbert-22-oq-01/meta.json
@@ -1,1 +1,81 @@
-{"id":"hilbert-22-oq-01","title":"Higher-Dimensional Uniformization","slug":"hilbert-22-oq-01","description":"Explores how the uniformization theorem generalizes to higher dimensions via Kodaira dimension, Yau's theorem, and Kobayashi hyperbolicity.","meta":{"author":"Kodaira, Yau, Kobayashi","date":"2026","status":"axiomatized","proofRepoPath":"Proofs/Hilbert22OQ01.lean","tags":["complex-geometry","uniformization","classification","research"],"badge":"axiom","sorries":1,"axiomCount":3,"lineCount":175,"assumptions":"3 axioms (Yau, Kobayashi), 1 sorry.","dateAdded":"2026-03-30","mathlib_version":"4.26.0","originalContributions":["Kodaira dimension as classification invariant","Enriques-Kodaira surface classification","Analogy table: 1D uniformization → higher-dim Kodaira"]},"sections":[{"id":"kodaira","title":"Kodaira Dimension","startLine":28,"endLine":55},{"id":"surfaces","title":"Surface Classification","startLine":57,"endLine":90},{"id":"yau","title":"Yau's Theorem","startLine":92,"endLine":110},{"id":"kobayashi","title":"Kobayashi Hyperbolicity","startLine":112,"endLine":140}],"conclusion":{"summary":"Higher-dimensional uniformization explored via Kodaira dimension and Yau's theorem.","openQuestions":[]},"crossReferences":[{"targetId":"hilbert-22","relationship":"parent-problem"}],"leanFile":{"imports":["Mathlib"],"namespace":"Hilbert22OQ01","lineCount":175,"axiomCount":3,"theoremCount":1,"definitionCount":6}}
+{
+  "id": "hilbert-22-oq-01",
+  "title": "Higher-Dimensional Uniformization",
+  "slug": "hilbert-22-oq-01",
+  "description": "Explores how the uniformization theorem generalizes to higher dimensions via Kodaira dimension, Yau's theorem, and Kobayashi hyperbolicity.",
+  "meta": {
+    "author": "Kodaira, Yau, Kobayashi",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Hilbert22OQ01.lean",
+    "tags": [
+      "complex-geometry",
+      "uniformization",
+      "classification",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 1,
+    "axiomCount": 3,
+    "lineCount": 175,
+    "assumptions": "3 axioms (Yau, Kobayashi), 1 sorry.",
+    "dateAdded": "2026-03-30",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "Kodaira dimension as classification invariant",
+      "Enriques-Kodaira surface classification",
+      "Analogy table: 1D uniformization \u2192 higher-dim Kodaira"
+    ]
+  },
+  "sections": [
+    {
+      "id": "kodaira",
+      "title": "Kodaira Dimension",
+      "startLine": 28,
+      "endLine": 55,
+      "summary": "Kodaira Dimension"
+    },
+    {
+      "id": "surfaces",
+      "title": "Surface Classification",
+      "startLine": 57,
+      "endLine": 90,
+      "summary": "Surface Classification"
+    },
+    {
+      "id": "yau",
+      "title": "Yau's Theorem",
+      "startLine": 92,
+      "endLine": 110,
+      "summary": "Yau's Theorem"
+    },
+    {
+      "id": "kobayashi",
+      "title": "Kobayashi Hyperbolicity",
+      "startLine": 112,
+      "endLine": 140,
+      "summary": "Kobayashi Hyperbolicity"
+    }
+  ],
+  "conclusion": {
+    "summary": "Higher-dimensional uniformization explored via Kodaira dimension and Yau's theorem.",
+    "openQuestions": [],
+    "implications": ""
+  },
+  "crossReferences": [
+    {
+      "targetId": "hilbert-22",
+      "relationship": "parent-problem"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "Hilbert22OQ01",
+    "lineCount": 175,
+    "axiomCount": 3,
+    "theoremCount": 1,
+    "definitionCount": 6
+  }
+}

--- a/src/data/proofs/intermediate-value-theorem-oq-03/meta.json
+++ b/src/data/proofs/intermediate-value-theorem-oq-03/meta.json
@@ -1,1 +1,73 @@
-{"id":"intermediate-value-theorem-oq-03","title":"IVT and Brouwer Fixed Point Connection","slug":"intermediate-value-theorem-oq-03","description":"Explores the equivalence of IVT and Brouwer in 1D, and why Brouwer is strictly stronger in higher dimensions. Proves the 1D case via g(x) = f(x) - x.","meta":{"author":"Classical topology","date":"2026","status":"axiomatized","proofRepoPath":"Proofs/IntermediateValueTheoremOQ03.lean","tags":["topology","fixed-point","ivt","brouwer","research"],"badge":"axiom","sorries":0,"axiomCount":1,"lineCount":155,"assumptions":"1 axiom (brouwer_2d). 0 sorries.","dateAdded":"2026-03-30","mathlib_version":"4.26.0","originalContributions":["1D Brouwer from IVT via g(x) = f(x) - x","IVT fails in 2D: S¹ example","Dimensional hierarchy: IVT ⊂ Brouwer ⊂ Schauder"]},"sections":[{"id":"1d-brouwer","title":"1D Brouwer from IVT","startLine":23,"endLine":45},{"id":"ivt-fails","title":"Why IVT Fails in 2D","startLine":62,"endLine":82}],"conclusion":{"summary":"IVT and Brouwer are equivalent in 1D but Brouwer is strictly stronger in higher dimensions.","openQuestions":[]},"crossReferences":[{"targetId":"intermediate-value-theorem","relationship":"parent-problem"},{"targetId":"schauder-fixed-point-oq-03","relationship":"related-problem","description":"Kakutani framework for infinite-dimensional extensions"}],"leanFile":{"imports":["Mathlib"],"namespace":"IVTBrouwer","lineCount":155,"axiomCount":1,"theoremCount":4,"definitionCount":0}}
+{
+  "id": "intermediate-value-theorem-oq-03",
+  "title": "IVT and Brouwer Fixed Point Connection",
+  "slug": "intermediate-value-theorem-oq-03",
+  "description": "Explores the equivalence of IVT and Brouwer in 1D, and why Brouwer is strictly stronger in higher dimensions. Proves the 1D case via g(x) = f(x) - x.",
+  "meta": {
+    "author": "Classical topology",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/IntermediateValueTheoremOQ03.lean",
+    "tags": [
+      "topology",
+      "fixed-point",
+      "ivt",
+      "brouwer",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 1,
+    "lineCount": 155,
+    "assumptions": "1 axiom (brouwer_2d). 0 sorries.",
+    "dateAdded": "2026-03-30",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "1D Brouwer from IVT via g(x) = f(x) - x",
+      "IVT fails in 2D: S\u00b9 example",
+      "Dimensional hierarchy: IVT \u2282 Brouwer \u2282 Schauder"
+    ]
+  },
+  "sections": [
+    {
+      "id": "1d-brouwer",
+      "title": "1D Brouwer from IVT",
+      "startLine": 23,
+      "endLine": 45,
+      "summary": "1D Brouwer from IVT"
+    },
+    {
+      "id": "ivt-fails",
+      "title": "Why IVT Fails in 2D",
+      "startLine": 62,
+      "endLine": 82,
+      "summary": "Why IVT Fails in 2D"
+    }
+  ],
+  "conclusion": {
+    "summary": "IVT and Brouwer are equivalent in 1D but Brouwer is strictly stronger in higher dimensions.",
+    "openQuestions": [],
+    "implications": ""
+  },
+  "crossReferences": [
+    {
+      "targetId": "intermediate-value-theorem",
+      "relationship": "parent-problem"
+    },
+    {
+      "targetId": "schauder-fixed-point-oq-03",
+      "relationship": "related-problem",
+      "description": "Kakutani framework for infinite-dimensional extensions"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "IVTBrouwer",
+    "lineCount": 155,
+    "axiomCount": 1,
+    "theoremCount": 4,
+    "definitionCount": 0
+  }
+}

--- a/src/data/proofs/konigsberg-oq-03/meta.json
+++ b/src/data/proofs/konigsberg-oq-03/meta.json
@@ -2,17 +2,23 @@
   "id": "konigsberg-oq-03",
   "title": "Eulerian Paths in Hypergraphs and Infinite Graphs",
   "slug": "konigsberg-oq-03",
-  "description": "Generalizes Euler's theorem to r-uniform hypergraphs (NP-complete for r≥3) and infinite graphs (Erdős-Grünwald-Weiszfeld characterization).",
+  "description": "Generalizes Euler's theorem to r-uniform hypergraphs (NP-complete for r\u22653) and infinite graphs (Erd\u0151s-Gr\u00fcnwald-Weiszfeld characterization).",
   "meta": {
-    "author": "Erdős-Grünwald-Weiszfeld (1936), Lonc-Naroski (2010)",
+    "author": "Erd\u0151s-Gr\u00fcnwald-Weiszfeld (1936), Lonc-Naroski (2010)",
     "date": "1936",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/KonigsbergOQ03.lean",
-    "tags": ["graph-theory", "euler-paths", "hypergraphs", "infinite-graphs"],
+    "tags": [
+      "graph-theory",
+      "euler-paths",
+      "hypergraphs",
+      "infinite-graphs"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 4,
     "lineCount": 110
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/law-of-cosines-oq-04/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-04/meta.json
@@ -1,1 +1,82 @@
-{"id":"law-of-cosines-oq-04","title":"Stewart's Theorem from Law of Cosines","slug":"law-of-cosines-oq-04","description":"Derives Stewart's theorem b²m + c²n = a(d² + mn) from the law of cosines applied to sub-triangles with supplementary angles. Includes median length formula as special case.","meta":{"author":"Matthew Stewart (1746)","date":"2026","status":"verified","proofRepoPath":"Proofs/LawOfCosinesOQ04.lean","tags":["geometry","stewarts-theorem","cevian","law-of-cosines","research"],"badge":"original","sorries":0,"axiomCount":0,"lineCount":160,"assumptions":"No axioms or sorries. All results proved from law of cosines.","dateAdded":"2026-03-30","mathlib_version":"4.26.0","originalContributions":["Stewart's theorem derived from supplementary angle law of cosines","Median length formula d² = (2b²+2c²-a²)/4 as special case","Pure algebraic proof via ring and nlinarith"]},"overview":{"historicalContext":"Stewart's theorem (Matthew Stewart, 1746) relates the length of a cevian to the sides of a triangle. It generalizes the law of cosines.","problemStatement":"Derive Stewart's theorem from the law of cosines / inner product form.","text":"Applies law of cosines to both sub-triangles using supplementary angles, then eliminates cosines by adding."},"sections":[{"id":"algebraic","title":"Algebraic Identity","startLine":30,"endLine":42},{"id":"derivation","title":"Stewart's from Cosines","startLine":44,"endLine":100},{"id":"median","title":"Median Length Formula","startLine":102,"endLine":121}],"conclusion":{"summary":"Stewart's theorem fully derived from law of cosines. 0 axioms, 0 sorries.","openQuestions":[]},"crossReferences":[{"targetId":"law-of-cosines","relationship":"parent-problem"}],"leanFile":{"imports":["Mathlib"],"namespace":"StewartsTheorem","lineCount":160,"axiomCount":0,"theoremCount":6,"definitionCount":3}}
+{
+  "id": "law-of-cosines-oq-04",
+  "title": "Stewart's Theorem from Law of Cosines",
+  "slug": "law-of-cosines-oq-04",
+  "description": "Derives Stewart's theorem b\u00b2m + c\u00b2n = a(d\u00b2 + mn) from the law of cosines applied to sub-triangles with supplementary angles. Includes median length formula as special case.",
+  "meta": {
+    "author": "Matthew Stewart (1746)",
+    "date": "2026",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LawOfCosinesOQ04.lean",
+    "tags": [
+      "geometry",
+      "stewarts-theorem",
+      "cevian",
+      "law-of-cosines",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 160,
+    "assumptions": "No axioms or sorries. All results proved from law of cosines.",
+    "dateAdded": "2026-03-30",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "Stewart's theorem derived from supplementary angle law of cosines",
+      "Median length formula d\u00b2 = (2b\u00b2+2c\u00b2-a\u00b2)/4 as special case",
+      "Pure algebraic proof via ring and nlinarith"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Stewart's theorem (Matthew Stewart, 1746) relates the length of a cevian to the sides of a triangle. It generalizes the law of cosines.",
+    "problemStatement": "Derive Stewart's theorem from the law of cosines / inner product form.",
+    "text": "Applies law of cosines to both sub-triangles using supplementary angles, then eliminates cosines by adding.",
+    "proofStrategy": "Applies law of cosines to both sub-triangles using supplementary angles, then eliminates cosines by adding.",
+    "keyInsights": []
+  },
+  "sections": [
+    {
+      "id": "algebraic",
+      "title": "Algebraic Identity",
+      "startLine": 30,
+      "endLine": 42,
+      "summary": "Algebraic Identity"
+    },
+    {
+      "id": "derivation",
+      "title": "Stewart's from Cosines",
+      "startLine": 44,
+      "endLine": 100,
+      "summary": "Stewart's from Cosines"
+    },
+    {
+      "id": "median",
+      "title": "Median Length Formula",
+      "startLine": 102,
+      "endLine": 121,
+      "summary": "Median Length Formula"
+    }
+  ],
+  "conclusion": {
+    "summary": "Stewart's theorem fully derived from law of cosines. 0 axioms, 0 sorries.",
+    "openQuestions": [],
+    "implications": ""
+  },
+  "crossReferences": [
+    {
+      "targetId": "law-of-cosines",
+      "relationship": "parent-problem"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "StewartsTheorem",
+    "lineCount": 160,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 3
+  }
+}

--- a/src/data/proofs/lebesgue-measure-oq-03/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-03/meta.json
@@ -1,1 +1,81 @@
-{"id":"lebesgue-measure-oq-03","title":"Infinite-Dimensional Measure Theory","slug":"lebesgue-measure-oq-03","description":"Explores why Lebesgue measure fails in infinite dimensions (no translation-invariant σ-finite measure) and what replaces it (Gaussian/Wiener measures). Proves the orthonormal separation argument.","meta":{"author":"Gross (1967), Wiener","date":"2026","status":"axiomatized","proofRepoPath":"Proofs/LebesgueMeasureOQ03.lean","tags":["measure-theory","infinite-dimensional","gaussian-measure","research"],"badge":"axiom","sorries":0,"axiomCount":3,"lineCount":170,"assumptions":"3 axioms. 0 sorries.","dateAdded":"2026-03-30","mathlib_version":"4.26.0","originalContributions":["Orthonormal vectors have distance √2 (proved)","√2 > 2/3 separation for disjoint balls (proved)","Framework: impossibility → Gaussian → Wiener"]},"sections":[{"id":"impossibility","title":"The Impossibility Result","startLine":20,"endLine":50},{"id":"separation","title":"Orthogonal Separation","startLine":52,"endLine":82},{"id":"gaussian","title":"Gaussian Measures","startLine":84,"endLine":108},{"id":"wiener","title":"Wiener Measure","startLine":110,"endLine":130}],"conclusion":{"summary":"No Lebesgue measure in ∞-dim. Gaussian and Wiener measures are the replacements.","openQuestions":[]},"crossReferences":[{"targetId":"lebesgue-measure","relationship":"parent-problem"}],"leanFile":{"imports":["Mathlib"],"namespace":"LebesgueMeasureOQ03","lineCount":170,"axiomCount":3,"theoremCount":4,"definitionCount":0}}
+{
+  "id": "lebesgue-measure-oq-03",
+  "title": "Infinite-Dimensional Measure Theory",
+  "slug": "lebesgue-measure-oq-03",
+  "description": "Explores why Lebesgue measure fails in infinite dimensions (no translation-invariant \u03c3-finite measure) and what replaces it (Gaussian/Wiener measures). Proves the orthonormal separation argument.",
+  "meta": {
+    "author": "Gross (1967), Wiener",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/LebesgueMeasureOQ03.lean",
+    "tags": [
+      "measure-theory",
+      "infinite-dimensional",
+      "gaussian-measure",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 3,
+    "lineCount": 170,
+    "assumptions": "3 axioms. 0 sorries.",
+    "dateAdded": "2026-03-30",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "Orthonormal vectors have distance \u221a2 (proved)",
+      "\u221a2 > 2/3 separation for disjoint balls (proved)",
+      "Framework: impossibility \u2192 Gaussian \u2192 Wiener"
+    ]
+  },
+  "sections": [
+    {
+      "id": "impossibility",
+      "title": "The Impossibility Result",
+      "startLine": 20,
+      "endLine": 50,
+      "summary": "The Impossibility Result"
+    },
+    {
+      "id": "separation",
+      "title": "Orthogonal Separation",
+      "startLine": 52,
+      "endLine": 82,
+      "summary": "Orthogonal Separation"
+    },
+    {
+      "id": "gaussian",
+      "title": "Gaussian Measures",
+      "startLine": 84,
+      "endLine": 108,
+      "summary": "Gaussian Measures"
+    },
+    {
+      "id": "wiener",
+      "title": "Wiener Measure",
+      "startLine": 110,
+      "endLine": 130,
+      "summary": "Wiener Measure"
+    }
+  ],
+  "conclusion": {
+    "summary": "No Lebesgue measure in \u221e-dim. Gaussian and Wiener measures are the replacements.",
+    "openQuestions": [],
+    "implications": ""
+  },
+  "crossReferences": [
+    {
+      "targetId": "lebesgue-measure",
+      "relationship": "parent-problem"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "LebesgueMeasureOQ03",
+    "lineCount": 170,
+    "axiomCount": 3,
+    "theoremCount": 4,
+    "definitionCount": 0
+  }
+}

--- a/src/data/proofs/mean-value-theorem-oq-02/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-02/meta.json
@@ -41,7 +41,7 @@
     ]
   },
   "overview": {
-    "historicalContext": "Taylor's theorem (Brook Taylor, 1715) with the Lagrange form of the remainder (Joseph-Louis Lagrange, 1797) is one of the most important results in calculus. It generalizes the Mean Value Theorem to higher order: f(b) = T_n(b) + f^(n+1)(c)/(n+1)! · (b-a)^(n+1).",
+    "historicalContext": "Taylor's theorem (Brook Taylor, 1715) with the Lagrange form of the remainder (Joseph-Louis Lagrange, 1797) is one of the most important results in calculus. It generalizes the Mean Value Theorem to higher order: f(b) = T_n(b) + f^(n+1)(c)/(n+1)! \u00b7 (b-a)^(n+1).",
     "problemStatement": "Is there a Mathlib-compatible formalization of the higher-order MVT (Taylor's theorem with Lagrange remainder)?",
     "text": "Defines the Taylor polynomial, axiomatizes the Lagrange remainder form, and derives the MVT as a special case. Mathlib has the integral remainder form but converting to Lagrange requires the generalized MVT for integrals.",
     "proofStrategy": "Define Taylor polynomials using iteratedDeriv and Finset.sum. Axiomatize the Lagrange form. Derive special cases (n=0 gives MVT, n=1 gives second-order expansion) by specializing and simplifying.",
@@ -59,14 +59,14 @@
     {
       "id": "taylor-polynomial",
       "title": "The Taylor Polynomial",
-      "summary": "Defines T_n(x) = Σ f^(k)(a)/k! · (x-a)^k and proves n=0,1 cases",
+      "summary": "Defines T_n(x) = \u03a3 f^(k)(a)/k! \u00b7 (x-a)^k and proves n=0,1 cases",
       "startLine": 39,
       "endLine": 69
     },
     {
       "id": "lagrange-remainder",
       "title": "Taylor's Theorem with Lagrange Remainder",
-      "summary": "Axiomatizes: f(b) - T_n(b) = f^(n+1)(c)/(n+1)! · (b-a)^(n+1)",
+      "summary": "Axiomatizes: f(b) - T_n(b) = f^(n+1)(c)/(n+1)! \u00b7 (b-a)^(n+1)",
       "startLine": 71,
       "endLine": 99
     },
@@ -80,14 +80,15 @@
     {
       "id": "second-order",
       "title": "Second-Order Taylor",
-      "summary": "f(b) = f(a) + f'(a)(b-a) + f''(c)/2·(b-a)²",
+      "summary": "f(b) = f(a) + f'(a)(b-a) + f''(c)/2\u00b7(b-a)\u00b2",
       "startLine": 129,
       "endLine": 155
     }
   ],
   "conclusion": {
     "summary": "Taylor's theorem with Lagrange remainder is formalized using Mathlib's iteratedDeriv. The Lagrange form is axiomatized (1 axiom) because converting from Mathlib's integral remainder requires substantial infrastructure. The MVT and second-order expansion are derived as special cases.",
-    "openQuestions": []
+    "openQuestions": [],
+    "implications": ""
   },
   "crossReferences": [
     {
@@ -98,7 +99,9 @@
   ],
   "references": [
     {
-      "authors": ["W. Rudin"],
+      "authors": [
+        "W. Rudin"
+      ],
       "title": "Principles of Mathematical Analysis",
       "year": "1976",
       "venue": "McGraw-Hill",
@@ -113,7 +116,11 @@
       "Mathlib.Analysis.SpecialFunctions.Pow.Deriv",
       "Mathlib.Tactic"
     ],
-    "opens": ["Real", "MeasureTheory", "Set"],
+    "opens": [
+      "Real",
+      "MeasureTheory",
+      "Set"
+    ],
     "namespace": "MeanValueTheoremOQ02",
     "lineCount": 155,
     "axiomCount": 1,

--- a/src/data/proofs/morleys-theorem-oq-01/meta.json
+++ b/src/data/proofs/morleys-theorem-oq-01/meta.json
@@ -26,7 +26,7 @@
     "mathlibDependencies": [
       {
         "theorem": "Real.sin_pos_of_pos_of_lt_pi",
-        "description": "sin is positive on (0, π)",
+        "description": "sin is positive on (0, \u03c0)",
         "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
       },
       {
@@ -47,11 +47,11 @@
     "historicalContext": "John Conway devised an elegant 'backward' proof of Morley's theorem: instead of starting with a triangle and finding the equilateral Morley triangle (hard), start with an equilateral triangle and reconstruct the original around it (easier). This file formalizes the construction and supporting angle computations.",
     "problemStatement": "Can morleys_theorem_axiom be proved via Conway's backward construction?",
     "text": "Formalizes the ear construction, proves all angle identities and the Morley side length formula, and reduces the full theorem to a coordinate verification.",
-    "proofStrategy": "Build three isoceles 'ear' triangles on the equilateral Morley triangle, one per side, with apex angles π/3 + α₃, π/3 + β₃, π/3 + γ₃. The Conway angle identities show the correct angles at each vertex. The symmetric side length formula 8R·sin(α/3)·sin(β/3)·sin(γ/3) gives the equilateral property.",
+    "proofStrategy": "Build three isoceles 'ear' triangles on the equilateral Morley triangle, one per side, with apex angles \u03c0/3 + \u03b1\u2083, \u03c0/3 + \u03b2\u2083, \u03c0/3 + \u03b3\u2083. The Conway angle identities show the correct angles at each vertex. The symmetric side length formula 8R\u00b7sin(\u03b1/3)\u00b7sin(\u03b2/3)\u00b7sin(\u03b3/3) gives the equilateral property.",
     "keyInsights": [
       "Conway's backward construction avoids the hard direction of the proof",
-      "The key identity α₃ + β₃ + γ₃ = π/3 drives all angle computations",
-      "The Morley side formula 8R·sin(α/3)·sin(β/3)·sin(γ/3) is symmetric, immediately giving the equilateral property",
+      "The key identity \u03b1\u2083 + \u03b2\u2083 + \u03b3\u2083 = \u03c0/3 drives all angle computations",
+      "The Morley side formula 8R\u00b7sin(\u03b1/3)\u00b7sin(\u03b2/3)\u00b7sin(\u03b3/3) is symmetric, immediately giving the equilateral property",
       "The remaining coordinate verification is finite and mechanical"
     ]
   },
@@ -66,14 +66,14 @@
     {
       "id": "angle-identities",
       "title": "Key Angle Identities",
-      "summary": "Trisected sum = π/3, positivity, bound < π/3",
+      "summary": "Trisected sum = \u03c0/3, positivity, bound < \u03c0/3",
       "startLine": 56,
       "endLine": 79
     },
     {
       "id": "ear-construction",
       "title": "Conway's Ear Construction",
-      "summary": "Ear apex angles, their sum (4π/3), base angles",
+      "summary": "Ear apex angles, their sum (4\u03c0/3), base angles",
       "startLine": 81,
       "endLine": 133
     },
@@ -87,7 +87,7 @@
     {
       "id": "side-formula",
       "title": "The Side Length Formula",
-      "summary": "Morley side length = 8R·sin(α/3)·sin(β/3)·sin(γ/3), symmetry, positivity",
+      "summary": "Morley side length = 8R\u00b7sin(\u03b1/3)\u00b7sin(\u03b2/3)\u00b7sin(\u03b3/3), symmetry, positivity",
       "startLine": 177,
       "endLine": 210
     },
@@ -101,7 +101,7 @@
     {
       "id": "trig-identities",
       "title": "Trig Identities for Computation",
-      "summary": "Product-to-sum, cos(α₃+β₃) = cos(π/3-γ₃)",
+      "summary": "Product-to-sum, cos(\u03b1\u2083+\u03b2\u2083) = cos(\u03c0/3-\u03b3\u2083)",
       "startLine": 232,
       "endLine": 260
     }
@@ -109,8 +109,9 @@
   "conclusion": {
     "summary": "All supporting lemmas for Conway's backward proof are verified (0 axioms, 0 sorries). The remaining step is the coordinate computation showing each Morley side equals the symmetric formula.",
     "openQuestions": [
-      "Complete the coordinate verification: place equilateral triangle in complex plane, compute ear vertices, verify side lengths match 8R·sin(α/3)·sin(β/3)·sin(γ/3)"
-    ]
+      "Complete the coordinate verification: place equilateral triangle in complex plane, compute ear vertices, verify side lengths match 8R\u00b7sin(\u03b1/3)\u00b7sin(\u03b2/3)\u00b7sin(\u03b3/3)"
+    ],
+    "implications": ""
   },
   "crossReferences": [
     {
@@ -121,7 +122,9 @@
   ],
   "references": [
     {
-      "authors": ["J. H. Conway"],
+      "authors": [
+        "J. H. Conway"
+      ],
       "title": "The power of mathematics (Morley's miracle)",
       "year": "1995",
       "venue": "In: Power (ed. A. Blackwell and D. MacKay)",
@@ -129,8 +132,12 @@
     }
   ],
   "leanFile": {
-    "imports": ["Mathlib"],
-    "opens": ["Real"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real"
+    ],
     "namespace": "MorleysTheoremOQ01",
     "lineCount": 297,
     "axiomCount": 0,

--- a/src/data/proofs/motivic-flag-maps-oq-02/meta.json
+++ b/src/data/proofs/motivic-flag-maps-oq-02/meta.json
@@ -25,12 +25,12 @@
     "mathlibDependencies": [
       {
         "theorem": "mul_geom_sum",
-        "description": "Geometric series formula: (x-1) * ∑ x^i = x^n - 1",
+        "description": "Geometric series formula: (x-1) * \u2211 x^i = x^n - 1",
         "module": "Mathlib.Algebra.Ring.GeomSum"
       },
       {
         "theorem": "Finset.sum_range_id",
-        "description": "Gauss sum formula: ∑_{i<n} i = n(n-1)/2",
+        "description": "Gauss sum formula: \u2211_{i<n} i = n(n-1)/2",
         "module": "Mathlib.Algebra.BigOperators.Ring"
       },
       {
@@ -44,12 +44,12 @@
       "Recursive Grassmannian motivic class via q-Pascal identity",
       "Explicit Grassmannian computations: Gr(1,2), Gr(1,3), Gr(2,3), Gr(2,4)",
       "q-factorial = complete flag class identity (proved)",
-      "Geometric series factorization: L^n - 1 = (L-1)·[n]_L (proved via mul_geom_sum)",
-      "GL_n decomposition: [GL_n] = (L-1)^n · [n]_L! · L^{T(n)} (proved)",
+      "Geometric series factorization: L^n - 1 = (L-1)\u00b7[n]_L (proved via mul_geom_sum)",
+      "GL_n decomposition: [GL_n] = (L-1)^n \u00b7 [n]_L! \u00b7 L^{T(n)} (proved)",
       "GL_n-flag variety structural relation (proved)",
       "Partial flag variety definition and motivic class factorization",
-      "Extension conjecture: maps to partial flags give parabolic × affine classes",
-      "Gaussian binomial identity statement: [Gr(d,n)] · [d]! · [n-d]! = [n]!"
+      "Extension conjecture: maps to partial flags give parabolic \u00d7 affine classes",
+      "Gaussian binomial identity statement: [Gr(d,n)] \u00b7 [d]! \u00b7 [n-d]! = [n]!"
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 3,
@@ -61,50 +61,55 @@
     {
       "id": "q-analogs",
       "title": "q-Analog Infrastructure",
-      "description": "q-numbers [n]_L = 1 + L + ... + L^{n-1} and q-factorials [n]_L! = ∏ [i]_L, connecting motivic algebra to combinatorics. Key result: [n]_L! = [Fl_n].",
+      "description": "q-numbers [n]_L = 1 + L + ... + L^{n-1} and q-factorials [n]_L! = \u220f [i]_L, connecting motivic algebra to combinatorics. Key result: [n]_L! = [Fl_n].",
       "startLine": 63,
-      "endLine": 140
+      "endLine": 140,
+      "summary": "q-Analog Infrastructure"
     },
     {
       "id": "grassmannians",
       "title": "Grassmannian Motivic Classes",
-      "description": "Recursive definition of [Gr(d,n)] via the q-Pascal identity. Verified for Gr(1,2), Gr(1,3), Gr(2,3), Gr(2,4). The coefficient 2 on L² in [Gr(2,4)] reflects two Schubert cells.",
+      "description": "Recursive definition of [Gr(d,n)] via the q-Pascal identity. Verified for Gr(1,2), Gr(1,3), Gr(2,3), Gr(2,4). The coefficient 2 on L\u00b2 in [Gr(2,4)] reflects two Schubert cells.",
       "startLine": 142,
-      "endLine": 231
+      "endLine": 231,
+      "summary": "Grassmannian Motivic Classes"
     },
     {
       "id": "partial-flags",
       "title": "Partial Flag Varieties",
-      "description": "Definition of partial flags Fl(d₁,...,dₖ; n) as nested subspaces. Motivic class factorization via iterated Grassmannian fibrations.",
+      "description": "Definition of partial flags Fl(d\u2081,...,d\u2096; n) as nested subspaces. Motivic class factorization via iterated Grassmannian fibrations.",
       "startLine": 233,
-      "endLine": 274
+      "endLine": 274,
+      "summary": "Partial Flag Varieties"
     },
     {
       "id": "extension-conjecture",
       "title": "Extension Conjecture",
-      "description": "States the conjectured extension of Bryan et al. to partial flags: [Ω²_β(Fl(d₁,...,dₖ; n+1))] = [Levi × U × A^{a'}]. The complete flag case recovers the original theorem.",
+      "description": "States the conjectured extension of Bryan et al. to partial flags: [\u03a9\u00b2_\u03b2(Fl(d\u2081,...,d\u2096; n+1))] = [Levi \u00d7 U \u00d7 A^{a'}]. The complete flag case recovers the original theorem.",
       "startLine": 276,
-      "endLine": 310
+      "endLine": 310,
+      "summary": "Extension Conjecture"
     },
     {
       "id": "gln-structure",
       "title": "GL_n Structure via q-Analogs",
-      "description": "Proved: [GL_n] = (L-1)^n · [n]_L! · L^{T(n)}, explaining why flag varieties appear in the GL_n formula. Uses mul_geom_sum from Mathlib.",
+      "description": "Proved: [GL_n] = (L-1)^n \u00b7 [n]_L! \u00b7 L^{T(n)}, explaining why flag varieties appear in the GL_n formula. Uses mul_geom_sum from Mathlib.",
       "startLine": 312,
-      "endLine": 345
+      "endLine": 345,
+      "summary": "GL_n Structure via q-Analogs"
     }
   ],
   "overview": {
-    "historicalContext": "Bryan et al. (arXiv:2601.07222) proved that motivic classes of based maps to complete flag varieties have a remarkably simple form: [GL_n × A^a]. A natural question is whether this extends to partial flag varieties — varieties parameterizing incomplete chains of subspaces. Partial flags include Grassmannians (single subspace) and other important moduli spaces in algebraic geometry.",
-    "problemStatement": "**Open Question**: Does the motivic class formula [Ω²_β(Fl_{n+1})] = [GL_n × A^a] extend to partial flag varieties?\n\nFor a partial flag Fl(d₁,...,dₖ; n+1), the conjectured extension involves the parabolic subgroup P = Levi ⋊ U corresponding to the flag type:\n$$[\\Omega^2_\\beta(\\text{Fl}(d_1,\\ldots,d_k; n+1))] = [\\text{Levi} \\times U \\times \\mathbb{A}^{a'}]$$\n\nwhere Levi = GL_{n₁} × ... × GL_{n_{k+1}} for block sizes nᵢ.",
+    "historicalContext": "Bryan et al. (arXiv:2601.07222) proved that motivic classes of based maps to complete flag varieties have a remarkably simple form: [GL_n \u00d7 A^a]. A natural question is whether this extends to partial flag varieties \u2014 varieties parameterizing incomplete chains of subspaces. Partial flags include Grassmannians (single subspace) and other important moduli spaces in algebraic geometry.",
+    "problemStatement": "**Open Question**: Does the motivic class formula [\u03a9\u00b2_\u03b2(Fl_{n+1})] = [GL_n \u00d7 A^a] extend to partial flag varieties?\n\nFor a partial flag Fl(d\u2081,...,d\u2096; n+1), the conjectured extension involves the parabolic subgroup P = Levi \u22ca U corresponding to the flag type:\n$$[\\Omega^2_\\beta(\\text{Fl}(d_1,\\ldots,d_k; n+1))] = [\\text{Levi} \\times U \\times \\mathbb{A}^{a'}]$$\n\nwhere Levi = GL_{n\u2081} \u00d7 ... \u00d7 GL_{n_{k+1}} for block sizes n\u1d62.",
     "text": "Extension of the Bryan et al. motivic class theorem from complete to partial flag varieties, with q-analog infrastructure and Grassmannian motivic classes.",
-    "proofStrategy": "We formalize the necessary infrastructure:\n1. **q-Analogs**: q-numbers [n]_L and q-factorials [n]_L! are defined and proved equal to flag variety classes\n2. **Grassmannians**: Motivic classes via recursive q-Pascal identity, with explicit small cases verified\n3. **Partial Flags**: Defined with motivic class factorization through Grassmannian fibers\n4. **Extension**: The conjecture is stated formally with parabolic subgroup structure\n5. **Structural Identity**: We prove [GL_n] = (L-1)^n · [Fl_n] · L^{T(n)}, revealing why flag varieties appear in GL_n",
+    "proofStrategy": "We formalize the necessary infrastructure:\n1. **q-Analogs**: q-numbers [n]_L and q-factorials [n]_L! are defined and proved equal to flag variety classes\n2. **Grassmannians**: Motivic classes via recursive q-Pascal identity, with explicit small cases verified\n3. **Partial Flags**: Defined with motivic class factorization through Grassmannian fibers\n4. **Extension**: The conjecture is stated formally with parabolic subgroup structure\n5. **Structural Identity**: We prove [GL_n] = (L-1)^n \u00b7 [Fl_n] \u00b7 L^{T(n)}, revealing why flag varieties appear in GL_n",
     "keyInsights": [
-      "The q-factorial [n]_L! equals the complete flag class [Fl_n] — this is the bridge between q-combinatorics and algebraic geometry",
+      "The q-factorial [n]_L! equals the complete flag class [Fl_n] \u2014 this is the bridge between q-combinatorics and algebraic geometry",
       "Grassmannian classes follow a recursive q-Pascal identity, paralleling classical binomial coefficients",
-      "The GL_n class decomposes as (L-1)^n times the flag class times a power of L — this explains the structural connection",
-      "For partial flags, the parabolic subgroup (Levi × unipotent radical) replaces GL_n in the extension conjecture",
-      "The first non-trivial Grassmannian [Gr(2,4)] = 1+L+2L²+L³+L⁴ shows Schubert cell multiplicity"
+      "The GL_n class decomposes as (L-1)^n times the flag class times a power of L \u2014 this explains the structural connection",
+      "For partial flags, the parabolic subgroup (Levi \u00d7 unipotent radical) replaces GL_n in the extension conjecture",
+      "The first non-trivial Grassmannian [Gr(2,4)] = 1+L+2L\u00b2+L\u00b3+L\u2074 shows Schubert cell multiplicity"
     ]
   },
   "conclusion": {
@@ -112,7 +117,7 @@
     "implications": "The extension conjecture for partial flags with parabolic subgroups is stated formally. Three sorries remain for algebraic identities that require careful induction.",
     "openQuestions": [
       "Prove Grassmannian duality [Gr(d,n)] = [Gr(n-d,n)] by induction on the q-Pascal identity",
-      "Prove the Gaussian binomial identity [Gr(d,n)] · [d]! · [n-d]! = [n]!",
+      "Prove the Gaussian binomial identity [Gr(d,n)] \u00b7 [d]! \u00b7 [n-d]! = [n]!",
       "Verify the extension conjecture for Grassmannians (d=1 case: maps to projective space)",
       "Connect to positroid varieties and the work of Galashin-Karp-Lam on amplituhedra"
     ]

--- a/src/data/proofs/prob-method-expectation-oq-01/meta.json
+++ b/src/data/proofs/prob-method-expectation-oq-01/meta.json
@@ -4,15 +4,21 @@
   "slug": "prob-method-expectation-oq-01",
   "description": "Bridges the gallery's Finset-based probabilistic method to Mathlib's MeasureTheory. Shows finite probability is a special case of measure-theoretic probability, with linearity of expectation proved from integral_add.",
   "meta": {
-    "author": "Erdős-Spencer, formalized via Mathlib MeasureTheory",
+    "author": "Erd\u0151s-Spencer, formalized via Mathlib MeasureTheory",
     "date": "1974",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/ProbMethodExpectationOQ01.lean",
-    "tags": ["probability", "probabilistic-method", "measure-theory", "combinatorics"],
+    "tags": [
+      "probability",
+      "probabilistic-method",
+      "measure-theory",
+      "combinatorics"
+    ],
     "badge": "axiom",
     "sorries": 2,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
     "lineCount": 100
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/pythagorean-triples-oq-02/meta.json
+++ b/src/data/proofs/pythagorean-triples-oq-02/meta.json
@@ -2,13 +2,19 @@
   "id": "pythagorean-triples-oq-02",
   "title": "Pythagorean Triples via Gaussian Integers",
   "slug": "pythagorean-triples-oq-02",
-  "description": "Shows that the parametric formula for Pythagorean triples (m²-n², 2mn, m²+n²) is the squaring map in ℤ[i]. Norm multiplicativity gives the Brahmagupta-Fibonacci identity and a product rule for triples. Fully verified, 0 axioms.",
+  "description": "Shows that the parametric formula for Pythagorean triples (m\u00b2-n\u00b2, 2mn, m\u00b2+n\u00b2) is the squaring map in \u2124[i]. Norm multiplicativity gives the Brahmagupta-Fibonacci identity and a product rule for triples. Fully verified, 0 axioms.",
   "meta": {
     "author": "Brahmagupta (628), Fibonacci (1225), Gauss (1801)",
     "date": "1801",
     "status": "verified",
     "proofRepoPath": "Proofs/PythagoreanTriplesOQ02.lean",
-    "tags": ["number-theory", "gaussian-integers", "pythagorean-triples", "algebraic", "research"],
+    "tags": [
+      "number-theory",
+      "gaussian-integers",
+      "pythagorean-triples",
+      "algebraic",
+      "research"
+    ],
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
@@ -17,31 +23,72 @@
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
-      {"theorem": "PythagoreanTriple", "description": "Predicate a² + b² = c²", "module": "Mathlib.NumberTheory.PythagoreanTriples"}
+      {
+        "theorem": "PythagoreanTriple",
+        "description": "Predicate a\u00b2 + b\u00b2 = c\u00b2",
+        "module": "Mathlib.NumberTheory.PythagoreanTriples"
+      }
     ],
     "originalContributions": [
       "Gaussian integer arithmetic framework (gaussMul, gaussNorm, gaussConj, gaussSq)",
-      "Norm multiplicativity: N(z₁z₂) = N(z₁)N(z₂)",
+      "Norm multiplicativity: N(z\u2081z\u2082) = N(z\u2081)N(z\u2082)",
       "Pythagorean triple from Gaussian squaring: gaussSq_pythagorean",
       "Brahmagupta-Fibonacci identity from norm multiplicativity",
       "Product rule for Pythagorean triples via Gaussian multiplication"
     ]
   },
   "overview": {
-    "text": "Connects Pythagorean triples to Gaussian integers: the parametric formula is squaring in ℤ[i], and norm multiplicativity gives the Brahmagupta-Fibonacci identity.",
+    "text": "Connects Pythagorean triples to Gaussian integers: the parametric formula is squaring in \u2124[i], and norm multiplicativity gives the Brahmagupta-Fibonacci identity.",
     "keyInsights": [
-      "The parametric formula (m²-n², 2mn, m²+n²) IS z² where z = m + ni",
+      "The parametric formula (m\u00b2-n\u00b2, 2mn, m\u00b2+n\u00b2) IS z\u00b2 where z = m + ni",
       "Norm multiplicativity explains why sums of squares are closed under multiplication",
       "Product of Pythagorean triples corresponds to Gaussian multiplication"
-    ]
+    ],
+    "proofStrategy": "Connects Pythagorean triples to Gaussian integers: the parametric formula is squaring in \u2124[i], and norm multiplicativity gives the Brahmagupta-Fibonacci identity."
   },
   "sections": [
-    {"id": "gaussian-arithmetic", "title": "Gaussian Integer Arithmetic", "startLine": 24, "endLine": 46},
-    {"id": "core-properties", "title": "Core Properties", "startLine": 51, "endLine": 68},
-    {"id": "pythagorean-triples", "title": "Pythagorean Triples from Squaring", "startLine": 73, "endLine": 95},
-    {"id": "brahmagupta-fibonacci", "title": "Brahmagupta-Fibonacci Identity", "startLine": 100, "endLine": 120},
-    {"id": "factoring", "title": "The Factoring Perspective", "startLine": 125, "endLine": 140},
-    {"id": "examples", "title": "Concrete Examples", "startLine": 145, "endLine": 170}
+    {
+      "id": "gaussian-arithmetic",
+      "title": "Gaussian Integer Arithmetic",
+      "startLine": 24,
+      "endLine": 46,
+      "summary": "Gaussian Integer Arithmetic"
+    },
+    {
+      "id": "core-properties",
+      "title": "Core Properties",
+      "startLine": 51,
+      "endLine": 68,
+      "summary": "Core Properties"
+    },
+    {
+      "id": "pythagorean-triples",
+      "title": "Pythagorean Triples from Squaring",
+      "startLine": 73,
+      "endLine": 95,
+      "summary": "Pythagorean Triples from Squaring"
+    },
+    {
+      "id": "brahmagupta-fibonacci",
+      "title": "Brahmagupta-Fibonacci Identity",
+      "startLine": 100,
+      "endLine": 120,
+      "summary": "Brahmagupta-Fibonacci Identity"
+    },
+    {
+      "id": "factoring",
+      "title": "The Factoring Perspective",
+      "startLine": 125,
+      "endLine": 140,
+      "summary": "The Factoring Perspective"
+    },
+    {
+      "id": "examples",
+      "title": "Concrete Examples",
+      "startLine": 145,
+      "endLine": 170,
+      "summary": "Concrete Examples"
+    }
   ],
   "conclusion": {
     "summary": "The Gaussian integer connection reveals the algebraic structure behind Pythagorean triples: the parametric formula is squaring, and norm multiplicativity gives the Brahmagupta-Fibonacci identity.",
@@ -49,7 +96,20 @@
     "openQuestions": []
   },
   "crossReferences": [
-    {"slug": "pythagorean-triples", "title": "Formula for Pythagorean Triples", "relation": "parent-problem", "relationship": "extends"}
+    {
+      "slug": "pythagorean-triples",
+      "title": "Formula for Pythagorean Triples",
+      "relation": "parent-problem",
+      "relationship": "extends"
+    }
   ],
-  "leanFile": {"imports": ["Mathlib"], "namespace": "PythagoreanTriplesOQ02", "lineCount": 173, "axiomCount": 0, "theoremCount": 14}
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "PythagoreanTriplesOQ02",
+    "lineCount": 173,
+    "axiomCount": 0,
+    "theoremCount": 14
+  }
 }

--- a/src/data/proofs/randomized-maxcut-oq-02/meta.json
+++ b/src/data/proofs/randomized-maxcut-oq-02/meta.json
@@ -1,1 +1,48 @@
-{"id":"randomized-maxcut-oq-02","title":"Weighted MaxCut Approximation","slug":"randomized-maxcut-oq-02","description":"Extends randomized MaxCut to weighted graphs: random partition achieves W/2 cut weight. Goemans-Williamson 0.878 approximation.","meta":{"author":"Goemans-Williamson (1995)","date":"2026","status":"axiomatized","proofRepoPath":"Proofs/RandomizedMaxcutOQ02.lean","tags":["algorithms","approximation","maxcut","randomized","research"],"badge":"axiom","sorries":0,"axiomCount":1,"lineCount":135,"assumptions":"1 axiom (exists good partition). 0 sorries.","dateAdded":"2026-03-30","mathlib_version":"4.26.0"},"conclusion":{"summary":"Weighted MaxCut: random partition gives 1/2 approximation. GW gives 0.878.","openQuestions":[]},"crossReferences":[{"targetId":"randomized-maxcut","relationship":"parent-problem"}],"leanFile":{"imports":["Mathlib"],"namespace":"WeightedMaxCut","lineCount":135,"axiomCount":1,"theoremCount":5,"definitionCount":5}}
+{
+  "id": "randomized-maxcut-oq-02",
+  "title": "Weighted MaxCut Approximation",
+  "slug": "randomized-maxcut-oq-02",
+  "description": "Extends randomized MaxCut to weighted graphs: random partition achieves W/2 cut weight. Goemans-Williamson 0.878 approximation.",
+  "meta": {
+    "author": "Goemans-Williamson (1995)",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/RandomizedMaxcutOQ02.lean",
+    "tags": [
+      "algorithms",
+      "approximation",
+      "maxcut",
+      "randomized",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 1,
+    "lineCount": 135,
+    "assumptions": "1 axiom (exists good partition). 0 sorries.",
+    "dateAdded": "2026-03-30",
+    "mathlib_version": "4.26.0"
+  },
+  "conclusion": {
+    "summary": "Weighted MaxCut: random partition gives 1/2 approximation. GW gives 0.878.",
+    "openQuestions": [],
+    "implications": ""
+  },
+  "crossReferences": [
+    {
+      "targetId": "randomized-maxcut",
+      "relationship": "parent-problem"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "WeightedMaxCut",
+    "lineCount": 135,
+    "axiomCount": 1,
+    "theoremCount": 5,
+    "definitionCount": 5
+  },
+  "sections": []
+}

--- a/src/data/proofs/roth-theorem-k3-oq-03/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03/meta.json
@@ -2,18 +2,24 @@
   "id": "roth-theorem-k3-oq-03",
   "title": "Density Increment Generalization to k-APs via Gowers Norms",
   "slug": "roth-theorem-k3-oq-03",
-  "description": "Formalizes the generalization of Roth's density increment to k-term arithmetic progressions using Gowers uniformity norms. For k=3, Fourier analysis suffices (U² norm). For k≥4, the U^{k-1} norm controls k-AP counts via the generalized von Neumann theorem.",
+  "description": "Formalizes the generalization of Roth's density increment to k-term arithmetic progressions using Gowers uniformity norms. For k=3, Fourier analysis suffices (U\u00b2 norm). For k\u22654, the U^{k-1} norm controls k-AP counts via the generalized von Neumann theorem.",
   "meta": {
     "author": "Gowers (2001), Green-Tao-Ziegler (2012)",
     "date": "2001",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/RothTheoremOQ03.lean",
-    "tags": ["additive-combinatorics", "gowers-norms", "arithmetic-progressions", "density-increment"],
+    "tags": [
+      "additive-combinatorics",
+      "gowers-norms",
+      "arithmetic-progressions",
+      "density-increment"
+    ],
     "badge": "axiom",
     "sorries": 2,
     "dateAdded": "2026-03-30",
     "axiomCount": 4,
     "assumptions": "4 axioms: gowersNorm (U^s norm function), kAPCount (k-AP counting operator), generalized_von_neumann (k-AP count controlled by U^{k-1} norm), density_increment_kAP (density increases on subprogression for k-AP-free sets). Removed: gowersNorm_nonneg, gowersNorm_mono (unused), inverse_theorem (had placeholder True conclusion).",
     "lineCount": 197
-  }
+  },
+  "sections": []
 }

--- a/src/data/proofs/schauder-fixed-point-oq-03/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-03/meta.json
@@ -1,1 +1,99 @@
-{"id":"schauder-fixed-point-oq-03","title":"Kakutani Fixed Point Theorem for Set-Valued Maps","slug":"schauder-fixed-point-oq-03","description":"Formalizes the Kakutani fixed point theorem framework: set-valued maps, upper hemicontinuity, and the main theorem for compact convex sets. Recovers Brouwer as a corollary.","meta":{"author":"Kakutani (1941)","date":"2026","status":"axiomatized","proofRepoPath":"Proofs/SchauderFixedPointOQ03.lean","tags":["fixed-point","kakutani","set-valued-map","game-theory","research"],"badge":"axiom","sorries":0,"axiomCount":1,"lineCount":171,"assumptions":"1 axiom: kakutani_finite_dim. 0 sorries.","dateAdded":"2026-03-30","mathlib_version":"4.26.0","originalContributions":["Set-valued map framework with graph, values properties","Upper hemicontinuity definition and continuous-is-UHC proof","Brouwer from Kakutani corollary","Nash equilibrium existence sketch"]},"overview":{"historicalContext":"Kakutani (1941) generalized Brouwer's theorem to set-valued maps. Nash (1950) used it to prove existence of Nash equilibria.","problemStatement":"Formalize the Kakutani fixed point theorem for set-valued maps.","text":"Defines set-valued maps, upper hemicontinuity, and axiomatizes Kakutani's theorem. Recovers Brouwer as a corollary."},"sections":[{"id":"set-valued","title":"Set-Valued Maps","startLine":23,"endLine":55},{"id":"uhc","title":"Upper Hemicontinuity","startLine":57,"endLine":82},{"id":"fixed-points","title":"Fixed Points","startLine":84,"endLine":98},{"id":"kakutani","title":"Kakutani's Theorem","startLine":100,"endLine":132},{"id":"brouwer","title":"Recovering Brouwer","startLine":134,"endLine":153}],"conclusion":{"summary":"Kakutani framework formalized with 1 axiom (the main theorem). Brouwer recovered as corollary. Nash equilibrium connection sketched.","openQuestions":["Prove kakutani_finite_dim from Brouwer via simplicial approximation"]},"crossReferences":[{"targetId":"schauder-fixed-point","relationship":"parent-problem"}],"leanFile":{"imports":["Mathlib"],"namespace":"KakutaniFixedPoint","lineCount":171,"axiomCount":1,"theoremCount":4,"definitionCount":8}}
+{
+  "id": "schauder-fixed-point-oq-03",
+  "title": "Kakutani Fixed Point Theorem for Set-Valued Maps",
+  "slug": "schauder-fixed-point-oq-03",
+  "description": "Formalizes the Kakutani fixed point theorem framework: set-valued maps, upper hemicontinuity, and the main theorem for compact convex sets. Recovers Brouwer as a corollary.",
+  "meta": {
+    "author": "Kakutani (1941)",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/SchauderFixedPointOQ03.lean",
+    "tags": [
+      "fixed-point",
+      "kakutani",
+      "set-valued-map",
+      "game-theory",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 1,
+    "lineCount": 171,
+    "assumptions": "1 axiom: kakutani_finite_dim. 0 sorries.",
+    "dateAdded": "2026-03-30",
+    "mathlib_version": "4.26.0",
+    "originalContributions": [
+      "Set-valued map framework with graph, values properties",
+      "Upper hemicontinuity definition and continuous-is-UHC proof",
+      "Brouwer from Kakutani corollary",
+      "Nash equilibrium existence sketch"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Kakutani (1941) generalized Brouwer's theorem to set-valued maps. Nash (1950) used it to prove existence of Nash equilibria.",
+    "problemStatement": "Formalize the Kakutani fixed point theorem for set-valued maps.",
+    "text": "Defines set-valued maps, upper hemicontinuity, and axiomatizes Kakutani's theorem. Recovers Brouwer as a corollary.",
+    "proofStrategy": "Defines set-valued maps, upper hemicontinuity, and axiomatizes Kakutani's theorem. Recovers Brouwer as a corollary.",
+    "keyInsights": []
+  },
+  "sections": [
+    {
+      "id": "set-valued",
+      "title": "Set-Valued Maps",
+      "startLine": 23,
+      "endLine": 55,
+      "summary": "Set-Valued Maps"
+    },
+    {
+      "id": "uhc",
+      "title": "Upper Hemicontinuity",
+      "startLine": 57,
+      "endLine": 82,
+      "summary": "Upper Hemicontinuity"
+    },
+    {
+      "id": "fixed-points",
+      "title": "Fixed Points",
+      "startLine": 84,
+      "endLine": 98,
+      "summary": "Fixed Points"
+    },
+    {
+      "id": "kakutani",
+      "title": "Kakutani's Theorem",
+      "startLine": 100,
+      "endLine": 132,
+      "summary": "Kakutani's Theorem"
+    },
+    {
+      "id": "brouwer",
+      "title": "Recovering Brouwer",
+      "startLine": 134,
+      "endLine": 153,
+      "summary": "Recovering Brouwer"
+    }
+  ],
+  "conclusion": {
+    "summary": "Kakutani framework formalized with 1 axiom (the main theorem). Brouwer recovered as corollary. Nash equilibrium connection sketched.",
+    "openQuestions": [
+      "Prove kakutani_finite_dim from Brouwer via simplicial approximation"
+    ],
+    "implications": ""
+  },
+  "crossReferences": [
+    {
+      "targetId": "schauder-fixed-point",
+      "relationship": "parent-problem"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "KakutaniFixedPoint",
+    "lineCount": 171,
+    "axiomCount": 1,
+    "theoremCount": 4,
+    "definitionCount": 8
+  }
+}

--- a/src/data/proofs/yang-mills-2d-oq-01/meta.json
+++ b/src/data/proofs/yang-mills-2d-oq-01/meta.json
@@ -8,11 +8,19 @@
     "date": "1991",
     "status": "verified",
     "proofRepoPath": "Proofs/YangMills2DOQ01.lean",
-    "tags": ["mathematical-physics", "yang-mills", "gauge-theory", "heat-kernel", "area-law", "casimir-scaling"],
+    "tags": [
+      "mathematical-physics",
+      "yang-mills",
+      "gauge-theory",
+      "heat-kernel",
+      "area-law",
+      "casimir-scaling"
+    ],
     "badge": "verified",
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 10,
     "lineCount": 147
-  }
+  },
+  "sections": []
 }


### PR DESCRIPTION
Re-applies TypeScript-required fields overwritten by recent PR merges.