### PR TITLE
Research: erdos-1012-oq-03 - prove list_path_to_hamiltonian (eliminate 1 sorry)

### DIFF
--- a/proofs/Proofs/Erdos1012OQ03.lean
+++ b/proofs/Proofs/Erdos1012OQ03.lean
@@ -46,8 +46,8 @@ Survey + proof infrastructure. Rédei proved modulo 2 infrastructure lemmas.
 - [x] List-based directed path definition
 - [x] Tournament insertion lemma (key step for Rédei)
 - [x] Rédei's theorem (proved modulo 2 infrastructure lemmas)
-- [ ] tournament_full_path_list (sorry — iterated insertion)
-- [ ] list_path_to_hamiltonian (sorry — list-to-equiv conversion)
+- [x] tournament_full_path_list (proved by induction)
+- [x] list_path_to_hamiltonian (proved via Equiv.ofBijective)
 - [ ] Ghouila-Houri proof
 - [ ] Moon-Moser proof
 - [ ] Directed threshold proof
@@ -243,13 +243,38 @@ lemma tournament_full_path_list (D : Digraph V) (hT : D.IsTournament)
       obtain ⟨k, hk_le, hp'⟩ := tournament_path_insert D hT l (by omega) hp u hu
       exact ⟨l.insertNth k u, by rw [List.length_insertNth (by omega)]; omega, hp'⟩
 
-/-- Convert a list-based Hamiltonian path to the equivalence-based definition. -/
+/-- Convert a list-based Hamiltonian path to the equivalence-based definition.
+    A nodup list of length (card V) gives a bijection Fin (card V) → V
+    via getElem, which yields the required equivalence. -/
 lemma list_path_to_hamiltonian (D : Digraph V) (l : List V)
     (hlen : l.length = Fintype.card V) (hp : IsDirectedPathList D l) :
     D.HasHamiltonianPath := by
-  -- A nodup list of length (Fintype.card V) bijects with Fin (card V),
-  -- giving the required equivalence. The arc condition transfers directly.
-  sorry
+  have hnd := hp.1
+  -- Every vertex appears in l (nodup list of full length covers V)
+  have hmem : ∀ v : V, v ∈ l := by
+    intro v; rw [← List.mem_toFinset]
+    have : l.toFinset = Finset.univ :=
+      Finset.eq_univ_of_card _ (by rw [l.toFinset_card_of_nodup hnd, hlen])
+    exact this ▸ Finset.mem_univ v
+  -- l defines a bijection Fin (card V) → V via index lookup
+  let f : Fin (Fintype.card V) → V := fun i => l[i.val]'(hlen ▸ i.isLt)
+  have hf_bij : Function.Bijective f := by
+    constructor
+    · -- Injective: distinct indices give distinct elements (nodup)
+      intro ⟨i, hi⟩ ⟨j, hj⟩ heq
+      simp only [f] at heq
+      have hi' : i < l.length := hlen ▸ hi
+      have hj' : j < l.length := hlen ▸ hj
+      ext
+      exact List.Nodup.getElem_inj_iff hnd |>.mp heq
+    · -- Surjective: every vertex is in l, so has a valid index
+      intro v
+      have hv := hmem v
+      rw [List.mem_iff_getElem] at hv
+      obtain ⟨i, hi, hvi⟩ := hv
+      exact ⟨⟨i, hlen ▸ hi⟩, hvi.symm⟩
+  -- Build the equivalence: σ.symm i = l[i]
+  exact ⟨(Equiv.ofBijective f hf_bij).symm, fun i hi => hp.2 i.val (hlen ▸ hi)⟩
 
 /-! ═══════════════════════════════════════════════════════════════════════════════
 PART III: GHOUILA-HOURI'S THEOREM

--- a/src/data/research/problems/erdos-1012-oq-03-incomplete-01.json
+++ b/src/data/research/problems/erdos-1012-oq-03-incomplete-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-1012-oq-03-incomplete-01",
   "title": "Complete directed Hamiltonian cycle thresholds proof",
-  "phase": "NEW",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -16,9 +16,9 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ACT",
     "since": "2026-03-30T16:34:54.972Z",
-    "iteration": 1,
+    "iteration": 2,
     "focus": "Initial exploration of the problem.",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
@@ -29,11 +29,23 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Proved list_path_to_hamiltonian (was sorry). Eliminated infrastructure sorry in R\u00e9dei theorem proof chain. 3S remain (all deep theorems).",
+    "builtItems": [
+      "Proved list_path_to_hamiltonian via Equiv.ofBijective in Erdos1012OQ03.lean:246-277",
+      "Key insight: nodup list of full length gives bijection, arc condition transfers directly"
+    ],
+    "insights": [
+      "list_path_to_hamiltonian: build equivalence from l.getElem, prove bijective via Nodup + full coverage",
+      "Injectivity: List.Nodup.getElem_inj_iff",
+      "Surjectivity: List.mem_iff_getElem + hmem (\u2200 v, v \u2208 l from Finset.eq_univ_of_card)",
+      "Arc condition: Equiv.ofBijective preserves function values, so \u03c3.symm i = l[i]"
+    ],
     "mathlibGaps": [],
-    "nextSteps": []
+    "nextSteps": [
+      "Remaining 3 sorries are deep theorems (ghouila_houri, moon_moser, directed_hamiltonian_threshold)",
+      "ghouila_houri proof outline: longest path \u2192 extend \u2192 close cycle (~200 lines)",
+      "moon_moser follows from R\u00e9dei + tournament rotation"
+    ]
   },
   "tags": [
     "seeker-selected",
@@ -54,5 +66,17 @@
   "started": "2026-03-30T16:34:54.972Z",
   "lastUpdate": "2026-03-30T16:34:54.972Z",
   "significance": 6,
-  "tractability": 6
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos1012OQ03.lean",
+      "filename": "Erdos1012OQ03.lean",
+      "lineCount": 364,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 8,
+      "sorryCount": 3,
+      "isAristotle": false
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Proved list_path_to_hamiltonian: converts list-based Hamiltonian path to Equiv-based definition
- Eliminated 1 infrastructure sorry in the Rédei theorem proof chain
- Sorries reduced: 4 → 3 (remaining are deep theorems: ghouila_houri, moon_moser, directed_hamiltonian_threshold)

## Approach
- Build bijection `Fin (card V) → V` via `l.getElem`
- Prove injective: `List.Nodup.getElem_inj_iff`
- Prove surjective: every vertex in l (from `Finset.eq_univ_of_card`)
- Arc condition transfers since `Equiv.ofBijective` preserves function values

## Status
**Outcome**: progress (1 sorry eliminated)
**Next Steps**: Deep theorems (ghouila_houri, moon_moser) require ~200-350 lines each

🤖 Generated by researcher-3