### PR TITLE
fix: remove True-stub theorems from 3 gallery proofs

### DIFF
--- a/proofs/Proofs/Erdos29OQ02.lean
+++ b/proofs/Proofs/Erdos29OQ02.lean
@@ -114,13 +114,14 @@ theorem basis_size_lower_bound_correct (A : Set ℕ) (hA : IsAdditiveBasis A) (N
 -- Part IV: Consistency with Counterexample
 -- ============================================================
 
-/-- The counterexample A = {0,1} ∪ {n ≥ 3} satisfies the CORRECT bound.
-    At N=2: |A ∩ [0,2]| = |{0,1}| = 2, and √3 ≈ 1.73, so 2 ≥ √3. ✓
-    (The FALSE bound used [1,2] giving |{1}| = 1 < √2.) -/
-theorem counterexample_satisfies_correct_bound :
-    -- The corrected bound is consistent with the counterexample
-    -- because including 0 in the interval adds one more element
-    True := trivial
+/-
+  The counterexample A = {0,1} ∪ {n ≥ 3} satisfies the CORRECT bound.
+  At N=2: |A ∩ [0,2]| = |{0,1}| = 2, and √3 ≈ 1.73, so 2 ≥ √3. ✓
+  (The FALSE bound used [1,2] giving |{1}| = 1 < √2.)
+
+  The corrected bound is consistent with the counterexample because including
+  0 in the interval adds one more element to the count.
+-/
 
 -- ============================================================
 -- Part V: Optimality and Tightness
@@ -144,13 +145,13 @@ theorem small_basis_exists (N : ℕ) (hN : 0 < N) :
       by omega⟩
   · simp
 
-/-- **Why the original was wrong**: The interval [1,N] excludes 0, which can be
-    a critical element of the basis. The counterexample A = {0,1} ∪ {n ≥ 3}
-    has 0 ∈ A, so representations like 0 + n = n are available.
-    By excluding 0 from the count, the original bound was too strong. -/
-theorem why_original_was_wrong :
-    -- The fix: include 0 in the counting interval
-    -- [0,N] instead of [1,N]
-    True := trivial
+/-
+  Why the original was wrong: The interval [1,N] excludes 0, which can be
+  a critical element of the basis. The counterexample A = {0,1} ∪ {n ≥ 3}
+  has 0 ∈ A, so representations like 0 + n = n are available.
+  By excluding 0 from the count, the original bound was too strong.
+
+  The fix: include 0 in the counting interval — use [0,N] instead of [1,N].
+-/
 
 end Erdos29OQ02

--- a/proofs/Proofs/IntermediateValueTheoremOQ03.lean
+++ b/proofs/Proofs/IntermediateValueTheoremOQ03.lean
@@ -51,16 +51,16 @@ theorem brouwer_1d (f : ℝ → ℝ) (hf : Continuous f)
 -- Part II: IVT from 1D Brouwer
 -- ============================================================
 
-/-- Conversely, IVT follows from the 1D Brouwer theorem.
+/-
+  Conversely, IVT follows from the 1D Brouwer theorem.
 
-    Given continuous f : [a,b] → ℝ with f(a) < 0 < f(b),
-    define g : [0,1] → [0,1] by g(t) = clamp(t - f(a + t(b-a))/M)
-    where M is chosen appropriately. Then a fixed point of g
-    gives a zero of f. -/
-theorem ivt_from_brouwer_sketch :
-    -- IVT and 1D Brouwer are equivalent
-    -- (Formal proof would require the clamping construction)
-    True := trivial
+  Given continuous f : [a,b] → ℝ with f(a) < 0 < f(b),
+  define g : [0,1] → [0,1] by g(t) = clamp(t - f(a + t(b-a))/M)
+  where M is chosen appropriately. Then a fixed point of g gives a zero of f.
+
+  IVT and 1D Brouwer are equivalent.
+  (A formal proof would require formalizing the clamping construction.)
+-/
 
 -- ============================================================
 -- Part III: The Dimensional Jump
@@ -117,14 +117,15 @@ theorem ivt_fails_2d :
   See also: schauder-fixed-point-oq-03 (Kakutani framework)
 -/
 
-/-- The key insight: IVT is about sign changes (1D phenomenon),
-    while Brouwer is about topological degree (nD phenomenon).
-    They coincide in 1D because sign change = degree 1 map. -/
-theorem dimensional_summary :
-    -- In 1D: IVT and Brouwer are the same theorem
-    -- In nD: Brouwer is strictly stronger
-    -- In ∞D: compactness is additionally needed
-    True := trivial
+/-
+  Dimensional summary: IVT is about sign changes (1D phenomenon),
+  while Brouwer is about topological degree (nD phenomenon).
+  They coincide in 1D because sign change = degree 1 map.
+
+  - In 1D: IVT and Brouwer are the same theorem
+  - In nD: Brouwer is strictly stronger
+  - In ∞D: compactness is additionally needed
+-/
 
 /-
   Summary

--- a/proofs/Proofs/LawOfCosinesOQ04.lean
+++ b/proofs/Proofs/LawOfCosinesOQ04.lean
@@ -118,16 +118,11 @@ theorem median_length_formula (a b c d : ℝ) (ha : a ≠ 0) (t : ℝ)
 -- Part IV: Special Case: Angle Bisector Length
 -- ============================================================
 
-/-- For an angle bisector, m/n = c/b (by the angle bisector theorem).
-    When m = ca/(b+c) and n = ba/(b+c), Stewart gives the angle
-    bisector length formula. -/
-theorem angle_bisector_stewarts (a b c d : ℝ)
-    (hb : 0 < b) (hc : 0 < c) (t : ℝ)
-    (hm : ∀ m, m = c * a / (b + c) → True)
-    (hn : ∀ n, n = b * a / (b + c) → True) :
-    -- The angle bisector length satisfies:
-    -- d² = bc((b+c)² - a²) / (b+c)²
-    True := trivial
+/-
+  For an angle bisector, m/n = c/b (by the angle bisector theorem).
+  When m = ca/(b+c) and n = ba/(b+c), Stewart's theorem gives the angle
+  bisector length formula: d² = bc((b+c)² - a²) / (b+c)²
+-/
 
 -- ============================================================
 -- Part V: Numerical Verification

--- a/src/data/proofs/erdos-29-oq-02/meta.json
+++ b/src/data/proofs/erdos-29-oq-02/meta.json
@@ -22,10 +22,10 @@
       "Explanation of why [1,N] was wrong (excludes 0 as a basis element)",
       "Real-valued form: |A ∩ [0,N]| ≥ √(N+1)"
     ],
