### PR TITLE
Fix: count noncomputable axiom declarations in auditor scanner

### DIFF
--- a/scripts/auditor/find-targets.ts
+++ b/scripts/auditor/find-targets.ts
@@ -277,7 +277,7 @@ function analyzeProof(id: string, galleryPath: string, tracker: Tracker): AuditT
     const content = stripLeanComments(rawContent)
 
     sorryCount += (content.match(/\bsorry\b/g) || []).length
-    axiomCount += (content.match(/^(?:private\s+)?axiom /gm) || []).length
+    axiomCount += (content.match(/^(?:(?:private|noncomputable)\s+)*axiom /gm) || []).length
 
     // True stubs: only count theorem/lemma declarations, not example (Issue #6130)
     for (const line of content.split('\n')) {


### PR DESCRIPTION
## Fix

The axiom-counting regex in `scripts/auditor/find-targets.ts` did not match `noncomputable axiom` declarations, causing false-positive "axiom overcount" alerts on every audit cycle for affected proofs.

## Root Cause

Old regex:
```
/^(?:private\s+)?axiom /gm
```
Only handles `axiom` and `private axiom`. Misses `noncomputable axiom`.

New regex:
```
/^(?:(?:private|noncomputable)\s+)*axiom /gm
```
Handles all modifier combinations: `axiom`, `private axiom`, `noncomputable axiom`, `private noncomputable axiom`, etc.

## Evidence

| Proof | meta.axiomCount | Old scanner | New scanner |
|---|---|---|---|
| erdos-96 | 3 | 2 (missed `noncomputable axiom cyclicOrder`) | **3** ✓ |
| erdos-756 | 5 | 2 (missed 3 `noncomputable axiom` decls) | **5** ✓ |

## Impact

Eliminates ~70% of recurring false-positive audit alerts (per issue analysis). The same proofs were re-flagged on every cycle, wasting auditor cycles on already-clean proofs.

Closes #9186

---
Automated fix by lean-mechanic agent.