### PR TITLE
Fix: correct badge=verified → badge=mathlib for 198 gallery proofs

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
@@ -18,7 +18,7 @@
       "eisenstein-criterion",
       "wiedijk-100"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries after PR #6856 eliminated all remaining assumptions. Former axioms B1 (disc_p_neg) and B2 (vandermonde_sq_eq_disc_p) are now proved. Axiom A (three_dvd_gal_card) was proved via complex conjugation. All Galois group order exclusions (|Gal|≠10, ≠20, ≠40) are now proved via Sylow theory.",

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02/meta.json
@@ -19,7 +19,7 @@
       "extension",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/angle-trisection-oq-02-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01/meta.json
@@ -18,7 +18,7 @@
       "polynomial-galois-group",
       "mathlib-bridge"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/angle-trisection-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-03-oq-01/meta.json
@@ -17,7 +17,7 @@
       "constructibility",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/angle-trisection-oq-02-oq-04/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-04/meta.json
@@ -14,7 +14,7 @@
       "angle trisection",
       "group theory"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 163,

--- a/src/data/proofs/angle-trisection-oq-05/meta.json
+++ b/src/data/proofs/angle-trisection-oq-05/meta.json
@@ -17,7 +17,7 @@
       "algebraic-characterization"
     ],
     "proofRepoPath": "Proofs/AngleTrisectionOQ05.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -14,7 +14,7 @@
       "recurrence",
       "n-dimensional-geometry"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/area-of-circle-oq-03-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-03/meta.json
@@ -17,7 +17,7 @@
       "ellipse",
       "geometric series"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 190,

--- a/src/data/proofs/ballot-problem-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01/meta.json
@@ -17,7 +17,7 @@
       "generalization",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
