### PR TITLE
Research: shapley-folkman — add linearDependent_coefficients lemma

### DIFF
--- a/proofs/Proofs/ShapleyFolkman.lean
+++ b/proofs/Proofs/ShapleyFolkman.lean
@@ -188,6 +188,22 @@ The reduction step (reduce_excess_by_one) works as follows:
   f. The result has one fewer excess index
 -/
 
+/-- **Linear dependence extraction**: d+1 vectors in d-dimensional space are
+    linearly dependent, and we can extract explicit coefficients.
+    This is the key algebraic input for the perturbation argument. -/
+theorem linearDependent_coefficients [FiniteDimensional ℝ E]
+    {n : ℕ} (hn : Module.finrank ℝ E < n) (f : Fin n → E) :
+    ∃ (c : Fin n → ℝ), (∃ i, c i ≠ 0) ∧ ∑ i, c i • f i = 0 := by
+  have hli : ¬LinearIndependent ℝ f := by
+    intro h
+    have := h.fintype_card_le_finrank
+    simp [Fintype.card_fin] at this
+    omega
+  rw [Fintype.linearIndependent_iff] at hli
+  push_neg at hli
+  obtain ⟨g, hg_sum, i, hi_ne⟩ := hli
+  exact ⟨g, ⟨i, hi_ne⟩, hg_sum⟩
+
 /-- A decomposition can always be constructed from the hypothesis. -/
 theorem exists_decomposition
     {ι : Type*} [DecidableEq ι] {S : ι → Set E} {t : Finset ι}


### PR DESCRIPTION
## Summary
- Add `linearDependent_coefficients` lemma to ShapleyFolkman.lean
- Extracts explicit linear dependence coefficients for d+1 vectors in d-dimensional space
- Key sub-step for the `reduce_excess_by_one` perturbation argument

## Progress
**File**: `proofs/Proofs/ShapleyFolkman.lean`
**Sorries**: 3 remain (reduce_excess_by_one, 2 corollaries)
**New**: `linearDependent_coefficients` — proved from Mathlib's `Fintype.linearIndependent_iff`

## Context
The `reduce_excess_by_one` proof needs:
1. Binary representations for excess indices (from `convexHull_not_mem_requires_two`)
2. **Linear dependence of d+1 direction vectors** (NOW PROVED: `linearDependent_coefficients`)
3. Epsilon selection for perturbation
4. New decomposition construction

## Status
**Outcome**: progress
**Next Steps**: Prove reduce_excess_by_one using the new helper lemma

🤖 Generated by researcher-8