### PR TITLE
Enrich Binet's Formula, Lamé Bound, Robustly Acyclic Orientations, Divisor Sum Identity

### DIFF
--- a/src/data/proofs/infinitude-primes-4k3/annotations.json
+++ b/src/data/proofs/infinitude-primes-4k3/annotations.json
@@ -1,1 +1,95 @@
-[]
+[
+  {
+    "id": "annotation-mul-mod-four-closure",
+    "lineStart": 45,
+    "lineEnd": 51,
+    "type": "insight",
+    "mathContext": "`mul_mod_four_one` encodes the group structure of $(\\mathbb{Z}/4\\mathbb{Z})^* = \\{1, 3\\}$: the identity element 1 is closed under multiplication ($1 \\cdot 1 \\equiv 1 \\pmod 4$). The proof is a single `calc` chain using `Nat.mul_mod` (which states $(a \\cdot b) \\% m = ((a \\% m) \\cdot (b \\% m)) \\% m$) and `norm_num` for the arithmetic. This is the arithmetic heart of the proof: any product of integers $\\equiv 1 \\pmod 4$ remains $\\equiv 1 \\pmod 4$, so a product $\\equiv 3 \\pmod 4$ must have at least one factor $\\equiv 3 \\pmod 4$.",
+    "significance": "This single-lemma multiplication closure is the key algebraic fact that makes the Euclid-style construction work for 3 mod 4 but not directly for 1 mod 4. In (ℤ/4ℤ)*, 3 has order 2 and 1 has order 1 — so a product is ≡ 3 iff it has an odd number of factors ≡ 3. The formalization of this in `factors_determine_mod_four` uses strong induction rather than counting, but the underlying reason is this group law.",
+    "relatedConcepts": [
+      "(ℤ/4ℤ)* group structure",
+      "Nat.mul_mod",
+      "multiplicative closure mod 4",
+      "quadratic residues mod 4"
+    ],
+    "prerequisites": [
+      "Nat.mul_mod: (a * b) % m = ((a % m) * (b % m)) % m",
+      "norm_num: numerical computation tactic"
+    ]
+  },
+  {
+    "id": "annotation-prime-dichotomy",
+    "lineStart": 53,
+    "lineEnd": 75,
+    "type": "insight",
+    "mathContext": "`prime_mod_four` establishes that every odd prime satisfies $p \\equiv 1 \\pmod 4$ or $p \\equiv 3 \\pmod 4$. The proof writes $p = 2k+1$ (from `hp.odd_of_ne_two`) and splits on $k$ even ($k = 2m$, giving $p = 4m+1$) vs $k$ odd ($k = 2m+1$, giving $p = 4m+3$). Both cases close by `omega`. This exhausts all possibilities since $p$ odd means $p \\not\\equiv 0, 2 \\pmod 4$, leaving only residues 1 and 3. The four residue classes $\\{0,1,2,3\\}$ mod 4 for odd numbers reduce to $\\{1,3\\}$ — exactly the units $(\\mathbb{Z}/4\\mathbb{Z})^*$.",
+    "significance": "This dichotomy is foundational for all mod-4 prime arguments. It shows that the classification of odd primes into two classes (1 mod 4 and 3 mod 4) is exhaustive and complete — there is no 'third class'. The proof by writing p = 2k+1 and splitting on k's parity is a standard elementary argument that translates cleanly into Lean via Nat.odd_of_ne_two and omega.",
+    "relatedConcepts": [
+      "odd primes mod 4",
+      "Nat.Prime.odd_of_ne_two",
+      "residue class dichotomy",
+      "units mod 4"
+    ],
+    "prerequisites": [
+      "Nat.Prime.odd_of_ne_two: prime p ≠ 2 → Odd p",
+      "Nat.odd_iff: Odd n ↔ n % 2 = 1",
+      "omega: linear arithmetic tactic"
+    ]
+  },
+  {
+    "id": "annotation-strong-induction-factors",
+    "lineStart": 78,
+    "lineEnd": 131,
+    "type": "key-theorem",
+    "mathContext": "`factors_determine_mod_four` proves: if every prime factor of $n$ is 2 or $\\equiv 1 \\pmod 4$, then $n \\not\\equiv 3 \\pmod 4$. The proof is by `Nat.strong_induction_on`: at each step, extract a prime factor $p$ via `Nat.exists_prime_and_dvd` (which requires $n \\neq 1$; since $n \\equiv 3 \\pmod 4$ we have $n \\geq 3$). Two cases: (1) $p = 2$: then $2 \\mid n$, but $n \\equiv 3 \\pmod 4$ implies $n$ is odd, contradiction by `omega`. (2) $p \\equiv 1 \\pmod 4$: write $n = p \\cdot m$. If $m = 1$ then $n = p \\equiv 1 \\pmod 4$, contradicting $n \\equiv 3 \\pmod 4$. If $m \\geq 2$, then $m < n$ and $m \\equiv 3 \\pmod 4$ (from $n \\equiv 3 \\equiv (1 \\cdot m) \\pmod 4$ via `Nat.mul_mod`), so IH applies.",
+    "significance": "This is the technical core of the proof — a strong induction that shows the mod-4 residue of n is completely determined by the residues of its prime factors. The key step is that dividing out a factor ≡ 1 (mod 4) preserves the mod-4 residue of the quotient, so if n ≡ 3 (mod 4), the quotient must also be ≡ 3 (mod 4). Strong induction terminates because m < n. This argument avoids any need for unique factorization (it works by finding one factor and reducing).",
+    "relatedConcepts": [
+      "Nat.strong_induction_on",
+      "Nat.exists_prime_and_dvd",
+      "multiplicativity of mod",
+      "contrapositive argument"
+    ],
+    "prerequisites": [
+      "Nat.strong_induction_on: induction with full IH on all m < n",
+      "Nat.exists_prime_and_dvd: n ≠ 1 → ∃ p prime, p ∣ n",
+      "Nat.mul_mod: (p * m) % 4 = (p % 4 * m % 4) % 4"
+    ]
+  },
+  {
+    "id": "annotation-main-construction",
+    "lineStart": 150,
+    "lineEnd": 191,
+    "type": "key-theorem",
+    "mathContext": "The main theorem constructs $N = 4 \\cdot (n+1)! - 1$ and shows $N \\equiv 3 \\pmod 4$ (immediate since $(n+1)! \\geq 1$ so $4 \\cdot (n+1)! \\geq 4$, hence $N \\geq 3$; and $4 \\cdot (n+1)! \\equiv 0 \\pmod 4$ so $N \\equiv 3 \\pmod 4$). By `has_prime_factor_3_mod_4`, $N$ has a prime factor $p \\equiv 3 \\pmod 4$. To show $p > n$: if $p \\leq n$, then $p \\leq n+1$, so `Nat.dvd_factorial` gives $p \\mid (n+1)!$, hence $p \\mid 4(n+1)!$. But $p \\mid N = 4(n+1)! - 1$, so $p \\mid 1$. Since $p$ is prime ($p \\geq 2$), this contradicts `hp.not_dvd_one`.",
+    "significance": "The factorial construction N = 4·(n+1)!-1 is elegant: the factor 4 ensures N ≡ 3 (mod 4), and (n+1)! ensures every prime ≤ n divides the large term 4·(n+1)!, making N ≡ -1 mod each of those primes. The proof that p ∤ N for p ≤ n is the divisibility chain: p|fact → p|4·fact → p|N+1 → p|1, contradiction. `Nat.dvd_factorial` (p prime, p ≤ m → p | m!) is the key Mathlib lemma.",
+    "relatedConcepts": [
+      "Euclid's proof structure",
+      "Nat.dvd_factorial",
+      "Nat.Prime.not_dvd_one",
+      "N = 4·(n+1)!-1 construction"
+    ],
+    "prerequisites": [
+      "Nat.dvd_factorial: p prime, p ≤ n → p ∣ n!",
+      "Nat.factorial_pos: (n)! ≥ 1",
+      "Nat.Prime.not_dvd_one: p prime → ¬(p ∣ 1)"
+    ]
+  },
+  {
+    "id": "annotation-set-infinitude",
+    "lineStart": 192,
+    "lineEnd": 207,
+    "type": "insight",
+    "mathContext": "`primes_3_mod_4_infinite` uses `Set.infinite_of_not_bddAbove`: a set $S \\subseteq \\mathbb{N}$ is infinite iff it is not bounded above. Given any bound $n$, `infinitely_many_primes_3_mod_4 n` produces $p > n$ with $p \\in S$, so $S$ is not bounded above. `no_largest_prime_3_mod_4` gives the equivalent no-largest-element form: assuming a largest prime $p \\equiv 3 \\pmod 4$, `infinitely_many_primes_3_mod_4 p` produces $q > p$ with $q \\equiv 3 \\pmod 4$, contradicting $p$ being largest. Both are immediate corollaries requiring only `omega` after applying the main theorem.",
+    "significance": "The two alternative formulations (set infinitude and no-largest-prime) demonstrate that the core theorem `infinitely_many_primes_3_mod_4` is the right primitive: both natural ways of stating 'infinitely many primes ≡ 3 (mod 4)' follow as trivial corollaries. The use of `Set.infinite_of_not_bddAbove` over `Set.infinite_of_injective` or `Set.infinite_range_of_injective` reflects Mathlib's standard approach to proving infinite sets via unboundedness.",
+    "relatedConcepts": [
+      "Set.infinite_of_not_bddAbove",
+      "Set.Infinite",
+      "no-largest-prime form",
+      "unbounded sets in ℕ"
+    ],
+    "prerequisites": [
+      "Set.infinite_of_not_bddAbove: ¬(BddAbove S) → S.Infinite",
+      "BddAbove: set has an upper bound in ℕ"
+    ]
+  }
+]

