### PR TITLE
Fix: prove formA_decomposition_unique in Erdos1065BatemanHorn (0 sorries)

### DIFF
--- a/proofs/Proofs/Erdos1065BatemanHorn.lean
+++ b/proofs/Proofs/Erdos1065BatemanHorn.lean
@@ -1,6 +1,7 @@
 import Mathlib.Data.Nat.Prime.Basic
 import Mathlib.Data.Set.Finite.Basic
 import Mathlib.Data.Nat.Basic
+import Mathlib.NumberTheory.Padics.PadicVal.Basic
 import Mathlib.Tactic
 
 /-
@@ -81,13 +82,22 @@ theorem formA_decomposition_unique {p k₁ k₂ q₁ q₂ : ℕ}
   -- q₁ and q₂ are odd (primes ≠ 2)
   have hq1_odd : ¬ 2 ∣ q₁ := by
     intro h
-    exact hq1_ne2 (hq1.eq_one_or_self_of_dvd 2 h |>.resolve_left (by norm_num))
+    exact hq1_ne2 (hq1.eq_one_or_self_of_dvd 2 h |>.resolve_left (by norm_num) |>.symm)
   have hq2_odd : ¬ 2 ∣ q₂ := by
     intro h
-    exact hq2_ne2 (hq2.eq_one_or_self_of_dvd 2 h |>.resolve_left (by norm_num))
-  sorry -- Requires 2-adic valuation argument: v₂(2^k·q) = k when q is odd,
-        -- so k₁ = k₂ from heq, then q₁ = q₂ by cancellation.
-        -- Aristotle candidate for companion file.
+    exact hq2_ne2 (hq2.eq_one_or_self_of_dvd 2 h |>.resolve_left (by norm_num) |>.symm)
+  -- Use 2-adic valuation: v₂(2^k · q) = k when q is odd
+  haveI : Fact (Nat.Prime 2) := ⟨by norm_num⟩
+  have hv1 : padicValNat 2 (2 ^ k₁ * q₁) = k₁ := by
+    rw [padicValNat.mul (pow_ne_zero k₁ two_ne_zero) hq1.ne_zero,
+        padicValNat.prime_pow, padicValNat.eq_zero_of_not_dvd hq1_odd, add_zero]
+  have hv2 : padicValNat 2 (2 ^ k₂ * q₂) = k₂ := by
+    rw [padicValNat.mul (pow_ne_zero k₂ two_ne_zero) hq2.ne_zero,
+        padicValNat.prime_pow, padicValNat.eq_zero_of_not_dvd hq2_odd, add_zero]
+  have hk : k₁ = k₂ := by
+    have hpv := congr_arg (padicValNat 2) heq
+    rw [hv1, hv2] at hpv; exact hpv
+  exact ⟨hk, Nat.eq_of_mul_eq_mul_left (pow_pos (by norm_num : 0 < 2) k₂) (hk ▸ heq)⟩
 
 -- ## Verified Examples: Form A with specific k values
 
@@ -245,14 +255,8 @@ theorem batemanHorn_k1_iff_safePrimes :
     Set.Infinite {p : ℕ | IsFormAWithK 1 p} ↔
     Set.Infinite {p : ℕ | IsSafePrime p} := by
   constructor
-  · intro h
-    convert h using 1
-    ext p
-    exact (safePrime_iff_formAK1 p).symm
-  · intro h
-    convert h using 1
-    ext p
-    exact safePrime_iff_formAK1 p
+  · intro h; exact h.mono (fun p hp => (safePrime_iff_formAK1 p).mpr hp)
+  · intro h; exact h.mono (fun p hp => (safePrime_iff_formAK1 p).mp hp)
 
 /-- BH for any single k implies infinitely many Form A primes overall. -/
 theorem batemanHorn_implies_formA_infinite (k : ℕ) :

--- a/src/data/proofs/erdos-1065-oq-05/meta.json
+++ b/src/data/proofs/erdos-1065-oq-05/meta.json
@@ -18,7 +18,7 @@
             "bateman-horn",
             "research"
         ],
