### PR TITLE
fix: correct undercounted axiom counts for 27 proofs

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-03/meta.json
@@ -20,5 +20,8 @@
     "axiomCount": 3,
     "lineCount": 80
   },
-  "sections": []
+  "sections": [],
+  "leanFile": {
+    "axiomCount": 3
+  }
 }

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-03/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-03/meta.json
@@ -1,106 +1,109 @@
 {
-    "id": "borsuk-ulam-oq-02-oq-03",
-    "title": "Dold's Theorem: Cohomological Index for Free G-Spaces",
-    "slug": "borsuk-ulam-oq-02-oq-03",
-    "description": "Axiomatized formalization of Dold's theorem (1983), which provides a unified cohomological index framework for Borsuk-Ulam type results. The Dold index assigns a numerical invariant to free G-spaces on spheres and shows equivariant maps respect it. From 5 axioms, we derive 11 theorems: classical Borsuk-Ulam (Z/2), Yang-Borsuk (Z/p), composite group bounds, and unification of the buDim framework from OQ02OQ01.",
-    "meta": {
-        "author": "Lean Genius (after Dold 1983)",
-        "status": "axiomatized",
-        "proofRepoPath": "Proofs/BorsukUlamOQ02OQ03.lean",
-        "tags": [
-            "topology",
-            "algebraic-topology",
-            "borsuk-ulam",
-            "equivariant",
-            "cohomology",
-            "group-actions",
-            "dold-theorem",
-            "research"
-        ],
-        "badge": "axiom",
-        "sorries": 0,
-        "axiomCount": 5,
-        "lineCount": 251,
-        "assumptions": "doldIndex function (cohomological index), doldIndex_one (trivial group), doldIndex_z2 (Z/2 antipodal = n), doldIndex_prime (Z/p rotation = 2n-1), doldIndex_dvd_mono (Dold's theorem: subgroup monotonicity).",
-        "originalContributions": [
-            "Axiomatized Dold cohomological index with 5 axioms (1 fewer than OQ02OQ01)",
-            "Proved borsuk_ulam_from_dold: classical BU as consequence of Dold index",
-            "Proved yang_borsuk_from_dold: Yang-Borsuk as consequence of Dold index",
-            "Proved z4_index_bound, z6_index_from_z2, z6_index_from_z3: composite bounds",
-            "Proved zpq_index_bound: general product-of-primes bound",
-            "Proved buDim unification: OQ02OQ01 axioms follow from Dold axioms",
-            "Complete formalizability assessment with ~1800 line gap analysis"
-        ],
-        "mathlibDependencies": [
-            {
-                "theorem": "Nat.Prime",
-                "description": "Primality predicate for natural numbers",
-                "module": "Mathlib.Data.Nat.Prime.Basic"
-            },
-            {
-                "theorem": "Nat.exists_prime_and_dvd",
-                "description": "Every natural number >= 2 has a prime divisor",
-                "module": "Mathlib.Data.Nat.Prime.Basic"
-            }
-        ]
-    },
-    "sections": [
-        {
-            "id": "dold-index",
-            "title": "The Dold Cohomological Index",
-            "startLine": 43,
-            "endLine": 60,
-            "summary": "Axiomatizes the cohomological index doldIndex(g, n) = ind_{Z/g}(S^n) as a function of group order and sphere dimension.",
-            "mathContext": "The cohomological index is defined via Borel equivariant cohomology: ind_G(X) = sup{k : H^k(BG) -> H^k_G(X) is injective}. We axiomatize rather than construct it."
-        },
-        {
-            "id": "axiom-properties",
-            "title": "Axiomatized Properties",
-            "startLine": 62,
-            "endLine": 92,
-            "summary": "Four properties: trivial group (index = 0), Z/2 (index = n), Z/p prime (index = 2n-1), and Dold's theorem (subgroup monotonicity).",
-            "mathContext": "These encode the classical values computed by Borsuk, Yang, and Dold, plus the core transfer-map argument that is Dold's main theorem."
-        },
-        {
-            "id": "borsuk-ulam-corollary",
-            "title": "Classical Borsuk-Ulam from Dold",
-            "startLine": 94,
-            "endLine": 108,
-            "summary": "Derives the Borsuk-Ulam theorem (no odd map S^n -> S^{n-1}) from the Dold index.",
-            "mathContext": "If an odd map S^n -> S^{n-1} existed, it would be Z/2-equivariant, contradicting ind_{Z/2}(S^n) = n > n-1 = ind_{Z/2}(S^{n-1})."
-        },
-        {
-            "id": "yang-borsuk-corollary",
-            "title": "Yang-Borsuk from Dold",
-            "startLine": 110,
-            "endLine": 122,
-            "summary": "Derives the Yang-Borsuk theorem (Z/p-equivariant obstruction) from the Dold index.",
-            "mathContext": "For prime p, the Z/p-equivariant Borsuk-Ulam follows from ind_{Z/p}(S^{2n-1}) = 2n-1 strictly exceeding ind_{Z/p}(S^{2n-3})."
-        },
-        {
-            "id": "composite-bounds",
-            "title": "Composite Group Bounds",
-            "startLine": 124,
-            "endLine": 160,
-            "summary": "Derives index bounds for Z/4, Z/6, Z/pq, and general composite groups from prime subgroup monotonicity.",
-            "mathContext": "Every composite group inherits index bounds from its prime subgroups via Dold's subgroup monotonicity. These bounds are tight for standard representations."
-        },
-        {
-            "id": "budim-unification",
-            "title": "Unification with buDim (OQ02OQ01)",
-            "startLine": 162,
-            "endLine": 200,
-            "summary": "Shows buDim(g, d) = doldIndex(g, d-1) and derives all OQ02OQ01 axioms from Dold axioms.",
-            "mathContext": "The buDim function from OQ02OQ01 is a repackaging of the Dold index. This unification reduces 6 axioms to 5 while preserving all consequences."
-        },
-        {
-            "id": "formalizability",
-            "title": "Formalizability Assessment",
-            "startLine": 202,
-            "endLine": 226,
-            "summary": "Complete gap analysis: ~1800 lines of equivariant cohomology needed to remove all axioms. Priority: transfer maps (~200 lines) for highest value per effort.",
-            "mathContext": "The axioms can be proved from singular cohomology + Borel construction + transfer maps. Mathlib currently lacks all three, but they are constructible."
-        }
+  "id": "borsuk-ulam-oq-02-oq-03",
+  "title": "Dold's Theorem: Cohomological Index for Free G-Spaces",
+  "slug": "borsuk-ulam-oq-02-oq-03",
+  "description": "Axiomatized formalization of Dold's theorem (1983), which provides a unified cohomological index framework for Borsuk-Ulam type results. The Dold index assigns a numerical invariant to free G-spaces on spheres and shows equivariant maps respect it. From 5 axioms, we derive 11 theorems: classical Borsuk-Ulam (Z/2), Yang-Borsuk (Z/p), composite group bounds, and unification of the buDim framework from OQ02OQ01.",
+  "meta": {
+    "author": "Lean Genius (after Dold 1983)",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/BorsukUlamOQ02OQ03.lean",
+    "tags": [
+      "topology",
+      "algebraic-topology",
+      "borsuk-ulam",
+      "equivariant",
+      "cohomology",
+      "group-actions",
+      "dold-theorem",
+      "research"
     ],
-    "openQuestions": []
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 5,
+    "lineCount": 251,
+    "assumptions": "doldIndex function (cohomological index), doldIndex_one (trivial group), doldIndex_z2 (Z/2 antipodal = n), doldIndex_prime (Z/p rotation = 2n-1), doldIndex_dvd_mono (Dold's theorem: subgroup monotonicity).",
+    "originalContributions": [
+      "Axiomatized Dold cohomological index with 5 axioms (1 fewer than OQ02OQ01)",
+      "Proved borsuk_ulam_from_dold: classical BU as consequence of Dold index",
+      "Proved yang_borsuk_from_dold: Yang-Borsuk as consequence of Dold index",
+      "Proved z4_index_bound, z6_index_from_z2, z6_index_from_z3: composite bounds",
+      "Proved zpq_index_bound: general product-of-primes bound",
+      "Proved buDim unification: OQ02OQ01 axioms follow from Dold axioms",
+      "Complete formalizability assessment with ~1800 line gap analysis"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.Prime",
+        "description": "Primality predicate for natural numbers",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "Nat.exists_prime_and_dvd",
+        "description": "Every natural number >= 2 has a prime divisor",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      }
+    ]
+  },
+  "sections": [
+    {
+      "id": "dold-index",
+      "title": "The Dold Cohomological Index",
+      "startLine": 43,
+      "endLine": 60,
+      "summary": "Axiomatizes the cohomological index doldIndex(g, n) = ind_{Z/g}(S^n) as a function of group order and sphere dimension.",
+      "mathContext": "The cohomological index is defined via Borel equivariant cohomology: ind_G(X) = sup{k : H^k(BG) -> H^k_G(X) is injective}. We axiomatize rather than construct it."
+    },
+    {
+      "id": "axiom-properties",
+      "title": "Axiomatized Properties",
+      "startLine": 62,
+      "endLine": 92,
+      "summary": "Four properties: trivial group (index = 0), Z/2 (index = n), Z/p prime (index = 2n-1), and Dold's theorem (subgroup monotonicity).",
+      "mathContext": "These encode the classical values computed by Borsuk, Yang, and Dold, plus the core transfer-map argument that is Dold's main theorem."
+    },
+    {
+      "id": "borsuk-ulam-corollary",
+      "title": "Classical Borsuk-Ulam from Dold",
+      "startLine": 94,
+      "endLine": 108,
+      "summary": "Derives the Borsuk-Ulam theorem (no odd map S^n -> S^{n-1}) from the Dold index.",
+      "mathContext": "If an odd map S^n -> S^{n-1} existed, it would be Z/2-equivariant, contradicting ind_{Z/2}(S^n) = n > n-1 = ind_{Z/2}(S^{n-1})."
+    },
+    {
+      "id": "yang-borsuk-corollary",
+      "title": "Yang-Borsuk from Dold",
+      "startLine": 110,
+      "endLine": 122,
+      "summary": "Derives the Yang-Borsuk theorem (Z/p-equivariant obstruction) from the Dold index.",
+      "mathContext": "For prime p, the Z/p-equivariant Borsuk-Ulam follows from ind_{Z/p}(S^{2n-1}) = 2n-1 strictly exceeding ind_{Z/p}(S^{2n-3})."
+    },
+    {
+      "id": "composite-bounds",
+      "title": "Composite Group Bounds",
+      "startLine": 124,
+      "endLine": 160,
+      "summary": "Derives index bounds for Z/4, Z/6, Z/pq, and general composite groups from prime subgroup monotonicity.",
+      "mathContext": "Every composite group inherits index bounds from its prime subgroups via Dold's subgroup monotonicity. These bounds are tight for standard representations."
+    },
+    {
+      "id": "budim-unification",
+      "title": "Unification with buDim (OQ02OQ01)",
+      "startLine": 162,
+      "endLine": 200,
+      "summary": "Shows buDim(g, d) = doldIndex(g, d-1) and derives all OQ02OQ01 axioms from Dold axioms.",
+      "mathContext": "The buDim function from OQ02OQ01 is a repackaging of the Dold index. This unification reduces 6 axioms to 5 while preserving all consequences."
+    },
+    {
+      "id": "formalizability",
+      "title": "Formalizability Assessment",
+      "startLine": 202,
+      "endLine": 226,
+      "summary": "Complete gap analysis: ~1800 lines of equivariant cohomology needed to remove all axioms. Priority: transfer maps (~200 lines) for highest value per effort.",
+      "mathContext": "The axioms can be proved from singular cohomology + Borel construction + transfer maps. Mathlib currently lacks all three, but they are constructible."
+    }
+  ],
+  "openQuestions": [],
+  "leanFile": {
+    "axiomCount": 5
+  }
 }

