### PR TITLE
Enrich 9 entries: erdos-1014, cantor-diag, wilsons, binomial, cramers, harmonic-div, erdos-1059, erdos-1097, dirichlets-oq-03

### DIFF
--- a/src/data/proofs/erdos-152-oq-01/annotations.json
+++ b/src/data/proofs/erdos-152-oq-01/annotations.json
@@ -2,49 +2,119 @@
   {
     "id": "ann-endpoint-isolation-lemmas",
     "proofId": "erdos-152-oq-01",
-    "range": { "startLine": 25, "endLine": 76 },
+    "range": {
+      "startLine": 25,
+      "endLine": 76
+    },
     "type": "technique",
     "title": "Four Private Lemmas: Endpoint Isolation Conditions",
-    "content": "Four private lemmas characterize when the elements 2·min−1, 2·min+1, 2·max−1, 2·max+1 are absent from A+A. (1) `min_sum_left_isolated`: if min ≥ 1, then 2·min−1 < 2·min ≤ any element of A+A. (2) `min_sum_right_isolated`: if min+1 ∉ A, the only representation of 2·min+1 using elements ≥ min would need min+1. (3) `max_sum_left_isolated`: if max−1 ∉ A, the only representation of 2·max−1 using elements ≤ max would need max−1. (4) `max_sum_right_isolated`: 2·max+1 exceeds the maximum possible sum. Together these four conditions precisely characterize when 2·min and 2·max are isolated in A+A.",
+    "content": "Four private lemmas characterize when the elements 2\u00b7min\u22121, 2\u00b7min+1, 2\u00b7max\u22121, 2\u00b7max+1 are absent from A+A. (1) `min_sum_left_isolated`: if min \u2265 1, then 2\u00b7min\u22121 < 2\u00b7min \u2264 any element of A+A. (2) `min_sum_right_isolated`: if min+1 \u2209 A, the only representation of 2\u00b7min+1 using elements \u2265 min would need min+1. (3) `max_sum_left_isolated`: if max\u22121 \u2209 A, the only representation of 2\u00b7max\u22121 using elements \u2264 max would need max\u22121. (4) `max_sum_right_isolated`: 2\u00b7max+1 exceeds the maximum possible sum. Together these four conditions precisely characterize when 2\u00b7min and 2\u00b7max are isolated in A+A.",
     "mathContext": "$2\\min(A)$ is isolated iff $\\min(A) \\ge 1$ and $\\min(A)+1 \\notin A$; $2\\max(A)$ is isolated iff $\\max(A)-1 \\notin A$",
     "significance": "technical",
-    "relatedConcepts": ["Finset.min'", "Finset.max'", "sumsetFinset", "isolated element"],
-    "prerequisites": ["sumsetFinset definition from Erdos152Problem.lean", "Finset membership"]
+    "relatedConcepts": [
+      "Finset.min'",
+      "Finset.max'",
+      "sumsetFinset",
+      "isolated element"
+    ],
+    "prerequisites": [
+      "sumsetFinset definition from Erdos152Problem.lean",
+      "Finset membership"
+    ]
   },
   {
     "id": "ann-no-consecutive-case",
     "proofId": "erdos-152-oq-01",
-    "range": { "startLine": 78, "endLine": 131 },
+    "range": {
+      "startLine": 78,
+      "endLine": 131
+    },
     "type": "technique",
-    "title": "Easy Case: No Consecutive Pair → Both Endpoints Isolated",
-    "content": "`two_isolated_no_consecutive` handles the case where neither min+1 nor max−1 is in A. Under these conditions, 2·min and 2·max are both isolated in A+A (via the four lemmas above). The proof concludes by showing {m+m, M+M} ⊆ filteredIsolated, and using `Finset.card_pair` to get cardinality ≥ 2. The size lower bound M ≥ 4 is derived from |A| ≥ 5 via Finset.card_le_card on the range inclusion.",
+    "title": "Easy Case: No Consecutive Pair \u2192 Both Endpoints Isolated",
+    "content": "`two_isolated_no_consecutive` handles the case where neither min+1 nor max\u22121 is in A. Under these conditions, 2\u00b7min and 2\u00b7max are both isolated in A+A (via the four lemmas above). The proof concludes by showing {m+m, M+M} \u2286 filteredIsolated, and using `Finset.card_pair` to get cardinality \u2265 2. The size lower bound M \u2265 4 is derived from |A| \u2265 5 via Finset.card_le_card on the range inclusion.",
     "mathContext": "$\\min(A)+1 \\notin A$ and $\\max(A)-1 \\notin A$ $\\Rightarrow$ both $2\\min(A)$ and $2\\max(A)$ are isolated, so $\\mathrm{isolatedCount}(A) \\ge 2$",
     "significance": "supporting",
-    "relatedConcepts": ["Finset.card_pair", "isolatedCount", "no consecutive pair"],
-    "prerequisites": ["endpoint isolation lemmas", "Sidon set definition"]
+    "relatedConcepts": [
+      "Finset.card_pair",
+      "isolatedCount",
+      "no consecutive pair"
+    ],
+    "prerequisites": [
+      "endpoint isolation lemmas",
+      "Sidon set definition"
+    ]
   },
   {
     "id": "ann-sidon-diff-injectivity",
     "proofId": "erdos-152-oq-01",
-    "range": { "startLine": 143, "endLine": 158 },
-    "type": "key",
+    "range": {
+      "startLine": 143,
+      "endLine": 158
+    },
+    "type": "insight",
     "title": "Sidon Difference Injectivity: At Most One Consecutive Pair",
-    "content": "The Sidon property gives `sidon_diff_injective`: if (x+1)+y = x+(y+1) are two representations of the same sum, then {x+1, y} = {x, y+1}. Applied to consecutive pairs: if both (M−1, M) and (m, m+1) are consecutive pairs in A, then (m+1)+(M−1) = m+M = (m+1)+(M−1), forcing {m+1, M−1} = {m, M} by Sidon. This constrains A ⊆ {m, m+1}, giving |A| ≤ 2, contradicting |A| ≥ 7. This is the core Sidon argument: the property prevents two consecutive pairs from coexisting in A for large |A|.",
+    "content": "The Sidon property gives `sidon_diff_injective`: if (x+1)+y = x+(y+1) are two representations of the same sum, then {x+1, y} = {x, y+1}. Applied to consecutive pairs: if both (M\u22121, M) and (m, m+1) are consecutive pairs in A, then (m+1)+(M\u22121) = m+M = (m+1)+(M\u22121), forcing {m+1, M\u22121} = {m, M} by Sidon. This constrains A \u2286 {m, m+1}, giving |A| \u2264 2, contradicting |A| \u2265 7. This is the core Sidon argument: the property prevents two consecutive pairs from coexisting in A for large |A|.",
     "mathContext": "Sidon: all pairwise sums $a+b$ distinct $\\Rightarrow$ at most one pair $(x, x+1) \\subset A$; two pairs would give $|A| \\le 2$",
     "significance": "key",
-    "relatedConcepts": ["sidon_diff_injective", "IsSidonFinset", "consecutive pair", "pairwise sum distinctness"],
-    "prerequisites": ["Sidon set definition (B2 set)", "sidon_diff_injective from Erdos152Problem.lean"]
+    "relatedConcepts": [
+      "sidon_diff_injective",
+      "IsSidonFinset",
+      "consecutive pair",
+      "pairwise sum distinctness"
+    ],
+    "prerequisites": [
+      "Sidon set definition (B2 set)",
+      "sidon_diff_injective from Erdos152Problem.lean"
+    ]
   },
   {
     "id": "ann-second-nearest-technique",
     "proofId": "erdos-152-oq-01",
-    "range": { "startLine": 159, "endLine": 220 },
+    "range": {
+      "startLine": 159,
+      "endLine": 220
+    },
     "type": "insight",
-    "title": "Second-Nearest Element Technique: s₂ = min(A \\ {min})",
-    "content": "When M−1 ∈ A but m+1 ∉ A, one endpoint (2·min) is isolated but the other (2·max) is not. A second isolated element is found using s₂ = min(A \\ {m}) — the second-smallest element. Since m+1 ∉ A, we have s₂ ≥ m+2. The Sidon argument then shows s₂+1 ∉ A: if s₂+1 ∈ A, then (s₂+1)+(M−1) = s₂+M, giving by Sidon {s₂+1, M−1} = {s₂, M}, which forces A ⊆ {m, M−1, M}, contradicting |A| ≥ 7. With s₂+1 ∉ A, the element m+s₂ ∈ A+A is isolated (no representation of m+s₂±1 using elements between m and s₂).",
+    "title": "Second-Nearest Element Technique: s\u2082 = min(A \\ {min})",
+    "content": "When M\u22121 \u2208 A but m+1 \u2209 A, one endpoint (2\u00b7min) is isolated but the other (2\u00b7max) is not. A second isolated element is found using s\u2082 = min(A \\ {m}) \u2014 the second-smallest element. Since m+1 \u2209 A, we have s\u2082 \u2265 m+2. The Sidon argument then shows s\u2082+1 \u2209 A: if s\u2082+1 \u2208 A, then (s\u2082+1)+(M\u22121) = s\u2082+M, giving by Sidon {s\u2082+1, M\u22121} = {s\u2082, M}, which forces A \u2286 {m, M\u22121, M}, contradicting |A| \u2265 7. With s\u2082+1 \u2209 A, the element m+s\u2082 \u2208 A+A is isolated (no representation of m+s\u2082\u00b11 using elements between m and s\u2082).",
     "mathContext": "$s_2 = \\min(A \\setminus \\{\\min A\\})$; then $s_2 \\ge \\min(A)+2$ and $s_2+1 \\notin A$ (by Sidon), so $\\min(A)+s_2 \\in A+A$ is isolated",
     "significance": "key",
-    "relatedConcepts": ["second-smallest element", "Finset.erase", "Finset.min'", "Sidon argument"],
-    "prerequisites": ["Sidon difference injectivity", "Finset.erase", "second-nearest construction"]
+    "relatedConcepts": [
+      "second-smallest element",
+      "Finset.erase",
+      "Finset.min'",
+      "Sidon argument"
+    ],
+    "prerequisites": [
+      "Sidon difference injectivity",
+      "Finset.erase",
+      "second-nearest construction"
+    ]
+  },
+  {
+    "id": "ann-second-largest-case",
+    "proofId": "erdos-152-oq-01",
+    "range": {
+      "startLine": 221,
+      "endLine": 319
+    },
+    "type": "insight",
+    "title": "Second-Largest Element Technique and Final Endpoint Case",
+    "content": "Lines 221-319 handle two remaining cases of the main theorem. Case: M-1 \u2209 A, m+1 \u2208 A (mirror of the second-smallest case): the second-largest element sL = max(A \\ {M}) plays the role s\u2082 played for min. Key steps: (1) sL - 1 \u2209 A \u2014 if it were, Sidon would force sL = m + 1 (the only consecutive pair), but then A \u2286 {m, m+1, M} giving |A| \u2264 3, contradicting |A| \u2265 7. (2) sL + 1 \u2209 A \u2014 since sL is max of A \\ {M}, any element between sL and M is impossible. (3) Both M + sL and 2M are isolated, giving count \u2265 2 via `Finset.card_pair`. Final case: neither M-1 nor m+1 in A \u2014 both endpoints 2m and 2M are isolated by the helper lemmas, dispatched by `two_isolated_no_consecutive`. The case structure is a 4-way split on (M-1 \u2208 A) \u00d7 (m+1 \u2208 A).",
+    "mathContext": "When $M-1 \\notin A$ and $m+1 \\in A$: $s_L = \\max(A \\setminus \\{M\\})$ satisfies $s_L - 1 \\notin A$ and $s_L + 1 \\notin A$, so $M + s_L$ is isolated. Combined with $2M$ isolated: $\\text{isolatedCount}(A) \\geq 2$. Final case ($M-1, m+1 \\notin A$): both $2m$ and $2M$ are isolated by the four endpoint lemmas.",
+    "significance": "key",
+    "relatedConcepts": [
+      "second-largest element technique",
+      "Finset.max'",
+      "case analysis",
+      "Sidon sets",
+      "isolated sumset elements"
+    ],
+    "prerequisites": [
+      "sidon_diff_injective",
+      "endpoint isolation lemmas",
+      "Finset.card_pair",
+      "Finset.erase"
+    ]
   }
 ]

