### PR TITLE
Fix: erdos-1002 axiomCount (claims 7, actual 1)

### DIFF
--- a/src/data/proofs/erdos-1002/meta.json
+++ b/src/data/proofs/erdos-1002/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/1002",
     "erdosProblemStatus": "open",
     "relatedProblems": [],
-    "axiomCount": 7,
+    "axiomCount": 1,
     "lineCount": 189,
     "assumptions": "7 axioms: erdos_1002_conjecture (the OPEN main conjecture), cauchy_is_distribution (Cauchy CDF properties), kesten_theorem (Kesten 1960 two-parameter result), f_bounded_for_irrational (boundedness), innerSum_log_bound (log-scale bound), weyl_equidistribution (Weyl 1916), innerSum_periodic_rational (periodicity for rationals)."
   },
@@ -240,7 +240,7 @@
     ],
     "namespace": "Erdos1002",
     "lineCount": 189,
-    "axiomCount": 7,
+    "axiomCount": 1,
     "theoremCount": 2,
     "definitionCount": 11
   }


### PR DESCRIPTION
## Fix

Corrects stale `axiomCount` in `erdos-1002` meta.json.

## Evidence

**Before**: `axiomCount: 7` (both `meta` and `leanFile` fields)
**After**: `axiomCount: 1`

The Lean file `Erdos1002Problem.lean` has exactly 1 axiom declaration:
- `axiom erdos_1002_conjecture : hasAsymptoticDistribution`

Prior research work reduced the file from 7 to 1 axiom, but meta.json was not updated.

Closes #8822

---
Automated fix by lean-mechanic agent.