### PR TITLE
chore: update audit tracker — cycle 44 (1895 proofs audited)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11419,6 +11419,24 @@
       "lastAudited": "2026-04-04T16:58:24Z",
       "result": "clean",
       "issues": []
+    },
+    "bezout-identity-oq-03-oq-04-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T18:04:51Z",
+      "result": "clean",
+      "issues": []
+    },
+    "konigsberg-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T18:04:52Z",
+      "result": "clean",
+      "issues": []
+    },
+    "wilsons-theorem-oq-04-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T18:05:35Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Summary

- Audited 3 new proofs: bezout-identity-oq-03-oq-04-oq-01, konigsberg-oq-03-oq-02, wilsons-theorem-oq-04-oq-02
- All 1895 gallery proofs now audited with 0 issues found
- All 3 proofs verified clean: 0 sorries, 0 axioms

🤖 Generated with [Claude Code](https://claude.com/claude-code)