### PR TITLE
fix: correct axiomCount=8 batch error for 50 gallery entries

### DIFF
--- a/src/data/proofs/erdos-1015/meta.json
+++ b/src/data/proofs/erdos-1015/meta.json
@@ -21,7 +21,7 @@
     "erdosNumber": 1015,
     "erdosUrl": "https://erdosproblems.com/1015",
     "erdosProblemStatus": "solved",
-    "axiomCount": 8,
+    "axiomCount": 2,
     "lineCount": 149,
     "assumptions": "10 axioms: moon_f3, moon_f3_n, ramseyNumber, and 7 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
@@ -208,7 +208,7 @@
     ],
     "namespace": null,
     "lineCount": 149,
-    "axiomCount": 8,
+    "axiomCount": 2,
     "theoremCount": 0,
     "definitionCount": 9
   }

--- a/src/data/proofs/erdos-1043/meta.json
+++ b/src/data/proofs/erdos-1043/meta.json
@@ -46,7 +46,7 @@
       "Upper and lower bounds on projection measures",
       "Connection to Bernoulli lemniscates"
     ],
-    "axiomCount": 8,
+    "axiomCount": 2,
     "lineCount": 270,
     "assumptions": "8 axiom(s) and 7 sorry(s). See the Lean source for details."
   },
@@ -252,7 +252,7 @@
     ],
     "namespace": "Erdos1043",
     "lineCount": 270,
-    "axiomCount": 8,
+    "axiomCount": 2,
     "theoremCount": 12,
     "definitionCount": 15
   }

--- a/src/data/proofs/erdos-1089/meta.json
+++ b/src/data/proofs/erdos-1089/meta.json
@@ -59,7 +59,7 @@
       "erdos1089Conjecture formalized via Filter.Tendsto"
     ],
     "dateAdded": "2025-12-29",
-    "axiomCount": 8,
+    "axiomCount": 4,
     "assumptions": "8 axioms: g_well_defined, g_1_3, g_2_3, g_3_3, cube_distances, erdos_lower_bound, erdos_straus_upper_bound, g_f_relationship. g_mono_d fully proved via isometric embedding with norm preservation via sum decomposition.",
     "prerequisites": [
       "Discrete and combinatorial geometry: point configurations and distances",
@@ -239,7 +239,7 @@
   "leanFile": {
     "lineCount": 389,
     "structureCount": 0,
-    "axiomCount": 8,
+    "axiomCount": 4,
     "theoremCount": 6,
     "substantiveTheoremCount": 5,
     "sorryTheorems": 0,

--- a/src/data/proofs/erdos-1110/meta.json
+++ b/src/data/proofs/erdos-1110/meta.json
@@ -58,7 +58,7 @@
       "example_1_representable theorem with constructive proof",
       "Connections to Problems #123, #845, #246"
     ],
-    "axiomCount": 8,
+    "axiomCount": 2,
     "lineCount": 265,
     "assumptions": "8 axioms: case_2_3_all_representable, even_representation, erdos_lewin_theorem, and 5 more. See Lean source for complete statements."
   },
@@ -260,7 +260,7 @@
     ],
     "namespace": "Erdos1110",
     "lineCount": 265,
-    "axiomCount": 8,
+    "axiomCount": 2,
     "theoremCount": 5,
     "definitionCount": 7
   }

--- a/src/data/proofs/erdos-1128/meta.json
+++ b/src/data/proofs/erdos-1128/meta.json
@@ -55,7 +55,7 @@
       "two_dim_negative axiom for ℵ₁² ↛ (ℵ₀)²₂",
       "erdos_1128_summary combining disproof and bad coloring existence"
     ],
-    "axiomCount": 8,
+    "axiomCount": 4,
     "lineCount": 166,
     "assumptions": "8 axioms: A, B, C, and 5 more. See Lean source for complete statements."
   },
@@ -214,7 +214,7 @@
     "opens": [],
     "namespace": "Erdos1128",
     "lineCount": 166,
-    "axiomCount": 8,
+    "axiomCount": 4,
     "theoremCount": 3,
     "definitionCount": 6
   }

--- a/src/data/proofs/erdos-136/meta.json
+++ b/src/data/proofs/erdos-136/meta.json
@@ -56,7 +56,7 @@
       "erdos_136 summary combining asymptotic and bounds"
     ],
     "dateAdded": "2026-01-19",
-    "axiomCount": 8,
+    "axiomCount": 4,
     "lineCount": 185,
     "assumptions": "8 axioms: f_exists, erdos_gyarfas_lower_bound, erdos_gyarfas_upper_bound, and 5 more. See Lean source for complete statements."
   },
@@ -149,7 +149,7 @@
     ],
     "namespace": "Erdos136",
     "lineCount": 185,
-    "axiomCount": 8,
+    "axiomCount": 4,
     "theoremCount": 3,
     "definitionCount": 6
   },

--- a/src/data/proofs/erdos-140/meta.json
+++ b/src/data/proofs/erdos-140/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/140",
     "erdosProblemStatus": "solved",
     "erdosPrizeValue": "$500",
