### PR TITLE
Fix: correct badge=formalized → badge=wip for 16 proofs with sorries

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-01/meta.json
@@ -15,7 +15,7 @@
       "dirichlet-characters",
       "gauss-sums"
     ],
-    "badge": "formalized",
+    "badge": "wip",
     "sorries": 5,
     "axiomCount": 0,
     "lineCount": 203,

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01/meta.json
@@ -17,7 +17,7 @@
       "lawvere"
     ],
     "proofRepoPath": "Proofs/CantorDiagonalizationOQ03OQ01.lean",
-    "badge": "formalized",
+    "badge": "wip",
     "sorries": 2,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04/meta.json
@@ -17,7 +17,7 @@
       "finite-fields",
       "module-theory"
     ],
-    "badge": "formalized",
+    "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
     "lineCount": 262,

--- a/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
@@ -15,7 +15,7 @@
       "companion-matrix",
       "rational-canonical-form"
     ],
-    "badge": "formalized",
+    "badge": "wip",
     "sorries": 3,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/erdos-100-oq-01/meta.json
+++ b/src/data/proofs/erdos-100-oq-01/meta.json
@@ -15,7 +15,7 @@
       "distance-sets",
       "guth-katz"
     ],
-    "badge": "formalized",
+    "badge": "wip",
     "sorries": 2,
     "axiomCount": 0,
     "lineCount": 165,

--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -12,7 +12,7 @@
       "hamiltonian-cycles",
       "tournaments"
     ],
-    "badge": "formalized",
+    "badge": "wip",
     "sorries": 2,
     "axiomCount": 0,
     "lineCount": 991,

--- a/src/data/proofs/erdos-637/meta.json
+++ b/src/data/proofs/erdos-637/meta.json
@@ -15,7 +15,7 @@
       "ramsey-theory",
       "degrees"
     ],
-    "badge": "formalized",
+    "badge": "wip",
     "sorries": 10,
     "erdosNumber": 637,
     "erdosUrl": "https://erdosproblems.com/637",

--- a/src/data/proofs/fundamental-theorem-calculus-oq-02/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus-oq-02/meta.json
@@ -16,7 +16,7 @@
       "open-question"
     ],
     "proofRepoPath": "Proofs/FundamentalTheoremCalculusStokes.lean",
-    "badge": "formalized",
+    "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
     "assumptions": "0 axioms. 1 sorry: d^2=0 in 2D (Clairaut's theorem) — needs bridge from Mathlib's iteratedFDeriv to concrete partial derivatives. Green's theorem in Stokes form now proved via GreensTheoremOQ01.greens_theorem_concrete.",

--- a/src/data/proofs/lhopital-oq-02/meta.json
+++ b/src/data/proofs/lhopital-oq-02/meta.json
@@ -16,7 +16,7 @@
       "real-analysis",
       "indeterminate-forms"
     ],
-    "badge": "formalized",
+    "badge": "wip",
     "sorries": 3,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/newton-inductive-step-oq-01/meta.json
+++ b/src/data/proofs/newton-inductive-step-oq-01/meta.json
@@ -18,7 +18,7 @@
       "maclaurin",
       "research"
     ],
-    "badge": "formalized",
+    "badge": "wip",
     "sorries": 1,
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/roth-theorem-k3-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-01/meta.json
@@ -16,7 +16,7 @@
       "quantitative-bounds",
       "roth-number"
     ],
-    "badge": "formalized",
+    "badge": "wip",
     "sorries": 5,
     "axiomCount": 0,
     "assumptions": "0 axioms. 5 sorries: density_upper_bound_from_iteration (density iteration needs M ≥ N^c), roth_quantitative_upper_bound, behrend_lower_bound, bloom_sisask_bound, kelley_meka_upper_bound.",

--- a/src/data/proofs/roth-theorem-k3-oq-02/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-02/meta.json
@@ -17,7 +17,7 @@
       "graph-theory",
       "regularity-lemma"
     ],
