### PR TITLE
Enrich 3-Moduli Non-Coprime CRT: GCD-LCM Distributive Law

### DIFF
--- a/src/data/proofs/chinese-remainder-non-coprime-oq-03/annotations.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-03/annotations.json
@@ -1,1 +1,62 @@
-[]
+[
+  {
+    "id": "ann-crt-nc03-strategy",
+    "proofId": "chinese-remainder-non-coprime-oq-03",
+    "range": { "startLine": 1, "endLine": 24 },
+    "type": "context",
+    "title": "Three-Moduli CRT: The Two-Step Reduction Strategy",
+    "content": "The module docstring explains the core strategy for extending the non-coprime CRT from 2 to 3 moduli. The direct approach (generalizing necessity and sufficiency simultaneously for 3 moduli) would require complex combinatorics. Instead, the proof uses iterated reduction: (1) Solve the first pair (m₁,m₂) to get x₀; (2) Show that gcd(lcm(m₁,m₂), m₃) divides x₀-a₃ using the GCD-LCM distributive law; (3) Apply the 2-moduli CRT again to (lcm(m₁,m₂), m₃). The GCD-LCM distributive law is the key: gcd(lcm(a,b), c) ∣ lcm(gcd(a,c), gcd(b,c)), proved by a 200-line Bézout-based argument. The file self-contains the 2-moduli CRT (private copies) so it imports cleanly.",
+    "mathContext": "Compatibility condition for 3 moduli: $\\gcd(m_i, m_j) \\mid (a_i - a_j)$ for all pairs. The iterated 2-moduli reduction works because $\\gcd(\\mathrm{lcm}(m_1,m_2), m_3) \\mid (x_0 - a_3)$ follows from $\\gcd(m_1,m_3) \\mid (x_0-a_3)$ and $\\gcd(m_2,m_3) \\mid (x_0-a_3)$, hence $\\mathrm{lcm}(\\gcd(m_1,m_3), \\gcd(m_2,m_3)) \\mid (x_0-a_3)$, and then the distributive law gives the required divisibility.",
+    "significance": "context",
+    "relatedConcepts": ["iterated 2-moduli reduction", "GCD-LCM distributive law", "EuclideanDomain", "Bézout identity"],
+    "prerequisites": ["Non-coprime CRT for 2 moduli (OQ02)", "EuclideanDomain.lcm_dvd", "dvd_trans"]
+  },
+  {
+    "id": "ann-crt-nc03-lemmas",
+    "proofId": "chinese-remainder-non-coprime-oq-03",
+    "range": { "startLine": 67, "endLine": 84 },
+    "type": "context",
+    "title": "Intermediate Lemmas: GCD Divisibility and Congruence Transfer",
+    "content": "Part I provides two helper lemmas. gcd_dvd_of_dvd_sub proves that m ∣ (x-a) implies gcd(m,p) ∣ (x-a), using the fact that gcd(m,p) divides m (EuclideanDomain.gcd_dvd_left) composed with the hypothesis. gcd_dvd_sub_of_congr proves: given m ∣ (x₀-a₁) and gcd(m,m₃) ∣ (a₁-a₃), conclude gcd(m,m₃) ∣ (x₀-a₃). This is a transitivity of congruence: x₀-a₃ = (x₀-a₁) + (a₁-a₃), and gcd(m,m₃) divides both summands. These two lemmas are the bridge that transfers pairwise GCD conditions from the original remainders to the intermediate solution x₀.",
+    "mathContext": "$m \\mid (x_0 - a_1)$ and $\\gcd(m,m_3) \\mid (a_1 - a_3)$ $\\Rightarrow$ $\\gcd(m,m_3) \\mid (x_0 - a_3)$. This follows by congruence transitivity: $x_0 \\equiv a_1 \\pmod{m}$ and $a_1 \\equiv a_3 \\pmod{\\gcd(m,m_3)}$, so $x_0 \\equiv a_3 \\pmod{\\gcd(m,m_3)}$ (since $\\gcd(m,m_3) \\mid m$).",
+    "significance": "supporting",
+    "relatedConcepts": ["gcd_dvd_of_dvd_sub", "gcd_dvd_sub_of_congr", "congruence transitivity"],
+    "prerequisites": ["EuclideanDomain.gcd_dvd_left", "dvd_trans", "dvd_add"]
+  },
+  {
+    "id": "ann-crt-nc03-dist-easy",
+    "proofId": "chinese-remainder-non-coprime-oq-03",
+    "range": { "startLine": 86, "endLine": 111 },
+    "type": "insight",
+    "title": "GCD-LCM Distributive Law: Easy Direction via Divisibility Chains",
+    "content": "The easy direction of the distributive law (lcm_gcd_dvd_gcd_lcm) proves: lcm(gcd(a,c), gcd(b,c)) ∣ gcd(lcm(a,b), c). This direction follows purely from the lattice structure of divisibility. To show lcm(gcd(a,c), gcd(b,c)) ∣ gcd(lcm(a,b), c), it suffices to show both gcd(a,c) and gcd(b,c) divide gcd(lcm(a,b), c). For gcd(a,c): it divides lcm(a,b) (since gcd(a,c)∣a∣lcm(a,b)) and it divides c, so it divides their gcd. The helper gcd_lcm_dvd_mul proves gcd(lcm(a,b),c) ∣ a·b by composing with lcm(a,b) ∣ a·b. This is used in the hard direction to anchor the Bézout expansion.",
+    "mathContext": "$\\gcd(a,c) \\mid a \\mid \\mathrm{lcm}(a,b)$ and $\\gcd(a,c) \\mid c$, so $\\gcd(a,c) \\mid \\gcd(\\mathrm{lcm}(a,b), c)$. Similarly for $\\gcd(b,c)$. Then $\\mathrm{lcm}(\\gcd(a,c),\\gcd(b,c)) \\mid \\gcd(\\mathrm{lcm}(a,b),c)$ by the LCM universal property (lcm_dvd).",
+    "significance": "supporting",
+    "relatedConcepts": ["lcm_gcd_dvd_gcd_lcm", "EuclideanDomain.dvd_gcd", "EuclideanDomain.lcm_dvd", "lattice of divisors"],
+    "prerequisites": ["EuclideanDomain.dvd_gcd", "EuclideanDomain.dvd_lcm_left/right", "dvd_trans"]
+  },
+  {
+    "id": "ann-crt-nc03-dist-hard",
+    "proofId": "chinese-remainder-non-coprime-oq-03",
+    "range": { "startLine": 136, "endLine": 321 },
+    "type": "insight",
+    "title": "GCD-LCM Hard Direction: A 185-Line Bézout Decomposition",
+    "content": "The hard direction gcd_lcm_dvd_lcm_gcd (proving gcd(lcm(a,b),c) ∣ lcm(gcd(a,c), gcd(b,c))) is a 185-line argument. The proof strategy: set g = gcd(a,b), factor a = g·α and b = g·β with IsCoprime α β (proved by Bézout cancellation). Set d' = gcd(g,c), factor g = d'·g' and c = d'·c' with IsCoprime g' c'. Write M = lcm(gcd(a,c), gcd(b,c)) as a linear combination of a and c (via M = gcd(a,c)·k₁ and Bézout: M = r₁·a + s₁·c). Similarly M = r₂·b + s₂·c. Subtract: r₁·a - r₂·b = (s₂-s₁)·c. Substitute a = g·α, b = g·β: g·(r₁·α - r₂·β) = (s₂-s₁)·c. Cancel d': g'·(r₁·α - r₂·β) = (s₂-s₁)·c'. Use IsCoprime g' c' to conclude c' ∣ (r₁·α - r₂·β). Then use IsCoprime α β to conclude β ∣ (r₁ - p_b·c'·w). Decompose M = m·(g·α·β) + T·c. Since gcd(lcm(a,b),c) divides both g·α·β (because lcm(a,b) ∣ g·α·β) and c, it divides M.",
+    "mathContext": "The core algebraic identity: $M = m \\cdot (g \\cdot \\alpha \\cdot \\beta) + T \\cdot c$. Since $\\mathrm{lcm}(a,b) \\mid g \\cdot \\alpha \\cdot \\beta$ (both $a = g\\alpha$ and $b = g\\beta$ divide it) and $\\gcd(\\mathrm{lcm}(a,b),c) \\mid \\mathrm{lcm}(a,b)$, we get $\\gcd(\\mathrm{lcm}(a,b),c) \\mid g\\alpha\\beta$. Combined with $\\gcd(\\mathrm{lcm}(a,b),c) \\mid c$, it divides $M$. The key CRT-within-a-proof structure: two coprimality arguments (IsCoprime α β and IsCoprime g' c') enable the divisibility cascade.",
+    "significance": "key",
+    "relatedConcepts": ["gcd_lcm_dvd_lcm_gcd", "Bézout decomposition", "IsCoprime cancellation", "coprime factoring"],
+    "prerequisites": ["IsCoprime α β via Bézout cancellation", "mul_left_cancel₀", "EuclideanDomain.gcd_eq_gcd_ab"]
+  },
+  {
+    "id": "ann-crt-nc03-sufficiency",
+    "proofId": "chinese-remainder-non-coprime-oq-03",
+    "range": { "startLine": 322, "endLine": 391 },
+    "type": "insight",
+    "title": "Three-Moduli Sufficiency, Iff, Uniqueness, and Proof History",
+    "content": "ed_crt_three_sufficient applies the strategy: (1) ed_crt_sufficient h12 gives x₀ satisfying m₁ and m₂; (2) gcd_dvd_sub_of_congr transfers h13 and h23 to get gcd(m₁,m₃) ∣ (x₀-a₃) and gcd(m₂,m₃) ∣ (x₀-a₃); (3) EuclideanDomain.lcm_dvd combines these; (4) gcd_lcm_dvd_lcm_gcd gives gcd(lcm(m₁,m₂),m₃) ∣ (x₀-a₃); (5) ed_crt_sufficient constructs x; (6) x satisfies all three via m₁ ∣ lcm(m₁,m₂) and m₂ ∣ lcm(m₁,m₂). ed_crt_three_iff combines with necessity. ed_crt_three_unique proves solutions agree mod lcm(m₁,lcm(m₂,m₃)) by EuclideanDomain.lcm_dvd. The summary records the proof history: originally proved using an axiom gcd_lcm_distrib, then via sorry, then fully verified with the direct Bézout proof.",
+    "mathContext": "$\\gcd(\\mathrm{lcm}(m_1,m_2), m_3) \\mid (x_0 - a_3)$ follows from $\\gcd(\\mathrm{lcm}(m_1,m_2), m_3) \\mid \\mathrm{lcm}(\\gcd(m_1,m_3), \\gcd(m_2,m_3))$ (hard distributive law) and $\\mathrm{lcm}(\\gcd(m_1,m_3), \\gcd(m_2,m_3)) \\mid (x_0 - a_3)$ (from individual gcd conditions). Uniqueness: $m_i \\mid (x-y)$ for $i=1,2,3$, so $\\mathrm{lcm}(m_1, \\mathrm{lcm}(m_2,m_3)) \\mid (x-y)$ by nested application of lcm_dvd.",
+    "significance": "key",
+    "relatedConcepts": ["ed_crt_three_sufficient", "ed_crt_three_iff", "ed_crt_three_unique", "EuclideanDomain.lcm_dvd"],
+    "prerequisites": ["gcd_lcm_dvd_lcm_gcd", "gcd_dvd_sub_of_congr", "ed_crt_sufficient", "EuclideanDomain.dvd_lcm_left/right"]
+  }
+]

