### PR TITLE
Fix: correct sorry count for erdos-404 (1→0)

### DIFF
--- a/src/data/proofs/erdos-404/meta.json
+++ b/src/data/proofs/erdos-404/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 404,
     "erdosUrl": "https://erdosproblems.com/404",
     "erdosProblemStatus": "open",
@@ -65,8 +65,8 @@
       "Legendre's formula for v_p(n!)",
       "Filter.Tendsto and convergence in Lean/Mathlib"
     ],
-    "lineCount": 253,
-    "assumptions": "2 axioms: lin_bound (f(2,2) <= 254), lin_bound_meaning (2^255 never divides such sums). 1 sorry in padic_val_factorial_asymp (Nat.log p n / n -> 0). The digit-sum identity, upper bound, and lower bound are all proved.",
+    "lineCount": 291,
+    "assumptions": "2 axioms: lin_bound (f(2,2) <= 254), lin_bound_meaning (2^255 never divides such sums). 0 sorries.",
     "theoremCount": 10
   },
   "overview": {
@@ -202,7 +202,7 @@
       "Filter"
     ],
     "namespace": "Erdos404",
-    "lineCount": 253,
+    "lineCount": 291,
     "axiomCount": 2,
     "theoremCount": 10,
     "definitionCount": 7


### PR DESCRIPTION
## Fix

Correct stale sorry count (1→0) and lineCount (253→291) in erdos-404 meta.json. The sorry in padic_val_factorial_asymp was resolved.

## Evidence

Verified: `grep -c "sorry" → 0`, `wc -l → 291`.

Closes #8263

---
Automated fix by lean-mechanic agent.