### PR TITLE
fix: correct line counts for 3 proofs, audit 7 proofs total

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
@@ -27,7 +27,7 @@
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 175,
+    "lineCount": 193,
     "assumptions": "Depends on newton_log_concavity axiom from AmgmInequalityOQ02.lean. 1 sorry remaining (elemSymm zero propagation).",
     "mathlib_version": "4.26.0"
   },
@@ -97,7 +97,7 @@
       "AmgmInequalityOQ02"
     ],
     "namespace": "AmgmInequalityOQ02OQ03",
-    "lineCount": 175,
+    "lineCount": 193,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 1

--- a/src/data/proofs/binomial-theorem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-03/meta.json
@@ -36,7 +36,7 @@
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 170,
+    "lineCount": 190,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0"
   },


### PR DESCRIPTION
## Summary

Audit cycle 10: verified 7 gallery proofs against their Lean source files.

**Line count fixes (3 proofs):**
- **cayley-hamilton-reduction-oq-02-oq-01**: meta lineCount 230→267, leanFile lineCount 188→267
- **amgm-inequality-oq-02-oq-03**: lineCount 175→193
- **binomial-theorem-oq-04-oq-03**: lineCount 170→190

**Clean audits (4 proofs):**
- cauchy-schwarz-oq-03-oq-02 (verified/mathlib - proper Mathlib attribution)
- de-moivre-oq-03-oq-01
- denumerability-rationals-oq-04
- (cayley-hamilton sorry/axiom counts verified correct)

## Test plan
- [ ] `pnpm build` passes
- [ ] `wc -l` on each Lean file matches the updated lineCount

🤖 Generated with [Claude Code](https://claude.com/claude-code)