### PR TITLE
Fix: correct badge for cauchy-schwarz-oq-02-oq-01 (original → mathlib)

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "cauchy-schwarz-oq-02-oq-01",
   "title": "Parseval's Identity: Energy Conservation in Fourier Analysis",
   "slug": "cauchy-schwarz-oq-02-oq-01",
-  "description": "Formalizes Parseval's identity — ∑|ĉₙ(f)|² = ∫|f|²dμ — as a consequence of the L² structure from CauchySchwarzOQ02. Proves: Parseval energy equality (tsum = integral), Bessel-Parseval tightness (Bessel's inequality is equality in total), Fourier orthonormality, Pythagorean theorem for finite Fourier sums, L² convergence of Fourier series, and completeness (zero-kernel). 10 theorems, 0 sorries.",
+  "description": "Formalizes Parseval's identity \u2014 \u2211|\u0109\u2099(f)|\u00b2 = \u222b|f|\u00b2d\u03bc \u2014 as a consequence of the L\u00b2 structure from CauchySchwarzOQ02. Proves: Parseval energy equality (tsum = integral), Bessel-Parseval tightness (Bessel's inequality is equality in total), Fourier orthonormality, Pythagorean theorem for finite Fourier sums, L\u00b2 convergence of Fourier series, and completeness (zero-kernel). 10 theorems, 0 sorries.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-03",
@@ -16,46 +16,40 @@
       "cauchy-schwarz",
       "orthonormality"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-04-03",
     "axiomCount": 0,
