### PR TITLE
Fix: correct axiomCount=0 for 4 gallery proofs with explicit axioms

### DIFF
--- a/src/data/proofs/erdos-15/meta.json
+++ b/src/data/proofs/erdos-15/meta.json
@@ -27,7 +27,7 @@
     "relatedProblems": [
       "erdos-28"
     ],
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 219,
     "prerequisites": [
       "Prime numbers and the prime number theorem",
@@ -35,7 +35,7 @@
       "Analytic number theory",
       "Distribution of primes in arithmetic progressions"
     ],
-    "assumptions": "11 axioms: prime_number_theorem, terms_tend_to_zero, alternating_terms_to_zero, and 8 more. See Lean source for complete statements.",
+    "assumptions": "1 axiom: terms_tend_to_zero (terms n/p_n → 0, consequence of PNT). See Lean source for complete statement.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -147,7 +147,7 @@
     ],
     "namespace": "Erdos15",
     "lineCount": 219,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 0,
     "definitionCount": 8
   },

--- a/src/data/proofs/erdos-231/meta.json
+++ b/src/data/proofs/erdos-231/meta.json
@@ -53,9 +53,9 @@
       "keranen_morphism axiom: 85-letter morphism",
       "erdos_231_disproved axiom: NO for k ≥ 4"
     ],
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 213,
-    "assumptions": "9 axioms: thue_squarefree, three_letters_not_enough, keranen_1992, and 6 more. See Lean source for complete statements."
+    "assumptions": "1 axiom: erdos_231_disproved (∀ k ≥ 4, no string of length 2^k-1 over k letters must contain an abelian square — Keränen 1992). See Lean source for complete statement."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #231**\n\nThis problem concerns abelian squares in combinatorics on words.\n\n**History:**\n- Erdős initially conjectured YES: strings of length 2^k - 1 over k letters must contain abelian squares\n- De Bruijn and Erdős found counterexamples for k = 4\n- The question evolved: can infinite abelian-square-free strings exist?\n- Keränen (1992) constructed an infinite abelian-square-free string over 4 letters\n\n**Context:**\n- Thue (early 1900s) showed squarefree strings exist over 3 letters\n- Abelian-square-free is a STRONGER property\n- 4 letters are both necessary and sufficient for abelian-square-free strings",
@@ -172,7 +172,7 @@
     ],
     "namespace": "Erdos231",
     "lineCount": 213,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 3,
     "definitionCount": 11
   },

--- a/src/data/proofs/erdos-297/meta.json
+++ b/src/data/proofs/erdos-297/meta.json
@@ -61,9 +61,9 @@
       "erdos_297_answer: affirmative answer to the subexponential growth question",
       "at_least_three_representations: verified examples {1}, {2,3,6}, {2,4,5,20}"
     ],
-    "axiomCount": 0,
+    "axiomCount": 3,
     "lineCount": 256,
-    "assumptions": "14 axioms: two_three_six_is_egyptian, two_four_five_twenty_is_egyptian, two_three_seven_fortytwo_is_egyptian, and 11 more. See Lean source for complete statements."
+    "assumptions": "3 axioms: liuSawhney_constant_bounds (0.9 < c < 0.92), liuSawhney_asymptotic (full exponential growth rate 2^{(c+o(1))N}), erdos_297_answer (subexponential growth confirmed). See Lean source for complete statements."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #297: Egyptian Fractions Summing to 1**\n\nThis problem, originally posed by Erdős and Graham [ErGr80, p.36], asks a deceptively simple counting question: among all subsets of {1,...,N}, how many have the property that the sum of their reciprocals equals exactly 1? Examples include {1}, {2,3,6}, and {2,4,5,20}.\n\nThe key question was the exponential growth rate: does the count grow like 2^{cN} for some constant c < 1 (meaning exponentially fewer than all 2^N subsets), or does it approach 2^N (meaning \"most\" subsets work)? The intuition that c < 1 comes from the divergence of the harmonic series: since the expected harmonic sum of a random subset is approximately (log N)/2, which grows without bound, most random subsets vastly overshoot the target of 1.\n\nA precursor appeared on MathOverflow in 2017, when Mikhail Tikhomirov asked about subsets with sum at most 1. Lucia, RaphaelB4, and js21 sketched proofs of the correct asymptotic for that variant, building confidence that c < 1 for the exact-sum version too.",
@@ -204,7 +204,7 @@
     ],
     "namespace": "Erdos297",
     "lineCount": 256,
