### PR TITLE
Enrich: Multinomial Analogs of Kummer's Theorem (kummer-theorem-oq-01)

### DIFF
--- a/src/data/proofs/kummer-theorem-oq-01/annotations.json
+++ b/src/data/proofs/kummer-theorem-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-kum01-multinomial-def",
+    "proofId": "kummer-theorem-oq-01",
+    "range": { "startLine": 24, "endLine": 33 },
+    "type": "definition",
+    "title": "Multinomial Coefficient: n! / (k₁! · ... · kₘ!)",
+    "content": "The multinomial coefficient `multinomial (ks : List ℕ)` is defined as `(ks.sum).factorial / (ks.map Nat.factorial).prod` — that is, n! / (k₁! · k₂! · ... · kₘ!) where n = k₁ + ... + kₘ. The `noncomputable` annotation is needed because natural number division of factorials is not decidably computable in Lean's kernel (it relies on classical logic). The definition generalizes `Nat.choose (a + b) a = (a+b)! / (a! · b!)` from 2 parts to arbitrarily many.",
+    "mathContext": "The multinomial coefficient $\\binom{n}{k_1, k_2, \\ldots, k_m} = \\frac{n!}{k_1! \\cdot k_2! \\cdots k_m!}$ counts the number of ways to arrange $n$ objects divided into $m$ groups of sizes $k_1, \\ldots, k_m$, equivalently the number of ways to partition a set of $n$ elements into labeled groups of those sizes. It equals the coefficient of $x_1^{k_1} x_2^{k_2} \\cdots x_m^{k_m}$ in $(x_1 + x_2 + \\cdots + x_m)^n$.",
+    "significance": "key",
+    "relatedConcepts": ["multinomial theorem", "counting partitions", "p-adic valuation", "Kummer's theorem"],
+    "prerequisites": ["factorials", "natural number division", "Lean noncomputable definitions"]
+  },
+  {
+    "id": "ann-kum01-iterated-decomp",
+    "proofId": "kummer-theorem-oq-01",
+    "range": { "startLine": 35, "endLine": 45 },
+    "type": "technique",
+    "title": "Iterated Binomial Decomposition via scanl",
+    "content": "The theorem `multinomial_eq_prod_choose` expresses the multinomial coefficient as a product of binomials. The Lean formulation uses `List.scanl (· + ·) 0` to compute partial sums [0, k₁, k₁+k₂, ...], then zips with the original list to form pairs (accumulatedSum, k_i). Each pair (acc, k) contributes `Nat.choose acc k` to the product. The `.tail` removes the initial (0, k₁) element which would give choose 0 k₁ = 0. This sorry is the general case requiring list induction.",
+    "mathContext": "The decomposition $\\binom{n}{k_1, \\ldots, k_m} = \\binom{k_1}{k_1} \\cdot \\binom{k_1+k_2}{k_2} \\cdot \\binom{k_1+k_2+k_3}{k_3} \\cdots \\binom{n}{k_m}$ or equivalently $\\prod_{i=1}^{m} \\binom{\\sum_{j=1}^{i} k_j}{k_i}$ follows from telescoping: $\\frac{n!}{\\prod k_j!} = \\frac{(k_1+k_2)!}{k_1! k_2!} \\cdot \\frac{(k_1+k_2+k_3)!}{(k_1+k_2)! k_3!} \\cdots \\frac{n!}{(n-k_m)! k_m!}$.",
+    "significance": "key",
+    "relatedConcepts": ["telescoping products", "List.scanl", "binomial coefficients", "induction on lists"],
+    "prerequisites": ["multinomial coefficient", "Nat.choose", "list operations in Lean"]
+  },
+  {
+    "id": "ann-kum01-pair-case",
+    "proofId": "kummer-theorem-oq-01",
+    "range": { "startLine": 47, "endLine": 51 },
+    "type": "insight",
+    "title": "Pair Case: Fully Proved via Nat.add_choose_eq",
+    "content": "The theorem `multinomial_pair` is the base case: `multinomial [a, b] = Nat.choose (a + b) a`. The proof is a single `simp` call using `Nat.add_choose_eq`, which states `choose (a+b) a = (a+b)! / (a! · b!)` (matching the definition). This confirms the multinomial definition is correct and consistent with the standard binomial coefficient. It also validates the approach: the pair case needs no induction, just unfolding the list operations.",
+    "mathContext": "For two parts: $\\binom{a+b}{a,b} = \\frac{(a+b)!}{a! \\cdot b!} = \\binom{a+b}{a}$. This is the binomial coefficient, and `Nat.add_choose_eq` in Mathlib states precisely $\\binom{a+b}{a} = (a+b)! / (a! \\cdot (a+b-a)!)$, which matches after noting $b = (a+b) - a$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.add_choose_eq", "Mathlib binomial coefficients", "list simp lemmas"],
+    "prerequisites": ["multinomial definition", "Nat.choose in Mathlib"]
+  },
+  {
+    "id": "ann-kum01-triple-case",
+    "proofId": "kummer-theorem-oq-01",
+    "range": { "startLine": 53, "endLine": 67 },
+    "type": "technique",
+    "title": "Triple Case: Factorial Rearrangement Complete, Division Sorry",
+    "content": "The theorem `multinomial_triple` states `multinomial [a, b, c] = choose (a+b) a * choose (a+b+c) (a+b)`. The proof makes significant progress: it rewrites the sum `a + (b + (c + 0)) = a+b+c` (using `omega`), rearranges the factorial product `a! · (b! · (c! · 1)) = a! · b! · c!` (using `ring`), and then expands both choose terms via `Nat.choose_eq_factorial_div_factorial`. The remaining sorry is the natural number division identity showing `(a+b+c)! / (a! · b! · c!) = ((a+b)! / (a! · b!)) * ((a+b+c)! / ((a+b)! · c!))`. This requires `Nat.div_mul_div_comm` or a similar lemma.",
+    "mathContext": "The identity needed is: $\\frac{(a+b+c)!}{a! \\cdot b! \\cdot c!} = \\frac{(a+b)!}{a! \\cdot b!} \\cdot \\frac{(a+b+c)!}{(a+b)! \\cdot c!}$. The RHS factors share $(a+b)!$ which cancels: $\\frac{(a+b)! \\cdot (a+b+c)!}{a! \\cdot b! \\cdot (a+b)! \\cdot c!} = \\frac{(a+b+c)!}{a! \\cdot b! \\cdot c!}$. In Lean, this requires that the denominators divide the numerators (non-trivial for `Nat.div`).",
+    "significance": "key",
+    "relatedConcepts": ["Nat.choose_eq_factorial_div_factorial", "Nat.div_mul_div_comm", "natural number division"],
+    "prerequisites": ["Nat.factorial divisibility", "Lean omega tactic", "ring tactic"]
+  },
+  {
+    "id": "ann-kum01-statement-stub",
+    "proofId": "kummer-theorem-oq-01",
+    "range": { "startLine": 60, "endLine": 68 },
+    "type": "context",
+    "title": "Kummer Multinomial Statement: Placeholder for Carry-Count Theorem",
+    "content": "The theorem `kummer_multinomial_statement` is a placeholder that returns `True` (via `trivial`). It documents the intended theorem — v_p(multinomial ks) = total carries when adding elements of ks in base p — without formalizing it. This is a deliberate design choice: the carry-counting formalism for base-p arithmetic is not currently in Mathlib, and formalizing it would require a separate development. The placeholder allows the file to document the mathematical goal while acknowledging the gap. This honest stub approach is characteristic of the gallery's formalized-but-not-complete status.",
+    "mathContext": "The full theorem would state: for prime $p$ and list $[k_1,\\ldots,k_m]$ with sum $n$, $v_p\\binom{n}{k_1,\\ldots,k_m} = \\sum_{i=1}^{m-1} c(k_i, k_1+\\cdots+k_{i-1}; p)$ where $c(a,b;p)$ counts carries when adding $a$ and $b$ in base $p$. By Kummer's theorem applied to each binomial factor in the decomposition and summing, $v_p(\\prod \\binom{S_i}{k_i}) = \\sum v_p\\binom{S_i}{k_i} = \\sum c(k_i, S_{i-1}; p)$.",
+    "significance": "context",
+    "relatedConcepts": ["p-adic valuation", "base-p carries", "Kummer's theorem", "Lean stub design"],
+    "prerequisites": ["Kummer's theorem (parent proof)", "p-adic valuation in Mathlib"]
+  }
+]

