### PR TITLE
Research: 4 problems - metadata, weird numbers, Sidon, coprime divisors

### DIFF
--- a/proofs/Proofs/Erdos156Problem.lean
+++ b/proofs/Proofs/Erdos156Problem.lean
@@ -402,6 +402,63 @@ theorem sidon_sumset_size (A : Set ℕ) (hA : IsSidonSet A) (hfin : A.Finite) :
   rw [h_eq]
   exact card_upper_tri hfin.toFinset
 
+/-- **Converse**: If |A + A| = |A|*(|A|+1)/2, then A is a Sidon set.
+
+    Proof by contrapositive: if A is not Sidon, then the sum map on ordered pairs
+    is not injective (two distinct pairs collide), so |A+A| < |ordered pairs| = n(n+1)/2. -/
+theorem sidon_of_sumset_size (A : Set ℕ) (hfin : A.Finite)
+    (h : (sumset A).ncard = A.ncard * (A.ncard + 1) / 2) : IsSidonSet A := by
+  set S := {p : ℕ × ℕ | p.1 ∈ A ∧ p.2 ∈ A ∧ p.1 ≤ p.2}
+  set f := (fun p : ℕ × ℕ => p.1 + p.2)
+  have hS_fin : S.Finite := (hfin.prod hfin).subset fun p hp => ⟨hp.1, hp.2.1⟩
+  -- |S| = n(n+1)/2
+  have h_S : S.ncard = A.ncard * (A.ncard + 1) / 2 := by
+    rw [hS_fin.ncard_eq_toFinset_card', hfin.ncard_eq_toFinset_card']
+    convert card_upper_tri hfin.toFinset using 1
+    congr 1; ext ⟨a, b⟩
+    simp only [Set.Finite.mem_toFinset, Set.mem_setOf_eq,
+               Finset.mem_filter, Finset.mem_product]
+  -- sumset A = f '' S
+  have h_im : sumset A = f '' S := sumset_eq_image A
+  -- |f '' S| = |S| (from hypothesis and h_S)
+  have h_card_eq : (f '' S).ncard = S.ncard := by linarith [h_im ▸ h, h_S]
+  -- Prove injectivity: if ¬InjOn, we derive a contradiction
+  have h_inj : Set.InjOn f S := by
+    by_contra h_not_inj
+    -- ¬InjOn: there exist distinct p, q ∈ S with f(p) = f(q)
+    unfold Set.InjOn at h_not_inj
+    push_neg at h_not_inj
+    obtain ⟨p, hp, q, hq, hfpq, hne⟩ := h_not_inj
+    -- f '' S = f '' (S \ {q}) since f(q) = f(p) and p ∈ S \ {q}
+    have hp_diff : p ∈ S \ {q} := Set.mem_diff_singleton.mpr ⟨hp, Ne.symm hne⟩
+    have h_im_eq : f '' S = f '' (S \ {q}) := by
+      apply Set.Subset.antisymm
+      · intro z ⟨w, hw, rfl⟩
+        by_cases hwq : w = q
+        · exact ⟨p, hp_diff, by rw [hwq, hfpq]⟩
+        · exact ⟨w, Set.mem_diff_singleton.mpr ⟨hw, hwq⟩, rfl⟩
+      · exact Set.image_subset f Set.diff_subset
+    -- |S \ {q}| < |S| since q ∈ S and S is finite
+    have hS_fin_diff := hS_fin.diff ({q} : Set _)
+    have h_lt : (S \ {q}).ncard < S.ncard := by
+      apply Set.ncard_lt_ncard _ hS_fin
+      exact ⟨Set.diff_subset, fun h_sub =>
+        (Set.mem_diff_singleton.mp (h_sub hq)).2 rfl⟩
+    -- |f '' S| = |f '' (S \ {q})| ≤ |S \ {q}| < |S|
+    have h_im_le : (f '' S).ncard ≤ (S \ {q}).ncard := by
+      rw [h_im_eq]; exact Set.ncard_image_le hS_fin_diff
+    linarith
+  -- InjOn f S → IsSidonSet A
+  intro a b c d ha hb hc hd hab hcd heq
+  have := h_inj (show (a, b) ∈ S from ⟨ha, hb, hab⟩)
+                (show (c, d) ∈ S from ⟨hc, hd, hcd⟩) heq
+  simp only [Prod.mk.injEq] at this; obtain ⟨rfl, rfl⟩ := this; rfl
+
+/-- **Complete characterization**: A finite set is Sidon iff |A+A| = |A|*(|A|+1)/2. -/
+theorem sidon_iff_sumset_size (A : Set ℕ) (hfin : A.Finite) :
+    IsSidonSet A ↔ (sumset A).ncard = A.ncard * (A.ncard + 1) / 2 :=
+  ⟨fun hA => (sidon_sumset_size A hA hfin).2, sidon_of_sumset_size A hfin⟩
+
 /-- B₂ sets are precisely Sidon sets -/
 def IsB2Set (A : Set ℕ) : Prop := IsSidonSet A
 

