### PR TITLE
Fix: status formalized→axiomatized for 21 open Erdős conjectures

### DIFF
--- a/src/data/proofs/erdos-1016/meta.json
+++ b/src/data/proofs/erdos-1016/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdos, Bondy",
     "sourceUrl": "https://erdosproblems.com/1016",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1016Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "extremal graph theory",
       "Hamiltonian graphs"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1016,
     "erdosUrl": "https://erdosproblems.com/1016",

--- a/src/data/proofs/erdos-1021/meta.json
+++ b/src/data/proofs/erdos-1021/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Simonovits",
     "sourceUrl": "https://erdosproblems.com/1021",
     "date": "1971",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1021Problem.lean",
     "tags": [
       "graph-theory",
@@ -16,7 +16,7 @@
       "turan-type",
       "bipartite-graphs"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 2,
     "erdosNumber": 1021,
     "erdosUrl": "https://erdosproblems.com/1021",

--- a/src/data/proofs/erdos-1092/meta.json
+++ b/src/data/proofs/erdos-1092/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős–Hajnal–Szemerédi",
     "sourceUrl": "https://erdosproblems.com/1092",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1092Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1098-oq-04/meta.json
+++ b/src/data/proofs/erdos-1098-oq-04/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (connected to Problem #1098), Gustafson 1973, Neumann 1976",
     "sourceUrl": "https://erdosproblems.com/1098",
     "date": "1973",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1098OQ04.lean",
     "tags": [
       "erdos",
@@ -79,7 +79,9 @@
     {
       "type": "paper",
       "title": "What is the probability that two group elements commute?",
-      "authors": ["W.H. Gustafson"],
+      "authors": [
+        "W.H. Gustafson"
+      ],
       "year": 1973,
       "journal": "Amer. Math. Monthly",
       "volume": "80",
@@ -88,7 +90,9 @@
     {
       "type": "paper",
       "title": "A problem of Paul Erdős on groups",
-      "authors": ["B.H. Neumann"],
+      "authors": [
+        "B.H. Neumann"
+      ],
       "year": 1976,
       "journal": "J. Austral. Math. Soc. Ser. A",
       "volume": "21",

--- a/src/data/proofs/erdos-1100/meta.json
+++ b/src/data/proofs/erdos-1100/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős",
     "sourceUrl": "https://erdosproblems.com/1100",
     "date": "1978",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1100ProblemProvable.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-1183/meta.json
+++ b/src/data/proofs/erdos-1183/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős–Ulam (1978)",
     "sourceUrl": "https://erdosproblems.com/1183",
     "date": "1978",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1183Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "lattice-theory",
       "powerset"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1183,
     "erdosUrl": "https://erdosproblems.com/1183",

--- a/src/data/proofs/erdos-156/meta.json
+++ b/src/data/proofs/erdos-156/meta.json
@@ -10,7 +10,7 @@
       "Sós"
     ],
     "sourceUrl": "https://erdosproblems.com/156",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos156Problem.lean",
     "tags": [
       "erdos",
@@ -18,7 +18,7 @@
       "additive-combinatorics",
       "extremal-combinatorics"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 3,
     "erdosNumber": 156,
     "erdosUrl": "https://erdosproblems.com/156",

--- a/src/data/proofs/erdos-202/meta.json
+++ b/src/data/proofs/erdos-202/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, Endre Szemerédi",
     "sourceUrl": "https://erdosproblems.com/202",
     "date": "1968",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos202Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "covering-systems",
       "combinatorics"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 3,
     "erdosNumber": 202,
     "erdosUrl": "https://erdosproblems.com/202",

--- a/src/data/proofs/erdos-263/meta.json
+++ b/src/data/proofs/erdos-263/meta.json
@@ -7,7 +7,7 @@
         "author": "Paul Erdős",
         "sourceUrl": "https://erdosproblems.com/263",
         "date": "1980s",
-        "status": "formalized",
+        "status": "axiomatized",
         "proofRepoPath": "Proofs/Stubs/Erdos263Problem.lean",
         "tags": [
             "erdos",

--- a/src/data/proofs/erdos-307/meta.json
+++ b/src/data/proofs/erdos-307/meta.json
@@ -7,7 +7,7 @@
     "author": "Barbeau (1976), Cambie",
     "sourceUrl": "https://erdosproblems.com/307",
     "date": "1976",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos307Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "egyptian-fractions",
       "reciprocals"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 2,
     "erdosNumber": 307,
     "erdosUrl": "https://erdosproblems.com/307",

--- a/src/data/proofs/erdos-411/meta.json
+++ b/src/data/proofs/erdos-411/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/411",
     "date": "1980",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos411Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "totient",
       "arithmetic-dynamics"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 411,
     "erdosUrl": "https://erdosproblems.com/411",

--- a/src/data/proofs/erdos-416/meta.json
+++ b/src/data/proofs/erdos-416/meta.json
@@ -8,7 +8,7 @@
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/416",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos416Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "asymptotics",
       "open-problem"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 416,
     "erdosUrl": "https://erdosproblems.com/416",

--- a/src/data/proofs/erdos-501/meta.json
+++ b/src/data/proofs/erdos-501/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, András Hajnal",
     "sourceUrl": "https://erdosproblems.com/501",
     "date": "1960",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos501Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "combinatorics",
       "independence"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 3,
     "erdosNumber": 501,
     "erdosUrl": "https://erdosproblems.com/501",

--- a/src/data/proofs/erdos-552/meta.json
+++ b/src/data/proofs/erdos-552/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, S.A. Burr, R.J. Faudree, C.C. Rousseau, R.H. Schelp",
     "sourceUrl": "https://erdosproblems.com/552",
     "date": "1989",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos552Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-604/meta.json
+++ b/src/data/proofs/erdos-604/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/604",
     "date": "1957-1997",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos604Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-609/meta.json
+++ b/src/data/proofs/erdos-609/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Graham, bounds by Day-Johnson, Janzer-Yip",
     "sourceUrl": "https://erdosproblems.com/609",
     "date": "",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos609Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "extremal-combinatorics",
       "open-problem"
     ],
-    "badge": "conjecture",
+    "badge": "axiom",
     "sorries": 16,
     "erdosNumber": 609,
     "erdosUrl": "https://erdosproblems.com/609",

--- a/src/data/proofs/erdos-629/meta.json
+++ b/src/data/proofs/erdos-629/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, Arthur Rubin, Herbert Taylor",
     "sourceUrl": "https://erdosproblems.com/629",
     "date": "1980",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos629Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-679/meta.json
+++ b/src/data/proofs/erdos-679/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős",
     "sourceUrl": "https://erdosproblems.com/679",
     "date": "1979",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos679Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-826/meta.json
+++ b/src/data/proofs/erdos-826/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős (1974)",
     "sourceUrl": "https://erdosproblems.com/826",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos826Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "arithmetic-functions",
       "open-problem"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 826,
     "erdosUrl": "https://erdosproblems.com/826",

--- a/src/data/proofs/erdos-901/meta.json
+++ b/src/data/proofs/erdos-901/meta.json
@@ -8,7 +8,7 @@
     "author": "Paul Erdős, László Lovász",
     "sourceUrl": "https://erdosproblems.com/901",
     "date": "1963-1975",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Stubs/Erdos901Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-938/meta.json
+++ b/src/data/proofs/erdos-938/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős [Er76d]",
     "sourceUrl": "https://erdosproblems.com/938",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos938Problem.lean",
     "tags": [
       "erdos",
@@ -16,7 +16,7 @@
       "squarefull-numbers",
       "open"
     ],
-    "badge": "formalized",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 938,
     "erdosUrl": "https://erdosproblems.com/938",


### PR DESCRIPTION
## Fix

Per CLAUDE.md Axiom Integrity Policy: _"Millennium Prize problems, Clay problems, and open conjectures: always `'axiomatized'`"_ — 21 Erdős problems with `erdosProblemStatus: "open"` were incorrectly labeled `status: "formalized"`.

## Evidence

**Before**: `"status": "formalized"` on open-problem Erdős entries  
**After**: `"status": "axiomatized"` to correctly reflect that these are open mathematical conjectures

Also fixes invalid `badge` values (`"formalized"`, `"conjecture"` are not valid TypeScript `ProofBadge` types) → `"axiom"` for 12 of the 21 proofs.

## Affected proofs (21)

| Slug | Sorries | Badge change |
|------|---------|-------------|
| erdos-156 | 3 | formalized → axiom |
| erdos-202 | 3 | formalized → axiom |
| erdos-263 | 7 | wip (kept) |
| erdos-307 | 2 | formalized → axiom |
| erdos-411 | 0 | formalized → axiom |
| erdos-416 | 0 | formalized → axiom |
| erdos-501 | 3 | formalized → axiom |
| erdos-552 | 12 | wip (kept) |
| erdos-604 | 1 | wip (kept) |
| erdos-609 | 16 | conjecture → axiom |
| erdos-629 | 7 | wip (kept) |
| erdos-679 | 10 | wip (kept) |
| erdos-826 | 0 | formalized → axiom |
| erdos-901 | 19 | wip (kept) |
| erdos-938 | 0 | formalized → axiom |
| erdos-1016 | 0 | formalized → axiom |
| erdos-1021 | 2 | formalized → axiom |
| erdos-1092 | 0 | infrastructure (kept) |
| erdos-1098-oq-04 | 0 | original (kept) |
| erdos-1100 | 3 | wip (kept) |
| erdos-1183 | 0 | formalized → axiom |

## Validation

`pnpm build` passes (exit 0, built in 3m 33s).

---
Automated fix by lean-mechanic agent.