### PR TITLE
Enrich Parseval's Identity: Fourier energy conservation

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-parseval-overview",
+    "proofId": "cauchy-schwarz-oq-02-oq-01",
+    "range": { "startLine": 7, "endLine": 45 },
+    "type": "context",
+    "title": "Parseval's Identity: Energy Conservation as Limit of Pythagorean Theorem",
+    "content": "The module docstring establishes the conceptual chain: CauchySchwarzOQ02 proves the Pythagorean theorem in L² (‖f+g‖² = ‖f‖² + ‖g‖² when ⟪f,g⟫=0). Fourier monomials eₙ(t) = e^{2πint/T} are orthonormal (⟪eₙ, eₘ⟫ = δₙₘ). Therefore finite partial sums satisfy ‖∑_{|k|≤N} ĉₖeₖ‖² = ∑_{|k|≤N}|ĉₖ|² (Pythagorean). As N→∞, the partial sums converge to f in L² (Fourier series L² convergence). By continuity of the norm, ‖Sₙ(f)‖² → ‖f‖². Combining: ∑|ĉₙ|² = ‖f‖². The file formalizes all 10 theorems needed for this chain: Parseval energy equality, HasSum form, summability, Bessel's inequality, orthonormality, orthogonality, norm 1, Pythagorean for finite sums, completeness (zero-kernel), and L² convergence.",
+    "mathContext": "Conceptual chain: $\\|f\\|^2 = \\lim_{N\\to\\infty}\\|S_N f\\|^2 = \\lim_{N\\to\\infty} \\sum_{|k|\\le N} |\\hat{c}_k|^2 = \\sum' k, |\\hat{c}_k|^2$. First equality: L² convergence. Second: Pythagorean for finite sums. Third: convergence of the sum. The chain shows Parseval as an infinite-dimensional Pythagoras.",
+    "significance": "context",
+    "relatedConcepts": ["L² convergence", "Pythagorean theorem", "Fourier monomials", "energy conservation", "Plancherel theorem"],
+    "prerequisites": ["CauchySchwarzOQ02 (pythagorean_L2)", "Fourier series L² theory", "Hilbert space completeness"]
+  },
+  {
+    "id": "ann-parseval-energy",
+    "proofId": "cauchy-schwarz-oq-02-oq-01",
+    "range": { "startLine": 66, "endLine": 95 },
+    "type": "insight",
+    "title": "Parseval, Bessel, and Summability: Three Facets of One Identity",
+    "content": "Parts I contains four theorems about Parseval's energy equality. parseval_energy wraps Mathlib's tsum_sq_fourierCoeff: ∑' n, ‖ĉₙ(f)‖² = ∫|f|² dμ. parseval_hassum wraps hasSum_sq_fourierCoeff: the HasSum form is stronger (it gives the series, not just its sum). fourier_coeff_sq_summable follows immediately from parseval_hassum.summable. bessel_fourier proves finite partial sums ≤ L² norm by sum_le_hasSum: a partial sum of a non-negative HasSum is bounded by the total. All four are one-liners delegating to Mathlib. The key type: f : Lp ℂ 2 (haarAddCircle), which is L²(T→ℂ) with Haar measure on the circle AddCircle T.",
+    "mathContext": "Parseval: $\\sum_{n\\in\\mathbb{Z}} |\\hat{c}_n(f)|^2 = \\int |f|^2 d\\mu$. Bessel: $\\sum_{n\\in S} |\\hat{c}_n|^2 \\le \\|f\\|^2_{L^2}$ for any finite $S$. Types: `Lp ℂ 2 (haarAddCircle (T := T))`, `fourierCoeff : (AddCircle T → ℂ) → ℤ → ℂ`.",
+    "significance": "key",
+    "relatedConcepts": ["parseval_energy", "parseval_hassum", "bessel_fourier", "tsum_sq_fourierCoeff", "sum_le_hasSum"],
+    "prerequisites": ["tsum_sq_fourierCoeff", "hasSum_sq_fourierCoeff", "HasSum.summable", "sum_le_hasSum"]
+  },
+  {
+    "id": "ann-parseval-orthonormal",
+    "proofId": "cauchy-schwarz-oq-02-oq-01",
+    "range": { "startLine": 105, "endLine": 118 },
+    "type": "insight",
+    "title": "Fourier Orthonormality: Three One-Liners from Mathlib",
+    "content": "Part II proves orthonormality of the Fourier system in three one-liner theorems. fourier_orthonormal: exact orthonormal_fourier — Mathlib provides this directly for the Fourier system on AddCircle T. fourier_modes_orthogonal: uses fourier_orthonormal.2 hnm — the second component of Orthonormal is the orthogonality for distinct elements. fourier_modes_norm_one: uses fourier_orthonormal.1 n — the first component is that each element has norm 1. The Orthonormal structure bundles both: Orthonormal 𝕜 v ↔ (∀ i, ‖v i‖ = 1) ∧ (∀ i j, i ≠ j → ⟪v i, v j⟫ = 0). These three theorems expose the Orthonormal structure as separate accessible facts for downstream proofs.",
+    "mathContext": "`Orthonormal ℂ (fourierLp (T := T) 2)` means: $\\|e_n\\|_{L^2} = 1$ and $\\langle e_n, e_m \\rangle = 0$ for $n \\ne m$. Where $e_n(t) = e^{2\\pi i n t / T}$ and inner product $\\langle f, g \\rangle = \\int \\bar{f} g \\, d\\mu$. Verification: $\\langle e_n, e_m \\rangle = \\int e^{2\\pi i(m-n)t/T} dt = \\delta_{nm}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["orthonormal_fourier", "Orthonormal", "fourierLp", "Kronecker delta", "haarAddCircle"],
+    "prerequisites": ["orthonormal_fourier (Mathlib)", "Orthonormal.1 (norm 1)", "Orthonormal.2 (orthogonality)"]
+  },
+  {
+    "id": "ann-parseval-pythagorean",
+    "proofId": "cauchy-schwarz-oq-02-oq-01",
+    "range": { "startLine": 143, "endLine": 176 },
+    "type": "insight",
+    "title": "Fourier Pythagorean Theorem: The One Original Proof in the File",
+    "content": "fourier_pythagorean_partial is the sole original contribution: ‖∑_{n∈S} cₙeₙ‖² = ∑|cₙ|² for any finite S ⊆ ℤ. The proof has three steps. Step 1: establish Kronecker delta — ⟪eₙ, eₘ⟫ = if n=m then 1 else 0 by case-splitting on n=m. Step 2: expand ⟪∑cᵢeᵢ, ∑cⱼeⱼ⟫ using inner product linearity (sum_inner, inner_sum, inner_smul_left, inner_smul_right), apply the Kronecker delta, and reduce via Finset.sum_ite_eq and mul_conj to ↑(∑|cₙ|²). Step 3: relate ‖v‖² = Re(⟪v,v⟫) via inner_self_eq_norm_sq_to_K, extract real part with congr_arg Complex.re, finish with norm_cast. The proof carefully handles the type coercion from ℝ to ℂ (via ↑(∑|cₙ|²)).",
+    "mathContext": "$\\|\\sum_{n\\in S} c_n e_n\\|^2 = \\langle \\sum c_i e_i, \\sum c_j e_j \\rangle = \\sum_i \\sum_j c_i \\overline{c_j} \\langle e_i, e_j \\rangle = \\sum_i c_i \\overline{c_i} = \\sum_i |c_i|^2$. Step 2 uses `inner_smul_left`/`inner_smul_right` to extract scalars, `hd` for Kronecker delta, `Finset.sum_ite_eq` to collapse the double sum, `Complex.mul_conj` for $c \\cdot \\bar{c} = |c|^2$.",
+    "significance": "key",
+    "relatedConcepts": ["fourier_pythagorean_partial", "inner_self_eq_norm_sq_to_K", "Finset.sum_ite_eq", "inner_smul_left", "Complex.mul_conj"],
+    "prerequisites": ["sum_inner", "inner_smul_left/right", "Finset.sum_ite_eq", "inner_self_eq_norm_sq_to_K", "Complex.normSq_eq_norm_sq"]
+  },
+  {
+    "id": "ann-parseval-completeness",
+    "proofId": "cauchy-schwarz-oq-02-oq-01",
+    "range": { "startLine": 189, "endLine": 217 },
+    "type": "insight",
+    "title": "Completeness and L² Convergence: The Two Corollaries",
+    "content": "Parts IV-V prove two corollaries. parseval_implies_completeness shows the Fourier system is complete (zero-kernel): if all Fourier coefficients vanish, f = 0. Proof: use hasSum_fourier_series_L2 to get HasSum (fun n => ĉₙeₙ) f. Substitute hf_zero (all ĉₙ = 0), so HasSum (fun _ => 0) f. By HasSum uniqueness (hL2.unique hasSum_zero), f = 0. fourier_series_L2_convergence is a one-liner wrapping hasSum_fourier_series_L2: the Fourier series ∑ ĉₙeₙ converges in L² to f. Together these prove the Fourier system {eₙ} is a Hilbert basis (orthonormal + complete) for L²(AddCircle T).",
+    "mathContext": "Completeness: $\\forall n, \\hat{c}_n(f) = 0 \\Rightarrow f = 0$. L² convergence: $f = \\sum_{n\\in\\mathbb{Z}} \\hat{c}_n(f) \\cdot e_n$ (convergence in $L^2$). Together: $\\{e_n\\}$ is a Hilbert basis. `HasSum.unique` gives uniqueness of sums in Hausdorff spaces.",
+    "significance": "key",
+    "relatedConcepts": ["parseval_implies_completeness", "fourier_series_L2_convergence", "hasSum_fourier_series_L2", "HasSum.unique", "Hilbert basis completeness"],
+    "prerequisites": ["hasSum_fourier_series_L2", "HasSum.unique", "hasSum_zero"]
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "cauchy-schwarz-oq-02-oq-01",
   "title": "Parseval's Identity: Energy Conservation in Fourier Analysis",
   "slug": "cauchy-schwarz-oq-02-oq-01",
-  "description": "Formalizes Parseval's identity \u2014 \u2211|\u0109\u2099(f)|\u00b2 = \u222b|f|\u00b2d\u03bc \u2014 as a consequence of the L\u00b2 structure from CauchySchwarzOQ02. Proves: Parseval energy equality (tsum = integral), Bessel-Parseval tightness (Bessel's inequality is equality in total), Fourier orthonormality, Pythagorean theorem for finite Fourier sums, L\u00b2 convergence of Fourier series, and completeness (zero-kernel). 10 theorems, 0 sorries.",
+  "description": "Formalizes Parseval's identity — ∑|ĉₙ(f)|² = ∫|f|²dμ — as a consequence of the L² structure from CauchySchwarzOQ02. Proves: Parseval energy equality (tsum = integral), Bessel-Parseval tightness (Bessel's inequality is equality in total), Fourier orthonormality, Pythagorean theorem for finite Fourier sums, L² convergence of Fourier series, and completeness (zero-kernel). 10 theorems, 0 sorries.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-03",
@@ -25,32 +25,36 @@
     "theoremCount": 10,
     "definitionCount": 0,
     "originalContributions": [
-      "fourier_pythagorean_partial: \u2016\u2211_{n\u2208S} c\u2099e\u2099\u2016\u00b2 = \u2211_{n\u2208S} |c\u2099|\u00b2 (Pythagorean for ONS \u2014 original proof expanding inner products with Kronecker delta)"
+      "fourier_pythagorean_partial: ‖∑_{n∈S} cₙeₙ‖² = ∑_{n∈S} |cₙ|² (Pythagorean for ONS — original proof expanding inner products with Kronecker delta)"
     ]
   },
   "overview": {
-    "historicalContext": "Parseval (1799) discovered the energy equality for Fourier series; Plancherel (1910) extended it to L\u00b2 functions. The identity \u2211|\u0109\u2099|\u00b2 = \u2016f\u2016\u00b2 is foundational to Fourier analysis, signal processing, and quantum mechanics. It expresses conservation of energy: total power in the frequency domain equals total power in the time domain.",
-    "problemStatement": "Formalize Parseval's identity \u2211_{n\u2208\u2124} |\u0109\u2099(f)|\u00b2 = \u2016f\u2016\u00b2_{L\u00b2} for Fourier coefficients on the circle, as a follow-up to the H\u00f6lder/L\u00b2 theory in CauchySchwarzOQ02.",
-    "text": "Parseval's identity connects the L\u00b2 norm to the Fourier coefficients: \u2211' n : \u2124, \u2016\u0109\u2099(f)\u2016\u00b2 = \u222b |f|\u00b2 d\u03bc for f \u2208 L\u00b2(AddCircle T). This is the limiting form of the Pythagorean theorem: since the Fourier monomials are orthonormal (\u27eae\u2099, e\u2098\u27eb = \u03b4\u2099\u2098), finite partial sums satisfy \u2016\u2211_{n\u2208S} \u0109\u2099e\u2099\u2016\u00b2 = \u2211_{n\u2208S} |\u0109\u2099|\u00b2 (Pythagorean). As the partial sums converge in L\u00b2 to f (completeness of the Fourier system), the left side approaches \u2016f\u2016\u00b2, yielding Parseval.",
-    "proofStrategy": "Apply Mathlib's hasSum_sq_fourierCoeff for Parseval, orthonormal_fourier for orthonormality, and hasSum_fourier_series_L2 for L\u00b2 convergence. The Pythagorean theorem for finite sums requires careful manipulation of inner products with orthonormal systems.",
+    "historicalContext": "Marc-Antoine Parseval des Chênes (1799) stated the identity ∑|ĉₙ|² = ‖f‖² for trigonometric series, motivated by questions about convergence. His proof was non-rigorous; the first rigorous treatment for continuous functions came from Fatou (1906). Michel Plancherel (1910) extended it to L²(ℝ) — showing the Fourier transform is an L² isometry. Bessel's inequality (Friedrich Bessel, 1828) is the finite approximation: ∑_{n∈S}|ĉₙ|² ≤ ‖f‖², with equality in total (Parseval) characterizing completeness of the orthonormal system. In quantum mechanics, Parseval is the normalization condition: total probability ‖ψ‖² = ∑|⟨n|ψ⟩|² is preserved by any orthonormal basis expansion. The conceptual chain formalized here: Pythagorean theorem in L² (CauchySchwarzOQ02) → orthonormality of Fourier monomials → finite Pythagorean sums → L² convergence → Parseval as limit.",
+    "problemStatement": "Formalize Parseval's identity ∑_{n∈ℤ} |ĉₙ(f)|² = ‖f‖²_{L²} for Fourier coefficients on the circle, as a follow-up to the Hölder/L² theory in CauchySchwarzOQ02.",
+    "text": "Parseval's identity connects the L² norm to the Fourier coefficients: ∑' n : ℤ, ‖ĉₙ(f)‖² = ∫ |f|² dμ for f ∈ L²(AddCircle T). This is the limiting form of the Pythagorean theorem: since the Fourier monomials are orthonormal (⟪eₙ, eₘ⟫ = δₙₘ), finite partial sums satisfy ‖∑_{n∈S} ĉₙeₙ‖² = ∑_{n∈S} |ĉₙ|² (Pythagorean). As the partial sums converge in L² to f (completeness of the Fourier system), the left side approaches ‖f‖², yielding Parseval.",
+    "proofStrategy": "Apply Mathlib's hasSum_sq_fourierCoeff for Parseval, orthonormal_fourier for orthonormality, and hasSum_fourier_series_L2 for L² convergence. The Pythagorean theorem for finite sums requires careful manipulation of inner products with orthonormal systems.",
     "keyInsights": [
-      "Parseval = limit of Pythagorean: Bessel's inequality \u2211_{n\u2208S}|\u0109\u2099|\u00b2 \u2264 \u2016f\u2016\u00b2 becomes equality in total",
-      "Completeness of Fourier system: zero-kernel property (all \u0109\u2099 = 0 \u27f9 f = 0)",
-      "L\u00b2 convergence gives Parseval via norm continuity: \u2016S\u2099(f)\u2016\u00b2 \u2192 \u2016f\u2016\u00b2",
-      "Connection to CauchySchwarzOQ02: the Pythagorean theorem applied to orthogonal Fourier modes"
+      "Parseval = limit of Pythagorean: Bessel's inequality ∑_{n∈S}|ĉₙ|² ≤ ‖f‖² becomes equality in total",
+      "Completeness of Fourier system: zero-kernel property (all ĉₙ = 0 ⟹ f = 0) follows from L² convergence",
+      "L² convergence gives Parseval via norm continuity: ‖Sₙ(f)‖² → ‖f‖²",
+      "Connection to CauchySchwarzOQ02: the Pythagorean theorem applied to orthogonal Fourier modes",
+      "fourier_pythagorean_partial is the only original proof: 30 lines expanding inner products using Kronecker delta and Finset.sum_ite_eq",
+      "9 of 10 theorems are Mathlib wrappers — the value is in organizing the API and exposing the conceptual chain"
     ],
     "prerequisites": [
       "Fourier analysis: Fourier coefficients, Fourier monomials, AddCircle",
-      "L\u00b2 spaces: Lp \u2102 2, haarAddCircle measure",
+      "L² spaces: Lp ℂ 2, haarAddCircle measure",
       "Inner product spaces: orthonormality, Hilbert basis"
     ]
   },
   "conclusion": {
-    "summary": "Parseval's identity fully verified: \u2211|\u0109\u2099(f)|\u00b2 = \u222b|f|\u00b2d\u03bc. 10 theorems including Parseval energy equality, Bessel tightness, Fourier orthonormality, Pythagorean theorem for finite Fourier sums, L\u00b2 convergence, and completeness. 0 sorries.",
-    "implications": "Parseval is foundational for Fourier analysis: it enables L\u00b2 theory of Fourier series, underlies Plancherel's theorem for the Fourier transform, and is essential for quantum mechanics (Hilbert space formulation). The connection to Pythagorean theorem shows Parseval as an infinite-dimensional Pythagoras.",
+    "summary": "Parseval's identity fully verified: ∑|ĉₙ(f)|² = ∫|f|²dμ. 10 theorems including Parseval energy equality, Bessel tightness, Fourier orthonormality, Pythagorean theorem for finite Fourier sums, L² convergence, and completeness. Badge: mathlib (9 of 10 wrap Mathlib; 1 original). 0 sorries.",
+    "implications": "Parseval is foundational for Fourier analysis: it enables L² theory of Fourier series, underlies Plancherel's theorem for the Fourier transform, and is essential for quantum mechanics (Hilbert space formulation). The completeness theorem (zero-kernel) is the key uniqueness result for Fourier series. The connection to Pythagorean theorem shows Parseval as an infinite-dimensional Pythagoras in L².",
     "openQuestions": [
-      "Prove the inner product Parseval: \u27eaf,g\u27eb = \u2211 \u0109\u2099(f)\u00b7conj(\u0109\u2099(g)) (Parseval-Plancherel)",
-      "Extend to general Hilbert bases: abstract Parseval for any orthonormal basis"
+      "Prove the inner product Parseval: ⟪f,g⟫ = ∑ ĉₙ(f)·conj(ĉₙ(g)) (Parseval-Plancherel polarization)",
+      "Extend to general Hilbert bases: abstract Parseval for any orthonormal basis in any Hilbert space",
+      "Formalize the Plancherel theorem for the Fourier transform on L²(ℝ): ‖f̂‖ = ‖f‖",
+      "Apply Parseval to the proof of the Riesz-Fischer theorem: L² is complete (Cauchy sequences converge)"
     ]
   },
   "leanFile": {
@@ -65,7 +69,7 @@
     {
       "targetId": "cauchy-schwarz-oq-02",
       "relationship": "extends",
-      "description": "CauchySchwarzOQ02 proves Pythagorean theorem in L\u00b2; OQ-01 applies it to Fourier modes to get Parseval"
+      "description": "CauchySchwarzOQ02 proves Pythagorean theorem in L²; OQ-01 applies it to Fourier modes to get Parseval"
     },
     {
       "targetId": "fourier-series",
@@ -73,5 +77,30 @@
       "description": "Uses Fourier series machinery (orthonormal_fourier, hasSum_fourier_series_L2) from FourierSeries.lean"
     }
   ],
