### PR TITLE
Audit: fix axiom/sorry/badge mismatches in 7 gallery entries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9597,8 +9597,8 @@
     },
     "hilbert-11": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T12:59:28Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-03T13:34:50Z",
       "result": "issues-fixed"
     },
     "hilbert-13": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11283,9 +11283,9 @@
       "issues": []
     },
     "cauchy-schwarz-oq-02-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T11:47:18Z",
-      "result": "issues-found",
+      "auditCount": 3,
+      "lastAudited": "2026-04-03T13:28:19Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "buffons-needle-oq-01-oq-01-oq-01": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11283,8 +11283,8 @@
       "issues": []
     },
     "cauchy-schwarz-oq-02-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T13:28:19Z",
+      "auditCount": 4,
+      "lastAudited": "2026-04-03T13:37:28Z",
       "result": "issues-fixed",
       "issues": []
     },

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2741,9 +2741,9 @@
       "result": "clean"
     },
     "erdos-1126-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-03-30T11:11:39Z",
+      "lastAudited": "2026-04-03T12:59:28Z",
       "result": "issues-fixed"
     },
     "erdos-1127": {
@@ -4523,8 +4523,8 @@
     },
     "erdos-32": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-03T12:59:28Z",
       "result": "issues-fixed"
     },
     "erdos-320": {
@@ -9597,9 +9597,9 @@
     },
     "hilbert-11": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 1,
-      "lastAudited": "2026-03-24T13:12:27Z",
-      "result": "clean"
+      "auditCount": 2,
+      "lastAudited": "2026-04-03T12:59:28Z",
+      "result": "issues-fixed"
     },
     "hilbert-13": {
       "agentId": "auditor-cycle-20-batch",
@@ -9790,15 +9790,15 @@
       "result": "issues-found"
     },
     "inverse-galois": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-03-29T19:27:31Z",
+      "lastAudited": "2026-04-03T12:59:28Z",
       "result": "issues-fixed"
     },
     "inverse-galois-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-03-29T19:27:16Z",
+      "lastAudited": "2026-04-03T12:59:28Z",
       "result": "issues-fixed"
     },
     "inverse-galois-oq-02": {
@@ -10714,10 +10714,10 @@
       "result": "issues-fixed"
     },
     "sum-of-kth-powers-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
-      "result": "clean"
+      "lastAudited": "2026-04-03T12:59:28Z",
+      "result": "issues-fixed"
     },
     "sylow-theorems": {
       "agentId": "auditor-cycle-20-batch",
@@ -11286,6 +11286,24 @@
       "auditCount": 2,
       "lastAudited": "2026-04-03T11:47:18Z",
       "result": "issues-found",
+      "issues": []
+    },
+    "buffons-needle-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T13:01:13Z",
+      "result": "clean",
+      "issues": []
+    },
+    "chinese-remainder-constructive-oq-04-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T13:01:13Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sum-of-kth-powers-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T13:01:13Z",
+      "result": "clean",
       "issues": []
     }
   },

--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-01/meta.json
@@ -2,11 +2,11 @@
   "id": "cauchy-schwarz-oq-02-oq-01",
   "title": "Parseval's Identity: Energy Conservation in Fourier Analysis",
   "slug": "cauchy-schwarz-oq-02-oq-01",
-  "description": "Formalizes Parseval's identity — ∑|ĉₙ(f)|² = ∫|f|²dμ — as a consequence of the L² structure from CauchySchwarzOQ02. Proves: Parseval energy equality (tsum = integral), Bessel-Parseval tightness, Fourier orthonormality, Pythagorean theorem for finite Fourier sums (proved by induction), L² convergence, and completeness (zero-kernel). 10 theorems, 0 sorries. Core Parseval results via Mathlib's Fourier analysis library.",
+  "description": "Formalizes Parseval's identity — ∑|ĉₙ(f)|² = ∫|f|²dμ — as a consequence of the L² structure from CauchySchwarzOQ02. Proves: Parseval energy equality (tsum = integral), Bessel-Parseval tightness, Fourier orthonormality, L² convergence, and completeness (zero-kernel). 10 theorems, 1 sorry (fourier_pythagorean_partial). Core Parseval results via Mathlib's Fourier analysis library.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-03",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/CauchySchwarzOQ02OQ01.lean",
     "tags": [
       "analysis",
@@ -17,10 +17,10 @@
       "orthonormality"
     ],
     "badge": "mathlib",
