### PR TITLE
Enrich solution-of-cubic-oq-03-oq-02: 6 annotations for casus irreducibilis

### DIFF
--- a/src/data/proofs/solution-of-cubic-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-02/annotations.json
@@ -1,88 +1,74 @@
-{
-  "annotations": [
-    {
-      "id": "ann-ci-definitions",
-      "proofId": "solution-of-cubic-oq-03-oq-02",
-      "range": { "startLine": 43, "endLine": 57 },
-      "type": "definition",
-      "title": "Depressed Cubic, Discriminant, and Cardano's D",
-      "content": "Four definitions capture the algebraic setup. `depressedCubic p q x` is x³+px+q, the standard reduced form of any cubic after eliminating the x² term. `discriminant p q` is Δ = −4p³ − 27q², the sign of which determines root structure: Δ > 0 gives three distinct real roots, Δ = 0 gives repeated roots, Δ < 0 gives one real and two complex conjugate roots. `cardanoD p q` is D = q²/4 + p³/27, the quantity appearing under the square root in Cardano's formula — related to the discriminant by D = −Δ/108. `isCasusIrreducibilis` simply asserts Δ > 0.",
-      "mathContext": "$\\Delta = -4p^3 - 27q^2,\\quad D = \\frac{q^2}{4} + \\frac{p^3}{27} = -\\frac{\\Delta}{108}$",
-      "significance": "context",
-      "relatedConcepts": ["depressed cubic", "discriminant", "Cardano's formula", "polynomial root structure"],
-      "prerequisites": ["algebra: polynomial equations", "complex numbers"]
-    },
-    {
-      "id": "ann-ci-d-neg",
-      "proofId": "solution-of-cubic-oq-03-oq-02",
-      "range": { "startLine": 63, "endLine": 74 },
-      "type": "insight",
-      "title": "Δ > 0 Forces D < 0: The Algebraic Key to Casus Irreducibilis",
-      "content": "The core algebraic fact: when the cubic has three distinct real roots (Δ > 0), Cardano's intermediate quantity D = q²/4 + p³/27 is necessarily negative. This is the reason the formula involves √D, which is purely imaginary. The Lean proof closes with a single `nlinarith` call — the arithmetic follows from Δ = −108D, so Δ > 0 directly gives D < 0. The companion theorem `p_neg_of_casus` shows p < 0 is also forced: since Δ = −4p³ − 27q² > 0 and −27q² ≤ 0, we need −4p³ > 0, hence p < 0.",
-      "mathContext": "$\\Delta > 0 \\Rightarrow D = -\\frac{\\Delta}{108} < 0 \\Rightarrow \\sqrt{D} \\in i\\mathbb{R}_{>0}$",
-      "significance": "key",
-      "relatedConcepts": ["discriminant", "Cardano's formula", "complex square roots"],
-      "prerequisites": ["algebra: polynomial discriminants", "nlinarith tactic"]
-    },
-    {
-      "id": "ann-ci-cardano-args",
-      "proofId": "solution-of-cubic-oq-03-oq-02",
-      "range": { "startLine": 80, "endLine": 87 },
-      "type": "definition",
-      "title": "Cardano's Complex Arguments",
-      "content": "When D < 0, Cardano's formula uses z₁ = −q/2 + √D and its conjugate z₂ = −q/2 − √D as cube root arguments. These are defined in ℂ with √D = i·√(−D), making both non-real. The definition uses `Complex.I * Real.sqrt(-cardanoD p q)` — note that `Real.sqrt` applies to the positive quantity −D (since D < 0), and Complex.I is the imaginary unit. The root formula is then x = ∛z₁ + ∛z₂.",
-      "mathContext": "$z_{1,2} = -\\frac{q}{2} \\pm \\sqrt{D} = -\\frac{q}{2} \\pm i\\sqrt{-D} \\in \\mathbb{C} \\setminus \\mathbb{R}$",
-      "significance": "context",
-      "relatedConcepts": ["Cardano's formula", "complex cube roots", "conjugate pairs"],
-      "prerequisites": ["complex numbers", "square roots of negative numbers"]
-    },
-    {
-      "id": "ann-ci-nonreal-proof",
-      "proofId": "solution-of-cubic-oq-03-oq-02",
-      "range": { "startLine": 89, "endLine": 105 },
-      "type": "insight",
-      "title": "Cardano's Arguments Are Non-Real: The Heart of Casus Irreducibilis",
-      "content": "The main theorem of Part I: in the casus irreducibilis, the imaginary part of cardanoArg is nonzero. The proof extracts the imaginary part using `simp` with Complex lemmas, reducing to showing `Real.sqrt(-cardanoD p q) ≠ 0`. This follows from `Real.sqrt_pos`: a real square root is positive iff its argument is positive, and −D > 0 because D < 0 (from cardanoD_neg_of_casus). The conjugate cardanoArgConj is handled identically by symmetry. This establishes that Cardano's formula is genuinely complex in the casus irreducibilis.",
-      "mathContext": "$(z_1).\\text{im} = \\sqrt{-D} > 0 \\neq 0$, so $z_1 \\notin \\mathbb{R}$",
-      "significance": "key",
-      "relatedConcepts": ["imaginary part", "complex cube roots", "Real.sqrt_pos"],
-      "prerequisites": ["complex numbers: real and imaginary parts", "Mathlib: Complex.I_im"]
-    },
-    {
-      "id": "ann-ci-trig-roots",
-      "proofId": "solution-of-cubic-oq-03-oq-02",
-      "range": { "startLine": 111, "endLine": 125 },
-      "type": "technique",
-      "title": "Viète's Trigonometric Form: Real Roots Without Complex Numbers",
-      "content": "The trigonometric (Viète's) substitution x = 2√(−p/3)·cos((θ+2πk)/3) gives three explicitly real roots, bypassing complex numbers entirely. With r = √(−p/3) (real since p < 0) and θ = arccos(−q/(2r³)), the three roots correspond to k = 0, 1, 2. The proof that these are real is trivial (they're explicitly ℝ values). The deeper result — that they satisfy x³+px+q = 0 — uses the triple angle identity 4cos³φ − 3cosφ = cos(3φ), stated but axiomatized in this formalization.",
-      "mathContext": "$x_k = 2\\sqrt{-p/3} \\cos\\!\\left(\\frac{\\theta + 2\\pi k}{3}\\right),\\quad \\theta = \\arccos\\!\\left(\\frac{-q}{2(-p/3)^{3/2}}\\right),\\quad k = 0, 1, 2$",
-      "significance": "key",
-      "relatedConcepts": ["Viète's substitution", "triple angle identity", "arccos", "trigonometric form of cube roots"],
-      "prerequisites": ["trigonometry: cosine, arccos", "triple angle identity", "real analysis"]
-    },
-    {
-      "id": "ann-ci-axioms-gap",
-      "proofId": "solution-of-cubic-oq-03-oq-02",
-      "range": { "startLine": 127, "endLine": 147 },
-      "type": "context",
-      "title": "Three Axiomatized Results: Distinctness, Root Verification, and Wantzel's Theorem",
-      "content": "Three results are described in docstring comments but not yet formally declared in Lean: (1) `trigRoots_distinct` — the three cosine values at angles θ/3, (θ+2π)/3, (θ+4π)/3 are distinct, requiring cos injectivity on [0,π]; (2) `trigRoot_is_root` — each trigonometric root satisfies the cubic, requiring expansion via the triple angle formula 4cos³φ−3cosφ = cos(3φ); (3) `wantzel_casus_irreducibilis` (1843) — the roots cannot be expressed using real-valued radicals alone, a Galois-theoretic result about the splitting field having group S₃. Note: these appear only as comments in the Lean source, not as actual `axiom` declarations.",
-      "mathContext": "$\\text{Wantzel (1843): } \\not\\exists \\text{ real radical expression for all three roots of } x^3+px+q=0 \\text{ when } \\Delta > 0$",
-      "significance": "context",
-      "relatedConcepts": ["Galois theory", "splitting field", "S₃", "radical extensions", "Wantzel's theorem"],
-      "prerequisites": ["Galois theory", "field extensions", "group theory: S₃ and A₃"]
-    },
-    {
-      "id": "ann-ci-example",
-      "proofId": "solution-of-cubic-oq-03-oq-02",
-      "range": { "startLine": 148, "endLine": 176 },
-      "type": "insight",
-      "title": "Concrete Example: x³ − 7x + 6 = 0 Has Three Real Roots",
-      "content": "The equation x³−7x+6 = 0 factors as (x−1)(x−2)(x+3) = 0, with roots 1, 2, −3 — all real. With p = −7, q = 6: Δ = −4(−7)³ − 27(36) = 1372 − 972 = 400 > 0, confirming the casus irreducibilis condition. Cardano's D = 36/4 + (−343)/27 = 9 − 343/27 ≈ 9 − 12.7 < 0, so the formula requires √D = i√(343/27 − 9). All three verifications (x=1, x=2, x=−3) close with `ring`, and `example_three_real_roots` packages them into an existential statement.",
-      "mathContext": "$x^3 - 7x + 6 = (x-1)(x-2)(x+3),\\quad \\Delta = 400 > 0,\\quad D = \\tfrac{36}{4} + \\tfrac{-343}{27} < 0$",
-      "significance": "key",
-      "relatedConcepts": ["polynomial factorization", "casus irreducibilis example", "Cardano's formula", "discriminant computation"],
-      "prerequisites": ["algebra: polynomial roots", "arithmetic"]
-    }
-  ]
-}
+[
+  {
+    "id": "ann-ci-header",
+    "proofId": "solution-of-cubic-oq-03-oq-02",
+    "range": { "startLine": 1, "endLine": 38 },
+    "type": "context",
+    "title": "Casus Irreducibilis: The First Historical Encounter with Necessity of Complex Numbers",
+    "content": "The casus irreducibilis ('irreducible case') is historically the first instance where complex numbers proved necessary — not merely convenient — even when all answers are real. For x³ + px + q = 0 with three distinct real roots (Δ = -4p³ - 27q² > 0), Cardano's formula (1545) necessarily passes through complex cube roots: x = ∛(-q/2 + √D) + ∛(-q/2 - √D) where D = q²/4 + p³/27 < 0. Since D < 0, the √D is purely imaginary. The complex cube roots cancel to give real results, but cannot be avoided. Rafael Bombelli (1572) first showed the complex routes were valid; Pierre Wantzel (1843) proved that no real-valued radical expression exists for all three roots.",
+    "mathContext": "The relationship: $\\Delta = -4p^3 - 27q^2 = -108D$, so $\\Delta > 0 \\Leftrightarrow D < 0$. When $D < 0$: $\\sqrt{D} = i\\sqrt{-D} \\in i\\mathbb{R}_{>0}$, making Cardano's cube root arguments $z_{1,2} = -q/2 \\pm i\\sqrt{-D}$ strictly complex. Yet their sum $\\sqrt[3]{z_1} + \\sqrt[3]{z_2} \\in \\mathbb{R}$ (the complex parts cancel). Wantzel's 1843 theorem (a precursor to Galois theory): the splitting field of $x^3+px+q$ over $\\mathbb{Q}(p,q)$ has Galois group $S_3$ or $A_3$, and no real radical tower resolves all three roots simultaneously.",
+    "significance": "context",
+    "relatedConcepts": ["casus irreducibilis", "Cardano's formula", "Wantzel's theorem", "Bombelli's rule", "Galois theory for cubics"],
+    "prerequisites": ["Cardano's formula for cubic equations", "complex numbers history", "discriminant of cubic"]
+  },
+  {
+    "id": "ann-ci-definitions",
+    "proofId": "solution-of-cubic-oq-03-oq-02",
+    "range": { "startLine": 43, "endLine": 57 },
+    "type": "concept",
+    "title": "Depressed Cubic, Discriminant, and Cardano's D: The Algebraic Setup",
+    "content": "Four definitions capture the algebraic setup. `depressedCubic p q x` is x³+px+q, the standard reduced form of any cubic after eliminating the x² term. `discriminant p q` is Δ = −4p³ − 27q², the sign of which determines root structure: Δ > 0 gives three distinct real roots, Δ = 0 gives repeated roots, Δ < 0 gives one real and two complex conjugate roots. `cardanoD p q` is D = q²/4 + p³/27, the quantity appearing under the square root in Cardano's formula — related to the discriminant by D = −Δ/108. `isCasusIrreducibilis` simply asserts Δ > 0.",
+    "mathContext": "$\\Delta = -4p^3 - 27q^2,\\quad D = \\frac{q^2}{4} + \\frac{p^3}{27} = -\\frac{\\Delta}{108}$. The depressed cubic form arises from $x^3 + px + q = 0$ via the substitution $x \\to x - a/3$ in the general cubic $x^3 + ax^2 + bx + c = 0$. Any cubic can be reduced to the depressed form. The discriminant $\\Delta$ is related to the resultant of $f$ and $f'$: $\\Delta = -\\text{Res}(f, f')/a$ for monic $f$.",
+    "significance": "supporting",
+    "relatedConcepts": ["depressed cubic form", "discriminant", "Cardano's formula", "polynomial root structure", "isCasusIrreducibilis"],
+    "prerequisites": ["algebra: polynomial equations", "polynomial discriminants", "Cardano's formula"]
+  },
+  {
+    "id": "ann-ci-d-neg",
+    "proofId": "solution-of-cubic-oq-03-oq-02",
+    "range": { "startLine": 59, "endLine": 74 },
+    "type": "insight",
+    "title": "Δ > 0 Forces D < 0 and p < 0: The Algebraic Heart of Casus Irreducibilis",
+    "content": "The core algebraic fact: when the cubic has three distinct real roots (Δ > 0), Cardano's intermediate quantity D = q²/4 + p³/27 is necessarily negative. Since Δ = -108D, the proof is a single `nlinarith`. The companion theorem `p_neg_of_casus` shows p < 0 is also forced: since Δ = −4p³ − 27q² > 0 and −27q² ≤ 0, we need −4p³ > 27q² ≥ 0, hence p³ < 0, so p < 0. The negativity of p guarantees √(-p/3) is real (needed for Viète's form).",
+    "mathContext": "$D < 0$ means $\\sqrt{D} = i\\sqrt{-D}$, making Cardano's arguments $z_{1,2} = -q/2 \\pm i\\sqrt{-D}$ non-real with $|z_{1,2}| = \\sqrt{(q/2)^2 + (-D)} = \\sqrt{-p^3/27}$. So the modulus of the cube root arguments is $|z| = (-p/3)^{3/2}$, which is real since $p < 0$. The argument is $\\theta = \\pm\\arctan(\\sqrt{-D}/(q/2))$ — this is what becomes the $\\theta/3$ in the trigonometric form.",
+    "significance": "key",
+    "relatedConcepts": ["cardanoD_neg_of_casus", "p_neg_of_casus", "nlinarith for algebraic inequalities", "sign of discriminant"],
+    "prerequisites": ["Δ = -108D algebraic identity", "nlinarith tactic", "sq_nonneg in Lean 4"]
+  },
+  {
+    "id": "ann-ci-nonreal-proof",
+    "proofId": "solution-of-cubic-oq-03-oq-02",
+    "range": { "startLine": 76, "endLine": 105 },
+    "type": "theorem",
+    "title": "Cardano's Arguments Are Genuinely Complex: im ≠ 0 via Real.sqrt_pos",
+    "content": "The theorems `cardanoArg_not_real` and `cardanoArgConj_not_real` prove the imaginary part of Cardano's cube root arguments is nonzero. For `cardanoArg p q = (-q/2 : ℝ) + I * √(-D)`, the imaginary part is `√(-D)` after simp. `Real.sqrt_pos.mpr` converts this to: `√(-D) > 0 ↔ -D > 0 ↔ D < 0`, which follows from `cardanoD_neg_of_casus`. The `linarith` closes the chain. The argument for the conjugate `cardanoArgConj` is identical since the sign change only affects im = -√(-D) which is also nonzero.",
+    "mathContext": "$(\\text{cardanoArg}).\\text{im} = \\sqrt{-D} > 0$ since $D < 0 \\Rightarrow -D > 0$. In Lean: `Complex.add_im`, `Complex.mul_im`, `Complex.I_im = 1` reduce the imaginary part to `Real.sqrt(-cardanoD p q)`. Then `Real.sqrt_pos : 0 < Real.sqrt x ↔ 0 < x` (for real x) finishes. The `ne_of_gt` gives `≠ 0` from `> 0`. This is the proof that Cardano's formula is **necessarily** complex in the casus irreducibilis — not an artifact of the formula but a mathematical necessity.",
+    "significance": "key",
+    "relatedConcepts": ["cardanoArg_not_real", "Real.sqrt_pos in Mathlib", "Complex.I_im = 1", "cardanoD_neg_of_casus"],
+    "prerequisites": ["Complex.add_im, mul_im in Lean 4", "Real.sqrt_pos theorem", "ne_of_gt"]
+  },
+  {
+    "id": "ann-ci-trig-roots",
+    "proofId": "solution-of-cubic-oq-03-oq-02",
+    "range": { "startLine": 107, "endLine": 147 },
+    "type": "technique",
+    "title": "Viète's Trigonometric Form: Three Real Roots Without Complex Numbers",
+    "content": "The `trigRoot p q k` formula for k ∈ {0,1,2} gives three explicitly real roots via x_k = 2√(-p/3) · cos((θ + 2πk)/3) where θ = arccos(-q/(2r³)) and r = √(-p/3). This bypasses complex numbers entirely: both √(-p/3) and arccos are real (p < 0 guarantees -p/3 > 0; the arccos argument lies in [-1,1] when Δ > 0). The proof that these satisfy x³+px+q = 0 requires the **triple angle identity** 4cos³φ - 3cosφ = cos(3φ), which reduces the verification to a direct computation. Wantzel's theorem (stated in comments, not as a Lean axiom) says this trigonometric form cannot be algebraically simplified to avoid complex numbers in a radical expression.",
+    "mathContext": "Substituting $x = 2r\\cos\\phi$ with $r = \\sqrt{-p/3}$ into $x^3+px+q=0$: $8r^3\\cos^3\\phi + 2pr\\cos\\phi + q = 0$. Dividing by $2r^3$: $4\\cos^3\\phi + \\frac{2p}{2r^2}\\cos\\phi + \\frac{q}{2r^3} = 0$. Since $p = -3r^2$: $4\\cos^3\\phi - 3\\cos\\phi = -\\frac{q}{2r^3}$, i.e., $\\cos(3\\phi) = -q/(2r^3)$. So $3\\phi = \\arccos(-q/(2r^3)) + 2\\pi k$, giving $\\phi_k = (\\theta + 2\\pi k)/3$.",
+    "significance": "key",
+    "relatedConcepts": ["trigRoot definition", "Viète's substitution", "triple angle identity", "Real.arccos in Mathlib", "Wantzel's theorem"],
+    "prerequisites": ["triple angle identity 4cos³φ-3cosφ=cos(3φ)", "Real.arccos in Lean 4", "Fin 3 in Lean 4"]
+  },
+  {
+    "id": "ann-ci-example",
+    "proofId": "solution-of-cubic-oq-03-oq-02",
+    "range": { "startLine": 148, "endLine": 178 },
+    "type": "insight",
+    "title": "Concrete Example: x³ - 7x + 6 = 0 — Three Real Roots via Complex Cube Roots",
+    "content": "The equation x³-7x+6 = 0 (p=-7, q=6) factors as (x-1)(x-2)(x+3), with roots 1, 2, -3 — all real. Verification: Δ = -4(-7)³ - 27(36) = 1372 - 972 = 400 > 0 (casus irreducibilis, proved by `norm_num`). Cardano's D = 36/4 + (-343)/27 = 9 - 343/27 < 0 (proved by `norm_num`). The three root verifications close with `ring`. The `example_three_real_roots` packages them as `∃ x₁ x₂ x₃ : ℝ, distinct ∧ all satisfy the cubic`. This concrete example illustrates the paradox: the three roots are integers (maximally real!), yet Cardano's formula requires √(-D) = i√(343/27 - 9) ≈ 1.76i.",
+    "mathContext": "For $x^3 - 7x + 6 = 0$: Cardano's formula gives $x = \\sqrt[3]{-3 + i\\sqrt{343/27 - 9}} + \\sqrt[3]{-3 - i\\sqrt{343/27 - 9}}$. Both cube roots are complex numbers of modulus $\\sqrt[3]{9 + (343/27-9)} = \\sqrt[3]{343/27} = 7/(3\\sqrt[3]{3})$ and argument $\\pm\\arctan(\\sqrt{343/27-9}/3)$. Their sum equals 1, 2, or -3 depending on which cube root branch is chosen — demonstrating that the choice of branch is the mechanism by which the three distinct roots emerge from Cardano's formula.",
+    "significance": "key",
+    "relatedConcepts": ["example_casus", "example_root_1/2/neg3", "example_three_real_roots", "norm_num for concrete computation", "ring tactic for polynomial verification"],
+    "prerequisites": ["norm_num tactic", "ring tactic in Lean 4", "polynomial factoring"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for `solution-of-cubic-oq-03-oq-02` (Casus Irreducibilis).

## Changes

- Fixed JSON format: previous annotations.json was wrapped in `{"annotations": [...]}` (invalid schema) — corrected to bare array `[...]`
- Added 6 high-quality annotations with improved mathContext and significance fields

## Annotations (6)

1. **Header context** (lines 1-38): Historical necessity of complex numbers; Cardano/Bombelli/Wantzel timeline; Galois group S₃ interpretation
2. **Algebraic setup** (lines 43-57): depressedCubic, discriminant, cardanoD, isCasusIrreducibilis; Δ = -108D identity
3. **D < 0 and p < 0** (lines 59-74): nlinarith proof; p < 0 ensures √(-p/3) is real for Viète form; modulus of cube root arguments
4. **Cardano arguments non-real** (lines 76-105): im ≠ 0 via Real.sqrt_pos; proof chain with Complex.I_im; necessity vs. convenience
5. **Viète's trigonometric form** (lines 107-147): cos substitution derivation; triple angle identity mechanism; Wantzel theorem context
6. **Concrete example** (lines 148-178): x³-7x+6=0 with roots 1,2,-3; Δ=400; D<0; branch selection mechanism in Cardano's formula

## Math coverage

- Δ > 0 ↔ D < 0 algebraic identity
- Cardano's formula necessarily involves complex cube roots when Δ > 0
- Viète's trigonometric substitution as the real alternative
- Triple angle identity 4cos³φ-3cosφ=cos(3φ) as the verification key
- Wantzel 1843: no real radical expression for all three roots