### PR TITLE
Enrich Kakutani Fixed Point: add annotations, sections, historicalContext

### DIFF
--- a/src/data/proofs/schauder-fixed-point-oq-03/annotations.json
+++ b/src/data/proofs/schauder-fixed-point-oq-03/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-set-valued-map",
+    "proofId": "schauder-fixed-point-oq-03",
+    "range": { "startLine": 30, "endLine": 49 },
+    "type": "definition",
+    "title": "Set-Valued Map Framework: Correspondences and Their Properties",
+    "content": "SetValuedMap X Y = X → Set Y is the type of correspondences: functions assigning a set (not a single element) to each input. This is the mathematical object at the heart of Kakutani's theorem. The graph of F is {(x,y) : y ∈ F(x)} ⊆ X × Y, capturing the multi-valued nature. Three property predicates: HasNonemptyValues (∀x, F(x) ≠ ∅), HasClosedValues (each F(x) is closed), HasConvexValues (each F(x) is convex). These three conditions, together with upper hemicontinuity, are exactly the hypotheses of Kakutani's theorem.",
+    "mathContext": "$F: X \\to 2^Y$; $\\text{Graph}(F) = \\{(x,y) : y \\in F(x)\\} \\subseteq X \\times Y$",
+    "significance": "key",
+    "relatedConcepts": ["correspondence", "set-valued map", "graph of a relation", "nonempty values", "convex values"],
+    "prerequisites": ["Set in Lean 4 (= type → Prop)", "Convex ℝ S in Mathlib", "IsClosed in TopologicalSpace"]
+  },
+  {
+    "id": "ann-upper-hemicontinuity",
+    "proofId": "schauder-fixed-point-oq-03",
+    "range": { "startLine": 55, "endLine": 74 },
+    "type": "concept",
+    "title": "Upper Hemicontinuity: Stability of Values Under Open Neighborhoods",
+    "content": "IsUpperHemicontinuous F says: for every open set V, the preimage {x : F(x) ⊆ V} is open. This is the correct generalization of continuity to set-valued maps — the values F(x) cannot 'suddenly explode' as x moves. The classical ε-δ statement is: for every x₀ and open neighborhood V ⊇ F(x₀), there exists a neighborhood U of x₀ such that F(x) ⊆ V for all x ∈ U. The theorem continuous_is_uhc shows that a continuous single-valued f viewed as F(x) = {f(x)} is UHC: {x : {f(x)} ⊆ V} = f⁻¹(V) is open by continuity of f.",
+    "mathContext": "$F$ is UHC iff $\\forall$ open $V \\subseteq Y$: $\\{x : F(x) \\subseteq V\\}$ is open in $X$",
+    "significance": "key",
+    "relatedConcepts": ["upper hemicontinuity", "lower hemicontinuity", "continuous correspondence", "preimage of open set"],
+    "prerequisites": ["TopologicalSpace in Lean 4", "IsOpen (preimage of open under continuous = open)", "Set.singleton_subset_iff"]
+  },
+  {
+    "id": "ann-fixed-point-defs",
+    "proofId": "schauder-fixed-point-oq-03",
+    "range": { "startLine": 80, "endLine": 87 },
+    "type": "definition",
+    "title": "Fixed Points of Set-Valued Maps: x ∈ F(x)",
+    "content": "IsFixedPoint F x asserts x ∈ F(x): the point x is selected by its own image. For single-valued maps f (viewed as F(x) = {f(x)}), fixedpoint_singlevalued confirms this reduces to f(x) = x. This equivalence, proved by simp [IsFixedPoint], is what brouwer_from_kakutani uses: after finding a Kakutani fixed point of F = {f(·)}, it recovers f(x) = x via this lemma.",
+    "mathContext": "$x$ is a fixed point of $F$ iff $x \\in F(x)$. For $F(x) = \\{f(x)\\}$: $x \\in \\{f(x)\\} \\iff f(x) = x$.",
+    "significance": "supporting",
+    "relatedConcepts": ["fixed point", "Brouwer fixed point", "singleton set membership"],
+    "prerequisites": ["Set.mem_singleton_iff", "IsFixedPoint definition"]
+  },
+  {
+    "id": "ann-kakutani-axiom",
+    "proofId": "schauder-fixed-point-oq-03",
+    "range": { "startLine": 93, "endLine": 113 },
+    "type": "concept",
+    "title": "Kakutani's Theorem Axiomatized for Finite-Dimensional Euclidean Space",
+    "content": "kakutani_finite_dim is an axiom asserting the Kakutani fixed point theorem for EuclideanSpace ℝ (Fin n): given S ⊆ ℝⁿ nonempty, compact, convex, and F : S → 2^S upper hemicontinuous with nonempty, closed, convex values, there exists x ∈ S with x ∈ F(x). The proof requires simplicial approximation (a technical finite-dimensional tool) and is axiomatized here rather than proved. The axiomatic approach is honest about what remains unproved while still allowing the framework to be used for corollaries and applications. Note: this is a genuine mathematical axiom (an unproved assumption), not a Lean implementation axiom — Kakutani's theorem is true but its proof has not been machine-verified here.",
+    "mathContext": "Let $S \\subseteq \\mathbb{R}^n$ be nonempty, compact, convex. Let $F: S \\to 2^S$ be UHC with nonempty, closed, convex values. Then $\\exists x \\in S: x \\in F(x)$.",
+    "significance": "key",
+    "relatedConcepts": ["Kakutani fixed point theorem", "simplicial approximation", "axiom vs proved theorem", "EuclideanSpace ℝ (Fin n)"],
+    "prerequisites": ["IsCompact, Convex ℝ S in Mathlib", "EuclideanSpace ℝ (Fin n)", "Lean 4 axiom declaration"]
+  },
+  {
+    "id": "ann-brouwer-corollary",
+    "proofId": "schauder-fixed-point-oq-03",
+    "range": { "startLine": 119, "endLine": 134 },
+    "type": "insight",
+    "title": "Brouwer as a Corollary: Single-Valued = Trivially UHC",
+    "content": "brouwer_from_kakutani derives the Brouwer fixed point theorem from Kakutani. Given a continuous f : S → S, define F(x) = {f(x)}. Then: (1) HasNonemptyValues: {f(x)} is always nonempty; (2) HasClosedValues: singletons are closed; (3) HasConvexValues: singletons are convex; (4) IsUpperHemicontinuous: continuous_is_uhc hf. Applying kakutani_finite_dim gives x with x ∈ {f(x)}, i.e., f(x) = x via fixedpoint_singlevalued. This proof elegantly shows Brouwer is a special case of Kakutani — every single-valued continuous map trivially satisfies all the set-valued hypotheses.",
+    "mathContext": "$F(x) = \\{f(x)\\}$ satisfies all Kakutani conditions; fixed point $x \\in F(x)$ becomes $f(x) = x$.",
+    "significance": "key",
+    "relatedConcepts": ["Brouwer fixed point theorem", "singleton as trivial correspondence", "convex_singleton", "isClosed_singleton"],
+    "prerequisites": ["kakutani_finite_dim (the axiom)", "continuous_is_uhc", "fixedpoint_singlevalued"]
+  },
+  {
+    "id": "ann-nash-connection",
+    "proofId": "schauder-fixed-point-oq-03",
+    "range": { "startLine": 136, "endLine": 166 },
+    "type": "context",
+    "title": "Nash Equilibrium: The Primary Application of Kakutani",
+    "content": "The historical motivation for Kakutani's theorem is Nash's (1950) proof of Nash equilibrium existence. In an n-player game with mixed strategies: each player's strategy space is a simplex (compact convex). The best response correspondence BR(s) = {profiles where every player is best-responding to others} is UHC with nonempty, closed, convex values (best responses to a fixed opponent strategy form a face of the simplex). By Kakutani, BR has a fixed point: a profile s* ∈ BR(s*), which is exactly a Nash equilibrium. The sketch in this file indicates the connection without formalizing the full Nash existence proof, which would require additionally formalizing mixed strategies, payoffs, and best responses.",
+    "mathContext": "Best response: $\\text{BR}(s) = \\{s' : u_i(s'_i, s_{-i}) \\geq u_i(\\sigma_i, s_{-i}) \\forall \\sigma_i, \\forall i\\}$. Kakutani: $\\exists s^*: s^* \\in \\text{BR}(s^*)$ = Nash equilibrium.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nash equilibrium", "best response correspondence", "mixed strategies", "game theory", "simplex"],
+    "prerequisites": ["Nash's 1950 paper", "mixed strategy Nash equilibrium definition", "Kakutani conditions for BR"]
+  }
+]

