### PR TITLE
Fix erdos-1002-oq-01: annotations.json plain array format

### DIFF
--- a/src/data/proofs/cevas-theorem-oq-02-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/cevas-theorem-oq-02-oq-01-oq-03/annotations.json
@@ -1,88 +1,167 @@
-{
-  "annotations": [
-    {
-      "id": "ann-context",
-      "proofId": "cevas-theorem-oq-02-oq-01-oq-03",
-      "range": { "startLine": 1, "endLine": 57 },
-      "type": "context",
-      "title": "Open Question: Geometric Meaning of Weight Parameters in Ceva's Theorem",
-      "content": "The header poses and answers OQ-02-OQ-01-OQ-03: what is the geometric meaning of the weight pair (α, β) encoding a cevian point D on side BC? The answer — that BD/DC = β/α — is the central result. The docstring also catalogs the special cases: α = β gives the midpoint (centroid case); the angle bisector theorem corresponds to weights α_D = |AC|, β_D = |AB| (incenter case); the symmedian uses square side-length weights. All 18 theorems are proved without axioms or sorries, from pure arithmetic using Mathlib field lemmas.",
-      "mathContext": "For $D = (\\alpha B + \\beta C)/(\\alpha + \\beta)$ on segment $BC$: $BD = \\beta|CB|/(\\alpha+\\beta)$, $DC = \\alpha|CB|/(\\alpha+\\beta)$, so $BD : DC = \\beta : \\alpha$. The Ceva balance condition $\\alpha_D\\alpha_E\\alpha_F = \\beta_D\\beta_E\\beta_F$ is equivalent to $(BD/DC)(CE/EA)(AF/FB) = 1$.",
-      "significance": "context",
-      "relatedConcepts": ["barycentric coordinates", "Ceva's theorem", "division ratio", "cevian triangle"],
-      "prerequisites": ["Ceva's theorem: concurrent cevians", "barycentric coordinates: affine combinations", "triangle geometry: cevians and transversals"]
+[
+  {
+    "id": "ann-context",
+    "proofId": "cevas-theorem-oq-02-oq-01-oq-03",
+    "range": {
+      "startLine": 1,
+      "endLine": 57
     },
-    {
-      "id": "ann-displacement-lemmas",
-      "proofId": "cevas-theorem-oq-02-oq-01-oq-03",
-      "range": { "startLine": 59, "endLine": 84 },
-      "type": "technique",
-      "title": "Displacement Decomposition: D Splits BC as Fractions β/(α+β) and α/(α+β)",
-      "content": "Three lemmas establish the coordinate geometry of D on BC. `weight_point_displacement` rewrites D = (αB + βC)/(α+β) as B + β(C-B)/(α+β), making clear that D lies on the ray from B toward C at fractional distance β/(α+β). `weight_point_distance_from_B` and `weight_point_distance_to_C` compute D-B = β(C-B)/(α+β) and C-D = α(C-B)/(α+β) explicitly. All three proofs use `field_simp [hαβ]; ring` after establishing α+β ≠ 0 by `linarith`. These decompositions are the building blocks for the division ratio theorem.",
-      "mathContext": "$D - B = \\frac{\\beta(C-B)}{\\alpha+\\beta}$ and $C - D = \\frac{\\alpha(C-B)}{\\alpha+\\beta}$ so $\\frac{D-B}{C-D} = \\frac{\\beta}{ \\alpha}$. The fraction $\\beta/(\\alpha+\\beta)$ is the **barycentric coordinate** of $D$ with respect to vertex $C$ in the $BC$ edge.",
-      "significance": "supporting",
-      "relatedConcepts": ["barycentric coordinates on a segment", "affine combination", "field_simp tactic"],
-      "prerequisites": ["real analysis: linear interpolation", "Lean 4: field_simp and ring tactics", "basic algebra: fraction manipulation"]
+    "type": "context",
+    "title": "Open Question: Geometric Meaning of Weight Parameters in Ceva's Theorem",
+    "content": "The header poses and answers OQ-02-OQ-01-OQ-03: what is the geometric meaning of the weight pair (\u03b1, \u03b2) encoding a cevian point D on side BC? The answer \u2014 that BD/DC = \u03b2/\u03b1 \u2014 is the central result. The docstring also catalogs the special cases: \u03b1 = \u03b2 gives the midpoint (centroid case); the angle bisector theorem corresponds to weights \u03b1_D = |AC|, \u03b2_D = |AB| (incenter case); the symmedian uses square side-length weights. All 18 theorems are proved without axioms or sorries, from pure arithmetic using Mathlib field lemmas.",
+    "mathContext": "For $D = (\\alpha B + \\beta C)/(\\alpha + \\beta)$ on segment $BC$: $BD = \\beta|CB|/(\\alpha+\\beta)$, $DC = \\alpha|CB|/(\\alpha+\\beta)$, so $BD : DC = \\beta : \\alpha$. The Ceva balance condition $\\alpha_D\\alpha_E\\alpha_F = \\beta_D\\beta_E\\beta_F$ is equivalent to $(BD/DC)(CE/EA)(AF/FB) = 1$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "barycentric coordinates",
+      "Ceva's theorem",
+      "division ratio",
+      "cevian triangle"
+    ],
+    "prerequisites": [
+      "Ceva's theorem: concurrent cevians",
+      "barycentric coordinates: affine combinations",
+      "triangle geometry: cevians and transversals"
+    ]
+  },
+  {
+    "id": "ann-displacement-lemmas",
+    "proofId": "cevas-theorem-oq-02-oq-01-oq-03",
+    "range": {
+      "startLine": 59,
+      "endLine": 84
     },
-    {
-      "id": "ann-division-ratio",
-      "proofId": "cevas-theorem-oq-02-oq-01-oq-03",
-      "range": { "startLine": 86, "endLine": 113 },
-      "type": "insight",
-      "title": "Main Theorem: BD/DC = β/α — The Swapped Division Ratio",
-      "content": "`weight_division_ratio` is the core result: for D = (αB + βC)/(α+β) with B ≠ C, we have (D-B)/(C-D) = β/α. The proof substitutes the displacement lemmas (hDB and hCD), then uses `field_simp` with several non-zero conditions to simplify β(C-B)/(α+β) ÷ α(C-B)/(α+β) = β/α. A key subtlety: the ratio is β/α, NOT α/β. The weight α governs how far D is from C (the 'pull' toward B), while β governs how far D is from B (the 'pull' toward C). This inversion is a common source of confusion when applying Ceva's theorem.",
-      "mathContext": "$\\frac{D-B}{C-D} = \\frac{\\beta(C-B)/(\\alpha+\\beta)}{\\alpha(C-B)/(\\alpha+\\beta)} = \\frac{\\beta}{\\alpha}$. Note the **swap**: large $\\alpha$ pulls $D$ toward $B$ (making $C-D = \\alpha(C-B)/(\\alpha+\\beta)$ large), but the $\\alpha$ weight controls $DC$, not $BD$.",
-      "significance": "key",
-      "relatedConcepts": ["division ratio", "mass point geometry", "Menelaus' theorem", "harmonic division"],
-      "prerequisites": ["Ceva's theorem", "division ratio in geometry", "field arithmetic"]
+    "type": "technique",
+    "title": "Displacement Decomposition: D Splits BC as Fractions \u03b2/(\u03b1+\u03b2) and \u03b1/(\u03b1+\u03b2)",
+    "content": "Three lemmas establish the coordinate geometry of D on BC. `weight_point_displacement` rewrites D = (\u03b1B + \u03b2C)/(\u03b1+\u03b2) as B + \u03b2(C-B)/(\u03b1+\u03b2), making clear that D lies on the ray from B toward C at fractional distance \u03b2/(\u03b1+\u03b2). `weight_point_distance_from_B` and `weight_point_distance_to_C` compute D-B = \u03b2(C-B)/(\u03b1+\u03b2) and C-D = \u03b1(C-B)/(\u03b1+\u03b2) explicitly. All three proofs use `field_simp [h\u03b1\u03b2]; ring` after establishing \u03b1+\u03b2 \u2260 0 by `linarith`. These decompositions are the building blocks for the division ratio theorem.",
+    "mathContext": "$D - B = \\frac{\\beta(C-B)}{\\alpha+\\beta}$ and $C - D = \\frac{\\alpha(C-B)}{\\alpha+\\beta}$ so $\\frac{D-B}{C-D} = \\frac{\\beta}{ \\alpha}$. The fraction $\\beta/(\\alpha+\\beta)$ is the **barycentric coordinate** of $D$ with respect to vertex $C$ in the $BC$ edge.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "barycentric coordinates on a segment",
+      "affine combination",
+      "field_simp tactic"
+    ],
+    "prerequisites": [
+      "real analysis: linear interpolation",
+      "Lean 4: field_simp and ring tactics",
+      "basic algebra: fraction manipulation"
+    ]
+  },
+  {
+    "id": "ann-division-ratio",
+    "proofId": "cevas-theorem-oq-02-oq-01-oq-03",
+    "range": {
+      "startLine": 86,
+      "endLine": 113
     },
-    {
-      "id": "ann-midpoint",
-      "proofId": "cevas-theorem-oq-02-oq-01-oq-03",
-      "range": { "startLine": 115, "endLine": 152 },
-      "type": "concept",
-      "title": "Midpoint Characterization: α = β iff D is the Midpoint",
-      "content": "`weight_midpoint_iff_of_ne` proves D = (B+C)/2 iff α = β. The forward direction uses cross-multiplication to get (α-β)(B-C) = 0, then `mul_eq_zero` splits into α = β (desired) or B = C (contradicted by hBC). `weight_fraction_from_B` proves the equivalent β/(α+β) = 1/2 iff α = β. `nonequal_weights_not_midpoint` collects the negation. Together these show that the centroid (which uses equal weights α = β = 1 for all three cevians) is the unique point where weight equality forces midpoints. Any asymmetry α ≠ β produces a cevian point off the midpoint.",
-      "mathContext": "$(\\alpha B + \\beta C)/(\\alpha+\\beta) = (B+C)/2 \\iff \\alpha = \\beta$. Proof: cross-multiply to get $(\\alpha - \\beta)(B-C) = 0$; since $B \\neq C$ we get $\\alpha = \\beta$. When $\\alpha = \\beta$: all three midpoints are cevian points, and the medians are concurrent at the **centroid** $G = (A+B+C)/3$.",
-      "significance": "key",
-      "relatedConcepts": ["centroid", "midpoint theorem", "barycentric coordinates", "medians of a triangle"],
-      "prerequisites": ["Euclidean geometry: midpoints and medians", "algebra: cross-multiplication and zero product property"]
+    "type": "insight",
+    "title": "Main Theorem: BD/DC = \u03b2/\u03b1 \u2014 The Swapped Division Ratio",
+    "content": "`weight_division_ratio` is the core result: for D = (\u03b1B + \u03b2C)/(\u03b1+\u03b2) with B \u2260 C, we have (D-B)/(C-D) = \u03b2/\u03b1. The proof substitutes the displacement lemmas (hDB and hCD), then uses `field_simp` with several non-zero conditions to simplify \u03b2(C-B)/(\u03b1+\u03b2) \u00f7 \u03b1(C-B)/(\u03b1+\u03b2) = \u03b2/\u03b1. A key subtlety: the ratio is \u03b2/\u03b1, NOT \u03b1/\u03b2. The weight \u03b1 governs how far D is from C (the 'pull' toward B), while \u03b2 governs how far D is from B (the 'pull' toward C). This inversion is a common source of confusion when applying Ceva's theorem.",
+    "mathContext": "$\\frac{D-B}{C-D} = \\frac{\\beta(C-B)/(\\alpha+\\beta)}{\\alpha(C-B)/(\\alpha+\\beta)} = \\frac{\\beta}{\\alpha}$. Note the **swap**: large $\\alpha$ pulls $D$ toward $B$ (making $C-D = \\alpha(C-B)/(\\alpha+\\beta)$ large), but the $\\alpha$ weight controls $DC$, not $BD$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "division ratio",
+      "mass point geometry",
+      "Menelaus' theorem",
+      "harmonic division"
+    ],
+    "prerequisites": [
+      "Ceva's theorem",
+      "division ratio in geometry",
+      "field arithmetic"
+    ]
+  },
+  {
+    "id": "ann-midpoint",
+    "proofId": "cevas-theorem-oq-02-oq-01-oq-03",
+    "range": {
+      "startLine": 115,
+      "endLine": 152
     },
-    {
-      "id": "ann-ceva-product",
-      "proofId": "cevas-theorem-oq-02-oq-01-oq-03",
-      "range": { "startLine": 154, "endLine": 200 },
-      "type": "concept",
-      "title": "Ceva Product Connection: Weight Balance ↔ Classical Ceva Product = 1",
-      "content": "`ceva_product_eq_weight_ratio` shows (βD/αD)(βE/αE)(βF/αF) = (βDβEβF)/(αDαEαF) by `field_simp`. `ceva_balance_iff_unit_product` then proves that the weight balance condition αDαEαF = βDβEβF is equivalent to the classical Ceva product equaling 1. The proof uses `div_eq_one_iff_eq` to reduce 'fraction = 1' to 'numerator = denominator'. `reversed_division_ratio` shows (β/α)(α/β) = 1, reflecting that reversing all cevians (swapping α↔β for each) preserves the balance condition. `ceva_balance_symmetric` is just `eq_comm`.",
-      "mathContext": "$\\alpha_D\\alpha_E\\alpha_F = \\beta_D\\beta_E\\beta_F \\iff \\frac{BD}{DC} \\cdot \\frac{CE}{EA} \\cdot \\frac{AF}{FB} = 1$. The weight balance condition is **exactly** the classical Ceva concurrence criterion, translated from signed ratios to positive weight products. This is the Euclidean analog of the OQ-02 spherical Ceva condition.",
-      "significance": "key",
-      "relatedConcepts": ["Ceva's theorem (classical)", "concurrent cevians", "signed vs. unsigned ratios", "barycentric coordinates"],
-      "prerequisites": ["Ceva's theorem", "fraction arithmetic in Lean 4", "div_eq_one_iff_eq"]
+    "type": "concept",
+    "title": "Midpoint Characterization: \u03b1 = \u03b2 iff D is the Midpoint",
+    "content": "`weight_midpoint_iff_of_ne` proves D = (B+C)/2 iff \u03b1 = \u03b2. The forward direction uses cross-multiplication to get (\u03b1-\u03b2)(B-C) = 0, then `mul_eq_zero` splits into \u03b1 = \u03b2 (desired) or B = C (contradicted by hBC). `weight_fraction_from_B` proves the equivalent \u03b2/(\u03b1+\u03b2) = 1/2 iff \u03b1 = \u03b2. `nonequal_weights_not_midpoint` collects the negation. Together these show that the centroid (which uses equal weights \u03b1 = \u03b2 = 1 for all three cevians) is the unique point where weight equality forces midpoints. Any asymmetry \u03b1 \u2260 \u03b2 produces a cevian point off the midpoint.",
+    "mathContext": "$(\\alpha B + \\beta C)/(\\alpha+\\beta) = (B+C)/2 \\iff \\alpha = \\beta$. Proof: cross-multiply to get $(\\alpha - \\beta)(B-C) = 0$; since $B \\neq C$ we get $\\alpha = \\beta$. When $\\alpha = \\beta$: all three midpoints are cevian points, and the medians are concurrent at the **centroid** $G = (A+B+C)/3$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "centroid",
+      "midpoint theorem",
+      "barycentric coordinates",
+      "medians of a triangle"
+    ],
+    "prerequisites": [
+      "Euclidean geometry: midpoints and medians",
+      "algebra: cross-multiplication and zero product property"
+    ]
+  },
+  {
+    "id": "ann-ceva-product",
+    "proofId": "cevas-theorem-oq-02-oq-01-oq-03",
+    "range": {
+      "startLine": 154,
+      "endLine": 200
     },
-    {
-      "id": "ann-special-configs",
-      "proofId": "cevas-theorem-oq-02-oq-01-oq-03",
-      "range": { "startLine": 202, "endLine": 250 },
-      "type": "concept",
-      "title": "Special Configurations: Centroid, Incenter, and Scale Invariance",
-      "content": "`centroid_equal_weights` and `centroid_weight_balance` confirm that equal weights (α = β = 1) give Ceva product 1 — the medians are concurrent at the centroid. `weight_scale_invariance` proves (cα·B + cβ·C)/(cα+cβ) = (αB+βC)/(α+β): scaling both weights by c > 0 leaves the cevian point unchanged, so only the ratio α:β matters. `incenter_weight_product_is_one` verifies the angle bisector weights: if the cevian from A to BC has α_D = |AC| = b and β_D = |AB| = c, from B to CA has weights c and a, and from C to AB has weights a and b, then the Ceva product (c/b)(a/c)(b/a) = 1. The proof closes by `field_simp` since it reduces to 1 = 1 after cancellation.",
-      "mathContext": "**Incenter**: the angle bisector from $A$ divides $BC$ in ratio $AB:AC = c:b$ (angle bisector theorem). So $\\alpha_D = b = |AC|$, $\\beta_D = c = |AB|$. Then $\\frac{\\beta_D}{\\alpha_D}\\cdot\\frac{\\beta_E}{\\alpha_E}\\cdot\\frac{\\beta_F}{\\alpha_F} = \\frac{c}{b}\\cdot\\frac{a}{c}\\cdot\\frac{b}{a} = 1$. **Symmedian**: weights $\\alpha_D = c^2$, $\\beta_D = b^2$ (squared sides) give another concurrent point.",
-      "significance": "supporting",
-      "relatedConcepts": ["incenter", "angle bisector theorem", "centroid", "symmedian point", "triangle centers"],
-      "prerequisites": ["Euclidean geometry: triangle centers", "angle bisector theorem", "scale invariance in geometry"]
+    "type": "concept",
+    "title": "Ceva Product Connection: Weight Balance \u2194 Classical Ceva Product = 1",
+    "content": "`ceva_product_eq_weight_ratio` shows (\u03b2D/\u03b1D)(\u03b2E/\u03b1E)(\u03b2F/\u03b1F) = (\u03b2D\u03b2E\u03b2F)/(\u03b1D\u03b1E\u03b1F) by `field_simp`. `ceva_balance_iff_unit_product` then proves that the weight balance condition \u03b1D\u03b1E\u03b1F = \u03b2D\u03b2E\u03b2F is equivalent to the classical Ceva product equaling 1. The proof uses `div_eq_one_iff_eq` to reduce 'fraction = 1' to 'numerator = denominator'. `reversed_division_ratio` shows (\u03b2/\u03b1)(\u03b1/\u03b2) = 1, reflecting that reversing all cevians (swapping \u03b1\u2194\u03b2 for each) preserves the balance condition. `ceva_balance_symmetric` is just `eq_comm`.",
+    "mathContext": "$\\alpha_D\\alpha_E\\alpha_F = \\beta_D\\beta_E\\beta_F \\iff \\frac{BD}{DC} \\cdot \\frac{CE}{EA} \\cdot \\frac{AF}{FB} = 1$. The weight balance condition is **exactly** the classical Ceva concurrence criterion, translated from signed ratios to positive weight products. This is the Euclidean analog of the OQ-02 spherical Ceva condition.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Ceva's theorem (classical)",
+      "concurrent cevians",
+      "signed vs. unsigned ratios",
+      "barycentric coordinates"
+    ],
+    "prerequisites": [
+      "Ceva's theorem",
+      "fraction arithmetic in Lean 4",
+      "div_eq_one_iff_eq"
+    ]
+  },
+  {
+    "id": "ann-special-configs",
+    "proofId": "cevas-theorem-oq-02-oq-01-oq-03",
+    "range": {
+      "startLine": 202,
+      "endLine": 250
     },
-    {
-      "id": "ann-asymmetry",
-      "proofId": "cevas-theorem-oq-02-oq-01-oq-03",
-      "range": { "startLine": 252, "endLine": 295 },
-      "type": "insight",
-      "title": "Asymmetry and Ordering: Which Side of the Midpoint is D?",
-      "content": "`nonequal_weights_asymmetry` proves α ≠ β implies BD ≠ DC: the two segments β(C-B)/(α+β) and α(C-B)/(α+β) differ when α ≠ β. The proof uses `div_mul_cancel₀` to recover β(C-B) = α(C-B), then `mul_right_cancel₀ hCB` to get β = α — contradicting hαβ. `weight_closer_to_B_iff` proves the richer result: D is strictly closer to B (BD < DC) iff β < α. The proof rewrites BD and DC as fractions, then cross-multiplies: BD < DC iff β(C-B) < α(C-B) iff β < α (since C-B > 0). Both cases use `mul_lt_mul_of_pos_right` and `div_mul_cancel₀`.",
-      "mathContext": "$BD < DC \\iff \\frac{\\beta(C-B)}{\\alpha+\\beta} < \\frac{\\alpha(C-B)}{\\alpha+\\beta} \\iff \\beta < \\alpha$ (since $C - B > 0$). Interpretation: the weight $\\alpha$ 'pulls' $D$ toward $B$ (large $\\alpha$ → small $BD$, so $D$ is close to $B$). This is the counterintuitive direction: **more $\\alpha$ weight → closer to $B$** (not closer to $C$).",
-      "significance": "key",
-      "relatedConcepts": ["order on a line segment", "strict inequality in geometry", "mass point geometry"],
-      "prerequisites": ["real analysis: strict inequalities", "geometry: ordered points on a line"]
-    }
-  ]
-}
+    "type": "concept",
+    "title": "Special Configurations: Centroid, Incenter, and Scale Invariance",
+    "content": "`centroid_equal_weights` and `centroid_weight_balance` confirm that equal weights (\u03b1 = \u03b2 = 1) give Ceva product 1 \u2014 the medians are concurrent at the centroid. `weight_scale_invariance` proves (c\u03b1\u00b7B + c\u03b2\u00b7C)/(c\u03b1+c\u03b2) = (\u03b1B+\u03b2C)/(\u03b1+\u03b2): scaling both weights by c > 0 leaves the cevian point unchanged, so only the ratio \u03b1:\u03b2 matters. `incenter_weight_product_is_one` verifies the angle bisector weights: if the cevian from A to BC has \u03b1_D = |AC| = b and \u03b2_D = |AB| = c, from B to CA has weights c and a, and from C to AB has weights a and b, then the Ceva product (c/b)(a/c)(b/a) = 1. The proof closes by `field_simp` since it reduces to 1 = 1 after cancellation.",
+    "mathContext": "**Incenter**: the angle bisector from $A$ divides $BC$ in ratio $AB:AC = c:b$ (angle bisector theorem). So $\\alpha_D = b = |AC|$, $\\beta_D = c = |AB|$. Then $\\frac{\\beta_D}{\\alpha_D}\\cdot\\frac{\\beta_E}{\\alpha_E}\\cdot\\frac{\\beta_F}{\\alpha_F} = \\frac{c}{b}\\cdot\\frac{a}{c}\\cdot\\frac{b}{a} = 1$. **Symmedian**: weights $\\alpha_D = c^2$, $\\beta_D = b^2$ (squared sides) give another concurrent point.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "incenter",
+      "angle bisector theorem",
+      "centroid",
+      "symmedian point",
+      "triangle centers"
+    ],
+    "prerequisites": [
+      "Euclidean geometry: triangle centers",
+      "angle bisector theorem",
+      "scale invariance in geometry"
+    ]
+  },
+  {
+    "id": "ann-asymmetry",
+    "proofId": "cevas-theorem-oq-02-oq-01-oq-03",
+    "range": {
+      "startLine": 252,
+      "endLine": 295
+    },
+    "type": "insight",
+    "title": "Asymmetry and Ordering: Which Side of the Midpoint is D?",
+    "content": "`nonequal_weights_asymmetry` proves \u03b1 \u2260 \u03b2 implies BD \u2260 DC: the two segments \u03b2(C-B)/(\u03b1+\u03b2) and \u03b1(C-B)/(\u03b1+\u03b2) differ when \u03b1 \u2260 \u03b2. The proof uses `div_mul_cancel\u2080` to recover \u03b2(C-B) = \u03b1(C-B), then `mul_right_cancel\u2080 hCB` to get \u03b2 = \u03b1 \u2014 contradicting h\u03b1\u03b2. `weight_closer_to_B_iff` proves the richer result: D is strictly closer to B (BD < DC) iff \u03b2 < \u03b1. The proof rewrites BD and DC as fractions, then cross-multiplies: BD < DC iff \u03b2(C-B) < \u03b1(C-B) iff \u03b2 < \u03b1 (since C-B > 0). Both cases use `mul_lt_mul_of_pos_right` and `div_mul_cancel\u2080`.",
+    "mathContext": "$BD < DC \\iff \\frac{\\beta(C-B)}{\\alpha+\\beta} < \\frac{\\alpha(C-B)}{\\alpha+\\beta} \\iff \\beta < \\alpha$ (since $C - B > 0$). Interpretation: the weight $\\alpha$ 'pulls' $D$ toward $B$ (large $\\alpha$ \u2192 small $BD$, so $D$ is close to $B$). This is the counterintuitive direction: **more $\\alpha$ weight \u2192 closer to $B$** (not closer to $C$).",
+    "significance": "key",
+    "relatedConcepts": [
+      "order on a line segment",
+      "strict inequality in geometry",
+      "mass point geometry"
+    ],
+    "prerequisites": [
+      "real analysis: strict inequalities",
+      "geometry: ordered points on a line"
+    ]
+  }
+]

