### PR TITLE
Fix: correct metadata counts for 3 proofs (audit cycle-38)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1847,10 +1847,10 @@
       "result": "clean"
     },
     "erdos-1012-oq-03": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:41:40Z",
-      "result": "clean"
+      "lastAudited": "2026-04-04T06:09:00Z",
+      "result": "issues-fixed"
     },
     "erdos-1013": {
       "agentId": "auditor-cycle-20-batch",
@@ -2783,9 +2783,9 @@
       "result": "clean"
     },
     "erdos-1131-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-04T03:13:06Z",
+      "lastAudited": "2026-04-04T06:09:00Z",
       "result": "issues-fixed"
     },
     "erdos-1132": {
@@ -3403,11 +3403,11 @@
       "result": "clean"
     },
     "erdos-157": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [
         "sorry mismatch corrected in meta.json"
       ],
-      "lastAudited": "2026-04-04T01:13:06Z",
+      "lastAudited": "2026-04-04T06:09:00Z",
       "result": "issues-fixed"
     },
     "erdos-158": {
@@ -11346,6 +11346,24 @@
       "auditCount": 1,
       "lastAudited": "2026-04-03T23:36:27Z",
       "result": "clean",
+      "issues": []
+    },
+    "fair-games-theorem-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T06:09:21Z",
+      "result": "issues-found",
+      "issues": []
+    },
+    "arithmetic-series-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T06:09:21Z",
+      "result": "issues-found",
+      "issues": []
+    },
+    "abel-ruffini-oq-04-oq-07": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T06:09:21Z",
+      "result": "issues-found",
       "issues": []
     }
   },

--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -13,10 +13,10 @@
       "tournaments"
     ],
     "badge": "formalized",
-    "sorries": 4,
+    "sorries": 2,
     "axiomCount": 0,
-    "lineCount": 1135,
-    "assumptions": "0 axioms. 4 sorries: (1) ghouila_houri (full proof needs longest-path argument ~200 lines), (2) arcCount_add_missing (helper lemma: arc + missing = n*(n-1)), (3) card_equiv_fixed_pair (helper lemma: counting bijections fixing two positions = (n-2)!), (4) hbad_card_le (inline step inside directed_hamiltonian_threshold: bad perm count bound). Moon-Moser theorem (sc_tournament_has_cycle + tournament_cycle_extendable + grow_cycle_to_hamiltonian) is now fully proved. Rédei fully proved by induction.",
+    "lineCount": 991,
+    "assumptions": "0 axioms. 2 sorries: (1) ghouila_houri (full proof needs longest-path argument ~200 lines), (2) directed_hamiltonian_threshold (arc-count threshold result — single top-level sorry). Moon-Moser theorem (sc_tournament_has_cycle + tournament_cycle_extendable + grow_cycle_to_hamiltonian) is now fully proved. Rédei fully proved by induction.",
     "dateAdded": "2026-03-30"
   },
   "overview": {

--- a/src/data/proofs/erdos-1131-oq-01/meta.json
+++ b/src/data/proofs/erdos-1131-oq-01/meta.json
@@ -23,10 +23,10 @@
     "erdosUrl": "https://erdosproblems.com/1131",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
-    "sorries": 0,
+    "sorries": 2,
     "theoremCount": 11,
     "lineCount": 293,
-    "assumptions": "2 axioms total: 1 own (erdos_1131_variance_conjecture — variance form of Erdős #1131 conjecture) + 1 inherited from Erdos1131Problem.lean (erdos_1131_conjecture). 2 sorries in dependency chain: 0 in this file, 2 in private lemmas of parent Erdos1131Problem.lean (chebyshev_interp, chebyshev_sq_expansion — these are private and do not affect OQ01's exported results).",
+    "assumptions": "2 axioms total: 1 own (erdos_1131_variance_conjecture — variance form of Erdős #1131 conjecture) + 1 inherited from Erdos1131Problem.lean (erdos_1131_conjecture). 2 sorries in imported parent Erdos1131Problem.lean: chebyshev_interp (line 761) and chebyshev_sq_expansion (line 808) — both private lemmas in the Chebyshev expansion route. OQ01's main theorem (lagrangeIntegral_strict_lower) uses a continuity/positivity argument and does not depend on these sorry'd lemmas, but they are counted in the proof family total.",
     "parentProof": "erdos-1131",
     "prerequisites": [
       "Lagrange interpolation and basis polynomials",

--- a/src/data/proofs/erdos-157/meta.json
+++ b/src/data/proofs/erdos-157/meta.json
@@ -18,7 +18,7 @@
       "density"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 157,
     "erdosUrl": "https://erdosproblems.com/157",
     "erdosProblemStatus": "solved",
@@ -58,9 +58,9 @@
       "Basis density lower bound",
       "Verified theorem: powers_of_two_sidon"
     ],
-    "axiomCount": 2,
-    "lineCount": 258,
-    "assumptions": "2 axiom(s) and 1 sorry. See the Lean source for details."
+    "axiomCount": 3,
+    "lineCount": 535,
+    "assumptions": "3 axioms: (1) pilatte_existence — the Pilatte 2023 existence result (infinite Sidon set that is an asymptotic basis of order 3); (2) sidon_counting_bound — counting bound for Sidon sets; (3) basis_counting_lower — lower bound for basis counting. 0 sorries (previously 1 sorry for pilatte_existence was axiomatized; sidon_counting_contradiction proved by Aristotle)."
   },
   "overview": {
     "historicalContext": "Sidon sets (B$_2$ sequences) — sets where all pairwise sums are distinct — were introduced by Simon Sidon in correspondence with Erdős in the 1930s. Erdős and Pál Turán proved in 1941 that a Sidon subset of $\\{1, \\ldots, N\\}$ has at most $(1+o(1))\\sqrt{N}$ elements, establishing their fundamental sparsity.\n\nAsymptotic bases of order $k$ — sets $A$ where every sufficiently large integer is a sum of at most $k$ elements of $A$ — require density at least $N^{1/k}$ by a counting argument. The tension between Sidon sparsity ($\\leq N^{1/2}$) and basis density ($\\geq N^{1/k}$) creates a natural threshold: coexistence requires $1/k \\leq 1/2$, i.e., $k \\geq 2$. But $k = 2$ is exactly the boundary and fails for subtle arithmetic reasons.\n\nErdős conjectured that order 3 should work, and this was open for decades despite partial results by Deshouillers and Plagne (2003) on finite Sidon sets. Cédric Pilatte (Oxford) settled the conjecture affirmatively in 2023 using a probabilistic construction, applying the Lovász Local Lemma and a careful densification argument. His proof is non-explicit: it shows such sets exist without constructing one.\n\nThis formalization includes two fully verified theorems: the equivalence of two Sidon set definitions, and the proof that $\\{2^k : k \\in \\mathbb{N}\\}$ forms a Sidon set (since binary representations are unique).",
@@ -159,8 +159,8 @@
       "BigOperators"
     ],
     "namespace": "Erdos157",
