### PR TITLE
Fix: correct badge/axiomCount for 5 proofs with wip/axiom mismatch

### DIFF
--- a/src/data/proofs/erdos-220/meta.json
+++ b/src/data/proofs/erdos-220/meta.json
@@ -17,7 +17,7 @@
       "gaps",
       "solved"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 2,
     "erdosNumber": 220,
     "erdosUrl": "https://erdosproblems.com/220",

--- a/src/data/proofs/erdos-395-oq-01/meta.json
+++ b/src/data/proofs/erdos-395-oq-01/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/395",
     "erdosProblemStatus": "open-question",
     "dateAdded": "2026-03-29",
-    "axiomCount": 2,
+    "axiomCount": 0,
     "lineCount": 161,
     "prerequisites": [
       "Erdős Problem #395 parent formalization",

--- a/src/data/proofs/erdos-625/meta.json
+++ b/src/data/proofs/erdos-625/meta.json
@@ -17,7 +17,7 @@
       "open-problem",
       "prize"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 20,
     "erdosNumber": 625,
     "erdosUrl": "https://erdosproblems.com/625",

--- a/src/data/proofs/erdos-644/meta.json
+++ b/src/data/proofs/erdos-644/meta.json
@@ -18,7 +18,7 @@
       "Helly-type",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 18,
     "erdosNumber": 644,
     "erdosUrl": "https://erdosproblems.com/644",

--- a/src/data/proofs/erdos-671/meta.json
+++ b/src/data/proofs/erdos-671/meta.json
@@ -17,7 +17,7 @@
       "lebesgue-function",
       "open"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 23,
     "erdosNumber": 671,
     "erdosUrl": "https://erdosproblems.com/671",


### PR DESCRIPTION
## Fix

Two complementary corrections:

1. **badge wip → axiom** for 4 proofs that have actual `axiom` declarations in Lean source but badge showing `wip` instead of `axiom`
2. **axiomCount correction** for 1 proof where axioms were eliminated (converted to theorems) but meta.json wasn't updated

## Evidence

**Before → After:**

| Proof | badge | axiomCount | Issue |
|-------|-------|------------|-------|
| erdos-220 | wip → axiom | 4 | 4 axiom decls present; badge=wip incorrect |
| erdos-625 | wip → axiom | 2 | 2 axiom decls present; badge=wip incorrect |
| erdos-644 | wip → axiom | 3 | 3 axiom decls present; badge=wip incorrect |
| erdos-671 | wip → axiom | 3 | 3 axiom decls present; badge=wip incorrect |
| erdos-395-oq-01 | wip (correct) | 2 → 0 | Axioms eliminated via `erdos_original_is_false` theorem proof; stale axiomCount |

Per CLAUDE.md policy: `axiom` badge is required when `axiom` declarations OR structure-encoded assumptions are present.

---
Automated fix by lean-mechanic agent.