### PR TITLE
fix: remove unused imports in basel-problem-oq-01-oq-01 + sync data

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -9445,11 +9445,12 @@
     },
     {
       "slug": "basel-problem-oq-01-incomplete-01",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T16:34:54.911Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T16:34:54.911Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.841Z",
+      "completed": "2026-03-30T19:13:14.840Z"
     },
     {
       "slug": "dirichlets-theorem-oq-03-incomplete-01",
@@ -9595,11 +9596,12 @@
     },
     {
       "slug": "erdos-1026-oq-03",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T16:34:54.975Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T16:34:54.975Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.906Z",
+      "completed": "2026-03-30T19:13:14.906Z"
     },
     {
       "slug": "erdos-1022-oq-03",
@@ -9627,11 +9629,12 @@
     },
     {
       "slug": "erdos-29-oq-02",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T17:47:50.026Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T17:47:50.026Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.897Z",
+      "completed": "2026-03-30T19:13:14.897Z"
     },
     {
       "slug": "erdos-445-oq-02",
@@ -9659,11 +9662,12 @@
     },
     {
       "slug": "erdos-69-oq-03",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T17:47:50.026Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T17:47:50.026Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.898Z",
+      "completed": "2026-03-30T19:13:14.898Z"
     },
     {
       "slug": "erdos-825-oq-03",
@@ -9675,11 +9679,12 @@
     },
     {
       "slug": "hilbert-21-oq-04",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T17:47:50.026Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T17:47:50.026Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.899Z",
+      "completed": "2026-03-30T19:13:14.899Z"
     },
     {
       "slug": "infinitude-primes-oq-04",
@@ -9732,11 +9737,12 @@
     },
     {
       "slug": "shannon-source-coding-oq-01",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T17:47:50.026Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T17:47:50.026Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.901Z",
+      "completed": "2026-03-30T19:13:14.901Z"
     },
     {
       "slug": "sum-of-kth-powers-oq-01",
@@ -9764,27 +9770,30 @@
     },
     {
       "slug": "arithmetic-series-oq-02-oq-02-oq-04",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T18:27:56.397Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T18:27:56.407Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.893Z",
+      "completed": "2026-03-30T19:13:14.893Z"
     },
     {
       "slug": "basel-problem-oq-01-oq-01",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T18:27:56.397Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T18:27:56.408Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.893Z",
+      "completed": "2026-03-30T19:13:14.893Z"
     },
     {
       "slug": "birthday-problem-oq-02-oq-03",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T18:27:56.397Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T18:27:56.408Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:56.355Z",
+      "completed": "2026-03-30T19:13:56.354Z"
     },
     {
       "slug": "bounded-prime-gaps-oq-04-oq-01-incomplete-01",
@@ -9804,19 +9813,21 @@
     },
     {
       "slug": "cantors-theorem-oq-02-oq-01",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T18:27:56.397Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T18:27:56.409Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:38.180Z",
+      "completed": "2026-03-30T19:13:38.179Z"
     },
     {
       "slug": "cayley-hamilton-reduction-oq-01-oq-01",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T18:27:56.397Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T18:27:56.409Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.894Z",
+      "completed": "2026-03-30T19:13:14.894Z"
     },
     {
       "slug": "cevas-theorem-oq-02-oq-04",
@@ -9836,19 +9847,21 @@
     },
     {
       "slug": "continuum-hypothesis-oq-01-oq-01",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T18:27:56.397Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T18:27:56.410Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.894Z",
+      "completed": "2026-03-30T19:13:14.894Z"
     },
     {
       "slug": "derangements-oq-03-oq-01",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T18:27:56.397Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T18:27:56.410Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.894Z",
+      "completed": "2026-03-30T19:13:14.894Z"
     },
     {
       "slug": "erdos-1-oq-02-incomplete-01",
@@ -9892,11 +9905,12 @@
     },
     {
       "slug": "erdos-106-incomplete-01",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T18:27:56.397Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T18:27:56.411Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.897Z",
+      "completed": "2026-03-30T19:13:14.897Z"
     },
     {
       "slug": "erdos-1066-oq-04-incomplete-01",
@@ -9916,11 +9930,12 @@
     },
     {
       "slug": "fundamental-theorem-algebra-oq-04-oq-01",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T18:27:56.397Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T18:27:56.412Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:38.181Z",
+      "completed": "2026-03-30T19:13:38.181Z"
     },
     {
       "slug": "basel-problem-oq-01-oq-02",
@@ -9932,11 +9947,12 @@
     },
     {
       "slug": "birthday-problem-oq-03-oq-03",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T18:39:05.245Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T18:39:05.258Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.902Z",
+      "completed": "2026-03-30T19:13:14.902Z"
     },
     {
       "slug": "cayley-hamilton-reduction-oq-01-oq-02",
@@ -9980,11 +9996,12 @@
     },
     {
       "slug": "descartes-rule-of-signs-oq-01-oq-02",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T18:39:05.245Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T18:39:05.259Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.903Z",
+      "completed": "2026-03-30T19:13:14.903Z"
     },
     {
       "slug": "dissection-of-cubes-oq-01-oq-01",
@@ -10012,19 +10029,21 @@
     },
     {
       "slug": "erdos-1006-oq-02-oq-01",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T18:39:05.245Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T18:39:05.260Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.904Z",
+      "completed": "2026-03-30T19:13:14.904Z"
     },
     {
       "slug": "erdos-1039-oq-02",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T18:39:05.245Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T18:39:05.260Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.904Z",
+      "completed": "2026-03-30T19:13:14.904Z"
     },
     {
       "slug": "erdos-106-oq-02-incomplete-01",
@@ -10036,11 +10055,12 @@
     },
     {
       "slug": "erdos-1087-incomplete-01",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T18:39:05.245Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T18:39:05.261Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.904Z",
+      "completed": "2026-03-30T19:13:14.904Z"
     },
     {
       "slug": "erdos-109-oq-01",
@@ -10068,11 +10088,12 @@
     },
     {
       "slug": "erdos-268-oq-01",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T18:39:05.245Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T18:39:05.262Z"
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.904Z",
+      "completed": "2026-03-30T19:13:14.904Z"
     },
     {
       "slug": "euler-polyhedral-formula-oq-02-oq-02",

--- a/src/data/proofs/basel-problem-oq-01-oq-01/index.ts
+++ b/src/data/proofs/basel-problem-oq-01-oq-01/index.ts
@@ -1,4 +1,4 @@
-import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import type { Proof, Annotation, ProofData } from '@/types/proof'
 import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 const meta = metaJson as any


### PR DESCRIPTION
## Summary
- Fix TS6196 build error from unused type imports in `basel-problem-oq-01-oq-01/index.ts`
- Sync registry.json with latest research state

## Test plan
- [x] `pnpm build` passes
- [x] Deployed to Cloudflare

🤖 Generated with [Claude Code](https://claude.com/claude-code)