--- a/src/data/proofs/infinitude-primes-4k3/meta.json
+++ b/src/data/proofs/infinitude-primes-4k3/meta.json
@@ -31,15 +31,16 @@
     ]
   },
   "overview": {
-    "historicalContext": "The infinitude of primes ≡ 3 (mod 4) is a special case of Dirichlet's 1837 theorem on primes in arithmetic progressions, but the elementary proof was known long before Dirichlet. It uses the same structure as Euclid's proof for all primes: construct a specific number that must have a prime factor of the desired form, and show that factor must be new.",
+    "historicalContext": "The infinitude of primes $\\equiv 3 \\pmod{4}$ is a special case of Dirichlet's 1837 theorem on primes in arithmetic progressions, but the elementary proof predates Dirichlet by centuries, being known in essentially the same form as Euclid's proof of the infinitude of all primes. The key asymmetry between the classes $1 \\pmod{4}$ and $3 \\pmod{4}$ is multiplicative: products of integers $\\equiv 1 \\pmod 4$ remain $\\equiv 1 \\pmod 4$ (since $(\\mathbb{Z}/4\\mathbb{Z})^* \\cong \\mathbb{Z}/2\\mathbb{Z}$ and 1 is the identity), but 3 is the unique non-identity element. This means a number $\\equiv 3 \\pmod 4$ must have an odd number of prime factors $\\equiv 3 \\pmod 4$, so at least one. The construction $N = 4 \\cdot (n+1)! - 1$ is the analogue of Euclid's $p_1 \\cdots p_k + 1$, adapted to force $N \\equiv 3 \\pmod 4$. The companion result for primes $\\equiv 1 \\pmod 4$ is more difficult: it requires showing that $x^2 + 1 \\equiv 0 \\pmod p$ has solutions only for $p \\equiv 1 \\pmod 4$, which needs Fermat's two-square theorem or quadratic reciprocity. Dirichlet's full theorem covers all arithmetic progressions $a, a+d, a+2d, \\ldots$ with $\\gcd(a,d)=1$, and uses Dirichlet characters and $L$-functions.",
     "problemStatement": "Prove that for every n : ℕ, there exists a prime p > n with p ≡ 3 (mod 4). This shows the set of such primes is infinite.",
     "text": "The key auxiliary lemma factors_determine_mod_four states: if all prime factors of n are either 2 or ≡ 1 (mod 4), then n ≢ 3 (mod 4). Proof by strong induction: case 2 | n contradicts n ≡ 3 (odd); case p | n with p ≡ 1 (mod 4) reduces to n/p via the identity (n/p) mod 4 = n mod 4 (since p ≡ 1). The main theorem takes N = 4·(n+1)! - 1: N ≡ 3 (mod 4), so has a prime factor p ≡ 3 (mod 4). Since p ≤ n would imply p | (n+1)!, we'd get p | 1, contradicting primality.",
     "proofStrategy": "Strong induction for factors_determine_mod_four: case p = 2 is immediate from parity; case p ≡ 1 uses multiplicativity of mod 4 to reduce to a smaller instance. Main proof: contradiction assuming p ≤ n, using Nat.dvd_factorial and Nat.Prime.not_dvd_one.",
     "keyInsights": [
-      "Products of (1 mod 4) numbers stay (1 mod 4) — the multiplicative structure of (ℤ/4ℤ)*",
-      "N = 4·(n+1)! - 1 avoids all primes ≤ n+1 that divide (n+1)!",
-      "The argument is fully elementary: no Gaussian integers, no quadratic reciprocity",
-      "Compare with the analogous proof for primes ≡ 1 (mod 4) which requires more machinery"
+      "The group $(\\mathbb{Z}/4\\mathbb{Z})^* = \\{1, 3\\}$ is cyclic of order 2: $3^2 \\equiv 1 \\pmod 4$. Products of elements $\\equiv 1$ stay $\\equiv 1$; a product $\\equiv 3$ requires an odd number of factors $\\equiv 3$. This is the multiplicative closure argument formalized in `mul_mod_four_one` and `factors_determine_mod_four`.",
+      "The construction $N = 4 \\cdot (n+1)! - 1 \\equiv 3 \\pmod 4$ is designed so that every prime $p \\leq n+1$ divides $(n+1)!$, hence divides $4 \\cdot (n+1)!$, but cannot divide $N = 4(n+1)! - 1$ (since it would then divide 1). So any prime factor of $N$ exceeds $n$.",
+      "The strong induction in `factors_determine_mod_four` works by finding a prime factor $p$ of $n$, dividing out, and reducing to $n/p < n$ — which inherits the hypothesis that all its prime factors are 2 or $\\equiv 1 \\pmod 4$. The base case $m=1$ gives immediate contradiction from $n=p \\equiv 3 \\pmod 4$ vs $p \\equiv 1 \\pmod 4$.",
+      "The parity constraint is crucial: $n \\equiv 3 \\pmod 4$ implies $n$ is odd, so $2 \\nmid n$. This eliminates the $p=2$ case in the strong induction immediately via `omega`, since $2 \\mid n$ and $n \\equiv 3 \\pmod 4$ would give $n \\equiv 0 \\pmod 2$ contradicting $n \\equiv 3 \\equiv 1 \\pmod 2$.",
+      "The contrast with $\\equiv 1 \\pmod 4$: for that case one cannot construct a Euclid-style number that is forced to have a prime factor $\\equiv 1 \\pmod 4$, because products of primes $\\equiv 3 \\pmod 4$ can also be $\\equiv 1 \\pmod 4$ (e.g., $3 \\times 3 = 9 \\equiv 1$). The proof for $1 \\pmod 4$ requires showing $4(p_1 \\cdots p_k)^2 + 1$ has a prime factor $\\equiv 1 \\pmod 4$, needing Fermat's theorem that $-1$ is a QR mod $p$ iff $p \\equiv 1 \\pmod 4$."
     ],
     "prerequisites": [
       "Nat.dvd_factorial: every prime ≤ n divides n!",
@@ -48,11 +49,12 @@
     ]
   },
   "conclusion": {
-    "summary": "Elementary proof that primes ≡ 3 (mod 4) are infinite, using N = 4·(n+1)!-1. Includes the set-theoretic infinitude statement and no-largest-prime form. 7 theorems, 0 axioms, 230 lines.",
-    "implications": "This elementary proof predates Dirichlet's theorem and illustrates the power of Euclid-style arguments. The contrast with the ≡ 1 (mod 4) case (which requires Fermat's two-square theorem or quadratic reciprocity) shows that different arithmetic progressions require different proof techniques.",
+    "summary": "Elementary proof that primes ≡ 3 (mod 4) are infinite, using N = 4·(n+1)!-1. The key lemma `factors_determine_mod_four` uses strong induction on the multiplicative structure of (ℤ/4ℤ)*. Includes the set-theoretic infinitude statement and no-largest-prime form. 7 theorems, 0 axioms, 230 lines.",
+    "implications": "This elementary proof predates Dirichlet's theorem and illustrates the power of Euclid-style arguments. The contrast with the ≡ 1 (mod 4) case (which requires Fermat's two-square theorem or quadratic reciprocity) shows that different arithmetic progressions require qualitatively different proof techniques — some progressions admit elementary proofs, others require analytic or algebraic machinery.",
     "openQuestions": [
-      "Prove Dirichlet's theorem in full generality: infinitely many primes in any AP with gcd(a,d)=1",
-      "Formalize the density: primes ≡ 3 (mod 4) have density 1/2 among all primes (equidistribution)"
+      "Prove Dirichlet's theorem in full generality: infinitely many primes in any AP $\\{a + nd : n \\geq 0\\}$ with $\\gcd(a,d) = 1$. This requires Dirichlet characters $\\chi : (\\mathbb{Z}/d\\mathbb{Z})^* \\to \\mathbb{C}^*$ and $L$-functions $L(s, \\chi) = \\sum_{n=1}^\\infty \\chi(n)/n^s$. Formalizing the non-vanishing $L(1, \\chi) \\neq 0$ for non-principal $\\chi$ is the key analytic step.",
+      "Formalize the equidistribution: primes $\\equiv a \\pmod d$ (with $\\gcd(a,d)=1$) have density $1/\\phi(d)$ among all primes (Dirichlet's theorem in its quantitative form, equivalent to the Prime Number Theorem for arithmetic progressions).",
+      "Prove the infinitude of primes $\\equiv 1 \\pmod 4$ elementarily: this requires showing that for any finite set $\\{p_1,\\ldots,p_k\\}$ of primes $\\equiv 1 \\pmod 4$, the number $N = 4(p_1 \\cdots p_k)^2 + 1$ has a prime factor $\\equiv 1 \\pmod 4$. This uses Fermat's theorem: $(-1|p) = 1$ iff $p \\equiv 1 \\pmod 4$."
     ]
   },
   "leanFile": {
@@ -64,10 +66,70 @@
   },
   "crossReferences": [
     {
-      "targetId": "infinitude-primes-4k1",
+      "id": "infinitude-primes-4k1",
+      "relationship": "sibling",
+      "description": "Companion proof for primes ≡ 1 (mod 4) — requires more machinery (Fermat's two-square theorem or quadratic reciprocity) compared to the elementary 3 mod 4 proof here."
+    },
+    {
+      "id": "infinitude-primes",
+      "relationship": "parent",
+      "description": "The base infinitude of primes result (Euclid's proof) — this proof uses the same Euclid-style factorial construction adapted to force a specific residue class."
+    },
+    {
+      "id": "dirichlets-theorem",
       "relationship": "related",
-      "description": "Companion proof for primes ≡ 1 (mod 4), requiring more machinery (sum of two squares)"
+      "description": "Dirichlet's theorem on primes in arithmetic progressions (1837) — the full generalization of this result to all APs a+nd with gcd(a,d)=1, requiring L-functions."
     }
   ],
-  "sections": []
+  "sections": [
+    {
+      "id": "sec-imports",
+      "title": "Imports and Setup",
+      "startLine": 1,
+      "endLine": 43,
+      "summary": "Imports Mathlib.Data.Nat.Prime.Basic, Factorial.Basic, ZMod.Basic, and Tactic. Module docstring explains the 8-step proof sketch: N = 4·(n+1)!-1 is ≡ 3 (mod 4), products of 1-mod-4 factors stay 1-mod-4, so N has a prime factor ≡ 3 (mod 4) exceeding n. Namespace InfinitudePrimes4k3, opens Nat."
+    },
+    {
+      "id": "sec-mul-mod-four",
+      "title": "Multiplicative Closure: 1 mod 4 × 1 mod 4 = 1 mod 4",
+      "startLine": 45,
+      "endLine": 51,
+      "summary": "mul_mod_four_one: if a % 4 = 1 and b % 4 = 1 then (a*b) % 4 = 1. Proved by calc chain using Nat.mul_mod and norm_num. This is the key arithmetic lemma encoding that {1 mod 4} is closed under multiplication in (ℤ/4ℤ)*."
+    },
+    {
+      "id": "sec-prime-mod-four",
+      "title": "Odd Prime Dichotomy: ≡ 1 or ≡ 3 (mod 4)",
+      "startLine": 53,
+      "endLine": 75,
+      "summary": "prime_mod_four: for any odd prime p, p % 4 = 1 or p % 4 = 3. Proof uses p.odd_of_ne_two to write p = 2k+1, then splits on k even (k=2m → p=4m+1 ≡ 1) vs k odd (k=2m+1 → p=4m+3 ≡ 3), both by omega. This exhausts all residues: p odd means p ≢ 0, 2 (mod 4)."
+    },
+    {
+      "id": "sec-factors-lemma",
+      "title": "Strong Induction: Factors Determine Mod-4 Residue",
+      "startLine": 78,
+      "endLine": 131,
+      "summary": "factors_determine_mod_four: if all prime factors of n are 2 or ≡ 1 (mod 4), then n % 4 ≠ 3. Proof by Nat.strong_induction_on: find a prime factor p via Nat.exists_prime_and_dvd; case p=2 contradicts n odd (omega); case p ≡ 1 (mod 4) uses Nat.mul_mod to show m = n/p also satisfies n % 4 = 3 (since p ≡ 1), then applies IH to m < n."
+    },
+    {
+      "id": "sec-has-prime-factor",
+      "title": "Key Lemma: n ≡ 3 (mod 4) Has a Prime Factor ≡ 3 (mod 4)",
+      "startLine": 132,
+      "endLine": 148,
+      "summary": "has_prime_factor_3_mod_4: for n ≥ 3 with n % 4 = 3, there exists p prime with p ∣ n and p % 4 = 3. Proved by contradiction: assuming all prime factors are 2 or ≡ 1 (mod 4), applies factors_determine_mod_four to get n % 4 ≠ 3, contradicting the hypothesis."
+    },
+    {
+      "id": "sec-main-theorem",
+      "title": "Main Theorem: Infinitely Many Primes ≡ 3 (mod 4)",
+      "startLine": 150,
+      "endLine": 199,
+      "summary": "infinitely_many_primes_3_mod_4: ∀ n, ∃ p prime, p > n ∧ p % 4 = 3. Construction: N = 4(n+1)!-1 ≡ 3 (mod 4) (by omega from factorial_pos). By has_prime_factor_3_mod_4, N has a prime factor p ≡ 3 (mod 4). If p ≤ n, then p ∣ (n+1)! (by Nat.dvd_factorial) → p ∣ 4(n+1)! → p ∣ 1 (from N + 1 = 4(n+1)!), contradicting hp.not_dvd_one. primes_3_mod_4_infinite and no_largest_prime_3_mod_4 follow by Set.infinite_of_not_bddAbove."
+    },
+    {
+      "id": "sec-examples",
+      "title": "Concrete Examples",
+      "startLine": 209,
+      "endLine": 228,
+      "summary": "Five `example` statements verifying that 3, 7, 11, 19, 23 are primes ≡ 3 (mod 4), each proved by `decide` or `Nat.prime_three`. These serve as sanity checks and illustrate the density of such primes: 3,7,11,19,23,31,43,47,... occupy every other odd residue class mod 4."
+    }
+  ]
 }

--- a/src/data/proofs/konigsberg-oq-01/annotations.json
+++ b/src/data/proofs/konigsberg-oq-01/annotations.json
@@ -1,1 +1,97 @@
-[]
+[
+  {
+    "id": "annotation-sq-circuit-construction",
+    "lineStart": 77,
+    "lineEnd": 101,
+    "type": "insight",
+    "mathContext": "The explicit Eulerian circuit for $C_4$ is a `Walk.cons` chain spelling out $A \\to B \\to C \\to D \\to A$. Each edge is justified by `trivial` (since `sqAdj A B = True` by definition). `sqCircuit_isEulerian` is proved by `Sym2.ind` (reducing edge membership to vertex pairs) followed by `cases a <;> cases b`, exhausting all $\\binom{4}{2} = 6$ possible undirected edges: for a 4-vertex graph, the full case analysis is feasible and mechanical. The key fact is that $C_4$'s 4-edge circuit visits each of the 4 edges exactly once since each undirected edge $\\{u,v\\}$ appears exactly once in `sqCircuit.edges`.",
+    "significance": "Demonstrates the canonical positive example: n-cycles are always Eulerian because all degrees are 2 (even) and a Hamiltonian circuit is simultaneously Eulerian. The proof technique — exhaustive case analysis via `cases a <;> cases b` — is characteristic of small finite graph verifications in Lean 4 where `native_decide` handles decidable membership checks efficiently.",
+    "relatedConcepts": [
+      "Walk.IsEulerian",
+      "Sym2.ind",
+      "Hamiltonian circuits as Eulerian circuits",
+      "cycle graphs Cₙ"
+    ],
+    "prerequisites": [
+      "SimpleGraph.Walk.IsEulerian: each edge traversed exactly once",
+      "Sym2.ind: induction on unordered pairs",
+      "Walk.cons: extend a walk by prepending an edge"
+    ]
+  },
+  {
+    "id": "annotation-k4-not-eulerian",
+    "lineStart": 241,
+    "lineEnd": 247,
+    "type": "key-theorem",
+    "mathContext": "The proof that $K_4$ has no Eulerian path is a two-line argument: `have hodd := h.card_odd_degree` gives that for any Eulerian walk $p$ from $u$ to $v$, the odd-degree vertex count is 0 or 2; `have := k4_four_odd` establishes (by `native_decide`) that $K_4$ has exactly 4 odd-degree vertices; `omega` resolves $4 = 0 \\lor 4 = 2$ to `False`. The central Mathlib lemma is `Walk.IsEulerian.card_odd_degree : p.IsEulerian → |\\{v : V \\mid \\text{Odd}(\\deg(v))\\}| = 0 \\lor = 2$. $K_4$ has $\\binom{4}{2} = 6$ edges and every vertex has degree 3 (connected to all other 3 vertices), giving 4 odd-degree vertices — exactly 2 too many for any Eulerian path.",
+    "significance": "K₄ is the canonical counterexample to Eulerian path existence. It is the smallest complete graph where all vertices have odd degree, making it a cleaner counterexample than the original Königsberg graph (which had degree sequence [3,3,3,5]). The proof pattern — compute odd-degree count by `native_decide`, then apply `card_odd_degree` and `omega` — is the standard template for all non-existence results in this file.",
+    "relatedConcepts": [
+      "Walk.IsEulerian.card_odd_degree",
+      "complete graph K₄",
+      "odd degree vertices",
+      "Königsberg bridge problem"
+    ],
+    "prerequisites": [
+      "Walk.IsEulerian.card_odd_degree: degree parity constraint for Eulerian walks",
+      "Fintype.card: cardinality of finite subtypes",
+      "native_decide: decidable computation for finite structures"
+    ]
+  },
+  {
+    "id": "annotation-regular-odd-no-euler",
+    "lineStart": 316,
+    "lineEnd": 334,
+    "type": "key-theorem",
+    "mathContext": "For a $k$-regular graph ($k$ odd) on $|V| \\geq 3$ vertices, every vertex has degree $k$ (odd), so the odd-degree set $\\{w : V \\mid \\text{Odd}(\\deg(w))\\}$ equals the full vertex set $V$. The proof establishes this equality via `Fintype.card_subtype` and `Finset.card_univ`, then uses `ext w; simp [hall_odd w]` to show the subtype characterizes all vertices. Once $|\\{w \\mid \\text{Odd}(\\deg w)\\}| = |V| \\geq 3$, `hp.card_odd_degree` gives $|V| = 0 \\lor |V| = 2$, contradicted by `omega`. This captures the general principle: in $\\mathbb{Z}/2\\mathbb{Z}$, odd-degree vertices form an even-cardinality set (handshaking), but when the graph is $k$-regular for odd $k$, the count is $|V|$ — which must be even and $\\geq 4$ for $|V| \\geq 3$.",
+    "significance": "This is the most general result in the file, subsuming K₄ (which is 3-regular) and any Petersen-style graph. The Petersen graph (3-regular on 10 vertices) is the paradigmatic example: all 10 vertices have odd degree 3, so no Eulerian path exists. The proof generalizes the Königsberg impossibility from one graph to an infinite family. The conversion between `Fintype.card_subtype` and `Finset.card_univ` is the key technical step for relating set cardinality to type cardinality in Mathlib.",
+    "relatedConcepts": [
+      "k-regular graphs",
+      "Petersen graph",
+      "handshaking lemma",
+      "Fintype.card_subtype"
+    ],
+    "prerequisites": [
+      "k-regular graph: every vertex has the same degree k",
+      "Fintype.card_subtype: cardinality of a subtype as a finset filter",
+      "Finset.card_univ: |Finset.univ| = Fintype.card V"
+    ]
+  },
+  {
+    "id": "annotation-euler-circuit-all-even",
+    "lineStart": 281,
+    "lineEnd": 296,
+    "type": "insight",
+    "mathContext": "Two complementary necessary conditions are formalized here. (1) `euler_circuit_implies_all_even`: for an Eulerian circuit ($u = v$), `hp.even_degree_iff` states $\\text{Even}(\\deg(w)) \\iff (w = u \\to \\text{False})$; since $u = u$ gives $u \\neq u = \\text{False}$, `false_implies` reduces the condition to `mpr trivial`, yielding evenness for every vertex. (2) `euler_trail_non_endpoint_even`: for a trail from $u$ to $v$ ($u \\neq v$), `even_degree_iff` states $\\text{Even}(\\deg(w)) \\iff (w = u \\lor w = v \\to \\text{False})$; for $w \\neq u, w \\neq v$, `tauto` resolves the hypothesis. Together these prove the necessity direction of Euler's theorem: Eulerian structures force strong degree constraints.",
+    "significance": "These theorems formalize the necessity direction of Euler's theorem in full generality. `Walk.IsEulerian.even_degree_iff` is the key Mathlib interface connecting Eulerian walk structure to vertex degrees. The careful case split on whether the walk is a circuit (u=v) or proper trail (u≠v) reflects the fundamental asymmetry in Euler's theorem: circuits require all-even degrees, while trails allow exactly two odd-degree vertices (the endpoints).",
+    "relatedConcepts": [
+      "Walk.IsEulerian.even_degree_iff",
+      "Euler's theorem necessity direction",
+      "circuit vs trail distinction",
+      "degree parity"
+    ],
+    "prerequisites": [
+      "Walk.IsEulerian.even_degree_iff: characterizes even degrees in Eulerian walks",
+      "Eulerian circuit: closed walk traversing each edge once (u = v)",
+      "Eulerian trail: open walk traversing each edge once (u ≠ v)"
+    ]
+  },
+  {
+    "id": "annotation-native-decide-pattern",
+    "lineStart": 86,
+    "lineEnd": 92,
+    "type": "technique",
+    "mathContext": "Throughout the file, `native_decide` verifies concrete finite computations: `sqCircuit_length : sqCircuit.edges.length = 4`, `sqCircuit_visits_all (v : SqVerts) : v \\in sqCircuit.support` (via `cases v <;> native_decide`), `k4_degree (v : K4Verts) : k4Graph.degree v = 3`, `k4_four_odd : Fintype.card \\{v \\mid \\text{Odd}(k4Graph.degree v)\\} = 4`, and the handshaking lemma verifications. These all reduce to decidable equality on small finite types. `native_decide` compiles Lean terms to native code — exponentially faster than kernel-level `decide` for computations over $\\leq 10$ vertex graphs. The pattern `cases v <;> native_decide` splits a universal statement over an inductive type into individual `native_decide` calls for each constructor.",
+    "significance": "The native_decide tactic is essential for keeping concrete graph proofs tractable. Without it, verifying degree computations or edge counts on K₄ would require explicit inductions over Finset.filter constructions. The technique exemplifies a key Lean 4 proof strategy: use decidability of finite structures to offload combinatorial verification to compiled computation, reserving symbolic proof steps for the mathematical structure.",
+    "relatedConcepts": [
+      "native_decide tactic",
+      "Decidable instances",
+      "finite type computations",
+      "decidable graph properties"
+    ],
+    "prerequisites": [
+      "DecidableEq on inductive types (derived automatically)",
+      "Fintype instances: required for native_decide on finite structures",
+      "native_decide vs decide: native compilation vs kernel reduction"
+    ]
+  }
+]

