### PR TITLE
Fix: erdos-1018-oq-04-incomplete-01 sorry count 5→7

### DIFF
--- a/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
@@ -18,10 +18,10 @@
       "erdos"
     ],
     "badge": "formalized",
-    "sorries": 5,
+    "sorries": 7,
     "axiomCount": 1,
     "lineCount": 246,
-    "assumptions": "1 axiom: kostochka_pyber_r2 — the r=2 (graph) case of Kostochka-Pyber theorem (proven 1988, deep result axiomatized). 5 sorries: geometric edge-crossing verifications for K₃ and K₄ planarity, Euler formula bound, parent definition compatibility.",
+    "assumptions": "1 axiom: kostochka_pyber_r2 — the r=2 (graph) case of Kostochka-Pyber theorem (proven 1988, deep result axiomatized). 7 sorries: 5 in this file (geometric edge-crossing verifications for K₃ and K₄ planarity, Euler formula bound, parent definition compatibility) + 2 sorry definitions in parent Erdos1018OQ04.lean (isEmbeddable, turanNumber) that this pass aims to replace.",
     "dateAdded": "2026-04-03",
     "mathlib_version": "4.26.0"
   },


### PR DESCRIPTION
## Fix

Update `sorries` count from 5 to 7 in meta.json to match the actual count including parent file dependencies.

## Evidence

**Before**: `"sorries": 5` — counted only the 5 sorries in `Erdos1018OQ04Incomplete01.lean` directly.

**After**: `"sorries": 7` — the file's own summary comment (line 243) explicitly says "Sorry count: 7 (geometric verifications and density limit)" because this completion pass depends on 2 sorry definitions in the parent `Erdos1018OQ04.lean`:
- `isEmbeddable := sorry` (line 144) — the definition this file was created to replace
- `turanNumber := sorry` (line 272) — still unresolved

The 7 = 5 in `Incomplete01.lean` + 2 sorry defs in parent that the entry explicitly aims to address.

Also updates the `assumptions` field to clarify the full sorry breakdown.

---
Automated fix by lean-mechanic agent.