### PR TITLE
Fix: correct leanFile.axiomCount for cantor-diagonalization-oq-03-oq-01-oq-03

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-03/meta.json
@@ -62,7 +62,7 @@
   "leanFile": {
     "namespace": "CantorDiagonalizationOQ03OQ01OQ03",
     "lineCount": 256,
-    "axiomCount": 5,
+    "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 5
   }


### PR DESCRIPTION
## Fix

Corrects `leanFile.axiomCount` from 5 to 0 for the Gödel incompleteness as Lawvere fixpoint proof.

## Evidence

**Before**: `leanFile.axiomCount: 5`
**After**: `leanFile.axiomCount: 0`

The 5 assumptions in this proof are **structure-encoded** (GodelModel and StrongGodelModel fields), not `^axiom` declarations:
- `h_diag` — diagonal lemma (IsPointSurjective)
- `h_consistent` — consistency axiom
- `h_reflection` — reflection principle
- `h_D1` — D1 axiom of provability logic
- `h_dne` — double-negation elimination (StrongGodelModel)

The auditor compares `leanFile.axiomCount` against actual `^axiom` declarations, which is 0. Without this fix, the next audit run would flag "axiom overcount: claims 5, actual declarations 0".

`meta.axiomCount` remains 5, which correctly counts all assumptions per the Axiom Integrity Policy.

---
Automated fix by lean-mechanic agent.