### PR TITLE
fix: remove phantom axiom names from erdos-100-oq-02 assumptions

### DIFF
--- a/src/data/proofs/erdos-100-oq-02/meta.json
+++ b/src/data/proofs/erdos-100-oq-02/meta.json
@@ -31,7 +31,7 @@
     "proofRepoPath": "Proofs/Erdos100OQ02.lean",
     "axiomCount": 0,
     "lineCount": 60,
-    "assumptions": "Inherits axioms from Erdos100Problem.lean (guthKatz_distinct_distances, piepmeyer_construction, kanold_bound, erdos_anning_theorem) via import."
+    "assumptions": "Inherits axioms from Erdos100Problem.lean (guthKatz_distinct_distances, piepmeyer_construction) via import."
   },
   "sections": [],
   "overview": {


### PR DESCRIPTION
## Summary

- **assumptions**: Removed `kanold_bound` and `erdos_anning_theorem` from the inherited axioms list — neither exists in `Erdos100Problem.lean`
- Parent file has exactly 2 axioms: `guthKatz_distinct_distances`, `piepmeyer_construction`

## Test plan

- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)