### PR TITLE
Enrich Decidable Factorial Compositeness (erdos-1059-oq-05)

### DIFF
--- a/src/data/proofs/erdos-1059-oq-05/annotations.json
+++ b/src/data/proofs/erdos-1059-oq-05/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-definition",
+    "proofId": "erdos-1059-oq-05",
+    "range": { "startLine": 28, "endLine": 30 },
+    "type": "definition",
+    "title": "AllFactorialSubtractionsComposite: Core Predicate",
+    "content": "The predicate `AllFactorialSubtractionsComposite n` asserts that for every k with k! < n, the number n − k! is composite (≥ 2 and not prime). This is the exact property Erdős 1059 asks about: do infinitely many primes p satisfy it? The definition is an unbounded universal quantifier (over all ℕ), making it a priori not decidable — the key contribution of this file is to make it decidable by bounding the quantifier.",
+    "mathContext": "$\\mathrm{AFSC}(n) \\iff \\forall k.\\, k! < n \\Rightarrow \\neg\\mathrm{Prime}(n - k!) \\wedge n - k! \\ge 2$",
+    "significance": "key",
+    "relatedConcepts": ["Erdős 1059", "factorial", "composite numbers", "unbounded quantifier"],
+    "prerequisites": ["Nat.factorial", "Nat.Prime", "Prop in Lean 4"]
+  },
+  {
+    "id": "ann-decidability",
+    "proofId": "erdos-1059-oq-05",
+    "range": { "startLine": 36, "endLine": 56 },
+    "type": "technique",
+    "title": "Decidability via Bounded Quantifier: k ≤ k! Bounds the Range",
+    "content": "The key lemma `factorial_lt_implies_lt` uses `Nat.self_le_factorial` (k ≤ k! for all k) to deduce k < n from k! < n. This bounds the universal quantifier to `Finset.range n`. The equivalence theorem `allFactorialSubtractionsComposite_iff_bounded` replaces the unbounded `∀ k : ℕ` with `∀ k ∈ Finset.range n`, and the `Decidable` instance is derived by `decidable_of_iff` since the bounded quantifier inherits decidability from `Finset.decidableBAll` and the decidability of `Nat.Prime`, `Nat.lt`, and arithmetic. This is a clean example of the Lean 4 pattern: show equivalence with a decidable form, then inherit decidability.",
+    "mathContext": "$k \\le k!$ for all $k$, so $k! < n \\Rightarrow k < n$; thus $\\mathrm{AFSC}(n) \\iff \\forall k < n.\\, k! < n \\Rightarrow \\ldots$, which is decidable over $\\mathrm{Finset.range}\\, n$",
+    "significance": "key",
+    "relatedConcepts": ["Nat.self_le_factorial", "decidable_of_iff", "Finset.decidableBAll", "Decidable typeclass"],
+    "prerequisites": ["Decidable typeclass in Lean 4", "Finset.range", "Nat.self_le_factorial"]
+  },
+  {
+    "id": "ann-witnesses",
+    "proofId": "erdos-1059-oq-05",
+    "range": { "startLine": 65, "endLine": 76 },
+    "type": "insight",
+    "title": "Witnesses 101 and 211: Uniform Verification by native_decide",
+    "content": "With the Decidable instance in place, `witness_101` and `witness_211` are each proved by a single `by native_decide` — no bespoke helper lemmas needed. The combined theorem `erdos_1059_witnesses` packages both witnesses as a single proposition: 101 and 211 are prime and satisfy AFSC. For comparison, the parent proof (Erdos1059Problem.lean) required a `factorial_lt_bound_101` helper and `interval_cases` over k = 0, ..., 4 for each prime. This file reduces that boilerplate by a factor of ~10 lines per prime verified.",
+    "mathContext": "101 and 211 are prime; $\\mathrm{AFSC}(101)$ and $\\mathrm{AFSC}(211)$ are verified computationally",
+    "significance": "key",
+    "relatedConcepts": ["native_decide", "Decidable instance application", "Erdős 1059 witnesses"],
+    "prerequisites": ["decAllFactorialSubtractionsComposite instance"]
+  },
+  {
+    "id": "ann-nonwitnesses",
+    "proofId": "erdos-1059-oq-05",
+    "range": { "startLine": 82, "endLine": 87 },
+    "type": "insight",
+    "title": "Non-Witnesses 89 and 223: Verified Failures",
+    "content": "The negation `¬AllFactorialSubtractionsComposite n` is also decidable, so non-witnesses are verified by `native_decide` too. For 89: 89 − 3! = 89 − 6 = 83, which is prime — a counterexample to AFSC(89). For 223: 223 − 4! = 223 − 24 = 199, which is prime — counterexample to AFSC(223). These non-witnesses demarcate the property precisely: not every prime satisfies it, and finding those that do (infinitely many?) is the open problem.",
+    "mathContext": "$89 - 3! = 83$ is prime (so $\\neg\\mathrm{AFSC}(89)$); $223 - 4! = 199$ is prime (so $\\neg\\mathrm{AFSC}(223)$)",
+    "significance": "supporting",
+    "relatedConcepts": ["non-witness", "counterexample", "decidable negation"],
+    "prerequisites": ["decAllFactorialSubtractionsComposite instance"]
+  }
+]

