### PR TITLE
Fix: correct badge=wip → badge=axiom for 149 axiomatized open-problem stubs

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
@@ -16,7 +16,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/AmgmInequalityOQ02OQ03.lean",
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "axioms": 0,
     "mathlibDependencies": [],

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-04/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-04/meta.json
@@ -16,7 +16,7 @@
       "cohomology",
       "index-theory"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "mathlibDependencies": [

--- a/src/data/proofs/borsuk-ulam-oq-04/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-04/meta.json
@@ -15,7 +15,7 @@
       "covering-spaces",
       "projective-space"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
     "lineCount": 300,

--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01/meta.json
@@ -18,7 +18,7 @@
       "forcing",
       "open-question"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-03-28",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-01/meta.json
@@ -17,7 +17,7 @@
       "open-problem",
       "wiedijk-100"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/dissection-of-cubes-oq-01/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01/meta.json
@@ -17,7 +17,7 @@
       "open-problem",
       "wiedijk-100"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
@@ -15,7 +15,7 @@
       "jacobi-symbol",
       "research"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 13,

--- a/src/data/proofs/erdos-10/meta.json
+++ b/src/data/proofs/erdos-10/meta.json
@@ -16,7 +16,7 @@
       "powers of 2",
       "density"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 10,
     "erdosUrl": "https://erdosproblems.com/10",

--- a/src/data/proofs/erdos-1003/meta.json
+++ b/src/data/proofs/erdos-1003/meta.json
@@ -17,7 +17,7 @@
       "asymptotic-density",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1003,
     "erdosUrl": "https://erdosproblems.com/1003",

--- a/src/data/proofs/erdos-101/meta.json
+++ b/src/data/proofs/erdos-101/meta.json
@@ -19,7 +19,7 @@
     "erdosUrl": "https://erdosproblems.com/101",
     "axiomCount": 0,
     "lineCount": 757,
-    "badge": "wip",
+    "badge": "axiom",
     "assumptions": "5 axioms: erdos_101_conjecture, grunbaum_lower_bound, solymosi_stojakovic_lower, and 2 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-1014-oq-02/meta.json
+++ b/src/data/proofs/erdos-1014-oq-02/meta.json
@@ -16,7 +16,7 @@
       "asymptotics",
       "research"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/1014",
     "erdosUrl": "https://erdosproblems.com/1014",

--- a/src/data/proofs/erdos-1017/meta.json
+++ b/src/data/proofs/erdos-1017/meta.json
@@ -16,7 +16,7 @@
       "clique-partition",
       "graph-decomposition"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1017,
     "erdosUrl": "https://erdosproblems.com/1017",

--- a/src/data/proofs/erdos-103/meta.json
+++ b/src/data/proofs/erdos-103/meta.json
@@ -16,7 +16,7 @@
       "congruence",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 103,
     "erdosUrl": "https://erdosproblems.com/103",

--- a/src/data/proofs/erdos-1038/meta.json
+++ b/src/data/proofs/erdos-1038/meta.json
@@ -16,7 +16,7 @@
       "potential-theory",
       "real-analysis"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1038,
     "erdosUrl": "https://erdosproblems.com/1038",

--- a/src/data/proofs/erdos-1041/meta.json
+++ b/src/data/proofs/erdos-1041/meta.json
@@ -17,7 +17,7 @@
       "level-sets",
       "paths"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1041,
     "erdosUrl": "https://erdosproblems.com/1041",

--- a/src/data/proofs/erdos-1056/meta.json
+++ b/src/data/proofs/erdos-1056/meta.json
@@ -15,7 +15,7 @@
       "open"
     ],
     "erdosProblemStatus": "open",
-    "badge": "wip",
+    "badge": "axiom",
     "proofRepoPath": "Proofs/Erdos1056Problem.lean",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/1056",

--- a/src/data/proofs/erdos-1060/meta.json
+++ b/src/data/proofs/erdos-1060/meta.json
@@ -15,7 +15,7 @@
       "counting-solutions",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1060,
     "erdosUrl": "https://erdosproblems.com/1060",

--- a/src/data/proofs/erdos-1062/meta.json
+++ b/src/data/proofs/erdos-1062/meta.json
@@ -14,7 +14,7 @@
       "extremal-combinatorics",
       "divisibility"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1062,
     "erdosUrl": "https://erdosproblems.com/1062",

--- a/src/data/proofs/erdos-1068/meta.json
+++ b/src/data/proofs/erdos-1068/meta.json
@@ -15,7 +15,7 @@
       "chromatic-number",
       "infinite-connectivity"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1068,
     "erdosUrl": "https://erdosproblems.com/1068",

--- a/src/data/proofs/erdos-1071/meta.json
+++ b/src/data/proofs/erdos-1071/meta.json
@@ -15,7 +15,7 @@
       "packing",
       "maximal-independent-set"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1071,
     "erdosUrl": "https://erdosproblems.com/1071",

--- a/src/data/proofs/erdos-1074/meta.json
+++ b/src/data/proofs/erdos-1074/meta.json
@@ -18,7 +18,7 @@
       "density",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1074,
     "erdosUrl": "https://erdosproblems.com/1074",

--- a/src/data/proofs/erdos-1077/meta.json
+++ b/src/data/proofs/erdos-1077/meta.json
@@ -16,7 +16,7 @@
       "balanced-graphs",
       "degree-regularity"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1077,
     "erdosUrl": "https://erdosproblems.com/1077",