--- a/src/data/proofs/konigsberg-oq-01/meta.json
+++ b/src/data/proofs/konigsberg-oq-01/meta.json
@@ -35,15 +35,16 @@
     ]
   },
   "overview": {
-    "historicalContext": "Euler's theorem (1736) for Königsberg bridges: a graph has an Eulerian circuit iff it is connected and all vertices have even degree. An Eulerian path exists iff exactly 0 or 2 vertices have odd degree. This formalization focuses on concrete examples and general necessary conditions, building on the base Königsberg formalization.",
-    "problemStatement": "Which concrete graph families have Eulerian circuits or paths? Prove the criterion for C₄, C₅, K₄, and odd-regular graphs.",
+    "historicalContext": "Leonhard Euler's 1736 paper on the Königsberg bridge problem is considered the birth of graph theory. Euler proved that no walk exists traversing all 7 bridges of Königsberg exactly once by showing the city graph has 4 odd-degree vertices (requiring exactly 0 or 2 for an Eulerian path). His generalization became Euler's theorem: a connected graph has an Eulerian circuit iff all vertices have even degree. This result was the first time a mathematical problem was solved by abstracting a physical structure into a graph and reasoning about connectivity. The proof of sufficiency (Hierholzer's algorithm, 1873) came more than a century after Euler's necessary condition. This formalization extends the basic Königsberg impossibility proof to concrete positive and negative examples: cycles $C_n$ have Eulerian circuits (all degrees 2, even), while $K_4$ and odd-regular graphs fail (too many odd-degree vertices). The central tool from Mathlib is `Walk.IsEulerian.card_odd_degree`, which directly gives the odd-degree count for any Eulerian walk.",
+    "problemStatement": "For the concrete graph families $C_4$, $C_5$, $K_4$, and general $k$-regular graphs with odd $k$: determine whether Eulerian circuits or paths exist. For $C_4$ and $C_5$: construct explicit Eulerian circuits and verify they are Eulerian. For $K_4$ and odd-regular graphs: prove no Eulerian path exists.",
     "text": "C₄ and C₅ (n-cycles) trivially have Eulerian circuits: all vertices have degree 2 (even), and a Hamiltonian cycle is also Eulerian. K₄ has all vertices of odd degree 3, so no Eulerian path exists by the odd-degree criterion. The general theorem: an odd-regular graph on n ≥ 3 vertices has all n vertices of odd degree, so with n ≥ 3 odd-degree vertices, no Eulerian path exists (requires ≤ 2 odd-degree vertices).",
-    "proofStrategy": "Define explicit circuits for C₄ and C₅, verify they visit all vertices and edges exactly once. For K₄: compute degrees = 3 (odd), then apply the odd-degree non-existence criterion. For odd-regular: n ≥ 3 all-odd-degree vertices violates the ≤ 2 odd-degree condition.",
+    "proofStrategy": "For C₄ and C₅: construct Walk.cons chains spelling out the cycle explicitly (A→B→C→D→A and A→B→C→D→E→A). Verify IsEulerian by cases a <;> cases b on the edge type. For K₄: compute degree = 3 by native_decide, show 4 odd-degree vertices, apply hp.card_odd_degree. For odd-regular: show |{v | Odd (deg v)}| = Fintype.card V ≥ 3, apply card_odd_degree to get a contradiction with 0 or 2.",
     "keyInsights": [
-      "Cycles Cₙ are Eulerian for all n ≥ 3: all degrees are 2 (even), and the cycle itself is the Eulerian circuit",
-      "K₄ is the smallest complete graph with no Eulerian path (all degrees 3 = odd)",
-      "Regular odd graphs with ≥3 vertices all fail: too many odd-degree vertices",
-      "Euler trail non-endpoint degrees are even: travel arrives and departs equally"
+      "For cycle graphs $C_n$ (all $n \\geq 3$), the cycle walk itself IS the Eulerian circuit: every edge appears exactly once, and since all degrees are 2 (each vertex appears as both entering and leaving endpoint once), the IsEulerian check reduces to a complete case analysis by `cases a <;> cases b`.",
+      "$K_4$ is the 'canonical' counterexample: it has $\\binom{4}{2} = 6$ edges and all 4 vertices with degree 3, so there are 4 odd-degree vertices. Any Eulerian path would need at most 2 odd-degree vertices — a gap of 2 is enough to prevent any Eulerian path.",
+      "The key Mathlib lemma `Walk.IsEulerian.card_odd_degree` is the central tool: it states that if $p$ is an Eulerian walk from $u$ to $v$, then the number of odd-degree vertices is 0 (if $u = v$, a circuit) or 2 (if $u \\neq v$, a trail). The non-existence proofs all reduce to showing this count exceeds 2.",
+      "The `regular_odd_no_euler` theorem is the cleanest general result: for odd $k$-regular graphs, every vertex has odd degree, so $|\\{v : \\text{Odd}(\\deg v)\\}| = |V| \\geq 3$. The proof converts between the set cardinality and Fintype.card using Finset.card_univ and ext.",
+      "Concrete computations by `native_decide`: degree values, edge counts, circuit lengths, and vertex visitation are all verified by Lean's native evaluator rather than symbolic proof — this keeps the proofs short and avoids constructing explicit inductions over small finite types."
     ],
     "prerequisites": [
       "Eulerian circuits: connected graph, all even degrees",
@@ -51,13 +52,57 @@
       "Graph degrees: handshaking lemma Σ deg = 2|E|"
     ]
   },
+  "sections": [
+    {
+      "id": "sec-imports",
+      "title": "Imports and Setup",
+      "startLine": 1,
+      "endLine": 23,
+      "summary": "Imports SimpleGraph.Trails (for Walk.IsEulerian, card_odd_degree), SimpleGraph.Connectivity, Algebra.Ring.Parity (for Even/Odd), and tactics. Opens SimpleGraph namespace."
+    },
+    {
+      "id": "sec-square",
+      "title": "Square Graph C₄: Explicit Eulerian Circuit",
+      "startLine": 25,
+      "endLine": 102,
+      "summary": "Defines SqVerts (inductive A|B|C|D), sqAdj (the cycle adjacency), sqGraph (SimpleGraph), proves sq_degree=2, sq_all_even, sq_edge_count=4, constructs sqCircuit (Walk A A via Walk.cons chain), proves sqCircuit_length=4, sqCircuit_visits_all, sqCircuit_isEulerian (by Sym2.ind + cases a cases b)."
+    },
+    {
+      "id": "sec-pentagon",
+      "title": "Pentagon Graph C₅: Explicit Eulerian Circuit",
+      "startLine": 104,
+      "endLine": 182,
+      "summary": "Analogous to C₄ with 5 vertices (A|B|C|D|E). Defines pentGraph, proves pent_degree=2, pent_all_even, pent_edge_count=5, constructs pentCircuit (5-edge Walk.cons chain), proves pentCircuit_length=5, pentCircuit_visits_all, pentCircuit_isEulerian."
+    },
+    {
+      "id": "sec-k4",
+      "title": "Complete Graph K₄: No Eulerian Path",
+      "startLine": 184,
+      "endLine": 249,
+      "summary": "Defines K4Verts (V1|V2|V3|V4), k4Adj (all 6 pairs), k4Graph. Proves k4_degree=3, k4_all_odd, k4_edge_count=6, k4_four_odd (4 odd-degree vertices by native_decide). k4_not_eulerian applies hp.card_odd_degree and gets 4 ≠ 0 and 4 ≠ 2 by omega."
+    },
+    {
+      "id": "sec-trail-theory",
+      "title": "General Trail Theory",
+      "startLine": 251,
+      "endLine": 298,
+      "summary": "Variable section with general G. Proves: euler_criterion_necessary (necessary condition for Eulerian paths via hp.card_odd_degree), no_eulerian_path_three_or_more_odd (≥3 odd vertices → no Euler path, immediate from card_odd_degree), euler_circuit_implies_all_even (circuit → all even via hp.even_degree_iff), euler_trail_non_endpoint_even (non-endpoint vertices in trail have even degree via tauto)."
+    },
+    {
+      "id": "sec-odd-regular",
+      "title": "Odd-Regular Graphs Have No Eulerian Path",
+      "startLine": 300,
+      "endLine": 356,
+      "summary": "regular_odd_no_euler: for k-odd-regular G with |V| ≥ 3, shows |{v | Odd(deg v)}| = |V| ≥ 3 via Fintype.card_subtype + ext, then contradicts hp.card_odd_degree via omega. Also verifies handshaking lemma (Σ deg = 2|E|) for C₄ and K₄ by native_decide."
+    }
+  ],
   "conclusion": {
-    "summary": "Eulerian circuit existence proved for C₄ and C₅, non-existence proved for K₄ and odd-regular graphs. General necessary conditions verified. 24 theorems, 8 definitions, 404 lines, 0 axioms.",
-    "implications": "This completes the concrete verification of Euler's theorem for common graph families, providing machine-verified examples for graph theory education.",
+    "summary": "Verifies Eulerian circuit existence for $C_4$ (explicit 4-edge circuit) and $C_5$ (explicit 5-edge circuit), and non-existence for $K_4$ (4 odd-degree vertices) and all odd-regular graphs with $|V| \\geq 3$. Proves general necessary conditions: Eulerian circuits require all-even degrees; Eulerian paths require $\\leq 2$ odd-degree vertices. 24 theorems, 8 definitions, 404 lines, 0 axioms.",
+    "implications": "This provides machine-verified concrete examples for Euler's theorem — the foundational result of graph theory. The combination of explicit circuit constructions (positive examples) with odd-degree counting arguments (negative examples) demonstrates both directions of the degree criterion. The `Walk.IsEulerian.card_odd_degree` lemma from Mathlib is the key bridge between the combinatorial structure and the algebraic degree counts.",
     "openQuestions": [
-      "Prove sufficiency of Euler's criterion (connected + all-even → Eulerian circuit) without axioms",
-      "Extend to directed Eulerian paths (see konigsberg-oq-02)",
-      "Prove Euler criterion for multigraphs and hypergraphs"
+      "Prove the sufficiency direction of Euler's theorem: if $G$ is connected and all degrees are even, then $G$ has an Eulerian circuit. This requires Hierholzer's algorithm (1873) or a constructive induction on $|E|$, both of which require more substantial formalization than the necessity direction.",
+      "Extend to Eulerian paths in directed graphs: the characterization is $\\mathrm{indeg}(v) = \\mathrm{outdeg}(v)$ for all $v$ (circuit) or exactly one source with $\\mathrm{outdeg} - \\mathrm{indeg} = 1$ and one sink. The directed version is formalized in konigsberg-oq-02.",
+      "Classify Eulerian graphs by their structure: BEST theorem (de Bruijn, van Aardenne-Ehrenfest, Smith, Tutte) counts the number of Eulerian circuits in a directed graph as $t_w(G) \\cdot \\prod_v (\\mathrm{outdeg}(v) - 1)!$, where $t_w(G)$ is an arborescence count. Can this be formalized using Mathlib's matrix-tree theorem?"
     ]
   },
   "leanFile": {
@@ -69,10 +114,14 @@
   },
   "crossReferences": [
     {
-      "targetId": "konigsberg-oq-02",
-      "relationship": "related",
-      "description": "Directed Euler path characterization; this file covers undirected concrete examples"
+      "id": "konigsberg",
+      "relationship": "parent",
+      "description": "Königsberg Bridges Problem — the original Eulerian impossibility proof that this file extends to positive examples and general theorems."
+    },
+    {
+      "id": "konigsberg-oq-02",
+      "relationship": "sibling",
+      "description": "Directed Euler Paths: In-Degree/Out-Degree Characterization — the directed analogue of this undirected Eulerian circuit theory."
     }
-  ],
-  "sections": []
+  ]
 }

