### PR TITLE
Fix: restore axiomCount for erdos-529 (7) and buffons-needle-oq-02-oq-02 (2)

### DIFF
--- a/src/data/proofs/buffons-needle-oq-02-oq-02/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-02/meta.json
@@ -61,9 +61,9 @@
       "smooth3D_mono/strictMono: monotonicity of expected crossings in arc length"
     ],
     "dateAdded": "2026-03-30",
-    "axiomCount": 1,
+    "axiomCount": 2,
     "lineCount": 376,
-    "assumptions": "1 axiom: smooth3D_buffon_eq (the expected crossing count formula for smooth 3D curves). No sorries.",
+    "assumptions": "2 axioms: smooth3DExpectedCrossings (expected crossings function for smooth 3D curves) and smooth3D_buffon_eq (the expected crossing count formula). No sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -228,7 +228,7 @@
     ],
     "namespace": "BuffonsNeedleOQ02OQ02",
     "lineCount": 376,
-    "axiomCount": 1,
+    "axiomCount": 2,
     "theoremCount": 15,
     "definitionCount": 4
   }

--- a/src/data/proofs/erdos-529/meta.json
+++ b/src/data/proofs/erdos-529/meta.json
@@ -106,9 +106,9 @@
       "erdos_529_summary theorem: combines established results",
       "erdos_529 theorem: combines Hara-Slade + sub-ballistic + Question 2"
     ],
-    "axiomCount": 5,
+    "axiomCount": 7,
     "lineCount": 306,
-    "assumptions": "5 axiom(s) and 0 sorry(s): tendsTo (convergence predicate), haraSlade_five_dim (5D self-avoiding walk result), duminilCopin_subBallistic (sub-ballistic diffusivity), conjecture_implies_question1, question2_high_dim. See the Lean source for details."
+    "assumptions": "7 axiom(s) and 0 sorry(s): endToEndDistance (end-to-end distance function for self-avoiding walk), expectedEndDistance (expected end-to-end distance), tendsTo (convergence predicate), haraSlade_five_dim (5D self-avoiding walk result), duminilCopin_subBallistic (sub-ballistic diffusivity), conjecture_implies_question1, question2_high_dim. See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #529: Self-Avoiding Walks**\n\nSelf-avoiding walks (SAWs) were first studied systematically by the chemist Paul Flory in 1949 as models for linear polymers in good solvents. Flory's mean-field prediction $\\nu = 3/(d+2)$ for the end-to-end distance exponent was remarkably accurate, setting the stage for decades of rigorous mathematical work.\n\nThe first rigorous high-dimensional result came from **Gordon Slade** (1987), who used the **lace expansion** — a perturbative technique introduced by Brydges and Spencer (1985) — to prove $d_k(n) \\sim D\\sqrt{n}$ for sufficiently large $k$. **Takashi Hara** and Slade (1991-92) refined this to all $k \\ge 5$, using computer-assisted bounds on the lace expansion coefficients. Their work established that mean-field behavior ($\\nu = 1/2$) holds above the upper critical dimension $d_c = 4$.\n\nThe low-dimensional case proved far more resistant. **Bernard Nienhuis** (1982) predicted $\\nu = 3/4$ in 2D using the exact solution of an O(n) loop model on the honeycomb lattice, and conformal field theory arguments connect 2D SAW to the SLE$_{8/3}$ process (Lawler, Schramm, Werner). The landmark result of **Hugo Duminil-Copin** and **Alan Hammond** (2013) proved $d_2(n) = o(n)$ (sub-ballistic growth) using a bridge decomposition argument, but the full Question 1 ($d_2(n)/\\sqrt{n} \\to \\infty$) remains open.\n\nThe definitive reference is the monograph *The Self-Avoiding Walk* by Madras and Slade (1993, 2nd ed. 2013). **Nathan Clisby** (2010) provided the most precise numerical estimates: $\\nu_3 \\approx 0.5876 \\pm 0.0002$.",
@@ -225,7 +225,7 @@
     ],
     "namespace": "Erdos529",
     "lineCount": 306,
-    "axiomCount": 5,
+    "axiomCount": 7,
     "theoremCount": 6,
     "definitionCount": 5
   },


### PR DESCRIPTION
## Fix

Restores correct `axiomCount` for two gallery proofs that were incorrectly updated by PR #9169 (audit cycle-30 batch fix).

## Root Cause

PR #9169 corrected axiomCounts based on the pre-fix auditor scanner that used regex `^(?:private\s+)?axiom` — which missed `noncomputable axiom` declarations. PR #9188 subsequently fixed the scanner. Now the scanner correctly finds the noncomputable axioms, revealing that #9169 made the wrong corrections.

## Evidence

**erdos-529** (`Proofs/Erdos529Problem.lean`):
- Before PR #9169: `axiomCount: 7` (correct)
- After PR #9169: `axiomCount: 5` (wrong — scanner was missing 2 noncomputable axioms)
- Lean source has 7 axioms: `endToEndDistance` + `expectedEndDistance` (both noncomputable) + `tendsTo`, `haraSlade_five_dim`, `duminilCopin_subBallistic`, `conjecture_implies_question1`, `question2_high_dim`

**buffons-needle-oq-02-oq-02** (`Proofs/BuffonsNeedleOQ02OQ02.lean`):
- Before PR #9169: `axiomCount: 2` (correct)
- After PR #9169: `axiomCount: 1` (wrong — scanner was missing `noncomputable axiom smooth3DExpectedCrossings`)
- Lean source has 2 axioms: `smooth3DExpectedCrossings` (noncomputable) + `smooth3D_buffon_eq`

---
Automated fix by lean-mechanic agent.