### PR TITLE
Fix: remove True-stub summary theorem from hilbert-14

### DIFF
--- a/proofs/Proofs/Hilbert14Invariants.lean
+++ b/proofs/Proofs/Hilbert14Invariants.lean
@@ -345,20 +345,20 @@ Hilbert's 14th problem highlighted the importance of:
 - The interplay between algebra and geometry in invariant theory
 -/
 
-/-- Summary of Hilbert's 14th Problem:
+/-
+  Summary of Hilbert's 14th Problem:
 
-    The answer is **conditionally positive**:
-    - YES for reductive groups (the important classical case)
-    - NO in general (Nagata's counterexample)
+  The answer is **conditionally positive**:
+  - YES for reductive groups (the important classical case) — proved by Hilbert (1890)
+    for SL_n/GL_n and generalized by Mumford–Haboush to all reductive groups.
+  - NO in general — Nagata's 1959 counterexample gives a non-reductive group G
+    acting on k[x₁,...,x₃₂] with non-finitely-generated invariant ring.
 
-    This represents a typical resolution pattern for Hilbert's problems:
-    the "obvious" conjecture fails, but a refined version holds. -/
-theorem hilbert_14_summary :
-    -- Reductive case: Yes
-    (∀ (k : Type*) [Field k] (n : ℕ) (G : Type*) [Group G] [Fintype G],
-      True) ∧ -- Finite groups have finitely generated invariants
-    -- General case: No
-    (∃ (counterexample : Prop), True) -- Nagata's counterexample exists
-    := ⟨fun _ _ _ _ _ => trivial, ⟨True, trivial⟩⟩
+  This represents a typical resolution pattern for Hilbert's problems:
+  the "obvious" conjecture fails, but a refined version holds.
+
+  (The formal proof of the reductive case requires deep algebraic geometry not yet
+  in Mathlib; the Nagata counterexample requires explicit construction of the group.)
+-/
 
 end Hilbert14Invariants

--- a/src/data/proofs/hilbert-14/meta.json
+++ b/src/data/proofs/hilbert-14/meta.json
@@ -136,7 +136,7 @@
     "namespace": "Hilbert14Invariants",
     "lineCount": 364,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 4,
     "definitionCount": 1
   },
   "crossReferences": [


### PR DESCRIPTION
## Fix

Removed `hilbert_14_summary` from `proofs/Proofs/Hilbert14Invariants.lean` — it proved `(∀..., True) ∧ (∃..., True)` (mathematically vacuous) while the doc-comment implied it captured the reductive-case positive result and Nagata's counterexample. Converted to a block comment preserving the explanatory text.

## Evidence

**Before**: `theorem hilbert_14_summary` proving `True ∧ True` under `badge: "original"`, `status: "verified"` — misleading to readers expecting mathematical content.

**After**: Plain `/-...-/` comment block with the same explanatory text; `leanFile.theoremCount` updated 5 → 4.

---
Automated fix by lean-mechanic agent.