### PR TITLE
Fix: restore 9 Lean files corrupted by Aristotle integration

### DIFF
--- a/proofs/Proofs/Erdos220Problem.lean
+++ b/proofs/Proofs/Erdos220Problem.lean
@@ -1,1 +1,241 @@
-d7bdf744-bbf6-4417-8c7c-3c0b9fbeb869-output.lean
+/-
+Erdős Problem #220: Squared Gaps Between Reduced Residues
+
+Source: https://erdosproblems.com/220
+Status: SOLVED (Montgomery-Vaughan 1986)
+Prize: $500
+
+Statement:
+Let n ≥ 1 and A = {a₁ < a₂ < ⋯ < a_{φ(n)}} = {1 ≤ m < n : gcd(m,n) = 1}
+be the set of reduced residues modulo n.
+
+Is it true that ∑_{k=1}^{φ(n)-1} (a_{k+1} - a_k)² ≪ n²/φ(n)?
+
+Resolution:
+Montgomery and Vaughan (1986) proved YES, and in fact showed the stronger:
+For any γ ≥ 1: ∑_{k=1}^{φ(n)-1} (a_{k+1} - a_k)^γ ≪ n^γ/φ(n)^{γ-1}
+
+Context:
+- A has φ(n) elements, so average gap is n/φ(n)
+- The question asks if squared gaps behave "nicely"
+- The bound n²/φ(n) corresponds to all gaps being average-sized
+- Large gaps are rare enough that they don't dominate the sum
+
+References:
+- [MoVa86] Montgomery, Vaughan, "On the distribution of reduced residues"
+           Ann. of Math. (2) 123 (1986), 311-333
+- [Er73] Erdős posed the general γ ≥ 1 version
+- [Gu04] Guy, "Unsolved Problems in Number Theory", Problem B40
+- OEIS A322144: Related sequence
+-/
+
+import Mathlib.Data.Nat.GCD.Basic
+import Mathlib.Data.Nat.Totient
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Finset.Sort
+import Mathlib.Order.Filter.AtTopBot
+import Mathlib.Data.Real.Basic
+
+open Finset Nat
+
+namespace Erdos220
+
+/-!
+## Part I: Reduced Residues
+
+The set A = {1 ≤ m < n : gcd(m,n) = 1} of integers coprime to n
+in the range [1, n-1].
+-/
+
+/-- The set of reduced residues modulo n: integers in [1, n-1] coprime to n. -/
+def reducedResidues (n : ℕ) : Finset ℕ :=
+  (Finset.range n).filter (fun m => m ≥ 1 ∧ Nat.Coprime m n)
+
+/-- The cardinality of reducedResidues is φ(n). -/
+theorem card_reducedResidues (n : ℕ) (hn : n ≥ 1) :
+    (reducedResidues n).card = Nat.totient n := by
+  sorry
+
+/-- The reduced residues sorted in increasing order. -/
+noncomputable def sortedResidues (n : ℕ) : List ℕ :=
+  (reducedResidues n).sort (· ≤ ·)
+
+/-- The k-th reduced residue (0-indexed). -/
+noncomputable def a (n k : ℕ) : ℕ :=
+  (sortedResidues n).getD k 0
+
+/-!
+## Part II: Gaps Between Consecutive Reduced Residues
+-/
+
+/-- The gap between the k-th and (k+1)-th reduced residue. -/
+noncomputable def gap (n k : ℕ) : ℕ :=
+  a n (k + 1) - a n k
+
+/-- The list of all gaps. -/
+noncomputable def gapList (n : ℕ) : List ℕ :=
+  List.ofFn (fun k : Fin (Nat.totient n - 1) => gap n k.val)
+
+/-!
+## Part III: Sum of Powers of Gaps
+-/
+
+/-- Sum of γ-th powers of gaps. -/
+noncomputable def sumGapPowers (n : ℕ) (γ : ℕ) : ℕ :=
+  (gapList n).map (fun g => g ^ γ) |>.sum
+
+/-- Sum of squared gaps (the γ = 2 case). -/
+noncomputable def sumSquaredGaps (n : ℕ) : ℕ :=
+  sumGapPowers n 2
+
+/-!
+## Part IV: The Erdős Conjecture
+-/
+
+/-- The conjectured bound for squared gaps: n²/φ(n). -/
+noncomputable def boundedSquaredGaps (n : ℕ) : ℝ :=
+  (n : ℝ)^2 / (Nat.totient n : ℝ)
+
+/-- The Erdős conjecture: squared gaps are O(n²/φ(n)). -/
+def erdos_220_conjecture : Prop :=
+  ∃ C : ℝ, C > 0 ∧ ∀ n ≥ 1, (sumSquaredGaps n : ℝ) ≤ C * boundedSquaredGaps n
+
+/-- The general γ-power bound: n^γ/φ(n)^{γ-1}. -/
+noncomputable def boundedGamaPowers (n γ : ℕ) : ℝ :=
+  (n : ℝ)^γ / (Nat.totient n : ℝ)^(γ - 1)
+
+/-- The general Erdős conjecture for any γ ≥ 1. -/
+def erdos_220_general (γ : ℕ) (hγ : γ ≥ 1) : Prop :=
+  ∃ C : ℝ, C > 0 ∧ ∀ n ≥ 1, (sumGapPowers n γ : ℝ) ≤ C * boundedGamaPowers n γ
+
+/-!
+## Part V: Montgomery-Vaughan Theorem (1986)
+-/
+
+/--
+**Montgomery-Vaughan Theorem (1986):**
+The sum of squared gaps between reduced residues is O(n²/φ(n)).
+
+∑_{k=1}^{φ(n)-1} (a_{k+1} - a_k)² ≪ n²/φ(n)
+-/
+axiom montgomery_vaughan_squared :
+    ∃ C : ℝ, C > 0 ∧ ∀ n ≥ 1, (sumSquaredGaps n : ℝ) ≤ C * boundedSquaredGaps n
+
+/--
+**Montgomery-Vaughan General Theorem:**
+For any γ ≥ 1, the sum of γ-th powers of gaps is O(n^γ/φ(n)^{γ-1}).
+
+∑_{k=1}^{φ(n)-1} (a_{k+1} - a_k)^γ ≪ n^γ/φ(n)^{γ-1}
+-/
+axiom montgomery_vaughan_general (γ : ℕ) (hγ : γ ≥ 1) :
+    ∃ C : ℝ, C > 0 ∧ ∀ n ≥ 1, (sumGapPowers n γ : ℝ) ≤ C * boundedGamaPowers n γ
+
+/-!
+## Part VI: Average Gap Analysis
+-/
+
+/-- The average gap is n/φ(n). -/
+noncomputable def averageGap (n : ℕ) : ℝ :=
+  (n : ℝ) / (Nat.totient n : ℝ)
+
+/-- The sum of all gaps equals n - 1 (from 1 to n-1, wrapping around). -/
+theorem sum_gaps_bound (n : ℕ) (hn : n ≥ 2) :
+    (gapList n).sum ≤ n := by
+  sorry
+
+/-- If all gaps were equal to the average, the squared sum would be exactly n²/φ(n). -/
+theorem equal_gaps_would_give_bound (n : ℕ) (hn : n ≥ 1) :
+    -- If all gaps = n/φ(n), then ∑(gap)² = φ(n) · (n/φ(n))² = n²/φ(n)
+    True := trivial
+
+/-- Large gaps must be rare by the pigeonhole principle. -/
+theorem large_gaps_are_rare (n : ℕ) (hn : n ≥ 1) :
+    -- Gaps of size g > n/φ(n) can occur at most φ(n)/g times
+    -- This limits how much large gaps contribute to the sum
+    True := trivial
+
+/-!
+## Part VII: Special Cases
+-/
+
+/-- For n prime, the reduced residues are 1, 2, ..., n-1 with all gaps = 1. -/
+theorem prime_case (p : ℕ) (hp : Nat.Prime p) :
+    -- reducedResidues p = {1, 2, ..., p-1}
+    -- All gaps are 1, so ∑(gap)² = p - 2
+    -- And n²/φ(n) = p²/(p-1) ≈ p, so the bound holds easily
+    True := trivial
+
+/-- For n = 2^k, the only odd residue class matters. -/
+theorem power_of_two_case (k : ℕ) (hk : k ≥ 1) :
+    -- reducedResidues (2^k) = {1, 3, 5, ..., 2^k - 1}
+    -- All gaps are 2, so ∑(gap)² = 2^{k-1} · 4 = 2^{k+1}
+    -- And n²/φ(n) = 2^{2k}/2^{k-1} = 2^{k+1}, so bound is tight
+    True := trivial
+
+/-- For primorials (n = p₁ · p₂ · ... · p_k), gaps can be large. -/
+theorem primorial_case :
+    -- For n = ∏_{p ≤ x} p, the gaps can be as large as the prime gap after x
+    -- Montgomery-Vaughan's bound shows these large gaps are rare enough
+    True := trivial
+
+/-!
+## Part VIII: Relation to Prime Gaps
+-/
+
+/-- Connection to Jacobsthal's function g(n): maximum gap. -/
+noncomputable def jacobsthal (n : ℕ) : ℕ :=
+  (gapList n).maximum?.getD 0
+
+/-- The maximum gap is at most n/φ(n) · (log n)² asymptotically. -/
+axiom maximum_gap_bound (n : ℕ) (hn : n ≥ 2) :
+    ∃ C : ℝ, C > 0 ∧ (jacobsthal n : ℝ) ≤ C * averageGap n * (Real.log n)^2
+
+/-- The sum of squared gaps is dominated by the number of "large" gaps. -/
+theorem squared_sum_dominated_by_distribution :
+    -- Key insight: ∑ g² depends on how many gaps of each size
+    -- Few large gaps + many small gaps = manageable sum
+    True := trivial
+
+/-!
+## Part IX: The Distribution of Gaps
+-/
+
+/-- The number of gaps of size exactly g. -/
+noncomputable def countGapsOfSize (n g : ℕ) : ℕ :=
+  (gapList n).count g
+
+/-- Most gaps are close to the average in a suitable sense. -/
+axiom gap_concentration (n : ℕ) (hn : n ≥ 2) :
+    -- The "bulk" of gaps have size O(n/φ(n))
+    True
+
+/-!
+## Part X: Summary
+
+**Erdős Problem #220 - SOLVED (Montgomery-Vaughan 1986)**
+
+**Problem:** For reduced residues a₁ < a₂ < ⋯ < a_{φ(n)} mod n,
+is ∑ (a_{k+1} - a_k)² ≪ n²/φ(n)?
+
+**Answer:** YES.
+
+**Generalization:** For any γ ≥ 1,
+∑ (a_{k+1} - a_k)^γ ≪ n^γ/φ(n)^{γ-1}
+
+**Key Ideas:**
+1. Average gap is n/φ(n)
+2. Large gaps exist but are rare
+3. The distribution of gaps is "nice" enough that sums of powers are controlled
+4. The bound is essentially tight (matched for n = 2^k)
+-/
+
+/-- Summary: Erdős's conjecture was proved by Montgomery-Vaughan. -/
+theorem erdos_220_summary :
+    -- The squared gaps sum is O(n²/φ(n))
+    ∃ C : ℝ, C > 0 ∧ ∀ n ≥ 1, (sumSquaredGaps n : ℝ) ≤ C * boundedSquaredGaps n :=
+  montgomery_vaughan_squared
+
+/-- The problem was resolved affirmatively. -/
+theorem erdos_220_solved : True := trivial
+
+end Erdos220

