### PR TITLE
Fix: lineCount mismatches in 3 Yang-Mills gallery proofs

### DIFF
--- a/src/data/proofs/yang-mills-2d/meta.json
+++ b/src/data/proofs/yang-mills-2d/meta.json
@@ -20,7 +20,7 @@
     "sorries": 1,
     "axiomCount": 1,
     "assumptions": "1 explicit axiom (gaugeTransform from YangMills/Classical.lean) plus structure-encoded assumptions: TwoDPartitionFunction requires representation decomposition and Casimir values. MigdalFormula encodes the exact Wilson loop expectation. SU(2)/SU(3) Casimir values are computed from representation theory. The 2D theory is exactly solvable — all results follow from these structures.",
-    "lineCount": 28043,
+    "lineCount": 28053,
     "mathlibDependencies": [
       {
         "theorem": "Real.exp_pos",
@@ -173,7 +173,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 28043,
+    "lineCount": 28053,
     "structureCount": 365,
     "axiomCount": 1,
     "theoremCount": 1786,

--- a/src/data/proofs/yang-mills-lattice/meta.json
+++ b/src/data/proofs/yang-mills-lattice/meta.json
@@ -19,7 +19,7 @@
     "sorries": 1,
     "axiomCount": 1,
     "assumptions": "1 explicit axiom (gaugeTransform from YangMills/Classical.lean) plus structure-encoded assumptions: WilsonLatticeAction requires coupling beta > 0 and character function. LinkVariable, LatticeGaugeTransform, and Plaquette encode lattice geometry. Wilson loop structures assume gauge-invariant trace. All lattice proofs (gauge invariance, bounds) are fully verified given these structures.",
-    "lineCount": 28043,
+    "lineCount": 28053,
     "mathlibDependencies": [
       {
         "theorem": "Finset.sum_nonneg",
@@ -146,7 +146,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 28043,
+    "lineCount": 28053,
     "structureCount": 365,
     "axiomCount": 1,
     "theoremCount": 1786,

--- a/src/data/proofs/yang-mills-transfer-matrix/meta.json
+++ b/src/data/proofs/yang-mills-transfer-matrix/meta.json
@@ -20,7 +20,7 @@
     "sorries": 1,
     "axiomCount": 1,
     "assumptions": "1 explicit axiom (gaugeTransform from YangMills/Classical.lean) plus structure-encoded assumptions: TransferMatrix requires lambda_0 > lambda_1 > 0 (Perron-Frobenius eigenvalue ordering), and LatticeTransferMatrix requires positivity and strict gap. These encode the physical assumption that the transfer matrix has a spectral gap, which is proven for finite-volume lattice gauge theory.",
-    "lineCount": 28043,
+    "lineCount": 28053,
     "mathlibDependencies": [
       {
         "theorem": "Real.log_pos",
@@ -136,7 +136,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 28043,
+    "lineCount": 28053,
     "structureCount": 365,
     "axiomCount": 1,
     "theoremCount": 1786,


### PR DESCRIPTION
## Fix

Corrects `lineCount` in `meta.json` for 3 Yang-Mills gallery proofs that all reference `YangMills/Exploration.lean`. The file has 28053 lines but all three claimed 28043.

## Evidence

```bash
wc -l proofs/Proofs/YangMills/Exploration.lean
   28053 proofs/Proofs/YangMills/Exploration.lean
```

| Proof | Before | After |
|-------|--------|-------|
| yang-mills-transfer-matrix | 28043 | 28053 |
| yang-mills-lattice | 28043 | 28053 |
| yang-mills-2d | 28043 | 28053 |

---
Automated fix by lean-mechanic agent.