### PR TITLE
fix: correct yang-mills sorries count 0→1

### DIFF
--- a/src/data/proofs/yang-mills/meta.json
+++ b/src/data/proofs/yang-mills/meta.json
@@ -22,7 +22,7 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Lie.Basic",


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: `yang-mills`
**Problem**: meta.json `sorries: 0` but `Proofs/YangMills/Exploration.lean` has 1 sorry in `coupling_controlled` (Mathlib API drift).

## Evidence

```
grep -n "sorry" proofs/Proofs/YangMills/Exploration.lean
# 22793:  sorry -- MATHLIB-DRIFT: multi-line proof with broken Real.log + calc chain
```

`YangMillsMassGap.lean` imports `YangMills/Exploration.lean` (line 4), so the combined source has 1 sorry.

The `assumptions` field already correctly documented this: "1 sorry (coupling_controlled in Exploration.lean, Mathlib drift)". Only the `sorries` count field was incorrect.

## Change

- `sorries`: 0 → 1

---
Discovered during gallery integrity audit.