### PR TITLE
Enrich Vandermonde Identity OQ04-OQ01: add annotations, sections, historicalContext

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-01/annotations.json
@@ -1,1 +1,98 @@
-[]
+[
+  {
+    "id": "ann-split-definitions",
+    "proofId": "binomial-theorem-oq-04-oq-01",
+    "range": { "startLine": 36, "endLine": 42 },
+    "type": "definition",
+    "title": "Split Map: lowPart and highPart Definitions",
+    "content": "lowPart m S = S.filter (· < m) retains elements of S strictly below the threshold m. highPart m S = (S.filter (m ≤ ·)).image (· - m) retains elements ≥ m then shifts them down by m. Together these define the split map S ↦ (lowPart m S, highPart m S), which is the forward direction of the bijection. The shift in highPart is what makes the high part a subset of range(n) when S ⊆ range(m+n): if y ∈ S with y ≥ m and y < m+n, then y-m ∈ {0,...,n-1}. This 'normalize by shifting' technique is fundamental to Finset bijections involving ranges.",
+    "mathContext": "$\\text{lowPart}(m, S) = \\{x \\in S : x < m\\}$, $\\text{highPart}(m, S) = \\{x - m : x \\in S, x \\geq m\\}$",
+    "significance": "key",
+    "relatedConcepts": ["Finset.filter", "Finset.image", "threshold split", "normalization by shift", "range bijection"],
+    "prerequisites": ["Finset.filter in Mathlib", "Finset.image (· - m)", "Nat subtraction semantics"]
+  },
+  {
+    "id": "ann-merge-definition",
+    "proofId": "binomial-theorem-oq-04-oq-01",
+    "range": { "startLine": 48, "endLine": 50 },
+    "type": "definition",
+    "title": "Merge Map: Inverse of the Split",
+    "content": "merge m A B = A ∪ B.image (· + m) is the inverse of the split: it combines A ⊆ range(m) and B ⊆ range(n) into a subset of range(m+n) by 'upshifting' B by m. The union is disjoint because A ⊆ range(m) and B.image(·+m) ⊆ {m,...,m+n-1}; this disjointness is established in merge_card using Finset.disjoint_left. The merge and split are mutually inverse: merge_lowPart_highPart and lowPart_merge + highPart_merge establish both directions of the bijection roundtrip.",
+    "mathContext": "$\\text{merge}(m, A, B) = A \\cup \\{b + m : b \\in B\\}$",
+    "significance": "key",
+    "relatedConcepts": ["Finset.union", "Finset.image (· + m)", "disjoint union", "inverse map", "upshift"],
+    "prerequisites": ["Finset.image with (· + m)", "disjoint union = disjoint + card additive", "range(m) ∩ {m,...} = ∅"]
+  },
+  {
+    "id": "ann-lowpart-card",
+    "proofId": "binomial-theorem-oq-04-oq-01",
+    "range": { "startLine": 70, "endLine": 92 },
+    "type": "theorem",
+    "title": "lowPart_card_add_highPart_card: Card Partition",
+    "content": "Proves |lowPart m S| + |highPart m S| = |S|: the split preserves total cardinality. The proof partition S into two disjoint pieces (below and above threshold) via S = S.filter(·<m) ∪ S.filter(m≤·), uses Finset.card_union_of_disjoint (disjointness holds by ω arithmetic on the filter conditions), then shows highPart has the same cardinality as the high-filter via Finset.card_image_of_injOn (the subtraction (·-m) is injective on elements where m ≤ x, proved by omega). This cardinality result is used in card_fiber to verify the fiber has the right size.",
+    "mathContext": "$|\\text{lowPart}(m,S)| + |\\text{highPart}(m,S)| = |S|$. The split $(S_{<m}, S_{\\geq m} - m)$ partitions $S$ without duplication.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.card_union_of_disjoint", "Finset.card_image_of_injOn", "injective subtraction", "partition cardinality"],
+    "prerequisites": ["Finset.disjoint_filter", "omega for ≤/< conditions on ℕ", "Set.InjOn and Finset.card_image_of_injOn"]
+  },
+  {
+    "id": "ann-roundtrip",
+    "proofId": "binomial-theorem-oq-04-oq-01",
+    "range": { "startLine": 98, "endLine": 139 },
+    "type": "theorem",
+    "title": "Round-Trip Properties: Split and Merge are Mutually Inverse",
+    "content": "Three theorems establish the bijection roundtrip. lowPart_merge (hA, hB): lowPart m (merge m A B) = A — when merging A ⊆ range(m) with B shifted up, the low part recovers exactly A (the B-elements exceed m, so they're excluded). highPart_merge (hA, hB): highPart m (merge m A B) = B — the high-filter picks exactly the shifted B elements, and shifting down recovers B. merge_lowPart_highPart (hS): merge m (lowPart m S) (highPart m S) = S — splitting then merging recovers the original set (by cases: if x < m it's in the low part, else it's in the high part and the ±m shifts cancel). Together these three theorems certify that split and merge are inverse bijections on their respective domains.",
+    "mathContext": "$\\text{lowPart}(m, \\text{merge}(m,A,B)) = A$, $\\text{highPart}(m, \\text{merge}(m,A,B)) = B$, $\\text{merge}(m, \\text{lowPart}(m,S), \\text{highPart}(m,S)) = S$",
+    "significance": "key",
+    "relatedConcepts": ["bijection inverse", "roundtrip property", "Finset extensionality", "by_cases on x < m", "omega for shift cancellation"],
+    "prerequisites": ["Finset.ext_iff (set equality via membership)", "rcases pattern matching on Or", "convert tactic for definitional equality up to omega"]
+  },
+  {
+    "id": "ann-fiber",
+    "proofId": "binomial-theorem-oq-04-oq-01",
+    "range": { "startLine": 170, "endLine": 236 },
+    "type": "insight",
+    "title": "Fiber Decomposition: card_fiber is the Combinatorial Heart",
+    "content": "fiber m n r k = ((range(m+n)).powersetCard r).filter(fun S => (lowPart m S).card = k) is the k-th fiber: r-subsets of range(m+n) whose low part has exactly k elements. The main combinatorial fact is card_fiber: |fiber m n r k| = C(m,k)·C(n,r-k). The proof uses Finset.card_bij with the bijection (A,B) ↔ merge m A B. The three conditions — maps into target (uses lowPart_subset_range, highPart_subset_range, and lowPart_card_add_highPart_card for the cardinality constraint), injectivity (via the calc chain S₁ = merge(low S₁, high S₁) = merge(low S₂, high S₂) = S₂), and surjectivity (witness merge m A B) — are all verified using the roundtrip theorems. The powersetCard_eq_biUnion_fiber lemma decomposes all r-subsets into disjoint fibers over k ∈ {0,...,r}.",
+    "mathContext": "$|\\text{fiber}(m,n,r,k)| = \\binom{m}{k}\\binom{n}{r-k}$. Decomposition: $\\binom{m+n}{r}\\text{-subsets} = \\bigsqcup_{k=0}^r \\text{fiber}(m,n,r,k)$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.card_bij", "fiber decomposition", "powersetCard", "Finset.biUnion", "PairwiseDisjoint fibers"],
+    "prerequisites": ["Finset.card_bij (bijection → equal cardinality)", "Finset.card_powersetCard = Nat.choose", "PairwiseDisjoint for disjoint biUnion card"]
+  },
+  {
+    "id": "ann-vandermonde-main",
+    "proofId": "binomial-theorem-oq-04-oq-01",
+    "range": { "startLine": 242, "endLine": 263 },
+    "type": "insight",
+    "title": "vandermonde_combinatorial: Main Theorem via Fiber Counting",
+    "content": "vandermonde_combinatorial m n r proves C(m+n,r) = Σ_{k=0}^r C(m,k)·C(n,r-k) by a clean three-step argument: (1) rewrite LHS as |powersetCard r (range(m+n))| using card_powersetCard + card_range; (2) rewrite as |biUnion over k of fiber m n r k| using powersetCard_eq_biUnion_fiber; (3) apply card_biUnion (valid since fibers are pairwise disjoint by fiber_disjoint) and then Finset.sum_congr to reduce each term to card_fiber. The proof is just 4 lines after the lemmas are available. This exemplifies the Lean approach to combinatorial bijection proofs: build up the bijection infrastructure (split/merge/fiber), then the main theorem is essentially bookkeeping.",
+    "mathContext": "$\\binom{m+n}{r} = \\left|\\bigsqcup_{k=0}^{r} \\text{fiber}(m,n,r,k)\\right| = \\sum_{k=0}^{r} \\left|\\text{fiber}(m,n,r,k)\\right| = \\sum_{k=0}^{r} \\binom{m}{k}\\binom{n}{r-k}$",
+    "significance": "key",
+    "relatedConcepts": ["Vandermonde convolution", "card_biUnion for disjoint union", "sum_congr", "powersetCard decomposition"],
+    "prerequisites": ["card_fiber", "fiber_disjoint (PairwiseDisjoint)", "powersetCard_eq_biUnion_fiber", "Finset.card_biUnion"]
+  },
+  {
+    "id": "ann-sum-squares",
+    "proofId": "binomial-theorem-oq-04-oq-01",
+    "range": { "startLine": 286, "endLine": 299 },
+    "type": "insight",
+    "title": "sum_squares_combinatorial: C(2n,n) = Σ C(n,k)²",
+    "content": "sum_squares_combinatorial n proves C(2n,n) = Σ_{k=0}^n C(n,k)² by specializing Vandermonde with m = n. The key step: set m = n in vandermonde_combinatorial to get C(2n,n) = Σ_{k=0}^n C(n,k)·C(n,n-k). Then apply Nat.choose_symm (C(n,n-k) = C(n,k)) to convert C(n,n-k) to C(n,k), giving C(n,k)·C(n,k) = C(n,k)². This identity has a natural combinatorial interpretation: an n-subset of a 2n-element set can be constructed by choosing k elements from the first n and n-k from the second n; summing over k gives the total count. The central binomial coefficient C(2n,n) is central to Catalan numbers, random walks, and the Wallis product for π.",
+    "mathContext": "$\\binom{2n}{n} = \\sum_{k=0}^{n} \\binom{n}{k}^2$. Specialization of Vandermonde at $m = n$, using $\\binom{n}{n-k} = \\binom{n}{k}$.",
+    "significance": "key",
+    "relatedConcepts": ["central binomial coefficient", "Nat.choose_symm", "sum of squares of binomials", "Catalan numbers", "Wallis product"],
+    "prerequisites": ["vandermonde_combinatorial", "Nat.choose_symm (Nat.choose n (n-k) = Nat.choose n k for k ≤ n)", "sq (a^2 = a*a)"]
+  },
+  {
+    "id": "ann-native-decide",
+    "proofId": "binomial-theorem-oq-04-oq-01",
+    "range": { "startLine": 267, "endLine": 281 },
+    "type": "technique",
+    "title": "Concrete Verifications via native_decide",
+    "content": "Four concrete examples verify the split-merge bijection computationally. (1) C(8,4) = 70 — the value of C(5+3,4). (2) lowPart 5 {0,1,4,6} = {0,1,4}: elements below threshold 5 are {0,1,4}. (3) highPart 5 {0,1,4,6} = {1}: the element 6 ≥ 5, shifted down: 6-5=1. (4) merge 5 {0,1,4} {1} = {0,1,4,6}: the upshift puts 1+5=6 back. The last example also verifies C(2·4,4) = Σ C(4,k)² = 70 (sum: 1+16+36+16+1 = 70). native_decide uses kernel evaluation for decidable propositions — it's fast for small Finsets and provides a sanity check that the definitions behave as intended.",
+    "mathContext": "$\\text{lowPart}(5, \\{0,1,4,6\\}) = \\{0,1,4\\}$, $\\text{highPart}(5, \\{0,1,4,6\\}) = \\{1\\}$ (since $6-5=1$), $\\text{merge}(5, \\{0,1,4\\}, \\{1\\}) = \\{0,1,4,6\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["native_decide tactic", "decidable computation", "sanity check", "concrete bijection example"],
+    "prerequisites": ["native_decide for Finset decidability", "DecidableEq ℕ", "Finset equality is decidable"]
+  }
+]

