### PR TITLE
Research: newton-inductive-step-oq-02 + feuerbachs-theorem-oq-02

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ02OQ04OQ01.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ04OQ01.lean
@@ -3,6 +3,7 @@ import Mathlib.FieldTheory.IntermediateField.Basic
 import Mathlib.GroupTheory.PGroup
 import Mathlib.FieldTheory.Tower
 import Mathlib.Tactic
+import Proofs.AngleTrisectionOQ02
 
 /-
 # Tower ↔ Galois 2-Group Equivalence via Mathlib
@@ -90,7 +91,10 @@ theorem quadratic_tower_degree (K : IntermediateField ℚ ℝ) (n : ℕ)
     obtain ⟨hfinK, hrank⟩ := ih
     constructor
     · exact IntermediateField.finiteDimensional_of_le_of_finiteDimensional hKL
-    · sorry -- finrank ℚ L = finrank ℚ K * finrank K L = 2^n * 2 = 2^(n+1)
+    · -- finrank ℚ L = finrank ℚ K * finrank K L = 2^n * 2 = 2^(n+1)
+      haveI := hfinK
+      rw [pow_succ, ← hrank, ← hdeg]
+      exact (Module.finrank_mul_finrank ℚ (↥K) (↥L)).symm
 
 /-- A number in a quadratic tower satisfies the degree criterion -/
 theorem tower_satisfies_degree (α : ℝ) (hα : ConstructibleViaTower α) :
@@ -112,8 +116,26 @@ theorem tower_satisfies_degree (α : ℝ) (hα : ConstructibleViaTower α) :
 theorem exists_index_two_subgroup {G : Type*} [Group G] [Fintype G]
     (hG : IsPGroup 2 G) (hnt : Fintype.card G > 1) :
     ∃ H : Subgroup G, H.index = 2 := by
-  sorry -- Follows from: center of p-group is non-trivial, quotient by
-       -- central element of order 2 gives subgroup of index 2
+  -- Standard proof: |G| = 2^n, get subgroup of order 2^(n-1) → index 2
+  obtain ⟨n, hn⟩ := IsPGroup.iff_card.mp hG
+  rw [Nat.card_eq_fintype_card] at hn
+  -- n ≥ 1 since |G| > 1
+  have hn1 : 1 ≤ n := by
+    rcases n with _ | n
+    · simp at hn; omega
+    · omega
+  -- 2^(n-1) divides |G| = 2^n
+  haveI : Fact (Nat.Prime 2) := Fact.mk (by norm_num)
+  have hdvd : 2 ^ (n - 1) ∣ Fintype.card G := by
+    rw [hn]; exact Nat.pow_dvd_pow 2 (Nat.sub_le n 1)
+  -- Sylow theory: there exists a subgroup of order 2^(n-1)
+  obtain ⟨H, hH⟩ := Sylow.exists_subgroup_card_pow_prime _ hdvd
+  refine ⟨H, ?_⟩
+  -- card H * H.index = card G, so 2^(n-1) * H.index = 2^n
+  have hmi := H.card_mul_index
+  rw [hH, hn, show n = (n - 1) + 1 from by omega, pow_succ] at hmi
+  -- hmi : 2 ^ (n - 1) * H.index = 2 ^ (n - 1) * 2
+  exact Nat.eq_of_mul_eq_left (by positivity) hmi
 
 /-- The order of a finite 2-group is a power of 2 -/
 theorem two_group_card_pow_two {G : Type*} [Group G] [Fintype G]
@@ -233,9 +255,9 @@ theorem tower_iff_galois_two_group (α : ℝ) (hα : IsIntegral ℚ α) :
    (Mathlib defines Galois groups of polynomials and Galois groups of
    extensions separately; bridging these needs ~100 lines)
 
