### PR TITLE
fix: correct bezout-oq02-oq01-oq02 badge (verified→mathlib)

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02/meta.json
@@ -13,7 +13,7 @@
       "factorization"
     ],
     "proofRepoPath": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. All results follow from Mathlib's instance chain: EuclideanDomain → GCDMonoid → UniqueFactorizationMonoid.",


### PR DESCRIPTION
## Summary

- **badge**: `verified`→`mathlib` (all results derive from Mathlib's instance chain)

This is a Tier B proof: `inferInstance` for UFD/ED, `UniqueFactorizationMonoid.irreducible_iff_prime`, `Int.gcd_dvd_left`, etc. No independent mathematical content — pure Mathlib bridge.

Previous fix attempt (PR #8474) only updated `audit-tracker.json` but missed the actual `meta.json` change.

## Test plan

- [ ] `pnpm build` passes
- [ ] Gallery page renders with `mathlib` badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)