### PR TITLE
Fix: add Aristotle companion for erdos-334 (balog exponent bound)

### DIFF
--- a/proofs/Proofs/Erdos334Aristotle.lean
+++ b/proofs/Proofs/Erdos334Aristotle.lean
@@ -1,0 +1,48 @@
+/-
+  Aristotle targets for Erdős Problem #334 (Smooth Number Representation)
+  Routine supporting lemmas for automated proof search.
+  See Erdos334Problem.lean for the main formalization.
+
+  Targets:
+  1. balog_exponent_pos — 0 < 4/(9√e) (positivity)
+  2. sqrt_exp_one_pos — 0 < √(exp 1) (positivity)
+  3. nine_sqrt_exp_pos — 0 < 9 * √(exp 1) (positivity)
+  4. balog_exponent_value — 4/(9√e) < 0.27 (numerical bound using exp 1 > 2.71)
+-/
+import Mathlib
+
+namespace Erdos334Aristotle
+
+open Real
+
+noncomputable def balogExponent : ℝ := 4 / (9 * Real.sqrt (Real.exp 1))
+
+/-- √(exp 1) is positive. -/
+theorem sqrt_exp_one_pos : (0 : ℝ) < Real.sqrt (Real.exp 1) := by
+  sorry
+
+/-- 9 * √(exp 1) is positive. -/
+theorem nine_sqrt_exp_pos : (0 : ℝ) < 9 * Real.sqrt (Real.exp 1) := by
+  sorry
+
+/-- The Balog exponent 4/(9√e) is positive. -/
+theorem balog_exponent_pos : (0 : ℝ) < balogExponent := by
+  sorry
+
+/-- exp 1 > 2.71 (a partial sum lower bound for e). -/
+theorem exp_one_gt_271 : (2.71 : ℝ) < Real.exp 1 := by
+  sorry
+
+/-- exp 1 > (1.646)^2, enabling the sqrt lower bound. -/
+theorem exp_one_gt_sq_1646 : (1.646 : ℝ) ^ 2 < Real.exp 1 := by
+  sorry
+
+/-- √(exp 1) > 1.646. -/
+theorem sqrt_exp_one_gt_1646 : (1.646 : ℝ) < Real.sqrt (Real.exp 1) := by
+  sorry
+
+/-- The Balog exponent satisfies 4/(9√e) < 0.27. -/
+theorem balog_exponent_value : balogExponent < 0.27 := by
+  sorry
+
+end Erdos334Aristotle


### PR DESCRIPTION
## Fix

Add Aristotle companion file for Erdős Problem #334 (Smooth Number Representation).

## Evidence

**Targets**: `balogExponent < 0.27` — the numerical bound `4/(9√e) ≈ 0.2695 < 0.27`

**Before**: No companion file; `balog_exponent_value` in the main file has an unproved sorry.

**After**: `proofs/Proofs/Erdos334Aristotle.lean` provides a ladder of routine targets:
- `sqrt_exp_one_pos` — positivity
- `nine_sqrt_exp_pos` — positivity  
- `balog_exponent_pos` — positivity
- `exp_one_gt_271` — Taylor partial-sum lower bound for e
- `exp_one_gt_sq_1646` — (1.646)² < e
- `sqrt_exp_one_gt_1646` — √e > 1.646
- `balog_exponent_value` — 4/(9√e) < 0.27 (main target)

The positivity lemmas and Taylor bound lemmas are strong Aristotle candidates. The numerical chain lets Aristotle attack the main bound step-by-step.

---
Automated fix by lean-mechanic agent.