### PR TITLE
feat: prove multinomial_eq_prod_choose — 0 sorries in kummer-theorem-oq-01

### DIFF
--- a/proofs/Proofs/KummerTheoremOQ01.lean
+++ b/proofs/Proofs/KummerTheoremOQ01.lean
@@ -1,4 +1,5 @@
 import Mathlib
+import Proofs.KummerTheoremOQ01Aristotle
 
 /-
 # Multinomial Analogs of Kummer's Theorem
@@ -43,7 +44,10 @@ theorem multinomial_eq_prod_choose : ∀ (ks : List ℕ),
     multinomial ks =
       (((ks.scanl (· + ·) (0 : ℕ)).zip ks).tail.map
         (fun ⟨acc, k⟩ => Nat.choose (acc + k) k)).prod := by
-  sorry
+  intro ks
+  have h := KummerMultinomialAristotle.multinomial_eq_prod_choose ks
+  simp only [KummerMultinomialAristotle.multinomial] at h
+  exact h
 
 /-- For two elements, the multinomial reduces to a binomial. -/
 theorem multinomial_pair (a b : ℕ) :

--- a/proofs/Proofs/KummerTheoremOQ01Aristotle.lean
+++ b/proofs/Proofs/KummerTheoremOQ01Aristotle.lean
@@ -116,42 +116,40 @@ theorem scanl_add_append (acc : ℕ) (ks : List ℕ) (k : ℕ) :
     (ks ++ [k]).scanl (· + ·) acc =
     ks.scanl (· + ·) acc ++ [acc + ks.sum + k] := by
   induction ks generalizing acc with
-  | nil => simp [List.scanl_cons]
+  | nil => simp
   | cons h t ih =>
-    simp only [List.cons_append, List.scanl_cons, List.singleton_append, List.sum_cons]
-    rw [ih (acc + h)]
-    simp only [List.append_assoc]
-    congr 2
-    omega
+    simp only [List.cons_append, List.scanl_cons, List.sum_cons]
+    congr 1
+    rw [ih (acc + h), show acc + h + t.sum + k = acc + (h + t.sum) + k from by omega]
+
+/-- Generalized version of zip_scanl_append_singleton with arbitrary initial accumulator.
+    By induction: cons case uses zip_cons_cons, then IH at (acc + h), then omega. -/
+private theorem zip_scanl_append_singleton_gen (acc : ℕ) (ks : List ℕ) (k : ℕ) :
+    ((ks ++ [k]).scanl (· + ·) acc).zip (ks ++ [k]) =
+    (ks.scanl (· + ·) acc).zip ks ++ [(acc + ks.sum, k)] := by
+  induction ks generalizing acc with
+  | nil => simp
+  | cons h t ih =>
+    simp only [List.cons_append, List.scanl_cons, List.sum_cons, List.zip_cons_cons]
+    congr 1
+    rw [ih (acc + h), show acc + h + t.sum = acc + (h + t.sum) from by omega]
 
 /-- The zip of (scanl 0 (ks ++ [k])) with (ks ++ [k]) decomposes as:
     zip (scanl 0 ks) ks ++ [(ks.sum, k)].
-    The last pair has ks.sum as first component (= last element of scanl 0 ks),
-    and k as second; this gives the binomial factor C(ks.sum + k, k) in the product.
-
-    Proof:
-    1. scanl 0 (ks ++ [k]) = scanl 0 ks ++ [ks.sum + k]  (from scanl_add_append with acc=0)
-       But only first |ks ++ [k]| = |ks|+1 elements of this zip are used.
-    2. zip (scanl 0 ks ++ [ks.sum + k]) (ks ++ [k])
-       = zip (scanl 0 ks) (ks ++ [k])          (via zip_append with |scanl ks| = |ks ++ [k]|,
-                                                  the extra [ks.sum+k] element gets dropped)
-       = zip (dropLast(scanl 0 ks) ++ [ks.sum]) (ks ++ [k])
-       = zip (dropLast(scanl 0 ks)) ks ++ [(ks.sum, k)]  (via zip_append with equal lengths)
-       = zip (scanl 0 ks) ks ++ [(ks.sum, k)]   (zip truncates to shorter list)
--/
+    Proved by specializing the generalized accumulator version at acc = 0. -/
 theorem zip_scanl_append_singleton (ks : List ℕ) (k : ℕ) :
     ((ks ++ [k]).scanl (· + ·) (0 : ℕ)).zip (ks ++ [k]) =
     (ks.scanl (· + ·) 0).zip ks ++ [(ks.sum, k)] := by
