### PR TITLE
Fix: correct axiomCount in 7 gallery entries (comment-parsing errors)

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "buffons-needle-oq-01-oq-01",
   "title": "Buffon-Barbier: Angular Average and the Smooth Curve Formula",
   "slug": "buffons-needle-oq-01-oq-01",
-  "description": "Proves the Buffon-Barbier smooth curve theorem (E[crossings] = 2L/(πd)) from first principles using the angular average identity ∫_0^π |a sin θ + b cos θ| dθ = 2√(a²+b²). This resolves the open question in buffons-needle-oq-01 by replacing the axiomatic smooth case with a concrete verified proof.",
+  "description": "Proves the Buffon-Barbier smooth curve theorem (E[crossings] = 2L/(\u03c0d)) from first principles using the angular average identity \u222b_0^\u03c0 |a sin \u03b8 + b cos \u03b8| d\u03b8 = 2\u221a(a\u00b2+b\u00b2). This resolves the open question in buffons-needle-oq-01 by replacing the axiomatic smooth case with a concrete verified proof.",
   "meta": {
     "author": "Barbier (1860); Lean formalization 2026",
     "sourceUrl": "https://en.wikipedia.org/wiki/Buffon%27s_noodle",
@@ -25,7 +25,7 @@
     "mathlibDependencies": [
       {
         "theorem": "intervalIntegral.integral_comp_add_right",
-        "description": "Change of variables u = θ + c in interval integrals",
+        "description": "Change of variables u = \u03b8 + c in interval integrals",
         "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral"
       },
       {
@@ -35,7 +35,7 @@
       },
       {
         "theorem": "intervalIntegral.integral_symm",
-        "description": "Symmetry of interval integrals: ∫_a^b = -∫_b^a",
+        "description": "Symmetry of interval integrals: \u222b_a^b = -\u222b_b^a",
         "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral"
       },
       {
@@ -45,44 +45,44 @@
       },
       {
         "theorem": "Real.sin_nonneg_of_mem_Icc",
-        "description": "sin θ ≥ 0 for θ ∈ [0, π]",
+        "description": "sin \u03b8 \u2265 0 for \u03b8 \u2208 [0, \u03c0]",
         "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
       },
       {
         "theorem": "Complex.cos_arg",
-        "description": "cos(arg z) = z.re / ‖z‖, used to define the rotation angle φ",
+        "description": "cos(arg z) = z.re / \u2016z\u2016, used to define the rotation angle \u03c6",
         "module": "Mathlib.Analysis.SpecialFunctions.Complex.Arg"
       },
       {
         "theorem": "Complex.sin_arg",
-        "description": "sin(arg z) = z.im / ‖z‖, used to define the rotation angle φ",
+        "description": "sin(arg z) = z.im / \u2016z\u2016, used to define the rotation angle \u03c6",
         "module": "Mathlib.Analysis.SpecialFunctions.Complex.Arg"
       }
     ],
     "originalContributions": [
-      "integral_sin_zero_pi: ∫_0^π sin θ dθ = 2 (proved via FTC)",
-      "integral_abs_sin_zero_pi: ∫_0^π |sin θ| dθ = 2 (using sin ≥ 0 on [0, π])",
-      "integral_abs_sin_shift: ∫_0^π |sin(θ + c)| dθ = 2 for any c (change of variables + periodicity)",
-      "angular_average: ∫_0^π |a sin θ + b cos θ| dθ = 2√(a²+b²) (via Complex.arg for the rotation angle)",
+      "integral_sin_zero_pi: \u222b_0^\u03c0 sin \u03b8 d\u03b8 = 2 (proved via FTC)",
+      "integral_abs_sin_zero_pi: \u222b_0^\u03c0 |sin \u03b8| d\u03b8 = 2 (using sin \u2265 0 on [0, \u03c0])",
+      "integral_abs_sin_shift: \u222b_0^\u03c0 |sin(\u03b8 + c)| d\u03b8 = 2 for any c (change of variables + periodicity)",
+      "angular_average: \u222b_0^\u03c0 |a sin \u03b8 + b cos \u03b8| d\u03b8 = 2\u221a(a\u00b2+b\u00b2) (via Complex.arg for the rotation angle)",
       "concreteSmoothExpectedCrossings: concrete double integral definition of expected crossings",
       "buffon_smooth_concrete: main theorem with explicit Fubini hypothesis",
       "hFubini_from_angular_average: proves the Fubini hypothesis from angular_average",
       "buffon_smooth_full: the complete Buffon-Barbier theorem with all hypotheses explicit"
     ],
     "dateAdded": "2026-02-25",
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 390,
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "In buffons-needle-oq-01 (Buffon's Noodle), the smooth curve case of the Buffon-Barbier theorem was left as an open question, formalized as an axiom. The question was: can the axiom `buffon_noodle_smooth_eq` be derived from Mathlib's arc length theory?\n\nThis file answers YES. The key insight is the **angular average identity**:\n  ∫_0^π |a sin θ + b cos θ| dθ = 2√(a² + b²)\n\nThis is the fundamental reason why the crossing probability depends only on arc length and not on the shape of the curve. For any direction (a, b) representing the tangent vector γ'(t), the integral of |crossings contribution| over all angles θ gives exactly 2‖γ'(t)‖. Integrating over t gives 2L/(πd).\n\nThe proof uses Complex.arg to find the rotation angle φ such that a sin θ + b cos θ = √(a²+b²) · sin(θ + φ), then applies the rotation-invariant identity ∫_0^π |sin(θ + c)| dθ = 2.",
-    "problemStatement": "**Open Question from buffons-needle-oq-01**: Can the smooth curve axiom\n  `buffon_noodle_smooth_eq : smoothExpectedCrossings γ a b d = 2 * arcLength(γ) / (π * d)`\nbe proved from Mathlib's arc length theory?\n\n**Theorem (Buffon-Barbier, 1860)**: For any smooth planar curve γ : [a,b] → ℝ² with arc length L, when dropped randomly on a floor with parallel lines (spacing d), the expected number of crossings is:\n  E[crossings] = 2L / (πd)\n\n**Answer**: YES — proved here using the angular average theorem and Fubini's theorem.",
-    "text": "Proves the Buffon-Barbier smooth curve theorem (E[crossings] = 2L/(πd)) from first principles using the angular average identity ∫_0^π |a sin θ + b cos θ| dθ = 2√(a²+b²). This resolves the open question in buffons-needle-oq-01 by replacing the axiomatic smooth case with a concrete verified proof.",
-    "proofStrategy": "**Key Identity**: ∫_0^π |a sin θ + b cos θ| dθ = 2√(a² + b²)\n\n**Why this works**:\n- The vector (a sin θ + b cos θ) measures how much the tangent direction (a, b) contributes to crossings for angle θ\n- Averaging over all angles θ ∈ [0, π] gives exactly 2‖(a,b)‖ = 2 times the speed\n- The formula 2L/(πd) follows by integrating over the curve and normalizing by πd\n\n**Proof of angular average** (the heart of the proof):\n1. For (a, b) = (0, 0): both sides = 0 ✓\n2. For (a, b) ≠ (0, 0): Let r = √(a²+b²) and φ = arg(a + bi)\n   - Then cos φ = a/r and sin φ = b/r\n   - So a sin θ + b cos θ = r(sin θ cos φ + cos θ sin φ) = r sin(θ + φ)\n   - Therefore: ∫_0^π |a sin θ + b cos θ| dθ = r ∫_0^π |sin(θ + φ)| dθ = r · 2 = 2r ✓\n\n**Rotation invariance**: ∫_0^π |sin(θ + c)| dθ = 2\n- Change variables u = θ + c: ∫_c^{c+π} |sin u| du\n- Split and use |sin(u+π)| = |sin u| to show ∫_c^{c+π} = ∫_0^π\n- Equals 2 by the basic integral ✓",
+    "historicalContext": "In buffons-needle-oq-01 (Buffon's Noodle), the smooth curve case of the Buffon-Barbier theorem was left as an open question, formalized as an axiom. The question was: can the axiom `buffon_noodle_smooth_eq` be derived from Mathlib's arc length theory?\n\nThis file answers YES. The key insight is the **angular average identity**:\n  \u222b_0^\u03c0 |a sin \u03b8 + b cos \u03b8| d\u03b8 = 2\u221a(a\u00b2 + b\u00b2)\n\nThis is the fundamental reason why the crossing probability depends only on arc length and not on the shape of the curve. For any direction (a, b) representing the tangent vector \u03b3'(t), the integral of |crossings contribution| over all angles \u03b8 gives exactly 2\u2016\u03b3'(t)\u2016. Integrating over t gives 2L/(\u03c0d).\n\nThe proof uses Complex.arg to find the rotation angle \u03c6 such that a sin \u03b8 + b cos \u03b8 = \u221a(a\u00b2+b\u00b2) \u00b7 sin(\u03b8 + \u03c6), then applies the rotation-invariant identity \u222b_0^\u03c0 |sin(\u03b8 + c)| d\u03b8 = 2.",
+    "problemStatement": "**Open Question from buffons-needle-oq-01**: Can the smooth curve axiom\n  `buffon_noodle_smooth_eq : smoothExpectedCrossings \u03b3 a b d = 2 * arcLength(\u03b3) / (\u03c0 * d)`\nbe proved from Mathlib's arc length theory?\n\n**Theorem (Buffon-Barbier, 1860)**: For any smooth planar curve \u03b3 : [a,b] \u2192 \u211d\u00b2 with arc length L, when dropped randomly on a floor with parallel lines (spacing d), the expected number of crossings is:\n  E[crossings] = 2L / (\u03c0d)\n\n**Answer**: YES \u2014 proved here using the angular average theorem and Fubini's theorem.",
+    "text": "Proves the Buffon-Barbier smooth curve theorem (E[crossings] = 2L/(\u03c0d)) from first principles using the angular average identity \u222b_0^\u03c0 |a sin \u03b8 + b cos \u03b8| d\u03b8 = 2\u221a(a\u00b2+b\u00b2). This resolves the open question in buffons-needle-oq-01 by replacing the axiomatic smooth case with a concrete verified proof.",
+    "proofStrategy": "**Key Identity**: \u222b_0^\u03c0 |a sin \u03b8 + b cos \u03b8| d\u03b8 = 2\u221a(a\u00b2 + b\u00b2)\n\n**Why this works**:\n- The vector (a sin \u03b8 + b cos \u03b8) measures how much the tangent direction (a, b) contributes to crossings for angle \u03b8\n- Averaging over all angles \u03b8 \u2208 [0, \u03c0] gives exactly 2\u2016(a,b)\u2016 = 2 times the speed\n- The formula 2L/(\u03c0d) follows by integrating over the curve and normalizing by \u03c0d\n\n**Proof of angular average** (the heart of the proof):\n1. For (a, b) = (0, 0): both sides = 0 \u2713\n2. For (a, b) \u2260 (0, 0): Let r = \u221a(a\u00b2+b\u00b2) and \u03c6 = arg(a + bi)\n   - Then cos \u03c6 = a/r and sin \u03c6 = b/r\n   - So a sin \u03b8 + b cos \u03b8 = r(sin \u03b8 cos \u03c6 + cos \u03b8 sin \u03c6) = r sin(\u03b8 + \u03c6)\n   - Therefore: \u222b_0^\u03c0 |a sin \u03b8 + b cos \u03b8| d\u03b8 = r \u222b_0^\u03c0 |sin(\u03b8 + \u03c6)| d\u03b8 = r \u00b7 2 = 2r \u2713\n\n**Rotation invariance**: \u222b_0^\u03c0 |sin(\u03b8 + c)| d\u03b8 = 2\n- Change variables u = \u03b8 + c: \u222b_c^{c+\u03c0} |sin u| du\n- Split and use |sin(u+\u03c0)| = |sin u| to show \u222b_c^{c+\u03c0} = \u222b_0^\u03c0\n- Equals 2 by the basic integral \u2713",
     "keyInsights": [
-      "The angular average ∫_0^π |a sin θ + b cos θ| dθ = 2√(a²+b²) is the KEY INSIGHT explaining why shape doesn't matter in Buffon's noodle",
-      "The rotation angle φ = arg(a+bi) works uniformly for all cases including a=0 using Complex.arg from Mathlib",
-      "The identity |sin(x+π)| = |sin x| (π-periodicity of |sin|) is what makes the rotation invariance proof work",
+      "The angular average \u222b_0^\u03c0 |a sin \u03b8 + b cos \u03b8| d\u03b8 = 2\u221a(a\u00b2+b\u00b2) is the KEY INSIGHT explaining why shape doesn't matter in Buffon's noodle",
+      "The rotation angle \u03c6 = arg(a+bi) works uniformly for all cases including a=0 using Complex.arg from Mathlib",
+      "The identity |sin(x+\u03c0)| = |sin x| (\u03c0-periodicity of |sin|) is what makes the rotation invariance proof work",
       "The proof avoids the co-area formula by using Fubini's theorem as an explicit hypothesis",
       "The hFubini hypothesis is exactly angular_average applied pointwise, so the full theorem follows automatically",
       "This resolves the open question in BuffonsNoodle.lean: the axiomatic smooth case can be replaced by this concrete proof"
@@ -99,21 +99,21 @@
       "title": "The Fundamental Angular Integral",
       "startLine": 59,
       "endLine": 82,
-      "summary": "integral_sin_zero_pi: ∫_0^π sin θ dθ = 2 via FTC. integral_abs_sin_zero_pi: ∫_0^π |sin θ| dθ = 2 using sin ≥ 0 on [0, π]."
+      "summary": "integral_sin_zero_pi: \u222b_0^\u03c0 sin \u03b8 d\u03b8 = 2 via FTC. integral_abs_sin_zero_pi: \u222b_0^\u03c0 |sin \u03b8| d\u03b8 = 2 using sin \u2265 0 on [0, \u03c0]."
     },
     {
       "id": "rotation-invariance",
       "title": "Rotation Invariance",
       "startLine": 83,
       "endLine": 141,
-      "summary": "integral_abs_sin_shift: ∫_0^π |sin(θ+c)| dθ = 2 for any c. Uses change of variables and π-periodicity of |sin|."
+      "summary": "integral_abs_sin_shift: \u222b_0^\u03c0 |sin(\u03b8+c)| d\u03b8 = 2 for any c. Uses change of variables and \u03c0-periodicity of |sin|."
     },
     {
       "id": "angular-average",
       "title": "The Angular Average Theorem",
       "startLine": 142,
       "endLine": 232,
-      "summary": "angular_average: ∫_0^π |a sin θ + b cos θ| dθ = 2√(a²+b²). Uses Complex.arg to find the rotation angle φ = arg(a+bi)."
+      "summary": "angular_average: \u222b_0^\u03c0 |a sin \u03b8 + b cos \u03b8| d\u03b8 = 2\u221a(a\u00b2+b\u00b2). Uses Complex.arg to find the rotation angle \u03c6 = arg(a+bi)."
     },
     {
       "id": "concrete-crossings",
@@ -139,10 +139,10 @@
   ],
   "conclusion": {
     "summary": "The Buffon-Barbier smooth curve theorem is proved from first principles using the angular average identity. The open question from BuffonsNoodle.lean is resolved: the axiomatic smooth case is not needed. The proof requires only Fubini's theorem (as an explicit hypothesis), not the full co-area formula.",
-    "implications": "**Mathematical Significance**:\n\n**1. Angular Average as the Central Identity**\nThe formula ∫_0^π |a sin θ + b cos θ| dθ = 2√(a²+b²) is the heart of integral geometry. It explains WHY the crossing probability depends only on length: every arc element contributes proportionally to its length, independent of direction.\n\n**2. The Cauchy-Crofton Connection**\nThis proof is a special case of the Cauchy-Crofton formula:\n   measure(lines meeting curve C) = 2 · length(C)\nOur proof gives an elementary verification using only Fubini and the angular average.\n\n**3. Eliminating Axioms**\nThe axiomatic treatment in BuffonsNoodle.lean used:\n  `noncomputable axiom smoothExpectedCrossings`\n  `axiom buffon_noodle_smooth_eq`\nThis file replaces both with proved theorems, improving the formalization.\n\n**4. Technique: Complex.arg for Rotation**\nUsing Complex.arg to find the rotation angle φ = arg(a+bi) is an elegant approach that handles all cases (a=0, a<0, a>0) uniformly through Mathlib's existing arg theory.",
+    "implications": "**Mathematical Significance**:\n\n**1. Angular Average as the Central Identity**\nThe formula \u222b_0^\u03c0 |a sin \u03b8 + b cos \u03b8| d\u03b8 = 2\u221a(a\u00b2+b\u00b2) is the heart of integral geometry. It explains WHY the crossing probability depends only on length: every arc element contributes proportionally to its length, independent of direction.\n\n**2. The Cauchy-Crofton Connection**\nThis proof is a special case of the Cauchy-Crofton formula:\n   measure(lines meeting curve C) = 2 \u00b7 length(C)\nOur proof gives an elementary verification using only Fubini and the angular average.\n\n**3. Eliminating Axioms**\nThe axiomatic treatment in BuffonsNoodle.lean used:\n  `noncomputable axiom smoothExpectedCrossings`\n  `axiom buffon_noodle_smooth_eq`\nThis file replaces both with proved theorems, improving the formalization.\n\n**4. Technique: Complex.arg for Rotation**\nUsing Complex.arg to find the rotation angle \u03c6 = arg(a+bi) is an elegant approach that handles all cases (a=0, a<0, a>0) uniformly through Mathlib's existing arg theory.",
     "openQuestions": [
       "Fully integrate with BuffonsNoodle.lean by removing the axioms and using concreteSmoothExpectedCrossings",
-      "Prove the integrability hypothesis (hInnerInt) from smoothness of γ",
+      "Prove the integrability hypothesis (hInnerInt) from smoothness of \u03b3",
       "Formalize the Cauchy-Crofton formula in full generality",
       "Higher-dimensional Cauchy-Crofton: expected crossings with hyperplane arrangements",
       "Prove the co-area formula in Mathlib to eliminate the Fubini hypothesis"
@@ -167,8 +167,8 @@
   ],
   "references": [
     {
-      "title": "Note sur un problème de calcul des probabilités",
-      "author": "Barbier, É.",
+      "title": "Note sur un probl\u00e8me de calcul des probabilit\u00e9s",
+      "author": "Barbier, \u00c9.",
       "year": "1860",
       "description": "Original generalization of Buffon's needle to arbitrary smooth curves, proving E[crossings] = 2L/(pi*d)"
     },
@@ -180,7 +180,7 @@
     },
     {
       "title": "Integral Geometry and Geometric Probability",
-      "author": "Santaló, L. A.",
+      "author": "Santal\u00f3, L. A.",
       "year": "1976",
       "description": "Foundational text on integral geometry; the angular average identity used here is a special case of the Cauchy-Crofton formula"
     }
@@ -196,7 +196,7 @@
     ],
     "namespace": "BuffonsNeedleOQ01OQ01",
     "lineCount": 390,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 2
   }

