### PR TITLE
Fix: correct sorry count for hilbert-22-oq-01 (1→2)

### DIFF
--- a/src/data/proofs/hilbert-22-oq-01/meta.json
+++ b/src/data/proofs/hilbert-22-oq-01/meta.json
@@ -15,10 +15,10 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 2,
     "axiomCount": 3,
     "lineCount": 175,
-    "assumptions": "3 axioms (Yau, Kobayashi), 1 sorry.",
+    "assumptions": "3 axioms (Yau, Kobayashi), 2 sorries.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "originalContributions": [


### PR DESCRIPTION
## Fix

Correct sorry count (1→2) in hilbert-22-oq-01 meta.json.

## Evidence

Verified: `grep -c "sorry" → 2`.

Closes #8269

---
Automated fix by lean-mechanic agent.