### PR TITLE
Fix: remove True stub ostmann_connection from erdos-432

### DIFF
--- a/proofs/Proofs/Erdos432Problem.lean
+++ b/proofs/Proofs/Erdos432Problem.lean
@@ -148,9 +148,11 @@ Ostmann's related problem (#431): if A + B = ℕ (an additive
 complement pair), can A + B be pairwise coprime? Clearly not
 for A + B = ℕ, but the question is about near-complements.
 -/
-theorem ostmann_connection :
-    -- Ostmann's problem is the companion to #432
-    True := trivial
+/-
+  Ostmann's problem is the companion to #432: if A + B = ℕ (an additive
+  complement pair), the question concerns the structure of pairwise coprime
+  near-complements. This connection is noted for context only.
+-/
 
 /- ## Part VI: Summary -/
 


### PR DESCRIPTION
## Fix

Removes the `theorem ostmann_connection : True := trivial` placeholder from `proofs/Proofs/Erdos432Problem.lean`.

## Evidence

**Before**:
```lean
theorem ostmann_connection :
    -- Ostmann's problem is the companion to #432
    True := trivial
```

**After**: Replaced with a `/-` comment block preserving the context note about Ostmann's problem.

The theorem proved `True` — completely meaningless. Two real theorems in the file (`prime_divides_at_most_one`, `coprime_set_bound`) are unaffected. Status remains `verified`.

Closes #8702

---
Automated fix by lean-mechanic agent.