### PR TITLE
Enrich Fair Games Theorem: Gambler's Ruin and Doubling Strategy

### DIFF
--- a/src/data/proofs/fair-games-theorem-oq-02/annotations.json
+++ b/src/data/proofs/fair-games-theorem-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-fgt02-game-5-10",
+    "proofId": "fair-games-theorem-oq-02",
+    "range": { "startLine": 26, "endLine": 42 },
+    "type": "definition",
+    "title": "Symmetric Fair Game: k=5, N=10",
+    "content": "game_5_10 instantiates GamblersRuin with N=10 (total stake) and k=5 (player's initial amount). This is the perfectly symmetric case: both players have equal stakes, so the probability of winning is exactly 1/2 by the Gambler's Ruin formula P(win) = k/N. The expected game duration E[T] = k(N-k) = 5·5 = 25. The proofs reduce to norm_num after simp unfolds the definitions.",
+    "mathContext": "Gambler's Ruin: player starts with $k$, opponent with $N-k$. For a fair coin ($p = 1/2$): $P(\\text{win}) = k/N$. Expected stopping time: $E[T] = k(N-k)$. For $(k,N) = (5,10)$: $P(\\text{win}) = 1/2$, $E[T] = 25$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Gambler's Ruin", "Optional Stopping Theorem", "random walk on integers", "harmonic functions"],
+    "prerequisites": ["probability theory", "random walks", "martingales"]
+  },
+  {
+    "id": "ann-fgt02-game-1-10",
+    "proofId": "fair-games-theorem-oq-02",
+    "range": { "startLine": 44, "endLine": 58 },
+    "type": "insight",
+    "title": "Underdog Game: P(win) = 1/10",
+    "content": "game_1_10 is the extreme case: player starts with $1 against an opponent with $9 (total $10). The probability of winning is just 1/10 — the player is 9-to-1 against. The expected game duration is only 9 (compared to 25 for the symmetric game). This illustrates a fundamental asymmetry: small initial position means very low win probability AND shorter expected game time (the player is likely to hit 0 quickly).",
+    "mathContext": "For $(k,N) = (1,10)$: $P(\\text{win}) = 1/10$, $E[T] = 1 \\cdot (10-1) = 9$. The formula $E[T] = k(N-k)$ reveals that the expected game length is maximized at $k = N/2$ (symmetric game) and minimized near $k = 1$ or $k = N-1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["asymmetric Gambler's Ruin", "casino advantage", "ruin probability"],
+    "prerequisites": ["Gambler's Ruin formula", "probability theory"]
+  },
+  {
+    "id": "ann-fgt02-doubling-algebra",
+    "proofId": "fair-games-theorem-oq-02",
+    "range": { "startLine": 79, "endLine": 95 },
+    "type": "technique",
+    "title": "Doubling Strategy: Geometric Series and Win Guarantee",
+    "content": "doublingBet k = 2^k is the bet size after k consecutive losses. doubling_total_invested proves by induction that Σᵢ₌₀^{k-1} 2^i = 2^k - 1 (geometric series). doubling_win_gain derives that 2^k - (2^k - 1) = 1: if you win on the k-th bet, your profit is exactly $1 regardless of k. The induction proof uses Finset.sum_range_succ and omega. This invariant explains the strategy's appeal: you always win exactly $1 whenever you eventually win.",
+    "mathContext": "Doubling bets: $b_0 = 1, b_1 = 2, b_2 = 4, \\ldots, b_k = 2^k$. Total investment after $k$ losses: $\\sum_{i=0}^{k-1} 2^i = 2^k - 1$. Win on bet $k$: receive $2 \\cdot 2^k = 2^{k+1}$... wait, actually: bet $2^k$, win doubles: receive $2^k$. Net: $2^k - (2^k - 1) = 1$.",
+    "significance": "key",
+    "relatedConcepts": ["geometric series", "betting strategies", "induction on natural numbers", "Finset.sum_range_succ"],
+    "prerequisites": ["geometric series", "natural number arithmetic", "Lean 4 induction"]
+  },
+  {
+    "id": "ann-fgt02-bankroll-limit",
+    "proofId": "fair-games-theorem-oq-02",
+    "range": { "startLine": 96, "endLine": 113 },
+    "type": "insight",
+    "title": "Bankroll Limits: Logarithmic Ceiling on Doublings",
+    "content": "maxDoublings B = ⌊log₂(B+1)⌋ is the maximum number of doublings possible with bankroll B. doubling_bankroll_limit proves 2^(maxDoublings B) - 1 ≤ B via Nat.pow_log_le_self. maxDoublings_power_of_two_minus_one gives the exact formula for B = 2^n - 1. The logarithmic growth of maxDoublings vs the exponential growth of required capital (2^n) is the mathematical reason the strategy fails: with \\$1000, you can survive only about 10 doublings (since 2^10 = 1024 > 1000).",
+    "mathContext": "$\\text{maxDoublings}(B) = \\lfloor \\log_2(B+1) \\rfloor$. The maximum investment after $m = \\text{maxDoublings}(B)$ losses is $2^m - 1 \\leq B$. But the next bet would require $2^m > B$, exceeding the bankroll. For $B = 2^n - 1$: exactly $n$ doublings possible.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.log in Lean/Mathlib", "exponential vs logarithmic growth", "bankroll management", "casino table limits"],
+    "prerequisites": ["logarithms", "Nat.log in Lean 4", "binary representation"]
+  },
+  {
+    "id": "ann-fgt02-expected-zero",
+    "proofId": "fair-games-theorem-oq-02",
+    "range": { "startLine": 129, "endLine": 136 },
+    "type": "technique",
+    "title": "E[Doubling Strategy] = 0: Direct Computation",
+    "content": "doubling_expected_value_zero proves (1-(1/2)^n)·1 + (1/2)^n·(-(2^n-1)) = 0 for all n > 0. This is a direct computation: the first term is the probability of winning (probability that you don't lose n times) times the gain ($1), and the second term is the probability of losing n times times the loss (2^n-1). The ring computation reduces to 0 after field_simp. This is a concrete instance of the Fair Games Theorem: no stopping strategy improves expected value in a fair game.",
+    "mathContext": "With $n$ doublings possible: $P(\\text{win before ruin}) = 1 - (1/2)^n$, gain $= 1$. $P(\\text{ruin}) = (1/2)^n$, loss $= 2^n - 1$. Expected value: $(1-(1/2)^n) \\cdot 1 + (1/2)^n \\cdot (-(2^n-1)) = 1 - (1/2)^n - 1 + (1/2)^n = 0$. QED by cancellation.",
+    "significance": "key",
+    "relatedConcepts": ["Optional Stopping Theorem", "martingale strategy", "zero-sum games", "field_simp and ring in Lean 4"],
+    "prerequisites": ["probability theory", "expected value", "geometric series", "Lean 4 ring tactics"]
+  }
+]

