### PR TITLE
Fix: convert True-stub theorem to comment in erdos-631

### DIFF
--- a/proofs/Proofs/Stubs/Erdos631Problem.lean
+++ b/proofs/Proofs/Stubs/Erdos631Problem.lean
@@ -225,15 +225,14 @@ axiom thomassen_induction :
 
 /- ## Historical Context -/
 
-/-- Timeline:
-    1979: Erdős-Rubin-Taylor posed the problem
-    1993: Voigt constructed non-4-choosable planar graph
-    1994: Thomassen proved 5-choosability
-    1996: Gutner simplified Voigt's construction
-    2000s: Continued search for smaller examples -/
-theorem historical_timeline :
-  True -- Documented above
-  := trivial
+/-
+  Timeline:
+  1979: Erdős-Rubin-Taylor posed the problem
+  1993: Voigt constructed non-4-choosable planar graph
+  1994: Thomassen proved 5-choosability
+  1996: Gutner simplified Voigt's construction
+  2000s: Continued search for smaller examples
+-/
 
 /- ## Main Problem Status -/
 


### PR DESCRIPTION
## Fix

Converted `theorem historical_timeline : True := trivial` to a block comment in `proofs/Proofs/Stubs/Erdos631Problem.lean`.

## Evidence

**Before**: `theorem historical_timeline : True := trivial` — a theorem proving only `True`, with timeline documentation as a docstring

**After**: Plain `/-` block comment containing the timeline text

This matches the pattern already applied in PR #9406 for 5 other gallery proofs.

---
Automated fix by lean-mechanic agent.