-        "sorries": 1,
+        "sorries": 0,
         "sourceUrl": "https://erdosproblems.com/1065",
         "erdosUrl": "https://erdosproblems.com/1065",
         "mathlibDependencies": [
@@ -54,8 +54,8 @@
             "Bateman-Horn conjecture background"
         ],
         "axiomCount": 1,
-        "assumptions": "1 axiom: batemanHorn_formAWithK_infinite (each k-layer of Form A primes is infinite — the BH conjecture prediction). 1 sorry: formA_decomposition_unique (uniqueness of (k,q) decomposition, provable via 2-adic valuation).",
-        "lineCount": 271,
+        "assumptions": "1 axiom: batemanHorn_formAWithK_infinite (each k-layer of Form A primes is infinite — the BH conjecture prediction). 0 sorries: formA_decomposition_unique was proved via 2-adic valuation (padicValNat 2 (2^k * q) = k when q is odd).",
+        "lineCount": 275,
         "relatedProblems": [
             {
                 "id": "erdos-1065",
@@ -86,7 +86,7 @@
             "title": "Decomposition Uniqueness",
             "startLine": 77,
             "endLine": 100,
-            "summary": "States that if p = 2^{k₁}q₁+1 = 2^{k₂}q₂+1 with q₁,q₂ odd primes, then k₁=k₂ and q₁=q₂. Currently sorry — requires 2-adic valuation argument.",
+            "summary": "Proves that if p = 2^{k₁}q₁+1 = 2^{k₂}q₂+1 with q₁,q₂ odd primes, then k₁=k₂ and q₁=q₂. Proved via padicValNat: v₂(2^k·q) = k when q is odd.",
             "mathContext": "$v_2(2^k q) = k$ when $q$ is odd, so $2^{k_1} q_1 = 2^{k_2} q_2$ with $q_i$ odd implies $k_1 = k_2$."
         },
         {
@@ -140,7 +140,7 @@
         }
     ],
     "leanFile": {
-        "lineCount": 271,
+        "lineCount": 275,
         "structureCount": 0,
         "axiomCount": 1,
         "theoremCount": 24,
@@ -152,6 +152,7 @@
             "Mathlib.Data.Nat.Prime.Basic",
             "Mathlib.Data.Set.Finite.Basic",
             "Mathlib.Data.Nat.Basic",
+            "Mathlib.NumberTheory.Padics.PadicVal.Basic",
             "Mathlib.Tactic"
         ],
         "opens": [],
@@ -178,8 +179,8 @@
         },
         {
             "name": "formA_decomposition_unique",
-            "type": "sorry",
-            "description": "Uniqueness of (k,q) decomposition when q is odd prime (1 sorry)"
+            "type": "verified",
+            "description": "Uniqueness of (k,q) decomposition when q is odd prime — proved via 2-adic valuation"
         },
         {
             "name": "batemanHorn_formAWithK_infinite",


### PR DESCRIPTION
## Fix

Proves the 1 remaining sorry in `Erdos1065BatemanHorn.lean` using the 2-adic valuation.

## Evidence

**Before**: `formA_decomposition_unique` had a sorry with comment "Requires 2-adic valuation argument"

**After**: Proved using `padicValNat`:
- `padicValNat 2 (2^k · q) = k` when `q` is odd (via `padicValNat.mul` + `padicValNat.prime_pow` + `padicValNat.eq_zero_of_not_dvd`)
- From `2^k₁·q₁ = 2^k₂·q₂`, taking 2-adic valuations gives `k₁ = k₂`
- Then `q₁ = q₂` by `Nat.eq_of_mul_eq_mul_left`

Also fixes:
- `.symm` regressions in `hq1_odd`/`hq2_odd` (Or direction mismatch)
- `batemanHorn_k1_iff_safePrimes` simplified using `Set.Infinite.mono`

**Meta.json**: sorries 1→0, updated assumptions, added padicValNat import, updated sections.

This replaces the conflicting PR #9225 (`work/erdos-1065-oq-06-fix`) which contained the same proof but had merge conflicts from other research branch changes.

---
Automated fix by lean-mechanic agent.