--- a/src/data/proofs/kummer-theorem-oq-01/meta.json
+++ b/src/data/proofs/kummer-theorem-oq-01/meta.json
@@ -21,5 +21,60 @@
     "definitionCount": 1,
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-03-30"
+  },
+  "crossReferences": [
+    {
+      "targetId": "kummer-theorem",
+      "relationship": "extends",
+      "description": "Generalizes Kummer's theorem from binomial coefficients C(n,k) to multinomial coefficients C(n; k₁,...,kₘ) via iterated binomial decomposition"
+    }
+  ],
+  "overview": {
+    "historicalContext": "Ernst Kummer proved in 1852 that the highest power of a prime p dividing the binomial coefficient C(n, k) equals the number of carries when adding k and n-k in base p. This elegant theorem connects combinatorics (counting subsets) with the arithmetic of positional numeral systems. The result was rediscovered and generalized throughout the 20th century. The multinomial extension is a natural question: the multinomial coefficient C(n; k₁, k₂, ..., kₘ) counts the number of ways to partition n objects into groups of sizes k₁, ..., kₘ (with n = k₁ + ... + kₘ). The key insight is that multinomial coefficients factor as products of binomials via a telescoping decomposition: C(n; k₁,...,kₘ) = C(k₁+k₂, k₁) · C(k₁+k₂+k₃, k₁+k₂) · ... · C(n, n-kₘ). Applying Kummer's theorem to each factor and summing gives the total carry count when adding k₁, k₂, ..., kₘ successively in base p.",
+    "problemStatement": "Can Kummer's theorem — $v_p\\binom{n}{k} = c(k, n-k; p)$ where $c$ counts base-$p$ carries — be extended to multinomial coefficients? That is, does $v_p\\binom{n}{k_1,\\ldots,k_m} = $ total carries when adding $k_1,\\ldots,k_m$ in base $p$? Answer: yes, via iterated binomial decomposition.",
+    "proofStrategy": "The file defines the multinomial coefficient as n! / (k₁! · ... · kₘ!) using `List.sum` and `List.prod`. The key identity `multinomial_eq_prod_choose` expresses this as a product of binomials via `List.scanl` accumulation. `multinomial_pair` is fully proved (reduces to `Nat.add_choose_eq`). `multinomial_triple` is partially proved: the factorial rearrangement is complete but the final division step has a sorry. `kummer_multinomial_statement` is a placeholder stub (returns `True`).",
+    "keyInsights": [
+      "The iterated decomposition $\\binom{n}{k_1,\\ldots,k_m} = \\prod_{i=1}^{m} \\binom{k_1+\\cdots+k_i}{k_1+\\cdots+k_{i-1}}$ is the algebraic heart of the extension. Each factor is an ordinary binomial to which Kummer's theorem applies directly.",
+      "Kummer's theorem for each binomial factor gives $v_p\\binom{k_1+\\cdots+k_i}{k_1+\\cdots+k_{i-1}} = c(k_i, k_1+\\cdots+k_{i-1}; p)$ — the carries when adding the $i$-th part to the running sum. Summing over all $i$ gives the total carries for adding all parts.",
+      "The Lean definition uses `List.scanl (· + ·) 0` to compute running sums, then `zip`s with the original list to form the binomial argument pairs. This matches the mathematical telescoping exactly, but the general proof requires list induction on `ks`.",
+      "The pair case `multinomial_pair` is trivially proved using `Nat.add_choose_eq`, confirming the definition is correct. The triple case requires the identity $(a+b+c)!/(a! \\cdot b! \\cdot c!) = (\\binom{a+b}{a})(\\binom{a+b+c}{a+b})$, proved up to the final factorial division.",
+      "The placeholder `kummer_multinomial_statement` returns `True` — a design choice to document the theorem statement without formalizing the full proof, which would require Kummer's theorem from Mathlib and a carry-counting formalism for base-p arithmetic."
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Module Header and Mathematical Overview",
+      "startLine": 1,
+      "endLine": 22,
+      "summary": "Imports Mathlib and provides a detailed docstring explaining the open question (can Kummer's theorem extend to multinomials?), the iterated binomial decomposition identity, and the key results to be proved."
+    },
+    {
+      "id": "definition",
+      "title": "Multinomial Coefficient Definition",
+      "startLine": 24,
+      "endLine": 33,
+      "summary": "Defines `multinomial (ks : List ℕ) : ℕ` as `(ks.sum).factorial / (ks.map Nat.factorial).prod` — i.e., n! / (k₁! · k₂! · ... · kₘ!). Marked `noncomputable` due to natural number division."
+    },
+    {
+      "id": "decomposition",
+      "title": "Binomial Factorization and Pair/Triple Cases",
+      "startLine": 35,
+      "endLine": 68,
+      "summary": "Three theorems: (1) `multinomial_eq_prod_choose` — general decomposition via scanl/zip (sorry); (2) `multinomial_pair` — fully proved base case reducing to Nat.add_choose_eq; (3) `multinomial_triple` — partial proof for trinomial case, factorial rearrangement complete but final division step sorry. Plus `kummer_multinomial_statement` stub returning True."
+    }
+  ],
+  "conclusion": {
+    "summary": "This file establishes the algebraic scaffolding for the multinomial extension of Kummer's theorem. The definition is correct (confirmed by `multinomial_pair`), the general factorization identity is stated and the triple case is partially proved. The full formalization requires completing two sorries and replacing the `kummer_multinomial_statement` stub with the actual carry-counting argument.",
+    "implications": "The multinomial Kummer theorem has applications in combinatorics (divisibility of multinomial coefficients, Lucas-type theorems for multinomials), algebraic topology (p-local decompositions of symmetric products), and number theory (p-adic valuations of products of factorials). The iterated binomial decomposition technique appears in other combinatorial contexts, such as q-analogs of multinomial coefficients.",
+    "openQuestions": [
+      "Can `multinomial_eq_prod_choose` be proved by list induction on `ks`? The `scanl`/`zip`/`tail` combination requires careful induction hypotheses about the accumulated running sum.",
+      "Can the sorry in `multinomial_triple` be closed? It requires the identity $(a+b+c)!/(a! \\cdot b! \\cdot c!) = ((a+b)!/(a! \\cdot b!)) \\cdot ((a+b+c)!/((a+b)! \\cdot c!))$ which is a natural number division identity needing `Nat.div_mul_div_comm` or similar.",
+      "Can `kummer_multinomial_statement` be formalized using Kummer's theorem from Mathlib? This would require a Lean formalism for base-p carries (not yet in Mathlib) and induction over the telescoping product.",
+      "Is there a q-analog? The q-binomial coefficient (Gaussian binomial) satisfies a Kummer-like theorem; the q-multinomial analog is less well-studied."
+    ]
+  },
+  "leanFile": {
+    "axiomCount": 0
   }
 }


### PR DESCRIPTION
## Summary

- Enriches `kummer-theorem-oq-01` (Multinomial Analogs of Kummer's Theorem) with full gallery metadata
- Adds `historicalContext`: Kummer 1852 → iterated decomposition → p-adic carry-count extension
- Adds 3 sections covering all 68 Lean lines
- Adds 5 `keyInsights` on telescoping decomposition, carry-count proof strategy, `List.scanl` encoding, proved pair case, and stub design
- Adds `conclusion` with 4 open questions on closing sorries and q-analogs
- Creates `annotations.json` with 5 annotations covering key mathematical concepts

## Annotations Added

1. **Multinomial Coefficient Definition** — `n! / (k₁! · ... · kₘ!)` via List ops
2. **Iterated Binomial Decomposition via scanl** — telescoping product technique
3. **Pair Case: Fully Proved** — base case via `Nat.add_choose_eq`
4. **Triple Case: Partial Proof** — factorial rearrangement complete, division sorry
5. **Kummer Multinomial Statement Stub** — `True` placeholder for carry-count theorem

🤖 Generated with [Claude Code](https://claude.com/claude-code)