### PR TITLE
fix: correct amgm-inequality-oq-02-oq-03 badge (original→wip)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
@@ -16,7 +16,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/AmgmInequalityOQ02OQ03.lean",
-    "badge": "original",
+    "badge": "wip",
     "sorries": 1,
     "axioms": 0,
     "mathlibDependencies": [],


### PR DESCRIPTION
## Summary

- **badge**: `original` → `wip` (proof has 1 sorry: elemSymm zero propagation)

Badge `original` requires 0 sorries and 0 axioms. This proof has 1 sorry and depends on `newton_log_concavity` axiom from parent module.

## Test plan

- [ ] `pnpm build` passes

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)