### PR TITLE
Fix: clamp section endLine to actual file length in 5 gallery proofs

### DIFF
--- a/src/data/proofs/arithmetic-series/meta.json
+++ b/src/data/proofs/arithmetic-series/meta.json
@@ -118,7 +118,7 @@
       "id": "triangular-numbers",
       "title": "Triangular Numbers",
       "startLine": 141,
-      "endLine": 187,
+      "endLine": 180,
       "summary": "Definition and properties of triangular numbers.",
       "mathContext": "$T_n = \\frac{n(n+1)}{2} = \\binom{n+1}{2}$. The $n$-th triangular number counts pairs from $n+1$ objects. Properties: $T_n + T_{n-1} = n^2$ (two consecutive triangulars make a square), $8T_n + 1 = (2n+1)^2$ (a square), and $T_n = \\sum_{k=1}^{n} k$ (definition as partial sum)."
     }

--- a/src/data/proofs/ballot-problem/meta.json
+++ b/src/data/proofs/ballot-problem/meta.json
@@ -135,7 +135,7 @@
       "id": "reflection-principle",
       "title": "The Reflection Principle",
       "startLine": 216,
-      "endLine": 255,
+      "endLine": 251,
       "summary": "Detailed explanation of the bijective proof technique.",
       "mathContext": "André's reflection bijection: for any 'bad' path (first touching $y=0$ at step $k$), reflect all votes before step $k$ ($+1 \\leftrightarrow -1$). This maps bad paths ending at $(p+q, p-q)$ bijectively to ALL paths ending at $(p+q, q-p)$. Count: $\\binom{p+q}{q}$ bad paths, so good paths $= \\binom{p+q}{p} - \\binom{p+q}{q}$."
     }

--- a/src/data/proofs/cevas-theorem/meta.json
+++ b/src/data/proofs/cevas-theorem/meta.json
@@ -119,7 +119,7 @@
       "id": "historical-context",
       "title": "Historical Context",
       "startLine": 209,
-      "endLine": 269,
+      "endLine": 263,
       "summary": "Extended discussion of Menelaus's theorem, applications, and generalizations.",
       "mathContext": "Menelaus's theorem (dual): points $D, E, F$ on sides $BC, CA, AB$ are collinear $\\iff$ $(AF/FB) \\cdot (BD/DC) \\cdot (CE/EA) = -1$. The sign difference ($+1$ for Ceva, $-1$ for Menelaus) reflects the parity: concurrent cevians require an even number of external divisions, while a transversal requires an odd number."
     }

--- a/src/data/proofs/erdos-320/meta.json
+++ b/src/data/proofs/erdos-320/meta.json
@@ -176,7 +176,7 @@
       "id": "summary",
       "title": "Part XI: Summary",
       "startLine": 219,
-      "endLine": 248,
+      "endLine": 232,
       "summary": "The theorem erdos_320_summary is GENUINELY PROVED by extracting S(1) = 2, S(2) = 4, S(3) = 8, S(8) = 255 from oeis_A072207 via nested tuple projections. The status string records the OPEN problem with the known bound gap. Final tally: 2 sorries, 8 axioms. Genuinely proved theorems: bgms_improves_bleicher_erdos, first_collision, erdos_320_summary, S_pos, S_one, S_two, S_three.",
       "mathContext": "The theorem erdos_320_summary is GENUINELY PROVED by extracting S(1) = 2, S(2) = 4, S(3) = 8, S(8) = 255 from oeis_A072207 via nested tuple projections. The status string records the OPEN problem with the known bound gap."
     }

--- a/src/data/proofs/erdos-933/meta.json
+++ b/src/data/proofs/erdos-933/meta.json
@@ -146,17 +146,9 @@
       "id": "examples",
       "title": "Examples",
       "startLine": 181,
-      "endLine": 198,
-      "summary": "Two concrete examples verified by `native_decide`: steinerbergerN 1 = 8 (8·9=72=2³·3², ratio≈4.33), steinerbergerN 2 = 512 (512·513=2⁹·3³·19, smooth=13824). Defines `exampleSequence := steinerbergerN`.",
+      "endLine": 197,
+      "summary": "Two concrete examples verified by `native_decide`: steinerbergerN 1 = 8 (8·9=72=2³·3², ratio≈4.33), steinerbergerN 2 = 512 (512·513=2⁹·3³·19, smooth=13824). Defines `exampleSequence := steinerbergerN`. The final theorems (`erdos_933`, `erdos_933_main`, `erdos_933_solved`) complete the file.",
       "mathContext": "Two concrete examples verified by `native_decide`: steinerbergerN 1 = 8 (8·9=72=2³·3², ratio≈4.33), steinerbergerN 2 = 512 (512·513=2⁹·3³·19, smooth=13824). Defines `exampleSequence := steinerbergerN`."
-    },
-    {
-      "id": "summary",
-      "title": "Summary",
-      "startLine": 199,
-      "endLine": 230,
-      "summary": "Three equivalent main results: `erdos_933 := steinerberger_proof` (one-line), `erdos_933_main` (explicit ∀M∃n unfolding), `erdos_933_solved` (synonym). Docstring summarizes: YES, Steinerberger's proof via n=2^{3^r}, k=3^r, l=r+1, Mahler upper bound.",
-      "mathContext": "Three equivalent main results: `erdos_933 := steinerberger_proof` (one-line), `erdos_933_main` (explicit ∀M∃n unfolding), `erdos_933_solved` (synonym). Docstring summarizes: YES, Steinerberger's proof via n=2^{3^r}, k=3^r, l=r+1, Mahler upper bound."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Fix

Clamp section `endLine` values that exceeded the actual Lean file length.

## Evidence

**Before**: Section `endLine` values pointed beyond EOF in 5 proofs:

| Proof | Section | Old endLine | File Lines |
|-------|---------|-------------|------------|
| arithmetic-series | triangular-numbers | 187 | 180 |
| ballot-problem | reflection-principle | 255 | 251 |
| cevas-theorem | historical-context | 269 | 263 |
| erdos-320 | summary | 248 | 232 |
| erdos-933 | examples | 198 | 197 |
| erdos-933 | summary | startLine=199, endLine=230 | 197 (section entirely beyond EOF) |

**After**: All `endLine` values clamped to actual file length; the erdos-933 `summary` section (with `startLine=199` beyond the 197-line file) was removed.

---
Automated fix by lean-mechanic agent.