### PR TITLE
feat: Aristotle companion for erdos-608 (numerical constant lemmas)

### DIFF
--- a/proofs/Proofs/Erdos608ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos608ProblemAristotle.lean
@@ -1,0 +1,29 @@
+/-
+  Aristotle targets for Erdős Problem #608: Edges in 5-Cycles
+
+  Routine numerical lemmas for automated proof search.
+  See Erdos608Problem.lean for the main formalization.
+
+  Candidates:
+  - c_approx: c = (2 + √2)/16 satisfies 0.213 < c < 0.214
+  - c_lt_two_ninths: c < 2/9
+-/
+import Mathlib
+
+namespace Erdos608
+
+open Real
+
+/-- The correct constant c = (2 + √2) / 16 ≈ 0.2134. -/
+noncomputable def c : ℝ := (2 + Real.sqrt 2) / 16
+
+/-- c ≈ 0.2134, so 0.213 < c < 0.214. -/
+lemma c_approx : c > 0.213 ∧ c < 0.214 := by sorry
+
+/-- c < 2/9, proving Erdős's original conjecture is false. -/
+lemma c_lt_two_ninths : c < 2/9 := by sorry
+
+/-- c > 0. -/
+lemma c_pos : c > 0 := by sorry
+
+end Erdos608


### PR DESCRIPTION
## Fix

Add Aristotle companion file `Erdos608ProblemAristotle.lean` targeting routine numerical lemmas in the `erdos-608` gallery proof.

## Evidence

**Before**: `Erdos608Problem.lean` has 13 sorries including two pure numerical computations with no Aristotle companion file.

**After**: Companion file exposes three numerical lemmas as Aristotle targets:
- `c_approx`: `(2 + √2)/16 > 0.213 ∧ (2 + √2)/16 < 0.214`
- `c_lt_two_ninths`: `(2 + √2)/16 < 2/9` — the key inequality showing Erdős's conjecture fails
- `c_pos`: `(2 + √2)/16 > 0`

**Aristotle checklist**: ✓ No def sorries ✓ No axioms ✓ No True stubs ✓ No `/-!` blocks ✓ No open conjectures

---
Automated fix by lean-mechanic agent.