### PR TITLE
Enrich cantor-diagonalization-oq-03-oq-01-oq-02: Rice's Theorem as Lawvere Instance

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-02/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-module-overview",
+    "proofId": "cantor-diagonalization-oq-03-oq-01-oq-02",
+    "range": { "startLine": 1, "endLine": 48 },
+    "type": "context",
+    "title": "Module Overview: Rice via Lawvere",
+    "content": "The file imports Mathlib's basic logic and tactic libraries, then provides a rich docstring explaining the three-layer architecture of the proof: (1) Abstract Rice via Bool Lawvere — the pure fixed-point obstruction; (2) Semantic Rice — the flip-program argument; (3) Kleene-Rice — the classical computability statement with Kleene's recursion theorem axiomatized. The docstring explicitly names the parent open question (OQ-02 from CantorDiagonalizationOQ03OQ01) that this file resolves.",
+    "mathContext": "Rice's theorem (1953): for any non-trivial property $P$ of partial computable functions that is *semantic* (depends only on what $\\varphi_e$ computes, not its index $e$), the set $\\{e \\mid \\varphi_e \\in P\\}$ is undecidable. The proof reduces to Lawvere's fixed-point theorem: if there were a point-surjective Bool-valued evaluation, $\\text{Bool.not}$ would have a fixed point, but $\\neg\\mathtt{false} = \\mathtt{true}$ and $\\neg\\mathtt{true} = \\mathtt{false}$ — both are not fixed points.",
+    "significance": "context",
+    "relatedConcepts": ["Rice's theorem", "Lawvere fixed-point theorem", "diagonal argument", "computability theory"],
+    "prerequisites": ["partial computable functions", "Gödel numbering", "undecidability"]
+  },
+  {
+    "id": "ann-eval-structure",
+    "proofId": "cantor-diagonalization-oq-03-oq-01-oq-02",
+    "range": { "startLine": 57, "endLine": 75 },
+    "type": "definition",
+    "title": "Evaluation Structures and Lawvere FPT",
+    "content": "EvalStructure packages a type of 'programs' (Ob), a type of 'values' (Val), and an evaluation function eval : Ob → Ob → Val. IsPointSurjective captures universality: every function g : Ob → Val is representable by some code a. The Lawvere FPT is proved in four lines: obtain the code a₀ for the diagonal function (fun a => f (eval a a)), then evaluate at a₀ itself. The term eval a₀ a₀ is the fixed point because ha₀ a₀ equates it with f (eval a₀ a₀).",
+    "mathContext": "Point-surjectivity formalizes the key hypothesis: $\\forall g : \\text{Ob} \\to \\text{Val},\\ \\exists a : \\text{Ob},\\ \\forall x : \\text{Ob},\\ \\text{eval}(a, x) = g(x)$. The Lawvere diagonal: apply point-surjectivity to $g(a) = f(\\text{eval}(a,a))$ to get $a_0$ with $\\text{eval}(a_0, x) = f(\\text{eval}(x,x))$ for all $x$. Then $\\text{eval}(a_0, a_0) = f(\\text{eval}(a_0, a_0))$, which is the desired fixed point.",
+    "significance": "key",
+    "relatedConcepts": ["point-surjectivity", "universal Turing machine", "Cartesian closed categories", "diagonal argument"],
+    "prerequisites": ["type theory", "function types in Lean 4", "dependent types"]
+  },
+  {
+    "id": "ann-abstract-rice",
+    "proofId": "cantor-diagonalization-oq-03-oq-01-oq-02",
+    "range": { "startLine": 80, "endLine": 121 },
+    "type": "technique",
+    "title": "Abstract Rice: Bool.not Has No Fixed Point",
+    "content": "abstract_rice proves that no evaluation structure over Bool can be point-surjective — in four lines. The tactic obtain applies Lawvere FPT with f = Bool.not to get a Bool value v such that !v = v. The `cases v <;> simp_all` then destructs v into true/false and closes both goals by simplification (¬true = false ≠ true, ¬false = true ≠ false). rice_induced_obstruction lifts this to arbitrary Val-valued evaluations by composing with d : Val → Bool, reducing to the Bool case. rice_undecidable_witness reformulates non-point-surjectivity positively: for every eval there exists a function no code can represent.",
+    "mathContext": "$\\text{Bool.not}$ has no fixed point: $\\neg\\mathtt{false} = \\mathtt{true} \\neq \\mathtt{false}$ and $\\neg\\mathtt{true} = \\mathtt{false} \\neq \\mathtt{true}$. Since Lawvere FPT would force a fixed point, no point-surjective Bool eval exists. Formally: $\\neg \\exists A, \\text{eval} : A \\to A \\to \\text{Bool}$ such that $\\forall g : A \\to \\text{Bool},\\ \\exists a,\\ \\forall x,\\ \\text{eval}(a,x) = g(x)$.",
+    "significance": "key",
+    "relatedConcepts": ["fixed-point theorem", "Boolean negation", "decidability", "universal machine"],
+    "prerequisites": ["Lawvere FPT (lawvere_fpt)", "Bool arithmetic", "by_contra and push_neg tactics"]
+  },
+  {
+    "id": "ann-semantic-rice",
+    "proofId": "cantor-diagonalization-oq-03-oq-01-oq-02",
+    "range": { "startLine": 126, "endLine": 164 },
+    "type": "technique",
+    "title": "Semantic Properties and the Flip Program Argument",
+    "content": "SemanticProperty formalizes extensionality: P(a) = P(b) whenever programs a and b compute the same function (∀ x, eval a x = eval b x). HasFlipProgram captures non-triviality via a program transformer that always negates the property. The key theorem semantic_rice_flip shows these two conditions are contradictory even without point-surjectivity: if flip(a) has the same semantics as a (h_flip_sem), then P(flip a) = P a (by SemanticProperty), but h_flip_prop says P(flip a) ≠ P a — direct contradiction at any point. Note: Classical.arbitrary is used to extract a concrete program from the Nonempty hypothesis.",
+    "mathContext": "The flip program argument: suppose $f$ is a total program transformer with $\\varphi_{f(e)} = \\varphi_e$ (same semantics) but $P(f(e)) \\neq P(e)$ for all $e$. Then for any $e$: $P(f(e)) = P(e)$ (by semantic property) and $P(f(e)) \\neq P(e)$ (by flip property) — contradiction. This does not require universality, only the existence of a semantic-flip transformer.",
+    "significance": "supporting",
+    "relatedConcepts": ["extensional equality", "non-trivial property", "program transformation", "Classical.arbitrary"],
+    "prerequisites": ["SemanticProperty definition", "Classical logic in Lean", "Nonempty typeclass"]
+  },
+  {
+    "id": "ann-halting-model",
+    "proofId": "cantor-diagonalization-oq-03-oq-01-oq-02",
+    "range": { "startLine": 173, "endLine": 188 },
+    "type": "insight",
+    "title": "The Halting Problem as a Rice Instance",
+    "content": "HaltingModel packages a concrete computation model: programs and inputs share the same type (Gödel coding), halts : Prog → Prog → Bool is the halting predicate, evaluate gives the output when halting, and universal asserts that halts is point-surjective. The theorem no_halting_model shows this model cannot exist: M.universal is definitionally the point-surjectivity condition, so abstract_rice applies immediately. This recovers the undecidability of the halting problem as a one-line corollary of abstract_rice.",
+    "mathContext": "The halting problem: $\\{\\langle e, x \\rangle \\mid \\varphi_e(x)\\downarrow\\}$ is undecidable. Encoding this as a Rice instance: take $P = $ 'the program halts on all inputs' (or more directly, point-surjectivity of halts). The model's `universal` field asserts $\\forall f : \\text{Prog} \\to \\text{Bool},\\ \\exists e,\\ \\forall x,\\ \\text{halts}(e,x) = f(x)$ — exactly IsPointSurjective for the halts evaluation structure.",
+    "significance": "key",
+    "relatedConcepts": ["halting problem", "Turing's undecidability theorem", "Gödel coding", "Rice's theorem"],
+    "prerequisites": ["abstract_rice theorem", "EvalStructure.IsPointSurjective", "Gödel numbering"]
+  },
+  {
+    "id": "ann-classical-rice",
+    "proofId": "cantor-diagonalization-oq-03-oq-01-oq-02",
+    "range": { "startLine": 210, "endLine": 262 },
+    "type": "definition",
+    "title": "Classical Rice from Kleene's Recursion Theorem",
+    "content": "ClassicalRiceModel axiomatizes the key computability-theoretic infrastructure: a code-to-behavior semantics map, a compile function (behavior → code) with h_compile ensuring universality, and kleene_rec (Kleene's recursion theorem): every code transformer f : Code → Code has a semantic fixed point e* with semantics(f(e*)) = semantics(e*). classical_rice_abstract constructs the 'flipper' f(e) = if P(e) = true then e₀ else e₁, applies kleene_rec to get e*, then derives contradiction: P(e*) = P(f(e*)) by semantic property (same semantics), but P(f(e*)) ≠ P(e*) because f always flips P. The split_ifs + Bool case analysis closes the proof.",
+    "mathContext": "Kleene's recursion theorem: $\\forall f : \\mathbb{N} \\to \\mathbb{N},\\ \\exists e^*,\\ \\varphi_{f(e^*)} = \\varphi_{e^*}$. The Rice flipper: $f(e) = \\begin{cases} e_0 & \\text{if } P(e) = \\mathtt{true} \\\\ e_1 & \\text{if } P(e) = \\mathtt{false} \\end{cases}$ where $P(e_0) = \\mathtt{false}$ and $P(e_1) = \\mathtt{true}$. At the fixed point $e^*$: $P(e^*) = P(f(e^*))$ by semantics, but $f$ flips $P$ by construction — contradiction. This is the classical computability proof of Rice's theorem.",
+    "significance": "key",
+    "relatedConcepts": ["Kleene's recursion theorem", "s-m-n theorem", "semantic fixed point", "non-trivial property"],
+    "prerequisites": ["ClassicalRiceModel structure", "SemanticProperty", "Bool case analysis in Lean 4", "split_ifs tactic"]
+  }
+]

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-02/meta.json
@@ -51,6 +51,79 @@
       "Classical logic: Classical.arbitrary for nonemptiness"
     ]
   },
