### PR TITLE
Fix: lineCount sync for 15 gallery proofs (batch 11)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-03/meta.json
@@ -18,7 +18,7 @@
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 57
+    "lineCount": 65
   },
   "overview": {
     "historicalContext": "The classical means — harmonic, geometric, and arithmetic — were studied since antiquity. Pythagoras and his school recognized all three; they appear in Euclid's *Elements* and in the music theory of ancient Greece. Cauchy gave the first rigorous proof of the AM-GM inequality in his 1821 *Cours d'analyse*. The unification of all these means under a single parametric family — the power mean $M_r$ — was systematically developed by Hardy, Littlewood, and Pólya in their landmark 1934 monograph *Inequalities*, which remains a standard reference in mathematical analysis. The extreme cases ($M_r \\to \\max$ as $r \\to +\\infty$, $M_r \\to \\min$ as $r \\to -\\infty$) complete this family geometrically: the power mean traces a continuous, monotone path from the minimum value through the geometric mean, arithmetic mean, and beyond, ultimately converging to the maximum. This perspective reveals the AM-GM inequality ($M_0 \\leq M_1$) as just one instance of a much richer monotonicity principle.",

--- a/src/data/proofs/area-of-circle-oq-01-oq-03-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03-oq-01/meta.json
@@ -34,7 +34,7 @@
       "arcLengthInv_quasi_periodic: σ(y+L) = σ(y)+2π, proved from arc-length quasi-periodicity",
       "exists_arclength_reparam': full arc-length reparametrization theorem with constant speed L/(2π)"
     ],
-    "lineCount": 340,
+    "lineCount": 517,
     "theoremCount": 22,
     "defCount": 3
   },

--- a/src/data/proofs/area-of-circle-oq-05/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05/meta.json
@@ -20,7 +20,7 @@
     "axiomCount": 0,
     "assumptions": "None. All results derived from Mathlib's integral_gaussian and standard Mathlib analysis lemmas.",
     "dateAdded": "2026-03-30",
-    "lineCount": 118,
+    "lineCount": 132,
     "mathlibDependencies": [
       {
         "theorem": "integral_gaussian",

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01/meta.json
@@ -33,7 +33,7 @@
       "Verified thresholds for d=3 (n=4), d=4 (n=6), d=5 (n=8) via decide",
       "birthday_threshold_statement: n=88 threshold stated for d=365 from axioms"
     ],
-    "lineCount": 220,
+    "lineCount": 243,
     "theoremCount": 25,
     "defCount": 2
   },

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-incomplete-01/meta.json
@@ -33,7 +33,7 @@
       "typeUniverse: CategoricalEval instance from the type universe (objects = types, apply = function application)",
       "sorry_diagnosis_resolved: documents that making e explicit is sufficient and necessary"
     ],
-    "lineCount": 185,
+    "lineCount": 240,
     "theoremCount": 7,
     "defCount": 3
   },

--- a/src/data/proofs/cramers-rule-oq-01-oq-04/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-04/meta.json
@@ -35,7 +35,7 @@
       "power_sums_determined_by_first_n: all pₖ for k > n are determined by p₁,...,pₙ (proved by induction on the large recurrence)",
       "cayley_hamilton: immediate wrapper for Matrix.aeval_self_charpoly, documenting the Cayley-Hamilton connection"
     ],
-    "lineCount": 343,
+    "lineCount": 327,
     "theoremCount": 17,
     "defCount": 2
   },

--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-01/meta.json
@@ -47,7 +47,7 @@
     ],
     "dateAdded": "2026-04-03",
     "axiomCount": 0,
-    "lineCount": 285
+    "lineCount": 328
   },
   "overview": {
     "historicalContext": "DissectionOfCubesOQ01 established that every nonempty cube dissection has at least 2 colliding cubes (collidingCubes.card ≥ 2). This OQ sub-question asks whether the lower bound of 2 is tight: can a cube dissection actually achieve exactly 2 colliding cubes?\n\nThis formalization answers YES within our mathematical model, where the covering constraint is a placeholder (covers_unit_cube : True). The geometric question — whether an actual tiling of the unit cube can have exactly one repeated size — remains open.",

--- a/src/data/proofs/erdos-1098-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1098-oq-01-oq-01/meta.json
@@ -31,7 +31,7 @@
       "three_clique_necessary_conditions: 3-clique implies non-abelian + all elements non-central + index ≥ 4",
       "erdos_1098_oq01_oq01: combines S₃ existence with necessity conditions"
     ],
