### PR TITLE
Enrich Cauchy-Schwarz OQ-02 and Cantor Diagonal: recovered from enricher-1

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -11602,6 +11602,13 @@
       "started": "2026-04-03T13:04:09.716Z",
       "status": "active",
       "lastUpdate": "2026-04-03T13:04:09.716Z"
+    },
+    {
+      "slug": "burnside-counting-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T07:05:01-07:00",
+      "status": "active"
     }
   ],
   "config": {

--- a/src/data/proofs/cantor-diagonalization-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02-oq-03/annotations.json
@@ -1,1 +1,62 @@
-[]
+[
+  {
+    "id": "ann-header-imports",
+    "proofId": "cantor-diagonalization-oq-02-oq-03",
+    "range": { "startLine": 1, "endLine": 33 },
+    "type": "context",
+    "title": "Setup: Generalizing Cantor's Diagonal to Regular Cardinals",
+    "content": "The file header states the generalisation precisely: for any regular uncountable cardinal $\\kappa$, ordinals below $\\kappa.\\text{ord}$ cannot be exhausted by fewer than $\\kappa$ many elements. The key condition is *regularity*, not mere uncountability.\n\n**Three Mathlib imports drive the proof**:\n- `Cardinal.Ordinal`: Basic interplay between cardinals and ordinals, defining `κ.ord` (the initial ordinal of a cardinal)\n- `Cardinal.Cofinality`: The cofinality function `cof(α)` and `IsRegular κ` (meaning `cof(κ.ord) = κ`)\n- `Ordinal.Arithmetic`: Ordinal addition, successor, `iSup`, and `BddAbove`\n\n**Why regular cardinals?** A cardinal $\\kappa$ is regular iff it cannot be written as a union of fewer than $\\kappa$ sets each of size $< \\kappa$. This is exactly the property that makes the diagonal argument work: no small family can `cover' all of $\\kappa$. Examples: $\\aleph_0, \\aleph_1, \\aleph_2, \\ldots, \\aleph_{\\omega+1}$ are all regular; $\\aleph_\\omega$ (the first singular cardinal) is not — it is a countable union of $\\aleph_n$'s.\n\n**The `open Cardinal Ordinal`** line makes `IsRegular`, `iSup`, `ord`, and `aleph` available without namespace prefixes throughout the file.",
+    "mathContext": "$\\kappa$ is regular iff $\\text{cof}(\\kappa.\\text{ord}) = \\kappa$; regular cardinals: $\\aleph_0, \\aleph_1, \\aleph_2, \\ldots$; first singular: $\\aleph_\\omega = \\sup_n \\aleph_n$ with $\\text{cof}(\\aleph_\\omega) = \\aleph_0 < \\aleph_\\omega$",
+    "significance": "context",
+    "relatedConcepts": ["regular cardinal", "singular cardinal", "cofinality", "initial ordinal", "IsRegular in Mathlib"],
+    "prerequisites": ["cardinal arithmetic", "ordinal arithmetic", "cofinality definition", "Lean 4 imports"]
+  },
+  {
+    "id": "ann-regular-sup-bounded",
+    "proofId": "cantor-diagonalization-oq-02-oq-03",
+    "range": { "startLine": 34, "endLine": 47 },
+    "type": "technique",
+    "title": "Regular Sup Bounded: The Abstract Diagonal Engine",
+    "content": "The theorem `regular_sup_bounded` is the core of everything: for regular $\\kappa$, the supremum of any $< \\kappa$-indexed family of ordinals below $\\kappa.\\text{ord}$ is still below $\\kappa.\\text{ord}$.\n\n**The one-line proof**:\n```lean\nOrdinal.iSup_lt_ord (hκ.cof_eq ▸ hι) hf\n```\nThis applies `Ordinal.iSup_lt_ord`, which states: `iSup f < o` if `cof(o) > #ι` and all `f i < o`. The cofinality hypothesis is satisfied by `hκ.cof_eq ▸ hι`:\n- `hκ.cof_eq : cof(κ.ord) = κ` (regularity of κ)\n- `hι : #ι < κ`\n- After rewriting: `cof(κ.ord) > #ι` ✓\n\n**Mathematical content**: Cofinality of $\\kappa.\\text{ord}$ equals $\\kappa$ for regular $\\kappa$. Any cofinal sequence in $\\kappa.\\text{ord}$ must have length $\\geq \\kappa$. So a family of length $< \\kappa$ cannot be cofinal — its supremum is strictly bounded below $\\kappa.\\text{ord}$.\n\n**This is the abstract diagonal**: the classical Cantor diagonal for $\\kappa = \\aleph_1$ says a countable sequence of countable ordinals has countable sup. This theorem says the same for all regular cardinals at once.",
+    "mathContext": "$\\kappa$ regular $\\Rightarrow$ $\\#\\iota < \\kappa$ $\\Rightarrow$ $\\sup_{i: \\iota} f(i) < \\kappa.\\text{ord}$; equivalently: $\\text{cof}(\\kappa.\\text{ord}) = \\kappa > \\#\\iota$ means no $\\iota$-indexed family is cofinal",
+    "significance": "key",
+    "relatedConcepts": ["cofinality", "iSup_lt_ord", "cofinal sequence", "IsRegular.cof_eq"],
+    "prerequisites": ["cofinality in Mathlib", "ordinal supremum (iSup)", "IsRegular definition", "▸ rewrite tactic"]
+  },
+  {
+    "id": "ann-succ-cardinals",
+    "proofId": "cantor-diagonalization-oq-02-oq-03",
+    "range": { "startLine": 48, "endLine": 67 },
+    "type": "technique",
+    "title": "Successor Bounds: κ.ord is a Limit Ordinal",
+    "content": "Two lemmas establish that $\\kappa.\\text{ord}$ is a limit ordinal (no predecessor) when $\\kappa$ is infinite.\n\n**`card_succ_lt_of_lt_infinite`**: If $\\mu < \\kappa$ and $\\kappa \\geq \\aleph_0$, then $\\mu + 1 < \\kappa$. Proof by cases on whether $\\mu$ is infinite:\n- If $\\mu \\geq \\aleph_0$: `add_one_of_aleph0_le` gives $\\mu + 1 = \\mu$ (infinite cardinals absorb +1), so $\\mu + 1 = \\mu < \\kappa$\n- If $\\mu < \\aleph_0$ (finite): `add_lt_aleph0` gives $\\mu + 1 < \\aleph_0 \\leq \\kappa$\n\n**`ord_succ_lt`**: If $\\alpha < \\kappa.\\text{ord}$, then $\\alpha + 1 < \\kappa.\\text{ord}$. The proof reduces to the cardinal version via `lt_ord` and `card_succ`.\n\n**Why this is needed**: The diagonal argument produces $\\sup f + 1$ as the ordinal exceeding all family members. We need $\\sup f + 1 < \\kappa.\\text{ord}$ to stay in range — this lemma provides exactly that, given that $\\sup f < \\kappa.\\text{ord}$ by `regular_sup_bounded`.\n\n**An important subtlety**: Cardinal addition is not the same as ordinal addition. `add_one_of_aleph0_le` is a *cardinal* identity; the ordinal version requires `Ordinal.add_one_eq_succ` and `Ordinal.card_succ`.",
+    "mathContext": "For infinite $\\kappa$: $\\mu < \\kappa \\Rightarrow \\mu + 1 < \\kappa$ (cardinals); $\\alpha < \\kappa.\\text{ord} \\Rightarrow \\alpha + 1 < \\kappa.\\text{ord}$ (ordinals); both because infinite cardinal addition absorbs finite increments",
+    "significance": "supporting",
+    "relatedConcepts": ["limit ordinal", "cardinal vs ordinal addition", "add_one_of_aleph0_le", "ord_succ_lt", "infinite cardinals"],
+    "prerequisites": ["cardinal arithmetic", "ordinal arithmetic", "aleph_0", "by_cases tactic", "push_neg"]
+  },
+  {
+    "id": "ann-diagonal-argument",
+    "proofId": "cantor-diagonalization-oq-02-oq-03",
+    "range": { "startLine": 68, "endLine": 99 },
+    "type": "insight",
+    "title": "The Generalized Diagonal: ∃ β < κ.ord exceeding the whole family",
+    "content": "The two key theorems of the file.\n\n**`regular_diagonal`**: Given a $< \\kappa$-indexed family $(f_i)$ of ordinals below $\\kappa.\\text{ord}$, there exists $\\beta < \\kappa.\\text{ord}$ with $f_i < \\beta$ for all $i$.\n\nProof assembly:\n1. `hsup`: $\\sup_i f_i < \\kappa.\\text{ord}$ (by `regular_sup_bounded`)\n2. `hsucc`: $\\sup_i f_i + 1 < \\kappa.\\text{ord}$ (by `ord_succ_lt`)\n3. `hbdd`: The range of $f$ is bounded above by $\\kappa.\\text{ord}$\n4. Witness: $\\beta = \\sup_i f_i + 1$; it satisfies $f_i \\leq \\sup_i f_i < \\sup_i f_i + 1$\n\nStep 4 uses `le_ciSup` (each $f_i \\leq \\sup_i f_i$, needing `BddAbove`) and `lt_add_of_pos_right` (+1 is strictly larger).\n\n**`regular_no_surjection`**: No $< \\kappa$-indexed family can surject onto ordinals below $\\kappa.\\text{ord}$.\n\nProof by contradiction: assume surjection $\\forall \\alpha < \\kappa.\\text{ord}, \\exists i, f_i = \\alpha$. Apply `regular_diagonal` to get $\\beta < \\kappa.\\text{ord}$ with $\\beta > f_i$ for all $i$. By surjectivity, $\\exists i, f_i = \\beta$. But then $f_i = \\beta > f_i$ — contradiction (`lt_irrefl`).\n\n**Classical Cantor in disguise**: For $\\kappa = \\aleph_1$, $f : \\mathbb{N} \\to \\omega_1$ (a sequence of countable ordinals), `regular_diagonal` gives a countable ordinal above all of them — the abstract form of 'the diagonal ordinal'.",
+    "mathContext": "$\\exists \\beta < \\kappa.\\text{ord}$ such that $\\forall i, f_i < \\beta$; equivalently, $\\kappa.\\text{ord}$ is not a supremum of any $< \\kappa$-indexed subset, which is exactly what $\\text{cof}(\\kappa.\\text{ord}) = \\kappa$ means",
+    "significance": "key",
+    "relatedConcepts": ["diagonal argument", "le_ciSup", "BddAbove", "lt_irrefl", "proof by contradiction", "cofinality"],
+    "prerequisites": ["regular_sup_bounded", "ord_succ_lt", "ordinal iSup", "BddAbove in Mathlib", "obtain pattern"]
+  },
+  {
+    "id": "ann-aleph1-recovery",
+    "proofId": "cantor-diagonalization-oq-02-oq-03",
+    "range": { "startLine": 100, "endLine": 142 },
+    "type": "insight",
+    "title": "The ℵ₁ Case: Recovering the Classical Diagonal for Countable Ordinals",
+    "content": "The final section instantiates the general theorem at $\\kappa = \\aleph_1$ to recover the classically stated diagonal argument.\n\n**`aleph0_lt_aleph1`** (private): $\\aleph_0 < \\aleph_1$. Proved by `aleph_lt_aleph.mpr` with `norm_num : 0 < 1`.\n\n**`aleph1_diagonal`**: For any sequence $f : \\mathbb{N} \\to \\text{Ord}$ with all $f(n) < \\aleph_1.\\text{ord}$, there exists $\\beta < \\aleph_1.\\text{ord}$ with $f(n) < \\beta$ for all $n$.\n\nInstantiation arguments:\n- `κ = aleph 1`, `hκ = isRegular_aleph_one` (Mathlib: $\\aleph_1$ is regular)\n- Infiniteness: `le_of_lt aleph0_lt_aleph1`\n- Index bound: `mk_nat ▸ aleph0_lt_aleph1` — the cardinality of $\\mathbb{N}$ is $\\aleph_0 < \\aleph_1$\n\n**Why singular cardinals fail**: The summary comment highlights the crucial point: $\\aleph_\\omega$ (first singular cardinal) has countable cofinality — there IS a countable cofinal sequence $\\aleph_0 < \\aleph_1 < \\aleph_2 < \\ldots$ converging to $\\aleph_\\omega$. So the diagonal argument fails at singular cardinals: a countably-indexed family CAN exhaust ordinals below $\\aleph_\\omega.\\text{ord}$. Regularity is not just sufficient but necessary for the conclusion.",
+    "mathContext": "$\\aleph_1.\\text{ord} = \\omega_1$ (first uncountable ordinal); $f: \\mathbb{N} \\to \\omega_1$ countable sequence of countable ordinals $\\Rightarrow \\exists \\beta < \\omega_1$ above all; fails for $\\aleph_\\omega$ since $\\text{cof}(\\aleph_\\omega) = \\aleph_0$",
+    "significance": "key",
+    "relatedConcepts": ["aleph numbers", "isRegular_aleph_one", "ω₁ (first uncountable ordinal)", "singular cardinals", "GCH"],
+    "prerequisites": ["aleph_lt_aleph in Mathlib", "mk_nat", "aleph1_diagonal", "regular vs singular cardinals"]
+  }
+]

--- a/src/data/proofs/cantor-diagonalization-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02-oq-03/meta.json
@@ -31,29 +31,31 @@
     ]
   },
   "overview": {
-    "historicalContext": "Hausdorff (1908) introduced the notion of regular cardinals: those equal to their own cofinality. For ℵ₀ (countability), regularity means no countable union of finite sets is countably infinite (in a set-theoretic sense). For ℵ₁, regularity means no countably-indexed family of countable ordinals has sup equal to ω₁. The diagonal argument — the engine behind Cantor's theorem — generalizes: for any regular κ, ordinals below κ cannot be 'reached' from below by < κ elements.",
-    "problemStatement": "Prove that the Cantor diagonal argument generalizes to regular cardinals: for any regular κ, there is no surjection from a set of size < κ onto ordinals below κ.ord.",
-    "text": "A cardinal κ is regular if cof(κ.ord) = κ — its cofinality equals itself. Regular cardinals include all successor cardinals (ℵ_{α+1}) and ℵ₀. For regular κ: if f : ι → κ.ord with #ι < κ, then iSup f < κ.ord. This is the abstract diagonal: we can always find an ordinal 'above' any bounded family. The key tool is Ordinal.iSup_lt_ord from Mathlib's cofinality theory.",
-    "proofStrategy": "Apply Ordinal.iSup_lt_ord directly using hκ.cof_eq (cofinality of κ.ord equals κ for regular κ). Derive the successor bound from case split (finite/infinite). Prove the diagonal result. Prove no surjection by taking the sup+1.",
+    "historicalContext": "Cantor (1874, 1891) introduced the diagonal argument to show $|\\mathbb{R}| > |\\mathbb{N}|$ and, more generally, $|2^X| > |X|$ for any set $X$. The abstract engine behind the argument is: any function from $X$ to its powerset fails to be surjective (the 'diagonal set' $\\{x : x \\notin f(x)\\}$ is missing from the range).\n\nHausdorff (1908) introduced the notion of *regular* and *singular* cardinals in his seminal work on ordered sets. A cardinal $\\kappa$ is regular if $\\text{cof}(\\kappa) = \\kappa$ — it cannot be expressed as a union of fewer than $\\kappa$ sets of size $< \\kappa$. Hausdorff showed that all successor cardinals $\\aleph_{\\alpha+1}$ are regular. The first potentially irregular (singular) cardinal is $\\aleph_\\omega = \\sup_n \\aleph_n$, which has cofinality $\\aleph_0$.\n\nThe ordinal-diagonal formulation relevant here — that for regular $\\kappa$, no $< \\kappa$-indexed family of ordinals $< \\kappa.\\text{ord}$ can be cofinal — is a direct consequence of the definition of cofinality. It abstracts the classical argument: 'a countable sequence of countable ordinals has countable supremum' (the $\\kappa = \\aleph_1$ case) to all regular cardinals simultaneously.\n\nThis generalisation is ubiquitous in combinatorial set theory: $\\Delta$-system lemma proofs, forcing constructions, and the theory of stationary sets all use the fact that regular cardinals 'close off' bounded families.",
+    "problemStatement": "Prove that the Cantor diagonal argument generalizes to all regular uncountable cardinals $\\kappa$: for regular $\\kappa$, (1) the supremum of any $< \\kappa$-indexed family of ordinals below $\\kappa.\\text{ord}$ is still below $\\kappa.\\text{ord}$, (2) there exists an ordinal below $\\kappa.\\text{ord}$ exceeding the entire family, and (3) no $< \\kappa$-sized set can surject onto ordinals below $\\kappa.\\text{ord}$.",
+    "proofStrategy": "The proof hinges on Mathlib's `Ordinal.iSup_lt_ord`: $\\sup_i f_i < o$ if $\\#\\iota < \\text{cof}(o)$ and all $f_i < o$. For regular $\\kappa$, `hκ.cof_eq` gives $\\text{cof}(\\kappa.\\text{ord}) = \\kappa$, so the hypothesis $\\#\\iota < \\kappa$ suffices. The diagonal ordinal is $\\sup_i f_i + 1$ (still below $\\kappa.\\text{ord}$ by a separate limit-ordinal lemma via case analysis on finite/infinite). No-surjection follows by contradiction: the diagonal ordinal would have to be in the range, but it exceeds all range elements.",
     "keyInsights": [
-      "Regular cardinal: cof(κ.ord) = κ — the abstract form of countable-closure",
-      "iSup_lt_ord: key Mathlib lemma about ordinal suprema and cofinality",
-      "Diagonal argument: take the sup of the family + 1 to exceed all values",
-      "No surjection: existence of the diagonal ordinal blocks any surjection"
+      "The entire diagonal argument reduces to one Mathlib lemma (`Ordinal.iSup_lt_ord`) whose hypothesis is exactly what regularity ($\\text{cof}(\\kappa.\\text{ord}) = \\kappa$) provides — the proof is then definitionally one line",
+      "Regular cardinals are precisely those for which the diagonal argument works: singular cardinals fail because their cofinality is smaller, making the $\\#\\iota < \\kappa$ condition insufficient — $\\aleph_\\omega$ has a countable cofinal sequence so $\\aleph_\\omega.\\text{ord}$ IS reachable from below by $\\aleph_0$ many ordinals",
+      "Cardinal arithmetic and ordinal arithmetic diverge: `μ + 1 = μ` for infinite cardinals (absorption) but `α + 1 > α` for all ordinals (successor always strictly larger) — the proof needs both, and the Lean code carefully navigates the `lt_ord` bridge between them",
+      "The `BddAbove` witness in `regular_diagonal` (bounding the range of $f$ by $\\kappa.\\text{ord}$) is needed for `le_ciSup` to apply — this is a Mathlib API requirement for `iSup` over an arbitrary type",
+      "Instantiating at $\\kappa = \\aleph_1$ recovers exactly the parent theorem (OQ-02): countable sequences of countable ordinals have countable supremum, so there are uncountably many countable ordinals"
     ],
     "prerequisites": [
-      "Cardinals and ordinals: basic set theory",
-      "Cofinality: cof(α) = smallest cofinal ordinal",
-      "Regular cardinals: κ = cof(κ.ord)"
+      "Cardinal and ordinal arithmetic in Mathlib (CardinalOrder, OrdinalArithmetic)",
+      "Cofinality: $\\text{cof}(\\alpha)$ and IsRegular",
+      "Ordinal iSup and BddAbove",
+      "Lean 4 ▸ rewrite and obtain tactic"
     ]
   },
   "conclusion": {
-    "summary": "Cantor diagonal generalized to regular cardinals: regular_sup_bounded, regular_diagonal, regular_no_surjection. All from Mathlib cofinality theory. 6 theorems, 142 lines, 0 axioms.",
-    "implications": "The regular cardinal version is the abstract backbone of many set-theoretic constructions: forcing posets, tree arguments, and closure systems. It generalizes the countable argument to uncountable cardinals.",
+    "summary": "This file generalizes the Cantor diagonal argument from $\\aleph_1$ to all regular uncountable cardinals $\\kappa$, in 142 lines with 0 axioms and 0 sorries. The proof reduces entirely to Mathlib's `Ordinal.iSup_lt_ord` via the cofinality definition of regularity, with supporting lemmas for the limit-ordinal property of $\\kappa.\\text{ord}$ and the $\\aleph_1$ instantiation recovering the classical case.",
+    "implications": "**Set theory and forcing**: Regularity is the key property behind club (closed unbounded) sets and stationary sets in set theory. The pressing lemma (Fodor's theorem) — that any regressive function on a stationary set is constant on a stationary set — uses exactly the diagonal closure property of regular cardinals. Forcing arguments routinely use regularity to show that small forcing does not add cofinal sequences through regular cardinals.\n\n**Infinite combinatorics**: The $\\Delta$-system lemma (a large family of finite sets contains a large subfamily with pairwise equal intersections) uses regularity. Tree combinatorics (Aronszajn trees, Suslin trees) are defined relative to $\\omega_1$-closure.\n\n**Large cardinal theory**: Inaccessible cardinals are regular limit cardinals (i.e., regular cardinals that are also limits). They arise as the first models of ZFC (Grothendieck universes), and their existence cannot be proved in ZFC. The diagonal property is a necessary ingredient of inaccessibility.",
     "openQuestions": [
-      "Prove König's theorem: cf(Π κ_i) > Σ κ_i (the cardinal product cofinality bound)",
-      "Formalize the diagonal lemma in logic (Cantor's theorem for definability)",
-      "Prove that singular cardinals (cof(κ) < κ) do NOT satisfy the diagonal property"
+      "Can Lean 4 prove König's theorem: $\\text{cf}(\\prod_i \\kappa_i) > \\sum_i \\kappa_i$ for infinite products of cardinals? This requires formalising the proof that a product of $\\kappa_i$-sized sets cannot be covered by a sum-sized set, using a diagonal argument in each coordinate.",
+      "Formalize Fodor's pressing-down lemma (Fodor 1956): for any regular uncountable $\\kappa$, any regressive function $f: S \\to \\kappa.\\text{ord}$ on a stationary set $S \\subseteq \\kappa.\\text{ord}$ (i.e., $f(\\alpha) < \\alpha$ for all $\\alpha \\in S$) is constant on some stationary subset. This requires formalising stationary and club sets in Lean.",
+      "Prove that singular cardinals do NOT satisfy the no-surjection property: for $\\kappa = \\aleph_\\omega$, exhibit an explicit $\\aleph_0$-indexed cofinal sequence in $\\aleph_\\omega.\\text{ord}$ (namely $\\omega_{n}^{\\text{ord}}$ for $n \\in \\mathbb{N}$) that surjects onto all ordinals below $\\aleph_\\omega.\\text{ord}$.",
+      "Can the file be extended to prove that all successor cardinals $\\aleph_{\\alpha+1}$ are regular (using `Cardinal.isRegular_aleph_succ` in Mathlib)? This would make the generalisation fully self-contained."
     ]
   },
   "leanFile": {
@@ -70,5 +72,41 @@
       "description": "Both use diagonal/back-and-forth arguments in set theory; ℚ characterization uses countable case, this uses regular cardinal generalization"
     }
   ],
