### PR TITLE
fix: correct axiomCount in meta.json for 3 proofs

### DIFF
--- a/src/data/proofs/erdos-455/meta.json
+++ b/src/data/proofs/erdos-455/meta.json
@@ -58,9 +58,9 @@
       "Proved gaps_pos, first_prime_ge_two, all_ge_two from Mathlib",
       "Alternative characterization nonDecGaps_alt with proof"
     ],
-    "axiomCount": 4,
+    "axiomCount": 1,
     "lineCount": 152,
-    "assumptions": "4 axioms: richter_lower_bound, erdos_455_conjecture, erdos_455_statement, and 1 more. See Lean source for complete statements."
+    "assumptions": "1 axiom: erdos_455_conjecture (the open conjecture stated as an abstract Prop)."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #455: Monotone Prime Gap Sequences**\n\nThis problem concerns sequences of primes where consecutive gaps never decrease — a discrete convexity condition. Such sequences must spread out increasingly, but the question is: how fast?\n\n**Historical Development:**\n- **Erdős** posed the problem: if $q_1 < q_2 < \\cdots$ are primes with $q_{n+1} - q_n \\geq q_n - q_{n-1}$, must $\\lim q_n/n^2 = \\infty$?\n- **Bernd Richter (1976)**, in *Über die Monotonie von Differenzenfolgen* (Acta Arithmetica), proved the partial result $\\liminf q_n/n^2 > 0.352$, establishing at least quadratic growth.\n- The full conjecture — superquadratic growth — remains open.\n\n**Context:** The sequence of all consecutive primes $(2, 3, 5, 7, 11, 13, \\ldots)$ does NOT satisfy the monotone-gap condition, since the gaps $1, 2, 2, 4, 2, \\ldots$ are not non-decreasing. Monotone-gap prime sequences must be carefully chosen subsequences. The problem connects to the Prime Number Theorem (which gives average gap $\\sim \\log n$) and to Cramér's conjecture on maximal gaps.",

--- a/src/data/proofs/erdos-914/meta.json
+++ b/src/data/proofs/erdos-914/meta.json
@@ -55,28 +55,13 @@
       "Kierstead-Kostochka proof approach",
       "Alon-Yuster and KSS generalizations"
     ],
-    "axiomCount": 5,
+    "axiomCount": 2,
     "lineCount": 210,
     "assumptions": [
-      {
-        "name": "case_r_equals_2",
-        "type": "axiom",
-        "description": "Dirac matching case: a graph on 2m vertices with minimum degree at least m contains m vertex-disjoint edges (K_2's). This is a consequence of Dirac's theorem on Hamiltonian cycles, since a Hamiltonian cycle on 2m vertices decomposes into m disjoint edges."
-      },
-      {
-        "name": "corradi_hajnal",
-        "type": "axiom",
-        "description": "Corradi-Hajnal theorem (1963): a graph on 3m vertices with minimum degree at least 2m contains m vertex-disjoint triangles. Proved via case analysis on a maximal collection of disjoint triangles."
-      },
       {
         "name": "hajnal_szemeredi",
         "type": "axiom",
         "description": "Hajnal-Szemeredi theorem (1970): for r >= 2 and m >= 1, a graph on rm vertices with minimum degree at least m(r-1) contains m vertex-disjoint copies of K_r. The core result solving Erdos Problem #914."
-      },
-      {
-        "name": "hajnal_szemeredi_factor",
-        "type": "axiom",
-        "description": "Perfect K_r-factor form: under the same hypotheses as hajnal_szemeredi, the m vertex-disjoint K_r's additionally cover all vertices (biUnion = univ). This is strictly stronger than mere existence of m disjoint cliques, requiring a covering argument."
       },
       {
         "name": "degree_condition_tight",

--- a/src/data/proofs/fourier-series-oq-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-01/meta.json
@@ -70,9 +70,9 @@
       "fourierPartialSum_smul: scalar linearity of partial sums",
       "fourierPartialSum_zero_fn: partial sums of zero"
     ],
-    "axiomCount": 5,
+    "axiomCount": 1,
     "lineCount": 441,
-    "assumptions": "5 axioms: carlesonConstant (existence of universal constant), carlesonConstant_pos (positivity), carleson_hunt_weak_type (Carleson-Hunt weak-type (2,2) maximal inequality), trigPoly_partialSum_eq (partial sums reproduce trig polys), trigPoly_dense_L2 (density of trig polys in L²). The first 3 encode the deep Carleson-Hunt theorem. The last 2 are provable from Mathlib but axiomatized for interface clarity."
+    "assumptions": "1 axiom: carlesonConstant (existence of universal Carleson constant C > 0 for the maximal inequality)."
   },
   "overview": {
     "historicalContext": "**Carleson's Theorem (1966)**\n\nOne of the great achievements of 20th-century harmonic analysis. The question of whether Fourier series converge pointwise goes back to Fourier himself (1807) and was a central problem for over 150 years.\n\n**Timeline:**\n- **1807**: Fourier conjectured that every periodic function equals its Fourier series\n- **1829**: Dirichlet proved convergence for piecewise smooth functions\n- **1876**: du Bois-Reymond gave a continuous function whose Fourier series diverges at a point\n- **1923**: Kolmogorov constructed an L¹ function whose Fourier series diverges everywhere\n- **1926**: Kolmogorov asked: does Carleson's theorem hold for L²?\n- **1966**: **Carleson proved it**: L² Fourier series converge pointwise a.e.\n- **1968**: Hunt extended to Lp for all p > 1\n\nCarleson's proof introduced time-frequency analysis techniques that became foundational in modern harmonic analysis. The formal verification project (Carleson4) is ongoing work by Floris van Doorn et al.",


### PR DESCRIPTION
## Fix

Corrects axiomCount in meta.json for 3 proofs where the count listed axioms that don't exist in the Lean source files.

## Evidence

| Proof | Before | After | Reason |
|-------|--------|-------|--------|
| erdos-455 | 4 | 1 | Only `axiom erdos_455_conjecture` exists; richter_lower_bound, erdos_455_statement were never declared |
| erdos-914 | 5 | 2 | Only `axiom hajnal_szemeredi` and `axiom degree_condition_tight` exist; case_r_equals_2, corradi_hajnal, hajnal_szemeredi_factor were never declared |
| fourier-series-oq-01 | 5 | 1 | Only `axiom carlesonConstant` exists; carlesonConstant_pos, carleson_hunt_weak_type, trigPoly_partialSum_eq, trigPoly_dense_L2 were never declared |

**Verification method**: `grep -n "^axiom " proofs/Proofs/<file>.lean` for each file confirms the actual axiom declaration count.

---
Automated fix by lean-mechanic agent.