### PR TITLE
Fix: correct stale sorry counts in 4 gallery entries

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05/meta.json
@@ -16,9 +16,9 @@
       "normal-distribution"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 1,
     "axiomCount": 0,
-    "assumptions": "None. The Gaussian integral itself is proved via Mathlib. Two sorries remain for standard normal normalization and radial integral (routine measure theory).",
+    "assumptions": "None. The Gaussian integral itself is proved via Mathlib. One sorry remains for radial integral (needs FTC for improper integrals).",
     "dateAdded": "2026-03-30",
     "lineCount": 107,
     "mathlibDependencies": [

--- a/src/data/proofs/erdos-106-oq-02/meta.json
+++ b/src/data/proofs/erdos-106-oq-02/meta.json
@@ -20,12 +20,12 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 106,
     "erdosUrl": "https://erdosproblems.com/106",
     "erdosProblemStatus": "open",
     "axiomCount": 6,
-    "assumptions": "6 axiom declarations: rotated_square_area (rotation preserves area), f_rot_bounded (Cauchy-Schwarz √n bound), f_rot_mono (monotone), g_ap_perfect_square (g(k²)=k), bku_theorem_ap (BKU 2024 result), f_rot_2 (Erdős f_rot(2)=1). ELIMINATED: g_ap_bounded (proved from f_rot_bounded + g_ap≤f_rot), f_rot_perfect_square (proved from g_ap_perfect_square + f_rot_bounded + g_ap≤f_rot). New: side_le_sqrt_two (contained squares have side≤√2), g_ap_le_f_rot (AP packings are general packings). 1 sorry: g_ap_set_nonempty (needs explicit tiny-square construction).",
+    "assumptions": "6 axiom declarations: rotated_square_area (rotation preserves area), f_rot_bounded (Cauchy-Schwarz √n bound), f_rot_mono (monotone), g_ap_perfect_square (g(k²)=k), bku_theorem_ap (BKU 2024 result), f_rot_2 (Erdős f_rot(2)=1). ELIMINATED: g_ap_bounded (proved from f_rot_bounded + g_ap≤f_rot), f_rot_perfect_square (proved from g_ap_perfect_square + f_rot_bounded + g_ap≤f_rot). New: side_le_sqrt_two (contained squares have side≤√2), g_ap_le_f_rot (AP packings are general packings). 0 sorries.",
     "lineCount": 455
   },
   "overview": {

--- a/src/data/proofs/hilbert-22-oq-01/meta.json
+++ b/src/data/proofs/hilbert-22-oq-01/meta.json
@@ -15,10 +15,10 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 0,
     "lineCount": 156,
-    "assumptions": "0 axioms, 1 sorry (IsKobayashiHyperbolic definition). Previously listed axioms (yau_theorem, disk_kobayashi_hyperbolic, plane_not_hyperbolic) do not exist in the file.",
+    "assumptions": "0 axioms, 0 sorries. IsKobayashiHyperbolic defined via Brody's theorem criterion.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "originalContributions": [

--- a/src/data/proofs/yang-mills/meta.json
+++ b/src/data/proofs/yang-mills/meta.json
@@ -22,7 +22,7 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Lie.Basic",


### PR DESCRIPTION
## Fix

Corrects sorry counts in meta.json for 4 gallery proofs where the count was higher than actual sorries in the Lean source (block-comment mentions of "sorry" had been counted as actual sorries).

## Evidence

| Proof | Before | After | Reason |
|-------|--------|-------|--------|
| hilbert-22-oq-01 | sorries=1 | sorries=0 | Sorry was in a removed definition |
| erdos-106-oq-02 | sorries=1 | sorries=0 | Sorry was eliminated |
| yang-mills | sorries=1 | sorries=0 | Wrapper file has no code, only imports |
| area-of-circle-oq-05 | sorries=2 | sorries=1 | One sorry was proved |

Verified by stripping block comments (`/- ... -/`) and line comments (`--`) before counting `\bsorry\b` matches.

---
Automated fix by lean-mechanic agent.