### PR TITLE
fix: remove True-stub theorems from 5 gallery proofs (batch 2)

### DIFF
--- a/proofs/Proofs/Erdos614Problem.lean
+++ b/proofs/Proofs/Erdos614Problem.lean
@@ -385,14 +385,13 @@ theorem f_case_k_eq_1 :
   -- preserving both hasPropertyP and edgeCount.
   sorry  -- Type transport via Fintype.equivFin
 
-/-- **FALSE THEOREM (removed)**: The original claimed k=n-2 forces complete graph.
+/- **FALSE THEOREM (removed)**: The original claimed k=n-2 forces complete graph.
     COUNTEREXAMPLE: The star graph K_{1,n-1} has n-1 edges and satisfies P(n-2),
     since the center has degree n-1 ≥ n-2 in the only n-subset (= V itself).
     So f(n, n-2) ≤ n-1 << n(n-1)/2 for n ≥ 4.
 
     The correct statement is: P(n-2) only requires max degree ≥ n-2 in the
     whole graph, which a single high-degree vertex achieves. -/
-theorem f_max_k_false_note : True := trivial
 
 /-
 ## Part 6: Monotonicity

--- a/proofs/Proofs/Erdos731Problem.lean
+++ b/proofs/Proofs/Erdos731Problem.lean
@@ -65,17 +65,15 @@ theorem centralBinom_five : centralBinom 5 = 252 := by native_decide
 
 /- ## Main Conjecture -/
 
-/-- **Erdős Problem #731** (OPEN): For almost all n, the least m with
+/- **Erdős Problem #731** (OPEN): For almost all n, the least m with
     m ∤ C(2n, n) satisfies m = exp((log n)^{1/2 + o(1)}).
     Placeholder: precise formulation requires asymptotic density. -/
-theorem erdos_731_conjecture : True := trivial
 
 /- ## Divisibility Properties of Central Binomials -/
 
-/-- **Kummer's Theorem**: The p-adic valuation of C(m+n, m) equals the
+/- **Kummer's Theorem**: The p-adic valuation of C(m+n, m) equals the
     number of carries when adding m and n in base p.
     Placeholder: full formalization needs p-adic valuations. -/
-theorem kummer_carries (p m n : ℕ) (hp : Nat.Prime p) : True := trivial
 
 /-- For prime p ≤ 2n, we have p | C(2n, n) iff there is at least one
     carry when adding n to itself in base p. -/
@@ -113,9 +111,8 @@ theorem two_divides_central (n : ℕ) (hn : n ≥ 1) : 2 ∣ centralBinom n := b
   rw [pascal, sym, ← two_mul]
   exact dvd_mul_right 2 _
 
-/-- The product of all primes ≤ x is roughly e^x (prime number theorem).
+/- The product of all primes ≤ x is roughly e^x (prime number theorem).
     Placeholder: full formalization needs Chebyshev functions. -/
-theorem primorial_asymptotic : True := trivial
 
 /- ## Asymptotic Analysis -/
 
@@ -129,10 +126,9 @@ theorem least_nondiv_counterexample : ¬Nat.Prime 4 ∧ centralBinom 2 = 6 := by
   · decide
   · native_decide
 
-/-- **EGRS (1975)**: The typical behavior is
+/- **EGRS (1975)**: The typical behavior is
     log(leastNonDivCentral n) ~ (log n)^{1/2}.
     Placeholder: full formalization needs probabilistic number theory. -/
-theorem egrs_typical_behavior : True := trivial
 
 /- ## Bounds -/
 

--- a/proofs/Proofs/Erdos864Problem.lean
+++ b/proofs/Proofs/Erdos864Problem.lean
@@ -485,7 +485,7 @@ theorem sidon_card_sq_le_2N (A : Finset ℕ) (N : ℕ) (hN : 0 < N)
   · have h_eq : (n + 1) ^ 2 = (n + 1) * n + (n + 1) := by ring
     omega
 
-/-- **FALSE (removed)**: The original claimed k(k+1)/2 - 1 ≤ 2N - 1 for
+/- **FALSE (removed)**: The original claimed k(k+1)/2 - 1 ≤ 2N - 1 for
     almost-Sidon A ⊆ {1,...,N} with |A| = k.
 
     COUNTEREXAMPLE: A = {1, 2, 4, 6, 7} ⊆ {1,...,7} is almost-Sidon
@@ -497,7 +497,6 @@ theorem sidon_card_sq_le_2N (A : Finset ℕ) (N : ℕ) (hN : 0 < N)
     strictly less than k(k+1)/2 - 1. The correct bound is:
     #{distinct sums} ≤ 2N - 1, i.e., k(k+1)/2 - (c-1) ≤ 2N - 1.
     The correct PROVED bound is `distinct_sums_bounded` above. -/
-theorem almost_sidon_sum_range_false_note : True := trivial
 
 /-- IsSidon means every sum has at most one representation. -/
 private lemma isSidon_sumRepCount_le_one {B : Finset ℕ} (hS : IsSidon B) (n : ℕ) :

--- a/proofs/Proofs/FundamentalTheoremCalculusLebesgue.lean
+++ b/proofs/Proofs/FundamentalTheoremCalculusLebesgue.lean
@@ -235,16 +235,14 @@ theorem monotone_ae_differentiable {f : ℝ → ℝ} (hf : Monotone f) :
     ∀ᵐ x ∂volume, DifferentiableAt ℝ f x :=
   hf.ae_differentiableAt
 