--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-03/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-03/meta.json
@@ -20,5 +20,8 @@
     "axiomCount": 2,
     "lineCount": 156
   },
-  "sections": []
+  "sections": [],
+  "leanFile": {
+    "axiomCount": 2
+  }
 }

--- a/src/data/proofs/collatz-structured-oq-03/meta.json
+++ b/src/data/proofs/collatz-structured-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "collatz-structured-oq-03",
   "title": "Growth Rate of Average Collatz Stopping Time",
   "slug": "collatz-structured-oq-03",
-  "description": "Formalizes the average Collatz stopping time S(N) and asks whether S(N) ~ c\u00b7log N. Defines stopping time via Nat.find, heuristic constant 1/log\u2082(4/3), and states the asymptotic growth question. Axiomatizes Terras density result.",
+  "description": "Formalizes the average Collatz stopping time S(N) and asks whether S(N) ~ c·log N. Defines stopping time via Nat.find, heuristic constant 1/log₂(4/3), and states the asymptotic growth question. Axiomatizes Terras density result.",
   "meta": {
     "status": "axiomatized",
     "proofRepoPath": "Proofs/CollatzStructuredOQ03.lean",
@@ -17,5 +17,8 @@
     "axiomCount": 1,
     "lineCount": 149
   },
-  "sections": []
+  "sections": [],
+  "leanFile": {
+    "axiomCount": 1
+  }
 }

