### PR TITLE
Enrich L'Hôpital ∞/∞ OQ-02: 7 annotations, Bernoulli history, fix sections

### DIFF
--- a/src/data/proofs/lhopital-oq-02/annotations.json
+++ b/src/data/proofs/lhopital-oq-02/annotations.json
@@ -1,1 +1,86 @@
-[]
+[
+  {
+    "id": "ann-lhop-overview",
+    "proofId": "lhopital-oq-02",
+    "range": { "startLine": 8, "endLine": 54 },
+    "type": "context",
+    "title": "Header: The Two-Variable Cauchy MVT Proof Strategy",
+    "content": "The header docstring explains why the ∞/∞ form requires a completely different proof from the 0/0 form. In the 0/0 case, Cauchy's MVT applies directly on [a, x] with the limit point a included. For ∞/∞, the functions diverge at a, so the MVT cannot be applied there. Instead, the proof fixes an auxiliary point x₀ between a and x, applies Cauchy's MVT on the compact interval [x, x₀], and relies on g → ∞ to make the correction terms involving g(x₀) and f(x₀) vanish.",
+    "mathContext": "The algebraic identity at the heart of the proof: $\\frac{f(x)}{g(x)} = \\frac{f(x)-f(x_0)}{g(x)-g(x_0)} \\cdot \\left(1 - \\frac{g(x_0)}{g(x)}\\right) + \\frac{f(x_0)}{g(x)}$. As $x \\to a^+$ with $x_0$ fixed: $f(x_0)/g(x) \\to 0$ and $g(x_0)/g(x) \\to 0$, so the ratio $f(x)/g(x)$ approaches the Cauchy MVT ratio $f'(\\xi)/g'(\\xi) \\to c$.",
+    "significance": "key",
+    "relatedConcepts": ["Cauchy's Mean Value Theorem", "L'Hôpital's rule 0/0 form", "indeterminate form ∞/∞", "two-variable argument"],
+    "prerequisites": ["Cauchy MVT", "filter-based limits in Mathlib", "HasDerivAt"]
+  },
+  {
+    "id": "ann-lhop-c0-signature",
+    "proofId": "lhopital-oq-02",
+    "range": { "startLine": 64, "endLine": 76 },
+    "type": "technique",
+    "title": "Private c=0 Lemma: Reducing the General Case",
+    "content": "The private theorem `lhopital_infty_right_zero` handles the special case where f'/g' → 0, avoiding the c parameter entirely. The general theorem then reduces to this via the substitution h(x) = f(x) − c·g(x), whose derivative ratio h'/g' = f'/g' − c tends to 0. This reduction is a standard trick that simplifies epsilon management: instead of tracking |f'/g' − c| < ε/2, we track |h'/g'| < ε/2.",
+    "mathContext": "If $f'/g' \\to c$, set $h = f - c \\cdot g$. Then $h'/g' = f'/g' - c \\to 0$ and $h(x)/g(x) = f(x)/g(x) - c$. So $f(x)/g(x) \\to c$ iff $h(x)/g(x) \\to 0$.",
+    "significance": "key",
+    "relatedConcepts": ["reduction to c=0", "epsilon management", "private theorem", "linear substitution"],
+    "prerequisites": ["HasDerivAt.sub", "HasDerivAt.const_mul", "Tendsto.sub"]
+  },
+  {
+    "id": "ann-lhop-delta-construction",
+    "proofId": "lhopital-oq-02",
+    "range": { "startLine": 79, "endLine": 115 },
+    "type": "technique",
+    "title": "Three-δ Construction: Finding x₀ and the Critical Bounds",
+    "content": "The proof uses three separate δ values, combined into a single δ₀ via min. δ₁ controls where f'/g' < ε/2. δ_gpos ensures g ≥ 1 (so g is positive and thus g ≠ 0). The anchor point x₀ = a + δ₀ is chosen inside (a,b) satisfying both. A third δ₂ ensures g(x) ≥ M where M = max(g(x₀)+1, 2|f(x₀)|/ε+1), which will force both correction terms to be small.",
+    "mathContext": "Need $x_0 \\in (a,b)$ with: (1) $|f'(\\xi)/g'(\\xi)| < \\varepsilon/2$ for $\\xi < x_0$, (2) $g(x_0) \\ge 1 > 0$. Then for $x < x_0$ close enough to $a$, need $g(x) \\ge M := \\max(g(x_0)+1,\\, 2|f(x_0)|/\\varepsilon + 1)$ to bound the correction terms.",
+    "significance": "technical",
+    "relatedConcepts": ["epsilon-delta argument", "Metric.tendsto_nhdsWithin_nhds", "Filter.tendsto_atTop", "min of deltas"],
+    "prerequisites": ["filter-based limit definitions", "Metric.tendsto_nhdsWithin_nhds", "tendsto_atTop"]
+  },
+  {
+    "id": "ann-lhop-cauchy-mvt",
+    "proofId": "lhopital-oq-02",
+    "range": { "startLine": 138, "endLine": 185 },
+    "type": "insight",
+    "title": "Cauchy's Mean Value Theorem Applied on [x, x₀]",
+    "content": "For fixed x < x₀, both f and g are continuous on [x, x₀] and differentiable on (x, x₀) (inherited from the hypotheses on (a,b)). Mathlib's `exists_ratio_deriv_eq_ratio_slope` (the Cauchy MVT) gives a point ξ ∈ (x, x₀) with (g(x₀)−g(x))·f'(ξ) = (f(x₀)−f(x))·g'(ξ). Since ξ < x₀ < a + δ₁, we have |f'(ξ)/g'(ξ)| < ε/2, giving the key bound on the MVT ratio.",
+    "mathContext": "Cauchy's MVT: for continuous $f,g$ on $[x,x_0]$ differentiable on $(x,x_0)$: $\\exists\\, \\xi \\in (x,x_0)$ with $(g(x_0)-g(x))\\cdot f'(\\xi) = (f(x_0)-f(x))\\cdot g'(\\xi)$, i.e., $\\frac{f(x_0)-f(x)}{g(x_0)-g(x)} = \\frac{f'(\\xi)}{g'(\\xi)}$. Since $\\xi < x_0$: $\\text{dist}(\\xi, a) < \\delta_1$, so $|f'(\\xi)/g'(\\xi)| < \\varepsilon/2$.",
+    "significance": "key",
+    "relatedConcepts": ["exists_ratio_deriv_eq_ratio_slope", "Cauchy MVT", "differentiableWithinAt", "DifferentiableOn"],
+    "prerequisites": ["Cauchy's Mean Value Theorem", "deriv vs HasDerivAt", "DifferentiableOn on Ioo"]
+  },
+  {
+    "id": "ann-lhop-algebraic-bound",
+    "proofId": "lhopital-oq-02",
+    "range": { "startLine": 186, "endLine": 224 },
+    "type": "insight",
+    "title": "Algebraic Identity and the ε/2 + ε/2 Bound",
+    "content": "The final calculation uses the algebraic identity f(x)/g(x) = [f'(ξ)/g'(ξ)] · [1 − g(x₀)/g(x)] + f(x₀)/g(x) to split the goal into two parts. For the first part: |f'(ξ)/g'(ξ)| < ε/2 and |1 − g(x₀)/g(x)| ≤ 1 (since 0 < g(x₀)/g(x) < 1). For the second: |f(x₀)/g(x)| < ε/2 since g(x) > 2|f(x₀)|/ε. The calc block chain makes each step explicit: abs_add, abs_mul, then the two separate bounds.",
+    "mathContext": "$|f/g| = |R(1-g(x_0)/g(x)) + f(x_0)/g(x)| \\le |R||1-g(x_0)/g(x)| + |f(x_0)|/g(x) \\le |R| \\cdot 1 + |f(x_0)|/g(x) < \\varepsilon/2 + \\varepsilon/2 = \\varepsilon$, where $R = f'(\\xi)/g'(\\xi)$ and $0 < g(x_0)/g(x) < 1$.",
+    "significance": "key",
+    "relatedConcepts": ["algebraic identity", "triangle inequality", "abs_add", "calc block", "epsilon split"],
+    "prerequisites": ["abs_add", "abs_mul", "div_lt_iff for positive denominators"]
+  },
+  {
+    "id": "ann-lhop-general-c",
+    "proofId": "lhopital-oq-02",
+    "range": { "startLine": 226, "endLine": 275 },
+    "type": "technique",
+    "title": "General c Case: Reducing to the c=0 Private Lemma",
+    "content": "The public theorem handles arbitrary c by defining h(x) = f(x) − c·g(x) and showing h'/g' → 0 via filter_upwards + field_simp. The key step uses Tendsto.sub and the fact that a constant function tends to c in order to get hdiv.sub tendsto_const_nhds, which after simp gives the zero limit. At the end, f(x)/g(x) = h(x)/g(x) + c (almost everywhere, where g ≠ 0), and since h/g → 0, the conclusion f/g → c follows via key.add tendsto_const_nhds.",
+    "mathContext": "Since $f'/g' \\to c$ and $c \\to c$: $h'/g' = (f'-c g')/g' = f'/g' - c \\to c - c = 0$. Then $f/g = h/g + c \\to 0 + c = c$. Everywhere $g(x) \\neq 0$ (which holds eventually since $g \\to +\\infty$).",
+    "significance": "supporting",
+    "relatedConcepts": ["filter_upwards", "Tendsto.sub", "tendsto_const_nhds", "Filter.tendsto_congr'"],
+    "prerequisites": ["filter-based limit arithmetic", "HasDerivAt.sub for h'", "almost-everywhere filter arguments"]
+  },
+  {
+    "id": "ann-lhop-variants",
+    "proofId": "lhopital-oq-02",
+    "range": { "startLine": 277, "endLine": 313 },
+    "type": "context",
+    "title": "Three Pending Variants: Left, atTop, atBot (3 Sorries)",
+    "content": "The three remaining variants (left approach, at +∞, at -∞) have complete formal statements but sorry proof bodies. Each is intended to reduce to the right-approach theorem via a change of variables: left approach via the reflection u = a + b − x, atTop via u = 1/(x−a) (which maps +∞ to a right neighborhood of 0), and atBot via u = −x. The sorry comments indicate the reduction strategy, making these good candidates for Aristotle proof search.",
+    "mathContext": "Left approach: substitute $u = a+b-x$, which maps $\\mathcal{N}^<[b]$ to $\\mathcal{N}^>[a]$ and reverses inequalities. AtTop: substitute $u = 1/x$, mapping $x \\to +\\infty$ to $u \\to 0^+$, with $f'(1/u)/g'(1/u) = $ a ratio tending to $c$. AtBot: substitute $u = -x$.",
+    "significance": "context",
+    "relatedConcepts": ["change of variables for limits", "Filter.tendsto_nhdsWithin_iff", "atTop vs nhdsWithin", "sorry"],
+    "prerequisites": ["right approach theorem", "filter map theorems", "substitution lemmas"]
+  }
+]

