### PR TITLE
Fix: sync research problem JSON with 15 newly-merged lean files

### DIFF
--- a/src/data/research/problems/abel-ruffini-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-oq-01.json
@@ -332,7 +332,8 @@
     "abel-ruffini-oq-04-oq-01",
     "abel-ruffini-oq-04-oq-02",
     "abel-ruffini-oq-04-oq-02-oq-03",
-    "abel-ruffini-oq-04-oq-03"
+    "abel-ruffini-oq-04-oq-03",
+    "abel-ruffini-oq-04-oq-07"
   ],
   "references": {
     "papers": [],
@@ -420,6 +421,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ03.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ04OQ07.lean",
+      "filename": "AbelRuffiniOQ04OQ07.lean",
+      "lineCount": 378,
+      "theoremCount": 12,
+      "axiomCount": 2,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ07.lean"
     }
   ]
 }

--- a/src/data/research/problems/abel-ruffini-oq-02.json
+++ b/src/data/research/problems/abel-ruffini-oq-02.json
@@ -49,7 +49,8 @@
     "abel-ruffini-oq-04-oq-01",
     "abel-ruffini-oq-04-oq-02",
     "abel-ruffini-oq-04-oq-02-oq-03",
-    "abel-ruffini-oq-04-oq-03"
+    "abel-ruffini-oq-04-oq-03",
+    "abel-ruffini-oq-04-oq-07"
   ],
   "references": {
     "papers": [],
@@ -138,6 +139,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ03.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ04OQ07.lean",
+      "filename": "AbelRuffiniOQ04OQ07.lean",
+      "lineCount": 378,
+      "theoremCount": 12,
+      "axiomCount": 2,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ07.lean"
     }
   ]
 }

--- a/src/data/research/problems/abel-ruffini-oq-03.json
+++ b/src/data/research/problems/abel-ruffini-oq-03.json
@@ -49,7 +49,8 @@
     "abel-ruffini-oq-04-oq-01",
     "abel-ruffini-oq-04-oq-02",
     "abel-ruffini-oq-04-oq-02-oq-03",
-    "abel-ruffini-oq-04-oq-03"
+    "abel-ruffini-oq-04-oq-03",
+    "abel-ruffini-oq-04-oq-07"
   ],
   "references": {
     "papers": [],
@@ -137,6 +138,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ03.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ04OQ07.lean",
+      "filename": "AbelRuffiniOQ04OQ07.lean",
+      "lineCount": 378,
+      "theoremCount": 12,
+      "axiomCount": 2,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ07.lean"
     }
   ]
 }

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-01.json
@@ -77,7 +77,8 @@
     "abel-ruffini-oq-04-oq-01",
     "abel-ruffini-oq-04-oq-02",
     "abel-ruffini-oq-04-oq-02-oq-03",
-    "abel-ruffini-oq-04-oq-03"
+    "abel-ruffini-oq-04-oq-03",
+    "abel-ruffini-oq-04-oq-07"
   ],
   "references": {
     "papers": [],
@@ -165,6 +166,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ03.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ04OQ07.lean",
+      "filename": "AbelRuffiniOQ04OQ07.lean",
+      "lineCount": 378,
+      "theoremCount": 12,
+      "axiomCount": 2,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ07.lean"
     }
   ]
 }

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-02-oq-03.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-02-oq-03.json
@@ -111,6 +111,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ03.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ04OQ07.lean",
+      "filename": "AbelRuffiniOQ04OQ07.lean",
+      "lineCount": 378,
+      "theoremCount": 12,
+      "axiomCount": 2,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ07.lean"
     }
   ],
   "relatedProofs": [
@@ -120,6 +131,7 @@
     "abel-ruffini-oq-04-oq-01",
     "abel-ruffini-oq-04-oq-02",
     "abel-ruffini-oq-04-oq-02-oq-03",
-    "abel-ruffini-oq-04-oq-03"
+    "abel-ruffini-oq-04-oq-03",
+    "abel-ruffini-oq-04-oq-07"
   ]
 }

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-02.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-02.json
@@ -66,7 +66,8 @@
     "abel-ruffini-oq-04-oq-01",
     "abel-ruffini-oq-04-oq-02",
     "abel-ruffini-oq-04-oq-02-oq-03",
-    "abel-ruffini-oq-04-oq-03"
+    "abel-ruffini-oq-04-oq-03",
+    "abel-ruffini-oq-04-oq-07"
   ],
   "references": {
     "papers": [],
@@ -158,6 +159,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ03.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ04OQ07.lean",
+      "filename": "AbelRuffiniOQ04OQ07.lean",
+      "lineCount": 378,
+      "theoremCount": 12,
+      "axiomCount": 2,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ07.lean"
     }
   ]
 }

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-03.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-03.json
@@ -57,7 +57,8 @@
     "abel-ruffini-oq-04-oq-01",
     "abel-ruffini-oq-04-oq-02",
     "abel-ruffini-oq-04-oq-02-oq-03",
-    "abel-ruffini-oq-04-oq-03"
+    "abel-ruffini-oq-04-oq-03",
+    "abel-ruffini-oq-04-oq-07"
   ],
   "references": {
     "papers": [],
@@ -143,6 +144,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ03.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ04OQ07.lean",
+      "filename": "AbelRuffiniOQ04OQ07.lean",
+      "lineCount": 378,
+      "theoremCount": 12,
+      "axiomCount": 2,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ07.lean"
     }
   ]
 }

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-06.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-06.json
@@ -44,7 +44,8 @@
     "abel-ruffini-oq-04-oq-01",
     "abel-ruffini-oq-04-oq-02",
     "abel-ruffini-oq-04-oq-02-oq-03",
-    "abel-ruffini-oq-04-oq-03"
+    "abel-ruffini-oq-04-oq-03",
+    "abel-ruffini-oq-04-oq-07"
   ],
   "references": {
     "papers": [],
@@ -130,6 +131,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ03.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ04OQ07.lean",
+      "filename": "AbelRuffiniOQ04OQ07.lean",
+      "lineCount": 378,
+      "theoremCount": 12,
+      "axiomCount": 2,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ07.lean"
     }
   ]
 }

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-07.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-07.json
@@ -49,7 +49,8 @@
     "abel-ruffini-oq-04-oq-01",
     "abel-ruffini-oq-04-oq-02",
     "abel-ruffini-oq-04-oq-02-oq-03",
-    "abel-ruffini-oq-04-oq-03"
+    "abel-ruffini-oq-04-oq-03",
+    "abel-ruffini-oq-04-oq-07"
   ],
   "references": {
     "papers": [],
@@ -137,6 +138,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ03.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ04OQ07.lean",
+      "filename": "AbelRuffiniOQ04OQ07.lean",
+      "lineCount": 378,
+      "theoremCount": 12,
+      "axiomCount": 2,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ07.lean"
     }
   ]
 }

--- a/src/data/research/problems/abel-ruffini-oq-04.json
+++ b/src/data/research/problems/abel-ruffini-oq-04.json
@@ -107,6 +107,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ03.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ04OQ07.lean",
+      "filename": "AbelRuffiniOQ04OQ07.lean",
+      "lineCount": 378,
+      "theoremCount": 12,
+      "axiomCount": 2,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ07.lean"
     }
   ],
   "relatedProofs": [
@@ -116,7 +127,8 @@
     "abel-ruffini-oq-04-oq-01",
     "abel-ruffini-oq-04-oq-02",
     "abel-ruffini-oq-04-oq-02-oq-03",
-    "abel-ruffini-oq-04-oq-03"
+    "abel-ruffini-oq-04-oq-03",
+    "abel-ruffini-oq-04-oq-07"
   ],
   "tags": [],
   "problemStatement": {

--- a/src/data/research/problems/abel-ruffini-oq-05.json
+++ b/src/data/research/problems/abel-ruffini-oq-05.json
@@ -46,7 +46,8 @@
     "abel-ruffini-oq-04-oq-01",
     "abel-ruffini-oq-04-oq-02",
     "abel-ruffini-oq-04-oq-02-oq-03",
-    "abel-ruffini-oq-04-oq-03"
+    "abel-ruffini-oq-04-oq-03",
+    "abel-ruffini-oq-04-oq-07"
   ],
   "references": {
     "papers": [],
@@ -134,6 +135,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ03.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ04OQ07.lean",
+      "filename": "AbelRuffiniOQ04OQ07.lean",
+      "lineCount": 378,
+      "theoremCount": 12,
+      "axiomCount": 2,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ07.lean"
     }
   ]
 }

