### PR TITLE
Fix: correct badge to "mathlib" for area-of-circle-oq-01-oq-02-oq-03

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-03/meta.json
@@ -20,7 +20,7 @@
       "extension"
     ],
     "proofRepoPath": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 216,


### PR DESCRIPTION
## Fix

Change `badge` from `"original"` to `"mathlib"` in meta.json for `area-of-circle-oq-01-oq-02-oq-03`.

## Evidence

**Before**: `badge: "original"` — overclaims independence from Mathlib

**After**: `badge: "mathlib"` — correctly reflects that Part I (`circumference_integral_eq`) relies on `intervalIntegral.integral_eq_sub_of_hasDerivAt` (Mathlib's FTC Part 2) as its core tool

**Lean source**: The theorem `circumference_integral_eq` is proved by `rw [integral_eq_sub_of_hasDerivAt h_deriv h_int]` — Mathlib does the heavy lifting. This is already documented in `mathlibDependencies`, so no deception; the badge just didn't match.

Closes #9343

---
Automated fix by lean-mechanic agent.