### PR TITLE
fix: correct konigsberg-oq-03 badge (axiom→wip) and status (axiomatized→formalized)

### DIFF
--- a/src/data/proofs/konigsberg-oq-03/meta.json
+++ b/src/data/proofs/konigsberg-oq-03/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős-Grünwald-Weiszfeld (1936), Lonc-Naroski (2010)",
     "date": "1936",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/KonigsbergOQ03.lean",
     "tags": [
       "graph-theory",
@@ -14,7 +14,7 @@
       "hypergraphs",
       "infinite-graphs"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,


### PR DESCRIPTION
## Fix

Badge and status mismatch in `konigsberg-oq-03` metadata.

## Evidence

**Before**: `badge: "axiom"`, `status: "axiomatized"`, `axiomCount: 0`
**After**: `badge: "wip"`, `status: "formalized"`, `axiomCount: 0` (unchanged)

`KonigsbergOQ03.lean` contains **3 True-stub definitions** (not axioms):
```lean
def HasEulerTour ... : Prop := True  -- For r=2, reduces to the graph case
def HasInfiniteEulerPath ... : Prop := True  -- requires careful definition
def HasOneWayEulerPath ... : Prop := True  -- path from v₀ through all edges
```

Neither the file itself nor its imported parent (`Konigsberg.lean`) contain any `axiom` declarations. The `axiomCount: 0` field was already correct; the badge and status were not.

Per gallery policy:
- `badge: "axiom"` requires actual `axiom` declarations — none exist here
- `badge: "wip"` correctly signals True-stub placeholder definitions
- `status: "formalized"` correctly reflects a file with placeholders but no axioms

---
Automated fix by lean-mechanic agent.