### PR TITLE
Enrich cayley-hamilton-minpoly-oq-04: annotations, sections, historicalContext

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-04/annotations.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-04/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-nonderog-overview",
+    "proofId": "cayley-hamilton-minpoly-oq-04",
+    "range": { "startLine": 1, "endLine": 41 },
+    "type": "context",
+    "title": "Nonderogatory Matrices: Cyclic Vectors and the Degree Bridge",
+    "content": "The module docstring frames the characterization theorem: M is nonderogatory (minpoly = charpoly) iff M has a cyclic vector v such that {v, Mv, ..., M^{n-1}v} forms a basis. The proof strategy is elegant and asymmetric: the forward direction (cyclic → nonderogatory) uses a contradiction argument on polynomial degrees — if deg(minpoly) < n, then minpoly annihilates v with degree < n, contradicting the cyclic vector property; therefore deg(minpoly) = n = deg(charpoly), and the bridge lemma forces minpoly = charpoly. The backward direction (nonderogatory → cyclic) requires the structure theorem for finitely generated K[X]-modules (V ≅ ⊕ K[X]/(dᵢ) with invariant factors d₁ | d₂ | ... | d_k), which is axiomatized since it requires substantial PID module theory. The file references Horn & Johnson §3.2.4 and Hoffman & Kunze §7.2, and extends earlier files on minpoly-charpoly divisibility (MinpolyCharpoly.lean) and similar matrices (CayleyHamiltonMinpolyOQ02.lean).",
+    "mathContext": "The condition $\\mu_M = \\chi_M$ (minpoly = charpoly) is equivalent to: (1) the invariant factor decomposition has a single factor $d_1 = \\chi_M$; (2) each eigenvalue $\\mu$ has exactly one Jordan block; (3) the commutant $\\{N : NM = MN\\}$ equals $K[M]$ (polynomials in $M$). The name 'nonderogatory' comes from 'not derogatory' — a matrix is derogatory if it has repeated eigenvalues with insufficiently large Jordan blocks, causing $\\mu_M \\neq \\chi_M$.",
+    "significance": "context",
+    "relatedConcepts": ["nonderogatory", "cyclic vector", "Krylov sequence", "companion matrix", "invariant factors", "rational canonical form"],
+    "prerequisites": ["LinearAlgebra.Matrix.Charpoly.Minpoly", "minpoly_dvd_charpoly", "charpoly_natDegree_eq_dim"]
+  },
+  {
+    "id": "ann-nonderog-definitions",
+    "proofId": "cayley-hamilton-minpoly-oq-04",
+    "range": { "startLine": 67, "endLine": 88 },
+    "type": "definition",
+    "title": "IsCyclicVector and IsNonderogatory: Two Algebraic Predicates",
+    "content": "Part I introduces three definitions. IsCyclicVector M v (line 67) uses the annihilator formulation: v is cyclic iff every polynomial p of degree < n that annihilates v (i.e., (aeval M p).mulVec v = 0) must be the zero polynomial. This captures the annihilator ideal perspective: the set of polynomials annihilating v forms an ideal in K[X], and IsCyclicVector says this ideal has no nonzero elements of degree < n. IsCyclicVectorLI M v (line 72) is the equivalent linear independence formulation: the Krylov vectors {M^k v : k < n} are linearly independent (hence form a basis since K^n has dimension n). IsNonderogatory M (line 86) is simply minpoly K M = M.charpoly. The file uses the annihilator formulation IsCyclicVector throughout the proofs (rather than IsCyclicVectorLI) because it connects more directly to the polynomial algebra: the annihilator polynomial of v as a K[X]-module element is the key object.",
+    "mathContext": "The K[X]-module structure on $K^n$: scalar multiplication by $X$ acts as $M$, so $X \\cdot v = Mv$. The annihilator of $v$ in $K[X]$ is $\\{p : p(M)v = 0\\}$, a principal ideal $(\\mathrm{ann}(v))$. The cyclic condition $\\mathrm{IsCyclicVector}\\ M\\ v$ says $\\deg(\\mathrm{ann}(v)) \\geq n$, which forces $\\mathrm{ann}(v) = (\\chi_M)$ since $\\mathrm{ann}(v) \\mid \\chi_M$ (Cayley-Hamilton) and $\\deg \\chi_M = n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["IsCyclicVector", "IsCyclicVectorLI", "IsNonderogatory", "K[X]-module", "annihilator ideal"],
+    "prerequisites": ["Matrix.mulVec", "Polynomial.aeval", "LinearIndependent"]
+  },
+  {
+    "id": "ann-nonderog-bridge",
+    "proofId": "cayley-hamilton-minpoly-oq-04",
+    "range": { "startLine": 98, "endLine": 133 },
+    "type": "insight",
+    "title": "Bridge Lemma: Equal Degree Forces minpoly = charpoly",
+    "content": "The bridge lemma minpoly_eq_charpoly_of_natDegree_eq proves: if natDegree(minpoly K M) = natDegree(M.charpoly), then IsNonderogatory M (i.e., minpoly = charpoly). The proof uses minpoly_dvd_charpoly M to write charpoly = minpoly * r. Degree additivity (natDegree_mul) gives natDegree(charpoly) = natDegree(minpoly) + natDegree(r), so the equal-degree hypothesis forces natDegree(r) = 0, i.e., r is a constant polynomial. Since charpoly is monic and charpoly = minpoly * r, the cofactor r must have leadingCoeff = 1 (proved via Monic.leadingCoeff). A monic polynomial of degree 0 must be 1 (eq_C_of_natDegree_eq_zero + leading coefficient). Therefore charpoly = minpoly * 1 = minpoly. This is the algebraic core: the divisibility relation minpoly | charpoly combined with equal degrees forces equality.",
+    "mathContext": "In any integral domain, if monic $f \\mid g$ and $\\deg f = \\deg g$, then $f = g$. Proof: $g = f \\cdot r$, $\\deg r = 0$, $r$ constant; $g$ monic and $f$ monic imply $r$'s leading coefficient is 1 (from $g = f \\cdot r$), so $r = 1$. This works over any commutative ring where the degree formula $\\deg(fg) = \\deg f + \\deg g$ holds (integral domain suffices).",
+    "significance": "key",
+    "relatedConcepts": ["minpoly_dvd_charpoly", "natDegree_mul", "Polynomial.Monic", "eq_C_of_natDegree_eq_zero"],
+    "prerequisites": ["minpoly.monic", "charpoly_monic", "natDegree_le_of_dvd"]
+  },
+  {
+    "id": "ann-nonderog-forward",
+    "proofId": "cayley-hamilton-minpoly-oq-04",
+    "range": { "startLine": 146, "endLine": 167 },
+    "type": "insight",
+    "title": "Forward Direction: Cyclic Vector Implies Nonderogatory via Degree Argument",
+    "content": "cyclic_implies_nonderogatory is the main forward theorem. Given IsCyclicVector M v, it proves IsNonderogatory M via the bridge lemma. The key step is showing natDegree(minpoly K M) = natDegree(charpoly). We know natDegree(minpoly) ≤ natDegree(charpoly) from minpoly | charpoly (natDegree_le_of_dvd). The proof then proceeds by contradiction: assume natDegree(minpoly) < natDegree(charpoly) = n. The minimal polynomial annihilates M, so (aeval M (minpoly K M)).mulVec v = 0 (via minpoly.aeval + simp). Since natDegree(minpoly) < n and the annihilating vector equation holds, IsCyclicVector says minpoly = 0. But minpoly is monic (Monic.ne_zero), contradiction. Therefore natDegree(minpoly) = n and the bridge lemma gives minpoly = charpoly. The proof is notable for its clean application of the by_contra + omega pattern and the direct use of IsCyclicVector's defining condition.",
+    "mathContext": "The key conceptual step: $\\mathrm{minpoly}(M)$ annihilates $M$, so $p(M)v = 0$ for $p = \\mathrm{minpoly}$. If $\\deg p < n$, this contradicts $v$ being cyclic. Therefore $\\deg(\\mathrm{minpoly}) = n$. Since $\\mathrm{minpoly} \\mid \\chi_M$ and both have degree $n$ and are monic, they are equal. The argument works over any field $K$, with no algebraic closure needed.",
+    "significance": "key",
+    "relatedConcepts": ["cyclic_implies_nonderogatory", "IsCyclicVector", "minpoly_eq_charpoly_of_natDegree_eq", "natDegree_le_of_dvd"],
+    "prerequisites": ["charpoly_natDegree_eq_dim", "minpoly.aeval", "minpoly.monic", "Fintype.card_fin"]
+  },
+  {
+    "id": "ann-nonderog-backward",
+    "proofId": "cayley-hamilton-minpoly-oq-04",
+    "range": { "startLine": 173, "endLine": 206 },
+    "type": "context",
+    "title": "Backward Direction: Three Approaches and the Infrastructure Gap",
+    "content": "Part IV discusses three distinct proof strategies for the backward direction (nonderogatory → cyclic vector) and explains why each requires substantial infrastructure not available as a single Mathlib lemma. Approach 1 (general fields): use the structure theorem for f.g. K[X]-modules — V ≅ K[X]/(d₁) ⊕ ... ⊕ K[X]/(d_k) with d₁ | ... | d_k. If minpoly = charpoly = d_k = d₁ · ... · d_k, then k = 1 (single cyclic summand) and the generator is the cyclic vector. Approach 2 (algebraically closed fields): use Jordan Normal Form — minpoly = charpoly forces exactly one Jordan block per eigenvalue, allowing construction of a cyclic vector by summing Jordan basis generators. Approach 3 (infinite fields): the set of non-cyclic vectors is a finite union of proper subspaces; infinite fields cannot be covered by finitely many proper subspaces. The axiom nonderogatory_has_cyclic_vector (line 205) formalizes this result with a note that it holds over ALL fields — including finite ones, which eliminates Approach 3 for the general case.",
+    "mathContext": "The structure theorem approach: $V \\cong \\bigoplus K[X]/(d_i)$ as $K[X]$-modules. The $i$-th summand has annihilator $(d_i)$. The minpoly is $d_k$ (largest invariant factor) and charpoly is $\\prod d_i$. If $d_k = \\prod d_i$ and $d_1 \\mid d_2 \\mid \\cdots \\mid d_k$, then $k=1$ (any other factoring would give $d_k < \\prod d_i$). The single summand $V \\cong K[X]/(\\chi_M)$ directly gives a cyclic vector: the image of $1 \\in K[X]$ under $K[X] \\to V$.",
+    "significance": "context",
+    "relatedConcepts": ["structure theorem for f.g. modules over PID", "invariant factors", "rational canonical form", "cyclic decomposition", "Jordan Normal Form"],
+    "prerequisites": ["nonderogatory_has_cyclic_vector (axiom)", "K[X]-module structure on V", "IsCyclicVector"]
+  },
+  {
+    "id": "ann-nonderog-summary",
+    "proofId": "cayley-hamilton-minpoly-oq-04",
+    "range": { "startLine": 286, "endLine": 316 },
+    "type": "context",
+    "title": "Summary: The Degree Bridge and the Proof-Infrastructure Gap",
+    "content": "The closing summary catalogs all 8 theorems under three categories. The two predicate definitions (IsCyclicVector, IsNonderogatory) are the algebraic encodings. The main result (nonderogatory_iff_cyclic_vector) is the full equivalence, combining the proved forward direction and the axiomatized backward direction. The degree characterization theorems (nonderogatory_iff_natDegree_eq, derogatory_iff_natDegree_lt) give an equivalent formulation in terms of polynomial degrees, useful for computations. The bridge lemma (minpoly_eq_charpoly_of_natDegree_eq) is the key algebraic ingredient, proving that same-degree monic polynomials related by divisibility must be equal. The asymmetry in the proof — forward direction fully verified (0 sorries, 1 clean contradiction argument), backward direction axiomatized (1 axiom requiring PID structure theorem) — reflects a common pattern in formal linear algebra: polynomial-theoretic properties of operators are easier to verify from first principles than the structural existence of special vectors or bases.",
+    "mathContext": "The degree characterization: $\\mathrm{IsNonderogatory}\\ M \\Leftrightarrow \\deg(\\mathrm{minpoly}\\ K\\ M) = n$. Since always $\\deg(\\mathrm{minpoly}) \\leq \\deg(\\chi_M) = n$, nonderogatory is equivalent to $\\mathrm{minpoly}$ achieving the maximum possible degree. Derogatory matrices ($\\deg(\\mathrm{minpoly}) < n$) have 'more eigenvalue repetition in Jordan blocks than the maximum'.",
+    "significance": "context",
+    "relatedConcepts": ["minpoly_eq_charpoly_of_natDegree_eq", "nonderogatory_iff_natDegree_eq", "derogatory_iff_natDegree_lt", "PID structure theorem gap"],
+    "prerequisites": ["All of Parts I-VI", "nonderogatory_has_cyclic_vector (axiom)"]
+  }
+]

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-04/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-04/meta.json
@@ -19,31 +19,33 @@
     "sorries": 0,
     "dateAdded": "2026-04-02",
     "axiomCount": 1,
