### PR TITLE
Fix: add Aristotle companion for erdos-610 (11 routine clique transversal targets)

### DIFF
--- a/proofs/Proofs/Stubs/Erdos610Aristotle.lean
+++ b/proofs/Proofs/Stubs/Erdos610Aristotle.lean
@@ -1,0 +1,96 @@
+/-
+  Aristotle targets for Erdős Problem #610
+  Routine supporting lemmas for automated proof search.
+  See Erdos610Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open conjecture (Erdős-Gallai-Tuza, Question 1/2)
+  - NOT theorems depending on def-sorries (triangleFreeIndependence, cliqueCoverNumber)
+  - Routine supporting facts: clique structure, transversal bounds, basic graph properties
+  - No definition sorries
+  - No axioms
+-/
+import Mathlib
+
+namespace Erdos610Aristotle
+
+open Finset Function SimpleGraph
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-- A clique in a graph is a set of pairwise adjacent vertices. -/
+def IsClique' (G : SimpleGraph V) (S : Finset V) : Prop :=
+  ∀ u ∈ S, ∀ v ∈ S, u ≠ v → G.Adj u v
+
+/-- A clique is maximal if no proper superset is also a clique. -/
+def IsMaximalClique' (G : SimpleGraph V) (S : Finset V) : Prop :=
+  IsClique' G S ∧ ∀ T : Finset V, S ⊂ T → ¬IsClique' G T
+
+/-- A set T is a clique transversal if it intersects every maximal clique. -/
+def IsCliqueTransversal' (G : SimpleGraph V) (T : Finset V) : Prop :=
+  ∀ C : Finset V, IsMaximalClique' G C → (T ∩ C).Nonempty
+
+-- Routine: The empty set is a clique (vacuously).
+-- Every pair of vertices from ∅ satisfies adjacency vacuously.
+theorem empty_is_clique (G : SimpleGraph V) : IsClique' G ∅ := by
+  sorry
+
+-- Routine: A singleton {v} is always a clique.
+-- There are no pairs of distinct vertices in {v}.
+theorem singleton_is_clique (G : SimpleGraph V) (v : V) : IsClique' G {v} := by
+  sorry
+
+-- Routine: Subsets of cliques are cliques.
+-- If S ⊆ T and T is a clique, any pair from S is also in T.
+theorem clique_subset (G : SimpleGraph V) (S T : Finset V)
+    (hST : S ⊆ T) (hT : IsClique' G T) : IsClique' G S := by
+  sorry
+
+-- Routine: In the complete graph ⊤, every set of vertices is a clique.
+-- In ⊤, u ≠ v implies Adj u v by definition.
+theorem complete_all_clique (S : Finset V) : IsClique' (⊤ : SimpleGraph V) S := by
+  sorry
+
+-- Routine: In the empty graph ⊥, only sets of size ≤ 1 are cliques.
+-- In ⊥, Adj u v is always False, so for S to be a clique, S cannot have two distinct vertices.
+theorem bot_clique_card_le_one (S : Finset V) (h : IsClique' (⊥ : SimpleGraph V) S) :
+    S.card ≤ 1 := by
+  sorry
+
+-- Routine: In the empty graph ⊥, a singleton {v} is a maximal clique.
+-- {v} is a clique; adding any vertex w ≠ v creates {v, w} which is not a clique in ⊥.
+theorem bot_singleton_is_maximal (v : V) :
+    IsMaximalClique' (⊥ : SimpleGraph V) {v} := by
+  sorry
+
+-- Routine: In the complete graph ⊤, the only maximal clique is Finset.univ.
+-- Finset.univ is a clique in ⊤ (every pair adjacent). Any proper subset S ⊊ univ
+-- can be extended by adding a missing vertex w, and {v, w} is always a clique in ⊤.
+theorem complete_univ_is_maximal [Nontrivial V] :
+    IsMaximalClique' (⊤ : SimpleGraph V) Finset.univ := by
+  sorry
+
+-- Routine: The full vertex set Finset.univ is always a clique transversal.
+-- It intersects every maximal clique since every nonempty clique contains a vertex in univ.
+theorem univ_is_transversal (G : SimpleGraph V) :
+    IsCliqueTransversal' G Finset.univ := by
+  sorry
+
+-- Routine: If S is a clique transversal and S ⊆ T, then T is also a transversal.
+-- Any intersection S ∩ C ⊆ T ∩ C, so nonemptiness is preserved.
+theorem transversal_supset (G : SimpleGraph V) (S T : Finset V)
+    (hST : S ⊆ T) (hS : IsCliqueTransversal' G S) : IsCliqueTransversal' G T := by
+  sorry
+
+-- Routine: Finset.univ.card = Fintype.card V.
+-- Standard Mathlib fact: the card of Finset.univ equals Fintype.card.
+theorem univ_card_eq : (Finset.univ : Finset V).card = Fintype.card V := by
+  sorry
+
+-- Routine: In the empty graph ⊥, every vertex is in some maximal clique.
+-- For any v : V, the singleton {v} is a maximal clique in ⊥.
+theorem bot_every_vertex_in_maximal_clique (v : V) :
+    ∃ C : Finset V, IsMaximalClique' (⊥ : SimpleGraph V) C ∧ v ∈ C := by
+  sorry
+
+end Erdos610Aristotle


### PR DESCRIPTION
## Fix

Adds Aristotle companion file `Erdos610Aristotle.lean` for Erdős Problem #610 (Clique Transversal Numbers, 17 sorries).

## Evidence

**Before**: `Erdos610Problem.lean` has 17 sorries with no Aristotle companion
**After**: 11 routine supporting lemmas exposed for automated proof search

## Targets included

- `empty_is_clique`, `singleton_is_clique`: base clique membership facts
- `clique_subset`: subsets of cliques are cliques (monotonicity)
- `complete_all_clique`: all subsets are cliques in the complete graph ⊤
- `bot_clique_card_le_one`: clique sizes ≤ 1 in the empty graph ⊥
- `bot_singleton_is_maximal`: singleton {v} is maximal in ⊥
- `complete_univ_is_maximal`: Finset.univ is the unique maximal clique in ⊤
- `univ_is_transversal`: Finset.univ always intersects every maximal clique
- `transversal_supset`: supsets of transversals are transversals
- `univ_card_eq`: `Finset.univ.card = Fintype.card V`
- `bot_every_vertex_in_maximal_clique`: every vertex appears in a maximal clique in ⊥

These support proofs of `tau_le_card`, `tau_empty`, and `tau_complete` in the main file.

---
Automated fix by lean-mechanic agent.