### PR TITLE
enrichment: geometric-series-oq-02-oq-05 resolvent and Neumann series

### DIFF
--- a/src/data/proofs/geometric-series-oq-02-oq-05/annotations.json
+++ b/src/data/proofs/geometric-series-oq-02-oq-05/annotations.json
@@ -1,1 +1,56 @@
-[]
+[
+  {
+    "lineStart": 35,
+    "lineEnd": 37,
+    "annotation": "The type signature encodes the full generality: 𝕜 is a NontriviallyNormedField (e.g., ℝ or ℂ), A is a complete NormedAlgebra over 𝕜 satisfying NormOneClass (‖1‖ = 1). CompleteSpace A is essential — without it the Neumann series ∑ Tⁿ may not converge. NormOneClass ensures the scalar embedding is isometric, which is used crucially in norm_algebraMap.",
+    "mathContext": "NormedAlgebra 𝕜 A means A is simultaneously a NormedRing and a normed 𝕜-module with ‖c • x‖ ≤ ‖c‖ · ‖x‖. NormOneClass adds ‖(1 : A)‖ = 1. Together these imply ‖algebraMap 𝕜 A c‖ = ‖c‖, making the scalar embedding isometric (proved as norm_algebraMap in § 1).",
+    "significance": "This variable declaration encodes the correct mathematical context for spectral theory: Banach algebras over ℝ or ℂ with multiplicative identity of norm 1. The hypotheses are minimal — removing any one makes the theorems false.",
+    "relatedConcepts": ["NormedAlgebra", "CompleteSpace", "NormOneClass", "Banach algebra", "spectral theory"],
+    "prerequisites": ["Normed vector spaces and normed rings", "Algebra over a field", "Completeness and Cauchy sequences"]
+  },
+  {
+    "lineStart": 42,
+    "lineEnd": 50,
+    "annotation": "Two foundational lemmas about the scalar embedding. norm_algebraMap proves ‖algebraMap 𝕜 A λ‖ = ‖λ‖ using algebraMap_eq_smul_one (c ↦ c • 1) and norm_smul combined with ‖1‖ = 1 from NormOneClass. algebraMap_isUnit propagates IsUnit from 𝕜 to A using RingHom.isUnit_map — nonzero scalars are units in A.",
+    "mathContext": "Crucially, algebraMap here is the canonical ring homomorphism 𝕜 → A sending c ↦ c · 1_A. It is not merely additive — it respects multiplication, so it maps units to units. The isometric property (norm-preserving) is stronger than the general NormedAlgebra bound ‖c • x‖ ≤ ‖c‖‖x‖, and requires NormOneClass for equality.",
+    "significance": "These two lemmas are invoked in every subsequent section. Without norm_algebraMap, the estimate ‖λ⁻¹ · a‖ ≤ ‖λ‖⁻¹ · ‖a‖ would not be sharp. Without algebraMap_isUnit, the product formula for units in resolvent_isUnit would fail.",
+    "relatedConcepts": ["algebraMap", "RingHom.isUnit_map", "norm_smul", "NormOneClass"],
+    "prerequisites": ["Ring homomorphisms and units", "Norm properties in NormedAlgebra"]
+  },
+  {
+    "lineStart": 60,
+    "lineEnd": 96,
+    "annotation": "The core of resolvent existence: three lemmas forming a logical chain. (1) norm_inv_smul_lt_one converts ‖a‖ < ‖λ‖ into ‖λ⁻¹a‖ < 1 via a calc chain: ‖λ⁻¹ · a‖ ≤ ‖λ⁻¹‖ · ‖a‖ = ‖λ‖⁻¹ · ‖a‖ < ‖λ‖⁻¹ · ‖λ‖ = 1. (2) resolvent_factorization proves λ·1 - a = λ · (1 - λ⁻¹ · a) algebraically. (3) resolvent_isUnit combines them: both λ·1 and (1 - λ⁻¹a) are units, so their product is.",
+    "mathContext": "The factorization λ·1 - a = λ·(1 - λ⁻¹a) is elementary algebra but requires careful use of mul_inv_cancel₀ and map_mul for the algebraMap. The key identity algebraMap(λ) * algebraMap(λ⁻¹) = algebraMap(λ · λ⁻¹) = algebraMap(1) = 1 is used in resolvent_factorization. In resolvent_isUnit, one_sub_isUnit (imported from OQ-02) handles the (1 - T) part.",
+    "significance": "This section answers the fundamental question: when is λ in the resolvent set ρ(a) = {λ : λ·1 - a is invertible}? Answer: whenever |λ| > ‖a‖, i.e., λ is outside the closed disk of radius ‖a‖. This gives the spectral containment σ(a) ⊆ B(0, ‖a‖).",
+    "relatedConcepts": ["resolvent set", "spectrum containment", "Neumann series", "IsUnit", "one_sub_isUnit"],
+    "prerequisites": ["Neumann series (OQ-02: one_sub_isUnit)", "IsUnit and unit products", "Algebraic manipulations with algebraMap"]
+  },
+  {
+    "lineStart": 109,
+    "lineEnd": 138,
+    "annotation": "resolvent_eq_neumann_series gives the explicit formula Ring.inverse(λ·1 - a) = λ⁻¹ · ∑ (λ⁻¹a)^n. The proof sets T = λ⁻¹a, factors λ·1 - a = λ·(1-T), uses Ring.inverse_unit for the product of units (giving (λ·(1-T))⁻¹ = (1-T)⁻¹ · λ⁻¹), then substitutes neumann_sum T hT for (1-T)⁻¹ = ∑ Tⁿ and map_inv₀ for the scalar inverse.",
+    "mathContext": "Ring.inverse is the unique total function satisfying a · Ring.inverse a = 1 for units and Ring.inverse a = 0 for non-units. For a unit u, Ring.inverse u = ↑u⁻¹. The simp lemma Units.val_mul and mul_comm are used to rearrange (↑uλ⁻¹ · ↑u(1-T)⁻¹) into the canonical order λ⁻¹ · ∑Tⁿ. The proof requires neumann_sum from OQ-02 as a black box.",
+    "significance": "This is the operator-theoretic analog of the geometric series 1/(λ-x) = ∑ xⁿ/λⁿ⁺¹. It shows the resolvent is analytic (hence holomorphic) in λ for |λ| > ‖a‖, with power series coefficients aⁿ/λⁿ⁺¹. This is the foundation for the Laurent expansion of R(λ,a) around ∞.",
+    "relatedConcepts": ["Neumann series", "Ring.inverse", "Laurent expansion", "analytic resolvent", "neumann_sum"],
+    "prerequisites": ["OQ-02: neumann_sum, neumann_summable", "Ring.inverse_unit", "Units.val_mul, map_inv₀"]
+  },
+  {
+    "lineStart": 183,
+    "lineEnd": 219,
+    "annotation": "The first resolvent identity R(λ) - R(μ) = (μ-λ)·R(λ)·R(μ) is proved purely algebraically, with no norm hypotheses — only IsUnit witnesses for both resolvent points. The key algebraic lemma is uλ⁻¹ - uμ⁻¹ = uλ⁻¹·(uμ - uλ)·uμ⁻¹, proved by ring after inserting uμ·uμ⁻¹ = 1 and uλ⁻¹·uλ = 1. The substitution uμ - uλ = algebraMap(μ) - algebraMap(λ) completes the proof.",
+    "mathContext": "The identity R(λ) - R(μ) = (μ-λ)R(λ)R(μ) can also be written R(λ)(λ·1-a) - R(μ)(μ·1-a) = (μ-λ)·1, which is trivially 1-1=0 after cancellation. The Lean proof avoids this slightly circular route by working directly with unit inverses. Note: this identity holds in any ring with two invertible elements — no completeness or norm is needed.",
+    "significance": "The first resolvent identity has several deep consequences: (1) it implies analyticity of R(λ,a) as a function of λ, (2) it shows that if T(λ) satisfies this identity, T is the resolvent of some closed operator, (3) it is used in perturbation theory to show that small perturbations of a move the resolvent continuously, and (4) it implies the resolvent map λ ↦ R(λ,a) is a homomorphism from (ℂ\\σ(a), +) to (A, ·) in the sense of pseudo-resolvents.",
+    "relatedConcepts": ["first resolvent identity", "pseudo-resolvent", "analytic vector-valued functions", "Kato perturbation theory"],
+    "prerequisites": ["IsUnit and ring inverse", "Algebraic manipulation with units", "No completeness needed"]
+  },
+  {
+    "lineStart": 225,
+    "lineEnd": 249,
+    "annotation": "resolvent_tendsto_zero proves ‖R(λ,a)‖ → 0 as ‖λ‖ → ∞ using squeeze_zero_norm'. The filter is Filter.comap (‖·‖) atTop — the neighborhood filter of ∞ on 𝕜 encoded via norms. 'Eventually' uses the set {λ : ‖a‖ + 1 ≤ ‖λ‖}, where resolvent_norm_bound applies (since ‖a‖ < ‖λ‖). The bound (‖λ‖ - ‖a‖)⁻¹ → 0 follows from tendsto_inv_atTop_zero composed with the cofinite shift r ↦ r - ‖a‖.",
+    "mathContext": "Filter.comap (‖·‖) atTop is the correct formulation of 'λ → ∞' for a normed field 𝕜 that may be non-Archimedean or otherwise exotic. It generates the filter of sets containing {λ : ‖λ‖ ≥ M} for all M. The composition tendsto_inv_atTop_zero.comp h_sub.comp tendsto_comap chains: ‖λ‖ → ∞ implies ‖λ‖ - ‖a‖ → ∞ implies (‖λ‖ - ‖a‖)⁻¹ → 0.",
+    "significance": "Decay at infinity is essential for the holomorphic functional calculus: the Dunford-Taylor integral f(a) = (2πi)⁻¹ ∮_Γ f(λ)R(λ,a) dλ converges because f(λ)·O(1/|λ|) is integrable along a large circle. It also shows the spectrum σ(a) is compact (closed and bounded), since R(λ,a) exists for large |λ|.",
+    "relatedConcepts": ["Filter.comap", "squeeze_zero_norm", "tendsto_inv_atTop_zero", "holomorphic functional calculus", "compactness of spectrum"],
+    "prerequisites": ["Mathlib Filter API: comap, atTop, squeeze_zero_norm'", "tendsto_inv_atTop_zero", "resolvent_norm_bound from § 4"]
+  }
+]

