### PR TITLE
Fix: remove True-stub theorems from 9 gallery proofs (batch 8)

### DIFF
--- a/proofs/Proofs/DissectionOfCubesOQ02.lean
+++ b/proofs/Proofs/DissectionOfCubesOQ02.lean
@@ -333,14 +333,12 @@ theorem polygon_dehn_zero (angles : List ℝ) (h : ∀ θ ∈ angles, ∃ n : �
 -- Part VII: The Dehn-Sydler Theorem (Statement)
 -- ========================================================================
 
-/-- **Dehn-Sydler Theorem** (1965): Two polyhedra in 3D are scissors congruent
+/- dehn_sydler_statement: **Dehn-Sydler Theorem** (1965): Two polyhedra in 3D are scissors congruent
 if and only if they have the same volume AND the same Dehn invariant.
 
 This shows that Dehn's invariant is not just necessary but SUFFICIENT
 (together with volume) for scissors congruence. -/
-theorem dehn_sydler_statement :
-    True := -- Placeholder: full formalization would require measure theory
-  trivial
+
 
 /-
 The Dehn-Sydler theorem was conjectured by Dehn (1901) and proved by

--- a/proofs/Proofs/Erdos515Problem.lean
+++ b/proofs/Proofs/Erdos515Problem.lean
@@ -178,14 +178,9 @@ there exists a single path C such that ∫_C |f|^{-λ} dz < ∞ for ALL λ > 0.
 This is the complete solution to Erdős's question.
 -/
 axiom lewis_rossi_weitsman_1984 : UniversalQuestion
-
-/--
-**Stronger Form:**
+/- lrw_subharmonic_version: **Stronger Form:**
 The Lewis-Rossi-Weitsman result actually holds for e^u where u is any
-subharmonic function, not just u = log|f| for entire f.
--/
-theorem lrw_subharmonic_version :
-  True := trivial  -- Placeholder for more general statement
+subharmonic function, not just u = log|f| for entire f. -/
 
 /-
 ## Part VII: Why This is Surprising

--- a/proofs/Proofs/Erdos637Problem.lean
+++ b/proofs/Proofs/Erdos637Problem.lean
@@ -61,10 +61,8 @@ def HasSmallRamsey (G : SimpleGraph V) (C : ℝ) : Prop :=
 def IsRamseyGraph (G : SimpleGraph V) : Prop :=
   ∃ C > 0, HasSmallRamsey G C
 
-/-- Random G(n, 1/2) is typically a Ramsey graph. -/
-theorem random_is_ramsey :
-    True := by  -- G(n, 1/2) satisfies IsRamseyGraph a.s.
-  trivial
+/- random_is_ramsey: Random G(n, 1/2) is typically a Ramsey graph. -/
+
 
 /- ## Part III: Induced Subgraphs -/
 
@@ -173,20 +171,14 @@ theorem ramsey_not_too_regular (G : SimpleGraph V) (hRamsey : IsRamseyGraph G)
 
 /- ## Part IX: Random Graphs -/
 
-/-- Random G(n, 1/2) has many distinct degrees a.s. -/
-theorem random_many_degrees :
-    True := by  -- G(n, 1/2) has ≈ n distinct degrees a.s.
-  trivial
+/- random_many_degrees: Random G(n, 1/2) has many distinct degrees a.s. -/
 
-/-- For random graphs, degree concentration implies few distinct degrees globally. -/
-theorem random_degree_concentration :
-    True := by  -- Degrees concentrate around n/2
-  trivial
 
-/-- But Ramsey graphs have limited structure. -/
-theorem ramsey_limited_structure :
-    True := by  -- No large clique or independent set
-  trivial
+/- random_degree_concentration: For random graphs, degree concentration implies few distinct degrees globally. -/
+
+
+/- ramsey_limited_structure: But Ramsey graphs have limited structure. -/
+
 
 /- ## Part X: Connections to Ramsey Theory -/
 
@@ -208,10 +200,8 @@ def FindLargeInduced (G : SimpleGraph V) : Prop :=
   ∃ S : Finset V, S.card ≥ Fintype.card V / 2 ∧
     inducedDistinctDegrees G S ≥ Nat.sqrt (Fintype.card V)
 
-/-- The problem is polynomial-time solvable. -/
-theorem polynomial_time_algorithm :
-    True := by  -- Can be found efficiently
-  trivial
+/- polynomial_time_algorithm: The problem is polynomial-time solvable. -/
+
 
 /- ## Part XII: Summary -/
 

--- a/proofs/Proofs/Erdos926Problem.lean
+++ b/proofs/Proofs/Erdos926Problem.lean
@@ -150,14 +150,8 @@ For k ≥ 3: ex(n; H_k) ≪ k · n^(3/2).
 
 This improves Füredi's (kn)^(3/2) to k · n^(3/2).
 -/
-
-/--
-**Erdős Problem #926: SOLVED**
-The answer is YES: ex(n; H_k) ≪_k n^(3/2).
--/
-theorem erdos_926 (k : ℕ) (hk : k ≥ 4) :
-    True :=  -- ex(n; H_k) ≪_k n^(3/2)
-  trivial
+/- erdos_926: **Erdős Problem #926: SOLVED**
+The answer is YES: ex(n; H_k) ≪_k n^(3/2). -/
 
 /-
 ## Part VII: Connection to Degeneracy
@@ -237,11 +231,7 @@ theorem erdos_926_summary :
     True    -- Problem is a special case of 2-degenerate conjecture
   := ⟨trivial, trivial, trivial⟩
 
-/--
-The order of magnitude is n^(3/2) for all k ≥ 3.
--/
-theorem erdos_926_order :
-    True :=  -- ex(n; H_k) = Θ_k(n^(3/2))
-  trivial
+/- erdos_926_order: The order of magnitude is n^(3/2) for all k ≥ 3. -/
+
 
 end Erdos926

--- a/proofs/Proofs/FourierSeriesOQ04.lean
+++ b/proofs/Proofs/FourierSeriesOQ04.lean
@@ -95,15 +95,9 @@ noncomputable def spherPartialSum {n : ℕ} (f : Torus n → ℂ)
 The n=2 pointwise convergence for L² is one of the major open problems
 in harmonic analysis. Carleson's theorem (1966) only covers n=1.
 -/
+/- carleson_1d_reference: In 1D, Carleson's theorem gives pointwise a.e. convergence for L^2. -/
 
-/-- In 1D, Carleson's theorem gives pointwise a.e. convergence for L^2. -/
-theorem carleson_1d_reference :
-    True :=  -- placeholder for the 1D result reference
-  trivial
+/- carleson_2d_open: The n=2 case for L^2 pointwise convergence is open. -/
 
-/-- The n=2 case for L^2 pointwise convergence is open. -/
-theorem carleson_2d_open :
-    True :=  -- status: OPEN
-  trivial
 
 end FourierSeriesOQ04

--- a/proofs/Proofs/Hilbert19OQ03.lean
+++ b/proofs/Proofs/Hilbert19OQ03.lean
@@ -329,12 +329,8 @@ axiom schauder_bootstrap
 The Alexandrov-Bakelman-Pucci (ABP) maximum principle is the foundation
 for all regularity theory in the fully nonlinear setting.
 -/
-
-/-- **ABP implies comparison**: The ABP maximum principle implies
+/- abp_implies_comparison: **ABP implies comparison**: The ABP maximum principle implies
     the comparison principle (uniqueness of viscosity solutions). -/
-theorem abp_implies_comparison :
-    (∃ (C : ℝ), C > 0) → True := by
-  intro _; trivial
 
 /-
 ## Section VII: Krylov-Safonov Theory
@@ -372,12 +368,8 @@ theorem sup_of_affine_is_convex (f : ℕ → ℝ → ℝ)
   simp only [hf]
   ring_nf
   linarith [mul_comm t (a * x), mul_comm t (a * y)]
-
-/-- Isaacs equations (differential games): F(M) = sup_α inf_β L_{αβ}(M).
+/- isaacs_regularity_open: Isaacs equations (differential games): F(M) = sup_α inf_β L_{αβ}(M).
     These are generally NOT convex, so Evans-Krylov does not directly apply. -/
-theorem isaacs_regularity_open :
-    True := by trivial
-    -- Full C^{2,α} for non-convex uniformly elliptic F is still partially open
 
 /-
 ## Section IX: Counterexamples — Limits of Regularity

--- a/proofs/Proofs/LawOfCosinesOQ03.lean
+++ b/proofs/Proofs/LawOfCosinesOQ03.lean
@@ -180,7 +180,7 @@ theorem area_positive (t : HyperbolicTriangleAngles) :
 -- PART 6: Euclidean Limit
 -- ============================================================
 
-/-- As side lengths approach 0, the hyperbolic law of cosines reduces
+/- euclidean_limit_informal: As side lengths approach 0, the hyperbolic law of cosines reduces
     to the Euclidean version. Using cosh(x) ≈ 1 + x²/2 and
     sinh(x) ≈ x for small x:
 
@@ -189,7 +189,4 @@ theorem area_positive (t : HyperbolicTriangleAngles) :
     c² ≈ a² + b² - 2ab·cos(C) + O(a²b²)
 
     The O(a²b²) term vanishes in the limit, recovering the Euclidean law. -/
-theorem euclidean_limit_informal :
-    True := trivial -- Informal statement; formal limit would require o(1) analysis
 
-end HyperbolicLawOfCosines

--- a/proofs/Proofs/LebesgueMeasure.lean
+++ b/proofs/Proofs/LebesgueMeasure.lean
@@ -316,13 +316,9 @@ theorem rationals_measure_zero :
   apply Set.Countable.measure_zero
   exact Set.countable_range _
 
-/-- The Cantor set has Lebesgue measure zero.
+/- cantor_set_measure_zero: The Cantor set has Lebesgue measure zero.
     (This is a standard example of an uncountable null set.) -/
-theorem cantor_set_measure_zero :
-    True := by
-  -- The Cantor set is uncountable but has measure 0
-  -- It's constructed by removing middle thirds, total length removed = 1
-  trivial
+
 
 /-- The integral of the indicator function of a null set is zero.
     This generalizes the Dirichlet function result to any measure-zero set. -/
@@ -401,14 +397,10 @@ section Applications
 noncomputable example : MeasureTheory.Lp ℝ 2 (volume : Measure ℝ) :=
   0  -- The zero function is in Lp
 
-/-- Hölder's inequality: For conjugate exponents p, q, we have
+/- holder_inequality_statement: Hölder's inequality: For conjugate exponents p, q, we have
     ‖f * g‖₁ ≤ ‖f‖_p * ‖g‖_q.
     This is fundamental to functional analysis. -/
-theorem holder_inequality_statement (p q : ENNReal)
-    (hpq : p.toReal⁻¹ + q.toReal⁻¹ = 1) (hp : 1 ≤ p) (hq : 1 ≤ q) :
-    True := by
-  -- Hölder's inequality is available as MeasureTheory.NNNorm.inner_le_Lp_mul_Lq
-  trivial
+
 
 end Applications
 

--- a/proofs/Proofs/PrimeNumberTheorem.lean
+++ b/proofs/Proofs/PrimeNumberTheorem.lean
@@ -399,14 +399,12 @@ Proved by composing three Mathlib results:
 theorem prime_counting_tendsto_top : Tendsto (fun x : ℝ => (primePi x : ℝ)) atTop atTop :=
   tendsto_natCast_atTop_iff.mpr (Nat.tendsto_primeCounting.comp tendsto_nat_floor_atTop)
 
-/-- **Euler's product formula connection**
+/- euler_product_connection: **Euler's product formula connection**
 
 The Euler product ζ(s) = ∏_p (1 - p^(-s))^(-1) connects PNT to the zeta function.
 Taking logarithms: log ζ(s) = ∑_p p^(-s) + O(1) for Re(s) > 1.
 The behavior of ζ(s) near s = 1 determines the distribution of primes. -/
-theorem euler_product_connection :
-    True := by  -- Placeholder for the deep connection
-  trivial
+
 
 /-! ═══════════════════════════════════════════════════════════════════════════════
 PART VIII: NUMERICAL EVIDENCE

--- a/src/data/proofs/dissection-of-cubes-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02/meta.json
@@ -39,7 +39,7 @@
       "polygon_dehn_zero: 2D Bolyai-Gerwien analog (all polygons have zero Dehn invariant)",
       "Conditional Hilbert's Third Problem: cube and tetrahedron not scissors congruent, assuming Dehn's theorem as hypothesis"
     ],