--- a/src/data/proofs/central-limit-theorem-oq-04/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-04/meta.json
@@ -46,8 +46,8 @@
       "CLTStructure: abstract structure capturing the universal CLT pattern across all independence types",
       "Structural comparison theorems for classical vs free vs boolean CLT"
     ],
-    "historicalContext": "Voiculescu introduced free probability in 1985 to study von Neumann algebras of free groups. The Free CLT — that the semicircle distribution is the universal limit under free convolution — was the founding result. Speicher (1990) developed the combinatorial theory via non-crossing partitions, and Muraki (2003) classified all five universal independences, each with its own CLT and limit law.",
-    "axiomCount": 8,
+    "historicalContext": "Voiculescu introduced free probability in 1985 to study von Neumann algebras of free groups. The Free CLT \u2014 that the semicircle distribution is the universal limit under free convolution \u2014 was the founding result. Speicher (1990) developed the combinatorial theory via non-crossing partitions, and Muraki (2003) classified all five universal independences, each with its own CLT and limit law.",
+    "axiomCount": 9,
     "lineCount": 649,
     "assumptions": "9 axioms (free probability not in Mathlib). Core axioms: freeCumulant (3), freeConv + linearization + identity (3), cumulant_determines_distribution, semicircle_cumulant_higher, free_clt. PROVED: freeConv_comm, freeConv_assoc (from cumulant determinism), Rtransform_additive (from cumulant linearity). Rtransform defined as coefficient sequence.",
     "mathlib_version": "4.26.0"
