### PR TITLE
Enrich schroeder-bernstein-oq-02: 6 annotations for Knaster-Tarski proof

### DIFF
--- a/src/data/proofs/schroeder-bernstein-oq-02/annotations.json
+++ b/src/data/proofs/schroeder-bernstein-oq-02/annotations.json
@@ -1,1 +1,73 @@
-[]
+[
+  {
+    "id": "ann-kt-header",
+    "proofId": "schroeder-bernstein-oq-02",
+    "range": { "startLine": 1, "endLine": 39 },
+    "type": "context",
+    "title": "Knaster-Tarski vs. Orbit Decomposition: Three Proofs of Schroeder-Bernstein",
+    "content": "The Schroeder-Bernstein theorem has three distinct formalization approaches in this gallery: (1) the parent proof via `Function.Embedding.schroeder_bernstein` (Mathlib's orbit decomposition), (2) this file's Knaster-Tarski fixed-point approach, and (3) the finite case via Fintype (OQ-04). The Knaster-Tarski proof is conceptually cleaner: define T(S) = (range g)ᶜ ∪ g(f(S)) as a monotone operator on the complete lattice Set α, take S* = lfp(T) (Knaster-Tarski least fixed point), and define the bijection piecewise: h(a) = f(a) if a ∈ S*, h(a) = g⁻¹(a) if a ∉ S*. The fixed point equation S* = T(S*) directly provides the properties needed for bijectivity. Zero sorries, zero axioms.",
+    "mathContext": "The **Knaster-Tarski fixed point theorem** (1955): on a complete lattice $(L, \\leq)$, every monotone function $f : L \\to L$ has a least fixed point $\\text{lfp}(f) = \\bigcap\\{x : f(x) \\leq x\\}$. In Mathlib: `OrderHom.lfp` applied to a monotone function on `Set α` (which is a complete lattice under $\\subseteq$). The three Schroeder-Bernstein proofs correspond to the three classical proofs: Cantor-Schroeder-Bernstein (orbit decomposition), Knaster-Tarski (lattice fixed point), and König's proof (matching in bipartite graphs).",
+    "significance": "context",
+    "relatedConcepts": ["Knaster-Tarski theorem", "Schroeder-Bernstein theorem", "complete lattices", "OrderHom.lfp in Mathlib", "orbit decomposition proof"],
+    "prerequisites": ["injective functions", "complete lattices in Lean 4", "Knaster-Tarski fixed point theorem"]
+  },
+  {
+    "id": "ann-kt-operator",
+    "proofId": "schroeder-bernstein-oq-02",
+    "range": { "startLine": 40, "endLine": 77 },
+    "type": "technique",
+    "title": "The CBS Operator: T(S) = (range g)ᶜ ∪ g(f(S)) and Its Fixed Point",
+    "content": "`cbsOp f g S = (Set.range g)ᶜ ∪ g '' (f '' S)` defines the Cantor-Bernstein-Schroeder operator. Monotonicity (`cbsOp_mono`) follows from `Set.image_subset` applied twice: S ⊆ S' → f(S) ⊆ f(S') → g(f(S)) ⊆ g(f(S')) → T(S) ⊆ T(S'). The `cbsHom` wraps this as an `OrderHom` (monotone function). `fixedSet f g = (cbsHom f g).lfp` applies the Knaster-Tarski least fixed point. `fixedSet_eq` extracts the fixed point equation T(S*) = S*, proved as `(cbsHom f g).map_lfp`.",
+    "mathContext": "The CBS operator $T(S) = (\\text{range}\\,g)^c \\cup g(f(S))$ has the interpretation: $a \\in T(S)$ iff either $a$ has no $g$-preimage (so it must use $f$), or the unique $g$-preimage of $a$ is in $f(S)$ (so $a$ 'inherited' from $S$ via $g\\circ f$). The least fixed point $S^* = \\text{lfp}(T)$ is the smallest set satisfying $S^* = T(S^*)$, which by Knaster-Tarski equals $\\bigcap\\{S : T(S) \\subseteq S\\} = \\bigcap\\{S : (\\text{range}\\,g)^c \\cup g(f(S)) \\subseteq S\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["cbsOp definition", "cbsHom OrderHom", "fixedSet via lfp", "fixedSet_eq", "OrderHom.lfp in Mathlib"],
+    "prerequisites": ["Set.image_subset monotonicity", "OrderHom in Mathlib", "Set lattice in Lean 4"]
+  },
+  {
+    "id": "ann-kt-properties",
+    "proofId": "schroeder-bernstein-oq-02",
+    "range": { "startLine": 79, "endLine": 120 },
+    "type": "theorem",
+    "title": "Three Properties of S* from the Fixed Point Equation",
+    "content": "The fixed point equation T(S*) = S* directly yields three key properties. (1) `compl_range_sub`: (range g)ᶜ ⊆ S* — elements with no g-preimage are in S*, proved by showing they're in T(S*) then rewriting via fixedSet_eq. (2) `not_fixedSet_mem_range`: if a ∉ S*, then a ∈ range g — by contrapositive from (1). (3) `gf_image_sub`: g(f(S*)) ⊆ S* — the right branch of T(S*) = S*. The helper `gb_mem_implies` (injectivity of g required) shows if g(b) ∈ S* then b ∈ f(S*) — by case analysis on T(S*) membership, using injectivity to extract the g-preimage.",
+    "mathContext": "The three properties extracted from $T(S^*) = (\\text{range}\\,g)^c \\cup g(f(S^*))$: (1) the left summand $\\subseteq S^*$; (2) its complement: $a \\notin S^* \\Rightarrow a \\in \\text{range}\\,g$; (3) the right summand $\\subseteq S^*$. Property (3) says $S^*$ is 'closed under $g\\circ f$'. These three properties are exactly what is needed to prove bijectivity of the piecewise map: (2) ensures $g^{-1}$ is defined outside $S^*$, (3) ensures the mixed cases in injectivity lead to contradictions, and (1)+(2) together give the partition.",
+    "significance": "key",
+    "relatedConcepts": ["compl_range_sub", "not_fixedSet_mem_range", "gf_image_sub", "gf_mem", "gb_mem_implies", "gb_not_fixedSet"],
+    "prerequisites": ["fixedSet_eq (T(S*)=S*)", "Set.mem_range", "Function.Injective for g"]
+  },
+  {
+    "id": "ann-kt-bijection",
+    "proofId": "schroeder-bernstein-oq-02",
+    "range": { "startLine": 122, "endLine": 145 },
+    "type": "concept",
+    "title": "The Piecewise Bijection: f on S*, g⁻¹ on S*ᶜ",
+    "content": "`ktBij f g a = if h : a ∈ fixedSet f g then f a else (not_fixedSet_mem_range f g h).choose` defines the bijection. For a ∉ S*, `not_fixedSet_mem_range` provides a proof `a ∈ range g`, from which `.choose` extracts the g-preimage. `ktBij_of_mem` gives h(a) = f(a) for a ∈ S* (via `dif_pos`). `ktBij_of_not_mem_spec` gives g(h(a)) = a for a ∉ S* (the g-inverse specification, via `dif_neg` and `.choose_spec`). The `Classical` and `noncomputable` pragmas are needed since `.choose` uses classical choice.",
+    "mathContext": "The bijection $h : \\alpha \\to \\beta$ is: $h(a) = f(a)$ if $a \\in S^*$, and $h(a) = g^{-1}(a)$ if $a \\notin S^*$. The second branch requires knowing $a \\in \\text{range}\\,g$ (guaranteed by `not_fixedSet_mem_range`) to form $g^{-1}(a)$. In Lean 4, this is encoded via `Classical.choice`: `.choose` extracts the witness from the existential $a \\in \\text{range}\\,g$, and `.choose_spec` gives $g(\\text{choose}) = a$. The `dif_pos`/`dif_neg` lemmas handle the `if h : P then ... else ...` pattern.",
+    "significance": "key",
+    "relatedConcepts": ["ktBij definition", "Classical.choice in Lean 4", "dif_pos/dif_neg", "ktBij_of_mem", "ktBij_of_not_mem_spec"],
+    "prerequisites": ["Classical.choice in Lean 4", "Exists.choose and Exists.choose_spec", "noncomputable in Lean 4"]
+  },
+  {
+    "id": "ann-kt-injectivity",
+    "proofId": "schroeder-bernstein-oq-02",
+    "range": { "startLine": 147, "endLine": 172 },
+    "type": "theorem",
+    "title": "Injectivity: Four-Case Analysis with Mixed Cases Giving Contradictions",
+    "content": "The injectivity proof `ktBij_injective` uses `by_cases h₁ : a₁ ∈ fixedSet f g` and `by_cases h₂ : a₂ ∈ fixedSet f g`, giving four cases. The easy cases: (1) both in S* — h(a₁) = f(a₁) = f(a₂) = h(a₂), injectivity of f gives a₁=a₂. (4) both outside S* — g(h(a₁)) = a₁ and g(h(a₂)) = a₂, with h(a₁) = h(a₂) giving g(a₁) = g(a₂), then a₁=a₂. The subtle cases: (2) a₁ ∈ S*, a₂ ∉ S* — h(a₁) = h(a₂) implies g(h(a₁)) = a₂, but g(f(a₁)) ∈ S* (by gf_mem), so a₂ ∈ S* — contradiction. Case (3) is symmetric.",
+    "mathContext": "Case (2) in detail: $h(a_1) = h(a_2)$ with $a_1 \\in S^*, a_2 \\notin S^*$. Then $h(a_1) = f(a_1)$ (left branch) and $g(h(a_2)) = a_2$ (right branch spec). So $g(f(a_1)) = g(h(a_1)) = g(h(a_2)) = a_2$. But $g(f(a_1)) \\in S^*$ by `gf_mem` (closure of $S^*$ under $g\\circ f$). Therefore $a_2 = g(f(a_1)) \\in S^*$, contradicting $a_2 \\notin S^*$. This is the clever use of the fixed-point property: $S^*$ is 'too closed' for the mixed case to be consistent.",
+    "significance": "key",
+    "relatedConcepts": ["ktBij_injective", "gf_mem for mixed case contradiction", "four-case analysis", "by_cases tactic"],
+    "prerequisites": ["ktBij_of_mem", "ktBij_of_not_mem_spec", "gf_mem (S* closed under g∘f)"]
+  },
+  {
+    "id": "ann-kt-surjectivity",
+    "proofId": "schroeder-bernstein-oq-02",
+    "range": { "startLine": 174, "endLine": 207 },
+    "type": "theorem",
+    "title": "Surjectivity and the Full Knaster-Tarski Schroeder-Bernstein Theorem",
+    "content": "Surjectivity `ktBij_surjective` proceeds by cases on `b ∈ f '' fixedSet f g`. If b = f(a) for a ∈ S*: then h(a) = f(a) = b, done. If b ∉ f(S*): then g(b) ∉ S* (by `gb_not_fixedSet`) and h(g(b)) = g⁻¹(g(b)) = b by injectivity of g. The `knasterTarski_equiv` function packages the bijection as an `Equiv` using `Equiv.ofBijective`. The `fixedSet_characterization` theorem restates T(S*) = S* as an explicit set equation for inspection — the 'explicit and inspectable' fixed point mentioned in the file header.",
+    "significance": "supporting",
+    "relatedConcepts": ["ktBij_surjective", "gb_not_fixedSet", "knasterTarski_equiv", "Equiv.ofBijective", "fixedSet_characterization"],
+    "prerequisites": ["gb_not_fixedSet theorem", "Equiv.ofBijective in Mathlib", "ktBij_of_not_mem_spec"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `schroeder-bernstein-oq-02` (Knaster-Tarski Proof of Schroeder-Bernstein).

## Annotations added (6)

1. **Header context** (lines 1-39): Three proofs in the gallery (orbit decomposition, Knaster-Tarski, Fintype); Knaster-Tarski theorem history; comparison of approaches
2. **CBS operator + fixed point** (lines 40-77): T(S) = (range g)ᶜ ∪ g(f(S)); monotonicity via Set.image_subset; OrderHom.lfp as the fixed-point mechanism; fixedSet_eq
3. **Properties of S*** (lines 79-120): Three key properties from T(S*)=S*; compl_range_sub, not_fixedSet_mem_range, gf_image_sub; gb_mem_implies (requires g injectivity)
4. **Bijection construction** (lines 122-145): Piecewise f on S* and g⁻¹ on S*ᶜ; Classical.choice for g-preimage; dif_pos/dif_neg pattern; ktBij_of_not_mem_spec
5. **Injectivity** (lines 147-172): Four-case analysis; mixed cases give contradictions via gf_mem (S* closed under g∘f); the elegant use of the fixed-point property
6. **Surjectivity + main theorem** (lines 174-207): Two-case analysis; gb_not_fixedSet for the b∉f(S*) case; knasterTarski_equiv via Equiv.ofBijective

## Math coverage

- Knaster-Tarski theorem on complete lattice Set α
- CBS operator T as monotone function and OrderHom
- Fixed point S* explicitly characterized as least fixed point of T
- Injectivity via contradiction in mixed cases using gf_mem closure property
- Three equivalent proofs of Schroeder-Bernstein in the gallery