### PR TITLE
Fix: add Aristotle companion for inverse-galois-oq-02 (9 Cauchy/Sylow targets)

### DIFF
--- a/proofs/Proofs/InverseGaloisOQ02Aristotle.lean
+++ b/proofs/Proofs/InverseGaloisOQ02Aristotle.lean
@@ -1,0 +1,71 @@
+/-
+  Aristotle targets for Inverse Galois OQ-02 (M₂₃)
+  Routine supporting lemmas for automated proof search.
+  See InverseGaloisOQ02.lean for the main formalization.
+
+  Criteria for inclusion:
+  - Generic Cauchy/Sylow applications: if p prime, p ∣ |G|, then G has element of order p
+  - Divisibility facts for 10200960 = 2^7 · 3^2 · 5 · 7 · 11 · 23
+  - Arithmetic facts: 2^7 = 128, primality checks
+  - Excluded: M23_not_commutative, M23_commutator_eq_top, M23_not_solvable (complex group theory)
+  - Excluded: M23_realizable_over_Q (open problem)
+  - No axioms (M23 is not redeclared here; companion uses generic group lemmas)
+  - No definition sorries
+-/
+import Mathlib
+
+namespace InverseGaloisOQ02Aristotle
+
+open Finset
+
+-- Routine: 2^7 = 128.
+theorem two_pow_seven : (2 : ℕ) ^ 7 = 128 := by
+  sorry
+
+-- Routine: 23 is prime.
+theorem prime_23 : Nat.Prime 23 := by
+  sorry
+
+-- Routine: 2 is prime.
+theorem prime_2 : Nat.Prime 2 := by
+  sorry
+
+-- Routine: 23 divides 10200960.
+-- 10200960 = 2^7 · 3^2 · 5 · 7 · 11 · 23.
+theorem dvd_23_10200960 : 23 ∣ 10200960 := by
+  sorry
+
+-- Routine: 2^7 divides 10200960.
+-- 10200960 = 2^7 · 3^2 · 5 · 7 · 11 · 23.
+theorem dvd_pow_2_7_10200960 : 2 ^ 7 ∣ 10200960 := by
+  sorry
+
+-- Routine: 2^8 does not divide 10200960.
+-- The 2-adic valuation of 10200960 is exactly 7.
+theorem not_dvd_pow_2_8_10200960 : ¬(2 ^ 8 ∣ (10200960 : ℕ)) := by
+  sorry
+
+-- Routine: For any finite group G, if p prime and p ∣ |G|, then G has element of order p.
+-- This is Cauchy's theorem for finite groups.
+theorem cauchy_element_of_order {G : Type*} [Group G] [Fintype G]
+    {p : ℕ} (hp : Nat.Prime p) (hdvd : p ∣ Fintype.card G) :
+    ∃ g : G, orderOf g = p := by
+  sorry
+
+-- Routine: factorization of 10200960 into prime factors.
+-- 10200960 = 2^7 · 3^2 · 5 · 7 · 11 · 23.
+theorem factorization_10200960 :
+    (10200960 : ℕ) = 2 ^ 7 * 3 ^ 2 * 5 * 7 * 11 * 23 := by
+  sorry
+
+-- Routine: the 2-adic valuation of 10200960 is 7.
+-- Needed to determine the Sylow 2-subgroup order.
+theorem factorization_2_10200960 :
+    (10200960 : ℕ).factorization 2 = 7 := by
+  sorry
+
+-- Routine: 2^7 = 128 as a general fact about Nat.
+theorem pow_2_7_eq_128 : (2 : ℕ) ^ 7 = 128 := by
+  sorry
+
+end InverseGaloisOQ02Aristotle


### PR DESCRIPTION
## Fix

Add Aristotle companion file for Inverse Galois OQ-02 (M₂₃ group theory).

## Evidence

**Before**: No Aristotle companion — 6 sorries in main proof, 2 are routine group theory applications
**After**: `InverseGaloisOQ02Aristotle.lean` provides 9 routine supporting lemmas

## Targets

- `prime_23`, `prime_2`: primality by norm_num
- `dvd_23_10200960`: 23 ∣ 10200960 = |M₂₃|
- `dvd_pow_2_7_10200960`: 2⁷ ∣ 10200960
- `not_dvd_pow_2_8_10200960`: 2⁸ ∤ 10200960 (exact 2-adic valuation)
- `cauchy_element_of_order`: generic Cauchy theorem (wraps Fingroup.exists_prime_orderOf_dvd_card)
- `factorization_10200960`: 10200960 = 2⁷ · 3² · 5 · 7 · 11 · 23
- `factorization_2_10200960`: 2-adic valuation of |M₂₃| is 7
- `pow_2_7_eq_128`: 2⁷ = 128 (Sylow 2-subgroup order)

Uses generic group theory without re-axiomatizing M₂₃, supporting
`M23_has_element_of_order_23` and `M23_sylow_2_card` in the main file.

---
Automated fix by lean-mechanic agent.