### PR TITLE
Fix: erdos-485 axiomCount 9→1

### DIFF
--- a/src/data/proofs/erdos-485/meta.json
+++ b/src/data/proofs/erdos-485/meta.json
@@ -22,9 +22,9 @@
     "erdosNumber": 485,
     "erdosUrl": "https://erdosproblems.com/485",
     "erdosProblemStatus": "solved",
-    "axiomCount": 9,
+    "axiomCount": 1,
     "lineCount": 225,
-    "assumptions": "9 axiom(s) and 0 sorry(s). See the Lean source for details.",
+    "assumptions": "1 axiom: schinzel_zannier_improved (Schinzel-Zannier 2009: f(k) ≫ log k). This deep algebraic result is not yet in Mathlib.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Fix

Correct the `axiomCount` in `erdos-485/meta.json` from 9 to 1.

## Evidence

**Before**: `"axiomCount": 9` — claimed 9 axioms
**After**: `"axiomCount": 1` — reflects the single actual axiom

The Lean file `Proofs/Erdos485Problem.lean` contains exactly one `axiom` declaration:
- `schinzel_zannier_improved` (Schinzel-Zannier 2009: f(k) ≫ log k)

There are no structure-encoded assumptions, no additional axiom declarations.
The previous count of 9 was stale metadata from an earlier version of the file.

The `assumptions` field has been updated to describe the axiom precisely.

---
Automated fix by lean-mechanic agent.