### PR TITLE
Audit: fix cauchy-schwarz-oq-02-oq-01 badge (original→mathlib)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -47,9 +47,9 @@
       "result": "clean"
     },
     "amgm-inequality": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-03-24T02:59:23Z",
+      "lastAudited": "2026-04-03T11:08:13Z",
       "result": "clean"
     },
     "amgm-inequality-oq-02": {
@@ -11280,6 +11280,12 @@
       "auditCount": 1,
       "lastAudited": "2026-04-03T09:33:04Z",
       "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T11:15:13Z",
+      "result": "issues-fixed",
       "issues": []
     }
   },

--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-01/meta.json
@@ -1,0 +1,105 @@
+{
+  "id": "cauchy-schwarz-oq-02-oq-01",
+  "title": "Parseval's Identity: Energy Conservation in Fourier Analysis",
+  "slug": "cauchy-schwarz-oq-02-oq-01",
+  "description": "Formalizes Parseval's identity — ∑|ĉₙ(f)|² = ∫|f|²dμ — as a consequence of the L² structure from CauchySchwarzOQ02. Proves: Parseval energy equality (tsum = integral), Bessel-Parseval tightness (Bessel's inequality is equality in total), Fourier orthonormality, Pythagorean theorem for finite Fourier sums, L² convergence of Fourier series, and completeness (zero-kernel). 10 theorems, 1 sorry (Pythagorean for finite sums).",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-04-03",
+    "status": "formalized",
+    "proofRepoPath": "Proofs/CauchySchwarzOQ02OQ01.lean",
+    "tags": [
+      "analysis",
+      "fourier",
+      "parseval",
+      "l2-spaces",
+      "cauchy-schwarz",
+      "orthonormality"
+    ],
+    "badge": "mathlib",
+    "sorries": 1,
+    "dateAdded": "2026-04-03",
+    "axiomCount": 0,
+    "assumptions": "1 sorry in fourier_pythagorean_partial (orthonormal system norm-sum identity for finite sums). Core results (Parseval, Bessel, L² convergence) derived directly from Mathlib's tsum_sq_fourierCoeff, hasSum_sq_fourierCoeff, orthonormal_fourier, and hasSum_fourier_series_L2.",
+    "lineCount": 198,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "tsum_sq_fourierCoeff",
+        "description": "Parseval identity: ∑' n, ‖ĉₙ(f)‖² = ∫ |f|² dμ",
+        "module": "Mathlib.Analysis.Fourier.AddCircle"
+      },
+      {
+        "theorem": "hasSum_sq_fourierCoeff",
+        "description": "HasSum form of Parseval: squared Fourier coefficients sum to L² norm",
+        "module": "Mathlib.Analysis.Fourier.AddCircle"
+      },
+      {
+        "theorem": "orthonormal_fourier",
+        "description": "Fourier monomials are orthonormal in L²(AddCircle T)",
+        "module": "Mathlib.Analysis.Fourier.AddCircle"
+      },
+      {
+        "theorem": "hasSum_fourier_series_L2",
+        "description": "Fourier series converges to f in L²",
+        "module": "Mathlib.Analysis.Fourier.AddCircle"
+      },
+      {
+        "theorem": "sum_le_hasSum",
+        "description": "Finite partial sums ≤ tsum (used for Bessel's inequality)",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      }
+    ],
+    "originalContributions": [
+      "fourier_pythagorean_partial: ‖∑_{n∈S} cₙeₙ‖² = ∑_{n∈S} |cₙ|² — attempted original proof of finite Pythagorean identity for orthonormal systems (1 sorry remaining)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Parseval (1799) discovered the energy equality for Fourier series; Plancherel (1910) extended it to L² functions. The identity ∑|ĉₙ|² = ‖f‖² is foundational to Fourier analysis, signal processing, and quantum mechanics. It expresses conservation of energy: total power in the frequency domain equals total power in the time domain.",
+    "problemStatement": "Formalize Parseval's identity ∑_{n∈ℤ} |ĉₙ(f)|² = ‖f‖²_{L²} for Fourier coefficients on the circle, as a follow-up to the Hölder/L² theory in CauchySchwarzOQ02.",
+    "text": "Parseval's identity connects the L² norm to the Fourier coefficients: ∑' n : ℤ, ‖ĉₙ(f)‖² = ∫ |f|² dμ for f ∈ L²(AddCircle T). This is the limiting form of the Pythagorean theorem: since the Fourier monomials are orthonormal (⟪eₙ, eₘ⟫ = δₙₘ), finite partial sums satisfy ‖∑_{n∈S} ĉₙeₙ‖² = ∑_{n∈S} |ĉₙ|² (Pythagorean). As the partial sums converge in L² to f (completeness of the Fourier system), the left side approaches ‖f‖², yielding Parseval.",
+    "proofStrategy": "Apply Mathlib's hasSum_sq_fourierCoeff for Parseval, orthonormal_fourier for orthonormality, and hasSum_fourier_series_L2 for L² convergence. The Pythagorean theorem for finite sums requires careful manipulation of inner products with orthonormal systems.",
+    "keyInsights": [
+      "Parseval = limit of Pythagorean: Bessel's inequality ∑_{n∈S}|ĉₙ|² ≤ ‖f‖² becomes equality in total",
+      "Completeness of Fourier system: zero-kernel property (all ĉₙ = 0 ⟹ f = 0)",
+      "L² convergence gives Parseval via norm continuity: ‖Sₙ(f)‖² → ‖f‖²",
+      "Connection to CauchySchwarzOQ02: the Pythagorean theorem applied to orthogonal Fourier modes"
+    ],
+    "prerequisites": [
+      "Fourier analysis: Fourier coefficients, Fourier monomials, AddCircle",
+      "L² spaces: Lp ℂ 2, haarAddCircle measure",
+      "Inner product spaces: orthonormality, Hilbert basis"
+    ]
+  },
+  "conclusion": {
+    "summary": "Parseval's identity formalized: ∑|ĉₙ(f)|² = ∫|f|²dμ. 10 theorems including Parseval energy equality, Bessel tightness, Fourier orthonormality, L² convergence, and completeness. 1 sorry in Pythagorean finite sum identity.",
+    "implications": "Parseval is foundational for Fourier analysis: it enables L² theory of Fourier series, underlies Plancherel's theorem for the Fourier transform, and is essential for quantum mechanics (Hilbert space formulation). The connection to Pythagorean theorem shows Parseval as an infinite-dimensional Pythagoras.",
+    "openQuestions": [
+      "Formalize the Pythagorean norm identity ‖∑_{n∈S} cₙeₙ‖² = ∑_{n∈S} |cₙ|² without sorry",
+      "Prove the inner product Parseval: ⟪f,g⟫ = ∑ ĉₙ(f)·conj(ĉₙ(g)) (Parseval-Plancherel)",
+      "Extend to general Hilbert bases: abstract Parseval for any orthonormal basis"
+    ]
+  },
+  "leanFile": {
+    "namespace": "ParsevalIdentity",
+    "lineCount": 198,
+    "axiomCount": 0,
+    "sorries": 1,
+    "theoremCount": 10,
+    "definitionCount": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "cauchy-schwarz-oq-02",
+      "relationship": "extends",
+      "description": "CauchySchwarzOQ02 proves Pythagorean theorem in L²; OQ-01 applies it to Fourier modes to get Parseval"
+    },
+    {
+      "targetId": "fourier-series",
+      "relationship": "applies",
+      "description": "Uses Fourier series machinery (orthonormal_fourier, hasSum_fourier_series_L2) from FourierSeries.lean"
+    }
+  ],
+  "sections": []
+}


