### PR TITLE
fix: prove multinomial_triple + add Aristotle companion for multinomial_eq_prod_choose

### DIFF
--- a/proofs/Proofs/KummerTheoremOQ01.lean
+++ b/proofs/Proofs/KummerTheoremOQ01.lean
@@ -35,28 +35,64 @@ noncomputable def multinomial (ks : List ℕ) : ℕ :=
   (ks.sum).factorial / (ks.map Nat.factorial).prod
 
 /-- A multinomial coefficient factors as a product of binomial coefficients.
-    C(k₁+k₂, k₁) · C(k₁+k₂+k₃, k₁+k₂) · ... -/
+    C(k₁+k₂, k₁) · C(k₁+k₂+k₃, k₁+k₂) · ...
+    Note: the pair (acc, k) from scanl/zip gives C(acc+k, k), not C(acc, k).
+    For ks = [k₁, k₂, k₃], the tail pairs are (k₁, k₂) and (k₁+k₂, k₃),
+    giving C(k₁+k₂, k₂) · C(k₁+k₂+k₃, k₃) = C(k₁+k₂, k₁) · C(k₁+k₂+k₃, k₁+k₂). -/
 theorem multinomial_eq_prod_choose : ∀ (ks : List ℕ),
-    multinomial ks = (ks.scanl (· + ·) 0).zip ks |>.tail |>.map
-      (fun ⟨acc, k⟩ => Nat.choose acc k) |>.prod := by
+    multinomial ks =
+      (((ks.scanl (· + ·) (0 : ℕ)).zip ks).tail.map
+        (fun ⟨acc, k⟩ => Nat.choose (acc + k) k)).prod := by
   sorry
 
 /-- For two elements, the multinomial reduces to a binomial. -/
 theorem multinomial_pair (a b : ℕ) :
     multinomial [a, b] = Nat.choose (a + b) a := by
-  simp [multinomial, Nat.add_choose_eq]
+  have hpos : 0 < a.factorial * b.factorial :=
+    Nat.mul_pos (Nat.factorial_pos a) (Nat.factorial_pos b)
+  have h := Nat.choose_mul_factorial_mul_factorial (Nat.le_add_right a b)
+  rw [show a + b - a = b from by omega] at h
+  -- h : (a+b).choose a * a! * b! = (a+b)!
+  simp only [multinomial, List.sum_cons, List.sum_nil, List.map_cons, List.map_nil,
+             List.prod_cons, List.prod_nil, mul_one]
+  rw [show a + (b + 0) = a + b from by omega]
+  -- Goal: (a+b)! / (a! * b!) = (a+b).choose a
+  have key : (a + b).choose a * (a.factorial * b.factorial) = (a + b).factorial :=
+    calc (a + b).choose a * (a.factorial * b.factorial)
+        = (a + b).choose a * a.factorial * b.factorial := by ring
+      _ = (a + b).factorial := h
+  rw [← key]
+  exact Nat.mul_div_cancel _ hpos
 
 /-- For three elements: C(a+b+c; a, b, c) = C(a+b, a) · C(a+b+c, a+b). -/
 theorem multinomial_triple (a b c : ℕ) :
     multinomial [a, b, c] = Nat.choose (a + b) a * Nat.choose (a + b + c) (a + b) := by
-  simp only [multinomial, List.sum_cons, List.map_cons, List.prod_cons]
+  simp only [multinomial, List.sum_cons, List.sum_nil, List.map_cons, List.map_nil,
+             List.prod_cons, List.prod_nil, mul_one]
   rw [show a + (b + (c + 0)) = a + b + c from by omega]
