### PR TITLE
Enrich Generalized CRT: add annotations, sections, cross-refs

### DIFF
--- a/src/data/proofs/bezout-identity-oq-03-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-01-oq-02/annotations.json
@@ -1,1 +1,98 @@
-[]
+[
+  {
+    "id": "ann-forward-direction",
+    "proofId": "bezout-identity-oq-03-oq-01-oq-02",
+    "range": { "startLine": 28, "endLine": 37 },
+    "type": "technique",
+    "title": "Forward Direction: Divisibility from Congruences via Transitivity",
+    "content": "If x ≡ a (mod m) and x ≡ b (mod n), then gcd(m,n) | (a-b). The proof decomposes a-b = (a-x) - (b-x): since m | (a-x) and gcd | m, we get gcd | (a-x); similarly gcd | (b-x). Then dvd_sub combines them. The key tactic step is using Int.modEq_iff_dvd to convert the modular congruence hypothesis x ≡ a [ZMOD m] into the divisibility m | (a-x), then chaining via Int.gcd_dvd_left. The calculation `a - b = (a - x) - (b - x)` is closed by `ring`, keeping the proof concise.",
+    "mathContext": "$m \\mid (a-x)$ and $n \\mid (b-x)$, so $\\gcd(m,n) \\mid (a-x)$ and $\\gcd(m,n) \\mid (b-x)$, hence $\\gcd(m,n) \\mid (a-b)$.",
+    "significance": "key",
+    "relatedConcepts": ["Int.modEq_iff_dvd", "Int.gcd_dvd_left", "dvd_sub", "divisibility transitivity"],
+    "prerequisites": ["Int.ModEq definition", "divisibility in ℤ", "ring tactic"]
+  },
+  {
+    "id": "ann-backward-direction",
+    "proofId": "bezout-identity-oq-03-oq-01-oq-02",
+    "range": { "startLine": 39, "endLine": 53 },
+    "type": "insight",
+    "title": "Backward Direction: Bézout-Based Explicit Construction",
+    "content": "Given gcd(m,n) | (a-b), the system is solvable by the explicit witness x = a - m·gcdA(m,n)·((a-b)/gcd). The first congruence x ≡ a (mod m) holds unconditionally: a - x = m·gcdA·k is divisible by m for any k. The second congruence x ≡ b (mod n) requires Bézout's identity: since gcd = m·gcdA + n·gcdB, we have b - x = (a-b) - m·gcdA·k = d·k - m·gcdA·k = n·gcdB·k (modulo n). The proof closes by linear_combination with -hk - k * hbez, where hbez is Bézout's identity Int.gcd_eq_gcd_ab and hk is a-b = d·k.",
+    "mathContext": "Witness: $x = a - m \\cdot \\text{gcdA}(m,n) \\cdot \\frac{a-b}{\\gcd(m,n)}$. Verification: $b - x = (a-b) - m \\cdot \\text{gcdA} \\cdot k = dk - m \\cdot \\text{gcdA} \\cdot k = n \\cdot \\text{gcdB} \\cdot k$.",
+    "significance": "key",
+    "relatedConcepts": ["Bézout coefficients", "Int.gcdA", "Int.gcd_eq_gcd_ab", "linear_combination tactic"],
+    "prerequisites": ["Bézout's identity: gcd = m·gcdA + n·gcdB", "Int.ediv_mul_cancel (exact division)"]
+  },
+  {
+    "id": "ann-generalized-crt-iff",
+    "proofId": "bezout-identity-oq-03-oq-01-oq-02",
+    "range": { "startLine": 55, "endLine": 60 },
+    "type": "concept",
+    "title": "Solvability Criterion: The Central Iff Theorem",
+    "content": "generalized_crt_iff packages both directions into a clean biconditional: the system x ≡ a (mod m), x ≡ b (mod n) is solvable if and only if gcd(m,n) | (a-b). The proof is a two-element anonymous constructor, applying the forward and backward lemmas. This is the generalization of the classical CRT (which only handles gcd=1) to arbitrary moduli and is the main theoretical result of the file.",
+    "mathContext": "$(\\exists x \\in \\mathbb{Z}: x \\equiv a \\pmod{m} \\wedge x \\equiv b \\pmod{n}) \\iff \\gcd(m,n) \\mid (a-b)$",
+    "significance": "key",
+    "relatedConcepts": ["Chinese Remainder Theorem", "solvability of congruences", "Gauss's generalization"],
+    "prerequisites": ["solvable_implies_gcd_dvd", "gcd_dvd_implies_solvable"]
+  },
+  {
+    "id": "ann-uniqueness-mod-lcm",
+    "proofId": "bezout-identity-oq-03-oq-01-oq-02",
+    "range": { "startLine": 67, "endLine": 82 },
+    "type": "technique",
+    "title": "Uniqueness via natAbs and lcm Divisibility",
+    "content": "crt_unique_mod_lcm proves that any two common solutions x and y are congruent mod lcm(m,n). The proof is technically subtle: Lean's Nat.lcm_dvd works for ℕ, but the divisibility goals are in ℤ. The proof routes through natAbs: Int.natAbs_dvd_natAbs converts m | (y-x) to m.natAbs | (y-x).natAbs, Nat.lcm_dvd combines these, and then the proof reconstructs the ℤ divisibility by cases on whether (y-x) equals its own natAbs or its negation. The Int.natAbs_eq case split is necessary because ℤ divisibility is signed while ℕ divisibility is unsigned.",
+    "mathContext": "$m \\mid (x-y)$ and $n \\mid (x-y)$ implies $\\text{lcm}(m,n) \\mid (x-y)$",
+    "significance": "key",
+    "relatedConcepts": ["Int.natAbs", "Nat.lcm_dvd", "Int.natAbs_dvd_natAbs", "signed vs unsigned divisibility"],
+    "prerequisites": ["Int.lcm definition", "Nat.lcm_dvd theorem", "Int.natAbs_eq (sign cases)"]
+  },
+  {
+    "id": "ann-gcd-lcm-identity",
+    "proofId": "bezout-identity-oq-03-oq-01-oq-02",
+    "range": { "startLine": 96, "endLine": 104 },
+    "type": "concept",
+    "title": "GCD × LCM = Product: The Fundamental Identity",
+    "content": "gcd_mul_lcm_eq proves m·n = gcd(m,n)·lcm(m,n), which is the fundamental relationship between GCD and LCM. In the coprime case gcd=1, this reduces to lcm(m,n) = m·n, confirming that uniqueness mod lcm(m,n) collapses to uniqueness mod m·n in the standard CRT. The proof of gcd_mul_lcm_eq is a one-liner (Nat.gcd_mul_lcm).symm, since Mathlib already has this identity.",
+    "mathContext": "$m \\cdot n = \\gcd(m,n) \\cdot \\text{lcm}(m,n)$; when $\\gcd(m,n)=1$: $\\text{lcm}(m,n) = m \\cdot n$",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.gcd_mul_lcm", "Nat.Coprime", "LCM as the smallest common multiple"],
+    "prerequisites": ["Nat.lcm definition", "Nat.Coprime.gcd_eq_one"]
+  },
+  {
+    "id": "ann-explicit-solution",
+    "proofId": "bezout-identity-oq-03-oq-01-oq-02",
+    "range": { "startLine": 111, "endLine": 136 },
+    "type": "definition",
+    "title": "Explicit Solution Formula genCRTSolution",
+    "content": "genCRTSolution m n a b = a - m·gcdA(m,n)·((a-b)/gcd(m,n)) is the unique computable formula for the CRT solution. The first congruence x ≡ a (mod m) holds unconditionally — a - x = m·gcdA·k is an explicit multiple of m. The second congruence x ≡ b (mod n) uses the Bézout identity and exact integer division Int.ediv_mul_cancel, then closes by linear_combination. The `set k := (a-b)/gcd` naming makes the proof readable by giving the integer quotient a name throughout.",
+    "mathContext": "$x = a - m \\cdot \\text{gcdA}(m,n) \\cdot \\frac{a-b}{\\gcd(m,n)}$",
+    "significance": "key",
+    "relatedConcepts": ["Int.gcdA", "Int.ediv_mul_cancel", "set tactic", "genCRT_mod_left", "genCRT_mod_right"],
+    "prerequisites": ["Bézout's identity gcd = m·gcdA + n·gcdB", "Int.ediv_mul_cancel (exact division)"]
+  },
+  {
+    "id": "ann-concrete-examples",
+    "proofId": "bezout-identity-oq-03-oq-01-oq-02",
+    "range": { "startLine": 150, "endLine": 170 },
+    "type": "context",
+    "title": "Solvable, Unsolvable, and Uniqueness Examples",
+    "content": "The examples section illustrates the full theory. The system x ≡ 1 (mod 4), x ≡ 3 (mod 6) is solvable (gcd=2, 2 | (-2)) with x=9. The system x ≡ 1 (mod 4), x ≡ 2 (mod 6) is unsolvable (2 ∤ (-1)), proved by omega. The uniqueness example shows x=12 and x=30 both solve x ≡ 0 (mod 6), x ≡ 3 (mod 9), and 30 ≡ 12 (mod 18) = (mod lcm(6,9)) confirms they are the same solution class.",
+    "mathContext": "Solvable: $x \\equiv 1 \\pmod{4}, x \\equiv 3 \\pmod{6}$, $\\gcd=2 \\mid -2$, solution $x=9$. Unsolvable: $2 \\nmid (1-2)$. Unique mod $\\text{lcm}(6,9)=18$: $12 \\equiv 30 \\pmod{18}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["decide tactic", "omega tactic", "modular arithmetic verification", "lcm as period"],
+    "prerequisites": ["generalized_crt_iff", "crt_unique_mod_lcm", "Int.gcd arithmetic"]
+  },
+  {
+    "id": "ann-image-characterization",
+    "proofId": "bezout-identity-oq-03-oq-01-oq-02",
+    "range": { "startLine": 177, "endLine": 201 },
+    "type": "insight",
+    "title": "Image Characterization and Complete CRT",
+    "content": "generalized_crt_modEq restates solvability as a ≡ b (mod gcd(m,n)): the image of x ↦ (x mod m, x mod n) is exactly the diagonal subgroup {(a,b) : a ≡ b (mod d)} of ℤ/mℤ × ℤ/nℤ. This is the precise sense in which the map fails surjectivity when gcd > 1. The complete theorem generalized_crt_full combines existence and uniqueness: given a ≡ b (mod d), there exists x with both congruences, and all solutions are congruent mod lcm(m,n). This is the Lean 4 machine-verified counterpart of Gauss's classic result in the Disquisitiones Arithmeticae (1801).",
+    "mathContext": "$\\text{Im}(\\mathbb{Z} \\to \\mathbb{Z}/m\\mathbb{Z} \\times \\mathbb{Z}/n\\mathbb{Z}) = \\{(a,b) : a \\equiv b \\pmod{\\gcd(m,n)}\\}$",
+    "significance": "key",
+    "relatedConcepts": ["image of a ring map", "diagonal subgroup", "Int.modEq_iff_dvd", "CRT ring isomorphism"],
+    "prerequisites": ["generalized_crt_iff", "crt_unique_mod_lcm", "Int.ModEq definition"]
+  }
+]

