### PR TITLE
fix: correct sorry/axiom counts in 6 gallery meta.json files (audit cycle-33)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -95,9 +95,9 @@
       "result": "clean"
     },
     "angle-trisection": {
-      "auditCount": 7,
+      "auditCount": 8,
       "issues": [],
-      "lastAudited": "2026-04-04T01:56:48Z",
+      "lastAudited": "2026-04-04T02:27:54Z",
       "result": "clean"
     },
     "angle-trisection-oq-01": {
@@ -756,10 +756,10 @@
       "result": "clean"
     },
     "buffons-needle-oq-02-oq-02": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-04-04T01:56:47Z",
-      "result": "clean"
+      "lastAudited": "2026-04-04T02:27:54Z",
+      "result": "issues-fixed"
     },
     "burnside-counting": {
       "auditCount": 1,
@@ -2783,10 +2783,10 @@
       "result": "clean"
     },
     "erdos-1131-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T22:23:24Z",
-      "result": "clean"
+      "lastAudited": "2026-04-04T02:27:53Z",
+      "result": "issues-fixed"
     },
     "erdos-1132": {
       "auditCount": 2,
@@ -5299,8 +5299,8 @@
     },
     "erdos-433": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-03T20:45:49Z",
+      "auditCount": 5,
+      "lastAudited": "2026-04-04T02:27:53Z",
       "result": "issues-fixed"
     },
     "erdos-434": {
@@ -5969,10 +5969,10 @@
       "result": "clean"
     },
     "erdos-529": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-04-04T01:56:47Z",
-      "result": "clean"
+      "lastAudited": "2026-04-04T02:27:54Z",
+      "result": "issues-fixed"
     },
     "erdos-53": {
       "agentId": "auditor-cycle-20-batch",
@@ -9802,10 +9802,10 @@
       "result": "issues-fixed"
     },
     "inverse-galois-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-04T00:23:52Z",
-      "result": "clean"
+      "lastAudited": "2026-04-04T02:27:54Z",
+      "result": "issues-fixed"
     },
     "inverse-galois-oq-06": {
       "auditCount": 1,
@@ -10102,15 +10102,15 @@
       "result": "clean"
     },
     "navier-stokes": {
-      "auditCount": 8,
+      "auditCount": 9,
       "issues": [],
-      "lastAudited": "2026-04-04T01:56:48Z",
+      "lastAudited": "2026-04-04T02:27:54Z",
       "result": "clean"
     },
     "navier-stokes-existence": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-04-04T01:56:48Z",
+      "lastAudited": "2026-04-04T02:27:54Z",
       "result": "clean"
     },
     "navier-stokes-oq-01": {
@@ -11169,9 +11169,9 @@
       "issues": []
     },
     "erdos-1021-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T22:23:24Z",
-      "result": "clean",
+      "auditCount": 4,
+      "lastAudited": "2026-04-04T02:27:54Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "gcd-algorithm-oq-01-oq-03": {

--- a/src/data/proofs/buffons-needle-oq-02-oq-02/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-02/meta.json
@@ -61,9 +61,9 @@
       "smooth3D_mono/strictMono: monotonicity of expected crossings in arc length"
     ],
     "dateAdded": "2026-03-30",
-    "axiomCount": 1,
+    "axiomCount": 2,
     "lineCount": 376,
-    "assumptions": "1 axiom: smooth3D_buffon_eq (the expected crossing count formula for smooth 3D curves). No sorries.",
+    "assumptions": "2 axioms: smooth3DExpectedCrossings (noncomputable axiom defining expected crossing count for smooth 3D curves) + smooth3D_buffon_eq (the Buffon–Barbier formula E = arcLength3D/(2d)). No sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -228,7 +228,7 @@
     ],
     "namespace": "BuffonsNeedleOQ02OQ02",
     "lineCount": 376,
-    "axiomCount": 1,
+    "axiomCount": 2,
     "theoremCount": 15,
     "definitionCount": 4
   }

--- a/src/data/proofs/erdos-1021-oq-01/meta.json
+++ b/src/data/proofs/erdos-1021-oq-01/meta.json
@@ -17,10 +17,10 @@
       "zarankiewicz"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 6,
     "axiomCount": 2,
     "lineCount": 191,
