### PR TITLE
feat: Glaisher bijection formalization (Partition Theorem OQ-04)

### DIFF
--- a/proofs/Proofs/PartitionTheoremOQ04.lean
+++ b/proofs/Proofs/PartitionTheoremOQ04.lean
@@ -1,0 +1,254 @@
+import Mathlib.Combinatorics.Enumerative.Partition.Basic
+import Mathlib.NumberTheory.Padics.PadicVal.Basic
+import Mathlib.Tactic
+
+/-!
+# Glaisher Bijection as a Computable Function
+
+This file formalizes the **Glaisher bijection** between partitions into distinct parts and
+partitions into odd parts, giving a constructive proof of Euler's Partition Theorem.
+
+## The Bijection
+
+**Forward map (Distinct → Odd):**
+For each distinct part k, write k = 2^a × b where b is odd (2-adic valuation).
+Replace k with 2^a copies of the odd part b.
+
+**Backward map (Odd → Distinct):**
+For each distinct value b appearing m times, write m in binary:
+m = Σᵢ εᵢ 2ⁱ. Replace m copies of b with distinct parts {2ⁱ × b | εᵢ = 1}.
+
+## Example
+
+Distinct {6, 5, 3} of 14:
+- 6 = 2¹ × 3 → {3, 3}
+- 5 = 2⁰ × 5 → {5}
+- 3 = 2⁰ × 3 → {3}
+Result: odd {5, 3, 3, 3}
+
+## Main Results
+
+- `glaisherFwdPart_sum`: forward step preserves weight
+- `glaisherFwd_sum`: forward map preserves total weight
+- `glaisherBwdStep_sum`: backward step preserves weight
+- `glaisherBwdStep_pow_two`: backward of 2^a copies of b = singleton {2^a * b}
+- `glaisherFwdPart_parts_odd`: forward produces only odd parts
+-/
+
+namespace GlaisherBijection
+
+open Nat
+
+/-! ## Forward Map: Distinct → Odd -/
+
+/-- Forward step: map distinct part k to its odd parts.
+    k = 2^a × b (b odd) → 2^a copies of b. -/
+def glaisherFwdPart (k : ℕ) : Multiset ℕ :=
+  Multiset.replicate (2 ^ padicValNat 2 k) (k / 2 ^ padicValNat 2 k)
+
+/-- Glaisher forward map: apply glaisherFwdPart to each element. -/
+def glaisherFwd (s : Multiset ℕ) : Multiset ℕ := s.bind glaisherFwdPart
+
+/-! ## Backward Map: Odd → Distinct -/
+
+/-- Backward step: odd b appearing m times → distinct parts via binary expansion of m.
+    If m is odd: include b; recurse on m/2 doubling b.
+    If m is even: skip; recurse on m/2 doubling b. -/
+def glaisherBwdStep (b m : ℕ) : Multiset ℕ :=
+  match m with
+  | 0 => 0
+  | n + 1 =>
+    (if (n + 1) % 2 = 1 then ({b} : Multiset ℕ) else 0) +
+    glaisherBwdStep (2 * b) ((n + 1) / 2)
+termination_by m
+
+/-- Backward map: for each distinct value b in s, apply glaisherBwdStep. -/
+def glaisherBwd (s : Multiset ℕ) : Multiset ℕ :=
+  s.toFinset.val.bind (fun b => glaisherBwdStep b (s.count b))
+
+/-! ## Helper Lemmas for glaisherBwdStep
+
+    Note: glaisherBwdStep uses well-founded recursion (since it recurses on m/2, not m-1).
+    In Lean 4, well-founded definitions are not definitionally transparent, so we need
+    explicit lemmas to unfold them. These are obviously true by definition. -/
+
+/-- Base case: glaisherBwdStep b 0 = 0 -/
+@[simp] lemma glaisherBwdStep_zero (b : ℕ) : glaisherBwdStep b 0 = 0 := by
+  simp [glaisherBwdStep]
+
+/-- Reduction lemma: explicit equation for glaisherBwdStep on nonzero input. -/
+private lemma glaisherBwdStep_eq (b : ℕ) {m : ℕ} (hm : m ≠ 0) :
+    glaisherBwdStep b m =
+    (if m % 2 = 1 then ({b} : Multiset ℕ) else 0) +
+    glaisherBwdStep (2 * b) (m / 2) := by
+  cases m with
+  | zero => exact absurd rfl hm
+  | succ n => simp [glaisherBwdStep]
+
+/-! ## Sum Preservation -/
+
+/-- Key factorization: 2^a × (k / 2^a) = k when k ≠ 0 (a = padicValNat 2 k). -/
+private lemma padic_factorization {k : ℕ} :
+    2 ^ padicValNat 2 k * (k / 2 ^ padicValNat 2 k) = k :=
+  Nat.mul_div_cancel' pow_padicValNat_dvd
+
+/-- The forward step preserves weight. -/
+theorem glaisherFwdPart_sum {k : ℕ} (hk : k ≠ 0) :
+    (glaisherFwdPart k).sum = k := by
+  simp only [glaisherFwdPart, Multiset.sum_replicate, smul_eq_mul]
+  exact padic_factorization
+
+/-- The forward map preserves total weight. -/
+theorem glaisherFwd_sum {s : Multiset ℕ} (hs : ∀ k ∈ s, k ≠ 0) :
+    (glaisherFwd s).sum = s.sum := by
+  simp only [glaisherFwd, Multiset.sum_bind]
+  -- Goal: (s.map (fun k => (glaisherFwdPart k).sum)).sum = s.sum
+  congr 1
+  -- Subgoal: s.map (fun k => (glaisherFwdPart k).sum) = s
+  have h_map : s.map (fun k => (glaisherFwdPart k).sum) = s.map (fun k => k) :=
+    Multiset.map_congr rfl (fun k hk => glaisherFwdPart_sum (hs k hk))
+  simp [h_map]
+
+/-- The backward step preserves weight: (glaisherBwdStep b m).sum = m * b. -/
+theorem glaisherBwdStep_sum (b m : ℕ) :
+    (glaisherBwdStep b m).sum = m * b := by
+  induction m using Nat.strong_induction_on generalizing b with
+  | _ m ih =>
+  match m with
+  | 0 => simp
+  | m + 1 =>
+    rw [glaisherBwdStep_eq b (Nat.succ_ne_zero m)]
+    by_cases h_odd : (m + 1) % 2 = 1
+    · simp only [h_odd, ↓reduceIte, Multiset.sum_add, Multiset.sum_singleton]
+      rw [ih ((m + 1) / 2) (Nat.div_lt_self (Nat.succ_pos m) (by norm_num)) (2 * b)]
+      have hdiv : m + 1 = 2 * ((m + 1) / 2) + 1 := by omega
+      nlinarith
+    · simp only [h_odd, ↓reduceIte, zero_add]
+      rw [ih ((m + 1) / 2) (Nat.div_lt_self (Nat.succ_pos m) (by norm_num)) (2 * b)]
+      have hdiv : m + 1 = 2 * ((m + 1) / 2) := by omega
+      nlinarith
+
+/-! ## Odd Part Property -/
+
+/-- Ground fact: padicValNat 2 2 = 1 (the 2-adic valuation of 2 is 1). -/
+private lemma padicValNat_two_two : padicValNat 2 2 = 1 := by native_decide
+
+/-- padicValNat 2 (2^n) = n for all n. -/
+private lemma padicValNat_two_pow (n : ℕ) : padicValNat 2 (2 ^ n) = n := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    rw [pow_succ, padicValNat.mul (pow_ne_zero n two_ne_zero) two_ne_zero, ih,
+        padicValNat_two_two]
+
+/-- The odd part of k (k / 2^(padicValNat 2 k)) is not divisible by 2, for k ≠ 0.
+
+    Proof via multiplicativity of padicValNat: if 2 ∣ (k/2^a), then
+    padicValNat 2 (k/2^a) ≥ 1, but by multiplicativity padicValNat 2 k =
+    padicValNat 2 (2^a) + padicValNat 2 (k/2^a) = a + (≥1) > a = padicValNat 2 k. -/
+private lemma oddPart_odd {k : ℕ} (hk : k ≠ 0) : ¬ 2 ∣ (k / 2 ^ padicValNat 2 k) := by
+  set a := padicValNat 2 k with ha_def
+  set m := k / 2 ^ a with hm_def
+  have hm_ne : m ≠ 0 := by
+    intro heq
+    -- padic_factorization : 2^a * m = k (after set substitution, explicit annotation needed)
+    have hdec : 2 ^ a * m = k := padic_factorization
+    rw [heq, Nat.mul_zero] at hdec
+    exact hk hdec.symm
+  -- Show padicValNat 2 m = 0 via multiplicativity
+  have h_padic_m : padicValNat 2 m = 0 := by
+    have hdec : 2 ^ a * m = k := padic_factorization  -- 2^a * m = k
+    have h_split : a + padicValNat 2 m = a := by
+      calc a + padicValNat 2 m
+          = padicValNat 2 (2 ^ a) + padicValNat 2 m := by rw [padicValNat_two_pow]
+        _ = padicValNat 2 (2 ^ a * m) := (padicValNat.mul (pow_ne_zero a two_ne_zero) hm_ne).symm
+        _ = padicValNat 2 k := by rw [hdec]
+        _ = a := rfl
+    omega
+  -- From padicValNat 2 m = 0: derive contradiction if 2 ∣ m
+  intro h_dvd
+  obtain ⟨m', hm'⟩ := h_dvd
+  have hm'_ne : m' ≠ 0 := by omega
+  -- If m = 2 * m', then padicValNat 2 m ≥ 1
+  have h_padic_pos : padicValNat 2 m ≥ 1 := by
+    rw [hm', padicValNat.mul two_ne_zero hm'_ne, padicValNat_two_two]
+    omega
+  omega
+
+/-- Every element of glaisherFwdPart k is odd. -/
+theorem glaisherFwdPart_parts_odd {k : ℕ} (hk : k ≠ 0) :
+    ∀ x ∈ glaisherFwdPart k, ¬ Even x := by
+  intro x hx
+  simp only [glaisherFwdPart, Multiset.mem_replicate] at hx
+  obtain ⟨_, rfl⟩ := hx
+  intro ⟨c, hc⟩
+  -- hc : k / 2^a = c + c; need to derive 2 ∣ (k / 2^a)
+  exact oddPart_odd hk ⟨c, by linarith⟩
+
+/-- The forward map produces only odd parts. -/
+theorem glaisherFwd_parts_odd {s : Multiset ℕ} (hs : ∀ k ∈ s, k ≠ 0) :
+    ∀ x ∈ glaisherFwd s, ¬ Even x := by
+  intro x hx
+  simp only [glaisherFwd, Multiset.mem_bind] at hx
+  obtain ⟨k, hk_in, hx_in⟩ := hx
+  exact glaisherFwdPart_parts_odd (hs k hk_in) x hx_in
+
+/-! ## Concrete Examples -/
+
+/-- Example: {6, 5, 3} (distinct, sums to 14) maps to {3, 3, 5, 3} (odd, sums to 14) -/
+example : glaisherFwd {6, 5, 3} = {3, 3, 5, 3} := by native_decide
+
+/-- Backward step: odd 3 appearing 3 times → {6, 3} (distinct parts of 9) -/
+example : glaisherBwdStep 3 3 = {6, 3} := by native_decide
+
+/-- Sum check: 3 copies of 3 → parts summing to 9 -/
+example : (glaisherBwdStep 3 3).sum = 9 := by native_decide
+
+/-! ## Key Inverse Lemma -/
+
+/-- Backward step on 2^a copies of b yields the singleton {2^a * b}.
+
+    This is the core inverse: the Glaisher map sends k = 2^a * b to 2^a copies of b,
+    and the backward step recovers k from those copies. -/
+theorem glaisherBwdStep_pow_two (a b : ℕ) :
+    glaisherBwdStep b (2 ^ a) = {2 ^ a * b} := by
+  induction a generalizing b with
+  | zero =>
+    simp only [pow_zero, one_mul]
+    rw [glaisherBwdStep_eq b one_ne_zero]
+    norm_num
+  | succ a ih =>
+    rw [pow_succ]
+    have h_ne : 2 ^ a * 2 ≠ 0 := by positivity
+    rw [glaisherBwdStep_eq b h_ne]
+    rw [if_neg (by omega : 2 ^ a * 2 % 2 ≠ 1)]
+    simp only [zero_add]
+    rw [Nat.mul_div_cancel _ (by norm_num : 0 < 2)]
+    rw [ih (2 * b)]
+    congr 1; ring
+
+/-! ## Bijectivity (Structured Sorrys) -/
+
+/-- Backward undoes forward for a single distinct part k.
+
+    Proof strategy: glaisherFwdPart k = replicate (2^a) b, so
+    glaisherBwd (replicate (2^a) b) = glaisherBwdStep b (2^a) = {2^a * b} = {k}. -/
+theorem glaisherBwd_glaisherFwdPart {k : ℕ} (hk : k ≠ 0) :
+    glaisherBwd (glaisherFwdPart k) = {k} := by
+  sorry
+
+/-- The maps are inverses on distinct positive multisets. -/
+theorem glaisherBwd_glaisherFwd {s : Multiset ℕ}
+    (hs_pos : ∀ k ∈ s, k ≠ 0) (hs_nodup : s.Nodup) :
+    glaisherBwd (glaisherFwd s) = s := by
+  sorry
+
+/-- **Constructive Euler Partition Theorem**: Glaisher gives an explicit bijection
+    between distinct-part and odd-part partitions of any n. -/
+theorem glaisher_bijection_exists (n : ℕ) :
+    ∃ (f : {p : Nat.Partition n // p ∈ Nat.Partition.distincts n} →
+           {p : Nat.Partition n // p ∈ Nat.Partition.odds n}),
+      Function.Bijective f := by
+  sorry
+
+end GlaisherBijection

--- a/proofs/Proofs/ShannonEntropyOQ01.lean
+++ b/proofs/Proofs/ShannonEntropyOQ01.lean
@@ -272,7 +272,9 @@ private lemma gaussianPDF_integral_eq_one (μ : ℝ) {σ : ℝ} (hσ : 0 < σ) :
 
 private lemma gaussianPDF_integrable (μ : ℝ) {σ : ℝ} (hσ : 0 < σ) :
     Integrable (gaussianPDF μ σ) := by
-  simp_rw [gaussianPDF_eq_gaussianPDFReal μ hσ]
+  have heq : gaussianPDF μ σ = ProbabilityTheory.gaussianPDFReal μ ⟨σ ^ 2, sq_nonneg σ⟩ :=
+    funext (gaussianPDF_eq_gaussianPDFReal μ hσ)
+  rw [heq]
   exact ProbabilityTheory.integrable_gaussianPDFReal μ _
 
 private lemma gaussianPDF_log (μ : ℝ) {σ : ℝ} (hσ : 0 < σ) (x : ℝ) :
@@ -284,13 +286,198 @@ private lemma gaussianPDF_log (μ : ℝ) {σ : ℝ} (hσ : 0 < σ) (x : ℝ) :
       Real.log_inv, Real.log_sqrt (by positivity), Real.log_exp]
   ring
 
+-- Helper: x * exp(-b*x^2) tends to 0 at +∞ (needed for IBP)
+private lemma mul_exp_tendsto_zero {b : ℝ} (hb : 0 < b) :
+    Filter.Tendsto (fun x : ℝ => x * Real.exp (-b * x ^ 2)) Filter.atTop (nhds 0) := by
+  -- Prove exp(-(b/2)*x^2) → 0 by showing -(b/2)*x^2 → -∞ elementarily
+  have hg : Filter.Tendsto (fun x : ℝ => Real.exp (-(b / 2) * x ^ 2)) Filter.atTop (nhds 0) := by
+    apply Real.tendsto_exp_atBot.comp
+    simp only [Filter.tendsto_atBot, Filter.eventually_atTop]
+    intro M
+    refine ⟨max 0 (Real.sqrt (max 0 (2 * (-M) / b))), fun x hx => ?_⟩
+    have hxr : Real.sqrt (max 0 (2 * (-M) / b)) ≤ x := le_trans (le_max_right 0 _) hx
+    have hc : (0 : ℝ) ≤ max 0 (2 * (-M) / b) := le_max_left 0 _
+    -- sqrt(c)^2 ≤ x^2 from sqrt(c) ≤ x
+    have hmm : Real.sqrt (max 0 (2 * (-M) / b)) * Real.sqrt (max 0 (2 * (-M) / b)) ≤ x * x :=
+      mul_le_mul hxr hxr (Real.sqrt_nonneg _) (le_trans (Real.sqrt_nonneg _) hxr)
+    -- max 0 (2*(-M)/b) = sqrt(c)^2 ≤ x^2
+    have hxsq : max 0 (2 * (-M) / b) ≤ x ^ 2 := by
+      nlinarith [Real.sq_sqrt hc, sq_nonneg x, sq_nonneg (Real.sqrt (max 0 (2 * (-M) / b)))]
+    -- Conclude -(b/2)*x^2 ≤ M
+    have hMx : 2 * (-M) / b ≤ x ^ 2 := le_trans (le_max_right 0 _) hxsq
+    have h2 : 2 * (-M) ≤ x ^ 2 * b := by
+      have := mul_le_mul_of_nonneg_right hMx hb.le
+      calc 2 * (-M) = 2 * (-M) / b * b := by field_simp [hb.ne']
+        _ ≤ x ^ 2 * b := this
+    nlinarith [mul_comm (x ^ 2) b]
+  -- Squeeze: 0 ≤ x*exp(-bx²) ≤ exp(-(b/2)x²) for large x
+  apply tendsto_of_tendsto_of_tendsto_of_le_of_le' tendsto_const_nhds hg
+  · filter_upwards [Filter.eventually_ge_atTop (0 : ℝ)] with x hx
+    exact mul_nonneg hx (Real.exp_nonneg _)
+  · filter_upwards [Filter.eventually_ge_atTop (max 0 (2 / b))] with x hx
+    have hx0 : 0 ≤ x := le_trans (le_max_left 0 (2/b)) hx
+    have hxb : 2 / b ≤ x := le_trans (le_max_right 0 (2/b)) hx
+    have h_bound : x ≤ b / 2 * x ^ 2 := by
+      have hbx : 1 ≤ b / 2 * x := by
+        have h2 : 2 ≤ b * x := by
+          calc 2 = b * (2 / b) := by field_simp [hb.ne']
+            _ ≤ b * x := mul_le_mul_of_nonneg_left hxb hb.le
+        linarith
+      nlinarith [mul_le_mul_of_nonneg_right hbx hx0]
+    have h_exp_le : b / 2 * x ^ 2 ≤ Real.exp (b / 2 * x ^ 2) := by
+      linarith [Real.add_one_le_exp (b / 2 * x ^ 2)]
+    calc x * Real.exp (-b * x ^ 2)
+        ≤ Real.exp (b / 2 * x ^ 2) * Real.exp (-b * x ^ 2) :=
+          mul_le_mul_of_nonneg_right (le_trans h_bound h_exp_le) (Real.exp_nonneg _)
+      _ = Real.exp (b / 2 * x ^ 2 + (-b * x ^ 2)) := (Real.exp_add _ _).symm
+      _ = Real.exp (-(b / 2) * x ^ 2) := by congr 1; ring
+
 private lemma gaussian_second_moment (μ : ℝ) {σ : ℝ} (hσ : 0 < σ) :
     ∫ x : ℝ, (x - μ) ^ 2 * gaussianPDF μ σ x = σ ^ 2 := by
-  sorry  -- Submitted to Aristotle
+  have hb : (0 : ℝ) < 1 / (2 * σ ^ 2) := by positivity
+  set b := (1 : ℝ) / (2 * σ ^ 2) with hb_def
+  -- Step 1: Rewrite in terms of b
+  have h_rw : ∫ x : ℝ, (x - μ) ^ 2 * gaussianPDF μ σ x =
+      (Real.sqrt (2 * Real.pi * σ ^ 2))⁻¹ * ∫ x : ℝ, x ^ 2 * Real.exp (-b * x ^ 2) := by
+    conv_lhs =>
+      arg 2; ext x
+      rw [show (x - μ) ^ 2 * gaussianPDF μ σ x =
+          (Real.sqrt (2 * Real.pi * σ ^ 2))⁻¹ *
+          ((x - μ) ^ 2 * Real.exp (-b * (x - μ) ^ 2)) by
+        unfold gaussianPDF
+        rw [show -(x - μ) ^ 2 / (2 * σ ^ 2) = -b * (x - μ) ^ 2 from by rw [hb_def]; ring]
+        ring]
+    rw [integral_const_mul]
+    congr 1
+    -- Translation invariance: ∫ f(x-μ) = ∫ f(x)
+    have key : ∀ x : ℝ, (fun y => y ^ 2 * Real.exp (-b * y ^ 2)) (x + (-μ)) =
+        (x - μ) ^ 2 * Real.exp (-b * (x - μ) ^ 2) := fun x => by ring_nf
+    rw [show (fun x : ℝ => (x - μ) ^ 2 * Real.exp (-b * (x - μ) ^ 2)) =
+            fun x => (fun y => y ^ 2 * Real.exp (-b * y ^ 2)) (x + (-μ)) from funext (fun x => (key x).symm)]
+    exact integral_add_right_eq_self (fun y => y ^ 2 * Real.exp (-b * y ^ 2)) (-μ)
+  -- Step 2: Compute ∫ x^2 * exp(-b*x^2) using IBP
+  -- G(x) = -x/(2b) * exp(-b*x^2) is the antiderivative of x^2*exp(-b*x^2) - (1/(2b))*exp(-b*x^2)
+  let G : ℝ → ℝ := fun x => -x / (2 * b) * Real.exp (-b * x ^ 2)
+  have hG_val_zero : G 0 = 0 := by simp [G]
+  have hG_deriv : ∀ x : ℝ, HasDerivAt G
+      (x ^ 2 * Real.exp (-b * x ^ 2) - (1 / (2 * b)) * Real.exp (-b * x ^ 2)) x := by
+    intro x
+    have h1 : HasDerivAt (fun x : ℝ => -x / (2 * b)) (-1 / (2 * b)) x :=
+      (hasDerivAt_id x).neg.div_const (2 * b)
+    have h2 : HasDerivAt (fun x : ℝ => Real.exp (-b * x ^ 2))
+        ((-2 * b * x) * Real.exp (-b * x ^ 2)) x := by
+      have h := ((hasDerivAt_pow 2 x).const_mul (-b)).exp
+      simp only [Nat.cast_ofNat] at h
+      convert h using 1; ring
+    have h3 := h1.mul h2
+    convert h3 using 1; field_simp [hb.ne']; ring
+  have hG_int : MeasureTheory.IntegrableOn
+      (fun x => x ^ 2 * Real.exp (-b * x ^ 2) - (1 / (2 * b)) * Real.exp (-b * x ^ 2))
+      (Set.Ioi 0) := by
+    have hint1 : MeasureTheory.IntegrableOn (fun x : ℝ => x ^ 2 * Real.exp (-b * x ^ 2)) (Set.Ioi 0) := by
+      have h := integrableOn_rpow_mul_exp_neg_mul_sq hb (s := 2) (by norm_num : (-1 : ℝ) < 2)
+      simp_rw [rpow_two] at h; exact h
+    have hint2 : MeasureTheory.IntegrableOn (fun x : ℝ => (1 / (2 * b)) * Real.exp (-b * x ^ 2)) (Set.Ioi 0) :=
+      ((integrable_exp_neg_mul_sq hb).const_mul _).integrableOn
+    exact hint1.sub hint2
+  have hG_int_Iic : MeasureTheory.IntegrableOn
+      (fun x => x ^ 2 * Real.exp (-b * x ^ 2) - (1 / (2 * b)) * Real.exp (-b * x ^ 2))
+      (Set.Iic 0) := by
+    have hint1 : MeasureTheory.IntegrableOn (fun x : ℝ => x ^ 2 * Real.exp (-b * x ^ 2)) (Set.Iic 0) := by
+      have h := integrable_rpow_mul_exp_neg_mul_sq hb (s := 2) (by norm_num : (-1 : ℝ) < 2)
+      simp_rw [rpow_two] at h; exact h.integrableOn
+    have hint2 : MeasureTheory.IntegrableOn (fun x : ℝ => (1 / (2 * b)) * Real.exp (-b * x ^ 2)) (Set.Iic 0) :=
+      ((integrable_exp_neg_mul_sq hb).const_mul _).integrableOn
+    exact hint1.sub hint2
+  -- G(x) → 0 at +∞
+  have hG_top : Filter.Tendsto G Filter.atTop (nhds 0) := by
+    simp only [G]
+    -- Use: -(x * exp(-b*x^2)) / (2*b) → 0, which equals -x/(2*b)*exp(-b*x^2)
+    have h : Filter.Tendsto (fun x : ℝ => -(x * Real.exp (-b * x ^ 2)) / (2 * b))
+        Filter.atTop (nhds 0) := by
+      have := ((mul_exp_tendsto_zero hb).neg).div_const (2 * b)
+      simp only [neg_zero, zero_div] at this
+      exact this
+    exact h.congr (fun x => by ring)
+  -- G(x) → 0 at -∞: G(-y) = y/(2b)*exp(-b*y^2) → 0 as y → +∞
+  have hG_bot : Filter.Tendsto G Filter.atBot (nhds 0) := by
+    have step1 : Filter.Tendsto (fun y : ℝ => G (-y)) Filter.atTop (nhds 0) := by
+      simp only [G, neg_neg, neg_sq]
+      -- Goal: Tendsto (fun y => y/(2*b) * exp(-b*y^2)) atTop (nhds 0)
+      have h : Filter.Tendsto (fun x : ℝ => x * Real.exp (-b * x ^ 2) / (2 * b))
+          Filter.atTop (nhds 0) := by
+        have := (mul_exp_tendsto_zero hb).div_const (2 * b)
+        simp only [zero_div] at this
+        exact this
+      exact h.congr (fun x => by ring)
+    exact (step1.comp Filter.tendsto_neg_atBot_atTop).congr (fun x => by simp [G, neg_neg])
+  -- Apply FTC on Ioi 0: ∫_{Ioi 0} G' = G(+∞) - G(0) = 0 - 0 = 0
+  have h_Ioi : ∫ x in Set.Ioi (0 : ℝ),
+      (x ^ 2 * Real.exp (-b * x ^ 2) - (1 / (2 * b)) * Real.exp (-b * x ^ 2)) =
+      0 - G 0 := by
+    apply integral_Ioi_of_hasDerivAt_of_tendsto'
+    · intro x _; exact hG_deriv x
+    · exact hG_int
+    · exact hG_top
+  -- Apply FTC on Iic 0: ∫_{Iic 0} G' = G(0) - G(-∞) = 0 - 0 = 0
+  have h_Iic : ∫ x in Set.Iic (0 : ℝ),
+      (x ^ 2 * Real.exp (-b * x ^ 2) - (1 / (2 * b)) * Real.exp (-b * x ^ 2)) =
+      G 0 - 0 := by
+    apply integral_Iic_of_hasDerivAt_of_tendsto'
+    · intro x _; exact hG_deriv x
+    · exact hG_int_Iic
+    · exact hG_bot
+  -- Combine: ∫_ℝ G' = 0
+  have hG'_int : MeasureTheory.Integrable
+      (fun x : ℝ => x ^ 2 * Real.exp (-b * x ^ 2) - (1 / (2 * b)) * Real.exp (-b * x ^ 2)) := by
+    apply MeasureTheory.Integrable.sub
+    · have h := integrable_rpow_mul_exp_neg_mul_sq hb (s := 2) (by norm_num : (-1 : ℝ) < 2)
+      simp_rw [rpow_two] at h; exact h
+    · exact (integrable_exp_neg_mul_sq hb).const_mul _
+  have h_full_zero : ∫ x : ℝ, (x ^ 2 * Real.exp (-b * x ^ 2) - (1 / (2 * b)) * Real.exp (-b * x ^ 2)) = 0 := by
+    rw [← MeasureTheory.integral_add_compl (measurableSet_Ioi) hG'_int]
+    simp only [Set.compl_Ioi]
+    rw [h_Iic, h_Ioi, hG_val_zero]
+    ring
+  -- Extract the second moment integral
+  have h_key : ∫ x : ℝ, x ^ 2 * Real.exp (-b * x ^ 2) =
+      (1 / (2 * b)) * ∫ x : ℝ, Real.exp (-b * x ^ 2) := by
+    have hint1 : Integrable (fun x : ℝ => x ^ 2 * Real.exp (-b * x ^ 2)) := by
+      have h := integrable_rpow_mul_exp_neg_mul_sq hb (s := 2) (by norm_num : (-1 : ℝ) < 2)
+      simp_rw [rpow_two] at h; exact h
+    have hint2 : Integrable (fun x : ℝ => (1 / (2 * b)) * Real.exp (-b * x ^ 2)) :=
+      (integrable_exp_neg_mul_sq hb).const_mul _
+    -- Rewrite h_full_zero in place to avoid alpha-equivalence issues with Eq.trans
+    rw [MeasureTheory.integral_sub hint1 hint2] at h_full_zero
+    rw [MeasureTheory.integral_const_mul] at h_full_zero
+    linarith
+  -- Step 3: Apply integral_gaussian and simplify
+  -- After h_rw and h_key: goal is (√(2πσ²))⁻¹ * (1/(2b) * ∫ exp(-b*x²)) = σ²
+  rw [h_rw, h_key, integral_gaussian b]
+  -- Now: (√(2πσ²))⁻¹ * (1/(2b) * √(π/b)) = σ²
+  have h_2b : (1 : ℝ) / (2 * b) = σ ^ 2 := by rw [hb_def]; field_simp [hσ.ne']
+  have h_sqrt_pb : Real.sqrt (Real.pi / b) = Real.sqrt (2 * Real.pi * σ ^ 2) := by
+    congr 1; rw [hb_def]; field_simp
+  rw [h_2b, h_sqrt_pb]
+  -- Now: (√(2πσ²))⁻¹ * (σ² * √(2πσ²)) = σ²
+  have hsqrt_pos : (0 : ℝ) < Real.sqrt (2 * Real.pi * σ ^ 2) :=
+    Real.sqrt_pos.mpr (by positivity)
+  rw [mul_comm (σ ^ 2), ← mul_assoc, inv_mul_cancel₀ hsqrt_pos.ne', one_mul]
 
 private lemma gaussian_quad_integrable (μ : ℝ) {σ : ℝ} (hσ : 0 < σ) :
     Integrable (fun x : ℝ => (x - μ) ^ 2 * gaussianPDF μ σ x) := by
-  sorry  -- Submitted to Aristotle
+  have hb : (0 : ℝ) < 1 / (2 * σ ^ 2) := by positivity
+  have hcore : Integrable (fun x : ℝ => x ^ 2 * Real.exp (-(1 / (2 * σ ^ 2)) * x ^ 2)) := by
+    have h := integrable_rpow_mul_exp_neg_mul_sq hb (s := 2) (by norm_num : (-1 : ℝ) < 2)
+    simp_rw [rpow_two] at h; exact h
+  have h_eq : (fun x : ℝ => (x - μ) ^ 2 * gaussianPDF μ σ x) =
+      fun x => (Real.sqrt (2 * Real.pi * σ ^ 2))⁻¹ *
+               ((x - μ) ^ 2 * Real.exp (-(1 / (2 * σ ^ 2)) * (x - μ) ^ 2)) := by
+    funext x; unfold gaussianPDF
+    rw [show -(x - μ) ^ 2 / (2 * σ ^ 2) = -(1 / (2 * σ ^ 2)) * (x - μ) ^ 2 from by ring]
+    ring
+  rw [h_eq]
+  exact (hcore.comp_sub_right μ).const_mul _
 
 /-- Differential entropy of the Gaussian N(μ, σ²) is ½ ln(2πeσ²).
 

--- a/research/problems/partition-theorem-oq-04/knowledge.md
+++ b/research/problems/partition-theorem-oq-04/knowledge.md
@@ -1,21 +1,82 @@
-# Knowledge Base: partition-theorem-oq-04
+# partition-theorem-oq-04
+## Glaisher Bijection Formalization — IN PROGRESS (sorries: bijectivity)
 
-Insights accumulated during research on this problem.
-
----
-
-## Problem Understanding
-
-[Initial observations about the problem will be recorded here]
+**Status: IN PROGRESS** — Core theorems proved. Bijectivity round-trip left as structured sorries.
 
 ---
 
-## Insights
+## Summary
 
-[Insights from research attempts will be accumulated here]
+`PartitionTheoremOQ04.lean` (~255 lines) formalizes the Glaisher bijection as a computable function:
+- `glaisherFwdPart k`: k = 2^a × b (b odd) → 2^a copies of b
+- `glaisherBwdStep b m`: binary expansion of count m → distinct parts
+- All key properties proved; bijectivity (round-trip) has structured sorries
+
+**Proved theorems (0 sorries for these)**:
+- `glaisherFwdPart_sum`: forward step preserves weight
+- `glaisherFwd_sum`: forward map preserves total weight
+- `glaisherBwdStep_sum`: backward step sum = m * b
+- `glaisherBwdStep_pow_two`: glaisherBwdStep b (2^a) = {2^a * b} — core inverse
+- `glaisherFwdPart_parts_odd`: forward produces only odd parts
+- `glaisherFwd_parts_odd`: all elements of forward image are odd
+
+**Structured sorries (future work)**:
+- `glaisherBwd_glaisherFwdPart`: backward(forward(k)) = {k}
+- `glaisherBwd_glaisherFwd`: full round-trip on distinct multisets
+- `glaisher_bijection_exists`: packaging as Function.Bijective on Nat.Partition
+
+**PR**: #9063
 
 ---
 
-## Dead Ends
+## Session Log
 
-[Approaches known not to work will be documented here]
+### Session 2026-04-03 (Session 1)
+**Mode**: FRESH
+**Outcome**: progress
+
+**What Was Done**:
+1. Created `PartitionTheoremOQ04.lean` (~255 lines) from scratch
+2. Defined `glaisherFwdPart` and `glaisherFwd` using `padicValNat 2 k`
+3. Defined `glaisherBwdStep b m` using well-founded recursion on `m/2`
+4. Proved `glaisherFwdPart_sum`, `glaisherFwd_sum`, `glaisherBwdStep_sum`
+5. Proved `oddPart_odd` via `padicValNat` multiplicativity chain
+6. Proved `glaisherFwdPart_parts_odd`, `glaisherFwd_parts_odd`
+7. Proved `glaisherBwdStep_pow_two` by induction on `a`
+8. Added concrete examples via `native_decide`
+9. Build succeeded: 0 errors, 3 sorry warnings (bijectivity)
+
+**Key Lean Fixes**:
+1. `termination_by m` (not `termination_by _ m => m`) for two-arg `(b m : ℕ)` form
+2. Well-founded recursion opacity: `simp [glaisherBwdStep]` works via `cases m with | succ n => simp [...]`
+3. `padicValNat.prime_pow_self` unknown; proved `padicValNat_two_pow` by induction using `padicValNat.mul`
+4. `decide` fails for `padicValNat 2 2 = 1`; use `native_decide`
+5. After `set a := padicValNat 2 k`, need explicit type annotation `have hdec : 2^a * m = k := padic_factorization`
+6. `Multiset.map_congr rfl` returns `s.map f = s.map (fun k => k)`, not `= s`; need `simp`
+7. `Nat.strong_induction_on` (not `Nat.strong_rec_on`)
+8. `Even x` destructs to `x = c + c`; need `⟨c, by linarith⟩` to supply `2 ∣ x`
+
+**Files Created**:
+- `proofs/Proofs/PartitionTheoremOQ04.lean` (255 lines)
+
+**Next Steps**:
+1. Prove `glaisherBwd_glaisherFwdPart`:
+   - `glaisherFwdPart k = replicate (2^a) b`
+   - Need: `toFinset (replicate n b) = {b}` for n ≥ 1
+   - Need: `count b (replicate n b) = n`
+   - Then `glaisherBwdStep b (2^a) = {2^a * b} = {k}` via `glaisherBwdStep_pow_two`
+2. Prove `glaisherBwd_glaisherFwd`: induction on s (Nodup), using single-part case
+
+---
+
+## Key Mathematical Insights
+
+1. **Well-founded recursion opacity in Lean 4**: Functions recursing on `m/2` are not definitionally transparent. `simp [f]` on `f 0` works but on `f (n+1)` requires `cases` to expose the equation lemma.
+
+2. **padicValNat multiplicativity** (`padicValNat.mul`): Key for `oddPart_odd`. Chain: `padicValNat 2 k = padicValNat 2 (2^a * m) = a + padicValNat 2 m`. Since this equals `a`, we get `padicValNat 2 m = 0`, i.e., m is odd.
+
+3. **Backward step inverse**: `glaisherBwdStep b (2^a) = {2^a * b}` by induction on `a`:
+   - Base: `glaisherBwdStep b 1 = {b}` (1 is odd)
+   - Step: `2^(a+1)` is even; skip; recurse `glaisherBwdStep (2b) (2^a) = {2^a*(2b)} = {2^(a+1)*b}`
+
+4. **`native_decide` required for padicValNat**: Kernel can't evaluate `padicValNat` (uses `Nat.find`).

--- a/research/problems/shannon-entropy-oq-01/knowledge.md
+++ b/research/problems/shannon-entropy-oq-01/knowledge.md
@@ -1,30 +1,28 @@
 # shannon-entropy-oq-01
-## Differential Entropy Formalization — Near complete: 2 moment lemmas pending Aristotle
+## Differential Entropy Formalization — COMPLETE
 
-**Status: IN PROGRESS** — All top-level theorems proved. 2 helper sorries remain (Gaussian moment lemmas, queued for Aristotle when pipeline unblocks).
+**Status: COMPLETED** — All sorries eliminated. Build succeeds with 0 errors.
 
 ---
 
 ## Summary
 
-`ShannonEntropyOQ01.lean` (~400 lines) formalizes differential entropy for continuous distributions:
+`ShannonEntropyOQ01.lean` (~475 lines) formalizes differential entropy for continuous distributions:
 - `differentialEntropy f = -∫ x, f x * log (f x)`
 - KL divergence non-negativity (Gibbs inequality)
 - Translation invariance, scale equivariance
 - Gaussian maximizes entropy at fixed variance
-- Gaussian entropy formula: h(N(μ,σ²)) = ½log(2πeσ²)
+- Gaussian entropy formula: h(N(μ,σ²)) = ½log(2πeσ²) — **fully proved**
 
-**Proved (0 sorries in body)**:
+**All theorems proved (0 sorries)**:
 - `kl_divergence_continuous_nonneg`: D(f||g) ≥ 0 for probability densities
 - `gibbs_inequality_continuous`: h(f) ≤ -∫ f log g (Gibbs corollary)
 - `differentialEntropy_translation_invariant`: h(f(·-c)) = h(f)
 - `gaussian_max_entropy`: for densities with ∫x²f ≤ σ², h(f) ≤ ½log(2πeσ²)
-- `differentialEntropy_scale_equivariant`: h((1/|a|)·f(·/a)) = h(f) + log|a| [Session 2]
-- `gaussianDifferentialEntropy`: h(gaussianPDF μ σ) = ½log(2πeσ²) modulo moment lemmas [Session 2]
-
-**Pending (Aristotle)**:
-- `gaussian_second_moment`: ∫ (x-μ)² · φ(x) dx = σ² — submitted to Aristotle
-- `gaussian_quad_integrable`: Integrable (fun x => (x-μ)² · φ(x)) — submitted to Aristotle
+- `differentialEntropy_scale_equivariant`: h((1/|a|)·f(·/a)) = h(f) + log|a|
+- `gaussianDifferentialEntropy`: h(gaussianPDF μ σ) = ½log(2πeσ²)
+- `gaussian_second_moment`: ∫ (x-μ)² · φ(x) dx = σ² — proved via IBP
+- `gaussian_quad_integrable`: Integrable (fun x => (x-μ)² · φ(x)) — proved
 
 **PR**: #8914
 
@@ -114,6 +112,36 @@
 
 **Files Modified**:
 - `proofs/Proofs/ShannonEntropyOQ01.lean` (line 274: gaussianPDF_integrable fix)
+
+### Session 2026-04-03 (Session 4) — COMPLETION
+**Mode**: REVISIT
+**Outcome**: completed
+
+**What Was Done**:
+1. Proved `gaussian_second_moment`: ∫(x-μ)²·φ(x)dx = σ² entirely in Lean without Aristotle
+   - Used IBP with antiderivative G(x) = -x/(2b)·exp(-b·x²)
+   - G'(x) = x²·exp(-bx²) - (1/2b)·exp(-bx²)
+   - `integral_Ioi_of_hasDerivAt_of_tendsto'` + `integral_Iic_of_hasDerivAt_of_tendsto'` give ∫G'=0
+   - ∫x²·exp(-bx²) = (1/2b)·∫exp(-bx²) = (1/2b)·√(π/b)
+   - Translation invariance + algebra gives σ²
+2. Proved `gaussian_quad_integrable` via `integrable_rpow_mul_exp_neg_mul_sq hb (s:=2)` + `comp_sub_right` + `const_mul`
+3. Fixed `gaussianPDF_integrable`: `simp_rw` can't rewrite inside `Integrable(f)` (function, not pointwise). Fixed with `funext + rw`.
+4. Fixed `mul_exp_tendsto_zero`: avoided `tendsto_pow_atTop` (unknown), `div_le_iff` (unknown), `pow_le_pow_left` (unknown). Used elementary squeeze via `mul_le_mul` + sqrt bounds.
+5. Fixed alpha-equivalence issue: `(integral_sub h1 h2).symm.trans h_full_zero` fails (Eq.trans sees `∫(a:ℝ)` vs `∫(x:ℝ)`). Fix: `rw [integral_sub h1 h2] at h_full_zero` mutates the hypothesis instead.
+6. Zero sorries. Build succeeds.
+
+**Key Lean Findings**:
+- `pow_le_pow_left` unavailable by that name — use `mul_le_mul` + `Real.sq_sqrt` + `nlinarith`
+- `div_le_iff` may fail in `rw` — compute manually: `calc 2*(-M) = 2*(-M)/b * b := by field_simp [hb.ne']; _ ≤ x^2*b := mul_le_mul_of_nonneg_right hMx hb.le`
+- `squeeze_zero` after `apply`: goals may be type-mismatched — use `tendsto_of_tendsto_of_tendsto_of_le_of_le'` directly
+- Alpha-equiv: `Eq.trans` distinguishes `∫(a:ℝ), f a` from `∫(x:ℝ), f x` syntactically; `rw [...] at h` is the workaround
+- `simp only [Filter.tendsto_atBot, Filter.eventually_atTop]` more robust than `rw [Filter.tendsto_atBot]`
+- `linarith [...]` in term mode is invalid — must use `by linarith [...]`
+
+**Files Modified**:
+- `proofs/Proofs/ShannonEntropyOQ01.lean` (~330 → 475 lines; 0 sorries)
+- `src/data/research/problems/shannon-entropy-oq-01.json`
+- `research/problems/shannon-entropy-oq-01/knowledge.md`
 
 ---
 

--- a/src/data/research/problems/partition-theorem-oq-04.json
+++ b/src/data/research/problems/partition-theorem-oq-04.json
@@ -1,7 +1,7 @@
 {
   "slug": "partition-theorem-oq-04",
-  "title": "[Problem Title]",
-  "phase": "OBSERVE",
+  "title": "Glaisher Bijection as Computable Function",
+  "phase": "ACT",
   "status": "active",
   "tier": "C",
   "path": "fast",
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ACT",
     "since": "2026-04-03T05:03:40-07:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "iteration": 2,
+    "focus": "Proving bijectivity round-trip. Core theorems all proved.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "Prove glaisherBwd_glaisherFwdPart using Multiset.toFinset and count lemmas",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,11 +29,34 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": [],
+    "progressSummary": "PROGRESS: 6 theorems proved (sum preservation, odd-parts, core inverse). 3 bijectivity sorries remain.",
+    "builtItems": [
+      "glaisherFwdPart_sum: forward step preserves weight (PartitionTheoremOQ04.lean:96)",
+      "glaisherFwd_sum: forward map preserves total weight (PartitionTheoremOQ04.lean:102)",
+      "glaisherBwdStep_sum: backward step sum = m*b (PartitionTheoremOQ04.lean:113)",
+      "glaisherBwdStep_pow_two: core inverse glaisherBwdStep b (2^a) = {2^a*b} (PartitionTheoremOQ04.lean:214)",
+      "glaisherFwdPart_parts_odd: forward produces only odd parts (PartitionTheoremOQ04.lean:180)",
+      "glaisherFwd_parts_odd: all forward-image elements odd (PartitionTheoremOQ04.lean:190)",
+      "oddPart_odd: k/2^(padicValNat 2 k) is odd for k!=0 (PartitionTheoremOQ04.lean:150)",
+      "padicValNat_two_pow: padicValNat 2 (2^n) = n by induction (PartitionTheoremOQ04.lean:138)"
+    ],
+    "insights": [
+      "Well-founded recursion on m/2 is opaque: simp [f] fails; need cases m with | succ n => simp [f]",
+      "padicValNat.mul gives multiplicativity: key for proving odd part via contradiction",
+      "native_decide required for padicValNat 2 2 = 1 (Nat.find cannot be kernel-reduced)",
+      "After set a := padicValNat 2 k, explicit type annotation needed: have hdec : 2^a*m = k := ...",
+      "glaisherBwdStep_pow_two proof: even case recurse with 2*b, odd case emit b; induction on a",
+      "termination_by m (not termination_by _ m => m) for two-arg (b m) form with match m"
+    ],
+    "mathlibGaps": [
+      "Multiset.toFinset_replicate: toFinset (replicate n b) = {b} for n>=1 (needed for bijectivity)",
+      "Multiset.count_replicate: count b (replicate n b) = n (check if in Mathlib)"
+    ],
+    "nextSteps": [
+      "Prove glaisherBwd_glaisherFwdPart: use toFinset_replicate + count_replicate + glaisherBwdStep_pow_two",
+      "Prove glaisherBwd_glaisherFwd: induction on s with Nodup, using single-part case",
+      "Consider Aristotle for the bijectivity round-trip sorries (HARD, known math)"
+    ],
     "markdown": "# Knowledge Base: partition-theorem-oq-04\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [

--- a/src/data/research/problems/shannon-entropy-oq-01.json
+++ b/src/data/research/problems/shannon-entropy-oq-01.json
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "COMPLETED",
     "since": "2026-03-30T17:32:58.852Z",
     "iteration": 2,
-    "focus": "Proved gaussian_max_entropy and Gibbs inequality. 2 sorries remain.",
+    "focus": "COMPLETE: All sorries eliminated. Build succeeds with 0 errors.",
     "blockers": [],
     "nextAction": "Prove differentialEntropy_scale_equivariant and gaussianDifferentialEntropy.",
     "attemptCounts": {
@@ -29,45 +29,52 @@
     }
   },
   "knowledge": {
-    "progressSummary": "NEAR-COMPLETE: 2 top-level sorries replaced with proofs; 2 moment lemmas pending Aristotle",
+    "progressSummary": "COMPLETE: All sorries eliminated. gaussian_second_moment and gaussian_quad_integrable proved using IBP via antiderivative G(x)=-x/(2b)*exp(-b*x^2) and integrable_rpow_mul_exp_neg_mul_sq.",
     "builtItems": [
       "ShannonEntropyOQ01.lean: differentialEntropy (def, line 43)",
       "ShannonEntropyOQ01.lean: klDivergenceCts (def, line 47)",
-      "ShannonEntropyOQ01.lean: kl_term_bound_cts (lemma, line 59) — proved",
-      "ShannonEntropyOQ01.lean: kl_divergence_continuous_nonneg (theorem, line 90) — proved",
-      "ShannonEntropyOQ01.lean: gibbs_inequality_continuous (theorem, line 117) — proved",
-      "ShannonEntropyOQ01.lean: differentialEntropy_translation_invariant (theorem, line 167) — proved",
+      "ShannonEntropyOQ01.lean: kl_term_bound_cts (lemma, line 59) \u2014 proved",
+      "ShannonEntropyOQ01.lean: kl_divergence_continuous_nonneg (theorem, line 90) \u2014 proved",
+      "ShannonEntropyOQ01.lean: gibbs_inequality_continuous (theorem, line 117) \u2014 proved",
+      "ShannonEntropyOQ01.lean: differentialEntropy_translation_invariant (theorem, line 167) \u2014 proved",
       "ShannonEntropyOQ01.lean: gaussianPDF (def, line 210)",
-      "ShannonEntropyOQ01.lean: gaussian_max_entropy (theorem, line 239) — proved",
+      "ShannonEntropyOQ01.lean: gaussian_max_entropy (theorem, line 239) \u2014 proved",
       "differentialEntropy_scale_equivariant proved in ShannonEntropyOQ01.lean via integral_comp_div",
       "gaussianPDF_eq_gaussianPDFReal helper lemma (bridges to Mathlib gaussianPDFReal)",
       "gaussianPDF_integral_eq_one proved via ProbabilityTheory.integral_gaussianPDFReal_eq_one",
       "gaussianPDF_integrable proved via ProbabilityTheory.integrable_gaussianPDFReal",
       "gaussianPDF_log proved - expands log density into linear form",
-      "gaussianDifferentialEntropy proved modulo gaussian_second_moment + gaussian_quad_integrable"
+      "gaussianDifferentialEntropy proved modulo gaussian_second_moment + gaussian_quad_integrable",
+      "gaussian_second_moment proved: \u222b(x-\u03bc)\u00b2*gaussianPDF = \u03c3\u00b2 via IBP + integral_gaussian",
+      "gaussian_quad_integrable proved: via integrable_rpow_mul_exp_neg_mul_sq + comp_sub_right + const_mul",
+      "mul_exp_tendsto_zero proved: x*exp(-b*x\u00b2)\u21920 via elementary squeeze (no tendsto_pow_atTop needed)",
+      "gaussianDifferentialEntropy proved: h(N(\u03bc,\u03c3\u00b2)) = \u00bdln(2\u03c0e\u03c3\u00b2) \u2014 complete with 0 sorries"
     ],
     "insights": [
-      "gaussian_max_entropy follows from Gibbs inequality + log expansion: log(gaussianPDF) = -½log(2πσ²) - x²/(2σ²), then integrate and use variance bound",
-      "Gibbs inequality h(f) ≤ -∫f log g requires ∫g = 1 AND integrability of gaussianPDF",
-      "gaussianPDF 0 σ normalization: congr 1; congr 1; ring to equate -(x-0)²/(2σ²) with -(1/(2σ²))*x², since ring handles field division in Lean 4",
-      "integrability of gaussianPDF 0 σ follows from integrable_exp_neg_mul_sq with b = 1/(2σ²)",
-      "∫x, A - ∫x, B in Lean 4 parses as ∫x, (A - ∫x, B) — always use explicit parentheses (∫x, A) - (∫x, B)",
-      "differentialEntropy_scale_equivariant requires ∫f=1 hypothesis (without it the identity is false)",
-      "gaussianDifferentialEntropy requires Gaussian second moment: ∫x, x² * gaussianPDF 0 σ x = σ²",
-      "integral_comp_div is the key for scale equivariance: ∫f(x/a)dx = |a|*∫f, simp [smul_eq_mul] needed to convert • to *",
+      "gaussian_max_entropy follows from Gibbs inequality + log expansion: log(gaussianPDF) = -\u00bdlog(2\u03c0\u03c3\u00b2) - x\u00b2/(2\u03c3\u00b2), then integrate and use variance bound",
+      "Gibbs inequality h(f) \u2264 -\u222bf log g requires \u222bg = 1 AND integrability of gaussianPDF",
+      "gaussianPDF 0 \u03c3 normalization: congr 1; congr 1; ring to equate -(x-0)\u00b2/(2\u03c3\u00b2) with -(1/(2\u03c3\u00b2))*x\u00b2, since ring handles field division in Lean 4",
+      "integrability of gaussianPDF 0 \u03c3 follows from integrable_exp_neg_mul_sq with b = 1/(2\u03c3\u00b2)",
+      "\u222bx, A - \u222bx, B in Lean 4 parses as \u222bx, (A - \u222bx, B) \u2014 always use explicit parentheses (\u222bx, A) - (\u222bx, B)",
+      "differentialEntropy_scale_equivariant requires \u222bf=1 hypothesis (without it the identity is false)",
+      "gaussianDifferentialEntropy requires Gaussian second moment: \u222bx, x\u00b2 * gaussianPDF 0 \u03c3 x = \u03c3\u00b2",
+      "integral_comp_div is the key for scale equivariance: \u222bf(x/a)dx = |a|*\u222bf, simp [smul_eq_mul] needed to convert \u2022 to *",
       "Integrable.comp_div from Mathlib.MeasureTheory.Measure.Haar.NormedSpace handles integrability under scaling",
-      "gaussianPDFReal in ProbabilityTheory namespace uses NNReal variance ⟨σ²,sq_nonneg σ⟩ - bridge via NNReal.coe_mk",
-      "gaussianDifferentialEntropy proof architecture: expand log → split integral → normalization + second moment → algebra"
+      "gaussianPDFReal in ProbabilityTheory namespace uses NNReal variance \u27e8\u03c3\u00b2,sq_nonneg \u03c3\u27e9 - bridge via NNReal.coe_mk",
+      "gaussianDifferentialEntropy proof architecture: expand log \u2192 split integral \u2192 normalization + second moment \u2192 algebra",
+      "IBP via antiderivative G(x)=-x/(2b)*exp(-b*x^2): G'(x)=x\u00b2exp(-bx\u00b2)-(1/2b)exp(-bx^2), FTC gives \u222bG'=0 over \u211d \u2192 \u222bx\u00b2exp = (1/2b)\u222bexp",
+      "Alpha-equiv issue in Eq.trans: use rw [integral_sub hint1 hint2] at h_full_zero to mutate hypothesis instead of .trans chain",
+      "pow_le_pow_left unavailable by that name in Lean4; use mul_le_mul + sq conversions instead",
+      "div_le_iff/le_div_iff may be unavailable; use field_simp + mul_le_mul_of_nonneg_right instead",
+      "tendsto_of_tendsto_of_tendsto_of_le_of_le (non-prime) expects Pi-order \u2264; use prime version for Filter.Eventually",
+      "gaussianPDF_integrable: simp_rw cannot rewrite under point-free Integrable f; use funext + rw instead",
+      "squeeze_zero may be unreliable; tendsto_of_tendsto_of_tendsto_of_le_of_le' is the robust alternative"
     ],
     "mathlibGaps": [
-      "Gaussian second moment: ∫x, x² * exp(-b*x²) dx = √π / (2*b^(3/2)) — exists in Mathlib but API unclear",
-      "differentialEntropy_scale_equivariant: needs measure-theoretic substitution/rescaling lemma"
+      "pow_le_pow_left has been renamed or moved \u2014 use mul_le_mul + sq rewrites",
+      "div_le_iff pattern may not match in rw; compute manually with field_simp + mul_le_mul_of_nonneg_right"
     ],
-    "nextSteps": [
-      "Aristotle: prove gaussian_second_moment via variance_fun_id_gaussianReal",
-      "Aristotle: prove gaussian_quad_integrable via polynomial * Gaussian integrability",
-      "After Aristotle: zero sorries remain in main proof, update status to completed"
-    ]
+    "nextSteps": []
   },
   "tags": [
     "seeker-selected"


### PR DESCRIPTION
## Summary

Formalizes the **Glaisher bijection** between distinct-part and odd-part partitions as a computable function in Lean 4. This provides constructive infrastructure for Euler's Partition Theorem (Wiedijk #45).

### Key Results (all proved)

- **`glaisherFwdPart_sum`**: forward step `k = 2^a·b → 2^a copies of b` preserves weight
- **`glaisherFwd_sum`**: full forward map preserves total weight
- **`glaisherBwdStep_sum`**: backward step `(b,m) → binary expansion` preserves weight: `sum = m·b`
- **`glaisherBwdStep_pow_two`**: core inverse lemma — `glaisherBwdStep b (2^a) = {2^a · b}`
- **`glaisherFwdPart_parts_odd`** / **`glaisherFwd_parts_odd`**: forward map produces only odd parts
- Concrete examples verified via `native_decide`: `glaisherFwd {6,5,3} = {3,3,5,3}`

### Structured Sorries (future work)

- `glaisherBwd_glaisherFwdPart`: single-part round-trip
- `glaisherBwd_glaisherFwd`: full bijection inverse
- `glaisher_bijection_exists`: packaging as `Function.Bijective`

### Proof Highlights

- Used `padicValNat` multiplicativity chain for the odd-part property
- `glaisherBwdStep` uses well-founded recursion on `m/2`; equation lemmas bridge opacity
- `Nat.strong_induction_on` for the backward sum preservation
- `glaisherBwdStep_pow_two` proved by induction on `a`

## Test plan

- [x] `docker-build.sh Proofs.PartitionTheoremOQ04` succeeds (3058 jobs, only 3 sorry warnings)
- [x] Native decide examples verify concrete bijection output

🤖 Generated with [Claude Code](https://claude.com/claude-code)