-  "sections": []
+  "sections": [
+    {
+      "id": "header-imports",
+      "title": "File Header and Imports",
+      "startLine": 1,
+      "endLine": 33,
+      "summary": "Overview of the generalisation, three Mathlib imports (Cardinal.Ordinal, Cardinal.Cofinality, Ordinal.Arithmetic), namespace declaration, and `open Cardinal Ordinal`."
+    },
+    {
+      "id": "regular-sup-bounded",
+      "title": "Part I: Regular Cardinals — Bounded Suprema",
+      "startLine": 34,
+      "endLine": 47,
+      "summary": "Theorem regular_sup_bounded: for regular κ, iSup of a <κ-indexed family below κ.ord is still below κ.ord. One-line proof via Ordinal.iSup_lt_ord with hκ.cof_eq bridging the regularity hypothesis."
+    },
+    {
+      "id": "succ-cardinals",
+      "title": "Part II: Successor Cardinals Below Infinite Cardinals",
+      "startLine": 48,
+      "endLine": 67,
+      "summary": "Lemmas card_succ_lt_of_lt_infinite (μ < κ and κ infinite ⟹ μ+1 < κ, by cases on finiteness) and ord_succ_lt (α < κ.ord ⟹ α+1 < κ.ord), providing the limit-ordinal property needed for the diagonal witness."
+    },
+    {
+      "id": "diagonal-argument",
+      "title": "Part III: The Generalized Diagonal Argument",
+      "startLine": 68,
+      "endLine": 99,
+      "summary": "Main results: regular_diagonal (witnesses ∃β < κ.ord exceeding all f(i) via sup+1) and regular_no_surjection (contradiction from diagonal ordinal being in the range). Uses le_ciSup, BddAbove, lt_irrefl."
+    },
+    {
+      "id": "aleph1-recovery",
+      "title": "Part IV: Recovering the ℵ₁ Case",
+      "startLine": 100,
+      "endLine": 142,
+      "summary": "Private lemma aleph0_lt_aleph1, then aleph1_diagonal instantiating regular_diagonal at κ=ℵ₁ with f: ℕ→Ord. Summary comment explains why regularity is necessary and singular cardinals fail."
+    }
+  ]
 }

