### PR TITLE
Fix: correct axiomCount for 6 proofs (underreported own axioms)

### DIFF
--- a/src/data/proofs/buffons-needle-oq-02-oq-02/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-02/meta.json
@@ -61,7 +61,7 @@
       "smooth3D_mono/strictMono: monotonicity of expected crossings in arc length"
     ],
     "dateAdded": "2026-03-30",
-    "axiomCount": 1,
+    "axiomCount": 2,
     "lineCount": 376,
     "assumptions": "Two axioms: smooth3DExpectedCrossings (defines the expected crossing count for smooth curves) and smooth3D_buffon_eq (the Buffon–Barbier formula E = L/(2d)). These require measure theory on the Grassmannian Gr(2,3) and the Cauchy–Crofton integral formula, which are beyond current Mathlib.",
     "mathlib_version": "4.26.0"
@@ -228,7 +228,7 @@
     ],
     "namespace": "BuffonsNeedleOQ02OQ02",
     "lineCount": 376,
-    "axiomCount": 1,
+    "axiomCount": 2,
     "theoremCount": 15,
     "definitionCount": 4
   }

--- a/src/data/proofs/erdos-504/meta.json
+++ b/src/data/proofs/erdos-504/meta.json
@@ -16,7 +16,7 @@
     ],
     "namespace": "Erdos504",
     "lineCount": 217,
-    "axiomCount": 4,
+    "axiomCount": 5,
     "theoremCount": 1,
     "definitionCount": 5
   },
@@ -37,7 +37,7 @@
     "erdosNumber": 504,
     "erdosUrl": "https://erdosproblems.com/504",
     "erdosProblemStatus": "solved",
-    "axiomCount": 4,
+    "axiomCount": 5,
     "lineCount": 217,
     "assumptions": "15 axiom(s). No sorries.",
     "mathlib_version": "4.26.0"

--- a/src/data/proofs/erdos-529/meta.json
+++ b/src/data/proofs/erdos-529/meta.json
@@ -106,9 +106,9 @@
       "erdos_529_summary theorem: combines established results",
       "erdos_529 theorem: combines Hara-Slade + sub-ballistic + Question 2"
     ],
-    "axiomCount": 5,
+    "axiomCount": 7,
     "lineCount": 306,
-    "assumptions": "5 axioms: tendsTo, haraSlade_five_dim, duminilCopin_subBallistic, conjecture_implies_question1, question2_high_dim. Structure fields are object definitions, not assumptions."
+    "assumptions": "7 axioms: endToEndDistance (end-to-end distance function for self-avoiding walks), expectedEndDistance (expected end-to-end distance d_k(n)), tendsTo (convergence predicate for sequences), haraSlade_five_dim (Hara-Slade 1992 mean-field theory for d≥5), duminilCopin_subBallistic (Duminil-Copin 2012 subballisticity), conjecture_implies_question1 (conjecture implies answer to Q1), question2_high_dim (answer to Q2 in high dimensions). 0 sorries."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #529: Self-Avoiding Walks**\n\nSelf-avoiding walks (SAWs) were first studied systematically by the chemist Paul Flory in 1949 as models for linear polymers in good solvents. Flory's mean-field prediction $\\nu = 3/(d+2)$ for the end-to-end distance exponent was remarkably accurate, setting the stage for decades of rigorous mathematical work.\n\nThe first rigorous high-dimensional result came from **Gordon Slade** (1987), who used the **lace expansion** — a perturbative technique introduced by Brydges and Spencer (1985) — to prove $d_k(n) \\sim D\\sqrt{n}$ for sufficiently large $k$. **Takashi Hara** and Slade (1991-92) refined this to all $k \\ge 5$, using computer-assisted bounds on the lace expansion coefficients. Their work established that mean-field behavior ($\\nu = 1/2$) holds above the upper critical dimension $d_c = 4$.\n\nThe low-dimensional case proved far more resistant. **Bernard Nienhuis** (1982) predicted $\\nu = 3/4$ in 2D using the exact solution of an O(n) loop model on the honeycomb lattice, and conformal field theory arguments connect 2D SAW to the SLE$_{8/3}$ process (Lawler, Schramm, Werner). The landmark result of **Hugo Duminil-Copin** and **Alan Hammond** (2013) proved $d_2(n) = o(n)$ (sub-ballistic growth) using a bridge decomposition argument, but the full Question 1 ($d_2(n)/\\sqrt{n} \\to \\infty$) remains open.\n\nThe definitive reference is the monograph *The Self-Avoiding Walk* by Madras and Slade (1993, 2nd ed. 2013). **Nathan Clisby** (2010) provided the most precise numerical estimates: $\\nu_3 \\approx 0.5876 \\pm 0.0002$.",
@@ -225,7 +225,7 @@
     ],
     "namespace": "Erdos529",
     "lineCount": 306,
