### PR TITLE
Add missing leanFile.sorries field to 7 audited gallery proofs

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-02/meta.json
@@ -56,6 +56,7 @@
     "namespace": "BorsukUlamOQ02OQ02",
     "lineCount": 160,
     "axiomCount": 0,
+    "sorries": 0,
     "theoremCount": 7,
     "definitionCount": 3
   },

--- a/src/data/proofs/erdos-15/meta.json
+++ b/src/data/proofs/erdos-15/meta.json
@@ -148,6 +148,7 @@
     "namespace": "Erdos15",
     "lineCount": 219,
     "axiomCount": 1,
+    "sorries": 0,
     "theoremCount": 0,
     "definitionCount": 8
   },

--- a/src/data/proofs/erdos-231/meta.json
+++ b/src/data/proofs/erdos-231/meta.json
@@ -173,6 +173,7 @@
     "namespace": "Erdos231",
     "lineCount": 213,
     "axiomCount": 1,
+    "sorries": 0,
     "theoremCount": 3,
     "definitionCount": 11
   },

--- a/src/data/proofs/erdos-297/meta.json
+++ b/src/data/proofs/erdos-297/meta.json
@@ -205,6 +205,7 @@
     "namespace": "Erdos297",
     "lineCount": 256,
     "axiomCount": 3,
+    "sorries": 0,
     "theoremCount": 4,
     "definitionCount": 9
   },

--- a/src/data/proofs/erdos-657/meta.json
+++ b/src/data/proofs/erdos-657/meta.json
@@ -221,6 +221,7 @@
     "namespace": "Erdos657",
     "lineCount": 222,
     "axiomCount": 1,
+    "sorries": 0,
     "theoremCount": 6,
     "definitionCount": 16
   },

--- a/src/data/proofs/hilbert-22/meta.json
+++ b/src/data/proofs/hilbert-22/meta.json
@@ -136,6 +136,7 @@
     "namespace": "Hilbert22Uniformization",
     "lineCount": 305,
     "axiomCount": 0,
+    "sorries": 0,
     "theoremCount": 6,
     "definitionCount": 6
   },

--- a/src/data/proofs/sum-of-divisors/meta.json
+++ b/src/data/proofs/sum-of-divisors/meta.json
@@ -64,6 +64,7 @@
     "namespace": "SumOfDivisors",
     "lineCount": 549,
     "axiomCount": 0,
+    "sorries": 0,
     "theoremCount": 81,
     "definitionCount": 4
   },


### PR DESCRIPTION
## Fix

Adds the missing `sorries: 0` field to the `leanFile` section of 7 gallery proofs flagged as `issues-found` in the audit tracker.

## Affected Proofs

- `sum-of-divisors` — leanFile.sorries missing
- `hilbert-22` — leanFile.sorries missing
- `borsuk-ulam-oq-02-oq-02` — leanFile.sorries missing
- `erdos-15` — leanFile.sorries missing
- `erdos-231` — leanFile.sorries missing
- `erdos-297` — leanFile.sorries missing
- `erdos-657` — leanFile.sorries missing

## Evidence

All 7 Lean source files confirmed to have 0 actual sorry tokens (non-comment). The `leanFile` section of each was missing the `sorries` key entirely. Build passes (`pnpm build` ✓).

---
Automated fix by lean-mechanic agent.