### PR TITLE
Fix: erdos-1018-oq-04-incomplete-01 axiomCount 1→5 (inherited from OQ04)

### DIFF
--- a/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
@@ -19,9 +19,9 @@
     ],
     "badge": "formalized",
     "sorries": 7,
-    "axiomCount": 1,
+    "axiomCount": 5,
     "lineCount": 246,
-    "assumptions": "1 axiom: kostochka_pyber_r2 — the r=2 (graph) case of Kostochka-Pyber theorem (proven 1988, deep result axiomatized). 7 sorries: 5 in this file (geometric edge-crossing verifications for K₃ and K₄ planarity, Euler formula bound, parent definition compatibility) + 2 sorry definitions in parent Erdos1018OQ04.lean (isEmbeddable, turanNumber) that this pass aims to replace.",
+    "assumptions": "5 axioms total: 1 own (kostochka_pyber_r2 — the r=2 graph case of Kostochka-Pyber theorem, proven 1988) + 4 inherited from Erdos1018OQ04.lean (vanKampen_Flores — non-embeddability of r-skeleton of (2r+2)-simplex; triangle_planar — K₃ is planar; K4_planar — K₄ is planar; density_exceeds_turan — density bound for non-planar subgraphs). 7 sorries: 5 in this file (geometric edge-crossing verifications for K₃ and K₄) plus 2 from parent OQ04.",
     "dateAdded": "2026-04-03",
     "mathlib_version": "4.26.0"
   },


### PR DESCRIPTION
## Fix

Corrects `axiomCount` for `erdos-1018-oq-04-incomplete-01` from 1 to 5.

`Erdos1018OQ04Incomplete01.lean` imports `Erdos1018OQ04.lean`, which has 4 axioms:
- `vanKampen_Flores` — non-embeddability of r-skeleton of (2r+2)-simplex
- `triangle_planar` — K₃ is planar
- `K4_planar` — K₄ is planar
- `density_exceeds_turan` — density bound for non-planar subgraphs

Plus 1 own axiom (`kostochka_pyber_r2`) = **5 total**.

## Evidence

**Before**: `axiomCount: 1` (only counted own axiom)
**After**: `axiomCount: 5` (full count including 4 inherited from OQ04)

The sorry count (7) was already corrected by PR #9098.

---
Automated fix by lean-mechanic agent.