### PR TITLE
Enrich fundamental-theorem-calculus-oq-02: add 8 annotations for Generalized Stokes Theorem

### DIFF
--- a/src/data/proofs/birthday-problem-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-k3-overview",
+    "proofId": "birthday-problem-oq-03-oq-01",
+    "range": { "startLine": 1, "endLine": 21 },
+    "type": "context",
+    "title": "k=3 Birthday Extension Counting: From n=23 to n=88",
+    "content": "The classical birthday problem asks: how many people to get 50% chance of some pair sharing a birthday? Answer: 23. This file addresses the k=3 generalization: how many for 50% chance that 3+ people share? Answer: 88 (for d=365 days). The formalization builds the extension-counting framework for computing exact probabilities recursively. The key idea: when adding person n+1 to a valid n-person assignment (where no day has ≥ k=3 people), the number of valid placement days is d minus the count of 'doubled' (full) days. This framework enables computing |noKWay(n+1)| from |noKWay(n)|.",
+    "mathContext": "Extension count: $|\\{j : |f^{-1}(j)| < k-1\\}| = d - \\#\\{\\text{full days}\\}$ valid days for person $n+1$. For $k=3$: doubled days are full days.",
+    "significance": "context",
+    "relatedConcepts": ["birthday problem", "k-way coincidence", "extension counting", "pigeonhole principle", "recursive probability"],
+    "prerequisites": ["birthday-problem-oq-03 (k-way definitions)", "Finset", "pigeonhole principle"]
+  },
+  {
+    "id": "ann-fiber-partition",
+    "proofId": "birthday-problem-oq-03-oq-01",
+    "range": { "startLine": 36, "endLine": 49 },
+    "type": "theorem",
+    "title": "Fiber Infrastructure: People Partitioned by Day",
+    "content": "`fiberAt f j` is the set of people assigned to day j, defined as a filter on the universe `Finset.univ`. `fiberAt_sum` proves the partition-of-unity: the sum of fiber sizes equals n (the total people). The proof uses `Finset.card_eq_sum_card_fiberwise` from Mathlib, which states that for any function f : α → β, the total cardinality equals the sum over fibers. The result is then a `linarith` call after normalizing with `simp`. This is the combinatorial backbone: people are partitioned by their assigned day.",
+    "mathContext": "$\\sum_{j \\in [d]} |f^{-1}(j)| = n$ where $f^{-1}(j) = \\{i : f(i) = j\\}$ is the fiber at day $j$",
+    "significance": "key",
+    "relatedConcepts": ["fiber decomposition", "partition", "counting", "Finset.card_eq_sum_card_fiberwise"],
+    "prerequisites": ["Finset.filter", "Finset.card_eq_sum_card_fiberwise", "Fintype.card_fin"]
+  },
+  {
+    "id": "ann-full-days-bound",
+    "proofId": "birthday-problem-oq-03-oq-01",
+    "range": { "startLine": 58, "endLine": 99 },
+    "type": "theorem",
+    "title": "Full Days Bound: Pigeonhole Prevents All Days Being Full",
+    "content": "`fullDays f k` is the set of days with exactly k-1 people (at maximum capacity). `fullDays_lt_d` proves the key lemma: if n < (k-1)·d (below the pigeonhole threshold), then #{full days} < d. The proof is by contradiction: if all d days were full (each with k-1 people), then the fiber sum would be ≥ (k-1)·d > n, contradicting `fiberAt_sum`. The contradiction argument uses `Finset.eq_univ_of_card` (if a subset has cardinality d, it's the whole Finset.univ) and `Finset.sum_le_sum` to lower-bound the fiber sum when all days are full.",
+    "mathContext": "$n < (k-1)d \\implies \\#\\{\\text{full days}\\} < d$. Proof: if all $d$ days have $k-1$ people, $\\sum |f^{-1}(j)| \\geq (k-1)d > n$, contradicting $\\sum = n$.",
+    "significance": "key",
+    "relatedConcepts": ["pigeonhole principle", "fiber sum", "contradiction", "full days", "capacity"],
+    "prerequisites": ["fiberAt_sum", "Finset.eq_univ_of_card", "Finset.sum_le_sum", "omega"]
+  },
+  {
+    "id": "ann-extension-count",
+    "proofId": "birthday-problem-oq-03-oq-01",
+    "range": { "startLine": 108, "endLine": 136 },
+    "type": "definition",
+    "title": "Extension Counting: d - #{full days} Valid Placements",
+    "content": "`extensionCount f k = d - (fullDays f k).card` is the number of days where person n+1 can be placed without violating the k-way constraint. `extensionCount_pos` proves this is strictly positive below the pigeonhole limit, using `fullDays_lt_d` and natural number subtraction arithmetic. `fullDays_k3` proves that for k=3, full days are exactly the doubled days (fiberAt = 2). `extension_possible_k3` specializes to k=3: if n < 2d and the assignment is valid, at least one extension is possible.",
+    "mathContext": "$\\text{extensionCount}(f,k) = d - \\#\\text{fullDays}(f,k) > 0$ when $n < (k-1)d$ (by the full-days bound)",
+    "significance": "key",
+    "relatedConcepts": ["extension count", "full days", "pigeonhole", "recursive structure", "k=3 specialization"],
+    "prerequisites": ["fullDays_lt_d", "fullDays_k3", "Nat.sub_pos_of_lt", "omega"]
+  },
+  {
+    "id": "ann-day-types",
+    "proofId": "birthday-problem-oq-03-oq-01",
+    "range": { "startLine": 145, "endLine": 199 },
+    "type": "insight",
+    "title": "Day Type Decomposition for k=3: Empty + Single + Double = d",
+    "content": "For k=3 (max 2 people per day), the days split into three types: empty (0 people), single (1 person), double (2 people). `day_type_trichotomy` uses `omega` on the validity hypothesis `card ≤ 2` to conclude card ∈ {0,1,2}. Three disjoint-filter lemmas prove pairwise disjointness of the type sets using `Finset.disjoint_filter.mpr` (filters with contradictory predicates are disjoint). `day_types_cover` assembles the covering result. `day_types_sum_d` proves |empty| + |single| + |double| = d by two applications of `Finset.card_union_of_disjoint` and the covering fact. This gives the combinatorial invariant: the type counts (a,b,c) with a+b+c=d and b+2c=n characterize all valid assignments.",
+    "mathContext": "For $k=3$: $|\\text{empty}| + |\\text{single}| + |\\text{double}| = d$ and $|\\text{single}| + 2|\\text{double}| = n$. This type vector $(a,b,c)$ determines the combinatorial structure of the assignment.",
+    "significance": "key",
+    "relatedConcepts": ["day type decomposition", "trichotomy", "disjoint partition", "multinomial counting", "type vector"],
+    "prerequisites": ["Finset.disjoint_filter", "Finset.card_union_of_disjoint", "Finset.eq_univ_iff_forall", "omega"]
+  },
+  {
+    "id": "ann-restriction",
+    "proofId": "birthday-problem-oq-03-oq-01",
+    "range": { "startLine": 208, "endLine": 221 },
+    "type": "theorem",
+    "title": "Restriction Monotonicity: Fewer People, Smaller Fibers",
+    "content": "`fiberAt_restrict_le` proves that restricting an (n+1)-person assignment f to the first n people (via `f ∘ Fin.castSucc`) has weakly smaller fibers at each day. The proof is by `Finset.card_le_card`: the restricted fiber at j is a subset of the full fiber at j (since `Fin.castSucc` embeds Fin n into Fin (n+1)). `restrict_valid` then shows restriction preserves the validity bound: if all fibers of f are ≤ m, so are the restricted fibers. This is the key 'downward monotonicity' property connecting the n+1 problem to the n problem in the recursion.",
+    "mathContext": "$|f|_{[n]}^{-1}(j)| \\leq |f^{-1}(j)|$ for all $j$ — removing a person can only shrink fibers. Enables: valid $(n+1)$-assignment $\\implies$ valid $n$-assignment.",
+    "significance": "supporting",
+    "relatedConcepts": ["restriction", "Fin.castSucc", "monotonicity", "recursive structure", "fiber inclusion"],
+    "prerequisites": ["Finset.card_le_card", "Fin.castSucc", "fiberAt", "Function.comp"]
+  }
+]

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-incomplete-01/annotations.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-incomplete-01/annotations.json
@@ -1,1 +1,72 @@
-[]
+[
+  {
+    "id": "ann-lawvere-overview",
+    "title": "Completing Categorical Lawvere: The Sorry Fix",
+    "type": "overview",
+    "startLine": 40,
+    "endLine": 49,
+    "mathContext": "The parent file CantorDiagonalizationOQ03OQ01.lean had 2 sorries in lawvere_categorical: the hypothesis used `(sorry : C.Pt (C.exp A B))` as a constant placeholder, never constructed from the quantified variable `a`. The fix: make the evaluation morphism e : C.Pt A → C.Pt (C.exp A B) an explicit parameter. This transforms the sorry into a well-typed proof: `e a` is a global element of B^A, and `C.apply (e a) x : C.Pt B` is well-formed. Proof reduces to lawvere_abstract via an EvalStructure.",
+    "significance": "This file is a case study in categorical proof formalization. The sorry in the parent was not a mathematical gap but a type-theoretic error: the evaluation morphism e must be universally quantified over global elements of A, not be a fixed constant. Making the abstract structure (EvalStructure) and the concrete instantiation (CategoricalEval) explicit separates the logical kernel from the categorical machinery.",
+    "relatedConcepts": ["Lawvere fixed-point theorem", "evaluation morphism", "cartesian closed category", "global elements", "sorry diagnosis"]
+  },
+  {
+    "id": "ann-eval-structure",
+    "title": "EvalStructure: Abstract Lawvere Kernel in 3 Lines",
+    "type": "structure",
+    "startLine": 50,
+    "endLine": 64,
+    "mathContext": "EvalStructure: Ob (codes), Val (values), eval : Ob → Ob → Val (applies code to input). IsPointSurjective: ∀ g : Ob → Val, ∃ a : Ob, ∀ x, eval a x = g x — every function is represented by a code. lawvere_abstract: if E is point-surjective then every f : Val → Val has a fixed point. Proof: obtain a₀ representing `a ↦ f (eval a a)`, then eval a₀ a₀ is a fixed point of f since f(eval a₀ a₀) = eval a₀ a₀.",
+    "significance": "The core of Lawvere's fixed-point theorem in its purest form. The diagonal argument `a ↦ f(eval a a)` is point-surjected to some code a₀, giving `eval a₀ a₀ = f(eval a₀ a₀)` — a fixed point. The two-line proof (obtain + exact) captures the entire argument. All subsequent theorems — categorical, type-theoretic, Cantor — reduce to this abstract kernel.",
+    "relatedConcepts": ["diagonal argument", "point-surjectivity", "fixed-point theorem", "self-application", "Lawvere 1969"]
+  },
+  {
+    "id": "ann-categorical-eval",
+    "title": "CategoricalEval: Cartesian Closed Categories at the Global-Element Level",
+    "type": "structure",
+    "startLine": 77,
+    "endLine": 88,
+    "mathContext": "CategoricalEval: Obj (objects), Hom : Obj → Obj → Type* (morphisms), exp : Obj → Obj → Obj (exponential), Pt : Obj → Type* (global elements = Hom(1, ·)), apply : Pt(exp A B) → Pt A → Pt B (evaluation at global elements), ptSurj : Hom A (exp A B) → Prop. HasFixedPoint C f := ∃ b : C.Pt B, f b = b. This abstracts a CCC by focusing on what matters for Lawvere: how global elements compose via evaluation.",
+    "significance": "The CategoricalEval structure axiomatizes exactly the CCC data needed for Lawvere's theorem at the global-element level, avoiding full category theory (functors, naturality, coherence). Working with Pt A = Hom(1, A) and apply = ev ∘ (id × pt) is sufficient for the diagonal argument. This is the 'point-set' model of a CCC.",
+    "relatedConcepts": ["cartesian closed category", "global elements", "evaluation morphism", "terminal object", "internal hom"]
+  },
+  {
+    "id": "ann-lawvere-categorical",
+    "title": "Lawvere's Theorem (Categorical, Corrected): 5-Line Proof",
+    "type": "theorem",
+    "startLine": 111,
+    "endLine": 127,
+    "mathContext": "lawvere_categorical: given C : CategoricalEval, A B : C.Obj, e : C.Pt A → C.Pt (C.exp A B), hSurj (∀ g : C.Pt A → C.Pt B, ∃ a, ∀ x, C.apply (e a) x = g x), and f : C.Pt B → C.Pt B, then C.HasFixedPoint f. Proof: let E := {Ob := C.Pt A, Val := C.Pt B, eval := fun a x => C.apply (e a) x}; have hE : E.IsPointSurjective := hSurj (definitional); exact lawvere_abstract E hE f.",
+    "significance": "The proof is 5 lines total. The 'let E' bundles categorical morphisms into an EvalStructure, making the reduction explicit. hSurj directly IS E.IsPointSurjective (definitional equality, no rewriting needed). The categorical theorem is not more general than the abstract one — it is the abstract one with different vocabulary. This transparency is the value of the EvalStructure abstraction.",
+    "relatedConcepts": ["EvalStructure reduction", "definitional equality", "let binding", "lawvere_abstract", "categorical fixed-point"]
+  },
+  {
+    "id": "ann-type-universe-cantor",
+    "title": "Type Universe as CCC and Categorical Cantor's Theorem",
+    "type": "definition",
+    "startLine": 148,
+    "endLine": 176,
+    "mathContext": "typeUniverse : CategoricalEval encodes types as objects, functions as morphisms, function-types as exponentials, terms as global elements (Pt = id), function application as apply. categorical_cantor: for any A : Type* and e : A → (A → Prop), e is not point-surjective. Proof: hNotFixed (∀ v : Prop, ¬v = v) derived from v = ¬v giving both v → ¬v and ¬v → v; then obtain a₀ from hSurj (fun a => ¬ e a a), get e a₀ a₀ = ¬ e a₀ a₀, apply hNotFixed.",
+    "significance": "hNotFixed uses classical logic on Prop: v = ¬v gives a proof of both v and ¬v simultaneously (lines 166-170). This explicit construction avoids omega/decide and works purely from the logical structure of Prop. categorical_cantor is the standard Cantor diagonal argument as a corollary of the categorical Lawvere framework, showing that 2^A surjects onto A is impossible in any reasonable setting.",
+    "relatedConcepts": ["Cantor's theorem", "diagonal function", "Prop negation", "function surjectivity", "type universe CCC"]
+  },
+  {
+    "id": "ann-no-surjection",
+    "title": "No Point-Surjective Evaluation When Fixed Points Fail",
+    "type": "theorem",
+    "startLine": 131,
+    "endLine": 138,
+    "mathContext": "no_categorical_surjection: if f : Pt B → Pt B has no fixed point (∀ v, f v ≠ v), then ¬ ∃ point-surjective evaluation e : Pt A → Pt(B^A). Proof by contradiction: assume hSurj, apply lawvere_categorical to get v with f v = v, contradict hf v hv. This is the contrapositive: point-surjectivity → fixed points; fixed-point-free f → no point-surjective e.",
+    "significance": "This is the form used in applications: to prove no surjection A → (A → B) exists, exhibit a fixed-point-free endomorphism of B (negation on Prop, successor on ℕ). no_categorical_surjection makes this chain explicit as a reusable theorem, separating the abstract impossibility from its concrete instantiation in categorical_cantor.",
+    "relatedConcepts": ["contrapositive", "fixed-point-free endomorphism", "no surjection", "Cantor's diagonal", "reusable theorem"]
+  },
+  {
+    "id": "ann-specialization",
+    "title": "Specialization to Type Theory and Sorry Diagnosis",
+    "type": "theorem",
+    "startLine": 210,
+    "endLine": 229,
+    "mathContext": "categorical_specializes_to_type_theoretic: for A B : Type* and e : A → (A → B) with Function.Surjective e, every f : B → B has a fixed point. Proof: build C := typeUniverse, apply lawvere_categorical C e, translate hSurj using congr_fun (pointwise equality: e a = g ↔ ∀ x, e a x = g x). sorry_diagnosis_resolved (line 192): identical to lawvere_categorical — the sorry in the parent was just a type error, not a mathematical gap.",
+    "significance": "congr_fun is the bridge: Function.Surjective e says ∃ a, e a = g (function equality), while lawvere_categorical needs ∀ x, e a x = g x (pointwise equality). congr_fun converts one to the other. categorical_specializes_to_type_theoretic closes the circle, confirming that the type-theoretic Lawvere is a special case of the categorical one, not an independent theorem.",
+    "relatedConcepts": ["Function.Surjective", "congr_fun", "pointwise equality", "type-theoretic Lawvere", "sorry diagnosis"]
+  }
+]

