### PR TITLE
Fix: batch axiomCount corrections for erdos-339/527/572

### DIFF
--- a/src/data/proofs/erdos-339/meta.json
+++ b/src/data/proofs/erdos-339/meta.json
@@ -58,9 +58,9 @@
       "IsSidonSet, IsBhSet definitions",
       "erdos_339_solved, erdos_339_summary theorems"
     ],
-    "axiomCount": 6,
+    "axiomCount": 3,
     "lineCount": 215,
-    "assumptions": "6 axioms: hegyvari_hennecart_plagne_1, hegyvari_hennecart_plagne_2, density_preservation, and 3 more. See Lean source for complete statements."
+    "assumptions": "3 axioms: hegyvari_hennecart_plagne_1, hegyvari_hennecart_plagne_2, squares_basis_of_order_4. See Lean source for complete statements."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #339: Additive Bases and Distinct Sums**\n\nThis problem explores the relationship between additive bases and 'restricted' representations using distinct elements.\n\n**Key History:**\n- Erdős-Graham (1980): Posed both conjectures in their monograph\n- Hegyvári-Hennecart-Plagne (2003): Proved both conjectures in J. Reine Angew. Math.\n\n**Mathematical Setting:**\nA set A ⊆ ℕ is a basis of order r if every large integer is a sum of r elements from A. The question is whether the 'restricted' sums (using r DISTINCT elements) also cover a positive fraction of integers.",
@@ -188,7 +188,7 @@
     ],
     "namespace": "Erdos339",
     "lineCount": 215,
-    "axiomCount": 6,
+    "axiomCount": 3,
     "theoremCount": 7,
     "definitionCount": 12
   },

--- a/src/data/proofs/erdos-527/meta.json
+++ b/src/data/proofs/erdos-527/meta.json
@@ -68,9 +68,9 @@
       "example_seq: canonical example aₙ = 1/(√n log n)",
       "erdos_527_main and erdos_527_strong: proved from axioms"
     ],
-    "axiomCount": 10,
+    "axiomCount": 3,
     "lineCount": 136,
-    "assumptions": "10 axioms: signMeasure, divergence_typical, dvoretzky_erdos_1959, and 7 more. See Lean source for complete statements."
+    "assumptions": "3 axioms: signMeasure, michelen_sawhney_2025, hausdorff_dimension_one. See Lean source for complete statements."
   },
   "overview": {
     "historicalContext": "Erdős Problem #527, posed in 1961 (p. 254), concerns the behavior of random power series on the unit circle. Given a sequence of real coefficients aₙ with divergent sum of squares and |aₙ| = o(1/√n), Erdős asked whether random sign choices almost surely yield convergence at some point on the unit circle.\n\nThe problem sits at the intersection of harmonic analysis, probability theory, and fractal geometry. Dvoretzky and Erdős (1959) had established that if coefficients decay no faster than c/√n, the random series diverges everywhere on the unit circle for almost all sign choices. This showed that the decay condition |aₙ| = o(1/√n) is sharp — any slower decay destroys convergence entirely.\n\nThe problem remained open for over 60 years until Michelen and Sawhney (2025) resolved it affirmatively. Their proof showed not merely that convergence occurs somewhere, but that the convergence set has Hausdorff dimension 1 — the largest possible geometric size for a measure-zero subset of the circle. This dramatic result reveals that even when divergence dominates almost everywhere, convergence persists on a rich fractal set.",
@@ -165,7 +165,7 @@
     ],
     "namespace": "Erdos527",
     "lineCount": 136,
-    "axiomCount": 10,
+    "axiomCount": 3,
     "theoremCount": 3,
     "definitionCount": 8
   },

--- a/src/data/proofs/erdos-572/meta.json
+++ b/src/data/proofs/erdos-572/meta.json
@@ -53,9 +53,9 @@
       "luwExponent, conjecturedExponent: exponent comparison",
       "erdos_klein_c4, odd_cycle_extremal: related results"
     ],
-    "axiomCount": 6,
+    "axiomCount": 3,
     "lineCount": 307,
-    "assumptions": "6 axiom(s) and 1 sorry(s). See the Lean source for details."
+    "assumptions": "3 axioms: benson_k3 (C₆ lower bound), benson_k5 (C₁₀ lower bound), lazebnik_ustimenko_woldar (general LUW bound). 0 sorries."
   },
   "overview": {
     "historicalContext": "**Extremal Graph Theory and Even Cycles**\n\nThis problem concerns the Turán-type extremal function ex(n; H), which asks for the maximum number of edges in an n-vertex graph containing no copy of H. For even cycles C_{2k}, this is one of the central open problems in extremal graph theory.\n\n**Historical Timeline:**\n- 1938: Erdős and Klein showed ex(n; C_4) ~ n^{3/2}, related to finite projective planes\n- 1964: Erdős conjectured ex(n; C_{2k}) >> n^{1+1/k} for k >= 3\n- 1966: Benson proved the conjecture for k=3 (girth 8) and k=5 (girth 12) using generalized polygons\n- 1974: Bondy-Simonovits proved the upper bound ex(n; C_{2k}) << kn^{1+1/k}\n- 1995: Lazebnik-Ustimenko-Woldar proved a weaker general lower bound\n\n**The Gap:**\nFor k=4 and k >= 6, the conjectured lower bound n^{1+1/k} remains unproved. The LUW bound gives n^{1+2/(3k-3+ν)} which is strictly weaker.",
@@ -157,7 +157,7 @@
     ],
     "namespace": "Erdos572",
     "lineCount": 307,
-    "axiomCount": 6,
+    "axiomCount": 3,
     "theoremCount": 8,
     "definitionCount": 7
   },


### PR DESCRIPTION
## Fix

Corrects `axiomCount` in 3 `meta.json` files where the count overstated the actual axioms in the Lean source.

## Evidence

| Proof | meta axiomCount | Lean axiomCount | Fix |
|-------|----------------|-----------------|-----|
| erdos-339 | 6 | 3 | `hegyvari_hennecart_plagne_1/2`, `squares_basis_of_order_4` |
| erdos-527 | 10 | 3 | `signMeasure`, `michelen_sawhney_2025`, `hausdorff_dimension_one` |
| erdos-572 | 6 | 3 | `benson_k3`, `benson_k5`, `lazebnik_ustimenko_woldar` |

Also corrected erdos-572 `assumptions` text: claimed "1 sorry" but source has 0 sorries.

All files remain `"axiomatized"` status.

Closes #8704

---
Automated fix by lean-mechanic agent.