--- a/src/data/proofs/lhopital-oq-02/meta.json
+++ b/src/data/proofs/lhopital-oq-02/meta.json
@@ -59,36 +59,56 @@
   },
   "sections": [
     {
+      "id": "zero-case",
+      "title": "Private Lemma: c = 0 Case (Core Engine)",
+      "startLine": 64,
+      "endLine": 224,
+      "summary": "Private theorem proving g→∞, f'/g'→0 ⟹ f/g→0 via three-δ construction + Cauchy MVT on [x, x₀] + algebraic identity.",
+      "mathContext": "Three-δ: fix $x_0$ near $a$ with $|f'/g'|<\\varepsilon/2$ for $\\xi < x_0$, then ensure $g(x) \\ge M = \\max(g(x_0)+1, 2|f(x_0)|/\\varepsilon+1)$. Key identity: $f/g = (f'/g')\\cdot(1-g(x_0)/g) + f(x_0)/g$."
+    },
+    {
       "id": "right-approach",
-      "title": "∞/∞ L'Hôpital — Right Approach",
-      "startLine": 50,
-      "endLine": 100,
-      "summary": "Main theorem: if g → ∞ as x → a⁺ and f'/g' → c, then f/g → c. Proof uses two-variable Cauchy MVT argument."
+      "title": "Main Theorem: ∞/∞ L'Hôpital, Right Approach",
+      "startLine": 226,
+      "endLine": 275,
+      "summary": "Public theorem for general c: reduce to c=0 via h(x)=f(x)-c·g(x), then apply the private lemma and add c back.",
+      "mathContext": "$f/g \\to c$ iff $h/g = (f-c\\cdot g)/g \\to 0$, where $h'/g' = f'/g' - c \\to 0$."
     },
     {
       "id": "variants",
-      "title": "Additional Variants",
-      "startLine": 105,
-      "endLine": 145,
-      "summary": "Left approach, at +∞, and at -∞ variants, reducible to the right approach case."
+      "title": "Additional Variants (3 Sorries Pending)",
+      "startLine": 277,
+      "endLine": 313,
+      "summary": "Left approach (reflection u=a+b-x), atTop (inversion u=1/x), and atBot (negation u=-x) — all sorry bodies.",
+      "mathContext": "Each reduces to the right approach via a substitution that maps the limit direction to $\\mathcal{N}^+[a]$."
     },
     {
       "id": "examples",
-      "title": "Examples and Relationship to 0/0",
-      "startLine": 150,
-      "endLine": 195,
-      "summary": "Classic examples (x/eˣ, ln(x)/cot(x)) and explanation of why ∞/∞ needs a separate proof."
+      "title": "Classic Examples: x/eˣ and ln(x)/cot(x)",
+      "startLine": 315,
+      "endLine": 333,
+      "summary": "Two canonical ∞/∞ examples as commentary. x/eˣ → 0 (x→∞), ln(x)/cot(x) → 0 (x→0⁺)."
+    },
+    {
+      "id": "comparison",
+      "title": "Why ∞/∞ Needs a Different Proof from 0/0",
+      "startLine": 335,
+      "endLine": 357,
+      "summary": "Explains why the 0/0 Cauchy MVT at the limit point fails for ∞/∞, and why the two-variable argument is necessary.",
+      "mathContext": "For $0/0$: MVT on $[a,x]$ gives $f(x)/g(x) = (f(x)-f(a))/(g(x)-g(a)) = f'(\\xi)/g'(\\xi)$ directly. For $\\infty/\\infty$: $f(a), g(a)$ don't exist; must use MVT on $[x, x_0]$ with $x_0 > a$ as anchor."
     }
   ],
   "overview": {
-    "historicalContext": "L'Hôpital's rule was published in 1696 in the first calculus textbook. The 0/0 form is the most well-known, but the ∞/∞ form is equally fundamental. Both forms are consequences of Cauchy's Mean Value Theorem, but the ∞/∞ case requires a more delicate two-variable argument because the function values at the limit point don't exist (they're infinite).",
+    "historicalContext": "L'Hôpital's rule was published in 1696 in the Marquis de l'Hôpital's textbook Analyse des infiniment petits, the first calculus textbook ever printed. The result was actually discovered by Johann Bernoulli, who communicated it to l'Hôpital as part of a private tutoring arrangement. The 0/0 form was the primary focus in the 18th and 19th centuries, but the ∞/∞ form is equally fundamental and arises naturally in applications like computing lim(x→∞) x/eˣ = 0. The modern rigorous proof using Cauchy's Mean Value Theorem was developed in the 19th century. The ∞/∞ form requires a genuinely different two-variable argument because the functions diverge at the limit point, preventing the direct MVT application that works for 0/0. As of Mathlib 4.26.0, all 26 L'Hôpital variants in Mathlib handle only the 0/0 form — this formalization fills that gap with the complementary ∞/∞ form.",
     "problemStatement": "**∞/∞ L'Hôpital's Rule**: If f and g are differentiable near a, g(x) → ∞ as x → a⁺, g'(x) ≠ 0, and f'(x)/g'(x) → c, then f(x)/g(x) → c.",
     "text": "Formalize the ∞/∞ form of L'Hôpital's rule, complementing Mathlib's 0/0 form.",
     "proofStrategy": "The proof fixes x₀ near a, applies Cauchy's MVT on (x, x₀), and rewrites f(x)/g(x) as a combination of f'(ξ)/g'(ξ) (close to c) and correction terms f(x₀)/g(x) and g(x₀)/g(x) that vanish as g(x) → ∞.",
     "keyInsights": [
-      "**Only g → ∞ is needed**: Unlike naive reductions via 1/f and 1/g, the direct proof only requires g → ∞, not both f and g",
-      "**Two-variable argument**: Fix x₀, let x → a⁺, then optimize x₀ → a⁺. This is fundamentally different from the 0/0 proof",
-      "**Cauchy MVT is the core tool**: Same foundation as the 0/0 form, but applied differently"
+      "Only $g \\to \\infty$ is needed, not both $f$ and $g$: the proof only uses divergence of $g$ to make correction terms $f(x_0)/g(x)$ and $g(x_0)/g(x)$ vanish, never requiring $f \\to \\infty$",
+      "The key algebraic identity $f/g = [f'/g'] \\cdot [1-g(x_0)/g] + f(x_0)/g$ decomposes the ratio into an MVT term (close to $c$) and two correction terms (that vanish as $g \\to \\infty$) — this is the central insight of the two-variable argument",
+      "The bound $|1 - g(x_0)/g(x)| \\le 1$ (since $0 < g(x_0) < g(x)$) is crucial: it ensures the MVT term contributes at most $|f'/g'|$, even without knowing the bracket is small",
+      "The reduction to $c=0$ via $h = f - c \\cdot g$ is a bookkeeping simplification that transforms 'ratio tends to $c$' into 'ratio tends to 0', making the epsilon argument cleaner",
+      "The three pending sorry variants (left, atTop, atBot) are proof-structure exercises — they contain the substitution strategy in comments and should be closable by Aristotle or by direct filter manipulation"
     ],
     "prerequisites": [
       "Cauchy's Mean Value Theorem",
@@ -100,10 +120,12 @@
     ]
   },
   "conclusion": {
-    "summary": "The ∞/∞ L'Hôpital's rule is fully proved for the right approach case via two-variable Cauchy MVT. Three variants (left, at +∞, at -∞) have statements formalized with proof bodies pending (3 sorries).",
-    "implications": "Completing the proofs would fill a genuine gap in Mathlib's calculus library: 26 variants of the 0/0 form but zero variants of the ∞/∞ form.",
+    "summary": "The ∞/∞ L'Hôpital's rule is fully proved for the right approach ($x \\to a^+$) via two-variable Cauchy MVT with explicit epsilon management. Three variants (left approach, $x \\to +\\infty$, $x \\to -\\infty$) are formally stated with sorry proof bodies pending, each accompanied by the intended substitution strategy.",
+    "implications": "This formalization fills a genuine gap in Mathlib's calculus library: as of v4.26.0, all 26 L'Hôpital variants handle only the 0/0 form. The right-approach proof is complete and could be contributed to Mathlib immediately. The two-variable argument with explicit delta construction is a template applicable to other limit theorems where direct MVT application at the limit point fails.",
     "openQuestions": [
-      "Can the proof be done by reducing to the 0/0 form via substitution u = 1/g(x)?"
+      "Can the three pending sorry variants be closed by Aristotle proof search? The substitution strategy is spelled out in comments (reflection for left approach, inversion for atTop, negation for atBot) — these may be straightforward filter manipulations.",
+      "The 0/0 form can sometimes be reduced to the ∞/∞ form via $u = 1/f(x)$. Is there a clean formal proof that the two forms are logically equivalent (derivable from each other), or does each require its own independent epsilon-delta argument?",
+      "Mathlib's 26 L'Hôpital variants include different derivative hypotheses (HasDerivAt, HasStrictDerivAt, DifferentiableOn). Should the ∞/∞ variants be stated for each hypothesis style to match the existing API surface?"
     ]
   },
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for **lhopital-oq-02** (L'Hôpital's Rule: ∞/∞ Form).

