### PR TITLE
Fix: erdos-1012-oq-03 sorry count 3→2 (sc_tournament_has_cycle proved)

### DIFF
--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -13,10 +13,10 @@
       "tournaments"
     ],
     "badge": "formalized",
-    "sorries": 3,
+    "sorries": 2,
     "axiomCount": 0,
-    "lineCount": 743,
-    "assumptions": "0 axioms. 3 sorries: (1) ghouila_houri (full proof needs longest-path argument ~200 lines), (2) sc_tournament_has_cycle (extract simple cycle from SC walk), (3) tournament_cycle_extendable (S⁺/S⁻ partition argument). Moon-Moser architecture complete modulo these 2 infrastructure lemmas. Rédei fully proved by induction.",
+    "lineCount": 991,
+    "assumptions": "0 axioms. 2 sorries: (1) ghouila_houri (line 300 — full proof needs longest-path argument), (2) directed_hamiltonian_threshold (line 959 — arc-count threshold). sc_tournament_has_cycle, grow_cycle_to_hamiltonian, tournament_cycle_extendable: fully proved. Moon-Moser and Rédei theorems: complete.",
     "dateAdded": "2026-03-30"
   },
   "overview": {


### PR DESCRIPTION
## Fix

Corrects stale sorry count in `erdos-1012-oq-03` meta.json after PR #9067 proved `sc_tournament_has_cycle` and `tournament_cycle_extendable` in the Lean file.

## Evidence

**Before**: `meta.sorries = 3`, listing sc_tournament_has_cycle, tournament_cycle_extendable, and ghouila_houri as open sorries.

**After**: `meta.sorries = 2`. Only `ghouila_houri` (line 300) and `directed_hamiltonian_threshold` (line 959) remain as actual `sorry` in the Lean file. Moon-Moser theorem is now fully proved.

Also corrects `lineCount` from 743 to 991 (file grew as proofs were completed).

Resolves auditor flag: `sorry mismatch: claims 3, actual 2`

---
Automated fix by lean-mechanic agent.