### PR TITLE
Enrich Rational Canonical Form: Companion Matrix (cayley-hamilton-reduction-oq-02-oq-01)

### DIFF
--- a/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-companion-definition",
+    "proofId": "cayley-hamilton-reduction-oq-02-oq-01",
+    "range": { "startLine": 61, "endLine": 81 },
+    "type": "definition",
+    "title": "Companion Matrix: Explicit Entry Formula",
+    "content": "The `companionMatrix` function is defined entry-by-entry using two conditions: the last column (j+1 = d) gets the negated polynomial coefficients, and the subdiagonal (i = j+1) gets 1. The definition is `noncomputable` because polynomial coefficients require field arithmetic. The formula encodes the F[X]-module structure: multiplying by x sends eⱼ to eⱼ₊₁ for j < d−1, and sends e_{d-1} to −a₀e₀ − a₁e₁ − ... − a_{d-1}e_{d-1} (the last column cancels the leading xᵈ term).",
+    "mathContext": "$C(p)_{ij} = \\begin{cases} -(p\\text{ coeff } i) & j+1 = d \\\\ 1 & i = j+1 \\\\ 0 & \\text{otherwise} \\end{cases}$ for $p(x) = x^d + a_{d-1}x^{d-1} + \\cdots + a_0$",
+    "significance": "key",
+    "relatedConcepts": ["F[X]-module", "cyclic module", "monic polynomial", "matrix entry formula"],
+    "prerequisites": ["matrix definition in Lean 4", "Fin arithmetic", "polynomial coefficients"]
+  },
+  {
+    "id": "ann-entry-lemmas",
+    "proofId": "cayley-hamilton-reduction-oq-02-oq-01",
+    "range": { "startLine": 84, "endLine": 108 },
+    "type": "technique",
+    "title": "Entry Lemmas: Subdiagonal, Last Column, Zero",
+    "content": "Three lemmas (`companionMatrix_subdiag`, `companionMatrix_last_col`, `companionMatrix_zero`) characterize the three entry types by case-splitting on the column conditions. Each proof uses `split_ifs` followed by `omega` (for arithmetic contradictions) or `rfl` (for direct confirmation). These lemmas are the building blocks for all higher-level properties — proving the orbit and annihilation theorems requires knowing exactly what each entry is.",
+    "mathContext": "$C(p)_{i,j} = 1$ if $i = j+1 < d$; $C(p)_{i,j} = -a_i$ if $j = d-1$; $C(p)_{i,j} = 0$ otherwise",
+    "significance": "technical",
+    "relatedConcepts": ["split_ifs tactic", "omega tactic", "index arithmetic"],
+    "prerequisites": ["companionMatrix definition", "Fin.val arithmetic"]
+  },
+  {
+    "id": "ann-orbit-lemma",
+    "proofId": "cayley-hamilton-reduction-oq-02-oq-01",
+    "range": { "startLine": 110, "endLine": 168 },
+    "type": "technique",
+    "title": "Orbit Argument: C(p)ᵏ · e₀ = eₖ",
+    "content": "The orbit section is the mathematical heart of the file. `companionMatrix_mulVec_basis` shows C(p) maps eⱼ to eⱼ₊₁ for j < d−1, and `companionMatrix_mulVec_last` shows C(p) maps e_{d-1} to −∑ aᵢ eᵢ. `companionMatrix_pow_basis` then proves by induction that C(p)ᵏ · e₀ = eₖ for k < d. This orbit {e₀, C(p)e₀, ..., C(p)^{d-1}e₀} = standard basis is the key structural fact: it means the entire d-dimensional space is generated cyclically by e₀ under multiplication by C(p), confirming C(p) is the matrix representation of multiplication-by-x on F[X]/(p).",
+    "mathContext": "$C(p)^k \\cdot e_0 = e_k$ for $k < d$; the orbit $\\{e_0, C(p)e_0, \\ldots, C(p)^{d-1}e_0\\}$ is the standard basis, so $F^d \\cong F[x]/(p)$ as $F[x]$-modules",
+    "significance": "key",
+    "relatedConcepts": ["cyclic module", "F[X]/(p)", "matrix powers", "basis generation"],
+    "prerequisites": ["companion matrix entries", "mulVec", "induction on nat"]
+  },
+  {
+    "id": "ann-sorry-theorems",
+    "proofId": "cayley-hamilton-reduction-oq-02-oq-01",
+    "range": { "startLine": 170, "endLine": 211 },
+    "type": "insight",
+    "title": "Three Sorry Theorems: Annihilation, Charpoly, Minpoly",
+    "content": "Three key theorems are stated with `sorry`. (1) `aeval_companionMatrix`: p(C(p)) = 0, proved conceptually via the orbit: p(C(p))·e₀ = C(p)^d·e₀ + ∑ aₖ C(p)^k·e₀ = (−∑ aᵢeᵢ) + (∑ aₖeₖ) = 0, then commutativity gives p(C(p))·eⱼ = 0. (2) `charpoly_companionMatrix`: charpoly(C(p)) = p, deduced from minpoly = p since both are monic of degree d. (3) `minpoly_companionMatrix`: minpoly(C(p)) = p, using that the orbit implies no polynomial of degree < d annihilates C(p). All infrastructure for completing these proofs is already in place; only the formal argument assembly remains.",
+    "mathContext": "$p(C(p)) = 0$; $\\mathrm{minpoly}(C(p)) = p$ (since orbit spans $\\Rightarrow$ no degree-$< d$ annihilator); $\\mathrm{charpoly}(C(p)) = p$ (monic, same degree)",
+    "significance": "key",
+    "relatedConcepts": ["Cayley-Hamilton theorem", "minimal polynomial", "characteristic polynomial", "non-derogatory matrix"],
+    "prerequisites": ["aeval", "minpoly", "charpoly", "Mathlib.LinearAlgebra.Matrix.Charpoly"]
+  },
+  {
+    "id": "ann-linear-case",
+    "proofId": "cayley-hamilton-reduction-oq-02-oq-01",
+    "range": { "startLine": 213, "endLine": 225 },
+    "type": "insight",
+    "title": "Base Case: C(x − c) = [c]",
+    "content": "For the linear polynomial x − c, the companion matrix is the 1×1 matrix [c]. The proof unfolds the definition, fixes i = j = 0 (the only entry in a 1×1 matrix), and simplifies using `Polynomial.coeff_sub`, `coeff_X`, `coeff_C`, and `ring`. This is not just a sanity check: it is the connection between the abstract companion matrix machinery and the concrete Jordan-block eigenvalue case. In the full RCF, degree-1 invariant factors correspond to eigenvalues, and C(x−c) = [c] is the 1×1 Jordan block with eigenvalue c.",
+    "mathContext": "$C(x - c) = \\begin{pmatrix} c \\end{pmatrix} \\in M_1(F)$; the 1×1 companion block is a Jordan block",
+    "significance": "supporting",
+    "relatedConcepts": ["Jordan canonical form", "eigenvalues", "linear factors", "1x1 matrix"],
+    "prerequisites": ["companionMatrix definition", "Polynomial.coeff_X", "Polynomial.coeff_C"]
+  },
+  {
+    "id": "ann-rcf-roadmap",
+    "proofId": "cayley-hamilton-reduction-oq-02-oq-01",
+    "range": { "startLine": 226, "endLine": 259 },
+    "type": "context",
+    "title": "RCF Roadmap: ~1800 Lines of Missing Infrastructure",
+    "content": "The roadmap documents the four components needed for a complete Lean formalization of the rational canonical form. The main bottleneck is Smith Normal Form for matrices over F[X] (~800 lines): this requires Euclidean algorithm for polynomials, elementary row/column operations, and the diagonalization theorem. The companion matrix file (~200 lines, partially complete here) is the second component. Block diagonal assembly (~300 lines) and uniqueness via Smith NF (~200 lines) complete the picture. The Smith NF gap reflects that Mathlib, while containing SNF for ℤ, does not yet have it for general Euclidean domains in the required constructive form.",
+    "mathContext": "RCF: every $A \\in M_n(F)$ is similar to $\\mathrm{diag}(C(p_1), \\ldots, C(p_k))$ where $p_1 | \\cdots | p_k$ are the invariant factors; $p_k = \\mathrm{minpoly}(A)$, $\\prod p_i = \\mathrm{charpoly}(A)$",
+    "significance": "context",
+    "relatedConcepts": ["Smith Normal Form", "invariant factors", "F[X]-module", "Jordan vs RCF"],
+    "prerequisites": ["PID module theory", "Euclidean domain", "Smith Normal Form"]
+  }
+]

