### PR TITLE
Enrich: Probabilistic Method Finset-MeasureTheory Bridge (prob-method-expectation-oq-01)

### DIFF
--- a/src/data/proofs/prob-method-expectation-oq-01/annotations.json
+++ b/src/data/proofs/prob-method-expectation-oq-01/annotations.json
@@ -1,1 +1,62 @@
-[]
+[
+  {
+    "id": "ann-pmeoq01-uniform-measure",
+    "proofId": "prob-method-expectation-oq-01",
+    "range": { "startLine": 26, "endLine": 37 },
+    "type": "definition",
+    "title": "uniformProbMeasure: Counting Measure Normalized to Probability",
+    "content": "`uniformProbMeasure (α : Type*) : Measure α` is defined as `(Fintype.card α : ℝ≥0∞)⁻¹ • Measure.count`. The first theorem `counting_measure_is_uniform` establishes that `Measure.count (Set.univ) = Fintype.card α` via `simp [Measure.count_apply_finite]`. The scalar `(card α)⁻¹` in `ℝ≥0∞` normalizes to total mass 1. Multiple typeclasses are required: `[Fintype α]`, `[MeasurableSpace α]`, `[MeasurableSingletonClass α]`, `[Nonempty α]` — the last ensuring card α > 0.",
+    "mathContext": "The *counting measure* on a finite set $\\{\\omega_1,\\ldots,\\omega_n\\}$ assigns measure $|A|$ to each set $A \\subseteq \\Omega$. Normalizing by $1/n$ gives the uniform probability measure $P(A) = |A|/n$. In Mathlib, `Measure.count` is the counting measure on a measurable space, and `ENNReal` (`ℝ≥0∞`) is used because measures can be infinite. The scaling `(n : ℝ≥0∞)⁻¹ • μ` multiplies all measure values by $1/n$.",
+    "significance": "key",
+    "relatedConcepts": ["Measure.count", "MeasurableSingletonClass", "Fintype.card", "ENNReal arithmetic"],
+    "prerequisites": ["Mathlib MeasureTheory", "Fintype and MeasurableSpace typeclasses", "ENNReal vs ℝ"]
+  },
+  {
+    "id": "ann-pmeoq01-bridge",
+    "proofId": "prob-method-expectation-oq-01",
+    "range": { "startLine": 39, "endLine": 51 },
+    "type": "technique",
+    "title": "Finset Expectation = Bochner Integral: The Bridge Lemma",
+    "content": "`finset_expectation_eq_integral` proves `(∑ a : α, X a) / Fintype.card α = ∫ a, X a ∂(uniformProbMeasure α)`. The proof uses `simp [uniformProbMeasure, integral_smul_measure, smul_eq_mul, integral_count]` to expand the RHS, then `rw [ENNReal.toReal_inv, ENNReal.toReal_natCast, div_eq_inv_mul]` to match the LHS. The key identity is `integral_count : ∫ a, f a ∂Measure.count = ∑ a, f a` (summing over all elements).",
+    "mathContext": "For a finite type $\\alpha$ with uniform probability measure $P = \\frac{1}{|\\alpha|} \\text{count}$, the Bochner integral $\\int f \\, dP = \\frac{1}{|\\alpha|} \\int f \\, d(\\text{count}) = \\frac{1}{|\\alpha|} \\sum_a f(a) = \\mathbb{E}[f]$ (the finite expectation). This identifies the gallery's Finset-based definition of expectation with the measure-theoretic Bochner integral, enabling use of Mathlib's integral lemmas.",
+    "significance": "key",
+    "relatedConcepts": ["integral_smul_measure", "integral_count", "ENNReal.toReal_inv", "Bochner integral"],
+    "prerequisites": ["Mathlib.MeasureTheory.Integral", "integral_count lemma", "ENNReal conversions"]
+  },
+  {
+    "id": "ann-pmeoq01-first-moment",
+    "proofId": "prob-method-expectation-oq-01",
+    "range": { "startLine": 53, "endLine": 95 },
+    "type": "technique",
+    "title": "First Moment Method: Contradiction via integral_mono_ae",
+    "content": "`first_moment_method` proves that if X : Ω → ℕ is measurable and integrable with E[X] < 1, then P({X = 0}) > 0. The proof: `by_contra h; push_neg at h` gives `μ {X=0} = 0`. Then `ae_iff` converts this to `X ω ≥ 1` a.e. (using that X is ℕ-valued, so X < 1 ↔ X = 0). Then `integral_mono_ae (integrable_const 1) hX_integ hae` gives E[X] ≥ 1, and `integral_const, measure_univ, ENNReal.one_toReal` gives ∫ 1 = 1. `linarith` closes with E[X] ≥ 1 contradicting the hypothesis.",
+    "mathContext": "The *first moment method* (or Markov's inequality argument): for a non-negative integer-valued random variable $X$, $\\mathbb{E}[X] = \\mathbb{E}[X \\cdot 1_{X \\geq 1}] \\geq \\mathbb{P}(X \\geq 1)$. If $\\mathbb{E}[X] < 1$, then $\\mathbb{P}(X \\geq 1) < 1$, so $\\mathbb{P}(X = 0) > 0$. This is used in the probabilistic method: if the expected number of 'bad' events is less than 1, then with positive probability there are no bad events, so a 'good' configuration exists.",
+    "significance": "key",
+    "relatedConcepts": ["integral_mono_ae", "ae_iff", "IsProbabilityMeasure", "Markov inequality", "probabilistic method"],
+    "prerequisites": ["Bochner integral monotonicity", "almost everywhere reasoning", "IsProbabilityMeasure typeclass"]
+  },
+  {
+    "id": "ann-pmeoq01-linearity",
+    "proofId": "prob-method-expectation-oq-01",
+    "range": { "startLine": 97, "endLine": 110 },
+    "type": "insight",
+    "title": "Linearity of Expectation = integral_add: The Simplest Proof",
+    "content": "`linearity_of_expectation` is proved by `integral_add hX hY` — a single term that directly applies the Mathlib lemma `MeasureTheory.integral_add`. This one-liner illustrates that linearity of expectation is not a deep theorem but a direct consequence of the linearity of the Bochner integral, itself built into the definition via the L¹ space structure. The `Integrable` hypotheses are essential: Lean's Bochner integral returns 0 for non-integrable functions, so without them linearity would fail.",
+    "mathContext": "Linearity of expectation $\\mathbb{E}[X+Y] = \\mathbb{E}[X] + \\mathbb{E}[Y]$ holds for all integrable random variables (no independence required). This is the most powerful elementary tool of the probabilistic method: when X = Σ Xᵢ (indicator sum), E[X] = Σ E[Xᵢ] = Σ P(Aᵢ), giving a clean formula for the expected number of elements. The proof `integral_add hX hY` uses the L¹ completion of the Bochner integral.",
+    "significance": "supporting",
+    "relatedConcepts": ["integral_add", "Integrable", "linearity of Bochner integral", "L¹ space"],
+    "prerequisites": ["Bochner integral definition", "Integrable predicate", "MeasureTheory.integral_add"]
+  },
+  {
+    "id": "ann-pmeoq01-indicator",
+    "proofId": "prob-method-expectation-oq-01",
+    "range": { "startLine": 111, "endLine": 119 },
+    "type": "definition",
+    "title": "Indicator RVs: E[1_A] = P(A) via integral_indicator",
+    "content": "`indicatorRV A = A.indicator (fun _ => 1)` is the indicator function of A, taking value 1 inside A and 0 outside. `expectation_indicator` proves `∫ ω, indicatorRV A ω ∂μ = (μ A).toReal` by `simp [indicatorRV, integral_indicator hA]`. The `.toReal` coercion converts from `ℝ≥0∞` (where μ A lives) to `ℝ` (where the Bochner integral lives). The `MeasurableSet A` hypothesis is needed by `integral_indicator`.",
+    "mathContext": "The *indicator random variable* $1_A(\\omega) = \\begin{cases} 1 & \\omega \\in A \\\\ 0 & \\omega \\notin A \\end{cases}$ is fundamental to probability: $\\mathbb{E}[1_A] = \\mathbb{P}(A)$. In measure theory, $\\int 1_A \\, d\\mu = \\mu(A)$ (assuming $A$ is measurable). The `.toReal` coercion from `ℝ≥0∞` to `ℝ` is lossless for finite measures and probability measures. Together with linearity, $\\mathbb{E}[X] = \\sum_i \\mathbb{P}(A_i)$ when $X = \\sum_i 1_{A_i}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Set.indicator", "integral_indicator", "MeasurableSet", "ENNReal.toReal"],
+    "prerequisites": ["Set.indicator in Lean", "integral_indicator lemma", "measure-theoretic integration"]
+  }
+]

