### PR TITLE
Fix: erdos-10-oq-01 lineCount 220→240

### DIFF
--- a/src/data/proofs/erdos-10-oq-01/meta.json
+++ b/src/data/proofs/erdos-10-oq-01/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 1,
     "axiomCount": 3,
-    "lineCount": 220,
+    "lineCount": 240,
     "assumptions": "3 axioms: (1) crocker_theorem — infinitely many odd integers not in RepSet 2, a proven 1971 result axiomatized here; (2) gallagher_density_approach — Gallagher 1975, proven via large sieve, axiomatized; (3) erdos_graham_conjecture — the main open conjecture that no finite k covers all large integers. 1 sorry in the illustrative density-vs-universal counterexample.",
     "dateAdded": "2026-04-03",
     "mathlib_version": "4.26.0"
@@ -147,7 +147,7 @@
       "Mathlib.Order.Filter.AtTopBot.Basic"
     ],
     "namespace": "Erdos10OQ01",
-    "lineCount": 220,
+    "lineCount": 240,
     "axiomCount": 3,
     "theoremCount": 12
   }


### PR DESCRIPTION
## Fix

Corrects the `lineCount` field in meta.json (both `meta.lineCount` and `leanFile.lineCount`) from 220 to 240 to match the actual line count of `Erdos10OQ01.lean`.

## Evidence

**Before**: `"lineCount": 220`
**After**: `"lineCount": 240`

Verified: `wc -l proofs/Proofs/Erdos10OQ01.lean` → 240 lines

Closes #8728

---
Automated fix by lean-mechanic agent.