### PR TITLE
fix: correct sorry/axiom counts for erdos-1145

### DIFF
--- a/src/data/proofs/erdos-1145/meta.json
+++ b/src/data/proofs/erdos-1145/meta.json
@@ -14,12 +14,12 @@
       "representation-functions",
       "open"
     ],
-    "sorries": 0,
+    "sorries": 2,
     "sourceUrl": "https://erdosproblems.com/1145",
     "erdosUrl": "https://erdosproblems.com/1145",
     "proofRepoPath": "Proofs/Erdos1145Problem.lean",
-    "axiomCount": 4,
-    "assumptions": "4 axioms: erdos_sarkozy_conjecture (main open conjecture), ruzsa_ratio_not_one, average_rep_grows, grekos_two_set. Eliminated 4 axioms: ruzsaA_infinite (proved via powers of 4), ruzsaB_infinite (proved via 2·4^k), sum_of_reps_bound (was vacuously true: RHS = 0), ruzsa_unique_rep (proved).",
+    "axiomCount": 3,
+    "assumptions": "3 axioms: erdos_sarkozy_conjecture (main open conjecture), average_rep_grows, grekos_two_set. 2 sorries: countingFn_ruzsaB (Set API bijection), ruzsa_ratio_not_one (needs witness at specific N). Eliminated 4 axioms: ruzsaA_infinite, ruzsaB_infinite, sum_of_reps_bound, ruzsa_unique_rep.",
     "badge": "axiom",
     "prerequisites": [
       "Additive number theory (sumsets, representation functions)",
@@ -133,7 +133,7 @@
     ]
   },
   "conclusion": {
-    "summary": "This formalization establishes the Erdős–Sárközy conjecture in Lean 4, connecting it to both the Erdős–Turán conjecture (Problem #28) as a special case and to Ruzsa's counterexample (Problem #331) showing the ratio condition is necessary. All 10 theorems are proved without sorry; the open conjecture and known results are axiomatized.",
+    "summary": "This formalization establishes the Erdős–Sárközy conjecture in Lean 4, connecting it to both the Erdős–Turán conjecture (Problem #28) as a special case and to Ruzsa's counterexample (Problem #331) showing the ratio condition is necessary. 8 of 10 theorems are proved; 2 sorries remain in the Ruzsa counting function section. The open conjecture and known results are axiomatized.",
     "implications": "A proof of this conjecture would simultaneously resolve the Erdős–Turán conjecture ($500 bounty), since it is strictly stronger. The formalization makes precise exactly what condition distinguishes the true conjecture from its false generalization.",
     "openQuestions": [
       "Can the asymptotic ratio condition aₙ/bₙ → 1 be weakened while preserving the conjecture?",
@@ -187,8 +187,8 @@
       "Pointwise"
     ],
     "namespace": "Erdos1145",
-    "lineCount": 552,
-    "axiomCount": 4,
+    "lineCount": 612,
+    "axiomCount": 3,
     "theoremCount": 10,
     "definitionCount": 10
   }


### PR DESCRIPTION
## Summary
- Sorry count 0→2: `countingFn_ruzsaB` (Set API bijection) and `ruzsa_ratio_not_one` (needs witness) have sorries
- Axiom count 4→3: `ruzsa_ratio_not_one` is a theorem (with sorry), not an axiom
- leanFile.lineCount 552→612
- Fixed conclusion that overclaimed "All 10 theorems proved without sorry"

## Test plan
- [ ] `pnpm build` passes
- [ ] Gallery page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)