### PR TITLE
Research: erdos-825-oq-03 - odd weird numbers axiom elimination + structural theorems

### DIFF
--- a/proofs/Proofs/Erdos470Problem.lean
+++ b/proofs/Proofs/Erdos470Problem.lean
@@ -67,6 +67,16 @@ subset of its proper divisors.
 -/
 def IsWeird (n : ℕ) : Prop := IsAbundant n ∧ ¬IsPseudoperfect n
 
+/-- Decidability of IsPseudoperfect: check all subsets of properDivisors. -/
+instance decidableIsPseudoperfect (n : ℕ) : Decidable (IsPseudoperfect n) :=
+  decidable_of_iff (∃ S ∈ n.properDivisors.powerset, S.sum id = n) ⟨
+    fun ⟨S, hmem, hsum⟩ => ⟨S, Finset.mem_powerset.mp hmem, hsum⟩,
+    fun ⟨S, hsub, hsum⟩ => ⟨S, Finset.mem_powerset.mpr hsub, hsum⟩⟩
+
+/-- Decidability of IsWeird. -/
+instance decidableIsWeird (n : ℕ) : Decidable (IsWeird n) :=
+  inferInstanceAs (Decidable (IsAbundant n ∧ ¬IsPseudoperfect n))
+
 /-
 ## The Smallest Weird Number: 70
 
@@ -93,9 +103,11 @@ theorem seventy_not_pseudoperfect : ¬IsPseudoperfect 70 := by
   exact this S (Finset.mem_powerset.mpr hS_sub) hS_sum
 
 /--
-No number below 70 is weird (verified by exhaustive check).
+No number below 70 is weird (verified by exhaustive check over all n < 70).
 -/
-axiom no_weird_below_70 (n : ℕ) (hn : n < 70) : ¬IsWeird n
+theorem no_weird_below_70 (n : ℕ) (hn : n < 70) : ¬IsWeird n := by
+  have h : ∀ m ∈ Finset.range 70, ¬IsWeird m := by native_decide
+  exact h n (Finset.mem_range.mpr hn)
 
 /--
 70 is the smallest weird number.
@@ -112,19 +124,20 @@ The sequence of weird numbers begins:
 All known weird numbers are even!
 -/
 
-/--
-836 is the second weird number.
--/
-
-/--
-4030 is the third weird number.
--/
-
 /-
 ## Open Question 1: Odd Weird Numbers
 
 Erdős asked whether any odd weird numbers exist. This remains open
 despite extensive computational searches.
+
+Key facts:
+- 945 = 3³ × 5 × 7 is the smallest odd abundant number
+- 945 is semiperfect (hence not weird): remove {3, 27} from proper
+  divisors, the rest sums to 945
+- Any odd weird must exceed 945
+
+Fang (2022): no odd weird numbers below 10^21.
+Liddy-Riedl (2018): any odd weird has ≥ 6 distinct prime divisors.
 -/
 
 /--
@@ -137,6 +150,47 @@ def OddWeird : Set ℕ := { n | IsWeird n ∧ Odd n }
 -/
 def erdos_470_part1 : Prop := ∃ n : ℕ, IsWeird n ∧ Odd n
 
+/--
+945 = 3³ × 5 × 7 is odd and abundant: σ(945) = 1920 > 1890 = 2 × 945.
+-/
+theorem nine45_odd_abundant : Odd 945 ∧ IsAbundant 945 := by
+  constructor
+  · exact ⟨472, by omega⟩
+  · unfold IsAbundant sigma; native_decide
+
+/--
+945 is semiperfect: its proper divisors {1,5,7,9,15,21,35,45,63,105,135,189,315}
+contain a subset summing to 945. (Remove 3 and 27 from the full set.)
+-/
+theorem nine45_semiperfect : IsPseudoperfect 945 := by
+  have : ∃ S ∈ (945 : ℕ).properDivisors.powerset, S.sum id = 945 := by native_decide
+  exact let ⟨S, hmem, hsum⟩ := this; ⟨S, Finset.mem_powerset.mp hmem, hsum⟩
+
+/--
+945 is not weird (it is semiperfect).
+-/
+theorem nine45_not_weird : ¬IsWeird 945 := fun ⟨_, hnp⟩ => hnp nine45_semiperfect
+
+/--
+No odd number below 945 is abundant. This establishes 945 as the smallest
+odd abundant number: any odd weird must be at least 945, and 945 itself
+is semiperfect.
+-/
+theorem no_odd_abundant_below_945 (n : ℕ) (hn : n < 945) (hodd : Odd n) :
+    ¬IsAbundant n := by
+  have h : ∀ m ∈ Finset.range 945, Odd m → ¬IsAbundant m := by native_decide
+  exact h n (Finset.mem_range.mpr hn) hodd
+
+/--
+Any odd weird number must exceed 945: numbers below 945 are not odd abundant,
+and 945 itself is semiperfect.
+-/
+theorem odd_weird_gt_945 (n : ℕ) (hw : IsWeird n) (hodd : Odd n) : 945 < n := by
+  by_contra h
+  push_neg at h
+  rcases Nat.lt_or_eq_of_le h with hlt | heq
+  · exact absurd hw.1 (no_odd_abundant_below_945 n hlt hodd)
+  · exact absurd (heq ▸ nine45_semiperfect) hw.2
 
 /-
 ## Computational Bounds on Odd Weird Numbers
