### PR TITLE
feat: prove Erdős 793 large_primes_satisfy_condition, fix syntax errors

### DIFF
--- a/proofs/Proofs/Erdos678Problem.lean
+++ b/proofs/Proofs/Erdos678Problem.lean
@@ -38,38 +38,58 @@ open Finset Nat
 
 /-- The LCM of consecutive integers from n+1 to n+k -/
 def intervalLcm (n k : ℕ) : ℕ :=
-  (Finset.range k).fold lcm 1 (fun i => n + 1 + i)
+  (Finset.range k).fold Nat.lcm 1 (fun i => n + 1 + i)
 
 /-- Alternative definition using Finset.Icc -/
 def intervalLcm' (n k : ℕ) : ℕ :=
-  (Finset.Icc (n + 1) (n + k)).fold lcm 1 id
+  (Finset.Icc (n + 1) (n + k)).fold Nat.lcm 1 id
 
 /-- The two definitions agree -/
 theorem intervalLcm_eq_intervalLcm' (n k : ℕ) (hk : k ≥ 1) :
     intervalLcm n k = intervalLcm' n k := by
-  sorry
+  simp only [intervalLcm, intervalLcm']
+  have himg : (Finset.range k).image (fun i => n + 1 + i) = Finset.Icc (n + 1) (n + k) := by
+    ext x
+    simp only [Finset.mem_image, Finset.mem_range, Finset.mem_Icc]
+    constructor
+    · rintro ⟨i, hi, rfl⟩; omega
+    · intro ⟨h1, h2⟩; exact ⟨x - (n + 1), by omega, by omega⟩
+  have hinj : Set.InjOn (fun i => n + 1 + i) (Finset.range k) := by
+    intro a _ b _ h
+    have h' : n + 1 + a = n + 1 + b := h
+    omega
+  conv_rhs => rw [← himg, Finset.fold_image hinj]
+  simp only [Function.comp, id]
 
 /-! ## Basic Properties of Interval LCM -/
 
 /-- LCM of empty interval is 1 -/
 theorem intervalLcm_zero (n : ℕ) : intervalLcm n 0 = 1 := by
-  unfold intervalLcm
-  simp [Finset.fold_empty]
+  simp [intervalLcm]
 
 /-- LCM of single element is that element -/
 theorem intervalLcm_one (n : ℕ) : intervalLcm n 1 = n + 1 := by
-  unfold intervalLcm
-  simp [Finset.range_one, Finset.fold_singleton]
+  simp [intervalLcm, Finset.range_succ,
+    Finset.fold_insert Finset.not_mem_range_self]
 
 /-- LCM increases when interval extends -/
 theorem intervalLcm_mono_right (n k : ℕ) :
     intervalLcm n k ∣ intervalLcm n (k + 1) := by
-  sorry
+  simp only [intervalLcm, Finset.range_succ,
+    Finset.fold_insert Finset.not_mem_range_self]
+  exact Nat.dvd_lcm_right _ _
 
 /-- Each element divides the interval LCM -/
 theorem dvd_intervalLcm (n k i : ℕ) (hi : i < k) :
     (n + 1 + i) ∣ intervalLcm n k := by
-  sorry
+  induction k with
+  | zero => omega
+  | succ k ih =>
+    simp only [intervalLcm, Finset.range_succ,
+      Finset.fold_insert Finset.not_mem_range_self]
+    rcases Nat.lt_succ_iff.mp hi |>.lt_or_eq with h | h
+    · exact Nat.dvd_trans (ih h) (Nat.dvd_lcm_right _ _)
+    · exact h ▸ Nat.dvd_lcm_left _ _
 
 /-! ## The Erdős Comparison Property -/
 
@@ -95,14 +115,6 @@ theorem selfridge_example_2 : erdosLcmComparison 132 139 7 := by
 
 /-! ## Computing Specific LCM Values -/
 
-/-- M(96,7) = lcm{97,98,99,100,101,102,103} -/
-theorem intervalLcm_96_7 : intervalLcm 96 7 = 1073741700 := by
-  native_decide
-
-/-- M(104,8) = lcm{105,106,107,108,109,110,111,112} -/
-theorem intervalLcm_104_8 : intervalLcm 104 8 = 786145080 := by
-  native_decide
-
 /-- Verification that M(96,7) > M(104,8) -/
 theorem lcm_comparison_96_104 : intervalLcm 96 7 > intervalLcm 104 8 := by
   native_decide
@@ -126,7 +138,11 @@ theorem cambie_2024 :
 theorem prime_power_divides_intervalLcm (n k p a : ℕ) (hp : p.Prime)
     (hpa : p ^ a ∈ Finset.Icc (n + 1) (n + k)) :
     p ^ a ∣ intervalLcm n k := by
-  sorry
+  obtain ⟨h1, h2⟩ := Finset.mem_Icc.mp hpa
+  have hi : p ^ a - (n + 1) < k := by omega
+  have heq : n + 1 + (p ^ a - (n + 1)) = p ^ a := by omega
+  calc p ^ a = n + 1 + (p ^ a - (n + 1)) := heq.symm
+    _ ∣ intervalLcm n k := dvd_intervalLcm n k _ hi
 
 /-- Key insight: an interval can "skip" a prime power -/
 theorem interval_skip_prime_power (n k p : ℕ) (hp : p.Prime)
@@ -150,8 +166,9 @@ theorem intervalLcm_chebyshev_upper (n k : ℕ) :
 /-! ## Erdős's Observations -/
 
 /-- The minimal n for which comparison holds grows faster than linearly -/
-def minimalN (k : ℕ) : ℕ :=
-  Nat.find (⟨96, 104, by sorry⟩ : ∃ n m : ℕ, erdosLcmComparison n m k)
+noncomputable def minimalN (k : ℕ) : ℕ :=
+  haveI := Classical.decPred (fun n => ∃ m : ℕ, erdosLcmComparison n m k)
+  Nat.find (⟨96, 104, by sorry⟩ : ∃ n, ∃ m : ℕ, erdosLcmComparison n m k)
 
 /-- Erdős proved n_k/k → ∞ -/
 theorem erdos_growth_rate : ∀ C : ℕ, ∃ K : ℕ, ∀ k ≥ K, minimalN k > C * k := by

--- a/proofs/Proofs/Stubs/Erdos793Problem.lean
+++ b/proofs/Proofs/Stubs/Erdos793Problem.lean
@@ -72,7 +72,7 @@ def Icc_nat (n : ℕ) : Finset ℕ := Finset.Icc 1 n
 
 /-- F(n): maximum size of a valid subset of {1,...,n} -/
 noncomputable def F (n : ℕ) : ℕ :=
-  sSup { A.card | A : Finset ℕ // A ⊆ Icc_nat n ∧ satisfiesCondition A }
+  sSup { k : ℕ | ∃ A : Finset ℕ, A ⊆ Icc_nat n ∧ satisfiesCondition A ∧ A.card = k }
 
 /-
 ## Prime Counting Function
@@ -86,14 +86,22 @@ noncomputable def primePi (n : ℕ) : ℕ :=
 
 /-- Primes in (n^{2/3}, n] can all be included -/
 theorem large_primes_satisfy_condition (n : ℕ) (hn : n ≥ 8) :
-    let A := (Finset.Icc 1 n).filter (fun p => Nat.Prime p ∧ p > n^(2/3 : ℝ))
+    let A := (Finset.Icc 1 n).filter (fun p => Nat.Prime p ∧ (p : ℝ) > (n : ℝ)^(2/3 : ℝ))
     satisfiesCondition A := by
   intro A
-  intro a ha b hb c hc hab hac
-  simp only [mem_filter, mem_Icc] at ha hb hc
-  -- a is prime and > n^{2/3}, so a > b and a > c
-  -- Thus a ∤ bc since a is prime and neither b nor c equals a
-  sorry
+  intro a ha b hb c hc hab hac hdvd
+  -- All elements are prime; a ∣ b*c implies a ∣ b or a ∣ c (Euclid),
+  -- forcing a = b or a = c (prime divides prime ⟹ equal), contradictions.
+  have hpa : Nat.Prime a := (Finset.mem_filter.mp ha).2.1
+  have hpb : Nat.Prime b := (Finset.mem_filter.mp hb).2.1
+  have hpc : Nat.Prime c := (Finset.mem_filter.mp hc).2.1
+  rcases hpa.dvd_mul.mp hdvd with h | h
+  · rcases hpb.eq_one_or_self_of_dvd a h with h1 | h2
+    · linarith [hpa.one_lt]
+    · exact hab h2
+  · rcases hpc.eq_one_or_self_of_dvd a h with h1 | h2
+    · linarith [hpa.one_lt]
+    · exact hac h2
 
 /-
 ## Known Bounds
@@ -177,7 +185,7 @@ def satisfiesConditionR (A : Finset ℕ) (r : ℕ) : Prop :=
 
 /-- F_r(n): maximum size for r-product condition -/
 noncomputable def F_r (n r : ℕ) : ℕ :=
-  sSup { A.card | A : Finset ℕ // A ⊆ Icc_nat n ∧ satisfiesConditionR A r }
+  sSup { k : ℕ | ∃ A : Finset ℕ, A ⊆ Icc_nat n ∧ satisfiesConditionR A r ∧ A.card = k }
 
 /-- Generalized conjecture: exponent becomes 2/(r+1) -/
 axiom generalized_bounds (r : ℕ) (hr : r ≥ 2) :

--- a/research/problems/erdos-678-incomplete-01/knowledge.md
+++ b/research/problems/erdos-678-incomplete-01/knowledge.md
@@ -1,0 +1,62 @@
+# Knowledge: Erdős 678 - LCM of Consecutive Integer Intervals
+
+## Problem Summary
+
+Erdős Problem #678: Let M(n,k) = lcm{n+1, ..., n+k}. Are there infinitely many m,n,k ≥ 3
+with m ≥ n+k such that M(n,k) > M(m,k+1)?
+
+Answer: YES (Stijn Cambie, 2024). The formalization has 7 remaining sorrys (down from 11,
+file now compiles).
+
+## Session 2026-04-04 (Session 1) - Fix compilation + prove 4 sorrys
+
+**Mode**: FRESH
+**Outcome**: progress
+
+### What I Did
+- Fixed compilation: file previously failed to build due to ambiguous `lcm` in
+  `(Finset.range k).fold lcm 1 (fun i => n+1+i)`. With `open Finset Nat`, Lean couldn't
+  resolve `lcm`. Fixed by using `Nat.lcm` explicitly.
+- Proved `intervalLcm_eq_intervalLcm'`: uses `Finset.fold_image` with bijection
+  `(fun i => n+1+i) : range k → Icc (n+1) (n+k)`, proved via `ext; simp; omega`
+- Proved `intervalLcm_mono_right`: `range k ⊆ range (k+1)` via `range_succ` + `fold_insert`
+  → `intervalLcm n (k+1) = Nat.lcm (n+k+1) (intervalLcm n k)` → `Nat.dvd_lcm_right`
+- Proved `dvd_intervalLcm`: induction on k, using `fold_insert` + `dvd_lcm_{left,right}`
+- Proved `prime_power_divides_intervalLcm`: direct from `dvd_intervalLcm` via bound arithmetic
+- Removed wrong expected values: `intervalLcm_96_7 = 1073741700` and `intervalLcm_104_8 = 786145080`
+  were WRONG (file never compiled, these were never verified). Actual values:
+  - `intervalLcm 96 7 = lcm(97..103) = 8,321,670,749,700` (not 1,073,741,700)
+  - `intervalLcm 104 8 = lcm(105..112) ≈ 3,803,928,503,760`
+- Fixed `minimalN` def: added `noncomputable` + `Classical.decPred` to fix typeclass error
+
+### Key Findings
+- `intervalLcm_chebyshev_upper` (M(n,k) ≤ 4^k) is **FALSE as stated** for n > 0:
+  M(96, 7) ≈ 8.3 × 10^12 ≫ 4^7 = 16384. True only for n=0 (i.e., lcm(1..k) ≤ 4^k).
+- Key fold manipulation pattern: `range_succ` + `fold_insert not_mem_range_self` converts
+  `intervalLcm n (k+1)` to `Nat.lcm (n+k+1) (intervalLcm n k)`.
+- `Finset.fold_image` signature: `(image g s).fold op b f = s.fold op b (f ∘ g)` when g injOn s.
+  Use `conv_rhs` to apply it to the RHS of an equality.
+
+### Files Modified
+- `proofs/Proofs/Erdos678Problem.lean`: fixed compilation, proved 4 sorrys (11→7)
+
+### PR
+- https://github.com/rjwalters/lean-genius/pull/9294
+
+### Remaining 7 Sorrys
+
+| Sorry | Why blocked |
+|-------|-------------|
+| `erdos_678_infinitely_many` | Needs Cambie 2024 proof |
+| `cambie_2024` | Needs Cambie 2024 proof |
+| `interval_skip_prime_power` | Complex prime power analysis |
+| `intervalLcm_growth` | Needs Chebyshev-type theorem |
+| `intervalLcm_chebyshev_upper` | FALSE as stated (should be restricted to n=0) |
+| `minimalN` existence | Needs k ≥ 7 existence for all large k |
+| `erdos_growth_rate` | Needs Erdős result on growth of minimal n |
+
+### Next Steps
+1. Fix `intervalLcm_chebyshev_upper` statement to `n = 0` version, then prove via
+   `Nat.centralBinom` or prime counting bounds
+2. Attempt `interval_skip_prime_power` — prime power gap analysis in intervals
+3. `erdos_678_infinitely_many` is OPEN (Cambie 2024 not yet in Mathlib)

--- a/src/data/proofs/erdos-793/meta.json
+++ b/src/data/proofs/erdos-793/meta.json
@@ -18,20 +18,20 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 793,
     "erdosUrl": "https://erdosproblems.com/793",
     "erdosProblemStatus": "open",
     "axiomCount": 5,
-    "lineCount": 191,
-    "assumptions": "5 axiom(s) and 1 sorry(s). See the Lean source for details.",
+    "lineCount": 199,
+    "assumptions": "5 axiom(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "This problem originates from Erdős's 1938 paper 'On sequences of integers no one of which divides the product of two others', one of his earliest contributions to multiplicative number theory and extremal combinatorics. The concept of primitive sets — where no element divides another — goes back to Besicovitch (1934) and Behrend (1935), who studied their density properties. Erdős strengthened the condition: instead of just pairwise non-divisibility, he required that no element $a$ divides the product $bc$ of any two other distinct elements. In his 1969 paper 'Some applications of graph theory to number theory', Erdős introduced an elegant bipartite graph construction to prove the upper bound, pioneering the use of extremal graph theory in number-theoretic problems. The graph has small integers and large primes as vertices, with edges encoding products in the set; the divisibility condition forces this graph to be $P_3$-free (no path of length 3), hence a forest. This technique — reducing a number theory problem to a forbidden subgraph problem — became a template for many later results in combinatorial number theory, including work by Pomerance and Alon on primitive sets and their generalizations. The exact constant $C$ in the secondary term remains open, connecting to deep questions about the distribution of smooth numbers and the multiplicative structure of integers.",
     "problemStatement": "Let $F(n)$ be the maximum cardinality of $A \\subseteq \\{1,\\ldots,n\\}$ such that $a \\nmid bc$ for all distinct $a, b, c \\in A$. Does there exist a constant $C$ such that $F(n) = \\pi(n) + (C + o(1)) \\cdot n^{2/3} \\cdot (\\log n)^{-2}$?",
     "text": "Let F(n) = max size of A ⊆ {1,...,n} where a ∤ bc for distinct a,b,c ∈ A. Is F(n) = π(n) + (C+o(1))·n^{2/3}·(log n)^{-2} for some constant C? Known: bounds with different constants c₁, c₂. OPEN.",
-    "proofStrategy": "The formalization captures: (1) The divisibility condition `satisfiesCondition` requiring $a \\nmid bc$ for distinct triples. (2) The extremal function $F(n)$ as a supremum over valid sets. (3) The prime counting function $\\pi(n)$ as the dominant term. (4) A proof sketch that primes $p > n^{2/3}$ automatically satisfy the condition. (5) Erdős's bounds $\\pi(n) + c_1 n^{2/3}(\\log n)^{-2} \\leq F(n) \\leq \\pi(n) + c_2 n^{2/3}(\\log n)^{-2}$. (6) The conjecture formalized via `Filter.Tendsto` for the normalized secondary term. (7) The bipartite graph construction (`ErdosGraph`) with the $P_3$-free property. (8) Generalization to $r$-products with exponent $2/(r+1)$.",
+    "proofStrategy": "The formalization captures: (1) The divisibility condition `satisfiesCondition` requiring $a \\nmid bc$ for distinct triples. (2) The extremal function $F(n)$ as a supremum over valid sets. (3) The prime counting function $\\pi(n)$ as the dominant term. (4) A machine-checked proof that primes $p > n^{2/3}$ satisfy the condition: if $a$ is prime and $a \\mid bc$ with $b, c$ also prime and $a \\neq b$, $a \\neq c$, then by Euclid's lemma $a \\mid b$ or $a \\mid c$, forcing $a = b$ or $a = c$ — a contradiction. (5) Erdős's bounds $\\pi(n) + c_1 n^{2/3}(\\log n)^{-2} \\leq F(n) \\leq \\pi(n) + c_2 n^{2/3}(\\log n)^{-2}$. (6) The conjecture formalized via `Filter.Tendsto` for the normalized secondary term. (7) The bipartite graph construction (`ErdosGraph`) with the $P_3$-free property. (8) Generalization to $r$-products with exponent $2/(r+1)$.",
     "keyInsights": [
       "**Large primes are free**: All primes $p > n^{2/3}$ satisfy the condition automatically. If $p \\mid bc$ with $b, c \\leq n$, then $p \\mid b$ or $p \\mid c$ (primality), but $b, c < p^{3/2}$ and $b, c \\neq p$ force $bc < p \\cdot n < p^2$, contradicting $p^2 \\mid bc$.",
       "**Graph theory meets number theory**: Erdős's 1969 bipartite graph — small integers $[1, n^{2/3}]$ on one side, large primes on the other, edges encoding products in $A$ — reduces the upper bound to a graph-theoretic statement: $P_3$-free graphs are forests with $|E| < |V|$.",


### PR DESCRIPTION
## Summary

- Proved the sole sorry in `Proofs/Stubs/Erdos793Problem.lean` (`large_primes_satisfy_condition`)
- Fixed three pre-existing syntax/type errors that prevented the file from compiling

## Mathematical Content

**Theorem proved**: If $A \subseteq \{1,\ldots,n\}$ consists only of primes and $a, b, c \in A$ with $a \neq b$, $a \neq c$, then $a \nmid bc$.

**Proof**: By Euclid's lemma (`Nat.Prime.dvd_mul`), $a \mid bc$ forces $a \mid b$ or $a \mid c$. Since $b$ and $c$ are also prime, `Nat.Prime.eq_one_or_self_of_dvd` gives $a = 1$ or $a = b$ (resp. $a = c$). Since $a$ is prime, $a \neq 1$, so $a = b$ or $a = c$, contradicting $a \neq b$ and $a \neq c$.

## Fixes Applied

| Line | Issue | Fix |
|------|-------|-----|
| 75, 180 | `sSup { A.card \| A : Finset ℕ // ... }` — invalid `//` in set comprehension | Changed to existential form `{ k \| ∃ A, ... ∧ A.card = k }` |
| 89 | `n^(2/3 : ℝ)` with `n : ℕ` — no `HPow ℕ ℝ` instance | Explicit casts: `(p : ℝ) > (n : ℝ)^(2/3 : ℝ)` |

## Result

- **Sorries**: 1 → 0
- **Axioms**: 5 (unchanged — all encode open-problem assumptions by design)
- Build: ✅ compiles with warnings only (unused `hn` variable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)