-    "axiomCount": 0,
+    "axiomCount": 3,
     "theoremCount": 4,
     "definitionCount": 9
   },

--- a/src/data/proofs/erdos-657/meta.json
+++ b/src/data/proofs/erdos-657/meta.json
@@ -68,9 +68,9 @@
         "relationship": "Distance multiplicity spectrum problem — both study how structural constraints on point sets affect the number of distinct distances"
       }
     ],
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 222,
-    "assumptions": "16 axiom(s). No sorries."
+    "assumptions": "1 axiom: f_tends_to_infinity (isosceles-free point sets must determine superlinearly many distinct distances). See Lean source for complete statement."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #657: Isosceles-Free Point Sets and Distinct Distances**\n\n**Origin (1973):** Erdős and Davies formulated this problem in [Er73], asking about the relationship between avoiding isosceles triangles and forcing many distinct distances. A point set $A \\subset \\mathbb{R}^2$ is *isosceles-free* if for every triple $\\{p, q, r\\} \\subset A$, the distances $d(p,q), d(p,r), d(q,r)$ are all distinct.\n\n**The Central Question:** Define $f(n) = \\min\\{|\\Delta(A)|/n : A \\subset \\mathbb{R}^2,\\; |A| = n,\\; A \\text{ isosceles-free}\\}$. Is $f(n) \\to \\infty$? This asks whether the isosceles-free condition forces *superlinearly* many distinct distances.\n\n**The 3-AP Connection:** In one dimension, a set $A \\subset \\mathbb{R}$ is isosceles-free iff it is 3-AP-free (contains no three-term arithmetic progression $a, a+d, a+2d$). This connects the problem to Roth's theorem (1953) and the function $r_3(N)$ measuring the maximum size of a 3-AP-free subset of $\\{1, \\ldots, N\\}$.\n\n**Dumitrescu's Breakthrough (2008):** Adrian Dumitrescu established both directions: $(\\log n)^c \\le f(n) \\le 2^{O(\\sqrt{\\log n})}$. The lower bound answers Erdős's question affirmatively ($f(n) \\to \\infty$), while the upper bound uses **Behrend's construction** (1946) of large 3-AP-free sets to build isosceles-free point sets with few distances.\n\n**Kelley-Meka Revolution (2023):** Zander Kelley and Raghu Meka proved the breakthrough bound $r_3(N) \\le N/2^{c(\\log N)^{1/9}}$, dramatically improving all previous 3-AP bounds. Via the 3-AP connection, this translates to $f(n) \\ge 2^{c(\\log n)^{1/9}}$, a super-polylogarithmic lower bound. Bloom and Sisask further refined the constant.\n\n**Straus's Observation:** In high dimensions ($\\mathbb{R}^k$ with $2^k \\ge n$), isosceles-free $n$-point sets can have as few as $n - 1$ distances (using hypercube vertices). This shows the problem is intrinsically low-dimensional.",
@@ -220,7 +220,7 @@
     ],
     "namespace": "Erdos657",
     "lineCount": 222,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 6,
     "definitionCount": 16
   },


### PR DESCRIPTION
## Fix

Four gallery proofs incorrectly reported `axiomCount: 0` in their `meta.json` despite having explicit `axiom` declarations in their Lean source files.

## Evidence

| Proof | Before | After | Lean axioms |
|-------|--------|-------|-------------|
| erdos-15 | axiomCount=0 | axiomCount=1 | `terms_tend_to_zero` |
| erdos-231 | axiomCount=0 | axiomCount=1 | `erdos_231_disproved` |
| erdos-297 | axiomCount=0 | axiomCount=3 | `liuSawhney_constant_bounds`, `liuSawhney_asymptotic`, `erdos_297_answer` |
| erdos-657 | axiomCount=0 | axiomCount=1 | `f_tends_to_infinity` |

All 4 proofs correctly have `status: "axiomatized"` and `badge: "axiom"` — only the `axiomCount` field was wrong.

The `assumptions` text in each file was also stale (listing prior axioms that had since been proved), updated to reflect the current set.

## Validation

- `pnpm build` passes (exit 0)
- Counts verified by `grep "^axiom "` on each Lean file

---
Automated fix by lean-mechanic agent.