### PR TITLE
Fix: correct sorry count for erdos-307-oq-02 (1→7)

### DIFF
--- a/src/data/proofs/erdos-307-oq-02/meta.json
+++ b/src/data/proofs/erdos-307-oq-02/meta.json
@@ -17,10 +17,10 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 7,
     "axiomCount": 0,
     "lineCount": 261,
-    "assumptions": "0 axioms, 1 sorry (tight bound for 3 primes reciprocal sum).",
+    "assumptions": "0 axioms, 7 sorries remaining.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "originalContributions": [


### PR DESCRIPTION
## Fix

Correct severely understated sorry count in erdos-307-oq-02 meta.json.

## Evidence

**Before**: `sorries: 1`, assumptions text: "0 axioms, 1 sorry"
**After**: `sorries: 7`, assumptions text: "0 axioms, 7 sorries remaining"

Verified: `grep -c "sorry" proofs/Proofs/Erdos307OQ02.lean → 7`

Closes #8266

---
Automated fix by lean-mechanic agent.