### PR TITLE
Fix: erdos-42 axiomCount 4→0 (axioms only in comments)

### DIFF
--- a/src/data/proofs/erdos-42/meta.json
+++ b/src/data/proofs/erdos-42/meta.json
@@ -20,7 +20,7 @@
     "erdosNumber": 42,
     "erdosUrl": "https://erdosproblems.com/42",
     "erdosProblemStatus": "open",
-    "axiomCount": 4,
+    "axiomCount": 0,
     "lineCount": 165,
     "prerequisites": [
       "Sidon sets (B₂ sequences) and their properties",
@@ -28,7 +28,7 @@
       "Extremal combinatorics and Ramsey theory",
       "Finite field constructions (Singer difference sets)"
     ],
-    "assumptions": "4 axiom declarations: sedov_M2, sedov_M3, ErdosProblem42, ErdosProblem42_constructive. sidon_size_bound proved from Mathlib via difference counting injection.",
+    "assumptions": "0 axioms, 0 sorries. The main conjecture (Erdős Problem 42) and Sedov's partial results are referenced in comments but not formally stated as Lean axioms or theorems. Open problem.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -152,7 +152,7 @@
     "opens": [],
     "namespace": null,
     "lineCount": 165,
-    "axiomCount": 4,
+    "axiomCount": 0,
     "theoremCount": 1,
     "definitionCount": 5
   },


### PR DESCRIPTION
## Fix

Corrects `axiomCount` in `erdos-42/meta.json` from 4 to 0.

## Evidence

**Before**: `axiomCount: 4`, `assumptions` listed 4 axiom names
**After**: `axiomCount: 0`, `assumptions` notes axioms exist only as comments

**Lean source shows**: `proofs/Proofs/Erdos42Problem.lean` has 0 `axiom` declarations. The 4 intended axioms (`sedov_M2`, `sedov_M3`, `ErdosProblem42`, `ErdosProblem42_constructive`) appear only as docstring comments at the end of the file, not as actual Lean axiom statements.

Status remains `"axiomatized"` — this is an open problem.

Closes #8699

---
Automated fix by lean-mechanic agent.