--- a/src/data/proofs/cauchy-schwarz-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/cauchy-schwarz-oq-03-oq-02/annotations.json
@@ -1,0 +1,82 @@
+[
+  {
+    "id": "ann-minkowski-overview",
+    "title": "Minkowski from Hölder: The Proof Chain",
+    "type": "overview",
+    "startLine": 37,
+    "endLine": 45,
+    "mathContext": "The Hölder–Minkowski chain: Young's inequality gives Hölder (∑fg ≤ ‖f‖_p·‖g‖_q), and Hölder gives Minkowski (‖f+g‖_p ≤ ‖f‖_p + ‖g‖_p). Minkowski's inequality is equivalent to the triangle inequality for Lp spaces. The classical proof technique: write ∑(f+g)^p = ∑(f+g)^(p-1)·f + ∑(f+g)^(p-1)·g, apply Hölder twice with conjugate exponents p and q=p/(p-1), then divide both sides by (∑(f+g)^p)^(1/q).",
+    "significance": "This file completes the answer to the open question from CauchySchwarzOQ03.lean: can Minkowski be derived from Hölder? Yes. The full chain Young → Hölder → Cauchy-Schwarz → Minkowski → Lp Banach space is now formally established across 4 files with 0 sorries and 0 axioms.",
+    "relatedConcepts": ["Hölder's inequality", "Lp spaces", "triangle inequality", "Young's inequality", "Riesz representation theorem"]
+  },
+  {
+    "id": "ann-minkowski-p1",
+    "title": "p=1 Case: Triangle Inequality for Finite Sums",
+    "type": "theorem",
+    "startLine": 49,
+    "endLine": 61,
+    "mathContext": "Two p=1 theorems: (1) minkowski_p1_nnreal gives equality ∑(f_i+g_i) = ∑f_i + ∑g_i for NNReal via Finset.sum_add_distrib — equality not inequality, because NNReal has no cancellation. (2) minkowski_p1_real gives ∑|f_i+g_i| ≤ ∑|f_i| + ∑|g_i| for signed reals by pointwise abs_add then Finset.sum_le_sum. The calc block makes the two-step argument explicit.",
+    "significance": "Establishes the base case p=1 in two forms. The NNReal version minkowski_p1_nnreal is a one-liner (Finset.sum_add_distrib), showing that p=1 Minkowski is trivial for nonnegative values. The real case requires the triangle inequality for absolute values, making it the first genuine inequality in the file.",
+    "relatedConcepts": ["triangle inequality", "NNReal", "Finset.sum_add_distrib", "abs_add", "sum monotonicity"]
+  },
+  {
+    "id": "ann-minkowski-nnreal",
+    "title": "General Minkowski for NNReal: NNReal.Lp_add_le",
+    "type": "theorem",
+    "startLine": 80,
+    "endLine": 84,
+    "mathContext": "For p ≥ 1 and NNReal-valued f, g on a finite index set s: (∑(f_i+g_i)^p)^(1/p) ≤ (∑f_i^p)^(1/p) + (∑g_i^p)^(1/p). Proved by delegating to NNReal.Lp_add_le, a Mathlib theorem that internalizes the Riesz (1910) argument: split ∑(f+g)^p using the identity, apply Hölder with exponents (p, q=p/(p-1)) to each half, factor out (∑(f+g)^p)^(1/q) to isolate (∑(f+g)^p)^(1/p).",
+    "significance": "The central theorem. This one-line proof formally confirms that Mathlib's NNReal.Lp_add_le — which is itself proved via Hölder — makes Minkowski an immediate consequence. The NNReal case is the foundation: all other variants (real, p=2, inner product, Lp integral) either specialize or lift from this.",
+    "relatedConcepts": ["NNReal.Lp_add_le", "Hölder's inequality", "conjugate exponents", "Finset Lp norm"]
+  },
+  {
+    "id": "ann-minkowski-real",
+    "title": "Real-Valued Minkowski via Lifting to NNReal",
+    "type": "theorem",
+    "startLine": 98,
+    "endLine": 119,
+    "mathContext": "Two theorems: (1) lp_sum_mono (auxiliary): if h_i ≤ k_i pointwise then (∑h_i^p)^(1/p) ≤ (∑k_i^p)^(1/p), proved by NNReal.rpow_le_rpow applied to Finset.sum_le_sum. (2) minkowski_real: (∑‖f_i+g_i‖₊^p)^(1/p) ≤ (∑‖f_i‖₊^p)^(1/p) + (∑‖g_i‖₊^p)^(1/p) via a calc block — first lp_sum_mono using nnnorm_add_le (‖f+g‖₊ ≤ ‖f‖₊ + ‖g‖₊), then NNReal.Lp_add_le. The nnnorm ‖·‖₊ lifts signed reals to NNReal.",
+    "significance": "The lifting strategy: real-valued Minkowski reduces to NNReal Minkowski. The key bridge is nnnorm_add_le, which transfers the absolute value triangle inequality to the NNReal setting. The lp_sum_mono lemma is independently useful: Lp norms are monotone in the function values.",
+    "relatedConcepts": ["nnnorm", "NNReal lifting", "lp_sum_mono", "nnnorm_add_le", "NNReal.rpow_le_rpow"]
+  },
+  {
+    "id": "ann-minkowski-p2",
+    "title": "p=2 Euclidean Triangle Inequality",
+    "type": "theorem",
+    "startLine": 134,
+    "endLine": 138,
+    "mathContext": "minkowski_p2_nnreal specializes minkowski_nnreal to p=2: (∑(f_i+g_i)²)^(1/2) ≤ (∑f_i²)^(1/2) + (∑g_i²)^(1/2). Proved in one line by calling minkowski_nnreal with norm_num : (1:ℝ) ≤ 2. This is the finite-dimensional Euclidean triangle inequality. Just as Cauchy-Schwarz is Hölder at p=q=2, the Euclidean triangle inequality is Minkowski at p=2.",
+    "significance": "Illustrates the specialization pattern: the general Minkowski framework subsumes the familiar Euclidean geometry. The one-line proof from the general case is a demonstration of the power of abstract inequality theory. The conceptual parallel to Cauchy-Schwarz at p=q=2 makes the Hölder–Minkowski duality concrete.",
+    "relatedConcepts": ["Euclidean norm", "p=2 special case", "norm_num", "Cauchy-Schwarz duality", "L2 norm"]
+  },
+  {
+    "id": "ann-minkowski-inner-product",
+    "title": "Inner Product Space Triangle Inequality via Cauchy-Schwarz",
+    "type": "theorem",
+    "startLine": 158,
+    "endLine": 169,
+    "mathContext": "Two theorems: (1) minkowski_inner_product: in any InnerProductSpace ℝ E, ‖u+v‖ ≤ ‖u‖ + ‖v‖, proved by norm_add_le (Mathlib). (2) norm_add_sq_le: ‖u+v‖² ≤ (‖u‖+‖v‖)² via nlinarith from minkowski_inner_product. The classical proof of (1) expands ‖u+v‖² = ‖u‖² + 2⟨u,v⟩ + ‖v‖² ≤ ‖u‖² + 2‖u‖‖v‖ + ‖v‖² = (‖u‖+‖v‖)² using ⟨u,v⟩ ≤ ‖u‖‖v‖ from Cauchy-Schwarz.",
+    "significance": "Closes the proof chain: Hölder → Cauchy-Schwarz → inner product triangle inequality. This is the abstract version of Minkowski: any inner product space satisfies ‖u+v‖ ≤ ‖u‖+‖v‖. The nlinarith proof of norm_add_sq_le shows how algebraic manipulations of norms in Lean avoid manual case splits.",
+    "relatedConcepts": ["InnerProductSpace", "norm_add_le", "Cauchy-Schwarz", "nlinarith", "inner product expansion"]
+  },
+  {
+    "id": "ann-minkowski-lp",
+    "title": "Integral Minkowski for Lp Measure Spaces",
+    "type": "theorem",
+    "startLine": 186,
+    "endLine": 194,
+    "mathContext": "Two theorems for measure-theoretic Lp spaces: minkowski_lp for general p (with Fact (1 ≤ p) typeclass instance) and minkowski_l2 for L2 (p=2). Both reduce to norm_add_le f g, which is the triangle inequality inherited from the NormedAddCommGroup instance on Lp ℝ p μ. The variable block (line 181) introduces the measure space: MeasurableSpace α and Measure α.",
+    "significance": "Shows that once Mathlib's Lp spaces are established as NormedAddCommGroup (which requires Minkowski in the construction), the triangle inequality is automatic. The Fact (1 ≤ p) typeclass pattern encodes the hypothesis p ≥ 1 as a typeclass constraint, enabling instance inference. The integral case connects to the finite-sum case via density arguments in Mathlib.",
+    "relatedConcepts": ["Lp spaces", "MeasureTheory", "Fact typeclass", "NormedAddCommGroup", "integral norm"]
+  },
+  {
+    "id": "ann-holder-minkowski-chain",
+    "title": "Hölder–Minkowski Duality: Combined Statement",
+    "type": "theorem",
+    "startLine": 215,
+    "endLine": 224,
+    "mathContext": "holder_minkowski_chain states both inequalities as a conjunction for NNReal functions: (1) Hölder: ∑f_i·g_i ≤ (∑f_i^p)^(1/p)·(∑g_i^q)^(1/q) via NNReal.inner_le_Lp_mul_Lq, and (2) Minkowski: (∑(f_i+g_i)^p)^(1/p) ≤ (∑f_i^p)^(1/p)+(∑g_i^p)^(1/p) via NNReal.Lp_add_le. Uses Real.HolderConjugate q for the condition 1/p+1/q=1. The proof is ⟨NNReal.inner_le_Lp_mul_Lq s f g hpq, NNReal.Lp_add_le hp f g s⟩.",
+    "significance": "Formalizes the Hölder–Minkowski duality: Hölder bounds the bilinear pairing ⟨f,g⟩ = ∑f_i·g_i while Minkowski bounds the norm ‖f+g‖_p. Together they establish Lp and Lq as a dual pair — the foundation for the Riesz representation theorem (Lp)* ≅ Lq and the entire edifice of functional analysis.",
+    "relatedConcepts": ["HolderConjugate", "NNReal.inner_le_Lp_mul_Lq", "dual spaces", "Riesz representation", "functional analysis"]
+  }
+]

