### PR TITLE
Fix: correct axiom count comment in BrouwerFixedPointOQ01OQ02 (2→1)

### DIFF
--- a/proofs/Proofs/BrouwerFixedPointOQ01OQ02.lean
+++ b/proofs/Proofs/BrouwerFixedPointOQ01OQ02.lean
@@ -39,7 +39,7 @@ axiom no_retraction_axiom (n : ℕ) (hn : n ≥ 1) : ¬∃ r : Retraction n, Tru
 This file derives no-retraction from **more primitive** axioms that precisely
 identify what singular homology contributes. The pure algebraic argument is fully proved.
 
-## Summary: 11 theorems, 0 sorries, 2 axioms
+## Summary: 11 theorems, 0 sorries, 1 axiom
 -/
 
 set_option linter.unusedVariables false


### PR DESCRIPTION
## Fix

Corrected the file header comment in BrouwerFixedPointOQ01OQ02.lean line 42: changed '2 axioms' to '1 axiom'.

## Evidence

**Before**: `## Summary: 11 theorems, 0 sorries, 2 axioms`
**After**: `## Summary: 11 theorems, 0 sorries, 1 axiom`

The 'axiom no_retraction_axiom' shown in the file header is inside a block comment code example (comparing with the parent BrouwerFixedPoint.lean), not an actual axiom declaration. The file has exactly 1 real axiom: \`singular_homology_retraction_split\`.

meta.json already correctly stated \`axiomCount: 1\`. This aligns the file documentation with the metadata.

Addresses audit-tracker \`issues-found\` entry for \`brouwer-fixed-point-oq-01-oq-02\`.

---
Automated fix by lean-mechanic agent.