### PR TITLE
fix: correct minor metadata for 2 proofs after audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10081,6 +10081,66 @@
       "lastAudited": "2026-03-30T13:41:29Z",
       "result": "clean",
       "issues": []
+    },
+    "angle-trisection-oq-05-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T14:03:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "area-of-circle-oq-01-oq-02-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T14:03:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "arithmetic-series-oq-02-oq-02-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T14:03:50Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bezout-identity-oq-04-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T14:03:50Z",
+      "result": "clean",
+      "issues": []
+    },
+    "binary-gcd": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T14:03:50Z",
+      "result": "clean",
+      "issues": []
+    },
+    "binary-gcd-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T14:05:18Z",
+      "result": "clean",
+      "issues": []
+    },
+    "binomial-theorem-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T14:05:18Z",
+      "result": "clean",
+      "issues": []
+    },
+    "birthday-problem-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T14:05:18Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "borsuk-ulam-oq-02-oq-01-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T14:05:18Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bounded-prime-gaps-oq-04-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T14:05:18Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "descartes-rule-of-signs-oq-02": {

--- a/src/data/proofs/birthday-problem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01/meta.json
@@ -123,8 +123,8 @@
     "namespace": "BirthdayKWayThreshold",
     "lineCount": 245,
     "axiomCount": 0,
-    "theoremCount": 14,
-    "definitionCount": 5
+    "theoremCount": 15,
+    "definitionCount": 4
   },
   "references": [
     {

--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-01/meta.json
@@ -18,7 +18,7 @@
     "badge": "formalized",
     "sorries": 5,
     "axiomCount": 0,
-    "lineCount": 198,
+    "lineCount": 203,
     "assumptions": "0 axioms. 5 sorries (Gauss sum norm, geometric series bound, cotangent sum, PV inequality, complete sum). Theorem statements and proof strategy documented.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0"


### PR DESCRIPTION
## Summary

Gallery audit cycle 3: audited 12 proofs, found 2 minor metadata issues.

**Fixes:**
- **birthday-problem-oq-03-oq-01**: leanFile.theoremCount 14→15, definitionCount 5→4
- **bounded-prime-gaps-oq-04-oq-01**: lineCount 198→203

**Clean audits (10):** angle-trisection-oq-05-oq-01, area-of-circle-oq-01-oq-02-oq-02-oq-01, arithmetic-series-oq-02-oq-02-oq-03, bezout-identity-oq-04-oq-01, binary-gcd, binary-gcd-oq-01, binomial-theorem-oq-02-oq-02, amgm-inequality-oq-03-oq-03, borsuk-ulam-oq-02-oq-01-oq-04, angle-trisection-oq-02-oq-01-oq-01.

## Test plan

- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)