### PR TITLE
Fix: remove True-stub theorems from Erdos864Problem.lean (batch 8)

### DIFF
--- a/proofs/Proofs/Erdos864Problem.lean
+++ b/proofs/Proofs/Erdos864Problem.lean
@@ -49,14 +49,6 @@ noncomputable def maxAlmostSidon (N : ℕ) : ℕ :=
 
 /- ## Main Conjecture -/
 
-/-- **Erdős Problem #864** (OPEN): The maximum almost-Sidon set in {1,...,N}
-    has size (1+o(1)) · (2/√3) · √N. -/
-theorem erdos_864_conjecture :
-  -- For all ε > 0, for sufficiently large N:
-  -- maxAlmostSidon N ≤ (2/√3 + ε) · √N
-  -- NOTE: The actual conjecture is OPEN. This placeholder states True only.
-  True := trivial
-
 /- ## Known Bounds -/
 
 /-- **Erdős–Freud (1991)**: Lower bound via reflected Sidon construction.
@@ -145,14 +137,6 @@ theorem isAlmostSidon_subset {A B : Finset ℕ} (h : IsAlmostSidon B) (hsub : A 
   omega
 
 /- ## Difference Version -/
-
-/-- For the difference analogue (at most one n with multiple a − b
-    representations), Erdős–Freud proved |A| ~ √N. -/
-theorem erdos_freud_difference_version :
-  -- The maximum size of A ⊆ {1,...,N} with at most one difference collision
-  -- is asymptotically √N
-  -- NOTE: The actual result is deep. This placeholder states True only.
-  True := trivial
 
 /- ## Structural Properties -/
 

--- a/src/data/proofs/erdos-864/meta.json
+++ b/src/data/proofs/erdos-864/meta.json
@@ -53,7 +53,7 @@
       "reflected_construction_bound: PROVED quantitative lower bound maxAlmostSidon(N) ≥ 2|B| for any Sidon B ⊆ {1,...,N/3}"
     ],
     "axiomCount": 1,
-    "lineCount": 823,
+    "lineCount": 806,
     "assumptions": "1 axiom: erdos_freud_lower_bound. Previously 2; sidon_upper_bound ELIMINATED by proving difference-counting bound (sidon_diff_counting_bound, sidon_card_sq_le_2N). reflected_construction_valid was proved as theorem in prior session.",
     "mathlib_version": "4.26.0"
   },
@@ -66,25 +66,11 @@
       "summary": "Defines `sumRepCount A n` as $|\\{(a,b) \\in A \\times A : a \\leq b,\\, a+b = n\\}|$, `multiRepSet A` as $\\{n : \\text{sumRepCount}(A, n) \\geq 2\\}$, `IsAlmostSidon A` as $|\\text{multiRepSet}(A)| \\leq 1$, `IsSidon A` as $|\\text{multiRepSet}(A)| = 0$, and `maxAlmostSidon N` as $\\sup$ over almost-Sidon subsets of $[1, N]$."
     },
     {
-      "id": "conjecture",
-      "title": "Main Conjecture",
-      "startLine": 50,
-      "endLine": 58,
-      "summary": "Axiomatizes `erdos_864_conjecture`: the maximum almost-Sidon set in $\\{1, \\ldots, N\\}$ has size $(1 + o(1)) \\cdot \\frac{2}{\\sqrt{3}} \\cdot \\sqrt{N}$. Currently a placeholder `True` axiom."
-    },
-    {
       "id": "bounds",
       "title": "Known Bounds",
       "startLine": 59,
       "endLine": 85,
       "summary": "Axiomatizes three bounds: Erdős-Freud lower bound $\\geq (2/\\sqrt{3} - \\varepsilon)\\sqrt{N}$, the classical Sidon upper bound $\\leq \\sqrt{N} + O(N^{1/4})$, and `almost_sidon_exceeds_sidon`: almost-Sidon can exceed $\\sqrt{N} + 1$. Proves `sidon_is_almost_sidon` via `omega`."
-    },
-    {
-      "id": "difference",
-      "title": "Difference Version",
-      "startLine": 86,
-      "endLine": 94,
-      "summary": "Axiomatizes `erdos_freud_difference_version`: for the difference analogue (at most one difference collision), the maximum is asymptotically $\\sqrt{N}$. Currently a placeholder `True` axiom."
     },
     {
       "id": "structural",
@@ -118,8 +104,7 @@
       "Is |A| ≤ (1+o(1))·(2/√3)·√N the correct upper bound for almost-Sidon sets?",
       "What is the maximum for k allowed collisions? Is there a formula f(k)·√N?",
       "Is the reflected construction the unique extremal configuration, or are there essentially different constructions?",
-      "Can the placeholder axioms (erdos_864_conjecture, erdos_freud_difference_version) be given non-trivial content?",
-      "What is the connection to Problem #840 (general collision bounds)?"
+"What is the connection to Problem #840 (general collision bounds)?"
     ]
   },
   "crossReferences": [
@@ -158,9 +143,9 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 822,
+    "lineCount": 806,
     "axiomCount": 1,
-    "theoremCount": 21,
+    "theoremCount": 19,
     "definitionCount": 5
   }
 }


### PR DESCRIPTION
## Fix

Removes two `theorem X : True := trivial` placeholders from `Erdos864Problem.lean` that provide no formal mathematical content.

## Evidence

**Removed**:
- `erdos_864_conjecture : True := trivial` (open conjecture placeholder — no formal statement)
- `erdos_freud_difference_version : True := trivial` (deep result placeholder — no formal statement)

**meta.json updates**:
- `meta.lineCount`: 823 → 806
- `leanFile.lineCount`: 822 → 806
- `leanFile.theoremCount`: 21 → 19
- Removed stale "conjecture" and "difference" section entries
- Removed stale openQuestion referencing the deleted placeholders

**Validation**: `pnpm build` completed successfully — `erdos-864` built cleanly.

Continues True-stub cleanup from batches 5–7 (#8680, #8682, #8688).

---
Automated fix by lean-mechanic agent.