### PR TITLE
Fix: sync stale meta.lineCount for 15 gallery proofs

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -56,7 +56,7 @@
     ],
     "dateAdded": "2026-02-24",
     "axiomCount": 0,
-    "lineCount": 1934,
+    "lineCount": 1938,
     "assumptions": "0 sorries. The IBP formula fourierCoeffOn_deriv_periodic is now proved via import from AreaOfCircleOQ01OQ02OQ02.lean.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/burnside-counting-oq-03/meta.json
+++ b/src/data/proofs/burnside-counting-oq-03/meta.json
@@ -25,7 +25,7 @@
     "axiomCount": 0,
     "assumptions": "4 sorries remain: fixed_factors_through_mod (orbit = cosets of <r>), polya_cyclic_fixed_count (bijection fixed-colorings ↔ Fin gcd → Fin k), polya_sum_identity (reindexing Σ_r k^gcd(r,n) = Σ_{d|n} φ(n/d)·k^d), polya_necklace_formula_statement (Burnside connection). All concrete n=4 computations are proved by native_decide.",
     "dateAdded": "2026-04-04",
-    "lineCount": 224,
+    "lineCount": 294,
     "theoremCount": 15,
     "definitionCount": 2,
     "mathlibDependencies": [

--- a/src/data/proofs/erdos-1034/meta.json
+++ b/src/data/proofs/erdos-1034/meta.json
@@ -26,7 +26,7 @@
       "erdos-1033"
     ],
     "axiomCount": 1,
-    "lineCount": 778,
+    "lineCount": 779,
     "assumptions": "3 axiom(s) and 3 sorries. See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-1036/meta.json
+++ b/src/data/proofs/erdos-1036/meta.json
@@ -25,7 +25,7 @@
       1031
     ],
     "axiomCount": 2,
-    "lineCount": 202,
+    "lineCount": 201,
     "assumptions": "2 axioms: shelah_1998 (Shelah 1998, main exponential bound) and nonRamseyExists (Erdős 1947, probabilistic method). All theorems fully proved from these axioms.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-157/meta.json
+++ b/src/data/proofs/erdos-157/meta.json
@@ -59,7 +59,7 @@
       "Verified theorem: powers_of_two_sidon"
     ],
     "axiomCount": 3,
-    "lineCount": 535,
+    "lineCount": 536,
     "assumptions": "3 axioms: (1) pilatte_existence — the Pilatte 2023 existence result (infinite Sidon set that is an asymptotic basis of order 3); (2) sidon_counting_bound — counting bound for Sidon sets; (3) basis_counting_lower — lower bound for basis counting. 0 sorries (previously 1 sorry for pilatte_existence was axiomatized; sidon_counting_contradiction proved by Aristotle)."
   },
   "overview": {

--- a/src/data/proofs/erdos-69/meta.json
+++ b/src/data/proofs/erdos-69/meta.json
@@ -45,7 +45,7 @@
       "Structure connecting Problem 69 to Problem 257"
     ],
     "axiomCount": 1,
-    "lineCount": 187,
+    "lineCount": 189,
     "prerequisites": [
       "Arithmetic functions (ω, d, Ω) and prime factorization",
       "Infinite series, absolute convergence, and summation interchange",

--- a/src/data/proofs/erdos-793/meta.json
+++ b/src/data/proofs/erdos-793/meta.json
@@ -129,7 +129,7 @@
       "Nat"
     ],
     "namespace": null,
-    "lineCount": 191,
+    "lineCount": 199,
     "axiomCount": 5,
     "theoremCount": 1,
     "definitionCount": 12

--- a/src/data/proofs/erdos-795/meta.json
+++ b/src/data/proofs/erdos-795/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/795",
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
-    "lineCount": 519,
+    "lineCount": 500,
     "assumptions": "15 sorry(s).",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-815/meta.json
+++ b/src/data/proofs/erdos-815/meta.json
@@ -57,7 +57,7 @@
       "erdos_815_summary: combines disproof with EFGS short cycle theorem"
     ],
     "axiomCount": 3,
