### PR TITLE
Enrich cayley-hamilton-minpoly-oq-01: annotations, sections, historicalContext

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-01/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-01/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-jcf-minpoly-overview",
+    "proofId": "cayley-hamilton-minpoly-oq-01",
+    "range": { "startLine": 1, "endLine": 34 },
+    "type": "context",
+    "title": "Jordan-Minpoly: From Blocks to Polynomials",
+    "content": "The module docstring establishes the central relationship: for f : Module.End K V over an algebraically closed field, the minimal polynomial encodes the entire Jordan block structure via minpoly K f = ∏_{μ eigenvalue} (X - μ)^{e_μ}, where e_μ = maxGenEigenspaceIndex f μ is the size of the LARGEST Jordan block associated to μ. The file proceeds in six parts: (I) eigenvalue ↔ root of minpoly, plus minpoly | charpoly; (II) generalized eigenspace structure (span = top over alg. closed, disjointness, stabilization); (III) nilpotent characterization: IsNilpotent f ↔ ∃ k, minpoly = X^k, proved via a UFD argument; (IV) semisimple characterization: IsSemisimple f ↔ Squarefree (minpoly); (V) three JCF axioms for results requiring full Jordan block matrix theory (not yet in Mathlib 4.26.0); (VI) corollaries. The distinction between proved and axiomatized results reflects the gap between Mathlib's triangularizability/Jordan-Chevalley theory (complete) and its Jordan Normal Form as an explicit block-matrix decomposition (not yet formalized).",
+    "mathContext": "The Jordan canonical form theorem (Jordan, 1870) says every endomorphism over $\\overline{K}$ is similar to a block-diagonal matrix with Jordan blocks $J_{\\mu,k}$ (eigenvalue $\\mu$ on diagonal, 1s on superdiagonal). The minimal polynomial extracts the coarsest information: $e_\\mu = $ size of the largest Jordan block for $\\mu$. In contrast, charpoly records all block sizes: $\\mathrm{charpoly}(f) = \\prod_\\mu (X-\\mu)^{d_\\mu}$ where $d_\\mu = \\dim(\\mathrm{genEigenspace}\\ \\mu)$ is the total algebraic multiplicity.",
+    "significance": "context",
+    "relatedConcepts": ["Jordan canonical form", "minimal polynomial", "maxGenEigenspaceIndex", "generalized eigenspace", "semisimple", "nilpotent"],
+    "prerequisites": ["Module.End", "minpoly K f", "genEigenspace", "IsAlgClosed", "FiniteDimensional"]
+  },
+  {
+    "id": "ann-jcf-minpoly-eigenvalue-bridge",
+    "proofId": "cayley-hamilton-minpoly-oq-01",
+    "range": { "startLine": 57, "endLine": 91 },
+    "type": "insight",
+    "title": "Eigenvalues as Roots: The Polynomial-Linear Algebra Bridge",
+    "content": "Part I establishes the fundamental bridge between linear and polynomial algebra. eigenvalue_iff_root_minpoly directly wraps Mathlib's hasEigenvalue_iff_isRoot: f.HasEigenvalue μ ↔ (minpoly K f).IsRoot μ. eigenvalue_linear_factor_dvd_minpoly immediately strengthens this via dvd_iff_isRoot: if μ is an eigenvalue then (X - C μ) divides minpoly K f. minpoly_dvd_charpoly wraps Matrix.minpoly_dvd_charpoly: minpoly K A ∣ A.charpoly — so every root of minpoly is a root of charpoly. The two foundational properties minpoly_annihilates (aeval f (minpoly K f) = 0) and minpoly_monic (minpoly K f).Monic are included. The annihilation property is what makes polynomial methods useful: we can substitute the endomorphism f for X in polynomial identities. A technical note in lines 87-91 explains why the degree bound natDegree (minpoly K f) ≤ finrank K V is not proved here: computing finrank K (End K V) triggers a deterministic whnf timeout in Lean 4.26.0.",
+    "mathContext": "The chain of implications: $f.\\mathrm{HasEigenvalue}\\ \\mu \\Leftrightarrow (\\mathrm{minpoly}_K f).\\mathrm{IsRoot}\\ \\mu \\Leftrightarrow (X - \\mu) \\mid \\mathrm{minpoly}_K f$. Combined with minpoly $\\mid$ charpoly: the eigenvalues of $f$ are exactly the roots of $\\mathrm{minpoly}_K f$, a subset of the roots of charpoly. Over an algebraically closed field they coincide (every root of charpoly is an eigenvalue).",
+    "significance": "key",
+    "relatedConcepts": ["HasEigenvalue", "Polynomial.IsRoot", "dvd_iff_isRoot", "hasEigenvalue_iff_isRoot", "minpoly_dvd_charpoly"],
+    "prerequisites": ["minpoly.aeval", "FiniteDimensional K V", "Polynomial.aeval"]
+  },
+  {
+    "id": "ann-jcf-minpoly-nilpotent",
+    "proofId": "cayley-hamilton-minpoly-oq-01",
+    "range": { "startLine": 131, "endLine": 194 },
+    "type": "insight",
+    "title": "Nilpotent Characterization: minpoly = X^k via UFD",
+    "content": "Part III gives the nilpotent-minpoly equivalence using a UFD argument. The key theorem minpoly_pow_X_of_nilpotent proves: IsNilpotent f → ∃ j, minpoly K f = X^j. Given f^n = 0, minpoly_dvd_pow_of_nilpotent uses minpoly.dvd to get minpoly K f ∣ X^n (since aeval f (X^n) = f^n = 0). Then, since X is prime in K[X] (dvd_prime_pow hX_prime), any divisor of X^n is associated to X^j for some j ≤ n. Both minpoly K f and X^j are monic; in an integral domain, associated monic polynomials are equal (Monic.eq_one_of_isUnit). The converse nilpotent_of_minpoly_pow_X: if minpoly = X^k, then aeval f (X^k) = f^k = 0 (direct from annihilation). eigenvalue_zero_of_nilpotent provides a complementary proof: eigenvalue μ of nilpotent f satisfies μ^k•v = f^k(v) = 0 with v ≠ 0 (eigenvector), so μ^k = 0 in K, and since K is a field μ = 0. This gives a concrete witnesses that nilpotent ↔ all eigenvalues are 0 ↔ minpoly is a pure power of X.",
+    "mathContext": "The UFD structure of $K[X]$: $X$ is irreducible (and hence prime since $K[X]$ is a PID), so $\\mathrm{minpoly} \\mid X^n$ implies $\\mathrm{minpoly} \\sim X^j$ (associated). Since both are monic and $K[X]^\\times = K^\\times$, the unit in the association must be 1. This is the polynomial analogue of: a natural number dividing a prime power $p^n$ must itself be a prime power $p^j$.",
+    "significance": "key",
+    "relatedConcepts": ["IsNilpotent", "Polynomial.prime_X", "dvd_prime_pow", "Monic.eq_one_of_isUnit", "minpoly.dvd"],
+    "prerequisites": ["UFD K[X]", "Polynomial.dvd_iff_isRoot", "IsNilpotent.eq_zero", "smul_eq_zero"]
+  },
+  {
+    "id": "ann-jcf-minpoly-semisimple",
+    "proofId": "cayley-hamilton-minpoly-oq-01",
+    "range": { "startLine": 206, "endLine": 216 },
+    "type": "insight",
+    "title": "Semisimple ↔ Squarefree Minpoly: Diagonalizability in Polynomial Form",
+    "content": "Part IV establishes the central diagonalizability criterion. isSemisimple_iff_squarefree_minpoly proves f.IsSemisimple ↔ Squarefree (minpoly K f). The forward direction wraps IsSemisimple.minpoly_squarefree from Mathlib's semisimple theory. The backward direction uses isSemisimple_of_squarefree_aeval_eq_zero: if p is squarefree and aeval f p = 0, then f is semisimple. semisimple_nilpotent_eq_zero proves the foundational uniqueness lemma: an endomorphism that is both semisimple and nilpotent must be zero (eq_zero_of_isNilpotent_isSemisimple). This is the key lemma in the Jordan-Chevalley uniqueness argument — if f = s + n = s' + n' are two decompositions with s,s' semisimple and n,n' nilpotent commuting, then s-s' = n'-n is both semisimple and nilpotent, hence zero. From a polynomial perspective: semisimple ↔ all Jordan blocks are 1×1 ↔ e_μ = 1 for all μ ↔ minpoly has distinct roots ↔ squarefree.",
+    "mathContext": "Squarefree means: no repeated irreducible factor. For $\\mathrm{minpoly}_K(f) = \\prod_\\mu (X-\\mu)^{e_\\mu}$, squarefree means $e_\\mu \\leq 1$ for all $\\mu$. This is precisely the condition for all Jordan blocks to be $1 \\times 1$ (diagonal blocks), i.e., $f$ is diagonalizable. Over non-algebraically-closed $K$, semisimple is the correct generalization: the minimal polynomial factors into distinct irreducible polynomials (not necessarily linear).",
+    "significance": "key",
+    "relatedConcepts": ["IsSemisimple", "Squarefree", "isSemisimple_of_squarefree_aeval_eq_zero", "Jordan-Chevalley decomposition", "eq_zero_of_isNilpotent_isSemisimple"],
+    "prerequisites": ["Module.IsSemisimple", "Polynomial.Squarefree", "IsSemisimple.minpoly_squarefree"]
+  },
+  {
+    "id": "ann-jcf-minpoly-axioms",
+    "proofId": "cayley-hamilton-minpoly-oq-01",
+    "range": { "startLine": 222, "endLine": 257 },
+    "type": "context",
+    "title": "The Three JCF Axioms: Mathlib's Current Frontier in Linear Algebra",
+    "content": "Part V axiomatizes three results that require the full Jordan block matrix decomposition — the explicit Jordan basis with eigenvalues on the diagonal and 1s on the superdiagonal — which is not yet in Mathlib 4.26.0. jordan_normal_form_basis states the existence of a Jordan basis: a sigma-indexed family e : (Σ i : Fin m, Fin (sizes i)) → V where f(e_{i,j}) = eigenvalues_i • e_{i,j} + e_{i,j+1} (with zero for the last position). The placeholder condition LinearMap.ker (LinearMap.id - f) ≤ ⊤ acknowledges that encoding linear independence of this sigma-indexed family requires additional infrastructure. minpoly_product_formula is the key JCF-minpoly formula: minpoly K f = ∏_{μ ∈ s} (X - C μ)^(maxGenEigenspaceIndex f μ), axiomatizing the precise exponents. maxGenEigenspaceIndex_exact is the tightness axiom: the exponent is not merely an upper bound — there exists a vector in maxGenEigenspace μ on which (f - μ)^{e-1} is nonzero. This exactness is what makes the product formula a sharp description rather than just a divisibility statement.",
+    "mathContext": "Mathlib 4.26.0 status: (1) triangularizability — exists a basis in which the matrix is upper-triangular (proved via iSup_maxGenEigenspace_eq_top + choice); (2) Jordan-Chevalley decomposition — $f = s + n$ with $s$ semisimple, $n$ nilpotent, $[s,n]=0$, both polynomials in $f$; (3) generalized eigenspaces and maxGenEigenspaceIndex. What is missing: the explicit Jordan block indexing that identifies which generalized eigenvectors form which Jordan chain, needed to prove the exponent formula $e_\\mu = \\max_i (\\text{block size}_i)$.",
+    "significance": "context",
+    "relatedConcepts": ["jordan_normal_form_basis", "minpoly_product_formula", "maxGenEigenspaceIndex_exact", "maxGenEigenspace", "IsAlgClosed"],
+    "prerequisites": ["Mathlib.LinearAlgebra.Eigenspace.Triangularizable", "Mathlib.LinearAlgebra.JordanChevalley", "Module.End.maxGenEigenspaceIndex"]
+  },
+  {
+    "id": "ann-jcf-minpoly-summary",
+    "proofId": "cayley-hamilton-minpoly-oq-01",
+    "range": { "startLine": 280, "endLine": 307 },
+    "type": "context",
+    "title": "The Minimal Polynomial as a Complete Jordan Block Invariant",
+    "content": "The closing summary frames the file's contribution. The minimal polynomial is a complete invariant of the Jordan block structure: it determines, for each eigenvalue μ, the size e_μ of the largest Jordan block, via minpoly = ∏ (X-μ)^{e_μ}. The four key equivalences form a complete algebraic characterization: eigenvalue ↔ root of minpoly; nilpotent ↔ minpoly = X^k; semisimple ↔ squarefree minpoly; semisimple + nilpotent = 0 (uniqueness for Jordan-Chevalley). The 20 theorems split into two groups. Parts I-IV (theorems 1-19) are fully verified: they rely on Mathlib's generalized eigenspace and semisimple theories, which are complete. Part V (3 axioms) requires the JNF block matrix, Mathlib's active development frontier. The summary notes the proof-of-axiom-to-verified trajectory is expected to complete when Mathlib formalizes the explicit Jordan block decomposition with a labeled basis.",
+    "mathContext": "The relation between minpoly and charpoly is: $\\mathrm{minpoly}_K(f) \\mid \\mathrm{charpoly}_K(f)$ (proved) and they have the same roots (both record the eigenvalues). The difference: charpoly records $d_\\mu = \\sum_i (\\text{block size}_i$ for eigenvalue $\\mu)$ (total multiplicity), while minpoly records $e_\\mu = \\max_i (\\text{block size}_i)$ (largest block). The ratio $d_\\mu - e_\\mu \\geq 0$ measures the presence of multiple Jordan blocks for each eigenvalue.",
+    "significance": "context",
+    "relatedConcepts": ["minpoly product formula", "Jordan-Chevalley uniqueness", "Mathlib JNF roadmap", "charpoly vs minpoly"],
+    "prerequisites": ["All of Parts I-IV", "jordan_normal_form_basis (axiom)", "minpoly_product_formula (axiom)"]
+  }
+]

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "cayley-hamilton-minpoly-oq-01",
   "title": "Jordan Canonical Form and the Minimal Polynomial",
   "slug": "cayley-hamilton-minpoly-oq-01",
