### PR TITLE
fix: correct yang-mills metadata (sorries 15→1, lineCount 48→28624)

### DIFF
--- a/src/data/proofs/yang-mills/meta.json
+++ b/src/data/proofs/yang-mills/meta.json
@@ -22,7 +22,7 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 15,
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Lie.Basic",
@@ -58,8 +58,8 @@
     "dateAdded": "2025-12-29",
     "millenniumProblem": "yang-mills",
     "axiomCount": 16,
-    "assumptions": "16 total assumptions: 1 explicit axiom (gaugeTransform) + 15 structure-encoded: CompactSimpleGaugeGroup (compact, connected, simple — 3), GaugeLieAlgebra (bracket_anticomm, bracket_jacobi — 2), FieldStrength (antisymmetric — 1), YangMillsAction (coupling_pos, action_nonneg — 2), WightmanQFT (vacuum_normalized, energy_bounded_below, vacuum_lowest_energy — 3), QuantumYangMillsTheory (nontrivial — 1), Instanton (action_formula — 1), EnergyMomentumTensor (symmetric, energy_density_nonneg — 2). The Yang-Mills 4D mass gap conjecture remains OPEN.",
-    "lineCount": 48,
+    "assumptions": "16 total assumptions: 1 explicit axiom (gaugeTransform) + 15 structure-encoded: CompactSimpleGaugeGroup (compact, connected, simple — 3), GaugeLieAlgebra (bracket_anticomm, bracket_jacobi — 2), FieldStrength (antisymmetric — 1), YangMillsAction (coupling_pos, action_nonneg — 2), WightmanQFT (vacuum_normalized, energy_bounded_below, vacuum_lowest_energy — 3), QuantumYangMillsTheory (nontrivial — 1), Instanton (action_formula — 1), EnergyMomentumTensor (symmetric, energy_density_nonneg — 2). 1 sorry (coupling_controlled in Exploration.lean, Mathlib drift). The Yang-Mills 4D mass gap conjecture remains OPEN.",
+    "lineCount": 28624,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -312,7 +312,7 @@
       "Matrix"
     ],
     "namespace": "YangMillsMassGap",
-    "lineCount": 48,
+    "lineCount": 28624,
     "axiomCount": 16,
     "theoremCount": 1805,
     "definitionCount": 260


### PR DESCRIPTION
## Summary

- **sorries**: 15 → 1 (14 sorries were eliminated without meta.json update)
- **lineCount**: 48 → 28,624 (was only counting wrapper file, not 4 submodule files)
- **leanFile.lineCount**: 48 → 28,624
- **assumptions**: Added mention of the 1 remaining sorry (coupling_controlled, Mathlib drift)

The sole remaining sorry is `coupling_controlled` at Exploration.lean:22793, marked as MATHLIB-DRIFT.

axiomCount (16), status (axiomatized), and badge (axiom) are all correct.

## Test plan

- [ ] `pnpm build` passes with updated metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)