-    "lineCount": 170,
+    "lineCount": 205,
     "theoremCount": 8,
     "defCount": 3
   },

--- a/src/data/proofs/erdos-157/meta.json
+++ b/src/data/proofs/erdos-157/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-157",
-  "title": "Erd\u0151s Problem #157: Infinite Sidon Set as Asymptotic Basis",
+  "title": "Erdős Problem #157: Infinite Sidon Set as Asymptotic Basis",
   "slug": "erdos-157",
   "description": "Does there exist an infinite Sidon set which is an asymptotic basis of order 3? YES (Pilatte 2023). Two theorems verified: sidon_iff_sidon_alt and powers_of_two_sidon.",
   "meta": {
-    "author": "Pilatte (2023), Erd\u0151s-Tur\u00e1n (1941)",
+    "author": "Pilatte (2023), Erdős-Turán (1941)",
     "sourceUrl": "https://erdosproblems.com/157",
     "date": "2023",
     "status": "axiomatized",
@@ -47,29 +47,29 @@
       }
     ],
     "originalContributions": [
-      "Definition of IsSidon (B\u2082 sequence property)",
+      "Definition of IsSidon (B₂ sequence property)",
       "Alternative characterization IsSidonAlt via sumset cardinality",
       "Verified theorem: sidon_iff_sidon_alt (equivalence of definitions)",
       "Definition of SumsetK for k-fold sums",
       "Definition of IsAsymptoticBasis for asymptotic bases",
       "Erdos157Conjecture formalization",
       "Pilatte's existence theorem statement",
-      "Sidon density upper bound (Erd\u0151s-Tur\u00e1n)",
+      "Sidon density upper bound (Erdős-Turán)",
       "Basis density lower bound",
       "Verified theorem: powers_of_two_sidon"
     ],
     "axiomCount": 2,
