### PR TITLE
fix: correct sorry counts for 4 proofs after recent research

### DIFF
--- a/src/data/proofs/erdos-1181/meta.json
+++ b/src/data/proofs/erdos-1181/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "lineCount": 296,
     "erdosNumber": 1181,
     "erdosUrl": "https://erdosproblems.com/1181",

--- a/src/data/proofs/erdos-614/meta.json
+++ b/src/data/proofs/erdos-614/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 614,
     "erdosUrl": "https://erdosproblems.com/614",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/prob-method-expectation-oq-01/meta.json
+++ b/src/data/proofs/prob-method-expectation-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős-Spencer, formalized via Mathlib MeasureTheory",
     "date": "1974",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/ProbMethodExpectationOQ01.lean",
     "tags": [
       "probability",
@@ -14,8 +14,8 @@
       "measure-theory",
       "combinatorics"
     ],
-    "badge": "axiom",
-    "sorries": 2,
+    "badge": "verified",
+    "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
     "lineCount": 94

--- a/src/data/proofs/quadratic-reciprocity-algorithm-oq-01/meta.json
+++ b/src/data/proofs/quadratic-reciprocity-algorithm-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Gauss (algorithm, 1801)",
     "date": "1801",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/QuadraticReciprocityAlgorithmOQ01.lean",
     "tags": [
       "number-theory",
@@ -16,8 +16,8 @@
       "jacobi-symbol",
       "verified-computation"
     ],
-    "badge": "axiom",
-    "sorries": 1,
+    "badge": "verified",
+    "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-03-30",
     "lineCount": 193,


### PR DESCRIPTION
## Fix

Correct sorry counts and status for 4 proofs whose Lean source changed in recent research PRs.

## Evidence

| Proof | Before | After | Cause |
|-------|--------|-------|-------|
| erdos-1181 | sorries=1 | sorries=0 | Sorry eliminated in #8382 |
| erdos-614 | sorries=0 | sorries=1 | Sorry added in #8377, meta not updated |
| prob-method-expectation-oq-01 | sorries=2, axiomatized | sorries=0, verified | Both sorries eliminated |
| quadratic-reciprocity-algorithm-oq-01 | sorries=1, formalized | sorries=0, verified | Sorry eliminated |

Two proofs (prob-method-expectation-oq-01, quadratic-reciprocity-algorithm-oq-01) upgraded to `verified` status: 0 sorries, 0 axioms, 0 structure-encoded assumptions.

Verified via comment-aware sorry counter (strips block and line comments).

---
Automated fix by lean-mechanic agent.