-    "axiomCount": 8,
+    "axiomCount": 1,
     "prerequisites": [
       "arithmetic-progressions",
       "density-arguments",
@@ -184,7 +184,7 @@
     ],
     "namespace": "Erdos140",
     "lineCount": 313,
-    "axiomCount": 8,
+    "axiomCount": 1,
     "theoremCount": 7,
     "definitionCount": 11
   },

--- a/src/data/proofs/erdos-176/meta.json
+++ b/src/data/proofs/erdos-176/meta.json
@@ -55,7 +55,7 @@
       "tao_erdos_discrepancy axiom: Erdős discrepancy conjecture (Tao 2015)",
       "szemeredi_theorem axiom: positive density sets contain arbitrarily long APs"
     ],
-    "axiomCount": 8,
+    "axiomCount": 2,
     "lineCount": 298,
     "references": [
       {
@@ -203,7 +203,7 @@
     ],
     "namespace": "Erdos176",
     "lineCount": 298,
-    "axiomCount": 8,
+    "axiomCount": 2,
     "theoremCount": 6,
     "definitionCount": 12
   },

--- a/src/data/proofs/erdos-227/meta.json
+++ b/src/data/proofs/erdos-227/meta.json
@@ -51,7 +51,7 @@
       "Captured Clunie-Hayman (1964) counterexample: limits fill [0, 1/2]",
       "Proved original conjecture is false using λ = 1/4"
     ],
-    "axiomCount": 8,
+    "axiomCount": 3,
     "lineCount": 220,
     "assumptions": "8 axiom(s) and 2 sorry(s). See the Lean source for details."
   },
@@ -203,7 +203,7 @@
     ],
     "namespace": "Erdos227",
     "lineCount": 220,
-    "axiomCount": 8,
+    "axiomCount": 3,
     "theoremCount": 5,
     "definitionCount": 9
   },

--- a/src/data/proofs/erdos-232/meta.json
+++ b/src/data/proofs/erdos-232/meta.json
@@ -67,7 +67,7 @@
         "relationship": "Chromatic number of the plane problem"
       }
     ],
-    "axiomCount": 8,
+    "axiomCount": 2,
     "lineCount": 346,
     "assumptions": "8 axiom(s) and 0 sorry(s). lebesgue_ball_area proved from Mathlib. upperDensity now uses proper Filter.limsup definition."
   },
@@ -214,7 +214,7 @@
     ],
     "namespace": "Erdos232",
     "lineCount": 346,
-    "axiomCount": 8,
+    "axiomCount": 2,
     "theoremCount": 12,
     "definitionCount": 8
   },

--- a/src/data/proofs/erdos-262/meta.json
+++ b/src/data/proofs/erdos-262/meta.json
@@ -62,7 +62,7 @@
       "erdos_262_summary: combining example and counterexample"
     ],
     "dateAdded": "2026-01-19",
-    "axiomCount": 8,
+    "axiomCount": 2,
     "lineCount": 177,
     "assumptions": "8 axioms: erdos_1975, factorial_not_irrationality, root_growth_necessary, and 5 more. See Lean source for complete statements."
   },
@@ -157,7 +157,7 @@
     ],
     "namespace": "Erdos262",
     "lineCount": 177,
-    "axiomCount": 8,
+    "axiomCount": 2,
     "theoremCount": 1,
     "definitionCount": 8
   },

--- a/src/data/proofs/erdos-270/meta.json
+++ b/src/data/proofs/erdos-270/meta.json
@@ -54,7 +54,7 @@
       "hansen_transcendental axiom: special case f(n)=n",
       "NondecreasingConjecture definition: remaining open problem"
     ],
-    "axiomCount": 8,
+    "axiomCount": 2,
     "lineCount": 254,
     "assumptions": "8 axioms: crmaric_kovac_2025, central_binomial_connection, hansen_1975, and 5 more. See Lean source for complete statements."
   },
@@ -169,7 +169,7 @@
     ],
     "namespace": "Erdos270",
     "lineCount": 254,
-    "axiomCount": 8,
+    "axiomCount": 2,
     "theoremCount": 3,
     "definitionCount": 9
   },

--- a/src/data/proofs/erdos-300/meta.json
+++ b/src/data/proofs/erdos-300/meta.json
@@ -58,7 +58,7 @@
       "erdos_300_summary: complete solution combining key results"
     ],
     "dateAdded": "2026-01-19",
-    "axiomCount": 8,
+    "axiomCount": 4,
     "lineCount": 265,
     "assumptions": "8 axioms: croot_theorem, erdos_graham_conjecture_false, trivial_lower_bound, and 5 more. See Lean source for complete statements."
   },
@@ -167,7 +167,7 @@
     ],
     "namespace": "Erdos300",
     "lineCount": 265,
-    "axiomCount": 8,
+    "axiomCount": 4,
     "theoremCount": 4,
     "definitionCount": 10
   },

