### PR TITLE
Enrich cantors-theorem-oq-01-oq-01: |P(R)|=aleph_2 Complete Characterization

### DIFF
--- a/src/data/proofs/cantors-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/cantors-theorem-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-proposition-definitions",
+    "proofId": "cantors-theorem-oq-01-oq-01",
+    "range": { "startLine": 38, "endLine": 54 },
+    "type": "definition",
+    "title": "The Proposition as a Lean Definition",
+    "content": "The proposition |𝒫(ℝ)| = ℵ₂ is captured as a Lean definition rather than a theorem — it is a mathematical statement whose truth value is independent of ZFC. The two definitions (powerSetRealIsAlephTwo and bethTwoIsAlephTwo) are immediately proved equivalent, demonstrating that the question can be phrased equivalently in terms of beth numbers. This is a good pattern for encoding independence results: define the proposition, prove equivalences, and then conditionally derive consequences.",
+    "mathContext": "$\\texttt{powerSetRealIsAlephTwo} : \\text{Prop} := \\#(\\text{Set } \\mathbb{R}) = \\aleph_2$. $\\texttt{bethTwoIsAlephTwo} : \\text{Prop} := \\beth_2 = \\aleph_2$. The proof of their equivalence uses $|\\mathcal{P}(\\mathbb{R})| = \\beth_2$ (unconditional), which comes from the parent file. The Lean universe annotation $\\text{Cardinal.}\\{0\\}$ pins everything to the first universe level, avoiding universe-polymorphism issues in cardinal comparisons.",
+    "significance": "key",
+    "relatedConcepts": ["beth hierarchy", "aleph hierarchy", "proposition encoding in Lean", "independence results"],
+    "prerequisites": ["Cardinal.beth definition", "Lean universe levels", "def vs theorem in Lean 4"]
+  },
+  {
+    "id": "ann-reformulations",
+    "proofId": "cantors-theorem-oq-01-oq-01",
+    "range": { "startLine": 60, "endLine": 72 },
+    "type": "theorem",
+    "title": "Reformulations: 2^𝔠 = ℵ₂ and 2^(2^ℵ₀) = ℵ₂",
+    "content": "The two reformulation theorems show that |𝒫(ℝ)| = ℵ₂ can be written as 2^𝔠 = ℵ₂ or 2^(2^ℵ₀) = ℵ₂. These are not trivial restatements — they make the exponential structure explicit, which is important for connecting to GCH (which is about 2^κ for cardinals κ) and to the beth function definition. The proof uses Cardinal.two_power_aleph0 to identify 2^ℵ₀ = 𝔠.",
+    "mathContext": "$|\\mathcal{P}(\\mathbb{R})| = 2^{|\\mathbb{R}|} = 2^{\\mathfrak{c}} = 2^{2^{\\aleph_0}}$. The GCH statement '$2^{\\aleph_n} = \\aleph_{n+1}$' applied at $\\aleph_1$: $2^{\\aleph_1} = \\aleph_2$. Combined with CH ($\\mathfrak{c} = \\aleph_1$): $2^{\\mathfrak{c}} = 2^{\\aleph_1} = \\aleph_2$. So $\\mathsf{GCH}_{\\mathfrak{c}}$ is literally '$2^{\\mathfrak{c}} = \\aleph_2$' and the reformulation makes this transparent.",
+    "significance": "supporting",
+    "relatedConcepts": ["cardinal exponentiation", "2^aleph_0 = continuum", "GCH formulation"],
+    "prerequisites": ["Cardinal.two_power_aleph0", "continuum = 2^aleph_0", "card_powerSet formula"]
+  },
+  {
+    "id": "ann-ch-extraction",
+    "proofId": "cantors-theorem-oq-01-oq-01",
+    "range": { "startLine": 79, "endLine": 99 },
+    "type": "theorem",
+    "title": "Extracting CH via Successor Cardinal Arithmetic",
+    "content": "The key technique: given |𝒫(ℝ)| = ℵ₂, first note that Cantor's theorem gives 𝔠 < |𝒫(ℝ)| = ℵ₂. Then ℵ₂ = succ(ℵ₁) (since aleph is order-preserving and 2 = succ(1)). Finally, x < succ(y) implies x ≤ y (Order.le_of_lt_succ). Combined with the unconditional ℵ₁ ≤ 𝔠, we get equality. This is the standard 'squeeze theorem' for cardinals, using the successor structure. The Lean proof must explicitly establish ℵ₂ = Order.succ(ℵ₁) since Mathlib represents cardinal succession via Order.succ.",
+    "mathContext": "Proof sketch: $\\mathfrak{c} < |\\mathcal{P}(\\mathbb{R})| = \\aleph_2 = \\text{succ}(\\aleph_1)$, so $\\mathfrak{c} \\leq \\aleph_1$ (Order.le\\_of\\_lt\\_succ). Unconditionally $\\aleph_1 \\leq \\mathfrak{c}$ (aleph\\_one\\_le\\_continuum). Thus $\\mathfrak{c} = \\aleph_1$. The identity $\\aleph_2 = \\text{succ}(\\aleph_1)$ requires: $2 = \\text{succ}(1)$ as ordinals (norm\\_num), then $\\aleph_{\\text{succ}(1)} = \\text{succ}(\\aleph_1)$ (Cardinal.aleph\\_succ).",
+    "significance": "key",
+    "relatedConcepts": ["Order.le_of_lt_succ", "Cardinal.aleph_succ", "aleph_one_le_continuum", "successor cardinals"],
+    "prerequisites": ["Cantor's theorem in Lean", "Order.succ for cardinals", "aleph_one_le_continuum"]
+  },
+  {
+    "id": "ann-main-iff",
+    "proofId": "cantors-theorem-oq-01-oq-01",
+    "range": { "startLine": 117, "endLine": 134 },
+    "type": "theorem",
+    "title": "Main Equivalence: The Complete Characterization",
+    "content": "The main theorem powerSetReal_iff_ch_and_gch is the cleanest statement of the result: |𝒫(ℝ)| = ℵ₂ iff CH ∧ GCH_at_continuum. The proof uses exact ⟨...⟩ for the forward direction (bundling the two separate implications) and the parent file's conditional theorem for the reverse direction. The not_powerSetReal_iff theorem immediately follows by push_neg — a one-line logical transformation that converts the iff negation into a disjunction of negations.",
+    "mathContext": "The Lean iff proof: $\\Rightarrow$: \\texttt{exact ⟨ch\\_of\\_powerSetReal h, gch\\_at\\_continuum\\_of\\_powerSetReal h⟩}. $\\Leftarrow$: \\texttt{exact CantorsTheoremOQ01.gch\\_and\\_ch\\_implies\\_powerSet\\_real\\_eq\\_aleph\\_two hgch hch}. The negation: $\\neg(A \\land B) \\iff \\neg A \\lor \\neg B$ by \\texttt{push\\_neg; rfl}. This gives the failure modes: CH fails ($\\mathfrak{c} > \\aleph_1$, which is consistent) or GCH at $\\mathfrak{c}$ fails ($2^{\\mathfrak{c}} \\neq \\aleph_2$, e.g., $2^{\\mathfrak{c}} = \\aleph_3$ under certain forcing models).",
+    "significance": "key",
+    "relatedConcepts": ["iff in Lean 4", "push_neg tactic", "conditional theorems", "failure modes"],
+    "prerequisites": ["CH and GCH_at_continuum definitions", "parent file's reverse direction theorem", "push_neg tactic"]
+  },
+  {
+    "id": "ann-summary",
+    "proofId": "cantors-theorem-oq-01-oq-01",
+    "range": { "startLine": 147, "endLine": 165 },
+    "type": "theorem",
+    "title": "Summary: Packaging All Results as a Single Theorem",
+    "content": "The summary theorem bundles three results into one anonymous constructor ⟨proof1, proof2, proof3⟩: the main equivalence, the unconditional lower bound, and the unconditional beth representation. This pattern — a summary theorem referencing all previous results — is useful for gallery proofs where readers want a single statement capturing the entire file's content. It also serves as an integration test: if any intermediate result is wrong, the summary fails to type-check.",
+    "mathContext": "The three components: (1) $|\\mathcal{P}(\\mathbb{R})| = \\aleph_2 \\iff \\mathsf{CH} \\land \\mathsf{GCH}_{\\mathfrak{c}}$; (2) $\\aleph_1 < |\\mathcal{P}(\\mathbb{R})|$ (ZFC-provable); (3) $|\\mathcal{P}(\\mathbb{R})| = \\beth_2$ (ZFC-provable). Together: the power set of $\\mathbb{R}$ is always $\\beth_2$, provably $> \\aleph_1$, and equals $\\aleph_2$ iff both CH and GCH at $\\mathfrak{c}$ hold. The gap $\\beth_2 > \\aleph_1$ can be made arbitrarily large by forcing: $\\beth_2$ can equal $\\aleph_3$, $\\aleph_{\\omega+1}$, etc.",
+    "significance": "supporting",
+    "relatedConcepts": ["anonymous constructor syntax", "integration testing via type-checking", "summary patterns in Lean 4"],
+    "prerequisites": ["And.intro / tuple syntax in Lean 4", "previous theorems in the file"]
+  }
+]

