### PR TITLE
Fix: lineCount mismatches in 21 gallery proofs (batch 1)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-04-oq-01/meta.json
@@ -47,7 +47,7 @@
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 311,
+    "lineCount": 334,
     "assumptions": "No axioms. 3 sorries remain for deep theorems requiring Galois correspondence glue: both directions of Tower ↔ Galois equivalence and the ℚ(√2) concrete example. Proved: quadratic_tower_degree (finrank multiplicativity), exists_index_two_subgroup (Sylow), gal_x2_minus_2_is_two_group (imported).",
     "originalContributions": [
       "Proper inductive definition of QuadraticTower replacing the alias TowerCriterion = DegreeCriterion",
@@ -165,7 +165,7 @@
       "FiniteDimensional"
     ],
     "namespace": "AngleTrisectionOQ02OQ04OQ01",
-    "lineCount": 311,
+    "lineCount": 334,
     "axiomCount": 0,
     "theoremCount": 12,
     "substantiveTheoremCount": 8,

--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -56,7 +56,7 @@
     ],
     "dateAdded": "2026-02-24",
     "axiomCount": 0,
-    "lineCount": 1472,
+    "lineCount": 1934,
     "assumptions": "1 sorry: exists_arclength_reparam (arc-length reparametrization). The IBP formula fourierCoeffOn_deriv_periodic is now proved via import from AreaOfCircleOQ01OQ02OQ02.lean.",
     "mathlib_version": "4.26.0"
   },
@@ -267,7 +267,7 @@
       "Topology"
     ],
     "namespace": "IsoperimetricOQ",
-    "lineCount": 1472,
+    "lineCount": 1934,
     "axiomCount": 0,
     "theoremCount": 52,
     "definitionCount": 12,

--- a/src/data/proofs/area-of-circle-oq-03-oq-02-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02-oq-02/meta.json
@@ -56,7 +56,7 @@
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
     "assumptions": "Fully verified: 0 axioms, 0 sorries.",
-    "lineCount": 165,
+    "lineCount": 204,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -154,7 +154,7 @@
       "intervalIntegral"
     ],
     "namespace": "AreaOfCircleOQ03OQ02OQ02",
-    "lineCount": 165,
+    "lineCount": 204,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 2,

--- a/src/data/proofs/collatz-structured-oq-02-oq-01/meta.json
+++ b/src/data/proofs/collatz-structured-oq-02-oq-01/meta.json
@@ -19,7 +19,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 172,
+    "lineCount": 213,
     "assumptions": "1 axiom: eliahou_cycle_bound — Eliahou (1993) proved any non-trivial Collatz cycle has period > 17 billion (Discrete Math 118:45–56). Fully machine-verified results: j=1 uniqueness theorem, halving bounds j=5..8, minimum cycle lengths, case complexity lower bound.",
     "dateAdded": "2026-04-03",
     "mathlib_version": "4.26.0"
@@ -136,7 +136,7 @@
       "Proofs.CollatzCycles"
     ],
     "namespace": "CollatzCyclesOQ01",
-    "lineCount": 172,
+    "lineCount": 213,
     "axiomCount": 1,
     "theoremCount": 14
   }

--- a/src/data/proofs/erdos-1001-oq-02/meta.json
+++ b/src/data/proofs/erdos-1001-oq-02/meta.json
@@ -67,7 +67,7 @@
       "convergence_faster_than_sqrtN: rate is better than O(1/√N)",
       "three_distance_connection: connects rate to three-distance theorem"
     ],
-    "lineCount": 200,
+    "lineCount": 296,
     "theoremCount": 6,
     "defCount": 5
   },
@@ -157,7 +157,7 @@
       "Mathlib.NumberTheory.ArithmeticFunction"
     ],
     "namespace": "Erdos1001OQ02",
-    "lineCount": 200,
+    "lineCount": 296,
     "axiomCount": 3,
     "theoremCount": 6,
     "definitionCount": 5

