### PR TITLE
Fix: add missing leanFile.sorries field to 28 gallery proofs

### DIFF
--- a/src/data/proofs/erdos-1033/meta.json
+++ b/src/data/proofs/erdos-1033/meta.json
@@ -306,6 +306,7 @@
     "lineCount": 388,
     "axiomCount": 3,
     "theoremCount": 16,
-    "definitionCount": 17
+    "definitionCount": 17,
+    "sorries": 7
   }
 }

--- a/src/data/proofs/erdos-1043/meta.json
+++ b/src/data/proofs/erdos-1043/meta.json
@@ -254,6 +254,7 @@
     "lineCount": 270,
     "axiomCount": 2,
     "theoremCount": 12,
-    "definitionCount": 15
+    "definitionCount": 15,
+    "sorries": 7
   }
 }

--- a/src/data/proofs/erdos-1049/meta.json
+++ b/src/data/proofs/erdos-1049/meta.json
@@ -281,6 +281,7 @@
     "theoremCount": 26,
     "substantiveTheoremCount": 22,
     "trivialSpecializations": 0,
-    "definitionCount": 12
+    "definitionCount": 12,
+    "sorries": 9
   }
 }

--- a/src/data/proofs/erdos-268/meta.json
+++ b/src/data/proofs/erdos-268/meta.json
@@ -214,6 +214,7 @@
     "lineCount": 286,
     "axiomCount": 1,
     "theoremCount": 15,
-    "definitionCount": 14
+    "definitionCount": 14,
+    "sorries": 8
   }
 }

--- a/src/data/proofs/erdos-549/meta.json
+++ b/src/data/proofs/erdos-549/meta.json
@@ -191,7 +191,8 @@
     "lineCount": 248,
     "axiomCount": 0,
     "theoremCount": 16,
