### PR TITLE
Enrich friendship-theorem-oq-03: 8 annotations, line numbers, cross-refs

### DIFF
--- a/src/data/proofs/friendship-theorem-oq-03/annotations.json
+++ b/src/data/proofs/friendship-theorem-oq-03/annotations.json
@@ -1,100 +1,190 @@
-{
-  "annotations": [
-    {
-      "id": "ann-open-question",
-      "proofId": "friendship-theorem-oq-03",
-      "range": { "startLine": 1, "endLine": 81 },
-      "type": "context",
-      "title": "Open Question: Does the Friendship Theorem Generalize to Hypergraphs?",
-      "content": "The file header poses and immediately answers the central question: does the Friendship Theorem of Erdős–Rényi–Sós (1966) extend to 3-uniform hypergraphs? For graphs (k=2), the theorem says every 'friendship graph' (every pair shares exactly one common neighbor) must have a universal vertex — a 'politician' who is friends with everyone. The docstring explains that for k=3, the Fano plane is a clean constructive counterexample: 7 vertices with 7 triples where every pair is in exactly one triple, but each vertex is in only 3 of the 7 triples. The mathematical background section includes the Fano plane's incidence diagram and the counting argument showing why no vertex can be universal (degree = (n-1)/2 grows slower than triple count n(n-1)/6).",
-      "mathContext": "A 3-uniform **friendship hypergraph** satisfies: $\\forall u \\neq v,\\, |\\{e \\in E : u \\in e \\wedge v \\in e\\}| = 1$. A **universal vertex** $c$ satisfies $\\forall e \\in E, c \\in e$. For the Fano plane: $n=7$, degree $= (7-1)/2 = 3$, and total triples $= 7$. Since $3 < 7$, no vertex is universal.",
-      "significance": "context",
-      "relatedConcepts": ["friendship theorem", "k-uniform hypergraphs", "Steiner triple systems", "Fano plane", "projective planes"],
-      "prerequisites": ["graph theory: Friendship Theorem and windmill graphs", "hypergraph theory basics", "finite geometry"]
+[
+  {
+    "id": "ann-open-question",
+    "proofId": "friendship-theorem-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 81
     },
-    {
-      "id": "ann-definitions",
-      "proofId": "friendship-theorem-oq-03",
-      "range": { "startLine": 83, "endLine": 113 },
-      "type": "definition",
-      "title": "Core Definitions: 3-Uniform Friendship Hypergraphs",
-      "content": "`Hypergraph3 V` is a structure holding a `Finset (Finset V)` of edges, each required to have cardinality 3 (the `uniform` field). `IsFriendship3` states the friendship property: for every pair of distinct vertices u ≠ v, the filter of edges containing both u and v has cardinality exactly 1. `IsUniversalVertex3 H c` says vertex c belongs to every edge of H — this is the 'politician' property. `vertexDegree H v` counts the edges containing v. These four definitions form the complete interface for the counterexample proof.",
-      "mathContext": "$\\text{Hypergraph3}(V) = \\{E \\subseteq \\binom{V}{3}\\}$. Friendship: $\\forall u \\neq v,\\, |\\{e \\in E : u,v \\in e\\}| = 1$. Universal: $\\forall e \\in E,\\, c \\in e$. Degree: $\\deg(v) = |\\{e \\in E : v \\in e\\}|$.",
-      "significance": "key",
-      "relatedConcepts": ["Finset cardinality", "hypergraph uniformity", "friendship property", "politician vertex"],
-      "prerequisites": ["Lean 4: structures and fields", "Finset.filter and Finset.card", "type classes: DecidableEq, Fintype"]
+    "type": "context",
+    "title": "Open Question: Does the Friendship Theorem Generalize to Hypergraphs?",
+    "content": "The file header poses and immediately answers the central question: does the Friendship Theorem of Erd\u0151s\u2013R\u00e9nyi\u2013S\u00f3s (1966) extend to 3-uniform hypergraphs? For graphs (k=2), the theorem says every 'friendship graph' (every pair shares exactly one common neighbor) must have a universal vertex \u2014 a 'politician' who is friends with everyone. The docstring explains that for k=3, the Fano plane is a clean constructive counterexample: 7 vertices with 7 triples where every pair is in exactly one triple, but each vertex is in only 3 of the 7 triples. The mathematical background section includes the Fano plane's incidence diagram and the counting argument showing why no vertex can be universal (degree = (n-1)/2 grows slower than triple count n(n-1)/6).",
+    "mathContext": "A 3-uniform **friendship hypergraph** satisfies: $\\forall u \\neq v,\\, |\\{e \\in E : u \\in e \\wedge v \\in e\\}| = 1$. A **universal vertex** $c$ satisfies $\\forall e \\in E, c \\in e$. For the Fano plane: $n=7$, degree $= (7-1)/2 = 3$, and total triples $= 7$. Since $3 < 7$, no vertex is universal.",
+    "significance": "context",
+    "relatedConcepts": [
+      "friendship theorem",
+      "k-uniform hypergraphs",
+      "Steiner triple systems",
+      "Fano plane",
+      "projective planes"
+    ],
+    "prerequisites": [
+      "graph theory: Friendship Theorem and windmill graphs",
+      "hypergraph theory basics",
+      "finite geometry"
+    ]
+  },
+  {
+    "id": "ann-definitions",
+    "proofId": "friendship-theorem-oq-03",
+    "range": {
+      "startLine": 83,
+      "endLine": 113
     },
-    {
-      "id": "ann-fano-construction",
-      "proofId": "friendship-theorem-oq-03",
-      "range": { "startLine": 115, "endLine": 151 },
-      "type": "definition",
-      "title": "The Fano Plane: Explicit Construction in Lean 4",
-      "content": "The Fano plane PG(2,2) is constructed as a `Hypergraph3 (Fin 7)`. The `triple` helper builds a 3-element Finset from three `Fin 7` values. `fanoEdges` explicitly lists all 7 triples matching the classical incidence structure: {0,1,3}, {1,2,4}, {2,3,5}, {3,4,6}, {4,5,0}, {5,6,1}, {6,0,2}. The `fanoPlane.uniform` proof uses `rcases` to enumerate all 7 edges and then `decide` to verify each has cardinality 3. The 7 triples correspond to the 7 lines of PG(2,2): each pair of points determines a unique line, matching the projective plane axioms over GF(2).",
-      "mathContext": "The Fano plane $\\text{PG}(2,2)$: points $= \\mathbb{F}_2^3 \\setminus \\{0\\}$ (7 nonzero vectors), lines $=$ 1-dimensional subspaces of $\\mathbb{F}_2^3$ (7 lines). In coordinates: $\\{(1,0,0),(0,1,0),(1,1,0)\\} \\leftrightarrow \\{0,1,3\\}$ in $\\text{Fin}\\,7$. It is the unique $\\text{STS}(7)$: the unique Steiner triple system of order 7.",
-      "significance": "key",
-      "relatedConcepts": ["projective plane PG(2,2)", "Steiner triple system STS(7)", "finite fields GF(2)", "combinatorial design"],
-      "prerequisites": ["finite geometry: projective planes", "combinatorial designs: Steiner triple systems", "Lean 4: Finset construction"]
+    "type": "definition",
+    "title": "Core Definitions: 3-Uniform Friendship Hypergraphs",
+    "content": "`Hypergraph3 V` is a structure holding a `Finset (Finset V)` of edges, each required to have cardinality 3 (the `uniform` field). `IsFriendship3` states the friendship property: for every pair of distinct vertices u \u2260 v, the filter of edges containing both u and v has cardinality exactly 1. `IsUniversalVertex3 H c` says vertex c belongs to every edge of H \u2014 this is the 'politician' property. `vertexDegree H v` counts the edges containing v. These four definitions form the complete interface for the counterexample proof.",
+    "mathContext": "$\\text{Hypergraph3}(V) = \\{E \\subseteq \\binom{V}{3}\\}$. Friendship: $\\forall u \\neq v,\\, |\\{e \\in E : u,v \\in e\\}| = 1$. Universal: $\\forall e \\in E,\\, c \\in e$. Degree: $\\deg(v) = |\\{e \\in E : v \\in e\\}|$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset cardinality",
+      "hypergraph uniformity",
+      "friendship property",
+      "politician vertex"
+    ],
+    "prerequisites": [
+      "Lean 4: structures and fields",
+      "Finset.filter and Finset.card",
+      "type classes: DecidableEq, Fintype"
+    ]
+  },
+  {
+    "id": "ann-fano-construction",
+    "proofId": "friendship-theorem-oq-03",
+    "range": {
+      "startLine": 115,
+      "endLine": 151
     },
-    {
-      "id": "ann-friendship-verification",
-      "proofId": "friendship-theorem-oq-03",
-      "range": { "startLine": 156, "endLine": 163 },
-      "type": "technique",
-      "title": "Friendship Property: 49-Case Decision Procedure",
-      "content": "`fano_is_friendship` proves that every pair of distinct Fin 7 vertices is in exactly one Fano triple. The proof strategy is `fin_cases u <;> fin_cases v <;> simp_all <;> decide`: enumerate all 7 × 7 = 49 cases of (u,v), use `simp_all` to simplify with the Fano plane definition (unfolding `IsFriendship3`, `fanoPlane`, `fanoEdges`, `triple`), and then close each case by `decide`. The 42 non-diagonal cases each require checking that exactly one of 7 triples contains both u and v — a finite computation that `decide` handles via kernel evaluation. This is the defining property of a Steiner triple system STS(7).",
-      "mathContext": "For each of the $\\binom{7}{2} = 21$ pairs $\\{u,v\\}$, exactly one triple $\\{a,b,c\\} \\in \\{\\{0,1,3\\},\\{1,2,4\\},\\{2,3,5\\},\\{3,4,6\\},\\{4,5,0\\},\\{5,6,1\\},\\{6,0,2\\}\\}$ satisfies $u,v \\in \\{a,b,c\\}$. This is the **Steiner property**: $\\text{STS}(n)$ is a partition of all pairs into triples.",
-      "significance": "supporting",
-      "relatedConcepts": ["Steiner triple systems", "decidable procedures in Lean 4", "fin_cases tactic", "combinatorial design verification"],
-      "prerequisites": ["combinatorics: Steiner triple systems", "Lean 4 decision procedures: decide tactic"]
+    "type": "definition",
+    "title": "The Fano Plane: Explicit Construction in Lean 4",
+    "content": "The Fano plane PG(2,2) is constructed as a `Hypergraph3 (Fin 7)`. The `triple` helper builds a 3-element Finset from three `Fin 7` values. `fanoEdges` explicitly lists all 7 triples matching the classical incidence structure: {0,1,3}, {1,2,4}, {2,3,5}, {3,4,6}, {4,5,0}, {5,6,1}, {6,0,2}. The `fanoPlane.uniform` proof uses `rcases` to enumerate all 7 edges and then `decide` to verify each has cardinality 3. The 7 triples correspond to the 7 lines of PG(2,2): each pair of points determines a unique line, matching the projective plane axioms over GF(2).",
+    "mathContext": "The Fano plane $\\text{PG}(2,2)$: points $= \\mathbb{F}_2^3 \\setminus \\{0\\}$ (7 nonzero vectors), lines $=$ 1-dimensional subspaces of $\\mathbb{F}_2^3$ (7 lines). In coordinates: $\\{(1,0,0),(0,1,0),(1,1,0)\\} \\leftrightarrow \\{0,1,3\\}$ in $\\text{Fin}\\,7$. It is the unique $\\text{STS}(7)$: the unique Steiner triple system of order 7.",
+    "significance": "key",
+    "relatedConcepts": [
+      "projective plane PG(2,2)",
+      "Steiner triple system STS(7)",
+      "finite fields GF(2)",
+      "combinatorial design"
+    ],
+    "prerequisites": [
+      "finite geometry: projective planes",
+      "combinatorial designs: Steiner triple systems",
+      "Lean 4: Finset construction"
+    ]
+  },
+  {
+    "id": "ann-friendship-verification",
+    "proofId": "friendship-theorem-oq-03",
+    "range": {
+      "startLine": 156,
+      "endLine": 163
     },
-    {
-      "id": "ann-no-universal",
-      "proofId": "friendship-theorem-oq-03",
-      "range": { "startLine": 169, "endLine": 178 },
-      "type": "insight",
-      "title": "No Universal Vertex: Degree 3 Rules Out All 7 Candidates",
-      "content": "`fano_no_universal` proves by contradiction: if some c : Fin 7 were in every Fano triple, we derive a contradiction by `fin_cases c` and `decide`. For each of the 7 possible universal vertex candidates, the `decide` kernel evaluation discovers that the candidate is missing from at least 4 triples (since each vertex is in exactly 3 of 7 triples). The absence of a universal vertex is the key fact that makes the Fano plane a counterexample to the hypergraph friendship conjecture. Structurally: a universal vertex would need degree 7 (in all 7 triples), but the Fano plane has degree 3 for every vertex — a factor-of-7/3 gap.",
-      "mathContext": "For all $v \\in \\{0,\\ldots,6\\}$: $\\deg(v) = |\\{e \\in \\text{fanoEdges} : v \\in e\\}| = 3 < 7 = |\\text{fanoEdges}|$. Hence $\\nexists c$ universal. Counting: $7 \\text{ vertices} \\times 3 \\text{ triples/vertex} = 21 = 7 \\text{ triples} \\times 3 \\text{ vertices/triple}$ (double counting confirms 3-regularity).",
-      "significance": "key",
-      "relatedConcepts": ["vertex degree in hypergraphs", "3-regularity of the Fano plane", "proof by contradiction", "double counting"],
-      "prerequisites": ["combinatorics: degree counting", "hypergraph regularity"]
+    "type": "technique",
+    "title": "Friendship Property: 49-Case Decision Procedure",
+    "content": "`fano_is_friendship` proves that every pair of distinct Fin 7 vertices is in exactly one Fano triple. The proof strategy is `fin_cases u <;> fin_cases v <;> simp_all <;> decide`: enumerate all 7 \u00d7 7 = 49 cases of (u,v), use `simp_all` to simplify with the Fano plane definition (unfolding `IsFriendship3`, `fanoPlane`, `fanoEdges`, `triple`), and then close each case by `decide`. The 42 non-diagonal cases each require checking that exactly one of 7 triples contains both u and v \u2014 a finite computation that `decide` handles via kernel evaluation. This is the defining property of a Steiner triple system STS(7).",
+    "mathContext": "For each of the $\\binom{7}{2} = 21$ pairs $\\{u,v\\}$, exactly one triple $\\{a,b,c\\} \\in \\{\\{0,1,3\\},\\{1,2,4\\},\\{2,3,5\\},\\{3,4,6\\},\\{4,5,0\\},\\{5,6,1\\},\\{6,0,2\\}\\}$ satisfies $u,v \\in \\{a,b,c\\}$. This is the **Steiner property**: $\\text{STS}(n)$ is a partition of all pairs into triples.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Steiner triple systems",
+      "decidable procedures in Lean 4",
+      "fin_cases tactic",
+      "combinatorial design verification"
+    ],
+    "prerequisites": [
+      "combinatorics: Steiner triple systems",
+      "Lean 4 decision procedures: decide tactic"
+    ]
+  },
+  {
+    "id": "ann-no-universal",
+    "proofId": "friendship-theorem-oq-03",
+    "range": {
+      "startLine": 169,
+      "endLine": 178
     },
-    {
-      "id": "ann-counterexample",
-      "proofId": "friendship-theorem-oq-03",
-      "range": { "startLine": 184, "endLine": 201 },
-      "type": "concept",
-      "title": "Main Theorem: Friendship Theorem Fails for Hypergraphs",
-      "content": "`friendship_theorem_fails_for_hypergraphs` asserts existence of a 3-uniform friendship hypergraph with no universal vertex. The proof is a one-liner: `exact ⟨fanoPlane, fano_is_friendship, fano_no_universal⟩`. The existential witness is the Fano plane, and the two components of the conjunction are the previously proved lemmas. The theorem's docstring is detailed, contrasting with the graph case: the Friendship Theorem (Erdős–Rényi–Sós, 1966) proved that every friendship GRAPH must have a universal vertex (the 'politician'), and moreover the graph must be a windmill. For hypergraphs, neither conclusion holds.",
-      "mathContext": "$\\exists H : \\text{Hypergraph3}(\\text{Fin}\\,7),\\, \\text{IsFriendship3}(H) \\wedge \\neg\\exists c,\\, \\text{IsUniversalVertex3}(H, c)$. Witness: $H = \\text{fanoPlane}$. This shows the friendship property does NOT force a universal vertex in 3-hypergraphs, in contrast to the graph case where the friendship property forces a windmill structure.",
-      "significance": "key",
-      "relatedConcepts": ["existential witness", "counterexample methodology", "Friendship Theorem (Erdős-Rényi-Sós)", "windmill graphs"],
-      "prerequisites": ["graph theory: windmill graphs and the Friendship Theorem", "hypergraph theory"]
+    "type": "insight",
+    "title": "No Universal Vertex: Degree 3 Rules Out All 7 Candidates",
+    "content": "`fano_no_universal` proves by contradiction: if some c : Fin 7 were in every Fano triple, we derive a contradiction by `fin_cases c` and `decide`. For each of the 7 possible universal vertex candidates, the `decide` kernel evaluation discovers that the candidate is missing from at least 4 triples (since each vertex is in exactly 3 of 7 triples). The absence of a universal vertex is the key fact that makes the Fano plane a counterexample to the hypergraph friendship conjecture. Structurally: a universal vertex would need degree 7 (in all 7 triples), but the Fano plane has degree 3 for every vertex \u2014 a factor-of-7/3 gap.",
+    "mathContext": "For all $v \\in \\{0,\\ldots,6\\}$: $\\deg(v) = |\\{e \\in \\text{fanoEdges} : v \\in e\\}| = 3 < 7 = |\\text{fanoEdges}|$. Hence $\\nexists c$ universal. Counting: $7 \\text{ vertices} \\times 3 \\text{ triples/vertex} = 21 = 7 \\text{ triples} \\times 3 \\text{ vertices/triple}$ (double counting confirms 3-regularity).",
+    "significance": "key",
+    "relatedConcepts": [
+      "vertex degree in hypergraphs",
+      "3-regularity of the Fano plane",
+      "proof by contradiction",
+      "double counting"
+    ],
+    "prerequisites": [
+      "combinatorics: degree counting",
+      "hypergraph regularity"
+    ]
+  },
+  {
+    "id": "ann-counterexample",
+    "proofId": "friendship-theorem-oq-03",
+    "range": {
+      "startLine": 184,
+      "endLine": 201
     },
-    {
-      "id": "ann-counting",
-      "proofId": "friendship-theorem-oq-03",
-      "range": { "startLine": 207, "endLine": 255 },
-      "type": "insight",
-      "title": "Counting Arguments: Degree Formula and Triple Count for Friendship 3-Hypergraphs",
-      "content": "This section proves general counting facts for friendship 3-hypergraphs and verifies them numerically for the Fano plane. `fano_edge_count`: there are exactly 7 triples (by `decide`). `fano_vertex_degree v = 3`: each vertex is in exactly 3 triples (by `fin_cases v <;> decide`). `fano_regular`: all vertices have the same degree 3. The general theorems `friendship3_degree_formula` and `friendship3_triple_count` state that for a friendship 3-hypergraph on n vertices: each vertex has degree (n-1)/2, and there are n(n-1)/6 triples. These are proved purely by arithmetic (omega). The Fano plane checks: n=7, degree=(7-1)/2=3 ✓, triples=7·6/6=7 ✓.",
-      "mathContext": "**Double counting**: Sum over vertices of degree $= 3|E|$ (each triple contributes 3 to vertex degrees). Also $= n \\cdot \\deg$ if $d$-regular. So $nd = 3|E|$. Since $\\deg = (n-1)/2$: $|E| = n(n-1)/6$. For $n=7$: $|E| = 7 \\cdot 6/6 = 7$. The divisibility conditions $2 \\mid (n-1)$ and $6 \\mid n(n-1)$ are necessary for an $\\text{STS}(n)$ to exist (equivalent to $n \\equiv 1$ or $3 \\pmod{6}$).",
-      "significance": "supporting",
-      "relatedConcepts": ["double counting", "Steiner triple system existence conditions", "regular hypergraphs", "divisibility constraints"],
-      "prerequisites": ["combinatorics: double counting", "arithmetic: divisibility and modular conditions"]
+    "type": "concept",
+    "title": "Main Theorem: Friendship Theorem Fails for Hypergraphs",
+    "content": "`friendship_theorem_fails_for_hypergraphs` asserts existence of a 3-uniform friendship hypergraph with no universal vertex. The proof is a one-liner: `exact \u27e8fanoPlane, fano_is_friendship, fano_no_universal\u27e9`. The existential witness is the Fano plane, and the two components of the conjunction are the previously proved lemmas. The theorem's docstring is detailed, contrasting with the graph case: the Friendship Theorem (Erd\u0151s\u2013R\u00e9nyi\u2013S\u00f3s, 1966) proved that every friendship GRAPH must have a universal vertex (the 'politician'), and moreover the graph must be a windmill. For hypergraphs, neither conclusion holds.",
+    "mathContext": "$\\exists H : \\text{Hypergraph3}(\\text{Fin}\\,7),\\, \\text{IsFriendship3}(H) \\wedge \\neg\\exists c,\\, \\text{IsUniversalVertex3}(H, c)$. Witness: $H = \\text{fanoPlane}$. This shows the friendship property does NOT force a universal vertex in 3-hypergraphs, in contrast to the graph case where the friendship property forces a windmill structure.",
+    "significance": "key",
+    "relatedConcepts": [
+      "existential witness",
+      "counterexample methodology",
+      "Friendship Theorem (Erd\u0151s-R\u00e9nyi-S\u00f3s)",
+      "windmill graphs"
+    ],
+    "prerequisites": [
+      "graph theory: windmill graphs and the Friendship Theorem",
+      "hypergraph theory"
+    ]
+  },
+  {
+    "id": "ann-counting",
+    "proofId": "friendship-theorem-oq-03",
+    "range": {
+      "startLine": 207,
+      "endLine": 255
     },
-    {
-      "id": "ann-dual-property",
-      "proofId": "friendship-theorem-oq-03",
-      "range": { "startLine": 257, "endLine": 307 },
-      "type": "concept",
-      "title": "Self-Duality: Any Two Fano Lines Meet in Exactly One Point",
-      "content": "`fano_dual_property` proves that any two distinct Fano triples intersect in exactly one vertex. The proof pattern mirrors `fano_is_friendship`: enumerate all pairs of distinct edges by `rcases he₁ ... <;> rcases he₂ ...` (7×7 = 49 cases), apply `decide` to those where the edges differ. This dual property is equivalent to the Fano plane being a projective plane: in PG(2,2), any two distinct lines meet in exactly one point (dual of 'any two distinct points determine a unique line'). The comparison table in the closing comment contrasts graphs and 3-hypergraphs systematically: windmill structure vs. STS richness, spectral forcing vs. counting failure.",
-      "mathContext": "$\\forall e_1 \\neq e_2 \\in \\text{fanoEdges},\\, |e_1 \\cap e_2| = 1$. This is the **projective plane axiom**: any two lines meet in exactly one point. Combined with the friendship property (any two points determine a unique line), the Fano plane satisfies all axioms of a finite projective plane of order 2, $\\text{PG}(2,2) \\cong \\mathbb{P}^2(\\mathbb{F}_2)$.",
-      "significance": "supporting",
-      "relatedConcepts": ["projective plane axioms", "self-duality in finite geometry", "PG(2,2) over GF(2)", "incidence geometry"],
-      "prerequisites": ["finite geometry: projective planes", "duality principle in projective geometry"]
-    }
-  ]
-}
+    "type": "insight",
+    "title": "Counting Arguments: Degree Formula and Triple Count for Friendship 3-Hypergraphs",
+    "content": "This section proves general counting facts for friendship 3-hypergraphs and verifies them numerically for the Fano plane. `fano_edge_count`: there are exactly 7 triples (by `decide`). `fano_vertex_degree v = 3`: each vertex is in exactly 3 triples (by `fin_cases v <;> decide`). `fano_regular`: all vertices have the same degree 3. The general theorems `friendship3_degree_formula` and `friendship3_triple_count` state that for a friendship 3-hypergraph on n vertices: each vertex has degree (n-1)/2, and there are n(n-1)/6 triples. These are proved purely by arithmetic (omega). The Fano plane checks: n=7, degree=(7-1)/2=3 \u2713, triples=7\u00b76/6=7 \u2713.",
+    "mathContext": "**Double counting**: Sum over vertices of degree $= 3|E|$ (each triple contributes 3 to vertex degrees). Also $= n \\cdot \\deg$ if $d$-regular. So $nd = 3|E|$. Since $\\deg = (n-1)/2$: $|E| = n(n-1)/6$. For $n=7$: $|E| = 7 \\cdot 6/6 = 7$. The divisibility conditions $2 \\mid (n-1)$ and $6 \\mid n(n-1)$ are necessary for an $\\text{STS}(n)$ to exist (equivalent to $n \\equiv 1$ or $3 \\pmod{6}$).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "double counting",
+      "Steiner triple system existence conditions",
+      "regular hypergraphs",
+      "divisibility constraints"
+    ],
+    "prerequisites": [
+      "combinatorics: double counting",
+      "arithmetic: divisibility and modular conditions"
+    ]
+  },
+  {
+    "id": "ann-dual-property",
+    "proofId": "friendship-theorem-oq-03",
+    "range": {
+      "startLine": 257,
+      "endLine": 307
+    },
+    "type": "concept",
+    "title": "Self-Duality: Any Two Fano Lines Meet in Exactly One Point",
+    "content": "`fano_dual_property` proves that any two distinct Fano triples intersect in exactly one vertex. The proof pattern mirrors `fano_is_friendship`: enumerate all pairs of distinct edges by `rcases he\u2081 ... <;> rcases he\u2082 ...` (7\u00d77 = 49 cases), apply `decide` to those where the edges differ. This dual property is equivalent to the Fano plane being a projective plane: in PG(2,2), any two distinct lines meet in exactly one point (dual of 'any two distinct points determine a unique line'). The comparison table in the closing comment contrasts graphs and 3-hypergraphs systematically: windmill structure vs. STS richness, spectral forcing vs. counting failure.",
+    "mathContext": "$\\forall e_1 \\neq e_2 \\in \\text{fanoEdges},\\, |e_1 \\cap e_2| = 1$. This is the **projective plane axiom**: any two lines meet in exactly one point. Combined with the friendship property (any two points determine a unique line), the Fano plane satisfies all axioms of a finite projective plane of order 2, $\\text{PG}(2,2) \\cong \\mathbb{P}^2(\\mathbb{F}_2)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "projective plane axioms",
+      "self-duality in finite geometry",
+      "PG(2,2) over GF(2)",
+      "incidence geometry"
+    ],
+    "prerequisites": [
+      "finite geometry: projective planes",
+      "duality principle in projective geometry"
+    ]
+  }
+]

--- a/src/data/proofs/friendship-theorem-oq-03/annotations.json
+++ b/src/data/proofs/friendship-theorem-oq-03/annotations.json
@@ -1,1 +1,100 @@
-[]
+{
+  "annotations": [
+    {
+      "id": "ann-open-question",
+      "proofId": "friendship-theorem-oq-03",
+      "range": { "startLine": 1, "endLine": 81 },
+      "type": "context",
+      "title": "Open Question: Does the Friendship Theorem Generalize to Hypergraphs?",
+      "content": "The file header poses and immediately answers the central question: does the Friendship Theorem of Erdős–Rényi–Sós (1966) extend to 3-uniform hypergraphs? For graphs (k=2), the theorem says every 'friendship graph' (every pair shares exactly one common neighbor) must have a universal vertex — a 'politician' who is friends with everyone. The docstring explains that for k=3, the Fano plane is a clean constructive counterexample: 7 vertices with 7 triples where every pair is in exactly one triple, but each vertex is in only 3 of the 7 triples. The mathematical background section includes the Fano plane's incidence diagram and the counting argument showing why no vertex can be universal (degree = (n-1)/2 grows slower than triple count n(n-1)/6).",
+      "mathContext": "A 3-uniform **friendship hypergraph** satisfies: $\\forall u \\neq v,\\, |\\{e \\in E : u \\in e \\wedge v \\in e\\}| = 1$. A **universal vertex** $c$ satisfies $\\forall e \\in E, c \\in e$. For the Fano plane: $n=7$, degree $= (7-1)/2 = 3$, and total triples $= 7$. Since $3 < 7$, no vertex is universal.",
+      "significance": "context",
+      "relatedConcepts": ["friendship theorem", "k-uniform hypergraphs", "Steiner triple systems", "Fano plane", "projective planes"],
+      "prerequisites": ["graph theory: Friendship Theorem and windmill graphs", "hypergraph theory basics", "finite geometry"]
+    },
+    {
+      "id": "ann-definitions",
+      "proofId": "friendship-theorem-oq-03",
+      "range": { "startLine": 83, "endLine": 113 },
+      "type": "definition",
+      "title": "Core Definitions: 3-Uniform Friendship Hypergraphs",
+      "content": "`Hypergraph3 V` is a structure holding a `Finset (Finset V)` of edges, each required to have cardinality 3 (the `uniform` field). `IsFriendship3` states the friendship property: for every pair of distinct vertices u ≠ v, the filter of edges containing both u and v has cardinality exactly 1. `IsUniversalVertex3 H c` says vertex c belongs to every edge of H — this is the 'politician' property. `vertexDegree H v` counts the edges containing v. These four definitions form the complete interface for the counterexample proof.",
+      "mathContext": "$\\text{Hypergraph3}(V) = \\{E \\subseteq \\binom{V}{3}\\}$. Friendship: $\\forall u \\neq v,\\, |\\{e \\in E : u,v \\in e\\}| = 1$. Universal: $\\forall e \\in E,\\, c \\in e$. Degree: $\\deg(v) = |\\{e \\in E : v \\in e\\}|$.",
+      "significance": "key",
+      "relatedConcepts": ["Finset cardinality", "hypergraph uniformity", "friendship property", "politician vertex"],
+      "prerequisites": ["Lean 4: structures and fields", "Finset.filter and Finset.card", "type classes: DecidableEq, Fintype"]
+    },
+    {
+      "id": "ann-fano-construction",
+      "proofId": "friendship-theorem-oq-03",
+      "range": { "startLine": 115, "endLine": 151 },
+      "type": "definition",
+      "title": "The Fano Plane: Explicit Construction in Lean 4",
+      "content": "The Fano plane PG(2,2) is constructed as a `Hypergraph3 (Fin 7)`. The `triple` helper builds a 3-element Finset from three `Fin 7` values. `fanoEdges` explicitly lists all 7 triples matching the classical incidence structure: {0,1,3}, {1,2,4}, {2,3,5}, {3,4,6}, {4,5,0}, {5,6,1}, {6,0,2}. The `fanoPlane.uniform` proof uses `rcases` to enumerate all 7 edges and then `decide` to verify each has cardinality 3. The 7 triples correspond to the 7 lines of PG(2,2): each pair of points determines a unique line, matching the projective plane axioms over GF(2).",
+      "mathContext": "The Fano plane $\\text{PG}(2,2)$: points $= \\mathbb{F}_2^3 \\setminus \\{0\\}$ (7 nonzero vectors), lines $=$ 1-dimensional subspaces of $\\mathbb{F}_2^3$ (7 lines). In coordinates: $\\{(1,0,0),(0,1,0),(1,1,0)\\} \\leftrightarrow \\{0,1,3\\}$ in $\\text{Fin}\\,7$. It is the unique $\\text{STS}(7)$: the unique Steiner triple system of order 7.",
+      "significance": "key",
+      "relatedConcepts": ["projective plane PG(2,2)", "Steiner triple system STS(7)", "finite fields GF(2)", "combinatorial design"],
+      "prerequisites": ["finite geometry: projective planes", "combinatorial designs: Steiner triple systems", "Lean 4: Finset construction"]
+    },
+    {
+      "id": "ann-friendship-verification",
+      "proofId": "friendship-theorem-oq-03",
+      "range": { "startLine": 156, "endLine": 163 },
+      "type": "technique",
+      "title": "Friendship Property: 49-Case Decision Procedure",
+      "content": "`fano_is_friendship` proves that every pair of distinct Fin 7 vertices is in exactly one Fano triple. The proof strategy is `fin_cases u <;> fin_cases v <;> simp_all <;> decide`: enumerate all 7 × 7 = 49 cases of (u,v), use `simp_all` to simplify with the Fano plane definition (unfolding `IsFriendship3`, `fanoPlane`, `fanoEdges`, `triple`), and then close each case by `decide`. The 42 non-diagonal cases each require checking that exactly one of 7 triples contains both u and v — a finite computation that `decide` handles via kernel evaluation. This is the defining property of a Steiner triple system STS(7).",
+      "mathContext": "For each of the $\\binom{7}{2} = 21$ pairs $\\{u,v\\}$, exactly one triple $\\{a,b,c\\} \\in \\{\\{0,1,3\\},\\{1,2,4\\},\\{2,3,5\\},\\{3,4,6\\},\\{4,5,0\\},\\{5,6,1\\},\\{6,0,2\\}\\}$ satisfies $u,v \\in \\{a,b,c\\}$. This is the **Steiner property**: $\\text{STS}(n)$ is a partition of all pairs into triples.",
+      "significance": "supporting",
+      "relatedConcepts": ["Steiner triple systems", "decidable procedures in Lean 4", "fin_cases tactic", "combinatorial design verification"],
+      "prerequisites": ["combinatorics: Steiner triple systems", "Lean 4 decision procedures: decide tactic"]
+    },
+    {
+      "id": "ann-no-universal",
+      "proofId": "friendship-theorem-oq-03",
+      "range": { "startLine": 169, "endLine": 178 },
+      "type": "insight",
+      "title": "No Universal Vertex: Degree 3 Rules Out All 7 Candidates",
+      "content": "`fano_no_universal` proves by contradiction: if some c : Fin 7 were in every Fano triple, we derive a contradiction by `fin_cases c` and `decide`. For each of the 7 possible universal vertex candidates, the `decide` kernel evaluation discovers that the candidate is missing from at least 4 triples (since each vertex is in exactly 3 of 7 triples). The absence of a universal vertex is the key fact that makes the Fano plane a counterexample to the hypergraph friendship conjecture. Structurally: a universal vertex would need degree 7 (in all 7 triples), but the Fano plane has degree 3 for every vertex — a factor-of-7/3 gap.",
+      "mathContext": "For all $v \\in \\{0,\\ldots,6\\}$: $\\deg(v) = |\\{e \\in \\text{fanoEdges} : v \\in e\\}| = 3 < 7 = |\\text{fanoEdges}|$. Hence $\\nexists c$ universal. Counting: $7 \\text{ vertices} \\times 3 \\text{ triples/vertex} = 21 = 7 \\text{ triples} \\times 3 \\text{ vertices/triple}$ (double counting confirms 3-regularity).",
+      "significance": "key",
+      "relatedConcepts": ["vertex degree in hypergraphs", "3-regularity of the Fano plane", "proof by contradiction", "double counting"],
+      "prerequisites": ["combinatorics: degree counting", "hypergraph regularity"]
+    },
+    {
+      "id": "ann-counterexample",
+      "proofId": "friendship-theorem-oq-03",
+      "range": { "startLine": 184, "endLine": 201 },
+      "type": "concept",
+      "title": "Main Theorem: Friendship Theorem Fails for Hypergraphs",
+      "content": "`friendship_theorem_fails_for_hypergraphs` asserts existence of a 3-uniform friendship hypergraph with no universal vertex. The proof is a one-liner: `exact ⟨fanoPlane, fano_is_friendship, fano_no_universal⟩`. The existential witness is the Fano plane, and the two components of the conjunction are the previously proved lemmas. The theorem's docstring is detailed, contrasting with the graph case: the Friendship Theorem (Erdős–Rényi–Sós, 1966) proved that every friendship GRAPH must have a universal vertex (the 'politician'), and moreover the graph must be a windmill. For hypergraphs, neither conclusion holds.",
+      "mathContext": "$\\exists H : \\text{Hypergraph3}(\\text{Fin}\\,7),\\, \\text{IsFriendship3}(H) \\wedge \\neg\\exists c,\\, \\text{IsUniversalVertex3}(H, c)$. Witness: $H = \\text{fanoPlane}$. This shows the friendship property does NOT force a universal vertex in 3-hypergraphs, in contrast to the graph case where the friendship property forces a windmill structure.",
+      "significance": "key",
+      "relatedConcepts": ["existential witness", "counterexample methodology", "Friendship Theorem (Erdős-Rényi-Sós)", "windmill graphs"],
+      "prerequisites": ["graph theory: windmill graphs and the Friendship Theorem", "hypergraph theory"]
+    },
+    {
+      "id": "ann-counting",
+      "proofId": "friendship-theorem-oq-03",
+      "range": { "startLine": 207, "endLine": 255 },
+      "type": "insight",
+      "title": "Counting Arguments: Degree Formula and Triple Count for Friendship 3-Hypergraphs",
+      "content": "This section proves general counting facts for friendship 3-hypergraphs and verifies them numerically for the Fano plane. `fano_edge_count`: there are exactly 7 triples (by `decide`). `fano_vertex_degree v = 3`: each vertex is in exactly 3 triples (by `fin_cases v <;> decide`). `fano_regular`: all vertices have the same degree 3. The general theorems `friendship3_degree_formula` and `friendship3_triple_count` state that for a friendship 3-hypergraph on n vertices: each vertex has degree (n-1)/2, and there are n(n-1)/6 triples. These are proved purely by arithmetic (omega). The Fano plane checks: n=7, degree=(7-1)/2=3 ✓, triples=7·6/6=7 ✓.",
+      "mathContext": "**Double counting**: Sum over vertices of degree $= 3|E|$ (each triple contributes 3 to vertex degrees). Also $= n \\cdot \\deg$ if $d$-regular. So $nd = 3|E|$. Since $\\deg = (n-1)/2$: $|E| = n(n-1)/6$. For $n=7$: $|E| = 7 \\cdot 6/6 = 7$. The divisibility conditions $2 \\mid (n-1)$ and $6 \\mid n(n-1)$ are necessary for an $\\text{STS}(n)$ to exist (equivalent to $n \\equiv 1$ or $3 \\pmod{6}$).",
+      "significance": "supporting",
+      "relatedConcepts": ["double counting", "Steiner triple system existence conditions", "regular hypergraphs", "divisibility constraints"],
+      "prerequisites": ["combinatorics: double counting", "arithmetic: divisibility and modular conditions"]
+    },
+    {
+      "id": "ann-dual-property",
+      "proofId": "friendship-theorem-oq-03",
+      "range": { "startLine": 257, "endLine": 307 },
+      "type": "concept",
+      "title": "Self-Duality: Any Two Fano Lines Meet in Exactly One Point",
+      "content": "`fano_dual_property` proves that any two distinct Fano triples intersect in exactly one vertex. The proof pattern mirrors `fano_is_friendship`: enumerate all pairs of distinct edges by `rcases he₁ ... <;> rcases he₂ ...` (7×7 = 49 cases), apply `decide` to those where the edges differ. This dual property is equivalent to the Fano plane being a projective plane: in PG(2,2), any two distinct lines meet in exactly one point (dual of 'any two distinct points determine a unique line'). The comparison table in the closing comment contrasts graphs and 3-hypergraphs systematically: windmill structure vs. STS richness, spectral forcing vs. counting failure.",
+      "mathContext": "$\\forall e_1 \\neq e_2 \\in \\text{fanoEdges},\\, |e_1 \\cap e_2| = 1$. This is the **projective plane axiom**: any two lines meet in exactly one point. Combined with the friendship property (any two points determine a unique line), the Fano plane satisfies all axioms of a finite projective plane of order 2, $\\text{PG}(2,2) \\cong \\mathbb{P}^2(\\mathbb{F}_2)$.",
+      "significance": "supporting",
+      "relatedConcepts": ["projective plane axioms", "self-duality in finite geometry", "PG(2,2) over GF(2)", "incidence geometry"],
+      "prerequisites": ["finite geometry: projective planes", "duality principle in projective geometry"]
+    }
+  ]
+}

--- a/src/data/proofs/friendship-theorem-oq-03/meta.json
+++ b/src/data/proofs/friendship-theorem-oq-03/meta.json
@@ -99,50 +99,90 @@
   ],
   "sections": [
     {
+      "id": "header",
+      "title": "File Header and Mathematical Background",
+      "description": "Detailed docstring posing the open question, presenting the Fano plane incidence structure, and explaining why the friendship theorem fails for hypergraphs via the degree formula.",
+      "summary": "Open question setup: does the Friendship Theorem generalize to 3-uniform hypergraphs? Answer: NO. The Fano plane is the counterexample.",
+      "startLine": 1,
+      "endLine": 81
+    },
+    {
       "id": "definitions",
       "title": "3-Uniform Hypergraph Definitions",
-      "description": "Definitions of 3-uniform hypergraphs, the friendship property, and universal vertices.",
-      "summary": "3-Uniform Hypergraph Definitions"
+      "description": "Definitions of 3-uniform hypergraphs, the friendship property, universal vertices, and vertex degree.",
+      "summary": "Hypergraph3, IsFriendship3, IsUniversalVertex3, vertexDegree — the complete interface for the counterexample.",
+      "startLine": 83,
+      "endLine": 113
     },
     {
       "id": "fano-plane",
       "title": "The Fano Plane",
       "description": "Construction of the Fano plane PG(2,2) as a 3-uniform hypergraph on 7 vertices with 7 triples.",
-      "summary": "The Fano Plane"
+      "summary": "Explicit construction: fanoEdges lists all 7 triples; fanoPlane verifies 3-uniformity by decide.",
+      "startLine": 115,
+      "endLine": 151
     },
     {
       "id": "friendship-verification",
       "title": "Friendship Property Verification",
       "description": "Proof that every pair of Fano plane vertices is in exactly one triple.",
-      "summary": "Friendship Property Verification"
+      "summary": "fano_is_friendship: 49-case decision procedure — fin_cases u <;> fin_cases v <;> decide.",
+      "startLine": 152,
+      "endLine": 163
     },
     {
       "id": "no-universal",
       "title": "No Universal Vertex",
       "description": "Proof that no vertex belongs to all 7 Fano triples.",
-      "summary": "No Universal Vertex"
+      "summary": "fano_no_universal: contradiction by fin_cases c <;> decide — each vertex is in exactly 3 of 7 triples.",
+      "startLine": 165,
+      "endLine": 178
     },
     {
       "id": "counterexample",
       "title": "The Main Counterexample",
       "description": "The friendship theorem does NOT generalize to 3-uniform hypergraphs.",
-      "summary": "The Main Counterexample"
+      "summary": "friendship_theorem_fails_for_hypergraphs: one-line assembly of the two sub-proofs.",
+      "startLine": 180,
+      "endLine": 201
     },
     {
       "id": "properties",
       "title": "Fano Plane Properties",
-      "description": "Edge count (7), vertex degree (3), 3-regularity, and the dual property.",
-      "summary": "Fano Plane Properties"
+      "description": "Edge count (7), vertex degree (3), 3-regularity.",
+      "summary": "fano_edge_count = 7, fano_vertex_degree v = 3 for all v, fano_regular.",
+      "startLine": 203,
+      "endLine": 219
     },
     {
       "id": "counting",
       "title": "General Counting Arguments",
-      "description": "Vertex degree and triple count formulas for friendship 3-hypergraphs.",
-      "summary": "General Counting Arguments"
+      "description": "Vertex degree formula (n-1)/2 and triple count formula n(n-1)/6 for general friendship 3-hypergraphs.",
+      "summary": "friendship3_degree_formula and friendship3_triple_count proved by omega; verified for the Fano plane.",
+      "startLine": 221,
+      "endLine": 255
+    },
+    {
+      "id": "dual-property",
+      "title": "Dual Property and Graph/Hypergraph Comparison",
+      "description": "Fano plane self-duality: any two distinct triples share exactly one vertex. Comparison table: graphs (windmill forced) vs. 3-hypergraphs (STS structures).",
+      "summary": "fano_dual_property: projective plane self-duality; closing comparison of friendship theorem for k=2 vs. k=3.",
+      "startLine": 257,
+      "endLine": 307
+    }
+  ],
+  "crossReferences": [
+    {
+      "relationship": "The original Friendship Theorem (Erdős–Rényi–Sós, 1966) proves that every friendship graph must have a universal 'politician' vertex and be a windmill — this formalization shows the analogous result fails completely for 3-uniform hypergraphs, where the Fano plane satisfies the friendship property with no universal vertex",
+      "targetId": "friendship-theorem"
+    },
+    {
+      "relationship": "The spectral proof that every k-regular friendship graph has k=2 uses algebraic constraints (eigenvalue analysis of the adjacency matrix) that force windmill structure — for 3-hypergraphs, these spectral constraints have no analog, which is why Steiner triple systems can satisfy the friendship property without being 'windmill hypergraphs'",
+      "targetId": "friendship-theorem-oq-01"
     }
   ],
   "overview": {
-    "historicalContext": "The Friendship Theorem (Erdos-Renyi-Sos, 1966) established that every finite graph with the friendship property must have a universal vertex. Sos (1976) posed the natural question of whether this extends to hypergraphs. Li and van Rees (2002) studied 'friendship 3-hypergraphs' — 3-uniform hypergraphs where every pair of vertices is in exactly one edge — and showed that Steiner triple systems provide counterexamples. The Fano plane (1892), the smallest non-trivial projective plane PG(2,2), is the simplest counterexample.",
+    "historicalContext": "The Friendship Theorem was proved by Erdős, Rényi, and Sós in 1966 in their paper 'On a problem of graph theory' (Studia Sci. Math. Hungarica). It states that every finite graph in which every pair of vertices has exactly one common neighbor must contain a 'universal vertex' — a politician who is friends with everyone — and the graph must be a windmill (triangles sharing a common vertex). The proof used both combinatorial and algebraic (spectral) arguments. Véra T. Sós (1976) posed the natural generalization to hypergraphs: does a k-uniform hypergraph where every (k-1)-subset of vertices is in exactly one edge necessarily have a universal vertex?\n\nLi and van Rees (2002) studied 'friendship 3-hypergraphs' and showed that Steiner triple systems are counterexamples. A Steiner triple system STS(n) exists if and only if n ≡ 1 or 3 (mod 6); the smallest is STS(7), the Fano plane, discovered by Gino Fano in 1892 as the projective plane PG(2,2) — the projective plane over GF(2). The Fano plane has been a central object in finite geometry and combinatorics for over a century: it is the smallest non-Desarguesian configuration, the automorphism group is GL(3,2) ≅ PSL(2,7) of order 168, and it appears in the construction of the exceptional Lie algebra g₂ and in the octonion multiplication table.",
     "problemStatement": "**Question**: Does the Friendship Theorem generalize to k-uniform hypergraphs? That is, if every (k-1)-subset of vertices is in exactly one hyperedge, must there be a vertex in every hyperedge?\n\n**Answer**: NO. The Fano plane is a 3-uniform hypergraph where every pair is in exactly one triple, yet no vertex belongs to all triples.",
     "text": "We construct the Fano plane as an explicit counterexample showing the friendship theorem fails for 3-uniform hypergraphs. Every pair of the 7 vertices is in exactly one of 7 triples, but each vertex is in only 3 triples.",
     "proofStrategy": "1. Define the Fano plane as a 3-uniform hypergraph on Fin 7 with 7 explicitly listed triples.\n2. Verify the friendship property by finite case analysis: for each of the 21 pairs of vertices, check that exactly one triple contains both.\n3. Prove no universal vertex exists by checking all 7 vertices: each is in only 3 of 7 triples.\n4. Combine to get the counterexample theorem.",
@@ -151,7 +191,8 @@
       "The Fano plane (projective plane PG(2,2)) is the simplest counterexample",
       "In a friendship 3-hypergraph on n vertices, each vertex has degree (n-1)/2, which grows linearly while the total number of triples n(n-1)/6 grows quadratically — so for n >= 7, no vertex can be universal",
       "The self-duality of the Fano plane (any two lines meet in exactly 1 point) is a bonus property verified here",
-      "Steiner triple systems provide a rich family of counterexamples for all admissible n >= 7"
+      "Steiner triple systems provide a rich family of counterexamples for all admissible n >= 7",
+      "The Fano plane's automorphism group GL(3,2) ≅ PSL(2,7) (order 168) is the second smallest non-abelian simple group and appears in the octonion multiplication table — the Lean proof's decidability approach gives a verified construction of this rich mathematical object"
     ],
     "prerequisites": [
       "Graph theory (friendship property, universal vertex)",
@@ -166,6 +207,11 @@
       "Characterize all friendship 3-hypergraphs (Steiner triple systems)",
       "Study friendship k-hypergraphs for k >= 4",
       "Determine which structural properties of friendship graphs DO generalize"
+    ],
+    "openQuestions": [
+      "Do friendship k-hypergraphs for k ≥ 4 also fail to have universal vertices? What is the smallest counterexample for each k, and is there a pattern?",
+      "Can all friendship 3-hypergraphs be characterized precisely as Steiner triple systems, or does the friendship property permit hypergraphs that are not STS (e.g., with repeated edges or non-uniform vertex degrees)?",
+      "Is there a non-computational proof of friendship theorem failure for 3-hypergraphs — one that gives structural insight rather than case-by-case verification — perhaps via a spectral or algebraic argument showing why the spectral method fails for hypergraphs?"
     ],
     "implications": "The Friendship Theorem does not generalize to 3-uniform hypergraphs. The Fano plane serves as a clean, constructive counterexample: it satisfies the friendship property (every pair in exactly one triple) but has no universal vertex (each vertex is in only 3 of 7 triples). This is fully verified in Lean 4 with 0 sorries and 0 axioms."
   }


### PR DESCRIPTION
Enrichment pass for friendship-theorem-oq-03 (Fano plane counterexample to hypergraph friendship theorem).

Quality improvements:
- **Added 8 annotations** covering all major proof sections (annotations were previously empty)
  - Covers: open question context, hypergraph definitions, Fano plane construction, friendship verification (decision procedure), no universal vertex (degree argument), main counterexample, counting formulas, dual property
  - Each annotation has `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`
- **Sections**: added `startLine`/`endLine` to all sections; added 9th section (dual-property, lines 257-307)
- **crossReferences**: added links to `friendship-theorem` and `friendship-theorem-oq-01` with mathematical explanations
- **historicalContext**: expanded with Gino Fano (1892), Sós (1976) generalization question, Li-van Rees (2002), automorphism group GL(3,2) ≅ PSL(2,7) connection to octonions
- **keyInsights**: added 6th insight about Fano automorphism group
- **openQuestions**: added 3 genuine open questions to conclusion