### PR TITLE
Fix: count True stubs as sorries (lebesgue-measure-oq-03, erdos-606-oq-03)

### DIFF
--- a/src/data/proofs/erdos-606-oq-03/meta.json
+++ b/src/data/proofs/erdos-606-oq-03/meta.json
@@ -17,10 +17,10 @@
       "research"
     ],
     "badge": "wip",
-    "sorries": 0,
+    "sorries": 1,
     "axiomCount": 0,
     "lineCount": 98,
-    "assumptions": "0 axioms, 0 sorries. WARNING: general_position_count proves True (placeholder). Sylvester-Gallai, Green-Tao, and Motzkin are mentioned in docstring comments but not axiomatized — they do not contribute to axiomCount.",
+    "assumptions": "0 axioms. 1 True-stub placeholder counted as sorry: general_position_count (line 42, proves True). Sylvester-Gallai, Green-Tao, and Motzkin are mentioned in docstring comments but not axiomatized — they do not contribute to axiomCount.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "originalContributions": [

--- a/src/data/proofs/lebesgue-measure-oq-03/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-03/meta.json
@@ -15,10 +15,10 @@
       "research"
     ],
     "badge": "wip",
-    "sorries": 0,
+    "sorries": 2,
     "axiomCount": 0,
     "lineCount": 132,
-    "assumptions": "0 axioms, 0 sorries. 2 True-stub placeholder theorems (ball_volume_vanishes, concentration_sketch). Orthonormal separation and framework theorems fully proved.",
+    "assumptions": "0 axioms. 2 True-stub placeholder theorems counted as sorries: ball_volume_vanishes (line 103) and concentration_sketch (line 112). Orthonormal separation and framework theorems fully proved.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "originalContributions": [


### PR DESCRIPTION
## Fix

Two gallery proofs had `sorries: 0` but contain True-stub placeholder theorems that represent unproven content.

## Evidence

**lebesgue-measure-oq-03** (`Proofs/LebesgueMeasureOQ03.lean`):
- Line 103: `theorem ball_volume_vanishes : True := trivial`
- Line 112: `theorem concentration_sketch : True := trivial`

**erdos-606-oq-03** (`Proofs/Erdos606OQ03.lean`):
- Line 42: `theorem general_position_count (n d : ℕ) : True := trivial`

**Before**:
- `lebesgue-measure-oq-03`: `sorries: 0`
- `erdos-606-oq-03`: `sorries: 0`

**After**:
- `lebesgue-measure-oq-03`: `sorries: 2` (both True stubs)
- `erdos-606-oq-03`: `sorries: 1` (one True stub)

The `wip` badge is already correct for both proofs — no overclaiming was occurring. This fix ensures the `sorries` count accurately reflects incompleteness.

The `assumptions` field in both meta.json files was updated to document the True stubs clearly.

Closes #9267
Closes #9270

---
Automated fix by lean-mechanic agent.