-/-- The Vitali covering theorem exists in Mathlib (`VitaliFamily`).
+/- The Vitali covering theorem exists in Mathlib (`VitaliFamily`).
 Vitali families provide the abstract framework for differentiation
 of measures, which underlies the proof that monotone functions are
 a.e. differentiable. -/
-theorem vitali_family_exists : True := trivial
 
-/-- The Lebesgue density theorem exists in Mathlib
+/- The Lebesgue density theorem exists in Mathlib
 (`VitaliFamily.ae_tendsto_measure_inter_div`).
 For a measurable set S: μ(S ∩ B(x,r)) / μ(B(x,r)) → 1_{S}(x) a.e. -/
-theorem lebesgue_density_exists : True := trivial
 
 -- ═══════════════════════════════════════════════════════════════
 -- Summary

--- a/proofs/Proofs/ParallelPostulateIndependence.lean
+++ b/proofs/Proofs/ParallelPostulateIndependence.lean
@@ -127,12 +127,11 @@ structure NeutralGeometry extends IncidenceGeometry where
     ℝ² as a model of incidence geometry. -/
 axiom euclidean_incidence_geometry : IncidenceGeometry
 
-/-- **Axiom:** The Euclidean plane satisfies neutral geometry.
+/- **Axiom:** The Euclidean plane satisfies neutral geometry.
 
     **Why an axiom?** Proving this requires verifying all neutral geometry axioms
     (incidence, betweenness, congruence, continuity) for ℝ². This is extensive
     but standard; we focus on the parallel postulate aspect. -/
-theorem euclidean_is_neutral : True := trivial
 
 /-- **Axiom:** The Euclidean plane satisfies the parallel postulate.
 
@@ -153,7 +152,7 @@ axiom euclidean_satisfies_parallel_postulate :
     2. Arcs of circles orthogonal to the unit circle -/
 axiom poincare_incidence_geometry : IncidenceGeometry
 
-/-- **Axiom:** The Poincaré disk satisfies neutral geometry.
+/- **Axiom:** The Poincaré disk satisfies neutral geometry.
 
     **Why an axiom?** The Poincaré disk model satisfies all neutral geometry
     axioms. Proving this requires:
@@ -163,7 +162,6 @@ axiom poincare_incidence_geometry : IncidenceGeometry
     4. Showing Dedekind continuity holds
 
     This was Beltrami's key contribution (1868). -/
-theorem poincare_is_neutral : True := trivial
 
 /-- **Axiom:** The Poincaré disk has the hyperbolic parallel property.
 

--- a/src/data/proofs/erdos-614/meta.json
+++ b/src/data/proofs/erdos-614/meta.json
@@ -165,9 +165,9 @@
       "Finset"
     ],
     "namespace": "Erdos614",
-    "lineCount": 454,
+    "lineCount": 453,
     "axiomCount": 2,
-    "theoremCount": 12,
+    "theoremCount": 11,
     "definitionCount": 7
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-731/meta.json
+++ b/src/data/proofs/erdos-731/meta.json
@@ -143,9 +143,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 305,
+    "lineCount": 301,
     "axiomCount": 3,
-    "theoremCount": 9,
+    "theoremCount": 5,
     "definitionCount": 3
   },
   "references": [

--- a/src/data/proofs/erdos-864/meta.json
+++ b/src/data/proofs/erdos-864/meta.json
@@ -158,9 +158,9 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 823,
+    "lineCount": 822,
     "axiomCount": 1,
-    "theoremCount": 22,
+    "theoremCount": 21,
     "definitionCount": 5
   }
 }

--- a/src/data/proofs/fundamental-theorem-calculus-oq-01/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus-oq-01/meta.json
@@ -154,9 +154,9 @@
       "intervalIntegral"
     ],
     "namespace": "FTCLebesgue",
-    "lineCount": 276,
+    "lineCount": 274,
     "axiomCount": 2,
-    "theoremCount": 7,
+    "theoremCount": 5,
     "definitionCount": 1
   },
   "crossReferences": [

--- a/src/data/proofs/parallel-postulate-independence/meta.json
+++ b/src/data/proofs/parallel-postulate-independence/meta.json
@@ -172,9 +172,9 @@
     ],
     "opens": [],
     "namespace": "ParallelPostulate",
-    "lineCount": 314,
+    "lineCount": 312,
     "axiomCount": 7,
-    "theoremCount": 3,
+    "theoremCount": 1,
     "definitionCount": 3
   },
   "references": [


### PR DESCRIPTION
## Fix

Removes 10 True-stub theorems from 5 gallery proofs, continuing the cleanup started in PR #8645.

## Evidence

**Before**: Each affected theorem proved `True := trivial` — a placeholder conveying no mathematical content but inflating theorem counts and misleading proof checkers.

**After**: Docstrings converted to block comments (`/-` instead of `/--`), preserving the explanatory content without masquerading as theorems.

### Files and stubs removed

| File | Stubs removed |
|------|--------------|
| `Erdos731Problem.lean` | `erdos_731_conjecture`, `kummer_carries`, `primorial_asymptotic`, `egrs_typical_behavior` |
| `Erdos614Problem.lean` | `f_max_k_false_note` |
| `Erdos864Problem.lean` | `almost_sidon_sum_range_false_note` |
| `FundamentalTheoremCalculusLebesgue.lean` | `vitali_family_exists`, `lebesgue_density_exists` |
| `ParallelPostulateIndependence.lean` | `euclidean_is_neutral`, `poincare_is_neutral` |

Updated `leanFile.lineCount` and `leanFile.theoremCount` in corresponding meta.json files.

---
Automated fix by lean-mechanic agent.