--- a/src/data/proofs/binomial-theorem-oq-04-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-01/meta.json
@@ -32,15 +32,16 @@
     ]
   },
   "overview": {
-    "historicalContext": "Vandermonde's identity (1772) states C(m+n,r) = Σ_{k=0}^r C(m,k)·C(n,r-k). The algebraic proof uses polynomial multiplication: (1+x)^m · (1+x)^n = (1+x)^{m+n}. But there is a beautiful combinatorial proof via an explicit bijection: choose r elements from m+n by splitting at position m — the low-part has k elements from {0,...,m-1} and the high-part has r-k elements from {m,...,m+n-1}.",
+    "historicalContext": "Vandermonde's identity C(m+n,r) = Σ_{k=0}^r C(m,k)·C(n,r-k) is one of the fundamental identities in combinatorics, with a history stretching back centuries before Vandermonde.\n\n**Chu Shih-chieh (1303 CE)**: In *Precious Mirror of the Four Elements*, the Chinese mathematician Zhu Shijie (Chu Shih-chieh) listed several binomial coefficient identities, including what we now call Vandermonde's convolution. This predates the European rediscovery by nearly 500 years.\n\n**Pascal (1654)**: In *Traité du triangle arithmétique*, Pascal implicitly used the identity in his recursive construction of the arithmetic triangle. The identity is essentially equivalent to Pascal's rule applied across rows.\n\n**Vandermonde (1772)**: Alexandre-Théophile Vandermonde's *Mémoire sur des irrationnelles de différens ordres avec une application au cercle* provided one of the first systematic treatments of the identity in Europe, establishing it as a special case of his more general hypergeometric formula. Ironically, Vandermonde is better known for the determinant bearing his name (which he did NOT introduce) than for the identity that does bear his name.\n\n**The algebraic proof** (polynomial multiplication): (1+x)^m · (1+x)^n = (1+x)^{m+n}; comparing coefficients of x^r on both sides yields Vandermonde's identity. This proof is short but gives no insight into *why* the identity holds.\n\n**The combinatorial proof** (split-by-threshold): Choose r elements from {0,...,m+n-1} by classifying them as 'low' (below m) or 'high' (m or above). Any r-subset S has k elements in the low part and r-k in the high part for some k ∈ {0,...,r}. The low part is a k-subset of {0,...,m-1} (C(m,k) choices), and the high part is an (r-k)-subset of {0,...,n-1} after shifting (C(n,r-k) choices). This bijective argument, formalized here, makes the identity *self-explanatory*.\n\n**Chu-Vandermonde generalization**: Gauss (1812) generalized Vandermonde's identity to hypergeometric series: ₂F₁(-n, b; c; 1) = (c-b)_n / (c)_n. Modern combinatorics uses the identity for convolution formulas in generating function theory, WZ (Wilf-Zeilberger) certification, and the theory of symmetric functions.",
     "problemStatement": "Prove Vandermonde's identity combinatorially, via an explicit bijection on Finsets, without algebraic or generating function arguments.",
     "text": "The bijection: for S ⊆ range(m+n) with |S|=r, define split(S) = (S ∩ range(m), S∩[m,m+n) - m). The forward map sends S to (lowPart m S, highPart m S). The inverse merge(A,B) = A ∪ B.image(·+m). These are mutually inverse: split(merge(A,B)) = (A,B) and merge(split(S)) = S. Since C(m,k)·C(n,r-k) counts pairs of appropriate sizes, summing over k gives C(m+n,r).",
     "proofStrategy": "Define lowPart, highPart, and merge explicitly on Finsets. Prove the roundtrip properties: split∘merge = id and merge∘split = id. Derive Vandermonde's formula by cardinality counting via the bijection.",
     "keyInsights": [
-      "Split at threshold: elements < m go to the low part, elements ≥ m shift down to the high part",
-      "Merge is the inverse: union with upshift reverses the split",
-      "Bijective proof: directly establishes C(m+n,r) = Σ C(m,k)·C(n,r-k) without algebra",
-      "Cleaner than polynomial proof: gives combinatorial insight, not just algebraic identity"
+      "**The split-by-threshold bijection** is more informative than the algebraic proof: lowPart m S = S.filter(·<m) and highPart m S = (S.filter(m≤·)).image(·-m) partition S into low and high pieces normalized to their respective ranges. The critical insight is that the high part is *shifted* by subtracting m, so it lands in range(n) rather than range(m,m+n). This normalization is what makes the bijection with (range m)-subsets × (range n)-subsets work.",
+      "**Fiber decomposition**: The key intermediate structure is `fiber m n r k` — the set of all r-subsets of range(m+n) whose low part has exactly k elements. The main lemma `card_fiber` proves |fiber m n r k| = C(m,k)·C(n,r-k) via `Finset.card_bij`. The bijection witness is (A,B) ↔ merge m A B, and the three conditions (maps-into, injectivity, surjectivity) all reduce to the roundtrip theorems lowPart_merge, highPart_merge, and merge_lowPart_highPart.",
+      "**Injectivity via calc chain**: The injectivity proof in card_fiber is a two-line calc: S₁ = merge(low S₁, high S₁) = merge(low S₂, high S₂) = S₂ — using merge_lowPart_highPart twice and the hypothesis (low S₁, high S₁) = (low S₂, high S₂). This is the characteristic pattern for injectivity of bijections defined by roundtrip: the identity S = merge(low S, high S) lets you substitute and conclude S₁ = S₂.",
+      "**Sum-of-squares corollary** C(2n,n) = Σ C(n,k)²: Setting m = n in Vandermonde gives C(2n,n) = Σ C(n,k)·C(n,n-k). Then Nat.choose_symm (C(n,n-k) = C(n,k)) converts the product to a square. Combinatorially: each n-subset of a 2n-set is uniquely determined by its intersection with the first half, so the sum over k (choosing k from the first n, and n-k from the second n) counts all C(2n,n) subsets. The central binomial coefficient C(2n,n) appears in random walk return probabilities, Catalan numbers (C_n = C(2n,n)/(n+1)), and the Wallis product for π.",
+      "**Bijective proofs vs algebraic proofs**: The algebraic proof (polynomial identity) is a 2-line proof in Lean using Nat.add_choose_eq. The bijective proof is 299 lines. The value of the longer proof is not efficiency but *explanation*: it reveals the combinatorial structure that makes the identity true, and the same technique (split a set by threshold, count pairs) generalizes to other sum identities. The Finset infrastructure (lowPart, highPart, merge, fiber) developed here is reusable for similar combinatorial bijection arguments."
     ],
     "prerequisites": [
       "Finset theory: filter, image, union, card",
@@ -49,12 +50,13 @@
     ]
   },
   "conclusion": {
-    "summary": "Vandermonde's identity proved via explicit bijection: split-by-threshold map, merge inverse, bijectivity verified. 14 theorems, 299 lines, 0 axioms.",
-    "implications": "Bijective proofs of combinatorial identities are valuable because they reveal the combinatorial structure that explains 'why' the identity holds. This approach generalizes to other convolution identities (Chu-Vandermonde, Zhu-Vandermonde variants).",
+    "summary": "Vandermonde's identity C(m+n,r) = Σ C(m,k)·C(n,r-k) proved via explicit split-by-threshold bijection. 14 theorems, 4 definitions, 299 lines, 0 axioms. The sum-of-squares corollary C(2n,n) = Σ C(n,k)² follows by symmetry.",
+    "implications": "Bijective proofs of combinatorial identities are valuable because they reveal *why* identities hold, not just that they hold. The split/merge/fiber infrastructure developed here is a reusable pattern for Lean formalization of combinatorial bijection proofs. The fiber decomposition technique — partitioning powersetCard by a statistic and computing fiber cardinalities — applies broadly to convolution-type identities.",
     "openQuestions": [
-      "Extend to the Chu-Vandermonde identity for hypergeometric functions",
-      "Prove the Zhu-Vandermonde generalization for negative integers",
-      "Apply the bijection technique to other binomial sum identities"
+      "Prove the Chu-Vandermonde identity for hypergeometric functions: ₂F₁(-n, b; c; 1) = (c-b)_n/(c)_n, generalizing the combinatorial proof to the complex analytic setting",
+      "Formalize Zeilberger's WZ algorithm to automatically verify binomial coefficient identities; Vandermonde's identity is in WZ's catalog of certifiable identities",
+      "Prove the q-Vandermonde identity (Gauss binomial coefficients): C_q(m+n,r) = Σ q^{k(m-k)} C_q(m,k)·C_q(n,r-k), which counts subspaces of vector spaces over GF(q)",
+      "Apply the fiber bijection technique to other convolutions: the Leibniz identity for derivatives, the convolution formula for Stirling numbers, or the ballot problem bijection"
     ]
   },
   "leanFile": {
@@ -66,10 +68,77 @@
   },
   "crossReferences": [
     {
-      "targetId": "binomial-theorem",
+      "id": "binomial-theorem",
       "relationship": "extends",
-      "description": "Binomial theorem and coefficients; OQ-04-OQ-01 proves Vandermonde's identity via combinatorial bijection"
+      "description": "Binomial theorem and coefficients — the parent entry establishing Nat.choose and C(n,k) in the gallery"
+    },
+    {
+      "id": "binomial-theorem-oq-04",
+      "relationship": "answers",
+      "description": "Open question OQ-04: can Vandermonde's identity be proved combinatorially? This file answers YES with an explicit bijection"
+    },
+    {
+      "id": "arithmetic-series-oq-02-oq-01",
+      "relationship": "related",
+      "description": "q-Hockey Stick Identity — another combinatorial identity in the gallery using Finset-theoretic induction"
     }
   ],
