### PR TITLE
Fix: pell-equation-oq-01 status should be verified

### DIFF
--- a/src/data/proofs/pell-equation-oq-01/meta.json
+++ b/src/data/proofs/pell-equation-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lagrange (existence), Lenstra (computational survey), Cohen-Lenstra (heuristics)",
     "date": "2002",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/PellEquationOQ01.lean",
     "tags": [
       "number-theory",


### PR DESCRIPTION
## Fix

Corrects metadata inconsistency: status was "axiomatized" but badge was "verified" — with 0 sorries and 0 axiomCount.

## Evidence

**Before**: status=axiomatized, badge=verified (inconsistent — axiomatized implies axiom badge)
**After**: status=verified, badge=verified (consistent — 0 sorries, 0 axioms confirmed in Lean source)

---
Automated fix by lean-mechanic agent.