+  "sections": [
+    {
+      "id": "imports-docstring",
+      "title": "Imports and Module Overview",
+      "startLine": 1,
+      "endLine": 48,
+      "summary": "Imports Mathlib.Logic.Function.Basic and Mathlib.Tactic, then provides a comprehensive docstring describing the three-layer proof architecture: Abstract Rice (Bool Lawvere), Semantic Rice (flip program), and Kleene-Rice (classical computability theorem)."
+    },
+    {
+      "id": "eval-structure-framework",
+      "title": "Evaluation Structure Framework",
+      "startLine": 50,
+      "endLine": 75,
+      "summary": "Defines EvalStructure (a triple of programs, values, and evaluation), IsPointSurjective (every function Ob → Val is represented by some code), and proves the Lawvere Fixed-Point Theorem: point-surjectivity forces every endomorphism to have a fixed point."
+    },
+    {
+      "id": "abstract-rice",
+      "title": "Abstract Rice Theorem",
+      "startLine": 77,
+      "endLine": 121,
+      "summary": "Proves abstract_rice (no Bool-evaluation can be point-surjective, since Bool.not has no fixed point), rice_induced_obstruction (composition with any d : Val → Bool inherits this obstruction), and rice_undecidable_witness (for every eval, there exists a Bool function no code can represent)."
+    },
+    {
+      "id": "semantic-properties",
+      "title": "Semantic Properties and Flip Programs",
+      "startLine": 123,
+      "endLine": 164,
+      "summary": "Defines SemanticProperty (extensional: programs with equal behavior have equal property value) and HasFlipProgram (a total transformer that inverts the property). Proves semantic_rice_flip: a semantic property with a same-semantics flip transformer is immediately contradictory — no point-surjectivity needed."
+    },
+    {
+      "id": "halting-problem",
+      "title": "The Halting Problem as Rice Instance",
+      "startLine": 166,
+      "endLine": 188,
+      "summary": "Defines HaltingModel (programs, halts predicate, evaluate, and decidable-universality axiom) and proves no_halting_model: no such model exists, because M.universal is exactly the point-surjectivity condition that abstract_rice refutes."
+    },
+    {
+      "id": "classical-rice",
+      "title": "Classical Rice Theorem (Axiomatized)",
+      "startLine": 190,
+      "endLine": 262,
+      "summary": "Defines ClassicalRiceModel axiomatizing Kleene's recursion theorem (every code transformer has a semantic fixed point). Proves classical_rice_abstract: any non-trivial semantic property leads to a flipper whose Kleene fixed point simultaneously satisfies and violates the property."
+    },
+    {
+      "id": "summary-checks",
+      "title": "Summary Type Checks",
+      "startLine": 264,
+      "endLine": 275,
+      "summary": "Six #check commands verify the types of all main theorems: abstract_rice, rice_induced_obstruction, rice_undecidable_witness, semantic_rice_flip, no_halting_model, and classical_rice_abstract."
+    }
+  ],
+  "crossReferences": [
+    {
+      "id": "cantor-diagonalization-oq-03-oq-01",
+      "title": "Lawvere Fixed-Point Theorem: Categorical Generalization",
+      "relationship": "Parent proof that established EvalStructure, IsPointSurjective, and the Lawvere FPT. This file answers OQ-02 from that entry."
+    },
+    {
+      "id": "cantor-diagonalization-oq-03-oq-01-oq-03",
+      "title": "Gödel's Incompleteness Theorem as a Lawvere Instance",
+      "relationship": "Sibling proof (OQ-03) applying the same Lawvere framework to formal proof systems; Rice (Bool.not) and Gödel (negation of provability) are parallel instantiations."
+    },
+    {
+      "id": "cantor-diagonalization-oq-03",
+      "title": "Lawvere Fixed-Point Theorem and Cantor's Theorem",
+      "relationship": "Grandparent proof establishing the original Lawvere FPT used here. Cantor (Prop, negation), Rice (Bool, not), Gödel (sentences, ¬Provable) form the diagonal family."
+    },
+    {
+      "id": "cantor-diagonalization",
+      "title": "Cantor Diagonalization",
+      "relationship": "Root of the diagonal argument family. Cantor's original uncountability argument is the special case Ob = ℕ, Val = Prop, f = negation."
+    }
+  ],
   "conclusion": {
     "summary": "Proved Rice's theorem as a Lawvere instance: no Bool-valued evaluation structure is point-surjective, which is the abstract essence of Rice's undecidability theorem. Derived 5 concrete results — abstract Rice, induced obstruction, undecidable witness, semantic flip, and no halting model — plus the classical Rice theorem from axiomatized Kleene recursion. 6 theorems, 0 axioms, 275 lines.",
     "implications": "This file completes the Lawvere fixed-point theorem application chain: Cantor (Prop, negation) → Rice (Bool, not) → Gödel (sentences, negation of provability). The key insight is that undecidability results in computability theory are not independent of diagonal arguments in set theory — they all share the same Lawvere fixed-point core. The `classical_rice_abstract` theorem shows that Rice follows from Kleene's recursion theorem, which in turn follows from the same diagonal construction.",


### PR DESCRIPTION
Enrichment pass for cantor-diagonalization-oq-03-oq-01-oq-02 (Rice's Theorem as a Lawvere Instance).

## Quality Improvements

**Annotations (annotations.json):**
- Added 6 annotations covering the full Lean file (275 lines):
  - Module overview with LaTeX formulation of Rice's theorem
  - EvalStructure/IsPointSurjective/lawvere_fpt with diagonal construction math
  - abstract_rice: Bool.not fixed-point impossibility
  - semantic_rice_flip: flip program argument without point-surjectivity
  - HaltingModel/no_halting_model: halting problem as one-line Rice corollary
  - ClassicalRiceModel/classical_rice_abstract: Kleene recursion theorem route
- All annotations include mathContext (LaTeX), significance, relatedConcepts, prerequisites

**Sections (meta.json):**
- Added 7 sections covering full file: imports, eval framework, abstract Rice, semantic properties, halting problem, classical Rice, summary checks

**Cross-references (meta.json):**
- Linked to parent (cantor-diagonalization-oq-03-oq-01), sibling (Gödel as Lawvere OQ-03), grandparent (Lawvere + Cantor OQ-03), and root (Cantor diagonalization)