### PR TITLE
Fix: erdos-121 axiomCount 7→0 (axioms only in comments)

### DIFF
--- a/src/data/proofs/erdos-121/meta.json
+++ b/src/data/proofs/erdos-121/meta.json
@@ -20,9 +20,9 @@
     "erdosNumber": 121,
     "erdosUrl": "https://erdosproblems.com/121",
     "erdosProblemStatus": "disproved",
-    "axiomCount": 7,
+    "axiomCount": 0,
     "lineCount": 75,
-    "assumptions": "7 axioms: f2_asymptotic, f3_full_density, f4_density_zero, and 4 more. See Lean source for complete statements.",
+    "assumptions": "0 axioms, 0 sorries. The key asymptotic results (f2_asymptotic, f3_full_density, f4_density_zero, etc.) appear as docstring comments in the Lean source but are not formally stated as axiom declarations.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -99,7 +99,7 @@
     "opens": [],
     "namespace": null,
     "lineCount": 75,
-    "axiomCount": 7,
+    "axiomCount": 0,
     "theoremCount": 0,
     "definitionCount": 4
   },


### PR DESCRIPTION
## Fix

Corrects `axiomCount` in `erdos-121/meta.json` from 7 to 0.

## Evidence

**Before**: `axiomCount: 7`, assumptions listed 7 axiom names
**After**: `axiomCount: 0`, assumptions notes they exist only as comments

**Lean source shows**: `Proofs/Erdos121Problem.lean` (75 lines) has 0 `axiom` declarations. The 7 intended axioms (`f2_asymptotic`, `f3_full_density`, `f4_density_zero`, etc.) appear only as docstring comments, not actual Lean axiom statements.

Status remains `"axiomatized"` — this is a disproved conjecture.

Closes #8701

---
Automated fix by lean-mechanic agent.