### PR TITLE
Fix: erdos-525-oq-02 sorries=0 not 1

### DIFF
--- a/src/data/proofs/erdos-525-oq-02/meta.json
+++ b/src/data/proofs/erdos-525-oq-02/meta.json
@@ -18,10 +18,10 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 1,
     "lineCount": 143,
-    "assumptions": "1 axiom (min_modulus_1d_bound), 1 sorry (min_modulus definition).",
+    "assumptions": "1 axiom (min_modulus_1d_bound). 0 sorries.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "originalContributions": [


### PR DESCRIPTION
## Summary

- Lean source has **0 sorries** (min_modulus definition sorry was resolved)
- 1 axiom (`min_modulus_1d_bound`) remains correct
- Updated `meta.sorries` and `assumptions` text

## Test plan

- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)