### PR TITLE
fix: correct badge/status for 8 entries with badge=axiom but zero actual axioms

### DIFF
--- a/src/data/proofs/erdos-1016/meta.json
+++ b/src/data/proofs/erdos-1016/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdos, Bondy",
     "sourceUrl": "https://erdosproblems.com/1016",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1016Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "extremal graph theory",
       "Hamiltonian graphs"
     ],
-    "badge": "axiom",
+    "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 1016,
     "erdosUrl": "https://erdosproblems.com/1016",

--- a/src/data/proofs/erdos-1183/meta.json
+++ b/src/data/proofs/erdos-1183/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős–Ulam (1978)",
     "sourceUrl": "https://erdosproblems.com/1183",
     "date": "1978",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1183Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "lattice-theory",
       "powerset"
     ],
-    "badge": "axiom",
+    "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 1183,
     "erdosUrl": "https://erdosproblems.com/1183",

--- a/src/data/proofs/erdos-411/meta.json
+++ b/src/data/proofs/erdos-411/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/411",
     "date": "1980",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos411Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "totient",
       "arithmetic-dynamics"
     ],
-    "badge": "axiom",
+    "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 411,
     "erdosUrl": "https://erdosproblems.com/411",

--- a/src/data/proofs/erdos-416/meta.json
+++ b/src/data/proofs/erdos-416/meta.json
@@ -8,7 +8,7 @@
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/416",
     "date": "",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos416Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "asymptotics",
       "open-problem"
     ],
-    "badge": "axiom",
+    "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 416,
     "erdosUrl": "https://erdosproblems.com/416",

--- a/src/data/proofs/erdos-826/meta.json
+++ b/src/data/proofs/erdos-826/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős (1974)",
     "sourceUrl": "https://erdosproblems.com/826",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos826Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "arithmetic-functions",
       "open-problem"
     ],
-    "badge": "axiom",
+    "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 826,
     "erdosUrl": "https://erdosproblems.com/826",

--- a/src/data/proofs/erdos-938/meta.json
+++ b/src/data/proofs/erdos-938/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős [Er76d]",
     "sourceUrl": "https://erdosproblems.com/938",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos938Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "squarefull-numbers",
       "open"
     ],
-    "badge": "axiom",
+    "badge": "formalized",
     "sorries": 0,
     "erdosNumber": 938,
     "erdosUrl": "https://erdosproblems.com/938",

--- a/src/data/proofs/furstenberg-correspondence-oq-02/meta.json
+++ b/src/data/proofs/furstenberg-correspondence-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Furstenberg (1977), Einsiedler-Ward (2011)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Ergodic_decomposition_theorem",
     "date": "1977",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/FurstenbergCorrespondenceOQ02.lean",
     "tags": [
       "ergodic-theory",
@@ -17,7 +17,7 @@
       "furstenberg",
       "szemerédi"
     ],
-    "badge": "axiom",
+    "badge": "formalized",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/puiseux-theorem/meta.json
+++ b/src/data/proofs/puiseux-theorem/meta.json
@@ -8,7 +8,7 @@
     "author": "Victor Puiseux (1850)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Puiseux_series",
     "date": "1850",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/PuiseuxTheorem.lean",
     "tags": [
       "algebra",
@@ -18,7 +18,7 @@
       "wiedijk-100",
       "classic"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

Eight gallery entries had `badge: "axiom"` and `status: "axiomatized"` despite having **zero** `axiom` declarations.

## Affected Entries

| Entry | Lean File | Sorries | Axioms | True Stubs | Fix |
|-------|-----------|---------|--------|------------|-----|
| erdos-1016 | Erdos1016Problem.lean | 0 | 0 | 0 | badge→formalized |
| erdos-1183 | Erdos1183Problem.lean | 0 | 0 | 0 | badge→formalized |
| erdos-411 | Erdos411Problem.lean | 0 | 0 | 0 | badge→formalized |
| erdos-416 | Erdos416Problem.lean | 0 | 0 | 0 | badge→formalized |
| erdos-826 | Erdos826Problem.lean | 0 | 0 | 0 | badge→formalized |
| erdos-938 | Erdos938Problem.lean | 0 | 0 | 0 | badge→formalized |
| furstenberg-correspondence-oq-02 | FurstenbergCorrespondenceOQ02.lean | 0 | 0 | 0 | badge→formalized |
| puiseux-theorem | (file with True stubs) | 0 | 0 | 3 | badge→wip |

## Evidence

All 7 "formalized" entries:
- Only import Mathlib (no non-Mathlib parent files with axioms)
- Zero `axiom` declarations
- Zero `sorry` proofs
- Zero `True := trivial` stubs
- Contain proven structural theorems about open problems

The `puiseux-theorem` entry additionally has 3 True-stub propositions, warranting `badge: "wip"` rather than `badge: "formalized"`.

Per gallery policy: `badge: "axiom"` requires actual `axiom` declarations. None exist in any of these files.

All `axiomCount: 0` values were already correct and remain unchanged.

---
Automated fix by lean-mechanic agent.