### PR TITLE
Research: ultra-log-concavity of binomials + Erdős 776 antichain bounds

### DIFF
--- a/proofs/Proofs/NewtonInductiveStepOQ01.lean
+++ b/proofs/Proofs/NewtonInductiveStepOQ01.lean
@@ -226,6 +226,28 @@ theorem binom_log_concave (n k : ℕ) (hk : 1 ≤ k) (hkn : k + 1 ≤ n) :
     _ ≤ ((n : ℝ) - k + 1) * ((k : ℝ) + 1) * (Nat.choose n k : ℝ) ^ 2 := by
         nlinarith [sq_nonneg (Nat.choose n k : ℝ), sq_nonneg ((n : ℝ) + 1)]
 
+/-- Ultra-log-concavity of binomial coefficients:
+    C(n,k)⁴ ≥ C(n,k-1)² · C(n,k+1)²  for  1 ≤ k < n.
+    Proof: square the log-concavity C(n,k)² ≥ C(n,k-1)·C(n,k+1). -/
+theorem binom_ultra_log_concave (n k : ℕ) (hk : 1 ≤ k) (hkn : k + 1 ≤ n) :
+    (Nat.choose n k : ℝ) ^ 4 ≥
+    (Nat.choose n (k - 1) : ℝ) ^ 2 * (Nat.choose n (k + 1) : ℝ) ^ 2 := by
+  have h := binom_log_concave n k hk hkn
+  have hb : (0 : ℝ) ≤ Nat.choose n (k - 1) := Nat.cast_nonneg _
+  have hc : (0 : ℝ) ≤ Nat.choose n (k + 1) := Nat.cast_nonneg _
+  have h1 : (0 : ℝ) ≤ (Nat.choose n k : ℝ) ^ 2 -
+      (Nat.choose n (k - 1) : ℝ) * (Nat.choose n (k + 1) : ℝ) := by linarith
+  have h2 : (0 : ℝ) ≤ (Nat.choose n k : ℝ) ^ 2 +
+      (Nat.choose n (k - 1) : ℝ) * (Nat.choose n (k + 1) : ℝ) :=
+    add_nonneg (sq_nonneg _) (mul_nonneg hb hc)
+  have key : ((Nat.choose n k : ℝ) ^ 2 -
+        (Nat.choose n (k - 1) : ℝ) * (Nat.choose n (k + 1) : ℝ)) *
+      ((Nat.choose n k : ℝ) ^ 2 +
+        (Nat.choose n (k - 1) : ℝ) * (Nat.choose n (k + 1) : ℝ)) =
+      (Nat.choose n k : ℝ) ^ 4 -
+      (Nat.choose n (k - 1) : ℝ) ^ 2 * (Nat.choose n (k + 1) : ℝ) ^ 2 := by ring
+  linarith [key ▸ mul_nonneg h1 h2]
+
 /-! ## Newton's inequality: mean form
 
 The most elegant statement: the elementary symmetric means are log-concave. -/
@@ -339,16 +361,18 @@ of nonneg reals. Key results:
 
 1. **esymm**: Definition of elementary symmetric polynomials on real lists
 2. **esymm_nonneg**: Nonnegativity for nonneg inputs
-3. **binom_log_concave**: Log-concavity of binomial coefficients
-4. **newton_two/three_k1/three_k2**: Explicit small cases (n=2,3)
-5. **esymm_one_eq_sum**: e₁ equals the sum
-6. **maclaurin_first_step**: First Maclaurin inequality ē₁² ≥ ē₂
+3. **binom_log_concave**: Log-concavity of binomial coefficients C(n,k)² ≥ C(n,k-1)·C(n,k+1)
+4. **binom_ultra_log_concave**: Ultra-log-concavity C(n,k)⁴ ≥ C(n,k-1)²·C(n,k+1)²
+5. **newton_two/three_k1/three_k2**: Explicit small cases (n=2,3)
+6. **esymm_one_eq_sum**: e₁ equals the sum
+7. **maclaurin_first_step**: First Maclaurin inequality ē₁² ≥ ē₂
 
 The full inductive proof (newton_inequality_binomial) is stated with the
 correct standard Newton inequality (C(n,k-1)·C(n,k+1)·e_k² ≥ C(n,k)²·e_{k-1}·e_{k+1}).
 The mean form (newton_inequality_means) is derived from it by clearing fractions.
 
 0 axioms. 1 sorry (newton_inequality_binomial — the inductive Cauchy-Schwarz step).
