### PR TITLE
Enrich 8 gallery proofs: QR Gauss sums, Erdős 131, prime gaps, EKR, ballot, Wilson's, Ceva

### DIFF
--- a/src/data/proofs/erdos-1006-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1006-oq-01/annotations.json
@@ -1,1 +1,62 @@
-[]
+[
+  {
+    "id": "ann-1006-orientation-structure",
+    "proofId": "erdos-1006-oq-01",
+    "range": { "startLine": 43, "endLine": 74 },
+    "type": "definition",
+    "title": "GraphOrientation: Encoding Edge Direction",
+    "content": "The GraphOrientation structure captures an orientation of a SimpleGraph G via four fields: `arc u v : Prop` (a directed edge from u to v), `covers` (every undirected edge is assigned a direction), `exclusive` (no edge is directed both ways), and `respects` (every arc corresponds to a graph edge). This avoids Mathlib's `Orientation` type from linear algebra. The three key predicates then build on top: `isAcyclic` uses a rank function (topological sort witness), `hasDependentArc` captures arcs that 'force' a rank ordering, and `isRobustlyAcyclic` combines acyclicity with absence of dependent arcs.",
+    "mathContext": "An orientation $O$ of $G$ is a function $\\mathrm{arc}: V \\times V \\to \\mathrm{Prop}$ with: for each $\\{u,v\\} \\in E(G)$, exactly one of $\\mathrm{arc}(u,v)$ or $\\mathrm{arc}(v,u)$ holds. $O$ is *acyclic* if $\\exists$ rank$: V \\to \\mathbb{N}$ such that $\\mathrm{arc}(u,v) \\Rightarrow \\mathrm{rank}(u) < \\mathrm{rank}(v)$.",
+    "significance": "key",
+    "relatedConcepts": ["topological sort", "DAG", "Hasse diagram", "acyclicity", "directed graph"],
+    "prerequisites": ["SimpleGraph in Mathlib", "Prop-valued predicates in Lean", "topological ordering"]
+  },
+  {
+    "id": "ann-1006-empty-robust",
+    "proofId": "erdos-1006-oq-01",
+    "range": { "startLine": 80, "endLine": 90 },
+    "type": "technique",
+    "title": "Base Case: Empty Graph is Robustly Acyclic",
+    "content": "emptyOrientation sets arc = False (no directed edges). The three structural conditions hold trivially: covers follows because the empty graph has no edges to cover, exclusive is vacuously true, respects is vacuously true. The proof of empty_graph_robust provides the rank function (constantly 0) and notes that the dependent arc condition is vacuously empty. This establishes the base case and demonstrates the Lean proof pattern for trivial orientations.",
+    "mathContext": "For $G = \\bot$ (the empty graph with no edges), any orientation is robustly acyclic since $E(G) = \\emptyset$ means there are no arcs that could form a cycle or be reversed.",
+    "significance": "technical",
+    "relatedConcepts": ["SimpleGraph.bot", "vacuous truth", "empty graph"],
+    "prerequisites": ["GraphOrientation definition", "isRobustlyAcyclic definition"]
+  },
+  {
+    "id": "ann-1006-cover-orientation",
+    "proofId": "erdos-1006-oq-01",
+    "range": { "startLine": 119, "endLine": 167 },
+    "type": "insight",
+    "title": "Cover Orientation: Posets Admit Robust Orientations",
+    "content": "isCoverGraphOf formalizes that G is the Hasse diagram of a PartialOrder on V: edges of G correspond exactly to covering pairs (u ⋖ v or v ⋖ u). The coverOrientation orients by u → v when u ⋖ v (the covering relation). The posetRank function counts |{x : x < a}|, giving a natural topological sort. posetRank_strictMono proves that a < b implies posetRank a < posetRank b (using Finset.card_lt_card). cover_graph_admits_robust then proves robustness: the rank function witnesses acyclicity, and any dependent arc (u,v) would require rank v ≤ rank u — but posetRank_strictMono guarantees rank u < rank v for u ⋖ v.",
+    "mathContext": "For a cover graph $G$ with poset $(V, \\leq)$: orient by $u \\to v$ iff $u \\lessdot v$ (cover relation). The rank $r(a) = |\\{x \\in V : x < a\\}|$ satisfies $a < b \\Rightarrow r(a) < r(b)$, making every arc go from lower to higher rank. No arc can be dependent since the rank strictly separates every covering pair.",
+    "significance": "key",
+    "relatedConcepts": ["partial order", "cover relation", "Hasse diagram", "topological sort", "Finset.card_lt_card"],
+    "prerequisites": ["PartialOrder in Mathlib", "CovBy (⋖) definition", "Fintype and decidability", "posetRank_strictMono"]
+  },
+  {
+    "id": "ann-1006-bipartite-robust",
+    "proofId": "erdos-1006-oq-01",
+    "range": { "startLine": 207, "endLine": 224 },
+    "type": "insight",
+    "title": "Bipartite Orientation is Robustly Acyclic",
+    "content": "bipartiteOrientation_robust is the most technically interesting proved result. The bipartite orientation sets arc(u,v) iff G.Adj u v ∧ side u = false ∧ side v = true (orient false-side to true-side). Acyclicity uses rank: false-side → 0, true-side → 1. For robustness, suppose arc (u,v) is dependent: for all rank functions consistent with other arcs, rank v ≤ rank u. We instantiate the rank function with false→0, true→1. All other arcs go false→true (rank 0 < 1), so this is a valid witness. But side u = false gives rank u = 0 and side v = true gives rank v = 1, so the dependent arc condition would require 1 ≤ 0 — contradiction by simp [hu, hv].",
+    "mathContext": "Bipartite orientation: $\\mathrm{arc}(u,v) \\Leftrightarrow \\{u,v\\} \\in E(G) \\wedge \\mathrm{side}(u)=0 \\wedge \\mathrm{side}(v)=1$. Rank witness: $r(v) = [\\mathrm{side}(v) = 1]$ (0 or 1). Dependence of $(u,v)$ requires $r(v) \\leq r(u)$ for ALL consistent rankings — but $r(u) = 0 < 1 = r(v)$ for all rank functions extending the bipartite structure.",
+    "significance": "key",
+    "relatedConcepts": ["bipartite graph", "2-coloring", "height-2 poset", "rank function", "proof by contradiction"],
+    "prerequisites": ["isBipartite' definition", "bipartiteOrientation construction", "hasDependentArc semantics"]
+  },
+  {
+    "id": "ann-1006-axioms",
+    "proofId": "erdos-1006-oq-01",
+    "range": { "startLine": 240, "endLine": 260 },
+    "type": "context",
+    "title": "Axiomatized Deep Results: The Full Characterization",
+    "content": "Three axioms capture the deep theorems that require nontrivial proof not yet formalized in Lean. cover_graph_characterization (Pretzel-Brightwell 1985) is the main result: robust orientation ↔ cover graph. The other direction (robust → cover graph) is the harder direction: one must show that the transitive closure of any robust orientation is a poset and the orientation is exactly its Hasse diagram. chromatic_lt_girth_implies_robust (Fisher-Fraughnaugh-Langley-West 1997) gives a sufficient condition for being a cover graph via a chromatic-girth bound. nesetril_rodl_counterexample (1978) asserts existence of non-cover graphs of every girth ≥ 3, showing the characterization is non-trivial and girth alone does not imply cover graph structure.",
+    "mathContext": "Pretzel-Brightwell: $G$ admits robust orientation $\\Leftrightarrow$ $G \\cong \\mathrm{Hasse}(P)$ for some poset $P$. Fisher et al.: $\\chi(G) < g(G) \\Rightarrow G$ is a cover graph. Nešetřil-Rödl: $\\forall g \\geq 3, \\exists G$ with $\\mathrm{girth}(G) = g$ and $G$ not a cover graph.",
+    "significance": "key",
+    "relatedConcepts": ["Pretzel-Brightwell theorem", "chromatic number", "girth", "Nešetřil-Rödl", "poset characterization"],
+    "prerequisites": ["isCoverGraph definition", "admitsRobustAcyclicOrientation", "SimpleGraph.Coloring", "SimpleGraph.Walk.length"]
+  }
+]