--- a/src/data/proofs/prob-method-expectation-oq-01/meta.json
+++ b/src/data/proofs/prob-method-expectation-oq-01/meta.json
@@ -20,5 +20,80 @@
     "axiomCount": 0,
     "lineCount": 119
   },
-  "sections": []
+  "crossReferences": [
+    {
+      "targetId": "prob-method-expectation",
+      "relationship": "extends",
+      "description": "Bridges the Finset-based probabilistic method to Mathlib's MeasureTheory, showing that the gallery's finite probability framework is a special case of the general measure-theoretic setup"
+    }
+  ],
+  "overview": {
+    "historicalContext": "Probability theory was placed on a rigorous foundation by Kolmogorov in his Grundbegriffe der Wahrscheinlichkeitsrechnung (1933), establishing the measure-theoretic axioms still used today. Paul Erdős pioneered the probabilistic method in combinatorics in the 1940s-50s: to prove existence of a combinatorial object, construct a random one and show it has positive probability of having the desired property. Erdős and Spencer formalized this in 'Probabilistic Methods in Combinatorics' (1974). The connection between finite probability (counting measures on finite sets) and Kolmogorov's framework is straightforward mathematically but requires explicit formalization in a proof assistant: Mathlib has both the Finset-based counting framework and the full Bochner integral machinery, but bridging them requires careful typeclass management.",
+    "problemStatement": "Is the gallery's Finset-based probabilistic method (prob(A) = |A|/|Ω|, E[X] = Σ X(ω)/|Ω|) a special case of Mathlib's MeasureTheory framework? Specifically, can the first moment method be proved using measure-theoretic tools, and can the Finset expectation be identified with the Bochner integral?",
+    "proofStrategy": "Five parts: (1) Construct `uniformProbMeasure` as `(card α)⁻¹ • Measure.count`; (2) Prove `finset_expectation_eq_integral` identifying Finset and integral expectations; (3) Prove `first_moment_method` (E[X] < 1 → P(X=0) > 0) by contradiction using `integral_mono_ae`; (4) Show linearity = `integral_add`; (5) Construct indicator RVs and prove E[1_A] = P(A) via `integral_indicator`. All 119 lines are fully proved.",
+    "keyInsights": [
+      "`uniformProbMeasure (α : Type*) : Measure α` is defined as `(Fintype.card α : ℝ≥0∞)⁻¹ • Measure.count`. The scaling by `(card α)⁻¹` normalizes the counting measure to total mass 1. The `ℝ≥0∞` coercion of `card α` handles the `ENNReal` arithmetic needed for measure theory in Lean.",
+      "`finset_expectation_eq_integral` proves `(Σ X a) / card α = ∫ a, X a ∂(uniformProbMeasure α)`. The proof uses `simp [uniformProbMeasure, integral_smul_measure, integral_count]` then `ENNReal.toReal_inv` for the cancellation. This bridge lemma makes the Finset expectation notation interchangeable with the Bochner integral.",
+      "The `first_moment_method` proof is the cleanest measure-theoretic argument in the file: assume P(X=0) = 0, then X ≥ 1 a.e. (established via `ae_iff` and a Nat inequality), so `integral_mono_ae` gives E[X] ≥ 1, contradicting the hypothesis. The `IsProbabilityMeasure` constraint is essential for `measure_univ = 1`.",
+      "`linearity_of_expectation` is a single line: `integral_add hX hY`. This is Lean's way of saying that linearity is a fundamental property of the Lebesgue/Bochner integral, not something requiring proof beyond citing the definition. The `Integrable` hypotheses ensure the integrals are well-defined.",
+      "`expectation_indicator` proves `∫ ω, 1_A(ω) ∂μ = (μ A).toReal` using `simp [indicatorRV, integral_indicator hA]`. The `.toReal` conversion from `ENNReal` to `ℝ` is necessary because probabilities live in `ℝ≥0∞` in Mathlib but expectations in `ℝ`."
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header: Finset-MeasureTheory Bridge Context",
+      "startLine": 1,
+      "endLine": 17,
+      "summary": "Documents the two probability frameworks (Finset-based and MeasureTheory), the goal of bridging them, and the parent proof. The comparison Finset vs MeasureTheory provides the motivation for each part."
+    },
+    {
+      "id": "uniform-measure",
+      "title": "Part I: Uniform Probability Measure on Finite Types",
+      "startLine": 19,
+      "endLine": 37,
+      "summary": "Proves `counting_measure_is_uniform` (Measure.count of univ = card α). Defines `uniformProbMeasure α` as `(card α)⁻¹ • Measure.count`, the uniform probability measure on a finite type."
+    },
+    {
+      "id": "expectation-bridge",
+      "title": "Part II: Finset Expectation = Measure-Theoretic Integral",
+      "startLine": 39,
+      "endLine": 51,
+      "summary": "Proves `finset_expectation_eq_integral`: (Σ X a) / card α = ∫ a, X a ∂(uniformProbMeasure α). Uses `integral_smul_measure`, `integral_count`, `ENNReal.toReal_inv`, and the `div_eq_inv_mul` identity."
+    },
+    {
+      "id": "first-moment",
+      "title": "Part III: First Moment Method in MeasureTheory",
+      "startLine": 53,
+      "endLine": 95,
+      "summary": "Proves `first_moment_method`: for ℕ-valued measurable integrable X with E[X] < 1, P(X=0) > 0. Proof by contradiction using `ae_iff`, `integral_mono_ae`, and `measure_univ = 1` from IsProbabilityMeasure."
+    },
+    {
+      "id": "linearity",
+      "title": "Part IV: Linearity of Expectation (One-Liner)",
+      "startLine": 97,
+      "endLine": 110,
+      "summary": "Proves `linearity_of_expectation` by `integral_add hX hY` — a one-liner showing that linearity is directly Mathlib's integral_add for integrable functions."
+    },
+    {
+      "id": "indicators",
+      "title": "Part V: Indicator Random Variables",
+      "startLine": 111,
+      "endLine": 119,
+      "summary": "Defines `indicatorRV A = A.indicator (fun _ => 1)`. Proves `expectation_indicator`: ∫ ω, 1_A(ω) ∂μ = (μ A).toReal using `integral_indicator hA`."
+    }
+  ],
+  "conclusion": {
+    "summary": "This 119-line fully verified (0 sorries, 0 axioms) file establishes the bridge between Finset-based finite probability and Mathlib's MeasureTheory framework. Five key results are proved: the uniform probability measure construction, the Finset/integral bridge, the first moment method, linearity of expectation, and indicator random variable expectations. The file demonstrates that the gallery's probabilistic method framework is a sound special case of the full measure-theoretic setup.",
+    "implications": "The bridge between discrete probability and measure-theoretic probability is fundamental for formalizing modern probabilistic combinatorics. Having this bridge in Lean enables applying Mathlib's rich measure theory (conditional expectation, martingales, ergodic theory) to combinatorial problems. The probabilistic method's most powerful modern tools (the Lovász Local Lemma, concentration inequalities, random algebraic methods) all require measure-theoretic foundations.",
+    "openQuestions": [
+      "Can `IsProbabilityMeasure (uniformProbMeasure α)` be proved? This would require showing the total mass equals 1: `(card α)⁻¹ * card α = 1` in `ℝ≥0∞`, which requires `card α ≠ 0` (guaranteed by `Nonempty α`).",
+      "Can the second moment method be formalized in MeasureTheory? The Paley-Zygmund inequality P(X > 0) ≥ E[X]² / E[X²] requires the Cauchy-Schwarz inequality for integrals, which is available in Mathlib.",
+      "Can the Lovász Local Lemma be formalized using dependency graph structures on probability spaces? This requires formalizing independence of events in MeasureTheory and graph-theoretic dependency, both of which are in Mathlib but not yet combined for LLL.",
+      "Can Azuma's inequality (martingale concentration) be formalized? This is one of the most useful probabilistic tools for combinatorics; Mathlib has martingales but not yet Azuma's inequality."
+    ]
+  },
+  "leanFile": {
+    "axiomCount": 0
+  }
 }


