### PR TITLE
Fix: correct sorry count for erdos-1066-oq-04 (1→2)

### DIFF
--- a/src/data/proofs/erdos-1066-oq-04/meta.json
+++ b/src/data/proofs/erdos-1066-oq-04/meta.json
@@ -17,10 +17,10 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 2,
     "axiomCount": 2,
-    "lineCount": 156,
-    "assumptions": "2 axioms (degree_le_kissing, greedy_independence). 1 sorry.",
+    "lineCount": 155,
+    "assumptions": "2 axioms (degree_le_kissing, greedy_independence). 2 sorries.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -81,7 +81,7 @@
       "Mathlib"
     ],
     "namespace": "Erdos1066OQ04",
-    "lineCount": 156,
+    "lineCount": 155,
     "axiomCount": 2,
     "theoremCount": 5,
     "definitionCount": 6


### PR DESCRIPTION
## Fix

Correct sorry count (1→2) and lineCount (156→155) in erdos-1066-oq-04 meta.json.

## Evidence

Verified: `grep -c "sorry" → 2`, `wc -l → 155`.

Closes #8265

---
Automated fix by lean-mechanic agent.