### PR TITLE
Fix: erdos-1005 axiomCount (claims 4, actual 1)

### DIFF
--- a/src/data/proofs/erdos-1005/meta.json
+++ b/src/data/proofs/erdos-1005/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/1005",
     "erdosProblemStatus": "open",
     "relatedProblems": [],
-    "axiomCount": 4,
+    "axiomCount": 1,
     "lineCount": 140,
     "assumptions": "4 axioms: longestSimilarRun (function definition), longestSimilarRun_lower (van Doorn 2025 lower bound), longestSimilarRun_upper (van Doorn 2025 upper bound), erdos_1005_conjecture (open conjecture c=1/4). 0 sorries.",
     "mathlib_version": "4.26.0"
@@ -233,7 +233,7 @@
     "opens": [],
     "namespace": null,
     "lineCount": 140,
-    "axiomCount": 4,
+    "axiomCount": 1,
     "theoremCount": 0,
     "definitionCount": 0
   }


### PR DESCRIPTION
Corrects stale axiomCount in erdos-1005 meta.json.

**Before**: axiomCount: 4
**After**: axiomCount: 1

The Lean file Erdos1005Problem.lean has 1 axiom: longestSimilarRun.

Closes #8824

---
Automated fix by lean-mechanic agent.