-  sorry
+  simpa using zip_scanl_append_singleton_gen 0 ks k
 
 /-- The RHS scanl/zip/tail/prod expression picks up factor C(ks.sum + k, k) on appending [k].
     For ks = [], both sides equal 1.
     For ks ≠ [], the tail distributes and the extra pair contributes C(ks.sum + k, k). -/
 theorem rhs_append_singleton (ks : List ℕ) (k : ℕ) :
-    (((ks ++ [k]).scanl (· + ·) (0 : ℕ)).zip (ks ++ [k])).tail.map
-        (fun ⟨acc, j⟩ => Nat.choose (acc + j) j) |>.prod =
-    ((ks.scanl (· + ·) (0 : ℕ)).zip ks).tail.map
-        (fun ⟨acc, j⟩ => Nat.choose (acc + j) j) |>.prod *
+    ((((ks ++ [k]).scanl (· + ·) (0 : ℕ)).zip (ks ++ [k])).tail.map
+        (fun ⟨acc, j⟩ => Nat.choose (acc + j) j)).prod =
+    (((ks.scanl (· + ·) (0 : ℕ)).zip ks).tail.map
+        (fun ⟨acc, j⟩ => Nat.choose (acc + j) j)).prod *
     Nat.choose (ks.sum + k) k := by
   rw [zip_scanl_append_singleton]
   cases ks with
@@ -162,10 +160,9 @@ theorem rhs_append_singleton (ks : List ℕ) (k : ℕ) :
     -- zip (scanl 0 (h :: t)) (h :: t) starts with (0, h), non-empty
     -- tail distributes: (l ++ [x]).tail = l.tail ++ [x] when l ≠ []
     have hne : (List.scanl (· + ·) 0 (h :: t)).zip (h :: t) ≠ [] := by
-      simp [List.scanl_cons]
-    rw [List.tail_append_of_ne_nil _ _ hne]
-    simp only [List.map_append, List.prod_append]
-    ring
+      simp
+    rw [List.tail_append_of_ne_nil hne]
+    simp only [List.map_append, List.prod_append, List.map_singleton, List.prod_singleton]
 
 /-- Main theorem: multinomial ks = product of C(partial_sum + kᵢ, kᵢ) over all kᵢ in ks.
     Proved by backward induction (List.reverseRecOn) using:

--- a/src/data/proofs/kummer-theorem-oq-01/meta.json
+++ b/src/data/proofs/kummer-theorem-oq-01/meta.json
@@ -13,10 +13,10 @@
     ],
     "proofRepoPath": "Proofs/KummerTheoremOQ01.lean",
     "badge": "formalized",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "0 axioms. 1 sorry: multinomial_eq_prod_choose (general list induction). Proved: multinomial_pair (binomial case), multinomial_triple (trinomial case via choose_mul_factorial_mul_factorial).",
-    "lineCount": 103,
+    "assumptions": "0 axioms, 0 sorries. All theorems fully proved: multinomial_eq_prod_choose (via companion file KummerTheoremOQ01Aristotle.lean using reverseRecOn induction), multinomial_pair, multinomial_triple.",
+    "lineCount": 108,
     "theoremCount": 4,
     "definitionCount": 1,
     "mathlib_version": "4.26.0",