--- a/src/data/proofs/fundamental-theorem-calculus-oq-02/annotations.json
+++ b/src/data/proofs/fundamental-theorem-calculus-oq-02/annotations.json
@@ -1,0 +1,206 @@
+[
+  {
+    "id": "ann-ftc-stokes-overview",
+    "proofId": "fundamental-theorem-calculus-oq-02",
+    "range": {
+      "startLine": 4,
+      "endLine": 43
+    },
+    "type": "context",
+    "title": "Generalized Stokes: One Theorem to Rule Them All",
+    "content": "The opening module comment frames the unifying vision: FTC (1D), Green's theorem (2D), the classical Stokes theorem (3D surface), and the divergence theorem (3D volume) are all special cases of a single identity \u2014 \u222b_M d\u03c9 = \u222b_{\u2202M} \u03c9. The formalization concentrates on the 1D and 2D cases where all the machinery can be made concrete with Mathlib. The 3D cases are documented but left to future work, pending Mathlib's development of integration theory on manifolds. This choice of scope reflects a mathematically honest balance: prove what is fully verified rather than axiomatizing the general statement.",
+    "mathContext": "$\\int_M d\\omega = \\int_{\\partial M} \\omega$ unifies: FTC ($n=1$), Green's theorem ($n=2$, planar), classical Stokes ($n=2$, surface), Gauss's divergence theorem ($n=3$)",
+    "significance": "context",
+    "relatedConcepts": [
+      "exterior derivative",
+      "boundary operator",
+      "oriented manifold",
+      "differential form",
+      "de Rham complex"
+    ],
+    "prerequisites": [
+      "FTC (1D)",
+      "Green's theorem",
+      "differential forms (conceptual)"
+    ]
+  },
+  {
+    "id": "ann-1d-forms",
+    "proofId": "fundamental-theorem-calculus-oq-02",
+    "range": {
+      "startLine": 59,
+      "endLine": 70
+    },
+    "type": "definition",
+    "title": "1D Differential Forms: extDeriv1D, intForm1D, bdryEval",
+    "content": "`extDeriv1D F = deriv F` is the exterior derivative taking a 0-form (function) to a 1-form (its derivative, thought of as the coefficient of dx). `intForm1D f a b = \u222b x in a..b, f x` integrates a 1-form f(x)dx over the oriented interval [a,b]. `bdryEval F a b = F b - F a` integrates a 0-form over the boundary \u2202[a,b] = {b} \u222a {a} with induced orientations (+1 at b, -1 at a). The Stokes theorem then says intForm1D (extDeriv1D F) a b = bdryEval F a b, i.e., \u222b_a^b F'(x)dx = F(b) - F(a).",
+    "mathContext": "The 1D de Rham complex: $\\Omega^0(\\mathbb{R}) \\xrightarrow{d} \\Omega^1(\\mathbb{R})$ where $d(F) = F' \\, dx$, $\\int_{[a,b]} d(F) = \\int_a^b F'(x)\\,dx$, $\\int_{\\partial[a,b]} F = F(b) - F(a)$",
+    "significance": "key",
+    "relatedConcepts": [
+      "exterior derivative",
+      "integration of forms",
+      "boundary evaluation",
+      "FTC Part 2"
+    ],
+    "prerequisites": [
+      "interval integrals (Mathlib)",
+      "deriv",
+      "HasDerivAt"
+    ]
+  },
+  {
+    "id": "ann-stokes-1d",
+    "proofId": "fundamental-theorem-calculus-oq-02",
+    "range": {
+      "startLine": 76,
+      "endLine": 110
+    },
+    "type": "theorem",
+    "title": "Stokes in 1D = FTC Part 2 (Three Variants)",
+    "content": "Three versions of the 1D Stokes theorem are proved. `stokes_1d` is the most general, assuming only ContinuousOn F and HasDerivAt pointwise; it calls `integral_eq_sub_of_hasDerivAt_of_le` from Mathlib. `stokes_1d_differentiable` is the cleanest version matching classical FTC: F differentiable, F' continuous. `stokes_1d_orientation` proves orientation-reversal (reversing [a,b] to [b,a] negates the integral) using `intervalIntegral.integral_symm` \u2014 this holds unconditionally since both sides are 0 for non-integrable functions. Together these show the Mathlib FTC API is exactly the 1D Stokes theorem.",
+    "mathContext": "$\\int_a^b F'(x)\\,dx = F(b) - F(a)$ (Stokes 1D); $\\int_b^a F'(x)\\,dx = -(\\int_a^b F'(x)\\,dx)$ (orientation-reversal)",
+    "significance": "key",
+    "relatedConcepts": [
+      "FTC Part 2",
+      "orientation reversal",
+      "Mathlib integral API",
+      "HasDerivAt",
+      "IntervalIntegrable"
+    ],
+    "prerequisites": [
+      "integral_eq_sub_of_hasDerivAt_of_le",
+      "intervalIntegral.integral_symm",
+      "ContinuousOn"
+    ]
+  },
+  {
+    "id": "ann-poincare-1d",
+    "proofId": "fundamental-theorem-calculus-oq-02",
+    "range": {
+      "startLine": 125,
+      "endLine": 148
+    },
+    "type": "theorem",
+    "title": "Poincar\u00e9 Lemma in 1D: Closed Forms are Exact",
+    "content": "`poincare_1d` proves the 1D Poincar\u00e9 lemma: every continuous function f (thought of as a 1-form f(x)dx) is exact \u2014 has an antiderivative. The canonical antiderivative is F(x) = \u222b_a^x f(t) dt, proved by `integral_hasDerivAt_right` from Mathlib (FTC Part 1). `exact_unique` then proves antiderivatives are unique up to a constant: if F' = G' = f, then F - G is constant, proved using `is_const_of_deriv_eq_zero` (a consequence of the mean value theorem). Together these establish the algebraic structure of the 1D de Rham complex.",
+    "mathContext": "The 1D Poincar\u00e9 lemma: $H^1_{\\text{dR}}(\\mathbb{R}) = 0$ (every closed 1-form is exact). Proof: $F(x) = \\int_a^x f(t)\\,dt$ satisfies $F' = f$ by FTC Part 1. Uniqueness: $F - G$ constant when $F' = G'$ by MVT.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Poincar\u00e9 lemma",
+      "antiderivative",
+      "de Rham cohomology",
+      "FTC Part 1",
+      "mean value theorem"
+    ],
+    "prerequisites": [
+      "integral_hasDerivAt_right",
+      "is_const_of_deriv_eq_zero",
+      "HasDerivAt"
+    ]
+  },
+  {
+    "id": "ann-2d-forms",
+    "proofId": "fundamental-theorem-calculus-oq-02",
+    "range": {
+      "startLine": 172,
+      "endLine": 189
+    },
+    "type": "definition",
+    "title": "2D Differential Forms: OneForm2D and Exterior Derivatives",
+    "content": "`OneForm2D` is a structure representing \u03c9 = P(x,y)dx + Q(x,y)dy as a pair of functions (P, Q). `extDeriv0_2D f` computes the gradient: d\u2080(f) = (\u2202f/\u2202x, \u2202f/\u2202y) using Lean's `deriv` for partial derivatives by fixing one coordinate. `extDeriv1_2D \u03c9` computes the curl: d\u2081(Pdx + Qdy) = (\u2202Q/\u2202x - \u2202P/\u2202y)dx\u2227dy. The curl is computed as a function returning a scalar (the coefficient of dx\u2227dy). These definitions directly encode the classical calculus operations in a Lean-native way, avoiding abstract sheaf theory.",
+    "mathContext": "$d_0(f) = \\nabla f = (\\partial_x f, \\partial_y f)$; $d_1(P\\,dx + Q\\,dy) = (\\partial_x Q - \\partial_y P)\\,dx\\wedge dy$ (the curl/rotation)",
+    "significance": "key",
+    "relatedConcepts": [
+      "gradient",
+      "curl",
+      "exterior derivative",
+      "1-form",
+      "2-form",
+      "de Rham complex"
+    ],
+    "prerequisites": [
+      "1D forms",
+      "partial derivatives via deriv",
+      "OneForm2D structure"
+    ]
+  },
+  {
+    "id": "ann-d-squared-zero",
+    "proofId": "fundamental-theorem-calculus-oq-02",
+    "range": {
+      "startLine": 195,
+      "endLine": 213
+    },
+    "type": "insight",
+    "title": "d\u00b2=0 and the Sorry: Clairaut's Theorem as a Formalization Challenge",
+    "content": "`dd_eq_zero_2D` states that for C\u00b2 functions f, the composition d\u2081\u2218d\u2080(f) = 0 \u2014 i.e., \u2202\u00b2f/\u2202x\u2202y = \u2202\u00b2f/\u2202y\u2202x (Clairaut/Schwarz theorem on equality of mixed partials). The proof is a sorry. The comment explains why: Mathlib proves this via `ContDiff.isSymmetric_iteratedFDeriv` which works at the level of Fr\u00e9chet derivatives (as symmetric bilinear forms on \u211d\u00b2), but bridging to the concrete partial derivative expressions used here requires unfolding the Mathlib API in a non-trivial way. This d\u00b2=0 property is the algebraic foundation enabling de Rham cohomology to be well-defined.",
+    "mathContext": "$d^2 = 0$: $d_1 \\circ d_0(f) = \\partial^2_x\\partial_y f - \\partial^2_y\\partial_x f = 0$ for $f \\in C^2$ by Clairaut's theorem. Equivalent to symmetry of the Hessian.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Clairaut's theorem",
+      "mixed partial derivatives",
+      "Hessian symmetry",
+      "de Rham cohomology",
+      "ContDiff"
+    ],
+    "prerequisites": [
+      "ContDiff.isSymmetric_iteratedFDeriv",
+      "Fr\u00e9chet derivative",
+      "partial derivatives"
+    ]
+  },
+  {
+    "id": "ann-greens-stokes",
+    "proofId": "fundamental-theorem-calculus-oq-02",
+    "range": {
+      "startLine": 241,
+      "endLine": 276
+    },
+    "type": "theorem",
+    "title": "Green's Theorem as 2D Stokes: Proof via GreensTheoremOQ01",
+    "content": "`lineIntegralRect \u03c9 a b c d` computes \u222e_{\u2202R} \u03c9 for the rectangle [a,b]\u00d7[c,d] counterclockwise as four FTC integrals along the four edges. `areaIntegralRect h a b c d` computes \u222c_R h as an iterated integral via Fubini. `stokes_2d_rectangle` proves lineIntegralRect = areaIntegralRect \u2218 extDeriv1_2D \u2014 Green's theorem in Stokes form \u2014 by delegating to `GreensTheoremOQ01.greens_theorem_concrete`. The proof is clean but requires many integrability hypotheses (\u2200 y, IntervalIntegrable for each cross-section) plus Fubini commutativity as a hypothesis. This honestly represents the technical content that Green's theorem requires.",
+    "mathContext": "$\\oint_{\\partial R} P\\,dx + Q\\,dy = \\iint_R \\left(\\frac{\\partial Q}{\\partial x} - \\frac{\\partial P}{\\partial y}\\right)\\,dA$ where $R = [a,b]\\times[c,d]$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Green's theorem",
+      "Fubini's theorem",
+      "iterated integrals",
+      "line integral",
+      "double integral"
+    ],
+    "prerequisites": [
+      "greens-theorem-oq-01",
+      "intervalIntegral",
+      "IntervalIntegrable",
+      "Fubini"
+    ]
+  },
+  {
+    "id": "ann-derham-cohomology",
+    "proofId": "fundamental-theorem-calculus-oq-02",
+    "range": {
+      "startLine": 341,
+      "endLine": 364
+    },
+    "type": "insight",
+    "title": "De Rham Cohomology of \u211d: H\u2070 = \u211d and H\u00b9 = 0",
+    "content": "`h1_trivial` proves H\u00b9_dR(\u211d) = 0: every continuous 1-form on \u211d is exact, by calling `poincare_1d` and extracting the antiderivative via `funext`. `h0_eq_constants` proves H\u2070_dR(\u211d) = \u211d: if d(F) = 0 (F is closed of degree 0), then F is constant, using `is_const_of_deriv_eq_zero`. Together: H\u2070(\u211d) = \u211d (constants, since \u211d is connected) and H\u00b9(\u211d) = 0 (contractible, so no topological obstructions). In contrast, H\u00b9(S\u00b9) = \u211d, showing the cohomology detects topology. The Stokes hierarchy is documented in the Part VII comment: n=1 (FTC), n=2 (Green), n=2 surface (Stokes), n=3 (Gauss).",
+    "mathContext": "$H^0_{\\text{dR}}(\\mathbb{R}) = \\mathbb{R}$ (connected), $H^1_{\\text{dR}}(\\mathbb{R}) = 0$ (contractible); contrast with $H^1_{\\text{dR}}(S^1) = \\mathbb{R}$ (angle form $d\\theta$ is closed but not exact)",
+    "significance": "key",
+    "relatedConcepts": [
+      "de Rham cohomology",
+      "H^0",
+      "H^1",
+      "Poincar\u00e9 lemma",
+      "connectedness",
+      "contractibility",
+      "S^1"
+    ],
+    "prerequisites": [
+      "poincare_1d",
+      "is_const_of_deriv_eq_zero",
+      "Poincar\u00e9 lemma",
+      "differential forms"
+    ]
+  }
+]

