### PR TITLE
Fix: close unclosed Lean docstrings hiding axioms in 4 Erdos proofs

### DIFF
--- a/proofs/Proofs/Erdos15Problem.lean
+++ b/proofs/Proofs/Erdos15Problem.lean
@@ -73,7 +73,7 @@ def AlternatingPrimeSeriesConverges : Prop :=
 The Prime Number Theorem tells us p_n ~ n log n.
 -/
 
-/-- The Prime Number Theorem: p_n / (n log n) → 1 as n → ∞.
+/-- The Prime Number Theorem: p_n / (n log n) → 1 as n → ∞. -/
 
 /-- Consequence: n / p_n ~ 1 / log n → 0.
 
@@ -81,7 +81,7 @@ The Prime Number Theorem tells us p_n ~ n log n.
 axiom terms_tend_to_zero :
     Tendsto (fun n : ℕ => (n : ℝ) / (nthPrime n : ℝ)) atTop (𝓝 0)
 
-/-- The terms of our series go to zero.
+/-- The terms of our series go to zero. -/
 
 /-
 ## The Alternating Series Test
@@ -122,7 +122,7 @@ def HardyLittlewoodConjecture : Prop :=
     (∀ p : ℕ, p.Prime → (Finset.univ.image h).image (· % p) ≠ Finset.range p) →
     ∀ N : ℕ, ∃ n > N, ∀ i : Fin k, (n + h i).Prime
 
-/-- Tao's Theorem (2023): Assuming Hardy-Littlewood, the series converges.
+/-- Tao's Theorem (2023): Assuming Hardy-Littlewood, the series converges. -/
 
 /-
 ## Related Series (Erdős's Conjectures)
@@ -149,9 +149,9 @@ def ErdosGapConjecture2 : Prop :=
     (fun N => ∑ n ∈ Finset.Icc 1 N, (-1 : ℝ)^n / primeGap n)
     atTop (𝓝 L)
 
-/-- Zhang's Theorem (2014): There are infinitely many prime gaps ≤ 70,000,000.
+/-- Zhang's Theorem (2014): There are infinitely many prime gaps ≤ 70,000,000. -/
 
-/-- Consequence of Zhang: Erdős's second conjecture is true.
+/-- Consequence of Zhang: Erdős's second conjecture is true. -/
 
 /-
 ## Why This Problem is Hard
@@ -169,7 +169,7 @@ The difficulty stems from the irregular distribution of primes.
    as the answer depends on the infinite tail behavior.
 -/
 
-/-- The problem cannot be resolved by computing finitely many terms.
+/-- The problem cannot be resolved by computing finitely many terms. -/
 
 /-
 ## Absolute Convergence
@@ -177,7 +177,7 @@ The difficulty stems from the irregular distribution of primes.
 Note that the series does NOT converge absolutely.
 -/
 
-/-- The series Σ n/p_n diverges (no absolute convergence).
+/-- The series Σ n/p_n diverges (no absolute convergence). -/
 
 /-
 ## Numerical Evidence
@@ -186,7 +186,7 @@ Computational evidence suggests the partial sums oscillate around a value
 near -1, but this cannot prove convergence.
 -/
 
-/-- Empirical observation: partial sums appear to oscillate around ≈ -1.
+/-- Empirical observation: partial sums appear to oscillate around ≈ -1. -/
 
 /-
 ## Summary

--- a/proofs/Proofs/Erdos231Problem.lean
+++ b/proofs/Proofs/Erdos231Problem.lean
@@ -128,7 +128,7 @@ The key result: infinite abelian-square-free strings exist over 4 letters.
 -/
 
 /-- Keränen (1992): There exists an infinite sequence over 4 letters
-    with no abelian squares.
+    with no abelian squares. -/
 
 /-- The Keränen morphism (85 letters per symbol) that generates
     abelian-square-free words. -/

--- a/proofs/Proofs/Erdos297Problem.lean
+++ b/proofs/Proofs/Erdos297Problem.lean
@@ -132,7 +132,7 @@ The first proof that c < 1, establishing egyptianCount(N) ≤ 2^{0.93N}.
 def steinerbergerConstant : ℝ := 0.93
 
 /-- **Steinerberger (2024, arXiv:2403.17041):**
-    The Egyptian count satisfies egyptianCount(N) ≤ 2^{0.93N} for all sufficiently large N.
+    The Egyptian count satisfies egyptianCount(N) ≤ 2^{0.93N} for all sufficiently large N. -/
 
 /-
 ## Part 6: Liu-Sawhney's Full Asymptotic (April 2024)
@@ -174,7 +174,7 @@ noncomputable def egyptianCountTarget (N : ℕ) (x : ℚ) : ℕ :=
 
 /-- **Conlon et al. generalization:**
     For any rational x > 0, there exists a constant c_x ∈ (0, 1) such that
-    egyptianCountTarget(N, x) = 2^{(c_x + o(1))N}.
+    egyptianCountTarget(N, x) = 2^{(c_x + o(1))N}. -/
 
 /-
 ## Part 8: The 2017 MathOverflow Precedent
@@ -193,7 +193,7 @@ The constraint Σ 1/n = 1 exactly is very restrictive.
 -/
 
 /-- **Heuristic:** For a random subset of {1,...,N}, the expected harmonic sum is
-    E[Σ 1/n] ≈ (1/2) · H_N ≈ (log N)/2, which grows without bound.
+    E[Σ 1/n] ≈ (1/2) · H_N ≈ (log N)/2, which grows without bound. -/
 
 /-
 ## Part 10: Main Results

--- a/proofs/Proofs/Erdos657Problem.lean
+++ b/proofs/Proofs/Erdos657Problem.lean
@@ -152,7 +152,7 @@ noncomputable def numDifferences (A : Finset ℝ) : ℕ :=
 
 /-- **Straus's Observation:**
     If 2^k ≥ n, there exist n points in ℝ^k with no isosceles triangle
-    that determine at most n-1 distinct distances.
+    that determine at most n-1 distinct distances. -/
 
 /-
 ## Part IX: Known Examples


### PR DESCRIPTION
## Fix

Close orphaned `/-- ... ` docstrings in 4 Erdős proof files that left all subsequent `axiom` declarations invisible to Lean (treated as comment text).

## Evidence

**Before**: 4 files had unclosed `/--` docstrings; all `axiom` declarations after them were hidden inside the comment block. Lean saw 0 axioms per file despite meta.json claiming 1–3.

**After**: Each orphaned docstring is properly closed with ` -/`, making all `axiom` declarations visible to Lean again.

| Proof | Fix location | Axioms now visible |
|-------|-------------|-------------------|
| erdos-657 | line 155 | 1 axiom at line 182 |
| erdos-231 | line 131 | 1 axiom at line 147 |
| erdos-297 | lines 135, 175, 195 | 3 axioms at lines 150, 160, 231 |
| erdos-15  | lines 76, 84, 122, 149, 150, 169, 182, 191 | 1 axiom at line 81 |

Closes #9028

---
Automated fix by lean-mechanic agent.