@@ -104,10 +104,10 @@
     {
       "id": "dilation",
       "title": "Dilation and Normalized Free Convolution",
-      "summary": "Axiomatizes dilation $D_c$ with cumulant scaling $\\kappa_n(D_c(\\mu)) = c^n \\kappa_n(\\mu)$ and R-transform scaling. Defines the normalized free convolution power $D_{1/\\sqrt{n}}(\\mu^{\\boxplus n})$ — the distribution of $(a_1 + \\cdots + a_n)/\\sqrt{n}$.",
+      "summary": "Axiomatizes dilation $D_c$ with cumulant scaling $\\kappa_n(D_c(\\mu)) = c^n \\kappa_n(\\mu)$ and R-transform scaling. Defines the normalized free convolution power $D_{1/\\sqrt{n}}(\\mu^{\\boxplus n})$ \u2014 the distribution of $(a_1 + \\cdots + a_n)/\\sqrt{n}$.",
       "startLine": 372,
       "endLine": 401,
-      "mathContext": "Axiomatizes dilation $D_c$ with cumulant scaling $\\kappa_n(D_c(\\mu)) = c^n \\kappa_n(\\mu)$ and R-transform scaling. Defines the normalized free convolution power $D_{1/\\sqrt{n}}(\\mu^{\\boxplus n})$ — the distribution of $(a_1 + \\cdots + a_n)/\\sqrt{n}$."
+      "mathContext": "Axiomatizes dilation $D_c$ with cumulant scaling $\\kappa_n(D_c(\\mu)) = c^n \\kappa_n(\\mu)$ and R-transform scaling. Defines the normalized free convolution power $D_{1/\\sqrt{n}}(\\mu^{\\boxplus n})$ \u2014 the distribution of $(a_1 + \\cdots + a_n)/\\sqrt{n}$."
     },
     {
       "id": "free-clt",
@@ -135,15 +135,15 @@
     }
   ],
   "overview": {
-    "historicalContext": "Free probability was invented by Dan-Virgil Voiculescu in 1985, motivated by problems in operator algebras — specifically, the isomorphism question for von Neumann algebras of free groups. The Free Central Limit Theorem was the founding result: if $a_1, a_2, \\ldots$ are freely independent, identically distributed non-commutative random variables with mean 0 and variance 1, then the normalized sums $(a_1 + \\cdots + a_n)/\\sqrt{n}$ converge in distribution to the semicircle (Wigner) distribution.\n\nRoland Speicher (1990) developed the combinatorial approach via non-crossing partitions, showing that free cumulants linearize free convolution — exactly paralleling how classical cumulants linearize classical convolution. Naofumi Muraki (2003) proved the remarkable classification theorem: there are exactly five universal notions of independence (classical, free, Boolean, monotone, anti-monotone), each with its own convolution, cumulants, partition lattice, and CLT limit law.",
+    "historicalContext": "Free probability was invented by Dan-Virgil Voiculescu in 1985, motivated by problems in operator algebras \u2014 specifically, the isomorphism question for von Neumann algebras of free groups. The Free Central Limit Theorem was the founding result: if $a_1, a_2, \\ldots$ are freely independent, identically distributed non-commutative random variables with mean 0 and variance 1, then the normalized sums $(a_1 + \\cdots + a_n)/\\sqrt{n}$ converge in distribution to the semicircle (Wigner) distribution.\n\nRoland Speicher (1990) developed the combinatorial approach via non-crossing partitions, showing that free cumulants linearize free convolution \u2014 exactly paralleling how classical cumulants linearize classical convolution. Naofumi Muraki (2003) proved the remarkable classification theorem: there are exactly five universal notions of independence (classical, free, Boolean, monotone, anti-monotone), each with its own convolution, cumulants, partition lattice, and CLT limit law.",
     "problemStatement": "**Open Question #4 from the CLT gallery:**\n\nHow does the topological perspective (renormalization flow, fixed points, attractors) extend to non-commutative probability, specifically to Voiculescu's free probability theory?\n\n**Answer:** The topological structure extends perfectly. In free probability:\n- Free convolution $\\boxplus$ replaces classical convolution $*$\n- The R-transform replaces the log-characteristic function\n- The semicircle distribution replaces the Gaussian\n- The semicircle is the unique fixed point and global attractor of the free renormalization flow\n\nMoreover, this pattern extends to all five universal independences classified by Muraki.",
-    "text": "This formalization shows that the topological perspective on the CLT — the Gaussian as a renormalization fixed point and global attractor — extends naturally to free (non-commutative) probability, where the semicircle distribution plays the role of the Gaussian. The formalization introduces a CLTStructure abstraction that captures the universal pattern.",
-    "proofStrategy": "The formalization builds the free probability analog in parallel to the classical CLT:\n\n1. **NC distributions** (§1): Moment sequences with extensionality\n2. **Free independence** (§2): Alternating centered products vanish\n3. **Free cumulants** (§3): Via non-crossing partitions, with moment-cumulant bijection\n4. **Free convolution monoid** (§4): Commutativity, associativity, identity, distribution law. Key proved result: `freeConvPow_cumulant` showing $\\kappa_k(\\mu^{\\boxplus n}) = n \\cdot \\kappa_k(\\mu)$\n5. **R-transform** (§5): Linearizes free convolution (Voiculescu's key insight). Proved: `Rtransform_freeConvPow`\n6. **Semicircle** (§6): Only $\\kappa_2 = 1$ nonzero; $R_w(z) = z$\n7. **Free CLT** (§7–8): Semicircle is fixed point of $T(\\mu) = D_{1/\\sqrt{2}}(\\mu \\boxplus \\mu)$ and global attractor\n8. **Universal structure** (§9): `CLTStructure` abstraction instantiated for free case, with structural verification theorems",
+    "text": "This formalization shows that the topological perspective on the CLT \u2014 the Gaussian as a renormalization fixed point and global attractor \u2014 extends naturally to free (non-commutative) probability, where the semicircle distribution plays the role of the Gaussian. The formalization introduces a CLTStructure abstraction that captures the universal pattern.",
+    "proofStrategy": "The formalization builds the free probability analog in parallel to the classical CLT:\n\n1. **NC distributions** (\u00a71): Moment sequences with extensionality\n2. **Free independence** (\u00a72): Alternating centered products vanish\n3. **Free cumulants** (\u00a73): Via non-crossing partitions, with moment-cumulant bijection\n4. **Free convolution monoid** (\u00a74): Commutativity, associativity, identity, distribution law. Key proved result: `freeConvPow_cumulant` showing $\\kappa_k(\\mu^{\\boxplus n}) = n \\cdot \\kappa_k(\\mu)$\n5. **R-transform** (\u00a75): Linearizes free convolution (Voiculescu's key insight). Proved: `Rtransform_freeConvPow`\n6. **Semicircle** (\u00a76): Only $\\kappa_2 = 1$ nonzero; $R_w(z) = z$\n7. **Free CLT** (\u00a77\u20138): Semicircle is fixed point of $T(\\mu) = D_{1/\\sqrt{2}}(\\mu \\boxplus \\mu)$ and global attractor\n8. **Universal structure** (\u00a79): `CLTStructure` abstraction instantiated for free case, with structural verification theorems",
     "keyInsights": [
       "The R-transform linearizes free convolution exactly as the log-characteristic function linearizes classical convolution: R(mu boxplus nu) = R(mu) + R(nu)",
       "The semicircle's R-transform is R_w(z) = z (linear), just as the Gaussian's log-characteristic function is -t^2/2 (quadratic). Both have only kappa_2 nonzero.",
       "The abstract CLTStructure shows the universal pattern: convolution monoid + cumulant linearization + renormalization = CLT. What varies across the five independences is only the partition lattice.",
-      "Free cumulant scaling (freeConvPow_cumulant): kappa_k(mu^{boxplus n}) = n * kappa_k(mu) — proved by induction from the linearization axiom and the Dirac identity trick",
+      "Free cumulant scaling (freeConvPow_cumulant): kappa_k(mu^{boxplus n}) = n * kappa_k(mu) \u2014 proved by induction from the linearization axiom and the Dirac identity trick",
       "Muraki's classification (2003): classical, free, Boolean, monotone, anti-monotone are the ONLY five universal independences. Each has its own limit law (Gaussian, semicircle, Bernoulli, arcsine, arcsine)."
     ],
     "prerequisites": [
@@ -154,7 +154,7 @@
   },
   "conclusion": {
     "summary": "This formalization answers the open question by showing that the topological perspective on the CLT extends naturally to non-commutative probability. The semicircle distribution is to free probability what the Gaussian is to classical probability: the unique fixed point and global attractor of the renormalization flow. The CLTStructure abstraction reveals this as a universal phenomenon across all five types of independence classified by Muraki. Key proved results include freeConvPow_add (distribution law), freeConvPow_cumulant (cumulant scaling), and Rtransform_freeConvPow (R-transform scaling).",
-    "implications": "**Theoretical significance**: The parallel between classical and free CLT is not a coincidence — it reflects a deep structural pattern. Muraki's classification shows exactly five universal independences, each producing a CLT with the same topological structure (renormalization fixed point + attractor). This suggests that the 'CLT phenomenon' is primarily about convolution monoid structure and cumulant linearization, not about the specific nature of independence.\n\n**Connections**: Free probability connects to random matrix theory (Wigner's semicircle law for eigenvalues of large random matrices), quantum information theory, and operator algebras. The R-transform is the main computational tool in free probability, analogous to Fourier analysis in classical probability.",
+    "implications": "**Theoretical significance**: The parallel between classical and free CLT is not a coincidence \u2014 it reflects a deep structural pattern. Muraki's classification shows exactly five universal independences, each producing a CLT with the same topological structure (renormalization fixed point + attractor). This suggests that the 'CLT phenomenon' is primarily about convolution monoid structure and cumulant linearization, not about the specific nature of independence.\n\n**Connections**: Free probability connects to random matrix theory (Wigner's semicircle law for eigenvalues of large random matrices), quantum information theory, and operator algebras. The R-transform is the main computational tool in free probability, analogous to Fourier analysis in classical probability.",
     "openQuestions": [
       "Can the Boolean CLT (convergence to the Bernoulli distribution) be formalized with the same CLTStructure framework?",
       "Can the moment-cumulant formula via non-crossing partitions be constructively implemented to reduce the axiom count?",
@@ -178,7 +178,7 @@
     ],
     "namespace": "FreeCLT",
     "lineCount": 649,
-    "axiomCount": 8,
+    "axiomCount": 9,
     "theoremCount": 22,
     "definitionCount": 9
   },
@@ -231,12 +231,12 @@
     {
       "targetId": "central-limit-theorem-oq-01-oq-01",
       "relationship": "sibling",
-      "description": "Sibling: Gnedenko-Kolmogorov domain of attraction theorem — characterizes which distributions are attracted to each stable law via regular variation"
+      "description": "Sibling: Gnedenko-Kolmogorov domain of attraction theorem \u2014 characterizes which distributions are attracted to each stable law via regular variation"
     },
     {
       "targetId": "central-limit-theorem-oq-01-oq-02",
       "relationship": "sibling",
-      "description": "Sibling: Lévy-Khintchine representation for infinitely divisible distributions"
+      "description": "Sibling: L\u00e9vy-Khintchine representation for infinitely divisible distributions"
     }
   ]
 }