--- a/src/data/proofs/fundamental-theorem-calculus-oq-02/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus-oq-02/meta.json
@@ -65,10 +65,11 @@
     "proofStrategy": "The formalization proceeds dimension by dimension:\n\n**1D (proved):** Define 0-forms (functions), 1-forms (coefficients of dx), and the exterior derivative d(F) = F'dx. Prove Stokes = FTC using Mathlib's `integral_eq_sub_of_hasDerivAt_of_le`. Prove the Poincare lemma using `integral_hasDerivAt_right` (the integral function is an antiderivative). Prove H^0 = constants using `is_const_of_deriv_eq_zero`.\n\n**2D (stated):** Define OneForm2D = (P,Q) and exterior derivatives d_0(f) = (df/dx, df/dy) and d_1(P,Q) = dQ/dx - dP/dy. State d^2 = 0 (Clairaut) and Green's theorem as ∫_{partial R} omega = ∫_R d(omega).\n\n**General (documented):** Describe the requirements for the fully general theorem on manifolds with boundary.",
     "keyInsights": [
       "The Fundamental Theorem of Calculus is the 1D Stokes theorem: M=[a,b] is a 1-manifold with boundary {a,b}, omega=F is a 0-form, and d(omega)=F'dx is a 1-form",
-      "d^2 = 0 (the key structural property enabling de Rham cohomology) corresponds to Clairaut's theorem on equality of mixed partial derivatives",
-      "The Poincare lemma (closed => exact on contractible domains) gives H^1_dR(R) = 0, while H^1_dR(S^1) = R shows topology matters",
-      "Orientation-reversal negates the integral — this is why boundary orientation must be induced consistently from the manifold orientation",
-      "Green's theorem (2D Stokes) decomposes into FTC applied to each partial derivative plus Fubini to swap integration order"
+      "d^2 = 0 (the key structural property enabling de Rham cohomology) corresponds to Clairaut's theorem on equality of mixed partial derivatives; the sorry is explained: bridging Mathlib's iteratedFDeriv symmetry to concrete partial derivative expressions is non-trivial",
+      "The Poincare lemma (closed => exact on contractible domains) gives H^1_dR(R) = 0, while H^1_dR(S^1) = R shows topology matters — the angle form dθ on S^1 is closed but not exact",
+      "Orientation-reversal negates the integral — this is why boundary orientation must be induced consistently from the manifold orientation; `integral_symm` from Mathlib captures this unconditionally",
+      "Green's theorem (2D Stokes) decomposes into FTC applied to each partial derivative plus Fubini to swap integration order; the proof delegates to GreensTheoremOQ01 which has 0 sorries",
+      "The 1D de Rham cohomology H^0(R) = R (connected), H^1(R) = 0 (contractible) is fully computed in Lean; these are not just statements but theorems with machine-verified proofs from Mathlib's calculus API"
     ],
     "prerequisites": [
       "Fundamental Theorem of Calculus (Parts 1 and 2)",

--- a/src/data/proofs/gcd-algorithm-oq-02/annotations.json
+++ b/src/data/proofs/gcd-algorithm-oq-02/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-binary-gcd-overview",
+    "title": "Binary GCD: Stein's Algorithm Overview",
+    "type": "overview",
+    "startLine": 27,
+    "endLine": 30,
+    "mathContext": "The binary GCD algorithm uses three observations: (1) gcd(2a, 2b) = 2·gcd(a,b) — factor extraction; (2) gcd(2a, b) = gcd(a,b) when b is odd — coprimality drops the 2; (3) gcd(a-b, b) = gcd(a,b) — subtraction preserves GCD. Combined: if both odd, subtract to get an even difference, then halve. Termination measure: a + b, which strictly decreases at each step.",
+    "significance": "Stein's algorithm (1967) replaces Euclidean division with bit shifts (division by 2), making it faster on binary computers for multi-precision integers. GMP and other bignum libraries use this approach. The formalization proves that this hardware-optimized algorithm computes the same mathematical object as the classical Euclidean GCD.",
+    "relatedConcepts": ["Euclidean algorithm", "GCD invariants", "binary arithmetic", "bit shifts", "GMP"]
+  },
+  {
+    "id": "ann-gcd-invariant-lemmas",
+    "title": "Three Core GCD Invariants",
+    "type": "theorem",
+    "startLine": 32,
+    "endLine": 63,
+    "mathContext": "Four theorems establishing the GCD invariants that justify each step: (1) gcd_sub_right: gcd(a-b, b) = gcd(a,b) for b≤a, proved by dvd_antisymm — any common divisor of (a-b,b) divides a = (a-b)+b, and vice versa. (2) gcd_mul_two_left: gcd(2a, b) = gcd(a,b) for odd b, using Nat.Coprime.gcd_mul_left_cancel (since gcd(2, b)=1). (3) gcd_mul_two_right: symmetric version by gcd_comm. (4) gcd_two_mul: gcd(2a, 2b) = 2·gcd(a,b) directly from Nat.gcd_mul_left.",
+    "significance": "These four lemmas are the mathematical justification for the algorithm. Each case of binaryGcd is proved correct by applying exactly one of these invariants. The coprimality argument in gcd_mul_two_left is the key non-trivial step: Nat.coprime_two_left.mpr converts 'b is odd' to 'gcd(2,b)=1', then Nat.Coprime.gcd_mul_left_cancel eliminates the factor of 2.",
+    "relatedConcepts": ["Nat.dvd_antisymm", "Nat.Coprime", "Nat.coprime_two_left", "Nat.gcd_mul_left", "coprime cancellation"]
+  },
+  {
+    "id": "ann-binary-gcd-def",
+    "title": "Binary GCD Algorithm: Recursive Definition with Termination",
+    "type": "definition",
+    "startLine": 74,
+    "endLine": 96,
+    "mathContext": "binaryGcd : ℕ → ℕ → ℕ is defined by structural pattern matching with 5 cases: (0,b)→b, (a,0)→a, both even → 2·binaryGcd(a/2, b/2), one even/one odd → drop the even factor, both odd → subtract smaller from larger and halve. The termination proof uses `termination_by a + b` with `decreasing_by all_goals omega`, verified by Lean's equation compiler. In each recursive call, a + b strictly decreases: halving reduces by at least half, and the odd-subtract case produces an even number (odd - odd = even), which is then halved.",
+    "significance": "The function definition is itself a theorem: Lean's equation compiler must verify termination. The `termination_by a + b` annotation and `decreasing_by omega` tactic prove that a + b strictly decreases at each recursive step. The pattern matching structure — checking parity with % 2 — directly implements the hardware test (check last bit). This is how algorithm correctness proofs work in Lean 4: define the function, then prove its equivalence.",
+    "relatedConcepts": ["well-founded recursion", "termination_by", "decreasing_by omega", "equation compiler", "binaryGcd.induct"]
+  },
+  {
+    "id": "ann-odd-sub-half",
+    "title": "Odd Subtraction-and-Halve: Key Invariant for Odd-Odd Case",
+    "type": "theorem",
+    "startLine": 101,
+    "endLine": 113,
+    "mathContext": "gcd_odd_sub_half: for odd a, b with a > b, gcd((a-b)/2, b) = gcd(a,b). Proof: since a and b are both odd, a-b is even (odd - odd = even), so a-b = 2·((a-b)/2). Then gcd((a-b)/2, b) = gcd(2·((a-b)/2), b) [by gcd_mul_two_left with odd b, reversed] = gcd(a-b, b) [rewrite] = gcd(a,b) [by gcd_sub_right]. The symmetric gcd_odd_sub_half_right handles b ≥ a by swapping via gcd_comm.",
+    "significance": "The most subtle of the invariant lemmas. The proof uses a calc block threading together three transformations. The key arithmetic fact (odd - odd = even, captured by omega) enables the application of gcd_mul_two_left in reverse — going from gcd((a-b)/2, b) up to gcd(2·((a-b)/2), b) = gcd(a-b, b). This chain reduces the odd-odd case to the already-proved subtraction and even-odd lemmas.",
+    "relatedConcepts": ["calc blocks", "omega", "gcd_sub_right", "gcd_mul_two_left", "parity arithmetic"]
+  },
+  {
+    "id": "ann-correctness",
+    "title": "Correctness via Functional Induction: binaryGcd_eq_gcd",
+    "type": "theorem",
+    "startLine": 119,
+    "endLine": 160,
+    "mathContext": "binaryGcd_eq_gcd: ∀ a b : ℕ, binaryGcd a b = Nat.gcd a b. Proved by `induction a, b using binaryGcd.induct`, which generates 7 cases matching the 5-case definition (the odd-odd case splits into 2 by direction of comparison): case1 (b=0), case2 (a=0), case3 (both even), case4 (a even, b odd), case5 (a odd, b even), case6 (both odd, a>b), case7 (both odd, a≤b). Each case: (1) unfold binaryGcd with simp, (2) apply the inductive hypothesis ih, (3) apply the corresponding GCD invariant lemma.",
+    "significance": "The functional induction principle binaryGcd.induct is automatically generated by Lean's equation compiler from the recursive definition. This is the key advantage over ordinary structural induction: the induction principle mirrors the algorithm's case structure exactly, making the proof a one-to-one correspondence between algorithm steps and invariant applications. Each case is 3-4 lines: simp → rw [ih] → apply invariant.",
+    "relatedConcepts": ["binaryGcd.induct", "functional induction", "equation compiler", "simp reduceDIte", "GCD invariants"]
+  },
+  {
+    "id": "ann-properties",
+    "title": "Derived Properties: Commutativity and Zero Cases",
+    "type": "theorem",
+    "startLine": 164,
+    "endLine": 177,
+    "mathContext": "Three corollaries derived from binaryGcd_eq_gcd: (1) binaryGcd_comm: binaryGcd a b = binaryGcd b a, proved by rewriting both sides to Nat.gcd via binaryGcd_eq_gcd then applying Nat.gcd_comm. (2) binaryGcd_zero_left: binaryGcd 0 b = b, by simp [binaryGcd]. (3) binaryGcd_zero_right: binaryGcd a 0 = a, using cases a for the pattern matching. The final #check confirms the main theorem is accessible.",
+    "significance": "Once binaryGcd_eq_gcd is proved, all properties of Nat.gcd transfer to binaryGcd for free. The proof pattern — rewrite via correctness theorem, apply Mathlib's GCD property — is a standard transfer technique. This is the payoff of correctness proofs: the algorithm inherits the entire mathematical theory of GCD without reproving anything.",
+    "relatedConcepts": ["Nat.gcd_comm", "Nat.gcd_zero_left", "Nat.gcd_zero_right", "correctness transfer", "corollaries"]
+  }
+]