-  rw [show Nat.factorial a * (Nat.factorial b * (Nat.factorial c * 1)) =
-    Nat.factorial a * Nat.factorial b * Nat.factorial c from by ring]
-  -- (a+b+c)! / (a! · b! · c!) = ((a+b)! / (a! · b!)) · ((a+b+c)! / ((a+b)! · c!))
-  rw [Nat.choose_eq_factorial_div_factorial (Nat.le_add_right a b),
-      Nat.choose_eq_factorial_div_factorial (Nat.le_add_right (a + b) c)]
-  sorry
+  -- Goal: (a+b+c)! / (a! * (b! * c!)) = C(a+b,a) * C(a+b+c,a+b)
+  -- Strategy: both sides * (a! * (b! * c!)) = (a+b+c)! via choose_mul_factorial
+  have hpos : 0 < a.factorial * (b.factorial * c.factorial) :=
+    Nat.mul_pos (Nat.factorial_pos a) (Nat.mul_pos (Nat.factorial_pos b) (Nat.factorial_pos c))
+  -- Use C(n,k) * k! * (n-k)! = n! twice
+  have h1 := Nat.choose_mul_factorial_mul_factorial (Nat.le_add_right a b)
+  have h2 := Nat.choose_mul_factorial_mul_factorial (Nat.le_add_right (a + b) c)
+  rw [show a + b - a = b from by omega] at h1
+  rw [show a + b + c - (a + b) = c from by omega] at h2
+  -- h1 : C(a+b,a) * a! * b! = (a+b)!
+  -- h2 : C(a+b+c,a+b) * (a+b)! * c! = (a+b+c)!
+  -- Key: RHS * denominator = (a+b+c)!
+  have key : Nat.choose (a + b) a * Nat.choose (a + b + c) (a + b) *
+      (a.factorial * (b.factorial * c.factorial)) = (a + b + c).factorial := by
+    calc Nat.choose (a + b) a * Nat.choose (a + b + c) (a + b) *
+            (a.factorial * (b.factorial * c.factorial))
+        = Nat.choose (a + b + c) (a + b) *
+            (Nat.choose (a + b) a * a.factorial * b.factorial) * c.factorial := by ring
+      _ = Nat.choose (a + b + c) (a + b) * (a + b).factorial * c.factorial := by rw [h1]
+      _ = (a + b + c).factorial := h2
+  -- Conclude: (a+b+c)! / denom = RHS  via (RHS * denom) / denom = RHS
+  rw [← key]
+  exact Nat.mul_div_cancel _ hpos
 
 /-- Kummer's theorem for multinomials (statement):
     The p-adic valuation of C(n; k₁,...,kₘ) equals the total number

