### PR TITLE
Enrich 7 proofs: cramers-rule, divisibility, erdos-1084, erdos-110, erdos-1178, fourier-series, furstenberg-correspondence (51 annotations)

### DIFF
--- a/src/data/proofs/erdos-10-oq-01/annotations.json
+++ b/src/data/proofs/erdos-10-oq-01/annotations.json
@@ -1,1 +1,86 @@
-[]
+[
+  {
+    "id": "ann-header-erdos10oq01",
+    "proofId": "erdos-10-oq-01",
+    "range": { "startLine": 1, "endLine": 35 },
+    "type": "context",
+    "title": "Erdős Problem #10 OQ-01: The Sufficiently Large Variant",
+    "content": "The module header frames Erdős Problem #10 OQ-01 as a weaker version of the full problem: instead of asking whether some fixed k works for ALL integers, OQ-01 asks whether some k works for all SUFFICIENTLY LARGE integers (i.e., all n ≥ N for some threshold N). This distinction matters because density arguments can in principle resolve the 'large' variant while being unable to rule out finitely many exceptions. The file is organized to prove the full logical hierarchy: which results imply OQ-01, which are provably weaker (Gallagher), and which imply ¬OQ-01 (Erdős-Graham). Crocker (1971), Gallagher (1975), and Granville-Soundararajan (1998) are the three key external results.",
+    "mathContext": "OQ-01: $\\exists k, N \\in \\mathbb{N},\\ \\forall n \\geq N,\\ n \\in S_k$ where $S_k = \\{n : n = p + \\sum_{i=1}^j 2^{a_i},\\ p \\text{ prime},\\ j \\leq k\\}$. The full Erdős #10: $\\exists k,\\ \\forall n \\geq 2,\\ n \\in S_k$. The file proves: Erdős10 $\\Rightarrow$ OQ-01 $\\Leftarrow$ G-S; Gallagher $\\not\\Rightarrow$ OQ-01; E-G $\\Rightarrow$ $\\neg$OQ-01.",
+    "significance": "context",
+    "relatedConcepts": ["Waring-Goldbach problem", "additive number theory", "prime representation", "density of integer sets", "covering congruences"],
+    "prerequisites": ["prime numbers", "additive combinatorics", "set density", "Goldbach-type conjectures"]
+  },
+  {
+    "id": "ann-core-defs",
+    "proofId": "erdos-10-oq-01",
+    "range": { "startLine": 48, "endLine": 77 },
+    "type": "definition",
+    "title": "IsPrimePlusKPowers, RepSet, OQ01, and Erdos10Main",
+    "content": "The definition `IsPrimePlusKPowers k n` encodes representability using a Multiset of exponents, allowing repeated exponents (e.g., 2^3 + 2^3 = 16 counts as 2 powers). This is more general than requiring distinct exponents. The `RepSet k` is the set of all representable integers for a given k, and `OQ01` is the existential quantification over k and a threshold N. The definition `Erdos10Main` is the universal version (no threshold N), and `main_implies_oq01` proves that the stronger assertion logically implies OQ-01 by instantiating the threshold at N=2.",
+    "mathContext": "$S_k = \\{n \\in \\mathbb{N} : \\exists p \\text{ prime},\\ \\exists a_1, \\ldots, a_j \\text{ (multiset)},\\ j \\leq k,\\ n = p + \\sum_i 2^{a_i}\\}$. Note: Multiset allows $a_i = a_j$ for $i \\neq j$, so $p + 2^a + 2^a = p + 2^{a+1}$ and $p + 2^3 + 2^3$ are both in $S_2$. The parent problem (Erdős10Main) is $S_k \\supseteq \\{n \\geq 2\\}$; OQ-01 is $S_k \\supseteq \\{n \\geq N\\}$ for some finite $N$.",
+    "significance": "key",
+    "relatedConcepts": ["Multiset in Lean 4", "prime numbers", "binary representation", "Goldbach conjecture", "Waring's problem"],
+    "prerequisites": ["Lean 4 Multiset", "Nat.Prime", "existential types in Lean"]
+  },
+  {
+    "id": "ann-monotonicity",
+    "proofId": "erdos-10-oq-01",
+    "range": { "startLine": 79, "endLine": 107 },
+    "type": "technique",
+    "title": "Monotonicity of RepSet and the Characterization RepSet 0 = Primes",
+    "content": "The monotonicity lemmas establish that `RepSet k ⊆ RepSet (k+1)` — adding more powers of 2 only expands the representable set. The proof is trivial: a Multiset witnessing k-representability also witnesses (k+1)-representability via `Nat.le_succ_of_le`. The characterization `repSet_zero_eq_primes` shows that with zero powers, a number must equal its prime part exactly — using `Multiset.card_eq_zero` and `Multiset.sum_zero`. This verifies that the Multiset-based definition correctly captures the k=0 edge case. The monotonicity of OQ-01 (`oq01_mono`) allows promoting any k-witness to a k'-witness for k' ≥ k.",
+    "mathContext": "$S_0 = \\{p : p \\text{ prime}\\}$ since $n = p + 0 = p$ with zero powers. $S_0 \\subseteq S_1 \\subseteq S_2 \\subseteq \\cdots$ is monotone increasing. Combined with the existential structure of OQ-01, once $k$ works (with threshold $N$), any $k' \\geq k$ also works (with the same threshold $N$).",
+    "significance": "supporting",
+    "relatedConcepts": ["Multiset.card", "monotone set families", "prime numbers as base case", "Lean 4 Finset monotonicity"],
+    "prerequisites": ["Multiset.card_eq_zero", "Nat.le_succ_of_le", "set extension lemmas"]
+  },
+  {
+    "id": "ann-crocker",
+    "proofId": "erdos-10-oq-01",
+    "range": { "startLine": 109, "endLine": 132 },
+    "type": "insight",
+    "title": "Crocker's Theorem: Infinitely Many Odd Integers Resist k=2",
+    "content": "Crocker's 1971 theorem is axiomatized: the set of odd integers not representable as a prime plus ≤2 powers of 2 is infinite. The proof of Crocker's original result used covering congruences — choosing a finite set of congruence conditions that collectively prevent any prime p from satisfying n − p = 2^a + 2^b. The key formal consequence `k_two_not_sufficient_large` extracts from the infiniteness of this set (via `Set.Infinite.exists_gt`) that for any threshold N, there exists n ≥ N not in RepSet 2. This directly shows k=2 fails OQ-01. The Crocker axiom represents a deep 1971 result that remains formally unproved in Mathlib.",
+    "mathContext": "Crocker's argument: for odd $n$, if $n = p + 2^a + 2^b$ then $p = n - 2^a - 2^b$ must be prime. Choosing $n$ from a suitable arithmetic progression forces $n - 2^a - 2^b$ to always be divisible by 3, 5, 7, or 11 for all choices of $a, b \\geq 0$. This uses that $2^a \\pmod{3}$ cycles with period 2 and $2^a \\pmod{5}$ cycles with period 4, so covering congruences can be chosen to ensure composite values. Infinitely many such odd $n$ exist.",
+    "significance": "key",
+    "relatedConcepts": ["covering congruences", "Sierpiński numbers", "odd integers and primes", "Set.Infinite.exists_gt", "Romanov's theorem"],
+    "prerequisites": ["covering congruences", "arithmetic progressions", "Nat.Prime", "Set.Infinite"]
+  },
+  {
+    "id": "ann-granville-soundararajan",
+    "proofId": "erdos-10-oq-01",
+    "range": { "startLine": 134, "endLine": 162 },
+    "type": "insight",
+    "title": "Granville-Soundararajan: k=4 Would Resolve OQ-01",
+    "content": "The Granville-Soundararajan conjecture is split by parity: k=3 is conjectured to suffice for odd integers ≥ 3, and k=4 for even integers ≥ 2. The asymmetry reflects that even n requires an extra adjustment. The combined theorem `granville_soundararajan_implies_oq01` proves OQ-01 with k=4 and N=3 by case-splitting on parity via `Nat.even_or_odd`, applying the even conjecture directly, and using `repSet_mono_le` to lift the odd (k=3) result to k=4. This is a clean example of how a conditional result about the conjecture can formally certify a specific value of k.",
+    "mathContext": "G-S Odd: $\\forall n \\geq 3$ odd, $n \\in S_3$. G-S Even: $\\forall n \\geq 2$ even, $n \\in S_4$. Since $S_3 \\subseteq S_4$, both parity cases land in $S_4$. Hence $\\{n \\geq 3\\} \\subseteq S_4$, giving OQ-01 with $k=4, N=3$. Granville-Soundararajan proved this in 1998 conditioned on the multiplicative order of 2 mod $p^2$ being large for most primes $p$ — related to the non-existence of Wieferich primes.",
+    "significance": "key",
+    "relatedConcepts": ["Granville-Soundararajan 1998", "Wieferich primes", "multiplicative order mod p²", "parity in additive number theory", "Romanov's density theorem"],
+    "prerequisites": ["Nat.even_or_odd", "repSet_mono_le", "existential instantiation"]
+  },
+  {
+    "id": "ann-gallagher-gap",
+    "proofId": "erdos-10-oq-01",
+    "range": { "startLine": 164, "endLine": 283 },
+    "type": "technique",
+    "title": "Gallagher's Density Gap: A Density-1 Set That Misses Infinitely Many Large Integers",
+    "content": "The theorem `gallagher_does_not_imply_oq01_in_principle` is the most computationally intensive result in the file. It constructs the set of non-perfect-squares as a witness: this set has density approaching 1 (since there are only ⌈√N⌉ squares up to N), yet it misses every perfect square n = m². The density bound is proved quantitatively using the threshold N₀ = ⌈4/ε²⌉ + 1. The proof shows that for N ≥ N₀, the count of non-squares is ≥ (1−ε)N. The key estimate Nat.sqrt(N) + 1 ≤ ε·N requires showing ε·√N > 2 from (ε·√N)² = ε²·N > 4, using `Real.nat_sqrt_le_real_sqrt`, `Real.mul_self_sqrt`, and `nlinarith` for the nonlinear arithmetic steps.",
+    "mathContext": "Let $S = \\mathbb{N} \\setminus \\{m^2 : m \\in \\mathbb{N}\\}$. Then $\\underline{d}(S) = 1$ since $\\#\\{m^2 \\leq N\\} = \\lfloor \\sqrt{N} \\rfloor + 1 = O(\\sqrt{N}) = o(N)$. For $N \\geq \\lceil 4/\\varepsilon^2 \\rceil + 1$: $\\varepsilon^2 N > 4$, so $\\varepsilon \\sqrt{N} > 2$ (since $(\\varepsilon \\sqrt{N})^2 = \\varepsilon^2 N > 4$), hence $\\varepsilon N = \\varepsilon \\sqrt{N} \\cdot \\sqrt{N} > 2\\sqrt{N} \\geq 2 \\lfloor \\sqrt{N} \\rfloor \\geq \\lfloor \\sqrt{N} \\rfloor + 1$. Yet $S$ misses $(N+1)^2$ for every $N$.",
+    "significance": "key",
+    "relatedConcepts": ["asymptotic density", "perfect squares", "Real.sqrt", "Nat.sqrt", "nlinarith", "Finset.filter_card_add_filter_neg_card_eq_card"],
+    "prerequisites": ["real square roots", "Finset.filter", "Nat.ceil", "density of sets of naturals"]
+  },
+  {
+    "id": "ann-erdos-graham-hierarchy",
+    "proofId": "erdos-10-oq-01",
+    "range": { "startLine": 285, "endLine": 316 },
+    "type": "insight",
+    "title": "Erdős-Graham Conjecture and the Complete Logical Hierarchy",
+    "content": "The Erdős-Graham conjecture — that for every fixed k, infinitely many large integers lie outside RepSet k — is the primary reason OQ-01 is believed to be false. Its formal consequence `oq01_false_from_conjecture` is a one-line proof: given any k and threshold N claimed by OQ-01, the conjecture produces n ≥ N not in RepSet k, giving a contradiction. The closing `#check` commands serve as a gallery of the hierarchy: `main_implies_oq01` (↘), `oq01_false_from_conjecture` (¬ from E-G), `granville_soundararajan_implies_oq01` (↗ conditional), and `k_two_not_sufficient_large` (Crocker lower bound). Together they form a complete formal picture of current mathematical knowledge about Erdős #10.",
+    "mathContext": "Erdős-Graham: $\\forall k \\in \\mathbb{N},\\ \\forall N \\in \\mathbb{N},\\ \\exists n \\geq N,\\ n \\notin S_k$. The formal hierarchy: Erdős10Main $\\Rightarrow$ OQ-01 (proved); G-S $\\Rightarrow$ OQ-01 (proved, conditional); Gallagher $\\not\\Rightarrow$ OQ-01 (proved by non-square counterexample); E-G $\\Rightarrow$ $\\neg$OQ-01 (proved, conditional); Crocker $\\Rightarrow$ $k=2$ fails OQ-01 (proved, with axiom).",
+    "significance": "key",
+    "relatedConcepts": ["Erdős-Graham conjecture", "logical hierarchy", "additive bases", "Romanov's theorem", "Fibonacci covering congruences"],
+    "prerequisites": ["classical logic", "Lean 4 intro/obtain patterns", "existential negation"]
+  }
+]