--- a/src/data/proofs/lagrange-four-squares-oq-02/annotations.json
+++ b/src/data/proofs/lagrange-four-squares-oq-02/annotations.json
@@ -1,1 +1,97 @@
-[]
+[
+  {
+    "id": "annotation-reptype-structure",
+    "lineStart": 51,
+    "lineEnd": 81,
+    "type": "insight",
+    "mathContext": "`RepType n` is a Lean 4 structure with fields $a_1 \\leq a_2 \\leq a_3 \\leq a_4$ (sorted) and $a_1^2 + a_2^2 + a_3^2 + a_4^2 = n$ (sum constraint). The `contribution` is computed as `permutations * signFactor` where `permutations = 24 / (vals.dedup.map (fun v => (vals.count v)!)).prod` (multinomial $4!/\\prod_i m_i!$) and `signFactor = 2^nonzeroCount`. This encodes the orbit size formula $|\\text{orbit}| = |G|/|\\text{Stab}|$ where $G = S_4 \\times (\\mathbb{Z}/2)^4$ of order 384: each permutation of the 4-tuple is counted by the multinomial (dividing out repeated entries), and each nonzero entry contributes a factor of 2 for its sign.",
+    "significance": "The RepType structure is the key abstraction: it separates the combinatorial type (equality/zero pattern) from the specific values. This makes it possible to prove general theorems ('for all k > 0, trivialType k has contribution 8') rather than only specific instances. The sorted constraint ensures canonical representation — each unordered set of four squares corresponds to exactly one sorted RepType.",
+    "relatedConcepts": [
+      "orbit-stabilizer theorem",
+      "multinomial coefficients",
+      "symmetry group S₄ × (ℤ/2)⁴",
+      "Lagrange representation types"
+    ],
+    "prerequisites": [
+      "Multinomial coefficient 4!/(m₁!m₂!...): permutations of a multiset",
+      "Sign factor 2^k: k nonzero entries each contribute ±1",
+      "Sorted representation: a₁ ≤ a₂ ≤ a₃ ≤ a₄ gives canonical form"
+    ]
+  },
+  {
+    "id": "annotation-general-type-proof-technique",
+    "lineStart": 188,
+    "lineEnd": 230,
+    "type": "technique",
+    "mathContext": "The proof of `trivialType_contribution (k : ℕ) (hk : 0 < k) : contribution = 8` exemplifies the general pattern used for all 6 type families. Step 1: `have h1 : (trivialType 1).contribution = 8 := by native_decide` — verify the canonical instance. Step 2: `suffices hp : (trivialType k).permutations = (trivialType 1).permutations` — reduce to showing permutation counts match. Step 3: `unfold RepType.permutations trivialType; simp only; congr 1; simp [List.dedup, List.count, hne]` — show the dedup/count structure of $[0,0,0,k]$ matches $[0,0,0,1]$ since both have dedup $[0,v]$ with counts $[3,1]$ for any $v \\neq 0$. Step 4: The sign factor equality follows from `trivialType_nonzeroCount` (nonzero count = 1 for all $k > 0$) + `simp [RepType.signFactor]`.",
+    "significance": "This proof technique — native_decide for a canonical instance + congr/simp for the parametric equality — avoids induction on k and works because permutations depend only on the equality pattern (which values are equal to which), not the actual values. The key insight: [0,0,0,k].dedup for k≠0 always gives a list with count structure [3,1], regardless of k. This is the formal version of 'the orbit size depends only on the symmetry type, not the representative'.",
+    "relatedConcepts": [
+      "List.dedup and List.count in Lean 4",
+      "congr tactic for structural equality",
+      "native_decide for canonical verification",
+      "type-theoretic orbit computation"
+    ],
+    "prerequisites": [
+      "List.dedup: deduplicate a list by first occurrence",
+      "List.count: count occurrences of an element",
+      "congr 1: reduce goal to subgoal about argument equality"
+    ]
+  },
+  {
+    "id": "annotation-contribution-table",
+    "lineStart": 543,
+    "lineEnd": 588,
+    "type": "insight",
+    "mathContext": "The complete contribution value table for four-square types has 10 entries, organized by (multiplicity pattern, nonzero count): $\\{1,8,16,24,32,48,64,96,192,384\\}$. These are exactly the divisors of $384 = 4! \\times 2^4$. The extremes: contribution 1 arises only from $(0,0,0,0)$ (the zero type, $n=0$, $\\text{Stab} = G$); contribution 384 arises from all-distinct nonzero $(a,b,c,d)$ ($|\\text{Stab}| = 1$). The pattern: multiplicity pattern determines $4!/\\prod m_i!$ (the multinomial), nonzero count determines $2^k$ (sign factor). A pattern $(2,1,1)$ with 4 nonzero entries gives $12 \\times 16 = 192$; with 3 nonzero gives $12 \\times 8 = 96$; with 2 nonzero gives $12 \\times 4 = 48$.",
+    "significance": "This table is the combinatorial heart of Jacobi's formula. The 10 contribution values partition the $r_4(n)$ count across all sorted types of $n$. The fact that all values are divisors of 384 reflects the orbit-stabilizer theorem: each orbit size divides $|G| = 384$. The table was verified computationally by checking specific instances by `native_decide` and then using the general type theorems for universality.",
+    "relatedConcepts": [
+      "divisors of 384",
+      "orbit-stabilizer theorem",
+      "Jacobi's four-square formula",
+      "multinomial × sign factor product"
+    ],
+    "prerequisites": [
+      "Lagrange's four-square theorem: every n is representable",
+      "Multinomial coefficient for permutations of multisets",
+      "Orbit-stabilizer: |orbit| = |G|/|Stab| = 384/|Stab|"
+    ]
+  },
+  {
+    "id": "annotation-enum-types-decidable",
+    "lineStart": 88,
+    "lineEnd": 115,
+    "type": "insight",
+    "mathContext": "`enumTypes n` uses the list monad to iterate over all sorted 4-tuples: `do let a₄ ← List.range (n+1); let a₃ ← List.range (a₄+1); let a₂ ← List.range (a₃+1); let a₁ ← List.range (a₂+1); guard (a₁^2+a₂^2+a₃^2+a₄^2 = n); return (a₁,a₂,a₃,a₄)`. The nested ranges enforce $a_1 \\leq a_2 \\leq a_3 \\leq a_4 \\leq n$, and `guard` filters to valid sums. `totalFromEnum n = sum of tupleContribution over enumTypes n` gives the total $r_4(n)$. The function `tupleContribution` computes the same formula as `RepType.contribution` directly on tuples. Verification: `totalFromEnum 1 = 8, 2 = 24, 3 = 32, ..., 16 = 24` all by `native_decide`.",
+    "significance": "The decidable enumeration makes the type classification algorithmic: for any concrete n, one can compute all sorted types and their contributions mechanically. This provides a checkable bridge between the abstract combinatorial theory and specific numerical values of r₄(n). The list monad notation makes the nested-loop enumeration concise and idiomatic in Lean 4.",
+    "relatedConcepts": [
+      "list monad for enumeration",
+      "guard combinator for filtering",
+      "native_decide for decidable verification",
+      "r₄(n) representation function"
+    ],
+    "prerequisites": [
+      "List monad: do-notation for list comprehension",
+      "guard: filter in list monad (guard p returns [] or [()])",
+      "List.range: generates [0, 1, ..., n-1]"
+    ]
+  },
+  {
+    "id": "annotation-orbit-stabilizer",
+    "lineStart": 595,
+    "lineEnd": 616,
+    "type": "key-theorem",
+    "mathContext": "The orbit-stabilizer theorems prove `384 / (trivialType k).contribution = 48` (for $k > 0$), `384 / (allEqualType k).contribution = 24`, etc. The stabilizer sizes correspond to the subgroup of $S_4 \\times (\\mathbb{Z}/2)^4$ fixing the sorted type: trivial $(0,0,0,k)$: $S_3 \\times (\\mathbb{Z}/2)^3$ fixes (permutes the three zeros, flips the zero signs) = $6 \\times 8 = 48$; all-equal $(k,k,k,k)$: $S_4$ fixes (any permutation), sign flips of nonzero entries are NOT stabilizers = $24$; all-distinct nonzero: only identity = $1$, orbit $= 384$. `stabilizer_product_trivial: 48 = 3! × 2^3` and `stabilizer_product_allEqual: 24 = 4!` formalize these group-theoretic decompositions.",
+    "significance": "These theorems connect the number-theoretic orbit computation (contribution = permutations × sign_factor) to the group-theoretic stabilizer formula (|orbit| = |G|/|Stab|). This is a formal verification that the combinatorial formula for contributions is consistent with the abstract orbit-stabilizer theorem. The stabilizer sizes 48, 24, 12, 4, 16, 8 for the six type families are all proved to equal 384 divided by the respective contributions.",
+    "relatedConcepts": [
+      "orbit-stabilizer theorem in group actions",
+      "S₄ × (ℤ/2)⁴ symmetry group",
+      "stabilizer subgroup computation",
+      "Burnside's lemma"
+    ],
+    "prerequisites": [
+      "Orbit-stabilizer theorem: |G| = |orbit| × |stabilizer|",
+      "S₄ action on 4-tuples: permutation group",
+      "(ℤ/2)⁴ action on 4-tuples: independent sign flips"
+    ]
+  }
+]