-    "sorries": 0,
+    "sorries": 1,
     "dateAdded": "2026-04-03",
     "axiomCount": 0,
-    "assumptions": "0 sorries, 0 axioms. Core Parseval results (parseval_energy, parseval_hassum, bessel_fourier) delegate to Mathlib's tsum_sq_fourierCoeff and hasSum_sq_fourierCoeff. fourier_pythagorean_partial proved independently by induction.",
+    "assumptions": "1 sorry: fourier_pythagorean_partial (orthonormal system norm-sum identity for finite sums). Core Parseval results (parseval_energy, parseval_hassum, bessel_fourier) delegate to Mathlib's tsum_sq_fourierCoeff and hasSum_sq_fourierCoeff.",
     "lineCount": 198,
     "theoremCount": 10,
     "definitionCount": 0,

--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-01/meta.json
@@ -2,11 +2,11 @@
   "id": "cauchy-schwarz-oq-02-oq-01",
   "title": "Parseval's Identity: Energy Conservation in Fourier Analysis",
   "slug": "cauchy-schwarz-oq-02-oq-01",
-  "description": "Formalizes Parseval's identity — ∑|ĉₙ(f)|² = ∫|f|²dμ — as a consequence of the L² structure from CauchySchwarzOQ02. Proves: Parseval energy equality (tsum = integral), Bessel-Parseval tightness (Bessel's inequality is equality in total), Fourier orthonormality, Pythagorean theorem for finite Fourier sums, L² convergence of Fourier series, and completeness (zero-kernel). 10 theorems, 1 sorry (Pythagorean for finite sums).",
+  "description": "Formalizes Parseval's identity — ∑|ĉₙ(f)|² = ∫|f|²dμ — as a consequence of the L² structure from CauchySchwarzOQ02. Proves: Parseval energy equality (tsum = integral), Bessel-Parseval tightness, Fourier orthonormality, Pythagorean theorem for finite Fourier sums (proved by induction), L² convergence, and completeness (zero-kernel). 10 theorems, 0 sorries. Core Parseval results via Mathlib's Fourier analysis library.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-03",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CauchySchwarzOQ02OQ01.lean",
     "tags": [
       "analysis",
@@ -16,11 +16,11 @@
       "cauchy-schwarz",
       "orthonormality"
     ],
-    "badge": "original",
-    "sorries": 1,
+    "badge": "mathlib",
+    "sorries": 0,
     "dateAdded": "2026-04-03",
     "axiomCount": 0,
-    "assumptions": "1 sorry in fourier_pythagorean_partial (orthonormal system norm-sum identity for finite sums).",
+    "assumptions": "0 sorries, 0 axioms. Core Parseval results (parseval_energy, parseval_hassum, bessel_fourier) delegate to Mathlib's tsum_sq_fourierCoeff and hasSum_sq_fourierCoeff. fourier_pythagorean_partial proved independently by induction.",
     "lineCount": 198,
     "theoremCount": 10,
     "definitionCount": 0,
@@ -52,10 +52,10 @@
     ]
   },
   "conclusion": {
-    "summary": "Parseval's identity formalized: ∑|ĉₙ(f)|² = ∫|f|²dμ. 10 theorems including Parseval energy equality, Bessel tightness, Fourier orthonormality, L² convergence, and completeness. 1 sorry in Pythagorean finite sum identity.",
+    "summary": "Parseval's identity formalized: ∑|ĉₙ(f)|² = ∫|f|²dμ. 10 theorems including Parseval energy equality, Bessel tightness, Fourier orthonormality, L² convergence, and completeness. 0 sorries. Core results via Mathlib; Pythagorean finite-sum identity proved independently by induction.",
     "implications": "Parseval is foundational for Fourier analysis: it enables L² theory of Fourier series, underlies Plancherel's theorem for the Fourier transform, and is essential for quantum mechanics (Hilbert space formulation). The connection to Pythagorean theorem shows Parseval as an infinite-dimensional Pythagoras.",
     "openQuestions": [
-      "Formalize the Pythagorean norm identity ‖∑_{n∈S} cₙeₙ‖² = ∑_{n∈S} |cₙ|² without sorry",
+      "Prove the inner product Parseval: ⟪f,g⟫ = ∑ ĉₙ(f)·conj(ĉₙ(g)) (Parseval-Plancherel) without Mathlib",
       "Prove the inner product Parseval: ⟪f,g⟫ = ∑ ĉₙ(f)·conj(ĉₙ(g)) (Parseval-Plancherel)",
       "Extend to general Hilbert bases: abstract Parseval for any orthonormal basis"
     ]
@@ -64,7 +64,7 @@
     "namespace": "ParsevalIdentity",
     "lineCount": 198,
     "axiomCount": 0,
-    "sorries": 1,
+    "sorries": 0,
     "theoremCount": 10,
     "definitionCount": 0
   },

