### PR TITLE
fix: remove True-stub theorems from 5 gallery proofs (batch 3)

### DIFF
--- a/proofs/Proofs/BorsukUlamOQ03.lean
+++ b/proofs/Proofs/BorsukUlamOQ03.lean
@@ -71,7 +71,7 @@ The simplest case: a continuous function on [-1, 1] must have
 an antipodal pair where f(x) = f(-x).
 -/
 
-/-- **1D Borsuk-Ulam Theorem (Interval Version)**
+/- **1D Borsuk-Ulam Theorem (Interval Version)**
 
     For any continuous f: [-1, 1] → ℝ, there exists x ∈ [-1, 1]
     such that f(x) = f(-x).
@@ -2108,7 +2108,6 @@ theorem no_retraction_implies_brouwer_1d :
     - No-retraction 1D ✓ (Section XLIV)
     - BU → Brouwer FP ✓ (Section XLIV, bu_implies_brouwer_1d)
     - No-retraction proved ✓ (Section XLIV, no_retraction_1d) -/
-theorem equivalence_chain_1d_summary : True := trivial
 
 /-
 ## Section XLV: Tucker-BU Bridge (Why Tucker ↔ BU)
@@ -2132,7 +2131,7 @@ boundary (by the antipodal constraint), it must end at an interior
 complementary edge. This is completely algorithmic.
 -/
 
-/-- **Tucker path-following terminates (1D version)**: In Tucker's 1D lemma,
+/- **Tucker path-following terminates (1D version)**: In Tucker's 1D lemma,
     the "path" is just a scan from left to right finding the first sign change.
     This is an O(n) algorithm, making 1D Tucker completely constructive. -/
 theorem tucker_path_following_1d (n : ℕ) (s : Fin (n + 2) → Bool)
@@ -2196,7 +2195,6 @@ theorem tucker_path_following_1d (n : ℕ) (s : Fin (n + 2) → Bool)
     - Commentary: why Tucker's lemma is more constructive than BU in higher dim
 
     **Grand total**: 94 + ~12 = ~106 proved results, 4 axioms, 0 sorries. -/
-theorem bu_session_summary_xlii_xlv : True := trivial
 
 /-
 ## Section XLVII: Sperner's 2D Lemma (Minimal Triangulation)
@@ -2222,7 +2220,7 @@ If C has label 3: triangle {v1,v2,C} has labels {1,2,3} — rainbow!
 So for ANY label assignment, a rainbow sub-triangle always exists.
 -/
 
-/-- **Sperner's 2D Lemma (minimal triangulation)**:
+/- **Sperner's 2D Lemma (minimal triangulation)**:
 
     Triangle with vertices labeled 1, 2, 3. One interior point C labeled c.
     Sub-triangles: {1,2,c}, {2,3,c}, {3,1,c}. A rainbow triangle always exists.
@@ -2460,7 +2458,6 @@ In nD (AXIOMIZED, n ≥ 2):
 
     In 1D, all nodes are PROVED. In nD, the axioms (BU, no-retraction,
     Brouwer FP, LS) are independent formal axioms but mathematically equivalent. -/
-theorem equivalence_web_summary : True := trivial
 
 /-
 ## Section L: The Complete 1D Equivalence Chain (Formal Composition)
@@ -2474,7 +2471,7 @@ are equivalent. The chain is:
 Each arrow is a formally proved implication (not a sketch).
 -/
 
-/-- **KKM → Brouwer FP (1D, composed)**: Composing KKM → No-retraction (Section XLVIII)
+/- **KKM → Brouwer FP (1D, composed)**: Composing KKM → No-retraction (Section XLVIII)
     with No-retraction → Brouwer FP (Section XLIV).
 
     This closes the chain: KKM 1D implies the Brouwer Fixed Point theorem.
@@ -2551,7 +2548,6 @@ theorem brouwer_implies_no_retraction_1d
     - KKM → Brouwer FP (kkm_implies_brouwer_1d, composed)
 
     All results are provably equivalent via IVT in Lean 4. -/
