### PR TITLE
fix: correct sorries count to 1 for erdos-433

### DIFF
--- a/src/data/proofs/erdos-433/meta.json
+++ b/src/data/proofs/erdos-433/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 433,
     "erdosUrl": "https://erdosproblems.com/433",
     "erdosProblemStatus": "solved",
@@ -53,7 +53,7 @@
     ],
     "axiomCount": 4,
     "lineCount": 314,
-    "assumptions": "4 axioms, 0 sorries. Axioms: (1) sylvester_frobenius: G({a,b}) = ab - a - b for coprime a, b (Sylvester-Frobenius formula); (2) dixmier_lower_bound: g(k,n) ≥ ⌊(n-2)/(k-1)⌋·(n-k+1) - 1; (3) dixmier_upper_bound: g(k,n) ≤ (⌊(n-1)/(k-1)⌋ - 1)·n - 1 (Dixmier 1990 bounds); (4) erdos_433_solved: the asymptotic formula g(k,n) ~ n²/(k-1) holds."
+    "assumptions": "4 axioms, 1 sorry. Axioms: (1) sylvester_frobenius: G({a,b}) = ab - a - b for coprime a, b (Sylvester-Frobenius formula); (2) dixmier_lower_bound: g(k,n) ≥ ⌊(n-2)/(k-1)⌋·(n-k+1) - 1; (3) dixmier_upper_bound: g(k,n) ≤ (⌊(n-1)/(k-1)⌋ - 1)·n - 1 (Dixmier 1990 bounds); (4) erdos_433_solved: the asymptotic formula g(k,n) ~ n²/(k-1) holds. Sorry: theorem g_two (line 203) — g(2,n) = n²-3n+1, follows from Sylvester-Frobenius on {n-1, n}."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #433**\n\nThis problem connects extremal combinatorics to the classical Frobenius number problem (also called the coin problem or money changing problem).\n\n**Key History:**\n- Sylvester-Frobenius (1884): G({a,b}) = ab - a - b for coprime a, b\n- Erdős-Graham (1972): First bounds g(k,n) < 2n²/k\n- Dixmier (1990): Proved exact asymptotic g(k,n) ~ n²/(k-1)\n\n**The Frobenius Problem:**\nGiven positive integers with gcd = 1, find the largest integer that cannot be represented as their non-negative linear combination. The \"Chicken McNugget\" problem is a famous example.",


### PR DESCRIPTION
## Fix

Corrects `sorries` count from 0 to 1 in `erdos-433/meta.json`. Updates `assumptions` text to document the sorry.

## Evidence

**Before**: `meta.sorries = 0`, but `theorem g_two` at line 203 of `Erdos433Problem.lean` uses `sorry` (Sylvester-Frobenius on {n-1, n}).

**After**: `meta.sorries = 1`, matching the actual Lean source.

The prior fix (#9052) corrected the assumptions text but did not update the numeric `sorries` field.

---
Automated fix by lean-mechanic agent.