--- a/src/data/proofs/erdos-320/meta.json
+++ b/src/data/proofs/erdos-320/meta.json
@@ -61,7 +61,7 @@
       "oeis_A072207: first 8 values with first_collision proved from axiom",
       "erdos_320_summary: key values extracted via tuple projections"
     ],
-    "axiomCount": 8,
+    "axiomCount": 2,
     "lineCount": 232,
     "assumptions": "8 axiom(s) and 0 sorry(s). S_one, S_two, S_three proved from oeis_A072207 axiom. S_pos proved directly. lower_bound_growth and log_S_leading_term now fully proved.",
     "dateUpdated": "2026-03-29"
@@ -209,7 +209,7 @@
     ],
     "namespace": "Erdos320",
     "lineCount": 232,
-    "axiomCount": 8,
+    "axiomCount": 2,
     "theoremCount": 9,
     "definitionCount": 15
   },

--- a/src/data/proofs/erdos-337/meta.json
+++ b/src/data/proofs/erdos-337/meta.json
@@ -68,7 +68,7 @@
       "erdos_337_summary: summary combining all results"
     ],
     "dateAdded": "2026-01-19",
-    "axiomCount": 8,
+    "axiomCount": 3,
     "lineCount": 298,
     "assumptions": "8 axioms: turjanyi_counterexample, ruzsa_turjanyi_generalization, ruzsa_turjanyi_positive, and 5 more. See Lean source for complete statements."
   },
@@ -223,7 +223,7 @@
     ],
     "namespace": "Erdos337",
     "lineCount": 298,
-    "axiomCount": 8,
+    "axiomCount": 3,
     "theoremCount": 4,
     "definitionCount": 11
   },

--- a/src/data/proofs/erdos-353/meta.json
+++ b/src/data/proofs/erdos-353/meta.json
@@ -51,7 +51,7 @@
       "Kovač's parallelogram counterexample axiom",
       "Kovač-Predojević cyclic quadrilateral theorem"
     ],
-    "axiomCount": 8,
+    "axiomCount": 4,
     "lineCount": 362,
     "assumptions": "8 axiom(s) and 1 sorry(s). See the Lean source for details."
   },
@@ -177,7 +177,7 @@
     ],
     "namespace": "Erdos353",
     "lineCount": 362,
-    "axiomCount": 8,
+    "axiomCount": 4,
     "theoremCount": 4,
     "definitionCount": 14
   },

--- a/src/data/proofs/erdos-356/meta.json
+++ b/src/data/proofs/erdos-356/meta.json
@@ -61,7 +61,7 @@
       "upper_bound and lower_bound_exists axioms: Θ(n²) growth",
       "erdos_356_solved: combined main result theorem"
     ],
-    "axiomCount": 8,
+    "axiomCount": 2,
     "lineCount": 241,
     "assumptions": "8 axioms: trivial_fails, trivial_collision_structure, beker_theorem, and 5 more. See Lean source for complete statements."
   },
@@ -182,7 +182,7 @@
     ],
     "namespace": "Erdos356",
     "lineCount": 241,
-    "axiomCount": 8,
+    "axiomCount": 2,
     "theoremCount": 2,
     "definitionCount": 11
   },

--- a/src/data/proofs/erdos-437/meta.json
+++ b/src/data/proofs/erdos-437/meta.json
@@ -63,7 +63,7 @@
       "L_upper_bound axiom: x·exp(-(1/√2+o(1))u(x))",
       "hyperelliptic_connection: link to algebraic curves"
     ],
-    "axiomCount": 8,
+    "axiomCount": 4,
     "lineCount": 284,
     "assumptions": "8 axiom(s) and 3 sorry(s). See the Lean source for details."
   },
@@ -241,7 +241,7 @@
     ],
     "namespace": "Erdos437",
     "lineCount": 284,
-    "axiomCount": 8,
+    "axiomCount": 4,
     "theoremCount": 5,
     "definitionCount": 9
   }

--- a/src/data/proofs/erdos-459/meta.json
+++ b/src/data/proofs/erdos-459/meta.json
@@ -58,7 +58,7 @@
       "irregular_growth theorem: infinitely many minimal and maximal cases",
       "erdos_459_solved theorem: main result"
     ],
-    "axiomCount": 8,
+    "axiomCount": 6,
     "lineCount": 231,
     "assumptions": "12 axioms: f_lower_bound, f_upper_bound, f_prime, and 9 more. See Lean source for complete statements."
   },
@@ -178,7 +178,7 @@
     ],
     "namespace": "Erdos459",
     "lineCount": 231,
-    "axiomCount": 8,
+    "axiomCount": 6,
     "theoremCount": 9,
     "definitionCount": 6
   },

--- a/src/data/proofs/erdos-471/meta.json
+++ b/src/data/proofs/erdos-471/meta.json
@@ -52,7 +52,7 @@
       "QSeq_monotone, QSeq_primes structural properties (fully proved)",
       "erdos_471_summary: combines StrongerQuestion, monotonicity, and primality preservation"
     ],
