### PR TITLE
Fix: erdos-1009-oq-02 sorries count stale (2→0)

### DIFF
--- a/src/data/proofs/erdos-1009-oq-02/meta.json
+++ b/src/data/proofs/erdos-1009-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (open question, K₄ analog of #1009)",
     "sourceUrl": "https://erdosproblems.com/1009",
     "date": "1971",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos1009OQ02Problem.lean",
     "tags": [
       "erdos",
@@ -20,7 +20,7 @@
       "extremal-combinatorics"
     ],
     "badge": "original",
-    "sorries": 2,
+    "sorries": 0,
     "erdosNumber": 1009,
     "erdosUrl": "https://erdosproblems.com/1009",
     "erdosProblemStatus": "open",
@@ -28,7 +28,7 @@
     "mathlib_version": "4.26.0",
     "lineCount": 221,
     "axiomCount": 0,
-    "assumptions": "2 sorries: (1) Turán bound arithmetic (n²/3 from CliqueFree 4 mod 3 cases); (2) bridge from absence of Clique4 to CliqueFree 4. Main open question stated as Prop.",
+    "assumptions": "0 sorries, 0 axioms. Both supporting theorems proved: turanK4_extremal (K₄-free graphs have ≤ ⌊n²/3⌋ edges, via Mathlib's CliqueFree.card_edgeFinset_le) and exceeds_turanK4_has_clique4 (contrapositive). The open question edgeDisjointK4_question is stated as a Prop definition — not proved and not axiomatized.",
     "mathlibDependencies": [
       {
         "theorem": "SimpleGraph.CliqueFree.card_edgeFinset_le",


### PR DESCRIPTION
## Fix

Update `erdos-1009-oq-02` meta.json to reflect actual proof state after research commit.

## Evidence

Research commit `a008ef30b9` (PR #9009) proved both sorries in `Erdos1009OQ02Problem.lean`:
1. `turanK4_extremal` — Turán bound proved via `CliqueFree.card_edgeFinset_le`
2. `exceeds_turanK4_has_clique4` — proved as contrapositive

The Lean file now has **0 sorry tactics** (only 1 occurrence of "sorry" which is inside a block comment on line 170). The meta.json was not updated in that commit.

**Before**:
- `sorries: 2`
- `status: "formalized"`
- `assumptions: "2 sorries: (1) Turán bound arithmetic; (2) bridge from absence of Clique4 to CliqueFree 4..."`

**After**:
- `sorries: 0`
- `status: "verified"`
- `assumptions: "0 sorries, 0 axioms. Both supporting theorems proved..."`

## Verification

- [x] JSON validates (`python3 -m json.tool`)
- [x] Gallery builds successfully (`pnpm build`)
- [x] No sorry tactics in Lean file (confirmed by comment-aware scan)
- [x] axiomCount: 0 already correct

---
Automated fix by lean-mechanic agent.