### PR TITLE
fix: correct sorry count for erdos-1126-oq-01 (1→4 sorries)

### DIFF
--- a/src/data/proofs/erdos-1126-oq-01/meta.json
+++ b/src/data/proofs/erdos-1126-oq-01/meta.json
@@ -21,7 +21,7 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 4,
     "erdosNumber": 1126,
     "erdosUrl": "https://erdosproblems.com/1126",
     "erdosProblemStatus": "solved",
@@ -66,7 +66,7 @@
     "dateAdded": "2026-03-24",
     "axiomCount": 5,
     "lineCount": 475,
-    "assumptions": "5 axioms: almost_multiplicative_stability, almost_jensen_stability, almost_derivation_stability, measurable_multiplicative_is_power, measurable_derivation_is_zero. continuous_derivation_is_zero proved from measurable_derivation_is_zero (continuous implies measurable)."
+    "assumptions": "5 axioms (almost_multiplicative_stability, almost_jensen_stability, almost_derivation_stability, measurable_multiplicative_is_power, measurable_derivation_is_zero). 4 sorries in measure-theoretic support lemmas."
   },
   "overview": {
     "historicalContext": "**Extending the de Bruijn-Jurkat Paradigm**\n\nThe de Bruijn-Jurkat theorem (1965-66) showed that almost additive functions can be corrected to truly additive functions a.e. This naturally raises the question: does the same stability hold for other fundamental functional equations?\n\n**The Key Equations:**\n1. **Multiplicative** (Cauchy exponential): $f(xy) = f(x)f(y)$ — characterizes exponentials and power functions\n2. **Jensen** (midpoint affinity): $f((x+y)/2) = (f(x)+f(y))/2$ — characterizes affine functions\n3. **Derivation** (Leibniz rule): $d(xy) = x \\cdot d(y) + y \\cdot d(x)$ — characterizes differentiation\n\n**Known Results:**\n- **Ger (1979)** showed stability holds for polynomial functional equations, which includes the derivation case\n- **Járai (2005)** gave a comprehensive treatment of regularity for functional equations in several variables\n- The multiplicative case reduces to the additive case via logarithms (for positive solutions)\n- The Jensen case is algebraically equivalent to the additive case modulo a constant",
@@ -178,12 +178,12 @@
       "Can the stability paradigm be extended to functional equations on locally compact groups beyond ℝ?",
       "What is the optimal null-set estimate: given an ε-null exceptional set, how small can the correction set be?",
       "Does stability hold for functional inequalities (e.g., almost sub-additive → sub-additive a.e.)?",
-      "Can the remaining sorry (almost Jensen → almost additive) be resolved using Mathlib's Fubini theorem? (log_of_mul_is_additive has been proved)"
+      "Can the remaining 4 sorries (measure-theoretic lemmas) be resolved using Mathlib's Fubini theorem? (log_of_mul_is_additive has been proved)"
     ]
   },
   "leanFile": {
     "path": "proofs/Proofs/Erdos1126OQ01Problem.lean",
     "filename": "Erdos1126OQ01Problem.lean",
-    "lineCount": 413
+    "lineCount": 475
   }
 }


### PR DESCRIPTION
## Summary

- Fix sorry count in `erdos-1126-oq-01/meta.json` from 1 to 4, matching the actual Lean source which has 4 sorries: `volume_preimage_double_null`, `volume_preimage_fst_null`, `volume_preimage_snd_null`, and `ae_double_of_almost_jensen`
- Fix stale `leanFile.lineCount` from 413 to 475 (matching `meta.lineCount` which was already correct)
- Update `assumptions` text to include "4 sorries in measure-theoretic support lemmas"
- Update `openQuestions` to reference "remaining 4 sorries" instead of singular "remaining sorry"

## Test plan

- [ ] Verify `pnpm build` succeeds with updated meta.json
- [ ] Confirm sorry count matches `grep -c "sorry" proofs/Proofs/Erdos1126OQ01Problem.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)