### PR TITLE
Fix: sum-of-divisors badge 'original' → 'mathlib'

### DIFF
--- a/src/data/proofs/sum-of-divisors/meta.json
+++ b/src/data/proofs/sum-of-divisors/meta.json
@@ -15,7 +15,7 @@
       "perfect-numbers",
       "amicable-numbers"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
@@ -24,10 +24,7 @@
     "theoremCount": 81,
     "definitionCount": 4,
     "originalContributions": [
-      "sigma_prime: σ(p) = p+1 for all primes (general theorem, not just specific values)",
-      "sigma_multiplicative: σ is multiplicative — σ(mn) = σ(m)σ(n) when gcd(m,n)=1",
-      "sigma_prime_pow: σ(p^k) = Σ_{i=0}^k p^i for prime p (prime power formula)",
-      "IsDeficient / IsPerfect / IsAbundant: classification predicates",
+      "IsDeficient / IsPerfect / IsAbundant: classification predicates (new definitions)",
       "six_is_perfect / twenty_eight_is_perfect: first two perfect numbers verified",
       "twelve_abundant / smallest_abundant: 12 is the smallest abundant number (minimality proof)",
       "amicable_220_284 / amicable_1184_1210: amicable pair verification",


### PR DESCRIPTION
## Fix

Corrects `badge` from `"original"` to `"mathlib"` for the sum-of-divisors gallery entry.

## Evidence

**Before**: `badge: "original"` — claims fully independent work (Tier A)

**After**: `badge: "mathlib"` — correctly reflects that core theorems wrap Mathlib:
- `sigma_multiplicative` is just `isMultiplicative_sigma` (Mathlib lemma)
- `sigma_prime_pow` wraps `sigma_apply_prime_pow` (Mathlib lemma)
- `sigma_prime` also uses `sigma_apply_prime_pow`

Genuinely original contributions retained in `originalContributions`:
- `IsDeficient / IsPerfect / IsAbundant` predicates
- Perfect number verifications (6, 28)
- `twelve_smallest_abundant` minimality proof
- Amicable pair verifications
- `abundancy_index`

Closes #8693

---
Automated fix by lean-mechanic agent.