### PR TITLE
Enrich cauchy-schwarz-oq-01-oq-03: Heisenberg uncertainty from Cauchy-Schwarz

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-03/annotations.json
@@ -1,1 +1,62 @@
-[]
+[
+  {
+    "id": "ann-cauchy-schwarz-foundation",
+    "proofId": "cauchy-schwarz-oq-01-oq-03",
+    "range": { "startLine": 41, "endLine": 50 },
+    "type": "technique",
+    "title": "Cauchy-Schwarz from Mathlib: inner_mul_le_norm_mul_sq",
+    "content": "cauchy_schwarz_sq wraps Mathlib's inner_mul_le_norm_mul_sq with a one-line proof: @inner_mul_le_norm_mul_sq ℂ E _ _ f g. The explicit universe annotation @inner_mul_le_norm_mul_sq ℂ E is needed because the type class arguments must be specified when Lean cannot infer them from the context. This is a deliberate choice to expose the Mathlib theorem rather than re-prove Cauchy-Schwarz — an example of library delegation for foundational facts.",
+    "mathContext": "$|\\langle f, g \\rangle|^2 \\le \\|f\\|^2 \\cdot \\|g\\|^2$ in any inner product space over $\\mathbb{C}$. The Lean form: \\texttt{Complex.normSq (inner f g : ℂ) ≤ ‖f‖^2 * ‖g‖^2}. Here \\texttt{Complex.normSq z = z.re^2 + z.im^2 = |z|^2}. This is the form needed for the subsequent Im-bound step.",
+    "significance": "supporting",
+    "relatedConcepts": ["inner_mul_le_norm_mul_sq", "Complex.normSq", "InnerProductSpace ℂ E", "Mathlib delegation"],
+    "prerequisites": ["Mathlib.Analysis.InnerProductSpace.Basic", "@-syntax for explicit arguments", "Complex.normSq definition"]
+  },
+  {
+    "id": "ann-im-bound",
+    "proofId": "cauchy-schwarz-oq-01-oq-03",
+    "range": { "startLine": 62, "endLine": 68 },
+    "type": "technique",
+    "title": "Imaginary Part Bound: (Im z)² ≤ |z|² by linarith",
+    "content": "im_sq_le_normSq proves (Im z)² ≤ |z|² for any z ∈ ℂ by unfolding normSq to z.re²+z.im² and then applying linarith [sq_nonneg z.re]. The proof is: the missing term z.re² is nonneg, so z.im² ≤ z.re²+z.im². This lemma is the bridge from Cauchy-Schwarz (which bounds |⟨f,g⟩|²) to the Robertson relation (which needs Im⟨f,g⟩). The quantum-mechanical interpretation: the commutator inner product ⟨[A,B]⟩ = 2i·Im⟨Aψ,Bψ⟩, so bounding Im² captures exactly the commutator term.",
+    "mathContext": "For $z = a + bi$: $\\text{normSq}(z) = a^2 + b^2 \\ge b^2 = (\\text{Im}\\, z)^2$. Lean: \\texttt{unfold Complex.normSq; simp only [Complex.normSq\\_mk]; linarith [sq\\_nonneg z.re]}. The physics: $|\\langle f, g \\rangle|^2 = (\\text{Re}\\langle f,g\\rangle)^2 + (\\text{Im}\\langle f,g\\rangle)^2 \\ge (\\text{Im}\\langle f,g\\rangle)^2$. The Robertson inequality retains only the Im part, losing the Re contribution (which the Schrödinger-Robertson inequality recovers).",
+    "significance": "key",
+    "relatedConcepts": ["Complex.normSq unfold", "sq_nonneg", "Robertson inequality", "imaginary part of inner product"],
+    "prerequisites": ["Complex.normSq = re² + im²", "linarith for linear arithmetic", "quantum commutator interpretation"]
+  },
+  {
+    "id": "ann-robertson-core",
+    "proofId": "cauchy-schwarz-oq-01-oq-03",
+    "range": { "startLine": 70, "endLine": 82 },
+    "type": "key",
+    "title": "robertson_core: The Algebraic Heart via calc Chain",
+    "content": "robertson_core is the main algebraic result: (Im⟨f,g⟩)² ≤ ‖f‖²·‖g‖². The proof is a two-step calc chain: (Im⟨f,g⟩)² ≤ normSq⟨f,g⟩ (by im_sq_le_normSq) ≤ ‖f‖²·‖g‖² (by cauchy_schwarz_sq). This modular composition is pedagogically clean: each step has its own lemma, and robertson_core is just their composition. The calc syntax makes the derivation chain explicit and readable.",
+    "mathContext": "$(\\text{Im}\\langle f, g \\rangle)^2 \\le |\\langle f, g \\rangle|^2 \\le \\|f\\|^2 \\cdot \\|g\\|^2$. Lean proof: \\texttt{calc ... \\_ ≤ Complex.normSq (inner f g : ℂ) := im\\_sq\\_le\\_normSq \\_ \\_ ≤ ‖f‖^2 * ‖g‖^2 := cauchy\\_schwarz\\_sq f g}. This is the Robertson uncertainty relation in abstract form: for $f = \\Delta A \\cdot \\psi$, $g = \\Delta B \\cdot \\psi$: $\\sigma_A^2 \\cdot \\sigma_B^2 = \\|f\\|^2 \\cdot \\|g\\|^2 \\ge (\\text{Im}\\langle f, g \\rangle)^2$.",
+    "significance": "key",
+    "relatedConcepts": ["calc proof syntax", "lemma composition", "Robertson uncertainty relation", "abstract operator inequality"],
+    "prerequisites": ["im_sq_le_normSq", "cauchy_schwarz_sq", "calc chaining in Lean 4"]
+  },
+  {
+    "id": "ann-heisenberg-bound",
+    "proofId": "cauchy-schwarz-oq-01-oq-03",
+    "range": { "startLine": 84, "endLine": 100 },
+    "type": "insight",
+    "title": "Heisenberg Bound: Specializing the Commutator Condition",
+    "content": "heisenberg_bound specializes robertson_core to the case Im⟨f,g⟩ = c/2. After rewriting with hc, the proof becomes: c²/4 ≤ ‖f‖²·‖g‖². This is an application of linarith [sq_nonneg (c/2)] after substituting the hypothesis. The condition Im⟨f,g⟩ = c/2 corresponds to the quantum-mechanical situation where [X,P] = iℏ forces Im⟨ΔX·ψ, ΔP·ψ⟩ = ℏ/2 for normalized ψ.",
+    "mathContext": "With $\\text{Im}\\langle f, g \\rangle = c/2$: from robertson\\_core, $(c/2)^2 \\le \\|f\\|^2 \\cdot \\|g\\|^2$, i.e., $c^2/4 \\le \\sigma_A^2 \\sigma_B^2$. In quantum mechanics: the canonical commutation relation $[\\hat{X}, \\hat{P}] = i\\hbar$ (Dirac, 1925) gives $\\text{Im}\\langle \\Delta X \\psi, \\Delta P \\psi \\rangle = \\hbar/2$ for normalized $\\psi$. Substituting $c = \\hbar$: $\\sigma_x^2 \\sigma_p^2 \\ge \\hbar^2/4$, i.e., $\\sigma_x \\sigma_p \\ge \\hbar/2$.",
+    "significance": "key",
+    "relatedConcepts": ["canonical commutation relation [X,P]=iℏ", "linarith tactic", "specialization from abstract to concrete"],
+    "prerequisites": ["robertson_core", "quantum commutator Im⟨Δx·ψ, Δp·ψ⟩=ℏ/2", "linarith for inequality arithmetic"]
+  },
+  {
+    "id": "ann-heisenberg-sqrt",
+    "proofId": "cauchy-schwarz-oq-01-oq-03",
+    "range": { "startLine": 107, "endLine": 128 },
+    "type": "technique",
+    "title": "Square-Root Form: |c|/2 ≤ ‖f‖·‖g‖ via nlinarith",
+    "content": "heisenberg_sqrt converts the squared form c²/4 ≤ ‖f‖²·‖g‖² into the square-root form |c|/2 ≤ ‖f‖·‖g‖. This requires proving that if a² ≤ b² (with b > 0), then |a| ≤ b. The proof uses nlinarith with hints [sq_abs c, sq_nonneg (‖f‖*‖g‖ - |c|/2)]. The hint (‖f‖*‖g‖ - |c|/2)² ≥ 0 gives ‖f‖²·‖g‖² - ‖f‖·‖g‖·|c| + c²/4 ≥ 0; combined with c²/4 ≤ ‖f‖²·‖g‖², nlinarith concludes. The positivity hypotheses hf, hg are needed to ensure division operations are valid.",
+    "mathContext": "From $c^2/4 \\le \\|f\\|^2 \\|g\\|^2$: want to prove $|c|/2 \\le \\|f\\| \\|g\\|$. Since both sides are nonneg, this is equivalent to $c^2/4 \\le (\\|f\\| \\|g\\|)^2$. The nlinarith hint: $(\\|f\\|\\|g\\| - |c|/2)^2 \\ge 0 \\Rightarrow \\|f\\|^2\\|g\\|^2 - \\|f\\|\\|g\\||c| + c^2/4 \\ge 0$. Combined with the hypothesis: $\\|f\\|^2\\|g\\|^2 \\ge c^2/4 \\ge c^2/4 - (\\|f\\|^2\\|g\\|^2 - \\|f\\|\\|g\\||c| + c^2/4) = \\|f\\|\\|g\\||c| - \\|f\\|^2\\|g\\|^2$. After dividing by $\\|f\\|\\|g\\| > 0$: $\\|f\\|\\|g\\| \\ge |c|/2$.",
+    "significance": "technical",
+    "relatedConcepts": ["nlinarith with polynomial hints", "sq_abs", "sqrt of both sides", "division by positive norm"],
+    "prerequisites": ["nlinarith tactic and polynomial hint syntax", "sq_abs for |c|² = c²", "div_le_iff for inequality manipulation"]
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-03/meta.json
@@ -23,19 +23,55 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "problemStatement": "Can the Heisenberg uncertainty principle be derived from the complex Cauchy-Schwarz inequality?",
+    "problemStatement": "Can the Heisenberg uncertainty principle σ_x·σ_p ≥ ℏ/2 be derived from the complex Cauchy-Schwarz inequality in an abstract inner product space, without assuming specific quantum-mechanical axioms?",
+    "historicalContext": "The Cauchy-Schwarz inequality has a tangled history: Augustin-Louis Cauchy proved the finite sum version in 1821, Viktor Bunyakovsky proved the integral version in 1859, and Hermann Schwarz independently proved the integral version in 1885 (whence the Western name). Heisenberg (1927) derived the position-momentum uncertainty principle σ_x·σ_p ≥ ℏ/2 through heuristic arguments about wave packet spreading. The clean algebraic derivation from an inner product inequality was given by H.P. Robertson (1929), who proved the general Robertson uncertainty relation σ_A·σ_B ≥ |⟨[A,B]⟩|/2 for arbitrary Hermitian observables. Schrödinger (1930) strengthened this to include a covariance term. The modern perspective, formalized here, is that the uncertainty principle is a purely algebraic consequence of the complex Cauchy-Schwarz inequality: it holds in any complex inner product space, with no quantum mechanics required. Only the physical identification of observables and commutators brings in the physics.",
     "keyInsights": [
-      "Cauchy-Schwarz: |⟨f,g⟩|² ≤ ‖f‖²·‖g‖²",
-      "Im bound: (Im⟨f,g⟩)² ≤ |⟨f,g⟩|²",
-      "Commutator substitution: Im⟨Δx·ψ, Δp·ψ⟩ = ℏ/2",
-      "Pure algebraic derivation — works in any complex inner product space"
+      "The Heisenberg uncertainty principle is a theorem of functional analysis: it follows from the complex Cauchy-Schwarz inequality in 3 algebraic steps, with no quantum axioms needed.",
+      "The imaginary part bound — (Im⟨f,g⟩)² ≤ |⟨f,g⟩|² — is the bridge between Cauchy-Schwarz and the commutator: the commutator ⟨[A,B]⟩ = 2i·Im⟨Aψ,Bψ⟩, so the Robertson relation σ_A²·σ_B² ≥ (Im⟨f,g⟩)² follows from dropping the real part of |⟨f,g⟩|².",
+      "robertson_core is the algebraic core: (Im⟨f,g⟩)² ≤ ‖f‖²·‖g‖². It is proved via a calc chain through im_sq_le_normSq and cauchy_schwarz_sq — two lines, modular composition.",
+      "The square-root form heisenberg_sqrt (‖f‖·‖g‖ ≥ |c|/2) uses nlinarith with sq_abs hints. The arithmetic is subtle: going from c²/4 ≤ ‖f‖²·‖g‖² to |c|/2 ≤ ‖f‖·‖g‖ requires multiplying non-negative quantities and taking square roots, which nlinarith handles via polynomial arithmetic.",
+      "The proof works over any type E with InnerProductSpace ℂ E structure — not just L²(ℝ). This generality is mathematically important: the uncertainty principle holds for any complex Hilbert space, including finite-dimensional ones."
     ],
-    "proofStrategy": "",
-    "historicalContext": ""
+    "proofStrategy": "Three-step algebraic derivation: (1) establish Cauchy-Schwarz as |⟨f,g⟩|² ≤ ‖f‖²·‖g‖²; (2) bound Im⟨f,g⟩ by showing (Im z)² ≤ |z|² for z ∈ ℂ via unfolding normSq; (3) chain these via calc in robertson_core: (Im⟨f,g⟩)² ≤ normSq⟨f,g⟩ ≤ ‖f‖²·‖g‖². The Heisenberg bound heisenberg_bound specializes the commutator condition Im⟨f,g⟩ = c/2 and applies linarith. The square-root form heisenberg_sqrt closes with nlinarith.",
+    "prerequisites": [
+      "Complex inner product spaces (InnerProductSpace ℂ E)",
+      "Mathlib's inner_mul_le_norm_mul_sq (Cauchy-Schwarz)",
+      "Complex.normSq and its relationship to real/imaginary parts",
+      "Robertson uncertainty relation (physics context)"
+    ]
   },
+  "sections": [
+    {
+      "id": "cauchy-schwarz-foundation",
+      "title": "Part 1: Cauchy-Schwarz as Variance Bound",
+      "startLine": 41,
+      "endLine": 50,
+      "summary": "cauchy_schwarz_sq wraps Mathlib's inner_mul_le_norm_mul_sq. norm_sq_nonneg' establishes ‖f‖² ≥ 0 as a helper. These two facts are the foundation for the entire derivation."
+    },
+    {
+      "id": "robertson-core",
+      "title": "Part 2: Robertson Uncertainty Relation",
+      "startLine": 52,
+      "endLine": 82,
+      "summary": "im_sq_le_normSq: (Im z)² ≤ |z|² proved by unfolding normSq and linarith on sq_nonneg(z.re). robertson_core: chains im_sq_le_normSq and cauchy_schwarz_sq in a calc proof to give (Im⟨f,g⟩)² ≤ ‖f‖²·‖g‖²."
+    },
+    {
+      "id": "heisenberg-bounds",
+      "title": "Part 3: Heisenberg Bounds in Two Forms",
+      "startLine": 84,
+      "endLine": 128,
+      "summary": "heisenberg_bound: specializes robertson_core to Im⟨f,g⟩ = c/2, giving c²/4 ≤ ‖f‖²·‖g‖². uncertainty_principle: the ℏ-specialization. heisenberg_sqrt: the multiplicative form ‖f‖·‖g‖ ≥ |c|/2 using nlinarith."
+    }
+  ],
   "conclusion": {
-    "summary": "YES. The uncertainty principle is a direct consequence of Cauchy-Schwarz applied to centered observables, plus the imaginary part bound.",
-    "implications": "YES. The uncertainty principle is a direct consequence of Cauchy-Schwarz applied to centered observables, plus the imaginary part bound."
+    "summary": "YES. The Heisenberg uncertainty principle follows from Cauchy-Schwarz in 3 algebraic steps. The Lean proof formalizes the Robertson 1929 argument in full generality over abstract complex inner product spaces. The key modular lemmas are im_sq_le_normSq and cauchy_schwarz_sq, chained in robertson_core.",
+    "implications": "This formalization demonstrates that fundamental physics principles can be reduced to pure mathematics with machine verification. The proof is fully general: σ_A·σ_B ≥ |Im⟨f,g⟩| for any vectors f, g in any complex inner product space. The connection to quantum mechanics is made only at the level of physical interpretation (identifying f with ΔX·ψ, g with ΔP·ψ, and the commutator with iℏ). A further step would formalize the Robertson relation as σ_A·σ_B ≥ |⟨[A,B]⟩|/2 for abstract Hermitian operators.",
+    "openQuestions": [
+      "Can the Robertson inequality be formalized for abstract Hermitian operators in Lean 4? This would require a formalization of bounded linear operators and their adjoints in Mathlib.",
+      "The Schrödinger-Robertson inequality strengthens the Robertson relation: σ_A²·σ_B² ≥ (Im⟨f,g⟩)² + (Re⟨f,g⟩)². Can this be formalized by modifying the Im-bound step to retain the Re term?",
+      "The minimum-uncertainty states (coherent states) saturate the inequality: ‖f‖·‖g‖ = |c|/2. Can Lean 4 formalize the condition for equality in Cauchy-Schwarz (f and g are proportional) and use it to characterize coherent states?",
+      "Can the energy-time uncertainty ΔE·Δt ≥ ℏ/2 be formalized? This requires more care since time is not an operator in quantum mechanics."
+    ]
   },
   "leanFile": {
     "namespace": "CauchySchwarzOQ01OQ03",


### PR DESCRIPTION
## Enrichment: cauchy-schwarz-oq-01-oq-03

Enriches the Heisenberg uncertainty principle formalization with full mathematical and historical context.

### Changes to meta.json
- **historicalContext**: Cauchy (1821), Bunyakovsky (1859), Schwarz (1885), Heisenberg (1927), Robertson (1929), Schrödinger (1930)
- **5 keyInsights**: 3-step derivation is pure algebra, Im bound bridges Cauchy-Schwarz to commutator, robertson_core as modular calc chain, nlinarith for sqrt form, abstract generality over any InnerProductSpace ℂ E
- **3 sections**: Cauchy-Schwarz foundation, Robertson core, Heisenberg bounds
- **conclusion**: summary + implications + 4 open questions (Robertson for operators, Schrödinger-Robertson inequality, coherent states, energy-time uncertainty)

### New annotations.json (5 annotations)
1. `ann-cauchy-schwarz-foundation`: Mathlib delegation via inner_mul_le_norm_mul_sq
2. `ann-im-bound`: im_sq_le_normSq bridge lemma — (Im z)² ≤ |z|² via linarith
3. `ann-robertson-core`: Two-step calc chain composition (key result)
4. `ann-heisenberg-bound`: Specialization of robertson_core to Im⟨f,g⟩ = c/2
5. `ann-heisenberg-sqrt`: nlinarith with sq_abs hints for square-root form

🤖 Generated with [Claude Code](https://claude.com/claude-code)