### PR TITLE
Fix: update stale lineCount in 8 meta.json files

### DIFF
--- a/src/data/proofs/burnside-counting-oq-03/meta.json
+++ b/src/data/proofs/burnside-counting-oq-03/meta.json
@@ -25,7 +25,7 @@
     "axiomCount": 0,
     "assumptions": "No sorries, no axioms. Uses Mathlib's ZMod.addOrderOf_coe for the orbit size formula (addOrderOf r = n / gcd(n, r.val)) and references MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group (Burnside's lemma). The core theorem polya_cyclic_fixed_count is independently proved via explicit bijection; the general necklace formula is stated conditionally with Burnside as a hypothesis.",
     "dateAdded": "2026-04-04",
-    "lineCount": 294,
+    "lineCount": 404,
     "theoremCount": 15,
     "definitionCount": 2,
     "mathlibDependencies": [

--- a/src/data/proofs/erdos-1059-oq-01/meta.json
+++ b/src/data/proofs/erdos-1059-oq-01/meta.json
@@ -75,7 +75,7 @@
       "Finset operations for counting",
       "Floor binary logarithm (Nat.log) and its monotonicity properties"
     ],
-    "lineCount": 340,
+    "lineCount": 396,
     "relatedProblems": [
       {
         "id": "erdos-1059",

--- a/src/data/proofs/erdos-220/meta.json
+++ b/src/data/proofs/erdos-220/meta.json
@@ -59,7 +59,7 @@
       "jacobsthal n: maximum gap function"
     ],
     "axiomCount": 4,
-    "lineCount": 241,
+    "lineCount": 226,
     "assumptions": "4 axioms (montgomery_vaughan_squared — squared gaps sum O(n²/φ(n)); montgomery_vaughan_general — γ-th power generalization; maximum_gap_bound — max gap ≤ C·n/φ(n)·(log n)²; gap_concentration — gap distribution measure estimate) and 2 sorries (sum_gaps_bound derivation; reduced_residues_count). 0 True-stub theorems."
   },
   "overview": {

--- a/src/data/proofs/erdos-277/meta.json
+++ b/src/data/proofs/erdos-277/meta.json
@@ -60,7 +60,7 @@
       "IsHighlyComposite, IsSuperabundant: related concepts"
     ],
     "axiomCount": 1,
-    "lineCount": 283,
+    "lineCount": 275,
     "assumptions": "4 axiom(s) and 0 sorries remain.(s). covering_crt_connection proved from Finset.mem_image."
   },
   "overview": {

--- a/src/data/proofs/erdos-290/meta.json
+++ b/src/data/proofs/erdos-290/meta.json
@@ -62,7 +62,7 @@
       "OEIS A375081 values recorded"
     ],
     "axiomCount": 2,
-    "lineCount": 244,
+    "lineCount": 263,
     "assumptions": "9 axiom(s) and 2 sorries(s). See the Lean source for details."
   },
   "overview": {

--- a/src/data/proofs/erdos-448/meta.json
+++ b/src/data/proofs/erdos-448/meta.json
@@ -59,7 +59,7 @@
       "erdos_448 theorem: the conjecture is false"
     ],
     "axiomCount": 2,
-    "lineCount": 298,
+    "lineCount": 307,
     "assumptions": "12 axiom(s) and 1 sorry(s). See the Lean source for details."
   },
   "overview": {

--- a/src/data/proofs/erdos-671/meta.json
+++ b/src/data/proofs/erdos-671/meta.json
@@ -63,7 +63,7 @@
       "MainConjecture definition: Q1 iff Q2?"
     ],
     "axiomCount": 3,
-    "lineCount": 269,
+    "lineCount": 249,
     "assumptions": "3 axiom(s) and 23 sorry(s). See the Lean source for details."
   },
   "overview": {

--- a/src/data/proofs/hilbert-23/meta.json
+++ b/src/data/proofs/hilbert-23/meta.json
@@ -45,7 +45,7 @@
     "dateAdded": "2025-12-29",
     "hilbertNumber": 23,
     "axiomCount": 0,
-    "lineCount": 335,
+    "lineCount": 328,
     "assumptions": "Main theorems are True stubs (e.g., euler_lagrange_weak_form and hilbert_23_status prove vacuous existential True propositions, not actual variational results). The Euler-Lagrange equation is not genuinely formalized. Variational infrastructure (Lagrangian structures, action functionals) is defined but the core mathematical content is not machine-verified.",
     "mathlib_version": "4.26.0"
   },


### PR DESCRIPTION
## Fix

Corrects stale `lineCount` fields in 8 meta.json files to match current Lean source files.

## Evidence

| Proof | Before | After | Diff |
|-------|--------|-------|------|
| burnside-counting-oq-03 | 294 | 404 | +110 |
| erdos-1059-oq-01 | 340 | 396 | +56 |
| erdos-290 | 244 | 263 | +19 |
| erdos-448 | 298 | 307 | +9 |
| erdos-277 | 283 | 275 | -8 |
| hilbert-23 | 335 | 328 | -7 |
| erdos-220 | 241 | 226 | -15 |
| erdos-671 | 269 | 249 | -20 |

These mismatches accumulated as researcher agents updated the Lean source files after the last lineCount sync.

---
Automated fix by lean-mechanic agent.