### PR TITLE
Enrich Lawvere FPT OQ03-OQ01: add annotations, sections, historicalContext

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01/annotations.json
@@ -1,1 +1,86 @@
-{"annotations": []}
+[
+  {
+    "id": "ann-eval-structure",
+    "proofId": "cantor-diagonalization-oq-03-oq-01",
+    "range": { "startLine": 41, "endLine": 60 },
+    "type": "definition",
+    "title": "EvalStructure: Minimal Abstract Framework for Lawvere",
+    "content": "EvalStructure bundles three components: Ob (type of 'codes' or 'objects'), Val (type of 'values' or 'outputs'), and eval : Ob → Ob → Val (the evaluation map, analogous to ev ∘ ⟨e, id⟩ : A → B in a CCC). EvalStructure.Endo E = E.Val → E.Val is the type of endomorphisms — the 'fixed-point-free functions' like Not, Bool.not, Nat.succ. IsPointSurjective: eval is point-surjective if every function g : Ob → Val is 'represented' by some code a₀: ∀ x, eval a₀ x = g x. This is the abstract counterpart of 'e : A → A → B is surjective' from the type-theoretic version. The structure requires no category theory imports — it captures only what the proof actually needs.",
+    "mathContext": "$(\\text{Ob}, \\text{Val}, \\text{eval})$ with $\\text{eval}$ point-surjective means: $\\forall g : \\text{Ob} \\to \\text{Val}, \\exists a_0 \\in \\text{Ob}, \\forall x, \\text{eval}(a_0, x) = g(x)$.",
+    "significance": "key",
+    "relatedConcepts": ["cartesian closed category", "evaluation map", "point-surjective", "global element", "abstract algebra in Lean 4"],
+    "prerequisites": ["structure keyword in Lean 4", "Type* (universe polymorphism)", "Prop vs Type"]
+  },
+  {
+    "id": "ann-lawvere-abstract",
+    "proofId": "cantor-diagonalization-oq-03-oq-01",
+    "range": { "startLine": 64, "endLine": 85 },
+    "type": "insight",
+    "title": "lawvere_abstract: The 2-Line Proof via Diagonal Construction",
+    "content": "lawvere_abstract proves: if E.IsPointSurjective, then every f : Val → Val has a fixed point. The proof is remarkably short. Define the diagonal g(a) = f(eval(a,a)) — this is the key construction, composing f with the 'self-evaluation' eval(a,a). By point-surjectivity, ∃ a₀ such that eval(a₀,x) = g(x) = f(eval(x,x)) for all x. Specializing at x = a₀: eval(a₀,a₀) = f(eval(a₀,a₀)), so eval(a₀,a₀) is a fixed point of f. The Lean proof is obtain ⟨a₀, ha₀⟩ := hE (fun a => f (E.eval a a)); exact ⟨E.eval a₀ a₀, (ha₀ a₀).symm⟩. This two-line proof is Lawvere's central insight: the diagonal construction, combined with point-surjectivity, forces a fixed point. The contrapositive no_surjection_abstract: if f has no fixed point, then evaluation cannot be point-surjective — this is the 'no surjection' form of Cantor/Halting.",
+    "mathContext": "Diagonal: $g(a) = f(\\text{eval}(a,a))$. By surjectivity: $\\exists a_0, \\text{eval}(a_0, x) = f(\\text{eval}(x,x))$. At $x=a_0$: $\\text{eval}(a_0,a_0) = f(\\text{eval}(a_0,a_0))$.",
+    "significance": "key",
+    "relatedConcepts": ["diagonal construction", "self-application", "fixed-point combinator", "Cantor's diagonal argument", "Gödel's diagonalization lemma"],
+    "prerequisites": ["point-surjectivity (IsPointSurjective)", "self-application pattern eval(a,a)", "obtain + exact for ∃ statements"]
+  },
+  {
+    "id": "ann-diagonal-lemma",
+    "proofId": "cantor-diagonalization-oq-03-oq-01",
+    "range": { "startLine": 87, "endLine": 95 },
+    "type": "theorem",
+    "title": "diagonal_not_representable: The Diagonal is Never in Range",
+    "content": "diagonal_not_representable states: if f has no fixed point, then the diagonal function (fun a => f(eval(a,a))) is not representable — there is no a₀ such that eval(a₀,x) = f(eval(x,x)) for all x. This is the explicit 'diagonal argument': the diagonal function always escapes the range of the evaluation. Proof: if such a₀ existed, specializing at x=a₀ gives eval(a₀,a₀) = f(eval(a₀,a₀)), contradicting hf. This theorem makes the 'escape' explicit: Cantor's diagonal sequence, Gödel's unprovable sentence, and the halting problem are all instances of this non-representability.",
+    "mathContext": "If $f(v) \\neq v$ for all $v$, then $\\nexists a_0: \\forall x, \\text{eval}(a_0, x) = f(\\text{eval}(x, x))$.",
+    "significance": "key",
+    "relatedConcepts": ["diagonal argument", "non-representability", "Gödel's diagonalization", "halting problem non-computability", "Russell's paradox"],
+    "prerequisites": ["no fixed point hypothesis", "self-application at a₀", "rintro + exact for negation goals"]
+  },
+  {
+    "id": "ann-type-recovery",
+    "proofId": "cantor-diagonalization-oq-03-oq-01",
+    "range": { "startLine": 97, "endLine": 134 },
+    "type": "theorem",
+    "title": "typeEval_surjective_iff and lawvere_type_recovery: The Bridge to Type Theory",
+    "content": "typeEvalStructure A B e constructs an EvalStructure from a function e : A → A → B by setting Ob=A, Val=B, eval=e. The key equivalence typeEval_surjective_iff proves: (typeEvalStructure A B e).IsPointSurjective ↔ Function.Surjective e. The forward direction: IsPointSurjective says ∃ a₀, eval a₀ = g (as a function), which via funext becomes Function.Surjective e. The backward direction: Function.Surjective e gives ∃ a₀, e a₀ = g (as a function), which via congr_fun gives point-surjectivity. lawvere_type_recovery applies lawvere_abstract to typeEvalStructure, recovering the type-theoretic Lawvere FPT. cantor_recovery applies lawvere_type_recovery with f=Not: the fixed point b satisfying ¬b = b leads to a contradiction via the standard self-referential reasoning.",
+    "mathContext": "$(\\text{typeEvalStructure}(A,B,e))\\text{.IsPointSurjective} \\iff \\text{Function.Surjective}(e : A \\to A \\to B)$.",
+    "significance": "key",
+    "relatedConcepts": ["Function.Surjective in Mathlib", "funext (function extensionality)", "congr_fun (applying equality of functions)", "Cantor's theorem", "Not as fixed-point-free endomorphism"],
+    "prerequisites": ["typeEvalStructure construction", "funext/congr_fun for Prop=Prop", "Function.Surjective: ∀ g, ∃ a, f a = g"]
+  },
+  {
+    "id": "ann-instances",
+    "proofId": "cantor-diagonalization-oq-03-oq-01",
+    "range": { "startLine": 136, "endLine": 165 },
+    "type": "insight",
+    "title": "Three Instances: Prop, Bool, ℕ — Different Fixed-Point-Free Endomorphisms",
+    "content": "Three concrete instances apply lawvere_abstract with specific Val types and fixed-point-free endomorphisms. cantor_instance: Val=Prop, f=Not. A Prop fixed point satisfies ¬v=v (as propositions), from which v→¬v and ¬v→v lead to contradiction via classical reasoning. The proof pattern: obtain ⟨v,hv⟩, then cast hv and hv.symm to get mutual implications, then derive v and ¬v simultaneously. bool_instance: Val=Bool, f=(!·) (boolean not). Fixed point would satisfy !v=v; cases v <;> simp at hv closes both cases (true≠false). nat_succ_instance: Val=ℕ, f=Nat.succ. Fixed point would satisfy n+1=n; Nat.succ_ne_self provides the contradiction directly. The three instances illustrate how a single abstract theorem encompasses fundamentally different mathematical phenomena: propositional self-reference (Cantor/Russell), boolean self-negation, and the non-zero-sum-free nature of successor.",
+    "mathContext": "Prop: $\\neg v = v$ is contradictory; Bool: $!v = v$ is contradictory; $\\mathbb{N}$: $n+1 = n$ is contradictory.",
+    "significance": "key",
+    "relatedConcepts": ["Bool.not fixed-point-free", "Nat.succ_ne_self", "cast tactic for Prop coercion", "cases on Bool", "instances of abstract theorems"],
+    "prerequisites": ["Nat.succ_ne_self in Mathlib", "cases on Bool (true/false)", "cast for Prop = Prop implications", "simp at hv for Bool contradictions"]
+  },
+  {
+    "id": "ann-categorical-eval",
+    "proofId": "cantor-diagonalization-oq-03-oq-01",
+    "range": { "startLine": 167, "endLine": 219 },
+    "type": "concept",
+    "title": "CategoricalEval: Abstract CCC Structure with Two Sorries",
+    "content": "CategoricalEval axiomatizes a cartesian closed category (CCC) at the level of global elements: Obj (objects), Hom (morphisms), exp A B (exponential object B^A), Pt B (global elements of B, i.e., morphisms 1 → B), apply (the evaluation on global elements: ev : B^A × A → B restricted to global elements), and ptSurj (point-surjectivity of a morphism Hom A (exp A B)). lawvere_categorical states the Lawvere FPT in this setting but has 2 sorries. The first sorry is a hole for providing a global element of exp A B from the surjectivity hypothesis — this requires defining the EvalStructure that the CategoricalEval induces, connecting the categorical apply to the abstract eval. The second sorry is the main theorem body, which should reduce to lawvere_abstract applied to the induced EvalStructure. The sorries are localized to this bridge between the categorical and computational frameworks; all other theorems are fully proved. In a genuine topos, Pt B = Hom(1,B) (global sections functor) and point-surjectivity is epimorphicity plus the existence of enough points.",
+    "mathContext": "$\\text{CCC with global elements: } \\text{ptSurj}(e : A \\to B^A) \\implies \\forall f : \\text{Pt}(B) \\to \\text{Pt}(B), \\exists b \\in \\text{Pt}(B): f(b) = b$.",
+    "significance": "supporting",
+    "relatedConcepts": ["cartesian closed category", "exponential object", "global element", "evaluation map", "topos and subobject classifier"],
+    "prerequisites": ["CCC structure (Obj, Hom, exp, terminal object)", "global elements = morphisms from terminal 1", "sorry as placeholder for unfinished proof steps"]
+  },
+  {
+    "id": "ann-topos-proxy",
+    "proofId": "cantor-diagonalization-oq-03-oq-01",
+    "range": { "startLine": 221, "endLine": 245 },
+    "type": "context",
+    "title": "Topos Connection: Prop as Subobject Classifier Ω",
+    "content": "topos_proxy_cantor proves: there is no surjective e : A → A → Prop. This is Cantor's theorem phrased as a topos-level statement: in the topos of sets (or the internal type theory of Lean), Prop acts as a proxy for the subobject classifier Ω. The power object P(A) = Ω^A = A → Prop corresponds to the type A → Prop in Lean, and Cantor's theorem says A cannot surject onto A → Prop. The proof reduces to cantor_recovery (which in turn reduces to lawvere_abstract). The longer prose comment explains the topos-theoretic setting: in a genuine topos, Cantor follows from Lawvere with B=Ω and f=¬ (the internal negation on Ω), since internal negation is always fixed-point-free (in a Boolean topos) or the Heyting negation. Johnstone's Elephant (A1.6.1) and MacLane-Moerdijk Sheaves IV.7 give the full categorical proof.",
+    "mathContext": "In a topos: $\\neg \\exists e: A \\twoheadrightarrow \\Omega^A$ (Cantor). Type-theoretically: $\\neg \\exists e: A \\to A \\to \\text{Prop}, \\text{Function.Surjective}(e)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["subobject classifier Ω", "power object P(A) = Ω^A", "topos Cantor theorem", "Johnstone Elephant", "MacLane-Moerdijk Sheaves in Geometry and Logic"],
+    "prerequisites": ["topos = CCC + subobject classifier", "P(A) = Ω^A = A → Prop in Set", "Function.Surjective for Prop-valued functions"]
+  }
+]

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01/meta.json
@@ -44,15 +44,16 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "F. William Lawvere (1969) showed that Cantor's diagonal argument is an instance of a general fixed-point theorem in cartesian closed categories. This unifies Cantor's theorem, Russell's paradox, the halting problem, and Gödel's incompleteness theorem.",
+    "historicalContext": "F. William Lawvere's 1969 paper 'Diagonal arguments and cartesian closed categories' (Springer LNM 92, pp. 134-145) revealed that Cantor's diagonal argument — and its many relatives — are all instances of a single fixed-point theorem in cartesian closed categories (CCCs). This unification is one of the great insights of categorical logic.\n\n**The historical precedents**: Cantor (1891) used the diagonal to show no surjection A → 2^A exists. Russell (1902) used self-reference to derive his paradox. Gödel (1931) used a diagonal construction to produce undecidable sentences. Church and Turing (1936) used diagonalization to show the halting problem is undecidable. All of these were recognized as related but treated case-by-case.\n\n**Lawvere's unification (1969)**: In a cartesian closed category, if a morphism e : A → B^A is 'point-surjective' (every global element 1 → B^A is in its image), then every endomorphism f : B → B has a fixed point. Taking the contrapositive: if f has no fixed point, then no point-surjection A → B^A exists. Concretely:\n- Cantor: B = {0,1} or Prop, f = Not (no fixed point)\n- Russell: B = {true,false}, f = not\n- Gödel: B = sentences, f = 'diagonalization of provability'\n- Halting: B = {halt, loop}, f = not-halt\n\n**Yanofsky (2003)**: Noson Yanofsky's survey 'A Universal Approach to Self-Referential Paradoxes, Incompleteness and Fixed Points' (The Bulletin of Symbolic Logic) popularized Lawvere's insight and extended it to a 'diagonal argument in a setting with enough structure.'\n\n**Topos theory**: In a topos (a CCC with a subobject classifier Ω), Lawvere's theorem with B = Ω and f = internal negation gives: no object A can surject onto its power object Ω^A = P(A). This is the topos-theoretic Cantor theorem, proved in Johnstone's Elephant (A1.6.1) and MacLane-Moerdijk's Sheaves in Geometry and Logic (IV.7). A full Lean formalization requires the topos typeclass, currently under development in Mathlib.",
     "problemStatement": "Can the Lawvere fixed-point theorem be formalized in a topos-theoretic setting in Lean, recovering the original categorical generality beyond type theory?",
     "text": "Generalizes Lawvere FPT to an abstract evaluation structure, proves type-theoretic recovery, and sketches the categorical framework.",
     "proofStrategy": "Define an abstract EvalStructure with objects, values, and evaluation. Prove the fixed-point theorem via diagonal construction. Show it recovers the type-theoretic version. Define a categorical framework for CCC with global elements.",
     "keyInsights": [
-      "The minimal structure for Lawvere is evaluation + point-surjectivity — no full CCC needed",
-      "Type-theoretic and categorical versions are connected via typeEvalStructure",
-      "Three concrete instances show the power: Prop (Cantor), Bool, ℕ (successor)",
-      "In a topos, Prop acts as a proxy for the subobject classifier Ω"
+      "**The 2-line core proof**: lawvere_abstract is proved in exactly two lines after pattern matching: (1) apply point-surjectivity to the diagonal function fun a => f(eval(a,a)), getting a₀; (2) specialize at a₀ to get eval(a₀,a₀) = f(eval(a₀,a₀)). This is the entire diagonal argument in its abstract form. All of Cantor, Russell, Gödel, and Turing fold into this 2-line proof.",
+      "**Minimal abstraction**: EvalStructure requires only three things — Ob (codes), Val (values), eval : Ob → Ob → Val — and a point-surjectivity condition. No category theory imports are needed. The structure captures exactly what the Lawvere proof needs and nothing more. typeEvalStructure bridges this to the type-theoretic setting via the equivalence typeEval_surjective_iff.",
+      "**Fixed-point-free endomorphisms determine Val**: The three instances use Not (Prop→Prop), (!·) (Bool→Bool), and Nat.succ (ℕ→ℕ) as the 'troublemaker' f. Each has no fixed point, so Lawvere forces non-surjectivity. The diversity of the instances — logical self-negation, boolean negation, successor arithmetic — shows how the single abstract theorem unifies phenomena that appear mathematically unrelated.",
+      "**Cantor recovery proof**: cantor_recovery applies lawvere_type_recovery with f=Not to get a Prop b with ¬b=b. From ¬b=b: (a) b→¬b (apply hb.symm and cast) and (b) ¬b→b (apply hb and cast). These give a liar-paradox-style contradiction. The proof is a direct formalization of the standard self-referential argument.",
+      "**The two sorries are localized and honest**: The sorries in lawvere_categorical are in the bridge between CategoricalEval (which models a CCC) and EvalStructure (which is purely computational). The gap is the sorry : C.Pt (C.exp A B) needed to provide a global element of the exponential — this requires relating the CategoricalEval.apply to an EvalStructure.eval. All core theorems (lawvere_abstract, instances, topos proxy) are fully proved."
     ],
     "prerequisites": [
       "Lawvere fixed-point theorem from CantorDiagonalizationOQ03",
@@ -60,20 +61,78 @@
       "Basic category theory: cartesian closed categories, exponentials"
     ]
   },
