### PR TITLE
chore: audit tracker - cycle-29 (all 1881 proofs audited)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11341,6 +11341,12 @@
       "lastAudited": "2026-04-03T22:03:34Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-1059-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-03T23:36:27Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Audit Cycle 29

**Result**: All 1881 gallery proofs audited — 0 unaudited remaining.

### This Cycle

- **erdos-1059-oq-02** (Selberg Sieve Framework for Erdős Problem 1059): **CLEAN**
  - sorries: 0 ✓ (matches meta.json)
  - axioms: 1 ✓ (`selberg_density_axiom` — correctly declared, matches axiomCount: 1)
  - True stubs: none ✓
  - Status: `axiomatized` / badge: `axiom` — correct for an axiomatized proof
  - No delegation opacity: Mathlib deps are only basic utilities (factorial, Finset, Prime)

### Root Cause Fix

Previous audit cycles (26–28) reported `erdos-1059-oq-02` as audited but the entry was never written to the main tracker. Root cause: `REPO_ROOT` env var is set to the worktree path, so `claim-target.sh` was writing to the worktree's tracker instead of the main repo's. Fixed this cycle by running the update with explicit `REPO_ROOT=/Users/rwalters/GitHub/lean-genius`.

### Gallery Status

- Total: 1881
- Audited: 1881 (100%)
- Unaudited: 0
- With issues: 22
- Critical: 0

🤖 Generated with [Claude Code](https://claude.ai/claude-code)