### PR TITLE
Enrich 6 gallery proofs: Power Means, Free Probability, Budan, Hilbert Symbols, Erdős 115 OQ-01, Erdős 1168

### DIFF
--- a/src/data/proofs/erdos-1168/annotations.json
+++ b/src/data/proofs/erdos-1168/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-aleph-defs",
+    "proofId": "erdos-1168",
+    "range": { "startLine": 40, "endLine": 43 },
+    "type": "definition",
+    "title": "ℵ_ω and ℵ_{ω+1} in Lean",
+    "content": "Defines the two cardinals central to the problem. aleph_omega = Cardinal.aleph ω₀ uses Lean's Cardinal.aleph function (which maps ordinals to beth/aleph cardinals) applied to the first infinite ordinal ω₀ = Ordinal.omega0. This gives ℵ_ω = sup{ℵ_0, ℵ_1, ℵ_2, …}, the first singular cardinal with cofinality ω. aleph_omega_succ = Cardinal.aleph (ω₀ + 1) gives ℵ_{ω+1}, its successor. Both are noncomputable because cardinals in Lean are defined via quotient types over types and their cardinalities, requiring classical logic.",
+    "mathContext": "$\\aleph_\\omega = \\sup_{n < \\omega} \\aleph_n$ (cofinality $\\omega$, the only singular cardinal among the $\\aleph_n$'s). $\\aleph_{\\omega+1}$ is a successor cardinal, hence regular, but its predecessor $\\aleph_\\omega$ is singular — the source of difficulty.",
+    "significance": "key",
+    "relatedConcepts": ["Cardinal.aleph in Mathlib", "singular cardinals", "regular cardinals", "cofinality"],
+    "prerequisites": ["set theory", "ordinal arithmetic", "Lean 4 Cardinal library"]
+  },
+  {
+    "id": "ann-is-homogeneous",
+    "proofId": "erdos-1168",
+    "range": { "startLine": 55, "endLine": 64 },
+    "type": "definition",
+    "title": "Homogeneous Sets and Partition Relations",
+    "content": "IsHomogeneous f S i formalizes the Ramsey theory concept: S is i-monochromatic under coloring f if every pair of distinct elements (a, b) in S is colored i. The condition a ≠ b handles the fact that f is defined on all pairs, not just unordered ones. partitionRelation κ targets formalizes κ → (targets)²_{ℵ₀}: for any type V with #V = κ and any ℕ-coloring f of pairs, there exists a color i and a homogeneous set S with |S| ≥ targets(i). The countable color set ℕ is used directly (no finiteness constraint).",
+    "mathContext": "$S$ is $i$-homogeneous for $f : V \\times V \\to \\omega$ if $\\forall a, b \\in S, a \\neq b \\Rightarrow f(a,b) = i$. The partition relation $\\kappa \\to (\\alpha_i)_{i < \\omega}^2$ holds iff $\\forall f : [\\kappa]^2 \\to \\omega, \\exists i, \\exists S, |S| \\geq \\alpha_i \\wedge S$ is $i$-homogeneous.",
+    "significance": "key",
+    "relatedConcepts": ["Ramsey theory", "infinite Ramsey theorem", "partition calculus", "arrow notation"],
+    "prerequisites": ["set theory", "combinatorics", "coloring problems", "Lean 4 Set and Cardinal"]
+  },
+  {
+    "id": "ann-conjecture-def",
+    "proofId": "erdos-1168",
+    "range": { "startLine": 75, "endLine": 92 },
+    "type": "definition",
+    "title": "The Open Conjecture and GCH Case",
+    "content": "erdos_1168_conjecture is defined as ¬ partitionRelation aleph_omega_succ targets — the negation of the partition relation, which is the desired 'negative relation' ℵ_{ω+1} ↛ (ℵ_{ω+1}, 3, 3, …)². This is a Lean Prop (not an axiom), so asserting it without proof would be circular. erdos_1168_under_gch is the one axiom: it asserts that GCH (formalized as ∀ κ, 2^κ = Order.succ κ) implies the conjecture. gch_implies_conjecture then proves that GCH implies the conjecture — a one-line proof applying the axiom.",
+    "mathContext": "GCH states $2^\\kappa = \\kappa^+$ for all infinite $\\kappa$. Under GCH, the Erdős-Hajnal-Rado stepping-up lemma gives: if $\\kappa \\not\\to (\\kappa, 3, \\ldots)^2_{\\aleph_0}$, then $\\kappa^+ \\not\\to (\\kappa^+, 3, \\ldots)^2_{\\aleph_0}$. Applied at $\\kappa = \\aleph_\\omega$, this gives the desired result.",
+    "significance": "key",
+    "relatedConcepts": ["GCH (Generalized Continuum Hypothesis)", "stepping-up lemma", "Erdős-Hajnal-Rado 1965", "independence from ZFC"],
+    "prerequisites": ["set theory", "cardinal arithmetic", "ordinal functions", "Lean 4 Prop vs axiom"]
+  },
+  {
+    "id": "ann-structural-homogeneity",
+    "proofId": "erdos-1168",
+    "range": { "startLine": 101, "endLine": 116 },
+    "type": "technique",
+    "title": "Homogeneity: Empty, Singleton, Monotonicity",
+    "content": "Three basic properties of IsHomogeneous proved cleanly. empty_homogeneous: ∅ is homogeneous for any color (vacuously: no pairs exist). Proof: Set.not_mem_empty. singleton_homogeneous: {v} is homogeneous (no distinct pairs). Proof: both elements are equal via Set.mem_singleton_iff, contradicting a ≠ b. IsHomogeneous.subset: if S is homogeneous and T ⊆ S then T is homogeneous. Proof: use hTS to embed T's pairs into S's pairs.",
+    "mathContext": "These are the Ramsey-theoretic base cases: size-0 and size-1 sets trivially satisfy any coloring constraint. The subset property is used in the antimonotonicity theorem below.",
+    "significance": "supporting",
+    "relatedConcepts": ["vacuous truth", "subset monotonicity", "set theory basics", "Lean 4 Set library"],
+    "prerequisites": ["elementary set theory", "Lean 4 Set.mem_singleton_iff"]
+  },
+  {
+    "id": "ann-antimonotonicity",
+    "proofId": "erdos-1168",
+    "range": { "startLine": 121, "endLine": 126 },
+    "type": "technique",
+    "title": "Partition Relation Antimonotonicity",
+    "content": "partitionRelation.mono_targets: if targets₂(i) ≤ targets₁(i) for all i, and partitionRelation κ targets₁ holds, then partitionRelation κ targets₂ holds. Weakening the target sizes makes the partition relation easier to satisfy (requires smaller homogeneous sets). The proof extracts the (i, S) pair from hp satisfying targets₁, then shows S satisfies targets₂ via transitivity of ≤. This is the key monotonicity lemma needed to reduce complex partition relation questions to simpler ones.",
+    "mathContext": "If $(\\beta_i) \\leq (\\alpha_i)$ pointwise and $\\kappa \\to (\\alpha_i)_i^2$, then $\\kappa \\to (\\beta_i)_i^2$. Contrapositive: $\\kappa \\not\\to (\\beta_i)_i^2$ does not immediately give $\\kappa \\not\\to (\\alpha_i)_i^2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["monotonicity", "partition calculus inequalities", "target reduction lemmas"],
+    "prerequisites": ["Cardinal ordering in Lean", "le_trans"]
+  }
+]

