### PR TITLE
enrichment: descartes-rule-of-signs-oq-02-oq-01 Budan upper bound scaffold

### DIFF
--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01/annotations.json
@@ -1,0 +1,56 @@
+[
+  {
+    "lineStart": 53,
+    "lineEnd": 56,
+    "annotation": "iterDeriv is a recursive definition of iterated polynomial differentiation: iterDeriv p 0 = p, iterDeriv p (k+1) = derivative (iterDeriv p k). This is the foundation for the Budan-Fourier sign-variation count V_p(x) = #{i : sign(p^(i)(x)) ≠ sign(p^(i+1)(x))}. Marked noncomputable because polynomial evaluation at arbitrary real values is noncomputable.",
+    "mathContext": "The k-th iterated derivative p^(k) of a polynomial of degree n has degree max(0, n-k). For k > n, p^(k) = 0. The Budan-Fourier sequence at point x is (p(x), p'(x), ..., p^(n)(x), 0), and sign variations are counted ignoring zeros. This definition mirrors the budanCount infrastructure in OQ-02.",
+    "significance": "iterDeriv is restated here (rather than imported from OQ-02) because the proof scaffold is self-contained. In a full implementation, this would be imported directly from OQ-02's namespace.",
+    "relatedConcepts": ["Budan-Fourier sequence", "sign variation count", "polynomial derivative", "Polynomial.derivative"],
+    "prerequisites": ["Polynomial.derivative in Mathlib", "Recursive definitions in Lean 4"]
+  },
+  {
+    "lineStart": 62,
+    "lineEnd": 70,
+    "annotation": "constant_no_roots proves that if natDegree(p) = 0 and p ≠ 0, then p(x) ≠ 0 for all x. Key step: eq_C_of_natDegree_eq_zero rewrites p as C c (a constant polynomial), then eval_C gives p(x) = c, and since p ≠ 0 means c ≠ 0 (via map_zero), we conclude p(x) ≠ 0.",
+    "mathContext": "natDegree 0 (the zero polynomial) is defined as 0 in Mathlib, not -∞ as in classical algebra. The hypothesis p ≠ 0 is needed to distinguish the zero polynomial (which technically has natDegree 0 but has all values 0) from genuine constants. eq_C_of_natDegree_eq_zero : natDegree p = 0 → p = C (p.coeff 0).",
+    "significance": "This is the base case for the Budan bound induction: a constant nonzero polynomial has 0 roots, and V_p(a) - V_p(b) ≥ 0, so the bound trivially holds.",
+    "relatedConcepts": ["eq_C_of_natDegree_eq_zero", "Polynomial.eval_C", "natDegree zero polynomial"],
+    "prerequisites": ["Polynomial.natDegree in Mathlib", "eq_C_of_natDegree_eq_zero"]
+  },
+  {
+    "lineStart": 72,
+    "lineEnd": 95,
+    "annotation": "linear_at_most_one_root proves #{x ∈ (a,b] : p(x) = 0} ≤ 1 when natDegree(p) = 1. Strategy: Set.Subsingleton.ncard_le_one reduces to showing any two roots are equal. By contradiction (by_contra hne), if x ≠ y are both roots, build {x,y} as a Finset ℝ with card = 2 (Finset.card_pair hne), embed it in p.roots.toFinset, compare with card_roots_le_degree ≤ 1 = natDegree, giving 2 ≤ 1, contradiction via omega.",
+    "mathContext": "card_roots_le_degree : p.roots.card ≤ p.natDegree. Here natDegree p = 1. The proof chain: 2 ≤ {x,y}.card ≤ p.roots.toFinset.card ≤ p.roots.card ≤ natDegree p = 1. The middle inequality uses Multiset.toFinset_card_le_card (a Finset has ≤ as many elements as the corresponding multiset, counting multiplicities). rw [hp] at hcard refers to hp : p.natDegree = 1, and omega closes 2 ≤ 1.",
+    "significance": "This is the degree-1 base case for the Budan induction. The proof elegantly avoids polynomial division and coefficient extraction, working instead at the level of root counting — which is what the Budan bound is about.",
+    "relatedConcepts": ["Polynomial.card_roots_le_degree", "Polynomial.mem_roots", "Set.Subsingleton", "Finset.card_pair"],
+    "prerequisites": ["Polynomial.roots (as Multiset)", "Multiset.toFinset and its cardinality", "Set.ncard for infinite types"]
+  },
+  {
+    "lineStart": 100,
+    "lineEnd": 107,
+    "annotation": "rolle_polynomial bridges Mathlib's analytic Rolle theorem (exists_deriv_eq_zero for continuous real functions) with the algebraic polynomial derivative. Given roots p(r₁) = p(r₂) = 0 with r₁ < r₂: (1) p.continuous.continuousOn gives continuity on [r₁,r₂], (2) exists_deriv_eq_zero produces c ∈ (r₁,r₂) with deriv p c = 0, (3) simp [Polynomial.deriv] translates `deriv p c = 0` to `(derivative p).eval c = 0`.",
+    "mathContext": "Mathlib has two notions of derivative for polynomials: the calculus deriv (defined as Fréchet derivative) and the algebraic Polynomial.derivative. Polynomial.deriv (or Polynomial.hasDerivAt) shows these agree. The simp lemma [Polynomial.deriv] does this translation. exists_deriv_eq_zero : r₁ < r₂ → ContinuousOn f [r₁,r₂] → f r₁ = f r₂ → ∃ c ∈ (r₁,r₂), deriv f c = 0.",
+    "significance": "Rolle's theorem is the engine of the Budan induction: between consecutive roots r₁ < r₂ of p lies a root of p'. This interleaving of roots of p and p' is what gives the derivative enough roots to 'pay for' the sign variations.",
+    "relatedConcepts": ["exists_deriv_eq_zero", "Polynomial.deriv", "Polynomial.hasDerivAt", "Rolle's theorem"],
+    "prerequisites": ["Mathlib's exists_deriv_eq_zero from Analysis.Calculus.LocalExtr.Rolle", "Polynomial.continuous (all polynomials are continuous)", "deriv vs Polynomial.derivative"]
+  },
+  {
+    "lineStart": 115,
+    "lineEnd": 134,
+    "annotation": "root_of_sign_change proves that if p(a) < 0 < p(b), there exists c ∈ (a,b) with p(c) = 0. Uses intermediate_value_Icc: since 0 ∈ [p(a), p(b)] and p is continuous on [a,b], there exists c ∈ [a,b] with p(c) = 0. Sharpening [a,b] to (a,b) uses sign conditions: p(a) < 0 ≠ 0 = p(c) so c ≠ a; p(b) > 0 ≠ 0 = p(c) so c ≠ b.",
+    "mathContext": "intermediate_value_Icc : a ≤ b → ContinuousOn f [a,b] → Set.Icc (f a) (f b) ⊆ f '' Set.Icc a b (or equivalent). The membership check h0_mem : 0 ∈ Set.Icc (p.eval a) (p.eval b) uses 0 ≥ p.eval a (by linarith from ha : p.eval a < 0) and 0 ≤ p.eval b (from hb). The endpoint exclusion uses rcases eq_or_lt_of_le.",
+    "significance": "This is an IVT-based existence theorem: sign change implies root. In the Budan induction, this would be used to show that when V_p(x) decreases, it corresponds to a real root (not just a sign-change artifact).",
+    "relatedConcepts": ["intermediate_value_Icc", "Polynomial.continuous", "IVT for polynomials", "sign change implies root"],
+    "prerequisites": ["Mathlib IVT: intermediate_value_Icc", "Polynomial.continuous", "linarith for order arithmetic"]
+  },
+  {
+    "lineStart": 139,
+    "lineEnd": 164,
+    "annotation": "sign_changes_factor and inductive_step_derivative are architectural placeholders proving `True := trivial`. They document where the remaining proof gaps are without introducing sorry or unsound axioms. sign_changes_factor should state how removing a root (x - r) from p affects the sign-variation count V_p. inductive_step_derivative should formalize the IH application to p' on sub-intervals. The docstrings describe the intended mathematics.",
+    "mathContext": "A placeholder proving `True` is mathematically sound (True is always true) but mathematically vacuous — it does not prove the stated pre-conditions or conclusion. This pattern is distinct from `sorry` (which accepts any goal) in that it commits to a specific theorem statement (`True`) that happens to be trivial. The leanFile metadata tracks these as 'type: placeholder' to distinguish from genuine proofs.",
+    "significance": "The proof roadmap in § 4 (lines 170-204) identifies the remaining 240-410 lines needed: sign-change accounting (80-120 lines) is the hardest and most novel part; the rest follows from combining the proved building blocks. This file serves as a research survey identifying the open subproblems.",
+    "relatedConcepts": ["proof scaffold", "Budan-Fourier sign variation", "inductive step via Rolle", "sign_changes_factor gap"],
+    "prerequisites": ["OQ-02: budanCount and sign-variation infrastructure", "Strong induction in Lean 4", "Polynomial factorization theorems"]
+  }
+]