-    "lineCount": 192,
-    "axiomCount": 2,
+    "lineCount": 535,
+    "axiomCount": 3,
     "theoremCount": 5,
     "definitionCount": 7
   },


### PR DESCRIPTION
## Integrity Fixes (Cycle-38)

### 1. erdos-1012-oq-03 — sorry count overclaimed

**Problem**: `sorries: 4` but Lean file now has 2 (researcher simplified the proof)

| Field | Was | Should Be |
|-------|-----|-----------|
| `sorries` | 4 | 2 |
| `lineCount` | 1135 | 991 |

The arc-threshold proof infrastructure (3 helper lemmas with sorries) was replaced with a single top-level `sorry` in `directed_hamiltonian_threshold`. Now only 2 sorries remain: `ghouila_houri` (line 300) and `directed_hamiltonian_threshold` (line 959).

### 2. erdos-1131-oq-01 — sorry count underclaimed (repeat fix)

**Problem**: `sorries: 0` but proof family has 2 sorries in imported parent

| Field | Was | Should Be |
|-------|-----|-----------|
| `sorries` | 0 | 2 |

The 2 sorries are in private lemmas of imported `Erdos1131Problem.lean`. Per audit policy, the `sorries` field reflects the full proof family count. This fix was in PR #9238 but was not included in the merge.

### 3. erdos-157 — axiom count underclaimed, sorry resolved

**Problem**: `sorries: 1` (now 0), `axiomCount: 2` (now 3)

| Field | Was | Should Be |
|-------|-----|-----------|
| `sorries` | 1 | 0 |
| `axiomCount` | 2 | 3 |
| `lineCount` | 258 | 535 |

Aristotle resolved `sidon_counting_contradiction`. A third axiom `basis_counting_lower` was added. File grew from 258 to 535 lines.

---
Discovered during gallery integrity audit (cycle-38).

🤖 Generated with [Claude Code](https://claude.com/claude-code)