### PR TITLE
Fix: correct sorry counts in 6 gallery proofs (audit cycle 10)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1498,9 +1498,11 @@
       "result": "clean"
     },
     "dirichlets-theorem-oq-03": {
-      "auditCount": 2,
-      "issues": [],
-      "lastAudited": "2026-03-30T13:40:31Z",
+      "auditCount": 3,
+      "issues": [
+        "sorry mismatch corrected in meta.json"
+      ],
+      "lastAudited": "2026-04-03T09:06:15Z",
       "result": "issues-fixed"
     },
     "dissection-of-cubes": {
@@ -3265,11 +3267,11 @@
       "result": "clean"
     },
     "erdos-138": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
-        "PR #6446: sorries 4\u21925"
+        "sorry mismatch corrected in meta.json"
       ],
-      "lastAudited": "2026-03-30T13:40:31Z",
+      "lastAudited": "2026-04-03T09:06:15Z",
       "result": "issues-fixed"
     },
     "erdos-139": {
@@ -3399,10 +3401,12 @@
       "result": "clean"
     },
     "erdos-157": {
-      "auditCount": 1,
-      "issues": [],
-      "lastAudited": "2026-03-24T12:44:33Z",
-      "result": "clean"
+      "auditCount": 2,
+      "issues": [
+        "sorry mismatch corrected in meta.json"
+      ],
+      "lastAudited": "2026-04-03T09:06:15Z",
+      "result": "issues-fixed"
     },
     "erdos-158": {
       "auditCount": 1,
@@ -5008,11 +5012,11 @@
       "result": "clean"
     },
     "erdos-392": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [
-        "PR #6444: sorries 2\u21923"
+        "sorry mismatch corrected in meta.json"
       ],
-      "lastAudited": "2026-03-24T18:20:00Z",
+      "lastAudited": "2026-04-03T09:06:15Z",
       "result": "issues-fixed"
     },
     "erdos-393": {
@@ -6629,11 +6633,11 @@
       "result": "clean"
     },
     "erdos-628": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [
-        "PR #6443: sorries 11\u219212, definitionCount 14\u219212"
+        "sorry mismatch corrected in meta.json"
       ],
-      "lastAudited": "2026-03-24T18:10:00Z",
+      "lastAudited": "2026-04-03T09:06:15Z",
       "result": "issues-fixed"
     },
     "erdos-629": {
@@ -10927,9 +10931,12 @@
     },
     "yang-mills": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 6,
-      "lastAudited": "2026-04-03T03:08:27Z",
-      "result": "issues-fixed"
+      "auditCount": 7,
+      "lastAudited": "2026-04-03T09:06:15Z",
+      "result": "issues-fixed",
+      "issues": [
+        "sorry mismatch corrected in meta.json"
+      ]
     },
     "yang-mills-2d": {
       "auditCount": 3,

--- a/src/data/proofs/dirichlets-theorem-oq-03/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "dirichlets-theorem-oq-03",
   "title": "Best Constant in Linnik's Theorem for Primes in Arithmetic Progressions",
   "slug": "dirichlets-theorem-oq-03",
-  "description": "Formalizes the Linnik constant L: the best exponent such that the least prime p ≡ a (mod q) satisfies p ≤ c·q^L. Current best: L ≤ 5 (Xylouris 2011). Conjectured: L = 1.",
+  "description": "Formalizes the Linnik constant L: the best exponent such that the least prime p \u2261 a (mod q) satisfies p \u2264 c\u00b7q^L. Current best: L \u2264 5 (Xylouris 2011). Conjectured: L = 1.",
   "meta": {
     "author": "Linnik (1944); Xylouris (2011)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Linnik%27s_theorem",
@@ -18,32 +18,34 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "axiomCount": 2,
     "lineCount": 139,
     "theoremCount": 8,
-    "assumptions": "2 axioms: linnik_theorem (existence of c,L) and xylouris_bound (5 ∈ admissibleExponents). 3 sorries: two in leastPrimeInAP (existence of prime in AP — requires Dirichlet's theorem from parent) and linnikConstant_pos (lower bound argument).",
-    "historicalContext": "Dirichlet proved in 1837 that there are infinitely many primes p ≡ a (mod q) for any coprime pair (a, q). The *quantitative* question — how large is the *first* such prime p(a, q)? — was answered by Linnik in 1944: p(a, q) ≤ c · q^L for absolute constants c and L. This L is the 'Linnik constant'. The history of bounding L spans decades: Pan Cheng-tung (1957) gave L ≤ 10000, Elliott-Halberstam (1966) reduced it to L ≤ 40, then Jutila (L ≤ 20), Chen (L ≤ 13.5), Wang (L ≤ 8), Heath-Brown (L ≤ 5.5, 1992), and finally Xylouris (L ≤ 5, 2011). Under the Generalized Riemann Hypothesis, L ≤ 2 + ε for any ε > 0. The unconditional conjecture is L = 1 + ε, or equivalently, linnikConstant = 1.",
-    "problemStatement": "For coprime integers a, q with q ≥ 1, let p(a, q) denote the least prime p ≡ a (mod q).\n\n**Linnik's theorem** (1944): There exist absolute constants c > 0 and L > 0 such that\n$$p(a,q) \\leq c \\cdot q^L$$\nfor all coprime pairs (a, q).\n\nThe **Linnik constant** is:\n$$L^* = \\inf\\{ L > 0 : \\text{Linnik's theorem holds with exponent } L \\}.$$\n\n**Currently known**: 1 ≤ L* ≤ 5. Best unconditional bound: L* ≤ 5 (Xylouris 2011). Under GRH: L* ≤ 2 + ε. **Conjectured**: L* = 1.",
-    "proofStrategy": "The formalization defines `leastPrimeInAP` via `Nat.find` (with sorry for the existence of a prime in each AP — this follows from Dirichlet's theorem, the parent entry). The `admissibleExponents` set collects all valid exponents, and `linnikConstant` is their infimum. Key proofs: (1) `heathBrown_bound` derives L ≤ 5.5 from Xylouris's L ≤ 5 by monotonicity of the bound in L; (2) `linnikConstant_le_5` follows from csInf_le applied to xylouris_bound; (3) `optimal_implies_le_one` uses a contradiction argument with δ = (L*-1)/2 — if L*>1 then 1+δ = (L*+1)/2 < L* would be admissible, contradicting L* being the infimum.",
+    "assumptions": "2 axioms: linnik_theorem (existence of c,L) and xylouris_bound (5 \u2208 admissibleExponents). 3 sorries: two in leastPrimeInAP (existence of prime in AP \u2014 requires Dirichlet's theorem from parent) and linnikConstant_pos (lower bound argument).",
+    "historicalContext": "Dirichlet proved in 1837 that there are infinitely many primes p \u2261 a (mod q) for any coprime pair (a, q). The *quantitative* question \u2014 how large is the *first* such prime p(a, q)? \u2014 was answered by Linnik in 1944: p(a, q) \u2264 c \u00b7 q^L for absolute constants c and L. This L is the 'Linnik constant'. The history of bounding L spans decades: Pan Cheng-tung (1957) gave L \u2264 10000, Elliott-Halberstam (1966) reduced it to L \u2264 40, then Jutila (L \u2264 20), Chen (L \u2264 13.5), Wang (L \u2264 8), Heath-Brown (L \u2264 5.5, 1992), and finally Xylouris (L \u2264 5, 2011). Under the Generalized Riemann Hypothesis, L \u2264 2 + \u03b5 for any \u03b5 > 0. The unconditional conjecture is L = 1 + \u03b5, or equivalently, linnikConstant = 1.",
+    "problemStatement": "For coprime integers a, q with q \u2265 1, let p(a, q) denote the least prime p \u2261 a (mod q).\n\n**Linnik's theorem** (1944): There exist absolute constants c > 0 and L > 0 such that\n$$p(a,q) \\leq c \\cdot q^L$$\nfor all coprime pairs (a, q).\n\nThe **Linnik constant** is:\n$$L^* = \\inf\\{ L > 0 : \\text{Linnik's theorem holds with exponent } L \\}.$$\n\n**Currently known**: 1 \u2264 L* \u2264 5. Best unconditional bound: L* \u2264 5 (Xylouris 2011). Under GRH: L* \u2264 2 + \u03b5. **Conjectured**: L* = 1.",
+    "proofStrategy": "The formalization defines `leastPrimeInAP` via `Nat.find` (with sorry for the existence of a prime in each AP \u2014 this follows from Dirichlet's theorem, the parent entry). The `admissibleExponents` set collects all valid exponents, and `linnikConstant` is their infimum. Key proofs: (1) `heathBrown_bound` derives L \u2264 5.5 from Xylouris's L \u2264 5 by monotonicity of the bound in L; (2) `linnikConstant_le_5` follows from csInf_le applied to xylouris_bound; (3) `optimal_implies_le_one` uses a contradiction argument with \u03b4 = (L*-1)/2 \u2014 if L*>1 then 1+\u03b4 = (L*+1)/2 < L* would be admissible, contradicting L* being the infimum.",
     "keyInsights": [
-      "The `leastPrimeInAP` definition has two sorry holes for the existence of a prime p ≡ a (mod q) — this is precisely Dirichlet's theorem. Filling these sorries requires the parent proof (infinitely many primes in AP with gcd(a,q)=1).",
-      "Admissible exponents form a ray: if L is admissible (p(a,q) ≤ c·q^L), then any L' > L is also admissible with the same c (since q^L ≤ q^{L'} for q ≥ 1). The Lean proof of `heathBrown_bound` exploits this via `Real.rpow_le_rpow`.",
-      "The `optimal_implies_le_one` proof is the highlight: assuming optimalLinnikConjecture (every 1+ε is admissible) and L* > 1, choose δ = (L*-1)/2. Then 1+δ ∈ admissibleExponents and csInf_le gives L* ≤ 1+δ < L*, a contradiction.",
-      "GRH would give L ≤ 2+ε via the conditional bound p(a,q) ≤ c·(φ(q)·log q)². The formalization defines `GRHImpliesSmallLinnik` as a Prop but does not prove it, acknowledging the conditional nature.",
-      "The linnikConstant_pos sorry asks for a lower bound argument: p(1,q) ≥ q+1 for large q shows L* ≥ 1. This would follow from Bertrand's postulate — the least prime > q has order roughly q."
+      "The `leastPrimeInAP` definition has two sorry holes for the existence of a prime p \u2261 a (mod q) \u2014 this is precisely Dirichlet's theorem. Filling these sorries requires the parent proof (infinitely many primes in AP with gcd(a,q)=1).",
+      "Admissible exponents form a ray: if L is admissible (p(a,q) \u2264 c\u00b7q^L), then any L' > L is also admissible with the same c (since q^L \u2264 q^{L'} for q \u2265 1). The Lean proof of `heathBrown_bound` exploits this via `Real.rpow_le_rpow`.",
+      "The `optimal_implies_le_one` proof is the highlight: assuming optimalLinnikConjecture (every 1+\u03b5 is admissible) and L* > 1, choose \u03b4 = (L*-1)/2. Then 1+\u03b4 \u2208 admissibleExponents and csInf_le gives L* \u2264 1+\u03b4 < L*, a contradiction.",
+      "GRH would give L \u2264 2+\u03b5 via the conditional bound p(a,q) \u2264 c\u00b7(\u03c6(q)\u00b7log q)\u00b2. The formalization defines `GRHImpliesSmallLinnik` as a Prop but does not prove it, acknowledging the conditional nature.",
+      "The linnikConstant_pos sorry asks for a lower bound argument: p(1,q) \u2265 q+1 for large q shows L* \u2265 1. This would follow from Bertrand's postulate \u2014 the least prime > q has order roughly q."
     ],
     "mathlib_version": "4.29.0",
     "originalContributions": [
       "Infimum-based definition of the Linnik constant via sInf on admissibleExponents",
-      "Monotonicity derivation: Heath-Brown L≤5.5 from Xylouris L≤5",
-      "Conditional proof: optimal conjecture implies linnikConstant ≤ 1 via csInf contradiction",
+      "Monotonicity derivation: Heath-Brown L\u22645.5 from Xylouris L\u22645",
+      "Conditional proof: optimal conjecture implies linnikConstant \u2264 1 via csInf contradiction",
       "GRH and optimal conjecture formalized as Prop definitions",
       "openQuestion stated as linnikConstant = 1"
     ]
   },
   "leanFile": {
-    "imports": ["Mathlib"],
+    "imports": [
+      "Mathlib"
+    ],
     "namespace": "LinnikConstant",
     "lineCount": 139,
     "axiomCount": 2,
@@ -58,22 +60,22 @@
       {
         "name": "heathBrown_bound",
         "status": "proved",
-        "description": "5.5 ∈ admissibleExponents, derived from xylouris_bound by monotonicity"
+        "description": "5.5 \u2208 admissibleExponents, derived from xylouris_bound by monotonicity"
       },
       {
         "name": "linnikConstant_le_5",
         "status": "proved",
-        "description": "linnikConstant ≤ 5, from csInf_le applied to xylouris_bound"
+        "description": "linnikConstant \u2264 5, from csInf_le applied to xylouris_bound"
       },
       {
         "name": "optimal_implies_le_one",
         "status": "proved",
-        "description": "optimalLinnikConjecture → linnikConstant ≤ 1, by contradiction with δ = (L*-1)/2"
+        "description": "optimalLinnikConjecture \u2192 linnikConstant \u2264 1, by contradiction with \u03b4 = (L*-1)/2"
       },
       {
         "name": "linnikConstant_pos",
         "status": "sorry",
-        "description": "linnikConstant ≥ 1 — requires Bertrand-style lower bound on p(a,q)"
+        "description": "linnikConstant \u2265 1 \u2014 requires Bertrand-style lower bound on p(a,q)"
       }
     ]
   },