-  "description": "Characterizes the minimal polynomial of a linear endomorphism via eigenvalues and Jordan block structure. Proves eigenvalues ↔ roots of minpoly, minpoly | charpoly, semisimple ↔ squarefree minpoly, nilpotent ↔ minpoly = X^k. Axiomatizes the JCF product formula: minpoly = Π (X-μ)^{e_μ} where e_μ = size of largest Jordan block for eigenvalue μ. 20 theorems, 0 definitions, 3 axioms.",
+  "description": "Characterizes the minimal polynomial of a linear endomorphism via eigenvalues and Jordan block structure. Proves eigenvalues \u2194 roots of minpoly, minpoly | charpoly, semisimple \u2194 squarefree minpoly, nilpotent \u2194 minpoly = X^k. Axiomatizes the JCF product formula: minpoly = \u03a0 (X-\u03bc)^{e_\u03bc} where e_\u03bc = size of largest Jordan block for eigenvalue \u03bc. 20 theorems, 0 definitions, 3 axioms.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
@@ -20,29 +20,31 @@
     "sorries": 0,
     "dateAdded": "2026-04-02",
     "axiomCount": 3,
-    "assumptions": "3 axioms: jordan_normal_form_basis (over algebraically closed field, V decomposes into Jordan blocks), minpoly_product_formula (minpoly K f = Π (X-μ)^{maxGenEigenspaceIndex f μ}), maxGenEigenspaceIndex_exact (the exponent equals exactly the size of the largest Jordan block).",
+    "assumptions": "3 axioms: jordan_normal_form_basis (over algebraically closed field, V decomposes into Jordan blocks), minpoly_product_formula (minpoly K f = \u03a0 (X-\u03bc)^{maxGenEigenspaceIndex f \u03bc}), maxGenEigenspaceIndex_exact (the exponent equals exactly the size of the largest Jordan block).",
     "lineCount": 307,
     "theoremCount": 20,
     "definitionCount": 0,
     "originalContributions": [
-      "eigenvalue_iff_root_minpoly: f.HasEigenvalue μ ↔ (minpoly K f).IsRoot μ",
-      "eigenvalue_linear_factor_dvd_minpoly: μ eigenvalue → (X-C μ) | minpoly",
-      "minpoly_dvd_charpoly: minpoly K A ∣ A.charpoly",
-      "isSemisimple_iff_squarefree_minpoly: semisimple ↔ minpoly squarefree",
-      "isNilpotent_iff_minpoly_pow: nilpotent ↔ minpoly = X^k",
-      "genEigenspace_nilpotent_restriction: (f - μI) restricted to genEigenspace is nilpotent"
+      "eigenvalue_iff_root_minpoly: f.HasEigenvalue \u03bc \u2194 (minpoly K f).IsRoot \u03bc",
+      "eigenvalue_linear_factor_dvd_minpoly: \u03bc eigenvalue \u2192 (X-C \u03bc) | minpoly",
+      "minpoly_dvd_charpoly: minpoly K A \u2223 A.charpoly",
+      "isSemisimple_iff_squarefree_minpoly: semisimple \u2194 minpoly squarefree",
+      "isNilpotent_iff_minpoly_pow: nilpotent \u2194 minpoly = X^k",
+      "genEigenspace_nilpotent_restriction: (f - \u03bcI) restricted to genEigenspace is nilpotent"
     ]
   },
   "overview": {
-    "historicalContext": "The Jordan canonical form theorem (Jordan 1870) says every endomorphism over an algebraically closed field decomposes into Jordan blocks. The minimal polynomial encodes the block structure: minpoly = Π (X-μ)^{e_μ} where e_μ is the size of the largest Jordan block for eigenvalue μ. This is the fundamental theorem connecting eigenvalue structure to polynomial algebra. Mathlib 4 has generalized eigenspaces and triangularizability but not the full Jordan block matrix decomposition.",
-    "problemStatement": "Prove the relationship between Jordan canonical form and the minimal polynomial: minpoly = Π (X-μ)^{e_μ}. Prove semisimple ↔ squarefree minpoly and nilpotent ↔ minpoly = X^k.",
-    "text": "For f : Module.End K V over algebraically closed K: eigenvalues are exactly the roots of minpoly. The minimal polynomial divides the characteristic polynomial. An endomorphism is semisimple (diagonalizable) iff its minimal polynomial is squarefree (no repeated roots). It is nilpotent iff minpoly = X^k for some k. The full JCF theorem: minpoly = Π (X-μ)^{maxGenEigenspaceIndex f μ} — the exponent records the largest Jordan block size.",
-    "proofStrategy": "Prove eigenvalue characterization, minpoly | charpoly, and semisimple/nilpotent characterizations from Mathlib's semisimple and eigenspace theory. Axiomatize the JCF product formula and maxGenEigenspaceIndex exactness (not yet in Mathlib).",
+    "historicalContext": "The Jordan canonical form theorem (Camille Jordan, Traité des substitutions, 1870) states that every endomorphism over an algebraically closed field is similar to a block-diagonal matrix with Jordan blocks. The minimal polynomial was studied by Weierstrass in his theory of matrix pencils (1868) and by Frobenius (1878), who established minpoly | charpoly and characterized semisimplicity via squarefree minpoly. The JCF-minpoly product formula minpoly = \u03a0(X-\u03bc)^{e_\u03bc} — where e_\u03bc is the largest Jordan block size for eigenvalue \u03bc — unifies these perspectives. The Jordan-Chevalley decomposition (Chevalley, 1951) f = s + n with s semisimple, n nilpotent, [s,n] = 0 follows from JCF and is now in Mathlib 4.26.0. The rational canonical form (Frobenius, 1879), which requires no algebraic closure, gives companion matrix blocks indexed by invariant factors. Mathlib 4.26.0 formalizes triangularizability, Jordan-Chevalley, and generalized eigenspaces, but not the explicit Jordan block matrix with labeled basis vectors \u2014 the gap between classical and formally verified.",
+    "problemStatement": "Prove the relationship between Jordan canonical form and the minimal polynomial: minpoly = \u03a0 (X-\u03bc)^{e_\u03bc}. Prove semisimple \u2194 squarefree minpoly and nilpotent \u2194 minpoly = X^k.",
+    "text": "For f : Module.End K V over algebraically closed K: eigenvalues are exactly the roots of minpoly. The minimal polynomial divides the characteristic polynomial. An endomorphism is semisimple (diagonalizable) iff its minimal polynomial is squarefree (no repeated roots). It is nilpotent iff minpoly = X^k for some k. The full JCF theorem: minpoly = \u03a0 (X-\u03bc)^{maxGenEigenspaceIndex f \u03bc} \u2014 the exponent records the largest Jordan block size.",
+    "proofStrategy": "Prove eigenvalue characterization, minpoly | charpoly, and semisimple/nilpotent characterizations from Mathlib's semisimple and eigenspace theory. The nilpotent direction uses a UFD argument: minpoly | X^n with X prime forces minpoly ~ X^j; monic + associated = equal. Axiomatize the JCF product formula and maxGenEigenspaceIndex exactness (not yet in Mathlib).",
     "keyInsights": [
       "Eigenvalues = roots of minpoly: the bridge between linear algebra and polynomial algebra",
-      "Semisimple ↔ squarefree minpoly: diagonalizability is captured by the polynomial structure",
-      "Nilpotent ↔ minpoly = X^k: all eigenvalues are 0",
-      "JCF product formula: exponents record the largest Jordan block per eigenvalue"
+      "Semisimple \u2194 squarefree minpoly: diagonalizability is captured by polynomial squarefreeness",
+      "Nilpotent \u2194 minpoly = X^k: all eigenvalues are 0, proved via UFD structure of K[X]",
+      "JCF product formula: exponents record the largest Jordan block per eigenvalue",
+      "UFD argument for nilpotent minpoly: X prime in K[X], so divisors of X^n are X^j; monic + associated forces equality",
+      "Semisimple + nilpotent = 0: squarefree \u2229 pure-power forces minpoly = X (1\u00d71 block), the uniqueness core of Jordan-Chevalley"
     ],
     "prerequisites": [
       "Eigenspaces and generalized eigenspaces: Module.End.HasEigenvalue, genEigenspace",
@@ -51,12 +53,13 @@
     ]
   },
   "conclusion": {
-    "summary": "Jordan-minpoly relationship formalized: eigenvalue ↔ root, minpoly|charpoly, semisimple ↔ squarefree, nilpotent ↔ X^k, JCF product formula axiomatized. 20 theorems, 307 lines, 3 axioms.",
-    "implications": "The JCF-minpoly connection is central to spectral theory, functional calculus, and representation theory. The axiomatized results reflect the current state of Mathlib: generalized eigenspaces exist but the full JNF block matrix is not yet formalized.",
+    "summary": "Jordan-minpoly relationship formalized: eigenvalue \u2194 root, minpoly|charpoly, semisimple \u2194 squarefree, nilpotent \u2194 X^k, JCF product formula axiomatized. 20 theorems, 307 lines, 3 axioms. The nilpotent characterization uses a UFD argument for monic divisors of X^n in K[X].",
+    "implications": "The JCF-minpoly connection is central to spectral theory, functional calculus, and representation theory. The axiomatized results reflect the current state of Mathlib: generalized eigenspaces and Jordan-Chevalley exist but the full JNF block matrix is not yet formalized. The semisimple \u2194 squarefree result enables algorithmic diagonalizability testing via GCD computation on the minimal polynomial.",
     "openQuestions": [
-      "Prove the JCF product formula in Lean when Mathlib adds Jordan block matrix decomposition",
-      "Prove the Jordan-Chevalley decomposition: f = s + n with s semisimple, n nilpotent, [s,n]=0",
-      "Formalize the rational canonical form (companion matrix decomposition, no algebraic closure needed)"
+      "Prove the JCF product formula in Lean when Mathlib adds Jordan block matrix decomposition with explicit basis indexing",
+      "Prove the Jordan-Chevalley decomposition: f = s + n with s semisimple, n nilpotent, [s,n] = 0, both polynomials in f",
+      "Formalize the rational canonical form (companion matrix decomposition over non-algebraically-closed fields via invariant factors)",
+      "Prove the rank-nullity tower: dim(genEigenspace \u03bc k) - dim(genEigenspace \u03bc k-1) = number of Jordan blocks of size \u2265 k for eigenvalue \u03bc"
     ]
   },
   "leanFile": {
@@ -78,5 +81,42 @@
       "description": "OQ-04 studies nonderogatory/cyclic vectors; OQ-01 studies Jordan structure and semisimplicity"
     }
   ],