--- a/src/data/proofs/erdos-1009/meta.json
+++ b/src/data/proofs/erdos-1009/meta.json
@@ -55,7 +55,7 @@
       "exceeds_turan_has_triangle: corollary of Turán's theorem"
     ],
     "axiomCount": 2,
-    "lineCount": 221,
+    "lineCount": 239,
     "assumptions": "2 axioms: boundFunction (opaque function), gyori_bound (C²-bound on f(c)). turan_extremal now proved from Mathlib's CliqueFree.card_edgeFinset_le. 5 former axioms converted to Prop defs."
   },
   "overview": {
@@ -232,7 +232,7 @@
       "SimpleGraph"
     ],
     "namespace": null,
-    "lineCount": 221,
+    "lineCount": 239,
     "axiomCount": 2,
     "theoremCount": 1,
     "definitionCount": 9

--- a/src/data/proofs/erdos-106-oq-02/meta.json
+++ b/src/data/proofs/erdos-106-oq-02/meta.json
@@ -26,7 +26,7 @@
     "erdosProblemStatus": "open",
     "axiomCount": 6,
     "assumptions": "6 axiom declarations: rotated_square_area (rotation preserves area), f_rot_bounded (Cauchy-Schwarz √n bound), f_rot_mono (monotone), g_ap_perfect_square (g(k²)=k), bku_theorem_ap (BKU 2024 result), f_rot_2 (Erdős f_rot(2)=1). ELIMINATED: g_ap_bounded (proved from f_rot_bounded + g_ap≤f_rot), f_rot_perfect_square (proved from g_ap_perfect_square + f_rot_bounded + g_ap≤f_rot). New: side_le_sqrt_two (contained squares have side≤√2), g_ap_le_f_rot (AP packings are general packings). 0 sorries.",
-    "lineCount": 455
+    "lineCount": 514
   },
   "overview": {
     "historicalContext": "**From Axis-Parallel to Rotated: The Last Barrier in Square Packing**\n\nThe 2024 breakthrough by Baek, Koizumi, and Ueoro completely resolved the axis-parallel case of Erdős's square packing conjecture, proving g(k²+1) = k. This leaves one fundamental question: can rotated squares do better?\n\nIn the axis-parallel formulation, all packed squares have sides parallel to the unit square. When rotation is allowed, the packing space is richer — a rotated square occupies a diamond-shaped region that could potentially fill space more efficiently.\n\nNo example is known where rotation helps. At perfect squares n = k², both f_rot(k²) = g(k²) = k, since the k×k grid (which is axis-parallel) is already optimal by Cauchy-Schwarz. The question is whether rotation helps at non-perfect-square values of n.",
@@ -175,7 +175,7 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 455,
+    "lineCount": 514,
     "axiomCount": 8,
     "theoremCount": 11,
     "substantiveTheoremCount": 8,

--- a/src/data/proofs/erdos-1155-oq-01-oq-07/meta.json
+++ b/src/data/proofs/erdos-1155-oq-01-oq-07/meta.json
@@ -49,7 +49,8 @@
         "description": "Closed interval neighborhood; used in limit characterization.",
         "module": "Mathlib.Topology.Order.Basic"
       }
-    ]
+    ],
+    "lineCount": 355
   },
   "theoremCount": 20,
   "defCount": 6,

--- a/src/data/proofs/erdos-335/meta.json
+++ b/src/data/proofs/erdos-335/meta.json
@@ -76,7 +76,7 @@
       "Sumset_singleton: PROVED — sumset of singletons is a singleton"
     ],
     "axiomCount": 3,
-    "lineCount": 300,
+    "lineCount": 319,
     "assumptions": "3 axioms: weyl_equidistribution, fractional_part_density_additive, erdos_335_conjecture (OPEN). See Lean source for complete statements."
   },
   "sections": [
@@ -187,7 +187,7 @@
       "Filter"
     ],
     "namespace": null,
