### PR TITLE
Fix: add Aristotle companion for lhopital-oq-02 (3 routine L'Hôpital variants)

### DIFF
--- a/proofs/Proofs/LHopitalOQ02Aristotle.lean
+++ b/proofs/Proofs/LHopitalOQ02Aristotle.lean
@@ -1,0 +1,77 @@
+/-
+  Aristotle targets for L'Hôpital OQ-02 (∞/∞ form)
+  Routine variants of lhopital_infty_right for automated proof search.
+  See LHopitalOQ02.lean for the main formalization.
+
+  Criteria for inclusion:
+  - lhopital_infty_left: left-approach variant, follows by reflection u = a + b - x
+  - lhopital_infty_atTop: atTop variant, follows by substitution
+  - lhopital_infty_atBot: atBot variant, follows by negation u = -x
+  - NOT lhopital_infty_right_zero (key lemma — already proved in main file)
+  - NOT any example applications (depend on specific functions)
+-/
+import Mathlib
+
+namespace LHopitalOQ02Aristotle
+
+open Set Filter Topology Real
+
+/-
+The main right-approach theorem (already proved in LHopitalOQ02.lean):
+If g(x) → ∞ as x → a⁺ on (a,b), and f'/g' → c, then f/g → c.
+
+The three sorries below are standard variants of this result.
+-/
+
+/-- **∞/∞ L'Hôpital — Left Approach**
+
+For g → ∞ as x → b⁻ on (a,b), if f'/g' → c, then f/g → c.
+
+Reduction to right approach: substitute u = a + b - x, which maps
+- x ∈ Ioo a b ↔ u ∈ Ioo a b
+- x → b⁻ corresponds to u → a⁺
+- HasDerivAt f (f' x) x implies HasDerivAt (f ∘ (a + b - ·)) (-f' (a+b-u)) u
+-/
+theorem lhopital_infty_left {f g f' g' : ℝ → ℝ} {a b c : ℝ}
+    (hab : a < b)
+    (hff' : ∀ x ∈ Ioo a b, HasDerivAt f (f' x) x)
+    (hgg' : ∀ x ∈ Ioo a b, HasDerivAt g (g' x) x)
+    (hg' : ∀ x ∈ Ioo a b, g' x ≠ 0)
+    (hgb : Tendsto g (𝓝[<] b) atTop)
+    (hdiv : Tendsto (fun x => f' x / g' x) (𝓝[<] b) (𝓝 c)) :
+    Tendsto (fun x => f x / g x) (𝓝[<] b) (𝓝 c) := by
+  sorry
+
+/-- **∞/∞ L'Hôpital — At +∞**
+
+For g → ∞ as x → +∞, if f'/g' → c, then f/g → c.
+
+Reduction to right approach: use the compactification substitution or
+apply the result on (a, ∞) treated as nhdsWithin Ioi a.
+-/
+theorem lhopital_infty_atTop {f g f' g' : ℝ → ℝ} {a c : ℝ}
+    (hff' : ∀ x ∈ Ioi a, HasDerivAt f (f' x) x)
+    (hgg' : ∀ x ∈ Ioi a, HasDerivAt g (g' x) x)
+    (hg' : ∀ x ∈ Ioi a, g' x ≠ 0)
+    (hgTop : Tendsto g atTop atTop)
+    (hdiv : Tendsto (fun x => f' x / g' x) atTop (𝓝 c)) :
+    Tendsto (fun x => f x / g x) atTop (𝓝 c) := by
+  sorry
+
+/-- **∞/∞ L'Hôpital — At -∞**
+
+For g → ∞ as x → -∞, if f'/g' → c, then f/g → c.
+
+Reduction to atTop: substitute u = -x, so f(-u) and g(-u) satisfy
+the atTop conditions with reversed derivatives.
+-/
+theorem lhopital_infty_atBot {f g f' g' : ℝ → ℝ} {a c : ℝ}
+    (hff' : ∀ x ∈ Iio a, HasDerivAt f (f' x) x)
+    (hgg' : ∀ x ∈ Iio a, HasDerivAt g (g' x) x)
+    (hg' : ∀ x ∈ Iio a, g' x ≠ 0)
+    (hgBot : Tendsto g atBot atTop)
+    (hdiv : Tendsto (fun x => f' x / g' x) atBot (𝓝 c)) :
+    Tendsto (fun x => f x / g x) atBot (𝓝 c) := by
+  sorry
+
+end LHopitalOQ02Aristotle


### PR DESCRIPTION
## Summary

- Adds `LHopitalOQ02Aristotle.lean` with 3 routine ∞/∞ L'Hôpital variants for Aristotle proof search
- All three follow from the `lhopital_infty_right` theorem (already proved in `LHopitalOQ02.lean`) via standard variable substitutions:
  - `lhopital_infty_left`: left-approach via reflection `u = a + b - x`
  - `lhopital_infty_atTop`: atTop variant via compactification
  - `lhopital_infty_atBot`: atBot variant via negation `u = -x`
- No definition sorries, no axioms

## Test plan
- [ ] File compiles with `import Mathlib` (modulo sorries)
- [ ] All 3 theorems are well-formed Lean 4
- [ ] Aristotle agent will pick this up for proof search

🤖 Generated with [Claude Code](https://claude.com/claude-code)