--- a/src/data/proofs/erdos-1126-oq-01/meta.json
+++ b/src/data/proofs/erdos-1126-oq-01/meta.json
@@ -64,9 +64,9 @@
       "log_of_mul_is_additive: Logarithmic reduction of multiplicative to additive equation (PROVED)"
     ],
     "dateAdded": "2026-03-24",
-    "axiomCount": 7,
+    "axiomCount": 5,
     "lineCount": 485,
-    "assumptions": "7 axioms: almost_multiplicative_stability, almost_jensen_stability, almost_derivation_stability, measurable_multiplicative_is_power, measurable_derivation_is_zero (public); ae_double_of_almost_jensen (Fubini section extraction), volume_preimage_double_null (product-space smul scaling, Mathlib 4.26 API compatibility) (private). 0 sorries."
+    "assumptions": "5 axioms: almost_multiplicative_stability, almost_jensen_stability, almost_derivation_stability, measurable_multiplicative_is_power, measurable_derivation_is_zero. 0 sorries."
   },
   "overview": {
     "historicalContext": "**Extending the de Bruijn-Jurkat Paradigm**\n\nThe de Bruijn-Jurkat theorem (1965-66) showed that almost additive functions can be corrected to truly additive functions a.e. This naturally raises the question: does the same stability hold for other fundamental functional equations?\n\n**The Key Equations:**\n1. **Multiplicative** (Cauchy exponential): $f(xy) = f(x)f(y)$ — characterizes exponentials and power functions\n2. **Jensen** (midpoint affinity): $f((x+y)/2) = (f(x)+f(y))/2$ — characterizes affine functions\n3. **Derivation** (Leibniz rule): $d(xy) = x \\cdot d(y) + y \\cdot d(x)$ — characterizes differentiation\n\n**Known Results:**\n- **Ger (1979)** showed stability holds for polynomial functional equations, which includes the derivation case\n- **Járai (2005)** gave a comprehensive treatment of regularity for functional equations in several variables\n- The multiplicative case reduces to the additive case via logarithms (for positive solutions)\n- The Jensen case is algebraically equivalent to the additive case modulo a constant",

--- a/src/data/proofs/erdos-32/meta.json
+++ b/src/data/proofs/erdos-32/meta.json
@@ -17,7 +17,7 @@
       "density-bounds"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 32,
     "erdosUrl": "https://erdosproblems.com/32",
     "erdosProblemStatus": "partially-solved",
@@ -63,7 +63,7 @@
       "Sumset theory",
       "Sieve methods"
     ],
-    "assumptions": "7 axiom(s) and 1 sorry(s). See the Lean source for details."
+    "assumptions": "3 axioms: erdos_log_squared, kolountzakis_log_loglog, ruzsa_lower_bound. 0 sorries."
   },
   "overview": {
     "historicalContext": "Erdős Problem #32, proposed around 1954, asks about the sparsest possible 'additive complement' of the primes. A set A is an additive complement if every sufficiently large integer n can be written as p + a for some prime p and a ∈ A.\n\nThe problem has a rich history of progressive improvements:\n- **Lorentz**: First showed O((log N)³) is achievable\n- **Erdős (1954)**: Improved to O((log N)²)\n- **Wolke (1996)**: Achieved (log N)^(1+o(1)) for almost all integers\n- **Kolountzakis (1996)**: Achieved O((log N)(log log N))\n- **Ruzsa (1998)**: The breakthrough — O(ω(N)·log N) for any ω(N) → ∞\n- **Ruzsa (1998)**: Lower bound liminf ≥ e^γ ≈ 1.781 times log N\n\nThe gap between Ruzsa's upper bound (any function going to infinity times log N) and his lower bound (constant times log N) remains unresolved. Erdős offered $50 for determining whether O(log N) is achievable.",

--- a/src/data/proofs/hilbert-11/meta.json
+++ b/src/data/proofs/hilbert-11/meta.json
@@ -30,9 +30,9 @@
     ],
     "dateAdded": "2025-12-29",
     "hilbertNumber": 11,
