### PR TITLE
Fix: batch axiomCount mismatches in erdos-1021, erdos-1020, erdos-1126-oq-01

### DIFF
--- a/src/data/proofs/erdos-1020/meta.json
+++ b/src/data/proofs/erdos-1020/meta.json
@@ -22,9 +22,9 @@
     "erdosNumber": 1020,
     "erdosUrl": "https://erdosproblems.com/1020",
     "erdosProblemStatus": "open",
-    "axiomCount": 11,
+    "axiomCount": 6,
     "lineCount": 326,
-    "assumptions": "11 axiom(s) and 0 sorry(s). See the Lean source for details.",
+    "assumptions": "6 axiom declarations: erdos_gallai_graphs (Erdős-Gallai theorem for graphs), luczak_mieczkowska (r=3 case, Łuczak-Mieczkowska 2014), huang_loh_sudakov (large n regime), frankl_upper_bound (Frankl's (k-1)·C(n-1,r-1) upper bound), construction1_lower (first extremal construction), construction2_lower (second extremal construction). 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -185,7 +185,7 @@
     ],
     "namespace": null,
     "lineCount": 326,
-    "axiomCount": 11,
+    "axiomCount": 6,
     "theoremCount": 4,
     "definitionCount": 11
   },

--- a/src/data/proofs/erdos-1021/meta.json
+++ b/src/data/proofs/erdos-1021/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Simonovits",
     "sourceUrl": "https://erdosproblems.com/1021",
     "date": "1971",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1021Problem.lean",
     "tags": [
       "graph-theory",
@@ -16,7 +16,7 @@
       "turan-type",
       "bipartite-graphs"
     ],
-    "badge": "axiom",
+    "badge": "formalized",
     "sorries": 2,
     "erdosNumber": 1021,
     "erdosUrl": "https://erdosproblems.com/1021",
@@ -25,9 +25,9 @@
       "erdos-572",
       "erdos-926"
     ],
-    "axiomCount": 4,
+    "axiomCount": 0,
     "lineCount": 241,
-    "assumptions": "4 axioms: G3_is_C6, erdos_simonovits_limit, C6_extremal_bound, kovari_sos_turan. 2 sorries remain.",
+    "assumptions": "0 axiom declarations. 2 sorries remain.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -253,7 +253,7 @@
     ],
     "namespace": "Erdos1021",
     "lineCount": 241,
-    "axiomCount": 4,
+    "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 17
   }

--- a/src/data/proofs/erdos-1126-oq-01/meta.json
+++ b/src/data/proofs/erdos-1126-oq-01/meta.json
@@ -64,9 +64,9 @@
       "log_of_mul_is_additive: Logarithmic reduction of multiplicative to additive equation (PROVED)"
     ],
     "dateAdded": "2026-03-24",
-    "axiomCount": 5,
+    "axiomCount": 3,
     "lineCount": 485,
-    "assumptions": "5 axioms: almost_multiplicative_stability, almost_jensen_stability, almost_derivation_stability, measurable_multiplicative_is_power, measurable_derivation_is_zero. 1 sorry remains (ae_double_of_almost_jensen, Fubini section extraction)."
+    "assumptions": "3 axiom declarations: almost_jensen_stability, almost_derivation_stability, measurable_derivation_is_zero. 1 sorry remains (ae_double_of_almost_jensen, Fubini section extraction)."
   },
   "overview": {
     "historicalContext": "**Extending the de Bruijn-Jurkat Paradigm**\n\nThe de Bruijn-Jurkat theorem (1965-66) showed that almost additive functions can be corrected to truly additive functions a.e. This naturally raises the question: does the same stability hold for other fundamental functional equations?\n\n**The Key Equations:**\n1. **Multiplicative** (Cauchy exponential): $f(xy) = f(x)f(y)$ — characterizes exponentials and power functions\n2. **Jensen** (midpoint affinity): $f((x+y)/2) = (f(x)+f(y))/2$ — characterizes affine functions\n3. **Derivation** (Leibniz rule): $d(xy) = x \\cdot d(y) + y \\cdot d(x)$ — characterizes differentiation\n\n**Known Results:**\n- **Ger (1979)** showed stability holds for polynomial functional equations, which includes the derivation case\n- **Járai (2005)** gave a comprehensive treatment of regularity for functional equations in several variables\n- The multiplicative case reduces to the additive case via logarithms (for positive solutions)\n- The Jensen case is algebraically equivalent to the additive case modulo a constant",
@@ -185,6 +185,6 @@
     "path": "proofs/Proofs/Erdos1126OQ01Problem.lean",
     "filename": "Erdos1126OQ01Problem.lean",
     "lineCount": 485,
-    "axiomCount": 5
+    "axiomCount": 3
   }
 }


### PR DESCRIPTION
## Fix

Correct axiomCount fields for three entries where meta.json overstated actual axiom counts.

## Evidence

| Proof | Before | After | Notes |
|-------|--------|-------|-------|
| erdos-1021 | axiomCount=4, status=axiomatized, badge=axiom | axiomCount=0, status=formalized, badge=formalized | File rewritten with 0 axioms, 2 sorries |
| erdos-1020 | axiomCount=11 | axiomCount=6 | 6 actual axioms: erdos_gallai_graphs, luczak_mieczkowska, huang_loh_sudakov, frankl_upper_bound, construction1_lower, construction2_lower |
| erdos-1126-oq-01 | axiomCount=5 | axiomCount=3 | 3 actual axioms: almost_jensen_stability, almost_derivation_stability, measurable_derivation_is_zero |

Updated both `meta.axiomCount` and `leanFile.axiomCount` in each file.

Closes #8716

---
Automated fix by lean-mechanic agent.