### PR TITLE
fix: correct conclusion field names in shannon-channel-coding-oq-02

### DIFF
--- a/src/data/proofs/shannon-channel-coding-oq-02/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02/meta.json
@@ -153,8 +153,8 @@
   ],
   "conclusion": {
     "summary": "This formalization proves the binary symmetric channel capacity formula C(BSC(p)) = log 2 - h(p) entirely from Mathlib and the existing Shannon entropy infrastructure, with zero axioms and zero sorries. The proof leverages the doubly stochastic structure of BSC to show that uniform input maximizes mutual information. The random coding existence lemma establishes the probabilistic method step needed for Shannon's full achievability proof.",
-    "impact": "Eliminates one of four axioms from the parent ShannonChannelCoding.lean formalization. The BSC capacity result is the most concrete and widely-cited application of the channel coding theorem.",
-    "futureWork": [
+    "implications": "Eliminates one of four axioms from the parent ShannonChannelCoding.lean formalization. The BSC capacity result is the most concrete and widely-cited application of the channel coding theorem.",
+    "openQuestions": [
       "Prove Fano's inequality (another parent axiom) from the conditional entropy machinery",
       "Formalize the joint typicality lemma needed for the full achievability proof",
       "Prove the channel coding converse using Fano's inequality",


### PR DESCRIPTION
## Summary
- Renames `impact` → `implications` and `futureWork` → `openQuestions` in conclusion
- Matches `ProofConclusion` type interface requirements
- Second fix for #8403 build failure

## Test plan
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)