### PR TITLE
fix: correct metadata for 4 proofs, audit 5 proofs total

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10171,6 +10171,36 @@
       "lastAudited": "2026-03-30T14:43:10Z",
       "result": "clean",
       "issues": []
+    },
+    "binomial-theorem-oq-04-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T15:21:01Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "cauchy-schwarz-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T15:21:51Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cayley-hamilton-reduction-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T15:22:41Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "de-moivre-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T15:23:39Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "denumerability-rationals-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T15:24:40Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "descartes-rule-of-signs-oq-02": {

--- a/src/data/proofs/binomial-theorem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-03/meta.json
@@ -109,7 +109,7 @@
     }
   ],
   "conclusion": {
-    "summary": "7 theorems proved with 0 sorries and 0 axioms. The q-Vandermonde identity — the Gaussian binomial analog of Vandermonde's convolution — is fully formalized over arbitrary commutative rings, with classical recovery at q=1, q-sum-of-squares corollary, and concrete verifications.",
+    "summary": "9 theorems proved with 0 sorries and 0 axioms. The q-Vandermonde identity — the Gaussian binomial analog of Vandermonde's convolution — is fully formalized over arbitrary commutative rings, with classical recovery at q=1, q-sum-of-squares corollary, and concrete verifications.",
     "implications": "**Theoretical Significance**: The q-Vandermonde identity is a cornerstone of q-combinatorics with applications across mathematics and physics.\n\nIn finite geometry, it counts subspaces by intersection dimension. In coding theory, it underlies bounds on subspace codes. In quantum group theory, it is a structure identity for quantized enveloping algebras. The formalization demonstrates that Lean 4's type system can handle the delicate natural number arithmetic required by q-analog identities.",
     "openQuestions": [
       "Can the q-Vandermonde identity be given a bijective proof via lattice path counting with q-weights?",
@@ -151,9 +151,9 @@
       "QBinomialCoefficients"
     ],
     "namespace": "BinomialTheoremOQ04OQ03",
-    "lineCount": 170,
+    "lineCount": 190,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 9,
     "definitionCount": 0
   },
   "references": [

--- a/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
@@ -40,7 +40,7 @@
     ],
     "dateAdded": "2026-03-30",
     "leanFile": {
-      "lineCount": 188,
+      "lineCount": 267,
       "structures": 0,
       "axioms": 0,
       "theorems": 7,
@@ -48,7 +48,7 @@
       "instances": 0
     },
     "axiomCount": 0,
-    "lineCount": 230,
+    "lineCount": 267,
     "assumptions": "0 axioms. 3 sorries (aeval, charpoly, minpoly — restructured without circular dependency). Orbit infrastructure fully proved.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/de-moivre-oq-03-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-03-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "de-moivre-oq-03-oq-01",
   "title": "De Moivre Extension to Irrational Exponents",
   "slug": "de-moivre-oq-03-oq-01",
-  "description": "Extends De Moivre's theorem to real and irrational exponents via Complex.cpow. Shows rational exponents give multi-valued roots, irrational exponents are single-valued on the principal branch, and connects to Weyl equidistribution.",
+  "description": "Extends De Moivre's theorem to real exponents via Complex.cpow. Proves the real-exponent formula on the principal branch, constructs rational multi-valued roots, and states Weyl equidistribution (axiom). Note: irrational single-valuedness theorem is a True stub (placeholder).",
   "meta": {
     "author": "De Moivre (1707), Weyl (1916)",
     "date": "1707",
@@ -18,7 +18,7 @@
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 1,
-    "assumptions": "1 axiom: weyl_equidistribution (density of irrational rotations on unit circle). de_moivre_real_exponent proved with principal branch hypothesis θ ∈ (-π, π].",
+    "assumptions": "1 axiom: weyl_equidistribution (density of irrational rotations on unit circle). 1 True stub: irrational_exponent_single_valued (proves True, not the actual claim). de_moivre_real_exponent proved with principal branch hypothesis θ ∈ (-π, π].",
     "lineCount": 74
   },
   "sections": [],

--- a/src/data/proofs/denumerability-rationals-oq-04/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-04/meta.json
@@ -15,11 +15,23 @@
       "constructive",
       "research"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 141,
-    "assumptions": "No axioms or sorries. Fully constructive.",
+    "assumptions": "No axioms or sorries. Core argument uses Mathlib's FTA (Polynomial.setOf_isRoot_finite) and Set.countable_iUnion. 1 True stub (choiceless_note, documentation only).",
+    "mathlibDependencies": [
+      {
+        "theorem": "Polynomial.setOf_isRoot_finite",
+        "description": "Fundamental theorem of algebra: each nonzero polynomial has finitely many roots",
+        "module": "Mathlib.FieldTheory.IsAlgClosed.Basic"
+      },
+      {
+        "theorem": "Set.countable_iUnion",
+        "description": "Countable union of countable sets is countable",
+        "module": "Mathlib.Order.Filter.CountableInter"
+      }
+    ],
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -46,7 +58,7 @@
     "namespace": "DenumerabilityOQ04",
     "lineCount": 141,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 5,
     "definitionCount": 1
   },
   "sections": []


### PR DESCRIPTION
## Summary

Gallery integrity audit cycle: 5 proofs audited, 4 with metadata corrections, 1 clean.

- **binomial-theorem-oq-04-oq-03**: Fixed theoremCount (7→9) and lineCount (170→190)
- **cayley-hamilton-reduction-oq-02-oq-01**: Fixed lineCount in both meta sections (230/188→267)
- **de-moivre-oq-03-oq-01**: Flagged True stub in `irrational_exponent_single_valued`, updated description for transparency
- **denumerability-rationals-oq-04**: Changed badge `original`→`mathlib` (core uses Mathlib FTA), added mathlibDependencies, fixed theoremCount (7→5), flagged True stub
- **cauchy-schwarz-oq-03-oq-02**: Clean — no issues found

## Test plan

- [ ] `pnpm build` passes with updated meta.json files
- [ ] No badge/status overclaims remain in audited proofs

🤖 Generated with [Claude Code](https://claude.com/claude-code)