--- a/src/data/proofs/lagrange-four-squares-oq-02/meta.json
+++ b/src/data/proofs/lagrange-four-squares-oq-02/meta.json
@@ -40,15 +40,16 @@
     ]
   },
   "overview": {
-    "historicalContext": "Lagrange's Four-Square Theorem (1770) says every natural number is a sum of four squares. The representation function r₄(n) counts the number of 4-tuples (a,b,c,d) with a²+b²+c²+d²=n (including order and signs). Jacobi (1834) proved r₄(n) = 8·Σ_{4∤d|n} d. The open question here is about the distribution of representations among different orderings — which orderings arise and with what multiplicity?",
+    "historicalContext": "Lagrange's Four-Square Theorem (1770) asserts every natural number $n$ is a sum of four squares. The representation function $r_4(n)$ counts ordered signed representations: tuples $(a,b,c,d) \\in \\mathbb{Z}^4$ with $a^2+b^2+c^2+d^2=n$. Jacobi (1834) proved $r_4(n) = 8 \\sum_{4 \\nmid d,\\, d \\mid n} d$ — a remarkable formula relating an additive problem to a multiplicative divisor sum. The natural combinatorial question is: how are the $r_4(n)$ representations distributed among the possible sorted types $(a_1,a_2,a_3,a_4)$ with $a_1 \\leq a_2 \\leq a_3 \\leq a_4$? This is governed by the orbit-stabilizer theorem for the group $G = S_4 \\times (\\mathbb{Z}/2\\mathbb{Z})^4$ of order $|G| = 24 \\times 16 = 384$, which acts on 4-tuples by permuting entries and flipping signs. The orbit of a sorted type $(a_1,a_2,a_3,a_4)$ has size $384/|\\text{Stab}|$, where the stabilizer size depends only on the zero-pattern and multiplicity-pattern of the tuple. The six symmetry-type families (trivial, all-equal, three-equal, two-pair, two-equal, two-nonzero-distinct) cover all possible zero/multiplicity patterns and yield contributions $\\{8, 16, 32, 96, 24, 48\\}$ — with the all-distinct nonzero type contributing 384 = the full group order.",
     "problemStatement": "How do representations n = a²+b²+c²+d² distribute among the possible orderings (signed tuples)? Classify all contribution patterns and prove each type family has a fixed contribution.",
-    "text": "The key insight is that contributions are determined by the symmetry type (zero pattern and multiplicity structure) of the 4-tuple. Each type corresponds to an orbit under the symmetry group S₄ × (ℤ/2ℤ)⁴ (permutations × sign changes). The stabilizer size determines the orbit size: |orbit| = 384/|stabilizer|. For example, the all-distinct nonzero type (a,b,c,d) with all different and all positive has stabilizer of size 1 (only the identity fixes it), so its orbit has 384 elements, contributing 384. The trivial type (0,0,0,k) has stabilizer of size 48 (= 4! · 2), contributing 8.",
-    "proofStrategy": "Define RepresentationType structures encoding multiplicity and sign patterns. Prove contribution formulas for each type using sign factor (2^nonzero_entries) × permutation factor. Verify orbit-stabilizer relations. Enumerate all types and compute totals. Verify for specific n by decidable computation.",
+    "text": "The key insight is that contributions are determined by the symmetry type (zero pattern and multiplicity structure) of the 4-tuple. Each type corresponds to an orbit under the symmetry group S₄ × (ℤ/2ℤ)⁴ (permutations × sign changes). The stabilizer size determines the orbit size: |orbit| = 384/|stabilizer|. For example, the all-distinct nonzero type (a,b,c,d) with all different and all positive has stabilizer of size 1 (only the identity fixes it), so its orbit has 384 elements, contributing 384. The trivial type (0,0,0,k) has stabilizer of size 48 (= 3! × 2³ = 6×8, fixing the three zeros and the nonzero sign), contributing 8.",
+    "proofStrategy": "Define RepType structures encoding multiplicity and sign patterns. Prove contribution formulas for each type using sign factor (2^nonzero_entries) × permutation factor. Verify orbit-stabilizer relations. Enumerate all types and compute totals. Verify for specific n by decidable computation.",
     "keyInsights": [
-      "Contribution = sign_factor × perm_factor = 2^(#nonzero) × (#permutations of distinct entries)",
-      "Orbit-stabilizer: contribution = 384/|stabilizer| where 384 = 4!·2⁴ = full symmetry group size",
-      "The trivial type (0,0,0,k) always contributes exactly 8 (proved for all k>0)",
-      "Jacobi's formula r₄(n) = 8·Σ d should be recoverable by summing over all type contributions"
+      "The contribution formula is $\\text{contribution} = \\text{permutations} \\times \\text{signFactor}$ where $\\text{permutations} = 4! / \\prod_i m_i!$ (multinomial for multiplicity pattern $(m_1,m_2,\\ldots)$) and $\\text{signFactor} = 2^{\\#\\text{nonzero}}$. For the all-distinct nonzero type: $24/1 \\times 16 = 384$. For trivial $(0,0,0,k)$: $24/6 \\times 2 = 4 \\times 2 = 8$.",
+      "The proof technique for 'general type theorems' is: (1) verify the contribution for a specific canonical instance ($k=1$ or $a=1,b=2$) by `native_decide`; (2) show permutations depend only on the equality-pattern (not the values), so `congr 1; simp [List.dedup, List.count, hne]`; (3) sign factor depends only on nonzero count via `simp [RepType.signFactor, nonzeroCount_lemma]`. This avoids induction on $k$ entirely.",
+      "The complete contribution value set is $\\{1, 8, 16, 24, 32, 48, 64, 96, 192, 384\\}$ — all divisors of $384 = 4! \\times 2^4 = |S_4 \\times (\\mathbb{Z}/2\\mathbb{Z})^4|$. Each value arises from a specific (multiplicity pattern, nonzero count) combination. The value 1 arises only from $(0,0,0,0)$ (which represents $n=0$, the unique trivial type with $k=0$).",
+      "The decidable enumeration `enumTypes n` uses list comprehension monad: it iterates over all $0 \\leq a_1 \\leq a_2 \\leq a_3 \\leq a_4 \\leq n$ and filters by $a_1^2+a_2^2+a_3^2+a_4^2 = n$. The function `totalFromEnum n = sum of tupleContribution over enumTypes n` is verified by `native_decide` to match known $r_4(n)$ values for $n \\leq 16$.",
+      "The orbit-stabilizer structure: for sorted type $(a_1,a_2,a_3,a_4)$, the stabilizer in $S_4 \\times (\\mathbb{Z}/2)^4$ consists of (permutations fixing the sorted tuple) × (sign flips fixing zero entries). For trivial $(0,0,0,k)$: stabilizer $= S_3 \\times (\\mathbb{Z}/2)^3 = 6 \\times 8 = 48$, giving orbit $384/48 = 8$. For all-equal $(k,k,k,k)$: stabilizer $= S_4 = 24$ (no sign freedom since $k \\neq 0$), giving $384/24 = 16$."
     ],
     "prerequisites": [
       "Lagrange's Four-Square Theorem: every n is a sum of 4 squares",
@@ -57,12 +58,12 @@
     ]
   },
   "conclusion": {
-    "summary": "All four-square representation type families classified and proved: 6 type families with fixed contributions {8,16,32,96,24,48}. Complete contribution value set {1,...,384} determined. Orbit-stabilizer structure verified. 105 theorems, 17 definitions, 651 lines, 0 axioms.",
-    "implications": "This provides a complete combinatorial analysis of how four-square representations distribute among orderings. The type classification is the key to understanding Jacobi's formula r₄(n) = 8·Σ_{4∤d|n} d as a sum over orbit contributions.",
+    "summary": "Complete combinatorial classification of four-square representation distributions: 6 type families (trivial, all-equal, three-equal, two-pair, two-equal, two-nonzero-distinct) with universal contributions {8,16,32,96,24,48}, full contribution value set {1,8,16,24,32,48,64,96,192,384}, orbit-stabilizer structure for all types, decidable enumeration verified for n ≤ 16. 105 theorems, 17 definitions, 651 lines, 0 axioms.",
+    "implications": "This provides a machine-verified combinatorial analysis of how four-square representations distribute among orderings. The type classification is the structural prerequisite for deriving Jacobi's formula r₄(n) = 8·Σ_{4∤d|n} d — each divisor d corresponds to a type contribution, and the sum organizes the 6 type families. The orbit-stabilizer verification connects the number-theoretic result to finite group theory.",
     "openQuestions": [
-      "Derive Jacobi's formula r₄(n) = 8·Σ_{4∤d|n} d from the type contribution analysis",
-      "Extend to six-square and eight-square representation distribution",
-      "Connection to modular forms: r₄(n) is a coefficient of an Eisenstein series"
+      "Derive Jacobi's formula $r_4(n) = 8 \\sum_{4 \\nmid d,\\, d \\mid n} d$ from the type contribution analysis: prove that `totalFromEnum n = 8 * σ*(n)` where $\\sigma^*(n) = \\sum_{4 \\nmid d \\mid n} d$. This requires connecting the combinatorial type enumeration to divisor sums, likely via a multiplicative function argument.",
+      "Extend to Legendre's three-square theorem and its representation counts: $r_3(n) = 12 H(-4n)$ where $H(-4n)$ is a Hurwitz class number. The three-square case is harder because not every $n$ is a sum of three squares ($n \\not\\equiv 0,4,7 \\pmod 8$).",
+      "Formalize the connection to modular forms: $r_4(n)$ is a coefficient of the theta series $\\theta(q)^4 = (\\sum_{n=-\\infty}^\\infty q^{n^2})^4 = \\sum_{n=0}^\\infty r_4(n) q^n$, which is an Eisenstein series of weight 2 for $\\Gamma_0(4)$. The identity $r_4(n) = 8\\sigma^*(n)$ follows from the equality of this theta series with the Eisenstein series."
     ]
   },
   "leanFile": {
@@ -74,10 +75,70 @@
   },
   "crossReferences": [
     {
-      "targetId": "lagrange-four-squares",
-      "relationship": "extends",
-      "description": "Lagrange's Four-Square Theorem (existence); this file studies the distribution of representations"
+      "id": "lagrange-four-squares",
+      "relationship": "parent",
+      "description": "Lagrange's Four-Square Theorem (existence: every n is a sum of four squares) — this file studies the distribution of those representations among orderings."
+    },
+    {
+      "id": "lagrange-four-squares-oq-01",
+      "relationship": "sibling",
+      "description": "Four-square distribution open question 1 — the companion file establishing the basic distribution analysis that this file extends with general type-family theorems."
+    },
+    {
+      "id": "jacobis-four-square-theorem",
+      "relationship": "related",
+      "description": "Jacobi's formula r₄(n) = 8·Σ_{4∤d|n} d (1834) — the exact formula for the total representation count whose distribution among types is analyzed here."
     }
   ],
-  "sections": []
+  "sections": [
+    {
+      "id": "sec-reptype",
+      "title": "RepType Structure and Core Definitions",
+      "startLine": 1,
+      "endLine": 115,
+      "summary": "Imports Mathlib.NumberTheory.SumFourSquares. Defines RepType (sorted 4-tuple structure with sum constraint), RepType.nonzeroCount (count of nonzero entries), RepType.permutations (multinomial 24/∏mᵢ!), RepType.signFactor (2^nonzeroCount), RepType.contribution (permutations × signFactor). Defines enumTypes (list monad search), typeCount, tupleContribution, and totalFromEnum. All definitions are computable."
+    },
+    {
+      "id": "sec-verification",
+      "title": "Computational Verification of Enumeration",
+      "startLine": 116,
+      "endLine": 165,
+      "summary": "Type counts for small n: typeCount_0 through typeCount_10, extended through typeCount_25. Contribution sums matching r₄(n): totalFromEnum_1 = 8 through totalFromEnum_16. Multinomial coefficient values: multinomial [4]=1, [3,1]=4, [2,2]=6, [2,1,1]=12, [1,1,1,1]=24. All proved by native_decide."
+    },
+    {
+      "id": "sec-structural-bounds",
+      "title": "Structural Bounds and Sign Factor Theory",
+      "startLine": 236,
+      "endLine": 295,
+      "summary": "nonzeroCount_le_four, signFactor_le_sixteen (≤ 16 = 2⁴), permutations_le_twentyfour (≤ 24 = 4!), contribution_le_384. Five theorems: signFactor_zero/one/two/three/four_nonzero (each nonzero count determines sign factor by simp). sorted_zeros_left_3 and sorted_zeros_left_2 (sorted tuple propagates zeros leftward via omega)."
+    },
+    {
+      "id": "sec-type-families",
+      "title": "General Type Family Theorems (6 Families)",
+      "startLine": 163,
+      "endLine": 540,
+      "summary": "Six general type families, each proved for ALL valid parameters: trivialType(k): (0,0,0,k) → contribution 8; allEqualType(k): (k,k,k,k) → 16; threeEqualType(k): (0,k,k,k) → 32; twoPairType(a,b): (a,a,b,b) with a<b → 96; twoEqualType(k): (0,0,k,k) → 24; twoNonzeroDistinct(a,b): (0,0,a,b) with a<b → 48. Each proved by the pattern: (1) native_decide for k=1, (2) congr+simp for permutation equality, (3) signFactor from nonzeroCount lemma."
+    },
+    {
+      "id": "sec-contribution-table",
+      "title": "Complete Contribution Value Table",
+      "startLine": 540,
+      "endLine": 590,
+      "summary": "Documents the complete 10-value contribution table: multiplicity patterns (4), (3,1), (2,2), (2,1,1), (1,1,1,1) × nonzero counts give values {1,8,16,24,32,48,64,96,192,384}. Seven concrete theorems verify each cell: contribution_one_is_zero=1, pattern_31_4nz=64, pattern_22_2nz=24, pattern_211_3nz=96, pattern_211_4nz=192, pattern_1111_3nz=192, allDistinctType_contribution=384."
+    },
+    {
+      "id": "sec-orbit-stabilizer",
+      "title": "Orbit-Stabilizer Analysis",
+      "startLine": 588,
+      "endLine": 616,
+      "summary": "Proves orbit_stabilizer theorems for all 6 type families: 384/(trivialType k).contribution=48, 384/(allEqualType k).contribution=24, 384/(threeEqualType k).contribution=12, 384/(twoPairType).contribution=4, 384/(twoEqualType k).contribution=16, 384/(twoNonzeroDistinct).contribution=8. stabilizer_product_trivial: 48=3!×2³; stabilizer_product_allEqual: 24=4!. symmetry_ratio: 384/16=24=4!."
+    },
+    {
+      "id": "sec-perfect-squares",
+      "title": "Perfect Square Analysis",
+      "startLine": 329,
+      "endLine": 340,
+      "summary": "For perfect squares n = k², analyzes the nontrivial contribution (total minus the trivial type): for n=4: 24-8=16 (from allEqualType); for n=9: 104-8=96 (nontrivial types); for n=16: 24-8=16 (allEqualType). These numerical checks verify the interplay between trivial and nontrivial type contributions to the known r₄(n) values."
+    }
+  ]
 }