## Quality improvements

**Annotations** (was 0, now 7):
- `ann-lhop-overview`: Two-variable Cauchy MVT proof strategy and algebraic identity
- `ann-lhop-c0-signature`: Why the c=0 reduction simplifies epsilon management
- `ann-lhop-delta-construction`: Three-δ construction (δ₁, δ_gpos, δ₂, anchor x₀)
- `ann-lhop-cauchy-mvt`: Cauchy MVT on [x, x₀] and the ξ < x₀ bound
- `ann-lhop-algebraic-bound`: The key identity f/g = R·(1-g₀/g) + f₀/g and ε/2+ε/2 bound
- `ann-lhop-general-c`: Reduction to c=0 via h=f-c·g using filter arithmetic
- `ann-lhop-variants`: Three pending sorry variants with substitution strategies

**meta.json**:
- `historicalContext`: Added Johann Bernoulli authorship, Mathlib gap (26 variants for 0/0, 0 for ∞/∞)
- `keyInsights`: 3 → 5 (algebraic identity insight, |1-g₀/g|≤1 bound observation)
- **Fixed section line numbers** — were off by ~150 lines; added 2 new sections (examples, comparison)
- `conclusion.openQuestions`: 1 → 3 (Aristotle automation, 0/0↔∞/∞ equivalence, Mathlib API surface)

## Axiom integrity
0 axiom declarations. 3 sorries (left approach, atTop, atBot — documented in sections). Status `formalized` is correct.