### PR TITLE
Research: minkowski-theorem-oq-02 — Dirichlet approximation via Minkowski (3 axioms)

### DIFF
--- a/proofs/Proofs/MinkowskiTheoremOQ02.lean
+++ b/proofs/Proofs/MinkowskiTheoremOQ02.lean
@@ -1,0 +1,284 @@
+import Proofs.MinkowskiFundamentalTheorem
+import Mathlib.Analysis.Convex.Basic
+import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
+import Mathlib.MeasureTheory.Group.GeometryOfNumbers
+import Mathlib.Data.Real.Basic
+import Mathlib.Tactic
+
+/-!
+# Dirichlet's Approximation Theorem via Minkowski's Lattice Point Theorem
+
+## What This Proves
+
+**Dirichlet's Approximation Theorem**: For any real α and positive integer Q,
+there exist integers p, q with 1 ≤ q ≤ Q and |qα − p| < 1/Q.
+
+This proof derives Dirichlet's theorem as a direct corollary of Minkowski's
+fundamental theorem (geometry of numbers), demonstrating the power of geometric
+methods in number theory.
+
+## Proof Strategy
+
+1. **Construct the Dirichlet parallelogram**
+   S = {(x, y) ∈ ℝ² : |x| < Q + 1, |αx − y| < 1/Q}
+2. **S is centrally symmetric**: |−x| = |x| and |α(−x) − (−y)| = |αx − y|
+3. **S is convex**: defined by linear constraints (intersection of halfspaces)
+4. **Area(S) = 4(Q+1)/Q > 4 = 2²**: key volume inequality for Minkowski
+5. **Apply Minkowski**: S contains a non-zero integer point (a, b) ∈ ℤ²
+6. **a ≠ 0**: if a = 0, then |b| < 1/Q < 1, so b = 0, contradicting nonzero
+7. **Conclusion**: q = |a| satisfies 1 ≤ q ≤ Q and |αq − p| < 1/Q
+
+## Historical Context
+
+This application of geometry of numbers to Diophantine approximation is one
+of the founding examples of Minkowski's 1896 work. The argument shows that
+a purely geometric fact (lattice points in parallelograms) immediately implies
+the arithmetic theorem on rational approximations.
+
+## Mathlib Foundation
+
+Uses `MinkowskiProved.minkowski_integer_lattice_proved` from the companion file
+`MinkowskiFundamentalTheorem.lean`. That theorem is fully proved (0 axioms) using
+Mathlib's `exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure`.
+
+## Axioms
+
+Three axioms handle measure-theoretic steps in this file:
+- `dirichletSet_convex`: the parallelogram is a convex set (linear halfplanes)
+- `dirichletSet_measurable`: the parallelogram is Lebesgue measurable (open set)
+- `dirichletSet_volume`: area = 4(Q+1)/Q, by Fubini or the shear-map argument
+
+The integer-coordinate extraction step is proved from `Submodule.mem_span_range_iff_exists_fun`.
+-/
+
+open MeasureTheory Set Real
+
+namespace DirichletFromMinkowski
+
+-- ============================================================
+-- PART 1: The Dirichlet Parallelogram
+-- ============================================================
+
+/-- The parallelogram for Dirichlet's theorem:
+    S = {(x, y) ∈ ℝ² : |x| < Q+1 and |αx − y| < 1/Q}.
+
+    This is centrally symmetric, convex, and has area 4(Q+1)/Q > 4. -/
+def dirichletSet (α : ℝ) (Q : ℕ) : Set (Fin 2 → ℝ) :=
+  {v | |v 0| < (Q : ℝ) + 1 ∧ |α * v 0 - v 1| < 1 / (Q : ℝ)}
+
+-- ============================================================
+-- PART 2: Central Symmetry (Proved)
+-- ============================================================
+
+/-- The Dirichlet parallelogram is centrally symmetric.
+    (x, y) ∈ S ⟹ (−x, −y) ∈ S, since |−x| = |x| and |α(−x) − (−y)| = |αx − y|. -/
+theorem dirichletSet_symmetric (α : ℝ) (Q : ℕ) :
+    ∀ v ∈ dirichletSet α Q, -v ∈ dirichletSet α Q := by
+  intro v ⟨hv0, hv1⟩
+  constructor
+  · -- |(-v) 0| = |-v 0| = |v 0|
+    simp only [Pi.neg_apply, abs_neg]; exact hv0
+  · -- |α * (-v 0) - (-v 1)| = |-(α * v 0 - v 1)| = |α * v 0 - v 1|
+    simp only [Pi.neg_apply]
+    rw [show α * -v 0 - -v 1 = -(α * v 0 - v 1) by ring, abs_neg]
+    exact hv1
+
+-- ============================================================
+-- PART 3: Measurability, Convexity, Volume (Axioms)
+-- ============================================================
+
+/-!
+### Measure-Theoretic Properties
+
+The Dirichlet parallelogram S can be described as the preimage of the open
+rectangle R = (−Q−1, Q+1) × (−1/Q, 1/Q) under the shear map T(x,y) = (x, αx−y).
+
+**Convexity**: S is the intersection of two open halfplanes, each convex.
+
+**Measurability**: S is open (preimage of open set under continuous map), hence measurable.
+
+**Volume**: T has determinant det([[1,0],[α,−1]]) = −1, so |det(T)| = 1.
+By the change-of-variables formula, vol(S) = vol(T⁻¹(R)) = vol(R) / |det(T)| = vol(R).
+vol(R) = 2(Q+1) · (2/Q) = 4(Q+1)/Q.
+-/
+
+/-- The Dirichlet parallelogram is convex (intersection of two halfplanes). -/
+axiom dirichletSet_convex (α : ℝ) (Q : ℕ) :
+    Convex ℝ (dirichletSet α Q)
+
+/-- The Dirichlet parallelogram is Lebesgue measurable. -/
+axiom dirichletSet_measurable (α : ℝ) (Q : ℕ) :
+    MeasurableSet (dirichletSet α Q)
+
+/-- The Lebesgue measure of the Dirichlet parallelogram equals 4(Q+1)/Q.
+
+    The shear T(x,y) = (x, αx−y) has determinant −1 and maps S to the rectangle
+    (−Q−1, Q+1) × (−1/Q, 1/Q). Since |det(T)| = 1, vol(S) = vol(rectangle) = 4(Q+1)/Q. -/
+axiom dirichletSet_volume (α : ℝ) (Q : ℕ) (hQ : 0 < Q) :
+    MeasureTheory.volume (dirichletSet α Q) =
+      ENNReal.ofReal (4 * ((Q : ℝ) + 1) / (Q : ℝ))
+
+-- ============================================================
+-- PART 4: Volume Exceeds the Minkowski Threshold 2² = 4
+-- ============================================================
+
+/-- The area 4(Q+1)/Q exceeds 4 = 2² when Q ≥ 1.
+    Area = 4 + 4/Q > 4. -/
+theorem dirichletSet_volume_gt_four (α : ℝ) (Q : ℕ) (hQ : 0 < Q) :
+    (2 : ENNReal) ^ 2 < MeasureTheory.volume (dirichletSet α Q) := by
+  rw [dirichletSet_volume α Q hQ]
+  have hQpos : (0 : ℝ) < (Q : ℝ) := Nat.cast_pos.mpr hQ
+  have hlt : (4 : ℝ) < 4 * ((Q : ℝ) + 1) / (Q : ℝ) := by
+    rw [lt_div_iff hQpos]; linarith
+  calc (2 : ENNReal) ^ 2
+      = ENNReal.ofReal 4 := by norm_num
+    _ < ENNReal.ofReal (4 * ((Q : ℝ) + 1) / (Q : ℝ)) :=
+        ENNReal.ofReal_lt_ofReal_of_nonneg (by norm_num) hlt
+
+-- ============================================================
+-- PART 5: Integer Coordinates from stdLattice 2
+-- ============================================================
+
+open MinkowskiProved in
+/-- A point in the standard integer lattice `stdLattice 2 = ℤ²` has integer coordinates.
+
+    This follows from `stdLattice 2 = Submodule.span ℤ {e₀, e₁}` where e₀ = (1,0), e₁ = (0,1).
+    Any element is `c₀ • e₀ + c₁ • e₁ = (c₀, c₁)` for integers c₀, c₁. -/
+lemma stdLattice2_coords (x : stdLattice 2) :
+    ∃ (a b : ℤ), (x : Fin 2 → ℝ) 0 = (a : ℝ) ∧ (x : Fin 2 → ℝ) 1 = (b : ℝ) := by
+  -- Membership in ℤ-span of standard basis
+  have hmem : (x : Fin 2 → ℝ) ∈
+      Submodule.span ℤ (Set.range (Pi.basisFun ℝ (Fin 2))) := x.2
+  -- Decompose: ∃ c : Fin 2 → ℤ, x = ∑ i, c i • e_i
+  rw [Submodule.mem_span_range_iff_exists_fun] at hmem
+  obtain ⟨c, hc⟩ := hmem
+  -- Convert ℤ-smul to ℝ-smul: x = ∑ i, (c i : ℝ) • e_i
+  have hc_real : (x : Fin 2 → ℝ) = ∑ i : Fin 2, (c i : ℝ) • Pi.basisFun ℝ (Fin 2) i := by
+    rw [hc]; simp_rw [zsmul_eq_smul_cast ℝ]
+  -- Extract coordinates: (∑ i, (c i : ℝ) • e_i) j = c j
+  refine ⟨c 0, c 1, ?_, ?_⟩
+  · -- Coordinate 0
+    rw [hc_real]
+    simp [Pi.basisFun_apply, Fin.sum_univ_two, Pi.single_apply]
+  · -- Coordinate 1
+    rw [hc_real]
+    simp [Pi.basisFun_apply, Fin.sum_univ_two, Pi.single_apply]
+
+-- ============================================================
+-- PART 6: Main Theorem — Dirichlet from Minkowski
+-- ============================================================
+
+/-- **Dirichlet's Approximation Theorem** derived from Minkowski's theorem.
+
+For any real α and positive integer Q, there exist integers p, q with
+1 ≤ q ≤ Q and |qα − p| < 1/Q.
+
+**Proof**:
+1. The parallelogram S = {|x| < Q+1, |αx−y| < 1/Q} has area 4(Q+1)/Q > 4 = 2².
+2. By Minkowski's theorem, S contains a nonzero integer point (a, b).
+3. If a = 0, then |b| < 1/Q < 1, forcing b = 0 (integer), contradicting nonzero.
+4. So a ≠ 0, giving q = |a| with 1 ≤ |a| ≤ Q (since |a| < Q+1 and a ∈ ℤ).
+5. Setting p = b (if a > 0) or p = -b (if a < 0), we get |qα − p| < 1/Q. -/
+theorem dirichlet_approximation_from_minkowski (α : ℝ) (Q : ℕ) (hQ : 0 < Q) :
+    ∃ (q p : ℤ), 1 ≤ q ∧ q ≤ Q ∧ |α * (q : ℝ) - (p : ℝ)| < 1 / (Q : ℝ) := by
+  -- Step 1: Apply Minkowski to get a nonzero integer point in S
+  obtain ⟨x, hx_ne, hx_S⟩ :=
+    MinkowskiProved.minkowski_integer_lattice_proved 2 (dirichletSet α Q)
+      (dirichletSet_symmetric α Q)
+      (dirichletSet_convex α Q)
+      (dirichletSet_volume_gt_four α Q hQ)
+  -- Step 2: Extract integer coordinates (a, b) from x ∈ ℤ²
+  obtain ⟨a, b, ha, hb⟩ := stdLattice2_coords x
+  -- Step 3: Parse membership x ∈ S
+  simp only [dirichletSet, Set.mem_setOf_eq] at hx_S
+  obtain ⟨ha_bound, hab_approx⟩ := hx_S
+  rw [ha] at ha_bound hab_approx
+  rw [hb] at hab_approx
+  -- Positivity facts
+  have hQpos : (0 : ℝ) < (Q : ℝ) := Nat.cast_pos.mpr hQ
+  -- Step 4: Show a ≠ 0 (the first coordinate is nonzero)
+  have ha_ne : a ≠ 0 := by
+    intro ha0; subst ha0
+    -- If a = 0: |α * 0 − b| = |b| < 1/Q < 1
+    simp only [Int.cast_zero, mul_zero, zero_sub, abs_neg] at hab_approx
+    -- |b| < 1/Q ≤ 1 since Q ≥ 1
+    have hQge1 : (1 : ℝ) ≤ (Q : ℝ) :=
+      by exact_mod_cast Nat.one_le_iff_ne_zero.mpr (Nat.pos_iff_ne_zero.mp hQ)
+    have hb_lt1 : |(b : ℝ)| < 1 :=
+      hab_approx.trans_le (div_le_one hQpos |>.mpr hQge1)
+    -- |b| < 1 and b : ℤ → b = 0
+    have hb0 : b = 0 := by
+      have hlt : b < (1 : ℤ) := by exact_mod_cast (abs_lt.mp hb_lt1).2
+      have hgt : -(1 : ℤ) < b := by exact_mod_cast (abs_lt.mp hb_lt1).1
+      omega
+    -- (a, b) = (0, 0) contradicts x ≠ 0
+    apply hx_ne
+    apply Subtype.ext
+    funext i
+    fin_cases i
+    · -- Coordinate 0: x 0 = (0:ℤ):ℝ = 0
+      simp only [Pi.zero_apply]; rw [ha]; simp
+    · -- Coordinate 1: x 1 = (b:ℝ) = 0
+      simp only [Pi.zero_apply]; rw [hb]; simp [hb0]
+  -- Step 5: Set q = |a|, p = b if a > 0, -b if a < 0
+  refine ⟨|a|, if 0 < a then b else -b, ?_, ?_, ?_⟩
+  · -- 1 ≤ |a|: since a ≠ 0 is an integer
+    exact Int.one_le_abs ha_ne
+  · -- |a| ≤ Q: from |a| < Q+1 and a ∈ ℤ
+    have hcast : |(a : ℝ)| < (Q : ℝ) + 1 := ha_bound
+    rw [Int.cast_abs] at hcast
+    have h : (|a| : ℝ) < (Q : ℝ) + 1 := hcast
+    have h' : |a| < (Q : ℤ) + 1 := by exact_mod_cast h
+    exact_mod_cast Int.lt_add_one_iff.mp h'
+  · -- |α * |a| − p| < 1/Q
+    split_ifs with hpos
+    · -- a > 0: |a| = a
+      rw [Int.abs_of_pos hpos]; exact hab_approx
+    · -- a < 0: |a| = −a, and α·(−a) − (−b) = −(α·a − b)
+      have hneg : a < 0 := lt_of_le_of_ne (le_of_not_lt hpos) ha_ne
+      rw [Int.abs_of_neg hneg]
+      push_cast
+      rw [show α * -(a : ℝ) - -(b : ℝ) = -(α * (a : ℝ) - (b : ℝ)) by ring, abs_neg]
+      exact hab_approx
+
+-- ============================================================
+-- PART 7: Corollary
+-- ============================================================
+
+/-- Dirichlet's theorem gives rational approximations of any precision.
+    For any ε > 0, there exist integers p, q > 0 with |α − p/q| < ε/q. -/
+theorem dirichlet_approximation_corollary (α : ℝ) (Q : ℕ) (hQ : 0 < Q) :
+    ∃ (q p : ℤ), 1 ≤ q ∧ q ≤ (Q : ℤ) ∧
+    |α - (p : ℝ) / (q : ℝ)| < 1 / ((Q : ℝ) * (q : ℝ)) := by
+  obtain ⟨q, p, hq1, hqQ, happrox⟩ := dirichlet_approximation_from_minkowski α Q hQ
+  refine ⟨q, p, hq1, hqQ, ?_⟩
+  have hqpos : (0 : ℝ) < (q : ℝ) := by exact_mod_cast Int.lt_of_lt_of_le Int.one_pos hq1
+  have hQpos : (0 : ℝ) < (Q : ℝ) := Nat.cast_pos.mpr hQ
+  rw [show α - (p : ℝ) / (q : ℝ) = (α * (q : ℝ) - (p : ℝ)) / (q : ℝ) by field_simp; ring,
+      abs_div, abs_of_pos hqpos, div_lt_div_iff hqpos (mul_pos hQpos hqpos)]
+  -- Goal: |α*q - p| * (Q*q) < 1 * q = q
+  -- From happrox: |α*q - p| < 1/Q, so |α*q - p| * Q < 1
+  have key : |α * (q : ℝ) - (p : ℝ)| * (Q : ℝ) < 1 := by rwa [lt_div_iff hQpos] at happrox
+  nlinarith
+
+end DirichletFromMinkowski
+
+-- ============================================================
+-- PART 8: Gallery Export
+-- ============================================================
+
+/-- **Dirichlet's Approximation Theorem** — proved via Minkowski's geometry of numbers.
+
+For any real α and positive integer Q, there exist integers p, q with
+1 ≤ q ≤ Q and |αq − p| < 1/Q.
+
+**Proof method**: Apply Minkowski's lattice point theorem to the parallelogram
+S = {(x,y) ∈ ℝ² : |x| < Q+1, |αx−y| < 1/Q}. This set has area 4(Q+1)/Q > 4,
+so it contains a nonzero integer lattice point (q,p) ∈ ℤ². The first coordinate
+q is nonzero (else the second is also 0, contradicting nonzero), and
+1 ≤ |q| ≤ Q and |αq−p| < 1/Q. -/
+theorem dirichlet_from_minkowski (α : ℝ) (Q : ℕ) (hQ : 0 < Q) :
+    ∃ (q p : ℤ), 1 ≤ q ∧ q ≤ Q ∧ |α * (q : ℝ) - (p : ℝ)| < 1 / (Q : ℝ) :=
+  DirichletFromMinkowski.dirichlet_approximation_from_minkowski α Q hQ
+
+#check dirichlet_from_minkowski

