### PR TITLE
Enrich: Density Increment Generalization to k-APs via Gowers Norms (roth-theorem-k3-oq-03)

### DIFF
--- a/src/data/proofs/roth-theorem-k3-oq-03/annotations.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03/annotations.json
@@ -1,1 +1,62 @@
-[]
+[
+  {
+    "id": "ann-roth03-gowers-norm",
+    "proofId": "roth-theorem-k3-oq-03",
+    "range": { "startLine": 80, "endLine": 115 },
+    "type": "definition",
+    "title": "Gowers U^s Norm: Hypercube Correlation Measure",
+    "content": "The `gowersNorm N s f` definition uses two helpers: `hypercubeShift h ω = Σᵢ (if ω i then h i else 0)` (the shift x + ω·h for binary vector ω ∈ {0,1}^s) and `conjugateByWeight ω z` (complex conjugate when the Hamming weight |ω| = Σ ωᵢ is odd). The norm itself averages over all x ∈ ZMod N and all shift vectors h ∈ (ZMod N)^s, taking the product over all 2^s hypercube vertices. Both helpers are `noncomputable` due to complex arithmetic.",
+    "mathContext": "The Gowers $U^s$ norm of $f : \\mathbb{Z}_N \\to \\mathbb{C}$ is defined by $\\|f\\|_{U^s}^{2^s} = \\mathbb{E}_{x, h_1,\\ldots,h_s} \\prod_{\\omega \\in \\{0,1\\}^s} \\mathcal{C}^{|\\omega|} f(x + \\omega \\cdot h)$ where $\\mathcal{C}$ denotes complex conjugation, $|\\omega| = \\sum_i \\omega_i$ is the Hamming weight, and $\\omega \\cdot h = \\sum_i \\omega_i h_i$. For $s=1$: $\\|f\\|_{U^1} = |\\mathbb{E}[f]|$. For $s=2$: $\\|f\\|_{U^2}^4 = \\sum_{\\xi} |\\hat{f}(\\xi)|^4$ (Fourier $L^4$ norm). For general $s$, this measures correlation of $f$ with $(s-1)$-order polynomial phases.",
+    "significance": "key",
+    "relatedConcepts": ["Gowers norms", "hypercube", "uniformity", "Fourier analysis", "additive combinatorics"],
+    "prerequisites": ["ZMod N", "Complex arithmetic in Lean", "Fin s → Bool type", "BigOperators"]
+  },
+  {
+    "id": "ann-roth03-kap-count",
+    "proofId": "roth-theorem-k3-oq-03",
+    "range": { "startLine": 117, "endLine": 135 },
+    "type": "definition",
+    "title": "k-AP Counting Operator: Normalized Double Average",
+    "content": "`kAPCount k f = (N⁻¹)² * Σ_{x,d ∈ ZMod N} ∏_{i=0}^{k-1} f i (x + i·d)`. The factor `(N⁻¹)²` normalizes to give the density of k-APs. For indicator functions 1_A, `kAPCount k (fun _ => 1_A)` gives the fraction of (x,d) pairs with {x, x+d, ..., x+(k-1)d} ⊆ A. The `Fin k → ZMod N → ℂ` type allows different functions for each AP position, enabling the generalized von Neumann application with the deviation function 1_A - δ.",
+    "mathContext": "The $k$-AP counting operator $\\Lambda_k(f_1,\\ldots,f_k) = \\mathbb{E}_{x,d \\in \\mathbb{Z}_N} \\prod_{i=0}^{k-1} f_i(x+id)$ measures weighted $k$-AP count. For $f_i = 1_A - \\delta$ (deviation from random), $|\\Lambda_k(1_A-\\delta,\\ldots,1_A-\\delta)| \\ll \\delta^k$ iff $A$ has roughly random $k$-AP behavior. The generalized von Neumann theorem bounds this by $\\|f_0\\|_{U^{k-1}}$, connecting $k$-AP count to the Gowers norm.",
+    "significance": "key",
+    "relatedConcepts": ["arithmetic progression counting", "density of APs", "von Neumann theorem", "indicator functions"],
+    "prerequisites": ["ZMod N arithmetic", "Fin k type", "BigOperators product notation"]
+  },
+  {
+    "id": "ann-roth03-von-neumann",
+    "proofId": "roth-theorem-k3-oq-03",
+    "range": { "startLine": 147, "endLine": 170 },
+    "type": "technique",
+    "title": "Generalized von Neumann: k-AP Count ≤ Gowers Norm (Axiom)",
+    "content": "The axiom `generalized_von_neumann` states that `|kAPCount k f| ≤ gowersNorm N (k-1) (f ⟨0, ...⟩)` when each `|f i x| ≤ 1`. This is the central technical lemma for the Gowers approach. The docstring explains the proof outline: the Gowers-Cauchy-Schwarz inequality iterates Cauchy-Schwarz 2^{k-2} times over the hypercube, each step doubling the number of arguments until the U^{k-1} norm appears. The `hbound` condition ensures the Cauchy-Schwarz iterations are valid.",
+    "mathContext": "The Gowers-Cauchy-Schwarz inequality states: $|\\Lambda_k(f_1,\\ldots,f_k)| \\leq \\|f_j\\|_{U^{k-1}}$ for any $j$, provided all $\\|f_i\\|_\\infty \\leq 1$. The proof proceeds by induction: in the base case $k=2$, $|\\Lambda_2(f_1,f_2)| = |\\mathbb{E}_{x,d} f_1(x)f_2(x+d)| \\leq \\|f_1\\|_\\infty \\cdot \\|f_2\\|_2 \\leq \\|f_1\\|_{U^1}$ (trivially). For $k \\geq 3$, apply Cauchy-Schwarz in $d$, then apply the Cauchy-Schwarz-Gowers (van der Corput) step to double the $h$ arguments, eventually arriving at the $U^{k-1}$ norm.",
+    "significance": "key",
+    "relatedConcepts": ["Cauchy-Schwarz inequality", "Gowers-Cauchy-Schwarz", "bounded functions", "Lean axiom"],
+    "prerequisites": ["Cauchy-Schwarz in Lean", "Gowers norms", "k-AP counting operator"]
+  },
+  {
+    "id": "ann-roth03-k3-proved",
+    "proofId": "roth-theorem-k3-oq-03",
+    "range": { "startLine": 247, "endLine": 270 },
+    "type": "insight",
+    "title": "k=3 Case Proved: Translation Between AP Notions + Roth Infrastructure",
+    "content": "`density_increment_k3_explicit` is fully proved (0 axioms, 0 sorries) by: (1) `haveI : NeZero N` from `hN : N ≥ 2`; (2) converting via `apFree_of_isKAPFreeZMod_three`; (3) applying `Szemeredi.Roth.density_increment_lemma` from `RothTheorem.lean`; (4) packaging the result back via `isKAPFreeZMod_three_of_apFree`. The explicit bound `δ' ≥ δ + δ²/100` comes directly from the Fourier-analytic Roth infrastructure, with the AP-free condition on A' preserved throughout.",
+    "mathContext": "For $k=3$: the U² norm equals the Fourier $L^4$ norm $\\|f\\|_{U^2}^4 = \\sum_\\xi |\\hat{f}(\\xi)|^4$, and the inverse theorem for $U^2$ is trivial: large $\\|f\\|_{U^2}$ implies large $|\\hat{f}(\\xi)|$ for some $\\xi$ (by Parseval). This gives an explicit density increment $\\delta' \\geq \\delta + \\delta^2/100$ on a subprogression of size $\\geq N^{1-\\delta^2/200}$. For $k \\geq 4$, no Fourier mode suffices — one needs correlations with degree-$(k-2)$ polynomial phases (the inverse theorem, proved by Green-Tao-Ziegler 2012).",
+    "significance": "key",
+    "relatedConcepts": ["Roth density increment", "Fourier L4 norm", "U² vs U^{k-1}", "Szemeredi.Roth.density_increment_lemma"],
+    "prerequisites": ["RothTheorem.lean infrastructure", "APFree vs IsKAPFreeZMod", "NeZero typeclass"]
+  },
+  {
+    "id": "ann-roth03-sorry",
+    "proofId": "roth-theorem-k3-oq-03",
+    "range": { "startLine": 226, "endLine": 245 },
+    "type": "context",
+    "title": "Szemerédi from Density Increment: The Missing Quantitative Bound",
+    "content": "`szemeredi_from_density_increment` has a sorry because `density_increment_kAP` only guarantees `δ' > δ` (some increase) but not a quantitative lower bound `δ' ≥ δ + g(δ,k)` with `g > 0` on (0,1]. Without such a bound, the density increases could converge to 0 (Zeno-like) and the iteration might not terminate in bounded steps. The docstring is precise about this: 'density might increase by amounts converging to 0, and N might reach 1 before density exceeds 1.' Fixing this would require adding a quantitative bound to `density_increment_kAP`.",
+    "mathContext": "To derive Szemerédi's theorem by density increment iteration: start with $\\delta_0 = \\delta$, after $t$ steps $\\delta_t \\geq \\delta + t \\cdot g(\\delta, k)$ for some $g > 0$. Since $\\delta_t \\leq 1$, the process terminates after $t^* \\leq (1-\\delta)/g(\\delta,k)$ steps. For $k=3$, $g(\\delta,3) = \\delta^2/100$ gives $t^* = O(1/\\delta^2)$, meaning $N \\geq $ a tower of height $O(1/\\delta^2)$ suffices. For $k \\geq 4$, the tower height grows with $k$, giving Szemerédi's theorem with a tower-type bound.",
+    "significance": "context",
+    "relatedConcepts": ["Szemerédi's theorem", "density increment iteration", "tower functions", "quantitative bounds"],
+    "prerequisites": ["density increment strategy", "Lean sorry", "Filter.atTop and limits"]
+  }
+]

