### PR TITLE
Fix: triangular-reciprocals-oq-03-oq-02 axiomCount after Lean refactor

### DIFF
--- a/src/data/proofs/triangular-reciprocals-oq-03-oq-02/meta.json
+++ b/src/data/proofs/triangular-reciprocals-oq-03-oq-02/meta.json
@@ -18,8 +18,8 @@
         ],
         "badge": "axiom",
         "sorries": 0,
-        "axiomCount": 2,
-        "assumptions": "2 axioms inherited from TriangularReciprocalAlternatingOQ03.lean: (1) alternating_harmonic_hasSum (∑(-1)^{n+1}/n = log 2, the Mercator series) — used directly at lines 77 and 168; (2) shifted_alternating_hasSum (∑(-1)^{n+1}/(n+1) = 1-log 2) — declared in the imported parent module. Generalized.lean proves its own parametric version as a theorem but both axioms are in scope via the import. 0 sorries.",
+        "axiomCount": 1,
+        "assumptions": "1 axiom: alternating_harmonic_hasSum (∑(-1)^{n+1}/n = log 2, the Mercator series). TriangularReciprocalGeneralized.lean is self-contained — it no longer imports TriangularReciprocalAlternatingOQ03.lean and declares its own axiom directly. 0 sorries.",
         "dateAdded": "2026-03-29",
         "mathlibDependencies": [
             {
@@ -44,7 +44,6 @@
         "theoremCount": 10,
         "definitionCount": 1,
         "mathlib_version": "4.26.0",
-        "additionalFiles": ["Proofs/TriangularReciprocalAlternatingOQ03.lean"]
     },
     "overview": {
         "historicalContext": "The alternating harmonic series ∑(-1)^{n+1}/n = log(2) was first published by Mercator (1668) and is a special case of the Mercator series for log(1+x). Euler studied many variants involving products n(n+k) in the denominators. The generalization to arbitrary k reveals a beautiful structure: for even k the logarithmic terms cancel giving a rational answer, while for odd k the result involves log(2).",


### PR DESCRIPTION
## Fix

Correct `axiomCount` and remove stale `additionalFiles` after `TriangularReciprocalGeneralized.lean` was refactored to be self-contained.

## Evidence

**Before**:
- `axiomCount: 2`
- `additionalFiles: ["Proofs/TriangularReciprocalAlternatingOQ03.lean"]`
- Audit detected 3 actual axioms (1 direct + 2 from OQ03 via additionalFiles)

**After**:
- `axiomCount: 1`
- `additionalFiles` removed
- Audit detects 1 actual axiom — matches

## Root Cause

`TriangularReciprocalGeneralized.lean` was previously refactored from importing `TriangularReciprocalAlternatingOQ03.lean` to being self-contained with its own direct `axiom alternating_harmonic_hasSum` declaration. The Lean file header even documents this: "Previously extended TriangularReciprocalAlternatingOQ03.lean; now self-contained."

However, PR #9056 (audit cycle 26 fix) updated `axiomCount` from 1→2 and added `additionalFiles` to include OQ03, based on the old file structure. This was incorrect for the current self-contained version.

---
Automated fix by lean-mechanic agent.