--- a/src/data/proofs/minkowski-theorem-oq-02/annotations.json
+++ b/src/data/proofs/minkowski-theorem-oq-02/annotations.json
@@ -1,0 +1,148 @@
+[
+  {
+    "id": "ann-minkdiri-header",
+    "proofId": "minkowski-theorem-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 52
+    },
+    "type": "context",
+    "title": "Dirichlet via Minkowski: Overview and Proof Strategy",
+    "content": "This file proves Dirichlet's approximation theorem as a direct application of Minkowski's fundamental theorem (geometry of numbers). The key idea: the parallelogram S = {|x| < Q+1, |αx−y| < 1/Q} has area 4(Q+1)/Q > 4 = 2², so by Minkowski it contains a nonzero integer point (q,p), which gives the desired approximation after a brief argument showing q ≠ 0.",
+    "mathContext": "Dirichlet's theorem (1842): for any α ∈ ℝ and Q ∈ ℕ₊, ∃ p,q ∈ ℤ with 1 ≤ q ≤ Q and |qα−p| < 1/Q. Minkowski's proof method (1896) replaces the elementary pigeonhole argument with a geometric volume argument.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Dirichlet's approximation theorem",
+      "Minkowski's lattice point theorem",
+      "geometry of numbers",
+      "Diophantine approximation"
+    ]
+  },
+  {
+    "id": "ann-minkdiri-set",
+    "proofId": "minkowski-theorem-oq-02",
+    "range": {
+      "startLine": 62,
+      "endLine": 68
+    },
+    "type": "definition",
+    "title": "The Dirichlet Parallelogram",
+    "content": "The set `dirichletSet α Q` = {v : Fin 2 → ℝ | |v 0| < Q+1 ∧ |α·v 0 − v 1| < 1/Q} is the key geometric object. In Cartesian coordinates (x,y), the conditions are |x| < Q+1 (a horizontal strip of width 2(Q+1)) and |αx−y| < 1/Q (a diagonal strip of vertical thickness 2/Q). Their intersection is a parallelogram.",
+    "mathContext": "The parallelogram has area 4(Q+1)/Q by the shear map argument: T(x,y) = (x, αx−y) maps S to the rectangle (−Q−1, Q+1) × (−1/Q, 1/Q). Since det(T) = det([[1,0],[α,−1]]) = −1, T preserves Lebesgue measure, giving vol(S) = 2(Q+1)·(2/Q) = 4(Q+1)/Q.",
+    "significance": "key-definition",
+    "relatedConcepts": [
+      "parallelogram",
+      "Lebesgue measure",
+      "shear map"
+    ]
+  },
+  {
+    "id": "ann-minkdiri-sym",
+    "proofId": "minkowski-theorem-oq-02",
+    "range": {
+      "startLine": 73,
+      "endLine": 83
+    },
+    "type": "theorem",
+    "title": "Central Symmetry (Proved, 0 Axioms)",
+    "content": "The proof that S is centrally symmetric is fully verified: if (x,y) ∈ S then (−x,−y) ∈ S. The first condition |−x| = |x| is abs_neg. For the second, α·(−x) − (−y) = −(αx−y), so |α(−x)−(−y)| = |−(αx−y)| = |αx−y| by abs_neg after ring normalization.",
+    "mathContext": "Central symmetry is one of the two hypotheses of Minkowski's theorem (the other being convexity). It is used in the pigeonhole argument to ensure that if s₁, s₂ ∈ S then −s₂ ∈ S, enabling the midpoint argument.",
+    "significance": "key-lemma",
+    "relatedConcepts": [
+      "central symmetry",
+      "Minkowski conditions"
+    ]
+  },
+  {
+    "id": "ann-minkdiri-axioms",
+    "proofId": "minkowski-theorem-oq-02",
+    "range": {
+      "startLine": 100,
+      "endLine": 115
+    },
+    "type": "gap",
+    "title": "Three Measure-Theoretic Axioms",
+    "content": "The three axioms handle measure theory: convexity (S is an intersection of two halfplanes, each defined by a linear inequality on a continuous functional), measurability (S is open hence Borel measurable), and volume (= 4(Q+1)/Q via Fubini or the shear map). These are mathematically routine but require Mathlib's measure theory machinery to formalize.",
+    "mathContext": "Convexity: the function (v: Fin 2 → ℝ) ↦ |α·v 0 − v 1| is convex (it's a norm of a linear functional), so its sublevel set is convex. Volume: formally this requires Fubini's theorem (inner integral = 2/Q for each x with |x| < Q+1, outer integral = 2(Q+1)) or the change-of-variables formula for linear maps.",
+    "significance": "gap",
+    "relatedConcepts": [
+      "Lebesgue measure",
+      "Fubini's theorem",
+      "convex sets",
+      "measurable sets"
+    ]
+  },
+  {
+    "id": "ann-minkdiri-volume",
+    "proofId": "minkowski-theorem-oq-02",
+    "range": {
+      "startLine": 122,
+      "endLine": 132
+    },
+    "type": "theorem",
+    "title": "Volume > 4: The Minkowski Threshold",
+    "content": "Proves (2:ENNReal)^2 < volume(S). The key inequality 4 < 4(Q+1)/Q holds since Q+1 > Q, equivalently 4·Q < 4·(Q+1) = 4Q+4. This is the critical step enabling Minkowski's theorem: volume > 2² means the ℤ² lattice (covolume 1) must contribute a nonzero point.",
+    "mathContext": "In ENNReal arithmetic: (2:ENNReal)^2 = ENNReal.ofReal 4, and ofReal 4 < ofReal(4(Q+1)/Q) by ENNReal.ofReal_lt_ofReal_of_nonneg (available from the MinkowskiFundamentalTheorem file). The bound 4(Q+1)/Q > 4 is proved by clearing denominators: 4(Q+1) > 4Q ↔ 4Q+4 > 4Q ↔ 4 > 0.",
+    "significance": "key-lemma",
+    "relatedConcepts": [
+      "Minkowski threshold",
+      "ENNReal arithmetic",
+      "volume bound"
+    ]
+  },
+  {
+    "id": "ann-minkdiri-intcoords",
+    "proofId": "minkowski-theorem-oq-02",
+    "range": {
+      "startLine": 138,
+      "endLine": 161
+    },
+    "type": "lemma",
+    "title": "Integer Coordinates from ℤ²-Membership",
+    "content": "The lemma stdLattice2_coords extracts integer coordinates from a point x in stdLattice 2 = Submodule.span ℤ {e₀,e₁}. By mem_span_range_iff_exists_fun, x = ∑ᵢ cᵢ•eᵢ for integers cᵢ. After converting ℤ-smul to ℝ-smul via zsmul_eq_smul_cast, evaluation gives x.val 0 = c₀ and x.val 1 = c₁.",
+    "mathContext": "This connects Mathlib's abstract ℤ-module structure to the concrete arithmetic that the proof needs. The ℤ-span of the standard basis {e₀=(1,0), e₁=(0,1)} is exactly ℤ² — the integer lattice points.",
+    "significance": "key-lemma",
+    "relatedConcepts": [
+      "integer lattice",
+      "ℤ-span",
+      "Submodule",
+      "basis extraction"
+    ]
+  },
+  {
+    "id": "ann-minkdiri-qnonzero",
+    "proofId": "minkowski-theorem-oq-02",
+    "range": {
+      "startLine": 195,
+      "endLine": 214
+    },
+    "type": "proof-technique",
+    "title": "The q ≠ 0 Argument",
+    "content": "The key parity argument: suppose a = 0 (first coordinate zero). Then the second condition becomes |α·0 − b| = |b| < 1/Q. Since Q ≥ 1, we have 1/Q ≤ 1, so |b| < 1. But b is an integer, so |b| < 1 forces b = 0 (proved by omega after casting to ℤ). This means (a,b) = (0,0), contradicting x ≠ 0 in ℤ². Therefore a ≠ 0.",
+    "mathContext": "The bound 1/Q ≤ 1 uses Q ≥ 1: since Q is a positive natural number, Q ≥ 1, so 1/Q ≤ 1/1 = 1. The integer argument uses: b < 1 and −1 < b (from |b| < 1) with b ∈ ℤ implies b = 0, proved by omega.",
+    "significance": "key-step",
+    "relatedConcepts": [
+      "parity argument",
+      "integer arithmetic",
+      "omega tactic"
+    ]
+  },
+  {
+    "id": "ann-minkdiri-sign",
+    "proofId": "minkowski-theorem-oq-02",
+    "range": {
+      "startLine": 215,
+      "endLine": 234
+    },
+    "type": "proof-technique",
+    "title": "Sign Normalization to Get Positive q",
+    "content": "Since a ≠ 0 is an integer, |a| ≥ 1. The set S is symmetric, so if (a,b) ∈ S then (−a,−b) ∈ S. Setting q = |a| and p = b (if a>0) or p = −b (if a<0), the condition |α·q−p| < 1/Q is preserved: if a>0, q=a and p=b; if a<0, q=−a and α·(−a)−(−b) = −(αa−b), same absolute value.",
+    "mathContext": "The sign case split: if a > 0 then |a|=a and the bound is directly hab_approx. If a < 0 then |a|=−a (Int.abs_of_neg) and α·(−a)−(−b) = −(α·a−b) by ring, so |α·(−a)−(−b)| = |−(α·a−b)| = |α·a−b| by abs_neg.",
+    "significance": "proof-step",
+    "relatedConcepts": [
+      "absolute value",
+      "sign argument",
+      "integer arithmetic"
+    ]
+  }
+]

