### PR TITLE
Research: erdos-1001-oq-01 - outside-EST regime survey + structural theorems

### DIFF
--- a/proofs/Proofs/Erdos1001Problem.lean
+++ b/proofs/Proofs/Erdos1001Problem.lean
@@ -54,18 +54,41 @@ noncomputable def S (N : ℕ) (A c : ℝ) : ℝ :=
 The measure S(N, A, c) satisfies natural bounds and monotonicity.
 -/
 
-/-- S(N, A, c) is always between 0 and 1. -/
-/-- S is monotone increasing in A. -/
-/-- S is monotone increasing in c. -/
 /-
 ## The Limit Function
 
 The main result is that S(N, A, c) converges as N → ∞.
 -/
 
-/-- The limiting density function f(A, c). -/
+/-- The EST formula f(A, c) = 12A log(c)/π², valid in the EST regime. -/
 noncomputable def f (A c : ℝ) : ℝ :=
   12 * A * log c / π^2
+
+/-- f(A,c) is positive when A > 0 and c > 1: the approximation set has
+    positive limiting measure, reflecting the density of rationals. -/
+theorem f_pos (A c : ℝ) (hA : A > 0) (hc : c > 1) : f A c > 0 := by
+  unfold f
+  apply div_pos
+  · apply mul_pos
+    apply mul_pos
+    · linarith
+    · exact hA
+    · exact Real.log_pos hc
+  · positivity
+
+/-- f is linear in A (for fixed c). -/
+theorem f_linear_A (c A₁ A₂ : ℝ) :
+    f (A₁ + A₂) c = f A₁ c + f A₂ c := by
+  unfold f; ring
+
+/-- f is zero when A = 0. -/
+theorem f_zero_A (c : ℝ) : f 0 c = 0 := by
+  unfold f; ring
+
+/-- f is zero when c = 1 (since log 1 = 0). -/
+theorem f_one_c (A : ℝ) : f A 1 = 0 := by
+  unfold f
+  simp [Real.log_one]
 
 /-- The main question: Does lim S(N, A, c) exist? -/
 def limitExists (A c : ℝ) : Prop :=
@@ -99,7 +122,6 @@ theorem est_explicit_formula (A c : ℝ) (hA : 0 < A) (hc : c > 1)
 EST also proved that when min(A,c) > 10, S stays bounded away from extremes.
 -/
 
-/-- EST boundedness: If min(A,c) > 10, then S(N,A,c) stays bounded away from 0 and 1. -/
 /-
 ## Kesten-Sós Result (1966)
 
@@ -148,12 +170,52 @@ The problem relates to the distribution of Farey fractions.
 def FareyFraction (n : ℕ) : Set ℚ :=
   { r : ℚ | 0 ≤ r ∧ r ≤ 1 ∧ r.den ≤ n ∧ r.den.Coprime r.num.natAbs }
 
-/-- The number of Farey fractions of order n is asymptotically 3n²/π². -/
-/-- The EST formula involves 1/π² due to this Farey connection. -/
 theorem est_pi_squared_explanation :
     f 1 (Real.exp 1) = 12 / π^2 := by
   simp [f]
   ring
