### PR TITLE
fix: correct stale leanFile section in triangular-reciprocals-oq-03-oq-02 meta.json

### DIFF
--- a/src/data/proofs/triangular-reciprocals-oq-03-oq-02/meta.json
+++ b/src/data/proofs/triangular-reciprocals-oq-03-oq-02/meta.json
@@ -121,7 +121,7 @@
     ],
     "leanFile": {
         "imports": [
-            "Proofs.TriangularReciprocalAlternatingOQ03"
+            "Mathlib"
         ],
         "opens": [
             "Finset",
@@ -131,8 +131,8 @@
             "Real"
         ],
         "namespace": "AlternatingTriangularReciprocals.Generalized",
-        "lineCount": 196,
-        "axiomCount": 0,
+        "lineCount": 202,
+        "axiomCount": 1,
         "theoremCount": 10,
         "definitionCount": 1
     }


### PR DESCRIPTION
## Summary

Gallery integrity audit found stale `leanFile` section in `triangular-reciprocals-oq-03-oq-02/meta.json` after a prior refactor made the file self-contained:

- **Wrong imports**: showed `Proofs.TriangularReciprocalAlternatingOQ03` — actual file imports `Mathlib` directly
- **Wrong axiomCount**: showed `0` — actual file declares `alternating_harmonic_hasSum` locally (count: 1)
- **Wrong lineCount**: showed `196` — actual file is 202 lines

Note: The primary `meta.axiomCount: 1` field was already correct from prior fixes (#9069). This fix corrects the secondary `leanFile` section to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Lean Auditor