### PR TITLE
Research: erdos-347 + hilbert-14-oq-01 + erdos-307-oq-02

### DIFF
--- a/proofs/Proofs/Erdos307Problem.lean
+++ b/proofs/Proofs/Erdos307Problem.lean
@@ -370,14 +370,84 @@ theorem no_size_two_solution :
       _ = 25 / 36 := by norm_num
   linarith
 
+/-- For 3 distinct primes, sum of reciprocals ≤ 1/2 + 1/3 + 1/5 = 31/30.
+    Proof: among 3 distinct primes, at least one ≥ 5 (only 2 primes < 5)
+    and among the other two, at least one ≥ 3 (only 1 prime < 3). -/
+private lemma reciprocal_sum_three_primes_le {Q : Finset ℕ} (hcard : Q.card = 3)
+    (hQ : IsSetOfPrimes Q) : reciprocalSum Q ≤ 31 / 30 := by
+  obtain ⟨c, t, hct, rfl, ht2⟩ := Finset.card_eq_succ.mp hcard
+  obtain ⟨a, b, hab, rfl⟩ := Finset.card_eq_two.mp ht2
+  simp only [Finset.mem_insert, Finset.mem_singleton, not_or] at hct
+  obtain ⟨hca, hcb⟩ := hct
+  have ha := hQ a (by simp)
+  have hb := hQ b (by simp)
+  have hc := hQ c (by simp)
+  have ha2 : (2 : ℚ) ≤ a := by exact_mod_cast ha.two_le
+  have hb2 : (2 : ℚ) ≤ b := by exact_mod_cast hb.two_le
+  have hc2 : (2 : ℚ) ≤ c := by exact_mod_cast hc.two_le
+  simp only [reciprocalSum, Finset.sum_insert hct, Finset.sum_pair hab]
+  -- At least one ≥ 5 (pigeonhole: only 2 primes < 5, namely {2, 3})
+  have h5 : 5 ≤ a ∨ 5 ≤ b ∨ 5 ≤ c := by
+    by_contra hall; push_neg at hall; obtain ⟨h5a, h5b, h5c⟩ := hall
+    have : a = 2 ∨ a = 3 := by have := ha.two_le; interval_cases a <;> simp_all
+    have : b = 2 ∨ b = 3 := by have := hb.two_le; interval_cases b <;> simp_all
+    have : c = 2 ∨ c = 3 := by have := hc.two_le; interval_cases c <;> simp_all
+    rcases ‹a = 2 ∨ a = 3› with rfl | rfl <;> rcases ‹b = 2 ∨ b = 3› with rfl | rfl <;>
+      rcases ‹c = 2 ∨ c = 3› with rfl | rfl <;> simp_all
+  -- Among any 2 distinct primes, one ≥ 3 (only 1 prime < 3)
+  have pair3 : ∀ x y : ℕ, Nat.Prime x → Nat.Prime y → x ≠ y →
+      (3 : ℚ) ≤ (x : ℚ) ∨ (3 : ℚ) ≤ (y : ℚ) := by
+    intro x y hx hy hxy; by_contra hall; push_neg at hall
+    have hx3 : x < 3 := by exact_mod_cast hall.1
+    have hy3 : y < 3 := by exact_mod_cast hall.2
+    have : x = 2 := le_antisymm (by omega) hx.two_le
+    have : y = 2 := le_antisymm (by omega) hy.two_le
+    exact hxy (by omega)
+  -- Bound each reciprocal, then combine
+  rcases h5 with h5a | h5b | h5c
+  · have : (a : ℚ)⁻¹ ≤ 1/5 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) (by exact_mod_cast h5a)
+    rcases pair3 b c hb hc (Ne.symm hcb) with h3 | h3
+    · have : (b : ℚ)⁻¹ ≤ 1/3 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) h3
+      have : (c : ℚ)⁻¹ ≤ 1/2 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) hc2
+      linarith
+    · have : (c : ℚ)⁻¹ ≤ 1/3 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) h3
+      have : (b : ℚ)⁻¹ ≤ 1/2 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) hb2
+      linarith
+  · have : (b : ℚ)⁻¹ ≤ 1/5 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) (by exact_mod_cast h5b)
+    rcases pair3 a c ha hc (Ne.symm hca) with h3 | h3
+    · have : (a : ℚ)⁻¹ ≤ 1/3 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) h3
+      have : (c : ℚ)⁻¹ ≤ 1/2 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) hc2
+      linarith
+    · have : (c : ℚ)⁻¹ ≤ 1/3 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) h3
+      have : (a : ℚ)⁻¹ ≤ 1/2 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) ha2
+      linarith
+  · have : (c : ℚ)⁻¹ ≤ 1/5 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) (by exact_mod_cast h5c)
+    rcases pair3 a b ha hb hab with h3 | h3
+    · have : (a : ℚ)⁻¹ ≤ 1/3 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) h3
+      have : (b : ℚ)⁻¹ ≤ 1/2 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) hb2
+      linarith
+    · have : (b : ℚ)⁻¹ ≤ 1/3 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) h3
+      have : (a : ℚ)⁻¹ ≤ 1/2 := by rw [one_div]; exact inv_le_inv_of_le (by norm_num) ha2
+      linarith
+
 /-- No solution with |P| = 2 and |Q| = 3 exists among primes.
