### PR TITLE
Fix: downgrade hilbert-14-oq-01 from verified to formalized/wip

### DIFF
--- a/src/data/proofs/hilbert-14-oq-01/meta.json
+++ b/src/data/proofs/hilbert-14-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Grosshans (1997), Nagata (1959), Weitzenböck (1932)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Hilbert%27s_fourteenth_problem",
     "date": "1997",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Hilbert14NonReductive.lean",
     "tags": [
       "invariant-theory",
@@ -16,7 +16,7 @@
       "hilbert-problems",
       "algebraic-geometry"
     ],
-    "badge": "verified",
+    "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "No axioms. Former grosshans_characterization axiom eliminated (was trivially provable placeholder). Grosshans theorem stated as GrosshansSubgroup G H → True since full statement requires AlgebraicGroup infrastructure not in Mathlib. All definitions and theorems fully proved.",


### PR DESCRIPTION
## Fix

hilbert-14-oq-01 claims `status: verified` with `badge: verified` but the main summary theorem is a True stub and multiple structure fields are placeholder-True.

## Evidence

**Before**: `status: verified`, `badge: verified`
**After**: `status: formalized`, `badge: wip`

From `Proofs/Hilbert14NonReductive.lean`:
- `GrosshansSubgroup.quotient_fg : True` — structure field placeholder
- `reductive_subgroup_grosshans` proves `GrosshansSubgroup G H → True` (vacuous)
- `characterization_summary : True := trivial` (line 321) — main theorem is vacuous

The `assumptions` field already correctly documents that "Grosshans theorem stated as GrosshansSubgroup G H → True since full statement requires AlgebraicGroup infrastructure not in Mathlib." This fix aligns `status` and `badge` with that reality.

Closes #9010

---
Automated fix by lean-mechanic agent.