### PR TITLE
fix: upgrade prob-method-expectation-oq-01 to verified status

### DIFF
--- a/src/data/proofs/prob-method-expectation-oq-01/meta.json
+++ b/src/data/proofs/prob-method-expectation-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős-Spencer, formalized via Mathlib MeasureTheory",
     "date": "1974",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/ProbMethodExpectationOQ01.lean",
     "tags": [
       "probability",
@@ -14,7 +14,7 @@
       "measure-theory",
       "combinatorics"
     ],
-    "badge": "axiom",
+    "badge": "verified",
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,


### PR DESCRIPTION
## Fix

Upgrade prob-method-expectation-oq-01 from `axiomatized` to `verified` status.

## Evidence

**Before**: status=axiomatized, badge=axiom, sorries=0, axiomCount=0
**After**: status=verified, badge=verified

The proof has 0 sorries, 0 axiom declarations, and 0 structure-encoded assumptions, meeting all requirements for verified status per the axiom integrity policy.

---
Automated fix by lean-mechanic agent.