### PR TITLE
Research: pascals-hexagon-oq-01 — 14 lemmas toward axiom elimination

### DIFF
--- a/proofs/Proofs/Erdos1014OQ02.lean
+++ b/proofs/Proofs/Erdos1014OQ02.lean
@@ -141,72 +141,25 @@ theorem log_over_l_faster_than_inv_log :
   linarith
 
 -- ══════════════════════════════════════════════════════════════════
--- § Step 3: Rate Bound for General k (Conditional)
+-- § Step 3: General k (conditional convergence)
 -- ══════════════════════════════════════════════════════════════════
 
-/-- Conditional rate for general k: If R(k,l) has power-law growth
-    R(k,l) ~ c·l^(k-1)/(log l)^(k-2), then the rate of convergence
-    to 1 is O(1/l), which is even faster than O(log l / l).
+/-- For general k with conjectured asymptotics R(k,l) ~ c·l^(k-1)/(log l)^(k-2),
+    the ratio R(k,l+1)/R(k,l) → 1 as l → ∞.
 
-    This follows because:
-    - R(k,l+1)/R(k,l) = [(l+1)/l]^(k-1) · [log l/log(l+1)]^(k-2) · [c(l+1)/c(l)]
-    - [(l+1)/l]^(k-1) = 1 + (k-1)/l + O(1/l²)
-    - [log l/log(l+1)]^(k-2) = 1 - O(1/(l·log l))
-    - The product is 1 + O(1/l)
--/
-theorem conditional_rate_general_k (k : ℕ) (hk : k ≥ 3) :
+    This is proved in `Erdos1014Problem.ratio_from_asymptotics` (the main file)
+    using a 3-factor decomposition R'/R = (R'/g')·(g'/g)·(g/R).
+
+    NOTE: The growth ratio g'/g = ((l+1)/l)^(k-1)·(log l/log(l+1))^(k-2)
+    converges to 1 at rate O(k/l), but this does NOT imply the overall
+    convergence is O(1/l) — the rate depends on how fast R(k,l)/g(l) → 1,
+    which the asymptotic hypothesis does not quantify. -/
+theorem conditional_convergence_general_k (k : ℕ) (hk : k ≥ 3) :
   (∀ ε : ℝ, ε > 0 → ∃ c : ℝ, c > 0 ∧ ∃ L₀ : ℕ, ∀ l : ℕ, l > L₀ →
     |(ramseyNumber k l : ℝ) / (c * (l : ℝ) ^ (k - 1) / (Real.log l) ^ (k - 2)) - 1| < ε) →
-  ∃ C : ℝ, C > 0 ∧ ∃ L₀ : ℕ, ∀ l : ℕ, l > L₀ →
-    |(ramseyNumber k (l + 1) : ℝ) / (ramseyNumber k l : ℝ) - 1| ≤ C / (l : ℝ) := by
-  intro h_asymp
-  obtain ⟨c, hc, L₁, hL₁⟩ := h_asymp (1/4) (by positivity)
-  refine ⟨4 * k, by positivity, ?_⟩
-  -- Growth ratio bound: |((l+1)/l)^(k-1) · (log l/log(l+1))^(k-2) - 1| ≤ 2k/l
-  have hgr : ∃ L₂ : ℕ, ∀ l : ℕ, l > L₂ →
-      |(((l : ℝ) + 1) / (l : ℝ)) ^ (k - 1) *
-       (Real.log (l : ℝ) / Real.log ((l : ℝ) + 1)) ^ (k - 2) - 1| ≤
-        (2 * k : ℝ) / (l : ℝ) := by
-    use max (4 * k) 2
-    intro l hl
-    have hl_pos : (0 : ℝ) < l := by exact_mod_cast (show 0 < l by omega)
-    have hl1_pos : (0 : ℝ) < (l : ℝ) + 1 := by linarith
-    have hlog_l : 0 < Real.log (l : ℝ) :=
-      Real.log_pos (by exact_mod_cast (show 1 < l by omega))
-    have hlog_l1 : 0 < Real.log ((l : ℝ) + 1) :=
-      Real.log_pos (by linarith)
-    -- Bernoulli-type bound for growth ratio
-    sorry
-  obtain ⟨L₂, hL₂⟩ := hgr
-  use max (max L₁ L₂) 2
-  intro l hl
-  have hl1 : l > L₁ := by omega
-  have hl2 : l > L₂ := by omega
-  have hl_pos : (0 : ℝ) < l := by exact_mod_cast (show 0 < l by omega)
-  have hl1_pos : (0 : ℝ) < (l : ℝ) + 1 := by linarith
-  have hlog_l : 0 < Real.log (l : ℝ) :=
-    Real.log_pos (by exact_mod_cast (show 1 < l by omega))
-  have hlog_l1 : 0 < Real.log ((l : ℝ) + 1) :=
-    Real.log_pos (by linarith)
-  set a := k - 1 with ha_def
-  set b := k - 2 with hb_def
-  set g := c * (l : ℝ) ^ a / (Real.log (l : ℝ)) ^ b
-  set g' := c * ((l : ℝ) + 1) ^ a / (Real.log ((l : ℝ) + 1)) ^ b
-  have hg_pos : 0 < g := div_pos (mul_pos hc (pow_pos hl_pos _)) (pow_pos hlog_l _)
-  have hg'_pos : 0 < g' := div_pos (mul_pos hc (pow_pos hl1_pos _)) (pow_pos hlog_l1 _)
-  set R := (ramseyNumber k l : ℝ)
-  set R' := (ramseyNumber k (l + 1) : ℝ)
-  have hα : |R' / g' - 1| < 1/4 := by
-    convert hL₁ (l + 1) (by omega) using 2; push_cast; ring
-  have hζ : |R / g - 1| < 1/4 := hL₁ l hl1
-  have hβ := hL₂ l hl2
-  have hR_pos : 0 < R := by
-    have hRg : R / g > 3/4 := by linarith [(abs_lt.mp hζ).1]
-    by_contra h; push_neg at h
-    have : R / g ≤ 0 := div_nonpos_of_nonpos_of_nonneg h (le_of_lt hg_pos)
-    linarith
-  -- Decompose and bound R'/R - 1 using 3-factor decomposition
-  sorry
+  ∀ ε : ℝ, ε > 0 → ∃ L₀ : ℕ, ∀ l : ℕ, l > L₀ →
+    |(ramseyNumber k (l + 1) : ℝ) / (ramseyNumber k l : ℝ) - 1| < ε :=
+  ratio_from_asymptotics k hk
 
 -- ══════════════════════════════════════════════════════════════════
 -- § Step 4: The Answer

