### PR TITLE
Fix: axiomCount mismatches in erdos-351, erdos-519, birch-swinnerton-dyer

### DIFF
--- a/proofs/Proofs/BirchSwinnertonDyer.lean
+++ b/proofs/Proofs/BirchSwinnertonDyer.lean
@@ -1623,8 +1623,8 @@ axiom regulator_pos (E : EllipticCurveQ) (hr : algebraicRank E > 0) :
     R = ĥ(P) where P generates E(ℚ)/torsion. -/
 theorem regulator_rank_one_is_height (_E : EllipticCurveQ)
     (_hr : algebraicRank _E = 1) :
-    True := -- Placeholder: R = ĥ(generator)
-  trivial
+    ∃ (h : CanonicalHeight _E) (g : ℝ), regulatorValue _E = h.height g := by
+  sorry -- Placeholder: R = ĥ(generator) for rank-1 curves
 
 /- **Explicit regulator computation for y² = x³ - 25x (n=5 curve)**
 

--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -14,9 +14,9 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "axiomCount": 19,
-    "assumptions": "19 axiom declarations encoding: (1) L-function analytic continuation and functional equation, (2) Hasse bound a_p^2 <= 4p, (3) BSD conjecture proven cases (Kolyvagin rank 0, Gross-Zagier+Kolyvagin rank 1), (4) parity conjecture (Dokchitsers), (5) L-values and ranks for specific curves, (6) Sha structure, (7) Elkies rank record, (8) Greenberg-Stevens theorem, (9) regulator positivity. Previously 21 axioms: BSD_CM_rank_zero was proved redundant (subsumed by Kolyvagin general result), gross_zagier_formula_detail was dead code (captured by GrossZagierData structure). No sorries.",
+    "assumptions": "19 axiom declarations encoding: (1) L-function analytic continuation and functional equation, (2) Hasse bound a_p^2 <= 4p, (3) BSD conjecture proven cases (Kolyvagin rank 0, Gross-Zagier+Kolyvagin rank 1), (4) parity conjecture (Dokchitsers), (5) L-values and ranks for specific curves, (6) Sha structure, (7) Elkies rank record, (8) Greenberg-Stevens theorem, (9) regulator positivity. 1 sorry: regulator_rank_one_is_height (R = ĥ(generator) for rank-1 curves).",
     "mathlibDependencies": [
       {
         "theorem": "WeierstrassCurve",

--- a/src/data/proofs/erdos-351/meta.json
+++ b/src/data/proofs/erdos-351/meta.json
@@ -47,9 +47,9 @@
       "Axiomatized Graham-Alekseyev theorem for p(x) = x²",
       "Verified bounds on n + 1/n"
     ],
-    "axiomCount": 2,
-    "lineCount": 111,
-    "assumptions": "2 axiom(s): erdos_351_open, graham_theorem_linear, graham_alekseyev_quadratic. See Lean source for complete statements."
+    "axiomCount": 0,
+    "lineCount": 107,
+    "assumptions": "0 axiom declarations. File has been rewritten with basic definitions and simple proved lemmas only. The main conjectured results (Graham's theorem, Alekseyev's theorem) are documented in comments but not stated as axioms or proved."
   },
   "overview": {
     "historicalContext": "Erdős Problem #351 concerns the additive structure of sequences of the form {p(n) + 1/n : n ∈ ℕ} where p(x) is a polynomial. The notion of 'strong completeness' is a robust form of additive completeness that survives removal of any finite set of elements.\n\nGraham (1963) proved the foundational case p(x) = x, showing that {n + 1/n : n ∈ ℕ} is strongly complete. This was a significant result in additive number theory.\n\nThe case p(x) = x² was resolved much later by combining Graham's work with Alekseyev's 2019 results on partitions into squares. The general question—whether ALL polynomials with positive leading coefficient yield strongly complete sets—remains open.",
@@ -127,7 +127,7 @@
     ],
     "namespace": "Erdos351",
     "lineCount": 107,
-    "axiomCount": 2,
+    "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 3
   },

--- a/src/data/proofs/erdos-519/meta.json
+++ b/src/data/proofs/erdos-519/meta.json
@@ -52,8 +52,8 @@
       "Roots of unity special case"
     ],
     "dateAdded": "2026-01-19",
-    "axiomCount": 5,
-    "assumptions": "7 axiom declarations: turan_bound (max power sum >= c/n), atkinson_theorem (absolute constant c=1/6), biro_1994 (improved to c=1/2), biro_2000 (c > 1/2), optimal_constant_conjecture (optimal c ~ 0.7), roots_of_unity_sum (orthogonality relation), computational_evidence (numerical c ~ 0.7)",
+    "axiomCount": 2,
+    "assumptions": "2 axiom declarations: atkinson_theorem (absolute constant c=1/6), biro_2000 (c > 1/2).",
     "prerequisites": [
       "Complex number arithmetic and absolute value",
       "Finite sums over indexed families (Finset.sum)",
@@ -181,7 +181,7 @@
     ],
     "namespace": "Erdos519",
     "lineCount": 268,
-    "axiomCount": 7,
+    "axiomCount": 2,
     "theoremCount": 6,
     "definitionCount": 7
   },


### PR DESCRIPTION
## Fix

Correct axiomCount fields and fix True stub theorem for three entries.

## Evidence

| Proof | Change | Details |
|-------|--------|---------|
| erdos-351 | axiomCount: 2→0 | File rewritten; no axiom declarations remain. Updated assumptions and lineCount (111→107). |
| erdos-519 | axiomCount: 5→2 (meta), 7→2 (leanFile) | Only `atkinson_theorem` and `biro_2000` present. Updated assumptions. |
| birch-swinnerton-dyer | True stub→sorry, sorries: 0→1 | `regulator_rank_one_is_height` was proving `True` instead of the actual statement. Replaced with existential + sorry. |

Closes #8717

---
Automated fix by lean-mechanic agent.