### PR TITLE
fix: correct axiomCount in meta.json for 5 more proofs

### DIFF
--- a/src/data/proofs/erdos-252/meta.json
+++ b/src/data/proofs/erdos-252/meta.json
@@ -46,9 +46,9 @@
       "Formalization of conditional results (Schinzel, prime k-tuples)",
       "Verified computational examples for small cases"
     ],
-    "axiomCount": 8,
+    "axiomCount": 5,
     "lineCount": 229,
-    "assumptions": "10 axioms: erdos_252_k0, erdos_252_k1, erdos_252_k2, and 7 more. See Lean source for complete statements.",
+    "assumptions": "5 axioms: erdos_252_k0 through erdos_252_k4 (irrationality of divisorPowerSum for k=0..4).",
     "theoremCount": 6
   },
   "leanFile": {
@@ -76,7 +76,7 @@
       "SchinzelHypothesisH",
       "PrimeKTuplesConjecture"
     ],
-    "axiomCount": 8,
+    "axiomCount": 5,
     "theoremCount": 6,
     "opens": [
       "scoped",

--- a/src/data/proofs/erdos-411/meta.json
+++ b/src/data/proofs/erdos-411/meta.json
@@ -48,9 +48,9 @@
             "Proved even preservation under g using Mathlib's Nat.totient_even",
             "Formalized Cambie's structural conjecture on the form of r = 2 solutions"
         ],
-        "axiomCount": 3,
+        "axiomCount": 0,
         "lineCount": 223,
-        "assumptions": "3 axioms: cambie_ratio4_148646 (ratio-4 solution), cambie_ratio4_4325798 (ratio-4 solution), steinerberger_r2_equiv (r=2 reduction to finite equation). cambie_ratio3 PROVED via strong induction using g(3m)=3g(m) and 3-divisibility of iterates. The r=2 solutions n=10, n=94 are proved via native_decide."
+        "assumptions": "No axioms. All results (cambie_ratio3, r=2 solutions n=10/94) are proved. Open conjecture stated as definition, not axiom."
     },
     "leanFile": {
         "path": "Proofs/Erdos411Problem.lean",
@@ -74,7 +74,7 @@
             "GeneralRatioRelation",
             "CambieConjecture"
         ],
-        "axiomCount": 3,
+        "axiomCount": 0,
         "theoremCount": 9,
         "sorryCount": 0
     },

--- a/src/data/proofs/erdos-416/meta.json
+++ b/src/data/proofs/erdos-416/meta.json
@@ -22,9 +22,9 @@
     "erdosNumber": 416,
     "erdosUrl": "https://erdosproblems.com/416",
     "erdosProblemStatus": "open",
-    "axiomCount": 4,
+    "axiomCount": 0,
     "lineCount": 165,
-    "assumptions": "4 axioms: Pillai_1929, Erdos_1935, Maier_Pomerance_1988, Ford_1998. See Lean source for complete statements.",
+    "assumptions": "No axioms. Historical bounds and open questions are stated as definitions/Prop, not axiom declarations.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-447/meta.json
+++ b/src/data/proofs/erdos-447/meta.json
@@ -63,9 +63,9 @@
       "IsKUnionFree and IsStrongUnionFree generalizations (Problem 1023)",
       "erdos_447_summary combining upper and lower bounds"
     ],
-    "axiomCount": 6,
+    "axiomCount": 2,
     "lineCount": 170,
-    "assumptions": "7 axioms: middleLayer_union_free, sperner_theorem, sarkozy_szemeredi_bound, and 4 more. See Lean source for complete statements."
+    "assumptions": "2 axioms: kleitman_theorem (optimal union-free bound (1+o(1))C(n,n/2)), lower_bound (middle layer is union-free)."
   },
   "leanFile": {
     "path": "Proofs/Erdos447Problem.lean",
@@ -96,7 +96,7 @@
       "IsKUnionFree",
       "IsStrongUnionFree"
     ],
