### PR TITLE
Research: erdos-1036-oq-01 - eliminate 2 axioms

### DIFF
--- a/proofs/Proofs/Erdos1036Problem.lean
+++ b/proofs/Proofs/Erdos1036Problem.lean
@@ -51,15 +51,6 @@ noncomputable def IsNonRamsey (G : SimpleGraph V) (c : ℝ) : Prop :=
 noncomputable def numInducedSubgraphClasses (G : SimpleGraph V) : ℕ :=
   Fintype.card (Finset V) -- placeholder: counts subsets, not isomorphism classes
 
-/- ## Classical Ramsey Bound -/
-
-/-- Ramsey's theorem (R(k,k) ≤ 2^{2k}): every n-vertex graph with
-    n ≥ R(k,k) has a clique or independent set of size k.
-    Equivalently, every n-vertex graph has max(ω,α) ≥ (1/2) log₂ n. -/
-axiom ramsey_lower_bound (G : SimpleGraph V) (hn : Fintype.card V ≥ 2) :
-    (cliqueNumber G : ℝ) ≥ log (Fintype.card V) / (2 * log 2) ∨
-    (independenceNumber G : ℝ) ≥ log (Fintype.card V) / (2 * log 2)
-
 /- ## Main Results: Induced Subgraph Diversity -/
 
 /-- Shelah's theorem (1998): Every non-Ramsey graph on n vertices contains
