### PR TITLE
Fix: erdos-157 sorry count mismatch (meta.json claims 3, actual is 2)

### DIFF
--- a/src/data/proofs/erdos-157/meta.json
+++ b/src/data/proofs/erdos-157/meta.json
@@ -18,7 +18,7 @@
       "density"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 157,
     "erdosUrl": "https://erdosproblems.com/157",
     "erdosProblemStatus": "solved",


### PR DESCRIPTION
## Summary

- The `meta.sorries` field in `src/data/proofs/erdos-157/meta.json` was `3`, but the actual Lean file (`proofs/Proofs/Erdos157Problem.lean`) contains only 2 `sorry` occurrences (lines 109 and 352).
- The `meta.assumptions` field already correctly stated "2 axiom(s) and 2 sorry(s)", so only the numeric `sorries` field was out of sync.
- Changed `"sorries": 3` to `"sorries": 2` to match reality.

## Verification

```
$ grep -n sorry proofs/Proofs/Erdos157Problem.lean
109:  sorry
352:  sorry
```

## Test plan

- [x] Verified sorry count in Lean source (2 occurrences)
- [x] Confirmed `meta.assumptions` already says "2 sorry(s)" -- consistent with the fix
- [x] Only `meta.sorries` changed; `leanFile` object left untouched

Generated with [Claude Code](https://claude.com/claude-code)