--- a/src/data/proofs/erdos-1006-oq-01/meta.json
+++ b/src/data/proofs/erdos-1006-oq-01/meta.json
@@ -34,15 +34,16 @@
     ]
   },
   "overview": {
-    "historicalContext": "Erdős Problem #1006 asks for a characterization of which graphs admit 'robustly acyclic' orientations — orientations where no single edge reversal can create a directed cycle. Pretzel (1985) and Brightwell showed these are exactly the cover graphs of partial orders (Hasse diagrams). Nešetřil and Rödl (1978) showed that for every girth g, there exist graphs with girth g that are NOT cover graphs. This connects orientation theory to poset theory in a surprising way.",
-    "problemStatement": "Characterize the finite graphs that admit a robustly acyclic orientation. Prove the Pretzel-Brightwell cover graph characterization.",
+    "historicalContext": "Erdős Problem #1006 asks: which finite graphs admit a 'robustly acyclic' orientation — one where no single edge reversal creates a directed cycle? The question arises from order theory: Hasse diagrams of partial orders are naturally robustly acyclic (the covering relation can't be reversed without collapsing the order). Oliver Pretzel (1985) proved that these are the *only* such graphs — a graph admits a robustly acyclic orientation if and only if it is the Hasse diagram (cover graph) of some partial order. Nešetřil and Rödl (1978), before the characterization was known, had already shown that the class is non-trivial: for every girth $g \\geq 3$, there exist graphs with girth $g$ that are NOT cover graphs (and hence admit no robust orientation). This was surprising because high girth graphs were expected to be structurally simple. Fisher, Fraughnaugh, Langley, and West (1997) later gave the sufficient condition $\\chi(G) < \\mathrm{girth}(G)$: when chromatic number is strictly less than girth, the graph is 'sparse enough' to be a cover graph. The formalization here proves the easy direction (cover graphs → robust orientation) and the bipartite special case, while axiomatizing the deeper characterization.",
+    "problemStatement": "Characterize the finite graphs that admit a robustly acyclic orientation: an orientation $O$ of $G$ is robustly acyclic if it is acyclic and for every edge $e$, reversing $e$ in $O$ yields another acyclic orientation. Prove the Pretzel-Brightwell theorem: $G$ admits a robustly acyclic orientation $\\Leftrightarrow$ $G$ is a cover graph of some poset.",
     "text": "An orientation is robustly acyclic if it is acyclic and reversing any single edge preserves acyclicity. Equivalently, an orientation is robust iff every edge is 'independent' (reversing it doesn't create a cycle). The Pretzel-Brightwell theorem: G has a robust orientation iff G is the Hasse diagram of some partial order — i.e., the edges of G can be made into cover relations of a poset. The connection: in a robust orientation, the transitive closure is a partial order, and the orientation is exactly the Hasse diagram.",
-    "proofStrategy": "Define robustly acyclic orientations and cover graphs. Axiomatize the Pretzel-Brightwell characterization. Prove easy cases: empty graphs and bipartite graphs. Axiomatize Nešetřil-Rödl examples showing the characterization is sharp. Axiomatize the sufficient condition χ < girth.",
+    "proofStrategy": "Define robustly acyclic orientations via `GraphOrientation` (a structure encoding arc function, coverage, exclusivity, and graph-consistency). Define `isAcyclic` via topological rank function, `hasDependentArc` as the property that some arc (u,v) forces rank v ≤ rank u even when all other arcs are considered. Prove easy cases constructively: empty graphs and bipartite graphs. For the bipartite case, the 2-coloring gives a height-2 rank function that witnesses acyclicity and blocks all dependent arcs. For cover graphs, the `posetRank` (count of elements strictly below) is the topological sort. Axiomatize the full characterization and the Nešetřil-Rödl counterexamples.",
     "keyInsights": [
-      "Robust = stable under edge reversal: removing the 'fragile' edges gives the Hasse diagram",
-      "Cover graph ↔ Hasse diagram: edges of G are exactly the cover relations of the poset",
-      "Chromatic number < girth: a sufficient condition that ensures enough structure for robust orientation",
-      "Nešetřil-Rödl: triangle-free graphs with no robust orientation exist — the characterization is non-trivial"
+      "Robust acyclicity has a topological meaning: an arc $(u,v)$ is *dependent* if every rank function consistent with the other arcs must have $\\mathrm{rank}(v) \\leq \\mathrm{rank}(u)$ — meaning the arc is 'forced' by the structure, and cannot be reversed without contradiction.",
+      "The cover graph connection is natural: the Hasse diagram of a poset is robust by construction, because every covering relation $u \\lessdot v$ has $\\mathrm{posetRank}(u) < \\mathrm{posetRank}(v)$, and no arc can be made dependent when the rank function is strictly monotone on covers.",
+      "Bipartite graphs are exactly the height-$\\leq 2$ cover graphs: the two-coloring corresponds to a poset with all elements on level 0 or level 1, and the bipartite orientation (false → true) is the Hasse diagram of this height-2 poset.",
+      "The Nešetřil-Rödl result is non-constructive: it asserts the existence of non-cover graphs of arbitrarily high girth using probabilistic or explicit algebraic constructions, showing that girth alone cannot bound the complexity of cover graph structure.",
+      "The Fisher-Fraughnaugh-Langley-West condition $\\chi(G) < g$ provides an effective sufficient criterion: graphs with few colors relative to their girth have enough local tree-like structure that a compatible poset orientation can be built."
     ],
     "prerequisites": [
       "Graph orientations: directed graphs from undirected",
@@ -50,13 +51,64 @@
       "Posets: partial orders, Hasse diagrams, cover relations"
     ]
   },
