### PR TITLE
Fix: birch-swinnerton-dyer sorry count (0 → 1)

### DIFF
--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -14,9 +14,9 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "axiomCount": 19,
-    "assumptions": "19 axiom declarations encoding: (1) L-function analytic continuation and functional equation, (2) Hasse bound a_p^2 <= 4p, (3) BSD conjecture proven cases (Kolyvagin rank 0, Gross-Zagier+Kolyvagin rank 1), (4) parity conjecture (Dokchitsers), (5) L-values and ranks for specific curves, (6) Sha structure, (7) Elkies rank record, (8) Greenberg-Stevens theorem, (9) regulator positivity. Previously 21 axioms: BSD_CM_rank_zero was proved redundant (subsumed by Kolyvagin general result), gross_zagier_formula_detail was dead code (captured by GrossZagierData structure). No sorries.",
+    "assumptions": "19 axiom declarations encoding: (1) L-function analytic continuation and functional equation, (2) Hasse bound a_p^2 <= 4p, (3) BSD conjecture proven cases (Kolyvagin rank 0, Gross-Zagier+Kolyvagin rank 1), (4) parity conjecture (Dokchitsers), (5) L-values and ranks for specific curves, (6) Sha structure, (7) Elkies rank record, (8) Greenberg-Stevens theorem, (9) regulator positivity. Previously 21 axioms: BSD_CM_rank_zero was proved redundant (subsumed by Kolyvagin general result), gross_zagier_formula_detail was dead code (captured by GrossZagierData structure). 1 sorry: `regulator_rank_one_is_height` (placeholder: R = ĥ(generator) for rank-1 curves).",
     "mathlibDependencies": [
       {
         "theorem": "WeierstrassCurve",


### PR DESCRIPTION
## Summary

- Corrects `meta.json` for birch-swinnerton-dyer: `sorries` field was `0` but the Lean source has 1 sorry at line 1627 in theorem `regulator_rank_one_is_height`
- Updates the `assumptions` text to document the sorry instead of claiming "No sorries"

## Changes

- `src/data/proofs/birch-swinnerton-dyer/meta.json`: `"sorries": 0` -> `"sorries": 1`; trailing `"No sorries."` -> `"1 sorry: \`regulator_rank_one_is_height\` (placeholder: R = ĥ(generator) for rank-1 curves)."`

## Evidence

`proofs/Proofs/BirchSwinnertonDyer.lean` line 1627:
```lean
  sorry -- Placeholder: R = ĥ(generator) for rank-1 curves
```