### PR TITLE
Fix: remove True-stub theorems from erdos-1100 and erdos-321 proofs

### DIFF
--- a/proofs/Proofs/Erdos1100ProblemProvable.lean
+++ b/proofs/Proofs/Erdos1100ProblemProvable.lean
@@ -178,10 +178,7 @@ def question1_almost_all_growth : Prop :=
         (fun n => (tauPerp n : ℝ) / (omega n) < M ∧ omega n > 0)
         (Finset.range x)).card / (x : ℝ) < ε
 
-/--
-**Status of Question 1: OPEN**
--/
-theorem question1_open : True := trivial
+/- Status of Question 1: OPEN -/
 
 /-
 ## Part IV: Question 2 - Upper Bound
@@ -206,10 +203,7 @@ theorem erdos_hall_max_lower_bound :
     ∀ ε > 0, ∃ X : ℕ, ∀ x : ℕ, x ≥ X →
       ∃ n : ℕ, n < x ∧ (tauPerp n : ℝ) > exp ((log (log x))^(2 - ε)) := by sorry
 
-/--
-**Status of Question 2: OPEN**
--/
-theorem question2_open : True := trivial
+/- Status of Question 2: OPEN -/
 
 /-
 ## Part V: Question 3 - Growth of g(k)
@@ -285,7 +279,7 @@ example : omega 12 = 2 := by native_decide
 ## Part VII: Why This Problem Is Hard
 -/
 
-/--
+/-
 **Structural Insight:**
 The coprime consecutive divisors depend delicately on the factorization of n.
 For n = p₁^a₁ · ... · p_k^a_k:
@@ -295,7 +289,6 @@ For n = p₁^a₁ · ... · p_k^a_k:
 
 The exponential bounds on g(k) show the structure is neither trivial nor chaotic.
 -/
-theorem structural_insight : True := trivial
 
 /-
 ## Part VIII: Summary

--- a/proofs/Proofs/Erdos321ProblemR1.lean
+++ b/proofs/Proofs/Erdos321ProblemR1.lean
@@ -63,17 +63,16 @@ theorem erdos_321_asymptotics :
     the content of the open problem. -/
 /- ## Observations -/
 
-/-- **Egyptian fraction connection**: The problem relates to
-    representations of rationals as sums of distinct unit fractions.
-    R(N) measures how many denominators from {1,...,N} can be used
-    while keeping all partial sums distinguishable. -/
-theorem egyptian_fraction_connection : True := trivial
+/-
+**Egyptian fraction connection**: The problem relates to
+representations of rationals as sums of distinct unit fractions.
+R(N) measures how many denominators from {1,...,N} can be used
+while keeping all partial sums distinguishable.
 
-/-- **Greedy construction**: A natural construction takes all n
-    with certain divisibility properties, ensuring subset sums
-    separate. The challenge is optimizing the selection criterion. -/
-theorem greedy_construction : True := trivial
+**Greedy construction**: A natural construction takes all n
+with certain divisibility properties, ensuring subset sums
+separate. The challenge is optimizing the selection criterion.
 
-/-- **OEIS sequences**: Related sequences A384927 and A391592
-    track computed values of R(N) for small N. -/
-theorem oeis_sequences : True := trivial
+**OEIS sequences**: Related sequences A384927 and A391592
+track computed values of R(N) for small N.
+-/


### PR DESCRIPTION
## Fix

Convert `theorem ... : True := trivial` status markers to regular block comments in two proof files.

## Evidence

**Before**: `erdos-1100` and `erdos-321` research files contained theorems like:
```lean
theorem question1_open : True := trivial
theorem structural_insight : True := trivial
theorem egyptian_fraction_connection : True := trivial
```
These proved nothing and were misleading — they appeared as proven theorems but had no mathematical content.

**After**: Content preserved as plain block comments (`/- ... -/`). The sorry count in `meta.json` for `erdos-1100` (3 sorries) is unchanged and accurate.

---
Automated fix by lean-mechanic agent.