### PR TITLE
Audit: cycle 24 tracker — re-flags unclosed-docstring axiom issues, new erdos-1009-oq-02 finding

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1758,8 +1758,8 @@
       "result": "clean"
     },
     "erdos-1006-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T05:24:38Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-03T19:22:46Z",
       "result": "clean"
     },
     "erdos-1006-oq-02": {
@@ -3349,9 +3349,9 @@
       "result": "clean"
     },
     "erdos-15": {
-      "auditCount": 3,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-04-03T18:56:54Z",
+      "lastAudited": "2026-04-03T19:28:01Z",
       "result": "issues-found"
     },
     "erdos-150": {
@@ -3403,12 +3403,12 @@
       "result": "clean"
     },
     "erdos-157": {
-      "auditCount": 2,
+      "auditCount": 4,
       "issues": [
         "sorry mismatch corrected in meta.json"
       ],
-      "lastAudited": "2026-04-03T09:06:15Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-03T19:19:08Z",
+      "result": "issues-found"
     },
     "erdos-158": {
       "auditCount": 2,
@@ -3699,9 +3699,9 @@
       "result": "clean"
     },
     "erdos-2-oq-01": {
-      "auditCount": 3,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-03T18:57:00Z",
+      "lastAudited": "2026-04-03T19:23:19Z",
       "result": "clean"
     },
     "erdos-20": {
@@ -3916,8 +3916,8 @@
     },
     "erdos-231": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T18:56:54Z",
+      "auditCount": 6,
+      "lastAudited": "2026-04-03T19:28:01Z",
       "result": "issues-found"
     },
     "erdos-232": {
@@ -4361,8 +4361,8 @@
     },
     "erdos-297": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T18:56:54Z",
+      "auditCount": 6,
+      "lastAudited": "2026-04-03T19:28:01Z",
       "result": "issues-found"
     },
     "erdos-298": {
@@ -6830,8 +6830,8 @@
     },
     "erdos-657": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T18:56:54Z",
+      "auditCount": 6,
+      "lastAudited": "2026-04-03T19:28:01Z",
       "result": "issues-found"
     },
     "erdos-658": {
@@ -9536,9 +9536,9 @@
       "result": "issues-fixed"
     },
     "greens-theorem-oq-04": {
-      "auditCount": 2,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T17:39:52Z",
+      "lastAudited": "2026-04-03T19:22:02Z",
       "result": "clean"
     },
     "halting-problem": {
@@ -10852,9 +10852,9 @@
       "result": "clean"
     },
     "triangular-reciprocals-oq-03-oq-02": {
-      "auditCount": 2,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T17:37:52Z",
+      "lastAudited": "2026-04-03T19:22:02Z",
       "result": "clean"
     },
     "twin-primes-special": {
@@ -11091,8 +11091,8 @@
       "issues": []
     },
     "euler-totient-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T05:51:42Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-03T19:22:46Z",
       "result": "clean",
       "issues": []
     },
@@ -11253,9 +11253,9 @@
       "issues": []
     },
     "erdos-1009-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T09:33:04Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-04-03T19:21:44Z",
+      "result": "issues-found",
       "issues": []
     },
     "erdos-1098-oq-01-oq-01": {


### PR DESCRIPTION
## Summary

- Filed issue #9041: `erdos-1009-oq-02` badge `original` should be `mathlib` (core Turán result via Mathlib); stale docstring claims "defer via sorry" after sorry was removed in #9009
- Re-flagged `erdos-15`, `erdos-231`, `erdos-297`, `erdos-657` as `issues-found`: their axiom declarations are inside unclosed `/-- ` docstrings (issue #9028); PR #9036 incorrectly dismissed these as false positives  
- Cleared false positives with verified analysis:
  - `greens-theorem-oq-04`: clean (2 of 3 OQ03 axioms verified as directly used)
  - `triangular-reciprocals-oq-03-oq-02`: clean (1 inherited axiom verified)
  - `erdos-2-oq-01`: clean (3 inherited axioms from Erdos2Problem.lean verified)
  - `euler-totient-oq-04`: clean (constructive proof, badge `original` justified)
  - `erdos-1006-oq-01`: clean (3 axioms match; single "sorry" is in a comment)

## Key Finding: PR #9036 Error

PR #9036 ("cycle 23 tracker") incorrectly cleared `erdos-15/231/297/657` as "stale tracker entries" by using `grep -c "^axiom"` (which does not strip comments). The detection script's `stripLeanComments()` correctly identifies these axioms as inside unclosed docstring blocks. See comment on PR #9036 and issue #9028 for full analysis.

## Active Issues

- **#9028** (open): 4 proofs with unclosed docstrings swallowing axiom declarations
- **#9035** (open): erdos-157 sorry count fix
- **#9041** (new): erdos-1009-oq-02 badge correction

🤖 Generated with [Claude Code](https://claude.com/claude-code)