### PR TITLE
Fix leanFile metadata: erdos-1126-oq-01, hilbert-23, erdos-1009-oq-02

### DIFF
--- a/src/data/proofs/erdos-1009-oq-02/meta.json
+++ b/src/data/proofs/erdos-1009-oq-02/meta.json
@@ -77,5 +77,13 @@
       "authors": ["P. Turán"],
       "year": 1941
     }
-  ]
+  ],
+  "leanFile": {
+    "path": "Proofs/Erdos1009OQ02Problem.lean",
+    "lineCount": 240,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 8,
+    "definitionCount": 5
+  }
 }

--- a/src/data/proofs/erdos-1126-oq-01/meta.json
+++ b/src/data/proofs/erdos-1126-oq-01/meta.json
@@ -65,7 +65,7 @@
     ],
     "dateAdded": "2026-03-24",
     "axiomCount": 7,
-    "lineCount": 485,
+    "lineCount": 472,
     "assumptions": "7 axioms: almost_multiplicative_stability, almost_jensen_stability, almost_derivation_stability, measurable_multiplicative_is_power, measurable_derivation_is_zero (public); ae_double_of_almost_jensen (Fubini section extraction), volume_preimage_double_null (product-space smul scaling, Mathlib 4.26 API compatibility) (private). 0 sorries."
   },
   "overview": {
@@ -184,7 +184,7 @@
   "leanFile": {
     "path": "proofs/Proofs/Erdos1126OQ01Problem.lean",
     "filename": "Erdos1126OQ01Problem.lean",
-    "lineCount": 485,
+    "lineCount": 472,
     "axiomCount": 7
   }
 }

--- a/src/data/proofs/hilbert-23/meta.json
+++ b/src/data/proofs/hilbert-23/meta.json
@@ -135,7 +135,14 @@
       "Can variational methods solve open problems in geometric analysis?"
     ]
   },
-  "leanFile": "Proofs/Hilbert23CalculusVariations.lean",
+  "leanFile": {
+    "path": "Proofs/Hilbert23CalculusVariations.lean",
+    "lineCount": 335,
+    "axiomCount": 0,
+    "sorries": 0,
+    "theoremCount": 4,
+    "definitionCount": 4
+  },
   "crossReferences": [
     {
       "targetId": "hilbert-19",


### PR DESCRIPTION
## Fix

Corrects stale/malformed `leanFile` metadata sections in three gallery proofs.

## Evidence

**erdos-1126-oq-01**:
- Before: `lineCount: 485` (both meta and leanFile sections)
- After: `lineCount: 472` (actual file has 472 lines; axiomCount=7 was already correct)

**hilbert-23**:
- Before: `"leanFile": "Proofs/Hilbert23CalculusVariations.lean"` (string, not object)
- After: proper `leanFile` object with `lineCount: 335, axiomCount: 0, sorries: 0`

**erdos-1009-oq-02**:
- Before: `leanFile` section missing entirely
- After: added `leanFile` object with `lineCount: 240, axiomCount: 0, sorries: 0`

All three flagged as `issues-found` in audit-tracker. Build passes (`pnpm build` ✓).

---
Automated fix by lean-mechanic agent.