### PR TITLE
Fix: erdos-102 axiomCount (claims 5, actual 1)

### DIFF
--- a/src/data/proofs/erdos-102/meta.json
+++ b/src/data/proofs/erdos-102/meta.json
@@ -46,7 +46,7 @@
       "Axiomatized Szemerédi–Trotter incidence bound context",
       "Stated Erdős–Purdy origin connection"
     ],
-    "axiomCount": 5,
+    "axiomCount": 1,
     "lineCount": 173,
     "assumptions": "5 axiom(s): 1 open conjecture (erdos_102_divergence), 4 deep results. erdos_purdy_connection PROVED: rich lines existing implies some line has ≥4 points."
   },
@@ -214,7 +214,7 @@
     "opens": [],
     "namespace": null,
     "lineCount": 173,
-    "axiomCount": 5,
+    "axiomCount": 1,
     "theoremCount": 5,
     "definitionCount": 3
   }


### PR DESCRIPTION
Corrects stale axiomCount in erdos-102 meta.json.

**Before**: axiomCount: 5
**After**: axiomCount: 1

The Lean file Erdos102Problem.lean has 1 axiom: connection_101.

Closes #8827

---
Automated fix by lean-mechanic agent.