### PR TITLE
fix: correct sorry counts in 3 gallery meta.json files (audit cycle-35)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -95,9 +95,9 @@
       "result": "clean"
     },
     "angle-trisection": {
-      "auditCount": 7,
+      "auditCount": 8,
       "issues": [],
-      "lastAudited": "2026-04-04T01:56:48Z",
+      "lastAudited": "2026-04-04T03:13:06Z",
       "result": "clean"
     },
     "angle-trisection-oq-01": {
@@ -2783,10 +2783,10 @@
       "result": "clean"
     },
     "erdos-1131-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T22:23:24Z",
-      "result": "clean"
+      "lastAudited": "2026-04-04T03:13:06Z",
+      "result": "issues-fixed"
     },
     "erdos-1132": {
       "auditCount": 2,
@@ -9802,10 +9802,10 @@
       "result": "issues-fixed"
     },
     "inverse-galois-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-04T00:23:52Z",
-      "result": "clean"
+      "lastAudited": "2026-04-04T03:13:06Z",
+      "result": "issues-fixed"
     },
     "inverse-galois-oq-06": {
       "auditCount": 1,
@@ -10102,15 +10102,15 @@
       "result": "clean"
     },
     "navier-stokes": {
-      "auditCount": 8,
+      "auditCount": 9,
       "issues": [],
-      "lastAudited": "2026-04-04T01:56:48Z",
+      "lastAudited": "2026-04-04T03:13:06Z",
       "result": "clean"
     },
     "navier-stokes-existence": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-04-04T01:56:48Z",
+      "lastAudited": "2026-04-04T03:13:06Z",
       "result": "clean"
     },
     "navier-stokes-oq-01": {
@@ -11169,9 +11169,9 @@
       "issues": []
     },
     "erdos-1021-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-03T22:23:24Z",
-      "result": "clean",
+      "auditCount": 4,
+      "lastAudited": "2026-04-04T03:13:06Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "gcd-algorithm-oq-01-oq-03": {

--- a/src/data/proofs/erdos-1021-oq-01/meta.json
+++ b/src/data/proofs/erdos-1021-oq-01/meta.json
@@ -17,10 +17,10 @@
       "zarankiewicz"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 6,
     "axiomCount": 2,
     "lineCount": 191,
-    "assumptions": "2 axioms: (1) kst_trivial_bound — Kővári-Sós-Turán O(n^{3/2}) upper bound (proven 1954, axiomatized); (2) probabilistic_lower_bound — ex(n, G_k) ≥ c·n^{3/2-1/(k-1)} (probabilistic method, axiomatized). 4 sorries in this file.",
+    "assumptions": "2 axioms: (1) kst_trivial_bound — Kővári-Sós-Turán O(n^{3/2}) upper bound (proven 1954, axiomatized); (2) probabilistic_lower_bound — ex(n, G_k) ≥ c·n^{3/2-1/(k-1)} (probabilistic method, axiomatized). 6 sorries in dependency chain: 4 in this file + 2 in parent Erdos1021Problem.lean (k3_case_solved, trivial_bound).",
     "dateAdded": "2026-04-03",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-1131-oq-01/meta.json
+++ b/src/data/proofs/erdos-1131-oq-01/meta.json
@@ -23,10 +23,10 @@
     "erdosUrl": "https://erdosproblems.com/1131",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
-    "sorries": 0,
+    "sorries": 2,
     "theoremCount": 11,
     "lineCount": 293,