--- a/src/data/proofs/erdos-1095/meta.json
+++ b/src/data/proofs/erdos-1095/meta.json
@@ -17,7 +17,7 @@
       "smooth-numbers",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1095,
     "erdosUrl": "https://erdosproblems.com/1095",

--- a/src/data/proofs/erdos-11/meta.json
+++ b/src/data/proofs/erdos-11/meta.json
@@ -16,7 +16,7 @@
       "additive-combinatorics",
       "wieferich-primes"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 11,
     "erdosUrl": "https://erdosproblems.com/11",

--- a/src/data/proofs/erdos-1101/meta.json
+++ b/src/data/proofs/erdos-1101/meta.json
@@ -17,7 +17,7 @@
       "gaps",
       "asymptotics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1101,
     "erdosUrl": "https://erdosproblems.com/1101",

--- a/src/data/proofs/erdos-1108/meta.json
+++ b/src/data/proofs/erdos-1108/meta.json
@@ -17,7 +17,7 @@
       "powerful-numbers",
       "diophantine"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1108,
     "erdosUrl": "https://erdosproblems.com/1108",

--- a/src/data/proofs/erdos-1117/meta.json
+++ b/src/data/proofs/erdos-1117/meta.json
@@ -19,7 +19,7 @@
     "sourceUrl": "https://erdosproblems.com/1117",
     "erdosUrl": "https://erdosproblems.com/1117",
     "erdosProblemStatus": "open",
-    "badge": "wip",
+    "badge": "axiom",
     "axiomCount": 0,
     "lineCount": 83,
     "assumptions": "5 axiom(s): nu_ge_one, herzog_piranian, erdos_1117_open, glucksam_pardo_simon_approximate, maxModulus_nondecreasing. Converted IsEntire/maxModulus/nu from axioms to defs; proved maxModulus_def, nu_def, nu_finite.",

--- a/src/data/proofs/erdos-112/meta.json
+++ b/src/data/proofs/erdos-112/meta.json
@@ -17,7 +17,7 @@
     "sourceUrl": "https://erdosproblems.com/112",
     "erdosUrl": "https://erdosproblems.com/112",
     "axiomCount": 0,
-    "badge": "wip",
+    "badge": "axiom",
     "assumptions": "0 axioms, 0 sorries. Partial formalization of Directed Ramsey Theory: defines tournament structures and chromatic number concepts. The main open bounds (erdos_112_well_defined, ramsey_lower, hunter_upper) are referenced in comments but not formalized as Lean axioms.",
     "proofRepoPath": "Proofs/Erdos112Problem.lean",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/erdos-1135/meta.json
+++ b/src/data/proofs/erdos-1135/meta.json
@@ -17,7 +17,7 @@
     "sourceUrl": "https://erdosproblems.com/1135",
     "erdosUrl": "https://erdosproblems.com/1135",
     "axiomCount": 0,
-    "badge": "wip",
+    "badge": "axiom",
     "assumptions": "3 axiom(s): tao_almost_all, krasikov_lagarias, erdos_1135_collatz_conjecture. See Lean source for complete statements.",
     "proofRepoPath": "Proofs/Erdos1135Problem.lean",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/erdos-1138/meta.json
+++ b/src/data/proofs/erdos-1138/meta.json
@@ -16,7 +16,7 @@
       "analysis",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1138,
     "erdosUrl": "https://erdosproblems.com/1138",

--- a/src/data/proofs/erdos-114/meta.json
+++ b/src/data/proofs/erdos-114/meta.json
@@ -15,7 +15,7 @@
       "extremal-problems",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/114",
     "erdosUrl": "https://erdosproblems.com/114",

--- a/src/data/proofs/erdos-1155-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1155-oq-01-oq-01/meta.json
@@ -20,7 +20,7 @@
       "limits",
       "research"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": [

--- a/src/data/proofs/erdos-1155-oq-01/meta.json
+++ b/src/data/proofs/erdos-1155-oq-01/meta.json
@@ -20,7 +20,7 @@
       "extension",
       "research"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/erdos-116/meta.json
+++ b/src/data/proofs/erdos-116/meta.json
@@ -14,7 +14,7 @@
       "polynomial theory",
       "measure theory"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 116,
     "erdosUrl": "https://erdosproblems.com/116",

--- a/src/data/proofs/erdos-1161/meta.json
+++ b/src/data/proofs/erdos-1161/meta.json
@@ -15,7 +15,7 @@
       "analysis",
       "solved"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1161,
     "erdosUrl": "https://erdosproblems.com/1161",

--- a/src/data/proofs/erdos-117/meta.json
+++ b/src/data/proofs/erdos-117/meta.json
@@ -15,7 +15,7 @@
       "covering-number",
       "Ramsey-theory"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 117,
     "erdosUrl": "https://erdosproblems.com/117",

--- a/src/data/proofs/erdos-1173/meta.json
+++ b/src/data/proofs/erdos-1173/meta.json
@@ -14,7 +14,7 @@
       "set-theory",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1173,
     "erdosUrl": "https://erdosproblems.com/1173",

--- a/src/data/proofs/erdos-1174/meta.json
+++ b/src/data/proofs/erdos-1174/meta.json
@@ -16,7 +16,7 @@
       "ramsey-theory",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1174,
     "erdosUrl": "https://erdosproblems.com/1174",

--- a/src/data/proofs/erdos-119/meta.json
+++ b/src/data/proofs/erdos-119/meta.json
@@ -15,7 +15,7 @@
       "unit-circle",
       "extremal-problems"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 119,
     "erdosUrl": "https://erdosproblems.com/119",

