### PR TITLE
Enrich erdos-1018-oq-04: 6 annotations, expanded historicalContext, keyInsights, openQuestions

### DIFF
--- a/src/data/proofs/erdos-1018-oq-04/annotations.json
+++ b/src/data/proofs/erdos-1018-oq-04/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-e1018-hypergraph-struct",
+    "proofId": "erdos-1018-oq-04",
+    "range": { "startLine": 35, "endLine": 38 },
+    "type": "definition",
+    "title": "Hypergraph Structure: Uniform Simplicial Complex",
+    "content": "The Hypergraph structure captures an r-uniform hypergraph: a collection of edges (Finset of Finsets) where every edge has exactly r vertices. The uniformity field `uniform : ∀ e ∈ edges, e.card = r` is a proof-valued field encoding the mathematical constraint directly in the type. This models an r-uniform hypergraph as an (r-1)-dimensional simplicial complex: each edge is an (r-1)-simplex, and the uniformity constraint ensures the complex is pure. The formalization uses Finset (Finset V) rather than Finset (Fin r → V) to make the edge-as-subset perspective natural.",
+    "mathContext": "$$H = (V, E) \\text{ with } E \\subseteq \\binom{V}{r}$$, i.e., $\\forall e \\in E, |e| = r$. As a simplicial complex: $H$ is the pure $(r-1)$-dimensional complex with $(r-1)$-simplices given by $E$.",
+    "significance": "The foundational definition. The structure-with-proof-field design lets the uniformity constraint be inherited automatically in induced sub-hypergraphs via the `induced` definition.",
+    "relatedConcepts": ["simplicial complex", "r-uniform hypergraph", "Finset.card", "structure with proof fields"],
+    "prerequisites": ["Finset API in Mathlib", "Structures with dependent fields in Lean 4"]
+  },
+  {
+    "id": "ann-e1018-vkf-axiom",
+    "proofId": "erdos-1018-oq-04",
+    "range": { "startLine": 162, "endLine": 163 },
+    "type": "axiom",
+    "title": "van Kampen-Flores Theorem: K_{2r+1}^(r) is Not Embeddable",
+    "content": "vanKampen_Flores axiomatizes the van Kampen-Flores theorem (proved independently by van Kampen and Flores, both 1933): for r ≥ 2, the complete r-uniform hypergraph on 2r+1 vertices cannot be embedded in R^(2(r-1)) as a simplicial complex. This is the direct generalization of K₅ being non-planar (r=2: K₅ not in R²). The proof uses the Borsuk-Ulam theorem via Z/2-equivariant topology: the deleted product construction of K_{2r+1}^(r) has a non-trivial Z/2-map to S^{2(r-1)-1}, which by Borsuk-Ulam cannot exist for an embeddable complex.",
+    "mathContext": "$$K_{2r+1}^{(r)} \\not\\hookrightarrow \\mathbb{R}^{2(r-1)}$$ for $r \\geq 2$, where the embedding is as an $(r-1)$-dimensional simplicial complex. Special cases: $K_5 \\not\\hookrightarrow \\mathbb{R}^2$ (Kuratowski), $K_7^{(3)} \\not\\hookrightarrow \\mathbb{R}^4$.",
+    "significance": "The key topological axiom providing the non-embeddability obstruction that generalizes K₅ non-planarity to all uniformities. Every non-embeddability result in this file derives from this axiom.",
+    "relatedConcepts": ["van Kampen-Flores theorem", "Borsuk-Ulam theorem", "deleted product", "Z/2-equivariant topology", "Kuratowski's theorem"],
+    "prerequisites": ["Simplicial complex embeddings", "van Kampen-Flores (1933)", "Borsuk-Ulam method"]
+  },
+  {
+    "id": "ann-e1018-k5-nonplanar",
+    "proofId": "erdos-1018-oq-04",
+    "range": { "startLine": 167, "endLine": 172 },
+    "type": "theorem",
+    "title": "Graph Case Recovery: K₅ is Non-Planar",
+    "content": "vanKampen_Flores_graph recovers the classical K₅ non-planarity result as a corollary of the van Kampen-Flores axiom for r=2. The proof instantiates vanKampen_Flores at r=2, uses simp to unfold criticalDim 2 = 2*(2-1) = 2, and uses convert to match K₅ = completeHypergraph 5 2 (since 2*2+1 = 5). The convert tactic handles the numerical matching, and norm_num closes the arithmetic goals. This shows the framework correctly reduces to the known graph case.",
+    "mathContext": "$$K_5 = K_{2\\cdot 2+1}^{(2)} \\not\\hookrightarrow \\mathbb{R}^{2(2-1)} = \\mathbb{R}^2$$ recovered from \\texttt{vanKampen\\_Flores 2}: \\texttt{criticalDim 2 = 2} and $2 \\cdot 2 + 1 = 5$.",
+    "significance": "Validates the framework by recovering classical planarity theory as a special case. The use of convert + norm_num is the standard pattern for specializing parametric theorems with numerical conditions.",
+    "relatedConcepts": ["Kuratowski's theorem", "K₅ non-planarity", "convert tactic", "criticalDim"],
+    "prerequisites": ["Kuratowski/Wagner planarity theorem", "criticalDim definition", "convert tactic in Lean 4"]
+  },
+  {
+    "id": "ann-e1018-conjecture",
+    "proofId": "erdos-1018-oq-04",
+    "range": { "startLine": 197, "endLine": 204 },
+    "type": "definition",
+    "title": "hypergraph_kostochka_pyber: The Generalized Open Conjecture",
+    "content": "hypergraph_kostochka_pyber formalizes the open conjecture: for every r ≥ 2 and ε > 0, there exists a constant C = C_{r,ε} such that every r-uniform hypergraph on sufficiently many vertices (n ≥ N) with ≥ n^{r-1+ε} edges contains a sub-hypergraph on ≤ C vertices that is not embeddable in R^{2(r-1)}. The nested quantifiers capture: universality over uniformity r, a ε-threshold, existence of a bounded-size obstruction C and a threshold N, then universality over all large enough vertex sets and dense enough hypergraphs. This is an OPEN problem for r ≥ 3.",
+    "mathContext": "$$\\forall r \\geq 2, \\forall \\varepsilon > 0, \\exists C, N:\\; \\forall H \\text{ r-uniform on } n \\geq N \\text{ vertices},\\; |E(H)| \\geq n^{r-1+\\varepsilon} \\implies \\exists S \\subseteq V(H),\\; |S| \\leq C,\\; K_{2r+1}^{(r)} \\hookrightarrow H[S] \\text{ non-embeddably}$$.",
+    "significance": "The central open problem of the file. The r=2 case is the proved Kostochka-Pyber (1988) theorem. Proving this for r=3 would be a major result in topological combinatorics.",
+    "relatedConcepts": ["Kostochka-Pyber theorem", "topological Ramsey theory", "extremal hypergraph theory", "bounded-size obstruction"],
+    "prerequisites": ["hasSmallNonEmbeddable", "isDenseHypergraph", "isNonEmbeddable", "criticalDim"]
+  },
+  {
+    "id": "ann-e1018-k7-3uniform",
+    "proofId": "erdos-1018-oq-04",
+    "range": { "startLine": 247, "endLine": 251 },
+    "type": "theorem",
+    "title": "K₇^(3) is Not Embeddable in R⁴",
+    "content": "K7_3_nonembeddable proves that the complete 3-uniform hypergraph on 7 vertices is not embeddable in R⁴. This is the r=3 instance of the van Kampen-Flores theorem. The proof follows the same pattern as vanKampen_Flores_graph: instantiate vanKampen_Flores at r=3, unfold criticalDim 3 = 2*(3-1) = 4, and use convert + norm_num to match K₇^(3) = completeHypergraph 7 3 (since 2*3+1 = 7). K₇^(3) has C(7,3) = 35 edges (proved by K7_3_edge_count via decide), making it the simplest non-planar object in 3-uniform hypergraph theory.",
+    "mathContext": "$$K_7^{(3)} = K_{2\\cdot 3+1}^{(3)} \\not\\hookrightarrow \\mathbb{R}^{2(3-1)} = \\mathbb{R}^4$$ with $|E(K_7^{(3)})| = \\binom{7}{3} = 35$. The analogy: $K_5$ (10 edges) is non-planar, $K_7^{(3)}$ (35 edges) is the 3-uniform non-$\\mathbb{R}^4$-embeddable analogue.",
+    "significance": "The first non-trivial instance — the 3-uniform case is the first open case of the generalized Kostochka-Pyber conjecture. K₇^(3) plays the role that K₅ plays for graphs.",
+    "relatedConcepts": ["3-uniform hypergraphs", "van Kampen-Flores for r=3", "K7_3_edge_count", "R⁴ embeddability"],
+    "prerequisites": ["van Kampen-Flores axiom", "criticalDim 3 = 4", "C(7,3) = 35"]
+  },
+  {
+    "id": "ann-e1018-turan-axiom",
+    "proofId": "erdos-1018-oq-04",
+    "range": { "startLine": 276, "endLine": 278 },
+    "type": "axiom",
+    "title": "Super-Linear Density Exceeds All Turán Numbers",
+    "content": "density_exceeds_turan axiomatizes the key comparison: for r ≥ 2, t > r, and ε > 0, the super-linear density n^{r-1+ε} eventually exceeds the Turán number ex(n, K_t^(r)) for any fixed t. This connects the edge density threshold n^{r-1+ε} to the Turán extremal framework: when a hypergraph is too dense to be K_t^(r)-free (for some bounded t), it must contain complete sub-hypergraphs, which are candidates for the non-embeddable sub-hypergraphs. The turanNumber function is defined with sorry (the exact Turán numbers for r ≥ 3 are largely unknown — the Turán density problem for K₄^(3) is one of the most famous open problems in combinatorics).",
+    "mathContext": "$$\\forall t > r,\\; \\forall \\varepsilon > 0:\\; n^{r-1+\\varepsilon} > \\text{ex}(n, K_t^{(r)}) \\text{ for large } n$$ where $\\text{ex}(n, K_t^{(r)})$ is the maximum edges in an $r$-uniform $K_t^{(r)}$-free hypergraph on $n$ vertices.",
+    "significance": "Bridges the density condition n^{r-1+ε} to Turán theory: densities above the Turán threshold force complete sub-hypergraphs, providing the candidate non-embeddable structures.",
+    "relatedConcepts": ["Turán problem for hypergraphs", "turanNumber (sorry)", "K₄^(3) Turán density problem", "extremal numbers"],
+    "prerequisites": ["Turán numbers for hypergraphs", "Hypergraph Turán densities (mostly unknown for r ≥ 3)"]
+  }
+]