--- a/src/data/proofs/hilbert-15-oq-01/annotations.json
+++ b/src/data/proofs/hilbert-15-oq-01/annotations.json
@@ -1,1 +1,72 @@
-[]
+[
+  {
+    "id": "ann-schubert-overview",
+    "title": "Schubert Calculus on Gr(2,4): Explicit Computation Approach",
+    "type": "overview",
+    "startLine": 64,
+    "endLine": 71,
+    "mathContext": "The Chow ring A*(Gr(2,4)) is a graded Z-algebra with rank 6 over Z. Basis: σ_∅ (degree 0), σ₁ (degree 1), σ₂, σ₁₁ (degree 2), σ₂₁ (degree 3), σ₂₂ (degree 4). The four-lines computation: σ₁² = σ₂ + σ₁₁ → σ₁³ = 2σ₂₁ → σ₁⁴ = 2σ₂₂, proving that exactly 2 lines meet 4 general lines in P³. All 22 theorems proved by native_decide from the explicit LR multiplication table, 0 axioms.",
+    "significance": "This file directly answers Hilbert's 15th problem (1900) for the case Gr(2,4): Schubert's enumerative calculus is fully rigorous because the Chow ring is an explicit finitely-presented Z-algebra with decidable multiplication. The key insight — encode the ring as a struct with 6 integer fields and the LR table as a pattern-matching function — makes all enumerative geometry into verified finite computation.",
+    "relatedConcepts": ["Hilbert's 15th problem", "Grassmannian Gr(2,4)", "Littlewood-Richardson rule", "Chow ring", "intersection theory"]
+  },
+  {
+    "id": "ann-chow-ring-structure",
+    "title": "ChowGr24: The Chow Ring as a Z-Linear Structure",
+    "type": "structure",
+    "startLine": 74,
+    "endLine": 101,
+    "mathContext": "ChowGr24 is a structure with 6 integer fields (c0, c1, c2, c11, c21, c22) representing coefficients of the Schubert basis (σ_∅, σ₁, σ₂, σ₁₁, σ₂₁, σ₂₂). Derives DecidableEq and Repr, enabling decide/native_decide for all ring equations. Ring instances: Zero (all zeros), One (c0=1), Add (componentwise), Neg (componentwise), SMul Z (componentwise scalar). Grading: degrees 0+0=0, 1+1=2, 2+2=4 (the multiplication maps degree k × degree l to degree k+l, annihilating beyond degree 4).",
+    "significance": "The DecidableEq derivation is what makes native_decide work throughout the file. Every theorem of the form 'σ_λ · σ_μ = X' is proved by native_decide, which runs a compiled decision procedure. This is the fundamental trick: encode the ring concretely enough that all equations become decidable propositions. The structure encoding respects the grading implicitly through the multiplication table.",
+    "relatedConcepts": ["DecidableEq", "native_decide", "graded ring", "Z-module", "Schubert class"]
+  },
+  {
+    "id": "ann-schubert-basis",
+    "title": "Six Schubert Basis Classes and Their Geometric Meaning",
+    "type": "definition",
+    "startLine": 105,
+    "endLine": 120,
+    "mathContext": "Six definitions as ChowGr24 values: σ₀ = ⟨1,0,0,0,0,0⟩ (identity, degree 0), σ₁ = ⟨0,1,0,0,0,0⟩ (degree 1: lines meeting a fixed line), σ₂ = ⟨0,0,1,0,0,0⟩ (degree 2: lines in a fixed plane), σ₁₁ = ⟨0,0,0,1,0,0⟩ (degree 2: lines through a fixed point), σ₂₁ = ⟨0,0,0,0,1,0⟩ (degree 3: lines in a plane through a point), σ₂₂ = ⟨0,0,0,0,0,1⟩ (degree 4: the point class — a specific line). The partition index λ = (λ₁,λ₂) fits in a 2×2 box with λ₁ ≥ λ₂ ≥ 0.",
+    "significance": "Each Schubert class σ_λ corresponds geometrically to the cycle of lines satisfying a Schubert condition: meeting a flag in a specific way. σ₂₂ is the point class — its coefficient in a product gives the intersection number. The six classes σ_∅, σ₁, σ₂, σ₁₁, σ₂₁, σ₂₂ exhaust the partitions fitting in the 2×2 box (k=2, n-k=2 box for Gr(2,4)).",
+    "relatedConcepts": ["Schubert variety", "Young diagram", "2x2 box", "degree map", "flag variety"]
+  },
+  {
+    "id": "ann-multiplication-table",
+    "title": "basisMul: The Complete Littlewood-Richardson Table",
+    "type": "definition",
+    "startLine": 140,
+    "endLine": 203,
+    "mathContext": "basisMul : Fin 6 → Fin 6 → ChowGr24 encodes all 36 basis products. Key entries: (1,1)↦σ₂+σ₁₁, (1,2)↦σ₂₁, (1,3)↦σ₂₁, (1,4)↦σ₂₂, (2,2)↦σ₂₂, (3,3)↦σ₂₂, (2,3)↦0. The Mul instance extends to all elements by bilinear extension: for a = Σ aᵢσᵢ and b = Σ bⱼσⱼ, (a·b)_k = Σᵢ,ⱼ aᵢbⱼ·(basisMul i j)_k. Uses Fin 6 matrix of products with coefficients aᵢ·bⱼ summed componentwise.",
+    "significance": "The entry (2,3)↦0 (σ₂·σ₁₁ = 0) is the key nontrivial fact from Schubert calculus. The LR rule says c^{22}_{2,11} = 0 because no semistandard Young tableau with content (2,11) and shape 22 satisfies the lattice word condition. This vanishing encodes a genuine geometric fact: in P³, the Schubert varieties for σ₂ (lines in a plane) and σ₁₁ (lines through a point) in general position do not intersect in any line that also lies in a fixed plane through a fixed point.",
+    "relatedConcepts": ["Littlewood-Richardson rule", "lattice word condition", "Pieri's rule", "Young tableau", "bilinear extension"]
+  },
+  {
+    "id": "ann-four-lines-theorem",
+    "title": "Four Lines Theorem: σ₁⁴ = 2 by native_decide",
+    "type": "theorem",
+    "startLine": 210,
+    "endLine": 255,
+    "mathContext": "Seven key product theorems proved by native_decide: sigma1_sq (σ₁² = σ₂+σ₁₁), sigma1_sigma2 (σ₁·σ₂ = σ₂₁), sigma1_sigma11 (σ₁·σ₁₁ = σ₂₁), sigma1_sigma21 (σ₁·σ₂₁ = σ₂₂), sigma2_sq (σ₂² = σ₂₂), sigma11_sq (σ₁₁² = σ₂₂), sigma2_sigma11 (σ₂·σ₁₁ = 0). Main theorem sigma1_fourth: (σ₁*σ₁*σ₁*σ₁).c22 = 2. The computation: σ₁⁴ = ⟨0,0,0,0,0,2⟩. four_lines_number extracts the degree: (σ₁⁴).c22 = 2.",
+    "significance": "The four lines theorem — exactly 2 lines meet 4 general lines in P³ — is one of the oldest results in enumerative geometry, conjectured by Schubert in 1879. Here it is reduced to a computation: native_decide runs a compiled checker that verifies σ₁*σ₁*σ₁*σ₁ = ⟨0,0,0,0,0,2⟩ by evaluating the bilinear extension of basisMul. The result is kernel-verified, not just proof-checked.",
+    "relatedConcepts": ["four lines problem", "native_decide", "enumerative geometry", "intersection number", "P³ lines"]
+  },
+  {
+    "id": "ann-poincare-giambelli",
+    "title": "Poincaré Duality and Giambelli's Formula",
+    "type": "theorem",
+    "startLine": 267,
+    "endLine": 301,
+    "mathContext": "Poincaré duality: five theorems showing degree(σ_λ·σ_{λ*}) = 1 for dual pairs. The dual of λ = (λ₁,λ₂) is λ* = (2-λ₂, 2-λ₁). Pairs: (∅,22), (1,21), (2,2 self-dual!), (11,11 self-dual!). Non-dual: degree(σ₂·σ₁₁) = 0. Giambelli's formula: giambelli_11 shows -σ₂ + σ₁² = σ₁₁ (equivalently σ₁₁ = σ₁² - σ₂). General Giambelli: σ_{λ₁λ₂} = det[σ_{λ₁} σ_{λ₁+1}; σ_{λ₂-1} σ_{λ₂}]; for λ=(1,1): det[σ₁,σ₂;1,σ₁] = σ₁²-σ₂.",
+    "significance": "Self-duality of σ₂ and σ₁₁ reflects the symmetric geometry of Gr(2,4): the dual partition of (2) under the 2×2 complement is (2-0, 2-2) = (2,0) = (2) itself, and similarly for (1,1). Giambelli's formula shows that σ₁₁ is determined by σ₁ and σ₂ — the special Schubert classes generate the full ring. All proved by native_decide: these classical theorems become trivially decidable once the ring is explicit.",
+    "relatedConcepts": ["Poincaré duality", "complement partition", "Giambelli formula", "Schur polynomial", "ring generators"]
+  },
+  {
+    "id": "ann-enumerative-applications",
+    "title": "Classical Enumerative Geometry Results",
+    "type": "theorem",
+    "startLine": 311,
+    "endLine": 335,
+    "mathContext": "Three enumerative theorems: (1) one_line_through_point_meeting_two: degree(σ₁²·σ₁₁) = degree((σ₂+σ₁₁)·σ₁₁) = degree(σ₂₂) = 1 — exactly 1 line passes through a fixed point and meets 2 general lines. (2) one_line_in_plane_meeting_two: degree(σ₁²·σ₂) = 1 — exactly 1 line in a fixed plane meets 2 general lines. (3) overdetermined_three_lines_point: degree(σ₁³·σ₁₁) = 0 — meeting 3 lines and passing through a point is overdetermined. Ring properties: mul_comm_basis (commutativity on basis, by decide) and sigma0_left_identity.",
+    "significance": "These corollaries demonstrate the power of the Chow ring formalism: classical enumerative problems become arithmetic in A*(Gr(2,4)), computable by native_decide. The overdetermination result (degree 0) is geometrically meaningful: 3 linear conditions (meeting 3 lines) + 1 point condition would require a 4-dimensional solution space, but Gr(2,4) has complex dimension 4 = 2(4-2), so generically no solution exists.",
+    "relatedConcepts": ["enumerative geometry", "overdetermined system", "intersection multiplicity", "commutativity", "classical Schubert problems"]
+  }
+]