### PR DESCRIPTION
## Enrichment: prob-method-expectation-oq-01

Enriches the Probabilistic Method Finset-MeasureTheory Bridge proof gallery entry with deep mathematical context.

### Changes
- **meta.json**: Added historicalContext (Kolmogorov 1933, Erdős probabilistic method 1940s-50s, Erdős-Spencer 1974), proofStrategy, 6 keyInsights on uniformProbMeasure/bridge lemma/first moment method/linearity=integral_add/indicator RVs; 5 sections covering all 119 Lean lines; conclusion with implications and 4 open questions (IsProbabilityMeasure proof, second moment method, LLL formalization, Azuma's inequality); crossReference to prob-method-expectation
- **annotations.json**: 5 annotations — uniformProbMeasure as scaled counting measure (definition), Finset/Bochner bridge lemma via integral_count (technique), first moment method by contradiction using integral_mono_ae (technique), linearity=integral_add one-liner (insight), indicator RVs E[1_A]=P(A) via integral_indicator (definition)

### Mathematical Content
Bridges Kolmogorov's 1933 measure-theoretic probability axioms with the gallery's Finset-based probabilistic method framework. Key insight: the first moment method (E[X] < 1 → P(X=0) > 0) follows cleanly from integral_mono_ae in Mathlib's Bochner integral machinery. Linearity of expectation reduces to integral_add — a one-liner that demonstrates the power of measure-theoretic foundations.

🤖 Enricher-2