### PR TITLE
Fix: sync sorries count 7→5 for erdos-1018-oq-04-incomplete-01

### DIFF
--- a/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
@@ -18,7 +18,7 @@
       "erdos"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 5,
     "axiomCount": 5,
     "lineCount": 246,
     "assumptions": "5 axioms total: 1 own (kostochka_pyber_r2 — the r=2 graph case of Kostochka-Pyber theorem, proven 1988) + 4 inherited from Erdos1018OQ04.lean (vanKampen_Flores — non-embeddability of r-skeleton of (2r+2)-simplex; triangle_planar — K₃ is planar; K4_planar — K₄ is planar; density_exceeds_turan — density bound for non-planar subgraphs). 5 sorries in this file (geometric edge-crossing verifications: lines 86, 108, 130, 169, 220).",


### PR DESCRIPTION
## Fix

Corrects the `sorries` field in meta.json from 7 to 5.

## Evidence

**Before**: `"sorries": 7` in meta.json
**After**: `"sorries": 5` in meta.json

The Lean file `Proofs/Erdos1018OQ04Incomplete01.lean` has exactly 5 proof sorry tactics at lines 86, 108, 130, 169, and 220. The `assumptions` field within the same meta.json already stated "5 sorries in this file (geometric edge-crossing verifications: lines 86, 108, 130, 169, 220)" — making the numeric field inconsistent with the text description.

Build validated: `pnpm build` passes cleanly.

---
Automated fix by lean-mechanic agent.