-theorem equivalence_cycle_1d : True := trivial
 
 /-
 ## Section LI: Combinatorial Degree for 1D Functions
@@ -2573,7 +2569,7 @@ For the odd part g(x) = f(x) - f(-x):
 So if g(-1) ≠ 0, g has opposite signs at ±1, and total_deg(g) is odd.
 -/
 
-/-- The sign function on ℝ: +1 for positive, -1 for negative, 0 at zero. -/
+/- The sign function on ℝ: +1 for positive, -1 for negative, 0 at zero. -/
 noncomputable def realSign (x : ℝ) : ℤ :=
   if x > 0 then 1
   else if x < 0 then -1
@@ -2903,7 +2899,6 @@ theorem circle_bu_two_pairs (f : ℝ → ℝ) (hf : Continuous f)
 
     **Grand total**: ~130+ proved results, 4 axioms, ~4 sorries
     (sorries are in quantitative bounds requiring bisection bracket analysis). -/
-theorem bu_session_4_summary : True := trivial
 
 /-
 ## Section LVI: Lyusternik-Shnirelmann (LS) Covering Theorem (1D)
@@ -2917,7 +2912,7 @@ Proof via BU: apply BU to f(x) = infDist(x, A₀). BU gives x₀ with
 infDist(x₀, A₀) = infDist(-x₀, A₀). If = 0, both in A₀. If > 0, both in A₁.
 -/
 
-/-- **LS Covering (1D, closed)**: Two closed sets covering [-1,1] ⇒
+/- **LS Covering (1D, closed)**: Two closed sets covering [-1,1] ⇒
     one contains an antipodal pair. -/
 theorem ls_covering_interval (A₀ A₁ : Set ℝ)
     (hA₀_closed : IsClosed A₀) (hA₁_closed : IsClosed A₁)
@@ -3101,7 +3096,6 @@ All arrows are proved. BU ↔ LS is the key new result.
 
 /-- **Complete equivalence web with LS**: BU ↔ LS proved via
     infDist argument (BU→LS) and antisymmetric cover (LS→BU). -/
-theorem equivalence_web_with_ls : True := trivial
 
 /-
 ## Section LX: BU → LS General (Axiom Reduction)
@@ -3125,7 +3119,7 @@ Apply BU to get x₀ with f(x₀) = f(-x₀). Then either:
   into Uₙ by the covering hypothesis.
 -/
 
-/-- Helper: Fin decomposition — every j : Fin (n+1) is either
+/- Helper: Fin decomposition — every j : Fin (n+1) is either
     Fin.castSucc k for some k : Fin n, or Fin.last n. -/
 private theorem fin_castSucc_or_last {n : ℕ} (j : Fin (n + 1)) :
     (∃ k : Fin n, j = Fin.castSucc k) ∨ j = Fin.last n := by
@@ -3314,7 +3308,6 @@ theorem ls_axiom_redundant :
     0 sorries. The complete 1D equivalence web (BU ↔ Tucker ↔ Sperner ↔
     Brouwer FP ↔ No-retraction ↔ KKM ↔ LS) extends to general dimensions
     via the infDist technique. -/
-theorem bu_session_5_summary : True := trivial
 
 /-
 ## Section LXIII: Ray-Sphere Intersection and No-Retraction → Brouwer FP
@@ -3334,7 +3327,7 @@ When x ∈ S^n: t = 1 is a root (since |x| = 1), and the product of roots
 is C/A = (|f(x)|²-1)/|d|² ≤ 0, so t₊ = 1 and r(x) = x.
 -/
 
-/-- Inner product on Fin k → ℝ (sum of coordinate products). -/
+/- Inner product on Fin k → ℝ (sum of coordinate products). -/
 noncomputable def ip (k : ℕ) (a b : Fin k → ℝ) : ℝ := ∑ i, a i * b i
 
 /-- Norm squared on Fin k → ℝ (sum of coordinate squares). -/
@@ -3687,7 +3680,6 @@ where p = ballProj and t is the raySphereT formula.
 - Continuity proved in Section LXIX via radial extension infrastructure
 - Prove BU → no_retraction via degree theory (reduces axioms 2 → 1)
 -/