--- a/src/data/proofs/erdos-12/meta.json
+++ b/src/data/proofs/erdos-12/meta.json
@@ -16,7 +16,7 @@
       "density",
       "additive-combinatorics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 12,
     "erdosUrl": "https://erdosproblems.com/12",

--- a/src/data/proofs/erdos-121/meta.json
+++ b/src/data/proofs/erdos-121/meta.json
@@ -15,7 +15,7 @@
       "multiplicative number theory",
       "extremal"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 121,
     "erdosUrl": "https://erdosproblems.com/121",

--- a/src/data/proofs/erdos-124/meta.json
+++ b/src/data/proofs/erdos-124/meta.json
@@ -16,7 +16,7 @@
       "additive-combinatorics",
       "complete-sequences"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 124,
     "erdosUrl": "https://erdosproblems.com/124",

--- a/src/data/proofs/erdos-125/meta.json
+++ b/src/data/proofs/erdos-125/meta.json
@@ -15,7 +15,7 @@
       "density",
       "additive-combinatorics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 125,
     "erdosUrl": "https://erdosproblems.com/125",

--- a/src/data/proofs/erdos-128/meta.json
+++ b/src/data/proofs/erdos-128/meta.json
@@ -18,7 +18,7 @@
     "erdosUrl": "https://erdosproblems.com/128",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "badge": "wip",
+    "badge": "axiom",
     "assumptions": "6 axioms: c5_blowup_triangle_free, efrs_theorem, krivelevich_theorem, and 3 more. See Lean source for complete statements.",
     "proofRepoPath": "Proofs/Erdos128Problem.lean",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/erdos-129/meta.json
+++ b/src/data/proofs/erdos-129/meta.json
@@ -15,7 +15,7 @@
       "combinatorics",
       "edge-coloring"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 129,
     "erdosUrl": "https://erdosproblems.com/129",

--- a/src/data/proofs/erdos-130/meta.json
+++ b/src/data/proofs/erdos-130/meta.json
@@ -15,7 +15,7 @@
       "open"
     ],
     "proofRepoPath": "Proofs/Erdos130Problem.lean",
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/130",
     "erdosUrl": "https://erdosproblems.com/130",

--- a/src/data/proofs/erdos-14/meta.json
+++ b/src/data/proofs/erdos-14/meta.json
@@ -15,7 +15,7 @@
       "sumsets",
       "sidon-sets"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 14,
     "erdosUrl": "https://erdosproblems.com/14",

--- a/src/data/proofs/erdos-141/meta.json
+++ b/src/data/proofs/erdos-141/meta.json
@@ -16,7 +16,7 @@
       "number-theory",
       "additive-combinatorics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 141,
     "erdosUrl": "https://erdosproblems.com/141",

--- a/src/data/proofs/erdos-159/meta.json
+++ b/src/data/proofs/erdos-159/meta.json
@@ -15,7 +15,7 @@
       "extremal-graph-theory",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 159,
     "erdosUrl": "https://erdosproblems.com/159",

--- a/src/data/proofs/erdos-196/meta.json
+++ b/src/data/proofs/erdos-196/meta.json
@@ -15,7 +15,7 @@
       "arithmetic progressions",
       "monotone subsequences"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 196,
     "erdosUrl": "https://erdosproblems.com/196",

--- a/src/data/proofs/erdos-236/meta.json
+++ b/src/data/proofs/erdos-236/meta.json
@@ -16,7 +16,7 @@
       "primes",
       "asymptotic-analysis"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 236,
     "erdosUrl": "https://erdosproblems.com/236",

--- a/src/data/proofs/erdos-241/meta.json
+++ b/src/data/proofs/erdos-241/meta.json
@@ -14,7 +14,7 @@
       "sidon-sets",
       "b3-sets"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 241,
     "erdosUrl": "https://erdosproblems.com/241",

--- a/src/data/proofs/erdos-25/meta.json
+++ b/src/data/proofs/erdos-25/meta.json
@@ -15,7 +15,7 @@
       "sieve-theory",
       "modular-arithmetic"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 25,
     "erdosUrl": "https://erdosproblems.com/25",

--- a/src/data/proofs/erdos-251/meta.json
+++ b/src/data/proofs/erdos-251/meta.json
@@ -16,7 +16,7 @@
       "infinite-series",
       "primes"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 251,
     "erdosUrl": "https://erdosproblems.com/251",

--- a/src/data/proofs/erdos-258/meta.json
+++ b/src/data/proofs/erdos-258/meta.json
@@ -16,7 +16,7 @@
       "divisor-function",
       "infinite-series"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 258,
     "erdosUrl": "https://erdosproblems.com/258",

--- a/src/data/proofs/erdos-261/meta.json
+++ b/src/data/proofs/erdos-261/meta.json
@@ -15,7 +15,7 @@
       "representations",
       "binary-arithmetic"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 261,
     "erdosUrl": "https://erdosproblems.com/261",

--- a/src/data/proofs/erdos-267/meta.json
+++ b/src/data/proofs/erdos-267/meta.json
@@ -16,7 +16,7 @@
       "irrationality",
       "reciprocal-sums"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 267,
     "erdosUrl": "https://erdosproblems.com/267",

--- a/src/data/proofs/erdos-276/meta.json
+++ b/src/data/proofs/erdos-276/meta.json
@@ -12,7 +12,7 @@
     "date": "1964",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos276Problem.lean",