--- a/src/data/proofs/minkowski-theorem-oq-02/index.ts
+++ b/src/data/proofs/minkowski-theorem-oq-02/index.ts
@@ -1,0 +1,36 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/MinkowskiTheoremOQ02.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const minkowskiTheoremOq02Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const minkowskiTheoremOq02Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const minkowskiTheoremOq02Data: ProofData = {
+  proof: minkowskiTheoremOq02Proof,
+  annotations: minkowskiTheoremOq02Annotations,
+}

--- a/src/data/proofs/minkowski-theorem-oq-02/meta.json
+++ b/src/data/proofs/minkowski-theorem-oq-02/meta.json
@@ -1,0 +1,228 @@
+{
+  "id": "minkowski-theorem-oq-02",
+  "title": "Dirichlet's Approximation Theorem via Minkowski's Lattice Point Theorem",
+  "slug": "minkowski-theorem-oq-02",
+  "description": "Dirichlet's approximation theorem (for any real α and positive integer Q, there exist integers p, q with 1 ≤ q ≤ Q and |qα − p| < 1/Q) proved as a corollary of Minkowski's fundamental theorem via a parallelogram of area 4(Q+1)/Q > 4.",
+  "meta": {
+    "author": "Johann Peter Gustav Lejeune Dirichlet (1842), proof method: Hermann Minkowski (1896)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Dirichlet%27s_approximation_theorem",
+    "date": "1842",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/MinkowskiTheoremOQ02.lean",
+    "tags": [
+      "number-theory",
+      "geometry",
+      "lattice",
+      "diophantine-approximation",
+      "geometry-of-numbers"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 3,
+    "assumptions": "Three axioms handle measure-theoretic steps: (1) dirichletSet_convex: the parallelogram {|x| < Q+1, |αx-y| < 1/Q} is convex — intersection of two halfplanes; (2) dirichletSet_measurable: it is Lebesgue measurable — open set hence Borel; (3) dirichletSet_volume: its area equals 4(Q+1)/Q — proved by Fubini or the shear map T(x,y)=(x,αx-y) with det(T)=-1 mapping S to a rectangle. The main theorem and all logical steps are fully proved.",
+    "dateAdded": "2026-04-03",
+    "mathlibDependencies": [
+      {
+        "theorem": "MinkowskiProved.minkowski_integer_lattice_proved",
+        "description": "Minkowski's theorem for ℤⁿ: if a centrally symmetric convex set has volume > 2ⁿ, it contains a nonzero integer point. Proved from Mathlib's geometry of numbers.",
+        "module": "Proofs.MinkowskiFundamentalTheorem"
+      },
+      {
+        "theorem": "Submodule.mem_span_range_iff_exists_fun",
+        "description": "Membership in ℤ-span of basis: x ∈ span ℤ {e_i} iff ∃ c : ι → ℤ, x = ∑ i, c i • e_i",
+        "module": "Mathlib.LinearAlgebra.Span"
+      },
+      {
+        "theorem": "exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure",
+        "description": "Mathlib's geometry of numbers theorem underlying Minkowski's result",
+        "module": "Mathlib.MeasureTheory.Group.GeometryOfNumbers"
+      }
+    ],
+    "originalContributions": [
+      "dirichletSet definition: {(x,y) : |x| < Q+1, |αx-y| < 1/Q}",
+      "dirichletSet_symmetric: central symmetry proved (0 axioms)",
+      "dirichletSet_volume_gt_four: area > 4 proved from volume axiom",
+      "stdLattice2_coords: integer coordinate extraction from ℤ²-membership",
+      "dirichlet_approximation_from_minkowski: main theorem (3 axioms, 0 sorries)",
+      "dirichlet_approximation_corollary: |α - p/q| < 1/(Qq) derived",
+      "Proof of q ≠ 0 via: q=0 → |p|<1/Q<1 → p=0 → contradiction"
+    ],
+    "mathlib_version": "4.26.0",
+    "prerequisites": [
+      "Minkowski's fundamental theorem (geometry of numbers)",
+      "Lebesgue measure and Fubini's theorem",
+      "Linear maps and change of variables",
+      "Integer lattices and ℤ-span decompositions"
+    ],
+    "relatedProofs": [
+      "minkowski-theorem"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Dirichlet's approximation theorem (1842) was one of Dirichlet's early results, predating his major work on Dirichlet series and L-functions. The elementary pigeonhole proof (divide [0,1) into Q subintervals and apply pigeonhole to the fractional parts {α}, {2α}, ..., {Qα}) was already elegant. However, Minkowski (1896) observed that his new lattice point theorem — the founding result of geometry of numbers — immediately yields Dirichlet's theorem as a special case. This geometric proof is one of the earliest applications of Minkowski's program: transforming arithmetic questions into geometric ones about convex bodies containing lattice points.",
+    "problemStatement": "**Dirichlet's Approximation Theorem**: For any real number α and positive integer Q, there exist integers p and q with 1 ≤ q ≤ Q such that |qα − p| < 1/Q.\n\nEquivalently: for any α ∈ ℝ and Q ∈ ℕ₊, there exists a rational p/q with 1 ≤ q ≤ Q satisfying |α − p/q| < 1/(qQ).",
+    "text": "Proves Dirichlet's approximation theorem as a corollary of Minkowski's lattice point theorem. The parallelogram S = {(x,y) ∈ ℝ² : |x| < Q+1, |αx−y| < 1/Q} is centrally symmetric, convex, and has area 4(Q+1)/Q > 4. By Minkowski, S contains a nonzero integer point (q,p). A parity argument shows the first coordinate q is nonzero: if q=0, then |p|<1/Q<1 forces p=0, contradicting the nonzero condition. Thus 1 ≤ |q| ≤ Q and |αq−p| < 1/Q.",
+    "proofStrategy": "**Minkowski-based proof**:\n1. **Construct parallelogram** S = {(x,y) ∈ ℝ² : |x| < Q+1, |αx−y| < 1/Q}\n2. **Area computation**: The shear T(x,y) = (x,αx−y) has det(T) = −1, so maps S to the rectangle (−Q−1, Q+1) × (−1/Q, 1/Q) with area 2(Q+1) · 2/Q = 4(Q+1)/Q > 4\n3. **Apply Minkowski**: Since area(S) > 4 = 2², Minkowski's theorem gives a nonzero integer point (q,p) ∈ S ∩ ℤ²\n4. **First coordinate nonzero**: If q = 0, then |α·0 − p| = |p| < 1/Q < 1, so p = 0 as an integer, contradicting (q,p) ≠ (0,0)\n5. **Bounds**: |q| < Q+1 and q ∈ ℤ give |q| ≤ Q; and |q| ≥ 1 since q ≠ 0\n6. **Sign adjustment**: Replace (q,p) with (|q|, sign(q)·p) to get positive first coordinate\n7. **Conclusion**: 1 ≤ q = |q| ≤ Q and |αq − p| < 1/Q",
+    "keyInsights": [
+      "The shear map T(x,y) = (x, αx−y) has determinant −1, so it preserves Lebesgue measure and maps the oblique parallelogram to an axis-aligned rectangle",
+      "The key asymmetry argument: the first coordinate of a nonzero ℤ²-point in S must be nonzero, else the second coordinate would be a nonzero integer of absolute value less than 1, a contradiction",
+      "The parallelogram is 'tall and thin' when Q is large: height 2/Q in the y-direction but width 2(Q+1) ≈ 2Q in x. Its area is always just barely above 4, giving only one 'extra' nonzero lattice point.",
+      "This proof method generalizes to simultaneous approximation: given α₁,...,αₙ and Q, the n+1 dimensional parallelotope {|x₀| < Q+1, |αᵢx₀ − xᵢ| < Q^(−1/n)} has volume > 2^(n+1), giving nonzero integer points for all coordinates simultaneously"
+    ],
+    "prerequisites": [
+      "Minkowski's fundamental theorem (geometry of numbers)",
+      "Lebesgue measure, Fubini's theorem",
+      "Linear algebra: determinants, change of variables",
+      "Integer lattices ℤⁿ and their properties"
+    ]
+  },
+  "sections": [
+    {
+      "id": "dirichlet-set",
+      "title": "The Dirichlet Parallelogram",
+      "startLine": 57,
+      "endLine": 68,
+      "summary": "Defines the parallelogram S = {(x,y) ∈ ℝ² : |x| < Q+1, |αx−y| < 1/Q} as a set in Fin 2 → ℝ. This is the centrally symmetric convex set to which Minkowski's theorem is applied.",
+      "mathContext": "Expressed as a subset of Fin 2 → ℝ (functions from {0,1} to ℝ, the Lean representation of ℝ²) to interface directly with MinkowskiProved.minkowski_integer_lattice_proved. The first coordinate constraint |v 0| < Q+1 gives width, while |α·v 0 − v 1| < 1/Q gives the 'diagonal' constraint."
+    },
+    {
+      "id": "symmetry",
+      "title": "Central Symmetry (Proved)",
+      "startLine": 72,
+      "endLine": 83,
+      "summary": "Proves the parallelogram is centrally symmetric: (x,y) ∈ S implies (−x,−y) ∈ S. This uses |−x| = |x| (abs_neg) and |α(−x) − (−y)| = |−(αx−y)| = |αx−y| (ring + abs_neg).",
+      "mathContext": "The key computation: α·(−v 0) − (−v 1) = −(α·v 0 − v 1), so the absolute value is unchanged. This is proved by ring normalization followed by abs_neg."
+    },
+    {
+      "id": "axioms",
+      "title": "Measure-Theoretic Axioms",
+      "startLine": 86,
+      "endLine": 115,
+      "summary": "Three axioms state: (1) convexity of S (intersection of halfplanes), (2) measurability of S (open set), (3) volume of S equals 4(Q+1)/Q. The volume follows from the shear T(x,y)=(x,αx−y) with |det(T)|=1 mapping S to a rectangle.",
+      "mathContext": "Volume computation: the image T(S) = {|x| < Q+1} × {|z| < 1/Q} has Lebesgue measure 2(Q+1)·(2/Q) = 4(Q+1)/Q. Since T has det = −1, T is measure-preserving, giving vol(S) = vol(T(S)) = 4(Q+1)/Q."
+    },
+    {
+      "id": "volume-bound",
+      "title": "Volume Exceeds Minkowski Threshold",
+      "startLine": 118,
+      "endLine": 132,
+      "summary": "Proves 4(Q+1)/Q > 4 = 2² when Q ≥ 1, establishing the Minkowski volume condition. Uses ENNReal.ofReal_lt_ofReal_of_nonneg from the parent MinkowskiFundamentalTheorem file.",
+      "mathContext": "4(Q+1)/Q > 4 ↔ Q+1 > Q (after multiplying by Q > 0), which holds since Q+1 = Q + 1 > Q. In ENNReal arithmetic: (2:ENNReal)^2 = ofReal 4 < ofReal(4(Q+1)/Q)."
+    },
+    {
+      "id": "int-coords",
+      "title": "Integer Coordinate Extraction",
+      "startLine": 135,
+      "endLine": 161,
+      "summary": "Proves any point in stdLattice 2 (= ℤ²) has integer coordinates, by decomposing using Submodule.mem_span_range_iff_exists_fun and converting ℤ-smul to ℝ-smul via zsmul_eq_smul_cast.",
+      "mathContext": "stdLattice 2 = Submodule.span ℤ {e₀, e₁} where eᵢ = Pi.basisFun ℝ (Fin 2) i = Pi.single i 1. A point in the span is ∑ i, cᵢ • eᵢ = fun j => cⱼ for integers c₀, c₁."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Main Theorem: Dirichlet from Minkowski",
+      "startLine": 163,
+      "endLine": 234,
+      "summary": "Proves dirichlet_approximation_from_minkowski: applies Minkowski to get nonzero integer (a,b) in S, extracts coordinates, shows a≠0 (else |b|<1/Q<1 forces b=0), sets q=|a| and p=b or -b to get positive q. Uses omega for the integer bound argument.",
+      "mathContext": "The q≠0 argument: if a=0, then |α·0 − b| = |b| < 1/Q ≤ 1/1 = 1 (since Q≥1), so b is an integer with |b| < 1, forcing b=0 by omega. But (a,b)=(0,0) contradicts x≠0 in stdLattice 2."
+    },
+    {
+      "id": "corollary",
+      "title": "Corollary: Approximation Bound",
+      "startLine": 237,
+      "endLine": 254,
+      "summary": "Derives |α − p/q| < 1/(Qq) from the main theorem: divides |αq−p| < 1/Q by q and rearranges, using nlinarith to close the nonlinear inequality.",
+      "mathContext": "|α−p/q| = |αq−p|/q < (1/Q)/q = 1/(Qq). The cross-multiplication gives |αq−p|·Q·q < q, which follows from |αq−p|·Q < 1 (the main bound) and q > 0."
+    }
+  ],
+  "conclusion": {
+    "summary": "Proves Dirichlet's approximation theorem as a clean application of Minkowski's geometry of numbers. The geometric argument reduces the arithmetic problem (rational approximation) to a volume computation (area of a parallelogram). Three measure-theoretic axioms cover the volume computation, while all logical steps — central symmetry, the Minkowski application, integer extraction, and the q≠0 argument — are fully proved.",
+    "implications": "This connection between Dirichlet's theorem and Minkowski's theorem is one of the founding examples of the geometry of numbers as a mathematical discipline. The same method generalizes to simultaneous approximation (Kronecker's theorem, Dirichlet multi-dimensional) and to the study of best approximations (continued fractions, LLL algorithm).",
+    "openQuestions": [
+      "Can the three measure-theoretic axioms be eliminated using Mathlib's measure theory (Fubini's theorem, linear maps preserve measure)?",
+      "Can Hurwitz's theorem (|α − p/q| < 1/(√5 · q²) for infinitely many p/q) be proved using Minkowski?",
+      "Can simultaneous Dirichlet approximation (n real numbers α₁,...,αₙ approximated by rationals with common denominator ≤ Q) be proved from higher-dimensional Minkowski?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "minkowski-theorem",
+      "relationship": "applies-to",
+      "description": "Uses Minkowski's theorem (MinkowskiProved.minkowski_integer_lattice_proved) as the key ingredient: the parallelogram area > 4 = 2² triggers the theorem for n=2"
+    },
+    {
+      "targetId": "dirichlets-theorem",
+      "relationship": "related",
+      "description": "The elementary pigeonhole proof of Dirichlet's theorem (via fractional parts) is complementary to this geometric proof"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Proofs.MinkowskiFundamentalTheorem",
+      "Mathlib.Analysis.Convex.Basic",
+      "Mathlib.MeasureTheory.Measure.Lebesgue.Basic",
+      "Mathlib.MeasureTheory.Group.GeometryOfNumbers",
+      "Mathlib.Data.Real.Basic",
+      "Mathlib.Tactic"
+    ],
+    "namespace": "DirichletFromMinkowski",
+    "axiomCount": 3,
+    "sorries": 0,
+    "mainTheorems": [
+      {
+        "name": "dirichlet_approximation_from_minkowski",
+        "type": "proved",
+        "description": "Main theorem: for any α and Q > 0, there exist integers q, p with 1 ≤ q ≤ Q and |αq − p| < 1/Q",
+        "leanType": "(α : ℝ) → (Q : ℕ) → 0 < Q → ∃ q p : ℤ, 1 ≤ q ∧ q ≤ Q ∧ |α * q - p| < 1 / Q"
+      },
+      {
+        "name": "dirichletSet_symmetric",
+        "type": "proved",
+        "description": "The Dirichlet parallelogram is centrally symmetric (0 axioms)",
+        "leanType": "∀ v ∈ dirichletSet α Q, -v ∈ dirichletSet α Q"
+      },
+      {
+        "name": "stdLattice2_coords",
+        "type": "proved",
+        "description": "Points in stdLattice 2 have integer coordinates (0 axioms)",
+        "leanType": "(x : stdLattice 2) → ∃ a b : ℤ, x 0 = a ∧ x 1 = b"
+      },
+      {
+        "name": "dirichlet_from_minkowski",
+        "type": "export",
+        "description": "Top-level export of the main result",
+        "leanType": "(α : ℝ) → (Q : ℕ) → 0 < Q → ∃ q p : ℤ, 1 ≤ q ∧ q ≤ Q ∧ |α * q - p| < 1 / Q"
+      }
+    ]
+  },
+  "references": [
+    {
+      "authors": "Dirichlet, Peter Gustav Lejeune",
+      "title": "Verallgemeinerung eines Satzes aus der Lehre von den Kettenbrüchen",
+      "year": "1842",
+      "venue": "Bericht Königl. Preuß. Akad. Wiss., pp. 93–95",
+      "note": "Original statement and elementary proof via the pigeonhole principle applied to fractional parts"
+    },
+    {
+      "authors": "Minkowski, Hermann",
+      "title": "Geometrie der Zahlen",
+      "year": "1896",
+      "venue": "Leipzig: Teubner",
+      "note": "Minkowski's geometric proof of Dirichlet's theorem as an application of the lattice point theorem (§17)"
+    },
+    {
+      "authors": "Cassels, J. W. S.",
+      "title": "An Introduction to the Geometry of Numbers",
+      "year": "1959",
+      "venue": "Springer, Grundlehren der mathematischen Wissenschaften 99",
+      "note": "Chapter II: Minkowski's theorem and its applications including Dirichlet's theorem (Theorem II.1.1)"
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "dirichlet_from_minkowski",
+      "type": "core",
+      "description": "Dirichlet's approximation theorem: for any α ∈ ℝ and Q ∈ ℕ₊, there exist integers p, q with 1 ≤ q ≤ Q and |αq − p| < 1/Q",
+      "leanType": "(α : ℝ) → (Q : ℕ) → 0 < Q → ∃ q p : ℤ, 1 ≤ q ∧ q ≤ Q ∧ |α * q - p| < 1 / Q"
+    }
+  ]
+}

--- a/src/data/research/problems/minkowski-theorem-oq-02.json
+++ b/src/data/research/problems/minkowski-theorem-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "minkowski-theorem-oq-02",
   "title": "Dirichlet approximation theorem as corollary of Minkowski lattice point theorem",
   "phase": "NEW",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "fast",
   "problemStatement": {
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "COMPLETED",
     "since": "2026-03-30T21:13:16.758Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Proved via Minkowski lattice point theorem",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Merged - done",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,11 +29,37 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "COMPLETE: Proved Dirichlet approximation theorem via Minkowski geometry of numbers (3 axioms, 0 sorries). PR #8752.",
+    "builtItems": [
+      "DirichletFromMinkowski.dirichletSet: {v : |v 0| < Q+1 \u2227 |\u03b1*v 0 - v 1| < 1/Q} (Fin 2 \u2192 \u211d)",
+      "DirichletFromMinkowski.dirichletSet_symmetric: central symmetry proved (0 axioms)",
+      "DirichletFromMinkowski.dirichletSet_volume_gt_four: (2:ENNReal)^2 < vol(S) proved",
+      "DirichletFromMinkowski.stdLattice2_coords: integer coordinate extraction from \u2124\u00b2",
+      "DirichletFromMinkowski.dirichlet_approximation_from_minkowski: main theorem (3 axioms)",
+      "DirichletFromMinkowski.dirichlet_approximation_corollary: |\u03b1-p/q| < 1/(Q*q)",
+      "dirichlet_from_minkowski: top-level export",
+      "proofs/Proofs/MinkowskiTheoremOQ02.lean (3 axioms, 0 sorries)",
+      "src/data/proofs/minkowski-theorem-oq-02/ (meta.json, annotations.json, index.ts)",
+      "PR #8752"
+    ],
+    "insights": [
+      "Dirichlet parallelogram S={|x|<Q+1, |\u03b1x-y|<1/Q} has area 4(Q+1)/Q > 4 = 2\u00b2",
+      "Shear map T(x,y)=(x,\u03b1x-y) has det=-1, maps S to axis-aligned rectangle, preserves Lebesgue measure",
+      "Key parity argument: if first coordinate a=0, then |b|<1/Q<1 forces b=0 (integer), contradicting nonzero point",
+      "Sign normalization: replace (a,b) with (|a|, sign(a)*b) to get positive first coordinate q",
+      "MinkowskiProved.minkowski_integer_lattice_proved (from companion file) directly applicable with n=2",
+      "Integer extraction from stdLattice 2 via Submodule.mem_span_range_iff_exists_fun + zsmul_eq_smul_cast"
+    ],
+    "mathlibGaps": [
+      "dirichletSet_convex: convexity of halfplane intersection (axiomatized)",
+      "dirichletSet_measurable: open set measurability (axiomatized)",
+      "dirichletSet_volume: 4(Q+1)/Q via Fubini or shear map (axiomatized)"
+    ],
+    "nextSteps": [
+      "Eliminate axioms using Mathlib convexity (Convex.inter, convex_ball) and Fubini theorem",
+      "Prove simultaneous Dirichlet approximation in \u211d\u207f using n+1 dimensional Minkowski",
+      "Prove Hurwitz theorem (|\u03b1-p/q| < 1/(\u221a5\u00b7q\u00b2) for infinitely many p/q) via stronger Minkowski"
+    ]
   },
   "tags": [
     "seeker-selected",


### PR DESCRIPTION
## Summary

Proves **Dirichlet's Approximation Theorem** as a corollary of Minkowski's lattice point theorem (geometry of numbers approach).

**Theorem**: For any α ∈ ℝ and Q ∈ ℕ₊, there exist integers p, q with 1 ≤ q ≤ Q and |qα − p| < 1/Q.

**Proof method** (Minkowski 1896):
- Construct the Dirichlet parallelogram S = {(x,y) : |x| < Q+1, |αx−y| < 1/Q}
- Its area is 4(Q+1)/Q > 4 = 2² (shear map argument: T(x,y)=(x,αx−y) has det=−1)
- By Minkowski, S contains a nonzero integer point (a, b)
- Show a ≠ 0: if a=0 then |b|<1/Q<1 forcing b=0, contradicting nonzero
- Set q=|a|, so 1 ≤ q ≤ Q and |αq−p| < 1/Q ✓

## Files

- `proofs/Proofs/MinkowskiTheoremOQ02.lean` — Lean 4 proof (3 axioms, 0 sorries)
- `src/data/proofs/minkowski-theorem-oq-02/` — Gallery data (meta.json, annotations.json, index.ts)

## Technical Details

**Lean infrastructure used**:
- `MinkowskiProved.minkowski_integer_lattice_proved` (from companion file, 0 axioms)
- `Submodule.mem_span_range_iff_exists_fun` for integer coordinate extraction
- `Int.one_le_abs`, `omega` for integer arithmetic

**Axioms** (3 total):
1. `dirichletSet_convex`: S is convex (intersection of halfplanes)
2. `dirichletSet_measurable`: S is Lebesgue measurable (open set)
3. `dirichletSet_volume`: vol(S) = 4(Q+1)/Q (Fubini or shear map)

All logical steps are fully proved: central symmetry, integer extraction from ℤ², q≠0 argument, sign normalization, and the corollary |α−p/q| < 1/(Qq).

## Labels

- `research`