### PR TITLE
chore: sync research listings and data

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -9757,11 +9757,12 @@
     },
     {
       "slug": "sum-of-kth-powers-oq-01",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T17:47:50.026Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T17:47:50.026Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T10:50:50.304Z",
+      "completed": "2026-04-03T10:50:50.304Z"
     },
     {
       "slug": "sylow-theorems-oq-04",
@@ -10897,11 +10898,12 @@
     },
     {
       "slug": "amgm-inequality-oq-03-oq-03-incomplete-01",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-03T07:37:00.135Z",
-      "status": "active",
-      "lastUpdate": "2026-04-03T07:37:00.135Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T10:50:50.304Z",
+      "completed": "2026-04-03T10:50:50.304Z"
     },
     {
       "slug": "bezout-identity-oq-04-oq-01-incomplete-01",
@@ -11030,11 +11032,12 @@
     },
     {
       "slug": "erdos-1126-oq-01-incomplete-01",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-03T08:12:38.874Z",
-      "status": "active",
-      "lastUpdate": "2026-04-03T08:12:38.874Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T10:50:50.295Z",
+      "completed": "2026-04-03T10:50:50.294Z"
     },
     {
       "slug": "erdos-1131-incomplete-01",
@@ -11198,11 +11201,12 @@
     },
     {
       "slug": "erdos-519-incomplete-01",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-03T08:51:33.913Z",
-      "status": "active",
-      "lastUpdate": "2026-04-03T08:51:33.913Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T10:50:50.297Z",
+      "completed": "2026-04-03T10:50:50.297Z"
     },
     {
       "slug": "erdos-564-incomplete-01",
@@ -11315,6 +11319,87 @@
       "started": "2026-04-03T09:15:40.651Z",
       "status": "active",
       "lastUpdate": "2026-04-03T09:15:40.651Z"
+    },
+    {
+      "slug": "shannon-entropy-oq-03-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-03T10:50:50.309Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T10:50:50.323Z"
+    },
+    {
+      "slug": "sum-of-kth-powers-oq-04-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-03T10:50:50.309Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T10:50:50.309Z",
+      "completed": "2026-04-03T10:50:50.309Z"
+    },
+    {
+      "slug": "fundamental-theorem-calculus-oq-01-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T10:50:50.309Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T10:50:50.323Z"
+    },
+    {
+      "slug": "stirling-formula-oq-01-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T10:50:50.309Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T10:50:50.323Z"
+    },
+    {
+      "slug": "cauchy-schwarz-oq-02-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T10:50:50.309Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T10:50:50.323Z"
+    },
+    {
+      "slug": "fundamental-theorem-calculus-oq-02-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T10:50:50.309Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T10:50:50.324Z"
+    },
+    {
+      "slug": "cayley-hamilton-oq-01-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T10:50:50.309Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T10:50:50.324Z"
+    },
+    {
+      "slug": "roth-theorem-k3-oq-02-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T10:50:50.309Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T10:50:50.324Z"
+    },
+    {
+      "slug": "roth-theorem-k3-oq-03-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T10:50:50.309Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T10:50:50.324Z"
+    },
+    {
+      "slug": "roth-theorem-k3-oq-01-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T10:50:50.309Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T10:50:50.325Z"
     }
   ],
   "config": {


### PR DESCRIPTION
Automated sync from deployer agent.

- Updated research-listings.json (44 added, 634 updated, 3577 total iterations)
- Synced registry.json from candidate pool