@@ -81,28 +83,28 @@
     {
       "id": "least-prime-definition",
       "title": "The Least Prime in an Arithmetic Progression",
-      "content": "The function `leastPrimeInAP a q` is defined via `Nat.find` applied to the existence of a prime p ≡ a (mod q). The two sorry holes supply the existence witness, which requires Dirichlet's theorem (the parent entry). Once proved, `leastPrimeInAP a q` is noncomputable but well-defined: it returns the smallest natural number that is prime and congruent to a modulo q."
+      "content": "The function `leastPrimeInAP a q` is defined via `Nat.find` applied to the existence of a prime p \u2261 a (mod q). The two sorry holes supply the existence witness, which requires Dirichlet's theorem (the parent entry). Once proved, `leastPrimeInAP a q` is noncomputable but well-defined: it returns the smallest natural number that is prime and congruent to a modulo q."
     },
     {
       "id": "linnik-constant-definition",
       "title": "The Linnik Constant as an Infimum",
-      "content": "The `admissibleExponents` set collects all L > 0 for which some c > 0 makes Linnik's bound hold. The `linnikConstant` is defined as `sInf admissibleExponents`. By `linnik_theorem` (axiom), this set is nonempty, so the infimum is the genuine best possible exponent. The range 1 ≤ L* ≤ 5 is established: the upper bound from `xylouris_bound`, the lower bound via a sorry."
+      "content": "The `admissibleExponents` set collects all L > 0 for which some c > 0 makes Linnik's bound hold. The `linnikConstant` is defined as `sInf admissibleExponents`. By `linnik_theorem` (axiom), this set is nonempty, so the infimum is the genuine best possible exponent. The range 1 \u2264 L* \u2264 5 is established: the upper bound from `xylouris_bound`, the lower bound via a sorry."
     },
     {
       "id": "monotonicity-derivation",
       "title": "Heath-Brown from Xylouris by Monotonicity",
-      "content": "The proof of `heathBrown_bound` (L ≤ 5.5) shows: if L = 5 is admissible then L = 5.5 is too, since q^5 ≤ q^{5.5} for q ≥ 1. This uses `Real.rpow_le_rpow` and `mul_le_mul_of_nonneg_left`. More generally, admissible exponents form a right-closed ray [L*, ∞) — the infimum L* is the only interesting value."
+      "content": "The proof of `heathBrown_bound` (L \u2264 5.5) shows: if L = 5 is admissible then L = 5.5 is too, since q^5 \u2264 q^{5.5} for q \u2265 1. This uses `Real.rpow_le_rpow` and `mul_le_mul_of_nonneg_left`. More generally, admissible exponents form a right-closed ray [L*, \u221e) \u2014 the infimum L* is the only interesting value."
     },
     {
       "id": "optimal-conjecture-proof",
-      "title": "Conditional: Optimal Conjecture Implies L* ≤ 1",
-      "content": "The most interesting proved theorem is `optimal_implies_le_one`. Assume `optimalLinnikConjecture`: every 1+ε is admissible. If L* > 1, set δ = (L*-1)/2 > 0. Then 1+δ = (L*+1)/2 < L* is admissible by hypothesis. But `csInf_le` applied to xylouris_bound (which gives a lower bound on the set) yields L* ≤ 1+δ < L*, a contradiction. This is a clean example of using the infimum characterization in Lean."
+      "title": "Conditional: Optimal Conjecture Implies L* \u2264 1",
+      "content": "The most interesting proved theorem is `optimal_implies_le_one`. Assume `optimalLinnikConjecture`: every 1+\u03b5 is admissible. If L* > 1, set \u03b4 = (L*-1)/2 > 0. Then 1+\u03b4 = (L*+1)/2 < L* is admissible by hypothesis. But `csInf_le` applied to xylouris_bound (which gives a lower bound on the set) yields L* \u2264 1+\u03b4 < L*, a contradiction. This is a clean example of using the infimum characterization in Lean."
     },
     {
       "id": "open-question",
       "title": "The Open Question: L* = 1",
-      "content": "The `openQuestion` is defined as `linnikConstant = 1`. This is equivalent to: for every ε > 0, there exist p(a,q) ≤ c·q^{1+ε} for all coprime (a,q). The current unconditional best is L* ≤ 5 (Xylouris 2011). Under GRH, L* ≤ 2+ε. The full conjecture L* = 1 is believed to follow from a suitable form of the Generalized Riemann Hypothesis combined with zero-free region estimates for Dirichlet L-functions."
+      "content": "The `openQuestion` is defined as `linnikConstant = 1`. This is equivalent to: for every \u03b5 > 0, there exist p(a,q) \u2264 c\u00b7q^{1+\u03b5} for all coprime (a,q). The current unconditional best is L* \u2264 5 (Xylouris 2011). Under GRH, L* \u2264 2+\u03b5. The full conjecture L* = 1 is believed to follow from a suitable form of the Generalized Riemann Hypothesis combined with zero-free region estimates for Dirichlet L-functions."
     }
   ],
-  "conclusion": "This formalization captures the Linnik constant framework: the infimum definition of L*, the known upper bound L* ≤ 5 from Xylouris, the monotonicity-based derivation of Heath-Brown's L ≤ 5.5, and a conditional proof that the optimal conjecture implies L* ≤ 1. The main gaps are: (1) sorries in leastPrimeInAP (needs Dirichlet's theorem); (2) linnikConstant_pos sorry (needs Bertrand-type lower bound); (3) GRHImpliesSmallLinnik is stated but not proved. The open question L* = 1 remains one of the central problems in analytic number theory."
+  "conclusion": "This formalization captures the Linnik constant framework: the infimum definition of L*, the known upper bound L* \u2264 5 from Xylouris, the monotonicity-based derivation of Heath-Brown's L \u2264 5.5, and a conditional proof that the optimal conjecture implies L* \u2264 1. The main gaps are: (1) sorries in leastPrimeInAP (needs Dirichlet's theorem); (2) linnikConstant_pos sorry (needs Bertrand-type lower bound); (3) GRHImpliesSmallLinnik is stated but not proved. The open question L* = 1 remains one of the central problems in analytic number theory."
 }

--- a/src/data/proofs/erdos-138/meta.json
+++ b/src/data/proofs/erdos-138/meta.json
@@ -2,9 +2,9 @@
   "id": "erdos-138",
   "title": "Van der Waerden Numbers Growth Rate",
   "slug": "erdos-138",
