### PR TITLE
Fix: add Aristotle companion for erdos-27 (5 routine lemma targets)

### DIFF
--- a/proofs/Proofs/Stubs/Erdos27Aristotle.lean
+++ b/proofs/Proofs/Stubs/Erdos27Aristotle.lean
@@ -1,0 +1,94 @@
+/-
+  Aristotle targets for Erdos Problem #27
+  Routine supporting lemmas for automated proof search.
+  See Erdos27Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main disproof (Filaseta-Ford-Konyagin-Pomerance-Yu)
+  - Routine supporting facts: logical equivalences, monotonicity, basic density bounds
+  - No definition sorries
+  - No axioms
+-/
+import Mathlib
+
+namespace Erdos27Aristotle
+
+open Finset Real Filter Topology
+
+/-- A congruence class: residue a modulo n with n > 0. -/
+structure Congruence where
+  residue : ℤ
+  modulus : ℕ
+  modulus_pos : modulus > 0
+
+/-- A congruence system with distinct moduli. -/
+structure CongruenceSystem where
+  congruences : Finset Congruence
+  distinct_moduli : ∀ c₁ ∈ congruences, ∀ c₂ ∈ congruences,
+    c₁.modulus = c₂.modulus → c₁ = c₂
+
+/-- An integer is covered if it satisfies some congruence. -/
+def CongruenceSystem.covers (S : CongruenceSystem) (x : ℤ) : Prop :=
+  ∃ c ∈ S.congruences, x ≡ c.residue [ZMOD c.modulus]
+
+/-- The number of uncovered integers in {1,...,M}. -/
+noncomputable def uncoveredCount (S : CongruenceSystem) (M : ℕ) : ℕ :=
+  ((Finset.range M).filter fun m => ∀ c ∈ S.congruences, ¬((m + 1 : ℤ) ≡ c.residue [ZMOD c.modulus])).card
+
+/-- Asymptotic uncovered density. -/
+noncomputable def asymptoticUncoveredDensity (S : CongruenceSystem) : ℝ :=
+  liminf (fun M => if M = 0 then 1 else (uncoveredCount S M : ℝ) / M) atTop
+
+/-- e-almost covering: uncovered density <= e. -/
+def IsAlmostCovering (S : CongruenceSystem) (ε : ℝ) : Prop :=
+  asymptoticUncoveredDensity S ≤ ε
+
+/-- Perfect covering: every integer is covered. -/
+def IsPerfectCovering (S : CongruenceSystem) : Prop :=
+  ∀ x : ℤ, S.covers x
+
+/-- Moduli in range [N, M]. -/
+def HasModuliInRange (S : CongruenceSystem) (N M : ℕ) : Prop :=
+  ∀ c ∈ S.congruences, N ≤ c.modulus ∧ c.modulus ≤ M
+
+/-- Moduli in range [N, floor(C*N)]. -/
+def HasModuliInCRange (S : CongruenceSystem) (N : ℕ) (C : ℝ) : Prop :=
+  HasModuliInRange S N (Nat.floor (C * N))
+
+/-- Erdos conjecture: exists C > 1, forall e > 0, forall N >= 1, exists S with moduli in [N, CN] that is e-almost covering. -/
+def ErdosConjecture : Prop :=
+  ∃ C : ℝ, C > 1 ∧ ∀ ε > 0, ∀ N : ℕ, N ≥ 1 →
+    ∃ S : CongruenceSystem, HasModuliInCRange S N C ∧ IsAlmostCovering S ε
+
+/-- Negation: forall C > 1, exists e > 0, exists N >= 1, no e-almost covering exists with moduli in [N, CN]. -/
+def ErdosConjectureNegation : Prop :=
+  ∀ C : ℝ, C > 1 → ∃ ε > 0, ∃ N : ℕ, N ≥ 1 ∧
+    ∀ S : CongruenceSystem, HasModuliInCRange S N C → ¬IsAlmostCovering S ε
+
+-- Routine: The conjecture and its negation are logical opposites.
+-- By de Morgan: exists C, forall e, forall N, exists S, P <-> not (forall C, exists e, exists N, forall S, not P)
+theorem conjecture_dichotomy : ErdosConjecture ↔ ¬ErdosConjectureNegation := by
+  sorry
+
+-- Routine: uncoveredCount is bounded by M.
+theorem uncoveredCount_le (S : CongruenceSystem) (M : ℕ) :
+    uncoveredCount S M ≤ M := by
+  sorry
+
+-- Routine: uncovered density is at most 1.
+theorem asymptoticUncoveredDensity_le_one (S : CongruenceSystem) :
+    asymptoticUncoveredDensity S ≤ 1 := by
+  sorry
+
+-- Routine: A perfect covering is a 0-almost covering.
+theorem perfect_is_zero_almost (S : CongruenceSystem) (h : IsPerfectCovering S) :
+    IsAlmostCovering S 0 := by
+  sorry
+
+-- Routine: IsAlmostCovering is monotone in e.
+theorem almostCovering_mono {S : CongruenceSystem} {ε₁ ε₂ : ℝ}
+    (h : IsAlmostCovering S ε₁) (hle : ε₁ ≤ ε₂) :
+    IsAlmostCovering S ε₂ := by
+  sorry
+
+end Erdos27Aristotle


### PR DESCRIPTION
## Summary

- Adds `proofs/Proofs/Stubs/Erdos27Aristotle.lean` as an Aristotle companion file for Erdos Problem #27 (Almost Covering Systems)
- Contains 5 routine supporting lemmas suitable for automated proof search:
  1. `conjecture_dichotomy` -- logical equivalence between conjecture and its negation (de Morgan / push_neg)
  2. `uncoveredCount_le` -- uncovered count bounded by M (Finset.filter cardinality bound)
  3. `asymptoticUncoveredDensity_le_one` -- density at most 1 (follows from count bound)
  4. `perfect_is_zero_almost` -- perfect covering implies 0-almost covering
  5. `almostCovering_mono` -- monotonicity of almost-covering in epsilon (le_trans)
- Excludes all research-level results: FFKPY main theorem, disproof, density vanishing, product bounds, perfect covering bounds

## Validation

- 0 axiom declarations
- 0 definition sorries
- 5 theorem sorries (all routine targets)
- Self-contained namespace (`Erdos27Aristotle`) with independent type definitions