### PR TITLE
Enrich Computing Matrix Functions via Cayley-Hamilton Reduction

### DIFF
--- a/src/data/proofs/cayley-hamilton-oq-02/annotations.json
+++ b/src/data/proofs/cayley-hamilton-oq-02/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-ch02-background",
+    "proofId": "cayley-hamilton-oq-02",
+    "range": { "startLine": 6, "endLine": 50 },
+    "type": "context",
+    "title": "Cayley-Hamilton as Reduction Algorithm: From Theorem to Computation",
+    "content": "The module docstring reframes Cayley-Hamilton as an algorithm rather than just a theorem. The key perspective: since charpoly(A) = 0 (as a matrix equation), the characteristic polynomial acts as a modular reduction — any polynomial in A reduces to one of degree < n. The docstring documents the Mathlib dependencies explicitly, including `Matrix.aeval_self_charpoly` (the Cayley-Hamilton theorem itself), `Polynomial.modByMonic_add_div` (the division algorithm), and `Polynomial.degree_modByMonic_lt` (the degree bound). This is companion to OQ-01 (which uses the tighter minpoly reduction): OQ-02 uses charpoly because it's always available (charpoly is computable from determinant), while minpoly may require eigenvalue computation.",
+    "mathContext": "$p(A) = p(A) \\bmod \\chi_A(A)$: since $\\chi_A(A) = 0$ (Cayley-Hamilton), any polynomial $p(X) = q(X)\\chi_A(X) + r(X)$ evaluates to $p(A) = r(A)$ where $\\deg(r) < n = \\deg(\\chi_A)$. This makes $K[A] = \\text{span}\\{I, A, \\ldots, A^{n-1}\\}$ an $n$-dimensional $K$-algebra.",
+    "significance": "context",
+    "relatedConcepts": ["Cayley-Hamilton theorem", "polynomial modular reduction", "K[A] as n-dimensional algebra", "matrix function computation"],
+    "prerequisites": ["Cayley-Hamilton theorem", "polynomial division algorithm", "matrix polynomial evaluation"]
+  },
+  {
+    "id": "ann-ch02-core-reduction",
+    "proofId": "cayley-hamilton-oq-02",
+    "range": { "startLine": 63, "endLine": 102 },
+    "type": "insight",
+    "title": "Core Reduction Theorem: The Cayley-Hamilton Modular Reduction",
+    "content": "The main theorem `aeval_eq_aeval_modByMonic` has a clean four-step proof: (1) charpoly is monic (from `Matrix.charpoly_monic`); (2) charpoly annihilates A (from `Matrix.aeval_self_charpoly`); (3) division gives f = q*charpoly + r (from `Polynomial.modByMonic_add_div`); (4) apply `aeval A` to both sides via `congr_arg`, then use step (2) to zero out the charpoly term. The proof structure is identical to OQ-01's minpoly version, but uses `A.charpoly` throughout rather than `minpoly K A`. The companion `aeval_sub_mod_eq_zero` reframes this: f - (f mod charpoly) is in the annihilator ideal. This works over any commutative ring R (not just fields), because charpoly is always available over commutative rings.",
+    "mathContext": "Write $f = q \\cdot \\chi_A + r$, then $f(A) = q(A)\\chi_A(A) + r(A) = q(A) \\cdot 0 + r(A) = r(A)$. Over a commutative ring $R$: $R[A] \\cong R[X]/(\\chi_A)$ as $R$-algebras (surjective via evaluation, kernel = $(\\chi_A)$ by Cayley-Hamilton and degree bound).",
+    "significance": "key",
+    "relatedConcepts": ["modByMonic_add_div", "aeval_self_charpoly", "congr_arg", "annihilator ideal"],
+    "prerequisites": ["Matrix.charpoly_monic", "Matrix.aeval_self_charpoly", "Polynomial.modByMonic_add_div"]
+  },
+  {
+    "id": "ann-ch02-power-reduction",
+    "proofId": "cayley-hamilton-oq-02",
+    "range": { "startLine": 135, "endLine": 161 },
+    "type": "insight",
+    "title": "Power Reduction: A^k as a Linear Combination of I, A, ..., A^{n-1}",
+    "content": "The power reduction theorem `power_eq_aeval_mod` is a one-liner from the core theorem: `A^k = aeval A (X^k) = aeval A (X^k mod charpoly(A))`. The `simp [map_pow, aeval_X]` normalizes `aeval A (X^k)` to `A^k`. This establishes that K[A] = span{I, A, ..., A^{n-1}} — every matrix power is a linear combination of the first n powers. For A a 3×3 matrix with charpoly λ³ - tr·λ² + (cofactors)·λ - det·I: A³ = tr·A² - (cofactors)·A + det·I, and A^100 requires reducing X^100 by this 3-term recurrence. `aeval_reduced` provides the existential form: for any f, there exists q of degree < n with aeval A f = aeval A q.",
+    "mathContext": "$A^k = (X^k \\bmod \\chi_A)(A)$. The computation: $X^k = q_k(X) \\cdot \\chi_A(X) + r_k(X)$ where $\\deg(r_k) < n$. Coefficients of $r_k$: given by the linear recurrence from the charpoly coefficients. For $\\chi_A = X^n - \\sum_{i=0}^{n-1} c_i X^i$: $r_k = c_0 r_{k-n} + \\ldots + c_{n-1} r_{k-1}$ (recurrence from Cayley-Hamilton).",
+    "significance": "key",
+    "relatedConcepts": ["matrix power recurrence", "Cayley-Hamilton recurrence", "K[A] basis", "Horner evaluation"],
+    "prerequisites": ["aeval_eq_aeval_modByMonic", "map_pow", "aeval_X", "degree_reduced_lt_charpoly"]
+  },
+  {
+    "id": "ann-ch02-congruence",
+    "proofId": "cayley-hamilton-oq-02",
+    "range": { "startLine": 166, "endLine": 195 },
+    "type": "insight",
+    "title": "Congruence: Evaluation Factors Through R[X]/(charpoly)",
+    "content": "The congruence theorem and ideal closure lemmas establish the algebraic structure: the evaluation map e_A: R[X] → M_n(R) defined by e_A(f) = f(A) factors through the quotient ring R[X]/(charpoly A). The three closure lemmas (congruence, annihilator_add, annihilator_mul_left) show that ker(e_A) = {f : f(A) = 0} is an ideal in R[X] containing (charpoly A). By Cayley-Hamilton, (charpoly A) ⊆ ker(e_A). Combined with degree bounds, over a field we get ker(e_A) = (charpoly A) exactly when minpoly = charpoly (nonderogatory case), and ker(e_A) = (minpoly A) in general.",
+    "mathContext": "The evaluation ring homomorphism $e_A: R[X] \\to M_n(R)$ satisfies $\\ker(e_A) \\supseteq (\\chi_A)$. Over a field $K$: $\\ker(e_A) = (\\mu_A)$ where $\\mu_A$ is the minimal polynomial. The image: $K[A] \\cong K[X]/(\\mu_A)$, with $\\dim_K K[A] = \\deg(\\mu_A) \\leq n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["quotient ring R[X]/(charpoly)", "ring homomorphism", "annihilator ideal", "evaluation map"],
+    "prerequisites": ["aeval_eq_aeval_modByMonic", "map_mul", "map_add"]
+  },
+  {
+    "id": "ann-ch02-partial-sums",
+    "proofId": "cayley-hamilton-oq-02",
+    "range": { "startLine": 201, "endLine": 224 },
+    "type": "insight",
+    "title": "Partial Sum Reduction: Foundation for Matrix Exponential Computation",
+    "content": "The `partial_sum_reduces` theorem is the key step toward computing matrix exponentials: for any power series truncation ∑_{k<N} cₖ Xᵏ, evaluating at A reduces to evaluating the remainder modulo charpoly. For the matrix exponential truncation ∑_{k<N} (tA)^k/k!, this gives: the N-th partial sum of exp(tA) can be expressed as a polynomial in A of degree < n. As N → ∞, this converges (over ℝ or ℂ) to exp(tA) = α₀(t)I + α₁(t)A + ... + α_{n-1}(t)A^{n-1}. The Putzer algorithm computes these αᵢ(t) by solving a triangular system of ODEs derived from the eigenvalues of A.",
+    "mathContext": "$e^{tA} = \\sum_{k=0}^{\\infty} \\frac{(tA)^k}{k!} = \\sum_{j=0}^{n-1} \\alpha_j(t) A^j$ where $\\alpha_j(t) = \\sum_{k=j}^{\\infty} \\frac{t^k}{k!} \\cdot [X^k \\bmod \\chi_A]_j$. The Putzer algorithm: $\\alpha_j(t)$ satisfies $\\dot{\\alpha} = P\\alpha$ where $P$ is the companion matrix of $\\chi_A$.",
+    "significance": "key",
+    "relatedConcepts": ["matrix exponential", "Putzer algorithm", "matrix ODE", "power series convergence"],
+    "prerequisites": ["partial_sum_reduces", "degree_reduced_lt_dim", "Finset.sum", "C polynomial"]
+  },
+  {
+    "id": "ann-ch02-nilpotent-idempotent",
+    "proofId": "cayley-hamilton-oq-02",
+    "range": { "startLine": 253, "endLine": 310 },
+    "type": "context",
+    "title": "Special Cases: Nilpotent and Idempotent Matrices",
+    "content": "The special cases make the abstract theory concrete. Nilpotent matrices (charpoly = X^n): `nilpotent_from_charpoly` directly applies Cayley-Hamilton — if charpoly = X^n, then A^n = aeval A (X^n) = 0. The idempotent section proves `idempotent_power` by induction: A^1 = A, and A^{k+1} = A^k · A = A · A = A by the induction hypothesis plus A² = A. For idempotents, the matrix exponential has a closed form: exp(tA) = I + (e^t - 1)A (since A^k = A for k ≥ 1, so ∑ (tA)^k/k! = I + A ∑_{k≥1} t^k/k! = I + (e^t - 1)A). The 2×2 examples ground the general theory in a concrete, low-dimensional case.",
+    "mathContext": "Nilpotent $A^n = 0$: $e^{tA} = \\sum_{k=0}^{n-1} \\frac{t^k A^k}{k!}$ (series terminates). Idempotent $A^2 = A$: $e^{tA} = I + (e^t - 1)A$ (since $A^k = A$ for $k \\geq 1$). Projection: $e^{tA}$ is a projection onto $\\text{range}(A)$ along $\\ker(A)$, scaled by $e^t$.",
+    "significance": "supporting",
+    "relatedConcepts": ["nilpotent matrix exponential", "idempotent matrix exponential", "projection exponential", "power induction"],
+    "prerequisites": ["nilpotent_from_charpoly", "idempotent_power", "pow_add", "pow_succ"]
+  }
+]