--- a/src/data/proofs/fair-games-theorem-oq-02/meta.json
+++ b/src/data/proofs/fair-games-theorem-oq-02/meta.json
@@ -36,5 +36,63 @@
     "theoremCount": 10,
     "definitionCount": 5
   },
-  "sections": []
+  "crossReferences": [
+    {
+      "targetId": "fair-games-theorem",
+      "relationship": "extends",
+      "description": "Concrete examples verifying the Optional Stopping Theorem for Gambler's Ruin and the doubling strategy"
+    }
+  ],
+  "overview": {
+    "historicalContext": "The Gambler's Ruin problem has roots in Huygens' 'De Ratiociniis in Ludo Aleae' (1657), the first systematic treatment of probability theory. Huygens solved the problem of a gambler starting with $k$ who plays against an opponent with $N-k$: what is the probability of ruin before reaching $N$? The answer, $P(\\text{win}) = k/N$ for a fair coin, was classical by the 18th century. The 'doubling strategy' (martingale betting system) has been used in French casinos since at least the 1700s. In the doubling strategy, you double your bet after every loss, guaranteeing a net profit of $1 whenever you win. Casinos countered this with table maximum bets. The mathematical explanation for why the strategy fails — even without table limits — comes from Doob's Optional Stopping Theorem (1953): for a fair game, the expected value of any stopping strategy with a finite stopping time is zero. This file applies both the classical Gambler's Ruin formulas and a direct computation to confirm these zero-expectation results.",
+    "problemStatement": "Can the abstract Fair Games Theorem (Optional Stopping Theorem) be verified on concrete gambling instances? Specifically: (1) For the Gambler's Ruin with $(k,N)$ parameters, verify the classical formulas $P(\\text{win}) = k/N$ and $E[T] = k(N-k)$. (2) For the doubling strategy with bankroll $B$, verify the expected gain is 0 by direct computation.",
+    "proofStrategy": "The file takes a concrete computational approach. Part I instantiates the GamblersRuin structure (from the parent FairGamesOQ01) with specific parameters (5, 10) and (1, 10), then dispatches to `simp + norm_num` to verify the classical formulas. Part II builds the doubling strategy algebra from scratch: geometric series for total investment, arithmetic for win gain, logarithm for bankroll limit. Part III provides a direct ring computation showing the weighted sum equals 0, confirming the Fair Games Theorem without invoking it abstractly.",
+    "keyInsights": [
+      "The (5, 10) game is perfectly symmetric: both players start with $5, so $P(\\text{win}) = 5/10 = 1/2$ and the expected game length is $E[T] = 5 \\cdot (10-5) = 25$. The formula $E[T] = k(N-k)$ comes from the optional stopping theorem applied to the martingale $X_t^2 - t$ where $X_t$ is the random walk.",
+      "The (1, 10) underdog example shows how dramatically initial position matters: starting with only 1/10 of the total stake gives only a 10% win probability. Casinos exploit this asymmetry: a player with \\$100 against the house with \\$1,000,000 has essentially zero chance of winning.",
+      "The doubling strategy's invariant is `doubling_win_gain`: regardless of how many consecutive losses, if you win the next bet, your net gain is exactly $1. This is proved by noting that $2^k - (2^k - 1) = 1$ — the winning bet covers all previous losses plus $1 profit.",
+      "The fatal flaw is captured by `doubling_bankroll_limit`: with bankroll $B$, you can sustain at most $\\lfloor \\log_2(B+1) \\rfloor$ consecutive losses. Even with a million-dollar bankroll ($2^{20}$), you can only survive 20 consecutive losses, which happens with probability $(1/2)^{20} \\approx 0.000001$ — rare but catastrophic.",
+      "The `doubling_expected_value_zero` computation is a beautiful direct verification: $E = (1 - (1/2)^n) \\cdot 1 + (1/2)^n \\cdot (-(2^n - 1)) = 0$. This holds for all $n$, confirming that no finite-stopping strategy can beat a fair game — even one that 'always wins' when it stops."
+    ]
+  },
+  "sections": [
+    {
+      "id": "gamblers-ruin-concrete",
+      "title": "Concrete Gambler's Ruin Examples (Part I)",
+      "startLine": 21,
+      "endLine": 58,
+      "summary": "Two concrete GamblersRuin instances. game_5_10 (k=5, N=10): P(win)=1/2, E[T]=25 — symmetric fair game. game_1_10 (k=1, N=10): P(win)=1/10, E[T]=9 — severe underdog. Both proved by simp+norm_num dispatching to parent formulas."
+    },
+    {
+      "id": "doubling-strategy",
+      "title": "Doubling Strategy Algebra (Part II)",
+      "startLine": 60,
+      "endLine": 113,
+      "summary": "Formalizes the doubling betting system: doublingBet k = 2^k, total investment = 2^k-1 (geometric series via induction), win gain = 1 always. maxDoublings B = ⌊log₂(B+1)⌋ bounds the strategy's reach; proved via Nat.pow_log_le_self and Nat.log_pow."
+    },
+    {
+      "id": "expected-value-zero",
+      "title": "E[Doubling Strategy] = 0 (Part III)",
+      "startLine": 114,
+      "endLine": 137,
+      "summary": "doubling_expected_value_zero proves (1-(1/2)^n)·1 + (1/2)^n·(-(2^n-1)) = 0 for all n > 0. Direct ring computation via field_simp and ring, confirming the Fair Games Theorem for the doubling strategy."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 138,
+      "endLine": 159,
+      "summary": "Documents Part I (2 game instances, 0 sorries), Part II (doubling strategy, 0 sorries), Part III (expected value, 0 sorries). Total: 0 sorries, 0 axioms, all 10 theorems fully verified."
+    }
+  ],
+  "conclusion": {
+    "summary": "All 10 theorems are fully machine-verified with 0 sorries and 0 axioms. The file provides concrete numerical checks of the Optional Stopping Theorem: P(win) = k/N and E[T] = k(N-k) for Gambler's Ruin, and E[gain] = 0 for the doubling strategy. The proofs are short (1-4 lines each) because the mathematical content was established in the parent file.",
+    "implications": "The concrete examples demonstrate a key principle of probability theory: in any fair game, no betting strategy can improve the expected outcome. This is the mathematical reason casinos have a positive edge — they enforce a slight asymmetry (house edge) that makes the game unfair. The doubling strategy fails not because of mathematical subtlety but because of the exponential growth of required capital (2^n) versus the linear growth of the win (always $1). This exponential-linear gap is precisely captured by `maxDoublings`.",
+    "openQuestions": [
+      "Can the Optional Stopping Theorem itself (not just the Gambler's Ruin formulas) be formalized in Lean 4? Doob's theorem requires a filtered probability space and integrability conditions — is Mathlib's probability library sufficient?",
+      "The doubling strategy with a table maximum bet $M$ (as in real casinos) terminates differently: you can only double ⌊log₂(M)⌋ times before hitting the limit. Can this variant be formalized as a finite stopping time martingale?",
+      "What is the variance of the Gambler's Ruin stopping time? The expected value $k(N-k)$ is classical, but the variance formula is more complex. Can it be formally derived from the martingale $X_t^2 - t$?",
+      "For biased coins with P(win) = p ≠ 1/2, the ruin probability is $(1-(q/p)^k)/(1-(q/p)^N)$ for $p \\neq q$. Can this generalization be formalized as a new structure extending GamblersRuin?"
+    ]
+  }
 }


### PR DESCRIPTION
Enrichment pass for `fair-games-theorem-oq-02` (10 theorems, 0 sorries, 0 axioms).

## Quality improvements

**meta.json:**
- Added historicalContext: Huygens 1657, doubling strategy 18th century, Doob's OST 1953
- Added problemStatement and proofStrategy
- Added 5 keyInsights: symmetry of (5,10) game, underdog game, doubling win-guarantee invariant, bankroll logarithm, E=0 computation
- Added 4 sections covering all 159 lines
- Added crossReferences to parent fair-games-theorem
- Added conclusion with casino math implications and 4 open questions

**annotations.json (new file):**
- Added 5 annotations covering all major theorems with LaTeX mathContext