-    "badge": "formalized",
+    "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
     "assumptions": "0 axioms. 1 sorry: roth_via_triangle_removal (the quantitative connection between the edge-disjointness lower bound and the triangle removal lemma). The RS graph construction, triangle-AP correspondence, edge-disjointness, and edge removal lower bound are all fully proved.",

--- a/src/data/proofs/shannon-entropy-oq-03/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-03/meta.json
@@ -16,7 +16,7 @@
       "open-question"
     ],
     "proofRepoPath": "Proofs/ShannonEntropySSA.lean",
-    "badge": "formalized",
+    "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
     "assumptions": "0 axioms. 1 sorry: strong subadditivity — needs conditional KL divergence ≥ 0. Entropy chain rule and subadditivity are fully proved.",

--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -15,7 +15,7 @@
       "combinatorics",
       "intermediate"
     ],
-    "badge": "formalized",
+    "badge": "wip",
     "sorries": 3,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/stirling-formula-oq-01/meta.json
+++ b/src/data/proofs/stirling-formula-oq-01/meta.json
@@ -16,7 +16,7 @@
       "factorials",
       "bernoulli-numbers"
     ],
-    "badge": "formalized",
+    "badge": "wip",
     "sorries": 2,
     "axiomCount": 0,
     "assumptions": "No axioms. 2 sorries: stirling_first_correction (core expansion requiring Euler-Maclaurin), stirling_two_term_expansion (restatement of first correction).",

--- a/src/data/proofs/taylor-sincos-convergence-oq-03/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-03/meta.json
@@ -13,7 +13,7 @@
       "open-question"
     ],
     "proofRepoPath": "Proofs/TaylorSinCosConvergenceOQ03.lean",
-    "badge": "formalized",
+    "badge": "wip",
     "sorries": 3,
     "axiomCount": 0,
     "assumptions": "0 axioms. 3 sorries: alternating tail bound, alternating remainder for sin, alternating remainder for cos. Partial sum bounds fully proved by induction on paired terms.",


### PR DESCRIPTION
## Fix

`formalized` is not a valid `ProofBadge` TypeScript type. Valid values are:
`original | mathlib | pedagogical | from-axioms | fallacy | wip | ai-solved | axiom | infrastructure`

Proofs with remaining sorries should use `badge=wip`. This batch fixes 16 gallery proofs that used the invalid `formalized` badge, which renders as nothing in the gallery UI.

## Evidence

**Before**: `"badge": "formalized"` — invalid TypeScript badge value, silently drops in UI

**After**: `"badge": "wip"` — valid badge showing Work-in-Progress (🚧) in gallery

All 16 affected proofs have `sorries > 0`, confirming `wip` is the appropriate badge.

Affected proofs:
- bounded-prime-gaps-oq-04-oq-01 (5 sorries)
- cantor-diagonalization-oq-03-oq-01 (2 sorries)
- cayley-hamilton-minpoly-oq-05-oq-01-oq-04 (1 sorry)
- cayley-hamilton-reduction-oq-02-oq-01 (3 sorries)
- erdos-100-oq-01 (2 sorries)
- erdos-1012-oq-03 (2 sorries)
- erdos-637 (10 sorries)
- fundamental-theorem-calculus-oq-02 (1 sorry)
- lhopital-oq-02 (3 sorries)
- newton-inductive-step-oq-01 (1 sorry)
- roth-theorem-k3-oq-01 (5 sorries)
- roth-theorem-k3-oq-02 (1 sorry)
- shannon-entropy-oq-03 (1 sorry)
- shapley-folkman (3 sorries)
- stirling-formula-oq-01 (2 sorries)
- taylor-sincos-convergence-oq-03 (3 sorries)

Note: 3 proofs with `badge=formalized` but `sorries=0` (area-of-circle-oq-01-oq-03, furstenberg-correspondence-oq-02, kummer-theorem-oq-01) require individual review to determine the correct badge (mathlib/original/etc.) — excluded from this batch fix.

---
Automated fix by lean-mechanic agent.