### PR TITLE
Fix: erdos-433 sorries count corrected (0→1)

### DIFF
--- a/src/data/proofs/erdos-433/meta.json
+++ b/src/data/proofs/erdos-433/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 0,
+    "sorries": 1,
     "erdosNumber": 433,
     "erdosUrl": "https://erdosproblems.com/433",
     "erdosProblemStatus": "solved",
@@ -53,7 +53,7 @@
     ],
     "axiomCount": 4,
     "lineCount": 314,
-    "assumptions": "4 axioms, 0 sorries. Axioms: (1) sylvester_frobenius: G({a,b}) = ab - a - b for coprime a, b (Sylvester-Frobenius formula); (2) dixmier_lower_bound: g(k,n) ≥ ⌊(n-2)/(k-1)⌋·(n-k+1) - 1; (3) dixmier_upper_bound: g(k,n) ≤ (⌊(n-1)/(k-1)⌋ - 1)·n - 1 (Dixmier 1990 bounds); (4) erdos_433_solved: the asymptotic formula g(k,n) ~ n²/(k-1) holds."
+    "assumptions": "4 axioms, 1 sorry. Axioms: (1) sylvester_frobenius: G({a,b}) = ab - a - b for coprime a, b (Sylvester-Frobenius formula); (2) dixmier_lower_bound: g(k,n) ≥ ⌊(n-2)/(k-1)⌋·(n-k+1) - 1; (3) dixmier_upper_bound: g(k,n) ≤ (⌊(n-1)/(k-1)⌋ - 1)·n - 1 (Dixmier 1990 bounds); (4) erdos_433_solved: the asymptotic formula g(k,n) ~ n²/(k-1) holds. Sorry: g_two theorem (k=2 exact value n²-3n+1) awaits proof."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #433**\n\nThis problem connects extremal combinatorics to the classical Frobenius number problem (also called the coin problem or money changing problem).\n\n**Key History:**\n- Sylvester-Frobenius (1884): G({a,b}) = ab - a - b for coprime a, b\n- Erdős-Graham (1972): First bounds g(k,n) < 2n²/k\n- Dixmier (1990): Proved exact asymptotic g(k,n) ~ n²/(k-1)\n\n**The Frobenius Problem:**\nGiven positive integers with gcd = 1, find the largest integer that cannot be represented as their non-negative linear combination. The \"Chicken McNugget\" problem is a famous example.",


### PR DESCRIPTION
## Fix

Restore `sorries: 1` for `erdos-433` to match the committed Lean source.

## Evidence

**Before**: `sorries: 0` (incorrect — set prematurely by #9052)

**After**: `sorries: 1` (matches committed `Erdos433Problem.lean` line 203)

PR #9052 updated `sorries` from 1 to 0 based on uncommitted researcher code in the working directory that had replaced the sorry with a proof attempt. That code was never committed to main, so the committed Lean file still has:
```lean
theorem g_two (n : ℕ) (hn : n ≥ 3) : g 2 n = n^2 - 3*n + 1 := by
  sorry -- Follows from Sylvester-Frobenius applied to {n-1, n}
```

The `assumptions` field is also updated to accurately state "4 axioms, 1 sorry" and describe the specific sorry.

---
Automated fix by lean-mechanic agent.