### PR TITLE
fix: remove True-stub theorems from 13 gallery proofs (batch 4)

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ01.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01.lean
@@ -95,21 +95,14 @@ noncomputable def irrationalityMeasure (α : ℝ) : ℝ :=
   sInf { s : ℝ | ∀ᶠ (pq : ℤ × ℕ) in Filter.atTop,
     pq.2 > 0 → |α - (pq.1 : ℝ) / (pq.2 : ℝ)| ≥ 1 / (pq.2 : ℝ) ^ s }
 
-/-- For any irrational number, the irrationality measure is at least 2
-    (by Dirichlet's approximation theorem). -/
-theorem irrationality_measure_ge_two (α : ℝ) (hα : Irrational α) :
-    -- Dirichlet: there are infinitely many p/q with |α - p/q| < 1/q²
-    -- so μ(α) ≥ 2
-    True := trivial  -- The actual proof requires Dirichlet's theorem
+/- For any irrational number, the irrationality measure is at least 2
+    (by Dirichlet's approximation theorem).
+    Dirichlet: there are infinitely many p/q with |α - p/q| < 1/q², so μ(α) ≥ 2. -/
 
-/-- Known irrationality measures:
+/- Known irrationality measures:
     - μ(e) = 2 (optimal — e is not a Liouville number)
     - μ(π) ≤ 7.6063 (Zeilberger-Zudilin, 2020)
     - μ(ζ(3)) ≤ 5.513891 (Rhin-Viola, 2001) -/
-theorem known_irrationality_measures :
-    -- These are specific numerical bounds from the literature
-    -- that calibrate the difficulty of proving irrationality
-    True := trivial
 
 -- ============================================================
 -- Part IV: Why ζ(5) is Hard
@@ -141,14 +134,11 @@ proving dim_ℚ(1, ζ(3), ζ(5), ..., ζ(2n+1)) ≥ (1 + o(1)) log(n)/(1 + log 2
 But this dimension bound doesn't specify which values are irrational.
 -/
 
-/-- **Summary**: ζ(5) irrationality remains open.
+/- **Summary**: ζ(5) irrationality remains open.
     - ζ(5) ≈ 1.0369277551...
     - ζ(5) is conjectured irrational (no conceptual obstruction)
     - Known: at least one of ζ(5), ζ(7), ζ(9), ζ(11) is irrational
     - Known: infinitely many odd zeta values are irrational
     - Unknown: which specific odd zeta values (beyond ζ(3)) are irrational -/
-theorem zeta_five_status :
-    -- The irrationality of ζ(5) is an open problem as of 2025
-    True := trivial
 
 end BaselProblemOQ01OQ01

--- a/proofs/Proofs/BoundedPrimeGapsOQ04OQ02.lean
+++ b/proofs/Proofs/BoundedPrimeGapsOQ04OQ02.lean
@@ -454,11 +454,10 @@ theorem bv_from_minimal_additions :
     with the Selberg sieve weights implies `maynard_tao_sieve` (the main
     bounded prime gaps axiom). This would reduce the axiom count of
     BoundedPrimeGaps.lean from 3 to 2. -/
-theorem six_additions_reduce_axiom_count :
-    -- BV follows from the 6 additions (stated above)
-    -- BV + sieve weights → maynard_tao_sieve
-    -- Net effect: 3 axioms → 2 axioms in BoundedPrimeGaps.lean
-    True := trivial
+/- six_additions_reduce_axiom_count:
+    BV follows from the 6 additions stated above.
+    BV + sieve weights → maynard_tao_sieve.
+    Net effect: 3 axioms → 2 axioms in BoundedPrimeGaps.lean. -/
 
 /-
 ## Part V: Impact Analysis — What Each Addition Unlocks Beyond BV

--- a/proofs/Proofs/Erdos184ProblemProvable.lean
+++ b/proofs/Proofs/Erdos184ProblemProvable.lean
@@ -243,25 +243,19 @@ def completeDecompProblem : Prop :=
 ## Part VIII: Why This Is Hard
 -/
 
-/--
-**The Gap:**
+/- **The Gap:**
 - Lower bound: (1+c)n from K_{3,n-3}
 - Upper bound: O(n log* n) from Bucić-Montgomery
 - Conjecture: O(n)
 
-Closing this gap is the challenge.
--/
-theorem open_problem_difficulty : True := trivial
+Closing this gap is the challenge. -/
 
-/--
-**Progress History:**
+/- **Progress History:**
 - 1966: Erdős-Gallai conjecture O(n)
 - 1966: Erdős-Gallai prove O(n log n)
 - 2014: Conlon-Fox-Sudakov prove O(n) for dense graphs
 - 2022: Bucić-Montgomery prove O(n log* n)
-- ???: General O(n) remains open
--/
-theorem progress_timeline : True := trivial
+- ???: General O(n) remains open -/
 
 /-
 ## Part IX: Summary

--- a/proofs/Proofs/Erdos351Problem.lean
+++ b/proofs/Proofs/Erdos351Problem.lean
@@ -42,16 +42,12 @@ def HasStronglyCompleteImage (P : ℚ[X]) : Prop :=
 
 /- ## Main Results -/
 
-/--
-**Erdős Problem #351** (Open):
+/- **Erdős Problem #351** (Open):
 
 The general conjecture asks: for every polynomial p(x) ∈ ℚ[x] with positive
 leading coefficient and positive degree, is {p(n) + 1/n : n ∈ ℕ} strongly complete?
 
-This remains open. The answer is unknown.
--/
-theorem erdos_351_open :
-  True := trivial  -- Placeholder: the general problem is open
+This remains open. The answer is unknown. -/
 
 /- ## Solved Cases -/
 

--- a/proofs/Proofs/Erdos523Problem.lean
+++ b/proofs/Proofs/Erdos523Problem.lean
@@ -169,24 +169,18 @@ def LittlewoodProblem : Prop :=
   -- This is related to flatness problems
   True
 
-/-- Random polynomials give typical behavior of Littlewood polynomials. -/
-theorem typical_littlewood :
-  -- Most Littlewood polynomials have max ≈ √(n log n)
-  True := trivial
+/- Random polynomials give typical behavior of Littlewood polynomials:
+  most Littlewood polynomials have max ≈ √(n log n). -/
 
 /-
 ## Part IX: Upper and Lower Bounds
 -/
 
-/-- Upper bound: max ≤ (1+ε)√(n log n) with high probability. -/
-theorem upper_bound_high_prob (n : ℕ) (hn : n ≥ 2) (ε : ℝ) (hε : ε > 0) :
-  -- P(maxModulus s ≤ (1+ε)√(n log n)) → 1 as n → ∞
-  True := trivial
+/- Upper bound: max ≤ (1+ε)√(n log n) with high probability.
+  P(maxModulus s ≤ (1+ε)√(n log n)) → 1 as n → ∞. -/
 
-/-- Lower bound: max ≥ (1-ε)√(n log n) with high probability. -/
-theorem lower_bound_high_prob (n : ℕ) (hn : n ≥ 2) (ε : ℝ) (hε : ε > 0) :
-  -- P(maxModulus s ≥ (1-ε)√(n log n)) → 1 as n → ∞
-  True := trivial
+/- Lower bound: max ≥ (1-ε)√(n log n) with high probability.
+  P(maxModulus s ≥ (1-ε)√(n log n)) → 1 as n → ∞. -/
 
 /-- Halász's proof combines upper and lower bounds. -/
 def halaszProofSketch : Prop :=

--- a/proofs/Proofs/Erdos589Problem.lean
+++ b/proofs/Proofs/Erdos589Problem.lean
@@ -290,13 +290,9 @@ def ExactGrowthOpen : Prop :=
     (∃ c C : ℝ, c > 0 ∧ C > 0 ∧ ∀ n : ℕ, n ≥ 10 →
       c * (n : ℝ)^α ≤ (g n : ℝ) ∧ (g n : ℝ) ≤ C * (n : ℝ)^α)
 
-/--
-**Balogh-Solymosi conjecture:**
+/- **Balogh-Solymosi conjecture:**
 The construction giving n^(5/6) may be close to optimal.
--/
-theorem balogh_solymosi_conjecture :
-  -- They suggest 5/6 might be the correct exponent
-  True := trivial
+(They suggest 5/6 might be the correct exponent — open conjecture.) -/
 
 /-
 ## Part X: Summary

--- a/proofs/Proofs/Erdos728Problem.lean
+++ b/proofs/Proofs/Erdos728Problem.lean
@@ -206,13 +206,9 @@ v_p(n!) + v_p((a+b-n)!) >= v_p(a!) + v_p(b!).
 Connection to Problem #729 and general factorial divisibility.
 -/
 
-/--
-**Problem #729 Connection:**
+/- **Problem #729 Connection:**
 Problem #729 asks related questions about factorial divisibility
-with different parameter constraints.
--/
-theorem problem_729_connection :
-    True := trivial  -- Placeholder for connection to Problem #729
+with different parameter constraints. -/
 
 /--
 **General Principle:**

--- a/proofs/Proofs/EulerPolyhedralOQ01OQ04.lean
+++ b/proofs/Proofs/EulerPolyhedralOQ01OQ04.lean
@@ -338,9 +338,8 @@ theorem hadwiger_5_from_4ct (G : SimpleGraph V) [DecidableRel G.Adj]
 axiom petersen_not_planar :
     ∃ (P : SimpleGraph (Fin 10)), ∀ [DecidableRel P.Adj], ¬ IsPlanar P
 
-/-- Whitney (1932): 3-connected planar graphs have unique embeddings. -/
-theorem whitney_unique_embedding (G : SimpleGraph V) [DecidableRel G.Adj]
-    (_hplanar : IsPlanar G) (_h3conn : True) : True := trivial
+/- Whitney (1932): 3-connected planar graphs have unique embeddings.
+    (Full formalization requires embedding uniqueness machinery.) -/
 
 /-- Euler's formula: V - E + F = 2 for connected planar graphs. -/
 axiom euler_formula (G : SimpleGraph V) [DecidableRel G.Adj]

--- a/proofs/Proofs/FermatsLastTheorem.lean
+++ b/proofs/Proofs/FermatsLastTheorem.lean
@@ -100,10 +100,10 @@ for some Γ₀(N) such that E and f have the same L-function. This means:
 
 where aₚ(E) = p + 1 - #E(𝔽ₚ) counts points over the finite field. -/
 
-/-- The Modularity Theorem for semi-stable elliptic curves (axiomatized).
-    This is the main theorem Wiles proved, requiring ~100 pages of proof. -/
-theorem ModularityTheorem_semistable :
-  True := trivial  -- Placeholder: "All semi-stable elliptic curves over ℚ are modular"
+/- The Modularity Theorem for semi-stable elliptic curves:
+    All semi-stable elliptic curves over ℚ are modular.
+    This is the main theorem Wiles proved, requiring ~100 pages of proof.
+    (Axiomatized in this file as the key step toward FLT.) -/
 
 /-! ## Part IV: Ribet's Theorem
 

--- a/proofs/Proofs/FermatsLastTheoremOQ03.lean
+++ b/proofs/Proofs/FermatsLastTheoremOQ03.lean
@@ -92,17 +92,14 @@ theorem asymptotic_flt_Q : AsymptoticFLT ℚ := by
     Over ℚ: proved by Breuil-Conrad-Diamond-Taylor (2001).
     Over totally real fields: partial results (many cases proved).
     Over general number fields: wide open. -/
-/-- Over number fields with more units, "trivial" solutions
+/- Over number fields with more units, "trivial" solutions
     involving units can exist even for large n.
 
     Example: In ℤ[ε] where ε is a root of unity,
     ε^n + (-ε)^n = 0 for odd n. While 0 is excluded by our
-    nontrivial condition, unit-rich rings allow more possibilities. -/
-theorem units_create_solutions :
-    -- In any ring with a nontrivial n-th root of unity ζ,
-    -- ζ^n = 1 provides a starting point for solutions.
-    -- (Not directly a Fermat solution, but related.)
-    True := trivial
+    nontrivial condition, unit-rich rings allow more possibilities.
+    In any ring with a nontrivial n-th root of unity ζ,
+    ζ^n = 1 provides a starting point for solutions. -/
 
 /-
   Summary

--- a/proofs/Proofs/Hilbert21RiemannHilbert.lean
+++ b/proofs/Proofs/Hilbert21RiemannHilbert.lean
@@ -332,15 +332,13 @@ Modern formulation: There is an equivalence of categories between:
 This is a cornerstone of the geometric Langlands program.
 -/
 
-/-- **The Riemann-Hilbert Correspondence (Derived Category Version)**
+/- **The Riemann-Hilbert Correspondence (Derived Category Version)**
 
     There is an equivalence of derived categories:
     D^b(RegularSingularDMod) ≃ D^b(Perv)
 
-    This was established by Kashiwara, Mebkhout, and others. -/
-theorem riemann_hilbert_correspondence :
-    -- An equivalence of categories (stated abstractly)
-    True := trivial
+    This was established by Kashiwara, Mebkhout, and others.
+    (Formalization requires derived category machinery not yet in Mathlib.) -/
 
 -- ============================================================
 -- PART 10: Summary

--- a/proofs/Proofs/ProbMethodAlteration.lean
+++ b/proofs/Proofs/ProbMethodAlteration.lean
@@ -53,9 +53,7 @@ theorem independent_set_bound (n d : ℕ) (hd : 0 < d) (hn : 0 < n) :
 -- Part III: Property B
 -- ═══════════════════════════════════════════════════
 
-/-- **Property B bound.** k-uniform hypergraph with fewer than 2^(k-1)
+/- **Property B bound.** k-uniform hypergraph with fewer than 2^(k-1)
     edges is 2-colorable. Placeholder: full statement needs hypergraph type. -/
-theorem property_b_bound (k m : ℕ) (hk : 2 ≤ k) (hm : m < 2 ^ (k - 1)) :
-    True := trivial
 
 end ProbMethod.Alteration

--- a/proofs/Proofs/ShannonSourceCodingOQ01.lean
+++ b/proofs/Proofs/ShannonSourceCodingOQ01.lean
@@ -282,16 +282,11 @@ axiom rateDistortion_convex {α β : Type*} [Fintype α] [Fintype β]
 -- Connection to Lossless Coding
 -- ============================================================
 
-/-- At zero Hamming distortion (D = 0), the only admissible test channel
+/- At zero Hamming distortion (D = 0), the only admissible test channel
     is the identity channel X̂ = X, so I(X;X̂) = H(X).
     Thus R(0) = H(X), recovering the lossless source coding theorem.
 
     This connects rate-distortion theory to Shannon's 1948 source
     coding theorem: the lossless case is the D = 0 endpoint. -/
-theorem rd_lossless_connection :
-    -- R(0) = H(X) for Hamming distortion on finite alphabets
-    -- The identity channel is the unique D=0-admissible channel
-    -- because d(x,x̂) = 0 iff x = x̂ under Hamming
-    True := trivial
 
 end InformationTheory.RateDistortion

--- a/src/data/proofs/basel-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01/meta.json
@@ -9,7 +9,11 @@
     "date": "2026-03-30",
     "status": "formalized",
     "proofRepoPath": "Proofs/BaselProblemOQ01OQ01.lean",
-    "tags": ["number-theory", "analysis", "open-problem"],
+    "tags": [
+      "number-theory",
+      "analysis",
+      "open-problem"
+    ],
     "badge": "formalized",
     "sorries": 0,
     "assumptions": "0 sorries, 0 axioms. 3 True-stub theorems (irrationality_measure_ge_two, known_irrationality_measures, zeta_five_status) prove True instead of their stated claims. Genuine content: partial sum bounds, tail estimates, and irrationality measure definition are fully verified.",
@@ -20,9 +24,25 @@
   },
   "sections": [],
   "crossReferences": [
-    {"targetId": "basel-problem-oq-01", "relationship": "extends", "description": "Adds computational bounds and the irrationality measure framework to the ζ(5) investigation."}
+    {
+      "targetId": "basel-problem-oq-01",
+      "relationship": "extends",
+      "description": "Adds computational bounds and the irrationality measure framework to the ζ(5) investigation."
+    }
   ],
-  "conclusion": {"summary": "ζ(5) irrationality remains open. This file provides partial sum bounds, tail estimates, and documents the difficulty gap.", "openQuestions": []},
-  "leanFile": {"imports": ["Mathlib"], "namespace": "BaselProblemOQ01OQ01", "lineCount": 154, "axiomCount": 0, "theoremCount": 10, "definitionCount": 2},
+  "conclusion": {
+    "summary": "ζ(5) irrationality remains open. This file provides partial sum bounds, tail estimates, and documents the difficulty gap.",
+    "openQuestions": []
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "namespace": "BaselProblemOQ01OQ01",
+    "lineCount": 144,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 2
+  },
   "references": []
 }

--- a/src/data/proofs/erdos-184/meta.json
+++ b/src/data/proofs/erdos-184/meta.json
@@ -172,9 +172,9 @@
       "Finset"
     ],
     "namespace": "Erdos184",
