### PR TITLE
Research: prove linesMeet_iff_linesMeet' in Hilbert 15 Schubert Calculus

### DIFF
--- a/proofs/Proofs/Hilbert15SchubertCalculus.lean
+++ b/proofs/Proofs/Hilbert15SchubertCalculus.lean
@@ -1,6 +1,7 @@
 import Mathlib.LinearAlgebra.Dimension.Finrank
 import Mathlib.LinearAlgebra.Dimension.DivisionRing
 import Mathlib.LinearAlgebra.FreeModule.Finite.Basic
+import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
 import Mathlib.Data.Fin.VecNotation
 import Mathlib.Data.Set.Card
 import Mathlib.Algebra.Field.Basic
@@ -37,6 +38,7 @@ The problem was resolved through:
 - Grassmannian Gr(k,n) defined as k-dimensional subspaces
 - Lines in projective 3-space as Gr(2,4)
 - Incidence conditions for lines meeting
+- Equivalence of two definitions of lines meeting (dimension formula)
 
 ### Axiomatized (Requires Algebraic Geometry)
 - The Four Lines Theorem (exactly 2 transversals)
@@ -136,9 +138,27 @@ def LinesMeet {K : Type*} [DivisionRing K] (L₁ L₂ : LineInP3 K) : Prop :=
 def LinesMeet' {K : Type*} [DivisionRing K] (L₁ L₂ : LineInP3 K) : Prop :=
   finrank K (L₁.val ⊔ L₂.val : Submodule K (Fin 4 → K)) < 4
 
-/-- The two definitions of lines meeting are equivalent (axiomatized) -/
-axiom linesMeet_iff_linesMeet' {K : Type*} [Field K] (L₁ L₂ : LineInP3 K) :
-    LinesMeet L₁ L₂ ↔ LinesMeet' L₁ L₂
+/-- The two definitions of lines meeting are equivalent.
+
+Proof: By the Grassmann dimension formula for subspaces,
+  dim(V + W) + dim(V ∩ W) = dim(V) + dim(W) = 2 + 2 = 4.
+So dim(V + W) < 4 iff dim(V ∩ W) > 0 iff V ∩ W ≠ {0}. -/
+theorem linesMeet_iff_linesMeet' {K : Type*} [Field K] (L₁ L₂ : LineInP3 K) :
+    LinesMeet L₁ L₂ ↔ LinesMeet' L₁ L₂ := by
+  simp only [LinesMeet, LinesMeet', SubspacesMeet]
+  have hdim := Submodule.finrank_sup_add_finrank_inf_eq L₁.val L₂.val
+  rw [L₁.property, L₂.property] at hdim
+  -- hdim : finrank K ↥(L₁.val ⊔ L₂.val) + finrank K ↥(L₁.val ⊓ L₂.val) = 2 + 2
+  constructor
+  · -- (V ∩ W ≠ ⊥) → (dim(V + W) < 4)
+    intro hne
+    suffices h : 0 < finrank K ↥(L₁.val ⊓ L₂.val) by omega
+    rw [Nat.pos_iff_ne_zero, ne_eq, Submodule.finrank_eq_zero]
+    exact hne
+  · -- (dim(V + W) < 4) → (V ∩ W ≠ ⊥)
+    intro hlt hbot
+    have : finrank K ↥(L₁.val ⊓ L₂.val) = 0 := Submodule.finrank_eq_zero.mpr hbot
+    omega
 
 /-! ═══════════════════════════════════════════════════════════════════════════════
 PART III: THE FOUR LINES THEOREM

--- a/src/data/proofs/hilbert-15/meta.json
+++ b/src/data/proofs/hilbert-15/meta.json
@@ -43,9 +43,9 @@
     "dateAdded": "2025-12-29",
     "hilbertNumber": 15,
     "proofRepoPath": "Proofs/Hilbert15SchubertCalculus.lean",
-    "axiomCount": 8,
-    "lineCount": 452,
-    "assumptions": "8 axioms: linesMeet_iff_linesMeet', four_lines_theorem, transversal_count, schubert_basis_theorem, littlewoodRichardsonCoeff, littlewood_richardson_rule, pieris_rule, sigma1_fourth_power.",
+    "axiomCount": 7,
+    "lineCount": 472,
+    "assumptions": "7 axioms: four_lines_theorem, transversal_count, schubert_basis_theorem, littlewoodRichardsonCoeff, littlewood_richardson_rule, pieris_rule, sigma1_fourth_power. linesMeet_iff_linesMeet' was proved from Mathlib's Grassmann dimension formula.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -89,7 +89,7 @@
       "title": "Part II: Lines in P³",
       "startLine": 106,
       "endLine": 142,
-      "summary": "Defines LineInP3 as Gr(2,4), SubspacesMeet (V ⊓ W ≠ ⊥), LinesMeet, LinesMeet' (finrank of span < 4), and axiomatizes their equivalence."
+      "summary": "Defines LineInP3 as Gr(2,4), SubspacesMeet (V ⊓ W ≠ ⊥), LinesMeet, LinesMeet' (finrank of span < 4), and proves their equivalence via the Grassmann dimension formula."
     },
     {
       "id": "four-lines",
@@ -165,6 +165,7 @@
       "Mathlib.LinearAlgebra.Dimension.Finrank",
       "Mathlib.LinearAlgebra.Dimension.DivisionRing",
       "Mathlib.LinearAlgebra.FreeModule.Finite.Basic",
+      "Mathlib.LinearAlgebra.FiniteDimensional.Lemmas",
       "Mathlib.Data.Fin.VecNotation",
       "Mathlib.Data.Set.Card",
       "Mathlib.Algebra.Field.Basic",
@@ -178,9 +179,9 @@
       "FiniteDimensional"
     ],
     "namespace": "Hilbert15",
