### PR TITLE
Audit: cycle 22 tracker — 2 new integrity issues filed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -547,9 +547,9 @@
       "result": "issues-fixed"
     },
     "birch-swinnerton-dyer": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-03-24T09:00:12Z",
+      "lastAudited": "2026-04-03T14:43:49Z",
       "result": "issues-found"
     },
     "birthday-problem": {
@@ -607,10 +607,10 @@
       "result": "issues-fixed"
     },
     "borsuk-ulam-oq-02-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-03-29T00:27:27Z",
-      "result": "clean"
+      "lastAudited": "2026-04-03T14:47:56Z",
+      "result": "issues-found"
     },
     "borsuk-ulam-oq-02-oq-03": {
       "auditCount": 1,
@@ -2741,10 +2741,10 @@
       "result": "clean"
     },
     "erdos-1126-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T12:59:28Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-03T14:44:11Z",
+      "result": "issues-found"
     },
     "erdos-1127": {
       "auditCount": 2,
@@ -11283,9 +11283,9 @@
       "issues": []
     },
     "cauchy-schwarz-oq-02-oq-01": {
-      "auditCount": 4,
-      "lastAudited": "2026-04-03T13:37:28Z",
-      "result": "issues-fixed",
+      "auditCount": 5,
+      "lastAudited": "2026-04-03T14:45:52Z",
+      "result": "issues-found",
       "issues": []
     },
     "buffons-needle-oq-01-oq-01-oq-01": {
@@ -11303,6 +11303,18 @@
     "sum-of-kth-powers-oq-01": {
       "auditCount": 1,
       "lastAudited": "2026-04-03T13:01:13Z",
+      "result": "clean",
+      "issues": []
+    },
+    "equivariant-borsuk-ulam-compact-lie": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T14:46:12Z",
+      "result": "clean",
+      "issues": []
+    },
+    "ballot-problem-oq-01-oq-04-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T14:48:22Z",
       "result": "clean",
       "issues": []
     }


### PR DESCRIPTION
## Summary

Audit cycle 22. Audited 4 proofs, confirmed 2 existing issues (pending in PR #8940), and filed 2 new issues:

**Existing issues (fix pending in PR #8940)**:
- `birch-swinnerton-dyer`: sorry count 0→1 (regulator_rank_one_is_height placeholder) — re-confirmed
- `erdos-1126-oq-01`: leanFile.axiomCount 5, should be 7 (2 private axioms) — re-confirmed

**New issues filed this cycle**:
- `cauchy-schwarz-oq-02-oq-01` → [#8955](https://github.com/rjwalters/lean-genius/issues/8955): Badge `original` should be `mathlib` — core results (`parseval_energy`, `parseval_hassum`, `fourier_series_L2_convergence`) are direct calls to Mathlib's `tsum_sq_fourierCoeff`, `hasSum_sq_fourierCoeff`, `hasSum_fourier_series_L2`. Failure Mode #5 (0 sorries with hidden Mathlib imports). Severity: MEDIUM.
- `borsuk-ulam-oq-02-oq-02` → [#8956](https://github.com/rjwalters/lean-genius/issues/8956): Status/badge `verified` but main theorem `EquivariantBorsukUlam := True` is a placeholder. File is an infrastructure survey; only 5 trivial equivariant-map lemmas are proved. Severity: **HIGH** (`loom:urgent` filed).

## Test plan
- [ ] Verify PR #8940 merges cleanly to resolve BSD and erdos-1126 discrepancies
- [ ] Mechanic picks up issues #8955 and #8956 for fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)