### PR TITLE
fix: correct sorry counts for erdos-1-oq-02 and erdos-1020

### DIFF
--- a/src/data/proofs/erdos-1-oq-02/meta.json
+++ b/src/data/proofs/erdos-1-oq-02/meta.json
@@ -18,10 +18,10 @@
       "berry-esseen"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "axiomCount": 1,
     "lineCount": 180,
-    "assumptions": "One axiom: anticoncentration_bound (Berry\u2013Esseen theorem for random subset sums). Three sorries: Cauchy\u2013Schwarz for sums, DFX bound assembly, f(1) DSS verification.",
+    "assumptions": "One axiom: anticoncentration_bound (Berry\u2013Esseen theorem for random subset sums). Two sorries remaining.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-1020/meta.json
+++ b/src/data/proofs/erdos-1020/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 1020,
     "erdosUrl": "https://erdosproblems.com/1020",
     "erdosProblemStatus": "open",


### PR DESCRIPTION
## Summary

- erdos-1-oq-02: sorry count 3→2 (one sorry eliminated)
- erdos-1020: sorry count 1→0 (all sorries eliminated)

## Test plan

- [ ] Verify `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)