-    "lineCount": 383,
+    "lineCount": 381,
     "axiomCount": 0,
     "assumptions": "No axiom declarations. Dehn's theorem is encoded as an explicit hypothesis (not an axiom) in hilbert_third_problem. ScissorsCongruent uses a simplified placeholder definition. The core number-theoretic result (arccos(1/3)/π is irrational) is fully proved.",
     "mathlib_version": "4.26.0"
@@ -176,7 +176,7 @@
       "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
     ],
     "namespace": "DissectionOfCubesOQ02",
-    "lineCount": 383,
+    "lineCount": 381,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-515/meta.json
+++ b/src/data/proofs/erdos-515/meta.json
@@ -64,7 +64,7 @@
       "erdos_515 theorem: main result"
     ],
     "axiomCount": 3,
-    "lineCount": 290,
+    "lineCount": 285,
     "assumptions": "4 axioms: huber_1957, zhang_1977, lewis_rossi_weitsman_1984, and 1 more. See Lean source for complete statements."
   },
   "overview": {
@@ -181,7 +181,7 @@
       "MeasureTheory"
     ],
     "namespace": "Erdos515",
-    "lineCount": 290,
+    "lineCount": 285,
     "axiomCount": 3,
     "theoremCount": 3,
     "definitionCount": 11