-  "sections": []
+  "sections": [
+    {
+      "title": "Part I: Eigenvalues and the Minimal Polynomial",
+      "startLine": 52,
+      "endLine": 91,
+      "summary": "eigenvalue_iff_root_minpoly wraps hasEigenvalue_iff_isRoot: eigenvalue \u2194 root of minpoly. eigenvalue_linear_factor_dvd_minpoly: (X - C \u03bc) | minpoly via dvd_iff_isRoot. minpoly_dvd_charpoly wraps Matrix.minpoly_dvd_charpoly. finite_eigenvalues: eigenvalue set is finite. minpoly_annihilates: aeval f (minpoly K f) = 0. minpoly_monic: minpoly is monic. Note: degree bound natDegree \u2264 finrank K V not proved here due to whnf timeout in Lean 4.26.0 when computing finrank K (End K V)."
+    },
+    {
+      "title": "Part II: Generalized Eigenspace Structure",
+      "startLine": 93,
+      "endLine": 124,
+      "summary": "generalized_eigenspaces_span_top: over algebraically closed K, \u2a06 (genEigenspace \u03bc k) = \u22a4, proved via iSup_genEigenspace_eq + iSup_maxGenEigenspace_eq_top. disjoint_generalized_eigenspaces: distinct eigenvalues give disjoint genEigenspaces (disjoint_genEigenspace). nilpotent_shift_on_genEigenspace: (f - \u03bcI) restricted to genEigenspace \u03bc k is nilpotent (isNilpotent_restrict_sub_algebraMap). genEigenspace_stabilizes: the chain stabilizes at maxGenEigenspaceIndex (genEigenspace_eq_genEigenspace_maxUnifEigenspaceIndex_of_le)."
+    },
+    {
+      "title": "Part III: Nilpotent Endomorphisms and the Minimal Polynomial",
+      "startLine": 126,
+      "endLine": 194,
+      "summary": "eigenvalue_zero_of_nilpotent: nilpotent f has only eigenvalue 0 (proof: \u03bc^k\u2022v = f^k(v) = 0, v\u22600, so \u03bc^k = 0, so \u03bc = 0 in a field). minpoly_dvd_pow_of_nilpotent: f^n = 0 \u21d2 minpoly | X^n via minpoly.dvd. minpoly_pow_X_of_nilpotent: nilpotent \u21d2 minpoly = X^j by UFD: X is prime, dvd_prime_pow, Associated monic polynomials are equal. nilpotent_of_minpoly_pow_X: converse via aeval f (X^k) = f^k = 0. nilpotent_iff_minpoly_pow_X: full iff combining both directions."
+    },
+    {
+      "title": "Part IV: Diagonalizability and the Minimal Polynomial",
+      "startLine": 196,
+      "endLine": 217,
+      "summary": "minpoly_squarefree_of_semisimple: IsSemisimple f \u21d2 Squarefree (minpoly K f) via IsSemisimple.minpoly_squarefree. isSemisimple_iff_squarefree_minpoly: full iff, backward direction uses isSemisimple_of_squarefree_aeval_eq_zero. semisimple_nilpotent_eq_zero: semisimple + nilpotent = 0 (eq_zero_of_isNilpotent_isSemisimple) \u2014 the uniqueness core of Jordan-Chevalley."
+    },
+    {
+      "title": "Part V: Jordan Normal Form (Axiomatic)",
+      "startLine": 218,
+      "endLine": 257,
+      "summary": "Three axioms for JCF results not yet in Mathlib 4.26.0. jordan_normal_form_basis: existence of a Jordan basis (sigma-indexed family with Jordan block action). minpoly_product_formula: minpoly K f = \u03a0_{\u03bc\u2208s} (X - C \u03bc)^(maxGenEigenspaceIndex f \u03bc). maxGenEigenspaceIndex_exact: the exponent is tight \u2014 there exists v in maxGenEigenspace \u03bc with (f - \u03bc)^{e-1}(v) \u2260 0. The placeholder condition LinearMap.ker (LinearMap.id - f) \u2264 \u22a4 in jordan_normal_form_basis acknowledges the sigma-family linear independence encoding challenge."
+    },
+    {
+      "title": "Part VI: Corollaries and Summary",
+      "startLine": 258,
+      "endLine": 307,
+      "summary": "jordan_block_power_dvd_minpoly: (X - C \u03bc)^{e_\u03bc} | minpoly K f by Finset.dvd_prod_of_mem applied to the product formula. diagonalizable_iff_squarefree_minpoly: alias of isSemisimple_iff_squarefree_minpoly. Summary docstring synthesizes the four key equivalences and the two-tier structure (Parts I-IV fully verified, Part V axiomatized pending Mathlib JNF block matrix)."
+    }
+  ]
 }


### PR DESCRIPTION
Enriches the Jordan Canonical Form / Minimal Polynomial gallery entry.

## Changes
- **annotations.json**: 6 new annotations — module overview (context), eigenvalue-minpoly bridge (insight), nilpotent UFD characterization (insight), semisimple↔squarefree iff (insight), the 3 JCF axioms context, summary synthesis
- **meta.json**: expanded historicalContext (Jordan 1870, Weierstrass, Frobenius, Chevalley 1951, Mathlib frontier); keyInsights 4→6 (UFD argument, semisimple+nilpotent=0); 6 sections covering all 307 lines; openQuestions 3→4

## Validation
`pnpm annotations:build` passes with no errors for this entry.

🤖 Generated by enricher-2