### PR TITLE
Fix: add Aristotle companion for erdos-626 (12 routine log/coefficient targets)

### DIFF
--- a/proofs/Proofs/Stubs/Erdos626Aristotle.lean
+++ b/proofs/Proofs/Stubs/Erdos626Aristotle.lean
@@ -1,0 +1,101 @@
+/-
+  Aristotle targets for Erdős Problem #626
+  Routine supporting lemmas for automated proof search.
+  See Erdos626Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open conjecture (whether lim g_k(n)/log n exists)
+  - NOT theorems depending on def-sorrys (g, h, ramseyNumber)
+  - Routine supporting facts: log positivity, coefficient bounds, algebraic identities
+  - No definition sorries
+  - No axioms
+-/
+import Mathlib
+
+namespace Erdos626Aristotle
+
+/-- Upper bound coefficient: 2 / log(k-2) for the Erdős upper bound. -/
+noncomputable def upperCoeff (k : ℕ) : ℝ :=
+  2 / Real.log (k - 2)
+
+/-- Lower bound coefficient: 1 / (4 · log k) for the Kostochka lower bound. -/
+noncomputable def lowerCoeff (k : ℕ) : ℝ :=
+  1 / (4 * Real.log k)
+
+/-- Bound ratio: upperCoeff / lowerCoeff. -/
+noncomputable def boundRatio (k : ℕ) : ℝ :=
+  upperCoeff k / lowerCoeff k
+
+-- Routine: upperCoeff 4 = 2 / Real.log 2.
+-- 4 - 2 = 2 as natural numbers, so upperCoeff 4 = 2 / log(2).
+theorem upperCoeff_k4 : upperCoeff 4 = 2 / Real.log 2 := by
+  simp [upperCoeff]
+
+-- Routine: lowerCoeff 4 = 1 / (4 * Real.log 4).
+-- Direct from definition.
+theorem lowerCoeff_k4 : lowerCoeff 4 = 1 / (4 * Real.log 4) := by
+  simp [lowerCoeff]
+
+-- Routine: For k ≥ 4, (k - 2 : ℕ) cast to ℝ is at least 2.
+-- Since k ≥ 4, natural subtraction k - 2 = k - 2 ≥ 2.
+theorem natSub_2_cast_ge_2 (k : ℕ) (hk : k ≥ 4) :
+    ((k - 2 : ℕ) : ℝ) ≥ 2 := by
+  sorry
+
+-- Routine: For k ≥ 4, (k : ℝ) ≥ 4.
+-- Direct cast of the natural number hypothesis.
+theorem natCast_ge_4 (k : ℕ) (hk : k ≥ 4) : (k : ℝ) ≥ 4 := by
+  sorry
+
+-- Routine: For k ≥ 4, Real.log k > 0.
+-- k ≥ 4 > 1, and log is positive on (1, ∞).
+theorem log_k_pos (k : ℕ) (hk : k ≥ 4) : Real.log k > 0 := by
+  sorry
+
+-- Routine: For k ≥ 4, Real.log (↑(k - 2)) > 0.
+-- (k - 2 : ℕ) ≥ 2 > 1 when k ≥ 4, so log((k-2 : ℕ)) > 0.
+theorem log_k_sub_2_pos (k : ℕ) (hk : k ≥ 4) : Real.log ((k - 2 : ℕ) : ℝ) > 0 := by
+  sorry
+
+-- Routine: For k ≥ 4, upperCoeff k > 0.
+-- upperCoeff k = 2 / log(k-2) > 0 since log(k-2) > 0.
+theorem upperCoeff_pos (k : ℕ) (hk : k ≥ 4) : upperCoeff k > 0 := by
+  sorry
+
+-- Routine: For k ≥ 4, lowerCoeff k > 0.
+-- lowerCoeff k = 1 / (4 * log k) > 0 since log k > 0.
+theorem lowerCoeff_pos (k : ℕ) (hk : k ≥ 4) : lowerCoeff k > 0 := by
+  sorry
+
+-- Routine: For k ≥ 4, upperCoeff k - lowerCoeff k > 0.
+-- Need: 2/log(k-2) > 1/(4*log k), i.e., 8*log k > log(k-2).
+-- Since k ≥ 4: log(k-2) ≤ log k < 8*log k.
+theorem upperCoeff_gt_lowerCoeff (k : ℕ) (hk : k ≥ 4) :
+    upperCoeff k - lowerCoeff k > 0 := by
+  sorry
+
+-- Routine: boundRatio k = 8 * Real.log k / Real.log (↑(k - 2)) for k ≥ 4.
+-- (2 / log(k-2)) / (1 / (4 * log k)) = 2 * (4 * log k) / log(k-2)
+-- = 8 * log k / log(k-2).
+theorem bound_ratio_formula (k : ℕ) (hk : k ≥ 4) :
+    boundRatio k = 8 * Real.log k / Real.log ((k - 2 : ℕ) : ℝ) := by
+  sorry
+
+-- Routine: log is positive for real arguments > 1.
+-- Real.log x > 0 iff x > 1.
+theorem log_pos_of_gt_one (x : ℝ) (hx : x > 1) : Real.log x > 0 := by
+  sorry
+
+-- Routine: log is monotone on ℝ.
+-- If x ≤ y then Real.log x ≤ Real.log y.
+theorem log_le_log_of_le (x y : ℝ) (hx : 0 < x) (hxy : x ≤ y) :
+    Real.log x ≤ Real.log y := by
+  sorry
+
+-- Routine: For k ≥ 4, log(k - 2) ≤ log k.
+-- (k - 2 : ℕ) ≤ k as naturals, so their logs satisfy the same bound.
+theorem log_k_sub_2_le_log_k (k : ℕ) (hk : k ≥ 4) :
+    Real.log ((k - 2 : ℕ) : ℝ) ≤ Real.log k := by
+  sorry
+
+end Erdos626Aristotle


### PR DESCRIPTION
## Fix

Add Aristotle companion file for Erdős Problem #626 with 12 routine supporting lemmas for automated proof search.

## Evidence

**Before**: No Aristotle companion file for erdos-626 (Chromatic Number and Girth)
**After**: `proofs/Proofs/Stubs/Erdos626Aristotle.lean` with 12 provable theorem targets:
- `upperCoeff_k4`, `lowerCoeff_k4`: specific values at k=4 (proved as anchors via simp)
- `natSub_2_cast_ge_2`: (k-2 : ℕ) as real ≥ 2 for k ≥ 4
- `natCast_ge_4`: coercion inequality for k ≥ 4
- `log_k_pos`: Real.log k > 0 for k ≥ 4
- `log_k_sub_2_pos`: Real.log (k-2) > 0 for k ≥ 4
- `upperCoeff_pos`: 2/log(k-2) > 0 for k ≥ 4
- `lowerCoeff_pos`: 1/(4*log k) > 0 for k ≥ 4
- `upperCoeff_gt_lowerCoeff`: upperCoeff k > lowerCoeff k for k ≥ 4
- `bound_ratio_formula`: boundRatio k = 8·log k / log(k-2) for k ≥ 4
- `log_pos_of_gt_one`: log x > 0 for x > 1
- `log_le_log_of_le`: monotonicity of Real.log
- `log_k_sub_2_le_log_k`: log(k-2) ≤ log k for k ≥ 4

Excludes open conjectures, definition sorries, and axioms per Aristotle pre-submission requirements.

---
Automated fix by lean-mechanic agent.