### PR TITLE
Enrich 4 proofs: subset-count-oq-02, ballot-problem-oq-03-oq-01, cayley-hamilton-minpoly-oq-05-oq-01-oq-01, binomial-theorem-oq-02-oq-02

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/lebesgue-measure-oq-01-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-thomae-def",
+    "proofId": "lebesgue-measure-oq-01-oq-01",
+    "range": { "startLine": 49, "endLine": 59 },
+    "type": "definition",
+    "title": "Thomae's Function via Classical Choice",
+    "content": "Thomae's function is defined by case-splitting on whether x is rational: if x = p/q in reduced form, return 1/q; otherwise return 0. The Lean definition uses `h.choose.den` to extract the denominator of the canonical rational representative, exploiting Lean's classical choice principle.",
+    "mathContext": "$$f(x) = \\begin{cases} \\frac{1}{q} & \\text{if } x = \\frac{p}{q} \\text{ in lowest terms}, \\\\ 0 & \\text{if } x \\in \\mathbb{R} \\setminus \\mathbb{Q}. \\end{cases}$$\nIn Lean: `if h : ∃ q : ℚ, (q : ℝ) = x then 1 / (h.choose.den : ℝ) else 0`.",
+    "significance": "The use of `h.choose` (Hilbert's epsilon) to extract the unique rational representative makes the definition noncomputable but mathematically clean. The `.den` field of a Lean `ℚ` is always positive and gives the reduced denominator.",
+    "relatedConcepts": ["rational-number-representation", "classical-choice", "noncomputable-definition", "reduced-fraction"],
+    "prerequisites": ["Lean 4 classical choice", "ℚ.den field", "Rat.cast embedding ℚ → ℝ"]
+  },
+  {
+    "id": "ann-zero-at-irrationals",
+    "proofId": "lebesgue-measure-oq-01-oq-01",
+    "range": { "startLine": 61, "endLine": 82 },
+    "type": "theorem",
+    "title": "Zero at Irrationals, Nonneg and Bounded",
+    "content": "Three basic properties are established: (1) f vanishes at every irrational by the `dif_neg` rewrite — the `else` branch triggers. (2) f ≥ 0 everywhere: both branches give nonneg values (`1/q > 0` and `0`). (3) f ≤ 1 since `1/q ≤ 1` for positive integer denominators `q ≥ 1`.",
+    "mathContext": "For $x \\in \\mathbb{R} \\setminus \\mathbb{Q}$: $f(x) = 0$. For all $x$: $0 \\leq f(x) \\leq 1$. In particular $f(1/q) = 1/q \\leq 1$ since $\\mathrm{den}(p/q) \\geq 1$.",
+    "significance": "These bounds are needed for measurability arguments and comparisons. The proof of `thomae_le_one` uses `div_le_one_of_le` with the positivity of `.den`, a typical Mathlib rational arithmetic pattern.",
+    "relatedConcepts": ["irrational-numbers", "function-bounds", "positivity-tactic"],
+    "prerequisites": ["Irrational definition in Mathlib", "div_le_one_of_le lemma"]
+  },
+  {
+    "id": "ann-support-in-rationals",
+    "proofId": "lebesgue-measure-oq-01-oq-01",
+    "range": { "startLine": 87, "endLine": 103 },
+    "type": "insight",
+    "title": "Support is Contained in the Countable Rationals",
+    "content": "The key structural lemma: the support of Thomae's function (set where f ≠ 0) is a subset of ℚ, embedded in ℝ. The proof is by contraposition — if x has no rational representative, the `dif_neg` branch sets f(x) = 0. Since ℚ is countable and countable sets have Lebesgue measure zero, the support has measure zero.",
+    "mathContext": "$$\\{x \\in \\mathbb{R} : f(x) \\neq 0\\} \\subseteq \\mathbb{Q} \\hookrightarrow \\mathbb{R}$$\n$$\\lambda(\\mathbb{Q}) = 0 \\implies \\lambda(\\{f \\neq 0\\}) = 0 \\implies f = 0 \\text{ a.e.}$$\nIn Lean: `measure_mono_null thomae_support_subset_rationals (Set.Countable.measure_zero ...)` gives `volume {x | thomae x ≠ 0} = 0`.",
+    "significance": "This is the entire content of the almost-everywhere argument. Countability → measure zero → integral zero is the three-step pipeline that makes both Thomae and Dirichlet functions trivially integrate to zero under Lebesgue theory.",
+    "relatedConcepts": ["support-of-function", "countable-set", "measure-zero", "Set.countable_range"],
+    "prerequisites": ["Set.Countable.measure_zero", "measure_mono_null", "Rat.cast countable range"]
+  },
+  {
+    "id": "ann-integral-zero",
+    "proofId": "lebesgue-measure-oq-01-oq-01",
+    "range": { "startLine": 109, "endLine": 118 },
+    "type": "theorem",
+    "title": "Main Result: Lebesgue Integral Equals Zero",
+    "content": "The main theorem `thomae_integral_zero` follows in one line from `integral_eq_zero_of_ae thomae_ae_zero`. The unit interval restriction `thomae_integral_unit_interval` follows from `ae_restrict_of_ae`, which transfers the global a.e. zero property to any measurable subset.",
+    "mathContext": "$$\\int_{\\mathbb{R}} f \\, d\\lambda = 0, \\qquad \\int_0^1 f \\, d\\lambda = 0.$$\nProof sketch: $f = 0$ a.e. $\\Longrightarrow$ $\\int f = \\int 0 = 0$. Formally: `integral_eq_zero_of_ae : (∀ᵐ x, f x = 0) → ∫ f = 0`.",
+    "significance": "The proof is a one-liner — all the work was done in establishing the a.e. zero property. This illustrates how Lebesgue integration dramatically simplifies arguments about functions with countable exceptional sets.",
+    "relatedConcepts": ["integral_eq_zero_of_ae", "ae_restrict_of_ae", "Lebesgue-integration"],
+    "prerequisites": ["MeasureTheory.integral_eq_zero_of_ae", "Filter.Eventually (ae)", "ae_restrict_of_ae"]
+  },
+  {
+    "id": "ann-riemann-lebesgue-contrast",
+    "proofId": "lebesgue-measure-oq-01-oq-01",
+    "range": { "startLine": 20, "endLine": 39 },
+    "type": "insight",
+    "title": "Riemann vs Lebesgue: The Key Contrast",
+    "content": "Thomae's function is a canonical example distinguishing Riemann and Lebesgue integration. It is Riemann integrable with integral 0 — provable by the ε-δ argument that for any ε > 0, only finitely many denominators q satisfy 1/q > ε. Yet the Lebesgue proof is far simpler: f = 0 a.e. requires no epsilon-delta reasoning, just countability of ℚ.",
+    "mathContext": "Riemann: For all $\\varepsilon > 0$, $|\\{q \\in \\mathbb{N} : 1/q > \\varepsilon\\}|$ is finite, so the set of jump discontinuities above $\\varepsilon$ is finite — manageable for Riemann sums. This gives $\\int_0^1 f \\, dx = 0$ (Riemann).\n\nLebesgue: $f = 0$ $\\lambda$-a.e. since $\\lambda(\\mathbb{Q}) = 0$. The integral follows trivially, without any epsilon-delta argument.",
+    "significance": "This contrast is why Lebesgue integration is considered more powerful: properties like 'zero almost everywhere' automatically propagate to integrals, bypassing detailed analysis of discontinuities. The Lebesgue integral handles all bounded measurable functions, while Riemann requires controlled discontinuities.",
+    "relatedConcepts": ["Riemann-integrability", "Lebesgue-theory", "discontinuities", "epsilon-delta"],
+    "prerequisites": ["Riemann integrability criteria (Lebesgue's criterion)", "Lebesgue measure", "a.e. convergence"]
+  },
+  {
+    "id": "ann-comparison-dirichlet",
+    "proofId": "lebesgue-measure-oq-01-oq-01",
+    "range": { "startLine": 124, "endLine": 153 },
+    "type": "connection",
+    "title": "Pointwise Ordering: Thomae ≤ Dirichlet",
+    "content": "The standard Dirichlet function is the indicator 1_ℚ (returns 1 for rationals, 0 for irrationals). Thomae refines this: at rational p/q it returns 1/q ≤ 1. The theorem `thomae_le_dirichlet` captures this pointwise inequality, and `dirichlet_integral_zero` shows both integrate to 0. The comparison reinforces that the integral vanishes independently for each function by the same measure-zero argument.",
+    "mathContext": "Define the standard Dirichlet function $D(x) = \\mathbf{1}_{\\mathbb{Q}}(x)$. Then:\n$$f(x) = \\frac{1}{q} \\leq 1 = D(x) \\quad \\text{for } x = p/q,$$\n$$f(x) = 0 = D(x) \\quad \\text{for } x \\in \\mathbb{R} \\setminus \\mathbb{Q}.$$\nSo $f \\leq D$ pointwise. Both satisfy $\\int f = \\int D = 0$ since $\\lambda(\\mathbb{Q}) = 0$.",
+    "significance": "The comparison shows Thomae's function sits 'between' the zero function and the standard Dirichlet function. The same proof strategy (countability → measure zero → integral zero) works for any function with countable support, illustrating a general principle of Lebesgue theory.",
+    "relatedConcepts": ["Dirichlet-function", "indicator-function", "pointwise-inequality", "dominated-convergence"],
+    "prerequisites": ["Standard Dirichlet function definition", "measure_mono_null for support"]
+  }
+]

