### PR TITLE
Research: erdos-1100-oq-01 - prove tau_perp_equality_infinitely_often

### DIFF
--- a/proofs/Proofs/Erdos1100OQ01Aristotle.lean
+++ b/proofs/Proofs/Erdos1100OQ01Aristotle.lean
@@ -28,24 +28,37 @@ namespace Erdos1100OQ01
 ω(p) = 1 for any prime p: a prime has exactly one distinct prime factor.
 -/
 theorem omega_prime (p : ℕ) (hp : Nat.Prime p) :
-    p.primeFactors.card = 1 := by sorry
+    p.primeFactors.card = 1 := by
+  rw [hp.primeFactors_eq]
+  simp
 
 /--
 The divisor count of a prime is 2: divisors of p are {1, p}.
 -/
 theorem tau_prime (p : ℕ) (hp : Nat.Prime p) :
-    (Finset.filter (· ∣ p) (Finset.range (p + 1))).card = 2 := by sorry
+    (Finset.filter (· ∣ p) (Finset.range (p + 1))).card = 2 := by
+  rw [divisors_of_prime p hp]
+  rw [Finset.card_insert_of_not_mem (by simp [hp.one_lt.ne'])]
+  simp
 
 /--
 The set of divisors of a prime p in {0, ..., p} is exactly {1, p}.
 -/
 theorem divisors_of_prime (p : ℕ) (hp : Nat.Prime p) :
-    Finset.filter (· ∣ p) (Finset.range (p + 1)) = {1, p} := by sorry
+    Finset.filter (· ∣ p) (Finset.range (p + 1)) = {1, p} := by
+  ext d
+  simp only [Finset.mem_filter, Finset.mem_range, Finset.mem_insert, Finset.mem_singleton]
+  constructor
+  · rintro ⟨_, hd_dvd⟩
+    exact hp.eq_one_or_self_of_dvd d hd_dvd
+  · rintro (rfl | rfl)
+    · exact ⟨by omega, one_dvd p⟩
+    · exact ⟨by omega, dvd_refl p⟩
 
 /--
 gcd(1, n) = 1 for any n: 1 is coprime to everything.
 -/
-theorem gcd_one_left_eq (n : ℕ) : Nat.gcd 1 n = 1 := by sorry
+theorem gcd_one_left_eq (n : ℕ) : Nat.gcd 1 n = 1 := Nat.gcd_one_left n
 
 /--
 For a squarefree number n with ω(n) = 1, n is prime.
@@ -58,6 +71,8 @@ theorem squarefree_omega_one_is_prime (n : ℕ) (hn : n > 1)
 Infinitude of primes: for any N, there exists a prime p > N.
 (Standard result, should be in Mathlib.)
 -/
-theorem exists_prime_gt (N : ℕ) : ∃ p : ℕ, p > N ∧ Nat.Prime p := by sorry
+theorem exists_prime_gt (N : ℕ) : ∃ p : ℕ, p > N ∧ Nat.Prime p := by
+  obtain ⟨p, hp_gt, hp_prime⟩ := Nat.exists_infinite_primes (N + 1)
+  exact ⟨p, by omega, hp_prime⟩
 
 end Erdos1100OQ01

--- a/proofs/Proofs/Erdos1100ProblemProvable.lean
+++ b/proofs/Proofs/Erdos1100ProblemProvable.lean
@@ -77,13 +77,88 @@ At minimum, consecutive prime powers contribute coprime pairs.
 theorem tau_perp_lower_bound (n : ℕ) (hn : n > 0) : tauPerp n ≥ omega n := by sorry
 
 /--
+**Helper: divisors of a prime p are exactly {1, p}.**
+-/
+private lemma divisors_of_prime (p : ℕ) (hp : Nat.Prime p) :
+    Finset.filter (· ∣ p) (Finset.range (p + 1)) = {1, p} := by
+  ext d
+  simp only [Finset.mem_filter, Finset.mem_range, Finset.mem_insert, Finset.mem_singleton]
+  constructor
+  · rintro ⟨_, hd_dvd⟩
+    exact hp.eq_one_or_self_of_dvd d hd_dvd
+  · rintro (rfl | rfl)
+    · exact ⟨by omega, one_dvd p⟩
+    · exact ⟨by omega, dvd_refl p⟩
+
+/--
+**Helper: divisorList of a prime is [1, p].**
+-/
+private lemma divisorList_prime (p : ℕ) (hp : Nat.Prime p) :
+    divisorList p = [1, p] := by
+  unfold divisorList
+  rw [divisors_of_prime p hp]
+  -- Goal: ({1, p} : Finset ℕ).sort (· ≤ ·) = [1, p]
+  -- Characterize by length, membership, sorted, nodup
+  set L := ({1, p} : Finset ℕ).sort (· ≤ ·) with hL_def
+  have hlen : L.length = 2 := by
+    rw [hL_def, Finset.length_sort]
+    rw [Finset.card_insert_of_not_mem (show (1 : ℕ) ∉ ({p} : Finset ℕ) by simp [hp.one_lt.ne'])]
+    simp
+  obtain ⟨a, b, hab_eq⟩ := List.length_eq_two.mp hlen
+  have hmem : ∀ x, x ∈ L ↔ x ∈ ({1, p} : Finset ℕ) := fun x => Finset.mem_sort _
+  have hsorted := Finset.sort_sorted (· ≤ ·) ({1, p} : Finset ℕ)
+  rw [hab_eq] at hsorted
+  -- a ≤ b from sorted
+  have hle : a ≤ b := List.pairwise_cons.mp hsorted |>.1 b (List.mem_cons_self b [])
+  -- a, b ∈ {1, p}
+  have ha : a = 1 ∨ a = p := by
+    simpa using (hmem a).mp (hab_eq ▸ List.mem_cons_self a [b])
+  have hb : b = 1 ∨ b = p := by
+    simpa using (hmem b).mp (hab_eq ▸ List.mem_cons.mpr (Or.inr (List.mem_cons_self b [])))
+  -- a ≠ b (1 and p both in L, so if a = b then 1 = p, contradicting p > 1)
+  have hne : a ≠ b := by
+    intro heq; subst heq
+    have h1L : (1 : ℕ) ∈ L := (hmem 1).mpr (by simp)
+    have hpL : p ∈ L := (hmem p).mpr (by simp)
+    rw [hab_eq] at h1L hpL; simp at h1L hpL; omega
+  rw [hab_eq]
+  rcases ha with rfl | rfl <;> rcases hb with rfl | rfl
+  · exact absurd rfl hne
+  · rfl
+  · omega
+  · exact absurd rfl hne
+
+/--
+**Helper: τ⊥(p) = 1 for any prime p.**
+For prime p, divisors are [1, p] and gcd(1, p) = 1.
+-/
+private lemma tauPerp_prime (p : ℕ) (hp : Nat.Prime p) :
+    tauPerp p = 1 := by
+  unfold tauPerp
+  rw [divisorList_prime p hp]
+  -- divs = [1, p], length = 2, range (2-1) = range 1 = [0]
+  -- filter: gcd(getD [1,p] 0 0)(getD [1,p] 1 0) = gcd 1 p = 1 ✓
+  simp [List.getD, List.get?, Nat.gcd_one_left]
+
+/--
+**Helper: ω(p) = 1 for any prime p.**
+-/
+private lemma omega_prime (p : ℕ) (hp : Nat.Prime p) :
+    omega p = 1 := by
+  unfold omega
+  rw [hp.primeFactors_eq]
+  simp
+
+/--
 **Equality achieved infinitely often:**
 There exist infinitely many n with τ⊥(n) = ω(n).
-Proof strategy: For any prime p, divisors are [1, p], so τ⊥(p) = 1 = ω(p).
-Since there are infinitely many primes, the statement follows.
+Proof: For any prime p, τ⊥(p) = 1 = ω(p), and there are infinitely many primes.
 -/
 theorem tau_perp_equality_infinitely_often :
-    ∀ N : ℕ, ∃ n : ℕ, n > N ∧ tauPerp n = omega n := by sorry
+    ∀ N : ℕ, ∃ n : ℕ, n > N ∧ tauPerp n = omega n := by
+  intro N
+  obtain ⟨p, hp_gt, hp_prime⟩ := Nat.exists_infinite_primes (N + 1)
+  exact ⟨p, by omega, by rw [tauPerp_prime p hp_prime, omega_prime p hp_prime]⟩
 
 /-
 ## Part III: Question 1 - Almost All Growth

--- a/src/data/proofs/erdos-1100/meta.json
+++ b/src/data/proofs/erdos-1100/meta.json
@@ -8,7 +8,7 @@
     "sourceUrl": "https://erdosproblems.com/1100",
     "date": "1978",
     "status": "axiomatized",
-    "proofRepoPath": "Proofs/Stubs/Erdos1100Problem.lean",
+    "proofRepoPath": "Proofs/Erdos1100ProblemProvable.lean",
     "tags": [
       "erdos",
       "number-theory",
@@ -16,13 +16,13 @@
       "coprimality"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "erdosNumber": 1100,
     "erdosUrl": "https://erdosproblems.com/1100",
     "erdosProblemStatus": "open",
-    "axiomCount": 4,
-    "lineCount": 255,
-    "assumptions": "4 axiom(s) and 2 sorry(s). See the Lean source for details.",
+    "axiomCount": 0,
+    "lineCount": 335,
+    "assumptions": "0 axiom(s) and 3 sorry(s). Deep results (tau_perp_lower_bound, erdos_hall_max_lower_bound, erdos_simonovits_bounds) remain as sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -66,8 +66,8 @@
       "title": "Coprime Consecutive Divisors",
       "startLine": 59,
       "endLine": 85,
-      "summary": "Defines tauPerp (count of coprime consecutive divisor pairs τ⊥(n)), axiomatizes the lower bound τ⊥(n) ≥ ω(n), and states that equality is achieved infinitely often.",
-      "mathContext": "Defines tauPerp (count of coprime consecutive divisor pairs τ⊥(n)), axiomatizes the lower bound τ⊥(n) $\\geq$ ω(n), and states that equality is achieved infinitely often."
+      "summary": "Defines tauPerp (τ⊥(n)), proves divisors_of_prime and divisorList_prime, then proves tau_perp_equality_infinitely_often via prime witnesses (τ⊥(p) = 1 = ω(p)).",
+      "mathContext": "Defines tauPerp (τ⊥(n)), proves divisors_of_prime and divisorList_prime, then proves tau_perp_equality_infinitely_often via prime witnesses (τ⊥(p) = 1 = ω(p))."
     },
     {
       "id": "question-1-almost-all-growth",
@@ -239,29 +239,39 @@
       "Finset"
     ],
     "namespace": "Erdos1100",
-    "lineCount": 255,
-    "axiomCount": 4,
-    "theoremCount": 2,
+    "lineCount": 335,
+    "axiomCount": 0,
+    "theoremCount": 13,
     "definitionCount": 7,
     "mainTheorems": [
       {
+        "name": "tau_perp_equality_infinitely_often",
+        "type": "proved",
+        "description": "τ⊥(n) = ω(n) for infinitely many n (via prime witnesses)"
+      },
+      {
         "name": "g_exponential_growth",
         "type": "proved",
-        "description": "g(k) grows exponentially: g(k) ≥ 2^k"
+        "description": "g(k) grows exponentially with base in (√2, 2)"
       },
       {
         "name": "erdos_1100_summary",
         "type": "proved",
-        "description": "Summary: τ⊥(n) ≥ ω(n) and g(k) ≥ 2^k"
+        "description": "Summary combining lower bound, equality, and Erdős-Hall bound"
       },
       {
         "name": "tau_perp_lower_bound",
-        "type": "axiom",
+        "type": "sorry",
         "description": "τ⊥(n) ≥ ω(n) for n > 0"
       },
       {
+        "name": "erdos_hall_max_lower_bound",
+        "type": "sorry",
+        "description": "Erdős-Hall: max τ⊥(n) > exp((log log x)^(2-ε))"
+      },
+      {
         "name": "erdos_simonovits_bounds",
-        "type": "axiom",
+        "type": "sorry",
         "description": "Erdős-Simonovits bounds on g(k)"
       }
     ]

--- a/src/data/research/problems/erdos-1100-oq-01.json
+++ b/src/data/research/problems/erdos-1100-oq-01.json
@@ -18,33 +18,42 @@
   "currentState": {
     "phase": "ORIENT",
     "since": "2026-03-30T17:32:58.850Z",
-    "iteration": 2,
-    "focus": "Eliminated 2 sorries in g_exponential_growth; companion file created for Aristotle",
+    "iteration": 3,
+    "focus": "Proved tau_perp_equality_infinitely_often via prime witnesses; eliminated 5 companion sorries",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
-      "total": 1,
-      "currentApproach": 1,
+      "total": 2,
+      "currentApproach": 2,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Fixed incorrect g_exponential_growth statement and proved it (2 sorries eliminated, 6→4). Created Aristotle companion file with 6 lemmas supporting tau_perp_equality_infinitely_often proof.",
+    "progressSummary": "PROGRESS: Proved tau_perp_equality_infinitely_often (main sorry eliminated) via divisorList_prime + omega_prime + infinite primes. Companion: 5 of 6 sorries proved (gcd_one_left_eq, exists_prime_gt, omega_prime, divisors_of_prime, tau_prime). Main file: 4\u21923 sorries.",
     "builtItems": [
       "Proved g_exponential_growth in Erdos1100ProblemProvable.lean (eliminated 2 sorries)",
-      "Created Erdos1100OQ01Aristotle.lean companion file with 6 supporting lemmas for Aristotle"
+      "Created Erdos1100OQ01Aristotle.lean companion file with 6 supporting lemmas for Aristotle",
+      "Proved divisors_of_prime via Nat.Prime.eq_one_or_self_of_dvd",
+      "Proved divisorList_prime via sort characterization (length+membership+sorted+nodup)",
+      "Proved tauPerp_prime: \u03c4\u22a5(p) = 1 for primes via divisorList reduction",
+      "Proved omega_prime: \u03c9(p) = 1 via Nat.Prime.primeFactors_eq",
+      "Proved tau_perp_equality_infinitely_often via prime witnesses + Nat.exists_infinite_primes",
+      "Proved companion lemmas: gcd_one_left_eq, exists_prime_gt, omega_prime, divisors_of_prime, tau_prime"
     ],
     "insights": [
-      "g_exponential_growth theorem was unprovable as stated: claimed ∃ α ≥ √2 with α^k ≤ g(k), but Erdős-Simonovits only gives (√2 - ε)^k asymptotic lower bound",
-      "Fixed g_exponential_growth by reformulating: now correctly states ∃ β < 2 with asymptotic lower bound approaching √2 and eventual upper bound β^k",
-      "tau_perp_equality_infinitely_often: proof strategy via primes (τ⊥(p) = 1 = ω(p)) is clear but requires proving divisorList p = [1, p] which needs sorted finset manipulation",
-      "The 4 remaining sorries in provable file are: tau_perp_lower_bound, tau_perp_equality_infinitely_often, erdos_hall_max_lower_bound, erdos_simonovits_bounds"
+      "g_exponential_growth theorem was unprovable as stated: claimed \u2203 \u03b1 \u2265 \u221a2 with \u03b1^k \u2264 g(k), but Erd\u0151s-Simonovits only gives (\u221a2 - \u03b5)^k asymptotic lower bound",
+      "Fixed g_exponential_growth by reformulating: now correctly states \u2203 \u03b2 < 2 with asymptotic lower bound approaching \u221a2 and eventual upper bound \u03b2^k",
+      "tau_perp_equality_infinitely_often: proof strategy via primes (\u03c4\u22a5(p) = 1 = \u03c9(p)) is clear but requires proving divisorList p = [1, p] which needs sorted finset manipulation",
+      "The 4 remaining sorries in provable file are: tau_perp_lower_bound, tau_perp_equality_infinitely_often, erdos_hall_max_lower_bound, erdos_simonovits_bounds",
+      "divisorList_prime proof: characterize Finset.sort output by length (= card), membership (mem_sort), sorted (sort_sorted), and nodup (from membership uniqueness) to determine exact list",
+      "tauPerp reduction: once divisorList p = [1, p] established, tauPerp p = 1 follows from gcd(1,p) = 1 (Nat.gcd_one_left) via list computation",
+      "Remaining 3 main sorries are deep results: tau_perp_lower_bound (needs induction on factorization), erdos_hall_max_lower_bound (Erd\u0151s-Hall 1978), erdos_simonovits_bounds (research-level)"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Aristotle: submit Erdos1100OQ01Aristotle.lean for automated proof of omega_prime, divisors_of_prime, etc.",
-      "After Aristotle integrates companion results, prove tau_perp_equality_infinitely_often using prime witnesses",
-      "tau_perp_lower_bound is combinatorially non-trivial: needs induction on factorization structure"
+      "tau_perp_lower_bound: possibly tractable via induction on prime factorization structure",
+      "erdos_hall_max_lower_bound + erdos_simonovits_bounds: axiomatize as deep results (unlikely provable from Mathlib)",
+      "squarefree_omega_one_is_prime in companion: submit to Aristotle or prove via Nat.factorization"
     ]
   },
   "tags": [
@@ -62,29 +71,29 @@
     "mathlib": []
   },
   "started": "2026-03-30T17:32:58.850Z",
-  "lastUpdate": "2026-03-30T18:50:00.000Z",
+  "lastUpdate": "2026-03-30T19:50:00.000Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1100ProblemProvable.lean",
       "filename": "Erdos1100ProblemProvable.lean",
-      "lineCount": 259,
-      "theoremCount": 9,
+      "lineCount": 335,
+      "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 7,
-      "sorryCount": 4,
+      "sorryCount": 3,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1100ProblemProvable.lean"
     },
     {
       "path": "Proofs/Erdos1100OQ01Aristotle.lean",
       "filename": "Erdos1100OQ01Aristotle.lean",
-      "lineCount": 65,
+      "lineCount": 78,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 6,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1100OQ01Aristotle.lean"
     }


### PR DESCRIPTION
## Summary
- Proved `tau_perp_equality_infinitely_often` via prime witnesses: for any N, choose prime p > N, then τ⊥(p) = 1 = ω(p)
- Added helper lemmas: `divisors_of_prime`, `divisorList_prime`, `tauPerp_prime`, `omega_prime`
- Companion file: proved 5 of 6 sorries (`gcd_one_left_eq`, `exists_prime_gt`, `omega_prime`, `divisors_of_prime`, `tau_prime`)
- Main file sorry delta: 4 → 3; companion sorry delta: 6 → 1

## Progress
- **Main file** (`Erdos1100ProblemProvable.lean`): 335 lines, 13 theorems, 3 sorries
- **Companion** (`Erdos1100OQ01Aristotle.lean`): 78 lines, 1 sorry remaining
- **Net**: eliminated 6 sorries across both files

## Remaining sorries (deep results)
- `tau_perp_lower_bound`: τ⊥(n) ≥ ω(n) — needs induction on prime factorization
- `erdos_hall_max_lower_bound`: Erdős-Hall 1978 extremal bound
- `erdos_simonovits_bounds`: Erdős-Simonovits exponential bounds on g(k)

## Key technique
The proof of `divisorList_prime` characterizes `Finset.sort` output by showing the sorted list has length 2, contains exactly {1, p}, is sorted by ≤, and has distinct elements — forcing it to be [1, p].

🤖 Generated by researcher-3