### PR TITLE
Research: erdos-1126-oq-01-oq-04 — algebraic proof structure for almost Jensen→additive

### DIFF
--- a/proofs/Proofs/Erdos1126OQ01Aristotle.lean
+++ b/proofs/Proofs/Erdos1126OQ01Aristotle.lean
@@ -1,0 +1,42 @@
+/-
+  Aristotle targets for Erdős Problem #1126, OQ-01
+  Measure-theoretic helper lemmas for the almost Jensen → almost additive proof.
+  See Erdos1126OQ01Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open conjecture
+  - Known results from measure theory (Fubini, null set preservation)
+  - Clean theorem statements with no definition sorries
+  - No axiom declarations
+
+  These lemmas support the proof of almost_jensen_implies_almost_additive_shifted.
+  The main theorem's algebraic structure is proved; these are the remaining
+  measure-theoretic gaps.
+-/
+import Mathlib
+import Mathlib.MeasureTheory.Measure.Prod
+
+open MeasureTheory Set
+
+namespace Erdos1126OQ01Aristotle
+
+/-! ## Null set preservation under linear maps and projections -/
+
+/-- Preimage of a null set under the scaling map (x,y) ↦ (2x,2y) is null.
+The map has determinant 4, so volume scales by 1/4. -/
+lemma volume_preimage_double_null {N : Set (ℝ × ℝ)} (hN : volume N = 0) :
+    volume ((fun p : ℝ × ℝ => (2 * p.1, 2 * p.2)) ⁻¹' N) = 0 := by
+  sorry
+
+/-- Preimage of a 1D null set under first projection is null in ℝ².
+Follows from volume(S × ℝ) = volume(S) · volume(ℝ) = 0 · ∞ = 0 in ENNReal. -/
+lemma volume_preimage_fst_null {S : Set ℝ} (hS : volume S = 0) :
+    volume (Prod.fst ⁻¹' S : Set (ℝ × ℝ)) = 0 := by
+  sorry
+
+/-- Preimage of a 1D null set under second projection is null in ℝ². -/
+lemma volume_preimage_snd_null {S : Set ℝ} (hS : volume S = 0) :
+    volume (Prod.snd ⁻¹' S : Set (ℝ × ℝ)) = 0 := by
+  sorry
+
+end Erdos1126OQ01Aristotle

--- a/proofs/Proofs/Erdos1126OQ01Problem.lean
+++ b/proofs/Proofs/Erdos1126OQ01Problem.lean
@@ -176,6 +176,49 @@ theorem jensen_iff_additive_shifted (f : ℝ → ℝ) :
 
 /- ## Part II: Almost Jensen → Almost Additive Reduction -/
 
+/- Helper lemmas for the almost Jensen → almost additive proof.
+These decompose the measure-theoretic components into clean, targeted statements. -/
+
+/-- Preimage of a null set under (x,y) ↦ (2x,2y) is null.
+Lebesgue measure scales as |det|⁻¹ under invertible linear maps; here det = 4. -/
+private lemma volume_preimage_double_null {N : Set (ℝ × ℝ)} (hN : volume N = 0) :
+    volume ((fun p : ℝ × ℝ => (2 * p.1, 2 * p.2)) ⁻¹' N) = 0 := by
+  -- volume(T⁻¹(N)) = |det T|⁻¹ · volume(N) = (1/4) · 0 = 0
+  -- Needs: MeasureTheory.addHaar_preimage_smul or Measure.map_linearEquiv
+  sorry
+
+/-- Preimage of a 1D null set under first projection is null in ℝ².
+S × ℝ has volume volume(S) · volume(ℝ) = 0 · ∞ = 0. -/
+private lemma volume_preimage_fst_null {S : Set ℝ} (hS : volume S = 0) :
+    volume (Prod.fst ⁻¹' S : Set (ℝ × ℝ)) = 0 := by
+  -- Needs: Measure.prod_prod, volume_eq_prod, and zero_mul in ENNReal
+  sorry
+
+/-- Preimage of a 1D null set under second projection is null in ℝ². -/
+private lemma volume_preimage_snd_null {S : Set ℝ} (hS : volume S = 0) :
+    volume (Prod.snd ⁻¹' S : Set (ℝ × ℝ)) = 0 := by
+  sorry
+
+/-- From almost Jensen, f(2z) = 2f(z) - f(0) for a.e. z.
+
+This is the key measure-theoretic step requiring Fubini section extraction.
+In the exact case, setting y=0 in Jensen gives f(x) = (f(2x)+f(0))/2 directly.
+In the a.e. case, y=0 cannot be chosen from a 2D a.e. condition, so we need:
+
+1. By Fubini (measure_ae_null_of_prod_null), since the null set N ⊂ ℝ²
+   has volume 0, for a.e. y₀, the section {x : (x,y₀) ∈ N} has measure 0.
+2. For such y₀: f((x+y₀)/2) = (f(x)+f(y₀))/2 for a.e. x.
+   Setting x = 2z: f(2z) = 2f(z+y₀/2) - f(y₀) for a.e. z.
+3. From the scaling substitution f(x+y) = (f(2x)+f(2y))/2 and step 2,
+   the translation z ↦ f(z+y₀/2)-f(z) is shown constant a.e. via a
+   second Fubini application, yielding f(2z) = 2f(z)-f(0) for a.e. z.
+
+Required Mathlib: MeasureTheory.Measure.Prod (measure_ae_null_of_prod_null,
+ae_ae_of_ae_prod, volume_eq_prod), null set preservation under affine maps. -/
+private lemma ae_double_of_almost_jensen (f : ℝ → ℝ) (hf : IsAlmostJensen f) :
+    ae_holds (fun z => f (2 * z) = 2 * f z - f 0) := by
+  sorry
+
 /-- **Almost Jensen reduces to almost additive (for shifted function).**
 If f is almost Jensen, then the shifted function g(x) = f(x) - f(0) satisfies
 the additive equation for a.e. (x,y) where Jensen also holds at (2x, 0) and (2y, 0).
@@ -194,26 +237,31 @@ Mathematical argument:
 theorem almost_jensen_implies_almost_additive_shifted (f : ℝ → ℝ)
     (hf : IsAlmostJensen f) :
     IsAlmostAdditive (fun x => f x - f 0) := by
-  -- The proof mirrors jensen_implies_shifted_additive but with measure theory.
-  -- Key steps (see detailed analysis below):
-  --
-  -- 1. From hf, get null set N ⊂ ℝ² where Jensen holds outside N
-  -- 2. Define N₁ = preimage of N under (a,b) ↦ (2a,2b): measure 0 by det(J) = 4 ≠ 0
-  -- 3. Outside N₁: Jensen at (2x,2y) gives f(x+y) = (f(2x)+f(2y))/2
-  -- 4. BLOCKING STEP: "Double lemma" f(2z) = 2f(z) - f(0) for a.e. z
-  --    This needs Fubini (MeasureTheory.ae_prod_iff) to extract a "good" b₀ such that
-  --    the y-section {x : (x, b₀) ∈ N} has measure 0. Then Jensen at (x, b₀) gives
-  --    f((x+b₀)/2) = (f(x)+f(b₀))/2 for a.e. x. Setting x = 2z - b₀ yields
-  --    f(z) in terms of f(2z-b₀) and f(b₀). A second application with a different
-  --    good section eliminates b₀, giving f(2z) = 2f(z) - f(0) for a.e. z.
-  -- 5. Combine steps 3-4: f(x+y) = f(x) + f(y) - f(0) for a.e. (x,y)
-  --    The combined null set is N ∪ N₁ ∪ (Fubini sections × ℝ) ∪ (ℝ × Fubini sections)
-  --
-  -- Required Mathlib lemmas:
-  --   MeasureTheory.ae_prod_iff (Fubini section extraction)
-  --   MeasureTheory.Measure.map_linear_eq (null set under linear maps)
-  --   measure_union_null (union of null sets)
-  sorry
+  -- Strategy: scaling substitution + ae double lemma (Fubini).
+  -- 1. From Jensen at (2x,2y): f(x+y) = (f(2x)+f(2y))/2 for a.e. (x,y)
+  -- 2. From ae_double: f(2z) = 2f(z)-f(0) for a.e. z
+  -- 3. Algebraic combination: f(x+y) = f(x)+f(y)-f(0) for a.e. (x,y)
+  obtain ⟨N_d, hN_d_null, hN_d⟩ := ae_double_of_almost_jensen f hf
+  obtain ⟨N, hN_null, hN⟩ := hf
+  -- Null set M = {(x,y) : (2x,2y) ∈ N} ∪ {(x,y) : x ∈ N_d} ∪ {(x,y) : y ∈ N_d}
+  refine ⟨(fun p : ℝ × ℝ => (2 * p.1, 2 * p.2)) ⁻¹' N ∪
+    Prod.fst ⁻¹' N_d ∪ Prod.snd ⁻¹' N_d, ?_, ?_⟩
+  · -- M is null: union of three null sets
+    exact measure_union_null
+      (measure_union_null (volume_preimage_double_null hN_null)
+        (volume_preimage_fst_null hN_d_null))
+      (volume_preimage_snd_null hN_d_null)
+  · -- For (x,y) ∉ M: (f(x+y)-f(0)) = (f(x)-f(0)) + (f(y)-f(0))
+    intro x y hxy
+    -- Scaling: Jensen at (2x,2y) gives f(x+y) = (f(2x)+f(2y))/2
+    have h_scale := hN (2 * x) (2 * y) (fun h => hxy (Or.inl (Or.inl h)))
+    have h_eq : (2 * x + 2 * y) / 2 = x + y := by ring
+    rw [h_eq] at h_scale
+    -- Double lemma: f(2x) = 2f(x)-f(0) and f(2y) = 2f(y)-f(0)
+    have h_dx := hN_d x (fun h => hxy (Or.inl (Or.inr h)))
+    have h_dy := hN_d y (fun h => hxy (Or.inr h))
+    -- Algebraic: f(x+y) = (2f(x)-f(0)+2f(y)-f(0))/2 = f(x)+f(y)-f(0)
+    simp only; linarith
 
 /- ## Part III: Multiplicative Functional Equation -/
 

--- a/src/data/research/problems/erdos-1126-oq-01-oq-04.json
+++ b/src/data/research/problems/erdos-1126-oq-01-oq-04.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-1126-oq-01-oq-04",
-  "title": "Can the remaining sorry (almost Jensen → almost additive) be resolved using M...",
+  "title": "Can the remaining sorry (almost Jensen \u2192 almost additive) be resolved using M...",
   "phase": "ORIENT",
   "status": "active",
   "tier": "C",
@@ -16,49 +16,58 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ORIENT",
-    "since": "2026-03-30T06:45:00Z",
-    "iteration": 1,
-    "focus": "Surveyed: the sorry requires Fubini section extraction + affine null set preservation. Mathlib has the tools but proof is ~50-100 lines.",
+    "phase": "ACT",
+    "since": "2026-03-30T08:58:00Z",
+    "iteration": 2,
+    "focus": "Implemented structured proof: algebraic combination proved, 4 targeted measure-theory sorries remain",
     "blockers": [],
-    "nextAction": "Implement the Fubini-based proof. Key: extract ae section, prove g(2z)=2g(z) ae, combine with scaling substitution.",
+    "nextAction": "Prove ae_double_of_almost_jensen using Fubini section extraction from MeasureTheory.Measure.Prod",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEY: The sorry (almost Jensen → almost additive) CAN be resolved using Mathlib. Requires: (1) Fubini section extraction (prod_right_ae), (2) null set preservation under affine maps, (3) ~50-100 lines of measure theory. The algebraic structure follows the exact proof but every \"set y=0\" step needs Fubini to extract ae sections instead.",
+    "progressSummary": "PROGRESS: Main theorem algebraic structure proved. 1 opaque sorry \u2192 4 clean helper sorries (3 null-set + 1 Fubini). Aristotle companion file created.",
     "builtItems": [
       "Surveyed proof requirements: identified 5-step proof strategy via Fubini sections",
       "Identified Mathlib infrastructure: integral_prod, prod_right_ae, Measure.prod",
       "Classified all 6 axioms as deep results (not easily eliminable)",
-      "Identified that almost_jensen_stability would become provable after sorry resolution"
+      "Identified that almost_jensen_stability would become provable after sorry resolution",
+      "Proved algebraic combination in almost_jensen_implies_almost_additive_shifted",
+      "Added volume_preimage_double_null helper lemma (sorry)",
+      "Added volume_preimage_fst_null helper lemma (sorry)",
+      "Added volume_preimage_snd_null helper lemma (sorry)",
+      "Added ae_double_of_almost_jensen helper lemma (sorry, key Fubini step)",
+      "Created Erdos1126OQ01Aristotle.lean companion file"
     ],
     "insights": [
       "The sorry requires proving g(x+y) = g(x)+g(y) a.e. where g(x)=f(x)-f(0) satisfies almost Jensen.",
-      "Step 1: Scale substitution (u,v)=(2x,2y) gives g(x+y)=(g(2x)+g(2y))/2 a.e. — uses null set preservation under linear maps.",
-      "Step 2: Need g(2z)=2g(z) a.e. — this is the HARD step. Cannot simply \"set y=0\" in 2D ae condition.",
-      "Step 3: Fubini section extraction: for a.e. b, Jensen holds for a.e. (a,b). Pick good b₀. This gives g((a+b₀)/2)=(g(a)+g(b₀))/2 for a.e. a.",
+      "Step 1: Scale substitution (u,v)=(2x,2y) gives g(x+y)=(g(2x)+g(2y))/2 a.e. \u2014 uses null set preservation under linear maps.",
+      "Step 2: Need g(2z)=2g(z) a.e. \u2014 this is the HARD step. Cannot simply \"set y=0\" in 2D ae condition.",
+      "Step 3: Fubini section extraction: for a.e. b, Jensen holds for a.e. (a,b). Pick good b\u2080. This gives g((a+b\u2080)/2)=(g(a)+g(b\u2080))/2 for a.e. a.",
       "Step 4: From step 3 with affine substitution, derive g(2z)=2g(z) for a.e. z via algebraic manipulation.",
       "Step 5: Combine steps 1+4: g(x+y) = (2g(x)+2g(y))/2 = g(x)+g(y) a.e.",
       "Mathlib infrastructure available: integral_prod (Fubini), prod_right_ae (ae sections), Measure.prod (product measures).",
-      "The IsDerivation definition only includes Leibniz rule (not additivity) — continuous_derivation_is_zero axiom may be harder to prove than expected.",
+      "The IsDerivation definition only includes Leibniz rule (not additivity) \u2014 continuous_derivation_is_zero axiom may be harder to prove than expected.",
       "The file has 6 axioms, all deep results. Only almost_jensen_stability could become derivable if the sorry is proved.",
-      "Null set preservation under (x,y)↦(2x,2y): Lebesgue measure scales as volume(T⁻¹(N)) = volume(N)/|det T| = 0. In Mathlib: MeasureTheory.Measure.addHaar_smul or similar.",
-      "Key algebraic identity: if g satisfies a.e. Jensen with g(0)=0, and we know g(2z)=2g(z) a.e., then g(x+y)=(g(2x)+g(2y))/2=g(x)+g(y) a.e."
+      "Null set preservation under (x,y)\u21a6(2x,2y): Lebesgue measure scales as volume(T\u207b\u00b9(N)) = volume(N)/|det T| = 0. In Mathlib: MeasureTheory.Measure.addHaar_smul or similar.",
+      "Key algebraic identity: if g satisfies a.e. Jensen with g(0)=0, and we know g(2z)=2g(z) a.e., then g(x+y)=(g(2x)+g(2y))/2=g(x)+g(y) a.e.",
+      "The proof decomposes into: (1) scaling substitution f(x+y)=(f(2x)+f(2y))/2, (2) ae double lemma f(2z)=2f(z)-f(0), (3) linarith combination.",
+      "The ae double lemma is the ONLY step requiring Fubini. Everything else is algebraic with null-set unions.",
+      "Null set for the combined proof: M = T\u207b\u00b9(N) \u222a (N_d \u00d7 \u211d) \u222a (\u211d \u00d7 N_d) where T(x,y)=(2x,2y)."
     ],
     "mathlibGaps": [
-      "Need ae_ae_of_ae_prod or prod_right_ae for ℝ² Lebesgue measure → ae sections",
-      "Need null set preservation under affine maps (linear isomorphisms of ℝ²)",
+      "Need ae_ae_of_ae_prod or prod_right_ae for \u211d\u00b2 Lebesgue measure \u2192 ae sections",
+      "Need null set preservation under affine maps (linear isomorphisms of \u211d\u00b2)",
       "May need filter_upwards for combining multiple ae conditions"
     ],
     "nextSteps": [
-      "Implement Fubini-based proof of almost_jensen_implies_almost_additive_shifted (~50-100 lines)",
-      "Key lemma to prove first: ae_double (g(2z) = 2g(z) a.e.) from ae Jensen + Fubini",
-      "Test with Docker build after writing proof",
-      "Once sorry eliminated, almost_jensen_stability axiom may become derivable from de_bruijn_jurkat_theorem + this result"
+      "Prove ae_double_of_almost_jensen: need Fubini section + shift elimination",
+      "Prove 3 null-set helpers: addHaar_preimage_smul, Measure.prod_prod, volume_eq_prod",
+      "Add import Mathlib.MeasureTheory.Measure.Prod when proving helpers",
+      "Check if Aristotle can auto-prove the 3 null-set lemmas"
     ],
     "markdown": "# Knowledge Base: erdos-1126-oq-01-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
@@ -106,5 +115,5 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1126Problem.lean"
     }
   ],
-  "lastUpdate": "2026-03-30T06:50:00Z"
+  "lastUpdate": "2026-03-30T08:58:00Z"
 }


### PR DESCRIPTION
## Summary
Research session for erdos-1126-oq-01-oq-04 (almost Jensen → almost additive via Fubini).

## Progress
- **Main theorem algebraic structure: PROVED.** The opaque sorry in `almost_jensen_implies_almost_additive_shifted` is replaced with a complete proof conditional on 4 clean helper lemmas.
- Proof strategy: scaling substitution `f(x+y) = (f(2x)+f(2y))/2` + double lemma `f(2z) = 2f(z)-f(0)` → `linarith` combination
- Null set: `M = T⁻¹(N) ∪ (N_d × ℝ) ∪ (ℝ × N_d)` where `T(x,y) = (2x,2y)`

## Remaining Sorries (4, down from 1 opaque)
1. `volume_preimage_double_null` — null set under scaling (needs `addHaar_preimage_smul`)
2. `volume_preimage_fst_null` — null set under projection (needs `Measure.prod_prod`)
3. `volume_preimage_snd_null` — same for second projection
4. `ae_double_of_almost_jensen` — **key Fubini step**: section extraction + shift elimination

## Files Modified
- `proofs/Proofs/Erdos1126OQ01Problem.lean` — 4 helper lemmas + proved main theorem body
- `proofs/Proofs/Erdos1126OQ01Aristotle.lean` — NEW: companion file for null-set lemmas
- `src/data/research/problems/erdos-1126-oq-01-oq-04.json` — knowledge update

## Status
**Outcome**: progress (algebraic proof complete, measure-theoretic helpers remain)
**Phase**: ORIENT → ACT
**Next Steps**: Prove `ae_double_of_almost_jensen` using `MeasureTheory.Measure.Prod` Fubini API

🤖 Generated by researcher-7