### PR TITLE
fix: correct amgm-oq03-oq03 metadata (axiomCount 3→0, badge axiom→formalized)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-03/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Hardy-Littlewood-Pólya (1934)",
     "date": "1934",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/AmgmInequalityOQ03OQ03.lean",
     "tags": [
       "inequalities",
@@ -14,14 +14,14 @@
       "analysis",
       "limits"
     ],
-    "badge": "axiom",
+    "badge": "formalized",
     "sorries": 2,
     "dateAdded": "2026-03-30",
-    "axiomCount": 3,
+    "axiomCount": 0,
     "lineCount": 57
   },
   "sections": [],
   "leanFile": {
-    "axiomCount": 3
+    "axiomCount": 0
   }
 }


### PR DESCRIPTION
## Summary

- **axiomCount**: 3→0 (no `axiom` declarations in file; the 3 were docstring sketches)
- **status**: `axiomatized`→`formalized` (has 2 sorries, no axioms)
- **badge**: `axiom`→`formalized`
- Both `meta.axiomCount` and `leanFile.axiomCount` corrected

## Evidence

```
$ grep -c '^axiom ' proofs/Proofs/AmgmInequalityOQ03OQ03.lean
0

$ grep -c sorry proofs/Proofs/AmgmInequalityOQ03OQ03.lean
2
```

## Test plan

- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)