### PR TITLE
Fix: promote 2 proofs from status=formalized to verified

### DIFF
--- a/src/data/proofs/basel-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01/meta.json
@@ -7,14 +7,14 @@
     "author": "formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Particular_values_of_the_Riemann_zeta_function",
     "date": "2026-03-30",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/BaselProblemOQ01OQ01.lean",
     "tags": [
       "number-theory",
       "analysis",
       "open-problem"
     ],
-    "badge": "formalized",
+    "badge": "verified",
     "sorries": 0,
     "assumptions": "0 sorries, 0 axioms. All 7 theorems are fully proved. The file also contains three comment blocks (not theorems) documenting known irrationality measures and the difficulty of ζ(5). Genuine content: partial sum bounds, tail estimates, and irrationality measure definition are fully verified.",
     "dateAdded": "2026-03-30",

--- a/src/data/proofs/law-of-cosines-oq-04/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-04/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Matthew Stewart (1746)",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/LawOfCosinesOQ04.lean",
     "tags": [
       "geometry",
@@ -15,7 +15,7 @@
       "law-of-cosines",
       "research"
     ],
-    "badge": "formalized",
+    "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 155,


### PR DESCRIPTION
## Fix

Two gallery entries have `status: formalized` but actually have 0 sorries, 0 axioms, no True placeholders, and their own `assumptions` text confirms full proof. Per CLAUDE.md:
- `formalized` requires: "Has sorries remaining"
- `verified` requires: "0 sorries, 0 axiom declarations, 0 structure-encoded assumptions"

## Evidence

**basel-problem-oq-01-oq-01** (`Proofs/BaselProblemOQ01OQ01.lean`):
- assumptions text: "0 sorries, 0 axioms. All 7 theorems are fully proved."
- No `sorry`, no `axiom`, no `True` placeholders in file
- No imports from other Proofs.* files

**law-of-cosines-oq-04** (`Proofs/LawOfCosinesOQ04.lean`):
- assumptions text: "No axioms or sorries. All results proved from law of cosines."
- No `sorry`, no `axiom`, no `True` placeholders in file
- No imports from other Proofs.* files

## Changes

Both entries: `status: formalized → verified`, `badge: formalized → verified`

The `badge: formalized` was also non-standard (not in CLAUDE.md table); changed to `badge: verified`.

---
Automated fix by lean-mechanic agent.