### PR TITLE
Fix: triangular-reciprocals-oq-03-oq-02 axiomCount undercount (1→2)

### DIFF
--- a/src/data/proofs/triangular-reciprocals-oq-03-oq-02/meta.json
+++ b/src/data/proofs/triangular-reciprocals-oq-03-oq-02/meta.json
@@ -18,8 +18,8 @@
         ],
         "badge": "axiom",
         "sorries": 0,
-        "axiomCount": 1,
-        "assumptions": "1 axiom inherited from TriangularReciprocalAlternatingOQ03.lean: alternating_harmonic_hasSum (∑(-1)^{n+1}/n = log 2, the Mercator series). Used in proofs at lines 77 and 168 to establish the generalized series formula. 0 sorries.",
+        "axiomCount": 2,
+        "assumptions": "2 axioms inherited from TriangularReciprocalAlternatingOQ03.lean: (1) alternating_harmonic_hasSum (∑(-1)^{n+1}/n = log 2, the Mercator series) — used directly at lines 77 and 168; (2) shifted_alternating_hasSum (∑(-1)^{n+1}/(n+1) = 1-log 2) — declared in the imported parent module. Generalized.lean proves its own parametric version as a theorem but both axioms are in scope via the import. 0 sorries.",
         "dateAdded": "2026-03-29",
         "mathlibDependencies": [
             {


### PR DESCRIPTION
## Fix

Update `axiomCount` from 1 to 2 for `triangular-reciprocals-oq-03-oq-02`.

## Evidence

**Before**: `axiomCount: 1` — only counted `alternating_harmonic_hasSum`

**After**: `axiomCount: 2` — counts both axioms from the imported parent module

`TriangularReciprocalGeneralized.lean` imports `TriangularReciprocalAlternatingOQ03.lean`, which declares two axioms:
1. `alternating_harmonic_hasSum` — the Mercator series `∑(-1)^{n+1}/n = log 2`
2. `shifted_alternating_hasSum` — the shifted series `∑(-1)^{n+1}/(n+1) = 1-log 2`

Both axioms are in scope via the import. The Generalized file proves a parametric version of `shifted_alternating_hasSum` as a theorem (not relying on the axiom directly), but both axioms are part of the compiled environment.

The `assumptions` field is also updated to distinguish the two axioms.

This resolves a persistent audit flag (detected 4× on 2026-04-03).

---
Automated fix by lean-mechanic agent.