-theorem bu_session_6_summary : True := trivial
 
 /-
 ## Section LXVII: BU → No Retraction (Axiom Reduction to 1)
@@ -3715,7 +3707,7 @@ Key properties:
   so the pasting lemma applies to the closed hemispheres.
 -/
 
-/-- Projection to first n+1 coordinates (dropping the last one). -/
+/- Projection to first n+1 coordinates (dropping the last one). -/
 noncomputable def proj (n : ℕ) (x : Fin (n+2) → ℝ) : Fin (n+1) → ℝ :=
   fun i => x (Fin.castSucc i)
 
@@ -4381,7 +4373,6 @@ All 4 axioms declared, 3 are now theorems. **0 sorries remaining!**
   (c) x₀_{n+1} = 0: filter argument using both branches → same limit
   (d) x₀ = 0: squeeze via bounds + normSqrt → 0
 -/
-theorem bu_session_7_summary : True := trivial
 
 -- ═══════════════════════════════════════════════════════════════════
 -- Section LXIX: Applications of Borsuk-Ulam
@@ -4452,17 +4443,15 @@ theorem ham_sandwich_general (d : ℕ) (hd : 1 ≤ d) :
   · intro b _ hb; simp [hb]
   · intro h; exact absurd (Finset.mem_univ _) h
 
-/-- The proof chain showing Ham Sandwich follows from BU. -/
-theorem ham_sandwich_from_bu (d : ℕ) (hd : 1 ≤ d) :
-    -- The proof uses BU on S^{d-1} for the direction, IVT for the offset
-    -- Proof outline:
-    -- 1. For fixed direction v ∈ S^{d-1}, each measure μ_i gives a continuous
-    --    function t ↦ μ_i({x : ⟨x,v⟩ ≤ t}) that is monotone 0 → μ_i(ℝ^d)
-    -- 2. By IVT, there's a unique t_i bisecting μ_i
-    -- 3. Map v ↦ (t_1(v) - t_d(v), ..., t_{d-1}(v) - t_d(v)) is continuous S^{d-1} → ℝ^{d-1}
-    -- 4. This map is odd (flipping v flips the halfspaces, exchanging t and -t)
-    -- 5. BU gives v₀ with all differences = 0, so t_1 = ... = t_d (common bisector)
-    True := trivial
+/- The proof chain showing Ham Sandwich follows from BU.
+    The proof uses BU on S^{d-1} for the direction, IVT for the offset.
+    Proof outline:
+    1. For fixed direction v ∈ S^{d-1}, each measure μ_i gives a continuous
+       function t ↦ μ_i({x : ⟨x,v⟩ ≤ t}) that is monotone 0 → μ_i(ℝ^d)
+    2. By IVT, there's a unique t_i bisecting μ_i
+    3. Map v ↦ (t_1(v) - t_d(v), ..., t_{d-1}(v) - t_d(v)) is continuous S^{d-1} → ℝ^{d-1}
+    4. This map is odd (flipping v flips the halfspaces, exchanging t and -t)
+    5. BU gives v₀ with all differences = 0, so t_1 = ... = t_d (common bisector) -/
 
 /-- The Necklace Splitting Theorem (Alon-West 1986):
     A necklace with t·k beads of each of k colors can be fairly divided
@@ -4542,18 +4531,16 @@ theorem kneser_formula_check :
     the general proof uses connectivity of the neighborhood complex). -/
 theorem petersen_chromatic : (kneserExamples[0]!).chromaticNumber = 3 := rfl
 
-/-- Lovász's proof technique for Kneser's conjecture:
+/- Lovász's proof technique for Kneser's conjecture:
     1. Build the "neighborhood complex" N(G) of the Kneser graph
     2. Show N(KG(n,k)) is (n-2k)-connected (using BU!)
     3. Apply Lovász's Topological Bound: χ(G) ≥ conn(N(G)) + 3
     4. Therefore χ(KG(n,k)) ≥ (n-2k) + 3 - 1 = n-2k+2
 
     The upper bound χ ≤ n-2k+2 is easy: color each k-subset by its minimum element.
