### PR TITLE
fix: correct sorry count for erdos-1145 (0→2 sorries)

### DIFF
--- a/src/data/proofs/erdos-1145/meta.json
+++ b/src/data/proofs/erdos-1145/meta.json
@@ -14,12 +14,12 @@
             "representation-functions",
             "open"
         ],
-        "sorries": 0,
+        "sorries": 2,
         "sourceUrl": "https://erdosproblems.com/1145",
         "erdosUrl": "https://erdosproblems.com/1145",
         "proofRepoPath": "Proofs/Erdos1145Problem.lean",
         "axiomCount": 4,
-        "assumptions": "4 axioms: erdos_sarkozy_conjecture (main open conjecture), ruzsa_ratio_not_one, average_rep_grows, grekos_two_set. Eliminated 4 axioms: ruzsaA_infinite (proved via powers of 4), ruzsaB_infinite (proved via 2·4^k), sum_of_reps_bound (was vacuously true: RHS = 0), ruzsa_unique_rep (proved).",
+        "assumptions": "4 axioms: erdos_sarkozy_conjecture (main open conjecture), ruzsa_ratio_not_one, average_rep_grows, grekos_two_set. Eliminated 4 axioms: ruzsaA_infinite (proved via powers of 4), ruzsaB_infinite (proved via 2·4^k), sum_of_reps_bound (was vacuously true: RHS = 0), ruzsa_unique_rep (proved). 2 sorries remaining (set bijection and one structural lemma).",
         "badge": "axiom",
         "prerequisites": [
             "Additive number theory (sumsets, representation functions)",
@@ -28,7 +28,7 @@
             "Asymptotic density of integer sets"
         ],
         "mathlib_version": "4.26.0",
-        "lineCount": 552,
+        "lineCount": 612,
         "dateUpdated": "2026-03-27"
     },
     "sections": [
@@ -133,7 +133,7 @@
         ]
     },
     "conclusion": {
-        "summary": "This formalization establishes the Erdős–Sárközy conjecture in Lean 4, connecting it to both the Erdős–Turán conjecture (Problem #28) as a special case and to Ruzsa's counterexample (Problem #331) showing the ratio condition is necessary. All 10 theorems are proved without sorry; the open conjecture and known results are axiomatized.",
+        "summary": "This formalization establishes the Erdős–Sárközy conjecture in Lean 4, connecting it to both the Erdős–Turán conjecture (Problem #28) as a special case and to Ruzsa's counterexample (Problem #331) showing the ratio condition is necessary. 10 theorems with 2 sorries remaining (a set bijection and one structural lemma); the open conjecture and known results are axiomatized.",
         "implications": "A proof of this conjecture would simultaneously resolve the Erdős–Turán conjecture ($500 bounty), since it is strictly stronger. The formalization makes precise exactly what condition distinguishes the true conjecture from its false generalization.",
         "openQuestions": [
             "Can the asymptotic ratio condition aₙ/bₙ → 1 be weakened while preserving the conjecture?",
@@ -187,7 +187,7 @@
             "Pointwise"
         ],
         "namespace": "Erdos1145",
-        "lineCount": 552,
+        "lineCount": 612,
         "axiomCount": 4,
         "theoremCount": 10,
         "definitionCount": 10


### PR DESCRIPTION
## Summary
- Corrects `sorries` from 0 to 2 in `erdos-1145/meta.json` to match the Lean source (`proofs/Proofs/Erdos1145Problem.lean`), which has 2 sorries: a set bijection and one structural lemma
- Updates `lineCount` from 552 to 612 in both `meta` and `leanFile` sections to match actual file length
- Appends sorry description to the `assumptions` field
- Fixes false claim in `conclusion.summary` that "All 10 theorems are proved without sorry"
- No changes to status, badge, or axiomCount (all correct)

## Test plan
- [ ] Verify `grep -c sorry proofs/Proofs/Erdos1145Problem.lean` returns 2
- [ ] Verify `wc -l proofs/Proofs/Erdos1145Problem.lean` returns 612
- [ ] Confirm `pnpm build` succeeds with updated meta.json

Generated with [Claude Code](https://claude.com/claude-code)