-  "sections": []
+  "sections": [
+    {
+      "id": "sec-split-map",
+      "title": "Part I–II: Split and Merge Maps",
+      "startLine": 32,
+      "endLine": 51,
+      "summary": "Defines the three core maps: lowPart m S = S.filter(·<m) (elements below threshold), highPart m S = (S.filter(m≤·)).image(·-m) (elements ≥ m, shifted down), and merge m A B = A ∪ B.image(·+m) (the inverse: A plus B shifted up by m)."
+    },
+    {
+      "id": "sec-range-properties",
+      "title": "Part III: Range and Cardinality Properties",
+      "startLine": 53,
+      "endLine": 93,
+      "summary": "lowPart_subset_range: lowPart m S ⊆ range m. highPart_subset_range: highPart m S ⊆ range n (when S ⊆ range(m+n)). lowPart_card_add_highPart_card: |lowPart m S| + |highPart m S| = |S| (proved via partition + injectivity of (·-m) on the high filter)."
+    },
+    {
+      "id": "sec-roundtrip",
+      "title": "Part IV: Round-Trip Properties",
+      "startLine": 94,
+      "endLine": 140,
+      "summary": "Three theorems certifying the bijection roundtrip: lowPart_merge (merge then split recovers A), highPart_merge (merge then split recovers B), merge_lowPart_highPart (split then merge recovers S). Together they establish split and merge are mutually inverse maps."
+    },
+    {
+      "id": "sec-merge-card",
+      "title": "Part V: Merge Cardinality and Range",
+      "startLine": 141,
+      "endLine": 165,
+      "summary": "merge_card: |merge m A B| = |A| + |B| (proved by disjointness of A and B.image(·+m), using Finset.card_union_of_disjoint). merge_subset_range: merge m A B ⊆ range(m+n) when A ⊆ range m, B ⊆ range n."
+    },
+    {
+      "id": "sec-fiber",
+      "title": "Part VI: Fiber Bijection — card_fiber",
+      "startLine": 166,
+      "endLine": 236,
+      "summary": "Defines fiber m n r k = r-subsets of range(m+n) with |lowPart| = k. Key lemmas: fiber_disjoint (fibers for different k are disjoint), powersetCard_eq_biUnion_fiber (all r-subsets = disjoint union of fibers). Main: card_fiber: |fiber m n r k| = C(m,k)·C(n,r-k), proved by Finset.card_bij with the (A,B) ↔ merge m A B bijection."
+    },
+    {
+      "id": "sec-vandermonde",
+      "title": "Part VII: Vandermonde's Identity — Main Theorem",
+      "startLine": 238,
+      "endLine": 263,
+      "summary": "vandermonde_combinatorial m n r: C(m+n,r) = Σ_{k=0}^r C(m,k)·C(n,r-k). Proof: LHS = |powersetCard r (range(m+n))| = |biUnion fibers| = Σ |fiber k| = Σ C(m,k)·C(n,r-k). The disjoint union uses fiber_disjoint; card_biUnion applies; card_fiber handles each summand."
+    },
+    {
+      "id": "sec-examples",
+      "title": "Part VIII: Concrete Verifications",
+      "startLine": 264,
+      "endLine": 281,
+      "summary": "Four native_decide examples: C(8,4)=70, lowPart 5 {0,1,4,6}={0,1,4}, highPart 5 {0,1,4,6}={1} (since 6-5=1), merge 5 {0,1,4} {1}={0,1,4,6}, and the sum-of-squares check C(8,4)=Σ C(4,k)²=70."
+    },
+    {
+      "id": "sec-sum-squares",
+      "title": "Part IX: Sum-of-Squares Corollary",
+      "startLine": 282,
+      "endLine": 299,
+      "summary": "sum_squares_combinatorial n: C(2n,n) = Σ_{k=0}^n C(n,k)². Derived from vandermonde_combinatorial at m=n, using Nat.choose_symm to convert C(n,n-k) to C(n,k) and sq to rewrite the product as a square."
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- Added 8 detailed annotations to `binomial-theorem-oq-04-oq-01` (Vandermonde's Identity via Combinatorial Bijection) covering all 9 parts of the Lean file
- Expanded `meta.json` with 8 sections, 5 deep keyInsights, comprehensive historicalContext (Chu Shih-chieh 1303 CE, Pascal 1654, Vandermonde 1772), 3 cross-references, and 4 open questions

## Annotations Added

- `ann-split-definitions`: lowPart/highPart definitions, threshold-split pattern, normalization by shift
- `ann-merge-definition`: merge as inverse map, upshift, disjoint union structure
- `ann-lowpart-card`: cardinality partition lemma, injective subtraction via InjOn
- `ann-roundtrip`: three roundtrip theorems certifying the bijection (lowPart_merge, highPart_merge, merge_lowPart_highPart)
- `ann-fiber`: fiber decomposition, card_fiber via Finset.card_bij, injectivity calc chain
- `ann-vandermonde-main`: main theorem proof via fiber counting, card_biUnion
- `ann-sum-squares`: C(2n,n) = Σ C(n,k)² corollary via Nat.choose_symm
- `ann-native-decide`: concrete examples verifying the split/merge bijection computationally

## Historical Context Added

Expanded from 2 sentences to full narrative covering:
- Chu Shih-chieh (1303 CE) — earliest known statement of the identity
- Pascal (1654) — implicit use in arithmetic triangle
- Vandermonde (1772) — European rediscovery (note: irony that Vandermonde is better known for the determinant he didn't introduce)
- Gauss (1812) — hypergeometric generalization
- Bijective vs algebraic proof comparison

🤖 Generated with [Claude Code](https://claude.com/claude-code)