-    Product ≤ (5/6)(31/30) = 31/36 < 1.
-    Needs tight bound: for 3 distinct primes, sum ≤ 31/30 (requires showing 3rd prime ≥ 5). -/
+    PROVED: product ≤ (5/6)(31/30) = 31/36 < 1. -/
 theorem no_two_three_solution :
     ¬∃ P Q : Finset ℕ, P.card = 2 ∧ Q.card = 3 ∧
       IsSetOfPrimes P ∧ IsSetOfPrimes Q ∧
       reciprocalProduct P Q = 1 := by
-  sorry
+  intro ⟨P, Q, hP2, hQ3, hPprime, hQprime, hprod⟩
+  have hP_le := reciprocal_sum_two_primes_le hP2 hPprime
+  have hQ_le := reciprocal_sum_three_primes_le hQ3 hQprime
+  have : reciprocalProduct P Q ≤ 31 / 36 := by
+    unfold reciprocalProduct
+    calc reciprocalSum P * reciprocalSum Q
+        ≤ (5 / 6) * (31 / 30) := by
+          apply mul_le_mul hP_le hQ_le
+          · exact Finset.sum_nonneg (fun i _ => inv_nonneg.mpr (Nat.cast_nonneg i))
+          · norm_num
+      _ = 31 / 36 := by norm_num
+  linarith
 
 /- ## Part XII: Summary -/
 

--- a/proofs/Proofs/Erdos347Problem.lean
+++ b/proofs/Proofs/Erdos347Problem.lean
@@ -100,3 +100,26 @@ theorem subsetSums_mono (A B : Set ℕ) (h : A ⊆ B) :
     subsetSums A ⊆ subsetSums B := by
   intro s ⟨S, hS, hs⟩
   exact ⟨S, Set.Subset.trans hS h, hs⟩
+
+/-- Any element of `A` is in `P(A)` (singleton subset sum). -/
+theorem mem_subsetSums_of_mem (A : Set ℕ) (a : ℕ) (ha : a ∈ A) :
+    a ∈ subsetSums A :=
+  ⟨{a}, by simpa using ha, by simp⟩
+
+/-- Disjoint witnesses combine: `∑S + ∑T ∈ P(A)` when `S, T ⊆ A` are disjoint. -/
+theorem subsetSums_add_of_disjoint (A : Set ℕ) (S T : Finset ℕ)
+    (hS : (↑S : Set ℕ) ⊆ A) (hT : (↑T : Set ℕ) ⊆ A) (hdisj : Disjoint S T) :
+    S.sum id + T.sum id ∈ subsetSums A := by
+  refine ⟨S ∪ T, ?_, Finset.sum_union hdisj⟩
+  simp only [Finset.coe_union]
+  exact Set.union_subset hS hT
+
+/-- The image of a cofinite subsequence is contained in the range of `a`. -/
+theorem cofiniteImage_subset (a ι : ℕ → ℕ) :
+    cofiniteImage a ι ⊆ Set.range a := by
+  intro x ⟨n, hn⟩
+  exact ⟨ι n, hn⟩
+
+/-- The identity is a cofinite subsequence (keeps all indices). -/
+theorem isCofiniteSubseq_id (a : ℕ → ℕ) : IsCofiniteSubseq a id :=
+  ⟨strictMono_id, by simp [Set.range_id]⟩

