### PR TITLE
chore: update audit tracker — cycle-42

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11413,6 +11413,12 @@
       "lastAudited": "2026-04-04T16:25:33Z",
       "result": "issues-fixed",
       "issues": []
+    },
+    "cantor-diagonalization-oq-03-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T16:58:24Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
Audit tracker update for cycle-42:
- cantor-diagonalization-oq-03-oq-01-oq-01: **clean** (0 sorries, 0 axioms, badge=original, status=verified — all correct)