### PR TITLE
Fix: erdos-220 — convert 6 True-stub theorems to comments

### DIFF
--- a/proofs/Proofs/Erdos220Problem.lean
+++ b/proofs/Proofs/Erdos220Problem.lean
@@ -143,40 +143,27 @@ theorem sum_gaps_bound (n : ℕ) (hn : n ≥ 2) :
     (gapList n).sum ≤ n := by
   sorry
 
-/-- If all gaps were equal to the average, the squared sum would be exactly n²/φ(n). -/
-theorem equal_gaps_would_give_bound (n : ℕ) (hn : n ≥ 1) :
-    -- If all gaps = n/φ(n), then ∑(gap)² = φ(n) · (n/φ(n))² = n²/φ(n)
-    True := trivial
+/-
+**Observation**: If all gaps were equal to the average n/φ(n), the squared sum would be
+exactly n²/φ(n): φ(n) · (n/φ(n))² = n²/φ(n). This motivates the conjecture's bound.
 
-/-- Large gaps must be rare by the pigeonhole principle. -/
-theorem large_gaps_are_rare (n : ℕ) (hn : n ≥ 1) :
-    -- Gaps of size g > n/φ(n) can occur at most φ(n)/g times
-    -- This limits how much large gaps contribute to the sum
-    True := trivial
+**Observation**: Large gaps must be rare by the pigeonhole principle.
+Gaps of size g > n/φ(n) can occur at most φ(n)/g times, limiting large-gap contributions.
+-/
 
 /-!
 ## Part VII: Special Cases
 -/
 
-/-- For n prime, the reduced residues are 1, 2, ..., n-1 with all gaps = 1. -/
-theorem prime_case (p : ℕ) (hp : Nat.Prime p) :
-    -- reducedResidues p = {1, 2, ..., p-1}
-    -- All gaps are 1, so ∑(gap)² = p - 2
-    -- And n²/φ(n) = p²/(p-1) ≈ p, so the bound holds easily
-    True := trivial
-
-/-- For n = 2^k, the only odd residue class matters. -/
-theorem power_of_two_case (k : ℕ) (hk : k ≥ 1) :
-    -- reducedResidues (2^k) = {1, 3, 5, ..., 2^k - 1}
-    -- All gaps are 2, so ∑(gap)² = 2^{k-1} · 4 = 2^{k+1}
-    -- And n²/φ(n) = 2^{2k}/2^{k-1} = 2^{k+1}, so bound is tight
-    True := trivial
-
-/-- For primorials (n = p₁ · p₂ · ... · p_k), gaps can be large. -/
-theorem primorial_case :
-    -- For n = ∏_{p ≤ x} p, the gaps can be as large as the prime gap after x
-    -- Montgomery-Vaughan's bound shows these large gaps are rare enough
-    True := trivial
+/-
+**Special cases**:
+- n prime: reducedResidues p = {1, 2, ..., p-1}, all gaps = 1, so ∑(gap)² = p - 2.
+  And n²/φ(n) = p²/(p-1) ≈ p, so the bound holds easily.
+- n = 2^k: reducedResidues = {1, 3, 5, ..., 2^k - 1}, all gaps = 2, so ∑(gap)² = 2^{k+1}.
+  And n²/φ(n) = 2^{2k}/2^{k-1} = 2^{k+1}, so bound is tight.
+- n primorial (n = ∏_{p ≤ x} p): gaps can be as large as the prime gap after x,
+  but Montgomery-Vaughan's bound shows these large gaps are rare enough.
+-/
 
 /-!
 ## Part VIII: Relation to Prime Gaps
@@ -190,11 +177,10 @@ noncomputable def jacobsthal (n : ℕ) : ℕ :=
 axiom maximum_gap_bound (n : ℕ) (hn : n ≥ 2) :
     ∃ C : ℝ, C > 0 ∧ (jacobsthal n : ℝ) ≤ C * averageGap n * (Real.log n)^2
 
-/-- The sum of squared gaps is dominated by the number of "large" gaps. -/
-theorem squared_sum_dominated_by_distribution :
-    -- Key insight: ∑ g² depends on how many gaps of each size
-    -- Few large gaps + many small gaps = manageable sum
-    True := trivial
+/-
+**Key insight**: ∑ g² depends on how many gaps of each size exist.
+Few large gaps + many small gaps = manageable sum, bounded by n²/φ(n).
+-/
 
 /-!
 ## Part IX: The Distribution of Gaps
@@ -235,7 +221,6 @@ theorem erdos_220_summary :
     ∃ C : ℝ, C > 0 ∧ ∀ n ≥ 1, (sumSquaredGaps n : ℝ) ≤ C * boundedSquaredGaps n :=
   montgomery_vaughan_squared
 
-/-- The problem was resolved affirmatively. -/
-theorem erdos_220_solved : True := trivial
+-- The problem was resolved affirmatively (Montgomery-Vaughan 1986).
 
 end Erdos220

--- a/src/data/proofs/erdos-220/meta.json
+++ b/src/data/proofs/erdos-220/meta.json
@@ -60,7 +60,7 @@
     ],
     "axiomCount": 4,
     "lineCount": 241,
-    "assumptions": "4 axiom(s) and 2 sorry(s). See the Lean source for details."
+    "assumptions": "4 axioms (montgomery_vaughan_squared — squared gaps sum O(n²/φ(n)); montgomery_vaughan_general — γ-th power generalization; maximum_gap_bound — max gap ≤ C·n/φ(n)·(log n)²; gap_concentration — gap distribution measure estimate) and 2 sorries (sum_gaps_bound derivation; reduced_residues_count). 0 True-stub theorems."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #220**\n\nThis problem concerns the gaps between consecutive reduced residues modulo n. The reduced residues are integers 1 ≤ m < n with gcd(m,n) = 1, and there are φ(n) of them.\n\n**Background:**\n- Average gap is n/φ(n)\n- Large gaps can occur (related to Jacobsthal's function)\n- Erdős asked if squared gaps sum to O(n²/φ(n))\n\n**History:**\n- Erdős posed the problem; $500 prize\n- The general γ ≥ 1 version was posed in [Er73]\n- Montgomery and Vaughan proved it in 1986 (Ann. of Math.)\n- Discussed in Guy's \"Unsolved Problems in Number Theory\" (B40)\n\n**Context:** The bound n²/φ(n) is what you'd get if all gaps were equal to the average. The theorem says even with gap variance, the squared sum doesn't exceed this by more than a constant factor.",


### PR DESCRIPTION
## Fix

Removed 6 theorem declarations that proved only `True := trivial` in `Erdos220Problem.lean`.

## Evidence

**Before**: 6 theorems with `True := trivial` bodies (equal_gaps_would_give_bound, large_gaps_are_rare, prime_case, power_of_two_case, primorial_case, squared_sum_dominated_by_distribution, erdos_220_solved) provided no mathematical content while appearing as formal results.

**After**: Content preserved as block comments; no `True := trivial` stubs remain. Also updated `meta.json` assumptions field to name each axiom explicitly.

Counts unchanged: `sorries: 2`, `axiomCount: 4`.

Addresses audit-tracker `issues-found` entry for `erdos-220`.

---
Automated fix by lean-mechanic agent.