--- a/src/data/proofs/lebesgue-measure-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-01-oq-01/meta.json
@@ -26,13 +26,15 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Thomae's function (also called the popcorn function or modified Dirichlet function) was introduced by Carl Johannes Thomae in 1875. It assigns f(p/q) = 1/q for rationals in lowest terms and f(x) = 0 for irrationals. Unlike the standard Dirichlet function, Thomae's function is Riemann integrable — it is continuous at every irrational and discontinuous at every rational. This formalization shows the Lebesgue integral is 0 via the measure-zero argument.",
+    "historicalContext": "Thomae's function was introduced by Carl Johannes Thomae in 1875 and later rediscovered independently many times, earning names like the 'popcorn function', 'raindrop function', and 'ruler function'. It was historically significant as an example of a function that is Riemann integrable despite having a dense set of discontinuities — challenging early intuitions about integration. Dirichlet's 1829 indicator function 1_ℚ, by contrast, is not Riemann integrable. Lebesgue's 1902 theory of integration finally unified these cases: both functions are zero a.e. (since ℚ has measure zero), so both have Lebesgue integral 0. The measure-zero argument, unavailable to Riemann, makes Lebesgue's approach dramatically simpler.",
     "problemStatement": "Prove that the modified Dirichlet function f(x) = 1/q for x = p/q in lowest terms (f(x) = 0 for irrational x) has Lebesgue integral 0 over ℝ and over [0,1].",
     "proofStrategy": "The proof uses the same strategy as the parent OQ01 (standard Dirichlet function): since Thomae's function is zero on irrationals and the rationals have Lebesgue measure zero, f = 0 almost everywhere. Then integral_eq_zero_of_ae gives ∫ f = 0.",
     "keyInsights": [
-      "**Same core argument**: Both the standard and modified Dirichlet functions are zero a.e., so both have integral 0",
-      "**Thomae ≤ Dirichlet pointwise**: The modified version is bounded above by the standard Dirichlet function",
-      "**Riemann vs Lebesgue**: Thomae's function is Riemann integrable (unlike the standard Dirichlet function), but the Lebesgue argument is simpler — no epsilon-delta needed"
+      "**Countable support → measure zero → integral zero**: The three-step pipeline applies to any function with countable support, whether Thomae or Dirichlet",
+      "**Lebesgue simpler than Riemann here**: The Lebesgue proof is a one-liner (`integral_eq_zero_of_ae`); the Riemann proof requires tracking finitely-many large denominators per ε",
+      "**Thomae ≤ Dirichlet pointwise**: f(p/q) = 1/q ≤ 1 = D(p/q), so Thomae is dominated by the indicator of ℚ — yet both integrate to 0",
+      "**Classical choice extracts the denominator**: The `.den` field of Lean's ℚ gives the reduced denominator; `h.choose.den` makes the definition noncomputable but canonical",
+      "**ae_restrict_of_ae transfers the result to [0,1]**: The global a.e. zero property restricts to any measurable subset with no additional work"
     ],
     "prerequisites": [
       "Lebesgue measure and integration",
@@ -46,35 +48,40 @@
       "title": "Part I: The Thomae Function",
       "startLine": 1,
       "endLine": 75,
-      "summary": "Defines `thomae : ℝ → ℝ` via classical choice on rational representation. Proves basic properties: zero at irrationals, nonneg, bounded by 1."
+      "summary": "Defines `thomae : ℝ → ℝ` via classical choice on rational representation. Proves basic properties: zero at irrationals, nonneg, bounded by 1.",
+      "mathContext": "$$f(x) = \\begin{cases} 1/q & x = p/q \\text{ reduced}, \\\\ 0 & x \\in \\mathbb{R} \\setminus \\mathbb{Q}. \\end{cases}$$\nBasic bounds: $0 \\leq f(x) \\leq 1$ for all $x \\in \\mathbb{R}$."
     },
     {
       "id": "ae-zero",
       "title": "Part II: Zero Almost Everywhere",
       "startLine": 76,
-      "endLine": 100,
-      "summary": "Proves support ⊆ ℚ (countable, measure zero), hence thomae = 0 a.e."
+      "endLine": 103,
+      "summary": "Proves support ⊆ ℚ (countable, measure zero), hence thomae = 0 a.e.",
+      "mathContext": "$$\\{x : f(x) \\neq 0\\} \\subseteq \\mathbb{Q}, \\quad \\lambda(\\mathbb{Q}) = 0 \\implies f = 0 \\; \\lambda\\text{-a.e.}$$\nKey Mathlib lemma: `Set.Countable.measure_zero` applied to `Set.countable_range (Rat.cast : ℚ → ℝ)`."
     },
     {
       "id": "integral",
       "title": "Part III: The Lebesgue Integral",
-      "startLine": 101,
-      "endLine": 120,
-      "summary": "Main result: ∫ thomae = 0 via integral_eq_zero_of_ae. Unit interval version proved via ae_restrict_of_ae."
+      "startLine": 104,
+      "endLine": 118,
+      "summary": "Main result: ∫ thomae = 0 via integral_eq_zero_of_ae. Unit interval version proved via ae_restrict_of_ae.",
+      "mathContext": "$$\\int_{\\mathbb{R}} f \\, d\\lambda = 0, \\qquad \\int_0^1 f \\, d\\lambda = 0.$$\nOne-line proof: `integral_eq_zero_of_ae thomae_ae_zero`. Restriction to $[0,1]$: `ae_restrict_of_ae thomae_ae_zero`."
     },
     {
       "id": "comparison",
       "title": "Part IV: Comparison with Standard Dirichlet",
-      "startLine": 121,
-      "endLine": 149,
-      "summary": "thomae ≤ dirichlet pointwise. Both have integral 0."
+      "startLine": 119,
+      "endLine": 153,
+      "summary": "thomae ≤ dirichlet pointwise. Both have integral 0.",
+      "mathContext": "Define $D(x) = \\mathbf{1}_{\\mathbb{Q}}(x)$. Then $f(x) \\leq D(x)$ pointwise: at $x = p/q$, $f(x) = 1/q \\leq 1 = D(x)$. Both satisfy $\\int f = \\int D = 0$ via the same countability argument."
     }
   ],
   "conclusion": {
     "summary": "Thomae's function has Lebesgue integral 0 because it is zero almost everywhere. The proof is a natural extension of the parent OQ01 result for the standard Dirichlet function.",
     "openQuestions": [
-      "Can we formalize the Riemann integrability of Thomae's function?",
-      "Can we prove that Thomae's function is continuous at every irrational?"
+      "Can we formalize the Riemann integrability of Thomae's function via Lebesgue's criterion (measure-zero discontinuities)?",
+      "Can we prove that Thomae's function is continuous at every irrational and discontinuous at every rational in Lean?",
+      "Can the popcorn function be used to construct an explicit example of a function that is Lebesgue but not Riemann integrable when extended to 2D?"
     ],
     "implications": "Thomae's function has Lebesgue integral 0 because it is zero almost everywhere. The proof is a natural extension of the parent OQ01 result for the standard Dirichlet function."
   },