--- a/src/data/proofs/erdos-637/meta.json
+++ b/src/data/proofs/erdos-637/meta.json
@@ -28,7 +28,7 @@
       "Induced subgraphs and vertex subsets",
       "Probabilistic method and random graph models (Erdős-Rényi G(n, 1/2))"
     ],
-    "lineCount": 253,
+    "lineCount": 243,
     "assumptions": "No axioms. 10 sorry(s) remain in the formalization.",
     "mathlib_version": "4.26.0"
   },
@@ -199,7 +199,7 @@
       "Finset"
     ],
     "namespace": "Erdos637",
-    "lineCount": 253,
+    "lineCount": 243,
     "axiomCount": 0,
     "theoremCount": 18,
     "definitionCount": 16

--- a/src/data/proofs/erdos-926/meta.json
+++ b/src/data/proofs/erdos-926/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/926",
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
-    "lineCount": 247,
+    "lineCount": 237,
     "assumptions": "14 axioms: hk_contains_c4, hk_2_degenerate, hk_bipartite, and 11 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
@@ -154,7 +154,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos926",
-    "lineCount": 247,
+    "lineCount": 237,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 3

--- a/src/data/proofs/fourier-series-oq-04/meta.json
+++ b/src/data/proofs/fourier-series-oq-04/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 109
+    "lineCount": 103
   },
   "leanFile": {
     "axiomCount": 0

--- a/src/data/proofs/hilbert-19-oq-03/meta.json
+++ b/src/data/proofs/hilbert-19-oq-03/meta.json
@@ -63,7 +63,7 @@
     "mathlib_version": "4.26.0",
     "axioms": 2,
     "axiomCount": 4,
-    "lineCount": 462,
+    "lineCount": 454,
     "assumptions": "4 axioms (Evans-Krylov theorem, Schauder estimates, comparison principle, ABP estimate). No sorries."
   },
   "overview": {
@@ -209,7 +209,7 @@
     ],
     "opens": [],
     "namespace": "Hilbert19OQ03",
