### PR TITLE
fix: correct sorry count and line count for erdos-434

### DIFF
--- a/src/data/proofs/erdos-434/meta.json
+++ b/src/data/proofs/erdos-434/meta.json
@@ -19,7 +19,7 @@
       "coin-problem"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 2,
     "erdosNumber": 434,
     "erdosUrl": "https://erdosproblems.com/434",
     "erdosProblemStatus": "solved",
@@ -69,8 +69,8 @@
       "Proved zero_representable, mem_representable, add_representable"
     ],
     "axiomCount": 4,
-    "lineCount": 328,
-    "assumptions": "4 axioms (kiss_2002, sylvester_frobenius, sylvester_count, frobenius_consecutive) and 5 sorries in theorems."
+    "lineCount": 372,
+    "assumptions": "4 axioms (kiss_2002, sylvester_frobenius, sylvester_count, frobenius_consecutive) and 2 sorries (nonrep_finite, topK_finite)."
   },
   "overview": {
     "historicalContext": "Erdős Problem #434 is closely related to the classical Frobenius problem (also called the coin problem or money changing problem). Given a set of positive integers with gcd = 1, only finitely many integers are non-representable as sums of elements from the set.\n\nThe Frobenius number is the largest such non-representable integer. For two coprime integers a and b, Sylvester proved in 1884 that this equals ab - a - b, and the count of non-representables is (a-1)(b-1)/2.\n\nProblem #434 asks a different question: not what is the largest non-representable integer, but which k-element subset of {1, ..., n} maximizes the COUNT of non-representable integers. Kiss (2002) proved that the answer is the 'top k' set: {n-k+1, ..., n}. Intuitively, using larger numbers creates more gaps in what's representable.\n\nThe problem connects to numerical semigroup theory, where the 'genus' of a semigroup (number of gaps) is a central invariant. Problem #434 asks which generators maximize the genus. The result is also remarkable from an optimization perspective: the greedy algorithm (always pick the largest available number) produces the provably optimal solution — a rare case in combinatorial optimization where greedy is exactly optimal.\n\nRamírez-Alfonsín (2005) showed that computing the Frobenius number for sets of 3 or more elements is NP-hard, making the clean explicit solution to the extremal problem all the more surprising.",
@@ -101,7 +101,7 @@
     ],
     "opens": [],
     "namespace": "Erdos434",
-    "lineCount": 310,
+    "lineCount": 372,
     "axiomCount": 4,
     "theoremCount": 15,
     "definitionCount": 10
@@ -217,7 +217,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #434 on the extremal Frobenius problem. Kiss (2002) proved that the 'top k' set {n-k+1, ..., n} maximizes the count of non-representable integers among all k-element subsets of {1, ..., n}. The proof has 5 sorries and 4 axioms (Kiss's theorem, Sylvester-Frobenius formula and count, consecutive Frobenius). Core representability theory (3 closure lemmas) and topK_5_2 are fully proved.",
+    "summary": "This formalization captures Erdős Problem #434 on the extremal Frobenius problem. Kiss (2002) proved that the 'top k' set {n-k+1, ..., n} maximizes the count of non-representable integers among all k-element subsets of {1, ..., n}. 2 sorries remain (finiteness lemmas) and 4 axioms (Kiss's theorem, Sylvester-Frobenius formula and count, consecutive Frobenius). Core representability theory and examples are fully proved.",
     "implications": "**Theoretical Significance**: The problem connects the classical Frobenius (coin) problem with extremal combinatorics and numerical semigroup theory.\n\nThe greedy approach of selecting largest elements is optimal, contrasting with many optimization problems where greedy fails. The result also connects to computational complexity: while the Frobenius problem for ≥ 3 elements is NP-hard, the extremal problem has a clean, explicit optimal solution.",
     "openQuestions": [
       "Exact formula for the maximum count of non-representables as a function of n and k?",


### PR DESCRIPTION
## Summary
- Sorry count 5→2: only `nonrep_finite` and `topK_finite` remain (3 former sorries now proved)
- Line count 328/310→372
- Updated assumptions and conclusion text

## Test plan
- [ ] `pnpm build` passes
- [ ] Gallery page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)