### PR TITLE
Enrich 7 gallery proofs: Erdős #5, #2 OQ-01, #131 OQ-01, #177 OQ-04, #1006 OQ-01, Burnside, cube-root-2

### DIFF
--- a/src/data/proofs/burnside-counting/annotations.json
+++ b/src/data/proofs/burnside-counting/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-burnside-header",
+    "proofId": "burnside-counting",
+    "range": { "startLine": 1, "endLine": 37 },
+    "type": "definition",
+    "title": "Imports and Setup: Group Actions, ZMod, and Colorings",
+    "content": "The file imports `Mathlib.GroupTheory.GroupAction.Quotient` (which contains Burnside's lemma as `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group`), `GroupTheory.SpecificGroups.Cyclic`, `Data.ZMod.Basic` for $\\mathbb{Z}/n\\mathbb{Z}$ arithmetic, and `Data.Fintype.Card` for cardinality. The docstring outlines three goals: state Burnside's lemma, define the cyclic group action on colorings, and count binary 4-necklaces.",
+    "mathContext": "A *coloring* of $n$ positions with $k$ colors is a function $\\text{Fin}\\, n \\to \\text{Fin}\\, k$. The cyclic group $\\mathbb{Z}/n\\mathbb{Z}$ acts on colorings by rotation: $(r \\cdot c)(i) = c(i - r \\pmod{n})$. The orbit-counting theorem says $|\\mathcal{C}/G| = \\frac{1}{|G|} \\sum_{g \\in G} |\\text{Fix}(g)|$, where $\\text{Fix}(g) = \\{c \\mid g \\cdot c = c\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group", "ZMod n", "Fintype.card"],
+    "prerequisites": ["Mathlib.GroupTheory.GroupAction.Quotient", "Mathlib.Data.ZMod.Basic", "Group actions and orbits"]
+  },
+  {
+    "id": "ann-burnside-lemma",
+    "proofId": "burnside-counting",
+    "range": { "startLine": 38, "endLine": 53 },
+    "type": "technique",
+    "title": "burnside_lemma: Direct Wrapping of Mathlib's Orbit-Counting Theorem",
+    "content": "`burnside_lemma` is a one-line proof that delegates entirely to `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group G X` from Mathlib. The theorem is stated in multiplicative form (avoiding division): $\\sum_{g \\in G} |\\text{Fix}(g)| = |X/G| \\times |G|$. The type signature requires `Fintype G`, `Fintype (fixedBy X g)` for all `g`, and `Fintype (orbitRel.Quotient G X)`.",
+    "mathContext": "The equivalence between the standard $|X/G| = \\frac{1}{|G|}\\sum |\\text{Fix}(g)|$ and the Lean form is: multiply both sides by $|G|$. For $G = \\mathbb{Z}/4\\mathbb{Z}$ and $X = \\{0,1\\}^4$: $|\\text{Fix}(0)| + |\\text{Fix}(1)| + |\\text{Fix}(2)| + |\\text{Fix}(3)| = 6 \\times 4 = 24$, verified by $16 + 2 + 4 + 2 = 24$.",
+    "significance": "key",
+    "relatedConcepts": ["MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group", "orbitRel.Quotient", "fixedBy"],
+    "prerequisites": ["Group theory in Mathlib", "Fintype.card", "MulAction API"]
+  },
+  {
+    "id": "ann-burnside-action",
+    "proofId": "burnside-counting",
+    "range": { "startLine": 54, "endLine": 109 },
+    "type": "definition",
+    "title": "Cyclic Action on Colorings: rotatedIndex, rotateColoring, cyclicAddActionOnColorings",
+    "content": "`rotateColoring n k r c` shifts every position by $-r \\pmod{n}$: position $i$ gets color $c((i + n - r) \\bmod n)$. The helper `rotatedIndex n r i` computes the source index $(i + n - r.\\text{val}) \\bmod n$ as a `Fin n`. The `cyclicAddActionOnColorings` instance proves this is an `AddAction (ZMod n) (Coloring n k)`: `zero_vadd` is proved via `rotatedIndex_zero` (a verified theorem); `add_vadd` uses the axiom `rotatedIndex_add` for composition.",
+    "mathContext": "The formula $(i + n - r) \\bmod n$ computes $i - r$ in $\\mathbb{Z}/n\\mathbb{Z}$ using natural number subtraction (avoiding underflow). `zero_vadd`: $(i + n - 0) \\bmod n = i$ (proved by `Nat.add_mod_right` + `Nat.mod_eq_of_lt`). `add_vadd`: rotating by $s$ then by $r$ equals rotating by $r + s$ — this composition law is `rotatedIndex_add` (axiomatized because the modular arithmetic proof requires careful case analysis in natural number arithmetic).",
+    "significance": "key",
+    "relatedConcepts": ["AddAction typeclass", "ZMod n", "rotatedIndex_zero (proved)", "rotatedIndex_add (axiom)"],
+    "prerequisites": ["Nat modular arithmetic", "AddAction typeclass", "ZMod.val_lt"]
+  },
+  {
+    "id": "ann-burnside-concrete-counts",
+    "proofId": "burnside-counting",
+    "range": { "startLine": 110, "endLine": 160 },
+    "type": "insight",
+    "title": "Counting Fixed Points: binary_4_colorings_count and constant_coloring_count",
+    "content": "`binary_4_colorings_count` verifies there are $2^4 = 16$ binary 4-colorings via `Fintype.card_fun` + `norm_num`. `constant_coloring_count` proves `{c : Coloring n k // IsConstant c}` has cardinality $k$: the bijection $f(c) = c(0)$ and inverse $g(v) = (\\lambda i, v)$ are verified explicitly with `Function.LeftInverse` / `RightInverse`. For $n=4, k=2$: constant colorings are $\\{0000, 1111\\}$, giving $|\\text{Fix}(\\text{rot}_1)| = |\\text{Fix}(\\text{rot}_3)| = 2$.",
+    "mathContext": "A coloring is fixed by rotation-by-1 iff $c(i) = c(i+1)$ for all $i$, i.e., $c$ is constant. A coloring is fixed by rotation-by-3 iff $c(i) = c(i-1)$ for all $i$, again constant. So $|\\text{Fix}(1)| = |\\text{Fix}(3)| = k$. For $k=2$: exactly 2 fixed colorings per odd rotation. The `DecidablePred` instance makes `IsConstant` computable via `decidable_of_iff` reduced to $\\forall i, c\\,i = c\\,0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Fintype.card_fun", "Equiv.ofBijective", "IsConstant predicate", "DecidablePred"],
+    "prerequisites": ["Fintype API", "Function.LeftInverse / RightInverse", "Fin arithmetic"]
+  },
+  {
+    "id": "ann-burnside-period2",
+    "proofId": "burnside-counting",
+    "range": { "startLine": 161, "endLine": 193 },
+    "type": "technique",
+    "title": "period2_count: Bijection with Fin 2 × Fin 2 for Period-2 Colorings",
+    "content": "`HasPeriod2 c` asserts $c(0) = c(2) \\wedge c(1) = c(3)$ — fixed by rotation-by-2. `period2_count` proves there are 4 such colorings by explicit bijection with $\\text{Fin}\\, 2 \\times \\text{Fin}\\, 2$: map $c \\mapsto (c(0), c(1))$, inverse $(a, b) \\mapsto [a, b, a, b]$. The `fin_cases` tactic and `Matrix.cons_val` lemmas handle all 4 positions. This gives $|\\text{Fix}(\\text{rot}_2)| = 4$.",
+    "mathContext": "The 4 period-2 binary 4-colorings are $\\{0000, 0101, 1010, 1111\\}$. Rotation by 2 maps $i \\mapsto i+2 \\pmod 4$, fixing exactly those $c$ with $c(0)=c(2)$ and $c(1)=c(3)$. The Lean proof uses the vector literal `![a, b, a, b]` for the inverse map, with `simp [Matrix.cons_val_zero, Matrix.cons_val_one, Matrix.head_cons]` to reduce `Fin 4` cases.",
+    "significance": "supporting",
+    "relatedConcepts": ["HasPeriod2", "Matrix.cons_val_zero", "fin_cases", "Equiv.ofBijective"],
+    "prerequisites": ["Fintype.card_prod", "Matrix.cons_val API", "fin_cases tactic"]
+  },
+  {
+    "id": "ann-burnside-axioms",
+    "proofId": "burnside-counting",
+    "range": { "startLine": 214, "endLine": 255 },
+    "type": "concept",
+    "title": "Five Axioms: Fixed-Point Sum, Setoid, Quotient Fintype, and Necklace Count",
+    "content": "The file closes with 5 axioms. `fixed_point_sum_binary_4` asserts $\\sum_{r \\in \\mathbb{Z}/4\\mathbb{Z}} |\\text{Fix}(r)| = 24$ (i.e., $16+2+4+2$) — this could be proved by `native_decide` since all predicates are decidable. `coloringSetoid n k` and `coloringQuotientFintype n k` axiomatize that the orbit relation is a setoid with a finite quotient type. `binary_necklaces_4` states the final result: 6 distinct necklaces. `IsFixedByRotation` and `ColoringEquiv` are defined as decidable predicates for downstream use.",
+    "mathContext": "The logical chain to eliminate all 5 axioms: (1) `fixed_point_sum_binary_4` by `native_decide`; (2) `coloringSetoid` from `orbitRel.isEquivalence` in Mathlib after connecting the `AddAction` to a `MulAction`; (3) `coloringQuotientFintype` from `Fintype.ofFinset`; (4) `binary_necklaces_4` by combining `burnside_lemma` with the fixed-point sum and $|\\mathbb{Z}/4\\mathbb{Z}| = 4$. The main obstacle is connecting the `AddAction` (additive) to the `MulAction` (multiplicative) API that `burnside_lemma` requires.",
+    "significance": "key",
+    "relatedConcepts": ["IsFixedByRotation", "ColoringEquiv", "orbitRel.isEquivalence", "native_decide", "AddAction vs MulAction"],
+    "prerequisites": ["Setoid API", "Fintype.card", "orbitRel in Mathlib", "burnside_lemma dependency"]
+  }
+]

