### PR TITLE
Enrich binary-gcd: Stein's algorithm with equation compiler techniques

### DIFF
--- a/src/data/proofs/binary-gcd/annotations.json
+++ b/src/data/proofs/binary-gcd/annotations.json
@@ -1,1 +1,62 @@
-[]
+[
+  {
+    "id": "ann-gcd-sub-right",
+    "proofId": "binary-gcd",
+    "range": { "startLine": 32, "endLine": 46 },
+    "type": "technique",
+    "title": "gcd_sub_right: GCD Subtraction Lemma via dvd_antisymm + dvd_add",
+    "content": "`gcd_sub_right` is proved by `Nat.dvd_antisymm`, reducing the equality to two divisibility inclusions. For gcd(a-b,b) | gcd(a,b): need to show gcd(a-b,b) | a and | b. The latter is trivial (gcd_dvd_right). For the former: gcd(a-b,b) divides both a-b and b, so it divides (a-b)+b = a by `Nat.dvd_add`. For gcd(a,b) | gcd(a-b,b): need to show gcd(a,b) | a-b and | b. The latter is again gcd_dvd_right. For a-b: `Nat.dvd_sub'` handles d | a and d | b → d | a-b. The proof avoids any computation — it is purely divisibility algebra. The hypothesis `h : b ≤ a` is needed for the natural number subtraction to be non-negative (in ℕ, a-b is only well-defined as a-b when b ≤ a).",
+    "mathContext": "The GCD subtraction lemma: $\\gcd(a-b, b) = \\gcd(a, b)$ for $b \\leq a$. Proof: let $d = \\gcd(a-b, b)$. Then $d \\mid (a-b)$ and $d \\mid b$, so $d \\mid (a-b) + b = a$, giving $d \\mid \\gcd(a, b)$. Conversely, let $e = \\gcd(a, b)$. Then $e \\mid a$ and $e \\mid b$, so $e \\mid a - b$ (for $b \\leq a$ in $\\mathbb{Z}$), giving $e \\mid \\gcd(a-b, b)$. By antisymmetry, $\\gcd(a-b, b) = \\gcd(a, b)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.dvd_antisymm for GCD equality", "Nat.dvd_add for divisibility of sums", "Nat.dvd_sub' for divisibility of differences", "Nat.gcd_dvd_left and gcd_dvd_right"],
+    "prerequisites": ["Nat.gcd divisibility properties in Mathlib.Data.Nat.GCD.Basic", "Natural number subtraction semantics (a-b = 0 when b > a in ℕ)"]
+  },
+  {
+    "id": "ann-coprimality-lemmas",
+    "proofId": "binary-gcd",
+    "range": { "startLine": 49, "endLine": 62 },
+    "type": "technique",
+    "title": "gcd_mul_two_left: Coprimality-Based Factor Cancellation in One Line",
+    "content": "`gcd_mul_two_left` is a one-liner: `Nat.coprime_two_left.mpr hb` converts `hb : b % 2 = 1` to `Coprime 2 b` (since `Nat.coprime_two_left` states `Coprime 2 n ↔ n % 2 = 1`), then `hcop.gcd_mul_left_cancel a` applies the Mathlib lemma `Coprime.gcd_mul_left_cancel : Coprime k n → Nat.gcd (k * m) n = Nat.gcd m n` with k=2, m=a, n=b. `gcd_mul_two_right` is then derived by commutativity: `rw [Nat.gcd_comm, gcd_mul_two_left ha, Nat.gcd_comm]`. `gcd_two_mul` (both even case) is a direct call to Mathlib's `Nat.gcd_mul_left 2 a b : Nat.gcd (2*a) (2*b) = 2 * Nat.gcd a b`.",
+    "mathContext": "The key identity: $\\gcd(2a, b) = \\gcd(a, b)$ when $b$ is odd. Algebraically: since $\\gcd(2, b) = 1$ (as $b$ is odd, $b$ shares no factor of 2 with 2), any common divisor of $2a$ and $b$ must divide $a$ (it cannot use the factor 2 from $2a$ since $b$ is odd). More precisely: if $d \\mid 2a$ and $d \\mid b$, and $\\gcd(d, 2) = 1$ (since $d \\mid b$ and $b$ odd), then $d \\mid a$ by Euclid's lemma. The Mathlib lemma `Coprime.gcd_mul_left_cancel` encodes: $\\gcd(km, n) = \\gcd(m, n)$ when $\\gcd(k, n) = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.coprime_two_left: Coprime 2 n ↔ n % 2 = 1", "Coprime.gcd_mul_left_cancel: coprime factor cancellation", "Nat.gcd_mul_left for common factor extraction", "Euclid's lemma for coprime divisibility"],
+    "prerequisites": ["Nat.Coprime definition and API in Mathlib.Data.Nat.GCD.Basic", "Nat.gcd_mul_left for the both-even case"]
+  },
+  {
+    "id": "ann-algorithm-def",
+    "proofId": "binary-gcd",
+    "range": { "startLine": 74, "endLine": 96 },
+    "type": "technique",
+    "title": "binaryGcd Definition: Well-Founded Recursion with termination_by / decreasing_by omega",
+    "content": "The `binaryGcd` definition uses `termination_by a + b` — the termination measure is the sum of the two arguments. Each recursive case must decrease this sum. The pattern match on `a + 1, b + 1` avoids the `0, 0` base cases being matched by the first two equations. The four `if` tests check parities using `%2`. The `decreasing_by all_goals omega` tactic discharges all 5 termination obligations in one stroke: for the both-even case, (a+1)/2 + (b+1)/2 < (a+1) + (b+1) since halving reduces the sum; for the even-odd cases, (a+1)/2 + (b+1) < (a+1) + (b+1) similarly; for the both-odd case with a+1 > b+1, (a+1-(b+1))/2 + (b+1) < (a+1) + (b+1) since the subtracted term is at least 2 and we halve. All of these are linear arithmetic facts over ℕ that omega handles after the divisibility contexts are established.",
+    "mathContext": "Well-founded recursion in Lean 4: a `def` with `termination_by expr` declares a well-founded measure. Lean generates proof obligations showing each recursive call decreases the measure. `decreasing_by tac` provides a single tactic to discharge all such obligations simultaneously. The measure $a + b$ works because: both-even: $(a/2) + (b/2) \\leq (a+b)/2 < a+b$ for $a+b > 0$; even-odd: $(a/2) + b < a + b$ for $a > 0$; both-odd: $(a-b)/2 + b < a + b$ since $a > b$ and $(a-b)/2 \\leq (a-b)/2 < a-b \\leq a$.",
+    "significance": "key",
+    "relatedConcepts": ["termination_by for well-founded recursion in Lean 4", "decreasing_by for discharging termination obligations", "omega tactic for linear arithmetic over ℕ", "equation compiler pattern matching with guards (if-then-else in def)"],
+    "prerequisites": ["Well-founded recursion in Lean 4 (WellFoundedRelation)", "Lean 4 pattern matching with decidable guards", "omega tactic for ℕ/ℤ linear arithmetic"]
+  },
+  {
+    "id": "ann-odd-sub-half",
+    "proofId": "binary-gcd",
+    "range": { "startLine": 101, "endLine": 113 },
+    "type": "insight",
+    "title": "gcd_odd_sub_half: The Both-Odd Case via a Three-Step Rewrite Chain",
+    "content": "`gcd_odd_sub_half` proves gcd((a-b)/2, b) = gcd(a, b) when both a,b are odd and a > b. The proof is a three-step `calc` chain: (step 1) gcd((a-b)/2, b) = gcd(2·((a-b)/2), b) by `(gcd_mul_two_left hb).symm` — since b is odd, we can multiply the first argument by 2 without changing the GCD; (step 2) gcd(2·((a-b)/2), b) = gcd(a-b, b) by rewriting `2·((a-b)/2) = a-b` (valid since a-b is even — proved by `omega` from both odd); (step 3) gcd(a-b, b) = gcd(a, b) by `gcd_sub_right`. The key arithmetic insight: when both a and b are odd, a-b is even (odd-odd=even), so (a-b)/2 is exact (no rounding) and 2·((a-b)/2) = a-b. This exactness is what makes the middle step valid.",
+    "mathContext": "When $a$ and $b$ are both odd with $a > b$: $a - b$ is even (parity argument: odd $-$ odd $=$ even). So $(a-b)/2$ is an integer and $2 \\cdot ((a-b)/2) = a-b$. The chain: $\\gcd((a-b)/2, b) = \\gcd(2 \\cdot (a-b)/2, b)$ [since $\\gcd(2, b) = 1$] $= \\gcd(a-b, b)$ [substituting $2 \\cdot (a-b)/2 = a-b$] $= \\gcd(a, b)$ [subtraction formula]. The `omega` tactic handles `(a - b) % 2 = 0` from `a % 2 = 1` and `b % 2 = 1`, and `a - b = 2 * ((a - b) / 2)` from the evenness fact.",
+    "significance": "key",
+    "relatedConcepts": ["calc chains in Lean 4 for multi-step equalities", "Parity arithmetic: odd−odd=even", "gcd_mul_two_left for factor-2 insertion", "gcd_sub_right for the subtraction step", "omega for parity reasoning over ℕ"],
+    "prerequisites": ["gcd_sub_right proved above", "gcd_mul_two_left proved above", "Lean 4 omega tactic for ℕ divisibility by 2"]
+  },
+  {
+    "id": "ann-correctness",
+    "proofId": "binary-gcd",
+    "range": { "startLine": 119, "endLine": 159 },
+    "type": "technique",
+    "title": "binaryGcd_eq_gcd: Correctness via the Equation Compiler's binaryGcd.induct",
+    "content": "The correctness proof uses `binaryGcd.induct` — the equation compiler automatically generates an induction principle from the recursive definition, with one case per branch. This is a distinctive Lean 4 feature: `induction a, b using binaryGcd.induct` gives 7 cases exactly matching the 7 branches of `binaryGcd`. Each case has the same hypotheses (parity conditions, comparison) and the induction hypothesis for the recursive sub-call. The proof in each case: (1) unfold binaryGcd with `simp only [binaryGcd, ...]`; (2) rewrite with the IH to replace `binaryGcd (...)` with `Nat.gcd (...)`; (3) apply the corresponding GCD lemma to re-express `Nat.gcd (a', b')` as `Nat.gcd (a, b)`. This structure makes the proof a clean 1-to-1 correspondence between algorithm cases and GCD lemma applications.",
+    "mathContext": "The `binaryGcd.induct` principle has the type: to prove `P a b` for all `a b`, it suffices to prove `P` for each branch of the recursive definition, with the induction hypothesis that `P` holds for the recursive sub-call's arguments. For the both-even case: given `ha : (a+1) % 2 = 0`, `hb : (b+1) % 2 = 0`, and `ih : binaryGcd ((a+1)/2) ((b+1)/2) = Nat.gcd ((a+1)/2) ((b+1)/2)`, prove `binaryGcd (a+1) (b+1) = Nat.gcd (a+1) (b+1)`. The proof: unfold to `2 * binaryGcd ((a+1)/2) ((b+1)/2) = 2 * Nat.gcd ((a+1)/2) ((b+1)/2)` by `ih`, then `gcd_two_mul.symm` closes it.",
+    "significance": "key",
+    "relatedConcepts": ["binaryGcd.induct: equation compiler generated induction principle", "Lean 4 equation compiler and inaccessible pattern induction", "simp with reduceDIte for conditional unfolding", "induction using custom induction principles in Lean 4"],
+    "prerequisites": ["Well-founded induction principles in Lean 4", "simp with reduceDIte to unfold conditional definitions", "All four GCD lemmas: gcd_sub_right, gcd_mul_two_left/right, gcd_two_mul, gcd_odd_sub_half/right"]
+  }
+]

