### PR TITLE
Fix: downgrade hilbert-22 and hilbert-23 from verified to formalized/wip

### DIFF
--- a/src/data/proofs/hilbert-22/meta.json
+++ b/src/data/proofs/hilbert-22/meta.json
@@ -7,7 +7,7 @@
     "proofRepoPath": "Proofs/Hilbert22Uniformization.lean",
     "author": "Koebe, Poincare",
     "date": "1907",
-    "status": "verified",
+    "status": "formalized",
     "tags": [
       "complex-analysis",
       "riemann-surfaces",
@@ -16,7 +16,7 @@
       "automorphic-functions",
       "advanced"
     ],
-    "badge": "original",
+    "badge": "wip",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -46,7 +46,7 @@
     "hilbertNumber": 22,
     "axiomCount": 0,
     "lineCount": 305,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "Main theorems are True stubs (e.g., hilbert_22_status proves existential True propositions, not real uniformization). Real uniformization infrastructure is partially formalized but the core mathematical content is not machine-verified.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -113,7 +113,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Hilbert's twenty-second problem is completely solved by the Uniformization Theorem. The theorem provides a complete classification of simply connected Riemann surfaces and shows that all Riemann surfaces can be uniformized by automorphic functions acting on one of three model spaces.\n\nThe proof by Koebe and Poincare in 1907 represents one of the high points of classical complex analysis and opened vast new areas of mathematics.",
+    "summary": "Hilbert's twenty-second problem is solved mathematically by the Uniformization Theorem (Koebe-Poincaré, 1907). This Lean formalization provides infrastructure for the classification of simply connected Riemann surfaces, but the main theorems are currently True stubs. Full machine-verification of the uniformization result remains as future work.",
     "implications": "**Theoretical Significance**: The Uniformization Theorem has far-reaching implications:\n\n1. **Hyperbolic Geometry**: Surfaces of genus >= 2 inherit a canonical hyperbolic metric from the uniformization\n\n2. **Teichmuller Theory**: The study of moduli spaces of Riemann surfaces relies fundamentally on uniformization\n\n**3. Number Theory**: Modular forms and Shimura varieties arise from uniformization of specific surfaces\n\n4. **String Theory**: Worldsheet physics uses conformal field theory on uniformized surfaces\n\n5. **Kleinian Groups**: 3-dimensional hyperbolic geometry connects to uniformization via quasi-Fuchsian groups.",
     "openQuestions": [
       "How does uniformization generalize to higher-dimensional complex manifolds?",

--- a/src/data/proofs/hilbert-23/meta.json
+++ b/src/data/proofs/hilbert-23/meta.json
@@ -7,7 +7,7 @@
     "proofRepoPath": "Proofs/Hilbert23CalculusVariations.lean",
     "author": "Euler, Lagrange, Hilbert, Tonelli, Pontryagin, et al.",
     "date": "1744-present",
-    "status": "verified",
+    "status": "formalized",
     "tags": [
       "analysis",
       "optimization",
@@ -16,7 +16,7 @@
       "research-program",
       "intermediate"
     ],
-    "badge": "verified",
+    "badge": "wip",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -46,7 +46,7 @@
     "hilbertNumber": 23,
     "axiomCount": 0,
     "lineCount": 335,
-    "assumptions": "0 axioms. Structures (Lagrangian, AdmissibleFunction, TestFunction, ControlSystem, CostFunctional) define mathematical objects. No axiom declarations.",
+    "assumptions": "Main theorems are True stubs (e.g., euler_lagrange_weak_form and hilbert_23_status prove vacuous existential True propositions, not actual variational results). The Euler-Lagrange equation is not genuinely formalized. Variational infrastructure (Lagrangian structures, action functionals) is defined but the core mathematical content is not machine-verified.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -126,7 +126,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Hilbert's twenty-third problem called for developing the calculus of variations, and the 20th century delivered spectacularly. The Euler-Lagrange equation provides necessary conditions for extrema. Direct methods (Tonelli) prove existence without solving differential equations. Optimal control theory (Pontryagin) extended these ideas to engineering. The field remains active, with applications to optimal transport, machine learning, and materials science.\n\nUnlike most Hilbert problems with definitive solutions, Problem 23 is a living research program that continues to evolve.",
+    "summary": "Hilbert's twenty-third problem called for developing the calculus of variations, and the 20th century delivered spectacularly — through Euler-Lagrange theory, direct methods (Tonelli), optimal control (Pontryagin), and geometric measure theory. This Lean formalization provides variational infrastructure (Lagrangian structures, action functionals, test functions) but the main theorems are currently True stubs. Full machine-verification of the core variational results remains as future work.",
     "implications": "**Theoretical Significance**: The development of calculus of variations has profound implications:\n\n1. **Classical Mechanics**: Hamilton's principle and Lagrangian mechanics\n\n2. **Modern Physics**: Quantum field theory uses action principles\n\n**3. Control Engineering**: Optimal control of dynamical systems\n\n4. **Machine Learning**: Neural networks as variational problems\n\n5. **Materials Science**: Phase transitions via Gamma-convergence\n\n6. **PDE Theory**: Many equations arise as Euler-Lagrange conditions.",
     "openQuestions": [
       "What is the regularity theory for general variational problems?",


### PR DESCRIPTION
## Fix

Both hilbert-22 and hilbert-23 claimed `status: verified` with `badge: original/verified` but their main theorems are vacuous True stubs, not genuine mathematical content.

## Evidence

**hilbert-22 Before**: `status: verified`, `badge: original`, `assumptions: "None. Fully verified..."`
**hilbert-22 After**: `status: formalized`, `badge: wip`, `assumptions` describes True-stub nature

**hilbert-23 Before**: `status: verified`, `badge: verified`, `assumptions: "0 axioms. Structures define..."`
**hilbert-23 After**: `status: formalized`, `badge: wip`, `assumptions` describes True-stub nature

Both `conclusion.summary` fields updated to remove language implying machine-verification.

**Lean evidence** (from Lean files):
- `hilbert_22_status` proves `∃ (_ : Prop), True` — not uniformization
- `euler_lagrange_weak_form` proves `∃ (integral_condition : Prop), integral_condition := ⟨True, trivial⟩`
- Both files have `structure Foo where field : True`

Closes #9003

---
Automated fix by lean-mechanic agent.