### PR TITLE
Fix: erdos-1021-oq-01 lineCount 170→191

### DIFF
--- a/src/data/proofs/erdos-1021-oq-01/meta.json
+++ b/src/data/proofs/erdos-1021-oq-01/meta.json
@@ -19,7 +19,7 @@
     "badge": "axiom",
     "sorries": 4,
     "axiomCount": 2,
-    "lineCount": 170,
+    "lineCount": 191,
     "assumptions": "2 axioms: (1) kst_trivial_bound — Kővári-Sós-Turán O(n^{3/2}) upper bound (proven 1954, axiomatized); (2) probabilistic_lower_bound — ex(n, G_k) ≥ c·n^{3/2-1/(k-1)} (probabilistic method, axiomatized). 4 sorries: k3 weak holds, k independence, uniform O() from o(), and limit computation.",
     "dateAdded": "2026-04-03",
     "mathlib_version": "4.26.0"
@@ -118,7 +118,7 @@
       "Proofs.Erdos1021Problem"
     ],
     "namespace": "Erdos1021OQ01",
-    "lineCount": 170,
+    "lineCount": 191,
     "axiomCount": 2,
     "theoremCount": 8
   }


### PR DESCRIPTION
## Fix

Corrects the `lineCount` field in meta.json (both `meta.lineCount` and `leanFile.lineCount`) from 170 to 191 to match the actual line count of `Erdos1021OQ01.lean`.

## Evidence

**Before**: `"lineCount": 170`
**After**: `"lineCount": 191`

Verified: `wc -l proofs/Proofs/Erdos1021OQ01.lean` → 191 lines

Closes #8729

---
Automated fix by lean-mechanic agent.