-  "description": "Erdős Problem #138 asks whether W(k)^{1/k} → ∞, where W(k) is the van der Waerden number - the minimum N such that any 2-coloring of {1,...,N} contains a monochromatic k-term arithmetic progression. This remains OPEN with a $500 prize.",
+  "description": "Erd\u0151s Problem #138 asks whether W(k)^{1/k} \u2192 \u221e, where W(k) is the van der Waerden number - the minimum N such that any 2-coloring of {1,...,N} contains a monochromatic k-term arithmetic progression. This remains OPEN with a $500 prize.",
   "meta": {
-    "author": "Erdős and Hajnal",
+    "author": "Erd\u0151s and Hajnal",
     "sourceUrl": "https://erdosproblems.com/138",
     "date": "1980",
     "status": "axiomatized",
@@ -32,12 +32,12 @@
     "originalContributions": [
       "Formalization of van der Waerden numbers via GuaranteeSet and sInf",
       "Axiomatized Berlekamp, Gowers, and Kozik-Shabanov bounds",
-      "Filter.Tendsto formulation of Erdős's growth rate conjecture",
+      "Filter.Tendsto formulation of Erd\u0151s's growth rate conjecture",
       "Hierarchy of related growth rate conjectures (quotient, difference, exponential)",
       "Proof schema: main conjecture implies ExponentialDiverges"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 5,
     "erdosNumber": 138,
     "erdosUrl": "https://erdosproblems.com/138",
     "erdosProblemStatus": "open",
@@ -48,15 +48,15 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Van der Waerden proved his theorem in 1927, answering a conjecture of Baudet. The original proof gave Ackermann-type bounds on W(k). Berlekamp (1968) gave the first strong lower bounds using finite field constructions: coloring integers by discrete logarithm mod p avoids long APs. Shelah (1988) obtained the first primitive recursive upper bound, and Gowers (2001) dramatically improved it to tower-of-height-5 using his uniformity norms, winning a Fields Medal partly for this work. Kozik and Shabanov (2016) established the current best general lower bound W(k) ≫ 2^k via the Lovász Local Lemma. Erdős posed this problem in 1980 with a $500 prize, asking whether W(k) grows faster than any exponential — the vast gap between known bounds remains one of the central open problems in Ramsey theory.",
-    "problemStatement": "Does W(k)^{1/k} → ∞ as k → ∞? Equivalently, do the van der Waerden numbers grow faster than any exponential c^k?",
-    "text": "Erdős Problem #138 asks whether W(k)^{1/k} → ∞, where W(k) is the van der Waerden number - the minimum N such that any 2-coloring of {1,...,N} contains a monochromatic k-term arithmetic progression. This remains OPEN with a $500 prize.",
-    "proofStrategy": "The formalization defines van der Waerden numbers using Mathlib's Finset infrastructure. Known bounds are axiomatized: Berlekamp's lower bound W(p+1) ≥ p·2^p for primes p, Gowers' tower-type upper bound from his Szemerédi proof, and the Kozik-Shabanov general lower bound W(k) ≫ 2^k. The main conjecture is stated using Filter.Tendsto. Related questions from Erdős (1980-1981) about W(k+1)/W(k), W(k+1)-W(k), and W(k)/2^k are also formalized.",
+    "historicalContext": "Van der Waerden proved his theorem in 1927, answering a conjecture of Baudet. The original proof gave Ackermann-type bounds on W(k). Berlekamp (1968) gave the first strong lower bounds using finite field constructions: coloring integers by discrete logarithm mod p avoids long APs. Shelah (1988) obtained the first primitive recursive upper bound, and Gowers (2001) dramatically improved it to tower-of-height-5 using his uniformity norms, winning a Fields Medal partly for this work. Kozik and Shabanov (2016) established the current best general lower bound W(k) \u226b 2^k via the Lov\u00e1sz Local Lemma. Erd\u0151s posed this problem in 1980 with a $500 prize, asking whether W(k) grows faster than any exponential \u2014 the vast gap between known bounds remains one of the central open problems in Ramsey theory.",
+    "problemStatement": "Does W(k)^{1/k} \u2192 \u221e as k \u2192 \u221e? Equivalently, do the van der Waerden numbers grow faster than any exponential c^k?",
+    "text": "Erd\u0151s Problem #138 asks whether W(k)^{1/k} \u2192 \u221e, where W(k) is the van der Waerden number - the minimum N such that any 2-coloring of {1,...,N} contains a monochromatic k-term arithmetic progression. This remains OPEN with a $500 prize.",
+    "proofStrategy": "The formalization defines van der Waerden numbers using Mathlib's Finset infrastructure. Known bounds are axiomatized: Berlekamp's lower bound W(p+1) \u2265 p\u00b72^p for primes p, Gowers' tower-type upper bound from his Szemer\u00e9di proof, and the Kozik-Shabanov general lower bound W(k) \u226b 2^k. The main conjecture is stated using Filter.Tendsto. Related questions from Erd\u0151s (1980-1981) about W(k+1)/W(k), W(k+1)-W(k), and W(k)/2^k are also formalized.",
     "keyInsights": [
       "The gap between exponential lower bounds and tower-type upper bounds remains vast",
       "Berlekamp's 1968 construction using finite field techniques gives strong lower bounds at prime values",
-      "Gowers' 2001 analytic proof of Szemerédi's theorem yields the current best upper bound",
-      "The main conjecture W(k)^{1/k} → ∞ would imply W(k)/2^k → ∞ but is strictly stronger",
+      "Gowers' 2001 analytic proof of Szemer\u00e9di's theorem yields the current best upper bound",
+      "The main conjecture W(k)^{1/k} \u2192 \u221e would imply W(k)/2^k \u2192 \u221e but is strictly stronger",
       "The formalization uses Filter.Tendsto to express divergence, which is the standard Mathlib idiom and enables compositional limit arguments"
     ],
     "prerequisites": [
@@ -95,7 +95,7 @@
       "title": "The Main Conjecture",
       "startLine": 109,
       "endLine": 119,
-      "summary": "Erdős Problem #138: Does W(k)^{1/k} → ∞?",
+      "summary": "Erd\u0151s Problem #138: Does W(k)^{1/k} \u2192 \u221e?",
       "mathContext": "$\\lim_{k \\to \\infty} W(k)^{1/k} = \\infty$ via `Filter.Tendsto atTop atTop`"
     },
     {
@@ -103,18 +103,18 @@
       "title": "Related Questions and Implications",
       "startLine": 120,
       "endLine": 176,
-      "summary": "Additional questions from Erdős (1980-1981) about growth rates, plus the implication chain: main conjecture → ExponentialDiverges",
+      "summary": "Additional questions from Erd\u0151s (1980-1981) about growth rates, plus the implication chain: main conjecture \u2192 ExponentialDiverges",
       "mathContext": "$W(k)^{1/k} \\to \\infty \\implies W(k)/2^k \\to \\infty \\implies W(k+1)/W(k) \\to \\infty$"
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures the structure of Erdős Problem #138, an OPEN problem with $500 prize. The van der Waerden numbers W(k) measure the threshold for guaranteed monochromatic arithmetic progressions. Known bounds leave a vast gap between W(k) ≫ 2^k and tower-type upper bounds. The main conjecture that W(k)^{1/k} → ∞ remains unresolved.",
-    "implications": "A proof would establish that van der Waerden numbers grow faster than any exponential, providing fundamental insight into Ramsey-theoretic thresholds. A disproof would show W(k) ≤ c^k for some c, constraining the growth rate.",
+    "summary": "This formalization captures the structure of Erd\u0151s Problem #138, an OPEN problem with $500 prize. The van der Waerden numbers W(k) measure the threshold for guaranteed monochromatic arithmetic progressions. Known bounds leave a vast gap between W(k) \u226b 2^k and tower-type upper bounds. The main conjecture that W(k)^{1/k} \u2192 \u221e remains unresolved.",
+    "implications": "A proof would establish that van der Waerden numbers grow faster than any exponential, providing fundamental insight into Ramsey-theoretic thresholds. A disproof would show W(k) \u2264 c^k for some c, constraining the growth rate.",
     "openQuestions": [
-      "Does W(k)^{1/k} → ∞? (Main conjecture, $500 prize)",
-      "Does W(k+1)/W(k) → ∞?",
-      "Does W(k+1) - W(k) → ∞?",
-      "Does W(k)/2^k → ∞?",
+      "Does W(k)^{1/k} \u2192 \u221e? (Main conjecture, $500 prize)",
+      "Does W(k+1)/W(k) \u2192 \u221e?",
+      "Does W(k+1) - W(k) \u2192 \u221e?",
+      "Does W(k)/2^k \u2192 \u221e?",
       "Can the tower bound be reduced to a simpler function?"
     ]
   },
@@ -146,11 +146,11 @@
       "title": "A construction for partitions which avoid long arithmetic progressions",
       "year": "1968",
       "venue": "Canadian Mathematical Bulletin",
-      "note": "Finite field construction giving W(p+1) ≥ p·2^p for primes p"
+      "note": "Finite field construction giving W(p+1) \u2265 p\u00b72^p for primes p"
     },
     {
       "authors": "W. Timothy Gowers",
-      "title": "A new proof of Szemerédi's theorem",
+      "title": "A new proof of Szemer\u00e9di's theorem",
       "year": "2001",
       "venue": "Geometric and Functional Analysis",
       "note": "Analytic proof yielding tower-of-height-5 upper bound"
@@ -160,24 +160,24 @@
       "title": "Improved algorithms for colorings of simple hypergraphs and applications",
       "year": "2016",
       "venue": "Journal of Combinatorial Theory, Series B",
-      "note": "Best general lower bound W(k) ≫ 2^k via Lovász Local Lemma"
+      "note": "Best general lower bound W(k) \u226b 2^k via Lov\u00e1sz Local Lemma"
     }
   ],
   "crossReferences": [
     {
       "targetId": "erdos-176",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: arithmetic-progressions, combinatorics, ramsey-theory, van-der-waerden"
+      "description": "Related Erd\u0151s problem sharing themes: arithmetic-progressions, combinatorics, ramsey-theory, van-der-waerden"
     },
     {
       "targetId": "erdos-645",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: arithmetic-progressions, combinatorics, ramsey-theory, van-der-waerden"
+      "description": "Related Erd\u0151s problem sharing themes: arithmetic-progressions, combinatorics, ramsey-theory, van-der-waerden"
     },
     {
       "targetId": "erdos-966",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: arithmetic-progressions, combinatorics, ramsey-theory, van-der-waerden"
+      "description": "Related Erd\u0151s problem sharing themes: arithmetic-progressions, combinatorics, ramsey-theory, van-der-waerden"
     }
   ]
 }

--- a/src/data/proofs/erdos-157/meta.json
+++ b/src/data/proofs/erdos-157/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-157",
-  "title": "Erdős Problem #157: Infinite Sidon Set as Asymptotic Basis",
+  "title": "Erd\u0151s Problem #157: Infinite Sidon Set as Asymptotic Basis",
   "slug": "erdos-157",
   "description": "Does there exist an infinite Sidon set which is an asymptotic basis of order 3? YES (Pilatte 2023). Two theorems verified: sidon_iff_sidon_alt and powers_of_two_sidon.",
   "meta": {
-    "author": "Pilatte (2023), Erdős-Turán (1941)",
+    "author": "Pilatte (2023), Erd\u0151s-Tur\u00e1n (1941)",
     "sourceUrl": "https://erdosproblems.com/157",
     "date": "2023",
     "status": "axiomatized",
@@ -18,7 +18,7 @@
       "density"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "erdosNumber": 157,
     "erdosUrl": "https://erdosproblems.com/157",
     "erdosProblemStatus": "solved",
@@ -47,14 +47,14 @@
       }
     ],
     "originalContributions": [
-      "Definition of IsSidon (B₂ sequence property)",
+      "Definition of IsSidon (B\u2082 sequence property)",
       "Alternative characterization IsSidonAlt via sumset cardinality",
       "Verified theorem: sidon_iff_sidon_alt (equivalence of definitions)",
       "Definition of SumsetK for k-fold sums",
       "Definition of IsAsymptoticBasis for asymptotic bases",
       "Erdos157Conjecture formalization",
       "Pilatte's existence theorem statement",
-      "Sidon density upper bound (Erdős-Turán)",
+      "Sidon density upper bound (Erd\u0151s-Tur\u00e1n)",
       "Basis density lower bound",
       "Verified theorem: powers_of_two_sidon"
     ],