--- a/src/data/proofs/cauchy-schwarz-oq-02/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02/annotations.json
@@ -1,1 +1,98 @@
-[]
+[
+  {
+    "id": "csq02-ann-01",
+    "proofId": "cauchy-schwarz-oq-02",
+    "range": { "startLine": 1, "endLine": 42 },
+    "type": "context",
+    "title": "Imports and Proof Architecture",
+    "content": "The file opens with six targeted Mathlib imports that supply the entire mathematical infrastructure: `Analysis.InnerProductSpace.Basic` for inner product spaces and the Cauchy-Schwarz inequality in abstract Hilbert spaces; `Analysis.MeanInequalities` for Hölder's and Minkowski's inequalities in the NNReal and Lp settings; `MeasureTheory.Function.L2Space` for the concrete L² function space over a measure space; `Analysis.MeanInequalitiesPow` for the power-mean machinery used in the Hölder conjugate calculations; `Topology.Algebra.Module.Basic` for the topological module structure on L²; and `Analysis.InnerProductSpace.Projection` for orthogonal projection results used implicitly in the Bessel section. The namespace `CauchySchwarzExtensions` keeps all 18 theorem names scoped, preventing collision with Mathlib's own Cauchy-Schwarz variants. The overview comment signals the file's organizing principle: Cauchy-Schwarz is not an isolated fact but the p=q=2 tip of the Hölder iceberg, and the L² structure theorems (Pythagorean, parallelogram, polarization) sit naturally adjacent to it.",
+    "mathContext": "The six imports collectively give access to: conjugate exponent arithmetic ($\\frac{1}{p}+\\frac{1}{q}=1$), the inequality $\\sum_{i} f_i g_i \\le \\left(\\sum_i f_i^p\\right)^{1/p}\\left(\\sum_i g_i^q\\right)^{1/q}$, the L² inner product $\\langle f, g\\rangle = \\int f g\\,d\\mu$, and the norm $\\|f\\|_2 = \\left(\\int f^2\\,d\\mu\\right)^{1/2}$.",
+    "significance": "context",
+    "relatedConcepts": ["Mathlib import strategy", "namespace scoping", "Lp spaces", "inner product spaces"],
+    "prerequisites": ["Lean 4 module system", "Mathlib library structure", "measure spaces"]
+  },
+  {
+    "id": "csq02-ann-02",
+    "proofId": "cauchy-schwarz-oq-02",
+    "range": { "startLine": 44, "endLine": 108 },
+    "type": "technique",
+    "title": "Hölder's Inequality and the L² Bridge",
+    "content": "Part 1 establishes `holder_finite_nnreal`, which delegates to Mathlib's `NNReal.inner_le_Lp_mul_Lq`. The key insight is that NNReal (non-negative reals) is exactly the right type for Hölder sums: subtraction is not needed, so the NNReal typeclass avoids spurious hypotheses about non-negativity. `cauchy_schwarz_from_holder` then specializes to p=q=2 using `Real.HolderConjugate.conjExponent`, which computes that the conjugate exponent of 2 is 2. This makes explicit the classical fact that Cauchy-Schwarz is Hölder at the self-conjugate point.\n\nPart 2 builds the bridge between abstract inner product space notation and concrete measure-theoretic integrals. `memLp_two_iff_sq_integrable` characterizes membership in L²: a function f is in L²(μ) if and only if f² is μ-integrable. `L2_inner_integrable` ensures that the pointwise product of two L² functions is integrable (a prerequisite for computing ⟨f,g⟩ as an integral). `L2_inner_eq_integral'` makes the identification ⟨f,g⟩ = ∫ f·g dμ fully explicit, and `L2_norm_sq_eq_integral` pins down ‖f‖² = ∫ f² dμ. These bridge lemmas are the scaffolding on which all subsequent L² proofs rest.",
+    "mathContext": "Hölder's inequality: for $\\frac{1}{p}+\\frac{1}{q}=1$, $\\sum_{i} f_i g_i \\le \\left(\\sum_i f_i^p\\right)^{1/p}\\left(\\sum_i g_i^q\\right)^{1/q}$. At $p=q=2$: $\\sum f_i g_i \\le \\sqrt{\\sum f_i^2}\\cdot\\sqrt{\\sum g_i^2}$ (Cauchy-Schwarz). The norm-integral bridge: $\\|f\\|_{L^2}^2 = \\int f(x)^2\\,d\\mu(x)$ and $\\langle f,g\\rangle_{L^2} = \\int f(x)g(x)\\,d\\mu(x)$.",
+    "significance": "key",
+    "relatedConcepts": ["Hölder's inequality", "NNReal", "conjugate exponents", "L² membership", "Bochner integral"],
+    "prerequisites": ["finite measure spaces", "NNReal typeclass", "Lp spaces in Mathlib", "inner product space axioms"]
+  },
+  {
+    "id": "csq02-ann-03",
+    "proofId": "cauchy-schwarz-oq-02",
+    "range": { "startLine": 110, "endLine": 133 },
+    "type": "concept",
+    "title": "Pythagorean Theorem in L²",
+    "content": "`pythagorean_L2` proves that if ⟨f,g⟩ = 0 in L² then ‖f+g‖² = ‖f‖² + ‖g‖². The proof expands ‖f+g‖² = ⟨f+g, f+g⟩ = ⟨f,f⟩ + 2⟨f,g⟩ + ⟨g,g⟩ and uses the hypothesis ⟨f,g⟩ = 0 to eliminate the cross term. `pythagorean_L2_iff` strengthens this to an equivalence: ‖f+g‖² = ‖f‖² + ‖g‖² if and only if ⟨f,g⟩ = 0. The reverse direction uses the fact that 2⟨f,g⟩ = 0 implies ⟨f,g⟩ = 0 (automatically satisfied over ℝ since char ≠ 2).\n\nThis result is the functional-analytic analogue of the classical Pythagorean theorem for right triangles, with orthogonality defined not by angle but by vanishing inner product. In Fourier analysis, this is the engine behind Parseval's identity: mutually orthogonal Fourier modes contribute their squared coefficients additively to the total L² norm.",
+    "mathContext": "Pythagorean theorem in $L^2(\\mu)$: if $\\langle f,g\\rangle = 0$ then $\\|f+g\\|^2 = \\|f\\|^2 + \\|g\\|^2$. Expansion: $\\|f+g\\|^2 = \\langle f+g,f+g\\rangle = \\|f\\|^2 + 2\\langle f,g\\rangle + \\|g\\|^2$. Orthogonality kills the cross term. The equivalence: $\\|f+g\\|^2 = \\|f\\|^2 + \\|g\\|^2 \\iff \\langle f,g\\rangle = 0$ over $\\mathbb{R}$.",
+    "significance": "key",
+    "relatedConcepts": ["orthogonality", "inner product expansion", "Parseval's theorem", "Fourier analysis", "right angle in Hilbert space"],
+    "prerequisites": ["inner product space over ℝ", "L² norm via integral", "bilinearity of inner product"]
+  },
+  {
+    "id": "csq02-ann-04",
+    "proofId": "cauchy-schwarz-oq-02",
+    "range": { "startLine": 134, "endLine": 173 },
+    "type": "insight",
+    "title": "Parallelogram Law and Polarization Identity",
+    "content": "The parallelogram law `parallelogram_law` is proved for any real InnerProductSpace E, not just L². It states ‖f+g‖² + ‖f-g‖² = 2‖f‖² + 2‖g‖². Geometrically, this says the sum of the squares of the diagonals of a parallelogram equals twice the sum of the squares of the sides. Jordan and von Neumann (1935) proved a Banach space is an inner product space if and only if its norm satisfies the parallelogram law, making this the definitive characterization of Hilbert space geometry. `parallelogram_law_L2` specializes to L².\n\nThe polarization identity `polarization_identity` recovers ⟨f,g⟩ from norms alone: ⟨f,g⟩ = (‖f+g‖² - ‖f-g‖²)/4. An alternative form gives (‖f+g‖² - ‖f‖² - ‖g‖²)/2. This makes the inner product a derived quantity from the norm geometry, and explains why any Banach space satisfying the parallelogram law can be endowed with a unique inner product structure. In quantum mechanics, this is how one passes between the bra-ket inner product and norm-based probability amplitudes.",
+    "mathContext": "Parallelogram law: $\\|f+g\\|^2 + \\|f-g\\|^2 = 2\\|f\\|^2 + 2\\|g\\|^2$. Polarization identity (real): $\\langle f,g\\rangle = \\frac{\\|f+g\\|^2 - \\|f-g\\|^2}{4}$. Alternative: $\\langle f,g\\rangle = \\frac{\\|f+g\\|^2 - \\|f\\|^2 - \\|g\\|^2}{2}$. Jordan–von Neumann: a Banach space is a Hilbert space $\\iff$ the parallelogram law holds for its norm.",
+    "significance": "key",
+    "relatedConcepts": ["Jordan-von Neumann theorem", "Banach space characterization", "Hilbert space", "norm geometry", "quantum mechanics"],
+    "prerequisites": ["InnerProductSpace typeclass", "norm vs inner product", "Banach spaces", "real vs complex polarization"]
+  },
+  {
+    "id": "csq02-ann-05",
+    "proofId": "cauchy-schwarz-oq-02",
+    "range": { "startLine": 174, "endLine": 218 },
+    "type": "technique",
+    "title": "Weighted Cauchy-Schwarz and AM-GM via Square-Root Substitution",
+    "content": "`weighted_cauchy_schwarz` proves (Σ wᵢaᵢ)² ≤ (Σ wᵢ)(Σ wᵢaᵢ²) for non-negative weights wᵢ. The proof uses the square-root substitution trick: define a'ᵢ = √wᵢ and b'ᵢ = √wᵢ·aᵢ. Then (Σ wᵢaᵢ) = Σ a'ᵢb'ᵢ, (Σ wᵢ) = Σ (a'ᵢ)², and (Σ wᵢaᵢ²) = Σ (b'ᵢ)². Standard Cauchy-Schwarz applied to the primed sequences yields (Σ a'ᵢb'ᵢ)² ≤ (Σ (a'ᵢ)²)(Σ (b'ᵢ)²), which is exactly the weighted inequality. This substitution is ubiquitous in competition mathematics and in probability theory, where wᵢ are probability weights and the inequality bounds the variance.\n\n`amgm_from_cauchy_schwarz` derives the arithmetic-geometric mean inequality (√(ab) ≤ (a+b)/2 for a,b ≥ 0) from Cauchy-Schwarz via the expansion (√a - √b)² ≥ 0, giving a + b - 2√(ab) ≥ 0. This shows AM-GM is a one-dimensional shadow of the general inner product inequality, and that these classical inequalities form a tightly interlocked system rather than independent facts.",
+    "mathContext": "Weighted Cauchy-Schwarz: $\\left(\\sum_i w_i a_i\\right)^2 \\le \\left(\\sum_i w_i\\right)\\left(\\sum_i w_i a_i^2\\right)$. Substitution: $a_i' = \\sqrt{w_i}$, $b_i' = \\sqrt{w_i}\\,a_i$ reduces to standard CS: $\\left(\\sum a_i' b_i'\\right)^2 \\le \\left(\\sum (a_i')^2\\right)\\left(\\sum (b_i')^2\\right)$. AM-GM: $(\\sqrt{a}-\\sqrt{b})^2 \\ge 0 \\implies \\sqrt{ab} \\le \\tfrac{a+b}{2}$.",
+    "significance": "key",
+    "relatedConcepts": ["weighted inequalities", "AM-GM inequality", "square-root substitution", "probability weights", "variance bounds"],
+    "prerequisites": ["standard Cauchy-Schwarz", "NNReal square roots", "Finset sum manipulation"]
+  },
+  {
+    "id": "csq02-ann-06",
+    "proofId": "cauchy-schwarz-oq-02",
+    "range": { "startLine": 219, "endLine": 260 },
+    "type": "concept",
+    "title": "L1-L2 Norm Comparison and Triangle Inequality via Cauchy-Schwarz",
+    "content": "`L1_le_sqrt_n_L2` proves ‖a‖₁² ≤ n·‖a‖₂² for vectors in ℝⁿ. This is Cauchy-Schwarz applied to the pair (|aᵢ|, 1): (Σ |aᵢ|·1)² ≤ (Σ aᵢ²)(Σ 1²) = n·Σaᵢ². The result bounds the L1 norm (computationally tractable, favored in sparse recovery) in terms of the L2 norm (geometrically natural). In compressed sensing and LASSO regression, this inequality is used to pass between sparsity-promoting L1 objectives and energy-measuring L2 objectives.\n\n`triangle_ineq_via_CS` recovers the triangle inequality ‖f+g‖ ≤ ‖f‖ + ‖g‖ from Cauchy-Schwarz, completing the verification that L² is a Banach space. The derivation ‖f+g‖² ≤ ‖f‖² + 2‖f‖‖g‖ + ‖g‖² = (‖f‖+‖g‖)² uses CS to bound the cross term ⟨f,g⟩ ≤ ‖f‖‖g‖. This is the historical argument by which Minkowski established the triangle inequality for L2 norms, predating the abstract inner product space framework.",
+    "mathContext": "L1-L2 comparison in $\\mathbb{R}^n$: $\\|a\\|_1^2 = \\left(\\sum_i |a_i|\\right)^2 \\le n \\sum_i a_i^2 = n\\|a\\|_2^2$. Triangle inequality: $\\|f+g\\|^2 \\le \\|f\\|^2 + 2\\|f\\|\\|g\\| + \\|g\\|^2 = (\\|f\\|+\\|g\\|)^2$, so $\\|f+g\\| \\le \\|f\\|+\\|g\\|$. Factor $\\sqrt{n}$ is tight: achieved by the all-ones vector.",
+    "significance": "supporting",
+    "relatedConcepts": ["norm comparison inequalities", "Minkowski inequality", "triangle inequality", "compressed sensing", "LASSO"],
+    "prerequisites": ["L1 and L2 norms", "Cauchy-Schwarz in inner product spaces", "Finset.card", "NNReal arithmetic"]
+  },
+  {
+    "id": "csq02-ann-07",
+    "proofId": "cauchy-schwarz-oq-02",
+    "range": { "startLine": 261, "endLine": 310 },
+    "type": "concept",
+    "title": "Bessel's Inequality for Finite Orthonormal Systems",
+    "content": "`bessel_finite` proves that for an orthonormal system {e₁,...,eₙ} in an inner product space H, the sum of squared Fourier coefficients is bounded by the norm squared: Σᵢ ⟨x,eᵢ⟩² ≤ ‖x‖² for any x ∈ H. The proof expands ‖x - Σᵢ ⟨x,eᵢ⟩eᵢ‖² ≥ 0. The orthogonal projection Px = Σᵢ ⟨x,eᵢ⟩eᵢ satisfies ‖Px‖² = Σᵢ ⟨x,eᵢ⟩² by the Pythagorean theorem (the orthonormal components are mutually orthogonal). Since x = Px + (x-Px) is an orthogonal decomposition, ‖x‖² = ‖Px‖² + ‖x-Px‖² ≥ ‖Px‖².\n\nBessel's inequality is the key finite-dimensional step toward Parseval's identity. Equality holds when {eᵢ} is a complete orthonormal basis — i.e., when the projection exhausts the entire element. In spectral theory, Bessel's inequality guarantees that for any x, the sequence of Fourier coefficients (⟨x,eᵢ⟩)ᵢ is always square-summable (belongs to l²), even before any completeness assumption is made. This is essential for defining Fourier series as L² objects.",
+    "mathContext": "Bessel's inequality: for orthonormal $\\{e_1,\\ldots,e_n\\}$ in $H$, $\\sum_{i=1}^n \\langle x, e_i\\rangle^2 \\le \\|x\\|^2$. Proof via projection: $0 \\le \\left\\|x - \\sum_i \\langle x,e_i\\rangle e_i\\right\\|^2 = \\|x\\|^2 - \\sum_i \\langle x,e_i\\rangle^2$. Equality (Parseval): $\\sum_i \\langle x,e_i\\rangle^2 = \\|x\\|^2$ iff $\\{e_i\\}$ is a complete ONB.",
+    "significance": "key",
+    "relatedConcepts": ["Bessel's inequality", "Parseval's identity", "orthonormal basis", "spectral theory", "Fourier coefficients", "l² summability"],
+    "prerequisites": ["orthonormal systems", "Pythagorean theorem in Hilbert space", "orthogonal projection", "completeness of ONB"]
+  },
+  {
+    "id": "csq02-ann-08",
+    "proofId": "cauchy-schwarz-oq-02",
+    "range": { "startLine": 311, "endLine": 335 },
+    "type": "insight",
+    "title": "Summary: The Cauchy-Schwarz Landscape",
+    "content": "The closing section consolidates 18 theorems into a coherent picture of the Cauchy-Schwarz landscape. The file demonstrates four perspectives on what is ultimately a single inequality: (1) algebraic — Cauchy-Schwarz is Hölder at the self-conjugate point p=q=2; (2) geometric — the Pythagorean theorem and the parallelogram law characterize the Hilbert space structure of L²; (3) analytic — the polarization identity reconstructs the inner product from purely metric data (the norm); (4) spectral — Bessel's inequality bounds the energy captured by any finite orthonormal subsystem.\n\nThe logical dependency chain is: Hölder (NNReal) → Cauchy-Schwarz (p=q=2) → L² norm bridges → Pythagorean theorem → Bessel's inequality → (limit) Parseval's identity. Every step is machine-verified with 0 sorries and 0 axioms, relying on Mathlib's `NNReal.inner_le_Lp_mul_Lq` and `L2Space`. The file exemplifies a design principle: when formalizing one result, carry through its natural family of extensions in the same namespace, so the logical relationships are visible and verified together.",
+    "mathContext": "The dependency chain: $\\text{H\\\"older}(p,q) \\xrightarrow{p=q=2} \\text{CS} \\xrightarrow{\\text{bridge}} \\|f\\|^2 = \\int f^2 \\xrightarrow{\\langle f,g\\rangle=0} \\text{Pythagorean} \\xrightarrow{\\text{ONB}} \\text{Bessel}: \\sum \\langle x,e_i\\rangle^2 \\le \\|x\\|^2 \\xrightarrow{\\text{complete}} \\text{Parseval}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["proof architecture", "theorem dependency", "functional analysis", "Parseval", "Hilbert space theory"],
+    "prerequisites": ["all previous sections", "Mathlib L2Space", "NNReal.inner_le_Lp_mul_Lq"]
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02/meta.json
@@ -8,13 +8,7 @@
     "date": "2026-02-15",
     "status": "verified",
     "proofRepoPath": "Proofs/CauchySchwarzOQ02.lean",
-    "tags": [
-      "analysis",
-      "cauchy-schwarz",
-      "holder-inequality",
-      "l2-spaces",
-      "measure-theory"
-    ],
+    "tags": ["analysis","cauchy-schwarz","holder-inequality","l2-spaces","measure-theory"],
     "badge": "original",
     "sorries": 0,
     "dateAdded": "2026-04-02",
@@ -39,9 +33,11 @@
     "proofStrategy": "Apply NNReal.inner_le_Lp_mul_Lq from Mathlib for Hölder. Use L2Space, MeasureTheory.inner_le_Lp_mul_Lq for the L² results. Derive Cauchy-Schwarz as p=q=2 specialization. Prove structural identities from inner product axioms.",
     "keyInsights": [
       "Hölder contains Cauchy-Schwarz: the p=q=2 case gives ∑ fg ≤ √(∑f²)√(∑g²)",
-      "L² Pythagorean theorem: orthogonality via inner product vanishing",
-      "Parallelogram law: characterizes inner product spaces (vs. general Banach spaces)",
-      "Polarization identity: recovers the inner product from the norm"
+      "L² Pythagorean theorem: orthogonality via inner product vanishing gives ‖f+g‖² = ‖f‖² + ‖g‖²",
+      "Parallelogram law: characterizes inner product spaces among all Banach spaces (Jordan–von Neumann 1935)",
+      "Polarization identity: recovers the inner product from the norm, making ⟨f,g⟩ a derived quantity",
+      "Bessel's inequality: ∑ᵢ ⟨x,eᵢ⟩² ≤ ‖x‖² for any finite orthonormal system; equality in the limit (complete ONB) gives Parseval's identity ∑|ĉₙ|² = ‖f‖²",
+      "Weighted Cauchy-Schwarz via square-root substitution: setting a'ᵢ=√wᵢ, b'ᵢ=√wᵢ·aᵢ reduces the weighted inequality to standard Cauchy-Schwarz, a trick that generalizes to any positive measure"
     ],
     "prerequisites": [
       "Inner product spaces: L² norm, ⟨f,g⟩, orthogonality",
@@ -50,12 +46,14 @@
     ]
   },
   "conclusion": {
-    "summary": "Cauchy-Schwarz extended to Hölder family: Hölder inequality, L² Pythagorean, parallelogram law, polarization identity, weighted Cauchy-Schwarz, Minkowski. 18 theorems, 335 lines, 0 axioms.",
+    "summary": "Cauchy-Schwarz extended to Hölder family: Hölder inequality, L² Pythagorean, parallelogram law, polarization identity, weighted Cauchy-Schwarz, Minkowski, Bessel's inequality. 18 theorems, 335 lines, 0 axioms.",
     "implications": "The Hölder-Minkowski family underlies all of functional analysis and harmonic analysis. The L² results are foundational for Fourier analysis (Parseval's identity follows from the Pythagorean theorem) and quantum mechanics (Hilbert space formulation).",
     "openQuestions": [
-      "Formalize Parseval's identity: ∑|ĉₙ|² = ‖f‖² for Fourier coefficients",
-      "Prove the reverse Hölder (Kantorovich) inequality",
-      "Formalize the Riesz representation theorem in L²"
+      "Formalize Parseval's identity: ∑|ĉₙ|² = ‖f‖² for Fourier coefficients (the infinite-dimensional limit of Bessel's inequality when the ONB is complete)",
+      "Prove Bessel's inequality in infinite dimensions: ∑ᵢ ⟨x,eᵢ⟩² ≤ ‖x‖² for a countably infinite orthonormal system, and show the partial sums converge",
+      "Formalize the complex polarization identity: ⟨f,g⟩ = (‖f+g‖² - ‖f-g‖² + i‖f+ig‖² - i‖f-ig‖²)/4 for complex Hilbert spaces",
+      "Prove the operator-norm version of Cauchy-Schwarz: |⟨Af,g⟩|² ≤ ⟨Af,f⟩·⟨Ag,g⟩ for positive operators A, used in quantum mechanics as the Robertson uncertainty principle",
+      "Formalize the Riesz representation theorem in L²: every bounded linear functional on L² is given by inner product with a unique element"
     ]
   },
   "leanFile": {
@@ -72,5 +70,69 @@
       "description": "Cauchy-Schwarz inequality; OQ-02 adds Hölder, L² structure theorems, and Minkowski"
     }
   ],
