### PR TITLE
chore: sync research listings and data

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -9254,19 +9254,21 @@
     },
     {
       "slug": "bezout-identity-oq-02-oq-01-oq-02",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T13:07:48.617Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T13:07:48.617Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T14:14:09.298Z",
+      "completed": "2026-03-30T14:14:09.298Z"
     },
     {
       "slug": "bezout-identity-oq-04-oq-01-oq-01",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T13:07:48.618Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T13:07:48.618Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T14:14:09.272Z",
+      "completed": "2026-03-30T14:14:09.272Z"
     },
     {
       "slug": "binomial-theorem-oq-02-oq-01-oq-01",
@@ -9286,11 +9288,12 @@
     },
     {
       "slug": "borsuk-ulam-oq-02-oq-02-oq-01",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T13:07:48.618Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T13:07:48.618Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T14:14:09.298Z",
+      "completed": "2026-03-30T14:14:09.298Z"
     },
     {
       "slug": "cantor-diagonalization-oq-01-oq-01-oq-02",
@@ -9361,27 +9364,30 @@
     },
     {
       "slug": "euler-totient-oq-01",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T13:52:05.694Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T13:52:05.694Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T14:14:09.302Z",
+      "completed": "2026-03-30T14:14:09.302Z"
     },
     {
       "slug": "feuerbachs-theorem-oq-02",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T13:52:05.694Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T13:52:05.694Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T14:14:09.303Z",
+      "completed": "2026-03-30T14:14:09.303Z"
     },
     {
       "slug": "fundamental-arithmetic-oq-02",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T13:52:05.694Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T13:52:05.694Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T14:14:09.303Z",
+      "completed": "2026-03-30T14:14:09.303Z"
     },
     {
       "slug": "konigsberg-oq-04",
@@ -9393,19 +9399,21 @@
     },
     {
       "slug": "kummer-theorem-oq-01",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T13:52:05.694Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T13:52:05.694Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T14:14:09.304Z",
+      "completed": "2026-03-30T14:14:09.304Z"
     },
     {
       "slug": "laws-of-large-numbers-oq-03",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T13:52:05.694Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T13:52:05.694Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T14:14:09.304Z",
+      "completed": "2026-03-30T14:14:09.304Z"
     },
     {
       "slug": "leibniz-pi-oq-02",


### PR DESCRIPTION
## Summary
- Sync research listings and data after merging PRs #8409, #8408, #8406
- Updated 557 listings, added 42 new entries
- Total iterations: 3292

Automated deployer sync.