### PR TITLE
Fix: correct badge/status for 3 complete proofs using invalid 'formalized' values

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Hurwitz (1901), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Isoperimetric_inequality",
     "date": "1901",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/AreaOfCircleOQ01OQ03.lean",
     "tags": [
       "analysis",
@@ -19,7 +19,7 @@
       "research",
       "isoperimetric"
     ],
-    "badge": "formalized",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/furstenberg-correspondence-oq-02/meta.json
+++ b/src/data/proofs/furstenberg-correspondence-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Furstenberg (1977), Einsiedler-Ward (2011)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Ergodic_decomposition_theorem",
     "date": "1977",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/FurstenbergCorrespondenceOQ02.lean",
     "tags": [
       "ergodic-theory",
@@ -17,7 +17,7 @@
       "furstenberg",
       "szemerédi"
     ],
-    "badge": "formalized",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/kummer-theorem-oq-01/meta.json
+++ b/src/data/proofs/kummer-theorem-oq-01/meta.json
@@ -4,7 +4,7 @@
   "slug": "kummer-theorem-oq-01",
   "description": "Extends Kummer's theorem from binomial to multinomial coefficients via iterated binomial decomposition. The p-adic valuation of a multinomial coefficient equals the total carries when adding the parts in base p.",
   "meta": {
-    "status": "formalized",
+    "status": "verified",
     "tags": [
       "combinatorics",
       "number-theory",
@@ -12,7 +12,7 @@
       "multinomial"
     ],
     "proofRepoPath": "Proofs/KummerTheoremOQ01.lean",
-    "badge": "formalized",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. All theorems fully proved: multinomial_eq_prod_choose (via companion file KummerTheoremOQ01Aristotle.lean using reverseRecOn induction), multinomial_pair, multinomial_triple.",


### PR DESCRIPTION
## Fix

Three gallery proofs with 0 sorries and 0 axioms used `badge=formalized` and `status=formalized` — neither value is valid in the TypeScript types.

- `ProofBadge` does not include `formalized`; valid values: `original | mathlib | pedagogical | from-axioms | fallacy | wip | ai-solved | axiom | infrastructure`  
- `ProofMeta.status` does not include `formalized`; valid values: `verified | pending | disputed | complete | open-question | axiomatized | conditional`

## Evidence

**Before**: `"badge": "formalized"`, `"status": "formalized"` — invalid, renders as nothing in gallery UI

**After**: `"badge": "mathlib"`, `"status": "verified"` — all three use `import Mathlib` with 0 sorries and 0 axioms

Affected:
- area-of-circle-oq-01-oq-03 (1938 lines, 0 sorries, 0 axioms — confirmed by code inspection)
- furstenberg-correspondence-oq-02 (413 lines, 0 sorries, 0 axioms)
- kummer-theorem-oq-01 (108 lines, 0 sorries, 0 axioms — includes Aristotle companion)

---
Automated fix by lean-mechanic agent.