### PR TITLE
fix: correct sorry/axiom counts for erdos-1066-oq-04

### DIFF
--- a/src/data/proofs/erdos-1066-oq-04/meta.json
+++ b/src/data/proofs/erdos-1066-oq-04/meta.json
@@ -17,10 +17,10 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 2,
-    "axiomCount": 2,
+    "sorries": 1,
+    "axiomCount": 1,
     "lineCount": 155,
-    "assumptions": "2 axioms (degree_le_kissing, greedy_independence). 2 sorries.",
+    "assumptions": "1 axiom (degree_le_kissing). 1 sorry (independenceRatio definition). Note: greedy_independence axiom asserts True (vacuous), and 2 theorems (greedy_lower_bound, ratio_greedy_bound) are True stubs needing proper formalization.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -82,7 +82,7 @@
     ],
     "namespace": "Erdos1066OQ04",
     "lineCount": 155,
-    "axiomCount": 2,
+    "axiomCount": 1,
     "theoremCount": 5,
     "definitionCount": 6
   }


### PR DESCRIPTION
## Summary

- **erdos-1066-oq-04** meta.json overcounted sorries (2 → 1) and axioms (2 → 1)
- `greedy_independence` is `axiom ... : True` — vacuous, not a real assumption
- 2 theorems (`greedy_lower_bound`, `ratio_greedy_bound`) are True stubs proving `True := trivial`
- Only 1 actual sorry: `independenceRatio` definition

## Evidence

**meta.json claimed**: 2 axioms, 2 sorries
**Lean file shows**: 1 real axiom (degree_le_kissing), 1 sorry (independenceRatio def), 1 vacuous axiom (greedy_independence : True), 2 True stubs

## Test plan

- [ ] Verify `grep -c sorry proofs/Proofs/Erdos1066OQ04.lean` returns 1 (in code, not comments)
- [ ] Verify gallery builds: `pnpm build`

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)