### PR TITLE
Research: 3 problems — eliminate 2 sorries, 1 axiom

### DIFF
--- a/proofs/Proofs/Erdos25LogDensity.lean
+++ b/proofs/Proofs/Erdos25LogDensity.lean
@@ -542,13 +542,152 @@ theorem logDensity_odds : HasLogDensity {n : ℕ | Odd n} (1/2) := by
   refine Filter.Tendsto.congr' ?_ (Tendsto.sub hfull hevens)
   exact hev_split.mono (fun N hN => hN.symm)
 
-/-- **Axiom: Numbers ≢ 0 (mod m) have log density (m-1)/m**.
+/-- ⌊N/m⌋ → ∞ as N → ∞ for any fixed m ≥ 1. -/
+private theorem tendsto_nat_div_m (m : ℕ) (hm : 1 ≤ m) :
+    Tendsto (fun n : ℕ => n / m) atTop atTop := by
+  rw [Filter.tendsto_atTop_atTop]
+  intro b; exact ⟨m * b, fun n hn => by omega⟩
 
-Generalizes: avoiding one residue class mod m removes 1/m of the density.
+/-- log(⌊N/m⌋) / log(N) → 1 as N → ∞ for any fixed m ≥ 2.
+    Proof: squeeze between 1 - log(2m)/log(N) and 1. -/
+private theorem tendsto_log_div_m_div_log (m : ℕ) (hm : 2 ≤ m) :
+    Tendsto (fun N : ℕ => Real.log (↑(N / m) : ℝ) / Real.log (↑N)) atTop (nhds 1) := by
+  have hlog_atTop : Tendsto (fun N : ℕ => Real.log (↑N : ℝ)) atTop atTop :=
+    Tendsto.comp tendsto_log_atTop tendsto_natCast_atTop_atTop
+  rw [show (1 : ℝ) = 1 - 0 from by ring]
+  have h_eq : (fun N : ℕ => 1 - (Real.log (↑N) - Real.log (↑(N / m) : ℝ)) / Real.log (↑N))
+      =ᶠ[atTop] (fun N : ℕ => Real.log (↑(N / m) : ℝ) / Real.log (↑N)) := by
+    filter_upwards [eventually_gt_atTop 1] with N hN
+    have hlog : Real.log (↑N : ℝ) ≠ 0 :=
+      Real.log_ne_zero_of_pos_of_ne_one (by positivity) (ne_of_gt (by exact_mod_cast hN))
+    field_simp; ring
+  apply Filter.Tendsto.congr' h_eq
+  apply Tendsto.sub tendsto_const_nhds
+  apply squeeze_zero_norm'
+  · filter_upwards [eventually_ge_atTop (2 * m)] with N (hN : 2 * m ≤ N)
+    have hNm_pos : (0 : ℝ) < ↑(N / m) := by exact_mod_cast (show 0 < N / m by omega)
+    have hNr_pos : (0 : ℝ) < ↑N := by exact_mod_cast (show 0 < N by omega)
+    have hlog_pos : 0 < Real.log (↑N : ℝ) :=
+      Real.log_pos (by exact_mod_cast (show 1 < N by omega))
+    have h_sub_nn : 0 ≤ Real.log (↑N : ℝ) - Real.log (↑(N / m) : ℝ) := by
+      apply sub_nonneg.mpr; apply Real.log_le_log hNm_pos
+      exact_mod_cast (Nat.div_le_self N m)
+    rw [Real.norm_eq_abs, abs_of_nonneg (div_nonneg h_sub_nn hlog_pos.le)]
+    simp only [div_eq_mul_inv]
+    apply mul_le_mul_of_nonneg_right _ (inv_nonneg.mpr hlog_pos.le)
+    calc Real.log (↑N : ℝ) - Real.log (↑(N / m) : ℝ)
+        = Real.log ((↑N : ℝ) / ↑(N / m)) :=
+          (Real.log_div (ne_of_gt hNr_pos) (ne_of_gt hNm_pos)).symm
+      _ ≤ Real.log (2 * m) := by
+          apply Real.log_le_log (div_pos hNr_pos hNm_pos)
+          -- N/(N/m) ≤ 2m: since N ≤ 2m * (N/m), dividing by N/m gives ≤ 2m
+          rw [div_le_iff hNm_pos]
+          push_cast [Nat.cast_le]
+          -- Need: ↑N ≤ 2 * ↑m * ↑(N / m) in ℝ, from ℕ inequality
+          have hnat : N ≤ 2 * m * (N / m) := by
+            have := Nat.div_add_mod N m
+            have := Nat.mod_lt N (show 0 < m by omega)
+            nlinarith [Nat.le_div_iff_mul_le (show 0 < m by omega) |>.mpr (by omega : 2 * m ≤ N)]
+          exact_mod_cast hnat
+  · exact Tendsto.div_atTop tendsto_const_nhds hlog_atTop
 
