### PR TITLE
Fix: sync stale meta.lineCount for 4 gallery proofs

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-02/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-02/meta.json
@@ -49,7 +49,7 @@
       "11 total theorems separating algebraic core (0 axioms) from homology computations (1 axiom)"
     ],
     "dateAdded": "2026-04-04",
-    "lineCount": 234,
+    "lineCount": 233,
     "assumptions": "1 axiom (singular_homology_retraction_split) encoding: H_{n-1}(S^{n-1}) ≅ ℤ, H_{n-1}(B^n) = 0, functoriality r ∘ i = id → r* ∘ i* = id*. The algebraic argument (Part II) is fully proved with 0 axioms."
   },
   "overview": {

--- a/src/data/proofs/burnside-counting-oq-03/meta.json
+++ b/src/data/proofs/burnside-counting-oq-03/meta.json
@@ -25,7 +25,7 @@
     "axiomCount": 0,
     "assumptions": "4 sorries remain: fixed_factors_through_mod (orbit = cosets of <r>), polya_cyclic_fixed_count (bijection fixed-colorings ↔ Fin gcd → Fin k), polya_sum_identity (reindexing Σ_r k^gcd(r,n) = Σ_{d|n} φ(n/d)·k^d), polya_necklace_formula_statement (Burnside connection). All concrete n=4 computations are proved by native_decide.",
     "dateAdded": "2026-04-04",
-    "lineCount": 230,
+    "lineCount": 224,
     "theoremCount": 15,
     "definitionCount": 2,
     "mathlibDependencies": [

--- a/src/data/proofs/cevas-theorem-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-02-oq-01-oq-03/meta.json
@@ -54,7 +54,7 @@
       "18 total theorems characterizing weight geometry"
     ],
     "dateAdded": "2026-04-04",
-    "lineCount": 291,
+    "lineCount": 296,
     "assumptions": "0 axioms, 0 sorries. All 18 theorems fully proved from Mathlib arithmetic lemmas."
   },
   "overview": {

--- a/src/data/proofs/greens-theorem-oq-02/meta.json
+++ b/src/data/proofs/greens-theorem-oq-02/meta.json
@@ -55,7 +55,7 @@
       "19 supporting lemmas on Lipschitz curves, line integrals, L¹ fields, and consequences"
     ],
     "dateAdded": "2026-04-04",
-    "lineCount": 510,
+    "lineCount": 507,
     "assumptions": "1 axiom (greens_theorem_l1curl — Whitney's 1957 theorem). 19 theorems with 0 sorries. Supporting results are fully proved using Mathlib's LipschitzWith, MeasureTheory, and trigonometric libraries."
   },
   "overview": {


### PR DESCRIPTION
## Fix

Corrects stale `lineCount` values in gallery `meta.json` files to match actual Lean source file line counts.

## Evidence

**Before → After**:
- `burnside-counting-oq-03`: 230 → 224 (file was trimmed)
- `cevas-theorem-oq-02-oq-01-oq-03`: 291 → 296 (file was extended)
- `greens-theorem-oq-02`: 510 → 507 (file was trimmed)
- `brouwer-fixed-point-oq-01-oq-02`: 234 → 233 (file was trimmed)

All counts verified by `wc -l` against the respective `proofs/Proofs/*.lean` files.

---
Automated fix by lean-mechanic agent.