### PR TITLE
Fix: sorries count mismatches in 5 gallery proofs

### DIFF
--- a/src/data/proofs/dirichlets-theorem-oq-03/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-03/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "axiomCount": 2,
     "lineCount": 139,
     "theoremCount": 8,

--- a/src/data/proofs/erdos-138/meta.json
+++ b/src/data/proofs/erdos-138/meta.json
@@ -37,7 +37,7 @@
       "Proof schema: main conjecture implies ExponentialDiverges"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 4,
     "erdosNumber": 138,
     "erdosUrl": "https://erdosproblems.com/138",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-392/meta.json
+++ b/src/data/proofs/erdos-392/meta.json
@@ -17,7 +17,7 @@
       "number-theory"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 392,
     "erdosUrl": "https://erdosproblems.com/392",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-628/meta.json
+++ b/src/data/proofs/erdos-628/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 12,
+    "sorries": 11,
     "erdosNumber": 628,
     "erdosUrl": "https://erdosproblems.com/628",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/yang-mills/meta.json
+++ b/src/data/proofs/yang-mills/meta.json
@@ -22,7 +22,7 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Lie.Basic",


### PR DESCRIPTION
## Fix

Corrects `meta.sorries` to match the actual number of `sorry` expressions in each proof's Lean source file (counting only code, not comments).

## Evidence

**Before**: 5 gallery proofs had incorrect `sorries` count in meta.json
**After**: `sorries` fields match actual Lean source file sorry counts

Fixes:
- `dirichlets-theorem-oq-03`: 3→2 (one sorry was in a block comment)
- `erdos-138`: 5→4 (one sorry was in a block comment)
- `erdos-392`: 3→2 (one sorry was in a block comment)
- `erdos-628`: 12→11 (one sorry was in a block comment)
- `yang-mills`: 1→0 (file is a 48-line wrapper with no sorry)

Note: Many other files have "sorry" appearing in comments like "no sorry, no axiom" — these are not actual Lean sorry expressions and are correctly excluded.

---
Automated fix by lean-mechanic agent.