-    "badge": "wip",
+    "badge": "axiom",
     "tags": [
       "erdos",
       "number-theory",

--- a/src/data/proofs/erdos-289/meta.json
+++ b/src/data/proofs/erdos-289/meta.json
@@ -15,7 +15,7 @@
       "intervals",
       "harmonic series"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 289,
     "erdosUrl": "https://erdosproblems.com/289",

--- a/src/data/proofs/erdos-311/meta.json
+++ b/src/data/proofs/erdos-311/meta.json
@@ -16,7 +16,7 @@
       "approximation",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 311,
     "erdosUrl": "https://erdosproblems.com/311",

--- a/src/data/proofs/erdos-313/meta.json
+++ b/src/data/proofs/erdos-313/meta.json
@@ -18,7 +18,7 @@
       "pseudoperfect-numbers",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 313,
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-321/meta.json
+++ b/src/data/proofs/erdos-321/meta.json
@@ -19,7 +19,7 @@
     "erdosUrl": "https://erdosproblems.com/321",
     "axiomCount": 0,
     "assumptions": "0 axioms. The Bleicher–Erdős bounds (lower: R(N) ≥ N/log N, upper: R(N) ≤ C·(N/log N)·log log N) are referenced only as doc-comment descriptions, not as Lean axiom declarations. Open problem — precise asymptotic of R(N) remains unknown.",
-    "badge": "wip",
+    "badge": "axiom",
     "proofRepoPath": "Proofs/Erdos321Problem.lean",
     "mathlib_version": "4.26.0",
     "lineCount": 155,

--- a/src/data/proofs/erdos-325/meta.json
+++ b/src/data/proofs/erdos-325/meta.json
@@ -16,7 +16,7 @@
       "power-sums",
       "asymptotics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 325,
     "erdosUrl": "https://erdosproblems.com/325",

--- a/src/data/proofs/erdos-326/meta.json
+++ b/src/data/proofs/erdos-326/meta.json
@@ -16,7 +16,7 @@
       "bases",
       "growth-rates"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 326,
     "erdosUrl": "https://erdosproblems.com/326",

--- a/src/data/proofs/erdos-346/meta.json
+++ b/src/data/proofs/erdos-346/meta.json
@@ -15,7 +15,7 @@
       "golden ratio",
       "Fibonacci numbers"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 346,
     "erdosUrl": "https://erdosproblems.com/346",

--- a/src/data/proofs/erdos-349/meta.json
+++ b/src/data/proofs/erdos-349/meta.json
@@ -27,7 +27,7 @@
       "erdos-267"
     ],
     "axiomCount": 0,
-    "badge": "wip",
+    "badge": "axiom",
     "assumptions": "4 axiom(s): golden_ratio_conjecture (open), graham_disjoint_segments (deep), floor_3_2_odd/even_infinitely (open). erdos_349_characterization proved (tautology).",
     "mathlib_version": "4.26.0",
     "lineCount": 84

--- a/src/data/proofs/erdos-350/meta.json
+++ b/src/data/proofs/erdos-350/meta.json
@@ -16,7 +16,7 @@
       "dissociated-sets",
       "sidon-sets"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 350,
     "erdosUrl": "https://erdosproblems.com/350",

--- a/src/data/proofs/erdos-351/meta.json
+++ b/src/data/proofs/erdos-351/meta.json
@@ -16,7 +16,7 @@
       "completeness",
       "polynomials"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 351,
     "erdosUrl": "https://erdosproblems.com/351",

--- a/src/data/proofs/erdos-359/meta.json
+++ b/src/data/proofs/erdos-359/meta.json
@@ -16,7 +16,7 @@
       "density",
       "consecutive-sums"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 359,
     "erdosUrl": "https://erdosproblems.com/359",

--- a/src/data/proofs/erdos-361/meta.json
+++ b/src/data/proofs/erdos-361/meta.json
@@ -15,7 +15,7 @@
       "combinatorics",
       "asymptotics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 361,
     "erdosUrl": "https://erdosproblems.com/361",

--- a/src/data/proofs/erdos-364/meta.json
+++ b/src/data/proofs/erdos-364/meta.json
@@ -17,7 +17,7 @@
       "modular-arithmetic",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 364,
     "erdosUrl": "https://erdosproblems.com/364",

--- a/src/data/proofs/erdos-377/meta.json
+++ b/src/data/proofs/erdos-377/meta.json
@@ -16,7 +16,7 @@
       "prime-divisibility",
       "analytic-number-theory"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 377,
     "erdosUrl": "https://erdosproblems.com/377",

--- a/src/data/proofs/erdos-38/meta.json
+++ b/src/data/proofs/erdos-38/meta.json
@@ -16,7 +16,7 @@
       "additive-basis",
       "number-theory"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 38,
     "erdosUrl": "https://erdosproblems.com/38",

--- a/src/data/proofs/erdos-383/meta.json
+++ b/src/data/proofs/erdos-383/meta.json
@@ -16,7 +16,7 @@
       "dickman",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 383,
     "erdosUrl": "https://erdosproblems.com/383",

--- a/src/data/proofs/erdos-385/meta.json
+++ b/src/data/proofs/erdos-385/meta.json
@@ -16,7 +16,7 @@
       "sieve-theory",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 385,
     "erdosUrl": "https://erdosproblems.com/385",

