### PR TITLE
Fix: convert True-stub theorems to comments in 5 more proofs

### DIFF
--- a/proofs/Proofs/Erdos181Problem.lean
+++ b/proofs/Proofs/Erdos181Problem.lean
@@ -222,8 +222,11 @@ This question is OPEN. Note:
   so R(Q_n) / 2^n ≤ C · 2^{(1-c)n}, which still → ∞.
   The question remains unresolved.
 -/
-theorem erdos_sos_question_open :
-  True := trivial -- This question is genuinely OPEN; we do not assert either direction
+/-
+  The question of whether R(Q_n) / 2^n → ∞ is genuinely OPEN.
+  The conjecture (erdos_181_conjecture) would imply R(Q_n)/2^n is BOUNDED,
+  but current bounds (Tikhomirov) leave this unresolved.
+-/
 
 /-- The conjecture answers Erdős-Sós negatively: R(Q_n)/2^n is bounded. -/
 theorem conjecture_implies_bounded_ratio :

--- a/proofs/Proofs/Erdos396Problem.lean
+++ b/proofs/Proofs/Erdos396Problem.lean
@@ -53,16 +53,15 @@ theorem n_divides_rarely :
 /-- Pomerance: the set of n with (n−k) | C(2n, n) has upper density < 1/3.
     The measure-theoretic statement requires density infrastructure;
     the existential structure here is a placeholder. -/
-theorem pomerance_density_bound (k : ℕ) :
-  -- Upper density of {n : (n−k) | C(2n,n)} is less than 1/3
-  True := trivial
+/-
+  Pomerance: the upper density of {n : (n−k) | C(2n,n)} is less than 1/3.
+  Measure-theoretic statement requires density infrastructure.
+-/
 
-/-- Pomerance: the set of n with ∏(n+i) | C(2n, n) for i=1..k has density 1.
-    The measure-theoretic statement requires density infrastructure;
-    the existential structure here is a placeholder. -/
-theorem pomerance_ascending_density (k : ℕ) :
-  -- {n : ascFactorial(n+1, k) | C(2n,n)} has asymptotic density 1
-  True := trivial
+/-
+  Pomerance: the set {n : ∏_{i=1}^{k}(n+i) | C(2n,n)} has asymptotic density 1.
+  Measure-theoretic statement requires density infrastructure.
+-/
 
 /- ## The Erdős–Graham Conjecture -/
 

--- a/proofs/Proofs/Erdos698Problem.lean
+++ b/proofs/Proofs/Erdos698Problem.lean
@@ -241,17 +241,21 @@ The GCD of binomial coefficients relates to:
 The largest power of prime p dividing C(m+n, m) equals
 the number of carries in adding m and n in base p.
 -/
-theorem kummer_theorem (p m n : ℕ) (hp : p.Prime) :
-  -- The p-adic valuation relates to carry count (placeholder)
-  True := trivial
+/-
+  Kummer's Theorem: the p-adic valuation of C(m+n, m) equals
+  the number of carries when adding m and n in base p.
+  (Placeholder — full Lean proof requires digit-carry formalization.)
+-/
 
 /--
 **Lucas' Theorem:**
 C(m, n) mod p can be computed from base-p digits of m and n.
 -/
-theorem lucas_theorem (p m n : ℕ) (hp : p.Prime) :
-  -- Modular reduction of binomial coefficients (placeholder)
-  True := trivial
+/-
+  Lucas' Theorem: C(m, n) mod p can be computed digit-by-digit
+  from the base-p representations of m and n.
+  (Placeholder — Mathlib has Nat.choose_symm_diff for related results.)
+-/
 
 /-
 ## Part IX: Summary

--- a/proofs/Proofs/Erdos755Problem.lean
+++ b/proofs/Proofs/Erdos755Problem.lean
@@ -199,10 +199,10 @@ In the Lenz construction:
 
 The constant 1/27 = 1/3³ arises from partitioning n points into 3 groups.
 -/
-theorem why_one_27th :
-  -- The 1/27 comes from optimally distributing n points into 3 groups
-  -- Each group contributes equally to the count
-  True := trivial
+/-
+  The 1/27 constant arises from optimally distributing n points into 3 equal groups:
+  the triangle count is maximized at (n/3)³ = n³/27 (leading term).
+-/
 
 /-
 ## Part VIII: Related Results
@@ -217,9 +217,10 @@ theorem why_one_27th :
 
 The jump to cubic growth at d = 6 is significant.
 -/
-theorem dimension_behavior :
-  -- d = 2: linear, d = 3: quadratic, d ≥ 6: cubic
-  True := trivial
+/-
+  Dimension-dependent growth: T₂(n) ≤ n (linear), T₃(n) = Θ(n²) (quadratic),
+  T_d(n) = Θ(n³) for d ≥ 6 even. The jump to cubic growth at d = 6 is significant.
+-/
 
 /-
 ## Part IX: Summary

--- a/proofs/Proofs/Hilbert14NonReductive.lean
+++ b/proofs/Proofs/Hilbert14NonReductive.lean
@@ -313,11 +313,11 @@ theorem reductive_subgroup_grosshans (G : Type*) [Group G] (H : Subgroup G)
     The same non-reductive group can have fg invariants for some representations
     and non-fg for others. The characterization is representation-dependent
     (Grosshans's theorem gives the embedding-dependent answer). -/
-theorem characterization_summary :
-    -- The characterization is:
-    -- 1. Reductive → always fg (proven)
-    -- 2. Non-reductive → depends on representation (Grosshans criterion)
-    -- 3. No purely group-theoretic characterization exists
-    True := trivial
+/-
+  Summary of Hilbert 14 characterization:
+  1. Reductive → invariant ring always finitely generated (proven, Hilbert's theorem)
+  2. Non-reductive → finite generation depends on the representation (Grosshans criterion)
+  3. No purely group-theoretic characterization exists — it is representation-dependent
+-/
 
 end Hilbert14.NonReductive


### PR DESCRIPTION
## Fix

Converted narrative theorems proving `True := trivial` to block comments in 5 proof files. These theorems provided no mathematical content — the substance was in surrounding docstrings.

## Evidence

**erdos-181** (Erdős #181 — Ramsey Numbers for Hypercubes):
- `erdos_sos_question_open` → comment (open question, no assertion possible)

**erdos-396** (Erdős #396 — Pomerance on Binomial Coefficients):
- `pomerance_density_bound` → comment
- `pomerance_ascending_density` → comment

**erdos-755** (Erdős #755 — Triangles in 6-uniform Hypergraphs):
- `why_one_27th` → comment
- `dimension_behavior` → comment

**erdos-698** (Erdős #698 — Kummer/Lucas for Binomial Divisibility):
- `kummer_theorem` → comment
- `lucas_theorem` → comment

**hilbert-14-non-reductive** (Hilbert 14 — Non-Reductive Invariant Rings):
- `characterization_summary` → comment

**After**: 8 True-stub theorems removed. No sorries, axioms, or mathematical content affected.

---
Automated fix by lean-mechanic agent.