-    "axiomCount": 8,
+    "axiomCount": 2,
     "lineCount": 274,
     "assumptions": "8 axioms: vinogradov_three_primes, vinogradov_distinct, vinogradov_smaller_primes, and 5 more. See Lean source for complete statements."
   },
@@ -162,7 +162,7 @@
     ],
     "namespace": "Erdos471",
     "lineCount": 274,
-    "axiomCount": 8,
+    "axiomCount": 2,
     "theoremCount": 7,
     "definitionCount": 8
   },

--- a/src/data/proofs/erdos-499/meta.json
+++ b/src/data/proofs/erdos-499/meta.json
@@ -61,7 +61,7 @@
       "IsPermutationMatrix definition",
       "birkhoff_von_neumann axiom: convex hull characterization"
     ],
-    "axiomCount": 8,
+    "axiomCount": 4,
     "lineCount": 284,
     "assumptions": "8 axiom(s). 0 sorries."
   },
@@ -184,7 +184,7 @@
     ],
     "namespace": "Erdos499",
     "lineCount": 284,
-    "axiomCount": 8,
+    "axiomCount": 4,
     "theoremCount": 5,
     "definitionCount": 7
   },

--- a/src/data/proofs/erdos-534/meta.json
+++ b/src/data/proofs/erdos-534/meta.json
@@ -62,7 +62,7 @@
       "prime_power_case and two_times_prime_case special cases",
       "erdos_534_summary combining all main results"
     ],
-    "axiomCount": 8,
+    "axiomCount": 3,
     "lineCount": 133,
     "assumptions": "8 axioms: multiples_of_p_size, multiples_of_p_intersecting, even_multiples_intersecting, and 5 more. See Lean source for complete statements."
   },
@@ -151,7 +151,7 @@
     ],
     "namespace": "Erdos534",
     "lineCount": 133,
-    "axiomCount": 8,
+    "axiomCount": 3,
     "theoremCount": 1,
     "definitionCount": 8
   },

--- a/src/data/proofs/erdos-543/meta.json
+++ b/src/data/proofs/erdos-543/meta.json
@@ -64,7 +64,7 @@
       "erdos_hall_lower: intermediate lower bound on log log log N",
       "erdos_543_summary: combines disproof and negation"
     ],
-    "axiomCount": 8,
+    "axiomCount": 2,
     "lineCount": 173,
     "assumptions": "8 axioms: f, f_le_card, empty_spanning_iff, and 5 more. See Lean source for complete statements."
   },
@@ -178,7 +178,7 @@
     ],
     "namespace": "Erdos543",
     "lineCount": 173,
-    "axiomCount": 8,
+    "axiomCount": 2,
     "theoremCount": 6,
     "definitionCount": 5
   },

--- a/src/data/proofs/erdos-561/meta.json
+++ b/src/data/proofs/erdos-561/meta.json
@@ -58,7 +58,7 @@
       "sizeRamsey_lower_bound theorem: lower bound R̂ ≥ max edges",
       "erdos_561 theorem: main result for uniform star unions"
     ],
-    "axiomCount": 8,
+    "axiomCount": 5,
     "lineCount": 227,
     "assumptions": "8 axioms: hasMonochromaticCopy, sizeRamseyNumber, sizeRamseyNumber_exists, and 5 more. See Lean source for complete statements."
   },
@@ -178,7 +178,7 @@
     ],
     "namespace": "Erdos561",
     "lineCount": 227,
-    "axiomCount": 8,
+    "axiomCount": 5,
     "theoremCount": 3,
     "definitionCount": 16
   },

--- a/src/data/proofs/erdos-581/meta.json
+++ b/src/data/proofs/erdos-581/meta.json
@@ -56,7 +56,7 @@
       "erdos_581 theorem: main result",
       "erdos_581_summary: combined summary"
     ],
-    "axiomCount": 8,
+    "axiomCount": 3,
     "lineCount": 261,
     "assumptions": "8 axioms: maxBipartiteEdges, f, half_edges_bipartite, and 5 more. See Lean source for complete statements."
   },
@@ -169,7 +169,7 @@
     ],
     "namespace": "Erdos581",
     "lineCount": 261,
-    "axiomCount": 8,
+    "axiomCount": 3,
     "theoremCount": 5,
     "definitionCount": 7
   },

--- a/src/data/proofs/erdos-615/meta.json
+++ b/src/data/proofs/erdos-615/meta.json
@@ -58,7 +58,7 @@
       "criticalWindow function: sqrt(log n / log log n)",
       "erdos_615 theorem: main result (conjecture is false)"
     ],
-    "axiomCount": 8,
+    "axiomCount": 2,
     "lineCount": 285,
     "assumptions": "8 axioms: ehss_upper_bound, sudakov_upper_bound, fox_loh_zhao_lower_bound, and 5 more. See Lean source for complete statements."
   },
@@ -179,7 +179,7 @@
     ],
     "namespace": "Erdos615",
     "lineCount": 285,
-    "axiomCount": 8,
+    "axiomCount": 2,
     "theoremCount": 3,
     "definitionCount": 11
   },