-    "axiomCount": 6,
+    "axiomCount": 2,
     "theoremCount": 1,
     "sorryCount": 0,
     "opens": [

--- a/src/data/proofs/erdos-725/meta.json
+++ b/src/data/proofs/erdos-725/meta.json
@@ -57,9 +57,9 @@
       "Stated exact values: L(1,n) = n!, L(2,n) = n! · D(n)",
       "Formalized GeneralAsymptotic and ExtendedConjecture (OPEN)"
     ],
-    "axiomCount": 9,
+    "axiomCount": 3,
     "lineCount": 169,
-    "assumptions": "9 axioms: erdos_kaplansky_1946, yamamoto_1951, L_as_permanent, and 6 more. See Lean source for complete statements."
+    "assumptions": "3 axioms: godsil_mckay_bounds (permanent-based bounds on L(k,n)), L_1_n (L(1,n) = n!), derangements (subfactorial D(n) for L(2,n) formula)."
   },
   "leanFile": {
     "path": "Proofs/Erdos725Problem.lean",
@@ -100,7 +100,7 @@
       "GeneralAsymptotic",
       "ExtendedConjecture"
     ],
-    "axiomCount": 9
+    "axiomCount": 3
   },
   "overview": {
     "historicalContext": "A $k \\times n$ Latin rectangle is a $k \\times n$ array filled with $n$ symbols such that each symbol appears exactly once per row and at most once per column. When $k = n$, this is a Latin square — objects studied since Euler's work on the 36 officers problem (1782).\n\nThe enumeration of Latin rectangles began with Euler and was pursued systematically in the 20th century. Erdős and Kaplansky (1946) proved the first asymptotic formula: $L(k,n) \\sim e^{-\\binom{k}{2}} (n!)^k$ when $k = o((\\log n)^{3/2-\\varepsilon})$. Their proof used a careful inclusion-exclusion sieve over column collision events, counting the expected number of repeated entries in any column and showing the higher-order correction terms vanish in this regime.\n\nYamamoto (1951) dramatically extended the validity of this formula to $k \\leq n^{1/3-o(1)}$, improving the growth from logarithmic to polynomial. This extension required refined estimates on the permanent of certain 0-1 matrices.\n\nGodsil and McKay (1990) connected Latin rectangle counting to matrix permanents, establishing two-sided bounds $c_1 \\cdot e^{-\\binom{k}{2}}(n!)^k \\leq L(k,n) \\leq c_2 \\cdot e^{-\\binom{k}{2}}(n!)^k$. Their work leveraged the resolution of van der Waerden's permanent conjecture by Egorychev (1981) and Falikman (1981). McKay and Wanless (2005) later extended the asymptotic to $k = o(n^{6/7})$, the current frontier. The full problem for $k = \\Theta(n)$ remains open.",


### PR DESCRIPTION
## Fix

Corrects axiomCount in meta.json for 5 proofs where the count listed axiom names that don't exist as `axiom` declarations in the Lean source.

## Evidence

| Proof | Before | After | Reason |
|-------|--------|-------|--------|
| erdos-252 | 8 | 5 | Only `erdos_252_k0` through `erdos_252_k4` exist |
| erdos-411 | 3 | 0 | All results proved; `cambie_ratio4_*` and `steinerberger_r2_equiv` were never declared |
| erdos-416 | 4 | 0 | `Pillai_1929`, `Erdos_1935`, etc. are discussed in comments only |
| erdos-447 | 6 | 2 | Only `kleitman_theorem` and `lower_bound` exist |
| erdos-725 | 9 | 3 | Only `godsil_mckay_bounds`, `L_1_n`, `derangements` exist |

**Verification**: `grep -n "^axiom " proofs/Proofs/<file>.lean` for each file.

Follow-up to #8415.

---
Automated fix by lean-mechanic agent.