--- a/src/data/research/problems/abel-ruffini-oq-06.json
+++ b/src/data/research/problems/abel-ruffini-oq-06.json
@@ -48,7 +48,8 @@
     "abel-ruffini-oq-04-oq-01",
     "abel-ruffini-oq-04-oq-02",
     "abel-ruffini-oq-04-oq-02-oq-03",
-    "abel-ruffini-oq-04-oq-03"
+    "abel-ruffini-oq-04-oq-03",
+    "abel-ruffini-oq-04-oq-07"
   ],
   "references": {
     "papers": [],
@@ -136,6 +137,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ03.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ04OQ07.lean",
+      "filename": "AbelRuffiniOQ04OQ07.lean",
+      "lineCount": 378,
+      "theoremCount": 12,
+      "axiomCount": 2,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ07.lean"
     }
   ]
 }

--- a/src/data/research/problems/arithmetic-series-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-01.json
@@ -47,7 +47,8 @@
     "arithmetic-series-oq-02-oq-02",
     "arithmetic-series-oq-02-oq-02-oq-01",
     "arithmetic-series-oq-02-oq-02-oq-03",
-    "arithmetic-series-oq-02-oq-04"
+    "arithmetic-series-oq-02-oq-04",
+    "arithmetic-series-oq-04"
   ],
   "references": {
     "papers": [],
@@ -147,6 +148,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ04.lean",
+      "filename": "ArithmeticSeriesOQ04.lean",
+      "lineCount": 198,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ04.lean"
     }
   ]
 }

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-01.json
@@ -57,7 +57,8 @@
     "arithmetic-series-oq-02-oq-02",
     "arithmetic-series-oq-02-oq-02-oq-01",
     "arithmetic-series-oq-02-oq-02-oq-03",
-    "arithmetic-series-oq-02-oq-04"
+    "arithmetic-series-oq-02-oq-04",
+    "arithmetic-series-oq-04"
   ],
   "references": {
     "papers": [],
@@ -156,6 +157,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ04.lean",
+      "filename": "ArithmeticSeriesOQ04.lean",
+      "lineCount": 198,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ04.lean"
     }
   ]
 }

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-01.json
@@ -115,6 +115,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ04.lean",
+      "filename": "ArithmeticSeriesOQ04.lean",
+      "lineCount": 198,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ04.lean"
     }
   ],
   "relatedProofs": [
@@ -124,7 +135,8 @@
     "arithmetic-series-oq-02-oq-02",
     "arithmetic-series-oq-02-oq-02-oq-01",
     "arithmetic-series-oq-02-oq-02-oq-03",
-    "arithmetic-series-oq-02-oq-04"
+    "arithmetic-series-oq-02-oq-04",
+    "arithmetic-series-oq-04"
   ],
   "tags": [],
   "problemStatement": {

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03.json
@@ -44,7 +44,8 @@
     "arithmetic-series-oq-02-oq-02",
     "arithmetic-series-oq-02-oq-02-oq-01",
     "arithmetic-series-oq-02-oq-02-oq-03",
-    "arithmetic-series-oq-02-oq-04"
+    "arithmetic-series-oq-02-oq-04",
+    "arithmetic-series-oq-04"
   ],
   "references": {
     "papers": [],
@@ -141,6 +142,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ04.lean",
+      "filename": "ArithmeticSeriesOQ04.lean",
+      "lineCount": 198,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ04.lean"
     }
   ]
 }

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-04.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-04.json
@@ -44,7 +44,8 @@
     "arithmetic-series-oq-02-oq-02",
     "arithmetic-series-oq-02-oq-02-oq-01",
     "arithmetic-series-oq-02-oq-02-oq-03",
-    "arithmetic-series-oq-02-oq-04"
+    "arithmetic-series-oq-02-oq-04",
+    "arithmetic-series-oq-04"
   ],
   "references": {
     "papers": [],
@@ -141,6 +142,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ04.lean",
+      "filename": "ArithmeticSeriesOQ04.lean",
+      "lineCount": 198,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ04.lean"
     }
   ]
 }

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02.json
@@ -123,6 +123,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ04.lean",
+      "filename": "ArithmeticSeriesOQ04.lean",
+      "lineCount": 198,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ04.lean"
     }
   ],
   "relatedProofs": [
@@ -132,6 +143,7 @@
     "arithmetic-series-oq-02-oq-02",
     "arithmetic-series-oq-02-oq-02-oq-01",
     "arithmetic-series-oq-02-oq-02-oq-03",
-    "arithmetic-series-oq-02-oq-04"
+    "arithmetic-series-oq-02-oq-04",
+    "arithmetic-series-oq-04"
   ]
 }

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01.json
@@ -61,7 +61,8 @@
     "arithmetic-series-oq-02-oq-02",
     "arithmetic-series-oq-02-oq-02-oq-01",
     "arithmetic-series-oq-02-oq-02-oq-03",
-    "arithmetic-series-oq-02-oq-04"
+    "arithmetic-series-oq-02-oq-04",
+    "arithmetic-series-oq-04"
   ],
   "references": {
     "papers": [],
@@ -160,6 +161,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ04.lean",
+      "filename": "ArithmeticSeriesOQ04.lean",
+      "lineCount": 198,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ04.lean"
     }
   ]
 }

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-04.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-04.json
@@ -47,7 +47,8 @@
     "arithmetic-series-oq-02-oq-02",
     "arithmetic-series-oq-02-oq-02-oq-01",
     "arithmetic-series-oq-02-oq-02-oq-03",
-    "arithmetic-series-oq-02-oq-04"
+    "arithmetic-series-oq-02-oq-04",
+    "arithmetic-series-oq-04"
   ],
   "references": {
     "papers": [],
@@ -147,6 +148,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ04.lean",
+      "filename": "ArithmeticSeriesOQ04.lean",
+      "lineCount": 198,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ04.lean"
     }
   ]
 }

--- a/src/data/research/problems/arithmetic-series-oq-02.json
+++ b/src/data/research/problems/arithmetic-series-oq-02.json
@@ -50,7 +50,8 @@
     "arithmetic-series-oq-02-oq-02",
     "arithmetic-series-oq-02-oq-02-oq-01",
     "arithmetic-series-oq-02-oq-02-oq-03",