--- a/src/data/proofs/burnside-counting/meta.json
+++ b/src/data/proofs/burnside-counting/meta.json
@@ -36,17 +36,17 @@
     ]
   },
   "overview": {
-    "historicalContext": "Burnside's lemma (also known as the Cauchy-Frobenius lemma or orbit-counting theorem) was first stated by Cauchy in 1845 and later by Frobenius (1887); Burnside popularized it in his 1897 book 'Theory of Groups of Finite Order'. The formula |X/G| = (1/|G|) Σ_{g∈G} |Fix(g)| counts distinct objects under symmetry. A classic application: binary necklaces of length n (cyclic sequences of 0s and 1s under rotation) — for n=4, there are exactly 6 distinct necklaces out of 16 total colorings.",
+    "historicalContext": "Burnside's lemma (also called the Cauchy-Frobenius lemma or orbit-counting theorem) has a tangled attribution history. Cauchy stated an equivalent result in 1845 in his work on permutation groups. Frobenius reproved and generalized it in 1887 using character theory. William Burnside included it in his influential 1897 textbook *Theory of Groups of Finite Order*, where its accessibility made it the standard reference — even though Burnside himself acknowledged Frobenius's priority. The lemma became a cornerstone of Pólya's 1937 enumeration theory, which extended it to weighted counting (the Pólya enumeration theorem). Applications span chemistry (counting isomers of molecules with rotational symmetry), combinatorics (counting graphs, tilings, and colorings up to symmetry), and coding theory. For binary necklaces of length $n$ under $\\mathbb{Z}/n\\mathbb{Z}$ rotation, the formula gives the $n$-th necklace number. For $n=4$: $\\frac{1}{4}(16 + 2 + 4 + 2) = 6$, matching the 6 equivalence classes $\\{0000\\}, \\{1111\\}, \\{0001,0010,0100,1000\\}, \\{0011,0110,1001,1100\\}, \\{0101,1010\\}, \\{0111,1011,1101,1110\\}$.",
     "problemStatement": "Apply Mathlib's MulAction orbit-counting theorem (Burnside's lemma) to count distinct colorings under group symmetry, specifically: how many distinct binary necklaces of length 4 exist?",
     "text": "Burnside's lemma: |X/G| × |G| = Σ_{g∈G} |Fix(g)|. For binary 4-necklaces under Z_4 rotation: |Fix(id)| = 16, |Fix(rot₁)| = 2, |Fix(rot₂)| = 4, |Fix(rot₃)| = 2, sum = 24, so |X/G| = 24/4 = 6 distinct necklaces.",
     "proofStrategy": "Part I directly applies MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group from Mathlib. Part II defines the ZMod n action on colorings by rotation and establishes its AddAction structure (using rotatedIndex for the explicit formula). Part III provides concrete counting lemmas: all 16 binary colorings, the 2 constant ones, and the 4 period-2 ones. The 5 axioms cover modular arithmetic details (rotatedIndex_add), the specific fixed-point computation (fixed_point_sum_binary_4), and the setoid/quotient structure needed for the necklace count.",
     "keyInsights": [
-      "Burnside's lemma is already in Mathlib as MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group — direct application, no proof needed",
-      "The additive group ZMod n acts on colorings by 'shift by r': c ↦ (i ↦ c(i - r))",
-      "rotatedIndex_add encodes group homomorphism property: rotating by r then s equals rotating by r+s",
-      "For binary 4-necklaces: identity fixes all 16, rotation by 1 or 3 fixes only 2 (constant), rotation by 2 fixes 4 (period-2)",
-      "The 6 equivalence classes: {0000}, {0001,0010,0100,1000}, {0011,0110,1100,1001}, {0101,1010}, {0111,1110,1101,1011}, {1111}",
-      "rotatedIndex_add is a provable lemma about (a + n - b) % n composition — axiomatized here for clarity"
+      "Burnside's lemma is in Mathlib as `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group` — the Lean proof is a one-line wrapper, with all content coming from Mathlib's group theory library",
+      "The `AddAction (ZMod n) (Coloring n k)` instance uses the formula $c \\mapsto (i \\mapsto c(i - r))$ for rotation by $r$. The subtraction $(i + n - r) \\bmod n$ is computed in $\\mathbb{N}$ to avoid underflow, making `rotatedIndex_add` a natural-number modular arithmetic identity that needs careful case analysis",
+      "Fixed points by rotation type: identity fixes all $k^n$ colorings; rotation by $d$ (where $d \\mid n$) fixes exactly $k^d$ colorings (those with period dividing $d$); odd rotations of $\\{0,1\\}^4$ fix only the 2 constant colorings",
+      "The `constant_coloring_count` and `period2_count` theorems are fully proved using explicit `Equiv.ofBijective` constructions — no axioms needed for the individual fixed-point counts",
+      "The main gap: connecting the `AddAction` (additive $\\mathbb{Z}/n\\mathbb{Z}$) to the `MulAction` API that `burnside_lemma` requires. Mathlib's `orbitRel.isEquivalence` works for `MulAction`; bridging to `AddAction` requires a group homomorphism from $(\\mathbb{Z}/n\\mathbb{Z}, +)$ to $(\\text{Sym}(X), \\circ)$, which `coloringSetoid` axiomatizes",
+      "Pólya's generalization: replace $|\\text{Fix}(g)|$ with a generating function weighted by color frequency. For 2-coloring with weights $b$ (black) and $w$ (white), Pólya gives the cycle index of $\\mathbb{Z}/4\\mathbb{Z}$: $\\frac{1}{4}((b+w)^4 + (b^2+w^2)^2 + 2(b^4+w^4))$"
     ],
     "prerequisites": [
       "Group actions and orbit-stabilizer theorem",
@@ -57,7 +57,7 @@
   },
   "conclusion": {
     "summary": "Burnside's lemma is formalized from Mathlib and applied to the classic necklace counting problem. The key mathematical content — the orbit-counting formula — is proved. The application to binary 4-necklaces is axiomatized pending formal proof of modular arithmetic details.",
-    "implications": "This formalization demonstrates how abstract group theory (orbit counting) applies to concrete combinatorial problems. Burnside's lemma is the foundation of Polya enumeration theory, used in chemistry (counting molecular structures), graph theory (counting graphs up to isomorphism), and combinatorics generally.",
+    "implications": "This formalization demonstrates the two-layer structure of applying abstract Mathlib theorems to concrete problems: (1) the abstract `burnside_lemma` wraps `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group` with zero proof effort; (2) the concrete application requires defining the specific action (cyclic rotation), verifying it satisfies the `AddAction` axioms, and computing fixed-point cardinalities for each group element. The fully verified lemmas (`binary_4_colorings_count`, `constant_coloring_count`, `period2_count`) show that fixed-point counting is elementarily decidable — the remaining axioms are a bridge-building problem between Mathlib's multiplicative and additive group-action APIs. Once that bridge is built (via a `MulAction` instance from the `AddAction` + `AddCommGroup (ZMod n)`), all 5 axioms collapse to `native_decide` or Mathlib lemmas. Burnside's lemma underlies Pólya enumeration (used in chemical isomer counting, OEIS necklace sequences), and this formalization provides the scaffolding for a full Pólya cycle index theorem in Lean 4.",
     "openQuestions": [
       "Prove rotatedIndex_add: (a + n - b) % n composition law in Lean 4",
       "Prove fixed_point_sum_binary_4 via native_decide",
@@ -84,5 +84,41 @@
       "description": "Lagrange's theorem underlies the orbit-stabilizer identity used in Burnside's lemma"
     }
   ],
-  "sections": []
+  "sections": [
+    {
+      "id": "sec-burnside-header",
+      "title": "Imports, Docstring, and Namespace",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "Imports Mathlib group action quotient, cyclic groups, ZMod, and Fintype cardinality. Docstring outlines the three goals: Burnside's lemma, ZMod n action on colorings, binary 4-necklace count. Opens BurnsideCounting namespace."
+    },
+    {
+      "id": "sec-burnside-lemma",
+      "title": "Part I: Burnside's Lemma from Mathlib",
+      "startLine": 38,
+      "endLine": 53,
+      "summary": "States burnside_lemma as a one-line delegation to MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group. The multiplicative form Σ|Fix(g)| = |X/G| × |G| avoids division. Requires Fintype instances for G, fixedBy X g, and orbitRel.Quotient G X."
+    },
+    {
+      "id": "sec-burnside-action",
+      "title": "Part II: Cyclic Group Action on Finite Colorings",
+      "startLine": 54,
+      "endLine": 109,
+      "summary": "Defines Coloring n k (Fin n → Fin k), rotateColoring and rotatedIndex. Proves rotatedIndex_zero (verified theorem). Axiomatizes rotatedIndex_add (composition law). Establishes cyclicAddActionOnColorings: AddAction (ZMod n) (Coloring n k) instance with verified zero_vadd and add_vadd (using the axiom)."
+    },
+    {
+      "id": "sec-burnside-concrete",
+      "title": "Part III: Concrete Fixed-Point Counts",
+      "startLine": 110,
+      "endLine": 193,
+      "summary": "binary_4_colorings_count: |Coloring 4 2| = 16 via norm_num. Defines IsConstant, proves constant_coloring_count (bijection with Fin k, fully verified). Derives constant_4_2. Defines HasPeriod2, proves period2_count = 4 via bijection with Fin 2 × Fin 2 using vector literals and fin_cases."
+    },
+    {
+      "id": "sec-burnside-axioms",
+      "title": "Part IV: Summary, Decidable Predicates, and 4 Final Axioms",
+      "startLine": 194,
+      "endLine": 255,
+      "summary": "Documents the 6 necklace classes and fixed-point computation in comments. Defines IsFixedByRotation (decidable) and ColoringEquiv. Axioms: fixed_point_sum_binary_4 (sum=24), coloringSetoid, coloringQuotientFintype, binary_necklaces_4 (= 6). Ends with #check statements confirming all definitions type-check."
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Enriches 7 gallery proof entries with annotations, expanded historicalContext, deepened sections and keyInsights:

- **burnside-counting** (Burnside's Lemma & Necklace Counting): 6 annotations; historicalContext (Cauchy 1845, Frobenius 1887, Burnside 1897, Pólya 1937); deepened keyInsights on AddAction/MulAction gap; 5 sections covering all 255 lines
- **erdos-5-prime-gaps** (Erdős #5: Prime Gap Limit Points): 6 annotations; expanded historicalContext (GPY 2005, Zhang 2013, Westzynthius 1931, Merikoski 2020s); 6 sections covering all 572 lines
- **erdos-2-oq-01** (Exact Maximum Minimum Modulus): annotations reformatted from non-standard format; **axiomCount corrected 0→3** (inherits `balister_bound`, `owens_construction`, `reciprocal_sum_ge_one`)
- **erdos-131-oq-01** (Nonaverageable Sets): 8 annotations; 5-decade historicalContext; 7 sections covering all 556 lines
- **erdos-177-oq-04** (Discrepancy of Sequences): 6 annotations; historicalContext (Roth 1954, Rudin-Shapiro, Beck 1981); 7 sections
- **erdos-1006-oq-01** (Orientations and Poset Rank): 5 annotations; expanded historicalContext (Pretzel 1985, Nešetřil-Rödl, FFLW 1997)
- **cube-root-2-irrational**: 8 annotations; expanded historicalContext (Pythagoreans, Delian problem, rational root theorem); 8 sections covering all 91 lines

## Test plan
- [x] `pnpm build` passes for all 7 enrichments
- [x] JSON validates (build includes JSON parsing)
- [x] axiomCount integrity verified for all entries