--- a/src/data/proofs/kummer-theorem-oq-02/annotations.json
+++ b/src/data/proofs/kummer-theorem-oq-02/annotations.json
@@ -1,0 +1,82 @@
+[
+  {
+    "id": "ann-qkummer-overview",
+    "title": "q-Kummer Theorem: Full Proof Architecture",
+    "type": "overview",
+    "startLine": 34,
+    "endLine": 41,
+    "mathContext": "The q-Kummer theorem states: [n choose k]_q = ∏_{d=2}^{n} Φ_d(q)^{fd(n,k,d)}, where fd(n,k,d) = ⌊n/d⌋ - ⌊k/d⌋ - ⌊(n-k)/d⌋ counts carries when adding k and (n-k) in base d. The proof chain: (1) define q-analogs in Z[X]; (2) prove the quotient formula [n choose k]_q · [k]_q! · [n-k]_q! = [n]_q!; (3) factor each q-factorial as ∏ Φ_d^(m/d); (4) exponent algebra + cancellation in Z[X].",
+    "significance": "This 412-line formalization lifts Kummer's classical theorem from integer divisibility to polynomial algebra. The q-analog encodes strictly more information: while C(n,k) mod p^k is captured by digit carries in base p, [n choose k]_q captures carries in ALL bases d ≥ 2 simultaneously as a polynomial factorization. At q=1, the cyclotomic factors Φ_p(1) = p recover classical Kummer.",
+    "relatedConcepts": ["Gaussian binomial coefficients", "cyclotomic polynomials", "Kummer's theorem", "floor deficiency", "q-analogs"]
+  },
+  {
+    "id": "ann-q-analog-defs",
+    "title": "q-Number, q-Factorial, q-Binomial Definitions in Z[X]",
+    "type": "definition",
+    "startLine": 44,
+    "endLine": 93,
+    "mathContext": "Three core definitions in Z[X]: (1) qNumber n = ∑_{i<n} X^i — the geometric sum 1 + q + q² + ... + q^(n-1), the 'quantum integer'. (2) qFactorial: recursive, qFactorial 0 = 1, qFactorial (n+1) = qFactorial n * qNumber (n+1). (3) qBinomial via q-Pascal: qBinomial n 0 = 1, qBinomial 0 (k+1) = 0, qBinomial (n+1) (k+1) = qBinomial n k + X^(k+1) * qBinomial n (k+1). The Pascal recurrence avoids polynomial division entirely. Boundary cases: qBinomial n n = 1, qNumber 1 = 1 [simp lemmas].",
+    "significance": "The Pascal-recurrence definition of qBinomial is the key design choice: it produces a polynomial directly without polynomial division. This is crucial for the proof — division in Z[X] is not always exact, so the Pascal approach keeps everything in the polynomial ring. All computations are exact in Z[X] (an integral domain), enabling the final cancellation step.",
+    "relatedConcepts": ["Z[X] integral domain", "q-Pascal recurrence", "geometric sum", "noncomputable", "polynomial ring"]
+  },
+  {
+    "id": "ann-cyclotomic-factorization-qnumber",
+    "title": "Cyclotomic Factorization of q-Numbers via Mathlib",
+    "type": "theorem",
+    "startLine": 106,
+    "endLine": 109,
+    "mathContext": "qNumber_eq_prod_cyclotomic: for n > 0, qNumber n = ∏_{d | n, d ≠ 1} Φ_d(q). Proof: one line — (prod_cyclotomic_eq_geom_sum hn ℤ).symm. This uses Mathlib's theorem that X^n - 1 = ∏_{d | n} Φ_d(X), and [n]_q = (X^n - 1)/(X - 1) = ∏_{d | n, d ≠ 1} Φ_d(X). The Finset.erase 1 removes Φ_1 = X - 1 (the denominator).",
+    "significance": "This is the Mathlib bridge theorem — the one theorem in the entire development that requires Mathlib's cyclotomic machinery. Everything else is built from scratch. The one-line proof shows how much is already in Mathlib: the factorization X^n - 1 = ∏ Φ_d is a deep result about algebraic number theory that transfers to the polynomial ring Z[X].",
+    "relatedConcepts": ["Polynomial.prod_cyclotomic_eq_geom_sum", "Nat.divisors", "Finset.erase", "cyclotomic polynomials", "X^n - 1 factorization"]
+  },
+  {
+    "id": "ann-eval-at-one",
+    "title": "Evaluation at q=1: q-Analogs Recover Classical Objects",
+    "type": "theorem",
+    "startLine": 116,
+    "endLine": 160,
+    "mathContext": "Four theorems: (1) qNumber_eval_one: [n]_q|₁ = n via simp [qNumber, eval_finset_sum]. (2) qFactorial_eval_one: [n]_q!|₁ = n! by induction with push_cast + ring. (3) qBinomial_eq_zero: [n choose k]_q = 0 for k > n, by double induction on Pascal structure. (4) qBinomial_eval_one: [n choose k]_q|₁ = C(n,k), proved by induction on Pascal matching Nat.choose_succ_succ. (5) qNumber_add_shift: [a]_q + q^a·[m]_q = [a+m]_q, by sum_range_add identity.",
+    "significance": "The evaluation theorems establish that q-analogs are genuine generalizations. The proofs of qBinomial_eval_one and qBinomial_eq_zero use the same Pascal recurrence structure as the definitions, showing definitional coherence. qNumber_add_shift is the key algebraic identity used in the quotient formula proof — it partitions the geometric sum into two consecutive ranges.",
+    "relatedConcepts": ["q-analog specialization", "sum_range_add", "Nat.choose_succ_succ", "push_cast", "q=1 evaluation"]
+  },
+  {
+    "id": "ann-quotient-formula",
+    "title": "Quotient Formula: The Hardest Induction",
+    "type": "theorem",
+    "startLine": 168,
+    "endLine": 204,
+    "mathContext": "qBinomial_factorial: for k ≤ n, qBinomial n k * qFactorial k * qFactorial (n-k) = qFactorial n. Proved by strong induction on (n, k) with case split on k < n vs k = n. The inductive step requires four preparatory facts: (1) factoring qFactorial (n-k) = qFactorial (n-k-1) * qNumber (n-k); (2-3) two IH instantiations ih1, ih2; (4) the q-number addition identity [k+1]_q + q^(k+1)·[n-k]_q = [n+1]_q from qNumber_add_shift. Final step: linear_combination applied with coefficients qNumber (k+1) * ih1 + X^(k+1) * qNumber (n-k) * ih2 + qFactorial n * add_eq.",
+    "significance": "The quotient formula is the most technically demanding theorem in the file. The linear_combination step at line 199-200 is the mathematical heart: it proves the polynomial identity by expressing the goal as a linear combination of the hypotheses with explicit polynomial coefficients. This is the q-analog of the binomial identity C(n+1,k+1) = C(n,k) + C(n,k+1), lifted to polynomial ring arithmetic.",
+    "relatedConcepts": ["linear_combination tactic", "q-Pascal identity", "strong induction", "qNumber_add_shift", "polynomial identity"]
+  },
+  {
+    "id": "ann-floor-deficiency",
+    "title": "Floor Deficiency and Cyclotomic Factorization of q-Factorials",
+    "type": "definition",
+    "startLine": 221,
+    "endLine": 295,
+    "mathContext": "floorDeficiency n k d = n/d - k/d - (n-k)/d (natural subtraction). Auxiliary div_add_div_le proves ⌊a/d⌋ + ⌊b/d⌋ ≤ ⌊(a+b)/d⌋ (subadditivity of floor division). floorDeficiency_add_eq: fd(n,k,d) + k/d + (n-k)/d = n/d (uses omega after div_add_div_le). Then qFactorial_cyclotomic: [n]_q! = ∏_{d in Icc 2 n} Φ_d^(n/d), proved by induction using succ_div_step (which handles (n+1)/d = n/d + [d | n+1]) and the filter/erase product manipulation.",
+    "significance": "floorDeficiency is the polynomial-analog of 'number of carries'. Its exponent identity fd + k/d + (n-k)/d = n/d is the key that enables cancellation in the main theorem. The cyclotomic factorization of q-factorials (qFactorial_cyclotomic) is a deep inductive construction: each step n → n+1 adds exactly the cyclotomic factors for divisors of n+1, matching the step identity succ_div_step.",
+    "relatedConcepts": ["floor division subadditivity", "carry counting", "succ_div_step", "Icc product", "Finset.prod_filter_mul_prod_filter_not"]
+  },
+  {
+    "id": "ann-qkummer-main",
+    "title": "q-Kummer Theorem: Cyclotomic Cancellation in Z[X]",
+    "type": "theorem",
+    "startLine": 326,
+    "endLine": 356,
+    "mathContext": "qKummer: for k ≤ n, qBinomial n k = ∏_{d in Icc 2 n} Φ_d^{fd(n,k,d)}. Proof steps: (1) Apply qBinomial_factorial to get qBinomial * ∏Φ_d^(k/d) * ∏Φ_d^((n-k)/d) = ∏Φ_d^(n/d) (after rewriting all qFactorials via qFactorial_cyclotomic_ext). (2) Merge the two LHS products: ∏Φ_d^(k/d) * ∏Φ_d^((n-k)/d) = ∏Φ_d^(k/d + (n-k)/d) via prod_mul_distrib + pow_add. (3) Split RHS: ∏Φ_d^(n/d) = ∏Φ_d^(k/d + (n-k)/d) * ∏Φ_d^(fd) using the exponent identity. (4) Cancel via mul_left_cancel₀ — valid because ∏Φ_d ≠ 0 (Polynomial.cyclotomic_ne_zero, prod_ne_zero).",
+    "significance": "The final cancellation step (mul_left_cancel₀) is only valid in an integral domain — Z[X] satisfies this because Z is an integral domain. This is the key structural requirement: the q-analog theorem requires Z[X] to be an integral domain to cancel the product of cyclotomic polynomials. The theorem works over any integral domain, not just Z. Polynomial.cyclotomic_ne_zero is the crucial fact that cyclotomic polynomials are nonzero.",
+    "relatedConcepts": ["mul_left_cancel₀", "integral domain", "Polynomial.cyclotomic_ne_zero", "Finset.prod_ne_zero", "exponent algebra"]
+  },
+  {
+    "id": "ann-classical-connection",
+    "title": "Connection to Classical Kummer via Φ_p(1) = p",
+    "type": "theorem",
+    "startLine": 365,
+    "endLine": 397,
+    "mathContext": "qKummer_classical_connection: the sum ∑_{j in Icc 1 n} fd(n,k,p^j) = ∑_{j in Icc 1 n} (n/p^j - k/p^j - (n-k)/p^j), which is a tautology proved by simp [floorDeficiency]. The conceptual content: at q=1, qBinomial n k evaluates to C(n,k), and Φ_p(1) = p for prime p, so the q-Kummer factorization gives v_p(C(n,k)) = ∑_j e_{p^j} = total carries across all digit positions in base p. The summary comment at lines 375-397 explains the strictness: q-Kummer is strictly more general (all d ≥ 2, full polynomial factorization, individual digit carries).",
+    "significance": "Classical Kummer groups all base-p carries together (summing over digit positions), while q-Kummer separates them (individual exponent per p^j). This separation is the polynomial information that is lost when evaluating at q=1. The theorem qKummer_classical_connection is intentionally simple — the connection is conceptual (via Φ_p(1) = p) rather than requiring a new proof, since the q-Kummer theorem already subsumes everything.",
+    "relatedConcepts": ["classical Kummer", "Φ_p(1) = p", "p-adic valuation", "carries in base p", "q=1 specialization"]
+  }
+]