-    "lineCount": 300,
+    "lineCount": 319,
     "axiomCount": 3,
     "theoremCount": 31,
     "definitionCount": 8

--- a/src/data/proofs/erdos-470/meta.json
+++ b/src/data/proofs/erdos-470/meta.json
@@ -64,7 +64,7 @@
       "erdos_470 summary theorem combining key results"
     ],
     "axiomCount": 3,
-    "lineCount": 568,
+    "lineCount": 630,
     "assumptions": "3 axioms: liddy_riedl_6_primes (odd weird has ≥6 prime divisors), melfi_conditional (prime gap hypothesis implies infinitely many primitive weirds), benkoski_erdos_density (weird numbers have positive density). All deep results; no routine axioms remain."
   },
   "overview": {
@@ -161,7 +161,7 @@
       "Set"
     ],
     "namespace": "Erdos470",
-    "lineCount": 568,
+    "lineCount": 630,
     "axiomCount": 3,
     "theoremCount": 35,
     "definitionCount": 14

--- a/src/data/proofs/erdos-761/meta.json
+++ b/src/data/proofs/erdos-761/meta.json
@@ -38,7 +38,7 @@
       }
     ],
     "axiomCount": 2,
-    "lineCount": 287,
+    "lineCount": 258,
     "assumptions": "2 axioms: erdos_761_question1 (OPEN), erdos_761_question2 (OPEN). Eliminated complete_dichrom (incorrect formula). Fixed IsAcyclicColoring definition from 'no monochromatic directed edge' to correct 'no monochromatic directed cycle' (Neumann-Lara 1982). Proved: isAcyclicColoring_of_no_mono_edge, dichrom_le_chrom, cochrom_le_chrom, bipartite_dichrom_le_two, odd_cycle_dichrom, dichrom_mono, acyclic_orientation_exists.",
     "mathlib_version": "4.26.0"
   },
@@ -124,7 +124,7 @@
       "SimpleGraph"
     ],
     "namespace": null,
-    "lineCount": 287,
+    "lineCount": 258,
     "axiomCount": 2,
     "theoremCount": 10,
     "definitionCount": 7

--- a/src/data/proofs/erdos-776/meta.json
+++ b/src/data/proofs/erdos-776/meta.json
@@ -54,7 +54,7 @@
       "Proved n_not_in_antichain_sizes: size n excluded from antichain distinct sizes"
     ],
     "axiomCount": 3,
-    "lineCount": 266,
+    "lineCount": 391,
     "assumptions": "4 axioms: erdos_trotter_r1 (known, Griggs 1983), erdos_trotter_upper (known), erdos_trotter_achievable (known), erdos_776_threshold (OPEN conjecture). sperner_theorem is proved via Mathlib.",
     "mathlib_version": "4.26.0"
   },
@@ -166,7 +166,7 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 266,
+    "lineCount": 391,
     "axiomCount": 4,
     "theoremCount": 10,
     "definitionCount": 6

--- a/src/data/proofs/erdos-783/meta.json
+++ b/src/data/proofs/erdos-783/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/783",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
-    "lineCount": 321,
+    "lineCount": 392,
     "assumptions": "2 axiom(s): erdos_783_conjecture (the open conjecture), primes_minimize_product (deep sieve-theoretic result). Formerly 4 axioms; maxPrimeCount and maxPrimeCount_spec now proved from Mathlib's prime reciprocal divergence (not_summable_one_div_on_primes via Nat.find).",
     "mathlib_version": "4.26.0"
   },
@@ -128,7 +128,7 @@
       "Nat"
     ],
     "namespace": "Erdos783",
-    "lineCount": 321,
+    "lineCount": 392,
     "axiomCount": 2,
     "theoremCount": 19,
     "definitionCount": 7

--- a/src/data/proofs/erdos-963/meta.json
+++ b/src/data/proofs/erdos-963/meta.json
@@ -21,7 +21,7 @@
         "erdosUrl": "https://erdosproblems.com/963",
         "erdosProblemStatus": "open",
         "axiomCount": 1,
