### PR TITLE
Fix: correct badge from 'axiom' to 'wip' for 7 Erdős proofs

### DIFF
--- a/src/data/proofs/erdos-1003/meta.json
+++ b/src/data/proofs/erdos-1003/meta.json
@@ -17,7 +17,7 @@
       "asymptotic-density",
       "open-problem"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 1003,
     "erdosUrl": "https://erdosproblems.com/1003",

--- a/src/data/proofs/erdos-1041/meta.json
+++ b/src/data/proofs/erdos-1041/meta.json
@@ -17,7 +17,7 @@
       "level-sets",
       "paths"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 1041,
     "erdosUrl": "https://erdosproblems.com/1041",

--- a/src/data/proofs/erdos-1060/meta.json
+++ b/src/data/proofs/erdos-1060/meta.json
@@ -15,7 +15,7 @@
       "counting-solutions",
       "open-problem"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 1060,
     "erdosUrl": "https://erdosproblems.com/1060",

--- a/src/data/proofs/erdos-1062/meta.json
+++ b/src/data/proofs/erdos-1062/meta.json
@@ -14,7 +14,7 @@
       "extremal-combinatorics",
       "divisibility"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 1062,
     "erdosUrl": "https://erdosproblems.com/1062",

--- a/src/data/proofs/erdos-1068/meta.json
+++ b/src/data/proofs/erdos-1068/meta.json
@@ -15,7 +15,7 @@
       "chromatic-number",
       "infinite-connectivity"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 1068,
     "erdosUrl": "https://erdosproblems.com/1068",

--- a/src/data/proofs/erdos-1071/meta.json
+++ b/src/data/proofs/erdos-1071/meta.json
@@ -15,7 +15,7 @@
       "packing",
       "maximal-independent-set"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 1071,
     "erdosUrl": "https://erdosproblems.com/1071",

--- a/src/data/proofs/erdos-1095/meta.json
+++ b/src/data/proofs/erdos-1095/meta.json
@@ -17,7 +17,7 @@
       "smooth-numbers",
       "open-problem"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 1095,
     "erdosUrl": "https://erdosproblems.com/1095",


### PR DESCRIPTION
## Fix

Correct `badge` from `"axiom"` to `"wip"` for 7 Erdős proof entries where the `assumptions` field explicitly documented that the badge was updated but the change was not applied to the JSON.

## Evidence

Each of these 7 entries has:
- `axiomCount: 0` (no actual axiom declarations in the Lean file)
- `sorries: 0` (no sorries remaining)
- `badge: "axiom"` (incorrect per the documented intent)
- `assumptions` field containing phrases like "badge updated from 'axiom' to 'wip'"

The `badge: "axiom"` is misleading because there are no axiom declarations or structure-encoded assumptions in these files.

## Files Changed

- `erdos-1062/meta.json`: badge axiom → wip
- `erdos-1041/meta.json`: badge axiom → wip  
- `erdos-1071/meta.json`: badge axiom → wip
- `erdos-1003/meta.json`: badge axiom → wip
- `erdos-1095/meta.json`: badge axiom → wip
- `erdos-1068/meta.json`: badge axiom → wip
- `erdos-1060/meta.json`: badge axiom → wip

---
Automated fix by lean-mechanic agent.