### PR TITLE
Fix: correct leanFile.axiomCount for 33 proofs + sorry count for 1 (audit cycle-39)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
@@ -110,7 +110,7 @@
     ],
     "namespace": "AmgmInequalityOQ02OQ03",
     "lineCount": 226,
-    "axiomCount": 0,
+    "axiomCount": 2,
     "theoremCount": 6,
     "definitionCount": 1
   },

--- a/src/data/proofs/angle-trisection-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-04-oq-01/meta.json
@@ -166,7 +166,7 @@
     ],
     "namespace": "AngleTrisectionOQ02OQ04OQ01",
     "lineCount": 334,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 12,
     "substantiveTheoremCount": 8,
     "duplicateTheorems": 0,

--- a/src/data/proofs/borsuk-ulam-oq-04/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-04/meta.json
@@ -138,7 +138,7 @@
     "opens": [],
     "namespace": "BorsukUlamOQ04",
     "lineCount": 300,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 4,
     "definitionCount": 11
   }

--- a/src/data/proofs/bounded-prime-gaps-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-01/meta.json
@@ -69,7 +69,7 @@
   "leanFile": {
     "namespace": "BoundedPrimeGapsOQ01",
     "lineCount": 438,
-    "axiomCount": 1,
+    "axiomCount": 3,
     "theoremCount": 26,
     "definitionCount": 5
   },

--- a/src/data/proofs/bounded-prime-gaps-oq-03-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03-oq-01/meta.json
@@ -142,7 +142,7 @@
     ],
     "namespace": "BoundedPrimeGapsOQ03OQ01",
     "lineCount": 383,
-    "axiomCount": 2,
+    "axiomCount": 5,
     "theoremCount": 24,
     "definitionCount": 5
   },

--- a/src/data/proofs/bounded-prime-gaps-oq-03/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03/meta.json
@@ -229,7 +229,7 @@
     ],
     "namespace": "BoundedPrimeGapsOQ03",
     "lineCount": 279,
-    "axiomCount": 1,
+    "axiomCount": 4,
     "theoremCount": 21,
     "definitionCount": 1
   }

--- a/src/data/proofs/bounded-prime-gaps-oq-04/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04/meta.json
@@ -186,7 +186,7 @@
     ],
     "namespace": "BoundedPrimeGapsOQ04",
     "lineCount": 366,
-    "axiomCount": 1,
+    "axiomCount": 4,
     "theoremCount": 15,
     "definitionCount": 10
   }

--- a/src/data/proofs/brouwer-fixed-point-oq-04/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04/meta.json
@@ -205,7 +205,7 @@
     ],
     "namespace": "KakutaniFPT",
     "lineCount": 473,
-    "axiomCount": 1,
+    "axiomCount": 3,
     "theoremCount": 23,
     "definitionCount": 15
   },

--- a/src/data/proofs/continuum-hypothesis-oq-01/meta.json
+++ b/src/data/proofs/continuum-hypothesis-oq-01/meta.json
@@ -173,7 +173,7 @@
     ],
     "namespace": "ContinuumHypothesisOQ01",
     "lineCount": 317,
-    "axiomCount": 10,
+    "axiomCount": 14,
     "theoremCount": 20,
     "definitionCount": 3
   },

--- a/src/data/proofs/continuum-hypothesis-oq-02/meta.json
+++ b/src/data/proofs/continuum-hypothesis-oq-02/meta.json
@@ -180,7 +180,7 @@
     ],
     "namespace": "ContinuumHypothesisOQ02",
     "lineCount": 584,
-    "axiomCount": 2,
+    "axiomCount": 16,
     "theoremCount": 32,
     "definitionCount": 6
   },

--- a/src/data/proofs/dissection-of-cubes-oq-01/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01/meta.json
@@ -140,7 +140,7 @@
     ],
     "namespace": "DissectionOfCubesOQ01",
     "lineCount": 274,
-    "axiomCount": 0,
+    "axiomCount": 2,
     "theoremCount": 5,
     "definitionCount": 4
   },

--- a/src/data/proofs/dissection-of-cubes-oq-03/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-03/meta.json
@@ -164,7 +164,7 @@
   "leanFile": {
     "namespace": "(builds on DissectionOfCubes namespace)",
     "lineCount": 599,
-    "axiomCount": 0,
+    "axiomCount": 2,
     "theoremCount": 17,
     "definitionCount": 13
   },

--- a/src/data/proofs/erdos-100-oq-02/meta.json
+++ b/src/data/proofs/erdos-100-oq-02/meta.json
@@ -95,7 +95,7 @@
     ],
     "namespace": "Erdos100OQ02",
     "lineCount": 60,
