### PR TITLE
Fix: correct status for 3 proofs claiming verified with inherited axioms

### DIFF
--- a/src/data/proofs/erdos-100-oq-02/meta.json
+++ b/src/data/proofs/erdos-100-oq-02/meta.json
@@ -6,14 +6,14 @@
   "meta": {
     "author": "Open problem",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "erdos-problems",
       "combinatorial-geometry",
       "extremal-combinatorics",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/erdos-1007-oq-05/meta.json
+++ b/src/data/proofs/erdos-1007-oq-05/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research",
     "sourceUrl": "https://erdosproblems.com/1007",
     "date": "2026-03-30",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1007OQ05.lean",
     "tags": [
       "graph-theory",
@@ -16,7 +16,7 @@
       "axiom-elimination",
       "open-question"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/erdos-105-oq-05/meta.json
+++ b/src/data/proofs/erdos-105-oq-05/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdos & Purdy (original problem), OQ-05 generalization",
     "sourceUrl": "https://erdosproblems.com/105",
     "date": "2024",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos105OQ05.lean",
     "tags": [
       "discrete-geometry",
@@ -18,7 +18,7 @@
       "open-problem",
       "research"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 105,
     "erdosUrl": "https://erdosproblems.com/105",


### PR DESCRIPTION
## Fix

3 gallery proofs were marked `status: verified` despite having `axiomCount > 0` from inherited axioms. Per the axiom integrity policy, `verified` requires 0 sorries + 0 axioms (including inherited).

## Evidence

| Proof | Old status | Old badge | axiomCount | Inherited from |
|-------|-----------|-----------|------------|----------------|
| `erdos-100-oq-02` | verified | verified | 2 | Erdos100Problem.lean (guthKatz_distinct_distances, piepmeyer_construction) |
| `erdos-1007-oq-05` | verified | original | 4 | Erdos1007Problem.lean (hasUnitEmbedding_exists, min_edges_dimension_4/5, k33_unique_minimum) |
| `erdos-105-oq-05` | verified | original | 3 | Erdos105Problem.lean (xichuan_counterexample, beck_szemeredi_trotter_positive, thresholdFunction) |

**Before**: \`status: verified\`, \`badge: verified/original\`
**After**: \`status: axiomatized\`, \`badge: axiom\`

Note: All three proofs already correctly declared \`axiomCount > 0\` and had accurate \`assumptions\` descriptions — the only error was the \`status\` and \`badge\` fields.

## Validation

\`pnpm build\` passes (exit 0).

---
Automated fix by lean-mechanic agent.