-    Together: χ(KG(n,k)) = n-2k+2. -/
-theorem lovasz_kneser_proof_structure :
-    -- The proof uses BU at a critical step to show N(KG(n,k)) is highly connected
-    -- This was the founding result of "topological combinatorics"
-    True := trivial
+    Together: χ(KG(n,k)) = n-2k+2.
+    The proof uses BU at a critical step to show N(KG(n,k)) is highly connected.
+    This was the founding result of "topological combinatorics". -/
 
 /-- Summary of the BU implication web.
     BU sits at the center of a remarkable network of equivalent statements:
@@ -4715,28 +4702,22 @@ theorem antipodal_degree_alt (n : ℕ) :
   unfold antipodalDegree
   ring
 
-/-- Key theorem: An odd continuous map f: S^n → S^n has odd degree.
+/- Key theorem: An odd continuous map f: S^n → S^n has odd degree.
     Combined with BU: if f: S^n → ℝ^n is continuous and odd,
     then f must have a zero (because the induced map to S^{n-1}
-    would have undefined degree at the zero). -/
-theorem odd_map_odd_degree (n : ℕ) (hn : 1 ≤ n) :
-    -- Every odd continuous map f: S^n → S^n has odd degree
-    -- In particular, deg(f) ≠ 0, so f is surjective
-    -- (Full formalization requires degree theory / homology not yet in Mathlib)
-    True := trivial
+    would have undefined degree at the zero).
+    Every odd continuous map f: S^n → S^n has odd degree; in particular
+    deg(f) ≠ 0, so f is surjective. Full formalization requires
+    degree theory / homology not yet in Mathlib. -/
 
-/-- Classification of maps S^n → S^n by degree:
-    - π_n(S^n) ≅ ℤ (the n-th homotopy group of S^n)
+/- Classification of maps S^n → S^n by degree:
+    - π_n(S^n) ≅ ℤ for all n ≥ 1 (Hurewicz theorem + computation)
     - Each integer d corresponds to a homotopy class of maps of degree d
     - degree 0 = null-homotopic (contractible to a point)
     - degree 1 = homotopic to identity
     - degree -1 = homotopic to a reflection -/
-theorem degree_classifies_maps :
-    -- π_n(S^n) ≅ ℤ for all n ≥ 1
-    -- This is the Hurewicz theorem + computation
-    True := trivial
 
-/-- The Borsuk-Ulam theorem in degree-theoretic form:
+/- The Borsuk-Ulam theorem in degree-theoretic form:
     If f: S^n → ℝ^n is continuous, then either:
     (a) f has a zero (if f is not everywhere nonzero), or
     (b) f/|f|: S^n → S^{n-1} is well-defined but has degree 0
@@ -4746,12 +4727,6 @@ theorem degree_classifies_maps :
     means any continuous f: S^n → S^{n-1} is null-homotopic.
     If f were also odd, its degree would be odd (nonzero) — contradiction!
     Therefore no odd continuous map S^n → S^{n-1} exists for n ≥ 2. -/
-theorem bu_degree_argument :
-    -- π_n(S^{n-1}) = 0 for n ≥ 2: any map S^n → S^{n-1} is null-homotopic
-    -- But odd maps have odd (nonzero) degree
-    -- Therefore: no odd continuous map S^n → S^{n-1} exists
-    -- This is BU for maps to S^{n-1} (hence to ℝ^n \ {0})
-    True := trivial
 
 /-- The equatorial Borsuk-Ulam generalization:
     Not only does every continuous f: S^n → ℝ^n have an antipodal pair,
@@ -4854,18 +4829,15 @@ theorem no_odd_map_between_spheres (n : ℕ) (hn : 1 ≤ n)
   rw [h_zero] at h_one
   simp at h_one
 
-/-- Corollary: BU is equivalent to the non-existence of odd maps S^n → S^{n-1}.
+/- Corollary: BU is equivalent to the non-existence of odd maps S^n → S^{n-1}.
 
     Direction 1 (BU → no odd map): `no_odd_map_between_spheres` above.
     Direction 2 (no odd map → BU): If f: S^n → ℝ^n has no antipodal pair,
     then g(x) = (f(x) - f(-x)) / |f(x) - f(-x)| is a continuous odd map
     S^n → S^{n-1}, contradicting the non-existence.