--- a/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
@@ -53,13 +53,68 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "problemStatement": "Define the companion matrix C(p) for a monic polynomial p and prove its key properties: charpoly(C(p)) = p and minpoly(C(p)) = p.",
-    "text": "The companion matrix is the fundamental building block of the rational canonical form. This file defines it and proves basic properties.",
-    "proofStrategy": "Direct definition using index arithmetic, with entry-level lemmas. The key theorems (charpoly = p, minpoly = p) are stated but require determinant computation and minimality arguments respectively.",
+    "historicalContext": "The companion matrix appears implicitly in Arthur Cayley's 1858 work on linear transformations, and was codified by Ferdinand Frobenius in his 1878 paper 'Über lineare Substitutionen und bilineare Formen', where the rational canonical form (Frobenius normal form) was established. Unlike the Jordan canonical form (Jordan 1870), which requires the characteristic polynomial to split into linear factors over the base field, the rational canonical form works over any field: it is the canonical block-diagonal decomposition using invariant factors rather than eigenvalues. The companion matrix C(p) is the matrix representation of multiplication by x on the quotient module F[X]/(p), making it the elementary algebraic object from which all F[X]-modules are built (via the primary decomposition theorem for modules over PIDs). The orbit argument — that {e₀, Ce₀, ..., C^{d-1}e₀} is the standard basis — is the key fact, and was known to Frobenius. The full RCF formalization in a proof assistant has been completed in Coq by Cano-Dénès (2012) and in Isabelle/HOL by Divasón-Thiemann (2016); a Lean 4 formalization is an active gap in Mathlib.",
+    "problemStatement": "Define the companion matrix $C(p)$ for a monic polynomial $p$ of degree $d$ and prove: (1) the orbit $\\{e_0, C(p)e_0, \\ldots, C(p)^{d-1}e_0\\}$ is the standard basis; (2) $p(C(p)) = 0$; (3) $\\mathrm{charpoly}(C(p)) = p$; (4) $\\mathrm{minpoly}(C(p)) = p$.",
+    "proofStrategy": "Five parts: explicit entry-formula definition, three entry-characterization lemmas, orbit argument (C(p)ᵏ·e₀ = eₖ proved by induction), three key theorems (sorry: annihilation, charpoly, minpoly), and the linear-polynomial base case C(x−c) = [c]. A final roadmap assesses the ~1800-line gap for the full RCF theorem.",
     "keyInsights": [
-      "Companion matrices are non-derogatory: minpoly = charpoly = p",
-      "The full RCF requires Smith Normal Form for F[X]-matrices (~800 lines) — main blocker",
-      "C(x-c) = [c] is the base case connecting eigenvalues to 1×1 companion blocks"
+      "The companion matrix C(p) is the canonical matrix representation of multiplication by x on F[X]/(p): the orbit {e₀, C(p)e₀, ..., C(p)^{d-1}e₀} = standard basis confirms the isomorphism F^d ≅ F[X]/(p) as F[X]-modules",
+      "Companion matrices are non-derogatory: minpoly = charpoly = p, making them the unique matrix type (up to similarity) with a given characteristic polynomial of full degree",
+      "The rational canonical form works over any field without splitting the characteristic polynomial, unlike Jordan form — this is its fundamental advantage for fields like ℚ or 𝔽_p",
+      "The orbit argument gives a clean proof of p(C(p)) = 0 without computing a determinant: C(p)^d·e₀ = (last-column action) = −∑ aᵢeᵢ, which cancels with the polynomial evaluation sum",
+      "The main formalization blocker is Smith Normal Form for F[X]-matrices (~800 lines): Mathlib has SNF for ℤ but not yet for arbitrary Euclidean domains in constructive form"
+    ]
+  },
+  "sections": [
+    {
+      "id": "companion-definition",
+      "title": "Part 1: Companion Matrix Definition",
+      "startLine": 59,
+      "endLine": 81,
+      "summary": "Defines `companionMatrix p : Matrix (Fin d) (Fin d) F` entry-by-entry: 1s on the subdiagonal, negated polynomial coefficients in the last column, 0 elsewhere."
+    },
+    {
+      "id": "entry-lemmas",
+      "title": "Part 2: Basic Entry Properties",
+      "startLine": 82,
+      "endLine": 108,
+      "summary": "Three lemmas characterizing the three entry types: `companionMatrix_subdiag` (subdiagonal = 1), `companionMatrix_last_col` (last column = −coeff), `companionMatrix_zero` (elsewhere = 0)."
+    },
+    {
+      "id": "orbit",
+      "title": "Part 3: Orbit of Standard Basis Vectors",
+      "startLine": 110,
+      "endLine": 168,
+      "summary": "Proves C(p)ᵏ·e₀ = eₖ for k < d by induction using the column action lemmas. The orbit {e₀, ..., e_{d-1}} equals the standard basis."
+    },
+    {
+      "id": "key-theorems",
+      "title": "Part 3b: Annihilation, Charpoly, Minpoly",
+      "startLine": 170,
+      "endLine": 211,
+      "summary": "Three theorems stated with sorry: p(C(p)) = 0 (orbit annihilation), charpoly(C(p)) = p (from minpoly = p), minpoly(C(p)) = p (orbit independence). All supporting infrastructure is proved."
+    },
+    {
+      "id": "linear-case",
+      "title": "Part 4: Linear Polynomial Base Case",
+      "startLine": 213,
+      "endLine": 225,
+      "summary": "Proves C(x−c) = [c] for the 1×1 companion matrix, connecting companion blocks to eigenvalues."
+    },
+    {
+      "id": "rcf-roadmap",
+      "title": "Part 5: Full RCF Roadmap",
+      "startLine": 226,
+      "endLine": 259,
+      "summary": "Documents the ~1800-line gap to a complete Lean formalization of the rational canonical form: SNF (~800), companion (~200), block assembly (~300), uniqueness (~200)."
+    }
+  ],
+  "conclusion": {
+    "summary": "The formalization defines the companion matrix with 6 fully proved results (definition, 3 entry lemmas, column action, orbit lemma, linear case) and 3 remaining sorries (annihilation, charpoly, minpoly). All conceptual infrastructure for closing the sorries is in place.",
+    "implications": "The companion matrix and rational canonical form are central to module theory over PIDs: the structure theorem for finitely generated modules over a PID is exactly the RCF when applied to F[X]-modules. Applications include: normal forms for linear recurrences (companion matrix of the characteristic polynomial of the recurrence), the theory of cyclic codes in coding theory, and the proof that every matrix satisfies its own characteristic polynomial (Cayley-Hamilton, for which the companion matrix gives the cleanest proof). A complete Lean formalization would unlock these applications in Mathlib.",
+    "openQuestions": [
+      "Can the 3 sorries be closed without Smith Normal Form? The annihilation sorry has a clear orbit proof; minpoly requires only degree comparison and divisibility; these may be achievable within ~50 additional lines.",
+      "Is Mathlib's existing Smith Normal Form for ℤ (Hermite normal form infrastructure) adaptable to F[X] via the generic Euclidean domain API?",
+      "The rational canonical form has been formalized in Coq (Cano-Dénès 2012) and Isabelle (Divasón-Thiemann 2016) — could a porting strategy from one of these reduce the estimated 1800-line effort?"
     ]
   },
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-reduction-oq-02-oq-01`.

## Quality improvements

- **Expanded `overview`**: historicalContext (Cayley 1858, Frobenius 1878, Coq/Isabelle formalizations), 5 keyInsights on F[X]/(p) isomorphism, non-derogatory property, RCF vs Jordan, orbit proof strategy, SNF bottleneck
- **New `annotations.json`**: 6 annotations covering all proof sections with LaTeX mathContext, significance, relatedConcepts, prerequisites
- **New `sections` array**: 6 entries covering Parts 1-5 (definition, entry lemmas, orbit, sorry theorems, linear case, roadmap)
- **New `conclusion`**: summary of proved/sorry state, implications (PID module theory, cyclic codes, Cayley-Hamilton), 3 open questions on sorry-closure strategies and formalization porting