### PR TITLE
Enrichment: Erdős 453 Axiom Elimination annotations and meta

### DIFF
--- a/src/data/proofs/erdos-453-oq-02/annotations.json
+++ b/src/data/proofs/erdos-453-oq-02/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-e453-indexing-bridge",
+    "proofId": "erdos-453-oq-02",
+    "range": { "startLine": 49, "endLine": 62 },
+    "type": "insight",
+    "title": "The Indexing Bridge: 1-Indexed nthPrime Unfolds to Nat.nth Nat.Prime",
+    "content": "The central design insight of this file is the definition `nthPrime n = if n = 0 then 0 else Nat.nth Nat.Prime (n - 1)` (line 49). This 1-indexed convention (p_1 = 2, p_2 = 3, ...) is conventional in number theory but Mathlib's Nat.nth is 0-indexed. The bridge `nthPrime n = Nat.nth Nat.Prime (n - 1)` for n ≥ 1 makes every Mathlib theorem about Nat.nth Nat.Prime directly applicable after unfolding nthPrime and simp-ing away the n ≠ 0 guard. The shifted function `fun n => nthPrime (n + 1) = fun n => Nat.nth Nat.Prime n` is exactly Nat.nth Nat.Prime, which is critical for the monotonicity theorem: Nat.nth_strictMono applies to the 0-indexed form, not the 1-indexed form.",
+    "mathContext": "\\text{nthPrime}(n) = \\begin{cases} 0 & n = 0 \\\\ \\text{Nat.nth Nat.Prime}(n-1) & n \\geq 1 \\end{cases}\\\\ \\text{Key: } (\\lambda n.\\, \\text{nthPrime}(n+1)) = (\\lambda n.\\, \\text{Nat.nth Nat.Prime}(n))\\\\ p_1=2,\\; p_2=3,\\; p_3=5,\\; p_4=7 \\quad (\\text{1-indexed})",
+    "significance": "key",
+    "relatedConcepts": ["Nat.nth", "1-indexed vs 0-indexed", "prime enumeration", "index shift"],
+    "prerequisites": ["Nat.nth", "Nat.Prime", "Nat.infinite_setOf_prime"]
+  },
+  {
+    "id": "ann-e453-primality-proof",
+    "proofId": "erdos-453-oq-02",
+    "range": { "startLine": 59, "endLine": 63 },
+    "type": "technique",
+    "title": "nthPrime_is_prime: Nat.nth_mem_of_infinite Replaces Parent Axiom",
+    "content": "nthPrime_is_prime (line 59) proves that nthPrime n is prime for n ≥ 1. The proof: (1) `unfold nthPrime` expands the definition; (2) `simp [Nat.not_eq_zero_of_lt (by omega : 0 < n)]` resolves the `if n = 0` guard using hn : n ≥ 1; (3) `exact Nat.nth_mem_of_infinite Nat.infinite_setOf_prime (n - 1)` applies Mathlib's theorem that every element enumerated by Nat.nth over an infinite set satisfies the predicate. The theorem `Nat.nth_mem_of_infinite {s : Set ℕ} (hs : s.Infinite) (k : ℕ) : Nat.nth s k ∈ s` directly gives primality since `∈ {n : ℕ | Nat.Prime n} = Nat.Prime n`. This is the cleanest of the three eliminations — one line once the indexing is resolved.",
+    "mathContext": "\\text{Nat.nth\\_mem\\_of\\_infinite}: s \\text{ infinite} \\Rightarrow \\text{Nat.nth}\\, s\\, k \\in s\\\\ \\text{Apply: } s = \\{p \\mid \\text{Nat.Prime}\\, p\\}, \\; k = n-1\\\\ \\Rightarrow \\text{Nat.nth Nat.Prime}(n-1) \\in \\{p \\mid \\text{Prime}\\, p\\} \\Rightarrow \\text{nthPrime}(n)\\text{ is prime}",
+    "significance": "key",
+    "relatedConcepts": ["Nat.nth_mem_of_infinite", "Nat.infinite_setOf_prime", "axiom elimination"],
+    "prerequisites": ["Nat.nth_mem_of_infinite", "Nat.infinite_setOf_prime", "Nat.not_eq_zero_of_lt"]
+  },
+  {
+    "id": "ann-e453-monotonicity-proof",
+    "proofId": "erdos-453-oq-02",
+    "range": { "startLine": 71, "endLine": 75 },
+    "type": "technique",
+    "title": "nthPrime_strictMono: Shifted Sequence + Nat.nth_strictMono",
+    "content": "nthPrime_strictMono (line 71) proves `StrictMono (fun n => nthPrime (n + 1))`. The shift n ↦ n+1 converts from 1-indexing to 0-indexing: `nthPrime (n+1) = Nat.nth Nat.Prime n`. The proof: (1) `intro a b hab` introduces a < b; (2) `unfold nthPrime; simp` reduces both sides to Nat.nth Nat.Prime; (3) `exact Nat.nth_strictMono Nat.infinite_setOf_prime hab` applies Mathlib's theorem `Nat.nth_strictMono : s.Infinite → StrictMono (Nat.nth s)`. The shift in the statement (n+1 instead of n) is necessary because 0-indexed strict monotonicity would trivially follow from 1-indexed via the shift; without it, we'd need to separately handle the n=0 case (nthPrime 0 = 0, which is not prime). The shifted version `StrictMono (fun n => nthPrime (n+1))` states exactly that the sequence of primes p_1, p_2, p_3, ... is strictly increasing.",
+    "mathContext": "\\text{Nat.nth\\_strictMono}: s \\text{ infinite} \\Rightarrow \\text{StrictMono}(\\text{Nat.nth}\\, s)\\\\ \\text{Statement: } a < b \\Rightarrow \\text{nthPrime}(a+1) < \\text{nthPrime}(b+1)\\\\ \\text{Unfolded: } a < b \\Rightarrow \\text{Nat.nth Nat.Prime}(a) < \\text{Nat.nth Nat.Prime}(b)\\; \\checkmark\\\\ p_1 < p_2 < p_3 < \\cdots \\quad (\\text{strict monotonicity of prime sequence})",
+    "significance": "key",
+    "relatedConcepts": ["Nat.nth_strictMono", "StrictMono", "index shift", "axiom elimination"],
+    "prerequisites": ["Nat.nth_strictMono", "Nat.infinite_setOf_prime", "StrictMono"]
+  },
+  {
+    "id": "ann-e453-nth-count",
+    "proofId": "erdos-453-oq-02",
+    "range": { "startLine": 81, "endLine": 104 },
+    "type": "technique",
+    "title": "Nat.count + decide: Proving Concrete Prime Values (esp. p_4 = 7)",
+    "content": "nthPrime_values proves p_1=2, p_2=3, p_3=5, p_4=7. For the first three, Mathlib has named constants: `Nat.nth_prime_zero_eq_two`, `Nat.nth_prime_one_eq_three`, `Nat.nth_prime_two_eq_five`. For p_4 = 7, there is no named constant, requiring the Nat.count technique (helper lemma nth_prime_three_eq_seven, line 81). The technique: (1) `have h_count : Nat.count Nat.Prime 7 = 3 := by decide` — Nat.count Nat.Prime n counts how many primes are ≤ n, and `Nat.count Nat.Prime 7 = 3` (the primes ≤ 7 are 2, 3, 5, 7, and 3 of them are < 7: 2, 3, 5) is decidable. (2) `have h_prime : Nat.Prime 7 := by decide` — primality of small numbers is decidable. (3) `rw [← h_count]; exact Nat.nth_count h_prime` — `Nat.nth_count : Nat.Prime p → Nat.nth Nat.Prime (Nat.count Nat.Prime p) = p` recovers p from its count. This pattern generalizes to any concrete prime beyond Mathlib's named constants.",
+    "mathContext": "\\text{Nat.nth\\_count}: \\text{Prime}\\, p \\Rightarrow \\text{Nat.nth Nat.Prime}(\\text{Nat.count Nat.Prime}\\, p) = p\\\\ \\text{Nat.count Nat.Prime}\\, 7 = 3 \\quad (2,3,5 \\text{ are the 3 primes} < 7)\\\\ \\Rightarrow \\text{Nat.nth Nat.Prime}\\, 3 = 7 \\Rightarrow \\text{nthPrime}\\, 4 = 7\\\\ \\text{General pattern: } p \\text{ prime}, c = |\\{q \\text{ prime} : q < p\\}| \\Rightarrow p_{c+1} = p",
+    "significance": "key",
+    "relatedConcepts": ["Nat.nth_count", "Nat.count", "decide tactic", "prime constants"],
+    "prerequisites": ["Nat.nth_count", "Nat.count", "Nat.Prime.decidable", "decide"]
+  },
+  {
+    "id": "ann-e453-log-product",
+    "proofId": "erdos-453-oq-02",
+    "range": { "startLine": 158, "endLine": 186 },
+    "type": "technique",
+    "title": "Convexity → Product Bound: Log Inequality → Real Inequality → Integer Inequality",
+    "content": "convexity_implies_product_bound (line 158) proves: if (n, log p_n) is a convex hull vertex, then p_n² > p_{n+i}·p_{n-i}. The proof chain has three stages. Stage 1 (log inequality): The convex hull vertex condition `2*a_n > a_{n-i} + a_{n+i}` where a_n = log p_n gives `2 log p_n > log p_{n-i} + log p_{n+i} = log(p_{n-i}·p_{n+i})`, hence `log(p_{n-i}·p_{n+i}) < log(p_n²)`. Stage 2 (real inequality): `Real.log_lt_log_iff (mul_pos ...) (pow_pos ...)` converts the log inequality to `p_{n-i}·p_{n+i} < p_n²`. Stage 3 (integer inequality): `exact_mod_cast` converts from ℝ to ℤ, using `Nat.mul_comm` to reorder factors. The positivity hypotheses for primes (`Nat.cast_pos.mpr (Nat.Prime.pos (nthPrime_is_prime ...))`) use the freshly-proved nthPrime_is_prime — demonstrating that eliminating the axiom propagates correctness through the whole argument.",
+    "mathContext": "\\text{IsConvexHullVertex}: 2a_n > a_{n-i} + a_{n+i} \\;\\forall\\, 0 < i < n\\\\ a_n = \\log p_n \\Rightarrow \\log(p_{n-i}p_{n+i}) < \\log(p_n^2)\\\\ \\xrightarrow{\\text{log\\_lt\\_log\\_iff}} p_{n-i}p_{n+i} < p_n^2\\\\ \\xrightarrow{\\text{exact\\_mod\\_cast}} p_n^2 > p_{n+i}p_{n-i} \\text{ in } \\mathbb{Z}",
+    "significance": "key",
+    "relatedConcepts": ["Real.log_lt_log_iff", "Real.log_mul", "Real.log_pow", "exact_mod_cast"],
+    "prerequisites": ["Real.log_lt_log_iff", "Real.log_mul", "Real.log_pow", "Nat.Prime.pos", "exact_mod_cast"]
+  },
+  {
+    "id": "ann-e453-remaining-axioms",
+    "proofId": "erdos-453-oq-02",
+    "range": { "startLine": 127, "endLine": 146 },
+    "type": "concept",
+    "title": "Remaining Axioms: PNT Consequence and Pomerance's Convex Hull Lemma",
+    "content": "Two axioms remain axiomatized in this file. (1) `logPrime_ratio_tendsto_zero` (line 127): log p_n / n → 0. This follows from the Prime Number Theorem: by PNT, p_n ~ n log n, so log p_n ~ log n + log log n = o(n). Mathlib has a version of PNT (`Nat.Prime.prime_counting_asymptotic`) but connecting it to the 1-indexed nthPrime and extracting the log/n → 0 consequence requires additional infrastructure. (2) `pomerance_convex_hull_lemma` (line 144): for any sequence a_n = o(n), there are infinitely many n where (n, a_n) is on the upper boundary of the convex hull. This is Pomerance's key geometric insight from 1979. A full proof would require formalizing discrete convex hull theory — the convex hull of the integer points {(k, a_k)} and the criteria for upper boundary vertices. This is substantially harder than routine Mathlib API work.",
+    "mathContext": "\\text{Axiom 1: } \\frac{\\log p_n}{n} \\to 0 \\quad (\\text{PNT: } p_n \\sim n\\log n \\Rightarrow \\log p_n = \\log n + \\log\\log n = o(n))\\\\ \\text{Axiom 2 (Pomerance 1979): } a_n = o(n) \\Rightarrow \\exists^\\infty n:\\; (n,a_n) \\in \\partial\\text{conv}\\{(k,a_k)\\}\\\\ \\text{Gap: discrete convex hull vertex theory not in Mathlib}",
+    "significance": "key",
+    "relatedConcepts": ["Prime Number Theorem", "Pomerance 1979", "convex hull vertex", "o(n) asymptotic"],
+    "prerequisites": ["PNT (Mathlib)", "Filter.Tendsto", "IsConvexHullVertex", "convex hull theory"]
+  }
+]