@@ -71,11 +62,27 @@ axiom shelah_1998 (c : ℝ) (hc : c > 0) :
       (numInducedSubgraphClasses G : ℝ) ≥ 2 ^ (c' * Fintype.card V)
 
 /-- Alon-Hajnal (1991): The sub-exponential precursor to Shelah's result.
-    They proved exp(n · (log n)^{-O(log log n)}) using regularity. -/
-axiom alon_hajnal_1991 (c : ℝ) (hc : c > 0) :
+    They proved exp(n · (log n)^{-O(log log n)}) using regularity.
+    Here derived from Shelah's stronger exponential bound, since 2^{c'n} ≥ (c'·ln2)·n. -/
+theorem alon_hajnal_1991 (c : ℝ) (hc : c > 0) :
     ∃ c' > 0, ∀ (V : Type*) [Fintype V] [DecidableEq V] (G : SimpleGraph V),
       IsNonRamsey G c →
-      (numInducedSubgraphClasses G : ℝ) ≥ c' * Fintype.card V
+      (numInducedSubgraphClasses G : ℝ) ≥ c' * Fintype.card V := by
+  obtain ⟨c'', hc''_pos, hc''⟩ := shelah_1998 c hc
+  refine ⟨c'' * Real.log 2, by positivity, ?_⟩
+  intro V _ _ G hG
+  have hshelah := hc'' V G hG
+  -- Shelah: numInducedSubgraphClasses G ≥ 2^(c''·n)
+  -- We show: 2^(c''·n) ≥ (c''·log 2)·n using exp(t) ≥ t
+  calc (numInducedSubgraphClasses G : ℝ)
+      ≥ (2 : ℝ) ^ (c'' * Fintype.card V) := hshelah
+    _ = Real.exp (Real.log 2 * (c'' * Fintype.card V)) :=
+        Real.rpow_def_of_pos (by norm_num : (2:ℝ) > 0) _
+    _ = Real.exp (c'' * ↑(Fintype.card V) * Real.log 2) := by congr 1; ring
+    _ ≥ c'' * ↑(Fintype.card V) * Real.log 2 := by
+        have h := Real.add_one_le_exp (c'' * ↑(Fintype.card V) * Real.log 2)
+        linarith
+    _ = c'' * Real.log 2 * ↑(Fintype.card V) := by ring
 
 /- ## The Optimal Constant Question (oq-01) -/
 

--- a/src/data/proofs/erdos-1036/meta.json
+++ b/src/data/proofs/erdos-1036/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-1036",
-  "title": "Erdős Problem #1036: Distinct Induced Subgraphs in Non-Ramsey Graphs",
+  "title": "Erd\u0151s Problem #1036: Distinct Induced Subgraphs in Non-Ramsey Graphs",
   "slug": "erdos-1036",
-  "description": "Let G be non-Ramsey (no trivial subgraph on > c log n vertices). Must G contain ≥ 2^{Ω_c(n)} non-isomorphic induced subgraphs? YES (Shelah 1998). Prior: Alon-Hajnal (1991) proved exp(n(log n)^{-O(log log n)}).",
+  "description": "Let G be non-Ramsey (no trivial subgraph on > c log n vertices). Must G contain \u2265 2^{\u03a9_c(n)} non-isomorphic induced subgraphs? YES (Shelah 1998). Prior: Alon-Hajnal (1991) proved exp(n(log n)^{-O(log log n)}).",
   "meta": {
-    "author": "Erdős-Rényi (question), Shelah (1998, solution)",
+    "author": "Erd\u0151s-R\u00e9nyi (question), Shelah (1998, solution)",
     "sourceUrl": "https://erdosproblems.com/1036",
     "date": "1998",
     "status": "axiomatized",
@@ -24,22 +24,22 @@
     "relatedProblems": [
       1031
     ],
-    "axiomCount": 3,
-    "lineCount": 141,
-    "assumptions": "3 axioms: ramsey_lower_bound (classical Ramsey theorem), shelah_1998 (exponential bound on induced subgraph classes), alon_hajnal_1991 (sub-exponential precursor). 2 sorries: optimalConstant_pos, optimalConstant_le_one.",
+    "axiomCount": 1,
+    "lineCount": 148,
+    "assumptions": "1 axiom (Shelah 1998) and 2 sorry(s). Alon-Hajnal derived from Shelah. Ramsey lower bound removed (unused).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "This problem originates from a question of Erdős and Rényi about the structural complexity of graphs that avoid large homogeneous (trivial) subgraphs. By Ramsey's theorem (1930), every n-vertex graph contains a clique or independent set of size at least (1/2) log₂ n. Erdős (1947) showed via the probabilistic method that random graphs G(n,1/2) achieve the opposite extreme: their largest clique and independent set are both O(log n). Such 'non-Ramsey' graphs exist in abundance but must be structurally complex. Erdős and Hajnal (1989) proved the first result in this direction: graphs avoiding K_{k,k} in both G and its complement have 2^{Ω(n)} distinct induced subgraphs. Alon and Hajnal (1991) extended this to all non-Ramsey graphs, proving a sub-exponential bound of exp(n·(log n)^{-O(log log n)}) using Szemerédi's regularity lemma. The full exponential bound 2^{Ω(n)} remained open until Shelah (1998) proved it using a deep partition argument connected to the Hales-Jewett theorem. Independently, Prömel and Rödl (1999) proved the related result that non-Ramsey graphs are c·log(n)-universal (Problem 1031), which gives a weaker but conceptually elegant approach to induced subgraph diversity.",
-    "problemStatement": "Let G be a graph on n vertices with no trivial (empty or complete) subgraph on more than c log n vertices. Must G contain at least 2^{Ω_c(n)} non-isomorphic induced subgraphs? Answered YES by Shelah (1998).",
-    "text": "Let G be non-Ramsey (no trivial subgraph on > c log n vertices). Must G contain ≥ 2^{Ω_c(n)} non-isomorphic induced subgraphs? YES (Shelah 1998). Prior: Alon-Hajnal (1991) proved exp(n(log n)^{-O(log log n)}).",
-    "proofStrategy": "The formalization defines non-Ramsey graphs via the noLargeTrivial predicate, builds the isomorphism equivalence relation on induced subgraphs (with reflexivity, symmetry, transitivity), defines the counting function i(G), and axiomatizes three key results: Erdős-Hajnal 1989 (bipartite avoidance case), Alon-Hajnal 1991 (sub-exponential bound), and Shelah 1998 (full exponential bound). An alternative proof path via Prömel-Rödl universality (Problem 1031) is also formalized.",
+    "historicalContext": "This problem originates from a question of Erd\u0151s and R\u00e9nyi about the structural complexity of graphs that avoid large homogeneous (trivial) subgraphs. By Ramsey's theorem (1930), every n-vertex graph contains a clique or independent set of size at least (1/2) log\u2082 n. Erd\u0151s (1947) showed via the probabilistic method that random graphs G(n,1/2) achieve the opposite extreme: their largest clique and independent set are both O(log n). Such 'non-Ramsey' graphs exist in abundance but must be structurally complex. Erd\u0151s and Hajnal (1989) proved the first result in this direction: graphs avoiding K_{k,k} in both G and its complement have 2^{\u03a9(n)} distinct induced subgraphs. Alon and Hajnal (1991) extended this to all non-Ramsey graphs, proving a sub-exponential bound of exp(n\u00b7(log n)^{-O(log log n)}) using Szemer\u00e9di's regularity lemma. The full exponential bound 2^{\u03a9(n)} remained open until Shelah (1998) proved it using a deep partition argument connected to the Hales-Jewett theorem. Independently, Pr\u00f6mel and R\u00f6dl (1999) proved the related result that non-Ramsey graphs are c\u00b7log(n)-universal (Problem 1031), which gives a weaker but conceptually elegant approach to induced subgraph diversity.",
+    "problemStatement": "Let G be a graph on n vertices with no trivial (empty or complete) subgraph on more than c log n vertices. Must G contain at least 2^{\u03a9_c(n)} non-isomorphic induced subgraphs? Answered YES by Shelah (1998).",
+    "text": "Let G be non-Ramsey (no trivial subgraph on > c log n vertices). Must G contain \u2265 2^{\u03a9_c(n)} non-isomorphic induced subgraphs? YES (Shelah 1998). Prior: Alon-Hajnal (1991) proved exp(n(log n)^{-O(log log n)}).",
+    "proofStrategy": "The formalization defines non-Ramsey graphs via the noLargeTrivial predicate, builds the isomorphism equivalence relation on induced subgraphs (with reflexivity, symmetry, transitivity), defines the counting function i(G), and axiomatizes three key results: Erd\u0151s-Hajnal 1989 (bipartite avoidance case), Alon-Hajnal 1991 (sub-exponential bound), and Shelah 1998 (full exponential bound). An alternative proof path via Pr\u00f6mel-R\u00f6dl universality (Problem 1031) is also formalized.",
     "keyInsights": [
-      "**Non-Ramsey Complexity:** Graphs with max(ω(G), α(G)) ≤ c log n are forced to have exponentially many non-isomorphic induced subgraphs — structural homogeneity avoidance implies diversity",
-      "**Three Eras of Progress:** Erdős-Hajnal 1989 (bipartite case, 2^{Ω(n)}), Alon-Hajnal 1991 (general case, sub-exponential via regularity), Shelah 1998 (general case, full 2^{Ω(n)})",
-      "**Complement Symmetry:** If G is non-Ramsey then so is its complement, and i(G) = i(Ḡ), since complementation permutes isomorphism classes",
-      "**Universality Connection:** Prömel-Rödl (Problem 1031) shows non-Ramsey graphs are c·log(n)-universal, giving a weaker 2^{Ω((log n)²)} bound via a cleaner argument",
-      "**Random-Like Behavior:** Non-Ramsey graphs satisfy i(G) = 2^{Θ(n)}, qualitatively matching random graphs G(n,1/2) which have i(G) = (1-o(1))·2^n",
+      "**Non-Ramsey Complexity:** Graphs with max(\u03c9(G), \u03b1(G)) \u2264 c log n are forced to have exponentially many non-isomorphic induced subgraphs \u2014 structural homogeneity avoidance implies diversity",
+      "**Three Eras of Progress:** Erd\u0151s-Hajnal 1989 (bipartite case, 2^{\u03a9(n)}), Alon-Hajnal 1991 (general case, sub-exponential via regularity), Shelah 1998 (general case, full 2^{\u03a9(n)})",
+      "**Complement Symmetry:** If G is non-Ramsey then so is its complement, and i(G) = i(\u1e20), since complementation permutes isomorphism classes",
+      "**Universality Connection:** Pr\u00f6mel-R\u00f6dl (Problem 1031) shows non-Ramsey graphs are c\u00b7log(n)-universal, giving a weaker 2^{\u03a9((log n)\u00b2)} bound via a cleaner argument",
+      "**Random-Like Behavior:** Non-Ramsey graphs satisfy i(G) = 2^{\u0398(n)}, qualitatively matching random graphs G(n,1/2) which have i(G) = (1-o(1))\u00b72^n",
       "**Shelah's Technique:** The proof uses a sophisticated partition argument and the Hales-Jewett theorem to extract exponentially many distinct induced patterns"
     ],
     "prerequisites": [
@@ -65,7 +65,7 @@
       "summary": "vertexCount definition: cardinality of the finite vertex set",
       "startLine": 1,
       "endLine": 1,
-      "mathContext": "$n = |V(G)| = \\text{Fintype.card}\\;V$ — the order of the graph, used throughout as the parameter in asymptotic bounds like $2^{\\Omega(n)}$."
+      "mathContext": "$n = |V(G)| = \\text{Fintype.card}\\;V$ \u2014 the order of the graph, used throughout as the parameter in asymptotic bounds like $2^{\\Omega(n)}$."
     },
     {
       "id": "trivial",
@@ -81,7 +81,7 @@
       "summary": "noLargeTrivial predicate, isNonRamsey definition (no trivial subgraph > c log n), and axiomatized existence of non-Ramsey graphs via the probabilistic method",
       "startLine": 1,
       "endLine": 1,
-      "mathContext": "$G$ is non-Ramsey with parameter $c$ if $\\max(\\omega(G), \\alpha(G)) \\leq c \\log_2 n$. By Erdős (1947), $G(n, 1/2)$ satisfies this with high probability for $c = 2 + \\varepsilon$."
+      "mathContext": "$G$ is non-Ramsey with parameter $c$ if $\\max(\\omega(G), \\alpha(G)) \\leq c \\log_2 n$. By Erd\u0151s (1947), $G(n, 1/2)$ satisfies this with high probability for $c = 2 + \\varepsilon$."
     },
     {
       "id": "induced",
@@ -105,12 +105,12 @@
       "summary": "allInducedSubsets (power set), sameIsoClass equivalence relation, distinctInducedCount (number of isomorphism classes), hasDistinctInduced predicate",
       "startLine": 1,
       "endLine": 1,
-      "mathContext": "$i(G) = |\\mathcal{P}(V) / {\\cong}|$ — the number of isomorphism classes of induced subgraphs. Defined via the quotient of $\\mathcal{P}(V(G))$ by the `sameIsoClass` equivalence relation."
+      "mathContext": "$i(G) = |\\mathcal{P}(V) / {\\cong}|$ \u2014 the number of isomorphism classes of induced subgraphs. Defined via the quotient of $\\mathcal{P}(V(G))$ by the `sameIsoClass` equivalence relation."
     },
     {
       "id": "conjecture",
-      "title": "The Erdős-Rényi Conjecture",
-      "summary": "erdos_renyi_conjecture: for every c > 0, there exists c' > 0 such that non-Ramsey graphs with parameter c have ≥ 2^{c'n} distinct induced subgraphs",
+      "title": "The Erd\u0151s-R\u00e9nyi Conjecture",
+      "summary": "erdos_renyi_conjecture: for every c > 0, there exists c' > 0 such that non-Ramsey graphs with parameter c have \u2265 2^{c'n} distinct induced subgraphs",
       "startLine": 1,
       "endLine": 1,
       "mathContext": "Conjecture: if $G$ has no trivial induced subgraph on $> c \\log n$ vertices, then $G$ has $\\geq 2^{c' n}$ distinct induced subgraphs."
@@ -118,18 +118,18 @@
     {
       "id": "alon-hajnal",
       "title": "Alon-Hajnal Bound (1991)",
-      "summary": "alonHajnalExponent (n·(log n)^{-O(log log n)}), axiomatized Alon-Hajnal bound, and proof that it is weaker than Shelah's bound",
+      "summary": "alonHajnalExponent (n\u00b7(log n)^{-O(log log n)}), axiomatized Alon-Hajnal bound, and proof that it is weaker than Shelah's bound",
       "startLine": 1,
       "endLine": 1,
-      "mathContext": "Alon-Hajnal (1991): $i(G) \\geq \\exp\\bigl(n \\cdot (\\log n)^{-O(\\log \\log n)}\\bigr)$ for non-Ramsey $G$. Sub-exponential — proved via Szemerédi's regularity lemma. Strictly weaker than Shelah's $2^{\\Omega(n)}$."
+      "mathContext": "Alon-Hajnal (1991): $i(G) \\geq \\exp\\bigl(n \\cdot (\\log n)^{-O(\\log \\log n)}\\bigr)$ for non-Ramsey $G$. Sub-exponential \u2014 proved via Szemer\u00e9di's regularity lemma. Strictly weaker than Shelah's $2^{\\Omega(n)}$."
     },
     {
       "id": "erdos-hajnal",
-      "title": "Erdős-Hajnal Bipartite Result (1989)",
-      "summary": "hasCompleteBipartite, avoidsBipartite predicates, axiomatized Erdős-Hajnal 1989 bound, and proof that non-Ramsey implies bipartite avoidance",
+      "title": "Erd\u0151s-Hajnal Bipartite Result (1989)",
+      "summary": "hasCompleteBipartite, avoidsBipartite predicates, axiomatized Erd\u0151s-Hajnal 1989 bound, and proof that non-Ramsey implies bipartite avoidance",
       "startLine": 1,
       "endLine": 1,
-      "mathContext": "Erdős-Hajnal (1989): if $G$ avoids $K_{k,k}$ in both $G$ and $\\bar{G}$, then $i(G) \\geq 2^{\\Omega(n)}$. Non-Ramsey graphs satisfy this avoidance condition, giving the first exponential bound in a special case."
+      "mathContext": "Erd\u0151s-Hajnal (1989): if $G$ avoids $K_{k,k}$ in both $G$ and $\\bar{G}$, then $i(G) \\geq 2^{\\Omega(n)}$. Non-Ramsey graphs satisfy this avoidance condition, giving the first exponential bound in a special case."
     },
     {
       "id": "shelah",
@@ -137,7 +137,7 @@
       "summary": "Axiomatized Shelah's theorem (2^{c'n} bound) and erdos_1036_solved establishing the conjecture is true",
       "startLine": 1,
       "endLine": 1,
-      "mathContext": "Shelah (1998): proved the Erdős-Rényi conjecture. Non-Ramsey graphs have $\\geq 2^{c'n}$ distinct induced subgraphs. Status: SOLVED."
+      "mathContext": "Shelah (1998): proved the Erd\u0151s-R\u00e9nyi conjecture. Non-Ramsey graphs have $\\geq 2^{c'n}$ distinct induced subgraphs. Status: SOLVED."
     },
     {
       "id": "comparison",
@@ -150,7 +150,7 @@
     {
       "id": "counting-args",
       "title": "Counting Arguments",
-      "summary": "distinct_upper (trivial 2^n upper bound), random_graph_distinct (random graphs near-maximize diversity), nonRamsey_random_like (non-Ramsey ≈ random in diversity)",
+      "summary": "distinct_upper (trivial 2^n upper bound), random_graph_distinct (random graphs near-maximize diversity), nonRamsey_random_like (non-Ramsey \u2248 random in diversity)",
       "startLine": 1,
       "endLine": 1,
       "mathContext": "Upper bound: $i(G) \\leq 2^n$ trivially. Random graphs: $i(G(n,1/2)) = (1 - o(1)) \\cdot 2^n$. Non-Ramsey graphs satisfy $i(G) = 2^{\\Theta(n)}$, qualitatively matching random graph behavior."
@@ -166,7 +166,7 @@
     {
       "id": "complement",
       "title": "Complement Symmetry",
-      "summary": "complement_nonRamsey (complement preserves non-Ramsey) and complement_distinct (i(G) = i(Ḡ))",
+      "summary": "complement_nonRamsey (complement preserves non-Ramsey) and complement_distinct (i(G) = i(\u1e20))",
       "startLine": 1,
       "endLine": 1,
       "mathContext": "If $\\max(\\omega(G), \\alpha(G)) \\leq k$ then $\\max(\\omega(\\bar{G}), \\alpha(\\bar{G})) \\leq k$ (since $\\omega(\\bar{G}) = \\alpha(G)$). Also $i(G) = i(\\bar{G})$ because complementation is a bijection on isomorphism classes."
@@ -174,37 +174,37 @@
     {
       "id": "problem-1031",
       "title": "Connection to Problem 1031",
-      "summary": "isKUniversal definition, universal_implies_distinct theorem, and via_universality providing an alternative proof of Problem 1036 through Prömel-Rödl universality",
+      "summary": "isKUniversal definition, universal_implies_distinct theorem, and via_universality providing an alternative proof of Problem 1036 through Pr\u00f6mel-R\u00f6dl universality",
       "startLine": 1,
       "endLine": 1,
-      "mathContext": "$G$ is $k$-universal if every $k$-vertex graph is an induced subgraph of $G$. Prömel-Rödl: non-Ramsey $\\Rightarrow$ $c\\log n$-universal $\\Rightarrow$ $i(G) \\geq 2^{\\Omega((\\log n)^2)}$. Weaker than Shelah but gives an alternative proof path."
+      "mathContext": "$G$ is $k$-universal if every $k$-vertex graph is an induced subgraph of $G$. Pr\u00f6mel-R\u00f6dl: non-Ramsey $\\Rightarrow$ $c\\log n$-universal $\\Rightarrow$ $i(G) \\geq 2^{\\Omega((\\log n)^2)}$. Weaker than Shelah but gives an alternative proof path."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #1036 asks whether non-Ramsey graphs must contain exponentially many non-isomorphic induced subgraphs. Shelah (1998) proved YES: i(G) ≥ 2^{c'n}. The formalization captures the full history from Erdős-Hajnal 1989 through Alon-Hajnal 1991 to Shelah 1998, includes complement symmetry arguments, and connects to Prömel-Rödl universality (Problem 1031) for an alternative proof path.",
-    "implications": "**Theoretical Significance**: Shelah's theorem reveals a deep connection between Ramsey-theoretic structure avoidance and combinatorial complexity.\n\nGraphs that lack homogeneous structure must compensate with exponential diversity in their induced subgraph patterns. This connects to quasi-randomness (non-Ramsey graphs share properties with random graphs), the Erdős-Hajnal conjecture (on induced subgraphs in H-free graphs), and computational complexity (graph isomorphism testing in structured graph classes).",
+    "summary": "Erd\u0151s Problem #1036 asks whether non-Ramsey graphs must contain exponentially many non-isomorphic induced subgraphs. Shelah (1998) proved YES: i(G) \u2265 2^{c'n}. The formalization captures the full history from Erd\u0151s-Hajnal 1989 through Alon-Hajnal 1991 to Shelah 1998, includes complement symmetry arguments, and connects to Pr\u00f6mel-R\u00f6dl universality (Problem 1031) for an alternative proof path.",
+    "implications": "**Theoretical Significance**: Shelah's theorem reveals a deep connection between Ramsey-theoretic structure avoidance and combinatorial complexity.\n\nGraphs that lack homogeneous structure must compensate with exponential diversity in their induced subgraph patterns. This connects to quasi-randomness (non-Ramsey graphs share properties with random graphs), the Erd\u0151s-Hajnal conjecture (on induced subgraphs in H-free graphs), and computational complexity (graph isomorphism testing in structured graph classes).",
     "openQuestions": [
       "What is the optimal constant c' = c'(c) in Shelah's theorem 2^{c'n}? Current methods do not give explicit bounds.",
       "Can non-Ramsey graphs be efficiently constructed, and can their distinct induced subgraphs be efficiently enumerated?",
       "Does an analogous result hold for hypergraphs: must non-Ramsey r-uniform hypergraphs have exponentially many distinct induced sub-hypergraphs?",
-      "How does the result connect to the Erdős-Hajnal conjecture on induced subgraphs in graphs avoiding a fixed pattern?",
+      "How does the result connect to the Erd\u0151s-Hajnal conjecture on induced subgraphs in graphs avoiding a fixed pattern?",
       "Can Shelah's proof be simplified, perhaps using the container method or regularity-based approaches?"
     ]
   },
   "crossReferences": [
     {
       "relationship": "related",
-      "description": "Erdős #1031 (induced regular subgraphs in non-Ramsey graphs) proves Prömel-Rödl universality, which provides an alternative proof path for the induced subgraph diversity of Problem 1036.",
+      "description": "Erd\u0151s #1031 (induced regular subgraphs in non-Ramsey graphs) proves Pr\u00f6mel-R\u00f6dl universality, which provides an alternative proof path for the induced subgraph diversity of Problem 1036.",
       "targetId": "erdos-1031"
     },
     {
       "relationship": "related",
-      "description": "The Erdős-Szekeres theorem is a foundational result in Ramsey theory (monotone subsequences), sharing the theme that avoiding simple structure forces complex patterns.",
+      "description": "The Erd\u0151s-Szekeres theorem is a foundational result in Ramsey theory (monotone subsequences), sharing the theme that avoiding simple structure forces complex patterns.",
       "targetId": "erdos-szekeres"
     },
     {
       "relationship": "related",
-      "description": "Erdős #88 studies Ramsey-theoretic questions about graph colorings, connecting to the non-Ramsey graph framework underlying Problem 1036.",
+      "description": "Erd\u0151s #88 studies Ramsey-theoretic questions about graph colorings, connecting to the non-Ramsey graph framework underlying Problem 1036.",
       "targetId": "erdos-88"
     }
   ],
@@ -212,9 +212,9 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 0,
-    "axiomCount": 0,
-    "theoremCount": 0,
+    "lineCount": 148,
+    "axiomCount": 1,
+    "theoremCount": 8,
     "definitionCount": 0
   }
 }

--- a/src/data/research/problems/erdos-1036-oq-01.json
+++ b/src/data/research/problems/erdos-1036-oq-01.json
@@ -18,37 +18,42 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-03-30T16:34:54.972Z",
-    "iteration": 2,
-    "focus": "Fresh formalization of Shelah theorem and optimal constant question",
+    "iteration": 4,
+    "focus": "Eliminated 2 axioms: proved alon_hajnal from shelah, removed unused ramsey_lower_bound",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
+      "total": 1,
+      "currentApproach": 1,
       "approachesTried": 0
     }
   },
   "knowledge": {
-    "progressSummary": "BUILD: Created fresh formalization (141 lines). Defined cliqueNumber, independenceNumber, IsNonRamsey, optimalConstant. Stated Shelah, Alon-Hajnal, Ramsey lower bound. Proved complement symmetry. 2 sorries remain.",
+    "progressSummary": "PROGRESS: Axiom count 3\u21921. Proved alon_hajnal_1991 from shelah_1998 (exponential dominates linear via exp(t)\u2265t). Removed unused ramsey_lower_bound axiom. 2 sorries remain (optimalConstant bounds).",
     "builtItems": [
       "Created Erdos1036Problem.lean from scratch (was corrupted/empty)",
       "Defined cliqueNumber, independenceNumber, IsNonRamsey, numInducedSubgraphClasses",
       "Defined optimalConstant function for oq-01",
       "Stated Shelah 1998 (main result), Alon-Hajnal 1991, Ramsey lower bound as axioms",
       "Proved cliqueNumber_compl, independenceNumber_compl, complement_nonramsey",
-      "Proved erdos_1036 summary theorem from Shelah axiom"
+      "Proved erdos_1036 summary theorem from Shelah axiom",
+      "Proved alon_hajnal_1991 from shelah_1998: 2^{c'n} \u2265 (c'\u00b7ln2)\u00b7n via exp(t)\u2265t",
+      "Removed unused ramsey_lower_bound axiom"
     ],
     "insights": [
       "independenceNumber G = cliqueNumber G\u1d9c by definition (rfl)",
       "independenceNumber G\u1d9c = cliqueNumber G needs compl_compl rewrite",
       "optimalConstant is defined via sSup of valid exponent constants",
-      "Random graphs G(n,1/2) achieve optimal constant 1"
+      "Random graphs G(n,1/2) achieve optimal constant 1",
+      "alon_hajnal derived from shelah: use c'\u00b7log2 as linear constant, chain 2^{c'n}=exp(c'n\u00b7log2)\u2265c'n\u00b7log2",
+      "exp(t)\u2265t follows from add_one_le_exp: t \u2264 t+1 \u2264 exp(t)",
+      "ramsey_lower_bound was unused in all proofs \u2014 safely removed"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove optimalConstant_pos (needs nonempty + bounded sSup argument)",
-      "Prove optimalConstant_le_one (needs numInducedSubgraphClasses \u2264 2^n bound)",
-      "Define proper isomorphism-class counting for numInducedSubgraphClasses"
+      "optimalConstant_pos: needs explicit non-Ramsey graph construction (BddAbove + nonempty sSup)",
+      "optimalConstant_le_one: needs numInducedSubgraphClasses \u2264 2^n + existence of non-Ramsey graph for large n",
+      "Fix numInducedSubgraphClasses placeholder (currently counts subsets not isomorphism classes)"
     ]
   },
   "tags": [
@@ -67,16 +72,16 @@
     "mathlib": []
   },
   "started": "2026-03-30T16:34:54.972Z",
-  "lastUpdate": "2026-03-30T16:34:54.972Z",
+  "lastUpdate": "2026-03-30T20:30:00.000Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1036Problem.lean",
       "filename": "Erdos1036Problem.lean",
-      "lineCount": 141,
-      "theoremCount": 6,
-      "axiomCount": 3,
+      "lineCount": 148,
+      "theoremCount": 8,
+      "axiomCount": 1,
       "defCount": 6,
       "sorryCount": 2,
       "isAristotle": false,


### PR DESCRIPTION
## Summary
- **Proved `alon_hajnal_1991`** from `shelah_1998`: exponential bound 2^{c'n} dominates linear c'n via the chain `2^{c'n} = exp(c'n·log 2) ≥ c'n·log 2` (using exp(t) ≥ t)
- **Removed unused `ramsey_lower_bound` axiom** (was not referenced by any proof)
- Axiom count: **3 → 1** (only `shelah_1998` remains)

## Key proof technique
The proof uses `Real.rpow_def_of_pos` to convert `2^(c'n)` to `exp(c'n · log 2)`, then applies `Real.add_one_le_exp` (the inequality `t + 1 ≤ exp(t)`) to get `exp(t) ≥ t`, yielding the linear bound.

## Remaining work
- 2 sorries: `optimalConstant_pos`, `optimalConstant_le_one` (require explicit graph construction)
- `numInducedSubgraphClasses` placeholder still counts subsets not isomorphism classes

🤖 Generated by researcher-3