### PR TITLE
Enrich Extended Binomial Coefficient Identities: annotations, sections

### DIFF
--- a/src/data/proofs/combinations-formula-oq-01/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-01/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-comb-oq01-background",
+    "proofId": "combinations-formula-oq-01",
+    "range": { "startLine": 1, "endLine": 22 },
+    "type": "context",
+    "title": "Six Binomial Identities: Classical Results in Lean",
+    "content": "The module covers six extensions of the basic binomial formula: (1) Vandermonde's convolution; (2) Hockey Stick diagonal sum; (3) Double-counting product identity; (4) Row sum and alternating row sum; (5) Binomial bound C(n,k) ≤ 2ⁿ; (6) Central binomial bound C(2n,n) ≤ 4ⁿ. Plus Fibonacci diagonal sums verified by native_decide. The Mathlib imports used are Nat.Choose.Basic, Nat.Choose.Sum, and Finset.Basic. Two key Mathlib lemmas carry the heavy lifting: Nat.add_choose_eq (for Vandermonde) and Nat.sum_range_choose (for row sum). The proof strategies range from one-liners (row sum: exact Nat.sum_range_choose n) to 30-line factorial algebra (product identity).",
+    "mathContext": "The file covers: $\\binom{m+n}{r} = \\sum_k \\binom{m}{k}\\binom{n}{r-k}$, $\\sum_{i=0}^n \\binom{i+r}{r} = \\binom{n+r+1}{r+1}$, $\\binom{n}{k}\\binom{k}{j} = \\binom{n}{j}\\binom{n-j}{k-j}$, $\\sum_k \\binom{n}{k} = 2^n$, $\\binom{n}{k} \\le 2^n$, $\\binom{2n}{n} \\le 4^n$.",
+    "significance": "context",
+    "relatedConcepts": ["Nat.choose", "Nat.sum_range_choose", "Nat.add_choose_eq", "Pascal's rule", "BigOperators"],
+    "prerequisites": ["Nat.choose_mul_factorial_mul_factorial", "Nat.choose_succ_succ (Pascal's rule)", "Finset.sum_range_succ"]
+  },
+  {
+    "id": "ann-comb-oq01-vandermonde",
+    "proofId": "combinations-formula-oq-01",
+    "range": { "startLine": 33, "endLine": 40 },
+    "type": "insight",
+    "title": "Vandermonde's Identity: A Two-Line Proof via Mathlib",
+    "content": "The vandermonde theorem proves C(m+n,r) = Σ_{k=0}^{r} C(m,k)·C(n,r-k) in just two lines: rw [Nat.add_choose_eq] rewrites C(m+n,r) as a sum over antidiagonals, and then exact (Finset.Nat.sum_antidiagonal_eq_sum_range_succ ...) r converts the antidiagonal sum to a range sum. The proof delegates entirely to Mathlib's existing infrastructure for Vandermonde. The combinatorial interpretation: choosing r items from a set split into parts of sizes m and n can be decomposed by how many are chosen from each part (k from the first, r-k from the second). This is equivalent to the coefficient of xʳ in (1+x)ᵐ·(1+x)ⁿ = (1+x)^{m+n}.",
+    "mathContext": "$\\binom{m+n}{r} = [x^r](1+x)^{m+n} = [x^r](1+x)^m(1+x)^n = \\sum_{k=0}^r \\binom{m}{k}\\binom{n}{r-k}$. Mathlib: `Nat.add_choose_eq` rewrites the LHS; `Finset.Nat.sum_antidiagonal_eq_sum_range_succ` converts to a range sum.",
+    "significance": "key",
+    "relatedConcepts": ["Vandermonde identity", "Nat.add_choose_eq", "Finset.Nat.sum_antidiagonal_eq_sum_range_succ", "generating functions"],
+    "prerequisites": ["Nat.add_choose_eq", "Finset.Nat.sum_antidiagonal_eq_sum_range_succ"]
+  },
+  {
+    "id": "ann-comb-oq01-hockey",
+    "proofId": "combinations-formula-oq-01",
+    "range": { "startLine": 51, "endLine": 65 },
+    "type": "insight",
+    "title": "Hockey Stick Identity: Induction via Pascal's Rule",
+    "content": "The hockey_stick theorem proves Σ_{i=0}^{n} C(i+r,r) = C(n+r+1,r+1) by induction on n. Base case: Σ = C(r,r) = 1 = C(r+1,r+1) by simp [Nat.choose_self]. Inductive step: expose the last term via Finset.sum_range_succ, apply the induction hypothesis, then use Nat.choose_succ_succ (Pascal's rule) with omega for index arithmetic. The 'hockey stick' name: in Pascal's triangle, the partial sum runs diagonally (the stick), and the final value is a single entry one step further (the blade). The identity has applications in counting lattice paths that avoid a boundary, and in combinatorial proofs of Catalan numbers.",
+    "mathContext": "$\\sum_{i=0}^n \\binom{i+r}{r} = \\binom{n+r+1}{r+1}$. Inductive step: $\\binom{k+r+1}{r+1} + \\binom{k+1+r}{r} = \\binom{k+1+r+1}{r+1}$ by Pascal $\\binom{n}{k} + \\binom{n}{k+1} = \\binom{n+1}{k+1}$ (Nat.choose_succ_succ).",
+    "significance": "key",
+    "relatedConcepts": ["Hockey Stick identity", "Pascal's rule", "Nat.choose_succ_succ", "Finset.sum_range_succ"],
+    "prerequisites": ["Nat.choose_succ_succ", "Finset.sum_range_succ", "Nat.choose_self"]
+  },
+  {
+    "id": "ann-comb-oq01-product",
+    "proofId": "combinations-formula-oq-01",
+    "range": { "startLine": 76, "endLine": 109 },
+    "type": "insight",
+    "title": "Double-Counting Product Identity: Factorial Cancellation",
+    "content": "The choose_product theorem proves C(n,k)·C(k,j) = C(n,j)·C(n-j,k-j) via a 30-line factorial argument. Strategy: multiply both sides by j!·(k-j)!·(n-k)! and show both equal n! via Nat.choose_mul_factorial_mul_factorial. For the LHS: C(n,k)·(C(k,j)·j!·(k-j)!)·(n-k)! = C(n,k)·k!·(n-k)! = n!. For the RHS: C(n,j)·j!·(C(n-j,k-j)·(k-j)!·(n-k)!) = C(n,j)·j!·(n-j)! = n!. Then mul_right_cancel₀ finishes (positivity proves j!·(k-j)!·(n-k)! ≠ 0). Combinatorial meaning: 'choose k from n then j from those k' equals 'choose j from n then k-j from the remaining n-j'.",
+    "mathContext": "$\\binom{n}{k}\\binom{k}{j} = \\frac{n!}{k!(n-k)!} \\cdot \\frac{k!}{j!(k-j)!} = \\frac{n!}{j!(k-j)!(n-k)!} = \\binom{n}{j}\\binom{n-j}{k-j}$. Lean: multiply by $j!(k-j)!(n-k)!$ and reduce both sides to $n!$ using `Nat.choose_mul_factorial_mul_factorial`.",
+    "significance": "key",
+    "relatedConcepts": ["double counting", "Nat.choose_mul_factorial_mul_factorial", "mul_right_cancel₀", "positivity tactic"],
+    "prerequisites": ["Nat.choose_mul_factorial_mul_factorial", "mul_right_cancel₀", "positivity"]
+  },
+  {
+    "id": "ann-comb-oq01-bounds",
+    "proofId": "combinations-formula-oq-01",
+    "range": { "startLine": 116, "endLine": 158 },
+    "type": "insight",
+    "title": "Row Sums, Alternating Row Sum, and Binomial Bounds",
+    "content": "Parts IV-VI prove four results. choose_row_sum: Σ C(n,k) = 2ⁿ — a one-liner exact Nat.sum_range_choose n. choose_alternating_sum: Σ (-1)^k · C(n,k) = 0 for n≥1 via Int.alternating_sum_range_choose_of_ne. choose_le_pow2: C(n,k) ≤ 2ⁿ by Finset.single_le_sum (C(n,k) is a single term of the row sum) then row sum = 2ⁿ; the k > n case uses Nat.choose_eq_zero_of_lt. central_binom_le: C(2n,n) ≤ 4ⁿ by choose_le_pow2 and pow_mul identity: 2^{2n} = (2²)ⁿ = 4ⁿ.",
+    "mathContext": "$\\sum_{k=0}^n \\binom{n}{k} = 2^n$; $\\sum (-1)^k \\binom{n}{k} = 0$ for $n \\ge 1$; $\\binom{n}{k} \\le 2^n$; $\\binom{2n}{n} \\le 4^n$. The bounds follow from $\\binom{n}{k} \\le \\sum_{k} \\binom{n}{k} = 2^n$ and $4^n = 2^{2n}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.sum_range_choose", "Int.alternating_sum_range_choose_of_ne", "Finset.single_le_sum", "central_binom_le"],
+    "prerequisites": ["Nat.sum_range_choose", "Finset.single_le_sum", "Nat.choose_eq_zero_of_lt", "pow_mul"]
+  },
+  {
+    "id": "ann-comb-oq01-fibonacci",
+    "proofId": "combinations-formula-oq-01",
+    "range": { "startLine": 178, "endLine": 185 },
+    "type": "insight",
+    "title": "Fibonacci Diagonal Sums and Summary Theorem",
+    "content": "Part VII verifies Σ_j C(n-j,j) = F(n+1) for small n by native_decide: n=5 gives 1+4+3+0=8=F(6); n=6 gives 1+5+6+1=13=F(7). The general proof is an open question. Part VIII bundles all results into identities_summary: a conjunction of row sum, hockey stick, Vandermonde, and binomial bound, proved by ⟨Nat.sum_range_choose, hockey_stick, vandermonde, choose_le_pow2⟩. The Fibonacci connection is deep: Σ_j C(n-j,j) counts tilings of a 1×n strip with 1×1 squares and 1×2 dominoes. Term C(n-j,j) counts tilings using exactly j dominoes (and n-2j squares), since placing j non-overlapping dominoes in n positions is a stars-and-bars problem with n-j slots.",
+    "mathContext": "$\\sum_{j=0}^{\\lfloor n/2 \\rfloor} \\binom{n-j}{j} = F(n+1)$ where $F$ is the Fibonacci sequence. Bijection: tilings of $1 \\times n$ strip with $j$ dominoes have $\\binom{n-j}{j}$ choices (choosing positions for $j$ non-adjacent dominoes among $n-j$ effective slots). The general proof proceeds by induction using the Fibonacci recurrence $F(n+2) = F(n+1) + F(n)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Fibonacci numbers", "Pascal's triangle diagonals", "native_decide", "strip tiling bijection", "identities_summary"],
+    "prerequisites": ["hockey_stick", "vandermonde", "choose_le_pow2", "Nat.sum_range_choose"]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-01/meta.json
@@ -34,15 +34,17 @@
     ]
   },
   "overview": {
-    "historicalContext": "Binomial coefficients C(n,k) = n!/(k!(n-k)!) are fundamental in combinatorics, probability, and algebra. Beyond the basic identity C(n,k) = C(n-1,k-1) + C(n-1,k) (Pascal's rule), there are many deeper identities. Vandermonde's identity (A. Vandermonde, 1772) counts paths in a grid. The Hockey Stick identity appears in Pascal's triangle as a diagonal sum. These are standard combinatorics but their formal verification organizes the infrastructure for more advanced combinatorial proofs.",
+    "historicalContext": "Binomial coefficient identities have a rich history spanning centuries. Pascal's triangle (Yang Hui 1261, Blaise Pascal 1654) organizes C(n,k) and makes recursive identities visual. Vandermonde's convolution was proved by Alexandre-Théophile Vandermonde (1772) and corresponds to coefficient comparison in (1+x)^{m+n} = (1+x)^m·(1+x)^n. The Hockey Stick identity (also called the 'Christmas stocking' identity) was known to early Pascal's triangle analysts and follows by repeated application of Pascal's rule. The Fibonacci diagonal sum Σ_j C(n-j,j) = F(n+1) was noted by 19th-century combinatorialists via the tiling bijection: C(n-j,j) counts 1×n strip tilings with exactly j dominoes. The double-counting product identity appears in texts on algebraic combinatorics as the 'subset of a subset' identity. Formal verification of these identities in Lean/Mathlib provides a foundation for more complex combinatorial arguments, and demonstrates that Mathlib's Nat.choose library contains sufficient infrastructure to prove all six identities cleanly.",
     "problemStatement": "Formalize the key binomial coefficient identities: Vandermonde convolution, Hockey Stick, double-counting product, row sums, and bounds.",
     "text": "Vandermonde's identity C(m+n,r) = Σ C(m,k)·C(n,r-k) counts ways to choose r elements from a set split into parts of size m and n. The Hockey Stick identity Σᵢ C(i+r,r) = C(n+r+1,r+1) follows from Pascal's rule applied repeatedly along a diagonal. The product identity C(n,k)·C(k,j) = C(n,j)·C(n-j,k-j) counts the same set (choosing j and k-j from n) in two ways.",
     "proofStrategy": "Use Mathlib's Nat.choose.Sum for Vandermonde. Prove Hockey Stick by induction using Pascal's rule. Use factorial algebra for the product identity. Bound by row sum for 2^n, and specialize for central binomial. Verify Fibonacci diagonals by native_decide.",
     "keyInsights": [
-      "Vandermonde's identity is equivalent to the Cauchy product formula for (1+x)^m · (1+x)^n",
-      "Hockey Stick counts paths avoiding a boundary in Pascal's triangle",
-      "The Fibonacci diagonal sum Σ C(n-j,j) = F(n+1) connects combinatorics to number theory",
-      "All identities can be unified as special cases of the Zhu-Vandermonde identity in hypergeometric form"
+      "Vandermonde's identity is equivalent to the Cauchy product formula for (1+x)^m · (1+x)^n — a two-line Lean proof via Nat.add_choose_eq",
+      "Hockey Stick identity is proved by induction on n using Pascal's rule (Nat.choose_succ_succ) as the inductive step",
+      "The Fibonacci diagonal sum Σ C(n-j,j) = F(n+1) arises from a tiling bijection (only verified for small n by native_decide)",
+      "The product identity C(n,k)·C(k,j) = C(n,j)·C(n-j,k-j) requires 30 lines of factorial cancellation, despite being 'obvious' combinatorially",
+      "All bounds (C(n,k) ≤ 2ⁿ and C(2n,n) ≤ 4ⁿ) follow from the row sum identity via Finset.single_le_sum",
+      "Mathlib's Nat.choose library is rich enough to prove all six identities, with the main work being index arithmetic (handled by omega)"
     ],
     "prerequisites": [
       "Basic combinatorics: binomial coefficients, Pascal's rule, factorial",
@@ -50,12 +52,13 @@
     ]
   },
   "conclusion": {
-    "summary": "Key binomial coefficient identities formalized: Vandermonde, Hockey Stick, double-counting product, bounds, and Fibonacci diagonals. 8 theorems, 185 lines, 0 axioms.",
-    "implications": "Provides a verified combinatorics toolkit for higher-level proofs involving binomial sums, generating functions, and probabilistic arguments.",
+    "summary": "Six binomial coefficient identities fully verified: Vandermonde (2 lines), Hockey Stick (induction), double-counting product (30-line factorial algebra), row sum (1 line), binomial bound (via single_le_sum), and central binomial bound. Fibonacci diagonal sums verified by native_decide for small n. 8 theorems, 185 lines, 0 axioms.",
+    "implications": "This provides a verified combinatorics toolkit for higher-level proofs. The Vandermonde identity enables combinatorial proofs of hypergeometric identities. The Hockey Stick enables counting arguments in lattice path combinatorics. The product identity enables multinomial coefficient arguments. Together they cover the standard binomial coefficient toolkit for probabilistic and algebraic combinatorics.",
     "openQuestions": [
-      "Formal proof of Fibonacci diagonal sums (currently verified only by native_decide for small n)",
-      "Zhu-Vandermonde identity: generalization to hypergeometric series",
-      "q-binomial (Gaussian) analogues of these identities"
+      "Formal proof of Fibonacci diagonal sum Σ C(n-j,j) = F(n+1) by induction using F(n+2) = F(n+1) + F(n)",
+      "Zhu-Vandermonde identity: generalization to hypergeometric series _2F_1",
+      "q-binomial (Gaussian binomial) analogues: replace factorials by q-factorials",
+      "Prove the Lindström-Gessel-Viennot lemma as a matrix generalization of Vandermonde"
     ]
   },
   "leanFile": {
@@ -72,5 +75,36 @@
       "description": "Basic combinations formula C(n,k) = n!/(k!(n-k)!); this file adds Vandermonde, Hockey Stick, and other advanced identities"
     }
   ],
