### PR TITLE
Enrichment: wilsons-theorem-oq-04 — Gauss-Wilson, primitive roots, 5 annotations

### DIFF
--- a/src/data/proofs/wilsons-theorem-oq-04/annotations.json
+++ b/src/data/proofs/wilsons-theorem-oq-04/annotations.json
@@ -1,1 +1,62 @@
-[]
+[
+  {
+    "id": "ann-gauss-wilson-theorem",
+    "proofId": "wilsons-theorem-oq-04",
+    "range": { "startLine": 43, "endLine": 52 },
+    "type": "insight",
+    "title": "Gauss–Wilson Classification Theorem",
+    "content": "The main theorem: `gauss_wilson` gives the full classification of moduli where the unit product is −1. The proof is a one-liner — `gaussWilson_classification n hn` — because all the work was done in OQ01. The docstring marks this as the 'standalone answer to open question OQ-04', explicitly connecting the Lean theorem to the informal question it resolves. The statement captures Gauss's 1801 result: primitive-root moduli are exactly {4, p^k, 2p^k}.",
+    "mathContext": "The right-hand side of the iff is an existential over triples $(p, k, \\text{condition})$: $\\exists p, k$ with $p$ prime, $p \\neq 2$, $k \\geq 1$, and $n = p^k$ or $n = 2p^k$, or separately $n = 4$. In Lean this is: `(∃ p k, Nat.Prime p ∧ p ≠ 2 ∧ k ≥ 1 ∧ (n = p ^ k ∨ n = 2 * p ^ k)) ∨ n = 4`.",
+    "significance": "key",
+    "relatedConcepts": ["primitive roots", "Wilson's theorem", "Disquisitiones Arithmeticae", "Euler's totient function"],
+    "prerequisites": ["modular arithmetic", "Nat.Prime in Mathlib", "WilsonsTheoremOQ01.gaussWilson_classification"]
+  },
+  {
+    "id": "ann-cyclic-equivalence",
+    "proofId": "wilsons-theorem-oq-04",
+    "range": { "startLine": 54, "endLine": 57 },
+    "type": "concept",
+    "title": "Group-Theoretic Formulation: Product = −1 ↔ Cyclic",
+    "content": "The theorem `gauss_wilson_cyclic` states the group-theoretic core: the unit product equals −1 iff the unit group is cyclic. This is the abstract algebraic insight that explains *why* the classification holds. Cyclic groups of even order have a unique element of order 2 (namely the generator raised to the half-power), which acts as the identity for pairing $g ↔ g^{-1}$ across all other elements. The proof is one line: `unitsProduct_eq_neg_one_iff_cyclic hn` from OQ02.",
+    "mathContext": "In a finite cyclic group $G = \\langle g \\rangle$ of even order $m$: $\\prod_{x \\in G} x = g^{0+1+\\cdots+(m-1)} = g^{m(m-1)/2}$. Since $|g| = m$ and $m$ is even, $g^{m/2}$ is the unique element of order 2. The product $g^{m(m-1)/2} = g^{m/2 \\cdot (m-1)} = (g^{m/2})^{m-1} = g^{m/2}$ (since $m-1$ is odd). For $(\\mathbb{Z}/n\\mathbb{Z})^\\times$, this is $-1$.",
+    "significance": "key",
+    "relatedConcepts": ["cyclic groups", "IsCyclic in Mathlib", "ZMod.isCyclic_units_iff", "unit group", "involution"],
+    "prerequisites": ["group theory", "ZMod in Mathlib", "IsCyclic typeclass"]
+  },
+  {
+    "id": "ann-wilson-corollary",
+    "proofId": "wilsons-theorem-oq-04",
+    "range": { "startLine": 59, "endLine": 65 },
+    "type": "technique",
+    "title": "Wilson's Theorem as Corollary: Supplying the Witness",
+    "content": "The corollary `gauss_wilson_prime` recovers Wilson's theorem from Gauss's generalization. The proof applies `gauss_wilson` at `n = p`, then proves the right-hand side by providing the explicit witness `(p, 1)`: `Nat.Prime p` (given), `p ≠ 2` (since `p ≥ 3`), `k = 1 ≥ 1`, and `n = p^1` (by `simp`). The `omega` tactic handles the arithmetic `p ≥ 3 → p ≠ 2`. This pattern — applying a general classification and supplying a witness — is characteristic of how corollaries are derived from `∃`-quantified theorems in Lean.",
+    "mathContext": "Wilson's theorem: $(p-1)! \\equiv -1 \\pmod{p}$ for prime $p$. In the `unitsProduct` formulation: $\\text{unitsProduct}(p) \\bmod p = p-1$. From Gauss–Wilson: this holds iff $p \\in \\{4, p'^k, 2p'^k\\}$ for odd prime $p'$. Taking $p' = p$, $k=1$: $p = p^1$ satisfies the classification for any odd prime $p$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Wilson's theorem", "Nat.Prime", "omega tactic", "simp"],
+    "prerequisites": ["WilsonsTheorem.lean", "gauss_wilson theorem", "Lean 4 existential witnesses"]
+  },
+  {
+    "id": "ann-namespace-imports",
+    "proofId": "wilsons-theorem-oq-04",
+    "range": { "startLine": 26, "endLine": 30 },
+    "type": "context",
+    "title": "Module Architecture: OQ Dependency Chain",
+    "content": "This file imports only `Proofs.WilsonsTheoremOQ01` and opens `WilsonsTheoremGeneralization` (from OQ01). The OQ01 module itself imports OQ02 (the abstract bridge), creating a chain: OQ02 (abstract bridge) → OQ01 (classification) → OQ04 (final statement). This modular architecture separates the work: OQ02 handles the concrete↔abstract equivalence, OQ01 applies Mathlib's cyclic classification, and OQ04 presents the clean public API. The `WilsonsTheoremGauss` namespace makes the theorems easily discoverable.",
+    "mathContext": "The import chain: `WilsonsTheoremOQ04` → `WilsonsTheoremOQ01` → `WilsonsTheoremOQ02`. OQ02 proves `unitsProduct_eq_neg_one_iff_cyclic` (the bridge). OQ01 proves `gaussWilson_classification` using Mathlib's `ZMod.isCyclic_units_iff`. OQ04 re-exports as `gauss_wilson` and `gauss_wilson_cyclic`.",
+    "significance": "context",
+    "relatedConcepts": ["Lean 4 namespaces", "modular proof architecture", "ZMod", "IsCyclic"],
+    "prerequisites": ["WilsonsTheoremOQ01", "WilsonsTheoremOQ02"]
+  },
+  {
+    "id": "ann-full-classification",
+    "proofId": "wilsons-theorem-oq-04",
+    "range": { "startLine": 1, "endLine": 24 },
+    "type": "concept",
+    "title": "Proof Architecture: Three-Layer Decomposition",
+    "content": "The file header summarizes the three-layer proof architecture. Layer 1 (OQ01): defines `unitsProduct n` as the concrete product of all integers in $\\{1, \\ldots, n-1\\}$ coprime to $n$, proves the classification directly using Mathlib's cyclic group theory, and provides computational verification for $n \\leq 50$ as a sanity check. Layer 2 (OQ02): proves the abstract bridge — that the concrete computation `unitsProduct n % n` equals $n-1$ iff the abstract unit group `(ZMod n)ˣ` satisfies `IsCyclic`. Layer 3 (OQ04, this file): assembles the public-facing statements, re-exports the main theorems under clean names, and proves the Wilson corollary.",
+    "mathContext": "The three layers correspond to three mathematical components: (1) the concrete number theory (products of coprime residues), (2) the algebraic bridge (ZMod units ↔ modular arithmetic), and (3) the classical result (Gauss 1801). The separation cleanly mirrors the historical development: Wilson (1770) → Gauss (1801) → modern group theory.",
+    "significance": "context",
+    "relatedConcepts": ["proof architecture", "modular Lean development", "ZMod", "unitsProduct"],
+    "prerequisites": ["Lean 4 modules", "WilsonsTheoremOQ01", "WilsonsTheoremOQ02"]
+  }
+]

