### PR TITLE
fix: audit batch — law-of-cosines-oq-04, hilbert-22-oq-01, konigsberg-oq-03

### DIFF
--- a/src/data/proofs/hilbert-22-oq-01/meta.json
+++ b/src/data/proofs/hilbert-22-oq-01/meta.json
@@ -16,9 +16,9 @@
     ],
     "badge": "axiom",
     "sorries": 1,
-    "axiomCount": 3,
-    "lineCount": 155,
-    "assumptions": "3 axioms (yau_theorem [True stub], disk_kobayashi_hyperbolic, plane_not_hyperbolic). 1 sorry (IsKobayashiHyperbolic definition).",
+    "axiomCount": 0,
+    "lineCount": 156,
+    "assumptions": "0 axioms, 1 sorry (IsKobayashiHyperbolic definition). Previously listed axioms (yau_theorem, disk_kobayashi_hyperbolic, plane_not_hyperbolic) do not exist in the file.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "originalContributions": [

--- a/src/data/proofs/konigsberg-oq-03/meta.json
+++ b/src/data/proofs/konigsberg-oq-03/meta.json
@@ -17,11 +17,12 @@
     "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-03-30",
-    "axiomCount": 4,
-    "lineCount": 74
+    "axiomCount": 0,
+    "lineCount": 75,
+    "assumptions": "0 axioms, 0 sorries. 3 True-stub definitions (HasEulerTour, HasInfiniteEulerPath, HasOneWayEulerPath). Structure fields (uniform, symm, loopless) are definitional, not assumptions."
   },
   "sections": [],
   "leanFile": {
-    "axiomCount": 4
+    "axiomCount": 0
   }
 }

--- a/src/data/proofs/law-of-cosines-oq-04/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-04/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Matthew Stewart (1746)",
     "date": "2026",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/LawOfCosinesOQ04.lean",
     "tags": [
       "geometry",
@@ -15,7 +15,7 @@
       "law-of-cosines",
       "research"
     ],
-    "badge": "original",
+    "badge": "formalized",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 160,


### PR DESCRIPTION
## Summary

Three metadata corrections from gallery integrity audit:

- **law-of-cosines-oq-04**: `verified` → `formalized` (1 True-stub theorem: angle_bisector_from_stewarts proves True)
- **hilbert-22-oq-01**: `axiomCount` 3 → 0 (referenced axioms yau_theorem, disk_kobayashi_hyperbolic, plane_not_hyperbolic don't exist in the Lean file)
- **konigsberg-oq-03**: `axiomCount` 4 → 0 (no axiom declarations; structure fields are definitional graph constraints)

## Severity

- law-of-cosines-oq-04: **CRITICAL** (True stub with verified status)
- hilbert-22-oq-01: **HIGH** (phantom axiom count)
- konigsberg-oq-03: **HIGH** (phantom axiom count)

## Test plan

- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)