### PR DESCRIPTION
## Enrichments

### subset-count-oq-02: Subset Counting for Multisets
- 6 annotations covering powerset theorem, doubling step, choose theorem, empty bound, Finset connection, examples
- 5 keyInsights (from 2), historicalContext expanded with Leibniz/Pascal history
- 3 openQuestions (distinct submultiset formula, generating functions, Mathlib contribution)

### ballot-problem-oq-03-oq-01: LGV Lemma 2×2 (2878 lines, 138 theorems)
- 9 annotations covering: northBeforeEast, Crossing Lemma (discrete IVT), pathSplitEquiv (Pascal), lgvDet definition, Vandermonde/Catalan/Ballot, splitAfterEast backbone, visitedPoints/sharedPoints, swapAtPoint involutivity, lindstrom_involution + lgv_lemma_2x2
- 9 sections grouping all 17 parts with LaTeX mathContext (sections was previously empty)

### cayley-hamilton-minpoly-oq-05-oq-01-oq-01: Nonderogatory → Cyclic Vector (Finite Fields, 362 lines)
- 7 annotations covering: union avoidance theorem, subsingleton argument (key finite field substitution), cardinality counting proof, helper lemmas (annihilator/GCD-Bezout/kernel), factor count bound ≤ n, proper subspace construction, Phase 4 cyclicity via GCD
- keyInsights expanded 3→5, historicalContext expanded (Gerstenhaber 1961), sections mathContext upgraded to LaTeX, stale sorry reference in conclusion fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)