--- a/src/data/proofs/bezout-identity-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-01-oq-02/meta.json
@@ -31,15 +31,16 @@
     ]
   },
   "overview": {
-    "historicalContext": "The classical Chinese Remainder Theorem (CRT) requires gcd(m,n) = 1. The generalization to arbitrary gcd was known to Gauss: the system is solvable iff the congruence condition d | (a-b) holds, and solutions are unique mod lcm(m,n). This formalization gives a fully machine-checked proof with an explicit solution formula using Bézout coefficients.",
+    "historicalContext": "The Chinese Remainder Theorem in its classical coprime form dates to the Sunzi Suanjing (Master Sun's Mathematical Manual, ~3rd–5th century CE), where a special case appears as a recreational puzzle. The theorem was systematically generalized to non-coprime moduli by Carl Friedrich Gauss in his Disquisitiones Arithmeticae (1801), where he characterizes exactly when a system of congruences is solvable and proves uniqueness modulo the lcm. The key insight — that the image of ℤ → ℤ/mℤ × ℤ/nℤ is the diagonal subgroup defined by a ≡ b (mod gcd(m,n)) — was known to 19th century number theorists but is rarely proved machine-verified with an explicit solution formula. In modern mathematics, the generalized CRT appears in algebraic number theory (ideal factorization in rings of integers), coding theory (construction of linear codes), and computer algebra (polynomial factoring via Hensel lifting). This formalization provides a fully machine-checked proof of the solvability criterion, the explicit Bézout-based solution formula, and uniqueness modulo the lcm.",
     "problemStatement": "Characterize the image of the map x ↦ (x mod m, x mod n) : ℤ → ℤ/mℤ × ℤ/nℤ when gcd(m,n) = d > 1. When is x ≡ a (mod m), x ≡ b (mod n) solvable?",
     "text": "The main result is generalized_crt_iff: the system is solvable iff Int.gcd m n divides (a - b). The forward direction uses that both m | (a-x) and n | (b-x) force d | (a-b) via the transitivity of divisibility. The backward direction constructs x = a - m·gcdA·((a-b)/d) using Bézout's identity. Uniqueness: if x and y are both solutions, then m | (x-y) and n | (x-y), so lcm(m,n) | (x-y). The image characterization follows: Im = {(a,b) : a ≡ b (mod gcd(m,n))}.",
     "proofStrategy": "Forward: Int.gcd_dvd_left and Int.gcd_dvd_right chain via transitivity. Backward: explicit construction using Int.gcdA and Int.gcdB, verified by linear_combination with Bézout's identity. Uniqueness: reduce to natAbs divisibility then cases on sign. The combined theorem generalized_crt_full packages existence + uniqueness.",
     "keyInsights": [
-      "The image of ℤ → ℤ/mℤ × ℤ/nℤ is exactly the congruence class modulo gcd(m,n)",
-      "Explicit solution: x = a - m·gcdA(m,n)·((a-b)/gcd(m,n))",
-      "The coprime case (gcd=1) recovers standard CRT as a special case",
-      "Solutions are unique modulo lcm(m,n), not modulo m·n"
+      "The image characterization Im = {(a,b) : a ≡ b (mod gcd(m,n))} reveals that the failure of surjectivity is precisely controlled by gcd: the larger the gcd, the more constrained the image, and surjectivity is recovered exactly when gcd=1.",
+      "The uniqueness proof routes through natAbs to bridge signed ℤ divisibility with the unsigned ℕ Nat.lcm_dvd theorem — a Lean 4 idiom for lcm-based uniqueness that avoids re-proving the theorem in ℤ.",
+      "The explicit solution x = a - m·gcdA·((a-b)/d) is computable via Mathlib's Int.gcdA, so genCRTSolution is a genuine algorithm, not just an existence proof — it can be evaluated by native_decide on concrete inputs.",
+      "The linear_combination tactic closes the second congruence in the backward direction by a single algebraic identity: -hk - k * hbez, where hbez encodes the Bézout relation gcd = m·gcdA + n·gcdB and hk encodes a-b = d·k.",
+      "The proof is structured in six self-contained parts (solvability, uniqueness, gcd-lcm identity, explicit formula, examples, image characterization), each building on the previous. This modular structure makes the formalization reusable as a library."
     ],
     "prerequisites": [
       "Bézout's identity: Int.gcd_eq_gcd_ab",
@@ -64,10 +65,87 @@
   },
   "crossReferences": [
     {
-      "targetId": "bezout-identity-oq-01",
+      "id": "bezout-identity-oq-03",
+      "relationship": "parent",
+      "description": "CRT via Bézout's Identity — the coprime version that this entry generalizes"
+    },
+    {
+      "id": "bezout-identity-oq-03-oq-01",
+      "relationship": "sibling",
+      "description": "CRT Ring Isomorphism ℤ/mnℤ ≅ ℤ/mℤ × ℤ/nℤ — the algebraic structure underlying this solvability characterization"
+    },
+    {
+      "id": "bezout-identity-oq-01",
       "relationship": "related",
-      "description": "BezoutIdentityOQ01 formalizes the extended Euclidean algorithm; this file uses Bézout coefficients from Mathlib to solve non-coprime CRT"
+      "description": "Computable extended Euclidean algorithm — provides an alternative to Mathlib's Int.gcdA used in the solution formula"
+    },
+    {
+      "id": "bezout-identity",
+      "relationship": "related",
+      "description": "Classical Bézout's Identity whose coefficients Int.gcdA and Int.gcdB drive the explicit CRT solution formula"
+    },
+    {
+      "id": "bezout-identity-oq-02",
+      "relationship": "sibling",
+      "description": "Euclid's Lemma — another application of Bézout's identity in number theory"
     }
   ],
-  "sections": []
+  "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header: Problem Statement and Key Results",
+      "startLine": 1,
+      "endLine": 21,
+      "summary": "Imports Mathlib Int.GCD, Coprime.Basic, and Tactic. Module documentation states the three main results: solvability criterion (gcd | a-b), image characterization, and uniqueness mod lcm."
+    },
+    {
+      "id": "sec-solvability",
+      "title": "Part I: Solvability Condition",
+      "startLine": 23,
+      "endLine": 60,
+      "summary": "Three theorems: solvable_implies_gcd_dvd (forward: congruences imply gcd | a-b via dvd_sub), gcd_dvd_implies_solvable (backward: explicit witness using Int.gcdA via Bézout), and generalized_crt_iff (biconditional package)."
+    },
+    {
+      "id": "sec-uniqueness",
+      "title": "Part II: Uniqueness Modulo LCM",
+      "startLine": 62,
+      "endLine": 89,
+      "summary": "Two theorems: crt_unique_mod_lcm (any two solutions are congruent mod lcm, proved via natAbs route) and crt_unique_iff_lcm (two solutions to the same system are congruent mod lcm)."
+    },
+    {
+      "id": "sec-gcd-lcm",
+      "title": "Part III: GCD and LCM Relationship",
+      "startLine": 91,
+      "endLine": 104,
+      "summary": "Two auxiliary lemmas: gcd_mul_lcm_eq (m·n = gcd·lcm) and coprime_lcm_eq_mul (in the coprime case lcm = product). These support the reduction to standard CRT."
+    },
+    {
+      "id": "sec-explicit-formula",
+      "title": "Part IV: Explicit Solution Formula",
+      "startLine": 106,
+      "endLine": 136,
+      "summary": "Definition genCRTSolution and two correctness lemmas: genCRT_mod_left (first congruence holds unconditionally) and genCRT_mod_right (second congruence under divisibility condition, using Bézout and exact division)."
+    },
+    {
+      "id": "sec-special-cases",
+      "title": "Part V: Special Cases and Concrete Examples",
+      "startLine": 138,
+      "endLine": 170,
+      "summary": "coprime_always_solvable (gcd=1 makes any system solvable) and concrete decide/omega examples: solvable (1 mod 4, 3 mod 6), unsolvable (1 mod 4, 2 mod 6), and uniqueness (12 and 30 both solve mod 6/9, agreeing mod 18)."
+    },
+    {
+      "id": "sec-image-characterization",
+      "title": "Part VI: Image Characterization and Complete CRT",
+      "startLine": 172,
+      "endLine": 201,
+      "summary": "generalized_crt_modEq (solvable iff a ≡ b (mod gcd)) and generalized_crt_full (existence + uniqueness in one theorem). Together these give the complete characterization of Im(ℤ → ℤ/mℤ × ℤ/nℤ)."
+    },
+    {
+      "id": "sec-summary",
+      "title": "Summary and #check Declarations",
+      "startLine": 202,
+      "endLine": 227,
+      "summary": "Prose summary of the four main results (solvability, uniqueness, formula, reduction) and #check declarations confirming all 12 theorems and 1 definition are accessible."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for **bezout-identity-oq-03-oq-01-oq-02** (Generalized CRT: Non-Coprime Image Characterization).

## Quality improvements

- **8 new annotations** (was 0) covering all 6 proof parts, each with `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`
- **7 sections** covering all 227 lines across 6 labeled parts
- **5 cross-references**: parent CRT via Bézout (oq-03), CRT ring isomorphism (oq-03-oq-01), computable extGcd (oq-01), classical Bézout identity, Euclid's Lemma
- **Expanded historicalContext**: Sunzi Suanjing (3rd–5th c. CE), Gauss Disquisitiones Arithmeticae (1801), algebraic number theory and coding theory applications
- **Deepened keyInsights**: 5 insights with Lean-specific detail on natAbs routing, linear_combination algebraic identity, computability of genCRTSolution, and modular proof architecture

## Axiom integrity

Verified: `axiomCount: 0` and `status: "verified"` are accurate. All 12 theorems proved without sorry; concrete examples verified by decide/omega/native_decide.