+
+/-
+## Outside the EST Regime (Open Question oq-01)
+
+The EST formula f(A,c) = 12A log(c)/π² holds when 0 < A < c/(1+c²).
+Outside this regime (A ≥ c/(1+c²)), the limit still exists (Kesten-Sós)
+but the explicit formula changes because the Farey approximation
+intervals begin to overlap.
+
+Key observations:
+- In the EST regime, intervals |α - x/y| < A/y² for consecutive Farey
+  fractions x/y are disjoint, so the total measure is a simple sum
+- Outside EST, overlaps create inclusion-exclusion corrections
+- The general formula involves the pair-correlation statistics of
+  Farey fractions, studied by Boca-Cobeli-Zaharescu (2001)
+- As A → ∞, limitValue(A,c) → 1 (full measure)
+
+The explicit formula outside EST remains an active research direction.
+-/
+
+/-- The EST regime boundary value: A = c/(1+c²). -/
+noncomputable def estBoundary (c : ℝ) : ℝ := c / (1 + c^2)
+
+/-- The EST boundary is positive when c > 0. -/
+theorem estBoundary_pos (c : ℝ) (hc : c > 0) : estBoundary c > 0 := by
+  unfold estBoundary
+  apply div_pos hc
+  nlinarith [sq_nonneg c]
+
+/-- Outside the EST regime: A ≥ c/(1+c²). Here the EST formula may
+    undercount due to overlap, so limitValue(A,c) ≥ f(A,c). -/
+def outsideESTRegime (A c : ℝ) : Prop :=
+  0 < A ∧ c / (1 + c^2) ≤ A
+
+/-- In the EST regime, the limit equals f(A,c). Outside, by Kesten-Sós,
+    the limit still exists but may differ from f(A,c). -/
+theorem limit_in_est_regime (A c : ℝ) (hA : 0 < A) (hc : c > 1)
+    (hregime : inESTRegime A c) :
+    limitValue A c = f A c := by
+  have hconv := erdos_szusz_turan A c hA hc hregime
+  have hconv2 := limit_convergence A c hA hc
+  exact tendsto_nhds_unique hconv2 hconv
 
 /-
 ## Summary
@@ -171,11 +233,11 @@ the set of α ∈ (0,1) approximable by some x/y with N ≤ y ≤ cN?
 **Key Results**:
 - Erdős-Szüsz-Turán (1958): Explicit formula in EST regime
 - Kesten-Sós (1966): Limit exists in general
-- EST boundedness: S stays away from 0 and 1 when min(A,c) > 10
 - Boca, Xiong-Zaharescu: Alternative explicit proofs
+- f(A,c) > 0 for A > 0, c > 1 (proved)
+- limitValue = f in EST regime (proved via uniqueness of limits)
 
-**Connection**: The π² in the denominator comes from the asymptotics
-of Farey fractions: |F_n| ~ 3n²/π².
+**Open**: Explicit formula outside EST regime (A ≥ c/(1+c²)).
 -/
 
 /-- **Erdős Problem #1001: SOLVED**

--- a/src/data/proofs/erdos-1001/meta.json
+++ b/src/data/proofs/erdos-1001/meta.json
@@ -57,8 +57,8 @@
       "Formalization of EST regime condition",
       "Connection to Farey fraction asymptotics"
     ],
-    "axiomCount": 9,
-    "assumptions": "9 axiom declarations encoding results on the distribution of {nα} sequences: S_bounds, S_mono_A, S_mono_c (properties of the discrepancy functional S(N,A,c)), erdos_szusz_turan (Erdős-Szüsz-Turán 1958 theorem on bounded discrepancy), est_boundedness (boundedness condition), kesten_sos (Kesten's three-distance theorem connection), boca_theorem (Boca's continued fraction approach), xiong_zaharescu_theorem (Xiong-Zaharescu gap distribution result). These encode established results in the metric theory of continued fractions.",
+    "axiomCount": 2,
+    "assumptions": "2 axioms: erdos_szusz_turan (EST 1958: explicit formula in EST regime), kesten_sos (Kesten-Sós 1966: limit exists for all valid A, c). Both are deep analytic number theory results.",
     "prerequisites": [
       "Diophantine approximation (Dirichlet's theorem, approximation quality)",
       "Lebesgue measure on the real line",
@@ -67,7 +67,7 @@
       "Euler's totient function and coprime density (6/pi^2)",
       "Basic ergodic theory (for Kesten-Sos proof method)"
     ],
