### PR TITLE
Fix: erdos-1012-oq-03 lineCount 991→1019, update sorry description

### DIFF
--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -15,8 +15,8 @@
     "badge": "wip",
     "sorries": 2,
     "axiomCount": 0,
-    "lineCount": 991,
-    "assumptions": "0 axioms. 2 sorries: (1) ghouila_houri (full proof needs longest-path argument ~200 lines), (2) directed_hamiltonian_threshold (arc-count threshold result — single top-level sorry). Moon-Moser theorem (sc_tournament_has_cycle + tournament_cycle_extendable + grow_cycle_to_hamiltonian) is now fully proved. Rédei fully proved by induction.",
+    "lineCount": 1019,
+    "assumptions": "0 axioms. 2 sorries: (1) ghouila_houri (full proof needs longest-path argument ~200 lines), (2) hamiltonian_of_few_missing_arcs (counting/probabilistic argument: if ≤n-2 arcs are missing from K*_n, a Hamiltonian cycle exists). directed_hamiltonian_threshold is now proved by reducing to hamiltonian_of_few_missing_arcs via missing_arcs_le. Moon-Moser theorem and Rédei are fully proved.",
     "dateAdded": "2026-03-30"
   },
   "overview": {


### PR DESCRIPTION
## Fix

PR #9341 proved `directed_hamiltonian_threshold` by decomposing it into two sub-lemmas, which grew the Lean file from 991 to 1019 lines. The meta.json was not updated.

## Evidence

**Before**:
- `meta.lineCount: 991` (incorrect — file is 1019 lines after #9341)
- `assumptions` text: "directed_hamiltonian_threshold (arc-count threshold result — single top-level sorry)" (incorrect — this is now proved)

**After**:
- `meta.lineCount: 1019` ✓
- `assumptions` text updated: sorry #2 is now `hamiltonian_of_few_missing_arcs` (counting/probabilistic argument — the private lemma that `directed_hamiltonian_threshold` delegates to)

Sorry count remains 2:
1. `ghouila_houri` (line 302) — unchanged
2. `hamiltonian_of_few_missing_arcs` (line 979) — new location of the arc-threshold sorry

---
Automated fix by lean-mechanic agent.