-    "lineCount": 192,
+    "lineCount": 258,
     "assumptions": "2 axiom(s) and 2 sorry(s). See the Lean source for details."
   },
   "overview": {
-    "historicalContext": "Sidon sets (B$_2$ sequences) \u2014 sets where all pairwise sums are distinct \u2014 were introduced by Simon Sidon in correspondence with Erd\u0151s in the 1930s. Erd\u0151s and P\u00e1l Tur\u00e1n proved in 1941 that a Sidon subset of $\\{1, \\ldots, N\\}$ has at most $(1+o(1))\\sqrt{N}$ elements, establishing their fundamental sparsity.\n\nAsymptotic bases of order $k$ \u2014 sets $A$ where every sufficiently large integer is a sum of at most $k$ elements of $A$ \u2014 require density at least $N^{1/k}$ by a counting argument. The tension between Sidon sparsity ($\\leq N^{1/2}$) and basis density ($\\geq N^{1/k}$) creates a natural threshold: coexistence requires $1/k \\leq 1/2$, i.e., $k \\geq 2$. But $k = 2$ is exactly the boundary and fails for subtle arithmetic reasons.\n\nErd\u0151s conjectured that order 3 should work, and this was open for decades despite partial results by Deshouillers and Plagne (2003) on finite Sidon sets. C\u00e9dric Pilatte (Oxford) settled the conjecture affirmatively in 2023 using a probabilistic construction, applying the Lov\u00e1sz Local Lemma and a careful densification argument. His proof is non-explicit: it shows such sets exist without constructing one.\n\nThis formalization includes two fully verified theorems: the equivalence of two Sidon set definitions, and the proof that $\\{2^k : k \\in \\mathbb{N}\\}$ forms a Sidon set (since binary representations are unique).",
-    "problemStatement": "**Erd\u0151s Problem #157 (SOLVED)**: Does there exist an infinite Sidon set which is an asymptotic basis of order 3?\n\n**Answer**: YES (Pilatte 2023)\n\n**Definitions**:\n- **Sidon set**: A \u2286 \u2115 where a + b = c + d (a \u2264 b, c \u2264 d) implies (a,b) = (c,d)\n- **Asymptotic basis of order k**: \u2203 N\u2080, \u2200 n \u2265 N\u2080, n is a sum of \u2264 k elements of A\n\n**Key insight**: Sidon sets grow like \u221aN = N^{1/2}. Order-k bases need N^{1/k} density. Since 1/3 < 1/2, order 3 is feasible while order 2 is not.",
+    "historicalContext": "Sidon sets (B$_2$ sequences) — sets where all pairwise sums are distinct — were introduced by Simon Sidon in correspondence with Erdős in the 1930s. Erdős and Pál Turán proved in 1941 that a Sidon subset of $\\{1, \\ldots, N\\}$ has at most $(1+o(1))\\sqrt{N}$ elements, establishing their fundamental sparsity.\n\nAsymptotic bases of order $k$ — sets $A$ where every sufficiently large integer is a sum of at most $k$ elements of $A$ — require density at least $N^{1/k}$ by a counting argument. The tension between Sidon sparsity ($\\leq N^{1/2}$) and basis density ($\\geq N^{1/k}$) creates a natural threshold: coexistence requires $1/k \\leq 1/2$, i.e., $k \\geq 2$. But $k = 2$ is exactly the boundary and fails for subtle arithmetic reasons.\n\nErdős conjectured that order 3 should work, and this was open for decades despite partial results by Deshouillers and Plagne (2003) on finite Sidon sets. Cédric Pilatte (Oxford) settled the conjecture affirmatively in 2023 using a probabilistic construction, applying the Lovász Local Lemma and a careful densification argument. His proof is non-explicit: it shows such sets exist without constructing one.\n\nThis formalization includes two fully verified theorems: the equivalence of two Sidon set definitions, and the proof that $\\{2^k : k \\in \\mathbb{N}\\}$ forms a Sidon set (since binary representations are unique).",
+    "problemStatement": "**Erdős Problem #157 (SOLVED)**: Does there exist an infinite Sidon set which is an asymptotic basis of order 3?\n\n**Answer**: YES (Pilatte 2023)\n\n**Definitions**:\n- **Sidon set**: A ⊆ ℕ where a + b = c + d (a ≤ b, c ≤ d) implies (a,b) = (c,d)\n- **Asymptotic basis of order k**: ∃ N₀, ∀ n ≥ N₀, n is a sum of ≤ k elements of A\n\n**Key insight**: Sidon sets grow like √N = N^{1/2}. Order-k bases need N^{1/k} density. Since 1/3 < 1/2, order 3 is feasible while order 2 is not.",
     "text": "Does there exist an infinite Sidon set which is an asymptotic basis of order 3? YES (Pilatte 2023). Two theorems verified: sidon_iff_sidon_alt and powers_of_two_sidon.",
-    "proofStrategy": "The formalization captures the problem structure:\n\n1. **Sidon definitions**: IsSidon (direct) and IsSidonAlt (via cardinality)\n2. **Verified equivalence**: sidon_iff_sidon_alt proved using Set.ncard\n3. **Basis definitions**: SumsetK and IsAsymptoticBasis\n4. **Counting bounds**: Sidon upper bound (\u221aN), basis lower bound (N^{1/k})\n5. **Pilatte's theorem**: Existence statement (sorry - probabilistic construction)\n6. **Verified example**: powers_of_two_sidon shows {2^k} is Sidon",
+    "proofStrategy": "The formalization captures the problem structure:\n\n1. **Sidon definitions**: IsSidon (direct) and IsSidonAlt (via cardinality)\n2. **Verified equivalence**: sidon_iff_sidon_alt proved using Set.ncard\n3. **Basis definitions**: SumsetK and IsAsymptoticBasis\n4. **Counting bounds**: Sidon upper bound (√N), basis lower bound (N^{1/k})\n5. **Pilatte's theorem**: Existence statement (sorry - probabilistic construction)\n6. **Verified example**: powers_of_two_sidon shows {2^k} is Sidon",
     "keyInsights": [
       "**Order 3 is the boundary**: Order 2 impossible (density too low), order 3 achievable (Pilatte's construction).",
-      "**Density arithmetic**: Sidon \u2264 \u221aN = N^{1/2}, basis needs \u2265 N^{1/k}. Compatible iff k \u2265 3.",
+      "**Density arithmetic**: Sidon ≤ √N = N^{1/2}, basis needs ≥ N^{1/k}. Compatible iff k ≥ 3.",
       "**Powers of 2 example**: The canonical Sidon set {1, 2, 4, 8, ...} demonstrates the definition (verified).",
       "**Probabilistic proof**: Pilatte's construction is non-explicit, using the probabilistic method.",
       "**Bug discovery**: The original example set was NOT Sidon - formal verification caught this error."
@@ -119,8 +119,8 @@
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erd\u0151s Problem #157 on infinite Sidon sets as asymptotic bases. The answer is YES for order 3 (Pilatte 2023), while order 2 is impossible due to density constraints. The formalization includes two verified theorems: the equivalence of Sidon definitions, and the proof that powers of 2 form a Sidon set.",
-    "implications": "This result clarifies the boundary between sparse sets with unique-sum structure and dense sets capable of representing all integers. The interplay between Sidon sparsity (\u221aN) and basis density (N^{1/k}) is fundamental to understanding additive structure.",
+    "summary": "We formalize Erdős Problem #157 on infinite Sidon sets as asymptotic bases. The answer is YES for order 3 (Pilatte 2023), while order 2 is impossible due to density constraints. The formalization includes two verified theorems: the equivalence of Sidon definitions, and the proof that powers of 2 form a Sidon set.",
+    "implications": "This result clarifies the boundary between sparse sets with unique-sum structure and dense sets capable of representing all integers. The interplay between Sidon sparsity (√N) and basis density (N^{1/k}) is fundamental to understanding additive structure.",
     "openQuestions": [
       "Can an explicit infinite Sidon set that is an order-3 basis be constructed?",
       "What is the smallest order k such that every infinite Sidon set is NOT an order-k basis?",
@@ -130,22 +130,22 @@
   "crossReferences": [
     {
       "relationship": "related",
-      "description": "Erd\u0151s #156 (Minimum Size of Maximal Sidon Sets) \u2014 both problems study Sidon sets; #156 asks about maximality while #157 asks about basis properties",
+      "description": "Erdős #156 (Minimum Size of Maximal Sidon Sets) — both problems study Sidon sets; #156 asks about maximality while #157 asks about basis properties",
       "targetId": "erdos-156"
     },
     {
       "relationship": "related",
-      "description": "Erd\u0151s #158 (B\u2082[g] Sets) \u2014 generalizes Sidon sets (B\u2082 = B\u2082[1]) to allow g representations per sum; the density constraints change as g grows",
+      "description": "Erdős #158 (B₂[g] Sets) — generalizes Sidon sets (B₂ = B₂[1]) to allow g representations per sum; the density constraints change as g grows",
       "targetId": "erdos-158"
     },
     {
       "relationship": "related",
-      "description": "Erd\u0151s #1 (Distinct Subset Sums) \u2014 another problem about additive structure of sets, exploring how sums interact with set density",
+      "description": "Erdős #1 (Distinct Subset Sums) — another problem about additive structure of sets, exploring how sums interact with set density",
       "targetId": "erdos-1"
     },
     {
       "relationship": "foundational",
-      "description": "Pilatte's proof uses the probabilistic method (specifically the Lov\u00e1sz Local Lemma) \u2014 the alteration method is a key technique in this family of arguments",
+      "description": "Pilatte's proof uses the probabilistic method (specifically the Lovász Local Lemma) — the alteration method is a key technique in this family of arguments",
       "targetId": "prob-method-alteration"
     }
   ],
@@ -168,8 +168,8 @@
     {
       "key": "ET41b",
       "authors": [
-        "P. Erd\u0151s",
-        "P. Tur\u00e1n"
+        "P. Erdős",
+        "P. Turán"
       ],
       "title": "On a problem of Sidon in additive number theory, and on some related problems",
       "venue": "Journal of the London Mathematical Society",

--- a/src/data/proofs/erdos-519/meta.json
+++ b/src/data/proofs/erdos-519/meta.json
@@ -61,7 +61,7 @@
       "Symmetric polynomials and Newton's identities",
       "Extremal problems in complex analysis"
     ],
-    "lineCount": 268
+    "lineCount": 287
   },
   "overview": {
     "historicalContext": "Turán's power sum problem originates from Pál Turán's extensive work on extremal problems in analysis during the 1940s and 1950s. Turán initially studied power sums in connection with his 'power sum method' — a technique he developed as an alternative to Vinogradov's method of exponential sums, with applications to the Riemann zeta function and prime number theory. Turán proved the weaker result that $\\max_{1 \\le k \\le n} |\\sum z_i^k| \\ge c/n$, where $c > 0$ depends on the configuration. The crucial question was whether the dependence on $n$ could be eliminated entirely. F.V. Atkinson resolved this in 1961, proving $c = 1/6$ as an absolute lower bound — the first proof that the maximum power sum is bounded away from zero independently of $n$. Biró (1994) substantially improved this to $c = 1/2$ using refined analytic methods, and in 2000 pushed past the $1/2$ barrier. Computational experiments by several researchers suggest the optimal constant is approximately $0.7$, but no rigorous proof of this value exists. The problem is closely related to Turán's power sum method, which has deep connections to the distribution of zeros of the Riemann zeta function, Dirichlet $L$-functions, and the theory of almost periodic functions.",

--- a/src/data/proofs/erdos-659-oq-01/meta.json
+++ b/src/data/proofs/erdos-659-oq-01/meta.json
@@ -33,7 +33,7 @@
       "achievesImprovedBound: formal definition of 'improvement' via little-o",
       "familyFourPointProperty: formal definition of 4-point property for families"
     ],
-    "lineCount": 160,
+    "lineCount": 207,
     "theoremCount": 4,
     "defCount": 5
   },

--- a/src/data/proofs/sperner-ndim-oq-01/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-01/meta.json
@@ -31,7 +31,7 @@
       "freudenthal_adjacency_theorem: main theorem — exactly 2 k-element sets lie between prefix sets at k-1 and k+1",
       "freudenthal_two_intermediate_sets: existence corollary extracting the two explicit Finsets"
     ],
