### PR TITLE
Research: erdos-776 - size-1/complement lemma + n-2 upper bound

### DIFF
--- a/proofs/Proofs/Erdos776Problem.lean
+++ b/proofs/Proofs/Erdos776Problem.lean
@@ -264,3 +264,128 @@ theorem n_not_in_antichain_sizes {n : ℕ} {F : Finset (Finset (Fin n))}
       Finset.card_le_one.mpr fun a ha b hb => (hall a ha).trans (hall b hb).symm
     omega
   exact absurd (Finset.subset_univ B) (hF B hBF Finset.univ hAF hBne)
+
+/- ## Complement Restriction Lemma -/
+
+/-- In an antichain over Fin n (n ≥ 3), if A = {a} (size 1) and B (size n−1)
+    both belong to F with A ≠ B, then every member of F is either A or B.
+
+    Proof: Since A ⊄ B (antichain), a ∉ B. Since |B| = n−1 and a ∉ B, B is the
+    complement of {a}. Any other C ∈ F satisfies a ∉ C (antichain with {a}),
+    hence C ⊆ complement({a}) = B; antichain then forces C = B. -/
+lemma size1_and_complement_pair_only {n : ℕ} (hn : 3 ≤ n)
+    {F : SubsetFamily n}
+    (hF : IsAntichainFamily F)
+    {A B : Finset (Fin n)}
+    (hA : A ∈ F) (hAcard : A.card = 1)
+    (hB : B ∈ F) (hBcard : B.card = n - 1)
+    (hAB : A ≠ B) :
+    ∀ C ∈ F, C = A ∨ C = B := by
+  -- Extract the unique element a of A
+  obtain ⟨a, rfl⟩ := Finset.card_eq_one.mp hAcard
+  intro C hC
+  -- a ∉ B: antichain gives ¬({a} ⊆ B)
+  have ha_notB : a ∉ B := by
+    have h := hF {a} hA B hB hAB
+    rwa [Finset.singleton_subset_iff] at h
+  -- B = Finset.univ.erase a: B ⊆ complement of {a} and both have card n−1
+  have hB_eq : B = Finset.univ.erase a := by
+    apply Finset.eq_of_subset_of_card_le
+    · intro x hx
+      rw [Finset.mem_erase]
+      exact ⟨fun heq => ha_notB (heq ▸ hx), Finset.mem_univ x⟩
+    · rw [Finset.card_erase_of_mem (Finset.mem_univ a), Finset.card_univ, Fintype.card_fin]
+      omega
+  -- Case split: C = {a} or C ≠ {a}
+  by_cases hCA : C = {a}
+  · left; exact hCA
+  · right
+    -- a ∉ C: antichain gives ¬({a} ⊆ C)
+    have ha_notC : a ∉ C := by
+      have h := hF {a} hA C hC hCA
+      rwa [Finset.singleton_subset_iff] at h
+    -- C ⊆ univ.erase a = B
+    have hCB : C ⊆ B := by
+      rw [hB_eq]
+      intro x hx
+      rw [Finset.mem_erase]
+      exact ⟨fun heq => ha_notC (heq ▸ hx), Finset.mem_univ x⟩
+    -- Antichain forces C = B
+    by_cases hCeqB : C = B
+    · exact hCeqB
+    · exact absurd hCB (hF C hC B hB hCeqB)
+
+/-- Upper bound: in any antichain over Fin n (n ≥ 4) with ≥ 2 sets,
+    the number of distinct set sizes is at most n − 2.
+
+    Cases:
+    (1) Both size 1 and size n−1 appear → F ⊆ {A,B} → |distinctSizes| ≤ 2 ≤ n−2.
+    (2) Size n−1 absent → distinctSizes ⊆ {1,...,n−2} → |distinctSizes| ≤ n−2.
+    (3) Size 1 absent → distinctSizes ⊆ {2,...,n−1} → |distinctSizes| ≤ n−2. -/
+theorem distinctSizes_card_le_n_sub_two {n : ℕ} (hn : 4 ≤ n)
+    {F : SubsetFamily n} (hF : IsAntichainFamily F) (hcard : 1 < F.card) :
+    (distinctSizes F).card ≤ n - 2 := by
+  have h0 := zero_not_in_antichain_sizes hF hcard
+  have hn' := n_not_in_antichain_sizes hF hcard
+  -- Every element k of distinctSizes F satisfies 1 ≤ k ≤ n−1
+  have hrange : ∀ k ∈ distinctSizes F, 1 ≤ k ∧ k ≤ n - 1 := by
+    intro k hk
+    unfold distinctSizes at hk
+    rw [Finset.mem_image] at hk
+    obtain ⟨A, hAF, rfl⟩ := hk
+    have hAle : A.card ≤ n := by
+      calc A.card ≤ Finset.univ.card := Finset.card_le_univ A
+        _ = Fintype.card (Fin n) := Finset.card_univ
+        _ = n := Fintype.card_fin n
+    have hA0 : A.card ≠ 0 := fun h => h0 (Finset.mem_image.mpr ⟨A, hAF, h⟩)
+    have hAnn : A.card ≠ n := fun h => hn' (Finset.mem_image.mpr ⟨A, hAF, h⟩)
+    omega
+  by_cases h1 : 1 ∈ distinctSizes F
+  · by_cases hn1 : (n - 1) ∈ distinctSizes F
+    · -- Both size 1 and size n−1 appear: apply size1_and_complement_pair_only
+      unfold distinctSizes at h1 hn1
+      rw [Finset.mem_image] at h1 hn1
+      obtain ⟨A, hA, hAcard⟩ := h1
+      obtain ⟨B, hB, hBcard⟩ := hn1
+      have hAB : A ≠ B := by intro h; rw [h] at hAcard; omega
+      have hpair : ∀ C ∈ F, C = A ∨ C = B :=
+        size1_and_complement_pair_only (by omega) hF hA hAcard hB hBcard hAB
+      have hFsub : F ⊆ ({A, B} : Finset (Finset (Fin n))) := by
+        intro C hC
+        simp only [Finset.mem_insert, Finset.mem_singleton]
+        exact hpair C hC
+      calc (distinctSizes F).card
+          ≤ F.card := Finset.card_image_le
+        _ ≤ ({A, B} : Finset (Finset (Fin n))).card := Finset.card_le_card hFsub
+        _ ≤ 2 := by
+            apply le_trans (Finset.card_insert_le A _)
+            simp
+        _ ≤ n - 2 := by omega
+    · -- Size n−1 absent: distinctSizes F ⊆ Icc 1 (n−2)
+      have hsub : distinctSizes F ⊆ Finset.Icc 1 (n - 2) := by
+        intro k hk
+        rw [Finset.mem_Icc]
+        obtain ⟨hk1, hkn⟩ := hrange k hk
+        refine ⟨hk1, ?_⟩
+        by_contra hkbig
+        push_neg at hkbig
+        have heqn1 : k = n - 1 := by omega
+        exact hn1 (heqn1 ▸ hk)
+      calc (distinctSizes F).card
+          ≤ (Finset.Icc 1 (n - 2)).card := Finset.card_le_card hsub
+        _ = n - 2 := by
+            rw [Finset.Nat.card_Icc]
+            omega
+  · -- Size 1 absent: distinctSizes F ⊆ Icc 2 (n−1)
+    have hsub : distinctSizes F ⊆ Finset.Icc 2 (n - 1) := by
+      intro k hk
+      rw [Finset.mem_Icc]
+      obtain ⟨hk1, hkn⟩ := hrange k hk
+      refine ⟨?_, hkn⟩
+      have hkne1 : k ≠ 1 := fun heq => h1 (heq ▸ hk)
+      omega
+    calc (distinctSizes F).card
+        ≤ (Finset.Icc 2 (n - 1)).card := Finset.card_le_card hsub
+      _ = n - 2 := by
+          rw [Finset.Nat.card_Icc]
+          omega

