### PR TITLE
Fix: audit cycle 11 — area-of-circle-oq-05 completed, 12 new proofs clean

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05/meta.json
@@ -5,7 +5,7 @@
   "description": "The Gaussian integral ∫ e^{-x²} dx = √π, proved via Mathlib's integral_gaussian. The appearance of π is explained by the polar-coordinate proof: squaring the integral gives a double integral ∫∫ e^{-(x²+y²)} dx dy that evaluates to the area of a circle.",
   "meta": {
     "author": "Pierre-Simon Laplace (1774, polar coordinate proof)",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/AreaOfCircleOQ05.lean",
     "tags": [
       "analysis",
@@ -15,10 +15,10 @@
       "probability",
       "normal-distribution"
     ],
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "mathlib",
+    "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "None. The Gaussian integral itself is proved via Mathlib. One sorry remains for radial integral (needs FTC for improper integrals).",
+    "assumptions": "None. All results derived from Mathlib's integral_gaussian and standard Mathlib analysis lemmas.",
     "dateAdded": "2026-03-30",
     "lineCount": 118,
     "mathlibDependencies": [

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -251,10 +251,12 @@
       "result": "clean"
     },
     "area-of-circle-oq-05": {
-      "auditCount": 1,
-      "issues": [],
-      "lastAudited": "2026-03-30T18:01:57Z",
-      "result": "clean"
+      "auditCount": 2,
+      "issues": [
+        "sorries 1\u21920, status formalized\u2192verified, badge wip\u2192mathlib (sorry was completed)"
+      ],
+      "lastAudited": "2026-04-03T09:33:04Z",
+      "result": "issues-fixed"
     },
     "arithmetic-series": {
       "auditCount": 1,
@@ -11205,6 +11207,78 @@
     "minkowski-theorem-oq-02": {
       "auditCount": 1,
       "lastAudited": "2026-04-03T08:38:00Z",
+      "result": "clean",
+      "issues": []
+    },
+    "angle-trisection-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T09:33:04Z",
+      "result": "clean",
+      "issues": []
+    },
+    "area-of-circle-oq-01-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T09:33:04Z",
+      "result": "clean",
+      "issues": []
+    },
+    "birthday-problem-oq-03-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T09:33:04Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cantor-diagonalization-oq-03-oq-01-incomplete-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T09:33:04Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cramers-rule-oq-01-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T09:33:04Z",
+      "result": "clean",
+      "issues": []
+    },
+    "dissection-of-cubes-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T09:33:04Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1001-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T09:33:04Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1009-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T09:33:04Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1098-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T09:33:04Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1098-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T09:33:04Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-659-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T09:33:04Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sperner-ndim-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T09:33:04Z",
       "result": "clean",
       "issues": []
     }


### PR DESCRIPTION
## Audit Cycle 11

### Fix: area-of-circle-oq-05

The `radial_integral` sorry was completed (FTC for improper integrals). Meta.json updated:
- `sorries`: 1 → 0
- `status`: formalized → verified
- `badge`: wip → mathlib (core result via Mathlib's `integral_gaussian`)

### 12 New Proofs Audited (all clean)

| Proof | Status/Badge | Result |
|-------|-------------|--------|
| angle-trisection-oq-02-oq-02 | axiomatized/axiom | clean |
| area-of-circle-oq-01-oq-03-oq-01 | axiomatized/axiom | clean |
| birthday-problem-oq-03-oq-01-oq-01 | axiomatized/axiom | clean |
| cantor-diagonalization-oq-03-oq-01-incomplete-01 | verified/original | clean |
| cramers-rule-oq-01-oq-04 | axiomatized/axiom | clean |
| dissection-of-cubes-oq-01-oq-01 | axiomatized/axiom | clean |
| erdos-1001-oq-03 | axiomatized/axiom | clean |
| erdos-1009-oq-02 | formalized/original | clean |
| erdos-1098-oq-01-oq-01 | axiomatized/axiom | clean |
| erdos-1098-oq-04 | formalized/original | clean |
| erdos-659-oq-01 | axiomatized/axiom | clean |
| sperner-ndim-oq-01 | verified/original | clean |

Gallery: 1876/1876 audited (100%). No integrity issues remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)