### PR TITLE
Enrich gallery proofs: IVT bisection, GCD/Binet, primes mod 4, Erdős smooth numbers (×5)

### DIFF
--- a/src/data/proofs/prime-reciprocal-divergence-oq-03/annotations.json
+++ b/src/data/proofs/prime-reciprocal-divergence-oq-03/annotations.json
@@ -1,1 +1,72 @@
-[]
+[
+  {
+    "id": "ann-erdos-smooth-defs",
+    "range": { "startLine": 61, "endLine": 75 },
+    "type": "concept",
+    "title": "Smooth and Rough Numbers: The Counting Dichotomy",
+    "body": "IsSmooth N k holds when every prime factor of k is ≤ N. IsRough N k holds when k has at least one prime factor > N. Together, every integer ≥ 2 is either N-smooth or N-rough for any N. The proof exploits this dichotomy: count smooth numbers from above (≤ √n · 2^π(N)) and rough numbers from above (< n/2 under the convergence assumption), showing both counts sum to less than n — contradiction, since [1..n] has n elements.",
+    "mathContext": "Smooth numbers (also called N-smooth or B-smooth) are central to factoring algorithms (e.g., the quadratic sieve, elliptic curve factorization). A number is B-smooth if all its prime factors are ≤ B. The count of B-smooth numbers up to n is denoted Ψ(n, B). Erdős's argument uses the cruder bound Ψ(n, N) ≤ √n · 2^π(N), which suffices for the combinatorial contradiction.",
+    "significance": "key",
+    "relatedConcepts": ["smooth-numbers", "rough-numbers", "counting-arguments", "prime-factorization"]
+  },
+  {
+    "id": "ann-erdos-sqfpart",
+    "range": { "startLine": 97, "endLine": 130 },
+    "type": "technique",
+    "title": "Squarefree Decomposition: k = b² · a via Nat.sq_mul_squarefree_of_pos",
+    "body": "Every positive integer k decomposes uniquely as k = b² · a where a is squarefree (not divisible by any perfect square > 1). Lean's Nat.sq_mul_squarefree_of_pos gives this decomposition via classical choice, yielding the squarefree part (sqfPart) and square-root part (sqRtPart). Key bounds: (1) b = sqRtPart k satisfies b² ≤ k so b ≤ √k (proved via nlinarith); (2) sqfPart_pos ensures a > 0. The noncomputable attribute is required since sqfPart/sqRtPart use classical choice (Nat.sq_mul_squarefree_of_pos via ∃ ... choose).",
+    "mathContext": "The squarefree decomposition is the basis of the factorization k = b² · a. For an N-smooth k, the squarefree part a has all prime factors ≤ N, so a ⊆ 2^{primesUpTo N} (it's a 0-1 combination of these primes). Meanwhile b ≤ √k ≤ √n. This is the key: k is determined by (b, a), and there are at most √n · 2^π(N) pairs.",
+    "significance": "key",
+    "relatedConcepts": ["squarefree-numbers", "noncomputable", "classical-choice", "square-root-bound"]
+  },
+  {
+    "id": "ann-erdos-squarefree-eq",
+    "range": { "startLine": 132, "endLine": 163 },
+    "type": "insight",
+    "title": "Squarefree Numbers Are Determined by Their Prime Support",
+    "body": "squarefree_eq_of_prime_dvd_iff proves: two squarefree positive naturals with identical prime divisors are equal. The proof uses Nat.factorization_prod_pow_eq_self to reconstruct each number from its factorization. For squarefree numbers, factorization values are in {0, 1} (by Nat.squarefree_iff_factorization_le_one). So identical prime-divisor sets imply identical factorizations, hence equal numbers. This algebraic lemma is the injectivity core of the smooth count argument.",
+    "mathContext": "In the ring ℤ, a squarefree number's factorization is its characteristic function on primes: p → 0 or 1. Two squarefree numbers are equal iff they have the same prime support. This is a discrete analogue of a set being determined by its indicator function. In Lean, the proof factors through Finsupp (factorization as ℕ →₀ ℕ), using ext to reduce to pointwise equality.",
+    "significance": "supporting",
+    "relatedConcepts": ["squarefree-numbers", "prime-factorization", "factorization-support", "lean-finsupp"]
+  },
+  {
+    "id": "ann-erdos-smooth-inj",
+    "range": { "startLine": 175, "endLine": 243 },
+    "type": "technique",
+    "title": "The Counting Injection: smoothSet ↪ range(√n) × powerset(primesUpTo N)",
+    "body": "smoothInj maps each N-smooth k ∈ [1,n] to the pair (sqRtPart k - 1, {primes ≤ N that divide sqfPart k}). The image lands in range(Nat.sqrt n) × powerset(primesUpTo N), whose cardinality is √n · 2^π(N). Injectivity: if two smooth numbers k₁, k₂ have the same image, then (i) sqRtPart k₁ = sqRtPart k₂ (from the first component, using positivity to cancel the -1), and (ii) sqfPart k₁ = sqfPart k₂ (from the second component via squarefree_eq_of_prime_dvd_iff). Then k₁ = b² · a = k₂. The -1 in sqRtPart k - 1 is needed since sqRtPart k ≥ 1 but range starts at 0.",
+    "mathContext": "The map k ↦ (√part, squarefree-prime-subset) is the formal realization of Erdős's bijection argument. The key insight is that the squarefree part a of an N-smooth number is a product of distinct primes ≤ N — i.e., a subset of primesUpTo N. Since squarefree numbers are determined by their prime support (squarefree_eq_of_prime_dvd_iff), the subset uniquely determines a. The injection is proved via Finset.card_le_card_of_injOn.",
+    "significance": "key",
+    "relatedConcepts": ["injection", "finset-cardinality", "squarefree-decomposition", "combinatorial-counting"]
+  },
+  {
+    "id": "ann-erdos-multiples",
+    "range": { "startLine": 249, "endLine": 267 },
+    "type": "technique",
+    "title": "Multiples Count Bijection: |{p,2p,...} ∩ [1,n]| = ⌊n/p⌋",
+    "body": "multiples_count proves the elementary fact that there are exactly ⌊n/p⌋ multiples of p in [1,n]. The Lean proof establishes the set equality by bijecting {j·p : j ∈ [1, n/p]} with {multiples of p in [1,n]}, then uses Finset.card_image_of_injective (multiplication by p is injective for p > 0). The size of [1, n/p] is n/p by Finset.card_Icc + omega. This result feeds into the rough number count: ≤ Σ_{p>N} n/p rough numbers in [1,n].",
+    "mathContext": "The bound |{rough numbers in [1,n]}| ≤ Σ_{p>N, prime} ⌊n/p⌋ follows by inclusion-exclusion (lower bound by union). Under the assumption Σ_{p>N} 1/p < 1/2, the sum ≤ n/2. Combined with smooth ≤ √n · 2^π(N), the two counts show that for large n, smooth + rough < n — contradicting the fact that [1,n] has n elements.",
+    "significance": "supporting",
+    "relatedConcepts": ["divisibility", "bijection", "floor-division", "inclusion-exclusion"]
+  },
+  {
+    "id": "ann-erdos-main",
+    "range": { "startLine": 299, "endLine": 339 },
+    "type": "insight",
+    "title": "Erdős's Main Contradiction: n = (2^{K+1})² + 1 Forces Smooth Count > n",
+    "body": "infinitely_many_primes_erdos proves: for any N, ∃ prime p > N. By contradiction: if all primes ≤ N, then smoothSet N n = [1,n] for all n (every number is N-smooth). But smooth_count_bound gives |smoothSet N n| ≤ √n · 2^K where K = π(N). Choosing n = (2^{K+1})² + 1: √n ≤ 2^{K+1} (since Nat.sqrt rounds down and (2^{K+1})² < n), so √n · 2^K ≤ 2^{K+1} · 2^K = 2^{2K+1}. But n = 2^{2K+2} + 1 > 2^{2K+1}. So n = |smoothSet| ≤ 2^{2K+1} < n, contradiction via omega.",
+    "mathContext": "The choice n = (2^{K+1})² + 1 is the Lean-friendly witness: it's just barely above (2^{K+1})², ensuring Nat.sqrt n ≤ 2^{K+1}. The arithmetic is handled by ring + omega after establishing the key inequality 2^{2K+1} < n. This is the combinatorial core of Erdős's 1938 proof — the analytic sum Σ1/p = ∞ is derived from this infinitely-many-primes step by the analytic argument in the parent proof.",
+    "significance": "key",
+    "relatedConcepts": ["proof-by-contradiction", "counting-argument", "smooth-number-bound", "erdos-proof"]
+  },
+  {
+    "id": "ann-erdos-comparison",
+    "range": { "startLine": 354, "endLine": 388 },
+    "type": "context",
+    "title": "Proof Comparison: Mathlib Analytic Path vs Erdős Elementary Path",
+    "body": "The closing notes make explicit what this file proves vs. the parent PrimeReciprocalDivergence.lean. This file proves infinitely many primes (and equivalently, prime_reciprocals_unbounded) via smooth number counting — no analysis required. The full Σ1/p = ∞ statement requires real-valued series, which the parent handles via Nat.Primes.not_summable_one_div (Mathlib's analytic infrastructure). This proof is 350 lines (vs ~160 for the analytic path), but entirely elementary: every step is a natural number computation or finite-set cardinality argument.",
+    "mathContext": "Erdős's 1938 paper 'Über die Reihe Σ1/p' gave this elementary proof as an alternative to Euler's 1737 analytic proof. The combinatorial smooth number approach has since become a template for elementary proofs in analytic number theory. The squarefree decomposition k = b²a is also the basis of Legendre's formula for π(x) and sieve theory. This Lean file isolates the combinatorial content, making it available as a building block independent of Mathlib's analysis library.",
+    "significance": "supporting",
+    "relatedConcepts": ["erdos-proof", "analytic-number-theory", "sieve-theory", "mathlib-analysis"]
+  }
+]