-    "lineCount": 242,
+    "lineCount": 311,
     "axiomCount": 7,
-    "theoremCount": 2,
+    "theoremCount": 8,
     "definitionCount": 7
   },
   "references": [

--- a/src/data/proofs/erdos-351/meta.json
+++ b/src/data/proofs/erdos-351/meta.json
@@ -126,7 +126,7 @@
       "Set"
     ],
     "namespace": "Erdos351",
-    "lineCount": 111,
+    "lineCount": 107,
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 3

--- a/src/data/proofs/erdos-523/meta.json
+++ b/src/data/proofs/erdos-523/meta.json
@@ -201,9 +201,9 @@
       "Real"
     ],
     "namespace": "Erdos523",
-    "lineCount": 247,
+    "lineCount": 241,
     "axiomCount": 3,
-    "theoremCount": 5,
+    "theoremCount": 7,
     "definitionCount": 21
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-589/meta.json
+++ b/src/data/proofs/erdos-589/meta.json
@@ -151,9 +151,9 @@
       "Real"
     ],
     "namespace": "Erdos589",
-    "lineCount": 343,
+    "lineCount": 339,
     "axiomCount": 4,
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 9
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-728/meta.json
+++ b/src/data/proofs/erdos-728/meta.json
@@ -172,7 +172,7 @@
       "Topology"
     ],
     "namespace": "Erdos728",