-2. ❌ `exists_index_two_subgroup` for 2-groups
-   (Standard but not directly in Mathlib — proof goes via center of p-group
-   being non-trivial, then quotienting by order-2 central element)
+2. ✅ `exists_index_two_subgroup` for 2-groups — NOW PROVED
+   (Via Sylow.exists_subgroup_card_pow_prime: get subgroup of order 2^(n-1),
+   then index = 2^n / 2^(n-1) = 2)
 
 3. ❌ Index-degree relation: [G : H] = [Fix(H) : K]
    (Available in Mathlib for Galois extensions, but the API connection
@@ -268,10 +290,11 @@ theorem sqrt2_constructible_tower :
       QuadraticTower ℚ ℝ K 1 ∧ (Real.sqrt 2 : ℝ) ∈ K := by
   sorry -- Needs: construction of ℚ(√2) as IntermediateField with degree 2
 
-/-- The Galois group of x² - 2 is ℤ/2ℤ, which is a 2-group -/
+/-- The Galois group of x² - 2 is ℤ/2ℤ, which is a 2-group.
+    Proved in AngleTrisectionOQ02.lean via divisibility squeeze. -/
 theorem gal_x2_minus_2_is_two_group :
-    IsPGroup 2 (X ^ 2 - C 2 : ℚ[X]).Gal := by
-  sorry -- Gal(x²-2) ≅ ℤ/2ℤ has order 2 = 2^1
+    IsPGroup 2 (X ^ 2 - C 2 : ℚ[X]).Gal :=
+  x_sq_sub_2_gal_is_2group
 
 -- ============================================================
 -- PART 9: Summary of What's Proved vs Axiomatized
@@ -281,27 +304,27 @@ theorem gal_x2_minus_2_is_two_group :
 ## Results Summary
 
 ### Proved (0 axioms):
-1. `quadratic_tower_degree`: QuadraticTower height n → degree = 2^n (partial; needs finrank multiplicativity)
+1. `quadratic_tower_degree`: QuadraticTower height n → degree = 2^n (FULLY PROVED via finrank_mul_finrank)
 2. `tower_satisfies_degree`: ConstructibleViaTower → DegreeCriterion
-3. `two_group_card_pow_two`: |G| = 2^n for 2-groups
-4. `two_group_order_one`: trivial 2-group characterization
-5. `two_group_subgroup`: subgroups of 2-groups are 2-groups (Mathlib)
-6. `two_group_solvable`: 2-groups are solvable (Mathlib)
-7. `tower_iff_galois_two_group`: full equivalence (combines two directions)
+3. `exists_index_two_subgroup`: non-trivial 2-group has index-2 subgroup (PROVED via Sylow)
+4. `two_group_card_pow_two`: |G| = 2^n for 2-groups
+5. `two_group_order_one`: trivial 2-group characterization
+6. `two_group_subgroup`: subgroups of 2-groups are 2-groups (Mathlib)
+7. `two_group_solvable`: 2-groups are solvable (Mathlib)
+8. `gal_x2_minus_2_is_two_group`: Gal(x²-2/ℚ) is a 2-group (from AngleTrisectionOQ02)
+9. `tower_iff_galois_two_group`: full equivalence (combines two directions)
 
-### Sorries (5 — deep results requiring substantial work):
-1. `quadratic_tower_degree` (sorry in step case): needs finrank multiplicativity for intermediate fields
-2. `exists_index_two_subgroup`: index-2 subgroup in non-trivial 2-group
-3. `galois_two_group_implies_tower`: Galois 2-group → quadratic tower
-4. `tower_implies_galois_two_group`: quadratic tower → Galois 2-group
-5. `sqrt2_constructible_tower`: concrete example
-6. `gal_x2_minus_2_is_two_group`: concrete example
+### Sorries (3 — deep results requiring Galois correspondence glue):
+1. `galois_two_group_implies_tower`: Galois 2-group → quadratic tower (~500 lines)
+2. `tower_implies_galois_two_group`: quadratic tower → Galois 2-group (~300 lines)
+3. `sqrt2_constructible_tower`: concrete example (needs ℚ(√2) construction)
 
 ### Key Contribution
 The proper inductive definition of `QuadraticTower` replaces the previous alias
-`TowerCriterion = DegreeCriterion` with a mathematically correct formulation,
-and the feasibility analysis identifies exactly where Mathlib's API needs
-extension to complete the proof.
+`TowerCriterion = DegreeCriterion` with a mathematically correct formulation.
+The tower degree theorem and index-2 subgroup lemma are now fully proved,
+establishing the key building blocks. The remaining gap is the Galois
+correspondence glue connecting Polynomial.Gal to IntermediateField.
 -/
 
 #check QuadraticTower

--- a/proofs/Proofs/FeuerbachsTheoremOQ02.lean
+++ b/proofs/Proofs/FeuerbachsTheoremOQ02.lean
@@ -91,6 +91,14 @@ def cross3 (u v : ℝ × ℝ × ℝ) : ℝ × ℝ × ℝ :=
    u.2.2 * v.1 - u.1 * v.2.2,
    u.1 * v.2.1 - u.2.1 * v.1)
 
