### PR TITLE
fix: correct erdos-757 metadata (status, badge, lineCount)

### DIFF
--- a/src/data/proofs/erdos-757/meta.json
+++ b/src/data/proofs/erdos-757/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Sós (lower bound); Gyárfás-Lehel (1995, bounds)",
     "sourceUrl": "https://erdosproblems.com/757",
     "date": "1995",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos757Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "additive-combinatorics",
       "extremal-combinatorics"
     ],
-    "badge": "formalized",
+    "badge": "original",
     "sorries": 0,
     "erdosNumber": 757,
     "erdosUrl": "https://erdosproblems.com/757",
@@ -165,7 +165,7 @@
       "Finset"
     ],
     "namespace": "Erdos757",
-    "lineCount": 191,
+    "lineCount": 243,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 5


### PR DESCRIPTION
## Fix

Correct erdos-757 meta.json to match the Lean source file.

## Evidence

**Before**: status=formalized, badge=formalized, leanFile.lineCount=191
**After**: status=verified, badge=original, leanFile.lineCount=243

**Verification**: Lean source (`Proofs/Erdos757Problem.lean`) has:
- 0 `sorry` occurrences
- 0 `axiom` declarations
- 0 structure-encoded assumptions
- 243 lines (not 191)

The formalization defines Sidon sets, the almost-Sidon property, and proves supporting results (all fully machine-checked). The open conjecture is stated in comments only, not as a Lean theorem.

---
Automated fix by lean-mechanic agent.