### PR TITLE
enrichment: 9 gallery proofs with deep mathematical annotations

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-gauss-sum-norm",
+    "proofId": "bounded-prime-gaps-oq-04-oq-01",
+    "range": { "startLine": 65, "endLine": 79 },
+    "type": "definition",
+    "title": "Gauss Sum and Its Norm",
+    "content": "The Gauss sum τ(χ) = Σ_{t=0}^{q-1} χ(t)·e^{2πit/q} is a weighted sum of roots of unity, acting as the 'Fourier transform coefficient' of the character χ. For primitive non-principal characters, |τ(χ)| = √q exactly — a fact proved via the identity τ(χ)·τ(χ̄) = χ(-1)·q (itself from character orthogonality) and |τ(χ)| = |τ(χ̄)|. This √q normalization is what produces the √q factor in the final inequality.",
+    "mathContext": "$\\tau(\\chi) = \\sum_{t=0}^{q-1} \\chi(t) e^{2\\pi i t/q}, \\quad |\\tau(\\chi)| = \\sqrt{q}$ for primitive $\\chi \\neq 1$",
+    "significance": "key",
+    "relatedConcepts": ["Gauss sums", "character orthogonality", "Fourier analysis on Z/qZ", "primitive characters"],
+    "prerequisites": ["Dirichlet characters", "roots of unity", "complex norm"]
+  },
+  {
+    "id": "ann-geometric-series",
+    "proofId": "bounded-prime-gaps-oq-04-oq-01",
+    "range": { "startLine": 84, "endLine": 99 },
+    "type": "technique",
+    "title": "Exponential Sum Bound via Geometric Series",
+    "content": "The key insight is that a partial sum of the geometric series Σ e^{2πiθn} has the closed form (e^{2πiθ(M+1)} · (1 - e^{2πiθN})) / (1 - e^{2πiθ}). The numerator has absolute value at most 2, while the denominator satisfies |1 - e^{2πiθ}| = 2|sin(πθ)| by the identity |e^{iφ} - 1| = 2|sin(φ/2)|. The bound 1/|sin(πθ)| diverges as θ → 0 (long-wavelength modes are harder to cancel) but is bounded away from the trivial bound N for fixed θ.",
+    "mathContext": "$\\left|\\sum_{n=M+1}^{M+N} e^{2\\pi i \\theta n}\\right| = \\frac{|1 - e^{2\\pi i \\theta N}|}{|1 - e^{2\\pi i \\theta}|} \\leq \\frac{2}{2|\\sin(\\pi\\theta)|} = \\frac{1}{|\\sin(\\pi\\theta)|}$",
+    "significance": "key",
+    "relatedConcepts": ["geometric series", "exponential sums", "half-angle identity", "Weyl sums"],
+    "prerequisites": ["complex exponential", "geometric series closed form", "trigonometric identities"]
+  },
+  {
+    "id": "ann-cotangent-sum",
+    "proofId": "bounded-prime-gaps-oq-04-oq-01",
+    "range": { "startLine": 104, "endLine": 113 },
+    "type": "technique",
+    "title": "Cotangent Sum via Harmonic Series",
+    "content": "After bounding each exponential partial sum by 1/|sin(πa/q)|, the total is Σ_{a=1}^{q-1} 1/|sin(πa/q)|. The concavity of sin on [0,π] gives |sin(πa/q)| ≥ 2a/q for a ≤ q/2 (the lower linear bound), so 1/|sin(πa/q)| ≤ q/(2a). Summing over a = 1,...,q/2 gives (q/2)·H_{q/2} ≈ (q/2)·log(q/2) ≈ (q/2)·log(q). The symmetric bound for a = q/2,...,q-1 doubles this, giving the (2q/π)·log(q) estimate.",
+    "mathContext": "$\\sum_{a=1}^{q-1} \\frac{1}{|\\sin(\\pi a/q)|} \\leq \\frac{q}{2} \\cdot 2 \\sum_{a=1}^{q/2} \\frac{q}{2a} = \\frac{q}{2} \\cdot H_{\\lfloor q/2\\rfloor} \\sim \\frac{q}{2}\\log q$",
+    "significance": "supporting",
+    "relatedConcepts": ["harmonic series", "concavity of sin", "cotangent sums", "Euler-Mascheroni constant"],
+    "prerequisites": ["harmonic series bound", "concavity inequality for sin", "Finset.sum bounds"]
+  },
+  {
+    "id": "ann-main-theorem",
+    "proofId": "bounded-prime-gaps-oq-04-oq-01",
+    "range": { "startLine": 119, "endLine": 141 },
+    "type": "insight",
+    "title": "Assembling the Inequality",
+    "content": "The main proof assembles the three lemmas. Starting with the Fourier expansion χ(n) = (1/τ(χ̄))·Σ_a χ̄(a)·e^{2πian/q}, summing over n in [M+1, M+N] and applying the triangle inequality gives |Σ χ(n)| ≤ (1/|τ(χ̄)|)·Σ_a |Σ_n e^{2πian/q}|. The geometric bound replaces each inner sum by 1/|sin(πa/q)|, the Gauss norm gives |τ(χ̄)| = √q, and the cotangent sum provides the log(q) factor. The constant 2/π < 1 absorbed into the bound makes the theorem slightly cleaner than the proof sketch.",
+    "mathContext": "$\\left|\\sum_n \\chi(n)\\right| \\leq \\frac{1}{\\sqrt{q}} \\cdot \\sum_{a=1}^{q-1} \\frac{1}{|\\sin(\\pi a/q)|} \\leq \\frac{1}{\\sqrt{q}} \\cdot \\frac{2q}{\\pi}(\\log q + 1) = \\frac{2}{\\pi}\\sqrt{q}(\\log q + 1) \\leq \\sqrt{q}(\\log q + 1)$",
+    "significance": "key",
+    "relatedConcepts": ["Pólya-Vinogradov inequality", "triangle inequality", "Fourier expansion of characters", "Bombieri-Vinogradov theorem"],
+    "prerequisites": ["Gauss sum norm", "geometric series bound", "cotangent sum bound", "character Fourier expansion"]
+  },
+  {
+    "id": "ann-complete-sum",
+    "proofId": "bounded-prime-gaps-oq-04-oq-01",
+    "range": { "startLine": 146, "endLine": 155 },
+    "type": "concept",
+    "title": "Complete Character Sum Orthogonality",
+    "content": "The complete sum Σ_{n=0}^{q-1} χ(n) = 0 for non-principal χ is a direct consequence of character orthogonality (or the fact that χ is a non-trivial group homomorphism). This is much easier than the Pólya-Vinogradov inequality (which handles *partial* sums) and would follow from Mathlib's `DirichletCharacter.sum_eq_zero_of_ne_one` or similar. It illustrates that the difficulty lies in controlling *incomplete* character sums over intervals not aligned with the full period.",
+    "mathContext": "$\\sum_{n=0}^{q-1} \\chi(n) = 0 \\quad \\text{for } \\chi \\neq \\chi_0 \\pmod{q}$",
+    "significance": "context",
+    "relatedConcepts": ["character orthogonality", "group homomorphisms", "incomplete vs complete sums"],
+    "prerequisites": ["Dirichlet characters as group homomorphisms", "Mathlib DirichletCharacter API"]
+  },
+  {
+    "id": "ann-proof-roadmap",
+    "proofId": "bounded-prime-gaps-oq-04-oq-01",
+    "range": { "startLine": 160, "endLine": 196 },
+    "type": "context",
+    "title": "Four-Phase Proof Plan",
+    "content": "The roadmap organizes the ~700-line full proof into four phases, each with a clear goal. Phase 1 (Gauss sum, ~300 lines) is the most complex because the double sum identity τ(χ)·τ(χ̄) = χ(-1)·q requires careful handling of character orthogonality in Lean. Phases 2-3 (geometric and cotangent bounds, ~300 lines total) are more elementary but require trigonometric lemmas. Phase 4 (assembly, ~100 lines) is mechanical once the three lemmas are proved. Mathlib's `ZMod.gaussSum` infrastructure may shorten Phase 1 significantly.",
+    "mathContext": "Total proof: $\\approx 700$ lines $= 300$ (Gauss) $+ 100$ (geometric) $+ 200$ (cotangent) $+ 100$ (assembly)",
+    "significance": "technical",
+    "relatedConcepts": ["proof engineering", "Mathlib ZMod.gaussSum", "DirichletCharacter API", "proof by phases"],
+    "prerequisites": ["Lean 4 tactic mode", "Mathlib number theory imports"]
+  }
+]

