### PR TITLE
fix: skip Lean source read for empty/missing annotation files

### DIFF
--- a/scripts/annotations/resolver.ts
+++ b/scripts/annotations/resolver.ts
@@ -253,6 +253,16 @@ export function validateLineAnnotations(
     return { valid: 0, misaligned: [] };
   }
 
+  // Nothing to validate if annotations array is empty
+  if (annotationsJson.length === 0) {
+    return { valid: 0, misaligned: [] };
+  }
+
+  // Skip if Lean source file doesn't exist (e.g. pending proof)
+  if (!fs.existsSync(leanSourcePath)) {
+    return { valid: 0, misaligned: [] };
+  }
+
   const leanSource = fs.readFileSync(leanSourcePath, 'utf-8');
   const parsed = parseLeanFile(leanSource, leanSourcePath);
 


### PR DESCRIPTION
## Summary

- `validateLineAnnotations` was crashing with ENOENT when `annotations.json` is an empty array but the referenced Lean source file doesn't exist
- Added early return for empty annotations arrays (nothing to validate)
- Added existence check before reading the Lean source file

## Why

The `brouwer-fixed-point-oq-01-oq-02` gallery entry (added today) has an empty `annotations.json` but references `BrouwerFixedPointOQ01OQ02.lean` which doesn't exist yet. This broke `pnpm build`.

## Test plan
- [ ] `pnpm annotations:build` completes without error
- [ ] `pnpm build` succeeds end-to-end