### PR TITLE
fix: remove unused TacticState import

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-04/index.ts
+++ b/src/data/proofs/amgm-inequality-oq-04/index.ts
@@ -1,4 +1,4 @@
-import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference, TacticState } from '@/types/proof'
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/AmgmInequalityOQ04.lean?raw'


### PR DESCRIPTION
## Summary
- Removes unused `TacticState` import from `amgm-inequality-oq-04/index.ts`
- Fixes TS6196 build error introduced by PR #8462

## Test plan
- [ ] `pnpm build` passes without TS6196 error