### PR TITLE
Fix: correct axiomCount for 2 borsuk-ulam proofs with inherited axioms

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-04/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-04/meta.json
@@ -37,8 +37,8 @@
       "fh_z4_bound and fh_z6_bound: proved from parent monotonicity",
       "fh_extends_monotonicity: proved that FH subsumes monotonicity"
     ],
-    "axiomCount": 0,
-    "assumptions": "0 local axiom declarations. All proofs use parent module BorsukUlamOQ02OQ01 axioms (buDim, buDim_prime, buDim_mono, etc.). Former axioms fh_point and fh_sphere_free_action are now proved theorems (by rfl). Former axioms fh_monotonicity and fh_restriction were logically unsound (asserted unconditional inequalities) and removed.",
+    "axiomCount": 4,
+    "assumptions": "4 axioms inherited from BorsukUlamOQ02OQ01.lean: buDim (Borsuk-Ulam dimension function), buDim_two (dimension 2 case), buDim_prime (prime dimension case), buDim_mono (monotonicity of buDim). 0 own axioms. 0 sorries.",
     "lineCount": 251
   },
   "overview": {

--- a/src/data/proofs/borsuk-ulam-oq-04/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-04/meta.json
@@ -17,9 +17,9 @@
     ],
     "badge": "wip",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 300,
-    "assumptions": "3 axiom(s): sphere_double_cover, fundamental_group_RPn, covering_space_obstruction. See Lean source for complete statements.",
+    "assumptions": "1 axiom inherited from BorsukUlam.lean: no_continuous_odd_nonzero_on_sphere (no continuous odd function from sphere is everywhere nonzero — the Borsuk-Ulam theorem). 0 own axioms. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Fix

Corrects `axiomCount` for 2 Borsuk-Ulam proofs that inherit axioms from parent imports.

## Changes

| Proof | Old | New | Source |
|-------|-----|-----|--------|
| `borsuk-ulam-oq-02-oq-01-oq-04` | 0 | 4 | BorsukUlamOQ02OQ01 (4 axioms: buDim, buDim_two, buDim_prime, buDim_mono) |
| `borsuk-ulam-oq-04` | 0 | 1 | BorsukUlam (1 axiom: no_continuous_odd_nonzero_on_sphere) |

---
Automated fix by lean-mechanic agent.