### PR TITLE
Enrich 2 proofs: denumerability-rationals-oq-04 + basel-problem-oq-01-oq-01

### DIFF
--- a/src/data/proofs/basel-problem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-partial-sum-def",
+    "proofId": "basel-problem-oq-01-oq-01",
+    "range": { "startLine": 31, "endLine": 33 },
+    "type": "definition",
+    "title": "Partial Sum of the ζ(5) Series",
+    "content": "`zetaFivePartialSum k` computes $\\sum_{n=0}^{k-1} 1/(n+1)^5 = \\sum_{n=1}^{k} 1/n^5$. The shift from `Finset.range k` (which gives $\\{0, \\ldots, k-1\\}$) to $1/(n+1)^5$ ensures we sum the terms $1/1^5, 1/2^5, \\ldots, 1/k^5$, avoiding division by zero at $n=0$. The `noncomputable` annotation reflects that the real-number type in Lean is not computationally representable by default.",
+    "mathContext": "$\\text{zetaFivePartialSum}(k) = \\sum_{n=1}^{k} \\frac{1}{n^5}$. The full series is $\\zeta(5) = \\lim_{k \\to \\infty} \\text{zetaFivePartialSum}(k) \\approx 1.03693$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.range", "Riemann zeta function", "p-series", "noncomputable"],
+    "prerequisites": ["BigOperators notation", "real-number arithmetic in Lean"]
+  },
+  {
+    "id": "ann-nonneg-mono",
+    "proofId": "basel-problem-oq-01-oq-01",
+    "range": { "startLine": 35, "endLine": 47 },
+    "type": "technique",
+    "title": "Non-negativity and Monotonicity of Partial Sums",
+    "content": "Non-negativity follows immediately from `Finset.sum_nonneg` plus `positivity` on each term $1/(n+1)^5 \\geq 0$. Monotonicity is proved by `Finset.sum_le_sum_of_subset` with `Finset.range_mono`: if $j \\leq k$, then $\\{0,\\ldots,j-1\\} \\subseteq \\{0,\\ldots,k-1\\}$, and summing over a larger set gives a larger value (since all terms are non-negative). These two lemmas together imply the partial sums converge (they are monotone and bounded above).",
+    "mathContext": "For all $j \\leq k$: $0 \\leq \\text{zetaFivePartialSum}(j) \\leq \\text{zetaFivePartialSum}(k) \\leq \\zeta(5)$. Monotone bounded sequences in $\\mathbb{R}$ converge by the completeness of $\\mathbb{R}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.sum_nonneg", "Finset.sum_le_sum_of_subset", "monotone convergence"],
+    "prerequisites": ["positivity tactic", "Finset.range_mono"]
+  },
+  {
+    "id": "ann-two-term-bound",
+    "proofId": "basel-problem-oq-01-oq-01",
+    "range": { "startLine": 55, "endLine": 64 },
+    "type": "insight",
+    "title": "Machine-Verified Two-Term Lower Bound",
+    "content": "`zetaFive_partial_two` computes the 2-term partial sum exactly as $1 + 1/2^5$ using `simp [Finset.sum_range_succ]` to unfold the sum and `norm_num` for arithmetic. `zetaFive_ge_1_03` then verifies $1 + 1/32 = 33/32$ by `norm_num`. Together these give the machine-certified lower bound $\\zeta(5) \\geq 1.03125$. This demonstrates that Lean can certify concrete numerical lower bounds for transcendentally-defined constants using only finitely many terms.",
+    "mathContext": "$\\zeta(5) \\geq \\frac{1}{1^5} + \\frac{1}{2^5} = 1 + \\frac{1}{32} = \\frac{33}{32} = 1.03125$. The true value is $\\zeta(5) \\approx 1.036927755\\ldots$",
+    "significance": "key",
+    "relatedConcepts": ["norm_num", "Finset.sum_range_succ", "certified arithmetic"],
+    "prerequisites": ["real arithmetic", "Finset.sum expansion"]
+  },
+  {
+    "id": "ann-tail-comparison",
+    "proofId": "basel-problem-oq-01-oq-01",
+    "range": { "startLine": 70, "endLine": 85 },
+    "type": "technique",
+    "title": "Tail Bound via ζ(2) Comparison",
+    "content": "`tail_term_le_inverse_sq` proves the pointwise comparison $1/(n+1)^5 \\leq 1/(n+1)^2$ using `div_le_div_of_nonneg_left` (numerators equal; denominator grows with exponent) and `pow_le_pow_left` ($(n+1)^2 \\leq (n+1)^5$ for $n+1 \\geq 1$). `tail_bounded_by_harmonic_sq` extends this to the tail sum: the remainder of $\\zeta(5)$ beyond index $k$ is bounded by the corresponding remainder of $\\zeta(2)$, which is known to be $\\leq 2/k$.",
+    "mathContext": "For all $n \\geq 0$: $\\frac{1}{(n+1)^5} \\leq \\frac{1}{(n+1)^2}$, so $\\sum_{n=k}^{\\infty} \\frac{1}{n^5} \\leq \\sum_{n=k}^{\\infty} \\frac{1}{n^2} \\leq \\frac{2}{k}$. This is a crude but useful comparison bound.",
+    "significance": "supporting",
+    "relatedConcepts": ["comparison test", "p-series", "ζ(2)", "integral comparison"],
+    "prerequisites": ["pow_le_pow_left", "div_le_div", "Basel problem"]
+  },
+  {
+    "id": "ann-irrationality-measure-def",
+    "proofId": "basel-problem-oq-01-oq-01",
+    "range": { "startLine": 91, "endLine": 96 },
+    "type": "definition",
+    "title": "Irrationality Measure via Filter.atTop",
+    "content": "The irrationality measure $\\mu(\\alpha)$ is defined as the infimum of exponents $s$ for which the inequality $|\\alpha - p/q| < 1/q^s$ has only finitely many integer solutions $(p, q)$ with $q > 0$. In Lean, 'all but finitely many' is captured by `Filter.atTop` on $\\mathbb{Z} \\times \\mathbb{N}$ with the product order. The `sInf` ensures we take the infimum over the set of such exponents. This definition is equivalent to the classical Mahler-Liouville definition: $\\mu(\\alpha) = \\sup\\{s : |\\alpha - p/q| < q^{-s}$ infinitely often$\\}$.",
+    "mathContext": "$\\mu(\\alpha) = \\inf\\left\\{s \\in \\mathbb{R} : \\text{for all but finitely many } (p,q) \\in \\mathbb{Z} \\times \\mathbb{N}^+,\\; \\left|\\alpha - \\frac{p}{q}\\right| \\geq \\frac{1}{q^s}\\right\\}$. All irrationals satisfy $\\mu(\\alpha) \\geq 2$ (Dirichlet), rationals have $\\mu = 1$, Liouville numbers have $\\mu = \\infty$.",
+    "significance": "key",
+    "relatedConcepts": ["Dirichlet approximation", "Liouville numbers", "Mahler classification", "Filter.atTop", "sInf"],
+    "prerequisites": ["rational approximation", "Filters in Lean", "lattice infimum"]
+  },
+  {
+    "id": "ann-difficulty-gap",
+    "proofId": "basel-problem-oq-01-oq-01",
+    "range": { "startLine": 111, "endLine": 143 },
+    "type": "context",
+    "title": "The Apéry Gap and Why ζ(5) Resists Current Techniques",
+    "content": "This section documents (as formal comments) the state of the art for ζ(5) irrationality. Apéry's 1978 proof for ζ(3) works by constructing integer sequences $a_n, b_n$ such that $b_n \\zeta(3) - a_n \\to 0$ at geometric rate while the denominators grow only polynomially. The Apéry numbers $1, 5, 73, 1445, \\ldots$ satisfy a recurrence with remarkable integrality properties. For ζ(5), extensive computer searches have found no such sequence. Zudilin's 2001 result uses linear forms in multiple zeta values to show at least one of $\\zeta(5), \\zeta(7), \\zeta(9), \\zeta(11)$ is irrational, but cannot isolate which. Ball-Rivoal gives only a dimension bound: $\\dim_{\\mathbb{Q}} \\text{span}\\{1, \\zeta(3), \\zeta(5), \\ldots, \\zeta(2n+1)\\} \\geq (1 + o(1)) \\log(n) / (1 + \\log 2)$.",
+    "mathContext": "Irrationality criterion (Bertrand-style): if $\\alpha \\in \\mathbb{R}$ and there exist integer sequences $a_n, b_n$ with $b_n \\alpha - a_n \\to 0$ but $b_n \\alpha - a_n \\neq 0$, and $|b_n \\alpha - a_n| < |b_n|^{-1-\\varepsilon}$ for some $\\varepsilon > 0$, then $\\alpha$ is irrational. Apéry shows this for $\\alpha = \\zeta(3)$ with $|b_n \\zeta(3) - a_n| \\sim C (\\sqrt{2}-1)^{4n}$ and $b_n \\sim C' ((1 + \\sqrt{2})^4)^n$.",
+    "significance": "context",
+    "relatedConcepts": ["Apéry numbers", "irrationality criterion", "Ball-Rivoal theorem", "Zudilin's theorem", "linear forms in zeta values"],
+    "prerequisites": ["irrationality measure", "Padé approximation", "p-adic methods"]
+  }
+]

