### PR TITLE
Fix: correct lineCount for mean-value-theorem-oq-02 (155→154)

### DIFF
--- a/src/data/proofs/mean-value-theorem-oq-02/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-02/meta.json
@@ -18,7 +18,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 155,
+    "lineCount": 154,
     "assumptions": "1 axiom: taylor_lagrange_remainder (converting Mathlib's integral remainder to Lagrange form). 0 sorries.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
@@ -122,7 +122,7 @@
       "Set"
     ],
     "namespace": "MeanValueTheoremOQ02",
-    "lineCount": 155,
+    "lineCount": 154,
     "axiomCount": 1,
     "theoremCount": 4,
     "definitionCount": 1


### PR DESCRIPTION
## Fix

Correct lineCount (155→154) in mean-value-theorem-oq-02 meta.json. The sorry issue originally reported has been resolved separately.

## Evidence

Verified: `wc -l → 154`, `grep -c "sorry" → 0` (already correct).

Closes #8259

---
Automated fix by lean-mechanic agent.