### PR DESCRIPTION
## Summary

- Gallery integrity fix: `cauchy-schwarz-oq-02-oq-01` (Parseval's Identity) was badged `original` but is a Mathlib bridge proof
- 9 of 10 theorems are direct one-liner Mathlib wrappers; only `fourier_pythagorean_partial` attempts original work (with 1 sorry)
- Added `mathlibDependencies` field with the 5 key Mathlib theorems used
- Updated `originalContributions` to reflect only the genuine attempt
- Added proof to `audit-tracker.json` (first audit, result: issues-fixed)

## Evidence

**Delegation opacity (Failure Mode #1)**: The Lean source shows:
- `parseval_energy` → `tsum_sq_fourierCoeff f` (1-line Mathlib wrapper)
- `parseval_hassum` → `hasSum_sq_fourierCoeff f` (1-line Mathlib wrapper)
- `fourier_orthonormal` → `orthonormal_fourier` (1-line Mathlib wrapper)
- `fourier_series_L2_convergence` → `hasSum_fourier_series_L2 f` (1-line Mathlib wrapper)
- etc.

The `proofStrategy` field in the overview even says "Apply Mathlib's hasSum_sq_fourierCoeff...", confirming the delegation.

## Test plan

- [ ] Verify badge shows `mathlib` on the gallery page for cauchy-schwarz-oq-02-oq-01
- [ ] Confirm sorries (1) and axiomCount (0) are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)