-
+    BU ↔ (no continuous odd map S^n → S^{n-1}).
+    Forward direction proved above; reverse uses normalization trick.
     This equivalence is stated in `bu_from_no_odd_map` (Section XL). -/
-theorem bu_iff_no_odd_map (n : ℕ) (hn : 1 ≤ n) :
-    -- BU ↔ (no continuous odd map S^n → S^{n-1})
-    -- Forward direction proved above; reverse uses normalization trick
-    True := trivial
 
 /-- The ℤ/2-equivariant category of spheres has a strict dimension hierarchy:
     - S^0 ↪ S^1 ↪ S^2 ↪ ... (equivariant inclusions exist)
@@ -4938,7 +4910,7 @@ end NoOddMapBetweenSpheres
 
 section IsobarycentricPoint
 
-/-- **Isobarycentric Point Theorem** (from BU):
+/- **Isobarycentric Point Theorem** (from BU):
     Given n+1 continuous functions on S^n summing to zero everywhere,
     there exists a point where all functions vanish simultaneously.
 
@@ -4947,11 +4919,9 @@ section IsobarycentricPoint
     2. BU gives x₀ with F(x₀) = F(-x₀), i.e., fᵢ(x₀) = fᵢ(-x₀) for i < n
     3. The sum constraint ∑ fᵢ = 0 forces fₙ(x₀) = fₙ(-x₀) too
     4. For the stronger conclusion (all fᵢ = 0): needs additional
-       antisymmetry or symmetry constraints on the fᵢ -/
-theorem isobarycentric_point_structure :
-    -- The proof uses BU on the first n components + sum constraint for the last
-    -- Full formalization requires careful handling of Fin (n+1) → Fin n projection
-    True := trivial
+       antisymmetry or symmetry constraints on the fᵢ.
+    The proof uses BU on the first n components + sum constraint for the last.
+    Full formalization requires careful handling of Fin (n+1) → Fin n projection. -/
 
 /-- Special case: for n+1 odd continuous functions on S^n summing to zero,
     there exists a common zero.

--- a/proofs/Proofs/Erdos759Problem.lean
+++ b/proofs/Proofs/Erdos759Problem.lean
@@ -244,9 +244,7 @@ def ringel_youngs_prop : Prop :=
     ∃ (V : Type*) (_ : Fintype V) (_ : DecidableEq V) (G : SimpleGraph V),
       isEmbeddableOn G ⟨n⟩ ∧ chromaticNumber G = heawood_number n
 
-/-- Girth and cochromatic number: high girth forces small χ but ζ can still grow.
-Trivially stated as True. -/
-theorem high_girth_cochromatic : True := trivial
+/- Girth and cochromatic number: high girth forces small χ but ζ can still grow. -/
 
 /-
 ## Part IX: Connection to Graph Structure

--- a/proofs/Proofs/Erdos956Problem.lean
+++ b/proofs/Proofs/Erdos956Problem.lean
@@ -246,13 +246,11 @@ axiom grid_construction (n : ℕ) (hn : n ≥ 10) :
 The crossing number and incidence bounds.
 -/
 
-/-- Szemerédi-Trotter incidence bound.
+/- Szemerédi-Trotter incidence bound.
     The number of incidences between n points and m lines is O(n^(2/3) m^(2/3) + n + m). -/
-theorem szemeredi_trotter (n m : ℕ) (hn : n ≥ 1) (hm : m ≥ 1) : True := trivial
 
-/-- The upper bound on h(n) uses incidence geometry.
+/- The upper bound on h(n) uses incidence geometry.
     The proof of h(n) ≪ n^(4/3) uses Szemerédi-Trotter. -/
-theorem upper_bound_uses_incidences : True := trivial
 
 /-
 ## Part XI: Special Cases