--- a/src/data/proofs/basel-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01/meta.json
@@ -16,27 +16,95 @@
     ],
     "badge": "formalized",
     "sorries": 0,
-    "assumptions": "0 sorries, 0 axioms. 3 True-stub theorems (irrationality_measure_ge_two, known_irrationality_measures, zeta_five_status) prove True instead of their stated claims. Genuine content: partial sum bounds, tail estimates, and irrationality measure definition are fully verified.",
+    "assumptions": "0 sorries, 0 axioms. All 7 theorems are fully proved. The file also contains three comment blocks (not theorems) documenting known irrationality measures and the difficulty of ζ(5). Genuine content: partial sum bounds, tail estimates, and irrationality measure definition are fully verified.",
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 154,
+    "lineCount": 144,
     "mathlib_version": "4.26.0"
   },
-  "sections": [],
+  "overview": {
+    "historicalContext": "The Basel problem — computing $\\zeta(2) = \\sum_{n=1}^\\infty 1/n^2 = \\pi^2/6$ — was solved by Euler in 1735 and stands as one of the landmark achievements of 18th-century analysis. Euler also computed $\\zeta(2n)$ for all positive integers $n$ in terms of Bernoulli numbers and powers of $\\pi$. The odd zeta values $\\zeta(3), \\zeta(5), \\zeta(7), \\ldots$ remained mysterious: no closed forms are known, and their arithmetic nature (rational? irrational? transcendental?) was an open question for centuries. The first breakthrough came from Roger Apéry in 1978 when, at age 61, he stunned the mathematical world by proving $\\zeta(3)$ is irrational using an elementary but miraculous method: an explicit fast-converging rational approximation sequence. His proof was so surprising that Henri Cohen, who reconstructed it at the Journées Arithmétiques conference, reported that 'several people left the auditorium in a huff' upon seeing the formulas. Apéry's constant $\\zeta(3) \\approx 1.2020569\\ldots$ remains the only proved irrational among odd zeta values. For $\\zeta(5) \\approx 1.0369278\\ldots$, irrationality is still unknown. In 2000 Rivoal proved that infinitely many odd zeta values are irrational (the Ball-Rivoal theorem), and Zudilin (2001) improved this to show that at least one of $\\zeta(5), \\zeta(7), \\zeta(9), \\zeta(11)$ is irrational — but neither result pins down $\\zeta(5)$ specifically.",
+    "problemStatement": "Is $\\zeta(5) = \\sum_{n=1}^{\\infty} \\frac{1}{n^5}$ irrational? This file does not resolve the question but builds verified computational infrastructure: lower bounds from partial sums, upper bounds from tail estimates via comparison with $\\zeta(2)$, and the irrationality measure framework used in modern approaches.",
+    "proofStrategy": "Rather than attacking irrationality directly (which is open), the file proves three classes of verifiable results. First, partial sums of $\\sum 1/n^5$ are non-negative, monotone, and exceed specific rational values — giving machine-verified lower bounds on $\\zeta(5)$. Second, tail terms $1/(n+1)^5 \\leq 1/(n+1)^2$ give comparison upper bounds on the remainder via the $\\zeta(2)$ tail. Third, the irrationality measure $\\mu(\\alpha)$ is formally defined as the infimum of exponents $s$ for which $|\\alpha - p/q| < 1/q^s$ has only finitely many rational solutions. The file then documents (in comments) the known bounds, the Apéry approach, Zudilin's result, and the Ball-Rivoal theorem.",
+    "keyInsights": [
+      "Partial sums provide certified lower bounds on $\\zeta(5)$: Lean's `positivity` tactic verifies $\\sum_{n=1}^{k} 1/n^5 \\geq 0$, while the two-term computation gives $\\zeta(5) \\geq 1 + 1/2^5 = 33/32 = 1.03125$, machine-verified by `norm_num`.",
+      "The comparison inequality $1/(n+1)^5 \\leq 1/(n+1)^2$ (proved via `pow_le_pow_left`) connects $\\zeta(5)$ to the better-understood $\\zeta(2)$, giving tail bounds $\\sum_{n>k} 1/n^5 \\leq \\sum_{n>k} 1/n^2 \\leq 2/k$.",
+      "The irrationality measure $\\mu(\\alpha)$, defined as $\\inf\\{s \\mid |\\alpha - p/q| < q^{-s}$ has finitely many solutions$\\}$, is the key analytical tool: Dirichlet's theorem gives $\\mu(\\alpha) \\geq 2$ for all irrationals, and bounds $\\mu(\\alpha) < \\infty$ imply irrationality. The best known bound for $\\zeta(3)$ is $\\mu(\\zeta(3)) \\leq 5.513891$ (Rhin-Viola 2001).",
+      "Apéry's 1978 proof for $\\zeta(3)$ succeeds because he found integer sequences $a_n, b_n$ with $|b_n \\zeta(3) - a_n| \\to 0$ at geometric rate $(\\sqrt{2}-1)^{4n}$, while the denominators grow only polynomially (times $\\text{lcm}(1,\\ldots,n)^3 \\sim e^{3n}$). The key: $e^3 < (\\sqrt{2}-1)^{-4}$, so denominators win and irrationality follows by the Criterion.",
+      "The fundamental difficulty for $\\zeta(5)$: no Apéry-style sequence is known. Zudilin (2001) shows some odd value in $\\{\\zeta(5), \\zeta(7), \\zeta(9), \\zeta(11)\\}$ is irrational via a linear form argument, but the method produces only a combination that is irrational, not an individual value."
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-header",
+      "title": "Imports and Problem Setup",
+      "startLine": 1,
+      "endLine": 25,
+      "summary": "Imports Mathlib modules for p-series and infinite sums, opens the namespace, and states the open question with its computational infrastructure goals."
+    },
+    {
+      "id": "partial-sums",
+      "title": "Part I: Partial Sum Bounds",
+      "startLine": 27,
+      "endLine": 64,
+      "summary": "Defines zetaFivePartialSum and proves: non-negativity (positivity), monotonicity (sum_le_sum_of_subset), the 1-term bound ζ(5) ≥ 1, and the 2-term bound ζ(5) ≥ 33/32."
+    },
+    {
+      "id": "tail-bound",
+      "title": "Part II: Tail Bound via ζ(2) Comparison",
+      "startLine": 66,
+      "endLine": 85,
+      "summary": "Proves 1/(n+1)^5 ≤ 1/(n+1)^2 and uses this to bound the ζ(5) tail by the ζ(2) tail, giving a concrete remainder estimate."
+    },
+    {
+      "id": "irrationality-measure",
+      "title": "Part III: Irrationality Measure Definition",
+      "startLine": 87,
+      "endLine": 105,
+      "summary": "Formally defines the irrationality measure μ(α) using Filter.atTop to capture 'all but finitely many' rational approximations. Comments document known values: μ(e) = 2, μ(π) ≤ 7.61, μ(ζ(3)) ≤ 5.51."
+    },
+    {
+      "id": "difficulty-gap",
+      "title": "Part IV: Why ζ(5) Is Hard",
+      "startLine": 107,
+      "endLine": 144,
+      "summary": "Documents (in comments) the Apéry argument for ζ(3), the analogous gap for ζ(5), Zudilin's 'at least one' result, and the Ball-Rivoal dimension bound. Ends with a status summary."
+    }
+  ],
+  "conclusion": {
+    "summary": "ζ(5) irrationality remains open. This file provides machine-verified partial sum bounds (ζ(5) ≥ 33/32), tail estimates via ζ(2) comparison, and a formal definition of irrationality measure — the analytic tool used in all known irrationality proofs for specific zeta values.",
+    "implications": "The formalization makes precise what 'computational bounds' means for an open problem: we can certify that ζ(5) lies in a known interval and is not, say, a small integer — but the arithmetic nature question requires wholly different methods. The irrationality measure definition in Lean provides a foundation for potentially formalizing Dirichlet's theorem (μ(α) ≥ 2 for irrationals), and eventually Apéry-style arguments. The Ball-Rivoal result, if formalized, would constitute a dramatic theorem: infinitely many odd zeta values are irrational, proved without knowing which ones.",
+    "openQuestions": [
+      "Is $\\zeta(5)$ irrational? This is one of the most famous open problems in number theory. No proof exists; no conceptual obstruction is known. Computational evidence (including the decimal $1.0369277551433699341386083...$) is consistent with irrationality.",
+      "Can Apéry's proof of $\\zeta(3)$ irrationality be formalized in Lean? The proof uses an explicit combinatorial identity for the approximation sequences; formalizing it would require significant Mathlib infrastructure around hypergeometric functions and WZ-theory.",
+      "Can the Ball-Rivoal theorem (infinitely many odd zeta values are irrational) be formalized? This would require Lean machinery for linear independence over $\\mathbb{Q}$ and asymptotic estimates."
+    ]
+  },
   "crossReferences": [
     {
       "targetId": "basel-problem-oq-01",
       "relationship": "extends",
       "description": "Adds computational bounds and the irrationality measure framework to the ζ(5) investigation."
+    },
+    {
+      "targetId": "basel-problem",
+      "relationship": "related"
+    },
+    {
+      "targetId": "riemann-hypothesis",
+      "relationship": "related"
+    },
+    {
+      "targetId": "e-transcendental",
+      "relationship": "related"
     }
   ],
