### PR TITLE
feat: prove 4 sorrys in Erdos678Problem, fix compilation

### DIFF
--- a/proofs/Proofs/Erdos678Problem.lean
+++ b/proofs/Proofs/Erdos678Problem.lean
@@ -38,38 +38,58 @@ open Finset Nat
 
 /-- The LCM of consecutive integers from n+1 to n+k -/
 def intervalLcm (n k : ℕ) : ℕ :=
-  (Finset.range k).fold lcm 1 (fun i => n + 1 + i)
+  (Finset.range k).fold Nat.lcm 1 (fun i => n + 1 + i)
 
 /-- Alternative definition using Finset.Icc -/
 def intervalLcm' (n k : ℕ) : ℕ :=
-  (Finset.Icc (n + 1) (n + k)).fold lcm 1 id
+  (Finset.Icc (n + 1) (n + k)).fold Nat.lcm 1 id
 
 /-- The two definitions agree -/
 theorem intervalLcm_eq_intervalLcm' (n k : ℕ) (hk : k ≥ 1) :
     intervalLcm n k = intervalLcm' n k := by
-  sorry
+  simp only [intervalLcm, intervalLcm']
+  have himg : (Finset.range k).image (fun i => n + 1 + i) = Finset.Icc (n + 1) (n + k) := by
+    ext x
+    simp only [Finset.mem_image, Finset.mem_range, Finset.mem_Icc]
+    constructor
+    · rintro ⟨i, hi, rfl⟩; omega
+    · intro ⟨h1, h2⟩; exact ⟨x - (n + 1), by omega, by omega⟩
+  have hinj : Set.InjOn (fun i => n + 1 + i) (Finset.range k) := by
+    intro a _ b _ h
+    have h' : n + 1 + a = n + 1 + b := h
+    omega
+  conv_rhs => rw [← himg, Finset.fold_image hinj]
+  simp only [Function.comp, id]
 
 /-! ## Basic Properties of Interval LCM -/
 
 /-- LCM of empty interval is 1 -/
 theorem intervalLcm_zero (n : ℕ) : intervalLcm n 0 = 1 := by
-  unfold intervalLcm
-  simp [Finset.fold_empty]
+  simp [intervalLcm]
 
 /-- LCM of single element is that element -/
 theorem intervalLcm_one (n : ℕ) : intervalLcm n 1 = n + 1 := by
-  unfold intervalLcm
-  simp [Finset.range_one, Finset.fold_singleton]
+  simp [intervalLcm, Finset.range_succ,
+    Finset.fold_insert Finset.not_mem_range_self]
 
 /-- LCM increases when interval extends -/
 theorem intervalLcm_mono_right (n k : ℕ) :
     intervalLcm n k ∣ intervalLcm n (k + 1) := by
-  sorry
+  simp only [intervalLcm, Finset.range_succ,
+    Finset.fold_insert Finset.not_mem_range_self]
+  exact Nat.dvd_lcm_right _ _
 
 /-- Each element divides the interval LCM -/
 theorem dvd_intervalLcm (n k i : ℕ) (hi : i < k) :
     (n + 1 + i) ∣ intervalLcm n k := by
-  sorry
+  induction k with
+  | zero => omega
+  | succ k ih =>
+    simp only [intervalLcm, Finset.range_succ,
+      Finset.fold_insert Finset.not_mem_range_self]
+    rcases Nat.lt_succ_iff.mp hi |>.lt_or_eq with h | h
+    · exact Nat.dvd_trans (ih h) (Nat.dvd_lcm_right _ _)
+    · exact h ▸ Nat.dvd_lcm_left _ _
 
 /-! ## The Erdős Comparison Property -/
 
@@ -95,14 +115,6 @@ theorem selfridge_example_2 : erdosLcmComparison 132 139 7 := by
 
 /-! ## Computing Specific LCM Values -/
 
-/-- M(96,7) = lcm{97,98,99,100,101,102,103} -/
-theorem intervalLcm_96_7 : intervalLcm 96 7 = 1073741700 := by
-  native_decide
-
-/-- M(104,8) = lcm{105,106,107,108,109,110,111,112} -/
-theorem intervalLcm_104_8 : intervalLcm 104 8 = 786145080 := by
-  native_decide
-
 /-- Verification that M(96,7) > M(104,8) -/
 theorem lcm_comparison_96_104 : intervalLcm 96 7 > intervalLcm 104 8 := by
   native_decide
@@ -126,7 +138,11 @@ theorem cambie_2024 :
 theorem prime_power_divides_intervalLcm (n k p a : ℕ) (hp : p.Prime)
     (hpa : p ^ a ∈ Finset.Icc (n + 1) (n + k)) :
     p ^ a ∣ intervalLcm n k := by
-  sorry
+  obtain ⟨h1, h2⟩ := Finset.mem_Icc.mp hpa
+  have hi : p ^ a - (n + 1) < k := by omega
+  have heq : n + 1 + (p ^ a - (n + 1)) = p ^ a := by omega
+  calc p ^ a = n + 1 + (p ^ a - (n + 1)) := heq.symm
+    _ ∣ intervalLcm n k := dvd_intervalLcm n k _ hi
 
 /-- Key insight: an interval can "skip" a prime power -/
 theorem interval_skip_prime_power (n k p : ℕ) (hp : p.Prime)
@@ -150,8 +166,9 @@ theorem intervalLcm_chebyshev_upper (n k : ℕ) :
 /-! ## Erdős's Observations -/
 
 /-- The minimal n for which comparison holds grows faster than linearly -/
-def minimalN (k : ℕ) : ℕ :=
-  Nat.find (⟨96, 104, by sorry⟩ : ∃ n m : ℕ, erdosLcmComparison n m k)
+noncomputable def minimalN (k : ℕ) : ℕ :=
+  haveI := Classical.decPred (fun n => ∃ m : ℕ, erdosLcmComparison n m k)
+  Nat.find (⟨96, 104, by sorry⟩ : ∃ n, ∃ m : ℕ, erdosLcmComparison n m k)
 
 /-- Erdős proved n_k/k → ∞ -/
 theorem erdos_growth_rate : ∀ C : ℕ, ∃ K : ℕ, ∀ k ≥ K, minimalN k > C * k := by

--- a/research/problems/erdos-678-incomplete-01/knowledge.md
+++ b/research/problems/erdos-678-incomplete-01/knowledge.md
@@ -1,0 +1,62 @@
+# Knowledge: Erdős 678 - LCM of Consecutive Integer Intervals
+
+## Problem Summary
+
+Erdős Problem #678: Let M(n,k) = lcm{n+1, ..., n+k}. Are there infinitely many m,n,k ≥ 3
+with m ≥ n+k such that M(n,k) > M(m,k+1)?
+
+Answer: YES (Stijn Cambie, 2024). The formalization has 7 remaining sorrys (down from 11,
+file now compiles).
+
+## Session 2026-04-04 (Session 1) - Fix compilation + prove 4 sorrys
+
+**Mode**: FRESH
+**Outcome**: progress
+
+### What I Did
+- Fixed compilation: file previously failed to build due to ambiguous `lcm` in
+  `(Finset.range k).fold lcm 1 (fun i => n+1+i)`. With `open Finset Nat`, Lean couldn't
+  resolve `lcm`. Fixed by using `Nat.lcm` explicitly.
+- Proved `intervalLcm_eq_intervalLcm'`: uses `Finset.fold_image` with bijection
+  `(fun i => n+1+i) : range k → Icc (n+1) (n+k)`, proved via `ext; simp; omega`
+- Proved `intervalLcm_mono_right`: `range k ⊆ range (k+1)` via `range_succ` + `fold_insert`
+  → `intervalLcm n (k+1) = Nat.lcm (n+k+1) (intervalLcm n k)` → `Nat.dvd_lcm_right`
+- Proved `dvd_intervalLcm`: induction on k, using `fold_insert` + `dvd_lcm_{left,right}`
+- Proved `prime_power_divides_intervalLcm`: direct from `dvd_intervalLcm` via bound arithmetic
+- Removed wrong expected values: `intervalLcm_96_7 = 1073741700` and `intervalLcm_104_8 = 786145080`
+  were WRONG (file never compiled, these were never verified). Actual values:
+  - `intervalLcm 96 7 = lcm(97..103) = 8,321,670,749,700` (not 1,073,741,700)
+  - `intervalLcm 104 8 = lcm(105..112) ≈ 3,803,928,503,760`
+- Fixed `minimalN` def: added `noncomputable` + `Classical.decPred` to fix typeclass error
+
+### Key Findings
+- `intervalLcm_chebyshev_upper` (M(n,k) ≤ 4^k) is **FALSE as stated** for n > 0:
+  M(96, 7) ≈ 8.3 × 10^12 ≫ 4^7 = 16384. True only for n=0 (i.e., lcm(1..k) ≤ 4^k).
+- Key fold manipulation pattern: `range_succ` + `fold_insert not_mem_range_self` converts
+  `intervalLcm n (k+1)` to `Nat.lcm (n+k+1) (intervalLcm n k)`.
+- `Finset.fold_image` signature: `(image g s).fold op b f = s.fold op b (f ∘ g)` when g injOn s.
+  Use `conv_rhs` to apply it to the RHS of an equality.
+
+### Files Modified
+- `proofs/Proofs/Erdos678Problem.lean`: fixed compilation, proved 4 sorrys (11→7)
+
+### PR
+- https://github.com/rjwalters/lean-genius/pull/9294
+
+### Remaining 7 Sorrys
+
+| Sorry | Why blocked |
+|-------|-------------|
+| `erdos_678_infinitely_many` | Needs Cambie 2024 proof |
+| `cambie_2024` | Needs Cambie 2024 proof |
+| `interval_skip_prime_power` | Complex prime power analysis |
+| `intervalLcm_growth` | Needs Chebyshev-type theorem |
+| `intervalLcm_chebyshev_upper` | FALSE as stated (should be restricted to n=0) |
+| `minimalN` existence | Needs k ≥ 7 existence for all large k |
+| `erdos_growth_rate` | Needs Erdős result on growth of minimal n |
+
+### Next Steps
+1. Fix `intervalLcm_chebyshev_upper` statement to `n = 0` version, then prove via
+   `Nat.centralBinom` or prime counting bounds
+2. Attempt `interval_skip_prime_power` — prime power gap analysis in intervals
+3. `erdos_678_infinitely_many` is OPEN (Cambie 2024 not yet in Mathlib)


### PR DESCRIPTION
## Summary

- **Fixed compilation**: file previously failed to build due to ambiguous `lcm` identifier (with `open Finset Nat`, Lean couldn't resolve `lcm` in fold expressions). Fixed by using `Nat.lcm` explicitly.
- **Proved 4 sorrys** (11 → 7 sorrys, file now builds for the first time):
  - `intervalLcm_eq_intervalLcm'`: uses `Finset.fold_image` + `ext`/`simp`/`omega` for the image equality
  - `intervalLcm_mono_right`: `Finset.range_succ` + `fold_insert` + `Nat.dvd_lcm_right`
  - `dvd_intervalLcm`: induction + `fold_insert` + `dvd_lcm_{left,right}`
  - `prime_power_divides_intervalLcm`: derived from `dvd_intervalLcm`
- **Fixed wrong expected values**: removed `intervalLcm_96_7` and `intervalLcm_104_8` whose values (1073741700 and 786145080) were incorrect — the file never compiled so they were never verified. Preserved `lcm_comparison_96_104` via `native_decide`.
- **Fixed `minimalN` definition**: added `noncomputable` + classical decidability to resolve typeclass synthesis failure.

## Remaining 7 sorrys

| Sorry | Why blocked |
|-------|-------------|
| `erdos_678_infinitely_many` | Needs Cambie 2024 result |
| `cambie_2024` | Needs Cambie 2024 result |
| `interval_skip_prime_power` | Complex prime power analysis |
| `intervalLcm_growth` | Needs PNT/Chebyshev |
| `intervalLcm_chebyshev_upper` | FALSE as stated (lcm(97..103) ≫ 4^7) |
| `minimalN` existence | Needs k ≥ 7 case from Cambie |
| `erdos_growth_rate` | Needs Erdős result |

Note: `intervalLcm_chebyshev_upper` (`M(n,k) ≤ 4^k`) is FALSE for n > 0 and large k (e.g., `intervalLcm 96 7 = lcm(97..103) ≈ 8.3 × 10¹²` ≫ `4^7 = 16384`).

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.Erdos678Problem` succeeds (3060+ jobs)
- [x] `selfridge_example_1` and `selfridge_example_2` verified by `native_decide`
- [x] `lcm_comparison_96_104` verified by `native_decide`

🤖 Generated with [Claude Code](https://claude.com/claude-code)