### PR TITLE
Fix gallery integrity: rice theorem status/badge/axiomCount

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/CantorDiagonalizationOQ03OQ01OQ02.lean",
     "tags": [
       "computability",
@@ -16,11 +16,11 @@
       "diagonal-argument",
       "abstract-logic"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-04",
-    "axiomCount": 0,
-    "assumptions": "None. Fully machine-verified (ClassicalRiceModel axiomatizes Kleene's recursion theorem as a hypothesis, not a global axiom).",
+    "axiomCount": 2,
+    "assumptions": "ClassicalRiceModel axiomatizes Kleene's recursion theorem via two structure fields: h_compile (universality of semantics) and kleene_rec (semantic fixed-point theorem). These are mathematical hypotheses used in classical_rice_abstract; the other five theorems (abstract_rice through no_halting_model) are fully axiom-free.",
     "lineCount": 275,
     "theoremCount": 6,
     "definitionCount": 4,
@@ -135,7 +135,7 @@
   "leanFile": {
     "namespace": "CantorDiagonalizationOQ03OQ01OQ02",
     "lineCount": 275,
-    "axiomCount": 0,
+    "axiomCount": 2,
     "theoremCount": 6,
     "definitionCount": 4
   }


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: `cantor-diagonalization-oq-03-oq-01-oq-02` (Rice's Theorem as a Lawvere Instance)

### Issues Fixed

**1. Status overclaim (MEDIUM)**
- `status: "verified"` → `status: "axiomatized"`
- `ClassicalRiceModel` has 2 assumption-carrying Prop fields: `h_compile` (universality of semantics) and `kleene_rec` (semantic fixed-point / Kleene recursion). Per CLAUDE.md, `verified` requires "0 structure-encoded assumptions."

**2. Badge mismatch (MEDIUM)**
- `badge: "original"` → `badge: "axiom"`
- Consistent with the corrected `axiomatized` status.

**3. axiomCount wrong (LOW)**
- `axiomCount: 0` → `axiomCount: 2`
- `ClassicalRiceModel.h_compile` + `ClassicalRiceModel.kleene_rec`

### Evidence

**meta.json claimed**: `status: "verified"`, `badge: "original"`, `axiomCount: 0`
**Lean file shows**: `ClassicalRiceModel` structure with 2 Prop-typed hypothesis fields used in `classical_rice_abstract`

### Note
The other 5 theorems in the file (`abstract_rice`, `rice_induced_obstruction`, `rice_undecidable_witness`, `semantic_rice_flip`, `no_halting_model`) are fully axiom-free — only `classical_rice_abstract` depends on ClassicalRiceModel's structure axioms.

---
Discovered during gallery integrity audit cycle 45.