-    "assumptions": "2 axioms: (1) kst_trivial_bound — Kővári-Sós-Turán O(n^{3/2}) upper bound (proven 1954, axiomatized); (2) probabilistic_lower_bound — ex(n, G_k) ≥ c·n^{3/2-1/(k-1)} (probabilistic method, axiomatized). 4 sorries in this file.",
+    "assumptions": "2 axioms: (1) kst_trivial_bound — Kővári-Sós-Turán O(n^{3/2}) upper bound (proven 1954, axiomatized); (2) probabilistic_lower_bound — ex(n, G_k) ≥ c·n^{3/2-1/(k-1)} (probabilistic method, axiomatized). 6 sorries total: 4 in this file + 2 in parent Erdos1021Problem.lean (k3_case_solved, trivial_bound).",
     "dateAdded": "2026-04-03",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-1131-oq-01/meta.json
+++ b/src/data/proofs/erdos-1131-oq-01/meta.json
@@ -23,10 +23,10 @@
     "erdosUrl": "https://erdosproblems.com/1131",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
-    "sorries": 0,
+    "sorries": 2,
     "theoremCount": 11,
     "lineCount": 293,
-    "assumptions": "2 axioms total: 1 own (erdos_1131_variance_conjecture — variance form of Erdős #1131 conjecture) + 1 inherited from Erdos1131Problem.lean (erdos_1131_conjecture). 0 sorries in this file (axioms captured in axiomCount).",
+    "assumptions": "2 axioms total: 1 own (erdos_1131_variance_conjecture — variance form of Erdős #1131 conjecture) + 1 inherited from Erdos1131Problem.lean (erdos_1131_conjecture). 2 sorries in parent Erdos1131Problem.lean (private lemmas: chebyshev_interp, chebyshev_sq_expansion) — these are private and do not affect OQ01's public interface.",
     "parentProof": "erdos-1131",
     "prerequisites": [
       "Lagrange interpolation and basis polynomials",

--- a/src/data/proofs/erdos-433/meta.json
+++ b/src/data/proofs/erdos-433/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 433,
     "erdosUrl": "https://erdosproblems.com/433",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-529/meta.json
+++ b/src/data/proofs/erdos-529/meta.json
@@ -106,9 +106,9 @@
       "erdos_529_summary theorem: combines established results",
       "erdos_529 theorem: combines Hara-Slade + sub-ballistic + Question 2"
     ],
-    "axiomCount": 5,
+    "axiomCount": 7,
     "lineCount": 306,
-    "assumptions": "5 axiom(s) and 0 sorry(s): tendsTo (convergence predicate), haraSlade_five_dim (5D self-avoiding walk result), duminilCopin_subBallistic (sub-ballistic diffusivity), conjecture_implies_question1, question2_high_dim. See the Lean source for details."
+    "assumptions": "7 axiom(s) and 0 sorry(s): tendsTo (convergence predicate), haraSlade_five_dim (5D self-avoiding walk result), duminilCopin_subBallistic (sub-ballistic diffusivity), conjecture_implies_question1, question2_high_dim (5 plain axiom declarations) + 2 noncomputable axioms: endToEndDistance (Euclidean distance to endpoint), expectedEndDistance (expected end-to-end distance formalization). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #529: Self-Avoiding Walks**\n\nSelf-avoiding walks (SAWs) were first studied systematically by the chemist Paul Flory in 1949 as models for linear polymers in good solvents. Flory's mean-field prediction $\\nu = 3/(d+2)$ for the end-to-end distance exponent was remarkably accurate, setting the stage for decades of rigorous mathematical work.\n\nThe first rigorous high-dimensional result came from **Gordon Slade** (1987), who used the **lace expansion** — a perturbative technique introduced by Brydges and Spencer (1985) — to prove $d_k(n) \\sim D\\sqrt{n}$ for sufficiently large $k$. **Takashi Hara** and Slade (1991-92) refined this to all $k \\ge 5$, using computer-assisted bounds on the lace expansion coefficients. Their work established that mean-field behavior ($\\nu = 1/2$) holds above the upper critical dimension $d_c = 4$.\n\nThe low-dimensional case proved far more resistant. **Bernard Nienhuis** (1982) predicted $\\nu = 3/4$ in 2D using the exact solution of an O(n) loop model on the honeycomb lattice, and conformal field theory arguments connect 2D SAW to the SLE$_{8/3}$ process (Lawler, Schramm, Werner). The landmark result of **Hugo Duminil-Copin** and **Alan Hammond** (2013) proved $d_2(n) = o(n)$ (sub-ballistic growth) using a bridge decomposition argument, but the full Question 1 ($d_2(n)/\\sqrt{n} \\to \\infty$) remains open.\n\nThe definitive reference is the monograph *The Self-Avoiding Walk* by Madras and Slade (1993, 2nd ed. 2013). **Nathan Clisby** (2010) provided the most precise numerical estimates: $\\nu_3 \\approx 0.5876 \\pm 0.0002$.",
@@ -225,7 +225,7 @@
     ],
     "namespace": "Erdos529",
     "lineCount": 306,
