### PR TITLE
fix: correct sorry counts for 5 proofs

### DIFF
--- a/src/data/proofs/dirichlets-theorem-oq-03/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "dirichlets-theorem-oq-03",
   "title": "Best Constant in Linnik's Theorem for Primes in Arithmetic Progressions",
   "slug": "dirichlets-theorem-oq-03",
-  "description": "Formalizes the Linnik constant L: the best exponent such that the least prime p \u2261 a (mod q) satisfies p \u2264 c\u00b7q^L. Current best: L \u2264 5 (Xylouris 2011). Conjectured: L = 1.",
+  "description": "Formalizes the Linnik constant L: the best exponent such that the least prime p ≡ a (mod q) satisfies p ≤ c·q^L. Current best: L ≤ 5 (Xylouris 2011). Conjectured: L = 1.",
   "meta": {
     "author": "Linnik (1944); Xylouris (2011)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Linnik%27s_theorem",
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "axiomCount": 2,
     "lineCount": 139
   },

--- a/src/data/proofs/erdos-138/meta.json
+++ b/src/data/proofs/erdos-138/meta.json
@@ -37,7 +37,7 @@
       "Proof schema: main conjecture implies ExponentialDiverges"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 4,
     "erdosNumber": 138,
     "erdosUrl": "https://erdosproblems.com/138",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-392/meta.json
+++ b/src/data/proofs/erdos-392/meta.json
@@ -17,7 +17,7 @@
       "number-theory"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 392,
     "erdosUrl": "https://erdosproblems.com/392",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-628/meta.json
+++ b/src/data/proofs/erdos-628/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 12,
+    "sorries": 11,
     "erdosNumber": 628,
     "erdosUrl": "https://erdosproblems.com/628",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-746/meta.json
+++ b/src/data/proofs/erdos-746/meta.json
@@ -19,7 +19,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 746,
     "erdosUrl": "https://erdosproblems.com/746",
     "erdosProblemStatus": "solved",


### PR DESCRIPTION
## Summary

Batch sorry count corrections — sorries were eliminated in code but meta.json wasn't updated.

| Proof | Old | New |
|-------|-----|-----|
| dirichlets-theorem-oq-03 | 3 | 2 |
| erdos-138 | 5 | 4 |
| erdos-392 | 3 | 2 |
| erdos-628 | 12 | 11 |
| erdos-746 | 3 | 2 |

## Test plan

- [ ] Verify `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)