-    "definitionCount": 14
+    "definitionCount": 14,
+    "sorries": 14
   },
   "references": [
     {

--- a/src/data/proofs/erdos-551/meta.json
+++ b/src/data/proofs/erdos-551/meta.json
@@ -178,7 +178,8 @@
     "lineCount": 604,
     "axiomCount": 0,
     "theoremCount": 26,
-    "definitionCount": 14
+    "definitionCount": 14,
+    "sorries": 22
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-601/meta.json
+++ b/src/data/proofs/erdos-601/meta.json
@@ -208,7 +208,8 @@
     "lineCount": 262,
     "axiomCount": 3,
     "theoremCount": 19,
-    "definitionCount": 13
+    "definitionCount": 13,
+    "sorries": 10
   },
   "references": [
     {

--- a/src/data/proofs/erdos-608/meta.json
+++ b/src/data/proofs/erdos-608/meta.json
@@ -205,7 +205,8 @@
     "lineCount": 270,
     "axiomCount": 0,
     "theoremCount": 14,
-    "definitionCount": 15
+    "definitionCount": 15,
+    "sorries": 13
   },
   "references": [
     {

--- a/src/data/proofs/erdos-625/meta.json
+++ b/src/data/proofs/erdos-625/meta.json
@@ -200,7 +200,8 @@
     "lineCount": 272,
     "axiomCount": 2,
     "theoremCount": 0,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "sorries": 20
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-629/meta.json
+++ b/src/data/proofs/erdos-629/meta.json
@@ -178,7 +178,8 @@
     "lineCount": 912,
     "axiomCount": 0,
     "theoremCount": 37,
-    "definitionCount": 14
+    "definitionCount": 14,
+    "sorries": 7
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-633/meta.json
+++ b/src/data/proofs/erdos-633/meta.json
@@ -159,7 +159,8 @@
     "lineCount": 236,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "sorries": 8
   },
   "references": [
     {

--- a/src/data/proofs/erdos-634/meta.json
+++ b/src/data/proofs/erdos-634/meta.json
@@ -196,7 +196,8 @@
     "lineCount": 298,
     "axiomCount": 3,
     "theoremCount": 16,
-    "definitionCount": 15
+    "definitionCount": 15,
+    "sorries": 7
   },
   "references": [
     {

--- a/src/data/proofs/erdos-637/meta.json
+++ b/src/data/proofs/erdos-637/meta.json
@@ -202,6 +202,7 @@
     "lineCount": 243,
     "axiomCount": 0,
     "theoremCount": 18,
-    "definitionCount": 16
+    "definitionCount": 16,
+    "sorries": 10
   }
 }

--- a/src/data/proofs/erdos-642/meta.json
+++ b/src/data/proofs/erdos-642/meta.json
@@ -195,7 +195,8 @@
     "lineCount": 266,
     "axiomCount": 2,
     "theoremCount": 12,
-    "definitionCount": 14
+    "definitionCount": 14,
+    "sorries": 6
   },
   "references": [
     {

--- a/src/data/proofs/erdos-644/meta.json
+++ b/src/data/proofs/erdos-644/meta.json
@@ -205,7 +205,8 @@
     "lineCount": 277,
     "axiomCount": 3,
     "theoremCount": 0,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "sorries": 18
   },
   "references": [
     {

--- a/src/data/proofs/erdos-660/meta.json
+++ b/src/data/proofs/erdos-660/meta.json
@@ -141,7 +141,8 @@
     "lineCount": 179,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "sorries": 10
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-671/meta.json
+++ b/src/data/proofs/erdos-671/meta.json
@@ -203,7 +203,8 @@
     "lineCount": 269,
     "axiomCount": 3,
     "theoremCount": 0,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "sorries": 23
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-673/meta.json
+++ b/src/data/proofs/erdos-673/meta.json
@@ -202,7 +202,8 @@
     "lineCount": 233,
     "axiomCount": 0,
     "theoremCount": 21,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "sorries": 20
   },
   "references": [
     {

--- a/src/data/proofs/erdos-674/meta.json
+++ b/src/data/proofs/erdos-674/meta.json
@@ -176,7 +176,8 @@
     "lineCount": 283,
     "axiomCount": 0,
     "theoremCount": 25,
-    "definitionCount": 12
+    "definitionCount": 12,
+    "sorries": 22
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-678/meta.json
+++ b/src/data/proofs/erdos-678/meta.json
@@ -171,6 +171,7 @@
     "lineCount": 170,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "sorries": 11
   }
 }

--- a/src/data/proofs/erdos-679/meta.json
+++ b/src/data/proofs/erdos-679/meta.json
@@ -281,6 +281,7 @@
     "lineCount": 259,
     "axiomCount": 0,
     "theoremCount": 16,
-    "definitionCount": 18
+    "definitionCount": 18,
+    "sorries": 10
   }
 }

--- a/src/data/proofs/erdos-771/meta.json
+++ b/src/data/proofs/erdos-771/meta.json
@@ -210,7 +210,8 @@
     "lineCount": 244,
     "axiomCount": 2,
     "theoremCount": 11,
-    "definitionCount": 16
+    "definitionCount": 16,
+    "sorries": 7
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-798/meta.json
+++ b/src/data/proofs/erdos-798/meta.json
@@ -175,7 +175,8 @@
     "lineCount": 311,
     "axiomCount": 3,
     "theoremCount": 11,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "sorries": 7
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-840/meta.json
+++ b/src/data/proofs/erdos-840/meta.json
@@ -128,7 +128,8 @@
     "lineCount": 229,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "sorries": 7
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-895/meta.json
+++ b/src/data/proofs/erdos-895/meta.json
@@ -157,7 +157,8 @@
     "lineCount": 187,
     "axiomCount": 0,
     "theoremCount": 13,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "sorries": 11
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-934/meta.json
+++ b/src/data/proofs/erdos-934/meta.json
@@ -184,7 +184,8 @@
     "lineCount": 234,
     "axiomCount": 4,
     "theoremCount": 10,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "sorries": 8
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-956/meta.json
+++ b/src/data/proofs/erdos-956/meta.json
@@ -207,7 +207,8 @@
     "lineCount": 309,
     "axiomCount": 2,
     "theoremCount": 12,
-    "definitionCount": 13
+    "definitionCount": 13,
+    "sorries": 6
   },
   "references": [
     {

--- a/src/data/proofs/erdos-977/meta.json
+++ b/src/data/proofs/erdos-977/meta.json
@@ -144,7 +144,8 @@
     "lineCount": 229,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "sorries": 23
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Add the `leanFile.sorries` field to 28 gallery proofs that have `meta.sorries > 0` but were missing the corresponding field in the `leanFile` section.

## Evidence

**Before**: `leanFile` section had `lineCount`, `axiomCount`, `theoremCount`, `definitionCount` but no `sorries` field for these 28 proofs.

**After**: `leanFile.sorries` is now populated to match `meta.sorries` (verified by comment-stripping the actual Lean source file before counting).

## Validation

- All 28 values verified against actual Lean file sorry counts (after stripping block and line comments)
- `meta.sorries` and `leanFile.sorries` are now consistent for all 28 proofs
- Build passes: `pnpm build` completes successfully
- Auditor still shows 0 issues

## Proofs Fixed (top 10 by sorry count)

| Proof | sorries |
|-------|---------|
| erdos-977 | 23 |
| erdos-671 | 23 |
| erdos-674 | 22 |
| erdos-551 | 22 |
| erdos-673 | 20 |
| erdos-625 | 20 |
| erdos-644 | 18 |
| erdos-549 | 14 |
| erdos-608 | 13 |
| erdos-895 | 11 |
| + 18 more | |

This continues the work from #9255 (which added `leanFile.sorries` to 7 proofs).

---
Automated fix by lean-mechanic agent.