### PR TITLE
Research: 3 problems — Minkowski axiom, Erdős 931 structural, Erdős 1145 axiom

### DIFF
--- a/proofs/Proofs/Erdos931Problem.lean
+++ b/proofs/Proofs/Erdos931Problem.lean
@@ -365,4 +365,89 @@ theorem two_mem_factors (n k : ℕ) (hk : 2 ≤ k) :
     2 ∈ consecutivePrimeFactors n k :=
   prime_le_k_mem_factors n k 2 Nat.prime_two hk
 
+/-
+## Hard Case Structure: Both Blocks Are Entirely Composite
+
+In the hard case (k₁ < n₁, n₂+k₂ < 2n₁, all prime factors ≤ n₁), both blocks
+must consist entirely of composite numbers. The proof: if n₁+i were prime, it
+would be a prime factor of the first product exceeding n₁ (since i ≥ 1),
+contradicting hypothesis h₇. Similarly for the second block via SamePrimeFactors.
+-/
+
+/-- In the hard case, every element of the first block is composite.
+    Proof: if n₁+i is prime and i ≥ 1, then n₁+i > n₁ is a prime factor
+    of the first product, contradicting the hypothesis that all prime factors ≤ n₁. -/
+theorem hard_case_first_block_composite (n₁ k₁ : ℕ)
+    (h₅ : k₁ < n₁)
+    (h₇ : ∀ p ∈ consecutivePrimeFactors n₁ k₁, p ≤ n₁)
+    (i : ℕ) (hi : i ∈ Finset.Icc 1 k₁) :
+    ¬ (n₁ + i).Prime := by
+  intro hp
+  -- n₁ + i is a prime factor of the product
+  have hmem : (n₁ + i) ∈ consecutivePrimeFactors n₁ k₁ :=
+    factor_prime_mem n₁ k₁ i hi (n₁ + i) hp (dvd_refl _)
+  -- By h₇, n₁ + i ≤ n₁
+  have := h₇ _ hmem
+  -- But i ≥ 1, so n₁ + i > n₁
+  simp only [Finset.mem_Icc] at hi
+  omega
+
+/-- In the hard case, every element of the second block is composite.
+    Proof: if n₂+j is prime and j ≥ 1, then n₂+j > n₁ (since n₂ ≥ n₁+k₁) is a
+    prime factor of the second product. By SamePrimeFactors, it's also a prime factor
+    of the first product, and by h₇ it must be ≤ n₁ — contradiction. -/
+theorem hard_case_second_block_composite (n₁ k₁ k₂ n₂ : ℕ)
+    (h₃ : n₁ + k₁ ≤ n₂)
+    (h₄ : SamePrimeFactors n₁ k₁ n₂ k₂)
+    (h₇ : ∀ p ∈ consecutivePrimeFactors n₁ k₁, p ≤ n₁)
+    (j : ℕ) (hj : j ∈ Finset.Icc 1 k₂) :
+    ¬ (n₂ + j).Prime := by
+  intro hp
+  -- n₂ + j is a prime factor of the second product
+  have hmem₂ : (n₂ + j) ∈ consecutivePrimeFactors n₂ k₂ :=
+    factor_prime_mem n₂ k₂ j hj (n₂ + j) hp (dvd_refl _)
+  -- By SamePrimeFactors, it's also a prime factor of the first product
+  have hmem₁ : (n₂ + j) ∈ consecutivePrimeFactors n₁ k₁ := h₄ ▸ hmem₂
+  -- By h₇, n₂ + j ≤ n₁
+  have hle := h₇ _ hmem₁
+  -- But n₂ + j > n₁
+  simp only [Finset.mem_Icc] at hj
+  omega
+
+/-- In the hard case, every prime factor of the second product is ≤ n₁.
+    Follows directly from SamePrimeFactors and the first-product bound. -/
+theorem hard_case_second_block_smooth (n₁ k₁ k₂ n₂ : ℕ)
+    (h₄ : SamePrimeFactors n₁ k₁ n₂ k₂)
+    (h₇ : ∀ p ∈ consecutivePrimeFactors n₁ k₁, p ≤ n₁) :
+    ∀ p ∈ consecutivePrimeFactors n₂ k₂, p ≤ n₁ := by
+  intro p hp
+  exact h₇ p (h₄ ▸ hp)
+
+/-- In the hard case, every element of the second block is n₁-smooth AND greater than n₁.
+    This is the core structural constraint: k₂ ≥ 3 consecutive integers, all composite,
+    all greater than n₁, all with prime factors ≤ n₁. By results on consecutive smooth
+    numbers (Størmer's theorem), this is extremely restrictive and likely impossible
+    for all but finitely many n₁. -/
+theorem hard_case_summary (k₁ k₂ n₁ n₂ : ℕ)
+    (h₁ : 3 ≤ k₂) (h₂ : k₂ ≤ k₁)
+    (h₃ : n₁ + k₁ ≤ n₂)
+    (h₄ : SamePrimeFactors n₁ k₁ n₂ k₂)
+    (h₅ : k₁ < n₁)
+    (h₆ : n₂ + k₂ < 2 * n₁)
+    (h₇ : ∀ p ∈ consecutivePrimeFactors n₁ k₁, p ≤ n₁) :
+    -- All elements of both blocks are composite
+    (∀ i ∈ Finset.Icc 1 k₁, ¬ (n₁ + i).Prime) ∧
+    (∀ j ∈ Finset.Icc 1 k₂, ¬ (n₂ + j).Prime) ∧
+    -- All prime factors of the second product are ≤ n₁
+    (∀ p ∈ consecutivePrimeFactors n₂ k₂, p ≤ n₁) ∧
+    -- All elements of the second block exceed n₁
+    (∀ j ∈ Finset.Icc 1 k₂, n₁ < n₂ + j) := by
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · exact hard_case_first_block_composite n₁ k₁ h₅ h₇
+  · exact hard_case_second_block_composite n₁ k₁ k₂ n₂ h₃ h₄ h₇
+  · exact hard_case_second_block_smooth n₁ k₁ k₂ n₂ h₄ h₇
+  · intro j hj
+    simp only [Finset.mem_Icc] at hj
+    omega
+
 end Erdos931

--- a/proofs/Proofs/MinkowskiFundamentalTheorem.lean
+++ b/proofs/Proofs/MinkowskiFundamentalTheorem.lean
@@ -38,10 +38,11 @@ to the arithmetic of lattices.
 - **Foundation (from Mathlib):** We use Mathlib's convexity, measure theory,
   and Euclidean space infrastructure.
 - **Original Contributions:** We define lattices and centrally symmetric sets,
-  state the theorem, and outline the classical pigeonhole proof.
-- **Proof Techniques:** The main theorem uses a beautiful covering argument
-  with the pigeonhole principle, which we axiomatize since full formalization
-  requires measure-theoretic machinery beyond current scope.
+  state the theorem, and prove it from Mathlib's geometry of numbers.
+- **Proof Techniques:** The main theorem uses Mathlib's
+  `exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure` which
+  implements the classical pigeonhole/covering argument with full
+  measure-theoretic rigor.
 
 ## Status
 - [x] Complete statement of theorem
@@ -50,7 +51,7 @@ to the arithmetic of lattices.
 - [x] Proof structure outlined
 - [x] Uses Mathlib for convexity and measure concepts
 - [x] Applications (Fermat's two squares, Lagrange's four squares)
-- [ ] Incomplete (main result axiomatized)
+- [x] Main result proved from Mathlib's geometry of numbers
 
 ## The Classical Proof (Pigeonhole Argument)
 
@@ -219,11 +220,14 @@ the lattice.
 We abstract the volume as a property of convex bodies.
 -/
 
-/-- Abstract volume for a convex body.
-    In full formalization, this would be the Lebesgue measure. -/
+/-- Volume for a convex body, connected to actual Lebesgue measure.
+    The `volume_eq` field bridges the abstract volume to measure theory,
+    enabling the proof of Minkowski's theorem from Mathlib. -/
 class HasVolume (n : ℕ) (S : ConvexBody n) where
   volume : ℝ
   volume_pos : 0 < volume
+  carrier_measurableSet : MeasurableSet S.carrier
+  volume_eq : MeasureTheory.volume S.carrier = ENNReal.ofReal volume
 
 /-- The critical volume threshold for Minkowski's theorem -/
 noncomputable def criticalVolume (L : Lattice n) : ℝ := (2 : ℝ) ^ n * L.covolume
@@ -234,6 +238,77 @@ theorem criticalVolume_pos (L : Lattice n) : 0 < criticalVolume n L := by
   apply mul_pos
   · exact pow_pos (by norm_num : (0 : ℝ) < 2) n
   · exact L.covolume_pos
+
+-- ============================================================
+-- PART 4.5: Bridge from Custom Types to Mathlib
+-- ============================================================
+
+/-!
+### Connecting Custom Lattice to Mathlib's Module.Basis
+
+The custom `Lattice n` type stores a basis as a matrix. We bridge this to
+Mathlib's `Module.Basis` by interpreting rows of the matrix as basis vectors
+and constructing a `LinearEquiv` from the transpose matrix multiplication.
+-/
+
+/-- The lattice basis vectors: row i of the basis matrix. -/
+def Lattice.basisVec (L : Lattice n) (i : Fin n) : EuclideanN n :=
+  fun j => L.basis i j
+
+/-- Linear equivalence from lattice basis matrix (transpose acts on standard basis).
+    Maps standard basis vector eᵢ to row_i(L.basis). -/
+noncomputable def Lattice.toLinearEquiv (L : Lattice n) :
+    (EuclideanN n) ≃ₗ[ℝ] (EuclideanN n) := by
+  apply LinearEquiv.ofBijective (L.basis.transpose.mulVecLin)
+  rw [← LinearMap.isUnit_iff_bijective, ← Matrix.isUnit_det_iff_isUnit_mulVecLin,
+      Matrix.det_transpose]
+  exact isUnit_iff_ne_zero.mpr L.basis_invertible
+
+/-- Module basis constructed from the lattice basis matrix.
+    The i-th basis vector is row_i(L.basis). -/
+noncomputable def Lattice.toModuleBasis (L : Lattice n) :
+    Module.Basis (Fin n) ℝ (EuclideanN n) :=
+  (Pi.basisFun ℝ (Fin n)).map (L.toLinearEquiv n)
+
+/-- The matrix of the module basis equals the original lattice matrix. -/
+theorem Lattice.toModuleBasis_matrix_eq (L : Lattice n) :
+    Matrix.of (L.toModuleBasis n) = L.basis := by
+  ext i j
+  simp only [toModuleBasis, Basis.map_apply, toLinearEquiv, LinearEquiv.ofBijective_apply,
+    Matrix.mulVecLin_apply, Pi.basisFun_apply, Matrix.of_apply]
+  -- (L.basis^T).mulVec (Pi.single i 1) at component j = L.basis i j
+  simp only [Matrix.mulVec, Matrix.dotProduct, Matrix.transpose_apply,
+    Pi.single_apply, mul_ite, mul_one, mul_zero, Finset.sum_ite_eq', Finset.mem_univ, ite_true]
+
+/-- Row i of the lattice basis matrix equals the i-th module basis vector. -/
+theorem Lattice.basisVec_eq_toModuleBasis (L : Lattice n) (i : Fin n) :
+    L.basisVec n i = L.toModuleBasis n i := by
+  ext j
+  simp only [basisVec]
+  -- This equals (Matrix.of (L.toModuleBasis n)) i j = L.basis i j
+  have := congr_fun (congr_fun (L.toModuleBasis_matrix_eq n) i) j
+  simp only [Matrix.of_apply] at this
+  exact this.symm
+
+/-- Lattice points are exactly the ℤ-span of the module basis vectors. -/
+theorem latticePoints_eq_span (L : Lattice n) :
+    latticePoints n L = ↑(Submodule.span ℤ (Set.range (L.toModuleBasis n))) := by
+  ext x
+  simp only [latticePoints, isLatticeVector, Set.mem_setOf_eq, SetLike.mem_coe]
+  -- Key: (fun j => L.basis i j) = L.toModuleBasis n i
+  have hbasis : ∀ i, (fun j => L.basis i j) = L.toModuleBasis n i :=
+    L.basisVec_eq_toModuleBasis n
+  constructor
+  · -- latticePoints → span: x = ∑ i, (c i : ℝ) • basis_i → x ∈ ℤ-span
+    rintro ⟨coeffs, hx⟩
+    simp_rw [hbasis] at hx
+    rw [Submodule.mem_span_range_iff_exists_fun]
+    exact ⟨coeffs, by simp_rw [zsmul_eq_smul_cast ℝ]; exact hx.symm⟩
+  · -- span → latticePoints: x ∈ ℤ-span → ∃ c, x = ∑ i, (c i : ℝ) • basis_i
+    intro hx
+    rw [Submodule.mem_span_range_iff_exists_fun] at hx
+    obtain ⟨coeffs, hx⟩ := hx
+    exact ⟨coeffs, by simp_rw [hbasis, zsmul_eq_smul_cast ℝ] at hx; exact hx.symm⟩
 
 -- ============================================================
 -- PART 5: Minkowski's Fundamental Theorem
@@ -253,28 +328,51 @@ The proof uses the pigeonhole principle:
 4. Use convexity and symmetry to find a non-zero lattice point in S
 -/
 
-/-- **Minkowski's Fundamental Theorem** (Axiomatized)
+/-- **Minkowski's Fundamental Theorem** — Proved from Mathlib
 
 If S is a centrally symmetric convex body in ℝⁿ with volume > 2ⁿ · det(L),
 then S contains a non-zero point of the lattice L.
 
-Proof outline:
-1. Let T = S/2 (scale S by factor 1/2).
-2. vol(T) = vol(S)/2ⁿ > det(L) = volume of fundamental domain.
-3. Consider translates T + p for all lattice points p ∈ L.
-4. By the pigeonhole principle, two translates must overlap:
-   ∃ p₁ ≠ p₂ in L, ∃ x ∈ (T + p₁) ∩ (T + p₂).
-5. Then x = t₁ + p₁ = t₂ + p₂ for some t₁, t₂ ∈ T.
-6. So t₁ - t₂ = p₂ - p₁ ∈ L (a non-zero lattice vector).
-7. But t₁ = s₁/2 and t₂ = s₂/2 for s₁, s₂ ∈ S.
-8. By symmetry, -s₂ ∈ S. By convexity, (s₁ + (-s₂))/2 ∈ S.
-9. This equals t₁ - t₂ = p₂ - p₁ ∈ S ∩ L, and it's non-zero.
-
-This proof requires measure theory and careful handling of
-the pigeonhole argument in infinite settings. -/
-axiom minkowski_fundamental (L : Lattice n) (S : ConvexBody n) [hv : HasVolume n S] :
+The proof bridges the custom Lattice/ConvexBody/HasVolume types to Mathlib's
+`exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure` via:
+1. `Lattice.toModuleBasis` — converts the basis matrix to a `Module.Basis`
+2. `HasVolume.volume_eq` — connects abstract volume to Lebesgue measure
+3. `latticePoints_eq_span` — identifies custom lattice points with ℤ-span -/
+theorem minkowski_fundamental (L : Lattice n) (S : ConvexBody n) [hv : HasVolume n S] :
     hv.volume > criticalVolume n L →
-    ∃ x ∈ S.carrier, x ∈ latticePoints n L ∧ x ≠ 0
+    ∃ x ∈ S.carrier, x ∈ latticePoints n L ∧ x ≠ 0 := by
+  intro h_vol
+  -- Bridge: construct Module.Basis from custom Lattice
+  set b := L.toModuleBasis n with hb_def
+  -- Bridge: convert volume inequality from ℝ to ENNReal
+  have h_vol_ennreal : MeasureTheory.volume (ZSpan.fundamentalDomain b) *
+      2 ^ Fintype.card (Fin n) < MeasureTheory.volume S.carrier := by
+    rw [ZSpan.volume_fundamentalDomain, L.toModuleBasis_matrix_eq, hv.volume_eq]
+    -- Need: ENNReal.ofReal |L.basis.det| * 2 ^ n < ENNReal.ofReal hv.volume
+    -- From: hv.volume > 2^n * |L.basis.det| (all positive reals)
+    unfold criticalVolume Lattice.covolume at h_vol
+    have h_nonneg : 0 ≤ |L.basis.det| * (2 : ℝ) ^ n :=
+      mul_nonneg (abs_nonneg _) (pow_nonneg (by norm_num) _)
+    rw [show ENNReal.ofReal |L.basis.det| * (2 : ENNReal) ^ Fintype.card (Fin n) =
+        ENNReal.ofReal (|L.basis.det| * (2 : ℝ) ^ n) from by
+      rw [Fintype.card_fin]
+      rw [ENNReal.ofReal_mul (abs_nonneg _)]
+      congr 1
+      rw [ENNReal.ofReal_pow (by norm_num : (0 : ℝ) ≤ 2)]
+      simp [ENNReal.ofReal_ofNat]]
+    exact ENNReal.ofReal_lt_ofReal_of_nonneg h_nonneg (by linarith [mul_comm ((2 : ℝ) ^ n) |L.basis.det|])
+  -- Apply Mathlib's geometry of numbers theorem directly
+  have h_mathlib := exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure
+    (ZSpan.isAddFundamentalDomain b volume) S.symmetric S.convex h_vol_ennreal
+  -- Extract the result and translate back to custom types
+  obtain ⟨⟨x, hx_span⟩, hne, hx_carrier⟩ := h_mathlib
+  refine ⟨x, hx_carrier, ?_, ?_⟩
+  · -- x is in latticePoints (via span equivalence)
+    rw [latticePoints_eq_span]
+    exact hx_span
+  · -- x ≠ 0 (from subtype nonzero)
+    intro h0
+    exact hne (Subtype.ext h0)
 
 /-- Equivalent formulation: volume ≥ 2ⁿ · det(L) with strict inequality implies
     existence of a non-zero lattice point. -/
@@ -451,15 +549,13 @@ end MinkowskiFundamentalTheorem
 -- ============================================================
 
 /-!
-## Minkowski's Theorem — Proved from Mathlib
+## Minkowski's Theorem — Direct Mathlib Proofs
 
-The axiom `minkowski_fundamental` above axiomatizes the main theorem because the proof
-requires measure-theoretic pigeonhole. Mathlib now provides exactly this:
-`MeasureTheory.exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure`
-in `Mathlib.MeasureTheory.Group.GeometryOfNumbers`.
-
-Below we prove the integer lattice case (ℤⁿ) from Mathlib, using actual Lebesgue measure
-instead of the abstract `HasVolume` typeclass.
+These proofs work directly with Mathlib types (Module.Basis, Submodule, Lebesgue measure)
+rather than the custom types from Parts 1-8. They serve as the foundation for the
+`minkowski_fundamental` theorem above, which bridges through `Lattice.toModuleBasis`
+and `HasVolume.volume_eq` to connect the custom API to Mathlib's
+`exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure`.
 -/
 
 namespace MinkowskiProved

--- a/src/data/proofs/minkowski-theorem/meta.json
+++ b/src/data/proofs/minkowski-theorem/meta.json
@@ -8,7 +8,7 @@
     "author": "Hermann Minkowski (1896)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Minkowski%27s_theorem",
     "date": "1896",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/MinkowskiFundamentalTheorem.lean",
     "tags": [
       "number-theory",
@@ -18,7 +18,7 @@
       "wiedijk-100",
       "classic"
     ],
-    "badge": "axiom",
+    "badge": "verified",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -40,6 +40,16 @@
         "theorem": "Nat.Prime.sq_add_sq",
         "description": "Fermat's two-squares theorem: primes p with p % 4 != 3 are sums of two squares",
         "module": "Mathlib.NumberTheory.SumTwoSquares"
+      },
+      {
+        "theorem": "exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure",
+        "description": "Minkowski's convex body theorem via measure-theoretic pigeonhole",
+        "module": "Mathlib.MeasureTheory.Group.GeometryOfNumbers"
+      },
+      {
+        "theorem": "ZSpan.isAddFundamentalDomain",
+        "description": "Fundamental domain for ℤ-span of a basis",
+        "module": "Mathlib.Algebra.Module.ZLattice.Basic"
       }
     ],
     "originalContributions": [
@@ -47,14 +57,16 @@
       "CentrallySymmetric predicate and origin membership proof",
       "ConvexBody bundling convexity, symmetry, and nonemptiness",
       "Critical volume threshold definition and positivity",
+      "Bridge from custom Lattice to Mathlib Module.Basis via LinearEquiv.ofBijective",
+      "HasVolume typeclass connecting abstract volume to Lebesgue measure",
+      "Full proof of minkowski_fundamental from Mathlib's GeometryOfNumbers (0 axioms)",
       "Integer lattice specialization reducing threshold to 2^n",
-      "Fermat two-squares theorem as a Minkowski application",
-      "Proved Minkowski for ℤⁿ from Mathlib's GeometryOfNumbers (axiom-free integer lattice case)"
+      "Fermat two-squares theorem as a Minkowski application"
     ],
     "dateAdded": "2025-12-29",
