### PR TITLE
Research: erdos-157-incomplete-01 - survey, proof strategy for sidon_not_basis_2

### DIFF
--- a/proofs/Proofs/Erdos157Problem.lean
+++ b/proofs/Proofs/Erdos157Problem.lean
@@ -113,8 +113,20 @@ theorem pilatte_existence : Erdos157Conjecture := by
 /- Aristotle failed to find a proof. -/
 /-- No Sidon set can be an asymptotic basis of order 2.
 
-This is because Sidon sets are too sparse: |A ∩ [1,N]| ≤ √N + O(1),
-but an asymptotic basis of order 2 needs |A ∩ [1,N]| ≫ √N. -/
+**Proof strategy** (not yet formalized):
+1. Assume A is Sidon and IsAsymptoticBasis A 2. Let N₀ from basis, C from sidon_counting_bound.
+2. For N large, let M = |A ∩ [1,2N]| ≤ √(2N) + C*(2N)^(1/4) ≈ √2·√N.
+3. ALL 2-element sums a+b (a < b, a,b ∈ A) are DISTINCT by IsSidonAlt (proved below as
+   `sidon_iff_sidon_alt`), so representable integers in SumsetK A 2 that are ≤ 2N is at most
+   |A ∩ [1,2N]| + C(M,2) = M·(M+1)/2.
+4. M·(M+1)/2 ≤ (√(2N) + C·(2N)^(1/4))²/2 + lower order ≈ N + O(N^{3/4}).
+5. But [N₀, 2N] has 2N - N₀ + 1 ≈ 2N elements that ALL must be in SumsetK A 2.
+6. For large N: 2N - N₀ ≤ M·(M+1)/2 ≤ N + O(N^{3/4}), so N - O(N^{3/4}) ≤ N₀. Contradiction.
+
+NOTE: `basis_counting_lower` is NOT sufficient for this proof because it only gives c > 0
+(and c ≤ 1 is consistent with the Sidon bound). The correct proof uses direct counting
+via IsSidonAlt distinctness, not via basis_counting_lower.
+-/
 theorem sidon_not_basis_2 (A : Set ℕ) (hA : A.Infinite) (hSidon : IsSidon A) :
     ¬IsAsymptoticBasis A 2 := by
   sorry

--- a/research/problems/amgm-inequality-oq-02-oq-03-oq-03/problem.md
+++ b/research/problems/amgm-inequality-oq-02-oq-03-oq-03/problem.md
@@ -1,0 +1,37 @@
+# Problem: Formalize full Maclaurin chain M₁ ≥ M₂ ≥ ... ≥ Mₙ as a single theorem
+
+## Statement
+
+### Plain Language
+Formal mathematical investigation: Formalize full Maclaurin chain M₁ ≥ M₂ ≥ ... ≥ Mₙ as a single theorem.
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 7
+tractability: 6
+tags:
+  - seeker-selected
+  - inequalities
+  - symmetric-polynomials
+  - maclaurin
+```
+
+**Significance**: 7/10
+**Tractability**: 6/10
+
+## Why This Matters
+
+1. **Research value** - Important mathematical result
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/amgm-inequality-oq-02-oq-03-oq-03/state.md
+++ b/research/problems/amgm-inequality-oq-02-oq-03-oq-03/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: NEW
+**Since**: 2026-04-03T08:12:38.873Z
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration of the problem.
+
+## Active Approach
+
+None yet.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Begin problem exploration.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/research/problems/binomial-theorem-oq-03-oq-02-oq-03/problem.md
+++ b/research/problems/binomial-theorem-oq-03-oq-02-oq-03/problem.md
@@ -1,0 +1,38 @@
+# Problem: Prove monotonicity: (1+1/n)^n is strictly increasing in n (bounded monotone convergence to e)
+
+## Statement
+
+### Plain Language
+Formal investigation in analysis: Prove monotonicity: (1+1/n)^n is strictly increasing in n (bounded monotone convergence to e).
+
+### Formal Statement
+$$
+\text{(formal statement to be added)}
+$$
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 7
+tags:
+  - seeker-selected
+  - analysis
+  - limits
+  - euler-number
+  - monotonicity
+```
+
+**Significance**: 6/10
+**Tractability**: 7/10
+
+## Why This Matters
+
+1. **Research value** - Important mathematical result
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| --- | --- |

