### PR TITLE
Fix: sync stale meta.lineCount for 5 proofs

### DIFF
--- a/src/data/proofs/erdos-1040/meta.json
+++ b/src/data/proofs/erdos-1040/meta.json
@@ -32,7 +32,7 @@
       "Measure theory: Lebesgue measure in the complex plane",
       "Approximation theory: Chebyshev polynomials and extremal polynomials"
     ],
-    "lineCount": 576,
+    "lineCount": 620,
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-224/meta.json
+++ b/src/data/proofs/erdos-224/meta.json
@@ -32,7 +32,7 @@
       }
     ],
     "axiomCount": 1,
-    "lineCount": 241,
+    "lineCount": 277,
     "assumptions": "1 axiom: danzer_grunbaum (Danzer-Grünbaum theorem: any 2^d+1 points contain an obtuse triple). 0 sorries. hypercube_card and hypercube_obtuse_free are proved theorems, not axioms.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-32/meta.json
+++ b/src/data/proofs/erdos-32/meta.json
@@ -56,7 +56,7 @@
       "Connection to Goldbach's conjecture"
     ],
     "axiomCount": 3,
-    "lineCount": 243,
+    "lineCount": 264,
     "prerequisites": [
       "Prime number theorem and prime distribution",
       "Additive complements",

--- a/src/data/proofs/erdos-433/meta.json
+++ b/src/data/proofs/erdos-433/meta.json
@@ -52,7 +52,7 @@
       "Gap counting and symmetry properties"
     ],
     "axiomCount": 4,
-    "lineCount": 314,
+    "lineCount": 398,
     "assumptions": "4 axioms, 0 sorries. Axioms: (1) sylvester_frobenius: G({a,b}) = ab - a - b for coprime a, b (Sylvester-Frobenius formula); (2) dixmier_lower_bound: g(k,n) ≥ ⌊(n-2)/(k-1)⌋·(n-k+1) - 1; (3) dixmier_upper_bound: g(k,n) ≤ (⌊(n-1)/(k-1)⌋ - 1)·n - 1 (Dixmier 1990 bounds); (4) erdos_433_solved: the asymptotic formula g(k,n) ~ n²/(k-1) holds. The g_two theorem (k=2 exact value n²-3n+1) has been proved."
   },
   "overview": {

--- a/src/data/proofs/erdos-986/meta.json
+++ b/src/data/proofs/erdos-986/meta.json
@@ -53,7 +53,7 @@
       "erdos_986_summary: combined results"
     ],
     "axiomCount": 3,
-    "lineCount": 239,
+    "lineCount": 224,
     "assumptions": "3 axiom(s) and 0 sorry(s). See the Lean source for details."
   },
   "overview": {


### PR DESCRIPTION
## Fix

5 gallery entries had stale `meta.lineCount` values (the `leanFile.lineCount` was already correct in each case — only the `meta` section copy was stale).

## Evidence

| Proof | Before | After | Actual |
|-------|--------|-------|--------|
| erdos-433 | 314 | 398 | 398 |
| erdos-1040 | 576 | 620 | 620 |
| erdos-224 | 241 | 277 | 277 |
| erdos-32 | 243 | 264 | 264 |
| erdos-986 | 239 | 224 | 224 |

No sorry counts or axiom counts were changed — those were all accurate.

---
Automated fix by lean-mechanic agent.