### PR TITLE
fix: correct lebesgue-measure-oq-03 axiomCount (3→0)

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-03/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-03/meta.json
@@ -16,9 +16,9 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 3,
+    "axiomCount": 0,
     "lineCount": 132,
-    "assumptions": "3 axioms. 0 sorries.",
+    "assumptions": "0 axioms, 0 sorries. 2 True-stub theorems (gaussian_measure_exists, abstract_wiener_well_defined). Previously claimed axioms don't exist in file.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "originalContributions": [


### PR DESCRIPTION
## Summary

- **axiomCount**: 3 → 0 (no axiom declarations exist in the Lean file)
- Added assumptions text documenting 2 True-stub theorems

## Test plan

- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)