### PR TITLE
chore: sync research listings and data

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -12499,11 +12499,12 @@
     },
     {
       "slug": "cantor-diagonalization-oq-03-oq-01-oq-01",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "fast",
       "started": "2026-04-04T09:42:47.007Z",
-      "status": "active",
-      "lastUpdate": "2026-04-04T09:42:47.023Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T16:46:53.625Z",
+      "completed": "2026-04-04T16:46:53.624Z"
     },
     {
       "slug": "cantor-diagonalization-oq-03-oq-01-oq-02",


### PR DESCRIPTION
Automated sync of research listings and data files.

- Added 44, updated 654 listings
- Total iterations: 3662

🤖 Generated by deployer agent