--- a/src/data/proofs/de-moivre-oq-03-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-03-oq-01/meta.json
@@ -21,5 +21,8 @@
     "assumptions": "1 axiom: weyl_equidistribution (density of irrational rotations on unit circle). de_moivre_real_exponent proved with principal branch hypothesis θ ∈ (-π, π].",
     "lineCount": 74
   },
-  "sections": []
+  "sections": [],
+  "leanFile": {
+    "axiomCount": 1
+  }
 }

--- a/src/data/proofs/descartes-rule-of-signs-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02/meta.json
@@ -240,6 +240,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 698
+    "lineCount": 698,
+    "axiomCount": 3
   }
 }

--- a/src/data/proofs/dirichlets-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02-oq-01/meta.json
@@ -216,6 +216,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 366
+    "lineCount": 366,
+    "axiomCount": 4
   }
 }

--- a/src/data/proofs/e-transcendental-oq-01/meta.json
+++ b/src/data/proofs/e-transcendental-oq-01/meta.json
@@ -210,7 +210,7 @@
     ],
     "namespace": null,
     "lineCount": 545,
-    "axiomCount": 1,
+    "axiomCount": 4,
     "theoremCount": 18,
     "definitionCount": 2
   },

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-03/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-03/meta.json
@@ -25,7 +25,8 @@
   "status": "axiomatized",
   "badge": "axiom",
   "leanFile": {
-    "lineCount": 113
+    "lineCount": 113,
+    "axiomCount": 3
   },
   "sections": []
 }

--- a/src/data/proofs/erdos-1126-oq-01/meta.json
+++ b/src/data/proofs/erdos-1126-oq-01/meta.json
@@ -2,9 +2,9 @@
   "id": "erdos-1126-oq-01",
   "title": "Extending de Bruijn-Jurkat to Other Functional Equations",
   "slug": "erdos-1126-oq-01",