-    "assumptions": "2 axioms total: 1 own (erdos_1131_variance_conjecture — variance form of Erdős #1131 conjecture) + 1 inherited from Erdos1131Problem.lean (erdos_1131_conjecture). 0 sorries in this file (axioms captured in axiomCount).",
+    "assumptions": "2 axioms total: 1 own (erdos_1131_variance_conjecture — variance form of Erdős #1131 conjecture) + 1 inherited from Erdos1131Problem.lean (erdos_1131_conjecture). 2 sorries in dependency chain: 0 in this file, 2 in private lemmas of parent Erdos1131Problem.lean (chebyshev_interp, chebyshev_sq_expansion — these are private and do not affect OQ01's exported results).",
     "parentProof": "erdos-1131",
     "prerequisites": [
       "Lagrange interpolation and basis polynomials",

--- a/src/data/proofs/inverse-galois-oq-02/meta.json
+++ b/src/data/proofs/inverse-galois-oq-02/meta.json
@@ -18,14 +18,14 @@
     ],
     "proofRepoPath": "Proofs/InverseGaloisOQ02.lean",
     "badge": "axiom",
-    "sorries": 6,
+    "sorries": 7,
     "axiomCount": 7,
     "prerequisites": [
       "Galois theory (Galois groups, splitting fields)",
       "Group theory (simple groups, solvability, commutator subgroups, derived series)",
       "Finite group classification (sporadic groups, Mathieu groups)"
     ],
-    "assumptions": "7 axioms total: 3 own (M23 — existence of M₂₃ as subgroup of S₂₃; M23_card — |M₂₃| = 10200960; M23_isSimple — M₂₃ is simple) + 4 inherited from InverseGalois.lean (inverse_galois_problem_open_conjecture, abelian_realizable, shafarevich_theorem, symmetric_group_realizable). The 3 own axioms are well-established mathematical facts, not conjectures. 6 sorries: M23_not_commutative (abelian simple → prime order chain), M23_commutator_eq_top (depends on not_commutative), M23_not_solvable (derived series API), 1 intentional sorry for the open realizability question, M23_has_element_of_order_23 (Cauchy's theorem), M23_sylow_2_card (Sylow theorems).",
+    "assumptions": "7 axioms total: 3 own (M23 — existence of M₂₃ as subgroup of S₂₃; M23_card — |M₂₃| = 10200960; M23_isSimple — M₂₃ is simple) + 4 inherited from InverseGalois.lean (inverse_galois_problem_open_conjecture, abelian_realizable, shafarevich_theorem, symmetric_group_realizable). The 3 own axioms are well-established mathematical facts, not conjectures. 7 sorries in dependency chain: 6 in this file (M23_not_commutative, M23_commutator_eq_top, M23_not_solvable, 1 intentional open realizability question, M23_has_element_of_order_23, M23_sylow_2_card) + 1 inherited from InverseGaloisOQ01.lean (inverse_galois_problem_open).",
     "leanFile": {
       "lineCount": 388,
       "theoremCount": 18,


### PR DESCRIPTION
## Summary

Fixes 3 sorry count mismatches. These were previously in PR #9193 (which covered 6 issues) but that PR overlapped with other concurrent fixes and has been closed. This is a clean re-submission of just the 3 remaining issues.

### Fixes

| Proof | Field | Old | New | Root Cause |
|-------|-------|-----|-----|------------|
| erdos-1131-oq-01 | sorries | 0 | 2 | 2 private sorry lemmas in parent `Erdos1131Problem.lean` (chebyshev_interp, chebyshev_sq_expansion) — private, don't affect OQ01's exports |
| erdos-1021-oq-01 | sorries | 4 | 6 | 2 public sorry theorems in parent `Erdos1021Problem.lean` (k3_case_solved, trivial_bound) |
| inverse-galois-oq-02 | sorries | 6 | 7 | 1 sorry inherited from imported `InverseGaloisOQ01.lean` (inverse_galois_problem_open) |

### Confirmed False Positives (Tracker Only)

- **navier-stokes** / **navier-stokes-existence**: 5 axioms in `NSAxioms` structure (structure-encoded per Axiom Integrity Policy, not grep-detectable)
- **angle-trisection**: 1 axiom from `PiTranscendental.lean` → `lindemann_theorem` (cross-prefix import, not followed by heuristic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)