--- a/proofs/Proofs/GodelIncompleteness.lean
+++ b/proofs/Proofs/GodelIncompleteness.lean
@@ -147,7 +147,7 @@ theorem diagonal_lemma (P : Nat → Formula) :
     specific Gödel number would depend on the encoding scheme. -/
 def G : Formula := ⟨42⟩
 
-/-- **Axiom:** The self-referential property of G.
+/- **Axiom:** The self-referential property of G.
 
     This axiom encapsulates the key step that requires the Diagonal Lemma:
     G is equivalent to the statement "G is not provable", i.e., G ↔ ¬Prov(⌜G⌝).
@@ -158,7 +158,6 @@ def G : Formula := ⟨42⟩
     3. Fixed-point construction via self-application
 
     We take this as an axiom to focus on the incompleteness argument structure. -/
-theorem G_self_reference : True := trivial
 
 -- ============================================================
 -- PART 7: The Incompleteness Proof
@@ -331,13 +330,12 @@ then T ⊬ (Prov(⌜⊥⌝) → ⊥), which is T ⊬ (¬Prov(⌜⊥⌝) ∨ ⊥)
     "if I am provable, then φ holds". -/
 def LobSentence (φ : Formula) : Formula := ⟨φ.code * 5 + 17⟩  -- Placeholder encoding
 
-/-- **Axiom:** The fixed-point property of the Löb sentence.
+/- **Axiom:** The fixed-point property of the Löb sentence.
 
     For any φ, there exists L such that: T ⊢ L ↔ (Prov(⌜L⌝) → φ)
 
     This follows from the diagonal lemma applied to the predicate
     λx. (Prov(x) → φ). -/
-theorem lob_sentence_fixed_point : ∀ φ : Formula, True := fun _ => trivial
 
 /-- **Löb's Theorem**
 

--- a/proofs/Proofs/Hilbert14InvariantsOQ01.lean
+++ b/proofs/Proofs/Hilbert14InvariantsOQ01.lean
@@ -69,12 +69,10 @@ theorem invariant_one {G R : Type*} [Group G] [CommRing R]
     polynomial of degree |G| over the invariant ring (by the orbit
     polynomial trick), so R^G is integral over a finitely generated
     subring. -/
-theorem finite_group_invariants_fg :
-    -- For any finite group G acting on a polynomial ring k[x₁,...,xₙ],
-    -- the invariant ring k[x₁,...,xₙ]^G is finitely generated.
-    -- (Statement is schematic; concrete instances require Mathlib's
-    -- MvPolynomial and group action infrastructure.)
-    True := trivial
+/- finite_group_invariants_fg: For any finite group G acting on a polynomial ring k[x₁,...,xₙ],
+    the invariant ring k[x₁,...,xₙ]^G is finitely generated.
+    (Statement is schematic; concrete instances require Mathlib's
+    MvPolynomial and group action infrastructure.) -/
 
 -- ═══════════════════════════════════════════════════════════════
 -- PART III: The Additive Group Case (Weitzenböck)
@@ -91,10 +89,8 @@ theorem finite_group_invariants_fg :
 
     For n ≤ 3 variables, the result is elementary.
     For large n, the invariant ring can require many generators. -/
-theorem weitzenbock_3_vars :
-    -- In ≤ 3 variables over char 0, any locally nilpotent derivation
-    -- has a finitely generated kernel.
-    True := trivial
+/- weitzenbock_3_vars: In ≤ 3 variables over char 0, any locally nilpotent
+    derivation has a finitely generated kernel. -/
 
 -- ═══════════════════════════════════════════════════════════════
 -- PART IV: Zariski's Finiteness Criterion
@@ -111,10 +107,8 @@ theorem weitzenbock_3_vars :
     regardless of whether the group is reductive.
 
     Zariski's proof uses the theory of algebraic surfaces. -/
-theorem zariski_dim_2 :
-    -- In dimension ≤ 2, every ring of the form L ∩ k[x₁,...,xₙ]
-    -- is finitely generated (L a subfield of the fraction field).
-    True := trivial
+/- zariski_dim_2: In dimension ≤ 2, every ring of the form L ∩ k[x₁,...,xₙ]
+    is finitely generated (L a subfield of the fraction field). -/
 
 -- ═══════════════════════════════════════════════════════════════
 -- PART V: The Boundary of Finite Generation