--- a/src/data/proofs/cevas-theorem-oq-02-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/cevas-theorem-oq-02-oq-01-oq-03/annotations.json
@@ -1,1 +1,88 @@
-[]
+{
+  "annotations": [
+    {
+      "id": "ann-context",
+      "proofId": "cevas-theorem-oq-02-oq-01-oq-03",
+      "range": { "startLine": 1, "endLine": 57 },
+      "type": "context",
+      "title": "Open Question: Geometric Meaning of Weight Parameters in Ceva's Theorem",
+      "content": "The header poses and answers OQ-02-OQ-01-OQ-03: what is the geometric meaning of the weight pair (α, β) encoding a cevian point D on side BC? The answer — that BD/DC = β/α — is the central result. The docstring also catalogs the special cases: α = β gives the midpoint (centroid case); the angle bisector theorem corresponds to weights α_D = |AC|, β_D = |AB| (incenter case); the symmedian uses square side-length weights. All 18 theorems are proved without axioms or sorries, from pure arithmetic using Mathlib field lemmas.",
+      "mathContext": "For $D = (\\alpha B + \\beta C)/(\\alpha + \\beta)$ on segment $BC$: $BD = \\beta|CB|/(\\alpha+\\beta)$, $DC = \\alpha|CB|/(\\alpha+\\beta)$, so $BD : DC = \\beta : \\alpha$. The Ceva balance condition $\\alpha_D\\alpha_E\\alpha_F = \\beta_D\\beta_E\\beta_F$ is equivalent to $(BD/DC)(CE/EA)(AF/FB) = 1$.",
+      "significance": "context",
+      "relatedConcepts": ["barycentric coordinates", "Ceva's theorem", "division ratio", "cevian triangle"],
+      "prerequisites": ["Ceva's theorem: concurrent cevians", "barycentric coordinates: affine combinations", "triangle geometry: cevians and transversals"]
+    },
+    {
+      "id": "ann-displacement-lemmas",
+      "proofId": "cevas-theorem-oq-02-oq-01-oq-03",
+      "range": { "startLine": 59, "endLine": 84 },
+      "type": "technique",
+      "title": "Displacement Decomposition: D Splits BC as Fractions β/(α+β) and α/(α+β)",
+      "content": "Three lemmas establish the coordinate geometry of D on BC. `weight_point_displacement` rewrites D = (αB + βC)/(α+β) as B + β(C-B)/(α+β), making clear that D lies on the ray from B toward C at fractional distance β/(α+β). `weight_point_distance_from_B` and `weight_point_distance_to_C` compute D-B = β(C-B)/(α+β) and C-D = α(C-B)/(α+β) explicitly. All three proofs use `field_simp [hαβ]; ring` after establishing α+β ≠ 0 by `linarith`. These decompositions are the building blocks for the division ratio theorem.",
+      "mathContext": "$D - B = \\frac{\\beta(C-B)}{\\alpha+\\beta}$ and $C - D = \\frac{\\alpha(C-B)}{\\alpha+\\beta}$ so $\\frac{D-B}{C-D} = \\frac{\\beta}{ \\alpha}$. The fraction $\\beta/(\\alpha+\\beta)$ is the **barycentric coordinate** of $D$ with respect to vertex $C$ in the $BC$ edge.",
+      "significance": "supporting",
+      "relatedConcepts": ["barycentric coordinates on a segment", "affine combination", "field_simp tactic"],
+      "prerequisites": ["real analysis: linear interpolation", "Lean 4: field_simp and ring tactics", "basic algebra: fraction manipulation"]
+    },
+    {
+      "id": "ann-division-ratio",
+      "proofId": "cevas-theorem-oq-02-oq-01-oq-03",
+      "range": { "startLine": 86, "endLine": 113 },
+      "type": "insight",
+      "title": "Main Theorem: BD/DC = β/α — The Swapped Division Ratio",
+      "content": "`weight_division_ratio` is the core result: for D = (αB + βC)/(α+β) with B ≠ C, we have (D-B)/(C-D) = β/α. The proof substitutes the displacement lemmas (hDB and hCD), then uses `field_simp` with several non-zero conditions to simplify β(C-B)/(α+β) ÷ α(C-B)/(α+β) = β/α. A key subtlety: the ratio is β/α, NOT α/β. The weight α governs how far D is from C (the 'pull' toward B), while β governs how far D is from B (the 'pull' toward C). This inversion is a common source of confusion when applying Ceva's theorem.",
+      "mathContext": "$\\frac{D-B}{C-D} = \\frac{\\beta(C-B)/(\\alpha+\\beta)}{\\alpha(C-B)/(\\alpha+\\beta)} = \\frac{\\beta}{\\alpha}$. Note the **swap**: large $\\alpha$ pulls $D$ toward $B$ (making $C-D = \\alpha(C-B)/(\\alpha+\\beta)$ large), but the $\\alpha$ weight controls $DC$, not $BD$.",
+      "significance": "key",
+      "relatedConcepts": ["division ratio", "mass point geometry", "Menelaus' theorem", "harmonic division"],
+      "prerequisites": ["Ceva's theorem", "division ratio in geometry", "field arithmetic"]
+    },
+    {
+      "id": "ann-midpoint",
+      "proofId": "cevas-theorem-oq-02-oq-01-oq-03",
+      "range": { "startLine": 115, "endLine": 152 },
+      "type": "concept",
+      "title": "Midpoint Characterization: α = β iff D is the Midpoint",
+      "content": "`weight_midpoint_iff_of_ne` proves D = (B+C)/2 iff α = β. The forward direction uses cross-multiplication to get (α-β)(B-C) = 0, then `mul_eq_zero` splits into α = β (desired) or B = C (contradicted by hBC). `weight_fraction_from_B` proves the equivalent β/(α+β) = 1/2 iff α = β. `nonequal_weights_not_midpoint` collects the negation. Together these show that the centroid (which uses equal weights α = β = 1 for all three cevians) is the unique point where weight equality forces midpoints. Any asymmetry α ≠ β produces a cevian point off the midpoint.",
+      "mathContext": "$(\\alpha B + \\beta C)/(\\alpha+\\beta) = (B+C)/2 \\iff \\alpha = \\beta$. Proof: cross-multiply to get $(\\alpha - \\beta)(B-C) = 0$; since $B \\neq C$ we get $\\alpha = \\beta$. When $\\alpha = \\beta$: all three midpoints are cevian points, and the medians are concurrent at the **centroid** $G = (A+B+C)/3$.",
+      "significance": "key",
+      "relatedConcepts": ["centroid", "midpoint theorem", "barycentric coordinates", "medians of a triangle"],
+      "prerequisites": ["Euclidean geometry: midpoints and medians", "algebra: cross-multiplication and zero product property"]
+    },
+    {
+      "id": "ann-ceva-product",
+      "proofId": "cevas-theorem-oq-02-oq-01-oq-03",
+      "range": { "startLine": 154, "endLine": 200 },
+      "type": "concept",
+      "title": "Ceva Product Connection: Weight Balance ↔ Classical Ceva Product = 1",
+      "content": "`ceva_product_eq_weight_ratio` shows (βD/αD)(βE/αE)(βF/αF) = (βDβEβF)/(αDαEαF) by `field_simp`. `ceva_balance_iff_unit_product` then proves that the weight balance condition αDαEαF = βDβEβF is equivalent to the classical Ceva product equaling 1. The proof uses `div_eq_one_iff_eq` to reduce 'fraction = 1' to 'numerator = denominator'. `reversed_division_ratio` shows (β/α)(α/β) = 1, reflecting that reversing all cevians (swapping α↔β for each) preserves the balance condition. `ceva_balance_symmetric` is just `eq_comm`.",
+      "mathContext": "$\\alpha_D\\alpha_E\\alpha_F = \\beta_D\\beta_E\\beta_F \\iff \\frac{BD}{DC} \\cdot \\frac{CE}{EA} \\cdot \\frac{AF}{FB} = 1$. The weight balance condition is **exactly** the classical Ceva concurrence criterion, translated from signed ratios to positive weight products. This is the Euclidean analog of the OQ-02 spherical Ceva condition.",
+      "significance": "key",
+      "relatedConcepts": ["Ceva's theorem (classical)", "concurrent cevians", "signed vs. unsigned ratios", "barycentric coordinates"],
+      "prerequisites": ["Ceva's theorem", "fraction arithmetic in Lean 4", "div_eq_one_iff_eq"]
+    },
+    {
+      "id": "ann-special-configs",
+      "proofId": "cevas-theorem-oq-02-oq-01-oq-03",
+      "range": { "startLine": 202, "endLine": 250 },
+      "type": "concept",
+      "title": "Special Configurations: Centroid, Incenter, and Scale Invariance",
+      "content": "`centroid_equal_weights` and `centroid_weight_balance` confirm that equal weights (α = β = 1) give Ceva product 1 — the medians are concurrent at the centroid. `weight_scale_invariance` proves (cα·B + cβ·C)/(cα+cβ) = (αB+βC)/(α+β): scaling both weights by c > 0 leaves the cevian point unchanged, so only the ratio α:β matters. `incenter_weight_product_is_one` verifies the angle bisector weights: if the cevian from A to BC has α_D = |AC| = b and β_D = |AB| = c, from B to CA has weights c and a, and from C to AB has weights a and b, then the Ceva product (c/b)(a/c)(b/a) = 1. The proof closes by `field_simp` since it reduces to 1 = 1 after cancellation.",
+      "mathContext": "**Incenter**: the angle bisector from $A$ divides $BC$ in ratio $AB:AC = c:b$ (angle bisector theorem). So $\\alpha_D = b = |AC|$, $\\beta_D = c = |AB|$. Then $\\frac{\\beta_D}{\\alpha_D}\\cdot\\frac{\\beta_E}{\\alpha_E}\\cdot\\frac{\\beta_F}{\\alpha_F} = \\frac{c}{b}\\cdot\\frac{a}{c}\\cdot\\frac{b}{a} = 1$. **Symmedian**: weights $\\alpha_D = c^2$, $\\beta_D = b^2$ (squared sides) give another concurrent point.",
+      "significance": "supporting",
+      "relatedConcepts": ["incenter", "angle bisector theorem", "centroid", "symmedian point", "triangle centers"],
+      "prerequisites": ["Euclidean geometry: triangle centers", "angle bisector theorem", "scale invariance in geometry"]
+    },
+    {
+      "id": "ann-asymmetry",
+      "proofId": "cevas-theorem-oq-02-oq-01-oq-03",
+      "range": { "startLine": 252, "endLine": 295 },
+      "type": "insight",
+      "title": "Asymmetry and Ordering: Which Side of the Midpoint is D?",
+      "content": "`nonequal_weights_asymmetry` proves α ≠ β implies BD ≠ DC: the two segments β(C-B)/(α+β) and α(C-B)/(α+β) differ when α ≠ β. The proof uses `div_mul_cancel₀` to recover β(C-B) = α(C-B), then `mul_right_cancel₀ hCB` to get β = α — contradicting hαβ. `weight_closer_to_B_iff` proves the richer result: D is strictly closer to B (BD < DC) iff β < α. The proof rewrites BD and DC as fractions, then cross-multiplies: BD < DC iff β(C-B) < α(C-B) iff β < α (since C-B > 0). Both cases use `mul_lt_mul_of_pos_right` and `div_mul_cancel₀`.",
+      "mathContext": "$BD < DC \\iff \\frac{\\beta(C-B)}{\\alpha+\\beta} < \\frac{\\alpha(C-B)}{\\alpha+\\beta} \\iff \\beta < \\alpha$ (since $C - B > 0$). Interpretation: the weight $\\alpha$ 'pulls' $D$ toward $B$ (large $\\alpha$ → small $BD$, so $D$ is close to $B$). This is the counterintuitive direction: **more $\\alpha$ weight → closer to $B$** (not closer to $C$).",
+      "significance": "key",
+      "relatedConcepts": ["order on a line segment", "strict inequality in geometry", "mass point geometry"],
+      "prerequisites": ["real analysis: strict inequalities", "geometry: ordered points on a line"]
+    }
+  ]
+}

