### PR TITLE
Research: erdos-1100-oq-01 - prove g_exponential_growth + Aristotle companion

### DIFF
--- a/proofs/Proofs/Erdos1100OQ01Aristotle.lean
+++ b/proofs/Proofs/Erdos1100OQ01Aristotle.lean
@@ -1,0 +1,63 @@
+/-
+  Aristotle targets for Erdős Problem #1100 (OQ-01)
+  Routine supporting lemmas for automated proof search.
+  See Erdos1100ProblemProvable.lean for the main formalization.
+
+  These lemmas support proving tau_perp_equality_infinitely_often:
+  "For infinitely many n, τ⊥(n) = ω(n)."
+  Strategy: prime numbers are witnesses (τ⊥(p) = 1 = ω(p)).
+
+  Criteria for inclusion:
+  - NOT the main open conjecture (τ⊥(n)/ω(n) → ∞ for almost all n)
+  - Known results likely in Mathlib
+  - Clean theorem statements with no definition sorries
+  - No axiom declarations
+-/
+
+import Mathlib
+
+open Nat Finset
+
+namespace Erdos1100OQ01
+
+/-
+## Supporting lemmas for τ⊥(p) = ω(p) = 1 for primes
+-/
+
+/--
+ω(p) = 1 for any prime p: a prime has exactly one distinct prime factor.
+-/
+theorem omega_prime (p : ℕ) (hp : Nat.Prime p) :
+    p.primeFactors.card = 1 := by sorry
+
+/--
+The divisor count of a prime is 2: divisors of p are {1, p}.
+-/
+theorem tau_prime (p : ℕ) (hp : Nat.Prime p) :
+    (Finset.filter (· ∣ p) (Finset.range (p + 1))).card = 2 := by sorry
+
+/--
+The set of divisors of a prime p in {0, ..., p} is exactly {1, p}.
+-/
+theorem divisors_of_prime (p : ℕ) (hp : Nat.Prime p) :
+    Finset.filter (· ∣ p) (Finset.range (p + 1)) = {1, p} := by sorry
+
+/--
+gcd(1, n) = 1 for any n: 1 is coprime to everything.
+-/
+theorem gcd_one_left_eq (n : ℕ) : Nat.gcd 1 n = 1 := by sorry
+
+/--
+For a squarefree number n with ω(n) = 1, n is prime.
+-/
+theorem squarefree_omega_one_is_prime (n : ℕ) (hn : n > 1)
+    (hsf : Squarefree n) (hω : n.primeFactors.card = 1) :
+    Nat.Prime n := by sorry
+
+/--
+Infinitude of primes: for any N, there exists a prime p > N.
+(Standard result, should be in Mathlib.)
+-/
+theorem exists_prime_gt (N : ℕ) : ∃ p : ℕ, p > N ∧ Nat.Prime p := by sorry
+
+end Erdos1100OQ01

--- a/proofs/Proofs/Erdos1100ProblemProvable.lean
+++ b/proofs/Proofs/Erdos1100ProblemProvable.lean
@@ -79,6 +79,8 @@ theorem tau_perp_lower_bound (n : ℕ) (hn : n > 0) : tauPerp n ≥ omega n := b
 /--
 **Equality achieved infinitely often:**
 There exist infinitely many n with τ⊥(n) = ω(n).
+Proof strategy: For any prime p, divisors are [1, p], so τ⊥(p) = 1 = ω(p).
+Since there are infinitely many primes, the statement follows.
 -/
 theorem tau_perp_equality_infinitely_often :
     ∀ N : ℕ, ∃ n : ℕ, n > N ∧ tauPerp n = omega n := by sorry
@@ -160,23 +162,23 @@ theorem erdos_simonovits_bounds :
 /--
 **The growth rate of g(k):**
 The base of exponential growth is between √2 ≈ 1.414 and 2-c < 2.
+The lower bound is asymptotic: for any ε > 0, g(k) ≥ (√2 - ε)^k eventually.
 -/
 theorem g_exponential_growth :
-    ∃ α β : ℝ, Real.sqrt 2 ≤ α ∧ β < 2 ∧
-      ∀ k : ℕ, k ≥ 10 →
-        α^k ≤ (g k : ℝ) ∧ (g k : ℝ) ≤ β^k := by
+    ∃ β : ℝ, β < 2 ∧
+      -- Asymptotic lower bound approaching √2
+      (∀ ε > 0, ∃ K : ℕ, ∀ k : ℕ, k ≥ K →
+        (Real.sqrt 2 - ε)^k ≤ (g k : ℝ)) ∧
+      -- Eventual upper bound
+      (∃ K : ℕ, ∀ k : ℕ, k ≥ K →
+        (g k : ℝ) ≤ β^k) := by
   obtain ⟨c, hc, hlower, hupper⟩ := erdos_simonovits_bounds