-  "description": "Can the de Bruijn-Jurkat theorem (almost additive \u2192 additive a.e.) be extended to multiplicative, Jensen, and derivation functional equations? We formalize the extensions and prove key structural connections.",
+  "description": "Can the de Bruijn-Jurkat theorem (almost additive → additive a.e.) be extended to multiplicative, Jensen, and derivation functional equations? We formalize the extensions and prove key structural connections.",
   "meta": {
-    "author": "Ger (1979), J\u00e1rai (2005)",
+    "author": "Ger (1979), Járai (2005)",
     "sourceUrl": "https://erdosproblems.com/1126",
     "date": "2026",
     "status": "axiomatized",
@@ -51,15 +51,15 @@
     "originalContributions": [
       "IsJensen: Jensen's functional equation f((x+y)/2) = (f(x)+f(y))/2",
       "IsMultiplicative: Multiplicative equation f(xy) = f(x)f(y)",
-      "IsDerivation: Leibniz rule d(xy) = x\u00b7d(y) + y\u00b7d(x)",
-      "jensen_implies_shifted_additive: Jensen \u2192 shifted function is additive (PROVED)",
+      "IsDerivation: Leibniz rule d(xy) = x·d(y) + y·d(x)",
+      "jensen_implies_shifted_additive: Jensen → shifted function is additive (PROVED)",
       "additive_plus_const_is_jensen: Additive + constant satisfies Jensen (PROVED)",
-      "jensen_iff_additive_shifted: Jensen \u2194 additive modulo constants (PROVED)",
+      "jensen_iff_additive_shifted: Jensen ↔ additive modulo constants (PROVED)",
       "mul_func_one: f(1) = 1 for multiplicative functions (PROVED)",
-      "mul_func_sq: f(x\u00b2) = f(x)\u00b2 (PROVED)",
+      "mul_func_sq: f(x²) = f(x)² (PROVED)",
       "derivation_at_one: d(1) = 0 (PROVED)",
-      "derivation_sq: d(x\u00b2) = 2x\u00b7d(x) (PROVED)",
-      "derivation_pow: Power rule d(x\u207f) = n\u00b7x\u207f\u207b\u00b9\u00b7d(x) (PROVED)",
+      "derivation_sq: d(x²) = 2x·d(x) (PROVED)",
+      "derivation_pow: Power rule d(xⁿ) = n·xⁿ⁻¹·d(x) (PROVED)",
       "stability_paradigm_summary: Unified stability for Jensen and derivation equations",
       "log_of_mul_is_additive: Logarithmic reduction of multiplicative to additive equation (PROVED)"
     ],
@@ -69,16 +69,16 @@
     "assumptions": "5 axioms: almost_multiplicative_stability, almost_jensen_stability, almost_derivation_stability, measurable_multiplicative_is_power, measurable_derivation_is_zero. 1 sorry remains (ae_double_of_almost_jensen, Fubini section extraction)."
   },
   "overview": {
-    "historicalContext": "**Extending the de Bruijn-Jurkat Paradigm**\n\nThe de Bruijn-Jurkat theorem (1965-66) showed that almost additive functions can be corrected to truly additive functions a.e. This naturally raises the question: does the same stability hold for other fundamental functional equations?\n\n**The Key Equations:**\n1. **Multiplicative** (Cauchy exponential): $f(xy) = f(x)f(y)$ \u2014 characterizes exponentials and power functions\n2. **Jensen** (midpoint affinity): $f((x+y)/2) = (f(x)+f(y))/2$ \u2014 characterizes affine functions\n3. **Derivation** (Leibniz rule): $d(xy) = x \\cdot d(y) + y \\cdot d(x)$ \u2014 characterizes differentiation\n\n**Known Results:**\n- **Ger (1979)** showed stability holds for polynomial functional equations, which includes the derivation case\n- **J\u00e1rai (2005)** gave a comprehensive treatment of regularity for functional equations in several variables\n- The multiplicative case reduces to the additive case via logarithms (for positive solutions)\n- The Jensen case is algebraically equivalent to the additive case modulo a constant",
-    "problemStatement": "**Open Question (from Erd\u0151s Problem #1126)**\n\nCan the de Bruijn-Jurkat theorem be extended to other functional equations, such as:\n- $f(xy) = f(x)f(y)$ (multiplicative/Cauchy exponential)\n- $f((x+y)/2) = (f(x)+f(y))/2$ (Jensen's equation)\n- $d(xy) = x \\cdot d(y) + y \\cdot d(x)$ (Leibniz/derivation rule)\n\nThe answer is **YES** for all three, making a.e. stability a universal phenomenon for algebraic functional equations.",
+    "historicalContext": "**Extending the de Bruijn-Jurkat Paradigm**\n\nThe de Bruijn-Jurkat theorem (1965-66) showed that almost additive functions can be corrected to truly additive functions a.e. This naturally raises the question: does the same stability hold for other fundamental functional equations?\n\n**The Key Equations:**\n1. **Multiplicative** (Cauchy exponential): $f(xy) = f(x)f(y)$ — characterizes exponentials and power functions\n2. **Jensen** (midpoint affinity): $f((x+y)/2) = (f(x)+f(y))/2$ — characterizes affine functions\n3. **Derivation** (Leibniz rule): $d(xy) = x \\cdot d(y) + y \\cdot d(x)$ — characterizes differentiation\n\n**Known Results:**\n- **Ger (1979)** showed stability holds for polynomial functional equations, which includes the derivation case\n- **Járai (2005)** gave a comprehensive treatment of regularity for functional equations in several variables\n- The multiplicative case reduces to the additive case via logarithms (for positive solutions)\n- The Jensen case is algebraically equivalent to the additive case modulo a constant",
+    "problemStatement": "**Open Question (from Erdős Problem #1126)**\n\nCan the de Bruijn-Jurkat theorem be extended to other functional equations, such as:\n- $f(xy) = f(x)f(y)$ (multiplicative/Cauchy exponential)\n- $f((x+y)/2) = (f(x)+f(y))/2$ (Jensen's equation)\n- $d(xy) = x \\cdot d(y) + y \\cdot d(x)$ (Leibniz/derivation rule)\n\nThe answer is **YES** for all three, making a.e. stability a universal phenomenon for algebraic functional equations.",
     "text": "Extends the de Bruijn-Jurkat stability theorem to multiplicative, Jensen, and derivation functional equations. Jensen's equation is proved equivalent to additivity modulo constants. The multiplicative case reduces via logarithms. Derivation stability follows from Ger's 1979 work.",
-    "proofStrategy": "**Formalization Strategy**\n\nThe 388-line Lean file covers three extensions:\n\n1. **Jensen \u2194 Additive** (Parts I-II): The central proved result. `jensen_implies_shifted_additive` shows that if $f$ satisfies Jensen's equation, then $g(x) = f(x) - f(0)$ is additive. The converse `additive_plus_const_is_jensen` shows additive + constant satisfies Jensen. Combined in `jensen_iff_additive_shifted`.\n\n2. **Multiplicative Functions** (Part III): Defines `IsMultiplicative` and proves basic properties: $f(1) = 1$ (when $f$ is nonzero), $f(x^2) = f(x)^2$, and the logarithmic reduction to additivity.\n\n3. **Derivation Equation** (Part V): Defines `IsDerivation` and proves the key structural theorems: $d(1) = 0$, $d(x^2) = 2x \\cdot d(x)$, and the power rule $d(x^n) = n x^{n-1} d(x)$ by induction \u2014 showing derivations generalize differentiation.\n\n4. **Stability Axioms** (Part IV): The deep extension theorems are axiomatized: almost multiplicative \u2192 multiplicative, almost Jensen \u2192 Jensen, almost derivation \u2192 derivation.",
+    "proofStrategy": "**Formalization Strategy**\n\nThe 388-line Lean file covers three extensions:\n\n1. **Jensen ↔ Additive** (Parts I-II): The central proved result. `jensen_implies_shifted_additive` shows that if $f$ satisfies Jensen's equation, then $g(x) = f(x) - f(0)$ is additive. The converse `additive_plus_const_is_jensen` shows additive + constant satisfies Jensen. Combined in `jensen_iff_additive_shifted`.\n\n2. **Multiplicative Functions** (Part III): Defines `IsMultiplicative` and proves basic properties: $f(1) = 1$ (when $f$ is nonzero), $f(x^2) = f(x)^2$, and the logarithmic reduction to additivity.\n\n3. **Derivation Equation** (Part V): Defines `IsDerivation` and proves the key structural theorems: $d(1) = 0$, $d(x^2) = 2x \\cdot d(x)$, and the power rule $d(x^n) = n x^{n-1} d(x)$ by induction — showing derivations generalize differentiation.\n\n4. **Stability Axioms** (Part IV): The deep extension theorems are axiomatized: almost multiplicative → multiplicative, almost Jensen → Jensen, almost derivation → derivation.",
     "keyInsights": [
       "**Jensen = Additive + Constant:** Jensen's equation $f((x+y)/2) = (f(x)+f(y))/2$ is exactly equivalent to saying $f(x) - f(0)$ is additive. This is proved constructively in Lean.",
       "**Logarithmic Reduction:** For positive multiplicative functions, $\\log \\circ f \\circ \\exp$ is additive. This reduces multiplicative stability to additive stability (de Bruijn-Jurkat).",
       "**Derivations Generalize Differentiation:** The power rule $d(x^n) = n x^{n-1} d(x)$ is proved by induction for abstract derivations, showing they satisfy the same formal rules as the derivative operator.",
       "**Continuous Derivations Vanish:** On $\\mathbb{R}$, the only continuous derivation is the zero function. This contrasts with additive functions where continuous ones form a 1-parameter family $f(x) = cx$.",
-      "**Universal Stability Paradigm:** All algebraic functional equations (additive, multiplicative, Jensen, Leibniz) exhibit a.e. stability: approximate solutions can be repaired to exact solutions. This is Ger's 1979 insight generalized by J\u00e1rai (2005)."
+      "**Universal Stability Paradigm:** All algebraic functional equations (additive, multiplicative, Jensen, Leibniz) exhibit a.e. stability: approximate solutions can be repaired to exact solutions. This is Ger's 1979 insight generalized by Járai (2005)."
     ],
     "prerequisites": [
       "Mathematical analysis",
@@ -92,7 +92,7 @@
       "title": "Definitions from Parent Problem",
       "startLine": 31,
       "endLine": 58,
-      "summary": "Redefines `IsAdditive`, `ae_holds`, `ae_pairs`, `ae_eq`, and `IsAlmostAdditive` from the parent Erd\u0151s #1126 formalization for self-containment.",
+      "summary": "Redefines `IsAdditive`, `ae_holds`, `ae_pairs`, `ae_eq`, and `IsAlmostAdditive` from the parent Erdős #1126 formalization for self-containment.",
       "mathContext": "$f(x+y) = f(x) + f(y)$ (Cauchy); $P$ holds a.e. means $P$ fails only on a Lebesgue null set."
     },
     {
@@ -100,12 +100,12 @@
       "title": "Jensen's Functional Equation",
       "startLine": 60,
       "endLine": 130,
-      "summary": "Defines `IsJensen` and proves the key equivalence: Jensen \u2194 additive modulo constant. Three theorems: `jensen_implies_shifted_additive` (forward), `additive_plus_const_is_jensen` (backward), `jensen_iff_additive_shifted` (iff).",
+      "summary": "Defines `IsJensen` and proves the key equivalence: Jensen ↔ additive modulo constant. Three theorems: `jensen_implies_shifted_additive` (forward), `additive_plus_const_is_jensen` (backward), `jensen_iff_additive_shifted` (iff).",
       "mathContext": "$f\\bigl(\\tfrac{x+y}{2}\\bigr) = \\tfrac{f(x)+f(y)}{2} \\iff f - f(0)$ is additive. Proved via the doubling formula $f(2z) = 2f(z) - f(0)$."
     },
     {
       "id": "almost-jensen",
-      "title": "Almost Jensen \u2192 Almost Additive",
+      "title": "Almost Jensen → Almost Additive",
       "startLine": 170,
       "endLine": 190,
       "summary": "States that almost Jensen reduces to almost additive for the shifted function. This reduces Jensen stability to de Bruijn-Jurkat.",
@@ -124,7 +124,7 @@
       "title": "Extension Theorems (Axiomatized)",
       "startLine": 252,
       "endLine": 280,
-      "summary": "Three stability axioms: `almost_multiplicative_stability`, `almost_jensen_stability`, `almost_derivation_stability` \u2014 the deep extension theorems.",
+      "summary": "Three stability axioms: `almost_multiplicative_stability`, `almost_jensen_stability`, `almost_derivation_stability` — the deep extension theorems.",
       "mathContext": "Almost $E$ $\\Rightarrow$ $\\exists$ exact $E$-solution agreeing a.e., for $E \\in \\{$multiplicative, Jensen, derivation$\\}$."
     },
     {
@@ -140,7 +140,7 @@
       "title": "Regularity Theorems",
       "startLine": 360,
       "endLine": 388,
-      "summary": "Axiomatizes regularity results: `measurable_multiplicative_is_power` (measurable multiplicative \u2192 power function) and `measurable_derivation_is_zero` (measurable derivation \u2192 zero).",
+      "summary": "Axiomatizes regularity results: `measurable_multiplicative_is_power` (measurable multiplicative → power function) and `measurable_derivation_is_zero` (measurable derivation → zero).",
       "mathContext": "Measurable $f(xy) = f(x)f(y)$ with $f > 0$: $f(x) = x^c$. Measurable derivation: $d = 0$. Tame vs. wild dichotomy."
     }
   ],
