### PR TITLE
Fix: correct axiomCount for fermats-last-theorem-oq-03 (4→3)

### DIFF
--- a/src/data/proofs/fermats-last-theorem-oq-03/meta.json
+++ b/src/data/proofs/fermats-last-theorem-oq-03/meta.json
@@ -16,9 +16,9 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 4,
-    "lineCount": 162,
-    "assumptions": "4 axioms (FLT/\u211a, Freitas-Hung-Siksek, modularity obstruction, trivially true). 0 sorries.",
+    "axiomCount": 3,
+    "lineCount": 140,
+    "assumptions": "3 axioms (flt_over_Q, freitas_hung_siksek, modularity_obstruction). 0 sorries.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -44,8 +44,8 @@
       "Mathlib"
     ],
     "namespace": "FermatsLastTheoremOQ03",
-    "lineCount": 162,
-    "axiomCount": 4,
+    "lineCount": 140,
+    "axiomCount": 3,
     "theoremCount": 4,
     "definitionCount": 3
   },


### PR DESCRIPTION
## Fix

Correct axiomCount (4→3) and lineCount (162→140) in fermats-last-theorem-oq-03. The 4th "trivially true" axiom doesn't exist.

## Evidence

**Before**: `axiomCount: 4`, `lineCount: 162`
**After**: `axiomCount: 3`, `lineCount: 140`

Verified: `grep -cE "^axiom " → 3` (flt_over_Q, freitas_hung_siksek, modularity_obstruction).

Closes #8268

---
Automated fix by lean-mechanic agent.