### PR TITLE
fix: correct erdos-1018-oq-04 sorries count (3→2), lineCount

### DIFF
--- a/src/data/proofs/erdos-1018-oq-04/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04/meta.json
@@ -18,10 +18,10 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "axiomCount": 4,
-    "lineCount": 301,
-    "assumptions": "4 axioms: van Kampen-Flores theorem, embeddability of K₃ and K₄ in R², density-exceeds-Turán threshold. 3 sorries: isEmbeddable definition, completeHypergraph_edgeCount, turanNumber definition.",
+    "lineCount": 308,
+    "assumptions": "4 axioms: van Kampen-Flores theorem, embeddability of K₃ and K₄ in R², density-exceeds-Turán threshold. 2 sorries: isEmbeddable definition, turanNumber definition.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -169,7 +169,7 @@
     "imports": ["Mathlib"],
     "opens": ["Finset"],
     "namespace": "Erdos1018OQ04",
-    "lineCount": 301,
+    "lineCount": 308,
     "axiomCount": 4,
     "theoremCount": 11,
     "definitionCount": 12


### PR DESCRIPTION
## Summary

- **sorries**: 3 → 2 (`completeHypergraph_edgeCount` is now fully proved)
- **lineCount**: 301 → 308
- **assumptions**: removed stale `completeHypergraph_edgeCount` sorry reference

## Evidence

```
$ grep -c sorry proofs/Proofs/Erdos1018OQ04.lean
2
$ grep -n sorry proofs/Proofs/Erdos1018OQ04.lean
144:  sorry -- Topological definition (isEmbeddable)
272:noncomputable def turanNumber (_n _t _r : ℕ) : ℕ := sorry
```

## Test plan

- [ ] `pnpm build` passes

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)