### PR TITLE
Add Aristotle companion file for Erdős #611 (Clique Transversal)

### DIFF
--- a/proofs/Proofs/Stubs/Erdos611Aristotle.lean
+++ b/proofs/Proofs/Stubs/Erdos611Aristotle.lean
@@ -1,0 +1,90 @@
+/-
+  Aristotle targets for Erdős Problem #611: Clique Transversal with Large Cliques
+  Routine supporting lemmas for automated proof search.
+  See Erdos611Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT theorems about cliqueTransversalNumber τ (def-sorry in main file)
+  - NOT theorems about k_threshold (def-sorry in main file)
+  - NOT the open questions about τ = o(n) (open conjecture)
+  - Routine: clique/transversal structural facts that do not require τ or k_threshold
+  - No definition sorries
+  - No axioms
+-/
+import Mathlib
+
+namespace Erdos611Aristotle
+
+open Finset SimpleGraph
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/-- A clique in a graph is a set of pairwise adjacent vertices -/
+def IsClique (G : SimpleGraph V) (S : Finset V) : Prop :=
+  ∀ u ∈ S, ∀ v ∈ S, u ≠ v → G.Adj u v
+
+/-- A clique is maximal if no proper superset is also a clique -/
+def IsMaximalClique (G : SimpleGraph V) (S : Finset V) : Prop :=
+  IsClique G S ∧ ∀ T : Finset V, S ⊂ T → ¬IsClique G T
+
+/-- Every maximal clique has size at least k -/
+def AllCliquesLarge (G : SimpleGraph V) (k : ℕ) : Prop :=
+  ∀ C : Finset V, IsMaximalClique G C → C.card ≥ k
+
+/-- Every maximal clique has size at least cn (for c ∈ (0,1)) -/
+def AllCliquesLinear (G : SimpleGraph V) (c : ℝ) : Prop :=
+  0 < c ∧ c ≤ 1 ∧ ∀ C : Finset V, IsMaximalClique G C →
+    (C.card : ℝ) ≥ c * Fintype.card V
+
+/-- A transversal hits every maximal clique -/
+def IsCliqueTransversal (G : SimpleGraph V) (T : Finset V) : Prop :=
+  ∀ C : Finset V, IsMaximalClique G C → (T ∩ C).Nonempty
+
+-- Routine: The empty set is a clique.
+-- No pairs u ≠ v to check, so the condition holds vacuously.
+theorem isClique_empty (G : SimpleGraph V) : IsClique G ∅ := by
+  sorry
+
+-- Routine: Any single vertex forms a clique.
+-- There are no pairs of distinct vertices in a singleton.
+theorem isClique_singleton (G : SimpleGraph V) (v : V) : IsClique G {v} := by
+  sorry
+
+-- Routine: A clique is preserved under subsets.
+-- If S is a clique and T ⊆ S, then T is also a clique.
+theorem isClique_mono (G : SimpleGraph V) {S T : Finset V}
+    (h : IsClique G S) (hTS : T ⊆ S) : IsClique G T := by
+  sorry
+
+-- Routine: AllCliquesLarge is monotone (downward) in k.
+-- If every clique has size ≥ k and k' ≤ k, then every clique has size ≥ k'.
+theorem allCliquesLarge_mono_param (G : SimpleGraph V) {k k' : ℕ}
+    (hk : k' ≤ k) (h : AllCliquesLarge G k) : AllCliquesLarge G k' := by
+  sorry
+
+-- Routine: AllCliquesLinear with c implies AllCliquesLarge with ⌈c * n⌉.
+-- If every clique has size ≥ c * n, it has size ≥ ⌈c * n⌉ ≥ 1 when c > 0.
+theorem allCliquesLinear_implies_large (G : SimpleGraph V) (c : ℝ) (hc : 0 < c)
+    (h : AllCliquesLinear G c) :
+    AllCliquesLarge G ⌈c * Fintype.card V⌉₊ := by
+  sorry
+
+-- Routine: A superset of a clique transversal is also a transversal.
+-- Adding vertices to T can only help it hit more cliques.
+theorem isCliqueTransversal_mono (G : SimpleGraph V) {S T : Finset V}
+    (hST : S ⊆ T) (hS : IsCliqueTransversal G S) : IsCliqueTransversal G T := by
+  sorry
+
+-- Routine: The full vertex set V is always a clique transversal.
+-- Every clique is a subset of V, so V intersects every clique.
+theorem isCliqueTransversal_univ (G : SimpleGraph V) [Nontrivial V] :
+    IsCliqueTransversal G Finset.univ := by
+  sorry
+
+-- Routine: A maximal clique is nonempty (assuming Nontrivial V).
+-- A clique must have at least one vertex to be maximal (otherwise it could be extended).
+theorem maximalClique_nonempty (G : SimpleGraph V) [Nontrivial V] (S : Finset V)
+    (hS : IsMaximalClique G S) : S.Nonempty := by
+  sorry
+
+end Erdos611Aristotle


### PR DESCRIPTION
## Fix

Creates `proofs/Proofs/Stubs/Erdos611Aristotle.lean` — an Aristotle companion file for Erdős Problem #611 (Clique Transversal with Large Cliques), which has 13 sorries and no existing companion file.

## Evidence

**Before**: `erdos-611` (13 sorries, `axiomatized`) had no Aristotle companion file  
**After**: 8 routine structural lemmas ready for Aristotle automated proof search

## Lemmas included

| Lemma | Why routine |
|-------|-------------|
| `isClique_empty` | Vacuous — no pairs in ∅ |
| `isClique_singleton` | Vacuous — no distinct pairs in {v} |
| `isClique_mono` | Subset restriction preserves adjacency |
| `allCliquesLarge_mono_param` | Downward monotone: k' ≤ k → AllCliquesLarge G k' |
| `allCliquesLinear_implies_large` | Linear bound implies natural-number bound |
| `isCliqueTransversal_mono` | Superset of transversal is transversal |
| `isCliqueTransversal_univ` | Full vertex set always hits every clique |
| `maximalClique_nonempty` | Maximal clique must contain a vertex |

Note: Avoids `cliqueTransversalNumber` (τ) and `k_threshold` — both are def-sorries
in the main file and Aristotle cannot prove theorems about undefined functions.

## Checklist

- [x] No `def ... := sorry`
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections
- [x] No open conjectures (lemmas are structural/combinatorial, not the open τ questions)

---
Automated fix by lean-mechanic agent.