### PR TITLE
Enrich sum-of-kth-powers-oq-04: 6 annotations, expanded historicalContext and keyInsights

### DIFF
--- a/src/data/proofs/sum-of-kth-powers-oq-04/annotations.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-04/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-emac-bernoulli-leading",
+    "proofId": "sum-of-kth-powers-oq-04",
+    "range": { "startLine": 46, "endLine": 58 },
+    "type": "theorem",
+    "title": "Bernoulli Polynomial is Monic of Degree k+1",
+    "content": "bernoulli_poly_leading proves two properties of the Bernoulli polynomial B_{k+1}: its leading coefficient is 1 (monic) and its degree is exactly k+1. The proof works in two steps: the private bernoulli_coeff_top lemma first establishes that the (k+1)-th coefficient is 1 via coeff_bernoulli (which gives coeff(B_n, i) = bernoulli(n-i) * C(n,i) for i ≤ n; at i = n this is bernoulli(0) * 1 = 1). Then natDegree is pinned by an antisymmetry argument: coeff_above shows coefficients at positions > k+1 are zero (via coeff_bernoulli returning 0 for out-of-range indices), and le_natDegree_of_ne_zero shows the degree is at least k+1.",
+    "mathContext": "$$\\text{leadingCoeff}(B_{k+1}) = 1,\\quad \\deg(B_{k+1}) = k+1$$ where $B_{k+1}(x) = \\sum_{j=0}^{k+1} \\binom{k+1}{j} b_{k+1-j} x^j$ and $b_0 = 1$. The leading term $\\binom{k+1}{k+1} b_0 x^{k+1} = x^{k+1}$ gives monicity.",
+    "significance": "Previously axiomatized — now fully proved from Mathlib's coeff_bernoulli API. This eliminated one of the two original axioms, leaving only monic_poly_ratio_tendsto as the remaining assumption.",
+    "relatedConcepts": ["Polynomial.bernoulli", "coeff_bernoulli", "Polynomial.leadingCoeff", "natDegree_le_iff_coeff_eq_zero"],
+    "prerequisites": ["Bernoulli polynomials in Mathlib", "Polynomial degree and leading coefficient"]
+  },
+  {
+    "id": "ann-emac-ratio-def",
+    "proofId": "sum-of-kth-powers-oq-04",
+    "range": { "startLine": 63, "endLine": 65 },
+    "type": "definition",
+    "title": "powerSumRatio: The Normalized Power Sum",
+    "content": "powerSumRatio k n is the ratio (∑_{i=0}^{n-1} i^k) / n^{k+1}, defined over ℚ with the convention that the value is 0 when n = 0 (to make it a total function). The denominator n^{k+1} normalizes the sum to the scale of 1/(k+1): by the Riemann sum interpretation, this ratio approximates ∫₀¹ x^k dx = 1/(k+1) for large n. The definition uses noncomputable because it involves rational division.",
+    "mathContext": "$$R_k(n) = \\begin{cases} 0 & n = 0 \\\\ \\dfrac{\\displaystyle\\sum_{i=0}^{n-1} i^k}{n^{k+1}} & n > 0 \\end{cases}$$ which is a discrete approximation to $\\int_0^1 x^k\\,dx = \\frac{1}{k+1}$.",
+    "significance": "The central quantity studied. All four theorems (k=0, k=1, general tendsto, and the Faulhaber rewriting) are statements about this ratio.",
+    "relatedConcepts": ["Riemann sums", "Faulhaber's formula", "Finset.sum", "noncomputable definition"],
+    "prerequisites": ["Finset.range in Mathlib", "Rational number arithmetic", "Sum of powers definitions"]
+  },
+  {
+    "id": "ann-emac-monic-axiom",
+    "proofId": "sum-of-kth-powers-oq-04",
+    "range": { "startLine": 73, "endLine": 75 },
+    "type": "axiom",
+    "title": "Monic Polynomial Ratio Tends to 1",
+    "content": "monic_poly_ratio_tendsto is the single remaining axiom: for any monic polynomial p of degree d ≥ 1 over ℚ, the ratio p(n)/n^d converges to 1 as n → ∞. The comment describes the proof strategy: write p = X^d + q with deg(q) < d, so p(n)/n^d = 1 + q(n)/n^d. Each term of q(n)/n^d has the form c/n^m with m ≥ 1, which tends to 0. The obstacle to proving this in Lean is the need to manipulate polynomial evaluation of lower-degree terms in the filter limit API — a nontrivial analytic argument not currently automated in Mathlib.",
+    "mathContext": "$$\\frac{p(n)}{n^d} \\xrightarrow{n\\to\\infty} 1 \\quad \\text{for monic } p \\text{ of degree } d \\geq 1$$ since $p(n) = n^d + a_{d-1}n^{d-1} + \\cdots + a_0 = n^d\\left(1 + \\frac{a_{d-1}}{n} + \\cdots + \\frac{a_0}{n^d}\\right) \\to n^d \\cdot 1$.",
+    "significance": "The key analytic gap: once this is proved, powerSumRatio_tendsto follows from bernoulli_poly_leading + Faulhaber's formula with no additional axioms. The proof strategy is clear but requires careful Mathlib filter API manipulation.",
+    "relatedConcepts": ["Polynomial.eval", "Filter.Tendsto", "Filter.atTop", "polynomial leading term decomposition"],
+    "prerequisites": ["Filter limits in Mathlib topology", "Polynomial evaluation over ℚ", "atTop filter"]
+  },
+  {
+    "id": "ann-emac-main-tendsto",
+    "proofId": "sum-of-kth-powers-oq-04",
+    "range": { "startLine": 105, "endLine": 138 },
+    "type": "theorem",
+    "title": "Main Theorem: Power Sum Ratio Converges to 1/(k+1)",
+    "content": "powerSumRatio_tendsto is the main result: Tendsto (powerSumRatio k) atTop (nhds (1/(k+1))). The four-step proof is a masterclass in filter manipulation: Step 1 uses filter_upwards to rewrite powerSumRatio for large n using Faulhaber's formula (sum_range_pow_eq_bernoulli_sub), expressing the ratio as (B_{k+1}(n) - c) / ((k+1) · n^{k+1}) where c = B_{k+1}(0). Step 2 targets this rewritten limit. Step 3 splits via sub_div and applies Filter.Tendsto.sub. Step 4 handles the two terms: B_{k+1}(n)/((k+1)·n^{k+1}) → 1/(k+1) using monic_poly_ratio_tendsto divided by the constant (k+1); and c/((k+1)·n^{k+1}) → 0 using const_div_pow_tendsto_zero.",
+    "mathContext": "$$R_k(n) = \\frac{B_{k+1}(n) - B_{k+1}(0)}{(k+1) n^{k+1}} \\xrightarrow{n\\to\\infty} \\frac{1}{k+1} - 0 = \\frac{1}{k+1}$$ since $B_{k+1}(n)/n^{k+1} \\to 1$ (monic axiom) and $B_{k+1}(0)/n^{k+1} \\to 0$.",
+    "significance": "The central theorem of the file. It transforms a discrete-to-continuous convergence statement into a clean chain of filter limit computations, leveraging Faulhaber's formula and the monic axiom.",
+    "relatedConcepts": ["filter_upwards", "sum_range_pow_eq_bernoulli_sub", "Filter.Tendsto.sub", "Filter.Tendsto.div_const"],
+    "prerequisites": ["Faulhaber's formula in Mathlib", "Filter.Tendsto API", "monic_poly_ratio_tendsto axiom", "bernoulli_poly_leading"]
+  },
+  {
+    "id": "ann-emac-k0-case",
+    "proofId": "sum-of-kth-powers-oq-04",
+    "range": { "startLine": 141, "endLine": 146 },
+    "type": "theorem",
+    "title": "Exact Formula k=0: Power Sum Ratio Equals 1",
+    "content": "powerSumRatio_k0 proves: for n ≠ 0, powerSumRatio 0 n = 1. The proof uses simp to compute ∑_{i<n} i⁰ = n (each term is 1, and there are n terms), then the denominator n^1 = n, so the ratio n/n = 1 by div_self. This is the degenerate case confirming that the constant function 1 has a power sum ratio identically 1, consistent with 1/(0+1) = 1.",
+    "mathContext": "$$R_0(n) = \\frac{\\sum_{i=0}^{n-1} 1}{n^1} = \\frac{n}{n} = 1 = \\frac{1}{0+1}$$ exactly, for all $n \\geq 1$.",
+    "significance": "The simplest verification: the k=0 case is exact, not just asymptotic. This grounds the abstract convergence theorem in a concrete equality.",
+    "relatedConcepts": ["Finset.sum_const", "div_self", "pow_zero"],
+    "prerequisites": ["Finset.card_range", "Rational division"]
+  },
+  {
+    "id": "ann-emac-k1-case",
+    "proofId": "sum-of-kth-powers-oq-04",
+    "range": { "startLine": 159, "endLine": 167 },
+    "type": "theorem",
+    "title": "Exact Formula k=1: Gauss Sum Ratio Is (n-1)/(2n)",
+    "content": "powerSumRatio_k1 proves: for n > 0, powerSumRatio 1 n = (n-1)/(2n). The proof uses the private gauss_sum_rat lemma: 2 · ∑_{i<n} i = n·(n-1) (proved by induction). From this, ∑ i = n(n-1)/2, and dividing by n² gives (n-1)/(2n). As n → ∞, this converges to 1/2 = 1/(1+1), confirming the main theorem in this special case. The proof uses field_simp + nlinarith to close the algebraic identity.",
+    "mathContext": "$$R_1(n) = \\frac{\\sum_{i=0}^{n-1} i}{n^2} = \\frac{n(n-1)/2}{n^2} = \\frac{n-1}{2n} \\xrightarrow{n\\to\\infty} \\frac{1}{2} = \\frac{1}{1+1}$$ using the Gauss sum $\\sum_{i=0}^{n-1} i = \\frac{n(n-1)}{2}$.",
+    "significance": "The most famous instance of the power sum formula: the Gauss summation n(n-1)/2 is verified over ℚ by induction, then used to prove the exact ratio. This case fully confirms the asymptotic theorem with an exact equality.",
+    "relatedConcepts": ["gauss_sum_rat (private lemma)", "Gauss summation formula", "field_simp", "nlinarith"],
+    "prerequisites": ["Gauss sum 1+2+...+(n-1) = n(n-1)/2", "Inductive proof of sum formulas", "field_simp tactic"]
+  }
+]

