### PR TITLE
Add Aristotle companion for Roth Theorem Quantitative Bounds

### DIFF
--- a/proofs/Proofs/RothTheoremQuantitativeAristotle.lean
+++ b/proofs/Proofs/RothTheoremQuantitativeAristotle.lean
@@ -1,0 +1,103 @@
+/-
+  Aristotle targets for Roth's Theorem Quantitative Bounds
+  Supporting analysis and density lemmas for automated proof search.
+  See RothTheoremQuantitative.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main quantitative bounds (Roth, Behrend, Kelley-Meka)
+  - Routine arithmetic and analytic facts about density and AP-free sets
+  - Clean theorem statements with no definition sorries
+  - No axioms
+-/
+import Mathlib
+
+namespace RothTheoremQuantitativeAristotle
+
+open Real Finset Filter
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART I: Density Arithmetic
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- If δ > 0, then δ² > 0. -/
+theorem delta_sq_pos (delta : ℝ) (hdelta : 0 < delta) : 0 < delta ^ 2 := by
+  sorry
+
+/-- If δ > 0, then 100 / δ² > 0. -/
+theorem density_bound_pos (delta : ℝ) (hdelta : 0 < delta) : 0 < 100 / delta ^ 2 := by
+  sorry
+
+/-- The density increment formula: δ + k * δ² / 100 is increasing in k. -/
+theorem density_increment_mono (delta : ℝ) (hdelta : 0 < delta) (k₁ k₂ : ℕ) (h : k₁ ≤ k₂) :
+    delta + k₁ * delta ^ 2 / 100 ≤ delta + k₂ * delta ^ 2 / 100 := by
+  sorry
+
+/-- After at most ⌊100/δ²⌋ density increments, the density exceeds 1. -/
+theorem density_exceeds_one_after_floor (delta : ℝ) (hdelta : 0 < delta) (hdelta1 : delta ≤ 1) :
+    ∃ k : ℕ, k ≤ ⌊100 / delta ^ 2⌋₊ + 1 ∧ delta + k * delta ^ 2 / 100 > 1 := by
+  sorry
+
+/-- The Roth iteration count ⌊100/δ²⌋ is monotone: smaller δ gives more iterations. -/
+theorem iteration_count_antimono (delta₁ delta₂ : ℝ) (h₁ : 0 < delta₁) (h₂ : 0 < delta₂)
+    (h : delta₁ ≤ delta₂) : ⌊100 / delta₂ ^ 2⌋₊ ≤ ⌊100 / delta₁ ^ 2⌋₊ := by
+  sorry
+
+/-- For δ = 1/√(log N), 100/δ² = 100 * log N. -/
+theorem roth_iteration_count_formula (N : ℕ) (hN : 2 < N) :
+    100 / (1 / sqrt (log N)) ^ 2 = 100 * log N := by
+  sorry
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART II: AP-Freeness Properties
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- AP-freeness is closed under taking subsets (in ZMod N). -/
+theorem apFree_mono {N : ℕ} {A B : Finset (ZMod N)}
+    (hAB : B ⊆ A)
+    (hA : ∀ a d : ZMod N, d ≠ 0 → a ∈ A → a + d ∈ A → a + 2 * d ∉ A) :
+    ∀ a d : ZMod N, d ≠ 0 → a ∈ B → a + d ∈ B → a + 2 * d ∉ B := by
+  sorry
+
+/-- A 2-element AP-free set: {0, 1} in ZMod N for N ≥ 3. -/
+theorem two_element_ap_free (N : ℕ) (hN : 3 ≤ N) :
+    ∀ a d : ZMod N, d ≠ 0 → a ∈ ({0, 1} : Finset (ZMod N)) →
+    a + d ∈ ({0, 1} : Finset (ZMod N)) → a + 2 * d ∉ ({0, 1} : Finset (ZMod N)) := by
+  sorry
+
+/-- The Roth number satisfies r₃(N) ≥ ⌊N/2⌋ for N ≥ 1. -/
+theorem rothNumber_ge_half (N : ℕ) [NeZero N] :
+    N / 2 ≤
+      Finset.sup (Finset.univ.powerset.filter
+        (fun A : Finset (ZMod N) => ∀ a d : ZMod N, d ≠ 0 → a ∈ A → a + d ∈ A → a + 2 * d ∉ A))
+        Finset.card := by
+  sorry
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART III: Logarithmic Growth Facts
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- log N → ∞ as N → ∞. -/
+theorem log_nat_tendsto_atTop :
+    Tendsto (fun N : ℕ => Real.log N) atTop atTop := by
+  sorry
+
+/-- For N ≥ 3, log(log N) > 0. -/
+theorem log_log_pos (N : ℕ) (hN : 3 ≤ N) : 0 < Real.log (Real.log N) := by
+  sorry
+
+/-- N / log(log N) → ∞ as N → ∞. -/
+theorem n_div_log_log_tendsto_atTop :
+    Tendsto (fun N : ℕ => (N : ℝ) / Real.log (Real.log N)) atTop atTop := by
+  sorry
+
+/-- For c > 0, N · exp(-c · √(log N)) is eventually greater than any constant. -/
+theorem behrend_lower_eventually_large (c : ℝ) (hc : 0 < c) (K : ℝ) :
+    ∀ᶠ N : ℕ in atTop, K < N * Real.exp (-c * Real.sqrt (Real.log N)) := by
+  sorry
+
+/-- The Behrend exponent satisfies: exp(-c√(log N)) → 1 relative to polynomial growth. -/
+theorem behrend_exponent_vs_poly (c ε : ℝ) (hc : 0 < c) (hε : 0 < ε) :
+    ∀ᶠ N : ℕ in atTop, Real.exp (-c * Real.sqrt (Real.log N)) ≥ (N : ℝ) ^ (-ε) := by
+  sorry
+
+end RothTheoremQuantitativeAristotle


