### PR TITLE
chore: sync research registry

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -12355,11 +12355,12 @@
     },
     {
       "slug": "ballot-problem-oq-01-oq-02-oq-02",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-04T05:15:05.956Z",
-      "status": "active",
-      "lastUpdate": "2026-04-04T05:15:05.956Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T21:07:53.430Z",
+      "completed": "2026-04-04T21:07:53.429Z"
     },
     {
       "slug": "bertrands-postulate-oq-03-oq-01",


### PR DESCRIPTION
Auto-generated sync PR from deployer.

Updates `research/registry.json` with current iteration counts and data.

🤖 Generated by deployer agent