--- a/src/data/proofs/prime-reciprocal-divergence-oq-03/meta.json
+++ b/src/data/proofs/prime-reciprocal-divergence-oq-03/meta.json
@@ -60,20 +60,26 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Erdős developed this elementary proof as part of his program to find 'proofs from THE BOOK' — the simplest possible proofs of fundamental results.",
-    "problemStatement": "Prove that there are infinitely many primes using only combinatorial counting, without real analysis.",
-    "text": "Elementary proof of infinitely many primes via smooth number counting.",
-    "proofStrategy": "By contradiction: if all primes ≤ N, then every integer is N-smooth. But smooth numbers up to n are bounded by √n · 2^{π(N)}, which is < n for large n.",
+    "historicalContext": "Erdős's 1938 paper 'Über die Reihe Σ1/p' (On the series Σ1/p) introduced a purely combinatorial proof that the sum of reciprocals of primes diverges. Euler had proved this in 1737 using his product formula for ζ(s) and analysis. Erdős's contribution was to show the result — and even the infinitude of primes — follows from simple counting: the squarefree decomposition k = b²·a shows that N-smooth numbers up to n number at most √n · 2^{π(N)}. If all primes were ≤ N, then [1..n] would be entirely smooth, but √n · 2^{π(N)} < n for large n — contradiction. The proof exemplified Erdős's 'BOOK proof' philosophy: find the most elegant, elementary argument. The squarefree decomposition it uses was known since Gauss; the smooth number counting bound prefigures the theory of friable numbers (Ψ(x, y)) central to modern analytic number theory and integer factorization algorithms (quadratic sieve, ECM).",
+    "problemStatement": "Prove that there are infinitely many primes using only combinatorial counting, without real analysis. The proof gives the combinatorial core of Erdős's Σ1/p = ∞ argument.",
+    "text": "The squarefree decomposition k = b²·a (Nat.sq_mul_squarefree_of_pos) injects N-smooth numbers in [1,n] into range(√n) × powerset(primesUpTo N), giving |smoothSet N n| ≤ √n · 2^{π(N)}. If all primes ≤ N, every integer is smooth, but for n = (2^{π(N)+1})² + 1 the bound √n · 2^{π(N)} ≤ 2^{π(N)+1} · 2^{π(N)} = 2^{2π(N)+1} < 2^{2π(N)+2} + 1 = n — contradiction. The injection's injectivity uses squarefree_eq_of_prime_dvd_iff: two squarefree numbers with the same prime support are equal.",
+    "proofStrategy": "By contradiction: if all primes ≤ N, then every integer is N-smooth. But smooth numbers up to n are bounded by √n · 2^{π(N)}, which is < n for large n (taking n = (2^{K+1})² + 1 with K = π(N)).",
     "keyInsights": [
-      "Any N-smooth integer k = m²·s with m ≤ √n and s squarefree with factors ≤ N",
-      "At most √n · 2^{π(N)} smooth numbers up to n",
-      "Contradiction for n > (2^{π(N)+1})²"
+      "Squarefree decomposition k = b²·a: b ≤ √n (sqRtPart_le_sqrt) and a ⊆ powerset of primes ≤ N, giving the injection into √n × 2^{π(N)} target",
+      "Two squarefree numbers with the same prime divisors are equal (squarefree_eq_of_prime_dvd_iff) — this is the injectivity core",
+      "n = (2^{K+1})² + 1 is chosen so Nat.sqrt n ≤ 2^{K+1}, making the arithmetic clean for omega",
+      "The file proves infinitely many primes (combinatorial core) but not Σ1/p = ∞ — that requires real-valued series in the parent proof",
+      "Zero analysis required: no limits, no topology, no measure theory — only Finset.card, Nat.sqrt, and ring arithmetic"
     ]
   },
   "conclusion": {
-    "summary": "Erdős's combinatorial proof of infinitely many primes is fully formalized with 0 sorries. Uses squarefree decomposition injection for the smooth number counting bound.",
-    "implications": "Demonstrates that the combinatorial core of Erdős's Σ1/p divergence proof can be formalized without any analytic machinery, complementing the parent proof's Mathlib-based approach.",
-    "openQuestions": []
+    "summary": "Erdős's combinatorial proof of infinitely many primes formalized with 0 sorries. Squarefree decomposition injection gives smooth count ≤ √n · 2^{π(N)}, yielding contradiction for n = (2^{π(N)+1})² + 1. 12 theorems, 7 definitions, 0 axioms, 388 lines.",
+    "implications": "The combinatorial core of Erdős's Σ1/p divergence proof can be formalized without analytic machinery. The squarefree decomposition and smooth number counting are templates for sieve theory and integer factorization algorithms. This file stands alone as a complete elementary proof of infinitely many primes, complementing both Euclid's classical argument and Mathlib's analytic approach.",
+    "openQuestions": [
+      "Formalize the full Erdős proof of Σ1/p = ∞ using the smooth/rough dichotomy and real-valued sums",
+      "Prove the Mertens theorem: Σ_{p≤x} 1/p = log log x + M + o(1), connecting the divergence rate to the Mertens constant M",
+      "Extend smooth number counting to prove Ψ(x, y) ≥ x^{ρ+o(1)} where ρ = u⁻¹ and u = log x / log y — the Canfield-Erdős-Pomerance theorem"
+    ]
   },
   "sections": [
     {
@@ -121,12 +127,19 @@
   ],
   "crossReferences": [
     {
-      "relationship": "Alternative proof to the analytic approach",
-      "sharedConcepts": [
-        "primes",
-        "divergence"
-      ],
-      "targetId": "prime-reciprocal-divergence"
+      "targetId": "prime-reciprocal-divergence",
+      "relationship": "related",
+      "description": "Parent proof using Mathlib's analytic Nat.Primes.not_summable_one_div — same result via real series vs combinatorial counting"
+    },
+    {
+      "targetId": "infinitude-primes-4k3",
+      "relationship": "related",
+      "description": "Another elementary proof of infinitely many primes (≡3 mod 4), using Euclid-style factorial construction vs smooth number counting"
+    },
+    {
+      "targetId": "gcd-algorithm-oq-01-oq-03",
+      "relationship": "related",
+      "description": "Binet's formula and Fibonacci: smooth numbers appear in the Lamé complexity argument via Fibonacci growth"
     }
   ]
 }


