### PR TITLE
Enrich: Pick's Theorem via Triangulation (picks-theorem-oq-01)

### DIFF
--- a/src/data/proofs/picks-theorem-oq-01/annotations.json
+++ b/src/data/proofs/picks-theorem-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-pick01-shoelace-def",
+    "proofId": "picks-theorem-oq-01",
+    "range": { "startLine": 70, "endLine": 83 },
+    "type": "definition",
+    "title": "Shoelace Formula: Area of a Lattice Triangle",
+    "content": "`shoelaceTriangle x₁ y₁ x₂ y₂ x₃ y₃ : ℚ` computes the area of the lattice triangle with given vertices as `|x₁(y₂-y₃) + x₂(y₃-y₁) + x₃(y₁-y₂)| / 2`. The `noncomputable` annotation is needed because ℚ division is not kernel-computable in Lean. The non-negativity lemma `shoelace_nonneg` uses `div_nonneg` with `Rat.cast_nonneg.mpr (abs_nonneg _)` — a clean one-liner confirming area ≥ 0.",
+    "mathContext": "The *shoelace formula* (also called the surveyor's formula or Gauss's area formula) computes the signed area of a polygon from its vertices: $2A = \\sum_{i} (x_i y_{i+1} - x_{i+1} y_i)$. For a triangle with vertices $(x_1,y_1),(x_2,y_2),(x_3,y_3)$, this gives $2A = x_1(y_2-y_3) + x_2(y_3-y_1) + x_3(y_1-y_2)$. For lattice points, $2A$ is always an integer, so the area is always a multiple of $\\frac{1}{2}$.",
+    "significance": "key",
+    "relatedConcepts": ["shoelace formula", "lattice triangles", "Rat.cast_nonneg", "abs_nonneg"],
+    "prerequisites": ["rational arithmetic in Lean", "absolute value", "noncomputable definitions"]
+  },
+  {
+    "id": "ann-pick01-primitive",
+    "proofId": "picks-theorem-oq-01",
+    "range": { "startLine": 163, "endLine": 183 },
+    "type": "definition",
+    "title": "IsPrimitive: Unimodular Lattice Triangles",
+    "content": "`IsPrimitive x₁ y₁ x₂ y₂ x₃ y₃ : Prop` asserts that `|x₁(y₂-y₃)+x₂(y₃-y₁)+x₃(y₁-y₂)| = 1`. This is the condition for a lattice triangle to contain no lattice points other than its three vertices. The `primitive_area` theorem proves that `IsPrimitive` triangles have shoelace area = 1/2 by simply unfolding the definition and rewriting with the hypothesis h (which states the absolute value equals 1), then `norm_num`.",
+    "mathContext": "A lattice triangle is *primitive* (or *fundamental* or *unimodular*) if the edge vectors from one vertex to the other two form a basis for $\\mathbb{Z}^2$. Equivalently, the $2\\times 2$ determinant $\\det(v_2-v_1, v_3-v_1)$ has absolute value 1. In Pick's theorem terminology, primitive triangles have $i=0$ interior points, $b=3$ boundary points, and area $A = \\frac{1}{2}$, giving $0 + \\frac{3}{2} - 1 = \\frac{1}{2}$. Every lattice triangle can be subdivided into primitive triangles by adding lattice points on edges and in the interior.",
+    "significance": "key",
+    "relatedConcepts": ["unimodular matrices", "SL₂(ℤ)", "lattice bases", "triangulation"],
+    "prerequisites": ["lattice theory", "determinants", "Pick's theorem"]
+  },
+  {
+    "id": "ann-pick01-rectangle",
+    "proofId": "picks-theorem-oq-01",
+    "range": { "startLine": 88, "endLine": 112 },
+    "type": "technique",
+    "title": "Pick's Formula for Rectangles: ring + push_cast",
+    "content": "The theorem `picks_rectangle (a b : ℕ) (ha hb)` proves `(a-1)*(b-1) + (2a+2b)/2 - 1 = a*b` in ℚ. The proof uses `push_cast` to coerce the ℕ arithmetic to ℚ, then `ring` for the algebraic identity. The non-zero casts `ha'` and `hb'` are needed to justify the coercions but the actual identity is handled by `ring`. Note: `Nat.cast_ne_zero.mpr (Nat.pos_iff_ne_zero.mp ha)` is the proof that `(a : ℚ) ≠ 0` from positivity.",
+    "mathContext": "For an $a \\times b$ axis-aligned rectangle with vertices at $(0,0),(a,0),(a,b),(0,b)$: interior lattice points $= (a-1)(b-1)$, boundary lattice points $= 2a + 2b$, area $= ab$. Pick's formula: $(a-1)(b-1) + \\frac{2a+2b}{2} - 1 = ab - a - b + 1 + a + b - 1 = ab$. This is the simplest non-trivial verification of Pick's theorem.",
+    "significance": "supporting",
+    "relatedConcepts": ["push_cast tactic", "Nat.cast_ne_zero", "ring tactic", "rational arithmetic"],
+    "prerequisites": ["Pick's theorem statement", "Lean ring tactics"]
+  },
+  {
+    "id": "ann-pick01-additivity",
+    "proofId": "picks-theorem-oq-01",
+    "range": { "startLine": 114, "endLine": 155 },
+    "type": "technique",
+    "title": "Pick's Additivity: linarith Closes the Key Inductive Lemma",
+    "content": "`picks_additivity` takes two polygons with Pick's formula satisfied (h₁: A₁ = i₁ + b₁/2 - 1, h₂: A₂ = i₂ + b₂/2 - 1) sharing an edge with k internal lattice points. It proves the union satisfies A₁+A₂ = (i₁+i₂+k) + (b₁+b₂-2k-2)/2 - 1. After `push_cast`, this follows immediately from `linarith` using h₁ and h₂. This is the inductive step of the triangulation proof — if both halves satisfy Pick's formula, so does the whole.",
+    "mathContext": "When polygons $P_1$ and $P_2$ share an edge, counting lattice points: the $k$ interior points of the shared edge become interior to the union (contributing $k$ to $i$), and the $k+2$ total shared edge points (including endpoints) are removed from both boundaries and not added back (net boundary change: $-2(k+2) + 2 = -2k-2$ from removing shared edge). The area is additive. So: $i_{\\cup} = i_1 + i_2 + k$, $b_{\\cup} = b_1 + b_2 - 2k - 2$. Substituting into Pick's formula and using $A_1 = i_1 + b_1/2 - 1$, $A_2 = i_2 + b_2/2 - 1$ gives the result by linear arithmetic.",
+    "significance": "key",
+    "relatedConcepts": ["linarith tactic", "polygon merging", "lattice point counting", "inductive proof strategy"],
+    "prerequisites": ["Pick's theorem statement", "linear arithmetic", "Lean push_cast"]
+  },
+  {
+    "id": "ann-pick01-triangulation-gap",
+    "proofId": "picks-theorem-oq-01",
+    "range": { "startLine": 185, "endLine": 206 },
+    "type": "context",
+    "title": "The Triangulation Gap: Mathlib's Missing Computational Geometry",
+    "content": "Part VI documents why the proof cannot be completed: formalizing that every simple lattice polygon admits a triangulation into primitive triangles requires (a) a Lean data type for simple polygons with vertex ordering; (b) proof that ear-clipping terminates and produces lattice triangles; (c) subdivision of any lattice triangle into primitive triangles. None of these exist in Mathlib. The `picks_from_triangulation` lemma is a tautology (proved by `hcount.symm`) that formalizes exactly what triangulation existence would give, making the gap precise. The comment explains the full four-step structure clearly.",
+    "mathContext": "The *ear-clipping* (or *ear decomposition*) algorithm for triangulating a simple polygon works by finding an 'ear' — a vertex v such that the triangle formed by v and its neighbors is entirely inside the polygon. By the two-ears theorem (Meisters 1975), every simple polygon with $\\geq 4$ vertices has at least two non-overlapping ears. Removing an ear reduces vertex count by 1; induction triangulates completely. For lattice polygons, each ear is a lattice triangle. Subdividing into *primitive* triangles requires further work: split any lattice triangle with interior or edge points by adding those lattice points as new vertices.",
+    "significance": "context",
+    "relatedConcepts": ["ear-clipping algorithm", "polygon triangulation", "Meisters two-ears theorem", "Mathlib computational geometry"],
+    "prerequisites": ["Jordan curve theorem", "simple polygon data structures", "Lean inductive types"]
+  }
+]