-        "lineCount": 633,
+        "lineCount": 672,
         "assumptions": "1 axiom: trivial_upper_bound (known result, f(n) ≤ ⌊log₂ n⌋ + 1). greedy_lower_bound now fully proved via greedy_dissociated + Nat.log arithmetic. 0 sorries. Conjecture stated as def ErdosProblem963 (not an axiom).",
         "mathlib_version": "4.26.0"
     },

--- a/src/data/proofs/feuerbachs-theorem-oq-02/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-02/meta.json
@@ -29,7 +29,7 @@
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 3,
-    "lineCount": 586,
+    "lineCount": 665,
     "assumptions": "3 axioms: feuerbach_3d_fails_general (structural), edge_midpoints_on_sphere (deep geometric), face_centroids_on_sphere (deep geometric). 5 sorries for tangency theorems. Circumcenter defined via Cramer rule (previously axiomatized).",
     "originalContributions": [
       "Complete 3D coordinate geometry infrastructure for tetrahedra in Lean 4",
@@ -146,7 +146,7 @@
       "Real"
     ],
     "namespace": "FeuerbachsTheoremOQ02",
-    "lineCount": 586,
+    "lineCount": 665,
     "axiomCount": 5,
     "theoremCount": 10,
     "substantiveTheoremCount": 6,

--- a/src/data/proofs/fourier-series-oq-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-01/meta.json
@@ -71,7 +71,7 @@
       "fourierPartialSum_zero_fn: partial sums of zero"
     ],
     "axiomCount": 6,
-    "lineCount": 427,
+    "lineCount": 642,
     "assumptions": "6 axioms: carlesonConstant (existence of universal Carleson constant C > 0), carleson_hunt_maximal (the Carleson-Hunt maximal inequality ‖S*f‖ ≤ C·‖f‖), trigPoly_exact_convergence (trig polys converge exactly), IsTrigPoly.memℒp_two (trig polys are in L²), trigPoly_L2_approx (trig poly L² approximation), carlesonConstant_nonneg (C ≥ 0). 0 sorries (divergenceSet_measure_bound and carleson_ae_convergence proved in #8596, additional framework proved in #8611)."
   },
   "overview": {

--- a/src/data/proofs/herons-formula-oq-03/meta.json
+++ b/src/data/proofs/herons-formula-oq-03/meta.json
@@ -42,7 +42,7 @@
       "Examples: 3-4-5 (area 6) and 5-12-13 (area 30) right triangles"
     ],
     "dateAdded": "2026-04-03",
-    "lineCount": 215,
+    "lineCount": 300,
     "theoremCount": 14,
     "definitionCount": 4,
     "prerequisites": [
@@ -168,7 +168,7 @@
       "Real"
     ],
     "namespace": "KahanHeron",
-    "lineCount": 215,
+    "lineCount": 300,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 4

--- a/src/data/proofs/newton-inductive-step-oq-01/meta.json
+++ b/src/data/proofs/newton-inductive-step-oq-01/meta.json
@@ -45,7 +45,7 @@
       "Newton's inequality in mean form (ē_k² ≥ ē_{k-1}·ē_{k+1}) fully proved, derived from the binomial form"
     ],
     "axiomCount": 0,
-    "lineCount": 336,
+    "lineCount": 378,
     "assumptions": "0 axiom declarations. 1 sorry: newton_inequality_binomial (the general inductive Cauchy-Schwarz step). newton_inequality_means is now fully proved (derived from newton_inequality_binomial).",
     "prerequisites": [
       "Elementary symmetric polynomials",
@@ -174,7 +174,7 @@
       "List"
     ],
     "namespace": "NewtonInductiveStepOQ01",
-    "lineCount": 336,
+    "lineCount": 378,
     "axiomCount": 0,
     "theoremCount": 18,
     "definitionCount": 2