@@ -17,7 +17,7 @@
       "permutations",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axioms": 0,
     "mathlibDependencies": [

--- a/src/data/proofs/ballot-problem-oq-03/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03/meta.json
@@ -16,7 +16,7 @@
       "lgv-lemma",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axioms": 0,
     "mathlibDependencies": [

--- a/src/data/proofs/basel-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01/meta.json
@@ -14,7 +14,7 @@
       "analysis",
       "open-problem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "assumptions": "0 sorries, 0 axioms. All 7 theorems are fully proved. The file also contains three comment blocks (not theorems) documenting known irrationality measures and the difficulty of ζ(5). Genuine content: partial sum bounds, tail estimates, and irrationality measure definition are fully verified.",
     "dateAdded": "2026-03-30",

--- a/src/data/proofs/bezout-identity-oq-03-oq-04/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-04/meta.json
@@ -13,7 +13,7 @@
       "B\u00e9zout",
       "algorithms"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 142,

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01/meta.json
@@ -14,7 +14,7 @@
             "binomial theorem",
             "combinatorics"
         ],
-        "badge": "verified",
+        "badge": "mathlib",
         "sorries": 0,
         "axiomCount": 0,
         "lineCount": 222,

--- a/src/data/proofs/binomial-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-03/meta.json
@@ -18,7 +18,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ03.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 269,

--- a/src/data/proofs/binomial-theorem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-03-oq-02/meta.json
@@ -18,7 +18,7 @@
       "mathlib-contribution",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/binomial-theorem-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-03/meta.json
@@ -21,7 +21,7 @@
       "vandermonde",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/binomial-theorem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-03/meta.json
@@ -17,7 +17,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/BinomialTheoremOQ04OQ03.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axioms": 0,
     "mathlibDependencies": [

--- a/src/data/proofs/binomial-theorem-oq-04/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04/meta.json
@@ -16,7 +16,7 @@
       "convolution",
       "pascal-triangle"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axioms": 0,
     "mathlibDependencies": [

--- a/src/data/proofs/birthday-problem-oq-02/meta.json
+++ b/src/data/proofs/birthday-problem-oq-02/meta.json
@@ -11,7 +11,7 @@
       "asymptotics",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "None. All theorems fully proved from Mathlib.",

--- a/src/data/proofs/birthday-problem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01/meta.json
@@ -17,7 +17,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/BirthdayProblemOQ03OQ01.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/birthday-problem-oq-03-oq-03/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-03/meta.json
@@ -15,7 +15,7 @@
       "asymptotics",
       "analysis"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/birthday-problem-oq-03/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03/meta.json
@@ -12,7 +12,7 @@
       "open-question"
     ],
     "proofRepoPath": "Proofs/BirthdayProblemOQ03.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "None. All theorems fully proved from Mathlib.",

--- a/src/data/proofs/buffons-needle-oq-01-oq-02/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-02/meta.json
@@ -20,7 +20,7 @@
       "research",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 21,

--- a/src/data/proofs/buffons-needle-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01/meta.json
@@ -21,7 +21,7 @@
       "cauchy-crofton",
       "extension"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/buffons-needle-oq-02-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-01/meta.json
@@ -21,7 +21,7 @@
       "linearity-of-expectation",
       "cauchy-crofton"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/buffons-needle-oq-02/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02/meta.json
@@ -22,7 +22,7 @@
       "linearity-of-expectation",
       "dimension-comparison"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/cantor-diagonalization-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03/meta.json
@@ -17,7 +17,7 @@
       "fixed-point",
       "wiedijk-100"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 149,

--- a/src/data/proofs/cantor-diagonalization-oq-04/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-04/meta.json
@@ -18,7 +18,7 @@
       "retraction",
       "y-combinator"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 304,

--- a/src/data/proofs/cantors-theorem-oq-02/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-02/meta.json
@@ -21,7 +21,7 @@
       "open-problem",
       "classic"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01/meta.json
@@ -19,7 +19,7 @@
       "competition-mathematics",
       "nlinarith"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-03-21",
     "axiomCount": 0,

--- a/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-01/meta.json
@@ -17,7 +17,7 @@
       "inner-product",
       "equality-characterization"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 91,

--- a/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-02/meta.json
@@ -20,7 +20,7 @@
       "young-inequality",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-03-28",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-02/meta.json
@@ -17,7 +17,7 @@
       "numerical-analysis",
       "extension"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-03/meta.json
@@ -18,7 +18,7 @@
       "computational-complexity",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-02/meta.json
@@ -18,7 +18,7 @@
       "haar-measure",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-03/meta.json
@@ -18,7 +18,7 @@
       "infinite-dimensional",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-02/meta.json
@@ -5,7 +5,7 @@
   "description": "Formalizes the relationship between [L:K] and the minimal polynomial degree: deg(minpoly K x) = finrank K K(x), deg(minpoly K x) | [L:K], tower decomposition, degree drop bounds, and characterization of when the degree is preserved.",
   "category": "abstract-algebra",
   "status": "verified",
-  "badge": "verified",
+  "badge": "mathlib",
   "difficulty": "intermediate",
   "leanFile": "Proofs/CayleyHamiltonMinpolyOQ05OQ02.lean",
   "lineCount": 262,

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05/meta.json
@@ -17,7 +17,7 @@
       "scalar-tower",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-03/meta.json
@@ -15,7 +15,7 @@
       "operator-algebras",
       "voiculescu"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 146,

--- a/src/data/proofs/central-limit-theorem-oq-01/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01/meta.json
@@ -20,7 +20,7 @@
       "cauchy",
       "levy-distribution"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/cevas-theorem-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-02-oq-02/meta.json
@@ -18,7 +18,7 @@
       "generalization",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/cevas-theorem-oq-04/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-04/meta.json
@@ -17,7 +17,7 @@
       "constructive",
       "algebraic"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/chinese-remainder-constructive-oq-03/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-03/meta.json
@@ -15,7 +15,7 @@
       "algorithms",
       "classical"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 318,

--- a/src/data/proofs/chinese-remainder-constructive-oq-04-oq-04/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-04-oq-04/meta.json
@@ -16,7 +16,7 @@
       "uniqueness",
       "canonical-form"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-04-02",

--- a/src/data/proofs/chinese-remainder-non-coprime-oq-04/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-04/meta.json
@@ -18,7 +18,7 @@
       "continued-fractions",
       "golden-ratio"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 15,

--- a/src/data/proofs/cramers-rule-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-02/meta.json
@@ -16,7 +16,7 @@
       "cramer",
       "schur-complement"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 462,

--- a/src/data/proofs/cramers-rule-oq-02/meta.json
+++ b/src/data/proofs/cramers-rule-oq-02/meta.json
@@ -19,7 +19,7 @@
       "algorithms",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/cramers-rule-oq-03/meta.json
+++ b/src/data/proofs/cramers-rule-oq-03/meta.json
@@ -15,7 +15,7 @@
       "quasideterminants",
       "cramer"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 175,

--- a/src/data/proofs/denumerability-rationals-oq-03/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-03/meta.json
@@ -19,7 +19,7 @@
       "coprimality",
       "wiedijk-100"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-03-22",

--- a/src/data/proofs/derangements-oq-03-oq-01/meta.json
+++ b/src/data/proofs/derangements-oq-03-oq-01/meta.json
@@ -15,7 +15,7 @@
       "asymptotics",
       "probability"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/desargues-theorem-oq-01/meta.json
+++ b/src/data/proofs/desargues-theorem-oq-01/meta.json
@@ -20,7 +20,7 @@
       "classic",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/desargues-theorem-oq-02/meta.json
+++ b/src/data/proofs/desargues-theorem-oq-02/meta.json
@@ -18,7 +18,7 @@
       "affine-plane",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/desargues-theorem-oq-04/meta.json
+++ b/src/data/proofs/desargues-theorem-oq-04/meta.json
@@ -20,7 +20,7 @@
       "extension",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "prerequisites": [
       "projective geometry",

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-01/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-01/meta.json
@@ -13,7 +13,7 @@
       "complex analysis",
       "Descartes rule"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 154,

--- a/src/data/proofs/descartes-rule-of-signs-oq-04/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-04/meta.json
@@ -18,7 +18,7 @@
       "research",
       "alternative-proof"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/dissection-of-cubes-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02/meta.json
@@ -17,7 +17,7 @@
       "polyhedra",
       "wiedijk-100"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-03-22",
     "mathlibDependencies": [

--- a/src/data/proofs/divisibility-by-3-oq-03/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-03/meta.json
@@ -17,7 +17,7 @@
       "algorithms",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "Fully verified: 0 axiom declarations, 0 sorries.",

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-01-oq-01/meta.json
@@ -16,7 +16,7 @@
       "multiplicative-functions",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 164,

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02-oq-01/meta.json
@@ -40,7 +40,7 @@
       "research",
       "open-problem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "mathlibDependencies": [

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03/meta.json
@@ -5,7 +5,7 @@
   "description": "Extends quadratic reciprocity from the Legendre symbol (prime moduli) to the Jacobi symbol (composite odd moduli), formalizing the generalized reciprocity law J(m,n)·J(n,m) = (-1)^((m-1)/2·(n-1)/2) for coprime odd m,n.",
   "category": "number-theory",
   "status": "verified",
-  "badge": "verified",
+  "badge": "mathlib",
   "difficulty": "intermediate",
   "leanFile": "Proofs/ElementaryQuadraticReciprocityOQ03.lean",
   "lineCount": 199,

--- a/src/data/proofs/erdos-1/meta.json
+++ b/src/data/proofs/erdos-1/meta.json
@@ -15,7 +15,7 @@
       "subset-sums",
       "extremal-combinatorics"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 1,
     "erdosUrl": "https://erdosproblems.com/1",

--- a/src/data/proofs/erdos-1002-oq-01/meta.json
+++ b/src/data/proofs/erdos-1002-oq-01/meta.json
@@ -16,7 +16,7 @@
       "distribution-functions",
       "axiom-elimination"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 1002,
     "erdosUrl": "https://erdosproblems.com/1002",

--- a/src/data/proofs/erdos-1007-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1007-oq-01-oq-01/meta.json
@@ -18,7 +18,7 @@
       "monotonicity",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/erdos-1007-oq-01/meta.json
+++ b/src/data/proofs/erdos-1007-oq-01/meta.json
@@ -18,7 +18,7 @@
       "extension",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/erdos-1035/meta.json
+++ b/src/data/proofs/erdos-1035/meta.json
@@ -15,7 +15,7 @@
       "extremal-graph-theory",
       "minimum-degree"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 1035,
     "erdosUrl": "https://erdosproblems.com/1035",

--- a/src/data/proofs/erdos-104/meta.json
+++ b/src/data/proofs/erdos-104/meta.json
@@ -16,7 +16,7 @@
       "unit-circles",
       "open-problem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 104,
     "erdosUrl": "https://erdosproblems.com/104",

--- a/src/data/proofs/erdos-1059-oq-03/meta.json
+++ b/src/data/proofs/erdos-1059-oq-03/meta.json
@@ -15,7 +15,7 @@
             "factorials",
             "computational"
         ],
-        "badge": "verified",
+        "badge": "mathlib",
         "sorries": 0,
         "erdosNumber": 1059,
         "erdosUrl": "https://erdosproblems.com/1059",

--- a/src/data/proofs/erdos-1059-oq-05/meta.json
+++ b/src/data/proofs/erdos-1059-oq-05/meta.json
@@ -17,7 +17,7 @@
             "automation",
             "tactics"
         ],
-        "badge": "verified",
+        "badge": "mathlib",
         "sorries": 0,
         "erdosNumber": 1059,
         "erdosUrl": "https://erdosproblems.com/1059",

--- a/src/data/proofs/erdos-1061/meta.json
+++ b/src/data/proofs/erdos-1061/meta.json
@@ -16,7 +16,7 @@
       "asymptotic-analysis",
       "open-problem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 1061,
     "erdosUrl": "https://erdosproblems.com/1061",

--- a/src/data/proofs/erdos-1073/meta.json
+++ b/src/data/proofs/erdos-1073/meta.json
@@ -16,7 +16,7 @@
       "divisibility",
       "wilson-theorem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 1073,
     "erdosUrl": "https://erdosproblems.com/1073",

--- a/src/data/proofs/erdos-1094/meta.json
+++ b/src/data/proofs/erdos-1094/meta.json
@@ -14,7 +14,7 @@
       "binomial-coefficients",
       "prime-factorization"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 1094,
     "erdosUrl": "https://erdosproblems.com/1094",

--- a/src/data/proofs/erdos-1095-oq-01/meta.json
+++ b/src/data/proofs/erdos-1095-oq-01/meta.json
@@ -16,7 +16,7 @@
       "smooth-numbers",
       "asymptotics"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 1095,
     "erdosUrl": "https://erdosproblems.com/1095",

--- a/src/data/proofs/erdos-1098-oq-01/meta.json
+++ b/src/data/proofs/erdos-1098-oq-01/meta.json
@@ -17,7 +17,7 @@
       "center",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "None. All 8 theorems fully proved from Mathlib.",

--- a/src/data/proofs/erdos-1099/meta.json
+++ b/src/data/proofs/erdos-1099/meta.json
@@ -17,7 +17,7 @@
       "liminf",
       "solved"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 1099,
     "erdosUrl": "https://erdosproblems.com/1099",

--- a/src/data/proofs/erdos-1142/meta.json
+++ b/src/data/proofs/erdos-1142/meta.json
@@ -13,7 +13,7 @@
       "number-theory",
       "open"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 1142,
     "erdosUrl": "https://erdosproblems.com/1142",

--- a/src/data/proofs/erdos-1179-oq-01/meta.json
+++ b/src/data/proofs/erdos-1179-oq-01/meta.json
@@ -18,7 +18,7 @@
       "open-question",
       "fourier-analysis"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 23,

--- a/src/data/proofs/erdos-124-complete-sequences/meta.json
+++ b/src/data/proofs/erdos-124-complete-sequences/meta.json
@@ -16,7 +16,7 @@
       "ai-solved",
       "complete-sequences"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 124,
     "erdosUrl": "https://www.erdosproblems.com/124",

--- a/src/data/proofs/erdos-142/meta.json
+++ b/src/data/proofs/erdos-142/meta.json
@@ -7,7 +7,7 @@
     "erdosNumber": 142,
     "status": "verified",
     "proofRepoPath": "Proofs/Erdos142Problem.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "erdosProblemStatus": "open",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-152-oq-01/meta.json
+++ b/src/data/proofs/erdos-152-oq-01/meta.json
@@ -15,7 +15,7 @@
             "sumsets",
             "isolated elements"
         ],
-        "badge": "verified",
+        "badge": "mathlib",
         "sorries": 0,
         "erdosNumber": 152,
         "erdosUrl": "https://erdosproblems.com/152",

--- a/src/data/proofs/erdos-152/meta.json
+++ b/src/data/proofs/erdos-152/meta.json
@@ -14,7 +14,7 @@
       "sidon-sets",
       "sumsets"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 152,
     "erdosUrl": "https://erdosproblems.com/152",

--- a/src/data/proofs/erdos-16/meta.json
+++ b/src/data/proofs/erdos-16/meta.json
@@ -16,7 +16,7 @@
       "covering-congruences",
       "disproved"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 16,
     "erdosUrl": "https://erdosproblems.com/16",

--- a/src/data/proofs/erdos-18/meta.json
+++ b/src/data/proofs/erdos-18/meta.json
@@ -16,7 +16,7 @@
       "divisor-sums",
       "open-problem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 18,
     "erdosUrl": "https://erdosproblems.com/18",

--- a/src/data/proofs/erdos-182/meta.json
+++ b/src/data/proofs/erdos-182/meta.json
@@ -16,7 +16,7 @@
       "regular-graphs",
       "solved"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 182,
     "erdosUrl": "https://erdosproblems.com/182",

--- a/src/data/proofs/erdos-203/meta.json
+++ b/src/data/proofs/erdos-203/meta.json
@@ -16,7 +16,7 @@
       "sierpinski",
       "open"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 203,
     "erdosUrl": "https://erdosproblems.com/203",

--- a/src/data/proofs/erdos-208/meta.json
+++ b/src/data/proofs/erdos-208/meta.json
@@ -16,7 +16,7 @@
       "gaps",
       "open-problem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 208,
     "erdosUrl": "https://erdosproblems.com/208",

--- a/src/data/proofs/erdos-249/meta.json
+++ b/src/data/proofs/erdos-249/meta.json
@@ -16,7 +16,7 @@
       "series",
       "open"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 249,
     "erdosUrl": "https://erdosproblems.com/249",

--- a/src/data/proofs/erdos-273/meta.json
+++ b/src/data/proofs/erdos-273/meta.json
@@ -16,7 +16,7 @@
       "modular-arithmetic",
       "combinatorial-number-theory"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 273,
     "erdosUrl": "https://erdosproblems.com/273",

--- a/src/data/proofs/erdos-30/meta.json
+++ b/src/data/proofs/erdos-30/meta.json
@@ -16,7 +16,7 @@
       "sidon-sets",
       "b2-sequences"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 30,
     "erdosUrl": "https://erdosproblems.com/30",

--- a/src/data/proofs/erdos-301/meta.json
+++ b/src/data/proofs/erdos-301/meta.json
@@ -15,7 +15,7 @@
       "extremal-combinatorics",
       "egyptian-fractions"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 301,
     "erdosUrl": "https://erdosproblems.com/301",

--- a/src/data/proofs/erdos-307-oq-02/meta.json
+++ b/src/data/proofs/erdos-307-oq-02/meta.json
@@ -16,7 +16,7 @@
       "erdos",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 298,

--- a/src/data/proofs/erdos-317/meta.json
+++ b/src/data/proofs/erdos-317/meta.json
@@ -16,7 +16,7 @@
       "diophantine-approximation",
       "open-problem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 317,
     "erdosUrl": "https://erdosproblems.com/317",

--- a/src/data/proofs/erdos-340/meta.json
+++ b/src/data/proofs/erdos-340/meta.json
@@ -16,7 +16,7 @@
       "greedy-algorithms",
       "open"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 340,
     "erdosUrl": "https://erdosproblems.com/340",

--- a/src/data/proofs/erdos-352/meta.json
+++ b/src/data/proofs/erdos-352/meta.json
@@ -16,7 +16,7 @@
       "lebesgue-measure",
       "convexity"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 352,
     "erdosUrl": "https://erdosproblems.com/352",

--- a/src/data/proofs/erdos-366/meta.json
+++ b/src/data/proofs/erdos-366/meta.json
@@ -17,7 +17,7 @@
       "consecutive-integers",
       "open-problem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 366,
     "erdosUrl": "https://erdosproblems.com/366",

--- a/src/data/proofs/erdos-369/meta.json
+++ b/src/data/proofs/erdos-369/meta.json
@@ -16,7 +16,7 @@
       "Dickman-function",
       "open"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosUrl": "https://erdosproblems.com/369",
     "sourceUrl": "https://erdosproblems.com/369",

--- a/src/data/proofs/erdos-373/meta.json
+++ b/src/data/proofs/erdos-373/meta.json
@@ -16,7 +16,7 @@
       "diophantine-equations",
       "abc-conjecture"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 373,
     "erdosUrl": "https://erdosproblems.com/373",

--- a/src/data/proofs/erdos-374/meta.json
+++ b/src/data/proofs/erdos-374/meta.json
@@ -15,7 +15,7 @@
       "perfect-squares",
       "open"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 374,
     "erdosUrl": "https://erdosproblems.com/374",

--- a/src/data/proofs/erdos-389/meta.json
+++ b/src/data/proofs/erdos-389/meta.json
@@ -15,7 +15,7 @@
       "consecutive integers",
       "products"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 389,
     "erdosUrl": "https://erdosproblems.com/389",

--- a/src/data/proofs/erdos-40/meta.json
+++ b/src/data/proofs/erdos-40/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "0 axiom(s) and 0 sorry(s). Fully verified.",
     "lineCount": 291,
-    "badge": "verified",
+    "badge": "mathlib",
     "mathlib_version": "4.26.0"
   },
   "sections": [

--- a/src/data/proofs/erdos-412/meta.json
+++ b/src/data/proofs/erdos-412/meta.json
@@ -18,7 +18,7 @@
       "open",
       "dynamical-systems"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 412,
     "erdosUrl": "https://erdosproblems.com/412",

--- a/src/data/proofs/erdos-432/meta.json
+++ b/src/data/proofs/erdos-432/meta.json
@@ -18,7 +18,7 @@
       "density",
       "open"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/432",
     "erdosUrl": "https://erdosproblems.com/432",

--- a/src/data/proofs/erdos-458/meta.json
+++ b/src/data/proofs/erdos-458/meta.json
@@ -16,7 +16,7 @@
       "primes",
       "open-problem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 458,
     "erdosUrl": "https://erdosproblems.com/458",

--- a/src/data/proofs/erdos-463/meta.json
+++ b/src/data/proofs/erdos-463/meta.json
@@ -18,7 +18,7 @@
       "rough-numbers",
       "sieve-theory"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 463,
     "erdosUrl": "https://erdosproblems.com/463",

--- a/src/data/proofs/erdos-468/meta.json
+++ b/src/data/proofs/erdos-468/meta.json
@@ -15,7 +15,7 @@
       "partial-sums",
       "combinatorial-number-theory"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 468,
     "erdosUrl": "https://erdosproblems.com/468",

--- a/src/data/proofs/erdos-469/meta.json
+++ b/src/data/proofs/erdos-469/meta.json
@@ -18,7 +18,7 @@
     "sourceUrl": "https://erdosproblems.com/469",
     "erdosUrl": "https://erdosproblems.com/469",
     "axiomCount": 0,
-    "badge": "verified",
+    "badge": "mathlib",
     "lineCount": 327,
     "assumptions": "0 axioms. All former axioms removed. The open conjectures (erdos469_conjecture, infinitely_many_primitive) are stated as def : Prop, not asserted as axioms. File is fully verified.",
     "proofRepoPath": "Proofs/Erdos469Problem.lean",

--- a/src/data/proofs/erdos-485-oq-02/meta.json
+++ b/src/data/proofs/erdos-485-oq-02/meta.json
@@ -19,7 +19,7 @@
       "open-problem",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/erdos-488/meta.json
+++ b/src/data/proofs/erdos-488/meta.json
@@ -15,7 +15,7 @@
       "density",
       "inclusion-exclusion"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 488,
     "erdosUrl": "https://erdosproblems.com/488",

--- a/src/data/proofs/erdos-493/meta.json
+++ b/src/data/proofs/erdos-493/meta.json
@@ -16,7 +16,7 @@
       "constructive-proof",
       "solved"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 493,
     "erdosUrl": "https://erdosproblems.com/493",

--- a/src/data/proofs/erdos-497/meta.json
+++ b/src/data/proofs/erdos-497/meta.json
@@ -15,7 +15,7 @@
       "Sperner theory",
       "Dedekind numbers"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 497,
     "erdosUrl": "https://erdosproblems.com/497",

--- a/src/data/proofs/erdos-50/meta.json
+++ b/src/data/proofs/erdos-50/meta.json
@@ -17,7 +17,7 @@
       "singular-functions",
       "measure-theory"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 50,
     "erdosUrl": "https://erdosproblems.com/50",

--- a/src/data/proofs/erdos-51/meta.json
+++ b/src/data/proofs/erdos-51/meta.json
@@ -17,7 +17,7 @@
       "carmichael-conjecture",
       "open"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 51,
     "erdosUrl": "https://erdosproblems.com/51",

--- a/src/data/proofs/erdos-520/meta.json
+++ b/src/data/proofs/erdos-520/meta.json
@@ -16,7 +16,7 @@
       "random-multiplicative-functions",
       "law-of-iterated-logarithm"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 520,
     "erdosUrl": "https://erdosproblems.com/520",

--- a/src/data/proofs/erdos-539/meta.json
+++ b/src/data/proofs/erdos-539/meta.json
@@ -17,7 +17,7 @@
       "additive-combinatorics",
       "open"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 539,
     "erdosUrl": "https://erdosproblems.com/539",

--- a/src/data/proofs/erdos-563/meta.json
+++ b/src/data/proofs/erdos-563/meta.json
@@ -15,7 +15,7 @@
       "probabilistic method",
       "edge coloring"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 563,
     "erdosUrl": "https://erdosproblems.com/563",

--- a/src/data/proofs/erdos-602/meta.json
+++ b/src/data/proofs/erdos-602/meta.json
@@ -17,7 +17,7 @@
       "infinite-sets",
       "open"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 602,
     "erdosUrl": "https://erdosproblems.com/602",

--- a/src/data/proofs/erdos-638/meta.json
+++ b/src/data/proofs/erdos-638/meta.json
@@ -15,7 +15,7 @@
       "infinite combinatorics",
       "cardinals"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 638,
     "erdosUrl": "https://erdosproblems.com/638",

--- a/src/data/proofs/erdos-65/meta.json
+++ b/src/data/proofs/erdos-65/meta.json
@@ -15,7 +15,7 @@
       "extremal-combinatorics",
       "cycles"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 65,
     "erdosUrl": "https://erdosproblems.com/65",

--- a/src/data/proofs/erdos-663/meta.json
+++ b/src/data/proofs/erdos-663/meta.json
@@ -15,7 +15,7 @@
       "consecutive-products",
       "asymptotic-bounds"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 663,
     "erdosUrl": "https://erdosproblems.com/663",

--- a/src/data/proofs/erdos-681/meta.json
+++ b/src/data/proofs/erdos-681/meta.json
@@ -15,7 +15,7 @@
       "least-prime-factor",
       "composites"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 681,
     "erdosUrl": "https://erdosproblems.com/681",

--- a/src/data/proofs/erdos-701/meta.json
+++ b/src/data/proofs/erdos-701/meta.json
@@ -15,7 +15,7 @@
       "intersecting-families",
       "extremal-set-theory"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 701,
     "erdosUrl": "https://erdosproblems.com/701",

--- a/src/data/proofs/erdos-728-factorial-divisibility/meta.json
+++ b/src/data/proofs/erdos-728-factorial-divisibility/meta.json
@@ -18,7 +18,7 @@
       "p-adic",
       "probabilistic-method"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 728,
     "erdosUrl": "https://www.erdosproblems.com/728",

--- a/src/data/proofs/erdos-770/meta.json
+++ b/src/data/proofs/erdos-770/meta.json
@@ -14,7 +14,7 @@
       "coprimality",
       "open"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/770",
     "erdosUrl": "https://erdosproblems.com/770",

--- a/src/data/proofs/erdos-828/meta.json
+++ b/src/data/proofs/erdos-828/meta.json
@@ -17,7 +17,7 @@
       "lehmer-conjecture",
       "open"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 828,
     "erdosUrl": "https://erdosproblems.com/828",

--- a/src/data/proofs/erdos-856/meta.json
+++ b/src/data/proofs/erdos-856/meta.json
@@ -17,7 +17,7 @@
       "sunflower-conjecture",
       "open"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 856,
     "erdosUrl": "https://erdosproblems.com/856",

--- a/src/data/proofs/erdos-875/meta.json
+++ b/src/data/proofs/erdos-875/meta.json
@@ -17,7 +17,7 @@
       "binary-representation",
       "popcount"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 875,
     "erdosUrl": "https://erdosproblems.com/875",

--- a/src/data/proofs/erdos-885/meta.json
+++ b/src/data/proofs/erdos-885/meta.json
@@ -16,7 +16,7 @@
       "divisors",
       "combinatorics"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 885,
     "erdosUrl": "https://erdosproblems.com/885",

--- a/src/data/proofs/erdos-897/meta.json
+++ b/src/data/proofs/erdos-897/meta.json
@@ -16,7 +16,7 @@
       "analytic-number-theory",
       "arithmetic-functions"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 897,
     "erdosUrl": "https://erdosproblems.com/897",

--- a/src/data/proofs/erdos-919/meta.json
+++ b/src/data/proofs/erdos-919/meta.json
@@ -16,7 +16,7 @@
       "ordinals",
       "infinite-combinatorics"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 919,
     "erdosUrl": "https://erdosproblems.com/919",

--- a/src/data/proofs/erdos-926/meta.json
+++ b/src/data/proofs/erdos-926/meta.json
@@ -15,7 +15,7 @@
       "turan-number",
       "probabilistic-method"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 926,
     "erdosUrl": "https://erdosproblems.com/926",

--- a/src/data/proofs/erdos-935/meta.json
+++ b/src/data/proofs/erdos-935/meta.json
@@ -14,7 +14,7 @@
       "powerful-numbers",
       "consecutive-products"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 935,
     "erdosUrl": "https://erdosproblems.com/935",

--- a/src/data/proofs/erdos-944/meta.json
+++ b/src/data/proofs/erdos-944/meta.json
@@ -16,7 +16,7 @@
       "critical-graphs",
       "vertex-critical"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 944,
     "erdosUrl": "https://erdosproblems.com/944",

--- a/src/data/proofs/erdos-951/meta.json
+++ b/src/data/proofs/erdos-951/meta.json
@@ -18,7 +18,7 @@
       "prime-counting",
       "open"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "erdosNumber": 951,
     "erdosUrl": "https://erdosproblems.com/951",

--- a/src/data/proofs/euler-polyhedral-formula-oq-01-oq-02/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-01-oq-02/meta.json
@@ -13,7 +13,7 @@
       "combinatorics",
       "coloring"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 141,

--- a/src/data/proofs/euler-polyhedral-formula-oq-01/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-01/meta.json
@@ -16,7 +16,7 @@
       "planar-graphs"
     ],
     "proofRepoPath": "Proofs/EulerPolyhedralOQ01.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/euler-totient-oq-02/meta.json
