### PR TITLE
Enrich sylow-theorems-oq-01: pq-group classification with commutator arguments

### DIFF
--- a/src/data/proofs/sylow-theorems-oq-01/annotations.json
+++ b/src/data/proofs/sylow-theorems-oq-01/annotations.json
@@ -2,17 +2,61 @@
   {
     "id": "ann-sylow-pq-unique-q",
     "proofId": "sylow-theorems-oq-01",
-    "range": {"startLine": 45, "endLine": 70},
+    "range": { "startLine": 144, "endLine": 159 },
     "type": "insight",
-    "title": "Why the Sylow q-Subgroup is Always Unique",
-    "body": "For p < q, the number n_q of Sylow q-subgroups satisfies n_q | p and n_q ≡ 1 (mod q). Since p < q, we can't have n_q = p (that would require p ≡ 1 mod q, impossible for p < q). So n_q = 1, meaning the Sylow q-subgroup is unique and therefore normal."
+    "title": "Why the Sylow q-Subgroup is Always Unique: p < q Forces n_q = 1",
+    "content": "`unique_sylow_q` is the cleanest argument in the file. From `sylow_q_count_constraint`: n_q | p (via `card_sylow_dvd_index`, using that index of Q = p) and n_q ≡ 1 (mod q) (via `card_sylow_modEq_one`). Since p is prime, `h.hp.eq_one_or_self_of_dvd` gives n_q ∈ {1, p}. If n_q = p: then p % q = 1 by the congruence condition. But p < q, so p % q = p (since p < q, division gives quotient 0 and remainder p). Substituting: p = 1, contradicting p being prime. `omega` closes this immediately after setting up the contradiction. The proof is 4 lines including the two hypothesis unpacking steps.",
+    "mathContext": "Sylow's third theorem: $n_q \\mid \\text{index}(Q)$ and $n_q \\equiv 1 \\pmod{q}$. Here $\\text{index}(Q) = |G|/|Q| = pq/q = p$. So $n_q \\mid p$ with $p$ prime gives $n_q \\in \\{1, p\\}$. If $n_q = p$: then $p \\equiv 1 \\pmod{q}$, i.e., $q \\mid (p-1)$. But $p < q$, so $p - 1 < q$, and the only multiple of $q$ in $\\{0, \\ldots, q-1\\}$ less than $q$ is $0$, giving $p - 1 = 0$, i.e., $p = 1$ — not prime. So $n_q = 1$.",
+    "significance": "key",
+    "relatedConcepts": ["card_sylow_dvd_index: n_p divides index of Sylow subgroup", "card_sylow_modEq_one: n_p ≡ 1 mod p (Sylow's third theorem)", "Nat.Prime.eq_one_or_self_of_dvd: prime divisors are 1 or p", "Nat.mod_eq_of_lt: n % m = n when n < m"],
+    "prerequisites": ["Sylow.card_sylow_dvd_index in Mathlib.GroupTheory.Sylow", "Nat.ModEq and modEq_iff_dvd' in Mathlib.Data.Nat.Defs", "sylow_q_index helper lemma computing index = p"]
   },
   {
-    "id": "ann-sylow-pq-classification",
+    "id": "ann-commutator-commutativity",
     "proofId": "sylow-theorems-oq-01",
-    "range": {"startLine": 130, "endLine": 170},
+    "range": { "startLine": 237, "endLine": 260 },
     "type": "insight",
-    "title": "The p | (q-1) Dichotomy",
-    "body": "The classification hinges on a single divisibility condition: does p divide q-1? If not, both Sylow subgroups are normal and G is cyclic. If yes, there exists a non-abelian semidirect product. The examples are illuminating: order 15 (3×5) is always cyclic since 3∤4, but order 6 (2×3) has S₃ since 2|2."
+    "title": "The Commutator Argument: Normal Subgroups with Trivial Intersection Commute",
+    "content": "The commutativity proof is a textbook argument made fully explicit in Lean. For g ∈ P, k ∈ Q: form c = g⁻¹(k⁻¹gk). Since P is normal: `hPN.conj_mem g hg k⁻¹` gives k⁻¹gk ∈ P (with simp to handle the k⁻¹ conjugation form), and g⁻¹ ∈ P trivially, so c ∈ P. Since Q is normal: `hQN.conj_mem k⁻¹ (...) g⁻¹` gives g⁻¹k⁻¹g ∈ Q, and k ∈ Q, so g⁻¹k⁻¹gk ∈ Q. But g⁻¹k⁻¹gk = g⁻¹(k⁻¹gk) = c by associativity (via `group` tactic). So c ∈ P ∩ Q = {1}. From c = 1: `inv_mul_eq_one` gives k⁻¹gk = g, then `calc` derives gk = kg.",
+    "mathContext": "For normal subgroups $P, Q \\trianglelefteq G$ with $P \\cap Q = \\{1\\}$, all elements of $P$ and $Q$ commute. Proof: for $g \\in P, k \\in Q$, the commutator $[g,k] = g^{-1}k^{-1}gk$. Then $[g,k] \\in P$: since $P \\trianglelefteq G$, $k^{-1}gk \\in P$, so $g^{-1}(k^{-1}gk) \\in P$. Similarly $[g,k] \\in Q$: since $Q \\trianglelefteq G$, $g^{-1}k^{-1}g \\in Q$, so $(g^{-1}k^{-1}g)k \\in Q$. Since $P \\cap Q = \\{1\\}$, $[g,k] = 1$, i.e., $gk = kg$.",
+    "significance": "key",
+    "relatedConcepts": ["Subgroup.Normal.conj_mem for conjugation in normal subgroups", "Subgroup.disjoint_def for P ∩ Q = {1}", "inv_mul_eq_one for a⁻¹b = 1 ↔ a = b", "group tactic for group identity simplification"],
+    "prerequisites": ["Subgroup.Normal definition and conj_mem in Mathlib.GroupTheory.Subgroup", "Disjoint for subgroups via Subgroup.disjoint_def", "P ∩ Q = {1} proved earlier via coprimality"]
+  },
+  {
+    "id": "ann-cyclic-generator",
+    "proofId": "sylow-theorems-oq-01",
+    "range": { "startLine": 261, "endLine": 297 },
+    "type": "technique",
+    "title": "Building a Cyclic Generator: orderOf_mul for Commuting Coprime-Order Elements",
+    "content": "The cyclic generator construction uses `isCyclic_of_prime_card` (prime-order groups are cyclic) to get generators g of P (order p) and k of Q (order q). `orderOf_eq_card_of_forall_mem_zpowers` converts 'g generates P' (∀ x, x ∈ zpowers g) to `orderOf g = |P| = p` after unfolding the Subgroup.orderOf_mk coercion. The key step: `hgk_comm.orderOf_mul_eq_mul_orderOf_of_coprime` states that if g and k commute and their orders are coprime, then orderOf(gk) = orderOf(g) * orderOf(k) = pq. Then `Subgroup.card_zpowers` gives |zpowers(gk)| = orderOf(gk) = pq = |G|, so `Subgroup.eq_top_of_card_eq` gives zpowers(gk) = ⊤, making every group element a power of gk.",
+    "mathContext": "For commuting elements $g, k$ with $\\gcd(\\mathrm{ord}(g), \\mathrm{ord}(k)) = 1$: $\\mathrm{ord}(gk) = \\mathrm{ord}(g) \\cdot \\mathrm{ord}(k)$. Proof: $(gk)^n = g^n k^n$ (by commutativity), so $(gk)^n = 1 \\Leftrightarrow g^n = k^{-n} \\in P \\cap Q = \\{1\\}$ (since $P$ and $Q$ have coprime orders) $\\Leftrightarrow$ $\\mathrm{ord}(g) \\mid n$ and $\\mathrm{ord}(k) \\mid n$ $\\Leftrightarrow$ $\\mathrm{lcm}(p,q) = pq \\mid n$.",
+    "significance": "key",
+    "relatedConcepts": ["isCyclic_of_prime_card: prime-order groups are cyclic", "orderOf_eq_card_of_forall_mem_zpowers for generator order", "Commute.orderOf_mul_eq_mul_orderOf_of_coprime for coprime commuting orders", "Subgroup.eq_top_of_card_eq for subgroup = top from equal cardinality"],
+    "prerequisites": ["IsCyclic.exists_generator in Mathlib.GroupTheory.GroupAction.Basic", "Subgroup.zpowers and card_zpowers in Mathlib.GroupTheory.Subgroup", "Nat.Coprime for p and q (distinct primes)"]
+  },
+  {
+    "id": "ann-factorization-api",
+    "proofId": "sylow-theorems-oq-01",
+    "range": { "startLine": 52, "endLine": 104 },
+    "type": "technique",
+    "title": "The Nat.factorization API: Extracting Prime Valuations with Finsupp",
+    "content": "The helper lemmas factorization_pq_at_q and factorization_pq_at_p compute v_q(pq) = 1 and v_p(pq) = 1 using Mathlib's Nat.factorization (a Finsupp from ℕ to ℕ). The pattern: `Nat.factorization_mul` splits factorization of a product into a sum of Finsupps. `(Nat.Prime.prime hp).factorization` gives the Finsupp.single p 1 for a prime p. `Finsupp.single_apply` then evaluates: `Finsupp.single p 1 q = if p = q then 1 else 0`. The `if_neg (Ne.symm h.hpq)` and `if_pos rfl` close the cases, and omega combines. This pattern generalizes to any product of distinct primes for computing Sylow subgroup orders. The `sylow_q_card` then applies `Q.card_eq_multiplicity` (|Q| = p^{v_p(|G|)}) and `pow_one` to get |Q| = q.",
+    "mathContext": "Mathlib's `Nat.factorization n` is a `Finsupp ℕ ℕ` — a finitely-supported function representing the prime factorization of $n$. For a prime $p$: `(Nat.Prime.prime hp).factorization = Finsupp.single p 1`. `Finsupp.add_apply` gives the value of a sum at a point. `Sylow.card_eq_multiplicity : Nat.card Q = p ^ (Fintype.card G).factorization p` — the Sylow subgroup has order equal to the full $p$-power in $|G|$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.factorization as Finsupp ℕ ℕ", "Nat.factorization_mul for products", "Finsupp.single_apply for prime factorization evaluation", "Sylow.card_eq_multiplicity for Sylow subgroup order", "Subgroup.card_mul_index for order × index = |G|"],
+    "prerequisites": ["Nat.factorization in Mathlib.Data.Nat.Factorization.Basic", "Finsupp and Finsupp.single in Mathlib.Data.Finsupp.Basic", "Sylow API in Mathlib.GroupTheory.Sylow"]
+  },
+  {
+    "id": "ann-nonabelian-p-count",
+    "proofId": "sylow-theorems-oq-01",
+    "range": { "startLine": 320, "endLine": 331 },
+    "type": "technique",
+    "title": "nonabelian_sylow_p_count: Proof by Contradiction Using the Full Cyclic Result",
+    "content": "`nonabelian_sylow_p_count` is a elegant proof by contradiction: assume n_p = 1 (from sylow_p_count giving n_p ∈ {1, q}). Then by sylow_normal_of_card_one, P is normal. Combined with sylow_q_normal (Q always normal), the hypothesis of cyclic_of_both_sylow_normal is satisfied, giving IsCyclic G — contradicting hncyc. So n_p = q. The proof structure `rcases ... with h1 | hq` handles the two cases from sylow_p_count; the first branch builds the contradiction in 3 lines, the second branch closes trivially with `exact hq`. This is a standard 'proof by minimum counterexample elimination' pattern.",
+    "mathContext": "When $p \\mid (q-1)$ and $G$ is non-cyclic: $n_p \\in \\{1, q\\}$ by the Sylow divisibility constraint. If $n_p = 1$: $P$ is normal, $Q$ is always normal (proved above), so $G$ is cyclic by the main theorem — contradiction with $G$ non-cyclic. Therefore $n_p = q$. This gives the expected Sylow count for the non-abelian case $\\mathbb{Z}/q \\rtimes \\mathbb{Z}/p$: indeed, the $q$ Sylow $p$-subgroups of $\\mathbb{Z}/q \\rtimes \\mathbb{Z}/p$ are precisely $\\{\\mathbb{Z}/p \\times \\{k\\} : k \\in \\mathbb{Z}/q\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Proof by contradiction using exfalso", "sylow_p_count for the two-case analysis", "cyclic_of_both_sylow_normal as the bridge to the contradiction", "rcases for case-splitting on disjunctions"],
+    "prerequisites": ["sylow_p_count proved in Part III", "cyclic_of_both_sylow_normal proved in Part IV", "sylow_q_normal proved in Part II"]
   }
 ]