--- a/proofs/Proofs/Hilbert14NonReductive.lean
+++ b/proofs/Proofs/Hilbert14NonReductive.lean
@@ -182,6 +182,22 @@ theorem reynoldsSum_on_invariant (r : R) (hr : r ∈ InvariantSubset G R) :
   simp_rw [hr']
   rw [Finset.sum_const, Finset.card_univ]
 
+/-- The Reynolds sum of zero is zero. -/
+theorem reynoldsSum_zero : reynoldsSum (0 : R) = 0 := by
+  simp [reynoldsSum, smul_zero]
+
+/-- The Reynolds sum respects negation. -/
+theorem reynoldsSum_neg (r : R) : reynoldsSum (-r) = -reynoldsSum r := by
+  simp only [reynoldsSum, smul_neg, Finset.sum_neg_distrib]
+
+/-- The Reynolds sum commutes with multiplication by invariant elements.
+    If s ∈ R^G, then Σ_g g•(s·r) = Σ_g (g•s)·(g•r) = Σ_g s·(g•r) = s · Σ_g g•r. -/
+theorem reynoldsSum_mul_invariant (s r : R) (hs : s ∈ InvariantSubset G R) :
+    reynoldsSum (s * r) = s * reynoldsSum r := by
+  simp only [reynoldsSum]
+  simp_rw [smul_mul', hs _]
+  exact (Finset.mul_sum Finset.univ (fun g => g • r) s).symm
+
 end FiniteGroupReynolds
 
 -- ═══════════════════════════════════════════════════════════════════

--- a/src/data/proofs/erdos-307/meta.json
+++ b/src/data/proofs/erdos-307/meta.json
@@ -17,7 +17,7 @@
       "reciprocals"
     ],
     "badge": "formalized",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 307,
     "erdosUrl": "https://erdosproblems.com/307",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-347/meta.json
+++ b/src/data/proofs/erdos-347/meta.json
@@ -42,7 +42,7 @@
     "originalContributions": [
       "Complete formal framework for subset sum density problems: subsetSums, HasDensity, HasRatioLimit, IsCofiniteSubseq",
       "Corrected subsetSums_insert with fresh-witness requirement (original subsetSums_add was incorrect for multiset-like reasoning)",
-      "Three proved structural properties: zero_mem_subsetSums, subsetSums_insert, subsetSums_mono"
+      "Seven proved structural properties: zero_mem_subsetSums, subsetSums_insert, subsetSums_mono, mem_subsetSums_of_mem, subsetSums_add_of_disjoint, cofiniteImage_subset, isCofiniteSubseq_id"
     ],
     "prerequisites": [
       "Subset sum theory: completeness ($P(A) \\supseteq \\{N_0, N_0+1,\\ldots\\}$), density of sumsets, and additive representations",
@@ -51,7 +51,7 @@
       "Cofinite sets and subsequences: strictly monotone reindexing with cofinite range, robustness under finite deletions",
       "Lean 4 and Mathlib: Finset.sum, StrictMono, Set.Finite, and noncomputable definitions"
     ],
-    "lineCount": 102,
+    "lineCount": 126,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -156,9 +156,9 @@
       "Set"
     ],
     "namespace": null,
-    "lineCount": 102,
+    "lineCount": 126,
     "axiomCount": 1,
-    "theoremCount": 3,
+    "theoremCount": 7,
     "definitionCount": 8
   },
   "mainTheorems": [
@@ -185,6 +185,30 @@
       "type": "supporting",
       "description": "Subset sums are monotone: A ⊆ B implies P(A) ⊆ P(B)",
       "leanType": "(A B : Set ℕ) → A ⊆ B → subsetSums A ⊆ subsetSums B"
+    },
+    {
+      "name": "mem_subsetSums_of_mem",
+      "type": "supporting",
+      "description": "Any element of A is in P(A) via the singleton subset sum",
+      "leanType": "(A : Set ℕ) → (a : ℕ) → a ∈ A → a ∈ subsetSums A"
+    },
+    {
+      "name": "subsetSums_add_of_disjoint",
+      "type": "core",
+      "description": "Disjoint witnesses combine: if S, T ⊆ A are disjoint finsets, then ∑S + ∑T ∈ P(A)",
+      "leanType": "(A : Set ℕ) → (S T : Finset ℕ) → ↑S ⊆ A → ↑T ⊆ A → Disjoint S T → S.sum id + T.sum id ∈ subsetSums A"
+    },
+    {
+      "name": "cofiniteImage_subset",
+      "type": "supporting",
+      "description": "The image of a cofinite subsequence is contained in the range of the original sequence",
+      "leanType": "(a ι : ℕ → ℕ) → cofiniteImage a ι ⊆ Set.range a"
+    },
+    {
+      "name": "isCofiniteSubseq_id",
+      "type": "supporting",
+      "description": "The identity reindexing is a cofinite subsequence (keeps all indices)",
+      "leanType": "(a : ℕ → ℕ) → IsCofiniteSubseq a id"
     }
   ],
   "crossReferences": [

--- a/src/data/proofs/hilbert-14-oq-01/meta.json
+++ b/src/data/proofs/hilbert-14-oq-01/meta.json
@@ -43,12 +43,12 @@
       "Proof that Reynolds operator is idempotent (retraction)",
       "Grosshans subgroup class definition",
       "Invariant subring construction (R^G is a Subring of R)",
-      "Reynolds sum for finite groups with invariance, additivity, and scaling proofs",
+      "Reynolds sum for finite groups with invariance, additivity, scaling, zero, negation, and invariant-multiplication proofs",
       "Survey of classification: finite groups, tori, G_a, unipotent groups",
       "Documentation of the complete characterization landscape"
     ],
