### PR TITLE
Fix: subset-count-multiset badge original→mathlib + audit tracker updates

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10696,9 +10696,9 @@
       "result": "issues-fixed"
     },
     "subset-count-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-04T14:14:41Z",
       "result": "clean"
     },
     "sum-of-kth-powers": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10378,9 +10378,9 @@
       "result": "clean"
     },
     "pythagorean-triples-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-04T14:19:53Z",
       "result": "clean"
     },
     "quadratic-reciprocity": {
@@ -10396,9 +10396,9 @@
       "result": "clean"
     },
     "quadratic-reciprocity-algorithm-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-04T14:19:35Z",
       "result": "clean"
     },
     "ramanujan-sum-fallacy": {
@@ -10408,9 +10408,9 @@
       "result": "clean"
     },
     "ramsey-r4k-extensions": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-04T14:18:57Z",
       "result": "clean"
     },
     "ramseys-theorem": {
@@ -10438,15 +10438,15 @@
       "result": "clean"
     },
     "randomized-maxcut-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-04T14:18:29Z",
       "result": "clean"
     },
     "rh-consequences": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-04T14:18:16Z",
       "result": "clean"
     },
     "riemann-hypothesis": {
@@ -10474,9 +10474,9 @@
       "result": "clean"
     },
     "roth-theorem-k3-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-04T14:17:58Z",
       "result": "clean"
     },
     "russell-1-plus-1": {
@@ -10498,9 +10498,9 @@
       "result": "clean"
     },
     "schauder-fixed-point-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-04T14:17:45Z",
       "result": "clean"
     },
     "schroeder-bernstein": {
@@ -10510,9 +10510,9 @@
       "result": "clean"
     },
     "schroeder-bernstein-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-04T14:17:18Z",
       "result": "clean"
     },
     "schroeder-bernstein-oq-04": {
@@ -10546,9 +10546,9 @@
       "result": "clean"
     },
     "shannon-entropy-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-04T14:16:48Z",
       "result": "clean"
     },
     "shannon-entropy-oq-03": {
@@ -10564,9 +10564,9 @@
       "result": "clean"
     },
     "shannon-source-coding-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-04T14:16:36Z",
       "result": "clean"
     },
     "shannon-source-coding-oq-02": {
@@ -10630,9 +10630,9 @@
       "result": "clean"
     },
     "sperner-ndim-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-04T14:15:41Z",
       "result": "clean"
     },
     "sqrt2-examples": {
@@ -10642,9 +10642,9 @@
       "result": "clean"
     },
     "sqrt2-examples-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-04T14:16:05Z",
       "result": "clean"
     },
     "sqrt2-from-axioms": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10678,9 +10678,9 @@
       "result": "clean"
     },
     "stirling-formula-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-04T13:02:24Z",
       "result": "clean"
     },
     "subset-count": {
@@ -10738,9 +10738,9 @@
       "result": "clean"
     },
     "sylow-theorems-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-04T13:02:24Z",
       "result": "clean"
     },
     "szemeredi-core": {
@@ -10762,9 +10762,9 @@
       "result": "clean"
     },
     "szemeredi-hypergraph-core": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-04T13:02:08Z",
       "result": "clean"
     },
     "szemeredi-regularity": {
@@ -10908,9 +10908,9 @@
       "result": "clean"
     },
     "wilsons-theorem-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-04T13:02:08Z",
       "result": "clean"
     },
     "wolstenholme-theorem": {
@@ -10953,9 +10953,9 @@
       "result": "clean"
     },
     "yang-mills-2d-oq-02": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-04T12:39:09Z",
+      "lastAudited": "2026-04-04T13:01:27Z",
       "result": "clean"
     },
     "yang-mills-lattice": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11163,9 +11163,9 @@
       "issues": []
     },
     "erdos-10-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-03T07:39:14Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-04-04T13:13:52Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "erdos-1021-oq-01": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1847,9 +1847,9 @@
       "result": "clean"
     },
     "erdos-1012-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-04T06:09:00Z",
