### PR TITLE
Fix: erdos-10 status axiomatized (open Erdos problem, 0 theorems)

### DIFF
--- a/src/data/proofs/erdos-10/meta.json
+++ b/src/data/proofs/erdos-10/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/10",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos10Problem.lean",
     "tags": [
       "erdos",
@@ -16,13 +16,13 @@
       "powers of 2",
       "density"
     ],
-    "badge": "verified",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 10,
     "erdosUrl": "https://erdosproblems.com/10",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "assumptions": "8 axiom declarations: erdos_10_conjecture (main conjecture), gallagher_density (density result), granville_soundararajan_odd/even (representation conjectures), grechuk_counterexample (k=3 counterexample), infinitely_many_exceptions_k2/k3 (exception existence), romanoff_positive_density (positive density). All results are deep number-theoretic facts axiomatized in the formalization.",
+    "assumptions": "Open problem. The Lean file contains only definitional infrastructure (sumPrimeAndTwoPows, Set.lowerDensity) with 0 theorem/lemma declarations and 0 axiom declarations. Key results (Erdos-Graham conjecture, Gallagher density, Granville-Soundararajan conjectures, Grechuk counterexample, covering congruence exceptions, Romanoff positive density) are described in doc-comments only.",
     "lineCount": 94,
     "prerequisites": [
       "Prime numbers and their distribution",
@@ -121,7 +121,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #10 is formalized comprehensively with all major results axiomatized: the Erdős-Graham conjecture ($\\neg \\exists k: \\{n > 1\\} \\subseteq S_k$), Gallagher's density theorem ($\\underline{d}(S_k) \\to 1$), Granville-Soundararajan conjectures ($k = 3$ for odd, $k = 4$ for even), Grechuk's counterexample ($1117175146 \\notin S_3$), covering congruence exceptions, and Romanoff's positive density. The parity barrier between odd and even integers is a central theme. All results are axiomatized (no proved theorems), reflecting the depth of the underlying number theory.",
+    "summary": "Erdős Problem #10 is an open problem with definitional infrastructure in Lean. The file defines $S_k$ (`sumPrimeAndTwoPows`) and `Set.lowerDensity` but contains no theorem, lemma, or axiom declarations. Key results -- the Erdős-Graham conjecture ($\\neg \\exists k: \\{n > 1\\} \\subseteq S_k$), Gallagher's density theorem ($\\underline{d}(S_k) \\to 1$), Granville-Soundararajan conjectures ($k = 3$ for odd, $k = 4$ for even), Grechuk's counterexample ($1117175146 \\notin S_3$), covering congruence exceptions, and Romanoff's positive density -- are described in doc-comments only, reflecting the depth of the underlying number theory.",
     "implications": "**Theoretical Significance**: Resolution would require advances in sieve methods beyond Gallagher's large sieve, or new techniques for handling lacunary additive bases.\n\nThe covering congruence argument connects to Erdős's work on covering systems. Understanding how well powers of 2 complement the primes illuminates fundamental questions in additive number theory and the distribution of primes in arithmetic progressions.",
     "openQuestions": [
       "Does there exist any finite $k$ that works for all sufficiently large integers? (The main open question.)",


### PR DESCRIPTION
## Summary

- Fix gallery integrity issue: Erdos Problem #10 incorrectly labeled `status: "verified"`, `badge: "verified"` despite being an open mathematical problem with 0 theorems in the Lean file
- Change `status` to `"axiomatized"` and `badge` to `"axiom"` per CLAUDE.md policy: "open conjectures: always axiomatized"
- Correct `assumptions` text (was claiming "8 axiom declarations" but Lean file has 0) and `conclusion.summary` (was saying "formalized comprehensively" for a file with only definitions)

## Details

The Lean file `proofs/Proofs/Erdos10Problem.lean` (94 lines) contains:
- 2 definitions: `sumPrimeAndTwoPows`, `Set.lowerDensity`
- 0 theorems, 0 lemmas, 0 axiom declarations
- All mathematical results described in doc-comments only

The `verified` status was incorrectly applied by a batch fix that set all proofs with 0 axioms + 0 sorries to verified, without accounting for the open-conjectures policy.

## Fields changed in meta.json
| Field | Before | After |
|-------|--------|-------|
| `meta.status` | `"verified"` | `"axiomatized"` |
| `meta.badge` | `"verified"` | `"axiom"` |
| `meta.assumptions` | "8 axiom declarations..." (inaccurate) | Accurate description of definitions-only file |
| `conclusion.summary` | "formalized comprehensively" | "open problem with definitional infrastructure" |

## Test plan

- [x] JSON validates (`python3 -m json.tool`)
- [x] Only `meta.json` changed, no Lean file modifications needed
- [x] `sorries: 0` and `axiomCount: 0` retained (correct per Lean file)
- [x] `erdosProblemStatus: "open"` already present and consistent with new status

Closes #8818

Generated with [Claude Code](https://claude.com/claude-code)