### PR TITLE
fix: prove multinomial_triple and fix 3 bugs in KummerTheoremOQ01

### DIFF
--- a/proofs/Proofs/KummerTheoremOQ01.lean
+++ b/proofs/Proofs/KummerTheoremOQ01.lean
@@ -35,28 +35,64 @@ noncomputable def multinomial (ks : List ℕ) : ℕ :=
   (ks.sum).factorial / (ks.map Nat.factorial).prod
 
 /-- A multinomial coefficient factors as a product of binomial coefficients.
-    C(k₁+k₂, k₁) · C(k₁+k₂+k₃, k₁+k₂) · ... -/
+    C(k₁+k₂, k₁) · C(k₁+k₂+k₃, k₁+k₂) · ...
+    Note: the pair (acc, k) from scanl/zip gives C(acc+k, k), not C(acc, k).
+    For ks = [k₁, k₂, k₃], the tail pairs are (k₁, k₂) and (k₁+k₂, k₃),
+    giving C(k₁+k₂, k₂) · C(k₁+k₂+k₃, k₃) = C(k₁+k₂, k₁) · C(k₁+k₂+k₃, k₁+k₂). -/
 theorem multinomial_eq_prod_choose : ∀ (ks : List ℕ),
-    multinomial ks = (ks.scanl (· + ·) 0).zip ks |>.tail |>.map
-      (fun ⟨acc, k⟩ => Nat.choose acc k) |>.prod := by
+    multinomial ks =
+      (((ks.scanl (· + ·) (0 : ℕ)).zip ks).tail.map
+        (fun ⟨acc, k⟩ => Nat.choose (acc + k) k)).prod := by
   sorry
 
 /-- For two elements, the multinomial reduces to a binomial. -/
 theorem multinomial_pair (a b : ℕ) :
     multinomial [a, b] = Nat.choose (a + b) a := by
-  simp [multinomial, Nat.add_choose_eq]
+  have hpos : 0 < a.factorial * b.factorial :=
+    Nat.mul_pos (Nat.factorial_pos a) (Nat.factorial_pos b)
+  have h := Nat.choose_mul_factorial_mul_factorial (Nat.le_add_right a b)
+  rw [show a + b - a = b from by omega] at h
+  -- h : (a+b).choose a * a! * b! = (a+b)!
+  simp only [multinomial, List.sum_cons, List.sum_nil, List.map_cons, List.map_nil,
+             List.prod_cons, List.prod_nil, mul_one]
+  rw [show a + (b + 0) = a + b from by omega]
+  -- Goal: (a+b)! / (a! * b!) = (a+b).choose a
+  have key : (a + b).choose a * (a.factorial * b.factorial) = (a + b).factorial :=
+    calc (a + b).choose a * (a.factorial * b.factorial)
+        = (a + b).choose a * a.factorial * b.factorial := by ring
+      _ = (a + b).factorial := h
+  rw [← key]
+  exact Nat.mul_div_cancel _ hpos
 
 /-- For three elements: C(a+b+c; a, b, c) = C(a+b, a) · C(a+b+c, a+b). -/
 theorem multinomial_triple (a b c : ℕ) :
     multinomial [a, b, c] = Nat.choose (a + b) a * Nat.choose (a + b + c) (a + b) := by
-  simp only [multinomial, List.sum_cons, List.map_cons, List.prod_cons]
+  simp only [multinomial, List.sum_cons, List.sum_nil, List.map_cons, List.map_nil,
+             List.prod_cons, List.prod_nil, mul_one]
   rw [show a + (b + (c + 0)) = a + b + c from by omega]
