### PR TITLE
fix: correct stale assumptions text in 4 gallery meta.json files (audit cycle-31)

### DIFF
--- a/src/data/proofs/erdos-504/meta.json
+++ b/src/data/proofs/erdos-504/meta.json
@@ -39,7 +39,7 @@
     "erdosProblemStatus": "solved",
     "axiomCount": 5,
     "lineCount": 217,
-    "assumptions": "15 axiom(s). No sorries.",
+    "assumptions": "5 axiom(s). No sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-756/meta.json
+++ b/src/data/proofs/erdos-756/meta.json
@@ -78,7 +78,7 @@
     ],
     "axiomCount": 5,
     "lineCount": 268,
-    "assumptions": "10 axioms: (1) hopf_pannwitz — largest distance multiplicity ≤ n, (2) bhowmick_construction — existence of point set with rich distances, (3) bhowmick_main — ⌊n/4⌋ rich distances for large n, (4) bhowmick_general — ⌊n/(2(m+1))⌋ distances with multiplicity ≥ n+m, (5) clemen_dumitrescu_liu — superpolynomial grid richness, (6-10) supporting axioms for distance counting, grid construction, and asymptotic bounds. 1 sorry in construction details."
+    "assumptions": "5 axioms: (1) hopf_pannwitz — largest distance multiplicity ≤ n, (2) bhowmick_main — ⌊n/4⌋ rich distances for large n, (3) squareGrid — construction of n×n square grid point set, (4) regularPolygon — construction of regular n-gon point set, (5) latticeInDisk — construction of lattice in disk. No sorries."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #756: Rich Distances in the Plane**\n\nThis problem, asked by Erdős and Pach, concerns distance multiplicities in finite point sets in the plane.\n\n**Historical Timeline:**\n- **1934:** Hopf and Pannwitz proved the largest distance among n points occurs at most n times (this is tight for regular polygons)\n- **Erdős-Pach:** Asked whether ALL other distances can have multiplicity > n (the \"strong\" form)\n- **2024:** Bhowmick answered affirmatively with an explicit construction achieving ⌊n/4⌋ rich distances\n- **2025:** Clemen, Dumitrescu, and Liu studied the square grid, finding superpolynomial richness\n\n**The Surprise:**\nDespite the classical Hopf-Pannwitz constraint on the largest distance, Bhowmick showed that MANY distances can be \"rich\" (occurring more than n times). The phenomenon is even stronger on structured sets like square grids.",

--- a/src/data/proofs/erdos-96/meta.json
+++ b/src/data/proofs/erdos-96/meta.json
@@ -57,7 +57,7 @@
     "dateAdded": "2026-01-19",
     "axiomCount": 3,
     "lineCount": 285,
-    "assumptions": "4 axiom(s). No sorries."
+    "assumptions": "3 axiom(s). No sorries."
   },
   "overview": {
     "historicalContext": "Erdős and Moser conjectured that a convex n-gon has O(n) unit distance pairs. Despite progress from O(n log n) bounds (Füredi 1990, Aggarwal 2015), the conjecture remains open. The Edelsbrunner-Hajnal (1991) lower bound of 2n - 7 suggests the Erdős-Fishburn conjecture of exactly 2n may be tight. The unit distance problem for general point sets (Erdős Problem #89, 1946) asks for the maximum number of unit distance pairs among n points in the plane, with best known bounds Ω(n^{1+c/log log n}) and O(n^{4/3}). The convex restriction dramatically simplifies the problem: in a convex polygon, each distance can appear at most twice on each side, giving much sharper bounds.",

--- a/src/data/proofs/hilbert-21/meta.json
+++ b/src/data/proofs/hilbert-21/meta.json
@@ -38,7 +38,7 @@
     "hilbertNumber": 21,
     "axiomCount": 4,
     "lineCount": 386,
-    "assumptions": "6 axiom(s). No sorries.",
+    "assumptions": "4 axiom(s). No sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Summary

- **hilbert-21**: `assumptions` text said "6 axiom(s)" but file has 4 axioms (3 `^axiom` + 1 `noncomputable axiom`)
- **erdos-96**: `assumptions` text said "4 axiom(s)" but file has 3 axioms
- **erdos-756**: `assumptions` text claimed "10 axioms" but file has 5; rewrote with accurate names (hopf_pannwitz, bhowmick_main, squareGrid, regularPolygon, latticeInDisk)
- **erdos-504**: `assumptions` text said "15 axiom(s)" but file has 5 axioms

In all cases the `axiomCount` field was already correct — only the human-readable `assumptions` description was stale.

## Root Cause

The audit scanner uses `grep -c "^axiom "` which misses `noncomputable axiom` declarations. This caused false-positive "axiom overcount" alerts in the tracker for proofs that correctly count all axiom variants. The `assumptions` text was written at an earlier stage with different axiom counts and never updated.

## Test Plan

- [x] Verified each file's actual axiom declarations with `grep -nE "(noncomputable\s+)?axiom "`
- [x] Confirmed `axiomCount` fields match actual counts in all 4 files
- [x] Confirmed `sorries` fields are correct

Discovered during gallery integrity audit cycle-31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)