-    "lineCount": 250,
+    "lineCount": 246,
     "axiomCount": 4,
     "theoremCount": 5,
     "definitionCount": 6

--- a/src/data/proofs/fermats-last-theorem-oq-03/meta.json
+++ b/src/data/proofs/fermats-last-theorem-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "fermats-last-theorem-oq-03",
   "title": "Fermat's Equation over Number Fields",
   "slug": "fermats-last-theorem-oq-03",
-  "description": "Explores x^n + y^n = z^n over number fields. Wiles (\u211a), Freitas-Hung-Siksek (real quadratic), and the modularity obstruction.",
+  "description": "Explores x^n + y^n = z^n over number fields. Wiles (ℚ), Freitas-Hung-Siksek (real quadratic), and the modularity obstruction.",
   "meta": {
     "author": "Wiles, Freitas-Hung-Siksek",
     "date": "2026",
@@ -44,9 +44,9 @@
       "Mathlib"
     ],
     "namespace": "FermatsLastTheoremOQ03",
-    "lineCount": 123,
+    "lineCount": 120,
     "axiomCount": 1,
-    "theoremCount": 4,
+    "theoremCount": 3,
     "definitionCount": 3
   },
   "sections": []

--- a/src/data/proofs/fermats-last-theorem/meta.json
+++ b/src/data/proofs/fermats-last-theorem/meta.json
@@ -286,7 +286,7 @@
     "namespace": "FermatsLastTheorem",
     "lineCount": 204,
     "axiomCount": 2,
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 0
   },
   "mainTheorems": [

--- a/src/data/proofs/hilbert-21/meta.json
+++ b/src/data/proofs/hilbert-21/meta.json
@@ -149,9 +149,9 @@
     ],
     "opens": [],
     "namespace": "Hilbert21",