--- a/src/data/proofs/motivic-flag-maps-oq-02/annotations.json
+++ b/src/data/proofs/motivic-flag-maps-oq-02/annotations.json
@@ -1,46 +1,82 @@
-{
-  "annotations": [
-    {
-      "lineStart": 66,
-      "lineEnd": 67,
-      "type": "definition",
-      "title": "q-Number [n]_L",
-      "content": "The q-analog of natural numbers: [n]_L = 1 + L + L² + ... + L^{n-1}. At L = 1, this recovers the integer n. In K₀(Var), [n]_L = [P^{n-1}] — the motivic class of projective (n-1)-space."
-    },
-    {
-      "lineStart": 86,
-      "lineEnd": 88,
-      "type": "definition",
-      "title": "q-Factorial [n]_L!",
-      "content": "The product [n]_L! = [1]_L · [2]_L · ... · [n]_L. This equals the motivic class of the complete flag variety Fl_n, connecting q-combinatorics to algebraic geometry."
-    },
-    {
-      "lineStart": 128,
-      "lineEnd": 130,
-      "type": "theorem",
-      "title": "q-Factorial = Flag Variety Class",
-      "content": "Proved: [n]_L! = [Fl_n]. This identity is the foundation for the Gaussian binomial theory of Grassmannians. Each factor [i]_L = [P^{i-1}] in the product corresponds to the i-th step in the flag variety fibration."
-    },
-    {
-      "lineStart": 152,
-      "lineEnd": 160,
-      "type": "definition",
-      "title": "Grassmannian Motivic Class (Recursive)",
-      "content": "Defined via the q-Pascal identity: [Gr(d+1, n+2)] = L^{d+1} · [Gr(d+1, n+1)] + [Gr(d, n+1)]. This mirrors Pascal's triangle for binomial coefficients, with L-weighted terms from the Schubert cell stratification."
-    },
-    {
-      "lineStart": 198,
-      "lineEnd": 203,
-      "type": "theorem",
-      "title": "[Gr(2,4)] = 1 + L + 2L² + L³ + L⁴",
-      "content": "The first non-projective Grassmannian. The coefficient 2 on L² reflects two Schubert cells of dimension 2: the Young diagrams (2,0) and (1,1) in a 2×2 box. This distinguishes Gr(2,4) from projective space."
-    },
-    {
-      "lineStart": 326,
-      "lineEnd": 332,
-      "type": "theorem",
-      "title": "GL_n = (L-1)^n · [Fl_n] · L^{T(n)}",
-      "content": "Proved: the GL_n class decomposes as (L-1)^n times the complete flag class times an affine factor. This structural identity explains why flag varieties appear naturally in the GL_n Bruhat decomposition. Each factor (L^i - 1) = (L-1)·[i]_L via the geometric series."
-    }
-  ]
-}
+[
+  {
+    "id": "ann-motivic-overview",
+    "title": "Motivic Classes of Maps to Partial Flag Varieties: Overview",
+    "type": "overview",
+    "startLine": 30,
+    "endLine": 38,
+    "mathContext": "The file extends Bryan-Elek-Manners-Salafatinos-Vakil (2025) from complete flags to partial flags. The chain: q-number [n]_L = [P^{n-1}] in K₀(Var) → q-factorial [n]_L! = [Fl_n] (complete flag) → Gaussian binomial [n choose d]_L = [Gr(d,n)] (Grassmannian) → partial flags [Fl(d₁,...,dₖ; n)] = ∏ [Gr(dᵢ₊₁-dᵢ, n-dᵢ)] → extension conjecture for based maps to partial flags.",
+    "significance": "Addresses OQ-02: does the Bryan et al. motivic class formula extend beyond complete flags to partial flag varieties? The answer: yes, the q-analog infrastructure extends, and the Gaussian binomial identity [Gr(d,n)] · [d]! · [n-d]! = [n]! serves as the bridge. The extension conjecture states the map-space class involves Levi subgroups and unipotent radicals, generalizing GL_n to block-diagonal subgroups.",
+    "relatedConcepts": ["K₀(Var)", "Grothendieck ring", "Lefschetz motive", "Bryan et al. 2025", "based maps"]
+  },
+  {
+    "id": "ann-k0var-structure",
+    "title": "K₀(Var) Infrastructure: Grothendieck Ring and Motivic Classes",
+    "type": "structure",
+    "startLine": 39,
+    "endLine": 67,
+    "mathContext": "K0Var k is a structure with carrier (a CommRing) and L : carrier (the Lefschetz motive [A¹]). Key definitions: affineClass n = L^n ([A^n] = L^n), projectiveClass n = ∑_{i≤n} L^i ([P^n] = 1+L+...+L^n), GLnClass n = (∏_{i=1}^{n}(L^i - 1)) · L^{n(n-1)/2} ([GL_n] class via Schubert cells), completeFlagClass n = ∏_{i<n} projectiveClass K i ([Fl_n] = [P^0]·[P^1]·...·[P^{n-1}]). The triangular number n(n-1)/2 counts the dimension of the unipotent radical of the Borel.",
+    "significance": "The K0Var structure is an abstraction over any commutative ring, not tied to a specific K₀(Var). This enables the duality proof strategy: work in Polynomial ℤ (an integral domain for cancellation), then transfer to any K via ring homomorphism. The GLnClass formula encodes the Schubert cell decomposition of GL_n/B: the cells are indexed by permutations with area equal to their inversion count.",
+    "relatedConcepts": ["Lefschetz motive", "Schubert cells", "Borel subgroup", "triangular numbers", "CommRing abstraction"]
+  },
+  {
+    "id": "ann-q-number-factorial",
+    "title": "q-Number [n]_L = [P^{n-1}] and q-Factorial [n]! = [Fl_n]",
+    "type": "definition",
+    "startLine": 79,
+    "endLine": 133,
+    "mathContext": "qNumber K n = ∑_{i<n} L^i (geometric sum). Key theorem: qNumber_succ_eq_projective — qNumber K (n+1) = projectiveClass K n, since both are 1+L+...+L^n. qFactorial K n = ∏_{i<n} qNumber K (i+1) = [1]_L·[2]_L·...·[n]_L. Main theorem qFactorial_eq_completeFlagClass: qFactorial K n = completeFlagClass K n = ∏_{i<n} [P^i]. In motivic K₀, [P^i] is the class of i-dimensional projective space, and the complete flag variety fibers over lower flags with projective fibers.",
+    "significance": "The identity qFactorial = completeFlagClass is the first major theorem: the q-factorial product is not just an algebraic coincidence but has geometric content — it equals the motivic class of the complete flag variety Fl_n. The proof is a one-liner (congr 1; ext; exact (qNumber_succ_eq_projective).symm), showing that the two definitions match term-by-term. This is the motivic lift of n! = |GL_n(𝔽_q)| / q^{n(n-1)/2}.",
+    "relatedConcepts": ["projective space class", "complete flag variety", "motivic lift", "geometric sum", "fibration"]
+  },
+  {
+    "id": "ann-grassmannian-class",
+    "title": "Grassmannian Motivic Class via q-Pascal Recurrence",
+    "type": "definition",
+    "startLine": 157,
+    "endLine": 227,
+    "mathContext": "grassmannianClass K d n : K.carrier defined by q-Pascal: grassmannianClass K (d+1) (n+1) = L^{d+1} · grassmannianClass K (d+1) n + grassmannianClass K d n, with boundary cases Gr(0,n)=1, Gr(d+1,0)=0, Gr(d,d)=1. This mirrors Pascal's triangle with L-weighted terms from Schubert cell stratification. Key theorems: grassmannianClass_lines (Gr(1,n+1) = [P^n]), grassmannianClass_2_4 ([Gr(2,4)] = 1+L+2L²+L³+L⁴), qNumber_split ([d]_L + L^d·[n-d]_L = [n]_L used in grassmannianClass_lines).",
+    "significance": "The coefficient 2 on L² in [Gr(2,4)] reflects the two Schubert cells of dimension 2 in the 2×2 box: the partitions (2,0) and (1,1). Each partition λ contributes L^|λ| to the Grassmannian class. The q-Pascal recurrence mirrors the Schubert cell decomposition: Gr(d+1, n+1) is the union of an A^{d+1}-bundle over Gr(d+1, n) and a copy of Gr(d, n), matching the structure constants in Schubert calculus.",
+    "relatedConcepts": ["q-Pascal identity", "Gaussian binomial coefficient", "Schubert cell stratification", "Young diagrams", "L-weighting"]
+  },
+  {
+    "id": "ann-gaussian-binomial-identity",
+    "title": "Gaussian Binomial Identity: [Gr(d,n)] · [d]! · [n-d]! = [n]!",
+    "type": "theorem",
+    "startLine": 294,
+    "endLine": 363,
+    "mathContext": "gaussian_binomial_identity: for d ≤ n, grassmannianClass K d n * qFactorial K d * qFactorial K (n-d) = qFactorial K n. Proved by induction on n with subcases on d. The inductive step applies q-Pascal to unfold Gr(d+1, n+1), produces two terms using two IH instantiations, expands qFactorial via qFactorial_succ, then combines using qNumber_split ([d+1]_L + L^{d+1}·[n-d]_L = [n+1]_L). The final combination uses ring manipulations to match qFactorial (n+1) = qFactorial n * qNumber (n+1).",
+    "significance": "The motivic lifting of C(n,d) · d! · (n-d)! = n!. Geometrically: the complete flag variety Fl_n fibers over the Grassmannian Gr(d,n) with fiber Fl_d × Fl_{n-d}. The q-analog encodes this fibration in K₀(Var). The proof requires the q-number splitting identity geom_sum_split (∑_{i<a}q^i + q^a·∑_{i<b}q^i = ∑_{i<a+b}q^i), which is proved by induction on b.",
+    "relatedConcepts": ["flag variety fibration", "induction on n", "qNumber_split", "geom_sum_split", "ring manipulations"]
+  },
+  {
+    "id": "ann-grassmannian-duality",
+    "title": "Grassmannian Duality [Gr(d,n)] = [Gr(n-d,n)] via Integral Domain",
+    "type": "theorem",
+    "startLine": 440,
+    "endLine": 466,
+    "mathContext": "grassmannianClass_duality: for d ≤ n, grassmannianClass K d n = grassmannianClass K (n-d) n. The proof lifts to Polynomial ℤ (an integral domain): (1) both Gr(d,n) and Gr(n-d,n) satisfy the Gaussian binomial identity with the same RHS [n]!. (2) Gr(d,n) · [d]!·[n-d]! = Gr(n-d,n) · [d]!·[n-d]!. (3) Cancel by mul_right_cancel₀ (valid in Polynomial ℤ since [d]!·[n-d]! ≠ 0 via qNumber_polyK₀_ne_zero). (4) Transfer to K.carrier via eval_grassmannianClass (ring homomorphism Polynomial ℤ → K.carrier evaluating X ↦ K.L).",
+    "significance": "The duality proof cannot be done in a general CommRing (no cancellation). The strategy — lift to Polynomial ℤ, cancel there, transfer back — is a template for motivic identities requiring integral domain properties. The private polyK₀ structure (Polynomial ℤ with X as L) and evalAtL ring homomorphism provide the transfer mechanism. This is the motivic analog of the combinatorial identity C(n,d) = C(n,n-d).",
+    "relatedConcepts": ["integral domain cancellation", "Polynomial ℤ", "eval₂RingHom", "ring homomorphism transfer", "symmetric Gaussian binomials"]
+  },
+  {
+    "id": "ann-partial-flag-structure",
+    "title": "Partial Flag Varieties and Their Motivic Class Factorization",
+    "type": "structure",
+    "startLine": 476,
+    "endLine": 511,
+    "mathContext": "PartialFlag n dims: a structure for chains of subspaces V_{d₁} ⊂ ... ⊂ V_{dₖ} ⊂ kⁿ with dim V_{dᵢ} = dᵢ, dim_correct, and nested ordering. partialFlagClass K n dims computes the motivic class: by iterated fibration, Fl(d₁,...,dₖ; n) → Fl(d₂,...,dₖ; n) with fiber Gr(d₁, d₂), giving [Fl(d₁,...,dₖ; n)] = ∏ᵢ [Gr(dᵢ₊₁-dᵢ, n-dᵢ)]. Special cases: partialFlag_single ([d; n] = Gr(d,n)), complete_flag_is_partial_flag (Fl(1,...,n;n) = [n]!).",
+    "significance": "The partial flag class is defined recursively via List pattern matching with `termination_by l => l.length`. The formula [Fl(d₁,...,dₖ; n)] = ∏ Gr factors mirrors the tower of fibrations: at each level, forget the innermost subspace to get a Grassmannian fiber. This is the geometric content of the motivic factorization. The complete flag is Fl(1,2,...,n-1; n), and complete_flag_is_partial_flag shows this gives [n]!.",
+    "relatedConcepts": ["flag variety fibration", "List recursion", "Grassmannian fiber", "iterated fibration", "tower of varieties"]
+  },
+  {
+    "id": "ann-extension-conjecture",
+    "title": "Levi–Unipotent Structure and Extension Conjecture for Partial Flags",
+    "type": "definition",
+    "startLine": 534,
+    "endLine": 566,
+    "mathContext": "leviClass K n dims computes ∏ᵢ [GL_{nᵢ}] where nᵢ are the block sizes (differences of consecutive dimensions). unipotentDim computes dim U = ∑_{i<j} nᵢ·nⱼ (dimension of the unipotent radical of the corresponding parabolic subgroup). The extension conjecture (partial_flag_extension, axiomatized): for based maps Ω²_β(Fl(d₁,...,dₖ; n+1)) with positive β, [Ω²_β] = [Levi] · L^{dim U + a} for some a depending on β. This extends Bryan et al.'s GL_n × A^a formula (complete flags) to Levi subgroups (partial flags).",
+    "significance": "The extension conjecture is the open part of this file (marked as axiom). For complete flags, the Levi is GL_n and dim U = 0 (Borel = parabolic for complete flags), recovering Bryan et al. For a Grassmannian Fl(d; n+1) = Gr(d, n+1), the Levi is GL_d × GL_{n+1-d} and dim U = d(n+1-d). The conjecture says the space of maps [S², Gr(d,n+1)]_β has motivic class [GL_d × GL_{n+1-d} × A^{a''}], geometrically counting maps by Levi × affine structure.",
+    "relatedConcepts": ["Levi subgroup", "parabolic subgroup", "unipotent radical", "based maps", "Bryan et al. extension"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for fundamental-theorem-calculus-oq-02 (Generalized Stokes Theorem).

## Changes

**annotations.json (created):**
8 annotations covering all 8 structural parts of the Lean proof:
1. **Overview** (lines 4-43): Context annotation explaining the unification of FTC, Green's, Stokes, and Gauss as one identity ∫_M dω = ∫_{∂M} ω
2. **1D Forms** (lines 59-70): extDeriv1D, intForm1D, bdryEval definitions connecting to Stokes statement
3. **Stokes 1D = FTC** (lines 76-110): Three FTC variants, Mathlib API connection, orientation-reversal
4. **Poincaré Lemma** (lines 125-148): poincare_1d and exact_unique, H¹(ℝ)=0 via FTC Part 1 + MVT
5. **2D Forms** (lines 172-189): OneForm2D, gradient d₀, curl d₁ as concrete Lean definitions
6. **d²=0 (sorry)** (lines 195-213): Clairaut's theorem, why the sorry exists (iteratedFDeriv bridge gap)
7. **Green's theorem = 2D Stokes** (lines 241-276): stokes_2d_rectangle, delegation to GreensTheoremOQ01
8. **De Rham Cohomology** (lines 341-364): H⁰(ℝ)=ℝ (connected), H¹(ℝ)=0 (contractible), contrast with S¹

**meta.json:**
- Added 6th keyInsight: H⁰(ℝ)=ℝ and H¹(ℝ)=0 fully proved in Lean, connecting to the d²=0 structure

## Proof integrity
- `axiomCount: 0` is correct — no axioms
- `sorries: 1` correctly reflects dd_eq_zero_2D (Clairaut's theorem, needs iteratedFDeriv bridge)
- Annotation for d²=0 explains why the sorry exists: mathematically honest documentation