### PR TITLE
Enrich erdos-1002-oq-01: 10 annotations, 5 keyInsights, Cauchy distribution history

### DIFF
--- a/src/data/proofs/erdos-1002-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1002-oq-01/annotations.json
@@ -1,3 +1,124 @@
 {
-  "annotations": []
+  "annotations": [
+    {
+      "id": "ann-definitions",
+      "proofId": "erdos-1002-oq-01",
+      "range": { "startLine": 19, "endLine": 35 },
+      "type": "definition",
+      "title": "Core Definitions for Erdős #1002",
+      "content": "Four definitions mirror the parent Erdos1002Problem.lean formalization. `IsDistributionFunction` captures the three properties a CDF must satisfy: monotonicity, limit 0 at −∞, and limit 1 at +∞. `cauchyDistribution ρ c` is the Cauchy CDF scaled by ρ. `deviation x` measures how far the fractional part {x} deviates from 1/2. `innerSum α n` is the cumulative deviation sum S(α, n) = Σₖ₌₁ⁿ (1/2 − {αk}), central to Erdős Problem #1002.",
+      "mathContext": "$\\text{IsDistributionFunction}(g) \\iff g \\text{ monotone},\\ \\lim_{c\\to-\\infty} g(c)=0,\\ \\lim_{c\\to+\\infty} g(c)=1$",
+      "significance": "context",
+      "relatedConcepts": ["Cauchy distribution", "fractional parts", "Weyl sums", "distribution functions"],
+      "prerequisites": ["real analysis: monotonicity and limits", "number theory: fractional parts", "measure theory basics"]
+    },
+    {
+      "id": "ann-cauchy-monotone",
+      "proofId": "erdos-1002-oq-01",
+      "range": { "startLine": 39, "endLine": 44 },
+      "type": "technique",
+      "title": "Monotonicity via arctan Composition",
+      "content": "The Cauchy CDF g(c) = (1/π)arctan(ρc) + 1/2 is monotone because arctan is strictly monotone and ρ > 0. The `gcongr` tactic handles monotone inequalities compositionally: a ≤ b implies ρa ≤ ρb (scaling with nonneg ρ), which implies arctan(ρa) ≤ arctan(ρb) (by arctan_strictMono). The constant shift and positive scaling 1/π preserve the inequality.",
+      "mathContext": "$a \\leq b \\Rightarrow \\rho a \\leq \\rho b\\ (\\rho > 0) \\Rightarrow \\arctan(\\rho a) \\leq \\arctan(\\rho b) \\Rightarrow g(a) \\leq g(b)$",
+      "significance": "supporting",
+      "relatedConcepts": ["monotone functions", "composition of monotone functions", "arctan strictly monotone"],
+      "prerequisites": ["real analysis: monotonicity", "Mathlib: arctan_strictMono"]
+    },
+    {
+      "id": "ann-filter-scaling",
+      "proofId": "erdos-1002-oq-01",
+      "range": { "startLine": 46, "endLine": 62 },
+      "type": "technique",
+      "title": "Linear Scaling Preserves Filter Limits at ±∞",
+      "content": "Two helper lemmas establish that c ↦ ρc (with ρ > 0) sends atTop to atTop and atBot to atBot. These are needed to compose with arctan's limit theorems. Given bound b, take c ≥ b/ρ, then ρc ≥ b. The positive denominator ρ makes the division well-defined, and `field_simp` closes the algebraic goal ρ·(b/ρ) = b.",
+      "mathContext": "$\\rho > 0 \\Rightarrow (c \\to +\\infty \\Rightarrow \\rho c \\to +\\infty)$ and $(c \\to -\\infty \\Rightarrow \\rho c \\to -\\infty)$",
+      "significance": "technical",
+      "relatedConcepts": ["filter theory", "atTop filter", "Tendsto"],
+      "prerequisites": ["Mathlib filter theory", "real analysis: limits at infinity"]
+    },
+    {
+      "id": "ann-cauchy-limit-top",
+      "proofId": "erdos-1002-oq-01",
+      "range": { "startLine": 64, "endLine": 73 },
+      "type": "insight",
+      "title": "CDF Upper Limit: arctan Composition Reaches 1",
+      "content": "The Cauchy CDF's limit as c → +∞ is 1. The proof chains filter composition: ρc → +∞ (tendsto_mul_atTop), then arctan(ρc) → π/2 (Real.tendsto_arctan_atTop composed with scaling). The constant-function continuity lemma closes the arithmetic: (1/π)(π/2) + 1/2 = 1 by field_simp. The `convert` tactic bridges the computed limit at 1/π·π/2+1/2 to the target 1.",
+      "mathContext": "$\\lim_{c \\to +\\infty} \\left(\\frac{1}{\\pi}\\arctan(\\rho c) + \\frac{1}{2}\\right) = \\frac{1}{\\pi} \\cdot \\frac{\\pi}{2} + \\frac{1}{2} = 1$",
+      "significance": "key",
+      "relatedConcepts": ["arctan limits", "CDF normalization", "filter composition"],
+      "prerequisites": ["real analysis: limits", "Mathlib: tendsto_arctan_atTop"]
+    },
+    {
+      "id": "ann-cauchy-limit-bot",
+      "proofId": "erdos-1002-oq-01",
+      "range": { "startLine": 75, "endLine": 84 },
+      "type": "insight",
+      "title": "CDF Lower Limit: arctan Symmetry Gives Zero",
+      "content": "The lower limit follows by symmetry: ρc → −∞ sends arctan(ρc) → −π/2, so (1/π)(−π/2) + 1/2 = 0. Together with the upper limit, this confirms total probability mass 1. The Cauchy distribution's CDF symmetry about 0 — g(−c) = 1 − g(c) — is visible in the mirror structure of the two limit proofs.",
+      "mathContext": "$\\lim_{c \\to -\\infty} \\left(\\frac{1}{\\pi}\\arctan(\\rho c) + \\frac{1}{2}\\right) = \\frac{1}{\\pi} \\cdot \\left(-\\frac{\\pi}{2}\\right) + \\frac{1}{2} = 0$",
+      "significance": "key",
+      "relatedConcepts": ["Cauchy distribution symmetry", "probability normalization", "arctan antisymmetry"],
+      "prerequisites": ["real analysis: limits", "trigonometry: arctan at −∞"]
+    },
+    {
+      "id": "ann-cauchy-distribution-main",
+      "proofId": "erdos-1002-oq-01",
+      "range": { "startLine": 86, "endLine": 90 },
+      "type": "concept",
+      "title": "Cauchy CDF is a Proper Distribution Function",
+      "content": "The main theorem assembles the three sub-proofs into a single constructor. The Cauchy distribution, named after Augustin-Louis Cauchy (1789–1857), has density f(x) = ρ/(π(ρ²+x²)) and heavier-than-Gaussian tails — so heavy it has no finite mean or variance. Cauchy introduced it as a counterexample showing the law of large numbers can fail. Here, any scale parameter ρ > 0 yields a valid CDF.",
+      "mathContext": "$g(c) = \\frac{1}{\\pi}\\arctan(\\rho c) + \\frac{1}{2}$ is monotone with $g(-\\infty)=0$ and $g(+\\infty)=1$",
+      "significance": "key",
+      "relatedConcepts": ["Cauchy distribution", "heavy-tailed distributions", "law of large numbers counterexample"],
+      "prerequisites": ["probability theory: distribution functions", "real analysis"]
+    },
+    {
+      "id": "ann-deviation-int-shift",
+      "proofId": "erdos-1002-oq-01",
+      "range": { "startLine": 94, "endLine": 100 },
+      "type": "technique",
+      "title": "Fractional Part Invariance Under Integer Shifts",
+      "content": "The key number-theoretic lemma: deviation(x + n) = deviation(x) for any integer n. This follows from {x + n} = {x} — fractional parts are invariant under integer shifts, since ⌊x + n⌋ = ⌊x⌋ + n. In Lean, the proof unfolds `Int.fract` and uses `Int.floor_add_intCast`, then `ring` for arithmetic. The `push_cast` handles integer-to-real coercions.",
+      "mathContext": "$\\{x + n\\} = x + n - \\lfloor x + n \\rfloor = x + n - (\\lfloor x \\rfloor + n) = \\{x\\}$ for $n \\in \\mathbb{Z}$",
+      "significance": "key",
+      "relatedConcepts": ["fractional parts", "floor function", "three-distance theorem", "equidistribution"],
+      "prerequisites": ["number theory: fractional parts and floor function"]
+    },
+    {
+      "id": "ann-deviation-rational-periodic",
+      "proofId": "erdos-1002-oq-01",
+      "range": { "startLine": 102, "endLine": 109 },
+      "type": "technique",
+      "title": "Deviation Periodicity for Rational Multiples",
+      "content": "For rational α = p/q, the map k ↦ deviation(α(k+1)) has period q. The algebraic identity (p/q)((k+q)+1) = (p/q)(k+1) + p shows that evaluating at k+q adds the integer p to the argument, and deviation_add_int then gives equality. Lean's `push_cast` manages ℤ/ℕ/ℝ coercions, while `field_simp` proves (p/q)·q = p when q ≠ 0.",
+      "mathContext": "$\\frac{p}{q}((k+q)+1) = \\frac{p}{q}(k+1) + p \\Rightarrow \\text{deviation}\\!\\left(\\tfrac{p}{q}(k+q+1)\\right) = \\text{deviation}\\!\\left(\\tfrac{p}{q}(k+1)\\right)$",
+      "significance": "key",
+      "relatedConcepts": ["rational arithmetic", "Weyl equidistribution", "three-distance theorem"],
+      "prerequisites": ["number theory: fractional parts", "type coercions in Lean 4"]
+    },
+    {
+      "id": "ann-cyclic-sum",
+      "proofId": "erdos-1002-oq-01",
+      "range": { "startLine": 111, "endLine": 127 },
+      "type": "insight",
+      "title": "Cyclic Sum Lemma: Periodic Functions Sum Equally Over Any Complete Period",
+      "content": "A q-periodic function's sum over any q consecutive integers equals its sum over the first q. Proved by induction on the start offset: base case is trivial, inductive step uses `Finset.sum_range_succ` and `sum_range_succ'` to compare sums shifted by one. The extra term g(m+q) at the right equals g(m) at the left by periodicity, so `linarith` closes from the inductive hypothesis. This lemma is reusable for any Weyl-type sum over a periodic function.",
+      "mathContext": "$\\sum_{k=0}^{q-1} g(n+k) = \\sum_{k=0}^{q-1} g(k)$ for any $q$-periodic $g: \\mathbb{N} \\to \\mathbb{R}$",
+      "significance": "key",
+      "relatedConcepts": ["periodic functions", "Weyl sums", "Finset.sum_range_succ"],
+      "prerequisites": ["combinatorics: finite sums", "mathematical induction"]
+    },
+    {
+      "id": "ann-innersum-periodic",
+      "proofId": "erdos-1002-oq-01",
+      "range": { "startLine": 129, "endLine": 138 },
+      "type": "concept",
+      "title": "Inner Sum Periodicity: S(α, n+q) = S(α, n) + S(α, q)",
+      "content": "The main periodicity theorem: for rational α = p/q with gcd(p,q)=1, the inner sum satisfies S(α, n+q) = S(α, n) + S(α, q). The proof splits the sum using `Finset.sum_range_add`, then applies `cyclic_sum_periodic` to equate the shifted partial sum with S(α, q). The coprimality hypothesis gcd(p,q)=1 appears in the statement but is not used in the proof body — the periodicity holds for any p/q, suggesting the hypothesis is stronger than necessary.",
+      "mathContext": "$S(\\alpha, n+q) = \\sum_{k=0}^{n-1} d(k) + \\sum_{k=0}^{q-1} d(n+k) = S(\\alpha, n) + S(\\alpha, q)$, $d(k) = \\tfrac{1}{2} - \\{\\tfrac{p}{q}(k+1)\\}$",
+      "significance": "key",
+      "relatedConcepts": ["Weyl equidistribution theorem", "three-distance theorem", "discrepancy theory", "Erdős #1002"],
+      "prerequisites": ["number theory: fractional parts", "finite sum decomposition"]
+    }
+  ]
 }

