### PR TITLE
Fix: erdos-157 lineCount 180→192

### DIFF
--- a/src/data/proofs/erdos-157/meta.json
+++ b/src/data/proofs/erdos-157/meta.json
@@ -59,7 +59,7 @@
       "Verified theorem: powers_of_two_sidon"
     ],
     "axiomCount": 2,
-    "lineCount": 180,
+    "lineCount": 192,
     "assumptions": "2 axiom(s) and 2 sorry(s). See the Lean source for details."
   },
   "overview": {
@@ -159,7 +159,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos157",
-    "lineCount": 180,
+    "lineCount": 192,
     "axiomCount": 2,
     "theoremCount": 5,
     "definitionCount": 7


### PR DESCRIPTION
## Fix

Corrects `meta.lineCount` for erdos-157 after the file grew following batch 4 merge.

## Evidence

**Before**: meta.lineCount = 180
**After**: meta.lineCount = 192 (matches actual Lean source)

---
Automated fix by lean-mechanic agent.