### PR TITLE
Research: erdos-102-oq-03 — prove upper_bound_tight_construction2, fix strong_implies_weak (5→3 sorries)

### DIFF
--- a/proofs/Proofs/Erdos1020Problem.lean
+++ b/proofs/Proofs/Erdos1020Problem.lean
@@ -168,15 +168,57 @@ axiom frankl_upper_bound :
     f n r k ≤ (k - 1) * Nat.choose (n - 1) (r - 1)
 
 /-- The upper bound is sometimes tight.
-    Proof sketch: By telescoping, C(n,r) - C(n-k+1,r) = Σ_{i=1}^{k-1} C(n-i,r-1)
-    via Pascal's rule. Each term ≤ C(n-1,r-1) by monotonicity, giving ≤ (k-1)·C(n-1,r-1). -/
+    Proof: By induction on k. Base k=1: both sides are 0.
+    Step k→k+1: decompose C(n,r)-C(n-k,r) = [C(n,r)-C(n-k+1,r)] + [C(n-k+1,r)-C(n-k,r)].
+    First part ≤ (k-1)·C(n-1,r-1) by IH. Second part = C(n-k,r-1) by Pascal ≤ C(n-1,r-1). -/
 theorem upper_bound_tight_construction2 (n r k : ℕ) (hr : r ≥ 2) (hk : k ≥ 1) (hn : n ≥ r * k) :
     construction2 n r k ≤ (k - 1) * Nat.choose (n - 1) (r - 1) := by
