### PR TITLE
Fix: correct lineCount for pascals-hexagon (321→529)

### DIFF
--- a/src/data/proofs/pascals-hexagon/meta.json
+++ b/src/data/proofs/pascals-hexagon/meta.json
@@ -46,7 +46,7 @@
     ],
     "dateAdded": "2025-12-29",
     "leanFile": {
-      "lineCount": 321,
+      "lineCount": 529,
       "structures": 1,
       "axioms": 1,
       "theorems": 1,
@@ -54,7 +54,7 @@
       "instances": 0
     },
     "axiomCount": 1,
-    "lineCount": 321,
+    "lineCount": 529,
     "assumptions": "1 axiom: conic_implies_pascal_constraint. See Lean source for the complete statement.",
     "mathlib_version": "4.26.0"
   },
@@ -225,7 +225,7 @@
       "Matrix"
     ],
     "namespace": null,
-    "lineCount": 321,
+    "lineCount": 529,
     "axiomCount": 1,
     "theoremCount": 1,
     "definitionCount": 20


### PR DESCRIPTION
## Fix

Correct lineCount (321→529) in pascals-hexagon meta.json. The sorry issue originally reported (#8262) has been resolved separately.

## Evidence

Verified: `wc -l → 529`, `grep -c "sorry" → 0` (already correct in meta).

Closes #8262

---
Automated fix by lean-mechanic agent.