--- a/src/data/proofs/erdos-453-oq-02/meta.json
+++ b/src/data/proofs/erdos-453-oq-02/meta.json
@@ -92,14 +92,16 @@
     }
   ],
   "overview": {
-    "historicalContext": "Erdős Problem #453 was solved by Pomerance (1979) using convex hull geometry on the prime number graph. The parent formalization (Erdos453Problem.lean) axiomatized 4 facts about primes and convex hulls. This follow-up eliminates the 2 axioms about the prime enumeration function (nthPrime_is_prime, nthPrime_strictMono) by proving them from Mathlib's Nat.nth API, and proves the concrete prime values that were left as sorry.",
+    "historicalContext": "Erdős Problem #453 asks about infinitely many primes p_n satisfying p_n² > p_{n+i}·p_{n-i} for all i. Erdős posed this in 1979; it was solved the same year by Carl Pomerance using a beautiful geometric argument: plot the points (n, log p_n) in the plane. The Prime Number Theorem gives log p_n ~ log n = o(n), so this discrete curve is sublinear. By a lemma about convex hulls of sublinear sequences (which Pomerance proved), infinitely many points (n, log p_n) lie on the upper boundary of the convex hull — at these boundary points, the concavity condition 2 log p_n > log p_{n-i} + log p_{n+i} holds, which is exactly p_n² > p_{n-i}·p_{n+i}. The Lean formalization story: the parent file (Erdos453Problem.lean) needed to axiomatize 4 facts, including basic properties of the prime enumeration function (nthPrime_is_prime, nthPrime_strictMono) that were left as axioms due to unfamiliarity with Mathlib's Nat.nth API. This OQ-02 file is an axiom elimination exercise: it discovers and applies Nat.nth_mem_of_infinite and Nat.nth_strictMono from Mathlib's Nat.Prime.Nth module, eliminating 2 axioms and 1 sorry.",
     "problemStatement": "Can the axioms in Erdős Problem #453's formalization be proved from Mathlib, reducing the assumption count?",
     "text": "Eliminates 2 of 4 axioms and the sorry from Erdős Problem #453 by proving nthPrime_is_prime and nthPrime_strictMono from Mathlib's Nat.nth API.",
     "proofStrategy": "The 1-indexed nthPrime function unfolds to Nat.nth Nat.Prime (n-1). For primality, Nat.nth_mem_of_infinite applied to Nat.infinite_setOf_prime gives the result directly. For strict monotonicity, the shift fun n => nthPrime (n+1) = Nat.nth Nat.Prime, and Nat.nth_strictMono provides monotonicity. For concrete values, Mathlib has nth_prime_{zero,one,two}_eq_{two,three,five}; the 4th prime uses the Nat.count/Nat.nth_count technique with decide.",
     "keyInsights": [
-      "**Indexing Bridge:** The 1-indexed nthPrime(n) = Nat.nth Nat.Prime (n-1) for n >= 1. The shifted function fun n => nthPrime(n+1) is exactly Nat.nth Nat.Prime, making Mathlib's API directly applicable.",
-      "**Nat.nth_count Technique:** For primes beyond index 2, Nat.nth Nat.Prime k = p can be proved by showing Nat.count Nat.Prime p = k (decidable) and applying Nat.nth_count.",
-      "**Axiom Triage:** Of the 4 parent axioms, 2 are routine (prime enumeration facts provable from Mathlib) and 2 are deep (PNT consequence and convex hull lemma). Eliminating the routine ones is high-value, low-cost work."
+      "Indexing bridge: nthPrime(n) = Nat.nth Nat.Prime (n-1) for n≥1; the shifted function λn. nthPrime(n+1) = λn. Nat.nth Nat.Prime n makes all Mathlib Nat.nth theorems directly applicable",
+      "Nat.nth_mem_of_infinite is the one-line key: if s is infinite and x = Nat.nth s k, then x ∈ s — this is exactly nthPrime_is_prime",
+      "The Nat.count + decide technique: to prove Nat.nth Nat.Prime 3 = 7, show Nat.count Nat.Prime 7 = 3 by decide, then apply Nat.nth_count. Generalizes to any prime beyond Mathlib's named constants",
+      "Axiom triage is the meta-lesson: 2 of 4 parent axioms were routine (Mathlib API unfamiliarity), 2 are genuinely deep (PNT consequence, discrete convex hull lemma). Separating these is as valuable as eliminating the routine ones",
+      "The log → product conversion chain (Real.log_mul, Real.log_pow, Real.log_lt_log_iff, exact_mod_cast) is a reusable pattern for proving multiplicative prime inequalities from additive log inequalities"
     ],
     "prerequisites": [
       "Number theory (primes, Nat.nth enumeration)",
@@ -109,35 +111,37 @@
   "sections": [
     {
       "id": "prime-sequence",
-      "title": "The Prime Sequence (Axiom-Free)",
+      "title": "Part I: The Prime Sequence (Axiom-Free)",
       "startLine": 36,
-      "endLine": 96,
-      "summary": "Defines the 1-indexed nthPrime and proves three facts that were axioms/sorry in the parent: nthPrime_is_prime via Nat.nth_mem_of_infinite, nthPrime_strictMono via Nat.nth_strictMono, and nthPrime_values using Mathlib's prime constants plus the Nat.count technique for p_4 = 7.",
-      "mathContext": "Proves nthPrime_is_prime, nthPrime_strictMono, and nthPrime_values from Mathlib's Nat.nth API, eliminating 2 axioms and 1 sorry from the parent file."
+      "endLine": 104,
+      "summary": "Defines nthPrime (1-indexed via Nat.nth Nat.Prime (n-1)) and proves three facts that were axioms/sorry in the parent. nthPrime_is_prime: Nat.nth_mem_of_infinite Nat.infinite_setOf_prime. nthPrime_strictMono: shifted form + Nat.nth_strictMono. nthPrime_values: Mathlib constants for p_1,p_2,p_3 and Nat.count+decide for p_4=7.",
+      "mathContext": "\\text{nthPrime}(n) = \\text{Nat.nth Nat.Prime}(n-1) \\quad (n \\geq 1)\\\\ \\text{nthPrime\\_is\\_prime: Nat.nth\\_mem\\_of\\_infinite}\\\\ \\text{nthPrime\\_strictMono: Nat.nth\\_strictMono}\\\\ p_1=2,\\; p_2=3,\\; p_3=5,\\; p_4=7\\; (\\text{Nat.nth\\_count})"
     },
     {
       "id": "remaining-axioms",
-      "title": "Remaining Axioms (Deep Results)",
-      "startLine": 98,
-      "endLine": 135,
-      "summary": "Retains 2 axioms from the parent: logPrime_ratio_tendsto_zero (PNT consequence) and pomerance_convex_hull_lemma (convex hull theory for discrete sequences). Documents why these remain axiomatized.",
-      "mathContext": "The PNT asymptotic log p_n / n -> 0 and Pomerance's convex hull vertex lemma require infrastructure beyond what's currently practical to formalize from Mathlib alone."
+      "title": "Part II: Remaining Axioms (Deep Results)",
+      "startLine": 106,
+      "endLine": 147,
+      "summary": "Retains 2 axioms from the parent: logPrime_ratio_tendsto_zero (PNT consequence: log p_n / n → 0) and pomerance_convex_hull_lemma (convex hull boundary lemma for sublinear sequences). Explains why each remains axiomatized and what infrastructure would be needed.",
+      "mathContext": "\\text{Axiom 1: } \\frac{\\log p_n}{n} \\to 0 \\quad (\\text{from PNT: } p_n \\sim n\\log n)\\\\ \\text{Axiom 2 (Pomerance 1979): } a_n = o(n) \\Rightarrow \\exists^\\infty n:\\; 2a_n > a_{n-i}+a_{n+i}\\; \\forall i\\\\ \\text{Lean gap: Nat.Prime.prime\\_counting\\_asymptotic not yet connected to 1-indexed nthPrime}"
     },
     {
       "id": "main-results",
-      "title": "Re-derived Main Results",
-      "startLine": 137,
-      "endLine": 195,
-      "summary": "Re-derives convexity_implies_product_bound and pomerance_1979 using the proved (not axiomatized) prime sequence facts, demonstrating that the main theorem chain works with fewer assumptions.",
-      "mathContext": "The full proof chain from convex hull vertices to p_n^2 > p_{n+i} p_{n-i} now rests on only 2 axioms instead of 4."
+      "title": "Part III: Re-derived Main Results (2 Axioms)",
+      "startLine": 148,
+      "endLine": 224,
+      "summary": "Re-derives convexity_implies_product_bound (log convexity → p_n² > p_{n+i}p_{n-i}) and pomerance_1979 (infinitely many such n) using the proved prime facts. The log→product conversion: Real.log_mul, Real.log_lt_log_iff, exact_mod_cast to ℤ. axiom_elimination_summary documents the 4→2 axiom reduction.",
+      "mathContext": "\\text{convexity\\_implies\\_product\\_bound: }\\\\ 2\\log p_n > \\log p_{n-i}+\\log p_{n+i} \\Rightarrow p_n^2 > p_{n+i}p_{n-i}\\\\ \\text{pomerance\\_1979: } \\forall N,\\; \\exists n\\geq N,\\; \\forall 0<i<n:\\; p_n^2 > p_{n+i}p_{n-i}\\\\ \\text{Axiom count: 4 (parent)} \\to \\text{2 (this file)}"
     }
   ],
   "conclusion": {
-    "summary": "Successfully reduced the axiom count of Erdős Problem #453 from 4 to 2 and eliminated the only sorry. The 2 eliminated axioms (nthPrime_is_prime, nthPrime_strictMono) and the sorry (nthPrime_values) were all provable from Mathlib's Nat.nth API. The 2 remaining axioms (logPrime_ratio_tendsto_zero, pomerance_convex_hull_lemma) require deep mathematical infrastructure.",
-    "implications": "The parent file's formalization is now stronger: the prime enumeration facts are machine-verified rather than assumed. Future work could target the remaining 2 axioms by connecting Mathlib's PNT to the logPrime ratio limit and formalizing discrete convex hull theory.",
+    "summary": "Axiom count reduced from 4 to 2, sorry count from 1 to 0. The key insight is that Mathlib's Nat.Data.Prime.Nth module contains exactly what was axiomatized — the 1-indexed → 0-indexed bridge unlocks Nat.nth_mem_of_infinite and Nat.nth_strictMono immediately. The 2 remaining axioms (PNT consequence and Pomerance's convex hull lemma) are genuinely hard and represent the mathematical core of the problem.",
+    "implications": "This formalization demonstrates the value of axiom triage: carefully separating routine API-gap axioms from mathematically deep axioms. The Nat.count + decide technique for proving concrete prime identities is a reusable pattern for any enumeration problem. The log → product conversion chain is a reusable blueprint for multiplicative prime inequalities.",
     "openQuestions": [
-      "Can logPrime_ratio_tendsto_zero be proved by connecting Mathlib's Prime Number Theorem to the 1-indexed nthPrime definition?",
-      "Can pomerance_convex_hull_lemma be proved by formalizing discrete convex hull vertex theory for sublinear sequences?"
+      "Can logPrime_ratio_tendsto_zero be proved by connecting Mathlib's Nat.Prime.prime_counting_asymptotic (PNT) to the 1-indexed nthPrime? The missing step is extracting log(p_n)/n → 0 from the density form π(n) ~ n/log n.",
+      "Can pomerance_convex_hull_lemma be proved by developing discrete convex hull theory for ℕ → ℝ sequences in Mathlib? The key ingredient is that a sublinear sequence must have infinitely many local convexity breakpoints.",
+      "Can the Nat.count + decide technique prove Nat.nth Nat.Prime k = p for arbitrarily large k? The decide call is O(p) in p (it counts primes ≤ p), so it works for small primes but would time out for large ones — is there a faster reflection-based approach?",
+      "What is the minimum Mathlib infrastructure needed to formalize Pomerance's full proof? Is there an existing Mathlib convex hull API (Mathlib.Analysis.Convex.Hull) that could be adapted to the discrete setting?"
     ]
   },
   "references": [


### PR DESCRIPTION
## Summary

Enriches `erdos-453-oq-02` (Erdős 453: Axiom Elimination for Prime Product Bound).

**Annotations added (6):**
- `ann-e453-indexing-bridge`: 1-indexed nthPrime = Nat.nth Nat.Prime (n-1); the bridge enabling all Mathlib Nat.nth API
- `ann-e453-primality-proof`: nthPrime_is_prime via Nat.nth_mem_of_infinite — one-line axiom elimination
- `ann-e453-monotonicity-proof`: nthPrime_strictMono via shifted sequence + Nat.nth_strictMono
- `ann-e453-nth-count`: Nat.count + decide technique for proving p_4 = 7 (and generalizing to arbitrary concrete primes)
- `ann-e453-log-product`: Log inequality → real inequality → integer inequality conversion chain
- `ann-e453-remaining-axioms`: PNT consequence and Pomerance's convex hull lemma — why they remain axiomatized

**Meta.json enhancements:**
- Expanded `historicalContext`: Erdős 1979, Pomerance's prime number graph and convex hull method, formalization backstory
- 5 `keyInsights` (was 3): added log→product pattern, axiom triage meta-lesson
- `mathContext` on all 3 sections with LaTeX formulas
- `conclusion.openQuestions`: 4 questions on PNT connection, discrete convex hull theory, decide scalability

🤖 Generated with [Claude Code](https://claude.com/claude-code)