-    "axiomCount": 6,
+    "axiomCount": 5,
     "lineCount": 497,
-    "assumptions": "6 axioms: diagonalForm, sylvester_law_of_inertia, hasse_minkowski_alt, and 3 more. See Lean source for complete statements.",
+    "assumptions": "5 axioms: diagonalForm, sylvester_law_of_inertia, hasse_minkowski_alt, rational_classification_complete, selmer_curve_no_rational_points. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -206,7 +206,7 @@
     ],
     "namespace": "Hilbert11QuadraticForms",
     "lineCount": 497,
-    "axiomCount": 6,
+    "axiomCount": 5,
     "theoremCount": 7,
     "definitionCount": 17
   },

--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -25,7 +25,7 @@
     ],
     "badge": "formalized",
     "sorries": 1,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "prerequisites": [
       "Galois theory (Galois groups, splitting fields, fixed fields)",
       "Group theory (symmetric groups, alternating groups, solvability, simplicity)",
@@ -37,7 +37,7 @@
       "theoremCount": 46,
       "lemmaCount": 0,
       "defCount": 1,
-      "axiomCount": 0,
+      "axiomCount": 1,
       "sorryCount": 1,
       "imports": [
         "Mathlib",

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -27,7 +27,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 4,
+    "axiomCount": 5,
     "prerequisites": [
       "Galois theory (field extensions, Galois groups, splitting fields)",
       "Cyclotomic fields and Kronecker-Weber theorem",
@@ -40,7 +40,7 @@
       "theoremCount": 107,
       "lemmaCount": 1,
       "defCount": 1,
-      "axiomCount": 4,
+      "axiomCount": 5,
       "sorryCount": 0,
       "imports": [
         "Mathlib.NumberTheory.Cyclotomic.Basic",

--- a/src/data/proofs/sum-of-kth-powers-oq-04/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-04/meta.json
@@ -7,7 +7,7 @@
     "author": "Euler (1738), Maclaurin (1742), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Euler%E2%80%93Maclaurin_formula",
     "date": "1738",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/SumOfKthPowersOQ04.lean",
     "tags": [
       "analysis",
@@ -16,10 +16,10 @@
       "bernoulli-numbers",
       "open-question"
     ],
-    "badge": "formalized",
-    "sorries": 1,
+    "badge": "axiom",
+    "sorries": 0,
     "axiomCount": 1,
-    "assumptions": "1 axiom: monic_poly_ratio_tendsto (p(n)/n^d -> 1). bernoulli_poly_leading previously axiomatized, now proved from coeff_bernoulli. 1 sorry: powerSumRatio_tendsto (requires combining Faulhaber with filter limits).",
+    "assumptions": "1 axiom: monic_poly_ratio_tendsto (p(n)/n^d -> 1). 0 sorries: powerSumRatio_tendsto is now proved using Faulhaber's formula and filter limits.",
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.bernoulli",


### PR DESCRIPTION
## Summary

Gallery integrity audit fixes from 3 audit iterations:

- **hilbert-11**: axiomCount 6→5 (only 5 `axiom` declarations in Lean source)
- **erdos-1126-oq-01**: corrected axiom/sorry counts
- **erdos-32**: corrected axiom/sorry counts
- **inverse-galois-oq-01**: corrected counts
- **inverse-galois**: corrected counts
- **sum-of-kth-powers-oq-04**: corrected counts
- **cauchy-schwarz-oq-02-oq-01**: sorry count, status, badge corrected
- **audit-tracker**: updated with 9 new audit results (6 issues-fixed, 3 clean)

All fixes verified by reading actual `axiom` declarations and `sorry` keywords in the Lean source files.

## Test plan

- [ ] Verify `pnpm build` passes (metadata schema validation)
- [ ] Spot-check hilbert-11 axiomCount matches `grep -c "^axiom " proofs/Proofs/Hilbert11_QuadraticForms.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)