--- a/src/data/proofs/erdos-1167/meta.json
+++ b/src/data/proofs/erdos-1167/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-1167",
-  "title": "Erdős Problem #1167: Stepping-Down Partition Relations",
+  "title": "Erd\u0151s Problem #1167: Stepping-Down Partition Relations",
   "slug": "erdos-1167",
-  "description": "For finite r ≥ 2, infinite cardinal λ, and cardinals κ_α (for all α < γ), does 2^λ → (κ_α + 1)^{r+1}_{α < γ} imply λ → (κ_α)^r_{α < γ}? A fundamental open question in infinitary combinatorics about transferring partition properties from higher to lower exponents.",
+  "description": "For finite r \u2265 2, infinite cardinal \u03bb, and cardinals \u03ba_\u03b1 (for all \u03b1 < \u03b3), does 2^\u03bb \u2192 (\u03ba_\u03b1 + 1)^{r+1}_{\u03b1 < \u03b3} imply \u03bb \u2192 (\u03ba_\u03b1)^r_{\u03b1 < \u03b3}? A fundamental open question in infinitary combinatorics about transferring partition properties from higher to lower exponents.",
   "meta": {
-    "author": "Erdős",
+    "author": "Erd\u0151s",
     "sourceUrl": "https://erdosproblems.com/1167",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1167Problem.lean",
@@ -26,7 +26,7 @@
     "mathlibDependencies": [
       {
         "theorem": "Cardinal.Basic",
-        "description": "Cardinal arithmetic including ℵ₀, cardinal addition, and Order.succ for successor cardinals",
+        "description": "Cardinal arithmetic including \u2135\u2080, cardinal addition, and Order.succ for successor cardinals",
         "module": "Mathlib.SetTheory.Cardinal.Basic"
       },
       {
@@ -68,18 +68,18 @@
       "infinite_ramsey_zero",
       "infinite_ramsey_one"
     ],
-    "axiomCount": 3,
+    "axiomCount": 2,
     "lineCount": 594,
     "assumptions": "2 axiom(s): erdos_1167_conjecture (OPEN), erdos_rado_theorem. The infinite Ramsey theorem (previously axiomatized) is now FULLY PROVED by induction on r using Ramsey's diagonal argument."
   },
   "overview": {
-    "historicalContext": "The partition calculus was founded by Erdős and Rado in their landmark 1956 paper 'A partition calculus in set theory', which systematized the study of Ramsey-type properties for infinite sets. The central achievement was the Erdős-Rado theorem: (2^κ)⁺ → (κ⁺)²_κ for infinite κ, establishing that exponentially larger cardinals satisfy partition relations at the next level. This 'stepping-up' lemma — going from exponent r to r+1 — became a core technique.\n\nProblem #1167 asks the reverse question: can partition properties be 'stepped down' from exponent r+1 to r? Specifically, if 2^λ → (κ_α + 1)^{r+1}_{α<γ} holds, does λ → (κ_α)^r_{α<γ} follow? The '+1' in the hypothesis accounts for the possibility of finite targets, where κ+1 > κ (for infinite κ, κ+1 = κ by cardinal absorption). This question was posed by Erdős, Hajnal, and Rado in their foundational work, reflecting their deep interest in understanding the exact relationship between partition relations at different exponents.\n\nThe problem remains open nearly 70 years later. While the stepping-up direction is well understood, stepping down is fundamentally harder because it requires extracting structure from colorings of smaller subsets — a process that generally loses information. The problem is catalogued as [Va99, 7.79] in Vaughan's survey and connects to the broader program of understanding the partition calculus hierarchy, including problems #1169 and #1171 on ordinal partition relations.",
-    "problemStatement": "**Erdős Problem #1167** (Erdős-Hajnal-Rado):\n\nFor finite $r \\geq 2$, infinite cardinal $\\lambda$, and cardinals $\\kappa_\\alpha$ (for all $\\alpha < \\gamma$), does\n$$2^\\lambda \\to (\\kappa_\\alpha + 1)^{r+1}_{\\alpha < \\gamma}$$\nimply\n$$\\lambda \\to (\\kappa_\\alpha)^r_{\\alpha < \\gamma}?$$\n\nThe notation $\\kappa \\to (\\lambda_\\alpha)^r_{\\alpha < \\gamma}$ means: for every $\\gamma$-coloring of $r$-element subsets of $\\kappa$, there exist $\\alpha < \\gamma$ and $H \\subseteq \\kappa$ with $|H| \\geq \\lambda_\\alpha$ such that all $r$-element subsets of $H$ receive color $\\alpha$.\n\n**Status**: Open.",
-    "text": "For finite r ≥ 2, infinite cardinal λ, and cardinals κ_α (for all α < γ), does 2^λ → (κ_α + 1)^{r+1}_{α < γ} imply λ → (κ_α)^r_{α < γ}? A fundamental open question in infinitary combinatorics about transferring partition properties from higher to lower exponents.",
-    "proofStrategy": "The formalization builds partition relation infrastructure from scratch in 594 lines of Lean 4 code. It defines RSubset, Coloring, IsMonochromatic, PartitionRelation, and IndexedPartitionRelation using Lean's dependent types and Mathlib's cardinal/ordinal API. Five structural lemmas are fully proved. Cardinal arithmetic lemmas clarify the role of '+1'. The infinite Ramsey theorem (ℵ₀ → (ℵ₀)^r_k for all finite r, k) is FULLY PROVED by induction on r: base cases r=0 (unique 0-subset) and r=1 (infinite pigeonhole) are established first, then the inductive step uses Ramsey's diagonal argument — fixing a vertex, applying the IH to a reduced coloring on an infinite subset, iterating to build a sequence, and extracting an infinite monochromatic subsequence via pigeonhole. The key technical challenge is lifting between subtypes and the ambient type when applying the IH to subsets. The conjecture and Erdős-Rado theorem remain as the only 2 axioms.",
+    "historicalContext": "The partition calculus was founded by Erd\u0151s and Rado in their landmark 1956 paper 'A partition calculus in set theory', which systematized the study of Ramsey-type properties for infinite sets. The central achievement was the Erd\u0151s-Rado theorem: (2^\u03ba)\u207a \u2192 (\u03ba\u207a)\u00b2_\u03ba for infinite \u03ba, establishing that exponentially larger cardinals satisfy partition relations at the next level. This 'stepping-up' lemma \u2014 going from exponent r to r+1 \u2014 became a core technique.\n\nProblem #1167 asks the reverse question: can partition properties be 'stepped down' from exponent r+1 to r? Specifically, if 2^\u03bb \u2192 (\u03ba_\u03b1 + 1)^{r+1}_{\u03b1<\u03b3} holds, does \u03bb \u2192 (\u03ba_\u03b1)^r_{\u03b1<\u03b3} follow? The '+1' in the hypothesis accounts for the possibility of finite targets, where \u03ba+1 > \u03ba (for infinite \u03ba, \u03ba+1 = \u03ba by cardinal absorption). This question was posed by Erd\u0151s, Hajnal, and Rado in their foundational work, reflecting their deep interest in understanding the exact relationship between partition relations at different exponents.\n\nThe problem remains open nearly 70 years later. While the stepping-up direction is well understood, stepping down is fundamentally harder because it requires extracting structure from colorings of smaller subsets \u2014 a process that generally loses information. The problem is catalogued as [Va99, 7.79] in Vaughan's survey and connects to the broader program of understanding the partition calculus hierarchy, including problems #1169 and #1171 on ordinal partition relations.",
+    "problemStatement": "**Erd\u0151s Problem #1167** (Erd\u0151s-Hajnal-Rado):\n\nFor finite $r \\geq 2$, infinite cardinal $\\lambda$, and cardinals $\\kappa_\\alpha$ (for all $\\alpha < \\gamma$), does\n$$2^\\lambda \\to (\\kappa_\\alpha + 1)^{r+1}_{\\alpha < \\gamma}$$\nimply\n$$\\lambda \\to (\\kappa_\\alpha)^r_{\\alpha < \\gamma}?$$\n\nThe notation $\\kappa \\to (\\lambda_\\alpha)^r_{\\alpha < \\gamma}$ means: for every $\\gamma$-coloring of $r$-element subsets of $\\kappa$, there exist $\\alpha < \\gamma$ and $H \\subseteq \\kappa$ with $|H| \\geq \\lambda_\\alpha$ such that all $r$-element subsets of $H$ receive color $\\alpha$.\n\n**Status**: Open.",
+    "text": "For finite r \u2265 2, infinite cardinal \u03bb, and cardinals \u03ba_\u03b1 (for all \u03b1 < \u03b3), does 2^\u03bb \u2192 (\u03ba_\u03b1 + 1)^{r+1}_{\u03b1 < \u03b3} imply \u03bb \u2192 (\u03ba_\u03b1)^r_{\u03b1 < \u03b3}? A fundamental open question in infinitary combinatorics about transferring partition properties from higher to lower exponents.",
+    "proofStrategy": "The formalization builds partition relation infrastructure from scratch in 594 lines of Lean 4 code. It defines RSubset, Coloring, IsMonochromatic, PartitionRelation, and IndexedPartitionRelation using Lean's dependent types and Mathlib's cardinal/ordinal API. Five structural lemmas are fully proved. Cardinal arithmetic lemmas clarify the role of '+1'. The infinite Ramsey theorem (\u2135\u2080 \u2192 (\u2135\u2080)^r_k for all finite r, k) is FULLY PROVED by induction on r: base cases r=0 (unique 0-subset) and r=1 (infinite pigeonhole) are established first, then the inductive step uses Ramsey's diagonal argument \u2014 fixing a vertex, applying the IH to a reduced coloring on an infinite subset, iterating to build a sequence, and extracting an infinite monochromatic subsequence via pigeonhole. The key technical challenge is lifting between subtypes and the ambient type when applying the IH to subsets. The conjecture and Erd\u0151s-Rado theorem remain as the only 2 axioms.",
     "keyInsights": [
-      "**Stepping up vs stepping down**: The Erdős-Rado theorem steps UP from exponent r to r+1, gaining a factor of 2^κ in the source. The conjecture asks whether the reverse direction holds — stepping DOWN from r+1 to r while shrinking the source from 2^λ to λ. Stepping up is constructive (transfinite recursion builds the monochromatic set); stepping down requires showing that structure in (r+1)-colorings implies structure in r-colorings.",
-      "**The +1 dichotomy**: For infinite κ_α, the '+1' is absorbed (κ + 1 = κ), so the conjecture reduces to whether 2^λ → (κ_α)^{r+1} implies λ → (κ_α)^r. For finite targets, κ_α + 1 > κ_α genuinely strengthens the hypothesis. The formalization explicitly proves this dichotomy with infinite_card_add_one and finite_card_add_one.",
+      "**Stepping up vs stepping down**: The Erd\u0151s-Rado theorem steps UP from exponent r to r+1, gaining a factor of 2^\u03ba in the source. The conjecture asks whether the reverse direction holds \u2014 stepping DOWN from r+1 to r while shrinking the source from 2^\u03bb to \u03bb. Stepping up is constructive (transfinite recursion builds the monochromatic set); stepping down requires showing that structure in (r+1)-colorings implies structure in r-colorings.",
+      "**The +1 dichotomy**: For infinite \u03ba_\u03b1, the '+1' is absorbed (\u03ba + 1 = \u03ba), so the conjecture reduces to whether 2^\u03bb \u2192 (\u03ba_\u03b1)^{r+1} implies \u03bb \u2192 (\u03ba_\u03b1)^r. For finite targets, \u03ba_\u03b1 + 1 > \u03ba_\u03b1 genuinely strengthens the hypothesis. The formalization explicitly proves this dichotomy with infinite_card_add_one and finite_card_add_one.",
       "**Building partition calculus in Lean 4**: The formalization constructs the full partition relation machinery from Finset and Cardinal, using dependent subtypes for r-element subsets and universal quantification over types to handle cardinal arithmetic in a universe-polymorphic way.",
       "**Full proof of the infinite Ramsey theorem**: The infinite Ramsey theorem is proved from first principles by induction on r, using Ramsey's diagonal argument in the inductive step. The proof constructs a sequence of vertices and colors by iteratively fixing a vertex, reducing the coloring, and applying the IH. Pigeonhole on the color sequence extracts an infinite monochromatic subsequence. The key challenge is the subtype lifting: applying the IH to infinite subsets requires embedding the reduced coloring on a subtype, applying the IH, and then transferring the monochromatic set back to the ambient type.",
       "**70 years unsolved**: Posed in 1956, this is among the longest-standing open problems in infinite combinatorics. The difficulty reflects the fundamental asymmetry between stepping up (constructive) and stepping down (requires information-theoretic arguments about colorings)."
@@ -97,14 +97,14 @@
       "title": "Problem Statement and Imports",
       "startLine": 1,
       "endLine": 52,
-      "summary": "Documentation header describing the stepping-down conjecture, its background in partition calculus, known partial results (Erdős-Rado, infinite Ramsey), and imports from Mathlib for cardinal/ordinal theory and tactics."
+      "summary": "Documentation header describing the stepping-down conjecture, its background in partition calculus, known partial results (Erd\u0151s-Rado, infinite Ramsey), and imports from Mathlib for cardinal/ordinal theory and tactics."
     },
     {
       "id": "core-defs",
       "title": "Core Definitions",
       "startLine": 53,
       "endLine": 91,
-      "summary": "Defines RSubset (r-element subsets), Coloring (functions from r-subsets to colors), IsMonochromatic (uniformity of color), PartitionRelation (uniform κ → (λ)^r_γ), and IndexedPartitionRelation (indexed κ → (κ_i)^r_{i<γ})."
+      "summary": "Defines RSubset (r-element subsets), Coloring (functions from r-subsets to colors), IsMonochromatic (uniformity of color), PartitionRelation (uniform \u03ba \u2192 (\u03bb)^r_\u03b3), and IndexedPartitionRelation (indexed \u03ba \u2192 (\u03ba_i)^r_{i<\u03b3})."
     },
     {
       "id": "structural-props",
@@ -118,21 +118,21 @@
       "title": "Cardinal Arithmetic for Partition Relations",
       "startLine": 162,
       "endLine": 209,
-      "summary": "Proves infinite_card_add_one (κ+1=κ for infinite κ), finite_card_add_one (n+1 genuinely larger), conjecture_simplifies_infinite_targets (+1 absorbed for infinite targets), and two_pow_infinite (2^λ ≥ ℵ₀)."
+      "summary": "Proves infinite_card_add_one (\u03ba+1=\u03ba for infinite \u03ba), finite_card_add_one (n+1 genuinely larger), conjecture_simplifies_infinite_targets (+1 absorbed for infinite targets), and two_pow_infinite (2^\u03bb \u2265 \u2135\u2080)."
     },
     {
       "id": "conjecture-and-results",
       "title": "The Conjecture and Known Results",
       "startLine": 210,
       "endLine": 245,
-      "summary": "States the open conjecture as an axiom (erdos_1167_conjecture). Axiomatizes the infinite Ramsey theorem (ℵ₀ → (ℵ₀)^r_k) and the Erdős-Rado theorem ((2^κ)⁺ → (κ⁺)²_κ) as reference points."
+      "summary": "States the open conjecture as an axiom (erdos_1167_conjecture). Axiomatizes the infinite Ramsey theorem (\u2135\u2080 \u2192 (\u2135\u2080)^r_k) and the Erd\u0151s-Rado theorem ((2^\u03ba)\u207a \u2192 (\u03ba\u207a)\u00b2_\u03ba) as reference points."
     },
     {
       "id": "consequences",
       "title": "Consequences and Consistency Checks",
       "startLine": 246,
       "endLine": 289,
-      "summary": "Proves the r=2 case instantiation, general r case, consistency with Ramsey (pairs, triples), and Erdős-Rado weakening via target monotonicity."
+      "summary": "Proves the r=2 case instantiation, general r case, consistency with Ramsey (pairs, triples), and Erd\u0151s-Rado weakening via target monotonicity."
     },
     {
       "id": "provable-ramsey",
@@ -143,14 +143,14 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #1167 — the stepping-down conjecture for partition relations — in 594 lines of Lean 4 code with only 2 axioms (the OPEN conjecture and the Erdős-Rado theorem) and 19 theorems. The infinite Ramsey theorem (ℵ₀ → (ℵ₀)^r_k for all finite r, k) is FULLY PROVED by induction on r using Ramsey's diagonal argument, eliminating the previous axiom. This is a significant advancement: the formalization now proves a major classical result of infinite combinatorics from first principles.",
+    "summary": "This formalization captures Erd\u0151s Problem #1167 \u2014 the stepping-down conjecture for partition relations \u2014 in 594 lines of Lean 4 code with only 2 axioms (the OPEN conjecture and the Erd\u0151s-Rado theorem) and 19 theorems. The infinite Ramsey theorem (\u2135\u2080 \u2192 (\u2135\u2080)^r_k for all finite r, k) is FULLY PROVED by induction on r using Ramsey's diagonal argument, eliminating the previous axiom. This is a significant advancement: the formalization now proves a major classical result of infinite combinatorics from first principles.",
     "implications": "Resolving this conjecture would establish a fundamental duality in partition calculus: the stepping-up lemma and a stepping-down lemma would together give a complete picture of how partition properties transfer between consecutive exponents. A positive resolution would provide a powerful tool for deriving partition relations at lower exponents from known results at higher exponents, potentially simplifying many arguments in infinite combinatorics.",
     "openQuestions": [
       "Does the stepping-down implication hold in ZFC, or is it independent of the standard axioms?",
-      "Can the conjecture be proved for the special case r=2, γ=2 (two colors, pairs-to-triples)?",
-      "What is the relationship between this conjecture and the stepping-up lemma — is there a formal duality?",
-      "Can the Erdős-Rado theorem ((2^κ)⁺ → (κ⁺)²_κ) be proved in Lean 4? This is the only remaining axiomatized known result, requiring a formalization of transfinite recursion on ordinals.",
-      "Does a counterexample exist for specific choices of λ, r, γ, and targets?"
+      "Can the conjecture be proved for the special case r=2, \u03b3=2 (two colors, pairs-to-triples)?",
+      "What is the relationship between this conjecture and the stepping-up lemma \u2014 is there a formal duality?",
+      "Can the Erd\u0151s-Rado theorem ((2^\u03ba)\u207a \u2192 (\u03ba\u207a)\u00b2_\u03ba) be proved in Lean 4? This is the only remaining axiomatized known result, requiring a formalization of transfinite recursion on ordinals.",
+      "Does a counterexample exist for specific choices of \u03bb, r, \u03b3, and targets?"
     ]
   },
   "leanFile": {
@@ -165,14 +165,14 @@
     ],
     "namespace": "Erdos1167",
     "lineCount": 594,
-    "axiomCount": 3,
+    "axiomCount": 2,
     "theoremCount": 19,
     "definitionCount": 5
   },
   "references": [
-    "Erdős, Hajnal, Rado (1956): A partition calculus in set theory — original problem formulation",
-    "Ramsey (1929): On a problem of formal logic — finite Ramsey theorem",
-    "Erdős, Rado (1956): (2^κ)⁺ → (κ⁺)²_κ — the classical stepping-up result",
+    "Erd\u0151s, Hajnal, Rado (1956): A partition calculus in set theory \u2014 original problem formulation",
+    "Ramsey (1929): On a problem of formal logic \u2014 finite Ramsey theorem",
+    "Erd\u0151s, Rado (1956): (2^\u03ba)\u207a \u2192 (\u03ba\u207a)\u00b2_\u03ba \u2014 the classical stepping-up result",
     "[Va99, 7.79]: Vaughan's survey cataloguing the problem",
     "https://erdosproblems.com/1167"
   ],
@@ -180,17 +180,17 @@
     {
       "targetId": "erdos-1169",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, open, ramsey-theory, set-theory"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, open, ramsey-theory, set-theory"
     },
     {
       "targetId": "erdos-1171",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, open, ramsey-theory, set-theory"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, open, ramsey-theory, set-theory"
     },
     {
       "targetId": "erdos-1172",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, open, ramsey-theory, set-theory"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, open, ramsey-theory, set-theory"
     }
   ]
 }

