### PR TITLE
Fix gallery integrity: cantor-godel badge and axiomCount

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-03/meta.json
@@ -16,10 +16,10 @@
       "provability-logic",
       "abstract-logic"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-04",
-    "axiomCount": 7,
+    "axiomCount": 5,
     "assumptions": "GodelModel axiomatizes the essentials of a Peano-strength formal system as structure fields: point-surjective evaluation (diagonal lemma), formal negation, consistency, reflection principle, and D1 axiom of provability logic. StrongGodelModel additionally axiomatizes double-negation elimination for the strong incompleteness result. These are mathematical hypotheses, not global Lean axioms.",
     "lineCount": 256,
     "theoremCount": 6,
@@ -62,7 +62,7 @@
   "leanFile": {
     "namespace": "CantorDiagonalizationOQ03OQ01OQ03",
     "lineCount": 256,
-    "axiomCount": 7,
+    "axiomCount": 5,
     "theoremCount": 6,
     "definitionCount": 5
   }


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: `cantor-diagonalization-oq-03-oq-01-oq-03` (Gödel's Incompleteness as Lawvere Instance)

### Issues Fixed

**1. Badge mismatch (MEDIUM)**
- `badge: "original"` → `badge: "axiom"`
- The proof has `status: "axiomatized"` with 5 structure-encoded hypothesis fields (`h_diag`, `h_consistent`, `h_reflection`, `h_D1`, `h_dne`). Per CLAUDE.md policy, `axiomatized` status requires `"axiom"` badge, not `"original"`.

**2. axiomCount wrong (LOW)**
- `axiomCount: 7` → `axiomCount: 5`
- Actual Prop-typed hypothesis fields: `GodelModel.h_diag`, `GodelModel.h_consistent`, `GodelModel.h_reflection`, `GodelModel.h_D1`, `StrongGodelModel.h_dne` = 5 total.

### Evidence

**meta.json claimed**: `badge: "original"`, `axiomCount: 7`
**Lean file shows**: 5 assumption-carrying structure fields (Prop-typed), 0 `axiom` declarations, status correctly `axiomatized`

---
Discovered during gallery integrity audit cycle 45.