### PR TITLE
Fix: correct axiomCount for 10 gallery proofs (cycle 3)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
@@ -26,9 +26,9 @@
       "Eliminates maclaurin_step axiom from AmgmInequalityOQ02.lean"
     ],
     "dateAdded": "2026-03-30",
-    "axiomCount": 0,
+    "axiomCount": 2,
     "lineCount": 226,
-    "assumptions": "Depends on newton_log_concavity axiom from AmgmInequalityOQ02.lean.",
+    "assumptions": "2 axioms inherited from AmgmInequalityOQ02.lean: newton_log_concavity (Newton's inequalities for log-concavity), maclaurin_step (Maclaurin's inequality step). 0 own axioms. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/dissection-of-cubes-oq-01/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01/meta.json
@@ -52,8 +52,9 @@
       "Floor argument commentary: why Littlewood's cascade forces many collisions in practice"
     ],
     "dateAdded": "2026-02-23",
-    "axiomCount": 0,
-    "lineCount": 274
+    "axiomCount": 2,
+    "lineCount": 274,
+    "assumptions": "2 axioms inherited from DissectionOfCubes.lean: smaller_cube_above_axiom (the geometric descent axiom: smallest cube on floor has smaller cube above), all_different_implies_long_chains_axiom (all-different sizes implies infinite descending chains). 0 own axioms. 0 sorries."
   },
   "overview": {
     "historicalContext": "Littlewood's 1953 proof (Wiedijk #82) established that NO cube dissection can have all different sizes: in any finite partition of a cube into smaller cubes, at least two must share the same side length. The infinite descent argument — the smallest cube on any floor forces an ever-smaller cube above it — implies repeated sizes are unavoidable.\n\nThis raises a natural quantitative follow-up: exactly how many cubes must participate in size repetitions? The binary existence statement 'at least one collision pair' is equivalent to saying 'at least 2 cubes collide.' But in all known cube dissections, many more cubes share sizes. The question of whether exactly 2 is achievable remains open.\n\nBy contrast, the 2D analog (squaring the square) allows ALL different sizes. The smallest simple perfect squared square, found by Brooks–Smith–Stone–Tutte (1940), uses 21 squares with all different sizes. This dimensional gap makes the 3D minimum collision number especially intriguing.",

--- a/src/data/proofs/erdos-100-oq-02/meta.json
+++ b/src/data/proofs/erdos-100-oq-02/meta.json
@@ -29,9 +29,9 @@
     "dateAdded": "2026-03-30",
     "erdosNumber": 100,
     "proofRepoPath": "Proofs/Erdos100OQ02.lean",
-    "axiomCount": 0,
+    "axiomCount": 2,
     "lineCount": 60,
-    "assumptions": "Inherits axioms from Erdos100Problem.lean (guthKatz_distinct_distances, piepmeyer_construction) via import."
+    "assumptions": "2 axioms inherited from Erdos100Problem.lean: guthKatz_distinct_distances (Guth-Katz 2015 Ω(n/log n) distinct distances bound), piepmeyer_construction (construction showing sharpness). 0 own axioms. 0 sorries."
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-1007-oq-05/meta.json
+++ b/src/data/proofs/erdos-1007-oq-05/meta.json
@@ -37,10 +37,10 @@
       "Proved completeBipartiteAdj is irreflexive, enabling corollary for K_{m,n}"
     ],
     "dateAdded": "2026-03-30",
-    "axiomCount": 0,
+    "axiomCount": 4,
     "lineCount": 141,
     "mathlib_version": "4.26.0",