--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01/index.ts
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01/index.ts
@@ -1,0 +1,38 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/DescartesRuleOfSignsOQ02OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const descartesRuleOfSignsOQ02OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const descartesRuleOfSignsOQ02OQ01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const descartesRuleOfSignsOQ02OQ01Data: ProofData = {
+  proof: descartesRuleOfSignsOQ02OQ01Proof,
+  annotations: descartesRuleOfSignsOQ02OQ01Annotations,
+}
+
+export default descartesRuleOfSignsOQ02OQ01Data

--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01/meta.json
@@ -12,7 +12,11 @@
       "algebra",
       "polynomials",
       "real-algebraic-geometry",
-      "root-isolation"
+      "root-isolation",
+      "rolle-theorem",
+      "budan-fourier",
+      "sign-variations",
+      "proof-scaffold"
     ],
     "badge": "original",
     "sorries": 0,
@@ -28,10 +32,16 @@
     ]
   },
   "overview": {
-    "problemStatement": "Prove the Budan upper bound: #roots(p, (a,b]) <= V_p(a) - V_p(b).",
-    "text": "Proof scaffold for Budan's upper bound via strong induction on polynomial degree. Building blocks: constant_no_roots, linear bound, Rolle for polynomials, IVT sign change. The full proof requires sign-change accounting across derivative levels.",
-    "proofStrategy": "Strong induction on deg(p). Base: deg 0/1 trivial. Step: Rolle gives derivative roots between polynomial roots, IH on p' for sub-intervals.",
-    "keyInsights": []
+    "historicalContext": "The Budan-Fourier theorem (1807/1820) predates and generalizes Descartes' Rule. François Budan de Boislaurent (1807) and Joseph Fourier (1820) independently proved that the number of real roots of a polynomial p in a half-open interval (a,b] is bounded by V_p(a) - V_p(b), where V_p(x) counts sign variations in the sequence (p(x), p'(x), p''(x), ..., p^(n)(x)). Descartes' Rule is the special case a=0, b=∞ for polynomials with non-negative coefficients. The theorem was central to 19th-century root isolation algorithms and remains the foundation of modern computer algebra systems' polynomial root isolation routines (e.g., Vincent's theorem, Uspensky's algorithm, the VCA/VAS algorithms). A complete Lean formalization requires connecting the Budan-Fourier sign-variation infrastructure from OQ-02 with Rolle's theorem and strong induction — an estimated 240-410 lines of work.",
+    "problemStatement": "Prove the Budan upper bound theorem: for any nonzero polynomial p ∈ ℝ[X] of degree n and real interval (a,b], #{x ∈ (a,b] : p(x) = 0} ≤ V_p(a) - V_p(b), where V_p(x) = #{i : p^(i)(x) and p^(i+1)(x) have opposite signs}. This file establishes the key building blocks and proof strategy as a research scaffold.",
+    "proofStrategy": "Strong induction on natDegree(p). Base cases: constant nonzero polynomial (no roots at all); linear polynomial (at most one root, proved via Finset.card_roots_le_degree). Inductive step: if p has consecutive roots r₁ < r₂ in (a,b], Rolle's theorem gives a root of p' in (r₁,r₂); apply the inductive hypothesis to p' (degree < deg p) on each sub-interval; the sign-change count for p' ≤ sign-change count of p minus the contribution of the root r₁. The main gap is the sign-change accounting lemma relating V_p(x) and V_{p'}(x).",
+    "keyInsights": [
+      "Rolle's theorem is the inductive engine: between consecutive roots of p lies a root of p'. This interleaving means #{roots of p in (a,b]} ≤ 1 + #{roots of p' in (a,b]}, giving room for the IH on p'.",
+      "The sign-variation count V_p(x) is defined via the iterated derivative sequence p, p', p'', ..., p^(n). At each root r of p, V_p changes by at least 1 going from a to r, accounting for the root — this is the sign-change accounting that remains to be formalized.",
+      "linear_at_most_one_root is proved via a counting argument: if x ≠ y are both roots, then {x,y} ⊂ roots(p) as a finset, giving card ≥ 2 > 1 = natDegree, contradicting card_roots_le_degree. This avoids polynomial division.",
+      "The placeholder theorems sign_changes_factor and inductive_step_derivative prove `True := trivial` — they document the proof structure and identify the remaining gaps without introducing unsound axioms.",
+      "root_of_sign_change uses IVT (intermediate_value_Icc): since p is continuous and changes sign from negative to positive, it must cross zero. The proof carefully excludes the endpoints by using the sign condition."
+    ]
   },
   "leanFile": {
     "namespace": "BudanUpperBound",
@@ -58,10 +68,73 @@
       },
       {
         "name": "linear_at_most_one_root",
-        "type": "sorry",
-        "description": "Linear polynomial has at most one root in interval"
+        "type": "proved",
+        "description": "Linear polynomial has at most one root in interval (proved via card_roots_le_degree counting argument)"
+      },
+      {
+        "name": "sign_changes_factor",
+        "type": "placeholder",
+        "description": "Sign-change accounting when factoring out a root (proves True — identifies the gap)"
+      },
+      {
+        "name": "inductive_step_derivative",
+        "type": "placeholder",
+        "description": "Inductive step framework (proves True — documents the induction architecture)"
       }
     ]
   },
