### PR TITLE
Enrich rh-consequences: 6 annotations, 10 sections, Mertens-RH-Li connection

### DIFF
--- a/src/data/proofs/rh-consequences/annotations.json
+++ b/src/data/proofs/rh-consequences/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-rh-mertens-def",
+    "proofId": "rh-consequences",
+    "range": { "startLine": 62, "endLine": 113 },
+    "type": "definition",
+    "title": "The Mertens Function M(n) = Σ_{k≤n} μ(k)",
+    "content": "The Mertens function M(n) is defined as a finite sum of the Möbius function values from 0 to n. In Lean 4, `ArithmeticFunction.moebius` is the Mathlib implementation of μ. The function starts at M(0) = 0 (since μ(0) = 0 by convention), M(1) = 1 (μ(1) = 1), and M(2) = 0 (μ(0) + μ(1) + μ(2) = 0 + 1 + (−1) = 0). The Möbius function satisfies: μ(1) = 1, μ(p) = −1 for primes, μ(p₁···pₖ) = (−1)ᵏ for products of distinct primes, and μ(n) = 0 if n has a squared prime factor. Specific values are proved by `native_decide` — this computational approach is only feasible because ArithmeticFunction.moebius is computable in Mathlib.",
+    "mathContext": "$M(n) = \\sum_{k=1}^{n} \\mu(k)$, where $\\mu$ is the Möbius function: $\\mu(1)=1$, $\\mu(p)=-1$, $\\mu(p_1 \\cdots p_k) = (-1)^k$ (distinct primes), $\\mu(n) = 0$ (n has squared factor). Known values: $M(100) = 1$, $M(1000) = 2$. The Mertens conjecture $|M(n)| < \\sqrt{n}$ was disproved by Odlyzko-te Riele (1985): a counterexample exists around $n \\approx e^{10^{64}}$.",
+    "significance": "key",
+    "relatedConcepts": ["Möbius function", "squarefree numbers", "Mertens conjecture", "Odlyzko-te Riele theorem", "ArithmeticFunction.moebius"],
+    "prerequisites": ["Möbius function definition", "prime factorization", "squarefree integers", "Mathlib's ArithmeticFunction library"]
+  },
+  {
+    "id": "ann-rh-mertens-bound-axiom",
+    "proofId": "rh-consequences",
+    "range": { "startLine": 150, "endLine": 153 },
+    "type": "axiom",
+    "title": "Axiom: RH Implies |M(n)| = O(√n)",
+    "content": "The most famous consequence of RH formalized here: under the Riemann Hypothesis, the Mertens function is bounded by a constant multiple of √n. This was proved by Littlewood (1912), who showed the equivalence RH ⟺ M(x) = O(x^{1/2+ε}) for all ε > 0. The sharper form (O(√n) with a single constant C rather than x^ε factors) also follows from RH via exponential sum techniques. The axiom is stated with ∃ C > 0 to capture the O-notation precisely without choosing a specific constant. The proof requires Perron's formula (connecting Dirichlet series to summatory functions) and bounds on ζ'(s)/ζ(s) inside the critical strip — neither is in Mathlib yet.",
+    "mathContext": "RH $\\Rightarrow$ $|M(n)| \\leq C\\sqrt{n}$ for some absolute constant $C > 0$. Proof sketch: by Perron's formula, $M(x) = \\frac{1}{2\\pi i} \\int_{\\sigma - iT}^{\\sigma + iT} \\frac{x^s}{s \\zeta(s)} ds + O(x^\\sigma/T)$. Under RH, shift the contour to $\\text{Re}(s) = 1/2 + \\epsilon$; the residue at $s=0$ gives 0, and the integral over the vertical line is $O(\\sqrt{x} \\log^2 x)$. The Mertens conjecture $|M(n)| < \\sqrt{n}$ is stronger but false.",
+    "significance": "key",
+    "relatedConcepts": ["Perron's formula", "Dirichlet series", "Mertens conjecture", "Littlewood equivalence", "exponential sums"],
+    "prerequisites": ["Riemann Hypothesis statement", "Perron's formula", "zeta function zeros", "O-notation for asymptotic bounds"]
+  },
+  {
+    "id": "ann-rh-trivial-consequences",
+    "proofId": "rh-consequences",
+    "range": { "startLine": 182, "endLine": 202 },
+    "type": "theorem",
+    "title": "Trivial Consequences: Zeros on Critical Line and Trivial Zeros off It",
+    "content": "The two simplest consequences of RH are proved directly from Mathlib's definition. First, `rh_zeros_on_critical_line`: if RH holds, then every non-trivial zero (not of the form s = −2(n+1) and not s = 1) has real part 1/2. This is just an unfolding of the definition `RiemannHypothesis := ∀ s, ζ(s) = 0 → ¬∃n, s = −2(n+1) → s ≠ 1 → s.re = 1/2`. Second, `trivial_zeros_negative_real_part`: the trivial zeros at s = −2, −4, −6, ... have real part < 0 (specifically −2n < 0), hence they are NOT on the critical line Re(s) = 1/2. This is proved by a simple real-number inequality: (−2·(n+1)).re = −2(n+1) < 0 since n+1 > 0.",
+    "mathContext": "Mathlib's definition: $\\text{RiemannHypothesis} := \\forall s \\in \\mathbb{C},\\ \\zeta(s) = 0 \\to \\neg(\\exists n, s = -2(n+1)) \\to s \\neq 1 \\to \\text{Re}(s) = 1/2$. Trivial zeros: $s_n = -2n$ for $n = 1, 2, 3, \\ldots$ have $\\text{Re}(s_n) = -2n < 0 < 1/2$. Non-trivial zeros: all other zeros (excluding the pole at $s=1$), conjectured (RH) to satisfy $\\text{Re}(s) = 1/2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["critical line", "trivial zeros", "non-trivial zeros", "Riemann zeta function", "Mathlib's RiemannHypothesis"],
+    "prerequisites": ["Riemann zeta function zeros", "critical line Re(s) = 1/2", "Mathlib's Complex.re projection"]
+  },
+  {
+    "id": "ann-rh-lis-criterion",
+    "proofId": "rh-consequences",
+    "range": { "startLine": 545, "endLine": 546 },
+    "type": "axiom",
+    "title": "Li's Criterion: RH ⟺ All Li Constants λₙ ≥ 0",
+    "content": "Li's criterion (proved by Xian-Jin Li in 1997, generalized by Bombieri-Lagarias in 1999) provides a completely different characterization of RH: the Riemann Hypothesis holds if and only if all the Li constants λₙ = (1/(n-1)!) (d^n/ds^n [s^{n-1} log ξ(s)])_{s=1} are non-negative. Here ξ(s) = (1/2)s(s-1)π^{-s/2}Γ(s/2)ζ(s) is the completed zeta function. The Li constants have the explicit form λₙ = Σ_{ρ} [1 − (1 − 1/ρ)^n] where the sum is over non-trivial zeros ρ. Since RH asserts all ρ have Re(ρ) = 1/2, each term [1 − (1 − 1/ρ)^n] is non-negative when Re(ρ) ≥ 1/2. The criterion is axiomatized because the `liConstant` function is opaque — its definition requires the zero set of ζ(s), not yet formalized.",
+    "mathContext": "Li constants: $\\lambda_n = \\frac{1}{(n-1)!} \\frac{d^n}{ds^n}[s^{n-1} \\log \\xi(s)]\\big|_{s=1} = \\sum_\\rho \\left[1 - \\left(1 - \\frac{1}{\\rho}\\right)^n\\right]$ (sum over non-trivial zeros $\\rho$). Li's theorem: $\\lambda_n \\geq 0$ for all $n \\geq 1$ $\\Leftrightarrow$ $\\text{Re}(\\rho) = 1/2$ for all non-trivial $\\rho$ $\\Leftrightarrow$ RH. Numerical computation: $\\lambda_1 = \\sum_\\rho \\text{Re}(1/\\rho) \\approx 0.0231\\ldots > 0$.",
+    "significance": "key",
+    "relatedConcepts": ["completed zeta function ξ(s)", "Gamma function", "Li constants", "Bombieri-Lagarias generalization", "non-trivial zeros"],
+    "prerequisites": ["Riemann xi function", "derivatives of complex functions", "zeta function zeros", "Li's criterion statement"]
+  },
+  {
+    "id": "ann-rh-triple-equivalence",
+    "proofId": "rh-consequences",
+    "range": { "startLine": 1020, "endLine": 1025 },
+    "type": "theorem",
+    "title": "RH Implies Mertens Bound, Li's Criterion, and Density Hypothesis",
+    "content": "The theorem `rh_triple_equivalence` packages three results: (1) RH ⟹ |M(n)| = O(√n) (Mertens bound), (2) RH ⟺ all Li constants ≥ 0 (Li's criterion), and (3) RH ⟹ Density Hypothesis. The Density Hypothesis states that N(σ,T) ≪ T^{2(1-σ)+ε} where N(σ,T) counts zeros with Re(ρ) ≥ σ — this is a quantitative strengthening of RH. The proof is immediate: just apply the three previously-stated axioms. The theorem documents that these diverse characterizations of RH all follow from a single hypothesis — illustrating how RH is a central organizing principle of analytic number theory.",
+    "mathContext": "Density Hypothesis (DH): $N(\\sigma, T) \\ll T^{2(1-\\sigma)+\\epsilon}$ for all $\\sigma \\geq 1/2$. RH $\\Rightarrow$ DH: under RH, $N(\\sigma, T) = 0$ for $\\sigma > 1/2$ (no zeros off the critical line), which vacuously satisfies DH. Li: RH $\\Leftrightarrow$ $\\lambda_n \\geq 0$. Mertens: RH $\\Rightarrow$ $|M(n)| = O(\\sqrt{n})$. All packaged in one theorem as evidence that RH unifies analytic number theory.",
+    "significance": "context",
+    "relatedConcepts": ["Density Hypothesis", "zero-free regions", "analytic number theory unification", "Lindelöf Hypothesis"],
+    "prerequisites": ["Riemann Hypothesis", "Mertens function", "Li constants", "zero-density estimates"]
+  },
+  {
+    "id": "ann-rh-chebyshev-psi-bound",
+    "proofId": "rh-consequences",
+    "range": { "startLine": 1053, "endLine": 1075 },
+    "type": "axiom",
+    "title": "RH Implies ψ(x) = x + O(√x log²x): von Koch's Bound",
+    "content": "The Chebyshev psi function ψ(x) = Σ_{pᵏ≤x} log p (sum of log p over prime powers ≤ x) is the most natural function for studying prime distribution. The Prime Number Theorem (unconditional) gives ψ(x) = x + o(x). Under RH, von Koch (1901) proved the much sharper ψ(x) = x + O(√x log²x). This is the optimal error term: without RH, a zero at Re(ρ) = 1/2 + δ gives an error term of at least Ω(x^{1/2+δ}), worse than √x. The bound follows from the explicit formula ψ(x) = x − Σ_{ρ} x^ρ/ρ − log(2π): under RH, |x^ρ/ρ| = x^{1/2}/|ρ|, and Σ_ρ 1/|ρ| converges with log²x growth. The theorem `rh_implies_theta_upper_from_psi` then derives the upper bound for the Chebyshev theta function θ(x) from ψ(x) ≥ θ(x).",
+    "mathContext": "von Koch (1901): RH $\\Rightarrow$ $\\psi(x) = x + O(\\sqrt{x} \\log^2 x)$. Explicit formula: $\\psi(x) = x - \\sum_{\\rho} \\frac{x^\\rho}{\\rho} - \\log 2\\pi - \\frac{1}{2}\\log(1 - x^{-2})$. Under RH: $|x^\\rho/\\rho| = x^{1/2}/|\\rho|$, and $\\sum_\\rho 1/|\\rho| \\log x = O(\\log^2 x)$. Unconditional PNT gives only $\\psi(x) = x + o(x)$, exponentially weaker.",
+    "significance": "key",
+    "relatedConcepts": ["Chebyshev psi function", "explicit formula for ψ(x)", "prime number theorem", "von Koch's theorem", "von Mangoldt function"],
+    "prerequisites": ["Chebyshev functions θ and ψ", "explicit formula for prime counting", "analytic continuation of ζ(s)", "prime number theorem"]
+  }
+]

