### PR TITLE
fix: replace vacuous True stub in erdos-100-oq-01 piepmeyer_upper

### DIFF
--- a/proofs/Proofs/Erdos100OQ01.lean
+++ b/proofs/Proofs/Erdos100OQ01.lean
@@ -118,9 +118,12 @@ For small n, exact values are known (OEIS A186704 for minimum diameter):
 - n = 7: minimum diameter = 6 (Harborth's configuration)
 -/
 
-/-- For n ≤ 9, Piepmeyer showed a configuration with diameter < 5.
-    This gives the upper bound f(9) ≤ 4 (i.e., 9 points fit in diameter 4). -/
-theorem piepmeyer_upper : ∃ n : ℕ, n = 9 ∧ (∃ d : ℕ, d ≤ 4 ∧ True) := ⟨9, rfl, 4, le_refl _, trivial⟩
+/-- For n ≤ 9, Piepmeyer showed a configuration of 9 non-collinear points
+    with all pairwise integer distances and diameter ≤ 4. -/
+theorem piepmeyer_upper : ∃ (S : Finset (ℝ × ℝ)), S.card = 9 ∧
+    (∀ p ∈ S, ∀ q ∈ S, p ≠ q → ∃ k : ℕ, 0 < k ∧ k ≤ 4 ∧
+      (p.1 - q.1)^2 + (p.2 - q.2)^2 = ↑(k^2)) := by
+  sorry -- Requires explicit witness: Piepmeyer's 9-point integer-distance configuration
 
 /-! ## Part IV: The Anning–Erdős Theorem
 

--- a/src/data/proofs/erdos-100-oq-01/meta.json
+++ b/src/data/proofs/erdos-100-oq-01/meta.json
@@ -16,10 +16,10 @@
       "guth-katz"
     ],
     "badge": "formalized",
-    "sorries": 1,
+    "sorries": 2,
     "axiomCount": 0,
-    "lineCount": 162,
-    "assumptions": "One sorry: Anning\u2013Erd\u0151s finiteness theorem (requires number theory + geometry argument).",
+    "lineCount": 165,
+    "assumptions": "Two sorries: (1) Piepmeyer's 9-point integer-distance configuration witness, (2) Anning\u2013Erd\u0151s finiteness theorem.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0"
   },


### PR DESCRIPTION
## Fix

Replace vacuous `∧ True` in `piepmeyer_upper` theorem with actual integer-distance geometric constraint and mark proof as `sorry`.

## Evidence

**Before**: `theorem piepmeyer_upper : ∃ n : ℕ, n = 9 ∧ (∃ d : ℕ, d ≤ 4 ∧ True) := ⟨9, rfl, 4, le_refl _, trivial⟩` — provable via `trivial`, no mathematical content.

**After**: Statement requires an actual `Finset (ℝ × ℝ)` of 9 points with pairwise integer distances ≤ 4. Proof is honestly marked `sorry`.

**Meta.json**: sorries 1→2, lineCount 162→165, assumptions updated.

Closes #8488

---
Automated fix by lean-mechanic agent.