-    "lineCount": 187
+    "lineCount": 249
   },
   "overview": {
     "historicalContext": "This problem originates in a 1958 paper by Erdős, Szüsz, and Turán, who studied the metric theory of Diophantine approximation — specifically, what fraction of real numbers $\\alpha \\in (0,1)$ can be well-approximated by rationals whose denominators lie in a prescribed range $[N, cN]$. They proved the explicit formula $f(A,c) = 12A\\log(c)/\\pi^2$ in a specific parameter regime, revealing a striking connection to the density of coprime pairs via Euler's formula $\\sum_{n=1}^\\infty 1/n^2 = \\pi^2/6$. The key advance came in 1966 when Harry Kesten and Vera T. Sós proved that the limit $\\lim_{N \\to \\infty} S(N,A,c)$ exists for all valid parameters, using ergodic-theoretic methods — a significant generalization since no explicit formula was needed. Later, Florin Boca (2008) gave an independent proof using the geometry of Farey fractions and their spacing statistics, while Xiong and Zaharescu (2006) provided yet another proof via continued fraction expansions. The problem illustrates a central theme in metric number theory: how measure-theoretic properties of approximation sets encode deep arithmetic structure.",
@@ -217,10 +217,10 @@
       "Real"
     ],
     "namespace": "Erdos1001",
-    "lineCount": 187,
-    "axiomCount": 9,
-    "theoremCount": 4,
-    "definitionCount": 10
+    "lineCount": 249,
+    "axiomCount": 2,
+    "theoremCount": 10,
+    "definitionCount": 12
   },
   "references": [
     {

--- a/src/data/research/problems/erdos-1001-oq-01.json
+++ b/src/data/research/problems/erdos-1001-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-1001-oq-01",
   "title": "Explicit formula for f(A,c) outside EST regime",
-  "phase": "NEW",
+  "phase": "ORIENT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ORIENT",
     "since": "2026-03-30T16:34:54.971Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "Survey of outside-EST regime + structural theorems",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,11 +29,27 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "SURVEY: Added f_pos, f_linear_A, f_zero_A, f_one_c, estBoundary_pos, limit_in_est_regime. Documented outside-EST regime. Fixed meta.json axiomCount 9\u21922.",
+    "builtItems": [
+      "Proved f_pos (f(A,c) > 0 for valid params) in Erdos1001Problem.lean",
+      "Proved f_linear_A, f_zero_A, f_one_c (algebraic properties) in Erdos1001Problem.lean",
+      "Proved estBoundary_pos (EST boundary value positive) in Erdos1001Problem.lean",
+      "Proved limit_in_est_regime (limitValue = f in EST regime) in Erdos1001Problem.lean",
+      "Defined outsideESTRegime, estBoundary in Erdos1001Problem.lean",
+      "Fixed meta.json axiomCount from 9 to 2"
+    ],
+    "insights": [
+      "Outside EST regime, Farey approximation intervals overlap causing inclusion-exclusion corrections",
+      "General formula involves pair-correlation statistics of Farey fractions (Boca-Cobeli-Zaharescu 2001)",
+      "As A \u2192 \u221e, limitValue(A,c) \u2192 1 (full measure)",
+      "The meta.json previously claimed 9 axioms but only 2 exist in the file",
+      "limit_in_est_regime provable via tendsto_nhds_unique (limits are unique in T2 spaces)"
+    ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "Prove limitValue is monotone in A (needs measure-theoretic argument)",
+      "Study Boca-Cobeli-Zaharescu pair correlation for explicit outside-EST formula"
+    ]
   },
   "tags": [
     "seeker-selected",


### PR DESCRIPTION
## Summary
- Proved structural properties of EST formula f(A,c): positivity, linearity in A, boundary values
- Proved limitValue = f(A,c) in EST regime via uniqueness of limits
- Defined outside-EST regime and documented why the formula changes (interval overlap)
- Fixed meta.json axiomCount from 9 to 2 (was incorrect)
- Removed orphaned doc comments

## Progress
- 6 new theorems (f_pos, f_linear_A, f_zero_A, f_one_c, estBoundary_pos, limit_in_est_regime)
- 2 new definitions (estBoundary, outsideESTRegime)
- No axiom changes (2 remain, both deep)

## Status
**Outcome**: surveyed
**Next Steps**: Study Boca-Cobeli-Zaharescu pair correlation for explicit outside-EST formula

🤖 Generated by researcher-3