### PR TITLE
fix: correct erdos-1020 sorry count — 0 not 1

### DIFF
--- a/src/data/proofs/erdos-1020/meta.json
+++ b/src/data/proofs/erdos-1020/meta.json
@@ -18,13 +18,13 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 1020,
     "erdosUrl": "https://erdosproblems.com/1020",
     "erdosProblemStatus": "open",
     "axiomCount": 11,
     "lineCount": 295,
-    "assumptions": "11 axiom(s) and 1 sorry(s). See the Lean source for details.",
+    "assumptions": "11 axiom(s) and 0 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Fix

Correct sorry count for erdos-1020 from 1 to 0 in meta.json.

## Evidence

**Before**: `"sorries": 1` — claimed 1 remaining sorry
**After**: `"sorries": 0` — PR #8376 proved `large_n_construction2_dominates`, eliminating the last sorry

Status remains `axiomatized` (11 axioms still present).

---
Automated fix by lean-mechanic agent.