--- a/src/data/proofs/erdos-63/meta.json
+++ b/src/data/proofs/erdos-63/meta.json
@@ -20,7 +20,7 @@
     "erdosNumber": 63,
     "erdosUrl": "https://erdosproblems.com/63",
     "erdosProblemStatus": "solved",
-    "axiomCount": 8,
+    "axiomCount": 1,
     "lineCount": 224,
     "prerequisites": [
       "Infinite graph theory",
@@ -145,7 +145,7 @@
     ],
     "namespace": "Erdos63",
     "lineCount": 224,
-    "axiomCount": 8,
+    "axiomCount": 1,
     "theoremCount": 4,
     "definitionCount": 13
   },

--- a/src/data/proofs/erdos-634/meta.json
+++ b/src/data/proofs/erdos-634/meta.json
@@ -53,7 +53,7 @@
     "relatedProblems": [
       "erdos-633"
     ],
-    "axiomCount": 8,
+    "axiomCount": 3,
     "assumptions": "8 axiom declarations: seven_not_dissectable (Beeson: 7 fails), eleven_not_dissectable (Beeson: 11 fails), soifer_theorem (similar dissection complete), two_not_similar_dissectable (2 not similar-dissectable), three_not_similar_dissectable (3 not similar-dissectable), five_not_similar_dissectable (5 not similar-dissectable), sww_theorem (self-similar characterization), zhang_2025 (sufficient condition for large n)",
     "lineCount": 298
   },
@@ -194,7 +194,7 @@
     ],
     "namespace": "Erdos634",
     "lineCount": 298,
-    "axiomCount": 8,
+    "axiomCount": 3,
     "theoremCount": 16,
     "definitionCount": 15
   },

--- a/src/data/proofs/erdos-641/meta.json
+++ b/src/data/proofs/erdos-641/meta.json
@@ -48,7 +48,7 @@
       "Related positive results (odd cycles, Gyárfás theorem)"
     ],
     "relatedProblems": [],
-    "axiomCount": 8,
+    "axiomCount": 1,
     "lineCount": 239,
     "assumptions": "8 axiom(s) and 2 sorry(s). See the Lean source for details."
   },
@@ -171,7 +171,7 @@
     ],
     "namespace": "Erdos641",
     "lineCount": 239,
-    "axiomCount": 8,
+    "axiomCount": 1,
     "theoremCount": 4,
     "definitionCount": 17
   },

--- a/src/data/proofs/erdos-651/meta.json
+++ b/src/data/proofs/erdos-651/meta.json
@@ -56,7 +56,7 @@
       "erdos_651_disproved theorem: full disproof of ErdosConjecture",
       "erdos_651_summary theorem: combining disproof with Pohoata-Zakharov and Suk"
     ],
-    "axiomCount": 8,
+    "axiomCount": 4,
     "lineCount": 211,
     "assumptions": "8 axioms: f_k, f_k_achieves, f_k_minimal, and 5 more. See Lean source for complete statements."
   },
@@ -169,7 +169,7 @@
     ],
     "namespace": "Erdos651",
     "lineCount": 211,
-    "axiomCount": 8,
+    "axiomCount": 4,
     "theoremCount": 4,
     "definitionCount": 5
   },

--- a/src/data/proofs/erdos-658/meta.json
+++ b/src/data/proofs/erdos-658/meta.json
@@ -56,7 +56,7 @@
       "erdos_658 theorem: main result",
       "erdos_658_answer theorem: final answer"
     ],
-    "axiomCount": 8,
+    "axiomCount": 2,
     "lineCount": 299,
     "assumptions": "9 axioms: graham_axis_aligned_true, qualitative_threshold, density_hales_jewett, and 6 more. See Lean source for complete statements."
   },
@@ -168,7 +168,7 @@
     ],
     "namespace": "Erdos658",
     "lineCount": 299,
-    "axiomCount": 8,
+    "axiomCount": 2,
     "theoremCount": 6,
     "definitionCount": 8
   },

--- a/src/data/proofs/erdos-703/meta.json
+++ b/src/data/proofs/erdos-703/meta.json
@@ -44,7 +44,7 @@
       "zero_avoiding_is_intersecting: proved connection to classical intersecting families",
       "erdos_703_solved: combined resolution theorem"
     ],
-    "axiomCount": 8,
+    "axiomCount": 2,
     "lineCount": 259,
     "assumptions": "8 axiom(s) and 1 sorry(s).",
     "mathlib_version": "4.26.0"
@@ -177,7 +177,7 @@
     ],
     "namespace": "Erdos703",
     "lineCount": 259,
-    "axiomCount": 8,
+    "axiomCount": 2,
     "theoremCount": 5,
     "definitionCount": 7
   }

--- a/src/data/proofs/erdos-708/meta.json
+++ b/src/data/proofs/erdos-708/meta.json
@@ -55,7 +55,7 @@
       "StrongerConjecture: possibly g(n) ≤ 2n",
       "Related variant: interval length c_n"
     ],