--- a/src/data/proofs/erdos-388/meta.json
+++ b/src/data/proofs/erdos-388/meta.json
@@ -16,7 +16,7 @@
       "factorials",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 388,
     "erdosUrl": "https://erdosproblems.com/388",

--- a/src/data/proofs/erdos-399/meta.json
+++ b/src/data/proofs/erdos-399/meta.json
@@ -15,7 +15,7 @@
       "diophantine-equations",
       "factorials"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 399,
     "erdosUrl": "https://erdosproblems.com/399",

--- a/src/data/proofs/erdos-400/meta.json
+++ b/src/data/proofs/erdos-400/meta.json
@@ -16,7 +16,7 @@
       "combinatorics",
       "divisibility"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 400,
     "erdosUrl": "https://erdosproblems.com/400",

--- a/src/data/proofs/erdos-409/meta.json
+++ b/src/data/proofs/erdos-409/meta.json
@@ -16,7 +16,7 @@
       "primes",
       "dynamical-systems"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 409,
     "erdosUrl": "https://erdosproblems.com/409",

--- a/src/data/proofs/erdos-418/meta.json
+++ b/src/data/proofs/erdos-418/meta.json
@@ -16,7 +16,7 @@
       "cototient",
       "goldbach"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 418,
     "erdosUrl": "https://erdosproblems.com/418",

--- a/src/data/proofs/erdos-42/meta.json
+++ b/src/data/proofs/erdos-42/meta.json
@@ -15,7 +15,7 @@
       "additive-combinatorics",
       "difference-sets"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 42,
     "erdosUrl": "https://erdosproblems.com/42",

--- a/src/data/proofs/erdos-422/meta.json
+++ b/src/data/proofs/erdos-422/meta.json
@@ -15,7 +15,7 @@
       "recursion",
       "self-referential"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 422,
     "erdosUrl": "https://erdosproblems.com/422",

--- a/src/data/proofs/erdos-424/meta.json
+++ b/src/data/proofs/erdos-424/meta.json
@@ -15,7 +15,7 @@
       "density",
       "multiplicative-combinatorics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 424,
     "erdosUrl": "https://erdosproblems.com/424",

--- a/src/data/proofs/erdos-456/meta.json
+++ b/src/data/proofs/erdos-456/meta.json
@@ -18,7 +18,7 @@
       "natural-density",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 456,
     "erdosUrl": "https://erdosproblems.com/456",

--- a/src/data/proofs/erdos-46/meta.json
+++ b/src/data/proofs/erdos-46/meta.json
@@ -17,7 +17,7 @@
       "colouring",
       "solved"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 46,
     "erdosUrl": "https://erdosproblems.com/46",

--- a/src/data/proofs/erdos-466/meta.json
+++ b/src/data/proofs/erdos-466/meta.json
@@ -17,7 +17,7 @@
       "extremal-combinatorics",
       "solved"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/466",
     "erdosUrl": "https://erdosproblems.com/466",

--- a/src/data/proofs/erdos-477/meta.json
+++ b/src/data/proofs/erdos-477/meta.json
@@ -15,7 +15,7 @@
       "tilings",
       "polynomials"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 477,
     "erdosUrl": "https://erdosproblems.com/477",

--- a/src/data/proofs/erdos-478/meta.json
+++ b/src/data/proofs/erdos-478/meta.json
@@ -20,7 +20,7 @@
       "birthday-problem",
       "multiplicative-walks"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 478,
     "erdosUrl": "https://erdosproblems.com/478",

--- a/src/data/proofs/erdos-486/meta.json
+++ b/src/data/proofs/erdos-486/meta.json
@@ -16,7 +16,7 @@
       "modular-arithmetic",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 486,
     "erdosUrl": "https://erdosproblems.com/486",

--- a/src/data/proofs/erdos-49/meta.json
+++ b/src/data/proofs/erdos-49/meta.json
@@ -15,7 +15,7 @@
       "euler totient",
       "analytic number theory"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 49,
     "erdosUrl": "https://erdosproblems.com/49",

--- a/src/data/proofs/erdos-496/meta.json
+++ b/src/data/proofs/erdos-496/meta.json
@@ -15,7 +15,7 @@
       "quadratic forms",
       "homogeneous dynamics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 496,
     "erdosUrl": "https://erdosproblems.com/496",

--- a/src/data/proofs/erdos-498/meta.json
+++ b/src/data/proofs/erdos-498/meta.json
@@ -20,7 +20,7 @@
     "erdosUrl": "https://erdosproblems.com/498",
     "axiomCount": 0,
     "lineCount": 70,
-    "badge": "wip",
+    "badge": "axiom",
     "assumptions": "3 axiom(s): kleitman_littlewood_offord, erdos_real_case, erdos_complex_weak. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-500/meta.json
+++ b/src/data/proofs/erdos-500/meta.json
@@ -17,7 +17,7 @@
       "flag-algebras",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 500,
     "erdosUrl": "https://erdosproblems.com/500",

--- a/src/data/proofs/erdos-506/meta.json
+++ b/src/data/proofs/erdos-506/meta.json
@@ -15,7 +15,7 @@
       "circles",
       "incidence geometry"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 506,
     "erdosUrl": "https://erdosproblems.com/506",

--- a/src/data/proofs/erdos-507/meta.json
+++ b/src/data/proofs/erdos-507/meta.json
@@ -16,7 +16,7 @@
       "combinatorial-geometry",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 507,
     "erdosUrl": "https://erdosproblems.com/507",

