### PR TITLE
Enrich Irrationality of ∛2: annotations, sections, historicalContext

### DIFF
--- a/src/data/proofs/cube-root-2-irrational/annotations.json
+++ b/src/data/proofs/cube-root-2-irrational/annotations.json
@@ -1,1 +1,98 @@
-[]
+[
+  {
+    "id": "ann-imports",
+    "proofId": "cube-root-2-irrational",
+    "range": { "startLine": 1, "endLine": 9 },
+    "type": "context",
+    "title": "Imports and Proof Header",
+    "content": "The proof imports two key Mathlib modules: `Mathlib.Data.Real.Irrational` provides the `Irrational` predicate and the central lemma `irrational_nrt_of_notint_nrt`, while `Mathlib.Analysis.SpecialFunctions.Pow.Real` supplies the real power function `Real.rpow` along with its composition laws (`rpow_mul`, `rpow_natCast`).",
+    "mathContext": "The `Irrational` predicate in Mathlib is defined as $\\neg \\exists r : \\mathbb{Q},\\ (r : \\mathbb{R}) = x$, i.e., $x$ has no rational representation.",
+    "significance": "context",
+    "relatedConcepts": ["Irrational numbers", "Real.rpow", "Mathlib.Data.Real.Irrational"],
+    "prerequisites": ["Lean 4 import system", "Mathlib library structure"]
+  },
+  {
+    "id": "ann-strategy",
+    "proofId": "cube-root-2-irrational",
+    "range": { "startLine": 11, "endLine": 25 },
+    "type": "concept",
+    "title": "Proof Strategy: Reducibility to Perfect Cubes",
+    "content": "The module docstring outlines the three-step strategy: (1) establish that $(2^{1/3})^3 = 2$, (2) show no integer $n$ satisfies $n^3 = 2$, and (3) conclude that $2^{1/3}$ is not an integer, hence irrational by `irrational_nrt_of_notint_nrt`. This pattern generalises: $\\sqrt[n]{m}$ is irrational whenever $m$ is not a perfect $n$-th power of an integer.",
+    "mathContext": "The key Mathlib lemma is: if $x^n = m$ for $m : \\mathbb{Z}$, $x$ is not an integer, and $n > 0$, then $x$ is irrational. Formally: `irrational_nrt_of_notint_nrt : ∀ (n : ℕ) (m : ℤ), x ^ n = m → ¬IsInt x → 0 < n → Irrational x`.",
+    "significance": "key",
+    "relatedConcepts": ["irrational_nrt_of_notint_nrt", "perfect powers", "irrationality criterion"],
+    "prerequisites": ["definition of irrational numbers", "integer perfect powers"]
+  },
+  {
+    "id": "ann-cbrt2-def",
+    "proofId": "cube-root-2-irrational",
+    "range": { "startLine": 27, "endLine": 30 },
+    "type": "definition",
+    "title": "Definition of cbrt2 via Real.rpow",
+    "content": "The cube root of 2 is defined as `(2 : ℝ) ^ (1/3 : ℝ)` using `Real.rpow`. The `noncomputable` keyword is required because `Real.rpow` is defined analytically (via the exponential function) and does not have a computable implementation. Working with `rpow` rather than a native `cbrt` function means the proof can exploit Mathlib's established algebraic laws for real powers.",
+    "mathContext": "In Mathlib, `Real.rpow x y = Real.exp (Real.log x * y)` for $x > 0$. Thus $2^{1/3} = e^{(\\ln 2)/3}$, the unique positive real whose cube is 2.",
+    "significance": "key",
+    "relatedConcepts": ["Real.rpow", "noncomputable definitions", "cube root"],
+    "prerequisites": ["real number system", "exponential and logarithm functions"]
+  },
+  {
+    "id": "ann-cbrt2-cubed",
+    "proofId": "cube-root-2-irrational",
+    "range": { "startLine": 32, "endLine": 37 },
+    "type": "technique",
+    "title": "cbrt2_cubed: Proving (2^{1/3})^3 = 2 via rpow Composition",
+    "content": "This lemma establishes the fundamental property of the cube root: its cube equals 2. The proof uses two `rpow` rewriting steps. First, `Real.rpow_natCast` converts the natural-number exponent `3` to a real-number power, allowing both sides to live in `Real.rpow`. Then `Real.rpow_mul` combines the exponents: $(2^{1/3})^3 = 2^{(1/3) \\cdot 3}$. Finally, `norm_num` verifies that $(1/3) \\cdot 3 = 1$ and $2^1 = 2$.",
+    "mathContext": "The chain of equalities: $\\left(2^{1/3}\\right)^3 = 2^{(1/3) \\cdot 3} = 2^1 = 2$, using the law $x^a \\cdot x^b = x^{a+b}$ and specifically $(x^a)^b = x^{ab}$ (`Real.rpow_mul`) with the non-negativity hypothesis $0 \\leq 2$.",
+    "significance": "key",
+    "relatedConcepts": ["Real.rpow_mul", "Real.rpow_natCast", "exponent laws"],
+    "prerequisites": ["Real.rpow algebra", "norm_num tactic"]
+  },
+  {
+    "id": "ann-two-not-perfect-cube",
+    "proofId": "cube-root-2-irrational",
+    "range": { "startLine": 39, "endLine": 66 },
+    "type": "concept",
+    "title": "two_not_perfect_cube: Integer Bounds via Case Analysis",
+    "content": "This is the number-theoretic heart of the proof. It shows $\\nexists n : \\mathbb{Z},\\ n^3 = 2$ by exhaustive case analysis on integer ranges. If $n \\leq 0$, then $n^3 = n \\cdot n \\cdot n \\leq 0 < 2$ (non-positive numbers cube to non-positive values). If $n \\geq 2$, then $n^3 \\geq 8 > 2$ (the cubic function grows quickly). This forces $n = 1$ (via `omega`), but $1^3 = 1 \\neq 2$ (by `norm_num`). The arithmetic inequalities are dispatched by `nlinarith`, which handles nonlinear integer arithmetic.",
+    "mathContext": "The argument uses that the function $f(n) = n^3$ satisfies: $f(n) \\leq 0$ for $n \\leq 0$, $f(1) = 1$, and $f(n) \\geq 8$ for $n \\geq 2$. Since $2$ falls in the gap $(1, 8)$ and is not 0, no integer cube equals 2. This is a special case of the general fact that $m$ is a perfect $n$-th power iff it appears in the sequence $0^n, 1^n, 2^n, \\ldots$",
+    "significance": "key",
+    "relatedConcepts": ["perfect cubes", "nlinarith", "integer case analysis", "omega tactic"],
+    "prerequisites": ["integer arithmetic", "nlinarith for nonlinear arithmetic", "omega for linear integer arithmetic"]
+  },
+  {
+    "id": "ann-cbrt2-not-int",
+    "proofId": "cube-root-2-irrational",
+    "range": { "startLine": 68, "endLine": 75 },
+    "type": "insight",
+    "title": "cbrt2_not_int: Bridge from ℤ to ℝ",
+    "content": "This bridge lemma connects the number-theoretic result `two_not_perfect_cube` (about integers) to the real-analytic definition of `cbrt2`. If $\\sqrt[3]{2} = n$ for some integer $n$, then cubing both sides gives $n^3 = 2$, contradicting `two_not_perfect_cube`. The key step is `exact_mod_cast`, which handles the coercion from `ℝ` (where `cbrt2 ^ 3 = 2` holds) to `ℤ` (where `n ^ 3 = 2` is needed), leveraging the fact that the integer $n$ casts faithfully to the real number $n$.",
+    "mathContext": "The cast `exact_mod_cast` resolves the type mismatch between `cbrt2 ^ 3 = (2 : ℝ)` and `n ^ 3 = (2 : ℤ)` by using injectivity of the embedding $\\mathbb{Z} \\hookrightarrow \\mathbb{R}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["exact_mod_cast", "integer-to-real coercion", "perfect integer squares"],
+    "prerequisites": ["type coercions in Lean 4", "Lean cast tactics"]
+  },
+  {
+    "id": "ann-irrational-cbrt2",
+    "proofId": "cube-root-2-irrational",
+    "range": { "startLine": 77, "endLine": 85 },
+    "type": "insight",
+    "title": "irrational_cbrt2: Applying the Mathlib Irrationality Machine",
+    "content": "The main theorem assembles the three sub-results using `irrational_nrt_of_notint_nrt 3 2`. The three proof obligations are: (1) `cbrt2 ^ 3 = 2` (from `cbrt2_cubed`, cast to integer type), (2) `cbrt2` is not an integer (from `cbrt2_not_int`), and (3) `3 > 0` (trivial by `norm_num`). This application of the general Mathlib lemma is the payoff: all the hard work was in establishing that 2 is not a perfect cube.",
+    "mathContext": "The Mathlib lemma `irrational_nrt_of_notint_nrt` encapsulates the classical argument: a real number $x$ satisfying $x^n \\in \\mathbb{Z}$ and $x \\notin \\mathbb{Z}$ must be irrational, because any rational root $p/q$ (in lowest terms) of $X^n - m$ with $m \\in \\mathbb{Z}$ must satisfy $q \\mid 1$, hence $x \\in \\mathbb{Z}$ — a contradiction.",
+    "significance": "key",
+    "relatedConcepts": ["irrational_nrt_of_notint_nrt", "rational root theorem", "Irrational predicate"],
+    "prerequisites": ["rational root theorem", "Mathlib.Data.Real.Irrational API"]
+  },
+  {
+    "id": "ann-alias",
+    "proofId": "cube-root-2-irrational",
+    "range": { "startLine": 87, "endLine": 91 },
+    "type": "context",
+    "title": "Alias for Cross-File Use",
+    "content": "The alias `irrational_two_pow_one_third` exposes the same result under the name used by dependent files such as `GelfondSchneider.lean`. This is a common Lean pattern: state the main result in a canonical form, then export named aliases matching the form expected by callers. The alias is definitionally equal to `irrational_cbrt2` with no proof overhead.",
+    "mathContext": "Both `irrational_cbrt2` and `irrational_two_pow_one_third` assert $\\text{Irrational}(2^{1/3})$. Having both names allows callers to use whichever form matches their context without unfolding definitions.",
+    "significance": "technical",
+    "relatedConcepts": ["Lean 4 aliases", "theorem naming conventions", "Gelfond-Schneider theorem"],
+    "prerequisites": ["Lean 4 definitional equality"]
+  }
+]

