### PR TITLE
fix: correct axiom count and assumptions text for erdos-1066-oq-04

### DIFF
--- a/src/data/proofs/erdos-1066-oq-04/meta.json
+++ b/src/data/proofs/erdos-1066-oq-04/meta.json
@@ -18,9 +18,9 @@
     ],
     "badge": "axiom",
     "sorries": 1,
-    "axiomCount": 1,
+    "axiomCount": 2,
     "lineCount": 155,
-    "assumptions": "1 axiom (degree_le_kissing). 1 sorry (independenceRatio definition). Note: greedy_independence axiom asserts True (vacuous), and 2 theorems (greedy_lower_bound, ratio_greedy_bound) are True stubs needing proper formalization.",
+    "assumptions": "1 axiom (degree_le_kissing). 1 vacuous axiom (greedy_independence asserts True). 1 sorry. 2 True-stub theorems.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -82,7 +82,7 @@
     ],
     "namespace": "Erdos1066OQ04",
     "lineCount": 155,
-    "axiomCount": 1,
+    "axiomCount": 2,
     "theoremCount": 5,
     "definitionCount": 6
   }


### PR DESCRIPTION
## Summary

- **axiomCount**: corrected from 1 to 2 in both `meta` and `leanFile` sections. There are 2 `axiom` keyword declarations in `Erdos1066OQ04.lean`: `degree_le_kissing` (meaningful) and `greedy_independence` (vacuous, asserts `True`). Per the axiom integrity policy, both must be counted.
- **assumptions text**: updated to concisely note the vacuous axiom and 2 True-stub theorems (`greedy_lower_bound`, `ratio_greedy_bound`).
- **sorries**: already correct at 1 after #8305; no change needed.

Follows up on #8305 which fixed the sorry count but undercounted axioms.

## Test plan

- [ ] Verify `meta.json` axiomCount matches `grep -c "^axiom " proofs/Proofs/Erdos1066OQ04.lean` (expect 2)
- [ ] Verify assumptions text accurately reflects the Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)