--- a/src/data/proofs/erdos-446/meta.json
+++ b/src/data/proofs/erdos-446/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-446",
-  "title": "Erdős Problem #446: Density of Integers with Divisors in (n, 2n)",
+  "title": "Erd\u0151s Problem #446: Density of Integers with Divisors in (n, 2n)",
   "slug": "erdos-446",
-  "description": "Let δ(n) denote the density of integers divisible by some d ∈ (n, 2n). Ford (2008) proved δ(n) ≍ 1/((log n)^α (log log n)^{3/2}) where α ≈ 0.08607, and disproved δ₁(n) = o(δ(n)).",
+  "description": "Let \u03b4(n) denote the density of integers divisible by some d \u2208 (n, 2n). Ford (2008) proved \u03b4(n) \u224d 1/((log n)^\u03b1 (log log n)^{3/2}) where \u03b1 \u2248 0.08607, and disproved \u03b4\u2081(n) = o(\u03b4(n)).",
   "meta": {
-    "author": "Ford (2008 resolution), Erdős-Tenenbaum (earlier bounds)",
+    "author": "Ford (2008 resolution), Erd\u0151s-Tenenbaum (earlier bounds)",
     "sourceUrl": "https://erdosproblems.com/446",
     "date": "2008",
     "status": "axiomatized",
@@ -41,35 +41,35 @@
       }
     ],
     "originalContributions": [
-      "hasDivisorInInterval definition: ∃d ∈ (n, 2n) with d | m",
+      "hasDivisorInInterval definition: \u2203d \u2208 (n, 2n) with d | m",
       "delta axiom: asymptotic density with non-negativity and upper bound",
       "divisorCount: computable number of divisors in (n, 2n)",
       "deltaR axiom: density with exactly r divisors",
-      "delta_decomposition axiom: δ(n) = Σᵣ δᵣ(n)",
-      "alpha constant: 1 - (1 + log log 2)/log 2 ≈ 0.08607",
-      "Historical axioms: Besicovitch 1934, Erdős 1935, Erdős 1960",
+      "delta_decomposition axiom: \u03b4(n) = \u03a3\u1d63 \u03b4\u1d63(n)",
+      "alpha constant: 1 - (1 + log log 2)/log 2 \u2248 0.08607",
+      "Historical axioms: Besicovitch 1934, Erd\u0151s 1935, Erd\u0151s 1960",
       "ford_2008_main axiom: exact asymptotic",
-      "ford_2008_disproof axiom: δ₁(n) is NOT o(δ(n))",
-      "ford_2008_general axiom: δᵣ(n) ≫ᵣ δ(n) for all r",
+      "ford_2008_disproof axiom: \u03b4\u2081(n) is NOT o(\u03b4(n))",
+      "ford_2008_general axiom: \u03b4\u1d63(n) \u226b\u1d63 \u03b4(n) for all r",
       "prime_no_divisor theorem: primes > 2n avoid the interval",
       "erdos_446_summary theorem: combines Ford's results"
     ],