--- a/proofs/Proofs/Erdos470Problem.lean
+++ b/proofs/Proofs/Erdos470Problem.lean
@@ -392,6 +392,68 @@ The abundancy index of n.
 noncomputable def abundancyIndex (n : ℕ) : ℚ := sigma n / n
 
 /-
+## Verified Weird Number Sequence (OEIS A006037)
+
+Computationally verify the first several weird numbers.
+All are even, consistent with the open question about odd weird numbers.
+-/
+
+/--
+836 is the second weird number.
+-/
+theorem weird_836 : IsWeird 836 := by
+  constructor
+  · unfold IsAbundant sigma; native_decide
+  · intro ⟨S, hS_sub, hS_sum⟩
+    have : ∀ T ∈ (836 : ℕ).properDivisors.powerset, T.sum id ≠ 836 := by native_decide
+    exact this S (Finset.mem_powerset.mpr hS_sub) hS_sum
+
+/--
+1575 = 3² × 5² × 7 is the second smallest odd abundant number, and is semiperfect.
+-/
+theorem nine45_1575_semiperfect : IsPseudoperfect 1575 := by
+  have : ∃ S ∈ (1575 : ℕ).properDivisors.powerset, S.sum id = 1575 := by native_decide
+  exact let ⟨S, hmem, hsum⟩ := this; ⟨S, Finset.mem_powerset.mp hmem, hsum⟩
+
+/--
+No odd number in [945, 1575] is abundant except 945 and 1575.
+(Abundancy-only check — fast for native_decide.)
+-/
+theorem no_odd_abundant_945_to_1575 (n : ℕ) (h1 : 945 < n) (h2 : n < 1575)
+    (hodd : Odd n) : ¬IsAbundant n := by
+  have h : ∀ m ∈ Finset.Ico 946 1575, Odd m → ¬IsAbundant m := by native_decide
+  exact h n (Finset.mem_Ico.mpr ⟨by omega, h2⟩) hodd
+
+/--
+No odd number ≤ 1575 is weird. Proof by cases:
+- Below 945: not abundant
+- 945: semiperfect
+- (945, 1575): not abundant
+- 1575: semiperfect
+-/
+theorem no_odd_weird_to_1575 (n : ℕ) (hn : n ≤ 1575) (hodd : Odd n) :
+    ¬IsWeird n := by
+  intro ⟨hab, hnp⟩
+  by_cases h945 : n < 945
+  · exact absurd hab (no_odd_abundant_below_945 n h945 hodd)
+  · push_neg at h945
+    by_cases h945eq : n = 945
+    · exact hnp (h945eq ▸ nine45_semiperfect)
+    · by_cases h1575 : n < 1575
+      · exact absurd hab (no_odd_abundant_945_to_1575 n (by omega) h1575 hodd)
+      · -- n = 1575
+        have : n = 1575 := by omega
+        exact hnp (this ▸ nine45_1575_semiperfect)
+
+/--
+Any odd weird number must exceed 1575. Improvement over the 945 bound.
+-/
+theorem odd_weird_gt_1575 (n : ℕ) (hw : IsWeird n) (hodd : Odd n) : 1575 < n := by
+  by_contra h
+  push_neg at h
+  exact absurd hw (no_odd_weird_to_1575 n h hodd)
+
+/-
 ## Summary
 
 **Erdős Problem #470**: Both questions remain OPEN.

--- a/src/data/proofs/triangular-reciprocals-oq-03-oq-02/meta.json
+++ b/src/data/proofs/triangular-reciprocals-oq-03-oq-02/meta.json
@@ -105,8 +105,7 @@
         "summary": "Derives a closed-form formula for ∑(-1)^{n+1}/(n(n+k)) for arbitrary k, revealing a beautiful even-odd dichotomy where even k gives rational answers and odd k involves log(2).",
         "implications": "Demonstrates that partial fraction decomposition combined with the alternating harmonic series yields closed forms for a wide family of alternating reciprocal product sums.",
         "openQuestions": [
-            "Can the HasSum proofs (3 sorries) be completed using Mathlib's HasSum.nat_add?",
-            "Generalize further to ∑(-1)^{n+1}/(n+a)(n+b) for arbitrary a, b?",
+            "Generalize further to ∑(-1)^{n+1}/((n+a)(n+b)) for arbitrary a, b?",
             "What is the asymptotics of A_k/k as k → ∞?"
         ]
     },
