### PR TITLE
Enrich 4 proofs: inverse-galois-oq-02, cramers-rule-oq-01-oq-03, erdos-117-oq-01, erdos-1009-oq-02

### DIFF
--- a/src/data/proofs/erdos-117-oq-01/annotations.json
+++ b/src/data/proofs/erdos-117-oq-01/annotations.json
@@ -1,24 +1,86 @@
 [
   {
-    "id": "ann-erdos117-oq01-header",
+    "id": "ann-e117-oq01-axioms",
     "proofId": "erdos-117-oq-01",
-    "range": {
-      "startLine": 1,
-      "endLine": 20
-    },
-    "type": "context",
-    "title": "The Gap in Pyber's Bounds",
-    "body": "Pyber showed c₁ⁿ ≤ h(n) ≤ c₂ⁿ with c₁ < c₂. The gap between c₁ and c₂ is the source of the open question: does h(n) grow at a single exponential rate, or does the growth rate oscillate?"
+    "range": { "startLine": 39, "endLine": 47 },
+    "type": "axiom",
+    "title": "Three Axioms: The Abelian Covering Number and Pyber's Bounds",
+    "content": "The file axiomatizes the abelian covering number h : ℕ → ℕ and its key properties. h(n) is the minimum number of abelian subgroups needed to cover any group with the n-commuting property (where any n+2 elements include two that commute). This is a subtle combinatorial group theory function that Erdős studied.\n\nThe axiom h_pos asserts h(n) ≥ 1 for n ≥ 1, which is trivially true since at least one covering subgroup is needed. The crucial axiom pyber_bounds encodes Pyber's 1987 theorem: there exist constants c₂ > c₁ > 1 such that c₁ⁿ ≤ h(n) ≤ c₂ⁿ for all n ≥ 1. This establishes that h(n) grows exponentially — it is not polynomial — but leaves open whether the rate converges to a single base.",
+    "mathContext": "Pyber (1987): $\\exists c_1, c_2 > 1$ with $c_1 < c_2$, such that $c_1^n \\leq h(n) \\leq c_2^n$ for all $n \\geq 1$. Equivalently, $\\log c_1 \\leq \\frac{\\log h(n)}{n} \\leq \\log c_2$. The $n$-commuting property: a group $G$ is $n$-commuting if among any $n+2$ elements, at least two commute. Equivalently, $G$ is not $(n+1)$-fold non-abelian.",
+    "significance": "key",
+    "relatedConcepts": ["abelian covering number", "n-commuting groups", "Pyber's theorem 1987", "exponential bounds in group theory"],
+    "prerequisites": ["group theory (abelian subgroups, subgroup covers)", "Erdős Problem #117 statement"]
   },
   {
-    "id": "ann-erdos117-oq01-fekete",
+    "id": "ann-e117-oq01-growthrate-def",
     "proofId": "erdos-117-oq-01",
-    "range": {
-      "startLine": 158,
-      "endLine": 170
-    },
-    "type": "insight",
-    "title": "Fekete's Lemma: The Submultiplicative Path",
-    "body": "If h(m+n) ≤ h(m)·h(n) for all m,n, then log(h) is subadditive and Fekete's subadditive lemma guarantees lim log(h(n))/n exists. This is the most natural path to resolving the convergence question — it reduces to a structural property of covering numbers."
+    "range": { "startLine": 57, "endLine": 77 },
+    "type": "definition",
+    "title": "The Logarithmic Growth Rate and Lower Bound",
+    "content": "The definition growthRate(n) = log(h(n))/n (with growthRate(0) = 0 by convention) is the central object of study. This is the standard 'normalized logarithm' that reveals exponential growth rates. If h(n) ~ cⁿ, then growthRate(n) → log c.\n\nThe theorem growthRate_lower_bound proves ∃ L > 0, ∀ n ≥ 1, growthRate(n) ≥ L using Pyber's lower bound c₁ⁿ ≤ h(n). The proof extracts c₁ from pyber_bounds via obtain, then computes: growthRate(n) = log(h(n))/n ≥ log(c₁ⁿ)/n = n·log(c₁)/n = log(c₁). Since c₁ > 1, log(c₁) > 0. The Lean proof chains through Real.log_pos, div_le_div_iff, and Real.log_le_log.",
+    "mathContext": "$r(n) = \\frac{\\log h(n)}{n}$ for $n \\geq 1$. Lower bound: $r(n) \\geq \\log c_1 > 0$ from Pyber. Proof: $r(n) = \\frac{\\log h(n)}{n} \\geq \\frac{\\log(c_1^n)}{n} = \\frac{n \\log c_1}{n} = \\log c_1$ using $\\log$ monotonicity and $h(n) \\geq c_1^n$.",
+    "significance": "key",
+    "relatedConcepts": ["logarithmic growth rate", "exponential growth", "Real.log in Mathlib", "Pyber's lower bound"],
+    "prerequisites": ["real logarithm properties", "Lean: obtain tactic, div_le_div_iff", "Filter API in Mathlib"]
+  },
+  {
+    "id": "ann-e117-oq01-upper-bound",
+    "proofId": "erdos-117-oq-01",
+    "range": { "startLine": 80, "endLine": 97 },
+    "type": "theorem",
+    "title": "Upper Bound from Pyber's Second Inequality",
+    "content": "The theorem growthRate_upper_bound proves ∃ U, ∀ n ≥ 1, growthRate(n) ≤ U, with U = log(c₂). The proof mirrors the lower bound argument, using the upper branch of Pyber's bounds: h(n) ≤ c₂ⁿ → log(h(n)) ≤ log(c₂ⁿ) = n·log(c₂) → growthRate(n) = log(h(n))/n ≤ log(c₂). An intermediate step establishes (h n : ℝ) ≥ 1 using exact_mod_cast to coerce the natural number h_pos into real numbers.\n\nTogether, the lower and upper bound theorems show log(c₁) ≤ growthRate(n) ≤ log(c₂) for all n ≥ 1 — the growth rate sequence is bounded within the interval [log c₁, log c₂], a necessary condition for the limit to exist.",
+    "mathContext": "$r(n) \\leq \\log c_2$ from $h(n) \\leq c_2^n$: $r(n) = \\frac{\\log h(n)}{n} \\leq \\frac{\\log(c_2^n)}{n} = \\log c_2$. Combined: $\\log c_1 \\leq r(n) \\leq \\log c_2$ for all $n \\geq 1$. This means $\\liminf r(n)$ and $\\limsup r(n)$ are both well-defined real numbers in $[\\log c_1, \\log c_2]$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Pyber's upper bound", "bounded sequences", "Real.log_le_log in Mathlib", "exact_mod_cast tactic"],
+    "prerequisites": ["real logarithm monotonicity", "natural-to-real coercion in Lean", "Pyber's theorem"]
+  },
+  {
+    "id": "ann-e117-oq01-liminf-limsup",
+    "proofId": "erdos-117-oq-01",
+    "range": { "startLine": 107, "endLine": 131 },
+    "type": "definition",
+    "title": "liminf and limsup of the Growth Rate via Mathlib's Filter API",
+    "content": "The definitions growthRateLimInf and growthRateLimSup use Mathlib's Filter.liminf and Filter.limsup with atTop — the filter of 'eventually large' natural numbers. This is the standard formalization of liminf/limsup in Lean 4: rather than working with explicit sequences and ε-δ definitions, Mathlib uses the more abstract filter framework.\n\nThe theorem limInf_le_limSup proves the always-true inequality liminf ≤ limsup, but requires supplying boundedness witnesses: (1) growthRate is eventually bounded above (witness: U from growthRate_upper_bound), and (2) a cobounded-under witness (essentially that no lower bound is eventually exceeded). The proof uses Filter.eventually_atTop.mpr and Filter.liminf_le_limsup from Mathlib.",
+    "mathContext": "Mathlib: $\\liminf_{n \\to \\infty} r(n) = \\inf\\{L : r(n) \\geq L \\text{ eventually}\\}$, $\\limsup_{n \\to \\infty} r(n) = \\sup\\{L : r(n) \\leq L \\text{ eventually}\\}$. Always: $\\liminf \\leq \\limsup$. Convergence $\\Leftrightarrow$ $\\liminf = \\limsup$. The Filter.atTop approach: $p$ holds 'eventually' iff $\\exists N, \\forall n \\geq N, p(n)$.",
+    "significance": "key",
+    "relatedConcepts": ["Filter.liminf in Mathlib", "Filter.limsup in Mathlib", "Filter.atTop", "liminf ≤ limsup", "IsBoundedUnder"],
+    "prerequisites": ["Mathlib Filter API", "liminf and limsup theory", "eventually-bounded sequences"]
+  },
+  {
+    "id": "ann-e117-oq01-open-question-defs",
+    "proofId": "erdos-117-oq-01",
+    "range": { "startLine": 140, "endLine": 165 },
+    "type": "definition",
+    "title": "Formalizing the Open Question: Convergence and Exponential Behavior",
+    "content": "Three propositions formalize different facets of the open question:\n\n**growthRateConverges**: ∃ L, Filter.Tendsto growthRate atTop (nhds L) — the standard Lean formalization of 'lim growthRate(n) = L'.\n\n**exponentialBaseExists**: ∃ c > 1, Tendsto growthRate atTop (nhds (log c)) — exists a single exponential base c such that h(n) ~ cⁿ.\n\n**ExponentialBehavior(c)**: For all ε > 0, eventually (c-ε)ⁿ ≤ h(n) ≤ (c+ε)ⁿ — the pointwise quantitative version of h(n) = Θ(cⁿ).\n\nThe theorem limit_determines_base proves that if growthRate(n) → L > 0, then c = exp(L) gives exponentialBaseExists. The proof constructs c = exp(L) and uses Real.log_exp to convert back. This chain makes precise what 'resolving the open question' means formally.",
+    "mathContext": "Open question: $\\lim_{n \\to \\infty} r(n) = \\lim_{n \\to \\infty} \\frac{\\log h(n)}{n}$ exists. If $L = \\lim r(n)$ exists, then $c = e^L > 1$ (since $L > \\log c_1 > 0$) and $h(n) = c^{n+o(n)}$. The exponential behavior condition $|\\log h(n)/n - \\log c| < \\epsilon$ is equivalent to $e^{(\\log c - \\epsilon)n} \\leq h(n) \\leq e^{(\\log c + \\epsilon)n} = (c \\cdot e^{\\epsilon})^n$.",
+    "significance": "key",
+    "relatedConcepts": ["Filter.Tendsto in Mathlib", "nhds (neighborhood filter)", "exponential growth base", "Θ-notation", "Real.log_exp"],
+    "prerequisites": ["Lean Filter.Tendsto API", "nhds filter", "exponential and logarithm in Lean/Mathlib"]
+  },
+  {
+    "id": "ann-e117-oq01-fekete",
+    "proofId": "erdos-117-oq-01",
+    "range": { "startLine": 186, "endLine": 189 },
+    "type": "theorem",
+    "title": "Fekete's Lemma: The Submultiplicativity Path to Convergence",
+    "content": "The theorem submultiplicative_implies_convergence shows that if h(m+n) ≤ h(m)·h(n) for all m,n, then growthRateConverges. The proof is a sorry marked as 'Fekete's subadditive lemma applied to log h'.\n\nFekete's lemma (1923): if f : ℕ → ℝ is subadditive (f(m+n) ≤ f(m)+f(n)), then lim f(n)/n exists and equals inf f(n)/n. Applied here: if h is submultiplicative, then log h is subadditive (log h(m+n) ≤ log(h(m)·h(n)) = log h(m) + log h(n)), so lim (log h(n))/n = inf (log h(n))/n exists.\n\nThe submultiplicativity of h is the key open structural question: does the covering number behave multiplicatively across scales? If covering an n-commuting group requires h(n) subgroups and an m-commuting group requires h(m), does an (m+n)-commuting group require at most h(m)·h(n)? This is a natural but non-obvious algebraic property.",
+    "mathContext": "Fekete (1923): $f: \\mathbb{N} \\to \\mathbb{R}$ subadditive ($f(m+n) \\leq f(m)+f(n)$) $\\Rightarrow$ $\\lim_{n\\to\\infty} f(n)/n = \\inf_{n\\geq 1} f(n)/n \\in [-\\infty, \\infty)$. Here: $h$ submultiplicative $\\Rightarrow$ $g = \\log \\circ h$ subadditive $\\Rightarrow$ $\\lim g(n)/n = \\lim \\frac{\\log h(n)}{n}$ exists. The sorry awaits Mathlib's `Subadditive.tendsto_div_atTop` or equivalent.",
+    "significance": "key",
+    "relatedConcepts": ["Fekete's subadditive lemma", "subadditive functions", "submultiplicative sequences", "liminf = inf for subadditive functions"],
+    "prerequisites": ["Fekete's lemma statement", "subadditive functions theory", "Lean sorry for open mathematical arguments"]
+  },
+  {
+    "id": "ann-e117-oq01-trivial-case",
+    "proofId": "erdos-117-oq-01",
+    "range": { "startLine": 192, "endLine": 197 },
+    "type": "theorem",
+    "title": "The Trivial Case and the Open Question Declaration",
+    "content": "The theorem growthRate_1 handles the edge case h(1) = 1 → growthRate(1) = 0. Since log(1) = 0, this is immediate from simp and Real.log_one. Mathematically, h(1) = 1 means a single abelian subgroup covers any 1-commuting group (any group where some pair commutes), which can be trivially satisfied by taking the whole group if it is abelian, or just the center.\n\nThe final definition erdos117OQ01 : Prop := exponentialBaseExists is the crisp formal statement of the open question. This pattern — defining the open problem as a named Prop — makes the open question a first-class mathematical object in Lean, enabling statements like 'X would follow from erdos117OQ01' to be formalized.",
+    "mathContext": "Boundary value: if $h(1) = 1$, then $r(1) = \\log(1)/1 = 0$. Note $0 < \\log c_1$, so the lower bound theorem gives $r(1) \\geq \\log c_1 > 0$ — but only for $h(1) \\geq c_1 > 1$. The condition $h(1) = 1$ means the 1-commuting case is trivial. The definition `erdos117OQ01 := exponentialBaseExists` packages Erdős Problem #117 OQ-01 as `∃ c > 1, Tendsto growthRate atTop (nhds (log c))`.",
+    "significance": "supporting",
+    "relatedConcepts": ["Real.log_one in Mathlib", "erdos117OQ01 proposition", "open problems as Lean Props", "boundary cases in analysis"],
+    "prerequisites": ["Real.log_one = 0", "Lean simp lemmas for log", "Prop definitions in Lean 4"]
   }
 ]

