### PR TITLE
Fix: downgrade pac-learning-bounds and prob-method-applications from verified/original

### DIFF
--- a/src/data/proofs/pac-learning-bounds/meta.json
+++ b/src/data/proofs/pac-learning-bounds/meta.json
@@ -7,7 +7,7 @@
     "author": "Vapnik-Chervonenkis (1971), Valiant (1984), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Vapnik%E2%80%93Chervonenkis_dimension",
     "date": "1984",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/PACLearning.lean",
     "tags": [
       "learning-theory",
@@ -16,7 +16,7 @@
       "cs-math-bridge",
       "advanced"
     ],
-    "badge": "original",
+    "badge": "wip",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/prob-method-applications/meta.json
+++ b/src/data/proofs/prob-method-applications/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdos and collaborators, formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Probabilistic_method",
     "date": "1947",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/ProbMethodApplications.lean",
     "tags": [
       "probabilistic-method",
@@ -16,7 +16,7 @@
       "graph-theory",
       "advanced"
     ],
-    "badge": "original",
+    "badge": "wip",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

Both proofs claim `status: verified` with `badge: original` but contain True stubs for their main theorems.

## Evidence

**pac-learning-bounds Before**: `status: verified`, `badge: original`
**pac-learning-bounds After**: `status: formalized`, `badge: wip`
- `fundamental_theorem_stat_learning` (line 101) proves `True := trivial` instead of PAC learnability
- `growthFunction` is a placeholder returning 0, making `sauer_shelah` trivially true

**prob-method-applications Before**: `status: verified`, `badge: original`  
**prob-method-applications After**: `status: formalized`, `badge: wip`
- `high_girth_high_chromatic` (line 25) proves `True := trivial` instead of graph existence

Both `assumptions` fields already accurately document the True stubs; this fix aligns `status` and `badge` with that reality.

Closes #9005

---
Automated fix by lean-mechanic agent.