### PR TITLE
Fix: add Aristotle companion for erdos-961 (sublinearity helpers)

### DIFF
--- a/proofs/Proofs/Erdos961Aristotle.lean
+++ b/proofs/Proofs/Erdos961Aristotle.lean
@@ -1,0 +1,39 @@
+/-
+  Aristotle targets for Erdős Problem #961 (Smooth Numbers in Consecutive Intervals)
+  Routine supporting lemmas for automated proof search.
+  See Erdos961Problem.lean for the main formalization.
+
+  Targets:
+  1. f_nonneg — 0 ≤ (f k : ℝ) (cast of ℕ, positivity)
+  2. log_atTop_tendsto — Real.log k → ∞ (Mathlib has Real.tendsto_log_atTop)
+  3. three_div_log_tendsto_zero — 3 / log k → 0 as k → ∞
+  4. three_k_div_log_isLittleO — (3k / log k) = o(k) as k → ∞
+  5. f_sublinear — f(k) = o(k) from the Erdős 1955 bound
+
+  Key axiom available: erdos_1955_bound : ∀ᶠ k in atTop, (f k : ℝ) < 3 * k / log k
+-/
+import Mathlib
+
+namespace Erdos961Aristotle
+
+open Filter Real Asymptotics
+
+/-- f(k) as a real is nonneg (cast of ℕ). -/
+theorem f_nonneg (k : ℕ) (f : ℕ → ℕ) : (0 : ℝ) ≤ (f k : ℝ) := by
+  sorry
+
+/-- Real.log is unbounded above. -/
+theorem log_tendsto_atTop : Filter.Tendsto Real.log Filter.atTop Filter.atTop := by
+  sorry
+
+/-- 3 / log k tends to 0. -/
+theorem three_div_log_tendsto_zero :
+    Filter.Tendsto (fun k : ℕ => (3 : ℝ) / Real.log k) Filter.atTop (nhds 0) := by
+  sorry
+
+/-- 3 * k / log k is o(k). -/
+theorem three_k_div_log_isLittleO :
+    (fun k : ℕ => (3 : ℝ) * k / Real.log k) =o[Filter.atTop] (fun k : ℕ => (k : ℝ)) := by
+  sorry
+
+end Erdos961Aristotle


### PR DESCRIPTION
## Fix

Add Aristotle companion file for Erdős Problem #961 (Smooth Numbers in Consecutive Intervals).

## Evidence

**Targets**: Helper lemmas supporting the `f_sublinear` sorry in the main file.

**Before**: No companion file; `f_sublinear` in the main file has an unproved sorry. The proof requires knowing that `3k/log(k) = o(k)` — a general analytic fact not immediately obvious from `erdos_1955_bound` alone.

**After**: `proofs/Proofs/Erdos961Aristotle.lean` provides:
- `f_nonneg` — cast of ℕ is nonneg (positivity, trivial)
- `log_tendsto_atTop` — `Real.log → ∞` (Mathlib: `Real.tendsto_log_atTop`)
- `three_div_log_tendsto_zero` — `3/log k → 0` (from log unboundedness)
- `three_k_div_log_isLittleO` — `(3k/log k) = o(k)` as k → ∞ (main building block)

These are the building blocks for proving `f(k) = o(k)` from `erdos_1955_bound`.

---
Automated fix by lean-mechanic agent.