### PR DESCRIPTION
## Fix

Create Aristotle companion file for `RothTheoremQuantitative.lean` which has 5 sorry theorems (major quantitative bounds) and no prior Aristotle companion.

## Evidence

**Target file**: `proofs/Proofs/RothTheoremQuantitative.lean` (5 sorries, 0 Aristotle failures)

**Companion created**: `proofs/Proofs/RothTheoremQuantitativeAristotle.lean`

**Aristotle targets** (12 routine lemmas in 3 groups):

*Density arithmetic*:
- `delta_sq_pos`, `density_bound_pos` — positivity facts
- `density_increment_mono` — monotonicity of density after increments
- `density_exceeds_one_after_floor` — existence of contradiction step
- `iteration_count_antimono` — smaller δ → more iterations
- `roth_iteration_count_formula` — 100/δ² = 100 log N for δ = 1/√(log N)

*AP-freeness*:
- `apFree_mono` — AP-freeness closed under subsets
- `two_element_ap_free` — {0,1} is AP-free in ZMod N (N ≥ 3)
- `rothNumber_ge_half` — r₃(N) ≥ N/2

*Logarithmic growth*:
- `log_nat_tendsto_atTop` — log N → ∞
- `log_log_pos` — log(log N) > 0 for N ≥ 3
- `n_div_log_log_tendsto_atTop` — N/log(log N) → ∞
- `behrend_lower_eventually_large` — Behrend lower bound grows without bound
- `behrend_exponent_vs_poly` — exp(-c√(log N)) ≥ N^(-ε) eventually

**Pre-submission checklist**:
- ✅ No `def ... := sorry`
- ✅ No `axiom` declarations
- ✅ No `theorem ... : True` placeholders
- ✅ No `/-!` docstring sections
- ✅ No open conjectures

---
Automated fix by lean-mechanic agent.