-    "arithmetic-series-oq-02-oq-04"
+    "arithmetic-series-oq-02-oq-04",
+    "arithmetic-series-oq-04"
   ],
   "references": {
     "papers": [],
@@ -150,6 +151,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ04.lean",
+      "filename": "ArithmeticSeriesOQ04.lean",
+      "lineCount": 198,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ04.lean"
     }
   ]
 }

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-01.json
@@ -158,7 +158,7 @@
     {
       "path": "Proofs/BallotProblemOQ03.lean",
       "filename": "BallotProblemOQ03.lean",
-      "lineCount": 2898,
+      "lineCount": 2879,
       "theoremCount": 119,
       "axiomCount": 0,
       "defCount": 31,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02.json
@@ -175,7 +175,7 @@
     {
       "path": "Proofs/BallotProblemOQ03.lean",
       "filename": "BallotProblemOQ03.lean",
-      "lineCount": 2898,
+      "lineCount": 2879,
       "theoremCount": 119,
       "axiomCount": 0,
       "defCount": 31,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01.json
@@ -159,7 +159,7 @@
     {
       "path": "Proofs/BallotProblemOQ03.lean",
       "filename": "BallotProblemOQ03.lean",
-      "lineCount": 2898,
+      "lineCount": 2879,
       "theoremCount": 119,
       "axiomCount": 0,
       "defCount": 31,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02.json
@@ -126,7 +126,7 @@
     {
       "path": "Proofs/BallotProblemOQ03.lean",
       "filename": "BallotProblemOQ03.lean",
-      "lineCount": 2898,
+      "lineCount": 2879,
       "theoremCount": 119,
       "axiomCount": 0,
       "defCount": 31,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-04-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-04-oq-01.json
@@ -181,7 +181,7 @@
     {
       "path": "Proofs/BallotProblemOQ03.lean",
       "filename": "BallotProblemOQ03.lean",
-      "lineCount": 2898,
+      "lineCount": 2879,
       "theoremCount": 119,
       "axiomCount": 0,
       "defCount": 31,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-04.json
@@ -165,7 +165,7 @@
     {
       "path": "Proofs/BallotProblemOQ03.lean",
       "filename": "BallotProblemOQ03.lean",
-      "lineCount": 2898,
+      "lineCount": 2879,
       "theoremCount": 119,
       "axiomCount": 0,
       "defCount": 31,

--- a/src/data/research/problems/ballot-problem-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01.json
@@ -154,7 +154,7 @@
     {
       "path": "Proofs/BallotProblemOQ03.lean",
       "filename": "BallotProblemOQ03.lean",
-      "lineCount": 2898,
+      "lineCount": 2879,
       "theoremCount": 119,
       "axiomCount": 0,
       "defCount": 31,

--- a/src/data/research/problems/ballot-problem-oq-02-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-02-oq-02.json
@@ -150,7 +150,7 @@
     {
       "path": "Proofs/BallotProblemOQ03.lean",
       "filename": "BallotProblemOQ03.lean",
-      "lineCount": 2898,
+      "lineCount": 2879,
       "theoremCount": 119,
       "axiomCount": 0,
       "defCount": 31,

--- a/src/data/research/problems/ballot-problem-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-02.json
@@ -155,7 +155,7 @@
     {
       "path": "Proofs/BallotProblemOQ03.lean",
       "filename": "BallotProblemOQ03.lean",
-      "lineCount": 2898,
+      "lineCount": 2879,
       "theoremCount": 119,
       "axiomCount": 0,
       "defCount": 31,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01.json
@@ -126,7 +126,7 @@
     {
       "path": "Proofs/BallotProblemOQ03.lean",
       "filename": "BallotProblemOQ03.lean",
-      "lineCount": 2898,
+      "lineCount": 2879,
       "theoremCount": 119,
       "axiomCount": 0,
       "defCount": 31,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-02.json
@@ -185,7 +185,7 @@
     {
       "path": "Proofs/BallotProblemOQ03.lean",
       "filename": "BallotProblemOQ03.lean",
-      "lineCount": 2898,
+      "lineCount": 2879,
       "theoremCount": 119,
       "axiomCount": 0,
       "defCount": 31,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-03.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-03.json
@@ -162,7 +162,7 @@
     {
       "path": "Proofs/BallotProblemOQ03.lean",
       "filename": "BallotProblemOQ03.lean",
-      "lineCount": 2898,
+      "lineCount": 2879,
       "theoremCount": 119,
       "axiomCount": 0,
       "defCount": 31,

--- a/src/data/research/problems/ballot-problem-oq-03.json
+++ b/src/data/research/problems/ballot-problem-oq-03.json
@@ -161,7 +161,7 @@
     {
       "path": "Proofs/BallotProblemOQ03.lean",
       "filename": "BallotProblemOQ03.lean",
-      "lineCount": 2898,
+      "lineCount": 2879,
       "theoremCount": 119,
       "axiomCount": 0,
       "defCount": 31,

--- a/src/data/research/problems/cayley-hamilton-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-oq-01-oq-01.json
@@ -326,6 +326,17 @@
       "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonReductionOQ02OQ01Aristotle.lean",
+      "filename": "CayleyHamiltonReductionOQ02OQ01Aristotle.lean",
+      "lineCount": 105,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 12,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01Aristotle.lean"
     }
   ]
 }

--- a/src/data/research/problems/cayley-hamilton-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-oq-01.json
@@ -322,6 +322,17 @@
       "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonReductionOQ02OQ01Aristotle.lean",
+      "filename": "CayleyHamiltonReductionOQ02OQ01Aristotle.lean",
+      "lineCount": 105,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 12,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01Aristotle.lean"
     }
   ]
 }

--- a/src/data/research/problems/cayley-hamilton-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-oq-02.json
@@ -327,6 +327,17 @@
       "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonReductionOQ02OQ01Aristotle.lean",
+      "filename": "CayleyHamiltonReductionOQ02OQ01Aristotle.lean",
+      "lineCount": 105,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 12,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01Aristotle.lean"
     }
   ]
 }

--- a/src/data/research/problems/cayley-hamilton-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-oq-03.json
@@ -325,6 +325,17 @@
       "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonReductionOQ02OQ01Aristotle.lean",
+      "filename": "CayleyHamiltonReductionOQ02OQ01Aristotle.lean",
+      "lineCount": 105,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 12,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01Aristotle.lean"
     }
   ]
 }

--- a/src/data/research/problems/cayley-hamilton-reduction-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-reduction-oq-01-oq-01.json
@@ -84,6 +84,17 @@
       "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonReductionOQ02OQ01Aristotle.lean",
+      "filename": "CayleyHamiltonReductionOQ02OQ01Aristotle.lean",
+      "lineCount": 105,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 12,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01Aristotle.lean"
     }
   ]
 }

--- a/src/data/research/problems/cayley-hamilton-reduction-oq-01-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-reduction-oq-01-oq-02.json
@@ -84,6 +84,17 @@
       "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonReductionOQ02OQ01Aristotle.lean",
+      "filename": "CayleyHamiltonReductionOQ02OQ01Aristotle.lean",
+      "lineCount": 105,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 12,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01Aristotle.lean"
     }
   ]
 }

--- a/src/data/research/problems/cayley-hamilton-reduction-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-reduction-oq-01.json
@@ -95,6 +95,17 @@
       "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonReductionOQ02OQ01Aristotle.lean",
+      "filename": "CayleyHamiltonReductionOQ02OQ01Aristotle.lean",
+      "lineCount": 105,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 12,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01Aristotle.lean"
     }
   ]
 }

--- a/src/data/research/problems/cayley-hamilton-reduction-oq-02-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-reduction-oq-02-oq-01.json
@@ -113,6 +113,17 @@
       "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonReductionOQ02OQ01Aristotle.lean",
+      "filename": "CayleyHamiltonReductionOQ02OQ01Aristotle.lean",
+      "lineCount": 105,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 12,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01Aristotle.lean"
     }
   ]
 }

--- a/src/data/research/problems/cayley-hamilton-reduction-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-reduction-oq-02.json
@@ -49,6 +49,17 @@
       "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonReductionOQ02OQ01Aristotle.lean",
+      "filename": "CayleyHamiltonReductionOQ02OQ01Aristotle.lean",
+      "lineCount": 105,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 12,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01Aristotle.lean"
     }
   ],
   "relatedProofs": [

--- a/src/data/research/problems/cayley-hamilton-reduction-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-reduction-oq-03.json
@@ -88,6 +88,17 @@
       "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonReductionOQ02OQ01Aristotle.lean",
+      "filename": "CayleyHamiltonReductionOQ02OQ01Aristotle.lean",
+      "lineCount": 105,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 12,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01Aristotle.lean"
     }
   ]
 }

--- a/src/data/research/problems/erdos-1-oq-01.json
+++ b/src/data/research/problems/erdos-1-oq-01.json
@@ -153,6 +153,7 @@
     "erdos-1057",
     "erdos-1058",
     "erdos-1059",
+    "erdos-1059-oq-02",
     "erdos-1059-oq-03",
     "erdos-1059-oq-05",
     "erdos-106",