@@ -147,18 +201,17 @@ Liddy and Riedl (2018) showed that any odd weird must have at least
 -/
 
 /--
-Fang's result: No odd weird numbers below 10^21.
--/
-
-/--
 The number of distinct prime divisors of n.
 -/
 def numPrimeDivisors (n : ℕ) : ℕ :=
   (n.divisors.filter Nat.Prime).card
 
 /--
-Liddy-Riedl result: Any odd weird number has at least 6 prime divisors.
+Liddy-Riedl (2018): any odd weird number has at least 6 distinct prime divisors.
+This is axiomatized — the proof requires deep sieve-theoretic arguments.
 -/
+axiom liddy_riedl_6_primes (n : ℕ) (hw : IsWeird n) (hodd : Odd n) :
+    6 ≤ numPrimeDivisors n
 
 /-
 ## Primitive Weird Numbers
@@ -175,7 +228,8 @@ def IsPrimitiveWeird (n : ℕ) : Prop :=
 /--
 Proper divisors are less than the number itself.
 -/
-axiom properDivisors_lt (n d : ℕ) (hd : d ∈ n.properDivisors) : d < n
+theorem properDivisors_lt (n d : ℕ) (hd : d ∈ n.properDivisors) : d < n :=
+  (Nat.mem_properDivisors.1 hd).2
 
 /--
 70 is primitive weird (trivially, since no number below 70 is weird).
@@ -217,10 +271,6 @@ for all large n. This would follow from conjectures like Cramér's.
 The n-th prime (axiomatized; p_1 = 2, p_2 = 3, etc.)
 -/
 axiom nthPrime : ℕ → ℕ
-
-/--
-Basic property: nthPrime produces primes.
--/
 
 /--
 The prime gap after the n-th prime.
@@ -265,49 +315,6 @@ abundancy index < 4.
 The abundancy index of n.
 -/
 noncomputable def abundancyIndex (n : ℕ) : ℚ := sigma n / n
-
-/--
-If all weird numbers are even, then abundancy index < 4 for all weird numbers.
--/
-
-/-
-## Examples of Weird Numbers
-
-Let's record some explicit weird numbers from OEIS A006037:
-70, 836, 4030, 5830, 7192, 7912, 9272, 10430, 10570, ...
--/
-
-/--
-The first several weird numbers.
--/
-
-/--
-All known weird numbers are even.
--/
-
-/-
-## Why 70 is Weird: A Detailed Analysis
-
-Divisors of 70: 1, 2, 5, 7, 10, 14, 35, 70
-Proper divisors: 1, 2, 5, 7, 10, 14, 35 (sum = 74 > 70, so abundant)
-
-To show 70 is not pseudoperfect, we must check that no subset sums to 70.
-The largest subset sum not exceeding 70 is at most 1+2+5+7+10+14+35 = 74,
-but we can't get exactly 70.
-
-Key observation: 35 is essential (74 - 35 = 39 < 70 without it).
-With 35, remaining budget is 70 - 35 = 35.
-Subsets of {1, 2, 5, 7, 10, 14} summing to 35: 1+2+5+7+10+14 = 39 ≠ 35.
-Various checks show no exact match exists.
--/
-
-/--
-σ(70) = 144.
--/
-
-/--
-The proper divisors of 70 are {1, 2, 5, 7, 10, 14, 35}.
--/
 
 /-
 ## Summary

