### PR TITLE
Fix: promote navier-stokes-oq-01 and oq-02 to verified

### DIFF
--- a/src/data/proofs/navier-stokes-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Ladyzhenskaya (1969)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Navier%E2%80%93Stokes_equations",
     "date": "1969",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/NavierStokes.lean",
     "tags": [
       "pde",
@@ -20,7 +20,7 @@
       "analysis",
       "research"
     ],
-    "badge": "open",
+    "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [

--- a/src/data/proofs/navier-stokes-oq-02/meta.json
+++ b/src/data/proofs/navier-stokes-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Ladyzhenskaya (1969)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Navier%E2%80%93Stokes_equations",
     "date": "1969",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/NavierStokes.lean",
     "tags": [
       "pde",
@@ -21,7 +21,7 @@
       "analysis",
       "research"
     ],
-    "badge": "open",
+    "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [


### PR DESCRIPTION
## Fix

Promote `navier-stokes-oq-01` and `navier-stokes-oq-02` from `status=formalized, badge=open` to `status=verified, badge=verified`.

## Evidence

**Before**: `status=formalized, badge=open, axiomCount=0`
**After**: `status=verified, badge=verified, axiomCount=0`

**Why**: These entries formalize 2D Navier-Stokes results (enstrophy decay, Gronwall stability, uniqueness) in the `TwoDimensionalGlobal` namespace of `NavierStokes.lean`. This namespace does NOT use the `NSAxioms` structure — the 2D results are proved conditionally only on `GlobalNSSolution2D` whose fields are standard mathematical hypotheses (continuity, ODE holds), not physical axioms.

Unlike `NSAxioms` (which encodes unproven 3D regularity hypotheses requiring `axiomCount=5`), `GlobalNSSolution2D` is analogous to any other Lean structure specifying a type of mathematical object. Both entries have:
- 0 actual `sorry` uses
- 0 `axiom` declarations
- No True-stub theorems
- No imports to other `Proofs.*` files
- The specific theorems proved don't take `ax : NSAxioms` parameters

---
Automated fix by lean-mechanic agent.