### PR TITLE
Fix: correct sorryCount in 8 research problem JSON files

### DIFF
--- a/src/data/research/problems/erdos-1012-oq-03-incomplete-01.json
+++ b/src/data/research/problems/erdos-1012-oq-03-incomplete-01.json
@@ -81,7 +81,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 8,
-      "sorryCount": 3,
+      "sorryCount": 4,
       "isAristotle": false
     }
   ]

--- a/src/data/research/problems/erdos-402-incomplete-01.json
+++ b/src/data/research/problems/erdos-402-incomplete-01.json
@@ -101,7 +101,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 5,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos402Problem.lean"
     }

--- a/src/data/research/problems/erdos-8-oq-01.json
+++ b/src/data/research/problems/erdos-8-oq-01.json
@@ -353,7 +353,7 @@
       "theoremCount": 3,
       "axiomCount": 2,
       "defCount": 8,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos815Problem.lean"
     },

--- a/src/data/research/problems/kummer-theorem-oq-01.json
+++ b/src/data/research/problems/kummer-theorem-oq-01.json
@@ -74,7 +74,7 @@
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KummerTheoremOQ01.lean"
     },
@@ -85,7 +85,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KummerTheoremOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/kummer-theorem-oq-02.json
+++ b/src/data/research/problems/kummer-theorem-oq-02.json
@@ -107,7 +107,7 @@
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KummerTheoremOQ01.lean"
     },
@@ -118,7 +118,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KummerTheoremOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/kummer-theorem-oq-03.json
+++ b/src/data/research/problems/kummer-theorem-oq-03.json
@@ -76,7 +76,7 @@
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KummerTheoremOQ01.lean"
     },
@@ -87,7 +87,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KummerTheoremOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/kummer-theorem.json
+++ b/src/data/research/problems/kummer-theorem.json
@@ -77,7 +77,7 @@
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KummerTheoremOQ01.lean"
     },
@@ -88,7 +88,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KummerTheoremOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/roth-theorem-k3-oq-01.json
+++ b/src/data/research/problems/roth-theorem-k3-oq-01.json
@@ -80,7 +80,7 @@
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 6,
+      "sorryCount": 5,
       "isAristotle": false
     }
   ]


### PR DESCRIPTION
## Fix

Six Lean files had stale `sorryCount` values in research problem JSON listings. The JSON values were set at an earlier point in time and not updated when the Lean files changed.

## Evidence

**Root cause**: `enrich-research.ts` counts `\bsorry\b` word-boundary matches. When Lean files are modified (sorrys proved or added), the research problem JSON listings don't automatically update.

**Files corrected**:

| Lean File | Problem(s) Affected | JSON Was | Actual Count |
|---|---|---|---|
| `KummerTheoremOQ01.lean` | kummer-theorem, kummer-theorem-oq-{01,02,03} | 1 | 0 |
| `KummerTheoremOQ01Aristotle.lean` | kummer-theorem, kummer-theorem-oq-{01,02,03} | 1 | 0 |
| `Erdos815Problem.lean` | erdos-8-oq-01 | 1 | 0 |
| `RothTheoremQuantitative.lean` | roth-theorem-k3-oq-01 | 6 | 5 |
| `Erdos1012OQ03.lean` | erdos-1012-oq-03-incomplete-01 | 3 | 4 |
| `Erdos402Problem.lean` | erdos-402-incomplete-01 | 1 | 5 |

**After**: 8 research problem JSON files have correct `sorryCount` values matching `\bsorry\b` counts in the actual Lean source files on main.

---
Automated fix by lean-mechanic agent.