### PR TITLE
Fix: erdos-218 axiomCount=2 not 5, sorries=0 not 1

### DIFF
--- a/src/data/proofs/erdos-218/meta.json
+++ b/src/data/proofs/erdos-218/meta.json
@@ -17,11 +17,11 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 218,
     "erdosUrl": "https://erdosproblems.com/218",
     "erdosProblemStatus": "open",
-    "axiomCount": 5,
+    "axiomCount": 2,
     "prerequisites": [
       "Prime numbers and basic properties of Nat.Prime",
       "Prime Number Theorem (average gap growth)",
@@ -31,7 +31,7 @@
       "Cramér probabilistic model for primes"
     ],
     "lineCount": 403,
-    "assumptions": "5 axioms: erdos_218a, erdos_218b, erdos_218c (3 open conjectures), green_tao (deep), average_gap_growth. 1 sorry: infinite_of_hasDensity_pos (finite set has density 0). Previously had more axioms; hasDensity_iff_upper_lower, gapIncreasingSet_infinite, gapDecreasingSet_infinite converted to theorems.",
+    "assumptions": "2 axioms: erdos_218a (gap increasing density 1/2), erdos_218b (gap decreasing density 1/2). 0 sorries. Previously had 5+ axioms; erdos_218c, green_tao, average_gap_growth removed; infinite_of_hasDensity_pos now fully proved.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -172,7 +172,7 @@
     ],
     "namespace": "Erdos218",
     "lineCount": 403,
-    "axiomCount": 5,
+    "axiomCount": 2,
     "theoremCount": 25,
     "definitionCount": 12
   },


### PR DESCRIPTION
## Summary

- Lean source has only **2 axiom** declarations (`erdos_218a`, `erdos_218b`), not 5
- Three axioms listed in meta.json (`erdos_218c`, `green_tao`, `average_gap_growth`) no longer exist in the Lean file
- `infinite_of_hasDensity_pos` is fully proved — **0 sorries**, not 1
- Updated `meta.axiomCount`, `leanFile.axiomCount`, `meta.sorries`, and `assumptions` text

## Evidence

| Field | Before | After | Source |
|-------|--------|-------|--------|
| `meta.axiomCount` | 5 | **2** | `grep -c "^axiom "` = 2 |
| `meta.sorries` | 1 | **0** | `grep -c sorry` = 0 |
| `leanFile.axiomCount` | 5 | **2** | Same as above |

## Test plan

- [ ] `pnpm build` passes
- [ ] Gallery page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)