### PR TITLE
fix: remove additionalFiles from inverse-galois-oq-02 (double-counting)

### DIFF
--- a/src/data/proofs/inverse-galois-oq-02/meta.json
+++ b/src/data/proofs/inverse-galois-oq-02/meta.json
@@ -17,10 +17,6 @@
       "mathieu-groups"
     ],
     "proofRepoPath": "Proofs/InverseGaloisOQ02.lean",
-    "additionalFiles": [
-      "Proofs/InverseGalois.lean",
-      "Proofs/InverseGaloisOQ01.lean"
-    ],
     "badge": "axiom",
     "sorries": 6,
     "axiomCount": 3,


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: `inverse-galois-oq-02`
**Problem**: `additionalFiles` included `InverseGalois.lean` and `InverseGaloisOQ01.lean`, causing the audit scanner to double-count their axioms/sorries as part of OQ02's metrics.

## Evidence

Both dependency files have their own gallery entries:
- `inverse-galois` → `Proofs/InverseGalois.lean` (4 axiom declarations, 0 sorry tactics)
- `inverse-galois-oq-01` → `Proofs/InverseGaloisOQ01.lean` (0 axioms, 1 sorry)

Scanner detected "axiom undercount: claims 3, actual 7" because it added 4 axioms from InverseGalois.lean. And "sorry mismatch: claims 6, actual 7" because it added 1 sorry from OQ01.lean.

**OQ02's own file** has exactly:
- 3 axiom declarations (M23, M23_card, M23_isSimple) ✓
- 6 sorry tactics ✓

## Fix

Remove `additionalFiles` field. OQ02's own counts (3 axioms, 6 sorries) already match the meta.json claims.

---
Discovered during gallery integrity audit.