-    "lineCount": 240,
+    "lineCount": 254,
     "assumptions": "3 axioms: efgs_short_cycles (Erdős-Faudree-Gyárfás-Schelp short cycle result), erdos_hajnal_k6 (Erdős-Hajnal K_6 structure theorem), narins_pokrovskiy_szabo (Narins-Pokrovskiy-Szabó 2017 counterexample to Erdős #815 conjecture). 0 sorries."
   },
   "overview": {

--- a/src/data/proofs/fair-games-theorem-oq-03/meta.json
+++ b/src/data/proofs/fair-games-theorem-oq-03/meta.json
@@ -19,7 +19,7 @@
     "badge": "wip",
     "sorries": 4,
     "axiomCount": 0,
-    "lineCount": 280,
+    "lineCount": 290,
     "assumptions": "4 sorries: any_bounded_strategy_preserves_expectation, two_strategies_same_expectation, risk_neutral_pricing_neutrality (pending WithTop.untopA simp API in Mathlib 4.26.0), doobs_maximal_inequality (pending NNReal-to-real conversion of Mathlib maximal_ineq). Note: FairGamesTheorem.lean has pre-existing build failures in Mathlib 4.26.0 due to IsStoppingTime API change from τ:Ω→ι to τ:Ω→WithTop ι.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/greens-theorem-oq-02/meta.json
+++ b/src/data/proofs/greens-theorem-oq-02/meta.json
@@ -206,7 +206,7 @@
     "imports": ["Mathlib", "Proofs.GreensTheoremOQ01"],
     "opens": ["MeasureTheory", "intervalIntegral", "Real"],
     "namespace": "GreensTheoremOQ02",
-    "lineCount": 510,
+    "lineCount": 507,
     "axiomCount": 1,
     "theoremCount": 19,
     "definitionCount": 4

--- a/src/data/proofs/hilbert-11/meta.json
+++ b/src/data/proofs/hilbert-11/meta.json
@@ -31,7 +31,7 @@
     "dateAdded": "2025-12-29",
     "hilbertNumber": 11,
     "axiomCount": 5,
-    "lineCount": 497,
+    "lineCount": 496,
     "assumptions": "5 axioms: diagonalForm, sylvester_law_of_inertia, hasse_minkowski_alt, rational_classification_complete, selmer_curve_no_rational_points. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/sum-of-kth-powers-oq-01/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-01/meta.json
@@ -52,7 +52,7 @@
       "faulhaber_completeness: All five formulas packaged as conjunction"
     ],
     "dateAdded": "2026-04-03",
-    "lineCount": 183,
+    "lineCount": 193,
     "theoremCount": 10,
     "definitionCount": 0,
     "prerequisites": [

--- a/src/data/proofs/sum-of-kth-powers-oq-04/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-04/meta.json
@@ -40,7 +40,7 @@
       "powerSumRatio_tendsto statement: general asymptotic 1/(k+1)"
     ],
     "dateAdded": "2026-03-30",
-    "lineCount": 158,
+    "lineCount": 169,
     "theoremCount": 4,
     "definitionCount": 1,
     "prerequisites": [

--- a/src/data/proofs/triangular-reciprocals-oq-03-oq-02/meta.json
+++ b/src/data/proofs/triangular-reciprocals-oq-03-oq-02/meta.json
@@ -40,7 +40,7 @@
             "Verification that k=1 gives 2·log 2 - 1 and k=2 gives 1/4",
             "Even k: logarithmic terms cancel, giving rational answer A_k/k"
         ],
-        "lineCount": 196,
+        "lineCount": 202,
         "theoremCount": 10,
         "definitionCount": 1,
         "mathlib_version": "4.26.0"


### PR DESCRIPTION
## Fix

Corrects 15 stale `lineCount` values in gallery `meta.json` files to match actual Lean source file line counts (verified via Python line iterator).

## Evidence

**Before → After** (actual line counts verified with `sum(1 for _ in open(f))`):

| Proof | Old | New | Note |
|-------|-----|-----|------|
| burnside-counting-oq-03 | 224 | 294 | Grew after polya_sum_identity proof in #9317 |
| erdos-795 | 519 | 500 | |
| erdos-815 | 240 | 254 | |
| sum-of-kth-powers-oq-04 | 158 | 169 | |
| sum-of-kth-powers-oq-01 | 183 | 193 | |
| fair-games-theorem-oq-03 | 280 | 290 | |
| erdos-793 (leanFile) | 191 | 199 | |
| triangular-reciprocals-oq-03-oq-02 | 196 | 202 | |
| area-of-circle-oq-01-oq-03 | 1934 | 1938 | |
| greens-theorem-oq-02 (leanFile) | 510 | 507 | |
| erdos-69 | 187 | 189 | |
| erdos-1036 | 202 | 201 | |
| hilbert-11 | 497 | 496 | |
| erdos-1034 | 778 | 779 | |
| erdos-157 | 535 | 536 | |

All changes are minimal string replacements (2 lines changed per file).

---
Automated fix by lean-mechanic agent.