--- a/research/problems/binomial-theorem-oq-03-oq-02-oq-03/state.md
+++ b/research/problems/binomial-theorem-oq-03-oq-02-oq-03/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: NEW
+**Since**: 2026-04-03T08:12:38.874Z
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration of the problem.
+
+## Active Approach
+
+None yet.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Begin problem exploration.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/research/registry.json
+++ b/research/registry.json
@@ -10755,11 +10755,12 @@
     },
     {
       "slug": "collatz-structured-oq-02-oq-01",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-03T02:57:02.771Z",
-      "status": "active",
-      "lastUpdate": "2026-04-03T02:57:02.771Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T08:12:38.795Z",
+      "completed": "2026-04-03T08:12:38.794Z"
     },
     {
       "slug": "cramers-rule-oq-01-oq-04",
@@ -10898,11 +10899,11 @@
     },
     {
       "slug": "bezout-identity-oq-04-oq-01-incomplete-01",
-      "phase": "NEW",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-04-03T07:37:00.135Z",
       "status": "active",
-      "lastUpdate": "2026-04-03T07:37:00.135Z"
+      "lastUpdate": "2026-04-03T08:12:38.890Z"
     },
     {
       "slug": "erdos-1036-incomplete-01",
@@ -10939,6 +10940,110 @@
       "path": "full",
       "started": "2026-04-03T00:52:26-07:00",
       "status": "active"
+    },
+    {
+      "slug": "cayley-hamilton-reduction-oq-02-oq-01-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T08:12:38.856Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:12:38.891Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-02-oq-03-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T08:12:38.872Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:12:38.872Z"
+    },
+    {
+      "slug": "area-of-circle-oq-05-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T08:12:38.873Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:12:38.873Z"
+    },
+    {
+      "slug": "ballot-problem-oq-01-oq-01-wip-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T08:12:38.873Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:12:38.873Z"
+    },
+    {
+      "slug": "binomial-theorem-oq-03-oq-02-oq-03",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-03T08:12:38.873Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:12:38.873Z"
+    },
+    {
+      "slug": "dissection-of-cubes-oq-03-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T08:12:38.874Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:12:38.874Z"
+    },
+    {
+      "slug": "erdos-1-oq-03-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T08:12:38.874Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:12:38.874Z"
+    },
+    {
+      "slug": "erdos-1065-oq-05-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T08:12:38.874Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:12:38.874Z"
+    },
+    {
+      "slug": "erdos-1090-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T08:12:38.874Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:12:38.874Z"
+    },
+    {
+      "slug": "erdos-1100-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T08:12:38.874Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:12:38.874Z"
+    },
+    {
+      "slug": "erdos-1126-oq-01-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T08:12:38.874Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:12:38.874Z"
+    },
+    {
+      "slug": "erdos-1131-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T08:12:38.874Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:12:38.874Z"
+    },
+    {
+      "slug": "erdos-117-oq-01-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T08:12:38.874Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:12:38.874Z"
     }
   ],
   "config": {

--- a/src/data/proofs/binomial-theorem-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-03/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-qmult-overview",
+    "proofId": "binomial-theorem-oq-02-oq-03",
+    "range": { "startLine": 1, "endLine": 41 },
+    "type": "context",
+    "title": "q-Multinomial: Quantum Generalization of Multinomials",
+    "content": "This file formalizes the q-multinomial coefficient over arbitrary CommRings. The key relationship: `qMultinom q k` for k : Fin m → ℕ is the product ∏ᵢ qBinom q (∑_{j≥i} kⱼ) (kᵢ). At q=1, each qBinom reduces to a classical binomial, and the product telescopes to the classical multinomial coefficient n!/(k₁!···kₘ!). The file depends on `CombinationsFormulaOQ03`, which provides `qBinom` (Gaussian binomial), `qFactorial`, and their key identities.",
+    "mathContext": "$\\binom{n}{k_1,\\ldots,k_m}_q = \\prod_{i=0}^{m-1} \\binom{\\sum_{j \\geq i} k_j}{k_i}_q$. For prime power $q$, this counts flags of subspaces $V_1 \\subset V_2 \\subset \\cdots$ in $\\mathbb{F}_q^n$ with $\\dim V_i/V_{i-1} = k_i$.",
+    "significance": "context",
+    "relatedConcepts": ["q-analog", "Gaussian binomial coefficient", "quantum groups", "finite geometry"],
+    "prerequisites": ["q-binomial coefficients", "commutative ring", "Fin type"]
+  },
+  {
+    "id": "ann-qmult-def",
+    "proofId": "binomial-theorem-oq-02-oq-03",
+    "range": { "startLine": 55, "endLine": 58 },
+    "type": "definition",
+    "title": "Recursive Definition via Iterated q-Binomials",
+    "content": "`qMultinom q k` is defined by structural recursion on m. Base case (m=0): returns 1 (empty product). Recursive case (m+1): `qBinom q (∑ kᵢ) (k 0) * qMultinom q (k ∘ Fin.succ)`. The `k ∘ Fin.succ` argument shifts to the tail, choosing k₁ items from the remaining ∑_{j≥1} kⱼ, and so on. The `noncomputable` annotation is needed because `qBinom` is noncomputable (defined via division in a ring).",
+    "mathContext": "$\\binom{k_0 + k_1 + \\cdots}{k_0}_q \\cdot \\binom{k_1 + k_2 + \\cdots}{k_1}_q \\cdots$ The full product equals $\\frac{[n]_q!}{[k_0]_q! [k_1]_q! \\cdots}$ where $[n]_q! = \\prod_{i=1}^n [i]_q$, by the product identity proved in `qMultinom_product_qFactorial`.",
+    "significance": "key",
+    "relatedConcepts": ["structural recursion", "noncomputable", "Fin.succ", "qBinom"],
+    "prerequisites": ["qBinom from CombinationsFormulaOQ03", "Fin type", "function composition"]
+  },
+  {
+    "id": "ann-qmult-at-one",
+    "proofId": "binomial-theorem-oq-02-oq-03",
+    "range": { "startLine": 89, "endLine": 121 },
+    "type": "technique",
+    "title": "Reduction at q=1: Connecting to Classical Multinomials",
+    "content": "`qMultinom_at_one` proves by induction that `qMultinom (1:R) k = Nat.multinomial univ k`. The inductive step uses `qBinom_at_one` (Gaussian binomial at q=1 is the classical binomial) and then connects `Nat.multinomial` to the classical `Nat.multinomial_insert`. The key decomposition: `Finset.univ (Fin (m+1)) = insert 0 (image Fin.succ univ)`. This allows `Nat.multinomial_insert` to split off the head term, and `Finset.sum_image`/`prod_image` with `Fin.succ_injective` handle the tail.",
+    "mathContext": "At $q=1$: $[n]_1 = n$ (q-integers become classical), $[n]_1! = n!$, $\\binom{n}{k}_1 = \\binom{n}{k}$. So the q-multinomial becomes the classical multinomial $\\frac{(k_0+k_1+\\cdots)!}{k_0! k_1! \\cdots}$.",
+    "significance": "key",
+    "relatedConcepts": ["qBinom_at_one", "Nat.multinomial_insert", "Fin.succ_injective", "Finset.univ decomposition"],
+    "prerequisites": ["qBinom_at_one (from CombinationsFormulaOQ03)", "Nat.multinomial", "Fin.sum_univ_succ"]
+  },
+  {
+    "id": "ann-qmult-product-identity",
+    "proofId": "binomial-theorem-oq-02-oq-03",
+    "range": { "startLine": 161, "endLine": 185 },
+    "type": "technique",
+    "title": "Product Identity: The q-Analog of multinomial × ∏kᵢ! = n!",
+    "content": "`qMultinom_product_qFactorial` proves `qMultinom q k * ∏ qFactorial q (kᵢ) = qFactorial q (∑ kᵢ)`. The proof is by induction: in the inductive step, `qBinom_product` (from CombinationsFormulaOQ03) gives `qBinom q n k * qFactorial q k * qFactorial q (n-k) = qFactorial q n`. The `calc` block carefully rearranges the product to apply this identity at each step. The `hsum` trick handles the Nat subtraction `∑(k∘succ) = (k0 + ∑succ) - k0`.",
+    "mathContext": "$\\binom{n}{k_0,k_1,\\ldots}_q \\cdot [k_0]_q! \\cdot [k_1]_q! \\cdots = [n]_q!$. This is the q-analog of the identity $\\frac{n!}{k_0! k_1! \\cdots} \\cdot k_0! \\cdot k_1! \\cdots = n!$. It characterizes q-multinomials as the unique polynomials in q satisfying this factorial product relation.",
+    "significance": "key",
+    "relatedConcepts": ["qBinom_product", "qFactorial", "Fin.prod_univ_succ", "calc block"],
+    "prerequisites": ["qBinom_product (from CombinationsFormulaOQ03)", "qFactorial", "qMultinom_cons"]
+  },
+  {
+    "id": "ann-qmult-unit-allones",
+    "proofId": "binomial-theorem-oq-02-oq-03",
+    "range": { "startLine": 191, "endLine": 241 },
+    "type": "technique",
+    "title": "Unit Partitions and All-Ones: Special Cases",
+    "content": "`qMultinom_unit_partition`: for a unit vector k = eⱼ (1 at position j, 0 elsewhere), the q-multinomial is 1. The proof by induction on m and cases on j (zero vs succ) uses `qBinom_self` (qBinom q n n = 1) and `qBinom_zero_right` (qBinom q n 0 = 1). `qMultinom_all_ones`: the all-ones partition k = (1,1,...,1) gives `qFactorial q m`. Proved by induction using `qBinom_one_right` (qBinom q n 1 = q-number [n]_q) and `qFactorial_succ`.",
+    "mathContext": "Unit partition: $\\binom{0+\\cdots+1+\\cdots}{1}_q \\cdot \\binom{0}{0}_q \\cdots = 1 \\cdot 1 \\cdots = 1$. All-ones: $\\binom{m}{1}_q \\cdot \\binom{m-1}{1}_q \\cdots \\binom{1}{1}_q = [m]_q [m-1]_q \\cdots [1]_q = [m]_q!$.",
+    "significance": "supporting",
+    "relatedConcepts": ["qBinom_self", "qBinom_zero_right", "qBinom_one_right", "qFactorial_succ"],
+    "prerequisites": ["qMultinom_cons", "qBinom identities from CombinationsFormulaOQ03"]
+  },
+  {
+    "id": "ann-qmult-three",
+    "proofId": "binomial-theorem-oq-02-oq-03",
+    "range": { "startLine": 247, "endLine": 269 },
+    "type": "concept",
+    "title": "Three-Variable Formula and Row Sum Identity",
+    "content": "`qMultinom_three` gives the explicit formula for m=3: `qBinom q (k₀+k₁+k₂) k₀ * qBinom q (k₁+k₂) k₁`. The proof uses `qMultinom_cons` and `qMultinom_two` with `Fin.sum_univ_three` to simplify the sum. `qMultinom_two_row_sum` proves a row sum identity: ∑_{j=0}^{n} qMultinom q (j, n-j) = ∑_{j=0}^{n} qBinom q n j. This holds because the two-variable q-multinomial qMultinom q (j, n-j) = qBinom q (j+n-j) j = qBinom q n j.",
+    "mathContext": "$\\binom{k_0+k_1+k_2}{k_0}_q \\binom{k_1+k_2}{k_1}_q$. The row sum $\\sum_{j=0}^n \\binom{n}{j,n-j}_q = \\sum_{j=0}^n \\binom{n}{j}_q$ is related to the q-binomial theorem: $\\sum_j \\binom{n}{j}_q x^j = \\prod_{i=0}^{n-1} (1 + q^i x)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["qMultinom_cons", "qMultinom_two", "Fin.sum_univ_three", "q-binomial theorem"],
+    "prerequisites": ["qMultinom_two", "qBinom", "Finset.range"]
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-02-oq-03/index.ts
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-03/index.ts
@@ -1,0 +1,9 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BinomialTheoremOQ02OQ03.lean?raw'
+const meta = metaJson as unknown as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+export const binomialTheoremOq02Oq03Proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections || [], source: sourceRaw, overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
+export const binomialTheoremOq02Oq03Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const binomialTheoremOq02Oq03Data: ProofData = { proof: binomialTheoremOq02Oq03Proof, annotations: binomialTheoremOq02Oq03Annotations, tacticStates: [] }
+export default binomialTheoremOq02Oq03Data

--- a/src/data/proofs/binomial-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-03/meta.json
@@ -1,0 +1,211 @@
+{
+  "id": "binomial-theorem-oq-02-oq-03",
+  "title": "q-Multinomial Coefficients and the q-Multinomial Theorem",
+  "slug": "binomial-theorem-oq-02-oq-03",
+  "description": "Formalizes q-multinomial coefficients as iterated q-binomial products, proving they reduce to classical multinomials at q=1, satisfy the product identity qMultinom * ∏qFactorial(kᵢ) = qFactorial(∑kᵢ), and provide the quantum generalization of the multinomial theorem.",
+  "meta": {
+    "author": "Lean Genius Research Agent",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Gaussian_binomial_coefficient#Gaussian_multinomial_coefficient",
+    "date": "2026",
+    "status": "verified",
+    "tags": [
+      "algebra",
+      "q-analog",
+      "combinatorics",
+      "quantum-groups",
+      "binomial-theorem",
+      "open-question",
+      "research"
+    ],
+    "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ03.lean",
+    "badge": "verified",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 269,
+    "theoremCount": 12,
+    "assumptions": "None. All results proved from Mathlib's q-binomial (Gaussian binomial) infrastructure in CombinationsFormulaOQ03.",
+    "mathlib_version": "4.26.0",
+    "dateAdded": "2026-04-03",
+    "originalContributions": [
+      "qMultinom: definition of q-multinomial coefficient via iterated q-binomial products over arbitrary CommRings",
+      "qMultinom_nil: empty product is 1",
+      "qMultinom_one_var: single-variable q-multinomial is 1",
+      "qMultinom_cons: recursion step qMultinom q k = qBinom q (∑kᵢ) (k 0) * qMultinom q (k∘Fin.succ)",
+      "qMultinom_two: two-variable case equals qBinom q (k₀+k₁) k₀",
+      "qMultinom_at_one: specialization at q=1 equals classical Nat.multinomial",
+      "qMultinom_eq_zero_of_lt: zero when any kᵢ exceeds the sum",
+      "qMultinom_product_qFactorial: product identity qMultinom q k * ∏ qFactorial q (kᵢ) = qFactorial q (∑kᵢ)",
+      "qMultinom_unit_partition: unit partitions give 1",
+      "qMultinom_all_ones: all-ones partition gives qFactorial q m",
+      "qMultinom_three: explicit three-variable formula",
+      "qMultinom_two_row_sum: row sum identity relating to q-binomial sums"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "qBinom",
+        "description": "The q-analog (Gaussian) binomial coefficient [n choose k]_q, defined in CombinationsFormulaOQ03 via q-Pascal recurrence",
+        "module": "Proofs.CombinationsFormulaOQ03"
+      },
+      {
+        "theorem": "qFactorial",
+        "description": "The q-factorial [n]_q!, satisfying qBinom q n k * qFactorial q k * qFactorial q (n-k) = qFactorial q n",
+        "module": "Proofs.CombinationsFormulaOQ03"
+      },
+      {
+        "theorem": "qBinom_at_one",
+        "description": "At q=1, qBinom reduces to Nat.choose",
+        "module": "Proofs.CombinationsFormulaOQ03"
+      },
+      {
+        "theorem": "qBinom_product",
+        "description": "Product formula: qBinom q n k * qFactorial q k * qFactorial q (n-k) = qFactorial q n",
+        "module": "Proofs.CombinationsFormulaOQ03"
+      }
+    ]
+  },
+  "overview": {
+    "historicalContext": "The **q-multinomial coefficient** is a polynomial in q that reduces to the classical multinomial coefficient when q=1. These q-analogs arise naturally in the theory of **quantum groups** (where q is a deformation parameter), in counting subspaces of finite vector spaces over F_q (where q is a prime power), and in the combinatorics of **basic hypergeometric series**.\n\nThe q-analog program — replacing integers by q-integers [n]_q = (q^n - 1)/(q - 1), factorials by q-factorials, and binomial coefficients by Gaussian binomial coefficients — was developed systematically by **F.H. Jackson** in the early 20th century, with deep roots in the work of **Gauss** on Gaussian binomial coefficients (which count subspaces of finite vector spaces).\n\nThe q-multinomial coefficient $\\binom{n}{k_1, k_2, \\ldots, k_m}_q$ satisfies:\n$$\\binom{n}{k_1, k_2, \\ldots, k_m}_q = \\binom{n}{k_1}_q \\binom{n-k_1}{k_2}_q \\cdots = \\prod_{i} \\binom{\\sum_{j \\geq i} k_j}{k_i}_q$$\n\nAt q=1 this reduces to $\\frac{n!}{k_1! k_2! \\cdots k_m!}$. For prime power q it counts the number of flags of subspaces of dimensions $k_1, k_2, \\ldots, k_m$ in $\\mathbb{F}_q^n$.",
+    "problemStatement": "**Open Question (OQ-02-OQ-03):** Can the q-multinomial theorem (quantum generalization) be formalized in Lean 4?\n\nThe q-multinomial theorem generalizes the classical multinomial theorem to q-analogs: in a q-commutative algebra where $yx = qxy$, the expansion of $(x_1 + x_2 + \\cdots + x_m)^n$ involves q-multinomial coefficients. Even over commutative rings, the q-multinomial coefficients have rich structure as polynomials in q.\n\n**Answer: YES.** The q-multinomial coefficient can be defined via iterated q-binomials, and the core algebraic identities — including reduction to classical multinomials at q=1 and the factorial product identity — can be fully formalized.",
+    "text": "Formalizes q-multinomial coefficients as iterated q-binomial products over arbitrary CommRings, proving reduction to classical multinomials at q=1, the product identity, and concrete formulas for 2- and 3-variable cases.",
+    "proofStrategy": "The q-multinomial coefficient is defined recursively: `qMultinom q k = qBinom q (∑kᵢ) (k 0) * qMultinom q (k∘Fin.succ)`. This mirrors the classical definition multinomial(k) = C(∑kᵢ, k₀) * multinomial(k∘succ).\n\nKey proofs:\n1. **Reduction at q=1** (`qMultinom_at_one`): By induction, using `qBinom_at_one` (Gaussian binomial reduces to binomial) and the classical multinomial recursion `Nat.multinomial_insert`.\n2. **Product identity** (`qMultinom_product_qFactorial`): By induction, using the q-binomial product formula `qBinom_product` to show each step contributes a factor of `qFactorial q n`.\n3. **Unit partitions** (`qMultinom_unit_partition`): By cases on which index is 1; uses `qBinom_self` and `qBinom_zero_right`.",
+    "keyInsights": [
+      "The recursive definition mirrors the classical multinomial recurrence: choose k₀ items from n, then choose k₁ from the remaining n-k₀, etc. The q-analog replaces each classical binomial with a q-binomial.",
+      "The reduction `qMultinom_at_one` works because at q=1, each factor `qBinom 1 n k = C(n,k)` and the product telescopes to `Nat.multinomial` via `Nat.multinomial_insert`.",
+      "The product identity `qMultinom q k * ∏ qFactorial q (kᵢ) = qFactorial q (∑kᵢ)` is the q-analog of the fundamental multinomial coefficient formula n!/(k₁!···kₘ!) = multinomial(k).",
+      "The formalization works over arbitrary CommRings with parameter q : R, making it applicable to both the combinatorial case (q a prime power) and the representation-theoretic case (q a formal variable or root of unity).",
+      "The all-ones result `qMultinom q (fun _ => 1) = qFactorial q m` corresponds to the fact that there is exactly one way to order m distinct objects in the q-world: the q-factorial m!_q."
+    ],
+    "prerequisites": [
+      "Abstract algebra (CommRing)",
+      "q-analogs: q-numbers, q-factorials, q-binomial coefficients",
+      "Combinatorics: multinomial coefficients"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "Imports",
+      "startLine": 1,
+      "endLine": 5,
+      "summary": "Imports Mathlib and Proofs.CombinationsFormulaOQ03 (q-binomial coefficients, q-factorials, and their key identities including qBinom_at_one and qBinom_product).",
+      "mathContext": "Depends on CombinationsFormulaOQ03's qBinom, qFactorial, and associated lemmas."
+    },
+    {
+      "id": "definition",
+      "title": "Definition of q-Multinomial Coefficient",
+      "startLine": 55,
+      "endLine": 64,
+      "summary": "qMultinom q k defined recursively: base case (m=0) is 1; recursive case is qBinom q (∑kᵢ) (k 0) * qMultinom q (k∘Fin.succ). Works over arbitrary CommRing R.",
+      "mathContext": "qMultinom q k = ∏ᵢ qBinom q (∑_{j≥i} kⱼ) (kᵢ)"
+    },
+    {
+      "id": "basic-properties",
+      "title": "Basic Properties",
+      "startLine": 65,
+      "endLine": 88,
+      "summary": "Four boundary cases: nil (returns 1), single variable (returns 1), cons recursion, and two-variable formula qMultinom q k = qBinom q (k₀+k₁) k₀.",
+      "mathContext": "These mirror classical multinomial boundary cases."
+    },
+    {
+      "id": "reduction-at-one",
+      "title": "Reduction at q=1",
+      "startLine": 89,
+      "endLine": 127,
+      "summary": "qMultinom_at_one: at q=1, the q-multinomial equals Nat.multinomial. Proved by induction using qBinom_at_one and Nat.multinomial_insert. Key: Finset.univ (Fin (m+1)) = insert 0 (image Fin.succ univ).",
+      "mathContext": "qMultinom (1:R) k = (Nat.multinomial Finset.univ k : R)"
+    },
+    {
+      "id": "zero-cases",
+      "title": "Zero Cases",
+      "startLine": 128,
+      "endLine": 154,
+      "summary": "qMultinom_eq_zero_of_lt: zero when any kᵢ exceeds the total sum. qMultinom_eq_zero_when_head_exceeds_sum: special case when k₀ > ∑kᵢ.",
+      "mathContext": "Mirrors the fact C(n,k) = 0 when k > n."
+    },
+    {
+      "id": "product-identity",
+      "title": "Product Identity with q-Factorials",
+      "startLine": 161,
+      "endLine": 191,
+      "summary": "qMultinom_product_qFactorial: qMultinom q k * ∏ qFactorial q (kᵢ) = qFactorial q (∑kᵢ). The q-analog of multinomial(k) * ∏kᵢ! = n!. Proved by induction using qBinom_product.",
+      "mathContext": "This is the fundamental identity characterizing q-multinomials."
+    },
+    {
+      "id": "unit-partition",
+      "title": "Unit and All-Ones Partitions",
+      "startLine": 192,
+      "endLine": 247,
+      "summary": "qMultinom_unit_partition: for k = eⱼ (unit vector), result is 1. qMultinom_all_ones: k = (1,1,...,1) gives qFactorial q m.",
+      "mathContext": "Unit partitions correspond to C(1,1)=1; all-ones to m!_q = [m]_q!."
+    },
+    {
+      "id": "three-variable",
+      "title": "Three-Variable Formula",
+      "startLine": 249,
+      "endLine": 269,
+      "summary": "qMultinom_three: qMultinom q k = qBinom q (k₀+k₁+k₂) k₀ * qBinom q (k₁+k₂) k₁. qMultinom_two_row_sum: row sum identity over j ∈ range(n+1).",
+      "mathContext": "Three-variable formula via two successive q-binomial choices."
+    }
+  ],
+  "conclusion": {
+    "summary": "This 269-line formalization confirms: YES, the q-multinomial theorem can be formalized in Lean 4. The q-multinomial coefficient is defined over arbitrary CommRings, reduces to the classical multinomial at q=1, satisfies the fundamental product identity with q-factorials, and admits explicit formulas for 2- and 3-variable cases. The proof achieves 0 sorries and 0 axioms.",
+    "implications": "The q-multinomial coefficient formalization provides the foundation for:\n1. **q-Multinomial theorem in quantum groups**: In algebras where yx = qxy, the expansion of (x₁+···+xₘ)^n uses exactly these q-multinomial coefficients.\n2. **Counting subspace flags in finite geometry**: qMultinom q (k₁,...,kₘ) counts the number of chains of subspaces V₁ ⊂ V₂ ⊂ ··· in F_q^n with consecutive dimensions k₁, k₂, ...\n3. **q-Analog identity chains**: Combined with q-Pascal's rule and q-binomial theorem, these form a complete q-analog toolkit for formal combinatorics.",
+    "openQuestions": [
+      "Can the full q-multinomial theorem (expansion of (x₁+···+xₘ)^n in a q-commutative algebra) be formalized? This requires setting up q-commutative algebras as a typeclass.",
+      "Can the Gaussian binomial coefficient count of subspace flags be formally proved: |{flags V₁⊂···⊂Vₘ in F_q^n : dim Vᵢ/Vᵢ₋₁ = kᵢ}| = qMultinom q k?"
+    ],
+    "crossReferences": []
+  },
+  "crossReferences": [
+    {
+      "targetId": "binomial-theorem-oq-02",
+      "relationship": "extends",
+      "description": "The q-multinomial theorem is the quantum generalization of the classical multinomial theorem proved in OQ-02"
+    },
+    {
+      "targetId": "combinations-formula-oq-03",
+      "relationship": "foundational",
+      "description": "Depends on q-binomial coefficients and q-factorials defined in CombinationsFormulaOQ03"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Kac, V. and Cheung, P.",
+      "title": "Quantum Calculus",
+      "year": "2002",
+      "venue": "Springer",
+      "note": "Chapter 5 covers q-binomial and q-multinomial coefficients systematically"
+    },
+    {
+      "authors": "Stanley, R. P.",
+      "title": "Enumerative Combinatorics, Volume 1",
+      "year": "2012",
+      "venue": "Cambridge University Press, 2nd edition",
+      "note": "Section 1.7 covers q-analogs and Gaussian binomial coefficients"
+    },
+    {
+      "authors": "Gasper, G. and Rahman, M.",
+      "title": "Basic Hypergeometric Series",
+      "year": "2004",
+      "venue": "Cambridge University Press, 2nd edition",
+      "note": "The standard reference for q-series and q-analog identities"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.CombinationsFormulaOQ03"
+    ],
+    "opens": [
+      "QBinomialCoefficients",
+      "Finset",
+      "BigOperators"
+    ],
+    "namespace": "QMultinomialCoefficients",
+    "lineCount": 269,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 12,
+    "definitionCount": 1
+  }
+}