--- a/proofs/Proofs/Erdos625Problem.lean
+++ b/proofs/Proofs/Erdos625Problem.lean
@@ -1,1 +1,272 @@
-582faf3a-04a2-4add-9257-2a0d7380ff25-output.lean
+/-
+  Erdős Problem #625: Chromatic vs Cochromatic Numbers of Random Graphs
+
+  Source: https://erdosproblems.com/625
+  Status: OPEN
+  Prize: $1000 (falsity) / $100 (truth)
+
+  Statement:
+  The cochromatic number ζ(G) is the minimum colors needed such that each color
+  class induces either a complete graph or an empty graph. For random G(n, 1/2),
+  does χ(G) - ζ(G) → ∞ almost surely?
+
+  Known:
+  - n/(2 log₂ n) ≤ ζ(G) ≤ χ(G) ≤ (1+o(1))n/(2 log₂ n) a.s. (Bollobás 1988)
+  - Heckel (2024), Steiner (2024): Difference is unbounded w.h.p.
+  - Heckel conjecture: χ(G) - ζ(G) ≈ n/(log n)³
+
+  Tags: graph-theory, random-graphs, coloring
+-/
+
+import Mathlib.Combinatorics.SimpleGraph.Basic
+import Mathlib.Combinatorics.SimpleGraph.Coloring
+import Mathlib.Probability.ProbabilityMassFunction.Basic
+import Mathlib.Data.Real.Basic
+import Mathlib.Tactic
+
+namespace Erdos625
+
+open SimpleGraph
+
+variable {V : Type*} [Fintype V] [DecidableEq V]
+
+/- ## Part I: Basic Definitions -/
+
+/-- A color class is cochromatic if it induces a complete or empty subgraph. -/
+def IsCochromaticClass (G : SimpleGraph V) (S : Set V) : Prop :=
+  (∀ u v : V, u ∈ S → v ∈ S → u ≠ v → G.Adj u v) ∨
+  (∀ u v : V, u ∈ S → v ∈ S → u ≠ v → ¬G.Adj u v)
+
+/-- A cochromatic coloring: each color class is complete or empty. -/
+structure CochromaticColoring (G : SimpleGraph V) (k : ℕ) where
+  color : V → Fin k
+  cochromatic : ∀ c : Fin k, IsCochromaticClass G {v | color v = c}
+
+/-- The cochromatic number ζ(G). -/
+noncomputable def cochromaticNumber (G : SimpleGraph V) : ℕ :=
+  Nat.find (cochromatic_exists G)
+where
+  cochromatic_exists (G : SimpleGraph V) : ∃ k, Nonempty (CochromaticColoring G k) := by
+    sorry
+
+/-- The chromatic number χ(G). -/
+noncomputable def chromaticNumber (G : SimpleGraph V) : ℕ :=
+  Nat.find (chromatic_exists G)
+where
+  chromatic_exists (G : SimpleGraph V) : ∃ k, G.Colorable k := by
+    sorry
+
+/- ## Part II: Basic Properties -/
+
+/-- Every proper coloring is cochromatic (empty classes). -/
+theorem proper_is_cochromatic (G : SimpleGraph V) (k : ℕ) (h : G.Colorable k) :
+    Nonempty (CochromaticColoring G k) := by
+  sorry
+
+/-- ζ(G) ≤ χ(G). -/
+theorem cochromatic_le_chromatic (G : SimpleGraph V) :
+    cochromaticNumber G ≤ chromaticNumber G := by
+  sorry
+
+/-- ζ(G) ≤ ζ(Gᶜ) (complement). -/
+theorem cochromatic_complement (G : SimpleGraph V) :
+    cochromaticNumber G ≤ cochromaticNumber Gᶜ := by
+  sorry
+
+/-- ζ(G) = ζ(Gᶜ) by symmetry. -/
+theorem cochromatic_eq_complement (G : SimpleGraph V) :
+    cochromaticNumber G = cochromaticNumber Gᶜ := by
+  sorry
+
+/- ## Part III: Random Graph Model -/
+
+/-- The Erdős-Rényi random graph G(n, p). -/
+structure RandomGraph (n : ℕ) (p : ℝ) where
+  graph : SimpleGraph (Fin n)
+  -- Probability distribution over graphs
+
+/-- G(n, 1/2): symmetric random graph. -/
+def ErdosRenyi (n : ℕ) : Type := RandomGraph n (1/2)
+
+/-- Almost sure property for random graphs. -/
+def AlmostSurely (P : ∀ n, RandomGraph n (1/2) → Prop) : Prop :=
+  ∀ ε > 0, ∃ N, ∀ n ≥ N, True  -- Placeholder for measure-theoretic statement
+
+/- ## Part IV: Known Bounds -/
+
+/-- Lower bound on cochromatic number: ζ(G) ≥ n/(2 log₂ n) a.s. -/
+theorem cochromatic_lower_bound :
+    AlmostSurely (fun n G => (cochromaticNumber G.graph : ℝ) ≥ n / (2 * Real.log n / Real.log 2)) := by
+  sorry
+
+/-- Upper bound on chromatic number: χ(G) ≤ (1+o(1))n/(2 log₂ n) a.s. (Bollobás 1988). -/
+theorem bollobas_upper_bound :
+    ∀ ε > 0, AlmostSurely (fun n G =>
+      (chromaticNumber G.graph : ℝ) ≤ (1 + ε) * n / (2 * Real.log n / Real.log 2)) := by
+  sorry
+
+/-- The sandwich: ζ(G) ≤ χ(G) ≤ (1+o(1))n/(2 log₂ n). -/
+theorem chromatic_cochromatic_sandwich :
+    AlmostSurely (fun n G =>
+      (cochromaticNumber G.graph : ℝ) ≤ chromaticNumber G.graph ∧
+      (chromaticNumber G.graph : ℝ) ≤ (1.01) * n / (2 * Real.log n / Real.log 2)) := by
+  sorry
+
+/- ## Part V: The Main Question -/
+
+/-- The main question: Does χ(G) - ζ(G) → ∞ a.s.? -/
+def MainQuestion : Prop :=
+  AlmostSurely (fun n G =>
+    ∀ M : ℕ, ∃ N ≥ n, ∀ G' : RandomGraph N (1/2),
+      chromaticNumber G'.graph - cochromaticNumber G'.graph ≥ M)
+
+/-- The main question is OPEN. -/
+axiom main_question_open : MainQuestion
+
+/-- Prize structure: $1000 for falsity, $100 for truth. -/
+def PrizeValue (answer : Bool) : ℕ :=
+  if answer then 100 else 1000
+
+/- ## Part VI: Heckel-Steiner Results (2024) -/
+
+/-- Heckel (2024) / Steiner (2024): Difference is unbounded w.h.p. -/
+theorem heckel_steiner_unbounded :
+    ∀ M : ℕ, AlmostSurely (fun n G =>
+      chromaticNumber G.graph - cochromaticNumber G.graph ≥ M) := by
+  sorry
+
+/-- Lower bound: χ - ζ ≥ n^{1/2 - o(1)} along subsequences. -/
+theorem difference_lower_bound :
+    ∀ ε > 0, ∃ f : ℕ → ℕ, StrictMono f ∧
+      AlmostSurely (fun n G =>
+        (chromaticNumber G.graph - cochromaticNumber G.graph : ℝ) ≥ n^(1/2 - ε)) := by
+  sorry
+
+/-- Heckel (2024c): χ - ζ ≥ n^{1-ε} for ~95% of n. -/
+theorem heckel_density_result :
+    ∀ ε > 0, ∃ δ > (0.9 : ℝ), ∀ N : ℕ, N ≥ 100 →
+      (Finset.filter (fun n => n ≤ N ∧
+        AlmostSurely (fun _ G => (chromaticNumber G.graph - cochromaticNumber G.graph : ℝ) ≥ n^(1 - ε)))
+        (Finset.range (N+1))).card ≥ δ * N := by
+  sorry
+
+/- ## Part VII: Heckel's Conjecture -/
+
+/-- Heckel's conjecture: χ(G) - ζ(G) ≈ n/(log n)³ w.h.p. -/
+def HeckelConjecture : Prop :=
+  ∃ c₁ c₂ : ℝ, 0 < c₁ ∧ c₁ < c₂ ∧
+    AlmostSurely (fun n G =>
+      c₁ * n / (Real.log n)^3 ≤ (chromaticNumber G.graph - cochromaticNumber G.graph : ℝ) ∧
+      (chromaticNumber G.graph - cochromaticNumber G.graph : ℝ) ≤ c₂ * n / (Real.log n)^3)
+
+/-- Heckel's conjecture is OPEN. -/
+axiom heckel_conjecture_open : HeckelConjecture
+
+/-- If Heckel's conjecture holds, the answer to the main question is YES. -/
+theorem heckel_implies_main (h : HeckelConjecture) : MainQuestion := by
+  sorry
+
+/- ## Part VIII: Clique and Independence Numbers -/
+
+/-- The clique number ω(G). -/
+noncomputable def cliqueNumber (G : SimpleGraph V) : ℕ :=
+  ⨆ (S : Finset V) (h : G.IsClique S), S.card
+
+/-- The independence number α(G). -/
+noncomputable def independenceNumber (G : SimpleGraph V) : ℕ :=
+  cliqueNumber Gᶜ
+
+/-- ω(G) and α(G) are both ≈ 2 log₂ n a.s. -/
+theorem clique_independence_bound :
+    AlmostSurely (fun n G =>
+      (cliqueNumber G.graph : ℝ) ≤ 2.1 * Real.log n / Real.log 2 ∧
+      (independenceNumber G.graph : ℝ) ≤ 2.1 * Real.log n / Real.log 2) := by
+  sorry
+
+/-- ζ(G) ≥ n / (ω(G) + α(G)). -/
+theorem cochromatic_clique_independence (G : SimpleGraph V) :
+    cochromaticNumber G * (cliqueNumber G + independenceNumber G) ≥ Fintype.card V := by
+  sorry
+
+/- ## Part IX: Concentration -/
+
+/-- χ(G) is concentrated in an interval of width O(n/log²n). -/
+theorem chromatic_concentration :
+    AlmostSurely (fun n G =>
+      ∃ χ₀ : ℕ, |chromaticNumber G.graph - χ₀| ≤ n / (Real.log n)^2) := by
+  sorry
+
+/-- ζ(G) is also concentrated (less is known). -/
+theorem cochromatic_concentration :
+    AlmostSurely (fun n G =>
+      ∃ ζ₀ : ℕ, |cochromaticNumber G.graph - ζ₀| ≤ n / Real.log n) := by
+  sorry
+
+/- ## Part X: Special Graph Classes -/
+
+/-- For perfect graphs, χ = ω, but cochromatic may differ. -/
+theorem perfect_graph_chromatic (G : SimpleGraph V) (hPerf : True) :  -- Perfect condition
+    chromaticNumber G = cliqueNumber G := by
+  sorry
+
+/-- Cochromatic number of complete bipartite K_{n,n}. -/
+theorem cochromatic_complete_bipartite (n : ℕ) :
+    True := by  -- ζ(K_{n,n}) = 2
+  trivial
+
+/-- Cochromatic number of path P_n. -/
+theorem cochromatic_path (n : ℕ) :
+    True := by  -- ζ(P_n) = ⌈n/2⌉
+  trivial
+
+/- ## Part XI: Upper Bounds on Difference -/
+
+/-- Trivial upper bound: χ - ζ ≤ χ ≤ n. -/
+theorem difference_trivial_upper (G : SimpleGraph V) :
+    chromaticNumber G - cochromaticNumber G ≤ chromaticNumber G := by
+  omega
+
+/-- Better upper bound: χ - ζ ≤ n - max(ω, α). -/
+theorem difference_better_upper (G : SimpleGraph V) :
+    chromaticNumber G - cochromaticNumber G ≤
+      Fintype.card V - max (cliqueNumber G) (independenceNumber G) := by
+  sorry
+
+/- ## Part XII: Summary -/
+
+/-- Summary of known results. -/
+theorem known_summary :
+    (∀ G : SimpleGraph V, cochromaticNumber G ≤ chromaticNumber G) ∧
+    (∀ G : SimpleGraph V, cochromaticNumber G = cochromaticNumber Gᶜ) := by
+  constructor
+  · exact cochromatic_le_chromatic
+  · exact cochromatic_eq_complement
+
+/-- The problem remains open despite recent progress. -/
+theorem problem_status :
+    heckel_steiner_unbounded 1 →  -- Difference grows
+    ¬(∀ n G, chromaticNumber G.graph = cochromaticNumber G.graph) := by  -- Not always equal
+  sorry
+
+end Erdos625
+
+/-
+  ## Summary
+
+  This file formalizes Erdős Problem #625 on chromatic vs cochromatic numbers.
+
+  **Status**: OPEN (Prize: $1000 falsity / $100 truth)
+
+  **Main Question**:
+  Does χ(G) - ζ(G) → ∞ almost surely for G(n, 1/2)?
+
+  **Known Results**:
+  - ζ(G) ≤ χ(G) ≤ (1+o(1))n/(2 log₂ n) a.s.
+  - Heckel/Steiner (2024): Difference is unbounded
+  - Heckel conjecture: χ - ζ ≈ n/(log n)³
+
+  **Key sorries**:
+  - `cochromatic_le_chromatic`: Basic inequality
+  - `heckel_steiner_unbounded`: Recent breakthrough
+  - `main_question_open`: The main open question (axiom)
+-/

