### PR TITLE
Enrich Gauss AGM OQ-04: add annotations, sections, historicalContext

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-04/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-04/annotations.json
@@ -1,1 +1,86 @@
-[]
+[
+  {
+    "id": "ann-agm-definitions",
+    "proofId": "amgm-inequality-oq-04",
+    "range": { "startLine": 45, "endLine": 73 },
+    "type": "definition",
+    "title": "AGM Iteration: agmStep, agmSeq, agmA, agmB",
+    "content": "agmStep (a b) = ((a+b)/2, √(ab)) is the single-step AGM map, producing the arithmetic mean and geometric mean. agmSeq a b n iterates this from (a₀,b₀) = (a,b), giving the pair (aₙ,bₙ) at step n. agmA and agmB extract the first and second components respectively. The recurrence theorems agmA_succ and agmB_succ unpack the iteration: agmA a b (n+1) = (agmA a b n + agmB a b n) / 2, agmB a b (n+1) = √(agmA a b n * agmB a b n). These are proved by simp using the definitions. The `noncomputable` annotation is needed because Real.sqrt is noncomputable (it depends on Classical.choice for the real square root).",
+    "mathContext": "$a_{n+1} = \\frac{a_n + b_n}{2}$, $b_{n+1} = \\sqrt{a_n b_n}$, starting from $(a_0, b_0) = (a, b)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["arithmetic mean", "geometric mean", "iteration in Lean", "noncomputable in Lean 4", "Nat.rec pattern matching"],
+    "prerequisites": ["Real.sqrt in Mathlib", "noncomputable def", "Prod.1 and Prod.2 for pair access"]
+  },
+  {
+    "id": "ann-am-ge-gm",
+    "proofId": "amgm-inequality-oq-04",
+    "range": { "startLine": 79, "endLine": 88 },
+    "type": "theorem",
+    "title": "am_ge_gm: (a+b)/2 ≥ √(ab)",
+    "content": "am_ge_gm proves (a+b)/2 ≥ √(ab) for non-negative reals. The proof: rewrite (a+b)/2 as √(((a+b)/2)²) (valid since (a+b)/2 ≥ 0), then apply Real.sqrt_le_sqrt to reduce to the algebraic bound ((a+b)/2)² ≥ ab. The latter is nlinarith [sq_nonneg (a-b)]: it unfolds to (a-b)²/4 ≥ 0. This is the classic proof that AM-GM follows from (a-b)² ≥ 0. The key Lean pattern is `rw [← Real.sqrt_sq hsum]` followed by `Real.sqrt_le_sqrt` — converting an inequality between non-negative reals to an inequality between their squares, handled by monotonicity of sqrt.",
+    "mathContext": "$\\frac{a+b}{2} \\geq \\sqrt{ab}$ because $\\left(\\frac{a+b}{2}\\right)^2 - ab = \\frac{(a-b)^2}{4} \\geq 0$.",
+    "significance": "key",
+    "relatedConcepts": ["AM-GM inequality", "Real.sqrt_le_sqrt (monotonicity)", "nlinarith with sq_nonneg", "Real.sqrt_sq (sqrt of square)"],
+    "prerequisites": ["Real.sqrt_sq: √(x²) = x for x ≥ 0", "Real.sqrt_le_sqrt: monotone", "nlinarith: nonlinear arithmetic"]
+  },
+  {
+    "id": "ann-sandwich-monotone",
+    "proofId": "amgm-inequality-oq-04",
+    "range": { "startLine": 93, "endLine": 141 },
+    "type": "theorem",
+    "title": "Sandwich and Monotonicity: bₙ ≤ bₙ₊₁ ≤ aₙ₊₁ ≤ aₙ",
+    "content": "Four theorems establish the key ordering invariant. agm_pos_aux (proved simultaneously for a and b by induction): both sequences stay positive — base case from ha, hb; inductive step uses linarith for a (arithmetic mean of positives is positive) and Real.sqrt_pos_of_pos for b. agmB_le_agmA (bₙ ≤ aₙ by induction, using am_ge_gm): base case from hab, inductive step applies am_ge_gm at each step. agmA_antitone (a-sequence is decreasing): antitone_nat_of_succ_le reduces to aₙ₊₁ ≤ aₙ, which is (aₙ+bₙ)/2 ≤ aₙ, equivalent to bₙ ≤ aₙ. agmB_monotone (b-sequence is increasing): by a calc showing bₙ = √(bₙ·bₙ) ≤ √(aₙ·bₙ) = bₙ₊₁ since aₙ ≥ bₙ. Together: b ≤ b₁ ≤ b₂ ≤ ... ≤ a₂ ≤ a₁ ≤ a.",
+    "mathContext": "$b = b_0 \\leq b_1 \\leq b_2 \\leq \\cdots \\leq a_2 \\leq a_1 \\leq a_0 = a$. Maintained by AM-GM at each step.",
+    "significance": "key",
+    "relatedConcepts": ["sandwich property", "antitone_nat_of_succ_le", "monotone_nat_of_le_succ", "joint induction", "Real.sqrt_le_sqrt for monotone b"],
+    "prerequisites": ["antitone_nat_of_succ_le and monotone_nat_of_le_succ (Mathlib API)", "mul_le_mul_of_nonneg_right for sqrt comparison", "calc chains for √(b·b) ≤ √(a·b)"]
+  },
+  {
+    "id": "ann-gap-contraction",
+    "proofId": "amgm-inequality-oq-04",
+    "range": { "startLine": 143, "endLine": 175 },
+    "type": "theorem",
+    "title": "Gap Contraction: aₙ₊₁ - bₙ₊₁ ≤ (aₙ - bₙ)/2",
+    "content": "gap_contracts proves the gap halves at each step: aₙ₊₁ - bₙ₊₁ ≤ (aₙ-bₙ)/2. Unpacking: (aₙ+bₙ)/2 - √(aₙbₙ) ≤ (aₙ-bₙ)/2. This is equivalent to √(aₙbₙ) ≥ bₙ, which is exactly the bₙ-monotonicity result. The final linarith closes the goal once hgm_ge_b (a restatement of bₙ₊₁ ≥ bₙ) is available. gap_bound combines gap_contracts with induction to get the geometric bound: aₙ - bₙ ≤ (a-b)/2ⁿ. This is linear convergence. The actual AGM convergence is quadratic (aₙ - bₙ ≈ constant · 4^{-2^n}), but the linear bound is sufficient to establish that the gap → 0. The `ring` tactic handles the rewriting (a-b)/2^n / 2 = (a-b)/2^{n+1}.",
+    "mathContext": "$a_{n+1} - b_{n+1} = \\frac{a_n+b_n}{2} - \\sqrt{a_n b_n} \\leq \\frac{a_n-b_n}{2}$ since $\\sqrt{a_n b_n} \\geq b_n$. Bound: $a_n - b_n \\leq \\frac{a-b}{2^n}$.",
+    "significance": "key",
+    "relatedConcepts": ["gap contraction", "linear vs quadratic convergence", "geometric bound 1/2^n", "induction on gap_bound", "linarith after restatement"],
+    "prerequisites": ["gap_contracts (one-step halving)", "agmB_monotone (√(a·b) ≥ b)", "induction + ring for /2^n recurrence"]
+  },
+  {
+    "id": "ann-convergence",
+    "proofId": "amgm-inequality-oq-04",
+    "range": { "startLine": 176, "endLine": 242 },
+    "type": "insight",
+    "title": "Convergence to Common Limit via Monotone Convergence Theorem",
+    "content": "The convergence argument uses Mathlib's monotone convergence theorem. agmA_bddBelow: the a-sequence is bounded below by b (b ≤ bₙ ≤ aₙ for all n). agmB_bddAbove: the b-sequence is bounded above by a (bₙ ≤ aₙ ≤ a for all n). These, combined with antitone/monotone, give convergence via tendsto_atTop_ciInf (a-sequence → inf) and tendsto_atTop_ciSup (b-sequence → sup). gap_tendsto_zero: the gap (aₙ - bₙ) → 0 by a squeeze argument: 0 ≤ aₙ-bₙ ≤ (a-b)/2ⁿ, and (a-b)·(1/2)ⁿ → 0 by tendsto_pow_atTop_nhds_zero_of_lt_one. agm_common_limit: inf aₙ = sup bₙ by showing ≥ (since aₙ ≥ bₙ forces inf ≥ sup via a max argument) and = (since the difference = limit of gap = 0 via tendsto_nhds_unique).",
+    "mathContext": "$\\inf_n a_n = \\sup_n b_n = M(a,b)$, proved via $a_n - b_n \\to 0$ and the monotone convergence theorem.",
+    "significance": "key",
+    "relatedConcepts": ["tendsto_atTop_ciInf", "tendsto_atTop_ciSup", "squeeze_zero", "tendsto_nhds_unique", "tendsto_pow_atTop_nhds_zero_of_lt_one"],
+    "prerequisites": ["ciInf/ciSup (conditional infimum/supremum in Mathlib)", "BddBelow/BddAbove types", "tendsto_nhds_unique (limits are unique)", "squeeze_zero: 0 ≤ f ≤ g → g → 0 → f → 0"]
+  },
+  {
+    "id": "ann-agm-value",
+    "proofId": "amgm-inequality-oq-04",
+    "range": { "startLine": 248, "endLine": 273 },
+    "type": "definition",
+    "title": "agm: The AGM as the Infimum of the a-Sequence",
+    "content": "agm a b = ⨅ n, agmA a b n defines the AGM as the infimum (greatest lower bound) of the decreasing a-sequence. Since agm_common_limit proves this infimum equals the supremum of the b-sequence, either choice would work; the infimum is used because the a-sequence is the more natural 'envelope.' agm_eq_limit_A and agm_eq_limit_B confirm the AGM is indeed the limit of both sequences. agm_bounds proves b ≤ agm a b ≤ a: the lower bound uses b = b₀ ≤ b₁ ≤ ... ≤ aₙ, so b is a lower bound for the aₙ (via ciInf_le); the upper bound uses agm ≤ a₀ = a (also via ciInf_le).",
+    "mathContext": "$M(a,b) = \\inf_n a_n = \\lim_{n\\to\\infty} a_n = \\lim_{n\\to\\infty} b_n$, with $b \\leq M(a,b) \\leq a$.",
+    "significance": "supporting",
+    "relatedConcepts": ["ciInf (conditional infimum)", "agm_common_limit", "ciInf_le (infimum is ≤ each term)", "agm_bounds"],
+    "prerequisites": ["ciInf_le (needs BddBelow)", "tendsto_atTop_ciInf gives the tendsto", "agm_common_limit bridges inf and sup"]
+  },
+  {
+    "id": "ann-elliptic-integrals",
+    "proofId": "amgm-inequality-oq-04",
+    "range": { "startLine": 274, "endLine": 306 },
+    "type": "concept",
+    "title": "Elliptic Integral Connection (Axiomatized): Gauss's Deep Theorem",
+    "content": "The three axioms capture Gauss's remarkable 1799 discovery. ellipticK : ℝ → ℝ axiomatizes the complete elliptic integral of the first kind K(k) = ∫₀^{π/2} dθ/√(1-k²sin²θ). ellipticK_zero : K(0) = π/2 (the degenerate case: integrand is identically 1, so K(0) = π/2). agm_ellipticK states Gauss's theorem: M(a,b) = a·π/(2·K(√(1-(b/a)²))). The complementary modulus k' = √(1-(b/a)²) converts between the usual (a,b) parameterization and the k-parameterization of elliptic integrals. These are axiomatized rather than proved because Mathlib 4.26.0 does not have a formalized K(k); it is a deep integral requiring theory of complete elliptic integrals. Notably: ellipticK_zero is consistent (K(0) = ∫₀^{π/2} 1 dθ = π/2) and agm_ellipticK is mathematically true but requires the full Gauss proof using complex analysis and modular forms.",
+    "mathContext": "$K(k) = \\int_0^{\\pi/2} \\frac{d\\theta}{\\sqrt{1-k^2\\sin^2\\theta}}$. Gauss's theorem: $M(a,b) = \\frac{a\\pi}{2K\\!\\left(\\sqrt{1-(b/a)^2}\\right)}$.",
+    "significance": "key",
+    "relatedConcepts": ["complete elliptic integral K(k)", "Gauss AGM theorem", "Legendre's relation", "elliptic modulus and complementary modulus", "axiom in Lean 4"],
+    "prerequisites": ["definition of K(k) as an integral", "complementary modulus k' = √(1-k²)", "Gauss's 1799 discovery (requires complex analysis + modular forms to prove)"]
+  }
+]

