### PR TITLE
fix: remove True stub from erdos-1098-oq-04

### DIFF
--- a/proofs/Proofs/Erdos1098OQ04.lean
+++ b/proofs/Proofs/Erdos1098OQ04.lean
@@ -125,10 +125,9 @@ The 5/8 theorem says more: the DENSITY of non-commuting pairs is bounded.
 These are complementary perspectives on the same non-abelian structure.
 -/
 
-/-- Summary remark: both Neumann's theorem and the 5/8 theorem characterize
-    the same "non-abelian distance" of G, through different lenses:
-    - Neumann: clique size in Γ(G) ↔ index of center
-    - Gustafson: global density in Γ(G) ≤ 5/8 -/
-theorem perspectives_summary : True := trivial
+/- Summary remark: both Neumann's theorem and the 5/8 theorem characterize
+   the same "non-abelian distance" of G, through different lenses:
+   - Neumann: clique size in Γ(G) ↔ index of center
+   - Gustafson: global density in Γ(G) ≤ 5/8 -/
 
 end Erdos1098OQ04

--- a/src/data/proofs/erdos-1098-oq-04/meta.json
+++ b/src/data/proofs/erdos-1098-oq-04/meta.json
@@ -25,7 +25,7 @@
     "erdosProblemStatus": "open",
     "dateAdded": "2026-04-02",
     "mathlib_version": "4.26.0",
-    "lineCount": 134,
+    "lineCount": 133,
     "axiomCount": 0,
     "assumptions": "0 sorries, 0 axioms. Core results (commProb G ≤ 1, equality iff abelian) obtained via Mathlib's commProb_le_one and commProb_eq_one_iff. The 5/8 theorem is stated as a Prop (open formalization goal, not an axiom). The nonCommGraph definition and nonCommDensity theorems are original infrastructure.",
     "mathlibDependencies": [


### PR DESCRIPTION
## Summary

- Remove `theorem perspectives_summary : True := trivial` True stub from `proofs/Proofs/Erdos1098OQ04.lean` (line 132)
- Convert the attached doc comment (`/-- ... -/`) to a regular comment (`/- ... -/`) since it no longer attaches to a declaration
- Update `lineCount` in `src/data/proofs/erdos-1098-oq-04/meta.json` from 134 to 133

This was caught during gallery integrity audit (cycle 36). The file has `"status": "verified"` and `"axiomCount": 0`, so True stubs are a critical integrity violation -- they inflate the apparent theorem count without contributing real content.

The `originalContributions` list in meta.json did not reference `perspectives_summary`, so no changes were needed there.

## Test plan

- [ ] Verify `proofs/Proofs/Erdos1098OQ04.lean` no longer contains any `True := trivial` stubs
- [ ] Verify `meta.json` lineCount matches actual file line count (133)
- [ ] Verify the comment block is now a regular comment, not a doc comment

Generated with [Claude Code](https://claude.com/claude-code)