### PR TITLE
feat: exact factorial check count formula + bound cleanup (Erdős 1059 OQ-01)

### DIFF
--- a/proofs/Proofs/Erdos1059OQ01.lean
+++ b/proofs/Proofs/Erdos1059OQ01.lean
@@ -20,6 +20,8 @@ So almost all large primes satisfy the property.
 6. `qualifyingPrimeCount_mono`: C(x) is monotone
 7. `factorialCheckCount_mono`: check count is monotone
 8. `factorialCheckCount_le_log`: factorialCheckCount n ≤ ⌊log₂ n⌋ + 2 (formalizes density heuristic)
+9. `factorialCheckCount_eq_of_interval`: exact count = l+1 when l! < n ≤ (l+1)!
+10. `factorialCheckCount_const_on_interval`: count is constant within each factorial level
 
 **Axiom** (1): `density_one_conjecture` — density equals 1
 
@@ -173,7 +175,7 @@ private lemma two_pow_pred_le_factorial {k : ℕ} (hk : 1 ≤ k) : 2^(k-1) ≤ k
 
 /-- If 2^m < n (and n ≥ 2), then m ≤ Nat.log 2 n.
     Proof: if m > log₂ n then 2^m ≥ 2^(log₂ n + 1) > n by Nat.lt_pow_succ_log_self. -/
-private lemma le_log_of_pow_lt {m n : ℕ} (hn : 2 ≤ n) (h : 2^m < n) : m ≤ Nat.log 2 n := by
+private lemma le_log_of_pow_lt {m n : ℕ} (h : 2^m < n) : m ≤ Nat.log 2 n := by
   by_contra hlt
   push_neg at hlt
   have hlt' : Nat.log 2 n + 1 ≤ m := hlt
@@ -181,7 +183,7 @@ private lemma le_log_of_pow_lt {m n : ℕ} (hn : 2 ≤ n) (h : 2^m < n) : m ≤ 
   have h2 : 2^(Nat.log 2 n + 1) ≤ 2^m := Nat.pow_le_pow_right (by omega) hlt'
   linarith
 
-/-- **Factorial Check Count Bound**: For n ≥ 2, factorialCheckCount n ≤ ⌊log₂ n⌋ + 2.
+/-- **Factorial Check Count Bound**: factorialCheckCount n ≤ ⌊log₂ n⌋ + 2.
 
     This formalizes the density heuristic's key asymptotic claim: for a prime
     p ∈ (l!, (l+1)!], only l+1 ≤ ⌊log₂ p⌋ + 2 conditions must be checked,
@@ -190,7 +192,7 @@ private lemma le_log_of_pow_lt {m n : ℕ} (hn : 2 ≤ n) (h : 2^m < n) : m ≤ 
     Proof: Show factorialCheckSet n ⊆ Finset.range (⌊log₂ n⌋ + 2):
     · k = 0: trivial (0 < ⌊log₂ n⌋ + 2)
     · k ≥ 1: 2^(k-1) ≤ k! < n, so 2^(k-1) < n, so k-1 ≤ ⌊log₂ n⌋ by log definition. -/
-theorem factorialCheckCount_le_log (n : ℕ) (hn : 2 ≤ n) :
+theorem factorialCheckCount_le_log (n : ℕ) :
     factorialCheckCount n ≤ Nat.log 2 n + 2 := by
   have hsubset : factorialCheckSet n ⊆ Finset.range (Nat.log 2 n + 2) := by
     intro k hk
@@ -200,7 +202,7 @@ theorem factorialCheckCount_le_log (n : ℕ) (hn : 2 ≤ n) :
     · omega
     · have h1 : 2^(k-1) ≤ k.factorial := two_pow_pred_le_factorial hkpos
       have h2 : 2^(k-1) < n := lt_of_le_of_lt h1 hk.2
-      have h3 : k-1 ≤ Nat.log 2 n := le_log_of_pow_lt hn h2
+      have h3 : k-1 ≤ Nat.log 2 n := le_log_of_pow_lt h2
       omega
   calc factorialCheckCount n
       = (factorialCheckSet n).card := rfl
