### PR TITLE
chore: update audit tracker (cycle 7 — 8 proofs audited)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1993,10 +1993,10 @@
       "result": "clean"
     },
     "erdos-1029": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-03-24T05:17:38Z",
-      "result": "clean"
+      "lastAudited": "2026-04-03T07:46:36Z",
+      "result": "issues-found"
     },
     "erdos-103": {
       "auditCount": 2,
@@ -9796,9 +9796,9 @@
       "result": "issues-fixed"
     },
     "inverse-galois-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T03:08:27Z",
+      "lastAudited": "2026-04-03T07:37:44Z",
       "result": "clean"
     },
     "inverse-galois-oq-06": {
@@ -11139,6 +11139,42 @@
       "auditCount": 1,
       "lastAudited": "2026-04-03T06:06:17Z",
       "result": "issues-found",
+      "issues": []
+    },
+    "amgm-inequality-oq-02-oq-01": {
+      "auditCount": 2,
+      "lastAudited": "2026-04-03T07:38:34Z",
+      "result": "clean",
+      "issues": []
+    },
+    "collatz-structured-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T07:39:03Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-10-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T07:39:14Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1021-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T07:39:41Z",
+      "result": "clean",
+      "issues": []
+    },
+    "gcd-algorithm-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T07:39:55Z",
+      "result": "clean",
+      "issues": []
+    },
+    "isosceles-triangle-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T07:40:04Z",
+      "result": "clean",
       "issues": []
     }
   },


### PR DESCRIPTION
## Summary

Audit cycle 7 results — 8 gallery proofs reviewed for integrity.

**All clean:**
- `amgm-inequality-oq-02-oq-01`: verified/original, 0 sorries, 0 axioms ✓
- `collatz-structured-oq-02-oq-01`: axiomatized/axiom, 0 sorries, 1 axiom ✓
- `erdos-10-oq-01`: axiomatized/axiom, 1 sorry, 3 axioms ✓
- `erdos-1021-oq-01`: axiomatized/axiom, 4 actual sorries (confirmed 1 grep hit in comment) ✓
- `gcd-algorithm-oq-01-oq-03`: verified/original, 0 sorries, 0 axioms ✓
- `inverse-galois-oq-02`: axiomatized/axiom, 6 actual sorries (confirmed 1 grep hit in comment), 3 axioms ✓
- `isosceles-triangle-oq-01`: verified/mathlib, 0 sorries, 0 axioms ✓

**Issues found:**
- `erdos-1029`: axiomCount claims 12, actual count in Lean file is 5 — filed as issue #8735

## Test plan

- [ ] Verify audit tracker JSON is valid
- [ ] Confirm no proofs were incorrectly marked (random spot check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)