### PR TITLE
Fix: navier-stokes axiomCount 0→5 and badge wip→axiom (NSAxioms structure)

### DIFF
--- a/src/data/proofs/navier-stokes-existence/meta.json
+++ b/src/data/proofs/navier-stokes-existence/meta.json
@@ -19,9 +19,9 @@
       "regularity",
       "research"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 5,
     "assumptions": "NSAxioms structure with 5 fields: Type II exponent bound, spectral gap on dissipation scale, theta dynamics bound, blowup rate estimate, BKM criterion. These encode the physical hypotheses needed for conditional 3D regularity.",
     "mathlibDependencies": [
       {

--- a/src/data/proofs/navier-stokes/meta.json
+++ b/src/data/proofs/navier-stokes/meta.json
@@ -52,9 +52,9 @@
       "regularity",
       "K-ball-concentration"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 5,
     "assumptions": "5 structure-encoded assumptions in NSAxioms (Type II exponent, spectral gap, theta dynamics, blowup rate, BKM criterion). 0 Lean axiom declarations, but the 3D regularity theorem is conditional on the NSAxioms structure (5 fields encoding physical hypotheses: Type II exponent, spectral gap, theta dynamics, blowup rate, and BKM criterion). These structure fields are mathematically equivalent to axiom declarations -- the assumptions were reorganized, not eliminated. The 2D global existence theorem (Ladyzhenskaya 1969) is genuinely unconditional. The Millennium Prize problem remains unsolved.",
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

Correct `axiomCount` and `badge` for `navier-stokes` and `navier-stokes-existence`, both of which use `NSAxioms` — a structure with 5 assumption-carrying fields.

## Evidence

**Before**:
- `axiomCount: 0` — incorrect, ignores structure-encoded assumptions
- `badge: "wip"` — incorrect, there are no sorries, only formalized axioms

**After**:
- `axiomCount: 5` — counts the 5 NSAxioms fields (Type II exponent, spectral gap, theta dynamics, blowup rate, BKM criterion)
- `badge: "axiom"` — correct per CLAUDE.md: axiomatized proofs with stated assumptions use axiom badge

## Root Cause

PR #9087 bulk-corrected `badge: "axiom" → "wip"` for proofs with `axiomCount=0`. But `axiomCount=0` was itself wrong for these proofs — the `assumptions` field already documented 5 structure-encoded fields in `NSAxioms`. The CLAUDE.md Axiom Integrity Policy explicitly calls out `NSAxioms` as an example of structure-encoded assumptions that must be counted.

## Files Changed

- `src/data/proofs/navier-stokes/meta.json`
- `src/data/proofs/navier-stokes-existence/meta.json`

---
Automated fix by lean-mechanic agent.