### PR TITLE
Fix: auditor scanner misses axioms in subdirectory imports

### DIFF
--- a/scripts/auditor/find-targets.ts
+++ b/scripts/auditor/find-targets.ts
@@ -153,19 +153,23 @@ function resolveAllLeanFiles(mainLeanPath: string, proofMeta: any): string[] {
   }
 
   // Detect submodule imports from main file (import Proofs.X.Y)
-  // Only follow imports into subdirectories that are prefixes of the main file name,
-  // to avoid counting sorries in shared libraries (e.g., GraphCore).
+  // Follow imports into subdirectories that are either:
+  //   1. A prefix of the main file name (e.g., "YangMills" prefix of "YangMillsProblem")
+  //   2. The same directory as the main file (e.g., main at YangMills/Exploration.lean → follow Proofs.YangMills.*)
+  // This avoids counting sorries in unrelated shared libraries (e.g., GraphCore).
   if (mainLeanPath && fs.existsSync(mainLeanPath)) {
     const mainBaseName = path.basename(mainLeanPath, '.lean')
+    const mainParentDir = path.basename(path.dirname(mainLeanPath))
     const content = fs.readFileSync(mainLeanPath, 'utf-8')
     const importRegex = /^import (Proofs\.\S+)/gm
     let match
     while ((match = importRegex.exec(content)) !== null) {
       const moduleParts = match[1].split('.')
-      // Only follow multi-level imports (Proofs.X.Y) where X is a prefix of the main file name
+      // Only follow multi-level imports (Proofs.X.Y)
       if (moduleParts.length < 3) continue
       const subDirName = moduleParts[1]
-      if (!mainBaseName.startsWith(subDirName)) continue
+      // Follow if X is a prefix of the main file name, OR if the main file lives in directory X
+      if (!mainBaseName.startsWith(subDirName) && mainParentDir !== subDirName) continue
 
       const modulePath = moduleParts.join('/')
       const subPath = path.join('proofs', modulePath + '.lean')


### PR DESCRIPTION
## Fix

Extend `resolveAllLeanFiles` in `scripts/auditor/find-targets.ts` to also follow submodule imports when the main Lean file lives inside the imported subdirectory (not just when the file name starts with the subdirectory name).

## Evidence

**Before**: `YangMills/Exploration.lean` imports `Proofs.YangMills.Classical`, but scanner checks `"Exploration".startsWith("YangMills")` → false → skips `Classical.lean` entirely. The axiom `gaugeTransform` in `Classical.lean` was invisible to the auditor.

**After**: Scanner additionally checks if the main file's parent directory matches the import subdirectory (`mainParentDir === subDirName`). For `YangMills/Exploration.lean`, `mainParentDir = "YangMills"` matches, so `Classical.lean` and `Quantum.lean` are now included.

Root-level imports to unrelated shared libraries (e.g., `Proofs.Graph.Core` from `Erdos321Problem.lean`) remain correctly blocked — `mainParentDir = "Proofs"` ≠ `"Graph"`.

Closes #8841

---
Automated fix by lean-mechanic agent.