### PR TITLE
Enrich Galois's Solvability Criterion

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-03/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-03/annotations.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "ann-imports",
+    "proofId": "abel-ruffini-oq-04-oq-03",
+    "range": { "startLine": 1, "endLine": 5 },
+    "type": "context",
+    "title": "Mathlib Dependencies and Setup",
+    "content": "The proof draws on three major areas of Mathlib. `FieldTheory.AbelRuffini` provides the foundational theory of solvability by radicals including the type `IsSolvableByRad` and the key theorem `solvableByRad.isSolvable'`. `GroupTheory.Solvable` provides the `IsSolvable` predicate for groups and the machinery of subnormal series. `FieldTheory.Galois.Basic` provides the Galois group functor `Polynomial.Gal` and basic results about Galois correspondence. The proof is stated in full generality over abstract fields F and E connected by an algebra structure, so results apply to any field extension — not just over ℚ. The `noncomputable` annotation is required because field theory in Lean involves non-constructive existence proofs.",
+    "mathContext": "The Galois group of a polynomial $q \\in F[x]$ is $\\operatorname{Gal}(q) = \\operatorname{Aut}(\\text{SplittingField}(q)/F)$, the group of field automorphisms of the splitting field fixing $F$. An extension $E/F$ with an algebra structure means there is a ring homomorphism $F \\to E$ making $E$ an $F$-vector space.",
+    "significance": "context",
+    "relatedConcepts": ["splitting field", "Galois correspondence", "solvable group", "algebra homomorphism"],
+    "prerequisites": ["field extensions", "group theory", "Galois theory basics", "type classes in Lean"]
+  },
+  {
+    "id": "ann-forward-direction",
+    "proofId": "abel-ruffini-oq-04-oq-03",
+    "range": { "startLine": 56, "endLine": 68 },
+    "type": "technique",
+    "title": "Forward Direction: Radical Solvability Implies Solvable Galois Group",
+    "content": "This is the easier direction of Galois's criterion, proved by a single application of Mathlib's `solvableByRad.isSolvable'`. The key idea is that a radical tower $F \\subset F(\\alpha_1) \\subset \\cdots \\subset K \\ni \\alpha$ produces a sequence of Galois groups with cyclic quotients at each step: adding a radical $\\sqrt[n]{\\beta}$ either does nothing to the Galois group or produces a cyclic extension. A group built from cyclic extensions in a subnormal series is solvable by definition. The fact that this single-line proof works reflects how deeply Mathlib has formalized radical extension theory.",
+    "mathContext": "If $\\alpha$ is solvable by radicals, there exists a tower $F = K_0 \\subset K_1 \\subset \\cdots \\subset K_m$ with $\\alpha \\in K_m$ and each $K_{i+1} = K_i(\\sqrt[n_i]{\\beta_i})$. The Galois group filtration $\\operatorname{Gal}(K_m/F) \\supset \\operatorname{Gal}(K_m/K_1) \\supset \\cdots$ has cyclic quotients $\\operatorname{Gal}(K_{i+1}/K_i) \\cong \\mathbb{Z}/n_i\\mathbb{Z}$, making $\\operatorname{Gal}(K_m/F)$ solvable. Since $\\operatorname{Gal}(q)$ embeds in $\\operatorname{Gal}(K_m/F)$ and subgroups of solvable groups are solvable, $\\operatorname{Gal}(q)$ is solvable.",
+    "significance": "key",
+    "relatedConcepts": ["radical tower", "cyclic extension", "solvable group", "IsSolvableByRad"],
+    "prerequisites": ["Galois correspondence", "tower theorem for field extensions", "cyclic groups"]
+  },
+  {
+    "id": "ann-contrapositive",
+    "proofId": "abel-ruffini-oq-04-oq-03",
+    "range": { "startLine": 70, "endLine": 76 },
+    "type": "insight",
+    "title": "Contrapositive: The Logical Heart of Abel-Ruffini",
+    "content": "The contrapositive of the forward direction — an unsolvable Galois group implies no radical formula exists — is the logical core of the Abel-Ruffini theorem. The proof is a trivial logical manipulation (function application and negation introduction), but its mathematical content is profound: it says that whenever we can detect group non-solvability (e.g., S₅ contains A₅ which is simple non-abelian), we can immediately certify that no radical formula exists for that polynomial. This is why group-theoretic computations can decide algebraic unsolvability.",
+    "mathContext": "The theorem states: if $\\neg \\operatorname{IsSolvable}(\\operatorname{Gal}(q))$, then $\\neg \\operatorname{IsSolvableByRad}(F, \\alpha)$. This is $\\lnot B \\Rightarrow \\lnot A$ given $A \\Rightarrow B$, proved constructively as a function: given a proof of $A$ (solvability by radicals), apply the forward direction to get $B$ (solvable Gal group), contradicting $\\lnot B$.",
+    "significance": "key",
+    "relatedConcepts": ["Abel-Ruffini theorem", "contrapositive", "S₅", "A₅ simplicity"],
+    "prerequisites": ["propositional logic", "solvable groups", "forward direction"]
+  },
+  {
+    "id": "ann-kummer-commentary",
+    "proofId": "abel-ruffini-oq-04-oq-03",
+    "range": { "startLine": 82, "endLine": 96 },
+    "type": "context",
+    "title": "Why Kummer Theory Is the Missing Ingredient",
+    "content": "This inline comment explains the mathematical gap preventing full formalization. The reverse direction requires constructing an explicit radical tower from the composition series of a solvable group. The key step is: given a cyclic Galois extension $L/K$ of prime degree $p$ where $K$ contains a primitive $p$-th root of unity $\\zeta_p$, Kummer theory guarantees $L = K(\\sqrt[p]{\\beta})$ for some $\\beta \\in K$. Iterating this over the composition series produces the radical tower. The characteristic 0 assumption ensures $\\zeta_p$ can always be adjoined without blowing up the Galois group structure.",
+    "mathContext": "Kummer's theorem: if $\\operatorname{char}(K) \\nmid n$ and $K$ contains all $n$-th roots of unity, then cyclic extensions of $K$ of degree $n$ are exactly the extensions $K(\\sqrt[n]{a})$ for $a \\in K$. For the reverse direction, one adjoin $\\zeta_p$ (a finite cyclic extension) then $\\sqrt[p]{\\beta}$ at each step, composing these into $K = F(\\zeta_{p_1})(\\sqrt[p_1]{\\beta_1})(\\zeta_{p_2})(\\sqrt[p_2]{\\beta_2}) \\cdots \\ni \\alpha$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Kummer theory", "cyclic extension", "composition series", "roots of unity"],
+    "prerequisites": ["solvable group composition series", "cyclotomic extensions", "Galois correspondence"]
+  },
+  {
+    "id": "ann-axiom",
+    "proofId": "abel-ruffini-oq-04-oq-03",
+    "range": { "startLine": 98, "endLine": 107 },
+    "type": "definition",
+    "title": "The Axiomatized Reverse Direction",
+    "content": "This `axiom` declaration formally encodes the unproved assumption that a solvable Galois group implies radical solvability. In Lean 4, `axiom` is logically equivalent to `theorem ... := by sorry` but makes the assumption explicit and permanent: it cannot be accidentally filled in. The `[CharZero F]` typeclass constraint encodes the characteristic 0 hypothesis. This axiom represents the precise Mathlib frontier: once `Mathlib.FieldTheory.KummerExtension` is sufficiently developed to handle this direction, this axiom can be replaced by a theorem.",
+    "mathContext": "The axiom states: $\\forall q, \\forall \\alpha \\in E, \\operatorname{char}(F) = 0 \\Rightarrow q(\\alpha) = 0 \\Rightarrow q$ irreducible $\\Rightarrow \\operatorname{IsSolvable}(\\operatorname{Gal}(q)) \\Rightarrow \\operatorname{IsSolvableByRad}(F, \\alpha)$.",
+    "significance": "key",
+    "relatedConcepts": ["axiom in Lean", "Kummer theory", "CharZero", "IsSolvable"],
+    "prerequisites": ["Lean 4 axioms vs theorems", "characteristic 0 fields", "solvable groups"]
+  },
+  {
+    "id": "ann-full-criterion",
+    "proofId": "abel-ruffini-oq-04-oq-03",
+    "range": { "startLine": 113, "endLine": 125 },
+    "type": "insight",
+    "title": "The Full Biconditional: Galois's Criterion",
+    "content": "This theorem assembles both directions into the complete iff statement. The proof is an anonymous constructor `⟨fun h => ..., fun h => ...⟩` for the biconditional, with each direction simply applying the appropriate theorem. The elegance of this assembly reflects Galois's original insight: solvability by radicals and group solvability are two descriptions of exactly the same mathematical phenomenon, one analytic and one algebraic. This is perhaps the first great example of a 'dictionary' between analysis and algebra in the history of mathematics.",
+    "mathContext": "$\\alpha$ is solvable by radicals over $F$ $\\iff$ $\\operatorname{Gal}(q)$ is a solvable group, where $q$ is the minimal polynomial of $\\alpha$ over $F$ (irreducible hypothesis), $\\operatorname{char}(F) = 0$.",
+    "significance": "key",
+    "relatedConcepts": ["Galois correspondence", "biconditional", "radical solvability", "solvable group"],
+    "prerequisites": ["forward and reverse directions", "iff in Lean"]
+  },
+  {
+    "id": "ann-rationals-specialization",
+    "proofId": "abel-ruffini-oq-04-oq-03",
+    "range": { "startLine": 131, "endLine": 138 },
+    "type": "technique",
+    "title": "Instantiation to ℚ: The Primary Case",
+    "content": "This corollary specializes the criterion to polynomials over ℚ, which is the primary case of historical and mathematical interest. The proof is immediate because ℚ has characteristic 0 (`[CharZero ℚ]` is a Mathlib instance). This makes the criterion directly applicable to questions like: can $x^5 - 5x + 12$ be solved by radicals? (Answer: compute its Galois group.) The specialization to ℚ is mathematically the most important instance because ℚ is the prime field of characteristic 0.",
+    "mathContext": "Since $\\operatorname{char}(\\mathbb{Q}) = 0$, Galois's criterion specializes to: for $q \\in \\mathbb{Q}[x]$ irreducible with root $\\alpha$, $\\alpha$ is solvable by radicals over $\\mathbb{Q}$ $\\iff$ $\\operatorname{Gal}(q)$ is solvable.",
+    "significance": "supporting",
+    "relatedConcepts": ["rational numbers", "characteristic 0", "polynomial over ℚ"],
+    "prerequisites": ["CharZero typeclass", "Galois criterion over general fields"]
+  },
+  {
+    "id": "ann-solvable-implies-formula",
+    "proofId": "abel-ruffini-oq-04-oq-03",
+    "range": { "startLine": 140, "endLine": 148 },
+    "type": "insight",
+    "title": "Justifying the Classical Formulas (Degree ≤ 4)",
+    "content": "This theorem — an immediate corollary of the reverse direction via `galois_criterion.mpr` — provides the theoretical justification for why quadratic, cubic, and quartic formulas exist. For irreducible polynomials of degree ≤ 4, the Galois group is a transitive subgroup of S₄. Every such subgroup is solvable (S₄ has the solvable series S₄ ⊃ A₄ ⊃ V₄ ⊃ {e} where V₄ is the Klein four-group). By this theorem, a solvable Galois group guarantees a radical formula — explaining Cardano's cubic formula (1545) and Ferrari's quartic formula as mathematical inevitabilities.",
+    "mathContext": "For degree $n \\leq 4$: $\\operatorname{Gal}(q) \\hookrightarrow S_n \\hookrightarrow S_4$, and $S_4$ is solvable via $S_4 \\supset A_4 \\supset V_4 = \\{e, (12)(34), (13)(24), (14)(23)\\} \\supset \\{e\\}$ with quotients $\\mathbb{Z}/2\\mathbb{Z}, \\mathbb{Z}/3\\mathbb{Z}, \\mathbb{Z}/2\\mathbb{Z} \\times \\mathbb{Z}/2\\mathbb{Z}$, all abelian.",
+    "significance": "key",
+    "relatedConcepts": ["S4 solvability", "Klein four-group", "A4", "Cardano's formula", "Ferrari's formula"],
+    "prerequisites": ["symmetric group", "solvable group", "degree bound on Galois groups"]
+  },
+  {
+    "id": "ann-abel-ruffini-special-case",
+    "proofId": "abel-ruffini-oq-04-oq-03",
+    "range": { "startLine": 154, "endLine": 163 },
+    "type": "insight",
+    "title": "Abel-Ruffini as a Special Case of Galois's Criterion",
+    "content": "This theorem formally subsumes the Abel-Ruffini theorem: if we can show a polynomial has an unsolvable Galois group (e.g., S₅), then by `galois_criterion.mp`, any radical expression for its root would yield a solvable Galois group — contradiction. The docstring explicitly notes that the criterion identifies solvability of the Galois group as the COMPLETE obstruction: it is both necessary and sufficient. This is more powerful than Abel-Ruffini, which only gave a sufficient condition for unsolvability (degree ≥ 5 with Galois group S_n). The criterion explains the boundary precisely.",
+    "mathContext": "For $q \\in F[x]$ irreducible with $\\operatorname{char}(F) = 0$: $\\neg \\operatorname{IsSolvable}(\\operatorname{Gal}(q)) \\Rightarrow \\neg \\operatorname{IsSolvableByRad}(F, \\alpha)$. The famous instance: $S_5$ is not solvable (its derived series $S_5 \\supset A_5 \\supset A_5 \\supset \\cdots$ stabilizes at $A_5$ since $A_5$ is perfect), so any polynomial over $\\mathbb{Q}$ with Galois group $S_5$ has no radical formula.",
+    "significance": "key",
+    "relatedConcepts": ["Abel-Ruffini theorem", "S₅ non-solvability", "A₅ simplicity", "derived series"],
+    "prerequisites": ["Galois criterion", "S₅ group theory", "perfect groups"]
+  }
+]