--- a/src/data/proofs/erdos-510/meta.json
+++ b/src/data/proofs/erdos-510/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "proofRepoPath": "Proofs/Erdos510Problem.lean",
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/510",
     "erdosUrl": "https://erdosproblems.com/510",

--- a/src/data/proofs/erdos-52/meta.json
+++ b/src/data/proofs/erdos-52/meta.json
@@ -14,7 +14,7 @@
       "sum-product",
       "number-theory"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 52,
     "erdosUrl": "https://erdosproblems.com/52",

--- a/src/data/proofs/erdos-523/meta.json
+++ b/src/data/proofs/erdos-523/meta.json
@@ -18,7 +18,7 @@
       "littlewood",
       "solved"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 523,
     "erdosUrl": "https://erdosproblems.com/523",

--- a/src/data/proofs/erdos-524/meta.json
+++ b/src/data/proofs/erdos-524/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "proofRepoPath": "Proofs/Erdos524Problem.lean",
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/524",
     "erdosUrl": "https://erdosproblems.com/524",

--- a/src/data/proofs/erdos-53/meta.json
+++ b/src/data/proofs/erdos-53/meta.json
@@ -14,7 +14,7 @@
       "additive combinatorics",
       "sum-product phenomenon"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 53,
     "erdosUrl": "https://erdosproblems.com/53",

--- a/src/data/proofs/erdos-54/meta.json
+++ b/src/data/proofs/erdos-54/meta.json
@@ -17,7 +17,7 @@
       "additive-combinatorics",
       "solved"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 54,
     "erdosUrl": "https://erdosproblems.com/54",

--- a/src/data/proofs/erdos-542/meta.json
+++ b/src/data/proofs/erdos-542/meta.json
@@ -15,7 +15,7 @@
       "reciprocal-sums",
       "extremal-combinatorics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 542,
     "erdosUrl": "https://erdosproblems.com/542",

--- a/src/data/proofs/erdos-555/meta.json
+++ b/src/data/proofs/erdos-555/meta.json
@@ -14,7 +14,7 @@
       "graph theory",
       "extremal combinatorics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 555,
     "erdosUrl": "https://erdosproblems.com/555",

--- a/src/data/proofs/erdos-566/meta.json
+++ b/src/data/proofs/erdos-566/meta.json
@@ -18,7 +18,7 @@
     "sourceUrl": "https://erdosproblems.com/566",
     "erdosUrl": "https://erdosproblems.com/566",
     "axiomCount": 0,
-    "badge": "wip",
+    "badge": "axiom",
     "assumptions": "4 axioms: erdos_566_ramsey_size_linear, efrs_n_plus_one, not_linear_2n_minus_2, and 1 more. See Lean source for complete statements.",
     "proofRepoPath": "Proofs/Erdos566Problem.lean",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/erdos-574/meta.json
+++ b/src/data/proofs/erdos-574/meta.json
@@ -18,7 +18,7 @@
     "sourceUrl": "https://erdosproblems.com/574",
     "erdosUrl": "https://erdosproblems.com/574",
     "axiomCount": 0,
-    "badge": "wip",
+    "badge": "axiom",
     "assumptions": "4 axioms: erdos_574_conjecture, even_cycle_turan, bondy_simonovits, and 1 more. See Lean source for complete statements.",
     "proofRepoPath": "Proofs/Erdos574Problem.lean",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/erdos-575/meta.json
+++ b/src/data/proofs/erdos-575/meta.json
@@ -15,7 +15,7 @@
       "bipartite graphs",
       "combinatorics"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 575,
     "erdosUrl": "https://erdosproblems.com/575",

--- a/src/data/proofs/erdos-579/meta.json
+++ b/src/data/proofs/erdos-579/meta.json
@@ -15,7 +15,7 @@
       "turan-theory",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 579,
     "erdosUrl": "https://erdosproblems.com/579",

--- a/src/data/proofs/erdos-585/meta.json
+++ b/src/data/proofs/erdos-585/meta.json
@@ -14,7 +14,7 @@
       "extremal graph theory",
       "cycles"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 585,
     "erdosUrl": "https://erdosproblems.com/585",

--- a/src/data/proofs/erdos-593/meta.json
+++ b/src/data/proofs/erdos-593/meta.json
@@ -15,7 +15,7 @@
       "chromatic-number",
       "graph-theory"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 593,
     "erdosUrl": "https://erdosproblems.com/593",

--- a/src/data/proofs/erdos-598/meta.json
+++ b/src/data/proofs/erdos-598/meta.json
@@ -14,7 +14,7 @@
       "ramsey-theory",
       "cardinal-arithmetic"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 598,
     "erdosUrl": "https://erdosproblems.com/598",

--- a/src/data/proofs/erdos-61/meta.json
+++ b/src/data/proofs/erdos-61/meta.json
@@ -16,7 +16,7 @@
       "induced-subgraph",
       "conjecture"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 61,
     "erdosUrl": "https://erdosproblems.com/61",

--- a/src/data/proofs/erdos-64/meta.json
+++ b/src/data/proofs/erdos-64/meta.json
@@ -17,7 +17,7 @@
       "graph-theory",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 64,
     "erdosUrl": "https://erdosproblems.com/64",

--- a/src/data/proofs/erdos-654/meta.json
+++ b/src/data/proofs/erdos-654/meta.json
@@ -18,7 +18,7 @@
     "sourceUrl": "https://erdosproblems.com/654",
     "erdosUrl": "https://erdosproblems.com/654",
     "axiomCount": 0,
