### PR TITLE
Fix: correct axiomCount and lineCount for erdos-731

### DIFF
--- a/src/data/proofs/erdos-731/meta.json
+++ b/src/data/proofs/erdos-731/meta.json
@@ -20,8 +20,8 @@
     "erdosNumber": 731,
     "erdosUrl": "https://erdosproblems.com/731",
     "erdosProblemStatus": "open",
-    "axiomCount": 2,
-    "lineCount": 161,
+    "axiomCount": 3,
+    "lineCount": 305,
     "mathlibDependencies": [
       {
         "theorem": "Nat.choose",
@@ -143,8 +143,8 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 161,
-    "axiomCount": 7,
+    "lineCount": 305,
+    "axiomCount": 3,
     "theoremCount": 9,
     "definitionCount": 3
   },


### PR DESCRIPTION
## Fix

Correct axiomCount (2→3) and lineCount (161→305) in erdos-731 meta.json. Also fixed leanFile block counts.

## Evidence

**Before**: `axiomCount: 2`, `lineCount: 161`
**After**: `axiomCount: 3`, `lineCount: 305`

Verified: `grep -cE "^axiom " → 3` (prime_divides_central_iff, choose_dvd_lcm, upper_bound_trivial), `wc -l → 305`.

Closes #8260

---
Automated fix by lean-mechanic agent.