### PR TITLE
Fix: downgrade 2 proofs from verified to axiomatized (transitive axiom dependencies)

### DIFF
--- a/src/data/proofs/greens-theorem-oq-04/meta.json
+++ b/src/data/proofs/greens-theorem-oq-04/meta.json
@@ -7,11 +7,11 @@
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Green%27s_theorem#Multiply-connected_regions",
     "date": "1828 (Green), formalized 2026",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/GreensTheoremOQ04.lean",
-    "badge": "verified",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 2,
     "mathlibDependencies": [
       {
         "theorem": "intervalIntegral.integral_const",
@@ -81,7 +81,7 @@
       "Line integrals and boundary orientation",
       "Topology of planar regions (fundamental group, Betti numbers)"
     ],
-    "assumptions": "0 axioms in this file. Depends on imported axioms from OQ-03: greens_theorem_typeI (Green's theorem for simply-connected TypeI regions) and disk_area_eq_pi (area of a disk).",
+    "assumptions": "2 axioms inherited from GreensTheoremOQ03.lean: greens_theorem_typeI (Green's theorem for simply-connected TypeI regions, used at lines 296, 280 to prove the main theorem) and disk_area_eq_pi (area of disk formula, used at lines 170, 179 to compute annular area). 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -238,7 +238,7 @@
     ],
     "namespace": "GreensTheoremOQ04",
     "lineCount": 587,
-    "axiomCount": 0,
+    "axiomCount": 2,
     "theoremCount": 23,
     "definitionCount": 14
   }

--- a/src/data/proofs/triangular-reciprocals-oq-03-oq-02/meta.json
+++ b/src/data/proofs/triangular-reciprocals-oq-03-oq-02/meta.json
@@ -7,7 +7,7 @@
         "author": "Generalization of Mercator (1668) / Euler series identities",
         "sourceUrl": "https://en.wikipedia.org/wiki/Harmonic_number#Alternating_harmonic_numbers",
         "date": "2026",
-        "status": "verified",
+        "status": "axiomatized",
         "proofRepoPath": "Proofs/TriangularReciprocalGeneralized.lean",
         "tags": [
             "analysis",
@@ -16,9 +16,10 @@
             "harmonic-numbers",
             "partial-fractions"
         ],
-        "badge": "verified",
+        "badge": "axiom",
         "sorries": 0,
-        "axiomCount": 0,
+        "axiomCount": 1,
+        "assumptions": "1 axiom inherited from TriangularReciprocalAlternatingOQ03.lean: alternating_harmonic_hasSum (∑(-1)^{n+1}/n = log 2, the Mercator series). Used in proofs at lines 77 and 168 to establish the generalized series formula. 0 sorries.",
         "dateAdded": "2026-03-29",
         "mathlibDependencies": [
             {


### PR DESCRIPTION
## Fix

Two gallery proofs claim `verified` with `axiomCount=0` but actually use axioms inherited from their parent proof files.

## Evidence

### greens-theorem-oq-04
- **Before**: `status: verified`, `axiomCount: 0`, `badge: verified`
- **After**: `status: axiomatized`, `axiomCount: 2`, `badge: axiom`
- **Why**: `GreensTheoremOQ04.lean` imports and uses `greens_theorem_typeI` and `disk_area_eq_pi` from `GreensTheoremOQ03.lean` (lines 170, 179, 296)
- **Parent** (`greens-theorem-oq-03`): correctly shows `axiomatized/axiom/axiomCount=2`

### triangular-reciprocals-oq-03-oq-02
- **Before**: `status: verified`, `axiomCount: 0`, `badge: verified`
- **After**: `status: axiomatized`, `axiomCount: 1`, `badge: axiom`
- **Why**: `TriangularReciprocalGeneralized.lean` opens and uses `alternating_harmonic_hasSum` (the Mercator series axiom) from `TriangularReciprocalAlternatingOQ03.lean` (lines 25, 77, 168)
- **Parent** (`triangular-reciprocals-oq-03`): correctly shows `axiomatized/axiom/axiomCount=2`

Per the axiom integrity policy: "axiomCount must reflect ALL assumptions: axiom declarations + assumption-carrying structure fields". Transitive axioms from imports count.

---
Automated fix by lean-mechanic agent.