### PR TITLE
Fix: add Aristotle companion for erdos-922

### DIFF
--- a/proofs/Proofs/Erdos922Aristotle.lean
+++ b/proofs/Proofs/Erdos922Aristotle.lean
@@ -1,0 +1,35 @@
+/-
+  Aristotle targets for Erdős Problem #922 (Folkman's Chromatic Number Bound)
+  Routine supporting lemmas for automated proof search.
+  See Erdos922Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - bipartite_chromatic_le_two: IsBipartite → chromaticNumber ≤ 2 (Mathlib)
+  - ratio_ge_of_two_card_bound: rational arithmetic from Folkman density bound
+  - NOT chromaticNumber' definition sorry (definition sorry, line 65)
+  - NOT folkman_zero_implies_bipartite (complex structural argument)
+  - NOT folkman_theorem (deep result, axiomatized)
+-/
+import Mathlib
+
+namespace Erdos922Aristotle
+
+open SimpleGraph
+
+-- Routine: A bipartite graph has chromatic number ≤ 2.
+-- Bipartite means Colorable 2, and Colorable n → chromaticNumber ≤ n.
+theorem bipartite_chromatic_le_two {V : Type*} [Fintype V]
+    (G : SimpleGraph V) [DecidableRel G.Adj] (hbip : G.IsBipartite) :
+    G.chromaticNumber ≤ 2 := by
+  sorry
+
+-- Routine: Rational arithmetic for the Folkman density bound.
+-- Given 2 * S ≥ W - k in ℕ (natural subtraction) and W > 0,
+-- show (S : ℚ) / W ≥ ((W : ℚ) - k) / (2 * W).
+-- Key: cast the hypothesis to ℚ and use field_simp + linarith.
+theorem ratio_ge_of_two_card_bound (S W k : ℕ) (hW : 0 < W)
+    (h : 2 * S ≥ W - k) :
+    (S : ℚ) / W ≥ ((W : ℚ) - k) / (2 * W) := by
+  sorry
+
+end Erdos922Aristotle


### PR DESCRIPTION
## Fix

Adds `Erdos922Aristotle.lean` with 2 routine supporting lemmas for Aristotle automated proof search on Folkman's chromatic number bound (Erdős Problem #922).

## Targets

- `bipartite_chromatic_le_two`: `G.IsBipartite → G.chromaticNumber ≤ 2`
  Uses Mathlib's `SimpleGraph.chromaticNumber` directly. Bipartite implies `Colorable 2`, and `Colorable n` implies `chromaticNumber ≤ n`.

- `ratio_ge_of_two_card_bound`: `2 * S ≥ W - k → (S:ℚ) / W ≥ ((W:ℚ) - k) / (2 * W)`
  Rational arithmetic from the Folkman density bound. Provable via `field_simp` + `linarith` after casting to ℚ.

## Excluded (not Aristotle-suitable)

- `chromaticNumber'` definition sorry (line 65) — definition sorry
- `folkman_zero_implies_bipartite` — complex structural argument
- `folkman_theorem` — deep result (axiomatized)

---
Automated fix by lean-mechanic agent.