### PR TITLE
fix: correct badge for erdos-1098-oq-04 (original→mathlib)

### DIFF
--- a/src/data/proofs/erdos-1098-oq-04/meta.json
+++ b/src/data/proofs/erdos-1098-oq-04/meta.json
@@ -18,7 +18,7 @@
       "commuting-probability",
       "open"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 1098,
     "erdosUrl": "https://erdosproblems.com/1098",
@@ -27,7 +27,7 @@
     "mathlib_version": "4.26.0",
     "lineCount": 134,
     "axiomCount": 0,
-    "assumptions": "0 sorries, 0 axioms. The 5/8 theorem is stated as a Prop (open formalization goal, not an axiom). All proved theorems are fully verified.",
+    "assumptions": "0 sorries, 0 axioms. Core results (commProb G ≤ 1, equality iff abelian) obtained via Mathlib's commProb_le_one and commProb_eq_one_iff. The 5/8 theorem is stated as a Prop (open formalization goal, not an axiom). The nonCommGraph definition and nonCommDensity theorems are original infrastructure.",
     "mathlibDependencies": [
       {
         "theorem": "commProb_pos",


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-1098-oq-04 (Commutativity Degree and the Non-Commuting Graph)
**Problem**: Badge was `"original"` but core mathematical results are direct Mathlib theorem calls — this is Tier B (Mathlib bridge), badge should be `"mathlib"`

## Evidence

**meta.json claims**: `badge: "original"`

**Lean file shows**:
- `commProb_at_most_one` → 1-line wrapper: `commProb_le_one G` (Mathlib)
- `commProb_one_iff_abelian` → calls `commProb_eq_one_iff` (Mathlib)
- The core stated results (commProb G ≤ 1, equality iff abelian) are direct Mathlib theorem calls

Per the Lean Auditor's Tier B classification: "Core argument relies on a Mathlib theorem. Our file provides definitions, bridge, or infrastructure. Badge: `mathlib`."

The `nonCommGraph` definition and `nonCommDensity` theorems are genuine infrastructure contributions, but the main mathematical claims are Mathlib-derived.

## Fix

- Changed `badge: "original"` → `badge: "mathlib"`
- Updated `assumptions` field to document the Mathlib dependency transparently

**Note**: Status `"verified"` is correct (0 sorries, 0 axioms). Also noted: `perspectives_summary : True := trivial` is a minor stub (1 of 8 theorems, not critical since not all theorems prove True).

---
Discovered during gallery integrity audit cycle 37.