--- a/src/data/proofs/wilsons-theorem-oq-04/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-04/meta.json
@@ -35,48 +35,53 @@
     ]
   },
   "overview": {
-    "historicalContext": "Gauss proved this generalization in his Disquisitiones Arithmeticae (1801, Article 73). Wilson's theorem (1770) states that (p-1)! ≡ -1 (mod p) for primes p. Gauss asked: for which n does ∏{k coprime to n} k ≡ -1 (mod n)? The answer is precisely n ∈ {1, 2, 4, p^k, 2p^k} for odd primes p — exactly the values where primitive roots exist, i.e., where (ℤ/nℤ)× is cyclic.",
-    "problemStatement": "For n ≥ 3, prove that the product of all integers in {1, ..., n-1} coprime to n is congruent to -1 modulo n if and only if n is 4, an odd prime power p^k, or twice an odd prime power 2p^k.",
-    "text": "The Gauss generalization characterizes when the product of the unit group mod n equals -1. The key insight is that this is equivalent to the unit group being cyclic, and Mathlib classifies exactly when (ℤ/nℤ)× is cyclic.",
-    "proofStrategy": "The proof has two layers:\n\n1. **Concrete ↔ Abstract Bridge**: Show that unitsProduct n % n = n-1 (concrete computation) is equivalent to ∏(ZMod n)ˣ = -1 (abstract algebra). This bridge is proved in OQ01/OQ02.\n\n2. **Cyclic Classification**: ∏ units = -1 iff the unit group is cyclic (Frobenius/Gauss). Mathlib's `ZMod.isCyclic_units_iff` gives: (ZMod n)ˣ is cyclic iff n ∈ {4, p^k, 2p^k}.",
+    "historicalContext": "Wilson's theorem — that $(p-1)! \\equiv -1 \\pmod{p}$ for primes $p$ — was stated by Edward Waring in 1770, attributed to John Wilson, and first proved rigorously by Joseph-Louis Lagrange (1771). Lagrange's proof used the fact that a polynomial of degree $n$ over $\\mathbb{Z}/p\\mathbb{Z}$ has at most $n$ roots.\n\nCarl Friedrich Gauss, in his landmark *Disquisitiones Arithmeticae* (1801, Article 73), asked and answered the deeper question: for which moduli $n$ does the product of all integers coprime to $n$ equal $-1 \\pmod{n}$? The answer is a beautiful classification: exactly when $n$ has a **primitive root** — an integer whose powers generate the entire multiplicative group $(\\mathbb{Z}/n\\mathbb{Z})^\\times$. The primitive-root moduli are precisely $n \\in \\{1, 2, 4, p^k, 2p^k\\}$ for odd primes $p$ and $k \\geq 1$.\n\nThe reason for the connection is elegant: if $(\\mathbb{Z}/n\\mathbb{Z})^\\times$ is cyclic of order $m$, then it has a unique element of order 2 (namely $-1$), and when you multiply all elements of a cyclic group together, they pair up as $g \\cdot g^{-1}$ *except* for elements equal to their own inverse (order 1 or 2). The product of all elements of a cyclic group of even order is therefore the unique element of order 2, which is $-1$.\n\nFor non-cyclic groups (like $(\\mathbb{Z}/p^2\\mathbb{Z})^\\times$ for... wait, those are cyclic — but $(\\mathbb{Z}/8\\mathbb{Z})^\\times \\cong \\mathbb{Z}/2 \\times \\mathbb{Z}/2$ is not), there are multiple elements of order 2, and their product is $+1$ instead of $-1$.\n\nThis result was later placed in the general framework of group theory by Frobenius and is now a standard theorem in algebraic number theory. Mathlib's `ZMod.isCyclic_units_iff` encodes precisely this classical classification.",
+    "problemStatement": "For $n \\geq 3$, prove: $\\prod_{\\substack{1 \\leq k \\leq n-1 \\\\ \\gcd(k,n)=1}} k \\equiv -1 \\pmod{n}$ if and only if $n \\in \\{4, p^k, 2p^k\\}$ for some odd prime $p$ and $k \\geq 1$. Equivalently: the product of the unit group $(\\mathbb{Z}/n\\mathbb{Z})^\\times$ equals $-1$ if and only if that group is cyclic.",
+    "proofStrategy": "The proof is organized in three layers across the WilsonsTheoremOQ* sequence. **OQ01** defines `unitsProduct n` (the concrete product of coprime residues) and proves `gaussWilson_classification` via computational verification for small $n$ and Mathlib's classification. **OQ02** builds the abstract bridge: `unitsProduct_eq_neg_one_iff_cyclic`, showing that the concrete product equals $n-1$ iff the abstract unit group `(ZMod n)ˣ` satisfies `IsCyclic`. **OQ04** (this file) assembles the final answer: `gauss_wilson` re-exports the classification as the standalone answer to the open question, and `gauss_wilson_cyclic` gives the group-theoretic formulation. The `gauss_wilson_prime` corollary recovers Wilson's original theorem as a special case by setting $k=1$ and using `Nat.Prime p` to satisfy the hypotheses.",
     "keyInsights": [
-      "The product of all units equals -1 iff the unit group is cyclic — a group-theoretic characterization",
-      "Cyclic unit groups correspond exactly to moduli with primitive roots: {1, 2, 4, p^k, 2p^k}",
-      "The concrete computation (unitsProduct n % n) connects to the abstract product (∏ (ZMod n)ˣ) via ZMod.val",
-      "For primes p, this recovers Wilson's theorem as a special case (p = p^1)"
-    ],
-    "prerequisites": [
-      "Number theory (modular arithmetic, Euler's totient)",
-      "Abstract algebra (cyclic groups, unit groups)"
+      "**Cyclic ↔ unique element of order 2**: In a cyclic group of even order, the product of all elements equals the unique involution (element of order 2). In $(\\mathbb{Z}/n\\mathbb{Z})^\\times$, the unique involution is $-1 \\equiv n-1$. So $\\prod \\text{units} = -1$ iff the group is cyclic — the group-theoretic core of Gauss's theorem.",
+      "**Primitive roots as generators**: A *primitive root* mod $n$ is an element of order $\\phi(n)$ in $(\\mathbb{Z}/n\\mathbb{Z})^\\times$. Such a root exists iff the group is cyclic. Gauss's 1801 classification of primitive-root moduli ($n \\in \\{1,2,4,p^k,2p^k\\}$) is therefore equivalent to the classification of cyclic unit groups, which Mathlib's `ZMod.isCyclic_units_iff` encodes directly.",
+      "**Wilson as a special case**: For a prime $p$, $(\\mathbb{Z}/p\\mathbb{Z})^\\times$ is cyclic of order $p-1$ (since $\\mathbb{Z}/p\\mathbb{Z}$ is a field, and the multiplicative group of a finite field is always cyclic). Gauss's theorem with $n = p = p^1$ immediately gives $(p-1)! \\equiv -1 \\pmod{p}$, Wilson's theorem. The corollary `gauss_wilson_prime` makes this derivation explicit.",
+      "**Why 4 is special**: $(\\mathbb{Z}/4\\mathbb{Z})^\\times = \\{1, 3\\} \\cong \\mathbb{Z}/2$ is cyclic (trivially, since it has order 2 — all groups of order 2 are cyclic). The product is $1 \\cdot 3 = 3 \\equiv -1 \\pmod{4}$. The modulus 8 fails: $(\\mathbb{Z}/8\\mathbb{Z})^\\times = \\{1,3,5,7\\} \\cong \\mathbb{Z}/2 \\times \\mathbb{Z}/2$ is not cyclic, and $1 \\cdot 3 \\cdot 5 \\cdot 7 = 105 \\equiv 1 \\pmod{8}$.",
+      "**Concrete ↔ abstract bridge (OQ01/OQ02)**: The Lean formalization requires connecting `unitsProduct n % n` (a concrete ℕ computation) to `∏ x : (ZMod n)ˣ, x` (an abstract algebraic product). This bridge is non-trivial because `ZMod.val` must be shown to preserve the product, and the coercion from `(ZMod n)ˣ` to `ℕ` requires careful handling of the unit group structure. OQ01/OQ02 do this work; OQ04 reuses the result.",
+      "**Computational verification as proof infrastructure**: The original OQ01 proved the theorem by combining Mathlib's `ZMod.isCyclic_units_iff` with a computational check for small $n$. This pattern — use `decide` or `native_decide` for small cases, then Mathlib for the general classification — is a powerful Lean proof strategy that avoids having to reprove classical results."
     ]
   },
   "sections": [
     {
       "id": "main-statement",
       "title": "Gauss–Wilson Main Statement",
-      "startLine": 40,
-      "endLine": 48,
-      "summary": "The full classification: unitsProduct n % n = n-1 ↔ n ∈ {4, p^k, 2p^k}."
+      "startLine": 43,
+      "endLine": 52,
+      "summary": "Theorem `gauss_wilson`: for n ≥ 3, the product of coprime residues mod n equals n−1 iff n is 4, an odd prime power p^k, or twice an odd prime power 2p^k. Proved as a re-export of `gaussWilson_classification` from OQ01, presented as the standalone answer to OQ-04.",
+      "mathContext": "$\\text{unitsProduct}(n) \\bmod n = n-1 \\iff n \\in \\{4\\} \\cup \\{p^k : p \\text{ odd prime}, k \\geq 1\\} \\cup \\{2p^k : p \\text{ odd prime}, k \\geq 1\\}$. The right-hand side is exactly the set of moduli admitting primitive roots."
     },
     {
       "id": "cyclic-equivalence",
       "title": "Cyclic Group Equivalence",
-      "startLine": 50,
-      "endLine": 54,
-      "summary": "The algebraic characterization: product = -1 iff (ZMod n)ˣ is cyclic."
+      "startLine": 54,
+      "endLine": 57,
+      "summary": "Theorem `gauss_wilson_cyclic`: the algebraic formulation — the product of all units mod n equals −1 iff (ZMod n)ˣ is cyclic. A one-line proof applying `unitsProduct_eq_neg_one_iff_cyclic` from OQ02.",
+      "mathContext": "$\\prod_{x \\in (\\mathbb{Z}/n\\mathbb{Z})^\\times} x = -1 \\iff (\\mathbb{Z}/n\\mathbb{Z})^\\times \\text{ is cyclic}$. In Lean: `unitsProduct n % n = n - 1 ↔ IsCyclic (ZMod n)ˣ`."
     },
     {
       "id": "prime-recovery",
       "title": "Recovery of Wilson's Theorem",
-      "startLine": 56,
-      "endLine": 63,
-      "summary": "For odd primes, the Gauss generalization specializes to Wilson's theorem."
+      "startLine": 59,
+      "endLine": 65,
+      "summary": "Corollary `gauss_wilson_prime`: for any odd prime p ≥ 3, the product of coprime residues mod p equals p−1. The proof applies `gauss_wilson` with the witness (p, 1) satisfying all hypotheses (Nat.Prime p, p ≠ 2, k=1, n = p^1).",
+      "mathContext": "Setting $n = p$ (prime), $k=1$: $p = p^1$ satisfies the classification, so $\\text{unitsProduct}(p) \\bmod p = p-1$, i.e., $(p-1)! \\equiv -1 \\pmod{p}$. Wilson's 1770 theorem follows as a special case."
     }
   ],
   "conclusion": {
-    "text": "The Gauss generalization is fully formalized with 0 sorries and 0 axioms. The classification leverages Mathlib's characterization of cyclic unit groups, while the concrete↔abstract bridge is built in OQ01/OQ02.",
-    "opens": [],
-    "implications": "This completes the answer to OQ-04 from the Wilson's theorem gallery entry."
+    "summary": "This file completes the OQ-04 resolution: Gauss's generalization of Wilson's theorem is fully formalized in Lean 4 with zero axioms and zero sorries. The proof leverages Mathlib's `ZMod.isCyclic_units_iff` and the concrete↔abstract bridge from OQ01/OQ02, yielding a three-theorem file that answers the open question, gives the group-theoretic formulation, and recovers the original Wilson's theorem as a corollary.",
+    "implications": "The Gauss–Wilson classification connects two major threads of elementary number theory: the structure of multiplicative groups mod $n$ and the existence of primitive roots. The Lean formalization demonstrates that Mathlib's algebraic hierarchy (ZMod, unit groups, IsCyclic) is rich enough to prove classical 19th-century results with minimal overhead. The proof pattern — bridging concrete modular arithmetic with abstract group theory — appears throughout number theory and serves as a template for further formalizations of results about $(\\mathbb{Z}/n\\mathbb{Z})^\\times$.",
+    "openQuestions": [
+      "Can the full structural theory of $(\\mathbb{Z}/n\\mathbb{Z})^\\times$ (including the Chinese Remainder Theorem decomposition for composite $n$) be formalized in a self-contained gallery entry?",
+      "The product of units formula $\\prod G = -1$ holds in any cyclic group with a unique involution. Is there a formalized version of this abstract group-theoretic lemma in Mathlib that could serve as a more direct proof route?",
+      "Artin's conjecture on primitive roots — that every integer $a \\neq -1$ and not a perfect square is a primitive root for infinitely many primes — remains open. Can the Lean infrastructure built here serve as a starting point for formalizing partial results (e.g., conditional on GRH)?",
+      "The Gauss–Wilson theorem has a $p$-adic analogue: for the $p$-adic integers $\\mathbb{Z}_p$, the product of units in $(\\mathbb{Z}/p^k\\mathbb{Z})^\\times$ converges $p$-adically. Is this formalized in Mathlib?"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary

Two enrichment passes on this branch:

### Pass 1: buffons-needle-oq-01-oq-01-oq-01
- Added full `overview`, `sections`, `conclusion` (was missing entirely)
- 6 annotations with LaTeX mathContext covering all proof sections
- Historical: Buffon 1777 → Barbier 1860 → Cauchy-Crofton
- Key: angular average identity, shape independence, axiom elimination methodology

### Pass 2: wilsons-theorem-oq-04 (Gauss-Wilson)
- Expanded `historicalContext`: Wilson→Lagrange→Gauss 1801 thread, cyclic group explanation
- 6 keyInsights: cyclic↔involution proof, primitive roots, Wilson as special case, why n=4 works, concrete↔abstract bridge
- 5 annotations: architecture, main theorem, cyclic equivalence, Wilson corollary, module chain
- Fixed `conclusion` schema; added 4 openQuestions including Artin's conjecture

Both entries: axiom integrity verified, all proofs 0 axioms 0 sorries.