### PR TITLE
Fix: add Aristotle companion for erdos-627 (12 routine log/coefficient targets)

### DIFF
--- a/proofs/Proofs/Stubs/Erdos627Aristotle.lean
+++ b/proofs/Proofs/Stubs/Erdos627Aristotle.lean
@@ -1,0 +1,92 @@
+/-
+  Aristotle targets for Erdős Problem #627
+  Routine supporting lemmas for automated proof search.
+  See Erdos627Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open question (limit existence of f(n)/(n/(log n)²))
+  - NOT theorems depending on def-sorries (f, ramseyNumber, mycielskiGraph, kneserGraph)
+  - Routine supporting facts: numerical bounds on log 2, coefficient positivity, chi/omega basics
+  - No definition sorries
+  - No axioms
+-/
+import Mathlib
+
+namespace Erdos627Aristotle
+
+open Real
+
+/-- The lower bound constant (log 2)²/4 for the potential limit. -/
+noncomputable def limitLowerBound : ℝ := (Real.log 2)^2 / 4
+
+/-- The upper bound constant (log 2)² for the potential limit. -/
+noncomputable def limitUpperBound : ℝ := (Real.log 2)^2
+
+/-- The lower coefficient in Kostochka's bound: 1/(4 log k). -/
+noncomputable def lowerCoeff (k : ℕ) : ℝ := 1 / (4 * Real.log k)
+
+/-- The upper coefficient in Erdős's bound: 2/log(k-2). -/
+noncomputable def upperCoeff (k : ℕ) : ℝ := 2 / Real.log (k - 2)
+
+-- Routine: (log 2)² > 0.
+-- log 2 > 0 since 2 > 1, so its square is positive.
+theorem log2_sq_pos : (Real.log 2)^2 > 0 := by
+  sorry
+
+-- Routine: log 2 > 0.
+-- 2 > 1, so log 2 > 0 by Real.log_pos.
+theorem log2_pos : Real.log 2 > 0 := by
+  sorry
+
+-- Routine: limitLowerBound < limitUpperBound.
+-- (log 2)²/4 < (log 2)²  iff  1/4 < 1  (dividing both sides by (log 2)² > 0).
+theorem limit_bounds_numerical : limitLowerBound < limitUpperBound := by
+  sorry
+
+-- Routine: limitLowerBound > 0.
+-- (log 2)²/4 > 0 since (log 2)² > 0 and 4 > 0.
+theorem limitLowerBound_pos : limitLowerBound > 0 := by
+  sorry
+
+-- Routine: limitUpperBound > 0.
+-- (log 2)² > 0 directly.
+theorem limitUpperBound_pos : limitUpperBound > 0 := by
+  sorry
+
+-- Routine: For k ≥ 4, log k > 0.
+-- k ≥ 4 > 1, so log k > 0 by Real.log_pos.
+theorem log_k_pos (k : ℕ) (hk : k ≥ 4) : Real.log k > 0 := by
+  sorry
+
+-- Routine: For k ≥ 4, log(k - 2) > 0.
+-- k ≥ 4 implies k - 2 ≥ 2 > 1, so log(k-2) > 0.
+theorem log_k_minus_2_pos (k : ℕ) (hk : k ≥ 4) : Real.log ((k : ℝ) - 2) > 0 := by
+  sorry
+
+-- Routine: For k ≥ 4, lowerCoeff k > 0.
+-- 1/(4 * log k) > 0 since log k > 0 and 4 > 0.
+theorem lowerCoeff_pos (k : ℕ) (hk : k ≥ 4) : lowerCoeff k > 0 := by
+  sorry
+
+-- Routine: For k ≥ 4, upperCoeff k > 0.
+-- 2/log(k-2) > 0 since log(k-2) > 0.
+theorem upperCoeff_pos (k : ℕ) (hk : k ≥ 4) : upperCoeff k > 0 := by
+  sorry
+
+-- Routine: For k ≥ 4, lowerCoeff k ≤ upperCoeff k.
+-- 1/(4 log k) ≤ 2/log(k-2) since log(k-2) ≤ log k and 1/4 ≤ 2.
+theorem lowerCoeff_le_upperCoeff (k : ℕ) (hk : k ≥ 4) :
+    lowerCoeff k ≤ upperCoeff k := by
+  sorry
+
+-- Routine: For k ≥ 4 and n ≥ 2, n^(1:ℝ) = n.
+-- Real.rpow with exponent 1 equals the base (as a real number cast).
+theorem rpow_one_cast (n : ℕ) (hn : n ≥ 2) : (n : ℝ)^(1 : ℝ) = n := by
+  sorry
+
+-- Routine: 4 * Real.log k > 0 for k ≥ 4.
+-- Product of two positive reals: 4 > 0 and log k > 0.
+theorem four_mul_log_pos (k : ℕ) (hk : k ≥ 4) : 4 * Real.log k > 0 := by
+  sorry
+
+end Erdos627Aristotle


### PR DESCRIPTION
## Fix

Adds Aristotle companion file `Erdos627Aristotle.lean` for Erdős Problem #627 (Chromatic Number and Clique Number Ratio, 16 sorries).

## Evidence

**Before**: `Erdos627Problem.lean` has 16 sorries with no Aristotle companion
**After**: 12 routine supporting lemmas exposed for automated proof search

## Targets included

Logarithm positivity:
- `log2_pos`: log 2 > 0
- `log2_sq_pos`: (log 2)² > 0
- `log_k_pos`: log k > 0 for k ≥ 4
- `log_k_minus_2_pos`: log(k-2) > 0 for k ≥ 4
- `four_mul_log_pos`: 4 * log k > 0 for k ≥ 4

Coefficient properties:
- `lowerCoeff_pos`: 1/(4 log k) > 0 for k ≥ 4
- `upperCoeff_pos`: 2/log(k-2) > 0 for k ≥ 4
- `lowerCoeff_le_upperCoeff`: lowerCoeff ≤ upperCoeff for k ≥ 4

Limit bounds:
- `limitLowerBound_pos`, `limitUpperBound_pos`: positivity
- `limit_bounds_numerical`: (log 2)²/4 < (log 2)² (key numerical comparison)
- `rpow_one_cast`: n^(1:ℝ) = n

---
Automated fix by lean-mechanic agent.