@@ -32,7 +32,7 @@
   "overview": {
     "historicalContext": "Ernst Kummer proved in 1852 that the highest power of a prime p dividing the binomial coefficient C(n, k) equals the number of carries when adding k and n-k in base p. This elegant theorem connects combinatorics (counting subsets) with the arithmetic of positional numeral systems. The result was rediscovered and generalized throughout the 20th century. The multinomial extension is a natural question: the multinomial coefficient C(n; k₁, k₂, ..., kₘ) counts the number of ways to partition n objects into groups of sizes k₁, ..., kₘ (with n = k₁ + ... + kₘ). The key insight is that multinomial coefficients factor as products of binomials via a telescoping decomposition: C(n; k₁,...,kₘ) = C(k₁+k₂, k₁) · C(k₁+k₂+k₃, k₁+k₂) · ... · C(n, n-kₘ). Applying Kummer's theorem to each factor and summing gives the total carry count when adding k₁, k₂, ..., kₘ successively in base p.",
     "problemStatement": "Can Kummer's theorem — $v_p\\binom{n}{k} = c(k, n-k; p)$ where $c$ counts base-$p$ carries — be extended to multinomial coefficients? That is, does $v_p\\binom{n}{k_1,\\ldots,k_m} = $ total carries when adding $k_1,\\ldots,k_m$ in base $p$? Answer: yes, via iterated binomial decomposition.",
-    "proofStrategy": "The file defines the multinomial coefficient as n! / (k₁! · ... · kₘ!) using `List.sum` and `List.prod`. The key identity `multinomial_eq_prod_choose` expresses this as a product of binomials via `List.scanl` accumulation (1 sorry remains for the general list induction). `multinomial_pair` is fully proved via `Nat.choose_mul_factorial_mul_factorial`. `multinomial_triple` is fully proved: uses `Nat.choose_mul_factorial_mul_factorial` twice to establish C(a+b,a)*C(a+b+c,a+b)*(a!*(b!*c!)) = (a+b+c)!, then concludes via `Nat.mul_div_cancel`. `kummer_multinomial_statement` is a placeholder stub (returns `True`).",
+    "proofStrategy": "The file defines the multinomial coefficient as n! / (k₁! · ... · kₘ!) using `List.sum` and `List.prod`. The key identity `multinomial_eq_prod_choose` is now fully proved via companion file `KummerTheoremOQ01Aristotle.lean`, which uses backward list induction (`List.reverseRecOn`) with two key lemmas: `multinomial_append_singleton` (LHS step: appending k multiplies by C(sum+k,k)) and `rhs_append_singleton` (RHS step: the scanl/zip/tail/prod picks up factor C(sum+k,k)). The `zip_scanl_append_singleton` lemma (proved by generalizing the accumulator and induction on `ks`) is the key auxiliary result. `multinomial_pair` and `multinomial_triple` are proved via `Nat.choose_mul_factorial_mul_factorial`. `kummer_multinomial_statement` is a placeholder stub (returns `True`).",
     "keyInsights": [
       "The iterated decomposition $\\binom{n}{k_1,\\ldots,k_m} = \\prod_{i=1}^{m} \\binom{k_1+\\cdots+k_i}{k_1+\\cdots+k_{i-1}}$ is the algebraic heart of the extension. Each factor is an ordinary binomial to which Kummer's theorem applies directly.",
       "Kummer's theorem for each binomial factor gives $v_p\\binom{k_1+\\cdots+k_i}{k_1+\\cdots+k_{i-1}} = c(k_i, k_1+\\cdots+k_{i-1}; p)$ — the carries when adding the $i$-th part to the running sum. Summing over all $i$ gives the total carries for adding all parts.",
@@ -61,17 +61,16 @@
       "title": "Binomial Factorization and Pair/Triple Cases",
       "startLine": 35,
       "endLine": 68,
-      "summary": "Three theorems: (1) `multinomial_eq_prod_choose` — general decomposition via scanl/zip (sorry); (2) `multinomial_pair` — fully proved base case reducing to Nat.add_choose_eq; (3) `multinomial_triple` — partial proof for trinomial case, factorial rearrangement complete but final division step sorry. Plus `kummer_multinomial_statement` stub returning True."
+      "summary": "Three theorems, all proved: (1) `multinomial_eq_prod_choose` — general decomposition via scanl/zip, proved by importing companion file `KummerTheoremOQ01Aristotle.lean`; (2) `multinomial_pair` — binomial case proved via `Nat.choose_mul_factorial_mul_factorial`; (3) `multinomial_triple` — trinomial case proved via two applications of `choose_mul_factorial_mul_factorial`. Plus `kummer_multinomial_statement` stub returning True (p-adic valuation statement, open)."
     }
   ],
   "conclusion": {
-    "summary": "This file establishes the algebraic scaffolding for the multinomial extension of Kummer's theorem. The definition is correct (confirmed by `multinomial_pair`), the general factorization identity is stated and the triple case is partially proved. The full formalization requires completing two sorries and replacing the `kummer_multinomial_statement` stub with the actual carry-counting argument.",
+    "summary": "This file fully establishes the algebraic scaffolding for the multinomial extension of Kummer's theorem. All sorries have been eliminated: `multinomial_eq_prod_choose` is proved via backward list induction in companion file `KummerTheoremOQ01Aristotle.lean`, `multinomial_pair` and `multinomial_triple` are directly proved via `Nat.choose_mul_factorial_mul_factorial`. The main open remaining formalization is `kummer_multinomial_statement` (the p-adic valuation statement itself, currently a `True` stub).",
     "implications": "The multinomial Kummer theorem has applications in combinatorics (divisibility of multinomial coefficients, Lucas-type theorems for multinomials), algebraic topology (p-local decompositions of symmetric products), and number theory (p-adic valuations of products of factorials). The iterated binomial decomposition technique appears in other combinatorial contexts, such as q-analogs of multinomial coefficients.",
     "openQuestions": [
-      "Can `multinomial_eq_prod_choose` be proved by list induction on `ks`? The `scanl`/`zip`/`tail` combination requires careful induction hypotheses about the accumulated running sum.",
-      "Can the sorry in `multinomial_triple` be closed? It requires the identity $(a+b+c)!/(a! \\cdot b! \\cdot c!) = ((a+b)!/(a! \\cdot b!)) \\cdot ((a+b+c)!/((a+b)! \\cdot c!))$ which is a natural number division identity needing `Nat.div_mul_div_comm` or similar.",
       "Can `kummer_multinomial_statement` be formalized using Kummer's theorem from Mathlib? This would require a Lean formalism for base-p carries (not yet in Mathlib) and induction over the telescoping product.",
-      "Is there a q-analog? The q-binomial coefficient (Gaussian binomial) satisfies a Kummer-like theorem; the q-multinomial analog is less well-studied."
+      "Is there a q-analog? The q-binomial coefficient (Gaussian binomial) satisfies a Kummer-like theorem; the q-multinomial analog is less well-studied.",
+      "Can `multinomial_eq_prod_choose` be made fully self-contained in the main file (without the companion import), using a more direct proof?"
     ]
   },
   "leanFile": {

--- a/src/data/research/problems/kummer-theorem-oq-01-incomplete-01.json
+++ b/src/data/research/problems/kummer-theorem-oq-01-incomplete-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "kummer-theorem-oq-01-incomplete-01",
   "title": "Multinomial Analogs of Kummer Theorem",
-  "phase": "NEW",
+  "phase": "COMPLETED",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -29,9 +29,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETE: multinomial_eq_prod_choose proved via zip_scanl_append_singleton_gen induction. 0 sorries, 0 axioms in both main and companion files.",
+    "builtItems": [
+      "zip_scanl_append_singleton_gen: private induction on ks (generalizing acc) in KummerTheoremOQ01Aristotle.lean:129-139",
+      "zip_scanl_append_singleton: specializes gen version at acc=0 in KummerTheoremOQ01Aristotle.lean:144-147",
+      "rhs_append_singleton: uses tail_append_of_ne_nil + map/prod simplification in KummerTheoremOQ01Aristotle.lean:152-170",
+      "multinomial_eq_prod_choose: proved by reverseRecOn induction in KummerTheoremOQ01Aristotle.lean:172-184"
+    ],
+    "insights": [
+      "Key: generalizing acc in zip_scanl_append_singleton from 0 to arbitrary acc enables clean induction. Without generalization, the cons case shifts accumulator and IH cannot be applied.",
+      "Fix: omega cannot close prod.mk equality directly after congr; use rw [show a = b from by omega] instead of congr+omega."
+    ],
     "mathlibGaps": [],
     "nextSteps": []
   },


