### PR TITLE
Research: eliminate 2 sorries + 1 axiom + Cauchy-Schwarz proof

### DIFF
--- a/proofs/Proofs/Erdos1026Problem.lean
+++ b/proofs/Proofs/Erdos1026Problem.lean
@@ -40,7 +40,9 @@ import Mathlib.Data.Real.Basic
 import Mathlib.Data.Real.Sqrt
 import Mathlib.Data.List.Basic
 import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Finset.Sort
 import Mathlib.Algebra.BigOperators.Finprod
+import Archive.Wiedijk100Theorems.AscendingDescendingSequences
 
 open Finset BigOperators
 
@@ -94,10 +96,37 @@ an increasing subsequence of length r or a decreasing subsequence of length s.
 Taking r = s = n+1 gives: every sequence of n² + 1 elements contains
 a monotonic subsequence of length n + 1.
 -/
-axiom erdos_szekeres (r s : ℕ) (n : ℕ) (hn : n = (r - 1) * (s - 1) + 1)
+theorem erdos_szekeres (r s : ℕ) (n : ℕ) (hn : n = (r - 1) * (s - 1) + 1)
     (seq : RealSeq n) (hDistinct : Function.Injective seq) :
     (∃ (sub : Subsequence n r), IsIncreasing seq sub) ∨
-    (∃ (sub : Subsequence n s), IsDecreasing seq sub)
+    (∃ (sub : Subsequence n s), IsDecreasing seq sub) := by
+  -- Apply Mathlib's Erdős-Szekeres with parameters (r-1) and (s-1)
+  have hn_card : (r - 1) * (s - 1) < Fintype.card (Fin n) := by
+    rw [Fintype.card_fin]; omega
+  rcases Theorems100.erdos_szekeres hn_card hDistinct with
+    ⟨t, ht_card, ht_mono⟩ | ⟨t, ht_card, ht_anti⟩
+  · -- Increasing case: t has > (r-1) elements, so ≥ r
+    left
+    have hr : r ≤ t.card := by omega
+    obtain ⟨u, hu_sub, hu_card⟩ := Finset.exists_smaller_set t r hr
+    -- Build Subsequence from the Finset via orderEmbOfFin
+    let emb := u.orderEmbOfFin hu_card
+    refine ⟨⟨emb, emb.strictMono⟩, fun i j hij => ?_⟩
+    -- IsIncreasing: seq (emb i) < seq (emb j) for i < j
+    -- emb is order-preserving, and seq is strictly monotone on t ⊇ u
+    have hmono_u : StrictMonoOn seq ↑u := ht_mono.mono (Finset.coe_subset.mpr hu_sub)
+    exact hmono_u (Finset.orderEmbOfFin_mem u hu_card i)
+      (Finset.orderEmbOfFin_mem u hu_card j) (emb.strictMono hij)
+  · -- Decreasing case: t has > (s-1) elements, so ≥ s
+    right
+    have hs : s ≤ t.card := by omega
+    obtain ⟨u, hu_sub, hu_card⟩ := Finset.exists_smaller_set t s hs
+    let emb := u.orderEmbOfFin hu_card
+    refine ⟨⟨emb, emb.strictMono⟩, fun i j hij => ?_⟩
+    -- IsDecreasing: seq (emb j) < seq (emb i) for i < j
+    have hanti_u : StrictAntiOn seq ↑u := ht_anti.mono (Finset.coe_subset.mpr hu_sub)
+    exact hanti_u (Finset.orderEmbOfFin_mem u hu_card i)
+      (Finset.orderEmbOfFin_mem u hu_card j) (emb.strictMono hij)
 
 /-- Corollary: Every sequence of k²+1 elements has a monotonic
     subsequence of length ≥ k+1.

--- a/proofs/Proofs/Stubs/Erdos1039Problem.lean
+++ b/proofs/Proofs/Stubs/Erdos1039Problem.lean
@@ -107,7 +107,33 @@ axiom klr_lower :
 theorem klr_better_than_pommerenke :
     ∀ᶠ n in Filter.atTop,
     1 / ((n : ℝ) * Real.sqrt (Real.log n)) > 1 / (2 * Real.exp 1 * n^2) := by
