### PR TITLE
Fix: erdos-1021-oq-01 sorry count 4→6 (includes parent dependencies)

### DIFF
--- a/src/data/proofs/erdos-1021-oq-01/meta.json
+++ b/src/data/proofs/erdos-1021-oq-01/meta.json
@@ -17,10 +17,10 @@
       "zarankiewicz"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 6,
     "axiomCount": 2,
     "lineCount": 191,
-    "assumptions": "2 axioms: (1) kst_trivial_bound — Kővári-Sós-Turán O(n^{3/2}) upper bound (proven 1954, axiomatized); (2) probabilistic_lower_bound — ex(n, G_k) ≥ c·n^{3/2-1/(k-1)} (probabilistic method, axiomatized). 4 sorries: k3 weak holds, k independence, uniform O() from o(), and limit computation.",
+    "assumptions": "2 axioms: (1) kst_trivial_bound — Kővári-Sós-Turán O(n^{3/2}) upper bound (proven 1954, axiomatized); (2) probabilistic_lower_bound — ex(n, G_k) ≥ c·n^{3/2-1/(k-1)} (probabilistic method, axiomatized). 6 sorries: 4 in this file (k3 weak holds, k independence, uniform O() from o(), limit computation) + 2 in imported Erdos1021Problem.lean (k3_case_solved, trivial_bound) which this file depends on.",
     "dateAdded": "2026-04-03",
     "mathlib_version": "4.26.0"
   },


### PR DESCRIPTION
## Fix

Update `erdos-1021-oq-01` sorries count from 4 to 6 to account for dependencies on sorries in the imported parent file.

## Evidence

**Before**: `"sorries": 4`
**After**: `"sorries": 6`

The OQ01 file explicitly depends on 2 sorries from the imported `Erdos1021Problem.lean`:
- `k3_case_solved` — line 127 of OQ01 comments: _"Requires k3_case_solved (itself a sorry in the parent)"_
- `trivial_bound` — KST upper bound, sorry in parent

Per CLAUDE.md policy, the total sorry count should reflect ALL sorry-based assumptions, including those inherited via imports that the proof explicitly depends on.

Breakdown: 4 (OQ01 own sorries) + 2 (parent dependencies) = 6.

---
Automated fix by lean-mechanic agent.