### PR TITLE
fix: correct sorry/axiom counts in 5 gallery entries (audit findings)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "area-of-circle-oq-01-oq-03",
   "title": "Isoperimetric Inequality: C² ≥ 4πA",
   "slug": "area-of-circle-oq-01-oq-03",
-  "description": "For any regular closed curve with circumference C enclosing area A, the isoperimetric inequality C² ≥ 4πA holds, with equality iff the curve is a circle. Proves 60+ theorems/lemmas (6 well-scoped sorries, 0 axioms) including arc-length reparametrization infrastructure, Wirtinger's inequality (proved from Fourier decomposition), Parseval's identity, the general isoperimetric inequality (for regular curves), equality characterization, and concrete verification for circles, squares, regular n-gons, and equilateral triangles.",
+  "description": "For any regular closed curve with circumference C enclosing area A, the isoperimetric inequality C² ≥ 4πA holds, with equality iff the curve is a circle. Proves 60+ theorems/lemmas (0 sorries, 0 axioms) including arc-length reparametrization infrastructure, Wirtinger's inequality (proved from Fourier decomposition), Parseval's identity, the general isoperimetric inequality (for regular curves), equality characterization, and concrete verification for circles, squares, regular n-gons, and equilateral triangles.",
   "meta": {
     "author": "Hurwitz (1901), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Isoperimetric_inequality",
@@ -19,8 +19,8 @@
       "research",
       "isoperimetric"
     ],
-    "badge": "wip",
-    "sorries": 6,
+    "badge": "formalized",
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Real.pi_lt_four",

--- a/src/data/proofs/erdos-1001-oq-02/meta.json
+++ b/src/data/proofs/erdos-1001-oq-02/meta.json
@@ -20,9 +20,9 @@
       "open-question"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 0,
     "axiomCount": 3,
-    "assumptions": "3 axioms: rangeTotientSum_asymptotic (qualitative convergence of weighted totient sum), rangeTotientSum_error (O(log N/N) error bound), convergence_rate_est (main rate: |S(N,A,c)-f(A,c)| = O(A log N/N)). All reduce to Mertens' theorem with quantitative error bounds, missing from Mathlib.",
+    "assumptions": "3 axioms: rangeTotientSum_asymptotic (qualitative convergence of weighted totient sum), rangeTotientSum_error (O(log N/N) error bound), convergence_rate_est (main rate: |S(N,A,c)-f(A,c)| = O(A log N/N)). All reduce to Mertens' theorem with quantitative error bounds, missing from Mathlib. 0 sorries.",
     "erdosNumber": 1001,
     "erdosUrl": "https://erdosproblems.com/1001",
     "mathlibDependencies": [

--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -13,10 +13,10 @@
       "tournaments"
     ],
     "badge": "formalized",
-    "sorries": 4,
+    "sorries": 3,
     "axiomCount": 0,
     "lineCount": 547,
-    "assumptions": "0 axioms. 4 sorries (Ghouila-Houri, cycle existence, cycle extension, directed threshold). Moon-Moser proved structurally via longest-cycle extension (modulo 2 infrastructure lemmas). Rédei fully proved. Tournament insertion and dichotomy lemmas proved.",
+    "assumptions": "0 axioms. 3 sorries (Ghouila-Houri, cycle existence, cycle extension). Moon-Moser proved structurally via longest-cycle extension (modulo 2 infrastructure lemmas). Rédei fully proved. Tournament insertion and dichotomy lemmas proved.",
     "dateAdded": "2026-03-30"
   },
   "overview": {

--- a/src/data/proofs/erdos-746/meta.json
+++ b/src/data/proofs/erdos-746/meta.json
@@ -19,7 +19,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 1,
     "erdosNumber": 746,
     "erdosUrl": "https://erdosproblems.com/746",
     "erdosProblemStatus": "solved",
@@ -82,7 +82,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 252,
-    "assumptions": "1 axiom (komlos_szemeredi_theorem), 3 sorries. Probabilistic statements use opaque AlmostSurely/ProbInGnm predicates since full formalization requires a measure space on graphs."
+    "assumptions": "1 axiom (komlos_szemeredi_theorem), 1 sorry. Probabilistic statements use opaque AlmostSurely/ProbInGnm predicates since full formalization requires a measure space on graphs."
   },
   "overview": {
     "historicalContext": "**The Erdős-Rényi Random Graph Revolution**\n\nErdős and Rényi's 1959–1966 papers on random graphs $G(n, m)$ revolutionized combinatorics by introducing probabilistic methods to study graph properties. They discovered that many graph properties exhibit **sharp thresholds**: the property jumps from almost surely absent to almost surely present as $m$ crosses a critical value.\n\n**The Matching-Hamiltonicity Connection**\n\nIn 1966, Erdős and Rényi proved that $G(n, m)$ with $m \\ge (1/2 + \\varepsilon) n \\log n$ almost surely has a perfect matching. Since a Hamiltonian cycle decomposes into two perfect matchings, they conjectured the same threshold for Hamiltonicity — one of the most natural questions in random graph theory.\n\n**The Path to Resolution**\n\nPósa (1976) proved Hamiltonicity for $Cn \\log n$ edges using his **rotation-extension technique**, a landmark method that became central to probabilistic combinatorics. Korshunov (1977) established the sharp threshold as $(1/2) n \\log n + (1/2) n \\log \\log n + o(n)$, confirming Erdős-Rényi's conjecture. Finally, Komlós and Szemerédi (1983) determined the precise limiting distribution: with $m = (1/2) n \\log n + (1/2) n \\log \\log n + cn$ edges, $\\Pr[\\text{Hamiltonian}] \\to e^{-e^{-2c}}$ — a **Gumbel (double exponential)** distribution.\n\n**The Threshold Coincidence**\n\nRemarkably, the Hamiltonicity threshold coincides with the connectivity threshold. Both are controlled by the same bottleneck: vertices of degree 0 or 1. The factor 2 in the Gumbel exponent $e^{-2c}$ reflects the two failure modes (degree 0 and degree 1) at the critical edge count.",

--- a/src/data/proofs/fourier-series-oq-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-01/meta.json
@@ -20,7 +20,7 @@
       "open-question"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "dateAdded": "2026-03-28",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -70,9 +70,9 @@
       "fourierPartialSum_smul: scalar linearity of partial sums",
       "fourierPartialSum_zero_fn: partial sums of zero"
     ],
