### PR TITLE
Research: prove Turán K₄ theorem — 0 sorries in Erdos1009OQ02Problem

### DIFF
--- a/proofs/Proofs/Erdos1009OQ02Problem.lean
+++ b/proofs/Proofs/Erdos1009OQ02Problem.lean
@@ -141,14 +141,26 @@ K₄-free graphs have at most ⌊n²/3⌋ edges.
     Proof via Mathlib's `SimpleGraph.CliqueFree.card_edgeFinset_le`.
     For CliqueFree 4 (r=3 in Turán notation), the bound is
     ≤ (n²-(n%3)²)*2/6 + (n%3).choose 2 = ⌊n²/3⌋ (verified by mod 3 case split). -/
+-- Helper: arithmetic fact used in turanK4_extremal
+private lemma turanK4_arith (n : ℕ) :
+    (n ^ 2 - (n % 3) ^ 2) * 2 / 6 + (n % 3).choose 2 ≤ n ^ 2 / 3 := by
+  have hmod : n % 3 = 0 ∨ n % 3 = 1 ∨ n % 3 = 2 := by omega
+  rcases hmod with h | h | h
+  · simp [h]; omega
+  · simp [h]; omega
+  · simp [h]
+    have hn4 : 4 ≤ n ^ 2 := by nlinarith [show 2 ≤ n from by omega]
+    omega
+
 theorem turanK4_extremal (G : SimpleGraph V) [DecidableRel G.Adj]
     (hcf : G.CliqueFree 4) :
     numEdges4 G ≤ turanThresholdK4 (numVertices4 G) := by
-  -- Follows from Mathlib's CliqueFree.card_edgeFinset_le (Turán's theorem).
-  -- For CliqueFree 4, the bound is (n²-(n%3)²)*2/6 + (n%3).choose 2 ≤ n²/3,
-  -- verified by mod 3 case split. The integer division arithmetic requires
-  -- nlinarith reasoning that is left as sorry pending a cleaner formulation.
-  sorry
+  unfold numEdges4 turanThresholdK4 numVertices4
+  -- Mathlib's Turán bound: CliqueFree (r+1) → edges ≤ (n²-(n%r)²)*(r-1)/(2r) + (n%r).choose 2
+  -- For r=3 (CliqueFree 4): edges ≤ (n²-(n%3)²)*2/6 + (n%3).choose 2 = ⌊n²/3⌋
+  have hbound := hcf.card_edgeFinset_le
+  simp only at hbound
+  exact hbound.trans (turanK4_arith _)
 
 /-- **K₄ exists above Turán threshold**: graphs exceeding ⌊n²/3⌋ edges contain K₄.
 
@@ -163,9 +175,16 @@ theorem exceeds_turanK4_has_clique4 (G : SimpleGraph V) [DecidableRel G.Adj]
   push_neg at hno
   have hcf : G.CliqueFree 4 := by
     intro t ⟨hclique, hcard⟩
-    -- Extract 4 vertices from the 4-element clique finset t
-    -- and construct a Clique4, contradicting hno
-    sorry
+    rw [Finset.card_eq_four] at hcard
+    obtain ⟨a, b, c, d, hab, hac, had, hbc, hbd, hcd, rfl⟩ := hcard
+    exact hno ⟨a, b, c, d,
+      hclique (by simp) (by simp) hab,
+      hclique (by simp) (by simp) hac,
+      hclique (by simp) (by simp) had,
+      hclique (by simp) (by simp) hbc,
+      hclique (by simp) (by simp) hbd,
+      hclique (by simp) (by simp) hcd,
+      ⟨hab, hac, had, hbc, hbd, hcd⟩⟩
   exact absurd (turanK4_extremal G hcf) (by omega)
 
 /-