-  "sections": []
+  "sections": [
+    {
+      "id": "sec-01-imports",
+      "title": "Imports and Namespace Setup",
+      "startLine": 1,
+      "endLine": 42,
+      "summary": "Six Mathlib imports providing NNReal Hölder, L² function spaces, and inner product space infrastructure. Namespace CauchySchwarzExtensions scopes all 18 theorems. Overview comment establishes the organizing principle: Cauchy-Schwarz as the p=q=2 case of Hölder."
+    },
+    {
+      "id": "sec-02-holder",
+      "title": "Part 1: Hölder's Inequality for Finite NNReal Sums",
+      "startLine": 44,
+      "endLine": 67,
+      "summary": "holder_finite_nnreal delegates to NNReal.inner_le_Lp_mul_Lq. cauchy_schwarz_from_holder specializes to p=q=2 via Real.HolderConjugate.conjExponent. Establishes the Hölder-Cauchy-Schwarz hierarchy in the discrete finite-sum setting."
+    },
+    {
+      "id": "sec-03-l2-bridge",
+      "title": "Part 2: L² Norm Bridge Lemmas",
+      "startLine": 68,
+      "endLine": 108,
+      "summary": "Four bridge lemmas connecting abstract inner product notation to measure-theoretic integrals: memLp_two_iff_sq_integrable, L2_inner_integrable, L2_inner_eq_integral' (⟨f,g⟩ = ∫ fg dμ), and L2_norm_sq_eq_integral (‖f‖² = ∫ f² dμ). These are the scaffolding for all subsequent L² results."
+    },
+    {
+      "id": "sec-04-pythagorean",
+      "title": "Part 3: Pythagorean Theorem in L²",
+      "startLine": 110,
+      "endLine": 133,
+      "summary": "pythagorean_L2 proves ⟨f,g⟩=0 implies ‖f+g‖²=‖f‖²+‖g‖² by expanding the inner product and eliminating the cross term. pythagorean_L2_iff establishes the biconditional. Fundamental for Parseval's identity and Fourier analysis."
+    },
+    {
+      "id": "sec-05-parallelogram",
+      "title": "Part 4: Parallelogram Law",
+      "startLine": 134,
+      "endLine": 151,
+      "summary": "parallelogram_law proved for generic InnerProductSpace ℝ E: ‖f+g‖²+‖f-g‖²=2‖f‖²+2‖g‖². parallelogram_law_L2 specializes to L². This law characterizes Hilbert space geometry among all Banach spaces (Jordan–von Neumann 1935)."
+    },
+    {
+      "id": "sec-06-polarization",
+      "title": "Part 5: Polarization Identity",
+      "startLine": 153,
+      "endLine": 173,
+      "summary": "polarization_identity proves ⟨f,g⟩=(‖f+g‖²-‖f-g‖²)/4. Alternative form: (‖f+g‖²-‖f‖²-‖g‖²)/2. The inner product is recovered from norm geometry alone, justifying why the parallelogram law suffices to define an inner product on any Banach space that satisfies it."
+    },
+    {
+      "id": "sec-07-weighted",
+      "title": "Part 6 & 7: Weighted Cauchy-Schwarz and AM-GM",
+      "startLine": 174,
+      "endLine": 218,
+      "summary": "weighted_cauchy_schwarz: (Σ wᵢaᵢ)² ≤ (Σ wᵢ)(Σ wᵢaᵢ²) proved via square-root substitution a'ᵢ=√wᵢ, b'ᵢ=√wᵢaᵢ reducing to standard CS. amgm_from_cauchy_schwarz: √(ab)≤(a+b)/2 via (√a-√b)²≥0. Both show classical scalar inequalities as special cases of the inner product framework."
+    },
+    {
+      "id": "sec-08-norm-triangle",
+      "title": "Part 8: L1-L2 Comparison and Triangle Inequality",
+      "startLine": 219,
+      "endLine": 260,
+      "summary": "L1_le_sqrt_n_L2 proves ‖a‖₁² ≤ n·‖a‖₂² (CS with the all-ones vector). triangle_ineq_via_CS recovers the triangle inequality ‖f+g‖≤‖f‖+‖g‖ from CS, reproducing Minkowski's original argument. Verifies L² is a Banach space."
+    },
+    {
+      "id": "sec-09-bessel",
+      "title": "Part 9: Bessel's Inequality for Finite Orthonormal Systems",
+      "startLine": 261,
+      "endLine": 335,
+      "summary": "bessel_finite proves ∑ᵢ⟨x,eᵢ⟩²≤‖x‖² for orthonormal {e₁,...,eₙ} via ‖x-Px‖²≥0 where Px=∑⟨x,eᵢ⟩eᵢ. Equality would give Parseval. Closing summary section establishes the full dependency chain from Hölder to Bessel and positions Parseval's identity as the natural next step."
+    }
+  ]
 }

