### PR TITLE
chore: sync listings.json with all recent meta.json badge changes

### DIFF
--- a/src/data/proofs/listings.json
+++ b/src/data/proofs/listings.json
@@ -871,7 +871,7 @@
     "slug": "area-of-circle-oq-03-oq-02",
     "description": "Archimedes' classical bounds on π from inscribed and circumscribed 96-gons: 223/71 < π < 22/7. Both bounds proved from Mathlib's pi_gt_d4/pi_lt_d4. Fully verified: 0 sorries, 0 axioms.",
     "status": "verified",
-    "badge": "original",
+    "badge": "mathlib",
     "tags": [
       "geometry",
       "analysis",
@@ -1864,6 +1864,24 @@
     ],
     "sorries": 0,
     "annotationCount": 5
+  },
+  {
+    "id": "binomial-theorem-oq-02-oq-01-oq-02",
+    "title": "Marginal Distributions of Multinomial Are Binomial",
+    "slug": "binomial-theorem-oq-02-oq-01-oq-02",
+    "description": "Proves that each marginal component of a multinomial distribution follows a binomial distribution, using the probability generating function (PGF) approach via the multinomial theorem.",
+    "status": "verified",
+    "badge": "verified",
+    "tags": [
+      "probability",
+      "multinomial distribution",
+      "binomial distribution",
+      "generating functions",
+      "marginal distribution",
+      "combinatorics"
+    ],
+    "sorries": 0,
+    "annotationCount": 0
   },
   {
     "id": "binomial-theorem-oq-02-oq-02",
@@ -2933,7 +2951,7 @@
     "slug": "cantor-diagonalization-oq-01-oq-01",
     "description": "Formalizes the Continuum Hypothesis: whether an intermediate cardinal exists between ℵ₀ and 2^ℵ₀ is independent of ZFC. Proves CH ↔ no intermediate, constructs explicit intermediates under ¬CH, and states König's constraint and Easton's theorem.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "set-theory",
       "cardinal-arithmetic",
@@ -4568,7 +4586,7 @@
     "dateAdded": "2026-04-02",
     "mathlibCount": 2,
     "sorries": 0,
-    "annotationCount": 0
+    "annotationCount": 6
   },
   {
     "id": "chinese-remainder-non-coprime",
@@ -4890,24 +4908,6 @@
     "annotationCount": 7
   },
   {
-    "id": "cramers-rule-oq-01-oq-01",
-    "title": "Cramer's Rule: Connection to LU Decomposition",
-    "slug": "cramers-rule-oq-01-oq-01",
-    "description": "Formalizes the algebraic connection between Cramer's Rule and LU decomposition. Proves the LU determinant formula det(LU) = (∏ L_ii) × (∏ U_ii), the inverse formula (LU)⁻¹ = U⁻¹L⁻¹, and the solution equivalence between forward/back substitution and Cramer's cofactor formula.",
-    "status": "verified",
-    "badge": "mathlib",
-    "tags": [
-      "linear-algebra",
-      "matrices",
-      "determinants",
-      "LU-decomposition",
-      "Cramer's rule",
-      "triangular matrices"
-    ],
-    "sorries": 0,
-    "annotationCount": 8
-  },
-  {
     "id": "cramers-rule-oq-01-oq-02",
     "title": "Quasideterminant Theory: Non-Commutative Analogue of Determinants",
     "slug": "cramers-rule-oq-01-oq-02",
@@ -4943,7 +4943,7 @@
       "open-problem"
     ],
     "sorries": 0,
-    "annotationCount": 3
+    "annotationCount": 5
   },
   {
     "id": "cramers-rule-oq-01-oq-04",
@@ -5750,7 +5750,7 @@
     "slug": "dissection-of-cubes-oq-01-oq-01",
     "description": "Proves that HasMinimalCollision is achievable: there exists a CubeDissection with exactly 2 colliding cubes. This shows the lower bound of 2 (from OQ-01) is tight within the formalization. Three axis-aligned cubes — two of size 1/4 and one of size 1/3 — form the explicit witness, with the two equal-size cubes as the unique collision pair.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "geometry",
       "impossibility",
@@ -6184,7 +6184,7 @@
     "slug": "elementary-quadratic-reciprocity-oq-03-oq-02",
     "description": "Defines the Kronecker symbol extending the Jacobi symbol to even moduli, negative integers, and zero. Proves values at special arguments, agreement with Jacobi for odd positive moduli, and states multiplicativity and generalized quadratic reciprocity.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "number-theory",
       "quadratic-reciprocity",
@@ -6300,7 +6300,7 @@
     "slug": "erdos-10",
     "description": "Is there some k such that every sufficiently large integer is the sum of a prime and at most k powers of 2? Erdős and Graham conjectured no such k exists. Gallagher showed the representable set has density arbitrarily close to 1.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number theory",
@@ -6385,7 +6385,7 @@
     "erdosNumber": 100,
     "mathlibCount": 1,
     "sorries": 0,
-    "annotationCount": 2
+    "annotationCount": 5
   },
   {
     "id": "erdos-1000",
@@ -6511,7 +6511,7 @@
     "slug": "erdos-1003",
     "description": "Are there infinitely many solutions to φ(n) = φ(n+1), where φ is the Euler totient function? Erdős conjectured yes, and made the stronger claim that φ(n) = φ(n+1) = ... = φ(n+k) has infinitely many solutions for every k ≥ 1.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -6812,7 +6812,7 @@
     "slug": "erdos-101",
     "description": "Given n points in ℝ² with no five collinear, is the number of lines containing exactly four points o(n²)? Grünbaum: ≫ n^{3/2}. Solymosi–Stojaković: n^{2−O(1/√log n)}. Open.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "combinatorial-geometry",
@@ -7099,7 +7099,7 @@
     "slug": "erdos-1016",
     "description": "Let h(n) be the minimum excess edges beyond n for an n-vertex pancyclic graph (containing all cycle lengths 3 to n). Estimate h(n): is h(n) >= log_2 n + log* n - O(1)? Known: log_2(n-1) - 1 <= h(n) <= log_2 n + log* n + O(1).",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "graph theory",
@@ -7271,7 +7271,7 @@
     "slug": "erdos-1021",
     "description": "For k ≥ 3, does there exist c_k > 0 such that ex(n, G_k) ≪ n^(3/2 - c_k)? Here G_k is the bipartite graph with k primary vertices and C(k,2) pair vertices. Even ex(n, G_k) = o(n^(3/2)) is unknown.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "graph-theory",
       "extremal-combinatorics",
@@ -7490,7 +7490,7 @@
     "slug": "erdos-103",
     "description": "Let h(n) count the number of incongruent sets of n points in ℝ² that minimize diameter with d(x,y) ≥ 1 for all distinct x,y. Is h(n) → ∞?",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "geometry",
@@ -7681,7 +7681,7 @@
     "slug": "erdos-1038",
     "description": "Determine the infimum and supremum of the measure of {x : |f(x)| < 1} for monic polynomials with roots in [-1,1]. Supremum = 2√2 (Tao, 2025); infimum bounds: 1.519 ≤ inf ≤ 1.835.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "measure-theory",
@@ -7754,7 +7754,7 @@
     "slug": "erdos-1041",
     "description": "For a monic polynomial with all roots in the unit disk, must there exist a path of length less than 2 in the sublevel set {z : |f(z)| < 1} connecting two roots?",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "complex-analysis",
@@ -8119,7 +8119,7 @@
     "slug": "erdos-1056",
     "description": "For k ≥ 2, does there exist a prime p and k consecutive intervals whose products are all ≡ 1 (mod p)? Known for k=2 (p=11, Erdős 1979) and k=3 (p=17, Makowski 1983). Guy's Problem A15. Status: OPEN.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -8193,6 +8193,27 @@
     "mathlibCount": 4,
     "sorries": 0,
     "annotationCount": 12
+  },
+  {
+    "id": "erdos-1059-oq-01",
+    "title": "Density of Factorial-Avoiding Primes (Erdős 1059, OQ-01)",
+    "slug": "erdos-1059-oq-01",
+    "description": "Formalizes the natural density question for Erdős Problem #1059: What fraction of all primes p satisfy AllFactorialSubtractionsComposite(p)? Provides a decidable instance, four new witnesses (461, 557, 673, 769), a proved logarithmic bound on check counts, counting functions for C(x) and π(x), and axiomatizes the density-1 conjecture. 0 sorries, 1 axiom.",
+    "status": "axiomatized",
+    "badge": "axiom",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "primes",
+      "factorials",
+      "natural-density",
+      "open-question"
+    ],
+    "dateAdded": "2026-04-04",
+    "erdosNumber": 1059,
+    "mathlibCount": 6,
+    "sorries": 0,
+    "annotationCount": 5
   },
   {
     "id": "erdos-1059-oq-02",
@@ -8290,7 +8311,7 @@
     ],
     "erdosNumber": 106,
     "sorries": 0,