@@ -153,17 +153,17 @@
     {
       "targetId": "erdos-907",
       "relationship": "related",
-      "description": "Decomposition of functions with continuous differences \u2014 studies additive function structure, the same Cauchy equation whose stability is extended here to Jensen, multiplicative, and derivation equations"
+      "description": "Decomposition of functions with continuous differences — studies additive function structure, the same Cauchy equation whose stability is extended here to Jensen, multiplicative, and derivation equations"
     },
     {
       "targetId": "erdos-908",
       "relationship": "related",
-      "description": "Functions with measurable differences \u2014 measure-theoretic conditions on additive functions closely parallel the a.e. stability framework generalized in this entry"
+      "description": "Functions with measurable differences — measure-theoretic conditions on additive functions closely parallel the a.e. stability framework generalized in this entry"
     },
     {
       "targetId": "erdos-1125",
       "relationship": "related",
-      "description": "Kemperman's inequality and monotonicity for functional equations \u2014 another branch of the functional equations tradition, studying convexity constraints related to the Jensen equation formalized here"
+      "description": "Kemperman's inequality and monotonicity for functional equations — another branch of the functional equations tradition, studying convexity constraints related to the Jensen equation formalized here"
     },
     {
       "targetId": "lebesgue-measure",
@@ -184,6 +184,7 @@
   "leanFile": {
     "path": "proofs/Proofs/Erdos1126OQ01Problem.lean",
     "filename": "Erdos1126OQ01Problem.lean",
-    "lineCount": 495
+    "lineCount": 495,
+    "axiomCount": 5
   }
 }

