### PR TITLE
Fix: remove True placeholder from erdos-1143 (covering_complement_relation)

### DIFF
--- a/proofs/Proofs/Erdos1143Problem.lean
+++ b/proofs/Proofs/Erdos1143Problem.lean
@@ -266,17 +266,19 @@ theorem density_two_three_five :
 ## Connection to Jacobsthal's Function
 -/
 
-/-- Jacobsthal's function h(k) asks for the minimal m such that any m
-    consecutive integers contain one coprime to a k-prime number.
-    F_k is the "dual" question: how many are covered rather than uncovered.
+/- Jacobsthal's function h(k) asks for the minimal m such that any m
+   consecutive integers contain one coprime to a k-prime number.
+   F_k is the "dual" question: how many are covered rather than uncovered.
 
-    If h denotes Jacobsthal's function and n = p₁···pᵤ, then
-    F_{h(u)-1}(p₁,...,pᵤ) = h(u) - 1 (all are covered).
-    See Erdős #970 for Jacobsthal's function. -/
-theorem covering_complement_relation (primes : Finset ℕ) (k : ℕ) :
-    -- uncovered = k - covered
-    -- Jacobsthal asks for min k such that uncovered = 0
-    True := by trivial
+   The key relationship is: uncovered = k - covered.
+   Jacobsthal asks for the minimal k such that uncovered = 0.
+
+   If h denotes Jacobsthal's function and n = p₁···pᵤ, then
+   F_{h(u)-1}(p₁,...,pᵤ) = h(u) - 1 (all are covered).
+   See Erdős #970 for Jacobsthal's function.
+
+   Formally stating this relationship requires defining Jacobsthal's function,
+   which is not yet available in this formalization. -/
 
 /-
 ## Summary

--- a/src/data/proofs/erdos-1143/meta.json
+++ b/src/data/proofs/erdos-1143/meta.json
@@ -54,8 +54,8 @@
     ],
     "historicalContext": "Erdős asked about F_k(p₁,...,pᵤ), the minimum number of integers divisible by at least one given prime in any interval of k consecutive integers. Erdős and Selfridge reportedly found the exact formula for 2 < α < 3 (where k = αpᵤ), but the paper has not been located. For α > 3, very little is known.",
     "axiomCount": 2,