-    "lineCount": 185,
+    "lineCount": 220,
     "theoremCount": 7,
     "defCount": 1
   },

--- a/src/data/proofs/yang-mills-2d/meta.json
+++ b/src/data/proofs/yang-mills-2d/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "axiomCount": 1,
     "assumptions": "1 explicit axiom (gaugeTransform from YangMills/Classical.lean) plus structure-encoded assumptions: TwoDPartitionFunction requires representation decomposition and Casimir values. MigdalFormula encodes the exact Wilson loop expectation. SU(2)/SU(3) Casimir values are computed from representation theory. The 2D theory is exactly solvable — all results follow from these structures.",
-    "lineCount": 28053,
+    "lineCount": 28075,
     "mathlibDependencies": [
       {
         "theorem": "Real.exp_pos",

--- a/src/data/proofs/yang-mills-lattice/meta.json
+++ b/src/data/proofs/yang-mills-lattice/meta.json
@@ -19,7 +19,7 @@
     "sorries": 0,
     "axiomCount": 1,
     "assumptions": "1 explicit axiom (gaugeTransform from YangMills/Classical.lean) plus structure-encoded assumptions: WilsonLatticeAction requires coupling beta > 0 and character function. LinkVariable, LatticeGaugeTransform, and Plaquette encode lattice geometry. Wilson loop structures assume gauge-invariant trace. All lattice proofs (gauge invariance, bounds) are fully verified given these structures.",
-    "lineCount": 28053,
+    "lineCount": 28075,
     "mathlibDependencies": [
       {
         "theorem": "Finset.sum_nonneg",

--- a/src/data/proofs/yang-mills-transfer-matrix/meta.json
+++ b/src/data/proofs/yang-mills-transfer-matrix/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "axiomCount": 1,
     "assumptions": "1 explicit axiom (gaugeTransform from YangMills/Classical.lean) plus structure-encoded assumptions: TransferMatrix requires lambda_0 > lambda_1 > 0 (Perron-Frobenius eigenvalue ordering), and LatticeTransferMatrix requires positivity and strict gap. These encode the physical assumption that the transfer matrix has a spectral gap, which is proven for finite-volume lattice gauge theory.",
-    "lineCount": 28053,
+    "lineCount": 28075,
     "mathlibDependencies": [
       {
         "theorem": "Real.log_pos",


### PR DESCRIPTION
## Fix

Sync stale `lineCount` values in 15 gallery `meta.json` files to match the actual Lean source file line counts.

## Evidence

**Before/After** (selected examples):

| Proof | Before | After |
|-------|--------|-------|
| area-of-circle-oq-01-oq-03-oq-01 | 340 | 517 |
| erdos-157 | 192 | 258 |
| cantor-diagonalization-oq-03-oq-01-incomplete-01 | 185 | 240 |
| erdos-659-oq-01 | 160 | 207 |
| dissection-of-cubes-oq-01-oq-01 | 285 | 328 |
| sperner-ndim-oq-01 | 185 | 220 |
| yang-mills-{lattice,2d,transfer-matrix} | 28053 | 28075 |
| amgm-inequality-oq-03-oq-03 | 57 | 65 |
| erdos-519 | 268 | 287 |
| cramers-rule-oq-01-oq-04 | 343 | 327 |
| (5 more) | ... | ... |

Root cause: Lean files were extended by recent research/fix commits but `lineCount` was not updated in sync.

Note: 9 proofs with empty/placeholder Lean files (containing UUID artifacts) were excluded — their `lineCount: 0` is left unchanged.

---
Automated fix by lean-mechanic agent.