--- a/src/data/proofs/rh-consequences/meta.json
+++ b/src/data/proofs/rh-consequences/meta.json
@@ -92,5 +92,76 @@
       "description": "Dirichlet L-functions extend the zeta function framework used here"
     }
   ],
-  "sections": []
+  "sections": [
+    {
+      "id": "mathlib-rh-definition",
+      "title": "Mathlib's RiemannHypothesis Definition",
+      "startLine": 38,
+      "endLine": 61,
+      "summary": "Documents that RiemannHypothesis is already in Mathlib (NumberTheory.LSeries.RiemannZeta) as: ∀ non-trivial zero s of ζ, Re(s) = 1/2."
+    },
+    {
+      "id": "mertens-function",
+      "title": "Mertens Function and Möbius Properties",
+      "startLine": 62,
+      "endLine": 149,
+      "summary": "Defines M(n) = Σ_{k≤n} μ(k) via ArithmeticFunction.moebius. Computes M(0) through M(30) by native_decide. Proves Möbius properties: μ(1)=1, μ(p)=-1, μ(squarefree)=±1, μ(non-squarefree)=0."
+    },
+    {
+      "id": "main-rh-axioms",
+      "title": "Main RH Consequences (Axioms)",
+      "startLine": 150,
+      "endLine": 203,
+      "summary": "States rh_implies_mertens_bound as an axiom. Proves trivial consequences: zeros on critical line (directly from definition), trivial zeros off critical line (real part = -2n < 0)."
+    },
+    {
+      "id": "chebyshev-functions",
+      "title": "Chebyshev Theta and Psi Functions",
+      "startLine": 114,
+      "endLine": 230,
+      "summary": "Defines θ(n) = Σ_{p≤n prime} log p and ψ(n) = Σ_{pᵏ≤n} log p (von Mangoldt). Proves θ ≤ ψ, both computable."
+    },
+    {
+      "id": "lis-criterion",
+      "title": "Li's Criterion: RH ⟺ λₙ ≥ 0",
+      "startLine": 531,
+      "endLine": 551,
+      "summary": "States Li's criterion (1997, Bombieri-Lagarias 1999): RH iff all Li constants λₙ ≥ 0. The liConstant function is opaque since it requires the zero set of ζ(s)."
+    },
+    {
+      "id": "zero-counting",
+      "title": "Zero Counting and Riemann-von Mangoldt Formula",
+      "startLine": 565,
+      "endLine": 603,
+      "summary": "States the Riemann-von Mangoldt formula: N(T) = (T/2π)log(T/2πe) + O(log T). Notes computational verifications: 10^13 zeros verified on critical line by Gourdon (2004)."
+    },
+    {
+      "id": "cross-equivalences",
+      "title": "RH Triple Equivalence",
+      "startLine": 1020,
+      "endLine": 1027,
+      "summary": "Packages RH ⟹ Mertens bound, RH ⟺ Li's criterion, and RH ⟹ Density Hypothesis into a single theorem."
+    },
+    {
+      "id": "chebyshev-bounds",
+      "title": "Chebyshev Bounds: von Koch's ψ(x) = x + O(√x log²x)",
+      "startLine": 1053,
+      "endLine": 1132,
+      "summary": "States von Koch's (1901) bound ψ(x) = x + O(√x log²x) conditional on RH. Derives θ upper bound from ψ≥θ. Proves various RH-conditional Chebyshev inequalities."
+    },
+    {
+      "id": "redheffer-matrix",
+      "title": "Redheffer Matrix and Mertens Connection",
+      "startLine": 1174,
+      "endLine": 1200,
+      "summary": "Defines Redheffer matrix R(i,j) = 1 if j=1 or j|i. Notes the remarkable connection: det(R_n) = M(n), so RH ⟺ |det(R_n)| = O(n^{1/2+ε})."
+    },
+    {
+      "id": "hadamard-product",
+      "title": "Hadamard Product Theory",
+      "startLine": 1463,
+      "endLine": 1533,
+      "summary": "States the Hadamard product representation of ξ(s) over non-trivial zeros. Connects to prime counting through explicit formula. All statements axiomatized due to missing complex analysis infrastructure."
+    }
+  ]
 }