-    "lineCount": 297,
-    "assumptions": "2 axiom(s), 0 sorry(s). 1 True-stub placeholder (covering_complement_relation). The 2 axioms are: covering_asymptotic (density main term) and covering_upper_bound (F_k ≤ k·density + |primes|). Previously 3 axioms: erdos_selfridge_exact was proved trivially (∃ x, f = x), alpha_gt_3_open lower bound proved (density < 1 makes LHS ≤ 0)."
+    "lineCount": 299,
+    "assumptions": "2 axiom(s), 0 sorry(s). The 2 axioms are: covering_asymptotic (density main term) and covering_upper_bound (F_k ≤ k·density + |primes|). Previously 3 axioms: erdos_selfridge_exact was proved trivially (∃ x, f = x), alpha_gt_3_open lower bound proved (density < 1 makes LHS ≤ 0)."
   },
   "overview": {
     "historicalContext": "Erdős Problem #1143 belongs to the rich tradition of **sieve-theoretic covering problems** dating back to Eratosthenes. The question of how many integers in a short interval are divisible by given primes connects to the **Selberg sieve**, the **large sieve**, and the distribution of prime gaps. Erdős formulated this problem as a quantitative version of the Chinese Remainder Theorem: while CRT tells us the *average* density of covered integers is $1 - \\prod(1 - 1/p_i)$, the problem asks about the *worst-case* covering over all starting positions. The parameter $\\alpha = k/p_u$ measures how many complete periods of the largest prime fit in the interval. Erdős and Selfridge reportedly solved the $2 < \\alpha < 3$ case exactly, but their paper has never been located — one of the tantalizing 'lost results' in combinatorial number theory. The dual problem (Erdős #970, Jacobsthal's function) asks about coprime elements instead; Iwaniec (1978) proved the best known bounds $h(k) = O(k^{0.735})$.",
@@ -120,12 +120,12 @@
       "title": "Jacobsthal Connection and Summary",
       "startLine": 241,
       "endLine": 273,
-      "summary": "Defines the complement relation between covering count and Jacobsthal's function: uncovered $= k - F_k$. `covering_complement_relation` is a True-stub placeholder. Closing summary documents the known results and open status.",
+      "summary": "Documents the complement relation between covering count and Jacobsthal's function: uncovered $= k - F_k$. The relationship is described in a comment (formally stating it requires defining Jacobsthal's function). Closing summary documents the known results and open status.",
       "mathContext": "Jacobsthal's function $h(u)$ is the minimal $m$ such that any $m$ consecutive integers contain one coprime to $p_1 \\cdots p_u$. The dual: $F_{h(u)-1} = h(u) - 1$ (all covered). See Erdős #970."
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős #1143, an open problem about covering intervals with multiples of primes. All theorems are fully proved (0 sorries). 2 axioms remain: covering_asymptotic (density main term) and covering_upper_bound (F_k upper bound). Previously 3 axioms: erdos_selfridge_exact was proved trivially, alpha_gt_3_open lower bound was proved. 1 True-stub placeholder for Jacobsthal connection.",
+    "summary": "This formalization captures Erdős #1143, an open problem about covering intervals with multiples of primes. All theorems are fully proved (0 sorries). 2 axioms remain: covering_asymptotic (density main term) and covering_upper_bound (F_k upper bound). Previously 3 axioms: erdos_selfridge_exact was proved trivially, alpha_gt_3_open lower bound was proved.",
     "implications": "**Theoretical Significance**: Understanding $F_k$ connects to several important areas: **sieve theory** (the covering function is closely related to sieve weights), **Jacobsthal's function** (the dual coprimality question), and the **distribution of smooth numbers** in short intervals.\n\nSharp estimates for $F_k$ in the $\\alpha > 3$ regime would have consequences for prime gap bounds and the structure of residue classes modulo products of small primes. The lost Erdős-Selfridge result, if reconstructed, could provide a template for the general case.",
     "openQuestions": [
       "What is the exact formula for $F_k$ when $k = \\alpha p_u$ with $\\alpha > 3$? Can the density approximation error be made uniform in the prime set?",
@@ -163,9 +163,9 @@
       "BigOperators"
     ],
     "namespace": "Erdos1143",
-    "lineCount": 297,
+    "lineCount": 299,
     "axiomCount": 2,
-    "theoremCount": 12,
+    "theoremCount": 11,
     "definitionCount": 3
   },
   "references": [


### PR DESCRIPTION
## Summary

- Removed the `True := by trivial` placeholder theorem `covering_complement_relation` from `proofs/Proofs/Erdos1143Problem.lean`
- Replaced the docstring + theorem with a plain `/-` comment block that preserves all mathematical insight about the Jacobsthal duality relationship
- Updated `src/data/proofs/erdos-1143/meta.json`: lineCount 297->299, theoremCount 12->11, removed True-stub references from assumptions, section summary, and conclusion summary

## What was wrong

The quality audit flagged `erdos-1143` as containing a `placeholder-proof`:
```
erdos-1143 -- Contains placeholder proof (True := trivial)
```

The theorem `covering_complement_relation` had type `True := by trivial`, which contributes no mathematical content and inflates the theorem count.

## What was fixed

The theorem was removed and its docstring converted to a plain comment (`/-` style). The comment preserves:
- The description of Jacobsthal's function and its duality with the covering function
- The key relationship: uncovered = k - covered
- The note that formally stating this requires defining Jacobsthal's function

The section header `## Connection to Jacobsthal's Function` is preserved intact.

## Unchanged fields

- `sorries`: 0 (unchanged)
- `axiomCount`: 2 (unchanged)
- `status`: "axiomatized" (unchanged)

## Build verification

- `pnpm annotations:build` passes with no erdos-1143-related errors
- meta.json validates as correct JSON
- Pre-existing build failure in `research:sync` (missing `candidate-pool.json`) is unrelated to these changes