### PR TITLE
fix(audit): correct sorry count for inverse-galois-oq-02 (5→6)

### DIFF
--- a/src/data/proofs/inverse-galois-oq-02/meta.json
+++ b/src/data/proofs/inverse-galois-oq-02/meta.json
@@ -22,7 +22,7 @@
       "Proofs/InverseGaloisOQ01.lean"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 6,
     "axiomCount": 3,
     "prerequisites": [
       "Galois theory (Galois groups, splitting fields)",


### PR DESCRIPTION
## Summary

- The Lean file `InverseGaloisOQ02.lean` contains **6 sorries** (lines 182, 201, 219, 269, 356, 361)
- `meta.json` outer `sorries` field was **5** (mismatch)
- `leanFile.sorryCount` already correctly reported **6** — now the top-level field is aligned

## Evidence

The 6 actual sorries:
1. Line 182 — `M23_not_commutative`
2. Line 201 — `M23_commutator_eq_top`
3. Line 219 — `M23_not_solvable`
4. Line 269 — Open problem (intentional `sorry`)
5. Line 356 — Element of order 23 (Cauchy's theorem)
6. Line 361 — Sylow 2 subgroup card

## Test plan

- [x] Verify `grep -c "sorry" proofs/Proofs/InverseGaloisOQ02.lean` returns 7 (including one in a comment), actual sorries = 6
- [x] `leanFile.sorryCount` field already said 6 — outer field now consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)