### PR TITLE
Enrich gallery proofs: erdos-114-oq-01, chinese-remainder-constructive-oq-04-oq-04, burnside-counting-oq-03, ballot-problem-oq-01-oq-04, roth-theorem-k3-oq-02

### DIFF
--- a/src/data/proofs/factor-remainder-nullstellensatz/annotations.json
+++ b/src/data/proofs/factor-remainder-nullstellensatz/annotations.json
@@ -2,67 +2,85 @@
   {
     "id": "ann-factor-ideal",
     "proofId": "factor-remainder-nullstellensatz",
-    "range": {
-      "startLine": 50,
-      "endLine": 53
-    },
-    "title": "Factor Theorem as Ideal Membership",
-    "type": "concept",
-    "content": "The Factor Theorem $f(a) = 0 \\iff (X-a) \\mid f$ restated as ideal membership. This perspective is the gateway to algebraic geometry: 'evaluation is zero' becomes 'belongs to the ideal'.",
-    "mathContext": "In algebraic geometry, the zero set $V(I)$ of an ideal $I$ is the set of points where all polynomials in $I$ vanish. The Factor Theorem says that $a \\in V((X - a))$ iff $f(a) = 0$ iff $f \\in (X - a)$.",
+    "range": { "startLine": 57, "endLine": 67 },
+    "type": "theorem",
+    "title": "factor_theorem_ideal: Factor Theorem as Ideal Membership",
+    "content": "`factor_theorem_ideal` restates the Factor Theorem as `f.eval a = 0 ↔ (X - C a) ∣ f`, proved in one line by `(dvd_iff_isRoot).symm`. This is the bridge between evaluation-based algebra and divisibility-based ring theory. The iff direction 'evaluation zero ↔ polynomial divisibility' is the key algebraic fact underlying algebraic geometry: 'a ∈ V(f)' (point lies on variety) becomes 'f ∈ (X-a)' (polynomial in ideal). `nonroot_iff_not_in_ideal` gives the contrapositive.",
+    "mathContext": "The Mathlib theorem `Polynomial.dvd_iff_isRoot : (X - C a) ∣ f ↔ f.IsRoot a` and `f.IsRoot a = (f.eval a = 0)` by definition. So `factor_theorem_ideal` is just the symmetric restatement. In algebraic geometry: the zero set $V(I) = \\{v \\mid \\forall f \\in I, f(v) = 0\\}$; the Factor Theorem gives $V((X - C a)) = \\{a\\}$, making the principal ideal $(X - a)$ the ideal-theoretic version of the point $a$.",
     "significance": "key",
-    "relatedConcepts": [
-      "ideal membership",
-      "polynomial evaluation",
-      "Factor Theorem"
-    ],
-    "prerequisites": [
-      "Polynomial.dvd_iff_isRoot"
-    ]
+    "relatedConcepts": ["Polynomial.dvd_iff_isRoot", "ideal membership", "polynomial evaluation", "Factor Theorem", "zero set V(I)"],
+    "prerequisites": ["Polynomial.dvd_iff_isRoot in Mathlib", "IsRoot definition", "principal ideals in polynomial rings"]
   },
   {
     "id": "ann-weak-nullstellensatz",
     "proofId": "factor-remainder-nullstellensatz",
-    "range": {
-      "startLine": 73,
-      "endLine": 77
-    },
-    "title": "Weak Nullstellensatz (Univariate)",
-    "type": "concept",
-    "content": "Over an algebraically closed field, every nonconstant polynomial has a root. This is the one-variable case of the general weak Nullstellensatz.",
-    "mathContext": "The general weak Nullstellensatz states: if $k$ is algebraically closed and $I \\subsetneq k[x_1, \\ldots, x_n]$ is a proper ideal, then $V(I) \\neq \\emptyset$. For $n = 1$, $k[x]$ is a PID, so $I = (f)$ for some $f$, and the result reduces to `IsAlgClosed.exists_root`.",
+    "range": { "startLine": 73, "endLine": 84 },
+    "type": "theorem",
+    "title": "weak_nullstellensatz_univariate: Algebraic Closure → Existence of Root",
+    "content": "`weak_nullstellensatz_univariate` proves: for an algebraically closed field k, every nonconstant polynomial has a root. The proof reduces directly to `IsAlgClosed.exists_root`: the algebraic closure condition says every nonconstant polynomial has a root. The `degree_eq_natDegree` lemma bridges between `Polynomial.natDegree > 0` and the `Polynomial.degree ≠ ⊥` condition that `IsAlgClosed.exists_root` requires. `exists_linear_factor` then chains this with the Factor Theorem to get a linear factor.",
+    "mathContext": "The general weak Nullstellensatz: if $k$ is algebraically closed and $I \\subsetneq k[x_1, \\ldots, x_n]$ is proper, then $V(I) \\neq \\emptyset$. For $n = 1$: $k[x]$ is a PID, so every proper ideal is $(f)$ for some $f$. `IsAlgClosed.exists_root` gives a root $a$, and the Factor Theorem gives $(X - a) \\mid f$, so $a \\in V(f)$. The proof chains: `weak_nullstellensatz_univariate` → `exists_linear_factor` → full factorization over $\\overline{k}$.",
     "significance": "key",
-    "relatedConcepts": [
-      "algebraic closure",
-      "IsAlgClosed",
-      "Nullstellensatz"
-    ],
-    "prerequisites": [
-      "IsAlgClosed.exists_root",
-      "Polynomial.degree_eq_natDegree"
-    ]
+    "relatedConcepts": ["IsAlgClosed.exists_root", "Polynomial.degree_eq_natDegree", "algebraic closure", "Nullstellensatz"],
+    "prerequisites": ["IsAlgClosed typeclass in Mathlib", "Polynomial.natDegree vs Polynomial.degree", "IsAlgClosed.exists_root"]
   },
   {
     "id": "ann-hierarchy",
     "proofId": "factor-remainder-nullstellensatz",
-    "range": {
-      "startLine": 108,
-      "endLine": 147
-    },
-    "title": "Nullstellensatz Hierarchy",
+    "range": { "startLine": 108, "endLine": 147 },
     "type": "concept",
-    "content": "Four levels of zero-set theorems:\n1. Factor Theorem (1 var, 1 poly)\n2. Weak Nullstellensatz (n vars, proper ideal → common zero)\n3. Strong Nullstellensatz ($I(V(J)) = \\sqrt{J}$)\n4. Combinatorial Nullstellensatz (Alon 1999, coefficient conditions → nonvanishing)",
-    "mathContext": "Each level generalizes the previous. The documentation outlines what Lean/Mathlib infrastructure would be needed for each level, serving as a roadmap for future formalization.",
+    "title": "Nullstellensatz Hierarchy: From Factor Theorem to Combinatorics",
+    "content": "The documentation (lines 119-151) outlines four levels: (1) Factor Theorem (1 var, 1 poly); (2) Weak Nullstellensatz (n vars, proper ideal has a zero); (3) Strong Nullstellensatz (I(V(J)) = √J); (4) Combinatorial Nullstellensatz (Alon 1999, coefficient condition → nonvanishing). Each level requires more machinery: Level 2 needs Jacobson ring theory, Level 3 needs radical ideals, Level 4 needs polynomial degree arguments. The formalization proves Level 2 (univariate) and defines the infrastructure for Levels 2-3 via zeroLocus and vanishingIdeal.",
+    "mathContext": "The hierarchy: (1) $f(a) = 0 \\iff (X-a) \\mid f$ (Factor Theorem). (2) Weak Nullstellensatz: $I \\subsetneq k[\\mathbf{x}] \\Rightarrow V(I) \\neq \\emptyset$ (algebraically closed $k$). (3) Strong Nullstellensatz: $I(V(J)) = \\sqrt{J}$ for any ideal $J$. (4) Combinatorial Nullstellensatz (Alon): if coeff of $\\prod x_i^{t_i}$ in $f$ is nonzero and $|S_i| > t_i$, then $\\exists s \\in \\prod S_i$ with $f(s) \\neq 0$. Level 4 has applications to combinatorics (graph coloring, sum-sets, Chevalley-Warning).",
     "significance": "key",
-    "relatedConcepts": [
-      "Hilbert's Nullstellensatz",
-      "radical ideal",
-      "algebraic variety",
-      "combinatorial Nullstellensatz"
-    ],
-    "prerequisites": [
-      "ideal theory",
-      "algebraic geometry basics"
-    ]
+    "relatedConcepts": ["Hilbert's Nullstellensatz", "radical ideal", "algebraic variety", "combinatorial Nullstellensatz", "Jacobson ring"],
+    "prerequisites": ["ideal theory", "algebraic geometry basics", "Chevalley-Warning theorem"]
+  },
+  {
+    "id": "ann-zero-locus-def",
+    "proofId": "factor-remainder-nullstellensatz",
+    "range": { "startLine": 166, "endLine": 173 },
+    "type": "definition",
+    "title": "zeroLocus: The Geometric Side of the V-I Galois Connection",
+    "content": "`zeroLocus S` is the set of points where every polynomial in S evaluates to zero: `{ v | ∀ f ∈ S, MvPolynomial.eval v f = 0 }`. This is the fundamental geometric object in algebraic geometry — an algebraic variety. The function V: (Sets of polynomials) → (Sets of points) is the first half of the Galois connection V ⊣ I. Key property proved: `zeroLocus_antimono` (S ⊆ T → V(T) ⊆ V(S)) — more equations means fewer solutions.",
+    "mathContext": "The zero locus of $S \\subseteq k[x_1, \\ldots, x_n]$ is $V(S) = \\{v : \\sigma \\to k \\mid \\forall f \\in S, f(v) = 0\\}$. In the Lean formalization, $\\sigma$ is a `Type*` (not necessarily finite), $k$ is a `CommRing`, and `MvPolynomial σ k` is the multivariate polynomial ring. `MvPolynomial.eval v f` computes $f(v)$ by substituting $v(i)$ for the $i$-th variable. The antimonotonicity: $S \\subseteq T \\Rightarrow V(T) \\subseteq V(S)$ follows directly from the universal quantifier.",
+    "significance": "key",
+    "relatedConcepts": ["MvPolynomial", "algebraic variety", "zeroLocus_antimono", "Galois connection V-I", "eval ring homomorphism"],
+    "prerequisites": ["MvPolynomial in Mathlib", "Set theory in Lean 4", "CommRing typeclass"]
+  },
+  {
+    "id": "ann-vanishing-ideal-def",
+    "proofId": "factor-remainder-nullstellensatz",
+    "range": { "startLine": 175, "endLine": 189 },
+    "type": "definition",
+    "title": "vanishingIdeal: The Algebraic Side, Proved to be an Ideal",
+    "content": "`vanishingIdeal W` collects all polynomials vanishing on every point in W, and is directly constructed as an `Ideal (MvPolynomial σ k)`. The construction proves all three ideal axioms inline: `add_mem'` (sum of vanishing polynomials vanishes), `zero_mem'` (zero polynomial vanishes), `smul_mem'` (scalar multiple of vanishing polynomial vanishes). All proofs use the ring homomorphism property of `MvPolynomial.eval v` via `map_add`, `map_zero`, `map_mul`.",
+    "mathContext": "The vanishing ideal $I(W) = \\{f \\in k[\\mathbf{x}] \\mid \\forall v \\in W, f(v) = 0\\}$ is always an ideal (not just a set). Proof that it is closed under addition: if $f(v) = g(v) = 0$ then $(f+g)(v) = f(v) + g(v) = 0$. Proof of `smul_mem'`: $(c \\cdot f)(v) = c \\cdot f(v) = c \\cdot 0 = 0$. In Lean, the `Ideal` type is a `Submodule` over the ring acting on itself, so `smul_mem'` has signature `smul_mem' c {f} hf`. This is more general than the usual ring-ideal definition.",
+    "significance": "key",
+    "relatedConcepts": ["Ideal in Lean 4", "MvPolynomial.eval ring hom", "map_add", "map_mul", "Submodule"],
+    "prerequisites": ["Ideal as Submodule in Mathlib", "MvPolynomial.eval as ring homomorphism", "smul_mem' axiom"]
+  },
+  {
+    "id": "ann-galois-connection",
+    "proofId": "factor-remainder-nullstellensatz",
+    "range": { "startLine": 201, "endLine": 211 },
+    "type": "theorem",
+    "title": "V-I Galois Connection: S ⊆ V(I(S)) and S ⊆ I(V(S))",
+    "content": "Two single-line proofs establish the fundamental Galois connection. `subset_zeroLocus_vanishingIdeal`: `W ⊆ V(I(W))` — every point of W lies in the zero locus of all polynomials vanishing on W. `subset_vanishingIdeal_zeroLocus`: `S ⊆ I(V(S))` — every polynomial in S vanishes on all zeros of S. Both are proved by `fun v hv f hf => hf v hv` and `fun f hf v hv => hv f hf` — just reordering the universal quantifiers. This captures the fundamental duality of algebraic geometry.",
+    "mathContext": "The Galois connection $V \\dashv I$: $S \\subseteq I(V(S))$ and $W \\subseteq V(I(W))$. More precisely: $I(V(S)) \\supseteq S$ and $V(I(W)) \\supseteq W$, i.e., $V$ and $I$ are order-reversing and $(V \\circ I \\circ V = V)$ and $(I \\circ V \\circ I = I)$. These are proved as `zeroLocus_vanishingIdeal_zeroLocus` and `vanishingIdeal_zeroLocus_vanishingIdeal` (the idempotence theorems). The strong Nullstellensatz sharpens $I(V(J)) \\supseteq J$ to equality $I(V(J)) = \\sqrt{J}$ over algebraically closed fields.",
+    "significance": "key",
+    "relatedConcepts": ["Galois connection", "algebraic variety", "zeroLocus", "vanishingIdeal", "strong Nullstellensatz", "radical ideal"],
+    "prerequisites": ["Galois connection in order theory", "algebraic geometry duality", "MvPolynomial evaluation"]
+  },
+  {
+    "id": "ann-idempotence",
+    "proofId": "factor-remainder-nullstellensatz",
+    "range": { "startLine": 236, "endLine": 255 },
+    "type": "theorem",
+    "title": "Idempotence: V(I(V(S))) = V(S) and I(V(I(W))) = I(W)",
+    "content": "Two idempotence theorems complete the Galois connection structure. `zeroLocus_vanishingIdeal_zeroLocus`: V(I(V(S))) = V(S) — applying V then I then V again returns the original zero set. `vanishingIdeal_zeroLocus_vanishingIdeal`: I(V(I(W))) = I(W) — applying I then V then I again returns the original vanishing ideal. These follow from the Galois connection inclusions: V(S) ⊇ V(I(V(S))) (from S ⊆ I(V(S)) and V antimonotone) and V(S) ⊆ V(I(V(S))) (from V(S) ⊆ V(I(V(S))) via `subset_zeroLocus_vanishingIdeal`).",
+    "mathContext": "Idempotence of a Galois connection: if $f \\dashv g$ then $f \\circ g \\circ f = f$ and $g \\circ f \\circ g = g$. Here $f = V$ and $g = I$. The proof of $V(I(V(S))) = V(S)$: (⊆) from $S \\subseteq I(V(S))$ and $V$ antimonotone gives $V(I(V(S))) \\subseteq V(S)$; (⊇) from $W = V(S) \\subseteq V(I(W))$ with $W = V(S)$ gives $V(S) \\subseteq V(I(V(S)))$. Note: $I(V(J)) = J$ would be the strong Nullstellensatz (true only when $J$ is radical), but $I(V(I(W))) = I(W)$ always holds since $I(W)$ is a vanishing ideal.",
+    "significance": "key",
+    "relatedConcepts": ["idempotence", "Galois connection", "strong Nullstellensatz", "radical ideal", "closure operator"],
+    "prerequisites": ["Galois connection idempotence", "Set.eq_of_subset_of_subset", "zeroLocus_antimono and vanishingIdeal_antimono"]
   }
 ]