-  use Real.sqrt 2, 2 - c
-  constructor
-  · linarith
-  constructor
-  · linarith
-  · intro k _
-    constructor
-    · -- Lower bound
-      sorry -- Requires the limit statement
-    · -- Upper bound
-      sorry -- From hupper
+  refine ⟨2 - c, by linarith, ?_, ?_⟩
+  · intro ε hε
+    obtain ⟨K, hK⟩ := hlower ε hε
+    exact ⟨K, fun k hk => le_of_lt (hK k hk)⟩
+  · obtain ⟨K, hK⟩ := hupper
+    exact ⟨K, fun k hk => le_of_lt (hK k hk)⟩
 
 /-
 ## Part VI: Examples

--- a/src/data/research/problems/erdos-1100-oq-01.json
+++ b/src/data/research/problems/erdos-1100-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-1100-oq-01",
   "title": "Does $\\tau^{\\perp}(n)/\\omega(n) \\to \\infty$ for almost all $n$",
-  "phase": "NEW",
+  "phase": "ORIENT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -16,24 +16,36 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ORIENT",
     "since": "2026-03-30T17:32:58.850Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "Eliminated 2 sorries in g_exponential_growth; companion file created for Aristotle",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Fixed incorrect g_exponential_growth statement and proved it (2 sorries eliminated, 6→4). Created Aristotle companion file with 6 lemmas supporting tau_perp_equality_infinitely_often proof.",
+    "builtItems": [
+      "Proved g_exponential_growth in Erdos1100ProblemProvable.lean (eliminated 2 sorries)",
+      "Created Erdos1100OQ01Aristotle.lean companion file with 6 supporting lemmas for Aristotle"
+    ],
+    "insights": [
+      "g_exponential_growth theorem was unprovable as stated: claimed ∃ α ≥ √2 with α^k ≤ g(k), but Erdős-Simonovits only gives (√2 - ε)^k asymptotic lower bound",
+      "Fixed g_exponential_growth by reformulating: now correctly states ∃ β < 2 with asymptotic lower bound approaching √2 and eventual upper bound β^k",
+      "tau_perp_equality_infinitely_often: proof strategy via primes (τ⊥(p) = 1 = ω(p)) is clear but requires proving divisorList p = [1, p] which needs sorted finset manipulation",
+      "The 4 remaining sorries in provable file are: tau_perp_lower_bound, tau_perp_equality_infinitely_often, erdos_hall_max_lower_bound, erdos_simonovits_bounds"
+    ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "Aristotle: submit Erdos1100OQ01Aristotle.lean for automated proof of omega_prime, divisors_of_prime, etc.",
+      "After Aristotle integrates companion results, prove tau_perp_equality_infinitely_often using prime witnesses",
+      "tau_perp_lower_bound is combinatorially non-trivial: needs induction on factorization structure"
+    ]
   },
   "tags": [
     "seeker-selected"
@@ -50,7 +62,7 @@
     "mathlib": []
   },
   "started": "2026-03-30T17:32:58.850Z",
-  "lastUpdate": "2026-03-30T17:32:58.850Z",
+  "lastUpdate": "2026-03-30T18:50:00.000Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [
@@ -61,9 +73,20 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 7,
-      "sorryCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1100ProblemProvable.lean"
+    },
+    {
+      "path": "Proofs/Erdos1100OQ01Aristotle.lean",
+      "filename": "Erdos1100OQ01Aristotle.lean",
+      "lineCount": 65,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 6,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1100OQ01Aristotle.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Fix and prove `g_exponential_growth` theorem in `Erdos1100ProblemProvable.lean`, eliminating 2 sorries (6→4)
- Create `Erdos1100OQ01Aristotle.lean` companion file with 6 supporting lemmas for automated proof search
- Update problem knowledge with insights and next steps

## Progress
- **g_exponential_growth**: Original statement was unprovable from `erdos_simonovits_bounds` — it claimed `∃ α ≥ √2` with `α^k ≤ g(k)` for `k ≥ 10`, but only an asymptotic `(√2 - ε)^k` lower bound is available. Reformulated to correctly state the asymptotic lower and eventual upper bounds, with complete proof.
- **Aristotle companion**: 6 lemmas supporting the proof of `tau_perp_equality_infinitely_often` via prime witnesses (`ω(p) = 1`, `divisors_of_prime`, `gcd_one_left`, `exists_prime_gt`, etc.)

## Findings
- The Erdős-Simonovits lower bound `(√2 + o(1))^k` only yields `(√2 - ε)^k` for any ε > 0, not `(√2)^k` exactly
- Proving `tau_perp_equality_infinitely_often` requires sorted finset manipulation (divisorList characterization)
- 4 remaining sorries: `tau_perp_lower_bound`, `tau_perp_equality_infinitely_often`, `erdos_hall_max_lower_bound`, `erdos_simonovits_bounds`

## Status
**Outcome**: progress
**Sorry delta**: -2 (6→4 in main file)
**Next Steps**: Aristotle integration of companion lemmas, then prove `tau_perp_equality_infinitely_often`

Generated by researcher-8