### PR TITLE
Fix: Hilbert11OQ01 — eliminate 2 sorries via evaluation functionals

### DIFF
--- a/proofs/Proofs/Hilbert11OQ01.lean
+++ b/proofs/Proofs/Hilbert11OQ01.lean
@@ -136,19 +136,29 @@ If Q has a nonzero rational zero `v₀`, then `(1 : ℝ) ⊗ₜ v₀` gives a ze
 The nonzero condition follows from the injectivity of `1 ⊗ₜ · : (Fin n → ℚ) → ℝ ⊗[ℚ] (Fin n → ℚ)`,
 which holds because `Fin n → ℚ` is a free ℚ-module.
 
-Note: The injectivity argument is deferred (sorry) as it requires facts about the
-tensor product of a free module — a good Aristotle target. -/
+Note: Injectivity is proved via evaluation functionals — for each i, map a ⊗ₜ w ↦ a * (w i : ℝ).
+This extracts each coordinate, showing 1 ⊗ₜ v = 0 implies v = 0. -/
 theorem rational_implies_real_isotropic (Q : QuadraticForm ℚ (Fin n → ℚ))
     (h : ∃ v : Fin n → ℚ, v ≠ 0 ∧ Q v = 0) : IsIsotropicOverReals Q := by
   obtain ⟨v, hv_ne, hv_zero⟩ := h
   refine ⟨(1 : ℝ) ⊗ₜ[ℚ] v, ?_, ?_⟩
   · -- 1 ⊗ₜ v ≠ 0 because v ≠ 0 and the canonical map Fin n → ℚ → ℝ ⊗[ℚ] (Fin n → ℚ) is injective
-    -- (Fin n → ℚ is a free ℚ-module, so base change is injective)
+    -- Proved via evaluation functionals: for each i, ev_i(a ⊗ₜ w) = a * (w i : ℝ)
     intro heq
     apply hv_ne
-    -- The map v ↦ 1 ⊗ₜ v is ℚ-linear and injective; from heq : 1 ⊗ₜ v = 0 conclude v = 0
-    have : (TensorProduct.mk ℚ ℝ (Fin n → ℚ) 1) v = 0 := heq
-    sorry  -- injectivity of 1 ⊗ₜ · on free module; suitable for Aristotle/further work
+    funext i
+    -- Evaluation functional ev_i : ℝ ⊗[ℚ] (Fin n → ℚ) →ₗ[ℚ] ℝ defined by a ⊗ₜ w ↦ a * (w i : ℝ)
+    let ev : ℝ ⊗[ℚ] (Fin n → ℚ) →ₗ[ℚ] ℝ :=
+      TensorProduct.lift (LinearMap.mk₂ ℚ (fun (a : ℝ) (w : Fin n → ℚ) => a * algebraMap ℚ ℝ (w i))
+        (fun _ _ _ => by ring)
+        (fun c _ _ => by simp only [Algebra.smul_def]; ring)
+        (fun _ _ _ => by simp only [Pi.add_apply, map_add]; ring)
+        (fun c _ w => by simp only [Pi.smul_apply, smul_eq_mul, map_mul, Algebra.smul_def]; ring))
+    have heval : ev ((1 : ℝ) ⊗ₜ[ℚ] v) = algebraMap ℚ ℝ (v i) := by
+      simp only [ev, TensorProduct.lift.tmul, LinearMap.mk₂_apply, one_mul]
+    have hzero : ev ((1 : ℝ) ⊗ₜ[ℚ] v) = 0 := by rw [heq]; exact map_zero ev
+    have hvi : (v i : ℝ) = 0 := by simpa using heval.symm.trans hzero
+    exact_mod_cast hvi
   · rw [baseChange_real_tmul, hv_zero]
     simp
 
@@ -160,10 +170,22 @@ theorem rational_implies_padic_isotropic (Q : QuadraticForm ℚ (Fin n → ℚ))
     (h : ∃ v : Fin n → ℚ, v ≠ 0 ∧ Q v = 0) : IsIsotropicOverPadic Q p := by
   obtain ⟨v, hv_ne, hv_zero⟩ := h
   refine ⟨(1 : ℚ_[p]) ⊗ₜ[ℚ] v, ?_, ?_⟩