### PR DESCRIPTION
Enrichment pass for **rh-consequences** (RH Consequences, 1735 lines, 9 axioms).

## Quality improvements

**Annotations** (6 new, 0 → 6):
- `ann-rh-mertens-def` (lines 62–113): Mertens function via ArithmeticFunction.moebius; Mertens conjecture disproof context (Odlyzko-te Riele 1985)
- `ann-rh-mertens-bound-axiom` (lines 150–153): rh_implies_mertens_bound — Perron's formula proof sketch; why O(√n) vs O(x^{1/2+ε}) matters
- `ann-rh-trivial-consequences` (lines 182–202): Trivial zeros off critical line; how the Mathlib definition makes this immediate
- `ann-rh-lis-criterion` (lines 545–546): Li's criterion (1997) — λₙ ≥ 0 ⟺ RH; Bombieri-Lagarias generalization; opaque liConstant
- `ann-rh-triple-equivalence` (lines 1020–1025): Packages Mertens bound, Li's criterion, and Density Hypothesis
- `ann-rh-chebyshev-psi-bound` (lines 1053–1075): von Koch's ψ(x) = x + O(√x log²x); explicit formula proof sketch

**10 sections** covering all major parts of the 1735-line file.

## Axiom integrity
axiomCount: 9, all documented (rh_implies_mertens_bound, lis_criterion, riemann_von_mangoldt_formula, RH_implies_DensityHypothesis, rh_implies_psi_bound, explicit_formula_error, zeta_in_selberg_class, explicit_formula_zero_free, hadamard_product_exists). Status: `axiomatized`. No undocumented assumptions.