-    "lineCount": 307,
-    "theoremCount": 10,
+    "lineCount": 323,
+    "theoremCount": 13,
     "definitionCount": 5,
     "mathlib_version": "4.26.0"
   },

--- a/src/data/research/problems/erdos-307-oq-02.json
+++ b/src/data/research/problems/erdos-307-oq-02.json
@@ -13,18 +13,21 @@
       "product_rigidity is a trivial iff but has complex formulation",
       "All 4 axioms (prime_reciprocal_divergence, product_rigidity, egyptian_count_growth, lcd_connection) were unused by any theorem",
       "egyptian_count_growth was also vacuously true (just take count=1)",
-      "Status changed from axiomatized to formalized after removing all axioms"
+      "Status changed from axiomatized to formalized after removing all axioms",
+      "Pigeonhole for 3 distinct primes: only 2 primes < 5 ({2,3}), so at least one ≥ 5; only 1 prime < 3, so among any pair at least one ≥ 3",
+      "Product bound: (5/6)(31/30) = 31/36 < 1, ruling out |P|=2,|Q|=3"
     ],
     "builtItems": [
       "prime_reciprocal_sum_lower_bound proved via AM-GM (sorry eliminated)",
-      "search_intractable converted from axiom to theorem via native_decide"
+      "search_intractable converted from axiom to theorem via native_decide",
+      "reciprocal_sum_three_primes_le: for 3 distinct primes, reciprocal sum ≤ 31/30",
+      "no_two_three_solution: no prime solution with |P|=2, |Q|=3 (product ≤ 31/36 < 1)"
     ],
-    "progressSummary": "COMPLETED: Axioms 5→0 (all removed as unused). 4 sorries remain. Key proof: no_size_two_solution proved via AM-GM upper bound. Status: formalized (0 axioms, 4 sorries).",
+    "progressSummary": "PROGRESS: Proved no_two_three_solution — no prime solution with |P|=2, |Q|=3. Used reciprocal_sum_three_primes_le (pigeonhole: 3 distinct primes include one ≥5, one ≥3). Sorries 3→2.",
     "nextSteps": [
-      "Prove prime_sets_disjoint via p-adic valuation argument",
-      "Prove one_helps_balance (needs P.card > 1 hypothesis)",
-      "Convert product_rigidity axiom to theorem (trivial iff)",
-      "Prove no_size_two_solution by prime case analysis"
+      "prime_sets_disjoint: needs p-adic valuation argument (v_p of reciprocal sum = -1)",
+      "prime_set_size_lower_bound (|P∪Q|≥60): computational, needs sum of first ~60 prime reciprocals < 2",
+      "Could prove no_three_two_solution (symmetric case) by similar argument"
     ]
   },
   "leanFiles": [
@@ -32,10 +35,10 @@
       "path": "Proofs/Erdos307Problem.lean",
       "filename": "Erdos307Problem.lean",
       "lineCount": 435,
-      "theoremCount": 20,
+      "theoremCount": 22,
       "axiomCount": 0,
       "defCount": 15,
-      "sorryCount": 4,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos307Problem.lean"
     }
@@ -44,5 +47,6 @@
     "erdos-3",
     "erdos-30",
     "erdos-307"
-  ]
+  ],
+  "lastUpdate": "2026-03-30T14:45:00.000Z"
 }