-    "assumptions": "1 axiom: nonderogatory_has_cyclic_vector — the converse direction: if M is nonderogatory (minpoly = charpoly), then there exists a cyclic vector v with {v, Mv, ..., M^{n-1}v} a basis. This requires constructing the cyclic vector from the rational canonical form, which is not yet fully formalized in Mathlib.",
+    "assumptions": "1 axiom: nonderogatory_has_cyclic_vector \u2014 the converse direction: if M is nonderogatory (minpoly = charpoly), then there exists a cyclic vector v with {v, Mv, ..., M^{n-1}v} a basis. This requires constructing the cyclic vector from the rational canonical form, which is not yet fully formalized in Mathlib.",
     "lineCount": 316,
     "theoremCount": 8,
     "definitionCount": 0,
     "originalContributions": [
-      "IsCyclicVector: predicate — v is cyclic for M if {v,Mv,...,M^{n-1}v} spans K^n",
-      "IsNonderogatory: predicate — minpoly M = charpoly M",
-      "cyclic_implies_nonderogatory: forward direction — cyclic vector implies minpoly = charpoly (fully proved)",
+      "IsCyclicVector: predicate \u2014 v is cyclic for M if {v,Mv,...,M^{n-1}v} spans K^n",
+      "IsNonderogatory: predicate \u2014 minpoly M = charpoly M",
+      "cyclic_implies_nonderogatory: forward direction \u2014 cyclic vector implies minpoly = charpoly (fully proved)",
       "minpoly_eq_charpoly_of_natDegree_eq: natDeg(minpoly) = n implies minpoly = charpoly",
       "nonderogatory_iff_cyclic_vector: full iff characterization (modulo converse axiom)",
       "minpoly_natDegree_eq_dim_of_cyclic: cyclic vector implies natDeg(minpoly) = dim",
       "nonderogatory_iff_natDegree_eq: equivalent characterization via natDegree",
-      "derogatory_iff_natDegree_lt: derogatory ↔ natDeg(minpoly) < n"
+      "derogatory_iff_natDegree_lt: derogatory \u2194 natDeg(minpoly) < n"
     ]
   },
   "overview": {
-    "historicalContext": "A matrix M is nonderogatory if its minimal polynomial equals its characteristic polynomial. This is equivalent to M having a cyclic vector — a vector v such that {v, Mv, M²v, ..., M^{n-1}v} forms a basis. Nonderogatory matrices are exactly those with a single Jordan block per eigenvalue (i.e., companion matrices in their rational canonical form). This characterization appears in many applications: control theory (controllability), functional calculus, and polynomial matrix theory.",
-    "problemStatement": "Prove that a matrix M ∈ M_n(K) is nonderogatory (minpoly = charpoly) if and only if it has a cyclic vector. Formalize both directions.",
+    "historicalContext": "The concept of a cyclic vector is classical in matrix theory and control theory. A matrix M \u2208 M_n(K) is nonderogatory (Frobenius, 1879) if its minimal and characteristic polynomials coincide; equivalently, it is similar to the companion matrix of its characteristic polynomial. The cyclic vector characterization connects to Krylov subspace methods (Krylov, 1931), now fundamental in numerical linear algebra (Lanczos, Arnoldi, GMRES). In control theory (Kalman, 1960s), the state matrix of a controllable linear system is nonderogatory, and the existence of a cyclic vector is equivalent to controllability from a single input. The Frobenius invariant factor decomposition establishes that nonderogatory matrices have a single invariant factor, while derogatory matrices have multiple. Mathlib 4.26.0 has the necessary minpoly and charpoly machinery but not the full structure theorem for f.g. modules over PIDs needed for the backward direction.",
+    "problemStatement": "Prove that a matrix M \u2208 M_n(K) is nonderogatory (minpoly = charpoly) if and only if it has a cyclic vector. Formalize both directions.",
     "text": "Forward direction: if v is cyclic for M, then the vector space K^n has a basis {v, Mv, ..., M^{n-1}v}. The minimal polynomial of M with respect to v is the unique monic polynomial p of minimal degree with p(M)v = 0. Since v is cyclic, this has degree n = deg(charpoly). Since minpoly | charpoly and both are monic of degree n, they are equal. Converse: if minpoly = charpoly, construct v as a suitable sum of basis vectors via rational canonical form (axiomatized).",
-    "proofStrategy": "Define IsCyclicVector and IsNonderogatory. Prove the forward direction via degree comparison: cyclic → natDeg(minpoly) = n → minpoly = charpoly. Axiomatize the converse (rational canonical form argument). Prove equivalent characterizations via natDegree.",
+    "proofStrategy": "Define IsCyclicVector and IsNonderogatory. Prove the forward direction via degree comparison: cyclic \u2192 natDeg(minpoly) = n \u2192 minpoly = charpoly (bridge lemma: equal-degree monic polynomials where one divides the other must be equal). Axiomatize the converse (rational canonical form / PID structure theorem argument). Prove equivalent characterizations via natDegree.",
     "keyInsights": [
       "Cyclic vector gives natDeg(minpoly) = n: the annihilator polynomial of a cyclic vector has full degree",
-      "minpoly | charpoly and equal degrees forces minpoly = charpoly (monic polynomials)",
+      "minpoly | charpoly and equal degrees forces minpoly = charpoly (monic cofactor must be 1)",
       "Nonderogatory = one Jordan block per eigenvalue = companion matrix in rational canonical form",
-      "The converse requires rational canonical form: construct cyclic vector from rational canonical basis"
+      "The converse requires rational canonical form: construct cyclic vector from invariant factor decomposition",
+      "Three approaches to the backward direction: PID structure theorem (all fields), JNF (alg. closed), union of proper subspaces (infinite fields only)",
+      "Annihilator formulation of IsCyclicVector captures the K[X]-module structure: v generates V as a K[M]-module"
     ],
     "prerequisites": [
       "Minimal polynomial: smallest monic polynomial annihilating M",
@@ -52,15 +54,17 @@
     ]
   },
   "conclusion": {
-    "summary": "Nonderogatory matrices characterized via cyclic vectors: forward direction (cyclic → minpoly = charpoly) fully proved, converse axiomatized. Equivalent natDegree characterizations proved. 8 theorems, 316 lines, 1 axiom.",
-    "implications": "The cyclic vector characterization is central to systems theory: a linear dynamical system is controllable iff its state matrix is nonderogatory. Completing the converse would give a fully verified characterization in Lean.",
+    "summary": "Nonderogatory matrices characterized via cyclic vectors: forward direction (cyclic \u2192 minpoly = charpoly) fully proved via degree bridge lemma, converse axiomatized (requires PID structure theorem). Equivalent natDegree characterizations proved. 8 theorems, 316 lines, 1 axiom.",
+    "implications": "The cyclic vector characterization is central to systems theory: a linear dynamical system is controllable from a single input iff its state matrix is nonderogatory. The bridge lemma (equal-degree monic polynomials where one divides the other are equal) is a reusable algebraic tool. Completing the converse would give a fully verified characterization useful in both pure and applied linear algebra.",
     "openQuestions": [
-      "Prove nonderogatory_has_cyclic_vector: formalize rational canonical form decomposition in Lean 4",
-      "Prove the simultaneous cyclic vector theorem: M₁, ..., M_k have a common cyclic vector iff they generate a cyclic algebra"
+      "Prove nonderogatory_has_cyclic_vector: formalize the rational canonical form (invariant factor decomposition) for matrices over a field in Lean 4",
+      "Prove the simultaneous cyclic vector theorem: M\u2081, ..., M_k have a common cyclic vector iff they generate a cyclic algebra",
+      "Extend to linear maps over infinite-dimensional spaces: cyclic vector theory for compact operators",
+      "Prove the Krylov basis theorem: IsCyclicVector M v \u2194 IsCyclicVectorLI M v (the annihilator and linear independence formulations are equivalent)"
     ]
   },
   "leanFile": {
-    "namespace": "CayleyHamiltonMinpolyOQ04",
+    "namespace": "Nonderogatory",
     "lineCount": 316,
     "axiomCount": 1,
     "theoremCount": 8,
@@ -73,5 +77,48 @@
       "description": "Cayley-Hamilton theorem (M satisfies its own characteristic polynomial); this file studies when minpoly = charpoly"
     }
   ],
