### PR TITLE
chore: sync research registry (deployer auto-sync)

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -12354,11 +12354,12 @@
     },
     {
       "slug": "bezout-identity-oq-01-oq-01",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "fast",
       "started": "2026-04-04T05:15:05.956Z",
-      "status": "active",
-      "lastUpdate": "2026-04-04T05:15:05.956Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T07:40:01.899Z",
+      "completed": "2026-04-04T07:40:01.899Z"
     },
     {
       "slug": "binary-gcd-oq-01-oq-03",


### PR DESCRIPTION
Automated sync of `research/registry.json` iteration counts generated by the deployer pipeline after merging PRs #9261, #9260, #9254.

No human review needed — auto-generated data file.