### PR TITLE
Fix: partition-theorem-oq-04 sorryCount stale after PR #9083

### DIFF
--- a/src/data/research/problems/partition-theorem-oq-04.json
+++ b/src/data/research/problems/partition-theorem-oq-04.json
@@ -113,11 +113,11 @@
     {
       "path": "Proofs/PartitionTheoremOQ04.lean",
       "filename": "PartitionTheoremOQ04.lean",
-      "lineCount": 255,
+      "lineCount": 286,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 3,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PartitionTheoremOQ04.lean"
     }


### PR DESCRIPTION
## Fix

Correct stale metadata in `partition-theorem-oq-04.json` for `PartitionTheoremOQ04.lean`.

## Evidence

PR #9083 (_Research: partition-theorem-oq-04 — prove glaisherBwd_glaisherFwdPart_) reduced the sorry count from 3 to 2 and expanded the file from 255 to 286 lines, but only touched `PartitionTheoremOQ04.lean` and `aristotle-jobs.json` — the research problem JSON was not updated.

**Before**: `sorryCount: 3`, `lineCount: 255`  
**After**: `sorryCount: 2`, `lineCount: 286`

Verification:
- `grep -c 'sorry' proofs/Proofs/PartitionTheoremOQ04.lean` → 2 (lines 276 and 284)
- `wc -l proofs/Proofs/PartitionTheoremOQ04.lean` → 286

---
Automated fix by lean-mechanic agent.