### PR TITLE
Fix: erdos-1029 axiomCount 12→5 (actual axioms in Lean source)

### DIFF
--- a/src/data/proofs/erdos-1029/meta.json
+++ b/src/data/proofs/erdos-1029/meta.json
@@ -22,9 +22,9 @@
     "erdosUrl": "https://erdosproblems.com/1029",
     "erdosProblemStatus": "open",
     "erdosPrizeValue": "$100/$1000",
-    "axiomCount": 12,
+    "axiomCount": 5,
     "lineCount": 173,
-    "assumptions": "12 axioms: ramsey_exists, erdos_szekeres_upper, upper_bound_asymptotic, and 9 more. See Lean source for complete statements.",
+    "assumptions": "5 axioms: ramsey_exists (Ramsey's theorem finiteness), erdos_szekeres_upper (upper bound R(k) ≤ C(2k-2,k-1)), spencer_lower_bound (Spencer's probabilistic lower bound), R_3 (R(3)=6), R_4 (R(4)=18). See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -210,7 +210,7 @@
     ],
     "namespace": null,
     "lineCount": 173,
-    "axiomCount": 12,
+    "axiomCount": 5,
     "theoremCount": 4,
     "definitionCount": 9
   }


### PR DESCRIPTION
## Fix

Update `erdos-1029` meta.json axiomCount from 12 to 5 to match the actual axiom declarations in the Lean source file.

## Evidence

**Before**: `"axiomCount": 12` with a vague assumptions string ("12 axioms: ramsey_exists, erdos_szekeres_upper, upper_bound_asymptotic, and 9 more")

**After**: `"axiomCount": 5` with accurate listing of all 5 axioms:
1. `ramsey_exists` — Ramsey's theorem finiteness
2. `erdos_szekeres_upper` — upper bound R(k) ≤ C(2k-2,k-1)
3. `spencer_lower_bound` — Spencer's probabilistic lower bound
4. `R_3` — R(3)=6
5. `R_4` — R(4)=18

Both `meta.axiomCount` and `leanFile.axiomCount` updated. The previous count of 12 appears to be from an earlier version of the file that had more axiom declarations.

Closes #8735

---
Automated fix by lean-mechanic agent.