--- a/src/data/proofs/picks-theorem-oq-01/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01/meta.json
@@ -31,10 +31,16 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "problemStatement": "Can the Pick's theorem axiom be proved constructively via triangulation into unit lattice triangles?",
-    "text": "A 206-line formalization answering YES in principle: the algebraic core of the triangulation proof is complete (0 sorries, 0 axioms). Proves Pick's formula for primitive triangles (base case), the shoelace area formula, Pick's formula for rectangles, and the key additivity lemma showing that merging polygons along shared edges preserves Pick's formula. The remaining gap is formalizing polygon triangulation into primitive lattice triangles, which requires computational geometry infrastructure not yet in Mathlib.",
-    "proofStrategy": "1. Base case: primitive (unimodular) lattice triangles have area 1/2, i=0, b=3, so 0+3/2-1=1/2 \u2713\n2. Additivity: when P\u2081 and P\u2082 share an edge with k interior lattice points, the union satisfies Pick's formula if both pieces do\n3. Triangulation: every simple lattice polygon can be decomposed into primitive triangles (ear-clipping + subdivision)\n4. Induction: apply additivity from step 2 repeatedly\n\nSteps 1-2 are fully proved; step 3 needs computational geometry infrastructure.",
-    "keyInsights": []
+    "historicalContext": "Georg Alexander Pick stated his theorem in 1899: for a polygon with vertices at integer lattice points, the area A equals i + b/2 - 1, where i is the number of interior lattice points and b is the number of boundary lattice points. The result was largely forgotten until Hugo Steinhaus included it in his 1969 book 'Mathematical Snapshots', after which it became a staple of mathematical olympiad training. The classical proof uses triangulation: decompose the polygon into primitive (unimodular) triangles — triangles with no lattice points other than their three vertices — and prove that Pick's formula is additive and holds for each primitive triangle. The primitivity condition is equivalent to the triangle having area exactly 1/2, which in turn is equivalent to the determinant of the edge vectors being ±1. This connection to determinants and the Smith normal form gives Pick's theorem deep connections to algebraic K-theory and the theory of lattice polytopes.",
+    "problemStatement": "Can the Pick's theorem axiom be proved constructively via triangulation into unit lattice triangles? The parent `picks-theorem` formalization axiomatizes the result; this file provides the constructive proof strategy and proves all the algebraic components.",
+    "proofStrategy": "The constructive proof has four steps: (1) Base case: primitive (unimodular) triangles satisfy Pick's formula (i=0, b=3, A=1/2, so 0+3/2-1=1/2). (2) Additivity: merging two polygons along a shared edge with k interior lattice points preserves Pick's formula. (3) Triangulation: every simple lattice polygon can be decomposed into primitive triangles by ear-clipping and edge subdivision. (4) Induction: apply additivity repeatedly. Steps 1-2 are fully formalized; step 3 requires computational geometry infrastructure not yet in Mathlib.",
+    "keyInsights": [
+      "A lattice triangle is primitive (unimodular) iff the absolute value of its cross-product determinant equals 1: |x₁(y₂-y₃)+x₂(y₃-y₁)+x₃(y₁-y₂)| = 1. This is the `IsPrimitive` definition in the file, and it is exactly the condition that the edge vectors form a basis for ℤ². `primitive_area` then immediately gives area 1/2 by dividing by 2.",
+      "Pick's formula is additive under polygon merging: if two polygons P₁ and P₂ share an edge with k interior lattice points (plus 2 endpoints), then i(union) = i₁+i₂+k (shared edge points become interior), b(union) = b₁+b₂-2k-2 (shared edge removed), A(union) = A₁+A₂. The key lemma `picks_additivity` proves this by pure linear arithmetic (`linarith`) from the two Pick's formula hypotheses.",
+      "The shoelace formula `shoelaceTriangle x₁ y₁ x₂ y₂ x₃ y₃ = |x₁(y₂-y₃)+x₂(y₃-y₁)+x₃(y₁-y₂)| / 2` always gives a non-negative rational that equals the area of the lattice triangle. The non-negativity `shoelace_nonneg` follows immediately from `abs_nonneg`. The connection to `IsPrimitive` gives a clean proof that primitive triangles have area exactly 1/2.",
+      "The rectangle case `picks_rectangle` provides a clean verification: for an a×b rectangle, i=(a-1)(b-1), b_boundary=2a+2b, A=ab. The Pick's formula identity `(a-1)(b-1) + (2a+2b)/2 - 1 = ab` is purely algebraic, proved by `ring` after `push_cast`. The concrete case `picks_rectangle_3x4` (12 interior, 14 boundary, area 12) is verified by `norm_num`.",
+      "The file is complete as a proof strategy document: steps 1-2 (base case and additivity) are fully machine-checked with 0 sorries; step 3 (triangulation existence) is the mathematical crux that requires computational geometry unavailable in Mathlib. The `picks_from_triangulation` lemma frames the inductive conclusion, making explicit what triangulation existence would give."
+    ]
   },
   "crossReferences": [
     {
@@ -53,5 +59,65 @@
     "theoremCount": 10,
     "definitionCount": 3
   },
-  "sections": []
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header and Proof Strategy",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "Imports Mathlib and provides a detailed docstring explaining the four-step constructive proof strategy: base case (primitive triangles), additivity, triangulation, and induction. Notes which steps are proved and which require missing Mathlib infrastructure."
+    },
+    {
+      "id": "unit-triangle",
+      "title": "Part I: Unit Right Triangle (Base Case Numeric Verification)",
+      "startLine": 42,
+      "endLine": 60,
+      "summary": "Proves `picks_unit_triangle`: Pick's formula 0 + 3/2 - 1 = 1/2 by norm_num. Proves `shoelace_unit_triangle`: the shoelace formula gives area 1/2 for the unit triangle at (0,0),(1,0),(0,1)."
+    },
+    {
+      "id": "shoelace",
+      "title": "Part II: Shoelace Formula Definition and Non-Negativity",
+      "startLine": 62,
+      "endLine": 83,
+      "summary": "Defines `shoelaceTriangle` (noncomputable, returns ℚ) as |x₁(y₂-y₃)+...| / 2. Proves `shoelace_nonneg` by `div_nonneg` and `abs_nonneg`. This gives the area of any lattice triangle."
+    },
+    {
+      "id": "rectangles",
+      "title": "Part III: Pick's Theorem for a×b Rectangles",
+      "startLine": 85,
+      "endLine": 112,
+      "summary": "Proves `picks_rectangle` for any positive a×b rectangle using `push_cast` + `ring`. Proves concrete `picks_rectangle_3x4` by `norm_num`. Confirms the formula (a-1)(b-1) + (2a+2b)/2 - 1 = ab algebraically."
+    },
+    {
+      "id": "additivity",
+      "title": "Part IV: Additivity of Pick's Formula",
+      "startLine": 114,
+      "endLine": 155,
+      "summary": "Proves `picks_additivity`: when two polygons satisfying Pick's formula share an edge with k shared interior lattice points, the union also satisfies Pick's formula. The proof is a one-liner `linarith` after `push_cast`. This is the key inductive lemma."
+    },
+    {
+      "id": "primitive-triangles",
+      "title": "Part V: Primitive (Unimodular) Lattice Triangles",
+      "startLine": 157,
+      "endLine": 183,
+      "summary": "Defines `IsPrimitive` as |det(edge vectors)| = 1. Proves `primitive_area`: primitive triangles have shoelace area 1/2 by unfolding and using h. Proves `picks_primitive_triangle` (alias of picks_unit_triangle). This is the true base case for the induction."
+    },
+    {
+      "id": "full-strategy",
+      "title": "Part VI: Full Proof Strategy and Triangulation Gap",
+      "startLine": 185,
+      "endLine": 206,
+      "summary": "Documents the remaining gap (primitive triangulation requires computational geometry) and proves `picks_from_triangulation`: given n primitive triangles and Pick's formula for the composite, the formula holds. This is the tautological conclusion that makes the inductive hypothesis explicit."
+    }
+  ],
+  "conclusion": {
+    "summary": "This 206-line fully verified file (0 sorries, 0 axioms) establishes the algebraic core of the constructive proof of Pick's theorem via triangulation. The base case (primitive triangles have area 1/2), the shoelace formula, Pick's formula for rectangles, and the additivity lemma are all machine-checked. The only gap is the triangulation existence theorem, which requires computational geometry infrastructure not yet in Mathlib.",
+    "implications": "Pick's theorem connects to several deep mathematical areas: the theory of lattice polytopes (Ehrhart polynomials generalize Pick to higher dimensions), algebraic K-theory (the unimodularity condition is the SL₂(ℤ) orbit), and toric geometry (the Newton polytope of a polynomial's lattice structure). The formalization here demonstrates that the algebraic content of the classical proof is entirely straightforward; the difficulty lies in the combinatorial geometry of triangulation.",
+    "openQuestions": [
+      "Can polygon triangulation into primitive lattice triangles be formalized in Lean/Mathlib? The ear-clipping algorithm requires a simple polygon data structure, Jordan curve theorem for polygons, and a proof that every simple polygon has an ear. None of these are currently in Mathlib.",
+      "Can the Ehrhart polynomial generalization be formalized? For a d-dimensional lattice polytope P, the Ehrhart polynomial i(P, t) counts lattice points in tP. Pick's theorem is the d=2, t=1 case. A Lean formalization would need the Euler characteristic of lattice polytopes.",
+      "Is there a simpler proof of triangulation existence specific to lattice polygons (avoiding general computational geometry)? For instance, the 'cut by a diagonal' approach requires only that some diagonal lies interior to the polygon, which for lattice polygons might be simpler to verify than for general polygons.",
+      "Can Mathlib's `MvPolynomial.Newton` or related machinery be used to give an algebraic proof of Pick's theorem via generating functions or residues, bypassing triangulation entirely?"
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

- Enriches `picks-theorem-oq-01` (Pick's Theorem via Triangulation) with full gallery metadata
- Fully verified file: 0 sorries, 0 axioms, 10 theorems, 3 definitions
- Adds `historicalContext`: Pick 1899 → Steinhaus 1969 → modern unimodularity connections
- Adds 6 sections covering all 206 Lean lines
- Adds 5 `keyInsights` on IsPrimitive/shoelace/rectangle/additivity/triangulation gap
- Adds `conclusion` with 4 open questions on triangulation formalization, Ehrhart generalization, simpler proofs
- Creates `annotations.json` with 5 annotations

## Annotations Added

1. **Shoelace Formula Definition** — noncomputable area via |det|/2
2. **IsPrimitive: Unimodular Lattice Triangles** — |det| = 1, area = 1/2
3. **Pick's Formula for Rectangles** — ring + push_cast proof
4. **Pick's Additivity** — key inductive lemma, closed by linarith
5. **Triangulation Gap** — missing Mathlib computational geometry documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)