--- a/src/data/research/problems/erdos-347.json
+++ b/src/data/research/problems/erdos-347.json
@@ -29,23 +29,33 @@
     }
   },
   "knowledge": {
-    "progressSummary": "AXIOM ELIMINATION + BUG FIX: Proved zero_mem_subsetSums and subsetSums_mono. Fixed incorrect subsetSums_add axiom (was false: fails when a already in witness finset). Axioms 4→1.",
+    "progressSummary": "BUILD: Added 4 structural API lemmas (mem_subsetSums_of_mem, subsetSums_add_of_disjoint, cofiniteImage_subset, isCofiniteSubseq_id). Theorems 3->7. Remaining: 1 axiom (erdos347_affirmative, the main theorem).",
     "builtItems": [
       "Proved zero_mem_subsetSums: empty finset witnesses 0 ∈ P(A)",
       "Proved subsetSums_mono: A⊆B → P(A)⊆P(B) via witness subset transitivity",
       "Fixed subsetSums_add → subsetSums_insert: requires a∉S as precondition",
-      "Identified bug: old subsetSums_add was FALSE (counterexample: A={2,3}, s=5, a=2)"
+      "Identified bug: old subsetSums_add was FALSE (counterexample: A={2,3}, s=5, a=2)",
+      "Proved mem_subsetSums_of_mem: singleton subset sum membership",
+      "Proved subsetSums_add_of_disjoint: disjoint witness combination",
+      "Proved cofiniteImage_subset: cofinite images contained in range",
+      "Proved isCofiniteSubseq_id: identity is cofinite subsequence"
     ],
     "insights": [
       "subsetSums_add was UNSOUND: for A={2,3}, s=5∈P(A), a=2∈A, but 7∉P(A)={0,2,3,5}",
       "Correct version needs a∉S precondition: can only add elements not already in witness",
       "CoveringSystem formalization uses Set ℕ (no repeats) — fine for this problem",
-      "Problem is SOLVED (Tao + van Doorn ideas), axiom erdos347_affirmative records this"
+      "Problem is SOLVED (Tao + van Doorn ideas), axiom erdos347_affirmative records this",
+      "Main axiom erdos347_affirmative requires Tao-van Doorn construction: perturb powers of 2 with controlled redundancy",
+      "Construction needs explicit sequence a(n) ~ c*2^n with enough representations to survive cofinite deletion",
+      "Ratio limit 2 is critical boundary: r<2 gives automatic completeness (Folkman), r>2 gives inevitable gaps",
+      "Full proof would need: (1) define sequence, (2) prove monotonicity+ratio, (3) prove cofinite robustness via redundancy argument"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "erdos347_affirmative is the only remaining axiom — records the solved result",
-      "Could construct explicit witness sequence satisfying ErdosProblem347 to eliminate last axiom"
+      "Define explicit candidate sequence (perturbed powers of 2 or similar)",
+      "Prove monotonicity and HasRatioLimit for the candidate",
+      "The hard part: prove cofinite robustness (density 1 after finite deletion)",
+      "Consider: countIn_univ and hasDensity_univ lemmas to support density arguments"
     ],
     "markdown": "# Erdős #347 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nIs there a sequence $A=\\{a_1\\leq a_2\\leq \\cdots\\}$ of integers with\\[\\lim \\frac{a_{n+1}}{a_n}=2\\]such that\\[P(A')= \\left\\{\\sum_{n\\in B}n : B\\subseteq A'\\textrm{ finite }\\right\\}\\]has density $1$ for every cofinite subsequence $A'$ of $A$?\n\n\n\n\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 5/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #346\n- Problem #348\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- ErGr80\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
@@ -63,15 +73,15 @@
     "mathlib": []
   },
   "started": "2026-01-13T00:53:52.153Z",