--- a/src/data/proofs/sylow-theorems-oq-01/meta.json
+++ b/src/data/proofs/sylow-theorems-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "sylow-theorems-oq-01",
   "title": "Classification of Groups of Order pq via Sylow Theorems",
   "slug": "sylow-theorems-oq-01",
-  "description": "For distinct primes p < q: if p \u2224 (q-1), the only group of order pq is cyclic. If p | (q-1), there are exactly two groups (cyclic + non-abelian semidirect product). Proves the Sylow counting arguments (n_q = 1, n_p \u2208 {1,q}), normality of unique Sylow subgroups, and states the classification theorem with concrete examples (orders 6, 15, 21, 35).",
+  "description": "For distinct primes p < q: if p does not divide (q-1), the only group of order pq is cyclic. If p divides (q-1), there are exactly two groups (cyclic + non-abelian semidirect product). Proves the Sylow counting arguments (n_q = 1, n_p ∈ {1,q}), normality of unique Sylow subgroups, and states the classification theorem with concrete examples (orders 6, 15, 21, 35).",
   "meta": {
     "author": "Burnside (1911); Sylow (1872)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Sylow_theorems#Examples",
@@ -23,16 +23,102 @@
     "lineCount": 387
   },
   "overview": {
-    "historicalContext": "The classification of groups of order pq is one of the first applications of Sylow's theorems taught in abstract algebra. Burnside's 1911 textbook included this classification as a foundational result.",
+    "historicalContext": "Ludwig Sylow (1872) published three landmark theorems about finite groups in Mathematische Annalen: existence of p-Sylow subgroups (subgroups of order p^k where p^k exactly divides |G|), conjugacy (all Sylow p-subgroups are conjugate), and counting (their number n_p satisfies n_p ≡ 1 mod p and n_p | |G|/p^k). These results, proved when group theory itself was nascent, became the primary tool for classifying finite groups by order. The classification of groups of order pq for distinct primes p < q was one of the first explicit applications: worked out in the late 19th century and consolidated by William Burnside in his 1911 textbook 'Theory of Groups of Finite Order.' The result is a model of beautiful algebra: the entire isomorphism type of a pq-group is determined by the single arithmetic condition p | (q-1). When p ∤ (q-1), both Sylow subgroups are normal, G is isomorphic to their direct product ℤ/p × ℤ/q ≅ ℤ/pq (cyclic since gcd(p,q)=1). When p | (q-1), a non-trivial homomorphism φ : ℤ/p → Aut(ℤ/q) ≅ ℤ/(q-1) exists (since p | (q-1) = |Aut(ℤ/q)|), giving a non-abelian semidirect product ℤ/q ⋊_φ ℤ/p. For order 6: p=2, q=3, 2 | 2, the non-abelian group is S₃. For order 15: p=3, q=5, 3 ∤ 4, only ℤ/15. This formalization uses Mathlib's Sylow API and proves all main cases including the hardest — the cyclic result — via a commutator argument.",
     "problemStatement": "Classify all groups of order pq for distinct primes p < q.",
-    "text": "Formalizes the pq-group classification using Sylow counting arguments. Proves uniqueness of Sylow q-subgroups, normality results, and the key divisibility/congruence constraints.",
+    "proofStrategy": "Define IsPQGroup as a structure bundling primes p < q and |G| = pq. Helper lemmas extract Sylow subgroup orders using Nat.factorization (p-adic and q-adic valuations of pq). The main proof thread: n_q = 1 (since n_q | p and n_q ≡ 1 mod q, with p < q impossible to satisfy otherwise), so Q is normal. For P: n_p | q gives n_p ∈ {1, q}; n_p = q requires q ≡ 1 mod p (i.e., p | (q-1)). When both P and Q are normal: prove P ∩ Q = {1} (coprime order argument), then elements of P and Q commute (commutator in P ∩ Q = {1}), then gk has order pq (coprime orders + commutativity via Commute.orderOf_mul_eq_mul_orderOf_of_coprime), so G = ⟨gk⟩ is cyclic.",
     "keyInsights": [
-      "The Sylow q-subgroup is always unique (n_q | p and n_q \u2261 1 mod q, with p < q)",
-      "The classification depends solely on whether p | (q-1)",
-      "Concrete examples verify the theory: order 15 cyclic, order 6 has S\u2083",
-      "Helper lemmas compute Sylow subgroup orders via prime factorization of pq"
+      "n_q = 1 always: the constraints n_q | p and n_q ≡ 1 mod q with p < q force n_q = 1, since n_q = p would require p ≡ 1 mod q, i.e., p % q = 1, but p < q gives p % q = p ≥ 2 — a contradiction proved by `omega`",
+      "Coprime intersection P ∩ Q = {1}: any x in both Sylow subgroups has orderOf x | p and orderOf x | q; since Nat.Coprime p q (proved via hp.coprime_iff_not_dvd), Nat.eq_one_of_dvd_coprimes gives orderOf x = 1, so x = 1 — a clean application of the coprimality API",
+      "Commutator argument for P–Q commutativity: the commutator c = g⁻¹k⁻¹gk lies in P (because P is normal: k⁻¹gk ∈ P, and g⁻¹ ∈ P, so their product is in P) and in Q (symmetrically); c ∈ P ∩ Q = {1} forces g⁻¹(k⁻¹gk) = 1, i.e., k⁻¹gk = g, i.e., gk = kg",
+      "Generator of the cyclic group: g has order p, k has order q, gk = kg (commutativity), gcd(p,q) = 1; `Commute.orderOf_mul_eq_mul_orderOf_of_coprime` gives orderOf(gk) = pq = |G|; then Subgroup.zpowers(gk) has cardinality pq = |G|, so it equals ⊤, making gk a generator",
+      "The factorization API: `Nat.factorization_mul` combined with `Nat.Prime.prime.factorization` (a prime n has factorization = Finsupp.single n 1) and `Finsupp.single_apply` with `if_pos/neg` extracts the p-adic and q-adic valuations of pq = 1 each — a pattern reusable for any product of distinct primes",
+      "sylow_normal_of_card_one uses the Subsingleton path: card = 1 → Subsingleton (Sylow p G) → all Sylow subgroups are equal → any conjugate of P equals P → normalizer = ⊤ → P is normal; formalized via `Sylow.smul_eq_iff_mem_normalizer` and `eq_top_iff`"
+    ]
+  },
+  "sections": [
+    {
+      "id": "setup",
+      "title": "Part I: IsPQGroup Structure and Helper Lemmas",
+      "startLine": 39,
+      "endLine": 116,
+      "summary": "IsPQGroup bundles primes p, q, the inequality p ≠ q, and |G| = pq. Helper lemmas: factorization_pq_at_q/p compute p-adic/q-adic valuations of pq using Nat.factorization + Finsupp.single_apply. sylow_q_card/sylow_p_card use Q.card_eq_multiplicity. sylow_q_index/sylow_p_index use card_mul_index + mul_left_cancel₀. sylow_normal_of_card_one: card=1 → Subsingleton → smul_eq_iff_mem_normalizer → normalizer_eq_top → normal.",
+      "mathContext": "The `IsPQGroup G` structure encodes: $p, q$ prime, $p \\neq q$, $|G| = pq$. Mathlib's `Sylow p G` is the type of Sylow $p$-subgroups of $G$; `Q.card_eq_multiplicity` states $|Q| = p^{v_p(|G|)}$ where $v_p$ is the $p$-adic valuation. Since $|G| = pq$ with $p, q$ distinct primes, $v_p(pq) = 1$ (computed via `Nat.factorization_mul` and `Finsupp.single_apply`), giving $|Q| = p$."
+    },
+    {
+      "id": "unique-sylow-q",
+      "title": "Part II: Sylow q-Subgroup is Unique (n_q = 1)",
+      "startLine": 125,
+      "endLine": 159,
+      "summary": "sylow_q_count_constraint: n_q | p (via card_sylow_dvd_index) and n_q ≡ 1 mod q (via card_sylow_modEq_one). unique_sylow_q: if n_q = p then p % q = 1, but p < q gives p % q = p ≥ 2 — contradiction by omega. sylow_q_normal: delegates to sylow_normal_of_card_one.",
+      "mathContext": "Sylow's third theorem: $n_q \\mid \\text{index}(Q) = p$ and $n_q \\equiv 1 \\pmod{q}$. Since $p < q$, the only divisor of $p$ satisfying $n_q \\equiv 1 \\pmod{q}$ is $n_q = 1$ (as $p < q$ means $p \\not\\equiv 1 \\pmod{q}$). Mathlib: `card_sylow_dvd_index` and `card_sylow_modEq_one`."
+    },
+    {
+      "id": "sylow-p-analysis",
+      "title": "Part III: Sylow p-Subgroup Analysis (n_p ∈ {1, q})",
+      "startLine": 168,
+      "endLine": 189,
+      "summary": "sylow_p_count: n_p | q (prime), so n_p ∈ {1, q} by hq.eq_one_or_self_of_dvd. unique_sylow_p_when_coprime: if n_p = q, then card_sylow_modEq_one gives q ≡ 1 mod p, so p | (q-1) by modEq_iff_dvd', contradicting hndvd.",
+      "mathContext": "Sylow's third theorem: $n_p \\mid \\text{index}(P) = q$. Since $q$ is prime, $n_p \\in \\{1, q\\}$. If $n_p = q$, then $q \\equiv 1 \\pmod{p}$ (from `card_sylow_modEq_one`), i.e., $p \\mid (q-1)$. Contrapositive: $p \\nmid (q-1) \\Rightarrow n_p = 1$."
+    },
+    {
+      "id": "cyclic-case",
+      "title": "Part IV: Both Sylow Subgroups Normal → G Cyclic",
+      "startLine": 198,
+      "endLine": 304,
+      "summary": "cyclic_of_both_sylow_normal: the core proof. (1) P ∩ Q = {1} by coprimality + Nat.eq_one_of_dvd_coprimes. (2) P–Q commutativity by commutator argument. (3) IsCyclic of prime-order subgroups by isCyclic_of_prime_card. (4) Get generators g (order p), k (order q). (5) orderOf(gk) = pq by Commute.orderOf_mul_eq. (6) zpowers(gk) = ⊤ by card = |G|.",
+      "mathContext": "When both Sylow subgroups $P$ (order $p$) and $Q$ (order $q$) are normal with $\\gcd(p,q)=1$: $P \\cap Q = \\{1\\}$ (order of any element in both divides $\\gcd(p,q)=1$). Commutativity: for $g \\in P, k \\in Q$, the commutator $c = g^{-1}k^{-1}gk \\in P$ (since $P$ normal: $k^{-1}gk \\in P$) and $c \\in Q$ (since $Q$ normal: $g^{-1}k^{-1}g \\in Q$); so $c = 1$, giving $gk = kg$. Then $\\mathrm{ord}(gk) = \\mathrm{lcm}(p,q) = pq = |G|$."
+    },
+    {
+      "id": "nonabelian-case",
+      "title": "Part V: Non-Abelian Case When p | (q-1)",
+      "startLine": 314,
+      "endLine": 331,
+      "summary": "nonAbelianPQExists: Prop asserting the non-cyclic pq-group exists (existence not proved, stated as a definition). nonabelian_sylow_p_count: if G is non-cyclic with p | (q-1), then n_p = q (proved by contradiction: n_p = 1 → both normal → G cyclic → contradiction).",
+      "mathContext": "When $p \\mid (q-1)$, there exists a non-trivial homomorphism $\\varphi : \\mathbb{Z}/p \\to \\operatorname{Aut}(\\mathbb{Z}/q) \\cong \\mathbb{Z}/(q-1)$ (since $p \\mid |\\operatorname{Aut}(\\mathbb{Z}/q)|$). The semidirect product $\\mathbb{Z}/q \\rtimes_\\varphi \\mathbb{Z}/p$ is a non-abelian group of order $pq$ with $n_p = q$."
+    },
+    {
+      "id": "classification",
+      "title": "Part VI: Complete Classification Theorem",
+      "startLine": 343,
+      "endLine": 359,
+      "summary": "pqClassification: Prop encoding the full classification as an if-then-else (non-divisibility branch: ∀ G, |G|=pq → IsCyclic G; divisibility branch: True placeholder pending isomorphism machinery). pq_cyclic_classification: the proved half — p ∤ (q-1) → every pq-group is cyclic.",
+      "mathContext": "The complete classification: (1) if $p \\nmid (q-1)$: unique group $\\mathbb{Z}/pq$; (2) if $p \\mid (q-1)$: exactly two groups — $\\mathbb{Z}/pq$ and $\\mathbb{Z}/q \\rtimes \\mathbb{Z}/p$. Case (1) is fully proved; case (2) uses `True` as a placeholder since stating the uniqueness of the semidirect product requires isomorphism machinery not yet formalized."
+    },
+    {
+      "id": "examples",
+      "title": "Part VII: Concrete Examples",
+      "startLine": 365,
+      "endLine": 382,
+      "summary": "Four omega-proved arithmetic facts: order 15 (3 ∤ 4 → cyclic), order 6 (2 | 2 → non-abelian exists), order 35 (5 ∤ 6 → cyclic), order 21 (3 | 6 → non-abelian exists).",
+      "mathContext": "The examples verify the arithmetic conditions: $15 = 3 \\times 5$: $3 \\nmid (5-1)=4$ (cyclic only); $6 = 2 \\times 3$: $2 \\mid (3-1)=2$ (two groups: $\\mathbb{Z}/6$ and $S_3$); $35 = 5 \\times 7$: $5 \\nmid (7-1)=6$ (cyclic only); $21 = 3 \\times 7$: $3 \\mid (7-1)=6$ (two groups: $\\mathbb{Z}/21$ and non-abelian)."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "sylow-theorem",
+      "relationship": "extends",
+      "description": "Applies Sylow theorems to classify groups of order pq"
+    }
+  ],
+  "conclusion": {
+    "summary": "A complete Lean 4 formalization of the pq-group classification: the cyclic direction (p ∤ (q-1) → IsCyclic G) is fully machine-checked via Sylow counting + commutator argument + order computation. The non-abelian direction is formalized as a Prop placeholder, with the counting result (n_p = q when G non-cyclic) proved. 20 theorems, 0 axioms, 0 sorries.",
+    "implications": "The commutator argument in cyclic_of_both_sylow_normal is a template for proving commutativity from normal subgroups with trivial intersection — a technique applicable to the classification of all groups of squarefree order and to the proof that abelian groups are precisely those where every pair of Sylow subgroups commute. The factorization_pq helper pattern (using Nat.factorization + Finsupp.single_apply + omega) generalizes to extracting prime power exponents in any product of distinct primes — reusable in other group order computations. The `Commute.orderOf_mul_eq_mul_orderOf_of_coprime` usage here is a key technique for building cyclic groups from commuting elements of coprime order.",
+    "openQuestions": [
+      "Can the non-abelian case be completed? Stating 'there are exactly two isomorphism classes' for p | (q-1) requires group isomorphism machinery in Lean 4/Mathlib — specifically, classifying semidirect products up to isomorphism, which involves the conjugacy classes of Hom(ℤ/p, Aut(ℤ/q))",
+      "Can the full squarefree-order classification be formalized? Every group of squarefree order n = p₁p₂···pₖ is a semidirect product of cyclic groups, with the structure determined by the divisibility relations among the pᵢ — a generalization of the pq case to multiple primes",
+      "The Feit-Thompson theorem (1963) proves all groups of odd order are solvable (~255 pages). Can Lean 4's Sylow + commutator infrastructure support even a partial formalization? Mathlib's existing group theory provides the building blocks, but the induction scheme and character theory arguments would require substantial new infrastructure"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
     ],
-    "proofStrategy": "Formalizes the pq-group classification using Sylow counting arguments. Proves uniqueness of Sylow q-subgroups, normality results, and the key divisibility/congruence constraints."
+    "namespace": "SylowPQ",
+    "lineCount": 387,
+    "axiomCount": 0,
+    "theoremCount": 20,
+    "sorryTheorems": 0,
+    "definitionCount": 3
   },
   "mainTheorems": [
     {
@@ -48,56 +134,37 @@
     {
       "name": "unique_sylow_p_when_coprime",
       "type": "core",
-      "description": "If p \u2224 (q-1), the Sylow p-subgroup is also unique"
+      "description": "If p does not divide (q-1), the Sylow p-subgroup is also unique"
     },
     {
       "name": "both_normal_when_coprime",
       "type": "core",
-      "description": "If p \u2224 (q-1), both Sylow subgroups are normal"
+      "description": "If p does not divide (q-1), both Sylow subgroups are normal"
     },
     {
       "name": "sylow_p_count",
       "type": "supporting",
-      "description": "n_p \u2208 {1, q} for groups of order pq"
+      "description": "n_p is either 1 or q for groups of order pq"
     },
     {
       "name": "cyclic_when_coprime",
       "type": "core",
-      "description": "p \u2224 (q-1) \u2192 G is cyclic (proved via commutator + order argument)"
+      "description": "p does not divide (q-1) implies G is cyclic (proved via commutator + order argument)"
     },
     {
       "name": "nonabelian_sylow_p_count",
       "type": "core",
-      "description": "p | (q-1) and \u00accyclic \u2192 n_p = q (proved by contradiction)"
+      "description": "p divides (q-1) and G not cyclic implies n_p = q (proved by contradiction)"
     },
     {
       "name": "pq_cyclic_classification",
       "type": "core",
-      "description": "p \u2224 (q-1) \u2192 every group of order pq is cyclic (proved)"
+      "description": "p does not divide (q-1) implies every group of order pq is cyclic (proved)"
     },
     {
       "name": "order_15_cyclic",
       "type": "supporting",
-      "description": "Groups of order 15 are cyclic (3 \u2224 4)"
+      "description": "Groups of order 15 are cyclic (3 does not divide 4)"
     }
-  ],
-  "crossReferences": [
-    {
-      "targetId": "sylow-theorem",
-      "relationship": "extends",
-      "description": "Applies Sylow theorems to classify groups of order pq"
-    }
-  ],
-  "leanFile": {
-    "imports": [
-      "Mathlib"
-    ],
-    "namespace": "SylowPQ",
-    "lineCount": 387,
-    "axiomCount": 0,
-    "theoremCount": 20,
-    "sorryTheorems": 0,
-    "definitionCount": 3
-  },
-  "sections": []
+  ]
 }


### PR DESCRIPTION
Enriches the `sylow-theorems-oq-01` gallery entry (Classification of Groups of Order pq via Sylow Theorems).

## Changes

**meta.json:**
- Expanded `overview.historicalContext` (>500 chars): Sylow 1872, Burnside 1911, pq classification history, semidirect product structure, concrete examples
- Expanded `overview.keyInsights` from 4 to 6 (n_q=1 argument, coprime intersection, commutator commutativity, cyclic generator via orderOf_mul, factorization API, sylow_normal_of_card_one path)
- Expanded `overview.proofStrategy` with precise theorem references
- Added 7 sections matching the file's 7 parts, each with mathContext
- Added full `conclusion` with implications (3 reusable patterns) and 3 openQuestions (isomorphism machinery, squarefree classification, Feit-Thompson)

**annotations.json (upgraded from 2 stub annotations to 5 full-schema annotations):**
1. `unique_sylow_q` — the p < q forcing argument
2. Commutator commutativity — Normal.conj_mem + disjoint_def
3. Cyclic generator — orderOf_mul for coprime commuting elements
4. Nat.factorization API — Finsupp pattern for Sylow subgroup orders
5. `nonabelian_sylow_p_count` — proof by contradiction pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)