+      "lastAudited": "2026-04-04T13:41:12Z",
       "result": "issues-fixed"
     },
     "erdos-1013": {
@@ -10690,10 +10690,10 @@
       "result": "clean"
     },
     "subset-count-multiset": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
-      "result": "clean"
+      "lastAudited": "2026-04-04T14:13:50Z",
+      "result": "issues-fixed"
     },
     "subset-count-oq-02": {
       "auditCount": 1,

--- a/src/data/proofs/subset-count-multiset/meta.json
+++ b/src/data/proofs/subset-count-multiset/meta.json
@@ -15,7 +15,7 @@
       "counting"
     ],
     "proofRepoPath": "Proofs/SubsetCountOQ02.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -30,15 +30,14 @@
       }
     ],
     "originalContributions": [
-      "Multiset powerset cardinality with pedagogical documentation",
-      "Fixed-size submultiset counting via binomial coefficients",
-      "Connection between Finset and Multiset powerset formulas",
+      "Pedagogical documentation connecting multiset and set powerset formulas",
+      "Bridge theorems connecting Finset and Multiset powerset perspectives",
       "Concrete examples including multisets with repeated elements"
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
     "lineCount": 120,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+    "assumptions": "None. Core results derived from Mathlib's Multiset.card_powerset and Multiset.card_powersetCard (0 axioms, 0 sorries)."
   },
   "overview": {
     "historicalContext": "The multiset (or *bag*) is a fundamental data structure generalizing sets by allowing repeated elements, formalized in computer science by Knuth (1981) and in mathematics dating back to Boole and De Morgan. The powerset counting formula $|\\mathcal{P}(S)| = 2^n$ for sets extends to multisets: Sylvester (1867) and later Cayley studied the enumeration of multiset submultisets in the context of symmetric functions and formal power series. For a multiset with $n$ total elements (counted with multiplicity), the number of submultisets is $2^n$ — not the product formula $\\prod(m_i + 1)$ for *distinct* submultisets. This distinction (counting with vs. without multiplicity) is subtle and important for generating function arguments. The multiset powerset is fundamental to the theory of formal power series: $\\sum_{k \\geq 0} |\\text{powersetCard}(k, s)| x^k = (1+x)^n$ is the generating function for submultiset counts, which specializes to the standard binomial theorem.",
@@ -99,7 +98,7 @@
     }
   ],
   "conclusion": {
-    "summary": "A clean generalization of the subset counting theorem to multisets. 5 theorems, 0 sorries, 0 axioms, with concrete examples.",
+    "summary": "A clean generalization of the subset counting theorem to multisets, derived from Mathlib. 7 theorems, 0 sorries, 0 axioms, with concrete examples.",
     "implications": "The multiset powerset formula is the foundation for generating function arguments in combinatorics.",
     "openQuestions": [
       "Can we formalize the DISTINCT submultiset count prod(m_i + 1)?",


### PR DESCRIPTION
## Summary

- **Gallery integrity fix**: `subset-count-multiset` had `badge: "original"` but the two core theorems (`multiset_powerset_card`, `multiset_choose_card`) are single-line delegations to Mathlib's `Multiset.card_powerset` and `Multiset.card_powersetCard` — a Tier B (Mathlib-derived) proof. Badge corrected to `"mathlib"`.
- Also fixed `conclusion.summary` theorem count (5→7) and updated `assumptions` field to note Mathlib dependency.
- `subset-count-oq-02` already had correct `badge: "mathlib"` — marked clean in audit tracker.

## Audit Findings

| Proof | Issue | Severity | Action |
|-------|-------|----------|--------|
| `subset-count-multiset` | Badge `original` should be `mathlib`; theorem count wrong (5 vs 7) | MEDIUM | Fixed in this PR |
| `subset-count-oq-02` | Clean — badge already `mathlib` | — | Marked clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)