-    "axiomCount": 5,
+    "axiomCount": 7,
     "theoremCount": 6,
     "definitionCount": 5
   },

--- a/src/data/proofs/inverse-galois-oq-02/meta.json
+++ b/src/data/proofs/inverse-galois-oq-02/meta.json
@@ -18,14 +18,14 @@
     ],
     "proofRepoPath": "Proofs/InverseGaloisOQ02.lean",
     "badge": "axiom",
-    "sorries": 6,
+    "sorries": 7,
     "axiomCount": 7,
     "prerequisites": [
       "Galois theory (Galois groups, splitting fields)",
       "Group theory (simple groups, solvability, commutator subgroups, derived series)",
       "Finite group classification (sporadic groups, Mathieu groups)"
     ],
-    "assumptions": "7 axioms total: 3 own (M23 — existence of M₂₃ as subgroup of S₂₃; M23_card — |M₂₃| = 10200960; M23_isSimple — M₂₃ is simple) + 4 inherited from InverseGalois.lean (inverse_galois_problem_open_conjecture, abelian_realizable, shafarevich_theorem, symmetric_group_realizable). The 3 own axioms are well-established mathematical facts, not conjectures. 6 sorries: M23_not_commutative (abelian simple → prime order chain), M23_commutator_eq_top (depends on not_commutative), M23_not_solvable (derived series API), 1 intentional sorry for the open realizability question, M23_has_element_of_order_23 (Cauchy's theorem), M23_sylow_2_card (Sylow theorems).",
+    "assumptions": "7 axioms total: 3 own (M23 — existence of M₂₃ as subgroup of S₂₃; M23_card — |M₂₃| = 10200960; M23_isSimple — M₂₃ is simple) + 4 inherited from InverseGalois.lean (inverse_galois_problem_open_conjecture, abelian_realizable, shafarevich_theorem, symmetric_group_realizable). The 3 own axioms are well-established mathematical facts, not conjectures. 7 sorries total: 6 in this file (M23_not_commutative, M23_commutator_eq_top, M23_not_solvable, 1 open realizability question, M23_has_element_of_order_23, M23_sylow_2_card) + 1 inherited from InverseGaloisOQ01.lean (inverse_galois_problem_open).",
     "leanFile": {
       "lineCount": 388,
       "theoremCount": 18,


### PR DESCRIPTION
## Summary

Fixes 6 genuine meta.json integrity issues found during audit cycle-33. Verifies 3 were false positives in the automated checker.

### Real Fixes

| Proof | Field | Old | New | Reason |
|-------|-------|-----|-----|--------|
| erdos-433 | sorries | 1 | 0 | Lean file has 0 sorries; 4 axioms correct |
| erdos-1131-oq-01 | sorries | 0 | 2 | 2 private sorries in parent Erdos1131Problem.lean |
| erdos-1021-oq-01 | sorries | 4 | 6 | 2 public sorries in parent Erdos1021Problem.lean |
| inverse-galois-oq-02 | sorries | 6 | 7 | 1 sorry from imported InverseGaloisOQ01.lean |
| erdos-529 | axiomCount | 5 | 7 | 2 noncomputable axiom declarations missed |
| buffons-needle-oq-02-oq-02 | axiomCount | 1 | 2 | smooth3DExpectedCrossings noncomputable axiom missed |

### Confirmed False Positives

- **navier-stokes** / **navier-stokes-existence**: Claim 5 axioms correctly (structure-encoded in NSAxioms). Grep finds 0 axiom declarations because assumptions are encoded in struct fields per the Axiom Integrity Policy.
- **angle-trisection**: Claims 1 axiom correctly (from imported PiTranscendental.lean lindemann_theorem). Checker misses this because PiTranscendental does not share a name prefix with AngleTrisection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)