### PR TITLE
Fix: close unclosed block comments in 4 Erdős Lean files

### DIFF
--- a/proofs/Proofs/Erdos15Problem.lean
+++ b/proofs/Proofs/Erdos15Problem.lean
@@ -73,7 +73,7 @@ def AlternatingPrimeSeriesConverges : Prop :=
 The Prime Number Theorem tells us p_n ~ n log n.
 -/
 
-/-- The Prime Number Theorem: p_n / (n log n) → 1 as n → ∞.
+/-- The Prime Number Theorem: p_n / (n log n) → 1 as n → ∞. -/
 
 /-- Consequence: n / p_n ~ 1 / log n → 0.
 

--- a/proofs/Proofs/Erdos231Problem.lean
+++ b/proofs/Proofs/Erdos231Problem.lean
@@ -128,7 +128,7 @@ The key result: infinite abelian-square-free strings exist over 4 letters.
 -/
 
 /-- Keränen (1992): There exists an infinite sequence over 4 letters
-    with no abelian squares.
+    with no abelian squares. -/
 
 /-- The Keränen morphism (85 letters per symbol) that generates
     abelian-square-free words. -/

--- a/proofs/Proofs/Erdos297Problem.lean
+++ b/proofs/Proofs/Erdos297Problem.lean
@@ -132,7 +132,7 @@ The first proof that c < 1, establishing egyptianCount(N) ≤ 2^{0.93N}.
 def steinerbergerConstant : ℝ := 0.93
 
 /-- **Steinerberger (2024, arXiv:2403.17041):**
-    The Egyptian count satisfies egyptianCount(N) ≤ 2^{0.93N} for all sufficiently large N.
+    The Egyptian count satisfies egyptianCount(N) ≤ 2^{0.93N} for all sufficiently large N. -/
 
 /-
 ## Part 6: Liu-Sawhney's Full Asymptotic (April 2024)
@@ -174,7 +174,7 @@ noncomputable def egyptianCountTarget (N : ℕ) (x : ℚ) : ℕ :=
 
 /-- **Conlon et al. generalization:**
     For any rational x > 0, there exists a constant c_x ∈ (0, 1) such that
-    egyptianCountTarget(N, x) = 2^{(c_x + o(1))N}.
+    egyptianCountTarget(N, x) = 2^{(c_x + o(1))N}. -/
 
 /-
 ## Part 8: The 2017 MathOverflow Precedent
@@ -193,7 +193,7 @@ The constraint Σ 1/n = 1 exactly is very restrictive.
 -/
 
 /-- **Heuristic:** For a random subset of {1,...,N}, the expected harmonic sum is
-    E[Σ 1/n] ≈ (1/2) · H_N ≈ (log N)/2, which grows without bound.
+    E[Σ 1/n] ≈ (1/2) · H_N ≈ (log N)/2, which grows without bound. -/
 
 /-
 ## Part 10: Main Results

--- a/proofs/Proofs/Erdos657Problem.lean
+++ b/proofs/Proofs/Erdos657Problem.lean
@@ -152,7 +152,7 @@ noncomputable def numDifferences (A : Finset ℝ) : ℕ :=
 
 /-- **Straus's Observation:**
     If 2^k ≥ n, there exist n points in ℝ^k with no isosceles triangle
-    that determine at most n-1 distinct distances.
+    that determine at most n-1 distinct distances. -/
 
 /-
 ## Part IX: Known Examples


### PR DESCRIPTION
## Summary

- **erdos-15** (line 76): unclosed `/--` swallowed `axiom terms_tend_to_zero`
- **erdos-231** (line 130): unclosed `/--` swallowed `axiom erdos_231_disproved`
- **erdos-297** (lines 134, 175, 195): 3 unclosed `/--` swallowed all 3 axioms
- **erdos-657** (line 153): unclosed `/--` swallowed `axiom f_tends_to_infinity`

Each fix adds `-/` to the end of the doc comment text, so subsequent section headers and axiom declarations are no longer inside the comment.

## Root Cause

Doc comments opened with `/--` were not closed before the next `/-` section header. Because Lean block comments nest, the section header `/-...-/` was treated as a nested comment inside the outer doc comment, and the outer comment remained open for the rest of the file.

## Impact

Without this fix, the `axiom` declarations are inside block comments and are not parsed by the Lean kernel. The `meta.json` fields `axiomCount` and `status: "axiomatized"` are correct in intent but the Lean files were structurally broken.

## Test Plan

- [x] `stripLeanComments` on fixed files: all show `stripped == raw` axiom count
- [ ] Confirm files parse without syntax errors (`lake check` or docker build)

---
🤖 Discovered and fixed by lean-auditor integrity scan