-  rw [show Nat.factorial a * (Nat.factorial b * (Nat.factorial c * 1)) =
-    Nat.factorial a * Nat.factorial b * Nat.factorial c from by ring]
-  -- (a+b+c)! / (a! · b! · c!) = ((a+b)! / (a! · b!)) · ((a+b+c)! / ((a+b)! · c!))
-  rw [Nat.choose_eq_factorial_div_factorial (Nat.le_add_right a b),
-      Nat.choose_eq_factorial_div_factorial (Nat.le_add_right (a + b) c)]
-  sorry
+  -- Goal: (a+b+c)! / (a! * (b! * c!)) = C(a+b,a) * C(a+b+c,a+b)
+  -- Strategy: both sides * (a! * (b! * c!)) = (a+b+c)! via choose_mul_factorial
+  have hpos : 0 < a.factorial * (b.factorial * c.factorial) :=
+    Nat.mul_pos (Nat.factorial_pos a) (Nat.mul_pos (Nat.factorial_pos b) (Nat.factorial_pos c))
+  -- Use C(n,k) * k! * (n-k)! = n! twice
+  have h1 := Nat.choose_mul_factorial_mul_factorial (Nat.le_add_right a b)
+  have h2 := Nat.choose_mul_factorial_mul_factorial (Nat.le_add_right (a + b) c)
+  rw [show a + b - a = b from by omega] at h1
+  rw [show a + b + c - (a + b) = c from by omega] at h2
+  -- h1 : C(a+b,a) * a! * b! = (a+b)!
+  -- h2 : C(a+b+c,a+b) * (a+b)! * c! = (a+b+c)!
+  -- Key: RHS * denominator = (a+b+c)!
+  have key : Nat.choose (a + b) a * Nat.choose (a + b + c) (a + b) *
+      (a.factorial * (b.factorial * c.factorial)) = (a + b + c).factorial := by
+    calc Nat.choose (a + b) a * Nat.choose (a + b + c) (a + b) *
+            (a.factorial * (b.factorial * c.factorial))
+        = Nat.choose (a + b + c) (a + b) *
+            (Nat.choose (a + b) a * a.factorial * b.factorial) * c.factorial := by ring
+      _ = Nat.choose (a + b + c) (a + b) * (a + b).factorial * c.factorial := by rw [h1]
+      _ = (a + b + c).factorial := h2
+  -- Conclude: (a+b+c)! / denom = RHS  via (RHS * denom) / denom = RHS
+  rw [← key]
+  exact Nat.mul_div_cancel _ hpos
 
 /-- Kummer's theorem for multinomials (statement):
     The p-adic valuation of C(n; k₁,...,kₘ) equals the total number

--- a/src/data/proofs/kummer-theorem-oq-01/meta.json
+++ b/src/data/proofs/kummer-theorem-oq-01/meta.json
@@ -13,10 +13,10 @@
     ],
     "proofRepoPath": "Proofs/KummerTheoremOQ01.lean",
     "badge": "formalized",
-    "sorries": 2,
+    "sorries": 1,
     "axiomCount": 0,
-    "assumptions": "0 axioms. 2 sorries: multinomial_eq_prod_choose (general decomposition), multinomial_triple (a+b+c case). Proved: multinomial_pair (reduces to choose).",
-    "lineCount": 68,
+    "assumptions": "0 axioms. 1 sorry: multinomial_eq_prod_choose (general list induction). Proved: multinomial_pair (binomial case), multinomial_triple (trinomial case via choose_mul_factorial_mul_factorial).",
+    "lineCount": 103,
     "theoremCount": 4,
     "definitionCount": 1,
     "mathlib_version": "4.26.0",