--- a/src/data/proofs/schauder-fixed-point-oq-03/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-03/meta.json
@@ -30,60 +30,92 @@
     ]
   },
   "overview": {
-    "historicalContext": "Kakutani (1941) generalized Brouwer's theorem to set-valued maps. Nash (1950) used it to prove existence of Nash equilibria.",
+    "historicalContext": "Shizuo Kakutani's 1941 paper 'A Generalization of Brouwer's Fixed Point Theorem' (Duke Mathematical Journal) extended Brouwer's theorem to set-valued maps (correspondences), replacing the continuity requirement with upper hemicontinuity. Kakutani's motivation was to provide a cleaner proof of the minimax theorem (von Neumann 1928) for zero-sum games. The theorem became famous nine years later when John Nash (1950) used it to prove the existence of Nash equilibria in finite n-player games, for which Nash received the 1994 Nobel Prize in Economics. The key insight of Nash's proof is that the 'best response correspondence' — mapping each strategy profile to the set of profiles where every player is best-responding — satisfies exactly the Kakutani conditions when strategy spaces are taken to be simplices of mixed strategies. The Kakutani fixed point theorem was itself later generalized to infinite-dimensional spaces by Glicksberg (1952) and Fan (1952), and to locally convex topological vector spaces by the Fan-Kakutani theorem. In modern mathematics, it appears in general equilibrium theory (Arrow-Debreu model, 1954), mechanism design, and social choice theory.",
     "problemStatement": "Formalize the Kakutani fixed point theorem for set-valued maps.",
     "text": "Defines set-valued maps, upper hemicontinuity, and axiomatizes Kakutani's theorem. Recovers Brouwer as a corollary.",
     "proofStrategy": "Defines set-valued maps, upper hemicontinuity, and axiomatizes Kakutani's theorem. Recovers Brouwer as a corollary.",
-    "keyInsights": []
+    "keyInsights": [
+      "Kakutani's theorem generalizes Brouwer by replacing the single-valuedness requirement with upper hemicontinuity (UHC) plus nonempty/closed/convex values. UHC is the 'right' continuity for set-valued maps because it prevents the values F(x) from suddenly expanding: for any open neighborhood V of F(x₀), all nearby F(x) are contained in V.",
+      "The Brouwer-from-Kakutani derivation (brouwer_from_kakutani) is a clean proof that F(x) = {f(x)} satisfies all Kakutani conditions trivially: singletons are closed (isClosed_singleton), convex (convex_singleton), nonempty (singleton_nonempty), and a continuous f gives UHC via continuous_is_uhc. This shows Brouwer is a strict special case.",
+      "The axiom kakutani_finite_dim is mathematically honest: the full proof requires simplicial approximation (constructing single-valued approximations to F and passing to a limit), which is technically demanding to formalize. Axiomatic treatment preserves the mathematical framework while flagging what remains unproved.",
+      "Nash's use of Kakutani (1950) transformed game theory: the best response correspondence BR satisfies all four Kakutani conditions when strategy spaces are simplices (mixed strategies), giving the existence of Nash equilibria for arbitrary finite games. This is arguably the most impactful application of a fixed point theorem in mathematics."
+    ]
   },
   "sections": [
     {
-      "id": "set-valued",
-      "title": "Set-Valued Maps",
-      "startLine": 23,
-      "endLine": 55,
-      "summary": "Set-Valued Maps"
+      "id": "sec-header",
+      "title": "Module Header and Problem Statement",
+      "startLine": 1,
+      "endLine": 24,
+      "summary": "Module documentation states the Kakutani fixed point theorem (Kakutani 1941): nonempty compact convex S ⊆ ℝⁿ, upper hemicontinuous F with nonempty/closed/convex values ⟹ ∃x, x ∈ F(x). Notes the connection to Nash equilibria and Brouwer/Schauder."
     },
     {
-      "id": "uhc",
-      "title": "Upper Hemicontinuity",
-      "startLine": 57,
-      "endLine": 82,
-      "summary": "Upper Hemicontinuity"
+      "id": "sec-set-valued",
+      "title": "Part I: Set-Valued Map Framework",
+      "startLine": 26,
+      "endLine": 50,
+      "summary": "Defines SetValuedMap X Y = X → Set Y. Defines graph {(x,y): y∈F(x)}. Predicates: HasNonemptyValues (∀x, F(x)≠∅), HasClosedValues (∀x, IsClosed(F(x))), HasConvexValues (∀x, Convex ℝ (F(x))). These three conditions form part of Kakutani's hypotheses."
     },
     {
-      "id": "fixed-points",
-      "title": "Fixed Points",
-      "startLine": 84,
-      "endLine": 98,
-      "summary": "Fixed Points"
+      "id": "sec-uhc",
+      "title": "Part II: Upper Hemicontinuity",
+      "startLine": 51,
+      "endLine": 74,
+      "summary": "IsUpperHemicontinuous F: for every open V, {x : F(x) ⊆ V} is open. Theorem continuous_is_uhc: a continuous f viewed as F(x)={f(x)} is UHC, proved by identifying {x : {f(x)}⊆V} = f⁻¹(V)."
     },
     {
-      "id": "kakutani",
-      "title": "Kakutani's Theorem",
-      "startLine": 100,
-      "endLine": 132,
-      "summary": "Kakutani's Theorem"
+      "id": "sec-fixed-points",
+      "title": "Part III: Fixed Points of Correspondences",
+      "startLine": 76,
+      "endLine": 87,
+      "summary": "IsFixedPoint F x ↔ x ∈ F(x). Theorem fixedpoint_singlevalued: for F(x)={f(x)}, x ∈ F(x) ↔ f(x)=x (by simp). This bridge lemma is used in brouwer_from_kakutani."
     },
     {
-      "id": "brouwer",
-      "title": "Recovering Brouwer",
-      "startLine": 134,
-      "endLine": 153,
-      "summary": "Recovering Brouwer"
+      "id": "sec-kakutani",
+      "title": "Part IV: Kakutani's Theorem (Axiomatized)",
+      "startLine": 89,
+      "endLine": 113,
+      "summary": "axiom kakutani_finite_dim: for S ⊆ EuclideanSpace ℝ (Fin n) nonempty/compact/convex and F:S→2^S UHC with nonempty/closed/convex values, ∃x:S, IsFixedPoint F x. Axiomatized because the proof requires simplicial approximation and convergence arguments."
+    },
+    {
+      "id": "sec-brouwer",
+      "title": "Part V: Brouwer as a Corollary",
+      "startLine": 115,
+      "endLine": 134,
+      "summary": "brouwer_from_kakutani: given continuous f:S→S, define F(x)={f(x)}. Verifies all four Kakutani conditions for singletons, applies kakutani_finite_dim, and extracts f(x)=x via fixedpoint_singlevalued."
+    },
+    {
+      "id": "sec-nash",
+      "title": "Part VI: Nash Equilibrium Connection",
+      "startLine": 136,
+      "endLine": 168,
+      "summary": "Prose sketch of Nash's (1950) application: best response correspondence BR:S→2^S satisfies Kakutani conditions when strategy spaces are simplices of mixed strategies. A Kakutani fixed point of BR is a Nash equilibrium. File summary confirms 1 axiom, 0 sorries."
     }
   ],
   "conclusion": {
-    "summary": "Kakutani framework formalized with 1 axiom (the main theorem). Brouwer recovered as corollary. Nash equilibrium connection sketched.",
+    "summary": "The Kakutani fixed point theorem framework is formalized with 8 definitions, 3 proved theorems, and 1 axiom (the main theorem). Brouwer's fixed point theorem is recovered as a corollary, and the connection to Nash equilibrium existence is sketched.",
+    "implications": "Kakutani's theorem is the central tool for existence proofs in mathematical economics: Nash equilibria (Nash 1950), Arrow-Debreu general equilibria (1954), and Walrasian equilibria. A Lean formalization would enable machine-verified proofs of fundamental economic existence theorems. The axiom kakutani_finite_dim is a precise statement of what needs to be proved — simplicial approximation + convergence — providing a roadmap for future formalization work.",
     "openQuestions": [
-      "Prove kakutani_finite_dim from Brouwer via simplicial approximation"
-    ],
-    "implications": ""
+      "Prove kakutani_finite_dim from Brouwer via simplicial approximation: the standard proof approximates F by piecewise-linear single-valued maps, applies Brouwer to each, and takes a convergent subsequence using compactness and upper hemicontinuity",
+      "Formalize the infinite-dimensional Kakutani-Fan-Glicksberg theorem: if X is a locally convex topological vector space and S ⊆ X is compact convex, then any UHC F:S→2^S with compact convex values has a fixed point",
+      "Formalize Nash equilibrium existence: define mixed strategies as probability measures on a finite action set, define the best response correspondence, and verify it satisfies the Kakutani conditions"
+    ]
   },
   "crossReferences": [
     {
-      "targetId": "schauder-fixed-point",
-      "relationship": "parent-problem"
+      "id": "schauder-fixed-point",
+      "relationship": "parent",
+      "description": "Schauder Fixed Point Theorem — the infinite-dimensional generalization that Kakutani's theorem further extends to set-valued maps"
+    },
+    {
+      "id": "schauder-fixed-point-oq-01",
+      "relationship": "sibling",
+      "description": "Schauder Projection Lemma — a technical tool in the Schauder/Kakutani proof chain"
+    },
+    {
+      "id": "brouwer-fixed-point",
+      "relationship": "related",
+      "description": "Brouwer Fixed Point Theorem — recovered as a corollary of Kakutani in this entry"
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Summary

- Added 6 detailed annotations to `schauder-fixed-point-oq-03` (Kakutani Fixed Point Theorem) covering set-valued map framework, upper hemicontinuity, fixed point definitions, the axiomatized main theorem, Brouwer-as-corollary, and Nash equilibrium connection
- Expanded `meta.json` with 7 detailed sections (with line ranges), 4 key insights (was empty), comprehensive historicalContext (Kakutani 1941, Nash 1950 Nobel connection, Glicksberg-Fan generalizations, Arrow-Debreu 1954), and 3 open questions in conclusion
- Fixed `crossReferences` to use `id` field consistently and added descriptions

## Annotations Added

- `ann-set-valued-map`: SetValuedMap framework, graph, HasNonemptyValues/HasClosedValues/HasConvexValues predicates
- `ann-upper-hemicontinuity`: UHC definition, continuous_is_uhc theorem, ε-δ characterization
- `ann-fixed-point-defs`: IsFixedPoint, fixedpoint_singlevalued bridge lemma
- `ann-kakutani-axiom`: The axiomatized main theorem, simplicial approximation context, honest mathematical status
- `ann-brouwer-corollary`: Four Kakutani conditions for singletons, brouwer_from_kakutani proof
- `ann-nash-connection`: Best response correspondence, Nash equilibrium as Kakutani fixed point

🤖 Generated with [Claude Code](https://claude.com/claude-code)