-    "annotationCount": 4
+    "annotationCount": 8
   },
   {
     "id": "erdos-1060",
@@ -8298,7 +8319,7 @@
     "slug": "erdos-1060",
     "description": "Let f(n) count solutions to k·σ(k) = n. Is f(n) ≤ n^{o(1/log log n)}? Perhaps even f(n) ≤ (log n)^{O(1)}? This problem remains OPEN.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -8338,7 +8359,7 @@
     "slug": "erdos-1062",
     "description": "Let f(n) = max |A| for A ⊆ {1,…,n} with no element dividing two distinct others. Lebensold: 0.6725n ≤ f(n) ≤ 0.6736n. Is lim f(n)/n irrational? OPEN.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -8498,7 +8519,7 @@
     "slug": "erdos-1068",
     "description": "Does every graph with chromatic number ℵ₁ contain a countable infinitely vertex-connected subgraph? Soukup (2015): uncountable sets can fail. Version of Erdős–Hajnal problem. Open.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "graph-theory",
@@ -8575,7 +8596,7 @@
     "slug": "erdos-1071",
     "description": "Can finitely many non-intersecting unit segments in [0,1]² be maximal? Yes (Danzer). Can a countably infinite maximal packing exist in some region? Open.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "geometry",
@@ -8633,7 +8654,7 @@
     "slug": "erdos-1074",
     "description": "Do the asymptotic densities of EHS numbers and Pillai primes exist? Both sets are infinite (Erdős-Hardy-Subbarao), but density questions remain OPEN.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -8697,7 +8718,7 @@
     "slug": "erdos-1077",
     "description": "Must dense graphs contain large balanced subgraphs? Jiang-Longbrake (2025) showed the optimal size is Θ(n^α) vertices, resolving ambiguities in the original problem.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "graph-theory",
@@ -9119,7 +9140,7 @@
     "slug": "erdos-1095",
     "description": "Let g(k) be the smallest n > k+1 such that all prime factors of C(n,k) exceed k. Estimate g(k). Known: exp(c·(log k)²) ≪ g(k) ≤ exp((1+o(1))k). Conjectured: log g(k) ~ k/log k. OPEN.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -9287,7 +9308,7 @@
     "erdosNumber": 1098,
     "mathlibCount": 3,
     "sorries": 0,
-    "annotationCount": 5
+    "annotationCount": 9
   },
   {
     "id": "erdos-1099",
@@ -9316,7 +9337,7 @@
     "slug": "erdos-11",
     "description": "Is every odd n > 1 the sum of a squarefree number and a power of 2? OPEN problem with deep connections to Wieferich primes. Verified up to 2^50.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -9371,7 +9392,7 @@
     "erdosNumber": 110,
     "mathlibCount": 3,
     "sorries": 0,
-    "annotationCount": 0
+    "annotationCount": 6
   },
   {
     "id": "erdos-1100",
@@ -9396,7 +9417,7 @@
     "slug": "erdos-1101",
     "description": "Given a pairwise coprime sequence u with convergent reciprocal series, when do the integers not divisible by any uᵢ have gaps bounded by the product formula?",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -9532,7 +9553,7 @@
     "slug": "erdos-1108",
     "description": "Does the set of finite sums of distinct factorials contain only finitely many k-th powers (for k >= 2)? Does it contain only finitely many powerful numbers?",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -9743,7 +9764,7 @@
     "slug": "erdos-1117",
     "description": "For a non-monomial entire f, let ν(r) count maximum modulus points on |z|=r. Can lim sup ν(r) = ∞? YES (Herzog–Piranian 1968). Can lim inf ν(r) = ∞? OPEN. Approximate answer by Glücksam–Pardo-Simón (2024).",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "complex-analysis",
@@ -9823,7 +9844,7 @@
     "slug": "erdos-112",
     "description": "Determine k(n,m): the minimum vertices guaranteeing an independent set of size n or a transitive tournament of size m in any directed graph. Known: R(n,m) ≤ k(n,m) ≤ R(n,m,m). Open.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "graph-theory",
@@ -10232,7 +10253,7 @@
     "slug": "erdos-1135",
     "description": "Does every positive integer eventually reach 1 under f(n) = n/2 (even) or (3n+1)/2 (odd)? Verified up to 2^68. Tao: almost all orbits attain small values. Open. $500.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -10291,7 +10312,7 @@
     "slug": "erdos-1138",
     "description": "For x/2 < y < x and C > 1, if d is the maximal prime gap below x, is π(y + Cd) - π(y) ~ Cd / log y?",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -10351,7 +10372,7 @@
     "slug": "erdos-114",
     "description": "For monic degree-n polynomials p(z), is the arc length of {|p(z)|=1} maximized by z^n-1? Tao (2025) proved this for large n. Solved for n=2 (Eremenko-Hayman 1999). $250 bounty. Status: OPEN (all n).",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "complex-analysis",
@@ -10747,7 +10768,7 @@
     "slug": "erdos-1155-oq-01-oq-01",
     "description": "Formalizes the open question of whether the ratio $f(n)/n^{3/2}$ converges to a specific positive constant $L$ in the triangle removal process. The triangle removal process repeatedly deletes edges of a uniformly random triangle from $K_n$ until no triangles remain; $f(n)$ counts the surviving edges. BFL (2015) established $f(n) = n^{3/2+o(1)}$ a.s., and the Erdős conjecture (parent OQ-01) asks for $\\Theta(n^{3/2})$ with bounded ratio. This formalization addresses the strictly stronger convergence question: does $f(n)/n^{3/2} \\to L$ for some $L > 0$? Thirteen theorems establish the hierarchy (convergence $\\Rightarrow$ Erdős $\\Rightarrow$ BFL), limit uniqueness, sharp asymptotics $f(n) \\sim L \\cdot n^{3/2}$ under convergence, ε-neighborhood and limsup/liminf characterizations, and a metric Cauchy criterion for the convergence conjecture. The limit $L$ (if it exists) would be determined by the differential equations governing the BFL analysis.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "triangle-removal",
@@ -10783,7 +10804,7 @@
     "dateAdded": "2026-03-30",
     "mathlibCount": 4,
     "sorries": 0,
-    "annotationCount": 0
+    "annotationCount": 12
   },
   {
     "id": "erdos-1157",
@@ -10847,7 +10868,7 @@
     "slug": "erdos-116",
     "description": "For a monic polynomial p with all roots in the unit disk, is |{|p(z)|<1}| ≥ n^{-O(1)}? PROVED: Krishnapur-Lundberg-Ramachandran showed |{|p(z)|<1}| ≥ c/log n, and this is tight up to log log factors.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "complex analysis",
@@ -10885,7 +10906,7 @@
     "slug": "erdos-1161",
     "description": "For permutations of [n], which cyclic orders k maximize the count of permutations having order k? SOLVED by Beker: max_k f_k(n) ~ (n-1)! and the maximizer is characterized by lcm divisibility.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -11023,7 +11044,7 @@
     "slug": "erdos-117",
     "description": "Estimate h(n): minimum Abelian subgroups to cover a group where every (n+1)-element subset has a commuting pair. Pyber: c₁^n < h(n) < c₂^n. Open.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "group-theory",
@@ -11055,7 +11076,7 @@
     ],
     "erdosNumber": 117,
     "sorries": 3,