-  "sections": []
+  "sections": [
+    {
+      "title": "§ 1. Building Blocks: Degree and Derivative Properties",
+      "startLine": 58,
+      "endLine": 95,
+      "description": "Two foundational theorems. constant_no_roots shows degree-0 polynomials have no roots (proved via eq_C_of_natDegree_eq_zero and simp). linear_at_most_one_root proves degree-1 polynomials have at most 1 root in any interval (a,b], using a card counting argument: if x ≠ y are both roots, {x,y} ⊂ roots(p) gives card ≥ 2 > 1 = natDegree, contradicting card_roots_le_degree.",
+      "theorems": ["constant_no_roots", "linear_at_most_one_root"],
+      "tactics": ["rw", "simp", "apply", "intro", "calc", "omega", "by_contra"]
+    },
+    {
+      "title": "§ 2. Sign Change Properties",
+      "startLine": 109,
+      "endLine": 142,
+      "description": "rolle_polynomial (proved) applies Mathlib's exists_deriv_eq_zero to polynomials: if p(r₁) = p(r₂) = 0 with r₁ < r₂, then p' has a root in (r₁,r₂). Uses p.continuous.continuousOn and Polynomial.deriv to translate between Mathlib's calculus deriv and the algebraic polynomial derivative. sign_changes_factor is a placeholder proving True — it identifies where the sign-change accounting lemma needs to go.",
+      "theorems": ["rolle_polynomial", "root_of_sign_change", "sign_changes_factor"],
+      "tactics": ["obtain", "exact", "simp", "intro", "linarith", "constructor", "rcases"]
+    },
+    {
+      "title": "§ 3. The Induction Framework",
+      "startLine": 144,
+      "endLine": 164,
+      "description": "inductive_step_derivative documents the induction structure for the main Budan bound. It takes the inductive hypothesis (IH: bound holds for all polynomials of degree ≤ n) and outlines how to apply it to p' on sub-intervals. Currently proves True — it is a scaffold identifying the types and dependencies needed for the real inductive step.",
+      "theorems": ["inductive_step_derivative"],
+      "tactics": ["exact"]
+    },
+    {
+      "title": "§ 4. Proof Completion Roadmap",
+      "startLine": 166,
+      "endLine": 204,
+      "description": "A detailed comment documenting the remaining 240-410 lines needed: (1) formalize sign-change counting connecting budanCount from OQ-02 with the derivative sequence (80-120 lines), (2) complete base cases (40-60 lines), (3) inductive step via Rolle with sign-change accounting (100-200 lines), (4) assembly (20-30 lines). Lists key Mathlib dependencies: exists_deriv_eq_zero, natDegree_derivative_le, IVT."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file establishes the foundational building blocks for Budan's upper bound theorem: constant and linear polynomial bounds (proved), Rolle's theorem for polynomials (proved), IVT-based root existence (proved), and documented placeholders for the sign-change accounting and inductive step. The three proved theorems are sound; the two placeholder theorems prove `True` to document proof architecture without introducing unsound assumptions.",
+    "implications": "Budan's theorem is the algorithmic heart of real root isolation: computer algebra systems use V_p(a) - V_p(b) as a quick upper bound on roots in (a,b] to bisect intervals. The theorem also implies Descartes' Rule (sign changes in coefficients = upper bound on positive roots) as a corollary. A complete Lean formalization would: (1) give a verified foundation for root isolation algorithms, (2) enable formal proofs of Sturm's theorem as a tighter cousin, and (3) contribute to Mathlib's polynomial root-counting infrastructure.",
+    "openQuestions": [
+      "Sign-change accounting: Formalize the lemma relating V_p(x) and V_{p'}(x) across a root of p — this is the heart of the induction and requires careful analysis of how sign variations change when a root is factored out",
+      "Sturm's theorem: Prove the exact root count #{x ∈ (a,b] : p(x) = 0} = #{sign changes in the Sturm sequence from a to b}, which gives a sharper (tight) bound compared to Budan",
+      "Vincent's theorem formalization: Prove that after sufficiently many bisections, each interval contains at most one real root (V=0 or V=1), forming the basis of the VAS/VCA root isolation algorithms",
+      "Extension to complex roots: Count complex roots via the argument principle — a contour integral generalization of the Budan-Fourier sign-variation count"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "descartes-rule-of-signs-oq-02",
+      "relationship": "extends",
+      "description": "OQ-02 provides the budanCount infrastructure (sign-variation count over derivative sequence) and the budan_upper_bound_axiom. This file proves the core building blocks needed to replace that axiom with a genuine proof."
+    },
+    {
+      "targetId": "descartes-rule-of-signs",
+      "relationship": "related",
+      "description": "Descartes' Rule of Signs is the special case of Budan's theorem for positive roots: the number of positive roots of p ≤ the number of sign changes in the coefficient sequence."
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- **Proof**: Proving Budan's Upper Bound in Lean (206 lines, proof scaffold with 3 proved theorems + 2 placeholders)
- **Missing index.ts**: Added for Vite gallery discovery
- **annotations.json**: 6 rich annotations covering iterDeriv, constant_no_roots, linear_at_most_one_root (counting argument via card_roots_le_degree), rolle_polynomial (Mathlib bridge), root_of_sign_change (IVT), and placeholder theorems architecture
- **Structured overview**: Historicalcontext (Budan 1807, Fourier 1820, modern CAS algorithms), problemStatement, proofStrategy (strong induction via Rolle interleaving), 5 keyInsights
- **Data fix**: `linear_at_most_one_root` corrected from "type: sorry" to "type: proved" (the Lean file has a complete proof); added sign_changes_factor and inductive_step_derivative as "type: placeholder"
- **4 sections**: Matching Lean file structure (building blocks, sign change properties, induction framework, roadmap)
- **Conclusion**: 4 open questions (sign-change accounting, Sturm's theorem, Vincent's theorem, argument principle)
- **crossReferences**: To parent OQ-02 and root descartes-rule-of-signs

## Labels
enrichment

🤖 Generated with [Claude Code](https://claude.com/claude-code)