### PR TITLE
Audit: cycle 20 tracker updates — 7 proofs verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -17,9 +17,9 @@
   },
   "entries": {
     "abel-ruffini": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-03-24T02:59:23Z",
+      "lastAudited": "2026-04-03T14:00:39Z",
       "result": "clean"
     },
     "abel-ruffini-oq-04": {
@@ -379,10 +379,10 @@
       "result": "clean"
     },
     "bertrands-postulate-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-03-24T03:35:12Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-03T14:00:39Z",
+      "result": "clean"
     },
     "bezout-identity": {
       "auditCount": 1,
@@ -433,10 +433,10 @@
       "result": "clean"
     },
     "bezout-identity-oq-03-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-03-24T03:49:23Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-03T14:00:39Z",
+      "result": "clean"
     },
     "bezout-identity-oq-03-oq-01-oq-01": {
       "auditCount": 1,
@@ -493,10 +493,10 @@
       "result": "clean"
     },
     "binomial-theorem-oq-01-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-03-24T03:49:23Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-03T14:00:39Z",
+      "result": "clean"
     },
     "binomial-theorem-oq-02": {
       "auditCount": 1,
@@ -1184,9 +1184,9 @@
       "result": "clean"
     },
     "chinese-remainder-constructive": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-03-24T04:35:30Z",
+      "lastAudited": "2026-04-03T14:00:39Z",
       "result": "clean"
     },
     "chinese-remainder-constructive-oq-03": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -23,9 +23,9 @@
       "result": "clean"
     },
     "abel-ruffini-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-03-24T02:59:23Z",
+      "lastAudited": "2026-04-03T13:58:53Z",
       "result": "clean"
     },
     "abel-ruffini-oq-04-oq-01": {


### PR DESCRIPTION
## Summary

Tracker updates from audit cycle 20:

- abel-ruffini-oq-04: clean (0 sorries, 0 axioms, mathlib badge)
- abel-ruffini: clean (0 sorries, 0 axioms, mathlib badge)
- bertrands-postulate-oq-03: clean (3 axioms match claimed, axiomatized status correct)
- binomial-theorem-oq-01-oq-01: clean
- bezout-identity-oq-03-oq-01: clean
- chinese-remainder-constructive: clean

All proofs verified by reading Lean source files for actual axiom/sorry counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)