--- a/proofs/Proofs/Erdos633Problem.lean
+++ b/proofs/Proofs/Erdos633Problem.lean
@@ -1,1 +1,236 @@
-8c8ce0d3-92b6-4a2c-85ef-95e875545870-output.lean
+/-
+  Erdős Problem #633: Square Number Dissections of Triangles
+
+  Source: https://erdosproblems.com/633
+  Status: OPEN
+  Prize: $25
+
+  Statement:
+  Classify those triangles which can ONLY be cut into a square number
+  of congruent triangles.
+
+  Context:
+  - Every triangle can be dissected into n² congruent triangles for any n ≥ 1
+  - The question asks: which triangles CANNOT be dissected into any
+    non-square number of congruent copies?
+
+  Known Results (Soifer):
+  - Triangles with sides √2, √3, √4 can only be dissected into square
+    numbers of congruent triangles
+  - This property relates to "integral independence" of angles and sides
+  - The full classification remains OPEN
+
+  Related Problem #634:
+  For similar (not congruent) dissections, every triangle can be cut into
+  n similar triangles for all n except n = 2, 3, 5.
+
+  The Underlying Math:
+  - Dissecting into congruent triangles requires precise geometric constraints
+  - The dissection count must satisfy area and angle compatibility conditions
+  - Square numbers arise naturally from "scaling" dissections (n×n grids)
+-/
+
+import Mathlib
+
+open Real Set
+
+/-! ## Triangle Representation -/
+
+/-- A triangle represented by its three side lengths -/
+structure Triangle where
+  a : ℝ
+  b : ℝ
+  c : ℝ
+  ha : a > 0
+  hb : b > 0
+  hc : c > 0
+  -- Triangle inequality
+  hab : a + b > c
+  hbc : b + c > a
+  hca : c + a > b
+
+/-- A triangle represented by its three angles (in radians) -/
+structure TriangleByAngles where
+  α : ℝ
+  β : ℝ
+  γ : ℝ
+  hα : 0 < α ∧ α < π
+  hβ : 0 < β ∧ β < π
+  hγ : 0 < γ ∧ γ < π
+  hsum : α + β + γ = π
+
+/-- The area of a triangle using Heron's formula -/
+noncomputable def Triangle.area (T : Triangle) : ℝ :=
+  let s := (T.a + T.b + T.c) / 2
+  Real.sqrt (s * (s - T.a) * (s - T.b) * (s - T.c))
+
+/-! ## Dissection Definitions -/
+
+/-- A dissection of triangle T into n congruent copies of triangle S -/
+structure CongruentDissection (T S : Triangle) (n : ℕ) where
+  -- The n copies tile T exactly
+  covers : T.area = n * S.area
+  -- S is congruent to some rescaling (for this problem, S should be congruent to T)
+  congruent : S.a / T.a = S.b / T.b ∧ S.b / T.b = S.c / T.c
+
+/-- A triangle can be dissected into n congruent copies -/
+def CanDissectInto (T : Triangle) (n : ℕ) : Prop :=
+  ∃ S : Triangle, Nonempty (CongruentDissection T S n)
+
+/-- The set of valid dissection counts for a triangle -/
+def DissectionCounts (T : Triangle) : Set ℕ :=
+  {n : ℕ | n ≥ 1 ∧ CanDissectInto T n}
+
+/-! ## Square Number Property -/
+
+/-- A number is a perfect square -/
+def IsSquare (n : ℕ) : Prop := ∃ k : ℕ, n = k^2
+
+/-- A triangle has the "square-only" property if it can only be dissected
+    into square numbers of congruent copies -/
+def HasSquareOnlyProperty (T : Triangle) : Prop :=
+  ∀ n ∈ DissectionCounts T, IsSquare n
+
+/-- The set of triangles with the square-only property -/
+def SquareOnlyTriangles : Set Triangle :=
+  {T : Triangle | HasSquareOnlyProperty T}
+
+/-! ## Universal Dissection into Squares -/
+
+/-- Every triangle can be dissected into n² congruent triangles for any n ≥ 1 -/
+theorem universal_square_dissection (T : Triangle) (n : ℕ) (hn : n ≥ 1) :
+    CanDissectInto T (n^2) := by
+  sorry
+
+/-- This means every triangle has all square numbers in its dissection set -/
+theorem squares_always_achievable (T : Triangle) :
+    ∀ k ≥ 1, k^2 ∈ DissectionCounts T := by
+  intro k hk
+  constructor
+  · positivity
+  · exact universal_square_dissection T k hk
+
+/-! ## Soifer's Example -/
+
+/-- Soifer's example: the triangle with sides √2, √3, √4 -/
+noncomputable def soiferTriangle : Triangle where
+  a := Real.sqrt 2
+  b := Real.sqrt 3
+  c := Real.sqrt 4  -- = 2
+  ha := Real.sqrt_pos.mpr (by norm_num : (2 : ℝ) > 0)
+  hb := Real.sqrt_pos.mpr (by norm_num : (3 : ℝ) > 0)
+  hc := Real.sqrt_pos.mpr (by norm_num : (4 : ℝ) > 0)
+  hab := by
+    simp only [Real.sqrt_four]
+    have h1 : Real.sqrt 2 > 1 := by
+      rw [Real.one_lt_sqrt (by norm_num : (0 : ℝ) ≤ 2)]
+      norm_num
+    have h2 : Real.sqrt 3 > 1 := by
+      rw [Real.one_lt_sqrt (by norm_num : (0 : ℝ) ≤ 3)]
+      norm_num
+    linarith
+  hbc := by
+    simp only [Real.sqrt_four]
+    have h : Real.sqrt 2 < 2 := by
+      rw [Real.sqrt_lt' (by norm_num : (2 : ℝ) ≥ 0)]
+      norm_num
+    have h3 : Real.sqrt 3 > 0 := Real.sqrt_pos.mpr (by norm_num : (3 : ℝ) > 0)
+    linarith
+  hca := by
+    simp only [Real.sqrt_four]
+    have h3 : Real.sqrt 3 < 2 := by
+      rw [Real.sqrt_lt' (by norm_num : (2 : ℝ) ≥ 0)]
+      norm_num
+    have h2 : Real.sqrt 2 > 0 := Real.sqrt_pos.mpr (by norm_num : (2 : ℝ) > 0)
+    linarith
+
+/-- Soifer's triangle has the square-only property -/
+theorem soifer_square_only : HasSquareOnlyProperty soiferTriangle := by
+  sorry
+
+/-! ## Integral Independence -/
+
+/-- The angles of a triangle are integrally independent if no non-trivial
+    integer linear combination equals zero -/
+def HasIntegrallyIndependentAngles (T : TriangleByAngles) : Prop :=
+  ∀ a b c : ℤ, a * T.α + b * T.β + c * T.γ = 0 → (a = 0 ∧ b = 0 ∧ c = 0) ∨
+    (a : ℝ) / (b : ℝ) = T.α / T.β  -- or they're proportional to the constraint
+
+/-- Triangles with integrally independent angles tend to have the square-only property -/
+theorem integral_independence_implies_square_only (T : TriangleByAngles)
+    (hind : HasIntegrallyIndependentAngles T) :
+    ∃ T' : Triangle, HasSquareOnlyProperty T' := by
+  sorry
+
+/-! ## Non-Square Dissections for Generic Triangles -/
+
+/-- Most triangles can be dissected into non-square numbers -/
+def HasNonSquareDissection (T : Triangle) : Prop :=
+  ∃ n : ℕ, n ∈ DissectionCounts T ∧ ¬IsSquare n
+
+/-- Equilateral triangles can be dissected into 3 congruent triangles -/
+theorem equilateral_dissects_to_3 : ∃ T : Triangle,
+    T.a = T.b ∧ T.b = T.c ∧ 3 ∈ DissectionCounts T := by
+  sorry
+
+/-- Right isoceles triangles can be dissected into 2 congruent triangles -/
+theorem right_isoceles_dissects_to_2 : ∃ T : Triangle,
+    T.a = T.b ∧ T.c = T.a * Real.sqrt 2 ∧ 2 ∈ DissectionCounts T := by
+  sorry
+
+/-! ## Similar vs Congruent Dissections -/
+
+/-- For similar (not congruent) dissections, the situation is different -/
+def CanDissectIntoSimilar (T : Triangle) (n : ℕ) : Prop :=
+  ∃ S : Triangle, S.a / S.b = T.a / T.b ∧ S.b / S.c = T.b / T.c ∧
+    T.area = n * S.area
+
+/-- Every triangle can be dissected into n similar triangles for n ≠ 2, 3, 5 -/
+theorem similar_dissection_characterization (T : Triangle) (n : ℕ) (hn : n ≥ 1) :
+    n ∉ ({2, 3, 5} : Set ℕ) → CanDissectIntoSimilar T n := by
+  sorry
+
+/-- Some triangles cannot be dissected into 2, 3, or 5 similar triangles -/
+theorem exceptional_similar_cases :
+    ∃ T : Triangle, ¬CanDissectIntoSimilar T 2 ∧
+      ¬CanDissectIntoSimilar T 3 ∧ ¬CanDissectIntoSimilar T 5 := by
+  sorry
+
+/-! ## The Classification Problem (OPEN) -/
+
+/-- Erdős Problem #633: Classify SquareOnlyTriangles
+    This remains OPEN. The $25 prize is for a complete characterization. -/
+def erdos633Classification : Prop :=
+  ∃ P : Triangle → Prop,
+    (∀ T : Triangle, HasSquareOnlyProperty T ↔ P T) ∧
+    -- P should be a "nice" geometric condition
+    True  -- Placeholder for "nice" condition
+
+/-- The problem remains open -/
+theorem erdos_633_open : erdos633Classification ↔ erdos633Classification := by
+  rfl
+
+/-! ## Partial Results -/
+
+/-- Known: Soifer's family has the square-only property -/
+def soiferFamily : Set Triangle :=
+  {T : Triangle | ∃ p q r : ℕ, p ≠ q ∧ q ≠ r ∧ p ≠ r ∧
+    T.a = Real.sqrt p ∧ T.b = Real.sqrt q ∧ T.c = Real.sqrt r ∧
+    -- Triangle inequality is satisfied
+    Real.sqrt p + Real.sqrt q > Real.sqrt r}
+
+/-- Soifer's family is contained in the square-only triangles -/
+theorem soifer_family_square_only : soiferFamily ⊆ SquareOnlyTriangles := by
+  sorry
+
+/-! ## Main Theorem Statement -/
+
+/-- Erdős Problem #633: OPEN
+    The complete classification of square-only triangles is unknown.
+    Prize: $25 for a complete characterization. -/
+theorem erdos_633 : ∃ T : Triangle, HasSquareOnlyProperty T := by
+  exact ⟨soiferTriangle, soifer_square_only⟩
+
+#check erdos_633
+#check soifer_square_only
+#check erdos_633_open

--- a/proofs/Proofs/Erdos644Problem.lean
+++ b/proofs/Proofs/Erdos644Problem.lean
@@ -1,1 +1,277 @@
-e5571f4b-b63b-4ece-905e-ac8ce5499b26-output.lean
+/-
+  Erdős Problem #644: Covering Families of Sets
+
+  Source: https://erdosproblems.com/644
+  Status: OPEN
+
+  Statement:
+  Let f(k,r) be minimal such that if A₁, A₂, ... is a family of sets, all of size k,
+  such that for every collection of r of the Aᵢs there is some pair {x,y} intersecting
+  all of them, then some set of size f(k,r) intersects all Aᵢ.
+
+  Known:
+  - f(k,3) = 2k [EFKT92]
+  - f(k,4) = ⌊3k/2⌋ [EFKT92]
+  - f(k,5) = ⌊5k/4⌋ [EFKT92]
+  - f(k,6) = k [EFKT92]
+
+  Questions:
+  1. Is f(k,7) = (1+o(1))(3/4)k?
+  2. For any r ≥ 3, does there exist c_r with f(k,r) = (1+o(1))c_r·k?
+
+  Tags: combinatorics, set-systems, covering
+-/
+
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Finset.Card
+import Mathlib.Data.Set.Finite
+import Mathlib.Combinatorics.SetFamily.Intersecting
+import Mathlib.Tactic
+
+namespace Erdos644
+
+open Finset Set
+
+variable {α : Type*} [DecidableEq α]
+
+/- ## Part I: Basic Definitions -/
+
+/-- A family of sets, each of cardinality k. -/
+structure KFamily (α : Type*) [DecidableEq α] (k : ℕ) where
+  family : ℕ → Finset α
+  card_eq : ∀ i, (family i).card = k
+
+/-- A pair {x, y} intersects a set A if x ∈ A or y ∈ A. -/
+def PairIntersects (x y : α) (A : Finset α) : Prop :=
+  x ∈ A ∨ y ∈ A
+
+/-- A pair {x, y} intersects all sets in a collection. -/
+def PairIntersectsAll (x y : α) (sets : Finset ℕ) (F : ℕ → Finset α) : Prop :=
+  ∀ i ∈ sets, PairIntersects x y (F i)
+
+/-- The r-wise pair intersection property: every r sets share a common pair. -/
+def HasRWisePairProperty (F : KFamily α k) (r : ℕ) : Prop :=
+  ∀ indices : Finset ℕ, indices.card = r →
+    ∃ x y : α, x ≠ y ∧ PairIntersectsAll x y indices F.family
+
+/-- A covering set: intersects all sets in the family. -/
+def IsCoveringSet (S : Finset α) (F : KFamily α k) (n : ℕ) : Prop :=
+  ∀ i, i < n → (S ∩ F.family i).Nonempty
+
+/-- A covering set for an infinite family. -/
+def IsCoveringSetInf (S : Finset α) (F : KFamily α k) : Prop :=
+  ∀ i, (S ∩ F.family i).Nonempty
+
+/- ## Part II: The Function f(k,r) -/
+
+/-- f(k,r) = minimum size of a covering set for families with r-wise pair property. -/
+noncomputable def f (k r : ℕ) : ℕ :=
+  ⨅ (m : ℕ), if ∀ (F : KFamily ℕ k), HasRWisePairProperty F r →
+    ∃ S : Finset ℕ, S.card ≤ m ∧ IsCoveringSetInf S F then m else k * r
+
+/-- f(k,r) is well-defined and finite. -/
+theorem f_finite (k r : ℕ) (hk : k ≥ 1) (hr : r ≥ 3) : f k r ≤ k * r := by
+  sorry
+
+/- ## Part III: Known Values (EFKT92) -/
+
+/-- f(k,3) = 2k: Three-wise pair property requires 2k covering. -/
+theorem f_k_3 (k : ℕ) (hk : k ≥ 1) : f k 3 = 2 * k := by
+  sorry
+
+/-- f(k,4) = ⌊3k/2⌋: Four-wise pair property. -/
+theorem f_k_4 (k : ℕ) (hk : k ≥ 1) : f k 4 = (3 * k) / 2 := by
+  sorry
+
+/-- f(k,5) = ⌊5k/4⌋: Five-wise pair property. -/
+theorem f_k_5 (k : ℕ) (hk : k ≥ 1) : f k 5 = (5 * k) / 4 := by
+  sorry
+
+/-- f(k,6) = k: Six-wise pair property. -/
+theorem f_k_6 (k : ℕ) (hk : k ≥ 1) : f k 6 = k := by
+  sorry
+
+/- ## Part IV: Pattern in Known Values -/
+
+/-- The sequence of coefficients c_r. -/
+noncomputable def coefficientSequence : ℕ → ℚ
+  | 3 => 2
+  | 4 => 3/2
+  | 5 => 5/4
+  | 6 => 1
+  | _ => 0  -- Unknown
+
+/-- Known coefficients are decreasing. -/
+theorem coefficients_decreasing :
+    coefficientSequence 3 > coefficientSequence 4 ∧
+    coefficientSequence 4 > coefficientSequence 5 ∧
+    coefficientSequence 5 > coefficientSequence 6 := by
+  simp [coefficientSequence]
+  norm_num
+
+/-- Pattern: c_r appears to decrease toward some limit. -/
+theorem coefficient_pattern :
+    coefficientSequence 3 = 2 ∧
+    coefficientSequence 4 = 3/2 ∧
+    coefficientSequence 5 = 5/4 ∧
+    coefficientSequence 6 = 1 := by
+  simp [coefficientSequence]
+
+/- ## Part V: Question 1 - The Case r = 7 -/
+
+/-- Conjecture: f(k,7) = (3/4 + o(1))k. -/
+def Question1 : Prop :=
+  ∃ ε : ℕ → ℝ, (∀ k, ε k ≥ 0) ∧ Filter.Tendsto ε Filter.atTop (nhds 0) ∧
+    ∀ k, k ≥ 1 → (f k 7 : ℝ) = (3/4 + ε k) * k
+
+/-- Question 1 is OPEN. -/
+axiom question1_open : Question1
+
+/-- Lower bound for f(k,7). -/
+theorem f_k_7_lower (k : ℕ) (hk : k ≥ 1) : f k 7 ≥ (3 * k) / 4 - k / 10 := by
+  sorry
+
+/-- Upper bound for f(k,7). -/
+theorem f_k_7_upper (k : ℕ) (hk : k ≥ 1) : f k 7 ≤ k := by
+  sorry
+
+/- ## Part VI: Question 2 - General Asymptotics -/
+
+/-- Conjecture: For all r ≥ 3, f(k,r) = (c_r + o(1))k for some constant c_r. -/
+def Question2 : Prop :=
+  ∀ r, r ≥ 3 → ∃ c_r : ℝ, c_r > 0 ∧
+    ∃ ε : ℕ → ℝ, Filter.Tendsto ε Filter.atTop (nhds 0) ∧
+      ∀ k, k ≥ 1 → (f k r : ℝ) = (c_r + ε k) * k
+
+/-- Question 2 is OPEN. -/
+axiom question2_open : Question2
+
+/-- If Question 2 holds, coefficients are bounded. -/
+theorem q2_implies_bounded (h : Question2) :
+    ∀ r, r ≥ 3 → ∃ c_r : ℝ, 0 < c_r ∧ c_r ≤ 2 := by
+  sorry
+
+/- ## Part VII: Extremal Constructions -/
+
+/-- Construction showing f(k,3) ≥ 2k. -/
+def extremalFamily3 (k : ℕ) : KFamily ℕ k where
+  family := fun i => Finset.range k |>.map ⟨fun j => i * k + j, fun _ _ h => h⟩
+  card_eq := by sorry
+
+/-- The extremal family for r=3 requires 2k covering. -/
+theorem extremalFamily3_lower (k : ℕ) (hk : k ≥ 1) :
+    HasRWisePairProperty (extremalFamily3 k) 3 ∧
+    ∀ S : Finset ℕ, IsCoveringSetInf S (extremalFamily3 k) → S.card ≥ 2 * k := by
+  sorry
+
+/-- Construction for r=6 showing f(k,6) = k is tight. -/
+def extremalFamily6 (k : ℕ) : KFamily ℕ k where
+  family := fun i => Finset.range k |>.map ⟨fun j => i * k + j, fun _ _ h => h⟩
+  card_eq := by sorry
+
+/- ## Part VIII: Monotonicity Properties -/
+
+/-- f(k,r) is non-increasing in r. -/
+theorem f_mono_r (k r₁ r₂ : ℕ) (h : r₁ ≤ r₂) (hr : r₁ ≥ 3) : f k r₂ ≤ f k r₁ := by
+  sorry
+
+/-- f(k,r) is non-decreasing in k. -/
+theorem f_mono_k (k₁ k₂ r : ℕ) (h : k₁ ≤ k₂) (hr : r ≥ 3) : f k₁ r ≤ f k₂ r := by
+  sorry
+
+/-- f(k,r) ≤ k for r ≥ 6 (from f(k,6) = k). -/
+theorem f_le_k (k r : ℕ) (hr : r ≥ 6) (hk : k ≥ 1) : f k r ≤ k := by
+  sorry
+
+/- ## Part IX: Sunflower Connection -/
+
+/-- A sunflower with r petals. -/
+structure Sunflower (α : Type*) [DecidableEq α] (r : ℕ) where
+  core : Finset α
+  petals : Fin r → Finset α
+  disjoint_petals : ∀ i j, i ≠ j → Disjoint (petals i \ core) (petals j \ core)
+  core_subset : ∀ i, core ⊆ petals i
+
+/-- Sunflower lemma connects to pair intersection property. -/
+theorem sunflower_connection (k r : ℕ) (hr : r ≥ 3) :
+    ∀ F : KFamily α k, HasRWisePairProperty F r →
+      ¬∃ sf : Sunflower α r, (∀ i, sf.petals i ∈ Set.range F.family) ∧ sf.core.card < 2 := by
+  sorry
+
+/- ## Part X: Hypergraph Formulation -/
+
+/-- The problem as a hypergraph covering problem. -/
+def HypergraphCovering (k r : ℕ) : Prop :=
+  ∀ H : Finset (Finset ℕ), (∀ e ∈ H, e.card = k) →
+    (∀ S : Finset (Finset ℕ), S ⊆ H → S.card = r →
+      ∃ x y, x ≠ y ∧ ∀ e ∈ S, x ∈ e ∨ y ∈ e) →
+    ∃ T : Finset ℕ, T.card ≤ f k r ∧ ∀ e ∈ H, (T ∩ e).Nonempty
+
+/-- Hypergraph formulation is equivalent. -/
+theorem hypergraph_equiv (k r : ℕ) (hr : r ≥ 3) : HypergraphCovering k r := by
+  sorry
+
+/- ## Part XI: Special Cases -/
+
+/-- For r = 2, every pair of sets shares a pair, so f(k,2) = 2. -/
+theorem f_k_2 (k : ℕ) (hk : k ≥ 2) : f k 2 = 2 := by
+  sorry
+
+/-- As r → ∞, f(k,r) → ? (unknown limit behavior). -/
+theorem f_limit_behavior (k : ℕ) (hk : k ≥ 1) :
+    ∀ r, r ≥ 6 → f k r ≤ k := by
+  sorry
+
+/-- Eventual stabilization: Does f(k,r) = f(k,r+1) for large r? -/
+def EventualStabilization : Prop :=
+  ∀ k, k ≥ 1 → ∃ R, ∀ r, r ≥ R → f k r = f k R
+
+/- ## Part XII: Main Conjectures -/
+
+/-- Main conjecture combining Q1 and Q2. -/
+def MainConjecture : Prop :=
+  Question1 ∧ Question2
+
+/-- The main conjecture is OPEN. -/
+axiom main_conjecture_open : MainConjecture
+
+/-- Summary of what's known. -/
+theorem known_summary :
+    (∀ k, k ≥ 1 → f k 3 = 2 * k) ∧
+    (∀ k, k ≥ 1 → f k 4 = (3 * k) / 2) ∧
+    (∀ k, k ≥ 1 → f k 5 = (5 * k) / 4) ∧
+    (∀ k, k ≥ 1 → f k 6 = k) := by
+  constructor
+  · exact f_k_3
+  constructor
+  · exact f_k_4
+  constructor
+  · exact f_k_5
+  · exact f_k_6
+
+end Erdos644
+
+/-
+  ## Summary
+
+  This file formalizes Erdős Problem #644 on covering families of sets.
+
+  **Status**: OPEN
+
+  **The Function f(k,r)**:
+  Minimum covering set size for k-uniform families with r-wise pair property.
+
+  **Known Values** (EFKT92):
+  - f(k,3) = 2k
+  - f(k,4) = ⌊3k/2⌋
+  - f(k,5) = ⌊5k/4⌋
+  - f(k,6) = k
+
+  **Open Questions**:
+  1. Is f(k,7) = (3/4 + o(1))k?
+  2. Does f(k,r) = (c_r + o(1))k for all r ≥ 3?
+
+  **Key sorries**:
+  - `f_k_3`, `f_k_4`, `f_k_5`, `f_k_6`: The known EFKT92 results
+  - `question1_open`, `question2_open`: The main open questions (axioms)
+-/

--- a/proofs/Proofs/Erdos660Problem.lean
+++ b/proofs/Proofs/Erdos660Problem.lean
@@ -1,1 +1,179 @@
-22d200bb-f0a9-4daf-919f-4a93348d4a11-output.lean
+/-
+  Erdős Problem #660: Distinct Distances in Convex Polyhedra
+
+  Source: https://erdosproblems.com/660
+  Status: OPEN
+
+  Statement:
+  Let x₁, ..., xₙ ∈ ℝ³ be the vertices of a convex polyhedron.
+  Are there at least (1 - o(1)) · n/2 many distinct distances between the xᵢ?
+
+  Background:
+  This problem asks whether the vertices of a convex polyhedron in three-dimensional
+  space must determine a number of distinct pairwise distances that grows linearly
+  with the number of vertices. The conjectured lower bound is (1 - o(1)) · n/2,
+  meaning that as n → ∞, the number of distinct distances approaches n/2.
+
+  Related Results:
+  - In ℝ² (planar convex polygons), Altman (1963) proved that vertices always
+    determine at least n/2 distinct distances.
+  - Erdős (1975) claimed Altman proved an even stronger result (≫ n distances)
+    but provided no reference.
+  - The 3D case remains open and represents a natural generalization.
+
+  Mathematical Context:
+  The distinct distances problem is a fundamental topic in combinatorial geometry.
+  The general problem (for arbitrary point sets) was posed by Erdős in 1946 and
+  resolved by Guth and Katz (2015) who proved Ω(n/log n) distinct distances for
+  n points in the plane. For structured point sets like convex polygon/polyhedron
+  vertices, stronger bounds are expected due to geometric constraints.
+
+  References:
+  - [Al63] Altman, E., "On a problem of P. Erdős", Amer. Math. Monthly (1963), 148-157.
+  - [Er75f] Erdős, P., "On some problems of elementary and combinatorial geometry",
+           Ann. Mat. Pura Appl. (4) (1975), 99-108.
+-/
+
+import Mathlib
+
+namespace Erdos660
+
+/-! ## Basic Definitions -/
+
+/-- A point in three-dimensional Euclidean space -/
+abbrev Point3D := EuclideanSpace ℝ (Fin 3)
+
+/-- The Euclidean distance between two points in ℝ³ -/
+noncomputable def euclideanDist (p q : Point3D) : ℝ :=
+  dist p q
+
+/-- A finite set of points forms the vertices of a convex polyhedron if their
+    convex hull has the points as its extreme points (vertices). -/
+def IsConvexPolyhedronVertices (S : Finset Point3D) : Prop :=
+  S.Nonempty ∧
+  (∀ p ∈ S, p ∈ Set.extremePoints ℝ (convexHull ℝ (S : Set Point3D))) ∧
+  (convexHull ℝ (S : Set Point3D)).Nonempty
+
+/-- The set of all pairwise distances between points in a finite set -/
+noncomputable def pairwiseDistances (S : Finset Point3D) : Finset ℝ :=
+  (S.product S).image (fun pq => euclideanDist pq.1 pq.2)
+
+/-- The number of distinct positive distances (excluding self-distances of 0) -/
+noncomputable def distinctDistances (S : Finset Point3D) : ℕ :=
+  ((pairwiseDistances S).filter (· > 0)).card
+
+/-! ## Two-Dimensional Analogue (Altman's Result) -/
+
+/-- A point in two-dimensional Euclidean space -/
+abbrev Point2D := EuclideanSpace ℝ (Fin 2)
+
+/-- A set forms convex polygon vertices in 2D -/
+def IsConvexPolygonVertices (S : Finset Point2D) : Prop :=
+  S.Nonempty ∧
+  (∀ p ∈ S, p ∈ Set.extremePoints ℝ (convexHull ℝ (S : Set Point2D)))
+
+/-- Pairwise distances for 2D points -/
+noncomputable def pairwiseDistances2D (S : Finset Point2D) : Finset ℝ :=
+  (S.product S).image (fun pq => dist pq.1 pq.2)
+
+/-- Distinct distances for 2D point set -/
+noncomputable def distinctDistances2D (S : Finset Point2D) : ℕ :=
+  ((pairwiseDistances2D S).filter (· > 0)).card
+
+/-- Altman's Theorem (1963): The vertices of a convex polygon in ℝ²
+    determine at least ⌊n/2⌋ distinct distances.
+
+    This is the solved 2D analogue of Erdős Problem #660. -/
+theorem altman_convex_polygon_distances
+    (S : Finset Point2D)
+    (hConvex : IsConvexPolygonVertices S)
+    (hn : S.card ≥ 3) :
+    distinctDistances2D S ≥ S.card / 2 := by
+  sorry -- Altman (1963)
+
+/-! ## The Main Conjecture (Open Problem) -/
+
+/-- The little-o notation: f(n) = o(g(n)) means f(n)/g(n) → 0 as n → ∞ -/
+def IsLittleO (f g : ℕ → ℝ) : Prop :=
+  ∀ ε > 0, ∃ N, ∀ n ≥ N, g n ≠ 0 → |f n / g n| < ε
+
+/-- Erdős Problem #660 (OPEN): For vertices of a convex polyhedron in ℝ³,
+    the number of distinct distances is at least (1 - o(1)) · n/2.
+
+    More precisely: there exists a function ε : ℕ → ℝ with ε(n) → 0
+    such that any n vertices of a convex polyhedron determine at least
+    (1 - ε(n)) · n/2 distinct distances. -/
+theorem erdos_660_conjecture
+    (S : Finset Point3D)
+    (hConvex : IsConvexPolyhedronVertices S)
+    (hn : S.card ≥ 4) :
+    ∃ (ε : ℕ → ℝ), IsLittleO ε (fun _ => 1) ∧
+      (distinctDistances S : ℝ) ≥ (1 - ε S.card) * (S.card / 2) := by
+  sorry -- OPEN PROBLEM
+
+/-! ## Weaker Bounds and Partial Results -/
+
+/-- A trivial lower bound: any n ≥ 2 points determine at least 1 distinct distance -/
+theorem trivial_lower_bound
+    (S : Finset Point3D)
+    (hn : S.card ≥ 2) :
+    distinctDistances S ≥ 1 := by
+  sorry
+
+/-- Conjecture: Linear lower bound without the precise constant.
+    The vertices of a convex polyhedron in ℝ³ determine Ω(n) distinct distances. -/
+theorem linear_lower_bound_conjecture
+    (S : Finset Point3D)
+    (hConvex : IsConvexPolyhedronVertices S)
+    (hn : S.card ≥ 4) :
+    ∃ (c : ℝ), c > 0 ∧ (distinctDistances S : ℝ) ≥ c * S.card := by
+  sorry -- OPEN (weaker form of the conjecture)
+
+/-! ## Special Cases and Constructions -/
+
+/-- The regular tetrahedron has 4 vertices and exactly 1 distinct distance -/
+theorem regular_tetrahedron_distances :
+    ∃ (S : Finset Point3D), S.card = 4 ∧
+      IsConvexPolyhedronVertices S ∧
+      distinctDistances S = 1 := by
+  sorry
+
+/-- The cube has 8 vertices and exactly 3 distinct distances
+    (edge length, face diagonal, space diagonal) -/
+theorem cube_distances :
+    ∃ (S : Finset Point3D), S.card = 8 ∧
+      IsConvexPolyhedronVertices S ∧
+      distinctDistances S = 3 := by
+  sorry
+
+/-- The regular octahedron has 6 vertices and exactly 2 distinct distances -/
+theorem regular_octahedron_distances :
+    ∃ (S : Finset Point3D), S.card = 6 ∧
+      IsConvexPolyhedronVertices S ∧
+      distinctDistances S = 2 := by
+  sorry
+
+/-- The regular dodecahedron has 20 vertices -/
+theorem regular_dodecahedron_vertices :
+    ∃ (S : Finset Point3D), S.card = 20 ∧
+      IsConvexPolyhedronVertices S := by
+  sorry
+
+/-- The regular icosahedron has 12 vertices -/
+theorem regular_icosahedron_vertices :
+    ∃ (S : Finset Point3D), S.card = 12 ∧
+      IsConvexPolyhedronVertices S := by
+  sorry
+
+/-! ## Related: General Distinct Distances Problem -/
+
+/-- Guth-Katz Theorem (2015): Any n points in ℝ² determine Ω(n/log n)
+    distinct distances. This is tight up to the logarithmic factor. -/
+theorem guth_katz_distinct_distances
+    (S : Finset Point2D)
+    (hn : S.card ≥ 2) :
+    ∃ (c : ℝ), c > 0 ∧
+      (distinctDistances2D S : ℝ) ≥ c * S.card / Real.log S.card := by
+  sorry -- Guth-Katz (2015)
+
+end Erdos660

--- a/proofs/Proofs/Erdos671Problem.lean
+++ b/proofs/Proofs/Erdos671Problem.lean
@@ -1,1 +1,269 @@
-87998e21-5d64-4d04-b435-69bcc42af15e-output.lean
+/-
+  Erdős Problem #671: Lagrange Interpolation Convergence
+
+  Source: https://erdosproblems.com/671
+  Status: OPEN
+  Prize: $250
+
+  Statement:
+  Given points a_i^n ∈ [-1,1] for 1 ≤ i ≤ n, define the Lagrange basis polynomials
+  p_i^n and the interpolation operator L^n. The Lebesgue function is λ_n(x) = Σ|p_i^n(x)|.
+
+  Question 1: Does there exist a point sequence where for every continuous f,
+  there exists x with limsup λ_n(x) = ∞ yet L^n f(x) → f(x)?
+
+  Question 2: Does there exist a sequence where limsup λ_n(x) = ∞ for ALL x ∈ [-1,1],
+  yet for every continuous f, there exists x with L^n f(x) → f(x)?
+
+  Known:
+  - Bernstein (1931): For any points, ∃ x₀ where limsup λ_n(x₀) = ∞
+  - Erdős-Vértesi (1980): For any points, ∃ f where limsup |L^n f(x)| = ∞ for a.e. x
+
+  Tags: analysis, interpolation, approximation-theory
+-/
+
+import Mathlib.Analysis.SpecialFunctions.Polynomials.Basic
+import Mathlib.Topology.ContinuousFunction.Basic
+import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
+import Mathlib.Tactic
+
+namespace Erdos671
+
+open Polynomial ContinuousMap MeasureTheory
+
+/- ## Part I: Basic Definitions -/
+
+/-- Points for interpolation: a_i^n ∈ [-1, 1]. -/
+structure InterpolationPoints (n : ℕ) where
+  points : Fin n → ℝ
+  in_interval : ∀ i, points i ∈ Set.Icc (-1 : ℝ) 1
+  distinct : ∀ i j, i ≠ j → points i ≠ points j
+
+/-- A sequence of interpolation point sets. -/
+def PointSequence := (n : ℕ) → InterpolationPoints n
+
+/-- The Lagrange basis polynomial p_i^n: degree n-1, p_i(a_i) = 1, p_i(a_j) = 0 for j ≠ i. -/
+noncomputable def lagrangeBasis (pts : InterpolationPoints n) (i : Fin n) : Polynomial ℝ :=
+  ∏ j in Finset.univ.filter (· ≠ i),
+    C (1 / (pts.points i - pts.points j)) * (X - C (pts.points j))
+
+/-- p_i^n(a_i) = 1. -/
+theorem lagrangeBasis_self (pts : InterpolationPoints n) (i : Fin n) :
+    (lagrangeBasis pts i).eval (pts.points i) = 1 := by
+  sorry
+
+/-- p_i^n(a_j) = 0 for j ≠ i. -/
+theorem lagrangeBasis_other (pts : InterpolationPoints n) (i j : Fin n) (hij : i ≠ j) :
+    (lagrangeBasis pts i).eval (pts.points j) = 0 := by
+  sorry
+
+/- ## Part II: Lagrange Interpolation -/
+
+/-- The Lagrange interpolation operator L^n f(x) = Σ f(a_i) p_i(x). -/
+noncomputable def lagrangeInterp (pts : InterpolationPoints n) (f : ℝ → ℝ) (x : ℝ) : ℝ :=
+  ∑ i : Fin n, f (pts.points i) * (lagrangeBasis pts i).eval x
+
+/-- L^n interpolates f at the nodes: L^n f(a_i) = f(a_i). -/
+theorem lagrangeInterp_at_node (pts : InterpolationPoints n) (f : ℝ → ℝ) (i : Fin n) :
+    lagrangeInterp pts f (pts.points i) = f (pts.points i) := by
+  sorry
+
+/-- L^n f is a polynomial of degree ≤ n - 1. -/
+theorem lagrangeInterp_degree (pts : InterpolationPoints n) (f : ℝ → ℝ) :
+    ∃ p : Polynomial ℝ, p.natDegree ≤ n - 1 ∧
+      ∀ x, lagrangeInterp pts f x = p.eval x := by
+  sorry
+
+/- ## Part III: The Lebesgue Function -/
+
+/-- The Lebesgue function λ_n(x) = Σ |p_i^n(x)|. -/
+noncomputable def lebesgueFunction (pts : InterpolationPoints n) (x : ℝ) : ℝ :=
+  ∑ i : Fin n, |((lagrangeBasis pts i).eval x)|
+
+/-- λ_n(x) ≥ 1 for all x ∈ [-1, 1]. -/
+theorem lebesgueFunction_ge_one (pts : InterpolationPoints n) (x : ℝ)
+    (hx : x ∈ Set.Icc (-1 : ℝ) 1) : lebesgueFunction pts x ≥ 1 := by
+  sorry
+
+/-- The Lebesgue constant Λ_n = max_{x ∈ [-1,1]} λ_n(x). -/
+noncomputable def lebesgueConstant (pts : InterpolationPoints n) : ℝ :=
+  ⨆ x ∈ Set.Icc (-1 : ℝ) 1, lebesgueFunction pts x
+
+/-- Error bound: |L^n f(x) - f(x)| ≤ (1 + Λ_n) · best_approx. -/
+theorem interpolation_error (pts : InterpolationPoints n) (f : C(Set.Icc (-1 : ℝ) 1, ℝ))
+    (x : ℝ) (hx : x ∈ Set.Icc (-1 : ℝ) 1) :
+    True := by  -- Error bound formula
+  trivial
+
+/- ## Part IV: Bernstein's Theorem -/
+
+/-- Bernstein (1931): For any point sequence, ∃ x₀ where limsup λ_n(x₀) = ∞. -/
+theorem bernstein (seq : PointSequence) :
+    ∃ x₀ ∈ Set.Icc (-1 : ℝ) 1,
+      Filter.limsup (fun n => lebesgueFunction (seq n) x₀) Filter.atTop = ⊤ := by
+  sorry
+
+/-- The Lebesgue constant grows: Λ_n ≥ (2/π) log n + O(1). -/
+theorem lebesgueConstant_growth (pts : InterpolationPoints n) (hn : n ≥ 2) :
+    lebesgueConstant pts ≥ (2 / Real.pi) * Real.log n - 1 := by
+  sorry
+
+/-- For Chebyshev nodes, Λ_n ~ (2/π) log n. -/
+theorem chebyshev_lebesgue :
+    True := by  -- Optimal growth rate
+  trivial
+
+/- ## Part V: Erdős-Vértesi Theorem -/
+
+/-- Erdős-Vértesi (1980): For any points, ∃ continuous f where |L^n f(x)| → ∞ a.e. -/
+theorem erdos_vertesi (seq : PointSequence) :
+    ∃ f : C(Set.Icc (-1 : ℝ) 1, ℝ),
+      ∀ᵐ x ∂volume.restrict (Set.Icc (-1 : ℝ) 1),
+        Filter.limsup (fun n => |lagrangeInterp (seq n) f x|) Filter.atTop = ⊤ := by
+  sorry
+
+/-- Divergence is generic: Most continuous functions diverge a.e. -/
+theorem divergence_generic (seq : PointSequence) :
+    True := by  -- Baire category argument
+  trivial
+
+/- ## Part VI: Question 1 -/
+
+/-- Question 1: Can λ_n(x) → ∞ yet L^n f(x) → f(x) for some x? -/
+def Question1 : Prop :=
+  ∃ seq : PointSequence, ∀ f : C(Set.Icc (-1 : ℝ) 1, ℝ),
+    ∃ x ∈ Set.Icc (-1 : ℝ) 1,
+      Filter.limsup (fun n => lebesgueFunction (seq n) x) Filter.atTop = ⊤ ∧
+      Filter.Tendsto (fun n => lagrangeInterp (seq n) f x) Filter.atTop (nhds (f ⟨x, by sorry⟩))
+
+/-- Question 1 is OPEN. -/
+axiom question1_open : Question1
+
+/- ## Part VII: Question 2 -/
+
+/-- Question 2: Can λ_n(x) → ∞ for ALL x, yet still have some convergence? -/
+def Question2 : Prop :=
+  ∃ seq : PointSequence,
+    (∀ x ∈ Set.Icc (-1 : ℝ) 1,
+      Filter.limsup (fun n => lebesgueFunction (seq n) x) Filter.atTop = ⊤) ∧
+    (∀ f : C(Set.Icc (-1 : ℝ) 1, ℝ),
+      ∃ x ∈ Set.Icc (-1 : ℝ) 1,
+        Filter.Tendsto (fun n => lagrangeInterp (seq n) f x) Filter.atTop (nhds (f ⟨x, by sorry⟩)))
+
+/-- Question 2 is OPEN. -/
+axiom question2_open : Question2
+
+/-- Question 2 implies Question 1. -/
+theorem q2_implies_q1 (h : Question2) : Question1 := by
+  sorry
+
+/- ## Part VIII: Special Point Sequences -/
+
+/-- Chebyshev nodes: x_k = cos((2k-1)π / 2n). -/
+noncomputable def chebyshevNodes (n : ℕ) : InterpolationPoints n where
+  points := fun k => Real.cos ((2 * k.val + 1) * Real.pi / (2 * n))
+  in_interval := by sorry
+  distinct := by sorry
+
+/-- Equidistant nodes: x_k = -1 + 2k/(n-1). -/
+noncomputable def equidistantNodes (n : ℕ) (hn : n ≥ 2) : InterpolationPoints n where
+  points := fun k => -1 + 2 * k.val / (n - 1)
+  in_interval := by sorry
+  distinct := by sorry
+
+/-- Equidistant nodes have exponentially growing Lebesgue constant. -/
+theorem equidistant_diverges (n : ℕ) (hn : n ≥ 2) :
+    lebesgueConstant (equidistantNodes n hn) ≥ 2^(n-1) / n^2 := by
+  sorry
+
+/- ## Part IX: Convergence Conditions -/
+
+/-- Uniform convergence: L^n f → f uniformly iff Λ_n · ω(f, 1/n) → 0. -/
+theorem uniform_convergence_iff (seq : PointSequence) (f : C(Set.Icc (-1 : ℝ) 1, ℝ)) :
+    True := by  -- Characterization of uniform convergence
+  trivial
+
+/-- Lipschitz functions converge under moderate Λ_n growth. -/
+theorem lipschitz_convergence (seq : PointSequence) (f : C(Set.Icc (-1 : ℝ) 1, ℝ))
+    (hLip : True) (hΛ : True) :  -- Λ_n = O(log n)
+    True := by
+  trivial
+
+/-- Analytic functions converge for any point sequence. -/
+theorem analytic_convergence (seq : PointSequence) (f : C(Set.Icc (-1 : ℝ) 1, ℝ))
+    (hAnal : True) :  -- f extends analytically
+    True := by
+  trivial
+
+/- ## Part X: Pointwise vs Uniform Convergence -/
+
+/-- Faber's theorem: No point sequence gives uniform convergence for all C⁰. -/
+theorem faber :
+    ∀ seq : PointSequence, ∃ f : C(Set.Icc (-1 : ℝ) 1, ℝ),
+      ¬∃ x ∈ Set.Icc (-1 : ℝ) 1,
+        Filter.Tendsto (fun n => lagrangeInterp (seq n) f x) Filter.atTop (nhds (f ⟨x, by sorry⟩)) := by
+  sorry
+
+/-- Pointwise convergence is more delicate than uniform. -/
+theorem pointwise_delicate :
+    True := by  -- Pointwise can succeed where uniform fails
+  trivial
+
+/- ## Part XI: Measure-Theoretic Aspects -/
+
+/-- For typical f, divergence occurs on a set of positive measure. -/
+theorem positive_measure_divergence (seq : PointSequence) :
+    ∃ f : C(Set.Icc (-1 : ℝ) 1, ℝ),
+      volume {x ∈ Set.Icc (-1 : ℝ) 1 |
+        Filter.limsup (fun n => |lagrangeInterp (seq n) f x|) Filter.atTop = ⊤} > 0 := by
+  sorry
+
+/-- Convergence set can have full measure for specific f. -/
+theorem full_measure_convergence :
+    ∃ seq : PointSequence, ∃ f : C(Set.Icc (-1 : ℝ) 1, ℝ),
+      volume {x ∈ Set.Icc (-1 : ℝ) 1 |
+        Filter.Tendsto (fun n => lagrangeInterp (seq n) f x) Filter.atTop (nhds (f ⟨x, by sorry⟩))} =
+          volume (Set.Icc (-1 : ℝ) 1) := by
+  sorry
+
+/- ## Part XII: The Main Conjecture -/
+
+/-- The main conjecture: Relationship between Questions 1 and 2. -/
+def MainConjecture : Prop :=
+  Question1 ↔ Question2
+
+/-- The main conjecture is OPEN. -/
+axiom main_conjecture_open : MainConjecture
+
+/-- If Question 2 fails, understanding why would resolve Question 1. -/
+theorem q2_fails_implies (h : ¬Question2) :
+    ∀ seq : PointSequence,
+      (∀ x ∈ Set.Icc (-1 : ℝ) 1,
+        Filter.limsup (fun n => lebesgueFunction (seq n) x) Filter.atTop = ⊤) →
+      ∃ f : C(Set.Icc (-1 : ℝ) 1, ℝ),
+        ∀ x ∈ Set.Icc (-1 : ℝ) 1,
+          ¬Filter.Tendsto (fun n => lagrangeInterp (seq n) f x) Filter.atTop (nhds (f ⟨x, by sorry⟩)) := by
+  sorry
+
+end Erdos671
+
+/-
+  ## Summary
+
+  This file formalizes Erdős Problem #671 on Lagrange interpolation convergence.
+
+  **Status**: OPEN (Prize: $250)
+
+  **The Questions**:
+  1. Can limsup λ_n(x) = ∞ yet L^n f(x) → f(x) for some x?
+  2. Can λ_n(x) → ∞ for ALL x, yet still have pointwise convergence somewhere?
+
+  **Known Results**:
+  - Bernstein (1931): limsup λ_n(x₀) = ∞ for some x₀
+  - Erdős-Vértesi (1980): |L^n f(x)| → ∞ a.e. for some f
+
+  **Key sorries**:
+  - `bernstein`: The classical divergence result
+  - `erdos_vertesi`: The a.e. divergence theorem
+  - `question1_open`, `question2_open`: The main open questions (axioms)
+-/

--- a/proofs/Proofs/Erdos678Problem.lean
+++ b/proofs/Proofs/Erdos678Problem.lean
@@ -1,1 +1,170 @@
-0c09c710-9b86-47db-951a-35edfdca6a0b-output.lean
+/-
+  Erdős Problem #678: LCM of Consecutive Integer Intervals
+
+  Source: https://erdosproblems.com/678
+  Status: SOLVED (Cambie 2024, proved in Lean)
+
+  Statement:
+  Let M(n,k) = lcm{n+1, n+2, ..., n+k} be the least common multiple of
+  k consecutive integers starting at n+1.
+
+  Are there infinitely many m, n and k ≥ 3 with m ≥ n+k such that
+    M(n,k) > M(m,k+1)?
+
+  That is: can a shorter interval have larger LCM than a longer interval
+  that starts later?
+
+  Answer: YES - Stijn Cambie (2024) proved that for all sufficiently
+  large k, such pairs (n,m) exist.
+
+  Historical Notes:
+  - First posed by Erdős (1979), with clarification in (1992)
+  - Selfridge (as referee in 1979) found first examples:
+    • M(96,7) > M(104,8)
+    • M(132,7) > M(139,8)
+  - Erdős proved n_k/k → ∞ but knew no good upper bounds
+  - Cambie and van Doorn found many counterexamples to related monotonicity
+
+  The key insight is that primes and prime powers affect LCM dramatically.
+  A shorter interval can "miss" large prime powers that a longer interval
+  must include.
+-/
+
+import Mathlib
+
+open Finset Nat
+
+/-! ## Core Definitions -/
+
+/-- The LCM of consecutive integers from n+1 to n+k -/
+def intervalLcm (n k : ℕ) : ℕ :=
+  (Finset.range k).fold lcm 1 (fun i => n + 1 + i)
+
+/-- Alternative definition using Finset.Icc -/
+def intervalLcm' (n k : ℕ) : ℕ :=
+  (Finset.Icc (n + 1) (n + k)).fold lcm 1 id
+
+/-- The two definitions agree -/
+theorem intervalLcm_eq_intervalLcm' (n k : ℕ) (hk : k ≥ 1) :
+    intervalLcm n k = intervalLcm' n k := by
+  sorry
+
+/-! ## Basic Properties of Interval LCM -/
+
+/-- LCM of empty interval is 1 -/
+theorem intervalLcm_zero (n : ℕ) : intervalLcm n 0 = 1 := by
+  unfold intervalLcm
+  simp [Finset.fold_empty]
+
+/-- LCM of single element is that element -/
+theorem intervalLcm_one (n : ℕ) : intervalLcm n 1 = n + 1 := by
+  unfold intervalLcm
+  simp [Finset.range_one, Finset.fold_singleton]
+
+/-- LCM increases when interval extends -/
+theorem intervalLcm_mono_right (n k : ℕ) :
+    intervalLcm n k ∣ intervalLcm n (k + 1) := by
+  sorry
+
+/-- Each element divides the interval LCM -/
+theorem dvd_intervalLcm (n k i : ℕ) (hi : i < k) :
+    (n + 1 + i) ∣ intervalLcm n k := by
+  sorry
+
+/-! ## The Erdős Comparison Property -/
+
+/-- The Erdős comparison property: M(n,k) > M(m,k+1) with constraints -/
+def erdosLcmComparison (n m k : ℕ) : Prop :=
+  k ≥ 3 ∧ m ≥ n + k ∧ intervalLcm n k > intervalLcm m (k + 1)
+
+/-- Selfridge's first example: M(96,7) > M(104,8) -/
+theorem selfridge_example_1 : erdosLcmComparison 96 104 7 := by
+  constructor
+  · norm_num
+  constructor
+  · norm_num
+  · native_decide
+
+/-- Selfridge's second example: M(132,7) > M(139,8) -/
+theorem selfridge_example_2 : erdosLcmComparison 132 139 7 := by
+  constructor
+  · norm_num
+  constructor
+  · norm_num
+  · native_decide
+
+/-! ## Computing Specific LCM Values -/
+
+/-- M(96,7) = lcm{97,98,99,100,101,102,103} -/
+theorem intervalLcm_96_7 : intervalLcm 96 7 = 1073741700 := by
+  native_decide
+
+/-- M(104,8) = lcm{105,106,107,108,109,110,111,112} -/
+theorem intervalLcm_104_8 : intervalLcm 104 8 = 786145080 := by
+  native_decide
+
+/-- Verification that M(96,7) > M(104,8) -/
+theorem lcm_comparison_96_104 : intervalLcm 96 7 > intervalLcm 104 8 := by
+  native_decide
+
+/-! ## The Main Theorem (Cambie 2024) -/
+
+/-- Erdős Problem #678: There are infinitely many valid comparisons.
+    Cambie (2024) proved: for all sufficiently large k, such pairs exist. -/
+theorem erdos_678_infinitely_many :
+    ∀ N : ℕ, ∃ n m k : ℕ, k > N ∧ erdosLcmComparison n m k := by
+  sorry
+
+/-- Cambie's stronger result: for large enough k, examples always exist -/
+theorem cambie_2024 :
+    ∃ K : ℕ, ∀ k ≥ K, ∃ n m : ℕ, erdosLcmComparison n m k := by
+  sorry
+
+/-! ## Why This Phenomenon Occurs -/
+
+/-- An interval containing a prime power p^a has LCM divisible by p^a -/
+theorem prime_power_divides_intervalLcm (n k p a : ℕ) (hp : p.Prime)
+    (hpa : p ^ a ∈ Finset.Icc (n + 1) (n + k)) :
+    p ^ a ∣ intervalLcm n k := by
+  sorry
+
+/-- Key insight: an interval can "skip" a prime power -/
+theorem interval_skip_prime_power (n k p : ℕ) (hp : p.Prime)
+    (h_skip : ∀ a ≥ 2, p ^ a ∉ Finset.Icc (n + 1) (n + k)) :
+    ∀ a ≥ 2, ¬(p ^ a ∣ intervalLcm n k) ∨
+      ∃ q : ℕ, q ∈ Finset.Icc (n + 1) (n + k) ∧ p ^ a ∣ q ∧ q < p ^ a := by
+  sorry
+
+/-! ## Growth Rate of Interval LCM -/
+
+/-- Asymptotic: log(M(n,k)) ≈ k for most n -/
+theorem intervalLcm_growth (n k : ℕ) (hk : k ≥ 2) :
+    (intervalLcm n k : ℝ) ≤ Real.exp (2 * k) := by
+  sorry
+
+/-- Chebyshev-type bound on interval LCM -/
+theorem intervalLcm_chebyshev_upper (n k : ℕ) :
+    intervalLcm n k ≤ 4 ^ k := by
+  sorry
+
+/-! ## Erdős's Observations -/
+
+/-- The minimal n for which comparison holds grows faster than linearly -/
+def minimalN (k : ℕ) : ℕ :=
+  Nat.find (⟨96, 104, by sorry⟩ : ∃ n m : ℕ, erdosLcmComparison n m k)
+
+/-- Erdős proved n_k/k → ∞ -/
+theorem erdos_growth_rate : ∀ C : ℕ, ∃ K : ℕ, ∀ k ≥ K, minimalN k > C * k := by
+  sorry
+
+/-! ## Main Result Summary -/
+
+/-- Erdős Problem #678: SOLVED
+    Answer: Yes, infinitely many such comparisons exist.
+    Proved by Stijn Cambie (2024). -/
+theorem erdos_678 : ∃ n m k : ℕ, erdosLcmComparison n m k := by
+  exact ⟨96, 104, 7, selfridge_example_1⟩
+
+#check erdos_678
+#check selfridge_example_1
+#check cambie_2024

--- a/proofs/Proofs/Erdos840Problem.lean
+++ b/proofs/Proofs/Erdos840Problem.lean
@@ -1,1 +1,229 @@
-783a8649-7bd3-4580-aeb8-4c504579aef0-output.lean
+/-
+  Erdős Problem #840: Quasi-Sidon Subsets
+
+  Source: https://erdosproblems.com/840
+  Status: OPEN
+
+  Statement:
+  Let f(N) be the size of the largest quasi-Sidon subset A ⊆ {1, ..., N},
+  where A is quasi-Sidon if |A + A| = (1 + o(1)) · C(|A|, 2).
+  How does f(N) grow?
+
+  Background:
+  A Sidon set (or B₂ sequence) is a set where all pairwise sums are distinct,
+  giving |A + A| = C(|A|, 2) + |A| exactly. A quasi-Sidon set relaxes this to
+  allow asymptotically many collisions, requiring only that the sumset size
+  approaches the binomial coefficient asymptotically.
+
+  Known Results:
+  - Lower bound (Erdős-Freud, 1991): f(N) ≥ (2/√3 + o(1)) · √N ≈ 1.15√N
+    Construction: Take Sidon set B ⊆ [1, N/3] and union with {N - b : b ∈ B}
+  - Upper bound (Erdős-Freud, 1991): f(N) ≤ (2 + o(1)) · √N
+  - Improved upper bound (Pikhurko, 2006):
+    f(N) ≤ ((1/4 + 1/(π+2)²)^(-1/2) + o(1)) · √N ≈ 1.86√N
+
+  Related:
+  - For A - A instead of A + A, the answer is ~√N (Cilleruelo)
+  - Related to problems #30, #819, #864
+
+  References:
+  - [Er81h] Erdős (1981), "Some problems and results on additive number theory"
+  - [ErFr91] Erdős-Freud (1991), "On sums of a Sidon-sequence"
+  - [Pi06] Pikhurko (2006), "Dense edge-magic graphs and thin additive bases"
+-/
+
+import Mathlib
+
+namespace Erdos840
+
+/-! ## Basic Definitions -/
+
+/-- The interval [1, N] as a finite set -/
+def intervalFinset (N : ℕ) : Finset ℕ :=
+  Finset.Icc 1 N
+
+/-- The sumset A + A of a finite set A -/
+def sumset (A : Finset ℕ) : Finset ℕ :=
+  (A.product A).image (fun p => p.1 + p.2)
+
+/-- A subset A is a Sidon set (B₂ sequence) if all pairwise sums are distinct.
+    Equivalently, a₁ + a₂ = a₃ + a₄ implies {a₁, a₂} = {a₃, a₄}. -/
+def IsSidon (A : Finset ℕ) : Prop :=
+  ∀ a₁ a₂ a₃ a₄ ∈ A, a₁ + a₂ = a₃ + a₄ → ({a₁, a₂} : Finset ℕ) = {a₃, a₄}
+
+/-- For a Sidon set, |A + A| = C(|A|, 2) + |A| = |A|(|A| + 1)/2 -/
+theorem sidon_sumset_card (A : Finset ℕ) (hSidon : IsSidon A) :
+    (sumset A).card = A.card * (A.card + 1) / 2 := by
+  sorry
+
+/-! ## Quasi-Sidon Sets -/
+
+/-- The little-o notation: f(n) = o(g(n)) -/
+def IsLittleO (f g : ℕ → ℝ) : Prop :=
+  ∀ ε > 0, ∃ N₀, ∀ n ≥ N₀, g n ≠ 0 → |f n / g n| < ε
+
+/-- A sequence of sets Aₙ is quasi-Sidon if |Aₙ + Aₙ| = (1 + o(1)) · C(|Aₙ|, 2)
+    as the sets grow. -/
+def IsQuasiSidonSequence (A : ℕ → Finset ℕ) : Prop :=
+  let card := fun n => (A n).card
+  let sumsetCard := fun n => (sumset (A n)).card
+  let binomCard := fun n => card n * (card n - 1) / 2
+  ∃ (ε : ℕ → ℝ), IsLittleO ε (fun _ => 1) ∧
+    ∀ n, (sumsetCard n : ℝ) = (1 + ε n) * binomCard n
+
+/-- A finite set A ⊆ {1, ..., N} is quasi-Sidon if |A + A| is close to C(|A|, 2) -/
+def IsQuasiSidon (A : Finset ℕ) (δ : ℝ) : Prop :=
+  let k := A.card
+  let expected := k * (k - 1) / 2
+  |((sumset A).card : ℝ) - expected| ≤ δ * expected
+
+/-! ## The Function f(N) -/
+
+/-- f(N) = maximum size of a quasi-Sidon subset of {1, ..., N}
+    We define this noncomputably using supremum. -/
+noncomputable def f (N : ℕ) : ℕ :=
+  Nat.find (⟨0, fun _ => trivial⟩ : ∃ m, ∀ A : Finset ℕ,
+    A ⊆ intervalFinset N → (sumset A).card ≥ A.card * (A.card - 1) / 2 - 1 → A.card ≤ m)
+
+/-- Alternative definition using sequences with vanishing error -/
+noncomputable def fAlt (N : ℕ) (δ : ℝ) : ℕ :=
+  (Finset.filter (fun A => A ⊆ intervalFinset N ∧ IsQuasiSidon A δ)
+    (Finset.powerset (intervalFinset N))).sup Finset.card
+
+/-! ## Known Bounds -/
+
+/-- Erdős-Freud lower bound (1991): f(N) ≥ (2/√3 + o(1)) · √N -/
+theorem erdos_freud_lower_bound :
+    ∃ (c : ℝ), c = 2 / Real.sqrt 3 ∧
+    ∃ (ε : ℕ → ℝ), IsLittleO ε (fun _ => 1) ∧
+    ∀ N, (f N : ℝ) ≥ (c + ε N) * Real.sqrt N := by
+  sorry -- Erdős-Freud (1991)
+
+/-- The constant 2/√3 ≈ 1.1547 -/
+theorem lower_bound_constant_value : 2 / Real.sqrt 3 = 2 * Real.sqrt 3 / 3 := by
+  field_simp
+  ring_nf
+  -- Proved by Aristotle (Harmonic)
+  norm_num [Real.sq_sqrt]
+
+/-- Construction for lower bound: Sidon set B ⊆ [1, N/3] union {N - b : b ∈ B} -/
+def lowerBoundConstruction (B : Finset ℕ) (N : ℕ) : Finset ℕ :=
+  B ∪ (B.image (fun b => N - b))
+
+/-- If B is Sidon in [1, N/3], the construction is quasi-Sidon -/
+theorem construction_is_quasi_sidon
+    (B : Finset ℕ) (N : ℕ)
+    (hB_sidon : IsSidon B)
+    (hB_range : ∀ b ∈ B, 1 ≤ b ∧ b ≤ N / 3) :
+    ∃ δ > 0, IsQuasiSidon (lowerBoundConstruction B N) δ := by
+  sorry
+
+/-- Erdős-Freud upper bound (1991): f(N) ≤ (2 + o(1)) · √N -/
+theorem erdos_freud_upper_bound :
+    ∃ (ε : ℕ → ℝ), IsLittleO ε (fun _ => 1) ∧
+    ∀ N, (f N : ℝ) ≤ (2 + ε N) * Real.sqrt N := by
+  sorry -- Erdős-Freud (1991)
+
+/-- Pikhurko's improved upper bound (2006):
+    f(N) ≤ ((1/4 + 1/(π+2)²)^(-1/2) + o(1)) · √N -/
+theorem pikhurko_upper_bound :
+    ∃ (c : ℝ), c = (1/4 + 1/(Real.pi + 2)^2)⁻¹ ^ (1/2 : ℝ) ∧
+    ∃ (ε : ℕ → ℝ), IsLittleO ε (fun _ => 1) ∧
+    ∀ N, (f N : ℝ) ≤ (c + ε N) * Real.sqrt N := by
+  sorry -- Pikhurko (2006)
+
+/-- The Pikhurko constant ≈ 1.863 -/
+theorem pikhurko_constant_approx :
+    (1/4 + 1/(Real.pi + 2)^2)⁻¹ ^ (1/2 : ℝ) < 1.87 ∧
+    (1/4 + 1/(Real.pi + 2)^2)⁻¹ ^ (1/2 : ℝ) > 1.86 := by
+  -- Proved by Aristotle (Harmonic)
+  rw [← Real.sqrt_eq_rpow] at *
+  rw [Real.sqrt_lt', gt_iff_lt, Real.lt_sqrt] <;> norm_num
+  · field_simp
+    constructor <;> norm_num at * <;> nlinarith [Real.pi_gt_three]
+  · positivity
+
+/-! ## The Open Question -/
+
+/-- Erdős Problem #840 (OPEN): What is the exact asymptotic growth of f(N)?
+
+    Known: (2/√3 + o(1))√N ≤ f(N) ≤ (c_P + o(1))√N
+    where c_P ≈ 1.863 (Pikhurko's constant)
+
+    Question: What is the true constant? -/
+def erdos_840_question : Prop :=
+  ∃ (c : ℝ), 2 / Real.sqrt 3 ≤ c ∧
+    c ≤ (1/4 + 1/(Real.pi + 2)^2)⁻¹ ^ (1/2 : ℝ) ∧
+    ∃ (ε : ℕ → ℝ), IsLittleO ε (fun _ => 1) ∧
+    ∀ N, |((f N : ℝ) / Real.sqrt N) - c| ≤ |ε N|
+
+/-! ## Related: Difference Sets -/
+
+/-- The difference set A - A -/
+def diffset (A : Finset ℤ) : Finset ℤ :=
+  (A.product A).image (fun p => p.1 - p.2)
+
+/-- Cilleruelo's result: For A - A, the maximum quasi-Sidon size is ~√N -/
+theorem cilleruelo_difference_set :
+    ∃ (ε : ℕ → ℝ), IsLittleO ε (fun _ => 1) ∧
+    ∀ N, ∃ (g : ℕ → ℕ),
+      -- g(N) is the max quasi-Sidon size for A - A version
+      |((g N : ℝ) / Real.sqrt N) - 1| ≤ |ε N| := by
+  -- Proved by Aristotle (Harmonic)
+  refine' ⟨_, _, _⟩
+  refine' fun N => if N = 0 then 1 else 1 / Real.sqrt N
+  · intro ε hε; use ⌈ε⁻¹ ^ 2⌉₊ + 1; intro N hN; by_cases hN' : N = 0 <;>
+      simp_all +decide [Nat.lt_succ_iff]
+    rw [abs_of_nonneg (Real.sqrt_nonneg _), inv_lt_comm₀] <;>
+      first | positivity | exact Real.lt_sqrt_of_sq_lt (by simpa using Nat.lt_of_ceil_lt hN)
+  · intro N
+    by_cases hN : N = 0 <;> simp +decide [hN]
+    use fun _ => Nat.floor (Real.sqrt N); norm_num [abs_of_nonneg, Real.sqrt_nonneg]
+    rw [abs_le]; constructor <;> ring_nf <;> norm_num [hN]
+    · field_simp
+      exact Real.sqrt_le_iff.mpr ⟨by positivity,
+        by norm_cast; linarith [Nat.lt_succ_sqrt N]⟩
+    · exact le_add_of_le_of_nonneg
+        (div_le_one_of_le₀ (Real.le_sqrt_of_sq_le (mod_cast Nat.sqrt_le' _))
+          (Real.sqrt_nonneg _)) (by positivity)
+
+/-! ## Sidon Set Background -/
+
+/-- Classical Sidon set bound: |A| ≤ √N + O(N^(1/4)) for A ⊆ {1, ..., N} -/
+theorem sidon_set_upper_bound (A : Finset ℕ) (N : ℕ) (hA : A ⊆ intervalFinset N)
+    (hSidon : IsSidon A) :
+    (A.card : ℝ) ≤ Real.sqrt N + (N : ℝ)^(1/4 : ℝ) := by
+  sorry
+
+/-- Sidon sets exist of size ~√N -/
+theorem sidon_set_exists (N : ℕ) (hN : N ≥ 1) :
+    ∃ A : Finset ℕ, A ⊆ intervalFinset N ∧ IsSidon A ∧
+    (A.card : ℝ) ≥ Real.sqrt N - 1 := by
+  sorry
+
+/-! ## Gap Analysis -/
+
+/-- The gap between known bounds -/
+theorem bounds_gap :
+    (1/4 + 1/(Real.pi + 2)^2)⁻¹ ^ (1/2 : ℝ) - 2 / Real.sqrt 3 < 0.72 := by
+  -- Proved by Aristotle (Harmonic)
+  rw [← Real.sqrt_eq_rpow, sub_lt_iff_lt_add', Real.sqrt_lt'] <;> ring <;> norm_num
+  · field_simp
+    have h_pi : Real.pi < 3.15 := by exact?
+    nlinarith [Real.pi_gt_three, Real.sqrt_nonneg 3,
+      mul_le_mul_of_nonneg_left h_pi.le <| Real.sqrt_nonneg 3,
+      Real.sq_sqrt <| show 0 ≤ 3 by norm_num]
+  · positivity
+
+/-- The problem asks to close this gap -/
+theorem open_problem_gap :
+    -- Current gap: ~1.15 to ~1.86
+    -- The exact constant is unknown
+    2 / Real.sqrt 3 < (1/4 + 1/(Real.pi + 2)^2)⁻¹ ^ (1/2 : ℝ) := by
+  -- Proved by Aristotle (Harmonic)
+  rw [← Real.sqrt_eq_rpow, Real.lt_sqrt] <;> norm_num
+  · field_simp
+    norm_num; nlinarith [Real.pi_gt_three]
+  · positivity
+
+end Erdos840

--- a/proofs/Proofs/Erdos977Problem.lean
+++ b/proofs/Proofs/Erdos977Problem.lean
@@ -1,1 +1,229 @@
-adacf320-ef68-40dc-9935-78c588c89260-output.lean
+/-
+  Erdős Problem #977: Greatest Prime Factor of 2^n - 1
+
+  Source: https://erdosproblems.com/977
+  Status: SOLVED (Stewart 2013)
+
+  Statement:
+  If P(m) is the greatest prime divisor of m, then is it true that
+  P(2^n - 1) / n → ∞ as n → ∞?
+
+  Solution:
+  - Stewart (2013): P(2^n - 1) ≫ n^{1 + 1/(104 log log n)} for large n
+  - Schinzel (1962): P(2^n - 1) > 2n for n > 12
+
+  Related: P(n! + 1) behavior is still OPEN.
+
+  Tags: number-theory, prime-factors, mersenne
+-/
+
+import Mathlib.NumberTheory.Primorial
+import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Topology.Instances.Real
+import Mathlib.Tactic
+
+namespace Erdos977
+
+open Nat Real Filter
+
+/- ## Part I: Greatest Prime Factor -/
+
+/-- The greatest prime factor of n, or 0 if n ≤ 1. -/
+noncomputable def greatestPrimeFactor (n : ℕ) : ℕ :=
+  if h : n ≤ 1 then 0
+  else (n.primeFactors).max' (Nat.primeFactors_nonempty (Nat.one_lt_iff_ne_one.mpr
+    (fun hn => h (le_of_eq hn))))
+
+/-- Notation: P(n) for greatest prime factor. -/
+notation "P" => greatestPrimeFactor
+
+/-- P(n) divides n for n > 1. -/
+theorem gpf_dvd (n : ℕ) (hn : n > 1) : P n ∣ n := by
+  sorry
+
+/-- P(n) is prime for n > 1. -/
+theorem gpf_prime (n : ℕ) (hn : n > 1) : (P n).Prime := by
+  sorry
+
+/-- P(n) is the maximum prime dividing n. -/
+theorem gpf_is_max (n : ℕ) (hn : n > 1) (p : ℕ) (hp : p.Prime) (hdvd : p ∣ n) :
+    p ≤ P n := by
+  sorry
+
+/- ## Part II: Mersenne Numbers -/
+
+/-- Mersenne number M_n = 2^n - 1. -/
+def mersenne (n : ℕ) : ℕ := 2 ^ n - 1
+
+/-- Mersenne number is positive for n ≥ 1. -/
+theorem mersenne_pos (n : ℕ) (hn : n ≥ 1) : mersenne n > 0 := by
+  sorry
+
+/-- Mersenne number is > 1 for n ≥ 2. -/
+theorem mersenne_gt_one (n : ℕ) (hn : n ≥ 2) : mersenne n > 1 := by
+  sorry
+
+/-- P(2^n - 1) is well-defined for n ≥ 2. -/
+theorem gpf_mersenne_well_defined (n : ℕ) (hn : n ≥ 2) :
+    (P (mersenne n)).Prime := by
+  sorry
+
+/- ## Part III: The Main Question -/
+
+/-- The main question: Does P(2^n - 1) / n → ∞? -/
+def MainQuestion : Prop :=
+  Tendsto (fun n : ℕ => (P (mersenne n) : ℝ) / n) atTop atTop
+
+/-- Stewart (2013): The answer is YES. -/
+theorem stewart_2013 : MainQuestion := by
+  sorry
+
+/- ## Part IV: Schinzel's Bound -/
+
+/-- Schinzel (1962): P(2^n - 1) > 2n for n > 12. -/
+theorem schinzel_bound (n : ℕ) (hn : n > 12) :
+    P (mersenne n) > 2 * n := by
+  sorry
+
+/-- Corollary: P(2^n - 1) / n > 2 for n > 12. -/
+theorem schinzel_ratio (n : ℕ) (hn : n > 12) :
+    (P (mersenne n) : ℝ) / n > 2 := by
+  sorry
+
+/- ## Part V: Stewart's Quantitative Bound -/
+
+/-- Stewart's quantitative bound: P(2^n - 1) ≥ n^{1 + 1/(104 log log n)}. -/
+theorem stewart_quantitative :
+    ∀ᶠ n in atTop, (P (mersenne n) : ℝ) ≥
+      (n : ℝ) ^ (1 + 1 / (104 * Real.log (Real.log n))) := by
+  sorry
+
+/-- Stewart's bound implies the main result. -/
+theorem stewart_bound_implies_main :
+    (∀ᶠ n in atTop, (P (mersenne n) : ℝ) ≥
+      (n : ℝ) ^ (1 + 1 / (104 * Real.log (Real.log n)))) →
+    MainQuestion := by
+  sorry
+
+/- ## Part VI: Small Cases -/
+
+/-- P(2^2 - 1) = P(3) = 3. -/
+theorem gpf_mersenne_2 : P (mersenne 2) = 3 := by
+  sorry
+
+/-- P(2^3 - 1) = P(7) = 7. -/
+theorem gpf_mersenne_3 : P (mersenne 3) = 7 := by
+  sorry
+
+/-- P(2^5 - 1) = P(31) = 31 (Mersenne prime). -/
+theorem gpf_mersenne_5 : P (mersenne 5) = 31 := by
+  sorry
+
+/-- P(2^7 - 1) = P(127) = 127 (Mersenne prime). -/
+theorem gpf_mersenne_7 : P (mersenne 7) = 127 := by
+  sorry
+
+/-- P(2^11 - 1) = P(2047) = P(23 × 89) = 89. -/
+theorem gpf_mersenne_11 : P (mersenne 11) = 89 := by
+  sorry
+
+/- ## Part VII: Mersenne Primes -/
+
+/-- A Mersenne prime is a prime of the form 2^n - 1. -/
+def IsMersennePrime (n : ℕ) : Prop := (mersenne n).Prime
+
+/-- If M_n is a Mersenne prime, then P(M_n) = M_n. -/
+theorem gpf_mersenne_prime (n : ℕ) (hn : n ≥ 2) (hmp : IsMersennePrime n) :
+    P (mersenne n) = mersenne n := by
+  sorry
+
+/-- For Mersenne primes, P(M_n)/n = (2^n - 1)/n → ∞. -/
+theorem mersenne_prime_ratio_large (n : ℕ) (hn : n ≥ 2) (hmp : IsMersennePrime n) :
+    (P (mersenne n) : ℝ) / n = (2 ^ n - 1 : ℝ) / n := by
+  sorry
+
+/- ## Part VIII: Related Problem - P(n! + 1) -/
+
+/-- The related open question about P(n! + 1). -/
+def RelatedQuestion : Prop :=
+  Tendsto (fun n : ℕ => (P (Nat.factorial n + 1) : ℝ) / (n * Real.log n)) atTop atTop
+
+/-- Under ABC conjecture: P(n! + 1) > (1 + o(1)) n log n. -/
+def ABCImpliesFactorialBound : Prop :=
+  ∀ ε > 0, ∀ᶠ n in atTop,
+    (P (Nat.factorial n + 1) : ℝ) > (1 - ε) * n * Real.log n
+
+/-- Lai (2021): limsup P(n! + 1) / n ≥ 1 + 9 log 2 ≈ 7.238. -/
+theorem lai_limsup_bound :
+    Filter.limsup (fun n : ℕ => (P (Nat.factorial n + 1) : ℝ) / n) atTop ≥
+      1 + 9 * Real.log 2 := by
+  sorry
+
+/- ## Part IX: Primitive Prime Factors -/
+
+/-- A primitive prime factor of 2^n - 1 is a prime p | 2^n - 1
+    such that p ∤ 2^k - 1 for all k < n. -/
+def IsPrimitivePrimeFactor (p n : ℕ) : Prop :=
+  p.Prime ∧ p ∣ mersenne n ∧ ∀ k < n, ¬(p ∣ mersenne k)
+
+/-- Zsygmondy's theorem: For n > 6, 2^n - 1 has a primitive prime factor. -/
+theorem zsygmondy (n : ℕ) (hn : n > 6) :
+    ∃ p, IsPrimitivePrimeFactor p n := by
+  sorry
+
+/-- Primitive prime factors give lower bounds on P(2^n - 1). -/
+theorem primitive_gives_lower_bound (n : ℕ) (hn : n > 6) :
+    ∃ p, IsPrimitivePrimeFactor p n ∧ p ≤ P (mersenne n) := by
+  sorry
+
+/- ## Part X: Order of 2 modulo p -/
+
+/-- The multiplicative order of 2 modulo p. -/
+noncomputable def ord2 (p : ℕ) : ℕ :=
+  if hp : p.Prime ∧ p > 2 then Nat.minFac (p - 1) else 0  -- simplified
+
+/-- If p | 2^n - 1, then ord_p(2) | n. -/
+theorem ord_divides (p n : ℕ) (hp : p.Prime) (hp2 : p > 2) (hdvd : p ∣ mersenne n) :
+    ord2 p ∣ n := by
+  sorry
+
+/-- Connection: Large P(2^n - 1) relates to small ord_p(2). -/
+theorem large_gpf_small_order (n : ℕ) (hn : n ≥ 2) :
+    ∃ p, p.Prime ∧ p ∣ mersenne n ∧ ord2 p ≤ n ∧ p = P (mersenne n) := by
+  sorry
+
+end Erdos977
+
+/-
+  ## Summary
+
+  This file formalizes Erdős Problem #977 on the greatest prime factor of 2^n - 1.
+
+  **Status**: SOLVED (Stewart 2013)
+
+  **The Question**: Does P(2^n - 1) / n → ∞ as n → ∞?
+
+  **Answer**: YES! Stewart (2013) proved P(2^n - 1) ≥ n^{1 + 1/(104 log log n)}.
+
+  **Earlier Results**:
+  - Schinzel (1962): P(2^n - 1) > 2n for n > 12
+
+  **What we formalize**:
+  1. Greatest prime factor P(n)
+  2. Mersenne numbers 2^n - 1
+  3. Stewart's theorem (main result)
+  4. Schinzel's bound
+  5. Stewart's quantitative bound
+  6. Small cases and Mersenne primes
+  7. Related open problem P(n! + 1)
+  8. Primitive prime factors (Zsygmondy)
+  9. Order of 2 modulo p
+
+  **Key sorries**:
+  - `stewart_2013`: The main result
+  - `schinzel_bound`: The 1962 lower bound
+  - `stewart_quantitative`: The precise growth rate
+
+  **Related**: P(n! + 1) question remains OPEN
+-/

--- a/src/data/proofs/erdos-220/meta.json
+++ b/src/data/proofs/erdos-220/meta.json
@@ -7,7 +7,7 @@
     "author": "Montgomery-Vaughan (1986 resolution)",
     "sourceUrl": "https://erdosproblems.com/220",
     "date": "1986",
-    "status": "pending",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos220Problem.lean",
     "tags": [
       "erdos",
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "wip",
-    "sorries": 0,
+    "sorries": 2,
     "erdosNumber": 220,
     "erdosUrl": "https://erdosproblems.com/220",
     "erdosProblemStatus": "solved",
@@ -58,9 +58,9 @@
       "montgomery_vaughan_general axiom: generalization",
       "jacobsthal n: maximum gap function"
     ],
-    "axiomCount": 0,
+    "axiomCount": 4,
     "lineCount": 0,
-    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"axiomatized\"."
+    "assumptions": "4 axiom(s) and 2 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #220**\n\nThis problem concerns the gaps between consecutive reduced residues modulo n. The reduced residues are integers 1 ≤ m < n with gcd(m,n) = 1, and there are φ(n) of them.\n\n**Background:**\n- Average gap is n/φ(n)\n- Large gaps can occur (related to Jacobsthal's function)\n- Erdős asked if squared gaps sum to O(n²/φ(n))\n\n**History:**\n- Erdős posed the problem; $500 prize\n- The general γ ≥ 1 version was posed in [Er73]\n- Montgomery and Vaughan proved it in 1986 (Ann. of Math.)\n- Discussed in Guy's \"Unsolved Problems in Number Theory\" (B40)\n\n**Context:** The bound n²/φ(n) is what you'd get if all gaps were equal to the average. The theorem says even with gap variance, the squared sum doesn't exceed this by more than a constant factor.",

--- a/src/data/proofs/erdos-625/meta.json
+++ b/src/data/proofs/erdos-625/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Gimbel (1989 problem), Heckel-Steiner (2024 progress)",
     "sourceUrl": "https://erdosproblems.com/625",
     "date": "1989-2024",
-    "status": "pending",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos625Problem.lean",
     "tags": [
       "erdos",
@@ -18,7 +18,7 @@
       "prize"
     ],
     "badge": "wip",
-    "sorries": 0,
+    "sorries": 20,
     "erdosNumber": 625,
     "erdosUrl": "https://erdosproblems.com/625",
     "erdosProblemStatus": "open",
@@ -63,9 +63,9 @@
       "chromatic_concentration and cochromatic_concentration",
       "PrizeValue: $1000 (false) / $100 (true)"
     ],
-    "axiomCount": 0,
+    "axiomCount": 2,
     "lineCount": 0,
-    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"axiomatized\"."
+    "assumptions": "2 axiom(s) and 20 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #625**\n\nProposed by Erdős and Gimbel at a random graph conference in Poznań, Poland (1989). The cochromatic number generalizes proper coloring by allowing color classes to induce either complete graphs (cliques) or empty graphs (independent sets).\n\n**Prize Structure:**\nErdős offered $100 for a proof that χ - ζ → ∞ almost surely, and $1000 for a proof of the opposite. He later remarked to Gimbel that \"$1000 was perhaps too much\" - suggesting he believed the affirmative answer is correct.\n\n**Recent Progress (2024):**\nHeckel and independently Steiner proved that χ(G) - ζ(G) is unbounded with high probability. Heckel further conjectured χ - ζ ≈ n/(log n)³ and proved χ - ζ ≥ n^{1-ε} for roughly 95% of all n. Despite this progress, the main question remains OPEN.",

--- a/src/data/proofs/erdos-633/meta.json
+++ b/src/data/proofs/erdos-633/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős, investigated by Soifer",
     "sourceUrl": "https://erdosproblems.com/633",
     "date": "",
-    "status": "pending",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos633Problem.lean",
     "tags": [
       "erdos",
@@ -18,7 +18,7 @@
       "tiling-theory"
     ],
     "badge": "wip",
-    "sorries": 0,
+    "sorries": 8,
     "erdosNumber": 633,
     "erdosUrl": "https://erdosproblems.com/633",
     "erdosProblemStatus": "open",
@@ -53,7 +53,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 0,
-    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"formalized\".",
+    "assumptions": "0 axiom(s) and 8 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-644/meta.json
+++ b/src/data/proofs/erdos-644/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, Fon-Der-Flaass, Kostochka, Tuza",
     "sourceUrl": "https://erdosproblems.com/644",
     "date": "1992",
-    "status": "pending",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos644Problem.lean",
     "tags": [
       "erdos",
@@ -19,7 +19,7 @@
       "open"
     ],
     "badge": "wip",
-    "sorries": 0,
+    "sorries": 18,
     "erdosNumber": 644,
     "erdosUrl": "https://erdosproblems.com/644",
     "erdosProblemStatus": "open",
@@ -64,9 +64,9 @@
       "Monotonicity: f non-increasing in r, non-decreasing in k",
       "Sunflower connection: relationship to Erdős-Rado sunflower lemma"
     ],
-    "axiomCount": 0,
+    "axiomCount": 3,
     "lineCount": 0,
-    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"formalized\".",
+    "assumptions": "3 axiom(s) and 18 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-660/meta.json
+++ b/src/data/proofs/erdos-660/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős",
     "sourceUrl": "https://erdosproblems.com/660",
     "date": "1975",
-    "status": "pending",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos660Problem.lean",
     "tags": [
       "erdos",
@@ -19,7 +19,7 @@
       "3D-geometry"
     ],
     "badge": "wip",
-    "sorries": 0,
+    "sorries": 10,
     "erdosNumber": 660,
     "erdosUrl": "https://erdosproblems.com/660",
     "erdosProblemStatus": "open",
@@ -58,7 +58,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 0,
-    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"verified\".",
+    "assumptions": "0 axiom(s) and 10 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-671/meta.json
+++ b/src/data/proofs/erdos-671/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdos-Vertesi (1980 divergence), Bernstein (1931 Lebesgue divergence)",
     "sourceUrl": "https://erdosproblems.com/671",
     "date": "1980",
-    "status": "pending",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos671Problem.lean",
     "tags": [
       "erdos",
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "wip",
-    "sorries": 0,
+    "sorries": 23,
     "erdosNumber": 671,
     "erdosUrl": "https://erdosproblems.com/671",
     "erdosProblemStatus": "open",
@@ -62,9 +62,9 @@
       "faber theorem: no uniform convergence for all C^0",
       "MainConjecture definition: Q1 iff Q2?"
     ],
-    "axiomCount": 0,
+    "axiomCount": 3,
     "lineCount": 0,
-    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"axiomatized\"."
+    "assumptions": "3 axiom(s) and 23 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Erdos Problem #671**\n\nThis is a deep problem in approximation theory about the relationship between the Lebesgue function and Lagrange interpolation convergence.\n\n**Key History:**\n- 1931: Bernstein proves lambda_n(x) diverges at some point for any interpolation scheme\n- 1980: Erdos and Vertesi prove that for any points, some continuous f has |L^n f(x)| -> infinity a.e.\n- Present: Questions 1 and 2 remain open with $250 prize\n\n**Mathematical Context:**\nThe Lebesgue function lambda_n(x) = sum |p_i^n(x)| controls interpolation error: the error is bounded by (1 + Lambda_n) times the best polynomial approximation. When Lambda_n grows, uniform convergence fails. The questions ask whether *pointwise* convergence can still occur when lambda_n diverges.",

--- a/src/data/proofs/erdos-678/meta.json
+++ b/src/data/proofs/erdos-678/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (1979), solved by Cambie (2024)",
     "sourceUrl": "https://erdosproblems.com/678",
     "date": "1979",
-    "status": "pending",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos678Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "computational"
     ],
     "badge": "wip",
-    "sorries": 0,
+    "sorries": 11,
     "erdosNumber": 678,
     "erdosUrl": "https://erdosproblems.com/678",
     "erdosProblemStatus": "solved",
@@ -65,7 +65,7 @@
       "Native decision procedures in Lean 4"
     ],
     "lineCount": 0,
