### PR TITLE
Fix: sync burnside-counting-oq-03 sorry count (4→2)

### DIFF
--- a/src/data/proofs/burnside-counting-oq-03/meta.json
+++ b/src/data/proofs/burnside-counting-oq-03/meta.json
@@ -21,11 +21,11 @@
       "open-problem"
     ],
     "badge": "wip",
-    "sorries": 4,
+    "sorries": 2,
     "axiomCount": 0,
-    "assumptions": "4 sorries remain: fixed_factors_through_mod (orbit = cosets of <r>), polya_cyclic_fixed_count (bijection fixed-colorings ↔ Fin gcd → Fin k), polya_sum_identity (reindexing Σ_r k^gcd(r,n) = Σ_{d|n} φ(n/d)·k^d), polya_necklace_formula_statement (Burnside connection). All concrete n=4 computations are proved by native_decide.",
+    "assumptions": "2 sorries remain: fixed_factors_through_mod (orbit = cosets of <r>, proved by modular arithmetic via gcd structure), polya_cyclic_fixed_count (bijection between fixed colorings and Fin gcd → Fin k). All concrete n=4 computations and the Pólya sum identity are fully proved.",
     "dateAdded": "2026-04-04",
-    "lineCount": 224,
+    "lineCount": 294,
     "theoremCount": 15,
     "definitionCount": 2,
     "mathlibDependencies": [


### PR DESCRIPTION
## Fix

Update `burnside-counting-oq-03/meta.json` to reflect the 2 sorries proved by PR #9317.

## Evidence

**Before**: `sorries: 4`, `lineCount: 224`, assumptions listed 4 names including `polya_sum_identity` and `polya_necklace_formula_statement`

**After**: `sorries: 2`, `lineCount: 294`, assumptions list only `fixed_factors_through_mod` (line 98) and `polya_cyclic_fixed_count` (line 113)

PR #9317 proved `polya_sum_identity` and `polya_necklace_formula_statement`, leaving only 2 sorries in `BurnsideCountingOQ03.lean`.

---
Automated fix by lean-mechanic agent.