### PR TITLE
feat: add Aristotle companion for erdos-631 (list coloring supporting lemmas)

### DIFF
--- a/proofs/Proofs/Stubs/Erdos631Aristotle.lean
+++ b/proofs/Proofs/Stubs/Erdos631Aristotle.lean
@@ -1,0 +1,98 @@
+/-
+  Aristotle targets for Erdős Problem #631 (List Chromatic Number of Planar Graphs)
+  Routine supporting lemmas for automated proof search.
+  See Erdos631Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main result (Thomassen's 5-choosability theorem)
+  - NOT theorems depending on def-sorries (listChromaticNumber, IsPlanar)
+  - Routine supporting facts: choosability monotonicity, list structure, bot graph
+  - No definition sorries
+  - No axioms
+-/
+import Mathlib
+
+namespace Erdos631Aristotle
+
+open Finset Function SimpleGraph
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-- A list assignment gives each vertex a finite set of available colors -/
+def ListAssignment (V C : Type*) := V → Finset C
+
+/-- A list coloring: each vertex gets a color from its list, and adjacent vertices differ -/
+def IsListColoring (G : SimpleGraph V) {C : Type*} [DecidableEq C]
+    (L : ListAssignment V C) (f : V → C) : Prop :=
+  (∀ v : V, f v ∈ L v) ∧ (∀ v w : V, G.Adj v w → f v ≠ f w)
+
+/-- A graph is k-choosable: for any list assignment with lists of size ≥ k, a proper list coloring exists -/
+def IsKChoosable (G : SimpleGraph V) (k : ℕ) : Prop :=
+  ∀ (C : Type*) [DecidableEq C] (L : ListAssignment V C),
+    (∀ v : V, (L v).card ≥ k) → ∃ f : V → C, IsListColoring G L f
+
+-- ===================================================================
+-- Section 1: Monotonicity of choosability
+-- ===================================================================
+
+/-- Routine: k-choosability is monotone — if G is k-choosable, it is also (k+1)-choosable.
+    Proof: any list with ≥ k+1 colors also has ≥ k colors (since k ≤ k+1). -/
+theorem choosable_monotone (G : SimpleGraph V) (k : ℕ) :
+    IsKChoosable G k → IsKChoosable G (k + 1) := by
+  sorry
+
+/-- Routine: k-choosability implies (k+m)-choosability for any m.
+    Proof: repeat application of choosable_monotone m times. -/
+theorem choosable_monotone_add (G : SimpleGraph V) (k m : ℕ) :
+    IsKChoosable G k → IsKChoosable G (k + m) := by
+  sorry
+
+-- ===================================================================
+-- Section 2: List coloring on bot graph (no edges)
+-- ===================================================================
+
+/-- Routine: In the bot graph, adjacency is always False.
+    The bot graph has no edges by definition. -/
+theorem bot_adj_false (v w : V) : ¬(⊥ : SimpleGraph V).Adj v w := by
+  sorry
+
+/-- Routine: A function f is a list coloring of the bot graph iff each f(v) ∈ L(v).
+    There are no edge constraints in the bot graph, so only the list membership matters. -/
+theorem bot_listcoloring_iff {C : Type*} [DecidableEq C]
+    (L : ListAssignment V C) (f : V → C) :
+    IsListColoring (⊥ : SimpleGraph V) L f ↔ ∀ v, f v ∈ L v := by
+  sorry
+
+-- ===================================================================
+-- Section 3: List cardinality and nonemptiness
+-- ===================================================================
+
+/-- Routine: If a list has card ≥ 1, it is nonempty.
+    Follows from Finset.card_pos. -/
+theorem list_nonempty_of_card_ge_one {C : Type*} (L : ListAssignment V C)
+    (h : ∀ v : V, (L v).card ≥ 1) : ∀ v : V, (L v).Nonempty := by
+  sorry
+
+/-- Routine: If a list has card ≥ k+1, it also has card ≥ k.
+    Simple arithmetic: k ≤ k+1. -/
+theorem list_card_mono {C : Type*} (L : ListAssignment V C) (k : ℕ)
+    (h : ∀ v : V, (L v).card ≥ k + 1) : ∀ v : V, (L v).card ≥ k := by
+  sorry
+
+-- ===================================================================
+-- Section 4: IsListColoring structural properties
+-- ===================================================================
+
+/-- Routine: IsListColoring is a conjunction; the first component is list membership. -/
+theorem listcoloring_mem {C : Type*} [DecidableEq C]
+    (G : SimpleGraph V) (L : ListAssignment V C) (f : V → C)
+    (h : IsListColoring G L f) (v : V) : f v ∈ L v := by
+  sorry
+
+/-- Routine: IsListColoring is a conjunction; the second component is the proper coloring condition. -/
+theorem listcoloring_proper {C : Type*} [DecidableEq C]
+    (G : SimpleGraph V) (L : ListAssignment V C) (f : V → C)
+    (h : IsListColoring G L f) (v w : V) (hvw : G.Adj v w) : f v ≠ f w := by
+  sorry
+
+end Erdos631Aristotle


### PR DESCRIPTION
## Fix

Adds `Erdos631Aristotle.lean` — an Aristotle companion file for Erdős Problem #631 (List Chromatic Number of Planar Graphs).

## Evidence

**Problem**: `Proofs/Stubs/Erdos631Problem.lean` has 10 sorries and no Aristotle companion file.

**After**: Companion file with 8 routine theorem sorries targeting Aristotle proof search:

| Lemma | Description |
|---|---|
| `choosable_monotone` | k-choosable → (k+1)-choosable (monotonicity via `omega`) |
| `choosable_monotone_add` | k-choosable → (k+m)-choosable |
| `bot_adj_false` | bot graph has no adjacency edges |
| `bot_listcoloring_iff` | list coloring on bot ↔ only membership constraint |
| `list_nonempty_of_card_ge_one` | list card ≥ 1 → nonempty |
| `list_card_mono` | list card ≥ k+1 → list card ≥ k |
| `listcoloring_mem` | IsListColoring → f(v) ∈ L(v) |
| `listcoloring_proper` | IsListColoring → proper coloring condition |

**Pre-submission checklist**:
- [x] No `def ... := sorry` (definition sorries)
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections (uses `/-` instead)
- [x] No open conjectures (Thomassen's theorem is axiomatized in the main file, not here)

All lemmas avoid the sorry-defined `listChromaticNumber` and `IsPlanar` from the main file.

---
Automated fix by lean-mechanic agent.