### PR TITLE
fix: correct sorry counts for 6 proofs

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1226,8 +1226,8 @@
       "issues": []
     },
     "erdos-138": {
-      "auditCount": 2,
-      "lastAudited": "2026-03-24T18:30:00Z",
+      "auditCount": 3,
+      "lastAudited": "2026-03-30T13:40:31Z",
       "result": "issues-fixed",
       "issues": [
         "PR #6446: sorries 4\u21925"
@@ -1250,8 +1250,8 @@
       ]
     },
     "erdos-746": {
-      "auditCount": 3,
-      "lastAudited": "2026-03-30T03:28:55Z",
+      "auditCount": 4,
+      "lastAudited": "2026-03-30T13:40:31Z",
       "result": "issues-fixed",
       "issues": [
         "PR #6440: sorry count 3\u21924",
@@ -9879,8 +9879,8 @@
       "issues": []
     },
     "dirichlets-theorem-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-03-29T17:00:23Z",
+      "auditCount": 2,
+      "lastAudited": "2026-03-30T13:40:31Z",
       "result": "issues-fixed",
       "issues": []
     },
@@ -10068,6 +10068,18 @@
       "auditCount": 1,
       "lastAudited": "2026-03-30T05:08:28Z",
       "result": "issues-fixed",
+      "issues": []
+    },
+    "amgm-inequality-oq-03-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T13:41:29Z",
+      "result": "clean",
+      "issues": []
+    },
+    "angle-trisection-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T13:41:29Z",
+      "result": "clean",
       "issues": []
     }
   },

--- a/src/data/proofs/dirichlets-theorem-oq-03/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-03/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "axiomCount": 2,
     "lineCount": 139
   },

--- a/src/data/proofs/erdos-138/meta.json
+++ b/src/data/proofs/erdos-138/meta.json
@@ -37,7 +37,7 @@
       "Proof schema: main conjecture implies ExponentialDiverges"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 5,
     "erdosNumber": 138,
     "erdosUrl": "https://erdosproblems.com/138",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-392/meta.json
+++ b/src/data/proofs/erdos-392/meta.json
@@ -17,7 +17,7 @@
       "number-theory"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "erdosNumber": 392,
     "erdosUrl": "https://erdosproblems.com/392",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-402/meta.json
+++ b/src/data/proofs/erdos-402/meta.json
@@ -17,7 +17,7 @@
       "solved"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 2,
     "erdosNumber": 402,
     "erdosUrl": "https://erdosproblems.com/402",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-628/meta.json
+++ b/src/data/proofs/erdos-628/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 11,
+    "sorries": 12,
     "erdosNumber": 628,
     "erdosUrl": "https://erdosproblems.com/628",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-746/meta.json
+++ b/src/data/proofs/erdos-746/meta.json
@@ -19,7 +19,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "erdosNumber": 746,
     "erdosUrl": "https://erdosproblems.com/746",
     "erdosProblemStatus": "solved",


### PR DESCRIPTION
## Summary

Gallery audit cycle found sorry count mismatches in 6 proofs. Root cause: multiple `sorry`/`by sorry` on a single line were undercounted.

- **erdos-138**: sorries 4→5 (line 46: two `by sorry` in one term)
- **erdos-402**: sorries 1→2 (main conjecture line 99 + quadruple hard case line 457)
- **erdos-628**: sorries 11→12 (line 209: two sorry'd type annotations)
- **erdos-392**: sorries 2→3 (line 218: two `by sorry`)
- **dirichlets-theorem-oq-03**: sorries 2→3 (line 34: `⟨sorry, sorry⟩`)
- **erdos-746**: sorries 2→3 (line 90: two `by sorry`)

Also audited 2 proofs clean: amgm-inequality-oq-03-oq-03, angle-trisection-oq-02-oq-01-oq-01.

## Test plan

- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)