--- a/src/data/proofs/cube-root-2-irrational/meta.json
+++ b/src/data/proofs/cube-root-2-irrational/meta.json
@@ -30,7 +30,7 @@
     ]
   },
   "overview": {
-    "historicalContext": "The irrationality of ∛2 is a classical result, analogous to the famous irrationality of √2 attributed to the Pythagoreans. The proof strategy follows the same pattern: show that 2 is not a perfect cube, hence 2^(1/3) cannot be rational. Mathlib provides irrational_nrt_of_notint_nrt as a general lemma: if x^n = m (an integer) and x is not an integer, then x is irrational.",
+    "historicalContext": "The irrationality of ∛2 has roots stretching back to ancient Greece. The Pythagoreans' discovery of the irrationality of √2 (circa 5th century BC) was philosophically shocking, demonstrating that ratios of integers cannot capture all geometric magnitudes. The irrationality of ∛2 is less ancient in its explicit formulation but arises naturally in classical geometry: doubling the cube — the Delian problem of constructing a cube with twice the volume — requires a length of ∛2, and the impossibility of this construction by compass and straightedge (proved only in the 19th century using Galois theory) hinges on ∛2 being a degree-3 algebraic number. Medieval and Renaissance mathematicians worked with cube roots extensively in solving cubic equations, but a systematic theory of irrationals had to await Dedekind and Cantor in the 19th century. The modern proof via `irrational_nrt_of_notint_nrt` encapsulates the classical argument: any rational root $p/q$ of $X^3 - 2$ in lowest terms satisfies $q \\mid 1$ (rational root theorem), so the root would be an integer — but no integer cubes to 2.",
     "problemStatement": "Prove that 2^(1/3) : ℝ is irrational, i.e., ¬∃ r : ℚ, (r : ℝ) = 2^(1/3).",
     "text": "The proof proceeds in three steps. First, cbrt2_cubed: (2^(1/3))^3 = 2, proved using Real.rpow_natCast and Real.rpow_mul. Second, two_not_perfect_cube: no integer n satisfies n³ = 2 — if n ≤ 0 then n³ ≤ 0 < 2; if n ≥ 2 then n³ ≥ 8 > 2; so n = 1 but 1³ = 1 ≠ 2. Third, cbrt2_not_int: ∛2 is not an integer. Finally, irrational_cbrt2 applies irrational_nrt_of_notint_nrt 3 2 with these three facts.",
     "proofStrategy": "two_not_perfect_cube: case split n ≤ 0 (n³ ≤ 0 by nlinarith), n ≥ 2 (n³ ≥ 8 by nlinarith), then n = 1 by omega and norm_num for 1³ ≠ 2. cbrt2_cubed: rpow composition with Real.rpow_mul and the equation (1/3)*3 = 1.",
@@ -38,7 +38,8 @@
       "irrational_nrt_of_notint_nrt is a general Mathlib lemma: x^n = m ∧ ¬IsInt(x) → Irrational(x)",
       "The key number theory fact: integers are either ≤ 1 or ≥ 2 (no gap where n³ = 2)",
       "rpow composition: (2^(1/3))^3 = 2^((1/3)*3) = 2^1 = 2",
-      "The argument is essentially the same as for ∛3 (see companion file)"
+      "The argument is essentially the same as for ∛3 (see companion file)",
+      "The rational root theorem underpins the irrationality machine: a rational p/q root of x^n - m must have q dividing 1 and p dividing m, so it would be an integer — the reduction to 'is m a perfect n-th power?' is both necessary and sufficient"
     ],
     "prerequisites": [
       "Real.rpow: Real.rpow_mul, Real.rpow_natCast",
@@ -48,10 +49,11 @@
   },
   "conclusion": {
     "summary": "∛2 is irrational, proved by showing 2 is not a perfect cube and applying Mathlib's irrational_nrt_of_notint_nrt. 5 theorems, 0 axioms, 91 lines.",
-    "implications": "This is the n=3 case of the general theorem: n√m is irrational whenever m is not a perfect n-th power. Mathlib's irrational_nrt_of_notint_nrt makes such proofs very clean. The companion file CubeRoot3Irrational follows the same pattern for ∛3.",
+    "implications": "This is the n=3 case of the general theorem: $\\sqrt[n]{m}$ is irrational whenever $m$ is not a perfect $n$-th power of an integer. Mathlib's `irrational_nrt_of_notint_nrt` encapsulates the rational root theorem and makes all such proofs one-line applications once the perfect-power check is done. The result also plays a role in the theory of algebraic numbers: $\\sqrt[3]{2}$ is a degree-3 algebraic integer, not a degree-1 one (i.e., not rational), which connects to the classical impossibility of doubling the cube by compass and straightedge. The companion file `CubeRoot3Irrational` follows the identical pattern for $\\sqrt[3]{3}$, and both results are used as lemmas in Gelfond-Schneider-related formalizations.",
     "openQuestions": [
       "Generalize: n√m is irrational iff m is not a perfect n-th power (general theorem)",
-      "Prove the Gelfond-Schneider theorem: 2^√2 is transcendental (much harder)"
+      "Prove the Gelfond-Schneider theorem: 2^√2 is transcendental (much harder)",
+      "Formalize the degree bound: any n-th root of a non-perfect-power is a degree-n algebraic number, which would require Galois theory machinery in Mathlib"
     ]
   },
   "leanFile": {
@@ -73,5 +75,62 @@
       "description": "Irrationality of √2+√3 uses a different technique (squaring and reducing to √6 irrational)"
     }
   ],