--- a/src/data/proofs/geometric-series-oq-02-oq-05/index.ts
+++ b/src/data/proofs/geometric-series-oq-02-oq-05/index.ts
@@ -1,0 +1,39 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference, TacticState } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import tacticStatesJson from './tacticStates.json'
+import sourceRaw from '../../../../proofs/Proofs/GeometricSeriesOQ02OQ05.lean?raw'
+
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const geometricSeriesOq02Oq05Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const geometricSeriesOq02Oq05Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const geometricSeriesOq02Oq05TacticStates: TacticState[] = tacticStatesJson as TacticState[]
+
+export const geometricSeriesOq02Oq05Data: ProofData = {
+  proof: geometricSeriesOq02Oq05Proof,
+  annotations: geometricSeriesOq02Oq05Annotations,
+  tacticStates: geometricSeriesOq02Oq05TacticStates,
+}

--- a/src/data/proofs/geometric-series-oq-02-oq-05/meta.json
+++ b/src/data/proofs/geometric-series-oq-02-oq-05/meta.json
@@ -71,7 +71,78 @@
       "description": "The resolvent series R(λ,a) = ∑ λ⁻⁽ⁿ⁺¹⁾ aⁿ is the operator-theoretic version of the partial fraction 1/(λ-x) = ∑ x^n/λ^{n+1} from the scalar geometric series."
     }
   ],
