### PR TITLE
fix: correct sorry counts for 6 proofs

### DIFF
--- a/src/data/proofs/dirichlets-theorem-oq-03/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-03/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "axiomCount": 2,
     "lineCount": 139
   },

--- a/src/data/proofs/erdos-138/meta.json
+++ b/src/data/proofs/erdos-138/meta.json
@@ -37,7 +37,7 @@
       "Proof schema: main conjecture implies ExponentialDiverges"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 5,
     "erdosNumber": 138,
     "erdosUrl": "https://erdosproblems.com/138",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-392/meta.json
+++ b/src/data/proofs/erdos-392/meta.json
@@ -17,7 +17,7 @@
       "number-theory"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "erdosNumber": 392,
     "erdosUrl": "https://erdosproblems.com/392",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-402/meta.json
+++ b/src/data/proofs/erdos-402/meta.json
@@ -17,7 +17,7 @@
       "solved"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 2,
     "erdosNumber": 402,
     "erdosUrl": "https://erdosproblems.com/402",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-628/meta.json
+++ b/src/data/proofs/erdos-628/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 11,
+    "sorries": 12,
     "erdosNumber": 628,
     "erdosUrl": "https://erdosproblems.com/628",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-746/meta.json
+++ b/src/data/proofs/erdos-746/meta.json
@@ -19,7 +19,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "erdosNumber": 746,
     "erdosUrl": "https://erdosproblems.com/746",
     "erdosProblemStatus": "solved",


### PR DESCRIPTION
## Fix

Corrected `meta.sorries` counts in 6 meta.json files where the recorded count was lower than the actual number of `sorry` occurrences in the Lean source files.

## Evidence

| Proof | Before | After |
|-------|--------|-------|
| dirichlets-theorem-oq-03 | 2 | 3 |
| erdos-138 | 4 | 5 |
| erdos-392 | 2 | 3 |
| erdos-402 | 1 | 2 |
| erdos-628 | 11 | 12 |
| erdos-746 | 2 | 3 |

Verified by parsing Lean files with comment-aware sorry counting (excluding `/-...-/` block comments and `--` line comments).

---
Automated fix by lean-mechanic agent.