### PR TITLE
Fix: correct badges for 3 gallery proofs (audit cycle-37)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-07/meta.json
@@ -22,6 +22,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 2,
+    "lineCount": 377,
     "assumptions": "Two axioms: (1) bringJerrard_reduction — the full Bring-Jerrard reduction eliminating x³ and x² terms via quadratic/cubic Tschirnhaus substitutions (requires polynomial resultant theory not in Mathlib); (2) bringRadical_not_in_radicals — the Bring radical is not expressible in radicals (follows from Abel-Ruffini but requires connecting the generic Galois group argument). The linear Tschirnhaus transform (depressed quintic) and all Bring radical properties are fully proved.",
     "dateAdded": "2026-04-03",
     "mathlibDependencies": [

--- a/src/data/proofs/arithmetic-series-oq-04/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-04/meta.json
@@ -16,11 +16,11 @@
       "arithmetic-series",
       "induction"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 177,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "lineCount": 197,
+    "assumptions": "0 axioms, 0 sorries. Core result relies on Mathlib's sum_Ico_pow (Faulhaber's formula) and sum_range_pow. The main theorem faulhaber_formula is a direct alias of sum_Ico_pow. Corollaries (p=1,2,3) and Bernoulli number values are derived from Mathlib.",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
       {

--- a/src/data/proofs/fair-games-theorem-oq-03/meta.json
+++ b/src/data/proofs/fair-games-theorem-oq-03/meta.json
@@ -16,7 +16,7 @@
       "doob",
       "wiedijk-100"
     ],
-    "badge": "verified",
+    "badge": "wip",
     "sorries": 4,
     "axiomCount": 0,
     "lineCount": 280,


### PR DESCRIPTION
## Integrity Fixes (Cycle-37)

Three gallery proofs audited for the first time. All have metadata issues.

### 1. fair-games-theorem-oq-03 — CRITICAL

**Problem**: `badge: "verified"` with 4 sorries (severity: CRITICAL)

| Field | Was | Should Be |
|-------|-----|-----------|
| `badge` | `"verified"` | `"wip"` |

A `verified` badge guarantees 0 sorries and 0 axioms. This proof has 4 pending sorries blocked by Mathlib 4.26.0 API changes.

### 2. arithmetic-series-oq-04 — HIGH

**Problem**: `badge: "verified"` but core result is a direct Mathlib alias (Delegation opacity)

| Field | Was | Should Be |
|-------|-----|-----------|
| `badge` | `"verified"` | `"mathlib"` |
| `lineCount` | 177 | 197 |
| `assumptions` | "None. Fully verified..." | Updated to document Mathlib dependency |

The main theorem `faulhaber_formula` is literally `sum_Ico_pow n p` — a direct alias. Per audit policy: badge must be `"mathlib"` when core result is obtained via Mathlib.

### 3. abel-ruffini-oq-04-oq-07 — LOW

**Problem**: `lineCount: null` (missing field)

Added `lineCount: 377`.

---
Discovered during gallery integrity audit (cycle-37).

🤖 Generated with [Claude Code](https://claude.com/claude-code)