### PR TITLE
fix: correct sorry/axiom counts for motivic-flag-maps-oq-02

### DIFF
--- a/src/data/proofs/motivic-flag-maps-oq-02/meta.json
+++ b/src/data/proofs/motivic-flag-maps-oq-02/meta.json
@@ -21,7 +21,7 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "mul_geom_sum",
@@ -49,12 +49,13 @@
       "GL_n-flag variety structural relation (proved)",
       "Partial flag variety definition and motivic class factorization",
       "Extension conjecture: maps to partial flags give parabolic × affine classes",
-      "Gaussian binomial identity statement: [Gr(d,n)] · [d]! · [n-d]! = [n]!"
+      "Gaussian binomial identity proved: [Gr(d,n)] · [d]! · [n-d]! = [n]!",
+      "Grassmannian duality proved: [Gr(d,n)] = [Gr(n-d,n)]"
     ],
     "dateAdded": "2026-03-30",
-    "axiomCount": 3,
+    "axiomCount": 2,
     "lineCount": 635,
-    "assumptions": "3 axiom(s): motivicClassPartialFlagMaps, partial_flag_extension (conjectured), grassmannian_maps_degree_1 (known but deep). 3 sorry(s): grassmannianClass_duality, grassmannianClass_lines, gaussian_binomial_identity (algebraic identities needing induction).",
+    "assumptions": "2 axiom(s): motivicClassPartialFlagMaps (motivic class of maps to partial flags), partial_flag_extension (conjectured extension to parabolic subgroups). 0 sorries — all algebraic identities (duality, lines, Gaussian binomial) are proved.",
     "mathlib_version": "4.26.0"
   },
   "sections": [
@@ -114,7 +115,7 @@
   },
   "conclusion": {
     "summary": "We formalize the extension question for Bryan et al.'s motivic class theorem to partial flag varieties. The key proved results are: q-factorials equal flag variety classes, GL_n decomposes via q-factorials, and Grassmannian classes satisfy the q-Pascal identity.",
-    "implications": "The extension conjecture for partial flags with parabolic subgroups is stated formally. Three sorries remain for algebraic identities that require careful induction.",
+    "implications": "The extension conjecture for partial flags with parabolic subgroups is stated formally. All algebraic identities (Grassmannian duality, lines, Gaussian binomial) are proved. Two axioms remain for the conjectured motivic class formulas.",
     "openQuestions": [
       "Prove Grassmannian duality [Gr(d,n)] = [Gr(n-d,n)] by induction on the q-Pascal identity",
       "Prove the Gaussian binomial identity [Gr(d,n)] · [d]! · [n-d]! = [n]!",


### PR DESCRIPTION
## Summary
- Sorry count 3→0: all three algebraic identities (`grassmannianClass_duality`, `grassmannianClass_lines`, `gaussian_binomial_identity`) are fully proved
- Axiom count 3→2: `grassmannian_maps_degree_1` doesn't exist in the Lean file
- Updated assumptions text, conclusion, and original contributions

## Test plan
- [ ] `pnpm build` passes
- [ ] Gallery page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)