### PR TITLE
Fix: basel-problem-oq-05 axiomCount 2→1

### DIFF
--- a/src/data/proofs/basel-problem-oq-05/meta.json
+++ b/src/data/proofs/basel-problem-oq-05/meta.json
@@ -37,12 +37,12 @@
       "Euler's proof structure outline connecting product and Taylor representations (relies on Mathlib hasSum_zeta_two; coefficient comparison step is a True placeholder)"
     ],
     "dateAdded": "2026-03-28",
-    "axiomCount": 2,
+    "axiomCount": 1,
     "theoremCount": 8,
     "substantiveTheoremCount": 3,
     "trueStubs": 1,
     "lineCount": 189,
-    "assumptions": "2 axioms: weierstrass_sin_product (Weierstrass product formula for sin), product_x2_coefficient (infinite product coefficient extraction). Both are deep results in complex analysis not yet in Mathlib. Note: euler_coefficient_comparison is a True placeholder — the key algebraic step equating x² coefficients is not actually proved.",
+    "assumptions": "1 axiom: weierstrass_sin_product (Weierstrass product formula for sin(πx)/(πx) = ∏(1 - x²/n²)). This is a deep result in complex analysis not yet in Mathlib. Note: product_x2_coefficient was previously axiomatized but is now proved algebraically (field_simp + ring). The euler_coefficient_comparison theorem remains a True placeholder.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Fix

Correct the `axiomCount` in `basel-problem-oq-05/meta.json` from 2 to 1.

## Evidence

**Before**: `"axiomCount": 2` — claimed both `weierstrass_sin_product` and `product_x2_coefficient` as axioms

**After**: `"axiomCount": 1` — only `weierstrass_sin_product` is an axiom

The `product_x2_coefficient` theorem was previously axiomatized but is now a fully proved theorem in `BaselProblemOQ05.lean` (lines 98-109). It's algebraically tautological (a Taylor-decomposition identity) and is proved via `field_simp` + `ring`. Only `weierstrass_sin_product` (the Weierstrass product formula for sin(πx)/(πx)) remains as a genuine axiom.

The `assumptions` field has been updated to accurately describe what is assumed.

---
Automated fix by lean-mechanic agent.