-    "axiomCount": 8,
+    "axiomCount": 5,
     "lineCount": 184,
     "assumptions": "8 axioms: g_exists, g_two, g_three, and 5 more. See Lean source for complete statements."
   },
@@ -168,7 +168,7 @@
     ],
     "namespace": "Erdos708",
     "lineCount": 184,
-    "axiomCount": 8,
+    "axiomCount": 5,
     "theoremCount": 3,
     "definitionCount": 7
   },

--- a/src/data/proofs/erdos-718/meta.json
+++ b/src/data/proofs/erdos-718/meta.json
@@ -55,7 +55,7 @@
       "dense_graphs_linked axiom: dense graphs are highly linked",
       "erdos_718_solved theorem: main result"
     ],
-    "axiomCount": 8,
+    "axiomCount": 2,
     "lineCount": 177,
     "assumptions": "8 axioms: dirac_1960, mader_1967, komlos_szemeredi_1996, and 5 more. See Lean source for complete statements."
   },
@@ -179,7 +179,7 @@
     "opens": [],
     "namespace": "Erdos718",
     "lineCount": 177,
-    "axiomCount": 8,
+    "axiomCount": 2,
     "theoremCount": 4,
     "definitionCount": 5
   },

--- a/src/data/proofs/erdos-73/meta.json
+++ b/src/data/proofs/erdos-73/meta.json
@@ -72,7 +72,7 @@
         "description": "Ramsey-type problems in graph theory — similar flavor of local-to-global structural results"
       }
     ],
-    "axiomCount": 8,
+    "axiomCount": 3,
     "lineCount": 226,
     "assumptions": "8 axiom(s) and 5 sorry(s). See the Lean source for details."
   },
@@ -201,7 +201,7 @@
     ],
     "namespace": "Erdos73",
     "lineCount": 226,
-    "axiomCount": 8,
+    "axiomCount": 3,
     "theoremCount": 9,
     "definitionCount": 10
   },

--- a/src/data/proofs/erdos-747/meta.json
+++ b/src/data/proofs/erdos-747/meta.json
@@ -67,7 +67,7 @@
       "kahn_general_r axiom: same threshold for all r",
       "erdos_747 theorem: main result"
     ],
-    "axiomCount": 8,
+    "axiomCount": 5,
     "lineCount": 313,
     "assumptions": "8 axioms: johansson_kahn_vu, kahn_precise_threshold, kahn_general_r, and 5 more. See Lean source for complete statements."
   },
@@ -196,7 +196,7 @@
     ],
     "namespace": "Erdos747",
     "lineCount": 313,
-    "axiomCount": 8,
+    "axiomCount": 5,
     "theoremCount": 2,
     "definitionCount": 10
   },

--- a/src/data/proofs/erdos-762/meta.json
+++ b/src/data/proofs/erdos-762/meta.json
@@ -46,7 +46,7 @@
       "egs_general_theorem: general bounded gap result",
       "proper_implies_cochromatic: proper colorings are cochromatic"
     ],
-    "axiomCount": 8,
+    "axiomCount": 5,
     "prerequisites": [
       "Graph theory fundamentals (vertices, edges, adjacency)",
       "Graph coloring and chromatic number",
@@ -185,7 +185,7 @@
     ],
     "namespace": "Erdos762",
     "lineCount": 240,
-    "axiomCount": 8,
+    "axiomCount": 5,
     "theoremCount": 4,
     "definitionCount": 4
   }

--- a/src/data/proofs/erdos-792/meta.json
+++ b/src/data/proofs/erdos-792/meta.json
@@ -61,7 +61,7 @@
       "erdos_792_bounds: summary combining bounds",
       "erdos_792_lower_bound_chain: chain of lower bounds"
     ],
-    "axiomCount": 8,
+    "axiomCount": 4,
     "lineCount": 117,
     "assumptions": "10 axioms: f (function), f_spec/f_tight (defining properties), erdos_lower_bound/alon_kleitman_bound/bourgain_bound/bedert_bound (lower bounds), egm_upper_bound/f_asymptotic (upper bounds), middle_third_construction (construction). Formerly 11 — interval_sum_free proved by omega.",
     "dateUpdated": "2026-03-27"
@@ -178,7 +178,7 @@
     ],
     "namespace": "Erdos792",
     "lineCount": 117,
-    "axiomCount": 8,
+    "axiomCount": 4,
     "theoremCount": 3,
     "definitionCount": 4
   },

--- a/src/data/proofs/erdos-797/meta.json
+++ b/src/data/proofs/erdos-797/meta.json
@@ -59,7 +59,7 @@
       "erdos_797_subquadratic: f(d) = o(d²) answering the original question",
       "erdos_797_summary proved theorem combining AMR upper and precise lower"
     ],
-    "axiomCount": 8,
+    "axiomCount": 3,
     "lineCount": 155,
     "assumptions": "8 axioms: f, f_realized, greedy_upper_bound, and 5 more. See Lean source for complete statements."
   },
