### PR TITLE
fix: correct erdos-606-oq-03 — axiomCount 3→0, True stub, badge

### DIFF
--- a/src/data/proofs/erdos-606-oq-03/meta.json
+++ b/src/data/proofs/erdos-606-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Sylvester, Green-Tao, Motzkin",
     "sourceUrl": "https://erdosproblems.com/606",
     "date": "2026",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos606OQ03.lean",
     "tags": [
       "combinatorial-geometry",
@@ -16,11 +16,11 @@
       "erdos",
       "research"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 0,
-    "axiomCount": 3,
-    "lineCount": 122,
-    "assumptions": "3 axioms. 0 sorries.",
+    "axiomCount": 0,
+    "lineCount": 98,
+    "assumptions": "0 axioms, 0 sorries. WARNING: general_position_count proves True (placeholder). Sylvester-Gallai, Green-Tao, and Motzkin are mentioned in comments but not axiomatized.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -45,8 +45,8 @@
       "Mathlib"
     ],
     "namespace": "Erdos606OQ03",
-    "lineCount": 122,
-    "axiomCount": 3,
+    "lineCount": 98,
+    "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 0
   },


### PR DESCRIPTION
## Summary

- **axiomCount**: 3 → 0 (Sylvester-Gallai, Green-Tao, Motzkin mentioned in comments only, not axiomatized)
- **status**: `axiomatized` → `formalized` (no axioms exist)
- **badge**: `axiom` → `wip` (contains True stub: `general_position_count` proves `True`)
- **lineCount**: 122 → 98
- **assumptions**: updated to note True stub and missing axiom declarations

## Evidence

```
$ grep -c "^axiom " proofs/Proofs/Erdos606OQ03.lean
0
$ grep "True := trivial" proofs/Proofs/Erdos606OQ03.lean
    True := trivial  (line 42, general_position_count)
```

## Test plan

- [ ] `pnpm build` passes

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)