+/-- Scalar triple product with repeated first and third argument is zero -/
+private lemma dot3_cross3_self_left (u v : ℝ × ℝ × ℝ) : dot3 u (cross3 u v) = 0 := by
+  unfold dot3 cross3; ring
+
+/-- Scalar triple product with repeated first and second argument is zero -/
+private lemma dot3_cross3_self_right (u v : ℝ × ℝ × ℝ) : dot3 u (cross3 v u) = 0 := by
+  unfold dot3 cross3; ring
+
 -- ============================================================
 -- PART 2: Tetrahedron Structure
 -- ============================================================
@@ -234,16 +242,87 @@ def Tetrahedron.faceCentroid_D (T : Tetrahedron) : Point3 :=
 -- PART 6: Circumsphere and Monge Point
 -- ============================================================
 
-/-- The circumcenter of a tetrahedron is equidistant from all four vertices.
-    We define it as the solution to the linear system arising from
-    |O - A|² = |O - B|² = |O - C|² = |O - D|². -/
-axiom Tetrahedron.circumcenter (T : Tetrahedron) : Point3
+/-- The circumcenter of a tetrahedron, defined via Cramer's rule.
+    Given edge vectors u = B-A, v = C-A, w = D-A, the circumcenter O = A + P where
+    P = (1/(2·det)) · ((u·u)(v×w) + (v·v)(w×u) + (w·w)(u×v))
+    and det = u·(v×w) is the scalar triple product (nonzero by nondegeneracy). -/
+noncomputable def Tetrahedron.circumcenter (T : Tetrahedron) : Point3 :=
+  let u := vec3 T.A T.B
+  let v := vec3 T.A T.C
+  let w := vec3 T.A T.D
+  let det := dot3 u (cross3 v w)
+  let vw := cross3 v w
+  let wu := cross3 w u
+  let uv := cross3 u v
+  let uu := dot3 u u
+  let vv := dot3 v v
+  let ww := dot3 w w
+  let s := 1 / (2 * det)
+  ( T.A.1 + s * (uu * vw.1 + vv * wu.1 + ww * uv.1),
+    T.A.2.1 + s * (uu * vw.2.1 + vv * wu.2.1 + ww * uv.2.1),
+    T.A.2.2 + s * (uu * vw.2.2 + vv * wu.2.2 + ww * uv.2.2) )
 
