### PR TITLE
Fix gallery integrity: erdos-1012-oq-03 sorry 2→1, lineCount 1549→1277

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1847,9 +1847,9 @@
       "result": "clean"
     },
     "erdos-1012-oq-03": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-04T13:41:12Z",
+      "lastAudited": "2026-04-04T19:24:10Z",
       "result": "issues-fixed"
     },
     "erdos-1013": {


### PR DESCRIPTION
## Summary

Follow-up correction after PR #9464 was merged: the Lean file was reorganized (partial helper lemmas removed, direct sorry placed on `ghouila_houri`), so the fix from #9464 overcorrected.

- Corrects `sorries` from 2 → 1 (only `ghouila_houri` remains)
- Corrects `lineCount` from 1549 → 1277 (file shrank after reorganization)
- Updates `assumptions` and `conclusion.summary` text

## Evidence

**meta.json (post-#9464)**: 2 sorries, 1549 lines
**Lean file now**: 1 sorry at line 302 (`ghouila_houri := by sorry`), 1277 lines

The file was reorganized between audit cycles: the two partial-proof helpers (`sc_digraph_has_directed_cycle` and `gh_cycle_extendable`) were removed and replaced with a single clean sorry on the main theorem.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)