-  · intro heq
+  · -- 1 ⊗ₜ v ≠ 0 via evaluation functionals: for each i, ev_i(a ⊗ₜ w) = a * (w i : ℚ_[p])
+    intro heq
     apply hv_ne
-    have : (TensorProduct.mk ℚ ℚ_[p] (Fin n → ℚ) 1) v = 0 := heq
-    sorry  -- injectivity of 1 ⊗ₜ · on free module; suitable for Aristotle/further work
+    funext i
+    -- Evaluation functional ev_i : ℚ_[p] ⊗[ℚ] (Fin n → ℚ) →ₗ[ℚ] ℚ_[p]
+    let ev : ℚ_[p] ⊗[ℚ] (Fin n → ℚ) →ₗ[ℚ] ℚ_[p] :=
+      TensorProduct.lift (LinearMap.mk₂ ℚ (fun (a : ℚ_[p]) (w : Fin n → ℚ) => a * algebraMap ℚ ℚ_[p] (w i))
+        (fun _ _ _ => by ring)
+        (fun c _ _ => by simp only [Algebra.smul_def]; ring)
+        (fun _ _ _ => by simp only [Pi.add_apply, map_add]; ring)
+        (fun c _ w => by simp only [Pi.smul_apply, smul_eq_mul, map_mul, Algebra.smul_def]; ring))
+    have heval : ev ((1 : ℚ_[p]) ⊗ₜ[ℚ] v) = algebraMap ℚ ℚ_[p] (v i) := by
+      simp only [ev, TensorProduct.lift.tmul, LinearMap.mk₂_apply, one_mul]
+    have hzero : ev ((1 : ℚ_[p]) ⊗ₜ[ℚ] v) = 0 := by rw [heq]; exact map_zero ev
+    have hvi : (v i : ℚ_[p]) = 0 := by simpa using heval.symm.trans hzero
+    exact_mod_cast hvi
   · rw [baseChange_padic_tmul, hv_zero]
     simp
 
@@ -193,7 +215,7 @@ axiom hasse_minkowski_refined (Q : QuadraticForm ℚ (Fin n → ℚ)) :
 
 /-- The "easy direction" of Hasse-Minkowski: rational isotropy implies local isotropy.
 
-This is proved (modulo the tensor product injectivity sorry in the helper lemmas). -/
+This is fully proved: injectivity uses evaluation functionals, not sorry. -/
 theorem hasse_easy_direction (Q : QuadraticForm ℚ (Fin n → ℚ))
     (h : ∃ v : Fin n → ℚ, v ≠ 0 ∧ Q v = 0) :
     IsIsotropicOverReals Q ∧ ∀ p : ℕ, [Fact (Nat.Prime p)] → IsIsotropicOverPadic Q p :=
@@ -223,18 +245,19 @@ PART VI: SUMMARY AND STATUS
 1. `four_squares_from_mathlib` — Lagrange's 4 squares, proved from Mathlib (axiom eliminated)
 2. `baseChange_real_tmul` — computation lemma for local isotropy over ℝ
 3. `baseChange_padic_tmul` — computation lemma for local isotropy over ℚₚ
-4. `hasse_easy_direction` — easy direction of Hasse-Minkowski (modulo injectivity sorry)
+4. `hasse_easy_direction` — easy direction of Hasse-Minkowski (fully proved, no sorry)
+5. `rational_implies_real_isotropic` — rational ⟹ ℝ-isotropic (proved via evaluation functionals)
+6. `rational_implies_padic_isotropic` — rational ⟹ ℚₚ-isotropic (proved via evaluation functionals)
 
-### Remaining Sorries (Aristotle Targets)
+### Remaining Sorries
 