--- a/src/data/proofs/cantors-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-01-oq-01/meta.json
@@ -4,7 +4,7 @@
   "slug": "cantors-theorem-oq-01-oq-01",
   "description": "Shows |P(R)| = aleph_2 is equivalent to CH + GCH at the continuum level. Proves the implication in both directions and establishes unconditional bounds.",
   "meta": {
-    "author": "Cantor / G\u00f6del / Cohen / Easton",
+    "author": "Cantor / Gödel / Cohen / Easton",
     "status": "verified",
     "proofRepoPath": "Proofs/CantorsTheoremOQ01OQ01.lean",
     "tags": [
@@ -17,25 +17,113 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 171,
-    "assumptions": "0 axioms, 0 sorries. Core cardinal facts via Mathlib (Cardinal.cantor, mk_set, aleph_one_le_continuum) and parent file CantorsTheoremOQ01.lean (CH/GCH definitions, conditional results).",
+    "assumptions": "0 axioms, 0 sorries. Core cardinal facts via Mathlib (Cardinal.cantor, mk_set, aleph_one_le_continuum) and parent file CantorsTheoremOQ01.lean (CH/GCH definitions, conditional results). The main equivalence theorem has no hypotheses; CH and GCH appear as logical propositions in the iff statement rather than as axioms.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The question whether |P(R)| = aleph_2 packages two independent set-theoretic axioms (CH and GCH at the continuum level) into a single cardinality equation. G\u00f6del (1938) showed CH is consistent with ZFC; Cohen (1963) showed its negation is also consistent. Easton (1970) showed that for regular cardinals, the power function can take almost any value.",
-    "problemStatement": "Is |P(R)| = aleph_2? This is independent of ZFC: it holds iff both CH (continuum = aleph_1) and GCH at continuum (2^continuum = successor of continuum) hold simultaneously.",
-    "text": "Complete characterization of |P(R)| = aleph_2 as equivalent to CH + GCH at the continuum level.",
-    "proofStrategy": "Forward direction: if |P(R)| = aleph_2, then since continuum < aleph_2 = succ(aleph_1) (Cantor), we get continuum <= aleph_1, combined with aleph_1 <= continuum gives CH. GCH follows similarly. Reverse uses the parent file's conditional theorem.",
+    "historicalContext": "The question '|𝒫(ℝ)| = ℵ₂?' sits at the intersection of two celebrated independence results. Cantor (1878) introduced the Continuum Hypothesis (𝔠 = ℵ₁), conjectured it was true, and it became Hilbert's first problem in 1900. Gödel (1938) constructed the constructible universe L to show CH is consistent with ZFC — his 1940 monograph 'The Consistency of the Axiom of Choice and of the Generalized Continuum-Hypothesis' proved both at once. Cohen (1963) invented forcing to show ¬CH is also consistent, a breakthrough that won the Fields Medal. Easton (1970) extended Cohen's work to show the power function on regular cardinals can take almost any value subject to König's theorem constraints. The specific question |𝒫(ℝ)| = ℵ₂ asks for the precise value, packaging both CH and GCH at the continuum into one equation. This formalization proves the complete equivalence: |𝒫(ℝ)| = ℵ₂ holds iff both CH and GCH at 𝔠 hold simultaneously.",
+    "problemStatement": "Is $|\\mathcal{P}(\\mathbb{R})| = \\aleph_2$? The formalization proves: $|\\mathcal{P}(\\mathbb{R})| = \\aleph_2 \\iff \\mathsf{CH} \\land \\mathsf{GCH}_{\\mathfrak{c}}$, where $\\mathsf{CH}$ is the Continuum Hypothesis ($\\mathfrak{c} = \\aleph_1$) and $\\mathsf{GCH}_{\\mathfrak{c}}$ is GCH at the continuum ($2^{\\mathfrak{c}} = \\aleph_2$). Unconditionally in ZFC: $\\aleph_1 < |\\mathcal{P}(\\mathbb{R})|$ and $|\\mathcal{P}(\\mathbb{R})| = \\beth_2$.",
+    "text": "Complete characterization of |P(R)| = aleph_2 as equivalent to CH + GCH at the continuum level, with unconditional lower bound aleph_1 < |P(R)|.",
+    "proofStrategy": "1. Definitions: powerSetRealIsAlephTwo and bethTwoIsAlephTwo established as equivalent via the parent file's beth representation. 2. Reformulations: |𝒫(ℝ)| = ℵ₂ restated as 2^𝔠 = ℵ₂ and as 2^(2^ℵ₀) = ℵ₂. 3. Forward direction (CH): From |𝒫(ℝ)| = ℵ₂, Cantor's theorem gives 𝔠 < ℵ₂ = succ(ℵ₁), so 𝔠 ≤ ℵ₁ by Order.le_of_lt_succ; combined with unconditional ℵ₁ ≤ 𝔠 gives CH. 4. Forward direction (GCH): From 2^𝔠 = ℵ₂ and CH (𝔠 = ℵ₁), we get 2^𝔠 = ℵ₂ = succ(ℵ₁) = succ(𝔠). 5. Reverse direction via parent file's gch_and_ch_implies_powerSet_real_eq_aleph_two. 6. Summary theorem packages the equivalence, unconditional bound, and beth representation.",
     "keyInsights": [
-      "|P(R)| = aleph_2 implies CH (not just consistent with it)",
-      "The proposition packages exactly two independent axioms",
-      "The unconditional lower bound aleph_1 < |P(R)| holds in ZFC"
+      "The proposition |𝒫(ℝ)| = ℵ₂ packages exactly two independent axioms (CH and GCH at 𝔠) into a single cardinality equation — neither axiom alone suffices, and the equivalence proof reveals precisely which logical content is encoded.",
+      "Cantor's own theorem provides the key leverage in the forward direction: |𝒫(ℝ)| = ℵ₂ forces 𝔠 < ℵ₂ = succ(ℵ₁), and successor cardinal arithmetic then extracts CH directly from the cardinality equation.",
+      "The unconditional bound ℵ₁ < |𝒫(ℝ)| holds in pure ZFC: Cantor gives |ℝ| < |𝒫(ℝ)|, and ℵ₁ ≤ 𝔠 = |ℝ| is ZFC-provable. So the power set of ℝ is provably 'bigger than ℵ₁' without any additional axioms.",
+      "The beth representation #(Set ℝ) = ℶ₂ is unconditional: ℶ₀ = ℵ₀, ℶ₁ = 2^ℵ₀ = 𝔠, ℶ₂ = 2^𝔠 = |𝒫(ℝ)|. The question |𝒫(ℝ)| = ℵ₂ is precisely whether the beth and aleph hierarchies agree at index 2.",
+      "The file demonstrates a clean proof architecture: define the proposition, state multiple equivalent reformulations, prove the iff directions separately, characterize the negation, and bundle everything into a summary theorem — a reusable pattern for independence-type results."
     ],
     "prerequisites": [
-      "Cardinal arithmetic",
-      "Beth and aleph hierarchies",
-      "Successor cardinals"
+      "Cardinal arithmetic (aleph, beth, continuum hierarchies)",
+      "Successor cardinals and Order.succ in Lean/Mathlib",
+      "Cantor's theorem |X| < |𝒫(X)| (Cardinal.cantor)",
+      "The independence of CH from ZFC (Gödel, Cohen) — motivational context",
+      "Lean universe polymorphism (Cardinal.{0})"
     ]
   },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "The Proposition and Beth Equivalence",
+      "startLine": 38,
+      "endLine": 54,
+      "summary": "Defines powerSetRealIsAlephTwo and bethTwoIsAlephTwo, proves they are equivalent via the parent file's beth representation.",
+      "mathContext": "$|\\mathcal{P}(\\mathbb{R})| = \\aleph_2$ is equivalent to $\\beth_2 = \\aleph_2$. The beth hierarchy: $\\beth_0 = \\aleph_0$, $\\beth_1 = 2^{\\aleph_0} = \\mathfrak{c}$, $\\beth_2 = 2^{\\mathfrak{c}} = |\\mathcal{P}(\\mathbb{R})|$. The question reduces to whether beth and aleph hierarchies agree at index 2 — which is what Generalized Continuum Hypothesis-style assumptions control."
+    },
+    {
+      "id": "reformulations",
+      "title": "Equivalent Reformulations",
+      "startLine": 60,
+      "endLine": 72,
+      "summary": "Restates |𝒫(ℝ)| = ℵ₂ as 2^𝔠 = ℵ₂ and as 2^(2^ℵ₀) = ℵ₂.",
+      "mathContext": "The chain: $|\\mathcal{P}(\\mathbb{R})| = 2^{\\mathfrak{c}} = 2^{2^{\\aleph_0}}$. Each step is unconditional; only the comparison to $\\aleph_2$ requires axioms. Lean requires careful universe annotations (Cardinal.{0}) to prevent universe-level mismatches in the cardinal arithmetic."
+    },
+    {
+      "id": "forward-ch",
+      "title": "Forward Direction: Extracting CH and GCH from |𝒫(ℝ)| = ℵ₂",
+      "startLine": 79,
+      "endLine": 112,
+      "summary": "Proves |𝒫(ℝ)| = ℵ₂ implies CH. Key step: Cantor + successor cardinal arithmetic.",
+      "mathContext": "The argument: $|\\mathcal{P}(\\mathbb{R})| = \\aleph_2 \\Rightarrow \\mathfrak{c} < \\aleph_2 = \\aleph_1^+ \\Rightarrow \\mathfrak{c} \\leq \\aleph_1$ (by Order.le_of_lt_succ). Combined with $\\aleph_1 \\leq \\mathfrak{c}$ (unconditional), this gives $\\mathfrak{c} = \\aleph_1$, which is CH. The key Lean identity: $\\aleph_2 = \\text{Order.succ}(\\aleph_1)$, proved by $\\aleph_2 = \\aleph_{\\text{succ}(1)} = \\text{succ}(\\aleph_1)$."
+    },
+    {
+      "id": "equivalence",
+      "title": "Complete Equivalence Theorem",
+      "startLine": 117,
+      "endLine": 134,
+      "summary": "The main theorem: |𝒫(ℝ)| = ℵ₂ iff CH ∧ GCH_at_continuum. Also characterizes the negation.",
+      "mathContext": "The iff uses both directions: the forward direction just proved and the reverse direction from the parent file's conditional theorem. The negation uses push_neg to rewrite $\\neg(A \\land B)$ as $\\neg A \\lor \\neg B$ — a standard logical step that clarifies the failure modes: either CH fails (𝔠 > ℵ₁) or GCH at 𝔠 fails ($2^{\\mathfrak{c}} \\neq \\aleph_2$)."
+    },
+    {
+      "id": "unconditional",
+      "title": "Unconditional Bounds",
+      "startLine": 137,
+      "endLine": 157,
+      "summary": "ℵ₁ < |𝒫(ℝ)| unconditionally. Summary theorem combines all results.",
+      "mathContext": "The bound $\\aleph_1 < |\\mathcal{P}(\\mathbb{R})|$ is ZFC-provable without CH. The summary theorem bundles: (1) main iff; (2) unconditional lower bound; (3) unconditional beth representation $|\\mathcal{P}(\\mathbb{R})| = \\beth_2$. Together: the power set of ℝ is always $\\beth_2$, always $> \\aleph_1$, and equals $\\aleph_2$ iff CH + GCH hold."
+    }
+  ],
+  "conclusion": {
+    "summary": "|𝒫(ℝ)| = ℵ₂ is precisely equivalent to CH + GCH at the continuum. The proposition packages exactly two independent set-theoretic axioms, with the unconditional bound ℵ₁ < |𝒫(ℝ)| holding in pure ZFC.",
+    "openQuestions": [
+      "Can Lean formalize the *independence* of CH from ZFC — i.e., prove that neither CH nor ¬CH is derivable from ZFC? This requires reasoning about models of set theory inside Lean, which is possible in principle using ZFC-in-type-theory frameworks.",
+      "Easton's theorem characterizes which power functions are consistent with ZFC for regular cardinals. Can the full generality be formalized in Lean 4 using Mathlib's cardinal infrastructure?",
+      "Martin's Maximum (MM) implies |𝒫(ℝ)| = ℵ₂ (Foreman-Magidor-Shelah, 1988). Can this connection be formalized to give a 'positive' axiom (rather than CH + GCH) that implies the equation?",
+      "The Singular Cardinal Hypothesis (SCH) and Shelah's PCF theory extend cardinal arithmetic results beyond regularity. How do these interact with the beth/aleph comparison framework at singular cardinals?"
+    ],
+    "implications": "The formalization shows that set-theoretic independence questions can have precise logical analyses even without resolving the independence itself. The technique — using successor cardinal arithmetic to extract CH from a cardinality equation — is reusable for other such characterizations."
+  },
+  "crossReferences": [
+    {
+      "targetId": "cantors-theorem-oq-01",
+      "relationship": "extends",
+      "description": "Imports CH, GCH_at_continuum definitions and the conditional theorem from the parent formalization"
+    },
+    {
+      "targetId": "cantors-theorem",
+      "relationship": "parent-problem",
+      "description": "Based on Cantor's theorem |X| < |𝒫(X)| which provides the key inequality 𝔠 < |𝒫(ℝ)|"
+    }
+  ],
+  "references": [
+    {
+      "author": "Gödel, K.",
+      "title": "The Consistency of the Axiom of Choice and of the Generalized Continuum-Hypothesis with the Axioms of Set Theory",
+      "year": 1940,
+      "note": "Proved CH is consistent with ZFC using the constructible universe L"
+    },
+    {
+      "author": "Cohen, P.J.",
+      "title": "The Independence of the Continuum Hypothesis, I–II",
+      "year": 1963,
+      "note": "Invented forcing to show ¬CH is consistent with ZFC; Fields Medal 1966"
+    },
+    {
+      "author": "Easton, W.B.",
+      "title": "Powers of Regular Cardinals",
+      "year": 1970,
+      "note": "Showed the power function on regular cardinals can be almost any monotone function satisfying König's theorem"
+    }
+  ],
   "leanFile": {
     "imports": [
       "Proofs.CantorsTheoremOQ01",
@@ -54,18 +142,5 @@
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 2
-  },
-  "crossReferences": [
-    {
-      "targetId": "cantors-theorem-oq-01",
-      "relationship": "extends",
-      "description": "Extends the parent formalization with equivalence characterization"
-    },
-    {
-      "targetId": "cantors-theorem",
-      "relationship": "related",
-      "description": "Based on Cantor's theorem |X| < |P(X)|"
-    }
-  ],
-  "sections": []
+  }
 }


### PR DESCRIPTION
Enriches `cantors-theorem-oq-01-oq-01` with comprehensive annotations and metadata.

## Changes
- **meta.json**: Added historical context (Gödel 1938 constructible universe L, Cohen 1963 forcing + Fields Medal, Easton 1970), full problem statement with LaTeX iff statement CH∧GCH, 5-part proof strategy, 5 key insights (two-axiom packaging, Cantor leverage, unconditional ZFC bounds, beth representation, proof architecture), 5 annotated sections, 4 open questions, 3 references
- **annotations.json**: Created 5 annotations covering:
  - `ann-proposition-definitions`: Why the proposition is a `def` not a `theorem` — encoding independence results in Lean
  - `ann-reformulations`: Chain of equivalences: |𝒫(ℝ)| = 2^𝔠 = 2^(2^ℵ₀), universe annotation subtleties
  - `ann-ch-extraction`: Successor cardinal arithmetic technique: x < succ(y) ⟹ x ≤ y (Order.le_of_lt_succ)
  - `ann-main-iff`: Complete equivalence theorem assembly and push_neg for negation characterization
  - `ann-summary`: Summary theorem as integration test pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)