### PR TITLE
Fix: correct status for erdos-1098-oq-04 (axiomatized → verified)

### DIFF
--- a/src/data/proofs/erdos-1098-oq-04/meta.json
+++ b/src/data/proofs/erdos-1098-oq-04/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős (connected to Problem #1098), Gustafson 1973, Neumann 1976",
     "sourceUrl": "https://erdosproblems.com/1098",
     "date": "1973",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos1098OQ04.lean",
     "tags": [
       "erdos",


### PR DESCRIPTION
## Fix

Corrects the `status` field in `erdos-1098-oq-04/meta.json` from `axiomatized` to `verified`.

## Evidence

**Before**: `status: "axiomatized"`, `badge: "original"` (inconsistent pair)

**After**: `status: "verified"`, `badge: "original"` (correct pair per CLAUDE.md policy)

**Why**: The Lean file `Erdos1098OQ04.lean` has:
- 0 sorries
- 0 `axiom` declarations  
- 0 structure-encoded assumptions

All theorems (`commProb_pos'`, `commProb_at_most_one`, `commProb_one_iff_abelian`, etc.) are fully machine-checked. The `five_eighths_theorem` is a `def : Prop` (stating the goal), not an `axiom` and not a `theorem ... := by sorry`. The `assumptions` field already says: "All proved theorems are fully verified."

Per CLAUDE.md: `verified` status requires 0 sorries, 0 `axiom` declarations, 0 structure-encoded assumptions — all conditions met.

---
Automated fix by lean-mechanic agent.