--- a/src/data/proofs/chinese-remainder-non-coprime-oq-03/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-03/meta.json
@@ -34,15 +34,17 @@
     ]
   },
   "overview": {
-    "historicalContext": "The classical Chinese Remainder Theorem requires pairwise coprime moduli. The non-coprime generalization (for 2 moduli) is: the system has a solution iff gcd(m₁,m₂)∣(a₁-a₂). Extending this to 3 moduli requires the GCD-LCM distributive law, which is nontrivial in general Euclidean domains.",
+    "historicalContext": "The 3-moduli non-coprime CRT was known classically for ℤ: pairwise GCD compatibility is necessary and sufficient for the system of congruences to be solvable. The algebraic extension to general EuclideanDomains requires the GCD-LCM distributive identity gcd(lcm(a,b),c) = lcm(gcd(a,c),gcd(b,c)). This identity is classical in lattice theory (Birkhoff, 1935) — it characterizes distributive lattices — but its proof in the divisibility lattice of a Euclidean domain requires nontrivial work. The Lean proof went through three stages: first using an axiom gcd_lcm_distrib, then a sorry placeholder, and finally a complete 185-line Bézout-based proof. This proof trajectory exemplifies the gap between 'known to be true' and 'formally verified': the distributive law is obvious in ℤ but requires a careful argument in general EuclideanDomains where there is no canonical representative for gcd.",
     "problemStatement": "In a Euclidean domain R, given moduli m₁, m₂, m₃ and remainders a₁, a₂, a₃, does the system m₁∣(x-a₁), m₂∣(x-a₂), m₃∣(x-a₃) have a solution? Prove it is equivalent to pairwise GCD compatibility.",
     "text": "The sufficiency proof uses a constructive 2-step reduction. Step 1: solve the first pair (m₁, m₂) using the 2-moduli CRT to get x₀ with m₁∣(x₀-a₁) and m₂∣(x₀-a₂). Step 2: the key is showing gcd(lcm(m₁,m₂), m₃)∣(x₀-a₃), which reduces to the GCD-LCM distributive law. Then apply the 2-moduli CRT again for (lcm(m₁,m₂), m₃). The hard direction of the distributive law gcd_lcm_dvd_lcm_gcd is proved by Bézout decomposition: write gcd(a,b) = u·a + v·b, then expand gcd(a,b)·gcd(a·b/(gcd(a,b)),c) using coprime factoring.",
     "proofStrategy": "Inherit necessity from ChineseRemainderNonCoprimeOQ02.lean. Prove GCD-LCM distributive law (both directions). Use iterated 2-moduli CRT application. Prove uniqueness via divisibility of the LCM.",
     "keyInsights": [
-      "The 3-moduli case reduces to two applications of the 2-moduli CRT",
-      "The GCD-LCM distributive law gcd(a, lcm(b,c)) = lcm(gcd(a,b), gcd(a,c)) is the key algebraic fact",
-      "Bézout's identity in Euclidean domains enables the hard direction of the distributive law",
-      "Solution uniqueness follows from divisibility by the iterated LCM"
+      "The 3-moduli case reduces to two applications of the 2-moduli CRT via iterated reduction",
+      "The GCD-LCM distributive law gcd(lcm(a,b), c) = lcm(gcd(a,c), gcd(b,c)) is the essential algebraic engine",
+      "Bézout's identity in Euclidean domains enables the 185-line hard direction of the distributive law",
+      "Solution uniqueness follows from divisibility by the iterated LCM lcm(m₁, lcm(m₂, m₃))",
+      "The proof went axiom → sorry → full proof: illustrating the gap between 'classical' and 'formally verified'",
+      "Coprime factoring through gcd(a,b) and gcd(gcd(a,b),c) creates two independent IsCoprime instances whose joint cancellation yields the final decomposition"
     ],
     "prerequisites": [
       "Euclidean domains: GCD, LCM, Bézout's identity",
@@ -51,11 +53,13 @@
     ]
   },
   "conclusion": {
-    "summary": "The 3-moduli non-coprime CRT is fully verified: solution exists iff pairwise GCD conditions hold, and is unique modulo the iterated LCM. The key GCD-LCM distributive law is proved by direct Bézout expansion. 7 theorems, 0 definitions, 391 lines, 0 axioms.",
-    "implications": "This completes the non-coprime CRT hierarchy up to 3 moduli in any Euclidean domain. The framework naturally extends to any finite number of moduli by induction.",
+    "summary": "The 3-moduli non-coprime CRT is fully verified: solution exists iff pairwise GCD conditions hold, and is unique modulo lcm(m₁, lcm(m₂, m₃)). The GCD-LCM distributive law is proved by a 185-line direct Bézout decomposition with nested coprime factoring. 7 theorems, 391 lines, 0 axioms. Previously required 1 axiom, now axiom-free.",
+    "implications": "This completes the non-coprime CRT hierarchy: 2-moduli (OQ02) and 3-moduli (OQ03) cases are both verified for all Euclidean domains. The proof technique — iterated 2-moduli reduction + GCD-LCM distributive law — generalizes to n moduli by induction. The distributive law proof also contributes independently: it verifies a classical lattice identity in the divisibility poset of Euclidean domains.",
     "openQuestions": [
-      "Generalize to n moduli: system solvable iff all pairwise GCD conditions hold (inductive case)",
-      "Module-theoretic version: CRT for modules over principal ideal domains"
+      "Generalize to n moduli by induction: solvable iff all pairwise GCD conditions hold, unique mod lcm(m₁,...,mₙ)",
+      "Formalize the GCD-LCM distributive law as a standalone Mathlib lemma for EuclideanDomains",
+      "Module-theoretic version: CRT for modules over PIDs (Chinese Remainder for module decomposition)",
+      "Computational complexity: how many Bézout steps does the iterated 3-moduli construction require?"
     ]
   },
   "leanFile": {
@@ -72,5 +76,30 @@
       "description": "2-moduli non-coprime CRT; this file extends to 3 moduli using iterated reduction"
     }
   ],
