### PR TITLE
chore: sync research listings and data

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -10526,11 +10526,12 @@
     },
     {
       "slug": "hilbert-11-oq-01",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T21:46:38.107Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T21:46:38.107Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T11:25:13.703Z",
+      "completed": "2026-04-03T11:25:13.703Z"
     },
     {
       "slug": "hilbert-15-oq-02",
@@ -10959,11 +10960,12 @@
     },
     {
       "slug": "amgm-inequality-oq-02-oq-03-oq-03",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-03T08:12:38.872Z",
-      "status": "active",
-      "lastUpdate": "2026-04-03T08:12:38.872Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T11:25:13.741Z",
+      "completed": "2026-04-03T11:25:13.741Z"
     },
     {
       "slug": "area-of-circle-oq-05-incomplete-01",


### PR DESCRIPTION
Automated sync from deployer agent. Added 44, updated 635 listings. 3582 total iterations.