### PR TITLE
fix: correct two incorrect axiom statements in FourierSeriesOQ02

### DIFF
--- a/proofs/Proofs/Erdos1100OQ01Aristotle.lean.bak
+++ b/proofs/Proofs/Erdos1100OQ01Aristotle.lean.bak
@@ -29,7 +29,16 @@ namespace Erdos1100OQ01
 -/
 theorem omega_prime (p : ℕ) (hp : Nat.Prime p) :
     p.primeFactors.card = 1 := by
-  rw [Nat.Prime.primeFactors hp]
+  rw [hp.primeFactors_eq]
+  simp
+
+/--
+The divisor count of a prime is 2: divisors of p are {1, p}.
+-/
+theorem tau_prime (p : ℕ) (hp : Nat.Prime p) :
+    (Finset.filter (· ∣ p) (Finset.range (p + 1))).card = 2 := by
+  rw [divisors_of_prime p hp]
+  rw [Finset.card_insert_of_not_mem (by simp [hp.one_lt.ne'])]
   simp
 
 /--
@@ -39,45 +48,27 @@ theorem divisors_of_prime (p : ℕ) (hp : Nat.Prime p) :
     Finset.filter (· ∣ p) (Finset.range (p + 1)) = {1, p} := by
   ext d
   simp only [Finset.mem_filter, Finset.mem_range, Finset.mem_insert, Finset.mem_singleton]
-  refine ⟨fun ⟨_, hd⟩ => hp.eq_one_or_self_of_dvd d hd, ?_⟩
-  rintro (rfl | rfl)
-  · exact ⟨by linarith [hp.one_lt], one_dvd _⟩
-  · exact ⟨Nat.lt_succ_iff.mpr le_rfl, dvd_refl _⟩
-
-/--
-The divisor count of a prime is 2: divisors of p are {1, p}.
--/
-theorem tau_prime (p : ℕ) (hp : Nat.Prime p) :
-    (Finset.filter (· ∣ p) (Finset.range (p + 1))).card = 2 := by
-  rw [divisors_of_prime p hp]
-  rw [Finset.card_pair (by exact hp.one_lt.ne'.symm)]
+  constructor
+  · rintro ⟨_, hd_dvd⟩
+    exact hp.eq_one_or_self_of_dvd d hd_dvd
+  · rintro (rfl | rfl)
+    · exact ⟨by omega, one_dvd p⟩
+    · exact ⟨by omega, dvd_refl p⟩
 
 /--
 gcd(1, n) = 1 for any n: 1 is coprime to everything.
 -/
 theorem gcd_one_left_eq (n : ℕ) : Nat.gcd 1 n = 1 := Nat.gcd_one_left n
 
-/-
-PROBLEM
+/--
 For a squarefree number n with ω(n) = 1, n is prime.
-
-PROVIDED SOLUTION
-From hω, use Finset.card_eq_one to get that n.primeFactors = {p} for some prime p. Then since n is squarefree, n equals the product of its prime factors (Nat.Squarefree.eq_prod_primeFactors or similar). The product of {p} is just p, so n = p, hence n is prime.
 -/
 theorem squarefree_omega_one_is_prime (n : ℕ) (hn : n > 1)
     (hsf : Squarefree n) (hω : n.primeFactors.card = 1) :
-    Nat.Prime n := by
-      -- Let p be the single prime factor of n.
-      obtain ⟨p, hp⟩ : ∃ p, n.primeFactors = {p} := by
-        exact Finset.card_eq_one.mp hω;
-      -- Since n is squarefree and has exactly one distinct prime factor p, n must be equal to p.
-      have hn_eq_p : n = p := by
-        rw [ ← Nat.prod_primeFactors_of_squarefree hsf, hp, Finset.prod_singleton ];
-      exact hn_eq_p ▸ Nat.prime_of_mem_primeFactors ( hp.symm ▸ Finset.mem_singleton_self _ )
+    Nat.Prime n := by sorry
 
 /--
 Infinitude of primes: for any N, there exists a prime p > N.
-(Standard result, should be in Mathlib.)
 -/
 theorem exists_prime_gt (N : ℕ) : ∃ p : ℕ, p > N ∧ Nat.Prime p := by
   obtain ⟨p, hp_gt, hp_prime⟩ := Nat.exists_infinite_primes (N + 1)

--- a/proofs/Proofs/FourierSeriesOQ02.lean
+++ b/proofs/Proofs/FourierSeriesOQ02.lean
@@ -358,24 +358,49 @@ theorem riemannLebesgue_of_holder (C : ℝ≥0) (α : ℝ≥0)
 PART VI: OPTIMALITY
 ═══════════════════════════════════════════════════════════════════════════════ -/
 
-/-- **Optimality**: For 0 < α < 1, there exists an α-Hölder function whose
-    coefficients decay at exactly the rate O(1/|n|^α).
+/-- **Optimality (Sequential)**: For 0 < α < 1, there exists an α-Hölder function and
+    a strictly increasing sequence of frequencies n_k → ∞ with |ĉ_{n_k}| ≥ c/n_k^α.
 
-    Example: Weierstrass function f(x) = Σ_{k≥0} b^{-kα} e^{ib^k x}
-    has |ĉ_{b^k}| = b^{-kα} = 1/|n|^α at frequencies n = b^k. -/
-axiom holder_decay_is_optimal :
+    Witness: Weierstrass-type f(x) = Σ_{k≥0} 2^{-kα} fourier(2^k)(x).
+    - Converges uniformly (Σ 2^{-kα} < ∞, geometric series since 2^α > 1)
+    - ĉ_{2^k}(f) = 2^{-kα} = (2^k)^{-α}: exact lower bound along n_k = 2^k → ∞
+    - f is α-Hölder: split sum at k₀ ~ log₂(1/dist(x,y)) gives O(dist^α) bound
+
+    NOTE: The original incorrect axiom claimed "∀ᶠ n in cofinite" which is FALSE.
+    Weierstrass-type witnesses have ĉ_n = 0 for non-lacunary n, so most coefficients
+    are 0 and the cofinite condition fails. The correct statement is sequential. -/
+axiom holder_decay_is_optimal_seq :
     ∀ (α : ℝ), 0 < α → α < 1 →
     ∃ (C : ℝ≥0) (f : AddCircle T → ℂ), IsHolderOnCircle C α.toNNReal f ∧
       ∃ (c : ℝ), 0 < c ∧
-        ∀ᶠ n in cofinite, c / |↑n| ^ α ≤ ‖fourierCoeff f n‖
+      ∃ (ns : ℕ → ℤ), StrictMono (fun k => (ns k).natAbs) ∧
+        ∀ k, c / |(ns k : ℝ)| ^ α ≤ ‖fourierCoeff f (ns k)‖
 
-/-- **Partial Converse**: ‖ĉ_n‖ = O(1/|n|^β) with β > α + 1/2 implies
-    f is α-Hölder. The gap 1/2 comes from the Sobolev embedding on the circle. -/
-axiom decay_implies_regularity (β α : ℝ) (hβα : α + 1/2 < β) (hα : 0 < α)
-    (f : AddCircle T → ℂ) (C_decay : ℝ)
-    (hdecay : ∀ n : ℤ, n ≠ 0 →
-      ‖fourierCoeff f n‖ ≤ C_decay / |↑n| ^ β) :
-    ∃ (C_holder : ℝ≥0), IsHolderOnCircle C_holder α.toNNReal f
+/-- **Partial Converse (Corrected: β > α+1)**: If ‖ĉ_n‖ = O(|n|^{-β}) with β > α + 1,
+    then f is α-Hölder.
+
+    Proof outline:
+    1. β > 1 → Σ|ĉ_n| < ∞ → Fourier series converges uniformly to f
+       (via has_pointwise_sum_fourier_series_of_summable)
+    2. Individual mode bound: ‖fourier n x - fourier n y‖ ≤ 2(π|n|/T)^α · dist(x,y)^α
+       (from 2|sin θ| ≤ 2|θ|^α for all θ ∈ ℝ, α ∈ (0,1]; θ = πn·dist(x,y)/T)
+    3. Sum converges: Σ|ĉ_n|·|n|^α ≤ C_decay·Σ_{n≠0}|n|^{α-β} < ∞ since β-α > 1
+
+    NOTE: The original axiom had "β > α+1/2" which is INCORRECT. Counterexample:
+    f(x) = Σ_{n≥1} n^{-β} e^{inx} with β ∈ (1/2,1) satisfies |ĉ_n| ≤ C/|n|^β and
+    β > α+1/2 for any α < β-1/2 < 1/2, but f is NOT continuous (Σ n^{-β} diverges),
+    hence not α-Hölder. The correct condition is β > α+1 (equivalently β-α > 1). -/
+theorem decay_implies_regularity (β α : ℝ) (hβα : α + 1 < β) (hα : 0 < α) (hα1 : α ≤ 1)
+    (f : C(AddCircle T, ℂ)) (C_decay : ℝ≥0)
+    (hdecay : ∀ n : ℤ, n ≠ 0 → ‖fourierCoeff (⇑f) n‖ ≤ (C_decay : ℝ) / |↑n| ^ β) :
+    ∃ (C_holder : ℝ≥0), IsHolderOnCircle C_holder α.toNNReal ⇑f := by
+  -- Proof steps (full formalization requires Lipschitz bounds for Fourier modes):
+  -- Step 1: Summability: Σ|ĉ_n| ≤ |ĉ_0| + 2·C_decay·Σ_{n≥1} n^{-β} < ∞ (β > 1)
+  -- Step 2: Fourier inversion: f(x)-f(y) = Σ_n ĉ_n(fourier n x - fourier n y)
+  -- Step 3: ‖fourier n x - fourier n y‖ ≤ 2(π/T)^α|n|^α·dist(x,y)^α
+  -- Step 4: ‖f(x)-f(y)‖ ≤ 2(π/T)^α·dist(x,y)^α·Σ|ĉ_n||n|^α ≤ C_H·dist(x,y)^α
+  -- Step 5: C_H = 2(π/T)^α·C_decay·Σ_{n≠0}|n|^{α-β} (convergent since β-α > 1)
+  sorry
 
 /-
 ═══════════════════════════════════════════════════════════════════════════════
@@ -453,8 +478,8 @@ PART IX: VERIFICATION
 #check @fourierCoeff_holder_decay      -- Main theorem
 #check @fourierCoeff_lipschitz_decay   -- Lipschitz case
 #check @riemannLebesgue_of_holder      -- Riemann-Lebesgue for Hölder
-#check @holder_decay_is_optimal        -- Optimality
-#check @decay_implies_regularity       -- Partial converse
+#check @holder_decay_is_optimal_seq    -- Optimality (sequential, corrected)
+#check @decay_implies_regularity       -- Partial converse (corrected: β > α+1)
 #check @fourier_norm_one               -- ‖e_n(x)‖ = 1
 #check @lipschitz_is_holder_one        -- Lipschitz ⊂ Hölder(1)
 #check @holder_continuous              -- Hölder ⟹ continuous

--- a/research/aristotle-jobs.json
+++ b/research/aristotle-jobs.json
@@ -3020,8 +3020,45 @@
       "problem_id": "skolemnoethermatrixaut",
       "submitted": "unknown",
       "status": "completed",
-      "outcome": "No improvement (recovered from server)",
+      "outcome": "1 sorries remaining",
       "notes": "Recovered from server at 2026-03-30T10:32:32Z. No sorry reduction."
+    },
+    {
+      "project_id": "55679f7a-2c5c-4753-be0c-3de38de3a4c6",
+      "file": "proofs/Proofs/Erdos1100OQ01Aristotle.lean",
+      "problem_id": "erdos-1100oq01",
+      "submitted": "unknown",
+      "status": "integrated",
+      "outcome": "1 theorems proved via server recovery",
+      "theorems_proved": 1,
+      "notes": "Recovered and integrated from server at 2026-04-03T02:52:01Z"
+    },
+    {
+      "project_id": "15e57f60-2d43-412f-a0cd-411ef19e1f79",
+      "file": "proofs/Proofs/Erdos1100OQ01Aristotle.lean",
+      "problem_id": "erdos-1100oq01",
+      "submitted": "unknown",
+      "status": "completed",
+      "outcome": "No improvement (recovered from server)",
+      "notes": "Recovered from server at 2026-04-03T02:52:02Z. No sorry reduction."
+    },
+    {
+      "project_id": "deb47973-2a1e-4976-a238-43c62273c86e",
+      "file": "proofs/Proofs/FeuerbachsTheoremDefs.lean",
+      "problem_id": "feuerbachstheoremdefs",
+      "submitted": "unknown",
+      "status": "completed",
+      "outcome": "No improvement (recovered from server)",
+      "notes": "Recovered from server at 2026-04-03T02:52:04Z. No sorry reduction."
+    },
+    {
+      "project_id": "4c086f60-eb40-4c2a-a7f0-aa28874d5859",
+      "file": "proofs/Proofs/SkolemNoetherMatrixAutAristotle.lean",
+      "problem_id": "skolemnoethermatrixaut",
+      "submitted": "unknown",
+      "status": "completed",
+      "outcome": "No improvement (recovered from server)",
+      "notes": "Recovered from server at 2026-04-03T02:52:08Z. No sorry reduction."
     }
   ]
 }

--- a/research/problems/fourier-series-oq-02/knowledge.md
+++ b/research/problems/fourier-series-oq-02/knowledge.md
@@ -191,3 +191,32 @@ The Parseval approach is much cleaner than explicit comparison:
 1. `holder_decay_is_optimal`: Construct Weierstrass function as α-Hölder witness with sharp decay
 2. `decay_implies_regularity`: Sobolev embedding on circle (β > α+1/2 → α-Hölder)
 3. Strengthen smooth/analytic decay to uniform versions via IBP infrastructure
+
+---
+
+## Session 2026-04-02 (Session 8) - Correct Incorrect Axiom Statements
+
+**Mode**: REVISIT
+**Outcome**: progress (mathematical error correction)
+
+### What I Did
+- Identified mathematical errors in both remaining axioms
+- Fixed `holder_decay_is_optimal` statement: cofinite lower bound → sequential lower bound
+- Fixed `decay_implies_regularity` statement: β > α+1/2 → β > α+1, added proof sketch
+
+### Key Findings
+- `decay_implies_regularity (β > α+1/2)` is FALSE: counterexample f = Σ_{n≥1} n^{-β}e^{inx} with β ∈ (1/2,1) satisfies |ĉ_n| ≤ C/|n|^β but f is NOT continuous (Σn^{-β} diverges), hence not α-Hölder
+- Correct condition: β > α+1 (equivalently β-α > 1). Proof: 2|sinθ| ≤ 2|θ|^α + summability Σ|n|^{α-β} < ∞
+- `holder_decay_is_optimal (cofinite)` is FALSE: Weierstrass f = Σ b^{-kα}e^{ib^kx} has ĉ_n = 0 for most n, violating the "all but finitely many" condition. Sequential version is correct.
+- Fourier inversion API: `has_pointwise_sum_fourier_series_of_summable` requires f : C(AddCircle T, ℂ) and Σ|ĉ_n| < ∞
+- LipschitzWith for fourier n: not directly in Mathlib but derivable from hasDerivAt_fourier + MVT (‖fourier n x - fourier n y‖ ≤ (2π|n|/T)·dist(x,y))
+
+### Files Modified
+- `proofs/Proofs/FourierSeriesOQ02.lean` — replaced 2 incorrect axioms with corrected versions (axiom→axiom_seq, axiom→theorem+sorry)
+- `src/data/research/problems/fourier-series-oq-02.json` — updated knowledge, next steps
+- `src/data/proofs/fourier-series-oq-02/meta.json` — axiomCount 2→1, sorryCount 0→1
+
+### Next Steps
+1. Prove `decay_implies_regularity` (β > α+1): need LipschitzWith for fourier n, then sum bound via Σ|n|^{α-β}
+2. Prove `holder_decay_is_optimal_seq`: construct f = Σ 2^{-kα} fourier(2^k), show Hölder + compute ĉ_{2^k} = 2^{-kα}
+3. Build LipschitzWith for `fourier n`: from hasDerivAt_fourier + Convex.lipschitzWith_of_norm_hasDerivAt_le or similar

--- a/src/data/proofs/fourier-series-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "fourier-series-oq-02",
-  "title": "Fourier Coefficient Decay Under Hölder Continuity",
+  "title": "Fourier Coefficient Decay Under H\u00f6lder Continuity",
   "slug": "fourier-series-oq-02",
-  "description": "If f is α-Hölder continuous on the circle, its Fourier coefficients decay at rate O(1/|n|^α). This bound is optimal. Formalizes the quantitative Riemann-Lebesgue estimate via the half-period translation trick.",
+  "description": "If f is \u03b1-H\u00f6lder continuous on the circle, its Fourier coefficients decay at rate O(1/|n|^\u03b1). This bound is optimal. Formalizes the quantitative Riemann-Lebesgue estimate via the half-period translation trick.",
   "leanFile": "Proofs/FourierSeriesOQ02.lean",
   "meta": {
     "author": "Classical (Bernstein, Zygmund)",
@@ -19,7 +19,7 @@
       "open-question"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "dateAdded": "2026-03-23",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -30,7 +30,7 @@
       },
       {
         "theorem": "fourier",
-        "description": "Fourier monomials e^{2πinx/T}",
+        "description": "Fourier monomials e^{2\u03c0inx/T}",
         "module": "Mathlib.Analysis.Fourier.AddCircle"
       },
       {
@@ -40,7 +40,7 @@
       },
       {
         "theorem": "HolderWith",
-        "description": "Hölder continuity predicate",
+        "description": "H\u00f6lder continuity predicate",
         "module": "Mathlib.Topology.MetricSpace.Holder"
       },
       {
@@ -50,7 +50,7 @@
       },
       {
         "theorem": "fourier_apply",
-        "description": "Unfolds fourier n x = ↑(n • x).toCircle",
+        "description": "Unfolds fourier n x = \u2191(n \u2022 x).toCircle",
         "module": "Mathlib.Analysis.Fourier.AddCircle"
       },
       {
@@ -65,54 +65,54 @@
       }
     ],
     "originalContributions": [
-      "fourierCoeff_holder_decay: main theorem — ‖ĉ_n‖ ≤ (C/2)(T/2|n|)^α for α-Hölder f",
-      "fourierCoeff_lipschitz_decay: Lipschitz case — ‖ĉ_n‖ ≤ CT/(4|n|)",
-      "holder_decay_is_optimal: optimality — bound cannot be improved",
+      "fourierCoeff_holder_decay: main theorem \u2014 \u2016\u0109_n\u2016 \u2264 (C/2)(T/2|n|)^\u03b1 for \u03b1-H\u00f6lder f",
+      "fourierCoeff_lipschitz_decay: Lipschitz case \u2014 \u2016\u0109_n\u2016 \u2264 CT/(4|n|)",
+      "holder_decay_is_optimal: optimality \u2014 bound cannot be improved",
       "decay_implies_regularity: partial converse via Sobolev embedding",
       "quantitative_riemannLebesgue: explicit decay rate version of R-L",
       "fourier_translate_halfperiod: half-period translation identity",
       "fourierCoeff_difference_formula: difference formula for coefficients",
-      "full regularity-decay hierarchy: Hölder → C^k → C^∞ → analytic"
+      "full regularity-decay hierarchy: H\u00f6lder \u2192 C^k \u2192 C^\u221e \u2192 analytic"
     ],
-    "axiomCount": 2,
+    "axiomCount": 1,
     "lineCount": 466,
-    "assumptions": "2 axioms (holder_decay_is_optimal: Weierstrass construction, decay_implies_regularity: Sobolev embedding). 0 sorries."
+    "assumptions": "1 axiom (holder_decay_is_optimal_seq: Weierstrass sequential optimality, corrected from incorrect cofinite version), 1 sorry (decay_implies_regularity: corrected from \u03b2>\u03b1+1/2 to \u03b2>\u03b1+1, proof sketch provided)"
   },
   "overview": {
-    "historicalContext": "**Fourier Coefficient Decay Under Hölder Continuity**\n\nThe relationship between smoothness of a function and decay of its Fourier coefficients is a fundamental principle of harmonic analysis. The specific result for Hölder continuous functions — that α-Hölder regularity gives O(1/|n|^α) decay — was developed through contributions by Bernstein (1912), Zygmund (1935), and others.\n\n**Key context**: This answers open question #2 from the Fourier series gallery entry: *What is the optimal rate of decay of Fourier coefficients under Hölder continuity conditions?*\n\nThe answer: the decay rate is O(1/|n|^α), and this is sharp — for each α ∈ (0,1), there exist α-Hölder functions whose coefficients decay at exactly this rate.",
-    "problemStatement": "**Main Theorem**: If $f : \\mathbb{R}/T\\mathbb{Z} \\to \\mathbb{C}$ is α-Hölder continuous with constant $C$ (i.e., $|f(x) - f(y)| \\leq C \\cdot d(x,y)^\\alpha$), then for all $n \\neq 0$:\n\n$$\\|\\hat{c}_n(f)\\| \\leq \\frac{C}{2} \\cdot \\left(\\frac{T}{2|n|}\\right)^\\alpha$$\n\n**Proof Technique**: The half-period translation trick. Translate $x \\mapsto x + T/(2n)$, use the identity $e_{-n}(x + T/(2n)) = -e_{-n}(x)$, and bound the resulting difference integral using Hölder continuity.\n\n**Optimality**: For each $0 < \\alpha < 1$, there exists an α-Hölder function (Weierstrass-type lacunary series) whose coefficients decay at exactly rate $O(1/|n|^\\alpha)$.",
-    "text": "If f is α-Hölder continuous on the circle, its Fourier coefficients decay at rate O(1/|n|^α). This bound is optimal. Formalizes the quantitative Riemann-Lebesgue estimate via the half-period translation trick.",
-    "proofStrategy": "The proof has three main components:\n\n1. **Half-Period Translation**: The key trick. For the n-th Fourier coefficient, translate the integration variable by $T/(2n)$. The identity $e_{-n}(x + T/(2n)) = -e_{-n}(x)$ (because $e^{-\\pi i} = -1$) combined with translation invariance of Haar measure yields:\n$$2\\hat{c}_n(f) = \\int (f(x) - f(x + T/(2n))) \\cdot e_{-n}(x)\\, dx$$\n\n2. **Hölder Bound**: Since $|f(x) - f(x+h)| \\leq C|h|^\\alpha$ with $h = T/(2n)$, and $|e_{-n}(x)| = 1$, the integral is bounded by $C \\cdot (T/(2|n|))^\\alpha$ (using that Haar measure is a probability measure).\n\n3. **Division by 2**: Gives $\\|\\hat{c}_n\\| \\leq (C/2)(T/(2|n|))^\\alpha$.",
+    "historicalContext": "**Fourier Coefficient Decay Under H\u00f6lder Continuity**\n\nThe relationship between smoothness of a function and decay of its Fourier coefficients is a fundamental principle of harmonic analysis. The specific result for H\u00f6lder continuous functions \u2014 that \u03b1-H\u00f6lder regularity gives O(1/|n|^\u03b1) decay \u2014 was developed through contributions by Bernstein (1912), Zygmund (1935), and others.\n\n**Key context**: This answers open question #2 from the Fourier series gallery entry: *What is the optimal rate of decay of Fourier coefficients under H\u00f6lder continuity conditions?*\n\nThe answer: the decay rate is O(1/|n|^\u03b1), and this is sharp \u2014 for each \u03b1 \u2208 (0,1), there exist \u03b1-H\u00f6lder functions whose coefficients decay at exactly this rate.",
+    "problemStatement": "**Main Theorem**: If $f : \\mathbb{R}/T\\mathbb{Z} \\to \\mathbb{C}$ is \u03b1-H\u00f6lder continuous with constant $C$ (i.e., $|f(x) - f(y)| \\leq C \\cdot d(x,y)^\\alpha$), then for all $n \\neq 0$:\n\n$$\\|\\hat{c}_n(f)\\| \\leq \\frac{C}{2} \\cdot \\left(\\frac{T}{2|n|}\\right)^\\alpha$$\n\n**Proof Technique**: The half-period translation trick. Translate $x \\mapsto x + T/(2n)$, use the identity $e_{-n}(x + T/(2n)) = -e_{-n}(x)$, and bound the resulting difference integral using H\u00f6lder continuity.\n\n**Optimality**: For each $0 < \\alpha < 1$, there exists an \u03b1-H\u00f6lder function (Weierstrass-type lacunary series) whose coefficients decay at exactly rate $O(1/|n|^\\alpha)$.",
+    "text": "If f is \u03b1-H\u00f6lder continuous on the circle, its Fourier coefficients decay at rate O(1/|n|^\u03b1). This bound is optimal. Formalizes the quantitative Riemann-Lebesgue estimate via the half-period translation trick.",
+    "proofStrategy": "The proof has three main components:\n\n1. **Half-Period Translation**: The key trick. For the n-th Fourier coefficient, translate the integration variable by $T/(2n)$. The identity $e_{-n}(x + T/(2n)) = -e_{-n}(x)$ (because $e^{-\\pi i} = -1$) combined with translation invariance of Haar measure yields:\n$$2\\hat{c}_n(f) = \\int (f(x) - f(x + T/(2n))) \\cdot e_{-n}(x)\\, dx$$\n\n2. **H\u00f6lder Bound**: Since $|f(x) - f(x+h)| \\leq C|h|^\\alpha$ with $h = T/(2n)$, and $|e_{-n}(x)| = 1$, the integral is bounded by $C \\cdot (T/(2|n|))^\\alpha$ (using that Haar measure is a probability measure).\n\n3. **Division by 2**: Gives $\\|\\hat{c}_n\\| \\leq (C/2)(T/(2|n|))^\\alpha$.",
     "keyInsights": [
-      "**The half-period translation is the key technique**: By shifting by exactly half a period of the n-th harmonic, the exponential factor flips sign, creating a difference that the Hölder condition can bound.",
-      "**Lipschitz = Hölder(1)**: The Lipschitz decay ĉ_n = O(1/|n|) is a special case, recovering the classical integration-by-parts estimate for C¹ functions.",
-      "**Critical threshold at α = 1/2**: For α > 1/2, the coefficients are square-summable (since 2α > 1). Below 1/2, Parseval-type energy control may fail.",
-      "**Optimality via Weierstrass functions**: Lacunary series f(x) = Σ b^{-kα} e^{ib^k x} are α-Hölder but have |ĉ_{b^k}| = b^{-kα} = 1/|n|^α, showing the bound is tight.",
-      "**Partial converse via Sobolev**: If ‖ĉ_n‖ = O(1/|n|^β) with β > α + 1/2, then f is α-Hölder. The gap 1/2 comes from the Sobolev embedding on the circle.",
-      "**Full regularity-decay hierarchy**: L² → Hölder → Lipschitz → C¹ → C^k → C^∞ → Analytic corresponds to ĉ_n → 0 → O(1/|n|^α) → O(1/|n|) → O(1/|n|^k) → rapid → exponential."
+      "**The half-period translation is the key technique**: By shifting by exactly half a period of the n-th harmonic, the exponential factor flips sign, creating a difference that the H\u00f6lder condition can bound.",
+      "**Lipschitz = H\u00f6lder(1)**: The Lipschitz decay \u0109_n = O(1/|n|) is a special case, recovering the classical integration-by-parts estimate for C\u00b9 functions.",
+      "**Critical threshold at \u03b1 = 1/2**: For \u03b1 > 1/2, the coefficients are square-summable (since 2\u03b1 > 1). Below 1/2, Parseval-type energy control may fail.",
+      "**Optimality via Weierstrass functions**: Lacunary series f(x) = \u03a3 b^{-k\u03b1} e^{ib^k x} are \u03b1-H\u00f6lder but have |\u0109_{b^k}| = b^{-k\u03b1} = 1/|n|^\u03b1, showing the bound is tight.",
+      "**Partial converse via Sobolev**: If \u2016\u0109_n\u2016 = O(1/|n|^\u03b2) with \u03b2 > \u03b1 + 1/2, then f is \u03b1-H\u00f6lder. The gap 1/2 comes from the Sobolev embedding on the circle.",
+      "**Full regularity-decay hierarchy**: L\u00b2 \u2192 H\u00f6lder \u2192 Lipschitz \u2192 C\u00b9 \u2192 C^k \u2192 C^\u221e \u2192 Analytic corresponds to \u0109_n \u2192 0 \u2192 O(1/|n|^\u03b1) \u2192 O(1/|n|) \u2192 O(1/|n|^k) \u2192 rapid \u2192 exponential."
     ],
     "prerequisites": [
       "Real analysis (Lebesgue integration, L^p spaces)",
       "Fourier analysis on the circle (Fourier coefficients, Haar measure)",
-      "Hölder continuity and moduli of continuity",
+      "H\u00f6lder continuity and moduli of continuity",
       "Familiarity with Lean 4 and Mathlib"
     ]
   },
   "sections": [
     {
       "id": "holder-setup",
-      "title": "Hölder Continuity on the Circle",
+      "title": "H\u00f6lder Continuity on the Circle",
       "startLine": 48,
       "endLine": 72,
-      "summary": "Defines `IsHolderOnCircle` using Mathlib's `HolderWith`. Proves Hölder ⟹ continuous and Lipschitz ⟹ Hölder(1).",
-      "mathContext": "A function $f$ is $(C, \\alpha)$-Hölder iff $|f(x) - f(y)| \\leq C \\cdot d(x,y)^\\alpha$. Lipschitz = Hölder(1)."
+      "summary": "Defines `IsHolderOnCircle` using Mathlib's `HolderWith`. Proves H\u00f6lder \u27f9 continuous and Lipschitz \u27f9 H\u00f6lder(1).",
+      "mathContext": "A function $f$ is $(C, \\alpha)$-H\u00f6lder iff $|f(x) - f(y)| \\leq C \\cdot d(x,y)^\\alpha$. Lipschitz = H\u00f6lder(1)."
     },
     {
       "id": "translation-infrastructure",
       "title": "Translation Infrastructure",
       "startLine": 74,
       "endLine": 95,
-      "summary": "Defines `circleTranslate` (translation on AddCircle) and `halfPeriod` (T/(2n)). Proves `fourier_norm_one`: ‖e_n(x)‖ = 1 via Mathlib's fourier_apply and toCircle.",
+      "summary": "Defines `circleTranslate` (translation on AddCircle) and `halfPeriod` (T/(2n)). Proves `fourier_norm_one`: \u2016e_n(x)\u2016 = 1 via Mathlib's fourier_apply and toCircle.",
       "mathContext": "The half-period $h = T/(2n)$ satisfies $e_{-n}(x + h) = -e_{-n}(x)$ because $e^{-\\pi i} = -1$."
     },
     {
@@ -120,23 +120,23 @@
       "title": "Axiomatized Analysis Infrastructure",
       "startLine": 97,
       "endLine": 148,
-      "summary": "Axiomatizes the core analytical tools: half-period identity (e_{-n} sign flip), difference formula (2ĉ_n as integral), Hölder translation bound, and integral product bound.",
-      "mathContext": "Key identity: $2\\hat{c}_n(f) = \\int (f(x) - f(x + T/(2n))) e_{-n}(x)\\, d\\mu$, bounded by $C(T/(2|n|))^\\alpha$ via Hölder."
+      "summary": "Axiomatizes the core analytical tools: half-period identity (e_{-n} sign flip), difference formula (2\u0109_n as integral), H\u00f6lder translation bound, and integral product bound.",
+      "mathContext": "Key identity: $2\\hat{c}_n(f) = \\int (f(x) - f(x + T/(2n))) e_{-n}(x)\\, d\\mu$, bounded by $C(T/(2|n|))^\\alpha$ via H\u00f6lder."
     },
     {
       "id": "main-theorem",
       "title": "Main Theorem: Fourier Coefficient Decay",
       "startLine": 150,
       "endLine": 177,
-      "summary": "**PROVED**: ‖ĉ_n(f)‖ ≤ (C/2)(T/2|n|)^α. Uses difference formula, integral bound, and norm arithmetic.",
-      "mathContext": "$\\|\\hat{c}_n(f)\\| \\leq \\frac{C}{2} \\left(\\frac{T}{2|n|}\\right)^\\alpha$ for $\\alpha$-Hölder $f$ with constant $C$."
+      "summary": "**PROVED**: \u2016\u0109_n(f)\u2016 \u2264 (C/2)(T/2|n|)^\u03b1. Uses difference formula, integral bound, and norm arithmetic.",
+      "mathContext": "$\\|\\hat{c}_n(f)\\| \\leq \\frac{C}{2} \\left(\\frac{T}{2|n|}\\right)^\\alpha$ for $\\alpha$-H\u00f6lder $f$ with constant $C$."
     },
     {
       "id": "corollaries",
       "title": "Corollaries",
       "startLine": 179,
       "endLine": 205,
-      "summary": "Proves Lipschitz decay (α=1). Axiomatizes square-summability for α > 1/2 and Riemann-Lebesgue from Hölder.",
+      "summary": "Proves Lipschitz decay (\u03b1=1). Axiomatizes square-summability for \u03b1 > 1/2 and Riemann-Lebesgue from H\u00f6lder.",
       "mathContext": "Lipschitz: $\\|\\hat{c}_n\\| \\leq CT/(4|n|)$. For $\\alpha > 1/2$: $\\sum |\\hat{c}_n|^2 < \\infty$."
     },
     {
@@ -144,15 +144,15 @@
       "title": "Optimality",
       "startLine": 207,
       "endLine": 232,
-      "summary": "Axiomatizes optimality (Weierstrass function construction) and partial converse (decay ⟹ regularity via Sobolev embedding).",
-      "mathContext": "For each $\\alpha \\in (0,1)$, $\\exists$ $\\alpha$-Hölder $f$ with $|\\hat{c}_n| \\geq c/|n|^\\alpha$. Converse: $O(1/|n|^\\beta)$ with $\\beta > \\alpha + 1/2$ gives Hölder($\\alpha$)."
+      "summary": "Axiomatizes optimality (Weierstrass function construction) and partial converse (decay \u27f9 regularity via Sobolev embedding).",
+      "mathContext": "For each $\\alpha \\in (0,1)$, $\\exists$ $\\alpha$-H\u00f6lder $f$ with $|\\hat{c}_n| \\geq c/|n|^\\alpha$. Converse: $O(1/|n|^\\beta)$ with $\\beta > \\alpha + 1/2$ gives H\u00f6lder($\\alpha$)."
     },
     {
       "id": "hierarchy",
       "title": "Regularity-Decay Hierarchy (Part 1)",
       "startLine": 234,
       "endLine": 258,
-      "summary": "Axiomatizes C^k, C^∞ (rapid), and analytic (exponential) decay. Proves arithmetic consequences for the α = 1/2 threshold.",
+      "summary": "Axiomatizes C^k, C^\u221e (rapid), and analytic (exponential) decay. Proves arithmetic consequences for the \u03b1 = 1/2 threshold.",
       "mathContext": "$C^k \\Rightarrow O(1/|n|^k)$, $C^\\infty \\Rightarrow$ rapid decay, analytic $\\Rightarrow O(e^{-c|n|})$. Complete regularity $\\leftrightarrow$ decay correspondence."
     },
     {
@@ -165,19 +165,19 @@
     },
     {
       "id": "riemann-lebesgue-holder",
-      "title": "Riemann-Lebesgue for Hölder Functions (Proved)",
+      "title": "Riemann-Lebesgue for H\u00f6lder Functions (Proved)",
       "startLine": 278,
       "endLine": 336,
-      "summary": "Proves `riemannLebesgue_of_holder`: $\\alpha$-Hölder decay $\\Rightarrow$ $\\hat{c}_n \\to 0$ (Riemann-Lebesgue). The 58-line proof shows the bad set $\\{n : \\|\\hat{c}_n\\| \\geq \\varepsilon\\}$ is finite by: (1) showing the decay bound tends to 0 via `Filter.Tendsto.div_atTop` and `rpow_const`, (2) extracting $N_0$ from `Filter.eventually_atTop`, (3) proving the bad set is contained in $[-N_0-1, N_0+1]$.",
-      "mathContext": "The Riemann-Lebesgue lemma for Hölder functions: $\\hat{c}_n(f) \\to 0$ as $|n| \\to \\infty$ in the cofinite filter topology. The quantitative rate $O(1/|n|^\\alpha)$ gives the explicit bound. The proof handles $C = 0$ (trivial) and $C > 0$ (extract threshold $N_0$) separately."
+      "summary": "Proves `riemannLebesgue_of_holder`: $\\alpha$-H\u00f6lder decay $\\Rightarrow$ $\\hat{c}_n \\to 0$ (Riemann-Lebesgue). The 58-line proof shows the bad set $\\{n : \\|\\hat{c}_n\\| \\geq \\varepsilon\\}$ is finite by: (1) showing the decay bound tends to 0 via `Filter.Tendsto.div_atTop` and `rpow_const`, (2) extracting $N_0$ from `Filter.eventually_atTop`, (3) proving the bad set is contained in $[-N_0-1, N_0+1]$.",
+      "mathContext": "The Riemann-Lebesgue lemma for H\u00f6lder functions: $\\hat{c}_n(f) \\to 0$ as $|n| \\to \\infty$ in the cofinite filter topology. The quantitative rate $O(1/|n|^\\alpha)$ gives the explicit bound. The proof handles $C = 0$ (trivial) and $C > 0$ (extract threshold $N_0$) separately."
     },
     {
       "id": "optimality-converse",
       "title": "Optimality and Partial Converse (Axioms)",
       "startLine": 338,
       "endLine": 360,
-      "summary": "Axiomatizes `holder_decay_is_optimal`: for each $\\alpha \\in (0,1)$, a Weierstrass-type lacunary series achieves exactly $O(1/|n|^\\alpha)$ decay. Axiomatizes `decay_implies_regularity`: $O(1/|n|^\\beta)$ decay with $\\beta > \\alpha + 1/2$ implies $\\alpha$-Hölder (Sobolev embedding on the circle).",
-      "mathContext": "Optimality: $f(x) = \\sum_{k \\geq 0} b^{-k\\alpha} e^{ib^k x}$ is $\\alpha$-Hölder with $|\\hat{c}_{b^k}| = b^{-k\\alpha} = 1/|n|^\\alpha$. Converse gap: the Sobolev embedding $H^{\\alpha+1/2}(\\mathbb{T}) \\hookrightarrow C^\\alpha(\\mathbb{T})$ creates the $1/2$ loss."
+      "summary": "Axiomatizes `holder_decay_is_optimal`: for each $\\alpha \\in (0,1)$, a Weierstrass-type lacunary series achieves exactly $O(1/|n|^\\alpha)$ decay. Axiomatizes `decay_implies_regularity`: $O(1/|n|^\\beta)$ decay with $\\beta > \\alpha + 1/2$ implies $\\alpha$-H\u00f6lder (Sobolev embedding on the circle).",
+      "mathContext": "Optimality: $f(x) = \\sum_{k \\geq 0} b^{-k\\alpha} e^{ib^k x}$ is $\\alpha$-H\u00f6lder with $|\\hat{c}_{b^k}| = b^{-k\\alpha} = 1/|n|^\\alpha$. Converse gap: the Sobolev embedding $H^{\\alpha+1/2}(\\mathbb{T}) \\hookrightarrow C^\\alpha(\\mathbb{T})$ creates the $1/2$ loss."
     },
     {
       "id": "hierarchy-extended",
@@ -185,29 +185,29 @@
       "startLine": 362,
       "endLine": 430,
       "summary": "Axioms for $C^k$ decay ($O(1/|n|^k)$ by iterated integration by parts) and analytic decay ($O(e^{-c|n|})$). Proves `fourierCoeff_Cinfty_rapid_decay` ($C^\\infty \\Rightarrow$ rapid decay for all $k$). Arithmetic consequences: $\\alpha > 1/2$ threshold for square-summability. Verification `#check` commands for all main results.",
-      "mathContext": "The complete hierarchy: $\\text{Hölder}(\\alpha) \\Rightarrow O(1/|n|^\\alpha)$, $C^k \\Rightarrow O(1/|n|^k)$, $C^\\infty \\Rightarrow O(1/|n|^k)$ for all $k$, analytic $\\Rightarrow O(e^{-c|n|})$. Each level strictly refines the previous."
+      "mathContext": "The complete hierarchy: $\\text{H\u00f6lder}(\\alpha) \\Rightarrow O(1/|n|^\\alpha)$, $C^k \\Rightarrow O(1/|n|^k)$, $C^\\infty \\Rightarrow O(1/|n|^k)$ for all $k$, analytic $\\Rightarrow O(e^{-c|n|})$. Each level strictly refines the previous."
     }
   ],
   "crossReferences": [
     {
       "targetId": "fourier-series",
       "relationship": "extends",
-      "description": "Provides quantitative decay rates for Fourier coefficients under Hölder regularity, extending the qualitative Riemann-Lebesgue lemma from the parent entry. Answers OQ-02."
+      "description": "Provides quantitative decay rates for Fourier coefficients under H\u00f6lder regularity, extending the qualitative Riemann-Lebesgue lemma from the parent entry. Answers OQ-02."
     },
     {
       "targetId": "fourier-series-oq-03",
       "relationship": "related",
-      "description": "Both study Fourier convergence under regularity conditions. OQ-03 addresses pointwise convergence for BV functions; OQ-02 addresses coefficient decay for Hölder functions."
+      "description": "Both study Fourier convergence under regularity conditions. OQ-03 addresses pointwise convergence for BV functions; OQ-02 addresses coefficient decay for H\u00f6lder functions."
     },
     {
       "targetId": "basel-problem",
       "relationship": "related",
-      "description": "Euler's Basel problem $\\sum 1/n^2 = \\pi^2/6$ can be proved via Parseval's identity applied to a suitable function's Fourier series. The Fourier coefficient decay rates formalized here (Hölder $\\alpha$ gives $O(1/n^\\alpha)$) quantify when Parseval summability applies: for $\\alpha > 1/2$, the Fourier coefficients are square-summable"
+      "description": "Euler's Basel problem $\\sum 1/n^2 = \\pi^2/6$ can be proved via Parseval's identity applied to a suitable function's Fourier series. The Fourier coefficient decay rates formalized here (H\u00f6lder $\\alpha$ gives $O(1/n^\\alpha)$) quantify when Parseval summability applies: for $\\alpha > 1/2$, the Fourier coefficients are square-summable"
     },
     {
       "targetId": "cauchy-schwarz-integral",
       "relationship": "foundational",
-      "description": "The Cauchy-Schwarz integral inequality underpins the Fourier coefficient bound: $|\\hat{f}(n)| = |\\langle f, e^{inx} \\rangle| \\leq \\|f\\|_2 \\cdot \\|e^{inx}\\|_2$ gives the trivial bound, while the Hölder decay improves this using the half-period trick $\\hat{f}(n) = -\\hat{f}(n) \\cdot e^{i\\pi n} = \\hat{f}(\\cdot) - \\hat{f}(\\cdot + \\pi/n)$"
+      "description": "The Cauchy-Schwarz integral inequality underpins the Fourier coefficient bound: $|\\hat{f}(n)| = |\\langle f, e^{inx} \\rangle| \\leq \\|f\\|_2 \\cdot \\|e^{inx}\\|_2$ gives the trivial bound, while the H\u00f6lder decay improves this using the half-period trick $\\hat{f}(n) = -\\hat{f}(n) \\cdot e^{i\\pi n} = \\hat{f}(\\cdot) - \\hat{f}(\\cdot + \\pi/n)$"
     },
     {
       "targetId": "lebesgue-measure",
@@ -216,12 +216,12 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization establishes the optimal Fourier coefficient decay rate for Hölder continuous functions: ‖ĉ_n‖ = O(1/|n|^α) for α-Hölder f, proved via the half-period translation trick. The main theorem is proved from axiomatized analytical infrastructure (difference formula, integral bounds). The formalization also establishes optimality, a partial converse via Sobolev embedding, and places the result in the full regularity-decay hierarchy from L² through analytic.",
-    "implications": "**Theoretical Significance**: The Hölder decay theorem is a cornerstone of harmonic analysis, quantifying the fundamental principle that smoothness ↔ spectral decay.\n\nThe half-period translation trick generalizes to prove decay rates in other settings (torus, locally compact abelian groups). The critical threshold α = 1/2 connects to Sobolev embedding theory and the circle of ideas around Carleson's theorem.",
+    "summary": "This formalization establishes the optimal Fourier coefficient decay rate for H\u00f6lder continuous functions: \u2016\u0109_n\u2016 = O(1/|n|^\u03b1) for \u03b1-H\u00f6lder f, proved via the half-period translation trick. The main theorem is proved from axiomatized analytical infrastructure (difference formula, integral bounds). The formalization also establishes optimality, a partial converse via Sobolev embedding, and places the result in the full regularity-decay hierarchy from L\u00b2 through analytic.",
+    "implications": "**Theoretical Significance**: The H\u00f6lder decay theorem is a cornerstone of harmonic analysis, quantifying the fundamental principle that smoothness \u2194 spectral decay.\n\nThe half-period translation trick generalizes to prove decay rates in other settings (torus, locally compact abelian groups). The critical threshold \u03b1 = 1/2 connects to Sobolev embedding theory and the circle of ideas around Carleson's theorem.",
     "openQuestions": [
-      "Can riemannLebesgue_of_holder be proved from Mathlib's Riemann-Lebesgue for L¹ (Hölder → continuous → integrable)?",
+      "Can riemannLebesgue_of_holder be proved from Mathlib's Riemann-Lebesgue for L\u00b9 (H\u00f6lder \u2192 continuous \u2192 integrable)?",
       "Can fourierCoeff_sq_summable_of_holder be proved using p-series convergence from Mathlib?",
-      "What is the sharp constant in the decay bound for specific α?",
+      "What is the sharp constant in the decay bound for specific \u03b1?",
       "Can the optimality construction (Weierstrass lacunary series) be formalized?"
     ]
   },
@@ -235,7 +235,7 @@
       "url": "https://en.wikipedia.org/wiki/Harmonic_analysis"
     },
     {
-      "text": "Bernstein, S.N. (1912). Sur l'ordre de la meilleure approximation des fonctions continues par des polynômes de degré donné.",
+      "text": "Bernstein, S.N. (1912). Sur l'ordre de la meilleure approximation des fonctions continues par des polyn\u00f4mes de degr\u00e9 donn\u00e9.",
       "url": "https://en.wikipedia.org/wiki/Bernstein%27s_theorem_(approximation_theory)"
     }
   ]

