### PR TITLE
fix: correct erdos-1015-oq-05 status/badge to verified/original

### DIFF
--- a/src/data/proofs/erdos-1015-oq-05/meta.json
+++ b/src/data/proofs/erdos-1015-oq-05/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erd\u0151s-Szekeres (1935)",
     "erdosNumber": 1015,
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos1015OQ05.lean",
     "tags": [
       "erdos",
@@ -15,14 +15,14 @@
       "axiom-elimination",
       "research"
     ],
-    "badge": "axiom",
+    "badge": "original",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/1015",
     "erdosUrl": "https://erdosproblems.com/1015",
     "erdosProblemStatus": "solved",
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 347,
+    "lineCount": 353,
     "assumptions": "No axioms in this file. All theorems proved from RamseysTheorem.lean. Eliminates 2 of the 8 parent axioms (ramseyNumber definition and ramsey_upper_bound).",
     "mathlib_version": "4.26.0"
   },
@@ -59,7 +59,7 @@
       "Finset"
     ],
     "namespace": "Erdos1015OQ05",
-    "lineCount": 347,
+    "lineCount": 353,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 1


### PR DESCRIPTION
## Summary
- Fixed `status`: axiomatized → verified (file has 0 axioms, 0 sorries)
- Fixed `badge`: axiom → original (all theorems fully proved)
- Fixed `lineCount`: 347 → 353 in both meta and leanFile sections

## Audit Details
- **Proof**: erdos-1015-oq-05
- **Risk**: HIGH (status/badge understate the proof's completeness)
- **Verification**: Confirmed 0 `sorry` and 0 `axiom` declarations in Lean source
- The file proves `ramseyNumber` definition via `Nat.find` and `ramsey_upper_bound` via Erdős-Szekeres bound — all complete proofs

## Test plan
- [ ] `pnpm build` passes
- [ ] Gallery page renders correctly with updated badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)