-    "assumptions": "None. All 10 theorems fully verified.",
+    "assumptions": "None. All 10 theorems fully verified. Core Parseval results (parseval_energy, parseval_hassum, fourier_series_L2_convergence) wrap Mathlib API (tsum_sq_fourierCoeff, hasSum_sq_fourierCoeff, hasSum_fourier_series_L2). Original contribution: fourier_pythagorean_partial with explicit inner product expansion.",
     "lineCount": 223,
     "theoremCount": 10,
     "definitionCount": 0,
     "originalContributions": [
-      "parseval_energy: ∑' n, ‖ĉₙ(f)‖² = ∫ t, ‖f t‖² ∂μ (energy equality)",
-      "parseval_hassum: HasSum form of Parseval identity",
-      "fourier_coeff_sq_summable: squared Fourier coefficients form a summable series",
-      "bessel_fourier: Bessel's inequality ∑_{n∈S} |ĉₙ|² ≤ ∫|f|² (tight by Parseval)",
-      "fourier_pythagorean_partial: ‖∑_{n∈S} cₙeₙ‖² = ∑_{n∈S} |cₙ|² (Pythagorean for ONS)",
-      "parseval_implies_completeness: zero Fourier coefficients ⟹ zero function",
-      "fourier_series_L2_convergence: Fourier series converges to f in L²"
+      "fourier_pythagorean_partial: \u2016\u2211_{n\u2208S} c\u2099e\u2099\u2016\u00b2 = \u2211_{n\u2208S} |c\u2099|\u00b2 (Pythagorean for ONS \u2014 original proof expanding inner products with Kronecker delta)"
     ]
   },
   "overview": {
-    "historicalContext": "Parseval (1799) discovered the energy equality for Fourier series; Plancherel (1910) extended it to L² functions. The identity ∑|ĉₙ|² = ‖f‖² is foundational to Fourier analysis, signal processing, and quantum mechanics. It expresses conservation of energy: total power in the frequency domain equals total power in the time domain.",
-    "problemStatement": "Formalize Parseval's identity ∑_{n∈ℤ} |ĉₙ(f)|² = ‖f‖²_{L²} for Fourier coefficients on the circle, as a follow-up to the Hölder/L² theory in CauchySchwarzOQ02.",
-    "text": "Parseval's identity connects the L² norm to the Fourier coefficients: ∑' n : ℤ, ‖ĉₙ(f)‖² = ∫ |f|² dμ for f ∈ L²(AddCircle T). This is the limiting form of the Pythagorean theorem: since the Fourier monomials are orthonormal (⟪eₙ, eₘ⟫ = δₙₘ), finite partial sums satisfy ‖∑_{n∈S} ĉₙeₙ‖² = ∑_{n∈S} |ĉₙ|² (Pythagorean). As the partial sums converge in L² to f (completeness of the Fourier system), the left side approaches ‖f‖², yielding Parseval.",
-    "proofStrategy": "Apply Mathlib's hasSum_sq_fourierCoeff for Parseval, orthonormal_fourier for orthonormality, and hasSum_fourier_series_L2 for L² convergence. The Pythagorean theorem for finite sums requires careful manipulation of inner products with orthonormal systems.",
+    "historicalContext": "Parseval (1799) discovered the energy equality for Fourier series; Plancherel (1910) extended it to L\u00b2 functions. The identity \u2211|\u0109\u2099|\u00b2 = \u2016f\u2016\u00b2 is foundational to Fourier analysis, signal processing, and quantum mechanics. It expresses conservation of energy: total power in the frequency domain equals total power in the time domain.",
+    "problemStatement": "Formalize Parseval's identity \u2211_{n\u2208\u2124} |\u0109\u2099(f)|\u00b2 = \u2016f\u2016\u00b2_{L\u00b2} for Fourier coefficients on the circle, as a follow-up to the H\u00f6lder/L\u00b2 theory in CauchySchwarzOQ02.",
+    "text": "Parseval's identity connects the L\u00b2 norm to the Fourier coefficients: \u2211' n : \u2124, \u2016\u0109\u2099(f)\u2016\u00b2 = \u222b |f|\u00b2 d\u03bc for f \u2208 L\u00b2(AddCircle T). This is the limiting form of the Pythagorean theorem: since the Fourier monomials are orthonormal (\u27eae\u2099, e\u2098\u27eb = \u03b4\u2099\u2098), finite partial sums satisfy \u2016\u2211_{n\u2208S} \u0109\u2099e\u2099\u2016\u00b2 = \u2211_{n\u2208S} |\u0109\u2099|\u00b2 (Pythagorean). As the partial sums converge in L\u00b2 to f (completeness of the Fourier system), the left side approaches \u2016f\u2016\u00b2, yielding Parseval.",
+    "proofStrategy": "Apply Mathlib's hasSum_sq_fourierCoeff for Parseval, orthonormal_fourier for orthonormality, and hasSum_fourier_series_L2 for L\u00b2 convergence. The Pythagorean theorem for finite sums requires careful manipulation of inner products with orthonormal systems.",
     "keyInsights": [
-      "Parseval = limit of Pythagorean: Bessel's inequality ∑_{n∈S}|ĉₙ|² ≤ ‖f‖² becomes equality in total",
-      "Completeness of Fourier system: zero-kernel property (all ĉₙ = 0 ⟹ f = 0)",
-      "L² convergence gives Parseval via norm continuity: ‖Sₙ(f)‖² → ‖f‖²",
+      "Parseval = limit of Pythagorean: Bessel's inequality \u2211_{n\u2208S}|\u0109\u2099|\u00b2 \u2264 \u2016f\u2016\u00b2 becomes equality in total",
+      "Completeness of Fourier system: zero-kernel property (all \u0109\u2099 = 0 \u27f9 f = 0)",
+      "L\u00b2 convergence gives Parseval via norm continuity: \u2016S\u2099(f)\u2016\u00b2 \u2192 \u2016f\u2016\u00b2",
       "Connection to CauchySchwarzOQ02: the Pythagorean theorem applied to orthogonal Fourier modes"
     ],
     "prerequisites": [
       "Fourier analysis: Fourier coefficients, Fourier monomials, AddCircle",
-      "L² spaces: Lp ℂ 2, haarAddCircle measure",
+      "L\u00b2 spaces: Lp \u2102 2, haarAddCircle measure",
       "Inner product spaces: orthonormality, Hilbert basis"
     ]
   },
   "conclusion": {
-    "summary": "Parseval's identity fully verified: ∑|ĉₙ(f)|² = ∫|f|²dμ. 10 theorems including Parseval energy equality, Bessel tightness, Fourier orthonormality, Pythagorean theorem for finite Fourier sums, L² convergence, and completeness. 0 sorries.",
-    "implications": "Parseval is foundational for Fourier analysis: it enables L² theory of Fourier series, underlies Plancherel's theorem for the Fourier transform, and is essential for quantum mechanics (Hilbert space formulation). The connection to Pythagorean theorem shows Parseval as an infinite-dimensional Pythagoras.",
+    "summary": "Parseval's identity fully verified: \u2211|\u0109\u2099(f)|\u00b2 = \u222b|f|\u00b2d\u03bc. 10 theorems including Parseval energy equality, Bessel tightness, Fourier orthonormality, Pythagorean theorem for finite Fourier sums, L\u00b2 convergence, and completeness. 0 sorries.",
+    "implications": "Parseval is foundational for Fourier analysis: it enables L\u00b2 theory of Fourier series, underlies Plancherel's theorem for the Fourier transform, and is essential for quantum mechanics (Hilbert space formulation). The connection to Pythagorean theorem shows Parseval as an infinite-dimensional Pythagoras.",
     "openQuestions": [
-      "Prove the inner product Parseval: ⟪f,g⟫ = ∑ ĉₙ(f)·conj(ĉₙ(g)) (Parseval-Plancherel)",
+      "Prove the inner product Parseval: \u27eaf,g\u27eb = \u2211 \u0109\u2099(f)\u00b7conj(\u0109\u2099(g)) (Parseval-Plancherel)",
       "Extend to general Hilbert bases: abstract Parseval for any orthonormal basis"
     ]
   },
@@ -71,7 +65,7 @@
     {
       "targetId": "cauchy-schwarz-oq-02",
       "relationship": "extends",
-      "description": "CauchySchwarzOQ02 proves Pythagorean theorem in L²; OQ-01 applies it to Fourier modes to get Parseval"
+      "description": "CauchySchwarzOQ02 proves Pythagorean theorem in L\u00b2; OQ-01 applies it to Fourier modes to get Parseval"
     },
     {
       "targetId": "fourier-series",


### PR DESCRIPTION
## Summary

- Corrects `badge: "original"` → `"mathlib"` for `cauchy-schwarz-oq-02-oq-01`
- Core theorems are direct single-line Mathlib API calls: `parseval_energy` = `exact tsum_sq_fourierCoeff f`, `parseval_hassum` = `exact hasSum_sq_fourierCoeff f`, `fourier_series_L2_convergence` = `exact hasSum_fourier_series_L2 f`, `fourier_orthonormal` = `exact orthonormal_fourier`
- Only `fourier_pythagorean_partial` has an original proof (explicit inner-product expansion with Kronecker delta calculations)
- `originalContributions` narrowed to just `fourier_pythagorean_partial`
- `assumptions` updated to document the Mathlib dependency accurately

Closes #8955

## Test plan
- [ ] meta.json parses as valid JSON
- [ ] `badge: "mathlib"` accurately reflects that core theorems wrap Mathlib API
- [ ] Gallery displays attribution correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)