-  "lastUpdate": "2026-03-24T08:15:00.000Z",
+  "lastUpdate": "2026-03-30T14:20:00.000Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [
     {
       "path": "Proofs/Erdos347Problem.lean",
       "filename": "Erdos347Problem.lean",
-      "lineCount": 103,
-      "theoremCount": 3,
+      "lineCount": 126,
+      "theoremCount": 7,
       "axiomCount": 1,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/hilbert-14-oq-01.json
+++ b/src/data/research/problems/hilbert-14-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Eliminated 1 axiom (grosshans_characterization → theorem, trivially provable placeholder). Added invariantSubring construction proving R^G is a Subring of R. Added reynoldsSum for finite groups with 3 proved properties (invariance, additivity, scaling). File now 307 lines, 0 axioms, 0 sorries, 10 theorems.",
+    "progressSummary": "COMPLETED: Added 3 Reynolds sum lemmas (zero, negation, invariant-multiplication). Reynolds operator API now complete: 7 properties proved. File has 0 axioms, 0 sorries. Deeper formalization blocked by Mathlib lacking AlgebraicGroup.",
     "builtItems": [
       "Hilbert14NonReductive.lean: InvariantSubset, ReynoldsOperator, GrosshansSubgroup definitions",
       "reynolds_idempotent: proved Reynolds operator is a retraction",
@@ -39,7 +39,10 @@
       "reynoldsSum: Σ_{g∈G} g•r for finite groups",
       "reynoldsSum_mem_invariant: Reynolds sum maps into R^G",
       "reynoldsSum_add: Reynolds sum is additive",
-      "reynoldsSum_on_invariant: on R^G, Reynolds sum = |G|·r"
+      "reynoldsSum_on_invariant: on R^G, Reynolds sum = |G|·r",
+      "reynoldsSum_zero: Reynolds sum of zero is zero",
+      "reynoldsSum_neg: Reynolds sum respects negation",
+      "reynoldsSum_mul_invariant: Reynolds sum commutes with invariant multiplication"
     ],
     "insights": [
       "No purely group-theoretic criterion: same non-reductive group can have fg invariants for some reps and not others",
@@ -49,7 +52,8 @@
       "Full formalization blocked by Mathlib gaps: AlgebraicGroup, Representation, GIT quotient infrastructure missing",
       "grosshans_characterization axiom was trivially provable (GrosshansSubgroup G H → True)",
       "Subring structure of R^G requires both DistribMulAction and MulDistribMulAction",
-      "Reynolds sum invariance proof uses Equiv.sum_comp and Equiv.mulLeft for reindexing"
+      "Reynolds sum invariance proof uses Equiv.sum_comp and Equiv.mulLeft for reindexing",
+      "Reynolds sum API is now complete: invariance, additivity, scaling, zero, neg, mul_invariant. These 7 properties characterize the unnormalized Reynolds operator for finite groups."
     ],
     "mathlibGaps": [
       "AlgebraicGroup (algebraic groups over fields)",
@@ -80,15 +84,15 @@
     "mathlib": []
   },
   "started": "2026-03-30T01:04:30.789Z",
-  "lastUpdate": "2026-03-30T02:30:00.000Z",
+  "lastUpdate": "2026-03-30T14:30:00.000Z",
   "significance": 8,
   "tractability": 5,
   "leanFiles": [
     {
       "path": "Proofs/Hilbert14NonReductive.lean",
       "filename": "Hilbert14NonReductive.lean",
-      "lineCount": 307,
-      "theoremCount": 10,
+      "lineCount": 323,
+      "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,
@@ -109,8 +113,8 @@
     {
       "path": "Proofs/Hilbert14NonReductive.lean",
       "filename": "Hilbert14NonReductive.lean",
-      "lineCount": 308,
-      "theoremCount": 10,
+      "lineCount": 323,
+      "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
Research session covering three problems.

### erdos-347 — Structural subset-sum API lemmas
- 4 proved lemmas: `mem_subsetSums_of_mem`, `subsetSums_add_of_disjoint`, `cofiniteImage_subset`, `isCofiniteSubseq_id`
- Theorems 3→7, axiom count unchanged (1)

### hilbert-14-oq-01 — Complete Reynolds sum API
- 3 proved lemmas: `reynoldsSum_zero`, `reynoldsSum_neg`, `reynoldsSum_mul_invariant`
- 0 axioms, 0 sorries, theorems 10→13

### erdos-307-oq-02 — Sorry elimination (no_two_three_solution)
- Proved `reciprocal_sum_three_primes_le`: 3 distinct primes have reciprocal sum ≤ 31/30
- Proved `no_two_three_solution`: no prime solution with |P|=2, |Q|=3
- Pigeonhole argument: among 3 distinct primes, one ≥5, and among any pair one ≥3
- Sorries 3→2

## Status
- **erdos-347**: in-progress (main axiom needs Tao-van Doorn construction)
- **hilbert-14-oq-01**: completed (blocked by Mathlib gaps)
- **erdos-307-oq-02**: in-progress (2 sorries remain)

🤖 Generated by researcher-6