-    "axiomCount": 0,
+    "axiomCount": 2,
     "theoremCount": 2,
     "definitionCount": 0
   },

--- a/src/data/proofs/erdos-1007-oq-05/meta.json
+++ b/src/data/proofs/erdos-1007-oq-05/meta.json
@@ -126,7 +126,7 @@
     ],
     "namespace": "Erdos1007OQ05",
     "lineCount": 141,
-    "axiomCount": 0,
+    "axiomCount": 4,
     "theoremCount": 5,
     "definitionCount": 0
   },

--- a/src/data/proofs/erdos-1014-oq-02/meta.json
+++ b/src/data/proofs/erdos-1014-oq-02/meta.json
@@ -137,7 +137,7 @@
     ],
     "namespace": "Erdos1014OQ02",
     "lineCount": 186,
-    "axiomCount": 0,
+    "axiomCount": 12,
     "theoremCount": 4,
     "definitionCount": 0,
     "substantiveTheoremCount": 4,

--- a/src/data/proofs/erdos-1017/meta.json
+++ b/src/data/proofs/erdos-1017/meta.json
@@ -228,7 +228,7 @@
     "opens": [],
     "namespace": null,
     "lineCount": 1,
-    "axiomCount": 0,
+    "axiomCount": 3,
     "theoremCount": 0,
     "definitionCount": 0
   }

--- a/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
@@ -18,7 +18,7 @@
       "erdos"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 7,
     "axiomCount": 5,
     "lineCount": 246,
     "assumptions": "5 axioms total: 1 own (kostochka_pyber_r2 — the r=2 graph case of Kostochka-Pyber theorem, proven 1988) + 4 inherited from Erdos1018OQ04.lean (vanKampen_Flores — non-embeddability of r-skeleton of (2r+2)-simplex; triangle_planar — K₃ is planar; K4_planar — K₄ is planar; density_exceeds_turan — density bound for non-planar subgraphs). 5 sorries in this file (geometric edge-crossing verifications: lines 86, 108, 130, 169, 220).",
@@ -119,7 +119,7 @@
     ],
     "namespace": "Erdos1018OQ04Completion",
     "lineCount": 246,
-    "axiomCount": 1,
+    "axiomCount": 5,
     "theoremCount": 11
   }
 }

--- a/src/data/proofs/erdos-1039/meta.json
+++ b/src/data/proofs/erdos-1039/meta.json
@@ -184,7 +184,7 @@
     "opens": [],
     "namespace": "Erdos1039",
     "lineCount": 303,
-    "axiomCount": 6,
+    "axiomCount": 5,
     "theoremCount": 9,
     "definitionCount": 16
   }

--- a/src/data/proofs/erdos-105-oq-05/meta.json
+++ b/src/data/proofs/erdos-105-oq-05/meta.json
@@ -183,7 +183,7 @@
     ],
     "namespace": "Erdos105OQ05",
     "lineCount": 206,
-    "axiomCount": 0,
+    "axiomCount": 3,
     "theoremCount": 4,
     "definitionCount": 9
   }

--- a/src/data/proofs/erdos-1131-oq-01/meta.json
+++ b/src/data/proofs/erdos-1131-oq-01/meta.json
@@ -109,7 +109,7 @@
       "Erdos1131"
     ],
     "namespace": "Erdos1131OQ01",
-    "axiomCount": 1,
+    "axiomCount": 2,
     "sorries": 0,
     "theoremCount": 11,
     "lineCount": 293,

--- a/src/data/proofs/erdos-1155-oq-01/meta.json
+++ b/src/data/proofs/erdos-1155-oq-01/meta.json
@@ -346,7 +346,7 @@
   "leanFile": {
     "lineCount": 411,
     "structureCount": 0,
-    "axiomCount": 0,
+    "axiomCount": 6,
     "theoremCount": 20,
     "lemmaCount": 0,
     "defCount": 6,

--- a/src/data/proofs/erdos-220/meta.json
+++ b/src/data/proofs/erdos-220/meta.json
@@ -169,7 +169,7 @@
     "opens": [],
     "namespace": null,
     "lineCount": 241,
-    "axiomCount": 0,
+    "axiomCount": 4,
     "theoremCount": 0,
     "definitionCount": 0
   },

--- a/src/data/proofs/erdos-25/meta.json
+++ b/src/data/proofs/erdos-25/meta.json
@@ -150,7 +150,7 @@
     ],
     "namespace": null,
     "lineCount": 166,
-    "axiomCount": 0,
+    "axiomCount": 3,
     "theoremCount": 8,
     "definitionCount": 6
   },