@@ -212,6 +214,51 @@ theorem checkCount_bound_769 : factorialCheckCount 769 ≤ Nat.log 2 769 + 2 := 
   have hc : factorialCheckCount 769 = 7 := checkCount_769
   have hlog : Nat.log 2 769 = 9 := by native_decide
   omega
+
+/-
+## Exact Factorial Check Count
+
+When the "level" l of n is known — i.e., l! < n ≤ (l+1)! — the factorial check
+count equals exactly l+1, not merely is bounded by ⌊log₂ n⌋ + 2.
+
+The proof identifies factorialCheckSet n = Finset.range (l+1):
+· k ≤ l → k! ≤ l! < n (k ∈ set) and k ≤ l ≤ l! < n (k < n)
+· k ≥ l+1 → k! ≥ (l+1)! ≥ n (k! < n fails, k ∉ set)
+-/
+
+/-- **Exact Count Formula**: For n in the factorial interval (l!, (l+1)!],
+    factorialCheckCount n = l + 1.
+
+    This upgrades the logarithmic upper bound to a precise closed form:
+    the check count depends only on which factorial interval contains n. -/
+theorem factorialCheckCount_eq_of_interval {n l : ℕ} (hl : l.factorial < n)
+    (hn : n ≤ (l + 1).factorial) : factorialCheckCount n = l + 1 := by
+  have hfcs : factorialCheckSet n = Finset.range (l + 1) := by
+    ext k
+    simp only [factorialCheckSet, Finset.mem_filter, Finset.mem_range]
+    constructor
+    · -- k ∈ factorialCheckSet n → k < l+1
+      intro ⟨_, hkfact⟩
+      by_contra hk
+      push_neg at hk
+      -- k ≥ l+1 implies k! ≥ (l+1)! ≥ n, contradicting k! < n
+      have hge : (l + 1).factorial ≤ k.factorial := Nat.factorial_le hk
+      linarith
+    · -- k < l+1 → k ∈ factorialCheckSet n
+      intro hk
+      have hkl : k ≤ l := Nat.lt_succ_iff.mp hk
+      refine ⟨?_, Nat.lt_of_le_of_lt (Nat.factorial_le hkl) hl⟩
+      -- k < n: k ≤ l ≤ l! < n
+      exact Nat.lt_of_le_of_lt (Nat.le_trans hkl (Nat.self_le_factorial l)) hl
+  simp [factorialCheckCount, hfcs, Finset.card_range]
+
+/-- The factorial check count is constant on each factorial interval: if m and n
+    both lie in (l!, (l+1)!], then factorialCheckCount m = factorialCheckCount n. -/
+theorem factorialCheckCount_const_on_interval {m n l : ℕ}
+    (hm : l.factorial < m) (hm2 : m ≤ (l + 1).factorial)
+    (hn : l.factorial < n) (hn2 : n ≤ (l + 1).factorial) :
+    factorialCheckCount m = factorialCheckCount n := by
+  rw [factorialCheckCount_eq_of_interval hm hm2, factorialCheckCount_eq_of_interval hn hn2]
 
 /-
 ## Natural Density
@@ -319,22 +366,31 @@ extending the gallery from 2 verified witnesses to 6:
   - Level-5 witnesses (p ∈ (120, 720)): 461, 557, 673 (requiring 6 checks each)
   - Level-6 witness (p ∈ (720, 5040)): 769 (requiring 7 checks)
 