--- a/src/data/proofs/erdos-115-oq-01/meta.json
+++ b/src/data/proofs/erdos-115-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-115-oq-01",
   "title": "Rate of o(1) Correction in Lemniscate Derivatives",
   "slug": "erdos-115-oq-01",
-  "description": "What is the exact rate of the o(1) correction in max|p'| \u2264 (1/2 + o(1))n\u00b2 on connected lemniscates? Formalizes the correction term, defines possible rates (O(1/n), O(1/log n), O(1/\u221an), O(n^{-\u03b1})), and states the open question about which rate is correct.",
+  "description": "What is the exact rate of the o(1) correction in max|p'| ≤ (1/2 + o(1))n² on connected lemniscates? Formalizes the correction term, defines possible rates (O(1/n), O(1/log n), O(1/√n), O(n^{-α})), and states the open question about which rate is correct.",
   "meta": {
     "author": "Eremenko, Lempert; Pommerenke",
     "sourceUrl": "https://erdosproblems.com/115",
@@ -24,7 +24,7 @@
     "assumptions": [
       "ComplexPoly, IsLemniscateConnected, maxDerivOnLemniscate: definitional",
       "maxDeriv_nonneg: non-negativity",
-      "eremenko_lempert: main (1/2+o(1))n\u00b2 bound",
+      "eremenko_lempert: main (1/2+o(1))n² bound",
       "chebyshev_poly, chebyshev_connected, chebyshev_asymptotic: Chebyshev extremals",
       "supCorrection, supCorrection_upper, correction_tends_to_zero: correction framework"
     ],
@@ -39,5 +39,8 @@
     "openQuestionOf": "erdos-115",
     "lineCount": 176
   },
-  "sections": []
+  "sections": [],
+  "leanFile": {
+    "axiomCount": 11
+  }
 }

--- a/src/data/proofs/erdos-1168/meta.json
+++ b/src/data/proofs/erdos-1168/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-1168",
-  "title": "Erd\u0151s Problem #1168: Negative Partition Relation for \u2135_{\u03c9+1}",
+  "title": "Erdős Problem #1168: Negative Partition Relation for ℵ_{ω+1}",
   "slug": "erdos-1168",
-  "description": "Prove \u2135_{\u03c9+1} \u219b (\u2135_{\u03c9+1}, 3, \u2026, 3)_{\u2135\u2080}\u00b2 without GCH. Open problem in set-theoretic combinatorics at the intersection of partition calculus and pcf theory.",
+  "description": "Prove ℵ_{ω+1} ↛ (ℵ_{ω+1}, 3, …, 3)_{ℵ₀}² without GCH. Open problem in set-theoretic combinatorics at the intersection of partition calculus and pcf theory.",
   "meta": {
     "erdosNumber": 1168,
     "status": "axiomatized",
@@ -29,7 +29,8 @@
     "dateAdded": "2026-03-28"
   },
   "leanFile": {
-    "lineCount": 153
+    "lineCount": 153,
+    "axiomCount": 1
   },
   "sections": []
 }

--- a/src/data/proofs/erdos-19-oq-01/meta.json
+++ b/src/data/proofs/erdos-19-oq-01/meta.json
@@ -2,9 +2,9 @@
   "id": "erdos-19-oq-01",
   "title": "Explicit Bounds on the EFL Threshold",
   "slug": "erdos-19-oq-01",