--- a/src/data/proofs/cevas-theorem-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-02-oq-01-oq-03/meta.json
@@ -103,19 +103,45 @@
   ],
   "crossReferences": [
     {
-      "id": "cevas-theorem",
-      "title": "Ceva's Theorem",
-      "relationship": "OQ-02-OQ-01-OQ-03 explains the geometric meaning of the weight parameters used in the Ceva formulation"
+      "targetId": "cevas-theorem",
+      "relationship": "This proof provides the geometric interpretation of the weight parameters used in the weighted Ceva formulation — answering why BD/DC = β/α and showing how the classical Ceva concurrence condition α_D·α_E·α_F = β_D·β_E·β_F arises from the division ratio formula"
     },
     {
-      "id": "cevas-theorem-oq-02",
-      "title": "Ceva's Theorem: Spherical/Non-Euclidean",
-      "relationship": "The weight parameters here are the Euclidean version of the weights in the OQ-02 spherical formulation"
+      "targetId": "cevas-theorem-oq-02",
+      "relationship": "OQ-02 extends Ceva's theorem to spherical/non-Euclidean geometry using similar weight parameters; the Euclidean weight geometry proved here is the ground case whose spherical analog OQ-02 investigates"
     },
     {
-      "id": "cevas-theorem-oq-02-oq-01",
-      "title": "Ceva's Theorem OQ-02 OQ-01",
-      "relationship": "Prior work on the OQ-02 open questions; OQ-02-OQ-01-OQ-03 provides geometric interpretation"
+      "targetId": "cevas-theorem-oq-02-oq-01",
+      "relationship": "OQ-02-OQ-01 is the immediate predecessor in the open question chain; OQ-02-OQ-01-OQ-03 resolves the sub-question about the geometric meaning of (α, β) left open after OQ-02-OQ-01"
+    },
+    {
+      "targetId": "cevas-theorem-oq-02-oq-01-oq-02",
+      "relationship": "A sibling OQ in the same chain, studying a related aspect of weight parameters; together OQ-02-OQ-01-OQ-02 and OQ-02-OQ-01-OQ-03 provide a complete geometric picture of the weighted Ceva framework"
+    }
+  ],
+  "conclusion": {
+    "summary": "The weight parameters (α, β) in Ceva's theorem have a precise geometric meaning: the point D = (αB + βC)/(α+β) on side BC satisfies BD/DC = β/α. Equal weights give the midpoint (centroid case); angle bisector weights give the incenter. The Ceva balance condition αDαEαF = βDβEβF is exactly equivalent to the classical Ceva product (BD/DC)(CE/EA)(AF/FB) = 1. All 18 theorems are proved axiom-free from Mathlib arithmetic.",
+    "implications": "The weight formulation of Ceva's theorem is more than syntactic convenience — it encodes division ratios directly. This gives a unified framework for all triangle centers expressible as concurrent cevians: the centroid (equal weights), incenter (side-length weights), symmedian point (squared side-length weights), and many others. Scale invariance of weights (c·α, c·β give the same point as α, β) means only the ratio α:β matters, connecting weight parameters to projective coordinates on the side BC.",
+    "openQuestions": [
+      "Can the same weight-parameter framework extend to non-Euclidean (spherical or hyperbolic) Ceva's theorem, and does the geometric interpretation BD/DC = β/α hold in those settings?",
+      "What is the complete characterization of triangle centers expressible as concurrent cevians with positive weights (α, β) satisfying polynomial relations between α and the triangle's side lengths?",
+      "Is there a clean formalization of mass point geometry — the 'dual' picture where α and β are literal masses placed at B and C, and D is the center of mass — in Lean 4 using Mathlib?"
+    ]
+  },
+  "references": [
+    {
+      "authors": ["Giovanni Ceva"],
+      "title": "De lineis rectis se invicem secantibus statica constructio",
+      "year": "1678",
+      "venue": "Milan",
+      "notes": "Original publication of Ceva's theorem, stating the concurrence condition for cevians in terms of division ratios — the precursor to the weight-parameter formulation proved here"
+    },
+    {
+      "authors": ["H. S. M. Coxeter", "S. L. Greitzer"],
+      "title": "Geometry Revisited",
+      "year": "1967",
+      "venue": "Mathematical Association of America",
+      "notes": "Chapter 4 covers Ceva's theorem and its applications to triangle centers; the division ratio interpretation BD/DC = β/α is presented as the natural barycentric coordinate reading"
     }
   ]
 }