+  "sections": [
+    {
+      "id": "sec-imports",
+      "title": "Imports and Setup",
+      "startLine": 28,
+      "endLine": 39,
+      "summary": "Imports all of Mathlib and opens SimpleGraph namespace. Introduces universe-polymorphic vertex type V. Names the orientation structure GraphOrientation to avoid conflict with Mathlib's Orientation from linear algebra."
+    },
+    {
+      "id": "sec-definitions",
+      "title": "Core Definitions: Orientation Predicates",
+      "startLine": 41,
+      "endLine": 74,
+      "summary": "Defines GraphOrientation (arc function with covers, exclusive, respects), isAcyclic (rank witness for topological order), hasDependentArc (arc forced by structure — reversing creates a cycle), isRobustlyAcyclic (acyclic and no dependent arcs), and admitsRobustAcyclicOrientation (graph has at least one robust orientation)."
+    },
+    {
+      "id": "sec-empty-graph",
+      "title": "Base Case: Empty Graph",
+      "startLine": 76,
+      "endLine": 90,
+      "summary": "Constructs emptyOrientation for the bottom SimpleGraph (no edges) with arc = False everywhere. Proves empty_graph_robust: the empty orientation is robustly acyclic because there are no arcs to form cycles or dependent edges."
+    },
+    {
+      "id": "sec-linear-order",
+      "title": "Linear Order Orientation",
+      "startLine": 92,
+      "endLine": 111,
+      "summary": "Constructs linearOrientation using a LinearOrder on V: orient u → v when u < v. This is acyclic (the linear order itself is the rank function) and is used as a building block for cover orientations."
+    },
+    {
+      "id": "sec-cover-graph",
+      "title": "Poset Orientation and Cover Graph Theorem",
+      "startLine": 113,
+      "endLine": 167,
+      "summary": "Defines isCoverGraphOf: G edges correspond exactly to covering pairs of a PartialOrder on V. Constructs coverOrientation: orient by u ⋖ v. Defines posetRank as |{x : x < a}| (count of elements strictly below). Proves posetRank_strictMono and cover_graph_admits_robust: cover graphs admit robust orientations."
+    },
+    {
+      "id": "sec-bipartite",
+      "title": "Bipartite Orientation",
+      "startLine": 169,
+      "endLine": 230,
+      "summary": "Defines isBipartite' and bipartiteOrientation (orient false-side to true-side). Proves bipartiteOrientation_acyclic (rank: false→0, true→1), bipartiteOrientation_robust (no arc can be dependent since reversing would cross the bipartition), and bipartite_admits_robust."
+    },
+    {
+      "id": "sec-axioms",
+      "title": "Axiomatized Deep Results",
+      "startLine": 232,
+      "endLine": 261,
+      "summary": "Defines isCoverGraph (existence of a PartialOrder making G a cover graph). Axiomatizes: cover_graph_characterization (Pretzel-Brightwell 1985: robust ↔ cover graph), chromatic_lt_girth_implies_robust (Fisher et al. 1997), nesetril_rodl_counterexample (1978: non-cover graphs of every girth ≥ 3 exist)."
+    }
+  ],
   "conclusion": {
-    "summary": "Robustly acyclic orientations formalized: cover graph characterization (Pretzel-Brightwell 1985) axiomatized, easy cases proved (empty, bipartite), Nešetřil-Rödl examples axiomatized. 6 theorems, 277 lines, 3 axioms.",
-    "implications": "The Pretzel-Brightwell characterization connects combinatorial orientation theory to order theory. It has applications in scheduling (poset scheduling = finding a robust orientation) and information flow analysis.",
+    "summary": "Formalizes Erdős #1006 OQ-01: characterizes robustly acyclic orientations as cover graphs of posets. Proves the easy direction constructively (cover graphs and bipartite graphs admit robust orientations) with machine-verified proofs. Axiomatizes the full equivalence (Pretzel-Brightwell 1985) and the counterexample existence (Nešetřil-Rödl 1978). 6 theorems, 277 lines, 3 axioms.",
+    "implications": "The Pretzel-Brightwell characterization is a striking bridge between orientation theory and order theory — it says that 'robustness under perturbation' in orientations is exactly captured by the poset structure of cover graphs. This has applications in scheduling (finding a robust ordering for job dependencies), lattice theory (identifying which graphs are Hasse diagrams), and database theory (stable acyclic transactions). The Nešetřil-Rödl result implies that the property is not monotone in girth alone — high-girth graphs can still fail to be cover graphs.",
     "openQuestions": [
-      "Prove cover_graph_characterization without axioms using Lean 4's poset theory",
-      "Formalize the Nešetřil-Rödl explicit counterexample constructions",
-      "Algorithmic complexity: is recognizing cover graphs in P? (known to be in P)"
+      "Prove cover_graph_characterization without axioms: formalize Pretzel's original proof that robustly acyclic orientations must be Hasse diagrams by showing that dependent arcs produce 'incomparable' elements in any linearization, forcing a poset structure.",
+      "Formalize the algorithmic recognition: cover graph recognition is in polynomial time (it reduces to testing whether a graph is the comparability graph of a partial order). Can this be encoded in Lean using Fintype computability?",
+      "Generalize to robustness under $k$ edge reversals: which graphs admit orientations that remain acyclic after any $k$ simultaneous edge reversals? This extends the Pretzel-Brightwell theory to $k$-robust orientations."
     ]
   },
   "leanFile": {
@@ -68,10 +120,19 @@
   },
   "crossReferences": [
     {
-      "targetId": "ramseys-theorem",
+      "id": "erdos-1006",
+      "relationship": "parent",
+      "description": "Erdős Problem #1006 main entry — the original problem about robustly acyclic orientations and girth constraints."
+    },
+    {
+      "id": "erdos-1006-oq-02",
+      "relationship": "sibling",
+      "description": "Minimum Chromatic Number for Non-Robustly-Orientable Graphs — the companion question about chromatic bounds for graphs that fail to have robust orientations."
+    },
+    {
+      "id": "ramseys-theorem",
       "relationship": "related",
-      "description": "Both involve Erdős problems in graph combinatorics; Ramsey studies colorings, this studies orientations"
+      "description": "Ramsey's Theorem — another foundational Erdős-area result connecting graph structure (colorings) to global combinatorial properties; both exhibit surprising phase transitions."
     }
-  ],
-  "sections": []
+  ]
 }


