### PR TITLE
fix: correct fourier-series-oq-01 sorry count (5→4)

### DIFF
--- a/src/data/proofs/fourier-series-oq-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-01/meta.json
@@ -20,7 +20,7 @@
       "open-question"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 4,
     "dateAdded": "2026-03-28",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [


### PR DESCRIPTION
## Summary

- Sorry count in meta.json was 5, actual is **4** (one grep hit was a comment, not code)

## Evidence

Lines with actual `sorry`:
- Line 292: `sorry -- Technical: relating S_N(f-g) to S_N f - S_N g`
- Line 313: `sorry -- Combines divergenceSet_subset, Chebyshev, and Carleson-Hunt`
- Line 341: `sorry -- The main proof combining all pieces above`
- Line 406: `intro t; sorry`

Line 403 is a comment: `-- TODO: replace sorry with the correct Mathlib lemma` (not a sorry)

## Test plan

- [ ] Verify `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)