### PR TITLE
fix: correct erdos-100-oq-02 lineCount (54→60)

### DIFF
--- a/src/data/proofs/erdos-100-oq-02/meta.json
+++ b/src/data/proofs/erdos-100-oq-02/meta.json
@@ -30,7 +30,7 @@
     "erdosNumber": 100,
     "proofRepoPath": "Proofs/Erdos100OQ02.lean",
     "axiomCount": 0,
-    "lineCount": 54,
+    "lineCount": 60,
     "assumptions": "Inherits axioms from Erdos100Problem.lean (guthKatz_distinct_distances, piepmeyer_construction, kanold_bound, erdos_anning_theorem) via import."
   },
   "sections": [],
@@ -69,7 +69,7 @@
       "Set"
     ],
     "namespace": "Erdos100OQ02",
-    "lineCount": 54,
+    "lineCount": 60,
     "axiomCount": 0,
     "theoremCount": 2,
     "definitionCount": 0


### PR DESCRIPTION
## Summary

- **lineCount**: 54 → 60

## Test plan

- [ ] `pnpm build` passes

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)