-    "lineCount": 462,
+    "lineCount": 454,
     "axiomCount": 4,
     "theoremCount": 18,
     "definitionCount": 10

--- a/src/data/proofs/law-of-cosines-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 3,
     "assumptions": "3 structure-encoded assumptions: (1) HyperbolicTriangle.law — the first law of cosines cosh(c)=cosh(a)cosh(b)-sinh(a)sinh(b)cos(C) is a structure field (not proved from metric axioms); (2) HyperbolicTriangleAngles.law2 — the second law of cosines cos(C)=-cos(A)cos(B)+sin(A)sin(B)cosh(c) is a structure field; (3) HyperbolicTriangleAngles.defect_pos — the angular defect A+B+C<π is a structure field. Also contains 1 True-stub theorem (euclidean_limit_informal).",
-    "lineCount": 195,
+    "lineCount": 192,
     "theoremCount": 13,
     "definitionCount": 0,
     "originalContributions": [
@@ -58,7 +58,7 @@
   },
   "leanFile": {
     "namespace": "HyperbolicLawOfCosines",
-    "lineCount": 195,
+    "lineCount": 192,
     "axiomCount": 3,
     "theoremCount": 13,
     "definitionCount": 2

--- a/src/data/proofs/lebesgue-measure/meta.json
+++ b/src/data/proofs/lebesgue-measure/meta.json
@@ -55,7 +55,7 @@
     ],
     "dateAdded": "2025-12-29",
     "axiomCount": 0,
