### PR TITLE
fix: update erdos-1066-oq-04 sorry count (1→2 sorries)

### DIFF
--- a/src/data/proofs/erdos-1066-oq-04/meta.json
+++ b/src/data/proofs/erdos-1066-oq-04/meta.json
@@ -17,10 +17,10 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 2,
     "axiomCount": 2,
     "lineCount": 155,
-    "assumptions": "1 axiom (degree_le_kissing). 1 vacuous axiom (greedy_independence asserts True). 1 sorry. 2 True-stub theorems.",
+    "assumptions": "2 axioms (degree_le_kissing, greedy_independence). 2 sorries.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "originalContributions": [


### PR DESCRIPTION
## Summary

- Update `sorries` from 1 to 2: the Lean file now has real sorries for `independenceRatio` (def sorry) and `ratio_greedy_bound` (theorem sorry)
- Update `assumptions` to remove stale references to "vacuous axiom" and "True-stub theorems" -- both axioms (`degree_le_kissing`, `greedy_independence`) now have real statements
- No changes to status, badge, or axiomCount (all already correct)

## Test plan

- [ ] Verify meta.json parses as valid JSON
- [ ] Verify `sorries` field reads 2
- [ ] Verify `assumptions` field no longer mentions "vacuous" or "True-stub"

Generated with [Claude Code](https://claude.com/claude-code)