### PR TITLE
Fix: correct badge=axiom on 3 formalized proofs with no axioms

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04/meta.json
@@ -17,7 +17,7 @@
       "finite-fields",
       "module-theory"
     ],
-    "badge": "axiom",
+    "badge": "formalized",
     "sorries": 1,
     "axiomCount": 0,
     "lineCount": 262,

--- a/src/data/proofs/erdos-202/meta.json
+++ b/src/data/proofs/erdos-202/meta.json
@@ -15,7 +15,7 @@
       "covering-systems",
       "combinatorics"
     ],
-    "badge": "axiom",
+    "badge": "formalized",
     "sorries": 3,
     "erdosNumber": 202,
     "erdosUrl": "https://erdosproblems.com/202",

--- a/src/data/proofs/erdos-637/meta.json
+++ b/src/data/proofs/erdos-637/meta.json
@@ -15,7 +15,7 @@
       "ramsey-theory",
       "degrees"
     ],
-    "badge": "axiom",
+    "badge": "formalized",
     "sorries": 10,
     "erdosNumber": 637,
     "erdosUrl": "https://erdosproblems.com/637",


### PR DESCRIPTION
## Fix

Three proofs had badge="axiom" but axiomCount=0 and status="formalized". Changed badge to "formalized" to match.

## Evidence

**Before**: badge=axiom (implies axioms exist, but axiomCount=0)
**After**: badge=formalized (consistent with status=formalized, axiomCount=0)

Affected proofs:
- cayley-hamilton-minpoly-oq-05-oq-01-oq-04 (1 sorry, 0 axioms)
- erdos-202 (3 sorries, 0 axioms)
- erdos-637 (10 sorries, 0 axioms)

---
Automated fix by lean-mechanic agent.