@@ -132,12 +126,10 @@ theorem zariski_dim_2 :
 
     Key point: the counterexample requires dim ≥ 3 (by Zariski) and
     non-reductive groups (by Hilbert-Mumford-Haboush). -/
-theorem nagata_counterexample_exists :
-    -- There exists a linear algebraic group action where the
-    -- invariant ring is not finitely generated.
-    True := trivial
+/- nagata_counterexample_exists: There exists a linear algebraic group action where the
+    invariant ring is not finitely generated. (Nagata 1958) -/
 
-/-- **Current State of Knowledge** (summary):
+/- **Current State of Knowledge** (summary):
 
     The characterization of finite generation for non-reductive groups
     remains incomplete. Known sufficient conditions:
@@ -152,6 +144,5 @@ theorem nagata_counterexample_exists :
 
     The gap between these remains an active research area in
     geometric invariant theory. -/
-theorem hilbert_14_open_landscape : True := trivial
 
 end Hilbert14OQ01

--- a/src/data/proofs/borsuk-ulam-oq-03-oq-03/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-03-oq-03/meta.json
@@ -197,9 +197,9 @@
       "Topology"
     ],
     "namespace": "BorsukUlamTucker2D",
-    "lineCount": 2633,
+    "lineCount": 5139,
     "axiomCount": 1,
-    "theoremCount": 123,
+    "theoremCount": 107,
     "definitionCount": 30
   },
   "references": [

--- a/src/data/proofs/erdos-759/meta.json
+++ b/src/data/proofs/erdos-759/meta.json
@@ -230,9 +230,9 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos759",
-    "lineCount": 297,
+    "lineCount": 295,
     "axiomCount": 6,
-    "theoremCount": 4,
+    "theoremCount": 3,
     "definitionCount": 19
   }
 }

--- a/src/data/proofs/erdos-956/meta.json
+++ b/src/data/proofs/erdos-956/meta.json
@@ -204,9 +204,9 @@
       "Finset"
     ],
     "namespace": "Erdos956",
-    "lineCount": 311,
+    "lineCount": 309,
     "axiomCount": 7,
-    "theoremCount": 14,
+    "theoremCount": 12,
     "definitionCount": 13
   },
   "references": [

--- a/src/data/proofs/godel-incompleteness/meta.json
+++ b/src/data/proofs/godel-incompleteness/meta.json
@@ -267,10 +267,10 @@
     }
   ],
   "leanFile": {
-    "lineCount": 467,
+    "lineCount": 465,
     "structureCount": 1,
     "axiomCount": 2,
-    "theoremCount": 15,
+    "theoremCount": 13,
     "lemmaCount": 0,
     "defCount": 12,
     "imports": [


### PR DESCRIPTION
## Fix

Removes 26 True-stub theorems from 5 proof files, continuing the cleanup from batches 1 (#8645) and 2 (#8669).

## Evidence

**Before**: Theorems proved `True := trivial` — conveying no mathematical content while inflating theorem counts.

**After**: Docstrings converted to block comments, preserving explanatory content.

### Files and stubs removed

| File | Gallery entry | Stubs removed |
|------|--------------|---------------|
| `BorsukUlamOQ03.lean` | borsuk-ulam-oq-03-oq-03 | 16 (9 session summaries + 7 proof sketches) |
| `GodelIncompleteness.lean` | godel-incompleteness | 2 (`G_self_reference`, `lob_sentence_fixed_point`) |
| `Erdos956Problem.lean` | erdos-956 | 2 (`szemeredi_trotter`, `upper_bound_uses_incidences`) |
| `Erdos759Problem.lean` | erdos-759 | 1 (`high_girth_cochromatic`) |
| `Hilbert14InvariantsOQ01.lean` | (research data only) | 5 |

Also corrects stale `leanFile.lineCount` for `borsuk-ulam-oq-03-oq-03` (was 2633, actual 5139 — file had grown significantly).

---
Automated fix by lean-mechanic agent.