### PR TITLE
Audit cycle 26: fix persistent triangular-reciprocals axiom false positive

### DIFF
--- a/proofs/Proofs/TriangularReciprocalGeneralized.lean
+++ b/proofs/Proofs/TriangularReciprocalGeneralized.lean
@@ -14,15 +14,21 @@
   Proof: Partial fractions 1/(n(n+k)) = (1/k)(1/n - 1/(n+k)), then rearrange
   using the alternating harmonic series ∑(-1)^{n+1}/n = log(2).
 
-  Axioms: 0 (imports from parent OQ03; parent has 2 axioms for the Mercator series)
-  Extends: TriangularReciprocalAlternatingOQ03.lean
+  Axioms: 1 (alternating_harmonic_hasSum: Mercator series ∑(-1)^{n+1}/n = log 2)
+  Previously extended TriangularReciprocalAlternatingOQ03.lean; now self-contained.
 -/
-import Proofs.TriangularReciprocalAlternatingOQ03
+import Mathlib
 
 namespace AlternatingTriangularReciprocals.Generalized
 
 open Finset BigOperators Filter Topology Real
-open AlternatingTriangularReciprocals (alternating_harmonic_hasSum)
+
+/-- The alternating harmonic series: ∑_{n=1}^∞ (-1)^{n+1}/n = log(2).
+    Mercator (1668). Boundary convergence of the power series for log(1+x)
+    requires Abel's theorem, not yet formalized in Mathlib. -/
+axiom alternating_harmonic_hasSum :
+    HasSum (fun n : ℕ => if n = 0 then (0 : ℝ) else (-1 : ℝ) ^ (n + 1) / (n : ℝ))
+      (Real.log 2)
 
 -- ═══════════════════════════════════════════════════
 -- Part II: Alternating Harmonic Partial Sums

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3699,9 +3699,9 @@
       "result": "clean"
     },
     "erdos-2-oq-01": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-04-03T19:23:19Z",
+      "lastAudited": "2026-04-03T20:15:41Z",
       "result": "clean"
     },
     "erdos-20": {
@@ -9536,9 +9536,9 @@
       "result": "issues-fixed"
     },
     "greens-theorem-oq-04": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-03T19:22:02Z",
+      "lastAudited": "2026-04-03T20:14:55Z",
       "result": "clean"
     },
     "halting-problem": {
@@ -10852,10 +10852,10 @@
       "result": "clean"
     },
     "triangular-reciprocals-oq-03-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-03T19:22:02Z",
-      "result": "clean"
+      "lastAudited": "2026-04-03T20:13:08Z",
+      "result": "issues-fixed"
     },
     "twin-primes-special": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Fixes the persistent `axiom overcount` false positive for `triangular-reciprocals-oq-03-oq-02` (tracked in #9050)
- Makes `TriangularReciprocalGeneralized.lean` self-contained by declaring its axiom directly
- Also updates audit tracker to mark all 3 cycle-26 proofs as clean

## Root Cause

`TriangularReciprocalGeneralized.lean` imported `alternating_harmonic_hasSum` from `TriangularReciprocalAlternatingOQ03.lean` via a 2-part import (`import Proofs.X`). The `find-targets.ts` script doesn't follow 2-part imports, so it found 0 axioms in the primary file while meta.json correctly claimed 1.

This could NOT be fixed via `additionalFiles` (the approach used in PR #9052 for the other two proofs): OQ03 has 2 axioms, but the Generalized file only depends on 1 — it re-proves `shifted_alternating_hasSum` as a theorem locally. Adding OQ03 as `additionalFiles` would report 2 axioms, not 1.

## Fix

Make `TriangularReciprocalGeneralized.lean` self-contained:
- Remove `import Proofs.TriangularReciprocalAlternatingOQ03`
- Remove `open AlternatingTriangularReciprocals (alternating_harmonic_hasSum)`
- Declare `axiom alternating_harmonic_hasSum` directly in the file
- Fix header comment: `Axioms: 0` → `Axioms: 1`
- Use `import Mathlib` (same as OQ03 itself)

## Verification

After this fix, `npx tsx scripts/auditor/find-targets.ts --issues` shows 0 issues (with PR #9052 also merged) or 2 issues (only the OQ03 family, pending #9052).

## Test plan

- [x] `grep -c "^axiom " TriangularReciprocalGeneralized.lean` → 1
- [x] `find-targets.ts --issues` no longer shows triangular proof
- [x] Audit tracker updated with cycle 26 results

Closes part of #9050

🤖 Generated with [Claude Code](https://claude.com/claude-code)