### PR TITLE
Enrich platonic-solids-oq-02: 6 annotations for Archimedean solid classification

### DIFF
--- a/src/data/proofs/platonic-solids-oq-02/annotations.json
+++ b/src/data/proofs/platonic-solids-oq-02/annotations.json
@@ -1,1 +1,73 @@
-[]
+[
+  {
+    "id": "ann-archimedes-header",
+    "proofId": "platonic-solids-oq-02",
+    "range": { "startLine": 1, "endLine": 27 },
+    "type": "context",
+    "title": "The 13 Archimedean Solids: Vertex-Transitivity Beyond Platonic Symmetry",
+    "content": "Archimedean solids are convex polyhedra where: (a) all faces are regular polygons (possibly mixed types), (b) the same arrangement of faces meets at every vertex (vertex-transitive), (c) they are not Platonic solids, prisms, or antiprisms. There are exactly 13. First systematically catalogued by Archimedes (now lost), rediscovered by Kepler (1619), formally classified by Grünbaum (1967). The formalization verifies the angle defect constraint for all 13, establishes their V, E, F counts with Euler formula, and states the full classification as an axiom (geometric realizability and completeness require constructions beyond what is formalized). Zero sorries, one axiom.",
+    "mathContext": "The **angle defect** condition: at each vertex of a convex polyhedron, the sum of face angles must be $< 2\\pi$ (otherwise the vertex 'lies flat' or creates a concavity). For a vertex type $(n_1, n_2, \\ldots, n_k)$: $\\sum_{i=1}^k \\frac{(n_i-2)\\pi}{n_i} < 2\\pi$, i.e., $\\sum (n_i-2)/n_i < 2$. By Descartes' theorem, the sum of all angle defects over all vertices of a convex polyhedron equals $4\\pi$ — this is equivalent to the Euler characteristic $V-E+F=2$.",
+    "significance": "context",
+    "relatedConcepts": ["Archimedean solids", "vertex-transitive polyhedra", "angle defect condition", "Kepler 1619", "Grünbaum 1967 classification"],
+    "prerequisites": ["Platonic solids classification", "vertex-transitive polyhedra", "Euler characteristic V-E+F=2"]
+  },
+  {
+    "id": "ann-archimedes-angle-defect",
+    "proofId": "platonic-solids-oq-02",
+    "range": { "startLine": 28, "endLine": 52 },
+    "type": "technique",
+    "title": "Angle Defect Computation: Integer Arithmetic via LCM Scaling",
+    "content": "`faceLcm faces` computes the LCM of all face sizes, providing a common denominator. `angleNumerator faces` computes the total interior angle sum in units of π·(1/faceLcm): for each face of size n, the interior angle contributes (n-2)/n = (n-2)·(L/n)/L, so the sum is `Σ (n-2)*(L/n)`. The angle defect is positive iff `angleNumerator < 2*faceLcm` (sum of angles < 2π = 2·(π·1)). This integer formulation eliminates real arithmetic entirely: all comparisons reduce to natural number inequalities, enabling `native_decide` to verify all 13 cases without floating-point.",
+    "mathContext": "For vertex type $(n_1,\\ldots,n_k)$ with $L = \\text{lcm}(n_1,\\ldots,n_k)$: each angle contributes $\\frac{(n_i-2)\\pi}{n_i} = \\frac{(n_i-2)(L/n_i)}{L}\\pi$. The angle sum is $\\frac{\\text{angleNumerator}}{L}\\pi$. The constraint is $\\frac{\\text{angleNumerator}}{L} < 2$, i.e., $\\text{angleNumerator} < 2L$. For $(3,6,6)$: $L = 6$, numerator $= 1\\cdot2 + 4\\cdot1 + 4\\cdot1 = 10$, and $10 < 12 = 2\\cdot6$ ✓. For $(4,6,10)$: $L = 60$, numerator $= 2\\cdot15 + 4\\cdot10 + 8\\cdot6 = 30+40+48 = 118 < 120$ ✓.",
+    "significance": "key",
+    "relatedConcepts": ["faceLcm definition", "angleNumerator definition", "hasPositiveDefect", "native_decide for arithmetic", "angle defect formula"],
+    "prerequisites": ["List.foldl in Lean 4", "Nat.lcm in Mathlib", "native_decide tactic"]
+  },
+  {
+    "id": "ann-archimedes-thirteen",
+    "proofId": "platonic-solids-oq-02",
+    "range": { "startLine": 57, "endLine": 115 },
+    "type": "concept",
+    "title": "The 13 Vertex Types: From Soccer Ball to Snub Dodecahedron",
+    "content": "The 13 vertex types are encoded as `List ℕ` definitions (face sizes in order around each vertex). They fall into natural families: truncations of Platonic solids (truncatedTetrahedron [3,6,6], truncatedCube [3,8,8], truncatedOctahedron [4,6,6], truncatedDodecahedron [3,10,10], truncatedIcosahedron [5,6,6]), rectifications (cuboctahedron [3,4,3,4], icosidodecahedron [3,5,3,5]), cantellations (rhombicuboctahedron [3,4,4,4], rhombicosidodecahedron [3,4,5,4]), omnitruncations (truncatedCuboctahedron [4,6,8], truncatedIcosidodecahedron [4,6,10]), and snubs (snubCube [3,3,3,3,4], snubDodecahedron [3,3,3,3,5]). All 13 pass `hasPositiveDefect` via `native_decide`.",
+    "mathContext": "The **snub solids** (snub cube and snub dodecahedron) are special: they cannot be obtained by truncation or rectification, and they come in left-handed and right-handed forms (enantiomorphs). Their vertex type [3,3,3,3,4] and [3,3,3,3,5] have four triangles + one square/pentagon at each vertex. The **truncated icosahedron** [5,6,6] is the soccer ball: 12 pentagons + 20 hexagons. `all_archimedean_valid` proves all 13 pass the angle defect test by `List.Forall` + individual `native_decide` calls.",
+    "significance": "key",
+    "relatedConcepts": ["truncated solids", "snub solids", "rectification", "cantellation", "truncatedIcosahedron = soccer ball"],
+    "prerequisites": ["Platonic solid operations (truncation, etc.)", "List.Forall in Lean 4", "native_decide"]
+  },
+  {
+    "id": "ann-archimedes-euler",
+    "proofId": "platonic-solids-oq-02",
+    "range": { "startLine": 120, "endLine": 165 },
+    "type": "concept",
+    "title": "ArchimedeanData: V, E, F Counts with Euler Formula Verification",
+    "content": "`ArchimedeanData` stores the name, vertex type, and (V, E, F) with a field `euler : vertices - edges + faces = 2` proved by `omega`. The 13 specific instances range from the truncated tetrahedron (12V, 18E, 8F) to the truncated icosidodecahedron (120V, 180E, 62F). Notable: the snub cube (24V, 60E, 38F) and snub dodecahedron (60V, 150E, 92F) have many more edges than faces — due to the four-triangle vertex type requiring many adjacencies. The `omega` tactic trivially verifies V-E+F=2 from the numerics.",
+    "significance": "supporting",
+    "relatedConcepts": ["ArchimedeanData structure", "Euler formula V-E+F=2", "omega tactic", "snub cube V-E-F counts", "vertex-edge-face tradeoffs"],
+    "prerequisites": ["Euler's polyhedron formula", "omega tactic in Lean 4"]
+  },
+  {
+    "id": "ann-archimedes-extremes",
+    "proofId": "platonic-solids-oq-02",
+    "range": { "startLine": 170, "endLine": 210 },
+    "type": "insight",
+    "title": "Extreme Cases: Tightest and Loosest Angle Defects",
+    "content": "Two extreme cases are formalized. `snubDodecahedron_tight`: the snub dodecahedron [3,3,3,3,5] has the smallest angle defect — angleNumerator = 29, faceLcm = 15, so the angle sum is 29π/15 = 1.9333...π, just under 2π. This makes it the 'flattest' Archimedean solid. `truncatedTetrahedron_largest_defect`: the truncated tetrahedron [3,6,6] has the largest defect — 2·faceLcm - angleNumerator = 2. These are computed exactly by `native_decide` and verified as theorems, providing concrete witnesses for the range of the angle defect across the 13 solids.",
+    "mathContext": "The snub dodecahedron angle sum: vertex type $[3,3,3,3,5]$. Each triangle contributes $\\pi/3$, the pentagon contributes $3\\pi/5$. Total: $4(\\pi/3) + 3\\pi/5 = (20+9)\\pi/15 = 29\\pi/15 \\approx 1.9333\\pi$. Angle defect: $2\\pi - 29\\pi/15 = \\pi/15 \\approx 12°$. This near-flatness explains why the snub dodecahedron closely approximates a sphere — the angle defect at each vertex is small, meaning the total curvature is concentrated in many small defects across 60 vertices. Contrast with the tetrahedron's angle defect of $\\pi$ (180°) per vertex.",
+    "significance": "key",
+    "relatedConcepts": ["snubDodecahedron_tight", "truncatedTetrahedron_largest_defect", "angle defect ≈ curvature", "near-spherical Archimedean solids"],
+    "prerequisites": ["angleNumerator and faceLcm definitions", "native_decide computation", "Descartes' theorem on angle defects"]
+  },
+  {
+    "id": "ann-archimedes-classification",
+    "proofId": "platonic-solids-oq-02",
+    "range": { "startLine": 170, "endLine": 231 },
+    "type": "insight",
+    "title": "Classification Theorem: Axiom for Completeness, Soccer Ball Corollary",
+    "content": "The `archimedean_classification` axiom states the completeness direction: any convex vertex-transitive polyhedron with regular faces that is not Platonic/prism/antiprism must be one of the 13. This is axiomatized (not proved) because the formal proof requires geometric realizability arguments — showing that each vertex type actually closes into a valid polyhedron — and completeness arguments — showing no other vertex type works geometrically. The computational verification (`hasPositiveDefect` for all 13) gives the necessary condition; the axiom adds sufficiency. Corollaries: `soccerBall_is_archimedean` (the soccer ball is Archimedean), `archimedean_not_platonic` (none of the 13 are Platonic).",
+    "mathContext": "The completeness proof (for humans): the angle defect constraint $\\sum (n_i-2)/n_i < 2$ limits the possible vertex types. With $k$ faces meeting at a vertex (each $\\geq 3$-gon), we get $k < 6$ (since each triangle contributes $\\geq 1/3$ to the angle ratio). For $k=3$: the constraint gives $(p-2)(q-2)(r-2) > 8$ — equivalent to the 3D Platonic solid constraint, yielding only 5 families. For $k=4,5$: finite enumeration gives the remaining Archimedean types. Geometric realizability (that a valid vertex type actually closes into a polyhedron) is proved by explicit construction via truncation, cantellation, or snubification.",
+    "significance": "key",
+    "relatedConcepts": ["archimedean_classification axiom", "soccerBall_is_archimedean", "archimedean_not_platonic", "geometric realizability", "Kepler's classification"],
+    "prerequisites": ["hasPositiveDefect verification", "vertex-transitive polyhedra definition", "geometric realizability vs combinatorial validity"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `platonic-solids-oq-02` (Classification of Archimedean Solids).

## Annotations added (6)

1. **Header context** (lines 1-27): Vertex-transitivity definition; Kepler/Grünbaum history; angle defect as key constraint; one axiom for completeness
2. **Angle defect computation** (lines 28-52): LCM-scaled integer arithmetic eliminating real numbers; angleNumerator < 2*faceLcm formula; concrete examples for (3,6,6) and (4,6,10)
3. **The 13 vertex types** (lines 57-115): Classification by family (truncations, rectifications, cantellations, snubs); snubs as enantiomorphic; soccer ball identification
4. **ArchimedeanData + Euler** (lines 120-165): V-E+F=2 structure; omega verification; snub cube/dodecahedron edge-heavy nature
5. **Extreme angle defects** (lines 170-210): Snub dodecahedron tightest (29π/15); truncated tetrahedron largest; near-spherical interpretation
6. **Classification theorem** (lines 170-231): Axiom for completeness (geometric realizability not formalized); soccer ball corollary; none of 13 are Platonic

## Math coverage

- Angle defect condition as exact integer arithmetic (no floating-point)
- All 13 Archimedean solids verified by native_decide
- Snub dodecahedron angle sum = 29π/15 (closest to 2π)
- Descartes' theorem connecting angle defects to Euler characteristic
- Soccer ball = truncated icosahedron [5,6,6] ∈ archimedeanTypes