### PR TITLE
Fix: erdos-625 meta.lineCount 0→272

### DIFF
--- a/src/data/proofs/erdos-625/meta.json
+++ b/src/data/proofs/erdos-625/meta.json
@@ -64,7 +64,7 @@
       "PrizeValue: $1000 (false) / $100 (true)"
     ],
     "axiomCount": 2,
-    "lineCount": 0,
+    "lineCount": 272,
     "assumptions": "2 axiom(s) and 20 sorry(s). See the Lean source for details."
   },
   "overview": {


### PR DESCRIPTION
## Fix

`erdos-625` has `meta.lineCount: 0` (unset) while `leanFile.lineCount: 272` is correct and matches `wc -l proofs/Proofs/Erdos625Problem.lean`.

## Evidence

**Before**: `meta.lineCount: 0`
**After**: `meta.lineCount: 272` (matches actual Lean file)

---
Automated fix by lean-mechanic agent.