--- a/src/data/proofs/erdos-1059-oq-05/meta.json
+++ b/src/data/proofs/erdos-1059-oq-05/meta.json
@@ -44,6 +44,45 @@
             "Finset.range and bounded quantifier decidability"
         ]
     },
+    "sections": [
+        {
+            "id": "definition",
+            "title": "Core Definition",
+            "startLine": 24,
+            "endLine": 30,
+            "summary": "Defines `AllFactorialSubtractionsComposite n`: for every k with k! < n, n − k! is composite (≥ 2 and not prime). An unbounded universal quantifier, not yet decidable."
+        },
+        {
+            "id": "decidability",
+            "title": "Decidability Infrastructure",
+            "startLine": 32,
+            "endLine": 56,
+            "summary": "Proves k ≤ k! bounds the quantifier to Finset.range n, derives an iff with a decidable bounded form, and creates the Decidable instance via decidable_of_iff."
+        },
+        {
+            "id": "witnesses",
+            "title": "Witness Verification (101, 211)",
+            "startLine": 58,
+            "endLine": 76,
+            "summary": "Verifies AFSC(101) and AFSC(211) by native_decide, and packages both as `erdos_1059_witnesses`. Each is a prime satisfying the Erdős 1059 condition."
+        },
+        {
+            "id": "non-witnesses",
+            "title": "Non-Witness Verification (89, 223)",
+            "startLine": 78,
+            "endLine": 87,
+            "summary": "Verifies ¬AFSC(89) (since 89−3! = 83 is prime) and ¬AFSC(223) (since 223−4! = 199 is prime) by native_decide."
+        }
+    ],
+    "conclusion": {
+        "summary": "The Decidable instance `decAllFactorialSubtractionsComposite` eliminates all boilerplate from Erdős 1059 prime verification. Any concrete n can be tested by a single `native_decide`. Four examples are verified: witnesses 101 and 211, non-witnesses 89 and 223.",
+        "implications": "The pattern used here — bounding an unbounded quantifier via a monotone size argument (k ≤ k!), then deriving decidability — is a general proof engineering technique. It appears in proofs about Fibonacci, Catalan numbers, and any property quantifying over 'small enough' inputs. The infrastructure makes it straightforward to search computationally for additional witnesses to Erdős 1059, or to verify that a gap between witnesses has no new primes satisfying the property.",
+        "openQuestions": [
+            "The main Erdős 1059 problem: are there infinitely many primes p with AllFactorialSubtractionsComposite(p) true? No theoretical progress is known; computational search with this decidable instance extends verification to any specific range.",
+            "Can the decidable instance be used to prove a density result: among the first N primes, what fraction satisfy the property? Does this fraction stabilize or vary?",
+            "Are there analogous Decidable instances for related factorial-subtraction properties (e.g., n − k! is prime for all k with k! < n)?"
+        ]
+    },
     "leanFile": {
         "imports": [
             "Mathlib.Data.Nat.Prime.Basic",


### PR DESCRIPTION
Enrichment pass for `erdos-1059-oq-05`.

## Quality improvements

- **New `annotations.json`**: 4 annotations covering all proof sections (definition, decidability construction, witness verification, non-witnesses) with LaTeX mathContext, significance, relatedConcepts, prerequisites
- **New `sections` array**: 4 entries with substantive summaries
- **New `conclusion`**: summary of decidability result, implications (bounded-quantifier pattern, computational search), 3 open questions on infinitely-many primes, density, and analogous decidable instances