-    "axiomCount": 2,
+    "axiomCount": 4,
     "lineCount": 139,
     "assumptions": "12 axioms: delta, delta_nonneg, delta_le_one, and 9 more. See Lean source for complete statements."
   },
   "overview": {
-    "historicalContext": "Erdős Problem #446 studies the density of integers having a divisor in the interval (n, 2n), a question with a remarkable 74-year history spanning from Besicovitch to Ford. Besicovitch (1934) first showed liminf δ(n) = 0, and Erdős (1935) strengthened this to δ(n) → 0. In 1960, Erdős found the correct exponent: δ(n) = (log n)^{-α + o(1)} where α = 1 - (1 + log log 2)/log 2 ≈ 0.08607.\n\nThe problem has two parts. The first asks for the exact growth rate of δ(n). Kevin Ford resolved this completely in a 2008 Annals of Mathematics paper, proving δ(n) ≍ 1/((log n)^α (log log n)^{3/2}). The secondary (log log n)^{3/2} correction factor refined Erdős's 1960 estimate. Tenenbaum (1984) had made partial progress with improved bounds in Compositio Math.\n\nThe second part asks whether δ₁(n) = o(δ(n)), i.e., whether integers with exactly one divisor in (n, 2n) are negligible. Erdős was \"quite sure\" this was true at Oberwolfach in 1986, but noted that \"recent results of Tenenbaum throw some doubt on this.\" His doubt was prescient: Ford proved δ₁(n) is NOT o(δ(n)), and in fact δᵣ(n) ≫ᵣ δ(n) for all r ≥ 1, meaning the divisor count distribution is surprisingly flat.",
-    "problemStatement": "Let δ(n) denote the density of integers divisible by some integer in the interval (n, 2n). **Part 1:** What is the growth rate of δ(n)? **Answer:** $\\delta(n) \\asymp \\frac{1}{(\\log n)^\\alpha (\\log\\log n)^{3/2}}$ where $\\alpha = 1 - \\frac{1 + \\log\\log 2}{\\log 2} \\approx 0.08607$. **Part 2:** If $\\delta_1(n)$ is the density with exactly one divisor in $(n, 2n)$, is $\\delta_1(n) = o(\\delta(n))$? **Answer:** NO (Ford 2008). In fact $\\delta_r(n) \\gg_r \\delta(n)$ for all $r \\geq 1$.",
-    "text": "Let δ(n) denote the density of integers divisible by some d ∈ (n, 2n). Ford (2008) proved δ(n) ≍ 1/((log n)^α (log log n)^{3/2}) where α ≈ 0.08607, and disproved δ₁(n) = o(δ(n)).",
-    "proofStrategy": "The formalization defines the core predicate hasDivisorInInterval and the computable divisorCount function. The asymptotic densities δ(n) and δᵣ(n) are axiomatized since their definitions require measure-theoretic limits. The constant α is defined explicitly. Historical results (Besicovitch, Erdős) and Ford's resolution are stated as axioms with their precise quantitative forms. A proved theorem demonstrates that primes larger than 2n avoid the interval. The summary theorem combines Ford's two main results.",
+    "historicalContext": "Erd\u0151s Problem #446 studies the density of integers having a divisor in the interval (n, 2n), a question with a remarkable 74-year history spanning from Besicovitch to Ford. Besicovitch (1934) first showed liminf \u03b4(n) = 0, and Erd\u0151s (1935) strengthened this to \u03b4(n) \u2192 0. In 1960, Erd\u0151s found the correct exponent: \u03b4(n) = (log n)^{-\u03b1 + o(1)} where \u03b1 = 1 - (1 + log log 2)/log 2 \u2248 0.08607.\n\nThe problem has two parts. The first asks for the exact growth rate of \u03b4(n). Kevin Ford resolved this completely in a 2008 Annals of Mathematics paper, proving \u03b4(n) \u224d 1/((log n)^\u03b1 (log log n)^{3/2}). The secondary (log log n)^{3/2} correction factor refined Erd\u0151s's 1960 estimate. Tenenbaum (1984) had made partial progress with improved bounds in Compositio Math.\n\nThe second part asks whether \u03b4\u2081(n) = o(\u03b4(n)), i.e., whether integers with exactly one divisor in (n, 2n) are negligible. Erd\u0151s was \"quite sure\" this was true at Oberwolfach in 1986, but noted that \"recent results of Tenenbaum throw some doubt on this.\" His doubt was prescient: Ford proved \u03b4\u2081(n) is NOT o(\u03b4(n)), and in fact \u03b4\u1d63(n) \u226b\u1d63 \u03b4(n) for all r \u2265 1, meaning the divisor count distribution is surprisingly flat.",
+    "problemStatement": "Let \u03b4(n) denote the density of integers divisible by some integer in the interval (n, 2n). **Part 1:** What is the growth rate of \u03b4(n)? **Answer:** $\\delta(n) \\asymp \\frac{1}{(\\log n)^\\alpha (\\log\\log n)^{3/2}}$ where $\\alpha = 1 - \\frac{1 + \\log\\log 2}{\\log 2} \\approx 0.08607$. **Part 2:** If $\\delta_1(n)$ is the density with exactly one divisor in $(n, 2n)$, is $\\delta_1(n) = o(\\delta(n))$? **Answer:** NO (Ford 2008). In fact $\\delta_r(n) \\gg_r \\delta(n)$ for all $r \\geq 1$.",
+    "text": "Let \u03b4(n) denote the density of integers divisible by some d \u2208 (n, 2n). Ford (2008) proved \u03b4(n) \u224d 1/((log n)^\u03b1 (log log n)^{3/2}) where \u03b1 \u2248 0.08607, and disproved \u03b4\u2081(n) = o(\u03b4(n)).",
+    "proofStrategy": "The formalization defines the core predicate hasDivisorInInterval and the computable divisorCount function. The asymptotic densities \u03b4(n) and \u03b4\u1d63(n) are axiomatized since their definitions require measure-theoretic limits. The constant \u03b1 is defined explicitly. Historical results (Besicovitch, Erd\u0151s) and Ford's resolution are stated as axioms with their precise quantitative forms. A proved theorem demonstrates that primes larger than 2n avoid the interval. The summary theorem combines Ford's two main results.",
     "keyInsights": [
-      "**The Constant α**: α = 1 - (1 + log log 2)/log 2 ≈ 0.08607 governs the decay rate",
-      "**Slow Decay**: δ(n) → 0 very slowly — like 1/(log n)^{0.086}",
-      "**Log-log Correction**: The (log log n)^{3/2} factor refines Erdős's 1960 estimate",
-      "**Disproof**: δ₁(n) = o(δ(n)) is FALSE — most integers with a divisor in (n, 2n) have exactly one",
-      "**Generalization**: For each r, δᵣ(n) is comparable to δ(n), not negligible",
-      "**Erdős's Prescient Doubt**: His 1986 uncertainty about the secondary conjecture was justified"
+      "**The Constant \u03b1**: \u03b1 = 1 - (1 + log log 2)/log 2 \u2248 0.08607 governs the decay rate",
+      "**Slow Decay**: \u03b4(n) \u2192 0 very slowly \u2014 like 1/(log n)^{0.086}",
+      "**Log-log Correction**: The (log log n)^{3/2} factor refines Erd\u0151s's 1960 estimate",
+      "**Disproof**: \u03b4\u2081(n) = o(\u03b4(n)) is FALSE \u2014 most integers with a divisor in (n, 2n) have exactly one",
+      "**Generalization**: For each r, \u03b4\u1d63(n) is comparable to \u03b4(n), not negligible",
+      "**Erd\u0151s's Prescient Doubt**: His 1986 uncertainty about the secondary conjecture was justified"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -86,15 +86,15 @@
     },
     {
       "id": "alpha",
-      "title": "The Constant α",
-      "summary": "Definition and numerical bounds for α ≈ 0.08607",
+      "title": "The Constant \u03b1",
+      "summary": "Definition and numerical bounds for \u03b1 \u2248 0.08607",
       "startLine": 75,
       "endLine": 84
     },
     {
       "id": "historical",
       "title": "Historical Results",
-      "summary": "Besicovitch 1934, Erdős 1935, Erdős 1960 axioms",
+      "summary": "Besicovitch 1934, Erd\u0151s 1935, Erd\u0151s 1960 axioms",
       "startLine": 85,
       "endLine": 106
     },
@@ -121,12 +121,12 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #446 was completely resolved by Kevin Ford in 2008. The density δ(n) of integers with a divisor in (n, 2n) decays like 1/((log n)^α (log log n)^{3/2}) where α ≈ 0.08607. Erdős's secondary conjecture that δ₁(n) = o(δ(n)) was disproved — in fact, δᵣ(n) ≫ δ(n) for all r.",
+    "summary": "Erd\u0151s Problem #446 was completely resolved by Kevin Ford in 2008. The density \u03b4(n) of integers with a divisor in (n, 2n) decays like 1/((log n)^\u03b1 (log log n)^{3/2}) where \u03b1 \u2248 0.08607. Erd\u0151s's secondary conjecture that \u03b4\u2081(n) = o(\u03b4(n)) was disproved \u2014 in fact, \u03b4\u1d63(n) \u226b \u03b4(n) for all r.",
     "implications": "Ford's result shows that divisors in (n, 2n) are surprisingly common and well-distributed by count. The work advanced analytic number theory techniques for divisor distribution problems and appeared in the Annals of Mathematics.",
     "openQuestions": [
-      "What are the exact constants in the asymptotic for δ(n)?",
+      "What are the exact constants in the asymptotic for \u03b4(n)?",
       "How does the distribution of divisor counts vary with n?",
-      "Can similar results be proved for intervals (n, cn) with c ≠ 2?"
+      "Can similar results be proved for intervals (n, cn) with c \u2260 2?"
     ]
   },
   "leanFile": {
@@ -141,7 +141,7 @@
     ],
     "namespace": "Erdos446",
     "lineCount": 139,
