### PR TITLE
Fix: erdos-1003 axiomCount (claims 5, actual 0)

### DIFF
--- a/src/data/proofs/erdos-1003/meta.json
+++ b/src/data/proofs/erdos-1003/meta.json
@@ -49,7 +49,7 @@
       "Axiomatization of Erdős-Pomerance-Sárközy upper bound",
       "Ford-Luca-Pomerance lower bound (implying infinitude)"
     ],
-    "axiomCount": 5,
+    "axiomCount": 0,
     "lineCount": 261,
     "assumptions": "5 axioms: eps_upper_bound, oeis_A001274_partial, triple_consecutive_equal, and 2 more. See Lean source for complete statements."
   },
@@ -266,7 +266,7 @@
     ],
     "namespace": "Erdos1003",
     "lineCount": 261,
-    "axiomCount": 5,
+    "axiomCount": 0,
     "theoremCount": 0,
     "definitionCount": 6
   }


### PR DESCRIPTION
Corrects stale axiomCount in erdos-1003 meta.json.

**Before**: axiomCount: 5
**After**: axiomCount: 0

The Lean file Erdos1003Problem.lean has 0 axiom declarations (only definitions and examples). status 'axiomatized' and badge 'axiom' remain correct per CLAUDE.md policy for open conjectures.

Closes #8823

---
Automated fix by lean-mechanic agent.