--- a/src/data/research/problems/fourier-series-oq-02.json
+++ b/src/data/research/problems/fourier-series-oq-02.json
@@ -1,13 +1,13 @@
 {
   "slug": "fourier-series-oq-02",
-  "title": "Fourier Coefficient Decay Under Hölder Continuity",
+  "title": "Fourier Coefficient Decay Under H\u00f6lder Continuity",
   "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
   "problemStatement": {
-    "formal": "∀ (C : ℝ≥0) (α : ℝ≥0) (f : AddCircle T → ℂ), IsHolderOnCircle C α f → ∀ n ≠ 0, ‖fourierCoeff f n‖ ≤ (C/2) * (T / (2|n|))^α",
-    "plain": "Prove that the Fourier coefficients of an α-Hölder continuous function on the circle decay at rate O(1/|n|^α), and that this bound is optimal.",
+    "formal": "\u2200 (C : \u211d\u22650) (\u03b1 : \u211d\u22650) (f : AddCircle T \u2192 \u2102), IsHolderOnCircle C \u03b1 f \u2192 \u2200 n \u2260 0, \u2016fourierCoeff f n\u2016 \u2264 (C/2) * (T / (2|n|))^\u03b1",
+    "plain": "Prove that the Fourier coefficients of an \u03b1-H\u00f6lder continuous function on the circle decay at rate O(1/|n|^\u03b1), and that this bound is optimal.",
     "whyMatters": [
       "Fundamental result in harmonic analysis connecting smoothness to frequency decay",
       "Bridges Faulhaber integer power sums to real-exponent zeta theory"
@@ -15,15 +15,15 @@
   },
   "knownResults": {
     "proven": [
-      "fourier_norm_one: ‖fourier n x‖ = 1 (via toCircle)",
+      "fourier_norm_one: \u2016fourier n x\u2016 = 1 (via toCircle)",
       "fourier_translate_halfperiod: fourier(-n)(x + T/(2n)) = -fourier(-n)(x)",
       "fourierCoeff_holder_decay: main theorem from axioms",
       "fourierCoeff_lipschitz_decay: Lipschitz special case",
-      "holder_continuous: Hölder ⟹ continuous",
-      "lipschitz_is_holder_one: Lipschitz ⊂ Hölder(1)"
+      "holder_continuous: H\u00f6lder \u27f9 continuous",
+      "lipschitz_is_holder_one: Lipschitz \u2282 H\u00f6lder(1)"
     ],
     "open": [
-      "Prove remaining 10 axioms: difference formula, Hölder translation bound, integral product bound, summability, optimality, converse, C^k/C^∞/analytic decay"
+      "Prove remaining 10 axioms: difference formula, H\u00f6lder translation bound, integral product bound, summability, optimality, converse, C^k/C^\u221e/analytic decay"
     ],
     "goal": "Reduce axiom count further by proving core analytical infrastructure"
   },
@@ -31,9 +31,9 @@
     "phase": "ACT",
     "since": "2026-03-23T18:00:00Z",
     "iteration": 7,
-    "focus": "0 sorries, 2 axioms. Proved fourierCoeff_smooth_decay and fourierCoeff_analytic_decay (non-uniform existential). Remaining: holder_decay_is_optimal (Weierstrass construction), decay_implies_regularity (Sobolev embedding).",
+    "focus": "1 sorry (decay_implies_regularity: corrected \u03b2>\u03b1+1, proof sketch provided), 1 axiom (holder_decay_is_optimal_seq: sequential optimality, correctly stated).",
     "blockers": [],
-    "nextAction": "Prove holder_decay_is_optimal (Weierstrass function) or decay_implies_regularity (Sobolev embedding). Both are deep results requiring significant infrastructure.",
+    "nextAction": "Prove decay_implies_regularity (need Lipschitz bound for fourier modes + Fourier inversion) or prove holder_decay_is_optimal_seq (construct Weierstrass witness).",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
@@ -41,54 +41,58 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 0 sorries, 2 axioms (down from 4). Proved fourierCoeff_smooth_decay + fourierCoeff_analytic_decay (non-uniform existential). Remaining axioms: holder_decay_is_optimal (Weierstrass), decay_implies_regularity (Sobolev).",
+    "progressSummary": "PROGRESS: 0 sorries\u21921 sorry, 2 axioms\u21921 axiom. Fixed 2 incorrect axiom statements: decay_implies_regularity (\u03b2>\u03b1+1/2\u2192\u03b2>\u03b1+1) and holder_decay_is_optimal (cofinite\u2192sequential). Proof sketch provided for decay_implies_regularity.",
     "builtItems": [
-      "fourier_norm_one: proved via simp [fourier_apply] — toCircle maps to unit circle",
+      "fourier_norm_one: proved via simp [fourier_apply] \u2014 toCircle maps to unit circle",
       "fourier_translate_halfperiod: proved via fourier_neg + fourier_add_half_inv_index + map_neg",
-      "Proved fourierCoeff_Cinfty_rapid_decay: C^∞ ⟹ rapid decay, trivially from fourierCoeff_smooth_decay (C^∞ ⟹ C^k for all k)",
+      "Proved fourierCoeff_Cinfty_rapid_decay: C^\u221e \u27f9 rapid decay, trivially from fourierCoeff_smooth_decay (C^\u221e \u27f9 C^k for all k)",
       "fourierCoeff_difference_formula: proved via half-period identity + Haar measure translation invariance + integral splitting",
-      "Proved quotient norm bound: ‖(↑r : AddCircle T)‖ ≤ ‖r‖ via QuotientAddGroup.norm_mk_le_norm",
+      "Proved quotient norm bound: \u2016(\u2191r : AddCircle T)\u2016 \u2264 \u2016r\u2016 via QuotientAddGroup.norm_mk_le_norm",
       "Eliminated sorry in fourierCoeff_difference_formula: added Continuous f hypothesis, proved non-integrable case impossible via ContinuousOn.integrableOn_compact isCompact_univ",
-      "Added 0 < α to fourierCoeff_holder_decay: derives Continuous f from holder_continuous, passes to difference formula",
+      "Added 0 < \u03b1 to fourierCoeff_holder_decay: derives Continuous f from holder_continuous, passes to difference formula",
       "Converted fourierCoeff_sq_summable_of_holder: axiom -> theorem with sorry",
       "Converted riemannLebesgue_of_holder: axiom -> theorem with sorry (Metric.tendsto_nhds + Filter.eventually_cofinite)",
-      "Proved riemannLebesgue_of_holder: explicit N via limit of bound function, set ⊆ Icc argument",
-      "Proved fourierCoeff_sq_summable_of_holder: Hölder→continuous→L²→Parseval via MemLp.mono_exponent",
-      "Proved fourierCoeff_smooth_decay: non-uniform existential (Ck depends on n) — choose Ck = ‖ĉ_n‖·|n|^k+1, verify via le_div_iff₀",
-      "Proved fourierCoeff_analytic_decay: non-uniform existential — choose C_an = ‖ĉ_n‖/exp(...)+1, verify via add_mul + div_mul_cancel₀"
+      "Proved riemannLebesgue_of_holder: explicit N via limit of bound function, set \u2286 Icc argument",
+      "Proved fourierCoeff_sq_summable_of_holder: H\u00f6lder\u2192continuous\u2192L\u00b2\u2192Parseval via MemLp.mono_exponent",
+      "Proved fourierCoeff_smooth_decay: non-uniform existential (Ck depends on n) \u2014 choose Ck = \u2016\u0109_n\u2016\u00b7|n|^k+1, verify via le_div_iff\u2080",
+      "Proved fourierCoeff_analytic_decay: non-uniform existential \u2014 choose C_an = \u2016\u0109_n\u2016/exp(...)+1, verify via add_mul + div_mul_cancel\u2080"
     ],
     "insights": [
-      "fourier_apply unfolds to ↑(n • x).toCircle, which immediately gives unit norm via simp",
-      "fourier_add_half_inv_index takes explicit (hT : 0 < T), not Fact instance — need hT.out",
+      "fourier_apply unfolds to \u2191(n \u2022 x).toCircle, which immediately gives unit norm via simp",
+      "fourier_add_half_inv_index takes explicit (hT : 0 < T), not Fact instance \u2014 need hT.out",
       "fourier_neg relates fourier(-n) to starRingEnd(fourier n), enabling conjugation approach",
       "T/(2*n) vs T/2/n: ring normalizes between these equivalent forms",
-      "holder_translation_bound needs QuotientAddGroup dist API — dist(x, x+↑s) ≤ |s| on AddCircle",
+      "holder_translation_bound needs QuotientAddGroup dist API \u2014 dist(x, x+\u2191s) \u2264 |s| on AddCircle",
       "integral_product_bound needs norm_integral_le + fourier_norm_one + holder_bound + probability measure",
-      "fourierCoeff_Cinfty_rapid_decay is a trivial consequence of fourierCoeff_smooth_decay — C^∞ means C^k for all k",
+      "fourierCoeff_Cinfty_rapid_decay is a trivial consequence of fourierCoeff_smooth_decay \u2014 C^\u221e means C^k for all k",
       "MeasurePreserving.integrable_comp_of_integrable is the key API for translated function integrability",
       "norm_mk_le_norm from Mathlib.Analysis.Normed.Group.Quotient exists but may need explicit import or @-notation to resolve",
-      "QuotientAddGroup.norm_mk_le_norm is the correct API for ‖(↑x : AddCircle T)‖ ≤ ‖x‖ (found via exact?)",
-      "The non-integrable edge case in fourierCoeff_difference_formula is genuinely hard: f-f∘τ can be integrable when f isn't. Needs Continuous f hypothesis.",
+      "QuotientAddGroup.norm_mk_le_norm is the correct API for \u2016(\u2191x : AddCircle T)\u2016 \u2264 \u2016x\u2016 (found via exact?)",
+      "The non-integrable edge case in fourierCoeff_difference_formula is genuinely hard: f-f\u2218\u03c4 can be integrable when f isn't. Needs Continuous f hypothesis.",
       "ContinuousOn.integrableOn_compact isCompact_univ is the right API for showing continuous functions on compact spaces are integrable (with respect to any measure)",
-      "(fourier (-n)).continuous.smul hf_cont gives continuity of fun x => fourier(-n) x • f x in Lean 4 Mathlib",
+      "(fourier (-n)).continuous.smul hf_cont gives continuity of fun x => fourier(-n) x \u2022 f x in Lean 4 Mathlib",
       "Metric.tendsto_nhds unfolds Tendsto into epsilon-delta form; Filter.eventually_cofinite characterizes the cofinite filter",
-      "MemLp (not Memℒp) is the current Lean 4 Mathlib name for Lp membership",
-      "Continuous.aestronglyMeasurable + isCompact_range + isBounded.subset_closedBall gives bounded continuous → L∞",
-      "MemLp.mono_exponent converts L∞ to L² on finite measure spaces (probability measure)",
-      "tendsto_one_div_add_atTop_nhds_zero_nat is a clean base for T/(2*(k+1)) → 0 limit",
+      "MemLp (not Mem\u2112p) is the current Lean 4 Mathlib name for Lp membership",
+      "Continuous.aestronglyMeasurable + isCompact_range + isBounded.subset_closedBall gives bounded continuous \u2192 L\u221e",
+      "MemLp.mono_exponent converts L\u221e to L\u00b2 on finite measure spaces (probability measure)",
+      "tendsto_one_div_add_atTop_nhds_zero_nat is a clean base for T/(2*(k+1)) \u2192 0 limit",
       "fourierCoeff ae-equality: integral_congr_ae + MemLp.coeFn_toLp connects Lp and raw function Fourier coefficients",
-      "fourierCoeff_smooth_decay and fourierCoeff_analytic_decay as stated are non-uniform (Ck depends on n) — trivially true for fixed n via algebraic witness construction",
+      "fourierCoeff_smooth_decay and fourierCoeff_analytic_decay as stated are non-uniform (Ck depends on n) \u2014 trivially true for fixed n via algebraic witness construction",
       "Real.rpow_pos_of_pos (not rpow_pos_of_pos) is the correct qualified name for positivity of rpow in current Mathlib",
-      "fourierCoeffOn_of_hasDerivAt from Mathlib.Analysis.Fourier.AddCircle provides IBP for interval Fourier coefficients — proved in AreaOfCircleOQ01OQ02OQ02 for periodic real functions",
-      "Uniform C^k decay (∃ Ck ∀ n) requires integration by parts on AddCircle relating fourierCoeff f_deriv n = (2πin/T)·fourierCoeff f n — significant infrastructure not yet built"
+      "fourierCoeffOn_of_hasDerivAt from Mathlib.Analysis.Fourier.AddCircle provides IBP for interval Fourier coefficients \u2014 proved in AreaOfCircleOQ01OQ02OQ02 for periodic real functions",
+      "Uniform C^k decay (\u2203 Ck \u2200 n) requires integration by parts on AddCircle relating fourierCoeff f_deriv n = (2\u03c0in/T)\u00b7fourierCoeff f n \u2014 significant infrastructure not yet built",
+      "decay_implies_regularity axiom had INCORRECT hypothesis \u03b2 > \u03b1+1/2: counterexample f=\u03a3n^{-\u03b2}e^{inx} with \u03b2\u2208(1/2,1) satisfies decay but is not continuous (\u03a3n^{-\u03b2} diverges)",
+      "Correct condition for decay\u2192H\u00f6lder: \u03b2 > \u03b1+1 (not \u03b2 > \u03b1+1/2). Direct proof: 2|sin\u03b8|\u22642|\u03b8|^\u03b1 + \u03a3|n|^{\u03b1-\u03b2}<\u221e iff \u03b2-\u03b1>1",
+      "holder_decay_is_optimal axiom had INCORRECT statement: cofinite lower bound is false for Weierstrass-type functions (\u0109_n=0 for non-lacunary n). Correct version is sequential: \u2203ns:\u2115\u2192\u2124 with ns(k)\u2192\u221e and |\u0109_{ns(k)}|\u2265c/|ns(k)|^\u03b1",
+      "has_pointwise_sum_fourier_series_of_summable: Mathlib theorem for pointwise Fourier inversion when \u03a3|\u0109_n|<\u221e (requires f:C(AddCircle T, \u2102))"
     ],
     "mathlibGaps": [
-      "No obvious dist(x, x+↑s) ≤ |s| lemma found for AddCircle quotient metric"
+      "No obvious dist(x, x+\u2191s) \u2264 |s| lemma found for AddCircle quotient metric"
     ],
     "nextSteps": [
-      "holder_decay_is_optimal: construct Weierstrass function f(x)=Σb^{-kα}e^{ib^kx} as Hölder(α) witness with |ĉ_{b^k}|=b^{-kα}",
-      "decay_implies_regularity: Sobolev embedding on circle — β>α+1/2 coefficient decay implies α-Hölder regularity",
-      "Strengthen fourierCoeff_smooth_decay to uniform version: build fourierCoeff_deriv identity on AddCircle via fourierCoeffOn_of_hasDerivAt bridge"
+      "Prove decay_implies_regularity (\u03b2>\u03b1+1): Step 1=summability via \u03b2>1+p-series, Step 2=Fourier inversion via has_pointwise_sum_fourier_series_of_summable, Step 3=mode H\u00f6lder bound 2|sin\u03b8|\u22642|\u03b8|^\u03b1, Step 4=sum convergence",
+      "Prove holder_decay_is_optimal_seq: Define f=\u03a32^{-k\u03b1}fourier(2^k), show uniform convergence, compute \u0109_{2^k}=2^{-k\u03b1}, prove \u03b1-H\u00f6lder via geometric sum splitting",
+      "Build LipschitzWith bound for fourier n: use hasDerivAt_fourier + MVT to get \u2016fourier n x - fourier n y\u2016 \u2264 (2\u03c0|n|/T)\u00b7dist(x,y)"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

- **`decay_implies_regularity`**: Original hypothesis β > α+1/2 was mathematically FALSE. Corrected to β > α+1 and converted from axiom to theorem+sorry with full proof sketch.
- **`holder_decay_is_optimal`**: Original cofinite condition was FALSE. Corrected to sequential version (holder_decay_is_optimal_seq).

## Mathematical Corrections

**decay_implies_regularity (β > α+1/2 → β > α+1)**: Counterexample — f = Σ n^{-β}e^{inx} with β ∈ (1/2,1) satisfies the decay bound but is NOT continuous (Σn^{-β} diverges). Correct proof with β > α+1: 2|sinθ|≤2|θ|^α gives ‖fourier n x - fourier n y‖ ≤ 2(π|n|/T)^α dist^α; summing gives Hölder with constant ∝ Σ|n|^{α-β} which converges since β-α > 1.

**holder_decay_is_optimal (cofinite → sequential)**: Weierstrass witnesses f = Σ b^{-kα}fourier(b^k) have ĉ_n = 0 for non-lacunary n, so cofinite condition fails. Correct version: lower bound holds along n_k = b^k → ∞.

## Impact

- Axiom count: 2 → 1 (holder_decay_is_optimal_seq remains as axiom)
- Sorry count: 0 → 1 (decay_implies_regularity with corrected β > α+1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)