### PR TITLE
Fix gallery integrity: erdos-1012-oq-03 sorry count and line count

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11437,6 +11437,12 @@
       "lastAudited": "2026-04-04T18:05:35Z",
       "result": "clean",
       "issues": []
+    },
+    "cantor-diagonalization-oq-03-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T19:20:35Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {

--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -13,10 +13,10 @@
       "tournaments"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 2,
     "axiomCount": 0,
-    "lineCount": 1277,
-    "assumptions": "0 axioms. 1 sorry: ghouila_houri (full proof needs longest-path argument ~200 lines tracking both in- and out-degrees). hamiltonian_of_few_missing_arcs and directed_hamiltonian_threshold are now fully proved: the fiber counting lemma hBadFor_bound (∀ p ∈ Missing, |BadFor p| ≤ n*(n-2)!) was proved via fiber decomposition + injection into Perm(Fin(n-2)) using Finset.orderIsoOfFin. Moon-Moser theorem and Rédei are also fully proved.",
+    "lineCount": 1549,
+    "assumptions": "0 axioms. 2 sorries in the Ghouila-Houri chain: (1) sc_digraph_has_directed_cycle (line 352): SC + positive out-degree implies a directed cycle; proof needs first-repeated-vertex extraction from a closed walk. (2) gh_cycle_extendable case k < n-1 (line 539): growing a short cycle under Ghouila-Houri degree conditions; needs SC routing + degree counting. hamiltonian_of_few_missing_arcs and directed_hamiltonian_threshold are fully proved (lines 1253–1520). Moon-Moser and Rédei are fully proved.",
     "dateAdded": "2026-03-30"
   },
   "overview": {
@@ -83,10 +83,10 @@
     }
   ],
   "conclusion": {
-    "summary": "Rédei's theorem (every tournament has a Hamiltonian path) is fully proved by induction via the tournament insertion lemma. Moon-Moser's theorem (every strongly connected tournament has a Hamiltonian cycle) is fully proved. directed_hamiltonian_threshold (arc count (n-1)² forces Hamiltonicity) is now fully proved via hamiltonian_of_few_missing_arcs, which was completed by proving the fiber counting lemma hBadFor_bound using Finset.orderIsoOfFin injections into Perm(Fin(n-2)). Only ghouila_houri remains as a sorry (1 sorry). The 1277-line file is the most substantial directed Hamiltonicity formalization in this gallery.",
+    "summary": "Rédei's theorem (every tournament has a Hamiltonian path) is fully proved by induction via the tournament insertion lemma. Moon-Moser's theorem (every strongly connected tournament has a Hamiltonian cycle) is fully proved. directed_hamiltonian_threshold (arc count (n-1)² forces Hamiltonicity) is fully proved via hamiltonian_of_few_missing_arcs. The Ghouila-Houri chain has 2 remaining sorries: sc_digraph_has_directed_cycle (cycle extraction from a closed walk) and gh_cycle_extendable case k < n-1 (cycle growth for short cycles). The 1549-line file is the most substantial directed Hamiltonicity formalization in this gallery.",
     "implications": "Directed Hamiltonicity thresholds have applications beyond pure graph theory: tournament Hamiltonian paths correspond to linear extensions of partial orders, with applications to voting theory (ranking candidates) and scheduling. Rédei's theorem has a direct combinatorial interpretation: in any round-robin tournament, there exists a ranking of all players consistent with the match results (as a directed path). Moon-Moser's result shows that strongly connected tournaments (those where outcomes don't create a dominant clique) have circular Hamiltonian cycles — a stronger consistency property.",
     "openQuestions": [
-      "Can `ghouila_houri` be fully proved? It requires a longest-path argument tracking both in- and out-degrees (~200 lines), analogous to the undirected Dirac theorem. This is the only remaining sorry.",
+      "Can the 2 remaining Ghouila-Houri sorries be closed? (1) sc_digraph_has_directed_cycle needs first-repeated-vertex extraction from a closed walk. (2) gh_cycle_extendable case k < n-1 needs SC routing through non-cycle vertices combined with degree counting — the hardest step in the Ghouila-Houri proof.",
       "Can Ghouila-Houri's theorem be fully formalized? The proof follows the Dirac argument for undirected graphs but requires tracking both in- and out-degrees. Is the analogous undirected Dirac theorem in Mathlib, and can the directed version be derived?",
       "Meyniel's condition (weaker than Ghouila-Houri: $\\delta^+(u) + \\delta^-(u) + \\delta^+(v) + \\delta^-(v) \\geq 2n-1$ for non-adjacent pairs) implies Hamiltonicity. Can this stronger result be formalized, or would it require substantially more tournament infrastructure?",
       "The arc threshold $(n-1)^2$ in `directed_hamiltonian_threshold` — is this the tight bound? What is the densest non-Hamiltonian strongly connected tournament on $n$ vertices, and can a tight threshold be proved in Lean?"


### PR DESCRIPTION
## Summary

- Corrects `sorries` field from 1 → 2 in `erdos-1012-oq-03`
- Corrects `lineCount` from 1277 → 1549
- Updates `assumptions` and `conclusion.summary` text

## Evidence

**meta.json claimed**: 1 sorry (ghouila_houri), 1277 lines
**Lean file shows**: 2 sorries at lines 352 and 539, 1549 lines total

The 2 sorries are both in the Ghouila-Houri proof chain:
1. `sc_digraph_has_directed_cycle` (line 352): incomplete proof that SC + positive out-degree implies a directed cycle — needs first-repeated-vertex extraction from a closed walk
2. `gh_cycle_extendable` case `k < n-1` (line 539): the harder cycle-growth case under Ghouila-Houri degree conditions

Status `"formalized"` / badge `"wip"` remain correct.

Also includes audit tracker update marking `cantor-diagonalization-oq-03-oq-01-oq-03` as clean (structure-encoded axioms, 0 sorries, correct `axiomatized` classification).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)