-  "sections": []
+  "sections": [
+    {
+      "title": "Part I: Parseval's Identity (Energy Equality)",
+      "startLine": 53,
+      "endLine": 95,
+      "summary": "parseval_energy (tsum_sq_fourierCoeff wrapper), parseval_hassum (hasSum_sq_fourierCoeff wrapper), fourier_coeff_sq_summable (summability from HasSum), bessel_fourier (partial sums ≤ L² norm via sum_le_hasSum). All four are one-liners wrapping Mathlib."
+    },
+    {
+      "title": "Part II: Fourier Orthonormality",
+      "startLine": 97,
+      "endLine": 119,
+      "summary": "fourier_orthonormal (exact orthonormal_fourier), fourier_modes_orthogonal (Orthonormal.2 hnm for distinct modes), fourier_modes_norm_one (Orthonormal.1 n for unit norm). Three one-liners exposing the Orthonormal structure components."
+    },
+    {
+      "title": "Part III: Pythagorean Theorem for Finite Fourier Sums",
+      "startLine": 121,
+      "endLine": 176,
+      "summary": "fourier_pythagorean_partial (original, 30-line proof): ‖∑_{n∈S} cₙeₙ‖² = ∑|cₙ|². Step 1: Kronecker delta via case split. Step 2: expand inner product with sum_inner/inner_smul_left/right, apply delta, collapse with sum_ite_eq, reduce mul_conj. Step 3: inner_self_eq_norm_sq_to_K + congr_arg Complex.re + norm_cast."
+    },
+    {
+      "title": "Parts IV-V: Completeness and L² Convergence",
+      "startLine": 178,
+      "endLine": 223,
+      "summary": "parseval_implies_completeness: all ĉₙ = 0 → f = 0, via hasSum_fourier_series_L2 + hf_zero substitution + HasSum.unique with hasSum_zero. fourier_series_L2_convergence: exact hasSum_fourier_series_L2 (one-liner). Together: Fourier system is a Hilbert basis."
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Enriches `cauchy-schwarz-oq-02-oq-01` (Parseval's Identity, 223 lines, 10 theorems).

- **5 new annotations** (annotations.json created from scratch): conceptual chain overview, Parseval/Bessel Mathlib wrappers, orthonormality three-liner, original Pythagorean proof (Kronecker delta + inner product expansion), completeness + L² convergence
- **historicalContext** expanded: Parseval 1799, Fatou 1906, Plancherel 1910, Bessel 1828, quantum mechanics normalization interpretation
- **keyInsights**: 4 → 6 (add original-vs-wrapper breakdown, Finset.sum_ite_eq technique)
- **4 sections** covering all 223 lines
- **conclusion/openQuestions**: 2 → 4 (inner product Parseval/polarization, abstract Hilbert basis, Plancherel for ℝ, Riesz-Fischer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)