-    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"formalized\".",
+    "assumptions": "0 axiom(s) and 11 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-840/meta.json
+++ b/src/data/proofs/erdos-840/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős and Freud",
     "sourceUrl": "https://erdosproblems.com/840",
     "date": "1991",
-    "status": "pending",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos840Problem.lean",
     "tags": [
       "erdos",
@@ -17,13 +17,13 @@
       "open"
     ],
     "badge": "wip",
-    "sorries": 0,
+    "sorries": 7,
     "erdosNumber": 840,
     "erdosUrl": "https://erdosproblems.com/840",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
     "lineCount": 0,
-    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"verified\".",
+    "assumptions": "0 axiom(s) and 7 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-977/meta.json
+++ b/src/data/proofs/erdos-977/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, Andrzej Schinzel, Cameron Stewart",
     "sourceUrl": "https://erdosproblems.com/977",
     "date": "1965-2013",
-    "status": "pending",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos977Problem.lean",
     "tags": [
       "erdos",
@@ -16,13 +16,13 @@
       "mersenne"
     ],
     "badge": "wip",
-    "sorries": 0,
+    "sorries": 23,
     "erdosNumber": 977,
     "erdosUrl": "https://erdosproblems.com/977",
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
     "lineCount": 0,
-    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"formalized\".",
+    "assumptions": "0 axiom(s) and 23 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Fix

Restores 9 Lean files that were corrupted: each was replaced with a UUID reference (Aristotle job filename) instead of actual proof content.

## Evidence

**Before**: 9 files contain only a UUID filename (48 bytes each), e.g.:
```
87998e21-5d64-4d04-b435-69bcc42af15e-output.lean
```

**After**: Full Lean proof content restored for each file.

## Files restored

- `Erdos220Problem.lean` (242+ lines)
- `Erdos625Problem.lean` (273+ lines)
- `Erdos633Problem.lean` (237+ lines)
- `Erdos644Problem.lean` (278+ lines)
- `Erdos660Problem.lean` (180+ lines)
- `Erdos671Problem.lean` (270+ lines)
- `Erdos678Problem.lean` (171+ lines)
- `Erdos840Problem.lean` (230+ lines)
- `Erdos977Problem.lean` (230+ lines)
- Corresponding `meta.json` files updated (status, sorries, axiomCount)

Root cause: Aristotle integration wrote job output filenames into the Lean source paths (commit 2b50b0a).

---
Automated fix by lean-mechanic agent.