### PR TITLE
fix: correct sorry count for erdos-1018-oq-04 (4 → 3)

### DIFF
--- a/proofs/Proofs/Erdos1018OQ04.lean
+++ b/proofs/Proofs/Erdos1018OQ04.lean
@@ -298,8 +298,8 @@ axiom density_exceeds_turan (t r : ℕ) (hr : r ≥ 2) (ht : t > r) :
 
   Axiom count: 4 (vanKampen_Flores, triangle_planar, K4_planar,
   density_exceeds_turan).
-  Sorry count: 4 (isEmbeddable def, completeHypergraph_edgeCount,
-  max_edges, turanNumber def).
+  Sorry count: 3 (isEmbeddable def, completeHypergraph_edgeCount,
+  turanNumber def).
 -/
 
 end Erdos1018OQ04

--- a/src/data/proofs/erdos-1018-oq-04/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04/meta.json
@@ -18,10 +18,10 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 3,
     "axiomCount": 4,
     "lineCount": 301,
-    "assumptions": "4 axioms: van Kampen-Flores theorem, embeddability of K₃ and K₄ in R², density-exceeds-Turán threshold. 4 sorries including topological embeddability definition.",
+    "assumptions": "4 axioms: van Kampen-Flores theorem, embeddability of K₃ and K₄ in R², density-exceeds-Turán threshold. 3 sorries: isEmbeddable definition, completeHypergraph_edgeCount, turanNumber definition.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [


### PR DESCRIPTION
## Summary

- **erdos-1018-oq-04** meta.json claimed 4 sorries, but the Lean file has only 3
- `max_edges` (lines 98-113) has a complete proof — was incorrectly listed as sorry'd
- Fixed `sorries` field (4 → 3), `assumptions` text, and Lean file trailing comment

## Evidence

**meta.json claimed**: `"sorries": 4` with `max_edges` listed as sorry'd
**Lean file shows**: 3 sorry keywords at lines 77, 141, 269 — `max_edges` is fully proved

## Test plan

- [ ] Verify `grep -c sorry proofs/Proofs/Erdos1018OQ04.lean` returns 3
- [ ] Verify gallery builds: `pnpm build`

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)