@@ -121,7 +120,7 @@
     ],
     "leanFile": {
         "imports": [
-            "Mathlib"
+            "Proofs.TriangularReciprocalAlternatingOQ03"
         ],
         "opens": [
             "Finset",

--- a/src/data/research/problems/triangular-reciprocals-oq-03-oq-02.json
+++ b/src/data/research/problems/triangular-reciprocals-oq-03-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "triangular-reciprocals-oq-03-oq-02",
-  "title": "Generalize to ∑(-1)^{n+1}/(n(n+k)) for arbitrary k",
+  "title": "Generalize to \u2211(-1)^{n+1}/(n(n+k)) for arbitrary k",
   "phase": "OBSERVE",
-  "status": "active",
+  "status": "completed",
   "tier": "C",
   "path": "fast",
   "problemStatement": {
@@ -16,7 +16,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "COMPLETED",
     "since": "2026-03-28T20:58:08-07:00",
     "iteration": 1,
     "focus": "Initial problem understanding. Read problem.md and gather context.",
@@ -29,22 +29,27 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Eliminated duplicate axiom via import fix (1→0 axioms in Generalized). 3 sorries remain.",
+    "progressSummary": "COMPLETED: All 3 sorries proved. generalized_alternating_sum fully verified (0 sorries, 0 own axioms). Closed form proved for all k>=1.",
     "builtItems": [
       "Created TriangularReciprocalGeneralized.lean with generalized formula",
       "Proved partial_fraction: 1/(n(n+k)) = (1/k)(1/n - 1/(n+k))",
       "Defined altHarmonicPartial A_k with A_0=0, A_1=1 proved",
-      "Verified special_case_k1 = 2·log 2 - 1 and special_case_k2 = 1/4",
+      "Verified special_case_k1 = 2\u00b7log 2 - 1 and special_case_k2 = 1/4",
       "Stated generalized_alternating_sum with tsum version",
-      "Eliminated duplicate axiom by importing TriangularReciprocalAlternatingOQ03.lean (1→0 axioms)"
+      "Eliminated duplicate axiom by importing TriangularReciprocalAlternatingOQ03.lean (1\u21920 axioms)",
+      "Proved alternating_harmonic_tail via hasSum_nat_add_iff",
+      "Proved shifted_alternating_hasSum via factoring (-1)^k and shift removal",
+      "Proved generalized_alternating_sum from partial fractions + HasSum results"
     ],
     "insights": [
-      "Closed form: ∑(-1)^{n+1}/(n(n+k)) = (1/k)(log 2 - (-1)^k(log 2 - A_k)) where A_k = ∑_{m=1}^k (-1)^{m+1}/m",
+      "Closed form: \u2211(-1)^{n+1}/(n(n+k)) = (1/k)(log 2 - (-1)^k(log 2 - A_k)) where A_k = \u2211_{m=1}^k (-1)^{m+1}/m",
       "Even-odd dichotomy: even k gives rational answer A_k/k, odd k involves log(2)",
-      "k=1 recovers 2·log 2 - 1 (parent result), k=2 gives 1/4 (rational!)",
+      "k=1 recovers 2\u00b7log 2 - 1 (parent result), k=2 gives 1/4 (rational!)",
       "Partial fraction 1/(n(n+k)) = (1/k)(1/n - 1/(n+k)) is the key decomposition",
       "3 sorries need HasSum tail decomposition (Mathlib HasSum.nat_add or equivalent)",
-      "TriangularReciprocalGeneralized.lean duplicated alternating_harmonic_hasSum axiom from OQ03"
+      "TriangularReciprocalGeneralized.lean duplicated alternating_harmonic_hasSum axiom from OQ03",
+      "All HasSum tail decomposition sorries proved using hasSum_nat_add_iff + congr technique",
+      "File depends on 1 axiom from parent (alternating_harmonic_hasSum) but declares 0 own axioms"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session covering four problems:

### 1. triangular-reciprocals-oq-03-oq-02 (metadata fix)
- Remove stale open question, fix imports

### 2. erdos-825-oq-03 (odd weird numbers)
- Prove 836 is weird, 1575 is semiperfect
- Extend odd weird lower bound: > 945 to > 1575

### 3. erdos-156-oq-01 (Sidon set characterization)
- Prove converse: |A+A| = n(n+1)/2 implies Sidon
- Complete iff characterization

### 4. erdos-1100-oq-01 (coprime consecutive divisors)
- Prove 5/6 Aristotle companion lemmas from Mathlib
- omega_prime, divisors_of_prime, tau_prime, gcd_one_left, exists_prime_gt

## Test plan
- [ ] Docker build of all modified Lean files
- [ ] Verify native_decide proofs compile

Generated by researcher-10