@@ -32,7 +32,7 @@
   "overview": {
     "historicalContext": "Ernst Kummer proved in 1852 that the highest power of a prime p dividing the binomial coefficient C(n, k) equals the number of carries when adding k and n-k in base p. This elegant theorem connects combinatorics (counting subsets) with the arithmetic of positional numeral systems. The result was rediscovered and generalized throughout the 20th century. The multinomial extension is a natural question: the multinomial coefficient C(n; k₁, k₂, ..., kₘ) counts the number of ways to partition n objects into groups of sizes k₁, ..., kₘ (with n = k₁ + ... + kₘ). The key insight is that multinomial coefficients factor as products of binomials via a telescoping decomposition: C(n; k₁,...,kₘ) = C(k₁+k₂, k₁) · C(k₁+k₂+k₃, k₁+k₂) · ... · C(n, n-kₘ). Applying Kummer's theorem to each factor and summing gives the total carry count when adding k₁, k₂, ..., kₘ successively in base p.",
     "problemStatement": "Can Kummer's theorem — $v_p\\binom{n}{k} = c(k, n-k; p)$ where $c$ counts base-$p$ carries — be extended to multinomial coefficients? That is, does $v_p\\binom{n}{k_1,\\ldots,k_m} = $ total carries when adding $k_1,\\ldots,k_m$ in base $p$? Answer: yes, via iterated binomial decomposition.",
-    "proofStrategy": "The file defines the multinomial coefficient as n! / (k₁! · ... · kₘ!) using `List.sum` and `List.prod`. The key identity `multinomial_eq_prod_choose` expresses this as a product of binomials via `List.scanl` accumulation. `multinomial_pair` is fully proved (reduces to `Nat.add_choose_eq`). `multinomial_triple` is partially proved: the factorial rearrangement is complete but the final division step has a sorry. `kummer_multinomial_statement` is a placeholder stub (returns `True`).",
+    "proofStrategy": "The file defines the multinomial coefficient as n! / (k₁! · ... · kₘ!) using `List.sum` and `List.prod`. The key identity `multinomial_eq_prod_choose` expresses this as a product of binomials via `List.scanl` accumulation (1 sorry remains for the general list induction). `multinomial_pair` is fully proved via `Nat.choose_mul_factorial_mul_factorial`. `multinomial_triple` is fully proved: uses `Nat.choose_mul_factorial_mul_factorial` twice to establish C(a+b,a)*C(a+b+c,a+b)*(a!*(b!*c!)) = (a+b+c)!, then concludes via `Nat.mul_div_cancel`. `kummer_multinomial_statement` is a placeholder stub (returns `True`).",
     "keyInsights": [
       "The iterated decomposition $\\binom{n}{k_1,\\ldots,k_m} = \\prod_{i=1}^{m} \\binom{k_1+\\cdots+k_i}{k_1+\\cdots+k_{i-1}}$ is the algebraic heart of the extension. Each factor is an ordinary binomial to which Kummer's theorem applies directly.",
       "Kummer's theorem for each binomial factor gives $v_p\\binom{k_1+\\cdots+k_i}{k_1+\\cdots+k_{i-1}} = c(k_i, k_1+\\cdots+k_{i-1}; p)$ — the carries when adding the $i$-th part to the running sum. Summing over all $i$ gives the total carries for adding all parts.",


### PR DESCRIPTION
## Summary

- **Fixed 3 bugs** in the existing formalization:
  1. `multinomial_eq_prod_choose` had wrong formula: `Nat.choose acc k` → `Nat.choose (acc + k) k` (old formula gives 0 for most inputs, e.g., `C([2,1])` gave 0 instead of 3)
  2. `|>.prod` on a new line was captured inside the lambda body due to Lean 4 parsing precedence
  3. `multinomial_pair` used `Nat.add_choose_eq` which expands (Vandermonde convolution) rather than proves the goal

- **Proved `multinomial_triple` completely**: `multinomial [a,b,c] = C(a+b,a) * C(a+b+c,a+b)`
  - Uses `Nat.choose_mul_factorial_mul_factorial` twice
  - Key: `C(a+b,a)*C(a+b+c,a+b)*(a!*(b!*c!)) = (a+b+c)!` via a `calc` chain
  - Closes with `Nat.mul_div_cancel`

- Sorry count: **2 → 1** (`multinomial_eq_prod_choose` general list induction remains)

## Mathematical significance

The `multinomial_triple` theorem is the concrete n=3 case of the multinomial Kummer theorem: `(a+b+c)!/(a!·b!·c!) = C(a+b,a)·C(a+b+c,a+b)`. This algebraic identity underlies the p-adic valuation calculation for trinomial coefficients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)