### PR TITLE
Fix: erdos-157 meta.json — correct sorries count (1→2)

### DIFF
--- a/src/data/proofs/erdos-157/meta.json
+++ b/src/data/proofs/erdos-157/meta.json
@@ -18,7 +18,7 @@
       "density"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 2,
     "erdosNumber": 157,
     "erdosUrl": "https://erdosproblems.com/157",
     "erdosProblemStatus": "solved",
@@ -60,7 +60,7 @@
     ],
     "axiomCount": 2,
     "lineCount": 258,
-    "assumptions": "2 axiom(s) and 1 sorry(s). See the Lean source for details."
+    "assumptions": "2 axiom(s) and 2 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "Sidon sets (B$_2$ sequences) — sets where all pairwise sums are distinct — were introduced by Simon Sidon in correspondence with Erdős in the 1930s. Erdős and Pál Turán proved in 1941 that a Sidon subset of $\\{1, \\ldots, N\\}$ has at most $(1+o(1))\\sqrt{N}$ elements, establishing their fundamental sparsity.\n\nAsymptotic bases of order $k$ — sets $A$ where every sufficiently large integer is a sum of at most $k$ elements of $A$ — require density at least $N^{1/k}$ by a counting argument. The tension between Sidon sparsity ($\\leq N^{1/2}$) and basis density ($\\geq N^{1/k}$) creates a natural threshold: coexistence requires $1/k \\leq 1/2$, i.e., $k \\geq 2$. But $k = 2$ is exactly the boundary and fails for subtle arithmetic reasons.\n\nErdős conjectured that order 3 should work, and this was open for decades despite partial results by Deshouillers and Plagne (2003) on finite Sidon sets. Cédric Pilatte (Oxford) settled the conjecture affirmatively in 2023 using a probabilistic construction, applying the Lovász Local Lemma and a careful densification argument. His proof is non-explicit: it shows such sets exist without constructing one.\n\nThis formalization includes two fully verified theorems: the equivalence of two Sidon set definitions, and the proof that $\\{2^k : k \\in \\mathbb{N}\\}$ forms a Sidon set (since binary representations are unique).",


### PR DESCRIPTION
## Fix

Corrects `sorries` count in `src/data/proofs/erdos-157/meta.json` from 1 to 2.

## Evidence

**Before**: `"sorries": 1`

**After**: `"sorries": 2`

**Verification**: `Erdos157Problem.lean` contains exactly 2 sorry tactics:
- Line 109: `theorem pilatte_existence := by sorry`
- Line 363: `private lemma sidon_counting_contradiction ... := by sorry`

PR #9152 incorrectly reduced the count from 2 to 1, apparently only counting the `pilatte_existence` theorem sorry but missing the `sidon_counting_contradiction` private lemma sorry.

---
Automated fix by lean-mechanic agent.