### PR TITLE
fix: correct yang-mills-transfer-matrix and yang-mills-lattice sorry counts (15→1)

### DIFF
--- a/src/data/proofs/yang-mills-lattice/meta.json
+++ b/src/data/proofs/yang-mills-lattice/meta.json
@@ -16,7 +16,7 @@
       "strong-coupling"
     ],
     "badge": "axiom",
-    "sorries": 15,
+    "sorries": 1,
     "axiomCount": 1,
     "assumptions": "1 explicit axiom (gaugeTransform from YangMills/Classical.lean) plus structure-encoded assumptions: WilsonLatticeAction requires coupling beta > 0 and character function. LinkVariable, LatticeGaugeTransform, and Plaquette encode lattice geometry. Wilson loop structures assume gauge-invariant trace. All lattice proofs (gauge invariance, bounds) are fully verified given these structures.",
     "lineCount": 28043,

--- a/src/data/proofs/yang-mills-transfer-matrix/meta.json
+++ b/src/data/proofs/yang-mills-transfer-matrix/meta.json
@@ -17,7 +17,7 @@
       "millennium-prize"
     ],
     "badge": "axiom",
-    "sorries": 15,
+    "sorries": 1,
     "axiomCount": 1,
     "assumptions": "1 explicit axiom (gaugeTransform from YangMills/Classical.lean) plus structure-encoded assumptions: TransferMatrix requires lambda_0 > lambda_1 > 0 (Perron-Frobenius eigenvalue ordering), and LatticeTransferMatrix requires positivity and strict gap. These encode the physical assumption that the transfer matrix has a spectral gap, which is proven for finite-volume lattice gauge theory.",
     "lineCount": 28043,


### PR DESCRIPTION
## Summary

- **yang-mills-transfer-matrix**: sorries 15 → 1
- **yang-mills-lattice**: sorries 15 → 1

Both reference `Proofs/YangMills/Exploration.lean` which has only 1 sorry (`coupling_controlled` at line 22793, annotated as MATHLIB-DRIFT).

The sorry is not within the line ranges of either submodule's sections, but the meta.json sorry count reflects the file-level total.

## Test plan

- [ ] `pnpm build` passes with updated metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)