### PR TITLE
fix: correct area-of-circle-oq-05 badge (verified→wip), lineCount

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05/meta.json
@@ -15,12 +15,12 @@
       "probability",
       "normal-distribution"
     ],
-    "badge": "verified",
+    "badge": "wip",
     "sorries": 2,
     "axiomCount": 0,
     "assumptions": "None. The Gaussian integral itself is proved via Mathlib. Two sorries remain for standard normal normalization and radial integral (routine measure theory).",
     "dateAdded": "2026-03-30",
-    "lineCount": 110,
+    "lineCount": 107,
     "mathlibDependencies": [
       {
         "theorem": "integral_gaussian",


### PR DESCRIPTION
## Summary

- **badge**: `verified` → `wip` (proof has 2 sorries: standard normal normalization, radial integral)
- **lineCount**: 110 → 107

Badge `verified` requires 0 sorries and 0 axioms.

## Test plan

- [ ] `pnpm build` passes

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)