### PR TITLE
fix: correct sorry counts for erdos-43 and pascals-hexagon

### DIFF
--- a/src/data/proofs/erdos-43/meta.json
+++ b/src/data/proofs/erdos-43/meta.json
@@ -16,7 +16,7 @@
       "difference-sets"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "erdosNumber": 43,
     "erdosUrl": "https://erdosproblems.com/43",
     "erdosProblemStatus": "open",
@@ -66,12 +66,12 @@
       "sidon_pair_bound: $\\binom{|A|}{2} \\le N$",
       "disjoint_diff_combined_bound: combined bound under disjoint differences",
       "tao_equal_size_bound: $m^2 \\le 2N+1$ when $|A|=|B|=m$",
-      "sidon_diff_count: $|A-A| = |A|^2 - |A| + 1$ (sorry)",
-      "disjoint_diff_total: combined difference count (sorry)"
+      "sidon_diff_count: $|A-A| = |A|^2 - |A| + 1$ (proved)",
+      "disjoint_diff_total: combined difference count (proved)"
     ],
     "axiomCount": 3,
-    "lineCount": 263,
-    "assumptions": "3 axioms (maxSidonSize, sidon_size_asymptotic, barreto_counterexample). 2 sorries."
+    "lineCount": 312,
+    "assumptions": "3 axioms (maxSidonSize, sidon_size_asymptotic, barreto_counterexample). 0 sorries — all theorems proved."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #43** ($100 bounty)\n\nThis is one of Erdős's celebrated prize problems in additive combinatorics, concerning the structure of **Sidon sets** (also called $B_2$ sets) under a disjoint difference constraint.\n\n**Historical Development:**\n- **Erdős & Turán (1941):** Proved $f(N) \\le \\sqrt{N} + O(N^{1/4})$ and constructed Sidon sets achieving $f(N) \\ge \\sqrt{N} - O(N^{1/4})$ using Singer difference sets from finite projective planes. This established $f(N) \\sim \\sqrt{N}$.\n- **Chowla (1944):** Simplified the Singer construction, showing explicit Sidon sets of size $\\sim \\sqrt{p}$ for primes $p$.\n- **Erdős (1950s-1970s):** Posed Problem #43 asking whether two Sidon sets with disjoint nonzero differences are \"complementary\" — their combined pair count cannot exceed what a single optimal Sidon set achieves, up to $O(1)$.\n- **Tao:** Proved partial results for the equal-size case: if $|A| = |B| = m$, then $m \\le (1/\\sqrt{2} + o(1))\\sqrt{N}$.\n- **Barreto:** Showed the equal-size variant with a multiplicative savings factor $(1-c)$ is false for infinitely many $N$.\n\n**Mathematical Context:**\nThe problem sits at the intersection of additive combinatorics and extremal set theory. Sidon sets are fundamental objects: a set $A \\subseteq \\{1,\\ldots,N\\}$ is Sidon if all pairwise sums $a + b$ ($a \\le b$) are distinct, equivalently if all nonzero differences are distinct. The maximum size $f(N) \\sim \\sqrt{N}$ arises because a Sidon set of size $m$ produces $\\binom{m}{2}$ distinct sums in $\\{2,\\ldots,2N\\}$, giving $\\binom{m}{2} \\lesssim N$. Problem #43 asks whether this constraint is tight even when the difference space is partitioned between two sets.",
@@ -180,7 +180,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #43 ($100 bounty) asks whether two Sidon sets with disjoint nonzero differences satisfy $\\binom{|A|}{2} + \\binom{|B|}{2} \\le \\binom{f(N)}{2} + O(1)$. The formalization captures the full landscape: the main OPEN conjecture, the equal-size variant (disproved by Barreto), Tao's partial bound $m \\le 0.707\\sqrt{N}$, and the underlying counting arguments. Two `sorry` placeholders remain for the counting lemmas (sidon_diff_count, disjoint_diff_total).",
+    "summary": "Erdős Problem #43 ($100 bounty) asks whether two Sidon sets with disjoint nonzero differences satisfy $\\binom{|A|}{2} + \\binom{|B|}{2} \\le \\binom{f(N)}{2} + O(1)$. The formalization captures the full landscape: the main OPEN conjecture, the equal-size variant (disproved by Barreto), Tao's partial bound $m \\le 0.707\\sqrt{N}$, and the counting arguments (all proved). 3 axioms remain for the open conjecture and known results.",
     "implications": "**Theoretical Significance**: **Mathematical Connections**\n\n1. **Extremal set theory:** The conjecture asks whether the Sidon property under difference-disjointness exhibits a sharp \"complementarity\" phenomenon\n**2. Additive combinatorics:** Connects to $B_2$ sequence theory and sumset problems\n3. **Erdős Problem #30:** The $f(N)$ asymptotic is a $1000 prize problem; sharper bounds on $f(N)$ would refine the conjecture\n4. **Multiplicative analogues:** Erdős Problem #425 studies the multiplicative Sidon version $F(n) = \\pi(n) + \\Theta(n^{3/4}(\\log n)^{-3/2})$.",
     "openQuestions": [
       "Does $\\binom{|A|}{2} + \\binom{|B|}{2} \\le \\binom{f(N)}{2} + O(1)$ hold for all Sidon sets with disjoint differences?",
@@ -281,7 +281,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 263,
+    "lineCount": 312,
     "axiomCount": 3,
     "theoremCount": 6,
     "definitionCount": 5

--- a/src/data/proofs/pascals-hexagon/meta.json
+++ b/src/data/proofs/pascals-hexagon/meta.json
@@ -19,7 +19,7 @@
       "classic"
     ],
     "badge": "axiom",
-    "sorries": 8,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Mathlib.LinearAlgebra.CrossProduct",
@@ -46,7 +46,7 @@
     ],
     "dateAdded": "2025-12-29",
     "leanFile": {
-      "lineCount": 791,
+      "lineCount": 581,
       "structures": 1,
       "axioms": 1,
       "theorems": 26,
@@ -54,8 +54,8 @@
       "instances": 0
     },
     "axiomCount": 1,
-    "lineCount": 791,
-    "assumptions": "1 axiom (conic_implies_pascal_constraint). 8 sorries in axiom-elimination research theorems.",
+    "lineCount": 581,
+    "assumptions": "1 axiom (conic_implies_pascal_constraint). 0 sorries — all theorems proved.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Summary
- **erdos-43**: sorry count 2→0 (`sidon_diff_count` and `disjoint_diff_total` both proved), line count 263→312
- **pascals-hexagon**: sorry count 8→0 (all research theorems proved), line count 791→581

Both proofs are in better shape than their meta.json claimed.

## Test plan
- [ ] `pnpm build` passes
- [ ] Gallery pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)