### PR TITLE
Audit cycle 40: tracker updates (burnside-oq-03, cevas-oq-02-oq-01-oq-03 clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6968,9 +6968,9 @@
     },
     "erdos-678": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-04T01:32:38Z",
-      "result": "issues-found"
+      "auditCount": 4,
+      "lastAudited": "2026-04-04T09:27:51Z",
+      "result": "issues-fixed"
     },
     "erdos-679": {
       "auditCount": 2,
@@ -7754,8 +7754,8 @@
     },
     "erdos-793": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:21:44Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-04T09:27:51Z",
       "result": "clean"
     },
     "erdos-794": {
@@ -11370,6 +11370,18 @@
       "auditCount": 1,
       "lastAudited": "2026-04-04T08:59:51Z",
       "result": "issues-found",
+      "issues": []
+    },
+    "burnside-counting-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T09:29:49Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cevas-theorem-oq-02-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T09:29:49Z",
+      "result": "clean",
       "issues": []
     }
   },


### PR DESCRIPTION
## Summary

Audit tracker updates for cycle 40. All new proofs verified clean:

- **burnside-counting-oq-03**: `formalized/wip` with 4 sorries — count matches Lean file ✓
- **cevas-theorem-oq-02-oq-01-oq-03**: `verified/original` with 0 sorries, 0 axioms — fully confirmed ✓
- **erdos-678**: `issues-fixed` (sorry count 11→7 in PR #9300)
- **erdos-793**: `clean` (1 sorry in Stubs file, matches claim)

🤖 Generated with [Claude Code](https://claude.com/claude-code)