### PR TITLE
Enrich 7 gallery entries: herons-formula-oq-01, roth-theorem-k3-oq-01, erdos-1022-oq-01, erdos-1097-oq-01, erdos-1162, erdos-1183, hurwitz-theorem-oq-03

### DIFF
--- a/src/data/proofs/erdos-1183/annotations.json
+++ b/src/data/proofs/erdos-1183/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-01",
+    "proofId": "erdos-1183",
+    "range": { "startLine": 40, "endLine": 62 },
+    "type": "definition",
+    "title": "Powerset Ramsey Structures: Colorings, Closure, and Chains",
+    "content": "Six interlocking definitions build the algebraic infrastructure. SubsetColoring n = Finset (Fin n) → Fin 2 treats a 2-coloring as a function on the powerset. IsUnionClosed and IsInterClosed are closure predicates on Finset (Finset (Fin n)). IsSublattice = IsUnionClosed ∧ IsInterClosed packages both. IsMonochromatic χ F c = ∀ A ∈ F, χ A = c captures the Ramsey condition. IsChain = ∀ A B, A ⊆ B ∨ B ⊆ A. The key design choice: all families live in Finset (Finset (Fin n)), enabling Finset.card arithmetic for the pigeonhole step.",
+    "mathContext": "$\\text{SubsetColoring}(n) = \\mathcal{P}(\\text{Fin}\\, n) \\to \\{0,1\\}$. $\\text{IsUnionClosed}(F) \\iff \\forall A,B \\in F,\\; A \\cup B \\in F$. $\\text{IsSublattice}(F) \\iff \\text{IsUnionClosed}(F) \\land \\text{IsInterClosed}(F)$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset-valued families", "lattice closure", "Ramsey coloring"],
+    "prerequisites": ["Mathlib.Data.Finset.Basic", "Fin 2 for 2-colorings"]
+  },
+  {
+    "id": "ann-02",
+    "proofId": "erdos-1183",
+    "range": { "startLine": 64, "endLine": 86 },
+    "type": "technique",
+    "title": "Chains Are Sublattices via union_eq_right / inter_eq_left",
+    "content": "The proof that every chain is a sublattice exploits a key identity: in a chain where A ⊆ B, we have A ∪ B = B (Finset.union_eq_right.mpr) and A ∩ B = A (Finset.inter_eq_left.mpr). The rcases on IsChain gives a disjunction h : A ⊆ B ∨ B ⊆ A; each branch rewrites the union/intersection to the appropriate side and uses rwa to get membership. chain_isSublattice then packages both results as a constructor pair.",
+    "mathContext": "$A \\subseteq B \\implies A \\cup B = B$ (Finset.union_eq_right). $A \\subseteq B \\implies A \\cap B = A$ (Finset.inter_eq_left). Chain implies $\\forall A,B \\in F:\\; A \\cup B, A \\cap B \\in F$.",
+    "significance": "key",
+    "relatedConcepts": ["chain = totally ordered set", "lattice operations", "Finset.union_eq_right"],
+    "prerequisites": ["Finset union/intersection identities", "IsChain definition"]
+  },
+  {
+    "id": "ann-03",
+    "proofId": "erdos-1183",
+    "range": { "startLine": 88, "endLine": 135 },
+    "type": "technique",
+    "title": "Standard Chain Construction and Injectivity via wlog",
+    "content": "initialSeg n k = Finset.univ.filter (fun i => i.val < k.val) defines the initial segment {0,...,k-1} ⊆ Fin n for k : Fin (n+1). stdChain n = Finset.univ.image (initialSeg n). The key proof is initialSeg_injective: distinct k give distinct sets. The proof uses 'wlog h : j < k' to reduce to one direction, then exhibits the witness ⟨j.val, hj_lt_n⟩ : Fin n which lies in initialSeg k (since j.val < k.val by h) but not in initialSeg j (since j.val ≮ j.val). stdChain_card then follows from card_image_of_injective + card_fin.",
+    "mathContext": "$\\text{initialSeg}(n, k) = \\{i \\in \\text{Fin}\\, n \\mid i < k\\}$. $|\\text{stdChain}(n)| = |\\text{image}(\\text{initialSeg}, \\text{Fin}(n{+}1))| = n+1$ (injectivity).",
+    "significance": "key",
+    "relatedConcepts": ["initial segments", "injective image cardinality", "wlog tactic", "Fin (n+1)"],
+    "prerequisites": ["Finset.card_image_of_injective", "Finset.card_fin", "wlog tactic in Lean 4"]
+  },
+  {
+    "id": "ann-04",
+    "proofId": "erdos-1183",
+    "range": { "startLine": 137, "endLine": 163 },
+    "type": "technique",
+    "title": "Pigeonhole via Color-Class Partition and omega",
+    "content": "exists_mono_color_class proves: for any S : Finset α and χ : α → Fin 2, some color class has ≥ ⌈|S|/2⌉ elements. The proof first establishes hpart: |S.filter (χ = 0)| + |S.filter (χ = 1)| = |S| using card_union_of_disjoint (the two classes partition S; fin_cases handles Fin 2 exhaustion). Then by_contra + push_neg gives strict upper bounds on both, and omega derives a contradiction from h₀ + h₁ contradicting hpart. The ⌈(n+1)/2⌉ appears as (S.card + 1) / 2 in natural number division.",
+    "mathContext": "$\\forall \\chi : S \\to \\{0,1\\},\\; \\exists c,\\; |\\{x \\in S : \\chi(x) = c\\}| \\geq \\lceil |S|/2 \\rceil$. Proof: $|C_0| + |C_1| = |S|$ implies $\\max(|C_0|, |C_1|) \\geq \\lceil |S|/2 \\rceil$.",
+    "significance": "key",
+    "relatedConcepts": ["pigeonhole principle", "Fin 2 case analysis", "Nat division ceiling", "omega tactic"],
+    "prerequisites": ["Finset.card_union_of_disjoint", "Finset.disjoint_filter", "fin_cases on Fin 2"]
+  },
+  {
+    "id": "ann-05",
+    "proofId": "erdos-1183",
+    "range": { "startLine": 164, "endLine": 199 },
+    "type": "insight",
+    "title": "The Main Lower Bound: f(n) ≥ ⌈(n+1)/2⌉ Assembled",
+    "content": "erdos1183_chain_bound assembles the three prior results. Given χ, apply exists_mono_color_class to stdChain n to get color c with ≥ (n+2)/2 elements. The filtered subchain is: (1) a sublattice (by chain_isSublattice on the filtered chain, which is still totally ordered); (2) monochromatic by construction; (3) of size ≥ (n+2)/2 (= ⌈(n+1)/2⌉ in ℕ division). The F(n) bound erdos1183_F_chain_bound extracts the union-closed component from IsSublattice. Note: the bound (n+2)/2 uses integer division where n+2 ÷ 2 = ⌈(n+1)/2⌉.",
+    "mathContext": "$f(n) \\geq \\lceil(n+1)/2\\rceil = \\lfloor(n+2)/2\\rfloor$. Proof: standard chain has $n{+}1$ elements; pigeonhole gives $\\lfloor(n{+}2)/2\\rfloor$ same-color elements forming a subchain, hence a sublattice.",
+    "significance": "key",
+    "relatedConcepts": ["Ramsey lower bounds", "chain + pigeonhole", "f(n) vs F(n)"],
+    "prerequisites": ["chain_isSublattice", "exists_mono_color_class", "stdChain_card"]
+  },
+  {
+    "id": "ann-06",
+    "proofId": "erdos-1183",
+    "range": { "startLine": 201, "endLine": 279 },
+    "type": "definition",
+    "title": "Abstract f(n) and F(n) via sSup and Conditional Completeness",
+    "content": "The abstract definitions use achievableSublattice n = { k | ∀ χ, ∃ mono sublattice of size ≥ k }, and erdos1183_f n = sSup (achievableSublattice n). This correctly captures f(n) as the largest universally achievable lower bound (previously sInf was used, giving 0 — the infimum of a downward-closed set). The key proof erdos1183_f_lower_bound uses le_csSup: the set is BddAbove (bounded by 2^n via card_le_card), and the chain bound shows (n+2)/2 ∈ achievableSublattice n. erdos1183_F_ge_f uses csSup_le_csSup: achievableSublattice ⊆ achievableUnionClosed (every sublattice is union-closed). Open conjectures (f_growth, F_superpolynomial) are stated as Prop definitions, not axioms.",
+    "mathContext": "$f(n) = \\sup\\{k : \\forall \\chi,\\; \\exists F \\text{ mono sublattice with } |F| \\geq k\\}$. $F(n) \\geq f(n)$ since sublattices are union-closed. Open: $f(n) = O(n)$? $F(n) \\geq n^{\\omega(n)}$?",
+    "significance": "key",
+    "relatedConcepts": ["conditionally complete lattice", "sSup vs sInf design", "BddAbove", "le_csSup"],
+    "prerequisites": ["Mathlib.Order.ConditionallyCompleteLattice.Basic", "csSup_le_csSup"]
+  }
+]