-The key new mathematical contribution is `factorialCheckCount_le_log`, which
-formally proves that factorialCheckCount(n) ≤ ⌊log₂ n⌋ + 2 for n ≥ 2. This is
-the rigorous version of the density heuristic's key observation: each prime
-requires only O(log n) conditions to check — logarithmically many, not linearly many.
-The proof uses the elementary bound 2^(k-1) ≤ k! for k ≥ 1, which itself follows
-by induction from the factorial recurrence.
+Key mathematical contributions:
+
+1. `factorialCheckCount_le_log`: factorialCheckCount(n) ≤ ⌊log₂ n⌋ + 2 for all n.
+   This is the rigorous version of the density heuristic's key observation: each prime
+   requires only O(log n) conditions — logarithmically many, not linearly many.
+   Proof: elementary bound 2^(k-1) ≤ k! for k ≥ 1 (induction on factorial recurrence).
+
+2. `factorialCheckCount_eq_of_interval`: when l! < n ≤ (l+1)!, factorialCheckCount n = l+1.
+   This exact formula identifies the check count with the "factorial level" of n:
+   the count jumps by exactly 1 at each factorial boundary and is constant within levels.
+   Proof: factorialCheckSet n = Finset.range (l+1) via double inclusion using Nat.factorial_le.
+
+3. `factorialCheckCount_const_on_interval`: check count is constant within each level.
+   This confirms the level structure is well-defined.
 
 Key counts at the six witnesses:
-  p = 101: 5 factorial checks (k = 0–4; 4! = 24 < 101 ≤ 120 = 5!)
-  p = 211: 6 factorial checks (k = 0–5; 5! = 120 < 211 ≤ 720 = 6!)
-  p = 461: 6 factorial checks (k = 0–5; level 5)
-  p = 557: 6 factorial checks (k = 0–5; level 5)
-  p = 673: 6 factorial checks (k = 0–5; level 5)
-  p = 769: 7 factorial checks (k = 0–6; 6! = 720 < 769 ≤ 5040 = 7!)
+  p = 101: 5 checks (level 4: 4! < 101 ≤ 5! = 120)
+  p = 211: 6 checks (level 5: 5! < 211 ≤ 6! = 720)
+  p = 461: 6 checks (level 5: 5! < 461 ≤ 6!)
+  p = 557: 6 checks (level 5: 5! < 557 ≤ 6!)
+  p = 673: 6 checks (level 5: 5! < 673 ≤ 6!)
+  p = 769: 7 checks (level 6: 6! < 769 ≤ 7! = 5040)
 
-Numerical verification: checkCount(769) = 7 ≤ log₂(769) + 2 = 9 + 2 = 11 ✓.
+Numerical verifications: checkCount(769) = 7 ≤ log₂(769) + 2 = 11 ✓;
+exact formula: 6! = 720 < 769 ≤ 5040 = 7!, count = 6+1 = 7 ✓.
 -/
 
 end Erdos1059OQ01

--- a/research/problems/erdos-1059-oq-01/knowledge.md
+++ b/research/problems/erdos-1059-oq-01/knowledge.md
@@ -52,3 +52,40 @@ The density-1 conjecture says lim C(x)/π(x) = 1. Proof requires PNT + Brun-Titc
 - Prove density_one_conjecture from selberg_density_axiom (OQ-02) once PNT/Brun-Titchmarsh available
 - Find more level-6 witnesses in (720, 5040) — next candidates: check primes after 769
 - The tighter asymptotic factorialCheckCount(n) = O(log n / log log n) would require Stirling
+
+---
+
+## Session 2026-04-04 (Session 2) - Exact Count Formula + Lint Cleanup
+
+**Mode**: REVISIT
+**Outcome**: progress
+
+### What I Did
+
+1. **Proved `factorialCheckCount_eq_of_interval`**: When l! < n ≤ (l+1)!, factorialCheckCount n = l+1.
+   This is the exact formula (not just a bound). Proof: show factorialCheckSet n = Finset.range(l+1)
+   by double inclusion using Nat.factorial_le and Nat.self_le_factorial.
+
+2. **Proved `factorialCheckCount_const_on_interval`**: The check count is constant within each
+   factorial level — if m and n both lie in (l!, (l+1)!], then factorialCheckCount m = factorialCheckCount n.
+
+3. **Removed unused hypothesis `hn : 2 ≤ n`** from `le_log_of_pow_lt` and
+   `factorialCheckCount_le_log`. The bound holds for all n (vacuously correct for n ≤ 1 since
+   factorialCheckSet is empty). This eliminates a lint warning and strengthens the theorem.
+
+4. Build: 0 sorries, 0 warnings, 1 axiom (density_one_conjecture).
+
+### Key Findings
+- The exact formula `factorialCheckCount n = l+1` (where l is the level of n) makes the
+  "level structure" of the problem explicit in Lean
+- The bound theorem `factorialCheckCount_le_log` holds for ALL n, not just n ≥ 2
+- `factorialCheckCount_const_on_interval` confirms checks are level-uniform — different primes
+  at the same level have identical check counts (e.g., 461, 557, 673 all = 6)
+
+### Files Modified
+- `proofs/Proofs/Erdos1059OQ01.lean`: 340 → 396 lines, 2 new theorems, strengthened 2 existing
+
+### Next Steps
+- Prove density_one_conjecture from selberg_density_axiom (OQ-02) once PNT/Brun-Titchmarsh available
+- The tighter asymptotic factorialCheckCount(n) = Θ(log n / log log n) would require Stirling
+- Cross-namespace: connect OQ-01 density conjecture to OQ-02 Selberg axiom via quantitative sieve

