### PR TITLE
Fix: find-targets.ts bidirectional axiom count check

### DIFF
--- a/scripts/auditor/find-targets.ts
+++ b/scripts/auditor/find-targets.ts
@@ -191,10 +191,14 @@ function detectIssues(target: AuditTarget): string[] {
     issues.push(`sorry mismatch: claims ${target.meta.claimedSorries}, actual ${target.actual.sorryCount}`)
   }
 
-  // Axiom count mismatch -- only flag when meta undercounts actual declarations.
-  // When claimed > actual, the difference may be structure-encoded assumptions (intentional).
-  if (target.meta.claimedAxioms >= 0 && target.actual.axiomCount > target.meta.claimedAxioms) {
-    issues.push(`axiom undercount: claims ${target.meta.claimedAxioms}, actual declarations ${target.actual.axiomCount}`)
+  // Axiom count mismatch -- check both directions.
+  // Note: structure-encoded assumptions should still be counted in meta.axiomCount per policy.
+  if (target.meta.claimedAxioms >= 0 && target.actual.axiomCount !== target.meta.claimedAxioms) {
+    if (target.actual.axiomCount > target.meta.claimedAxioms) {
+      issues.push(`axiom undercount: claims ${target.meta.claimedAxioms}, actual declarations ${target.actual.axiomCount}`)
+    } else {
+      issues.push(`axiom overcount: claims ${target.meta.claimedAxioms}, actual declarations ${target.actual.axiomCount}`)
+    }
   }
 
   // Verified with sorries


### PR DESCRIPTION
## Fix

Add bidirectional axiom count checking to `scripts/auditor/find-targets.ts`.

## Evidence

**Before**: Only detects when `meta.axiomCount < actual lean declarations`
```typescript
if (target.actual.axiomCount > target.meta.claimedAxioms) {
  issues.push(`axiom undercount: ...`)
}
```

**After**: Detects both undercounts and overcounts
```typescript
if (target.actual.axiomCount !== target.meta.claimedAxioms) {
  if (target.actual.axiomCount > target.meta.claimedAxioms) {
    issues.push(`axiom undercount: ...`)
  } else {
    issues.push(`axiom overcount: ...`)
  }
}
```

Per CLAUDE.md axiom integrity policy: `axiomCount` must reflect ALL assumptions (axiom declarations + structure-encoded). When meta claims more than actual Lean declarations, it should be flagged for review.

Verified: script runs cleanly against 1876 targets.

Closes #8750

---
Automated fix by lean-mechanic agent.