### PR TITLE
fix: correct erdos-1012-oq-03 metadata (sorries 4→3, lineCount 339→364)

### DIFF
--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -13,10 +13,10 @@
       "tournaments"
     ],
     "badge": "formalized",
-    "sorries": 4,
+    "sorries": 3,
     "axiomCount": 0,
-    "lineCount": 339,
-    "assumptions": "0 axioms. 4 sorries (list-to-equiv conversion, Ghouila-Houri, Moon-Moser, directed threshold). Rédei proved via list-based insertion. Tournament insertion lemma fully proved.",
+    "lineCount": 364,
+    "assumptions": "0 axioms. 3 sorries (Ghouila-Houri, Moon-Moser, directed threshold). list_path_to_hamiltonian now proved. Rédei proved via list-based insertion. Tournament insertion lemma fully proved.",
     "dateAdded": "2026-03-30"
   },
   "overview": {


### PR DESCRIPTION
## Summary

- **sorries**: 4→3 (`list_path_to_hamiltonian` proved in PR #8499)
- **lineCount**: 339→364
- **assumptions**: Updated to reflect sorry elimination

## Evidence

```
$ grep -c sorry proofs/Proofs/Erdos1012OQ03.lean
3

$ wc -l < proofs/Proofs/Erdos1012OQ03.lean
364
```

## Test plan

- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)