### PR TITLE
Fix auditor false positives for structure-encoded assumptions

### DIFF
--- a/scripts/auditor/find-targets.ts
+++ b/scripts/auditor/find-targets.ts
@@ -304,7 +304,12 @@ function analyzeProof(id: string, galleryPath: string, tracker: Tracker): AuditT
       status: proofMeta.status || 'unknown',
       badge: proofMeta.badge || 'unknown',
       claimedSorries: proofMeta.sorries ?? -1,
-      claimedAxioms: proofMeta.axiomCount ?? -1,
+      // Use leanFile.axiomCount (raw declarations) for comparison when present.
+      // meta.axiomCount counts ALL assumptions including structure-encoded ones.
+      // leanFile.axiomCount counts only ^axiom declarations, matching what we detect.
+      claimedAxioms: (typeof meta.leanFile === 'object' && meta.leanFile !== null && meta.leanFile.axiomCount !== undefined)
+        ? meta.leanFile.axiomCount
+        : (proofMeta.axiomCount ?? -1),
     },
     actual: {
       sorryCount,


### PR DESCRIPTION
## Fix

Resolves persistent false positive "axiom overcount" warnings in `scripts/auditor/find-targets.ts` (issue #9205).

## Root Cause

`detectIssues()` compared `meta.axiomCount` (total mathematical assumptions, including structure fields) against the actual `^axiom` declaration count. For proofs using structure-encoded assumptions, these always differ — causing permanent false positives.

## Fix

When `leanFile.axiomCount` is present in meta.json, use it for the axiom declaration comparison instead of `meta.axiomCount`. This separates two different things:
- `meta.axiomCount` = total mathematical assumptions (for display/documentation)
- `leanFile.axiomCount` = raw Lean `axiom` declarations (for structural verification)

## Before / After

**navier-stokes**: `meta.axiomCount=5` (NSAxioms structure), `leanFile.axiomCount=0`
- Before: ❌ `axiom overcount: claims 5, actual declarations 0`
- After: ✅ no issue (0 == 0)

**navier-stokes-existence**: same pattern, same fix
**angle-trisection**: `meta.axiomCount=1` (inherited from PiTranscendental), `leanFile.axiomCount=0`
- Before: ❌ `axiom overcount: claims 1, actual declarations 0`
- After: ✅ no issue (0 == 0)

Verified: `npx tsx scripts/auditor/find-targets.ts --all --json` shows `detectedIssues: []` for all three.

Closes #9205

---
Automated fix by lean-mechanic agent.