--- a/src/data/proofs/erdos-1018-oq-04/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04/meta.json
@@ -39,15 +39,17 @@
     ]
   },
   "overview": {
-    "historicalContext": "Kostochka and Pyber (1988) resolved Erdős Problem #1018: graphs with n^(1+ε) edges contain K₅ subdivisions on O_ε(1) vertices. The natural question is how this extends to higher uniformity. For r-uniform hypergraphs, viewed as (r-1)-dimensional simplicial complexes, the analogue of planarity is embeddability in R^(2(r-1)). The van Kampen-Flores theorem (1933) provides the topological obstruction: the complete r-uniform hypergraph on 2r+1 vertices is not embeddable in R^(2(r-1)), generalizing the non-planarity of K₅.",
+    "historicalContext": "Erdős Problem #1018 asked whether every dense graph (with n^{1+ε} edges) must contain a non-planar subgraph on only O_ε(1) vertices. Kostochka and Pyber (1988) answered affirmatively: n^{1+ε} edges force a K₅ topological minor on a bounded number of vertices. The key insight was that K₅ non-planarity is the topological obstruction for graphs: by Kuratowski, every non-planar graph contains K₅ or K_{3,3} as a minor. For r-uniform hypergraphs viewed as (r-1)-dimensional simplicial complexes, the natural analogue of planarity is embeddability in R^{2(r-1)}: a generic (r-1)-dimensional complex embeds in R^{2(r-1)+1} by general position, so R^{2(r-1)} is the first dimension where non-embeddability can occur. The van Kampen-Flores theorem, proved independently by van Kampen and Flores in 1933 using the newly proved Borsuk-Ulam theorem, establishes the minimal obstruction: K_{2r+1}^{(r)} is not embeddable in R^{2(r-1)}. The proof uses deleted products and Z/2-equivariant topology — the same framework used by Lovász in his proof of the Kneser conjecture (1978). For r=2 this gives K₅ non-planarity; for r=3 it gives K₇^{(3)} non-embeddability in R⁴. The Turán density of K₄^{(3)} — asking for the maximum edges in a K₄^{(3)}-free 3-uniform hypergraph — is one of the most famous open problems in extremal combinatorics (Turán 1941, still unsolved). The super-linear density threshold n^{r-1+ε} exceeds these Turán numbers for large n, making the conjecture well-motivated.",
     "problemStatement": "For r ≥ 2 and ε > 0, does every r-uniform hypergraph on n vertices with at least n^(r-1+ε) edges contain a sub-hypergraph on O_{r,ε}(1) vertices that is not embeddable in R^(2(r-1))? This is OPEN for r ≥ 3.",
     "text": "Formalizes the hypergraph extension of Erdős 1018. Defines r-uniform hypergraphs, the density threshold n^(r-1+ε), and the topological obstruction via the van Kampen-Flores theorem. States the generalized Kostochka-Pyber conjecture and proves recovery of the graph case (r=2). Explicit treatment of the 3-uniform case (K₇³, R⁴).",
     "proofStrategy": "The framework parallels the graph case: (1) density threshold n^(r-1+ε) generalizes n^(1+ε), (2) topological obstruction via van Kampen-Flores generalizes K₅ non-planarity, (3) the conjecture asks for bounded-size non-embeddable sub-hypergraphs. The 3-uniform case (density n^(2+ε), obstruction in R⁴) is the first non-trivial instance.",
     "keyInsights": [
-      "The van Kampen-Flores theorem provides the correct higher-dimensional obstruction: K_{2r+1}^(r) is not embeddable in R^(2(r-1)), generalizing K₅ non-planarity",
-      "The density threshold n^(r-1+ε) is the natural generalization: for r=2 it gives n^(1+ε), and it exceeds hypergraph Turán numbers for large n",
-      "The critical dimension 2(r-1) is determined by the topology: an (r-1)-dimensional complex generically embeds in R^(2(r-1)+1) but not always in R^(2(r-1))",
-      "The 3-uniform case (density n^(2+ε), obstruction K₇³ in R⁴, 35 edges) is the simplest open instance"
+      "The van Kampen-Flores theorem is the higher-dimensional K₅: K_{2r+1}^{(r)} is not embeddable in R^{2(r-1)}, proved using Borsuk-Ulam + deleted products. For r=2: K₅ non-planar. For r=3: K₇^{(3)} not in R⁴",
+      "The critical dimension 2(r-1) is determined by general position: a generic (r-1)-simplex lives in R^{r-1}, and a generic (r-1)-dimensional simplicial complex embeds in R^{2(r-1)+1} but can obstruct embedding in R^{2(r-1)}",
+      "The density threshold n^{r-1+ε} is the super-Turán regime: Turán numbers for r-uniform complete subhypergraphs are polynomially smaller than n^{r-1+ε} for large n, so dense hypergraphs force complete sub-hypergraphs as candidates for non-embeddable pieces",
+      "The Hypergraph structure uses a Finset-of-Finsets model with a proof-valued uniformity field, allowing the uniformity constraint to be inherited automatically by sub-hypergraphs via the induced definition",
+      "The isEmbeddable definition has a sorry: formalizing it requires geometric realization of simplicial complexes in R^d as a topological space — infrastructure not yet in Mathlib, making the isNonEmbeddable and vanKampen_Flores axiom necessary",
+      "K₇^{(3)} has C(7,3) = 35 edges — proved by decide. The analogous K₅ has C(5,2) = 10 edges. The ratio 35/10 shows how much richer 3-uniform hypergraph theory is compared to graphs"
     ],
     "prerequisites": [
       "Graph theory and hypergraph basics",
@@ -116,7 +118,13 @@
   "conclusion": {
     "summary": "The hypergraph extension of Erdős 1018 asks whether n^(r-1+ε) edge density in r-uniform hypergraphs forces non-embeddable (in R^(2(r-1))) sub-hypergraphs of bounded size. The van Kampen-Flores theorem provides the topological obstruction, generalizing K₅ non-planarity. The conjecture is OPEN for r ≥ 3.",
     "implications": "If true, establishes a topological Ramsey-type principle for hypergraphs: sufficiently dense r-uniform hypergraphs must contain topologically complex sub-structures of bounded size, connecting extremal combinatorics to topological combinatorics in higher dimensions.",
-    "openQuestions": []
+    "openQuestions": [
+      "Prove the generalized Kostochka-Pyber conjecture for r=3: does n^{2+ε} edge density in 3-uniform hypergraphs force a K₇^{(3)}-subdivision on O_ε(1) vertices?",
+      "Formalize isEmbeddable: define geometric realization of simplicial complexes in R^d and almost-embeddings (maps where disjoint simplices have disjoint images) in Mathlib",
+      "Prove the van Kampen-Flores theorem from Borsuk-Ulam in Lean: requires deleted product construction, Z/2-equivariant maps, and Smith theory for Z/2",
+      "Determine the Turán density of K₄^{(3)}: the maximum asymptotic edge density of a K₄^{(3)}-free 3-uniform hypergraph. Turán conjectured 2/9 in 1941; still unsolved",
+      "Does the Erdős-Ko-Rado theorem (1961) for intersecting families connect to the BU dimension of the hypergraph Kneser complex?"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary

Enriches the `erdos-1018-oq-04` gallery entry (Hypergraph Extension of Non-Planar Subgraph Density, 308 lines, 4 axioms, 2 sorries).

**Annotations** (6 new, all validated):
- `ann-e1018-hypergraph-struct` — `Hypergraph structure` (line 35): r-uniform simplicial complex model with proof-valued uniformity field
- `ann-e1018-vkf-axiom` — `vanKampen_Flores` (line 162): topological obstruction via Borsuk-Ulam + deleted products — generalizes K₅ non-planarity
- `ann-e1018-k5-nonplanar` — `vanKampen_Flores_graph` (line 167): K₅ non-planarity recovered via convert + norm_num from r=2 instance
- `ann-e1018-conjecture` — `hypergraph_kostochka_pyber` (line 197): the generalized Kostochka-Pyber open conjecture formalized with all quantifiers
- `ann-e1018-k7-3uniform` — `K7_3_nonembeddable` (line 247): K₇^(3) not embeddable in R⁴ — the first open case (35 edges, r=3)
- `ann-e1018-turan-axiom` — `density_exceeds_turan` (line 276): super-linear density eventually exceeds Turán numbers for any fixed complete sub-hypergraph

**Meta.json improvements:**
- `historicalContext`: expanded from 4 sentences to full narrative (Kostochka-Pyber 1988, van Kampen-Flores 1933, Borsuk-Ulam proof, Lovász-Kneser parallel, Turán K₄^(3) density problem)
- `keyInsights`: expanded from 4 to 6 entries covering VKF generalization, critical dimension topology, super-Turán density, Finset model design rationale, isEmbeddable sorry, K₇^(3) vs K₅ edge count comparison
- `openQuestions`: filled (was empty) with 5 questions: r=3 conjecture, isEmbeddable formalization, VKF from Borsuk-Ulam, Turán density K₄^(3), EKR connection

## Labels
`enrichment`

🤖 Generated with [Claude Code](https://claude.com/claude-code)