--- a/src/data/proofs/erdos-1183/meta.json
+++ b/src/data/proofs/erdos-1183/meta.json
@@ -61,15 +61,16 @@
     ]
   },
   "overview": {
-    "historicalContext": "Erdős and Ulam posed this problem in 1978 [Er78, p.39] as a Ramsey-type question about the powerset lattice. Given a 2-coloring of all subsets of {1,...,n}, how large a monochromatic sublattice (closed under unions and intersections) must exist? They defined two variants: f(n) for full sublattices and F(n) for union-closed families only.",
+    "historicalContext": "Erdős and Ulam posed this problem in their 1978 survey [Er78, p.39] as a Ramsey-type question about the powerset lattice. The powerset 2^{[n]} has a natural lattice structure under ∪ and ∩, and any 2-coloring raises the question: how large a monochromatic sublattice must always exist? The trivial lower bound ⌈(n+1)/2⌉ comes from the nested chain ∅ ⊂ {1} ⊂ {1,2} ⊂ ... ⊂ {1,...,n}: by pigeonhole, one color class forms a monochromatic chain of this size, and any chain is a sublattice. Erdős and Ulam reported having 'no plausible conjecture' for the true order of magnitude. Howorka subsequently proved that F(n) > n^{ω(n)} under the special restriction that all same-size subsets receive the same color, but the general case remains open. The problem connects to Frankl's union-closed conjecture (1979, proved by Gilmer 2022 and strengthened by Sawin 2023) and to Dilworth's theorem on chain decompositions in partially ordered sets. For the Lean formalization, a key architectural correction was needed: the initial attempt defined f(n) via sInf (yielding 0, the infimum of a downward-closed set) rather than sSup (the supremum of achievable lower bounds).",
     "problemStatement": "Let f(n) be maximal such that in any 2-coloring of the subsets of {1,...,n} there is always a monochromatic family of at least f(n) sets which is closed under taking unions and intersections. Estimate f(n). Similarly define F(n) requiring only union-closure.",
     "text": "We formalize the Erdős-Ulam problem on monochromatic sublattice families and prove the trivial lower bound f(n) ≥ ⌈(n+1)/2⌉ via the standard chain argument.",
     "proofStrategy": "Construct the standard chain ∅ ⊂ {0} ⊂ {0,1} ⊂ ... ⊂ {0,...,n-1} (n+1 elements). Show any chain is a sublattice. Apply pigeonhole to get a monochromatic subchain of size ≥ ⌈(n+1)/2⌉.",
     "keyInsights": [
-      "In a chain, the union of two comparable sets equals the larger one, so chains are automatically union-closed",
-      "Similarly, the intersection equals the smaller one, so chains are intersection-closed",
-      "The standard chain has exactly n+1 elements (proved via injectivity of initial segments)",
-      "Pigeonhole on 2-colorings guarantees a color class of size ≥ ⌈(n+1)/2⌉"
+      "**Chain = sublattice**: In a chain, A ∪ B equals the larger of A, B (Finset.union_eq_right/left.mpr), and A ∩ B equals the smaller. This makes every chain automatically a sublattice with a 2-line proof per operation.",
+      "**Injectivity via wlog**: The proof that distinct k give distinct initialSeg n k uses 'wlog h : j < k' to reduce to one direction, then exhibits j.val as a witness in initialSeg k but not in initialSeg j, closing with omega.",
+      "**sSup vs sInf**: The correct definition of f(n) uses sSup { k | every coloring admits a mono sublattice of size ≥ k }. Using sInf on this downward-closed set would give 0. The le_csSup approach requires proving BddAbove (the set is bounded by 2^n) and membership (the chain bound puts (n+2)/2 in the set).",
+      "**Prop definitions for open conjectures**: The two open conjectures (f_growth_conjecture: f(n) = O(n), F_superpolynomial_conjecture: F(n) ≥ n^{ω(n)}) are stated as Prop-valued definitions rather than axioms, making them formally present without being assumed true.",
+      "**F(n) ≥ f(n) via inclusion**: achievableSublattice ⊆ achievableUnionClosed because every sublattice is in particular union-closed. csSup_le_csSup then gives F(n) ≥ f(n) with a single line."
     ],
     "prerequisites": [
       "Finite set theory",
@@ -161,9 +162,10 @@
       "Improving the bound beyond ⌈(n+1)/2⌉ likely requires non-chain families"
     ],
     "openQuestions": [
-      "What is the true order of magnitude of f(n)?",
-      "Is F(n) superpolynomial but subexponential?",
-      "Does Howorka's result for same-size colorings extend to general colorings?"
+      "What is the true order of magnitude of f(n)? Is it linear, polynomial, or exponential in n?",
+      "Is F(n) superpolynomial (≥ n^{ω(n)}) for general 2-colorings, not just same-size ones?",
+      "Does Howorka's result for same-size colorings extend to arbitrary 2-colorings?",
+      "Can the sSup definition of f(n) be computed or bounded more tightly than ⌈(n+1)/2⌉ ≤ f(n) ≤ 2^n?"
     ]
   },
   "crossReferences": [
@@ -174,9 +176,32 @@
   ],
   "references": [
     {
-      "key": "Er78",
-      "citation": "P. Erdős, Problems and results in combinatorial analysis and combinatorial number theory, Proc. Ninth Southeastern Conf. on Combinatorics, Graph Theory, and Computing, 1978, pp. 39.",
-      "url": "https://erdosproblems.com/1183"
+      "authors": "Erdős, P.",
+      "title": "Problems and results in combinatorial analysis and combinatorial number theory",
+      "year": "1978",
+      "venue": "Proc. Ninth Southeastern Conf. on Combinatorics, Graph Theory, and Computing",
+      "note": "Original problem statement [Er78, p.39]: f(n) and F(n) definitions; no plausible conjecture for growth rate"
+    },
+    {
+      "authors": "Frankl, P.",
+      "title": "On the trace of finite sets",
+      "year": "1983",
+      "venue": "Journal of Combinatorial Theory, Series A 34(1), pp. 41-45",
+      "note": "Union-closed conjecture (1979): every union-closed family has an element in ≥ half the sets; proved by Gilmer (2022)"
+    },
+    {
+      "authors": "Dilworth, R. P.",
+      "title": "A decomposition theorem for partially ordered sets",
+      "year": "1950",
+      "venue": "Annals of Mathematics 51(1), pp. 161-166",
+      "note": "Dilworth's theorem: minimum chain cover = maximum antichain; relevant to the chain-pigeonhole approach"
+    },
+    {
+      "authors": "Gilmer, J.",
+      "title": "A constant bound for the union-closed sets conjecture",
+      "year": "2022",
+      "venue": "arXiv:2211.09055",
+      "note": "Proved the union-closed conjecture with constant 0.01 (later improved by Sawin and others); F(n) connects to this via union-closed families"
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enriches 7 gallery proof entries with annotations and expanded metadata:

1. **herons-formula-oq-01** — 6 annotations, expanded Heron/Brahmagupta history, Bretschneider reference
2. **roth-theorem-k3-oq-01** — 6 annotations, van der Waerden/Erdős-Turán/Kelley-Meka history, 7 references
3. **erdos-1022-oq-01** — 6 annotations, Bernstein/EFL context, Fin.castSucc monotonicity technique
4. **erdos-1097-oq-01** — 6 annotations, Szemerédi/Gowers context, exact_mod_cast bridge technique
5. **erdos-1162** — 6 annotations, Miller/Pyber/RDT history, Nat.card choice, 1/16 arithmetic
6. **erdos-1183** — 6 annotations, Erdős-Ulam 1978, sSup vs sInf correction, Frankl/Dilworth/Gilmer refs
7. **hurwitz-theorem-oq-03** — 6 annotations, Brahmagupta/Hamilton/Adams history, NSquareIdentity structure, n=3 overdetermined orthogonality proof, 4 references

Each entry: `annotations.json` with mathContext, significance, relatedConcepts, prerequisites fields; expanded historicalContext (>200 chars), 4-5 keyInsights, 3-4 openQuestions, additional references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)