### PR TITLE
Fix: count private axiom declarations in audit integrity checks

### DIFF
--- a/scripts/auditor/find-targets.ts
+++ b/scripts/auditor/find-targets.ts
@@ -249,7 +249,7 @@ function analyzeProof(id: string, galleryPath: string, tracker: Tracker): AuditT
     const content = stripLeanComments(rawContent)
 
     sorryCount += (content.match(/\bsorry\b/g) || []).length
-    axiomCount += (content.match(/^axiom /gm) || []).length
+    axiomCount += (content.match(/^(?:private\s+)?axiom /gm) || []).length
 
     // True stubs: only count theorem/lemma declarations, not example (Issue #6130)
     for (const line of content.split('\n')) {


### PR DESCRIPTION
## Summary

- The axiom-counting regex in `scripts/auditor/find-targets.ts` used `^axiom /gm`, which only matched public axiom declarations
- `private axiom` declarations were missed, causing false "axiom overcount" issues (e.g., erdos-1126-oq-01 claims 7 axioms in meta.json but the script only counted 5 because 2 are `private axiom`)
- Fixed the regex to `^(?:private\s+)?axiom /gm` so both `axiom foo` and `private axiom foo` are counted

## Test plan

- [ ] Verify erdos-1126-oq-01 no longer shows a false axiom overcount when running the auditor
- [ ] Confirm proofs with only public axioms are unaffected