### PR TITLE
fix: correct metadata for 2 proofs, audit 3 proofs total

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10201,6 +10201,24 @@
       "lastAudited": "2026-03-30T15:24:40Z",
       "result": "issues-fixed",
       "issues": []
+    },
+    "cantor-diagonalization-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T15:46:36Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "e-transcendental-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T15:47:15Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "erdos-1-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-03-30T15:47:51Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "descartes-rule-of-signs-oq-02": {

--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02/meta.json
@@ -18,7 +18,7 @@
       "konig-theorem",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
@@ -55,8 +55,8 @@
       "smallest_excluded_is_aleph_omega: ℵ_ω is first excluded value"
     ],
     "axiomCount": 0,
-    "lineCount": 227,
-    "assumptions": "None. All results proved from Mathlib's cofinality API with 0 axioms."
+    "lineCount": 255,
+    "assumptions": "0 axioms, 0 sorries. Core result (konig_cofinality) derived from Mathlib's Cardinal.lt_cof_power. All other results built on Mathlib cofinality API."
   },
   "overview": {
     "historicalContext": "**König's Theorem and the Continuum Problem**\n\n- **1905**: Julius König proved his inequality on sums and products of cardinals\n- **1940-1963**: Gödel and Cohen showed CH is independent of ZFC\n- **1970**: Easton proved König's constraint is the ONLY ZFC constraint on 2^ℵ₀\n- **Present**: Mathlib formalizes König's theorem as Cardinal.lt_cof_power\n\nKönig's constraint is the strongest thing ZFC can say about the size of the continuum beyond Cantor's basic bound ℵ₁ ≤ 2^ℵ₀.",

--- a/src/data/proofs/e-transcendental-oq-03/meta.json
+++ b/src/data/proofs/e-transcendental-oq-03/meta.json
@@ -40,7 +40,7 @@
     "dateAdded": "2026-03-30",
     "axiomCount": 2,
     "assumptions": "2 axiom declarations: irrational_liouvilleWith_two (Dirichlet's approximation theorem for irrationals), e_not_liouvilleWith_gt_two (upper bound from CF expansion of e)",
-    "lineCount": 206,
+    "lineCount": 219,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -149,7 +149,7 @@
       "Real"
     ],
     "namespace": "ETranscendentalOQ03",
-    "lineCount": 206,
+    "lineCount": 219,
     "axiomCount": 2,
     "theoremCount": 4,
     "definitionCount": 0


### PR DESCRIPTION
## Summary

Gallery integrity audit cycle 12: 3 proofs audited, 2 with metadata corrections, 1 clean.

- **cantor-diagonalization-oq-01-oq-01-oq-02**: Badge `verified`→`mathlib` (core result wraps Mathlib's `Cardinal.lt_cof_power`), lineCount 227→255
- **e-transcendental-oq-03**: lineCount 206→219
- **erdos-1-oq-02**: Clean — no issues found

## Test plan

- [ ] `pnpm build` passes with updated meta.json files
- [ ] Badge changes accurately reflect Mathlib dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)