--- a/src/data/proofs/sum-of-kth-powers-oq-04/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-04/meta.json
@@ -51,14 +51,17 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The Euler-Maclaurin formula, discovered independently by Euler (1738) and Maclaurin (1742), connects discrete sums to integrals with correction terms involving Bernoulli numbers. The simplest consequence is the asymptotic formula: for power sums, the ratio sum_{i<n} i^k / n^{k+1} converges to 1/(k+1) as n -> infinity, matching the integral of x^k from 0 to 1.",
+    "historicalContext": "The Euler-Maclaurin formula was discovered independently by Euler (1738) in 'Methodus generalis summandi progressiones' and by Maclaurin (1742) in 'Treatise of Fluxions'. It provides an asymptotic expansion connecting a discrete sum ∑_{j=a}^{b} f(j) to the integral ∫_a^b f(x) dx plus correction terms involving Bernoulli numbers B_{2k} and derivatives of f. The simplest consequence, requiring no correction terms, is: ∑_{i=0}^{n-1} i^k / n^{k+1} → 1/(k+1), which matches the Riemann sum approximation to ∫₀¹ x^k dx = 1/(k+1). Faulhaber's formula (1631), which gives the exact closed form (k+1)·∑ i^k = B_{k+1}(n) - B_{k+1}(0) using Bernoulli polynomials, provides the algebraic route to this asymptotic. Johann Faulhaber computed power sums up to k=17 by hand; the Bernoulli polynomial formulation was clarified by Jakob Bernoulli in 'Ars Conjectandi' (1713). The formalization here shows that the asymptotic is a purely algebraic consequence of Faulhaber's formula and the monicity of B_{k+1}, requiring only one non-trivial analytical axiom.",
     "problemStatement": "$$\\frac{\\sum_{i=0}^{n-1} i^k}{n^{k+1}} \\to \\frac{1}{k+1} \\quad \\text{as } n \\to \\infty$$",
     "text": "A 101-line formalization of asymptotic power sum behavior. Defines the normalized power sum ratio, axiomatizes Bernoulli polynomial leading behavior, and proves exact formulas for k=0 (trivial) and k=1 (via Gauss sum). The general asymptotic theorem is stated with proof strategy documented.",
     "proofStrategy": "The proof uses Faulhaber's formula: (k+1) * sum i^k = B_{k+1}(n) - B_{k+1}(0), where B_{k+1} is the Bernoulli polynomial. Since B_{k+1} is monic of degree k+1, the ratio B_{k+1}(n)/n^{k+1} -> 1, giving sum i^k / n^{k+1} -> 1/(k+1).",
     "keyInsights": [
-      "The asymptotic 1/(k+1) matches the integral of x^k from 0 to 1 — this is the Riemann sum interpretation",
-      "Faulhaber's formula provides the exact algebraic connection between power sums and Bernoulli polynomials",
-      "The k=1 case (n-1)/(2n) -> 1/2 is proved from the Gauss sum formula"
+      "The asymptotic 1/(k+1) is the Riemann sum interpretation: ∑_{i<n} (i/n)^k · (1/n) → ∫₀¹ x^k dx = 1/(k+1), where each term i^k/n^{k+1} = (i/n)^k/n is a rectangle of width 1/n at height (i/n)^k",
+      "Faulhaber's formula bridges the algebraic and analytic: (k+1)·∑ i^k = B_{k+1}(n) - B_{k+1}(0) lets the limit reduce to the fact that B_{k+1}(n)/n^{k+1} → 1 (monicity of B_{k+1})",
+      "bernoulli_poly_leading was previously an axiom but is now proved from Mathlib's coeff_bernoulli API: coeff(B_n, n) = bernoulli(0) · C(n,n) = 1, and coefficients above degree n vanish — a clean proof of monicity without algebraic manipulation",
+      "The main proof is a three-step filter computation: rewrite using Faulhaber (filter_upwards), split numerator (sub_div + Tendsto.sub), apply the monic limit axiom and const_div_pow_tendsto_zero independently",
+      "The k=1 case gives the exact formula (n-1)/(2n) for all n > 0, not just asymptotically — confirmed by the Gauss induction gauss_sum_rat proving 2·∑ i = n(n-1) in ℚ",
+      "The one remaining axiom (monic_poly_ratio_tendsto) has a clear proof strategy but requires decomposing a polynomial into its leading term plus lower-degree terms in the Mathlib filter API — an achievable but technically involved formalization target"
     ]
   },
   "sections": [
@@ -106,8 +109,10 @@
     "summary": "The asymptotic formula sum i^k / n^{k+1} -> 1/(k+1) is stated and the k=0 and k=1 cases are proved. The general case remains as a sorry requiring filter limit manipulation with Faulhaber's formula.",
     "implications": "Connects discrete power sums to continuous integration via the Riemann sum interpretation, laying groundwork for a full Euler-Maclaurin formalization in Lean 4.",
     "openQuestions": [
-      "Can the full Euler-Maclaurin formula with Bernoulli correction terms be formalized?",
-      "Can the error term in the Euler-Maclaurin approximation be bounded?"
+      "Prove monic_poly_ratio_tendsto: decompose p = X^d + q with deg(q) < d, show q(n)/n^d → 0 term by term using const_div_pow_tendsto_zero for each monomial",
+      "Can the full Euler-Maclaurin formula with Bernoulli correction terms be formalized? The formula ∑_{j=a}^{b} f(j) = ∫_a^b f + (f(a)+f(b))/2 + ∑ B_{2k}/(2k)! · (f^{(2k-1)}(b) - f^{(2k-1)}(a)) requires differentiation and big-O error term infrastructure",
+      "Extend to the error term: ∑ i^k = n^{k+1}/(k+1) + n^k/2 + O(n^{k-1}), proving the sub-leading Bernoulli correction",
+      "Can the Riemann sum interpretation be formalized directly using Mathlib's MeasureTheory.intervalIntegral, proving ∑ f(i/n)/n → ∫₀¹ f for smooth f?"
     ]
   },
   "references": [


### PR DESCRIPTION
## Summary

Enriches the `sum-of-kth-powers-oq-04` gallery entry (Euler-Maclaurin Asymptotics for Power Sums, 169 lines, 1 axiom).

**Annotations** (6 new, all validated):
- `ann-emac-bernoulli-leading` — `bernoulli_poly_leading` (line 46): proves B_{k+1} is monic of degree k+1 via `coeff_bernoulli` API — previously an axiom, now proved
- `ann-emac-ratio-def` — `powerSumRatio` (line 63): the normalized ratio definition with Riemann sum interpretation
- `ann-emac-monic-axiom` — `monic_poly_ratio_tendsto` (line 73): the remaining axiom with documented proof strategy (lower-degree terms → 0)
- `ann-emac-main-tendsto` — `powerSumRatio_tendsto` (line 105): main theorem, four-step filter proof combining Faulhaber + monic axiom + const_div_pow
- `ann-emac-k0-case` — `powerSumRatio_k0` (line 141): exact k=0 formula (ratio = 1) via div_self
- `ann-emac-k1-case` — `powerSumRatio_k1` (line 159): exact k=1 formula (n-1)/(2n) via Gauss sum induction

**Meta.json improvements:**
- `historicalContext`: expanded from 2 sentences to full narrative (Euler 1738, Maclaurin 1742, Faulhaber 1631, Bernoulli 1713)
- `keyInsights`: expanded from 3 to 6 entries: Riemann sum interpretation, Faulhaber bridge, bernoulli_poly_leading now proved, 4-step filter proof structure, exact k=1 Gauss sum, remaining axiom proof path
- `openQuestions`: expanded from 2 to 4 with specific Lean proof strategies for monic axiom and full Euler-Maclaurin

## Labels
`enrichment`

🤖 Generated with [Claude Code](https://claude.com/claude-code)