--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -918,6 +918,11 @@
       "passes": 1,
       "lastEnriched": "2026-04-03T12:06:39Z",
       "quality": 100
+    },
+    "cantor-diagonalization-oq-03-oq-01": {
+      "passes": 1,
+      "lastEnriched": "2026-04-03T14:07:48Z",
+      "quality": 30
     }
   },
   "elementary-quadratic-reciprocity-oq-03-oq-03": {

--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-01.json
@@ -1,0 +1,64 @@
+{
+  "slug": "abel-ruffini-galois-extensions-oq-01",
+  "title": "Formalize the explicit quintic unsolvability: construct a specific degree-5 p...",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "",
+    "plain": "",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-04-03T05:50:14-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [],
+    "markdown": "# Knowledge Base: abel-ruffini-galois-extensions-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [],
+  "relatedProofs": [
+    "abel-ruffini",
+    "abel-ruffini-galois-extensions"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-04-03T05:50:14-07:00",
+  "significance": 7,
+  "leanFiles": [
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
+      "filename": "AbelRuffiniGaloisExtensions.lean",
+      "lineCount": 535,
+      "theoremCount": 57,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensions.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
@@ -1,0 +1,158 @@
+{
+  "slug": "amgm-inequality-oq-02-oq-01-oq-01",
+  "title": "Prove the full Newton-Girard recurrence: p_k = Σ_{i=1}^k (-1)^{i-1} eᵢ p_{k-i}",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "",
+    "plain": "",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-04-03T05:50:13-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [],
+    "markdown": "# Knowledge Base: amgm-inequality-oq-02-oq-01-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [],
+  "relatedProofs": [
+    "amgm-inequality",
+    "amgm-inequality-oq-02",
+    "amgm-inequality-oq-02-oq-01",
+    "amgm-inequality-oq-02-oq-03",
+    "amgm-inequality-oq-03",
+    "amgm-inequality-oq-03-oq-01",
+    "amgm-inequality-oq-03-oq-03",
+    "amgm-inequality-oq-04"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-04-03T05:50:13-07:00",
+  "significance": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/AmgmInequalityOQ02.lean",
+      "filename": "AmgmInequalityOQ02.lean",
+      "lineCount": 544,
+      "theoremCount": 16,
+      "axiomCount": 2,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ02Aristotle.lean",
+      "filename": "AmgmInequalityOQ02Aristotle.lean",
+      "lineCount": 353,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02Aristotle.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ02Defs.lean",
+      "filename": "AmgmInequalityOQ02Defs.lean",
+      "lineCount": 394,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02Defs.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
+      "filename": "AmgmInequalityOQ02OQ02.lean",
+      "lineCount": 960,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
+      "filename": "AmgmInequalityOQ02OQ03.lean",
+      "lineCount": 227,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
+      "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
+      "lineCount": 67,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ03OQ03.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ03.lean",
+      "filename": "AmgmInequalityOQ03.lean",
+      "lineCount": 373,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ03OQ03.lean",
+      "filename": "AmgmInequalityOQ03OQ03.lean",
+      "lineCount": 66,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ03.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ04.lean",
+      "filename": "AmgmInequalityOQ04.lean",
+      "lineCount": 308,
+      "theoremCount": 21,
+      "axiomCount": 3,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/angle-trisection-oq-01-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-01-oq-03.json
@@ -1,0 +1,251 @@
+{
+  "slug": "angle-trisection-oq-01-oq-03",
+  "title": "Prove the angle trisection impossibility from this degree criterion",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "",
+    "plain": "",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-04-03T05:50:19-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [],
+    "markdown": "# Knowledge Base: angle-trisection-oq-01-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [],
+  "relatedProofs": [
+    "angle-trisection",
+    "angle-trisection-oq-01",
+    "angle-trisection-oq-02",
+    "angle-trisection-oq-02-oq-01",
+    "angle-trisection-oq-02-oq-01-oq-01",
+    "angle-trisection-oq-02-oq-02",
+    "angle-trisection-oq-02-oq-03",
+    "angle-trisection-oq-02-oq-03-oq-01",
+    "angle-trisection-oq-02-oq-04",
+    "angle-trisection-oq-02-oq-04-oq-01",
+    "angle-trisection-oq-03",
+    "angle-trisection-oq-05",
+    "angle-trisection-oq-05-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-04-03T05:50:19-07:00",
+  "significance": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/AngleTrisection.lean",
+      "filename": "AngleTrisection.lean",
+      "lineCount": 384,
+      "theoremCount": 23,
+      "axiomCount": 0,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisection.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionCos20Gal.lean",
+      "filename": "AngleTrisectionCos20Gal.lean",
+      "lineCount": 475,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionEmbedding.lean",
+      "filename": "AngleTrisectionEmbedding.lean",
+      "lineCount": 175,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionEmbedding.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionOQ01.lean",
+      "filename": "AngleTrisectionOQ01.lean",
+      "lineCount": 367,
+      "theoremCount": 40,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ01.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionOQ02.lean",
+      "filename": "AngleTrisectionOQ02.lean",
+      "lineCount": 299,
+      "theoremCount": 15,
+      "axiomCount": 1,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionOQ02OQ01.lean",
+      "filename": "AngleTrisectionOQ02OQ01.lean",
+      "lineCount": 116,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionOQ02OQ01OQ01.lean",
+      "filename": "AngleTrisectionOQ02OQ01OQ01.lean",
+      "lineCount": 124,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionOQ02OQ02.lean",
+      "filename": "AngleTrisectionOQ02OQ02.lean",
+      "lineCount": 286,
+      "theoremCount": 27,
+      "axiomCount": 1,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionOQ02OQ03.lean",
+      "filename": "AngleTrisectionOQ02OQ03.lean",
+      "lineCount": 1800,
+      "theoremCount": 150,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionOQ02OQ03Ext.lean",
+      "filename": "AngleTrisectionOQ02OQ03Ext.lean",
+      "lineCount": 298,
+      "theoremCount": 55,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ03Ext.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionOQ02OQ03OQ01.lean",
+      "filename": "AngleTrisectionOQ02OQ03OQ01.lean",
+      "lineCount": 741,
+      "theoremCount": 32,
+      "axiomCount": 0,
+      "defCount": 9,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionOQ02OQ04.lean",
+      "filename": "AngleTrisectionOQ02OQ04.lean",
+      "lineCount": 164,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ04.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionOQ02OQ04OQ01.lean",
+      "filename": "AngleTrisectionOQ02OQ04OQ01.lean",
+      "lineCount": 335,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 3,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionOQ03.lean",
+      "filename": "AngleTrisectionOQ03.lean",
+      "lineCount": 227,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ03.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionOQ04.lean",
+      "filename": "AngleTrisectionOQ04.lean",
+      "lineCount": 600,
+      "theoremCount": 43,
+      "axiomCount": 0,
+      "defCount": 10,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ04.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionOQ05.lean",
+      "filename": "AngleTrisectionOQ05.lean",
+      "lineCount": 696,
+      "theoremCount": 27,
+      "axiomCount": 0,
+      "defCount": 9,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ05.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionOQ05OQ01.lean",
+      "filename": "AngleTrisectionOQ05OQ01.lean",
+      "lineCount": 295,
+      "theoremCount": 28,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ05OQ01.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-04.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-04.json
@@ -1,0 +1,218 @@
+{
+  "slug": "binomial-theorem-oq-02-oq-04",
+  "title": "Is there a direct Lean proof of the multinomial theorem by induction on |s| t...",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "",
+    "plain": "",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-04-03T05:50:19-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [],
+    "markdown": "# Knowledge Base: binomial-theorem-oq-02-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [],
+  "relatedProofs": [
+    "binomial-theorem",
+    "binomial-theorem-oq-01",
+    "binomial-theorem-oq-01-oq-01",
+    "binomial-theorem-oq-02",
+    "binomial-theorem-oq-02-oq-01",
+    "binomial-theorem-oq-02-oq-02",
+    "binomial-theorem-oq-02-oq-03",
+    "binomial-theorem-oq-03",
+    "binomial-theorem-oq-03-oq-02",
+    "binomial-theorem-oq-04",
+    "binomial-theorem-oq-04-oq-01",
+    "binomial-theorem-oq-04-oq-02",
+    "binomial-theorem-oq-04-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-04-03T05:50:19-07:00",
+  "significance": 4,
+  "leanFiles": [
+    {
+      "path": "Proofs/BinomialTheorem.lean",
+      "filename": "BinomialTheorem.lean",
+      "lineCount": 177,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheorem.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ01.lean",
+      "filename": "BinomialTheoremOQ01.lean",
+      "lineCount": 265,
+      "theoremCount": 17,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ01.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ01Aristotle.lean",
+      "filename": "BinomialTheoremOQ01Aristotle.lean",
+      "lineCount": 112,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ01Aristotle.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ01OQ01.lean",
+      "filename": "BinomialTheoremOQ01OQ01.lean",
+      "lineCount": 221,
+      "theoremCount": 17,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ02.lean",
+      "filename": "BinomialTheoremOQ02.lean",
+      "lineCount": 281,
+      "theoremCount": 17,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ02OQ01.lean",
+      "filename": "BinomialTheoremOQ02OQ01.lean",
+      "lineCount": 223,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ02OQ02.lean",
+      "filename": "BinomialTheoremOQ02OQ02.lean",
+      "lineCount": 180,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ02OQ03.lean",
+      "filename": "BinomialTheoremOQ02OQ03.lean",
+      "lineCount": 270,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ03.lean",
+      "filename": "BinomialTheoremOQ03.lean",
+      "lineCount": 589,
+      "theoremCount": 33,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ03OQ02.lean",
+      "filename": "BinomialTheoremOQ03OQ02.lean",
+      "lineCount": 216,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ04.lean",
+      "filename": "BinomialTheoremOQ04.lean",
+      "lineCount": 196,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ04.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ04OQ01.lean",
+      "filename": "BinomialTheoremOQ04OQ01.lean",
+      "lineCount": 300,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ04OQ02.lean",
+      "filename": "BinomialTheoremOQ04OQ02.lean",
+      "lineCount": 112,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ04OQ02.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ04OQ03.lean",
+      "filename": "BinomialTheoremOQ04OQ03.lean",
+      "lineCount": 191,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ04OQ03.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-04.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-04.json
@@ -1,0 +1,194 @@
+{
+  "slug": "borsuk-ulam-oq-02-oq-04",
+  "title": "For non-free ℤ/p actions: does the equivariant index still control vanishing,...",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "",
+    "plain": "",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-04-03T05:50:19-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [],
+    "markdown": "# Knowledge Base: borsuk-ulam-oq-02-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [],
+  "relatedProofs": [
+    "borsuk-ulam",
+    "borsuk-ulam-oq-02",
+    "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-04",
+    "borsuk-ulam-oq-02-oq-02",
+    "borsuk-ulam-oq-02-oq-03",
+    "borsuk-ulam-oq-03",
+    "borsuk-ulam-oq-03-oq-01",
+    "borsuk-ulam-oq-03-oq-01-oq-01",
+    "borsuk-ulam-oq-03-oq-03",
+    "borsuk-ulam-oq-04"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-04-03T05:50:19-07:00",
+  "significance": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/BorsukUlam.lean",
+      "filename": "BorsukUlam.lean",
+      "lineCount": 266,
+      "theoremCount": 9,
+      "axiomCount": 1,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlam.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ01.lean",
+      "filename": "BorsukUlamOQ01.lean",
+      "lineCount": 329,
+      "theoremCount": 5,
+      "axiomCount": 2,
+      "defCount": 10,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02.lean",
+      "filename": "BorsukUlamOQ02.lean",
+      "lineCount": 390,
+      "theoremCount": 18,
+      "axiomCount": 1,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01.lean",
+      "filename": "BorsukUlamOQ02OQ01.lean",
+      "lineCount": 147,
+      "theoremCount": 6,
+      "axiomCount": 4,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ04.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ04.lean",
+      "lineCount": 252,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ04.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ02.lean",
+      "filename": "BorsukUlamOQ02OQ02.lean",
+      "lineCount": 161,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ03.lean",
+      "filename": "BorsukUlamOQ02OQ03.lean",
+      "lineCount": 252,
+      "theoremCount": 12,
+      "axiomCount": 5,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ03.lean",
+      "filename": "BorsukUlamOQ03.lean",
+      "lineCount": 5140,
+      "theoremCount": 211,
+      "axiomCount": 2,
+      "defCount": 35,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ03.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ03OQ01.lean",
+      "filename": "BorsukUlamOQ03OQ01.lean",
+      "lineCount": 1164,
+      "theoremCount": 41,
+      "axiomCount": 1,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ03OQ01OQ01.lean",
+      "filename": "BorsukUlamOQ03OQ01OQ01.lean",
+      "lineCount": 435,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ03OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ03OQ03.lean",
+      "filename": "BorsukUlamOQ03OQ03.lean",
+      "lineCount": 2634,
+      "theoremCount": 123,
+      "axiomCount": 1,
+      "defCount": 30,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ03OQ03.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ04.lean",
+      "filename": "BorsukUlamOQ04.lean",
+      "lineCount": 301,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 8,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ04.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-02.json
@@ -1,0 +1,147 @@
+{
+  "slug": "buffons-needle-oq-01-oq-01-oq-02",
+  "title": "Prove the integrability hypothesis (hInnerInt) from smoothness of γ",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "",
+    "plain": "",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-04-03T05:50:14-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [],
+    "markdown": "# Knowledge Base: buffons-needle-oq-01-oq-01-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [],
+  "relatedProofs": [
+    "buffons-needle",
+    "buffons-needle-oq-01",
+    "buffons-needle-oq-01-oq-01",
+    "buffons-needle-oq-01-oq-01-oq-01",
+    "buffons-needle-oq-01-oq-02",
+    "buffons-needle-oq-02",
+    "buffons-needle-oq-02-oq-01",
+    "buffons-needle-oq-02-oq-02"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-04-03T05:50:14-07:00",
+  "significance": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/BuffonsNeedle.lean",
+      "filename": "BuffonsNeedle.lean",
+      "lineCount": 267,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedle.lean"
+    },
+    {
+      "path": "Proofs/BuffonsNeedleOQ01.lean",
+      "filename": "BuffonsNeedleOQ01.lean",
+      "lineCount": 251,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01.lean"
+    },
+    {
+      "path": "Proofs/BuffonsNeedleOQ01OQ01.lean",
+      "filename": "BuffonsNeedleOQ01OQ01.lean",
+      "lineCount": 391,
+      "theoremCount": 7,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 5,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BuffonsNeedleOQ01OQ01OQ01.lean",
+      "filename": "BuffonsNeedleOQ01OQ01OQ01.lean",
+      "lineCount": 224,
+      "theoremCount": 7,
+      "axiomCount": 1,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BuffonsNeedleOQ01OQ02.lean",
+      "filename": "BuffonsNeedleOQ01OQ02.lean",
+      "lineCount": 326,
+      "theoremCount": 23,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BuffonsNeedleOQ02.lean",
+      "filename": "BuffonsNeedleOQ02.lean",
+      "lineCount": 263,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ02.lean"
+    },
+    {
+      "path": "Proofs/BuffonsNeedleOQ02OQ01.lean",
+      "filename": "BuffonsNeedleOQ02OQ01.lean",
+      "lineCount": 310,
+      "theoremCount": 18,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BuffonsNeedleOQ02OQ02.lean",
+      "filename": "BuffonsNeedleOQ02OQ02.lean",
+      "lineCount": 377,
+      "theoremCount": 15,
+      "axiomCount": 1,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ02OQ02.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/burnside-counting-oq-01.json
+++ b/src/data/research/problems/burnside-counting-oq-01.json
@@ -1,0 +1,66 @@
+{
+  "slug": "burnside-counting-oq-01",
+  "title": "[Problem Title]",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "C",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{[LaTeX formulation of the theorem/conjecture]}",
+    "plain": "[Explain what we're trying to prove in accessible terms]",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-04-03T07:05:01-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [],
+    "markdown": "# Knowledge Base: burnside-counting-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "number-theory  # or: algebra, analysis, topology, combinatorics, etc.",
+    "prime-gaps",
+    "sieve-methods"
+  ],
+  "relatedProofs": [
+    "burnside-counting"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-04-03T07:05:01-07:00",
+  "leanFiles": [
+    {
+      "path": "Proofs/BurnsideCounting.lean",
+      "filename": "BurnsideCounting.lean",
+      "lineCount": 256,
+      "theoremCount": 6,
+      "axiomCount": 5,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BurnsideCounting.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -1,0 +1,195 @@
+{
+  "slug": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01",
+  "title": "Can Mathlib's Radon-Nikodým machinery (`MeasureTheory",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "",
+    "plain": "",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-04-03T05:50:14-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [],
+    "markdown": "# Knowledge Base: cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [],
+  "relatedProofs": [
+    "cauchy-schwarz",
+    "cauchy-schwarz-integral",
+    "cauchy-schwarz-integral-oq-01",
+    "cauchy-schwarz-integral-oq-01-oq-01",
+    "cauchy-schwarz-integral-oq-01-oq-01-oq-01",
+    "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02",
+    "cauchy-schwarz-integral-oq-01-oq-01-oq-02",
+    "cauchy-schwarz-integral-oq-01-oq-02",
+    "cauchy-schwarz-integral-oq-02",
+    "cauchy-schwarz-integral-oq-02-oq-01",
+    "cauchy-schwarz-integral-oq-02-oq-02",
+    "cauchy-schwarz-integral-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-04-03T05:50:14-07:00",
+  "significance": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/CauchySchwarzIntegral.lean",
+      "filename": "CauchySchwarzIntegral.lean",
+      "lineCount": 118,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegral.lean"
+    },
+    {
+      "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
+      "filename": "CauchySchwarzIntegralOQ01.lean",
+      "lineCount": 229,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01.lean"
+    },
+    {
+      "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
+      "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
+      "lineCount": 154,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
+      "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
+      "lineCount": 184,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
+      "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
+      "lineCount": 218,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
+      "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
+      "lineCount": 152,
+      "theoremCount": 8,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
+      "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
+      "lineCount": 601,
+      "theoremCount": 29,
+      "axiomCount": 2,
+      "defCount": 7,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
+      "filename": "CauchySchwarzIntegralOQ02.lean",
+      "lineCount": 264,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ02.lean"
+    },
+    {
+      "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
+      "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
+      "lineCount": 92,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
+      "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
+      "lineCount": 407,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
+      "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
+      "lineCount": 118,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
+      "filename": "CauchySchwarzIntegralOQ03.lean",
+      "lineCount": 182,
+      "theoremCount": 20,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ03.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-01.json
@@ -1,0 +1,254 @@
+{
+  "slug": "cayley-hamilton-minpoly-oq-01-oq-01",
+  "title": "Prove the JCF product formula in Lean when Mathlib adds Jordan block matrix d...",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "",
+    "plain": "",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-04-03T05:50:14-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [],
+    "markdown": "# Knowledge Base: cayley-hamilton-minpoly-oq-01-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [],
+  "relatedProofs": [
+    "cayley-hamilton",
+    "cayley-hamilton-minpoly",
+    "cayley-hamilton-minpoly-oq-01",
+    "cayley-hamilton-minpoly-oq-02",
+    "cayley-hamilton-minpoly-oq-02-oq-01",
+    "cayley-hamilton-minpoly-oq-02-oq-02",
+    "cayley-hamilton-minpoly-oq-02-oq-03",
+    "cayley-hamilton-minpoly-oq-03",
+    "cayley-hamilton-minpoly-oq-04",
+    "cayley-hamilton-minpoly-oq-05",
+    "cayley-hamilton-minpoly-oq-05-oq-01",
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-01",
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-02",
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-03",
+    "cayley-hamilton-minpoly-oq-05-oq-01-oq-04",
+    "cayley-hamilton-minpoly-oq-05-oq-02"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-04-03T05:50:14-07:00",
+  "significance": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ01.lean",
+      "lineCount": 308,
+      "theoremCount": 20,
+      "axiomCount": 3,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ02.lean",
+      "filename": "CayleyHamiltonMinpolyOQ02.lean",
+      "lineCount": 132,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ02.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ02OQ01.lean",
+      "lineCount": 218,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ02.lean",
+      "filename": "CayleyHamiltonMinpolyOQ02OQ02.lean",
+      "lineCount": 391,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ03.lean",
+      "filename": "CayleyHamiltonMinpolyOQ02OQ03.lean",
+      "lineCount": 137,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ03.lean",
+      "filename": "CayleyHamiltonMinpolyOQ03.lean",
+      "lineCount": 369,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ03.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ03Aristotle.lean",
+      "filename": "CayleyHamiltonMinpolyOQ03Aristotle.lean",
+      "lineCount": 115,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ03Aristotle.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ04.lean",
+      "filename": "CayleyHamiltonMinpolyOQ04.lean",
+      "lineCount": 317,
+      "theoremCount": 8,
+      "axiomCount": 1,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ04Backward.lean",
+      "filename": "CayleyHamiltonMinpolyOQ04Backward.lean",
+      "lineCount": 481,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 4,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ04BackwardAristotle.lean",
+      "filename": "CayleyHamiltonMinpolyOQ04BackwardAristotle.lean",
+      "lineCount": 126,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04BackwardAristotle.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05.lean",
+      "lineCount": 233,
+      "theoremCount": 23,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01.lean",
+      "lineCount": 271,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ01.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ01.lean",
+      "lineCount": 363,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
+      "lineCount": 271,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ03.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ03.lean",
+      "lineCount": 346,
+      "theoremCount": 19,
+      "axiomCount": 0,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
+      "lineCount": 263,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 4,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ02.lean",
+      "filename": "CayleyHamiltonMinpolyOQ05OQ02.lean",
+      "lineCount": 263,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ02.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/central-limit-theorem-oq-01-oq-04.json
+++ b/src/data/research/problems/central-limit-theorem-oq-01-oq-04.json
@@ -1,0 +1,158 @@
+{
+  "slug": "central-limit-theorem-oq-01-oq-04",
+  "title": "Can the Berry-Esseen rate-of-convergence theorem be generalized to α-stable l...",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "",
+    "plain": "",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-04-03T05:50:19-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [],
+    "markdown": "# Knowledge Base: central-limit-theorem-oq-01-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [],
+  "relatedProofs": [
+    "central-limit-theorem",
+    "central-limit-theorem-oq-01",
+    "central-limit-theorem-oq-01-oq-01",
+    "central-limit-theorem-oq-01-oq-02",
+    "central-limit-theorem-oq-01-oq-03",
+    "central-limit-theorem-oq-02",
+    "central-limit-theorem-oq-03",
+    "central-limit-theorem-oq-04"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-04-03T05:50:19-07:00",
+  "significance": 7,
+  "leanFiles": [
+    {
+      "path": "Proofs/CentralLimitTheorem.lean",
+      "filename": "CentralLimitTheorem.lean",
+      "lineCount": 621,
+      "theoremCount": 16,
+      "axiomCount": 12,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheorem.lean"
+    },
+    {
+      "path": "Proofs/CentralLimitTheoremOQ01.lean",
+      "filename": "CentralLimitTheoremOQ01.lean",
+      "lineCount": 314,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01.lean"
+    },
+    {
+      "path": "Proofs/CentralLimitTheoremOQ01OQ01.lean",
+      "filename": "CentralLimitTheoremOQ01OQ01.lean",
+      "lineCount": 1131,
+      "theoremCount": 54,
+      "axiomCount": 3,
+      "defCount": 7,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/CentralLimitTheoremOQ01OQ02.lean",
+      "filename": "CentralLimitTheoremOQ01OQ02.lean",
+      "lineCount": 323,
+      "theoremCount": 18,
+      "axiomCount": 0,
+      "defCount": 13,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/CentralLimitTheoremOQ01OQ03.lean",
+      "filename": "CentralLimitTheoremOQ01OQ03.lean",
+      "lineCount": 147,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/CentralLimitTheoremOQ02.lean",
+      "filename": "CentralLimitTheoremOQ02.lean",
+      "lineCount": 730,
+      "theoremCount": 19,
+      "axiomCount": 1,
+      "defCount": 11,
+      "sorryCount": 4,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ02.lean"
+    },
+    {
+      "path": "Proofs/CentralLimitTheoremOQ03.lean",
+      "filename": "CentralLimitTheoremOQ03.lean",
+      "lineCount": 242,
+      "theoremCount": 8,
+      "axiomCount": 14,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ03.lean"
+    },
+    {
+      "path": "Proofs/CentralLimitTheoremOQ03OQ01.lean",
+      "filename": "CentralLimitTheoremOQ03OQ01.lean",
+      "lineCount": 199,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/CentralLimitTheoremOQ04.lean",
+      "filename": "CentralLimitTheoremOQ04.lean",
+      "lineCount": 650,
+      "theoremCount": 21,
+      "axiomCount": 9,
+      "defCount": 10,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ04.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/chinese-remainder-constructive-oq-03-oq-01.json
+++ b/src/data/research/problems/chinese-remainder-constructive-oq-03-oq-01.json
@@ -1,0 +1,99 @@
+{
+  "slug": "chinese-remainder-constructive-oq-03-oq-01",
+  "title": "Can the optimality of prime bases be proved for all k (not just k ≤ 6), requi...",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "",
+    "plain": "",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-04-03T05:50:14-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [],
+    "markdown": "# Knowledge Base: chinese-remainder-constructive-oq-03-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [],
+  "relatedProofs": [
+    "chinese-remainder-constructive",
+    "chinese-remainder-constructive-oq-03",
+    "chinese-remainder-constructive-oq-04",
+    "chinese-remainder-constructive-oq-04-oq-04"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-04-03T05:50:14-07:00",
+  "significance": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/ChineseRemainderConstructive.lean",
+      "filename": "ChineseRemainderConstructive.lean",
+      "lineCount": 417,
+      "theoremCount": 17,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ChineseRemainderConstructive.lean"
+    },
+    {
+      "path": "Proofs/ChineseRemainderConstructiveOQ03.lean",
+      "filename": "ChineseRemainderConstructiveOQ03.lean",
+      "lineCount": 319,
+      "theoremCount": 24,
+      "axiomCount": 0,
+      "defCount": 9,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ChineseRemainderConstructiveOQ03.lean"
+    },
+    {
+      "path": "Proofs/ChineseRemainderConstructiveOQ04.lean",
+      "filename": "ChineseRemainderConstructiveOQ04.lean",
+      "lineCount": 157,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ChineseRemainderConstructiveOQ04.lean"
+    },
+    {
+      "path": "Proofs/ChineseRemainderConstructiveOQ04OQ04.lean",
+      "filename": "ChineseRemainderConstructiveOQ04OQ04.lean",
+      "lineCount": 123,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ChineseRemainderConstructiveOQ04OQ04.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-04.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-04.json
@@ -1,0 +1,147 @@
+{
+  "slug": "descartes-rule-of-signs-oq-01-oq-04",
+  "title": "Can the proof be made constructive (using decidable instances for Polynomial",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "",
+    "plain": "",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-04-03T05:50:14-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [],
+    "markdown": "# Knowledge Base: descartes-rule-of-signs-oq-01-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [],
+  "relatedProofs": [
+    "descartes-rule-of-signs",
+    "descartes-rule-of-signs-oq-01",
+    "descartes-rule-of-signs-oq-01-oq-01",
+    "descartes-rule-of-signs-oq-01-oq-02",
+    "descartes-rule-of-signs-oq-02",
+    "descartes-rule-of-signs-oq-02-oq-01",
+    "descartes-rule-of-signs-oq-03",
+    "descartes-rule-of-signs-oq-04"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-04-03T05:50:14-07:00",
+  "significance": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/DescartesRuleOfSigns.lean",
+      "filename": "DescartesRuleOfSigns.lean",
+      "lineCount": 577,
+      "theoremCount": 35,
+      "axiomCount": 8,
+      "defCount": 11,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSigns.lean"
+    },
+    {
+      "path": "Proofs/DescartesRuleOfSignsOQ01.lean",
+      "filename": "DescartesRuleOfSignsOQ01.lean",
+      "lineCount": 1075,
+      "theoremCount": 30,
+      "axiomCount": 1,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ01.lean"
+    },
+    {
+      "path": "Proofs/DescartesRuleOfSignsOQ01OQ01.lean",
+      "filename": "DescartesRuleOfSignsOQ01OQ01.lean",
+      "lineCount": 155,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/DescartesRuleOfSignsOQ01OQ02.lean",
+      "filename": "DescartesRuleOfSignsOQ01OQ02.lean",
+      "lineCount": 272,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/DescartesRuleOfSignsOQ02.lean",
+      "filename": "DescartesRuleOfSignsOQ02.lean",
+      "lineCount": 699,
+      "theoremCount": 30,
+      "axiomCount": 3,
+      "defCount": 8,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ02.lean"
+    },
+    {
+      "path": "Proofs/DescartesRuleOfSignsOQ02OQ01.lean",
+      "filename": "DescartesRuleOfSignsOQ02OQ01.lean",
+      "lineCount": 192,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/DescartesRuleOfSignsOQ03.lean",
+      "filename": "DescartesRuleOfSignsOQ03.lean",
+      "lineCount": 441,
+      "theoremCount": 24,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ03.lean"
+    },
+    {
+      "path": "Proofs/DescartesRuleOfSignsOQ04.lean",
+      "filename": "DescartesRuleOfSignsOQ04.lean",
+      "lineCount": 496,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ04.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-01-oq-01.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-01-oq-01.json
@@ -1,0 +1,182 @@
+{
+  "slug": "elementary-quadratic-reciprocity-oq-01-oq-01",
+  "title": "Can a Gauss sum proof provide a third formal QR pathway alongside Eisenstein ...",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "",
+    "plain": "",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-04-03T05:50:14-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [],
+    "markdown": "# Knowledge Base: elementary-quadratic-reciprocity-oq-01-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [],
+  "relatedProofs": [
+    "elementary-quadratic-reciprocity",
+    "elementary-quadratic-reciprocity-oq-01",
+    "elementary-quadratic-reciprocity-oq-02",
+    "elementary-quadratic-reciprocity-oq-03",
+    "elementary-quadratic-reciprocity-oq-03-oq-01",
+    "elementary-quadratic-reciprocity-oq-03-oq-01-oq-01",
+    "elementary-quadratic-reciprocity-oq-03-oq-01-oq-02",
+    "elementary-quadratic-reciprocity-oq-03-oq-02",
+    "elementary-quadratic-reciprocity-oq-03-oq-02-oq-01",
+    "elementary-quadratic-reciprocity-oq-03-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-04-03T05:50:14-07:00",
+  "significance": 7,
+  "leanFiles": [
+    {
+      "path": "Proofs/ElementaryQuadraticReciprocity.lean",
+      "filename": "ElementaryQuadraticReciprocity.lean",
+      "lineCount": 358,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocity.lean"
+    },
+    {
+      "path": "Proofs/ElementaryQuadraticReciprocityOQ01.lean",
+      "filename": "ElementaryQuadraticReciprocityOQ01.lean",
+      "lineCount": 629,
+      "theoremCount": 31,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocityOQ01.lean"
+    },
+    {
+      "path": "Proofs/ElementaryQuadraticReciprocityOQ02.lean",
+      "filename": "ElementaryQuadraticReciprocityOQ02.lean",
+      "lineCount": 176,
+      "theoremCount": 7,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocityOQ02.lean"
+    },
+    {
+      "path": "Proofs/ElementaryQuadraticReciprocityOQ03.lean",
+      "filename": "ElementaryQuadraticReciprocityOQ03.lean",
+      "lineCount": 200,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocityOQ03.lean"
+    },
+    {
+      "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ01.lean",
+      "filename": "ElementaryQuadraticReciprocityOQ03OQ01.lean",
+      "lineCount": 312,
+      "theoremCount": 24,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ01OQ01.lean",
+      "filename": "ElementaryQuadraticReciprocityOQ03OQ01OQ01.lean",
+      "lineCount": 165,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ01OQ01OQ04.lean",
+      "filename": "ElementaryQuadraticReciprocityOQ03OQ01OQ01OQ04.lean",
+      "lineCount": 148,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ01OQ01OQ04.lean"
+    },
+    {
+      "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ01OQ02.lean",
+      "filename": "ElementaryQuadraticReciprocityOQ03OQ01OQ02.lean",
+      "lineCount": 190,
+      "theoremCount": 18,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean",
+      "filename": "ElementaryQuadraticReciprocityOQ03OQ02.lean",
+      "lineCount": 224,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ02OQ01.lean",
+      "filename": "ElementaryQuadraticReciprocityOQ03OQ02OQ01.lean",
+      "lineCount": 268,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ03.lean",
+      "filename": "ElementaryQuadraticReciprocityOQ03OQ03.lean",
+      "lineCount": 103,
+      "theoremCount": 3,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ03.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/erdos-8-oq-01.json
+++ b/src/data/research/problems/erdos-8-oq-01.json
@@ -369,6 +369,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos816Problem.lean"
     },
     {
+      "path": "Proofs/Erdos817Aristotle.lean",
+      "filename": "Erdos817Aristotle.lean",
+      "lineCount": 99,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 12,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos817Aristotle.lean"
+    },
+    {
       "path": "Proofs/Erdos817Problem.lean",
       "filename": "Erdos817Problem.lean",
       "lineCount": 233,
@@ -1115,6 +1126,17 @@
       "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos876Problem.lean"
+    },
+    {
+      "path": "Proofs/Erdos877Aristotle.lean",
+      "filename": "Erdos877Aristotle.lean",
+      "lineCount": 97,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 9,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos877Aristotle.lean"
     },
     {
       "path": "Proofs/Erdos877Problem.lean",

--- a/src/data/research/problems/euler-identity-oq-02.json
+++ b/src/data/research/problems/euler-identity-oq-02.json
@@ -1,0 +1,75 @@
+{
+  "slug": "euler-identity-oq-02",
+  "title": "Is there a formalization of Euler's identity as a theorem in the *p*-adic set...",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "",
+    "plain": "",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-04-03T05:50:19-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [],
+    "markdown": "# Knowledge Base: euler-identity-oq-02\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [],
+  "relatedProofs": [
+    "euler-identity",
+    "euler-identity-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-04-03T05:50:19-07:00",
+  "significance": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/EulerIdentity.lean",
+      "filename": "EulerIdentity.lean",
+      "lineCount": 342,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerIdentity.lean"
+    },
+    {
+      "path": "Proofs/EulerIdentityOQ01.lean",
+      "filename": "EulerIdentityOQ01.lean",
+      "lineCount": 214,
+      "theoremCount": 7,
+      "axiomCount": 3,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerIdentityOQ01.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/shannon-channel-coding-oq-03.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-03.json
@@ -1,0 +1,87 @@
+{
+  "slug": "shannon-channel-coding-oq-03",
+  "title": "Can Fano's inequality be stated with the full H(X|Y) <= h(P_e) + P_e*log(|X|-...",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "",
+    "plain": "",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-04-03T05:50:13-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [],
+    "markdown": "# Knowledge Base: shannon-channel-coding-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [],
+  "relatedProofs": [
+    "shannon-channel-coding",
+    "shannon-channel-coding-oq-02",
+    "shannon-channel-coding-oq-04"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-04-03T05:50:13-07:00",
+  "significance": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/ShannonChannelCoding.lean",
+      "filename": "ShannonChannelCoding.lean",
+      "lineCount": 229,
+      "theoremCount": 8,
+      "axiomCount": 4,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCoding.lean"
+    },
+    {
+      "path": "Proofs/ShannonChannelCodingOQ02.lean",
+      "filename": "ShannonChannelCodingOQ02.lean",
+      "lineCount": 298,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ02.lean"
+    },
+    {
+      "path": "Proofs/ShannonChannelCodingOQ04.lean",
+      "filename": "ShannonChannelCodingOQ04.lean",
+      "lineCount": 225,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ04.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/shannon-entropy-oq-01.json
+++ b/src/data/research/problems/shannon-entropy-oq-01.json
@@ -112,11 +112,11 @@
     {
       "path": "Proofs/ShannonEntropyOQ01.lean",
       "filename": "ShannonEntropyOQ01.lean",
-      "lineCount": 331,
+      "lineCount": 437,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 4,
+      "sorryCount": 3,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonEntropyOQ01.lean"
     },

--- a/src/data/research/problems/shannon-entropy-oq-02.json
+++ b/src/data/research/problems/shannon-entropy-oq-02.json
@@ -96,13 +96,24 @@
     {
       "path": "Proofs/ShannonEntropyOQ01.lean",
       "filename": "ShannonEntropyOQ01.lean",
-      "lineCount": 331,
+      "lineCount": 437,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 4,
+      "sorryCount": 3,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonEntropyOQ01.lean"
+    },
+    {
+      "path": "Proofs/ShannonEntropyOQ01Aristotle.lean",
+      "filename": "ShannonEntropyOQ01Aristotle.lean",
+      "lineCount": 29,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 3,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonEntropyOQ01Aristotle.lean"
     },
     {
       "path": "Proofs/ShannonEntropyOQ02.lean",

--- a/src/data/research/problems/shannon-entropy-oq-03.json
+++ b/src/data/research/problems/shannon-entropy-oq-03.json
@@ -101,13 +101,24 @@
     {
       "path": "Proofs/ShannonEntropyOQ01.lean",
       "filename": "ShannonEntropyOQ01.lean",
-      "lineCount": 331,
+      "lineCount": 437,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 4,
+      "sorryCount": 3,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonEntropyOQ01.lean"
+    },
+    {
+      "path": "Proofs/ShannonEntropyOQ01Aristotle.lean",
+      "filename": "ShannonEntropyOQ01Aristotle.lean",
+      "lineCount": 29,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 3,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonEntropyOQ01Aristotle.lean"
     },
     {
       "path": "Proofs/ShannonEntropyOQ02.lean",

--- a/src/data/research/problems/shannon-entropy.json
+++ b/src/data/research/problems/shannon-entropy.json
@@ -152,13 +152,24 @@
     {
       "path": "Proofs/ShannonEntropyOQ01.lean",
       "filename": "ShannonEntropyOQ01.lean",
-      "lineCount": 331,
+      "lineCount": 437,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 4,
+      "sorryCount": 3,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonEntropyOQ01.lean"
+    },
+    {
+      "path": "Proofs/ShannonEntropyOQ01Aristotle.lean",
+      "filename": "ShannonEntropyOQ01Aristotle.lean",
+      "lineCount": 29,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 3,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonEntropyOQ01Aristotle.lean"
     },
     {
       "path": "Proofs/ShannonEntropyOQ02.lean",

--- a/src/data/research/problems/szemeredi-core-oq-01.json
+++ b/src/data/research/problems/szemeredi-core-oq-01.json
@@ -1,0 +1,74 @@
+{
+  "slug": "szemeredi-core-oq-01",
+  "title": "Formalize the energy increment lemma: if a partition has an irregular pair, t...",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "A",
+  "path": "full",
+  "problemStatement": {
+    "formal": "",
+    "plain": "",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-04-03T05:50:14-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [],
+    "markdown": "# Knowledge Base: szemeredi-core-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [],
+  "relatedProofs": [
+    "szemeredi-core"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-04-03T05:50:14-07:00",
+  "significance": 8,
+  "leanFiles": [
+    {
+      "path": "Proofs/SzemerediCore.lean",
+      "filename": "SzemerediCore.lean",
+      "lineCount": 111,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediCore.lean"
+    },
+    {
+      "path": "Proofs/SzemerediCoreOQ03.lean",
+      "filename": "SzemerediCoreOQ03.lean",
+      "lineCount": 186,
+      "theoremCount": 0,
+      "axiomCount": 1,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediCoreOQ03.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Recovered enrichments from PR #8921 that were lost when the enricher-1 branch was reset during deploy.

- **cauchy-schwarz-oq-02**: 8 annotations, sections, Hölder/L² theory coverage
- **cantor-diagonalization-oq-02-oq-03**: 5 annotations, sections, historical context

Original commits from enricher-1 agent (2026-04-03).

Closes #8921