--- a/src/data/research/problems/erdos-776.json
+++ b/src/data/research/problems/erdos-776.json
@@ -1,6 +1,6 @@
 {
   "slug": "erdos-776",
-  "title": "Erdős #776",
+  "title": "Erd\u0151s #776",
   "phase": "OBSERVE",
   "status": "active",
   "tier": "B",
@@ -18,8 +18,8 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-01-15T08:39:26.858Z",
-    "iteration": 3,
-    "focus": "Added structural lemmas and IsAntichain rename. Ready for axiom elimination.",
+    "iteration": 4,
+    "focus": "Proved size1_and_complement_pair_only + distinctSizes_card_le_n_sub_two. Upper bound for r=1 case established. Need achievability construction.",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,41 +29,48 @@
     }
   },
   "knowledge": {
-    "progressSummary": "AXIOM ELIMINATION: Proved erdos_776_threshold from erdos_trotter_exact (4→3 axioms)",
+    "progressSummary": "AXIOM ELIMINATION: Proved size1_and_complement_pair_only (structural pair lemma) + distinctSizes_card_le_n_sub_two (n-2 upper bound). Building toward proving erdos_trotter_r1.",
     "builtItems": [
       "Proved size_availability (axiom->theorem) in Erdos776Problem.lean",
       "Proved size_variety_tradeoff (axiom->theorem) via Finset.card_biUnion + Finset.sum_le_sum",
       "Proved middle_layer_antichain (axiom->theorem) via powersetCard construction",
       "Proved sperner_theorem (axiom->theorem) via Mathlib LYM bridge",
-      "Renamed IsAntichain → IsAntichainFamily (Mathlib collision fix)",
+      "Renamed IsAntichain \u2192 IsAntichainFamily (Mathlib collision fix)",
       "Proved empty_not_in_nontrivial_antichain via Finset.empty_subset + antichain contradiction",
       "Proved univ_not_in_nontrivial_antichain via Finset.subset_univ + antichain contradiction",
       "Proved same_size_is_antichain via Finset.eq_of_subset_of_card_le + omega",
       "Proved zero_not_in_antichain_sizes via Finset.card_eq_zero + card_le_one",
       "Proved n_not_in_antichain_sizes via Finset.eq_univ_of_card + card_le_one",
-      "erdos_776_threshold proved from erdos_trotter_exact + Nat.find (was axiom)"
+      "erdos_776_threshold proved from erdos_trotter_exact + Nat.find (was axiom)",
+      "Proved size1_and_complement_pair_only: size-1 + size-(n-1) coexistence forces F \u2286 {A,B} (2-element family)",
+      "Proved distinctSizes_card_le_n_sub_two: any antichain over Fin n (n\u22654) has \u2264 n-2 distinct sizes"
     ],
     "insights": [
-      "size_availability axiom has trivially True conclusion — provable with intro; trivial",
+      "size_availability axiom has trivially True conclusion \u2014 provable with intro; trivial",
       "size_variety_tradeoff provable via partition-by-cardinality: biUnion of disjoint filters, sum of lower bounds",
       "middle_layer_antichain provable by constructing powersetCard (n/2) univ and showing antichain + singleton image",
       "sperner_theorem: Mathlib has IsAntichain.sperner via LYM, but custom IsAntichain definition creates bridge gap",
-      "IsAntichain.sperner in Mathlib.Combinatorics.SetFamily.LYM gives Sperner bound directly. Bridge: custom IsAntichain ↔ Mathlib IsAntichain (· ⊆ ·) via Finset.mem_coe.",
-      "IsAntichain naming conflict with Mathlib.Order.Antichain — renamed to IsAntichainFamily",
-      "SubsetFamily is opaque def: theorems using ∈ F need F : Finset (Finset (Fin n)) in signatures",
-      "Key structural results proved: ∅ and univ excluded from non-trivial antichains",
-      "Sizes 0 and n excluded from distinctSizes of antichains with ≥2 sets",
+      "IsAntichain.sperner in Mathlib.Combinatorics.SetFamily.LYM gives Sperner bound directly. Bridge: custom IsAntichain \u2194 Mathlib IsAntichain (\u00b7 \u2286 \u00b7) via Finset.mem_coe.",
+      "IsAntichain naming conflict with Mathlib.Order.Antichain \u2014 renamed to IsAntichainFamily",
+      "SubsetFamily is opaque def: theorems using \u2208 F need F : Finset (Finset (Fin n)) in signatures",
+      "Key structural results proved: \u2205 and univ excluded from non-trivial antichains",
+      "Sizes 0 and n excluded from distinctSizes of antichains with \u22652 sets",
       "Same-size families are automatically antichains (via Finset.eq_of_subset_of_card_le)",
       "Remaining 3 known-result axioms require substantial combinatorial constructions to prove",
-      "erdos_776_threshold follows from erdos_trotter_exact via Nat.find — the threshold is just the minimum N"
+      "erdos_776_threshold follows from erdos_trotter_exact via Nat.find \u2014 the threshold is just the minimum N",
+      "Key structural insight: if {a}\u2208F and B (size n-1) \u2208F in antichain, then B=univ\\{a} (forced by antichain+cardinality)",
+      "Upper bound proof splits into 3 cases: both sizes 1,n-1 present (\u2192F\u22642 sets\u2264n-2), size n-1 absent (\u2192Icc 1 (n-2)), size 1 absent (\u2192Icc 2 (n-1))",
+      "The upper bound for erdos_trotter_r1 is now proved as a theorem (distinctSizes_card_le_n_sub_two)",
+      "Remaining: achievability lower bound (need explicit n-2 size antichain construction) for erdos_trotter_r1"
     ],
     "mathlibGaps": [],
     "nextSteps": [
+      "Prove achievability: for n>3, exhibit antichain F with n-2 distinct sizes and r=1 \u2014 construction needed",
+      "Convert erdos_trotter_r1 from axiom to theorem using distinctSizes_card_le_n_sub_two + achievability",
       "Prove erdos_trotter_achievable constructively (need antichain with n-3 distinct sizes and multiplicity r)",
-      "Prove erdos_trotter_r1 using structural lemmas (sizes 0,n excluded → at most n-1, need 1 more exclusion)",
-      "erdos_trotter_upper is hardest known-result axiom — may need Bollobás set-pairs inequality"
+      "erdos_trotter_upper is hardest remaining axiom \u2014 may need Bollobas set-pairs inequality"
     ],
-    "markdown": "# Erdős #776 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $r\\geq 2$ and $A_1,\\ldots,A_m\\subseteq \\{1,\\ldots,n\\}$ be such that $A_i\\not\\subseteq A_j$ for all $i\\neq j$ and for any $t$ if there exists some $i$ with $\\lvert A_i\\rvert=t$ then there must exist at least $r$ sets of that size.\n\nHow large must $n$ be (as a function of $r$) to ensure that there is such a family which achieves $n-3$ distinct sizes of sets?\n\n\n\nA problem of Erd\\H{o}s and Trotter. For $r=1$ and $n>3$ the maximum possible is $n-2$. For $r>1$ and $n$ sufficiently large $n-3$ is achievable, but $n-2$ is never achievable.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #775\n- Problem #777\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Gu83\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
+    "markdown": "# Erd\u0151s #776 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $r\\geq 2$ and $A_1,\\ldots,A_m\\subseteq \\{1,\\ldots,n\\}$ be such that $A_i\\not\\subseteq A_j$ for all $i\\neq j$ and for any $t$ if there exists some $i$ with $\\lvert A_i\\rvert=t$ then there must exist at least $r$ sets of that size.\n\nHow large must $n$ be (as a function of $r$) to ensure that there is such a family which achieves $n-3$ distinct sizes of sets?\n\n\n\nA problem of Erd\\H{o}s and Trotter. For $r=1$ and $n>3$ the maximum possible is $n-2$. For $r>1$ and $n$ sufficiently large $n-3$ is achievable, but $n-2$ is never achievable.\n\n\nBack to the problem\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #775\n- Problem #777\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Gu83\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"
   },
   "tags": [
     "erdos"
@@ -86,8 +93,8 @@
     {
       "path": "Proofs/Erdos776Problem.lean",
       "filename": "Erdos776Problem.lean",
-      "lineCount": 267,
-      "theoremCount": 11,
+      "lineCount": 391,
+      "theoremCount": 13,
       "axiomCount": 3,
       "defCount": 6,
       "sorryCount": 0,

--- a/src/data/research/problems/newton-inductive-step-oq-02.json
+++ b/src/data/research/problems/newton-inductive-step-oq-02.json
@@ -29,12 +29,20 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "PROGRESS: Fixed newton_inequality_binomial statement (binomial coefficients were on wrong side). Proved newton_inequality_means from corrected version. 1 sorry remains (inductive Cauchy-Schwarz step).",
+    "builtItems": [
+      "Fixed newton_inequality_binomial to standard form: C(n,k-1)*C(n,k+1)*e_k^2 >= C(n,k)^2*e_{k-1}*e_{k+1}",
+      "Proved newton_inequality_means by clearing fractions from corrected binomial form"
+    ],
+    "insights": [
+      "Original statement had C(n,k)^2 * e_k^2 >= C(n,k-1)*C(n,k+1)*e_{k-1}*e_{k+1} which is WEAKER than standard",
+      "Standard Newton inequality has coefficients swapped, making it equivalent to mean form",
+      "Mean form proof: unfold esymmMean, rw [div_pow, div_mul_div_comm, div_le_div_iff], linarith"
+    ],
     "mathlibGaps": [],
-    "nextSteps": [],
-    "markdown": "# Knowledge Base: newton-inductive-step-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+    "nextSteps": [
+      "Prove newton_inequality_binomial inductive step using Cauchy-Schwarz on esymm recurrence"
+    ]
   },
   "tags": [],
   "relatedProofs": [


### PR DESCRIPTION
## Summary

Research session for erdos-776 (Erdős-Trotter antichain size diversity).

## Progress

- **2 new proved theorems** advancing toward axiom elimination
- Files modified: `proofs/Proofs/Erdos776Problem.lean`, `src/data/research/problems/erdos-776.json`

## New Theorems

### `size1_and_complement_pair_only` (lemma)
If a size-1 set `{a}` and a size-(n-1) set `B` both appear in an antichain `F` over `Fin n` (n≥3), then `F ⊆ {{a}, B}` (the family has at most 2 members). Key insight: antichain forces `a ∉ B`, cardinality forces `B = univ \ {a}`, then any other `C ∈ F` must satisfy `a ∉ C` (antichain) hence `C ⊆ B` hence `C = B`.

### `distinctSizes_card_le_n_sub_two` (theorem)
Any antichain over `Fin n` (n≥4) with ≥2 sets has at most `n-2` distinct set sizes. Proof by case analysis:
1. Both size 1 and size n-1 appear → `F ⊆ {A,B}` → `|distinctSizes| ≤ 2 ≤ n-2`
2. Size n-1 absent → `distinctSizes F ⊆ Icc 1 (n-2)` → `|distinctSizes| ≤ n-2`
3. Size 1 absent → `distinctSizes F ⊆ Icc 2 (n-1)` → `|distinctSizes| ≤ n-2`

## Status
**Outcome**: progress — upper bound for `erdos_trotter_r1` established  
**Axiom count**: 3 (unchanged — need achievability construction to complete r=1 proof)  
**Next Steps**: Exhibit explicit antichain achieving n-2 distinct sizes for n>3 (achievability direction)

🤖 Generated by researcher-4