--- a/src/data/proofs/amgm-inequality-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04/meta.json
@@ -27,15 +27,16 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Gauss discovered the AGM iteration around 1799 and found its remarkable connection to elliptic integrals. The AGM converges quadratically, making it one of the fastest algorithms for computing elliptic integrals and, via Legendre's relation, for computing pi. The Brent-Salamin algorithm (1976) uses this connection for rapid pi computation.",
+    "historicalContext": "The arithmetic-geometric mean and its connection to elliptic integrals is one of Gauss's most beautiful discoveries, linking elementary iteration to deep transcendental function theory.\n\n**Gauss (1791, 1799)**: Carl Friedrich Gauss first recorded the AGM in his mathematical diary on 30 May 1799 (age 21), noting the remarkable identity M(1, √2) = π/ω where ω is a period of the lemniscate. His *Nachlass* (unpublished notes) developed the theory extensively, connecting AGM to elliptic integrals, theta functions, and modular forms. Gauss recognized that M(1,k') = π/(2K(k)) expresses the elliptic integral K in terms of a rapidly converging iteration.\n\n**Legendre (1811–1828)**: Adrien-Marie Legendre's *Traité des fonctions elliptiques* established elliptic integrals as a systematic theory, discovering Legendre's relation: K·K' + K'·K = π/2 (where K' = K(k'), k' = √(1-k²)). This relation, combined with Gauss's AGM identity, leads to algorithms for computing π.\n\n**Jacobi and theta functions (1829–1832)**: Carl Jacobi connected elliptic integrals to his theta functions θ₁, θ₂, θ₃, θ₄ and showed that the AGM ratio can be expressed in terms of these rapidly converging q-series. Gauss's notebooks contain equivalent formulas, predating Jacobi.\n\n**Brent-Salamin algorithm (1976)**: Richard Brent and Eugene Salamin independently discovered that AGM combined with Legendre's relation gives a formula for π that converges quadratically: starting from a₀=1, b₀=1/√2, the formula π ≈ 4M(a₀,b₀)²/(1-Σ 2^{n+1}(aₙ²-bₙ²)) doubles the number of correct digits with each iteration. This is among the fastest algorithms for computing π to high precision.\n\n**Borwein brothers (1984–1987)**: Jonathan and Peter Borwein used AGM-based algorithms to compute π to millions of digits and developed the theory of 'ultraquadratic' convergence — some AGM-based iterations converge like r^{2^n} for various r. Their book *Pi and the AGM* (1987) is the definitive reference.\n\n**Modern status**: Elliptic integrals remain a rich area with connections to algebraic geometry (elliptic curves), cryptography (elliptic curve cryptography), and physics (period integrals of Calabi-Yau manifolds). Mathlib does not yet have a formalized K(k), making the AGM-elliptic integral connection an active frontier for formalization.",
     "problemStatement": "Define the AGM iteration aₙ₊₁ = (aₙ+bₙ)/2, bₙ₊₁ = sqrt(aₙbₙ) for a >= b > 0. Prove both sequences converge to a common limit M(a,b). State Gauss's theorem: M(a,b) = a*pi/(2*K(sqrt(1-(b/a)^2))).",
     "text": "The arithmetic-geometric mean M(a,b) is the common limit of the AGM iteration. Gauss proved M(a,b) = a*pi/(2*K(k')) where K is the complete elliptic integral of the first kind.",
     "proofStrategy": "The convergence proof proceeds in four steps: (1) AM >= GM gives the sandwich property b_n <= b_{n+1} <= a_{n+1} <= a_n, (2) gap contraction a_{n+1} - b_{n+1} <= (a_n - b_n)/2 gives exponential decay, (3) Mathlib's monotone convergence theorem (tendsto_atTop_ciInf/ciSup) gives existence of both limits, (4) the gap tending to zero forces the limits to coincide.",
     "keyInsights": [
-      "**AM >= GM is the engine**: The inequality (a+b)/2 >= sqrt(ab) ensures the sandwich property at each step, maintaining b_n <= a_n throughout.",
-      "**Quadratic convergence**: The gap a_n - b_n contracts by at least half each step, giving a_n - b_n <= (a-b)/2^n. The actual convergence is even faster (quadratic, not just linear).",
-      "**Gauss's deep connection**: M(a,b) = a*pi/(2*K(k')) links a simple real iteration to elliptic integrals, connecting elementary analysis to deep transcendental function theory.",
-      "**Monotone convergence**: The a-sequence is antitone and bounded below, the b-sequence is monotone and bounded above. Mathlib's `tendsto_atTop_ciInf` and `tendsto_atTop_ciSup` give convergence directly."
+      "**AM-GM is the engine**: am_ge_gm proves (a+b)/2 ≥ √(ab) by the identity ((a+b)/2)² - ab = (a-b)²/4 ≥ 0, handled by nlinarith [sq_nonneg (a-b)]. This single inequality drives the entire convergence: it establishes bₙ ≤ aₙ at each step (sandwich), which in turn implies aₙ is decreasing and bₙ is increasing. The Lean proof uses Real.sqrt_sq to convert to a squared inequality, then Real.sqrt_le_sqrt for monotonicity.",
+      "**Gap halving via squeeze**: The gap contraction aₙ₊₁ - bₙ₊₁ ≤ (aₙ-bₙ)/2 follows elegantly from the observation that bₙ₊₁ = √(aₙbₙ) ≥ bₙ (proved as a calc chain: bₙ = √(bₙ²) ≤ √(aₙbₙ) = bₙ₊₁). This gives aₙ - bₙ ≤ (a-b)/2ⁿ by induction. The actual convergence is quadratic (doubly exponential: gap ≈ C·4^{-2^n}) but the linear bound suffices to prove gap → 0.",
+      "**Monotone convergence + tendsto_nhds_unique**: agm_common_limit identifies the two limits by showing inf aₙ - sup bₙ = lim(aₙ - bₙ) = 0. The key Mathlib tools: tendsto_atTop_ciInf/ciSup for existence, tendsto_nhds_unique to identify the limit of the gap with the limit computed via subtraction. This is a clean application of the separation-of-convergence technique: prove the sequences converge, then prove their limits coincide.",
+      "**The 3 axioms are mathematically honest**: ellipticK, ellipticK_zero, and agm_ellipticK axiomatize K(k) and Gauss's connection theorem. The first two are self-consistent (K(0) = ∫₀^{π/2} 1 dθ = π/2), and the third is deep: Gauss's proof requires the theory of theta functions or analytic continuation. This is a clean separation of what can be proved from Mathlib's current library vs what requires new theory.",
+      "**Connection to Brent-Salamin π computation**: The axiom agm_ellipticK expresses K(k) in terms of AGM. Combined with Legendre's relation K(k)·K(k') + K(k')·K(k) = π/2, one can express π entirely in terms of AGM iterations. Setting a=1, b=1/√2: M(1,1/√2) = π/(2K(1/√2)). Legendre's relation gives K(1/√2) = π/(4M(1,1/√2)). Solving: M(1,1/√2) = π/√2/M(1,1/√2), so M(1,1/√2)² = π/(2√2), giving π = √2·M(1,1/√2)². This is essentially the Brent-Salamin formula."
     ],
     "prerequisites": [
       "Real analysis: monotone convergence for bounded sequences, squeeze theorem",
@@ -44,14 +45,79 @@
     ]
   },
   "conclusion": {
-    "summary": "Fully proves convergence of the Gauss AGM iteration to a common limit M(a,b), with 0 sorries. The sandwich property, gap contraction, and convergence all follow from AM >= GM and Mathlib's monotone convergence. The elliptic integral connection (3 axioms) captures Gauss's deep result linking AGM to K(k).",
-    "implications": "The AGM provides quadratically convergent computation of elliptic integrals and, via Legendre's identity, of pi. The formalization demonstrates how a simple arithmetic iteration connects to deep transcendental function theory.",
+    "summary": "The Gauss AGM iteration is fully formalized: 22 theorems, 8 definitions, 3 axioms (ellipticK function, K(0)=π/2, and Gauss's connection theorem). Convergence to the common limit M(a,b) is machine-verified from AM-GM and Mathlib's monotone convergence theorem. The elliptic integral axioms are mathematically honest: they capture Gauss's deep 1799 theorem which requires techniques (theta functions, modular forms) not yet in Mathlib.",
+    "implications": "This formalization demonstrates the power of Mathlib's real analysis infrastructure: tendsto_atTop_ciInf/ciSup, squeeze_zero, and tendsto_nhds_unique combine to give a clean convergence proof from first principles. The AGM is central to high-performance computation of π and elliptic integrals (Brent-Salamin algorithm). A full formalization of Gauss's theorem would require formalizing K(k) and Legendre's relation in Mathlib.",
     "openQuestions": [
-      "Can K(k) be defined and its basic properties proved in Lean from Mathlib's integral theory?",
-      "Can the quadratic convergence rate (a_n - b_n = O(4^{-2^n})) be formalized?",
-      "Can Gauss's theorem be proved (not just axiomatized) from the integral representation?"
+      "Define K(k) = ∫₀^{π/2} dθ/√(1-k²sin²θ) in Lean using Mathlib's intervalIntegral and prove its basic properties (K(0)=π/2, K increasing, K→∞ as k→1⁻)",
+      "Formalize Legendre's relation K(k)·K'(k) + K(k')·K'(k') = π/2 where k' = √(1-k²)",
+      "Prove Gauss's AGM theorem M(a,b) = aπ/(2K(k')) from the Fourier series representation of K or from the hypergeometric series identity K(k) = (π/2)·₂F₁(1/2,1/2;1;k²)",
+      "Prove the quadratic convergence rate: aₙ - bₙ = O(M(a,b)·(b/a)^{2^n}), showing that the gap contracts doubly exponentially rather than merely geometrically",
+      "Formalize the Brent-Salamin formula: π = 4M(1,1/√2)²/(1-Σ_{n=1}^∞ 2^n(aₙ²-bₙ²)) using Legendre's relation and the AGM identity"
     ]
   },
