### PR TITLE
fix: JSON syntax error and audit tracker sync

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11176,6 +11176,30 @@
       "lastAudited": "2026-04-03T07:40:04Z",
       "result": "clean",
       "issues": []
+    },
+    "binomial-theorem-oq-02-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T08:38:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1018-oq-04-incomplete-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T08:38:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1155-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T08:38:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "minkowski-theorem-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T08:38:00Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {

--- a/src/data/proofs/three-place-identity-oq-02/meta.json
+++ b/src/data/proofs/three-place-identity-oq-02/meta.json
@@ -111,5 +111,5 @@
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 5
-  },
+  }
 }


### PR DESCRIPTION
## Summary

- Fix trailing comma in `three-place-identity-oq-02/meta.json` (introduced by PR #8755) that was breaking the build
- Update audit tracker (cycle 9)

## Test plan

- [x] `pnpm build` passes locally with this fix
- [x] Site deployed to Cloudflare Pages successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)