### PR DESCRIPTION
## Enrichments

Adds rich annotations, sections, cross-references, and expanded historical context to 6 gallery proofs:

### euler-totient-oq-04
- 11 annotations: GCD class definition, partition structure, cardinality bijection, main identity
- 7 sections, 4 cross-references, historicalContext (Euler 1763, Gauss, Hardy & Wright)

### infinitude-primes-4k1
- 6 annotations: Euler's criterion, odd prime factor helper, N=(2·(n+1)!)²+1 construction, examples
- 6 sections, 4 cross-references, 5 keyInsights, 3 openQuestions

### gcd-algorithm-oq-01-oq-03
- 8 annotations: five-step Fibonacci identity, multiplicative growth, Binet's formula (paired induction), φ⁵>10
- 7 sections, 3 cross-references, historicalContext (Lamé 1844, Binet 1843, Fibonacci 1202, Kepler 1611)

### intermediate-value-theorem-oq-02
- 7 annotations: bisection defs, width formula, sign invariant, approx_ivt, monotone uniqueness
- 7 sections, 4 cross-references, historicalContext (Bolzano 1817, Cauchy 1821, Bishop 1967)

### infinitude-primes-4k3
- 6 annotations: mul_mod_four_one, prime classification, factors_determine_mod_four (strong induction), N=4·(n+1)!-1
- 6 sections, 3 cross-references, 5 keyInsights including Chebyshev's bias open question

### prime-reciprocal-divergence-oq-03
- 7 annotations: smooth/rough defs, sqfPart decomposition, squarefree uniqueness lemma, counting injection, multiples bijection, main theorem, proof comparison
- Expanded historicalContext (Erdős 1938 vs Euler 1737, BOOK proof, smooth number theory), 5 keyInsights, 3 openQuestions including Mertens theorem

🤖 Generated with [Claude Code](https://claude.com/claude-code)