### PR TITLE
Fix: inverse-galois-oq-02 meta.json schema compliance

### DIFF
--- a/src/data/proofs/inverse-galois-oq-02/meta.json
+++ b/src/data/proofs/inverse-galois-oq-02/meta.json
@@ -147,7 +147,9 @@
       "Is M₂₃ a Galois group over ℚ? (The central open question)",
       "Can middle convolution specialization from ℚ(t) to ℚ be completed for M₂₃?",
       "Does M₂₃'s connection to the binary Golay code suggest coding-theoretic approaches to realizability?"
-    ]
+    ],
+    "summary": "M₂₃ is axiomatized as a simple subgroup of S₂₃ with |M₂₃| = 10200960 = 2⁷·3²·5·7·11·23. We establish it is perfect and not solvable, placing it beyond the reach of Shafarevich's theorem. The realizability of M₂₃ as a Galois group over ℚ remains open — the last sporadic simple group with unknown status.",
+    "implications": "Resolving M₂₃ realizability would complete the sporadic group chapter of the Inverse Galois Problem, demonstrating all 26 sporadic simple groups are Galois groups over ℚ."
   },
   "crossReferences": [
     {


### PR DESCRIPTION
Add missing summary/implications to conclusion, rename section description→summary to fix build.