@@ -156,7 +156,7 @@
     ],
     "namespace": "Erdos797",
     "lineCount": 155,
-    "axiomCount": 8,
+    "axiomCount": 3,
     "theoremCount": 1,
     "definitionCount": 6
   },

--- a/src/data/proofs/erdos-799/meta.json
+++ b/src/data/proofs/erdos-799/meta.json
@@ -57,7 +57,7 @@
       "alon_krivelevich_sudakov_1999 axiom: χ_L(G) ≍ n / log n",
       "erdos_799 theorem: the main solved result"
     ],
-    "axiomCount": 8,
+    "axiomCount": 2,
     "lineCount": 178,
     "assumptions": "8 axioms: list_chromatic_ge_chromatic, list_chromatic_gap_unbounded, listChromaticRandom, and 5 more. See Lean source for complete statements."
   },
@@ -170,7 +170,7 @@
     ],
     "namespace": "Erdos799",
     "lineCount": 178,
-    "axiomCount": 8,
+    "axiomCount": 2,
     "theoremCount": 1,
     "definitionCount": 4
   },

--- a/src/data/proofs/erdos-80/meta.json
+++ b/src/data/proofs/erdos-80/meta.json
@@ -69,7 +69,7 @@
       "erdos_log_conjecture definition: open weaker conjecture",
       "erdos_80_summary theorem: comprehensive summary with proof"
     ],
-    "axiomCount": 8,
+    "axiomCount": 3,
     "lineCount": 230,
     "assumptions": "8 axioms: alon_trotter_bound, fox_loh_bound, erdos_polynomial_conjecture_false, and 5 more. See Lean source for complete statements."
   },
@@ -167,7 +167,7 @@
     ],
     "namespace": "Erdos80",
     "lineCount": 230,
-    "axiomCount": 8,
+    "axiomCount": 3,
     "theoremCount": 1,
     "definitionCount": 10
   },

--- a/src/data/proofs/erdos-81/meta.json
+++ b/src/data/proofs/erdos-81/meta.json
@@ -50,7 +50,7 @@
         "relationship": "Related clique partition problem"
       }
     ],
-    "axiomCount": 8,
+    "axiomCount": 4,
     "lineCount": 290,
     "assumptions": "8 axioms: split_is_chordal, extremal_construction_exists, erdos_ordman_zalcstein, and 5 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
@@ -172,7 +172,7 @@
     ],
     "namespace": "Erdos81",
     "lineCount": 290,
-    "axiomCount": 8,
+    "axiomCount": 4,
     "theoremCount": 4,
     "definitionCount": 9
   },

--- a/src/data/proofs/erdos-876/meta.json
+++ b/src/data/proofs/erdos-876/meta.json
@@ -47,7 +47,7 @@
       "reciprocalSum definition and sullivan_bound axiom",
       "powers_of_two_sumfree theorem sketch"
     ],
-    "axiomCount": 8,
+    "axiomCount": 1,
     "lineCount": 263,
     "assumptions": "8 axiom(s) and 2 sorry(s). See the Lean source for details."
   },
@@ -166,7 +166,7 @@
     ],
     "namespace": "Erdos876",
     "lineCount": 263,
-    "axiomCount": 8,
+    "axiomCount": 1,
     "theoremCount": 3,
     "definitionCount": 9
   },

--- a/src/data/proofs/erdos-883/meta.json
+++ b/src/data/proofs/erdos-883/meta.json
@@ -51,7 +51,7 @@
       "erdos_883_question_2_solved theorem: Q2 answer is YES",
       "erdos_883_partial theorem: partial answer to Q1"
     ],
-    "axiomCount": 8,
+    "axiomCount": 2,
     "prerequisites": [
       "Graph theory: simple graphs, adjacency, subgraph structure",
       "Number theory: coprimality (gcd), divisibility, primes",
@@ -194,7 +194,7 @@
     ],
     "namespace": "Erdos883",
     "lineCount": 216,
-    "axiomCount": 8,
+    "axiomCount": 2,
     "theoremCount": 4,
     "definitionCount": 6
   }

--- a/src/data/proofs/erdos-911/meta.json
+++ b/src/data/proofs/erdos-911/meta.json
@@ -51,7 +51,7 @@
       "graphRamseyNumber axiom: vertex Ramsey number",
       "erdos_911_statement theorem: equivalence"
     ],
-    "axiomCount": 8,
+    "axiomCount": 3,
     "lineCount": 238,
     "assumptions": "8 axiom(s) and 0 sorry(s). Axioms: sizeRamseyNumber, sizeRamseyNumber_spec, sizeRamseyNumber_minimal, beck_path_size_ramsey, bounded_degree_linear_size_ramsey, complete_graph_size_ramsey, vertex_ramsey_number, size_ramsey_upper_bound."
   },
@@ -187,7 +187,7 @@
     ],
     "namespace": "Erdos911",
     "lineCount": 238,
-    "axiomCount": 8,
+    "axiomCount": 3,
     "theoremCount": 10,
     "definitionCount": 7
   }