--- a/src/data/proofs/erdos-44/meta.json
+++ b/src/data/proofs/erdos-44/meta.json
@@ -137,7 +137,7 @@
     ],
     "namespace": "Erdos44",
     "lineCount": 346,
-    "axiomCount": 1,
+    "axiomCount": 4,
     "theoremCount": 8,
     "definitionCount": 0
   },

--- a/src/data/proofs/erdos-625/meta.json
+++ b/src/data/proofs/erdos-625/meta.json
@@ -198,7 +198,7 @@
     "opens": [],
     "namespace": null,
     "lineCount": 0,
-    "axiomCount": 0,
+    "axiomCount": 2,
     "theoremCount": 0,
     "definitionCount": 0
   },

--- a/src/data/proofs/erdos-644/meta.json
+++ b/src/data/proofs/erdos-644/meta.json
@@ -203,7 +203,7 @@
     "opens": [],
     "namespace": null,
     "lineCount": 277,
-    "axiomCount": 0,
+    "axiomCount": 3,
     "theoremCount": 0,
     "definitionCount": 0
   },

--- a/src/data/proofs/erdos-671/meta.json
+++ b/src/data/proofs/erdos-671/meta.json
@@ -201,7 +201,7 @@
     "opens": [],
     "namespace": null,
     "lineCount": 269,
-    "axiomCount": 0,
+    "axiomCount": 3,
     "theoremCount": 0,
     "definitionCount": 0
   },

--- a/src/data/proofs/erdos-780/meta.json
+++ b/src/data/proofs/erdos-780/meta.json
@@ -210,7 +210,7 @@
     ],
     "namespace": "Erdos780",
     "lineCount": 221,
-    "axiomCount": 2,
+    "axiomCount": 14,
     "theoremCount": 7,
     "definitionCount": 12
   },

--- a/src/data/proofs/erdos-820/meta.json
+++ b/src/data/proofs/erdos-820/meta.json
@@ -183,7 +183,7 @@
     ],
     "namespace": "Erdos820",
     "lineCount": 284,
-    "axiomCount": 4,
+    "axiomCount": 3,
     "theoremCount": 4,
     "definitionCount": 12
   },

--- a/src/data/proofs/four-color-theorem-oq-02/meta.json
+++ b/src/data/proofs/four-color-theorem-oq-02/meta.json
@@ -74,6 +74,6 @@
     ]
   },
   "leanFile": {
-    "axiomCount": 0
+    "axiomCount": 2
   }
 }

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -281,7 +281,7 @@
     ],
     "namespace": "InverseGaloisProblem",
     "lineCount": 1882,
-    "axiomCount": 4,
+    "axiomCount": 5,
     "theoremCount": 107,
     "definitionCount": 1
   },

--- a/src/data/proofs/yang-mills-2d/meta.json
+++ b/src/data/proofs/yang-mills-2d/meta.json
@@ -175,7 +175,7 @@
   "leanFile": {
     "lineCount": 28053,
     "structureCount": 365,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 1786,
     "lemmaCount": 0,
     "defCount": 251,

--- a/src/data/proofs/yang-mills-lattice/meta.json
+++ b/src/data/proofs/yang-mills-lattice/meta.json
@@ -148,7 +148,7 @@
   "leanFile": {
     "lineCount": 28053,
     "structureCount": 365,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 1786,
     "lemmaCount": 0,
     "defCount": 251,

--- a/src/data/proofs/yang-mills-transfer-matrix/meta.json
+++ b/src/data/proofs/yang-mills-transfer-matrix/meta.json
@@ -138,7 +138,7 @@
   "leanFile": {
     "lineCount": 28053,
     "structureCount": 365,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "theoremCount": 1786,
     "lemmaCount": 0,
     "defCount": 251,


### PR DESCRIPTION
## Summary

- Corrected `leanFile.axiomCount` in 34 gallery `meta.json` files to match actual axiom declarations detected by the auditor script
- 31 proofs had undercounts (axiomCount too low), 2 had overcounts (axiomCount too high)
- Also fixed `meta.sorries` for `erdos-1018-oq-04-incomplete-01` (5 -> 7, accounting for 2 inherited sorries from parent file)

## Verification

After applying fixes, `find-targets.ts --stats` reports 3 remaining issues (down from 34+3=37). The 3 remaining are pre-existing structure-encoded axiom cases for `navier-stokes`, `navier-stokes-existence`, and `angle-trisection` -- these are outside the scope of this fix.

## Test plan

- [x] All 34 current values verified against expected before overwriting
- [x] `npx tsx scripts/auditor/find-targets.ts --stats` shows 3 issues (all pre-existing, unrelated)
- [x] JSON formatting preserved (indent=2, trailing newline)