-  "description": "What is the explicit threshold N\u2080 such that the Kang-Kelly-K\u00fchn-Methuku-Osthus asymptotic proof of the Erd\u0151s-Faber-Lov\u00e1sz conjecture takes over? This formalization defines the threshold, proves the finite reduction theorem (EFL reduces to checking finitely many cases in [10, N\u2080)), and establishes structural bounds.",
+  "description": "What is the explicit threshold N₀ such that the Kang-Kelly-Kühn-Methuku-Osthus asymptotic proof of the Erdős-Faber-Lovász conjecture takes over? This formalization defines the threshold, proves the finite reduction theorem (EFL reduces to checking finitely many cases in [10, N₀)), and establishes structural bounds.",
   "meta": {
-    "author": "Kang, Kelly, K\u00fchn, Methuku, Osthus (2021); Hindman (1981)",
+    "author": "Kang, Kelly, Kühn, Methuku, Osthus (2021); Hindman (1981)",
     "sourceUrl": "https://erdosproblems.com/19",
     "date": "2021",
     "status": "axiomatized",
@@ -64,5 +64,8 @@
     "openQuestionOf": "erdos-19",
     "lineCount": 394
   },
-  "sections": []
+  "sections": [],
+  "leanFile": {
+    "axiomCount": 3
+  }
 }

--- a/src/data/proofs/erdos-225/meta.json
+++ b/src/data/proofs/erdos-225/meta.json
@@ -122,7 +122,7 @@
     ],
     "namespace": "Erdos225",
     "lineCount": 339,
-    "axiomCount": 2,
+    "axiomCount": 3,
     "theoremCount": 9,
     "definitionCount": 8
   },

--- a/src/data/proofs/erdos-349/meta.json
+++ b/src/data/proofs/erdos-349/meta.json
@@ -185,6 +185,7 @@
     ]
   },
   "leanFile": {
-    "lineCount": 101
+    "lineCount": 101,
+    "axiomCount": 4
   }
 }

--- a/src/data/proofs/erdos-533/meta.json
+++ b/src/data/proofs/erdos-533/meta.json
@@ -144,7 +144,7 @@
     "opens": [],
     "namespace": null,
     "lineCount": 265,
-    "axiomCount": 3,
+    "axiomCount": 4,
     "theoremCount": 15,
     "definitionCount": 5
   },

--- a/src/data/proofs/erdos-684/meta.json
+++ b/src/data/proofs/erdos-684/meta.json
@@ -174,7 +174,7 @@
     ],
     "namespace": "Erdos684",
     "lineCount": 395,
-    "axiomCount": 5,
+    "axiomCount": 6,
     "theoremCount": 11,
     "definitionCount": 10
   },

--- a/src/data/proofs/erdos-725/meta.json
+++ b/src/data/proofs/erdos-725/meta.json
@@ -99,7 +99,8 @@
       "permanent",
       "GeneralAsymptotic",
       "ExtendedConjecture"
-    ]
+    ],
+    "axiomCount": 9
   },
   "overview": {
     "historicalContext": "A $k \\times n$ Latin rectangle is a $k \\times n$ array filled with $n$ symbols such that each symbol appears exactly once per row and at most once per column. When $k = n$, this is a Latin square — objects studied since Euler's work on the 36 officers problem (1782).\n\nThe enumeration of Latin rectangles began with Euler and was pursued systematically in the 20th century. Erdős and Kaplansky (1946) proved the first asymptotic formula: $L(k,n) \\sim e^{-\\binom{k}{2}} (n!)^k$ when $k = o((\\log n)^{3/2-\\varepsilon})$. Their proof used a careful inclusion-exclusion sieve over column collision events, counting the expected number of repeated entries in any column and showing the higher-order correction terms vanish in this regime.\n\nYamamoto (1951) dramatically extended the validity of this formula to $k \\leq n^{1/3-o(1)}$, improving the growth from logarithmic to polynomial. This extension required refined estimates on the permanent of certain 0-1 matrices.\n\nGodsil and McKay (1990) connected Latin rectangle counting to matrix permanents, establishing two-sided bounds $c_1 \\cdot e^{-\\binom{k}{2}}(n!)^k \\leq L(k,n) \\leq c_2 \\cdot e^{-\\binom{k}{2}}(n!)^k$. Their work leveraged the resolution of van der Waerden's permanent conjecture by Egorychev (1981) and Falikman (1981). McKay and Wanless (2005) later extended the asymptotic to $k = o(n^{6/7})$, the current frontier. The full problem for $k = \\Theta(n)$ remains open.",

--- a/src/data/proofs/erdos-909-oq-01/meta.json
+++ b/src/data/proofs/erdos-909-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-909-oq-01",
   "title": "Characterize Dimension-Stable Spaces",
   "slug": "erdos-909-oq-01",
-  "description": "Characterize all topological spaces S with dim(S \u00d7 S) = dim(S). Anderson-Keisler showed such spaces exist for all n \u2265 1, but the structural criterion is unknown. This formalization defines dimension-stability, proves necessary conditions from the product inequality, handles the 0-dimensional case, and shows that dimension mismatch precludes stability.",
+  "description": "Characterize all topological spaces S with dim(S × S) = dim(S). Anderson-Keisler showed such spaces exist for all n ≥ 1, but the structural criterion is unknown. This formalization defines dimension-stability, proves necessary conditions from the product inequality, handles the 0-dimensional case, and shows that dimension mismatch precludes stability.",
   "meta": {
     "author": "Anderson, Keisler (1967); Engelking (1978)",
     "sourceUrl": "https://erdosproblems.com/909",
@@ -35,5 +35,8 @@
     "openQuestionOf": "erdos-909",
     "lineCount": 255
   },
-  "sections": []
+  "sections": [],
+  "leanFile": {
+    "axiomCount": 2
+  }
 }

--- a/src/data/proofs/four-color-theorem-oq-02/meta.json
+++ b/src/data/proofs/four-color-theorem-oq-02/meta.json
@@ -2,7 +2,7 @@
   "id": "four-color-theorem-oq-02",
   "title": "Minimal Unavoidable Reducible Configurations",
   "slug": "four-color-theorem-oq-02",