--- a/src/data/proofs/binary-gcd/meta.json
+++ b/src/data/proofs/binary-gcd/meta.json
@@ -18,9 +18,9 @@
     "sorries": 0,
     "originalContributions": [
       "binaryGcd: recursive implementation of Stein's algorithm in Lean 4",
-      "gcd_sub_right: gcd(a-b, b) = gcd(a, b) for b \u2264 a",
+      "gcd_sub_right: gcd(a-b, b) = gcd(a, b) for b ≤ a",
       "gcd_mul_two_left: gcd(2a, b) = gcd(a, b) when b is odd",
-      "gcd_two_mul: gcd(2a, 2b) = 2\u00b7gcd(a, b)",
+      "gcd_two_mul: gcd(2a, 2b) = 2·gcd(a, b)",
       "gcd_odd_sub_half: gcd((a-b)/2, b) = gcd(a, b) for both odd, a > b"
     ],
     "dateAdded": "2026-03-30",
@@ -29,20 +29,52 @@
     "assumptions": ""
   },
   "overview": {
-    "historicalContext": "Josef Stein published this algorithm in 1967. It replaces division with bit shifts, making it faster on binary hardware.",
+    "historicalContext": "GCD computation is one of the oldest algorithms in mathematics, appearing in Euclid's Elements (~300 BC) as 'anthyphairesis' (mutual subtraction). Euclid's algorithm computes gcd(a,b) by repeatedly replacing the larger number with its remainder modulo the smaller — elegant, but division is expensive on binary hardware (requiring multiple clock cycles versus a single bit shift for halving). Josef Stein published the Binary GCD algorithm in 1967, crediting Israeli programmers who had used it on early computers where integer division was slow or unavailable. The algorithm replaces all division with three bit-manipulation identities: gcd(2a,2b) = 2·gcd(a,b), gcd(2a,b) = gcd(a,b) when b is odd (since gcd(2,odd)=1), and gcd(a-b,b) = gcd(a,b). When both arguments are odd, their difference is even (odd minus odd = even), so a halving step always follows the subtraction, and the sum a+b strictly decreases in every recursive call. Modern implementations in the GNU Multiple Precision Arithmetic Library (GMP) and LLVM use variants of this algorithm, often outperforming the Euclidean method by 2-3× on 64-bit hardware where integer division latency can be 20-90 clock cycles versus 1 cycle for bit shifts. The Lean 4 formalization exploits the equation compiler's `binaryGcd.induct` principle — automatically generated from the well-founded recursive definition — providing one induction case per algorithm branch for a proof that mirrors the algorithm's structure exactly.",
     "problemStatement": "Formalize the Binary GCD algorithm and prove it computes the GCD correctly.",
-    "text": "Binary GCD (Stein's algorithm) uses subtraction and division by 2 instead of Euclidean division.",
-    "proofStrategy": "Define the algorithm by well-founded recursion on a+b. Prove three key lemmas (even factor extraction, coprime reduction, odd subtraction) and combine for correctness.",
+    "proofStrategy": "Define binaryGcd by well-founded recursion with `termination_by a + b` (proved by `decreasing_by all_goals omega`). Prove four supporting lemmas: gcd_sub_right by Nat.dvd_antisymm + Nat.dvd_add/dvd_sub'; gcd_mul_two_left by Nat.Coprime.gcd_mul_left_cancel; gcd_two_mul as a one-liner via Nat.gcd_mul_left; gcd_odd_sub_half by combining the previous two. The main correctness theorem binaryGcd_eq_gcd is proved by `binaryGcd.induct` with 7 cases (case1/2: base cases, case3-7: recursive cases), each applying the corresponding lemma and re-assembling with the induction hypothesis.",
     "keyInsights": [
-      "Three key lemmas: gcd(2a,2b)=2\u00b7gcd(a,b), gcd(2a,b)=gcd(a,b) for odd b, gcd(a-b,b)=gcd(a,b)",
-      "When both arguments are odd, their difference is even, enabling the halving step",
-      "Termination: a+b strictly decreases in every recursive call"
-    ],
-    "prerequisites": [
-      "GCD properties",
-      "Basic number theory"
+      "The three algorithm cases cover all parity combinations: both even (factor out 2), one even one odd (drop the even factor using coprimality), both odd (subtract and halve, always getting an even difference since odd−odd=even)",
+      "gcd_mul_two_left uses `Nat.coprime_two_left.mpr hb` to prove Coprime 2 b from b%2=1, then delegates to `Coprime.gcd_mul_left_cancel` — a one-line proof that compactly encodes the argument 'gcd ignores coprime factors'",
+      "The `binaryGcd.induct` principle gives exactly 7 cases matching the 7 branches of the recursive definition (case1: a=0, case2: b=0, case3-4: a even, case5: a odd b even, case6-7: both odd), making each proof case a direct translation of the corresponding algorithm step",
+      "Termination is proved by `decreasing_by all_goals omega`, which dispatches all non-trivial goals of the form (a+1)/2 + (b+1) < a+1+b+1 etc. in one stroke — `omega` handles the linear arithmetic after unfolding the division-by-2 cases",
+      "gcd_odd_sub_half uses a three-step rewrite chain: gcd((a-b)/2, b) = gcd(2·((a-b)/2), b) by gcd_mul_two_left [since b odd] = gcd(a-b, b) [rewriting 2·((a-b)/2) = a-b, valid since a-b is even] = gcd(a, b) by gcd_sub_right",
+      "The basic properties (commutativity, zero cases) are all one-liners via the correctness theorem plus Nat.gcd_comm/gcd_zero_left/right, demonstrating that once correctness is established, all structural properties transfer for free from Nat.gcd"
     ]
   },