+++ b/src/data/proofs/euler-totient-oq-02/meta.json
@@ -7,7 +7,7 @@
     "status": "verified",
     "tags": ["number-theory", "multiplicative-functions", "modular-arithmetic", "totient"],
     "proofRepoPath": "Proofs/EulerTotientOQ02.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. All results from Mathlib's Nat.totient API, ZMod, and CRT.",

--- a/src/data/proofs/fair-games-theorem-oq-01/meta.json
+++ b/src/data/proofs/fair-games-theorem-oq-01/meta.json
@@ -17,7 +17,7 @@
       "research",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/fair-games-theorem-oq-02/meta.json
+++ b/src/data/proofs/fair-games-theorem-oq-02/meta.json
@@ -16,7 +16,7 @@
       "wiedijk-100",
       "classic"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 159,

--- a/src/data/proofs/feuerbachs-theorem-oq-01/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-01/meta.json
@@ -21,7 +21,7 @@
       "tangency",
       "heron"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/feuerbachs-theorem/meta.json
+++ b/src/data/proofs/feuerbachs-theorem/meta.json
@@ -18,7 +18,7 @@
       "wiedijk-100",
       "classic"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/four-color-theorem-oq-01/meta.json
+++ b/src/data/proofs/four-color-theorem-oq-01/meta.json
@@ -15,7 +15,7 @@
             "open-question",
             "advanced"
         ],
