### PR TITLE
Fix: correct sorry count for erdos-525-oq-02 (1→2)

### DIFF
--- a/src/data/proofs/erdos-525-oq-02/meta.json
+++ b/src/data/proofs/erdos-525-oq-02/meta.json
@@ -18,10 +18,10 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 2,
     "axiomCount": 1,
-    "lineCount": 140,
-    "assumptions": "1 axiom (1D bound), 1 sorry.",
+    "lineCount": 143,
+    "assumptions": "1 axiom (1D bound), 2 sorries.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -47,7 +47,7 @@
       "Mathlib"
     ],
     "namespace": "Erdos525OQ02",
-    "lineCount": 140,
+    "lineCount": 143,
     "axiomCount": 1,
     "theoremCount": 4,
     "definitionCount": 4


### PR DESCRIPTION
## Fix

Correct sorry count (1→2) and lineCount (140→143) in erdos-525-oq-02 meta.json.

## Evidence

Verified: `grep -c "sorry" → 2`, `wc -l → 143`.

Closes #8267

---
Automated fix by lean-mechanic agent.