-  "sections": []
+  "sections": [
+    {
+      "title": "Part I: Definitions",
+      "startLine": 53,
+      "endLine": 88,
+      "summary": "IsCyclicVector M v (annihilator formulation): every polynomial of degree < n annihilating v must be 0. IsCyclicVectorLI M v (linear independence formulation): Krylov vectors {M^k v : k < n} are linearly independent. IsNonderogatory M: minpoly K M = M.charpoly. The annihilator formulation is used throughout proofs; IsCyclicVectorLI is included for reference. The docstring explains the K[X]-module perspective: IsCyclicVector says the annihilator ideal has no low-degree elements."
+    },
+    {
+      "title": "Part II: Bridge Lemma",
+      "startLine": 89,
+      "endLine": 133,
+      "summary": "minpoly_eq_charpoly_of_natDegree_eq: natDeg(minpoly) = natDeg(charpoly) \u21d2 minpoly = charpoly. Proof: write charpoly = minpoly * r via minpoly_dvd_charpoly; degree additivity forces natDeg(r) = 0; r is monic (leadingCoeff = 1 from charpoly monic and minpoly monic); monic degree-0 polynomial must be 1; so charpoly = minpoly * 1 = minpoly."
+    },
+    {
+      "title": "Part III: Forward Direction (Cyclic \u2192 Nonderogatory)",
+      "startLine": 134,
+      "endLine": 167,
+      "summary": "cyclic_implies_nonderogatory: applies bridge lemma after proving natDeg(minpoly) = n. Key steps: (1) natDeg(minpoly) \u2264 natDeg(charpoly) = n from minpoly | charpoly; (2) by contradiction assume natDeg(minpoly) < n; (3) minpoly.aeval gives (aeval M (minpoly K M)).mulVec v = 0; (4) IsCyclicVector forces minpoly = 0; (5) contradiction with Monic.ne_zero. Clean by_contra + omega proof."
+    },
+    {
+      "title": "Part IV: Backward Direction (Nonderogatory \u2192 Cyclic, Axiomatized)",
+      "startLine": 169,
+      "endLine": 206,
+      "summary": "Comment discusses three approaches: (1) PID structure theorem V \u2245 K[X]/(d\u2081) \u2295 ... \u2295 K[X]/(d_k), minpoly = charpoly forces k = 1; (2) Jordan Normal Form for alg. closed fields; (3) union of proper subspaces for infinite fields. axiom nonderogatory_has_cyclic_vector: IsNonderogatory M \u2192 \u2203 v, IsCyclicVector M v. Holds over ALL fields (finite included), ruling out Approach 3 for the general statement."
+    },
+    {
+      "title": "Part V: Full Characterization",
+      "startLine": 208,
+      "endLine": 223,
+      "summary": "nonderogatory_iff_cyclic_vector: full iff combining the proved forward direction and the axiomatized backward direction. nonderogatory_has_cyclic_vector provides the \u2192 direction, cyclic_implies_nonderogatory provides the \u2190 direction."
+    },
+    {
+      "title": "Part VI: Corollaries",
+      "startLine": 225,
+      "endLine": 253,
+      "summary": "minpoly_natDegree_eq_dim_of_cyclic: cyclic \u2192 natDeg(minpoly) = n (repackages intermediate step from forward direction). nonderogatory_algebra_dim: nonderogatory \u2192 natDeg(minpoly) = n (same via IsNonderogatory). nonderogatory_minpoly_dvd_charpoly: minpoly | charpoly for nonderogatory M (trivially, since they're equal)."
+    },
+    {
+      "title": "Part VII: Degree Characterization",
+      "startLine": 254,
+      "endLine": 284,
+      "summary": "nonderogatory_iff_natDegree_eq: IsNonderogatory M \u2194 natDeg(minpoly) = n. derogatory_iff_natDegree_lt: \u00acIsNonderogatory M \u2194 natDeg(minpoly) < n (requires Nontrivial hypothesis). Both proved cleanly by combining bridge lemma with charpoly_natDegree_eq_dim."
+    }
+  ]
 }


### PR DESCRIPTION
Enriches the Nonderogatory Matrices / Cyclic Vectors gallery entry.

## Changes
- **annotations.json**: 6 new annotations — module overview (context), cyclic/nonderogatory definitions (definition), bridge lemma insight, forward direction insight, backward direction infrastructure context, summary synthesis (context)
- **meta.json**: expanded historicalContext (Frobenius invariant factors, Krylov subspaces, Kalman controllability, Mathlib PID gap); keyInsights 4→6; 7 sections covering all 316 lines; openQuestions 2→4

## Validation
`pnpm annotations:build` passes with no errors for this entry.

🤖 Generated by enricher-2