--- a/src/data/research/problems/erdos-1059-oq-01.json
+++ b/src/data/research/problems/erdos-1059-oq-01.json
@@ -29,17 +29,21 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Added level-6 witness 769 and proved factorialCheckCount_le_log (0 sorries, 1 axiom)",
+    "progressSummary": "PROGRESS: 0 sorries, 1 axiom (density_one_conjecture); proved exact count formula + bound holds for all n",
     "builtItems": [
       "factorialCheckCount_le_log in Erdos1059OQ01.lean: proved factorialCheckCount n <= Nat.log 2 n + 2",
       "two_pow_pred_le_factorial (private): 2^(k-1) <= k! for k >= 1, proved by induction",
       "witness_769 + prime_769: first level-6 witness (p = 769 in (720, 5040))",
-      "six_prime_witnesses: packages all 6 verified witnesses (101, 211, 461, 557, 673, 769)"
+      "six_prime_witnesses: packages all 6 verified witnesses (101, 211, 461, 557, 673, 769)",
+      "factorialCheckCount_eq_of_interval: exact count equals l+1 when l-factorial < n <= (l+1)-factorial",
+      "factorialCheckCount_const_on_interval: count is constant within each factorial level"
     ],
     "insights": [
       "769 is the first level-6 witness (p in (720, 5040)); requires 7 factorial checks vs 6 for level-5",
       "Proved factorialCheckCount(n) <= log2(n) + 2 — elementary bound via 2^(k-1) <= k! induction",
-      "Bound is tight at n=3 (count=3, log=1) and n=7 (count=4, log=2)"
+      "Bound is tight at n=3 (count=3, log=1) and n=7 (count=4, log=2)",
+      "Exact formula: factorialCheckCount(n) = l+1 iff l-factorial < n <= (l+1)-factorial; count is uniquely determined by the factorial level of n",
+      "factorialCheckCount_le_log holds for ALL n (not just n>=2): vacuously true when n<=1 since factorialCheckSet is empty"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary

Extends the Erdős 1059 OQ-01 formalization with two new theorems and a cleanup:

1. **`factorialCheckCount_eq_of_interval`** (new): When `l! < n ≤ (l+1)!`, `factorialCheckCount n = l+1` exactly. This upgrades the logarithmic upper bound to a precise closed form — the check count is uniquely determined by the factorial level of `n`.

2. **`factorialCheckCount_const_on_interval`** (new): The check count is constant within each factorial interval. Formally proves what the concrete values suggest: 461, 557, 673 each require 6 checks; 769 requires 7 checks; any two numbers at the same level have identical check counts.

3. **Lint cleanup**: Removed unused `hn : 2 ≤ n` from `le_log_of_pow_lt` and `factorialCheckCount_le_log`. The bound holds for ALL `n` (vacuously for `n ≤ 1` since `factorialCheckSet` is empty). Eliminates warning, strengthens the theorem.

**Status**: 0 sorries, 0 warnings, 1 axiom (`density_one_conjecture` — unavoidable, requires PNT + Brun-Titchmarsh).

## Test plan

- [x] `docker-build.sh Proofs.Erdos1059OQ01` — clean build, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)