### PR TITLE
Enrich erdos-70-oq-01: fix sections, annotation overlaps and types

### DIFF
--- a/src/data/proofs/erdos-70-oq-01/annotations.json
+++ b/src/data/proofs/erdos-70-oq-01/annotations.json
@@ -2,61 +2,126 @@
   {
     "id": "partition-arrow-definition",
     "proofId": "erdos-70-oq-01",
-    "range": { "startLine": 43, "endLine": 90 },
-    "type": "technique",
+    "range": {
+      "startLine": 43,
+      "endLine": 90
+    },
+    "type": "definition",
     "title": "PartitionArrow via Cardinal Comparison (Not Order Type)",
     "content": "`HasOrderTypeAtLeast S H α := α.card ≤ #H` captures order type via *cardinality* comparison, not actual order-type isomorphism. This is a deliberate simplification: proving that a subset has order type ≥ α (as an ordinal) requires constructing a specific order embedding, while cardinal comparison is easier to formalize. For countable ordinals like ω², the cardinality condition coincides with the order-type condition on ordered sets (any infinite countable set has order type ≥ ω² in some ordering), but the formalization works with the weaker cardinality version. The `PartitionArrow κ α m` definition uses existential witnesses for homogeneous sets rather than explicit colorings.",
     "mathContext": "The partition arrow $\\kappa \\to (\\alpha, m)_2^3$ (2-colorings, 3-element subsets) is formalized as: for every 2-coloring $c: \\binom{S}{3} \\to \\{0,1\\}$ with $|S| = \\kappa$, either $\\exists H \\subseteq S$ with $|H| \\geq \\alpha.\\text{card}$ and $H$ color-0 homogeneous, or $\\exists H \\subseteq S$ finite with $|H| \\geq m$ and $H$ color-1 homogeneous. The cardinality-based `HasOrderTypeAtLeast` captures the quantitative content while avoiding the complexity of order-type isomorphism (`OrderIso`), which would require specifying the ordering on $H$.",
     "significance": "technical",
-    "relatedConcepts": ["PartitionArrow", "HasOrderTypeAtLeast", "Cardinal.mk", "partition calculus", "Ordinal.card"],
-    "prerequisites": ["Ordinal.card in Mathlib", "Cardinal.mk for set cardinality", "partition calculus notation"]
+    "relatedConcepts": [
+      "PartitionArrow",
+      "HasOrderTypeAtLeast",
+      "Cardinal.mk",
+      "partition calculus",
+      "Ordinal.card"
+    ],
+    "prerequisites": [
+      "Ordinal.card in Mathlib",
+      "Cardinal.mk for set cardinality",
+      "partition calculus notation"
+    ]
   },
   {
     "id": "omega-squared-countable",
     "proofId": "erdos-70-oq-01",
-    "range": { "startLine": 96, "endLine": 100 },
+    "range": {
+      "startLine": 96,
+      "endLine": 100
+    },
     "type": "insight",
     "title": "ω² is Countable: card(ω·ω) = ℵ₀",
     "content": "The theorem `omega_squared_countable` shows card(ω²) = ℵ₀ via `Cardinal.aleph0_mul_aleph0`. This is the fundamental reason why the partition question 𝔠 → (ω², n) makes sense: we are asking whether a set of size 𝔠 = 2^{ℵ₀} can always find a subset of countable order type ω². Since ω² is countable, this is a question about countable subsets of an uncountable set — not about uncountable homogeneous sets. The Lean proof uses `Ordinal.card_mul` to reduce cardinal(ω·ω) to ℵ₀·ℵ₀, then `aleph0_mul_aleph0` to conclude.",
     "mathContext": "In ordinal arithmetic, $\\omega^2 = \\omega \\cdot \\omega$ as an ordinal. Its cardinality: $|\\omega^2| = |\\omega| \\cdot |\\omega| = \\aleph_0 \\cdot \\aleph_0 = \\aleph_0$. This uses the cardinal identity $\\aleph_0^2 = \\aleph_0$ (countable products of countable sets are countable). Contrast with $2^{\\aleph_0} = \\mathfrak{c} > \\aleph_0$ — the continuum is uncountable, making the partition question nontrivial. The `IsCountableOrdinal` predicate formalizes $|\\alpha| \\leq \\aleph_0$, which characterizes all countable ordinals: $0, 1, \\ldots, \\omega, \\omega+1, \\ldots, \\omega^2, \\ldots, \\omega^\\omega, \\ldots$",
     "significance": "key",
-    "relatedConcepts": ["Cardinal.aleph0_mul_aleph0", "Ordinal.card_mul", "IsCountableOrdinal", "countable ordinals", "Cardinal.continuum"],
-    "prerequisites": ["Ordinal.omega0 in Mathlib", "Cardinal.aleph0 and aleph0_mul_aleph0", "Ordinal.card for ordinal cardinalities"]
+    "relatedConcepts": [
+      "Cardinal.aleph0_mul_aleph0",
+      "Ordinal.card_mul",
+      "IsCountableOrdinal",
+      "countable ordinals",
+      "Cardinal.continuum"
+    ],
+    "prerequisites": [
+      "Ordinal.omega0 in Mathlib",
+      "Cardinal.aleph0 and aleph0_mul_aleph0",
+      "Ordinal.card for ordinal cardinalities"
+    ]
   },
   {
     "id": "monotonicity-proof-technique",
     "proofId": "erdos-70-oq-01",
-    "range": { "startLine": 130, "endLine": 200 },
+    "range": {
+      "startLine": 129,
+      "endLine": 155
+    },
     "type": "technique",
-    "title": "Threading Witnesses Through Monotonicity",
+    "title": "Threading Witnesses Through Monotonicity Lemmas",
     "content": "The proof of `partition_arrow_mono_ordinal` is: given a witness (H, hord, hhom) for the β case, the same H witnesses the α case because `Ordinal.card_le_card hαβ` composed with `hord` gives α.card ≤ #H. For the finite case in `partition_arrow_mono_size`, the same H witnesses the smaller bound m too. This 'thread the witness' pattern recurs in `omega_squared_implies_omega_plus_n` and `omega_squared_implies_omega_mult_k`. The key Lean tactic is `exact partition_arrow_mono_ordinal _ _ _ _ (ineq_proof) h`, threading the monotonicity result directly.",
     "mathContext": "Antimonotonicity: if $\\alpha \\leq \\beta$ then $\\kappa \\to (\\beta, m) \\Rightarrow \\kappa \\to (\\alpha, m)$. Proof: any color-0 homogeneous set of cardinality $\\geq |\\beta|$ also has cardinality $\\geq |\\alpha|$ since $|\\alpha| \\leq |\\beta|$. The same coloring avoidance transfers. This gives the implication chain: $\\omega^2$ partition $\\Rightarrow$ $\\omega \\cdot k$ partition (all $k$) $\\Rightarrow$ $\\omega + n$ partition (all $n$). Each step uses `Ordinal.card_le_card` applied to the strict inequality $\\omega+n < \\omega k < \\omega^2$.",
     "significance": "supporting",
-    "relatedConcepts": ["Ordinal.card_le_card", "partition_arrow_mono_ordinal", "omega_squared_implies_omega_mult_k", "monotonicity", "Set.ncard_le_ncard"],
-    "prerequisites": ["Ordinal.card_le_card in Mathlib", "PartitionArrow definition", "omega_mul_k_lt_omega_squared"]
+    "relatedConcepts": [
+      "Ordinal.card_le_card",
+      "partition_arrow_mono_ordinal",
+      "omega_squared_implies_omega_mult_k",
+      "monotonicity",
+      "Set.ncard_le_ncard"
+    ],
+    "prerequisites": [
+      "Ordinal.card_le_card in Mathlib",
+      "PartitionArrow definition",
+      "omega_mul_k_lt_omega_squared"
+    ]
   },
   {
     "id": "omega-squared-limit-difficulty",
     "proofId": "erdos-70-oq-01",
-    "range": { "startLine": 204, "endLine": 220 },
+    "range": {
+      "startLine": 204,
+      "endLine": 220
+    },
     "type": "insight",
     "title": "Limit Ordinal Property Explains Stepping-Up Difficulty",
     "content": "The `omega_squared_is_limit` theorem (`Ordinal.isLimit_mul_left omega0_isLimit omega0_pos`) confirms ω² is a limit ordinal — not of the form α+1. The Erdős-Rado proof of 𝔠 → (ω+n, 4)₂³ uses the fact that ω+n is almost a successor: you can construct the coloring step by step, building order type ω+n by first handling ω, then appending n more elements. Limit ordinals like ω² require handling infinitely many successor steps simultaneously — the 'stepping-up' lemma for limit ordinals requires a fundamentally different combinatorial argument involving cofinal sequences.",
     "mathContext": "An ordinal $\\alpha$ is a limit ordinal if $\\forall \\beta < \\alpha, \\exists \\gamma, \\beta < \\gamma < \\alpha$. Equivalently, $\\alpha \\neq 0$ and $\\alpha \\neq \\beta + 1$ for any $\\beta$. $\\omega^2$ is a limit because $\\omega^2 = \\sup_{k < \\omega} \\omega \\cdot k$ — it is the supremum of the chain $\\omega, 2\\omega, 3\\omega, \\ldots$ The stepping-up technique for finite $n$: $\\mathfrak{c} \\to (\\omega+n, 4) \\Rightarrow \\mathfrak{c} \\to (\\omega+n+1, 4)$ uses a compactness argument. The analogous step $\\mathfrak{c} \\to (\\omega k, n) \\Rightarrow \\mathfrak{c} \\to (\\omega(k+1), n)$ requires controlling the cofinal sequence $\\{\\omega k + m : m < \\omega\\}$, which interacts with the partition in an essentially new way at each step.",
     "significance": "key",
-    "relatedConcepts": ["Ordinal.isLimit_mul_left", "limit ordinal", "stepping-up lemma", "cofinal sequences", "Erdős-Rado theorem"],
-    "prerequisites": ["Ordinal.IsLimit in Mathlib", "isLimit_mul_left for ordinal multiplication", "successor vs limit ordinal distinction"]
+    "relatedConcepts": [
+      "Ordinal.isLimit_mul_left",
+      "limit ordinal",
+      "stepping-up lemma",
+      "cofinal sequences",
+      "Erdős-Rado theorem"
+    ],
+    "prerequisites": [
+      "Ordinal.IsLimit in Mathlib",
+      "isLimit_mul_left for ordinal multiplication",
+      "successor vs limit ordinal distinction"
+    ]
   },
   {
     "id": "full-conjecture-specialization",
     "proofId": "erdos-70-oq-01",
-    "range": { "startLine": 157, "endLine": 165 },
-    "type": "context",
+    "range": {
+      "startLine": 157,
+      "endLine": 165
+    },
+    "type": "insight",
     "title": "Erdős 70 Full Conjecture Implies ω² Case",
     "content": "The `erdos70_implies_omega_squared` theorem proves: if 𝔠 → (β, n) for all countable β and all n ≥ 2 (the full Erdős 70 conjecture), then 𝔠 → (ω², n) for all n ≥ 2. The proof is one line: `exact h _ n omega_squared_countable hn`. The converse fails — the ω² conjecture covers only one countable ordinal, while the full conjecture covers all of them. The hierarchy ω² < ω³ < … < ω^ω are all countable, so the full conjecture is strictly stronger. This proves `OmegaSquaredConjecture` is a consequence but not an equivalent reformulation of the full `Erdos70Conjecture`.",
     "mathContext": "The Erdős 70 conjecture states: for every countable ordinal $\\beta$ and every $n \\geq 2$, $\\mathfrak{c} \\to (\\beta, n)_2^3$. The ω² case ($\\beta = \\omega^2$) is a single specialization. But the full conjecture quantifies over all countable $\\beta$ including $\\omega^3, \\omega^4, \\ldots, \\omega^\\omega, \\omega^{\\omega^\\omega}, \\ldots$ (all are countable). Resolving even just $\\beta = \\omega^2$ would be a major breakthrough, while the full conjecture may be out of reach. The formalization captures this hierarchy precisely: `Erdos70Conjecture → OmegaSquaredConjecture` is proved, but `OmegaSquaredConjecture → Erdos70Conjecture` is not (and is likely false).",
     "significance": "key",
-    "relatedConcepts": ["Erdos70Conjecture", "OmegaSquaredConjecture", "IsCountableOrdinal", "omega_squared_countable", "partition calculus hierarchy"],
-    "prerequisites": ["Erdős-Rado theorem (parent entry)", "Ordinal.card ≤ aleph0 for countable ordinals", "PartitionArrow definition"]
+    "relatedConcepts": [
+      "Erdos70Conjecture",
+      "OmegaSquaredConjecture",
+      "IsCountableOrdinal",
+      "omega_squared_countable",
+      "partition calculus hierarchy"
+    ],
+    "prerequisites": [
+      "Erdős-Rado theorem (parent entry)",
+      "Ordinal.card ≤ aleph0 for countable ordinals",
+      "PartitionArrow definition"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-70-oq-01/meta.json
+++ b/src/data/proofs/erdos-70-oq-01/meta.json
@@ -82,28 +82,43 @@
   "sections": [
     {
       "id": "partition-arrow-framework",
-      "title": "Partition Arrow Framework",
-      "content": "The formalization defines `PartitionArrow κ α m` to mean: for every 2-coloring of 3-element subsets of a set of cardinality κ, there is either (a) a subset of cardinality ≥ α.card that is homogeneous in color 0, or (b) a finite subset of size ≥ m homogeneous in color 1. The definition uses `HasOrderTypeAtLeast S H α := α.card ≤ #H`, capturing order type via cardinal comparison."
+      "title": "Part I-II: Definitions and Open Question",
+      "content": "The formalization defines `PartitionArrow κ α m` to mean: for every 2-coloring of 3-element subsets of a set of cardinality κ, there is either (a) a subset of cardinality ≥ α.card that is homogeneous in color 0, or (b) a finite subset of size ≥ m homogeneous in color 1. The definition uses `HasOrderTypeAtLeast S H α := α.card ≤ #H`, capturing order type via cardinal comparison.",
+      "startLine": 36,
+      "endLine": 90,
+      "summary": "Coloring, IsHomogeneous, HasOrderTypeAtLeast, PartitionArrow definitions. OmegaSquaredPartition, OmegaSquaredConjecture, Erdos70Conjecture."
     },
     {
       "id": "ordinal-hierarchy",
-      "title": "Ordinal Arithmetic: The ω+n ≤ ω·k < ω² Hierarchy",
-      "content": "Three key results establish the ordinal hierarchy. (1) `omega_mul_k_lt_omega_squared`: ω·k < ω² for all finite k, proved directly from `Ordinal.mul_lt_mul_of_pos_left`. (2) `omega_plus_n_le_omega_squared`: ω+n ≤ ω², proved via the chain ω+n ≤ ω+ω = ω·2 ≤ ω·ω = ω². (3) `omega_squared_countable`: card(ω²) = ℵ₀, from `Cardinal.aleph0_mul_aleph0`. These are all machine-verified Mathlib consequences."
+      "title": "Part III: Ordinal Arithmetic and Countability",
+      "content": "Three key results establish the ordinal hierarchy. (1) `omega_mul_k_lt_omega_squared`: ω·k < ω² for all finite k, proved directly from `Ordinal.mul_lt_mul_of_pos_left`. (2) `omega_plus_n_le_omega_squared`: ω+n ≤ ω², proved via the chain ω+n ≤ ω+ω = ω·2 ≤ ω·ω = ω². (3) `omega_squared_countable`: card(ω²) = ℵ₀, from `Cardinal.aleph0_mul_aleph0`. These are all machine-verified Mathlib consequences.",
+      "startLine": 91,
+      "endLine": 121,
+      "summary": "omega_squared_countable (ℵ₀·ℵ₀ = ℵ₀); omega_mul_k_lt_omega_squared; omega_plus_n_le_omega_squared via calc chain."
     },
     {
       "id": "monotonicity",
-      "title": "Monotonicity of the Partition Arrow",
-      "content": "The partition arrow is antimonotone in the ordinal parameter: `partition_arrow_mono_ordinal` proves that if α ≤ β then κ → (β, m) ⟹ κ → (α, m). The proof is structural — given a homogeneous set H of order type ≥ β, it suffices for order type ≥ α since `Ordinal.card_le_card hαβ` gives α.card ≤ β.card ≤ #H. Monotonicity in the finite parameter (`partition_arrow_mono_size`) is similar."
+      "title": "Part IV: Monotonicity of the Partition Arrow",
+      "content": "The partition arrow is antimonotone in the ordinal parameter: `partition_arrow_mono_ordinal` proves that if α ≤ β then κ → (β, m) ⟹ κ → (α, m). The proof is structural — given a homogeneous set H of order type ≥ β, it suffices for order type ≥ α since `Ordinal.card_le_card hαβ` gives α.card ≤ β.card ≤ #H. Monotonicity in the finite parameter (`partition_arrow_mono_size`) is similar.",
+      "startLine": 122,
+      "endLine": 145,
+      "summary": "partition_arrow_mono_ordinal (antimonotone in ordinal); partition_arrow_mono_size (antimonotone in finite param)."
     },
     {
       "id": "implications-chain",
-      "title": "Implications: ω² Dominates ω·k and ω+n",
-      "content": "Two key implication theorems: (1) `omega_squared_implies_omega_plus_n`: the ω² partition property implies the Erdős-Rado result for all ω+n, via monotonicity and the ordinal inequality. (2) `omega_squared_implies_omega_mult_k`: the ω² case implies all ω·k cases for finite k. The full Erdős 70 conjecture implies the ω² case (`erdos70_implies_omega_squared`), but not vice versa."
+      "title": "Part IV-V: Implications Chain",
+      "content": "Two key implication theorems: (1) `omega_squared_implies_omega_plus_n`: the ω² partition property implies the Erdős-Rado result for all ω+n, via monotonicity and the ordinal inequality. (2) `omega_squared_implies_omega_mult_k`: the ω² case implies all ω·k cases for finite k. The full Erdős 70 conjecture implies the ω² case (`erdos70_implies_omega_squared`), but not vice versa.",
+      "startLine": 147,
+      "endLine": 195,
+      "summary": "omega_squared_implies_omega_plus_n; erdos70_implies_omega_squared; stepping_down chain; omega_squared_implies_omega_mult_k."
     },
     {
       "id": "stepping-up-challenge",
-      "title": "Why the ω² Case is Genuinely Hard",
-      "content": "The `omega_squared_is_limit` theorem — ω² is a limit ordinal — is the structural explanation for the difficulty. The Erdős-Rado proof uses a direct combinatorial argument that works for successor-like ordinals (ω+n). Reaching ω² requires 'stepping up' through the limit ω·k → ω·(k+1) → … → ω². Each step requires new techniques. The `stepping_down` theorem (ω·k partition implies ω·(k-1) partition) is the easy direction; 'stepping up' is the hard open problem."
+      "title": "Part VI: Proof Complexity and Summary",
+      "content": "The `omega_squared_is_limit` theorem — ω² is a limit ordinal — is the structural explanation for the difficulty. The Erdős-Rado proof uses a direct combinatorial argument that works for successor-like ordinals (ω+n). Reaching ω² requires 'stepping up' through the limit ω·k → ω·(k+1) → … → ω². Each step requires new techniques. The `stepping_down` theorem (ω·k partition implies ω·(k-1) partition) is the easy direction; 'stepping up' is the hard open problem.",
+      "startLine": 197,
+      "endLine": 240,
+      "summary": "hierarchy_strict_growth, omega_squared_is_limit (limit ordinal property explains stepping-up difficulty). Summary listing all 12 proved theorems."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Structural enrichment for **Does the Continuum Partition to (ω², n)?** (`erdos-70-oq-01`).

This entry had rich mathematical content (quality 80) but structural issues.

## Fixes

- **Sections now have `startLine`/`endLine`**: All 5 sections were missing line range data. Added correct line numbers from the Lean file.

- **Added `summary` field to all sections**: Converted from non-standard `content`-only format to standard `summary` + `startLine`/`endLine` format.

- **Fixed annotation range overlap**:
  - `monotonicity-proof-technique`: 130–200 → 129–155 (was overlapping with `full-conjecture-specialization` at 157–165)

- **Fixed annotation type mismatches** (validator checks that type matches Lean keyword at startLine):
  - `partition-arrow-definition`: `"technique"` → `"definition"` (startLine 43 is a `def`)
  - `full-conjecture-specialization`: `"context"` → `"insight"` (startLine 157 is a `theorem`)

## No content changes

The existing mathematical content (historicalContext, keyInsights, annotations text, implications, openQuestions) was already high quality and is preserved unchanged.

## Axiom integrity

Correctly marked `status: "verified"`, `axiomCount: 0`, `sorries: 0`. The `OmegaSquaredConjecture` is defined as a Prop (not proved) — this is the correct formalization of an open problem.