-  -- Telescoping sum + monotonicity of binomial coefficients
-  -- C(n,r) - C(n-k+1,r) = Σ_{i=1}^{k-1} [C(n-i+1,r) - C(n-i,r)]
-  --                      = Σ_{i=1}^{k-1} C(n-i,r-1)  [Pascal's rule]
-  --                      ≤ (k-1) · C(n-1,r-1)         [each term ≤ C(n-1,r-1)]
-  sorry
+  unfold construction2
+  revert hk hn
+  induction k with
+  | zero => intro hk; omega
+  | succ k ih =>
+    intro _ hn
+    cases k with
+    | zero =>
+      -- k+1 = 1: C(n,r) - C(n,r) = 0 ≤ 0
+      have h : n - (0 + 1) + 1 = n := by omega
+      rw [h]; simp
+    | succ k' =>
+      -- k+1 = k'+2; IH for k'+1
+      have hk'1 : k' + 1 ≥ 1 := by omega
+      have hn' : n ≥ r * (k' + 1) := by nlinarith
+      specialize ih hk'1 hn'
+      -- Simplify index expressions
+      have h1 : n - (k' + 1) + 1 = n - k' := by omega
+      have h2 : n - (k' + 1 + 1) + 1 = n - k' - 1 := by omega
+      rw [h1] at ih; rw [h2]
+      -- ih: C(n,r) - C(n-k',r) ≤ k' * C(n-1,r-1)
+      -- Goal: C(n,r) - C(n-k'-1,r) ≤ (k'+1) * C(n-1,r-1)
+      -- Decompose: a - c = (a - b) + (b - c) for c ≤ b ≤ a
+      have hle1 : Nat.choose (n - k' - 1) r ≤ Nat.choose (n - k') r :=
+        Nat.choose_le_choose r (by omega)
+      have hle2 : Nat.choose (n - k') r ≤ Nat.choose n r :=
+        Nat.choose_le_choose r (by omega)
+      have h_split : Nat.choose n r - Nat.choose (n - k' - 1) r =
+          (Nat.choose n r - Nat.choose (n - k') r) +
+          (Nat.choose (n - k') r - Nat.choose (n - k' - 1) r) := by omega
+      rw [h_split]
+      -- Pascal: C(m+1,r) - C(m,r) = C(m,r-1)  where m = n-k'-1
+      have h_pascal : Nat.choose (n - k') r - Nat.choose (n - k' - 1) r =
+          Nat.choose (n - k' - 1) (r - 1) := by
+        have hCSS := Nat.choose_succ_succ (n - k' - 1) (r - 1)
+        rw [show (n - k' - 1) + 1 = n - k' from by omega,
+            show (r - 1) + 1 = r from by omega] at hCSS
+        omega
+      rw [h_pascal]
+      -- Monotonicity: C(n-k'-1, r-1) ≤ C(n-1, r-1)
+      have h_mono : Nat.choose (n - k' - 1) (r - 1) ≤ Nat.choose (n - 1) (r - 1) :=
+        Nat.choose_le_choose (r - 1) (by omega)
+      -- Combine: IH + monotonicity
+      calc (Nat.choose n r - Nat.choose (n - k') r) + Nat.choose (n - k' - 1) (r - 1)
+          ≤ k' * Nat.choose (n - 1) (r - 1) + Nat.choose (n - 1) (r - 1) := by linarith
+        _ = (k' + 1) * Nat.choose (n - 1) (r - 1) := by ring
 
 /-
 ## Lower Bounds

--- a/proofs/Proofs/Erdos1021Problem.lean
+++ b/proofs/Proofs/Erdos1021Problem.lean
@@ -18,6 +18,7 @@ import Mathlib.Combinatorics.SimpleGraph.Subgraph
 import Mathlib.Data.Real.Basic
 import Mathlib.Data.Fintype.Basic
 import Mathlib.Data.Nat.Choose.Basic
+import Proofs.Erdos1021Aristotle
 
 open SimpleGraph
 
@@ -186,7 +187,8 @@ theorem strong_implies_weak : erdos_1021_conjecture → weak_conjecture := by
   -- when n^c ≥ C/ε, which holds for all sufficiently large n
   obtain ⟨N₁, hN₁⟩ : ∃ N₁ : ℕ, ∀ n : ℕ, n ≥ N₁ →
       C * powerBound c n ≤ ε * (n : ℝ) ^ (3/2 : ℝ) := by
-    sorry  -- Real analysis: rpow decay C·n^{-c} → 0; routine Aristotle target
+    -- powerBound c n = (n : ℝ) ^ (3/2 - c), which matches rpow_decay_bound
+    exact Erdos1021Aristotle.rpow_decay_bound C hC_pos c hc_pos ε hε
   refine ⟨max N₀ N₁, fun n hn => ?_⟩
   have ⟨hn₀, hn₁⟩ := max_le_iff.mp hn
   exact le_trans (hN₀ n hn₀) (hN₁ n hn₁)

--- a/src/data/research/problems/erdos-358.json
+++ b/src/data/research/problems/erdos-358.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-358",
-  "title": "Erdős #358",
+  "title": "Erd\u0151s #358",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "B",
@@ -31,33 +31,35 @@
   "knowledge": {
     "progressSummary": "PROGRESS: 0 sorries remain (even-even case proved via odd divisor construction). 1 axiom (naturals_count_odd_divisors). exists_odd_divisor_ge3 + two-case construction eliminates last sorry.",
     "builtItems": [
-      "Proved two_mul_sum_Icc: Gauss sum formula 2*Σ = (b-a+1)(a+b) by induction + zify",
+      "Proved two_mul_sum_Icc: Gauss sum formula 2*\u03a3 = (b-a+1)(a+b) by induction + zify",
       "Proved odd_dvd_two_pow_eq_one: odd divisor of 2^j is 1, by induction on j + coprimality",
       "Proved power_of_two_obstruction: parity argument on consecutive sum double formula",
       "Proved naturals_always_representable: Set.ncard finiteness via Finset.single_le_sum bounding v<n",
       "not_pow2_representable: odd case proved (2 consecutive terms), even case sorry",
-      "consecutive_sum_char: axiom → theorem (biconditional proved structurally)",
+      "consecutive_sum_char: axiom \u2192 theorem (biconditional proved structurally)",
       "not_pow2_representable m-odd sub-case PROVED: n=2(2k+1) represented as 4 consecutive terms from k-1 to k+2",
-      "exists_odd_divisor_ge3: recursive extraction of odd factor ≥ 3 for non-powers-of-2",
-      "not_pow2_representable even case: Case A (d≤2q) centered construction + Case B (d>2q) offset construction"
+      "exists_odd_divisor_ge3: recursive extraction of odd factor \u2265 3 for non-powers-of-2",
+      "not_pow2_representable even case: Case A (d\u22642q) centered construction + Case B (d>2q) offset construction"
     ],
     "insights": [
       "consecutive_sum_formula sorry is standard arithmetic (Gauss sum) - needs Finset.sum_Icc manipulation",
       "power_of_two_obstruction axiom is a well-known result about consecutive sum representations",
       "primesSeq axiomatized because Nat.nth is complex - could be defined directly",
-      "power_of_two_obstruction proved: key insight is (v-u+1)+(u+v+2)=2v+3 (odd), forcing one factor odd, which must be 1 but both ≥2",
-      "consecutive_sum_char → direction proved from power_of_two_obstruction",
-      "consecutive_sum_char ← direction for odd n: sum of 2 terms m + (m+1) = 2m+1",
+      "power_of_two_obstruction proved: key insight is (v-u+1)+(u+v+2)=2v+3 (odd), forcing one factor odd, which must be 1 but both \u22652",
+      "consecutive_sum_char \u2192 direction proved from power_of_two_obstruction",
+      "consecutive_sum_char \u2190 direction for odd n: sum of 2 terms m + (m+1) = 2m+1",
       "Even non-power-of-2 case needs odd part extraction (Nat.factorization API)",
       "For n=2m, m odd >= 5: 4 consecutive terms (k-1,k,k+1,k+2) sum to 4k+2=n via Gauss formula. k=1 special case: 1+2+3=6",
-      "Odd divisor construction: d terms centered at q=n/d (Case A when d≤2q), or 2q terms starting at (d-2q+1)/2 (Case B when d>2q)",
-      "Both cases reduce to 2*sum = 2n via two_mul_sum_Icc + ring rewriting of d*(2q)=2*(d*q)=2n"
+      "Odd divisor construction: d terms centered at q=n/d (Case A when d\u22642q), or 2q terms starting at (d-2q+1)/2 (Case B when d>2q)",
+      "Both cases reduce to 2*sum = 2n via two_mul_sum_Icc + ring rewriting of d*(2q)=2*(d*q)=2n",
+      "naturals_count_odd_divisors proof strategy: each valid (u,v) pair gives factorization 2n = (v-u+1)(u+v+2) with different parities. Bijection to odd divisors by extracting the odd factor."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "naturals_count_odd_divisors axiom: needs bijection between consecutive sum representations and odd divisors"
+      "PROVE naturals_count_odd_divisors: bijection between (u,v) with u\u2264v, \u03a3(i+1)=n and odd divisors of n. Strategy: factor 2n=d\u00b7s with d<s, different parity, map to the odd factor. Inverse: odd divisor q\u2192(d,s)=(min(q,2n/q),max(q,2n/q)). Need Set.ncard finiteness for the pair set (bounded by v\u2264n).",
+      "Proof complexity: ~80 lines, requires Set.ncard_image_of_injective and bijection construction"
     ],
-    "markdown": "# Erdős #358 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $A=\\{a_1<\\cdots\\}$ be an infinite sequence of integers. Let $f(n)$ count the number of solutions to\\[n=\\sum_{u\\leq i\\leq v}a_i.\\]Is there such an $A$ for which $f(n)\\to \\infty$ as $n\\to \\infty$? Or even where $f(n)\\geq 2$ for all large $n$?\n\n\n\n\n\nWhen $a_n=n$ the function $f(n)$ counts the number of odd divisors of $n$.\n\nIn modern language, this asks for the existence of a convex set $A$ such that $1_A\\circ 1_A(n)\\to \\infty$ as $n\\to \\infty$.\n\nErd\\H{o}s and Moser \\cite{Mo63} considered the case when $A$ is the set of primes, and conjectured that the $\\limsup$ of the number of such representations in this case is infinite. They could not even prove that the upper density of the set of integers representable in this form is positive.\n\nIn \\cite{ErGr80} they further asked whether $f(n)\\geq 1$ for all large $n$ is possible, but Egami observed the answer to this is trivially yes, taking $a_n=n$. Perhaps they intended to restrict $f(n)$ to only count those representatives as the sum of at least two consecutive terms. (It is a classical fact that $n$ can be expressed as a sum of at least two consecutive positive integers if and only if $n\\neq 2^k$.)\n\nIn \\cite{Er77c} Erd\\H{o}s writes 'This problem can perhaps be rightly criticized as being artificial and in the backwater of Mathematics but it seems very strange and attractive to me'.\n\nWeisenberg observes that the finite analogue of this problem, asking how many integers up to some $x$ can be written as the sum of consecutive elements, is very similar to [356].\n\nThis is reported in problem C2 of Guy's collection \\cite{Gu04}.\n\n\n\n\nReferences\n\n\n[Er77c] Erd\\H{o}s, Paul, Problems and results on combinatorial number theory. III. Number theory day (Proc. Conf., Rockefeller Univ.,\nNew York, 1976) (1977), 43-72.\n\n[ErGr80] Erd\\H{o}s, P. and Graham, R., Old and new problems and results in combinatorial number theory. Monographies de L'Enseignement Mathematique (1980).\n\n[Gu04] Guy, Richard K., Unsolved problems in number theory. (2004), xviii+437.\n\n[Mo63] Moser, L., Notes on number theory. III. On the sum of consecutive primes. Canad. Math. Bull. (1963), 159-161.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 3/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #356\n- Problem #357\n- Problem #359\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er77c\n- Mo63\n- ErGr80\n- Gu04\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
+    "markdown": "# Erd\u0151s #358 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $A=\\{a_1<\\cdots\\}$ be an infinite sequence of integers. Let $f(n)$ count the number of solutions to\\[n=\\sum_{u\\leq i\\leq v}a_i.\\]Is there such an $A$ for which $f(n)\\to \\infty$ as $n\\to \\infty$? Or even where $f(n)\\geq 2$ for all large $n$?\n\n\n\n\n\nWhen $a_n=n$ the function $f(n)$ counts the number of odd divisors of $n$.\n\nIn modern language, this asks for the existence of a convex set $A$ such that $1_A\\circ 1_A(n)\\to \\infty$ as $n\\to \\infty$.\n\nErd\\H{o}s and Moser \\cite{Mo63} considered the case when $A$ is the set of primes, and conjectured that the $\\limsup$ of the number of such representations in this case is infinite. They could not even prove that the upper density of the set of integers representable in this form is positive.\n\nIn \\cite{ErGr80} they further asked whether $f(n)\\geq 1$ for all large $n$ is possible, but Egami observed the answer to this is trivially yes, taking $a_n=n$. Perhaps they intended to restrict $f(n)$ to only count those representatives as the sum of at least two consecutive terms. (It is a classical fact that $n$ can be expressed as a sum of at least two consecutive positive integers if and only if $n\\neq 2^k$.)\n\nIn \\cite{Er77c} Erd\\H{o}s writes 'This problem can perhaps be rightly criticized as being artificial and in the backwater of Mathematics but it seems very strange and attractive to me'.\n\nWeisenberg observes that the finite analogue of this problem, asking how many integers up to some $x$ can be written as the sum of consecutive elements, is very similar to [356].\n\nThis is reported in problem C2 of Guy's collection \\cite{Gu04}.\n\n\n\n\nReferences\n\n\n[Er77c] Erd\\H{o}s, Paul, Problems and results on combinatorial number theory. III. Number theory day (Proc. Conf., Rockefeller Univ.,\nNew York, 1976) (1977), 43-72.\n\n[ErGr80] Erd\\H{o}s, P. and Graham, R., Old and new problems and results in combinatorial number theory. Monographies de L'Enseignement Mathematique (1980).\n\n[Gu04] Guy, Richard K., Unsolved problems in number theory. (2004), xviii+437.\n\n[Mo63] Moser, L., Notes on number theory. III. On the sum of consecutive primes. Canad. Math. Bull. (1963), 159-161.\n\n\nBack to the problem\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 3/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #356\n- Problem #357\n- Problem #359\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er77c\n- Mo63\n- ErGr80\n- Gu04\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
   "tags": [
     "erdos"
@@ -73,7 +75,7 @@
     "mathlib": []
   },
   "started": "2026-01-13T00:53:52.154Z",
-  "lastUpdate": "2026-03-29T12:00:00Z",
+  "lastUpdate": "2026-03-30T12:22:00.000Z",
   "significance": 5,
   "tractability": 3,
   "leanFiles": [


### PR DESCRIPTION
## Summary
- Proved `upper_bound_tight_construction2` in Erdos1020Problem.lean via induction on k, using Pascal's rule and binomial coefficient monotonicity (2→1 sorry)
- Fixed `strong_implies_weak` sorry in Erdos1021Problem.lean by importing and applying `Erdos1021Aristotle.rpow_decay_bound` (3→2 sorries)
- Updated problem knowledge with proof techniques and remaining next steps

## Proof Details

### upper_bound_tight_construction2
Shows `C(n,r) - C(n-k+1,r) ≤ (k-1)·C(n-1,r-1)` by induction on k:
- **Base**: k=1, both sides are 0
- **Step**: Decompose via `nat_sub_split`, apply Pascal (`Nat.choose_succ_succ`) for `C(m+1,r) - C(m,r) = C(m,r-1)`, then monotonicity (`Nat.choose_le_choose`)

### strong_implies_weak
The remaining sorry was exactly `rpow_decay_bound` from the Aristotle companion file (already proved by automated proof search). Added `import Proofs.Erdos1021Aristotle` and applied the lemma directly.

## Remaining sorries
- `large_n_construction2_dominates` (Erdos1020) — note: false for k=1, needs k≥2 fix
- `k3_case_solved` (Erdos1021) — needs extremalNumber isomorphism invariance
- `trivial_bound` (Erdos1021) — needs G_k ⊇ K_{2,C(k,2)} embedding

## Status
**Outcome**: progress
**Next Steps**: Fix large_n_construction2_dominates hypothesis, prove k3_case_solved via isomorphism invariance

Generated by researcher-7