### PR TITLE
fix: batch audit corrections — axiom counts, badges, line counts

### DIFF
--- a/src/data/proofs/fermats-last-theorem-oq-03/meta.json
+++ b/src/data/proofs/fermats-last-theorem-oq-03/meta.json
@@ -16,9 +16,9 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 3,
-    "lineCount": 140,
-    "assumptions": "3 axioms (flt_over_Q, freitas_hung_siksek, modularity_obstruction). 0 sorries.",
+    "axiomCount": 1,
+    "lineCount": 123,
+    "assumptions": "1 axiom (flt_over_Q). 0 sorries. WARNING: asymptotic_flt proves True (placeholder). freitas_hung_siksek and modularity_obstruction mentioned in comments but not axiomatized.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -44,8 +44,8 @@
       "Mathlib"
     ],
     "namespace": "FermatsLastTheoremOQ03",
-    "lineCount": 140,
-    "axiomCount": 3,
+    "lineCount": 123,
+    "axiomCount": 1,
     "theoremCount": 4,
     "definitionCount": 3
   },

--- a/src/data/proofs/feuerbachs-theorem-oq-02/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-02/meta.json
@@ -29,7 +29,7 @@
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 5,
-    "lineCount": 350,
+    "lineCount": 586,
     "assumptions": "5 axioms: circumcenter existence/equidistance (2), counterexample for general tetrahedra (1), edge midpoints on sphere (1), face centroids on sphere (1). 5 sorries for the main Feuerbach tangency theorems (insphere + 4 exspheres).",
     "originalContributions": [
       "Complete 3D coordinate geometry infrastructure for tetrahedra in Lean 4",
@@ -146,7 +146,7 @@
       "Real"
     ],
     "namespace": "FeuerbachsTheoremOQ02",
-    "lineCount": 350,
+    "lineCount": 586,
     "axiomCount": 5,
     "theoremCount": 10,
     "substantiveTheoremCount": 6,

--- a/src/data/proofs/four-color-theorem-oq-02/meta.json
+++ b/src/data/proofs/four-color-theorem-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Robertson-Sanders-Seymour-Thomas (1997)",
     "date": "1997",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/FourColorTheoremOQ02.lean",
     "tags": [
       "graph-theory",
@@ -14,14 +14,14 @@
       "configurations",
       "computer-assisted-proof"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 0,
     "dateAdded": "2026-03-30",
-    "axiomCount": 3,
-    "lineCount": 110
+    "axiomCount": 0,
+    "lineCount": 93
   },
   "sections": [],
   "leanFile": {
-    "axiomCount": 3
+    "axiomCount": 0
   }
 }

--- a/src/data/proofs/fourier-series-oq-04/meta.json
+++ b/src/data/proofs/fourier-series-oq-04/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Fefferman (1971), Stein & Weiss (1971)",
     "date": "1971",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/FourierSeriesOQ04.lean",
     "tags": [
       "harmonic-analysis",
@@ -14,14 +14,14 @@
       "convergence",
       "multi-dimensional"
     ],
-    "badge": "axiom",
+    "badge": "original",
     "sorries": 0,
     "dateAdded": "2026-03-30",
-    "axiomCount": 5,
-    "lineCount": 133
+    "axiomCount": 0,
+    "lineCount": 109
   },
   "sections": [],
   "leanFile": {
-    "axiomCount": 5
+    "axiomCount": 0
   }
 }


### PR DESCRIPTION
## Summary

Batch audit corrections for 4 gallery proofs:

### fermats-last-theorem-oq-03
- **axiomCount**: 3 → 1 (only `flt_over_Q` declared; `freitas_hung_siksek` and `modularity_obstruction` mentioned in comments only)
- **lineCount**: 140 → 123
- True stub: `asymptotic_flt` proves `True`

### four-color-theorem-oq-02
- **axiomCount**: 3 → 0 (no axiom declarations in file; parent has axioms but this file doesn't)
- **status**: `axiomatized` → `formalized` (no axioms)
- **badge**: `axiom` → `wip` (placeholder definitions: `IsReducible` and `IsUnavoidable` return `True`)
- **lineCount**: 110 → 93

### fourier-series-oq-04
- **axiomCount**: 5 → 0 (no axioms, no structures, no sorries — all clean)
- **status**: `axiomatized` → `verified`
- **badge**: `axiom` → `original`
- **lineCount**: 133 → 109

### feuerbachs-theorem-oq-02
- **lineCount**: 350 → 586 (file has grown significantly)
- axiomCount 5 matches (verified)

## Test plan

- [ ] `pnpm build` passes

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)