### PR TITLE
Add Aristotle companion for Erdős Problem #545

### DIFF
--- a/proofs/Proofs/Stubs/Erdos545Aristotle.lean
+++ b/proofs/Proofs/Stubs/Erdos545Aristotle.lean
@@ -1,0 +1,48 @@
+/-
+  Aristotle targets for Erdős Problem #545
+  Routine supporting lemmas for automated proof search.
+  See Erdos545Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main results (Ramsey numbers, decompositions — depend on def-sorrys)
+  - Routine supporting facts: monochromatic clique properties, valid coloring basics
+  - No definition sorries
+  - No axioms
+-/
+import Mathlib
+
+namespace Erdos545Aristotle
+
+open Finset
+
+/-- Routine: The empty set is vacuously a monochromatic clique of any color. -/
+theorem monoClique_empty (n : ℕ) (c : Fin n → Fin n → Bool) (b : Bool) :
+    ∀ i ∈ (∅ : Finset (Fin n)), ∀ j ∈ (∅ : Finset (Fin n)), i ≠ j → c i j = b := by
+  sorry
+
+/-- Routine: A singleton set is vacuously a monochromatic clique of any color.
+    There are no pairs of distinct elements to check. -/
+theorem monoClique_singleton (n : ℕ) (c : Fin n → Fin n → Bool) (v : Fin n) (b : Bool) :
+    ∀ i ∈ ({v} : Finset (Fin n)), ∀ j ∈ ({v} : Finset (Fin n)), i ≠ j → c i j = b := by
+  sorry
+
+/-- Routine: Monochromatic clique property is downward closed under subsets. -/
+theorem monoClique_subset (n : ℕ) (c : Fin n → Fin n → Bool) (S T : Finset (Fin n)) (b : Bool)
+    (hT : ∀ i ∈ T, ∀ j ∈ T, i ≠ j → c i j = b)
+    (hST : S ⊆ T) :
+    ∀ i ∈ S, ∀ j ∈ S, i ≠ j → c i j = b := by
+  sorry
+
+/-- Routine: A valid coloring is symmetric. -/
+theorem validColoring_symm (n : ℕ) (c : Fin n → Fin n → Bool)
+    (hc : (∀ i j : Fin n, c i j = c j i) ∧ (∀ i : Fin n, c i i = false))
+    (i j : Fin n) : c i j = c j i := by
+  sorry
+
+/-- Routine: A valid coloring has no self-loops (irreflexive). -/
+theorem validColoring_irrefl (n : ℕ) (c : Fin n → Fin n → Bool)
+    (hc : (∀ i j : Fin n, c i j = c j i) ∧ (∀ i : Fin n, c i i = false))
+    (i : Fin n) : c i i = false := by
+  sorry
+
+end Erdos545Aristotle


### PR DESCRIPTION
## Summary

Adds Aristotle companion for Erdős Problem #545 with 5 routine Ramsey/clique lemmas about monochromatic cliques and valid edge colorings.

- `monoClique_empty`: empty set is vacuously monochromatic
- `monoClique_singleton`: singleton is vacuously monochromatic
- `monoClique_subset`: monochromatic clique property is downward closed under subsets
- `validColoring_symm`: a valid coloring satisfies symmetry
- `validColoring_irrefl`: a valid coloring has no self-loops

## File

`proofs/Proofs/Stubs/Erdos545Aristotle.lean` — namespace `Erdos545Aristotle`, imports only `Mathlib`, no def-sorrys, no axioms.

## Test plan

- [ ] Confirm file parses cleanly (no syntax errors)
- [ ] Confirm no def-sorrys or axiom declarations
- [ ] Confirm 5 theorem targets with `by sorry` bodies are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)