### PR TITLE
Enrich: Discriminant of the Depressed Cubic (solution-of-cubic-oq-03-oq-01)

### DIFF
--- a/src/data/proofs/solution-of-cubic-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-01/annotations.json
@@ -1,1 +1,62 @@
-[]
+[
+  {
+    "id": "ann-cubic01-discriminant-def",
+    "proofId": "solution-of-cubic-oq-03-oq-01",
+    "range": { "startLine": 20, "endLine": 32 },
+    "type": "definition",
+    "title": "Two Faces of the Discriminant: Coefficient vs Root Form",
+    "content": "Two complementary definitions capture the discriminant: `discriminant (p q : R) := -4*p^3 - 27*q^2` (coefficient form) and `rootDiscriminant (x₁ x₂ x₃ : R) := (x₁-x₂)^2*(x₁-x₃)^2*(x₂-x₃)^2` (root-separation form). Both are defined over an arbitrary `CommRing R`, making them applicable over ℤ, ℚ, ℝ, ℂ, and polynomial rings. The main theorem connects these two forms.",
+    "mathContext": "The *discriminant* of a monic polynomial $f$ is $\\Delta(f) = \\prod_{i < j} (r_i - r_j)^2$ where $r_1,\\ldots,r_n$ are the roots. For the depressed cubic $x^3 + px + q$, this gives $\\Delta = (r_1-r_2)^2(r_1-r_3)^2(r_2-r_3)^2 = -4p^3 - 27q^2$. The coefficient formula $-4p^3-27q^2$ comes from eliminating roots via resultants: $\\Delta(f) = (-1)^{n(n-1)/2} \\text{Res}(f, f')/a_n$.",
+    "significance": "key",
+    "relatedConcepts": ["polynomial discriminant", "Vandermonde product", "CommRing generality", "resultant"],
+    "prerequisites": ["polynomial roots", "symmetric polynomials", "CommRing in Lean 4"]
+  },
+  {
+    "id": "ann-cubic01-vieta",
+    "proofId": "solution-of-cubic-oq-03-oq-01",
+    "range": { "startLine": 34, "endLine": 46 },
+    "type": "definition",
+    "title": "IsRootTriple: Vieta's Formulas as a Lean Structure",
+    "content": "The `IsRootTriple p q x₁ x₂ x₃ : Prop` structure has three fields: `sum_zero : x₁+x₂+x₃=0`, `sum_products : x₁x₂+x₁x₃+x₂x₃=p`, `product : x₁x₂x₃=-q`. This encodes Vieta's formulas for the depressed cubic. Using a `structure` rather than a tuple allows dot-notation access (`h.sum_zero`) and makes proof steps more readable. The structure lives in `Prop` since it packages three equations.",
+    "mathContext": "For the depressed cubic $x^3 + 0 \\cdot x^2 + p \\cdot x + q$, Vieta's formulas give: $x_1+x_2+x_3 = 0$, $x_1x_2+x_1x_3+x_2x_3 = p$, $x_1x_2x_3 = -q$. These follow from expanding $(x-x_1)(x-x_2)(x-x_3) = x^3 - e_1 x^2 + e_2 x - e_3$ and matching coefficients with $x^3 + 0 \\cdot x^2 + p \\cdot x + q$.",
+    "significance": "key",
+    "relatedConcepts": ["Vieta's formulas", "elementary symmetric polynomials", "Lean 4 structure syntax"],
+    "prerequisites": ["polynomial factorization", "symmetric functions", "Lean 4 structures"]
+  },
+  {
+    "id": "ann-cubic01-ring-proof",
+    "proofId": "solution-of-cubic-oq-03-oq-01",
+    "range": { "startLine": 55, "endLine": 65 },
+    "type": "technique",
+    "title": "Ring Closes the Discriminant Identity After Vieta Substitution",
+    "content": "The proof of `discriminant_eq_root_form` has three steps: (1) `rw [← h.sum_products, ← show q = -(x₁*x₂*x₃) from by linarith [h.product]]` — rewrite p and q using Vieta's formulas; (2) `have hx₃ : x₃ = -(x₁+x₂) := by linarith [h.sum_zero]` — express x₃ from sum_zero; (3) `rw [hx₃]; ring` — substitute x₃ and close. After these substitutions, both sides are polynomials in x₁, x₂ alone and `ring` checks equality over any CommRing.",
+    "mathContext": "After substituting $p = x_1x_2+x_1x_3+x_2x_3$, $q = -(x_1x_2x_3)$, and $x_3 = -(x_1+x_2)$, both $-4p^3-27q^2$ and $(x_1-x_2)^2(x_1-x_3)^2(x_2-x_3)^2$ become polynomials in $x_1,x_2$ over $\\mathbb{Z}$. Their equality is a universal identity in $\\mathbb{Z}[x_1,x_2]$, verifiable by the `ring` tactic via polynomial normalization.",
+    "significance": "key",
+    "relatedConcepts": ["ring tactic", "linarith tactic", "polynomial identities", "CommRing normalization"],
+    "prerequisites": ["Lean 4 ring tactic", "have tactic", "rw with ← arrow"]
+  },
+  {
+    "id": "ann-cubic01-distinct-roots",
+    "proofId": "solution-of-cubic-oq-03-oq-01",
+    "range": { "startLine": 68, "endLine": 82 },
+    "type": "technique",
+    "title": "Δ > 0 → Distinct Roots: simp with Equality Kills the Product",
+    "content": "`distinct_roots_of_pos_discriminant` uses `rw [discriminant_eq_root_form]` to convert the hypothesis to `rootDiscriminant > 0`, then `refine ⟨?_, ?_, ?_⟩ <;> intro heq <;> simp [heq] at hΔ` handles all three inequality goals at once. For each case (say x₁=x₂): `intro heq` assumes equality, `simp [heq]` evaluates `(x₁-x₂)^2 = 0`, the product becomes 0, contradicting `0 < 0`.",
+    "mathContext": "In an ordered field: if $\\Delta = (x_1-x_2)^2(x_1-x_3)^2(x_2-x_3)^2 > 0$, then each factor must be positive (since all are non-negative, a zero factor would make the product zero). Each factor $(x_i-x_j)^2 > 0$ iff $x_i \\neq x_j$. So $\\Delta > 0$ is equivalent to all pairwise root differences being nonzero, i.e., all three roots are distinct.",
+    "significance": "supporting",
+    "relatedConcepts": ["simp tactic", "linear ordered field", "positivity of squares", "refine with multiple goals"],
+    "prerequisites": ["real analysis in Lean", "simp lemmas for squares", "ordered field"]
+  },
+  {
+    "id": "ann-cubic01-repeated-roots",
+    "proofId": "solution-of-cubic-oq-03-oq-01",
+    "range": { "startLine": 84, "endLine": 89 },
+    "type": "technique",
+    "title": "Δ = 0 → Repeated Roots: positivity + linarith by Contradiction",
+    "content": "`repeated_root_of_zero_discriminant` proceeds by contradiction: `by_contra h_all_ne; push_neg at h_all_ne` gives `h12: x₁≠x₂`, `h13: x₁≠x₃`, `h23: x₂≠x₃`. Then `have h1 : (x₁-x₂)^2 > 0 := by positivity` (three times) gives each factor positive. `mul_pos (mul_pos h1 h2) h3` gives the product positive, and `linarith` derives False from `product > 0` and `hΔ : product = 0`.",
+    "mathContext": "The key fact: in $\\mathbb{R}$, $(x-y)^2 > 0$ whenever $x \\neq y$. This is handled by `positivity` which uses `sq_pos_of_ne_zero : a ≠ 0 → 0 < a^2` (or similar). If all three roots are distinct, all squared differences are positive, their product is positive (by `mul_pos`), contradicting $\\Delta = 0$. By contrapositive, $\\Delta = 0$ implies some pair of roots coincide.",
+    "significance": "supporting",
+    "relatedConcepts": ["positivity tactic", "sq_pos_of_ne_zero", "mul_pos", "by_contra + push_neg"],
+    "prerequisites": ["positivity tactic in Lean 4", "ordered field properties", "linarith"]
+  }
+]

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-01/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-01/meta.json
@@ -22,8 +22,71 @@
   "sorryCount": 0,
   "status": "verified",
   "badge": "verified",
