### PR TITLE
Fix: erdos-519 sorries count 1→0 (proved by PR #8816)

### DIFF
--- a/src/data/proofs/erdos-519/meta.json
+++ b/src/data/proofs/erdos-519/meta.json
@@ -16,7 +16,7 @@
       "turan"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 519,
     "erdosUrl": "https://erdosproblems.com/519",
     "erdosProblemStatus": "solved",


### PR DESCRIPTION
## Fix

Update `sorries` count from 1 to 0 for `erdos-519` (Power Sums of Complex Numbers).

## Evidence

**Before**: `sorries: 1` in meta.json
**After**: `sorries: 0`

PR #8816 (`Fix Erdos519Problem.lean: resolve build errors and prove why_first_one_matters`) proved the remaining sorry in this file, but did not update `meta.json`. The Lean source now has 0 actual sorries in code (verified by comment-stripping analysis).

The `axiomCount: 2` and `status: axiomatized` remain correct — the proof still has 2 `axiom` declarations.

---
Automated fix by lean-mechanic agent.