--- a/proofs/Proofs/PascalsHexagon.lean
+++ b/proofs/Proofs/PascalsHexagon.lean
@@ -491,25 +491,281 @@ theorem pascalConstraint_projTransform (M : Matrix (Fin 3) (Fin 3) ℝ) (hM : M.
     exact (mul_eq_zero.mp h).resolve_left hdet
   · intro h; rw [h, mul_zero]
 
-/-
-### Roadmap for Full Axiom Elimination
+-- ============================================================
+-- PART 13: Scaling Lemma and Parametric Coverage
+-- ============================================================
 
-**Completed:**
-1. `pascal_std_conic_parametrized`: Pascal's theorem for the standard conic x₀²+x₁²=x₂²
-2. `stdConic_det_factored`: Scalar triple product formula det(P(a),P(b),P(c)) = 4(a-b)(b-c)(c-a)
-3. `collinear_projTransform`: Collinearity is projectively invariant
-4. `threeVectorMatrix_projTransform`: Determinant of transformed vectors = det(M) · original
+/-!
+## Scaling and Coverage for Full Axiom Elimination
 
-**Remaining for full proof:**
-1. `pascalConstraint_projTransform` (above): needs adjugate composition identity
-2. **Sylvester's law**: Any non-degenerate symmetric conic matrix can be diagonalized by
-   congruence to ±diag(1,1,-1). For real projective conics, the signature determines the
-   conic type. Non-empty non-degenerate conics have signature (2,1), equivalent to stdConic.
-3. **stdConic parametric coverage**: Show every point on stdConic (with x₂ ≠ 0) is of the
-   form stdConicPoint(t) for some t. (The point at infinity (1,0,-1) is the limit t→∞.)
-4. **Assembly**: Combine Sylvester's law + parametric coverage + projective invariance +
-   `pascal_std_conic_parametrized` to prove `conic_implies_pascal_constraint`.
+### Building blocks for reducing `conic_implies_pascal_constraint` to standard results:
+
+1. **Cross product bilinearity**: `cross(c₁·u, c₂·v) = (c₁c₂) · cross(u,v)`
+2. **Determinant multilinearity**: `det(α·u, β·v, γ·w) = αβγ · det(u,v,w)`
+3. **Scaling lemma**: Pascal constraint preserved under scalar multiples
+4. **Exceptional point**: (-1,0,1) — the unique stdConic point not covered by stdConicPoint
+5. **Exceptional lemmas**: Pascal holds with (-1,0,1) at each hexagon position
+6. **Sylvester's law**: Any non-degenerate conic with a real point ≅ stdConic
+7. **Assembly**: Combine all pieces to derive the axiom
 -/
+
+/-- Cross product is bilinear with respect to scalar multiplication:
+    cross(c₁·u, c₂·v) = (c₁·c₂) · cross(u,v).
+    Proved componentwise via ring. -/
+theorem crossProduct_smul_smul (c₁ c₂ : ℝ) (u v : Fin 3 → ℝ) :
+    crossProduct (c₁ • u) (c₂ • v) = (c₁ * c₂) • crossProduct u v := by
+  ext i; fin_cases i <;>
+    simp only [crossProduct, Pi.smul_apply, smul_eq_mul, Fin.isValue] <;>
+    ring
+
+/-- Determinant of threeVectorMatrix is multilinear in scalar factors:
+    det(α·u, β·v, γ·w) = α·β·γ · det(u,v,w). -/
+theorem threeVectorMatrix_det_smul (α β γ : ℝ) (u v w : Fin 3 → ℝ) :
+    (threeVectorMatrix (α • u) (β • v) (γ • w)).det =
+    α * β * γ * (threeVectorMatrix u v w).det := by
+  simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply,
+    Pi.smul_apply, smul_eq_mul]
+  ring
+
+/-- The exceptional point on stdConic not covered by stdConicPoint parametrization.
+    This is the unique real point with x₀ + x₂ = 0. -/
+def exceptionalPoint : ProjPoint :=
+  fun i => match i with | 0 => -1 | 1 => 0 | 2 => 1
+
+/-- The exceptional point lies on stdConic. -/
+theorem exceptionalPoint_on_conic : pointOnConic exceptionalPoint stdConic := by
+  unfold pointOnConic conicQuadraticForm exceptionalPoint stdConic
+  simp only [Fin.sum_univ_three, Fin.isValue, Matrix.of_apply]
+  norm_num
+
+/-- Valid points on stdConic have x₂ ≠ 0.
+    Proof: if x₂ = 0 then x₀² + x₁² = 0, which over ℝ forces x₀ = x₁ = 0. -/
+theorem stdConic_x2_ne_zero (p : ProjPoint) (hp : pointOnConic p stdConic)
+    (hv : ProjPoint.valid p) : p 2 ≠ 0 := by
+  intro h2
+  apply hv
+  unfold pointOnConic conicQuadraticForm stdConic at hp
+  simp only [Fin.sum_univ_three, Fin.isValue, Matrix.of_apply] at hp
+  ext i; fin_cases i <;> nlinarith [sq_nonneg (p 0), sq_nonneg (p 1)]
+
+/-- Scaling all 6 points preserves the Pascal constraint.
+
+    The proof uses modular building blocks:
+    1. Cross product bilinearity simplifies inner and outer cross products
+    2. Determinant multilinearity factors out the scalar products
+    3. The original det = 0 by hypothesis -/
+theorem pascalConstraint_of_smul (c₁ c₂ c₃ c₄ c₅ c₆ : ℝ)
+    (A B C D E F : ProjPoint)
+    (h : pascalConstraint A B C D E F) :
+    pascalConstraint (c₁ • A) (c₂ • B) (c₃ • C) (c₄ • D) (c₅ • E) (c₆ • F) := by
+  unfold pascalConstraint lineIntersection lineThrough at h ⊢
+  simp only [crossProduct_smul_smul]
+  rw [threeVectorMatrix_det_smul, h, mul_zero]
+
+-- ============================================================
+-- PART 13b: Exceptional Point Lemmas
+-- ============================================================
+
+/-!
+### Pascal with the Exceptional Point
+
+The parametrization `stdConicPoint(t) = (1-t², 2t, 1+t²)` covers all real points on
+stdConic except `(-1, 0, 1)`. We prove Pascal holds with this exceptional point at
+each of the 6 hexagon positions, closing the gap left by `pascal_std_conic_parametrized`.
+
+Each proof substitutes the specific coordinates and lets `ring` verify the polynomial
+identity (degree ~10 in 5 variables, ~2000 terms).
+-/
+
+/-- **Pascal with exceptional point at position A.** -/
+theorem pascal_std_conic_exceptionalA (b c d e f : ℝ) :
+    pascalConstraint exceptionalPoint (stdConicPoint b) (stdConicPoint c)
+      (stdConicPoint d) (stdConicPoint e) (stdConicPoint f) := by
+  unfold pascalConstraint lineIntersection lineThrough exceptionalPoint stdConicPoint
+  simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, crossProduct]
+  ring
+
+/-- **Pascal with exceptional point at position B.** -/
+theorem pascal_std_conic_exceptionalB (a c d e f : ℝ) :
+    pascalConstraint (stdConicPoint a) exceptionalPoint (stdConicPoint c)
+      (stdConicPoint d) (stdConicPoint e) (stdConicPoint f) := by
+  unfold pascalConstraint lineIntersection lineThrough exceptionalPoint stdConicPoint
+  simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, crossProduct]
+  ring
+
+/-- **Pascal with exceptional point at position C.** -/
+theorem pascal_std_conic_exceptionalC (a b d e f : ℝ) :
+    pascalConstraint (stdConicPoint a) (stdConicPoint b) exceptionalPoint
+      (stdConicPoint d) (stdConicPoint e) (stdConicPoint f) := by
+  unfold pascalConstraint lineIntersection lineThrough exceptionalPoint stdConicPoint
+  simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, crossProduct]
+  ring
+
+/-- **Pascal with exceptional point at position D.** -/
+theorem pascal_std_conic_exceptionalD (a b c e f : ℝ) :
+    pascalConstraint (stdConicPoint a) (stdConicPoint b) (stdConicPoint c)
+      exceptionalPoint (stdConicPoint e) (stdConicPoint f) := by
+  unfold pascalConstraint lineIntersection lineThrough exceptionalPoint stdConicPoint
+  simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, crossProduct]
+  ring
+
+/-- **Pascal with exceptional point at position E.** -/
+theorem pascal_std_conic_exceptionalE (a b c d f : ℝ) :
+    pascalConstraint (stdConicPoint a) (stdConicPoint b) (stdConicPoint c)
+      (stdConicPoint d) exceptionalPoint (stdConicPoint f) := by
+  unfold pascalConstraint lineIntersection lineThrough exceptionalPoint stdConicPoint
+  simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, crossProduct]
+  ring
+
+/-- **Pascal with exceptional point at position F.** -/
+theorem pascal_std_conic_exceptionalF (a b c d e : ℝ) :
+    pascalConstraint (stdConicPoint a) (stdConicPoint b) (stdConicPoint c)
+      (stdConicPoint d) (stdConicPoint e) exceptionalPoint := by
+  unfold pascalConstraint lineIntersection lineThrough exceptionalPoint stdConicPoint
+  simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, crossProduct]
+  ring
+
+-- ============================================================
+-- PART 13c: Multi-Exceptional and Coverage
+-- ============================================================
+
+/-!
+### Multi-Exceptional Cases
+
+When two or more hexagon vertices are the exceptional point (-1,0,1):
+- **Adjacent pair** (e.g., A=B=exc): cross(A,B) = 0 → P = 0 → det has zero row → det = 0
+- **Non-adjacent pair** (e.g., A=C=exc): requires direct computation
+- **Three alternating** (A=C=E=exc): requires direct computation
+
+We prove the non-adjacent cases via ring and handle adjacent cases via a general lemma.
+-/
+
+/-- If two adjacent hexagon vertices are proportional, the Pascal determinant is zero.
+    When A and B are proportional, cross(A,B) = 0, making P = 0, giving a zero row. -/
+theorem pascalConstraint_of_proportional_AB (c : ℝ) (A C D E F : ProjPoint) :
+    pascalConstraint A (c • A) C D E F := by
+  unfold pascalConstraint lineIntersection lineThrough
+  simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, crossProduct,
+    Pi.smul_apply, smul_eq_mul]
+  ring
+
+/-- Pascal with exceptional points at non-adjacent positions A and C. -/
+theorem pascal_std_conic_exceptionalAC (b d e f : ℝ) :
+    pascalConstraint exceptionalPoint (stdConicPoint b) exceptionalPoint
+      (stdConicPoint d) (stdConicPoint e) (stdConicPoint f) := by
+  unfold pascalConstraint lineIntersection lineThrough exceptionalPoint stdConicPoint
+  simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, crossProduct]
+  ring
+
+/-- Pascal with exceptional points at non-adjacent positions A and D (opposite vertices). -/
+theorem pascal_std_conic_exceptionalAD (b c e f : ℝ) :
+    pascalConstraint exceptionalPoint (stdConicPoint b) (stdConicPoint c)
+      exceptionalPoint (stdConicPoint e) (stdConicPoint f) := by
+  unfold pascalConstraint lineIntersection lineThrough exceptionalPoint stdConicPoint
+  simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, crossProduct]
+  ring
+
+/-- Pascal with exceptional points at three alternating positions A, C, E. -/
+theorem pascal_std_conic_exceptionalACE (b d f : ℝ) :
+    pascalConstraint exceptionalPoint (stdConicPoint b) exceptionalPoint
+      (stdConicPoint d) exceptionalPoint (stdConicPoint f) := by
+  unfold pascalConstraint lineIntersection lineThrough exceptionalPoint stdConicPoint
+  simp only [threeVectorMatrix, Matrix.det_fin_three, Matrix.of_apply, crossProduct]
+  ring
+
+/-- **Pascal's theorem for ALL real points on stdConic.**
+
+    Every valid point on x₀²+x₁²=x₂² is either:
+    - A scalar multiple of stdConicPoint(t) for some t (when x₀+x₂ ≠ 0)
+    - A scalar multiple of exceptionalPoint = (-1,0,1) (when x₀+x₂ = 0)
+
+    Proof combines the parametrized result, 6 single-exceptional lemmas,
+    multi-exceptional lemmas, adjacent-proportional lemma, and the scaling lemma.
+
+    TODO: Complete the 2⁶ case analysis or use algebraic argument. -/
+theorem pascal_stdConic_all_points
+    (A B C D E F : ProjPoint)
+    (hA : pointOnConic A stdConic) (hB : pointOnConic B stdConic)
+    (hC : pointOnConic C stdConic) (hD : pointOnConic D stdConic)
+    (hE : pointOnConic E stdConic) (hF : pointOnConic F stdConic)
+    (hAv : ProjPoint.valid A) (hBv : ProjPoint.valid B)
+    (hCv : ProjPoint.valid C) (hDv : ProjPoint.valid D)
+    (hEv : ProjPoint.valid E) (hFv : ProjPoint.valid F) :
+    pascalConstraint A B C D E F := by sorry
+
+-- ============================================================
+-- PART 14: Sylvester's Law (Conic Equivalence)
+-- ============================================================
+
+/-!
+## Sylvester's Law of Inertia for Conics
+
+A non-degenerate real symmetric 3×3 matrix with an isotropic vector (a real point on
+the conic) has signature (2,1). By Sylvester's law, it is congruent to diag(1,1,-1).
+
+This means: for any non-degenerate conic C with a real point, there exists an
+invertible M such that Mᵀ · C · M = stdConic. Equivalently, every real point on C
+maps (via M⁻¹) to a real point on stdConic, preserving the Pascal constraint.
+-/
+
+/-- **Sylvester's law for conics:** Any non-degenerate symmetric conic with a real point
+    is congruent to the standard conic diag(1,1,-1).
+
+    This is a well-known result from the theory of quadratic forms over ℝ.
+    The proof requires showing that a non-degenerate quadratic form of rank 3 with an
+    isotropic vector has signature (2,1), and then diagonalizing by congruence.
+
+    TODO: Prove from Mathlib's `QuadraticForm` or `BilinForm` theory. -/
+theorem sylvester_conic_equivalence (C : Conic) (hC : C.nondegenerate) (hCS : C.symmetric)
+    (hpoint : ∃ p : ProjPoint, ProjPoint.valid p ∧ pointOnConic p C) :
+    ∃ M : Matrix (Fin 3) (Fin 3) ℝ, M.det ≠ 0 ∧
+    ∀ p : ProjPoint, pointOnConic p C ↔
+      pointOnConic (projTransform M p) stdConic := by sorry
+
+-- ============================================================
+-- PART 15: Assembly (Proof of the Main Axiom)
+-- ============================================================
+
+/-!
+## Assembly
+
+Given all the building blocks:
+1. `pascal_stdConic_all_points`: Pascal for all real points on stdConic
+2. `pascalConstraint_projTransform`: Pascal constraint is projectively invariant
+3. `sylvester_conic_equivalence`: Any non-degenerate conic ≅ stdConic
+
+We can derive `conic_implies_pascal_constraint` (modulo the sorries in Sylvester and
+coverage). This reduces the axiom to two clearly identified, well-known results.
+
+### Sorry inventory (toward full axiom elimination):
+- `pascal_stdConic_all_points`: case analysis assembling parametric + exceptional lemmas
+- `sylvester_conic_equivalence`: Sylvester's law of inertia for quadratic forms
+- `conic_implies_pascal_constraint_proof`: needs validity of transformed points
+-/
+
+/-- **Main theorem (assembly):** Six points on any non-degenerate conic satisfy Pascal's constraint.
+
+    Proof sketch:
+    1. By Sylvester, ∃ M with M mapping C to stdConic
+    2. The 6 image points are on stdConic
+    3. By `pascal_stdConic_all_points`, Pascal holds for the images
+    4. By `pascalConstraint_projTransform`, Pascal holds for the originals -/
+theorem conic_implies_pascal_constraint_proof
+    (C : Conic) (hC : C.nondegenerate) (hCS : C.symmetric)
+    (hex : InscribedHexagon C) :
+    pascalConstraint hex.A hex.B hex.C' hex.D hex.E hex.F := by
+  -- Get the equivalence to stdConic
+  obtain ⟨M, hMdet, hMequiv⟩ := sylvester_conic_equivalence C hC hCS
+    ⟨hex.A, hex.hAvalid, hex.hA⟩
+  -- Apply projective invariance: Pascal for M-images ↔ Pascal for originals
+  rw [← pascalConstraint_projTransform M hMdet]
+  -- Need Pascal for points on stdConic; transform the on-conic hypotheses
+  exact pascal_stdConic_all_points _ _ _ _ _ _
+    ((hMequiv hex.A).mp hex.hA) ((hMequiv hex.B).mp hex.hB)
+    ((hMequiv hex.C').mp hex.hC) ((hMequiv hex.D).mp hex.hD)
+    ((hMequiv hex.E).mp hex.hE) ((hMequiv hex.F).mp hex.hF)
+    sorry sorry sorry sorry sorry sorry  -- validity of transformed points
+
 -- ============================================================
 -- Export main results
 -- ============================================================
@@ -527,3 +783,9 @@ theorem pascalConstraint_projTransform (M : Matrix (Fin 3) (Fin 3) ℝ) (hM : M.
 #check @crossProduct_projTransform
 #check @stdConic_det_factored
 #check @pascalConstraint_projTransform
+#check @crossProduct_smul_smul
+#check @threeVectorMatrix_det_smul
+#check @pascalConstraint_of_smul
+#check @pascal_stdConic_all_points
+#check @sylvester_conic_equivalence
+#check @conic_implies_pascal_constraint_proof

--- a/proofs/Proofs/Stubs/Erdos43Problem.lean
+++ b/proofs/Proofs/Stubs/Erdos43Problem.lean
@@ -84,11 +84,37 @@ axiom barreto_counterexample : ¬EqualSizeVariant
 theorem sidon_pair_bound (A : Finset ℤ) (N : ℕ)
     (hS : IsSidonSet A) (hR : ∀ a ∈ A, 1 ≤ a ∧ a ≤ N) :
   A.card.choose 2 ≤ N := by
-  -- Proof: The nonzero differences of a Sidon set A ⊆ {1,...,N} all lie in
-  -- {-(N-1),...,-1,1,...,N-1}. There are |A|(|A|-1) distinct nonzero differences
-  -- (by the Sidon property), so |A|(|A|-1) ≤ 2(N-1) ≤ 2N. Hence C(|A|,2) ≤ N.
-  -- Key subgoal: the difference map (a,b) ↦ a-b is injective on off-diagonal pairs.
-  sorry
+  -- C(n,2) = n*(n-1)/2, so it suffices to show n*(n-1) ≤ 2*N
+  rw [Nat.choose_two_right]
+  suffices h : A.card * (A.card - 1) ≤ 2 * N by omega
+  -- n*(n-1) = |A.offDiag| (off-diagonal pairs)
+  rw [← Finset.card_offDiag]
+  -- The difference map (a,b) ↦ a-b is injective on A.offDiag (by Sidon)
+  -- and maps into Finset.Icc (1-N) (N-1) which has ≤ 2N elements
+  set f : ℤ × ℤ → ℤ := fun p => p.1 - p.2
+  set T := Finset.Icc (1 - (N : ℤ)) ((N : ℤ) - 1)
+  -- Injectivity on offDiag
+  have hinj : Set.InjOn f ↑A.offDiag := by
+    intro ⟨a₁, b₁⟩ h₁ ⟨a₂, b₂⟩ h₂ heq
+    simp only [Finset.mem_coe, Finset.mem_offDiag] at h₁ h₂
+    have := sidon_diff_injective A hS h₁.1 h₁.2.1 h₂.1 h₂.2.1 h₁.2.2 heq
+    exact Prod.ext this.1 this.2
+  -- Image maps into T
+  have hfT : A.offDiag.image f ⊆ T := by
+    intro d hd
+    obtain ⟨⟨a, b⟩, hp, rfl⟩ := Finset.mem_image.mp hd
+    simp only [Finset.mem_offDiag] at hp
+    have ⟨ha1, haN⟩ := hR a hp.1
+    have ⟨hb1, hbN⟩ := hR b hp.2.1
+    simp only [T, f, Finset.mem_Icc]
+    constructor <;> omega
+  -- Card inequality: |offDiag| = |image| ≤ |T| ≤ 2N
+  calc A.offDiag.card
+      = (A.offDiag.image f).card := (Finset.card_image_of_injOn hinj).symm
+    _ ≤ T.card := Finset.card_le_card hfT
+    _ ≤ 2 * N := by
+        simp only [T, Finset.card_Icc, Int.toNat_le]
+        omega
 
 /-- Disjoint differences force the nonzero differences of A and B
     to be completely disjoint, so the total number of distinct nonzero
@@ -99,10 +125,67 @@ theorem disjoint_diff_combined_bound (A B : Finset ℤ) (N : ℕ)
     (hRA : ∀ a ∈ A, 1 ≤ a ∧ a ≤ N) (hRB : ∀ b ∈ B, 1 ≤ b ∧ b ≤ N)
     (hD : DisjointDifferences A B) :
   A.card.choose 2 + B.card.choose 2 ≤ N := by
-  -- Proof: Disjoint nonzero differences of A and B together give
-  -- |A|(|A|-1) + |B|(|B|-1) distinct nonzero integers in {-(N-1),...,N-1}.
-  -- So |A|(|A|-1) + |B|(|B|-1) ≤ 2(N-1), giving C(|A|,2) + C(|B|,2) ≤ N-1 ≤ N.
-  sorry
+  -- Reduce to: |A|*(|A|-1) + |B|*(|B|-1) ≤ 2*N
+  simp only [Nat.choose_two_right]
+  suffices h : A.card * (A.card - 1) + B.card * (B.card - 1) ≤ 2 * N by omega
+  rw [← Finset.card_offDiag, ← Finset.card_offDiag]
+  set f : ℤ × ℤ → ℤ := fun p => p.1 - p.2
+  set T := Finset.Icc (1 - (N : ℤ)) ((N : ℤ) - 1)
+  -- Images of A.offDiag and B.offDiag under f are disjoint
+  have hdisj : Disjoint (A.offDiag.image f) (B.offDiag.image f) := by
+    rw [Finset.disjoint_left]
+    intro d hda hdb
+    -- d ∈ diffSet A and d ∈ diffSet B
+    obtain ⟨⟨a₁, b₁⟩, hp₁, rfl⟩ := Finset.mem_image.mp hda
+    obtain ⟨⟨a₂, b₂⟩, hp₂, heq⟩ := Finset.mem_image.mp hdb
+    simp only [Finset.mem_offDiag] at hp₁ hp₂
+    -- a₁ - b₁ ∈ diffSet A
+    have hfA : f (a₁, b₁) ∈ diffSet A := by
+      simp only [diffSet, Finset.mem_image]
+      exact ⟨(a₁, b₁), Finset.mem_product.mpr ⟨hp₁.1, hp₁.2.1⟩, rfl⟩
+    -- a₂ - b₂ ∈ diffSet B (and equals a₁ - b₁)
+    have hfB : f (a₁, b₁) ∈ diffSet B := by
+      rw [show f (a₁, b₁) = f (a₂, b₂) from heq]
+      simp only [diffSet, Finset.mem_image]
+      exact ⟨(a₂, b₂), Finset.mem_product.mpr ⟨hp₂.1, hp₂.2.1⟩, rfl⟩
+    -- By DisjointDifferences, a₁ - b₁ = 0, contradicting a₁ ≠ b₁
+    have h0 := hD _ hfA hfB
+    simp only [f] at h0
+    exact absurd (sub_eq_zero.mp h0) hp₁.2.2
+  -- Both injective on their offDiags
+  have hinjA : Set.InjOn f ↑A.offDiag := by
+    intro ⟨a₁, b₁⟩ h₁ ⟨a₂, b₂⟩ h₂ heq
+    simp only [Finset.mem_coe, Finset.mem_offDiag] at h₁ h₂
+    exact Prod.ext (sidon_diff_injective A hA h₁.1 h₁.2.1 h₂.1 h₂.2.1 h₁.2.2 heq).1
+      (sidon_diff_injective A hA h₁.1 h₁.2.1 h₂.1 h₂.2.1 h₁.2.2 heq).2
+  have hinjB : Set.InjOn f ↑B.offDiag := by
+    intro ⟨a₁, b₁⟩ h₁ ⟨a₂, b₂⟩ h₂ heq
+    simp only [Finset.mem_coe, Finset.mem_offDiag] at h₁ h₂
+    exact Prod.ext (sidon_diff_injective B hB h₁.1 h₁.2.1 h₂.1 h₂.2.1 h₁.2.2 heq).1
+      (sidon_diff_injective B hB h₁.1 h₁.2.1 h₂.1 h₂.2.1 h₁.2.2 heq).2
+  -- Both images ⊆ T
+  have hAT : A.offDiag.image f ⊆ T := by
+    intro d hd; obtain ⟨⟨a, b⟩, hp, rfl⟩ := Finset.mem_image.mp hd
+    simp only [Finset.mem_offDiag] at hp
+    have ⟨ha1, haN⟩ := hRA a hp.1
+    have ⟨hb1, hbN⟩ := hRA b hp.2.1
+    simp only [T, f, Finset.mem_Icc]
+    constructor <;> omega
+  have hBT : B.offDiag.image f ⊆ T := by
+    intro d hd; obtain ⟨⟨a, b⟩, hp, rfl⟩ := Finset.mem_image.mp hd
+    simp only [Finset.mem_offDiag] at hp
+    have ⟨ha1, haN⟩ := hRB a hp.1
+    have ⟨hb1, hbN⟩ := hRB b hp.2.1
+    simp only [T, f, Finset.mem_Icc]
+    constructor <;> omega
+  -- Combined: |offDiag A| + |offDiag B| = |image A ∪ image B| ≤ |T| ≤ 2N
+  calc A.offDiag.card + B.offDiag.card
+      = (A.offDiag.image f).card + (B.offDiag.image f).card := by
+          rw [Finset.card_image_of_injOn hinjA, Finset.card_image_of_injOn hinjB]
+    _ = (A.offDiag.image f ∪ B.offDiag.image f).card :=
+          (Finset.card_union_of_disjoint hdisj).symm
+    _ ≤ T.card := Finset.card_le_card (Finset.union_subset hAT hBT)
+    _ ≤ 2 * N := by simp only [T, Finset.card_Icc, Int.toNat_le]; omega
 
 /- ## Tao's Partial Result
 
@@ -122,11 +205,20 @@ theorem tao_equal_size_bound (A B : Finset ℤ) (N : ℕ)
     (hRA : ∀ a ∈ A, 1 ≤ a ∧ a ≤ N) (hRB : ∀ b ∈ B, 1 ≤ b ∧ b ≤ N)
     (hD : DisjointDifferences A B) (hEq : A.card = B.card) :
   (A.card : ℝ) ^ 2 ≤ 2 * N + 1 := by
-  -- Proof from disjoint_diff_combined_bound: 2·C(m,2) ≤ N where m = A.card
-  -- → m*(m-1) ≤ N (via Nat.choose_two_right)
-  -- → m ≤ N+1 (case split: m ≥ 2 gives m ≤ m*(m-1) ≤ N)
-  -- → m² = m*(m-1)+m ≤ N+(N+1) = 2N+1 (in ℝ via nlinarith)
-  sorry
+  -- From disjoint_diff_combined_bound: C(m,2) + C(m,2) ≤ N
+  have hcomb := disjoint_diff_combined_bound A B N hA hB hRA hRB hD
+  rw [hEq] at hcomb
+  -- So 2 * C(m,2) ≤ N, i.e., m*(m-1) ≤ N
+  set m := A.card with hm_def
+  have hm_bound : m * (m - 1) ≤ N := by
+    rw [Nat.choose_two_right] at hcomb; omega
+  -- m ≤ N + 1 (from m*(m-1) ≤ N)
+  have hm_le : m ≤ N + 1 := by nlinarith [Nat.zero_le m]
+  -- m² ≤ 2N+1 in ℕ, then cast to ℝ
+  have hm_sq_nat : m * m ≤ 2 * N + 1 := by nlinarith
+  calc (m : ℝ) ^ 2 = ↑(m * m) := by push_cast; ring
+    _ ≤ ↑(2 * N + 1) := Nat.cast_le.mpr hm_sq_nat
+    _ = 2 * ↑N + 1 := by push_cast; ring
 
 /- ## Counting Arguments -/
 

--- a/src/data/proofs/erdos-1014-oq-02/meta.json
+++ b/src/data/proofs/erdos-1014-oq-02/meta.json
@@ -2,11 +2,11 @@
     "id": "erdos-1014-oq-02",
     "title": "Erdős #1014 OQ-02: Rate of Convergence is O(log l / l)",
     "slug": "erdos-1014-oq-02",
-    "description": "Answers the open question: what is the rate of convergence of R(k,l+1)/R(k,l) to 1? For k=3, the rate is O(log l / l), which is strictly faster than O(1/log l). The proof combines the Ramsey recurrence bound R(3,l+1) - R(3,l) ≤ l+1 with the Kim lower bound R(3,l) ≥ c·l²/log l. Also proves that log l/l < 1/log l for large l, confirming the rate is faster than the conjectured O(1/log l). For general k with conjectured asymptotics, the rate would be O(1/l).",
+    "description": "Answers the open question: what is the rate of convergence of R(k,l+1)/R(k,l) to 1? For k=3, the rate is O(log l / l), which is strictly faster than O(1/log l). The proof combines the Ramsey recurrence bound R(3,l+1) - R(3,l) ≤ l+1 with the Kim lower bound R(3,l) ≥ c·l²/log l. Also proves that log l/l < 1/log l for large l. For general k, the ratio converges to 1 under conjectured asymptotics (proved via ratio_from_asymptotics).",
     "meta": {
         "author": "Erdős",
         "erdosNumber": 1014,
-        "status": "formalized",
+        "status": "axiomatized",
         "proofRepoPath": "Proofs/Erdos1014OQ02.lean",
         "tags": [
             "erdos",
@@ -17,22 +17,25 @@
             "research"
         ],
         "badge": "axiom",
-        "sorries": 2,
+        "sorries": 0,
         "sourceUrl": "https://erdosproblems.com/1014",
         "erdosUrl": "https://erdosproblems.com/1014",
         "erdosProblemStatus": "open",
         "dateAdded": "2026-03-28",
         "axiomCount": 0,
-        "lineCount": 233,
-        "assumptions": "6 axioms: ramseyNumber (definition), ramsey_monotone_right, ramsey_recurrence, ramsey_k2, ramsey_symm, R3_lower_bound. 2 sorries in conditional general-k rate theorem (growth ratio bound and 3-factor combination).",
+        "lineCount": 186,
+        "assumptions": "Inherits axioms from Erdos1014Problem.lean: ramseyNumber (definition), ramsey_monotone_right, ramsey_recurrence, ramsey_k2, ramsey_symm, R3_lower. All theorems fully proved (0 sorries).",
         "mathlib_version": "4.26.0",
         "leanFiles": [
             {
-                "sorryCount": 2
+                "sorryCount": 0
             }
         ],
         "originalContributions": [
-            "Audit: 2 actual sorries in conditional_rate_general_k (Bernoulli bound + ratio decomposition). Main results sorry-free."
+            "Proved rate_of_convergence_k3: |R(3,l+1)/R(3,l) - 1| ≤ C·log l/l from recurrence + Kim lower bound",
+            "Proved log_over_l_faster_than_inv_log: (log l)² < l from Mathlib's little-o",
+            "Fixed conditional_rate_general_k: removed incorrect O(1/l) claim (only o(1) follows from the hypothesis), delegated to ratio_from_asymptotics",
+            "Eliminated 2 sorries: file now fully proved (0 sorries)"
         ]
     },
     "crossReferences": [
@@ -82,17 +85,17 @@
         },
         {
             "id": "general-k",
-            "title": "Conditional Rate for General k",
-            "startLine": 205,
-            "endLine": 285,
-            "summary": "Under the conjectured asymptotics $R(k,l) \\sim c \\cdot l^{k-1}/(\\log l)^{k-2}$, the rate is $O(1/l)$, even faster. Contains 2 sorries for technical Bernoulli-type bounds.",
-            "mathContext": "The growth ratio $((l+1)/l)^{k-1} \\cdot (\\log l/\\log(l+1))^{k-2}$ differs from 1 by $O(1/l)$, combined with the 3-factor sandwich decomposition."
+            "title": "Conditional Convergence for General k",
+            "startLine": 143,
+            "endLine": 162,
+            "summary": "Under the conjectured asymptotics $R(k,l) \\sim c \\cdot l^{k-1}/(\\log l)^{k-2}$, the ratio $R(k,l+1)/R(k,l) \\to 1$, proved by delegating to `ratio_from_asymptotics` from the main file. Note: the O(1/l) rate does not follow from the given hypothesis — the overall rate depends on how fast $R(k,l)/g(l) \\to 1$, which is unspecified.",
+            "mathContext": "The growth ratio $((l+1)/l)^{k-1} \\cdot (\\log l/\\log(l+1))^{k-2}$ converges to 1 at rate $O(k/l)$, but the asymptotic error contributes an unquantified $o(1)$ term."
         },
         {
             "id": "answer",
             "title": "Summary Corollary",
-            "startLine": 290,
-            "endLine": 320,
+            "startLine": 164,
+            "endLine": 186,
             "summary": "Combines rate_of_convergence_k3 and log_over_l_faster_than_inv_log into a single statement answering OQ-02.",
             "mathContext": "The rate is $O(\\log l / l)$ for $k=3$, strictly faster than $O(1/\\log l)$."
         }
@@ -100,13 +103,13 @@
     "overview": {
         "historicalContext": "Erdős Problem #1014 asks whether R(k,l+1)/R(k,l) → 1 as l → ∞. OQ-01 proved this for k=3. This follow-up quantifies the convergence rate, answering: how fast does the ratio approach 1?",
         "problemStatement": "What is the rate of convergence of R(k,l+1)/R(k,l) to 1? Is it O(1/log l)?",
-        "text": "For k=3, the rate of convergence is O(log l / l), which is strictly faster than O(1/log l). Under conjectured asymptotics for general k, the rate would be O(1/l).",
+        "text": "For k=3, the rate of convergence is O(log l / l), which is strictly faster than O(1/log l). Under conjectured asymptotics for general k, the ratio converges to 1 (the rate depends on the speed of asymptotic convergence).",
         "proofStrategy": "Combine the Ramsey recurrence (giving linear increment bounds) with the Kim lower bound (giving quadratic-over-log growth) to obtain explicit rate bounds. Then prove log l / l < 1/log l for large l using Mathlib's little-o results.",
         "keyInsights": [
             "The rate O(log l / l) for k=3 is FASTER than the conjectured O(1/log l), answering the open question in the affirmative direction",
             "The Ramsey recurrence is the key: it constrains increments to be linear while values grow super-linearly",
             "The constant C = 2/c in the rate bound is explicit, where c is from Kim's R(3,l) ≥ c·l²/log l",
-            "For general k with power-law asymptotics, the rate would be O(1/l), coming from ((l+1)/l)^(k-1) = 1 + O(1/l)"
+            "For general k with power-law asymptotics, the ratio R(k,l+1)/R(k,l) → 1 (the growth ratio contributes O(k/l), but the overall rate depends on the speed of asymptotic convergence)"
         ],
         "prerequisites": [
             "Ramsey theory",
@@ -115,7 +118,7 @@
         ]
     },
     "conclusion": {
-        "summary": "The rate of convergence of R(3,l+1)/R(3,l) to 1 is O(log l / l), strictly faster than O(1/log l). This is proved from the Ramsey recurrence and Kim lower bound. For general k with conjectured asymptotics, the rate would be O(1/l).",
+        "summary": "The rate of convergence of R(3,l+1)/R(3,l) to 1 is O(log l / l), strictly faster than O(1/log l). This is proved from the Ramsey recurrence and Kim lower bound. For general k, the ratio converges to 1 under conjectured asymptotics.",
         "implications": "The fast convergence rate suggests that Ramsey numbers grow very smoothly for k=3, with consecutive values differing by a negligible fraction of their magnitude.",
         "openQuestions": [
             "Can the constant C = 2/c be improved, perhaps to 1/c?",
@@ -133,7 +136,7 @@
             "Topology"
         ],
         "namespace": "Erdos1014OQ02",
-        "lineCount": 233,
+        "lineCount": 186,
         "axiomCount": 6,
         "theoremCount": 4,
         "definitionCount": 0,
@@ -152,10 +155,10 @@
                 "leanType": "∃ L₀, ∀ l > L₀, log l / l < 1 / log l"
             },
             {
-                "name": "conditional_rate_general_k",
+                "name": "conditional_convergence_general_k",
                 "type": "key",
-                "description": "Under power-law asymptotics, the rate for general k is O(1/l) [2 sorries]",
-                "leanType": "(asymptotic hyp) → ∃ C > 0, ∃ L₀, ∀ l > L₀, |R(k,l+1)/R(k,l) - 1| ≤ C/l"
+                "description": "Under power-law asymptotics, R(k,l+1)/R(k,l) → 1 (proved via ratio_from_asymptotics)",
+                "leanType": "(asymptotic hyp) → ∀ ε > 0, ∃ L₀, ∀ l > L₀, |R(k,l+1)/R(k,l) - 1| < ε"
             },
             {
                 "name": "rate_is_O_log_over_l_not_inv_log",

--- a/src/data/proofs/erdos-456/meta.json
+++ b/src/data/proofs/erdos-456/meta.json
@@ -24,7 +24,7 @@
     "erdosUrl": "https://erdosproblems.com/456",
     "erdosProblemStatus": "open",
     "dateAdded": "2025-01-15",
-    "dateUpdated": "2026-03-28",
+    "dateUpdated": "2026-03-30",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
       {
@@ -65,7 +65,7 @@
       "Formalized all three conjectures as ErdosProblem456_Part1/2/3",
       "Created Aristotle companion for van_doorn_power_of_two and density_implies_witness",
       "Proved almostAll_infinitely_often: density-0 exceptions → infinitely many witnesses (pigeonhole)",
-      "Eliminated erdos_strict_inequality axiom (4→3): part1_implies_infinitely_many now proved from AlmostAll hypothesis"
+      "Eliminated erdos_strict_inequality axiom (3→2): part1_implies_infinitely_many now proved from AlmostAll hypothesis via almostAll_infinitely_often pigeonhole lemma"
     ],
     "mathContext": {
       "field": "Number Theory",
@@ -130,53 +130,53 @@
   },
   "sections": [
     {
-      "id": "imports",
-      "title": "Imports and Namespace",
-      "startLine": 28,
-      "endLine": 34,
-      "summary": "Imports `Nat.Prime.Basic` for the `Nat.Prime` predicate and `Nat.Totient` for Euler's totient function $\\varphi$. Opens `Nat` namespace for convenience."
-    },
-    {
-      "id": "core-functions",
+      "id": "definitions",
       "title": "Core Definitions",
-      "startLine": 35,
-      "endLine": 49,
+      "startLine": 49,
+      "endLine": 61,
       "summary": "Defines `smallestPrimeMod1 n` $= \\inf\\{p : p$ prime, $n \\mid p - 1\\}$ and `smallestTotientDiv n` $= \\inf\\{m > 0 : n \\mid \\varphi(m)\\}$ via `sInf`. Both are noncomputable (depend on Dirichlet's theorem for well-definedness)."
     },
     {
-      "id": "pn-properties",
-      "title": "Properties of $p_n$",
-      "startLine": 50,
-      "endLine": 70,
-      "summary": "Axiomatizes Dirichlet's theorem (infinitely many primes $\\equiv 1 \\pmod{n}$) and three properties of $p_n$: `smallestPrimeMod1_prime` ($p_n$ is prime), `smallestPrimeMod1_cong` ($n \\mid p_n - 1$), `smallestPrimeMod1_minimal` ($p_n \\le p$ for any prime $p \\equiv 1$)."
+      "id": "deep-axioms",
+      "title": "Deep Axioms (2 remaining)",
+      "startLine": 63,
+      "endLine": 88,
+      "summary": "Two deep axioms that cannot be proved from Mathlib: `linnik_bound` ($p_n \\le n^L$ for some constant $L$, Linnik 1944) and `m_over_n_diverges` ($m_n/n \\to \\infty$ for almost all $n$, Erdős 1979). Dirichlet's theorem `dirichlet_primes_mod1` is now a proved theorem using Mathlib's `Nat.forall_exists_prime_gt_and_modEq` from `PrimesInAP`."
     },
     {
-      "id": "mn-properties",
-      "title": "Properties of $m_n$",
-      "startLine": 71,
-      "endLine": 87,
-      "summary": "Axiomatizes three properties of $m_n$: `smallestTotientDiv_pos` ($m_n > 0$), `smallestTotientDiv_divides` ($n \\mid \\varphi(m_n)$), `smallestTotientDiv_minimal` ($m_n \\le m$ for any $m > 0$ with $n \\mid \\varphi(m)$)."
+      "id": "proved-properties",
+      "title": "Proved Properties (9 formerly axioms)",
+      "startLine": 90,
+      "endLine": 160,
+      "summary": "Nine properties formerly stated as axioms, now all proved from `sInf` well-ordering and Dirichlet's theorem: `primes_mod1_nonempty`, `totient_div_set_nonempty`, `smallestPrimeMod1_{prime,cong,minimal}` ($p_n$ is prime, $n \\mid p_n - 1$, minimality), `smallestTotientDiv_{pos,divides,minimal}` ($m_n > 0$, $n \\mid \\varphi(m_n)$, minimality), and `m_le_p` ($m_n \\le p_n$)."
     },
     {
-      "id": "known-results",
-      "title": "Known Results",
-      "startLine": 88,
-      "endLine": 119,
-      "summary": "States four known results: `m_le_p` ($m_n \\le p_n$, trivial), `linnik_bound` ($p_n \\le n^L$), `m_over_n_diverges` ($m_n/n \\to \\infty$ a.a.), `van_doorn_power_of_two` ($m_n \\le 2n$ for $n = 2^{2k+1}$). The former `erdos_strict_inequality` axiom was eliminated by proving `almostAll_infinitely_often`."
+      "id": "van-doorn",
+      "title": "Van Doorn's Result",
+      "startLine": 162,
+      "endLine": 183,
+      "summary": "Proves `van_doorn_power_of_two`: for $n = 2^{2k+1}$, $m_n \\le 2n$. Uses $\\varphi(2^{2k+2}) = 2^{2k+1} = n$ via `Nat.totient_prime_pow_succ` and minimality of $m_n$."
     },
     {
       "id": "density",
       "title": "Natural Density",
-      "startLine": 120,
-      "endLine": 129,
-      "summary": "Defines `AlmostAll P`: $\\forall \\varepsilon > 0,\\, \\exists N,\\, \\forall M \\ge N,\\, |\\{n < M : \\neg P(n)\\}| < M$. This encodes 'the exceptional set has density $0$' in the natural density sense."
+      "startLine": 185,
+      "endLine": 211,
+      "summary": "Defines `AlmostAll P`: $\\forall \\varepsilon > 0,\\, \\exists N,\\, \\forall M \\ge N,\\, |\\{n < M : \\neg P(n)\\}| < \\varepsilon M$. Proves `almostAll_mono`: if $P \\Rightarrow Q$ pointwise, then `AlmostAll P` $\\Rightarrow$ `AlmostAll Q`."
     },
     {
       "id": "conjectures",
       "title": "The Three Erdős Conjectures",
-      "startLine": 130,
-      "endLine": 168,
-      "summary": "Defines `ErdosProblem456_Part1`: $m_n < p_n$ for a.a. $n$. `Part2`: $p_n/m_n \\to \\infty$ for a.a. $n$ (formalized as $\\forall C,\\, C \\cdot m_n \\le p_n$ a.a.). `Part3`: infinitely many 'rigid' primes $p$ with unique preimage $n = p - 1$. Proves `part2_implies_part1` and `part1_implies_infinitely_many` (via `almostAll_infinitely_often` pigeonhole lemma)."
+      "startLine": 213,
+      "endLine": 248,
+      "summary": "Defines `ErdosProblem456_Part1` ($m_n < p_n$ a.a.), `Part2` ($p_n/m_n \\to \\infty$ a.a.), `Part3` (infinitely many rigid primes). Proves `part2_implies_part1` (specialize at $C=2$, use $m_n \\ge 1$) and `part1_implies_infinitely_many` (via `almostAll_infinitely_often` pigeonhole lemma, no axiom dependency)."
+    },
+    {
+      "id": "pigeonhole",
+      "title": "Density Implies Infinitely Many",
+      "startLine": 249,
+      "endLine": 288,
+      "summary": "Proves `almostAll_infinitely_often`: if $P$ holds for almost all $n$, then for every $N$ there exists $n \\ge N$ with $P(n)$. Proof by contradiction via pigeonhole: take $\\varepsilon = 1/2$, $M = \\max(N_0, 2N+1)$; if no witness in $[N, M)$, exceptions $\\ge M - N > M/2$, contradicting the density bound."
     }
   ],
   "conclusion": {

--- a/src/data/research/problems/erdos-1014.json
+++ b/src/data/research/problems/erdos-1014.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: Assessed and marked complete.",
+    "progressSummary": "PROGRESS: Eliminated 2 sorries in OQ02 (corrected incorrect O(1/l) rate claim). Main file: 12 axioms, 0 sorries.",
     "builtItems": [
       "Proved diagonal_ramsey_upper from ramsey_upper_erdos_szekeres (4 lines)",
       "Proved ratio_equiv_difference from monotonicity + positivity + real analysis (35 lines)",
@@ -44,7 +44,8 @@
       "increment_bound_general: R(k,l+1) ≤ R(k,l) + R(k-1,l+1)",
       "Fixed R3_lower axiom from ∀c to ∃c (consistency fix)",
       "ramsey_pos proved as theorem from ramsey_k2 + ramsey_monotone_left iterated (eliminates 1 axiom)",
-      "ramsey_mono_left_ge2: R(2,l) ≤ R(k,l) for k ≥ 2 via induction on k"
+      "ramsey_mono_left_ge2: R(2,l) ≤ R(k,l) for k ≥ 2 via induction on k",
+      "Eliminated 2 sorries in Erdos1014OQ02.lean by replacing conditional_rate_general_k (incorrect O(1/l) claim) with conditional_convergence_general_k (correct o(1) via ratio_from_asymptotics)"
     ],
     "insights": [
       "2 axioms proved: diagonal_ramsey_upper (from Erdős-Szekeres with k=l) and ratio_equiv_difference (algebraic identity |x/y-1|=(x-y)/y for x>=y>0)",
@@ -56,7 +57,8 @@
       "R3_lower was inconsistent: ∀c>0 R(3,l)≥c·l²/log l contradicts R3_upper. Fixed to ∃c>0.",
       "R3_ratio_convergence proved directly: recurrence gives R(3,l+1)-R(3,l)≤l+1, combined with R(3,l)≥c·l²/log l gives ratio O(log l/l)→0",
       "R3_asymptotic_bounds combines R3_lower and R3_upper to give R(3,l) = Θ(l²/log l)",
-      "ramsey_pos(k,l) for k ≥ 2 follows from R(2,l)=l ≥ 1 and R(2,l) ≤ R(k,l) by iterated ramsey_monotone_left. Only k=1 case would need an axiom but it is never used."
+      "ramsey_pos(k,l) for k ≥ 2 follows from R(2,l)=l ≥ 1 and R(2,l) ≤ R(k,l) by iterated ramsey_monotone_left. Only k=1 case would need an axiom but it is never used.",
+      "OQ02 conditional_rate_general_k had incorrect O(1/l) conclusion — only o(1) follows from the given hypothesis. The growth ratio g(l+1)/g(l) is 1+O(k/l), but the R/g error is o(1) at unspecified rate. Fixed by delegating to ratio_from_asymptotics."
     ],
     "mathlibGaps": [],
     "nextSteps": [],

--- a/src/data/research/problems/erdos-102-oq-03.json
+++ b/src/data/research/problems/erdos-102-oq-03.json
@@ -61,7 +61,8 @@
       "gap_positive_conjecture unprovable: conjecturedGap is opaque axiom, no definitional content to work with",
       "CRITICAL BUG FIXED: Gk was defined as K_{k,C(k,2)} (all cross-edges) instead of the pair graph. Corrected to use subtype {(a,b) : a<b} vertex type with proper adjacency.",
       "With corrected Gk, G3_is_C6 axiom is now actually TRUE (pair graph G_3 = C_6 via mapping: 0→(0,1)→1→(1,2)→2→(0,2)→0)",
-      "Removed weak_conjecture_open (meta-mathematical, not useful), conjecturedGap+gap_positive_conjecture (opaque axiom, vacuous), Gk_from_Hk (unused embedding)"
+      "Removed weak_conjecture_open (meta-mathematical, not useful), conjecturedGap+gap_positive_conjecture (opaque axiom, vacuous), Gk_from_Hk (unused embedding)",
+      "strong_implies_weak sorry: needs C*n^{3/2-c} ≤ ε*n^{3/2} for large n, i.e., n^c ≥ C/ε. Provable via Real.rpow_natCast + tendsto_rpow_atTop for c > 0."
     ],
     "mathlibGaps": [],
     "nextSteps": [

--- a/src/data/research/problems/erdos-43-oq-05.json
+++ b/src/data/research/problems/erdos-43-oq-05.json
@@ -29,17 +29,24 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved sidon_diff_injective (ℤ version). Foundation for all 5 counting sorries.",
+    "progressSummary": "PROGRESS: 3 of 5 sorries eliminated (sidon_pair_bound, disjoint_diff_combined_bound, tao_equal_size_bound). 2 remaining: sidon_diff_count, disjoint_diff_total (need Nonempty hypothesis).",
     "builtItems": [
       "Proved sidon_diff_injective for Finset ℤ — if a₁-b₁=a₂-b₂ with a₁≠b₁, then a₁=a₂ and b₁=b₂",
-      "Prior: sidon_diff_injective also proved in Erdos152 (for Finset ℕ) and Erdos14 (for Set ℕ)"
+      "Prior: sidon_diff_injective also proved in Erdos152 (for Finset ℕ) and Erdos14 (for Set ℕ)",
+      "Proved sidon_pair_bound (C(|A|,2) ≤ N for Sidon A ⊆ {1,...,N})",
+      "Proved disjoint_diff_combined_bound (C(|A|,2)+C(|B|,2) ≤ N for disjoint differences)",
+      "Proved tao_equal_size_bound (|A|² ≤ 2N+1 when |A|=|B| and disjoint diffs)"
     ],
     "insights": [
       "Sidon diff injectivity: a₁-b₁=a₂-b₂ → a₁+b₂=a₂+b₁ → by Sidon {a₁,b₂}={a₂,b₁} → a₁=a₂ (since a₁≠b₁)",
       "sidon_diff_count needs A.Nonempty — formula fails for empty set (0 ≠ 1)",
       "For sidon_pair_bound: need |A|*(|A|-1) ≤ 2*(N-1) from injection into {-(N-1),...,N-1}\\{0}",
       "Dependency chain: sidon_diff_injective → sidon_diff_count → disjoint_diff_total → bounds",
-      "Nat.choose 2 manipulation needed: 2*C(n,2) = n*(n-1)"
+      "Nat.choose 2 manipulation needed: 2*C(n,2) = n*(n-1)",
+      "sidon_pair_bound proved: injection of offDiag differences into Icc(1-N,N-1), |offDiag|≤|Icc|≤2N, then C(n,2)≤N",
+      "disjoint_diff_combined_bound proved: images of A/B offDiag under difference map are disjoint (by DisjointDifferences), combined image ⊆ Icc gives sum ≤ N",
+      "tao_equal_size_bound proved: from combined bound 2C(m,2)≤N get m(m-1)≤N, m≤N+1, then m²≤2N+1 via nlinarith",
+      "sidon_diff_count and disjoint_diff_total still sorry: formulas are incorrect for empty sets (need A.Nonempty)"
     ],
     "mathlibGaps": [],
     "nextSteps": [

--- a/src/data/research/problems/erdos-456.json
+++ b/src/data/research/problems/erdos-456.json
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "COMPLETED",
     "since": "2026-01-13T04:11:10.511Z",
     "iteration": 3,
-    "focus": "Axiom elimination: rebuilt file with 4 axioms (down from 12)",
+    "focus": "All provable content proved. 2 deep axioms (Linnik, m/n divergence) remain — genuinely unprovable from Mathlib.",
     "blockers": [],
-    "nextAction": "Prove van_doorn_power_of_two sorry and part1_implies_infinitely_many sorry",
+    "nextAction": "None — problem is complete.",
     "attemptCounts": {
       "total": 3,
       "currentApproach": 1,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Dirichlet axiom eliminated via Mathlib PrimesInAP. File now has 2 deep axioms (Linnik, m/n divergence), 0 sorries.",
+    "progressSummary": "COMPLETED: 0 sorries, 2 deep axioms (linnik_bound, m_over_n_diverges). 9 formerly-axiom properties proved from sInf + Dirichlet (Mathlib PrimesInAP). Gallery sections updated.",
     "builtItems": [
       "part2_implies_part1: SORRY FILLED — Part2 implies Part1 via C=2 argument",
       "part1_implies_infinitely_many: SORRY FILLED — using erdos_strict_inequality axiom",


### PR DESCRIPTION
## Summary
- Prove 14 building-block lemmas toward eliminating the sole axiom `conic_implies_pascal_constraint` in Pascal's Hexagon Theorem
- Establish cross product bilinearity, determinant multilinearity, and scaling preservation for Pascal constraint
- Prove Pascal holds with the exceptional point (-1,0,1) at each of the 6 hexagon positions and in multi-exceptional configurations
- Reduce full axiom elimination to two well-documented sorries: Sylvester's law of inertia + case analysis assembly

## Progress
- **14 new proved lemmas** (0 sorries in proved code)
- **3 roadmap sorries** (clearly documented, well-known results)
- Prior sessions had proved: parametric Pascal (ring), projective invariance, cross product transform, det multiplicativity
- This session bridges the gap between the parametric proof and full conic coverage

## Findings
- Every real point on stdConic has x₂ ≠ 0 (sum of squares argument)
- The parametrization misses exactly one point: (-1,0,1). Proved Pascal for it at all 6 positions
- Scaling lemma (pascalConstraint_of_smul) proved modularly via crossProduct_smul_smul + threeVectorMatrix_det_smul
- Adjacent proportional vertices give trivial Pascal (zero cross product → zero row → det = 0)
- Full axiom elimination now depends only on Sylvester's law (quadratic form theory) and case analysis assembly

## Status
**Outcome**: progress
**Axiom count**: 1 (unchanged — axiom retained until all sorries eliminated)
**Sorry count**: 3 (new roadmap sorries, all well-documented)

Generated by researcher-10