### PR TITLE
Fix: correct leanFile metadata for BSD, CauchySchwarz, Erdos1018 OQ04

### DIFF
--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -50,9 +50,9 @@
       }
     ],
     "leanFile": {
-      "lineCount": 7437,
+      "lineCount": 7422,
       "structureCount": 92,
-      "axiomCount": 21,
+      "axiomCount": 19,
       "theoremCount": 254,
       "lemmaCount": 3,
       "defCount": 143,
@@ -681,8 +681,8 @@
       "ComplexConjugate"
     ],
     "namespace": "BirchSwinnertonDyer",
-    "lineCount": 7437,
-    "axiomCount": 21,
+    "lineCount": 7422,
+    "axiomCount": 19,
     "theoremCount": 254,
     "definitionCount": 143
   },

--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-01/meta.json
@@ -59,7 +59,7 @@
   },
   "leanFile": {
     "namespace": "ParsevalIdentity",
-    "lineCount": 198,
+    "lineCount": 223,
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 10,

--- a/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
@@ -18,10 +18,10 @@
       "erdos"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 5,
     "axiomCount": 5,
     "lineCount": 246,
-    "assumptions": "5 axioms total: 1 own (kostochka_pyber_r2 — the r=2 graph case of Kostochka-Pyber theorem, proven 1988) + 4 inherited from Erdos1018OQ04.lean (vanKampen_Flores — non-embeddability of r-skeleton of (2r+2)-simplex; triangle_planar — K₃ is planar; K4_planar — K₄ is planar; density_exceeds_turan — density bound for non-planar subgraphs). 7 sorries in this file (geometric edge-crossing verifications).",
+    "assumptions": "5 axioms total: 1 own (kostochka_pyber_r2 — the r=2 graph case of Kostochka-Pyber theorem, proven 1988) + 4 inherited from Erdos1018OQ04.lean (vanKampen_Flores — non-embeddability of r-skeleton of (2r+2)-simplex; triangle_planar — K₃ is planar; K4_planar — K₄ is planar; density_exceeds_turan — density bound for non-planar subgraphs). 5 sorries in this file (geometric edge-crossing verifications: lines 86, 108, 130, 169, 220).",
     "dateAdded": "2026-04-03",
     "mathlib_version": "4.26.0"
   },


### PR DESCRIPTION
## Fix

Three gallery proofs had stale `leanFile` section metadata inconsistent with the actual Lean source files.

## Evidence

### 1. birch-swinnerton-dyer

| Field | Was | Should Be |
|-------|-----|-----------|
| `meta.leanFile.lineCount` | 7437 | 7422 |
| `meta.leanFile.axiomCount` | 21 | 19 |
| `leanFile.lineCount` | 7437 | 7422 |
| `leanFile.axiomCount` | 21 | 19 |

The 2 removed axioms are documented in the `assumptions` field: `BSD_CM_rank_zero` was subsumed by Kolyvagin's general result, and `gross_zagier_formula_detail` was dead code.

### 2. cauchy-schwarz-oq-02-oq-01

| Field | Was | Should Be |
|-------|-----|-----------|
| `leanFile.lineCount` | 198 | 223 |

Top-level `meta.lineCount` (223) was correct; leanFile section was stale.

### 3. erdos-1018-oq-04-incomplete-01

| Field | Was | Should Be |
|-------|-----|-----------|
| `meta.sorries` | 7 | 5 |

Actual sorry count in file: 5 (lines 86, 108, 130, 169, 220). The previous count of 7 was set when the file was initially written with planned sorries; 2 were eliminated during implementation.

---
Automated fix by lean-mechanic agent.