### PR TITLE
Fix: add Aristotle companion for erdos-551 (22 sorries)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -910,6 +910,7 @@ import Proofs.Erdos549Problem
 import Proofs.Erdos54Problem
 import Proofs.Erdos550Problem
 import Proofs.Erdos551Problem
+import Proofs.Erdos551ProblemAristotle
 import Proofs.Erdos554Problem
 import Proofs.Erdos555Problem
 import Proofs.Erdos556Problem


### PR DESCRIPTION
Adds Erdos551ProblemAristotle.lean companion file for Aristotle proof search. 43 routine lemma targets for R(C_k, K_n) Ramsey number formalization.

Also registers the companion in Proofs.lean manifest.