--- a/src/data/proofs/law-of-cosines-oq-03/annotations.json
+++ b/src/data/proofs/law-of-cosines-oq-03/annotations.json
@@ -1,1 +1,97 @@
-[]
+[
+  {
+    "id": "annotation-structure-axiom-pattern",
+    "lineStart": 77,
+    "lineEnd": 94,
+    "type": "insight",
+    "mathContext": "`HyperbolicTriangle` is a Lean 4 structure where the law $\\cosh c = \\cosh a \\cosh b - \\sinh a \\sinh b \\cos C$ is a *structure field* (a proposition stored as data), not a proved theorem. The field `law : Real.cosh c = Real.cosh a * Real.cosh b - Real.sinh a * Real.sinh b * Real.cos C` is a hypothesis that any `HyperbolicTriangle` must supply. The theorem `hyperbolic_law_of_cosines (t : HyperbolicTriangle)` then just extracts `t.law`. This is mathematically equivalent to `axiom hyperbolic_law_of_cosines : ...` but scoped to objects satisfying the structure constraints ($a,b,c > 0$, $C \\in (0,\\pi)$).",
+    "significance": "Structure-encoded axioms are a common pattern in Lean 4 for axiomatizing geometric theories without committing to a specific model. The alternative — proving the law from the Poincaré disk — requires formalizing the hyperbolic metric, geodesics, and triangle congruence. The structure-field approach allows the mathematical content (Pythagorean theorem, angle defect) to be formalized while deferring the model-theoretic grounding. The CLAUDE.md axiom integrity policy requires this pattern to be reflected in axiomCount (3 structure-encoded assumptions in this file).",
+    "relatedConcepts": [
+      "structure-encoded axioms",
+      "axiom integrity policy",
+      "Lean 4 structures as bundled hypotheses",
+      "geometric axiomatization"
+    ],
+    "prerequisites": [
+      "Lean 4 structure: a record type bundling data and propositions",
+      "Structure field as proposition: storing a proof as a field value",
+      "Axiom integrity: structure-encoded axioms count toward axiomCount"
+    ]
+  },
+  {
+    "id": "annotation-hyperbolic-pythagorean",
+    "lineStart": 120,
+    "lineEnd": 131,
+    "type": "key-theorem",
+    "mathContext": "The hyperbolic Pythagorean theorem: when $C = \\pi/2$, $\\cosh c = \\cosh a \\cosh b$. The proof: `rw [hC, Real.cos_pi_div_two] at h` transforms $t.\\text{law}$ to $\\cosh c = \\cosh a \\cosh b - \\sinh a \\sinh b \\cdot 0$, then `linarith`. The Euclidean analogue is $c^2 = a^2 + b^2$. The substitution $x^2 \\to \\cosh x$ is an approximation: $\\cosh x \\approx 1 + x^2/2$ for small $x$ gives $(1+c^2/2) \\approx (1+a^2/2)(1+b^2/2) \\approx 1 + (a^2+b^2)/2$, recovering $c^2 \\approx a^2+b^2$.",
+    "significance": "The hyperbolic Pythagorean theorem is simpler than the general law (no cos C correction) but differs fundamentally from the Euclidean version. Since cosh is superadditive and cosh(a)·cosh(b) > cosh(a+b) only for large values, the relationship between c and a,b is nontrivial. Geometrically: in hyperbolic geometry, right triangles are 'more spread out' than Euclidean right triangles of the same leg lengths.",
+    "relatedConcepts": [
+      "Real.cos_pi_div_two = 0",
+      "Euclidean Pythagorean theorem",
+      "cosh multiplicativity",
+      "right hyperbolic triangles"
+    ],
+    "prerequisites": [
+      "Real.cos_pi_div_two: cos(π/2) = 0 in Mathlib",
+      "Hyperbolic law as starting point (extracted from structure)",
+      "linarith after rewrite"
+    ]
+  },
+  {
+    "id": "annotation-second-law-no-euclidean-analogue",
+    "lineStart": 136,
+    "lineEnd": 167,
+    "type": "insight",
+    "mathContext": "The second law $\\cos C = -\\cos A \\cos B + \\sin A \\sin B \\cosh c$ expresses an angle $C$ in terms of the other angles $A, B$ and side $c$. In Euclidean geometry, knowing all three angles only determines the shape (not size) of a triangle (AAA similarity). In hyperbolic geometry, $(\\cos C + \\cos A \\cos B)/(\\sin A \\sin B) = \\cosh c$ uniquely determines $c$ from $A, B, C$. This is because the Euclidean scaling symmetry $\\lambda \\cdot \\triangle$ does not exist in hyperbolic geometry — curvature $K = -1$ breaks scale invariance.",
+    "significance": "The non-existence of similar (non-congruent) triangles is one of the most striking features of hyperbolic geometry. It means that AAA is a congruence criterion in hyperbolic geometry (unlike in Euclidean geometry where it only gives similarity). The second law formalizes this rigidity: given three angles summing to less than π, the triangle is uniquely determined up to congruence. This has no Euclidean analogue precisely because Euclidean geometry admits scale transformations.",
+    "relatedConcepts": [
+      "AAA congruence in hyperbolic geometry",
+      "scale invariance broken by curvature",
+      "no hyperbolic similarity",
+      "HyperbolicTriangleAngles structure"
+    ],
+    "prerequisites": [
+      "AAA similarity in Euclidean geometry (not congruence)",
+      "Curvature K = -1: breaks scale invariance",
+      "Second law as structure field law2"
+    ]
+  },
+  {
+    "id": "annotation-angular-defect",
+    "lineStart": 168,
+    "lineEnd": 178,
+    "type": "insight",
+    "mathContext": "The angular defect $\\delta = \\pi - (A+B+C) > 0$ equals the hyperbolic area by Gauss-Bonnet: $\\text{Area}(T) = |K|^{-1}(\\pi - (A+B+C)) = \\pi - (A+B+C)$ for $K=-1$. `angle_sum_lt_pi` extracts `t.defect_pos` from the structure. `area_positive` follows by `linarith`. The maximum area is $\\pi$ (ideal triangles with all vertices at infinity, $A=B=C=0$). Degenerately small triangles approach Euclidean triangles with $\\delta \\to 0$.",
+    "significance": "The area-angle identity is a profound consequence of hyperbolic geometry. It means there is a natural upper bound on triangle areas, and that 'large' hyperbolic triangles are characterized by their angles approaching 0. For the sphere (K=+1), the spherical excess A+B+C-π equals the area — both positive and negative curvature encode geometry in the angle sum.",
+    "relatedConcepts": [
+      "Gauss-Bonnet theorem",
+      "angular defect = area",
+      "ideal triangles (area π)",
+      "defect_pos structure field"
+    ],
+    "prerequisites": [
+      "Gauss-Bonnet for constant curvature: Area = (angle sum deviation from π)/|K|",
+      "Ideal triangles: vertices at ∂H², A=B=C=0, Area=π",
+      "linarith from defect_pos > 0"
+    ]
+  },
+  {
+    "id": "annotation-cosh-sinh-identities",
+    "lineStart": 46,
+    "lineEnd": 72,
+    "type": "technique",
+    "mathContext": "Six hyperbolic function identities are proved as wrappers around Mathlib: `cosh_sq_sub_sinh_sq` uses `have := Real.cosh_sq_sub_sinh_sq x; linarith` (Mathlib's version gives the same identity, so one `linarith` suffices). `cosh_ge_one` uses `nlinarith [cosh_sq_sub_sinh_sq x, sq_nonneg (Real.sinh x), Real.cosh_pos x]` — from $\\cosh^2 x - \\sinh^2 x = 1$ and $\\sinh^2 x \\geq 0$, we get $\\cosh^2 x \\geq 1$, and $\\cosh x > 0$, so $\\cosh x \\geq 1$ by `nlinarith`. The remaining four are direct equalities from Mathlib: `Real.sinh_neg`, `Real.cosh_neg`, `Real.sinh_zero`, `Real.cosh_zero`.",
+    "significance": "These identities form the algebraic backbone for all computations in the file. cosh²x - sinh²x = 1 is the hyperbolic analogue of cos²x + sin²x = 1. cosh ≥ 1 reflects that cosh x is a distance function (always at least the minimum value 1, attained at x=0). The parity theorems (sinh odd, cosh even) are analogues of sin odd, cos even. Setting up these identities as named local theorems (rather than inline Mathlib calls) documents the mathematical structure clearly.",
+    "relatedConcepts": [
+      "Real.cosh_sq_sub_sinh_sq",
+      "Real.cosh_pos",
+      "hyperbolic function parities",
+      "nlinarith for nonlinear inequalities"
+    ],
+    "prerequisites": [
+      "Real.cosh_sq_sub_sinh_sq: Mathlib's Pythagorean identity for cosh/sinh",
+      "sq_nonneg: x^2 ≥ 0 for any real x",
+      "nlinarith: nonlinear arithmetic tactic for polynomial inequalities"
+    ]
+  }
+]

--- a/src/data/proofs/law-of-cosines-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03/meta.json
@@ -31,15 +31,16 @@
     ]
   },
   "overview": {
-    "historicalContext": "Hyperbolic geometry was independently discovered by Bolyai, Lobachevsky, and Gauss in the 19th century as a consistent non-Euclidean geometry. The hyperbolic law of cosines cosh(c) = cosh(a)cosh(b) - sinh(a)sinh(b)cos(C) is the direct analogue of the Euclidean c² = a² + b² - 2ab·cos(C), with the correspondence x² ↔ cosh(x). The angle sum A+B+C < π (angular defect = area) is one of the most striking features of hyperbolic triangles.",
+    "historicalContext": "Hyperbolic geometry was independently discovered in the early 19th century as the first consistent non-Euclidean geometry, resolving centuries of attempts to prove Euclid's fifth postulate. Lobachevsky published in 1829-1830, Bolyai in 1832; Gauss had known privately since the 1820s. The hyperbolic law of cosines $\\cosh c = \\cosh a \\cosh b - \\sinh a \\sinh b \\cos C$ is the direct analogue of the Euclidean $c^2 = a^2 + b^2 - 2ab\\cos C$, with the substitution $x^2 \\leftrightarrow \\cosh x - 1 \\approx x^2/2$ (valid for small $x$, via Taylor series). This correspondence is exact: the Euclidean law is recovered in the limit as side lengths $\\to 0$ (infinite curvature radius). The second law $\\cos C = -\\cos A \\cos B + \\sin A \\sin B \\cosh c$ has no Euclidean analogue — in hyperbolic geometry, the angles of a triangle completely determine its side lengths (up to congruence), unlike in Euclidean geometry where AAA gives only similarity. The angular defect $\\pi - (A+B+C) > 0$ equals the hyperbolic area by the Gauss-Bonnet theorem, so larger triangles have larger defects. This file formalizes the laws as structure-encoded axioms (not derived from a metric model), consistent with Lean Genius's approach of axiomatizing non-trivial geometric assumptions.",
     "problemStatement": "Formalize the hyperbolic law of cosines and its dual (angle version) in Lean 4 using Real.cosh, Real.sinh, Real.cos, and prove the key theorems including the hyperbolic Pythagorean theorem.",
     "text": "The HyperbolicTriangle structure packages sides a, b, c > 0, angle C ∈ (0, π), and the law cosh(c) = cosh(a)·cosh(b) - sinh(a)·sinh(b)·cos(C) as a field. The hyperbolic law of cosines theorem simply extracts this field. The hyperbolic Pythagorean theorem follows by substituting C = π/2 and using cos(π/2) = 0. The second law (for angles) is in HyperbolicTriangleAngles, encoding cos(C) = -cos(A)cos(B) + sin(A)sin(B)·cosh(c) and the angular defect A+B+C < π. The Euclidean limit (formal informal note) shows cosh(x) ≈ 1 + x²/2 and sinh(x) ≈ x for small x recovers c² ≈ a² + b² - 2ab·cos(C).",
     "proofStrategy": "The main identities cosh² - sinh² = 1, cosh ≥ 1, sinh(-x) = -sinh(x), cosh(-x) = cosh(x) are proved using Mathlib lemmas. The main law is an axiom encoded in the structure. The Pythagorean theorem substitutes Real.cos_pi_div_two = 0.",
     "keyInsights": [
-      "Hyperbolic law: cosh(c) = cosh(a)cosh(b) - sinh(a)sinh(b)cos(C) is the exact hyperbolic analogue",
-      "Angular defect: π - (A+B+C) > 0 equals the area of the hyperbolic triangle (Gauss-Bonnet)",
-      "Second law (dual): relates angles directly, with no Euclidean analogue (angles determine sides)",
-      "Euclidean limit: as side lengths → 0, hyperbolic law → Euclidean law via Taylor expansion"
+      "The structure-encoding pattern: `HyperbolicTriangle.law` and `HyperbolicTriangleAngles.law2` are structure fields (propositions stored as data), not proved from metric axioms. This is a valid formalization choice — it axiomatizes the law in the object language rather than deriving it from a specific geometric model (Poincaré disk, hyperboloid, Klein disk). The status `axiomatized` correctly reflects this.",
+      "The hyperbolic Pythagorean theorem $\\cosh c = \\cosh a \\cosh b$ (when $C = \\pi/2$) follows in two lines: rewrite with `Real.cos_pi_div_two = 0` to get $\\cosh c = \\cosh a \\cosh b - \\sinh a \\sinh b \\cdot 0$, then `linarith`. The analogous Euclidean result ($c^2 = a^2 + b^2$) follows from the same substitution in the Euclidean law.",
+      "The second law $\\cos C = -\\cos A \\cos B + \\sin A \\sin B \\cosh c$ has no Euclidean analogue because in Euclidean geometry AAA gives only similarity (no metric). In hyperbolic geometry, angles completely determine the triangle up to congruence — there is no 'hyperbolic similarity' that is not congruence.",
+      "The Euclidean limit: Taylor expanding $\\cosh x \\approx 1 + x^2/2$ and $\\sinh x \\approx x$ for small $x$ gives $1 + c^2/2 \\approx (1 + a^2/2)(1 + b^2/2) - ab\\cos C$, which simplifies to $c^2 \\approx a^2 + b^2 - 2ab\\cos C + O(a^2 b^2)$. This confirms that the Euclidean law is the first-order approximation of the hyperbolic law near a point.",
+      "The angular defect $\\delta = \\pi - (A+B+C) > 0$ is the key quantitative feature: by the Gauss-Bonnet theorem for constant curvature $-1$, the area of a hyperbolic triangle equals $\\delta$. Ideal triangles (all vertices at infinity, $A=B=C=0$) have area $\\pi$ — the maximum possible."
     ],
     "prerequisites": [
       "Hyperbolic functions: Real.cosh, Real.sinh and their Mathlib identities",
@@ -48,12 +49,12 @@
     ]
   },
   "conclusion": {
-    "summary": "Hyperbolic law of cosines scaffold: both laws encoded as structure assumptions, Pythagorean theorem and angular defect derived from those assumptions. 13 theorems, 3 structure-encoded axioms, 195 lines.",
-    "implications": "The hyperbolic law of cosines is the fundamental tool for computing distances and angles in hyperbolic space. This formalization could serve as a foundation for hyperbolic trigonometry in Lean, with applications to Kleinian groups, 3-manifolds, and geometric group theory.",
+    "summary": "Hyperbolic law of cosines axiomatized via structure fields: both laws (first and second), hyperbolic Pythagorean theorem, angular defect > 0. Hyperbolic function identities (cosh²-sinh²=1, cosh≥1, parities) proved from Mathlib. 13 theorems, 3 structure-encoded axioms, 192 lines.",
+    "implications": "The hyperbolic law of cosines is the fundamental computational tool for hyperbolic trigonometry, used to compute distances and angles in hyperbolic space. It is the basis for hyperbolic trigonometry tables, used in Thurston's geometrization program, and essential for studying hyperbolic 3-manifolds and Kleinian groups. The structure-encoding approach here is appropriate for an axiomatic development — deriving the law from a specific model (Poincaré disk, hyperboloid) would require substantially more infrastructure.",
     "openQuestions": [
-      "Prove the hyperbolic law of sines: sinh(a)/sin(A) = sinh(b)/sin(B) = sinh(c)/sin(C)",
-      "Formalize the Gauss-Bonnet theorem: area = π - (A+B+C) for hyperbolic triangles",
-      "Connect to specific models (Poincaré disk, hyperboloid model)"
+      "Derive the hyperbolic law of cosines from the Poincaré disk model (or hyperboloid model): prove that for the metric $ds^2 = (dx^2 + dy^2)/(1-x^2-y^2)^2$, the distance function $d(P,Q) = \\text{arcosh}(1 + 2|P-Q|^2/((1-|P|^2)(1-|Q|^2)))$ satisfies the law $\\cosh d(P,R) = \\cosh d(P,Q)\\cosh d(Q,R) - \\sinh d(P,Q)\\sinh d(Q,R)\\cos\\angle PQR$.",
+      "Formalize the hyperbolic law of sines: $\\sinh a / \\sin A = \\sinh b / \\sin B = \\sinh c / \\sin C = 2R$ where $R$ is the circumradius. This follows from the first and second laws combined.",
+      "Prove the Gauss-Bonnet theorem for hyperbolic triangles: $\\text{Area}(T) = \\pi - (A+B+C)$ for a triangle with angles $A,B,C$ in the hyperbolic plane of curvature $-1$. This requires formalizing the integral of the Gaussian curvature over a region."
     ]
   },
   "leanFile": {
@@ -63,6 +64,58 @@
     "theoremCount": 13,
     "definitionCount": 2
   },
