### PR TITLE
fix: correct stale sorry/line counts for 3 proofs

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -650,15 +650,15 @@
       "issues": []
     },
     "erdos-1020": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:17:37Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-03-30T11:10:03Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "erdos-1021": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T05:17:37Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-03-30T11:10:55Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "erdos-1022": {
@@ -9163,9 +9163,9 @@
       "issues": []
     },
     "erdos-1126-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T18:15:35Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-03-30T11:11:39Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "erdos-1139": {

--- a/src/data/proofs/erdos-1020/meta.json
+++ b/src/data/proofs/erdos-1020/meta.json
@@ -18,13 +18,13 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 1020,
     "erdosUrl": "https://erdosproblems.com/1020",
     "erdosProblemStatus": "open",
     "axiomCount": 11,
-    "lineCount": 253,
-    "assumptions": "11 axiom(s) and 2 sorry(s). See the Lean source for details.",
+    "lineCount": 295,
+    "assumptions": "11 axiom(s) and 1 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -184,7 +184,7 @@
       "Nat"
     ],
     "namespace": null,
-    "lineCount": 253,
+    "lineCount": 295,
     "axiomCount": 11,
     "theoremCount": 4,
     "definitionCount": 11

--- a/src/data/proofs/erdos-1021/meta.json
+++ b/src/data/proofs/erdos-1021/meta.json
@@ -17,7 +17,7 @@
       "bipartite-graphs"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 1021,
     "erdosUrl": "https://erdosproblems.com/1021",
     "erdosProblemStatus": "open",
@@ -27,7 +27,7 @@
     ],
     "axiomCount": 4,
     "lineCount": 260,
-    "assumptions": "4 axioms: G3_is_C6, erdos_simonovits_limit, C6_extremal_bound, kovari_sos_turan. 3 sorries remain.",
+    "assumptions": "4 axioms: G3_is_C6, erdos_simonovits_limit, C6_extremal_bound, kovari_sos_turan. 2 sorries remain.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -252,7 +252,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos1021",
-    "lineCount": 260,
+    "lineCount": 262,
     "axiomCount": 4,
     "theoremCount": 5,
     "definitionCount": 17

--- a/src/data/proofs/erdos-1126-oq-01/meta.json
+++ b/src/data/proofs/erdos-1126-oq-01/meta.json
@@ -21,7 +21,7 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 1,
     "erdosNumber": 1126,
     "erdosUrl": "https://erdosproblems.com/1126",
     "erdosProblemStatus": "solved",
@@ -184,6 +184,6 @@
   "leanFile": {
     "path": "proofs/Proofs/Erdos1126OQ01Problem.lean",
     "filename": "Erdos1126OQ01Problem.lean",
-    "lineCount": 475
+    "lineCount": 495
   }
 }


### PR DESCRIPTION
## Summary

- **erdos-1020**: sorry count 2→1, lineCount 253→295
- **erdos-1021**: sorry count 3→2, lineCount 260→262  
- **erdos-1126-oq-01**: sorry count 4→1, leanFile.lineCount 475→495

All verified against current Lean source files.

## Test plan

- [ ] `pnpm build` passes
- [ ] Gallery pages render correct sorry counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)