--- a/src/data/proofs/erdos-1002-oq-01/meta.json
+++ b/src/data/proofs/erdos-1002-oq-01/meta.json
@@ -27,14 +27,16 @@
     "assumptions": "No axioms. All results proved from Mathlib: Cauchy CDF validity via arctan monotonicity and limits, inner sum periodicity via fractional part invariance under integer shifts."
   },
   "overview": {
-    "historicalContext": "This file proves two supporting results for Erdős Problem #1002 that were previously axiomatized:\n\n1. **Cauchy CDF validity**: The function g(c) = (1/π)arctan(ρc) + 1/2 is a valid distribution function — monotone with g(-∞) = 0 and g(+∞) = 1.\n\n2. **Inner sum periodicity**: For rational α = p/q, the inner sum S(α, n) = Σ(1/2 - {αk}) satisfies S(α, n+q) = S(α, n) + S(α, q).",
+    "historicalContext": "The Cauchy distribution was introduced by Augustin-Louis Cauchy (1789–1857) as a deliberate counterexample to Poisson's claim that the law of large numbers holds universally. Its density $f(x) = \\rho/(\\pi(\\rho^2+x^2))$ has tails so heavy that neither mean nor variance is finite, making it the canonical distribution to which the central limit theorem does not apply.\n\nThe inner sum $S(\\alpha, n) = \\sum_{k=1}^n (1/2 - \\{\\alpha k\\})$ appears in discrepancy theory and three-distance theorem research. For rational $\\alpha = p/q$, the fractional parts $\\{(p/q)k\\}$ cycle with period $q$, giving the relation $S(\\alpha, n+q) = S(\\alpha, n) + S(\\alpha, q)$. This is a direct consequence of the fundamental identity $\\{x + n\\} = \\{x\\}$ for integer $n$.\n\nBoth results were originally stated as axioms in the parent Erdős #1002 formalization. This companion file proves them from Mathlib, contributing to the long-term goal of reducing the axiom count from 7 toward 0. The remaining 5 axioms include deep ergodic and analytic results such as Kesten's theorem and Weyl equidistribution.",
     "problemStatement": "**Axiom Elimination**\n\nTwo axioms in Erdos1002Problem.lean are proved from Mathlib:\n\n1. `cauchy_is_distribution`: The Cauchy CDF g(c) = (1/π)arctan(ρc) + 1/2 is monotone with correct limits at ±∞.\n\n2. `innerSum_periodic_rational`: For rational α = p/q with gcd(p,q) = 1, S(p/q, n+q) = S(p/q, n) + S(p/q, q).",
     "text": "Proves the Cauchy CDF is a valid distribution function and the inner sum is periodic for rational arguments, eliminating 2 of 7 axioms from the Erdős #1002 formalization.",
     "proofStrategy": "**Cauchy CDF**: Monotonicity follows from arctan being strictly monotone (arctan_strictMono) composed with multiplication by ρ > 0. The limits use Real.tendsto_arctan_atTop/atBot composed with scaling, then algebraic simplification (1/π · π/2 + 1/2 = 1).\n\n**Periodic Sum**: The key insight is that deviation(p/q · k) has period q as a function of k, because p/q · (k+q) = p/q · k + p and fract(x + integer) = fract(x). A cyclic sum lemma then shows Σ g(n+k) = Σ g(k) for any periodic g, proved by induction using sum_range_succ and sum_range_succ'.",
     "keyInsights": [
-      "arctan is strictly monotone and tends to ±π/2, making (1/π)arctan(ρ·) + 1/2 a valid CDF",
-      "Fractional parts satisfy fract(x + n) = fract(x) for integer n, giving periodicity of the inner sum for rational α",
-      "Summing a periodic function over any complete period gives the same result, proved by induction"
+      "arctan is strictly monotone and tends to ±π/2, making (1/π)arctan(ρ·) + 1/2 a valid CDF for any scale parameter ρ > 0",
+      "Fractional parts satisfy {x + n} = {x} for integer n, giving the periodicity of the inner sum for rational α = p/q with period q",
+      "The cyclic sum lemma — that any q-periodic function sums equally over any q consecutive integers — is proved by induction using Finset.sum_range_succ and sum_range_succ', and is reusable for any Weyl-type sum",
+      "The coprimality hypothesis gcd(p,q) = 1 appears in the theorem statement but is not used in the formal proof body — the periodicity result holds for all integers p and naturals q ≥ 1",
+      "Filter composition is the key Lean technique: tendsto_mul_atTop/atBot composes with tendsto_arctan_atTop/atBot to derive the CDF limits, with convert handling the arithmetic simplification 1/π·(π/2)+1/2 = 1"
     ],
     "prerequisites": [
       "Real analysis: monotonicity, limits at infinity",
@@ -64,8 +66,9 @@
     "summary": "Two axioms from the Erdős #1002 formalization are proved from Mathlib, reducing the axiom count from 7 to 5. The Cauchy CDF validity follows from standard arctan properties, and the inner sum periodicity follows from the invariance of fractional parts under integer shifts.",
     "implications": "Reduces the assumption count in the Erdős #1002 formalization. The remaining 5 axioms include the open main conjecture, Kesten's deep ergodic result, Weyl equidistribution, and bounds for irrational α.",
     "openQuestions": [
-      "Can the remaining axioms (Weyl equidistribution, inner sum log bound) be proved from Mathlib?",
-      "Can Kesten's theorem be formalized from first principles?"
+      "Can the remaining axioms in Erdős #1002 — Weyl equidistribution and the inner sum log bound for irrational α — be proved from Mathlib?",
+      "Can Kesten's deep ergodic theorem on the behavior of S(α, n) for Liouville numbers α be formalized in Lean 4?",
+      "Is the coprimality condition gcd(p,q) = 1 truly needed for innerSum_periodic_rational, or can the hypothesis be dropped?"
     ]
   },
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for **erdos-1002-oq-01** (Erdős #1002 OQ-01: Proving Cauchy CDF and Periodic Sum Axioms).

## Changes

**annotations.json** — was empty, now has 10 annotations:
- All major proof sections covered with mathContext, significance, relatedConcepts, prerequisites
- Definitions, Cauchy monotonicity, filter scaling lemmas, CDF limits, fractional part invariance, rational periodicity, cyclic sum lemma, main theorems

**meta.json** improvements:
- `historicalContext`: expanded with Cauchy's original motivation (counterexample to law of large numbers), discrepancy theory context for inner sums, Weyl equidistribution relationship
- `keyInsights`: 3 → 5 entries, including filter composition technique and observation that coprimality hypothesis is unused in formal proof body
- `openQuestions`: 2 → 3, with more specific formulations pointing to Kesten's theorem and the unused coprimality condition

## Axiom Integrity

Status `verified` / badge `verified` / `axiomCount: 0` is accurate — this file has no `axiom` declarations and no assumption-carrying structures. Both theorems are proved from Mathlib.