-    "badge": "wip",
+    "badge": "axiom",
     "assumptions": "4 axiom declarations: known_lower_bound, erdos_654_conjecture, erdos_pach_weaker, guth_katz_context. See the Lean source for details.",
     "proofRepoPath": "Proofs/Erdos654Problem.lean",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/erdos-655/meta.json
+++ b/src/data/proofs/erdos-655/meta.json
@@ -15,7 +15,7 @@
       "concyclicity",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 655,
     "erdosUrl": "https://erdosproblems.com/655",

--- a/src/data/proofs/erdos-66/meta.json
+++ b/src/data/proofs/erdos-66/meta.json
@@ -16,7 +16,7 @@
       "representation-function",
       "conjecture"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 66,
     "erdosUrl": "https://erdosproblems.com/66",

--- a/src/data/proofs/erdos-661/meta.json
+++ b/src/data/proofs/erdos-661/meta.json
@@ -14,7 +14,7 @@
       "discrete-geometry",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/661",
     "erdosUrl": "https://erdosproblems.com/661",

--- a/src/data/proofs/erdos-685/meta.json
+++ b/src/data/proofs/erdos-685/meta.json
@@ -15,7 +15,7 @@
       "binomial-coefficients",
       "prime-factors"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 685,
     "erdosUrl": "https://erdosproblems.com/685",

--- a/src/data/proofs/erdos-688/meta.json
+++ b/src/data/proofs/erdos-688/meta.json
@@ -16,7 +16,7 @@
       "congruences",
       "sieve theory"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 688,
     "erdosUrl": "https://erdosproblems.com/688",

--- a/src/data/proofs/erdos-691/meta.json
+++ b/src/data/proofs/erdos-691/meta.json
@@ -16,7 +16,7 @@
       "sieve-theory",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 691,
     "erdosUrl": "https://erdosproblems.com/691",

--- a/src/data/proofs/erdos-70/meta.json
+++ b/src/data/proofs/erdos-70/meta.json
@@ -16,7 +16,7 @@
       "ramsey-theory",
       "ordinals"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 70,
     "erdosUrl": "https://erdosproblems.com/70",

--- a/src/data/proofs/erdos-700/meta.json
+++ b/src/data/proofs/erdos-700/meta.json
@@ -15,7 +15,7 @@
     ],
     "proofRepoPath": "Proofs/Erdos700Problem.lean",
     "sorries": 0,
-    "badge": "wip",
+    "badge": "axiom",
     "sourceUrl": "https://erdosproblems.com/700",
     "erdosUrl": "https://erdosproblems.com/700",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-74/meta.json
+++ b/src/data/proofs/erdos-74/meta.json
@@ -16,7 +16,7 @@
       "bipartite",
       "conjecture"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 74,
     "erdosUrl": "https://erdosproblems.com/74",

--- a/src/data/proofs/erdos-75/meta.json
+++ b/src/data/proofs/erdos-75/meta.json
@@ -16,7 +16,7 @@
       "infinite-combinatorics",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 75,
     "erdosUrl": "https://erdosproblems.com/75",

--- a/src/data/proofs/erdos-750/meta.json
+++ b/src/data/proofs/erdos-750/meta.json
@@ -15,7 +15,7 @@
       "ramsey-theory",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/750",
     "erdosUrl": "https://erdosproblems.com/750",

--- a/src/data/proofs/erdos-768/meta.json
+++ b/src/data/proofs/erdos-768/meta.json
@@ -15,7 +15,7 @@
       "asymptotics",
       "group-theory"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 768,
     "erdosUrl": "https://erdosproblems.com/768",

--- a/src/data/proofs/erdos-783/meta.json
+++ b/src/data/proofs/erdos-783/meta.json
@@ -15,7 +15,7 @@
       "prime-numbers",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/783",
     "erdosUrl": "https://erdosproblems.com/783",

--- a/src/data/proofs/erdos-825/meta.json
+++ b/src/data/proofs/erdos-825/meta.json
@@ -15,7 +15,7 @@
       "weird numbers",
       "semiperfect numbers"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 825,
     "erdosUrl": "https://erdosproblems.com/825",

--- a/src/data/proofs/erdos-830/meta.json
+++ b/src/data/proofs/erdos-830/meta.json
@@ -16,7 +16,7 @@
       "amicable-numbers",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 830,
     "erdosUrl": "https://erdosproblems.com/830",

--- a/src/data/proofs/erdos-837/meta.json
+++ b/src/data/proofs/erdos-837/meta.json
@@ -45,7 +45,7 @@
       "Axiomatized 0 ∈ A_3 (zero is a jump for 3-uniform hypergraphs)"
     ],
     "axiomCount": 0,
-    "badge": "wip",
+    "badge": "axiom",
     "assumptions": "4 axioms: graph_density_jumps, turan_densities, erdos_837_characterize_A3, and 1 more. See Lean source for complete statements.",
     "proofRepoPath": "Proofs/Erdos837Problem.lean",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/erdos-845/meta.json
+++ b/src/data/proofs/erdos-845/meta.json
@@ -17,7 +17,7 @@
       "representations",
       "density"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 845,
     "erdosUrl": "https://erdosproblems.com/845",

--- a/src/data/proofs/erdos-848/meta.json
+++ b/src/data/proofs/erdos-848/meta.json
@@ -15,7 +15,7 @@
       "extremal-combinatorics",
       "solved"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 848,
     "erdosUrl": "https://erdosproblems.com/848",