-    "lineCount": 388,
+    "lineCount": 386,
     "axiomCount": 6,
-    "theoremCount": 3,
+    "theoremCount": 5,
     "definitionCount": 5
   },
   "references": [

--- a/src/data/proofs/prob-method-alteration/meta.json
+++ b/src/data/proofs/prob-method-alteration/meta.json
@@ -169,9 +169,9 @@
       "BigOperators"
     ],
     "namespace": "ProbMethod.Alteration",
-    "lineCount": 61,
+    "lineCount": 59,
     "axiomCount": 0,
-    "theoremCount": 3,
+    "theoremCount": 2,
     "definitionCount": 0
   },
   "references": [

--- a/src/data/proofs/shannon-source-coding-oq-01/meta.json
+++ b/src/data/proofs/shannon-source-coding-oq-01/meta.json
@@ -181,9 +181,9 @@
     ],
     "opens": [],
     "namespace": "InformationTheory.RateDistortion",
-    "lineCount": 297,
+    "lineCount": 292,
     "axiomCount": 1,
-    "theoremCount": 17,
+    "theoremCount": 16,
     "definitionCount": 9,
     "mainTheorems": [
       {


### PR DESCRIPTION
## Summary

- Removes 17 `theorem X : True := trivial` stubs from 13 Lean proof files
- Each stub is replaced by a block comment preserving the mathematical description
- Updates `meta.json` for 11 gallery entries (`theoremCount`, `lineCount`)

## Files Changed

| File | Stubs Removed |
|------|--------------|
| ProbMethodAlteration.lean | 1 (property_b_bound) |
| Erdos589Problem.lean | 1 (balogh_solymosi_conjecture) |
| FermatsLastTheorem.lean | 1 (ModularityTheorem_semistable) |
| Erdos351Problem.lean | 1 (erdos_351_open) |
| BaselProblemOQ01OQ01.lean | 3 (irrationality_measure_ge_two, known_irrationality_measures, zeta_five_status) |
| Erdos728Problem.lean | 1 (problem_729_connection) |
| BoundedPrimeGapsOQ04OQ02.lean | 1 (six_additions_reduce_axiom_count) |
| Hilbert21RiemannHilbert.lean | 1 (riemann_hilbert_correspondence) |
| Erdos523Problem.lean | 3 (typical_littlewood, upper_bound_high_prob, lower_bound_high_prob) |
| ShannonSourceCodingOQ01.lean | 1 (rd_lossless_connection) |
| EulerPolyhedralOQ01OQ04.lean | 1 (whitney_unique_embedding) |
| FermatsLastTheoremOQ03.lean | 1 (units_create_solutions) |
| Erdos184ProblemProvable.lean | 2 (open_problem_difficulty, progress_timeline) |

Continues the True-stub cleanup started in batches 2 (#8669) and 3 (#8673).

🤖 Generated with [Claude Code](https://claude.com/claude-code)