### PR DESCRIPTION
## Summary

- Closes the last sorry in `KummerTheoremOQ01.lean` (general multinomial factorization identity)
- New companion file `KummerTheoremOQ01Aristotle.lean` (181 lines, 0 sorries, 0 axioms)
- Both files verified by Docker-wrapped Lean 4 build

## Key Proof Technique

The critical insight: `zip_scanl_append_singleton` requires induction with a **generalized accumulator**. The theorem `zip_scanl_append_singleton_gen (acc : ℕ) (ks : List ℕ) (k : ℕ)` proves the identity for arbitrary `acc`, enabling the cons case to apply the IH at the shifted accumulator `acc + h`. Arithmetic closure uses `rw [show a + h + t.sum = a + (h + t.sum) from by omega]`.

The main theorem `multinomial_eq_prod_choose` follows by `List.reverseRecOn` using:
- `multinomial_append_singleton`: LHS recurrence (appending k multiplies by C(sum+k,k))
- `rhs_append_singleton`: RHS recurrence (scanl/zip/tail/prod picks up C(sum+k,k))

## Test plan
- [x] `docker-build.sh Proofs.KummerTheoremOQ01Aristotle` — build succeeds
- [x] `docker-build.sh Proofs.KummerTheoremOQ01` — build succeeds
- [x] `sorries: 0` confirmed in meta.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)