### PR TITLE
Fix: remove True-stub theorems from hilbert-17 and greens-theorem proofs

### DIFF
--- a/proofs/Proofs/GreensTheorem.lean
+++ b/proofs/Proofs/GreensTheorem.lean
@@ -183,8 +183,15 @@ provides the foundation for proving this by:
 1. Decomposing general regions into rectangles
 2. Showing boundary integrals cancel on shared edges
 3. Summing to get the result for the full region -/
-theorem greens_theorem_general (F : VectorField2D) (curl : Curl2D) (D : GreenRegion)
-    : True := trivial
+/-
+**Green's Theorem (General Form)**: For a continuously differentiable vector field F = (P, Q)
+and a region D bounded by a positively oriented, piecewise smooth, simple closed curve C:
+
+  ∮_C (P dx + Q dy) = ∬_D (∂Q/∂x - ∂P/∂y) dA
+
+The full formalization requires path integrals over arbitrary curves, which exceed the current
+Mathlib coverage. See axiom `greens_theorem_rectangle` for the axiomatized rectangle case.
+-/
 
 -- ============================================================
 -- PART 6: Special Cases and Applications
@@ -347,6 +354,5 @@ end GreensTheorem
 #check GreensTheorem.VectorField2D
 #check GreensTheorem.Rectangle
 #check GreensTheorem.greens_theorem_rectangle
-#check GreensTheorem.greens_theorem_general
 #check GreensTheorem.areaVectorField
 #check GreensTheorem.unitSquare_area

--- a/proofs/Proofs/Hilbert17SumOfSquares.lean
+++ b/proofs/Proofs/Hilbert17SumOfSquares.lean
@@ -420,12 +420,10 @@ Mathlib has `IsRealClosed` for fields satisfying these properties.
 -- Note: Mathlib's real closed field theory is in development
 -- #check IsRealClosed (if available)
 
-/-- The real numbers form a real closed field.
-    This is a fundamental fact that enables Artin's proof. -/
-theorem real_is_real_closed : True := by
-  -- In full Mathlib, this would be: IsRealClosed ℝ
-  -- We state as True as a placeholder
-  trivial
+/-
+The real numbers form a real closed field (IsRealClosed ℝ in Mathlib).
+This is a fundamental fact that enables Artin's proof.
+-/
 
 /-- **Transfer Principle**: Statements about polynomial inequalities that hold in one
     real closed field hold in all real closed fields. This is key to Artin's proof.


### PR DESCRIPTION
## Fix

Convert `theorem ... : True := trivial` placeholders to block comments in two gallery proof files.

## Evidence

**hilbert-17** (`Hilbert17SumOfSquares.lean`):
- **Before**: `theorem real_is_real_closed : True := by trivial` — stated placeholder for `IsRealClosed ℝ` but proved `True`
- **After**: Converted to a plain comment noting the Mathlib equivalent

**greens-theorem** (`GreensTheorem.lean`):
- **Before**: `theorem greens_theorem_general ... : True := trivial` — claimed to prove the general Green's theorem but proved only `True`
- **After**: Converted to a block comment with the actual theorem statement; dangling `#check` removed

No meta.json changes needed — `sorries` counts remain accurate, `status` values unchanged.

---
Automated fix by lean-mechanic agent.