-  "sections": [],
+  "sections": [
+    {
+      "id": "sec-eval-structure",
+      "title": "Part 1: Abstract Evaluation Structure",
+      "startLine": 33,
+      "endLine": 60,
+      "summary": "EvalStructure (Ob, Val, eval). EvalStructure.Endo = Val → Val. IsPointSurjective: every g : Ob → Val is represented by some code a₀. This is the minimal abstract setting for Lawvere's theorem, modeling the data of a CCC without category theory imports."
+    },
+    {
+      "id": "sec-lawvere-abstract",
+      "title": "Part 2: Abstract Lawvere Fixed-Point Theorem",
+      "startLine": 62,
+      "endLine": 85,
+      "summary": "lawvere_abstract: if IsPointSurjective, then every f : Val → Val has a fixed point. 2-line proof via diagonal construction. no_surjection_abstract: contrapositive — if f has no fixed point, evaluation cannot be point-surjective."
+    },
+    {
+      "id": "sec-diagonal-lemma",
+      "title": "Part 3: Diagonal Lemma",
+      "startLine": 87,
+      "endLine": 95,
+      "summary": "diagonal_not_representable: when f has no fixed point, the diagonal function fun a => f(eval(a,a)) is never representable. This is the explicit statement of the 'escape from range' that drives all diagonal arguments."
+    },
+    {
+      "id": "sec-type-recovery",
+      "title": "Part 4: Recovery of Type-Theoretic Version",
+      "startLine": 97,
+      "endLine": 134,
+      "summary": "typeEvalStructure constructs EvalStructure from e : A → A → B. typeEval_surjective_iff: IsPointSurjective ↔ Function.Surjective e (via funext/congr_fun). lawvere_type_recovery recovers the type-theoretic Lawvere FPT. cantor_recovery: no surjection A → A → Prop (applying Not as the fixed-point-free endomorphism)."
+    },
+    {
+      "id": "sec-instances",
+      "title": "Part 5: Concrete Instances",
+      "startLine": 136,
+      "endLine": 165,
+      "summary": "Three instances: cantor_instance (Val=Prop, f=Not — Cantor's theorem), bool_instance (Val=Bool, f=(!·) — closed by cases <;> simp), nat_succ_instance (Val=ℕ, f=Nat.succ — closed by Nat.succ_ne_self)."
+    },
+    {
+      "id": "sec-categorical",
+      "title": "Part 6: Categorical Framework (CCC with Global Elements)",
+      "startLine": 167,
+      "endLine": 219,
+      "summary": "CategoricalEval: Obj, Hom, exp (exponential), Pt (global elements), apply, ptSurj. HasFixedPoint. lawvere_categorical: Lawvere FPT in categorical setting — has 2 sorries (bridge between CategoricalEval.apply and EvalStructure.eval). All other theorems fully proved."
+    },
+    {
+      "id": "sec-topos",
+      "title": "Part 7: Topos Connection",
+      "startLine": 221,
+      "endLine": 245,
+      "summary": "Prose sketch: in a topos, B=Ω with internal negation gives Cantor's theorem (no A → P(A) surjection). topos_proxy_cantor: type-level proxy using Prop as Ω — no surjection A → A → Prop. Proof via cantor_recovery."
+    }
+  ],
   "conclusion": {
-    "summary": "The abstract evaluation structure captures the essential content of Lawvere's theorem without requiring full CCC machinery. The type-theoretic version is recovered as a special case. The full topos-theoretic formalization awaits Mathlib's topos infrastructure.",
-    "implications": "Demonstrates that diagonal arguments across mathematics (Cantor, Russell, halting, Gödel) share a common abstract structure.",
+    "summary": "The abstract evaluation structure captures the essential content of Lawvere's 1969 theorem without requiring full CCC machinery. 14 theorems, 6 definitions, 0 axioms, 2 sorries (in the categorical bridge section). The type-theoretic version is recovered, three concrete instances are verified, and the topos connection is sketched.",
+    "implications": "All diagonal arguments in mathematics — Cantor's uncountability, Russell's paradox, Gödel's incompleteness, Turing's halting problem — are instances of a single 2-line proof: find a diagonal code, evaluate it at itself, get a fixed point of any endomorphism. This formalization demonstrates that categorical abstraction, even when only partially formalized, reveals deep structural unity across apparently disconnected results.",
     "openQuestions": [
-      "Can Rice's theorem be derived as a Lawvere instance?",
-      "Is there a constructive analogue without propositional extensionality?"
+      "Complete the categorical bridge: close the 2 sorries in lawvere_categorical by explicitly constructing the EvalStructure induced by a CategoricalEval, connecting CategoricalEval.apply to EvalStructure.eval",
+      "Derive Rice's theorem as a Lawvere instance: Val = {computable functions}, f = 'complement a non-trivial semantic property', yielding Rice's theorem (no non-trivial property of computable functions is decidable)",
+      "Formalize Gödel's incompleteness theorem as a Lawvere instance: Val = sentences, point-surjectivity = the diagonal lemma of provability logic, f = 'negate provability'",
+      "Prove the constructive analogue without classical logic: propositional extensionality is used in cantor_recovery; can the theorem be restated using explicit witnesses instead?",
+      "Formalize topos-level Cantor using Mathlib's category theory: once Mathlib has a topos typeclass with subobject classifier Ω, lawvere_categorical can be completed and applied with B=Ω, f=internal negation"
     ]
   },
   "crossReferences": [
     {
-      "targetId": "cantor-diagonalization-oq-03",
+      "id": "cantor-diagonalization-oq-03",
       "relationship": "extends",
-      "description": "Parent: type-theoretic Lawvere FPT. This file generalizes to abstract evaluation structures."
+      "description": "Parent: type-theoretic Lawvere FPT in the Lean type system. This file generalizes to abstract evaluation structures and the categorical setting."
+    },
+    {
+      "id": "schauder-fixed-point-oq-03",
+      "relationship": "related",
+      "description": "Kakutani fixed-point theorem — another fixed-point theorem in the gallery, topological rather than diagonal in nature, with different hypotheses and proof structure"
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Summary

- Added 7 detailed annotations to `cantor-diagonalization-oq-03-oq-01` (Lawvere Fixed-Point Theorem: Categorical Generalization)
- Expanded `meta.json` with 7 sections, 5 keyInsights, comprehensive historicalContext, 2 cross-references, and 5 open questions

## Annotations Added

- `ann-eval-structure`: EvalStructure (Ob, Val, eval) — minimal abstract CCC data
- `ann-lawvere-abstract`: 2-line diagonal proof, no_surjection_abstract contrapositive
- `ann-diagonal-lemma`: diagonal_not_representable — explicit non-representability statement
- `ann-type-recovery`: typeEval_surjective_iff (IsPointSurjective ↔ Function.Surjective), lawvere_type_recovery, cantor_recovery
- `ann-instances`: Three instances (Prop/Not, Bool/!, ℕ/succ) with different proof techniques
- `ann-categorical-eval`: CategoricalEval structure, 2 sorries, why they exist
- `ann-topos-proxy`: topos_proxy_cantor, Prop as Ω proxy, references to Johnstone/MacLane-Moerdijk

## Historical Context Added

Full narrative from Cantor 1891 through Lawvere 1969, Yanofsky 2003 survey, and topos theory connection. Explains how Cantor, Russell, Gödel, and Turing are all instances of the same 2-line proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)