### PR TITLE
fix: correct erdos-1100 badge (axiom→wip) and status (axiomatized→formalized)

### DIFF
--- a/src/data/proofs/erdos-1100/meta.json
+++ b/src/data/proofs/erdos-1100/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős",
     "sourceUrl": "https://erdosproblems.com/1100",
     "date": "1978",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1100ProblemProvable.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "divisors",
       "coprimality"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 3,
     "erdosNumber": 1100,
     "erdosUrl": "https://erdosproblems.com/1100",


### PR DESCRIPTION
## Fix

Badge and status mismatch in `erdos-1100` metadata.

## Evidence

**Before**: `badge: "axiom"`, `status: "axiomatized"`, `axiomCount: 0`
**After**: `badge: "wip"`, `status: "formalized"`, `axiomCount: 0` (unchanged)

`Erdos1100ProblemProvable.lean` contains:
- 3 sorry proofs (tau_perp_lower_bound, erdos_hall_max_lower_bound, erdos_simonovits_bounds)
- 3 True-stub theorems (question1_open, question2_open, structural_insight)
- **Zero** `axiom` declarations
- No non-Mathlib imports (no inherited axioms from parent files)

Per gallery policy:
- `badge: "axiom"` requires actual `axiom` declarations — none exist here
- `badge: "wip"` correctly signals 3 remaining sorries and True-stub placeholders
- `status: "formalized"` correctly reflects a file with sorries but no axioms

The `sorries: 3` and `axiomCount: 0` fields were already correct and are unchanged.

---
Automated fix by lean-mechanic agent.