-  "crossReferences": [],
-  "sections": []
+  "crossReferences": [
+    {
+      "id": "law-of-cosines",
+      "relationship": "parent",
+      "description": "Euclidean law of cosines c²=a²+b²-2ab·cos(C) — the classical result this hyperbolic version generalizes. The hyperbolic law recovers the Euclidean law in the small-side-length limit."
+    },
+    {
+      "id": "law-of-cosines-oq-01",
+      "relationship": "sibling",
+      "description": "Spherical law of cosines: cos(c) = cos(a)cos(b) + sin(a)sin(b)cos(C) — the positive-curvature analogue. Together with the hyperbolic law, these three form the complete picture for constant-curvature spaces."
+    },
+    {
+      "id": "gauss-bonnet",
+      "relationship": "related",
+      "description": "Gauss-Bonnet theorem — establishes that the area of a hyperbolic triangle equals its angular defect π-(A+B+C), connecting the angular defect theorem here to differential geometry."
+    }
+  ],
+  "sections": [
+    {
+      "id": "sec-imports",
+      "title": "Imports and Namespace",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "Imports Mathlib trigonometry (Real.cosh, Real.sinh, Real.cos) and ExpDeriv. Module docstring explains the hyperbolic law and the approach: work algebraically with cosh/sinh identities. References: Ratcliffe 'Foundations of Hyperbolic Manifolds' Ch.3, Cannon et al. 'Hyperbolic Geometry'. Namespace HyperbolicLawOfCosines, opens Real."
+    },
+    {
+      "id": "sec-cosh-sinh-identities",
+      "title": "Hyperbolic Function Identities",
+      "startLine": 45,
+      "endLine": 72,
+      "summary": "Six basic identities proved from Mathlib: cosh_sq_sub_sinh_sq (cosh²x - sinh²x = 1, from Real.cosh_sq_sub_sinh_sq + linarith), cosh_ge_one (1 ≤ cosh x, from nlinarith using cosh_sq_sub_sinh_sq and cosh_pos), sinh_neg' (sinh(-x) = -sinh x, from Real.sinh_neg), cosh_neg' (cosh(-x) = cosh x), sinh_zero', cosh_zero'. These are Mathlib wrappers with local names."
+    },
+    {
+      "id": "sec-hyperbolic-triangle",
+      "title": "HyperbolicTriangle Structure and First Law",
+      "startLine": 73,
+      "endLine": 132,
+      "summary": "HyperbolicTriangle structure: fields a,b,c:ℝ (sides >0), C:ℝ (angle ∈ (0,π)), and law (structure-encoded axiom): cosh c = cosh a * cosh b - sinh a * sinh b * cos C. hyperbolic_law_of_cosines simply extracts t.law. hyperbolic_pythagorean (C=π/2): rewrites with Real.cos_pi_div_two=0, then linarith. cosh_side_ge_one: applies cosh_ge_one."
+    },
+    {
+      "id": "sec-second-law",
+      "title": "Second Hyperbolic Law of Cosines (Angle Version)",
+      "startLine": 133,
+      "endLine": 178,
+      "summary": "HyperbolicTriangleAngles structure: fields A,B,C (angles ∈ (0,π)), c>0, defect_pos (A+B+C < π, structure-encoded), law2 (cos C = -cos A * cos B + sin A * sin B * cosh c, structure-encoded). hyperbolic_law_of_cosines_dual extracts t.law2. angle_sum_lt_pi extracts t.defect_pos. area_positive proves π-(A+B+C)>0 by linarith from defect_pos."
+    },
+    {
+      "id": "sec-euclidean-limit",
+      "title": "Euclidean Limit (Informal Note)",
+      "startLine": 179,
+      "endLine": 192,
+      "summary": "Informal comment (not a theorem) explaining the Euclidean limit: Taylor expansions cosh(x) ≈ 1 + x²/2 and sinh(x) ≈ x for small x give 1 + c²/2 ≈ (1+a²/2)(1+b²/2) - ab·cos(C), recovering c² ≈ a²+b²-2ab·cos(C) up to O(a²b²). This shows the hyperbolic law is a deformation of the Euclidean law parametrized by curvature."
+    }
+  ]
 }

--- a/src/data/proofs/sqrt2-plus-sqrt3-irrational/annotations.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-irrational/annotations.json
@@ -1,1 +1,97 @@
-[]
+[
+  {
+    "id": "annotation-irrational-definition",
+    "lineStart": 19,
+    "lineEnd": 22,
+    "type": "insight",
+    "mathContext": "`irrational_sqrt_six` uses the Mathlib lemma `irrational_sqrt_natCast_iff : Irrational (sqrt (n : ℝ)) ↔ ¬IsSquare n` (for $n : \\mathbb{N}$). `IsSquare n` means $\\exists k, n = k * k$ (in $\\mathbb{N}$). For $n = 6$: `native_decide` checks all $k \\in \\{0,1,2,\\ldots\\}$ up to $\\sqrt{6} < 3$, verifying $0^2=0, 1^2=1, 2^2=4, 3^2=9 \\neq 6$, so `¬IsSquare 6`. The `Irrational x` predicate in Lean is `¬ ∃ r : ℚ, (r : ℝ) = x` — not the existence of an irrational witness, but the negation of rationality.",
+    "significance": "irrational_sqrt_natCast_iff is the key bridge between computational primality/squareness and analytical irrationality. The decidability of IsSquare for natural numbers (it suffices to check k ≤ √n) makes native_decide applicable. This pattern — verify a finite condition computationally to prove an analytic property — is characteristic of Lean 4 irrationality proofs.",
+    "relatedConcepts": [
+      "irrational_sqrt_natCast_iff",
+      "IsSquare predicate",
+      "native_decide for finite checks",
+      "Irrational definition in Mathlib"
+    ],
+    "prerequisites": [
+      "Irrational x: ¬ ∃ r : ℚ, (r : ℝ) = x",
+      "IsSquare n: ∃ k, n = k * k (for natural n)",
+      "irrational_sqrt_natCast_iff: Irrational √n ↔ ¬IsSquare n"
+    ]
+  },
+  {
+    "id": "annotation-sqrt-mul-identity",
+    "lineStart": 24,
+    "lineEnd": 35,
+    "type": "technique",
+    "mathContext": "The algebraic identity $(\\sqrt{2}+\\sqrt{3})^2 = 5 + 2\\sqrt{6}$ is proved in a structured way: first establish `h6 : sqrt 2 * sqrt 3 = sqrt 6` via `rw [← sqrt_mul h2 3]; norm_num`. Here `sqrt_mul h2 3 : sqrt 2 * sqrt 3 = sqrt (2 * 3)` requires the non-negativity hypothesis `h2 : (0:ℝ) ≤ 2`, and `norm_num` simplifies $\\sqrt{2 \\cdot 3} = \\sqrt{6}$. Then `ring_nf` expands $(\\sqrt{2}+\\sqrt{3})^2 = \\sqrt{2}^2 + 2\\sqrt{2}\\sqrt{3} + \\sqrt{3}^2$, `rw [sq_sqrt h2, sq_sqrt h3, h6]` substitutes $\\sqrt{2}^2 \\to 2$, $\\sqrt{3}^2 \\to 3$, $\\sqrt{2}\\sqrt{3} \\to \\sqrt{6}$, and `ring` finishes.",
+    "significance": "The proof demonstrates the standard Lean 4 approach to sqrt algebra: ring_nf handles polynomial expansion, but sqrt-specific facts (sq_sqrt and sqrt_mul) require explicit rewrites. The non-negativity hypotheses (h2, h3) are required by Lean's Real.sqrt definition (which returns 0 for negative arguments), even though they are obviously true here. This is a common pattern in Lean 4: obvious conditions still need to be spelled out for sqrt rewrites.",
+    "relatedConcepts": [
+      "Real.sqrt_mul: sqrt a * sqrt b = sqrt (a * b) for a ≥ 0",
+      "Real.sq_sqrt: sqrt a ^ 2 = a for a ≥ 0",
+      "ring_nf: normalize ring expressions",
+      "norm_num for numeric goals"
+    ],
+    "prerequisites": [
+      "Real.sqrt_mul: requires non-negativity hypothesis for the first argument",
+      "Real.sq_sqrt: √a² = a requires a ≥ 0",
+      "ring_nf: expand and normalize polynomial/ring expressions"
+    ]
+  },
+  {
+    "id": "annotation-main-proof-structure",
+    "lineStart": 36,
+    "lineEnd": 53,
+    "type": "key-theorem",
+    "mathContext": "The main proof `irrational_sqrt2_plus_sqrt3 : Irrational (sqrt 2 + sqrt 3)` unfolds `Irrational` and takes `intro ⟨r, hr⟩` to get `r : ℚ` and `hr : (r : ℝ) = sqrt 2 + sqrt 3`. The chain: `rw [hr, sqrt2_plus_sqrt3_sq]` gives `hsq : (r:ℝ)^2 = 5 + 2*sqrt 6`; `linarith` gives `h6 : sqrt 6 = ((r:ℝ)^2 - 5)/2`; construct `q : ℚ` as `(r^2 - 5)/2` with `simp [Rat.cast_div, Rat.cast_sub, Rat.cast_pow, Rat.cast_natCast]` to align the cast; `exact irrational_sqrt_six ⟨q, ...⟩` closes by contradiction.",
+    "significance": "The proof is an elegant three-step reduction: (1) if √2+√3=r∈ℚ then (2) √6=(r²-5)/2∈ℚ then (3) contradiction with irrational_sqrt_six. The cast arithmetic (Rat.cast_div, etc.) is the most technical part — converting between ℚ-level arithmetic and ℝ-level arithmetic requires explicit cast lemmas. In modern Lean 4 with norm_cast or push_cast, this can often be automated.",
+    "relatedConcepts": [
+      "Rat.cast arithmetic lemmas",
+      "Irrational as negated existence",
+      "proof by contradiction pattern",
+      "reduction to simpler irrationality"
+    ],
+    "prerequisites": [
+      "Rat.cast_div: (↑(a/b) : ℝ) = ↑a / ↑b",
+      "Rat.cast_pow: (↑(r^n) : ℝ) = (↑r)^n",
+      "intro ⟨r, hr⟩: destructs ∃ r : ℚ, (r:ℝ) = x into witnesses"
+    ]
+  },
+  {
+    "id": "annotation-squaring-trick-generalization",
+    "lineStart": 36,
+    "lineEnd": 53,
+    "type": "insight",
+    "mathContext": "The squaring trick generalizes: $\\sqrt{a} + \\sqrt{b} \\in \\mathbb{Q}$ iff $\\sqrt{a}, \\sqrt{b} \\in \\mathbb{Q}$ (for non-negative rationals $a, b$). Proof: if $\\sqrt{a}+\\sqrt{b} = r \\in \\mathbb{Q}$, then $(\\sqrt{a}+\\sqrt{b})^2 = a+b+2\\sqrt{ab} = r^2$, so $\\sqrt{ab} = (r^2-a-b)/2 \\in \\mathbb{Q}$. Then $(\\sqrt{a}-\\sqrt{b}) = (a-b)/(\\sqrt{a}+\\sqrt{b}) = (a-b)/r \\in \\mathbb{Q}$, giving $\\sqrt{a} = (r + (a-b)/r)/2 \\in \\mathbb{Q}$. This is stronger than what the file proves: it shows rationality of the sum requires rationality of each term.",
+    "significance": "The generalization shows that the file's approach is essentially tight: the reduction to √6 is not just a convenient trick but a necessary consequence. If √6 were rational, then since √2 is irrational, we couldn't have √2+√3=r. The proof can be extended: for distinct squarefree integers a,b, √a+√b is always irrational (since √(ab) is irrational when ab is squarefree).",
+    "relatedConcepts": [
+      "sum of square roots rationality criterion",
+      "Besicovitch independence theorem",
+      "squarefree numbers",
+      "minimal polynomial technique"
+    ],
+    "prerequisites": [
+      "If √a + √b = r ∈ ℚ then √(ab) ∈ ℚ (by squaring)",
+      "Squarefree n: n = 1 or n is not divisible by any perfect square > 1",
+      "Linear independence of {1, √a₁, ..., √aₙ} over ℚ (Besicovitch)"
+    ]
+  },
+  {
+    "id": "annotation-minimal-polynomial",
+    "lineStart": 24,
+    "lineEnd": 35,
+    "type": "insight",
+    "mathContext": "The minimal polynomial of $\\alpha = \\sqrt{2}+\\sqrt{3}$ over $\\mathbb{Q}$ is $f(x) = x^4 - 10x^2 + 1$. Proof: $\\alpha^2 = 5 + 2\\sqrt{6}$ (the identity proved here), so $\\alpha^2 - 5 = 2\\sqrt{6}$, hence $(\\alpha^2-5)^2 = 24$, giving $\\alpha^4 - 10\\alpha^2 + 25 = 24$, so $\\alpha^4 - 10\\alpha^2 + 1 = 0$. The polynomial $f$ is irreducible over $\\mathbb{Q}$ (it has no rational roots by rational root theorem; the only candidates are $\\pm 1$ and both give $f(\\pm 1) = 1-10+1 = -8 \\neq 0$; and $f$ has no quadratic factor over $\\mathbb{Q}$ since any factorization $f = (x^2+ax+b)(x^2-ax+c)$ requires $ac+bc = -10$ and $bc = 1$ and $a(c-b) = 0$, leading to contradictions). Irrationality follows: $f(\\alpha) = 0$ with $f$ irreducible over $\\mathbb{Q}$ means $[\\mathbb{Q}(\\alpha):\\mathbb{Q}] = 4 > 1$, so $\\alpha \\notin \\mathbb{Q}$.",
+    "significance": "The minimal polynomial perspective gives a stronger result: not only is √2+√3 irrational, but it generates a degree-4 extension of ℚ. The file's squaring trick essentially derives the key relation α²-5=2√6 → (α²-5)²=24, which is exactly computing the minimal polynomial. Formalizing the full irreducibility argument would require polynomial arithmetic over ℚ and the rational root theorem.",
+    "relatedConcepts": [
+      "minimal polynomial over ℚ",
+      "rational root theorem",
+      "degree of field extension",
+      "irreducible polynomial"
+    ],
+    "prerequisites": [
+      "Minimal polynomial: smallest monic polynomial over ℚ vanishing at α",
+      "Rational root theorem: rational roots of monic integer poly are ±divisors of constant term",
+      "[ℚ(α):ℚ] = deg(min_poly(α))"
+    ]
+  }
+]

