### PR TITLE
Add Aristotle companion for Erdős #748 (Cameron-Erdős sum-free count)

### DIFF
--- a/proofs/Proofs/Erdos748Aristotle.lean
+++ b/proofs/Proofs/Erdos748Aristotle.lean
@@ -1,0 +1,49 @@
+/-
+  Aristotle targets for Erdős Problem #748 (Cameron-Erdős Conjecture on Sum-Free Sets)
+  Routine supporting lemmas for automated proof search.
+  See Erdos748Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main theorems (cameron_erdos_proved — requires deep asymptotic analysis)
+  - Small computable values of f(n) for n = 1, 2, 3
+  - f is defined as the card of a Finset filter, so small values are decidable
+
+  Excluded:
+  - cameron_erdos_proved: requires careful asymptotic analysis of log(f(n))/n
+  - trivial_lower_bound: stated as axiom in main file (not a sorry)
+  - green_upper_bound: Green's theorem (deep), stated as axiom
+  - precise_asymptotic: deep asymptotic result, stated as axiom
+
+  Strategy for f_1, f_2, f_3:
+  - f n = (sumFreeSubsets n).card
+  - sumFreeSubsets n = (Finset.Icc 1 n).powerset.filter IsSumFree
+  - For n = 1, 2, 3 the computation is finite and decidable
+  - Try: decide, native_decide, or simp [f, sumFreeSubsets, IsSumFree]
+-/
+import Mathlib
+import Proofs.Erdos748Problem
+
+namespace Erdos748Aristotle
+
+open Erdos748
+
+/-- f(1) = 2: The sum-free subsets of {1} are {} and {1}.
+    Strategy: decide (or native_decide) — finite computation. -/
+theorem f_1 : f 1 = 2 := by
+  sorry
+
+/-- f(2) = 3: The sum-free subsets of {1,2} are {}, {1}, {2}.
+    (Note: {1,2} is not sum-free since 1+1=2, but {1,2} requires 1+1=2 with repeated use;
+    IsSumFree allows repetition, so {2} is fine but {1,2}: 1 ∈ A ∧ 1 ∈ A ∧ 2 ∈ A ∧ 1+1=2 fails.)
+    Strategy: decide (or native_decide) — finite computation. -/
+theorem f_2 : f 2 = 3 := by
+  sorry
+
+/-- f(3) = 6: The sum-free subsets of {1,2,3} are {}, {1}, {2}, {3}, {1,3}, {2,3}.
+    ({1,3} is not sum-free: 1+3=4 ∉ {1,3}, 1+1=2 ∉ {1,3}, 3+3=6 ∉ {1,3} — wait, it IS sum-free.
+     {1,2}: 1+1=2 ∈ {1,2} — not sum-free. {1,2,3}: 1+2=3 ∈ set — not sum-free.)
+    Strategy: decide (or native_decide) — finite computation. -/
+theorem f_3 : f 3 = 6 := by
+  sorry
+
+end Erdos748Aristotle


### PR DESCRIPTION
## Fix

Creates `Erdos748Aristotle.lean` with 3 computable theorem targets for the Cameron-Erdős conjecture formalization.

## Evidence

**Target file**: `proofs/Proofs/Erdos748Problem.lean` — 4 sorries remaining, 3 computable

**Before**: No Aristotle companion for erdos-748
**After**: Companion with `f_1`, `f_2`, `f_3` — specific values of the sum-free counting function

## Targets

| Theorem | Statement | Strategy |
|---------|-----------|----------|
| `f_1` | `f 1 = 2` | `decide`/`native_decide` |
| `f_2` | `f 2 = 3` | `decide`/`native_decide` |
| `f_3` | `f 3 = 6` | `decide`/`native_decide` |

`f n` is defined as `(sumFreeSubsets n).card` where `sumFreeSubsets n = (Finset.Icc 1 n).powerset.filter IsSumFree`. For small n, this is a finite computation.

## Excluded

- `cameron_erdos_proved`: requires careful asymptotic analysis of `log(f(n))/n`
- `trivial_lower_bound`, `green_upper_bound`, `precise_asymptotic`: declared as `axiom` in main file

---
Automated fix by lean-mechanic agent.