### PR TITLE
Enrich Fubini/Green's Theorem OQ-01-01: 6 annotations, Fubini history

### DIFF
--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -923,6 +923,16 @@
       "passes": 1,
       "lastEnriched": "2026-04-03T14:07:48Z",
       "quality": 30
+    },
+    "erdos-1002-oq-01": {
+      "passes": 1,
+      "lastEnriched": "2026-04-03T22:44:36Z",
+      "quality": 32
+    },
+    "solution-of-cubic-oq-03-oq-02": {
+      "passes": 1,
+      "lastEnriched": "2026-04-03T22:44:37Z",
+      "quality": 45
     }
   },
   "elementary-quadratic-reciprocity-oq-03-oq-03": {

--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -923,16 +923,6 @@
       "passes": 1,
       "lastEnriched": "2026-04-03T14:07:48Z",
       "quality": 30
-    },
-    "erdos-1002-oq-01": {
-      "passes": 1,
-      "lastEnriched": "2026-04-03T22:44:36Z",
-      "quality": 32
-    },
-    "solution-of-cubic-oq-03-oq-02": {
-      "passes": 1,
-      "lastEnriched": "2026-04-03T22:44:37Z",
-      "quality": 45
     }
   },
   "elementary-quadratic-reciprocity-oq-03-oq-03": {

--- a/src/data/proofs/greens-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-fubini-interval-swap-signature",
+    "proofId": "greens-theorem-oq-01-oq-01",
+    "range": { "startLine": 42, "endLine": 46 },
+    "type": "definition",
+    "title": "intervalIntegral_swap: Fubini for Rectangles",
+    "content": "This theorem establishes that iterated interval integrals over a rectangle can be swapped, provided the integrand is measurable and integrable on the product region. The hypotheses encode the non-degeneracy of the rectangle (a ≤ b, c ≤ d) and the integrability conditions required for Fubini's theorem. This is the core technical engine behind the analytic content of Green's theorem in this formalization.",
+    "mathContext": "For $f : [a,b] \\times [c,d] \\to \\mathbb{R}$, the theorem establishes $\\int_c^d \\int_a^b f(x,y)\\,dx\\,dy = \\int_a^b \\int_c^d f(x,y)\\,dy\\,dx$ under measurability of $(x,y) \\mapsto f(x,y)$ and integrability on $[a,b] \\times [c,d]$ with the product of restricted Lebesgue measures.",
+    "significance": "key",
+    "relatedConcepts": ["Fubini's theorem", "iterated integrals", "product measure", "intervalIntegral", "Lebesgue integral"],
+    "prerequisites": ["Mathlib intervalIntegral API", "product measurability", "Integrable predicate"]
+  },
+  {
+    "id": "ann-fubini-set-integral-conversion",
+    "proofId": "greens-theorem-oq-01-oq-01",
+    "range": { "startLine": 48, "endLine": 53 },
+    "type": "technique",
+    "title": "Reducing Interval Integrals to Set Integrals via integral_of_le",
+    "content": "The proof bridges Mathlib's `intervalIntegral` API and its set integral API using `integral_of_le`, which converts an oriented interval integral `∫ x in a..b` into a set integral over `Ioc a b = (a,b]` when `a ≤ b`. The rw/simp_rw calls systematically push this conversion from the outermost to innermost integrals on both sides. This reduction is necessary because the Fubini machinery (`integral_integral_swap`) operates on Bochner integrals against product measures, not syntactic interval notation.",
+    "mathContext": "When $a \\le b$: $\\int_a^b f\\,dx = \\int_{(a,b]} f\\,d\\mu$ where $\\mu$ is Lebesgue measure restricted to $(a,b] = \\mathrm{Ioc}(a,b)$. The signed interval integral $\\int_a^b$ differs from $\\int_b^a$ by a sign, but for $a \\le b$ it agrees with the set integral.",
+    "significance": "technical",
+    "relatedConcepts": ["intervalIntegral.integral_of_le", "set integral", "Ioc", "oriented integral"],
+    "prerequisites": ["Mathlib interval integral API", "Ioc vs Icc distinction", "set integrals"]
+  },
+  {
+    "id": "ann-fubini-ioc-integrability",
+    "proofId": "greens-theorem-oq-01-oq-01",
+    "range": { "startLine": 61, "endLine": 65 },
+    "type": "technique",
+    "title": "Transferring Icc Integrability to Ioc via Measure Monotonicity",
+    "content": "Integrability on the closed rectangle `Icc a b × Icc c d` is transferred to the half-open rectangle `Ioc a b × Ioc c d` by exploiting measure monotonicity: `Ioc ⊆ Icc` implies the restricted measure is smaller, and `Integrable.mono_measure` propagates integrability to smaller measures. The `Measure.prod_mono` lemma applies monotonicity componentwise to the product measure. The two boundary points added/removed have measure zero, so this step is measure-theoretically trivial but syntactically necessary.",
+    "mathContext": "Since $(a,b] \\subseteq [a,b]$, we have $\\mu|_{(a,b]} \\le \\mu|_{[a,b]}$ as measures, so $f \\in L^1(\\mu|_{[a,b]} \\otimes \\mu|_{[c,d]})$ implies $f \\in L^1(\\mu|_{(a,b]} \\otimes \\mu|_{(c,d]})$ via $\\|f\\|_{L^1(\\text{small})} \\le \\|f\\|_{L^1(\\text{large})}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Measure.restrict_mono", "Ioc_subset_Icc_self", "Integrable.mono_measure", "null boundary"],
+    "prerequisites": ["measure restriction", "Icc vs Ioc", "Measure.prod_mono"]
+  },
+  {
+    "id": "ann-fubini-swap-core",
+    "proofId": "greens-theorem-oq-01-oq-01",
+    "range": { "startLine": 66, "endLine": 71 },
+    "type": "insight",
+    "title": "Fubini Applied: integral_integral_swap Closes the Goal",
+    "content": "All prior steps were scaffolding to reach this line: a single call to Mathlib's `MeasureTheory.integral_integral_swap`, which encapsulates Fubini's theorem for Bochner integrals on product measures. The `.symm` reverses the conclusion from LHS = RHS to RHS = LHS to match the goal orientation. Every conversion done above (interval → set integral, Icc → Ioc measure transfer) was precisely to put the goal in the form expected by this one lemma.",
+    "mathContext": "`integral_integral_swap` states: for integrable $f$ on $(X \\times Y, \\mu \\otimes \\nu)$, $\\int_X \\int_Y f(x,y)\\,d\\nu\\,d\\mu = \\int_Y \\int_X f(x,y)\\,d\\mu\\,d\\nu$. This is the abstract measure-theoretic Fubini theorem — the entire proof reduces to verifying its hypotheses.",
+    "significance": "key",
+    "relatedConcepts": ["MeasureTheory.integral_integral_swap", "Fubini-Tonelli theorem", "Bochner integral", "sigma-finite measure", "product measure"],
+    "prerequisites": ["Bochner integral", "product sigma-algebra", "sigma-finiteness of Lebesgue measure"]
+  },
+  {
+    "id": "ann-fubini-compact-integrability",
+    "proofId": "greens-theorem-oq-01-oq-01",
+    "range": { "startLine": 107, "endLine": 120 },
+    "type": "concept",
+    "title": "Continuous Functions on Compact Rectangles Are Automatically Integrable",
+    "content": "The `fubini_of_continuous` theorem eliminates the integrability hypothesis by exploiting compactness: the product `isCompact_Icc.prod isCompact_Icc` gives a compact rectangle, and `ContinuousOn.integrableOn_compact` immediately yields integrability for any continuous function. The final step `Measure.restrict_prod_eq_prod_restrict` converts the integrability statement from the form `IntegrableOn f (S ×ˢ T)` to the product-measure form required by `intervalIntegral_swap`.",
+    "mathContext": "For compact $K \\subset \\mathbb{R}^n$, any $f \\in C^0(K)$ satisfies $\\int_K |f|\\,d\\mu \\le \\mu(K) \\cdot \\sup_K |f| < \\infty$, so $f \\in L^1(K)$. Therefore continuous $f$ on $[a,b] \\times [c,d]$ is integrable, and Fubini applies without further conditions.",
+    "significance": "key",
+    "relatedConcepts": ["isCompact_Icc", "ContinuousOn.integrableOn_compact", "Measure.restrict_prod_eq_prod_restrict", "C⁰ implies L¹", "compact support"],
+    "prerequisites": ["compactness", "continuous function theory", "Lebesgue integrability on compact sets"]
+  },
+  {
+    "id": "ann-fubini-greens-c1-wrapper",
+    "proofId": "greens-theorem-oq-01-oq-01",
+    "range": { "startLine": 122, "endLine": 129 },
+    "type": "context",
+    "title": "Green's Theorem Fubini Step: The C¹ Corollary",
+    "content": "The `greens_fubini_for_C1` lemma is a one-line wrapper that packages the Fubini exchange for the C¹ setting of Green's theorem. In the proof of Green's theorem, switching the order of integration is precisely what converts a double integral of ∂Q/∂x − ∂P/∂y over a rectangle into iterated integrals that telescope to boundary values. This lemma isolates and names that exchange step, making its role in the Green's theorem proof explicit and reusable.",
+    "mathContext": "Green's theorem: $\\oint_{\\partial D} P\\,dx + Q\\,dy = \\iint_D \\left(\\frac{\\partial Q}{\\partial x} - \\frac{\\partial P}{\\partial y}\\right)dA$. The Fubini exchange on $\\frac{\\partial P}{\\partial y}$ allows $\\int_a^b \\int_c^d \\frac{\\partial P}{\\partial y}\\,dy\\,dx = \\int_c^d \\int_a^b \\frac{\\partial P}{\\partial y}\\,dx\\,dy$, enabling the inner integral to be evaluated by the fundamental theorem of calculus.",
+    "significance": "context",
+    "relatedConcepts": ["Green's theorem", "Stokes' theorem", "C¹ regularity", "partial derivatives", "fundamental theorem of calculus"],
+    "prerequisites": ["multivariable calculus", "Green's theorem statement", "C¹ differentiability"]
+  }
+]