### PR DESCRIPTION
## Summary

Enrichment pass on 5 gallery proofs — adding mathContext, significance, relatedConcepts, prerequisites to all annotations, fixing type mismatches, adding structured overview/sections/conclusion to meta.json files.

- **erdos-114-oq-01** (Tao's lemniscate threshold): rewrote 5 annotations + added 3 new ones covering lemniscate axioms, Nat.find threshold construction, computability perspective
- **chinese-remainder-constructive-oq-04-oq-04** (Minimal CRT solution): fixed annotation types (context→concept, technique→lemma), added structured meta.json with historicalContext, proofStrategy, keyInsights, sections, conclusion
- **burnside-counting-oq-03** (Pólya enumeration): rewrote annotations with mathContext, added 4 new ones for orbit characterization, bijection, fiber decomposition, necklace application; added meta.json overview fields
- **ballot-problem-oq-01-oq-04** (Chung-Feller theorem): rewrote all 5 annotations with proper schema + added 2 new ones; fixed annotation type errors (proof→insight, context→concept, context→axiom)
- **roth-theorem-k3-oq-02** (Roth's theorem via Ruzsa-Szemerédi): rewrote 6 annotations + added 3 new ones for RS vertex definition, backward triangle direction, edge removal bound

## Labels

enrichment