### PR TITLE
Fix: restore IsMultiplicativeSidon definition in Erdos795Problem.lean

### DIFF
--- a/proofs/Proofs/Stubs/Erdos795Problem.lean
+++ b/proofs/Proofs/Stubs/Erdos795Problem.lean
@@ -364,26 +364,7 @@ theorem raghavan_error_is_smaller (n : ℕ) (hn : n ≥ 4) :
 unexpected end of input; expected ','-/
 /-- A multiplicative Sidon set: no non-trivial product relations -/
 def IsMultiplicativeSidon (A : Finset ℕ) : Prop :=
-  ∀ a b c d
-
-/- Aristotle failed to load this code into its environment. Double check that the syntax is correct.
-
-unexpected token '∈'; expected command
-Function expected at
-  IsMultiplicativeSidon
-but this term has type
-  ?m.1
-
-Note: Expected a function because this term is being applied to the argument
-  A
-Function expected at
-  HasDistinctSubsetProducts
-but this term has type
-  ?m.2
-
-Note: Expected a function because this term is being applied to the argument
-  A-/
-∈ A, a * b = c * d → ({a, b} : Finset ℕ) = {c, d}
+  ∀ a b c d ∈ A, a * b = c * d → ({a, b} : Finset ℕ) = {c, d}
 
 /-- Multiplicative Sidon implies distinct subset products -/
 theorem sidon_implies_distinct_products (A : Finset ℕ)


### PR DESCRIPTION
## Fix

Restore the broken `IsMultiplicativeSidon` definition in `proofs/Proofs/Stubs/Erdos795Problem.lean`.

## Root Cause

An Aristotle error comment block was embedded inside the definition body, splitting the `∀` quantifier across two separate syntactic units:

```lean
-- BROKEN (before):
def IsMultiplicativeSidon (A : Finset ℕ) : Prop :=
  ∀ a b c d          ← incomplete quantifier

/- Aristotle failed ... unexpected token '∈' ... -/   ← embedded error comment

∈ A, a * b = c * d → ({a, b} : Finset ℕ) = {c, d}   ← stray top-level expression
```

This caused Lean to fail with "unexpected token '∈'; expected command" and then cascade errors in all subsequent definitions that reference `IsMultiplicativeSidon` or `HasDistinctSubsetProducts`.

## Evidence

**Before**: `IsMultiplicativeSidon` definition is syntactically broken; Lean sees `∀ a b c d` as an incomplete expression body and `∈ A, ...` as a stray top-level expression.

**After**: Definition restored to a single valid line:
```lean
def IsMultiplicativeSidon (A : Finset ℕ) : Prop :=
  ∀ a b c d ∈ A, a * b = c * d → ({a, b} : Finset ℕ) = {c, d}
```

This unblocks Aristotle from submitting `Erdos795Problem.lean` and restores the ability to type-check downstream theorems (`sidon_implies_distinct_products`, `distinct_products_not_sidon`).

---
Automated fix by lean-mechanic agent.