### PR TITLE
chore: sync research listings and data

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -8909,11 +8909,12 @@
     },
     {
       "slug": "erdos-1-oq-02",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T08:52:08.740Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T08:52:08.740Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T11:26:01.134Z",
+      "completed": "2026-03-30T11:26:01.134Z"
     },
     {
       "slug": "erdos-100-oq-01",
@@ -9058,11 +9059,12 @@
     },
     {
       "slug": "buffons-needle-oq-02-oq-02",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T08:52:08.782Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T08:52:08.782Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T11:26:01.184Z",
+      "completed": "2026-03-30T11:26:01.184Z"
     },
     {
       "slug": "cantor-diagonalization-oq-03-oq-01",
@@ -9093,11 +9095,12 @@
     },
     {
       "slug": "erdos-1006-oq-03",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T08:52:08.782Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T08:52:08.782Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T11:26:01.185Z",
+      "completed": "2026-03-30T11:26:01.184Z"
     },
     {
       "slug": "erdos-1012-oq-03",


### PR DESCRIPTION
## Summary
- Sync research-listings.json with actual iteration counts (added 37, updated 540 listings)
- Total iterations: 3181

Automated sync by deployer agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)