--- a/src/data/proofs/cayley-hamilton-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-02/meta.json
@@ -32,15 +32,17 @@
     ]
   },
   "overview": {
-    "historicalContext": "The Cayley-Hamilton theorem (every matrix satisfies its characteristic polynomial) has a powerful computational corollary: any matrix polynomial reduces to degree < n. This means A^100 can be expressed as c₀I + c₁A + ... + c_{n-1}A^{n-1}. The matrix exponential e^{tA} = Σ (tA)^k/k! reduces to e^{tA} = c₀(t)I + c₁(t)A + ... + c_{n-1}(t)A^{n-1}, where c_i(t) satisfy a linear ODE from charpoly.",
+    "historicalContext": "The Cayley-Hamilton theorem was proved independently by Arthur Cayley (1858, for 2×2 and 3×3 matrices) and William Hamilton (1853, for quaternion matrices). The general proof was given by Ferdinand Frobenius (1879) using the Laplace expansion of the adjugate. The computational corollary — that polynomial functions of A reduce to degree < n — was exploited by Sylvester (1883) in his 'matrix function' theory and later systematized by Buchheim (1886) for computing f(A) via interpolation at eigenvalues. The matrix exponential formula e^{tA} = ∑_{k<n} αₖ(t)Aᵏ is the basis of the Putzer algorithm (1966), which computes αₖ(t) by solving a triangular ODE system. This representation is central to the Cayley-Hamilton approach to ODE: solutions to ẋ = Ax with x(0) = x₀ are x(t) = e^{tA}x₀ = ∑αₖ(t)Aᵏx₀. Lean 4 formalization uses `Matrix.aeval_self_charpoly` (Wiedijk's Formalizing 100 Theorems #49) as the foundation.",
     "problemStatement": "Prove that aeval A p = aeval A (p mod charpoly A) and derive the degree bound and computational applications.",
     "text": "The characteristic polynomial charpoly(A) is monic of degree n and satisfies aeval A (charpoly A) = 0 (Cayley-Hamilton). For any polynomial p, write p = q * charpoly + r (polynomial division). Then aeval A p = aeval A r, since the charpoly term vanishes. The remainder r has degree < n by the division algorithm. This reduction applies to any matrix polynomial: power series, matrix exponentials, etc.",
     "proofStrategy": "Apply Cayley-Hamilton via Matrix.aeval_self_charpoly. Use Polynomial.modByMonic_add_div for the division algorithm. Prove the reduction theorem. Derive power reduction, congruence property, and partial sum reduction as corollaries.",
     "keyInsights": [
-      "Cayley-Hamilton gives aeval A (charpoly) = 0, so charpoly is in the annihilator",
-      "Division algorithm: any p = q*charpoly + r, so aeval A p = aeval A r",
-      "Degree < n: the Cayley-Hamilton reduction is dimension-bounded",
-      "Matrix exponential: reduces to a degree-(n-1) polynomial in A with time-dependent coefficients"
+      "The evaluation map e_A: R[X] → M_n(R) factors through R[X]/(charpoly): K[A] ≅ R[X]/(charpoly A) as R-algebras, making every polynomial in A a linear combination of {I, A, ..., A^{n-1}}",
+      "The division algorithm proof (4 lines: monic + annihilate + divide + substitute) is the same structure as the minpoly version in OQ-01, differing only by using charpoly instead of minpoly",
+      "Power reduction A^k = (X^k mod charpoly)(A) gives a linear recurrence: the coefficients satisfy the recurrence relation from the charpoly coefficients — analogous to the characteristic equation of a linear recurrence sequence",
+      "Partial sum reduction is the algebraic foundation for the Putzer algorithm: the convergence e^{tA} = ∑αₖ(t)Aᵏ follows from applying polynomial evaluation to the exponential series",
+      "Over commutative rings R (not just fields), charpoly is always available via the determinant formula — making this reduction applicable to integer and polynomial matrix rings",
+      "The nilpotent and idempotent special cases give closed-form matrix exponentials: exp(tA) = ∑_{k<d} tᵏAᵏ/k! (nilpotent, d = nilpotency index) and exp(tA) = I + (eᵗ-1)A (idempotent)"
     ],
     "prerequisites": [
       "Cayley-Hamilton theorem: M satisfies its characteristic polynomial",
@@ -49,12 +51,13 @@
     ]
   },
   "conclusion": {
-    "summary": "Cayley-Hamilton reduction for matrix functions: aeval A p = aeval A (p mod charpoly), degree < n bound, power reduction, matrix exponential framework. 20 theorems, 358 lines, 0 axioms.",
-    "implications": "This is the theoretical foundation for efficient matrix exponentiation and ODE solving. The computation of e^{tA} by reducing X^k/k! mod charpoly(A) is the Putzer algorithm. Applications include numerical ODEs, signal processing, and control theory.",
+    "summary": "20 theorems, 358 lines, 0 axioms. A complete formalization of the Cayley-Hamilton polynomial reduction: the core theorem (f(A) = (f mod χ_A)(A)), degree bounds (<n), power reduction (A^k via X^k mod χ_A), congruence and ideal structure, partial sum reduction, and special cases (nilpotent, idempotent, 2×2, scalar). Works over any commutative ring R, not just fields. The file provides the theoretical foundation for matrix function computation, with partial sums as the bridge to analytic functions like exp(tA).",
+    "implications": "The Cayley-Hamilton reduction theorem is the algebraic foundation for numerical matrix computations. The Putzer algorithm (1966) computes e^{tA} = ∑αₖ(t)Aᵏ by using this reduction to derive a triangular ODE for the αₖ. This is a concrete, verified mathematical foundation for: (1) exact solution of ODEs ẋ = Ax (control theory); (2) efficient discrete-time propagation A^k (signal processing, Markov chains); (3) Chebyshev approximations to matrix functions in numerical linear algebra. The connection to the quotient ring R[X]/(χ_A) shows that K[A] is an n-dimensional commutative subalgebra of M_n(K), with the reduction theorem being the surjection K[X] → K[A].",
     "openQuestions": [
-      "Formalize the Putzer algorithm for e^{tA} using this reduction",
-      "Prove Sylvester's formula for functions of matrices (rational canonical form)",
-      "Apply to discrete-time systems: A^k via Cayley-Hamilton"
+      "Formalize the Putzer algorithm: given eigenvalues λ₁,...,λₙ of A, prove e^{tA} = ∑ₖ Pₖ(t)ρₖ where ρₖ = ∏_{i<k}(A-λᵢI) and Ṗₖ = λₖPₖ + Pₖ₋₁?",
+      "Prove Sylvester's interpolation formula f(A) = ∑ⱼ f(λⱼ)Zⱼ where Zⱼ are the Frobenius covariants (projections onto eigenspaces)?",
+      "Extend `partial_sum_reduces` to formal power series over complete rings (p-adics, formal Laurent series)?",
+      "Can this file be used to derive discrete-time transition matrix A^k in closed form from the characteristic equation?"
     ]
   },
   "leanFile": {
@@ -76,5 +79,62 @@
       "description": "OQ-01 uses minpoly (tighter); OQ-02 uses charpoly (more accessible for computation)"
     }
   ],