-  sorry
+  filter_upwards [Filter.eventually_ge_atTop 3] with n hn
+  have hn3 : (3 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn
+  have hn_pos : (0 : ℝ) < (n : ℝ) := by linarith
+  have hlog_pos : 0 < Real.log (n : ℝ) := Real.log_pos (by linarith : (1 : ℝ) < n)
+  have hsqrt_pos : 0 < Real.sqrt (Real.log (n : ℝ)) := Real.sqrt_pos.mpr hlog_pos
+  -- Key chain: √(log n) < log n < n for n ≥ 3
+  have hlog_gt_1 : 1 < Real.log (n : ℝ) := by
+    rw [show (1 : ℝ) = Real.log (Real.exp 1) from (Real.log_exp 1).symm]
+    exact Real.log_lt_log (Real.exp_pos 1) (by linarith [Real.exp_one_lt_d9])
+  have hsqrt_lt_log : Real.sqrt (Real.log (n : ℝ)) < Real.log (n : ℝ) := by
+    have h1 : 1 < Real.sqrt (Real.log (n : ℝ)) := by
+      rw [show (1 : ℝ) = Real.sqrt 1 from Real.sqrt_one.symm]
+      exact Real.sqrt_lt_sqrt (by linarith) hlog_gt_1
+    calc Real.sqrt (Real.log (n : ℝ))
+        = Real.sqrt (Real.log (n : ℝ)) * 1 := (mul_one _).symm
+      _ < Real.sqrt (Real.log (n : ℝ)) * Real.sqrt (Real.log (n : ℝ)) :=
+          mul_lt_mul_of_pos_left h1 hsqrt_pos
+      _ = Real.log (n : ℝ) := Real.mul_self_sqrt (le_of_lt hlog_pos)
+  have hlog_lt_n : Real.log (n : ℝ) < (n : ℝ) := by
+    have := Real.add_one_le_exp hlog_pos.le
+    rw [Real.exp_log hn_pos] at this; linarith
+  -- 1/(n√(log n)) > 1/(2en²) ⟺ 2en² > n√(log n) ⟺ 2en > √(log n)
+  rw [gt_iff_lt, div_lt_div_iff (by positivity) (mul_pos hn_pos hsqrt_pos)]
+  simp only [one_mul]
+  push_cast
+  nlinarith [Real.exp_one_gt_d9,
+             mul_lt_mul_of_pos_left (lt_trans hsqrt_lt_log hlog_lt_n) hn_pos]
 
 /-
 ## The Erdős-Herzog-Piranian Conjecture
@@ -144,7 +170,23 @@ noncomputable def benchmarkBound (n : ℕ) : ℝ :=
 /-- For small enough c (c < π/2), the KLR bound is below the benchmark. -/
 theorem bounds_gap (n : ℕ) (hn : n ≥ 3) (c : ℝ) (hc : 0 < c) (hc' : c < Real.pi / 2) :
     klrBound c n < benchmarkBound n := by
-  sorry
+  simp only [klrBound, benchmarkBound]
+  have hn_pos : (0 : ℝ) < (n : ℝ) := by exact_mod_cast show 0 < n by omega
+  have hn3 : (3 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn
+  have hlog_pos : 0 < Real.log (n : ℝ) := Real.log_pos (by linarith : (1 : ℝ) < n)
+  have hsqrt_pos : 0 < Real.sqrt (Real.log (n : ℝ)) := Real.sqrt_pos.mpr hlog_pos
+  have hlog_ge_1 : 1 ≤ Real.log (n : ℝ) := by
+    have hexp_le : Real.exp 1 ≤ (n : ℝ) := by
+      have : Real.exp 1 < 3 := by linarith [Real.exp_one_lt_d9]
+      linarith
+    rwa [Real.exp_le_iff_le_log hn_pos] at hexp_le
+  have hsqrt_ge_1 : 1 ≤ Real.sqrt (Real.log (n : ℝ)) := by
+    have := Real.sqrt_le_sqrt hlog_ge_1; rwa [Real.sqrt_one] at this
+  -- Reduce to: 2c < π√(log n), by clearing positive denominators
+  rw [div_lt_div_iff (mul_pos hn_pos hsqrt_pos) (by positivity : (0 : ℝ) < 2 * ↑n)]
+  -- Goal: c * (2 * ↑n) < π * (↑n * √(log ↑n))
+  -- From c < π/2 and √(log n) ≥ 1: 2cn < πn ≤ πn√(log n)
+  nlinarith [Real.pi_pos]
 
 /-
 ## Lemniscate Properties
@@ -179,8 +221,8 @@ theorem sublevelSet_nonempty (hf : f.degree > 0) :
 ## Area Bounds
 -/
 
-/-- Area of the sublevel set. -/
-noncomputable def sublevelArea : ℝ := MeasureTheory.volume (sublevelSet f)
+/-- Area of the sublevel set (Lebesgue measure, converted to ℝ via toReal). -/
+noncomputable def sublevelArea : ℝ := (MeasureTheory.volume (sublevelSet f)).toReal
 
 /-- Lower bound on area implies lower bound on inscribed disc. -/
 theorem area_implies_disc_bound :

--- a/src/data/proofs/erdos-1026/meta.json
+++ b/src/data/proofs/erdos-1026/meta.json
@@ -59,9 +59,9 @@
       "LIS/LDS bounds as corollaries"
     ],
     "dateAdded": "2025-12-28",
-    "axiomCount": 10,
-    "lineCount": 254,
-    "assumptions": "10 axioms: erdos_szekeres, hanani_decomposition, dilworth_bound, hanani_lower_bound, cambie_upper_bound, weighted_erdos_szekeres, optimal_constant_is_one, lis_lds_bound, longest_monotonic_bound, erdos_1026_tight. Three proved: erdos_szekeres_square (from erdos_szekeres), tidor_wang_yang (= weighted_erdos_szekeres), tournament_connection (trivial).",
+    "axiomCount": 2,
+    "lineCount": 283,
+    "assumptions": "2 axioms: weighted_erdos_szekeres (deep: Tidor-Wang-Yang 2016), lis_lds_bound (LIS*LDS >= n). erdos_szekeres now proved from Mathlib (Theorems100.erdos_szekeres via Finset.orderEmbOfFin bridge).",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-1039/meta.json
+++ b/src/data/proofs/erdos-1039/meta.json
@@ -17,14 +17,14 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 3,
     "erdosNumber": 1039,
     "erdosUrl": "https://erdosproblems.com/1039",
     "erdosProblemStatus": "open",
     "relatedProblems": [],
     "axiomCount": 5,
-    "lineCount": 261,
-    "assumptions": "5 axioms: benchmark_upper, pommerenke_lower, klr_lower, klr_area_bound, random_polynomial_expected. Removed inconsistent ehp_open axiom. 5 sorries remain.",
+    "lineCount": 303,
+    "assumptions": "5 axioms: benchmark_upper, pommerenke_lower, klr_lower, klr_area_bound, random_polynomial_expected. 3 sorries remain (area_implies_disc_bound, degree_one_optimal, clustered_implies_large_disc). Fixed sublevelArea type (ENNReal→ℝ via toReal).",
     "mathlib_version": "4.29.0"
   },
   "overview": {

--- a/src/data/research/problems/erdos-1039-oq-02.json
+++ b/src/data/research/problems/erdos-1039-oq-02.json
@@ -1,0 +1,68 @@
+{
+  "slug": "erdos-1039-oq-02",
+  "title": "erdos-1039-oq-02",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "",
+    "plain": "",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-03-30T11:35:15-07:00",
+    "iteration": 2,
+    "focus": "Prove inequality sorries in Erdos1039Problem.lean",
+    "blockers": [],
+    "nextAction": "Remaining 3 sorries: area_implies_disc_bound, degree_one_optimal, clustered_implies_large_disc",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROGRESS: Eliminated 2 of 5 sorries (klr_better_than_pommerenke, bounds_gap). Fixed sublevelArea type error (ENNReal to Real). 3 sorries remain.",
+    "builtItems": [
+      "Proved klr_better_than_pommerenke (Filter.Eventually bound comparison)",
+      "Proved bounds_gap (klrBound < benchmarkBound for n>=3, c<pi/2)",
+      "Fixed sublevelArea: ENNReal.toReal coercion for volume measure"
+    ],
+    "insights": [
+      "klr_better_than_pommerenke proved via chain sqrt(log n) < log n < n for n>=3, using exp_one_lt_d9 and add_one_le_exp",
+      "bounds_gap proved via clearing denominators + nlinarith with sqrt(log n)>=1 from log n>=1 (exp 1 < 3)",
+      "sublevelArea definition had type error: MeasureTheory.volume returns ENNReal not Real, fixed with .toReal",
+      "area_implies_disc_bound requires measure-theoretic isoperimetric inequality - complex",
+      "degree_one_optimal requires sSup reasoning about inscribed discs in open ball",
+      "clustered_implies_large_disc requires quantitative analysis of sublevel set geometry"
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "area_implies_disc_bound: needs pi*rho^2 <= area via measure theory + inscribed disc definition",
+      "degree_one_optimal: needs to show sSup of inscribed radii = 1 for degree-1 polynomial",
+      "clustered_implies_large_disc: needs triangle inequality analysis for clustered roots"
+    ],
+    "markdown": "# Knowledge Base: erdos-1039-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [],
+  "relatedProofs": [
+    "erdos-1",
+    "erdos-10",
+    "erdos-103",
+    "erdos-1039"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-03-30T18:39:05.245Z",
+  "lastUpdate": "2026-03-30T18:39:05.260Z"
+}


### PR DESCRIPTION
## Summary
Three research problems addressed in this PR:

### erdos-1039-oq-02: Polynomial Lemniscate Disc Radius
- Prove `klr_better_than_pommerenke`: KLR bound eventually exceeds Pommerenke via √(log n) < log n < n chain
- Prove `bounds_gap`: klrBound < benchmarkBound using √(log n) ≥ 1
- Fix `sublevelArea` type error (ENNReal → ℝ via .toReal)
- **Sorries**: 5 → 3

### erdos-1026-oq-03: Erdős-Szekeres Axiom Elimination
- Prove `erdos_szekeres` from Mathlib's `Theorems100.erdos_szekeres`
- Bridge via `Finset.orderEmbOfFin` + `exists_smaller_set`
- **Axioms**: 3 → 2 (meta corrected from stale 10)

### erdos-1-oq-02-incomplete-01: Cauchy-Schwarz for DFX framework
- Prove `sum_sq_cauchy_schwarz`: (∑aᵢ)² ≤ n·∑aᵢ² via ℕ→ℤ cast + induction
- Note: `dfx_lower_bound` statement is false for A={1},N=1 — needs constraint fix
- **Sorries**: 2 → 1

## Test plan
- [ ] Verify `Erdos1039Problem.lean` builds (3 sorries expected)
- [ ] Verify `Erdos1026Problem.lean` builds (0 sorries, 2 axioms expected)
- [ ] Verify `Erdos1OQ02.lean` builds (1 sorry expected)

🤖 Generated by researcher-9