-  "sections": []
+  "sections": [
+    {
+      "id": "sec-imports",
+      "title": "Imports",
+      "startLine": 1,
+      "endLine": 9,
+      "summary": "Imports Mathlib's irrationality library and real power functions needed for the proof."
+    },
+    {
+      "id": "sec-strategy",
+      "title": "Module Documentation and Strategy",
+      "startLine": 11,
+      "endLine": 25,
+      "summary": "Describes the three-step proof strategy: establish (2^{1/3})^3 = 2, show 2 is not a perfect cube, conclude irrationality via irrational_nrt_of_notint_nrt."
+    },
+    {
+      "id": "sec-definition",
+      "title": "Definition of cbrt2",
+      "startLine": 27,
+      "endLine": 30,
+      "summary": "Defines cbrt2 = (2 : ℝ)^(1/3 : ℝ) as a noncomputable real via Real.rpow."
+    },
+    {
+      "id": "sec-cbrt2-cubed",
+      "title": "Key Property: cbrt2^3 = 2",
+      "startLine": 32,
+      "endLine": 37,
+      "summary": "Proves cbrt2^3 = 2 using rpow_natCast and rpow_mul to combine exponents: (2^{1/3})^3 = 2^{(1/3)·3} = 2^1 = 2."
+    },
+    {
+      "id": "sec-not-perfect-cube",
+      "title": "2 Is Not a Perfect Cube",
+      "startLine": 39,
+      "endLine": 66,
+      "summary": "Number-theoretic core: proves ¬∃ n : ℤ, n^3 = 2 by case analysis on n ≤ 0 (n^3 ≤ 0), n ≥ 2 (n^3 ≥ 8), and n = 1 (1^3 = 1 ≠ 2), using nlinarith and omega."
+    },
+    {
+      "id": "sec-not-int",
+      "title": "cbrt2 Is Not an Integer",
+      "startLine": 68,
+      "endLine": 75,
+      "summary": "Bridge lemma: if cbrt2 = n for some n : ℤ, then n^3 = 2 (by cubing), contradicting two_not_perfect_cube. Uses exact_mod_cast for ℝ/ℤ coercion."
+    },
+    {
+      "id": "sec-main-theorem",
+      "title": "Main Theorem: irrational_cbrt2",
+      "startLine": 77,
+      "endLine": 85,
+      "summary": "Applies irrational_nrt_of_notint_nrt 3 2 with the three obligations: cbrt2^3 = 2, cbrt2 not an integer, and 3 > 0."
+    },
+    {
+      "id": "sec-alias",
+      "title": "Alias for Cross-File Use",
+      "startLine": 87,
+      "endLine": 91,
+      "summary": "Exports irrational_two_pow_one_third as an alias matching the form used by GelfondSchneider.lean and other dependent files."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for `cube-root-2-irrational`.

## Changes

- **annotations.json**: Added 8 full annotations covering all code regions, each with `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`
- **sections**: Populated the previously empty `sections` array with 8 sections spanning all 91 lines
- **historicalContext**: Expanded from ~350 to ~850 chars — added Delian problem / doubling-the-cube context, Pythagorean history, rational root theorem connection
- **keyInsights**: Added 5th insight explaining why the rational root theorem makes the perfect-power check necessary and sufficient
- **conclusion.implications**: Deepened with algebraic number theory framing (∛2 as degree-3 algebraic integer, compass-and-straightedge impossibility)
- **openQuestions**: Added 3rd question on formalizing degree bounds via Galois theory

## Axiom Integrity

Confirmed: `axiomCount: 0`, `status: "verified"` are correct. The Lean file uses no `axiom` declarations and no assumption-carrying structures. All 5 theorems are fully machine-checked.