-  "sections": []
+  "sections": [
+    {
+      "id": "module-doc",
+      "title": "Module Documentation: Cayley-Hamilton as Computational Tool",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Header with computational framing (A^100 via degree-n reduction), 5 key results, mathematical significance (matrix exponential, ODEs, signal processing), and Mathlib dependencies including aeval_self_charpoly and modByMonic_add_div."
+    },
+    {
+      "id": "part1-reduction",
+      "title": "Part 1: The Polynomial Reduction Theorem",
+      "startLine": 59,
+      "endLine": 102,
+      "summary": "charpoly_annihilates (one-line Cayley-Hamilton), aeval_eq_aeval_modByMonic (core reduction via division algorithm), aeval_sub_mod_eq_zero (difference in annihilator). Works over any commutative ring R."
+    },
+    {
+      "id": "part2-degree",
+      "title": "Part 2: Degree Bounds",
+      "startLine": 104,
+      "endLine": 130,
+      "summary": "degree_reduced_lt_charpoly (deg(r) < deg(χ_A)) and degree_reduced_lt_dim (deg(r) < n). Both use calc chains and Nontrivial hypothesis to ensure the ring is non-degenerate."
+    },
+    {
+      "id": "part3-power",
+      "title": "Part 3: Matrix Power Reduction",
+      "startLine": 131,
+      "endLine": 161,
+      "summary": "power_eq_aeval_mod (A^k = aeval A (X^k mod χ_A), one-liner via simp) and aeval_reduced (existential: every evaluation equals one of degree < n). K[A] = span{I,...,A^{n-1}}."
+    },
+    {
+      "id": "part4-congruence",
+      "title": "Part 4: Congruence and Annihilator Ideal Structure",
+      "startLine": 162,
+      "endLine": 195,
+      "summary": "congruence (same remainder → same evaluation), charpoly_multiple_annihilates (ideal generator), annihilator_add and annihilator_mul_left (ideal closure). Together show ker(e_A) ⊇ (χ_A)."
+    },
+    {
+      "id": "part5-partial-sums",
+      "title": "Part 5: Partial Sum Reduction for Power Series",
+      "startLine": 197,
+      "endLine": 224,
+      "summary": "partial_sum_reduces (truncated power series reduces mod χ_A) and partial_sum_reduced_bound (degree bound on reduced sum). Foundation for matrix exponential via Putzer algorithm."
+    },
+    {
+      "id": "part6-nilpotent",
+      "title": "Part 6: Nilpotent Matrices — Charpoly = X^n",
+      "startLine": 226,
+      "endLine": 251,
+      "summary": "nilpotent_from_charpoly (χ_A = X^n → A^n = 0, direct from Cayley-Hamilton) and nilpotent_higher_powers_vanish (A^d = 0 → A^k = 0 for k ≥ d via pow_add)."
+    },
+    {
+      "id": "part7-special",
+      "title": "Parts 7: Idempotent Matrices and Concrete Examples",
+      "startLine": 253,
+      "endLine": 310,
+      "summary": "idempotent_power (A^k = A by induction, closed-form exponential I+(e^t-1)A). Concrete 2×2 power reduction, identity powers (one_pow), zero powers (zero_pow), scalar matrices. Closes with summary comment and 5 #check commands."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for `cayley-hamilton-oq-02`.

## Quality Improvements

**Annotations (was: 0, now: 6)**
- Background: Cayley-Hamilton as reduction algorithm with computational framing
- Core reduction theorem: 4-step proof walkthrough with quotient ring interpretation
- Power reduction: A^k recurrence and K[A] = span{I,...,A^{n-1}}
- Congruence and ideal structure: ker(e_A) ⊇ (χ_A)
- Partial sums: bridge to Putzer algorithm for matrix exponential
- Nilpotent/idempotent special cases with closed-form exponentials

**historicalContext**: Expanded — Cayley 1858, Hamilton 1853, Frobenius 1879, Buchheim 1886, Putzer 1966.

**keyInsights**: 4 → 6, including R[A] ≅ R[X]/(χ_A) isomorphism, power recurrence from charpoly, commutative ring generality.

**sections**: Added 8 sections covering all 7 code parts.

**conclusion**: Expanded with Putzer algorithm, Sylvester interpolation, formal power series extension.

## Axiom Integrity

Status `verified` / badge `original` / axiomCount 0 is correct: 20 theorems, 0 sorries, 0 axioms.