@@ -992,6 +993,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021OQ01.lean"
     },
     {
+      "path": "Proofs/Erdos1021OQ01Aristotle.lean",
+      "filename": "Erdos1021OQ01Aristotle.lean",
+      "lineCount": 80,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 13,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021OQ01Aristotle.lean"
+    },
+    {
       "path": "Proofs/Erdos1021Problem.lean",
       "filename": "Erdos1021Problem.lean",
       "lineCount": 242,
@@ -1247,11 +1259,11 @@
     {
       "path": "Proofs/Erdos1036Problem.lean",
       "filename": "Erdos1036Problem.lean",
-      "lineCount": 160,
+      "lineCount": 202,
       "theoremCount": 7,
-      "axiomCount": 1,
+      "axiomCount": 2,
       "defCount": 6,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1036Problem.lean"
     },
@@ -1324,11 +1336,11 @@
     {
       "path": "Proofs/Erdos1040Problem.lean",
       "filename": "Erdos1040Problem.lean",
-      "lineCount": 577,
+      "lineCount": 621,
       "theoremCount": 21,
       "axiomCount": 4,
       "defCount": 19,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1040Problem.lean"
     },
@@ -1683,6 +1695,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1058Problem.lean"
+    },
+    {
+      "path": "Proofs/Erdos1059OQ02.lean",
+      "filename": "Erdos1059OQ02.lean",
+      "lineCount": 232,
+      "theoremCount": 7,
+      "axiomCount": 1,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1059OQ02.lean"
     },
     {
       "path": "Proofs/Erdos1059OQ03.lean",
@@ -2292,8 +2315,8 @@
     {
       "path": "Proofs/Erdos1098OQ04.lean",
       "filename": "Erdos1098OQ04.lean",
-      "lineCount": 135,
-      "theoremCount": 8,
+      "lineCount": 134,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,
@@ -3489,6 +3512,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos117OQ01.lean"
     },
     {
+      "path": "Proofs/Erdos117OQ01Aristotle.lean",
+      "filename": "Erdos117OQ01Aristotle.lean",
+      "lineCount": 104,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 13,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos117OQ01Aristotle.lean"
+    },
+    {
       "path": "Proofs/Erdos117Problem.lean",
       "filename": "Erdos117Problem.lean",
       "lineCount": 63,
@@ -4006,6 +4040,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos155Problem.lean"
     },
     {
+      "path": "Proofs/Erdos156Aristotle.lean",
+      "filename": "Erdos156Aristotle.lean",
+      "lineCount": 99,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 12,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos156Aristotle.lean"
+    },
+    {
       "path": "Proofs/Erdos156OQ02.lean",
       "filename": "Erdos156OQ02.lean",
       "lineCount": 294,
@@ -4030,11 +4075,11 @@
     {
       "path": "Proofs/Erdos157Problem.lean",
       "filename": "Erdos157Problem.lean",
-      "lineCount": 446,
-      "theoremCount": 5,
-      "axiomCount": 2,
+      "lineCount": 536,
+      "theoremCount": 4,
+      "axiomCount": 3,
       "defCount": 7,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos157Problem.lean"
     },

--- a/src/data/research/problems/erdos-1-oq-02.json
+++ b/src/data/research/problems/erdos-1-oq-02.json
@@ -611,6 +611,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021OQ01.lean"
     },
     {
+      "path": "Proofs/Erdos1021OQ01Aristotle.lean",
+      "filename": "Erdos1021OQ01Aristotle.lean",
+      "lineCount": 80,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 13,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021OQ01Aristotle.lean"
+    },
+    {
       "path": "Proofs/Erdos1021Problem.lean",
       "filename": "Erdos1021Problem.lean",
       "lineCount": 242,
@@ -866,11 +877,11 @@
     {
       "path": "Proofs/Erdos1036Problem.lean",
       "filename": "Erdos1036Problem.lean",
-      "lineCount": 160,
+      "lineCount": 202,
       "theoremCount": 7,
-      "axiomCount": 1,
+      "axiomCount": 2,
       "defCount": 6,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1036Problem.lean"
     },
@@ -943,11 +954,11 @@
     {
       "path": "Proofs/Erdos1040Problem.lean",
       "filename": "Erdos1040Problem.lean",
-      "lineCount": 577,
+      "lineCount": 621,
       "theoremCount": 21,
       "axiomCount": 4,
       "defCount": 19,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1040Problem.lean"
     },
@@ -1302,6 +1313,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1058Problem.lean"
+    },
+    {
+      "path": "Proofs/Erdos1059OQ02.lean",
+      "filename": "Erdos1059OQ02.lean",
+      "lineCount": 232,
+      "theoremCount": 7,
+      "axiomCount": 1,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1059OQ02.lean"
     },
     {
       "path": "Proofs/Erdos1059OQ03.lean",
@@ -1911,8 +1933,8 @@
     {
       "path": "Proofs/Erdos1098OQ04.lean",
       "filename": "Erdos1098OQ04.lean",
-      "lineCount": 135,
-      "theoremCount": 8,
+      "lineCount": 134,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,
@@ -3108,6 +3130,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos117OQ01.lean"
     },
     {
+      "path": "Proofs/Erdos117OQ01Aristotle.lean",
+      "filename": "Erdos117OQ01Aristotle.lean",
+      "lineCount": 104,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 13,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos117OQ01Aristotle.lean"
+    },
+    {
       "path": "Proofs/Erdos117Problem.lean",
       "filename": "Erdos117Problem.lean",
       "lineCount": 63,
@@ -3625,6 +3658,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos155Problem.lean"
     },
     {
+      "path": "Proofs/Erdos156Aristotle.lean",
+      "filename": "Erdos156Aristotle.lean",
+      "lineCount": 99,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 12,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos156Aristotle.lean"
+    },
+    {
       "path": "Proofs/Erdos156OQ02.lean",
       "filename": "Erdos156OQ02.lean",
       "lineCount": 294,
@@ -3649,11 +3693,11 @@
     {
       "path": "Proofs/Erdos157Problem.lean",
       "filename": "Erdos157Problem.lean",
-      "lineCount": 446,
-      "theoremCount": 5,
-      "axiomCount": 2,
+      "lineCount": 536,
+      "theoremCount": 4,
+      "axiomCount": 3,
       "defCount": 7,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos157Problem.lean"
     },
@@ -4352,6 +4396,7 @@
     "erdos-1057",
     "erdos-1058",
     "erdos-1059",
+    "erdos-1059-oq-02",
     "erdos-1059-oq-03",
     "erdos-1059-oq-05",
     "erdos-106",

--- a/src/data/research/problems/erdos-1-oq-03.json
+++ b/src/data/research/problems/erdos-1-oq-03.json
@@ -173,6 +173,7 @@
     "erdos-1057",
     "erdos-1058",
     "erdos-1059",
+    "erdos-1059-oq-02",
     "erdos-1059-oq-03",
     "erdos-1059-oq-05",
     "erdos-106",
@@ -1012,6 +1013,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021OQ01.lean"
     },
     {
+      "path": "Proofs/Erdos1021OQ01Aristotle.lean",
+      "filename": "Erdos1021OQ01Aristotle.lean",
+      "lineCount": 80,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 13,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021OQ01Aristotle.lean"
+    },
+    {
       "path": "Proofs/Erdos1021Problem.lean",
       "filename": "Erdos1021Problem.lean",
       "lineCount": 242,
@@ -1267,11 +1279,11 @@
     {
       "path": "Proofs/Erdos1036Problem.lean",
       "filename": "Erdos1036Problem.lean",
-      "lineCount": 160,
+      "lineCount": 202,
       "theoremCount": 7,
-      "axiomCount": 1,
+      "axiomCount": 2,
       "defCount": 6,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1036Problem.lean"
     },
@@ -1344,11 +1356,11 @@
     {
       "path": "Proofs/Erdos1040Problem.lean",
       "filename": "Erdos1040Problem.lean",
-      "lineCount": 577,
+      "lineCount": 621,
       "theoremCount": 21,
       "axiomCount": 4,
       "defCount": 19,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1040Problem.lean"
     },
@@ -1703,6 +1715,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1058Problem.lean"
+    },
+    {
+      "path": "Proofs/Erdos1059OQ02.lean",
+      "filename": "Erdos1059OQ02.lean",
+      "lineCount": 232,
+      "theoremCount": 7,
+      "axiomCount": 1,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1059OQ02.lean"
     },
     {
       "path": "Proofs/Erdos1059OQ03.lean",
@@ -2312,8 +2335,8 @@
     {
       "path": "Proofs/Erdos1098OQ04.lean",
       "filename": "Erdos1098OQ04.lean",
-      "lineCount": 135,
-      "theoremCount": 8,
+      "lineCount": 134,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,
@@ -3509,6 +3532,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos117OQ01.lean"
     },
     {
+      "path": "Proofs/Erdos117OQ01Aristotle.lean",
+      "filename": "Erdos117OQ01Aristotle.lean",
+      "lineCount": 104,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 13,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos117OQ01Aristotle.lean"
+    },
+    {
       "path": "Proofs/Erdos117Problem.lean",
       "filename": "Erdos117Problem.lean",
       "lineCount": 63,
@@ -4026,6 +4060,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos155Problem.lean"
     },
     {
+      "path": "Proofs/Erdos156Aristotle.lean",
+      "filename": "Erdos156Aristotle.lean",
+      "lineCount": 99,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 12,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos156Aristotle.lean"
+    },
+    {
       "path": "Proofs/Erdos156OQ02.lean",
       "filename": "Erdos156OQ02.lean",
       "lineCount": 294,
@@ -4050,11 +4095,11 @@
     {
       "path": "Proofs/Erdos157Problem.lean",
       "filename": "Erdos157Problem.lean",
-      "lineCount": 446,
-      "theoremCount": 5,
-      "axiomCount": 2,
+      "lineCount": 536,
+      "theoremCount": 4,
+      "axiomCount": 3,
       "defCount": 7,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos157Problem.lean"
     },

--- a/src/data/research/problems/erdos-1-oq-04.json
+++ b/src/data/research/problems/erdos-1-oq-04.json
@@ -150,6 +150,7 @@
     "erdos-1057",
     "erdos-1058",
     "erdos-1059",
+    "erdos-1059-oq-02",
     "erdos-1059-oq-03",
     "erdos-1059-oq-05",
     "erdos-106",
@@ -989,6 +990,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021OQ01.lean"
     },
     {
+      "path": "Proofs/Erdos1021OQ01Aristotle.lean",
+      "filename": "Erdos1021OQ01Aristotle.lean",
+      "lineCount": 80,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 13,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021OQ01Aristotle.lean"
+    },
+    {
       "path": "Proofs/Erdos1021Problem.lean",
       "filename": "Erdos1021Problem.lean",
       "lineCount": 242,
@@ -1244,11 +1256,11 @@
     {
       "path": "Proofs/Erdos1036Problem.lean",
       "filename": "Erdos1036Problem.lean",
-      "lineCount": 160,
+      "lineCount": 202,
       "theoremCount": 7,
-      "axiomCount": 1,
+      "axiomCount": 2,
       "defCount": 6,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1036Problem.lean"
     },
@@ -1321,11 +1333,11 @@
     {
       "path": "Proofs/Erdos1040Problem.lean",
       "filename": "Erdos1040Problem.lean",
-      "lineCount": 577,
+      "lineCount": 621,
       "theoremCount": 21,
       "axiomCount": 4,
       "defCount": 19,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1040Problem.lean"
     },
@@ -1680,6 +1692,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1058Problem.lean"
+    },
+    {
+      "path": "Proofs/Erdos1059OQ02.lean",
+      "filename": "Erdos1059OQ02.lean",
+      "lineCount": 232,
+      "theoremCount": 7,
+      "axiomCount": 1,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1059OQ02.lean"
     },
     {
       "path": "Proofs/Erdos1059OQ03.lean",
@@ -2289,8 +2312,8 @@
     {
       "path": "Proofs/Erdos1098OQ04.lean",
       "filename": "Erdos1098OQ04.lean",
-      "lineCount": 135,
-      "theoremCount": 8,
+      "lineCount": 134,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,
@@ -3486,6 +3509,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos117OQ01.lean"
     },
     {
+      "path": "Proofs/Erdos117OQ01Aristotle.lean",
+      "filename": "Erdos117OQ01Aristotle.lean",
+      "lineCount": 104,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 13,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos117OQ01Aristotle.lean"
+    },
+    {
       "path": "Proofs/Erdos117Problem.lean",
       "filename": "Erdos117Problem.lean",
       "lineCount": 63,
@@ -4003,6 +4037,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos155Problem.lean"
     },
     {
+      "path": "Proofs/Erdos156Aristotle.lean",
+      "filename": "Erdos156Aristotle.lean",
+      "lineCount": 99,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 12,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos156Aristotle.lean"
+    },
+    {
       "path": "Proofs/Erdos156OQ02.lean",
       "filename": "Erdos156OQ02.lean",
       "lineCount": 294,
@@ -4027,11 +4072,11 @@
     {
       "path": "Proofs/Erdos157Problem.lean",
       "filename": "Erdos157Problem.lean",
-      "lineCount": 446,
-      "theoremCount": 5,
-      "axiomCount": 2,
+      "lineCount": 536,
+      "theoremCount": 4,
+      "axiomCount": 3,
       "defCount": 7,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos157Problem.lean"
     },

--- a/src/data/research/problems/erdos-10-oq-01.json
+++ b/src/data/research/problems/erdos-10-oq-01.json
@@ -158,6 +158,7 @@
     "erdos-1057",
     "erdos-1058",
     "erdos-1059",
+    "erdos-1059-oq-02",
     "erdos-1059-oq-03",
     "erdos-1059-oq-05",
     "erdos-106",
@@ -807,6 +808,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021OQ01.lean"
     },
     {
+      "path": "Proofs/Erdos1021OQ01Aristotle.lean",
+      "filename": "Erdos1021OQ01Aristotle.lean",
+      "lineCount": 80,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 13,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021OQ01Aristotle.lean"
+    },
+    {
       "path": "Proofs/Erdos1021Problem.lean",
       "filename": "Erdos1021Problem.lean",
       "lineCount": 242,
@@ -1062,11 +1074,11 @@
     {
       "path": "Proofs/Erdos1036Problem.lean",
       "filename": "Erdos1036Problem.lean",
-      "lineCount": 160,
+      "lineCount": 202,
       "theoremCount": 7,
-      "axiomCount": 1,
+      "axiomCount": 2,
       "defCount": 6,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1036Problem.lean"
     },
@@ -1139,11 +1151,11 @@
     {
       "path": "Proofs/Erdos1040Problem.lean",
       "filename": "Erdos1040Problem.lean",
-      "lineCount": 577,
+      "lineCount": 621,
       "theoremCount": 21,
       "axiomCount": 4,
       "defCount": 19,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1040Problem.lean"
     },
@@ -1498,6 +1510,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1058Problem.lean"
+    },
+    {
+      "path": "Proofs/Erdos1059OQ02.lean",
+      "filename": "Erdos1059OQ02.lean",
+      "lineCount": 232,
+      "theoremCount": 7,
+      "axiomCount": 1,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1059OQ02.lean"
     },
     {
       "path": "Proofs/Erdos1059OQ03.lean",
@@ -2107,8 +2130,8 @@
     {
       "path": "Proofs/Erdos1098OQ04.lean",
       "filename": "Erdos1098OQ04.lean",
-      "lineCount": 135,
-      "theoremCount": 8,
+      "lineCount": 134,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-10.json
+++ b/src/data/research/problems/erdos-10.json
@@ -142,6 +142,7 @@
     "erdos-1057",
     "erdos-1058",
     "erdos-1059",
+    "erdos-1059-oq-02",
     "erdos-1059-oq-03",
     "erdos-1059-oq-05",
     "erdos-106",
@@ -793,6 +794,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021OQ01.lean"
     },
     {
+      "path": "Proofs/Erdos1021OQ01Aristotle.lean",
+      "filename": "Erdos1021OQ01Aristotle.lean",
+      "lineCount": 80,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 13,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021OQ01Aristotle.lean"
+    },
+    {
       "path": "Proofs/Erdos1021Problem.lean",
       "filename": "Erdos1021Problem.lean",
       "lineCount": 242,
@@ -1048,11 +1060,11 @@
     {
       "path": "Proofs/Erdos1036Problem.lean",
       "filename": "Erdos1036Problem.lean",
-      "lineCount": 160,
+      "lineCount": 202,
       "theoremCount": 7,
-      "axiomCount": 1,
+      "axiomCount": 2,
       "defCount": 6,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1036Problem.lean"
     },
@@ -1125,11 +1137,11 @@
     {
       "path": "Proofs/Erdos1040Problem.lean",
       "filename": "Erdos1040Problem.lean",
-      "lineCount": 577,
+      "lineCount": 621,
       "theoremCount": 21,
       "axiomCount": 4,
       "defCount": 19,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1040Problem.lean"
     },
@@ -1484,6 +1496,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1058Problem.lean"
+    },
+    {
+      "path": "Proofs/Erdos1059OQ02.lean",
+      "filename": "Erdos1059OQ02.lean",
+      "lineCount": 232,
+      "theoremCount": 7,
+      "axiomCount": 1,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1059OQ02.lean"
     },
     {
       "path": "Proofs/Erdos1059OQ03.lean",
@@ -2093,8 +2116,8 @@
     {
       "path": "Proofs/Erdos1098OQ04.lean",
       "filename": "Erdos1098OQ04.lean",
-      "lineCount": 135,
-      "theoremCount": 8,
+      "lineCount": 134,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-102-oq-03.json
+++ b/src/data/research/problems/erdos-102-oq-03.json
@@ -143,6 +143,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021OQ01.lean"
     },
     {
+      "path": "Proofs/Erdos1021OQ01Aristotle.lean",
+      "filename": "Erdos1021OQ01Aristotle.lean",
+      "lineCount": 80,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 13,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021OQ01Aristotle.lean"
+    },
+    {
       "path": "Proofs/Erdos1021Problem.lean",
       "filename": "Erdos1021Problem.lean",
       "lineCount": 242,

--- a/src/data/research/problems/erdos-1021-oq-01.json
+++ b/src/data/research/problems/erdos-1021-oq-01.json
@@ -99,6 +99,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021OQ01.lean"
     },
     {
+      "path": "Proofs/Erdos1021OQ01Aristotle.lean",
+      "filename": "Erdos1021OQ01Aristotle.lean",
+      "lineCount": 80,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 13,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021OQ01Aristotle.lean"
+    },
+    {
       "path": "Proofs/Erdos1021Problem.lean",
       "filename": "Erdos1021Problem.lean",
       "lineCount": 242,

--- a/src/data/research/problems/erdos-103-oq-01.json
+++ b/src/data/research/problems/erdos-103-oq-01.json
@@ -181,11 +181,11 @@
     {
       "path": "Proofs/Erdos1036Problem.lean",
       "filename": "Erdos1036Problem.lean",
-      "lineCount": 160,
+      "lineCount": 202,
       "theoremCount": 7,
-      "axiomCount": 1,
+      "axiomCount": 2,
       "defCount": 6,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1036Problem.lean"
     },

--- a/src/data/research/problems/erdos-1036-incomplete-01.json
+++ b/src/data/research/problems/erdos-1036-incomplete-01.json
@@ -62,6 +62,9 @@
     "erdos-1036"
   ],
   "relatedProofs": [
+    "erdos-1",
+    "erdos-10",
+    "erdos-103",
     "erdos-1036"
   ],
   "references": {

--- a/src/data/research/problems/erdos-1036-oq-01.json
+++ b/src/data/research/problems/erdos-1036-oq-01.json
@@ -79,11 +79,11 @@
     {
       "path": "Proofs/Erdos1036Problem.lean",
       "filename": "Erdos1036Problem.lean",
-      "lineCount": 160,
+      "lineCount": 202,
       "theoremCount": 7,
-      "axiomCount": 1,
+      "axiomCount": 2,
       "defCount": 6,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1036Problem.lean"
     }

--- a/src/data/research/problems/erdos-1040-oq-05.json
+++ b/src/data/research/problems/erdos-1040-oq-05.json
@@ -129,11 +129,11 @@
     {
       "path": "Proofs/Erdos1040Problem.lean",
       "filename": "Erdos1040Problem.lean",
-      "lineCount": 577,
+      "lineCount": 621,
       "theoremCount": 21,
       "axiomCount": 4,
       "defCount": 19,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1040Problem.lean"
     }

--- a/src/data/research/problems/erdos-105-oq-05.json
+++ b/src/data/research/problems/erdos-105-oq-05.json
@@ -74,6 +74,7 @@
     "erdos-1057",
     "erdos-1058",
     "erdos-1059",
+    "erdos-1059-oq-02",
     "erdos-1059-oq-03",
     "erdos-1059-oq-05"
   ],
@@ -273,6 +274,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1058Problem.lean"
+    },
+    {
+      "path": "Proofs/Erdos1059OQ02.lean",
+      "filename": "Erdos1059OQ02.lean",
+      "lineCount": 232,
+      "theoremCount": 7,
+      "axiomCount": 1,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1059OQ02.lean"
     },
     {
       "path": "Proofs/Erdos1059OQ03.lean",

--- a/src/data/research/problems/erdos-1059-oq-01.json
+++ b/src/data/research/problems/erdos-1059-oq-01.json
@@ -43,6 +43,7 @@
     "erdos-10",
     "erdos-105",
     "erdos-1059",
+    "erdos-1059-oq-02",
     "erdos-1059-oq-03",
     "erdos-1059-oq-05"
   ],
@@ -56,6 +57,17 @@
   "significance": 7,
   "tractability": 6,
   "leanFiles": [
+    {
+      "path": "Proofs/Erdos1059OQ02.lean",
+      "filename": "Erdos1059OQ02.lean",
+      "lineCount": 232,
+      "theoremCount": 7,
+      "axiomCount": 1,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1059OQ02.lean"
+    },
     {
       "path": "Proofs/Erdos1059OQ03.lean",
       "filename": "Erdos1059OQ03.lean",

--- a/src/data/research/problems/erdos-1059-oq-02.json
+++ b/src/data/research/problems/erdos-1059-oq-02.json
@@ -47,6 +47,7 @@
     "erdos-10",
     "erdos-105",
     "erdos-1059",
+    "erdos-1059-oq-02",
     "erdos-1059-oq-03",
     "erdos-1059-oq-05"
   ],
@@ -60,6 +61,17 @@
   "significance": 6,
   "tractability": 5,
   "leanFiles": [
+    {
+      "path": "Proofs/Erdos1059OQ02.lean",
+      "filename": "Erdos1059OQ02.lean",
+      "lineCount": 232,
+      "theoremCount": 7,
+      "axiomCount": 1,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1059OQ02.lean"
+    },
     {
       "path": "Proofs/Erdos1059OQ03.lean",
       "filename": "Erdos1059OQ03.lean",

--- a/src/data/research/problems/erdos-1059-oq-03.json
+++ b/src/data/research/problems/erdos-1059-oq-03.json
@@ -57,6 +57,7 @@
     "erdos-10",
     "erdos-105",
     "erdos-1059",
+    "erdos-1059-oq-02",
     "erdos-1059-oq-03",
     "erdos-1059-oq-05"
   ],
@@ -70,6 +71,17 @@
   "significance": 5,
   "tractability": 7,
   "leanFiles": [
+    {
+      "path": "Proofs/Erdos1059OQ02.lean",
+      "filename": "Erdos1059OQ02.lean",
+      "lineCount": 232,
+      "theoremCount": 7,
+      "axiomCount": 1,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1059OQ02.lean"
+    },
     {
       "path": "Proofs/Erdos1059OQ03.lean",
       "filename": "Erdos1059OQ03.lean",

--- a/src/data/research/problems/erdos-1059-oq-05.json
+++ b/src/data/research/problems/erdos-1059-oq-05.json
@@ -60,6 +60,7 @@
     "erdos-10",
     "erdos-105",
     "erdos-1059",
+    "erdos-1059-oq-02",
     "erdos-1059-oq-03",
     "erdos-1059-oq-05"
   ],
@@ -73,6 +74,17 @@
   "significance": 5,
   "tractability": 7,
   "leanFiles": [
+    {
+      "path": "Proofs/Erdos1059OQ02.lean",
+      "filename": "Erdos1059OQ02.lean",
+      "lineCount": 232,
+      "theoremCount": 7,
+      "axiomCount": 1,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1059OQ02.lean"
+    },
     {
       "path": "Proofs/Erdos1059OQ03.lean",
       "filename": "Erdos1059OQ03.lean",

--- a/src/data/research/problems/erdos-1059.json
+++ b/src/data/research/problems/erdos-1059.json
@@ -57,6 +57,7 @@
     "erdos-10",
     "erdos-105",
     "erdos-1059",
+    "erdos-1059-oq-02",
     "erdos-1059-oq-03",
     "erdos-1059-oq-05"
   ],
@@ -70,6 +71,17 @@
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
+    {
+      "path": "Proofs/Erdos1059OQ02.lean",
+      "filename": "Erdos1059OQ02.lean",
+      "lineCount": 232,
+      "theoremCount": 7,
+      "axiomCount": 1,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1059OQ02.lean"
+    },
     {
       "path": "Proofs/Erdos1059OQ03.lean",
       "filename": "Erdos1059OQ03.lean",

--- a/src/data/research/problems/erdos-109-oq-01.json
+++ b/src/data/research/problems/erdos-109-oq-01.json
@@ -200,8 +200,8 @@
     {
       "path": "Proofs/Erdos1098OQ04.lean",
       "filename": "Erdos1098OQ04.lean",
-      "lineCount": 135,
-      "theoremCount": 8,
+      "lineCount": 134,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-109.json
+++ b/src/data/research/problems/erdos-109.json
@@ -208,8 +208,8 @@
     {
       "path": "Proofs/Erdos1098OQ04.lean",
       "filename": "Erdos1098OQ04.lean",
-      "lineCount": 135,
-      "theoremCount": 8,
+      "lineCount": 134,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1098-oq-01-oq-01.json
+++ b/src/data/research/problems/erdos-1098-oq-01-oq-01.json
@@ -90,8 +90,8 @@
     {
       "path": "Proofs/Erdos1098OQ04.lean",
       "filename": "Erdos1098OQ04.lean",
-      "lineCount": 135,
-      "theoremCount": 8,
+      "lineCount": 134,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1098-oq-01.json
+++ b/src/data/research/problems/erdos-1098-oq-01.json
@@ -116,8 +116,8 @@
     {
       "path": "Proofs/Erdos1098OQ04.lean",
       "filename": "Erdos1098OQ04.lean",
-      "lineCount": 135,
-      "theoremCount": 8,
+      "lineCount": 134,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1098-oq-03.json
+++ b/src/data/research/problems/erdos-1098-oq-03.json
@@ -107,8 +107,8 @@
     {
       "path": "Proofs/Erdos1098OQ04.lean",
       "filename": "Erdos1098OQ04.lean",
-      "lineCount": 135,
-      "theoremCount": 8,
+      "lineCount": 134,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1098-oq-04.json
+++ b/src/data/research/problems/erdos-1098-oq-04.json
@@ -90,8 +90,8 @@
     {
       "path": "Proofs/Erdos1098OQ04.lean",
       "filename": "Erdos1098OQ04.lean",
-      "lineCount": 135,
-      "theoremCount": 8,
+      "lineCount": 134,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-156-oq-01.json
+++ b/src/data/research/problems/erdos-156-oq-01.json
@@ -73,6 +73,17 @@
   "tractability": 7,
   "leanFiles": [
     {
+      "path": "Proofs/Erdos156Aristotle.lean",
+      "filename": "Erdos156Aristotle.lean",
+      "lineCount": 99,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 12,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos156Aristotle.lean"
+    },
+    {
       "path": "Proofs/Erdos156OQ02.lean",
       "filename": "Erdos156OQ02.lean",
       "lineCount": 294,

--- a/src/data/research/problems/erdos-156-oq-02.json
+++ b/src/data/research/problems/erdos-156-oq-02.json
@@ -83,6 +83,17 @@
   "tractability": 6,
   "leanFiles": [
     {
+      "path": "Proofs/Erdos156Aristotle.lean",
+      "filename": "Erdos156Aristotle.lean",
+      "lineCount": 99,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 12,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos156Aristotle.lean"
+    },
+    {
       "path": "Proofs/Erdos156OQ02.lean",
       "filename": "Erdos156OQ02.lean",
       "lineCount": 294,

--- a/src/data/research/problems/erdos-156.json
+++ b/src/data/research/problems/erdos-156.json
@@ -74,6 +74,17 @@
   "tractability": 4,
   "leanFiles": [
     {
+      "path": "Proofs/Erdos156Aristotle.lean",
+      "filename": "Erdos156Aristotle.lean",
+      "lineCount": 99,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 12,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos156Aristotle.lean"
+    },
+    {
       "path": "Proofs/Erdos156OQ02.lean",
       "filename": "Erdos156OQ02.lean",
       "lineCount": 294,

--- a/src/data/research/problems/erdos-43-oq-05.json
+++ b/src/data/research/problems/erdos-43-oq-05.json
@@ -117,13 +117,24 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos432Problem.lean"
     },
     {
+      "path": "Proofs/Erdos433Aristotle.lean",
+      "filename": "Erdos433Aristotle.lean",
+      "lineCount": 158,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos433Aristotle.lean"
+    },
+    {
       "path": "Proofs/Erdos433Problem.lean",
       "filename": "Erdos433Problem.lean",
-      "lineCount": 315,
+      "lineCount": 399,
       "theoremCount": 6,
       "axiomCount": 4,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos433Problem.lean"
     },
@@ -181,6 +192,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos436Problem.lean"
+    },
+    {
+      "path": "Proofs/Erdos437Aristotle.lean",
+      "filename": "Erdos437Aristotle.lean",
+      "lineCount": 100,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 15,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos437Aristotle.lean"
     },
     {
       "path": "Proofs/Erdos437Problem.lean",

--- a/src/data/research/problems/erdos-43.json
+++ b/src/data/research/problems/erdos-43.json
@@ -97,13 +97,24 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos432Problem.lean"
     },
     {
+      "path": "Proofs/Erdos433Aristotle.lean",
+      "filename": "Erdos433Aristotle.lean",
+      "lineCount": 158,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos433Aristotle.lean"
+    },
+    {
       "path": "Proofs/Erdos433Problem.lean",
       "filename": "Erdos433Problem.lean",
-      "lineCount": 315,
+      "lineCount": 399,
       "theoremCount": 6,
       "axiomCount": 4,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos433Problem.lean"
     },
@@ -161,6 +172,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos436Problem.lean"
+    },
+    {
+      "path": "Proofs/Erdos437Aristotle.lean",
+      "filename": "Erdos437Aristotle.lean",
+      "lineCount": 100,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 15,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos437Aristotle.lean"
     },
     {
       "path": "Proofs/Erdos437Problem.lean",

--- a/src/data/research/problems/erdos-5.json
+++ b/src/data/research/problems/erdos-5.json
@@ -368,11 +368,11 @@
     {
       "path": "Proofs/Erdos511Problem.lean",
       "filename": "Erdos511Problem.lean",
-      "lineCount": 284,
+      "lineCount": 286,
       "theoremCount": 4,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos511Problem.lean"
     },

--- a/src/data/research/problems/erdos-69-oq-03.json
+++ b/src/data/research/problems/erdos-69-oq-03.json
@@ -118,6 +118,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos694Problem.lean"
     },
     {
+      "path": "Proofs/Erdos695Aristotle.lean",
+      "filename": "Erdos695Aristotle.lean",
+      "lineCount": 102,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 13,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos695Aristotle.lean"
+    },
+    {
       "path": "Proofs/Erdos695Problem.lean",
       "filename": "Erdos695Problem.lean",
       "lineCount": 252,

--- a/src/data/research/problems/erdos-695.json
+++ b/src/data/research/problems/erdos-695.json
@@ -65,6 +65,17 @@
   "tractability": 4,
   "leanFiles": [
     {
+      "path": "Proofs/Erdos695Aristotle.lean",
+      "filename": "Erdos695Aristotle.lean",
+      "lineCount": 102,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 13,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos695Aristotle.lean"
+    },
+    {
       "path": "Proofs/Erdos695Problem.lean",
       "filename": "Erdos695Problem.lean",
       "lineCount": 252,

--- a/src/data/research/problems/erdos-746-oq-04.json
+++ b/src/data/research/problems/erdos-746-oq-04.json
@@ -70,11 +70,11 @@
     {
       "path": "Proofs/Erdos746Problem.lean",
       "filename": "Erdos746Problem.lean",
-      "lineCount": 253,
+      "lineCount": 272,
       "theoremCount": 7,
-      "axiomCount": 1,
+      "axiomCount": 2,
       "defCount": 17,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos746Problem.lean"
     }

--- a/src/data/research/problems/erdos-8-oq-01.json
+++ b/src/data/research/problems/erdos-8-oq-01.json
@@ -349,9 +349,9 @@
     {
       "path": "Proofs/Erdos815Problem.lean",
       "filename": "Erdos815Problem.lean",
-      "lineCount": 241,
+      "lineCount": 255,
       "theoremCount": 3,
-      "axiomCount": 2,
+      "axiomCount": 3,
       "defCount": 8,
       "sorryCount": 0,
       "isAristotle": false,
@@ -389,6 +389,17 @@
       "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos817Problem.lean"
+    },
+    {
+      "path": "Proofs/Erdos818Aristotle.lean",
+      "filename": "Erdos818Aristotle.lean",
+      "lineCount": 104,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 14,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos818Aristotle.lean"
     },
     {
       "path": "Proofs/Erdos818Problem.lean",
@@ -655,13 +666,24 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos839Problem.lean"
     },
     {
+      "path": "Proofs/Erdos840Aristotle.lean",
+      "filename": "Erdos840Aristotle.lean",
+      "lineCount": 111,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 14,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos840Aristotle.lean"
+    },
+    {
       "path": "Proofs/Erdos840Problem.lean",
       "filename": "Erdos840Problem.lean",
-      "lineCount": 1,
-      "theoremCount": 0,
+      "lineCount": 230,
+      "theoremCount": 12,
       "axiomCount": 0,
-      "defCount": 0,
-      "sorryCount": 0,
+      "defCount": 11,
+      "sorryCount": 7,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos840Problem.lean"
     },

--- a/src/data/research/problems/fair-games-theorem-oq-01.json
+++ b/src/data/research/problems/fair-games-theorem-oq-01.json
@@ -44,7 +44,8 @@
   "relatedProofs": [
     "fair-games-theorem",
     "fair-games-theorem-oq-01",
-    "fair-games-theorem-oq-02"
+    "fair-games-theorem-oq-02",
+    "fair-games-theorem-oq-03"
   ],
   "references": {
     "papers": [],
@@ -89,6 +90,28 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FairGamesTheoremOQ02.lean"
+    },
+    {
+      "path": "Proofs/FairGamesTheoremOQ03.lean",
+      "filename": "FairGamesTheoremOQ03.lean",
+      "lineCount": 291,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 8,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FairGamesTheoremOQ03.lean"
+    },
+    {
+      "path": "Proofs/FairGamesTheoremOQ03Aristotle.lean",
+      "filename": "FairGamesTheoremOQ03Aristotle.lean",
+      "lineCount": 122,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 11,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FairGamesTheoremOQ03Aristotle.lean"
     }
   ]
 }

--- a/src/data/research/problems/fair-games-theorem-oq-02.json
+++ b/src/data/research/problems/fair-games-theorem-oq-02.json
@@ -56,7 +56,8 @@
   "relatedProofs": [
     "fair-games-theorem",
     "fair-games-theorem-oq-01",
-    "fair-games-theorem-oq-02"
+    "fair-games-theorem-oq-02",
+    "fair-games-theorem-oq-03"
   ],
   "references": {
     "papers": [],
@@ -100,6 +101,28 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FairGamesTheoremOQ02.lean"
+    },
+    {
+      "path": "Proofs/FairGamesTheoremOQ03.lean",
+      "filename": "FairGamesTheoremOQ03.lean",
+      "lineCount": 291,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 8,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FairGamesTheoremOQ03.lean"
+    },
+    {
+      "path": "Proofs/FairGamesTheoremOQ03Aristotle.lean",
+      "filename": "FairGamesTheoremOQ03Aristotle.lean",
+      "lineCount": 122,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 11,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FairGamesTheoremOQ03Aristotle.lean"
     }
   ]
 }

--- a/src/data/research/problems/feuerbachs-theorem-oq-01.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-01.json
@@ -115,6 +115,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FeuerbachsTheoremOQ02.lean"
     },
     {
+      "path": "Proofs/FeuerbachsTheoremOQ02Aristotle.lean",
+      "filename": "FeuerbachsTheoremOQ02Aristotle.lean",
+      "lineCount": 124,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 14,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FeuerbachsTheoremOQ02Aristotle.lean"
+    },
+    {
       "path": "Proofs/FeuerbachsTheoremOQ05.lean",
       "filename": "FeuerbachsTheoremOQ05.lean",
       "lineCount": 267,

--- a/src/data/research/problems/feuerbachs-theorem-oq-02.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-02.json
@@ -85,6 +85,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FeuerbachsTheoremOQ02.lean"
     },
     {
+      "path": "Proofs/FeuerbachsTheoremOQ02Aristotle.lean",
+      "filename": "FeuerbachsTheoremOQ02Aristotle.lean",
+      "lineCount": 124,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 14,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FeuerbachsTheoremOQ02Aristotle.lean"
+    },
+    {
       "path": "Proofs/FeuerbachsTheoremOQ05.lean",
       "filename": "FeuerbachsTheoremOQ05.lean",
       "lineCount": 267,

--- a/src/data/research/problems/feuerbachs-theorem-oq-03.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-03.json
@@ -108,6 +108,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FeuerbachsTheoremOQ02.lean"
     },
     {
+      "path": "Proofs/FeuerbachsTheoremOQ02Aristotle.lean",
+      "filename": "FeuerbachsTheoremOQ02Aristotle.lean",
+      "lineCount": 124,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 14,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FeuerbachsTheoremOQ02Aristotle.lean"
+    },
+    {
       "path": "Proofs/FeuerbachsTheoremOQ05.lean",
       "filename": "FeuerbachsTheoremOQ05.lean",
       "lineCount": 267,

--- a/src/data/research/problems/feuerbachs-theorem-oq-05.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-05.json
@@ -140,6 +140,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FeuerbachsTheoremOQ02.lean"
     },
     {
+      "path": "Proofs/FeuerbachsTheoremOQ02Aristotle.lean",
+      "filename": "FeuerbachsTheoremOQ02Aristotle.lean",
+      "lineCount": 124,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 14,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FeuerbachsTheoremOQ02Aristotle.lean"
+    },
+    {
       "path": "Proofs/FeuerbachsTheoremOQ05.lean",
       "filename": "FeuerbachsTheoremOQ05.lean",
       "lineCount": 267,

--- a/src/data/research/problems/kummer-theorem-oq-01.json
+++ b/src/data/research/problems/kummer-theorem-oq-01.json
@@ -70,7 +70,7 @@
     {
       "path": "Proofs/KummerTheoremOQ01.lean",
       "filename": "KummerTheoremOQ01.lean",
-      "lineCount": 105,
+      "lineCount": 109,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 1,
@@ -81,7 +81,7 @@
     {
       "path": "Proofs/KummerTheoremOQ01Aristotle.lean",
       "filename": "KummerTheoremOQ01Aristotle.lean",
-      "lineCount": 185,
+      "lineCount": 182,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/kummer-theorem-oq-02.json
+++ b/src/data/research/problems/kummer-theorem-oq-02.json
@@ -103,7 +103,7 @@
     {
       "path": "Proofs/KummerTheoremOQ01.lean",
       "filename": "KummerTheoremOQ01.lean",
-      "lineCount": 105,
+      "lineCount": 109,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 1,
@@ -114,7 +114,7 @@
     {
       "path": "Proofs/KummerTheoremOQ01Aristotle.lean",
       "filename": "KummerTheoremOQ01Aristotle.lean",
-      "lineCount": 185,
+      "lineCount": 182,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/kummer-theorem-oq-03.json
+++ b/src/data/research/problems/kummer-theorem-oq-03.json
@@ -72,7 +72,7 @@
     {
       "path": "Proofs/KummerTheoremOQ01.lean",
       "filename": "KummerTheoremOQ01.lean",
-      "lineCount": 105,
+      "lineCount": 109,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 1,
@@ -83,7 +83,7 @@
     {
       "path": "Proofs/KummerTheoremOQ01Aristotle.lean",
       "filename": "KummerTheoremOQ01Aristotle.lean",
-      "lineCount": 185,
+      "lineCount": 182,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/kummer-theorem.json
+++ b/src/data/research/problems/kummer-theorem.json
@@ -73,7 +73,7 @@
     {
       "path": "Proofs/KummerTheoremOQ01.lean",
       "filename": "KummerTheoremOQ01.lean",
-      "lineCount": 105,
+      "lineCount": 109,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 1,
@@ -84,7 +84,7 @@
     {
       "path": "Proofs/KummerTheoremOQ01Aristotle.lean",
       "filename": "KummerTheoremOQ01Aristotle.lean",
-      "lineCount": 185,
+      "lineCount": 182,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/partition-theorem-oq-01.json
+++ b/src/data/research/problems/partition-theorem-oq-01.json
@@ -95,7 +95,7 @@
     {
       "path": "Proofs/PartitionTheoremOQ04.lean",
       "filename": "PartitionTheoremOQ04.lean",
-      "lineCount": 255,
+      "lineCount": 287,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/partition-theorem-oq-03.json
+++ b/src/data/research/problems/partition-theorem-oq-03.json
@@ -86,7 +86,7 @@
     {
       "path": "Proofs/PartitionTheoremOQ04.lean",
       "filename": "PartitionTheoremOQ04.lean",
-      "lineCount": 255,
+      "lineCount": 287,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 4,


### PR DESCRIPTION
## Fix

Adds missing `leanFiles` entries and `relatedProofs` cross-references for 15 lean files that were merged to main but not yet reflected in the research problem JSON data.

## Evidence

**Before**: 91 research problem JSON files lacked entries for 15 lean files that exist on main  
**After**: All 15 files referenced with correct metadata (lineCount, sorryCount, theoremCount verified against source)

## Files Added

| Lean File | Type |
|-----------|------|
| AbelRuffiniOQ04OQ07.lean | Main proof |
| ArithmeticSeriesOQ04.lean | Main proof |
| Erdos1059OQ02.lean | Main proof |
| FairGamesTheoremOQ03.lean | Main proof |
| FeuerbachsTheoremOQ02Aristotle.lean | Aristotle companion |
| CayleyHamiltonReductionOQ02OQ01Aristotle.lean | Aristotle companion |
| Erdos1021OQ01Aristotle.lean | Aristotle companion |
| Erdos117OQ01Aristotle.lean | Aristotle companion |
| Erdos156Aristotle.lean | Aristotle companion |
| Erdos433Aristotle.lean | Aristotle companion |
| Erdos437Aristotle.lean | Aristotle companion |
| Erdos695Aristotle.lean | Aristotle companion |
| Erdos818Aristotle.lean | Aristotle companion |
| Erdos840Aristotle.lean | Aristotle companion |
| FairGamesTheoremOQ03Aristotle.lean | Aristotle companion |

---
Automated fix by lean-mechanic agent.