--- a/proofs/Proofs/KummerTheoremOQ01Aristotle.lean
+++ b/proofs/Proofs/KummerTheoremOQ01Aristotle.lean
@@ -1,0 +1,184 @@
+/-
+  Aristotle targets for KummerTheoremOQ01 — multinomial coefficient decomposition.
+  See KummerTheoremOQ01.lean for the main formalization.
+
+  Primary target: `multinomial_eq_prod_choose` — the general binomial factorization
+  identity showing multinomial ks = product of C(partial_sum + k, k) over all k.
+
+  Proof strategy (backward list induction via List.reverseRecOn):
+
+  Step 1: `factorial_dvd`
+    (ks.map Nat.factorial).prod ∣ ks.sum.factorial
+    Induction: k! * prod ∣ k! * sum! ∣ (k+sum)!
+
+  Step 2: `multinomial_mul_factorial`
+    multinomial ks * prod_factorial = sum_factorial
+    Follows from Nat.div_mul_cancel + factorial_dvd.
+
+  Step 3: `multinomial_append_singleton`
+    multinomial (ks ++ [k]) = multinomial ks * C(sum(ks) + k, k)
+    Both sides * prod_factorial * k! = (sum+k)! by the key identity.
+
+  Step 4: `zip_scanl_append_singleton`
+    zip (scanl 0 (ks ++ [k])) (ks ++ [k]) = zip (scanl 0 ks) ks ++ [(ks.sum, k)]
+    The last pair is (ks.sum, k), giving factor C(ks.sum + k, k) in the product.
+    Proof: scanl_append_singleton + zip_append (with |scanl ks| = |ks ++ [k]| = |ks|+1).
+
+  Step 5: `rhs_append_singleton`
+    The RHS scanl/zip/tail/prod picks up factor C(ks.sum + k, k) on appending [k].
+
+  Step 6: `multinomial_eq_prod_choose`
+    By List.reverseRecOn: base trivial; step uses steps 3 + 5 + IH.
+
+  Key Mathlib lemmas:
+  - Nat.factorial_mul_factorial_dvd_factorial_add : i! * j! ∣ (i+j)!
+  - Nat.choose_mul_factorial_mul_factorial : C(n,k) * k! * (n-k)! = n!
+  - List.zip_append : zip (l₁++r₁) (l₂++r₂) = zip l₁ l₂ ++ zip r₁ r₂ (|l₁| = |l₂|)
+  - List.scanl_cons : scanl f b (a :: l) = [b] ++ scanl f (f b a) l
+  - List.length_scanl : (scanl f b l).length = l.length + 1
+-/
+import Mathlib
+
+namespace KummerMultinomialAristotle
+
+open Nat List
+
+/-- The multinomial coefficient n! / (k₁! · k₂! · ... · kₘ!) -/
+noncomputable def multinomial (ks : List ℕ) : ℕ :=
+  (ks.sum).factorial / (ks.map Nat.factorial).prod
+
+/-- Product of factorials is always positive. -/
+theorem prod_factorial_pos (ks : List ℕ) : 0 < (ks.map Nat.factorial).prod := by
+  apply List.prod_pos
+  intro x hx
+  simp only [List.mem_map] at hx
+  obtain ⟨n, -, rfl⟩ := hx
+  exact Nat.factorial_pos n
+
+/-- The product of factorials divides the factorial of the sum.
+    Induction: k! * prod(ks) ∣ k! * sum(ks)! ∣ (k + sum(ks))!. -/
+theorem factorial_dvd (ks : List ℕ) :
+    (ks.map Nat.factorial).prod ∣ ks.sum.factorial := by
+  induction ks with
+  | nil => simp
+  | cons k ks ih =>
+    simp only [List.map_cons, List.prod_cons, List.sum_cons]
+    exact (mul_dvd_mul_left k.factorial ih).trans
+      (Nat.factorial_mul_factorial_dvd_factorial_add k ks.sum)
+
+/-- The multinomial coefficient is an integer: multinomial ks * prod_factorial = sum_factorial. -/
+theorem multinomial_mul_factorial (ks : List ℕ) :
+    multinomial ks * (ks.map Nat.factorial).prod = ks.sum.factorial := by
+  simp only [multinomial]
+  exact Nat.div_mul_cancel (factorial_dvd ks)
+
+/-- Appending a singleton multiplies the multinomial by C(sum + k, k).
+    Both sides times the denominator equal (sum + k)!. -/
+theorem multinomial_append_singleton (ks : List ℕ) (k : ℕ) :
+    multinomial (ks ++ [k]) = multinomial ks * Nat.choose (ks.sum + k) k := by
+  have hprod : 0 < (ks.map Nat.factorial).prod * k.factorial :=
+    Nat.mul_pos (prod_factorial_pos ks) (Nat.factorial_pos k)
+  apply Nat.eq_of_mul_eq_mul_right hprod
+  -- LHS * denom: use multinomial_mul_factorial on ks ++ [k]
+  have lhs_eq : multinomial (ks ++ [k]) * ((ks.map Nat.factorial).prod * k.factorial) =
+      (ks.sum + k).factorial := by
+    have h := multinomial_mul_factorial (ks ++ [k])
+    simp only [List.sum_append, List.sum_singleton, List.map_append, List.map_singleton,
+               List.prod_append, List.prod_singleton, Nat.add_zero] at h
+    linarith
+  -- RHS * denom: C(sum+k,k) * k! * sum! = (sum+k)!  via choose_mul_factorial_mul_factorial
+  have rhs_eq : multinomial ks * Nat.choose (ks.sum + k) k *
+      ((ks.map Nat.factorial).prod * k.factorial) = (ks.sum + k).factorial := by
+    have hchoose := Nat.choose_mul_factorial_mul_factorial (Nat.le_add_left k ks.sum)
+    simp only [Nat.add_sub_cancel] at hchoose
+    -- hchoose : (ks.sum + k).choose k * k! * ks.sum! = (ks.sum + k)!
+    calc multinomial ks * Nat.choose (ks.sum + k) k *
+            ((ks.map Nat.factorial).prod * k.factorial)
+        = Nat.choose (ks.sum + k) k * k.factorial *
+            (multinomial ks * (ks.map Nat.factorial).prod) := by ring
+      _ = Nat.choose (ks.sum + k) k * k.factorial * ks.sum.factorial := by
+            rw [multinomial_mul_factorial]
+      _ = (ks.sum + k).factorial := hchoose
+  linarith
+
+/-- foldl (·+·) b ks = b + ks.sum.
+    Used to identify the accumulator at the end of scanl. -/
+theorem foldl_add_eq (b : ℕ) (ks : List ℕ) : List.foldl (· + ·) b ks = b + ks.sum := by
+  induction ks generalizing b with
+  | nil => simp
+  | cons k ks ih =>
+    simp only [List.foldl_cons, List.sum_cons, ih]
+    omega
+
+/-- The general scanl append singleton lemma (with arbitrary initial accumulator).
+    scanl (·+·) acc (ks ++ [k]) = scanl (·+·) acc ks ++ [acc + ks.sum + k] -/
+theorem scanl_add_append (acc : ℕ) (ks : List ℕ) (k : ℕ) :
+    (ks ++ [k]).scanl (· + ·) acc =
+    ks.scanl (· + ·) acc ++ [acc + ks.sum + k] := by
+  induction ks generalizing acc with
+  | nil => simp [List.scanl_cons]
+  | cons h t ih =>
+    simp only [List.cons_append, List.scanl_cons, List.singleton_append, List.sum_cons]
+    rw [ih (acc + h)]
+    simp only [List.append_assoc]
+    congr 2
+    omega
+
+/-- The zip of (scanl 0 (ks ++ [k])) with (ks ++ [k]) decomposes as:
+    zip (scanl 0 ks) ks ++ [(ks.sum, k)].
+    The last pair has ks.sum as first component (= last element of scanl 0 ks),
+    and k as second; this gives the binomial factor C(ks.sum + k, k) in the product.
+
+    Proof:
+    1. scanl 0 (ks ++ [k]) = scanl 0 ks ++ [ks.sum + k]  (from scanl_add_append with acc=0)
+       But only first |ks ++ [k]| = |ks|+1 elements of this zip are used.
+    2. zip (scanl 0 ks ++ [ks.sum + k]) (ks ++ [k])
+       = zip (scanl 0 ks) (ks ++ [k])          (via zip_append with |scanl ks| = |ks ++ [k]|,
+                                                  the extra [ks.sum+k] element gets dropped)
+       = zip (dropLast(scanl 0 ks) ++ [ks.sum]) (ks ++ [k])
+       = zip (dropLast(scanl 0 ks)) ks ++ [(ks.sum, k)]  (via zip_append with equal lengths)
+       = zip (scanl 0 ks) ks ++ [(ks.sum, k)]   (zip truncates to shorter list)
+-/
+theorem zip_scanl_append_singleton (ks : List ℕ) (k : ℕ) :
+    ((ks ++ [k]).scanl (· + ·) (0 : ℕ)).zip (ks ++ [k]) =
+    (ks.scanl (· + ·) 0).zip ks ++ [(ks.sum, k)] := by
+  sorry
+
+/-- The RHS scanl/zip/tail/prod expression picks up factor C(ks.sum + k, k) on appending [k].
+    For ks = [], both sides equal 1.
+    For ks ≠ [], the tail distributes and the extra pair contributes C(ks.sum + k, k). -/
+theorem rhs_append_singleton (ks : List ℕ) (k : ℕ) :
+    (((ks ++ [k]).scanl (· + ·) (0 : ℕ)).zip (ks ++ [k])).tail.map
+        (fun ⟨acc, j⟩ => Nat.choose (acc + j) j) |>.prod =
+    ((ks.scanl (· + ·) (0 : ℕ)).zip ks).tail.map
+        (fun ⟨acc, j⟩ => Nat.choose (acc + j) j) |>.prod *
+    Nat.choose (ks.sum + k) k := by
+  rw [zip_scanl_append_singleton]
+  cases ks with
+  | nil =>
+    -- zip [] [] = [], so ([] ++ [(0, k)]).tail = [(0, k)].tail = []
+    simp
+  | cons h t =>
+    -- zip (scanl 0 (h :: t)) (h :: t) starts with (0, h), non-empty
+    -- tail distributes: (l ++ [x]).tail = l.tail ++ [x] when l ≠ []
+    have hne : (List.scanl (· + ·) 0 (h :: t)).zip (h :: t) ≠ [] := by
+      simp [List.scanl_cons]
+    rw [List.tail_append_of_ne_nil _ _ hne]
+    simp only [List.map_append, List.prod_append]
+    ring
+
+/-- Main theorem: multinomial ks = product of C(partial_sum + kᵢ, kᵢ) over all kᵢ in ks.
+    Proved by backward induction (List.reverseRecOn) using:
+    - multinomial_append_singleton: LHS step
+    - rhs_append_singleton: RHS step -/
+theorem multinomial_eq_prod_choose : ∀ (ks : List ℕ),
+    multinomial ks =
+      (((ks.scanl (· + ·) (0 : ℕ)).zip ks).tail.map
+        (fun ⟨acc, k⟩ => Nat.choose (acc + k) k)).prod := by
+  intro ks
+  induction ks using List.reverseRecOn with
+  | nil => simp [multinomial]
+  | append_singleton ks k ih =>
+    rw [multinomial_append_singleton, ih, rhs_append_singleton]
+
+end KummerMultinomialAristotle

