### PR TITLE
fix: add missing summary fields to shannon-channel-coding-oq-02 sections

### DIFF
--- a/src/data/proofs/shannon-channel-coding-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02/meta.json
@@ -54,9 +54,9 @@
     "historicalContext": "The binary symmetric channel (BSC) is the simplest non-trivial noisy channel model and serves as the canonical example for Shannon's channel coding theorem. Shannon showed that the capacity of BSC(p) -- the crossover probability -- equals 1 - h(p) bits (or log 2 - h(p) nats), where h(p) is the binary entropy function. This result demonstrates that reliable communication is possible even over noisy channels, as long as the data rate stays below C.\n\nThe capacity-achieving input distribution for BSC is uniform (Bernoulli 1/2), which follows from the symmetric structure of the channel. The key insight is that BSC is doubly stochastic: both row sums and column sums of the transition matrix equal 1. This means uniform input produces uniform output, maximizing the output entropy H(Y) = log 2.\n\nThe random coding argument, also due to Shannon, shows that randomly chosen codebooks achieve rates below capacity with high probability. The existence of a good deterministic codebook then follows by the probabilistic method -- if the expected error is small, at least one specific codebook must have small error.",
     "problemStatement": "**BSC Capacity Formula**: For a binary symmetric channel with crossover probability $0 < p < 1$:\n$$C(\\text{BSC}(p)) = \\log 2 - h(p) \\text{ nats}$$\nwhere $h(p) = -(p \\ln p + (1-p) \\ln(1-p))$ is the binary entropy function.\n\n**Random Coding Existence**: If the average error probability over a random ensemble of codebooks is at most $\\varepsilon$, then there exists a specific codebook with error probability $\\leq \\varepsilon$.",
     "text": "Proves BSC capacity = log 2 - h(p) and establishes the random coding existence lemma.",
