### PR TITLE
fix: correct axiomCount=0 for 7 entries that inherit axioms from imported files

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
@@ -26,7 +26,7 @@
       "Eliminates maclaurin_step axiom from AmgmInequalityOQ02.lean"
     ],
     "dateAdded": "2026-03-30",
-    "axiomCount": 0,
+    "axiomCount": 2,
     "lineCount": 226,
     "assumptions": "Depends on newton_log_concavity axiom from AmgmInequalityOQ02.lean.",
     "mathlib_version": "4.26.0"

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-04/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-04/meta.json
@@ -37,7 +37,7 @@
       "fh_z4_bound and fh_z6_bound: proved from parent monotonicity",
       "fh_extends_monotonicity: proved that FH subsumes monotonicity"
     ],
-    "axiomCount": 0,
+    "axiomCount": 4,
     "assumptions": "0 local axiom declarations. All proofs use parent module BorsukUlamOQ02OQ01 axioms (buDim, buDim_prime, buDim_mono, etc.). Former axioms fh_point and fh_sphere_free_action are now proved theorems (by rfl). Former axioms fh_monotonicity and fh_restriction were logically unsound (asserted unconditional inequalities) and removed.",
     "lineCount": 251
   },

--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01/meta.json
@@ -56,7 +56,7 @@
       "gch_no_intermediates_anywhere: GCH eliminates intermediates at all levels",
       "not_gch_from_intermediate: intermediate cardinals imply ¬GCH"
     ],
-    "axiomCount": 0,
+    "axiomCount": 4,
     "lineCount": 306,
     "assumptions": "3 axioms: easton_consistent_values (Easton's theorem — consistency of various continuum values), martins_axiom_neutral_on_ch (MA compatible with both CH and ¬CH), pfa_implies_not_ch (PFA implies 2^ℵ₀ = ℵ₂). Also inherits axioms from ContinuumHypothesis.lean for Gödel/Cohen independence."
   },