--- a/src/data/proofs/pascals-hexagon/meta.json
+++ b/src/data/proofs/pascals-hexagon/meta.json
@@ -54,7 +54,7 @@
       "instances": 0
     },
     "axiomCount": 1,
-    "lineCount": 581,
+    "lineCount": 712,
     "assumptions": "1 axiom (conic_implies_pascal_constraint). 0 sorries — all theorems proved.",
     "mathlib_version": "4.26.0"
   },
@@ -225,7 +225,7 @@
       "Matrix"
     ],
     "namespace": null,
-    "lineCount": 581,
+    "lineCount": 712,
     "axiomCount": 1,
     "theoremCount": 26,
     "definitionCount": 24

--- a/src/data/proofs/sum-of-kth-powers-oq-04/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-04/meta.json
@@ -40,7 +40,7 @@
       "powerSumRatio_tendsto statement: general asymptotic 1/(k+1)"
     ],
     "dateAdded": "2026-03-30",
-    "lineCount": 126,
+    "lineCount": 158,
     "theoremCount": 4,
     "definitionCount": 1,
     "prerequisites": [
@@ -133,7 +133,7 @@
       "Filter"
     ],
     "namespace": "SumOfKthPowersAsymptotic",
-    "lineCount": 126,
+    "lineCount": 158,
     "axiomCount": 1,
     "theoremCount": 4,
     "definitionCount": 1

--- a/src/data/proofs/yang-mills-2d-oq-02/meta.json
+++ b/src/data/proofs/yang-mills-2d-oq-02/meta.json
@@ -22,7 +22,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 1,
     "assumptions": "1 axiom: casimir_scaling_4d_approximate (the 4D approximate Casimir scaling conjecture). Parts I and II are fully proved: 2D exact scaling follows from Migdal formula; exact 4D scaling fails from string breaking.",
-    "lineCount": 210,
+    "lineCount": 244,
     "originalContributions": [
       "linearPotential: V(r) = σ·r definition",
       "migdalTension: σ_R = g²·C₂(R)/(2·dim R)",
@@ -59,7 +59,7 @@
   },
   "leanFile": {
     "namespace": "YangMills2DOQ02",
-    "lineCount": 210,
+    "lineCount": 244,
     "axiomCount": 1,
     "theoremCount": 9,
     "definitionCount": 5


### PR DESCRIPTION
## Fix

Corrects `lineCount` in `meta.json` for 21 gallery proofs where the recorded value did not match the actual Lean source file length.

## Evidence

All values verified by counting actual lines in the Lean source files:

| Proof | Before | After |
|-------|--------|-------|
| area-of-circle-oq-01-oq-03 | 1472 | 1934 |
| erdos-1155-oq-01-oq-07 | 0 | 355 |
| fourier-series-oq-01 | 427 | 642 |
| pascals-hexagon | 581 | 712 |
| erdos-776 | 266 | 391 |
| erdos-1001-oq-02 | 200 | 296 |
| herons-formula-oq-03 | 215 | 300 |
| feuerbachs-theorem-oq-02 | 586 | 665 |
| erdos-783 | 321 | 392 |
| erdos-470 | 568 | 630 |
| erdos-106-oq-02 | 455 | 514 |
| newton-inductive-step-oq-01 | 336 | 378 |
| collatz-structured-oq-02-oq-01 | 172 | 213 |
| area-of-circle-oq-03-oq-02-oq-02 | 165 | 204 |
| yang-mills-2d-oq-02 | 210 | 244 |
| sum-of-kth-powers-oq-04 | 126 | 158 |
| erdos-761 | 287 | 258 |
| angle-trisection-oq-02-oq-04-oq-01 | 311 | 334 |
| erdos-335 | 300 | 319 |
| erdos-1009 | 221 | 239 |
| erdos-963 | 633 | 672 (meta only; leanFile was already correct) |

**Validation**: `pnpm build` completed successfully.

---
Automated fix by lean-mechanic agent.