### PR TITLE
Fix: replace /-! with /- in Erdos1126OQ01Aristotle companion

### DIFF
--- a/proofs/Proofs/Erdos1126OQ01Aristotle.lean
+++ b/proofs/Proofs/Erdos1126OQ01Aristotle.lean
@@ -19,7 +19,7 @@ open MeasureTheory Set
 
 namespace Erdos1126OQ01Aristotle
 
-/-! ## Null set preservation — PROVED in main file
+/- ## Null set preservation — PROVED in main file
 
 These are now proved using:
 - Measure.quasiMeasurePreserving_fst/snd (product measures)


### PR DESCRIPTION
## Fix

Replace `/-!` module docstring marker with `/-` regular block comment in `Erdos1126OQ01Aristotle.lean`.

## Evidence

**Before**: `/-! ## Null set preservation — PROVED in main file`
**After**: `/- ## Null set preservation — PROVED in main file`

Per the Aristotle pre-submission checklist in `research/SORRY-CLASSIFICATION.md`: "No `/-!` docstring sections (use `/-` instead — parser incompatibility)". The `/-!` marker is reserved for Lean 4 module documentation and causes parse errors in the Aristotle proof search pipeline.

---
Automated fix by lean-mechanic agent.