--- a/src/data/proofs/kummer-theorem-oq-01/meta.json
+++ b/src/data/proofs/kummer-theorem-oq-01/meta.json
@@ -13,10 +13,10 @@
     ],
     "proofRepoPath": "Proofs/KummerTheoremOQ01.lean",
     "badge": "formalized",
-    "sorries": 2,
+    "sorries": 1,
     "axiomCount": 0,
-    "assumptions": "0 axioms. 2 sorries: multinomial_eq_prod_choose (general decomposition), multinomial_triple (a+b+c case). Proved: multinomial_pair (reduces to choose).",
-    "lineCount": 68,
+    "assumptions": "0 axioms. 1 sorry: multinomial_eq_prod_choose (general list induction). Proved: multinomial_pair (binomial case), multinomial_triple (trinomial case via choose_mul_factorial_mul_factorial).",
+    "lineCount": 103,
     "theoremCount": 4,
     "definitionCount": 1,
     "mathlib_version": "4.26.0",
@@ -32,7 +32,7 @@
   "overview": {
     "historicalContext": "Ernst Kummer proved in 1852 that the highest power of a prime p dividing the binomial coefficient C(n, k) equals the number of carries when adding k and n-k in base p. This elegant theorem connects combinatorics (counting subsets) with the arithmetic of positional numeral systems. The result was rediscovered and generalized throughout the 20th century. The multinomial extension is a natural question: the multinomial coefficient C(n; k₁, k₂, ..., kₘ) counts the number of ways to partition n objects into groups of sizes k₁, ..., kₘ (with n = k₁ + ... + kₘ). The key insight is that multinomial coefficients factor as products of binomials via a telescoping decomposition: C(n; k₁,...,kₘ) = C(k₁+k₂, k₁) · C(k₁+k₂+k₃, k₁+k₂) · ... · C(n, n-kₘ). Applying Kummer's theorem to each factor and summing gives the total carry count when adding k₁, k₂, ..., kₘ successively in base p.",
     "problemStatement": "Can Kummer's theorem — $v_p\\binom{n}{k} = c(k, n-k; p)$ where $c$ counts base-$p$ carries — be extended to multinomial coefficients? That is, does $v_p\\binom{n}{k_1,\\ldots,k_m} = $ total carries when adding $k_1,\\ldots,k_m$ in base $p$? Answer: yes, via iterated binomial decomposition.",
-    "proofStrategy": "The file defines the multinomial coefficient as n! / (k₁! · ... · kₘ!) using `List.sum` and `List.prod`. The key identity `multinomial_eq_prod_choose` expresses this as a product of binomials via `List.scanl` accumulation. `multinomial_pair` is fully proved (reduces to `Nat.add_choose_eq`). `multinomial_triple` is partially proved: the factorial rearrangement is complete but the final division step has a sorry. `kummer_multinomial_statement` is a placeholder stub (returns `True`).",
+    "proofStrategy": "The file defines the multinomial coefficient as n! / (k₁! · ... · kₘ!) using `List.sum` and `List.prod`. The key identity `multinomial_eq_prod_choose` expresses this as a product of binomials via `List.scanl` accumulation (1 sorry remains for the general list induction). `multinomial_pair` is fully proved via `Nat.choose_mul_factorial_mul_factorial`. `multinomial_triple` is fully proved: uses `Nat.choose_mul_factorial_mul_factorial` twice to establish C(a+b,a)*C(a+b+c,a+b)*(a!*(b!*c!)) = (a+b+c)!, then concludes via `Nat.mul_div_cancel`. `kummer_multinomial_statement` is a placeholder stub (returns `True`).",
     "keyInsights": [
       "The iterated decomposition $\\binom{n}{k_1,\\ldots,k_m} = \\prod_{i=1}^{m} \\binom{k_1+\\cdots+k_i}{k_1+\\cdots+k_{i-1}}$ is the algebraic heart of the extension. Each factor is an ordinary binomial to which Kummer's theorem applies directly.",
       "Kummer's theorem for each binomial factor gives $v_p\\binom{k_1+\\cdots+k_i}{k_1+\\cdots+k_{i-1}} = c(k_i, k_1+\\cdots+k_{i-1}; p)$ — the carries when adding the $i$-th part to the running sum. Summing over all $i$ gives the total carries for adding all parts.",


### PR DESCRIPTION
## Summary

- Fixes 3 bugs in KummerTheoremOQ01.lean (type annotation, scanl lambda capture, incorrect proof)
- Fully proves `multinomial_triple` (trinomial coefficient decomposition) using `Nat.choose_mul_factorial_mul_factorial`
- Adds Aristotle companion with fully proved helper lemmas:
  - `factorial_dvd`: product of factorials divides factorial of sum
  - `multinomial_mul_factorial`: the integrality identity
  - `multinomial_append_singleton`: backward induction step for LHS
  - `scanl_add_append`: general scanl singleton append
  - `rhs_append_singleton`: backward induction step for RHS
  - `multinomial_eq_prod_choose`: complete proof structure (1 sorry: `zip_scanl_append_singleton`)

One sorry remains in the companion: `zip_scanl_append_singleton` — the zip identity needed for the backward induction step. Submitted to Aristotle for overnight proof search.

## Test plan

- [ ] `multinomial_triple` compiles in KummerTheoremOQ01.lean (sorry count 2→1)
- [ ] Aristotle companion builds with 1 sorry
- [ ] After Aristotle: integrate solution to close final sorry