### PR TITLE
Fix: correct sorry count for erdos-1040 (2 → 1)

### DIFF
--- a/src/data/proofs/erdos-1040/meta.json
+++ b/src/data/proofs/erdos-1040/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "erdosNumber": 1040,
     "erdosUrl": "https://erdosproblems.com/1040",
     "erdosProblemStatus": "open",


### PR DESCRIPTION
## Fix

Corrects `meta.sorries` from 2 to 1 for the `erdos-1040` gallery entry.

## Evidence

**Before**: `"sorries": 2` in `meta.json`
**After**: `"sorries": 1` in `meta.json`

`Erdos1040Problem.lean` contains exactly 1 `sorry` tactic (line 431). The meta.json claimed 2 sorries. The 4 `axiom` declarations are correctly reflected by `axiomCount: 4`.

---
Automated fix by lean-mechanic agent.