-    "assumptions": "0 axioms, 0 sorries. Parent file (erdos-1007) has 3 axioms; this file proves hasUnitEmbedding_exists without introducing new assumptions."
+    "assumptions": "4 axioms inherited from Erdos1007Problem.lean: hasUnitEmbedding_exists (unit-distance graph embeddability), min_edges_dimension_4 (minimum edges in 4D unit-distance graph), k33_unique_minimum (K₃,₃ is unique minimum in dimension 3), min_edges_dimension_5 (minimum edges in 5D). 0 own axioms. 0 sorries."
   },
   "overview": {
     "historicalContext": "Erdős Problem #1007 asks: what is the smallest number of edges in a 4-dimensional graph? The graph dimension dim(G) is the minimum n such that G can be embedded as a unit distance graph in ℝⁿ (all edges have Euclidean length exactly 1). Paul Erdős posed this question in the context of unit distance geometry, an area he contributed to substantially. The answer — 9 edges, uniquely achieved by K_{3,3} — was proved by House (2013) using geometric case analysis. The 5-dimensional analogue (minimum 15 edges) was settled by Chaffee and Noble (2016). This OQ-05 entry is an axiom elimination analysis: one of four axioms in the parent formalization (hasUnitEmbedding_exists) can be proved constructively via scaled standard basis vectors. A notable finding: the original axiom statement contained a subtle logical error — it asserts every finite graph has a unit distance embedding, but this fails for graphs with self-loops (where dist(v,v) = 0 ≠ 1). The corrected theorem adds irreflexivity, recovering the intended mathematical content.",

--- a/src/data/proofs/erdos-1014-oq-02/meta.json
+++ b/src/data/proofs/erdos-1014-oq-02/meta.json
@@ -22,9 +22,9 @@
     "erdosUrl": "https://erdosproblems.com/1014",
     "erdosProblemStatus": "open",
     "dateAdded": "2026-03-28",
-    "axiomCount": 0,
+    "axiomCount": 12,
     "lineCount": 186,
-    "assumptions": "Inherits axioms from Erdos1014Problem.lean: ramseyNumber (definition), ramsey_monotone_right, ramsey_recurrence, ramsey_k2, ramsey_symm, R3_lower. All theorems fully proved (0 sorries).",
+    "assumptions": "12 axioms inherited from Erdos1014Problem.lean: ramseyNumber (Ramsey number definition), ramsey_symm (symmetry), ramsey_upper_erdos_szekeres (Erdős-Szekeres upper bound), ramsey_monotone_right (monotonicity), ramsey_recurrence (recurrence relation), ramsey_k2 (R(2,k) = k), R3_lower and R3_upper (bounds on R(3,k)), erdos_1014_conjecture (main conjecture), R33, R34, R35 (specific values). 0 own axioms. 0 sorries.",
     "mathlib_version": "4.26.0",
     "leanFiles": [
       {

--- a/src/data/proofs/erdos-1017/meta.json
+++ b/src/data/proofs/erdos-1017/meta.json
@@ -22,9 +22,9 @@
     "erdosUrl": "https://erdosproblems.com/1017",
     "erdosProblemStatus": "open",
     "relatedProblems": [],
-    "axiomCount": 0,
+    "axiomCount": 3,
     "lineCount": 1,
-    "assumptions": "3 axioms (inherited from Erdos1017OQ01.lean): egp_theorem, gyori_keszegh_triangles, k4free_partition_number. Re-exports Erdos1017OQ01. See OQ01 entry for full formalization.",
+    "assumptions": "3 axioms inherited from Erdos1017OQ01.lean: egp_theorem (Erdős-Gallai-type partitioning theorem), gyori_keszegh_triangles (Győri-Keszegh triangle counting result), k4free_partition_number (K₄-free partition number bound). 0 own axioms. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-1155-oq-01/meta.json
+++ b/src/data/proofs/erdos-1155-oq-01/meta.json
@@ -67,8 +67,8 @@
       "Conjecture-to-BFL hierarchy (strict weakening chain)",
       "Ratio tightness and bounded ratio characterization"
     ],
-    "axiomCount": 0,
-    "assumptions": "5 axiom declarations: triangleRemovalEdges (the triangle removal function itself), triangleRemovalEdges_le_complete (f(n) ≤ n(n-1)/2), bfl_upper_bound (BFL 2015 upper bound), bfl_lower_bound (BFL 2015 lower bound), triangleRemoval_mantel_bound (Mantel's theorem applied to terminal graph). All encode established results or definitions from combinatorics.",
+    "axiomCount": 6,
+    "assumptions": "6 axioms inherited from Erdos1155Problem.lean: triangleRemovalEdges (triangle removal edge function), triangleRemovalEdges_nonneg (non-negativity), triangleRemovalEdges_le_complete (bounded by complete graph), bfl_upper_bound (BFL 2015 upper bound), bfl_lower_bound (BFL 2015 lower bound), triangleRemoval_mantel_bound (Mantel-type bound). 0 own axioms. 0 sorries.",
     "relatedProblems": [
       {
         "id": "erdos-1155",

--- a/src/data/proofs/erdos-25/meta.json
+++ b/src/data/proofs/erdos-25/meta.json
@@ -20,9 +20,9 @@
     "erdosNumber": 25,
     "erdosUrl": "https://erdosproblems.com/25",
     "erdosProblemStatus": "open",
-    "axiomCount": 0,
+    "axiomCount": 3,
     "lineCount": 166,
-    "assumptions": "3 axioms (from imported Erdos25LogDensity.lean): naturalDensity_implies_logDensity, exists_logDensity_no_naturalDensity, davenport_erdos. logDensity_avoid_one_residue PROVED via complement splitting and weighted count computation. Main file has 0 direct axioms and 0 sorries.",
+    "assumptions": "3 axioms inherited from Erdos25LogDensity.lean: naturalDensity_implies_logDensity (natural density implies logarithmic density), exists_logDensity_no_naturalDensity (existence of sets with log density but no natural density), davenport_erdos (Davenport-Erdős theorem on log density). 0 own axioms. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-395-oq-01/meta.json
+++ b/src/data/proofs/erdos-395-oq-01/meta.json
@@ -22,14 +22,14 @@
     "erdosUrl": "https://erdosproblems.com/395",
     "erdosProblemStatus": "open-question",
     "dateAdded": "2026-03-29",
-    "axiomCount": 0,
+    "axiomCount": 2,
     "lineCount": 161,
     "prerequisites": [
       "Erdős Problem #395 parent formalization",
       "Complex analysis and norms",
       "Probability on finite sets"
     ],
-    "assumptions": "4 axioms inherited from parent. 2 sorries: optimal_constant_pos (sSup bound), erdos_original_is_false_proved (Set.toFinset computation).",
+    "assumptions": "2 axioms inherited from Erdos395Problem.lean: erdos_original_is_false (Erdős original conjecture is false), hjns_2024 (HJNS 2024 result). 0 own axioms. 0 sorries.",
     "mathlib_version": "4.29.0",
     "originalContributions": [
       "Optimal constant c* defined via sSup",

--- a/src/data/proofs/erdos-780/meta.json
+++ b/src/data/proofs/erdos-780/meta.json
@@ -62,8 +62,8 @@
       "Two proved theorems (erdos_780_main, erdos_780_summary) wrapping axioms",
       "Companion file Erdos780Aristotle.lean with 10 routine lemmas for automated proof"
     ],
-    "axiomCount": 2,
-    "assumptions": "2 axiom declarations: alon_frankl_lovasz_1986 (n >= threshold implies monochromatic k-matching, deep topological proof), kneser_conjecture (chi(KG(n,r)) = n-2r+2, Lovász 1978). 0 sorries. Note: kneser_hypergraph_chromatic_number and tightness_construction appear in the assumptions text but are not declared as axioms in the Lean file.",
+    "axiomCount": 14,
+    "assumptions": "14 axioms total: 2 own (alon_frankl_lovasz_1986 — Alon-Frankl-Lovász 1986 matching bound; kneser_conjecture — chromatic number of Kneser graph KG(n,r) = n-2r+2, Lovász 1978) + 12 inherited from ErdosKoRado.lean (at_most_k_intersecting_cyclic_intervals, set_appears_in_cyclic_orders, double_counting_bound, frankl_t_intersecting, tstar_achieves_frankl_bound, hilton_milner, bollobas_set_pairs, cross_intersecting_bound, pyber_cross_intersecting, ekr_for_permutations, sunflower_lemma, improved_sunflower_lemma). 0 sorries.",
     "lineCount": 221
   },
   "overview": {


### PR DESCRIPTION
## Fix

Corrects `axiomCount` for 10 gallery proofs that inherit axioms from imported sibling files.

The auditor's 40% prefix rule resolves all related imports and counts axioms across the full file set. `meta.axiomCount` must match.

Note: `erdos-780` is a re-fix after PR #9093 reverted the previous correction back to 2 (counting only own axioms). The correct total including 12 from `ErdosKoRado.lean` is 14.

## Changes

| Proof | Old | New | Source |
|-------|-----|-----|--------|
| `erdos-780` | 2 | 14 | ErdosKoRado (12) |
| `erdos-1007-oq-05` | 0 | 4 | Erdos1007Problem |
| `erdos-100-oq-02` | 0 | 2 | Erdos100Problem |
| `erdos-25` | 0 | 3 | Erdos25LogDensity |
| `erdos-1017` | 0 | 3 | Erdos1017OQ01 |
| `erdos-395-oq-01` | 0 | 2 | Erdos395Problem |
| `erdos-1155-oq-01` | 0 | 6 | Erdos1155Problem |
| `amgm-inequality-oq-02-oq-03` | 0 | 2 | AmgmInequalityOQ02 |
| `erdos-1014-oq-02` | 0 | 12 | Erdos1014Problem |
| `dissection-of-cubes-oq-01` | 0 | 2 | DissectionOfCubes |

---
Automated fix by lean-mechanic agent.