-    "axiomCount": 2,
+    "axiomCount": 6,
     "lineCount": 427,
-    "assumptions": "2 axioms: carlesonConstant (existence of universal Carleson constant C > 0), carleson_hunt_maximal (the Carleson-Hunt maximal inequality ‖S*f‖ ≤ C·‖f‖). 2 sorries: divergenceSet_measure_bound, carleson_ae_convergence (combining all pieces). 2 previously sorry'd theorems proved in #8596."
+    "assumptions": "6 axioms: carlesonConstant (existence of universal Carleson constant C > 0), carleson_hunt_maximal (the Carleson-Hunt maximal inequality ‖S*f‖ ≤ C·‖f‖), trigPoly_exact_convergence (trig polys converge exactly), IsTrigPoly.memℒp_two (trig polys are in L²), trigPoly_L2_approx (trig poly L² approximation), carlesonConstant_nonneg (C ≥ 0). 0 sorries (divergenceSet_measure_bound and carleson_ae_convergence proved in #8596, additional framework proved in #8611)."
   },
   "overview": {
     "historicalContext": "**Carleson's Theorem (1966)**\n\nOne of the great achievements of 20th-century harmonic analysis. The question of whether Fourier series converge pointwise goes back to Fourier himself (1807) and was a central problem for over 150 years.\n\n**Timeline:**\n- **1807**: Fourier conjectured that every periodic function equals its Fourier series\n- **1829**: Dirichlet proved convergence for piecewise smooth functions\n- **1876**: du Bois-Reymond gave a continuous function whose Fourier series diverges at a point\n- **1923**: Kolmogorov constructed an L¹ function whose Fourier series diverges everywhere\n- **1926**: Kolmogorov asked: does Carleson's theorem hold for L²?\n- **1966**: **Carleson proved it**: L² Fourier series converge pointwise a.e.\n- **1968**: Hunt extended to Lp for all p > 1\n\nCarleson's proof introduced time-frequency analysis techniques that became foundational in modern harmonic analysis. The formal verification project (Carleson4) is ongoing work by Floris van Doorn et al.",


### PR DESCRIPTION
## Summary

Gallery integrity audit found 5 entries with metadata that lagged behind Lean file changes (sorries/axioms resolved in other PRs but meta.json not updated).

- **area-of-circle-oq-01-oq-03**: `sorries: 6 → 0`, badge `wip → formalized` (all 6 sorries were resolved)
- **fourier-series-oq-01**: `sorries: 2 → 0`, `axiomCount: 2 → 6` (#8596/#8611 resolved sorries and added 4 new axioms replacing them)
- **erdos-746**: `sorries: 3 → 1`, update assumptions text (2 sorries resolved)
- **erdos-1012-oq-03**: `sorries: 4 → 3`, update assumptions text (1 sorry resolved)
- **erdos-1001-oq-02**: `sorries: 3 → 0`, update assumptions text (all 3 sorries resolved)

All changes verified by running `find-targets.ts` which detected the mismatches, and manually inspecting the Lean files using the same comment-stripping logic as the auditor script.

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --issues` should show 0 issues after merge
- [x] All 5 `sorries` fields now match actual Lean file content
- [x] `fourier-series-oq-01` axiomCount updated to reflect 6 actual axiom declarations

🤖 Generated with [Claude Code](https://claude.com/claude-code)