### PR TITLE
fix: correct sorry count and status for erdos-307-oq-02

### DIFF
--- a/src/data/proofs/erdos-307-oq-02/meta.json
+++ b/src/data/proofs/erdos-307-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Research (sorry elimination for Erd\u0151s 307)",
     "sourceUrl": "https://erdosproblems.com/307",
     "date": "2026",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos307OQ02.lean",
     "tags": [
       "number-theory",
@@ -16,11 +16,11 @@
       "erdos",
       "research"
     ],
-    "badge": "axiom",
-    "sorries": 7,
+    "badge": "wip",
+    "sorries": 1,
     "axiomCount": 0,
     "lineCount": 261,
-    "assumptions": "0 axioms, 7 sorries remaining.",
+    "assumptions": "0 axioms. 1 sorry remaining (reciprocal_sum_three_primes_le: tight bound for 3 distinct primes).",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "originalContributions": [


### PR DESCRIPTION
## Summary

- **erdos-307-oq-02** meta.json claimed 7 sorries, actual is **1**
- Changed status from `axiomatized` to `formalized` (0 axioms exist)
- Changed badge from `axiom` to `wip` (no axioms to justify `axiom` badge)
- Updated assumptions text to reflect actual state

## Evidence

**meta.json claimed**: 7 sorries, status "axiomatized", badge "axiom"
**Lean file shows**: 1 sorry (line 112, reciprocal_sum_three_primes_le), 0 axiom keywords
**File's own comment (line 258)**: "1 sorry (supporting lemma), 0 axioms"

## Test plan

- [ ] Verify `grep -c sorry proofs/Proofs/Erdos307OQ02.lean` returns 1 (in code)
- [ ] Verify gallery builds: `pnpm build`

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)