### PR TITLE
fix: correct erdos-1118-oq-02 axiomCount (3→0), status to verified/original

### DIFF
--- a/src/data/proofs/erdos-1118-oq-02/meta.json
+++ b/src/data/proofs/erdos-1118-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Camera, Gol'dberg, Oka",
     "sourceUrl": "https://erdosproblems.com/1118",
     "date": "2026",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos1118OQ02.lean",
     "tags": [
       "complex-analysis",
@@ -16,11 +16,11 @@
       "erdos",
       "research"
     ],
-    "badge": "axiom",
+    "badge": "original",
     "sorries": 0,
-    "axiomCount": 3,
-    "lineCount": 120,
-    "assumptions": "3 axioms. 0 sorries.",
+    "axiomCount": 0,
+    "lineCount": 103,
+    "assumptions": "0 axioms. 0 sorries. All theorems fully proved.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0"
   },
@@ -40,8 +40,8 @@
       "Mathlib"
     ],
     "namespace": "Erdos1118OQ02",
-    "lineCount": 120,
-    "axiomCount": 3,
+    "lineCount": 103,
+    "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 1
   },


### PR DESCRIPTION
## Summary
- Fixed `axiomCount`: 3 → 0 (Lean file has no axiom declarations; "3 axioms" was from comments only)
- Fixed `status`: axiomatized → verified
- Fixed `badge`: axiom → original
- Fixed `lineCount`: 120 → 103

## Audit Details
- **Proof**: erdos-1118-oq-02
- **Risk**: CRITICAL (false axiom count claim)
- **Root cause**: The meta.json was populated from comment text mentioning "3 axioms" as conceptual assumptions, but no formal `axiom` declarations exist in the Lean source

## Test plan
- [ ] `pnpm build` passes
- [ ] Gallery page renders correctly with updated badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)