-  "sections": []
+  "sections": [
+    {
+      "title": "Part 0: Self-Contained 2-Moduli CRT",
+      "startLine": 25,
+      "endLine": 65,
+      "summary": "Private copies of ed_crt_necessary, ed_crt_sufficient, and ed_crt_three_necessary from OQ02. Self-contained so this file can be imported independently. The necessity proof deduces gcd ∣ (a-b) by dvd_sub; sufficiency constructs x = a - m·(gcdA·q) via Bézout; three-moduli necessity applies the pairwise version three times."
+    },
+    {
+      "title": "Part I: Intermediate Lemmas",
+      "startLine": 67,
+      "endLine": 84,
+      "summary": "gcd_dvd_of_dvd_sub: m ∣ (x-a) implies gcd(m,p) ∣ (x-a) by gcd_dvd_left composition. gcd_dvd_sub_of_congr: congruence transfer — m ∣ (x₀-a₁) and gcd(m,m₃) ∣ (a₁-a₃) give gcd(m,m₃) ∣ (x₀-a₃) by x₀-a₃ = (x₀-a₁) + (a₁-a₃)."
+    },
+    {
+      "title": "Part II: GCD-LCM Distributive Law",
+      "startLine": 86,
+      "endLine": 321,
+      "summary": "Easy direction (lcm_gcd_dvd_gcd_lcm): lattice chain reasoning via dvd_gcd and dvd_lcm. Helper lemmas: lcm_dvd_mul (lcm(a,b) ∣ a·b) and gcd_lcm_dvd_mul (gcd(lcm(a,b),c) ∣ a·b). Hard direction (gcd_lcm_dvd_lcm_gcd): 185-line Bézout argument. Set g=gcd(a,b), factor a=gα, b=gβ (IsCoprime α β). Set d'=gcd(g,c), factor g=d'g', c=d'c' (IsCoprime g' c'). Write M as linear combination of a,c and b,c; subtract to get g(r₁α-r₂β)=(s₂-s₁)c; cancel d'; use IsCoprime g' c' to get c'∣(r₁α-r₂β); use IsCoprime α β to get β∣(r₁-p_b·c'·w); decompose M=m·(gαβ)+T·c."
+    },
+    {
+      "title": "Part III: Three-Moduli CRT and Summary",
+      "startLine": 322,
+      "endLine": 391,
+      "summary": "ed_crt_three_sufficient: (1) solve (m₁,m₂) to get x₀; (2) transfer pairwise conditions to x₀; (3) apply lcm_dvd and gcd_lcm_dvd_lcm_gcd; (4) apply ed_crt_sufficient for (lcm(m₁,m₂), m₃); (5) recover m₁ and m₂ conditions via dvd_lcm_left/right. ed_crt_three_iff combines with necessity. ed_crt_three_unique: lcm(m₁,lcm(m₂,m₃)) ∣ (x-y) by nested EuclideanDomain.lcm_dvd. Summary: proof history (axiom → sorry → verified), 7 theorems listed."
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Enriches `chinese-remainder-non-coprime-oq-03` (CRT for Three Non-Coprime Moduli, 391 lines, 7 theorems).

- **5 new annotations** covering all parts: two-step reduction strategy, congruence transfer lemmas, GCD-LCM easy direction, 185-line Bézout hard direction proof, sufficiency/iff/uniqueness
- **historicalContext** expanded: Birkhoff 1935 distributive lattices, classical-vs-formal gap, axiom→sorry→verified proof trajectory
- **keyInsights**: 4 → 6 (add proof history insight and nested coprime factoring)
- **4 sections** covering the complete file
- **conclusion/openQuestions**: 2 → 4 (n-moduli induction, standalone Mathlib lemma, module CRT, complexity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)