--- a/src/data/proofs/erdos-1168/meta.json
+++ b/src/data/proofs/erdos-1168/meta.json
@@ -24,13 +24,72 @@
     "lineCount": 153,
     "theoremCount": 5,
     "definitionCount": 6,
-    "assumptions": "1 axiom: erdos_1168_under_gch (known under GCH). Open conjecture is a def, not axiom. 5 structural theorems proved.",
+    "assumptions": "1 axiom: erdos_1168_under_gch (known under GCH via Erdős-Hajnal-Rado stepping-up lemma). Open conjecture is a def, not an axiom. 5 structural theorems proved.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-03-28"
+  },
+  "overview": {
+    "historicalContext": "Partition calculus — the study of the arrow notation κ → (α)²_λ — was systematically developed by Erdős and Rado in their 1956 paper 'A partition calculus in set theory.' The notation κ → (α₀, α₁, …)²_c (due to Erdős-Hajnal-Rado 1965) means: for any c-coloring of 2-element subsets of κ, there exists a color i and a homogeneous set of size αᵢ. The problem of negative partition relations for ℵ_{ω+1} — the successor of the first singular cardinal ℵ_ω — sits at the heart of 'pcf theory' (possible cofinalities), developed by Shelah in the 1970s-1980s. The singular nature of ℵ_ω (it is the supremum of the sequence ℵ_0, ℵ_1, ℵ_2, … with countable cofinality) gives its successor special combinatorial properties. Under GCH, the desired negative partition relation follows from the Erdős-Hajnal-Rado 'stepping-up lemma' applied at ℵ_ω. Proving it in ZFC alone — without assuming GCH — requires the much deeper structural theory of singular cardinals that Shelah pioneered. Shelah's 1992 result that ℵ_ω^{ℵ_0} < ℵ_{ω_4} (provable in ZFC) exemplifies the power of pcf theory for such problems.",
+    "problemStatement": "Prove in ZFC (without assuming GCH) that\n$$\\aleph_{\\omega+1} \\not\\to (\\aleph_{\\omega+1}, 3, 3, \\ldots)^2_{\\aleph_0}$$\nThat is, there exists a coloring $f : [\\aleph_{\\omega+1}]^2 \\to \\omega$ of 2-element subsets using countably many colors such that:\n- Color 0: has no monochromatic set of cardinality $\\aleph_{\\omega+1}$\n- Colors $i \\geq 1$: each has no monochromatic triangle (3-element set)\n\nFormal Lean definition: `¬ partitionRelation aleph_omega_succ targets` where `targets 0 = ℵ_{ω+1}` and `targets (i+1) = 3`.",
+    "proofStrategy": "The file axiomatizes the known GCH result (erdos_1168_under_gch) and proves that it implies the conjecture. The main definitions — partitionRelation and IsHomogeneous — are fully proved properties of Lean's Set and Cardinal libraries. Five structural theorems are proved: (1) empty and singleton sets are trivially homogeneous; (2) homogeneity is monotone under subsets; (3) the partition relation is antimonotone in targets (weaker targets are easier to satisfy); (4) GCH implies the conjecture. The open question — whether the conjecture holds in ZFC alone — is formalized as a Lean Prop (erdos_1168_conjecture) without being asserted. The ZFC proof would require encoding pcf theory into Lean's cardinal arithmetic library.",
+    "keyInsights": [
+      "The arrow notation ℵ_{ω+1} ↛ (ℵ_{ω+1}, 3, 3, …)²_{ℵ₀} packs a complex combinatorial statement: there is a 'wild' countably-colored Ramsey coloring of pairs from ℵ_{ω+1} where no single color achieves its target homogeneous set. Color 0 fails at ℵ_{ω+1} (a large homogeneous set), while colors 1, 2, … fail at triangles (a small target).",
+      "The singularity of ℵ_ω — specifically its cofinality cf(ℵ_ω) = ℵ_0 — is the key feature making ℵ_{ω+1} interesting. Successor cardinals of regular cardinals (like ℵ_2 = (ℵ_1)⁺) behave differently from successors of singular cardinals. The 'singular cardinal hypothesis' (a strengthening of GCH for singular cardinals) is independent of ZFC, making the problem delicate.",
+      "Under GCH, the result uses the stepping-up lemma: if ℵ_ω ↛ (ℵ_ω, 3, …)²_{ℵ_0} holds, then ℵ_{ω+1} ↛ (ℵ_{ω+1}, 3, …)²_{ℵ_0} follows. GCH gives good control over cardinal arithmetic at ℵ_ω. Without GCH, one must instead use pcf theory to control possible values of ℵ_ω^{ℵ_0}.",
+      "pcf theory (Shelah) is the main candidate tool for a ZFC proof. For a set A of regular cardinals, pcf(A) = {cf(∏A/U) : U ultrafilter on A} is the set of possible cofinalities. Shelah proved that |pcf({ℵ_n : n < ω})| < ℵ_ω (in ZFC!), which gives cardinal arithmetic results without GCH. Whether this is enough to prove Problem 1168 in ZFC is the core difficulty.",
+      "The Lean formalization is exemplary: IsHomogeneous uses a symmetric relation (f a b = i for all distinct a, b in S), and partitionRelation is universe-polymorphic (works for any type V with cardinality κ). The five proved theorems cover the basic combinatorial properties without requiring any set-theoretic set theory beyond Mathlib's cardinal library.",
+      "The target function uses Lean's `fun | 0 => ... | _ + 1 => ...` pattern matching to define countably many targets: color 0 targets ℵ_{ω+1} (the big homogeneous set) and all other colors target 3 (triangles). This clean encoding shows that Lean's dependent type system handles the countable-color partition relation naturally."
+    ]
+  },
+  "sections": [
+    {
+      "id": "problem-statement",
+      "title": "Problem Statement and Context",
+      "startLine": 1,
+      "endLine": 34,
+      "summary": "Docstring stating Erdős Problem #1168: prove ℵ_{ω+1} ↛ (ℵ_{ω+1}, 3, …, 3)²_{ℵ₀} in ZFC without GCH. Provides context: GCH case known via Erdős-Hajnal-Rado, ZFC case requires pcf theory (Shelah)."
+    },
+    {
+      "id": "cardinals",
+      "title": "Part I: The Cardinals ℵ_ω and ℵ_{ω+1}",
+      "startLine": 37,
+      "endLine": 44,
+      "summary": "Defines aleph_omega = Cardinal.aleph ω₀ (the supremum of the ℵ_n sequence) and aleph_omega_succ = Cardinal.aleph (ω₀ + 1) (its successor). Both are noncomputable due to classical set theory."
+    },
+    {
+      "id": "partition-framework",
+      "title": "Part II-III: Partition Relation Framework",
+      "startLine": 45,
+      "endLine": 84,
+      "summary": "Defines IsHomogeneous (all pairs in S colored the same), partitionRelation (for any coloring, some color achieves its target size), targets function (color 0: ℵ_{ω+1}, colors ≥ 1: 3), and erdos_1168_conjecture (the open problem as a negation of partitionRelation)."
+    },
+    {
+      "id": "known-results",
+      "title": "Part IV: Known Results (GCH Case)",
+      "startLine": 85,
+      "endLine": 98,
+      "summary": "Axiomatizes erdos_1168_under_gch (the GCH-conditional version, known from Erdős-Hajnal-Rado). Proves gch_implies_conjecture: GCH → erdos_1168_conjecture, a one-line application of the axiom."
+    },
+    {
+      "id": "structural-theorems",
+      "title": "Part V: Structural Theorems",
+      "startLine": 99,
+      "endLine": 153,
+      "summary": "Five ZFC-provable theorems: empty_homogeneous, singleton_homogeneous (base cases), IsHomogeneous.subset (monotonicity), partitionRelation.mono_targets (antimonotonicity in targets), and a summary of the problem state."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file provides a clean Lean 4 formalization of Erdős Problem #1168: the open question of whether ℵ_{ω+1} ↛ (ℵ_{ω+1}, 3, 3, …)²_{ℵ₀} holds in ZFC. The GCH case is axiomatized (1 axiom), the open conjecture is defined as a Lean Prop, and five structural theorems are proved. The file correctly represents the state of the art: the ZFC case is open.",
+    "implications": "A ZFC proof of Erdős 1168 would be a significant advance in set-theoretic combinatorics, demonstrating that pcf theory can resolve partition relation questions that previously required GCH. It would also provide a non-trivial theorem in Lean about large cardinals (at the level of ℵ_ω and its successor), extending Mathlib's cardinal library into research territory. Such a formalization would likely require encoding Shelah's pcf theory — a substantial Lean project in its own right.",
+    "openQuestions": [
+      "Can pcf theory be encoded in Lean 4 using Mathlib's existing ordinal and cardinal infrastructure? The key pcf result needed is |pcf({ℵ_n : n < ω})| < ℵ_ω — can this be proved in Lean from ZFC?",
+      "Is there a simpler combinatorial proof of Erdős 1168 not going through pcf theory, perhaps using a direct Ramsey-theoretic construction of the required coloring?",
+      "Does the Lean formulation of partitionRelation correctly capture the set-theoretic partition relation κ → (α₀, α₁, …)²_c? In particular, does the use of a Lean type V with #V = κ accurately model the ordinal-based version?",
+      "Can the stepping-up lemma (used in the GCH proof) be formalized in Lean 4 using Mathlib's cardinal arithmetic, and would it suffice to prove Erdős 1168 under a weaker assumption than full GCH?"
+    ]
   },
   "leanFile": {
     "lineCount": 153,
     "axiomCount": 1
-  },
-  "sections": []
+  }
 }


### PR DESCRIPTION
## Enrichment passes for 6 gallery entries

All enrichments include: historicalContext 400+ chars, LaTeX problemStatement, proofStrategy, 5-6 keyInsights, full sections coverage, conclusion with openQuestions, and annotations with mathContext + significance + relatedConcepts + prerequisites.

| Entry | Highlights | Fixes |
|-------|-----------|-------|
| amgm-inequality-oq-03-oq-03 | Power Mean extreme cases; n^{1/r}→1 squeeze | — |
| central-limit-theorem-oq-01-oq-03 | Free probability, Bercovici-Pata bijection | badge: verified→formalized |
| descartes-rule-of-signs-oq-02-oq-01 | Budan 1807, Rolle+IVT building blocks | badge: original→formalized; mainTheorems corrected |
| elementary-quadratic-reciprocity-oq-03-oq-03 | Jacobi/Hilbert symbols, 5-level CFT ladder | axiomCount: 3→1 |
| erdos-115-oq-01 | Lemniscate derivative rate, 4 rate hypotheses | — |
| erdos-1168 | Partition calculus, pcf theory, ℵ_{ω+1}↛... in ZFC | — |