### PR TITLE
Fix: correct axiomCount and status for erdos-1007-oq-05

### DIFF
--- a/src/data/proofs/erdos-1007-oq-05/meta.json
+++ b/src/data/proofs/erdos-1007-oq-05/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research",
     "sourceUrl": "https://erdosproblems.com/1007",
     "date": "2026-03-30",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos1007OQ05.lean",
     "tags": [
       "graph-theory",
@@ -37,10 +37,10 @@
       "Proved completeBipartiteAdj is irreflexive, enabling corollary for K_{m,n}"
     ],
     "dateAdded": "2026-03-30",
-    "axiomCount": 3,
-    "lineCount": 130,
+    "axiomCount": 0,
+    "lineCount": 141,
     "mathlib_version": "4.26.0",
-    "assumptions": "3 axioms from parent file: min_edges_dimension_4 (House 2013), k33_unique_minimum (House 2013), min_edges_dimension_5 (Chaffee-Noble 2016). The hasUnitEmbedding_exists axiom is proved."
+    "assumptions": "0 axioms, 0 sorries. Parent file (erdos-1007) has 3 axioms; this file proves hasUnitEmbedding_exists without introducing new assumptions."
   },
   "overview": {
     "historicalContext": "Erdős Problem #1007 asks: what is the smallest number of edges in a graph with dimension 4? The answer is 9, achieved uniquely by K_{3,3} (House 2013). This OQ analyzes which axioms in the formalization can be eliminated.",
@@ -100,8 +100,8 @@
       "Finset"
     ],
     "namespace": "Erdos1007OQ05",
-    "lineCount": 130,
-    "axiomCount": 3,
+    "lineCount": 141,
+    "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 0
   },


### PR DESCRIPTION
## Fix

Correct axiomCount (3→0), status (axiomatized→verified), lineCount (130→141) for erdos-1007-oq-05. The 3 axioms are in the parent file, not this one.

## Evidence

**Before**: `axiomCount: 3`, `status: axiomatized`, `lineCount: 130`
**After**: `axiomCount: 0`, `status: verified`, `lineCount: 141`

Verified: `grep -cE "^axiom " → 0`, `grep -c "sorry" → 0`, `wc -l → 141`, no structures.

Closes #8264

---
Automated fix by lean-mechanic agent.