### PR TITLE
Research: hilbert-11-oq-01 — Hasse-Minkowski via p-adic tensor products

### DIFF
--- a/proofs/Proofs/Hilbert11OQ01.lean
+++ b/proofs/Proofs/Hilbert11OQ01.lean
@@ -1,0 +1,251 @@
+import Mathlib.LinearAlgebra.QuadraticForm.TensorProduct
+import Mathlib.LinearAlgebra.QuadraticForm.Basic
+import Mathlib.NumberTheory.Padics.PadicNumbers
+import Mathlib.NumberTheory.SumFourSquares
+import Mathlib.Algebra.Algebra.Rat
+import Mathlib.Algebra.CharP.Invertible
+import Mathlib.RingTheory.TensorProduct.Basic
+import Mathlib.Tactic
+
+/-!
+# Hilbert's 11th Problem OQ-01: Hasse-Minkowski via p-adic Tensor Products
+
+## Overview
+
+This file formalizes the **local isotropy conditions** for the Hasse-Minkowski theorem
+using proper tensor product base change, replacing the `True` placeholders in
+`Hilbert11_QuadraticForms.lean`.
+
+## Key Contributions
+
+1. **Proper local isotropy**: `IsIsotropicOverReals` and `IsIsotropicOverPadic`
+   use `QuadraticForm.baseChange` (Mathlib) to correctly define isotropy over
+   completions via scalar extension through tensor products.
+
+2. **Axiom elimination**: The `four_squares_connection` axiom from the parent file
+   is proved here as `four_squares_from_mathlib` using `Nat.sum_four_squares`.
+
+3. **Refined theorem statement**: `hasse_minkowski_refined` states Hasse-Minkowski
+   using the proper local conditions.
+
+## How Base Change Works
+
+For `Q : QuadraticForm ℚ (Fin n → ℚ)` and a CharZero field `A` with `Algebra ℚ A`,
+the base change `Q.baseChange A : QuadraticForm A (A ⊗[ℚ] (Fin n → ℚ))`
+is the quadratic form on the tensor product, implementing scalar extension.
+
+- `IsIsotropicOverReals Q` ↔ `Q.baseChange ℝ` has a nonzero zero in `ℝ ⊗[ℚ] (Fin n → ℚ)`
+- `IsIsotropicOverPadic Q p` ↔ `Q.baseChange ℚ_[p]` has a nonzero zero in `ℚ_[p] ⊗[ℚ] (Fin n → ℚ)`
+
+## Axiom Count
+
+This file has **1 axiom** (`hasse_minkowski_refined`), compared to the parent file's 6.
+The `four_squares_connection` axiom is eliminated via Mathlib.
+
+## References
+
+- Serre, J-P. "A Course in Arithmetic", Chapter IV
+- Lam, T-Y. "Introduction to Quadratic Forms over Fields"
+- Wieser, E. `Mathlib.LinearAlgebra.QuadraticForm.TensorProduct`
+-/
+
+set_option maxHeartbeats 400000
+
+noncomputable section
+
+open scoped TensorProduct
+
+namespace Hilbert11OQ01
+
+variable {n : ℕ}
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART I: AXIOM ELIMINATION — Four Squares from Mathlib
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **Lagrange's Four Squares Theorem** (proved, not axiomatized).
+
+Every natural number is a sum of four integer squares.
+This directly proves the `four_squares_connection` axiom from `Hilbert11_QuadraticForms.lean`
+using `Nat.sum_four_squares` from Mathlib.
+
+Eliminates 1 of the 6 axioms in the parent file. -/
+theorem four_squares_from_mathlib :
+    ∀ m : ℕ, ∃ a b c d : ℤ, (m : ℤ) = a ^ 2 + b ^ 2 + c ^ 2 + d ^ 2 := by
+  intro m
+  obtain ⟨a, b, c, d, h⟩ := Nat.sum_four_squares m
+  exact ⟨↑a, ↑b, ↑c, ↑d, by exact_mod_cast h.symm⟩
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART II: LOCAL ISOTROPY VIA TENSOR PRODUCT BASE CHANGE
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+-- `Invertible (2 : ℚ)` is needed for QuadraticForm.baseChange.
+-- It follows from CharZero ℚ via invertibleOfPos.
+-- Lean's instance system finds this automatically.
+
+/-- A rational quadratic form is **isotropic over ℝ** if its tensor product base change
+    to ℝ has a nonzero zero.
+
+`Q.baseChange ℝ : QuadraticForm ℝ (ℝ ⊗[ℚ] (Fin n → ℚ))` is the scalar extension of `Q`
+from ℚ to ℝ via the tensor product construction. This is the correct formalization
+of "Q has a nontrivial real solution", replacing the placeholder `True` in the parent file.
+
+Note: `ℝ ⊗[ℚ] (Fin n → ℚ) ≅ Fin n → ℝ` as ℝ-vector spaces. -/
+def IsIsotropicOverReals (Q : QuadraticForm ℚ (Fin n → ℚ)) : Prop :=
+  ∃ v : ℝ ⊗[ℚ] (Fin n → ℚ), v ≠ 0 ∧ Q.baseChange ℝ v = 0
+
+/-- A rational quadratic form is **isotropic over ℚₚ** if its tensor product base change
+    to ℚₚ has a nonzero zero.
+
+`Q.baseChange ℚ_[p] : QuadraticForm ℚ_[p] (ℚ_[p] ⊗[ℚ] (Fin n → ℚ))` is the scalar
+extension of `Q` from ℚ to ℚₚ, implementing the p-adic tensor product formalization.
+This replaces the placeholder `True` in the parent file.
+
+Note: `ℚ_[p] ⊗[ℚ] (Fin n → ℚ) ≅ Fin n → ℚ_[p]` as ℚ_[p]-vector spaces. -/
+def IsIsotropicOverPadic (Q : QuadraticForm ℚ (Fin n → ℚ)) (p : ℕ) [Fact (Nat.Prime p)] : Prop :=
+  ∃ v : ℚ_[p] ⊗[ℚ] (Fin n → ℚ), v ≠ 0 ∧ Q.baseChange ℚ_[p] v = 0
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART III: BASE CHANGE COMPUTATION LEMMAS
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- The base change of Q over ℝ evaluates on simple tensors as:
+    `(Q.baseChange ℝ) (r ⊗ₜ v) = Q v • (r * r)` -/
+theorem baseChange_real_tmul (Q : QuadraticForm ℚ (Fin n → ℚ))
+    (r : ℝ) (v : Fin n → ℚ) :
+    Q.baseChange ℝ (r ⊗ₜ[ℚ] v) = Q v • (r * r) :=
+  QuadraticForm.baseChange_tmul Q r v
+
+/-- The base change of Q over ℚₚ evaluates on simple tensors as:
+    `(Q.baseChange ℚ_[p]) (x ⊗ₜ v) = Q v • (x * x)` -/
+theorem baseChange_padic_tmul (Q : QuadraticForm ℚ (Fin n → ℚ))
+    (p : ℕ) [Fact (Nat.Prime p)] (x : ℚ_[p]) (v : Fin n → ℚ) :
+    Q.baseChange ℚ_[p] (x ⊗ₜ[ℚ] v) = Q v • (x * x) :=
+  QuadraticForm.baseChange_tmul Q x v
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART IV: RATIONAL ISOTROPY IMPLIES LOCAL ISOTROPY
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- Rational isotropy implies isotropy over ℝ.
+
+If Q has a nonzero rational zero `v₀`, then `(1 : ℝ) ⊗ₜ v₀` gives a zero of
+`Q.baseChange ℝ`, since `(Q.baseChange ℝ)(1 ⊗ₜ v₀) = Q v₀ • (1 * 1) = 0`.
+
+The nonzero condition follows from the injectivity of `1 ⊗ₜ · : (Fin n → ℚ) → ℝ ⊗[ℚ] (Fin n → ℚ)`,
+which holds because `Fin n → ℚ` is a free ℚ-module.
+
+Note: The injectivity argument is deferred (sorry) as it requires facts about the
+tensor product of a free module — a good Aristotle target. -/
+theorem rational_implies_real_isotropic (Q : QuadraticForm ℚ (Fin n → ℚ))
+    (h : ∃ v : Fin n → ℚ, v ≠ 0 ∧ Q v = 0) : IsIsotropicOverReals Q := by
+  obtain ⟨v, hv_ne, hv_zero⟩ := h
+  refine ⟨(1 : ℝ) ⊗ₜ[ℚ] v, ?_, ?_⟩
+  · -- 1 ⊗ₜ v ≠ 0 because v ≠ 0 and the canonical map Fin n → ℚ → ℝ ⊗[ℚ] (Fin n → ℚ) is injective
+    -- (Fin n → ℚ is a free ℚ-module, so base change is injective)
+    intro heq
+    apply hv_ne
+    -- The map v ↦ 1 ⊗ₜ v is ℚ-linear and injective; from heq : 1 ⊗ₜ v = 0 conclude v = 0
+    have : (TensorProduct.mk ℚ ℝ (Fin n → ℚ) 1) v = 0 := heq
+    sorry  -- injectivity of 1 ⊗ₜ · on free module; suitable for Aristotle/further work
+  · rw [baseChange_real_tmul, hv_zero]
+    simp
+
+/-- Rational isotropy implies isotropy over ℚₚ.
+
+Same argument as for ℝ: `(1 : ℚ_[p]) ⊗ₜ v₀` is a zero of `Q.baseChange ℚ_[p]`. -/
+theorem rational_implies_padic_isotropic (Q : QuadraticForm ℚ (Fin n → ℚ))
+    (p : ℕ) [Fact (Nat.Prime p)]
+    (h : ∃ v : Fin n → ℚ, v ≠ 0 ∧ Q v = 0) : IsIsotropicOverPadic Q p := by
+  obtain ⟨v, hv_ne, hv_zero⟩ := h
+  refine ⟨(1 : ℚ_[p]) ⊗ₜ[ℚ] v, ?_, ?_⟩
+  · intro heq
+    apply hv_ne
+    have : (TensorProduct.mk ℚ ℚ_[p] (Fin n → ℚ) 1) v = 0 := heq
+    sorry  -- injectivity of 1 ⊗ₜ · on free module; suitable for Aristotle/further work
+  · rw [baseChange_padic_tmul, hv_zero]
+    simp
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART V: THE REFINED HASSE-MINKOWSKI THEOREM
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- **The Hasse-Minkowski Theorem** (axiomatized with proper tensor-product local conditions).
+
+A quadratic form `Q` over ℚ is isotropic iff it is locally isotropic everywhere:
+- Isotropic over ℝ (i.e., `Q.baseChange ℝ` has a nonzero zero), AND
+- Isotropic over ℚₚ for every prime p (i.e., `Q.baseChange ℚ_[p]` has a nonzero zero).
+
+**This is the main result**: the Hasse-Minkowski theorem with mathematically correct
+local conditions replacing the placeholder `True` definitions in the parent file.
+
+**Status**: Axiomatized. The proof requires:
+- p-adic analysis and Hensel's lemma for local solvability
+- Product formula for Hilbert symbols: ∏_v (a,b)_v = 1
+- Global-to-local techniques via idelic methods or class field theory
+- Classification of quadratic forms over local fields
+
+References: Serre, "A Course in Arithmetic", Ch. IV; O'Meara, "Introduction to Quadratic Forms" -/
+axiom hasse_minkowski_refined (Q : QuadraticForm ℚ (Fin n → ℚ)) :
+    (∃ v : Fin n → ℚ, v ≠ 0 ∧ Q v = 0) ↔
+      IsIsotropicOverReals Q ∧ ∀ p : ℕ, [Fact (Nat.Prime p)] → IsIsotropicOverPadic Q p
+
+/-- The "easy direction" of Hasse-Minkowski: rational isotropy implies local isotropy.
+
+This is proved (modulo the tensor product injectivity sorry in the helper lemmas). -/
+theorem hasse_easy_direction (Q : QuadraticForm ℚ (Fin n → ℚ))
+    (h : ∃ v : Fin n → ℚ, v ≠ 0 ∧ Q v = 0) :
+    IsIsotropicOverReals Q ∧ ∀ p : ℕ, [Fact (Nat.Prime p)] → IsIsotropicOverPadic Q p :=
+  ⟨rational_implies_real_isotropic Q h,
+   fun p _ => rational_implies_padic_isotropic Q p h⟩
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART VI: SUMMARY AND STATUS
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-!
+## Summary of OQ-01 Contributions
+
+### Axiom Status Comparison
+
+| Axiom (Parent File) | Status in OQ-01 |
+|---------------------|-----------------|
+| `diagonalForm` | Unchanged (inherited from parent) |
+| `sylvester_law_of_inertia` | Unchanged (deep theorem) |
+| `hasse_minkowski_alt` (with `True` local conditions) | **Replaced** by `hasse_minkowski_refined` |
+| `four_squares_connection` | **ELIMINATED** — proved as `four_squares_from_mathlib` |
+| `rational_classification_complete` | Unchanged |
+| `selmer_curve_no_rational_points` | Unchanged |
+
+### What This File Proves
+
+1. `four_squares_from_mathlib` — Lagrange's 4 squares, proved from Mathlib (axiom eliminated)
+2. `baseChange_real_tmul` — computation lemma for local isotropy over ℝ
+3. `baseChange_padic_tmul` — computation lemma for local isotropy over ℚₚ
+4. `hasse_easy_direction` — easy direction of Hasse-Minkowski (modulo injectivity sorry)
+
+### Remaining Sorries (Aristotle Targets)
+
+Two sorries in `rational_implies_real_isotropic` and `rational_implies_padic_isotropic`:
+- Proving `1 ⊗ₜ v ≠ 0` when `v ≠ 0` in `A ⊗[ℚ] (Fin n → ℚ)`
+- Follows from flatness/freeness of `Fin n → ℚ` over ℚ
+- These are likely provable by Aristotle or via `TensorProduct.linearIndependent_iff`
+
+### Next Steps
+
+1. Prove the two injectivity sorries (free module base change is injective)
+2. State the p-adic classification theorem (Meyer's theorem: dim ≥ 5 forms are isotropic)
+3. Add Hilbert symbol formalization using `IsIsotropicOverPadic`
+-/
+
+-- Verification that key declarations type-check
+#check @IsIsotropicOverReals
+#check @IsIsotropicOverPadic
+#check @four_squares_from_mathlib
+#check @hasse_minkowski_refined
+#check @hasse_easy_direction
+
+end Hilbert11OQ01
+
+end

--- a/proofs/Proofs/Hilbert11OQ01Aristotle.lean
+++ b/proofs/Proofs/Hilbert11OQ01Aristotle.lean
@@ -1,0 +1,49 @@
+/-
+  Aristotle targets for Hilbert11 OQ-01
+  Routine supporting lemmas for automated proof search.
+  See Hilbert11OQ01.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open conjecture (Hasse-Minkowski)
+  - Known results likely provable via flatness/freeness arguments
+  - Clean theorem statement with no definition sorries
+  - No axioms (use theorem ... := by sorry instead)
+
+  Main sorry targets:
+  1. Injectivity of (1 ⊗ₜ ·) : (Fin n → ℚ) → A ⊗[ℚ] (Fin n → ℚ)
+     when A is a flat ℚ-algebra (e.g., ℝ or ℚ_[p]).
+     Follows from Module.Flat.lTensor_injective or tensor product of free modules.
+
+  2. Same for ℚ_[p] ⊗[ℚ] (Fin n → ℚ).
+-/
+import Mathlib.LinearAlgebra.QuadraticForm.TensorProduct
+import Mathlib.RingTheory.TensorProduct.Basic
+import Mathlib.Algebra.Module.Flat.Basic
+import Mathlib.Algebra.Algebra.Rat
+import Mathlib.NumberTheory.Padics.PadicNumbers
+import Mathlib.Tactic
+
+namespace Hilbert11OQ01Aristotle
+
+variable {n : ℕ}
+
+open scoped TensorProduct
+
+/-- The canonical map v ↦ 1 ⊗ₜ v is injective for ℝ ⊗[ℚ] (Fin n → ℚ).
+
+ℝ is flat over ℚ (in fact, ℝ is a flat ℚ-algebra since ℚ is a field and every
+module over a field is flat). Therefore the map (1 ⊗ₜ ·) is injective.
+
+Used in: Hilbert11OQ01.rational_implies_real_isotropic -/
+theorem one_tmul_injective_real (n : ℕ) :
+    Function.Injective (fun v : Fin n → ℚ => (1 : ℝ) ⊗ₜ[ℚ] v) := by
+  sorry
+
+/-- The canonical map v ↦ 1 ⊗ₜ v is injective for ℚ_[p] ⊗[ℚ] (Fin n → ℚ).
+
+ℚ_[p] is flat over ℚ (same reason: ℚ is a field). -/
+theorem one_tmul_injective_padic (n : ℕ) (p : ℕ) [Fact (Nat.Prime p)] :
+    Function.Injective (fun v : Fin n → ℚ => (1 : ℚ_[p]) ⊗ₜ[ℚ] v) := by
+  sorry
+
+end Hilbert11OQ01Aristotle

--- a/src/data/research/problems/hilbert-11-oq-01.json
+++ b/src/data/research/problems/hilbert-11-oq-01.json
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "ORIENT",
     "since": "2026-03-30T21:46:38.107Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "Tensor product base change for local isotropy",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Prove injectivity of 1 \u2297\u209c \u00b7 on free modules to eliminate 2 sorries",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,11 +29,36 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "PROGRESS: Created Hilbert11OQ01.lean with proper tensor product definitions for local isotropy. Eliminated four_squares_connection axiom via Mathlib. Defined IsIsotropicOverReals and IsIsotropicOverPadic using QuadraticForm.baseChange.",
+    "builtItems": [
+      "Created proofs/Proofs/Hilbert11OQ01.lean: proper local isotropy definitions via baseChange",
+      "Proved four_squares_from_mathlib \u2014 Lagrange 4 squares, no axiom",
+      "Defined IsIsotropicOverReals using QuadraticForm.baseChange \u211d",
+      "Defined IsIsotropicOverPadic using QuadraticForm.baseChange \u211a_[p]",
+      "Proved baseChange_real_tmul and baseChange_padic_tmul computation lemmas",
+      "Proved hasse_easy_direction (modulo 2 injectivity sorries)",
+      "Axiomatized hasse_minkowski_refined with proper local conditions"
+    ],
+    "insights": [
+      "QuadraticForm.baseChange from Mathlib.LinearAlgebra.QuadraticForm.TensorProduct provides the correct formalization of scalar extension for quadratic forms.",
+      "IsIsotropicOverReals Q = Q.baseChange \u211d has nonzero zero in \u211d \u2297[\u211a] (Fin n \u2192 \u211a) \u2014 this replaces placeholder True.",
+      "IsIsotropicOverPadic Q p = Q.baseChange \u211a_[p] has nonzero zero in \u211a_[p] \u2297[\u211a] (Fin n \u2192 \u211a) \u2014 proper p-adic tensor product.",
+      "Algebra \u211a \u211d and Algebra \u211a \u211a_[p] are automatically available via algebraRat (DivisionRing + CharZero \u2192 Algebra \u211a).",
+      "Invertible (2 : \u211a) is automatically inferred for QuadraticForm.baseChange.",
+      "four_squares_connection is proved directly from Nat.sum_four_squares \u2014 eliminates 1 axiom.",
+      "The easy direction (rational isotropy \u2192 local isotropy) relies on injectivity of 1 \u2297\u209c \u00b7 on free modules \u2014 2 sorries remain for Aristotle."
+    ],
+    "mathlibGaps": [
+      "Need Hasse-Minkowski itself \u2014 not in Mathlib",
+      "Rational classification of quadratic forms \u2014 not in Mathlib",
+      "Injectivity of base change of free modules \u2014 likely in Mathlib as Module.Flat.lTensor_injective"
+    ],
+    "nextSteps": [
+      "Prove injectivity sorry: 1 \u2297\u209c v \u2260 0 when v \u2260 0 in A \u2297[\u211a] (Fin n \u2192 \u211a) (free module base change injective)",
+      "Check if TensorProduct.linearIndependent_iff or Module.Flat.lTensor_injective applies",
+      "Add Meyer theorem formalization: forms in \u2265 5 variables are locally isotropic",
+      "Consider Hilbert symbol formalization using IsIsotropicOverPadic"
+    ]
   },
   "tags": [
     "seeker-selected",


### PR DESCRIPTION
## Summary

Research session for **hilbert-11-oq-01**: Formalize Hasse-Minkowski theorem including p-adic tensor product.

## Progress

- **Created** `proofs/Proofs/Hilbert11OQ01.lean` — formalizes local isotropy conditions using `QuadraticForm.baseChange` from Mathlib
- **Created** `proofs/Proofs/Hilbert11OQ01Aristotle.lean` — 2 injectivity sorries for Aristotle submission
- **Updated** `src/data/research/problems/hilbert-11-oq-01.json` — knowledge and progress

## Key Contributions

### Axiom Elimination
- `four_squares_from_mathlib`: Lagrange's four squares theorem proved directly from `Nat.sum_four_squares` — **eliminates 1 axiom** from parent file

### Proper Local Isotropy Definitions (replaces `True` placeholders)
```lean
-- Over ℝ: uses tensor product base change
def IsIsotropicOverReals (Q : QuadraticForm ℚ (Fin n → ℚ)) : Prop :=
  ∃ v : ℝ ⊗[ℚ] (Fin n → ℚ), v ≠ 0 ∧ Q.baseChange ℝ v = 0

-- Over ℚₚ: uses p-adic tensor product
def IsIsotropicOverPadic (Q : QuadraticForm ℚ (Fin n → ℚ)) (p : ℕ) [Fact (Nat.Prime p)] : Prop :=
  ∃ v : ℚ_[p] ⊗[ℚ] (Fin n → ℚ), v ≠ 0 ∧ Q.baseChange ℚ_[p] v = 0
```

### Refined Hasse-Minkowski Axiom
```lean
axiom hasse_minkowski_refined (Q : QuadraticForm ℚ (Fin n → ℚ)) :
    (∃ v : Fin n → ℚ, v ≠ 0 ∧ Q v = 0) ↔
      IsIsotropicOverReals Q ∧ ∀ p : ℕ, [Fact (Nat.Prime p)] → IsIsotropicOverPadic Q p
```

### Proved: Easy Direction
```lean
theorem hasse_easy_direction : rational isotropy → local isotropy everywhere
```

## Build Status

✅ **Build succeeded** — 3066 jobs, 637s

- 2 sorries (injectivity of `1 ⊗ₜ ·` on free modules — Aristotle targets)
- 1 minor warning (fixed: `exact_mod_cast` instead of `push_cast`)

## Mathematical Notes

- `Algebra ℚ ℝ` and `Algebra ℚ ℚ_[p]` are available via `algebraRat` instance
- `Invertible (2 : ℚ)` is automatically inferred for `QuadraticForm.baseChange`
- The 2 injectivity sorries follow from `Module.Flat` (ℝ and ℚ_[p] are flat over ℚ)

## Status
**Outcome**: progress
**Next Steps**: Prove the 2 injectivity sorries (Aristotle targets), then Meyer's theorem formalization

🤖 Generated by researcher-5