--- a/src/data/proofs/erdos-1014-oq-02/meta.json
+++ b/src/data/proofs/erdos-1014-oq-02/meta.json
@@ -1,188 +1,188 @@
 {
-    "id": "erdos-1014-oq-02",
-    "title": "Erdős #1014 OQ-02: Rate of Convergence is O(log l / l)",
-    "slug": "erdos-1014-oq-02",
-    "description": "Answers the open question: what is the rate of convergence of R(k,l+1)/R(k,l) to 1? For k=3, the rate is O(log l / l), which is strictly faster than O(1/log l). The proof combines the Ramsey recurrence bound R(3,l+1) - R(3,l) ≤ l+1 with the Kim lower bound R(3,l) ≥ c·l²/log l. Also proves that log l/l < 1/log l for large l. For general k, the ratio converges to 1 under conjectured asymptotics (proved via ratio_from_asymptotics).",
-    "meta": {
-        "author": "Erdős",
-        "erdosNumber": 1014,
-        "status": "axiomatized",
-        "proofRepoPath": "Proofs/Erdos1014OQ02.lean",
-        "tags": [
-            "erdos",
-            "graph-theory",
-            "ramsey-theory",
-            "combinatorics",
-            "asymptotics",
-            "research"
-        ],
-        "badge": "axiom",
-        "sorries": 0,
-        "sourceUrl": "https://erdosproblems.com/1014",
-        "erdosUrl": "https://erdosproblems.com/1014",
-        "erdosProblemStatus": "open",
-        "dateAdded": "2026-03-28",
-        "axiomCount": 0,
-        "lineCount": 186,
-        "assumptions": "Inherits axioms from Erdos1014Problem.lean: ramseyNumber (definition), ramsey_monotone_right, ramsey_recurrence, ramsey_k2, ramsey_symm, R3_lower. All theorems fully proved (0 sorries).",
-        "mathlib_version": "4.26.0",
-        "leanFiles": [
-            {
-                "sorryCount": 0
-            }
-        ],
-        "originalContributions": [
-            "Proved rate_of_convergence_k3: |R(3,l+1)/R(3,l) - 1| ≤ C·log l/l from recurrence + Kim lower bound",
-            "Proved log_over_l_faster_than_inv_log: (log l)² < l from Mathlib's little-o",
-            "Fixed conditional_rate_general_k: removed incorrect O(1/l) claim (only o(1) follows from the hypothesis), delegated to ratio_from_asymptotics",
-            "Eliminated 2 sorries: file now fully proved (0 sorries)"
-        ]
-    },
-    "crossReferences": [
-        {
-            "relationship": "extends",
-            "description": "Answers OQ-02 from the parent formalization: the rate of convergence of R(k,l+1)/R(k,l) to 1.",
-            "targetId": "erdos-1014"
-        },
-        {
-            "relationship": "extends",
-            "description": "Builds on OQ-01's proof that R(3,l+1)/R(3,l) → 1 by quantifying the rate.",
-            "targetId": "erdos-1014-oq-01"
-        }
+  "id": "erdos-1014-oq-02",
+  "title": "Erdős #1014 OQ-02: Rate of Convergence is O(log l / l)",
+  "slug": "erdos-1014-oq-02",
+  "description": "Answers the open question: what is the rate of convergence of R(k,l+1)/R(k,l) to 1? For k=3, the rate is O(log l / l), which is strictly faster than O(1/log l). The proof combines the Ramsey recurrence bound R(3,l+1) - R(3,l) ≤ l+1 with the Kim lower bound R(3,l) ≥ c·l²/log l. Also proves that log l/l < 1/log l for large l. For general k, the ratio converges to 1 under conjectured asymptotics (proved via ratio_from_asymptotics).",
+  "meta": {
+    "author": "Erdős",
+    "erdosNumber": 1014,
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos1014OQ02.lean",
+    "tags": [
+      "erdos",
+      "graph-theory",
+      "ramsey-theory",
+      "combinatorics",
+      "asymptotics",
+      "research"
     ],
-    "sections": [
-        {
-            "id": "axioms",
-            "title": "Axioms",
-            "startLine": 27,
-            "endLine": 50,
-            "summary": "Axiomatizes the Ramsey number with monotonicity, recurrence, R(2,l)=l, symmetry, and the Kim lower bound.",
-            "mathContext": "Standard Ramsey number properties shared with the parent formalization."
-        },
-        {
-            "id": "positivity",
-            "title": "Positivity and Increment Bound",
-            "startLine": 55,
-            "endLine": 90,
-            "summary": "Proves $R(k,l) \\geq 1$ from $R(2,l) = l$ and left-monotonicity, and $R(3,l+1) \\leq R(3,l) + (l+1)$ from the recurrence.",
-            "mathContext": "The increment bound is the key structural lemma: consecutive $R(3,l)$ values differ by at most $l+1$."
-        },
-        {
-            "id": "rate-k3",
-            "title": "Explicit Rate Bound for k=3",
-            "startLine": 95,
-            "endLine": 158,
-            "summary": "**Main theorem**: $|R(3,l+1)/R(3,l) - 1| \\leq C \\cdot \\log l / l$ for an explicit constant $C = 2/c$ where $c$ is the Kim lower bound constant.",
-            "mathContext": "The rate $O(\\log l / l)$ arises from dividing the linear increment bound by the quadratic-over-log lower bound: $(l+1)/(c \\cdot l^2/\\log l) = O(\\log l / l)$."
-        },
-        {
-            "id": "comparison",
-            "title": "Rate Comparison: O(log l/l) vs O(1/log l)",
-            "startLine": 163,
-            "endLine": 200,
-            "summary": "Proves $\\log l / l < 1/\\log l$ for large $l$, confirming the rate is strictly faster than $O(1/\\log l)$. Uses Mathlib's $\\log = o(x^{1/2})$.",
-            "mathContext": "Equivalent to $(\\log l)^2 < l$, which holds since $\\log x = o(x^{1/2})$ from Mathlib."
-        },
-        {
-            "id": "general-k",
-            "title": "Conditional Convergence for General k",
-            "startLine": 143,
-            "endLine": 162,
-            "summary": "Under the conjectured asymptotics $R(k,l) \\sim c \\cdot l^{k-1}/(\\log l)^{k-2}$, the ratio $R(k,l+1)/R(k,l) \\to 1$, proved by delegating to `ratio_from_asymptotics` from the main file. Note: the O(1/l) rate does not follow from the given hypothesis — the overall rate depends on how fast $R(k,l)/g(l) \\to 1$, which is unspecified.",
-            "mathContext": "The growth ratio $((l+1)/l)^{k-1} \\cdot (\\log l/\\log(l+1))^{k-2}$ converges to 1 at rate $O(k/l)$, but the asymptotic error contributes an unquantified $o(1)$ term."
-        },
-        {
-            "id": "answer",
-            "title": "Summary Corollary",
-            "startLine": 164,
-            "endLine": 186,
-            "summary": "Combines rate_of_convergence_k3 and log_over_l_faster_than_inv_log into a single statement answering OQ-02.",
-            "mathContext": "The rate is $O(\\log l / l)$ for $k=3$, strictly faster than $O(1/\\log l)$."
-        }
+    "badge": "axiom",
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/1014",
+    "erdosUrl": "https://erdosproblems.com/1014",
+    "erdosProblemStatus": "open",
+    "dateAdded": "2026-03-28",
+    "axiomCount": 12,
+    "lineCount": 186,
+    "assumptions": "Inherits axioms from Erdos1014Problem.lean: ramseyNumber (definition), ramsey_monotone_right, ramsey_recurrence, ramsey_k2, ramsey_symm, R3_lower. All theorems fully proved (0 sorries).",
+    "mathlib_version": "4.26.0",
+    "leanFiles": [
+      {
+        "sorryCount": 0
+      }
     ],
-    "overview": {
-        "historicalContext": "Erdős Problem #1014 asks whether R(k,l+1)/R(k,l) → 1 as l → ∞. OQ-01 proved this for k=3. This follow-up quantifies the convergence rate, answering: how fast does the ratio approach 1?",
-        "problemStatement": "What is the rate of convergence of R(k,l+1)/R(k,l) to 1? Is it O(1/log l)?",
-        "text": "For k=3, the rate of convergence is O(log l / l), which is strictly faster than O(1/log l). Under conjectured asymptotics for general k, the ratio converges to 1 (the rate depends on the speed of asymptotic convergence).",
-        "proofStrategy": "Combine the Ramsey recurrence (giving linear increment bounds) with the Kim lower bound (giving quadratic-over-log growth) to obtain explicit rate bounds. Then prove log l / l < 1/log l for large l using Mathlib's little-o results.",
-        "keyInsights": [
-            "The rate O(log l / l) for k=3 is FASTER than the conjectured O(1/log l), answering the open question in the affirmative direction",
-            "The Ramsey recurrence is the key: it constrains increments to be linear while values grow super-linearly",
-            "The constant C = 2/c in the rate bound is explicit, where c is from Kim's R(3,l) ≥ c·l²/log l",
-            "For general k with power-law asymptotics, the ratio R(k,l+1)/R(k,l) → 1 (the growth ratio contributes O(k/l), but the overall rate depends on the speed of asymptotic convergence)"
-        ],
-        "prerequisites": [
-            "Ramsey theory",
-            "Asymptotic analysis",
-            "Real analysis (little-o notation)"
-        ]
-    },
-    "conclusion": {
-        "summary": "The rate of convergence of R(3,l+1)/R(3,l) to 1 is O(log l / l), strictly faster than O(1/log l). This is proved from the Ramsey recurrence and Kim lower bound. For general k, the ratio converges to 1 under conjectured asymptotics.",
-        "implications": "The fast convergence rate suggests that Ramsey numbers grow very smoothly for k=3, with consecutive values differing by a negligible fraction of their magnitude.",
-        "openQuestions": [
-            "Can the constant C = 2/c be improved, perhaps to 1/c?",
-            "Can the rate bound for general k be proved unconditionally from the recurrence?",
-            "Is the O(log l / l) rate tight, or could it be O(1/l) even for k=3?"
-        ]
-    },
-    "leanFile": {
-        "imports": [
-            "Mathlib"
-        ],
-        "opens": [
-            "Real",
-            "Filter",
-            "Topology"
-        ],
-        "namespace": "Erdos1014OQ02",
-        "lineCount": 186,
-        "axiomCount": 6,
-        "theoremCount": 4,
-        "definitionCount": 0,
-        "substantiveTheoremCount": 4,
-        "mainTheorems": [
-            {
-                "name": "rate_of_convergence_k3",
-                "type": "core",
-                "description": "Explicit rate bound: |R(3,l+1)/R(3,l) - 1| ≤ (2/c) · log l / l",
-                "leanType": "∃ C > 0, ∃ L₀, ∀ l > L₀, |R(3,l+1)/R(3,l) - 1| ≤ C · log l / l"
-            },
-            {
-                "name": "log_over_l_faster_than_inv_log",
-                "type": "core",
-                "description": "For large l, log l / l < 1 / log l, confirming O(log l/l) is faster than O(1/log l)",
-                "leanType": "∃ L₀, ∀ l > L₀, log l / l < 1 / log l"
-            },
-            {
-                "name": "conditional_convergence_general_k",
-                "type": "key",
-                "description": "Under power-law asymptotics, R(k,l+1)/R(k,l) → 1 (proved via ratio_from_asymptotics)",
-                "leanType": "(asymptotic hyp) → ∀ ε > 0, ∃ L₀, ∀ l > L₀, |R(k,l+1)/R(k,l) - 1| < ε"
-            },
-            {
-                "name": "rate_is_O_log_over_l_not_inv_log",
-                "type": "core",
-                "description": "Summary corollary combining the rate bound and comparison",
-                "leanType": "(rate bound) ∧ (log l/l < 1/log l)"
-            }
-        ]
-    },
-    "references": [
-        {
-            "key": "Er71",
-            "citation": "Erdős, P., On some extremal problems on r-graphs, Discrete Mathematics 1(1) (1971), 1–6.",
-            "type": "paper"
-        },
-        {
-            "key": "Ki95",
-            "citation": "Kim, J.H., The Ramsey number R(3,t) has order of magnitude t²/log t, Random Structures & Algorithms 7(3) (1995), 173–207.",
-            "type": "paper"
-        },
-        {
-            "key": "AKS80",
-            "citation": "Ajtai, M., Komlós, J., and Szemerédi, E., A note on Ramsey numbers, Journal of Combinatorial Theory Series A 29(3) (1980), 354–360.",
-            "type": "paper"
-        }
+    "originalContributions": [
+      "Proved rate_of_convergence_k3: |R(3,l+1)/R(3,l) - 1| ≤ C·log l/l from recurrence + Kim lower bound",
+      "Proved log_over_l_faster_than_inv_log: (log l)² < l from Mathlib's little-o",
+      "Fixed conditional_rate_general_k: removed incorrect O(1/l) claim (only o(1) follows from the hypothesis), delegated to ratio_from_asymptotics",
+      "Eliminated 2 sorries: file now fully proved (0 sorries)"
     ]
+  },
+  "crossReferences": [
+    {
+      "relationship": "extends",
+      "description": "Answers OQ-02 from the parent formalization: the rate of convergence of R(k,l+1)/R(k,l) to 1.",
+      "targetId": "erdos-1014"
+    },
+    {
+      "relationship": "extends",
+      "description": "Builds on OQ-01's proof that R(3,l+1)/R(3,l) → 1 by quantifying the rate.",
+      "targetId": "erdos-1014-oq-01"
+    }
+  ],
+  "sections": [
+    {
+      "id": "axioms",
+      "title": "Axioms",
+      "startLine": 27,
+      "endLine": 50,
+      "summary": "Axiomatizes the Ramsey number with monotonicity, recurrence, R(2,l)=l, symmetry, and the Kim lower bound.",
+      "mathContext": "Standard Ramsey number properties shared with the parent formalization."
+    },
+    {
+      "id": "positivity",
+      "title": "Positivity and Increment Bound",
+      "startLine": 55,
+      "endLine": 90,
+      "summary": "Proves $R(k,l) \\geq 1$ from $R(2,l) = l$ and left-monotonicity, and $R(3,l+1) \\leq R(3,l) + (l+1)$ from the recurrence.",
+      "mathContext": "The increment bound is the key structural lemma: consecutive $R(3,l)$ values differ by at most $l+1$."
+    },
+    {
+      "id": "rate-k3",
+      "title": "Explicit Rate Bound for k=3",
+      "startLine": 95,
+      "endLine": 158,
+      "summary": "**Main theorem**: $|R(3,l+1)/R(3,l) - 1| \\leq C \\cdot \\log l / l$ for an explicit constant $C = 2/c$ where $c$ is the Kim lower bound constant.",
+      "mathContext": "The rate $O(\\log l / l)$ arises from dividing the linear increment bound by the quadratic-over-log lower bound: $(l+1)/(c \\cdot l^2/\\log l) = O(\\log l / l)$."
+    },
+    {
+      "id": "comparison",
+      "title": "Rate Comparison: O(log l/l) vs O(1/log l)",
+      "startLine": 163,
+      "endLine": 200,
+      "summary": "Proves $\\log l / l < 1/\\log l$ for large $l$, confirming the rate is strictly faster than $O(1/\\log l)$. Uses Mathlib's $\\log = o(x^{1/2})$.",
+      "mathContext": "Equivalent to $(\\log l)^2 < l$, which holds since $\\log x = o(x^{1/2})$ from Mathlib."
+    },
+    {
+      "id": "general-k",
+      "title": "Conditional Convergence for General k",
+      "startLine": 143,
+      "endLine": 162,
+      "summary": "Under the conjectured asymptotics $R(k,l) \\sim c \\cdot l^{k-1}/(\\log l)^{k-2}$, the ratio $R(k,l+1)/R(k,l) \\to 1$, proved by delegating to `ratio_from_asymptotics` from the main file. Note: the O(1/l) rate does not follow from the given hypothesis — the overall rate depends on how fast $R(k,l)/g(l) \\to 1$, which is unspecified.",
+      "mathContext": "The growth ratio $((l+1)/l)^{k-1} \\cdot (\\log l/\\log(l+1))^{k-2}$ converges to 1 at rate $O(k/l)$, but the asymptotic error contributes an unquantified $o(1)$ term."
+    },
+    {
+      "id": "answer",
+      "title": "Summary Corollary",
+      "startLine": 164,
+      "endLine": 186,
+      "summary": "Combines rate_of_convergence_k3 and log_over_l_faster_than_inv_log into a single statement answering OQ-02.",
+      "mathContext": "The rate is $O(\\log l / l)$ for $k=3$, strictly faster than $O(1/\\log l)$."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Erdős Problem #1014 asks whether R(k,l+1)/R(k,l) → 1 as l → ∞. OQ-01 proved this for k=3. This follow-up quantifies the convergence rate, answering: how fast does the ratio approach 1?",
+    "problemStatement": "What is the rate of convergence of R(k,l+1)/R(k,l) to 1? Is it O(1/log l)?",
+    "text": "For k=3, the rate of convergence is O(log l / l), which is strictly faster than O(1/log l). Under conjectured asymptotics for general k, the ratio converges to 1 (the rate depends on the speed of asymptotic convergence).",
+    "proofStrategy": "Combine the Ramsey recurrence (giving linear increment bounds) with the Kim lower bound (giving quadratic-over-log growth) to obtain explicit rate bounds. Then prove log l / l < 1/log l for large l using Mathlib's little-o results.",
+    "keyInsights": [
+      "The rate O(log l / l) for k=3 is FASTER than the conjectured O(1/log l), answering the open question in the affirmative direction",
+      "The Ramsey recurrence is the key: it constrains increments to be linear while values grow super-linearly",
+      "The constant C = 2/c in the rate bound is explicit, where c is from Kim's R(3,l) ≥ c·l²/log l",
+      "For general k with power-law asymptotics, the ratio R(k,l+1)/R(k,l) → 1 (the growth ratio contributes O(k/l), but the overall rate depends on the speed of asymptotic convergence)"
+    ],
+    "prerequisites": [
+      "Ramsey theory",
+      "Asymptotic analysis",
+      "Real analysis (little-o notation)"
+    ]
+  },
+  "conclusion": {
+    "summary": "The rate of convergence of R(3,l+1)/R(3,l) to 1 is O(log l / l), strictly faster than O(1/log l). This is proved from the Ramsey recurrence and Kim lower bound. For general k, the ratio converges to 1 under conjectured asymptotics.",
+    "implications": "The fast convergence rate suggests that Ramsey numbers grow very smoothly for k=3, with consecutive values differing by a negligible fraction of their magnitude.",
+    "openQuestions": [
+      "Can the constant C = 2/c be improved, perhaps to 1/c?",
+      "Can the rate bound for general k be proved unconditionally from the recurrence?",
+      "Is the O(log l / l) rate tight, or could it be O(1/l) even for k=3?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "Filter",
+      "Topology"
+    ],
+    "namespace": "Erdos1014OQ02",
+    "lineCount": 186,
+    "axiomCount": 6,
+    "theoremCount": 4,
+    "definitionCount": 0,
+    "substantiveTheoremCount": 4,
+    "mainTheorems": [
+      {
+        "name": "rate_of_convergence_k3",
+        "type": "core",
+        "description": "Explicit rate bound: |R(3,l+1)/R(3,l) - 1| ≤ (2/c) · log l / l",
+        "leanType": "∃ C > 0, ∃ L₀, ∀ l > L₀, |R(3,l+1)/R(3,l) - 1| ≤ C · log l / l"
+      },
+      {
+        "name": "log_over_l_faster_than_inv_log",
+        "type": "core",
+        "description": "For large l, log l / l < 1 / log l, confirming O(log l/l) is faster than O(1/log l)",
+        "leanType": "∃ L₀, ∀ l > L₀, log l / l < 1 / log l"
+      },
+      {
+        "name": "conditional_convergence_general_k",
+        "type": "key",
+        "description": "Under power-law asymptotics, R(k,l+1)/R(k,l) → 1 (proved via ratio_from_asymptotics)",
+        "leanType": "(asymptotic hyp) → ∀ ε > 0, ∃ L₀, ∀ l > L₀, |R(k,l+1)/R(k,l) - 1| < ε"
+      },
+      {
+        "name": "rate_is_O_log_over_l_not_inv_log",
+        "type": "core",
+        "description": "Summary corollary combining the rate bound and comparison",
+        "leanType": "(rate bound) ∧ (log l/l < 1/log l)"
+      }
+    ]
+  },
+  "references": [
+    {
+      "key": "Er71",
+      "citation": "Erdős, P., On some extremal problems on r-graphs, Discrete Mathematics 1(1) (1971), 1–6.",
+      "type": "paper"
+    },
+    {
+      "key": "Ki95",
+      "citation": "Kim, J.H., The Ramsey number R(3,t) has order of magnitude t²/log t, Random Structures & Algorithms 7(3) (1995), 173–207.",
+      "type": "paper"
+    },
+    {
+      "key": "AKS80",
+      "citation": "Ajtai, M., Komlós, J., and Szemerédi, E., A note on Ramsey numbers, Journal of Combinatorial Theory Series A 29(3) (1980), 354–360.",
+      "type": "paper"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-1155-oq-01/meta.json
+++ b/src/data/proofs/erdos-1155-oq-01/meta.json
@@ -67,7 +67,7 @@
       "Conjecture-to-BFL hierarchy (strict weakening chain)",
       "Ratio tightness and bounded ratio characterization"
     ],
-    "axiomCount": 0,
+    "axiomCount": 4,
     "assumptions": "5 axiom declarations: triangleRemovalEdges (the triangle removal function itself), triangleRemovalEdges_le_complete (f(n) ≤ n(n-1)/2), bfl_upper_bound (BFL 2015 upper bound), bfl_lower_bound (BFL 2015 lower bound), triangleRemoval_mantel_bound (Mantel's theorem applied to terminal graph). All encode established results or definitions from combinatorics.",
     "relatedProblems": [
       {

--- a/src/data/proofs/erdos-2-oq-01/meta.json
+++ b/src/data/proofs/erdos-2-oq-01/meta.json
@@ -1,112 +1,112 @@
 {
-    "id": "erdos-2-oq-01",
-    "title": "Exact Maximum Minimum Modulus for Covering Systems",
-    "slug": "erdos-2-oq-01",
-    "description": "Structural theorems about the exact maximum minimum modulus M for covering systems. Proves existence, uniqueness, and the gap 42 ≤ M ≤ 616,000 from Owens' construction and Balister et al.'s bound. Characterizes the achievable set as an initial segment [0, M].",
-    "meta": {
-        "author": "Based on Hough (2015), Balister-Bollobás-Morris-Sahasrabudhe-Tiba (2022), Owens (2014)",
-        "sourceUrl": "https://erdosproblems.com/2",
-        "date": "2015, 2022",
-        "status": "axiomatized",
-        "proofRepoPath": "Proofs/Erdos2OQ01.lean",
-        "tags": [
-            "erdos",
-            "covering-systems",
-            "number-theory",
-            "modular-arithmetic",
-            "combinatorics",
-            "extension"
-        ],
-        "badge": "axiom",
-        "sorries": 0,
-        "erdosNumber": 2,
-        "erdosUrl": "https://erdosproblems.com/2",
-        "erdosProblemStatus": "open-question",
-        "relatedProblems": [
-            {
-                "id": "erdos-2",
-                "relation": "Parent formalization. This OQ extends it with structural theorems about the gap [42, 616000]."
-            }
-        ],
-        "dateAdded": "2026-03-29",
-        "axiomCount": 0,
-        "lineCount": 232,
-        "prerequisites": [
-            "Covering systems and congruence classes",
-            "Well-ordering principle for natural numbers",
-            "Basic properties of achievability (monotonicity)",
-            "Erdős Problem #2 parent formalization"
-        ],
-        "mathlib_version": "4.29.0",
-        "originalContributions": [
-            "Formal definition of IsExactMaxMinModulus with equivalent characterizations",
-            "Existence proof using well-ordering (Nat.find on the complement of the achievable set)",
-            "Uniqueness proof via monotonicity contradiction",
-            "Gap theorem: 42 ≤ M ≤ 616,000 from Owens and Balister bounds",
-            "Complete characterization of achievable set as initial segment [0, M]",
-            "Gap narrowing framework for future bound improvements"
-        ],
-        "assumptions": []
-    },
-    "overview": {
-        "historicalContext": "Erdős Problem #2 asked whether the minimum modulus of a covering system can be arbitrarily large. This was resolved negatively by Hough (2015) and improved by Balister et al. (2022), giving the upper bound M ≤ 616,000. The best construction, by Owens (2014), achieves minimum modulus 42. The exact value of M remains one of the most prominent open questions in covering system theory. This formalization proves that M exists as a well-defined mathematical object and constrains it to the interval [42, 616000], establishing the structural framework for any future narrowing of the gap.",
-        "problemStatement": "What is the exact maximum possible minimum modulus M for covering systems with distinct moduli ≥ 2?",
-        "text": "Structural theorems about the exact maximum minimum modulus M for covering systems. Currently 42 ≤ M ≤ 616,000.",
-        "proofStrategy": "Define achievability as a downward-monotone predicate on ℕ. Use the well-ordering principle (Nat.find) on the set of non-achievable values to extract the exact boundary M. Prove M is unique via monotonicity. Derive the gap [42, 616000] from Owens' construction (lower bound) and Balister et al.'s theorem (upper bound). Characterize the achievable set as exactly {0, 1, ..., M}.",
-        "keyInsights": [
-            "**Achievability is downward-monotone**: if min modulus m is achievable, so is any m' ≤ m",
-            "**Well-ordering gives existence**: the smallest non-achievable value n₀ determines M = n₀ - 1",
-            "**Uniqueness from monotonicity**: any two exact maxima must be equal (contradiction if M₁ ≠ M₂)",
-            "**The achievable set is an initial segment**: Achievable m ↔ m ≤ M",
-            "**Gap narrowing framework**: any improved bound (lower or upper) directly constrains M"
-        ],
-        "prerequisites": [
-            "Covering systems and congruence classes",
-            "Well-ordering principle for natural numbers",
-            "Achievability monotonicity",
-            "Erdős Problem #2 parent formalization"
-        ]
-    },
-    "sections": [
-        {
-            "id": "achievability",
-            "title": "Achievability",
-            "summary": "Defines achievability and proves downward-monotonicity, with concrete results for 42 and 616000.",
-            "startLine": 28,
-            "endLine": 57,
-            "mathContext": "A minimum modulus value $m$ is achievable if some covering system has all moduli $\\geq m$. This is downward-monotone: if $m$ is achievable, so is $m' \\leq m$. Owens shows $42$ is achievable; Balister shows nothing above $616{,}000$ is."
-        },
-        {
-            "id": "exact-max-def",
-            "title": "The Exact Maximum Minimum Modulus",
-            "summary": "Defines IsExactMaxMinModulus and proves equivalence with the covering system bound characterization.",
-            "startLine": 59,
-            "endLine": 80,
-            "mathContext": "$M$ is the exact maximum minimum modulus iff $M$ is achievable and $M+1$ is not. Equivalently: some covering system achieves min modulus $M$, and every covering system has at least one modulus $\\leq M$."
-        },
-        {
-            "id": "existence-uniqueness",
-            "title": "Existence and Uniqueness",
-            "summary": "Proves M exists (well-ordering + Nat.find) and is unique (monotonicity contradiction).",
-            "startLine": 82,
-            "endLine": 115,
-            "mathContext": "Existence uses the well-ordering principle on $\\mathbb{N}$: the set $\\{n \\mid \\lnot\\text{Achievable}(n)\\}$ is nonempty (contains $616{,}001$), so $\\texttt{Nat.find}$ extracts its minimum $n_0$. Then $M = n_0 - 1$. Uniqueness follows because if $M_1 < M_2$ were both exact maxima, then $M_1 + 1 \\leq M_2$ would make $M_1 + 1$ achievable, contradicting $M_1$ being exact."
-        },
-        {
-            "id": "gap",
-            "title": "The Gap [42, 616000]",
-            "summary": "Proves 42 ≤ M ≤ 616000 from Owens and Balister bounds.",
-            "startLine": 117,
-            "endLine": 145,
-            "mathContext": "Lower bound: if $M < 42$ then $M+1 \\leq 42$ is achievable (Owens), contradicting $M$ being exact. Upper bound: if $M > 616{,}000$ then $M$ is not achievable (Balister), contradicting the definition."
-        },
-        {
-            "id": "characterization",
-            "title": "Complete Characterization of the Achievable Set",
-            "summary": "Proves Achievable m ↔ m ≤ M, characterizing achievability as an initial segment.",
-            "startLine": 147,
-            "endLine": 170,
-            "mathContext": "The achievable set is exactly $\\{0, 1, \\ldots, M\\}$. This follows from downward-monotonicity (achievable below $M$) and non-achievability above $M$ (from the exact max definition). The gap narrowing theorem provides a framework for improving bounds."
-        }
+  "id": "erdos-2-oq-01",
+  "title": "Exact Maximum Minimum Modulus for Covering Systems",
+  "slug": "erdos-2-oq-01",
+  "description": "Structural theorems about the exact maximum minimum modulus M for covering systems. Proves existence, uniqueness, and the gap 42 ≤ M ≤ 616,000 from Owens' construction and Balister et al.'s bound. Characterizes the achievable set as an initial segment [0, M].",
+  "meta": {
+    "author": "Based on Hough (2015), Balister-Bollobás-Morris-Sahasrabudhe-Tiba (2022), Owens (2014)",
+    "sourceUrl": "https://erdosproblems.com/2",
+    "date": "2015, 2022",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos2OQ01.lean",
+    "tags": [
+      "erdos",
+      "covering-systems",
+      "number-theory",
+      "modular-arithmetic",
+      "combinatorics",
+      "extension"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "erdosNumber": 2,
+    "erdosUrl": "https://erdosproblems.com/2",
+    "erdosProblemStatus": "open-question",
+    "relatedProblems": [
+      {
+        "id": "erdos-2",
+        "relation": "Parent formalization. This OQ extends it with structural theorems about the gap [42, 616000]."
+      }
+    ],
+    "dateAdded": "2026-03-29",
+    "axiomCount": 3,
+    "lineCount": 232,
+    "prerequisites": [
+      "Covering systems and congruence classes",
+      "Well-ordering principle for natural numbers",
+      "Basic properties of achievability (monotonicity)",
+      "Erdős Problem #2 parent formalization"
+    ],
+    "mathlib_version": "4.29.0",
+    "originalContributions": [
+      "Formal definition of IsExactMaxMinModulus with equivalent characterizations",
+      "Existence proof using well-ordering (Nat.find on the complement of the achievable set)",
+      "Uniqueness proof via monotonicity contradiction",
+      "Gap theorem: 42 ≤ M ≤ 616,000 from Owens and Balister bounds",
+      "Complete characterization of achievable set as initial segment [0, M]",
+      "Gap narrowing framework for future bound improvements"
+    ],
+    "assumptions": "3 axiom(s) inherited from imported Lean file. 0 sorry(s)."
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #2 asked whether the minimum modulus of a covering system can be arbitrarily large. This was resolved negatively by Hough (2015) and improved by Balister et al. (2022), giving the upper bound M ≤ 616,000. The best construction, by Owens (2014), achieves minimum modulus 42. The exact value of M remains one of the most prominent open questions in covering system theory. This formalization proves that M exists as a well-defined mathematical object and constrains it to the interval [42, 616000], establishing the structural framework for any future narrowing of the gap.",
+    "problemStatement": "What is the exact maximum possible minimum modulus M for covering systems with distinct moduli ≥ 2?",
+    "text": "Structural theorems about the exact maximum minimum modulus M for covering systems. Currently 42 ≤ M ≤ 616,000.",
+    "proofStrategy": "Define achievability as a downward-monotone predicate on ℕ. Use the well-ordering principle (Nat.find) on the set of non-achievable values to extract the exact boundary M. Prove M is unique via monotonicity. Derive the gap [42, 616000] from Owens' construction (lower bound) and Balister et al.'s theorem (upper bound). Characterize the achievable set as exactly {0, 1, ..., M}.",
+    "keyInsights": [
+      "**Achievability is downward-monotone**: if min modulus m is achievable, so is any m' ≤ m",
+      "**Well-ordering gives existence**: the smallest non-achievable value n₀ determines M = n₀ - 1",
+      "**Uniqueness from monotonicity**: any two exact maxima must be equal (contradiction if M₁ ≠ M₂)",
+      "**The achievable set is an initial segment**: Achievable m ↔ m ≤ M",
+      "**Gap narrowing framework**: any improved bound (lower or upper) directly constrains M"
+    ],
+    "prerequisites": [
+      "Covering systems and congruence classes",
+      "Well-ordering principle for natural numbers",
+      "Achievability monotonicity",
+      "Erdős Problem #2 parent formalization"
     ]
+  },
+  "sections": [
+    {
+      "id": "achievability",
+      "title": "Achievability",
+      "summary": "Defines achievability and proves downward-monotonicity, with concrete results for 42 and 616000.",
+      "startLine": 28,
+      "endLine": 57,
+      "mathContext": "A minimum modulus value $m$ is achievable if some covering system has all moduli $\\geq m$. This is downward-monotone: if $m$ is achievable, so is $m' \\leq m$. Owens shows $42$ is achievable; Balister shows nothing above $616{,}000$ is."
+    },
+    {
+      "id": "exact-max-def",
+      "title": "The Exact Maximum Minimum Modulus",
+      "summary": "Defines IsExactMaxMinModulus and proves equivalence with the covering system bound characterization.",
+      "startLine": 59,
+      "endLine": 80,
+      "mathContext": "$M$ is the exact maximum minimum modulus iff $M$ is achievable and $M+1$ is not. Equivalently: some covering system achieves min modulus $M$, and every covering system has at least one modulus $\\leq M$."
+    },
+    {
+      "id": "existence-uniqueness",
+      "title": "Existence and Uniqueness",
+      "summary": "Proves M exists (well-ordering + Nat.find) and is unique (monotonicity contradiction).",
+      "startLine": 82,
+      "endLine": 115,
+      "mathContext": "Existence uses the well-ordering principle on $\\mathbb{N}$: the set $\\{n \\mid \\lnot\\text{Achievable}(n)\\}$ is nonempty (contains $616{,}001$), so $\\texttt{Nat.find}$ extracts its minimum $n_0$. Then $M = n_0 - 1$. Uniqueness follows because if $M_1 < M_2$ were both exact maxima, then $M_1 + 1 \\leq M_2$ would make $M_1 + 1$ achievable, contradicting $M_1$ being exact."
+    },
+    {
+      "id": "gap",
+      "title": "The Gap [42, 616000]",
+      "summary": "Proves 42 ≤ M ≤ 616000 from Owens and Balister bounds.",
+      "startLine": 117,
+      "endLine": 145,
+      "mathContext": "Lower bound: if $M < 42$ then $M+1 \\leq 42$ is achievable (Owens), contradicting $M$ being exact. Upper bound: if $M > 616{,}000$ then $M$ is not achievable (Balister), contradicting the definition."
+    },
+    {
+      "id": "characterization",
+      "title": "Complete Characterization of the Achievable Set",
+      "summary": "Proves Achievable m ↔ m ≤ M, characterizing achievability as an initial segment.",
+      "startLine": 147,
+      "endLine": 170,
+      "mathContext": "The achievable set is exactly $\\{0, 1, \\ldots, M\\}$. This follows from downward-monotonicity (achievable below $M$) and non-achievability above $M$ (from the exact max definition). The gap narrowing theorem provides a framework for improving bounds."
+    }
+  ]
 }

--- a/src/data/proofs/erdos-395-oq-01/meta.json
+++ b/src/data/proofs/erdos-395-oq-01/meta.json
@@ -2,9 +2,9 @@
   "id": "erdos-395-oq-01",
   "title": "Optimal Constant in Reverse Littlewood-Offord",
   "slug": "erdos-395-oq-01",
-  "description": "Structural theorems about the optimal constant c in the reverse Littlewood-Offord problem P(|sum| \u2264 \u221a2) \u2265 c/n. Formalizes the critical role of the \u221a2 threshold, monotonicity in threshold, tightness of the 1/n rate, and the counterexample exceeding threshold 1.",
+  "description": "Structural theorems about the optimal constant c in the reverse Littlewood-Offord problem P(|sum| ≤ √2) ≥ c/n. Formalizes the critical role of the √2 threshold, monotonicity in threshold, tightness of the 1/n rate, and the counterexample exceeding threshold 1.",
   "meta": {
-    "author": "He-Ju\u0161kevi\u010dius-Narayanan-Spiro (2024), Carnielli-Carolino (2011)",
+    "author": "He-Juškevičius-Narayanan-Spiro (2024), Carnielli-Carolino (2011)",
     "sourceUrl": "https://erdosproblems.com/395",
     "date": "2024",
     "status": "axiomatized",
@@ -22,10 +22,10 @@
     "erdosUrl": "https://erdosproblems.com/395",
     "erdosProblemStatus": "open-question",
     "dateAdded": "2026-03-29",
-    "axiomCount": 0,
+    "axiomCount": 2,
     "lineCount": 161,
     "prerequisites": [
-      "Erd\u0151s Problem #395 parent formalization",
+      "Erdős Problem #395 parent formalization",
       "Complex analysis and norms",
       "Probability on finite sets"
     ],
@@ -35,7 +35,7 @@
       "Optimal constant c* defined via sSup",
       "Counterexample exceeds threshold 1 (derived from parent axiom)",
       "Monotonicity of counts in threshold parameter",
-      "\u221a2 is critical: result holds at \u221a2, fails at 1",
+      "√2 is critical: result holds at √2, fails at 1",
       "Rate tightness summary from extremal example",
       "Extremal example has unit vectors (proved)"
     ]


### PR DESCRIPTION
## Fix

Seven gallery entries had `badge: "axiom"` and `status: "axiomatized"` correctly (they DO use axioms), but `axiomCount: 0` incorrectly — they import Lean files that contain axiom declarations.

## Corrections

| Entry | Imported File | Axioms in File | Old Count | New Count |
|-------|--------------|----------------|-----------|-----------|
| amgm-inequality-oq-02-oq-03 | AmgmInequalityOQ02.lean | newton_log_concavity, maclaurin_step | 0 | 2 |
| borsuk-ulam-oq-02-oq-01-oq-04 | BorsukUlamOQ02OQ01.lean | 4 axioms | 0 | 4 |
| cantor-diagonalization-oq-01-oq-01 | ContinuumHypothesis.lean | 4 axioms | 0 | 4 |
| erdos-1014-oq-02 | Erdos1014Problem.lean | 12 axioms | 0 | 12 |
| erdos-1155-oq-01 | Erdos1155Problem.lean | 4 axioms | 0 | 4 |
| erdos-2-oq-01 | Erdos2Problem.lean | balister_bound, owens_construction, reciprocal_sum_ge_one | 0 | 3 |
| erdos-395-oq-01 | Erdos395Problem.lean | erdos_original_is_false, hjns_2024 | 0 | 2 |

## Policy Reference

Per the axiom integrity policy: `axiomCount` must reflect ALL assumptions including those inherited from imported Lean files. The badge and status were already correct in all cases.

---
Automated fix by lean-mechanic agent.