### PR TITLE
Enrich Rational Canonical Form: Similarity Invariance (cayley-hamilton-minpoly-oq-02-oq-03)

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-03/annotations.json
@@ -1,1 +1,86 @@
-[]
+[
+  {
+    "id": "ann-rcf-background",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-03",
+    "range": { "startLine": 5, "endLine": 28 },
+    "type": "context",
+    "title": "Rational Canonical Form: Mathematical Background",
+    "content": "The module header introduces the Rational Canonical Form (RCF), also called the Frobenius normal form. Unlike the Jordan canonical form — which requires an algebraically closed field — the RCF exists over any field $F$. It represents each matrix as a block diagonal of companion matrices $C(p_1), \\ldots, C(p_k)$ where the invariant factors $p_1 \\mid p_2 \\mid \\cdots \\mid p_k$ are the elementary divisors of the $F[x]$-module $F^n$ (with $x$ acting by multiplication by $A$). This module-theoretic perspective, combined with the structure theorem for finitely generated modules over PIDs, is the conceptual foundation of the RCF.",
+    "mathContext": "$A \\sim B \\Leftrightarrow$ they have the same invariant factors $p_1 \\mid \\cdots \\mid p_k$, where $p_k = m_A$ and $\\prod p_i = \\chi_A$",
+    "significance": "context",
+    "relatedConcepts": ["Jordan canonical form", "Smith normal form", "PID module classification", "invariant factors", "Frobenius normal form"],
+    "prerequisites": ["linear algebra over fields", "polynomial rings", "module theory", "PIDs"]
+  },
+  {
+    "id": "ann-variable-setup",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-03",
+    "range": { "startLine": 29, "endLine": 33 },
+    "type": "technical",
+    "title": "Generic Matrix Setup with DecidableEq",
+    "content": "The `variable` declaration uses `{n : Type*}` (an arbitrary type) with `[DecidableEq n]` and `[Fintype n]` type class constraints. This is the idiomatic Lean/Mathlib way to parametrize over arbitrary finite index types, more general than fixing `Fin n`. The `DecidableEq` requirement enables `if-then-else` and equality checks in matrix computations. Opening `Matrix` and `Polynomial` namespaces gives direct access to `Matrix.charpoly`, `minpoly`, and polynomial operations.",
+    "mathContext": "$A \\in M_{n \\times n}(F)$ where $n$ is a finite type and $F$ is a field",
+    "significance": "technical",
+    "relatedConcepts": ["Fintype type class", "DecidableEq", "Mathlib matrix conventions", "universe polymorphism"],
+    "prerequisites": ["Lean 4 type classes", "Mathlib matrix types"]
+  },
+  {
+    "id": "ann-charpoly-similar",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-03",
+    "range": { "startLine": 37, "endLine": 44 },
+    "type": "technique",
+    "title": "Characteristic Polynomial Invariance via Conjugation",
+    "content": "The proof of `charpoly_similar` is a single call to `Matrix.charpoly_conj_of_isUnit`, after `subst hSim` eliminates the hypothesis $B = P^{-1}AP$ by substituting. The mathematical reason: $\\chi_{P^{-1}AP}(x) = \\det(xI - P^{-1}AP) = \\det(P^{-1}(xI-A)P) = \\det(P^{-1})\\det(xI-A)\\det(P) = \\chi_A(x)$, using multiplicativity of the determinant and $\\det(P^{-1})\\det(P) = 1$. The use of `IsUnit P` (rather than `Invertible P` or `det P ≠ 0`) reflects Mathlib's preferred algebraic formulation of invertibility.",
+    "mathContext": "$\\chi_{P^{-1}AP}(x) = \\det(xI - P^{-1}AP) = \\det(P)^{-1}\\det(xI-A)\\det(P) = \\chi_A(x)$",
+    "significance": "key",
+    "relatedConcepts": ["characteristic polynomial", "determinant multiplicativity", "conjugation invariance", "IsUnit in Mathlib"],
+    "prerequisites": ["characteristic polynomial definition", "matrix determinant", "invertible matrices"]
+  },
+  {
+    "id": "ann-minpoly-similar",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-03",
+    "range": { "startLine": 46, "endLine": 52 },
+    "type": "technique",
+    "title": "Minimal Polynomial Invariance via Polynomial Evaluation",
+    "content": "The proof delegates to `minpoly_conj_of_isUnit`, which encapsulates the key insight: for any polynomial $p \\in F[x]$, we have $p(P^{-1}AP) = P^{-1}p(A)P$. This holds by induction since $(P^{-1}AP)^k = P^{-1}A^kP$ and linearity. Consequently, $p(P^{-1}AP) = 0 \\Leftrightarrow p(A) = 0$, meaning $A$ and $P^{-1}AP$ share their set of annihilating polynomials. The minimal polynomial — the monic generator of this ideal — is therefore the same for both.",
+    "mathContext": "$p(P^{-1}AP) = P^{-1}p(A)P$, so $\\{p : p(A) = 0\\} = \\{p : p(P^{-1}AP) = 0\\}$ and $m_{P^{-1}AP} = m_A$",
+    "significance": "key",
+    "relatedConcepts": ["minimal polynomial", "annihilating polynomial", "polynomial evaluation at matrix", "Cayley-Hamilton theorem"],
+    "prerequisites": ["minimal polynomial definition", "polynomial ring over matrices", "ideal theory"]
+  },
+  {
+    "id": "ann-invariant-factors-def",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-03",
+    "range": { "startLine": 54, "endLine": 74 },
+    "type": "definition",
+    "title": "InvariantFactorsEqual: A Necessary Proxy",
+    "content": "The definition `InvariantFactorsEqual A B := A.charpoly = B.charpoly ∧ minpoly F A = minpoly F B` captures two necessary conditions for similarity but is explicitly noted as \"necessary but not sufficient\". The full invariant factor sequence $(p_1, \\ldots, p_k)$ determines the similarity class; knowing only the product (charpoly) and the largest element (minpoly) does not uniquely determine the sequence. For example, two 4×4 matrices with charpoly $x^4$ and minpoly $x^2$ might have invariant factor sequences $(x^2, x^2)$ or — if the minimal polynomial equals the charpoly — $(1, x^4)$ cannot arise. The `similar_implies_invariant_data` theorem bundles both invariance results into this predicate.",
+    "mathContext": "Two $n \\times n$ matrices are similar $\\Rightarrow$ `InvariantFactorsEqual`, but the converse requires the full invariant factor sequence, not just $\\chi$ and $m$",
+    "significance": "supporting",
+    "relatedConcepts": ["invariant factors", "Smith normal form", "elementary divisors", "similarity classification"],
+    "prerequisites": ["characteristic polynomial", "minimal polynomial", "invariant factor theory"]
+  },
+  {
+    "id": "ann-companion-matrix",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-03",
+    "range": { "startLine": 76, "endLine": 92 },
+    "type": "definition",
+    "title": "Companion Matrix: Building Block of RCF",
+    "content": "The `CompanionMatrixProp C p` definition captures what makes $C$ a companion matrix for monic polynomial $p$: both its characteristic polynomial and its minimal polynomial equal $p$. The companion matrix $C(p)$ for $p(x) = x^d + c_{d-1}x^{d-1} + \\cdots + c_0$ is the $d \\times d$ matrix with 1s on the subdiagonal and the negated coefficients in the last column. The key property — $p(C(p)) = 0$ with $p$ of minimal degree — is immediate from Cayley-Hamilton plus the fact that $p$ is both the characteristic and minimal polynomial of $C(p)$. The RCF theorem states that every matrix is similar to a block diagonal of companion matrices.",
+    "mathContext": "$C(p) = \\begin{pmatrix} 0 & 0 & \\cdots & -c_0 \\\\ 1 & 0 & \\cdots & -c_1 \\\\ 0 & 1 & \\cdots & -c_2 \\\\ \\vdots & & \\ddots & \\vdots \\\\ 0 & 0 & \\cdots & -c_{d-1}\\end{pmatrix}$, with $\\chi_{C(p)} = m_{C(p)} = p$",
+    "significance": "supporting",
+    "relatedConcepts": ["companion matrix", "cyclic module", "Cayley-Hamilton theorem", "rational canonical form blocks"],
+    "prerequisites": ["characteristic polynomial", "minimal polynomial", "block diagonal matrices"]
+  },
+  {
+    "id": "ann-gap-analysis",
+    "proofId": "cayley-hamilton-minpoly-oq-02-oq-03",
+    "range": { "startLine": 94, "endLine": 130 },
+    "type": "insight",
+    "title": "RCF Formalization Roadmap: ~1800 Lines Needed",
+    "content": "The assessment section provides a structured gap analysis. Mathlib already has: `Matrix.charpoly`, the Cayley-Hamilton theorem (`aeval_self_charpoly`), `minpoly`, and both conjugation invariance lemmas. What's missing for the full RCF: (1) **Smith normal form** for matrices over $F[x]$ (~800 lines): diagonalization via elementary row/column operations, invariant factor extraction — this is the hardest piece; (2) **Companion matrix construction** (~200 lines): explicit building of $C(p)$ from a polynomial and proof that charpoly = minpoly = $p$; (3) **Block diagonal assembly** (~300 lines) and **full RCF theorem** (~500 lines): existence, uniqueness, and the characterization $A \\sim B \\Leftrightarrow$ same RCF. The total of ~1800 lines is substantial but well-scoped.",
+    "mathContext": "Full RCF: $A \\sim \\text{diag}(C(p_1), \\ldots, C(p_k))$ for unique invariant factors $p_1 \\mid \\cdots \\mid p_k$, extracted from Smith normal form of $(xI - A) \\in M_n(F[x])$",
+    "significance": "context",
+    "relatedConcepts": ["Smith normal form", "PID diagonalization", "elementary operations", "block diagonal matrices", "Mathlib formalization effort"],
+    "prerequisites": ["matrices over PIDs", "Smith normal form algorithm", "module structure theorem"]
+  }
+]

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "cayley-hamilton-minpoly-oq-02-oq-03",
   "title": "Rational Canonical Form: Similarity Invariance",
   "slug": "cayley-hamilton-minpoly-oq-02-oq-03",
