### PR TITLE
fix: correct law-of-cosines-oq-03 axiom masking (structure-encoded assumptions)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2419,10 +2419,10 @@
       "result": "clean"
     },
     "erdos-1085": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-03-24T02:56:22Z",
-      "result": "issues-found"
+      "lastAudited": "2026-04-03T05:58:50Z",
+      "result": "clean"
     },
     "erdos-1086": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11116,6 +11116,30 @@
       "lastAudited": "2026-04-03T05:51:43Z",
       "result": "clean",
       "issues": []
+    },
+    "bezout-identity-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T06:06:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-131-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T06:06:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "law-of-cosines-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T06:06:17Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "sum-of-divisors": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T06:06:17Z",
+      "result": "issues-found",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {

--- a/src/data/proofs/law-of-cosines-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03/meta.json
@@ -2,11 +2,11 @@
   "id": "law-of-cosines-oq-03",
   "title": "Hyperbolic Law of Cosines",
   "slug": "law-of-cosines-oq-03",
-  "description": "Formalizes the hyperbolic law of cosines cosh(c) = cosh(a)·cosh(b) - sinh(a)·sinh(b)·cos(C) and its dual (second law of cosines relating angles). Defines HyperbolicTriangle and HyperbolicTriangleAngles structures encoding the geometry. Proves the hyperbolic Pythagorean theorem (C=π/2 gives cosh(c) = cosh(a)·cosh(b)), the angle defect (A+B+C < π), and key hyperbolic function identities. 13 theorems, 0 definitions, 0 axioms.",
+  "description": "Axiomatizes the hyperbolic law of cosines cosh(c) = cosh(a)·cosh(b) - sinh(a)·sinh(b)·cos(C) and its dual (second law of cosines relating angles). The laws are encoded as structure fields (assumptions), not proved from a hyperbolic metric model. Proves the hyperbolic Pythagorean theorem (C=π/2 gives cosh(c) = cosh(a)·cosh(b)), the angle defect (A+B+C < π), and key hyperbolic function identities from Mathlib. 13 theorems, 2 structures, 3 structure-encoded axioms.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/LawOfCosinesOQ03.lean",
     "tags": [
       "hyperbolic-geometry",
@@ -15,11 +15,11 @@
       "differential-geometry",
       "trigonometry"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 0,
-    "assumptions": "None. The HyperbolicTriangle structure encodes the law of cosines as a hypothesis defining valid triangles.",
+    "axiomCount": 3,
+    "assumptions": "3 structure-encoded assumptions: (1) HyperbolicTriangle.law — the first law of cosines cosh(c)=cosh(a)cosh(b)-sinh(a)sinh(b)cos(C) is a structure field (not proved from metric axioms); (2) HyperbolicTriangleAngles.law2 — the second law of cosines cos(C)=-cos(A)cos(B)+sin(A)sin(B)cosh(c) is a structure field; (3) HyperbolicTriangleAngles.defect_pos — the angular defect A+B+C<π is a structure field. Also contains 1 True-stub theorem (euclidean_limit_informal).",
     "lineCount": 195,
     "theoremCount": 13,
     "definitionCount": 0,
@@ -48,7 +48,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Hyperbolic law of cosines, Pythagorean theorem, dual angle formula, and angular defect formalized. Both the first and second laws of cosines are stated. 13 theorems, 0 axioms, 195 lines.",
+    "summary": "Hyperbolic law of cosines scaffold: both laws encoded as structure assumptions, Pythagorean theorem and angular defect derived from those assumptions. 13 theorems, 3 structure-encoded axioms, 195 lines.",
     "implications": "The hyperbolic law of cosines is the fundamental tool for computing distances and angles in hyperbolic space. This formalization could serve as a foundation for hyperbolic trigonometry in Lean, with applications to Kleinian groups, 3-manifolds, and geometric group theory.",
     "openQuestions": [
       "Prove the hyperbolic law of sines: sinh(a)/sin(A) = sinh(b)/sin(B) = sinh(c)/sin(C)",
@@ -59,9 +59,9 @@
   "leanFile": {
     "namespace": "HyperbolicLawOfCosines",
     "lineCount": 195,
-    "axiomCount": 0,
+    "axiomCount": 3,
     "theoremCount": 13,
-    "definitionCount": 0
+    "definitionCount": 2
   },
   "crossReferences": [],
   "sections": []


### PR DESCRIPTION
## Summary

Gallery integrity audit finding — CRITICAL severity.

- **Proof**: `law-of-cosines-oq-03`
- **Problem**: Axiom masking via structure-encoded assumptions + True stub

## Evidence

**meta.json claimed**:
- `status: "verified"`, `badge: "original"`, `axiomCount: 0`

**Lean source shows**:
- `HyperbolicTriangle.law` — the hyperbolic law of cosines is a structure field (an assumption, not proved)
- `HyperbolicTriangleAngles.law2` — the dual law of cosines is a structure field
- `HyperbolicTriangleAngles.defect_pos` — `A+B+C < π` is a structure field
- `euclidean_limit_informal : True := trivial` — True-stub theorem
- The main "theorems" (`hyperbolic_law_of_cosines`, `hyperbolic_law_of_cosines_dual`) just return `t.law` and `t.law2` — tautological given the structure assumptions

Per the Axiom Integrity Policy: structure-encoded hypotheses count as axioms. `axiomCount: 0` was wrong.

## Fix

Updated `meta.json`:
- `status: "verified"` → `"axiomatized"`
- `badge: "original"` → `"axiom"`
- `axiomCount: 0` → `3`
- Updated `assumptions`, `description`, `conclusion.summary`, and `leanFile.axiomCount`

---
Discovered during automated gallery integrity audit (cycle 4).