+  "crossReferences": [
+    {
+      "id": "amgm-inequality",
+      "relationship": "extends",
+      "description": "Parent AM-GM inequality entry — this entry applies AM-GM iteratively to define the AGM and prove its convergence"
+    },
+    {
+      "id": "fourier-series-oq-02-oq-03",
+      "relationship": "related",
+      "description": "Fourier decay analysis — Fourier series techniques are relevant to K(k) via the Fourier expansion of complete elliptic integrals"
+    }
+  ],
+  "sections": [
+    {
+      "id": "sec-definitions",
+      "title": "§ 1: Core Definitions",
+      "startLine": 41,
+      "endLine": 74,
+      "summary": "agmStep (a,b) = ((a+b)/2, √(ab)). agmSeq iterates from (a,b). agmA/agmB extract components. Recurrence theorems: agmA_succ and agmB_succ unpack the iteration formulas. All noncomputable (Real.sqrt requires Classical.choice)."
+    },
+    {
+      "id": "sec-am-ge-gm",
+      "title": "§ 2: AM ≥ GM",
+      "startLine": 75,
+      "endLine": 88,
+      "summary": "am_ge_gm: (a+b)/2 ≥ √(ab) for a,b ≥ 0. Proof: rw [← Real.sqrt_sq hsum] converts to squared form, then Real.sqrt_le_sqrt reduces to ((a+b)/2)² ≥ ab, closed by nlinarith [sq_nonneg (a-b)]."
+    },
+    {
+      "id": "sec-positivity-ordering",
+      "title": "§ 3: Positivity and Ordering Invariants",
+      "startLine": 89,
+      "endLine": 141,
+      "summary": "agm_pos_aux (joint induction): both sequences remain positive. agmB_le_agmA (induction + am_ge_gm): bₙ ≤ aₙ. agmA_antitone: a-sequence is decreasing (by bₙ ≤ aₙ). agmB_monotone: b-sequence is increasing (calc: bₙ = √(bₙ²) ≤ √(aₙbₙ) = bₙ₊₁)."
+    },
+    {
+      "id": "sec-gap",
+      "title": "§ 4: Gap Contraction",
+      "startLine": 143,
+      "endLine": 175,
+      "summary": "gap_contracts: aₙ₊₁-bₙ₊₁ ≤ (aₙ-bₙ)/2 (since bₙ₊₁ ≥ bₙ). gap_bound: aₙ-bₙ ≤ (a-b)/2ⁿ by induction with ring for the /2 step."
+    },
+    {
+      "id": "sec-convergence",
+      "title": "§ 5: Convergence",
+      "startLine": 176,
+      "endLine": 242,
+      "summary": "agmA_bddBelow (below by b₀=b), agmB_bddAbove (above by a₀=a). agmA_tendsto/agmB_tendsto via tendsto_atTop_ciInf/ciSup. gap_tendsto_zero via squeeze_zero + geometric decay. agm_common_limit: inf aₙ = sup bₙ by ≤ direction (max argument) and = direction (tendsto_nhds_unique applied to the gap)."
+    },
+    {
+      "id": "sec-agm-value",
+      "title": "§ 6: The AGM Value M(a,b)",
+      "startLine": 244,
+      "endLine": 273,
+      "summary": "agm a b = ⨅ n, agmA a b n. agm_eq_limit_A/B: both sequences converge to agm. agm_bounds: b ≤ agm a b ≤ a (via ciInf_le at n=0)."
+    },
+    {
+      "id": "sec-elliptic",
+      "title": "§ 7: Elliptic Integral Connection (Axiomatized)",
+      "startLine": 274,
+      "endLine": 307,
+      "summary": "Three axioms: ellipticK : ℝ → ℝ (K(k) function, not in Mathlib), ellipticK_zero : K(0) = π/2, agm_ellipticK : M(a,b) = aπ/(2K(√(1-(b/a)²))). These are Gauss's 1799 deep theorem; the proof requires theta functions or hypergeometric series not yet in Mathlib."
+    }
+  ],
   "leanFile": {
     "imports": ["Mathlib"],
     "opens": ["Filter", "Set", "Real"],


### PR DESCRIPTION
## Summary

- Added 7 detailed annotations to `amgm-inequality-oq-04` (Gauss AGM Iteration and Elliptic Integrals) covering all 7 sections of the Lean file
- Expanded `meta.json` with 7 sections (line ranges), 5 deep keyInsights, comprehensive historicalContext (Gauss 1799 diary, Legendre, Jacobi, Brent-Salamin 1976, Borwein brothers 1984-1987), 2 cross-references, and 5 open questions

## Annotations Added

- `ann-agm-definitions`: agmStep/agmSeq/agmA/agmB definitions, noncomputable annotation, recurrence theorems
- `ann-am-ge-gm`: am_ge_gm proof via Real.sqrt_sq + Real.sqrt_le_sqrt + nlinarith [sq_nonneg (a-b)]
- `ann-sandwich-monotone`: four invariant theorems (positivity, bₙ≤aₙ, antitone, monotone)
- `ann-gap-contraction`: gap_contracts and gap_bound, linear vs quadratic convergence
- `ann-convergence`: tendsto_atTop_ciInf/ciSup, squeeze_zero, agm_common_limit via tendsto_nhds_unique
- `ann-agm-value`: agm definition as ciInf, agm_eq_limit_A/B, agm_bounds
- `ann-elliptic-integrals`: three axioms, Gauss's 1799 theorem, why axiomatized (K(k) not in Mathlib)

## Historical Context Added

Full narrative from Gauss's 1799 diary entry to the Brent-Salamin algorithm (1976) and Borwein brothers (1984-87), with mathematical detail on the Legendre relation and Brent-Salamin formula.

🤖 Generated with [Claude Code](https://claude.com/claude-code)