-  "description": "Proves similarity invariance of characteristic and minimal polynomials. Assesses RCF formalization: ~1800 lines needed, Smith normal form is the main gap.",
+  "description": "Proves similarity invariance of characteristic and minimal polynomials using Mathlib, defines invariant factor data and companion matrix properties, and provides a detailed gap analysis showing ~1800 lines are needed for full Rational Canonical Form formalization with Smith normal form as the main missing ingredient.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -21,18 +21,97 @@
     "theoremCount": 3,
     "mathlib_version": "4.26.0"
   },
+  "overview": {
+    "historicalContext": "The classification of square matrices up to similarity was a central problem of 19th-century algebra. Weierstrass (1867) studied the problem for bilinear forms; Jordan (1870) proved his canonical form over algebraically closed fields, where every matrix decomposes into Jordan blocks. But Jordan form fails over general fields: the real matrix $\\begin{pmatrix}0&-1\\\\1&0\\end{pmatrix}$ has no real Jordan form. The solution — valid over any field — is the **Rational Canonical Form** (RCF), developed by Frobenius (1878–1879) using the theory of **invariant factors**. Henry John Stephen Smith (1861) had already developed the Smith normal form for integer matrices, and its extension to polynomial matrices over a PID provides the key computational tool for extracting invariant factors from the matrix $xI - A$. The RCF theorem states: every matrix is similar to a unique block-diagonal matrix of companion matrices $C(p_1), C(p_2), \\ldots, C(p_k)$ where $p_1 \\mid p_2 \\mid \\cdots \\mid p_k$ are the invariant factors.",
+    "problemStatement": "For a square matrix $A \\in M_n(F)$ over a field $F$, two matrices $A, B$ are **similar** if there exists an invertible $P$ with $B = P^{-1}AP$. The Rational Canonical Form addresses: when are two matrices similar? The key insight is that similarity is equivalent to isomorphism of $F[x]$-modules $F^n$ (with $x$ acting by $A$), and invariant factor decomposition classifies such modules. This entry proves the necessary ingredients: similar matrices have the same characteristic polynomial $\\chi_A = \\det(xI - A)$ and minimal polynomial $m_A$ (the monic polynomial of least degree annihilating $A$).",
+    "proofStrategy": "Both main theorems (`charpoly_similar` and `minpoly_similar`) are proved in single lines by delegating to Mathlib's `Matrix.charpoly_conj_of_isUnit` and `minpoly_conj_of_isUnit` respectively. The pattern is: substitute $B = P^{-1}AP$ via `subst hSim`, then apply the Mathlib conjugation lemma directly. The file also defines `InvariantFactorsEqual` as a conjunction of equal charpolys and minpolys (necessary but not sufficient for full invariant factor equality), and `CompanionMatrixProp` as a proposition capturing the defining property of companion matrices. A detailed assessment section catalogues what Mathlib currently provides and what remains to be formalized for the full RCF theorem.",
+    "keyInsights": [
+      "The characteristic polynomial $\\chi_{P^{-1}AP} = \\chi_A$ follows immediately from the multiplicativity of the determinant: $\\det(xI - P^{-1}AP) = \\det(P^{-1}(xI-A)P) = \\det(P^{-1})\\det(xI-A)\\det(P) = \\chi_A$, with $\\det(P^{-1})\\det(P) = 1$.",
+      "Minimal polynomial invariance $m_{P^{-1}AP} = m_A$ follows from the fact that $p(P^{-1}AP) = P^{-1}p(A)P$ for any polynomial $p$ (by induction), so $p(P^{-1}AP) = 0 \\Leftrightarrow p(A) = 0$, meaning $A$ and $P^{-1}AP$ have identical annihilating polynomials.",
+      "The `InvariantFactorsEqual` predicate (charpoly ∧ minpoly equal) is strictly weaker than full invariant factor equality: two 4×4 matrices can share both the characteristic and minimal polynomial while having different invariant factor sequences — e.g., the matrices with invariant factors $(x^2, x^2)$ vs. $(1, x^4)$ could have the same charpoly $x^4$ but different minimal polynomials.",
+      "The Smith normal form for polynomial matrices is the key missing ingredient: given $xI - A$ as a matrix over $F[x]$ (a PID), Smith normal form diagonalizes it to $\\text{diag}(f_1, f_2, \\ldots, f_n)$ where each $f_i \\mid f_{i+1}$, giving the invariant factors as the nonzero entries.",
+      "This formalization exemplifies the Mathlib delegation pattern: rather than reproving known results, the file imports Mathlib's verified conjugation lemmas and wraps them in a similarity-framed API, making the mathematical structure explicit while keeping proof effort minimal."
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-header",
+      "title": "Imports and Module Overview",
+      "startLine": 1,
+      "endLine": 28,
+      "summary": "Imports `CharacteristicPolynomial`, `Charpoly.Basic`, and `Tactic` from Mathlib. The docstring introduces the Rational Canonical Form, defines similarity ($B = P^{-1}AP$), and outlines the four parts: similarity invariance of polynomials, invariant factors, companion matrices, and a formalization assessment."
+    },
+    {
+      "id": "setup",
+      "title": "Namespace and Variable Context",
+      "startLine": 29,
+      "endLine": 33,
+      "summary": "Opens the `Matrix` and `Polynomial` namespaces. Declares the universe-polymorphic index type `n` (with `DecidableEq` and `Fintype`), and the field `F`. This setup enables the theorems to apply to all finite-dimensional matrices over arbitrary fields."
+    },
+    {
+      "id": "charpoly-similarity",
+      "title": "Characteristic Polynomial Similarity Invariance",
+      "startLine": 35,
+      "endLine": 44,
+      "summary": "Proves `charpoly_similar`: if $B = P^{-1}AP$ and $P$ is invertible (`IsUnit P`), then $B.\\text{charpoly} = A.\\text{charpoly}$. The proof is one line: `subst hSim` followed by `Matrix.charpoly_conj_of_isUnit`."
+    },
+    {
+      "id": "minpoly-similarity",
+      "title": "Minimal Polynomial Similarity Invariance",
+      "startLine": 46,
+      "endLine": 52,
+      "summary": "Proves `minpoly_similar`: similar matrices have the same minimal polynomial over $F$. Delegates to `minpoly_conj_of_isUnit` from Mathlib's `Charpoly.Basic`. Both theorems together confirm that charpoly and minpoly are complete similarity invariants in their respective roles."
+    },
+    {
+      "id": "invariant-factors",
+      "title": "Invariant Factor Data Definition",
+      "startLine": 54,
+      "endLine": 74,
+      "summary": "Defines `InvariantFactorsEqual A B` as the conjunction of equal charpoly and minpoly — a necessary but not sufficient condition for full invariant factor equality. Proves `similar_implies_invariant_data` combining both similarity invariance theorems into this predicate."
+    },
+    {
+      "id": "companion-matrix",
+      "title": "Companion Matrix Property",
+      "startLine": 76,
+      "endLine": 92,
+      "summary": "Defines `CompanionMatrixProp C p`: a matrix $C$ is a companion matrix for monic $p$ if $C.\\text{charpoly} = p$ and $\\text{minpoly}(C) = p$. The docstring shows the explicit matrix form and notes that Cayley-Hamilton gives $p(C(p)) = 0$ with $p$ minimal."
+    },
+    {
+      "id": "assessment",
+      "title": "Formalization Gap Analysis",
+      "startLine": 94,
+      "endLine": 136,
+      "summary": "Catalogues Mathlib's current coverage (charpoly, Cayley-Hamilton, minpoly, conjugation invariance) and identifies the three missing ingredients for full RCF: Smith normal form for $F[x]$-matrices (~800 lines), companion matrix construction (~200 lines), and block diagonal assembly + the full RCF existence/uniqueness theorem (~800 lines). Total estimated effort: ~1800 lines."
+    }
+  ],
+  "conclusion": {
+    "summary": "This entry proves that similar matrices have identical characteristic and minimal polynomials, delegating to Mathlib's verified conjugation lemmas. It defines the key auxiliary structures (`InvariantFactorsEqual`, `CompanionMatrixProp`) and provides a detailed roadmap showing that the full Rational Canonical Form theorem requires approximately 1800 additional lines of Lean, with Smith normal form for polynomial matrices as the central missing piece.",
+    "implications": "The Rational Canonical Form is the correct substitute for Jordan form when working over non-algebraically-closed fields. It classifies all finitely generated torsion modules over PIDs, making it central to abstract algebra. In Lean 4, a complete formalization would require extending Mathlib's PID module theory to $F[x]$-matrices and constructively computing Smith normal form — a substantial but well-defined project. The similarity invariance results proved here are the first and most accessible steps, already available as one-liners in Mathlib.",
+    "openQuestions": [
+      "Can Smith normal form for polynomial matrices over a field be formalized in Lean/Mathlib? This would be the key contribution enabling full RCF (estimated ~800 lines for the diagonalization algorithm alone).",
+      "Is `InvariantFactorsEqual` (charpoly ∧ minpoly equality) actually sufficient for similarity when $n \\leq 3$? For $n = 2$, the charpoly alone determines the similarity class; for $n = 3$, does minpoly together with charpoly suffice?",
+      "Can the Rational Canonical Form be constructed purely from Mathlib's existing `Module.Free.chooseBasis` and `PID` theory, without a standalone Smith normal form algorithm?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-02",
+      "relationship": "extends"
+    },
+    {
+      "targetId": "cayley-hamilton",
+      "relationship": "uses"
+    },
+    {
+      "targetId": "cayley-hamilton-minpoly",
+      "relationship": "related"
+    }
+  ],
   "leanFile": {
     "namespace": "CayleyHamiltonMinpolyOQ02OQ03",
     "lineCount": 136,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 2
-  },
-  "crossReferences": [
-    {
-      "targetId": "cayley-hamilton-minpoly-oq-02",
-      "relationship": "extends"
-    }
-  ],
-  "sections": []
+  }
 }


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-minpoly-oq-02-oq-03`.

## Quality Improvements

- **Historical context**: Traces RCF from Frobenius (1878-79), Jordan (1870), and Smith normal form (1861), explaining why RCF exists over any field while Jordan form requires algebraic closure
- **Problem statement**: Framed in terms of $F[x]$-module classification and invariant factors
- **Proof strategy**: Explains the Mathlib delegation pattern — both main theorems proved in 1-2 lines via `charpoly_conj_of_isUnit` and `minpoly_conj_of_isUnit`
- **Key insights**: 5 insights covering determinant multiplicativity, polynomial evaluation duality, the limitation of `InvariantFactorsEqual`, Smith normal form as the main gap, and the delegation-to-Mathlib pattern
- **Sections**: 7 sections covering all parts of the file including the detailed assessment section
- **Annotations**: 7 annotations with LaTeX `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`
- **Conclusion**: Implications for PID module theory, plus 3 open questions about formalizing Smith normal form and completing the full RCF
- **Cross-references**: Added links to `cayley-hamilton` and `cayley-hamilton-minpoly`

## Notes

Axiom integrity: `axiomCount: 0` and `status: "verified"` are accurate — both main theorems are fully proved via Mathlib lemmas with 0 sorries. The `InvariantFactorsEqual` definition is annotated as "necessary but not sufficient" for full similarity classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)