-        "badge": "verified",
+        "badge": "mathlib",
         "sorries": 0,
         "mathlibDependencies": [
             {

--- a/src/data/proofs/fourier-series/meta.json
+++ b/src/data/proofs/fourier-series/meta.json
@@ -19,7 +19,7 @@
       "wiedijk-100",
       "classic"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2025-12-29",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/friendship-theorem-oq-03/meta.json
+++ b/src/data/proofs/friendship-theorem-oq-03/meta.json
@@ -43,7 +43,7 @@
       "research",
       "open-problem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "axiomCount": 0,
     "sorries": 0,
     "mathlibDependencies": [

--- a/src/data/proofs/friendship-theorem/meta.json
+++ b/src/data/proofs/friendship-theorem/meta.json
@@ -16,7 +16,7 @@
       "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/FriendshipTheorem.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/fundamental-arithmetic-oq-02/meta.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-02/meta.json
@@ -16,7 +16,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/FundamentalArithmeticOQ02.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,

--- a/src/data/proofs/furstenberg-correspondence-oq-01/meta.json
+++ b/src/data/proofs/furstenberg-correspondence-oq-01/meta.json
@@ -18,7 +18,7 @@
       "cantor-space",
       "correspondence-principle"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "No axioms. All results proved from Mathlib's topology, measure theory, and dynamics libraries.",

--- a/src/data/proofs/gcd-algorithm-oq-02/meta.json
+++ b/src/data/proofs/gcd-algorithm-oq-02/meta.json
@@ -16,7 +16,7 @@
       "binary-arithmetic",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. Correctness fully proved via functional induction.",

--- a/src/data/proofs/geometric-series-oq-02-oq-03/meta.json
+++ b/src/data/proofs/geometric-series-oq-02-oq-03/meta.json
@@ -18,7 +18,7 @@
       "topology",
       "extension"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-03-29",
     "axiomCount": 0,

--- a/src/data/proofs/halting-problem/meta.json
+++ b/src/data/proofs/halting-problem/meta.json
@@ -14,7 +14,7 @@
       "classic",
       "intermediate"
     ],
-    "badge": "verified",
+    "badge": "from-axioms",
     "sorries": 0,
     "mathlibDependencies": [],
     "originalContributions": [

--- a/src/data/proofs/harmonic-divergence-oq-02/meta.json
+++ b/src/data/proofs/harmonic-divergence-oq-02/meta.json
@@ -14,7 +14,7 @@
       "condensation test",
       "logarithmic"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 156,

--- a/src/data/proofs/harmonic-divergence-oq-04/meta.json
+++ b/src/data/proofs/harmonic-divergence-oq-04/meta.json
@@ -15,7 +15,7 @@
       "condensation-test",
       "classic"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-03-29",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/hilbert-15-oq-01/meta.json
+++ b/src/data/proofs/hilbert-15-oq-01/meta.json
@@ -20,7 +20,7 @@
       "poincare-duality",
       "hilbert-problems"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/hilbert-22-oq-01/meta.json
+++ b/src/data/proofs/hilbert-22-oq-01/meta.json
@@ -14,7 +14,7 @@
       "classification",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 155,

--- a/src/data/proofs/infinitude-primes-oq-03/meta.json
+++ b/src/data/proofs/infinitude-primes-oq-03/meta.json
@@ -9,7 +9,7 @@
     "date": "Classical result, formalized 2026",
     "status": "verified",
     "proofRepoPath": "Proofs/InfinitudePrimes3k2.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [

--- a/src/data/proofs/intermediate-value-theorem-oq-01/meta.json
+++ b/src/data/proofs/intermediate-value-theorem-oq-01/meta.json
@@ -17,7 +17,7 @@
       "constructive",
       "convergence"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-03-21",
     "axiomCount": 0,

--- a/src/data/proofs/knights-tour-oblique-oq-01/meta.json
+++ b/src/data/proofs/knights-tour-oblique-oq-01/meta.json
@@ -16,7 +16,7 @@
       "Knuth",
       "generalization"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "None (purely algebraic). The theorem four_oblique_corners is complete: it exhibits 4 distinct tour positions where the turn is oblique. The proof does not depend on native_decide or computational enumeration, unlike the 8×8 case.",

--- a/src/data/proofs/kroneckers-jugendtraum/meta.json
+++ b/src/data/proofs/kroneckers-jugendtraum/meta.json
@@ -14,7 +14,7 @@
       "hilbert-problems",
       "advanced"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/lagrange-theorem-oq-05/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-05/meta.json
@@ -15,7 +15,7 @@
       "orbit-stabilizer",
       "classic"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-03-29",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/law-of-cosines-oq-01/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01/meta.json
@@ -17,7 +17,7 @@
       "classic",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/law-of-cosines-oq-04/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-04/meta.json
@@ -15,7 +15,7 @@
       "law-of-cosines",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 155,

--- a/src/data/proofs/lebesgue-measure-oq-01-oq-01/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-01-oq-01/meta.json
@@ -18,7 +18,7 @@
       "countable-sets",
       "real-analysis"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 153,

--- a/src/data/proofs/mathematical-induction-oq-01/meta.json
+++ b/src/data/proofs/mathematical-induction-oq-01/meta.json
@@ -12,7 +12,7 @@
       "open-question"
     ],
     "proofRepoPath": "Proofs/MathematicalInductionOQ01.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 150,

--- a/src/data/proofs/mathematical-induction/meta.json
+++ b/src/data/proofs/mathematical-induction/meta.json
@@ -18,7 +18,7 @@
       "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/MathematicalInduction.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/minkowski-theorem/meta.json
+++ b/src/data/proofs/minkowski-theorem/meta.json
@@ -18,7 +18,7 @@
       "wiedijk-100",
       "classic"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/morleys-theorem/meta.json
+++ b/src/data/proofs/morleys-theorem/meta.json
@@ -18,7 +18,7 @@
       "wiedijk-100",
       "classic"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/napoleons-theorem/meta.json
+++ b/src/data/proofs/napoleons-theorem/meta.json
@@ -16,7 +16,7 @@
       "complex-coordinates",
       "classic"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/navier-stokes-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01/meta.json
@@ -20,7 +20,7 @@
       "analysis",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [

--- a/src/data/proofs/navier-stokes-oq-02/meta.json
+++ b/src/data/proofs/navier-stokes-oq-02/meta.json
@@ -21,7 +21,7 @@
       "analysis",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "mathlibDependencies": [

--- a/src/data/proofs/pell-equation-oq-01/meta.json
+++ b/src/data/proofs/pell-equation-oq-01/meta.json
@@ -16,7 +16,7 @@
       "computational-complexity",
       "open-problem"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-03-30",

--- a/src/data/proofs/picks-theorem-oq-01/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01/meta.json
@@ -12,7 +12,7 @@
       "open-question"
     ],
     "proofRepoPath": "Proofs/PicksTheoremOQ01.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. All theorems fully proved. The main gap for completing the full Pick's theorem proof is formalizing polygon triangulation into primitive lattice triangles.",

--- a/src/data/proofs/platonic-solids-oq-01/meta.json
+++ b/src/data/proofs/platonic-solids-oq-01/meta.json
@@ -18,7 +18,7 @@
       "research",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 53,

--- a/src/data/proofs/prime-reciprocal-divergence-oq-03/meta.json
+++ b/src/data/proofs/prime-reciprocal-divergence-oq-03/meta.json
@@ -16,7 +16,7 @@
       "erdos",
       "elementary"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/prob-method-expectation-oq-01/meta.json
+++ b/src/data/proofs/prob-method-expectation-oq-01/meta.json
@@ -14,7 +14,7 @@
       "measure-theory",
       "combinatorics"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,

--- a/src/data/proofs/prob-method-expectation/meta.json
+++ b/src/data/proofs/prob-method-expectation/meta.json
@@ -16,7 +16,7 @@
       "probability",
       "intermediate"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/prob-method-lovasz-local/meta.json
+++ b/src/data/proofs/prob-method-lovasz-local/meta.json
@@ -15,7 +15,7 @@
       "graph-theory",
       "advanced"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/prob-method-second-moment/meta.json
+++ b/src/data/proofs/prob-method-second-moment/meta.json
@@ -16,7 +16,7 @@
       "probability",
       "intermediate"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/pythagorean-theorem-oq-03/meta.json
+++ b/src/data/proofs/pythagorean-theorem-oq-03/meta.json
@@ -17,7 +17,7 @@
       "pythagorean-theorem",
       "generalization"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/roth-theorem-k3/meta.json
+++ b/src/data/proofs/roth-theorem-k3/meta.json
@@ -16,7 +16,7 @@
       "arithmetic-progressions",
       "marquee-phase-3"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/russell-1-plus-1/meta.json
+++ b/src/data/proofs/russell-1-plus-1/meta.json
@@ -16,7 +16,7 @@
       "beginner"
     ],
     "proofRepoPath": "Proofs/OnePlusOne.lean",
-    "badge": "verified",
+    "badge": "from-axioms",
     "sorries": 0,
     "mathlibDependencies": [],
     "originalContributions": [

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-01/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-01/meta.json
@@ -13,7 +13,7 @@
       "discriminant",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-03-28",

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-03/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-03/meta.json
@@ -5,7 +5,7 @@
   "description": "Proves that Ferrari's resolvent cubic for the quartic equation reduces to a depressed cubic solvable by Cardano's formula, completing the quartic-cubic-Cardano solution chain.",
   "category": "algebra",
   "status": "verified",
-  "badge": "verified",
+  "badge": "mathlib",
   "difficulty": "intermediate",
   "leanFile": "Proofs/SolutionOfCubicOQ03OQ03.lean",
   "lineCount": 262,

--- a/src/data/proofs/solution-of-cubic-oq-03/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03/meta.json
@@ -18,7 +18,7 @@
       "symmetric-polynomials",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/solution-of-cubic/meta.json
+++ b/src/data/proofs/solution-of-cubic/meta.json
@@ -19,7 +19,7 @@
       "classic",
       "complex-numbers"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2025-12-29",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/sperner-ndim-oq-03/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-03/meta.json
@@ -18,7 +18,7 @@
       "fixed-point-theory",
       "advanced"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "originalContributions": [
       "n-dimensional displacement coloring definition via barycentric coordinates",

--- a/src/data/proofs/sqrt2-examples/meta.json
+++ b/src/data/proofs/sqrt2-examples/meta.json
@@ -17,7 +17,7 @@
       "propositional-logic",
       "ordered-rings"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/sqrt2-from-axioms-oq-01/meta.json
+++ b/src/data/proofs/sqrt2-from-axioms-oq-01/meta.json
@@ -17,7 +17,7 @@
       "primes",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/sqrt2-from-axioms/meta.json
+++ b/src/data/proofs/sqrt2-from-axioms/meta.json
@@ -15,7 +15,7 @@
       "first-principles",
       "classic"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/subset-count-oq-02/meta.json
+++ b/src/data/proofs/subset-count-oq-02/meta.json
@@ -15,7 +15,7 @@
       "binomial-coefficient",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. All theorems fully proved using Mathlib's multiset powerset API.",

--- a/src/data/proofs/sum-of-kth-powers-oq-01/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-01/meta.json
@@ -16,7 +16,7 @@
       "power-sums",
       "open-question"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "None. All results follow from Mathlib's sum_range_pow theorem.",

--- a/src/data/proofs/sylow-theorems-oq-01/meta.json
+++ b/src/data/proofs/sylow-theorems-oq-01/meta.json
@@ -16,7 +16,7 @@
       "classification",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 axiom declarations, 0 sorries. All 3 previously sorry'd theorems proved: cyclic_when_coprime via commutator argument + order calculation, nonabelian_sylow_p_count by contradiction, pq_cyclic_classification by universal instantiation.",

--- a/src/data/proofs/sylow-theorems-oq-04/meta.json
+++ b/src/data/proofs/sylow-theorems-oq-04/meta.json
@@ -17,7 +17,7 @@
       "alternating-group",
       "research"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 axiom declarations, 0 sorries. All results fully verified. Exact Sylow numbers computed by native_decide. Simplicity uses Mathlib's alternatingGroup.isSimpleGroup_five.",

--- a/src/data/proofs/szemeredi-counting/meta.json
+++ b/src/data/proofs/szemeredi-counting/meta.json
@@ -16,7 +16,7 @@
       "regularity",
       "marquee-phase-3"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/three-place-identity-oq-02/meta.json
+++ b/src/data/proofs/three-place-identity-oq-02/meta.json
@@ -13,7 +13,7 @@
       "open-question"
     ],
     "proofRepoPath": "Proofs/ThreePlaceIdentityOQ02.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. All theorems fully proved.",

--- a/src/data/proofs/triangle-inequality-oq-03/meta.json
+++ b/src/data/proofs/triangle-inequality-oq-03/meta.json
@@ -18,7 +18,7 @@
       "topology"
     ],
     "proofRepoPath": "Proofs/TriangleInequalityOQ03.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 255,

--- a/src/data/proofs/triangular-reciprocals-oq-01/meta.json
+++ b/src/data/proofs/triangular-reciprocals-oq-01/meta.json
@@ -14,7 +14,7 @@
       "figurate-numbers",
       "classic"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-03-29",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/vietas-formulas-oq-03/meta.json
+++ b/src/data/proofs/vietas-formulas-oq-03/meta.json
@@ -17,7 +17,7 @@
       "newtons-identities",
       "power-sums"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 31,

--- a/src/data/proofs/wilsons-theorem-oq-04/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-04/meta.json
@@ -15,7 +15,7 @@
       "primitive-roots",
       "generalization"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "None. All theorems are fully proved. The classification relies on Mathlib's ZMod.isCyclic_units_iff and the concrete↔abstract bridge from OQ01/OQ02.",

--- a/src/data/proofs/yang-mills-2d-oq-01/meta.json
+++ b/src/data/proofs/yang-mills-2d-oq-01/meta.json
@@ -16,7 +16,7 @@
       "area-law",
       "casimir-scaling"
     ],
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,


### PR DESCRIPTION
## Fix

`verified` is not a valid `ProofBadge` TypeScript type. Valid badges: `original | mathlib | pedagogical | from-axioms | fallacy | wip | ai-solved | axiom | infrastructure`

`badge=verified` silently renders as nothing in the gallery UI (no badge shown), even though these are fully machine-checked proofs.

## Changes

- **196 proofs**: `badge=verified` → `badge=mathlib` (all use `import Mathlib` directly or via parent `Proofs.*` files that import Mathlib; all have `status=verified`, 0 sorries, 0 axioms)
- **2 proofs**: `badge=verified` → `badge=from-axioms` (self-contained with zero imports):
  - `halting-problem` — "Complete proof with zero imports, Self-contained formalization of diagonal argument"
  - `russell-1-plus-1` — "Self-contained Peano arithmetic from scratch"

## Evidence

All 198 affected proofs have `status=verified` (0 sorries, 0 axioms). The badge field is independent from status — `badge=mathlib` indicates the proof uses Mathlib theorems for the main result, while `status=verified` indicates it's fully machine-checked.

Note: Some `mathlib`-badged proofs may warrant refinement to `original` or `pedagogical` based on deeper content review — that's a follow-up enrichment task, not a bug.

---
Automated fix by lean-mechanic agent.