### PR TITLE
Fix: add Aristotle companion for erdos-607 (geometric/cardinality lemmas)

### DIFF
--- a/proofs/Proofs/Stubs/Erdos607Aristotle.lean
+++ b/proofs/Proofs/Stubs/Erdos607Aristotle.lean
@@ -1,0 +1,90 @@
+/-
+  Aristotle targets for Erdős Problem #607
+  Routine supporting lemmas for automated proof search.
+  See Erdos607Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - first_point_on_line: t=0 shows point1 lies on the line through it (simp)
+  - second_point_on_line: t=1 shows point2 lies on the line through it (ring)
+  - incidenceCount_le_n: filter over Fin n has ≤ n elements (Finset.card_filter_le)
+  - fin_univ_card: |univ (Fin n)| = n (Finset.card_univ / Fintype.card_fin)
+  - filter_card_le_univ: filtered Finset ≤ original (Finset.card_filter_le)
+  - sqrt_nat_nonneg: Real.sqrt(n) ≥ 0 (Real.sqrt_nonneg)
+  - exp_mul_sqrt_pos: exp(c * sqrt n) > 0 (Real.exp_pos)
+  - NOT szemeredi_trotter_607 (deep Szemerédi-Trotter — not a routine lemma)
+  - NOT lower_bound_construction (complex construction — not a routine lemma)
+  - NOT sorries in def-positions (incidenceSignature, F, generalPositionConfig, gridConfig)
+  - NOT statements with sorry in body (lines_at_most_binomial, incidence_bound_constrains_signature)
+-/
+import Mathlib
+
+namespace Erdos607Aristotle
+
+open Finset Function
+
+/-- A point in ℝ² -/
+abbrev Point := EuclideanSpace ℝ (Fin 2)
+
+/-- A line in ℝ² determined by two distinct points -/
+structure Line607 where
+  point1 : Point
+  point2 : Point
+  ne : point1 ≠ point2
+
+/-- A point lies on a line iff it is collinear with the defining points -/
+def Line607.contains (l : Line607) (p : Point) : Prop :=
+  ∃ t : ℝ, p = l.point1 + t • (l.point2 - l.point1)
+
+/-- Two points determine a line -/
+def lineThroughPair607 (p q : Point) (h : p ≠ q) : Line607 :=
+  ⟨p, q, h⟩
+
+/-- A point configuration: n distinct points in ℝ² -/
+structure PointConfig607 (n : ℕ) where
+  points : Fin n → Point
+  distinct : Function.Injective points
+
+/-- Count of points on a line -/
+noncomputable def incidenceCount607 {n : ℕ} (config : PointConfig607 n) (l : Line607) : ℕ :=
+  (Finset.univ.filter fun i => l.contains (config.points i)).card
+
+-- Routine: The first endpoint lies on the line through two points.
+-- Using t = 0: point1 = point1 + 0 • (point2 - point1) = point1.
+theorem first_point_on_line (p q : Point) (h : p ≠ q) :
+    (lineThroughPair607 p q h).contains p := by
+  sorry
+
+-- Routine: The second endpoint lies on the line through two points.
+-- Using t = 1: point2 = point1 + 1 • (point2 - point1) = point1 + (point2 - point1) = point2.
+theorem second_point_on_line (p q : Point) (h : p ≠ q) :
+    (lineThroughPair607 p q h).contains q := by
+  sorry
+
+-- Routine: The incidence count for any line is at most n.
+-- The filter is over Finset.univ : Finset (Fin n), which has n elements.
+theorem incidenceCount607_le_n {n : ℕ} (config : PointConfig607 n) (l : Line607) :
+    incidenceCount607 config l ≤ n := by
+  sorry
+
+-- Routine: Finset.univ for Fin n has exactly n elements.
+-- Finset.card_univ + Fintype.card_fin.
+theorem fin_univ_card (n : ℕ) : (Finset.univ : Finset (Fin n)).card = n := by
+  sorry
+
+-- Routine: A filtered Finset has at most as many elements as the original.
+-- Finset.card_filter_le.
+theorem filter_card_le_univ {n : ℕ} (p : Fin n → Prop) [DecidablePred p] :
+    (Finset.univ.filter p).card ≤ (Finset.univ : Finset (Fin n)).card := by
+  sorry
+
+-- Routine: Real.sqrt of a nonneg real is nonneg.
+-- Real.sqrt_nonneg.
+theorem sqrt_nat_nonneg (n : ℕ) : 0 ≤ Real.sqrt (n : ℝ) := by
+  sorry
+
+-- Routine: exp(c * sqrt n) is strictly positive for any real c and nat n.
+-- Real.exp_pos.
+theorem exp_mul_sqrt_pos (c : ℝ) (n : ℕ) : 0 < Real.exp (c * Real.sqrt n) := by
+  sorry
+
+end Erdos607Aristotle


### PR DESCRIPTION
## Fix

Add Aristotle companion file for Erdős Problem #607 (Incidence Signatures of Point Configurations).

## Evidence

**Before**: `erdos-607` had 20 sorries and no Aristotle companion file. Routine supporting lemmas were unreachable by automated proof search.

**After**: `proofs/Proofs/Stubs/Erdos607Aristotle.lean` provides 7 routine targets:
- `first_point_on_line` / `second_point_on_line` — endpoint-on-line via `t=0` and `t=1`
- `incidenceCount607_le_n` — filter cardinality bound (≤ n elements over Fin n)
- `fin_univ_card` / `filter_card_le_univ` — Finset cardinality facts
- `sqrt_nat_nonneg` / `exp_mul_sqrt_pos` — `Real.sqrt`/`Real.exp` routine facts

**Excluded** (not suitable for Aristotle):
- `szemeredi_trotter_607` — deep Szemerédi-Trotter result
- `lower_bound_construction` — complex construction
- Def-sorries (`incidenceSignature`, `F`, `generalPositionConfig`, `gridConfig`)
- Statements with sorry in the body (`lines_at_most_binomial`, `incidence_bound_constrains_signature`)

## Pre-submission checklist
- [x] No `def ... := sorry`
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections

---
Automated fix by lean-mechanic agent.