+  "sections": [
+    {
+      "id": "gcd-lemmas",
+      "title": "Part I: Key GCD Lemmas",
+      "startLine": 32,
+      "endLine": 62,
+      "summary": "Four GCD lemmas used in the correctness proof. gcd_sub_right: gcd(a-b,b)=gcd(a,b) by dvd_antisymm + dvd_add. gcd_mul_two_left: gcd(2a,b)=gcd(a,b) for odd b, via Coprime.gcd_mul_left_cancel. gcd_mul_two_right: symmetric via gcd_comm. gcd_two_mul: gcd(2a,2b)=2·gcd(a,b) as one-liner.",
+      "mathContext": "The three fundamental GCD identities used by the algorithm: (1) $\\gcd(a-b,b) = \\gcd(a,b)$ for $b \\leq a$ — since any common divisor of $a-b$ and $b$ also divides $a = (a-b)+b$; (2) $\\gcd(2a,b) = \\gcd(a,b)$ when $\\gcd(2,b)=1$ — since $2$ is coprime to $b$, it contributes nothing to the GCD; (3) $\\gcd(2a,2b) = 2\\gcd(a,b)$ — factoring out the common factor 2."
+    },
+    {
+      "id": "algorithm",
+      "title": "Part II: The Binary GCD Algorithm",
+      "startLine": 66,
+      "endLine": 113,
+      "summary": "The binaryGcd definition: well-founded recursion on a+b with 5 cases (base cases, both even, a even/b odd, a odd/b even, both odd with comparison). Termination by decreasing_by all_goals omega. Supporting lemmas gcd_odd_sub_half and gcd_odd_sub_half_right for the both-odd case.",
+      "mathContext": "The algorithm: if $a = 0$ return $b$; if $b = 0$ return $a$; if both even: $2 \\cdot \\text{binaryGcd}(a/2, b/2)$; if $a$ even $b$ odd: $\\text{binaryGcd}(a/2, b)$; if $a$ odd $b$ even: $\\text{binaryGcd}(a, b/2)$; if both odd and $a > b$: $\\text{binaryGcd}((a-b)/2, b)$; if both odd and $a \\leq b$: $\\text{binaryGcd}(a, (b-a)/2)$. Termination: in each recursive case, $a' + b' < a + b$ since at least one argument is halved."
+    },
+    {
+      "id": "correctness",
+      "title": "Part II: Correctness Theorem",
+      "startLine": 119,
+      "endLine": 159,
+      "summary": "binaryGcd_eq_gcd: binaryGcd a b = Nat.gcd a b, proved by binaryGcd.induct with 7 cases. Each case applies the corresponding GCD lemma (gcd_two_mul, gcd_mul_two_left/right, gcd_odd_sub_half/right) and re-assembles with the induction hypothesis.",
+      "mathContext": "The correctness invariant: at each recursive call with arguments $(a', b')$, we have $\\gcd(a', b') = \\gcd(a, b)$. By induction (using the well-founded measure $a+b$), $\\text{binaryGcd}(a', b') = \\text{Nat.gcd}(a', b') = \\text{Nat.gcd}(a, b)$. The 7-case `binaryGcd.induct` principle provides exactly the case structure of the recursive definition."
+    },
+    {
+      "id": "properties",
+      "title": "Part III: Basic Properties",
+      "startLine": 163,
+      "endLine": 174,
+      "summary": "Three one-liners: binaryGcd_comm via gcd_comm + correctness; binaryGcd_zero_left by simp; binaryGcd_zero_right by cases + simp.",
+      "mathContext": "Commutativity: $\\text{binaryGcd}(a,b) = \\text{Nat.gcd}(a,b) = \\text{Nat.gcd}(b,a) = \\text{binaryGcd}(b,a)$, using correctness twice and Nat.gcd_comm. Zero cases follow directly from the base case equations of the definition."
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "gcd-algorithm",
@@ -51,10 +83,12 @@
     }
   ],
   "conclusion": {
-    "summary": "Defines binaryGcd with well-founded recursion and proves all supporting lemmas. The main correctness theorem binaryGcd_eq_gcd is fully proved using equation compiler induction.",
-    "implications": "Binary GCD is the standard GCD algorithm in modern hardware-optimized libraries.",
+    "summary": "A complete Lean 4 formalization of Stein's Binary GCD algorithm: definition by well-founded recursion, four supporting GCD lemmas, and the main correctness theorem binaryGcd_eq_gcd = Nat.gcd via the equation compiler's binaryGcd.induct principle. 10 theorems, 0 axioms, 0 sorries.",
+    "implications": "The formalization demonstrates two important Lean 4 techniques: (1) the `termination_by` / `decreasing_by omega` pattern for algorithm termination — applicable to any algorithm with a decreasing numeric measure; (2) the equation compiler's auto-generated induction principle (`binaryGcd.induct`) that mirrors the recursive definition's case structure. The `Nat.Coprime.gcd_mul_left_cancel` approach to gcd_mul_two_left generalizes to any coprimality argument about GCD factors. The proof that binaryGcd = Nat.gcd establishes full correctness, giving all of Nat.gcd's properties (commutativity, associativity, Bezout identity, etc.) to binaryGcd for free.",
     "openQuestions": [
-      "What is the formal step count comparison with the Euclidean algorithm?"
+      "What is the formal step count comparison with the Euclidean algorithm? The binary algorithm uses O(log²n) bit operations versus O(M(n) log n) for the Euclidean method with fast multiplication M(n) — can this comparison be formalized in Lean 4?",
+      "Can the algorithm be extended to the integer GCD (handling negative inputs) or to Gaussian integers ℤ[i], where the binary GCD structure generalizes via norm arguments?",
+      "The GMP library uses a Lehmer-Schönhage hybrid that switches between binary and Euclidean methods based on input size. Can a formally verified adaptive implementation be built in Lean 4 that matches GMP's performance model?"
     ]
   },
   "leanFile": {
@@ -79,6 +113,5 @@
       "type": "core",
       "description": "Correctness: binaryGcd a b = Nat.gcd a b"
     }
