### PR TITLE
fix: correct meta.json for erdos-1012-oq-03 (sorry count 3→2, line count 743→991)

### DIFF
--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -13,16 +13,16 @@
       "tournaments"
     ],
     "badge": "formalized",
-    "sorries": 3,
+    "sorries": 2,
     "axiomCount": 0,
-    "lineCount": 743,
-    "assumptions": "0 axioms. 3 sorries: (1) ghouila_houri (full proof needs longest-path argument ~200 lines), (2) sc_tournament_has_cycle (extract simple cycle from SC walk), (3) tournament_cycle_extendable (S⁺/S⁻ partition argument). Moon-Moser architecture complete modulo these 2 infrastructure lemmas. Rédei fully proved by induction.",
+    "lineCount": 991,
+    "assumptions": "0 axioms. 2 sorries: (1) ghouila_houri (full proof needs longest-path argument ~200 lines), (2) directed_hamiltonian_threshold (arc-count threshold result). Moon-Moser theorem (sc_tournament_has_cycle + tournament_cycle_extendable + grow_cycle_to_hamiltonian) is now fully proved. Rédei fully proved by induction.",
     "dateAdded": "2026-03-30"
   },
   "overview": {
     "historicalContext": "The theory of directed Hamiltonian cycles developed in the 1930s–1970s as a directed counterpart to the celebrated undirected results of Dirac (1952) and others. Rédei (1934) proved that every tournament (complete directed graph) has a Hamiltonian path — a result with a clean inductive proof via vertex insertion. Moon and Moser (1963) strengthened this: strongly connected tournaments always have Hamiltonian cycles, not just paths. Ghouila-Houri (1960) gave the directed analogue of Dirac's theorem: a strongly connected digraph in which every vertex has both in-degree and out-degree $\\geq n/2$ has a Hamiltonian cycle. Meyniel (1973) gave a weaker sufficient condition (sum of degrees $\\geq 2n-1$ for non-adjacent pairs), matching the degree-sum form of Ore's undirected theorem. Erdős Problem 1012 (undirected) asks about long cycle thresholds; this OQ explores the directed analogues.",
     "problemStatement": "For directed graphs: (1) What minimum degree condition on a strongly connected digraph guarantees a Hamiltonian cycle? (Ghouila-Houri, 1960: $\\delta^+(v) \\geq n/2$ and $\\delta^-(v) \\geq n/2$ for all $v$.) (2) Do all strongly connected tournaments have Hamiltonian cycles? (Moon-Moser, 1963: yes.) (3) Do all tournaments have Hamiltonian paths? (Rédei, 1934: yes.) (4) What arc-count threshold forces Hamiltonicity in a strongly connected digraph?",
-    "proofStrategy": "The file builds up from scratch: Digraph structure, degree definitions, Tournament and StronglyConnected predicates, Hamiltonian cycle/path definitions. Rédei's theorem is fully proved by induction: `tournament_path_insert` extends a Hamiltonian path by inserting a new vertex into an existing path (always possible in a tournament), and `tournament_full_path_list` builds the full path by induction; `list_path_to_hamiltonian` converts the list representation to the `Equiv`-based definition. Moon-Moser's architecture is complete: cycle infrastructure (IsDirectedCycleList), non-insertable vertex dichotomy (if a cycle cannot be extended by inserting a vertex, the vertex's successors and predecessors have specific structure), and inductive growth to Hamiltonian — modulo 2 infrastructure sorries. Ghouila-Houri and the arc threshold remain as sorries.",
+    "proofStrategy": "The file builds up from scratch: Digraph structure, degree definitions, Tournament and StronglyConnected predicates, Hamiltonian cycle/path definitions. Rédei's theorem is fully proved by induction: `tournament_path_insert` extends a Hamiltonian path by inserting a new vertex into an existing path (always possible in a tournament), and `tournament_full_path_list` builds the full path by induction; `list_path_to_hamiltonian` converts the list representation to the `Equiv`-based definition. Moon-Moser's theorem is now fully proved: `sc_tournament_has_cycle` (extract a simple cycle from a Hamiltonian path + SC walk), `tournament_cycle_non_insertable` (S⁺/S⁻ partition argument), `tournament_cycle_extendable` (cycle extension using SC contradiction), and `grow_cycle_to_hamiltonian` (well-founded induction growing any cycle to Hamiltonian). Ghouila-Houri and the arc threshold remain as sorries.",
     "keyInsights": [
       "Rédei's 1934 theorem (every tournament has a Hamiltonian path) has a beautiful constructive proof: start with a single vertex, and inductively insert each new vertex $v$ into the existing Hamiltonian path. Since $v$ beats some vertices and loses to others in the tournament, there always exists a position to insert $v$ maintaining the directed path property. This is formalized via `tournament_path_insert` — a pure induction argument.",
       "The Moon-Moser theorem requires strong connectivity, unlike Rédei's path result. The proof strategy is a 'longest cycle' argument: take a longest directed cycle $C$ in the tournament; if $|C| < n$, take a vertex $v \\notin C$; partition $C$ into $S^+ = \\{\\text{successors of } v \\text{ in } C\\}$ and $S^- = \\{\\text{predecessors of } v \\text{ in } C\\}$; strong connectivity forces the cycle to be extendable, contradicting maximality.",
@@ -71,22 +71,22 @@
       "id": "part-iv-moon-moser",
       "title": "Part IV: Moon-Moser Theorem and Infrastructure",
       "startLine": 302,
-      "endLine": 694,
-      "summary": "Extensive infrastructure: IsDirectedCycleList (list-based cycle definition), non-insertable vertex dichotomy (if vertex v can't be inserted into cycle C, S⁺/S⁻ partition must close), list_cycle_to_hamiltonian (cycle list → Equiv), grow_cycle_to_hamiltonian (induction on deficit), moon_moser theorem (sorry: needs sc_tournament_has_cycle + tournament_cycle_extendable). Ends with Rédei's theorem: fully proved by induction."
+      "endLine": 941,
+      "summary": "Extensive infrastructure: IsDirectedCycleList (list-based cycle definition), sc_tournament_has_cycle (fully proved: Hamiltonian path + SC walk gives initial cycle), tournament_cycle_non_insertable (S⁺/S⁻ partition dichotomy when no insertion point exists), tournament_cycle_extendable (fully proved: SC contradiction forces cycle extension), list_cycle_to_hamiltonian (cycle list → Equiv), grow_cycle_to_hamiltonian (well-founded induction growing any cycle to Hamiltonian), moon_moser theorem (FULLY PROVED: no sorries). Ends with Rédei's theorem: fully proved by induction."
     },
     {
       "id": "part-v-threshold",
       "title": "Part V: Edge Threshold + Proof Roadmap",
-      "startLine": 695,
-      "endLine": 743,
-      "summary": "Defines arcCount. States directed_hamiltonian_threshold: (n-1)² < arcCount ∧ strongly connected → Hamiltonian cycle (sorry). Proof roadmap documenting remaining sorry targets for Moon-Moser (sc_tournament_has_cycle, tournament_cycle_extendable) and Ghouila-Houri."
+      "startLine": 943,
+      "endLine": 991,
+      "summary": "Defines arcCount. States directed_hamiltonian_threshold: (n-1)² < arcCount ∧ strongly connected → Hamiltonian cycle (sorry). Proof roadmap (now outdated: Moon-Moser is fully proved; remaining sorries are ghouila_houri and directed_hamiltonian_threshold). Closes with #check commands verifying all four main theorems."
     }
   ],
   "conclusion": {
-    "summary": "Rédei's theorem (every tournament has a Hamiltonian path) is fully proved by induction via the tournament insertion lemma. Moon-Moser's architecture is complete modulo two infrastructure sorries. Ghouila-Houri and the arc threshold remain stated but unproved. The 743-line file is the most substantial directed Hamiltonicity formalization attempted in this gallery.",
+    "summary": "Rédei's theorem (every tournament has a Hamiltonian path) is fully proved by induction via the tournament insertion lemma. Moon-Moser's theorem (every strongly connected tournament has a Hamiltonian cycle) is now fully proved: sc_tournament_has_cycle, tournament_cycle_extendable, and grow_cycle_to_hamiltonian are all complete with no sorries. Ghouila-Houri and the arc threshold remain stated but unproved (2 sorries). The 991-line file is the most substantial directed Hamiltonicity formalization in this gallery.",
     "implications": "Directed Hamiltonicity thresholds have applications beyond pure graph theory: tournament Hamiltonian paths correspond to linear extensions of partial orders, with applications to voting theory (ranking candidates) and scheduling. Rédei's theorem has a direct combinatorial interpretation: in any round-robin tournament, there exists a ranking of all players consistent with the match results (as a directed path). Moon-Moser's result shows that strongly connected tournaments (those where outcomes don't create a dominant clique) have circular Hamiltonian cycles — a stronger consistency property.",
     "openQuestions": [
-      "Can the three remaining sorries be eliminated? `sc_tournament_has_cycle` (extract a simple cycle from a closed walk in a strongly connected tournament) is a standard graph theory lemma needing ~20 lines; `tournament_cycle_extendable` (the S⁺/S⁻ partition argument) needs ~80 lines as noted in the proof roadmap.",
+      "Can the two remaining sorries be eliminated? `ghouila_houri` requires a longest-path argument tracking both in- and out-degrees (~200 lines). `directed_hamiltonian_threshold` requires identifying the extremal structure and reducing to Moon-Moser or Ghouila-Houri.",
       "Can Ghouila-Houri's theorem be fully formalized? The proof follows the Dirac argument for undirected graphs but requires tracking both in- and out-degrees. Is the analogous undirected Dirac theorem in Mathlib, and can the directed version be derived?",
       "Meyniel's condition (weaker than Ghouila-Houri: $\\delta^+(u) + \\delta^-(u) + \\delta^+(v) + \\delta^-(v) \\geq 2n-1$ for non-adjacent pairs) implies Hamiltonicity. Can this stronger result be formalized, or would it require substantially more tournament infrastructure?",
       "The arc threshold $(n-1)^2$ in `directed_hamiltonian_threshold` — is this the tight bound? What is the densest non-Hamiltonian strongly connected tournament on $n$ vertices, and can a tight threshold be proved in Lean?"


### PR DESCRIPTION
## Summary

Gallery integrity audit found stale metadata for `erdos-1012-oq-03`:

- **Sorry count overclaimed**: meta.json said 3 sorries, but `sc_tournament_has_cycle` and `tournament_cycle_extendable` are now fully proved in the Lean source — only `ghouila_houri` and `directed_hamiltonian_threshold` remain as sorries (count: 2)
- **Moon-Moser is fully proved**: `moon_moser` theorem calls `sc_tournament_has_cycle` + `grow_cycle_to_hamiltonian` (which uses `tournament_cycle_extendable`), all sorry-free
- **Line count stale**: 743 → 991 (proof grew with full implementations of the infrastructure lemmas)
- **Section line ranges updated** to match actual file structure
- **Assumptions, proofStrategy, conclusion** updated to reflect current proof status

## Evidence

```
$ grep -n "sorry" proofs/Proofs/Erdos1012OQ03.lean | grep -v "^[0-9]*:.*--\|^[0-9]*:.*/-"
300:  sorry    ← ghouila_houri
959:  sorry    ← directed_hamiltonian_threshold
966: (comment mentioning sc_tournament_has_cycle — in proof roadmap text, NOT actual sorry)
968: (comment mentioning S⁺/S⁻ — in proof roadmap text, NOT actual sorry)
```

Actual sorry count: **2**. meta.json claimed: **3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Lean Auditor