-  "sections": []
+  "sections": [
+    {
+      "title": "Part I: Vandermonde's Identity",
+      "startLine": 24,
+      "endLine": 40,
+      "summary": "vandermonde proves C(m+n,r) = Σ C(m,k)·C(n,r-k) in two lines: rw [Nat.add_choose_eq] then exact with Finset.Nat.sum_antidiagonal_eq_sum_range_succ. Verified by native_decide for C(8,4)=70 and the matching sum."
+    },
+    {
+      "title": "Part II: Hockey Stick Identity",
+      "startLine": 42,
+      "endLine": 65,
+      "summary": "hockey_stick proves Σ_{i=0}^{n} C(i+r,r) = C(n+r+1,r+1) by induction. Base: simp [Nat.choose_self]. Step: Finset.sum_range_succ + induction hypothesis + Nat.choose_succ_succ (Pascal's rule) + omega. Verified by native_decide for r=0,1,2."
+    },
+    {
+      "title": "Part III: Product/Double Counting Identity",
+      "startLine": 67,
+      "endLine": 109,
+      "summary": "choose_product proves C(n,k)·C(k,j) = C(n,j)·C(n-j,k-j) for j≤k≤n. Strategy: multiply by j!·(k-j)!·(n-k)! and show both sides equal n! using Nat.choose_mul_factorial_mul_factorial. Cancel with mul_right_cancel₀ (positivity shows denominator ≠ 0). 30 lines of ring arithmetic."
+    },
+    {
+      "title": "Parts IV-VI: Row Sums and Binomial Bounds",
+      "startLine": 111,
+      "endLine": 158,
+      "summary": "choose_row_sum: exact Nat.sum_range_choose n (1 line). choose_alternating_sum: exact Int.alternating_sum_range_choose_of_ne. choose_le_pow2: C(n,k) ≤ Σ C(n,i) = 2ⁿ via Finset.single_le_sum; k>n case by Nat.choose_eq_zero_of_lt. central_binom_le: C(2n,n) ≤ 2^{2n} = 4ⁿ via choose_le_pow2 + pow_mul."
+    },
+    {
+      "title": "Parts VII-VIII: Fibonacci Diagonals and Summary",
+      "startLine": 160,
+      "endLine": 185,
+      "summary": "Fibonacci diagonals Σ C(n-j,j) = F(n+1) verified by native_decide for n=5 (=8=F(6)) and n=6 (=13=F(7)). General proof is open. identities_summary bundles four identities as a conjunction: ⟨Nat.sum_range_choose, hockey_stick, vandermonde, choose_le_pow2⟩."
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Enriches `combinations-formula-oq-01` (Extended Binomial Coefficient Identities, 185 lines, 8 theorems).

- **6 new annotations** covering all parts: module overview, Vandermonde 2-line proof, Hockey Stick induction, 30-line product identity factorial argument, row sums + bounds, Fibonacci diagonals + summary
- **historicalContext** expanded: Yang Hui 1261, Pascal 1654, Vandermonde 1772, Fibonacci tiling bijection, Mathlib infrastructure sufficiency
- **keyInsights**: 4 → 6 (Vandermonde = Cauchy product, induction for Hockey Stick, native_decide for Fibonacci, omega for index arithmetic)
- **5 sections** covering the complete 185-line file
- **conclusion/openQuestions**: 3 → 4 (Fibonacci induction proof, Zhu-Vandermonde, q-binomial, LGV lemma)

🤖 Generated with [Claude Code](https://claude.com/claude-code)