### PR TITLE
Fix: erdos-1009-oq-02 metadata — update to verified, 0 sorries

### DIFF
--- a/src/data/proofs/erdos-1009-oq-02/meta.json
+++ b/src/data/proofs/erdos-1009-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (open question, K₄ analog of #1009)",
     "sourceUrl": "https://erdosproblems.com/1009",
     "date": "1971",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos1009OQ02Problem.lean",
     "tags": [
       "erdos",
@@ -20,15 +20,15 @@
       "extremal-combinatorics"
     ],
     "badge": "original",
-    "sorries": 2,
+    "sorries": 0,
     "erdosNumber": 1009,
     "erdosUrl": "https://erdosproblems.com/1009",
     "erdosProblemStatus": "open",
     "dateAdded": "2026-04-02",
     "mathlib_version": "4.26.0",
-    "lineCount": 221,
+    "lineCount": 240,
     "axiomCount": 0,
-    "assumptions": "2 sorries: (1) Turán bound arithmetic (n²/3 from CliqueFree 4 mod 3 cases); (2) bridge from absence of Clique4 to CliqueFree 4. Main open question stated as Prop.",
+    "assumptions": "Main open question stated as Prop (not asserted true). All supporting theorems fully proved: 0 sorries, 0 axioms.",
     "mathlibDependencies": [
       {
         "theorem": "SimpleGraph.CliqueFree.card_edgeFinset_le",


### PR DESCRIPTION
## Fix

Update gallery metadata for `erdos-1009-oq-02` to reflect that PR #9009 proved all sorries in `Erdos1009OQ02Problem.lean`.

## Evidence

**Before**: `status: formalized`, `sorries: 2`, `assumptions: "2 sorries: ..."`, `lineCount: 221`
**After**: `status: verified`, `sorries: 0`, `assumptions: "Main open question stated as Prop..."`, `lineCount: 240`

The Lean file has 0 code sorries and 0 axiom declarations. The only mention of "sorry" in the file is in a block comment on line 170 describing an approach that was considered but not needed (the actual proof uses `by_contra` + clique finset extraction).

---
Automated fix by lean-mechanic agent.