-/-- The circumcenter is equidistant from all four vertices -/
-axiom Tetrahedron.circumcenter_equidist (T : Tetrahedron) :
+/-- Helper: the circumcenter displacement P = O - A satisfies 2·dot3(u, P) = dot3(u, u),
+    i.e., P solves the circumcenter system for the u = B-A equation.
+    Proof: by Cramer's rule, dot3(u, P) uses dot3(u, v×w) = det and
+    dot3(u, w×u) = dot3(u, u×v) = 0 (scalar triple product with repeated vector). -/
+private lemma circumcenter_dot_eq (T : Tetrahedron) :
+    let u := vec3 T.A T.B
+    let v := vec3 T.A T.C
+    let w := vec3 T.A T.D
+    let det := dot3 u (cross3 v w)
+    let P := vec3 T.A T.circumcenter
+    2 * dot3 u P = dot3 u u := by
+  simp only [Tetrahedron.circumcenter, vec3, dot3, cross3]
+  have hdet : dot3 (vec3 T.A T.B) (cross3 (vec3 T.A T.C) (vec3 T.A T.D)) ≠ 0 :=
+    T.nondegenerate
+  field_simp [vec3, dot3, cross3] at hdet ⊢
+  ring
+
+/-- Helper: similar for v = C-A -/
+private lemma circumcenter_dot_eq_v (T : Tetrahedron) :
+    let u := vec3 T.A T.B
+    let v := vec3 T.A T.C
+    let w := vec3 T.A T.D
+    let P := vec3 T.A T.circumcenter
+    2 * dot3 v P = dot3 v v := by
+  simp only [Tetrahedron.circumcenter, vec3, dot3, cross3]
+  have hdet : dot3 (vec3 T.A T.B) (cross3 (vec3 T.A T.C) (vec3 T.A T.D)) ≠ 0 :=
+    T.nondegenerate
+  field_simp [vec3, dot3, cross3] at hdet ⊢
+  ring
+
+/-- Helper: similar for w = D-A -/
+private lemma circumcenter_dot_eq_w (T : Tetrahedron) :
+    let u := vec3 T.A T.B
+    let v := vec3 T.A T.C
+    let w := vec3 T.A T.D
+    let P := vec3 T.A T.circumcenter
+    2 * dot3 w P = dot3 w w := by
+  simp only [Tetrahedron.circumcenter, vec3, dot3, cross3]
+  have hdet : dot3 (vec3 T.A T.B) (cross3 (vec3 T.A T.C) (vec3 T.A T.D)) ≠ 0 :=
+    T.nondegenerate
+  field_simp [vec3, dot3, cross3] at hdet ⊢
+  ring
+
+/-- The circumcenter is equidistant from all four vertices.
+    Proof: |OB|² - |OA|² = |u|² - 2(u·P) = |u|² - |u|² = 0, where P = O - A
+    and the system equation 2(u·P) = |u|² holds by Cramer's rule. -/
+theorem Tetrahedron.circumcenter_equidist (T : Tetrahedron) :
   dist3_sq T.circumcenter T.A = dist3_sq T.circumcenter T.B ∧
   dist3_sq T.circumcenter T.A = dist3_sq T.circumcenter T.C ∧
-  dist3_sq T.circumcenter T.A = dist3_sq T.circumcenter T.D
+  dist3_sq T.circumcenter T.A = dist3_sq T.circumcenter T.D := by
+  -- Strategy: dist3_sq O X = ∑(Xi - Oi)². For X ∈ {B,C,D}, express Xi - Oi = (Xi - Ai) - Pi
+  -- Then dist3_sq O X - dist3_sq O A = |u|² - 2(u·P) where u = X - A, P = O - A
+  -- By the circumcenter_dot_eq lemmas, 2(u·P) = |u|², so the difference is 0.
+  refine ⟨?_, ?_, ?_⟩ <;> {
+    simp only [dist3_sq, Tetrahedron.circumcenter, vec3, dot3, cross3]
+    have hdet : dot3 (vec3 T.A T.B) (cross3 (vec3 T.A T.C) (vec3 T.A T.D)) ≠ 0 :=
+      T.nondegenerate
+    simp only [vec3, dot3, cross3] at hdet
+    field_simp
+    ring
+  }
 
 /-- Circumradius: distance from circumcenter to any vertex -/
 def Tetrahedron.circumradius (T : Tetrahedron) : ℝ :=

--- a/proofs/Proofs/NewtonInductiveStepOQ01.lean
+++ b/proofs/Proofs/NewtonInductiveStepOQ01.lean
@@ -120,13 +120,17 @@ We prove Newton's inequality in the "binomial mean" form:
 This is equivalent to ē_k² ≥ ē_{k-1} · ē_{k+1} where ē_k = e_k / C(n,k).
 -/
 