--- a/src/data/proofs/erdos-1084-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1084-oq-01/annotations.json
@@ -1,1 +1,86 @@
-[]
+[
+  {
+    "id": "ann-header-1084oq01",
+    "proofId": "erdos-1084-oq-01",
+    "range": { "startLine": 1, "endLine": 38 },
+    "type": "context",
+    "title": "Erdős #1084 OQ-01: The f₃(n) = 6n − Θ(n^{2/3}) Conjecture",
+    "content": "The module header frames the Erdős conjecture on unit-distance pairs among separated points in 3D. The key claim is that the maximum f₃(n) deviates from the kissing-number leading term 6n by exactly Θ(n^{2/3}). This is non-trivial in both directions: the upper bound Bezdek-Reid (2013) and the lower bound (FCC cluster construction) each require geometric arguments. The file reduces the axiom count from 9 to 4 by proving the handshaking lemma, formalizing the kissing number as a concrete definition, and proving the 1D case f₁(n) = n−1 fully. References span from Erdős (1946, 1975) through Harborth (1974), Schütte-van der Waerden (1953), and Bezdek-Reid (2013).",
+    "mathContext": "$f_d(n) = \\max\\{\\text{unitPairs}(C) : C \\text{ is a separated }n\\text{-point config in }\\mathbb{R}^d\\}$. The conjecture: $f_3(n) = 6n - \\Theta(n^{2/3})$. Equivalently: $\\exists c_1, c_2 > 0,\\ \\forall n \\geq n_0$: $6n - c_1 n^{2/3} \\leq f_3(n) \\leq 6n - c_2 n^{2/3}$.",
+    "significance": "context",
+    "relatedConcepts": ["unit-distance graphs", "sphere packing", "FCC lattice", "kissing number", "Kepler conjecture", "isoperimetric inequality"],
+    "prerequisites": ["discrete geometry", "Euclidean distance", "combinatorial geometry", "asymptotic notation"]
+  },
+  {
+    "id": "ann-core-defs-1084",
+    "proofId": "erdos-1084-oq-01",
+    "range": { "startLine": 39, "endLine": 59 },
+    "type": "definition",
+    "title": "SepConfig, unitPairs, unitDegree: The Geometric Data Types",
+    "content": "The `SepConfig d n` structure encodes the problem: n points in EuclideanSpace ℝ (Fin d) with all pairwise distances ≥ 1. The minimum distance constraint ensures no two spheres of radius 1/2 centered at the points overlap — making the configuration a sphere packing. The `unitPairs` counts ordered pairs {i < j} with dist = 1 as a `Finset.filter` over Fin n × Fin n, and `unitDegree` counts the unit-distance neighbors of a single point. The filter-based approach allows Lean to apply Finset combinatorics (handshaking, injection arguments) without analysis.",
+    "mathContext": "$C = (p_1, \\ldots, p_n) \\in (\\mathbb{R}^d)^n$ with $\\|p_i - p_j\\| \\geq 1$ for $i \\neq j$. $\\text{unitPairs}(C) = |\\{(i,j): i < j,\\ \\|p_i - p_j\\| = 1\\}|$. $\\text{deg}(i) = |\\{j \\neq i : \\|p_i - p_j\\| = 1\\}|$. Handshaking: $2 \\cdot \\text{unitPairs} = \\sum_i \\text{deg}(i)$.",
+    "significance": "key",
+    "relatedConcepts": ["EuclideanSpace in Lean 4", "Finset.filter", "sphere packing", "unit-distance graph", "Fintype.card"],
+    "prerequisites": ["Lean 4 structures", "EuclideanSpace", "Finset combinatorics", "dist notation"]
+  },
+  {
+    "id": "ann-1d-theory",
+    "proofId": "erdos-1084-oq-01",
+    "range": { "startLine": 61, "endLine": 264 },
+    "type": "technique",
+    "title": "Complete 1D Theory: f₁(n) = n−1 via Left-Endpoint Injection",
+    "content": "The 1D case is fully machine-verified. `f1_upper` proves unitPairs1D ≤ n−1 by constructing an injection from unit pairs to non-maximal points: each unit pair {i < j} maps to its left endpoint (minimum-valued). This endpoint cannot be the global maximum, so the injection lands in Fin n minus the maximum — n−1 points. The 4-case split in the injectivity proof handles all orientation combinations. `f1_achieve` shows n−1 is attained by the consecutive integer configuration {0,1,...,n−1}. The triangle lemma proves two unit neighbors of x in 1D are at distance 2 (not 1) from each other, confirming separation.",
+    "mathContext": "In $\\mathbb{R}$: $|x - y| = 1 \\Rightarrow y = x \\pm 1$. Two unit neighbors of $x$ are $x-1$ and $x+1$, at distance 2 from each other. So $\\deg(x) \\leq 2$ and $2 \\cdot f_1(n) \\leq 2n$, giving $f_1(n) \\leq n$. The tight bound $f_1(n) = n-1$ comes from the left-endpoint injection: each of the $n-1$ unit pairs $\\{k, k+1\\}$ maps injectively to non-maximal point $k$.",
+    "significance": "key",
+    "relatedConcepts": ["injection into Fin", "Finset.card_image_of_injOn", "1D packing", "left-endpoint injection", "Finset.card_erase_of_mem"],
+    "prerequisites": ["abs_eq", "Fin.lt_def", "Finset.InjOn", "absolute value inequalities"]
+  },
+  {
+    "id": "ann-kissing-handshaking",
+    "proofId": "erdos-1084-oq-01",
+    "range": { "startLine": 265, "endLine": 391 },
+    "type": "technique",
+    "title": "Kissing Numbers, Handshaking, and the Upper Bounds f₂(n) ≤ 3n, f₃(n) ≤ 6n",
+    "content": "The kissing number τ(d) is formalized as a concrete definition: τ(1)=2, τ(2)=6, τ(3)=12. The value τ(3)=12 was the Newton-Gregory problem, settled by Schütte-van der Waerden (1953). The handshaking bound is proved: 2·unitPairs = Σᵢ deg(i). Combined with the axiom deg(i) ≤ τ(d), the double-count gives 2·pairs ≤ τ(d)·n. For d=2: f₂(n) ≤ 3n. For d=3: f₃(n) ≤ 6n. The FCC lower bound axiom states f₃(n) ≥ 6n − c·n^{2/3} via explicit cluster constructions where interior FCC points each have 12 contacts but boundary points lose O(1) contacts, and there are Θ(n^{2/3}) boundary points.",
+    "mathContext": "$\\tau(3) = 12$ (Schütte-van der Waerden 1953). $\\text{deg}(i) \\leq \\tau(d)$ (degree ≤ kissing axiom). Double-counting: $2 \\cdot \\text{unitPairs} = \\sum_i \\text{deg}(i) \\leq \\tau(d) \\cdot n$, giving $f_3(n) \\leq 6n$. FCC interior: each sphere contacts 12 others in $A_3$ lattice. Boundary: $\\Theta(n^{2/3})$ points have degree $< 12$, contributing deficit $\\Theta(n^{2/3})$.",
+    "significance": "key",
+    "relatedConcepts": ["kissing number", "Schütte-van der Waerden 1953", "handshaking lemma", "double-counting", "FCC lattice", "sphere packing"],
+    "prerequisites": ["Finset.sum_comm", "degree in graphs", "Finset.card_filter", "Newton-Gregory problem"]
+  },
+  {
+    "id": "ann-central-conjecture",
+    "proofId": "erdos-1084-oq-01",
+    "range": { "startLine": 392, "endLine": 425 },
+    "type": "insight",
+    "title": "erdos_1084_oq01: The Θ Sandwich from FCC and Bezdek-Reid",
+    "content": "The central theorem `erdos_1084_oq01` formalizes the Erdős conjecture as a consequence of two axioms: the FCC cluster lower bound (f₃(n) ≥ 6n − c₁·n^{2/3}) and the Bezdek-Reid upper bound (f₃(n) < 6n − 0.926·n^{2/3}). Together these sandwich f₃(n) between two expressions of the form 6n − Θ(n^{2/3}). The proof is deductively trivial, but the formalization demonstrates that once both parts are axiomatized, the Θ result is a formal logical consequence. The constant 0.926 is the sharp bound from Bezdek-Reid (2013) via the isoperimetric method for finite sphere packings.",
+    "mathContext": "$6n - c_1 n^{2/3} \\leq f_3(n) < 6n - 0.926 n^{2/3}$. The lower bound requires: a ball of $n$ FCC lattice points (face-centered cubic, also denoted $A_3$) has boundary of size $\\Theta(n^{2/3})$. Bezdek-Reid's method: use the isoperimetric inequality for sphere cluster surfaces to bound the total surface area, then relate to boundary contact loss.",
+    "significance": "key",
+    "relatedConcepts": ["Bezdek-Reid 2013", "FCC lattice", "isoperimetric method", "discrete sphere surface area", "Theta notation"],
+    "prerequisites": ["asymptotic bounds", "Lean 4 axioms", "FCC contact structure", "discrete ball surface"]
+  },
+  {
+    "id": "ann-isoperimetric-exponent",
+    "proofId": "erdos-1084-oq-01",
+    "range": { "startLine": 426, "endLine": 487 },
+    "type": "insight",
+    "title": "Isoperimetric Exponent (d−1)/d: The Universal Pattern for f_d(n)",
+    "content": "The isoperimetric exponent section formalizes the pattern: in dimension d, the correction term below the kissing-number bound τ(d)·n/2 scales as n^{(d-1)/d}. For d=2, (d-1)/d = 1/2 matches Harborth's √n correction. For d=3, (d-1)/d = 2/3 matches Bezdek-Reid. The proofs establish: α(2) = 1/2, α(3) = 2/3 (arithmetic), 0 < α(d) < 1 for d ≥ 2, and α is strictly increasing in d. This pattern reflects the isoperimetric principle: a ball of volume n in ℝ^d has surface area Θ(n^{(d-1)/d}), and boundary spheres in the optimal cluster have fewer contacts than interior ones.",
+    "mathContext": "$\\alpha(d) = (d-1)/d$: $\\alpha(2) = 1/2$, $\\alpha(3) = 2/3$, $\\alpha(d) \\nearrow 1$. Isoperimetric: discrete ball $B_r \\cap L$ in lattice $L$ of density $\\rho$ has $|B_r| \\approx \\rho \\omega_d r^d = n$ and surface $|\\partial B_r| \\approx \\rho' \\omega_{d-1} r^{d-1} = O(n^{(d-1)/d})$. Each boundary sphere misses $O(1)$ contacts, giving total deficit $O(n^{(d-1)/d})$ from the leading term $\\tau(d) n / 2$.",
+    "significance": "key",
+    "relatedConcepts": ["isoperimetric inequality", "surface-to-volume ratio", "discrete balls in lattices", "FCC lattice surface", "Harborth formula scaling"],
+    "prerequisites": ["real division", "Nat.cast arithmetic", "isoperimetric inequality", "ball volume in ℝ^d"]
+  },
+  {
+    "id": "ann-2d-harborth",
+    "proofId": "erdos-1084-oq-01",
+    "range": { "startLine": 488, "endLine": 607 },
+    "type": "technique",
+    "title": "Harborth's 2D Formula and Verification of the n^{1/2} Exponent",
+    "content": "Harborth's 1974 exact formula f₂(n) = ⌊3n − √(12n−3)⌋ is axiomatized. The Lean formalization verifies the exponent scaling: √(12n−3) ≤ √(12n) = 2√3·√n, confirming the correction term is O(n^{1/2}) = O(n^{α(2)}). This validates the isoperimetric exponent framework for d=2: the exact 2D formula's correction ∼ 2√3·n^{1/2} matches the prediction. The bound uses `Real.sqrt` monotonicity. Together with the isoperimetric exponent section, this makes the d=2 instance concrete: the hexagonal (triangular lattice) arrangement achieves 3n − Θ(√n) unit pairs, matching α(2) = 1/2.",
+    "mathContext": "Harborth: $f_2(n) = \\lfloor 3n - \\sqrt{12n - 3} \\rfloor$. Correction: $\\sqrt{12n - 3} \\leq \\sqrt{12n} = 2\\sqrt{3} \\cdot n^{1/2} \\approx 3.46 \\cdot n^{1/2}$. Matches $\\alpha(2) = 1/2$. Leading term: $\\tau(2)/2 = 3$ from kissing number $\\tau(2) = 6$. For $d=3$: $\\tau(3)/2 = 6$ and $\\alpha(3) = 2/3$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Harborth 1974", "Real.sqrt monotonicity", "floor function", "triangular lattice packing", "hexagonal arrangement"],
+    "prerequisites": ["Real.sqrt", "Nat.floor", "Real.sqrt_le_sqrt", "square root identities"]
+  }
+]