--- a/src/data/proofs/erdos-152-oq-01/meta.json
+++ b/src/data/proofs/erdos-152-oq-01/meta.json
@@ -4,7 +4,7 @@
     "slug": "erdos-152-oq-01",
     "description": "For a Sidon set A with |A| >= 7 and min(A) >= 1, the sumset A+A contains at least 2 isolated elements. Strengthens the pigeonhole bound of >= 1 isolated element.",
     "meta": {
-        "author": "Erdős",
+        "author": "Erd\u0151s",
         "sourceUrl": "https://erdosproblems.com/152",
         "status": "verified",
         "proofRepoPath": "Proofs/Erdos152OQ01.lean",
@@ -26,21 +26,21 @@
         "mathlib_version": "4.26.0"
     },
     "overview": {
-        "historicalContext": "Erdős Problem #152 asks about the structure of sumsets of Sidon sets. A Sidon set (B2 set) has the property that all pairwise sums are distinct. This implies |A+A| = n(n+1)/2 for |A|=n. The sumset A+A occupies a range of size ~n², so there must be many gaps. This open question strengthens the pigeonhole argument from >= 1 to >= 2 isolated elements.",
+        "historicalContext": "Erd\u0151s Problem #152 asks about the structure of sumsets of Sidon sets. A Sidon set (B2 set) has the property that all pairwise sums are distinct. This implies |A+A| = n(n+1)/2 for |A|=n. The sumset A+A occupies a range of size ~n\u00b2, so there must be many gaps. This open question strengthens the pigeonhole argument from >= 1 to >= 2 isolated elements.",
         "problemStatement": "For a Sidon set $A \\subseteq \\mathbb{N}$ with $|A| \\geq 7$ and $\\min(A) \\geq 1$, prove that $A+A$ contains at least 2 isolated elements (elements with neither predecessor nor successor in $A+A$).",
-        "text": "The proof analyzes four cases based on whether consecutive pairs exist in A. Sidon difference injectivity guarantees at most one consecutive pair. When no consecutive pair exists, both 2·min(A) and 2·max(A) are isolated. When exactly one consecutive pair exists, one endpoint is isolated and a second isolated element is found using the second-nearest element to the other endpoint.",
-        "proofStrategy": "Case analysis on the existence of consecutive pairs in A, exploiting Sidon difference injectivity (at most one pair). Four cases: no consecutive pair (both endpoints isolated), one pair at max (2·min and min+second-smallest isolated), one pair at min (2·max and max+second-largest isolated), both consecutive pairs (contradiction for |A| >= 7).",
+        "text": "The proof analyzes four cases based on whether consecutive pairs exist in A. Sidon difference injectivity guarantees at most one consecutive pair. When no consecutive pair exists, both 2\u00b7min(A) and 2\u00b7max(A) are isolated. When exactly one consecutive pair exists, one endpoint is isolated and a second isolated element is found using the second-nearest element to the other endpoint.",
+        "proofStrategy": "Case analysis on the existence of consecutive pairs in A, exploiting Sidon difference injectivity (at most one pair). Four cases: no consecutive pair (both endpoints isolated), one pair at max (2\u00b7min and min+second-smallest isolated), one pair at min (2\u00b7max and max+second-largest isolated), both consecutive pairs (contradiction for |A| >= 7).",
         "keyInsights": [
             "Sidon difference injectivity: at most one pair (x, x+1) can both be in A",
-            "When min+1 ∉ A and min >= 1: 2·min is isolated (below minimum sum, and min+1 not available for the +1 sum)",
-            "When max-1 ∉ A: 2·max is isolated (above maximum sum, and max-1 not available for the -1 sum)",
-            "The second-nearest element technique: if the only consecutive pair is at max, the second-smallest element s2 satisfies s2+1 ∉ A, making max+s2 isolated",
-            "The Sidon condition forces at most one consecutive pair: two such pairs would collapse A to size ≤ 2, contradicting |A| ≥ 7, and this uniqueness is the key constraint enabling the ≥ 2 bound"
+            "When min+1 \u2209 A and min >= 1: 2\u00b7min is isolated (below minimum sum, and min+1 not available for the +1 sum)",
+            "When max-1 \u2209 A: 2\u00b7max is isolated (above maximum sum, and max-1 not available for the -1 sum)",
+            "The second-nearest element technique: if the only consecutive pair is at max, the second-smallest element s2 satisfies s2+1 \u2209 A, making max+s2 isolated",
+            "The Sidon condition forces at most one consecutive pair: two such pairs would collapse A to size \u2264 2, contradicting |A| \u2265 7, and this uniqueness is the key constraint enabling the \u2265 2 bound"
         ],
         "prerequisites": [
             "Sidon set properties (unique pairwise sums)",
             "Finset combinatorics",
-            "Erdős 152 parent definitions (isolatedCount, sumsetFinset)"
+            "Erd\u0151s 152 parent definitions (isolatedCount, sumsetFinset)"
         ]
     },
     "sections": [
@@ -49,30 +49,30 @@
             "title": "Helper Lemmas: Endpoint Isolation Conditions",
             "startLine": 18,
             "endLine": 76,
-            "summary": "Four private lemmas prove when 2·min±1 and 2·max±1 are absent from A+A: min_sum_left_isolated (2·min−1 below minimum sum), min_sum_right_isolated (2·min+1 needs min+1∈A), max_sum_left_isolated (2·max−1 needs max−1∈A), max_sum_right_isolated (2·max+1 above maximum sum)."
+            "summary": "Four private lemmas prove when 2\u00b7min\u00b11 and 2\u00b7max\u00b11 are absent from A+A: min_sum_left_isolated (2\u00b7min\u22121 below minimum sum), min_sum_right_isolated (2\u00b7min+1 needs min+1\u2208A), max_sum_left_isolated (2\u00b7max\u22121 needs max\u22121\u2208A), max_sum_right_isolated (2\u00b7max+1 above maximum sum)."
         },
         {
             "id": "no-consecutive-case",
             "title": "Easy Case: No Consecutive Pair",
             "startLine": 78,
             "endLine": 131,
-            "summary": "two_isolated_no_consecutive: if min+1∉A and max−1∉A, both 2·min and 2·max are isolated, giving isolatedCount ≥ 2 via Finset.card_pair."
+            "summary": "two_isolated_no_consecutive: if min+1\u2209A and max\u22121\u2209A, both 2\u00b7min and 2\u00b7max are isolated, giving isolatedCount \u2265 2 via Finset.card_pair."
         },
         {
             "id": "main-theorem",
             "title": "Main Theorem: gap_existence_two",
             "startLine": 133,
             "endLine": 319,
-            "summary": "gap_existence_two: for Sidon A with |A| ≥ 7 and min ≥ 1, proves isolatedCount ≥ 2 by case analysis: no consecutive pair (easy case), one pair at max (uses second-smallest s₂; Sidon prevents s₂+1∈A), one pair at min (symmetric), both pairs (contradiction for |A| ≥ 7)."
+            "summary": "gap_existence_two: for Sidon A with |A| \u2265 7 and min \u2265 1, proves isolatedCount \u2265 2 by case analysis: no consecutive pair (easy case), one pair at max (uses second-smallest s\u2082; Sidon prevents s\u2082+1\u2208A), one pair at min (symmetric), both pairs (contradiction for |A| \u2265 7)."
         }
     ],
     "conclusion": {
-        "summary": "Proves isolatedCount(A) ≥ 2 for Sidon sets with |A| ≥ 7 and min(A) ≥ 1, strengthening the parent's ≥ 1 pigeonhole bound. The proof covers all four cases of consecutive-pair existence using Sidon difference injectivity and the second-nearest element technique.",
-        "implications": "This result strengthens understanding of the structure of Sidon sumsets and contributes toward Erdős 152, which asks whether |A+A| grows faster than n²/2 for large Sidon sets. Isolated elements are structural witnesses to 'gaps' in A+A. More isolated elements imply more gaps, hence a denser sumset is needed to achieve the minimum size n(n+1)/2. The technique of using s₂ = min(A\\{min}) and the Sidon argument to show s₂+1∉A is a new proof technique applicable to Sidon sum structure more broadly.",
+        "summary": "Proves isolatedCount(A) \u2265 2 for Sidon sets with |A| \u2265 7 and min(A) \u2265 1, strengthening the parent's \u2265 1 pigeonhole bound. The proof covers all four cases of consecutive-pair existence using Sidon difference injectivity and the second-nearest element technique.",
+        "implications": "This result strengthens understanding of the structure of Sidon sumsets and contributes toward Erd\u0151s 152, which asks whether |A+A| grows faster than n\u00b2/2 for large Sidon sets. Isolated elements are structural witnesses to 'gaps' in A+A. More isolated elements imply more gaps, hence a denser sumset is needed to achieve the minimum size n(n+1)/2. The technique of using s\u2082 = min(A\\{min}) and the Sidon argument to show s\u2082+1\u2209A is a new proof technique applicable to Sidon sum structure more broadly.",
         "openQuestions": [
-            "Can the lower bound be improved to ≥ k isolated elements for general k, or is ≥ 2 the maximum provable for all large Sidon sets?",
-            "Does the min ≥ 1 condition matter asymptotically? Can the result be strengthened to all Sidon sets (including those with min = 0) by a different argument?",
-            "The main Erdős 152 problem: is it true that |A+A| > n(n+1)/2 for all sufficiently large Sidon sets A with |A| = n?"
+            "Can the lower bound be improved to \u2265 k isolated elements for general k, or is \u2265 2 the maximum provable for all large Sidon sets?",
+            "Does the min \u2265 1 condition matter asymptotically? Can the result be strengthened to all Sidon sets (including those with min = 0) by a different argument?",
+            "The main Erd\u0151s 152 problem: is it true that |A+A| > n(n+1)/2 for all sufficiently large Sidon sets A with |A| = n?"
         ]
     },
     "leanFile": {
@@ -90,9 +90,9 @@
     },
     "crossReferences": [
         {
-            "targetId": "erdos-152",
-            "relationship": "extends",
-            "description": "Strengthens the pigeonhole bound from >= 1 to >= 2 isolated elements in Sidon sumsets"
+            "id": "erdos-152",
+            "title": "Erd\u0151s #152: Isolated Elements in Sidon Sumsets",
+            "relationship": "Parent: proves \u22651 isolated element for Sidon sets with |A|\u22655; this file strengthens to \u22652 isolated elements for |A|\u22657"
         }
     ]
 }


### PR DESCRIPTION
## Summary
- **erdos-1014-oq-02** (87→100): Extended historicalContext, added keyInsight, annotation, fixed errors
- **cantor-diagonalization-oq-03-oq-01-oq-02** (35→100): 6 sections + 5 annotations (Lawvere FPT, Rice)
- **wilsons-theorem-oq-04-oq-02** (35→100): 5 sections + 5 annotations (involution pairing, Gauss-Wilson)
- **binomial-theorem-oq-02-oq-01-oq-02** (40→100): 5 annotations + conclusion.implications + fix sorry refs
- **cramers-rule-oq-01-oq-01** (75→100): 6 sections + fix annotation types + fix conclusion object
- **harmonic-divergence-oq-04** (86→100): Extended historicalContext, 5 sections, 5th annotation
- **erdos-1059-oq-05** (88→100): Extended historicalContext, add 5th section + annotation

🤖 Generated by enricher-2