-  "description": "Formalizes the theory of unavoidable reducible configuration sets for the Four Color Theorem. Historical progression: Appel-Haken 1476 \u2192 RSST 633. Open: minimum size unknown.",
+  "description": "Formalizes the theory of unavoidable reducible configuration sets for the Four Color Theorem. Historical progression: Appel-Haken 1476 → RSST 633. Open: minimum size unknown.",
   "meta": {
     "author": "Robertson-Sanders-Seymour-Thomas (1997)",
     "date": "1997",
@@ -20,5 +20,8 @@
     "axiomCount": 3,
     "lineCount": 110
   },
-  "sections": []
+  "sections": [],
+  "leanFile": {
+    "axiomCount": 3
+  }
 }

--- a/src/data/proofs/fourier-series-oq-04/meta.json
+++ b/src/data/proofs/fourier-series-oq-04/meta.json
@@ -20,5 +20,8 @@
     "axiomCount": 5,
     "lineCount": 133
   },
-  "sections": []
+  "sections": [],
+  "leanFile": {
+    "axiomCount": 5
+  }
 }

--- a/src/data/proofs/hilbert-13-oq-04/meta.json
+++ b/src/data/proofs/hilbert-13-oq-04/meta.json
@@ -160,7 +160,8 @@
   },
   "leanFile": {
     "path": "proofs/Proofs/Hilbert13GeneralSpaces.lean",
-    "filename": "Hilbert13GeneralSpaces.lean"
+    "filename": "Hilbert13GeneralSpaces.lean",
+    "axiomCount": 6
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/konigsberg-oq-03/meta.json
+++ b/src/data/proofs/konigsberg-oq-03/meta.json
@@ -20,5 +20,8 @@
     "axiomCount": 4,
     "lineCount": 101
   },
-  "sections": []
+  "sections": [],
+  "leanFile": {
+    "axiomCount": 4
+  }
 }

--- a/src/data/proofs/motivic-flag-maps-oq-02/meta.json
+++ b/src/data/proofs/motivic-flag-maps-oq-02/meta.json
@@ -129,5 +129,8 @@
       "relationship": "parent",
       "description": "Parent proof formalizing the complete flag case of Bryan et al."
     }
-  ]
+  ],
+  "leanFile": {
+    "axiomCount": 2
+  }
 }

--- a/src/data/proofs/p-vs-np/meta.json
+++ b/src/data/proofs/p-vs-np/meta.json
@@ -124,7 +124,8 @@
     ],
     "opens": [
       "ComplexityCore"
-    ]
+    ],
+    "axiomCount": 121
   },
   "overview": {
     "historicalContext": "The P vs NP problem is one of the most important unsolved problems in mathematics and computer science, designated a Clay Mathematics Institute Millennium Prize Problem in 2000 with a $1,000,000 reward.\n\nThe foundations were laid by Alan Turing (1936) with the formalization of computation, and by Juris Hartmanis and Richard Stearns (1965) who established computational complexity theory with the Time Hierarchy Theorem. Stephen Cook (1971) formulated the P vs NP question and proved the Cook-Levin theorem, showing that the Boolean satisfiability problem (SAT) is NP-complete — the first problem shown to have this property. Leonid Levin independently proved the same result in 1973 in the Soviet Union.\n\nRichard Karp (1972) demonstrated the practical significance by showing 21 natural combinatorial problems are NP-complete via reduction chains from SAT, including CLIQUE, VERTEX COVER, HAMILTONIAN PATH, and SUBSET SUM. Russell Ladner (1975) proved that if P ≠ NP, then NP-intermediate problems must exist — problems in NP that are neither in P nor NP-complete.\n\nDespite over 50 years of effort, the problem remains open. Three major 'barrier results' explain why traditional proof techniques have failed: relativization (Baker-Gill-Solovay, 1975), natural proofs (Razborov-Rudich, 1994), and algebrization (Aaronson-Wigderson, 2009). Any proof must circumvent all three barriers simultaneously.",

--- a/src/data/proofs/roth-theorem-k3-oq-03/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03/meta.json
@@ -21,5 +21,8 @@
     "assumptions": "2 axioms: generalized_von_neumann (k-AP count controlled by U^{k-1} norm via Gowers-Cauchy-Schwarz), density_increment_kAP (density increases on subprogression for k-AP-free sets). gowersNorm and kAPCount are now constructive definitions.",
     "lineCount": 259
   },
-  "sections": []
+  "sections": [],
+  "leanFile": {
+    "axiomCount": 2
+  }
 }

--- a/src/data/proofs/sylow-theorems-oq-02/meta.json
+++ b/src/data/proofs/sylow-theorems-oq-02/meta.json
@@ -225,6 +225,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 393
+    "lineCount": 393,
+    "axiomCount": 5
   }
 }


### PR DESCRIPTION
## Fix

Corrected `leanFile.axiomCount` in 27 meta.json files where the recorded count was lower than the actual number of `axiom` declarations in the Lean source files. These proofs had axioms not reflected in their metadata.

## Evidence

**Before**: 27 proofs had axiomCount lower than reality (some had 0 when the Lean file had 3-121 axioms).

**After**: All 27 axiomCounts match actual `axiom` declarations in the corresponding Lean files.

Notable corrections:
| Proof | Before | After |
|-------|--------|-------|
| p-vs-np | 0 | 121 |
| erdos-115-oq-01 | 0 | 11 |
| erdos-725 | 0 | 9 |
| hilbert-13-oq-04 | 0 | 6 |
| borsuk-ulam-oq-02-oq-03 | 0 | 5 |
| fourier-series-oq-04 | 0 | 5 |
| erdos-1126-oq-01 | 0 | 5 |
| sylow-theorems-oq-02 | 0 | 5 |

Note: Only fixed _undercounted_ axioms (meta < actual). Cases where meta > actual may reflect legitimate structure-encoded assumptions per the axiom integrity policy.

---
Automated fix by lean-mechanic agent.