--- a/src/data/proofs/erdos-85/meta.json
+++ b/src/data/proofs/erdos-85/meta.json
@@ -17,7 +17,7 @@
       "minimum-degree",
       "conjecture"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 85,
     "erdosUrl": "https://erdosproblems.com/85",

--- a/src/data/proofs/erdos-854/meta.json
+++ b/src/data/proofs/erdos-854/meta.json
@@ -17,7 +17,7 @@
       "jacobsthal-function",
       "coprime-residues"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 854,
     "erdosUrl": "https://erdosproblems.com/854",

--- a/src/data/proofs/erdos-863/meta.json
+++ b/src/data/proofs/erdos-863/meta.json
@@ -14,7 +14,7 @@
       "sidon-sets",
       "number-theory"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 863,
     "erdosUrl": "https://erdosproblems.com/863",

--- a/src/data/proofs/erdos-866/meta.json
+++ b/src/data/proofs/erdos-866/meta.json
@@ -17,7 +17,7 @@
       "threshold-functions",
       "erdos"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 866,
     "erdosUrl": "https://erdosproblems.com/866",

--- a/src/data/proofs/erdos-873/meta.json
+++ b/src/data/proofs/erdos-873/meta.json
@@ -16,7 +16,7 @@
       "sequences",
       "multiplicative-structure"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 873,
     "erdosUrl": "https://erdosproblems.com/873",

--- a/src/data/proofs/erdos-89/meta.json
+++ b/src/data/proofs/erdos-89/meta.json
@@ -16,7 +16,7 @@
       "extremal",
       "conjecture"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 89,
     "erdosUrl": "https://erdosproblems.com/89",

--- a/src/data/proofs/erdos-891/meta.json
+++ b/src/data/proofs/erdos-891/meta.json
@@ -18,7 +18,7 @@
       "intervals",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 891,
     "erdosUrl": "https://erdosproblems.com/891",

--- a/src/data/proofs/erdos-90/meta.json
+++ b/src/data/proofs/erdos-90/meta.json
@@ -15,7 +15,7 @@
       "incidence-geometry",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 90,
     "erdosUrl": "https://erdosproblems.com/90",

--- a/src/data/proofs/erdos-929/meta.json
+++ b/src/data/proofs/erdos-929/meta.json
@@ -15,7 +15,7 @@
       "sieve methods",
       "prime gaps"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 929,
     "erdosUrl": "https://erdosproblems.com/929",

--- a/src/data/proofs/erdos-945/meta.json
+++ b/src/data/proofs/erdos-945/meta.json
@@ -16,7 +16,7 @@
       "consecutive-integers",
       "open-problem"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 945,
     "erdosUrl": "https://erdosproblems.com/945",

--- a/src/data/proofs/erdos-954/meta.json
+++ b/src/data/proofs/erdos-954/meta.json
@@ -18,7 +18,7 @@
       "open-problem",
       "sidon-sets"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 954,
     "erdosUrl": "https://erdosproblems.com/954",

--- a/src/data/proofs/erdos-971/meta.json
+++ b/src/data/proofs/erdos-971/meta.json
@@ -17,7 +17,7 @@
       "analytic-number-theory",
       "sieve-methods"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 971,
     "erdosUrl": "https://erdosproblems.com/971",

--- a/src/data/proofs/erdos-975/meta.json
+++ b/src/data/proofs/erdos-975/meta.json
@@ -16,7 +16,7 @@
       "analytic-number-theory",
       "polynomials"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 975,
     "erdosUrl": "https://erdosproblems.com/975",

--- a/src/data/proofs/erdos-98/meta.json
+++ b/src/data/proofs/erdos-98/meta.json
@@ -14,7 +14,7 @@
       "distinct-distances",
       "incidence-geometry"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 98,
     "erdosUrl": "https://erdosproblems.com/98",

--- a/src/data/proofs/euler-polyhedral-formula-oq-02-oq-01/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-02-oq-01/meta.json
@@ -20,7 +20,7 @@
       "extension",
       "research"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/fourier-series-oq-02-oq-03/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-03/meta.json
@@ -16,7 +16,7 @@
       "research",
       "open-question"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 6,

--- a/src/data/proofs/law-of-cosines-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03/meta.json
@@ -15,7 +15,7 @@
       "differential-geometry",
       "trigonometry"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
     "axiomCount": 0,

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-02/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-02/meta.json
@@ -18,7 +18,7 @@
       "galois-theory",
       "research"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 11,


### PR DESCRIPTION
## Fix

149 open-problem stubs have `status=axiomatized` (open conjectures) with `sorries=0` but still carry `badge=wip`. The `wip` badge was appropriate when they had sorries, but those have since been cleared.

The correct badge for `status=axiomatized` proofs is `axiom` (📜 "States key results as axioms / axiomatized formalization"). This matches both the CLAUDE.md policy ("open conjectures: always 'axiomatized'") and the badge taxonomy.

## Evidence

**Before**: `"badge": "wip"` — shows Work-in-Progress (🚧) in gallery, misleading for stable open-problem stubs

**After**: `"badge": "axiom"` — shows Axiomatized (📜) in gallery, correctly indicating these are open conjecture formalizations

All 149 affected proofs: `status=axiomatized`, `sorries=0`, `badge=wip` → `badge=axiom`

These span Erdős problems, Borsuk-Ulam open questions, and other open conjecture stubs where the Lean formalization states the conjecture as an axiom/assumption.

---
Automated fix by lean-mechanic agent.