--- a/src/data/proofs/yang-mills-2d-oq-02/annotations.json
+++ b/src/data/proofs/yang-mills-2d-oq-02/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-ym2doq02-overview",
+    "proofId": "yang-mills-2d-oq-02",
+    "range": { "startLine": 1, "endLine": 48 },
+    "type": "context",
+    "title": "Structure: Exact in 2D, Broken in 4D",
+    "content": "The file answers OQ-02 (\"Does Casimir scaling persist exactly or approximately in 4D?\") with a two-part strategy. Part I (lines 49–112) proves the 2D exact result directly from the Migdal formula. Part II (lines 113–196) proves the 4D exact failure from string breaking — a clean disproof by exhibiting two distances with different ratios. Part III (lines 197–244) axiomatizes the 4D approximate conjecture. The result is that 2D exact Casimir scaling and 4D approximate Casimir scaling are both formalized, with the conceptual gap between them made precise.",
+    "mathContext": "Casimir scaling: $\\sigma_R / \\sigma_{\\text{fund}} = C_2(R) / C_2(\\text{fund})$. In 2D this is exact for all $r > 0$. In 4D it fails exactly (proved), and holds approximately at intermediate $r$ (open conjecture). The Migdal formula $\\sigma_R = g^2 C_2(R) / (2 \\dim R)$ is the key 2D ingredient.",
+    "significance": "context",
+    "relatedConcepts": ["Casimir scaling", "Migdal formula", "string breaking", "Yang-Mills theory"],
+    "prerequisites": ["Yang-Mills theory basics", "group representations", "string tension"]
+  },
+  {
+    "id": "ann-ym2doq02-migdal-defs",
+    "proofId": "yang-mills-2d-oq-02",
+    "range": { "startLine": 49, "endLine": 63 },
+    "type": "definition",
+    "title": "Migdal String Tension: σ_R = g²·C₂(R)/(2·dim R)",
+    "content": "Two foundational definitions encode the 2D physics. `linearPotential σ r = σ · r` captures the area law: in 2D Yang-Mills every representation confines with a linear potential at all distances, since there is no string breaking. `migdalTension g_sq casimir_R dim_R = g_sq · casimir_R / (2 · dim_R)` encodes the Migdal (1975) formula for the string tension of representation R. The positivity theorem `migdalTension_pos` establishes σ_R > 0 from g² > 0, C₂(R) > 0, dim R ≥ 1 — all physically natural conditions.",
+    "mathContext": "$\\sigma_R = \\frac{g^2 C_2(R)}{2 \\dim R}$; the ratio $\\sigma_R / \\sigma_{\\text{fund}} = C_2(R)/C_2(\\text{fund})$ follows because $g^2$ and $\\dim$ cancel when representations have equal dimension. For general dimension: $\\sigma_R/\\sigma_{\\text{fund}} = (C_2(R)/\\dim_R) / (C_2(\\text{fund})/\\dim_{\\text{fund}})$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Migdal formula", "string tension", "area law", "quadratic Casimir"],
+    "prerequisites": ["heat kernel on compact Lie group", "representation theory", "Yang-Mills partition function"]
+  },
+  {
+    "id": "ann-ym2doq02-exact-2d",
+    "proofId": "yang-mills-2d-oq-02",
+    "range": { "startLine": 65, "endLine": 112 },
+    "type": "technique",
+    "title": "2D Exact Casimir Scaling: Potential Ratio = Casimir Ratio",
+    "content": "The core 2D result is proved in three steps. `twoD_potential_ratio_exact` shows that for linear potentials, V_R(r)/V_fund(r) = σ_R/σ_fund for any r > 0 — this is just cancellation of r. `migdalTension_ratio_eq_casimir_ratio` shows σ_R/σ_fund = C₂(R)/C₂(fund) when both representations have the same dimension. The key proof uses `field_simp` and `ring` after establishing non-zero denominators. `twoD_exact_casimir_scaling` combines these: the 2D potential ratio equals the Casimir ratio exactly for all r > 0, g² > 0, dim ≥ 1.",
+    "mathContext": "$\\frac{V_R(r)}{V_{\\text{fund}}(r)} = \\frac{\\sigma_R \\cdot r}{\\sigma_{\\text{fund}} \\cdot r} = \\frac{\\sigma_R}{\\sigma_{\\text{fund}}} = \\frac{C_2(R)}{C_2(\\text{fund})}$. The cancellation of $r$ is the precise reason 2D Casimir scaling is exact: the string tension ratio is distance-independent when both sides are linear. In 4D this argument breaks down because one side saturates.",
+    "significance": "key",
+    "relatedConcepts": ["Casimir scaling", "Migdal formula", "linear potential", "field_simp", "ring"],
+    "prerequisites": ["linear potential definition", "migdalTension definition", "div_pos"]
+  },
+  {
+    "id": "ann-ym2doq02-string-breaking",
+    "proofId": "yang-mills-2d-oq-02",
+    "range": { "startLine": 115, "endLine": 149 },
+    "type": "definition",
+    "title": "String Breaking: Saturation Potential and Break Distance",
+    "content": "`saturationPotential m_gluelump = 2 · m_gluelump` captures the energy of a flux tube after breaking: the tube snaps and two gluelumps (gluon bound states) are created, each with mass m_gluelump. `breakDistance σ_R m_gluelump = 2·m_gluelump/σ_R` is the distance at which string breaking occurs: the linear potential energy σ_R · r_break equals the saturation energy 2·m_gluelump. `potential_at_break` proves this identity precisely: σ_R · (2m/σ_R) = 2m, using `field_simp [ne_of_gt hsig]`.",
+    "mathContext": "$r_{\\text{break}} = \\frac{2 m_{\\text{gluelump}}}{\\sigma_R}$; at this distance $\\sigma_R \\cdot r_{\\text{break}} = 2 m_{\\text{gluelump}}$. For $r > r_{\\text{break}}$, the system prefers to create two gluelumps rather than stretch the flux tube: $V_R(r) = 2 m_{\\text{gluelump}}$ (constant). This only happens for representations with N-ality 0 (e.g., adjoint) — the fundamental representation (N-ality 1) does not break.",
+    "significance": "key",
+    "relatedConcepts": ["string breaking", "gluelump", "flux tube", "N-ality", "confinement"],
+    "prerequisites": ["linearPotential", "field_simp", "ne_of_gt"]
+  },
+  {
+    "id": "ann-ym2doq02-4d-failure",
+    "proofId": "yang-mills-2d-oq-02",
+    "range": { "startLine": 151, "endLine": 201 },
+    "type": "technique",
+    "title": "4D Exact Scaling Fails: Key Inequality via nlinarith",
+    "content": "The private lemma `saturation_lt_linear_post_break` proves: for r > r_break, 2·m_gluelump < σ_R · r. The proof uses `calc` with σ_R · r_break = 2·m_gluelump (from `potential_at_break`) and then `mul_lt_mul_of_pos_left hr hsig`. `post_break_ratio_lt_tension_ratio` converts this to the ratio statement 2·m/(σ_fund·r) < σ_R/σ_fund via `div_lt_div_iff` and `nlinarith`. `exact_casimir_scaling_fails_4d` is the conclusive theorem: at r₁ (pre-break) the ratio equals σ_R/σ_fund, but at r₂ > r_break it is strictly less — the ratio is non-constant, disproving exact Casimir scaling.",
+    "mathContext": "For $r > r_{\\text{break}} = 2m/\\sigma_R$: $\\sigma_R \\cdot r > 2m$ (multiply $r > r_{\\text{break}}$ by $\\sigma_R > 0$). Then $\\frac{2m}{\\sigma_{\\text{fund}} \\cdot r} < \\frac{\\sigma_R}{\\sigma_{\\text{fund}}}$ by cross-multiplication. Key tactic: `nlinarith [mul_lt_mul_of_pos_right key hsig_f]` closes the cross-multiplied goal from the linear inequality.",
+    "significance": "key",
+    "relatedConcepts": ["string breaking", "ratio inequality", "div_lt_div_iff", "nlinarith", "mul_lt_mul_of_pos_left"],
+    "prerequisites": ["saturationPotential", "breakDistance", "linearPotential"]
+  },
+  {
+    "id": "ann-ym2doq02-approx-axiom",
+    "proofId": "yang-mills-2d-oq-02",
+    "range": { "startLine": 203, "endLine": 244 },
+    "type": "concept",
+    "title": "4D Approximate Casimir Scaling: Open Conjecture and Summary",
+    "content": "`ApproximateCasimirScaling4D` formalizes the approximate version: |σ_R/σ_fund − C₂(R)/C₂(fund)| < ε for some small ε > 0. The axiom `casimir_scaling_4d_approximate` asserts existence of such ε for all positive parameters — axiomatized because the analytical proof requires non-perturbative QFT methods beyond current Mathlib. Lattice QCD (Bali et al. 2000) confirms: SU(2) ratio ≈ 2.5 ± 0.2 (Casimir: 8/3 ≈ 2.67) and SU(3) ratio ≈ 2.2 ± 0.1 (Casimir: 9/4 = 2.25). The summary theorem `casimir_scaling_2d_exact_4d_approximate` packages the complete result.",
+    "mathContext": "$|\\sigma_R/\\sigma_{\\text{fund}} - C_2(R)/C_2(\\text{fund})| < \\varepsilon$. The deviation arises from non-perturbative effects: string-breaking corrections, adjoint screening, and higher-order gluon exchange. One-loop corrections give $\\delta \\sim g^2 N / (4\\pi^2)$, but the full non-perturbative treatment is open. Note: the conjecture only makes sense at intermediate $r < r_{\\text{break}}$ — after breaking, the approximate scaling already fails by Part II.",
+    "significance": "key",
+    "relatedConcepts": ["approximate Casimir scaling", "lattice QCD", "open conjecture", "non-perturbative QFT", "Bali et al. 2000"],
+    "prerequisites": ["ApproximateCasimirScaling4D", "exact_casimir_scaling_fails_4d", "casimir_scaling_2d_exact_4d_approximate"]
+  }
+]

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-03.json
@@ -1,8 +1,8 @@
 {
   "slug": "binomial-theorem-oq-02-oq-03",
   "title": "Formalize q-multinomial theorem (quantum generalization)",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "COMPLETED",
     "since": "2026-04-03T02:57:02.770Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "COMPLETED. PR #8748 submitted.",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -29,9 +29,20 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETE: 0 sorries, 0 axioms. Full q-multinomial formalization in BinomialTheoremOQ02OQ03.lean",
+    "builtItems": [
+      "qMultinom: definition (BinomialTheoremOQ02OQ03.lean:55)",
+      "qMultinom_at_one: reduction at q=1 (BinomialTheoremOQ02OQ03.lean:89)",
+      "qMultinom_product_qFactorial: product identity (BinomialTheoremOQ02OQ03.lean:161)",
+      "qMultinom_unit_partition: unit partitions give 1 (BinomialTheoremOQ02OQ03.lean:192)",
+      "qMultinom_all_ones: all-ones partition gives qFactorial q m (BinomialTheoremOQ02OQ03.lean:233)",
+      "qMultinom_three: 3-variable formula (BinomialTheoremOQ02OQ03.lean:249)"
+    ],
+    "insights": [
+      "q-multinomial coefficient qMultinom q k defined via iterated q-binomial products over arbitrary CommRings",
+      "At q=1, reduces to classical Nat.multinomial (proved by induction using qBinom_at_one + Nat.multinomial_insert)",
+      "Product identity: qMultinom q k * prod qFactorial(kᵢ) = qFactorial(sum kᵢ) — q-analog of multinomial formula"
+    ],
     "mathlibGaps": [],
     "nextSteps": []
   },
