### PR TITLE
chore: sync research listings and data

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -9532,11 +9532,11 @@
     },
     {
       "slug": "erdos-1012-oq-03-incomplete-01",
-      "phase": "NEW",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-03-30T16:34:54.972Z",
       "status": "active",
-      "lastUpdate": "2026-03-30T16:34:54.972Z"
+      "lastUpdate": "2026-04-04T00:38:42.403Z"
     },
     {
       "slug": "erdos-1018-oq-04-incomplete-01",
@@ -11901,11 +11901,12 @@
     },
     {
       "slug": "erdos-815-incomplete-01",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-03T22:44:23.339Z",
-      "status": "active",
-      "lastUpdate": "2026-04-03T22:44:23.339Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T00:38:42.369Z",
+      "completed": "2026-04-04T00:38:42.369Z"
     },
     {
       "slug": "erdos-986-incomplete-01",


### PR DESCRIPTION
## Summary
- Updated research-listings.json: 44 added, 640 updated, 3606 total iterations
- Auto-generated by deployer sync cycle

## Changes
- `src/data/research/research-listings.json` — iteration count sync

🤖 Deployer agent auto-sync