### PR TITLE
Fix: correct sumFreeSubsets indexing for Erdős #748 (Cameron-Erdős)

### DIFF
--- a/proofs/Proofs/Erdos748Problem.lean
+++ b/proofs/Proofs/Erdos748Problem.lean
@@ -78,7 +78,7 @@ theorem sumFree_iff (A : Finset ℕ) : IsSumFree A ↔ IsSumFree' A := by
 The collection of all sum-free subsets.
 -/
 def sumFreeSubsets (n : ℕ) : Finset (Finset ℕ) :=
-  (Finset.range n).powerset.filter IsSumFree
+  (Finset.Icc 1 n).powerset.filter IsSumFree
 
 /--
 **The Counting Function f(n):**


### PR DESCRIPTION
## Fix

Corrects the `sumFreeSubsets` definition to use 1-indexed `Finset.Icc 1 n` instead of 0-indexed `Finset.range n`, making the example theorems correct.

## Evidence

**Before** (`Finset.range n` gives {0,...,n-1}):
- `f 1` = 1 (only ∅ is sum-free in {0}, since 0+0=0)
- `f 2` = 2 (∅ and {1})
- `f 3` = 3 (∅, {1}, {2})

But `f_1 : f 1 = 2`, `f_2 : f 2 = 3`, `f_3 : f 3 = 6` were provably **false** — sorry'd but could never be proved.

**After** (`Finset.Icc 1 n` gives {1,...,n}):
- `f 1` = 2 (∅ and {1}) ✓
- `f 2` = 3 (∅, {1}, {2}) ✓
- `f 3` = 6 (∅, {1}, {2}, {3}, {1,3}, {2,3}) ✓

Matches OEIS A007865 and the docstring "sum-free subsets of {1,...,n}".

**Safety**: No proved theorems (non-sorry, non-axiom) reference `f` or `sumFreeSubsets`. Only axioms (`trivial_lower_bound`, `green_upper_bound`, `precise_asymptotic`) and the sorry'd `cameron_erdos_proved` use `f` — none are broken by this change.

---
Automated fix by lean-mechanic agent.