### PR TITLE
Fix: convert True-stub theorems to comments in 5 more proofs

### DIFF
--- a/proofs/Proofs/DenumerabilityRationalsOQ04.lean
+++ b/proofs/Proofs/DenumerabilityRationalsOQ04.lean
@@ -115,11 +115,12 @@ theorem algebraic_countable_type :
 
     In particular, we never need to "choose" a root — we just
     know the root set is finite, which suffices for countability. -/
-theorem choiceless_note :
-    -- The proof is constructive in the sense that it avoids
-    -- the full axiom of choice. Lean's Prop-valued choice
-    -- (which is a theorem, not an axiom) suffices.
-    True := trivial
+/-
+  The proof is constructive: it avoids the full axiom of choice.
+  Lean's Prop-valued choice (which is a theorem, not an axiom) suffices
+  because we never need to pick a canonical root — knowing the root set
+  is finite is enough for countability.
+-/
 
 /-
   Summary

--- a/proofs/Proofs/DissectionOfCubesOQ02OQ02.lean
+++ b/proofs/Proofs/DissectionOfCubesOQ02OQ02.lean
@@ -333,9 +333,12 @@ This is axiomatized because the sufficiency proof requires:
   - Analysis of orthogonal prisms and their Dehn invariants
   - An exchange lemma for polyhedral decompositions
   - Induction on the tensor product structure -/
-theorem dehn_sydler_theorem :
-    -- The statement: ∀ P Q, scissors_congruent P Q ↔ Vol P = Vol Q ∧ D P = D Q
-    True := trivial
+/-
+  Dehn-Sydler theorem (axiomatized): two polyhedra are scissors-congruent iff
+  they have equal volume AND equal Dehn invariant.
+  ∀ P Q, scissors_congruent P Q ↔ Vol P = Vol Q ∧ D P = D Q.
+  (Backward direction is Sydler 1965; requires deep polyhedral decomposition theory.)
+-/
 
 -- ========================================================================
 -- Part XI: 2D Contrast and Consequences

--- a/proofs/Proofs/Erdos1165Problem.lean
+++ b/proofs/Proofs/Erdos1165Problem.lean
@@ -152,10 +152,11 @@ directly part of the problem statement.
     visit count is achieved at a unique site almost surely.
     This motivates the 2D question: in higher dimensions, the
     structure of favourite sites becomes more complex. -/
-theorem bass_griffin_1d_unique :
-  True := trivial  -- P(|F_1D(n)| = 1 for all large n) = 1
-
-theorem bass_griffin_context : True := bass_griffin_1d_unique
+/-
+  Bass-Griffin (1985): In 1D, for large n, the favourite site is unique almost surely.
+  Formally: P(|F_1D(n)| = 1 for all sufficiently large n) = 1.
+  This motivates the 2D question about the structure of favourite sites.
+-/
 
 /- ## Summary
 

--- a/proofs/Proofs/Erdos435Problem.lean
+++ b/proofs/Proofs/Erdos435Problem.lean
@@ -146,8 +146,10 @@ example : ¬IsPrimePower 6 := by
 If n = p^k, then C(n, p^j) ≡ 0 (mod p) for appropriate j,
 making the representation problem degenerate.
 -/
-theorem prime_power_degenerate (n : ℕ) (hPP : IsPrimePower n) :
-    True := trivial  -- The formula doesn't apply to prime powers
+/-
+  Prime power case: if n = p^k, then C(n, p^j) ≡ 0 (mod p) for appropriate j,
+  making the Frobenius representation problem degenerate (the formula doesn't apply).
+-/
 
 /-
 **Lucas' Theorem Connection:**
@@ -178,8 +180,11 @@ For n not a prime power, gcd{C(n,1), C(n,2), ..., C(n,n-1)} = 1
 For coprime a, b, the largest non-representable integer is ab - a - b.
 This is the 2-generator case.
 -/
-theorem classical_frobenius (a b : ℕ) (ha : a > 0) (hb : b > 0) (hcop : Nat.Coprime a b) :
-    True := trivial  -- Sylvester-Frobenius formula (placeholder body)
+/-
+  Classical Frobenius (Sylvester-Frobenius formula): for coprime a, b > 0,
+  the largest integer not representable as xa + yb (x, y ≥ 0) is ab - a - b.
+  (Placeholder — Lean proof requires arithmetic with Nat.Coprime and combinatorics.)
+-/
 
 /-
 **Sylvester-Denumerant:**

--- a/proofs/Proofs/Erdos649Problem.lean
+++ b/proofs/Proofs/Erdos649Problem.lean
@@ -196,8 +196,11 @@ The failure is not just for (2, 7) - there are infinitely many failing pairs.
 If 2 is a primitive root modulo prime q > 2, then there are constraints on
 which primes p can satisfy P(n) = p, P(n+1) = q.
 -/
-theorem primitive_root_obstruction (_p _q : ℕ) (_hp : _p.Prime) (_hq : _q.Prime) :
-    True := trivial
+/-
+  Primitive Root Obstruction: if 2 is a primitive root mod prime q > 2,
+  there are constraints (via the Legendre symbol) on which primes p can
+  satisfy P(n) = p and P(n+1) = q simultaneously.
+-/
 
 /--
 **Tong's Theorem:**
@@ -293,9 +296,11 @@ The deeper reason for the counterexamples.
 If P(n) = p (so n is a p-smooth number times a power of p),
 and P(n+1) = q, this imposes constraints via the Legendre symbol.
 -/
-theorem quadratic_residue_constraint (_p _q : ℕ) (_hp : _p.Prime) (_hq : _q.Prime)
-    (_hpq : _p ≠ _q) :
-    True := trivial
+/-
+  Quadratic Residue Constraint: if P(n) = p and P(n+1) = q (distinct primes),
+  this imposes constraints via the Legendre symbol (quadratic residue conditions
+  on the relationship between p and q).
+-/
 
 /--
 **Order of 2 modulo 7:**


### PR DESCRIPTION
## Fix

Converted narrative theorems proving `True := trivial` to block comments in 5 more proof files. Mathematical content preserved as prose.

## Evidence

**denumerability-rationals-oq-04**:
- `choiceless_note` → comment (choiceless proof structure explanation)

**dissection-of-cubes-oq-02-oq-02**:
- `dehn_sydler_theorem` → comment (full Dehn-Sydler equivalence statement)

**erdos-1165** (Favourite Sites of 2D Random Walk):
- `bass_griffin_1d_unique` → comment (P(|F_1D(n)| = 1 for large n) = 1)
- `bass_griffin_context` → merged into same comment

**erdos-435** (Erdős #435 — Binomial Frobenius):
- `prime_power_degenerate` → comment
- `classical_frobenius` → comment (Sylvester-Frobenius formula)

**erdos-649** (Erdős #649 — Consecutive Prime Largest Factors):
- `primitive_root_obstruction` → comment
- `quadratic_residue_constraint` → comment

**After**: 8 True-stub theorems removed. No sorries, axioms, or mathematical content affected.

---
Automated fix by lean-mechanic agent.