### PR TITLE
Add Aristotle companion file for Erdős #671 (Lagrange interpolation)

### DIFF
--- a/proofs/Proofs/Erdos671Aristotle.lean
+++ b/proofs/Proofs/Erdos671Aristotle.lean
@@ -1,0 +1,67 @@
+/-
+  Aristotle targets for Erdős Problem #671 (Lagrange Interpolation Convergence)
+  Routine algebraic properties of Lagrange basis polynomials.
+  See Erdos671Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the open questions (Q1, Q2) or deep divergence theorems (Bernstein, Erdős-Vértesi)
+  - Routine algebraic properties: basis evaluation at nodes, interpolation property
+  - Clean standalone definitions without sorry
+  - No axioms
+-/
+import Mathlib
+
+namespace Erdos671Aristotle
+
+open Polynomial
+
+/-- Points for interpolation: n distinct points in [-1, 1]. -/
+structure InterpPts (n : ℕ) where
+  pts : Fin n → ℝ
+  distinct : ∀ i j : Fin n, i ≠ j → pts i ≠ pts j
+
+/-- Lagrange basis polynomial: p_i = ∏_{j ≠ i} (1/(a_i - a_j)) · (X - a_j). -/
+noncomputable def lagBasis (interp : InterpPts n) (i : Fin n) : Polynomial ℝ :=
+  ∏ j ∈ Finset.univ.filter (· ≠ i),
+    C (1 / (interp.pts i - interp.pts j)) * (X - C (interp.pts j))
+
+/-- a_i ≠ a_j whenever i ≠ j, so (a_i - a_j) ≠ 0. -/
+theorem pts_sub_ne_zero (interp : InterpPts n) (i j : Fin n) (hij : i ≠ j) :
+    interp.pts i - interp.pts j ≠ 0 := by
+  sorry
+
+/-- Each basis factor evaluates to 1 at the pivot: (1/(a_i-a_j)) · (a_i - a_j) = 1. -/
+theorem basis_factor_self (interp : InterpPts n) (i j : Fin n) (hij : i ≠ j) :
+    (1 / (interp.pts i - interp.pts j)) * (interp.pts i - interp.pts j) = 1 := by
+  sorry
+
+/-- Each basis factor evaluates to 0 at another node: (1/(a_i-a_j)) · (a_k - a_j) = 0 when k = j. -/
+theorem basis_factor_other (interp : InterpPts n) (i j : Fin n) (hij : i ≠ j) :
+    (1 / (interp.pts i - interp.pts j)) * (interp.pts j - interp.pts j) = 0 := by
+  sorry
+
+/-- p_i(a_j) = 0 for i ≠ j: the product contains a zero factor at j. -/
+theorem lagBasis_other_zero (interp : InterpPts n) (i j : Fin n) (hij : i ≠ j) :
+    (lagBasis interp i).eval (interp.pts j) = 0 := by
+  sorry
+
+/-- p_i(a_i) = 1: each factor in the product evaluates to 1 at the pivot node. -/
+theorem lagBasis_self_one (interp : InterpPts n) (i : Fin n) :
+    (lagBasis interp i).eval (interp.pts i) = 1 := by
+  sorry
+
+/-- Lagrange interpolation operator: L^n f(x) = Σ_i f(a_i) · p_i(x). -/
+noncomputable def lagInterp (interp : InterpPts n) (f : ℝ → ℝ) (x : ℝ) : ℝ :=
+  ∑ i : Fin n, f (interp.pts i) * (lagBasis interp i).eval x
+
+/-- Partition of unity: Σ_i p_i(x) = 1 for all x (follows from interpolating the constant 1). -/
+theorem lagBasis_sum_one (interp : InterpPts n) (x : ℝ) :
+    ∑ i : Fin n, (lagBasis interp i).eval x = 1 := by
+  sorry
+
+/-- Interpolation at a node: L^n f(a_k) = f(a_k). -/
+theorem lagInterp_node (interp : InterpPts n) (f : ℝ → ℝ) (k : Fin n) :
+    lagInterp interp f (interp.pts k) = f (interp.pts k) := by
+  sorry
+
+end Erdos671Aristotle


### PR DESCRIPTION
## Fix

Creates an Aristotle companion file targeting routine algebraic supporting lemmas for Erdős Problem #671 (Lagrange interpolation convergence).

## Evidence

**Proof**: `Erdos671Problem.lean` has 23 sorries and 3 axioms (for open questions Q1, Q2, MainConjecture). Most sorries are for deep analysis theorems (Bernstein, Erdős-Vértesi) or open conjectures — not suitable for Aristotle.

**Companion targets** (9 routine algebraic lemmas in `Erdos671Aristotle.lean`):
- `pts_sub_ne_zero` — distinctness implies non-zero difference
- `basis_factor_self` — `(1/(a-b))·(a-b) = 1`
- `basis_factor_other` — `(1/(a-b))·(b-b) = 0`
- `lagBasis_other_zero` — basis polynomial = 0 at other nodes (zero factor in product)
- `lagBasis_self_one` — basis polynomial = 1 at own node (product of 1s)
- `lagBasis_sum_one` — partition of unity: `Σ p_i(x) = 1`
- `lagInterp_node` — interpolation recovers function values at nodes

**Excluded from companion** (not suitable for Aristotle):
- `bernstein`, `erdos_vertesi` — deep classical theorems requiring measure theory
- `q2_implies_q1`, `faber`, `equidistant_diverges` — deep analysis results
- All sorries in `def` fields (`chebyshevNodes`, `equidistantNodes`) — Aristotle skips these
- `lebesgueConstant_growth` — requires classical approximation theory

**Pre-submission checklist**:
- [x] No `def ... := sorry`
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections
- [x] No open conjectures

---
Automated fix by lean-mechanic agent.