-    "proofStrategy": "The capacity proof has five stages:\n\n1. **BSC symmetry**: Show that for BSC, the per-input output entropy sum ∑_y W(x,y)·log W(x,y) = p·log(p) + (1-p)·log(1-p) is independent of the input symbol x.\n\n2. **H(Y|X) = h(p)**: Unfold the conditional entropy definition on the transposed joint distribution. All joint probabilities are positive, so simplify: the denominator ∑_y' p(x)·W(x,y') = p(x) cancels, giving ∑_x p(x) · ∑_y W(x,y)·log W(x,y) = -h(p). Negate to get h(p).\n\n3. **Chain rule**: MI(X;Y) = H(Y) - H(Y|X) via mutual information symmetry and the chain rule.\n\n4. **Upper bound**: MI ≤ H(Y) - h(p) ≤ log|Bool| - h(p) = log 2 - h(p) for all inputs.\n\n5. **Capacity**: Uniform Bernoulli(1/2) input achieves equality (BSC is doubly stochastic, so output is also uniform with H(Y) = log 2). The supremum equals this maximum value.",
+    "proofStrategy": "The capacity proof has five stages:\n\n1. **BSC symmetry**: Show that for BSC, the per-input output entropy sum \u2211_y W(x,y)\u00b7log W(x,y) = p\u00b7log(p) + (1-p)\u00b7log(1-p) is independent of the input symbol x.\n\n2. **H(Y|X) = h(p)**: Unfold the conditional entropy definition on the transposed joint distribution. All joint probabilities are positive, so simplify: the denominator \u2211_y' p(x)\u00b7W(x,y') = p(x) cancels, giving \u2211_x p(x) \u00b7 \u2211_y W(x,y)\u00b7log W(x,y) = -h(p). Negate to get h(p).\n\n3. **Chain rule**: MI(X;Y) = H(Y) - H(Y|X) via mutual information symmetry and the chain rule.\n\n4. **Upper bound**: MI \u2264 H(Y) - h(p) \u2264 log|Bool| - h(p) = log 2 - h(p) for all inputs.\n\n5. **Capacity**: Uniform Bernoulli(1/2) input achieves equality (BSC is doubly stochastic, so output is also uniform with H(Y) = log 2). The supremum equals this maximum value.",
     "keyInsights": [
-      "BSC is doubly stochastic: uniform input → uniform output, maximizing H(Y) = log 2",
+      "BSC is doubly stochastic: uniform input \u2192 uniform output, maximizing H(Y) = log 2",
       "H(Y|X) = h(p) for BSC regardless of input distribution, because the channel noise is input-independent",
       "The chain rule MI = H(Y) - H(Y|X) immediately gives both the achievable MI value and the upper bound",
       "For degenerate (point mass) inputs, MI = 0 because H(X) = 0, providing the edge case in the capacity proof",
@@ -75,70 +75,80 @@
       "title": "Uniform Input Distribution",
       "startLine": 33,
       "endLine": 41,
-      "description": "Defines the uniform Bernoulli(1/2) distribution on Bool and proves positivity."
+      "description": "Defines the uniform Bernoulli(1/2) distribution on Bool and proves positivity.",
+      "summary": "Defines the uniform Bernoulli(1/2) distribution on Bool and proves positivity."
     },
     {
       "id": "bsc-properties",
       "title": "BSC Properties",
       "startLine": 43,
       "endLine": 54,
-      "description": "BSC transition probability positivity for 0 < p < 1."
+      "description": "BSC transition probability positivity for 0 < p < 1.",
+      "summary": "BSC transition probability positivity for 0 < p < 1."
     },
     {
       "id": "marginals",
       "title": "Channel Marginal Distributions",
       "startLine": 56,
       "endLine": 72,
-      "description": "X-marginal equals input distribution; BSC+uniform Y-marginal is uniform."
+      "description": "X-marginal equals input distribution; BSC+uniform Y-marginal is uniform.",
+      "summary": "X-marginal equals input distribution; BSC+uniform Y-marginal is uniform."
     },
     {
       "id": "bsc-symmetry",
       "title": "BSC Output Entropy Symmetry",
       "startLine": 74,
       "endLine": 85,
-      "description": "Per-input output entropy is constant across all input symbols."
+      "description": "Per-input output entropy is constant across all input symbols.",
+      "summary": "Per-input output entropy is constant across all input symbols."
     },
     {
       "id": "chain-rule",
       "title": "Chain Rule: MI = H(Y) - H(Y|X)",
       "startLine": 87,
       "endLine": 100,
-      "description": "Derives the H(Y) - H(Y|X) form of mutual information via symmetry and the standard chain rule."
+      "description": "Derives the H(Y) - H(Y|X) form of mutual information via symmetry and the standard chain rule.",
+      "summary": "Derives the H(Y) - H(Y|X) form of mutual information via symmetry and the standard chain rule."
     },
     {
       "id": "conditional-entropy",
       "title": "BSC Conditional Output Entropy",
       "startLine": 102,
       "endLine": 146,
-      "description": "The main computation: H(Y|X) = h(p) for BSC with any positive input distribution."
+      "description": "The main computation: H(Y|X) = h(p) for BSC with any positive input distribution.",
+      "summary": "The main computation: H(Y|X) = h(p) for BSC with any positive input distribution."
     },
     {
       "id": "uniform-entropy",
       "title": "Entropy of Uniform Distribution",
       "startLine": 148,
       "endLine": 161,
-      "description": "Shannon entropy of uniform distribution on Bool equals log 2."
+      "description": "Shannon entropy of uniform distribution on Bool equals log 2.",
+      "summary": "Shannon entropy of uniform distribution on Bool equals log 2."
     },
     {
       "id": "bsc-mi",
       "title": "BSC Mutual Information Bounds",
       "startLine": 163,
       "endLine": 220,
-      "description": "MI = log 2 - h(p) for uniform input; MI ≤ log 2 - h(p) for all inputs."
+      "description": "MI = log 2 - h(p) for uniform input; MI \u2264 log 2 - h(p) for all inputs.",
+      "summary": "MI = log 2 - h(p) for uniform input; MI \u2264 log 2 - h(p) for all inputs."
     },
     {
       "id": "capacity",
       "title": "BSC Capacity Theorem",
       "startLine": 222,
       "endLine": 240,
-      "description": "Channel capacity equals log 2 - h(p), proved via antisymmetry of sSup."
+      "description": "Channel capacity equals log 2 - h(p), proved via antisymmetry of sSup.",
+      "summary": "Channel capacity equals log 2 - h(p), proved via antisymmetry of sSup."
     },
     {
       "id": "random-coding",
       "title": "Random Coding Existence Lemma",
       "startLine": 242,
       "endLine": 262,
-      "description": "The probabilistic method for codebook selection in Shannon's achievability proof."
+      "description": "The probabilistic method for codebook selection in Shannon's achievability proof.",
+      "summary": "The probabilistic method for codebook selection in Shannon's achievability proof."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Adds required `summary` field to all 10 sections in `shannon-channel-coding-oq-02/meta.json`
- Fixes TypeScript build error where `ProofSection` type requires `summary` but sections only had `description`
- Uses the existing `description` value as the `summary` content

## Test plan
- [ ] `pnpm build` passes without TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)