### PR TITLE
Enrich Extended Euclidean Algorithm: add annotations, sections, cross-refs

### DIFF
--- a/src/data/proofs/bezout-identity-oq-01/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-01/annotations.json
@@ -1,1 +1,110 @@
-[]
+[
+  {
+    "id": "ann-extgcd-def",
+    "proofId": "bezout-identity-oq-01",
+    "range": { "startLine": 34, "endLine": 41 },
+    "type": "definition",
+    "title": "extGcd: Computable Well-Founded Recursive Algorithm",
+    "content": "The extended Euclidean algorithm extGcd : ℕ → ℕ → ℤ × ℤ × ℕ is defined by structural recursion on b. The base case extGcd a 0 = (1, 0, a) returns the trivial Bézout decomposition a·1 + 0·0 = a. The recursive case swaps the arguments (as in the ordinary Euclidean algorithm) and updates the Bézout coefficients: the new x is the old y, and the new y is old_x - ⌊a/b⌋ · old_y. Lean requires the termination witness `have : a % (b+1) < b+1` to confirm that the recursive call's second argument is strictly smaller. The `have` term proves a % (b+1) < b+1 via Nat.mod_lt, enabling the well-founded recursion.",
+    "mathContext": "Base: $\\text{extGcd}(a, 0) = (1, 0, a)$; Recursive: $\\text{extGcd}(a, b+1) = (y', x' - \\lfloor a/(b+1)\\rfloor \\cdot y', g')$ where $(x', y', g') = \\text{extGcd}(b+1, a \\bmod (b+1))$",
+    "significance": "key",
+    "relatedConcepts": ["Euclidean algorithm", "well-founded recursion", "Bézout coefficients", "termination proof"],
+    "prerequisites": ["Nat.mod_lt (termination)", "well-founded recursion in Lean 4", "extended Euclidean algorithm"]
+  },
+  {
+    "id": "ann-projections",
+    "proofId": "bezout-identity-oq-01",
+    "range": { "startLine": 43, "endLine": 50 },
+    "type": "technique",
+    "title": "Named Projections Avoid Destructuring Pitfalls",
+    "content": "Rather than destructuring the triple output with let-bindings in later proofs (which can cause definitional reduction failures in Lean 4), three helper definitions extract each component: extGcdX, extGcdY, extGcdG. Using named projections `.1`, `.2.1`, `.2.2` via dot notation keeps the proof terms small and allows Lean's elaborator to reduce them definitionally. This is a common Lean 4 idiom when working with tuple-returning recursive functions.",
+    "mathContext": "$\\text{extGcdX}(a,b) = (\\text{extGcd}(a,b))_1$, $\\text{extGcdY}(a,b) = (\\text{extGcd}(a,b))_{2,1}$, $\\text{extGcdG}(a,b) = (\\text{extGcd}(a,b))_{2,2}$",
+    "significance": "technical",
+    "relatedConcepts": ["Lean 4 projections", "tuple destructuring", "definitional reduction", "dot notation"],
+    "prerequisites": ["Lean 4 product types", "projection syntax .1 .2.1 .2.2"]
+  },
+  {
+    "id": "ann-unfolding-lemmas",
+    "proofId": "bezout-identity-oq-01",
+    "range": { "startLine": 52, "endLine": 62 },
+    "type": "technique",
+    "title": "Unfolding Lemmas Make the Algorithm's Cases Explicit",
+    "content": "extGcd_zero and extGcd_succ serve as `simp` and rewrite lemmas that expose the two branches of extGcd without forcing Lean to unfold the well-founded recursion machinery. Without these, proofs would need to reduce extGcd by delta-unfolding, which can be slow or fail. extGcd_succ in particular is non-trivial: it uses `simp [extGcd]` to discharge the definitional equality through Lean's built-in unfolding of well-founded recursive definitions.",
+    "mathContext": "$\\text{extGcd}(a, 0) = (1, 0, a)$ and $\\text{extGcd}(a, b+1) = $ recursive update formula",
+    "significance": "supporting",
+    "relatedConcepts": ["simp lemmas", "well-founded unfolding", "definitional equality", "Lean 4 recursion kernel"],
+    "prerequisites": ["@[simp] attribute", "Lean 4 well-founded recursion elaboration"]
+  },
+  {
+    "id": "ann-gcd-correctness",
+    "proofId": "bezout-identity-oq-01",
+    "range": { "startLine": 70, "endLine": 85 },
+    "type": "technique",
+    "title": "GCD Correctness by Well-Founded Induction",
+    "content": "The proof that (extGcd a b).2.2 = Nat.gcd a b proceeds by well-founded induction on b using Nat.strongRecOn, mirroring the recursion structure of extGcd. The base case b=0 follows from Nat.gcd_zero_right. The inductive step rewrites extGcd_succ, obtains the IH at the reduced pair (b+1, a%(b+1)), and then chains three Nat.gcd identities: gcd_comm to swap arguments, gcd_rec to peel off one step (gcd(b+1, a) = gcd(a%(b+1), b+1)), and gcd_comm again to restore order. The entire argument mirrors the standard textbook proof that the Euclidean algorithm computes the GCD.",
+    "mathContext": "$\\gcd(a, b+1) = \\gcd(b+1, a) = \\gcd(a \\bmod (b+1), b+1) = \\gcd(b+1, a \\bmod (b+1))$",
+    "significance": "key",
+    "relatedConcepts": ["Nat.strongRecOn", "Nat.gcd_rec", "Nat.gcd_comm", "Euclidean algorithm correctness"],
+    "prerequisites": ["well-founded induction in Lean 4", "Nat.gcd_rec: gcd(a,b) = gcd(b, a%b)"]
+  },
+  {
+    "id": "ann-division-algorithm",
+    "proofId": "bezout-identity-oq-01",
+    "range": { "startLine": 116, "endLine": 119 },
+    "type": "insight",
+    "title": "The Division Algorithm as the Algebraic Bridge",
+    "content": "The key identity hdiv : (a : ℤ) = ⌊a/(b+1)⌋ · (b+1) + (a%(b+1)) is the division algorithm a = q·b + r in ℤ. It is proved by lifting Nat.div_add_mod a (b+1) from ℕ to ℤ using `zify`. This identity bridges the recursive Bézout equation (which is stated for (b+1) and a%(b+1)) and the goal (stated for a and b+1). Without it, the linear relationship between a, b+1, and the quotient q cannot be expressed algebraically.",
+    "mathContext": "$a = \\lfloor a/(b+1)\\rfloor \\cdot (b+1) + (a \\bmod (b+1))$ (division algorithm in $\\mathbb{Z}$)",
+    "significance": "key",
+    "relatedConcepts": ["division algorithm", "Nat.div_add_mod", "zify tactic", "integer lifting"],
+    "prerequisites": ["Nat.div_add_mod", "zify tactic in Lean 4", "Euclidean division in ℤ"]
+  },
+  {
+    "id": "ann-linear-combination",
+    "proofId": "bezout-identity-oq-01",
+    "range": { "startLine": 120, "endLine": 120 },
+    "type": "technique",
+    "title": "linear_combination Closes the Bézout Step in One Line",
+    "content": "The single tactic `linear_combination hrec + hdiv * y'` is the algebraic heart of the Bézout proof. Given hrec : (b+1)·x' + (a%(b+1))·y' = g and hdiv : a = q·(b+1) + a%(b+1), the goal is a·y' + (b+1)·(x' - q·y') = g. Expanding: a·y' + (b+1)·x' - q·(b+1)·y' = (q·(b+1) + a%(b+1))·y' + (b+1)·x' - q·(b+1)·y' = (b+1)·x' + a%(b+1)·y' = g. The linear_combination tactic encodes this as a ring identity and verifies it automatically. This one-line closure replaces what would otherwise be several pages of manual ring arithmetic.",
+    "mathContext": "Goal: $a \\cdot y' + (b+1)(x' - q y') = g$. From hrec and hdiv: $a y' + (b+1)x' - q(b+1)y' = (q(b+1) + r)y' + (b+1)x' - q(b+1)y' = (b+1)x' + ry' = g$.",
+    "significance": "key",
+    "relatedConcepts": ["linear_combination tactic", "ring arithmetic", "Bézout identity", "algebraic manipulation"],
+    "prerequisites": ["linear_combination tactic in Lean 4 / Mathlib", "ring identity verification"]
+  },
+  {
+    "id": "ann-bezout-main",
+    "proofId": "bezout-identity-oq-01",
+    "range": { "startLine": 93, "endLine": 120 },
+    "type": "insight",
+    "title": "Main Correctness Theorem: Bézout via Well-Founded Induction",
+    "content": "extGcd_bezout is the central result: for any a, b : ℕ, the output (x, y, g) of extGcd satisfies a·x + b·y = g (in ℤ). The proof structure mirrors extGcd exactly: well-founded induction on b, with base case discharged by simp, and inductive step using the local names x', y', g' for the recursive result. The names are introduced via `set` to give the elaborator concrete terms to work with. The proof is fully abstract — it uses no computation at all, only the algebraic structure of the algorithm's recursion.",
+    "mathContext": "For all $a, b \\in \\mathbb{N}$: $a \\cdot (\\text{extGcd}(a,b))_1 + b \\cdot (\\text{extGcd}(a,b))_{2,1} = (\\text{extGcd}(a,b))_{2,2}$",
+    "significance": "key",
+    "relatedConcepts": ["Bézout's identity", "well-founded induction", "constructive mathematics", "algorithm correctness"],
+    "prerequisites": ["extGcd definition", "Nat.strongRecOn", "division algorithm (hdiv)"]
+  },
+  {
+    "id": "ann-native-decide",
+    "proofId": "bezout-identity-oq-01",
+    "range": { "startLine": 132, "endLine": 163 },
+    "type": "context",
+    "title": "Computational Verification via native_decide",
+    "content": "Nine concrete examples verify the algorithm on pairs including (12,8), (35,15), (17,5), and (252,198). The native_decide tactic compiles these propositions to native code and evaluates them at kernel level — this is both a correctness sanity check and a demonstration that extGcd is genuinely computable (not just axiomatically asserted). The fact that native_decide can evaluate extGcd confirms that the well-founded recursion was defined in a computationally transparent way; a non-computable definition would fail here.",
+    "mathContext": "E.g., $\\text{extGcd}(12, 8) = (x, y, 4)$ with $12x + 8y = 4$; $\\text{extGcd}(252, 198) = (x, y, 18)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["native_decide tactic", "computational verification", "decidable propositions", "kernel evaluation"],
+    "prerequisites": ["native_decide in Lean 4", "computability requirements for well-founded recursion"]
+  },
+  {
+    "id": "ann-existential-bezout",
+    "proofId": "bezout-identity-oq-01",
+    "range": { "startLine": 165, "endLine": 208 },
+    "type": "context",
+    "title": "Existential Bézout, Divisibility, and Positivity Properties",
+    "content": "The final section derives corollaries from the main theorems. bezout_via_extGcd provides the classical existential form ∃ x y, gcd(a,b) = a·x + b·y by using extGcdX and extGcdY as explicit witnesses. The gcd positivity lemma (extGcd_gcd_pos) derives from Nat.pos_of_ne_zero plus the fact that a = 0 ∧ b = 0 implies gcd = 0. The divisibility lemmas extGcd_gcd_dvd_left and extGcd_gcd_dvd_right follow immediately from extGcd_gcd plus Nat.gcd_dvd_left/right — they are one-liners because all the work is already done.",
+    "mathContext": "$\\exists x, y \\in \\mathbb{Z}: \\gcd(a,b) = ax + by$; $a \\neq 0 \\lor b \\neq 0 \\Rightarrow \\gcd(a,b) > 0$; $\\gcd(a,b) \\mid a$ and $\\gcd(a,b) \\mid b$",
+    "significance": "supporting",
+    "relatedConcepts": ["existential witnesses", "Nat.gcd_dvd_left", "Nat.pos_of_ne_zero", "Bézout corollaries"],
+    "prerequisites": ["extGcd_bezout", "extGcd_gcd", "Nat.gcd_dvd_left", "Nat.gcd_dvd_right"]
+  }
+]