--- a/src/data/proofs/greens-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01/meta.json
@@ -45,14 +45,16 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Fubini's theorem (1907) and its extension by Tonelli (1909) are fundamental results in measure theory that justify interchanging the order of integration in double integrals. The concrete version for iterated Riemann/Lebesgue integrals is essential for applications like Green's theorem.",
+    "historicalContext": "Fubini's theorem was proved by Guido Fubini in 1907, establishing that the double integral of an absolutely integrable function can be computed as an iterated integral in either order. Leonida Tonelli's 1909 extension (now called the Fubini-Tonelli theorem) relaxed the hypothesis from absolute integrability to nonnegativity, enabling the theorem to be used to prove integrability. The result was fundamental to the development of Lebesgue's integration theory and has been a cornerstone of modern analysis ever since. In Lean 4/Mathlib, the theorem appears as `MeasureTheory.integral_integral_swap` for Bochner integrals on product measures, but the gallery's Green's theorem formalization uses Mathlib's `intervalIntegral` API, which requires a concrete bridge. This file provides exactly that bridge: a three-step conversion (interval integral → set integral → product measure integral → Fubini → reverse) that makes the abstract theorem concrete enough for the rectangle integrals appearing in Green's theorem.",
     "problemStatement": "Can the hFubini hypothesis in GreensTheoremOQ01.lean be proved from Mathlib's measure-theoretic Fubini theorem?",
     "text": "Bridges Mathlib's abstract Fubini theorem to the concrete iterated interval integrals needed for Green's theorem.",
     "proofStrategy": "1. Convert intervalIntegral to set_integral on Ioc intervals\n2. Express iterated set_integral as a product measure integral\n3. Apply Mathlib's Fubini (MeasureTheory.integral_integral_swap)\n4. Convert back to interval integrals",
     "keyInsights": [
-      "**intervalIntegral ↔ set_integral**: The interval integral ∫ x in a..b is defined via Lebesgue integral on Ioc, with sign handling.",
-      "**Product measure**: The double integral over a rectangle equals the integral against the product measure, which is what Mathlib's Fubini theorem works with.",
-      "**C¹ sufficiency**: For C¹ vector fields (standard for Green's theorem), all measurability and integrability conditions are automatic."
+      "Mathlib's `integral_of_le` converts `∫ x in a..b` to a set integral over `Ioc a b` — this syntactic bridge is the key that unlocks the abstract Fubini theorem for concrete interval integrals",
+      "The Icc → Ioc measure transfer is measure-theoretically trivial (two boundary points have measure zero) but syntactically essential: `integral_integral_swap` requires the `Ioc` product, while the integrability hypothesis naturally comes in the `Icc` form",
+      "For C¹ vector fields (standard for Green's theorem), all measurability and integrability conditions are automatic via compactness: `isCompact_Icc.prod isCompact_Icc` + `ContinuousOn.integrableOn_compact`",
+      "The proof is a three-step pipeline: (1) convert to set integrals, (2) transfer integrability to smaller Ioc measure, (3) invoke `integral_integral_swap` — all steps are pure API manipulation with no new mathematics",
+      "The same bridge pattern (interval integral → set integral → Fubini → back) is reusable for any theorem that needs to swap integration order over a rectangle, not just Green's theorem"
     ]
   },
   "sections": [
@@ -97,8 +99,9 @@
     "summary": "The hFubini hypothesis in Green's theorem CAN be eliminated using Mathlib's Fubini theorem, under standard measurability/integrability conditions. For C¹ vector fields, these are automatic.",
     "implications": "With the intervalIntegral_swap proof completed, Green's theorem (OQ-01) becomes fully proved from Mathlib without any hypotheses about integration order.",
     "openQuestions": [
-      "Complete the intervalIntegral ↔ set_integral conversion to finish the proof",
-      "Can this bridge be generalized to n-dimensional iterated integrals?"
+      "Can this bridge be generalized to n-dimensional iterated integrals over hyperrectangles, providing a Fubini theorem for `∫ x₁ in a₁..b₁, ∫ x₂ in a₂..b₂, … ∫ xₙ in aₙ..bₙ, f(x₁,…,xₙ)`?",
+      "Does Mathlib contain (or could it be contributed) a version of `intervalIntegral_swap` as a standalone lemma, avoiding the need for each application to reimplement the Ioc/Icc conversion?",
+      "The integrability hypothesis uses the product of Icc-restricted measures. Can this be weakened to just L¹ integrability on the open rectangle `Ioo a b × Ioo c d`, and does Mathlib provide the necessary tools?"
     ]
   },
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for **greens-theorem-oq-01-oq-01** (Fubini's Theorem for Iterated Interval Integrals).

## Quality improvements

**Annotations** (was 0, now 6):
- `ann-fubini-interval-swap-signature`: Main theorem signature with full math context
- `ann-fubini-set-integral-conversion`: integral_of_le bridge, Ioc vs interval notation
- `ann-fubini-ioc-integrability`: Measure monotonicity for Icc→Ioc transfer
- `ann-fubini-swap-core`: integral_integral_swap as the core Fubini application
- `ann-fubini-compact-integrability`: Compactness + continuity → integrability pipeline
- `ann-fubini-greens-c1-wrapper`: Green's theorem context for the C¹ corollary

**meta.json**:
- `historicalContext`: Expanded with Fubini 1907, Tonelli 1909, and Mathlib API gap context
- `keyInsights`: 3 → 5 (three-step pipeline, Ioc/Icc distinction, reusability)
- Fixed `openQuestions[0]`: Removed stale "complete the proof" question (proof is done with 0 sorries)
- Added 3 genuine open questions: n-dim generalization, Mathlib contribution potential, Ioo weakening

## Axiom integrity
0 axiom declarations, 0 sorries, 0 structure-encoded assumptions. Status `verified` is correct.