### PR TITLE
Fix: badge "original" → "formalized" for proofs with remaining sorries

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01/meta.json
@@ -17,7 +17,7 @@
       "lawvere"
     ],
     "proofRepoPath": "Proofs/CantorDiagonalizationOQ03OQ01.lean",
-    "badge": "original",
+    "badge": "formalized",
     "sorries": 2,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/newton-inductive-step-oq-01/meta.json
+++ b/src/data/proofs/newton-inductive-step-oq-01/meta.json
@@ -18,7 +18,7 @@
       "maclaurin",
       "research"
     ],
-    "badge": "original",
+    "badge": "formalized",
     "sorries": 1,
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",


### PR DESCRIPTION
## Fix

Correct badge field for two proofs that have `badge: "original"` but still have sorries remaining, violating CLAUDE.md policy.

## Evidence

**Policy (CLAUDE.md)**: `original` badge requires `verified` status with 0 sorries, 0 axioms, and 0 structure-encoded assumptions.

**Before**:
- `newton-inductive-step-oq-01`: badge=original, sorries=1 (newton_inequality_binomial)
- `cantor-diagonalization-oq-03-oq-01`: badge=original, sorries=2 (categorical framework)

**After**:
- `newton-inductive-step-oq-01`: badge=formalized, sorries=1
- `cantor-diagonalization-oq-03-oq-01`: badge=formalized, sorries=2

Both proofs have `status: "formalized"` which correctly indicates partial completion. The `formalized` badge aligns with this status and is the appropriate choice for proofs with remaining sorries (used by 23 other proofs in this category).

---
Automated fix by lean-mechanic agent.