### PR TITLE
Fix: add Aristotle companion for bounded-prime-gaps-oq-04-oq-01 (3 analytic NT targets)

### DIFF
--- a/proofs/Proofs/BoundedPrimeGapsOQ04OQ01Aristotle.lean
+++ b/proofs/Proofs/BoundedPrimeGapsOQ04OQ01Aristotle.lean
@@ -1,0 +1,54 @@
+/-
+  Aristotle targets for Bounded Prime Gaps OQ-04-OQ-01 (Pólya-Vinogradov)
+  Routine supporting lemmas for automated proof search.
+  See BoundedPrimeGapsOQ04OQ01.lean for the main formalization.
+
+  Criteria for inclusion:
+  - complete_character_sum_zero: Σ_{n<q} χ(n) = 0 for χ ≠ 1 (Mathlib API call)
+  - gaussSumNorm: |τ(χ)| = √q for primitive χ (Mathlib's gaussSum.norm_eq)
+  - geom_partial_sum_bound: geometric series ≤ 1/|sin(πθ)| (known bound)
+  - NOT cotangent_sum_bound (complex harmonic sum estimate)
+  - NOT polya_vinogradov (main theorem)
+
+  Note: complete_character_sum_zero is likely DirichletCharacter.sum_eq_zero
+  or similar in Mathlib. Gauss sum norm follows from IsPrimitive + gaussSum.norm.
+-/
+import Mathlib
+
+namespace BoundedPrimeGapsOQ04OQ01Aristotle
+
+open Complex Real Finset
+
+-- Routine: Complete character sum vanishes for non-principal character.
+-- For χ ≠ 1 and χ a Dirichlet character mod q, ∑_{n=0}^{q-1} χ(n) = 0.
+-- This is a standard result from character orthogonality in Mathlib:
+-- DirichletCharacter.sum_eq_zero or MulChar.sum_eq_zero_of_ne_one.
+theorem complete_character_sum_zero (q : ℕ) (hq : 1 ≤ q) (χ : DirichletCharacter ℂ q)
+    (hχ : χ ≠ 1) :
+    ∑ n in Finset.range q, (χ n : ℂ) = 0 := by
+  sorry
+
+-- Routine: The absolute value of the Gauss sum of a primitive character equals √q.
+-- |τ(χ)| = √q for χ primitive mod q.
+-- Uses: IsPrimitive.gaussSum_norm or norm_gaussSum_eq of Mathlib.
+-- Proof: τ(χ) · τ(χ̄) = χ(-1) · q (double sum identity), and |τ(χ̄)| = |τ(χ)|
+-- by conjugation symmetry, so |τ(χ)|² = q.
+theorem gaussSumNorm (q : ℕ) (hq : 2 ≤ q) (χ : DirichletCharacter ℂ q)
+    (hχ : χ ≠ 1) (hprim : χ.IsPrimitive) :
+    ‖∑ t in Finset.range q, χ t * exp (2 * ↑π * I * ↑(t : ℤ) / ↑q)‖ =
+    Real.sqrt (q : ℝ) := by
+  sorry
+
+-- Routine: Geometric series partial sum bound.
+-- |∑_{n=M+1}^{M+N} e^{2πiθn}| ≤ 1/|sin(πθ)| for θ ∉ ℤ.
+-- Proof: the sum = e^{2πiθ(M+1)} · (1 - e^{2πiθN}) / (1 - e^{2πiθ})
+-- so |sum| ≤ 2 / |1 - e^{2πiθ}| = 2 / (2|sin(πθ)|) = 1/|sin(πθ)|
+-- using |1 - e^{iα}| = 2|sin(α/2)|.
+theorem geom_partial_sum_bound (θ : ℝ) (hθ : ∀ k : ℤ, θ ≠ ↑k)
+    (M N : ℕ) :
+    ‖∑ n in Finset.Icc (M + 1) (M + N),
+      exp (2 * ↑π * I * ↑θ * ↑(n : ℤ))‖ ≤
+    1 / |Real.sin (π * θ)| := by
+  sorry
+
+end BoundedPrimeGapsOQ04OQ01Aristotle


### PR DESCRIPTION
## Summary

- Adds `BoundedPrimeGapsOQ04OQ01Aristotle.lean` with 3 analytic number theory targets for Aristotle
- Targets are routine supporting lemmas for the Pólya-Vinogradov inequality:
  - `complete_character_sum_zero`: Σ χ(n) = 0 for non-principal Dirichlet character (likely `DirichletCharacter.sum_eq_zero` in Mathlib)
  - `gaussSumNorm`: |τ(χ)| = √q for primitive χ (via Mathlib `gaussSum.norm`)
  - `geom_partial_sum_bound`: geometric series ≤ 1/|sin(πθ)| (classical ≤2/|1-e^{iα}| bound)
- Excludes the main `polya_vinogradov` theorem (too complex for automated search) and `cotangent_sum_bound` (requires harmonic sum analysis)

## Test plan
- [ ] File compiles with `import Mathlib` (modulo sorries)
- [ ] `complete_character_sum_zero` is recognized by Aristotle as a Mathlib API call

🤖 Generated with [Claude Code](https://claude.com/claude-code)