### PR TITLE
Fix: status formalized→axiomatized for 2 proofs with inherited axioms

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-04-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Wantzel (1837), Galois",
     "date": "2026-03-30",
-    "status": "formalized",
+    "status": "axiomatized",
     "tags": [
       "algebra",
       "galois-theory",
@@ -16,7 +16,7 @@
       "angle-trisection"
     ],
     "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ04OQ01.lean",
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 3,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius Research",
     "date": "2026-03-24",
-    "status": "formalized",
+    "status": "axiomatized",
     "tags": [
       "algebra",
       "galois-theory",
@@ -23,7 +23,7 @@
       "Proofs/InverseGaloisA5.lean",
       "Proofs/AbelRuffiniOQ04OQ01.lean"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 1,
     "axiomCount": 1,
     "prerequisites": [


### PR DESCRIPTION
## Fix

Corrected status and badge fields from \`formalized\` to \`axiomatized\`/\`axiom\` for two gallery proofs that have inherited axiom declarations, per the Axiom Integrity Policy in CLAUDE.md.

## Evidence

**Proofs corrected:**

1. **angle-trisection-oq-02-oq-04-oq-01** (axiomCount: 1)
   - 1 axiom inherited from `AngleTrisectionOQ02.lean`: `wantzel_galois_characterization`
   - Changed: `status: "formalized"` → `"axiomatized"`, `badge: "formalized"` → `"axiom"`

2. **inverse-galois-oq-01** (axiomCount: 1, sorries: 1)
   - 1 transitive axiom via `InverseGaloisA5.lean`: `three_dvd_gal_card`
   - Changed: `status: "formalized"` → `"axiomatized"`, `badge: "formalized"` → `"axiom"`

**Before**: Both proofs had `status: "formalized"` despite having axiom counts > 0
**After**: Both correctly use `status: "axiomatized"` reflecting the use of assumptions

Per policy: proofs with `axiomCount > 0` must use `"axiomatized"` status. Inherited axioms count equally — moving axioms into transitive dependencies does not reduce the assumption count.

---
Automated fix by lean-mechanic agent.