@@ -63,13 +63,13 @@
     "assumptions": "2 axiom(s) and 2 sorry(s). See the Lean source for details."
   },
   "overview": {
-    "historicalContext": "Sidon sets (B$_2$ sequences) — sets where all pairwise sums are distinct — were introduced by Simon Sidon in correspondence with Erdős in the 1930s. Erdős and Pál Turán proved in 1941 that a Sidon subset of $\\{1, \\ldots, N\\}$ has at most $(1+o(1))\\sqrt{N}$ elements, establishing their fundamental sparsity.\n\nAsymptotic bases of order $k$ — sets $A$ where every sufficiently large integer is a sum of at most $k$ elements of $A$ — require density at least $N^{1/k}$ by a counting argument. The tension between Sidon sparsity ($\\leq N^{1/2}$) and basis density ($\\geq N^{1/k}$) creates a natural threshold: coexistence requires $1/k \\leq 1/2$, i.e., $k \\geq 2$. But $k = 2$ is exactly the boundary and fails for subtle arithmetic reasons.\n\nErdős conjectured that order 3 should work, and this was open for decades despite partial results by Deshouillers and Plagne (2003) on finite Sidon sets. Cédric Pilatte (Oxford) settled the conjecture affirmatively in 2023 using a probabilistic construction, applying the Lovász Local Lemma and a careful densification argument. His proof is non-explicit: it shows such sets exist without constructing one.\n\nThis formalization includes two fully verified theorems: the equivalence of two Sidon set definitions, and the proof that $\\{2^k : k \\in \\mathbb{N}\\}$ forms a Sidon set (since binary representations are unique).",
-    "problemStatement": "**Erdős Problem #157 (SOLVED)**: Does there exist an infinite Sidon set which is an asymptotic basis of order 3?\n\n**Answer**: YES (Pilatte 2023)\n\n**Definitions**:\n- **Sidon set**: A ⊆ ℕ where a + b = c + d (a ≤ b, c ≤ d) implies (a,b) = (c,d)\n- **Asymptotic basis of order k**: ∃ N₀, ∀ n ≥ N₀, n is a sum of ≤ k elements of A\n\n**Key insight**: Sidon sets grow like √N = N^{1/2}. Order-k bases need N^{1/k} density. Since 1/3 < 1/2, order 3 is feasible while order 2 is not.",
+    "historicalContext": "Sidon sets (B$_2$ sequences) \u2014 sets where all pairwise sums are distinct \u2014 were introduced by Simon Sidon in correspondence with Erd\u0151s in the 1930s. Erd\u0151s and P\u00e1l Tur\u00e1n proved in 1941 that a Sidon subset of $\\{1, \\ldots, N\\}$ has at most $(1+o(1))\\sqrt{N}$ elements, establishing their fundamental sparsity.\n\nAsymptotic bases of order $k$ \u2014 sets $A$ where every sufficiently large integer is a sum of at most $k$ elements of $A$ \u2014 require density at least $N^{1/k}$ by a counting argument. The tension between Sidon sparsity ($\\leq N^{1/2}$) and basis density ($\\geq N^{1/k}$) creates a natural threshold: coexistence requires $1/k \\leq 1/2$, i.e., $k \\geq 2$. But $k = 2$ is exactly the boundary and fails for subtle arithmetic reasons.\n\nErd\u0151s conjectured that order 3 should work, and this was open for decades despite partial results by Deshouillers and Plagne (2003) on finite Sidon sets. C\u00e9dric Pilatte (Oxford) settled the conjecture affirmatively in 2023 using a probabilistic construction, applying the Lov\u00e1sz Local Lemma and a careful densification argument. His proof is non-explicit: it shows such sets exist without constructing one.\n\nThis formalization includes two fully verified theorems: the equivalence of two Sidon set definitions, and the proof that $\\{2^k : k \\in \\mathbb{N}\\}$ forms a Sidon set (since binary representations are unique).",
+    "problemStatement": "**Erd\u0151s Problem #157 (SOLVED)**: Does there exist an infinite Sidon set which is an asymptotic basis of order 3?\n\n**Answer**: YES (Pilatte 2023)\n\n**Definitions**:\n- **Sidon set**: A \u2286 \u2115 where a + b = c + d (a \u2264 b, c \u2264 d) implies (a,b) = (c,d)\n- **Asymptotic basis of order k**: \u2203 N\u2080, \u2200 n \u2265 N\u2080, n is a sum of \u2264 k elements of A\n\n**Key insight**: Sidon sets grow like \u221aN = N^{1/2}. Order-k bases need N^{1/k} density. Since 1/3 < 1/2, order 3 is feasible while order 2 is not.",
     "text": "Does there exist an infinite Sidon set which is an asymptotic basis of order 3? YES (Pilatte 2023). Two theorems verified: sidon_iff_sidon_alt and powers_of_two_sidon.",
-    "proofStrategy": "The formalization captures the problem structure:\n\n1. **Sidon definitions**: IsSidon (direct) and IsSidonAlt (via cardinality)\n2. **Verified equivalence**: sidon_iff_sidon_alt proved using Set.ncard\n3. **Basis definitions**: SumsetK and IsAsymptoticBasis\n4. **Counting bounds**: Sidon upper bound (√N), basis lower bound (N^{1/k})\n5. **Pilatte's theorem**: Existence statement (sorry - probabilistic construction)\n6. **Verified example**: powers_of_two_sidon shows {2^k} is Sidon",
+    "proofStrategy": "The formalization captures the problem structure:\n\n1. **Sidon definitions**: IsSidon (direct) and IsSidonAlt (via cardinality)\n2. **Verified equivalence**: sidon_iff_sidon_alt proved using Set.ncard\n3. **Basis definitions**: SumsetK and IsAsymptoticBasis\n4. **Counting bounds**: Sidon upper bound (\u221aN), basis lower bound (N^{1/k})\n5. **Pilatte's theorem**: Existence statement (sorry - probabilistic construction)\n6. **Verified example**: powers_of_two_sidon shows {2^k} is Sidon",
     "keyInsights": [
       "**Order 3 is the boundary**: Order 2 impossible (density too low), order 3 achievable (Pilatte's construction).",
-      "**Density arithmetic**: Sidon ≤ √N = N^{1/2}, basis needs ≥ N^{1/k}. Compatible iff k ≥ 3.",
+      "**Density arithmetic**: Sidon \u2264 \u221aN = N^{1/2}, basis needs \u2265 N^{1/k}. Compatible iff k \u2265 3.",
       "**Powers of 2 example**: The canonical Sidon set {1, 2, 4, 8, ...} demonstrates the definition (verified).",
       "**Probabilistic proof**: Pilatte's construction is non-explicit, using the probabilistic method.",
       "**Bug discovery**: The original example set was NOT Sidon - formal verification caught this error."
@@ -119,8 +119,8 @@
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erdős Problem #157 on infinite Sidon sets as asymptotic bases. The answer is YES for order 3 (Pilatte 2023), while order 2 is impossible due to density constraints. The formalization includes two verified theorems: the equivalence of Sidon definitions, and the proof that powers of 2 form a Sidon set.",
-    "implications": "This result clarifies the boundary between sparse sets with unique-sum structure and dense sets capable of representing all integers. The interplay between Sidon sparsity (√N) and basis density (N^{1/k}) is fundamental to understanding additive structure.",
+    "summary": "We formalize Erd\u0151s Problem #157 on infinite Sidon sets as asymptotic bases. The answer is YES for order 3 (Pilatte 2023), while order 2 is impossible due to density constraints. The formalization includes two verified theorems: the equivalence of Sidon definitions, and the proof that powers of 2 form a Sidon set.",
+    "implications": "This result clarifies the boundary between sparse sets with unique-sum structure and dense sets capable of representing all integers. The interplay between Sidon sparsity (\u221aN) and basis density (N^{1/k}) is fundamental to understanding additive structure.",
     "openQuestions": [
       "Can an explicit infinite Sidon set that is an order-3 basis be constructed?",
       "What is the smallest order k such that every infinite Sidon set is NOT an order-k basis?",
@@ -130,22 +130,22 @@
   "crossReferences": [
     {
       "relationship": "related",
-      "description": "Erdős #156 (Minimum Size of Maximal Sidon Sets) — both problems study Sidon sets; #156 asks about maximality while #157 asks about basis properties",
+      "description": "Erd\u0151s #156 (Minimum Size of Maximal Sidon Sets) \u2014 both problems study Sidon sets; #156 asks about maximality while #157 asks about basis properties",
       "targetId": "erdos-156"
     },
     {
       "relationship": "related",
-      "description": "Erdős #158 (B₂[g] Sets) — generalizes Sidon sets (B₂ = B₂[1]) to allow g representations per sum; the density constraints change as g grows",
+      "description": "Erd\u0151s #158 (B\u2082[g] Sets) \u2014 generalizes Sidon sets (B\u2082 = B\u2082[1]) to allow g representations per sum; the density constraints change as g grows",
       "targetId": "erdos-158"
     },
     {
       "relationship": "related",
-      "description": "Erdős #1 (Distinct Subset Sums) — another problem about additive structure of sets, exploring how sums interact with set density",
+      "description": "Erd\u0151s #1 (Distinct Subset Sums) \u2014 another problem about additive structure of sets, exploring how sums interact with set density",
       "targetId": "erdos-1"
     },
     {
       "relationship": "foundational",
-      "description": "Pilatte's proof uses the probabilistic method (specifically the Lovász Local Lemma) — the alteration method is a key technique in this family of arguments",
+      "description": "Pilatte's proof uses the probabilistic method (specifically the Lov\u00e1sz Local Lemma) \u2014 the alteration method is a key technique in this family of arguments",
       "targetId": "prob-method-alteration"
     }
   ],
@@ -168,8 +168,8 @@
     {
       "key": "ET41b",
       "authors": [
-        "P. Erdős",
-        "P. Turán"
+        "P. Erd\u0151s",
+        "P. Tur\u00e1n"
       ],
       "title": "On a problem of Sidon in additive number theory, and on some related problems",
       "venue": "Journal of the London Mathematical Society",

--- a/src/data/proofs/erdos-392/meta.json
+++ b/src/data/proofs/erdos-392/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-392",
-  "title": "Erdős Problem #392: Optimal Factorization of n!",
+  "title": "Erd\u0151s Problem #392: Optimal Factorization of n!",
   "slug": "erdos-392",
-  "description": "Let A(n) be the minimum number of factors needed to write n! = a₁...aₜ with each aᵢ ≤ n². Then A(n) = n/2 - n/(2 log n) + o(n/log n).",
+  "description": "Let A(n) be the minimum number of factors needed to write n! = a\u2081...a\u209c with each a\u1d62 \u2264 n\u00b2. Then A(n) = n/2 - n/(2 log n) + o(n/log n).",
   "meta": {
     "author": "Cambie (2020s)",
     "sourceUrl": "https://erdosproblems.com/392",
@@ -17,7 +17,7 @@
       "number-theory"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "erdosNumber": 392,
     "erdosUrl": "https://erdosproblems.com/392",
     "erdosProblemStatus": "solved",
@@ -53,7 +53,7 @@
     "originalContributions": [
       "Clean formalization of the optimal factorization problem for n!",
       "Definition of valid factorizations with monotonicity and bound constraints",
-      "Statement of the main asymptotic A(n, n²) = n/2 - n/(2 log n) + o(n/log n)",
+      "Statement of the main asymptotic A(n, n\u00b2) = n/2 - n/(2 log n) + o(n/log n)",
       "Statement of the variant with bound n: A(n, n) = n - n/log n + o(n/log n)",
       "Cambie's implication showing the main result follows from the variant",
       "Connection to Stirling's approximation for the lower bound intuition",
@@ -64,15 +64,15 @@
     "assumptions": "12 axiom(s) and 3 sorries(s). See the Lean source for details."
   },
   "overview": {
-    "historicalContext": "Erdős Problem #392 asks about the most efficient way to express n! as a product of bounded factors. Given the constraint that each factor aᵢ ≤ n², what is the minimum number of factors needed?\n\nThe answer involves a beautiful interplay between Stirling's approximation and factor pairing. Stirling tells us log(n!) ≈ n log n, so if each factor is at most n², contributing at most 2 log n to the logarithm, we need roughly (n log n)/(2 log n) = n/2 factors.\n\nCambie observed that the problem with bound n² can be reduced to the variant with bound n via factor pairing. If a₁...aₜ = n! with each aᵢ ≤ n, define a'ᵢ = a₂ᵢ₋₁ · a₂ᵢ. Then each a'ᵢ ≤ n² and we have roughly t/2 factors. The variant with bound n is solved by a greedy algorithm: use n as often as possible, then n-1, and so on.",
-    "problemStatement": "**Erdős Problem #392**: Let $A(n)$ denote the least value of $t$ such that\n$$n! = a_1 \\cdots a_t$$\nwith $a_1 \\leq \\cdots \\leq a_t \\leq n^2$. Is it true that\n$$A(n) = \\frac{n}{2} - \\frac{n}{2\\log n} + o\\left(\\frac{n}{\\log n}\\right)?$$\n\n**Status**: SOLVED\n\n**Answer**: YES. The formula is correct.\n\n**Variant**: With bound $a_t \\leq n$, we have $A(n) = n - n/\\log n + o(n/\\log n)$.",
-    "text": "Let A(n) be the minimum number of factors needed to write n! = a₁...aₜ with each aᵢ ≤ n². Then A(n) = n/2 - n/(2 log n) + o(n/log n).",
-    "proofStrategy": "Our formalization takes a structured approach:\n\n1. **Define valid factorizations**: A valid factorization of n! into t factors with bound B requires the product to equal n!, the sequence to be monotone increasing, and all factors bounded by B.\n\n2. **Axiomatize the minimum**: A(n, B) is the least t for which a valid factorization exists.\n\n3. **State the main theorem**: The asymptotic formula A(n, n²) = n/2 - n/(2 log n) + o(n/log n).\n\n4. **State the variant**: With bound n, we get A(n, n) = n - n/log n + o(n/log n).\n\n5. **Cambie's observation**: The main result follows from the variant by factor pairing.\n\n6. **Verify small cases**: We check A(2,4)=1, A(3,9)=1, A(4,16)=2, A(5,25)=2.",
+    "historicalContext": "Erd\u0151s Problem #392 asks about the most efficient way to express n! as a product of bounded factors. Given the constraint that each factor a\u1d62 \u2264 n\u00b2, what is the minimum number of factors needed?\n\nThe answer involves a beautiful interplay between Stirling's approximation and factor pairing. Stirling tells us log(n!) \u2248 n log n, so if each factor is at most n\u00b2, contributing at most 2 log n to the logarithm, we need roughly (n log n)/(2 log n) = n/2 factors.\n\nCambie observed that the problem with bound n\u00b2 can be reduced to the variant with bound n via factor pairing. If a\u2081...a\u209c = n! with each a\u1d62 \u2264 n, define a'\u1d62 = a\u2082\u1d62\u208b\u2081 \u00b7 a\u2082\u1d62. Then each a'\u1d62 \u2264 n\u00b2 and we have roughly t/2 factors. The variant with bound n is solved by a greedy algorithm: use n as often as possible, then n-1, and so on.",
+    "problemStatement": "**Erd\u0151s Problem #392**: Let $A(n)$ denote the least value of $t$ such that\n$$n! = a_1 \\cdots a_t$$\nwith $a_1 \\leq \\cdots \\leq a_t \\leq n^2$. Is it true that\n$$A(n) = \\frac{n}{2} - \\frac{n}{2\\log n} + o\\left(\\frac{n}{\\log n}\\right)?$$\n\n**Status**: SOLVED\n\n**Answer**: YES. The formula is correct.\n\n**Variant**: With bound $a_t \\leq n$, we have $A(n) = n - n/\\log n + o(n/\\log n)$.",
+    "text": "Let A(n) be the minimum number of factors needed to write n! = a\u2081...a\u209c with each a\u1d62 \u2264 n\u00b2. Then A(n) = n/2 - n/(2 log n) + o(n/log n).",
+    "proofStrategy": "Our formalization takes a structured approach:\n\n1. **Define valid factorizations**: A valid factorization of n! into t factors with bound B requires the product to equal n!, the sequence to be monotone increasing, and all factors bounded by B.\n\n2. **Axiomatize the minimum**: A(n, B) is the least t for which a valid factorization exists.\n\n3. **State the main theorem**: The asymptotic formula A(n, n\u00b2) = n/2 - n/(2 log n) + o(n/log n).\n\n4. **State the variant**: With bound n, we get A(n, n) = n - n/log n + o(n/log n).\n\n5. **Cambie's observation**: The main result follows from the variant by factor pairing.\n\n6. **Verify small cases**: We check A(2,4)=1, A(3,9)=1, A(4,16)=2, A(5,25)=2.",
     "keyInsights": [
-      "**Factor bound tradeoff**: Larger bounds allow fewer factors. With bound n², roughly half as many factors are needed compared to bound n.",
-      "**Stirling's role**: The asymptotic log(n!) ≈ n log n explains the leading n/2 term: (n log n)/(2 log n) = n/2.",
+      "**Factor bound tradeoff**: Larger bounds allow fewer factors. With bound n\u00b2, roughly half as many factors are needed compared to bound n.",
+      "**Stirling's role**: The asymptotic log(n!) \u2248 n log n explains the leading n/2 term: (n log n)/(2 log n) = n/2.",
       "**Greedy optimality**: For bound n, a greedy algorithm is optimal: use n repeatedly, then n-1, etc. This gives the explicit formula.",
-      "**Factor pairing**: Cambie's key insight - pairing consecutive factors a₂ᵢ₋₁·a₂ᵢ stays under n² and halves the count.",
+      "**Factor pairing**: Cambie's key insight - pairing consecutive factors a\u2082\u1d62\u208b\u2081\u00b7a\u2082\u1d62 stays under n\u00b2 and halves the count.",
       "**Correction term**: The -n/(2 log n) correction comes from the detailed structure of factorial primes."
     ],
     "prerequisites": [
@@ -99,11 +99,11 @@
     },
     {
       "id": "main-theorem",
-      "title": "Main Result: Bound n²",
+      "title": "Main Result: Bound n\u00b2",
       "startLine": 64,
       "endLine": 85,
-      "summary": "The main asymptotic: A(n, n²) = n/2 - n/(2 log n) + o(n/log n).",
-      "mathContext": "The main asymptotic: A(n, n²) = n/2 - n/(2 $\\log n$) + o(n/$\\log n$)."
+      "summary": "The main asymptotic: A(n, n\u00b2) = n/2 - n/(2 log n) + o(n/log n).",
+      "mathContext": "The main asymptotic: A(n, n\u00b2) = n/2 - n/(2 $\\log n$) + o(n/$\\log n$)."
     },
     {
       "id": "variant",
@@ -142,8 +142,8 @@
       "title": "Asymptotic Behavior",
       "startLine": 180,
       "endLine": 197,
-      "summary": "A(n, n²) ~ n/2 and the correction term is lower order.",
-      "mathContext": "Mathematical content: A(n, n²) ~ n/2 and the correction term is lower order."
+      "summary": "A(n, n\u00b2) ~ n/2 and the correction term is lower order.",
+      "mathContext": "Mathematical content: A(n, n\u00b2) ~ n/2 and the correction term is lower order."
     },
     {
       "id": "summary",
@@ -155,13 +155,13 @@
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erdős Problem #392 on optimal factorization of n!. With factor bound n², the minimum number of factors is A(n) = n/2 - n/(2 log n) + o(n/log n). This follows from the variant with bound n via Cambie's factor pairing observation.",
+    "summary": "We formalize Erd\u0151s Problem #392 on optimal factorization of n!. With factor bound n\u00b2, the minimum number of factors is A(n) = n/2 - n/(2 log n) + o(n/log n). This follows from the variant with bound n via Cambie's factor pairing observation.",
     "implications": "**Theoretical Significance**: This problem connects several areas:\n\n1. **Combinatorial number theory**: Factorizations of n! with constraints\n**2. Analytic number theory**: Stirling's approximation and prime factorization\n3. **Algorithmic aspects**: The greedy algorithm for the bound-n variant\n4. **Asymptotic analysis**: Little-o notation and error terms.",
     "openQuestions": [
       "What is the exact constant in the error term o(n/log n)?",
-      "Can the greedy algorithm be generalized to bound n²?",
-      "What happens with other bounds like n^α for α ≠ 1, 2?",
-      "Is there a closed form for A(n, n²) for small n?"
+      "Can the greedy algorithm be generalized to bound n\u00b2?",
+      "What happens with other bounds like n^\u03b1 for \u03b1 \u2260 1, 2?",
+      "Is there a closed form for A(n, n\u00b2) for small n?"
     ]
   },
   "leanFile": {
@@ -185,17 +185,17 @@
     {
       "targetId": "erdos-391",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: asymptotics, factorial, factorization, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: asymptotics, factorial, factorization, number-theory"
     },
     {
       "targetId": "erdos-1054",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: asymptotics, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: asymptotics, number-theory"
     },
     {
       "targetId": "erdos-1073",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: factorial, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: factorial, number-theory"
     }
   ]
 }

--- a/src/data/proofs/erdos-628/meta.json
+++ b/src/data/proofs/erdos-628/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-628",
-  "title": "Erdős Problem #628: The Erdős-Lovász Tihany Conjecture",
+  "title": "Erd\u0151s Problem #628: The Erd\u0151s-Lov\u00e1sz Tihany Conjecture",
   "slug": "erdos-628",
-  "description": "If χ(G) = k and G is K_k-free, must G be (a,b)-splittable for a,b ≥ 2 with a + b = k + 1? Special cases proven: a = b = 3 (Brown-Jung), quasi-line graphs, α = 2 (Balogh et al.).",
+  "description": "If \u03c7(G) = k and G is K_k-free, must G be (a,b)-splittable for a,b \u2265 2 with a + b = k + 1? Special cases proven: a = b = 3 (Brown-Jung), quasi-line graphs, \u03b1 = 2 (Balogh et al.).",
   "meta": {
-    "author": "Erdős-Lovász (conjecture), Brown-Jung (a=b=3), Balogh-Kostochka-Prince-Stiebitz (special cases)",
+    "author": "Erd\u0151s-Lov\u00e1sz (conjecture), Brown-Jung (a=b=3), Balogh-Kostochka-Prince-Stiebitz (special cases)",
     "sourceUrl": "https://erdosproblems.com/628",
     "date": "1968",
     "status": "axiomatized",
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 11,
+    "sorries": 12,
     "erdosNumber": 628,
     "erdosUrl": "https://erdosproblems.com/628",
     "erdosProblemStatus": "open",
@@ -55,14 +55,14 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The Erdős–Lovász Tihany Conjecture is one of the most prominent open problems in structural graph theory. It was formulated by Paul Erdős and László Lovász at the 1968 Tihany conference on graph theory, held at Lake Balaton in Hungary — one of the most influential graph theory meetings of the era.\n\n**The question arose from a fundamental observation**: if a graph has $\\chi(G) = k$ but contains no $K_k$, then its high chromatic number must come from global structure rather than local density. The conjecture asserts this global structure is rich enough to be 'split' into two independently high-chromatic parts.\n\n**Timeline of results:**\n- **1968**: Erdős and Lovász formulate the conjecture at Tihany. Erdős initially asked about the $a = b = 3$ case.\n- **1969**: Jason I. Brown and Heinrich Jung independently proved the $a = b = 3$ case, showing that $K_5$-free 5-chromatic graphs contain two vertex-disjoint odd cycles. This was remarkably quick — only a year after the conjecture was posed.\n- **2006**: The Strong Perfect Graph Theorem (Chudnovsky et al.) shows Tihany is vacuous for perfect graphs, since perfect graphs always contain $K_{\\chi}$.\n- **2009**: Balogh, Kostochka, Prince, and Stiebitz proved two major special cases: (i) quasi-line graphs (where every vertex neighborhood is a union of two cliques), and (ii) graphs with independence number $\\alpha = 2$. These represented the first progress beyond Brown–Jung in 40 years.\n- **2022**: Zi-Xia Song published a comprehensive survey of the conjecture's status and partial results.\n\n**Connection to Lovász**: László Lovász, co-author of the conjecture, went on to win the Abel Prize (2021) partly for his foundational work in graph theory, including the Lovász theta function and the proof of Kneser's conjecture using topology. The Tihany Conjecture reflects his deep interest in graph structure.",
-    "problemStatement": "Let $G$ be a graph with $\\chi(G) = k$ that contains no $K_k$ (complete graph on $k$ vertices).\n\n**Definition:** $G$ is $(a,b)$-**splittable** if it contains vertex-disjoint induced subgraphs $G[S]$ and $G[T]$ with $\\chi(G[S]) \\ge a$ and $\\chi(G[T]) \\ge b$.\n\n**Conjecture (Erdős–Lovász 1968):** For all $a, b \\ge 2$ with $a + b = k + 1$, $G$ is $(a,b)$-splittable.\n\n**Status:** OPEN in general\n\n**Proved cases:**\n- $a = b = 3$ (Brown–Jung 1969): equivalent to two disjoint odd cycles\n- Quasi-line graphs (Balogh et al. 2009): neighborhoods are unions of two cliques\n- $\\alpha(G) = 2$ (Balogh et al. 2009): very small independence number",
-    "text": "If χ(G) = k and G is K_k-free, must G be (a,b)-splittable for a,b ≥ 2 with a + b = k + 1? Special cases proven: a = b = 3 (Brown-Jung), quasi-line graphs, α = 2 (Balogh et al.).",
-    "proofStrategy": "The Lean formalization captures the complete mathematical framework:\n\n1. **Graph parameters**: Sorry'd noncomputable definitions of $\\chi(G)$, $\\omega(G)$, `IsCliqueFree`, and vertex disjointness.\n2. **Splittability**: `IsSplittable G a b` via disjoint vertex sets with high-$\\chi$ induced subgraphs, plus an equivalent formulation `HasDisjointHighChromatic`.\n3. **Tihany Conjecture**: Both the full conjecture `TihanyConjecture` (quantifying over all $k \\ge 5$) and the per-pair version `TihanyForPair a b`.\n4. **Brown–Jung**: Axiomatized `TihanyForPair 3 3`, with `tihany_3_3` proved from it, plus axiomatized odd-cycle formulation `brown_jung_odd_cycles`.\n5. **Quasi-line graphs**: `IsLineGraph` (sorry'd), `IsQuasiLine` (neighborhoods as two cliques), axiomatized `balogh_quasi_line`.\n6. **Independence number 2**: Sorry'd `independenceNumber`, axiomatized `balogh_alpha_2`.\n7. **Critical graphs**: `IsCritical G k` (vertex-critical), sorry'd `contains_critical` and `critical_min_degree` ($\\delta \\ge k-1$).\n8. **Perfect graphs**: `IsPerfect`, sorry'd vacuousness for Tihany (`perfect_tihany_vacuous`).\n9. **Partial results**: Sorry'd weak splittability and easy $a=2$ case, symmetric conjecture definition.\n10. **Odd cycles**: Sorry'd $\\chi(C_{2k+1}) = 3$ and disjoint-odd-cycles-imply-splittability.\n11. **Summary**: `erdos_628_status` combining all three proved special cases.",
+    "historicalContext": "The Erd\u0151s\u2013Lov\u00e1sz Tihany Conjecture is one of the most prominent open problems in structural graph theory. It was formulated by Paul Erd\u0151s and L\u00e1szl\u00f3 Lov\u00e1sz at the 1968 Tihany conference on graph theory, held at Lake Balaton in Hungary \u2014 one of the most influential graph theory meetings of the era.\n\n**The question arose from a fundamental observation**: if a graph has $\\chi(G) = k$ but contains no $K_k$, then its high chromatic number must come from global structure rather than local density. The conjecture asserts this global structure is rich enough to be 'split' into two independently high-chromatic parts.\n\n**Timeline of results:**\n- **1968**: Erd\u0151s and Lov\u00e1sz formulate the conjecture at Tihany. Erd\u0151s initially asked about the $a = b = 3$ case.\n- **1969**: Jason I. Brown and Heinrich Jung independently proved the $a = b = 3$ case, showing that $K_5$-free 5-chromatic graphs contain two vertex-disjoint odd cycles. This was remarkably quick \u2014 only a year after the conjecture was posed.\n- **2006**: The Strong Perfect Graph Theorem (Chudnovsky et al.) shows Tihany is vacuous for perfect graphs, since perfect graphs always contain $K_{\\chi}$.\n- **2009**: Balogh, Kostochka, Prince, and Stiebitz proved two major special cases: (i) quasi-line graphs (where every vertex neighborhood is a union of two cliques), and (ii) graphs with independence number $\\alpha = 2$. These represented the first progress beyond Brown\u2013Jung in 40 years.\n- **2022**: Zi-Xia Song published a comprehensive survey of the conjecture's status and partial results.\n\n**Connection to Lov\u00e1sz**: L\u00e1szl\u00f3 Lov\u00e1sz, co-author of the conjecture, went on to win the Abel Prize (2021) partly for his foundational work in graph theory, including the Lov\u00e1sz theta function and the proof of Kneser's conjecture using topology. The Tihany Conjecture reflects his deep interest in graph structure.",
+    "problemStatement": "Let $G$ be a graph with $\\chi(G) = k$ that contains no $K_k$ (complete graph on $k$ vertices).\n\n**Definition:** $G$ is $(a,b)$-**splittable** if it contains vertex-disjoint induced subgraphs $G[S]$ and $G[T]$ with $\\chi(G[S]) \\ge a$ and $\\chi(G[T]) \\ge b$.\n\n**Conjecture (Erd\u0151s\u2013Lov\u00e1sz 1968):** For all $a, b \\ge 2$ with $a + b = k + 1$, $G$ is $(a,b)$-splittable.\n\n**Status:** OPEN in general\n\n**Proved cases:**\n- $a = b = 3$ (Brown\u2013Jung 1969): equivalent to two disjoint odd cycles\n- Quasi-line graphs (Balogh et al. 2009): neighborhoods are unions of two cliques\n- $\\alpha(G) = 2$ (Balogh et al. 2009): very small independence number",
+    "text": "If \u03c7(G) = k and G is K_k-free, must G be (a,b)-splittable for a,b \u2265 2 with a + b = k + 1? Special cases proven: a = b = 3 (Brown-Jung), quasi-line graphs, \u03b1 = 2 (Balogh et al.).",
+    "proofStrategy": "The Lean formalization captures the complete mathematical framework:\n\n1. **Graph parameters**: Sorry'd noncomputable definitions of $\\chi(G)$, $\\omega(G)$, `IsCliqueFree`, and vertex disjointness.\n2. **Splittability**: `IsSplittable G a b` via disjoint vertex sets with high-$\\chi$ induced subgraphs, plus an equivalent formulation `HasDisjointHighChromatic`.\n3. **Tihany Conjecture**: Both the full conjecture `TihanyConjecture` (quantifying over all $k \\ge 5$) and the per-pair version `TihanyForPair a b`.\n4. **Brown\u2013Jung**: Axiomatized `TihanyForPair 3 3`, with `tihany_3_3` proved from it, plus axiomatized odd-cycle formulation `brown_jung_odd_cycles`.\n5. **Quasi-line graphs**: `IsLineGraph` (sorry'd), `IsQuasiLine` (neighborhoods as two cliques), axiomatized `balogh_quasi_line`.\n6. **Independence number 2**: Sorry'd `independenceNumber`, axiomatized `balogh_alpha_2`.\n7. **Critical graphs**: `IsCritical G k` (vertex-critical), sorry'd `contains_critical` and `critical_min_degree` ($\\delta \\ge k-1$).\n8. **Perfect graphs**: `IsPerfect`, sorry'd vacuousness for Tihany (`perfect_tihany_vacuous`).\n9. **Partial results**: Sorry'd weak splittability and easy $a=2$ case, symmetric conjecture definition.\n10. **Odd cycles**: Sorry'd $\\chi(C_{2k+1}) = 3$ and disjoint-odd-cycles-imply-splittability.\n11. **Summary**: `erdos_628_status` combining all three proved special cases.",
     "keyInsights": [
-      "**$(a,b)$-splittability captures distributed chromatic structure:** If $\\chi(G) = k$ without a $K_k$, the high coloring requirement must come from the graph's global topology. Splittability says this requirement is spread enough to decompose into two independently demanding parts. The constraint $a + b = k + 1$ is tight — $a + b = k$ would follow trivially from any partition.",
-      "**$K_k$-free $k$-chromatic graphs are deeply imperfect:** Perfect graphs always have $\\omega = \\chi$, so they contain $K_\\chi$ and don't satisfy the Tihany hypothesis. The conjecture is about the most imperfect possible graphs — those where $\\chi$ exceeds $\\omega$ by the maximum possible amount relative to clique size.",
-      "**The $a = b = 3$ case reduces to odd cycle topology:** Brown–Jung showed that $K_5$-free 5-chromatic graphs contain two disjoint odd cycles. Odd cycles are the minimal 3-chromatic graphs (by the bipartite characterization: $\\chi = 2 \\iff$ no odd cycle). This reduction connects chromatic structure to cycle structure, a theme in graph minor theory.",
+      "**$(a,b)$-splittability captures distributed chromatic structure:** If $\\chi(G) = k$ without a $K_k$, the high coloring requirement must come from the graph's global topology. Splittability says this requirement is spread enough to decompose into two independently demanding parts. The constraint $a + b = k + 1$ is tight \u2014 $a + b = k$ would follow trivially from any partition.",
+      "**$K_k$-free $k$-chromatic graphs are deeply imperfect:** Perfect graphs always have $\\omega = \\chi$, so they contain $K_\\chi$ and don't satisfy the Tihany hypothesis. The conjecture is about the most imperfect possible graphs \u2014 those where $\\chi$ exceeds $\\omega$ by the maximum possible amount relative to clique size.",
+      "**The $a = b = 3$ case reduces to odd cycle topology:** Brown\u2013Jung showed that $K_5$-free 5-chromatic graphs contain two disjoint odd cycles. Odd cycles are the minimal 3-chromatic graphs (by the bipartite characterization: $\\chi = 2 \\iff$ no odd cycle). This reduction connects chromatic structure to cycle structure, a theme in graph minor theory.",
       "**Quasi-line structure constrains coloring:** In quasi-line graphs, every neighborhood is a union of two cliques. This means the local structure is well-controlled: each vertex 'sees' at most two cliques in its vicinity. Balogh et al. exploited this to prove Tihany by analyzing how chromatic number distributes across such structured neighborhoods.",
       "**The $\\alpha = 2$ case is Ramsey-constrained:** When $\\alpha(G) = 2$, the complement $\\bar{G}$ is triangle-free. By Ramsey theory, $|V(G)| \\le R(3, \\omega(\\bar{G})+1)$, bounding the graph's size. This constraint, combined with $K_k$-freeness and $\\chi = k$, severely limits the graph structure, enabling the proof."
     ],
@@ -86,7 +86,7 @@
     {
       "id": "basic-definitions",
       "title": "Basic Definitions",
-      "summary": "Sorry'd noncomputable chromaticNumber and cliqueNumber, IsCliqueFree (ω < k) and AreDisjoint (vertex set disjointness) predicates",
+      "summary": "Sorry'd noncomputable chromaticNumber and cliqueNumber, IsCliqueFree (\u03c9 < k) and AreDisjoint (vertex set disjointness) predicates",
       "startLine": 31,
       "endLine": 48,
       "mathContext": "$\\\\chi(G)$ = chromatic number, $\\\\omega(G)$ = clique number. $K_k$-free: $\\\\omega(G) < k$. Since $\\\\chi \\\\geq \\\\omega$, these graphs have $\\\\chi > \\\\omega$."
@@ -94,7 +94,7 @@
     {
       "id": "splittability",
       "title": "The (a,b)-Splittability Property",
-      "summary": "IsSplittable definition (disjoint vertex sets with χ ≥ a and χ ≥ b on induced subgraphs), plus equivalent HasDisjointHighChromatic formulation using S ∩ T = ∅",
+      "summary": "IsSplittable definition (disjoint vertex sets with \u03c7 \u2265 a and \u03c7 \u2265 b on induced subgraphs), plus equivalent HasDisjointHighChromatic formulation using S \u2229 T = \u2205",
       "startLine": 49,
       "endLine": 65,
       "mathContext": "$(a,b)$-splittable: $V = A \\\\sqcup B$ with $\\\\chi(G[A]) \\\\geq a$ and $\\\\chi(G[B]) \\\\geq b$. The chromatic number splits across a vertex partition."
@@ -102,14 +102,14 @@
     {
       "id": "tihany-conjecture",
       "title": "The Tihany Conjecture",
-      "summary": "Full TihanyConjecture definition (universal over k ≥ 5 and valid (a,b) pairs) and TihanyForPair (per-pair version with k = a + b - 1)",
+      "summary": "Full TihanyConjecture definition (universal over k \u2265 5 and valid (a,b) pairs) and TihanyForPair (per-pair version with k = a + b - 1)",
       "startLine": 66,
       "endLine": 86,
       "mathContext": "Full conjecture: $\\\\forall k \\\\geq 5$, $\\\\forall a,b \\\\geq 2$ with $a+b=k+1$: $\\\\chi(G)=k$, $G$ is $K_k$-free $\\\\Rightarrow$ $G$ is $(a,b)$-splittable."
     },
     {
       "id": "brown-jung",
-      "title": "Brown–Jung Theorem (a = b = 3)",
+      "title": "Brown\u2013Jung Theorem (a = b = 3)",
       "summary": "Axiomatized brown_jung_theorem (TihanyForPair 3 3), proved tihany_3_3 instantiation, and axiomatized brown_jung_odd_cycles (two disjoint odd cycles formulation)",
       "startLine": 87,
       "endLine": 110,
@@ -126,7 +126,7 @@
     {
       "id": "alpha-2",
       "title": "Independence Number 2",
-      "summary": "Sorry'd independenceNumber definition and axiomatized balogh_alpha_2 (Tihany for all pairs when α = 2)",
+      "summary": "Sorry'd independenceNumber definition and axiomatized balogh_alpha_2 (Tihany for all pairs when \u03b1 = 2)",
       "startLine": 135,
       "endLine": 151,
       "mathContext": "Balogh et al.: proved for $\\\\alpha(G) = 2$ (independence number 2). When $G$ has no independent triple, the structure is constrained enough."
@@ -134,15 +134,15 @@
     {
       "id": "critical-graphs",
       "title": "Critical Graphs",
-      "summary": "IsCritical definition (χ = k, removing any vertex drops χ), sorry'd contains_critical (k-critical subgraph existence), sorry'd critical_min_degree (δ ≥ k-1)",
+      "summary": "IsCritical definition (\u03c7 = k, removing any vertex drops \u03c7), sorry'd contains_critical (k-critical subgraph existence), sorry'd critical_min_degree (\u03b4 \u2265 k-1)",
       "startLine": 152,
       "endLine": 169,
       "mathContext": "$G$ is $k$-critical if $\\\\chi(G) = k$ but $\\\\chi(G-v) < k$ for every $v$. Critical graphs are the hardest case: minimal counterexamples must be critical."
     },
     {
       "id": "perfect-graphs",
-      "title": "Perfect Graphs — Tihany Vacuous",
-      "summary": "IsPerfect definition, sorry'd perfect_clique_free (K_{χ+1}-free), sorry'd perfect_tihany_vacuous (perfect graphs satisfy Tihany hypothesis vacuously)",
+      "title": "Perfect Graphs \u2014 Tihany Vacuous",
+      "summary": "IsPerfect definition, sorry'd perfect_clique_free (K_{\u03c7+1}-free), sorry'd perfect_tihany_vacuous (perfect graphs satisfy Tihany hypothesis vacuously)",
       "startLine": 170,
       "endLine": 186,
       "mathContext": "Perfect: $\\\\chi(H) = \\\\omega(H)$ for every induced subgraph $H$. Perfect graphs are $K_{\\\\chi+1}$-free, so Tihany is trivially true for them."
@@ -150,7 +150,7 @@
     {
       "id": "partial-results",
       "title": "Bounds and Partial Results",
-      "summary": "Sorry'd weak_splittability (single high-χ part), sorry'd tihany_a_eq_2 (easy a=2 case), and TihanySymmetric definition (a = b case)",
+      "summary": "Sorry'd weak_splittability (single high-\u03c7 part), sorry'd tihany_a_eq_2 (easy a=2 case), and TihanySymmetric definition (a = b case)",
       "startLine": 187,
       "endLine": 203,
       "mathContext": "Weak splittability (one high-$\\\\chi$ part) is easier. The $(2,k-1)$ case is known. The general $(a,b)$ case remains open for most $k$."
@@ -158,7 +158,7 @@
     {
       "id": "odd-cycles",
       "title": "Odd Cycles and (3,3)-Splittability",
-      "summary": "Sorry'd odd_cycle_chi_3 (χ(C_{2k+1}) = 3), sorry'd disjoint_odd_cycles_splittable with sorry'd cycle hypotheses connecting cycle theory to splittability",
+      "summary": "Sorry'd odd_cycle_chi_3 (\u03c7(C_{2k+1}) = 3), sorry'd disjoint_odd_cycles_splittable with sorry'd cycle hypotheses connecting cycle theory to splittability",
       "startLine": 204,
       "endLine": 220,
       "mathContext": "$\\\\chi(C_{2k+1}) = 3$. Disjoint odd cycles can build graphs with $\\\\chi = k$ and specific clique structure."
@@ -166,15 +166,15 @@
     {
       "id": "main-status",
       "title": "Main Problem Status and Verification",
-      "summary": "erdos_628_status combining Brown–Jung, quasi-line, and α=2 results (proved from three axioms), plus #check verifications of key declarations",
+      "summary": "erdos_628_status combining Brown\u2013Jung, quasi-line, and \u03b1=2 results (proved from three axioms), plus #check verifications of key declarations",
       "startLine": 221,
       "endLine": 246,
       "mathContext": "Partial: Brown-Jung ($a=b=3$), quasi-line graphs, $\\\\alpha=2$ case. Full conjecture for general $k \\\\geq 5$ remains OPEN."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #628 — the Erdős–Lovász Tihany Conjecture (1968) — is OPEN in general. The conjecture asserts that $K_k$-free $k$-chromatic graphs are $(a,b)$-splittable for all valid pairs. Three special cases are proved: $a = b = 3$ (Brown–Jung 1969, via disjoint odd cycles), quasi-line graphs (Balogh et al. 2009, via neighborhood structure), and $\\alpha = 2$ (Balogh et al. 2009, via Ramsey-type constraints). The formalization captures the full framework: splittability definitions, the conjecture, all proved cases, critical graph theory, perfect graph vacuousness, and the odd-cycle connection.",
-    "implications": "This conjecture connects to several deep themes: (1) **Graph decomposition theory** — Tihany asks when chromatic complexity can be decomposed into independent parts, a question with algorithmic implications for divide-and-conquer coloring; (2) **Critical graph theory** — understanding $K_k$-free $k$-critical graphs is essential, as these are the 'atoms' of chromatic structure; (3) **Perfect graph theory** — the SPGT shows Tihany is vacuous for perfect graphs, so the conjecture probes the structure of imperfection; (4) **Topological graph theory** — the $a=b=3$ case reduces to disjoint odd cycles, connecting to the Erdős–Pósa theorem on cycle packing; (5) **Ramsey theory** — the $\\alpha = 2$ case exploits Ramsey bounds on graph size.",
+    "summary": "Erd\u0151s Problem #628 \u2014 the Erd\u0151s\u2013Lov\u00e1sz Tihany Conjecture (1968) \u2014 is OPEN in general. The conjecture asserts that $K_k$-free $k$-chromatic graphs are $(a,b)$-splittable for all valid pairs. Three special cases are proved: $a = b = 3$ (Brown\u2013Jung 1969, via disjoint odd cycles), quasi-line graphs (Balogh et al. 2009, via neighborhood structure), and $\\alpha = 2$ (Balogh et al. 2009, via Ramsey-type constraints). The formalization captures the full framework: splittability definitions, the conjecture, all proved cases, critical graph theory, perfect graph vacuousness, and the odd-cycle connection.",
+    "implications": "This conjecture connects to several deep themes: (1) **Graph decomposition theory** \u2014 Tihany asks when chromatic complexity can be decomposed into independent parts, a question with algorithmic implications for divide-and-conquer coloring; (2) **Critical graph theory** \u2014 understanding $K_k$-free $k$-critical graphs is essential, as these are the 'atoms' of chromatic structure; (3) **Perfect graph theory** \u2014 the SPGT shows Tihany is vacuous for perfect graphs, so the conjecture probes the structure of imperfection; (4) **Topological graph theory** \u2014 the $a=b=3$ case reduces to disjoint odd cycles, connecting to the Erd\u0151s\u2013P\u00f3sa theorem on cycle packing; (5) **Ramsey theory** \u2014 the $\\alpha = 2$ case exploits Ramsey bounds on graph size.",
     "openQuestions": [
       "Does the Tihany Conjecture hold for all $(a,b)$ pairs? The next open case is $a = 3, b = 4$ (i.e., $k = 6$).",
       "Can the quasi-line and $\\alpha = 2$ proofs be unified or generalized to a broader class?",
@@ -185,19 +185,19 @@
   },
   "crossReferences": [
     {
-      "relationship": "Problem #627 studies the maximum χ/ω ratio over n-vertex graphs. Tihany concerns the structural consequences when this ratio is at its extreme (χ = k, ω < k).",
+      "relationship": "Problem #627 studies the maximum \u03c7/\u03c9 ratio over n-vertex graphs. Tihany concerns the structural consequences when this ratio is at its extreme (\u03c7 = k, \u03c9 < k).",
       "targetId": "erdos-627"
     },
     {
-      "relationship": "Problem #626 explores the chromatic number–girth trade-off, another facet of how high chromatic number arises without large cliques.",
+      "relationship": "Problem #626 explores the chromatic number\u2013girth trade-off, another facet of how high chromatic number arises without large cliques.",
       "targetId": "erdos-626"
     },
     {
-      "relationship": "Ramsey theory underpins the α = 2 case (bounding graph size via R(3,k)) and provides structural constraints on K_k-free graphs.",
+      "relationship": "Ramsey theory underpins the \u03b1 = 2 case (bounding graph size via R(3,k)) and provides structural constraints on K_k-free graphs.",
       "targetId": "ramseys-theorem"
     },
     {
-      "relationship": "Erdős Problem #1 on Ramsey numbers relates through the fundamental question of how graph parameters (χ, ω, α) interact under extremal constraints.",
+      "relationship": "Erd\u0151s Problem #1 on Ramsey numbers relates through the fundamental question of how graph parameters (\u03c7, \u03c9, \u03b1) interact under extremal constraints.",
       "targetId": "erdos-1"
     }
   ],

--- a/src/data/proofs/yang-mills/meta.json
+++ b/src/data/proofs/yang-mills/meta.json
@@ -22,7 +22,7 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "Lie.Basic",
@@ -58,7 +58,7 @@
     "dateAdded": "2025-12-29",
     "millenniumProblem": "yang-mills",
     "axiomCount": 16,
-    "assumptions": "16 total assumptions: 1 explicit axiom (gaugeTransform) + 15 structure-encoded: CompactSimpleGaugeGroup (compact, connected, simple — 3), GaugeLieAlgebra (bracket_anticomm, bracket_jacobi — 2), FieldStrength (antisymmetric — 1), YangMillsAction (coupling_pos, action_nonneg — 2), WightmanQFT (vacuum_normalized, energy_bounded_below, vacuum_lowest_energy — 3), QuantumYangMillsTheory (nontrivial — 1), Instanton (action_formula — 1), EnergyMomentumTensor (symmetric, energy_density_nonneg — 2). 1 sorry (coupling_controlled in Exploration.lean, Mathlib drift). The Yang-Mills 4D mass gap conjecture remains OPEN.",
+    "assumptions": "16 total assumptions: 1 explicit axiom (gaugeTransform) + 15 structure-encoded: CompactSimpleGaugeGroup (compact, connected, simple \u2014 3), GaugeLieAlgebra (bracket_anticomm, bracket_jacobi \u2014 2), FieldStrength (antisymmetric \u2014 1), YangMillsAction (coupling_pos, action_nonneg \u2014 2), WightmanQFT (vacuum_normalized, energy_bounded_below, vacuum_lowest_energy \u2014 3), QuantumYangMillsTheory (nontrivial \u2014 1), Instanton (action_formula \u2014 1), EnergyMomentumTensor (symmetric, energy_density_nonneg \u2014 2). 1 sorry (coupling_controlled in Exploration.lean, Mathlib drift). The Yang-Mills 4D mass gap conjecture remains OPEN.",
     "lineCount": 48,
     "mathlib_version": "4.26.0"
   },
@@ -103,7 +103,7 @@
     {
       "id": "gauge-fields",
       "title": "Gauge Fields and Field Strength",
-      "summary": "Defines `GaugeField G 𝔤` (connection 1-form $A_\\mu(x) \\in \\mathfrak{g}$) and `FieldStrength G 𝔤` ($F_{\\mu\\nu}$ with antisymmetry). Proves $F_{\\mu\\mu} = 0$ using module arithmetic ($a = -a \\implies 2a = 0 \\implies a = 0$) and that the antisymmetric tensor has 6 independent components.",
+      "summary": "Defines `GaugeField G \ud835\udd24` (connection 1-form $A_\\mu(x) \\in \\mathfrak{g}$) and `FieldStrength G \ud835\udd24` ($F_{\\mu\\nu}$ with antisymmetry). Proves $F_{\\mu\\mu} = 0$ using module arithmetic ($a = -a \\implies 2a = 0 \\implies a = 0$) and that the antisymmetric tensor has 6 independent components.",
       "mathContext": "$A_\\mu(x) \\in \\mathfrak{g}$. $F_{\\mu\\nu} = -F_{\\nu\\mu}$, $F_{\\mu\\mu} = 0$ (char $\\neq 2$). $\\binom{4}{2} = 6$ independent components.",
       "file": "Proofs/YangMills/Classical.lean",
       "startLine": 43,
@@ -157,7 +157,7 @@
     {
       "id": "millennium",
       "title": "The Millennium Problem Statement",
-      "summary": "Defines `YangMillsMillenniumProblem G 𝔤`: $\\exists$ quantum Yang-Mills theory for gauge group $G$ with a positive mass gap. This is the formal statement of the Clay Mathematics Institute problem.",
+      "summary": "Defines `YangMillsMillenniumProblem G \ud835\udd24`: $\\exists$ quantum Yang-Mills theory for gauge group $G$ with a positive mass gap. This is the formal statement of the Clay Mathematics Institute problem.",
       "mathContext": "$\\exists\\, \\text{QYM} : \\text{QuantumYangMillsTheory}(G, \\mathfrak{g}),\\; \\exists \\Delta > 0,\\; \\text{hasMassGap}(\\text{QYM}, \\Delta)$.",
       "file": "Proofs/YangMills/Quantum.lean",
       "startLine": 111,
@@ -166,7 +166,7 @@
     {
       "id": "partial-results",
       "title": "Known Partial Results",
-      "summary": "States asymptotic freedom ($\\exists b_0 > 0$), lattice Yang-Mills well-definedness ($\\exists Z > 0$), and Wilson area law ($\\exists \\sigma > 0$). These are proved trivially — the physical content is in the naming, not the formal proofs.",
+      "summary": "States asymptotic freedom ($\\exists b_0 > 0$), lattice Yang-Mills well-definedness ($\\exists Z > 0$), and Wilson area law ($\\exists \\sigma > 0$). These are proved trivially \u2014 the physical content is in the naming, not the formal proofs.",
       "mathContext": "$\\exists b_0 > 0$ (asymptotic freedom). $\\exists Z > 0$ (lattice partition function). $\\exists \\sigma > 0$ (string tension).",
       "file": "Proofs/YangMills/Classical.lean",
       "startLine": 260,
@@ -237,10 +237,10 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization provides infrastructure for the Yang-Mills Millennium Prize Problem across 28,570 lines and 162 parts. The rigorous core (~36% of the file) covers classical gauge theory, lattice gauge theory with proven gauge invariance and bounds, exactly solvable 2D Yang-Mills with Migdal formula, and a proven finite-volume mass gap via transfer matrix / Perron-Frobenius. The remaining ~64% is heuristic exploration of confinement mechanisms, anomalies, SUSY, and deconfinement physics. The 4D mass gap conjecture remains OPEN — this is infrastructure, not progress toward the solution.",
+    "summary": "This formalization provides infrastructure for the Yang-Mills Millennium Prize Problem across 28,570 lines and 162 parts. The rigorous core (~36% of the file) covers classical gauge theory, lattice gauge theory with proven gauge invariance and bounds, exactly solvable 2D Yang-Mills with Migdal formula, and a proven finite-volume mass gap via transfer matrix / Perron-Frobenius. The remaining ~64% is heuristic exploration of confinement mechanisms, anomalies, SUSY, and deconfinement physics. The 4D mass gap conjecture remains OPEN \u2014 this is infrastructure, not progress toward the solution.",
     "implications": "Resolution of the Yang-Mills mass gap problem would put quantum chromodynamics on rigorous mathematical foundations, explaining from first principles why quarks and gluons are confined inside hadrons. It would be the first rigorous construction of a 4D interacting quantum field theory and would likely require fundamentally new mathematical techniques bridging functional analysis, probability theory, and geometric analysis.",
     "openQuestions": [
-      "Can a rigorous quantum Yang-Mills theory be constructed on $\\mathbb{R}^4$? No 4D interacting QFT satisfying the Wightman axioms has ever been built — the problem remains the central open challenge in mathematical physics.",
+      "Can a rigorous quantum Yang-Mills theory be constructed on $\\mathbb{R}^4$? No 4D interacting QFT satisfying the Wightman axioms has ever been built \u2014 the problem remains the central open challenge in mathematical physics.",
       "Can the continuum limit of lattice Yang-Mills theory ($a \\to 0$ with physics fixed) be rigorously controlled? Wilson's lattice formulation works at finite spacing, but the $a \\to 0$ limit is unproven.",
       "Is confinement (area law for Wilson loops) provable from first principles in 4D? In 2D it follows from exact solvability, but the 4D case requires controlling non-perturbative effects.",
       "What is the role of instantons and topological sectors in the mass gap? The $\\theta$-vacuum structure and chiral symmetry breaking suggest deep connections between topology and the mass gap."
@@ -260,7 +260,7 @@
     {
       "targetId": "hilbert-5",
       "relationship": "foundational",
-      "description": "Hilbert's 5th Problem on Lie groups provides the mathematical foundation for gauge groups — compact simple Lie groups like SU(2) and SU(3) are the gauge groups of the Standard Model."
+      "description": "Hilbert's 5th Problem on Lie groups provides the mathematical foundation for gauge groups \u2014 compact simple Lie groups like SU(2) and SU(3) are the gauge groups of the Standard Model."
     },
     {
       "targetId": "brouwer-fixed-point",
@@ -270,7 +270,7 @@
     {
       "targetId": "yang-mills-transfer-matrix",
       "relationship": "has-submodule",
-      "description": "Proven finite-volume mass gap via transfer matrix / Perron-Frobenius — the strongest rigorous result in this formalization"
+      "description": "Proven finite-volume mass gap via transfer matrix / Perron-Frobenius \u2014 the strongest rigorous result in this formalization"
     },
     {
       "targetId": "yang-mills-lattice",
@@ -323,14 +323,14 @@
       "title": "Conservation of Isotopic Spin and Isotopic Gauge Invariance",
       "year": "1954",
       "venue": "Physical Review 96(1), 191-195",
-      "note": "The foundational paper introducing non-abelian gauge theory — the mathematical framework for the Standard Model of particle physics"
+      "note": "The foundational paper introducing non-abelian gauge theory \u2014 the mathematical framework for the Standard Model of particle physics"
     },
     {
       "authors": "Jaffe, Arthur; Witten, Edward",
       "title": "Quantum Yang-Mills Theory",
       "year": "2000",
       "venue": "Clay Mathematics Institute Millennium Problems",
-      "note": "Official problem statement for the $1 million Clay prize — proving existence of the mass gap"
+      "note": "Official problem statement for the $1 million Clay prize \u2014 proving existence of the mass gap"
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
## Audit Cycle 10 — Sorry Count Corrections

Automated audit detected 6 proofs with sorry count mismatches between meta.json and actual Lean source. All corrected.

### Fixes

| Proof | Old Count | Correct Count | Notes |
|-------|-----------|---------------|-------|
| erdos-157 | 2 | 3 | 3 sorries in Erdos157Problem.lean |
| erdos-628 | 11 | 12 | 12 sorries in Stubs/Erdos628Problem.lean |
| erdos-392 | 2 | 3 | 3 sorries in Stubs/Erdos392Problem.lean |
| erdos-138 | 4 | 5 | 5 sorries in Stubs/Erdos138Problem.lean |
| dirichlets-theorem-oq-03 | 2 | 3 | 3 sorries in DirichletsTheoremOQ03.lean |
| yang-mills | 0 | 1 | `coupling_controlled` theorem in Exploration.lean:22791 has MATHLIB-DRIFT sorry (Real.log + calc chain broke) |

### Status Notes

- All 6 proofs remain `axiomatized` — no status change needed
- The yang-mills sorry is a regression from a Mathlib API change; a separate mechanic issue should address the proof repair
- No `verified` proofs affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)