### PR TITLE
Fix: erdos-10 status/badge correction (verified → axiomatized)

### DIFF
--- a/src/data/proofs/erdos-10/meta.json
+++ b/src/data/proofs/erdos-10/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/10",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos10Problem.lean",
     "tags": [
       "erdos",
@@ -16,13 +16,13 @@
       "powers of 2",
       "density"
     ],
-    "badge": "verified",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 10,
     "erdosUrl": "https://erdosproblems.com/10",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "assumptions": "8 axiom declarations: erdos_10_conjecture (main conjecture), gallagher_density (density result), granville_soundararajan_odd/even (representation conjectures), grechuk_counterexample (k=3 counterexample), infinitely_many_exceptions_k2/k3 (exception existence), romanoff_positive_density (positive density). All results are deep number-theoretic facts axiomatized in the formalization.",
+    "assumptions": "Open problem: Erdős Problem #10 asks whether there exists k such that every sufficiently large integer is a sum of a prime and at most k powers of 2. The Lean file contains 0 formal axiom declarations — it defines the key sets (sumPrimeAndTwoPows, Set.lowerDensity) but leaves the main results as doc-comment descriptions. Classified as axiomatized per CLAUDE.md policy for open conjectures.",
     "lineCount": 94,
     "prerequisites": [
       "Prime numbers and their distribution",


### PR DESCRIPTION
## Fix

Corrects `erdos-10` (Sums of a Prime and Powers of 2) from `"verified"` to `"axiomatized"`.

## Evidence

**Before**:
- `status: "verified"`, `badge: "verified"` ← incorrect
- `assumptions` claims "8 axiom declarations" but Lean file has 0 formal axioms

**After**:
- `status: "axiomatized"`, `badge: "axiom"` ← correct per CLAUDE.md policy
- `assumptions` accurately describes: 0 formal axioms, problem is open, results are doc-comment descriptions only

Per CLAUDE.md: "Open conjectures: always `axiomatized`". Erdős Problem #10 is an open problem Erdős described as "probably unattackable" — it cannot be `"verified"`.

Closes #8818

---
Automated fix by lean-mechanic agent.