--- a/src/data/proofs/erdos-117-oq-01/meta.json
+++ b/src/data/proofs/erdos-117-oq-01/meta.json
@@ -28,14 +28,15 @@
     "lineCount": 204
   },
   "overview": {
-    "historicalContext": "**Pinning Down the Exponential Base**\n\nPyber's 1987 breakthrough showed that h(n) — the minimum number of abelian subgroups needed to cover groups with the n-commuting property — grows exponentially: c₁ⁿ ≤ h(n) ≤ c₂ⁿ for 1 < c₁ < c₂. But is the growth rate precise? Does log(h(n))/n converge to a single value?",
+    "historicalContext": "**Pinning Down the Exponential Base**\n\nErdős introduced the abelian covering number h(n) as part of his investigation of commutativity in finite groups. A group G has the n-commuting property if among any n+2 elements, at least two commute — or equivalently, G cannot be partitioned into n+1 pairwise non-commuting pairs. The covering number h(n) asks: what is the minimum size of a cover by abelian subgroups that works for all groups with this property?\n\nThe first exponential lower bound was proved by Isaacs in earlier work. Pyber's landmark 1987 paper established both exponential bounds c₁ⁿ ≤ h(n) ≤ c₂ⁿ with explicit constants satisfying c₂ > c₁ > 1. This settled the 'polynomial vs exponential' question but opened a new one: do the bounds converge to a single exponential base? Knowing the precise base c would give h(n) = Θ(cⁿ) — a clean asymptotic characterization.\n\nThe connection to Fekete's lemma (1923) provides a natural structural approach. Fekete's theorem states that subadditive functions f (with f(m+n) ≤ f(m)+f(n)) satisfy lim f(n)/n = inf f(n)/n. If h is submultiplicative (h(m+n) ≤ h(m)·h(n)), then log h is subadditive and the limit exists. The question of submultiplicativity of h is thus a key open structural problem.",
     "problemStatement": "**Problem Statement**\n\nDoes lim_{n→∞} log(h(n))/n exist?\n\nIf yes, h(n) = Θ(cⁿ) for c = e^L where L is the limit.\n\n**Status**: OPEN",
     "text": "Formalizes the question of whether the abelian covering number h(n) has a well-defined exponential growth rate.",
     "proofStrategy": "**Approach**\n\n1. Define growthRate(n) = log(h(n))/n\n2. Prove bounded from Pyber: log(c₁) ≤ growthRate(n) ≤ log(c₂)\n3. Define liminf/limsup\n4. State convergence as liminf = limsup\n5. Connect to Fekete's lemma via submultiplicativity",
     "keyInsights": [
-      "**Bounded growth rate**: Pyber's bounds immediately give log(c₁) ≤ log(h(n))/n ≤ log(c₂) for all n ≥ 1",
-      "**Fekete's lemma path**: If h is submultiplicative (h(m+n) ≤ h(m)·h(n)), then log h is subadditive and Fekete's lemma gives convergence",
-      "**Structural question**: Whether the limit exists reveals whether the covering number has a clean multiplicative structure across scales"
+      "**Bounded growth rate from Pyber**: The bounds c₁ⁿ ≤ h(n) ≤ c₂ⁿ immediately give log(c₁) ≤ log(h(n))/n ≤ log(c₂) for all n ≥ 1. The growth rate sequence is bounded in [log c₁, log c₂], so liminf and limsup both exist. The open question is whether they coincide.",
+      "**Fekete's lemma as the path forward**: If h is submultiplicative (h(m+n) ≤ h(m)·h(n)), then log h is subadditive. Fekete's classical lemma (1923) then guarantees lim log(h(n))/n = inf log(h(n))/n exists. The submultiplicativity question is the key open structural problem.",
+      "**Filter API formalization**: The use of Filter.liminf, Filter.limsup, and Filter.Tendsto with atTop in Lean 4 reflects Mathlib's abstract but powerful filter-based approach to limits, avoiding cumbersome ε-N quantifier chains.",
+      "**Open problems as Lean Props**: The declaration 'def erdos117OQ01 : Prop := exponentialBaseExists' makes the open question a first-class Lean object. Other theorems can formally depend on this Prop, enabling 'assuming Erdős #117-OQ-01, then...' arguments to be machine-checked."
     ],
     "prerequisites": [
       "Group theory: abelian subgroups, covering numbers",


### PR DESCRIPTION
## Three enrichment passes

### 1. inverse-galois-oq-02 (Mathieu group M₂₃)
- Added 9 annotations (was empty); coverage: all 9 code sections
- Topics: M₂₃ axioms, order factorization, non-primality chain, non-abelian→perfect, non-solvable, Shafarevich barrier, open problem + rigidity obstruction, Sylow structure, sporadic census
- Expanded conclusion: negative result scenario, 4 proof approaches, 4th open question

### 2. cramers-rule-oq-01-oq-03 (Cramer vs Gaussian complexity)
- Replaced 3 malformed annotations (wrong body field, bad start lines) with 7 proper ones
- Topics: Leibniz formula defs, det formula, cramer ops + bound, Gaussian O(n³) proof, factorial_ge_cube, exact counts n=1-4, single-component Cramer
- Expanded historicalContext with Cramer 1750, Gauss, Chinese Nine Chapters, 20th-century context
- Expanded keyInsights from 3 to 5

### 3. erdos-117-oq-01 (Exponential growth rate of abelian covering number)
- Replaced 2 malformed annotations (body field, missing mathContext) with 7 proper ones
- Topics: Pyber's 3 axioms, growthRate def + lower bound, upper bound, liminf/limsup via Filter API, open question defs + limit_determines_base, Fekete's lemma + submultiplicativity, trivial case + open Prop
- Expanded historicalContext: Erdős problem context, Isaacs' earlier bound, Pyber 1987, Fekete 1923
- Expanded keyInsights from 3 to 4

All annotations have: mathContext (LaTeX), significance, relatedConcepts, prerequisites