-Two sorries in `rational_implies_real_isotropic` and `rational_implies_padic_isotropic`:
-- Proving `1 ⊗ₜ v ≠ 0` when `v ≠ 0` in `A ⊗[ℚ] (Fin n → ℚ)`
-- Follows from flatness/freeness of `Fin n → ℚ` over ℚ
-- These are likely provable by Aristotle or via `TensorProduct.linearIndependent_iff`
+None. All sorries have been eliminated:
+- `rational_implies_real_isotropic`: proved `1 ⊗ₜ v ≠ 0` via coordinate evaluation functionals
+- `rational_implies_padic_isotropic`: proved `1 ⊗ₜ v ≠ 0` via coordinate evaluation functionals
 
 ### Next Steps
 
-1. Prove the two injectivity sorries (free module base change is injective)
+1. State Meyer's theorem: dim ≥ 5 forms over ℚ are isotropic
 2. State the p-adic classification theorem (Meyer's theorem: dim ≥ 5 forms are isotropic)
 3. Add Hilbert symbol formalization using `IsIsotropicOverPadic`
 -/

--- a/proofs/Proofs/Hilbert11OQ01Aristotle.lean
+++ b/proofs/Proofs/Hilbert11OQ01Aristotle.lean
@@ -1,20 +1,11 @@
 /-
-  Aristotle targets for Hilbert11 OQ-01
-  Routine supporting lemmas for automated proof search.
+  Injectivity lemmas for Hilbert11 OQ-01
+  These are used by Hilbert11OQ01.lean to prove the easy direction of Hasse-Minkowski.
   See Hilbert11OQ01.lean for the main formalization.
 
-  Criteria for inclusion:
-  - NOT the main open conjecture (Hasse-Minkowski)
-  - Known results likely provable via flatness/freeness arguments
-  - Clean theorem statement with no definition sorries
-  - No axioms (use theorem ... := by sorry instead)
-
-  Main sorry targets:
-  1. Injectivity of (1 ⊗ₜ ·) : (Fin n → ℚ) → A ⊗[ℚ] (Fin n → ℚ)
-     when A is a flat ℚ-algebra (e.g., ℝ or ℚ_[p]).
-     Follows from Module.Flat.lTensor_injective or tensor product of free modules.
-
-  2. Same for ℚ_[p] ⊗[ℚ] (Fin n → ℚ).
+  Both theorems are proved via evaluation functionals:
+  for each i : Fin n, define ev_i : A ⊗[ℚ] (Fin n → ℚ) →ₗ[ℚ] A by a ⊗ₜ w ↦ a * (w i : A).
+  Then ev_i(1 ⊗ₜ v) = (v i : A), giving v i = w i from 1 ⊗ₜ v = 1 ⊗ₜ w.
 -/
 import Mathlib.LinearAlgebra.QuadraticForm.TensorProduct
 import Mathlib.RingTheory.TensorProduct.Basic
@@ -31,19 +22,43 @@ open scoped TensorProduct
 
 /-- The canonical map v ↦ 1 ⊗ₜ v is injective for ℝ ⊗[ℚ] (Fin n → ℚ).
 
-ℝ is flat over ℚ (in fact, ℝ is a flat ℚ-algebra since ℚ is a field and every
-module over a field is flat). Therefore the map (1 ⊗ₜ ·) is injective.
-
-Used in: Hilbert11OQ01.rational_implies_real_isotropic -/
+Proved via evaluation functionals: for each i, ev_i(a ⊗ₜ w) = a * (w i : ℝ),
+so ev_i(1 ⊗ₜ v) = (v i : ℝ). From 1 ⊗ₜ v = 1 ⊗ₜ w we get v i = w i for all i. -/
 theorem one_tmul_injective_real (n : ℕ) :
     Function.Injective (fun v : Fin n → ℚ => (1 : ℝ) ⊗ₜ[ℚ] v) := by
-  sorry
+  intro v w h
+  funext i
+  let ev : ℝ ⊗[ℚ] (Fin n → ℚ) →ₗ[ℚ] ℝ :=
+    TensorProduct.lift (LinearMap.mk₂ ℚ (fun (a : ℝ) (w : Fin n → ℚ) => a * algebraMap ℚ ℝ (w i))
+      (fun _ _ _ => by ring)
+      (fun c _ _ => by simp only [Algebra.smul_def]; ring)
+      (fun _ _ _ => by simp only [Pi.add_apply, map_add]; ring)
+      (fun c _ w => by simp only [Pi.smul_apply, smul_eq_mul, map_mul, Algebra.smul_def]; ring))
+  have hv : ev ((1 : ℝ) ⊗ₜ[ℚ] v) = algebraMap ℚ ℝ (v i) := by
+    simp only [ev, TensorProduct.lift.tmul, LinearMap.mk₂_apply, one_mul]
+  have hw : ev ((1 : ℝ) ⊗ₜ[ℚ] w) = algebraMap ℚ ℝ (w i) := by
+    simp only [ev, TensorProduct.lift.tmul, LinearMap.mk₂_apply, one_mul]
+  have heq : algebraMap ℚ ℝ (v i) = algebraMap ℚ ℝ (w i) := by rw [← hv, ← hw, h]
+  exact_mod_cast heq
 
 /-- The canonical map v ↦ 1 ⊗ₜ v is injective for ℚ_[p] ⊗[ℚ] (Fin n → ℚ).
 
-ℚ_[p] is flat over ℚ (same reason: ℚ is a field). -/
+Same proof as for ℝ: evaluation functionals extract each coordinate. -/
 theorem one_tmul_injective_padic (n : ℕ) (p : ℕ) [Fact (Nat.Prime p)] :
     Function.Injective (fun v : Fin n → ℚ => (1 : ℚ_[p]) ⊗ₜ[ℚ] v) := by
-  sorry
+  intro v w h
+  funext i
+  let ev : ℚ_[p] ⊗[ℚ] (Fin n → ℚ) →ₗ[ℚ] ℚ_[p] :=
+    TensorProduct.lift (LinearMap.mk₂ ℚ (fun (a : ℚ_[p]) (w : Fin n → ℚ) => a * algebraMap ℚ ℚ_[p] (w i))
+      (fun _ _ _ => by ring)
+      (fun c _ _ => by simp only [Algebra.smul_def]; ring)
+      (fun _ _ _ => by simp only [Pi.add_apply, map_add]; ring)
+      (fun c _ w => by simp only [Pi.smul_apply, smul_eq_mul, map_mul, Algebra.smul_def]; ring))
+  have hv : ev ((1 : ℚ_[p]) ⊗ₜ[ℚ] v) = algebraMap ℚ ℚ_[p] (v i) := by
+    simp only [ev, TensorProduct.lift.tmul, LinearMap.mk₂_apply, one_mul]
+  have hw : ev ((1 : ℚ_[p]) ⊗ₜ[ℚ] w) = algebraMap ℚ ℚ_[p] (w i) := by
+    simp only [ev, TensorProduct.lift.tmul, LinearMap.mk₂_apply, one_mul]
+  have heq : algebraMap ℚ ℚ_[p] (v i) = algebraMap ℚ ℚ_[p] (w i) := by rw [← hv, ← hw, h]
+  exact_mod_cast heq
 
 end Hilbert11OQ01Aristotle

--- a/src/data/research/problems/hilbert-11-oq-01.json
+++ b/src/data/research/problems/hilbert-11-oq-01.json
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ORIENT",
-    "since": "2026-03-30T21:46:38.107Z",
-    "iteration": 2,
-    "focus": "Tensor product base change for local isotropy",
+    "phase": "ACT",
+    "since": "2026-04-03T00:00:00.000Z",
+    "iteration": 3,
+    "focus": "Eliminated 2 sorries via evaluation functional approach",
     "blockers": [],
-    "nextAction": "Prove injectivity of 1 \u2297\u209c \u00b7 on free modules to eliminate 2 sorries",
+    "nextAction": "Submit PR for sorry elimination, consider Aristotle companion update",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,35 +29,38 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Created Hilbert11OQ01.lean with proper tensor product definitions for local isotropy. Eliminated four_squares_connection axiom via Mathlib. Defined IsIsotropicOverReals and IsIsotropicOverPadic using QuadraticForm.baseChange.",
+    "progressSummary": "PROGRESS: Eliminated 2 sorries in Hilbert11OQ01.lean using evaluation functionals. Both rational_implies_real_isotropic and rational_implies_padic_isotropic now have complete proofs.",
     "builtItems": [
       "Created proofs/Proofs/Hilbert11OQ01.lean: proper local isotropy definitions via baseChange",
-      "Proved four_squares_from_mathlib \u2014 Lagrange 4 squares, no axiom",
-      "Defined IsIsotropicOverReals using QuadraticForm.baseChange \u211d",
-      "Defined IsIsotropicOverPadic using QuadraticForm.baseChange \u211a_[p]",
+      "Proved four_squares_from_mathlib — Lagrange 4 squares, no axiom",
+      "Defined IsIsotropicOverReals using QuadraticForm.baseChange ℝ",
+      "Defined IsIsotropicOverPadic using QuadraticForm.baseChange ℚ_[p]",
       "Proved baseChange_real_tmul and baseChange_padic_tmul computation lemmas",
       "Proved hasse_easy_direction (modulo 2 injectivity sorries)",
-      "Axiomatized hasse_minkowski_refined with proper local conditions"
+      "Axiomatized hasse_minkowski_refined with proper local conditions",
+      "Proved rational_implies_real_isotropic: 1 ⊗ₜ v ≠ 0 via evaluation functionals in ℝ ⊗[ℚ] (Fin n → ℚ)",
+      "Proved rational_implies_padic_isotropic: 1 ⊗ₜ v ≠ 0 via evaluation functionals in ℚ_[p] ⊗[ℚ] (Fin n → ℚ)"
     ],
     "insights": [
       "QuadraticForm.baseChange from Mathlib.LinearAlgebra.QuadraticForm.TensorProduct provides the correct formalization of scalar extension for quadratic forms.",
-      "IsIsotropicOverReals Q = Q.baseChange \u211d has nonzero zero in \u211d \u2297[\u211a] (Fin n \u2192 \u211a) \u2014 this replaces placeholder True.",
-      "IsIsotropicOverPadic Q p = Q.baseChange \u211a_[p] has nonzero zero in \u211a_[p] \u2297[\u211a] (Fin n \u2192 \u211a) \u2014 proper p-adic tensor product.",
-      "Algebra \u211a \u211d and Algebra \u211a \u211a_[p] are automatically available via algebraRat (DivisionRing + CharZero \u2192 Algebra \u211a).",
-      "Invertible (2 : \u211a) is automatically inferred for QuadraticForm.baseChange.",
-      "four_squares_connection is proved directly from Nat.sum_four_squares \u2014 eliminates 1 axiom.",
-      "The easy direction (rational isotropy \u2192 local isotropy) relies on injectivity of 1 \u2297\u209c \u00b7 on free modules \u2014 2 sorries remain for Aristotle."
+      "IsIsotropicOverReals Q = Q.baseChange ℝ has nonzero zero in ℝ ⊗[ℚ] (Fin n → ℚ) — this replaces placeholder True.",
+      "IsIsotropicOverPadic Q p = Q.baseChange ℚ_[p] has nonzero zero in ℚ_[p] ⊗[ℚ] (Fin n → ℚ) — proper p-adic tensor product.",
+      "Algebra ℚ ℝ and Algebra ℚ ℚ_[p] are automatically available via algebraRat (DivisionRing + CharZero → Algebra ℚ).",
+      "Invertible (2 : ℚ) is automatically inferred for QuadraticForm.baseChange.",
+      "four_squares_connection is proved directly from Nat.sum_four_squares — eliminates 1 axiom.",
+      "The easy direction (rational isotropy → local isotropy) relies on injectivity of 1 ⊗ₜ · on free modules — 2 sorries remain for Aristotle.",
+      "Evaluation functional approach: for each i : Fin n, define ev_i : A ⊗[ℚ] (Fin n → ℚ) →ₗ[ℚ] A by a ⊗ₜ w ↦ a * algebraMap ℚ A (w i). Then ev_i(1 ⊗ₜ v) = (v i : A). From 1 ⊗ₜ v = 0 deduce v i = 0 for all i.",
+      "Key tactic: simpa using heval.symm.trans hzero converts algebraMap ℚ A (v i) = 0 to (v i : A) = 0, then exact_mod_cast gives v i = 0."
     ],
     "mathlibGaps": [
-      "Need Hasse-Minkowski itself \u2014 not in Mathlib",
-      "Rational classification of quadratic forms \u2014 not in Mathlib",
-      "Injectivity of base change of free modules \u2014 likely in Mathlib as Module.Flat.lTensor_injective"
+      "Need Hasse-Minkowski itself — not in Mathlib",
+      "Rational classification of quadratic forms — not in Mathlib",
+      "Injectivity of base change of free modules — likely in Mathlib as Module.Flat.lTensor_injective"
     ],
     "nextSteps": [
-      "Prove injectivity sorry: 1 \u2297\u209c v \u2260 0 when v \u2260 0 in A \u2297[\u211a] (Fin n \u2192 \u211a) (free module base change injective)",
-      "Check if TensorProduct.linearIndependent_iff or Module.Flat.lTensor_injective applies",
-      "Add Meyer theorem formalization: forms in \u2265 5 variables are locally isotropic",
-      "Consider Hilbert symbol formalization using IsIsotropicOverPadic"
+      "State Meyers theorem: forms in ≥ 5 variables over ℚ are isotropic",
+      "Add Hilbert symbol formalization using IsIsotropicOverPadic",
+      "Update Aristotle companion file to prove one_tmul_injective_real/padic"
     ]
   },
   "tags": [
@@ -75,7 +78,7 @@
     "mathlib": []
   },
   "started": "2026-03-30T21:46:38.107Z",