-/-- Newton's inequality (unnormalized form):
-    C(n,k)² · e_k(x₁,...,xₙ)² ≥ C(n,k-1) · C(n,k+1) · e_{k-1} · e_{k+1}
-    for all nonneg x₁,...,xₙ and 1 ≤ k ≤ n-1. -/
+/-- Newton's inequality (standard form):
+    C(n,k-1) · C(n,k+1) · e_k² ≥ C(n,k)² · e_{k-1} · e_{k+1}
+    for all nonneg x₁,...,xₙ and 1 ≤ k ≤ n-1.
+
+    This is equivalent to the mean form ē_k² ≥ ē_{k-1}·ē_{k+1}
+    where ē_k = e_k/C(n,k) are the elementary symmetric means. -/
 theorem newton_inequality_binomial (xs : List ℝ) (hxs : ∀ x ∈ xs, (0 : ℝ) ≤ x)
     (k : ℕ) (hk : 1 ≤ k) (hkn : k + 1 ≤ xs.length) :
-    (Nat.choose xs.length k : ℝ) ^ 2 * esymm xs k ^ 2 ≥
     (Nat.choose xs.length (k - 1) : ℝ) * (Nat.choose xs.length (k + 1) : ℝ) *
+    esymm xs k ^ 2 ≥
+    (Nat.choose xs.length k : ℝ) ^ 2 *
     (esymm xs (k - 1) * esymm xs (k + 1)) := by
   -- Proved by induction on xs
   induction xs generalizing k with
@@ -236,9 +240,23 @@ noncomputable def esymmMean (xs : List ℝ) (k : ℕ) : ℝ :=
 theorem newton_inequality_means (xs : List ℝ) (hxs : ∀ x ∈ xs, (0 : ℝ) ≤ x)
     (k : ℕ) (hk : 1 ≤ k) (hkn : k + 1 ≤ xs.length) :
     esymmMean xs k ^ 2 ≥ esymmMean xs (k - 1) * esymmMean xs (k + 1) := by
-  -- This follows from newton_inequality_binomial by dividing both sides
-  -- by C(n,k)² (which is positive for valid k).
-  sorry
+  -- Follows from newton_inequality_binomial: the mean form is just the
+  -- binomial form with denominators cleared.
+  have hni := newton_inequality_binomial xs hxs k hk hkn
+  -- Binomial coefficients are positive for valid k
+  set n := xs.length with hn
+  have hckm : (0 : ℝ) < Nat.choose n (k - 1) :=
+    Nat.cast_pos.mpr (Nat.choose_pos (by omega))
+  have hck : (0 : ℝ) < Nat.choose n k :=
+    Nat.cast_pos.mpr (Nat.choose_pos (by omega))
+  have hckp : (0 : ℝ) < Nat.choose n (k + 1) :=
+    Nat.cast_pos.mpr (Nat.choose_pos (by omega))
+  -- Unfold and clear fractions
+  unfold esymmMean
+  rw [ge_iff_le, div_pow, div_mul_div_comm,
+      div_le_div_iff (mul_pos hckm hckp) (pow_pos hck 2)]
+  -- Goal: esymm (k-1) * esymm (k+1) * C(n,k)^2 ≤ esymm k^2 * (C(n,k-1) * C(n,k+1))
+  linarith
 
 /-! ## Consequences of Newton's inequality -/
 
@@ -316,8 +334,8 @@ namespace NewtonInductiveStepOQ01
 
 /-! ## Summary
 
-We formalize Newton's inequality e_k² ≥ e_{k-1} · e_{k+1} for elementary
-symmetric polynomials of nonneg reals. Key results:
+We formalize Newton's inequality for elementary symmetric polynomials
+of nonneg reals. Key results:
 
 1. **esymm**: Definition of elementary symmetric polynomials on real lists
 2. **esymm_nonneg**: Nonnegativity for nonneg inputs
@@ -327,10 +345,10 @@ symmetric polynomials of nonneg reals. Key results:
 6. **maclaurin_first_step**: First Maclaurin inequality ē₁² ≥ ē₂
 
 The full inductive proof (newton_inequality_binomial) is stated with the
-correct type and the inductive structure sketched. The key difficulty is the
-careful bookkeeping of the two-term recurrence through the Cauchy-Schwarz step.
+correct standard Newton inequality (C(n,k-1)·C(n,k+1)·e_k² ≥ C(n,k)²·e_{k-1}·e_{k+1}).
+The mean form (newton_inequality_means) is derived from it by clearing fractions.
 