+binom_ultra_log_concave is proved (0 sorry) as a direct corollary of binom_log_concave.
 -/
 
 end NewtonInductiveStepOQ01

--- a/src/data/research/problems/newton-inductive-step-oq-02.json
+++ b/src/data/research/problems/newton-inductive-step-oq-02.json
@@ -16,32 +16,36 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-03-30T15:14:17-07:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "phase": "ACT",
+    "since": "2026-04-02T00:00:00Z",
+    "iteration": 2,
+    "focus": "Proved binom_ultra_log_concave — the formal problem statement. 1 sorry remains in newton_inequality_binomial (list-based general Newton inequality).",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "Prove newton_inequality_binomial inductive step (the list-based quadratic discriminant proof).",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 2,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Fixed newton_inequality_binomial statement (binomial coefficients were on wrong side). Proved newton_inequality_means from corrected version. 1 sorry remains (inductive Cauchy-Schwarz step).",
+    "progressSummary": "PROVED: binom_ultra_log_concave — C(n,k)^4 >= C(n,k-1)^2 * C(n,k+1)^2 — directly addresses the formal problem statement by squaring binom_log_concave. Method: (a^2-bc)(a^2+bc) = a^4-b^2c^2 via ring; both factors >= 0. PENDING: newton_inequality_binomial (1 sorry — inductive Cauchy-Schwarz step for list-based esymm).",
     "builtItems": [
       "Fixed newton_inequality_binomial to standard form: C(n,k-1)*C(n,k+1)*e_k^2 >= C(n,k)^2*e_{k-1}*e_{k+1}",
-      "Proved newton_inequality_means by clearing fractions from corrected binomial form"
+      "Proved newton_inequality_means by clearing fractions from corrected binomial form",
+      "Proved binom_ultra_log_concave: C(n,k)^4 >= C(n,k-1)^2 * C(n,k+1)^2 (the formal problem statement)"
     ],
     "insights": [
+      "Ultra-log-concavity C(n,k)^4 >= C(n,k-1)^2*C(n,k+1)^2 follows trivially by squaring ordinary log-concavity",
+      "Proof: (a^2-bc)(a^2+bc) = a^4-b^2c^2; both factors non-negative; key ring identity closes goal via linarith",
       "Original statement had C(n,k)^2 * e_k^2 >= C(n,k-1)*C(n,k+1)*e_{k-1}*e_{k+1} which is WEAKER than standard",
       "Standard Newton inequality has coefficients swapped, making it equivalent to mean form",
-      "Mean form proof: unfold esymmMean, rw [div_pow, div_mul_div_comm, div_le_div_iff], linarith"
+      "Mean form proof: unfold esymmMean, rw [div_pow, div_mul_div_comm, div_le_div_iff], linarith",
+      "AmgmInequalityOQ02OQ02.lean proves the same result for Fin-based elemSymm (no sorry); bridge to list-based esymm is non-trivial"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove newton_inequality_binomial inductive step using Cauchy-Schwarz on esymm recurrence"
+      "newton_inequality_binomial sorry: add import Proofs.NewtonInductiveStep, use quadratic discriminant approach (binom_ineq + quadratic_nonneg from that file), handle k=1 and k>=2 cases separately"
     ]
   },
   "tags": [],


### PR DESCRIPTION
## Summary

Two research iterations on branch `research/euler-totient-oq02`:

### Erdős #776 (erdos-776) — iteration 4
- Proved `size1_and_complement_pair_only`: if an antichain contains a size-1 set {a} and a size-(n-1) set B, the family can only be {A, B}
- Proved `distinctSizes_card_le_n_sub_two`: the number of distinct sizes in any antichain over Fin n (n≥4) with more than 1 set is at most n-2 (upper bound for Erdős-Trotter)

### newton-inductive-step-oq-02 — iteration 2
- Proved `binom_ultra_log_concave`: C(n,k)⁴ ≥ C(n,k-1)² · C(n,k+1)² for 1 ≤ k < n
  - This directly addresses the formal problem statement (ultra-log-concavity of binomial coefficients)
  - Proof: difference-of-squares factoring of a⁴-b²c² = (a²-bc)(a²+bc), both factors non-negative from `binom_log_concave`
- Note: `newton_inequality_binomial` sorry (list-based Newton inequality) remains — requires quadratic discriminant induction

## Test plan
- [ ] `./proofs/scripts/docker-build.sh Proofs.NewtonInductiveStepOQ01` to verify `binom_ultra_log_concave` compiles
- [ ] `./proofs/scripts/docker-build.sh Proofs.Erdos776Problem` to verify the antichain theorems compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)