--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-01/meta.json
@@ -24,13 +24,68 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "problemStatement": "Prove the Pólya-Vinogradov inequality: |Σ_{n=M+1}^{M+N} χ(n)| ≤ √q·log(q) for non-principal Dirichlet characters χ mod q.",
-    "proofStrategy": "Fourier expansion via Gauss sums → geometric series bounds → cotangent sum estimate → assembly with |τ(χ)| = √q.",
+    "historicalContext": "The Pólya-Vinogradov inequality was proved independently in 1918 by George Pólya (Göttingen, in the Göttinger Nachrichten) and Ivan Vinogradov (Russia), making it one of the first major results in analytic number theory obtained simultaneously by two researchers working independently. Their common insight was to apply the Fourier expansion of Dirichlet characters via Gauss sums to reduce a character sum to a sum of exponential terms, each controlled by geometric series. The result is essentially tight: the √q factor comes from the Gauss sum normalization and cannot be improved, while Montgomery and Vaughan showed in 1977 that (under GRH) the log(q) can be replaced by log(log(q)). The unconditional improvement to √q·log(log(q)) for primitive characters (in an averaged sense) remains an active area. The inequality is the single most useful tool in the analytic theory of Dirichlet characters and underpins the quantitative equidistribution of primes in arithmetic progressions.",
+    "problemStatement": "For any non-principal primitive Dirichlet character $\\chi$ modulo $q \\geq 2$ and any integers $M, N$: $$\\left|\\sum_{n=M+1}^{M+N} \\chi(n)\\right| \\leq \\sqrt{q} \\cdot \\log(q)$$",
+    "proofStrategy": "Fourier expansion via Gauss sums → geometric series bounds → cotangent sum estimate → assembly with |τ(χ)| = √q. Specifically: (1) expand χ(n) = (1/τ(χ̄))·Σ_a χ̄(a)·e^{2πian/q}, (2) sum over n in the interval and apply triangle inequality, (3) bound each exponential partial sum by 1/|sin(πa/q)| using geometric series, (4) divide by |τ(χ̄)| = √q, (5) bound the resulting cotangent sum Σ 1/|sin(πa/q)| by (2q/π)·log(q) via harmonic series comparison.",
     "keyInsights": [
-      "Gauss sum bound |τ(χ)| = √q is the foundation — proved via τ(χ)·τ(χ̄) = χ(-1)·q",
-      "Geometric series partial sum bounded by 1/|sin(πa/q)|",
-      "Cotangent sum reduces to harmonic series, giving log(q) factor",
-      "Full proof ~700 lines, most tractable of the 6 BV prerequisites"
+      "Gauss sum norm |τ(χ)| = √q is the foundational bound — proved from the identity τ(χ)·τ(χ̄) = χ(-1)·q, which itself follows from orthogonality of characters modulo q. Since |τ(χ)| = |τ(χ̄)|, we get |τ(χ)|² = q.",
+      "The geometric series bound |Σ_{n=M+1}^{M+N} e^{2πiθn}| ≤ 1/|sin(πθ)| comes from the closed form (1-e^{2πiθN})/(1-e^{2πiθ}): the numerator has absolute value ≤ 2, and |1-e^{2πiθ}| = 2|sin(πθ)| by the half-angle identity.",
+      "The cotangent sum Σ_{a=1}^{q-1} 1/|sin(πa/q)| ≤ (2q/π)·log(q) is bounded by exploiting concavity of sin: for 1 ≤ a ≤ q/2, we have |sin(πa/q)| ≥ 2a/q, so 1/|sin(πa/q)| ≤ q/(2a), converting the sum to a harmonic series.",
+      "The assembly step divides the character sum by |τ(χ̄)| = √q and multiplies by the cotangent sum, giving (1/√q)·(2q/π)·log(q) = (2/π)·√q·log(q) ≤ √q·log(q) since 2/π < 1.",
+      "This formalization is a key prerequisite for the Bombieri-Vinogradov theorem (bounded-prime-gaps-oq-04), which in turn is a prerequisite for conditional bounded prime gap results. The five sorries correspond to the four main steps (Gauss norm, geometric bound, cotangent bound, full assembly) plus the easy orthogonality consequence."
+    ]
+  },
+  "sections": [
+    {
+      "id": "gauss-sum-bound",
+      "title": "Gauss Sum Norm",
+      "startLine": 61,
+      "endLine": 79,
+      "summary": "States gaussSumNorm: for a primitive non-principal character χ mod q, the Gauss sum τ(χ) = Σ_t χ(t)·e^{2πit/q} has norm exactly √q. Proof deferred (sorry) — requires orthogonality of roots of unity."
+    },
+    {
+      "id": "geometric-series",
+      "title": "Geometric Series Bound",
+      "startLine": 80,
+      "endLine": 99,
+      "summary": "States geom_partial_sum_bound: |Σ_{n=M+1}^{M+N} e^{2πiθn}| ≤ 1/|sin(πθ)|. Proof deferred (sorry) — uses closed form for geometric series and half-angle identity."
+    },
+    {
+      "id": "cotangent-sum",
+      "title": "Cotangent Sum Bound",
+      "startLine": 100,
+      "endLine": 113,
+      "summary": "States cotangent_sum_bound: Σ_{a=1}^{q-1} 1/|sin(πa/q)| ≤ (2q/π)·(log q + 1). Proof deferred (sorry) — reduces to harmonic series via concavity of sin."
+    },
+    {
+      "id": "polya-vinogradov",
+      "title": "Pólya-Vinogradov Inequality",
+      "startLine": 115,
+      "endLine": 141,
+      "summary": "States the main theorem: |Σ_{n=M+1}^{M+N} χ(n)| ≤ √q·(log q + 1). Proof deferred (sorry) — assembles the three lemmas above via triangle inequality and the Fourier expansion of χ."
+    },
+    {
+      "id": "complete-character-sum",
+      "title": "Complete Character Sum Vanishes",
+      "startLine": 142,
+      "endLine": 155,
+      "summary": "States complete_character_sum_zero: Σ_{n=0}^{q-1} χ(n) = 0 for non-principal χ. Proof deferred (sorry) — follows from character orthogonality, simpler than the main inequality."
+    },
+    {
+      "id": "proof-roadmap",
+      "title": "Roadmap to Full Proof",
+      "startLine": 156,
+      "endLine": 203,
+      "summary": "Detailed four-phase proof plan (~700 lines total): Gauss sum bound (~300 lines), geometric series (~100 lines), cotangent sum (~200 lines), assembly (~100 lines). Lists Mathlib infrastructure required."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization precisely states all components of the Pólya-Vinogradov inequality in Lean 4 with a detailed four-phase proof roadmap. All five sorries correspond to well-understood mathematical arguments; the formalization is complete at the statement level and is structured to support incremental completion of each phase.",
+    "implications": "Completing this formalization would unlock the Bombieri-Vinogradov theorem (the parent goal), which is the key analytic ingredient in the bounded prime gap problem. The Pólya-Vinogradov inequality also has independent significance as the sharpest unconditional bound on character sums over intervals, with applications throughout analytic number theory including zero-free regions for L-functions and exponential sum bounds in cryptography.",
+    "openQuestions": [
+      "Can the log(q) factor be replaced by log(log(q)) unconditionally? Montgomery-Vaughan achieved this under GRH in 1977; the unconditional improvement is open.",
+      "Is there a simpler Lean proof avoiding Fourier expansion entirely? Some elementary approaches exist but are typically longer.",
+      "Can Mathlib's existing `ZMod.gaussSum` and `DirichletCharacter` infrastructure be leveraged to shorten the Gauss sum phase below the estimated 300 lines?"
     ]
   },
   "crossReferences": [


### PR DESCRIPTION
## Summary

Enriches 9 proof gallery entries with detailed mathematical content:

- **konigsberg-oq-03**: Hypergraph Euler tours — Lonc-Naroski 2010, infinite graph theory
- **euler-totient-oq-01**: Carmichael's λ function — LCM of orders, Monoid.exponent
- **elementary-quadratic-reciprocity-oq-03-oq-01-oq-02**: Jacobi symbol computation — recursive reduction algorithm
- **bounded-prime-gaps-oq-04-oq-01**: Pólya-Vinogradov inequality — Gauss sum norm, Montgomery-Vaughan
- **elementary-quadratic-reciprocity-oq-03-oq-02-oq-01**: Kronecker symbol extension — multiplicativity proofs
- **erdos-1015-oq-05**: Ramsey axiom elimination — Erdős-Szekeres bound, Nat.find definition
- **collatz-structured-oq-03**: Average Collatz stopping time — Terras density, heuristic constant
- **euler-totient-oq-02**: Totient multiplicativity — CRT proof, prime power formula, unit group connection

Each entry receives:
- Historical context with LaTeX mathematical notation
- Key insights explaining proof strategy and mathematical depth
- Sections with line numbers for gallery navigation
- Conclusion with open research questions
- 5-6 targeted annotations at key theorem/definition lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)