### PR TITLE
Fix: define missing muPosDeg_pos_of_small_diameter in erdos-1040

### DIFF
--- a/proofs/Proofs/Erdos1040Problem.lean
+++ b/proofs/Proofs/Erdos1040Problem.lean
@@ -405,6 +405,17 @@ theorem muPosDeg_infimum (F : Set ℂ) (hF : F.Infinite) :
   -- Contradiction: muPosDeg F < muPosDeg F + ε ≤ muPosDeg F
   exact absurd hle (not_le.mpr (ENNReal.lt_add_right hmu_ne_top hε.ne'))
 
+/-- When transfinite diameter < 1, corrected μ(F) > 0.
+    Proof sketch: by `small_diameter_disc`, every sublevel set of a degree ≥ 1
+    polynomial contains a ball of radius ≥ c > 0, so sublevelMeasure p ≥
+    volume(ball z₀ c) > 0 uniformly. Hence the infimum muPosDeg F ≥
+    volume(ball 0 c) > 0. -/
+theorem muPosDeg_pos_of_small_diameter (F : Set ℂ) (hF : IsClosed F) (hFi : F.Infinite)
+    (hρ : transfiniteDiameter F < 1) : muPosDeg F > 0 := by
+  -- From small_diameter_disc: ∃ c > 0 s.t. every degree > 0 poly's sublevel set
+  -- contains a ball of radius ≥ c. Measure of that ball > 0, giving uniform lower bound.
+  sorry
+
 /-
 ## The Open Question
 -/

--- a/src/data/proofs/erdos-1040/meta.json
+++ b/src/data/proofs/erdos-1040/meta.json
@@ -17,22 +17,22 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 4,
     "erdosNumber": 1040,
     "erdosUrl": "https://erdosproblems.com/1040",
     "erdosProblemStatus": "open",
     "relatedProblems": [
       1039
     ],
-    "axiomCount": 7,
-    "assumptions": "7 axiom declarations: transfiniteDiameter_eq (Fekete's limit theorem), lineSegment_determined (line segment mu determined by diameter), disc_determined (disc mu determined by radius), lineSegment_diameter (line segment capacity = length/4), disc_diameter (disc capacity = radius), small_diameter_disc (qualitative disc containment for ρ < 1), erdos_netanyahu (quantitative disc bounds, 1973). 4 sorries in theorems.",
+    "axiomCount": 9,
+    "assumptions": "9 axiom declarations: transfiniteDiameter_eq (Fekete's limit theorem), lineSegment_determined (line segment mu determined by diameter), disc_determined (disc mu determined by radius), lineSegment_diameter (line segment capacity = length/4), disc_diameter (disc capacity = radius), small_diameter_disc (qualitative disc containment for ρ < 1), erdos_netanyahu (quantitative disc bounds, 1973), lineSegment_muPosDeg_zero (EHP 1958 line segment case), disc_muPosDeg_zero (EHP 1958 disc case). 4 sorries in theorems.",
     "prerequisites": [
       "Complex analysis: polynomial lemniscates and sublevel sets",
       "Potential theory: transfinite diameter and logarithmic capacity",
       "Measure theory: Lebesgue measure in the complex plane",
       "Approximation theory: Chebyshev polynomials and extremal polynomials"
     ],
-    "lineCount": 461,
+    "lineCount": 536,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -130,7 +130,7 @@
     {
       "id": "mu-properties",
       "title": "Properties of μ",
-      "summary": "Structural theorems: anti-monotonicity ($F \\subseteq G \\implies \\mu(G) \\leq \\mu(F)$, note reversal, PROVED) and infimum approximation ($\\mu(F)$ can be approached within $\\varepsilon$ by some polynomial, PROVED). New: muPosDeg_pos_of_small_diameter (PROVED) showing $\\mu(F) > 0$ when $\\rho(F) < 1$ via Haar measure positivity.",
+      "summary": "Structural theorems: anti-monotonicity ($F \\subseteq G \\implies \\mu(G) \\leq \\mu(F)$, note reversal, PROVED) and infimum approximation ($\\mu(F)$ can be approached within $\\varepsilon$ by some polynomial, PROVED). muPosDeg_pos_of_small_diameter (sorry) states $\\mu(F) > 0$ when $\\rho(F) < 1$ via disc containment.",
       "startLine": 204,
       "endLine": 217,
       "mathContext": "$F \\subseteq G \\implies \\mu(G) \\leq \\mu(F)$ (anti-monotone). $\\forall \\varepsilon > 0, \\exists f: |S(f)| < \\mu(F) + \\varepsilon$."
@@ -138,14 +138,14 @@
     {
       "id": "open-question",
       "title": "The Open Question and Current State",
-      "summary": "Names the main open question `erdos_1040_question` and states the current knowledge. Split into two parts: Part 1 ($\\mu = 0$ for segments/discs with $\\rho \\geq 1$, sorry — needs EHP formula) and Part 2 ($\\mu > 0$ when $\\rho < 1$, PROVED via muPosDeg_pos_of_small_diameter + Haar measure). Also includes OQ-05 extensions of Erdős-Netanyahu bounds.",
+      "summary": "Names the main open question `erdos_1040_question` and states the current knowledge. Split into two parts: Part 1 ($\\mu = 0$ for segments/discs with $\\rho \\geq 1$, axiomatized via EHP 1958) and Part 2 ($\\mu > 0$ when $\\rho < 1$, sorry via muPosDeg_pos_of_small_diameter). Also includes OQ-05 extensions of Erdős-Netanyahu bounds.",
       "startLine": 218,
       "endLine": 249,
       "mathContext": "Known: $\\rho(F) \\geq 1 \\implies \\mu(F) = 0$ for segments and discs; $\\rho(F) < 1 \\implies \\mu(F) > 0$ for all $F$. General case open since 1958."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #1040 formalizes one of the fundamental open questions in the geometry of polynomial lemniscates: whether the infimum $\\mu(F)$ of sublevel set measures is determined by the transfinite diameter $\\rho(F)$. The Lean formalization builds a complete framework from the $n$-th diameter and Fekete point theory through to the two forms of the conjecture, axiomatizing the known results of EHP (1958) and the Erdős-Netanyahu (1973) quantitative bounds. 5 axioms remain (capacity formulas, disc containment, EN bounds). 5 sorries remain for structural properties of $\\rho$ and $\\mu$.",
+    "summary": "Erdős Problem #1040 formalizes one of the fundamental open questions in the geometry of polynomial lemniscates: whether the infimum $\\mu(F)$ of sublevel set measures is determined by the transfinite diameter $\\rho(F)$. The Lean formalization builds a complete framework from the $n$-th diameter and Fekete point theory through to the two forms of the conjecture, axiomatizing the known results of EHP (1958) and the Erdős-Netanyahu (1973) quantitative bounds. 9 axiom declarations (capacity formulas, disc containment, EN bounds, EHP known cases). 4 sorries remain for structural properties of $\\rho$ and $\\mu$.",
     "implications": "1. **Potential Theory and Polynomial Geometry**: A positive resolution would establish that logarithmic capacity completely controls the measure-theoretic behavior of polynomial lemniscates, unifying capacity theory with the geometry of sublevel sets\n\n2. **Extremal Polynomial Theory**: Understanding $\\mu(F)$ requires identifying near-optimal polynomials for general sets, extending the role of Chebyshev polynomials (for intervals) and power functions (for discs) to arbitrary compact sets\n\n**3. Conformal Invariance**: Since $\\rho(F)$ is related to the conformal mapping radius of $\\mathbb{C} \\setminus F$, a positive answer would connect sublevel set area to conformal geometry\n\n4. **Connection to Problem #1039**: Problems 1039 and 1040 together ask about the inner structure (inscribed disc) and total size (area) of lemniscates — two complementary aspects of the same geometric question\n\n5. **Approximation Theory**: The problem has implications for polynomial approximation on compact sets, as sublevel set size controls the rate of polynomial convergence.",
     "openQuestions": [
       "Is $\\mu(F) = 0$ when $\\rho(F) \\geq 1$ for general closed infinite sets? (The main conjecture, open since 1958)",
@@ -230,8 +230,8 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 461,
-    "axiomCount": 7,
+    "lineCount": 536,
+    "axiomCount": 9,
     "theoremCount": 18,
     "substantiveTheoremCount": 19,
     "trivialSpecializations": 0,


### PR DESCRIPTION
## Fix

Defines the missing `muPosDeg_pos_of_small_diameter` theorem that was referenced but never declared, causing a compilation error.

## Evidence

**Before**: `muPosDeg_pos_of_small_diameter` used at line 440 of `Erdos1040Problem.lean` but undefined anywhere — Lean compilation error.
**After**: Theorem defined at line 413 with `sorry` proof (derives μ(F) > 0 from `small_diameter_disc` axiom). Meta.json corrected: sorry count 5→4, axiom count 7→9, section descriptions fixed.

Closes #8279

---
Automated fix by lean-mechanic agent.