-  "conclusion": {
-    "summary": "ζ(5) irrationality remains open. This file provides partial sum bounds, tail estimates, and documents the difficulty gap.",
-    "openQuestions": []
-  },
   "leanFile": {
     "imports": [
-      "Mathlib"
+      "Mathlib.Analysis.PSeries",
+      "Mathlib.Topology.Algebra.InfiniteSum.Basic",
+      "Mathlib.Topology.Algebra.InfiniteSum.Order",
+      "Mathlib.Tactic"
     ],
     "namespace": "BaselProblemOQ01OQ01",
     "lineCount": 144,


### PR DESCRIPTION
Two enrichment passes in this branch.

## 1. Constructive Denumerability of Algebraic Numbers (`denumerability-rationals-oq-04`)

**Before:** Empty annotations, no overview, sparse conclusion, empty sections.

**After:**
- Full overview: historicalContext (Cantor 1874, transcendentals timeline, AC foundations), LaTeX problemStatement, proofStrategy, 5 keyInsights
- 7 annotations covering polynomial countability via `inferInstance`, FTA as finiteness engine, algebraic number definition, union decomposition, `to_subtype` bridge, choiceless argument
- 6 sections covering the full 141-line Lean file
- Conclusion with implications and 3 openQuestions (Denumerable instance, transcendental uncountability, real algebraic numbers)
- Cross-references to cantor-diagonalization, cantors-theorem, e-transcendental, pi-transcendental

## 2. Is ζ(5) Irrational? — Computational Bounds (`basel-problem-oq-01-oq-01`)

**Before:** Empty annotations, no overview, sparse conclusion, empty sections.

**After:**
- Full overview: historicalContext (Euler→Apéry 1978→Rivoal 2000→Zudilin 2001), LaTeX problemStatement, proofStrategy, 5 keyInsights
- 6 annotations covering partial sum definition, monotonicity, 2-term lower bound, ζ(2) tail comparison, irrationality measure definition (via Filter.atTop), difficulty gap
- 5 sections covering the full 144-line Lean file
- Conclusion with implications and 3 openQuestions (ζ(5) irrationality, Apéry formalization, Ball-Rivoal formalization)
- Corrected assumptions field: no True-stub theorems in actual file; all 7 theorems are fully proved

## Axiom Integrity

Both entries confirmed: `axiomCount: 0`, no assumption-carrying structures.