### PR TITLE
Fix: axiomCount 7→0 in 4 gallery proofs with stale assumptions

### DIFF
--- a/src/data/proofs/erdos-112/meta.json
+++ b/src/data/proofs/erdos-112/meta.json
@@ -16,9 +16,9 @@
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/112",
     "erdosUrl": "https://erdosproblems.com/112",
-    "axiomCount": 7,
+    "axiomCount": 0,
     "badge": "axiom",
-    "assumptions": "7 axioms: erdos_112_well_defined, ramsey_lower, hunter_upper, and 4 more. See Lean source for complete statements.",
+    "assumptions": "0 axioms, 0 sorries. Partial formalization of Directed Ramsey Theory: defines tournament structures and chromatic number concepts. The main open bounds (erdos_112_well_defined, ramsey_lower, hunter_upper) are referenced in comments but not formalized as Lean axioms.",
     "proofRepoPath": "Proofs/Erdos112Problem.lean",
     "mathlib_version": "4.26.0",
     "lineCount": 77
@@ -217,7 +217,7 @@
   "leanFile": {
     "lineCount": 77,
     "structureCount": 0,
-    "axiomCount": 7,
+    "axiomCount": 0,
     "theoremCount": 0,
     "lemmaCount": 0,
     "defCount": 3,

--- a/src/data/proofs/erdos-359/meta.json
+++ b/src/data/proofs/erdos-359/meta.json
@@ -52,9 +52,9 @@
       "Formalization of Andrews' asymptotic conjecture",
       "Formalization of Porubsky's density bounds"
     ],
-    "axiomCount": 7,
+    "axiomCount": 0,
     "lineCount": 207,
-    "assumptions": "7 axioms: macmahon_initial_values, growth_faster_than_linear, growth_slower_than_polynomial, and 4 more. See Lean source for complete statements."
+    "assumptions": "0 axioms, 0 sorries. Partial formalization of MacMahon's sequence problem: defines the sequence recursively and proves 6 basic structural properties. The main open conjectures about density and asymptotic growth (macmahon_initial_values, growth_faster_than_linear, etc.) are not formalized."
   },
   "overview": {
     "historicalContext": "Erdos Problem #359 concerns MacMahon's 'prime numbers of measurement' (OEIS A002048), a sequence defined by P.A. MacMahon in the early 20th century. The sequence starts with 1, and each subsequent term is the smallest positive integer that cannot be expressed as a sum of consecutive earlier terms.\n\nThe sequence begins: 1, 2, 4, 5, 8, 10, 14, 15, 21, 22, 26, 28, ...\n\nGeorge Andrews studied this sequence in 1975 and conjectured that a_k ~ (k log k) / (log log k). Stefan Porubsky proved partial results in 1977, establishing bounds comparing the sequence to the prime counting function.\n\nThe question of the exact growth rate remains OPEN. It is conjectured that a_k/k tends to infinity (superlinear growth) but a_k/k^{1+c} tends to 0 for any c > 0 (subpolynomial growth).",
@@ -146,7 +146,7 @@
     ],
     "namespace": "Erdos359",
     "lineCount": 207,
-    "axiomCount": 7,
+    "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 7
   },

--- a/src/data/proofs/erdos-507/meta.json
+++ b/src/data/proofs/erdos-507/meta.json
@@ -58,9 +58,9 @@
       "higher_dimensional_analog: d-dimensional trivial bounds (axiomatized)"
     ],
     "dateAdded": "2026-01-19",
-    "axiomCount": 7,
+    "axiomCount": 0,
     "lineCount": 83,
