### PR TITLE
Enrich euler-identity-oq-01: annotation coverage, historical depth, section expansion

### DIFF
--- a/src/data/proofs/euler-identity-oq-01/annotations.json
+++ b/src/data/proofs/euler-identity-oq-01/annotations.json
@@ -36,6 +36,18 @@
     "prerequisites": ["complex numbers", "mathematical induction", "Lean ring tactic", "Mathlib Complex.I_sq"]
   },
   {
+    "id": "ann-algebraic-identities",
+    "proofId": "euler-identity-oq-01",
+    "range": { "startLine": 57, "endLine": 87 },
+    "type": "technique",
+    "title": "Powers of i: Four Algebraic Identities Proved by Induction",
+    "content": "The algebraic core of the proof: four theorems establishing how powers of i simplify. I_pow_even (k : ℕ) : I^{2k} = (-1)^k — proved by induction, with base case I^0 = 1 (trivial) and inductive step using I^{2(k+1)} = I^{2k} · I^2 = (-1)^k · (-1) = (-1)^{k+1}. I_pow_odd (k : ℕ) : I^{2k+1} = I · (-1)^k — a one-liner from I_pow_even and pow_succ. expTerm_even (x k) : expTerm(ix)(2k) = evenTerm(x)(k) — rewrites (ix)^{2k}/(2k)! = i^{2k} · x^{2k}/(2k)! = (-1)^k · x^{2k}/(2k)! using I_pow_even. expTerm_odd (x k) : expTerm(ix)(2k+1) = oddTerm(x)(k) — similarly converts odd-indexed terms using I_pow_odd. These four results are the only purely algebraic (non-analytic) content of the proof: they require no topology, no limits, only ring arithmetic and induction.",
+    "mathContext": "$i^{2k} = (-1)^k$ (induction from $i^2 = -1$: $i^{2(k+1)} = i^{2k} \\cdot i^2 = (-1)^k \\cdot (-1) = (-1)^{k+1}$); $i^{2k+1} = i \\cdot (-1)^k$ (from $i^{2k+1} = i^{2k} \\cdot i$). These imply $(ix)^{2k} = i^{2k} x^{2k} = (-1)^k x^{2k}$ and $(ix)^{2k+1} = i^{2k+1} x^{2k+1} = i(-1)^k x^{2k+1}$, converting general exponential series terms into recognizable cos/sin series terms.",
+    "significance": "key",
+    "relatedConcepts": ["I_pow_even", "I_pow_odd", "expTerm_even", "expTerm_odd", "imaginary unit", "de Moivre's formula", "Complex.I_sq"],
+    "prerequisites": ["complex numbers", "mathematical induction", "Lean ring tactic", "Mathlib Complex.I_sq"]
+  },
+  {
     "id": "ann-axioms",
     "proofId": "euler-identity-oq-01",
     "range": { "startLine": 88, "endLine": 135 },


### PR DESCRIPTION
## Enrichment Summary

Quality improvements for `euler-identity-oq-01` (Euler's Formula via Taylor Series Splitting).

### Changes

**Annotation coverage (annotations.json):**
- Added `ann-algebraic-identities` (lines 57-87): covers the 4 algebraic identity theorems (`I_pow_even`, `I_pow_odd`, `expTerm_even`, `expTerm_odd`) — previously uncovered section. Includes full `mathContext` with LaTeX showing the induction step, `relatedConcepts`, and `prerequisites`.

**Historical context (meta.json `overview.historicalContext`):**
- Expanded from 2 sentences to a full historical narrative: Roger Cotes 1714 precursor, de Moivre 1722 formula, Euler's 1748 publication context, the unification of analysis/algebra/geometry, and Euler's identity as "the most beautiful equation"

**Key insights:**
- Added 5th insight: the Mathlib circularity trap (cos defined from exp, not via Taylor series) and how this proof resolves it by axiomatizing the Taylor series identifications

**Sections:**
- Fixed `main-theorem` section to accurate line range 129-173
- Added `axioms-tsum-cos-sin` section (88-127): covers the 3 axioms
- Added `axiom-elimination-roadmap` section (175-213): covers the roadmap comments

**Conclusion:**
- Richer `implications` explaining independence from `Complex.exp_mul_I` and the axiom elimination template
- Added 3rd `openQuestion`: ODE characterization approach (0-axiom path)
- Updated `summary` to consistently say 3 axioms (matches `axiomCount: 3`)

**Cross-references:**
- Added link to `taylor-sincos-convergence`, which provides the convergence results needed to eliminate the `cos_eq_tsum` and `sin_eq_tsum` axioms

### Build
- `pnpm build` ✅
- No new annotation validation errors introduced