-**Proof status**: HARD (~80 lines) - requires summing over residue classes. -/
-axiom logDensity_avoid_one_residue (m : ℕ) (hm : 2 ≤ m) :
-    HasLogDensity {n : ℕ | n ≠ 0 ∧ ¬(m ∣ n)} ((m - 1 : ℝ) / m)
+/-- H_{⌊N/m⌋} / log(N) → 1 as N → ∞.
+    Factors as (H_{N/m} / log(N/m)) · (log(N/m) / log(N)), both → 1. -/
+private theorem tendsto_harmonicSum_div_m_div_log (m : ℕ) (hm : 2 ≤ m) :
+    Tendsto (fun N : ℕ => harmonicSum (N / m) / Real.log (↑N)) atTop (nhds 1) := by
+  have hfactor : (fun N : ℕ => harmonicSum (N / m) / Real.log (↑(N / m) : ℝ) *
+      (Real.log (↑(N / m) : ℝ) / Real.log (↑N))) =ᶠ[atTop]
+      (fun N : ℕ => harmonicSum (N / m) / Real.log (↑N)) := by
+    filter_upwards [eventually_ge_atTop (2 * m + 2)] with N hN
+    have hlog : Real.log (↑(N / m) : ℝ) ≠ 0 := by
+      have h2 : 1 < (↑(N / m) : ℝ) := by exact_mod_cast (show 1 < N / m by omega)
+      exact ne_of_gt (Real.log_pos h2)
+    field_simp
+  rw [show (1 : ℝ) = 1 * 1 from by ring]
+  exact Filter.Tendsto.congr' hfactor
+    (Tendsto.mul
+      (tendsto_harmonic_div_log.comp (tendsto_nat_div_m m (by omega)))
+      (tendsto_log_div_m_div_log m hm))
+
+/-- The weighted count of multiples of m equals (1/m) · H_{⌊N/m⌋}. -/
+theorem logWeightedCount_multiples (m : ℕ) (hm : 1 ≤ m) (N : ℕ) :
+    logWeightedCount {n : ℕ | m ∣ n ∧ n ≠ 0} N = (1 / (m : ℝ)) * harmonicSum (N / m) := by
+  induction N with
+  | zero => simp [logWeightedCount, harmonicSum, harmonic_zero]
+  | succ n ih =>
+    rw [logWeightedCount_succ]
+    by_cases hdvd : m ∣ (n + 1)
+    · have hmem : (n + 1) ∈ {k : ℕ | m ∣ k ∧ k ≠ 0} ∧ (n + 1) ≠ 0 :=
+        ⟨⟨hdvd, Nat.succ_ne_zero n⟩, Nat.succ_ne_zero n⟩
+      rw [if_pos hmem, ih]
+      have hdiv : (n + 1) / m = n / m + 1 := by
+        rw [Nat.succ_div n m, if_pos hdvd]
+      rw [hdiv, harmonicSum_succ', mul_add]
+      congr 1
+      obtain ⟨k, hk⟩ := hdvd
+      have hk_pos : 0 < k := by omega
+      have h_eq : (↑(n + 1) : ℝ) = (m : ℝ) * ((↑(n / m) : ℝ) + 1) := by
+        have : n / m + 1 = k := by rw [Nat.succ_div n m, if_pos hdvd]; ring
+        rw [this]; push_cast; linarith [hk]
+      rw [h_eq]; field_simp
+    · have hmem : ¬((n + 1) ∈ {k : ℕ | m ∣ k ∧ k ≠ 0} ∧ (n + 1) ≠ 0) := by
+        intro ⟨⟨hd, _⟩, _⟩; exact hdvd hd
+      rw [if_neg hmem, add_zero, ih]
+      have hdiv : (n + 1) / m = n / m := by
+        rw [Nat.succ_div n m, if_neg hdvd, add_zero]
+      rw [hdiv]
+
+/-- Multiples and non-multiples of m partition ℕ⁺. -/
+private theorem multiples_partition (m : ℕ) (hm : 1 ≤ m) :
+    (Set.univ : Set ℕ) \ {0} = {n : ℕ | n ≠ 0 ∧ m ∣ n} ∪ {n : ℕ | n ≠ 0 ∧ ¬(m ∣ n)} := by
+  ext n; simp only [Set.mem_diff, Set.mem_univ, Set.mem_singleton_iff, true_and,
+    Set.mem_union, Set.mem_setOf_eq]
+  tauto
+
+/-- Multiples and non-multiples of m are disjoint. -/
+private theorem multiples_disjoint (m : ℕ) :
+    Disjoint {n : ℕ | n ≠ 0 ∧ m ∣ n} {n : ℕ | n ≠ 0 ∧ ¬(m ∣ n)} := by
+  rw [Set.disjoint_left]; intro n ⟨_, hd⟩ ⟨_, hnd⟩; exact hnd hd
+
+/-- **Numbers ≢ 0 (mod m) have log density (m-1)/m**.
+    Proof: multiples of m have density 1/m (via weighted count = (1/m)·H_{⌊N/m⌋}),
+    so non-multiples have density 1 - 1/m = (m-1)/m by complementation. -/
+theorem logDensity_avoid_one_residue (m : ℕ) (hm : 2 ≤ m) :
+    HasLogDensity {n : ℕ | n ≠ 0 ∧ ¬(m ∣ n)} ((m - 1 : ℝ) / m) := by
+  -- First prove multiples of m have density 1/m
+  have h_mult : HasLogDensity {n : ℕ | n ≠ 0 ∧ m ∣ n} (1 / m) := by
+    unfold HasLogDensity logDensityRatio
+    have h_eq : (fun N : ℕ => (1 / (m : ℝ)) * (harmonicSum (N / m) / Real.log (↑N)))
+        =ᶠ[atTop] (fun N => if N ≤ 1 then (0 : ℝ)
+          else logWeightedCount {n : ℕ | n ≠ 0 ∧ m ∣ n} N / Real.log (↑N)) := by
+      filter_upwards [eventually_gt_atTop 1] with N hN
+      simp only [show ¬(N ≤ 1) by omega, ↓reduceIte]
+      -- Swap the set to match logWeightedCount_multiples
+      have hset : {n : ℕ | n ≠ 0 ∧ m ∣ n} = {n : ℕ | m ∣ n ∧ n ≠ 0} := by ext; tauto
+      rw [hset, logWeightedCount_multiples m (by omega) N]; ring
+    exact Filter.Tendsto.congr' h_eq
+      (show Tendsto (fun N => (1 / (m : ℝ)) * (harmonicSum (N / m) / Real.log (↑N)))
+          atTop (nhds (1 / m)) from by
+        have h := Tendsto.mul (tendsto_const_nhds (x := (1 / (m : ℝ))))
+          (tendsto_harmonicSum_div_m_div_log m hm)
+        simp only [mul_one] at h; exact h)
+  -- Then use complement splitting: density(non-mult) = 1 - 1/m = (m-1)/m
+  have hfull := logDensity_full
+  have hunion := multiples_partition m (by omega)
+  have hdisj := multiples_disjoint m
+  suffices h : HasLogDensity {n : ℕ | n ≠ 0 ∧ ¬(m ∣ n)} (1 - 1 / (m : ℝ)) by
+    convert h using 1; field_simp
+  unfold HasLogDensity at *
+  have hev_split : ∀ᶠ N in atTop,
+      logDensityRatio {n : ℕ | n ≠ 0 ∧ ¬(m ∣ n)} N =
+      logDensityRatio (Set.univ \ {0}) N - logDensityRatio {n | n ≠ 0 ∧ m ∣ n} N := by
+    filter_upwards [eventually_gt_atTop 1] with N hN
+    have h1 : ¬(N ≤ 1) := by omega
+    unfold logDensityRatio
+    simp only [h1, ↓reduceIte]
+    rw [hunion, logWeightedCount_union_disjoint hdisj N, add_div]; ring
+  exact Filter.Tendsto.congr' (hev_split.mono (fun N hN => hN.symm))
+    (Tendsto.sub hfull h_mult)
 
 /- ## Part VI: Connection to Natural Density -/
 

--- a/proofs/Proofs/HeronsFormulaOQ01.lean
+++ b/proofs/Proofs/HeronsFormulaOQ01.lean
@@ -144,10 +144,41 @@ theorem isoperimetric_quadrilateral {a b c d : ℝ}
     (h2 : b + c + d > a) (h3 : a + c + d > b)
     (h4 : a + b + d > c) (h5 : a + b + c > d) :
     brahmaguptaProduct a b c d ≤ ((a + b + c + d) / 4) ^ 4 := by
-  -- By AM-GM⁴: (s-a)(s-b)(s-c)(s-d) ≤ ((s-a+s-b+s-c+s-d)/4)⁴ = (s/2)⁴
-  -- since (s-a)+(s-b)+(s-c)+(s-d) = 2s. And (s/2)⁴ = ((a+b+c+d)/4)⁴.
-  -- Proof requires three applications of AM-GM for 2 variables.
-  sorry
+  -- By repeated 2-variable AM-GM: xy ≤ ((x+y)/2)² from (x-y)² ≥ 0.
+  -- Applied three times to get the 4-variable version.
+  unfold brahmaguptaProduct semiperimeter
+  set sa := (a + b + c + d) / 2 - a with hsa_def
+  set sb := (a + b + c + d) / 2 - b with hsb_def
+  set sc := (a + b + c + d) / 2 - c with hsc_def
+  set sd := (a + b + c + d) / 2 - d with hsd_def
+  have hsa : 0 < sa := by rw [hsa_def]; linarith
+  have hsb : 0 < sb := by rw [hsb_def]; linarith
+  have hsc : 0 < sc := by rw [hsc_def]; linarith
+  have hsd : 0 < sd := by rw [hsd_def]; linarith
+  -- Sum identities
+  have hab_sum : sa + sb = c + d := by rw [hsa_def, hsb_def]; ring
+  have hcd_sum : sc + sd = a + b := by rw [hsc_def, hsd_def]; ring
+  have hfinal : sa + sb + sc + sd = a + b + c + d := by
+    rw [hsa_def, hsb_def, hsc_def, hsd_def]; ring
+  -- AM-GM step 1: sa·sb ≤ ((sa+sb)/2)²
+  have hab : sa * sb ≤ ((sa + sb) / 2) ^ 2 := by nlinarith [sq_nonneg (sa - sb)]
+  -- AM-GM step 2: sc·sd ≤ ((sc+sd)/2)²
+  have hcd : sc * sd ≤ ((sc + sd) / 2) ^ 2 := by nlinarith [sq_nonneg (sc - sd)]
+  -- Combine pairs
+  have hprod : sa * sb * (sc * sd) ≤ ((sa + sb) / 2) ^ 2 * ((sc + sd) / 2) ^ 2 :=
+    mul_le_mul hab hcd (mul_nonneg hsc.le hsd.le) (by positivity)
+  -- AM-GM step 3: ((sa+sb)/2)·((sc+sd)/2) ≤ ((sa+sb+sc+sd)/4)²
+  have hpair : ((sa + sb) / 2) * ((sc + sd) / 2) ≤ ((sa + sb + sc + sd) / 4) ^ 2 := by
+    nlinarith [sq_nonneg ((sa + sb) / 2 - (sc + sd) / 2)]
+  -- Chain: sa·sb·sc·sd ≤ ((sa+sb)/2)²·((sc+sd)/2)² = (product)² ≤ ((sum/4)²)² = (sum/4)⁴
+  calc sa * sb * sc * sd
+      = sa * sb * (sc * sd) := by ring
+    _ ≤ ((sa + sb) / 2) ^ 2 * ((sc + sd) / 2) ^ 2 := hprod
+    _ = (((sa + sb) / 2) * ((sc + sd) / 2)) ^ 2 := by ring
+    _ ≤ (((sa + sb + sc + sd) / 4) ^ 2) ^ 2 :=
+        pow_le_pow_left (by positivity) hpair 2
+    _ = ((sa + sb + sc + sd) / 4) ^ 4 := by ring
+    _ = ((a + b + c + d) / 4) ^ 4 := by rw [hfinal]
 
 -- ════════════════════════════════════════════════════════════════
 -- PART VII: The Brahmagupta Formula (Axiomatized)

--- a/src/data/proofs/erdos-25/meta.json
+++ b/src/data/proofs/erdos-25/meta.json
@@ -20,9 +20,9 @@
     "erdosNumber": 25,
     "erdosUrl": "https://erdosproblems.com/25",
     "erdosProblemStatus": "open",
-    "axiomCount": 4,
+    "axiomCount": 3,
     "lineCount": 166,
-    "assumptions": "4 axioms (from imported Erdos25LogDensity.lean): logDensity_avoid_one_residue, naturalDensity_implies_logDensity, exists_logDensity_no_naturalDensity, davenport_erdos. Main file has 0 direct axioms and 0 sorries.",
+    "assumptions": "3 axioms (from imported Erdos25LogDensity.lean): naturalDensity_implies_logDensity, exists_logDensity_no_naturalDensity, davenport_erdos. logDensity_avoid_one_residue PROVED via complement splitting and weighted count computation. Main file has 0 direct axioms and 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/herons-formula-oq-01/meta.json
+++ b/src/data/proofs/herons-formula-oq-01/meta.json
@@ -17,7 +17,7 @@
       "open-question"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 1,
     "assumptions": "1 axiom: Brahmagupta's formula for inscribed quadrilaterals (requires cyclic quadrilateral definition and diagonal angle analysis). 1 sorry: isoperimetric inequality (AM-GM for 4 variables).",
     "mathlibDependencies": [
@@ -37,7 +37,7 @@
       "Concrete examples: 3-4-5, unit square, 2x3 rectangle"
     ],
     "dateAdded": "2026-03-30",
-    "lineCount": 193,
+    "lineCount": 224,
     "theoremCount": 13,
     "definitionCount": 3,
     "prerequisites": [
@@ -48,7 +48,7 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Brahmagupta, the great Indian mathematician-astronomer, discovered in 628 AD that Heron's formula for triangle area generalizes to cyclic quadrilaterals. For a quadrilateral inscribed in a circle with sides a, b, c, d and semi-perimeter s = (a+b+c+d)/2, the area is sqrt((s-a)(s-b)(s-c)(s-d)). Setting d = 0 recovers Heron's formula. The formula holds only for cyclic (inscribed) quadrilaterals — for general quadrilaterals, the area depends on the diagonal angles.",
+    "historicalContext": "Brahmagupta, the great Indian mathematician-astronomer, discovered in 628 AD that Heron's formula for triangle area generalizes to cyclic quadrilaterals. For a quadrilateral inscribed in a circle with sides a, b, c, d and semi-perimeter s = (a+b+c+d)/2, the area is sqrt((s-a)(s-b)(s-c)(s-d)). Setting d = 0 recovers Heron's formula. The formula holds only for cyclic (inscribed) quadrilaterals \u2014 for general quadrilaterals, the area depends on the diagonal angles.",
     "problemStatement": "For a cyclic quadrilateral with sides $a, b, c, d$ and semi-perimeter $s = (a+b+c+d)/2$:\n\n$$\\text{Area} = \\sqrt{(s-a)(s-b)(s-c)(s-d)}$$\n\nSpecial cases: setting $d = 0$ gives Heron's formula; equal sides gives the square area formula.",
     "text": "A 193-line formalization of Brahmagupta's formula for cyclic quadrilaterals. The Brahmagupta product (s-a)(s-b)(s-c)(s-d) is defined and its algebraic properties proved: expansion in terms of side lengths, cyclic and reversal symmetry, reduction to Heron's formula when d=0, non-negativity under quadrilateral inequalities, and exact formulas for rectangles (area = ab) and squares (area = a^2). Brahmagupta's formula itself is axiomatized (requires cyclic quadrilateral geometry). The isoperimetric inequality (square maximizes area for fixed perimeter) is stated with proof strategy via AM-GM.",
     "proofStrategy": "The algebraic properties are proved by ring arithmetic (unfold + ring). Non-negativity follows from the quadrilateral inequality constraints ensuring all four factors are non-negative. The reduction to Heron is a direct computation. Rectangle/square formulas follow by expanding and simplifying. The main formula is axiomatized because a full proof requires: (1) formalizing cyclic quadrilateral geometry, (2) applying the law of cosines to supplementary opposite angles, and (3) connecting to diagonal angles.",
@@ -158,7 +158,9 @@
       "Mathlib.Analysis.SpecialFunctions.Pow.Real",
       "Mathlib.Tactic"
     ],
-    "opens": ["Real"],
+    "opens": [
+      "Real"
+    ],
     "namespace": "Brahmagupta",
     "lineCount": 193,
     "axiomCount": 1,

--- a/src/data/research/problems/erdos-25.json
+++ b/src/data/research/problems/erdos-25.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-25",
-  "title": "Erdős #25",
+  "title": "Erd\u0151s #25",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "A",
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: Assessed and marked complete.",
+    "progressSummary": "PROGRESS: Eliminated logDensity_avoid_one_residue axiom (4\u21923 axioms). Proved via generalized weighted count for multiples + complement splitting.",
     "builtItems": [
       "Proved logWeightedCount_nonneg in Erdos25LogDensity.lean",
       "Proved logWeightedCount_mono in Erdos25LogDensity.lean",
@@ -55,7 +55,11 @@
       "Proved logDensity_mem_unit: d>=0 via ge_of_tendsto, d<=1 via limsup_le_limsup + harmonic ratio comparison",
       "Proved logDensity_unique via tendsto_nhds_unique in Erdos25Problem.lean",
       "PROVED finite_sieve_density_exists via exfalso (contradictory hypotheses, 4 lines)",
-      "REMOVED sieve_density_positive (false axiom, replaced with counterexample comment)"
+      "REMOVED sieve_density_positive (false axiom, replaced with counterexample comment)",
+      "Proved logDensity_avoid_one_residue: numbers not divisible by m have log density (m-1)/m",
+      "logWeightedCount_multiples: weighted count of multiples of m = (1/m) \u00b7 H_{\u230aN/m\u230b}",
+      "tendsto_log_div_m_div_log: log(\u230aN/m\u230b)/log(N) \u2192 1 (squeeze argument)",
+      "tendsto_harmonicSum_div_m_div_log: H_{\u230aN/m\u230b}/log(N) \u2192 1"
     ],
     "insights": [
       "The axiom logDensityRatio_bounded claiming ratio <= 1 for N >= 2 is mathematically incorrect since H_N/log N > 1 for all finite N",
@@ -65,12 +69,18 @@
       "The Problem file axiomatized logDensity separately from LogDensity files constructive HasLogDensity - unifying them eliminated 3 axioms at once",
       "d<=1 proof requires limsup comparison (not pointwise bound) because harmonicSum/log > 1 for all finite N",
       "sieved_set_nonempty axiom was unsound: false when seq_n 0 = 1 (mod 1 excludes everything)",
-      "finite_sieve_density_exists hypothesis (∀ i≥N, seq_n i = seq_n N) contradicts StrictMono seq_n — axiom proved vacuously via exfalso+omega",
-      "sieve_density_positive is mathematically false: prime sieve (seq_n=primes, seq_a=0) yields sieved set {1} with log density 0, not >0"
+      "finite_sieve_density_exists hypothesis (\u2200 i\u2265N, seq_n i = seq_n N) contradicts StrictMono seq_n \u2014 axiom proved vacuously via exfalso+omega",
+      "sieve_density_positive is mathematically false: prime sieve (seq_n=primes, seq_a=0) yields sieved set {1} with log density 0, not >0",
+      "logDensity_avoid_one_residue follows from complement splitting: full set (density 1) minus multiples (density 1/m) = non-multiples (density (m-1)/m)",
+      "logWeightedCount_multiples generalizes logWeightedCount_evens via Nat.succ_div for divisibility case splits"
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
-    "markdown": "# Erdős #25 - Knowledge Base\n\n## Problem Statement\n\nLet $n_1 View the LaTeX source\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 6/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #60\n- Problem #486\n- Problem #24\n- Problem #26\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er95\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
+    "nextSteps": [
+      "Prove naturalDensity_implies_logDensity: requires summation by parts / Abel summation (~100 lines)",
+      "Prove exists_logDensity_no_naturalDensity: requires explicit construction (~150 lines)",
+      "davenport_erdos: deep theorem, likely stays as axiom"
+    ],
+    "markdown": "# Erd\u0151s #25 - Knowledge Base\n\n## Problem Statement\n\nLet $n_1 View the LaTeX source\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 6/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #337\n- Problem #2000\n- Problem #60\n- Problem #486\n- Problem #24\n- Problem #26\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er95\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
   },
   "tags": [
     "erdos"


### PR DESCRIPTION
## Summary
- **erdos-485-oq-01**: Proved `lacunary_positive_lower_bound` — eliminates last sorry (1→0 sorries)
  - Two disjoint translated copies of support in support(p²), combined size 2k-1
- **erdos-25**: Proved `logDensity_avoid_one_residue` — eliminates axiom (4→3 axioms)
  - Numbers not divisible by m have log density (m-1)/m, via weighted count + complement splitting
- **herons-formula-oq-01**: Proved `isoperimetric_quadrilateral` — eliminates sorry (1→0 sorries)
  - 4-variable AM-GM via three applications of 2-variable AM-GM

## Delta
| Problem | Sorries | Axioms | Lines |
|---------|---------|--------|-------|
| erdos-485-oq-01 | 1→0 | 3 (unchanged) | 401→451 |
| erdos-25 (LogDensity) | 0 (unchanged) | 4→3 | 598→736 |
| herons-formula-oq-01 | 1→0 | 1 (unchanged) | 194→224 |

🤖 Generated by researcher-10