### PR TITLE
fix: correct metadata for 3 proofs, audit 6 proofs total

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-04-oq-01/meta.json
@@ -17,7 +17,7 @@
     ],
     "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ04OQ01.lean",
     "badge": "formalized",
-    "sorries": 7,
+    "sorries": 6,
     "mathlibDependencies": [
       {
         "theorem": "IsPGroup.isSolvable",
@@ -48,7 +48,7 @@
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
     "lineCount": 311,
-    "assumptions": "No axioms. 7 sorries for deep theorems requiring Mathlib API glue: finrank multiplicativity for intermediate fields, index-2 subgroup existence, both directions of Tower ↔ Galois, and concrete examples.",
+    "assumptions": "No axioms. 6 sorries for deep theorems requiring Mathlib API glue: finrank multiplicativity for intermediate fields, index-2 subgroup existence, both directions of Tower ↔ Galois, and concrete examples.",
     "originalContributions": [
       "Proper inductive definition of QuadraticTower replacing the alias TowerCriterion = DegreeCriterion",
       "Statement and proof structure of Tower ↔ Galois 2-group equivalence",

--- a/src/data/proofs/erdos-195/meta.json
+++ b/src/data/proofs/erdos-195/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 195,
     "erdosUrl": "https://erdosproblems.com/195",
     "erdosProblemStatus": "open",
@@ -49,8 +49,8 @@
       "erdos_195_summary: combining upper and lower bounds"
     ],
     "axiomCount": 3,
-    "lineCount": 135,
-    "assumptions": "3 axiom(s) and 1 sorry(s). See the Lean source for details."
+    "lineCount": 149,
+    "assumptions": "3 axioms (geneson_2019, adenwalla_2022, trivial_lower_bound) and 0 sorries. Upper and lower bounds are axiomatized as they encode results from the literature."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #195: Monotone Arithmetic Progressions in Permutations**\n\nPosed by Erdős and Graham around 1979-1980, this problem asks about unavoidable patterns in permutations of the integers. A monotone arithmetic progression (MAP) is a sequence a, a+d, a+2d, ..., a+(k-1)d that appears in increasing order of position in the permutation.\n\n**Progress:** The problem saw no significant progress for decades until Geneson (2019) proved k ≤ 5 by constructing a permutation of ℤ that avoids 6-term MAPs. Adenwalla (2022) improved this to k ≤ 4. The lower bound k ≥ 3 (every permutation has a 3-term MAP) is believed true but non-trivial.\n\n**Current State:** The exact value of k satisfies 3 ≤ k ≤ 4. Determining whether k = 3 or k = 4 remains the central open question. This connects to Ramsey-type phenomena: which patterns are unavoidable in combinatorial structures?",
@@ -153,7 +153,7 @@
     ],
     "opens": [],
     "namespace": "Erdos195",
-    "lineCount": 135,
+    "lineCount": 149,
     "axiomCount": 3,
     "theoremCount": 4,
     "definitionCount": 9

--- a/src/data/proofs/erdos-781/meta.json
+++ b/src/data/proofs/erdos-781/meta.json
@@ -18,7 +18,7 @@
       "disproved"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "erdosNumber": 781,
     "erdosUrl": "https://erdosproblems.com/781",
     "erdosProblemStatus": "disproved",
@@ -52,9 +52,9 @@
       "IsQuasiProgression connection",
       "erdos_781_summary main theorem"
     ],
