### PR TITLE
Enrich borsuk-ulam-oq-02-oq-01: 6 annotations, expanded historicalContext, 6 keyInsights

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-bu-budim-function",
+    "proofId": "borsuk-ulam-oq-02-oq-01",
+    "range": { "startLine": 52, "endLine": 52 },
+    "type": "axiom",
+    "title": "buDim: Equivariant BU Dimension Function",
+    "content": "The axiom buDim (n d : ℕ) : ℕ introduces the equivariant Borsuk-Ulam dimension for the cyclic group Z/n acting on a d-dimensional representation space. This integer-valued invariant captures the minimum sphere dimension where any Z/n-equivariant continuous map to the representation must have a zero. By axiomatizing buDim as an abstract function rather than defining it topologically, the file can study its algebraic properties (monotonicity, prime-factor behavior) purely in terms of group order and representation dimension, without requiring Lean's topological infrastructure.",
+    "mathContext": "$$\\text{buDim}(n, d) = \\min\\{k \\mid \\forall f: S^k \\to V_d \\text{ Z/n-equivariant continuous}, \\exists x, f(x) = 0\\}$$ where $V_d$ is a $d$-dimensional real representation of $\\mathbb{Z}/n\\mathbb{Z}$.",
+    "significance": "The central object of study: a numerical invariant encoding how large a sphere must be before equivariance forces a zero. All six proved theorems are statements about this single function.",
+    "relatedConcepts": ["equivariant topology", "Borsuk-Ulam theorem", "representation theory", "cohomological index theory"],
+    "prerequisites": ["Cyclic groups and their actions", "Equivariant continuous maps", "Sphere topology"]
+  },
+  {
+    "id": "ann-bu-classical-z2",
+    "proofId": "borsuk-ulam-oq-02-oq-01",
+    "range": { "startLine": 61, "endLine": 61 },
+    "type": "axiom",
+    "title": "Classical Borsuk-Ulam: Z/2 Base Case",
+    "content": "buDim_two axiomatizes the classical Borsuk-Ulam theorem in terms of buDim: every Z/2-equivariant (odd) continuous map f : S^n → R^{n+1} must vanish somewhere, giving buDim(2, n+1) = n. This is Borsuk's 1933 result, equivalently stated by Lyusternik and Schnirelmann as: there is no odd map S^n → S^{n-1}. In the buDim framework, it says the n-sphere is the minimal domain that forces a zero in an (n+1)-dimensional target under the antipodal action. This axiom is the Z/2 anchor from which z4_lower_bound and z6_lower_bound_z2 are derived via monotonicity.",
+    "mathContext": "$$\\text{buDim}(2, n+1) = n$$ encoding: every odd map $f : S^n \\to \\mathbb{R}^{n+1}$ satisfies $f(x_0) = 0$ for some $x_0 \\in S^n$, or equivalently $f(-x) = -f(x) \\implies \\exists x, f(x) = 0$.",
+    "significance": "The Z/2 base case is the foundation — composite group lower bounds for Z/4 and Z/6 are derived by applying monotonicity to reduce to this axiom.",
+    "relatedConcepts": ["Borsuk-Ulam theorem", "antipodal maps", "odd continuous functions", "Lyusternik-Schnirelmann theorem"],
+    "prerequisites": ["Classical Borsuk-Ulam theorem (1933)", "Antipodal Z/2 action on spheres"]
+  },
+  {
+    "id": "ann-bu-yang-borsuk",
+    "proofId": "borsuk-ulam-oq-02-oq-01",
+    "range": { "startLine": 66, "endLine": 67 },
+    "type": "axiom",
+    "title": "Yang-Borsuk Theorem for Prime-Order Groups",
+    "content": "buDim_prime axiomatizes Yang's 1954 generalization: for any prime p, the equivariant BU dimension for the standard complex representation of Z/p of complex dimension n equals 2n-1. The Z/p action rotates each complex coordinate by e^{2πi/p}. This is the definitive result for prime-order groups, proved by Yang using Smith theory and the Serre spectral sequence. The axiom provides the prime-case baseline for all derived composite group bounds: zpq_lower_bound uses this to get buDim(pq, 2n) ≥ 2n-1.",
+    "mathContext": "$$\\text{buDim}(p, 2n) = 2n - 1 \\quad \\text{for prime } p,\\; n \\geq 1$$ where the representation is $\\mathbb{C}^n$ with $g \\cdot (z_1, \\ldots, z_n) = (e^{2\\pi i/p} z_1, \\ldots, e^{2\\pi i/p} z_n)$ for a generator $g \\in \\mathbb{Z}/p$.",
+    "significance": "Yang's theorem (1954) completes the prime case and is the input to zpq_lower_bound. The buDim value 2n-1 ties the abstract invariant to the geometry of odd-dimensional spheres.",
+    "relatedConcepts": ["Yang-Borsuk theorem", "Smith theory", "Serre spectral sequence", "complex representations of Z/p"],
+    "prerequisites": ["Yang (1954) equivariant BU theorem", "Complex representations of prime cyclic groups", "Primitive roots of unity"]
+  },
+  {
+    "id": "ann-bu-monotonicity",
+    "proofId": "borsuk-ulam-oq-02-oq-01",
+    "range": { "startLine": 71, "endLine": 71 },
+    "type": "axiom",
+    "title": "Monotonicity: Divisibility Implies Stronger Equivariant Constraint",
+    "content": "buDim_mono axiomatizes the restriction principle: if p divides n, then Z/p embeds in Z/n as a subgroup, and every Z/n-equivariant map restricts to a Z/p-equivariant map. A map that must vanish for Z/p-equivariant reasons must also vanish when viewed as Z/n-equivariant, so the constraint from p propagates to n: buDim(p, d) ≤ buDim(n, d). This monotonicity axiom is the engine driving every composite group lower bound: z4_lower_bound uses p=2, n=4; z6_lower_bound_z2 uses p=2, n=6; z6_lower_bound_z3 uses p=3, n=6; zpq_lower_bound uses the prime factor of pq.",
+    "mathContext": "$$p \\mid n \\implies \\text{buDim}(p, d) \\leq \\text{buDim}(n, d)$$ reflecting the inclusion $\\mathbb{Z}/p \\hookrightarrow \\mathbb{Z}/n$ and the restriction functor on equivariant maps: $f$ is $\\mathbb{Z}/n$-equivariant $\\implies$ $f$ is $\\mathbb{Z}/p$-equivariant.",
+    "significance": "The single most-used axiom in the file. Every composite bound is a chain: buDim(p, d) ≤ buDim(n, d) from monotonicity combined with the known value of buDim(p, d) from buDim_two or buDim_prime.",
+    "relatedConcepts": ["subgroup restriction", "equivariant map restriction", "index theory monotonicity", "subgroup inclusion"],
+    "prerequisites": ["Subgroups of cyclic groups: Z/p ≤ Z/n when p | n", "Restriction of group actions to subgroups"]
+  },
+  {
+    "id": "ann-bu-composite-prime-bound",
+    "proofId": "borsuk-ulam-oq-02-oq-01",
+    "range": { "startLine": 79, "endLine": 82 },
+    "type": "theorem",
+    "title": "Every Composite Group Has a Prime-Derived Lower Bound",
+    "content": "buDim_composite_has_prime_bound proves: for any n ≥ 2, there exists a prime p with p | n and buDim(p, d) ≤ buDim(n, d). The proof is two lines: first apply Nat.exists_prime_and_dvd (since n ≥ 2 implies n ≠ 1, so n has a prime factor), then apply buDim_mono with the extracted prime divisor. This existential theorem establishes that no composite group can be 'easier' than all its prime subgroups simultaneously — there is always a prime subgroup whose constraint propagates upward.",
+    "mathContext": "$$\\forall n \\geq 2,\\; \\forall d:\\; \\exists p \\text{ prime},\\; p \\mid n \\text{ and } \\text{buDim}(p, d) \\leq \\text{buDim}(n, d)$$ proved using \\texttt{Nat.exists\\_prime\\_and\\_dvd}: $n \\geq 2 \\iff n \\neq 1 \\implies \\exists p \\text{ prime}, p \\mid n$.",
+    "significance": "The abstract justification for studying prime subgroups: every composite group's BU behavior is bounded below by at least one prime subgroup. The specific composite bounds for Z/4, Z/6, Z/pq are instances of this general principle.",
+    "relatedConcepts": ["Nat.exists_prime_and_dvd", "prime factorization", "BU dimension lower bounds", "prime subgroups"],
+    "prerequisites": ["Every integer ≥ 2 has a prime factor", "buDim_mono axiom"]
+  },
+  {
+    "id": "ann-bu-zpq-bound",
+    "proofId": "borsuk-ulam-oq-02-oq-01",
+    "range": { "startLine": 111, "endLine": 116 },
+    "type": "theorem",
+    "title": "Z/pq Lower Bound: Yang-Borsuk Meets Monotonicity",
+    "content": "zpq_lower_bound proves: for primes p, q and any n ≥ 1, buDim(pq, 2n) ≥ 2n-1. The proof chains two steps: buDim_mono with p | pq gives buDim(p, 2n) ≤ buDim(pq, 2n), and buDim_prime gives buDim(p, 2n) = 2n-1, so by transitivity the bound 2n-1 ≤ buDim(pq, 2n) follows. Note that p and q need not be distinct — the proof works for p = q, covering Z/p² as well as semiprimes. This generalizes z6_lower_bound_z3 and covers Z/15, Z/21, Z/35, Z/p² for any prime p.",
+    "mathContext": "$$\\text{buDim}(pq, 2n) \\geq 2n - 1 \\quad \\text{for primes } p, q,\\; n \\geq 1$$ via the chain: $\\text{buDim}(pq, 2n) \\stackrel{\\text{mono}}{\\geq} \\text{buDim}(p, 2n) \\stackrel{\\text{Yang}}{=} 2n - 1$.",
+    "significance": "Unifies Z/6, Z/10, Z/15, Z/p² under a single bound. Together with the open conjecture that equality holds, this would completely determine buDim for semiprimes in the standard complex representation.",
+    "relatedConcepts": ["semiprimes", "Yang-Borsuk theorem", "prime squares Z/p²", "monotonicity chain"],
+    "prerequisites": ["Yang-Borsuk theorem (buDim_prime)", "buDim_mono axiom", "Divisibility p | pq"]
+  }
+]

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01/meta.json
@@ -63,14 +63,17 @@
     }
   ],
   "overview": {
-    "historicalContext": "The Borsuk-Ulam theorem (1933) is a cornerstone of combinatorial topology. Its equivariant generalization replaces the Z/2 antipodal action with general group actions. For prime-order cyclic groups, Yang (1954) and Borsuk gave the definitive answer. The composite case remains largely open.",
+    "historicalContext": "The Borsuk-Ulam theorem was conjectured by Ulam and proved by Borsuk in 1933: every continuous map f : S^n → R^n satisfying f(-x) = -f(x) (odd map) must vanish. An equivalent formulation — no continuous odd map from S^n to S^{n-1} exists — became a fundamental tool in combinatorics via the Lovász-Kneser theorem (1978). The equivariant generalization asks: if a higher-order cyclic group Z/n acts on a sphere, what is the minimum sphere dimension that forces an equivariant map to vanish? Conner and Floyd (1956) and Yang (1954) extended the theory to prime-order groups using Smith theory and the Serre spectral sequence, obtaining the definitive Yang-Borsuk theorem: buDim(p, 2n) = 2n-1 for prime p. The composite case — what happens for Z/4, Z/6, Z/pq — requires the Fadell-Husseini ideal-valued index theory (1988), which axiomatizes properties of a cohomological index that controls equivariant map zeros. The present formalization abstracts away the topological content, treating buDim as an axiomatized function and deriving composite lower bounds from prime subgroup monotonicity alone.",
     "problemStatement": "For non-prime |G|, what is the optimal equivariant Borsuk-Ulam dimension?",
     "text": "An abstract framework for studying equivariant Borsuk-Ulam dimensions of cyclic groups Z/n with composite n. The file axiomatizes the known results (classical BU for Z/2, Yang-Borsuk for Z/p, monotonicity under divisibility) and derives concrete lower bounds for Z/4, Z/6, and general Z/pq. All 6 theorems are fully proved from the axioms with 0 sorries.",
     "proofStrategy": "Axiomatize the BU dimension function and known results. Derive composite group bounds from prime subgroup monotonicity. State the open conjecture.",
     "keyInsights": [
-      "Monotonicity under divisibility is the key structural principle for bounding composite BU dimensions",
-      "Both prime subgroups of Z/6 give the same bound 2n-1, so no additional information from having two primes",
-      "The open question reduces to whether composite groups have strictly higher BU dimensions than all prime subgroups"
+      "Monotonicity under divisibility is the engine: p | n implies Z/p ≤ Z/n, so every Z/n-equivariant map restricts to a Z/p-equivariant map — the constraint propagates up through the subgroup lattice",
+      "Yang-Borsuk (1954) gives the exact value for primes: buDim(p, 2n) = 2n-1 using the complex rotation representation. This is the sharp upper input for all composite lower bounds",
+      "Z/6 gets both Z/2 and Z/3 bounds simultaneously, but they agree: both give 2n-1 for the complex representation, so having two distinct prime subgroups provides no extra information over one",
+      "The zpq_lower_bound proof works for p = q, covering prime squares Z/p² with the same 2n-1 bound — composite group structure does not appear to add extra constraint in the standard representation",
+      "Axiomatizing buDim as an abstract ℕ → ℕ → ℕ function avoids topological infrastructure entirely: Smith theory, Serre spectral sequences, and Fadell-Husseini index theory are all encapsulated in four axioms, letting the algebraic argument be machine-verified",
+      "The open conjecture (buDim(n, d) = max_{p|n} buDim(p, d)) would mean composite groups add zero extra topological obstruction — the prime factorization completely determines the equivariant BU dimension"
     ],
     "prerequisites": [
       "Classical Borsuk-Ulam theorem",


### PR DESCRIPTION
## Summary

Enriches the `borsuk-ulam-oq-02-oq-01` gallery entry (Equivariant Borsuk-Ulam for Non-Prime Groups, 146 lines).

**Annotations** (6 new, all validated):
- `ann-bu-budim-function` — axiom `buDim` function (line 52): abstract equivariant BU dimension, mathContext with set-builder definition
- `ann-bu-classical-z2` — axiom `buDim_two` (line 61): classical Borsuk-Ulam Z/2 base case, Lyusternik-Schnirelmann connection
- `ann-bu-yang-borsuk` — axiom `buDim_prime` (lines 66-67): Yang-Borsuk theorem (1954), Smith theory context
- `ann-bu-monotonicity` — axiom `buDim_mono` (line 71): divisibility-implies-constraint principle, restriction functor explanation
- `ann-bu-composite-prime-bound` — theorem (lines 79-82): every composite group has a prime-derived lower bound via Nat.exists_prime_and_dvd
- `ann-bu-zpq-bound` — theorem (lines 111-116): Z/pq lower bound covering semiprimes and prime squares Z/p²

**Meta.json improvements:**
- `historicalContext`: expanded from 3 sentences to full narrative covering Borsuk (1933), Lyusternik-Schnirelmann, Lovász-Kneser (1978), Yang (1954), Fadell-Husseini (1988), and the axiomatization strategy
- `keyInsights`: expanded from 3 to 6 entries covering the monotonicity engine, Yang-Borsuk sharp value, Z/6 dual prime coincidence, prime squares Z/p², axiomatization approach, and the open conjecture significance

## Labels
`enrichment`

🤖 Generated with [Claude Code](https://claude.com/claude-code)