--- a/src/data/proofs/sqrt2-plus-sqrt3-irrational/meta.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-irrational/meta.json
@@ -29,15 +29,16 @@
     ]
   },
   "overview": {
-    "historicalContext": "The irrationality of √2 + √3 is a classical exercise in real analysis, notable because it requires more than just knowing √2 and √3 are irrational individually. The proof via squaring is elegant: if the sum were rational, squaring would make √6 rational, which is known to be false.",
+    "historicalContext": "The irrationality of $\\sqrt{2}$ has been known since ancient Greece — the Pythagoreans discovered it around 500 BC (the legendary proof by contradiction showing $\\sqrt{2} = p/q$ leads to both $p$ and $q$ being even). However, the irrationality of $\\sqrt{2} + \\sqrt{3}$ is more subtle: it does not follow trivially from the individual irrationalities (the sum of two irrationals can be rational, e.g., $\\sqrt{2} + (1 - \\sqrt{2}) = 1$). The correct approach is algebraic: the minimal polynomial of $\\sqrt{2} + \\sqrt{3}$ over $\\mathbb{Q}$ is $x^4 - 10x^2 + 1$ (degree 4, irreducible over $\\mathbb{Q}$), which shows $[\\mathbb{Q}(\\sqrt{2}+\\sqrt{3}):\\mathbb{Q}] = 4$ and in particular $\\sqrt{2}+\\sqrt{3} \\notin \\mathbb{Q}$. The short proof here bypasses field extensions: squaring maps the question to $\\sqrt{6} \\in \\mathbb{Q}$? which fails since 6 is not a perfect square. The general theorem (Besicovitch, 1940) states: $\\sum_i \\sqrt{a_i} \\in \\mathbb{Q}$ iff each $\\sqrt{a_i}$ is already rational.",
     "problemStatement": "Prove that √2 + √3 : ℝ is irrational.",
     "text": "The proof is by contradiction. Assume √2 + √3 = r for some r : ℚ. The algebraic identity (√2 + √3)² = 5 + 2√6 gives r² = 5 + 2√6, hence √6 = (r² - 5)/2. Since r is rational, (r² - 5)/2 is rational, but √6 is irrational (6 is not a perfect square, checked by native_decide). Contradiction. The algebraic identity is proved using sq_sqrt and sqrt_mul.",
     "proofStrategy": "sqrt2_plus_sqrt3_sq: ring_nf then rw [sq_sqrt h2, sq_sqrt h3] to convert √2² and √3², and √2·√3 = √6 via sqrt_mul. Main proof: assume ⟨r, hr⟩, square both sides, rearrange to get √6 = rational, then apply irrational_sqrt_six.",
     "keyInsights": [
-      "Squaring maps the irrationality question to a simpler one about √6",
-      "The identity (√a + √b)² = a + b + 2√(ab) is the key algebraic trick",
-      "√6 irrational: 6 = 2·3 is not a perfect square, checked computationally",
-      "The argument generalizes: √a + √b is irrational whenever ab is not a perfect square"
+      "The squaring technique reduces irrationality of $\\sqrt{a} + \\sqrt{b}$ to irrationality of $\\sqrt{ab}$: if $\\sqrt{a} + \\sqrt{b} = r \\in \\mathbb{Q}$, then $(\\sqrt{a}+\\sqrt{b})^2 = a + b + 2\\sqrt{ab} = r^2 \\in \\mathbb{Q}$, so $\\sqrt{ab} = (r^2 - a - b)/2 \\in \\mathbb{Q}$. For $a=2, b=3$: $\\sqrt{6} \\in \\mathbb{Q}$? No, since $6 = 2 \\cdot 3$ is not a perfect square.",
+      "Lean 4 `Irrational x` is defined as `¬ ∃ r : ℚ, (↑r : ℝ) = x` — literally, $x$ is not in the image of the canonical embedding $\\mathbb{Q} \\hookrightarrow \\mathbb{R}$. The proof `intro ⟨r, hr⟩` destructs this negation, giving $r : \\mathbb{Q}$ and `hr : (↑r : ℝ) = √2 + √3`.",
+      "`irrational_sqrt_natCast_iff` is the key Mathlib lemma: `Irrational (sqrt n) ↔ ¬IsSquare n` (for $n : \\mathbb{N}$). For $n=6$: `¬IsSquare (6 : ℕ)` is verified by `native_decide` since no $k$ satisfies $k^2 = 6$ among the 10 naturals $\\{0, \\ldots, 9\\}$.",
+      "The algebraic identity proof `sqrt2_plus_sqrt3_sq` uses `ring_nf` to expand $(\\sqrt{2}+\\sqrt{3})^2$, then `rw [sq_sqrt h2, sq_sqrt h3]` to replace $\\sqrt{2}^2 \\to 2$ and $\\sqrt{3}^2 \\to 3$, and `rw [← sqrt_mul h2 3]` to convert $\\sqrt{2} \\cdot \\sqrt{3} = \\sqrt{2 \\cdot 3} = \\sqrt{6}$. Finally `ring` closes the goal.",
+      "Generalization: the Besicovitch (1940) theorem states $\\{\\sqrt{a_1}, \\ldots, \\sqrt{a_n}\\}$ are linearly independent over $\\mathbb{Q}$ when the $a_i$ are distinct squarefree positive integers. In particular, $\\sqrt{2} + \\sqrt{3}$ is irrational (and in fact $[\\mathbb{Q}(\\sqrt{2},\\sqrt{3}):\\mathbb{Q}] = 4$). The minimal polynomial $x^4 - 10x^2 + 1$ is irreducible over $\\mathbb{Q}$ (checked by noting it has no rational roots and no quadratic factors over $\\mathbb{Q}$)."
     ],
     "prerequisites": [
       "Real.sqrt: sq_sqrt, sqrt_mul",
@@ -46,11 +47,12 @@
     ]
   },
   "conclusion": {
-    "summary": "√2 + √3 irrational via (√2+√3)² = 5 + 2√6 and irrationality of √6. Concise 54-line proof. 3 theorems, 0 axioms.",
-    "implications": "The squaring technique for proving irrationality of sums of square roots is a powerful method that generalizes to many combinations. This file demonstrates how Lean 4 handles the algebraic manipulation smoothly via ring_nf and sqrt identities.",
+    "summary": "√2 + √3 is irrational: proved via the squaring identity (√2+√3)² = 5+2√6 and irrationality of √6 (from irrational_sqrt_natCast_iff and ¬IsSquare 6 by native_decide). Concise 54-line proof. 3 theorems, 0 axioms.",
+    "implications": "The squaring technique demonstrates how algebraic manipulation can reduce hard irrationality questions to simpler ones. The proof is constructive in the sense that it shows √6 would be rational if √2+√3 were — a clear logical chain. The Lean 4 proof is clean because ring_nf and sqrt_mul handle the algebraic identity automatically, while native_decide handles the finite computation.",
     "openQuestions": [
-      "Prove √2 + √3 + √5 is irrational (requires three-level squaring argument)",
-      "Characterize when Σ_{i} √aᵢ is irrational in terms of the aᵢ"
+      "Prove that $\\sqrt{2} + \\sqrt{3} + \\sqrt{5}$ is irrational: squaring gives $\\sqrt{2}+\\sqrt{3}+\\sqrt{5} = r$ implies $\\sqrt{6}+\\sqrt{10}+\\sqrt{15} \\in \\mathbb{Q}$ (from $(r-\\sqrt{5})^2 = 5 + 2\\sqrt{6} + 2\\sqrt{10}\\cdot ?$); requires a more involved algebraic argument.",
+      "Formalize Besicovitch's theorem (1940): $\\{\\sqrt{a_1}, \\ldots, \\sqrt{a_n}\\}$ are linearly independent over $\\mathbb{Q}$ when $a_1, \\ldots, a_n$ are distinct squarefree positive integers. This would give a complete characterization: $\\sum_i r_i \\sqrt{a_i} \\in \\mathbb{Q}$ iff all $r_i = 0$ for $a_i > 1$.",
+      "Formalize the minimal polynomial of $\\sqrt{2}+\\sqrt{3}$ over $\\mathbb{Q}$: show the polynomial $f(x) = x^4 - 10x^2 + 1$ satisfies $f(\\sqrt{2}+\\sqrt{3}) = 0$ and is irreducible over $\\mathbb{Q}$ (via Eisenstein or rational root theorem). This would give the stronger result $[\\mathbb{Q}(\\sqrt{2}+\\sqrt{3}):\\mathbb{Q}] = 4$."
     ]
   },
   "leanFile": {
@@ -62,10 +64,49 @@
   },
   "crossReferences": [
     {
-      "targetId": "cube-root-2-irrational",
+      "id": "cube-root-2-irrational",
       "relationship": "related",
-      "description": "Companion irrationality result using a different technique (cube roots vs sum of square roots)"
+      "description": "Companion irrationality result using a different technique (minimal polynomial / p-adic valuation for cube roots vs squaring trick for sum of square roots)."
+    },
+    {
+      "id": "irrational-sqrt-2",
+      "relationship": "parent",
+      "description": "Irrationality of √2 — the classical Pythagorean result that provides the foundation. The irrationality of √2+√3 requires √6 ∉ ℚ as an intermediate step, which uses the same non-perfect-square criterion."
+    },
+    {
+      "id": "algebraic-numbers",
+      "relationship": "related",
+      "description": "Algebraic numbers over ℚ: √2+√3 is algebraic of degree 4 with minimal polynomial x⁴-10x²+1. Irrationality is equivalent to this polynomial having degree > 1."
     }
   ],
-  "sections": []
+  "sections": [
+    {
+      "id": "sec-imports",
+      "title": "Imports and Setup",
+      "startLine": 1,
+      "endLine": 17,
+      "summary": "Module docstring explains the 4-step strategy: assume √2+√3=r, square to get r²=5+2√6, rearrange to √6=(r²-5)/2 ∈ ℚ, contradict √6 irrational. Imports Mathlib.Data.Real.Irrational, Sqrt, Tactic. Opens Real. Namespace Sqrt2PlusSqrt3Irrational."
+    },
+    {
+      "id": "sec-sqrt6-irrational",
+      "title": "√6 is Irrational (Auxiliary Lemma)",
+      "startLine": 19,
+      "endLine": 23,
+      "summary": "irrational_sqrt_six: Irrational (sqrt 6). Proof: native_decide proves ¬IsSquare (6 : ℕ) (no k satisfies k²=6), then irrational_sqrt_natCast_iff.mpr gives the result. This is the key auxiliary that feeds into the main proof."
+    },
+    {
+      "id": "sec-algebraic-identity",
+      "title": "Key Algebraic Identity: (√2+√3)² = 5 + 2√6",
+      "startLine": 24,
+      "endLine": 35,
+      "summary": "sqrt2_plus_sqrt3_sq: (sqrt 2 + sqrt 3)^2 = 5 + 2 * sqrt 6. Proved by: (1) h6 : sqrt 2 * sqrt 3 = sqrt 6 via ← sqrt_mul h2 3 + norm_num; (2) ring_nf expands; (3) rw [sq_sqrt h2, sq_sqrt h3, h6] replaces √2²→2, √3²→3, √2·√3→√6; (4) ring closes."
+    },
+    {
+      "id": "sec-main-theorem",
+      "title": "Main Theorem: √2+√3 is Irrational",
+      "startLine": 36,
+      "endLine": 53,
+      "summary": "irrational_sqrt2_plus_sqrt3: Irrational (sqrt 2 + sqrt 3). Proof by contradiction: intro ⟨r, hr⟩ gives r:ℚ with hr:(r:ℝ)=√2+√3. Squaring via sqrt2_plus_sqrt3_sq gives hsq:(r:ℝ)²=5+2√6. linarith gives h6:√6=(r²-5)/2. Constructs rational witness q=(r²-5)/2 with cast computation, then exact irrational_sqrt_six ⟨q, ...⟩."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for three gallery entries.

## gcd-algorithm-oq-01-oq-03: Binet's Formula and Lamé's 5-Digit Bound
- 6 annotations (five-step identity, growth bound, main theorem, Vieta's formulas, Binet paired induction, φ⁵>10)
- 8 sections covering 280-line file
- Expanded historicalContext: Lamé 1844 complexity theory, Binet/Bernoulli/Euler priority
- 5 keyInsights with LaTeX (five-step growth, paired induction, nearest integer, φ⁵, Vieta)
- 3 crossReferences (gcd-algorithm-oq-01, gcd-algorithm, binary-gcd)

## erdos-1006-oq-01: Robustly Acyclic Orientations and Cover Graphs
- 5 annotations (GraphOrientation, empty graph, cover orientation, bipartite robustness, axioms)
- 6 sections covering 277-line file
- Expanded historicalContext: Pretzel/Brightwell 1985, Nešetřil-Rödl 1978, Fisher et al. 1997
- 5 keyInsights with LaTeX
- 3 crossReferences (erdos-1006, erdos-1006-oq-02, ramseys-theorem)

## euler-totient-oq-04: Divisor Sum Identity via GCD Partition
- 8 annotations + 7 sections covering 231-line file
- Expanded historicalContext: Euler 1763, Gauss, Möbius, cyclotomic polynomial connection
- 3 crossReferences

All entries: axiom integrity verified, quality improvements for annotations/sections/cross-refs.