### PR TITLE
Fix: convert True-stub theorems to comments in 5 gallery proofs

### DIFF
--- a/proofs/Proofs/CantorDiagonalizationOQ01OQ01.lean
+++ b/proofs/Proofs/CantorDiagonalizationOQ01OQ01.lean
@@ -220,18 +220,15 @@ Key facts:
 The question remains one of the deepest open problems in set theory.
 -/
 
-/-- Martin's Axiom is compatible with both CH and ¬CH. -/
-theorem martins_axiom_neutral_on_ch :
-    -- MA is consistent with CH
-    True ∧
-    -- MA + ¬CH is also consistent
-    True := ⟨trivial, trivial⟩
+/-
+  Martin's Axiom is compatible with both CH and ¬CH:
+  MA is consistent with CH, and MA + ¬CH is also consistent.
+-/
 
-/-- PFA (Proper Forcing Axiom) implies ¬CH: 2^ℵ₀ = ℵ₂ under PFA.
-    This is a theorem of Todorcevic and Velickovic. -/
-theorem pfa_implies_not_ch :
-    True  -- Placeholder: PFA → 2^ℵ₀ = ℵ₂
-  := trivial
+/-
+  PFA (Proper Forcing Axiom) implies ¬CH: 2^ℵ₀ = ℵ₂ under PFA.
+  This is a theorem of Todorcevic and Velickovic.
+-/
 
 /-
 ═══════════════════════════════════════════════════════════════════════════════

--- a/proofs/Proofs/Erdos1077Problem.lean
+++ b/proofs/Proofs/Erdos1077Problem.lean
@@ -125,10 +125,11 @@ The correct answer is m ≈ n^α vertices:
 
     Lower bound: Jiang-Longbrake show 6-balanced subgraphs exist.
     Upper bound: Complete bipartite graphs show this is tight. -/
-theorem erdos_1077_resolution :
-    -- The original conjecture is false (answer is False, not True)
-    True := by
-  trivial
+/-
+  Erdős #1077 Resolution: The original conjecture is false.
+  The optimal number of vertices in a guaranteed D-balanced subgraph
+  of a graph with n^{1+α} edges is Θ(n^α) (Jiang-Longbrake 2025).
+-/
 
 /- ## Notes on the Problem Statement
 

--- a/proofs/Proofs/Erdos318Problem.lean
+++ b/proofs/Proofs/Erdos318Problem.lean
@@ -311,8 +311,11 @@ theorem erdos_318_summary :
 - Positive density: SOLVED (NO, counterexamples exist)
 - Squares: OPEN (announced proof never appeared)
 -/
-theorem erdos_318_status :
-  True  -- Recording the mixed status
-  := trivial
+/-
+  Problem Status (mixed):
+  - Arithmetic progressions: SOLVED (YES, Sattler 1982)
+  - Positive density: SOLVED (NO, counterexamples exist)
+  - Squares: OPEN (announced proof never appeared)
+-/
 
 end Erdos318

--- a/proofs/Proofs/FairGamesTheorem.lean
+++ b/proofs/Proofs/FairGamesTheorem.lean
@@ -105,13 +105,12 @@ def isFairGame {Ω : Type*} {m : MeasurableSpace Ω}
     (μ : MeasureTheory.Measure Ω) : Prop :=
   MeasureTheory.Martingale f ℱ μ
 
-/-- Example: A sequence of fair coin flips accumulated into cumulative sum
-    forms a martingale. If each flip has E[flip] = 0, then E[cumulative sum] = 0
-    regardless of when we stop. -/
-theorem fair_coin_flip_martingale_property :
-    -- For any fair game (martingale), the expected value at any time n
-    -- equals the expected initial value
-    True := by trivial
+/-
+  Example: A sequence of fair coin flips accumulated into cumulative sum
+  forms a martingale. If each flip has E[flip] = 0, then E[cumulative sum] = 0
+  regardless of when we stop. For any fair game (martingale), the expected value
+  at any time n equals the expected initial value.
+-/
 
 end MartingaleDefinitions
 

--- a/proofs/Proofs/Hilbert11_QuadraticForms.lean
+++ b/proofs/Proofs/Hilbert11_QuadraticForms.lean
@@ -372,12 +372,10 @@ def BrauerManinObstruction (X : Type*) : Prop :=
   -- There exists a Brauer class that obstructs rational points
   True -- Full definition requires algebraic geometry
 
-/-- For quadratic forms, the Brauer-Manin obstruction is the only obstruction. -/
-theorem quadratic_forms_brauer_manin_only :
-    -- For quadratic forms, the Brauer-Manin obstruction vanishes,
-    -- so Hasse-Minkowski holds
-    True := by
-  trivial
+/-
+  For quadratic forms, the Brauer-Manin obstruction is the only obstruction.
+  The Brauer-Manin obstruction vanishes, so Hasse-Minkowski holds.
+-/
 
 /-! ═══════════════════════════════════════════════════════════════════════════════
 PART VIII: EXTENSIONS TO NUMBER FIELDS


### PR DESCRIPTION
## Fix

Convert `theorem X : True := trivial` placeholders to block comments in 5 gallery proof files.

## Evidence

**Before**: Theorems with `True` return type that provide no mathematical content
**After**: Block comments documenting the intended content

## Files Changed

- `FairGamesTheorem.lean`: `fair_coin_flip_martingale_property : True` → comment
- `CantorDiagonalizationOQ01OQ01.lean`: `martins_axiom_neutral_on_ch : True ∧ True` + `pfa_implies_not_ch : True` → comments
- `Hilbert11_QuadraticForms.lean`: `quadratic_forms_brauer_manin_only : True` → comment
- `Erdos318Problem.lean`: `erdos_318_status : True` → comment
- `Erdos1077Problem.lean`: `erdos_1077_resolution : True` → comment

Follows the same pattern as PRs #9389, #9393-9398.

---
Automated fix by lean-mechanic agent.