### PR TITLE
Audit: fix axiom counter to include private axiom declarations

### DIFF
--- a/scripts/auditor/find-targets.ts
+++ b/scripts/auditor/find-targets.ts
@@ -249,7 +249,7 @@ function analyzeProof(id: string, galleryPath: string, tracker: Tracker): AuditT
     const content = stripLeanComments(rawContent)
 
     sorryCount += (content.match(/\bsorry\b/g) || []).length
-    axiomCount += (content.match(/^axiom /gm) || []).length
+    axiomCount += (content.match(/^(?:private\s+)?axiom /gm) || []).length
 
     // True stubs: only count theorem/lemma declarations, not example (Issue #6130)
     for (const line of content.split('\n')) {


### PR DESCRIPTION
## Bug Fix: Axiom Counter Missing `private axiom`

**Detected during**: erdos-1126-oq-01 audit (cycle 22)

## Problem

`find-targets.ts` counted axioms with `/^axiom /gm` which only matches public `axiom` declarations. `private axiom` declarations (which start with `private`, not `axiom`) were missed, causing false-positive "axiom overcount" audit issues.

**Example**: `erdos-1126-oq-01` correctly claims `axiomCount: 7` (5 public + 2 private axioms), but the script found only 5 and flagged it as overcounted.

## Fix

```ts
// Before
axiomCount += (content.match(/^axiom /gm) || []).length

// After
axiomCount += (content.match(/^(?:private\s+)?axiom /gm) || []).length
```

## Verification

Running `--stats` after the fix: false positive for erdos-1126-oq-01 cleared, "with issues" dropped from 2 → 1 (only the real BSD sorry mismatch remains, fixed in #8948).

---
Discovered and fixed during gallery integrity audit (cycle 22).