### PR DESCRIPTION
## Enrichment Summary

8 gallery proofs enriched with annotations, historical context, key insights, and sections.

### Proofs Enriched

1. **Gauss Sums (QR)** — 10 annotations, quadratic residue characters, Gauss's original proof strategy
2. **Erdős #131 (Sidon Sets)** — 10 annotations, probabilistic construction, B_h generalization
3. **Erdős #5 (Prime Gap Limit Points)** — 10 annotations, Zhang 2013 breakthrough, bounded gaps
4. **Erdős-Ko-Rado** — 10 annotations, Katona double-counting (1972), ALZW 2020 sunflower
5. **Ballot Problem (OQ-01/02)** — 10 annotations, fiber bijection (extractOpponents/reconstructSeq), LGV connection
6. **Wilson's Theorem (OQ-01)** — 10 annotations, Wilson primes (5/13/563), Gauss-Wilson classification
7. **Ceva's Theorem (OQ-01)** — 10 annotations, 9 sections, explicit concurrency formula, Routh 1/7 theorem
   - Historical context: Giovanni Ceva 1678, Al-Mu'taman ibn Hûd ~1085, Routh 1891
   - Covers all 907 lines: geometric foundations through Routh's theorem
   - AffineMap2D transfer strategy documented, altitude/incenter/orthocenter applications

🤖 Generated with [Claude Code](https://claude.com/claude-code)