### PR TITLE
fix: correct sorry count and stats for pascals-hexagon (0→8 sorries)

### DIFF
--- a/src/data/proofs/pascals-hexagon/meta.json
+++ b/src/data/proofs/pascals-hexagon/meta.json
@@ -19,7 +19,7 @@
       "classic"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 8,
     "mathlibDependencies": [
       {
         "theorem": "Mathlib.LinearAlgebra.CrossProduct",
@@ -46,16 +46,16 @@
     ],
     "dateAdded": "2025-12-29",
     "leanFile": {
-      "lineCount": 529,
+      "lineCount": 791,
       "structures": 1,
       "axioms": 1,
-      "theorems": 1,
-      "definitions": 16,
+      "theorems": 26,
+      "definitions": 24,
       "instances": 0
     },
     "axiomCount": 1,
-    "lineCount": 529,
-    "assumptions": "1 axiom: conic_implies_pascal_constraint. See Lean source for the complete statement.",
+    "lineCount": 791,
+    "assumptions": "1 axiom (conic_implies_pascal_constraint). 8 sorries in axiom-elimination research theorems.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -225,10 +225,10 @@
       "Matrix"
     ],
     "namespace": null,
-    "lineCount": 529,
+    "lineCount": 791,
     "axiomCount": 1,
-    "theoremCount": 1,
-    "definitionCount": 20
+    "theoremCount": 26,
+    "definitionCount": 24
   },
   "references": [
     {


### PR DESCRIPTION
## Summary

- **sorry count**: `0` → `8` (critically stale — PascalsHexagon.lean has 8 sorries in axiom-elimination research theorems that were never reflected in meta.json)
- **lineCount**: `529` → `791` (both `meta.lineCount` and `leanFile.lineCount`)
- **theoremCount**: `1` → `26` (25 new theorems added for standard conic case, projective transforms, exceptional points, Sylvester's law, etc.)
- **definitionCount**: `16`/`20` (was inconsistent between the two leanFile sections) → `24` (actual count of `def`/`noncomputable def` declarations)
- **assumptions** text updated to reflect sorry inventory

### Sorry inventory in PascalsHexagon.lean

| Location | Sorries | Description |
|----------|---------|-------------|
| `pascal_stdConic_all_points` (line 694) | 1 | Case analysis assembling parametric + exceptional lemmas |
| `sylvester_conic_equivalence` (line 723) | 1 | Sylvester's law of inertia for quadratic forms |
| `conic_implies_pascal_constraint_proof` (line 767) | 6 | Validity of transformed points |

### Not changed (correct as-is)

- `status`: `"axiomatized"` — correct, there is 1 axiom
- `badge`: `"axiom"` — correct
- `axiomCount`: `1` — correct (`conic_implies_pascal_constraint`)

## Test plan

- [ ] Verify `pnpm build` passes with updated meta.json
- [ ] Confirm sorry count matches `grep -c sorry proofs/Proofs/PascalsHexagon.lean` output
- [ ] Confirm line count matches `wc -l proofs/Proofs/PascalsHexagon.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)