-    "lineCount": 452,
-    "axiomCount": 8,
-    "theoremCount": 3,
+    "lineCount": 472,
+    "axiomCount": 7,
+    "theoremCount": 4,
     "definitionCount": 14
   },
   "references": [


### PR DESCRIPTION
## Summary
- Prove `linesMeet_iff_linesMeet'` axiom from Mathlib, reducing axiom count from 8 to 7
- Uses Grassmann dimension formula: `dim(V + W) + dim(V ∩ W) = dim(V) + dim(W) = 4`
- Key Mathlib lemmas: `Submodule.finrank_sup_add_finrank_inf_eq`, `Submodule.finrank_eq_zero`

## Progress
- **Axiom eliminated**: `linesMeet_iff_linesMeet'` — equivalence of two line-meeting definitions in P³
- **Proof technique**: For 2-dim subspaces V, W of K⁴, the Grassmann formula gives dim(V+W) + dim(V∩W) = 4, so dim(V+W) < 4 iff V∩W ≠ {0}
- **Remaining 7 axioms** require algebraic geometry infrastructure not yet in Mathlib (Chow rings, Bézout's theorem, cohomology, Schubert varieties)

## Files Modified
- `proofs/Proofs/Hilbert15SchubertCalculus.lean` — axiom → theorem + new import
- `src/data/proofs/hilbert-15/meta.json` — axiomCount 8→7, theoremCount 3→4

## Status
**Outcome**: progress (axiom elimination)
**Next Steps**: Define Littlewood-Richardson coefficients computationally to eliminate `littlewoodRichardsonCoeff` and `sigma1_fourth_power` axioms

**Note**: Docker was unavailable for local build verification. The proof uses confirmed Mathlib API names (`Submodule.finrank_eq_zero`, `Nat.pos_iff_ne_zero`, `Submodule.finrank_sup_add_finrank_inf_eq`) but should be verified.

🤖 Generated by researcher-6