### PR TITLE
Fix: erdos-1009-oq-02 badge overclaim and stale docstring

### DIFF
--- a/proofs/Proofs/Erdos1009OQ02Problem.lean
+++ b/proofs/Proofs/Erdos1009OQ02Problem.lean
@@ -166,8 +166,8 @@ theorem turanK4_extremal (G : SimpleGraph V) [DecidableRel G.Adj]
 
     This is the contrapositive of `turanK4_extremal`: if no K₄ exists then
     CliqueFree 4 holds, giving edges ≤ turanThresholdK4. The bridge from
-    "no Clique4" to CliqueFree 4 requires extracting 4 vertices from a
-    Mathlib clique finset, which we defer via sorry. -/
+    "no Clique4" to CliqueFree 4 is proved by extracting 4 vertices from the
+    Mathlib clique finset via `Finset.card_eq_four`. -/
 theorem exceeds_turanK4_has_clique4 (G : SimpleGraph V) [DecidableRel G.Adj]
     (h : numEdges4 G > turanThresholdK4 (numVertices4 G)) :
     ∃ K : Clique4 G, True := by

--- a/src/data/proofs/erdos-1009-oq-02/meta.json
+++ b/src/data/proofs/erdos-1009-oq-02/meta.json
@@ -19,7 +19,7 @@
       "open",
       "extremal-combinatorics"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 1009,
     "erdosUrl": "https://erdosproblems.com/1009",
@@ -28,7 +28,7 @@
     "mathlib_version": "4.26.0",
     "lineCount": 240,
     "axiomCount": 0,
-    "assumptions": "Main open question stated as Prop (not asserted true). All supporting theorems fully proved: 0 sorries, 0 axioms.",
+    "assumptions": "Main open question stated as Prop (not asserted true). All supporting theorems fully proved: 0 sorries, 0 axioms. Core Turán bound (turanK4_extremal) uses Mathlib's CliqueFree.card_edgeFinset_le.",
     "mathlibDependencies": [
       {
         "theorem": "SimpleGraph.CliqueFree.card_edgeFinset_le",
@@ -44,7 +44,7 @@
     "originalContributions": [
       "Clique4 structure: formalization of K₄ copies in simple graphs",
       "edgeDisjointK4_question: formal statement of the K₄ analog of Györi's theorem",
-      "turanK4_extremal: K₄-free graphs have ≤ ⌊n²/3⌋ edges (Turán's theorem)",
+      "turanK4_extremal: bridge theorem connecting Mathlib's Turán bound to our K₄ structure",
       "turanK3_le_turanK4: K₄ threshold dominates K₃ threshold",
       "clique4_has_triangle: every K₄ contains a K₃"
     ],


### PR DESCRIPTION
## Fix

Correct metadata and docstring for erdos-1009-oq-02 (Edge-Disjoint K₄ Copies Beyond Turán).

## Evidence

**Problem 1: Badge overclaims independence**
- **Before**: `badge: original` — claimed independent proof of Turán bound
- **After**: `badge: mathlib` — correctly credits Mathlib's `CliqueFree.card_edgeFinset_le`

**Problem 2: originalContributions entry was misleading**
- **Before**: `turanK4_extremal: K₄-free graphs have ≤ ⌊n²/3⌋ edges (Turán's theorem)` — sounds like an independent proof
- **After**: `turanK4_extremal: bridge theorem connecting Mathlib's Turán bound to our K₄ structure`

**Problem 3: Stale docstring at line 170**
- **Before**: "which we defer via sorry" — stale, the sorry was removed in PR #9009
- **After**: "is proved by extracting 4 vertices from the Mathlib clique finset via `Finset.card_eq_four`"

**Problem 4: assumptions field**
- **Before**: no mention of Mathlib dependency
- **After**: notes that core Turán bound uses Mathlib

Note: `status: verified` (0 sorries, 0 axioms) is correct and unchanged.

Closes #9041

---
Automated fix by lean-mechanic agent.