### PR TITLE
Fix: lineCount mismatches in birch-swinnerton-dyer and harmonic-divergence-oq-02

### DIFF
--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -681,7 +681,7 @@
       "ComplexConjugate"
     ],
     "namespace": "BirchSwinnertonDyer",
-    "lineCount": 7437,
+    "lineCount": 7422,
     "axiomCount": 21,
     "theoremCount": 254,
     "definitionCount": 143

--- a/src/data/proofs/harmonic-divergence-oq-02/meta.json
+++ b/src/data/proofs/harmonic-divergence-oq-02/meta.json
@@ -17,7 +17,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 142,
+    "lineCount": 156,
     "assumptions": "None. All results fully proved via Cauchy condensation.",
     "mathlib_version": "4.26.0"
   },
@@ -123,7 +123,7 @@
       "Real"
     ],
     "namespace": "HarmonicDivergenceOQ02",
-    "lineCount": 142,
+    "lineCount": 156,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 1


### PR DESCRIPTION
## Fix

Corrects stale `lineCount` values in two gallery proofs where the Lean source files grew after the last metadata sync.

## Evidence

**birch-swinnerton-dyer**
- Before: `leanFile.lineCount = 7437`
- After: `leanFile.lineCount = 7422`
- Actual file (`BirchSwinnertonDyer.lean`): 7422 lines
- Note: `meta.lineCount` was already correct at 7422

**harmonic-divergence-oq-02**
- Before: `meta.lineCount = 142`, `leanFile.lineCount = 142`
- After: `meta.lineCount = 156`, `leanFile.lineCount = 156`
- Actual file (`HarmonicDivergenceOQ02.lean`): 156 lines

---
Automated fix by lean-mechanic agent.