### PR TITLE
Fix: add Aristotle companion for erdos-549 (14 sorries)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -907,6 +907,7 @@ import Proofs.Erdos543Problem
 import Proofs.Erdos544Problem
 import Proofs.Erdos547Problem
 import Proofs.Erdos549Problem
+import Proofs.Erdos549ProblemAristotle
 import Proofs.Erdos54Problem
 import Proofs.Erdos550Problem
 import Proofs.Erdos551Problem


### PR DESCRIPTION
Adds Erdos549ProblemAristotle.lean companion file for Aristotle proof search. Routine lemma targets for bipartite tree Ramsey number formalization (star graphs, double stars, broom graphs, Burr-Erdős formula).

Also registers the companion in Proofs.lean manifest.