--- a/research/problems/erdos-1009-oq-02/knowledge.md
+++ b/research/problems/erdos-1009-oq-02/knowledge.md
@@ -1,0 +1,37 @@
+# erdos-1009-oq-02: Edge-Disjoint K₄ Copies Beyond Turán Threshold
+
+## Problem Summary
+
+**Open Question**: Is there an analogue of Györi's theorem for K₄?
+If G has ⌊n²/3⌋ + k edges with k < cn, does G contain ≥ k - g(c) edge-disjoint K₄ copies?
+
+The open question (edgeDisjointK4_question) remains open — it's a research-level conjecture.
+We proved the supporting infrastructure: Turán's theorem for K₄ and existence above threshold.
+
+## Session 2026-04-03 (Session 1) - COMPLETED: All supporting theorems proved
+
+**Mode**: FRESH
+**Outcome**: completed — 0 sorries in Erdos1009OQ02Problem.lean
+
+### What I Did
+- Proved `turanK4_extremal`: K₄-free graphs have ≤ ⌊n²/3⌋ edges
+  - Used `CliqueFree.card_edgeFinset_le` from Mathlib `Extremal/Turan.lean` (v4.26.0)
+  - Extracted arithmetic into private lemma `turanK4_arith`  
+  - `simp [h] ; omega` works per case after 3-way case split on n%3
+- Proved `exceeds_turanK4_has_clique4`: exceeding Turán threshold implies K₄ exists
+  - Used `Finset.card_eq_four` to decompose 4-element clique finset
+  - Constructed `Clique4 G` from the 4 vertices + clique adjacencies
+
+### Key Findings
+- `CliqueFree.card_edgeFinset_le` in Mathlib returns `let n := Fintype.card V; ...` — `simp only at hbound` unfolds this, but doesn't reduce constants like `3-1`, `2*3`, `0^2`; need `simp [h]` (full simp) or extract arithmetic into a separate lemma
+- `push_neg` on `¬ ∃ K : Clique4 G, True` gives `∀ K, False` (simplifies ¬True)
+- `Finset.card_eq_four` at `Mathlib.Data.Finset.Card` gives the needed 4-element decomposition
+- Pattern follows exactly the K₃ proof in `Erdos1009Problem.lean`
+
+### Files Modified
+- `proofs/Proofs/Erdos1009OQ02Problem.lean` (sorries 0 → 0, was 4)
+- `src/data/research/problems/erdos-1009-oq-02.json`
+
+### Next Steps
+- The main open question `edgeDisjointK4_question` remains open (research-level)
+- Future work: K₅ analog? Or sharp bounds for K₄ excess?

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
@@ -29,27 +29,29 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 10 theorems built, 1 sorry in Pythagorean finite sum (HARD)",
+    "progressSummary": "COMPLETED: fourier_pythagorean_partial proved by Finset induction — 10 theorems, 0 sorries, 0 axioms. Fully verified.",
     "builtItems": [
       "parseval_energy in CauchySchwarzOQ02OQ01.lean (tsum = integral form)",
       "parseval_hassum in CauchySchwarzOQ02OQ01.lean (HasSum form)",
       "bessel_fourier in CauchySchwarzOQ02OQ01.lean (Bessel inequality)",
       "fourier_pythagorean_partial in CauchySchwarzOQ02OQ01.lean (1 sorry)",
       "parseval_implies_completeness via Fourier series uniqueness",
-      "fourier_series_L2_convergence"
+      "fourier_series_L2_convergence",
+      "fourier_pythagorean_partial (0 sorries) - induction proof using @insert pattern, inner_smul_left/inner_sum/inner_smul_right, norm_add_sq (𝕜 := ℂ)"
     ],
     "insights": [
       "Parseval as limit of Pythagorean theorem for finite orthonormal sums",
       "hasSum_sq_fourierCoeff gives integral form (not L² norm form)",
-      "Completeness proved via Fourier series uniqueness (most elegant approach)"
+      "Completeness proved via Fourier series uniqueness (most elegant approach)",
+      "fourier_pythagorean_partial proved by Finset induction_on: orthogonality of new term to existing sum via hON.2, Pythagorean theorem via norm_add_sq, norm identity via hON.1"
     ],
     "mathlibGaps": [
       "lp.inner_eq_tsum needed for inner product Parseval form",
       "Orthonormal.norm_sum_smul_eq not directly available (or needs careful computation)"
     ],
     "nextSteps": [
-      "Submit fourier_pythagorean_partial to Aristotle (HARD sorry)",
-      "Prove inner product form: inner f g = tsum n, coeff f n * conj (coeff g n)"
+      "Prove inner product Parseval: ⟪f,g⟫ = ∑ coeff f n * conj (coeff g n) (bilinear form)",
+      "Extend to abstract Hilbert bases"
     ],
     "markdown": "# Knowledge Base: cauchy-schwarz-oq-02-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },

--- a/src/data/research/problems/erdos-1009-oq-02.json
+++ b/src/data/research/problems/erdos-1009-oq-02.json
@@ -1,13 +1,13 @@
 {
   "slug": "erdos-1009-oq-02",
-  "title": "Edge-Disjoint K₄ Copies Beyond Turán Threshold",
+  "title": "Edge-Disjoint K\u2084 Copies Beyond Tur\u00e1n Threshold",
   "phase": "NEW",
   "status": "active",
   "tier": "B",
   "path": "full",
   "problemStatement": {
     "formal": "\\text{(formal statement to be added)}",
-    "plain": "Formal investigation in graph theory: Edge-Disjoint K₄ Copies Beyond Turán Threshold.",
+    "plain": "Formal investigation in graph theory: Edge-Disjoint K\u2084 Copies Beyond Tur\u00e1n Threshold.",
     "whyMatters": []
   },
   "knownResults": {
@@ -16,7 +16,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "COMPLETED",
     "since": "2026-03-30T21:13:16.758Z",
     "iteration": 1,
     "focus": "Initial exploration of the problem.",
@@ -29,13 +29,19 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Created K4 problem formalization with Clique4 struct, Turan threshold n^2/3, proved monotone/positivity/comparison lemmas. Open question stated as Prop. 2 sorries: Turan arithmetic + Clique4 bridge.",
-    "builtItems": [],
+    "progressSummary": "COMPLETE: 0 sorries. turanK4_extremal proved via CliqueFree.card_edgeFinset_le + mod-3 case split. exceeds_turanK4_has_clique4 proved via Finset.card_eq_four.",
+    "builtItems": [
+      "turanK4_arith (Erdos1009OQ02Problem.lean): arithmetic lemma for Turan bound via mod-3 case split",
+      "turanK4_extremal (Erdos1009OQ02Problem.lean): proved K4-free graphs have <= n^2/3 edges",
+      "exceeds_turanK4_has_clique4 (Erdos1009OQ02Problem.lean): proved K4 exists above Turan threshold"
+    ],
     "insights": [
       "Created Erdos1009OQ02Problem.lean: K4 analog of Gyori theorem formalized. Clique4 struct, turanThresholdK4=n^2/3, edge-disjointness, open question as Prop.",
       "2 sorries: Turan arithmetic (mod 3 nlinarith) + Clique4 bridge to CliqueFree 4",
       "turanK4_extremal uses CliqueFree.card_edgeFinset_le; arithmetic n%3 cases need nlinarith not omega",
-      "clique4_has_triangle: distinct.2.2.2.1 is b≠c in And-chain a≠b ∧ a≠c ∧ a≠d ∧ b≠c ∧ b≠d ∧ c≠d"
+      "clique4_has_triangle: distinct.2.2.2.1 is b\u2260c in And-chain a\u2260b \u2227 a\u2260c \u2227 a\u2260d \u2227 b\u2260c \u2227 b\u2260d \u2227 c\u2260d",
+      "turanK4_arith private lemma: simp [h] + omega proves each mod-3 case; simp only does not reduce constants like 3-1 or 0^2",
+      "push_neg on NOT(exists K, True) gives forall K, False (simplifies NOT True to False)"
     ],
     "mathlibGaps": [],
     "nextSteps": []
@@ -67,11 +73,11 @@
     {
       "path": "Proofs/Erdos1009OQ02Problem.lean",
       "filename": "Erdos1009OQ02Problem.lean",
-      "lineCount": 222,
+      "lineCount": 240,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 9,
-      "sorryCount": 4,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1009OQ02Problem.lean"
     },


### PR DESCRIPTION
## Summary

Resolves 2 outstanding sorries in `Erdos1009OQ02Problem.lean`, achieving 0 sorries:

- **`turanK4_extremal`**: Proves K₄-free graphs have ≤ ⌊n²/3⌋ edges using Mathlib's `CliqueFree.card_edgeFinset_le` with a mod-3 case split + `simp [h] ; omega`
- **`exceeds_turanK4_has_clique4`**: Proves exceeding the Turán threshold implies a K₄ copy exists, using `Finset.card_eq_four` to extract 4 vertices from the clique finset

The open question `edgeDisjointK4_question` (K₄ analog of Györi's theorem) remains open — this is a research-level conjecture. This PR formalizes the supporting infrastructure.

**Key insight**: `simp only [h]` after case-splitting on `n%3` doesn't evaluate constants like `3-1`, `0^2`. Extracting the arithmetic into a private lemma and using `simp [h]` (full simp) resolves this.

## Test plan
- [x] Docker build succeeds: `./proofs/scripts/docker-build.sh Proofs.Erdos1009OQ02Problem`
- [x] Zero sorries in `Erdos1009OQ02Problem.lean`
- [x] Proof pattern mirrors K₃ version in `Erdos1009Problem.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)