### PR TITLE
Fix: add Aristotle companion for erdos-609 (7 routine targets)

### DIFF
--- a/proofs/Proofs/Stubs/Erdos609Aristotle.lean
+++ b/proofs/Proofs/Stubs/Erdos609Aristotle.lean
@@ -1,0 +1,78 @@
+/-
+  Aristotle targets for Erdős Problem #609
+  Routine supporting lemmas for automated proof search.
+  See Erdos609Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main results (Day-Johnson, Girão-Hunter, Janzer-Yip — open/deep)
+  - NOT theorems depending on def-sorrys (erdos609_f, cycleRamsey, doublingConstruction)
+  - Routine supporting facts: graph structure, bipartiteness, complete graph properties
+  - No definition sorries
+  - No axioms
+-/
+import Mathlib
+
+namespace Erdos609Aristotle
+
+open SimpleGraph Finset
+
+/-- The complete graph on a type: every two distinct vertices are adjacent. -/
+def completeGraph (V : Type*) : SimpleGraph V where
+  Adj x y := x ≠ y
+  symm := fun _ _ h => h.symm
+  loopless := fun _ h => h rfl
+
+/-- An edge coloring of V using n colors. -/
+def EdgeColoring' (V : Type*) [DecidableEq V] (n : ℕ) :=
+  Sym2 V → Fin n
+
+/-- A cycle in a graph as a nonempty vertex list with adjacency. -/
+def IsCycle {V : Type*} (G : SimpleGraph V) (cycle : List V) : Prop :=
+  cycle.length ≥ 3 ∧
+  cycle.Nodup ∧
+  (∀ i : Fin (cycle.length - 1), G.Adj (cycle.get ⟨i.val, by omega⟩)
+    (cycle.get ⟨i.val + 1, by omega⟩)) ∧
+  G.Adj (cycle.getLast (by simp_all)) (cycle.head (by simp_all))
+
+/-- A cycle is odd if its length is odd. -/
+def IsOddCycle {V : Type*} (G : SimpleGraph V) (cycle : List V) : Prop :=
+  IsCycle G cycle ∧ Odd cycle.length
+
+-- Routine: The complete graph K_n has no self-loops.
+-- By definition, Adj x y requires x ≠ y.
+theorem completeGraph_loopless (V : Type*) (x : V) :
+    ¬(completeGraph V).Adj x x := by
+  sorry
+
+-- Routine: In K_n, x and y are adjacent iff x ≠ y.
+-- This follows directly from the definition of completeGraph.
+theorem completeGraph_adj_iff {V : Type*} (x y : V) :
+    (completeGraph V).Adj x y ↔ x ≠ y := by
+  sorry
+
+-- Routine: An odd cycle has length ≥ 3.
+-- An odd cycle is a cycle (length ≥ 3) with odd length.
+theorem isOddCycle_length_ge_3 {V : Type*} (G : SimpleGraph V) (cycle : List V)
+    (h : IsOddCycle G cycle) : cycle.length ≥ 3 := by
+  sorry
+
+-- Routine: An odd cycle has odd length.
+-- This is part of the definition of IsOddCycle.
+theorem isOddCycle_odd_length {V : Type*} (G : SimpleGraph V) (cycle : List V)
+    (h : IsOddCycle G cycle) : Odd cycle.length := h.2
+
+-- Routine: 2^n > 0 for all n.
+-- Positive powers of a positive base are positive.
+theorem two_pow_pos (n : ℕ) : 2 ^ n > 0 := Nat.pos_pow_of_pos n (by norm_num)
+
+-- Routine: K_{2^n} has 2^n vertices.
+-- Fintype.card (Fin (2^n)) = 2^n.
+theorem complete_2n_card (n : ℕ) : Fintype.card (Fin (2 ^ n)) = 2 ^ n := by
+  sorry
+
+-- Routine: 2^n + 1 > 2^n.
+-- Adding 1 to a natural number gives a strictly larger natural number.
+theorem two_pow_plus_one_gt (n : ℕ) : 2 ^ n + 1 > 2 ^ n := by
+  sorry
+
+end Erdos609Aristotle


### PR DESCRIPTION
## Summary

- Adds `proofs/Proofs/Stubs/Erdos609Aristotle.lean` for Aristotle proof search
- 7 routine targets: `completeGraph_loopless`, `completeGraph_adj_iff`, `isOddCycle_length_ge_3`, `isOddCycle_odd_length`, `two_pow_pos`, `complete_2n_card`, `two_pow_plus_one_gt`
- Avoids dep-sorrys (`erdos609_f`, `cycleRamsey`, `doublingConstruction`)
- 0 axioms, 0 def-sorrys, no `/-!` docstrings

🤖 Generated with [Claude Code](https://claude.com/claude-code)