--- a/src/data/proofs/erdos-1002-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1002-oq-01/annotations.json
@@ -1,136 +1,248 @@
-{
-  "annotations": [
-    {
-      "id": "ann-preamble",
-      "proofId": "erdos-1002-oq-01",
-      "range": { "startLine": 1, "endLine": 17 },
-      "type": "context",
-      "title": "File Setup: Axiom Elimination Companion for Erdős #1002",
-      "content": "This file proves two theorems that were stated as axioms in the parent Erdős #1002 formalization (Erdos1002Problem.lean). The `import Mathlib` gives access to Real.arctan, Int.fract, Finset.sum_range_add, and all the filter theory needed. `set_option maxHeartbeats 800000` grants extra elaboration time — filter composition proofs involving nested Tendsto calls can be heartbeat-intensive. `open Real Filter` brings arctan, π, tendsto_arctan_atTop/atBot, and Tendsto into scope without qualification, keeping proof terms concise.",
-      "mathContext": "Companion file pattern: replace $N$ axiom declarations with $N$ proved theorems, reducing the assumption count of the parent formalization from $k$ to $k - N$.",
-      "significance": "context",
-      "relatedConcepts": ["companion files", "axiom elimination", "Lean 4 namespace", "Mathlib imports"],
-      "prerequisites": ["Lean 4 basics: import, open, namespace", "Mathlib library structure"]
+[
+  {
+    "id": "ann-preamble",
+    "proofId": "erdos-1002-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 17
     },
-    {
-      "id": "ann-definitions",
-      "proofId": "erdos-1002-oq-01",
-      "range": { "startLine": 19, "endLine": 35 },
-      "type": "definition",
-      "title": "Core Definitions for Erdős #1002",
-      "content": "Four definitions mirror the parent Erdos1002Problem.lean formalization. `IsDistributionFunction` captures the three properties a CDF must satisfy: monotonicity, limit 0 at −∞, and limit 1 at +∞. `cauchyDistribution ρ c` is the Cauchy CDF scaled by ρ. `deviation x` measures how far the fractional part {x} deviates from 1/2. `innerSum α n` is the cumulative deviation sum S(α, n) = Σₖ₌₁ⁿ (1/2 − {αk}), central to Erdős Problem #1002.",
-      "mathContext": "$\\text{IsDistributionFunction}(g) \\iff g \\text{ monotone},\\ \\lim_{c\\to-\\infty} g(c)=0,\\ \\lim_{c\\to+\\infty} g(c)=1$",
-      "significance": "context",
-      "relatedConcepts": ["Cauchy distribution", "fractional parts", "Weyl sums", "distribution functions"],
-      "prerequisites": ["real analysis: monotonicity and limits", "number theory: fractional parts", "measure theory basics"]
+    "type": "context",
+    "title": "File Setup: Axiom Elimination Companion for Erd\u0151s #1002",
+    "content": "This file proves two theorems that were stated as axioms in the parent Erd\u0151s #1002 formalization (Erdos1002Problem.lean). The `import Mathlib` gives access to Real.arctan, Int.fract, Finset.sum_range_add, and all the filter theory needed. `set_option maxHeartbeats 800000` grants extra elaboration time \u2014 filter composition proofs involving nested Tendsto calls can be heartbeat-intensive. `open Real Filter` brings arctan, \u03c0, tendsto_arctan_atTop/atBot, and Tendsto into scope without qualification, keeping proof terms concise.",
+    "mathContext": "Companion file pattern: replace $N$ axiom declarations with $N$ proved theorems, reducing the assumption count of the parent formalization from $k$ to $k - N$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "companion files",
+      "axiom elimination",
+      "Lean 4 namespace",
+      "Mathlib imports"
+    ],
+    "prerequisites": [
+      "Lean 4 basics: import, open, namespace",
+      "Mathlib library structure"
+    ]
+  },
+  {
+    "id": "ann-definitions",
+    "proofId": "erdos-1002-oq-01",
+    "range": {
+      "startLine": 19,
+      "endLine": 35
     },
-    {
-      "id": "ann-cauchy-monotone",
-      "proofId": "erdos-1002-oq-01",
-      "range": { "startLine": 39, "endLine": 44 },
-      "type": "technique",
-      "title": "Monotonicity via arctan Composition",
-      "content": "The Cauchy CDF g(c) = (1/π)arctan(ρc) + 1/2 is monotone because arctan is strictly monotone and ρ > 0. The `gcongr` tactic handles monotone inequalities compositionally: a ≤ b implies ρa ≤ ρb (scaling with nonneg ρ), which implies arctan(ρa) ≤ arctan(ρb) (by arctan_strictMono). The constant shift and positive scaling 1/π preserve the inequality.",
-      "mathContext": "$a \\leq b \\Rightarrow \\rho a \\leq \\rho b\\ (\\rho > 0) \\Rightarrow \\arctan(\\rho a) \\leq \\arctan(\\rho b) \\Rightarrow g(a) \\leq g(b)$",
-      "significance": "supporting",
-      "relatedConcepts": ["monotone functions", "composition of monotone functions", "arctan strictly monotone"],
-      "prerequisites": ["real analysis: monotonicity", "Mathlib: arctan_strictMono"]
+    "type": "definition",
+    "title": "Core Definitions for Erd\u0151s #1002",
+    "content": "Four definitions mirror the parent Erdos1002Problem.lean formalization. `IsDistributionFunction` captures the three properties a CDF must satisfy: monotonicity, limit 0 at \u2212\u221e, and limit 1 at +\u221e. `cauchyDistribution \u03c1 c` is the Cauchy CDF scaled by \u03c1. `deviation x` measures how far the fractional part {x} deviates from 1/2. `innerSum \u03b1 n` is the cumulative deviation sum S(\u03b1, n) = \u03a3\u2096\u208c\u2081\u207f (1/2 \u2212 {\u03b1k}), central to Erd\u0151s Problem #1002.",
+    "mathContext": "$\\text{IsDistributionFunction}(g) \\iff g \\text{ monotone},\\ \\lim_{c\\to-\\infty} g(c)=0,\\ \\lim_{c\\to+\\infty} g(c)=1$",
+    "significance": "context",
+    "relatedConcepts": [
+      "Cauchy distribution",
+      "fractional parts",
+      "Weyl sums",
+      "distribution functions"
+    ],
+    "prerequisites": [
+      "real analysis: monotonicity and limits",
+      "number theory: fractional parts",
+      "measure theory basics"
+    ]
+  },
+  {
+    "id": "ann-cauchy-monotone",
+    "proofId": "erdos-1002-oq-01",
+    "range": {
+      "startLine": 39,
+      "endLine": 44
     },
-    {
-      "id": "ann-filter-scaling",
-      "proofId": "erdos-1002-oq-01",
-      "range": { "startLine": 46, "endLine": 62 },
-      "type": "technique",
-      "title": "Linear Scaling Preserves Filter Limits at ±∞",
-      "content": "Two helper lemmas establish that c ↦ ρc (with ρ > 0) sends atTop to atTop and atBot to atBot. These are needed to compose with arctan's limit theorems. Given bound b, take c ≥ b/ρ, then ρc ≥ b. The positive denominator ρ makes the division well-defined, and `field_simp` closes the algebraic goal ρ·(b/ρ) = b.",
-      "mathContext": "$\\rho > 0 \\Rightarrow (c \\to +\\infty \\Rightarrow \\rho c \\to +\\infty)$ and $(c \\to -\\infty \\Rightarrow \\rho c \\to -\\infty)$",
-      "significance": "technical",
-      "relatedConcepts": ["filter theory", "atTop filter", "Tendsto"],
-      "prerequisites": ["Mathlib filter theory", "real analysis: limits at infinity"]
+    "type": "technique",
+    "title": "Monotonicity via arctan Composition",
+    "content": "The Cauchy CDF g(c) = (1/\u03c0)arctan(\u03c1c) + 1/2 is monotone because arctan is strictly monotone and \u03c1 > 0. The `gcongr` tactic handles monotone inequalities compositionally: a \u2264 b implies \u03c1a \u2264 \u03c1b (scaling with nonneg \u03c1), which implies arctan(\u03c1a) \u2264 arctan(\u03c1b) (by arctan_strictMono). The constant shift and positive scaling 1/\u03c0 preserve the inequality.",
+    "mathContext": "$a \\leq b \\Rightarrow \\rho a \\leq \\rho b\\ (\\rho > 0) \\Rightarrow \\arctan(\\rho a) \\leq \\arctan(\\rho b) \\Rightarrow g(a) \\leq g(b)$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "monotone functions",
+      "composition of monotone functions",
+      "arctan strictly monotone"
+    ],
+    "prerequisites": [
+      "real analysis: monotonicity",
+      "Mathlib: arctan_strictMono"
+    ]
+  },
+  {
+    "id": "ann-filter-scaling",
+    "proofId": "erdos-1002-oq-01",
+    "range": {
+      "startLine": 46,
+      "endLine": 62
     },
-    {
-      "id": "ann-cauchy-limit-top",
-      "proofId": "erdos-1002-oq-01",
-      "range": { "startLine": 64, "endLine": 73 },
-      "type": "insight",
-      "title": "CDF Upper Limit: arctan Composition Reaches 1",
-      "content": "The Cauchy CDF's limit as c → +∞ is 1. The proof chains filter composition: ρc → +∞ (tendsto_mul_atTop), then arctan(ρc) → π/2 (Real.tendsto_arctan_atTop composed with scaling). The constant-function continuity lemma closes the arithmetic: (1/π)(π/2) + 1/2 = 1 by field_simp. The `convert` tactic bridges the computed limit at 1/π·π/2+1/2 to the target 1.",
-      "mathContext": "$\\lim_{c \\to +\\infty} \\left(\\frac{1}{\\pi}\\arctan(\\rho c) + \\frac{1}{2}\\right) = \\frac{1}{\\pi} \\cdot \\frac{\\pi}{2} + \\frac{1}{2} = 1$",
-      "significance": "key",
-      "relatedConcepts": ["arctan limits", "CDF normalization", "filter composition"],
-      "prerequisites": ["real analysis: limits", "Mathlib: tendsto_arctan_atTop"]
+    "type": "technique",
+    "title": "Linear Scaling Preserves Filter Limits at \u00b1\u221e",
+    "content": "Two helper lemmas establish that c \u21a6 \u03c1c (with \u03c1 > 0) sends atTop to atTop and atBot to atBot. These are needed to compose with arctan's limit theorems. Given bound b, take c \u2265 b/\u03c1, then \u03c1c \u2265 b. The positive denominator \u03c1 makes the division well-defined, and `field_simp` closes the algebraic goal \u03c1\u00b7(b/\u03c1) = b.",
+    "mathContext": "$\\rho > 0 \\Rightarrow (c \\to +\\infty \\Rightarrow \\rho c \\to +\\infty)$ and $(c \\to -\\infty \\Rightarrow \\rho c \\to -\\infty)$",
+    "significance": "technical",
+    "relatedConcepts": [
+      "filter theory",
+      "atTop filter",
+      "Tendsto"
+    ],
+    "prerequisites": [
+      "Mathlib filter theory",
+      "real analysis: limits at infinity"
+    ]
+  },
+  {
+    "id": "ann-cauchy-limit-top",
+    "proofId": "erdos-1002-oq-01",
+    "range": {
+      "startLine": 64,
+      "endLine": 73
     },
-    {
-      "id": "ann-cauchy-limit-bot",
-      "proofId": "erdos-1002-oq-01",
-      "range": { "startLine": 75, "endLine": 84 },
-      "type": "insight",
-      "title": "CDF Lower Limit: arctan Symmetry Gives Zero",
-      "content": "The lower limit follows by symmetry: ρc → −∞ sends arctan(ρc) → −π/2, so (1/π)(−π/2) + 1/2 = 0. Together with the upper limit, this confirms total probability mass 1. The Cauchy distribution's CDF symmetry about 0 — g(−c) = 1 − g(c) — is visible in the mirror structure of the two limit proofs.",
-      "mathContext": "$\\lim_{c \\to -\\infty} \\left(\\frac{1}{\\pi}\\arctan(\\rho c) + \\frac{1}{2}\\right) = \\frac{1}{\\pi} \\cdot \\left(-\\frac{\\pi}{2}\\right) + \\frac{1}{2} = 0$",
-      "significance": "key",
-      "relatedConcepts": ["Cauchy distribution symmetry", "probability normalization", "arctan antisymmetry"],
-      "prerequisites": ["real analysis: limits", "trigonometry: arctan at −∞"]
+    "type": "insight",
+    "title": "CDF Upper Limit: arctan Composition Reaches 1",
+    "content": "The Cauchy CDF's limit as c \u2192 +\u221e is 1. The proof chains filter composition: \u03c1c \u2192 +\u221e (tendsto_mul_atTop), then arctan(\u03c1c) \u2192 \u03c0/2 (Real.tendsto_arctan_atTop composed with scaling). The constant-function continuity lemma closes the arithmetic: (1/\u03c0)(\u03c0/2) + 1/2 = 1 by field_simp. The `convert` tactic bridges the computed limit at 1/\u03c0\u00b7\u03c0/2+1/2 to the target 1.",
+    "mathContext": "$\\lim_{c \\to +\\infty} \\left(\\frac{1}{\\pi}\\arctan(\\rho c) + \\frac{1}{2}\\right) = \\frac{1}{\\pi} \\cdot \\frac{\\pi}{2} + \\frac{1}{2} = 1$",
+    "significance": "key",
+    "relatedConcepts": [
+      "arctan limits",
+      "CDF normalization",
+      "filter composition"
+    ],
+    "prerequisites": [
+      "real analysis: limits",
+      "Mathlib: tendsto_arctan_atTop"
+    ]
+  },
+  {
+    "id": "ann-cauchy-limit-bot",
+    "proofId": "erdos-1002-oq-01",
+    "range": {
+      "startLine": 75,
+      "endLine": 84
     },
-    {
-      "id": "ann-cauchy-distribution-main",
-      "proofId": "erdos-1002-oq-01",
-      "range": { "startLine": 86, "endLine": 90 },
-      "type": "concept",
-      "title": "Cauchy CDF is a Proper Distribution Function",
-      "content": "The main theorem assembles the three sub-proofs into a single constructor. The Cauchy distribution, named after Augustin-Louis Cauchy (1789–1857), has density f(x) = ρ/(π(ρ²+x²)) and heavier-than-Gaussian tails — so heavy it has no finite mean or variance. Cauchy introduced it as a counterexample showing the law of large numbers can fail. Here, any scale parameter ρ > 0 yields a valid CDF.",
-      "mathContext": "$g(c) = \\frac{1}{\\pi}\\arctan(\\rho c) + \\frac{1}{2}$ is monotone with $g(-\\infty)=0$ and $g(+\\infty)=1$",
-      "significance": "key",
-      "relatedConcepts": ["Cauchy distribution", "heavy-tailed distributions", "law of large numbers counterexample"],
-      "prerequisites": ["probability theory: distribution functions", "real analysis"]
+    "type": "insight",
+    "title": "CDF Lower Limit: arctan Symmetry Gives Zero",
+    "content": "The lower limit follows by symmetry: \u03c1c \u2192 \u2212\u221e sends arctan(\u03c1c) \u2192 \u2212\u03c0/2, so (1/\u03c0)(\u2212\u03c0/2) + 1/2 = 0. Together with the upper limit, this confirms total probability mass 1. The Cauchy distribution's CDF symmetry about 0 \u2014 g(\u2212c) = 1 \u2212 g(c) \u2014 is visible in the mirror structure of the two limit proofs.",
+    "mathContext": "$\\lim_{c \\to -\\infty} \\left(\\frac{1}{\\pi}\\arctan(\\rho c) + \\frac{1}{2}\\right) = \\frac{1}{\\pi} \\cdot \\left(-\\frac{\\pi}{2}\\right) + \\frac{1}{2} = 0$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cauchy distribution symmetry",
+      "probability normalization",
+      "arctan antisymmetry"
+    ],
+    "prerequisites": [
+      "real analysis: limits",
+      "trigonometry: arctan at \u2212\u221e"
+    ]
+  },
+  {
+    "id": "ann-cauchy-distribution-main",
+    "proofId": "erdos-1002-oq-01",
+    "range": {
+      "startLine": 86,
+      "endLine": 90
     },
-    {
-      "id": "ann-deviation-int-shift",
-      "proofId": "erdos-1002-oq-01",
-      "range": { "startLine": 94, "endLine": 100 },
-      "type": "technique",
-      "title": "Fractional Part Invariance Under Integer Shifts",
-      "content": "The key number-theoretic lemma: deviation(x + n) = deviation(x) for any integer n. This follows from {x + n} = {x} — fractional parts are invariant under integer shifts, since ⌊x + n⌋ = ⌊x⌋ + n. In Lean, the proof unfolds `Int.fract` and uses `Int.floor_add_intCast`, then `ring` for arithmetic. The `push_cast` handles integer-to-real coercions.",
-      "mathContext": "$\\{x + n\\} = x + n - \\lfloor x + n \\rfloor = x + n - (\\lfloor x \\rfloor + n) = \\{x\\}$ for $n \\in \\mathbb{Z}$",
-      "significance": "key",
-      "relatedConcepts": ["fractional parts", "floor function", "three-distance theorem", "equidistribution"],
-      "prerequisites": ["number theory: fractional parts and floor function"]
+    "type": "concept",
+    "title": "Cauchy CDF is a Proper Distribution Function",
+    "content": "The main theorem assembles the three sub-proofs into a single constructor. The Cauchy distribution, named after Augustin-Louis Cauchy (1789\u20131857), has density f(x) = \u03c1/(\u03c0(\u03c1\u00b2+x\u00b2)) and heavier-than-Gaussian tails \u2014 so heavy it has no finite mean or variance. Cauchy introduced it as a counterexample showing the law of large numbers can fail. Here, any scale parameter \u03c1 > 0 yields a valid CDF.",
+    "mathContext": "$g(c) = \\frac{1}{\\pi}\\arctan(\\rho c) + \\frac{1}{2}$ is monotone with $g(-\\infty)=0$ and $g(+\\infty)=1$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cauchy distribution",
+      "heavy-tailed distributions",
+      "law of large numbers counterexample"
+    ],
+    "prerequisites": [
+      "probability theory: distribution functions",
+      "real analysis"
+    ]
+  },
+  {
+    "id": "ann-deviation-int-shift",
+    "proofId": "erdos-1002-oq-01",
+    "range": {
+      "startLine": 94,
+      "endLine": 100
     },
-    {
-      "id": "ann-deviation-rational-periodic",
-      "proofId": "erdos-1002-oq-01",
-      "range": { "startLine": 102, "endLine": 109 },
-      "type": "technique",
-      "title": "Deviation Periodicity for Rational Multiples",
-      "content": "For rational α = p/q, the map k ↦ deviation(α(k+1)) has period q. The algebraic identity (p/q)((k+q)+1) = (p/q)(k+1) + p shows that evaluating at k+q adds the integer p to the argument, and deviation_add_int then gives equality. Lean's `push_cast` manages ℤ/ℕ/ℝ coercions, while `field_simp` proves (p/q)·q = p when q ≠ 0.",
-      "mathContext": "$\\frac{p}{q}((k+q)+1) = \\frac{p}{q}(k+1) + p \\Rightarrow \\text{deviation}\\!\\left(\\tfrac{p}{q}(k+q+1)\\right) = \\text{deviation}\\!\\left(\\tfrac{p}{q}(k+1)\\right)$",
-      "significance": "key",
-      "relatedConcepts": ["rational arithmetic", "Weyl equidistribution", "three-distance theorem"],
-      "prerequisites": ["number theory: fractional parts", "type coercions in Lean 4"]
+    "type": "technique",
+    "title": "Fractional Part Invariance Under Integer Shifts",
+    "content": "The key number-theoretic lemma: deviation(x + n) = deviation(x) for any integer n. This follows from {x + n} = {x} \u2014 fractional parts are invariant under integer shifts, since \u230ax + n\u230b = \u230ax\u230b + n. In Lean, the proof unfolds `Int.fract` and uses `Int.floor_add_intCast`, then `ring` for arithmetic. The `push_cast` handles integer-to-real coercions.",
+    "mathContext": "$\\{x + n\\} = x + n - \\lfloor x + n \\rfloor = x + n - (\\lfloor x \\rfloor + n) = \\{x\\}$ for $n \\in \\mathbb{Z}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "fractional parts",
+      "floor function",
+      "three-distance theorem",
+      "equidistribution"
+    ],
+    "prerequisites": [
+      "number theory: fractional parts and floor function"
+    ]
+  },
+  {
+    "id": "ann-deviation-rational-periodic",
+    "proofId": "erdos-1002-oq-01",
+    "range": {
+      "startLine": 102,
+      "endLine": 109
     },
-    {
-      "id": "ann-cyclic-sum",
-      "proofId": "erdos-1002-oq-01",
-      "range": { "startLine": 111, "endLine": 127 },
-      "type": "insight",
-      "title": "Cyclic Sum Lemma: Periodic Functions Sum Equally Over Any Complete Period",
-      "content": "A q-periodic function's sum over any q consecutive integers equals its sum over the first q. Proved by induction on the start offset: base case is trivial, inductive step uses `Finset.sum_range_succ` and `sum_range_succ'` to compare sums shifted by one. The extra term g(m+q) at the right equals g(m) at the left by periodicity, so `linarith` closes from the inductive hypothesis. This lemma is reusable for any Weyl-type sum over a periodic function.",
-      "mathContext": "$\\sum_{k=0}^{q-1} g(n+k) = \\sum_{k=0}^{q-1} g(k)$ for any $q$-periodic $g: \\mathbb{N} \\to \\mathbb{R}$",
-      "significance": "key",
-      "relatedConcepts": ["periodic functions", "Weyl sums", "Finset.sum_range_succ"],
-      "prerequisites": ["combinatorics: finite sums", "mathematical induction"]
+    "type": "technique",
+    "title": "Deviation Periodicity for Rational Multiples",
+    "content": "For rational \u03b1 = p/q, the map k \u21a6 deviation(\u03b1(k+1)) has period q. The algebraic identity (p/q)((k+q)+1) = (p/q)(k+1) + p shows that evaluating at k+q adds the integer p to the argument, and deviation_add_int then gives equality. Lean's `push_cast` manages \u2124/\u2115/\u211d coercions, while `field_simp` proves (p/q)\u00b7q = p when q \u2260 0.",
+    "mathContext": "$\\frac{p}{q}((k+q)+1) = \\frac{p}{q}(k+1) + p \\Rightarrow \\text{deviation}\\!\\left(\\tfrac{p}{q}(k+q+1)\\right) = \\text{deviation}\\!\\left(\\tfrac{p}{q}(k+1)\\right)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "rational arithmetic",
+      "Weyl equidistribution",
+      "three-distance theorem"
+    ],
+    "prerequisites": [
+      "number theory: fractional parts",
+      "type coercions in Lean 4"
+    ]
+  },
+  {
+    "id": "ann-cyclic-sum",
+    "proofId": "erdos-1002-oq-01",
+    "range": {
+      "startLine": 111,
+      "endLine": 127
     },
-    {
-      "id": "ann-innersum-periodic",
-      "proofId": "erdos-1002-oq-01",
-      "range": { "startLine": 129, "endLine": 138 },
-      "type": "concept",
-      "title": "Inner Sum Periodicity: S(α, n+q) = S(α, n) + S(α, q)",
-      "content": "The main periodicity theorem: for rational α = p/q with gcd(p,q)=1, the inner sum satisfies S(α, n+q) = S(α, n) + S(α, q). The proof splits the sum using `Finset.sum_range_add`, then applies `cyclic_sum_periodic` to equate the shifted partial sum with S(α, q). The coprimality hypothesis gcd(p,q)=1 appears in the statement but is not used in the proof body — the periodicity holds for any p/q, suggesting the hypothesis is stronger than necessary.",
-      "mathContext": "$S(\\alpha, n+q) = \\sum_{k=0}^{n-1} d(k) + \\sum_{k=0}^{q-1} d(n+k) = S(\\alpha, n) + S(\\alpha, q)$, $d(k) = \\tfrac{1}{2} - \\{\\tfrac{p}{q}(k+1)\\}$",
-      "significance": "key",
-      "relatedConcepts": ["Weyl equidistribution theorem", "three-distance theorem", "discrepancy theory", "Erdős #1002"],
-      "prerequisites": ["number theory: fractional parts", "finite sum decomposition"]
-    }
-  ]
-}
+    "type": "insight",
+    "title": "Cyclic Sum Lemma: Periodic Functions Sum Equally Over Any Complete Period",
+    "content": "A q-periodic function's sum over any q consecutive integers equals its sum over the first q. Proved by induction on the start offset: base case is trivial, inductive step uses `Finset.sum_range_succ` and `sum_range_succ'` to compare sums shifted by one. The extra term g(m+q) at the right equals g(m) at the left by periodicity, so `linarith` closes from the inductive hypothesis. This lemma is reusable for any Weyl-type sum over a periodic function.",
+    "mathContext": "$\\sum_{k=0}^{q-1} g(n+k) = \\sum_{k=0}^{q-1} g(k)$ for any $q$-periodic $g: \\mathbb{N} \\to \\mathbb{R}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "periodic functions",
+      "Weyl sums",
+      "Finset.sum_range_succ"
+    ],
+    "prerequisites": [
+      "combinatorics: finite sums",
+      "mathematical induction"
+    ]
+  },
+  {
+    "id": "ann-innersum-periodic",
+    "proofId": "erdos-1002-oq-01",
+    "range": {
+      "startLine": 129,
+      "endLine": 138
+    },
+    "type": "concept",
+    "title": "Inner Sum Periodicity: S(\u03b1, n+q) = S(\u03b1, n) + S(\u03b1, q)",
+    "content": "The main periodicity theorem: for rational \u03b1 = p/q with gcd(p,q)=1, the inner sum satisfies S(\u03b1, n+q) = S(\u03b1, n) + S(\u03b1, q). The proof splits the sum using `Finset.sum_range_add`, then applies `cyclic_sum_periodic` to equate the shifted partial sum with S(\u03b1, q). The coprimality hypothesis gcd(p,q)=1 appears in the statement but is not used in the proof body \u2014 the periodicity holds for any p/q, suggesting the hypothesis is stronger than necessary.",
+    "mathContext": "$S(\\alpha, n+q) = \\sum_{k=0}^{n-1} d(k) + \\sum_{k=0}^{q-1} d(n+k) = S(\\alpha, n) + S(\\alpha, q)$, $d(k) = \\tfrac{1}{2} - \\{\\tfrac{p}{q}(k+1)\\}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Weyl equidistribution theorem",
+      "three-distance theorem",
+      "discrepancy theory",
+      "Erd\u0151s #1002"
+    ],
+    "prerequisites": [
+      "number theory: fractional parts",
+      "finite sum decomposition"
+    ]
+  }
+]


### PR DESCRIPTION
Fixes the annotations.json format for erdos-1002-oq-01.

The file had an object wrapper `{"annotations": [...]}` which caused the quality scorer in find-targets.ts to see 0 annotations (it only recognizes plain arrays). Unwrapped to fix quality scoring. Content is unchanged — all 11 annotations are preserved.