### PR TITLE
Fix: add additionalFiles to 3 proofs for find-targets.ts axiom resolution

### DIFF
--- a/src/data/proofs/erdos-2-oq-01/meta.json
+++ b/src/data/proofs/erdos-2-oq-01/meta.json
@@ -38,6 +38,7 @@
       "Erdős Problem #2 parent formalization"
     ],
     "mathlib_version": "4.29.0",
+    "additionalFiles": ["Proofs/Erdos2Problem.lean"],
     "originalContributions": [
       "Formal definition of IsExactMaxMinModulus with equivalent characterizations",
       "Existence proof using well-ordering (Nat.find on the complement of the achievable set)",

--- a/src/data/proofs/greens-theorem-oq-04/meta.json
+++ b/src/data/proofs/greens-theorem-oq-04/meta.json
@@ -82,7 +82,8 @@
       "Topology of planar regions (fundamental group, Betti numbers)"
     ],
     "assumptions": "2 axioms inherited from GreensTheoremOQ03.lean: greens_theorem_typeI (Green's theorem for simply-connected TypeI regions, used at lines 296, 280 to prove the main theorem) and disk_area_eq_pi (area of disk formula, used at lines 170, 179 to compute annular area). 0 sorries.",
-    "mathlib_version": "4.26.0"
+    "mathlib_version": "4.26.0",
+    "additionalFiles": ["Proofs/GreensTheoremOQ03.lean"]
   },
   "overview": {
     "historicalContext": "Green's theorem for multiply-connected regions is the natural generalization needed when the domain has holes (non-trivial topology). The classical treatment appears in Ahlfors' 'Complex Analysis' (1953) and Apostol's 'Mathematical Analysis' (1974). The key insight is that the boundary integral must account for all boundary components with correct orientation: the outer boundary counterclockwise, inner boundaries (holes) clockwise. This ensures the region always lies to the left of the traversed boundary.\n\nThe multiply-connected extension is foundational to:\n- **Complex analysis**: Cauchy's integral formula and the residue theorem require circulation around punctured disks\n- **De Rham cohomology**: Non-trivial first cohomology H^1(D) = R^n arises from n holes, with each hole contributing an independent 'period'\n- **Physics**: Gauss's law with interior conductors, the Aharonov-Bohm effect, and vortex dynamics in fluid mechanics all rely on this extension",

--- a/src/data/proofs/triangular-reciprocals-oq-03-oq-02/meta.json
+++ b/src/data/proofs/triangular-reciprocals-oq-03-oq-02/meta.json
@@ -43,7 +43,8 @@
         "lineCount": 196,
         "theoremCount": 10,
         "definitionCount": 1,
-        "mathlib_version": "4.26.0"
+        "mathlib_version": "4.26.0",
+        "additionalFiles": ["Proofs/TriangularReciprocalAlternatingOQ03.lean"]
     },
     "overview": {
         "historicalContext": "The alternating harmonic series ∑(-1)^{n+1}/n = log(2) was first published by Mercator (1668) and is a special case of the Mercator series for log(1+x). Euler studied many variants involving products n(n+k) in the denominators. The generalization to arbitrary k reveals a beautiful structure: for even k the logarithmic terms cancel giving a rational answer, while for odd k the result involves log(2).",


### PR DESCRIPTION
## Fix

Adds `additionalFiles` field to `meta.json` for 3 proofs that import parent Lean files via simple 2-part `import Proofs.X` statements. This allows `find-targets.ts` to correctly resolve inherited axioms and eliminates the false-positive overcounts reported in the audit.

## Evidence

**Before**: `find-targets.ts` reported false axiom overcounts for 3 proofs because it only follows 3-part imports (`import Proofs.X.Y`) when resolving axiom inheritance, causing it to miss axioms already correctly counted in `meta.json`.

**After**: Each proof's `meta.json` now explicitly lists its parent file in `additionalFiles`, giving the script a deterministic path to the correct source of axioms.

| Proof | additionalFiles added |
|-------|----------------------|
| `triangular-reciprocals-oq-03-oq-02` | `Proofs/TriangularReciprocalAlternatingOQ03.lean` |
| `greens-theorem-oq-04` | `Proofs/GreensTheoremOQ03.lean` |
| `erdos-2-oq-01` | `Proofs/Erdos2Problem.lean` |

Closes #9050

---
Automated fix by lean-mechanic agent.