-    "axiomCount": 1,
-    "lineCount": 544,
-    "assumptions": "1 axiom: minkowski_fundamental (the main convex body theorem for general lattices using custom HasVolume typeclass). The integer lattice case (ℤⁿ) is now PROVED from Mathlib's GeometryOfNumbers module (MinkowskiProved.minkowski_integer_lattice_proved). The general lattice axiom remains because the custom Lattice/HasVolume types need refactoring to use actual Lebesgue measure.",
+    "axiomCount": 0,
+    "lineCount": 662,
+    "assumptions": "None. The main theorem minkowski_fundamental is fully proved from Mathlib's GeometryOfNumbers via bridge lemmas connecting custom Lattice/ConvexBody/HasVolume types to Mathlib's Module.Basis, ZSpan, and Lebesgue measure.",
     "mathlib_version": "4.26.0",
     "prerequisites": [
       "Convex sets and convexity in real vector spaces",
@@ -67,7 +79,7 @@
   "overview": {
     "historicalContext": "Hermann Minkowski (1864--1909), a Lithuanian-German mathematician and one of Einstein's teachers at ETH Zurich, presented his convex body theorem in 'Geometrie der Zahlen' (1896), founding the field now called the geometry of numbers. The central idea was revolutionary: purely geometric reasoning about volumes and convex sets could yield arithmetic conclusions about the existence of integer points. Minkowski had first announced the result in 1889 and developed it over several years.\n\nThe theorem emerged from Minkowski's study of quadratic forms and their arithmetic properties. He realized that asking whether a quadratic form represents small values is equivalent to asking whether a certain ellipsoid contains lattice points -- transforming an algebraic question into a geometric one. This insight connected two previously separate mathematical traditions: the algebraic theory of quadratic forms (Gauss, Hermite) and the geometry of convex bodies.\n\nMinkowski's theorem was immediately recognized as fundamental. Hilbert used Minkowski's bound to prove the finiteness of the ideal class group of algebraic number fields, one of the cornerstones of algebraic number theory. The classical proof via the pigeonhole principle applied to lattice translates of the scaled set $S/2$ is a model of mathematical elegance: a deep arithmetic conclusion follows from a simple volume comparison.\n\nBlichfeldt (1914) refined the result into a counting generalization. Siegel later extended the geometry of numbers to adelic settings, connecting it to the theory of automorphic forms. Today the theorem underpins lattice-based cryptography (LWE, NTRU, FHE), where the guaranteed existence of short lattice vectors is central to both security proofs and cryptanalytic attacks. The shortest vector problem (SVP) and closest vector problem (CVP), both related to Minkowski's bounds, are believed to be hard even for quantum computers, making lattice cryptography a leading candidate for post-quantum security.",
     "problemStatement": "**Minkowski's Fundamental Theorem (Wiedijk #40)**: Let $L$ be a lattice in $\\mathbb{R}^n$ with covolume $V = |\\det(B)|$, where $B$ is a basis matrix. If $S \\subseteq \\mathbb{R}^n$ is:\n\n1. **Convex**: for all $x, y \\in S$ and $0 \\leq t \\leq 1$, the point $tx + (1-t)y \\in S$\n2. **Centrally symmetric**: $x \\in S \\Rightarrow -x \\in S$\n3. **Sufficiently large**: $\\text{vol}(S) > 2^n \\cdot V$\n\nThen $S$ contains a non-zero lattice point: $\\exists\\, p \\in S \\cap L,\\; p \\neq 0$.\n\nFor the standard lattice $\\mathbb{Z}^n$ (covolume 1), the threshold simplifies to $\\text{vol}(S) > 2^n$.",
-    "text": "A 453-line formalization of Minkowski's Fundamental Theorem (Wiedijk #40) with 9 theorems, 7 definitions, and 1 axiom. Defines custom `Lattice` and `ConvexBody` structures, proves the origin membership lemma for symmetric convex sets, establishes the critical volume threshold $2^n \\cdot \\text{covol}(L)$, and specializes to the integer lattice $\\mathbb{Z}^n$. The main theorem is axiomatized (measure-theoretic pigeonhole argument). Includes Fermat's two-squares theorem as an application via Mathlib's `Nat.Prime.sq_add_sq`.",
+    "text": "A 662-line formalization of Minkowski's Fundamental Theorem (Wiedijk #40) with 19 theorems, 14 definitions, and 0 axioms. Defines custom `Lattice` and `ConvexBody` structures, bridges them to Mathlib's `Module.Basis` and `ZSpan` infrastructure, and proves the main theorem from Mathlib's `exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure`. Includes Fermat's two-squares theorem as an application via Mathlib's `Nat.Prime.sq_add_sq`.",
     "proofStrategy": "**The Classical Pigeonhole Proof:**\n\n1. **Scale**: Consider $T = S/2 = \\{x/2 : x \\in S\\}$. Since $S$ is convex and symmetric, $T$ is also convex and symmetric, with $\\text{vol}(T) = \\text{vol}(S)/2^n > V$.\n\n2. **Translate**: For each lattice point $p \\in L$, consider the translate $T + p$. All translates have the same volume $\\text{vol}(T) > V$.\n\n3. **Pigeonhole**: The translates $\\{T + p : p \\in L\\}$ partition the same space as the fundamental domains. Since each has volume exceeding the fundamental domain volume $V$, two translates must overlap: $\\exists\\, p_1 \\neq p_2$ such that $(T + p_1) \\cap (T + p_2) \\neq \\emptyset$.\n\n4. **Extract the lattice point**: If $x \\in (T + p_1) \\cap (T + p_2)$, then $x = s_1/2 + p_1 = s_2/2 + p_2$ for $s_1, s_2 \\in S$. The difference $p_2 - p_1 = (s_1 - s_2)/2 \\in L$ is nonzero. By central symmetry $-s_2 \\in S$, and by convexity $(s_1 + (-s_2))/2 = p_2 - p_1 \\in S$. This is a nonzero lattice point in $S$.",
     "keyInsights": [
       "The volume bound $2^n$ is sharp: the open cube $(-1,1)^n$ has volume exactly $2^n$ and contains no nonzero integer points. For the closed cube $[-1,1]^n$, the boundary equality case still guarantees a lattice point (Minkowski's refinement)",
@@ -132,8 +144,8 @@
       "title": "Minkowski's Fundamental Theorem",
       "startLine": 240,
       "endLine": 307,
-      "summary": "States the main theorem as `axiom minkowski_fundamental`: given $\\text{vol}(S) > \\text{critVol}(L)$, there exists $x \\in S \\cap L$ with $x \\neq 0$. Derives `minkowski_fundamental'` (unfolding `criticalVolume`) and `minkowski_integer_lattice` (specializing to $\\mathbb{Z}^n$ where the threshold is simply $2^n$).",
-      "mathContext": "The main theorem is axiomatized because the full proof requires: (1) constructing Lebesgue measure on $\\mathbb{R}^n$, (2) applying Fubini's theorem to count lattice translate overlaps, (3) the measure-theoretic pigeonhole principle for infinite families of translates. The integer lattice specialization uses `standardLattice_covolume` to simplify $2^n \\cdot 1 = 2^n$."
+      "summary": "Proves `minkowski_fundamental` from Mathlib: given $\\text{vol}(S) > \\text{critVol}(L)$, there exists $x \\in S \\cap L$ with $x \\neq 0$. The proof bridges custom types to Mathlib via `Lattice.toModuleBasis` and `HasVolume.volume_eq`, then applies `exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure`. Derives `minkowski_fundamental'` and `minkowski_integer_lattice` as corollaries.",
+      "mathContext": "The proof connects custom types to Mathlib in three steps: (1) `Lattice.toModuleBasis` constructs a `Module.Basis` from the matrix via `LinearEquiv.ofBijective` on the transpose, (2) `HasVolume.volume_eq` bridges abstract volume to Lebesgue measure, (3) `latticePoints_eq_span` identifies custom lattice points with the ℤ-span. The integer lattice specialization uses `standardLattice_covolume` to simplify $2^n \\cdot 1 = 2^n$."
     },
     {
       "id": "applications",
@@ -161,13 +173,13 @@
     }
   ],
   "conclusion": {
-    "summary": "Minkowski's Fundamental Theorem is the cornerstone of the geometry of numbers, elegantly connecting the volume of convex symmetric bodies to the existence of non-trivial lattice points. The formalization defines lattices via basis matrices with nonzero determinant, introduces convex bodies bundling symmetry and convexity, establishes the critical volume threshold $2^n \\cdot \\text{covol}(L)$, and proves the origin membership lemma for symmetric convex sets. The main theorem is axiomatized due to the measure-theoretic demands of the infinite pigeonhole argument. The file demonstrates the theorem's power through Fermat's two-squares theorem (via Mathlib) and describes Dirichlet approximation and Lagrange's four-squares as further applications.",
+    "summary": "Minkowski's Fundamental Theorem is the cornerstone of the geometry of numbers, elegantly connecting the volume of convex symmetric bodies to the existence of non-trivial lattice points. The formalization defines lattices via basis matrices with nonzero determinant, introduces convex bodies bundling symmetry and convexity, establishes the critical volume threshold $2^n \\cdot \\text{covol}(L)$, and fully proves the main theorem from Mathlib's geometry of numbers module. Bridge lemmas connect the custom Lattice/ConvexBody/HasVolume API to Mathlib's Module.Basis, ZSpan, and Lebesgue measure infrastructure. The file demonstrates the theorem's power through Fermat's two-squares theorem (via Mathlib) and describes Dirichlet approximation and Lagrange's four-squares as further applications.",
     "implications": "**Algebraic Number Theory**: Minkowski's bound on ideal norms proves finiteness of class groups, one of the deepest results in algebraic number theory. **Diophantine Equations**: The theorem provides non-constructive existence proofs for integer solutions to equations (sums of squares, Pell equations, norm equations in number fields). **Cryptography**: Lattice-based schemes (LWE, Ring-LWE, NTRU, fully homomorphic encryption) derive security from the computational hardness of lattice problems, while Minkowski's theorem guarantees the existence of short vectors that attacks attempt to find. **Coding Theory**: Sphere packing bounds in R^n use Minkowski-type volume arguments to limit code density.",
     "openQuestions": [
-      "Can the main axiom be replaced by a full proof using Mathlib's measure theory (MeasureTheory.Measure.Lebesgue, Fubini's theorem, change of variables for lattice translates)?",
       "Can Minkowski's successive minima and the second fundamental theorem be formalized in Lean?",
       "Can Dirichlet's approximation theorem be stated and proved as a direct corollary of the integer lattice specialization?",
-      "Can the Minkowski bound on ideal norms be formalized, connecting the convex body theorem to finiteness of class groups in algebraic number fields?"
+      "Can the Minkowski bound on ideal norms be formalized, connecting the convex body theorem to finiteness of class groups in algebraic number fields?",
+      "Can Blichfeldt's generalization (k+1 lattice points when vol > k det) be proved from Mathlib?"
     ]
   },
   "crossReferences": [
@@ -229,6 +241,8 @@
       "Mathlib.Analysis.Convex.Basic",
       "Mathlib.Analysis.Normed.Field.Basic",
       "Mathlib.MeasureTheory.Measure.Lebesgue.Basic",
+      "Mathlib.MeasureTheory.Group.GeometryOfNumbers",
+      "Mathlib.Algebra.Module.ZLattice.Basic",
       "Mathlib.LinearAlgebra.Matrix.Determinant.Basic",
       "Mathlib.NumberTheory.SumTwoSquares",
       "Mathlib.Data.Real.Basic",
@@ -240,15 +254,15 @@
       "Metric"
     ],
     "namespace": "MinkowskiFundamentalTheorem",
-    "lineCount": 453,
-    "axiomCount": 1,
-    "theoremCount": 9,
-    "definitionCount": 7,
+    "lineCount": 662,
+    "axiomCount": 0,
+    "theoremCount": 19,
+    "definitionCount": 14,
     "mainTheorems": [
       {
         "name": "minkowski_fundamental",
-        "type": "axiom",
-        "description": "The main convex body theorem: vol(S) > 2^n covol(L) implies S contains a nonzero lattice point",
+        "type": "proved",
+        "description": "The main convex body theorem: vol(S) > 2^n covol(L) implies S contains a nonzero lattice point. Proved from Mathlib's geometry of numbers.",
         "leanType": "(L : Lattice n) -> (S : ConvexBody n) -> [hv : HasVolume n S] -> hv.volume > criticalVolume n L -> exists x in S.carrier, x in latticePoints n L and x != 0"
       },
       {
@@ -320,7 +334,7 @@
     {
       "name": "minkowski_fundamental",
       "type": "core",
-      "description": "A convex symmetric body of volume > 2^n covol(L) contains a nonzero lattice point",
+      "description": "A convex symmetric body of volume > 2^n covol(L) contains a nonzero lattice point. Fully proved from Mathlib.",
       "leanType": "(L : Lattice n) -> (S : ConvexBody n) -> [hv : HasVolume n S] -> hv.volume > criticalVolume n L -> exists x in S.carrier, x in latticePoints n L and x != 0"
     },
     {


### PR DESCRIPTION
## Summary
Research session covering three problems:

### 1. minkowski-theorem-oq-01 — Axiom Elimination (Wiedijk #40)
- Replace `axiom minkowski_fundamental` with theorem proved from Mathlib
- **Result: 0 axioms, 0 sorries** (was 1 axiom) — status: verified

### 2. erdos-931 — Structural Lemmas for Hard Case
- Prove 4 structural lemmas: both blocks composite, n₁-smooth in hard case
- 2 axioms remain, +4 theorems

### 3. erdos-1145 — Axiom Elimination (ruzsa_ratio_not_one)
- Replace axiom with theorem: prove ruzsaB = 2·ruzsaA bijection
- Prove countingFn identity and ratio non-convergence skeleton
- 4 axioms → 3 axioms, +2 sorries (routine set bijection + ratio bound)

## Net Impact
- **1 axiom fully eliminated** (Minkowski, Wiedijk #40 → verified)
- **1 axiom converted to theorem with 2 routine sorries** (Erdős 1145)
- **4 structural lemmas proved** (Erdős 931)

Generated by researcher-9