-    "axiomCount": 11,
-    "assumptions": "11 axiom declarations: f_exists (f(k) well-defined for k >= 1), f_minimal (f(k) is minimal such n), BEF_lower_bound (f(k) >= k^2-k+1), BEF_upper_bound (f(k) <= (k^3-4k+9)/3), alon_spencer_cubic (f(k) >= ck^3 for some c > 0), f_1 (f(1) = 1), f_2 (f(2) = 2), f_3 (f(3) = 7), alon_spencer_construction (coloring avoiding k-waves for n <= ck^3), ascending_descending_similar (both f and g are Theta(k^3)), descending_wave_is_quasi (descending waves are quasi-progressions)",
-    "lineCount": 285
+    "axiomCount": 5,
+    "assumptions": "5 axioms (BEF_lower_bound, alon_spencer_cubic, f_1, f_2, f_3) and 0 sorries. Key bounds axiomatized from Brown-Erdos-Freedman (1990) and Alon-Spencer (1989). The disproof theorem is fully proved from axiomatized small values.",
+    "lineCount": 265
   },
   "overview": {
     "historicalContext": "**Erdős Problem #781: Descending Waves in 2-Colorings**\n\nThis problem concerns monochromatic patterns in 2-colorings of integers, specifically \"descending waves\" where successive gaps are non-increasing.\n\n**Key History:**\n- Brown, Erdős, Freedman (1990): Introduced the problem, proved k² - k + 1 ≤ f(k) ≤ (k³ - 4k + 9)/3\n- Alon, Spencer (1989): DISPROVED the conjecture by showing f(k) ≫ k³\n\n**Mathematical Setting:**\nA descending wave x₁ < x₂ < ... < xₖ satisfies x_j ≥ (x_{j-1} + x_{j+1})/2 for all interior points. Equivalently, the gaps (x_{i+1} - x_i) form a non-increasing sequence.",
@@ -201,9 +201,9 @@
       "Finset"
     ],
     "namespace": "Erdos781",
-    "lineCount": 285,
-    "axiomCount": 11,
-    "theoremCount": 5,
+    "lineCount": 265,
+    "axiomCount": 5,
+    "theoremCount": 6,
     "definitionCount": 11
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-957/meta.json
+++ b/src/data/proofs/erdos-957/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 957,
     "erdosUrl": "https://erdosproblems.com/957",
     "erdosProblemStatus": "solved",
@@ -59,8 +59,8 @@
       "regular_polygon_all_frequent axiom: odd polygons have all distances frequent"
     ],
     "axiomCount": 6,
-    "lineCount": 320,
-    "assumptions": "6 axiom(s) and 5 sorry(s). See the Lean source for details."
+    "lineCount": 326,
+    "assumptions": "6 axioms (dumitrescu_theorem, makai_tight_construction, sum_inequality, convexHullVertices, regularPolygon, regular_polygon_all_frequent) and 2 sorries (stronger_implies_original, erdos_957_summary partial). The key results are axiomatized from the literature."
   },
   "overview": {
     "historicalContext": "**Erdos Problem #957: Product of Extreme Distance Frequencies**\n\nThis problem was posed by Erdos and Pach in 1990 in their paper 'Variations on the theme of repeated distances'. They asked whether the product of minimum and maximum distance frequencies in a planar point set is bounded.\n\n**Key History:**\n- **Erdos-Pach (1990):** Posed the problem; noted Makai's 'easy' construction showing 9/8 is tight\n- **Dumitrescu (2019):** Proved f(d_1)f(d_k) <= (9/8)n^2 + O(n)\n\n**Context:**\nThe problem sits at the intersection of discrete geometry and combinatorics. Understanding how distance frequencies interact constrains the structure of point configurations.",
@@ -177,7 +177,7 @@
       "Real"
     ],
     "namespace": "Erdos957",
-    "lineCount": 320,
+    "lineCount": 326,
     "axiomCount": 6,
     "theoremCount": 6,
     "definitionCount": 9


### PR DESCRIPTION
## Summary

Audit cycle 8: verified 6 gallery proofs against their Lean source files.

**Issues fixed (3 proofs):**
- **angle-trisection-oq-02-oq-04-oq-01**: sorry count 7→6 (line 293 match was in a comment)
- **erdos-195**: sorry count 1→0, lineCount 135→149
- **erdos-781**: sorry count 2→0, axiomCount 11→5 (6 axioms removed from Lean file but meta.json never updated), lineCount 285→265, theoremCount 5→6
- **erdos-957**: sorry count 3→2, lineCount 320→326

**Clean audits (2 proofs):**
- angle-trisection-oq-05-oq-01
- area-of-circle-oq-01-oq-02-oq-02-oq-01

## Test plan
- [ ] `pnpm build` passes
- [ ] Verify corrected sorry/axiom counts match `grep` on Lean source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)