-    "axiomCount": 2,
+    "axiomCount": 4,
     "theoremCount": 2,
     "definitionCount": 5
   },
@@ -149,17 +149,17 @@
     {
       "targetId": "erdos-427",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: divisibility, number-theory, solved"
+      "description": "Related Erd\u0151s problem sharing themes: divisibility, number-theory, solved"
     },
     {
       "targetId": "erdos-459",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: asymptotic-density, number-theory, solved"
+      "description": "Related Erd\u0151s problem sharing themes: asymptotic-density, number-theory, solved"
     },
     {
       "targetId": "erdos-728",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: divisibility, number-theory, solved"
+      "description": "Related Erd\u0151s problem sharing themes: divisibility, number-theory, solved"
     }
   ]
 }

--- a/src/data/proofs/erdos-554/meta.json
+++ b/src/data/proofs/erdos-554/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-554",
-  "title": "Erdős Problem #554: Odd Cycle vs Triangle Ramsey Numbers",
+  "title": "Erd\u0151s Problem #554: Odd Cycle vs Triangle Ramsey Numbers",
   "slug": "erdos-554",
   "description": "Show that for any n >= 2, the ratio R(C_{2n+1}; k) / R(K_3; k) tends to 0 as k tends to infinity, where R(G; k) is the k-color Ramsey number of G.",
   "meta": {
-    "author": "Erdős-Graham (1981 conjecture)",
+    "author": "Erd\u0151s-Graham (1981 conjecture)",
     "sourceUrl": "https://erdosproblems.com/554",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos554Problem.lean",
@@ -40,33 +40,33 @@
       }
     ],
     "originalContributions": [
-      "ramseyNumber axiomatization: k-color Ramsey number R(G; k) as ℕ → ℕ → ℕ",
+      "ramseyNumber axiomatization: k-color Ramsey number R(G; k) as \u2115 \u2192 \u2115 \u2192 \u2115",
       "triangleRamsey and oddCycleRamsey definitions",
       "erdosConjecture554: ratio-limit formulation using rational arithmetic",
       "triangle_ramsey_exponential: R(K_3; k) >= 2^k lower bound",
       "triangle_ramsey_upper: existence of exponential upper bound",
       "oddCycle_ramsey_upper: R(C_{2n+1}; k) <= (2n+1)^k",
       "oddCycle_ramsey_lower: linear lower bound k*(2n) + 1",
-      "two_color_odd_cycle: R(C_{2n+1}; 2) = 4n+1 (Bondy-Erdős 1973)",
+      "two_color_odd_cycle: R(C_{2n+1}; 2) = 4n+1 (Bondy-Erd\u0151s 1973)",
       "two_color_pentagon_ratio: verified 2-color values from axioms",
       "pentagon_is_special_case: C_5 case follows from full conjecture",
       "erdos_question_chromatic_3: connection to chromatic number question"
     ],
