### PR TITLE
Fix: erdos-1146 axiomCount 2→5 (includes used parent axioms)

### DIFF
--- a/src/data/proofs/erdos-1146/meta.json
+++ b/src/data/proofs/erdos-1146/meta.json
@@ -61,7 +61,7 @@
       "Definition Erdos1146Conjecture (main open question)",
       "Proved growth_satisfies_ruzsa_necessary (rpow algebra: C·x² - x ≥ x^(3/2) for large x)"
     ],
-    "axiomCount": 2,
+    "axiomCount": 5,
     "prerequisites": [
       "erdos-37",
       "schnirelmann-density",
@@ -69,7 +69,7 @@
       "mann-theorem"
     ],
     "lineCount": 287,
-    "assumptions": "2 axiom(s): smooth23_not_lacunary (deep result about ratios of smooth numbers) and smooth23_schnirelmann_zero (Schnirelmann density of smooth numbers is 0). No sorries remain."
+    "assumptions": "5 axioms total: 2 declared in this file (smooth23_not_lacunary — deep result about ratios of smooth numbers; smooth23_schnirelmann_zero — Schnirelmann density of smooth numbers is 0) + 3 from imported Erdos37Problem.lean that are directly used in proofs (smooth23_counting — counting function ~ C·(log N)² used in growth_satisfies_ruzsa_necessary; mann_theorem — used in mann_lower_bound; erdos_37_disproved — used in single_prime_not_essential). No sorries remain."
   },
   "overview": {
     "historicalContext": "Imre Ruzsa posed this problem in 1999, building on his resolution of Erdős Problem #37 about essential components in additive number theory. A set $B \\subseteq \\mathbb{N}$ is an *essential component* if $\\sigma(A + B) > \\sigma(A)$ for every set $A$ with $0 < \\sigma(A) < 1$, where $\\sigma$ denotes the Schnirelmann density. Ruzsa proved that essential components must have counting function growth $\\geq (\\log N)^{1+c}$ for some $c > 0$, ruling out lacunary sets (which have counting function $O(\\log N)$).\n\nThe set $\\{2^m \\cdot 3^n : m, n \\geq 0\\}$ of 3-smooth numbers has counting function $\\sim C(\\log N)^2$, placing it exactly at the threshold with $c = 1$. Ruzsa called this 'the simplest set with a chance to be an essential component,' making it a natural test case for the boundary between essential and non-essential sets in additive combinatorics.",


### PR DESCRIPTION
## Fix

Update `axiomCount` from 2 to 5 in meta.json to reflect all axioms actually used in proofs.

## Evidence

**Before**: `"axiomCount": 2` — counted only the 2 axioms declared in `Erdos1146Problem.lean`.

**After**: `"axiomCount": 5` — `Erdos1146Problem.lean` imports and directly uses 3 axioms from `Erdos37Problem.lean` in theorem proofs:
- `smooth23_counting` — used at line 127 in `growth_satisfies_ruzsa_necessary`
- `mann_theorem` — used at line 215 in `mann_lower_bound`  
- `erdos_37_disproved` — used at line 285 in `single_prime_not_essential`

Plus 2 declared in the file itself (`smooth23_not_lacunary`, `smooth23_schnirelmann_zero`) = 5 total.

Note: 3 other axioms in `Erdos37Problem.lean` (`ruzsa_essential_component_lower_bound`, `ruzsa_essential_component_construction`, `schnirelmann_theorem`) are NOT used in `Erdos1146Problem.lean` proofs and are not counted.

Also updates the `assumptions` field to clarify the full axiom breakdown.

---
Automated fix by lean-mechanic agent.