### PR TITLE
fix: correct amgm-oq02-oq03 metadata (sorry→0, badge wip→axiom, lineCount)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Maclaurin (1729) / Hardy-Littlewood-Pólya (1934), formalized in Lean 4",
     "sourceUrl": "",
     "date": "1729",
-    "status": "formalized",
+    "status": "axiomatized",
     "tags": [
       "combinatorics",
       "inequalities",
@@ -16,8 +16,8 @@
       "research"
     ],
     "proofRepoPath": "Proofs/AmgmInequalityOQ02OQ03.lean",
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "axiom",
+    "sorries": 0,
     "axioms": 0,
     "mathlibDependencies": [],
     "originalContributions": [
@@ -27,8 +27,8 @@
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 193,
-    "assumptions": "Depends on newton_log_concavity axiom from AmgmInequalityOQ02.lean. 1 sorry remaining (elemSymm zero propagation).",
+    "lineCount": 226,
+    "assumptions": "Depends on newton_log_concavity axiom from AmgmInequalityOQ02.lean.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -66,7 +66,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The maclaurin_step axiom is eliminated: Mₖ ≥ Mₖ₊₁ is now proved from Newton's log-concavity. 1 sorry remains for elemSymm zero propagation (a routine supporting lemma).",
+    "summary": "The maclaurin_step axiom is eliminated: Mₖ ≥ Mₖ₊₁ is now proved from Newton's log-concavity (including the elemSymm zero propagation lemma).",
     "implications": "Reduces the axiom count of the Maclaurin inequality formalization by 1. The remaining newton_log_concavity axiom is the deeper result (requires polarization + induction on n).",
     "openQuestions": [
       "Can the remaining sorry (elemSymm zero propagation) be eliminated?",
@@ -97,7 +97,7 @@
       "AmgmInequalityOQ02"
     ],
     "namespace": "AmgmInequalityOQ02OQ03",
-    "lineCount": 193,
+    "lineCount": 226,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 1


### PR DESCRIPTION
## Summary

- **sorries**: 1→0 (the `normElemSymm_zero_succ` lemma is now fully proved, no `sorry` in file)
- **badge**: `wip`→`axiom` (0 sorries but depends on imported `newton_log_concavity` axiom)
- **status**: `formalized`→`axiomatized` (no sorries remaining; depends on axiom via import)
- **lineCount**: 193→226 (both `meta.lineCount` and `leanFile.lineCount`)
- **assumptions**: Removed stale "1 sorry remaining (elemSymm zero propagation)" text
- **conclusion**: Updated to reflect sorry elimination

## Evidence

```
$ grep -c sorry proofs/Proofs/AmgmInequalityOQ02OQ03.lean
0

$ wc -l < proofs/Proofs/AmgmInequalityOQ02OQ03.lean
226

$ grep "^axiom " proofs/Proofs/AmgmInequalityOQ02OQ03.lean
(none — but imports newton_log_concavity axiom from AmgmInequalityOQ02.lean)
```

## Test plan

- [ ] `pnpm build` passes with updated metadata
- [ ] Gallery page renders correctly with `axiom` badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)