-    "assumptions": "7 axioms: lower_bound_trivial, upper_bound_trivial, kps_lower_bound, and 4 more. See Lean source for complete statements."
+    "assumptions": "0 axioms, 0 sorries. Partial formalization of Heilbronn's Triangle Problem: defines triangle geometry framework. The main bounds (lower_bound_trivial, kps_lower_bound, Heilbronn upper bound) are referenced in comments but not formalized as Lean axioms."
   },
   "overview": {
     "historicalContext": "Hans Heilbronn posed the triangle problem in the 1940s while at the University of Bristol: given $n$ points in a convex region, how small must the smallest triangle area be? Erdős quickly observed the lower bound $\\alpha(n) \\geq c/n^2$ via a greedy placement argument and conjectured that the true order should be closer to $1/n^2$ than to $1/n$. The problem attracted attention from some of the strongest combinatorialists of the 20th century. In 1981, Komlós, Pintz, and Szemerédi [KPS81] achieved the first breakthrough on the upper bound side, proving $\\alpha(n) \\leq C/n^{8/7}$ using Szemerédi's regularity lemma—one of the early geometric applications of this fundamental tool. The following year, the same trio [KPS82] improved the lower bound to $\\alpha(n) \\geq c(\\log n)/n^2$ using a sophisticated probabilistic argument involving the Lovász Local Lemma. Remarkably, both bounds stood essentially unchanged for over 40 years. In 2024, Cohen, Pohoata, and Zakharov [CPZ24] finally improved the upper bound to $\\alpha(n) \\leq C/n^{7/6+o(1)}$ using incidence geometry and the polynomial method of Guth and Katz. The gap between the lower bound exponent 2 and upper bound exponent 7/6 remains enormous, making this one of the most fundamental open problems in combinatorial geometry.",
@@ -175,7 +175,7 @@
     "opens": [],
     "namespace": null,
     "lineCount": 83,
-    "axiomCount": 7,
+    "axiomCount": 0,
     "theoremCount": 0,
     "definitionCount": 4
   },

--- a/src/data/proofs/erdos-975/meta.json
+++ b/src/data/proofs/erdos-975/meta.json
@@ -47,9 +47,9 @@
       "The famous n² + 1 asymptotic with constant 3/π",
       "Verified divisor counts: τ(1)=1, τ(2)=2, τ(6)=4, τ(12)=6, τ(p)=2 for prime p"
     ],
-    "axiomCount": 7,
+    "axiomCount": 0,
     "lineCount": 183,
-    "assumptions": "7 axioms: vanDerCorput_lower_bound, erdos_upper_bound, erdos_975, and 4 more. See Lean source for complete statements."
+    "assumptions": "0 axioms, 0 sorries. Partial formalization: defines divisor sum functions and polynomial value framework. The main open bounds (vanDerCorput_lower_bound, erdos_upper_bound, erdos_975) are referenced in comments but not formalized as Lean axioms."
   },
   "overview": {
     "historicalContext": "The divisor function τ(n) counts how many positive integers divide n. Erdős Problem #975 asks whether the sum Σ_{n≤x} τ(f(n)) for an irreducible polynomial f has a precise asymptotic formula of the form c·x·log(x) for some constant c > 0.\n\nVan der Corput (1939) established the lower bound, showing the sum grows at least as fast as x log x. Erdős (1952) proved the matching upper bound using elementary methods, establishing that the growth is Θ(x log x).\n\nChristopher Hooley (1963) resolved the problem for irreducible quadratic polynomials, showing that an asymptotic formula exists with an explicit (though complicated) constant. The general case for higher-degree polynomials remains open.",
@@ -150,7 +150,7 @@
     ],
     "namespace": "Erdos975",
     "lineCount": 183,
-    "axiomCount": 7,
+    "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 3
   },


### PR DESCRIPTION
## Fix

Corrects stale `axiomCount` fields in 4 gallery proofs. Each claimed `axiomCount: 7` but the current Lean source has 0 actual `axiom` declarations. The assumption names referenced in the metadata were from older versions of the files.

## Evidence

For each proof, `grep -c "^axiom " proofs/Proofs/Erdos*.lean` returns 0.

The assumption names listed (vanDerCorput_lower_bound, macmahon_initial_values, lower_bound_trivial, erdos_112_well_defined, etc.) do NOT appear as axiom declarations in the current Lean files — they were referenced from older versions.

| Proof | Before | After |
|-------|--------|-------|
| erdos-975 (Divisor Sums over Polynomial Values) | axiomCount=7 | axiomCount=0 |
| erdos-507 (Heilbronn's Triangle Problem) | axiomCount=7 | axiomCount=0 |
| erdos-359 (MacMahon's Prime Numbers of Measurement) | axiomCount=7 | axiomCount=0 |
| erdos-112 (Directed Ramsey Theory) | axiomCount=7 | axiomCount=0 |

Also updates `assumptions` field to accurately describe the current state: partial formalization with 0 axioms and 0 sorries.

---
Automated fix by lean-mechanic agent.