-  "overview": "## Motivation\n\nThe **holomorphic functional calculus** is the crown jewel of Banach algebra theory: given a Banach algebra element $a$ and a holomorphic function $f$ on a neighborhood of the spectrum $\\sigma(a)$, one defines\n\n$$f(a) = \\frac{1}{2\\pi i} \\oint_\\Gamma f(\\lambda) R(\\lambda, a) \\, d\\lambda$$\n\nwhere $R(\\lambda, a) = (\\lambda \\cdot 1 - a)^{-1}$ is the **resolvent**. This file formalizes the resolvent and its Neumann series representation — the analytical engine that powers this integral.\n\n## Key Results\n\n1. **Resolvent existence**: When $\\|a\\| < |\\lambda|$, the element $\\lambda \\cdot 1 - a$ is invertible, proved by factoring as $\\lambda(1 - \\lambda^{-1}a)$ and applying the Neumann series\n\n2. **Neumann series expansion**: $R(\\lambda, a) = \\lambda^{-1} \\sum_{n=0}^{\\infty} (\\lambda^{-1} a)^n$\n\n3. **Norm bound**: $\\|R(\\lambda, a)\\| \\leq (|\\lambda| - \\|a\\|)^{-1}$, showing the resolvent decays as $|\\lambda| \\to \\infty$\n\n4. **First resolvent identity**: $R(\\lambda) - R(\\mu) = (\\mu - \\lambda) R(\\lambda) R(\\mu)$, the fundamental algebraic identity of spectral theory",
+  "overview": {
+    "historicalContext": "The resolvent and its Neumann series representation are classical tools from early 20th-century functional analysis. Hilbert introduced the resolvent (1906) in his work on integral equations. Dunford and Taylor (1938) formalized the holomorphic functional calculus, with the resolvent norm bound and its vanishing at infinity being the key estimates enabling the Dunford-Taylor integral f(a) = (2πi)⁻¹ ∮ f(λ)R(λ,a) dλ. The first resolvent identity — R(λ) - R(μ) = (μ-λ)R(λ)R(μ) — was recognized by Hilbert as fundamental to spectral theory, later central to Kato's perturbation theory (1966). Lean 4 formalization via Mathlib's NormedAlgebra and CompleteSpace provides a fully verified foundation for this classical analysis.",
+    "problemStatement": "Given a Banach algebra element a and a spectral variable λ with ‖a‖ < |λ|, establish: (1) R(λ,a) = (λ·1 - a)⁻¹ exists, (2) R(λ,a) = λ⁻¹ ∑_{n≥0} (λ⁻¹a)^n (Neumann series), (3) ‖R(λ,a)‖ ≤ (|λ| - ‖a‖)⁻¹ (norm bound), (4) R(λ) - R(μ) = (μ-λ)R(λ)R(μ) (first resolvent identity), and (5) ‖R(λ,a)‖ → 0 as |λ| → ∞. Together these are the analytical prerequisites for defining f(a) = (2πi)⁻¹ ∮ f(λ)R(λ,a) dλ for holomorphic f.",
+    "proofStrategy": "The central insight is a factorization: λ·1 - a = λ·(1 - λ⁻¹a). Since λ ≠ 0, the embedded scalar λ is a unit (via algebraMap_isUnit). The condition ‖a‖ < |λ| translates to ‖λ⁻¹a‖ < 1, so by the Neumann series from OQ-02, (1 - λ⁻¹a) is also a unit. Their product is invertible. The explicit Neumann series for R(λ,a) follows by composing Ring.inverse with the factored form. Norm bounds use submultiplicativity and the geometric series bound. The first resolvent identity is purely algebraic: multiply both sides by (λ·1-a)(μ·1-a) and expand. The vanishing at infinity follows from the norm bound via tendsto_inv_atTop_zero.",
+    "keyInsights": [
+      "Factorization bridge: λ·1 - a = λ·(1 - λ⁻¹a) reduces resolvent existence to the Neumann convergence condition ‖T‖ < 1, connecting spectral theory to the geometric series",
+      "NormOneClass algebra: The hypothesis ‖1‖ = 1 is essential — it ensures ‖algebraMap λ‖ = ‖λ‖ (norm_algebraMap), making the scalar embedding isometric",
+      "Ring.inverse vs IsUnit: Lean's Ring.inverse is total (returns 0 for non-units) but equals the unit inverse when IsUnit holds. The proof carefully tracks IsUnit witnesses alongside Ring.inverse computations",
+      "First resolvent identity is purely algebraic: No norm conditions needed — it holds for any two resolvent points via the identity uλ⁻¹ - uμ⁻¹ = uλ⁻¹(uμ - uλ)uμ⁻¹ for units",
+      "Decay at infinity via squeeze: resolvent_tendsto_zero combines the norm bound (‖R(λ)‖ ≤ (‖λ‖ - ‖a‖)⁻¹) with the fact that (‖λ‖ - ‖a‖)⁻¹ → 0 using Filter.comap on ‖·‖"
+    ]
+  },
+  "sections": [
+    {
+      "title": "§ 1. Scalar Embedding and Norm Properties",
+      "startLine": 38,
+      "endLine": 51,
+      "description": "Establishes that the scalar embedding algebraMap 𝕜 A is isometric (norm_algebraMap) and maps nonzero scalars to units (algebraMap_isUnit). These foundational lemmas underpin every subsequent estimate in the file.",
+      "theorems": ["norm_algebraMap", "algebraMap_isUnit"],
+      "tactics": ["rw", "simp", "exact"]
+    },
+    {
+      "title": "§ 2. The Resolvent Exists via Neumann Series",
+      "startLine": 52,
+      "endLine": 97,
+      "description": "Three lemmas building to resolvent existence. norm_inv_smul_lt_one converts ‖a‖ < ‖λ‖ into ‖λ⁻¹a‖ < 1 via a calc chain. resolvent_factorization proves λ·1 - a = λ·(1 - λ⁻¹a) algebraically. resolvent_isUnit combines these with the Neumann series from OQ-02 to show λ·1 - a is invertible.",
+      "theorems": ["norm_inv_smul_lt_one", "resolvent_factorization", "resolvent_isUnit"],
+      "tactics": ["calc", "rw", "exact", "apply", "linarith"]
+    },
+    {
+      "title": "§ 3. Neumann Series Representation of the Resolvent",
+      "startLine": 98,
+      "endLine": 138,
+      "description": "Explicitly computes Ring.inverse (λ·1 - a) = λ⁻¹ · ∑ (λ⁻¹a)^n. The summability follows from norm_inv_smul_lt_one and neumann_summable. The series identity uses resolvent_factorization, Ring.inverse_unit for products of units, and neumann_sum from OQ-02.",
+      "theorems": ["resolvent_series_summable", "resolvent_eq_neumann_series"],
+      "tactics": ["set", "rw", "simp", "congr", "exact"]
+    },
+    {
+      "title": "§ 4. Norm Bound on the Resolvent",
+      "startLine": 139,
+      "endLine": 178,
+      "description": "Proves ‖R(λ,a)‖ ≤ (‖λ‖ - ‖a‖)⁻¹ via a six-step calc chain: submultiplicativity of norm, norm_neumann_le from OQ-02, norm_inv, and algebraic simplification of ‖λ‖⁻¹·(1 - ‖λ‖⁻¹·‖a‖)⁻¹ = (‖λ‖ - ‖a‖)⁻¹ by field_simp.",
+      "theorems": ["resolvent_norm_bound"],
+      "tactics": ["calc", "apply", "rw", "linarith", "field_simp"]
+    },
+    {
+      "title": "§ 5. First Resolvent Identity",
+      "startLine": 179,
+      "endLine": 220,
+      "description": "Proves R(λ) - R(μ) = (μ-λ)·R(λ)·R(μ) for any two resolvent points. Uses only algebraic manipulations on units: extracts IsUnit witnesses, rewrites Ring.inverse as unit inverses, and proves the identity via uλ⁻¹ - uμ⁻¹ = uλ⁻¹·(uμ - uλ)·uμ⁻¹ by ring after cancellation.",
+      "theorems": ["first_resolvent_identity"],
+      "tactics": ["obtain", "rw", "have", "ring", "simp"]
+    },
+    {
+      "title": "§ 6. Resolvent Vanishes at Infinity",
+      "startLine": 221,
+      "endLine": 250,
+      "description": "Proves Filter.Tendsto (R(λ,a)) (comap ‖·‖ atTop) (nhds 0) via squeeze_zero_norm'. The upper bound (‖R(λ)‖ ≤ (‖λ‖ - ‖a‖)⁻¹) is eventually verified using resolvent_norm_bound. The bound itself tends to 0 via tendsto_inv_atTop_zero composed with the shift r ↦ r - ‖a‖.",
+      "theorems": ["resolvent_tendsto_zero"],
+      "tactics": ["apply", "rw", "refine", "simp", "linarith", "exact"]
+    }
+  ],
+  "conclusion": {
+    "summary": "This file provides a complete Lean 4 formalization of the resolvent R(λ,a) = (λ·1 - a)⁻¹ for Banach algebra elements, building on the Neumann series from OQ-02. The six theorems constitute the analytical prerequisites for the holomorphic functional calculus: existence via Neumann factorization, explicit series representation, quantitative norm bound, the fundamental first resolvent identity, and decay at infinity.",
+    "implications": "The resolvent established here is the integral kernel of the holomorphic functional calculus f(a) = (2πi)⁻¹ ∮ f(λ)R(λ,a) dλ. The norm bound ensures the Dunford-Taylor integral converges; the first resolvent identity implies R is a pseudo-resolvent (and hence the resolvent of some operator); the vanishing at infinity validates deforming contours through ∞ in the Cauchy integral. These results are also the foundation for the Gelfand transform, C*-algebra theory, and the spectral mapping theorem.",
+    "openQuestions": [
+      "Holomorphic functional calculus: Formalize f(a) = (2πi)⁻¹ ∮ f(λ)R(λ,a) dλ in Lean using Mathlib's complex line integral and prove the spectral mapping theorem f(σ(a)) = σ(f(a))",
+      "Spectral radius formula: Prove lim_{n→∞} ‖aⁿ‖^{1/n} = sup{|λ| : λ ∈ σ(a)} using the resolvent's analyticity outside the spectrum",
+      "Operator theory extension: Extend to unbounded operators and closed operators on Hilbert space, where the resolvent condition ‖R(λ,T)‖ ≤ 1/dist(λ,σ(T)) is more delicate",
+      "Perturbation theory: Formalize Kato's first resolvent identity application — how small perturbations of a move the spectrum continuously"
+    ]
+  },
   "references": [
     {
       "type": "book",


### PR DESCRIPTION
## Summary

- **Proof**: Resolvent and Neumann Series: Toward the Holomorphic Functional Calculus (250 lines, 0 sorries, badge: original)
- **Missing index.ts**: Added `index.ts` so the proof page is discoverable by Vite glob import
- **Structured overview**: Converted markdown string `overview` to ProofOverview object (historicalContext tracing Hilbert 1906 → Dunford-Taylor 1938 → Kato 1966; problemStatement with 5 key results; proofStrategy explaining the λ·1-a = λ·(1-λ⁻¹a) factorization; 5 keyInsights on NormOneClass isometry, Ring.inverse tracking, algebraic resolvent identity, filter squeeze)
- **6 sections**: Matching the 6 numbered sections in the Lean file (scalar embedding, resolvent existence, Neumann series, norm bound, first resolvent identity, vanishes at infinity)
- **Conclusion**: Summary + 4 open questions (holomorphic calculus, spectral radius formula, unbounded operators, Kato perturbation theory)
- **6 annotations**: Rich mathContext, significance, relatedConcepts, prerequisites for each proof section

## Labels
enrichment

🤖 Generated with [Claude Code](https://claude.com/claude-code)