-    "axiomCount": 5,
+    "axiomCount": 7,
     "theoremCount": 6,
     "definitionCount": 5
   },

--- a/src/data/proofs/erdos-756/meta.json
+++ b/src/data/proofs/erdos-756/meta.json
@@ -76,7 +76,7 @@
       "multiplicity_trivial_upper theorem: multiplicity ≤ n²",
       "erdos_756 theorem: main result"
     ],
-    "axiomCount": 2,
+    "axiomCount": 5,
     "lineCount": 268,
     "assumptions": "10 axioms: (1) hopf_pannwitz — largest distance multiplicity ≤ n, (2) bhowmick_construction — existence of point set with rich distances, (3) bhowmick_main — ⌊n/4⌋ rich distances for large n, (4) bhowmick_general — ⌊n/(2(m+1))⌋ distances with multiplicity ≥ n+m, (5) clemen_dumitrescu_liu — superpolynomial grid richness, (6-10) supporting axioms for distance counting, grid construction, and asymptotic bounds. 1 sorry in construction details."
   },
@@ -223,7 +223,7 @@
     ],
     "namespace": "Erdos756",
     "lineCount": 268,
-    "axiomCount": 2,
+    "axiomCount": 5,
     "theoremCount": 8,
     "definitionCount": 15
   },

--- a/src/data/proofs/erdos-96/meta.json
+++ b/src/data/proofs/erdos-96/meta.json
@@ -55,7 +55,7 @@
       "erdos_96_summary: proved conjunction of bounds"
     ],
     "dateAdded": "2026-01-19",
-    "axiomCount": 2,
+    "axiomCount": 3,
     "lineCount": 285,
     "assumptions": "4 axiom(s). No sorries."
   },
@@ -150,7 +150,7 @@
     ],
     "namespace": "Erdos96",
     "lineCount": 285,
-    "axiomCount": 2,
+    "axiomCount": 3,
     "theoremCount": 2,
     "definitionCount": 10
   },

--- a/src/data/proofs/hilbert-21/meta.json
+++ b/src/data/proofs/hilbert-21/meta.json
@@ -36,7 +36,7 @@
     ],
     "dateAdded": "2025-12-29",
     "hilbertNumber": 21,
-    "axiomCount": 3,
+    "axiomCount": 4,
     "lineCount": 386,
     "assumptions": "6 axiom(s). No sorries.",
     "mathlib_version": "4.26.0"
@@ -150,7 +150,7 @@
     "opens": [],
     "namespace": "Hilbert21",
     "lineCount": 386,
-    "axiomCount": 3,
+    "axiomCount": 4,
     "theoremCount": 5,
     "definitionCount": 5
   },


### PR DESCRIPTION
## Fix

6 gallery proofs had `axiomCount` values lower than the actual number of `axiom` / `noncomputable axiom` declarations in their Lean source files. Both `meta.axiomCount` and `leanFile.axiomCount` are updated to reflect reality.

## Evidence

| Proof | Old | New | Missing axiom(s) |
|-------|-----|-----|-----------------|
| `buffons-needle-oq-02-oq-02` | 1 | 2 | `smooth3DExpectedCrossings` (noncomputable) |
| `erdos-504` | 4 | 5 | `isConvexPosition` |
| `erdos-529` | 5 | 7 | `endToEndDistance`, `expectedEndDistance` (both noncomputable) |
| `erdos-756` | 2 | 5 | `squareGrid`, `regularPolygon`, `latticeInDisk` (all noncomputable) |
| `erdos-96` | 2 | 3 | `cyclicOrder` (noncomputable) |
| `hilbert-21` | 3 | 4 | `realization_criterion` |

All proofs were already `status: axiomatized` — only the count was wrong. Also updated `erdos-529` assumptions text to list all 7 axioms (was listing only 5, omitting the 2 noncomputable ones).

## Validation

`pnpm build` passes (exit 0).

---
Automated fix by lean-mechanic agent.