### PR TITLE
fix: correct erdos-614 sorries count and lineCount

### DIFF
--- a/src/data/proofs/erdos-614/meta.json
+++ b/src/data/proofs/erdos-614/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 614,
     "erdosUrl": "https://erdosproblems.com/614",
     "erdosProblemStatus": "open",
@@ -55,7 +55,7 @@
     ],
     "axiomCount": 2,
     "sorryCount": 1,
-    "lineCount": 340,
+    "lineCount": 454,
     "assumptions": "2 axioms: f_lower_bound, f_mono_k. f_case_k_eq_1 converted to theorem (1 sorry: type transport). f_upper_bound proved via complete graph construction."
   },
   "overview": {
@@ -165,7 +165,7 @@
       "Finset"
     ],
     "namespace": "Erdos614",
-    "lineCount": 269,
+    "lineCount": 454,
     "axiomCount": 2,
     "theoremCount": 12,
     "definitionCount": 7


### PR DESCRIPTION
## Summary
- Fixed `sorries` field: 0 → 1 (Lean file has 1 sorry at `f_case_k_eq_1` line 386)
- Fixed `lineCount`: 340 (meta) / 269 (leanFile) → 454 (actual)
- Verified: `axiomCount` (2), `status` (axiomatized), `badge` (axiom) all correct

## Audit Details
- **Proof**: erdos-614
- **Risk**: HIGH (sorry count mismatch — claims fewer sorries than exist)
- **Severity**: The `sorryCount` field (1) was already correct, but the `sorries` field (0) was inconsistent

## Test plan
- [ ] `pnpm build` passes
- [ ] Gallery page renders correctly with updated metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)