-    "lineCount": 425,
+    "lineCount": 417,
     "assumptions": "0 axioms, 0 sorries. Note: 2 theorems prove True as application stubs (dominated convergence and Fubini iteration placeholders). All substantive results are fully verified.",
     "mathlib_version": "4.26.0"
   },
@@ -248,7 +248,7 @@
       "Topology"
     ],
     "namespace": "LebesgueMeasure",
-    "lineCount": 425,
+    "lineCount": 417,
     "axiomCount": 0,
     "theoremCount": 22,
     "definitionCount": 0

--- a/src/data/proofs/prime-number-theorem/meta.json
+++ b/src/data/proofs/prime-number-theorem/meta.json
@@ -55,7 +55,7 @@
     ],
     "dateAdded": "2025-12-29",
     "axiomCount": 8,
-    "lineCount": 462,
+    "lineCount": 460,
     "assumptions": "8 axioms: primeNumberTheorem (PNT itself), li_equiv_approx_axiom (Li ~ x/ln x), nth_prime_asymptotic_axiom, mertens_sum_primes_axiom, prime_gaps_sublinear_axiom, RiemannHypothesis_statement, pnt_rh_error_axiom, chebyshev_bounds_axiom. Eliminated 5 axioms by proving from Mathlib: ratio_iff_equiv (via isEquivalent_iff_tendsto_one), equiv_iff_error (definitional), li_iff_equiv (transitivity of ~), prime_counting_tendsto_top (Nat.tendsto_primeCounting), prime_density_tends_to_zero (from PNT).",
     "mathlib_version": "4.26.0",
     "prerequisites": [
@@ -320,7 +320,7 @@
       "BigOperators"
     ],
     "namespace": "PrimeNumberTheorem",
-    "lineCount": 462,
+    "lineCount": 460,
     "axiomCount": 8,
     "theoremCount": 15,
     "definitionCount": 9,


### PR DESCRIPTION
## Fix

Remove 16 True-stub theorems (`theorem X : True := trivial`) and convert to block comments.

## Evidence

**Before**: 9 gallery proof files contained theorems that proved only `True` (mathematically meaningless placeholders)
**After**: Stubs replaced with block comments preserving the documentation

Files fixed:
- `DissectionOfCubesOQ02.lean`: `dehn_sydler_statement`
- `Erdos515Problem.lean`: `lrw_subharmonic_version`
- `Erdos637Problem.lean`: `random_is_ramsey`, `random_many_degrees`, `random_degree_concentration`, `ramsey_limited_structure`, `polynomial_time_algorithm`
- `Erdos926Problem.lean`: `erdos_926`, `erdos_926_order`
- `FourierSeriesOQ04.lean`: `carleson_1d_reference`, `carleson_2d_open`
- `Hilbert19OQ03.lean`: `isaacs_regularity_open`, `abp_implies_comparison`
- `LawOfCosinesOQ03.lean`: `euclidean_limit_informal`
- `LebesgueMeasure.lean`: `cantor_set_measure_zero`, `holder_inequality_statement`
- `PrimeNumberTheorem.lean`: `euler_product_connection`

---
Automated fix by lean-mechanic agent.