### PR TITLE
Fix: add Aristotle companion for erdos-492 (ratio limit tendsto)

### DIFF
--- a/proofs/Proofs/Erdos492Aristotle.lean
+++ b/proofs/Proofs/Erdos492Aristotle.lean
@@ -1,0 +1,51 @@
+/-
+  Aristotle targets for Erdős Problem #492 (Uniform Distribution Relative to Fixed Sequence)
+  Routine supporting lemmas for automated proof search.
+  See Erdos492Problem.lean for the main formalization.
+
+  Targets:
+  1. naturals_ratio_limit — (n+2)/(n+1) → 1 as n → ∞
+  2. one_add_one_div_tendsto_one — 1 + 1/(n+1) → 1 as n → ∞
+  3. nat_succ_div_self_tendsto_one — (n+1)/n → 1 as n → ∞
+  4. one_div_succ_tendsto_zero — 1/(n+1) → 0 as n → ∞
+
+  Context: These support the ratioLimit field of `naturalsSeq : UnityRatioSeq`
+  which requires Filter.Tendsto (fun n => seq(n+1)/seq(n)) atTop (nhds 1)
+  where seq(n) = n+1, giving the ratio (n+2)/(n+1) → 1.
+-/
+import Mathlib
+
+namespace Erdos492Aristotle
+
+open Filter Real Topology
+
+/-- 1/(n+1) → 0 as n → ∞. -/
+theorem one_div_succ_tendsto_zero :
+    Filter.Tendsto (fun n : ℕ => (1 : ℝ) / (n + 1)) Filter.atTop (nhds 0) := by
+  sorry
+
+/-- 1 + 1/(n+1) → 1 as n → ∞. -/
+theorem one_add_one_div_tendsto_one :
+    Filter.Tendsto (fun n : ℕ => 1 + (1 : ℝ) / (n + 1)) Filter.atTop (nhds 1) := by
+  sorry
+
+/-- (n+2)/(n+1) → 1 as n → ∞.
+    This is the key limit for naturalsSeq.ratioLimit. -/
+theorem naturals_ratio_limit :
+    Filter.Tendsto (fun n : ℕ => ((n + 2 : ℕ) : ℝ) / ((n + 1 : ℕ) : ℝ))
+      Filter.atTop (nhds 1) := by
+  sorry
+
+/-- (n+1)/n → 1 as n → ∞ (alternative form). -/
+theorem nat_succ_div_self_tendsto_one :
+    Filter.Tendsto (fun n : ℕ => ((n + 1 : ℕ) : ℝ) / (n : ℝ))
+      Filter.atTop (nhds 1) := by
+  sorry
+
+/-- For any a > 0: (n+a)/n → 1 as n → ∞. -/
+theorem nat_add_div_tendsto_one (a : ℝ) (ha : 0 < a) :
+    Filter.Tendsto (fun n : ℕ => ((n : ℝ) + a) / (n : ℝ))
+      Filter.atTop (nhds 1) := by
+  sorry
+
+end Erdos492Aristotle


### PR DESCRIPTION
## Fix

Add Aristotle companion file for Erdős Problem #492 (Uniform Distribution Relative to Fixed Sequence).

## Evidence

**Target**: The `naturalsSeq.ratioLimit` sorry in the main file requires proving `(n+2)/(n+1) → 1`.

**Before**: No companion file; `naturalsSeq : UnityRatioSeq` definition has a `sorry` in its `ratioLimit` field.

**After**: `proofs/Proofs/Erdos492Aristotle.lean` provides a ladder of standalone tendsto targets:
- `one_div_succ_tendsto_zero` — 1/(n+1) → 0 (base case)
- `one_add_one_div_tendsto_one` — 1 + 1/(n+1) → 1 (additive form)
- `naturals_ratio_limit` — (n+2)/(n+1) → 1 (main target)
- `nat_succ_div_self_tendsto_one` — (n+1)/n → 1 (related form)
- `nat_add_div_tendsto_one` — generalization: (n+a)/n → 1

These are standard Filter.Tendsto facts that Aristotle can approach via `tendsto_natCast_atTop_nhds`, `Filter.Tendsto.div`, and arithmetic reasoning.

---
Automated fix by lean-mechanic agent.