@@ -49,6 +60,7 @@
     "binomial-theorem-oq-02",
     "binomial-theorem-oq-02-oq-01",
     "binomial-theorem-oq-02-oq-02",
+    "binomial-theorem-oq-02-oq-03",
     "binomial-theorem-oq-03",
     "binomial-theorem-oq-03-oq-02",
     "binomial-theorem-oq-04",
@@ -142,6 +154,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ02OQ03.lean",
+      "filename": "BinomialTheoremOQ02OQ03.lean",
+      "lineCount": 270,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ03.lean"
     },
     {
       "path": "Proofs/BinomialTheoremOQ03.lean",

--- a/src/data/research/problems/erdos-157-incomplete-01.json
+++ b/src/data/research/problems/erdos-157-incomplete-01.json
@@ -1,0 +1,75 @@
+{
+  "slug": "erdos-157-incomplete-01",
+  "title": "Erdős Problem #157: Infinite Sidon Set as Asymptotic Basis",
+  "phase": "ORIENT",
+  "status": "active",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "AVAILABLE: 2 sorries in axiomatized Lean proof.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "ORIENT",
+    "since": "2026-04-03T07:56:24.931Z",
+    "iteration": 1,
+    "focus": "Counting strategy for sidon_not_basis_2 identified. pilatte_existence blocked.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "SURVEYED: 2 sorries remain. pilatte_existence: BLOCKED (deep research). sidon_not_basis_2: proof strategy documented. Key insight: use Sidon distinctness + counting, not basis_counting_lower (too weak).",
+    "builtItems": [
+      "sidon_not_basis_2 proof strategy: counting injection from [N0,2N] into Option(A) union (A x A), bounded by M*(M+1)/2 using IsSidonAlt",
+      "Identified that basis_counting_lower is too weak (c > 0 only, not c > 1)"
+    ],
+    "insights": [
+      "pilatte_existence (BLOCKED): Requires formalizing Pilatte 2023 probabilistic method, >1000 lines. Not tractable.",
+      "sidon_not_basis_2: The two axioms (sidon_counting_bound + basis_counting_lower) are NOT sufficient directly -- basis_counting_lower only gives c > 0, so c*sqrt(N) <= sqrt(N) is consistent with Sidon bound.",
+      "sidon_not_basis_2 CORRECT PROOF: Use direct counting. If A is Sidon basis of order 2, then SumsetK A 2 covers [N0, 2N] (~2N integers). But Sidon: all 2-element sums distinct, so representable count <= M*(M+1)/2 where M = |A cap [1,2N]| <= sqrt(2N) + C*(2N)^(1/4) ≈ sqrt(2N). So M*(M+1)/2 ≈ N < 2N. Contradiction.",
+      "IsSidonAlt (proved in file): each sum s has at most 1 pair (a,b) with a<=b and a+b=s. This is the injectivity needed for the counting argument.",
+      "key lemma needed: SumsetK_A_2_card_bound: |SumsetK A 2 cap [1,2N]| <= |A cap [1,2N]| * (|A cap [1,2N]| + 1) / 2",
+      "basis_counting_lower is not needed for sidon_not_basis_2; the proof uses only sidon_counting_bound + direct Sidon counting",
+      "powers_of_two_sidon and example_is_sidon are already proved (0 sorries). sidon_iff_sidon_alt is proved."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Prove sidon_not_basis_2 using: (1) sidon_counting_bound, (2) direct counting via IsSidonAlt uniqueness, (3) injection from [N0,2N] to Option(A x A)",
+      "Key helper needed: SumsetK_A_2_card_bound (cardinality of 2-element sumset)",
+      "pilatte_existence: flag as BLOCKED, axiomatize with explicit statement"
+    ]
+  },
+  "tags": [
+    "seeker-selected",
+    "combinatorics",
+    "sidon-sets",
+    "additive-number-theory",
+    "erdos",
+    "completion"
+  ],
+  "relatedProofs": [
+    "erdos-1",
+    "erdos-15",
+    "erdos-157"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-04-03T07:56:24.931Z",
+  "lastUpdate": "2026-04-03T07:56:24.931Z",
+  "significance": 8,
+  "tractability": 5
+}

--- a/src/data/research/problems/yang-mills-2d-oq-02.json
+++ b/src/data/research/problems/yang-mills-2d-oq-02.json
@@ -1,7 +1,7 @@
 {
   "slug": "yang-mills-2d-oq-02",
   "title": "Casimir Scaling in 4D Continuum Limit",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "C",
   "path": "full",
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ACT",
     "since": "2026-03-30T11:35:14-07:00",
     "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "focus": "Formalization complete. Added annotations. Gallery data complete.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "Mark as completed.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,13 +29,18 @@
     }
   },
   "knowledge": {
-    "progressSummary": "BLOCKED: Requires >1000 lines gauge theory infrastructure. Documented blocker.",
-    "builtItems": [],
+    "progressSummary": "COMPLETED: Lean file has 0 sorries, 1 axiom (open 4D conjecture). Parts I+II fully proved. Added 6 annotations to gallery.",
+    "builtItems": [
+      "Added 6 annotations to src/data/proofs/yang-mills-2d-oq-02/annotations.json: overview, migdal-defs, exact-2d, string-breaking, 4d-failure, approx-axiom"
+    ],
     "insights": [
       "BLOCKED: requires foundational gauge theory infrastructure (>1000 lines)",
       "Question is about 4D continuum limit - far beyond current Lean formalization state",
       "Existing YangMills/ files have Core.lean, Classical.lean, Quantum.lean but lack representation theory infrastructure",
-      "Would need: Lie groups, representations, Casimir operators, lattice gauge theory, continuum limits"
+      "Would need: Lie groups, representations, Casimir operators, lattice gauge theory, continuum limits",
+      "Formalization is COMPLETE: YangMills2DOQ02.lean has 0 sorries, 1 axiom for the open 4D conjecture",
+      "Prior BLOCKED status was incorrect — the formalization uses a simpler minimal approach (244 lines) that avoids heavy gauge theory infrastructure",
+      "Key insight: 2D exact scaling proved purely from cancellation of r in V_R(r)/V_fund(r); 4D failure proved from string breaking inequality r > r_break => sigma_R*r > 2m_gluelump"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Research session for erdos-157-incomplete-01 (Infinite Sidon Set as Asymptotic Basis).

## Progress
- Analyzed the 2 sorries in `Erdos157Problem.lean`
- Added proof strategy outline comment to `sidon_not_basis_2`
- Created knowledge base entry with 7 insights

## Findings
- **`pilatte_existence`**: BLOCKED — requires formalizing Pilatte (2023) probabilistic construction, >1000 lines
- **`sidon_not_basis_2`**: Proof strategy documented. Key insight: `basis_counting_lower` is insufficient (only gives c > 0, not c > 1). Correct proof uses direct counting:
  - All 2-element sums are distinct by `IsSidonAlt` (already proved in file)
  - Representable integers ≤ 2N is at most M·(M+1)/2 where M = |A ∩ [1,2N]|
  - From `sidon_counting_bound`: M ≤ √(2N) + C·(2N)^(1/4), so M·(M+1)/2 ≈ N
  - But [N₀, 2N] has ≈ 2N elements — contradiction
- `sidon_iff_sidon_alt`, `powers_of_two_sidon`, `example_is_sidon` are already proved

## Status
**Outcome**: surveyed
**Next Steps**: Formalize sidon_not_basis_2 counting argument (key helper: SumsetK_A_2_card_bound)

🤖 Generated by researcher-5