--- a/src/data/proofs/erdos-470/meta.json
+++ b/src/data/proofs/erdos-470/meta.json
@@ -48,24 +48,26 @@
     ],
     "originalContributions": [
       "Formal definitions of sigma, IsAbundant, IsPseudoperfect, and IsWeird",
+      "Decidable instances for IsPseudoperfect and IsWeird enabling native_decide proofs",
       "Statement of both OPEN Erdős questions in Lean 4",
-      "Definition of IsPrimitiveWeird and the primitive weird set",
-      "Axiomatization of Benkoski-Erdős positive density result",
-      "Axiomatization of Fang's computational bound (no odd weird below 10^21)",
-      "Axiomatization of Liddy-Riedl result (odd weird has ≥6 prime divisors)",
-      "Axiomatization of Melfi's conditional infinitude result",
-      "Theorem: 70 is the smallest weird number",
+      "Proved: 70 is abundant (native_decide), not pseudoperfect (powerset exhaustion)",
+      "Proved: no weird number below 70 (exhaustive computation via native_decide)",
+      "Proved: 70 is the smallest weird number and primitive weird",
+      "Proved: 945 is odd and abundant, 945 is semiperfect (hence not weird)",
+      "Proved: no odd number below 945 is abundant (native_decide)",
+      "Proved: any odd weird number exceeds 945",
+      "Axiomatization of Liddy-Riedl, Melfi, Benkoski-Erdős deep results",
       "erdos_470 summary theorem combining key results"
     ],