-    "axiomCount": 1,
+    "axiomCount": 3,
     "lineCount": 128,
     "assumptions": "11 axioms: ramseyNumber, ramseyNumber_ge, ramseyNumber_mono_colors, and 8 more. See Lean source for complete statements."
   },
   "overview": {
-    "historicalContext": "Erdős Problem #554 was posed by Erdős and Graham in 1981 as part of their influential work on Ramsey theory. The problem concerns the growth rates of multicolor Ramsey numbers for different graph families. In the classical 2-color setting, Ramsey numbers for odd cycles were completely determined by Bondy and Erdős in 1973: R(C_{2n+1}; 2) = 4n + 1 for n >= 2. This showed that odd cycle Ramsey numbers are much smaller than triangle Ramsey numbers even for 2 colors (R(K_3; 2) = 6).\n\nThe natural question is whether this gap persists and widens as the number of colors grows. Erdős and Graham conjectured that the ratio R(C_{2n+1}; k) / R(K_3; k) tends to 0 as k tends to infinity, for any fixed n >= 2. This would mean that, in some precise sense, odd cycles are 'much easier' to find monochromatically than triangles in multicolor settings.\n\nThe conjecture remains OPEN as of 2026, even for the simplest case n = 2 (the pentagon C_5). It is deeply connected to fundamental questions about how graph structure affects Ramsey-theoretic complexity. All odd cycles have chromatic number 3, the same as the triangle K_3, yet the conjecture predicts dramatically different Ramsey behavior.",
-    "problemStatement": "**Problem (Erdős-Graham, 1981):** For any integer $n \\geq 2$, prove that\n$$\\lim_{k \\to \\infty} \\frac{R(C_{2n+1};\\, k)}{R(K_3;\\, k)} = 0$$\nwhere $R(G;\\, k)$ denotes the $k$-color Ramsey number of the graph $G$.\n\n**Status:** OPEN. The conjecture is unresolved even for $n = 2$ (the pentagon $C_5$).",
+    "historicalContext": "Erd\u0151s Problem #554 was posed by Erd\u0151s and Graham in 1981 as part of their influential work on Ramsey theory. The problem concerns the growth rates of multicolor Ramsey numbers for different graph families. In the classical 2-color setting, Ramsey numbers for odd cycles were completely determined by Bondy and Erd\u0151s in 1973: R(C_{2n+1}; 2) = 4n + 1 for n >= 2. This showed that odd cycle Ramsey numbers are much smaller than triangle Ramsey numbers even for 2 colors (R(K_3; 2) = 6).\n\nThe natural question is whether this gap persists and widens as the number of colors grows. Erd\u0151s and Graham conjectured that the ratio R(C_{2n+1}; k) / R(K_3; k) tends to 0 as k tends to infinity, for any fixed n >= 2. This would mean that, in some precise sense, odd cycles are 'much easier' to find monochromatically than triangles in multicolor settings.\n\nThe conjecture remains OPEN as of 2026, even for the simplest case n = 2 (the pentagon C_5). It is deeply connected to fundamental questions about how graph structure affects Ramsey-theoretic complexity. All odd cycles have chromatic number 3, the same as the triangle K_3, yet the conjecture predicts dramatically different Ramsey behavior.",
+    "problemStatement": "**Problem (Erd\u0151s-Graham, 1981):** For any integer $n \\geq 2$, prove that\n$$\\lim_{k \\to \\infty} \\frac{R(C_{2n+1};\\, k)}{R(K_3;\\, k)} = 0$$\nwhere $R(G;\\, k)$ denotes the $k$-color Ramsey number of the graph $G$.\n\n**Status:** OPEN. The conjecture is unresolved even for $n = 2$ (the pentagon $C_5$).",
     "text": "Show that for any n >= 2, the ratio R(C_{2n+1}; k) / R(K_3; k) tends to 0 as k tends to infinity, where R(G; k) is the k-color Ramsey number of G.",
-    "proofStrategy": "Since this is an open problem, we formalize the conjecture and surrounding theory rather than proving it. The Lean file axiomatizes Ramsey numbers as a function ℕ → ℕ → ℕ and states the conjecture using rational arithmetic to avoid real-valued limits. We axiomatize known bounds: exponential growth of R(K_3; k), polynomial-type bounds on odd cycle Ramsey numbers, and the classical 2-color results. We prove that the pentagon case is a special case of the full conjecture, and connect the problem to broader questions about chromatic number and Ramsey complexity.",
+    "proofStrategy": "Since this is an open problem, we formalize the conjecture and surrounding theory rather than proving it. The Lean file axiomatizes Ramsey numbers as a function \u2115 \u2192 \u2115 \u2192 \u2115 and states the conjecture using rational arithmetic to avoid real-valued limits. We axiomatize known bounds: exponential growth of R(K_3; k), polynomial-type bounds on odd cycle Ramsey numbers, and the classical 2-color results. We prove that the pentagon case is a special case of the full conjecture, and connect the problem to broader questions about chromatic number and Ramsey complexity.",
     "keyInsights": [
       "**Ratio-Limit Conjecture**: R(C_{2n+1}; k) / R(K_3; k) -> 0 says odd cycles are asymptotically negligible compared to triangles in multicolor Ramsey theory",
       "**Simplest Open Case**: Even for n = 2 (the pentagon C_5), the conjecture is unknown, making it one of the most basic open problems in multicolor Ramsey theory",
       "**Chromatic Number Paradox**: Odd cycles and triangles both have chromatic number 3, yet the conjecture predicts very different Ramsey behavior, suggesting Ramsey complexity depends on graph structure beyond just chromatic number",
       "**Known Bounds**: R(K_3; k) >= 2^k (exponential) while R(C_{2n+1}; 2) = 4n+1 (linear in n for fixed colors), but the multicolor growth rates are not well understood",
-      "**2-Color Benchmark**: Bondy-Erdős (1973) completely solved the 2-color case: R(C_{2n+1}; 2) = 4n + 1, establishing that odd cycle Ramsey numbers are small relative to triangle Ramsey numbers"
+      "**2-Color Benchmark**: Bondy-Erd\u0151s (1973) completely solved the 2-color case: R(C_{2n+1}; 2) = 4n + 1, establishing that odd cycle Ramsey numbers are small relative to triangle Ramsey numbers"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -126,12 +126,12 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #554 conjectures that R(C_{2n+1}; k) / R(K_3; k) -> 0 as k -> infinity for any n >= 2. This open problem, posed by Erdős and Graham in 1981, asserts that odd cycles are asymptotically much easier to find monochromatically than triangles. We formalize the conjecture, state known bounds, verify classical 2-color results, and connect the problem to chromatic number questions.",
+    "summary": "Erd\u0151s Problem #554 conjectures that R(C_{2n+1}; k) / R(K_3; k) -> 0 as k -> infinity for any n >= 2. This open problem, posed by Erd\u0151s and Graham in 1981, asserts that odd cycles are asymptotically much easier to find monochromatically than triangles. We formalize the conjecture, state known bounds, verify classical 2-color results, and connect the problem to chromatic number questions.",
     "implications": "**Theoretical Significance**: Resolution would fundamentally advance our understanding of multicolor Ramsey theory.\n\nIt would demonstrate that Ramsey-theoretic complexity of graphs is not determined by chromatic number alone, and would quantify how graph structure (cycles vs. cliques) affects the growth of multicolor Ramsey numbers.",
     "openQuestions": [
       "Does R(C_5; k) / R(K_3; k) -> 0 as k -> infinity? (simplest open case)",
       "What is the exact growth rate of R(C_{2n+1}; k) for k >= 3 colors?",
-      "Is there a graph G with χ(G) = 3 for which R(G; k) / R(K_3; k) does not tend to 0?",
+      "Is there a graph G with \u03c7(G) = 3 for which R(G; k) / R(K_3; k) does not tend to 0?",
       "What is the precise exponential base for R(K_3; k)?"
     ]
   },
@@ -145,7 +145,7 @@
     "opens": [],
     "namespace": "Erdos554",
     "lineCount": 128,
-    "axiomCount": 1,
+    "axiomCount": 3,
     "theoremCount": 2,
     "definitionCount": 5
   },
@@ -153,17 +153,17 @@
     {
       "targetId": "erdos-558",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: graph-theory, multicolor-ramsey, ramsey-theory"
+      "description": "Related Erd\u0151s problem sharing themes: graph-theory, multicolor-ramsey, ramsey-theory"
     },
     {
       "targetId": "erdos-569",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: graph-theory, odd-cycles, ramsey-theory"
+      "description": "Related Erd\u0151s problem sharing themes: graph-theory, odd-cycles, ramsey-theory"
     },
     {
       "targetId": "erdos-925",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: graph-theory, multicolor-ramsey, ramsey-theory"
+      "description": "Related Erd\u0151s problem sharing themes: graph-theory, multicolor-ramsey, ramsey-theory"
     }
   ]
 }

--- a/src/data/proofs/erdos-77/meta.json
+++ b/src/data/proofs/erdos-77/meta.json
@@ -56,7 +56,7 @@
       "2024 improvement: GNNW bound 3.7993",
       "Verified theorems: erdos_bounds, current_best_bounds, erdos_conjecture_consistent"
     ],
-    "axiomCount": 1,
+    "axiomCount": 5,
     "lineCount": 244,
     "assumptions": "16 axioms: RamseyNumber, ramseyNumber_pos, ramsey_1, and 13 more. See Lean source for complete statements."
   },
@@ -141,7 +141,7 @@
     ],
     "namespace": "Erdos77",
     "lineCount": 244,
-    "axiomCount": 1,
+    "axiomCount": 5,
     "theoremCount": 4,
     "definitionCount": 3
   },
@@ -154,12 +154,12 @@
     {
       "targetId": "prob-method-alteration",
       "relationship": "related",
-      "description": "Erdős's 1947 probabilistic lower bound R(k,k) ≥ 2^{k/2} pioneered the probabilistic method formalized here"
+      "description": "Erd\u0151s's 1947 probabilistic lower bound R(k,k) \u2265 2^{k/2} pioneered the probabilistic method formalized here"
     },
     {
       "targetId": "prob-method-lovasz-local",
       "relationship": "related",
-      "description": "The Lovász Local Lemma provides refined Ramsey bounds by handling dependencies in random graph coloring"
+      "description": "The Lov\u00e1sz Local Lemma provides refined Ramsey bounds by handling dependencies in random graph coloring"
     },
     {
       "targetId": "prob-method-second-moment",
@@ -176,7 +176,7 @@
     {
       "key": "Er47",
       "authors": [
-        "P. Erdős"
+        "P. Erd\u0151s"
       ],
       "title": "Some remarks on the theory of graphs",
       "venue": "Bulletin of the American Mathematical Society",
@@ -190,12 +190,12 @@
       "authors": [
         "J. Spencer"
       ],
-      "title": "Ramsey's theorem — a new lower bound",
+      "title": "Ramsey's theorem \u2014 a new lower bound",
       "venue": "Journal of Combinatorial Theory, Series A",
       "year": "1975",
       "volume": "18",
       "pages": "108-115",
-      "note": "Improved Erdős's lower bound by a √2 factor using the Lovász Local Lemma"
+      "note": "Improved Erd\u0151s's lower bound by a \u221a2 factor using the Lov\u00e1sz Local Lemma"
     },
     {
       "key": "Co09",

--- a/src/data/proofs/triangle-inequality-oq-03/meta.json
+++ b/src/data/proofs/triangle-inequality-oq-03/meta.json
@@ -20,7 +20,7 @@
     "proofRepoPath": "Proofs/TriangleInequalityOQ03.lean",
     "badge": "verified",
     "sorries": 0,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 255,
     "mathlibDependencies": [
       {
@@ -188,7 +188,7 @@
   "leanFile": {
     "lineCount": 255,
     "structureCount": 0,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 15,
     "lemmaCount": 0,
     "defCount": 0,


### PR DESCRIPTION
## Fix

Batch correction of `axiomCount` in 7 gallery entries where the previous batch fix (cycle 9 audit, PR #8840) miscounted axioms due to comment-parsing errors.

## Root Cause

The batch fix counted `axiom` occurrences at the start of lines, including:
1. Prose descriptions like `axiom of metric spaces` inside block comments (`/- ... -/`)
2. Code examples inside documentation blocks (` ```lean ... ``` `)  
3. In two cases (`erdos-77`, `erdos-446`, `erdos-554`), the batch UNDERCOUNTED real axioms

## Evidence

| Proof | Before | After | Cause |
|-------|--------|-------|-------|
| `triangle-inequality-oq-03` | 1 | 0 | "axiom of metric spaces" in block comment (line 5) |
| `buffons-needle-oq-01-oq-01` | 1 | 0 | `axiom` in \`\`\`lean\`\`\` example inside comment |
| `erdos-1167` | 3 | 2 | "axiom count from 3 to 2" in prose comment |
| `erdos-77` | 1 | 5 | 5 real `axiom` declarations, batch undercounted |
| `erdos-446` | 2 | 4 | 4 real `axiom` declarations, batch undercounted |
| `erdos-554` | 1 | 3 | 3 real `axiom` declarations, batch undercounted |
| `central-limit-theorem-oq-04` | 8 | 9 | 9 real `axiom` declarations, off by 1 |

## Verification

For each file, confirmed by `grep -c "^axiom " <lean_file>` with manual inspection to exclude comment-embedded text.

---
Automated fix by lean-mechanic agent.