-0 axioms. 2 sorries (general inductive cases — deep polynomial bookkeeping).
+0 axioms. 1 sorry (newton_inequality_binomial — the inductive Cauchy-Schwarz step).
 -/
 
 end NewtonInductiveStepOQ01

--- a/src/data/proofs/angle-trisection-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-04-oq-01/meta.json
@@ -17,7 +17,7 @@
     ],
     "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ04OQ01.lean",
     "badge": "formalized",
-    "sorries": 6,
+    "sorries": 3,
     "mathlibDependencies": [
       {
         "theorem": "IsPGroup.isSolvable",
@@ -48,13 +48,14 @@
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
     "lineCount": 311,
-    "assumptions": "No axioms. 6 sorries for deep theorems requiring Mathlib API glue: finrank multiplicativity for intermediate fields, index-2 subgroup existence, both directions of Tower ↔ Galois, and concrete examples.",
+    "assumptions": "No axioms. 3 sorries remain for deep theorems requiring Galois correspondence glue: both directions of Tower ↔ Galois equivalence and the ℚ(√2) concrete example. Proved: quadratic_tower_degree (finrank multiplicativity), exists_index_two_subgroup (Sylow), gal_x2_minus_2_is_two_group (imported).",
     "originalContributions": [
       "Proper inductive definition of QuadraticTower replacing the alias TowerCriterion = DegreeCriterion",
       "Statement and proof structure of Tower ↔ Galois 2-group equivalence",
       "Feasibility analysis identifying exactly which Mathlib API connections are missing",
-      "Proof that tower degree = 2^n by structural induction (modulo finrank multiplicativity)",
-      "Key 2-group lemmas: existence of index-2 subgroups, trivial characterization"
+      "Full proof that quadratic tower of height n has degree 2^n via finrank_mul_finrank tower law",
+      "Proof that every non-trivial 2-group has index-2 subgroup via Sylow subgroup existence",
+      "Connection to AngleTrisectionOQ02: imported Gal(x²-2) is a 2-group result"
     ]
   },
   "overview": {

--- a/src/data/proofs/feuerbachs-theorem-oq-02/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-02/meta.json
@@ -28,9 +28,9 @@
       }
     ],
     "dateAdded": "2026-03-30",
-    "axiomCount": 5,
+    "axiomCount": 3,
     "lineCount": 586,
-    "assumptions": "5 axioms: circumcenter existence/equidistance (2), counterexample for general tetrahedra (1), edge midpoints on sphere (1), face centroids on sphere (1). 5 sorries for the main Feuerbach tangency theorems (insphere + 4 exspheres).",
+    "assumptions": "3 axioms: feuerbach_3d_fails_general (structural), edge_midpoints_on_sphere (deep geometric), face_centroids_on_sphere (deep geometric). 5 sorries for tangency theorems. Circumcenter defined via Cramer rule (previously axiomatized).",
     "originalContributions": [
       "Complete 3D coordinate geometry infrastructure for tetrahedra in Lean 4",
       "Formalization of orthocentric tetrahedra with proof that third perpendicularity follows from first two",


### PR DESCRIPTION
## Summary
Two research improvements in a single branch:

### 1. Newton's Inequality (NewtonInductiveStepOQ01.lean)
- **Bug fix**: Corrected `newton_inequality_binomial` statement — the original had binomial coefficients on the wrong side, making it too weak to derive the mean form
- **Proved** `newton_inequality_means` from the corrected binomial form by clearing fractions
- Net: 2 sorries → 1 sorry

### 2. Feuerbach 3D (FeuerbachsTheoremOQ02.lean)  
- **Eliminated 2 axioms**: Replaced axiom `circumcenter` with Cramer's rule definition
- **Proved** `circumcenter_equidist` via scalar triple product identities
- Net: 5 axioms → 3 axioms

## Status
**Outcome**: progress (1 sorry eliminated, 2 axioms eliminated, 1 bug fix)

🤖 Generated by researcher-3