### PR TITLE
fix: correct axiomCount and lineCount for yang-mills-2d-oq-01

### DIFF
--- a/src/data/proofs/yang-mills-2d-oq-01/meta.json
+++ b/src/data/proofs/yang-mills-2d-oq-01/meta.json
@@ -19,8 +19,9 @@
     "badge": "verified",
     "sorries": 0,
     "dateAdded": "2026-03-30",
-    "axiomCount": 10,
-    "lineCount": 147
+    "axiomCount": 0,
+    "assumptions": "None. Fully verified with 0 axioms, 0 sorries. All theorems (heat kernel positivity, decay, Wilson loop area law, SU(2) string tension, partition function bounds) are proved from definitions using Mathlib tactics.",
+    "lineCount": 308
   },
   "sections": []
 }


### PR DESCRIPTION
## Fix

Correct metadata for yang-mills-2d-oq-01: axiomCount was 10 (should be 0) and lineCount was 147 (should be 308).

## Evidence

**Before**: `axiomCount: 10`, `lineCount: 147`
**After**: `axiomCount: 0`, `lineCount: 308`, added `assumptions` field

The Lean source file `Proofs/YangMills2DOQ01.lean` has 0 `axiom` declarations, 0 sorries, and 308 lines. All theorems (heat kernel positivity/decay, Wilson loop area law, SU(2) string tension, partition function bounds) are fully proved from definitions.

---
Automated fix by lean-mechanic agent.