### PR TITLE
fix: correct badge for angle-trisection (wip→axiom)

### DIFF
--- a/src/data/proofs/angle-trisection/meta.json
+++ b/src/data/proofs/angle-trisection/meta.json
@@ -18,7 +18,7 @@
       "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/AngleTrisection.lean",
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Integrity Issue

**Proof**: angle-trisection (Impossibility of Trisecting an Angle)
**Problem**: Badge was `"wip"` (stale from when the file had sorries), but status is `"axiomatized"` with 0 sorries

## Evidence

**meta.json claims**: `status: "axiomatized"`, `badge: "wip"`, `sorries: 0`, `axiomCount: 1`

**Reality**:
- 0 real sorries in `AngleTrisection.lean` ✓
- 0 own `axiom` declarations in the file
- 1 inherited axiom: `lindemann_theorem` from `PiTranscendental.lean` (correctly documented in `assumptions` field)
- The "wip" badge is stale — likely set when the file had sorries and never updated when they were removed

## Fix

Changed `badge: "wip"` → `badge: "axiom"` to match the `status: "axiomatized"` per CLAUDE.md policy:
> `axiomatized` status requires badge `axiom`

The proof is mathematically complete (Wantzel's algebraic criterion for angle trisection + cube doubling, Lindemann's transcendence for circle squaring) but properly axiomatized via the inherited Lindemann theorem.

---
Discovered during gallery integrity audit cycle 38.