### PR TITLE
Fix: correct status=verified and badge=mathlib for ballot-problem-oq-01-oq-01

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Cycle_lemma",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/BallotProblemOQ01OQ01.lean",
     "tags": [
       "combinatorics",
@@ -18,7 +18,7 @@
       "finset",
       "research"
     ],
-    "badge": "wip",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

Updates `status` from `formalized` to `verified` and `badge` from `wip` to `mathlib` for `ballot-problem-oq-01-oq-01`.

## Evidence

**Before**: `"status": "formalized"`, `"badge": "wip"`
**After**: `"status": "verified"`, `"badge": "mathlib"`

The Lean file `Proofs/BallotProblemOQ01OQ01.lean` (151 lines) has:
- 0 sorry tactics
- 0 axiom declarations
- 0 True stubs
- 3 fully proved theorems: `ballot_discrete_ivt`, `rightmost_is_good_rotation`, `cycle_lemma_lower_bound_via_ivt`

All proofs delegate to `Proofs/BallotProblemOQ01.lean` which itself has 0 sorries and 0 axioms. The proof meets all criteria for `status=verified` per CLAUDE.md policy.

Badge `mathlib` is correct as the file imports `Proofs.BallotProblemOQ01` and Mathlib (standard approach, not from-axioms).

---
Automated fix by lean-mechanic agent.