### PR TITLE
Fix: 2 auditor-detected metadata corrections (cantor-oq02 + erdos-1012)

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-02/meta.json
@@ -135,7 +135,7 @@
   "leanFile": {
     "namespace": "CantorDiagonalizationOQ03OQ01OQ02",
     "lineCount": 275,
-    "axiomCount": 2,
+    "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 4
   }

--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -13,9 +13,9 @@
       "tournaments"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 1549,
+    "lineCount": 1277,
     "assumptions": "0 axioms. 2 sorries in the Ghouila-Houri chain: (1) sc_digraph_has_directed_cycle (line 352): SC + positive out-degree implies a directed cycle; proof needs first-repeated-vertex extraction from a closed walk. (2) gh_cycle_extendable case k < n-1 (line 539): growing a short cycle under Ghouila-Houri degree conditions; needs SC routing + degree counting. hamiltonian_of_few_missing_arcs and directed_hamiltonian_threshold are fully proved (lines 1253–1520). Moon-Moser and Rédei are fully proved.",
     "dateAdded": "2026-03-30"
   },


### PR DESCRIPTION
## Fixes

### 1. cantor-diagonalization-oq-03-oq-01-oq-02 — `leanFile.axiomCount` overcount

**Before**: `leanFile.axiomCount: 2`
**After**: `leanFile.axiomCount: 0`

PR #9462 introduced this issue by setting `leanFile.axiomCount=2`, but `ClassicalRiceModel`'s 2 assumptions (`h_compile`, `kleene_rec`) are **structure fields**, not `^axiom` declarations. Per the auditor spec, `leanFile.axiomCount` tracks only raw `^axiom` declarations. `meta.axiomCount=2` correctly describes the total assumptions.

Without this fix: auditor flags `"axiom overcount: claims 2, actual declarations 0"`.

### 2. erdos-1012-oq-03 — `sorries` and `lineCount` overcount

**Before**: `sorries: 2`, `lineCount: 1549`
**After**: `sorries: 1`, `lineCount: 1277`

PR #9464 ran against an in-progress version of the Lean file with 2 sorries. The current committed file (`2b57882797`) has 1 sorry (at line 302) and 1277 lines.

## Evidence

Verified by `npx tsx scripts/auditor/find-targets.ts --issues`:
- `cantor-diagonalization-oq-03-oq-01-oq-02`: "axiom overcount: claims 2, actual declarations 0"
- `erdos-1012-oq-03`: "sorry mismatch: claims 2, actual 1"

---
Automated fix by lean-mechanic agent.