-    "assumptions": "0 sorries, 0 axioms. 2 True-stub theorems (counterexample_satisfies_correct_bound, why_original_was_wrong) prove True instead of their stated claims. Core counting argument and sqrt bound are fully verified.",
+    "assumptions": "0 sorries, 0 axioms. All core results fully verified.",
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 156,
+    "lineCount": 157,
     "prerequisites": ["Additive bases", "Sumsets", "Finset cardinality"],
     "mathlib_version": "4.26.0"
   },
@@ -57,9 +57,9 @@
   "leanFile": {
     "imports": ["Mathlib"],
     "namespace": "Erdos29OQ02",
-    "lineCount": 156,
+    "lineCount": 157,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 7,
     "definitionCount": 4,
     "mainTheorems": [
       {"name": "basis_size_squared_lower_bound", "type": "proved", "description": "N+1 ≤ |A ∩ [0,N]|²"},

--- a/src/data/proofs/intermediate-value-theorem-oq-03/meta.json
+++ b/src/data/proofs/intermediate-value-theorem-oq-03/meta.json
@@ -18,7 +18,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 142,
+    "lineCount": 143,
     "assumptions": "1 axiom (brouwer_2d). 0 sorries.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
@@ -65,9 +65,9 @@
       "Mathlib"
     ],
     "namespace": "IVTBrouwer",
-    "lineCount": 142,
+    "lineCount": 143,
     "axiomCount": 1,
-    "theoremCount": 4,
+    "theoremCount": 2,
     "definitionCount": 0
   }
 }

--- a/src/data/proofs/law-of-cosines-oq-04/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-04/meta.json
@@ -18,7 +18,7 @@
     "badge": "formalized",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 160,
+    "lineCount": 155,
     "assumptions": "No axioms or sorries. All results proved from law of cosines.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
@@ -74,9 +74,9 @@
       "Mathlib"
     ],
     "namespace": "StewartsTheorem",
-    "lineCount": 160,
+    "lineCount": 155,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 5,
     "definitionCount": 3
   }
 }


### PR DESCRIPTION
## Fix

Removes 5 placeholder `theorem foo : True := trivial` statements across 3 files.
These theorems proved nothing (just `True`) while appearing to be genuine mathematical
results, inflating apparent proof content.

## Addresses

- Closes #8636 — erdos-29-oq-02: 2 True-stub theorems hiding behind sorries=0
- Closes #8637 — intermediate-value-theorem-oq-03: 2 undisclosed True-stub theorems
- Closes #8640 — law-of-cosines-oq-04: 1 undisclosed True-stub theorem

## Evidence

**Before**: `theorem counterexample_satisfies_correct_bound : True := trivial`

**After**: Converted to `/-  ... explanatory content ... -/` block comment

All 5 theorems contained only explanatory narrative content (no mathematical claims
worth formalizing). The explanatory text is preserved as block comments.

## Verification

- `pnpm build` passes
- No mathematical content removed — only placeholder theorems converted to comments

---
Automated fix by lean-mechanic agent.