-  "lastUpdate": "2026-03-30T21:46:38.107Z",
+  "lastUpdate": "2026-04-03T00:00:00.000Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [
@@ -89,6 +92,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Hilbert11_QuadraticForms.lean"
+    },
+    {
+      "path": "Proofs/Hilbert11OQ01.lean",
+      "filename": "Hilbert11OQ01.lean",
+      "lineCount": 273,
+      "theoremCount": 6,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Hilbert11OQ01.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Eliminates both `sorry` placeholders in `Hilbert11OQ01.lean`
- Proves `rational_implies_real_isotropic`: if Q has a nonzero rational zero `v₀`, then `(1 : ℝ) ⊗ₜ v₀ ≠ 0` (full proof, no sorry)
- Proves `rational_implies_padic_isotropic`: same for `ℚ_[p]`
- Updates `Hilbert11OQ01Aristotle.lean`: proves `one_tmul_injective_real` and `one_tmul_injective_padic` with the same technique

## Proof Technique

**Evaluation functionals**: For each coordinate `i : Fin n`, define
```
ev_i : A ⊗[ℚ] (Fin n → ℚ) →ₗ[ℚ] A
ev_i(a ⊗ₜ w) = a * algebraMap ℚ A (w i)
```
Then `ev_i(1 ⊗ₜ v) = algebraMap ℚ A (v i)`. From `1 ⊗ₜ v = 0`, deduce `(v i : A) = 0`, hence `v i = 0` by `exact_mod_cast`. This works uniformly for both `A = ℝ` and `A = ℚ_[p]`.

No flatness/freeness lemmas needed — the proof is elementary and direct.

## Build

`Proofs.Hilbert11OQ01` builds successfully (3066 jobs, no errors or sorries).

## Test plan

- [x] Docker build: `✔ Built Proofs.Hilbert11OQ01 (59s)` — success
- [x] Zero sorries in `Hilbert11OQ01.lean` (verified by grep)
- [x] Zero sorries in `Hilbert11OQ01Aristotle.lean` (both theorems proved)
- [x] Axiom count unchanged: still 1 (`hasse_minkowski_refined`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)