+  "crossReferences": [
+    {
+      "targetId": "solution-of-cubic-oq-03",
+      "relationship": "extends",
+      "description": "Provides the discriminant formula and root-separation interpretation for the depressed cubic, extending the OQ-03 open question framework"
+    },
+    {
+      "targetId": "solution-of-cubic",
+      "relationship": "related",
+      "description": "Connects the discriminant Δ = -4p³-27q² to Cardano's formula, where Δ/108 appears under the square root"
+    }
+  ],
+  "overview": {
+    "historicalContext": "The discriminant of the cubic emerged from the 16th-century algebraic revolution in northern Italy. Scipione del Ferro discovered the depressed cubic formula around 1515 but kept it secret; Niccolò Tartaglia rediscovered it around 1530 and shared it with Gerolamo Cardano under an oath of secrecy. Cardano published the formula in Ars Magna (1545), together with the first systematic treatment of cubic equations including complex numbers. The expression -4p³-27q² appears naturally in Cardano's formula: the cube roots involve √(q²/4 + p³/27) = √(-Δ/108). When Δ > 0 (the 'casus irreducibilis'), Cardano's formula requires the square root of a negative number even when all three roots are real — the first systematic encounter with complex numbers. The modern treatment of the discriminant as the square of the Vandermonde product (x₁-x₂)(x₁-x₃)(x₂-x₃) appears in Lagrange's Réflexions sur la résolution algébrique des équations (1771) and was systematized by Galois theory.",
+    "problemStatement": "For the depressed cubic x³+px+q=0 with roots x₁, x₂, x₃, prove that Δ = -4p³-27q² = (x₁-x₂)²(x₁-x₃)²(x₂-x₃)². Prove that Δ > 0 implies three distinct roots, and Δ = 0 implies a repeated root.",
+    "proofStrategy": "The main identity is a pure polynomial calculation: after substituting Vieta's formulas (p = Σᵢⱼ xᵢxⱼ, q = -(x₁x₂x₃)) and reducing x₃ = -(x₁+x₂), the identity -4p³-27q² = (x₁-x₂)²(x₁-x₃)²(x₂-x₃)² is verified by `ring`. The sign theorems rewrite via `discriminant_eq_root_form`, then use `positivity` to show squared differences are positive when roots differ, and `linarith` to get contradictions.",
+    "keyInsights": [
+      "The `IsRootTriple p q x₁ x₂ x₃` structure packages Vieta's formulas as a Lean Prop: `sum_zero` (x₁+x₂+x₃=0), `sum_products` (x₁x₂+x₁x₃+x₂x₃=p), `product` (x₁x₂x₃=-q). Using a structure rather than three separate hypotheses makes the main theorem's proof cleaner — a single `h : IsRootTriple` can be passed and destructured.",
+      "The proof of `discriminant_eq_root_form` is entirely algebraic: substitute p = h.sum_products and q = -h.product using `rw`, then extract `hx₃ : x₃ = -(x₁+x₂)` from `linarith [h.sum_zero]`, substitute `rw [hx₃]`, and close with `ring`. This makes explicit that the identity is a universal polynomial law — it holds in any commutative ring, requiring no field structure, no analysis, no ordering.",
+      "The CommRing generality of the main theorem is mathematically significant: the identity Δ = rootDiscriminant holds over ℤ[p,q,x₁,x₂,x₃] as a polynomial identity, not just over ℝ. The file uses `variable {R : Type*} [CommRing R]` to capture this. The sign-based theorems necessarily specialize to ℝ because they require an ordered field (Δ > 0 makes no sense in a general ring).",
+      "For `distinct_roots_of_pos_discriminant`, after `rw [discriminant_eq_root_form]`, the hypothesis is `(x₁-x₂)²·(x₁-x₃)²·(x₂-x₃)² > 0`. If x₁=x₂ (or similarly), then `simp [heq]` evaluates (x₁-x₂) = 0, making the product 0 — contradicting `> 0`. Three subgoals are handled by `<;> intro heq <;> simp [heq] at hΔ`.",
+      "For `repeated_root_of_zero_discriminant`, the proof by contradiction shows: if all roots are distinct, then each squared difference is > 0 (by `positivity`), so their product is > 0 (by `mul_pos`), contradicting hΔ = 0 (by `linarith`). The `positivity` tactic handles `(x₁-x₂)^2 > 0` from `x₁ ≠ x₂` automatically."
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Section I: Discriminant Definitions",
+      "startLine": 1,
+      "endLine": 32,
+      "summary": "Module header explains the discriminant formula, root nature from sign, and Cardano's context. Defines `discriminant (p q : R) := -4*p^3 - 27*q^2` and `rootDiscriminant (x₁ x₂ x₃ : R) := (x₁-x₂)^2*(x₁-x₃)^2*(x₂-x₃)^2` over a CommRing R."
+    },
+    {
+      "id": "vieta",
+      "title": "Section II: Vieta's Formulas via IsRootTriple",
+      "startLine": 34,
+      "endLine": 46,
+      "summary": "Defines `IsRootTriple p q x₁ x₂ x₃ : Prop` as a structure with three fields: sum_zero (x₁+x₂+x₃=0), sum_products (Σᵢⱼxᵢxⱼ=p), product (x₁x₂x₃=-q). This packages Vieta's formulas for the depressed cubic."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Section III: Discriminant Equality (Main Theorem)",
+      "startLine": 48,
+      "endLine": 65,
+      "summary": "Proves `discriminant_eq_root_form`: Δ = rootDiscriminant when IsRootTriple holds. Proof: rw with h.sum_products, derive x₃=-(x₁+x₂) from h.sum_zero, then ring. Valid over any CommRing R."
+    },
+    {
+      "id": "sign-theorems",
+      "title": "Section IV: Sign Determines Root Nature over ℝ",
+      "startLine": 67,
+      "endLine": 89,
+      "summary": "Two theorems over ℝ: `distinct_roots_of_pos_discriminant` (Δ>0 → all roots distinct, proved by simp+contradiction) and `repeated_root_of_zero_discriminant` (Δ=0 → some roots coincide, proved by positivity+linarith)."
+    }
+  ],
+  "conclusion": {
+    "summary": "A concise 89-line fully verified formalization proving that Δ = -4p³-27q² equals the squared Vandermonde product (x₁-x₂)²(x₁-x₃)²(x₂-x₃)² for the depressed cubic, with sign-based theorems for root nature. The main identity proof is a clean ring calculation; the sign theorems use positivity and linarith elegantly.",
+    "implications": "The discriminant connects algebra, geometry, and topology. In algebraic geometry, the discriminant locus {(p,q) : Δ(p,q) = 0} is a curve in parameter space where the cubic has a repeated root (a bifurcation set in dynamical systems). In Galois theory, the discriminant determines whether the Galois group of the polynomial is contained in the alternating group: for cubics over ℚ, Gal(f) ⊆ A₃ (cyclic order 3) iff Δ is a perfect square in ℚ.",
+    "openQuestions": [
+      "Can the casus irreducibilis be formalized? When Δ > 0 and the roots are real, Cardano's formula requires complex cube roots. Formalizing that the three real roots can be expressed as Re(cube_root(complex_number)) would require complex analysis in Lean.",
+      "Can this be extended to the general cubic x³+bx²+cx+d? The substitution x → x-b/3 depresses the cubic, giving the discriminant Δ = 18abcd - 4b³d + b²c² - 4ac³ - 27a²d². A Lean proof would need the substitution lemma.",
+      "Can Cardano's formula itself be formalized? The formula x = ∛(-q/2+√(Δ/108)) + ∛(-q/2-√(Δ/108)) requires cube roots over ℂ and careful branch selection. Lean has `Complex.exp` and `Complex.log` but not yet a polished cube root API.",
+      "Can the Galois group result be proved: Gal(x³+px+q) ⊆ A₃ iff Δ is a perfect square in the base field? This would require Mathlib's Galois theory formalization and connecting the discriminant to the field discriminant."
+    ]
+  },
   "leanFile": {
     "lineCount": 89
-  },
-  "sections": []
+  }
 }


### PR DESCRIPTION
## Summary

- Enriches `solution-of-cubic-oq-03-oq-01` (Discriminant of the Depressed Cubic) with full gallery metadata
- Fully verified file: 0 sorries, 0 axioms, 5 theorems, 2 definitions
- Adds `historicalContext`: del Ferro → Tartaglia/Cardano (Ars Magna 1545) → Lagrange (1771)
- Adds 4 sections covering all 89 Lean lines
- Adds 5 `keyInsights` on CommRing generality/IsRootTriple/ring proof/distinct roots/repeated roots
- Adds `conclusion` with 4 open questions on casus irreducibilis, Cardano's formula, Galois groups
- Fills `annotations.json` (was empty []) with 5 annotations

## Annotations Added

1. **Two Faces of the Discriminant** — coefficient vs root-separation form, CommRing R
2. **IsRootTriple: Vieta's Formulas as Structure** — dot-notation Prop structure
3. **Ring Closes via Vieta Substitution** — rw + linarith + ring proof strategy
4. **Δ > 0 → Distinct Roots** — refine + simp[heq] kills factors
5. **Δ = 0 → Repeated Roots** — by_contra + positivity + mul_pos + linarith

🤖 Generated with [Claude Code](https://claude.com/claude-code)