-  ],
-  "sections": []
+  ]
 }


### PR DESCRIPTION
Enriches the `binary-gcd` gallery entry (Binary GCD / Stein's Algorithm).

## Changes

**meta.json:**
- Expanded `overview.historicalContext` (>400 chars): Euclid ~300BC anthyphairesis, Stein 1967, Israeli programmers, GMP/LLVM usage, Lean 4 equation compiler
- Converted `overview.text` (dead field) — removed, kept proper fields
- Expanded `overview.keyInsights` from 3 to 6 (algorithm parity cases, coprimality one-liner, binaryGcd.induct 7 cases, omega termination, odd-sub-half chain, properties-for-free)
- Added 4 sections: gcd-lemmas, algorithm, correctness, properties — each with `mathContext`
- Expanded `conclusion.implications` with Lean 4 technique discussion
- Expanded `conclusion.openQuestions` from 1 to 3 (step count comparison, Gaussian integer extension, GMP adaptive hybrid)

**annotations.json (new — was empty):**
- 5 rich annotations with mathContext, significance, relatedConcepts, prerequisites:
  1. `gcd_sub_right` — dvd_antisymm + dvd_add/dvd_sub' pattern
  2. `gcd_mul_two_left` — Nat.Coprime.gcd_mul_left_cancel one-liner
  3. `binaryGcd` definition — termination_by / decreasing_by omega
  4. `gcd_odd_sub_half` — three-step calc chain with parity insight
  5. `binaryGcd_eq_gcd` — equation compiler's binaryGcd.induct principle

🤖 Generated with [Claude Code](https://claude.com/claude-code)