### PR TITLE
fix: update newton-inductive-step-oq-01 sorry count 2→1

### DIFF
--- a/src/data/proofs/newton-inductive-step-oq-01/meta.json
+++ b/src/data/proofs/newton-inductive-step-oq-01/meta.json
@@ -19,7 +19,7 @@
       "research"
     ],
     "badge": "original",
-    "sorries": 2,
+    "sorries": 1,
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -42,11 +42,11 @@
       "Newton's inequality for n=3 k=2: (xy+xz+yz)² ≥ 3xyz(x+y+z)",
       "First Maclaurin inequality: ē₁² ≥ ē₂",
       "AM-GM connection: (Σxᵢ/n)² ≥ (Σᵢ<ⱼ xᵢxⱼ)/C(n,2)",
-      "Statement of general Newton inequality with inductive proof structure"
+      "Newton's inequality in mean form (ē_k² ≥ ē_{k-1}·ē_{k+1}) fully proved, derived from the binomial form"
     ],
     "axiomCount": 0,
     "lineCount": 336,
-    "assumptions": "None. 0 axiom declarations. 2 sorries in the general inductive case (newton_inequality_binomial, newton_inequality_means).",
+    "assumptions": "0 axiom declarations. 1 sorry: newton_inequality_binomial (the general inductive Cauchy-Schwarz step). newton_inequality_means is now fully proved (derived from newton_inequality_binomial).",
     "prerequisites": [
       "Elementary symmetric polynomials",
       "Binomial coefficients and absorption identities",


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: `newton-inductive-step-oq-01`
**Problem**: meta.json claimed 2 sorries but Lean file has 1 sorry — `newton_inequality_means` was proved after meta.json was last updated.

## Changes

- `sorries`: 2 → 1
- `assumptions`: corrected to reflect only `newton_inequality_binomial` remaining
- `originalContributions`: updated to note `newton_inequality_means` is fully proved

## Evidence

```
grep -n "sorry" proofs/Proofs/NewtonInductiveStepOQ01.lean
# 154:    sorry   (in newton_inequality_binomial only)
```

The file itself documents at the bottom: "0 axioms. 1 sorry (newton_inequality_binomial — the inductive Cauchy-Schwarz step)."

`newton_inequality_means` is derived from `newton_inequality_binomial` by clearing binomial coefficient denominators — fully proved using `linarith`.

---
Discovered during gallery integrity audit.