### PR TITLE
Add Aristotle companion for Erdős #437 (square partial products)

### DIFF
--- a/proofs/Proofs/Erdos437Aristotle.lean
+++ b/proofs/Proofs/Erdos437Aristotle.lean
@@ -1,0 +1,99 @@
+/-
+  Aristotle targets for Erdos437 (Square Partial Products)
+  Routine supporting lemmas for automated proof search.
+  See Erdos437Problem.lean for the main formalization.
+
+  These lemmas provide building blocks for partial product square counting:
+  - IsSquare and squareCount basic properties
+  - Division arithmetic for L(x)/x bound proofs
+  - Powers-of-four square counting
+  - u(x) = sqrt(log x * log log x) basic properties
+  - Real.exp inequalities for growth rate comparisons
+-/
+import Mathlib
+
+open Real Nat Finset
+
+namespace Erdos437.Aristotle
+
+/-
+  ## Section 1: IsSquare Helpers
+-/
+
+/-- 4^k is a perfect square (= (2^k)^2) -/
+lemma isSquare_pow_four (k : ℕ) : IsSquare (4 ^ k) := by
+  sorry
+
+/-- Product of two squares is a square -/
+lemma isSquare_mul (a b : ℕ) (ha : IsSquare a) (hb : IsSquare b) : IsSquare (a * b) := by
+  sorry
+
+/-- 4^i * 4^j = 4^(i+j) -/
+lemma pow_four_mul (i j : ℕ) : 4 ^ i * 4 ^ j = 4 ^ (i + j) := by
+  sorry
+
+/-- 4^k ≥ 1 for all k -/
+lemma pow_four_pos (k : ℕ) : 4 ^ k ≥ 1 := by
+  sorry
+
+/-
+  ## Section 2: List Partial Products
+-/
+
+/-- Partial product of a list is the product of the first k elements -/
+lemma partial_product_cons (a : ℕ) (as : List ℕ) :
+    (a :: as).foldl (· * ·) 1 = a * as.foldl (· * ·) 1 := by
+  sorry
+
+/-- The product of List.range k mapped to 4^(i+1) is 4^(k*(k+1)/2) -/
+lemma pow_four_range_product (k : ℕ) :
+    (List.range k).foldl (fun acc i => acc * 4 ^ (i + 1)) 1 =
+    4 ^ (k * (k + 1) / 2) := by
+  sorry
+
+/-
+  ## Section 3: Division Arithmetic for L(x)/x
+-/
+
+/-- If a ≥ x * c and x > 0, then a / x ≥ c for reals -/
+lemma div_ge_of_ge_mul (a x c : ℝ) (hx : x > 0) (h : a ≥ x * c) : a / x ≥ c := by
+  sorry
+
+/-- If a ≤ x * c and x > 0, then a / x ≤ c for reals -/
+lemma div_le_of_le_mul (a x c : ℝ) (hx : x > 0) (h : a ≤ x * c) : a / x ≤ c := by
+  sorry
+
+/-- x > 0 as real when x ≥ 1 as natural -/
+lemma cast_pos_of_ge_one (x : ℕ) (hx : x ≥ 1) : (x : ℝ) > 0 := by
+  sorry
+
+/-- (L x : ℝ) / x is in [0, 1] when L x ≤ x -/
+lemma div_L_le_one (L x : ℕ) (h : L ≤ x) (hx : x ≥ 1) : (L : ℝ) / x ≤ 1 := by
+  sorry
+
+/-
+  ## Section 4: u(x) = sqrt(log x * log log x) Properties
+-/
+
+/-- u(x) ≥ 0 for x ≥ 2 -/
+lemma u_nonneg (x : ℕ) (hx : x ≥ 2) :
+    Real.sqrt (Real.log x * Real.log (Real.log x)) ≥ 0 := by
+  sorry
+
+/-- Real.exp is monotone -/
+lemma exp_mono (a b : ℝ) (h : a ≤ b) : Real.exp a ≤ Real.exp b := by
+  sorry
+
+/-- For c > 0 and u > 0, exp(-c * u) < 1 -/
+lemma exp_neg_lt_one (c u : ℝ) (hc : c > 0) (hu : u > 0) : Real.exp (-(c * u)) < 1 := by
+  sorry
+
+/-- sqrt 2 > 0 -/
+lemma sqrt_two_pos : Real.sqrt 2 > 0 := by
+  sorry
+
+/-- 1 / sqrt 2 < sqrt 2 -/
+lemma inv_sqrt_two_lt_sqrt_two : 1 / Real.sqrt 2 < Real.sqrt 2 := by
+  sorry
+
+end Erdos437.Aristotle


### PR DESCRIPTION
## Fix

Creates Aristotle companion file for Erdős #437 (Square Partial Products) exposing 14 provable supporting lemmas.

## Evidence

**Before**: `proofs/Proofs/Erdos437Problem.lean` has 3 sorries with no Aristotle companion
**After**: `proofs/Proofs/Erdos437Aristotle.lean` provides IsSquare helpers, division arithmetic for L(x)/x bounds, and growth rate properties

## Lemmas included
- `isSquare_pow_four`, `isSquare_mul`, `pow_four_mul`, `pow_four_pos`: IsSquare basics
- `partial_product_cons`, `pow_four_range_product`: partial product arithmetic
- `div_ge_of_ge_mul`, `div_le_of_le_mul`, `cast_pos_of_ge_one`, `div_L_le_one`: division helpers
- `u_nonneg`, `exp_mono`, `exp_neg_lt_one`, `sqrt_two_pos`, `inv_sqrt_two_lt_sqrt_two`: growth rate helpers

---
Automated fix by lean-mechanic agent.