### PR DESCRIPTION
## Summary

- **cramers-rule-oq-01-oq-04**: 8 annotations — Newton-Girard power sum identities, Cayley-Hamilton, Faddeev-LeVerrier algorithm
- **divisibility-by-3-oq-04-oq-02**: 7 annotations — position independence, unique multiple lemma, detection rate theorem, ZMod perspective, nines vs threes
- **erdos-1084-oq-01**: 7 annotations — unit-distance configurations, kissing number, FCC/Bezdek-Reid conjecture, exponent monotonicity
- **erdos-110-oq-03**: 7 annotations — generalized EHS conjecture at cardinal κ, Lambie-Hanson ℵ₁ case, limit cardinal open cases
- **erdos-1178**: 6 annotations — Brown-Erdős-Sós conjecture, exr/dr threshold functions, Sárközy-Selkow upper bound
- **fourier-series-oq-01**: 8 annotations — Carleson maximal operator, Carleson-Hunt weak-type (2,2) inequality, divergence set measure bound (Chebyshev + Carleson-Hunt), a.e. convergence via countable null union
- **furstenberg-correspondence**: 7 annotations — upper Banach density, measure-preserving System structure, Poincaré recurrence from Mathlib, Furstenberg correspondence axiom, Szemerédi k=2 via Poincaré, multiple recurrence axiom k≥3

🤖 Generated by enricher-2