### PR TITLE
feat: Aristotle companion for erdos-771 (prime multiples lemmas)

### DIFF
--- a/proofs/Proofs/Erdos771ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos771ProblemAristotle.lean
@@ -1,0 +1,49 @@
+/-
+  Aristotle targets for Erdős Problem #771 (Subsets Avoiding a Given Sum)
+  Routine supporting lemmas for automated proof search.
+  See Erdos771Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - prime_multiples_size: |(multiples of p in {1,...,n})| = ⌊n/p⌋ (Mathlib count)
+  - prime_multiples_avoid: multiples of p form an m-avoiding set when p ∤ m
+    (any subset sum of p-multiples is divisible by p, but p ∤ m)
+  - NOT f_characterization (maximal characterization of f, definitional)
+  - NOT erdos_graham_conjecture_true (main theorem: f(n) ~ n/2·log n)
+  - NOT leading_constant (asymptotic constant analysis)
+-/
+import Mathlib
+
+namespace Erdos771ProblemAristotle
+
+open Finset BigOperators Real Nat
+
+/-- The set {1, ..., n}. -/
+def Icc_n (n : ℕ) : Finset ℕ := Finset.Icc 1 n
+
+/-- Multiples of p in {1,...,n}. -/
+def primeMutliples (p n : ℕ) : Finset ℕ :=
+  (Icc_n n).filter (fun k => p ∣ k)
+
+-- Routine: Count of multiples of p in {1,...,n} equals ⌊n/p⌋.
+-- Uses Finset.Nat.card_multiples or Icc filter card formula.
+theorem prime_multiples_size (p n : ℕ) (hp : p > 0) :
+    (primeMutliples p n).card = n / p := by
+  sorry
+
+-- Routine: The set of all subset sums of S.
+noncomputable def subsetSums (S : Finset ℕ) : Finset ℕ :=
+  (S.powerset.image (fun A => ∑ a ∈ A, a)).filter (· > 0)
+
+-- Routine: Definition of sum-avoidance.
+def AvoidSum (S : Finset ℕ) (m : ℕ) : Prop :=
+  m ∉ subsetSums S
+
+-- Routine: Multiples of prime p avoid sum m when p ∤ m.
+-- Every element of primeMutliples p n is divisible by p; any
+-- nonempty subset sum is also divisible by p; since p ∤ m, m cannot
+-- be achieved as a subset sum.
+theorem prime_multiples_avoid (p m n : ℕ) (hp : Nat.Prime p) (hpm : ¬p ∣ m) :
+    AvoidSum (primeMutliples p n) m := by
+  sorry
+
+end Erdos771ProblemAristotle


### PR DESCRIPTION
## Fix

Adds `Erdos771ProblemAristotle.lean` with two routine supporting lemmas for Aristotle's automated proof search.

## Evidence

**Target**: `erdos-771` (Subsets Avoiding a Given Sum) — 7 sorries, no Aristotle companion

**Lemmas selected**:
1. `prime_multiples_size`: Count of multiples of `p` in `{1,...,n}` equals `⌊n/p⌋` — routine Finset count, likely has a direct Mathlib equivalent
2. `prime_multiples_avoid`: Multiples of prime `p` avoid sum `m` when `p ∤ m` — algebraic: every subset sum of `p`-multiples is divisible by `p`, so `m` (with `p ∤ m`) cannot be achieved

These are supporting lemmas for the Erdős-Graham lower bound construction (`S` = multiples of smallest prime not dividing `m`).

## Checklist

- [x] No `def ... := sorry` (definition sorries)
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections (uses `/-` instead)
- [x] No open conjectures

---
Automated fix by lean-mechanic agent.