-    "annotationCount": 2
+    "annotationCount": 7
   },
   {
     "id": "erdos-1170",
@@ -11122,7 +11143,7 @@
     "slug": "erdos-1173",
     "description": "Does there exist a free set of cardinality ℵ_{ω+1}?",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "combinatorics",
@@ -11140,7 +11161,7 @@
     "slug": "erdos-1174",
     "description": "Does there exist a K₄-free graph such that every countable edge coloring contains a monochromatic triangle, and does the analogous infinite generalization hold?",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "combinatorics",
@@ -11229,7 +11250,7 @@
     "erdosNumber": 1178,
     "mathlibCount": 3,
     "sorries": 0,
-    "annotationCount": 0
+    "annotationCount": 7
   },
   {
     "id": "erdos-1179",
@@ -11320,7 +11341,7 @@
     "slug": "erdos-1183",
     "description": "In any 2-coloring of the subsets of {1,...,n}, there exists a monochromatic family closed under unions and intersections. How large must it be? The trivial chain bound gives ⌈(n+1)/2⌉. Erdős and Ulam had 'no plausible conjecture' for the true order of magnitude.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "combinatorics",
@@ -11339,7 +11360,7 @@
     "slug": "erdos-119",
     "description": "For points z_i on the unit circle, define M_n = max_{|z|=1} |∏(z - z_i)|. Parts 1-2 (limsup M_n = ∞, M_n > n^c i.o.) are solved. Part 3 (∑M_k > n^{1+c}) remains open.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "complex-analysis",
@@ -11357,7 +11378,7 @@
     "slug": "erdos-12",
     "description": "How large can a set A be if no element a divides the sum b+c of two larger elements? Three OPEN questions about density, sparseness, and reciprocal sums.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -11394,7 +11415,7 @@
     "slug": "erdos-121",
     "description": "Let F_k(N) be the max size of A ⊆ {1,…,N} with no k-element product a perfect square. Conjecture F_{2k+1}(N) = (1-o(1))N. DISPROVED by Tao (2024): F_k(N) ≤ (1-c_k)N for k ≥ 4.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number theory",
@@ -11451,7 +11472,7 @@
     "slug": "erdos-124",
     "description": "For bases 3 ≤ d₁ < ... < dᵣ with Σ1/(dᵢ-1) ≥ 1, can all large integers be written as Σcᵢaᵢ with cᵢ ∈ {0,1} and aᵢ having only digits {0,1} in base dᵢ? Q1 PROVED. Q2 open (proved for {3,4,7}).",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -11490,7 +11511,7 @@
     "slug": "erdos-125",
     "description": "Let A = {digits 0,1 in base 3}, B = {digits 0,1 in base 4}. Does A + B have positive density? Known: |A+B ∩ [1,x]| ≫ x^{0.9777}, upper density ≤ 0.696. OPEN.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -11545,7 +11566,7 @@
     "slug": "erdos-128",
     "description": "If every induced subgraph on ≥ ⌊n/2⌋ vertices has > n²/50 edges, must G contain a triangle? 1/50 is best possible (C₅ blow-up). Partial: EFRS (1/16), Krivelevich (3n/5, 1/25), Razborov (27/1024). Open ($250).",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "graph-theory",
@@ -11563,7 +11584,7 @@
     "slug": "erdos-129",
     "description": "R(n;k,r) is the smallest N such that every r-coloring of K_N has n vertices with no monochromatic K_k. Erdős–Gyárfás conjecture: C₁^{n^{1/(k-1)}} < R(n;k,r) < C₂^{n^{1/(k-1)}}.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "graph-theory",
@@ -11602,7 +11623,7 @@
     "slug": "erdos-130",
     "description": "Given an infinite set A ⊆ ℝ² with no 3 collinear and no 4 cocircular points, form the integer distance graph G(A). Can χ(G(A)) be infinite? Anning–Erdős shows the clique number must be finite. Open.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "combinatorial-geometry",
@@ -11819,7 +11840,7 @@
     "slug": "erdos-14",
     "description": "For A ⊆ ℕ, let B be integers with exactly one representation as a+b (a≤b, a,b∈A). (a) Is |{1,...,N}\\B| ≫ N^{1/2−ε}? (b) Can |{1,...,N}\\B| = o(√N)? ESS: ≪ N^{1/2+ε} achievable, ≫ N^{1/3−ε} infinitely often.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "additive-combinatorics",
@@ -11873,7 +11894,7 @@
     "slug": "erdos-141",
     "description": "Are there k consecutive primes in arithmetic progression for every k >= 3?",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "primes",
@@ -12212,7 +12233,7 @@
     "slug": "erdos-156",
     "description": "Does there exist a maximal Sidon set A ⊂ {1,...,N} of size O(N^{1/3})?",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "sidon-sets",
@@ -12271,7 +12292,7 @@
     "slug": "erdos-159",
     "description": "Does there exist c > 0 such that R(C₄, Kₙ) ≪ n^{2-c}? Known bounds: n^{3/2}/(log n)^{3/2} ≪ R(C₄, Kₙ) ≪ n²/(log n)².",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "graph-theory",
@@ -13122,7 +13143,7 @@
     "slug": "erdos-196",
     "description": "Must every permutation of ℕ contain a monotone 4-term arithmetic progression? k=3: YES (DEGS 1977). k=4: OPEN. k=5: NO (DEGS 1977). LeSaulnier–Vijay (2011) showed odd-CD 4-APs are avoidable.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "combinatorics",
@@ -13297,7 +13318,7 @@
     "slug": "erdos-202",
     "description": "How many disjoint congruence classes can have moduli bounded by N? Bounds involve L(N) = exp(√(log N · log log N)).",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -13703,7 +13724,7 @@
     "slug": "erdos-220",
     "description": "For reduced residues a₁ < ⋯ < a_{φ(n)} mod n, is ∑(a_{k+1}-a_k)² ≪ n²/φ(n)? Montgomery-Vaughan (1986) proved YES, with general bound for any power γ ≥ 1.",
     "status": "axiomatized",
-    "badge": "wip",
+    "badge": "axiom",
     "tags": [
       "erdos",
       "number-theory",
@@ -14046,7 +14067,7 @@
     "slug": "erdos-236",
     "description": "Is it true that f(n) = o(log n), where f(n) counts solutions to n = p + 2^k with p prime? Erdős proved infinitely many n have f(n) ≫ log log n, showing the conjecture is tight if true.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -14167,7 +14188,7 @@
     "slug": "erdos-241",
     "description": "Let f(N) be the maximum size of A ⊆ {1,...,N} with all three-element sums distinct. Is f(N) ~ N^{1/3}? Bose–Chowla achieved N^{1/3}; Green's upper bound is ~1.519·N^{1/3}. OPEN ($100 prize).",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "additive-combinatorics",
@@ -14399,7 +14420,7 @@
     "slug": "erdos-251",
     "description": "Is the sum Σ pₙ/2ⁿ irrational, where pₙ is the nth prime? This OPEN problem asks about the arithmetic nature of a beautiful constant involving primes and powers of 2.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -14540,7 +14561,7 @@
     "slug": "erdos-258",
     "description": "Is the sum of τ(n)/(a₁·...·aₙ) irrational for sequences with aₙ → ∞? Solved for monotone sequences by Erdős-Straus (1971).",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -14621,7 +14642,7 @@
     "slug": "erdos-261",
     "description": "Can every positive integer n be represented as n/2^n = Σ k/2^k over a set of distinct positive integers? Cusick proved infinitely many n work; the full conjecture remains open.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -14737,7 +14758,7 @@
     "slug": "erdos-267",
     "description": "If n₁ < n₂ < ... is a sequence with n_{k+1}/n_k ≥ c > 1, must Σ 1/F_{n_k} be irrational? PARTIALLY SOLVED: Special cases proved, general conjecture OPEN.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -14942,7 +14963,7 @@
     "slug": "erdos-276",
     "description": "Does there exist a Lucas sequence (a_{n+2} = a_{n+1} + a_n) with all terms composite yet no integer dividing every term? Graham (1964) gave a construction via covering congruences. The deeper question of necessity remains open.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -15247,7 +15268,7 @@
     "slug": "erdos-289",
     "description": "For all sufficiently large k, do there exist k disjoint non-adjacent intervals I₁,...,Iₖ ⊂ ℕ (each of size ≥ 2) with ∑ᵢ ∑_{n ∈ Iᵢ} 1/n = 1? Hickerson–Montgomery found 5 intervals summing to 2.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number theory",
@@ -15679,7 +15700,7 @@
     "slug": "erdos-307",
     "description": "Are there two finite sets of primes P, Q with (Σ 1/p)(Σ 1/q) = 1? Prime version: OPEN. Coprime version: SOLVED by Cambie with (1 + 1/5)(1/2 + 1/3) = 1.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -15799,7 +15820,7 @@
     "slug": "erdos-311",
     "description": "Is δ(N) = e^{-(c+o(1))N} for c ∈ (0,1), where δ(N) is the minimal nonzero |1 - Σ 1/n| over A ⊆ {1,...,N}? Lower: e^{-(1+o(1))N}. Upper: exp(-cN/(log N log log N)³) (Tang). Open.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -15840,7 +15861,7 @@
     "slug": "erdos-313",
     "description": "Are there infinitely many m such that ∑ 1/p = 1 − 1/m for some set of distinct primes P? These m are called primary pseudoperfect numbers. Only 8 are known (OEIS A054377). Each m equals the product of its primes.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -16027,7 +16048,7 @@
     "slug": "erdos-321",
     "description": "Let R(N) be the max size of A ⊆ {1,...,N} with all reciprocal subset sums distinct. Bleicher–Erdős: R(N) = Θ(N/log N) up to iterated log factors. The precise correction is open.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -16106,7 +16127,7 @@
     "slug": "erdos-325",
     "description": "Let f_{k,3}(x) count integers ≤ x that are sums of three k-th powers. Is it true that f_{k,3}(x) ≫ x^{3/k} for k ≥ 3?",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -16126,7 +16147,7 @@
     "slug": "erdos-326",
     "description": "Let A be an additive basis of order 2. Must there exist a subset B which is also a basis such that the growth ratio of B has no limit?",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "additive-combinatorics",
@@ -16603,7 +16624,7 @@
     "slug": "erdos-346",
     "description": "If a lacunary sequence is strongly complete but fragile (removing any infinite subset destroys completeness), must a_{n+1}/a_n → φ?",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number theory",
@@ -16658,7 +16679,7 @@
     "slug": "erdos-349",
     "description": "For what (t,α) is ⌊tα^n⌋ a complete sequence? Conjectured for all t > 0 and 1 < α < (1+√5)/2. Whether ⌊(3/2)^n⌋ is odd/even infinitely often is unknown. Open.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -16696,7 +16717,7 @@
     "slug": "erdos-350",
     "description": "If A is a finite dissociated set (all subset sums distinct) of positive integers, prove that the sum of reciprocals is less than 2. Proved by Ryavec.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -16716,7 +16737,7 @@
     "slug": "erdos-351",
     "description": "Is {p(n) + 1/n : n in N} strongly complete for all polynomials p(x)? General case open; solved for p(x) = x and p(x) = x².",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -16876,7 +16897,7 @@
     "slug": "erdos-359",
     "description": "What is the density of MacMahon's sequence where each term is the smallest integer not expressible as a sum of consecutive earlier terms? Conjectured: a_k ~ (k log k) / (log log k).",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -16940,7 +16961,7 @@
     "slug": "erdos-361",
     "description": "For c > 0, what is the maximum size of A ⊆ {1,...,⌊cn⌋} such that n is not a subset sum from A? Does this depend on n irregularly? Possibly Θ(√n).",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -17000,7 +17021,7 @@
     "slug": "erdos-364",
     "description": "A positive integer n is powerful if p | n implies p² | n. Are there three consecutive powerful numbers? The quadruple case is impossible (proved), but the triple case remains OPEN.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -17282,7 +17303,7 @@
     "slug": "erdos-377",
     "description": "Is there an absolute constant C such that ∑_{p≤n, p∤C(2n,n)} 1/p ≤ C for all n? The main conjecture is OPEN, but EGRS75 proved f(n) averages to γ₀ = ∑log(k)/2^k and is ≤ c·log(log(n)) for c < 1.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -17343,7 +17364,7 @@
     "slug": "erdos-38",
     "description": "Does there exist a set B that is NOT an additive basis but still has the density-boosting property: for any set A with Schnirelmann density α, some translate A ∪ (A+b) achieves density ≥ α + f(α)?",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "additive-combinatorics",
@@ -17422,7 +17443,7 @@
     "slug": "erdos-383",
     "description": "For every k, are there infinitely many primes p such that p is the largest prime divisor of ∏_{i=0}^k (p² + i)?",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -17461,7 +17482,7 @@
     "slug": "erdos-385",
     "description": "Is F(n) = max{m + p(m) : m < n, m composite} greater than n for all large n, and does F(n) - n tend to infinity?",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -17521,7 +17542,7 @@
     "slug": "erdos-388",
     "description": "Can one classify all solutions of ∏(m₁+i) = ∏(m₂+j) where k₁, k₂ > 3 and the blocks are disjoint? Erdős conjectured only finitely many solutions exist. Generalizes to proportional products a·∏(m₁+i) = b·∏(m₂+j).",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -17775,7 +17796,7 @@
     "slug": "erdos-399",
     "description": "Is it true that there are no solutions to n! = x^k ± y^k with xy > 1 and k > 2? Disproved by Barfield: 10! = 48^4 - 36^4.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -17835,7 +17856,7 @@
     "slug": "erdos-400",
     "description": "For k ≥ 2, let g_k(n) = max{(a₁+⋯+aₖ)-n : a₁!⋯aₖ! | n!}. Is Σ g_k(n) ~ cₖ·x·log x? Is g_k(n) concentrated around cₖ·log x?",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -18020,7 +18041,7 @@
     "slug": "erdos-409",
     "description": "How many iterations of n mapsto phi(n) + 1 are needed before reaching a prime? F(n) = o(n) trivially; can infinitely many n reach the same prime? What is the density of n reaching a fixed prime? A problem of Finucane.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -18079,7 +18100,7 @@
     "slug": "erdos-411",
     "description": "Define $g(n) = n + \\varphi(n)$ and let $g^k$ denote the $k$-th iterate. For which $n$ and $r$ does $g^{k+r}(n) = 2 \\cdot g^k(n)$ for all large $k$? Known $r = 2$ solutions: $n = 10, 94$. Cambie found ratio-3 and ratio-4 solutions. Steinerberger (2025) reduced the $r = 2$ case to $\\varphi(n) + \\varphi(n + \\varphi(n)) = n$. OPEN in general.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -18185,7 +18206,7 @@
     "slug": "erdos-416",
     "description": "Let V(x) count the number of n ≤ x such that φ(m) = n is solvable. Does V(2x)/V(x) → 2? Is there an asymptotic formula for V(x)? Despite remarkable progress by Pillai, Erdős, Maier-Pomerance, and Ford, both questions remain open.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -18223,7 +18244,7 @@
     "slug": "erdos-418",
     "description": "Are there infinitely many positive integers not of the form n - phi(n)? Yes - integers 2^k * 509203 are non-cototients.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -18266,7 +18287,7 @@
     "slug": "erdos-42",
     "description": "For every maximal Sidon set A ⊆ {1,...,N}, does there exist a Sidon set B of size M with (A−A) ∩ (B−B) = {0}? Proved for M ≤ 3 (Sedov). Open in general.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -18326,7 +18347,7 @@
     "slug": "erdos-422",
     "description": "f(1)=f(2)=1, f(n) = f(n-f(n-1))+f(n-f(n-2)). Not even known if well-defined for all n. Does f miss infinitely many integers? OEIS A005185. Open.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -18365,7 +18386,7 @@
     "slug": "erdos-424",
     "description": "Start with {2,3}, iteratively append a_i · a_j − 1. Does the resulting set have positive density? No element ≡ 1 (mod 3) appears, so density ≤ 2/3. OEIS A005244.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -19098,7 +19119,7 @@
     "slug": "erdos-456",
     "description": "Compare pₙ (smallest prime ≡ 1 mod n) with mₙ (smallest m with n | φ(m)). Is mₙ < pₙ for almost all n? Does pₙ/mₙ → ∞? Three open questions about their relationship.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -19181,7 +19202,7 @@
     "slug": "erdos-46",
     "description": "Does every finite colouring of ℕ have a monochromatic solution to 1 = Σ 1/nᵢ? Proved by Croot. Erdős–Graham generalization to arbitrary rationals also holds.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -19328,7 +19349,7 @@
     "slug": "erdos-466",
     "description": "Is there δ > 0 such that arbitrarily many points fit in a large disk with all pairwise distances bounded away from integers by ≥ δ? PROVED: Graham showed N(X,1/10) ≥ (log X)/10; Sárközy (1976) proved N(X,δ) > X^{1/2−δ^{1/7}}, nearly matching Konyagin's upper bound X^{1/2}.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -19577,7 +19598,7 @@
     "slug": "erdos-477",
     "description": "Is there a polynomial f: ℤ → ℤ of degree ≥ 2 and a set A ⊆ ℤ such that every integer has a unique representation a + f(n)? Sekanina (1959) showed no for f(x) = x². Erdős–Graham conjecture: no for all such f. Open.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number theory",
@@ -19595,7 +19616,7 @@
     "slug": "erdos-478",
     "description": "Let p be a prime and A_p = { k! mod p : 1 ≤ k < p }. Is it true that |A_p| ~ (1 - 1/e) · p? The factorial residue set is conjectured to cover a density (1 - 1/e) fraction of residues, motivated by the birthday-type heuristic for multiplicative random walks. Status: OPEN.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -19824,7 +19845,7 @@
     "slug": "erdos-486",
     "description": "For any choice of forbidden residue classes modulo each n, must the set of integers avoiding all forbidden classes have a logarithmic density?",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -19902,7 +19923,7 @@
     "slug": "erdos-49",
     "description": "Let A ⊆ {1,…,N} with φ(a₁) < ⋯ < φ(aₜ). The primes form such a set. Tao (2023) proved |A| ≤ (1+o(1))π(N), confirming primes are asymptotically largest.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number theory",
@@ -20061,7 +20082,7 @@
     "slug": "erdos-496",
     "description": "For irrational α > 0 and any ε > 0, there exist positive integers x, y, z with |x² + y² − αz²| < ε. Proved by Margulis (1987) using unipotent dynamics on homogeneous spaces.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number theory",
@@ -20099,7 +20120,7 @@
     "slug": "erdos-498",
     "description": "For complex z₁,...,zₙ with |zᵢ| ≥ 1, at most C(n,⌊n/2⌋) signed sums Σεᵢzᵢ fall in any unit disc. Solved by Kleitman (1965), generalized to Hilbert spaces (1970).",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "combinatorics",
@@ -20198,7 +20219,7 @@
     "slug": "erdos-500",
     "description": "Determine ex₃(n, K₄³): the maximum number of 3-edges on n vertices avoiding K₄³. Turán (1941) conjectured π(K₄³) = 5/9. Best bounds: 5/9 ≤ π ≤ 0.5612 (Razborov 2010). Status: OPEN.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "extremal-combinatorics",
@@ -20219,7 +20240,7 @@
     "slug": "erdos-501",
     "description": "For bounded sets A_x with outer measure < 1, must infinite independent sets exist? Answer depends on set-theoretic axioms!",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "set-theory",
@@ -20311,7 +20332,7 @@
     "slug": "erdos-506",
     "description": "What is the minimum number of distinct circles determined by n points in ℝ², not all concyclic? Elliott (1967): ≥ C(n-1,2) for n > 393. Segre: fails for n = 8. Open for small n.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "geometry",
@@ -20329,7 +20350,7 @@
     "slug": "erdos-507",
     "description": "Estimate α(n), the smallest area such that every n-point set in the unit disk contains a triangle of area ≤ α(n). Best bounds: (log n)/n² ≪ α(n) ≪ 1/n^{7/6+o(1)}. Status: OPEN.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "geometry",
@@ -20412,7 +20433,7 @@
     "slug": "erdos-510",
     "description": "For finite A ⊂ ℕ of size N, must there exist θ with ∑ cos(nθ) < −c√N for absolute c > 0? Best known: −cN^{1/7} (Bedert 2025). Sidon sets show √N is optimal. OPEN.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "harmonic-analysis",
@@ -20617,7 +20638,7 @@
     "slug": "erdos-52",
     "description": "For a finite set A of integers, is max(|A+A|, |A·A|) ≫ |A|^{2-ε} for every ε > 0? Erdős–Szemerédi proved a super-linear bound; Bloom (2025) achieved |A|^{1.335}. OPEN ($250 prize).",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "additive-combinatorics",
@@ -20695,7 +20716,7 @@
     "slug": "erdos-523",
     "description": "For random ±1 polynomials, max_{|z|=1} |f(z)| = (C+o(1))√(n log n)? SOLVED: YES with C = 1 (Halász 1973).",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "analysis",
@@ -20717,7 +20738,7 @@
     "slug": "erdos-524",
     "description": "Determine the correct order of magnitude of M_n(t) = max_{x∈[-1,1]} |Σ_{k≤n} (±1)·x^k| for a.e. t ∈ (0,1), where signs come from binary digits of t. Known: n^{1/2-ε} ≪ M_n ≪ √(n/log log n) i.o. OPEN.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "analysis",
@@ -20864,7 +20885,7 @@
     "slug": "erdos-53",
     "description": "For every k, if |A| is sufficiently large, are there at least |A|^k integers representable as sums or products of distinct elements of A? PROVED by Chang (2003). Erdős–Szemerédi upper bound: exp(c(log|A|)² log log|A|).",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number theory",
@@ -21080,7 +21101,7 @@
     "slug": "erdos-54",
     "description": "A set A is Ramsey 2-complete if every 2-colouring yields monochromatic sums covering all large integers. Conlon–Fox–Pham (2021) showed the minimum growth rate is Θ((log N)²).",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -21141,7 +21162,7 @@
     "slug": "erdos-542",
     "description": "If A ⊆ {1,...,n} with lcm(a,b) > n for distinct a,b ∈ A, must ∑ 1/a ≤ 31/30? Solved by Schinzel-Szekeres (1959).",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -21399,7 +21420,7 @@
     "slug": "erdos-555",
     "description": "Determine R(C₂ₙ; k), the multicolor Ramsey number of even cycles. Erdős showed k^{1+1/(2n)} ≪ R(C₂ₙ; k) ≪ k^{1+1/(n-1)}. For C₄, Chung-Graham gave k²-k+1 < R(C₄;k) ≤ k²+k+1. The exact growth rate is open.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "Ramsey theory",
@@ -21631,7 +21652,7 @@
     "slug": "erdos-566",
     "description": "If every k-vertex subgraph of G has at most 2k−3 edges, is G Ramsey size linear? True for ≤ n+1 edges (EFRS 1993), false for 2n−2 edges. Implies Problem #567. Open.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "graph-theory",
@@ -21806,7 +21827,7 @@
     "slug": "erdos-574",
     "description": "Is ex(n; {C_{2k−1}, C_{2k}}) = (1+o(1))·(n/2)^{1+1/k} for k ≥ 2? Conjectured that forbidding C_{2k−1} in addition to C_{2k} does not change the extremal number asymptotically. Open.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "graph-theory",
@@ -21825,7 +21846,7 @@
     "slug": "erdos-575",
     "description": "For a finite family F of graphs containing a bipartite member, does some bipartite G ∈ F satisfy ex(n;G) ≪ ex(n;F)? That is, does a single bipartite graph control the extremal function? Erdős–Simonovits (1982).",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "extremal graph theory",
@@ -21902,7 +21923,7 @@
     "slug": "erdos-579",
     "description": "For δ > 0 and n large, must every K₂,₂,₂-free graph on n vertices with ≥ δn² edges contain an independent set of size ≫_δ n? Proved for δ > 1/8 by EHSS. Open for general δ.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "graph-theory",
@@ -22042,7 +22063,7 @@
     "slug": "erdos-585",
     "description": "What is the maximum number of edges in an n-vertex graph with no two edge-disjoint cycles on the same vertex set? Known: Ω(n log log n) ≤ f(n) ≤ O(n(log n)^C). The gap remains open.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "graph theory",
@@ -22220,7 +22241,7 @@
     "slug": "erdos-593",
     "description": "Characterize finite 3-uniform hypergraphs appearing in every 3-uniform hypergraph of chromatic number > ℵ₀. For graphs, the answer is bipartite graphs. The 3-uniform case remains OPEN ($500 prize).",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "set-theory",
@@ -22321,7 +22342,7 @@
     "slug": "erdos-598",
     "description": "Can one color countable subsets of an infinite set m with κ = (2^ℵ₀)⁺ colors so that every κ-sized subset contains all colors? OPEN.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "set-theory",
@@ -22596,7 +22617,7 @@
     "slug": "erdos-609",
     "description": "Let f(n) = min cycle length forced in n-colorings of K_{2^n+1}. K_{2^n} can avoid all odd cycles, but K_{2^n+1} cannot. Estimate f(n). OPEN with exponential gap between bounds.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "ramsey-theory",
@@ -22617,7 +22638,7 @@
     "slug": "erdos-61",
     "description": "For any graph H, does there exist c > 0 such that every H-free graph on n vertices has a clique or independent set of size at least n^c?",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "graph-theory",
@@ -22958,7 +22979,7 @@
     "slug": "erdos-625",
     "description": "For G(n, 1/2), does χ(G) - ζ(G) → ∞ almost surely? The cochromatic number ζ(G) allows color classes to be cliques or independent sets. Heckel/Steiner (2024) proved the difference is unbounded. Prize: $1000 (false) / $100 (true).",
     "status": "axiomatized",
-    "badge": "wip",
+    "badge": "axiom",
     "tags": [
       "erdos",
       "graph-theory",
@@ -23274,7 +23295,7 @@
     "slug": "erdos-64",
     "description": "Does every finite graph with minimum degree ≥ 3 contain a cycle of length 2^k for some k ≥ 2? OPEN ($1000 prize).",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "extremal-graph-theory",
@@ -23372,7 +23393,7 @@
     "slug": "erdos-644",
     "description": "Let f(k,r) be the minimum size of a covering set for k-uniform families where every r sets share a common pair. Known: f(k,3)=2k, f(k,4)=⌊3k/2⌋, f(k,5)=⌊5k/4⌋, f(k,6)=k. Is f(k,7)=(3/4+o(1))k?",
     "status": "axiomatized",
-    "badge": "wip",
+    "badge": "axiom",
     "tags": [
       "erdos",
       "combinatorics",
@@ -23590,7 +23611,7 @@
     "slug": "erdos-654",
     "description": "Given n points in the plane with no four on a circle, must some point determine (1-o(1))n distinct distances? Known: each point has ≥ (n-1)/3 distinct distances. Status: OPEN.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "geometry",
@@ -23609,7 +23630,7 @@
     "slug": "erdos-655",
     "description": "With no circle centered at any point containing 3+ others, do n points in ℝ² determine ≥ (1+c)n/2 distinct distances? FALSE as stated (Hunter). Likely intended with no 4 concyclic. Open.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "combinatorial-geometry",
@@ -23730,7 +23751,7 @@
     "slug": "erdos-66",
     "description": "Is there a set A ⊆ ℕ such that the representation function r_A(n) = |{(a,b) ∈ A² : a+b=n}| satisfies lim r_A(n)/log(n) = c ≠ 0?",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -23771,7 +23792,7 @@
     "slug": "erdos-661",
     "description": "Do there exist point sets x₁,...,xₙ and y₁,...,yₙ in ℝ² with o(n/√log n) distinct bipartite distances? Is F(2n) = o(f(2n))? In ℝ⁴ all distances can be equal (Lenz). $50 reward. Open.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "combinatorial-geometry",
@@ -23991,7 +24012,7 @@
     "slug": "erdos-671",
     "description": "Can Lagrange interpolation converge at points where the Lebesgue function diverges? Two open questions with $250 prize. Bernstein (1931) and Erdos-Vertesi (1980) established fundamental divergence results.",
     "status": "axiomatized",
-    "badge": "wip",
+    "badge": "axiom",
     "tags": [
       "erdos",
       "analysis",
@@ -24288,7 +24309,7 @@
     "slug": "erdos-685",
     "description": "For n^ε < k ≤ n^{1-ε}, is ω(C(n,k)) = (1+o(1))·k·Σ_{k<p<n} 1/p? Trivial lower bound: log C(n,k)/log n, tight when k > n^{1-o(1)}.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -24347,7 +24368,7 @@
     "slug": "erdos-688",
     "description": "Define εₙ as the max ε such that choosing one residue class per prime in (n^ε, n] covers [1,n]. Estimate εₙ; is εₙ = o(1)? Erdős showed εₙ ≫ (log log log n)/(log log n).",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number theory",
@@ -24422,7 +24443,7 @@
     "slug": "erdos-691",
     "description": "Find a necessary and sufficient condition for a set A ⊆ ℕ to be a Behrend sequence (its multiples have density 1). Known for coprime sets: Σ 1/a = ∞. General criterion remains open.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -24623,7 +24644,7 @@
     "slug": "erdos-70",
     "description": "Let 𝔠 be the cardinality of the continuum, β be any countable ordinal, and 2 ≤ n < ω. Is it true that 𝔠 → (β, n)₂³? OPEN.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "partition-calculus",
@@ -24663,7 +24684,7 @@
     "slug": "erdos-700",
     "description": "Study f(n) = min_{1<k≤n/2} gcd(n, C(n,k)). When does f(n) = n/P(n)? Are there ∞ many n with f(n) > √n? Is f(n) ≪ n/(log n)^A? Known: f(pq) = p, f(p²) ≥ p. Open.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -25551,7 +25572,7 @@
     "slug": "erdos-74",
     "description": "For f(n) → ∞, is there a graph with infinite chromatic number where every n-vertex subgraph can be made bipartite by deleting ≤ f(n) edges?",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "graph-theory",
@@ -25780,7 +25801,7 @@
     "slug": "erdos-75",
     "description": "Is there a graph of chromatic number ℵ₁ such that every sufficiently large finite subgraph on n vertices has an independent set of size > n^{1−ε}? A $1000 Erdős prize problem.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "graph-theory",
@@ -25799,7 +25820,7 @@
     "slug": "erdos-750",
     "description": "For f(m) → ∞, does there exist an infinite-chromatic graph where every m-vertex subgraph has an independent set of size ≥ m/2 - f(m)? Solved for f(m) = εm (EHS82). Open for sublinear f.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "graph-theory",
@@ -26195,7 +26216,7 @@
     "slug": "erdos-768",
     "description": "Determine the exact asymptotic density of integers n where every prime divisor p has a witness divisor d > 1 with d ≡ 1 (mod p).",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -26540,7 +26561,7 @@
     "slug": "erdos-783",
     "description": "Given budget C on reciprocal sums, which pairwise coprime A ⊆ {2,...,n} minimizes unsieved integers? Conjectured: first k primes with Σ 1/p_i ≤ C. Status: OPEN.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -27500,7 +27521,7 @@
     "slug": "erdos-825",
     "description": "Is there an absolute constant C > 0 such that every n with σ(n) > Cn is the distinct sum of proper divisors of n? Equivalently, do weird numbers have bounded abundancy?",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number theory",
@@ -27518,7 +27539,7 @@
     "slug": "erdos-826",
     "description": "Are there infinitely many n such that τ(n+k) ≪ k for all k ≥ 1? This open problem asks whether the divisor function can be controlled linearly along shifted sequences from infinitely many starting points.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -27622,7 +27643,7 @@
     "slug": "erdos-830",
     "description": "Are there infinitely many amicable pairs? Two numbers are amicable if each is the sum of the other's proper divisors, like 220 and 284.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -27766,7 +27787,7 @@
     "slug": "erdos-837",
     "description": "Define A_k as the density jump values for k-uniform hypergraphs. For graphs, A_2 = {1−1/m : m ≥ 1} by Erdős–Stone. What is A_3? Connected to hypergraph Turán problem. Open.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "graph-theory",
@@ -27942,7 +27963,7 @@
     "slug": "erdos-845",
     "description": "For C > 0, does the set of integers expressible as sums of 3-smooth numbers b₁ < ... < bₜ with bₜ ≤ Cb₁ have density 0? Disproved: all integers have such representations with C = 6.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -28002,7 +28023,7 @@
     "slug": "erdos-848",
     "description": "Max |A| with A ⊆ {1,...,N} and ab+1 never squarefree for a,b ∈ A. Extremal sets: {n ≡ 7 (mod 25)} or {n ≡ 18 (mod 25)}, giving N/25. Solved by Sawhney for large N.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -28042,7 +28063,7 @@
     "slug": "erdos-85",
     "description": "Is the minimum degree threshold f(n) for forcing a 4-cycle monotone? That is, is f(n+1) ≥ f(n) for all large n?",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "graph-theory",
@@ -28141,7 +28162,7 @@
     "slug": "erdos-854",
     "description": "Study the gaps between consecutive integers coprime to primorials. Erdős asked to estimate the smallest missing gap and whether the number of distinct gaps is proportional to the maximal gap.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -28342,7 +28363,7 @@
     "slug": "erdos-863",
     "description": "For B₂[r] sets in {1,...,N}, do the asymptotic constants cᵣ (sums) and c'ᵣ (differences) differ when r ≥ 2? For r = 1 (Sidon sets), c₁ = c'₁ = 1. Erdős conjectured c'ᵣ < cᵣ. Open.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "additive-combinatorics",
@@ -28399,7 +28420,7 @@
     "slug": "erdos-866",
     "description": "For k ≥ 3, define g_k(N) as the minimal threshold such that A ⊆ {1,...,2N} with |A| ≥ N + g_k(N) contains all pairwise sums of some b₁,...,b_k. Known: g₃=2, g₄≤2032, g₅≍log N, g₆≍√N. General bounds have gaps.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "additive-combinatorics",
       "sumsets",
@@ -28558,7 +28579,7 @@
     "slug": "erdos-873",
     "description": "Can the count of k-tuples with small LCM be made subpolynomial by choosing k large enough? An open problem of Erdős and Szemerédi on multiplicative structure of sequences.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -28924,7 +28945,7 @@
     "slug": "erdos-89",
     "description": "Does every set of n distinct points in ℝ² determine ≫ n/√(log n) many distinct distances?",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "combinatorial-geometry",
@@ -28962,7 +28983,7 @@
     "slug": "erdos-891",
     "description": "For k ≥ 2 and large n, must every interval [n, n + p₁···pₖ) contain an integer with more than k prime factors? OPEN, even for k = 2 (intervals of length 6).",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -29163,7 +29184,7 @@
     "slug": "erdos-90",
     "description": "What is the maximum number u(n) of unit-distance pairs among n points in ℝ²? Erdős conjectured u(n) = n^{1+O(1/log log n)}. Best upper bound is O(n^{4/3}) by Spencer–Szemerédi–Trotter. $500 prize.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "combinatorial-geometry",
@@ -29818,7 +29839,7 @@
     "slug": "erdos-929",
     "description": "Let S(k) be the minimal x such that a positive density of n have n+1,...,n+k all x-smooth. Is S(k) ≥ k^{1−o(1)}? Known: k^{1/2−o(1)} ≤ S(k) ≤ k·(log³ k)/(log² k · log⁴ k) by Ford–Green–Konyagin–Maynard–Tao.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number theory",
@@ -30018,7 +30039,7 @@
     "slug": "erdos-938",
     "description": "Are there only finitely many three-term arithmetic progressions among consecutive powerful numbers?",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -30093,7 +30114,7 @@
     ],
     "erdosNumber": 94,
     "sorries": 2,
-    "annotationCount": 3
+    "annotationCount": 5
   },
   {
     "id": "erdos-940",
@@ -30200,7 +30221,7 @@
     "slug": "erdos-945",
     "description": "How long can a run of consecutive integers be where all have distinct numbers of divisors? Is the maximum length bounded by a polynomial in log x?",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -30402,7 +30423,7 @@
     "slug": "erdos-954",
     "description": "Define a greedy sequence 0 = a₀ < a₁ < ⋯ where a_{k+1} is minimal with representation count < a_{k+1}. Is R(x) = x + O(x^{1/4+o(1)})? Even R(x) ≤ (1+o(1))x is open. Status: OPEN.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -30781,7 +30802,7 @@
     "slug": "erdos-971",
     "description": "For p(a,d) the least prime congruent to a mod d, does there exist c > 0 such that p(a,d) > (1+c)φ(d)log d for many residue classes a, for all large d?",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -30862,7 +30883,7 @@
     "slug": "erdos-975",
     "description": "Does the sum of divisor counts over polynomial values have an asymptotic formula with a specific constant?",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "number-theory",
@@ -30962,7 +30983,7 @@
     "slug": "erdos-98",
     "description": "Let h(n) = min distinct distances for n points with no 3 collinear and no 4 concyclic. Does h(n)/n → ∞? Known: h(n) < n·exp(c√(log n)). Even h(n) ≥ n is unknown. Open.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "erdos",
       "combinatorial-geometry",
@@ -32106,7 +32127,7 @@
     "slug": "fourier-series-oq-02-oq-03",
     "description": "Investigates the sharpness of the constant 1/2 in the Fourier coefficient decay bound for Hölder functions: ‖ĉ_n(f)‖ ≤ (1/2)·C·(T/(2|n|))^α. Proves structural properties and states sharpness via extremal sawtooth functions.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "harmonic-analysis",
       "fourier-series",
@@ -32457,7 +32478,7 @@
     "dateAdded": "2026-03-30",
     "mathlibCount": 5,
     "sorries": 0,
-    "annotationCount": 0
+    "annotationCount": 6
   },
   {
     "id": "gcd-algorithm",
@@ -32972,7 +32993,7 @@
     "dateAdded": "2026-04-03",
     "mathlibCount": 2,
     "sorries": 0,
-    "annotationCount": 0
+    "annotationCount": 7
   },
   {
     "id": "hilbert-10",
@@ -33094,7 +33115,7 @@
     "dateAdded": "2026-03-29",
     "mathlibCount": 3,
     "sorries": 0,
-    "annotationCount": 4
+    "annotationCount": 9
   },
   {
     "id": "hilbert-15",
@@ -33765,7 +33786,7 @@
       "mathieu-groups"
     ],
     "sorries": 6,
-    "annotationCount": 0
+    "annotationCount": 7
   },
   {
     "id": "inverse-galois-oq-06",
@@ -33824,7 +33845,7 @@
     "dateAdded": "2026-03-28",
     "mathlibCount": 2,
     "sorries": 0,
-    "annotationCount": 0
+    "annotationCount": 7
   },
   {
     "id": "isosceles-triangle",
@@ -34794,7 +34815,7 @@
     "dateAdded": "2026-03-30",
     "mathlibCount": 3,
     "sorries": 0,
-    "annotationCount": 0
+    "annotationCount": 7
   },
   {
     "id": "navier-stokes-regularity",
@@ -35306,7 +35327,7 @@
     "dateAdded": "2026-03-28",
     "mathlibCount": 2,
     "sorries": 0,
-    "annotationCount": 0
+    "annotationCount": 7
   },
   {
     "id": "platonic-solids-oq-02",
@@ -35327,7 +35348,7 @@
     "dateAdded": "2026-03-28",
     "mathlibCount": 1,
     "sorries": 0,
-    "annotationCount": 0
+    "annotationCount": 6
   },
   {
     "id": "poincare-conjecture",
@@ -36161,7 +36182,7 @@
     "dateAdded": "2026-03-30",
     "mathlibCount": 3,
     "sorries": 0,
-    "annotationCount": 0
+    "annotationCount": 6
   },
   {
     "id": "schroeder-bernstein-oq-04",
@@ -36442,7 +36463,7 @@
     "slug": "solution-of-cubic-oq-03-oq-02",
     "description": "Formalizes the casus irreducibilis: when the depressed cubic x³+px+q=0 has three distinct real roots (Δ>0), Cardano's formula necessarily involves non-real complex cube roots. Proves D<0 implies non-real arguments, verifies a concrete example (x³-7x+6=0), and states Wantzel's impossibility theorem.",
     "status": "axiomatized",
-    "badge": "axiom",
+    "badge": "wip",
     "tags": [
       "algebra",
       "cubic-equations",
@@ -36454,7 +36475,7 @@
     ],
     "dateAdded": "2026-03-28",
     "sorries": 0,
-    "annotationCount": 0
+    "annotationCount": 6
   },
   {
     "id": "solution-of-cubic-oq-03-oq-03",
@@ -36776,7 +36797,7 @@
     "slug": "subset-count-multiset",
     "description": "Generalizes the subset counting theorem to multisets: a multiset with n elements has 2^n submultisets, and the number of k-element submultisets is C(n,k).",
     "status": "verified",
-    "badge": "original",
+    "badge": "mathlib",
     "tags": [
       "combinatorics",
       "multisets",
@@ -37128,7 +37149,7 @@
     ],
     "dateAdded": "2026-03-30",
     "sorries": 3,
-    "annotationCount": 0
+    "annotationCount": 6
   },
   {
     "id": "taylor-theorem",


### PR DESCRIPTION
## Fix

Regenerates `listings.json` from all individual `meta.json` files to sync the gallery index with recent badge corrections that were applied to individual files but not propagated to the index.

## Evidence

**Before**: `listings.json` had stale badge data — axiom badges for 151 proofs that were corrected in their `meta.json` files, missing 2 new proof entries, stale entry for `cramers-rule-oq-01-oq-01` (no proof directory exists).

**After**: `listings.json` reflects current state of all `meta.json` files.

## Changes

- **151 proofs**: `axiom → wip` (fixes from #9407 + #9413 not reflected in index)
- **4 proofs**: `wip → axiom` (fixes from #9414 not reflected in index)  
- **2 proofs**: badge corrections (area-of-circle-oq-03-oq-02: `original → mathlib` from #9402)
- **2 new entries**: `binomial-theorem-oq-02-oq-01-oq-02` (verified, #9396) and `erdos-1059-oq-01` (axiom, #9404)
- **1 removed**: `cramers-rule-oq-01-oq-01` stale entry (no proof directory)

Generated via `pnpm annotations:build`, build verified with `pnpm build`.

---
Automated fix by lean-mechanic agent.