### PR TITLE
feat: add Aristotle companion file for erdos-1048 (4 sorries)

### DIFF
--- a/proofs/Proofs/Erdos1048ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos1048ProblemAristotle.lean
@@ -1,0 +1,61 @@
+/-
+  Aristotle targets for Erdős Problem #1048
+  Routine supporting lemmas for automated proof search.
+  See Erdos1048Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main disproof construction or deep analysis results
+  - Known results: openness, monic verification, root characterization
+  - Clean theorem statements with no definition sorries
+
+  Excluded (deep results kept in main file):
+  - lemniscate_bounded (requires growth analysis of monic polynomials)
+  - zn_diameter (diameter computation for unit lemniscate)
+  - diameter_2_sharp (sharpness construction)
+  - exterior_unbounded (asymptotic growth argument)
+  - pommerenke_insight (partial proof needing construction details)
+-/
+import Mathlib
+
+namespace Erdos1048.Aristotle
+
+open Complex Polynomial Set Metric
+
+/- Definitions mirrored from main file -/
+
+def IsMonic (f : ℂ[X]) : Prop := f.leadingCoeff = 1
+
+noncomputable def roots (f : ℂ[X]) : Set ℂ :=
+  { z : ℂ | f.eval z = 0 }
+
+def RootsBoundedBy (f : ℂ[X]) (r : ℝ) : Prop :=
+  ∀ z ∈ roots f, Complex.abs z ≤ r
+
+def lemniscate (f : ℂ[X]) (c : ℝ) : Set ℂ :=
+  { z : ℂ | Complex.abs (f.eval z) < c }
+
+noncomputable def pommerenkeCounterexample (r : ℝ) (n : ℕ) : ℂ[X] :=
+  X ^ n - C (r ^ n : ℂ)
+
+/- ## Section 1: Topological Properties -/
+
+-- Lemniscates are open: preimage of (-∞, c) under continuous |f|
+theorem lemniscate_isOpen (f : ℂ[X]) (c : ℝ) (hc : c > 0) :
+    IsOpen (lemniscate f c) := by sorry
+
+/- ## Section 2: Counterexample Properties -/
+
+-- z^n - r^n is monic (leading coefficient of X^n is 1)
+theorem counterexample_monic (r : ℝ) (n : ℕ) (hn : n ≥ 1) :
+    IsMonic (pommerenkeCounterexample r n) := by sorry
+
+-- Roots of z^n - r^n are r times n-th roots of unity
+theorem counterexample_roots (r : ℝ) (n : ℕ) (hn : n ≥ 1) (hr : r > 0) :
+    roots (pommerenkeCounterexample r n) =
+      { r * Complex.exp (2 * Real.pi * I * k / n) | (k : ℤ) (hk : 0 ≤ k ∧ k < n) } := by sorry
+
+-- All roots of z^n - r^n have absolute value exactly r
+theorem counterexample_bounded (r : ℝ) (n : ℕ) (hn : n ≥ 1) (hr : r > 0) :
+    RootsBoundedBy (pommerenkeCounterexample r n) r := by sorry
+
+end Erdos1048.Aristotle


### PR DESCRIPTION
## Fix

Add Aristotle companion file for erdos-1048 (polynomial lemniscate diameter) with 4 routine sorries.

## Evidence

**Before**: Erdős #1048 had 10 sorries in the main file and no companion file.

**After**: `Erdos1048ProblemAristotle.lean` extracts 4 routine lemmas:
- Lemniscate openness (continuous preimage)
- Pommerenke counterexample is monic
- Roots of z^n - r^n are r × n-th roots of unity
- All roots bounded by r

Deep results (diameter computations, boundedness, construction details) remain only in the main file.

---
Automated fix by lean-mechanic agent.