-    "axiomCount": 5,
-    "lineCount": 337,
-    "assumptions": "17 axioms: seventy_is_abundant, seventy_not_pseudoperfect, no_weird_below_70, and 14 more. See Lean source for complete statements."
+    "axiomCount": 4,
+    "lineCount": 344,
+    "assumptions": "4 axioms: nthPrime (n-th prime function), liddy_riedl_6_primes (odd weird has ≥6 prime divisors), melfi_conditional (prime gap hypothesis implies infinitely many primitive weirds), benkoski_erdos_density (weird numbers have positive density). All deep results; no routine axioms remain."
   },
   "overview": {
     "historicalContext": "A number n is called **weird** if it is abundant (σ(n) > 2n, or equivalently the sum of proper divisors exceeds n) but not pseudoperfect (n cannot be written as the sum of any subset of its proper divisors). Weird numbers are the 'leftover' abundant numbers that can't achieve self-representation.\n\nWeird numbers were introduced and studied by Benkoski and Erdős [BeEr74], who proved that weird numbers have **positive asymptotic density**—a surprising result meaning a positive fraction of all integers are weird.\n\nThe smallest weird number is **70**:\n- Divisors of 70: 1, 2, 5, 7, 10, 14, 35, 70\n- σ(70) = 144 > 140 = 2×70 ✓ (abundant)\n- No subset of {1, 2, 5, 7, 10, 14, 35} sums to exactly 70 ✓ (not pseudoperfect)\n\nThe sequence of weird numbers (OEIS A006037) begins: 70, 836, 4030, 5830, 7192, 7912, 9272, ...\n\n**Remarkably, all known weird numbers are even!** This leads to Erdős's first question.",
     "problemStatement": "**Two OPEN Questions from Erdős**:\n\n1. **Odd Weird Numbers**: Are there any odd weird numbers?\n   - All weird numbers found so far are even\n   - Fang (2022) showed: No odd weird below 10^21\n   - Liddy-Riedl (2018) showed: Any odd weird must have at least 6 prime divisors\n\n2. **Primitive Weird Numbers**: Are there infinitely many primitive weird numbers?\n   - A weird number is **primitive** if none of its proper divisors is weird\n   - 70 is trivially primitive (no weird numbers below it)\n   - Melfi (2015) proved infinitely many primitive weirds exist conditionally on a prime gap hypothesis\n\n**Status**: Both questions remain OPEN as of 2024.\n\n**Erdős offered $10 for solving the odd weird question.**",
     "text": "A number n is called weird if σ(n) ≥ 2n (abundant) but n is not pseudoperfect (cannot be expressed as the sum of any subset of its proper divisors). Erdős asked two OPEN questions: (1) Are there any odd weird numbers? (2) Are there infinitely many primitive weird numbers?",
-    "proofStrategy": "We formalize both open questions by:\n\n1. **Defining the divisor sum function**: σ(n) = Σ_{d|n} d using Mathlib's divisors\n\n2. **Defining abundance**: n is abundant iff σ(n) > 2n\n\n3. **Defining pseudoperfectness**: n is pseudoperfect iff some subset of its proper divisors sums to n\n\n4. **Defining weirdness**: n is weird iff n is abundant AND n is not pseudoperfect\n\n5. **Defining primitive weirdness**: n is primitive weird iff n is weird AND no proper divisor of n is weird\n\n6. **Stating the open questions**:\n   - erdos_470_part1: ∃ n, IsWeird n ∧ Odd n\n   - erdos_470_part2: PrimitiveWeirdSet.Infinite\n\n7. **Recording known results as axioms**: Benkoski-Erdős density, Fang bound, Liddy-Riedl, Melfi conditional",
+    "proofStrategy": "We formalize both open questions with a combination of computational verification and axiomatization of deep results:\n\n1. **Core definitions** with Decidable instances enabling native_decide proofs\n2. **70 is the smallest weird number**: proved computationally (was previously axiomatized)\n3. **945 is the smallest odd abundant number**: proved via native_decide over all odd n < 945\n4. **945 is semiperfect**: proved by subset-sum exhaustion, so 945 is not weird\n5. **Any odd weird > 945**: structural theorem combining the above\n6. **Deep results axiomatized**: Liddy-Riedl (6 prime divisors), Melfi (conditional infinitude), Benkoski-Erdős (positive density)",
     "keyInsights": [
       "**Why 70 is weird**: The proper divisors {1, 2, 5, 7, 10, 14, 35} sum to 74 > 70 (abundant), but no subset sums to exactly 70. Key observation: 35 is needed (without it, max sum is 39), but with 35 you need the remaining divisors to sum to 35, which is impossible from {1,2,5,7,10,14}.",
       "**Positive density paradox**: Despite being unable to represent themselves as subset sums, weird numbers are actually common! Benkoski and Erdős proved they have positive density, meaning infinitely many exist with positive proportion.",
@@ -82,75 +84,51 @@
   "sections": [
     {
       "id": "definitions",
-      "title": "Core Definitions",
+      "title": "Core Definitions and Decidability",
       "startLine": 45,
-      "endLine": 69,
-      "summary": "Definitions of sigma (σ), IsAbundant, IsPseudoperfect, and IsWeird.",
-      "mathContext": "Definitions of sigma (σ), IsAbundant, IsPseudoperfect, and IsWeird."
+      "endLine": 78,
+      "summary": "Definitions of $\\sigma(n)$, IsAbundant, IsPseudoperfect, IsWeird, plus Decidable instances enabling computational verification via native_decide.",
+      "mathContext": "$\\sigma(n) = \\sum_{d \\mid n} d$. Decidability of IsPseudoperfect: enumerate all subsets of $n.\\text{properDivisors}$ via powerset."
     },
     {
       "id": "smallest-weird",
       "title": "The Smallest Weird Number: 70",
-      "startLine": 70,
-      "endLine": 100,
-      "summary": "Axioms establishing 70 as abundant, not pseudoperfect, and the smallest weird.",
-      "mathContext": "Axioms establishing 70 as abundant, not pseudoperfect, and the smallest weird."
-    },
-    {
-      "id": "oeis-sequence",
-      "title": "The Weird Number Sequence",
-      "startLine": 101,
-      "endLine": 119,
-      "summary": "OEIS A006037 values: 70, 836, 4030, 5830, 7192, 7912, 9272, ...",
-      "mathContext": "OEIS A006037 values: 70, 836, 4030, 5830, 7192, 7912, 9272, ..."
+      "startLine": 80,
+      "endLine": 116,
+      "summary": "Proves 70 is abundant (native_decide), not pseudoperfect (powerset exhaustion), and no number below 70 is weird (exhaustive computation). Formerly axiomatized, now fully proved.",
+      "mathContext": "$\\sigma(70) = 144 > 140 = 2 \\times 70$. No subset of $\\{1,2,5,7,10,14,35\\}$ sums to 70."
     },
     {
       "id": "odd-weird",
       "title": "Open Question 1: Odd Weird Numbers",
-      "startLine": 120,
-      "endLine": 161,
-      "summary": "Formal statement of the odd weird question with Fang and Liddy-Riedl bounds.",
-      "mathContext": "Formal statement of the odd weird question with Fang and Liddy-Riedl bounds."
+      "startLine": 127,
+      "endLine": 214,
+      "summary": "Formal statement of the odd weird question. Proves 945 is the smallest odd abundant number, 945 is semiperfect (hence not weird), and any odd weird number must exceed 945. Axiomatizes Liddy-Riedl's 6-prime-divisor bound.",
+      "mathContext": "$945 = 3^3 \\times 5 \\times 7$, $\\sigma(945) = 1920 > 1890 = 2 \\times 945$. Proper divisors minus $\\{3, 27\\}$ sum to 945. Any odd weird $n > 945$."
     },
     {
       "id": "primitive-weird",
       "title": "Primitive Weird Numbers",
-      "startLine": 162,
-      "endLine": 204,
-      "summary": "Definition of IsPrimitiveWeird, Open Question 2, and seventy_is_primitive_weird proof.",
-      "mathContext": "Definition of IsPrimitiveWeird, Open Question 2, and seventy_is_primitive_weird proof."
+      "startLine": 216,
+      "endLine": 259,
+      "summary": "Definition of IsPrimitiveWeird, Open Question 2 (infinitely many?), and proof that 70 is primitive weird.",
+      "mathContext": "70 is primitive weird: it is weird and every proper divisor $d < 70$ is not weird."
     },
     {
       "id": "conditional-results",
-      "title": "Conditional Results: Prime Gaps",
-      "startLine": 207,
-      "endLine": 237,
-      "summary": "Melfi's conditional infinitude result based on prime gap hypothesis.",
-      "mathContext": "Melfi's conditional infinitude result based on prime gap hypothesis."
-    },
-    {
-      "id": "density",
-      "title": "Positive Density of Weird Numbers",
-      "startLine": 238,
-      "endLine": 254,
-      "summary": "Benkoski-Erdős theorem: weird numbers have positive asymptotic density.",
-      "mathContext": "Benkoski-Erdős theorem: weird numbers have positive asymptotic density."
-    },
-    {
-      "id": "detailed-analysis",
-      "title": "Why 70 is Weird: Detailed Analysis",
-      "startLine": 294,
-      "endLine": 320,
-      "summary": "Complete analysis of why no subset of 70's proper divisors sums to 70.",
-      "mathContext": "Complete analysis of why no subset of 70's proper divisors sums to 70."
+      "title": "Conditional Results and Density",
+      "startLine": 262,
+      "endLine": 304,
+      "summary": "Melfi's conditional infinitude of primitive weirds (from prime gap hypothesis) and Benkoski-Erdős positive density theorem.",
+      "mathContext": "If $p_{n+1} - p_n < \\sqrt{p_n}/10$ eventually, then PrimitiveWeirdSet is infinite. Weird numbers have positive asymptotic density."
     },
     {
       "id": "summary",
       "title": "Summary",
-      "startLine": 321,
-      "endLine": 346,
-      "summary": "erdos_470 summary theorem combining key established results.",
-      "mathContext": "erdos_470 summary theorem combining key established results."
+      "startLine": 319,
+      "endLine": 344,
+      "summary": "The erdos_470 summary theorem combining: 70 is smallest weird, 70 is primitive weird, positive density, Melfi conditional.",
+      "mathContext": "Combined theorem asserting all key established results about Erdős Problem #470."
     }
   ],
   "conclusion": {
@@ -179,9 +157,9 @@
       "Set"
     ],
     "namespace": "Erdos470",
-    "lineCount": 337,
-    "axiomCount": 5,
-    "theoremCount": 3,
+    "lineCount": 344,
+    "axiomCount": 4,
+    "theoremCount": 12,
     "definitionCount": 13
   },
   "crossReferences": [

--- a/src/data/research/problems/erdos-825-oq-03.json
+++ b/src/data/research/problems/erdos-825-oq-03.json
@@ -1,13 +1,13 @@
 {
   "slug": "erdos-825-oq-03",
-  "title": "Do odd weird numbers exist (Erdős Problem #470)",
-  "phase": "NEW",
+  "title": "Do odd weird numbers exist (Erd\u0151s Problem #470)",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
   "problemStatement": {
     "formal": "\\text{(formal statement to be added)}",
-    "plain": "Formal mathematical investigation: Do odd weird numbers exist (Erdős Problem #470).",
+    "plain": "Formal mathematical investigation: Do odd weird numbers exist (Erd\u0151s Problem #470).",
     "whyMatters": []
   },
   "knownResults": {
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-03-30T17:32:58.851Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "Axiom elimination and odd weird number structural theorems",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,11 +29,32 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Added Decidable instances, proved 945 smallest odd abundant + semiperfect, proved odd_weird_gt_945. Eliminated 2 axioms (properDivisors_lt, no_weird_below_70). 4A remain (all deep).",
+    "builtItems": [
+      "Decidable instances for IsPseudoperfect and IsWeird in Erdos470Problem.lean:70-78",
+      "Proved no_weird_below_70 (was axiom) via native_decide in Erdos470Problem.lean:108-110",
+      "Proved properDivisors_lt (was axiom) from Mathlib in Erdos470Problem.lean:231",
+      "Proved nine45_odd_abundant in Erdos470Problem.lean:156-159",
+      "Proved nine45_semiperfect in Erdos470Problem.lean:165-167",
+      "Proved nine45_not_weird in Erdos470Problem.lean:172",
+      "Proved no_odd_abundant_below_945 in Erdos470Problem.lean:179-182",
+      "Proved odd_weird_gt_945 in Erdos470Problem.lean:188-193",
+      "Added liddy_riedl_6_primes axiom in Erdos470Problem.lean:213-214"
+    ],
+    "insights": [
+      "IsPseudoperfect is decidable by enumerating subsets of properDivisors.powerset",
+      "945 = 3^3 * 5 * 7 is the smallest odd abundant number (sigma=1920 > 1890=2*945)",
+      "945 is semiperfect: remove {3,27} from proper divisors, rest sums to 945",
+      "Any odd weird number must exceed 945 (no odd abundant below, 945 semiperfect)",
+      "properDivisors_lt follows immediately from Nat.mem_properDivisors",
+      "no_weird_below_70 provable by native_decide with Decidable IsWeird instance",
+      "Reduced axiom count from 5 to 4 in Erdos470Problem.lean"
+    ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "Strengthen odd_weird bound beyond 945 (check more odd abundant numbers for semiperfectness)",
+      "Fang bound (no odd weird below 10^21) cannot be proved computationally in Lean"
+    ]
   },
   "tags": [
     "seeker-selected"
@@ -54,15 +75,15 @@
   "tractability": 6,
   "leanFiles": [
     {
-      "path": "Proofs/Erdos825Problem.lean",
-      "filename": "Erdos825Problem.lean",
-      "lineCount": 106,
-      "theoremCount": 3,
-      "axiomCount": 0,
-      "defCount": 8,
+      "path": "Proofs/Erdos470Problem.lean",
+      "filename": "Erdos470Problem.lean",
+      "lineCount": 344,
+      "theoremCount": 12,
+      "axiomCount": 4,
+      "defCount": 13,
       "sorryCount": 0,
       "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos825Problem.lean"
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos470Problem.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Eliminated 2 axioms from Erdos470Problem.lean (`properDivisors_lt` from Mathlib, `no_weird_below_70` via `native_decide`)
- Added `Decidable` instances for `IsPseudoperfect` and `IsWeird`, enabling computational proofs
- Proved 945 is the smallest odd abundant number and is semiperfect (hence not weird)
- Proved any odd weird number must exceed 945
- Added Liddy-Riedl axiom (odd weird has ≥6 prime divisors)
- Net axiom change: 5 → 4 (all remaining are deep results). Theorems: 3 → 12.

## Progress
- **Axioms eliminated**: `properDivisors_lt` (trivial from `Nat.mem_properDivisors`), `no_weird_below_70` (exhaustive computation via `native_decide` with new `Decidable IsWeird` instance)
- **New theorems**: `nine45_odd_abundant`, `nine45_semiperfect`, `nine45_not_weird`, `no_odd_abundant_below_945`, `odd_weird_gt_945`
- **New axiom**: `liddy_riedl_6_primes` (deep sieve-theoretic result)

## Status
**Outcome**: progress
**Next Steps**: Strengthen odd weird lower bound beyond 945 by checking more odd abundant numbers for semiperfectness

🤖 Generated by researcher-3