--- a/src/data/proofs/abel-ruffini-oq-04-oq-03/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-03/meta.json
@@ -35,6 +35,86 @@
     "theoremCount": 7,
     "definitionCount": 0
   },
+  "overview": {
+    "historicalContext": "Évariste Galois (1811–1832) developed the foundations of what became Galois theory in a memoir written the night before his fatal duel on May 30, 1832 — at the age of 20. His central insight was to associate to each polynomial a group (now called the Galois group) encoding the symmetries among its roots. Galois's criterion — that a polynomial is solvable by radicals if and only if its Galois group is solvable — is the capstone of this theory and provides the complete algebraic characterization of radical solvability. The work resolved centuries of effort to find explicit root formulas generalizing the quadratic formula. The Abel-Ruffini theorem (Ruffini 1799, Abel 1824) had established that the general quintic polynomial has no radical formula, but Galois identified the exact obstruction: the Galois group must be a solvable group. The very concept of a solvable group originates in this theorem. Galois's memoir was published posthumously by Liouville in 1846 and fundamentally transformed algebra from the study of equations to the study of symmetry and group theory.",
+    "problemStatement": "Let $F$ be a field of characteristic 0, $q \\in F[x]$ an irreducible polynomial, and $\\alpha$ a root of $q$ in some extension $E/F$. The Galois group $\\operatorname{Gal}(q)$ acts by permuting the roots of $q$. Galois's criterion states: $\\alpha$ is expressible by radicals over $F$ (i.e., by nested applications of $+, -, \\times, \\div, \\sqrt[n]{\\cdot}$) if and only if $\\operatorname{Gal}(q)$ is a solvable group — one admitting a subnormal series $1 = G_k \\trianglelefteq \\cdots \\trianglelefteq G_0 = \\operatorname{Gal}(q)$ with abelian quotients.",
+    "proofStrategy": "The proof splits into two directions. The forward direction (fully proved via Mathlib's `solvableByRad.isSolvable'`) uses the fact that radical extensions have solvable Galois groups: a radical tower $F \\subset F(\\alpha_1) \\subset \\cdots \\subset F(\\alpha_1,\\ldots,\\alpha_n) \\ni \\alpha$ produces a filtration of Galois groups with cyclic (hence abelian) quotients, which is precisely the definition of solvable. The reverse direction (axiomatized, requires Kummer theory) constructs the radical tower from the composition series of the solvable Galois group: each cyclic-of-prime-order quotient $\\mathbb{Z}/p\\mathbb{Z}$ corresponds, by Kummer theory, to a radical extension step $K(\\zeta_p)(\\sqrt[p]{\\beta})/K$. Composing these radical steps yields a tower containing all roots of $q$. The characteristic 0 hypothesis ensures that primitive $p$-th roots of unity $\\zeta_p$ exist in appropriate extensions.",
+    "keyInsights": [
+      "The solvability of a group — having a subnormal series with abelian quotients — is not merely an algebraic curiosity but the exact algebraic shadow of the analytic notion of expressing roots by nested radicals. Galois made this correspondence bijective: solvable groups correspond exactly to radical-expressible roots.",
+      "The characteristic 0 hypothesis (or more generally char $F \\nmid |\\operatorname{Gal}(q)|$) is essential for the reverse direction: Kummer theory requires the existence of primitive $n$-th roots of unity. Over fields of characteristic $p$, Artin–Schreier theory replaces Kummer theory for $p$-cyclic extensions, complicating the picture.",
+      "Abel–Ruffini is now a corollary: the symmetric group $S_5$ is not solvable (since $A_5$ is the smallest non-abelian simple group and is a normal subgroup of $S_5$), so any polynomial whose Galois group is $S_5$ — e.g., a generic degree-5 polynomial over $\\mathbb{Q}$ — cannot be solved by radicals.",
+      "The one-line forward direction proof (`solvableByRad.isSolvable' hq hroot hrad`) reflects the depth of Mathlib's radical tower formalization. The axiomatized reverse direction highlights a genuine Mathlib gap: Kummer theory for cyclic extensions, though classical, is not yet fully mechanized.",
+      "The criterion explains the existence of quadratic, cubic, and quartic formulas: the Galois groups of irreducible polynomials of degree $\\leq 4$ are subgroups of $S_4$, which is solvable (via $S_4 \\supset A_4 \\supset V_4 \\supset \\{e\\}$), so all their roots are expressible by radicals."
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "Imports",
+      "startLine": 1,
+      "endLine": 5,
+      "summary": "Imports from Mathlib covering Abel-Ruffini theory, solvable group theory, and Galois theory basics."
+    },
+    {
+      "id": "documentation",
+      "title": "Module Documentation",
+      "startLine": 6,
+      "endLine": 39,
+      "summary": "Research context: documents what is proved (forward direction via Mathlib), what is axiomatized (reverse direction, needing Kummer theory), and key references including Galois's 1831 memoir."
+    },
+    {
+      "id": "setup",
+      "title": "Namespace and Variable Setup",
+      "startLine": 41,
+      "endLine": 51,
+      "summary": "Declares the GaloisCriterion namespace with abstract fields F and E, setting up the general field-extension context."
+    },
+    {
+      "id": "forward-direction",
+      "title": "Part 1: Forward Direction (Proved)",
+      "startLine": 52,
+      "endLine": 76,
+      "summary": "Proves the forward direction of Galois's criterion: solvability by radicals implies solvability of the Galois group, using Mathlib's solvableByRad.isSolvable'. Includes the contrapositive, which immediately yields the Abel-Ruffini theorem."
+    },
+    {
+      "id": "reverse-direction-axiom",
+      "title": "Part 2: Reverse Direction (Axiomatized)",
+      "startLine": 79,
+      "endLine": 108,
+      "summary": "States and axiomatizes the reverse direction: a solvable Galois group implies solvability by radicals. Explains the required ingredients (composition series, Kummer theory, radical towers) and why this is not yet provable in Mathlib."
+    },
+    {
+      "id": "full-criterion",
+      "title": "Part 3: The Full Iff Criterion",
+      "startLine": 109,
+      "endLine": 125,
+      "summary": "Combines both directions into the full biconditional galois_criterion: over a characteristic 0 field, a root is solvable by radicals iff its Galois group is solvable."
+    },
+    {
+      "id": "applications",
+      "title": "Part 4: Applications",
+      "startLine": 127,
+      "endLine": 148,
+      "summary": "Specializes the criterion to ℚ (the primary case of interest) and derives the converse of Abel-Ruffini: solvable Galois group guarantees the existence of a radical formula, explaining quadratic/cubic/quartic formulas."
+    },
+    {
+      "id": "abel-ruffini-special-case",
+      "title": "Part 5: Abel-Ruffini as Special Case",
+      "startLine": 150,
+      "endLine": 165,
+      "summary": "Derives Abel-Ruffini from Galois's criterion: an unsolvable Galois group (e.g., S₅) is both necessary and sufficient for non-solvability by radicals, making Galois's criterion the complete characterization."
+    }
+  ],
+  "conclusion": {
+    "summary": "This proof formalizes Galois's solvability criterion in Lean 4 with Mathlib: a root of an irreducible polynomial over a characteristic 0 field is solvable by radicals if and only if its Galois group is solvable. The forward direction is fully machine-checked using Mathlib's radical tower theory; the reverse direction is axiomatized, awaiting Kummer theory formalization in Mathlib.",
+    "implications": "Galois's criterion is arguably the most important theorem in classical algebra. It provides a complete decision procedure for the radical solvability of polynomial equations via group theory — transforming an analytic question (existence of a radical formula) into a purely algebraic one (is this group solvable?). The theorem also demonstrates the power of the Galois correspondence, linking field extensions to group-theoretic properties. It subsumes and explains all prior results: why degree ≤ 4 polynomials have formulas, why the general quintic does not, and what the obstruction is in every case. The gap identified in this formalization — Kummer theory — represents an important frontier for Mathlib contributors.",
+    "openQuestions": [
+      "Can the reverse direction be formally proved in Mathlib once Kummer theory for cyclic extensions is fully formalized? The key missing ingredient is a theorem that cyclic Galois extensions of degree $n$ (over a field containing $\\zeta_n$) are generated by $n$-th roots.",
+      "What happens in characteristic $p > 0$? The criterion requires modification: for $p$-cyclic extensions, Artin–Schreier theory (extensions by roots of $x^p - x - a$) replaces Kummer theory. Can a unified statement be formalized in Lean?",
+      "The Galois group of a polynomial can be difficult to compute in practice. Are there decision procedures for determining solvability of Galois groups of explicit polynomials that could be mechanized in Lean?",
+      "The inverse Galois problem asks: which finite groups occur as Galois groups over $\\mathbb{Q}$? Every solvable group does (by Shafarevich's theorem), but the full problem remains open for all finite groups."
+    ]
+  },
   "crossReferences": [
     {
       "targetId": "abel-ruffini",
@@ -46,6 +126,5 @@
       "relationship": "extends",
       "description": "Extends the A5 simplicity chain with the converse direction"
     }
-  ],
-  "sections": []
+  ]
 }


### PR DESCRIPTION
Enrichment pass for abel-ruffini-oq-04-oq-03. Quality improvements:

- Added complete `overview` section with historicalContext (Galois 1811–1832, fatal duel memoir, Liouville publication 1846), LaTeX problemStatement, proofStrategy explaining both directions via radical towers and Kummer theory
- Added 5 keyInsights covering: solvable group/radical correspondence, characteristic 0 necessity, Abel-Ruffini as corollary, Mathlib gap (Kummer theory), degree ≤ 4 formula explanation
- Added 8 `sections` covering all 165 lines of the Lean file
- Added `conclusion` with mathematical implications and 4 openQuestions (Kummer theory formalization, char p case, Galois group computation algorithms, inverse Galois problem)
- Created `annotations.json` with 9 annotations covering all major proof sections, each with mathContext (LaTeX), significance, relatedConcepts, and prerequisites