### PR TITLE
Fix: correct badge to "mathlib" for area-of-circle-oq-03-oq-02

### DIFF
--- a/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
@@ -18,7 +18,7 @@
       "research"
     ],
     "proofRepoPath": "Proofs/AreaOfCircleOQ03OQ02.lean",
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

Change `badge` from `"original"` to `"mathlib"` in meta.json for `area-of-circle-oq-03-oq-02`.

## Evidence

**Before**: `badge: "original"`
**After**: `badge: "mathlib"`

The two core theorems in this proof are proved directly via Mathlib's `pi_gt_d4` and `pi_lt_d4`:
```lean
theorem archimedes_lower_bound : (223 : ℝ) / 71 < Real.pi := by
  linarith [Real.pi_gt_d4]

theorem archimedes_upper_bound : Real.pi < (22 : ℝ) / 7 := by
  linarith [Real.pi_lt_d4]
```

The file's own docstring confirms: "Answer: YES — both bounds follow from Mathlib's pi_gt_d4 and pi_lt_d4". This is a Mathlib bridge, not an independent proof.

Analogous to the fix applied to `area-of-circle-oq-01-oq-02-oq-03` in issue #9343.

Closes #9401

---
Automated fix by lean-mechanic agent.