### PR TITLE
Fix: convert True-stub theorems to comments in 4 Erdős proofs

### DIFF
--- a/proofs/Proofs/Erdos1049Problem.lean
+++ b/proofs/Proofs/Erdos1049Problem.lean
@@ -264,9 +264,10 @@ theorem S_as_lambert (t : ℝ) (ht : t > 1) :
   sorry
 
 /-- Lambert series preserve arithmetic structure. -/
-theorem lambert_arithmetic_property :
-    -- Lambert series of arithmetic functions have special properties
-    True := trivial
+/-
+  Lambert series of arithmetic functions have special properties
+  (e.g. Dirichlet series convolution structure at the level of coefficients).
+-/
 
 /-
 ## Part IX: Partial Results
@@ -275,14 +276,15 @@ What is known towards Chowla's conjecture.
 -/
 
 /-- S(p/q) is irrational for certain p/q (partial results). -/
-theorem partial_rational_results :
-    -- Some specific rational values have been verified
-    True := trivial
+/-
+  S(p/q) is irrational for certain p/q (partial results toward Chowla's conjecture).
+  Some specific rational values have been verified.
+-/
 
-/-- Linear independence results. -/
-theorem linear_independence_partial :
-    -- Partial results on linear independence of S values
-    True := trivial
+/-
+  Partial results on linear independence of S values over ℚ:
+  certain finite sets {S(r₁), ..., S(rₖ)} are known to be linearly independent.
+-/
 
 /-- Approximation bounds for S(t). -/
 theorem S_bounds (t : ℝ) (ht : t > 1) :

--- a/proofs/Proofs/Erdos1081Problem.lean
+++ b/proofs/Proofs/Erdos1081Problem.lean
@@ -273,10 +273,11 @@ distributed. They cluster in ways that create more sums than expected.
 Specifically, numbers of the form a² and b³ for small a, b contribute
 disproportionately to sums.
 -/
-theorem heuristic_failure_explanation :
-  -- The set of squarefull numbers has multiplicative structure
-  -- that increases the sum count beyond naive predictions
-  True := trivial
+/-
+  The heuristic fails because squarefull numbers are not uniformly distributed:
+  the multiplicative structure of the set {a² : a ∈ ℕ} ∪ {b³ : b ∈ ℕ}
+  creates more pairwise sums than a naive probabilistic argument predicts.
+-/
 
 /-
 ## Part VIII: Connection to Quadratic Forms
@@ -290,10 +291,11 @@ with large discriminant.
 Key insight: Representing n as a sum of two squarefull numbers is
 related to representing n by quadratic forms.
 -/
-theorem quadratic_form_connection :
-  -- The count A(x) is controlled by representation numbers
-  -- of binary quadratic forms
-  True := trivial
+/-
+  Blomer-Granville's approach: counting sums of two squarefull numbers ≤ x
+  is controlled by representation numbers of binary quadratic forms
+  with large discriminant.
+-/
 
 /-
 ## Part IX: Summary

--- a/proofs/Proofs/Erdos575Problem.lean
+++ b/proofs/Proofs/Erdos575Problem.lean
@@ -71,19 +71,19 @@ The exact order is typically a fractional power of n. -/
 
 /-- ex(n; F) ≤ ex(n; G) for any G ∈ F: excluding more graphs can
 only reduce the extremal function. -/
-theorem exFamily_le_member :
-  -- Adding more forbidden graphs reduces the maximum edge count
-  True := trivial
+/-
+  ex(n; F) ≤ ex(n; G) for any G ∈ F: adding more forbidden graphs
+  reduces the maximum edge count (monotonicity of the extremal function).
+-/
 
-/-- If F contains a bipartite graph, then ex(n; F) = o(n²):
-the family extremal function is subquadratic. -/
-theorem family_with_bipartite_subquadratic :
-  -- Follows from the Kővári–Sós–Turán bound on the bipartite member
-  True := trivial
+/-
+  If F contains a bipartite graph, then ex(n; F) = o(n²):
+  the family extremal function is subquadratic.
+  Follows from the Kővári–Sós–Turán bound on the bipartite member.
+-/
 
-/-- The conjecture implies that for families with a bipartite member,
-the asymptotic behavior of ex(n; F) is controlled by a single
-bipartite graph in the family. -/
-theorem single_graph_controls :
-  -- This is the precise content of Erdős Problem #575
-  True := trivial
+/-
+  The conjecture (Erdős Problem #575) asserts that for families with
+  a bipartite member, the asymptotic behavior of ex(n; F) is controlled
+  by a single bipartite graph in the family.
+-/

--- a/proofs/Proofs/Erdos606OQ03.lean
+++ b/proofs/Proofs/Erdos606OQ03.lean
@@ -37,9 +37,10 @@ theorem max_hyperplanes (n d : ℕ) (hd : d ≥ 1) :
 
 /-- In general position (no d+1 points on a hyperplane),
     n points determine exactly C(n,d) hyperplanes. -/
-theorem general_position_count (n d : ℕ) :
-    -- exactly C(n,d) hyperplanes for n points in general position
-    True := trivial
+/-
+  In general position (no d+1 points on a hyperplane),
+  n points determine exactly C(n,d) hyperplanes.
+-/
 
 -- ============================================================
 -- Part II: The Sylvester-Gallai Theorem


### PR DESCRIPTION
## Fix

Converted narrative theorems proving \`True := trivial\` to block comments in 4 Erdős proof files. These theorems provided no mathematical content — their meaning was already captured in the surrounding docstring comments.

## Evidence

**erdos-575** (Erdős #575 — Family Extremal Functions):
- `exFamily_le_member` → comment
- `family_with_bipartite_subquadratic` → comment
- `single_graph_controls` → comment

**erdos-606-oq-03** (Erdős #606 OQ-03 — Higher-Dimensional Sylvester-Gallai):
- `general_position_count` → comment

**erdos-1049** (Erdős #1049 — Chowla's Conjecture):
- `lambert_arithmetic_property` → comment
- `partial_rational_results` → comment
- `linear_independence_partial` → comment

**erdos-1081** (Erdős #1081 — Squarefull Number Sums):
- `heuristic_failure_explanation` → comment
- `quadratic_form_connection` → comment

**After**: 9 True-stub theorems removed. No sorries, axioms, or mathematical content affected. All docstring text preserved as block comments.

---
Automated fix by lean-mechanic agent.