--- a/src/data/proofs/roth-theorem-k3-oq-03/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03/meta.json
@@ -21,7 +21,86 @@
     "assumptions": "2 axioms: generalized_von_neumann (k-AP count controlled by U^{k-1} norm via Gowers-Cauchy-Schwarz), density_increment_kAP (density increases on subprogression, AP-free preserved). gowersNorm and kAPCount constructive. density_increment_k3_explicit includes AP-free preservation via Roth infrastructure.",
     "lineCount": 280
   },
-  "sections": [],
+  "crossReferences": [
+    {
+      "targetId": "roth-theorem-k3",
+      "relationship": "extends",
+      "description": "Generalizes the k=3 density increment strategy to k-term APs via Gowers U^{k-1} norms, with the k=3 case derived directly from the parent Roth infrastructure"
+    }
+  ],
+  "overview": {
+    "historicalContext": "Klaus Roth (1953) proved the first quantitative result on 3-AP-free sets using Fourier analysis — his density increment strategy showed that any 3-AP-free set A ⊆ {1,...,N} has density o(1). Endre Szemerédi extended this to k-APs in 1975 using his regularity lemma, but without quantitative bounds. Timothy Gowers (1998, 2001) revolutionized the field by introducing the Gowers uniformity norms U^s and proving that the U^{k-1} norm controls k-AP counts via the generalized von Neumann theorem — yielding the first elementary quantitative proof of Szemerédi's theorem. Ben Green and Terence Tao (2008) applied Gowers norms to prove that the primes contain arbitrarily long arithmetic progressions, a major landmark. Green, Tao, and Tamar Ziegler (2012) completed the picture by proving the inverse theorem for all Gowers norms, connecting large U^{k-1} norm to correlation with nilsequences (bracket polynomial phases). Gowers won the Fields Medal in 1998 partly for this work.",
+    "problemStatement": "Can Roth's density increment strategy — which uses Fourier analysis and the U²=L⁴ norm for k=3 — be extended to k-term arithmetic progressions using Gowers U^{k-1} norms? Specifically, can the generalized von Neumann theorem and the density increment be formalized for general k?",
+    "proofStrategy": "The file builds the Gowers framework in 9 parts: (1) k-AP-free sets and equivalence with Szemeredi.Roth.APFree for k=3; (2) Gowers norm definition via hypercube shifts; (3) k-AP counting operator; (4) generalized von Neumann theorem (axiomatized); (5) inverse theorem structure (documented); (6) density increment for general k (axiomatized); (7) Szemerédi from density increment (sorry); (8) k=3 case proved from RothTheorem.lean; (9) comparison table k=3 vs k≥4.",
+    "keyInsights": [
+      "The Gowers U^s norm ||f||_{U^s}^{2^s} = E_{x, h₁,...,hₛ} ∏_{ω ∈ {0,1}^s} C^{|ω|} f(x + ω·h) measures s-th order uniformity of f : ZMod N → ℂ. The `gowersNorm` definition encodes this with `hypercubeShift` (the shift x + ω·h for hypercube vertex ω) and `conjugateByWeight` (conjugate when |ω| is odd). For s=2, this equals the Fourier L^4 norm, directly connecting to Roth's Fourier approach.",
+      "The generalized von Neumann theorem (axiom `generalized_von_neumann`) states that `|Λ_k(f₁,...,fₖ)| ≤ min_i ||fᵢ||_{U^{k-1}}`. This is the key technical lemma that allows Gowers norms to control k-AP counts. Its proof requires the Gowers-Cauchy-Schwarz inequality — an iterated Cauchy-Schwarz over the hypercube — which is the central analytic argument in Gowers (2001).",
+      "The k=3 case `density_increment_k3_explicit` is fully proved (no axioms) from the parent `RothTheorem.lean` infrastructure via `Szemeredi.Roth.density_increment_lemma`. The proof translates between `IsKAPFreeZMod A 3` and `Szemeredi.Roth.APFree A` using `apFree_of_isKAPFreeZMod_three` and `isKAPFreeZMod_three_of_apFree`, then applies the existing Fourier-analytic density increment with explicit bound δ' ≥ δ + δ²/100.",
+      "The comparison table in Part IX crystallizes the k=3 vs k≥4 divide: for k=3, U² = Fourier L⁴ and the inverse theorem is trivial (Parseval), giving δ²/100 explicit increment. For k≥4, U^{k-1} requires the inverse theorem (nilsequence correlation, proven by Green-Tao-Ziegler 2012 in ~5000 lines), giving only a tower-type bound c(δ,k). The sorry in `szemeredi_from_density_increment` reflects the missing quantitative lower bound on the density increment amount.",
+      "The `IsKAPFreeZMod` definition uses `Fin k` as the AP index type, making it uniformly applicable for all k ≥ 2. The equivalence with `APFree` (which uses the specific form a, a+d, a+2d) is proved by fin_cases on Fin 3, a clean Lean 4 technique for case-splitting over a small finite type."
+    ]
+  },
+  "sections": [
+    {
+      "id": "kap-free",
+      "title": "Part I: k-AP-Free Sets and Equivalence with APFree",
+      "startLine": 1,
+      "endLine": 65,
+      "summary": "Defines `IsKAPFreeZMod A k` using Fin k as AP index. Proves `apFree_of_isKAPFreeZMod_three` and `isKAPFreeZMod_three_of_apFree` — the equivalence with Szemeredi.Roth.APFree for k=3 — using fin_cases on Fin 3."
+    },
+    {
+      "id": "gowers-norms",
+      "title": "Parts II-III: Gowers Norms and k-AP Counting Operator",
+      "startLine": 67,
+      "endLine": 135,
+      "summary": "Defines `hypercubeShift h ω = Σᵢ (if ω i then h i else 0)`, `conjugateByWeight ω z` (conjugates when Hamming weight is odd), `gowersNorm N s f` (U^s norm via hypercube average), and `kAPCount k f` (arithmetic progression counting operator as double average over (x,d))."
+    },
+    {
+      "id": "von-neumann-axiom",
+      "title": "Part IV: Generalized von Neumann Theorem (Axiom)",
+      "startLine": 137,
+      "endLine": 170,
+      "summary": "Axiom `generalized_von_neumann`: |kAPCount k f| ≤ gowersNorm N (k-1) (f 0) when each |f i x| ≤ 1. The docstring explains the Gowers-Cauchy-Schwarz inequality needed for the proof."
+    },
+    {
+      "id": "density-increment-axiom",
+      "title": "Parts V-VI: Inverse Theorem + Density Increment for k≥3 (Axiom)",
+      "startLine": 171,
+      "endLine": 225,
+      "summary": "Docstring for the inverse theorem (U^{k-1} large → nilsequence correlation). Axiom `density_increment_kAP`: k-AP-free A with density δ has a subprogression A' with higher density and still k-AP-free."
+    },
+    {
+      "id": "szemeredi-sorry",
+      "title": "Part VII: Szemerédi from Density Increment (Sorry)",
+      "startLine": 226,
+      "endLine": 245,
+      "summary": "Theorem `szemeredi_from_density_increment` has a sorry. The docstring explains the blocker: density_increment_kAP gives δ' > δ but not a quantitative lower bound δ' ≥ δ + g(δ,k) needed for the iteration to terminate in bounded steps."
+    },
+    {
+      "id": "k3-proved",
+      "title": "Part VIII: k=3 Case Proved from RothTheorem.lean",
+      "startLine": 247,
+      "endLine": 270,
+      "summary": "Theorem `density_increment_k3_explicit` (no axioms, no sorry): translates between k-AP notions, applies Szemeredi.Roth.density_increment_lemma, and produces A' with δ' ≥ δ + δ²/100 and still 3-AP-free."
+    },
+    {
+      "id": "comparison",
+      "title": "Part IX: k=3 vs k≥4 Comparison",
+      "startLine": 272,
+      "endLine": 280,
+      "summary": "Markdown comparison table: k=3 uses U²=Fourier L⁴ with explicit δ²/100 increment; k≥4 uses U^{k-1} with tower-type c(δ,k). Documents proof length (~1400 lines for k=3 proved; ~5000+ estimated for k≥4)."
+    }
+  ],
+  "conclusion": {
+    "summary": "This 280-line file axiomatizes the Gowers norm framework for k-AP density increment. Two axioms (generalized von Neumann, density increment for k≥3) state the deep analytic results; the k=3 case is fully proved from existing infrastructure. The sorry in `szemeredi_from_density_increment` captures the remaining gap: a quantitative lower bound on the density increment needed to ensure iteration terminates.",
+    "implications": "The Gowers uniformity norm framework is the central tool of modern additive combinatorics, underlying the Green-Tao theorem (primes contain long APs), Bergelson-Leibman (polynomial extensions), and the Hales-Jewett theorem. Formalizing the generalized von Neumann theorem in Lean would be a significant contribution to additive combinatorics in Mathlib.",
+    "openQuestions": [
+      "Can `generalized_von_neumann` be proved? The proof requires the Gowers-Cauchy-Schwarz inequality, an iterated application of Cauchy-Schwarz indexed by binary strings. This would need Lean 4 formalization of the hypercube combinatorics and complex-valued Cauchy-Schwarz.",
+      "Can `szemeredi_from_density_increment` be proved? The blocker is a quantitative lower bound g(δ,k) > 0 on the density increment. For k=3, g(δ) = δ²/100 is known; for k≥4, bounds are tower-type and require the Green-Tao-Ziegler inverse theorem.",
+      "Can the inverse theorem for Gowers norms be formalized? Green-Tao-Ziegler (2012) prove that large ||f||_{U^{k-1}} implies correlation with a polynomial phase (nilsequence). Formalizing this would require Lean 4 nilpotent groups and polynomial maps.",
+      "Is there a simpler proof of Szemerédi's theorem that avoids Gowers norms and the inverse theorem? Hypergraph regularity (Frankl-Rödl, Gowers) and ergodic theory (Furstenberg) give alternative proofs, but none are yet formalized in Lean."
+    ]
+  },
   "leanFile": {
     "axiomCount": 2
   }


### PR DESCRIPTION
## Summary

- Enriches `roth-theorem-k3-oq-03` (Density Increment Generalization via Gowers Norms) with full gallery metadata
- 2 axioms, 1 sorry, constructive Gowers norm definitions
- Adds `historicalContext`: Roth 1953 → Szemerédi 1975 → Gowers 1998/2001 → Green-Tao 2008 → GTZ 2012
- Adds 7 sections covering all 280 Lean lines
- Adds 5 `keyInsights` on U^s norm/von Neumann/k=3 proved/tower bounds/sorry blocker
- Adds `conclusion` with 4 open questions on Gowers-CS proof and inverse theorem formalization
- Fills `annotations.json` (was empty []) with 5 annotations

## Annotations Added

1. **Gowers U^s Norm** — hypercubeShift + conjugateByWeight + noncomputable definition
2. **k-AP Counting Operator** — normalized double average, Fin k → ZMod N → ℂ
3. **Generalized von Neumann (Axiom)** — Gowers-Cauchy-Schwarz outline
4. **k=3 Case Proved** — translation between AP notions + Roth infrastructure
5. **Szemerédi Sorry** — missing quantitative lower bound g(δ,k) > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)