--- a/src/data/proofs/erdos-953/meta.json
+++ b/src/data/proofs/erdos-953/meta.json
@@ -59,7 +59,7 @@
       "circle_separation lemma: radii differing by 1",
       "singleton_avoids and pair_half_avoids verified examples"
     ],
-    "axiomCount": 8,
+    "axiomCount": 2,
     "lineCount": 291,
     "assumptions": "8 axioms: trivial_upper_bound, circle_separation, kovac_lower_bound, thin_annulus_property, erdos_465_upper, erdos_466_lower, erdos_953_asymptotic, erdos_953."
   },
@@ -201,7 +201,7 @@
     ],
     "namespace": "Erdos953",
     "lineCount": 291,
-    "axiomCount": 8,
+    "axiomCount": 2,
     "theoremCount": 13,
     "definitionCount": 5
   }

--- a/src/data/proofs/erdos-962/meta.json
+++ b/src/data/proofs/erdos-962/meta.json
@@ -57,7 +57,7 @@
       "IsSmooth definition: smooth numbers",
       "erdos_962_summary: combining Tang and Tao bounds"
     ],
-    "axiomCount": 8,
+    "axiomCount": 2,
     "lineCount": 192,
     "assumptions": "8 axioms: k_bounded, k_monotone, k_pos, and 5 more. See Lean source for complete statements."
   },
@@ -171,7 +171,7 @@
     ],
     "namespace": "Erdos962",
     "lineCount": 192,
-    "axiomCount": 8,
+    "axiomCount": 2,
     "theoremCount": 2,
     "definitionCount": 7
   },

--- a/src/data/proofs/erdos-973/meta.json
+++ b/src/data/proofs/erdos-973/meta.json
@@ -58,7 +58,7 @@
       "erdos_973_unit_disk, erdos_973_turan_constrained (proved): derived results",
       "erdos_973 (proved): summary combining all three regimes"
     ],
-    "axiomCount": 8,
+    "axiomCount": 4,
     "lineCount": 188,
     "assumptions": "8 axioms: maxPowerSum, maxPowerSum_spec, erdos_unit_disk_construction, and 5 more. See Lean source for complete statements."
   },
@@ -178,7 +178,7 @@
     ],
     "namespace": "Erdos973",
     "lineCount": 188,
-    "axiomCount": 8,
+    "axiomCount": 4,
     "theoremCount": 4,
     "definitionCount": 13
   },

--- a/src/data/proofs/erdos-983/meta.json
+++ b/src/data/proofs/erdos-983/meta.json
@@ -67,7 +67,7 @@
       "smoothCount definition: Ψ(x, y) counting function",
       "erdos_983 theorem: combining negative answer with sublinearity"
     ],
-    "axiomCount": 8,
+    "axiomCount": 2,
     "lineCount": 206,
     "assumptions": "8 axioms: f_upper_bound, f_mono_k, erdos_question_answer, and 5 more. See Lean source for complete statements."
   },
@@ -167,7 +167,7 @@
     ],
     "namespace": "Erdos983",
     "lineCount": 206,
-    "axiomCount": 8,
+    "axiomCount": 2,
     "theoremCount": 1,
     "definitionCount": 9
   },

--- a/src/data/proofs/erdos-999/meta.json
+++ b/src/data/proofs/erdos-999/meta.json
@@ -57,7 +57,7 @@
       "LimsupSet: the set of infinitely approximable reals",
       "erdos_999_summary: proved conjunction of main results"
     ],
-    "axiomCount": 8,
+    "axiomCount": 2,
     "lineCount": 147,
     "assumptions": "8 axioms: easy_direction, hard_direction, erdos_bounded_case, and 5 more. See Lean source for complete statements."
   },
@@ -176,7 +176,7 @@
     ],
     "namespace": "Erdos999",
     "lineCount": 147,
-    "axiomCount": 8,
+    "axiomCount": 2,
     "theoremCount": 2,
     "definitionCount": 12
   },


### PR DESCRIPTION
## Fix

50 gallery entries had `axiomCount: 8` in their meta.json files, but their
Lean source files contain only 1-6 explicit `axiom` declarations. This was
caused by a batch process that incorrectly set the count to 8.

## Evidence

All 50 affected files have only Mathlib imports (plus one with `GraphCore.lean`
which has 0 axioms), so the correct axiomCount is simply the number of
`axiom` declarations in the file itself.

**Distribution of corrections:**
| Old | New | Count |
|-----|-----|-------|
| 8 | 1 | 4 entries |
| 8 | 2 | 21 entries |
| 8 | 3 | 9 entries |
| 8 | 4 | 11 entries |
| 8 | 5 | 4 entries |
| 8 | 6 | 1 entry |

**Left unchanged:** 11 entries that genuinely have 8 axiom declarations.

## Verification

- Spot-checked each file's `axiom` declarations against new count
- `pnpm build` passes without errors
- Badges and status values are unchanged (axiom/axiomatized already correct)

---
Automated fix by lean-mechanic agent.