--- a/src/data/proofs/bezout-identity-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01/meta.json
@@ -31,15 +31,16 @@
     ]
   },
   "overview": {
-    "historicalContext": "Bézout's identity gcd(a,b) = a·x + b·y (with x, y ∈ ℤ) is proved non-constructively by Mathlib (Int.gcdA, Int.gcdB). The question is whether the extended Euclidean algorithm can be formalized as a fully computable function with a verified correctness proof in Lean 4. This file gives a self-contained implementation using well-founded recursion on b.",
+    "historicalContext": "The extended Euclidean algorithm traces its roots to Euclid's Elements (Book VII, ~300 BCE), where Propositions 1–3 describe the process for finding the greatest common divisor using repeated subtraction. The efficient division-based form (computing remainders rather than subtracting) was known in India by the 7th century (Brahmagupta) and described algorithmically by al-Khwarizmi (~825 CE). The identity now known as Bézout's identity — that gcd(a,b) is always an integer linear combination ax + by — was proved in full generality by Étienne Bézout in his 1779 work on algebraic equations. The extended version of the Euclidean algorithm that actually computes the Bézout coefficients x and y appears in number theory textbooks as a companion to the GCD algorithm. In computer science, the algorithm is a cornerstone of modular arithmetic, RSA key generation, and polynomial GCD computations. Modern proof assistants typically prove Bézout's identity existentially via Mathlib's Int.gcdA/Int.gcdB (which extract coefficients from the Euclidean algorithm internally), but this gallery entry provides a fully transparent, computable Lean 4 implementation with a machine-verified correctness proof.",
     "problemStatement": "Define a computable function extGcd : ℕ → ℕ → ℤ × ℤ × ℕ implementing the extended Euclidean algorithm and prove a·extGcd(a,b).x + b·extGcd(a,b).y = gcd(a,b).",
     "text": "The algorithm: extGcd a 0 = (1, 0, a) (base case); extGcd a (b+1) = let r = extGcd (b+1) (a mod (b+1)) in (r.y, r.x - ⌊a/(b+1)⌋·r.y, r.z). The GCD correctness proof tracks the standard Euclidean algorithm: extGcd_gcd reduces to Nat.gcd_comm and Nat.gcd_rec. The Bézout proof uses well-founded induction with the key step: setting hdiv : a = (a/(b+1))·(b+1) + (a%(b+1)), the linear_combination tactic closes the goal from the inductive hypothesis via hdiv * y'.",
     "proofStrategy": "Well-founded induction using Nat.strongRecOn (matches the recursion structure). GCD proof: straightforward Nat.gcd identity chain. Bézout proof: set x' and y' as the recursive results, use hdiv (division algorithm) to express a = q(b+1) + r, then linear_combination closes via one-step algebra.",
     "keyInsights": [
-      "Using projections (r.1, r.2.1, r.2.2) instead of let-destructuring avoids definitional issues",
-      "Lean's well-founded recursion on `b` tracks termination via Nat.mod_lt",
-      "linear_combination closes the key Bézout step in one tactic from hrec + hdiv * y'",
-      "native_decide enables efficient concrete verification for specific inputs"
+      "The linear_combination tactic closes the entire Bézout inductive step in a single line (hrec + hdiv * y'), replacing what would otherwise be several manual ring-arithmetic steps. This demonstrates the power of Lean 4's algebraic tactic infrastructure for number theory.",
+      "Using dot-projection syntax (.1, .2.1, .2.2) instead of let-destructuring is a deliberate design choice: let-bound variables in Lean 4 can fail to reduce definitionally inside recursive functions, while projections always reduce. This is an important idiom for well-founded recursive definitions returning tuples.",
+      "The termination argument is explicit: Lean requires the `have : a % (b+1) < b+1 := Nat.mod_lt ...` term before the recursive call, making the proof of termination local to the definition rather than deferred to a separate `termination_by` clause.",
+      "native_decide proves concrete examples (12,8), (35,15), (252,198) by kernel-level native code evaluation, confirming both correctness and genuine computability. A non-computable sorry-free proof would still satisfy `decide` for small instances, but native_decide is the gold standard.",
+      "The GCD correctness proof (extGcd_gcd) and Bézout correctness proof (extGcd_bezout) are structurally parallel but mathematically independent: extGcd_gcd only uses Nat.gcd identities, while extGcd_bezout uses the division algorithm. Combining them gives extGcd_correct, the combined form."
     ],
     "prerequisites": [
       "Well-founded recursion in Lean 4: Nat.strongRecOn",
@@ -64,10 +65,94 @@
   },
   "crossReferences": [
     {
-      "targetId": "bezout-identity-oq-03-oq-01-oq-02",
+      "id": "bezout-identity",
+      "relationship": "parent",
+      "description": "The classical Bézout's identity whose computability this entry establishes"
+    },
+    {
+      "id": "bezout-identity-oq-03-oq-01-oq-02",
       "relationship": "related",
-      "description": "BezoutIdentityOQ03OQ01OQ02 uses Bézout coefficients from Mathlib; this file provides a computable alternative implementation"
+      "description": "Uses Mathlib's Int.gcdA/Int.gcdB for Bézout coefficients; this file provides a computable alternative"
+    },
+    {
+      "id": "bezout-identity-oq-02",
+      "relationship": "sibling",
+      "description": "Euclid's Lemma via Bézout — a key application of the identity proved here"
+    },
+    {
+      "id": "bezout-identity-oq-03",
+      "relationship": "sibling",
+      "description": "Chinese Remainder Theorem via Bézout — another application enabled by the computable coefficients"
+    },
+    {
+      "id": "binary-gcd",
+      "relationship": "related",
+      "description": "Binary GCD (Stein's algorithm) — an alternative computable GCD algorithm of the same spirit"
     }
   ],
-  "sections": []
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header and Problem Statement",
+      "startLine": 1,
+      "endLine": 25,
+      "summary": "Imports Mathlib GCD and tactic libraries. Module documentation states the open question (can extGcd be fully formalized as computable?), lists the three things proved (Bézout correctness, GCD correctness, computability), and describes the approach (well-founded recursion on b using explicit projections)."
+    },
+    {
+      "id": "sec-extgcd-def",
+      "title": "Definition: Extended Euclidean Algorithm",
+      "startLine": 27,
+      "endLine": 51,
+      "summary": "Defines extGcd : ℕ → ℕ → ℤ × ℤ × ℕ by well-founded recursion on b with explicit termination proof Nat.mod_lt. Defines three projection helpers: extGcdX, extGcdY, extGcdG."
+    },
+    {
+      "id": "sec-unfolding",
+      "title": "Unfolding Lemmas: Base and Recursive Cases",
+      "startLine": 52,
+      "endLine": 62,
+      "summary": "extGcd_zero and extGcd_succ expose the two branches of extGcd as @[simp] / rewrite lemmas, avoiding direct unfolding of the well-founded recursion machinery in later proofs."
+    },
+    {
+      "id": "sec-gcd-correctness",
+      "title": "GCD Correctness: Third Component Equals Nat.gcd",
+      "startLine": 64,
+      "endLine": 85,
+      "summary": "Proves (extGcd a b).2.2 = Nat.gcd a b by well-founded induction on b. Inductive step chains Nat.gcd_comm and Nat.gcd_rec to align with the Euclidean recursion."
+    },
+    {
+      "id": "sec-bezout-correctness",
+      "title": "Bézout Correctness: a·x + b·y = gcd(a,b)",
+      "startLine": 87,
+      "endLine": 120,
+      "summary": "Main theorem: extGcd_bezout proves a·x + b·y = g by well-founded induction. Key step: division algorithm identity hdiv lifts Nat.div_add_mod to ℤ; linear_combination closes the goal in one line."
+    },
+    {
+      "id": "sec-combined",
+      "title": "Combined Correctness and Existential Bézout",
+      "startLine": 122,
+      "endLine": 130,
+      "summary": "extGcd_correct combines extGcd_bezout and extGcd_gcd to state the full correctness: a·x + b·y = Nat.gcd a b."
+    },
+    {
+      "id": "sec-native-decide",
+      "title": "Computational Verification via native_decide",
+      "startLine": 132,
+      "endLine": 163,
+      "summary": "Nine concrete examples verify extGcd on (12,8), (35,15), (17,5), and (252,198) using native_decide, confirming both the GCD output and the Bézout identity for each pair."
+    },
+    {
+      "id": "sec-existential-bezout",
+      "title": "Existential Bézout via Computable Witnesses",
+      "startLine": 165,
+      "endLine": 182,
+      "summary": "bezout_via_extGcd derives the classical existential form ∃ x y, gcd(a,b) = a·x+b·y using extGcdX and extGcdY as explicit computable witnesses."
+    },
+    {
+      "id": "sec-properties",
+      "title": "Derived Properties: Positivity and Divisibility",
+      "startLine": 184,
+      "endLine": 208,
+      "summary": "Three corollaries: extGcd_gcd_pos (gcd > 0 when a ≠ 0 ∨ b ≠ 0), extGcd_gcd_dvd_left (gcd ∣ a), extGcd_gcd_dvd_right (gcd ∣ b). All follow immediately from extGcd_gcd plus standard Nat.gcd lemmas."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for **bezout-identity-oq-01** (Extended Euclidean Algorithm as Computable Function).

## Quality improvements

- **9 new annotations** (was 0) covering all major proof sections, each with `mathContext` (LaTeX formulas), `significance`, `relatedConcepts`, and `prerequisites`
- **9 sections** added covering all 208 lines from imports through the divisibility properties
- **5 cross-references** added: parent bezout-identity, Euclid's Lemma (oq-02), CRT (oq-03), binary-gcd, and the existing cross-ref to oq-03-oq-01-oq-02
- **Expanded historicalContext**: Euclid (~300 BCE), Brahmagupta (7th c.), al-Khwarizmi (~825 CE), Bézout (1779)
- **Deepened keyInsights**: 5 insights with proof-specific detail on linear_combination, dot-projection idiom, termination proof structure, native_decide, and structural parallelism of the two correctness proofs

## Axiom integrity

Verified: `axiomCount: 0` and `status: "verified"` are accurate. No `axiom` declarations, no structure-encoded assumptions. All 10 theorems proved without sorry; native_decide examples confirm computability.