### PR TITLE
Enrich amgm-inequality-oq-02-oq-03-oq-03: add 5 annotations, sections, context

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03/annotations.json
@@ -1,1 +1,62 @@
-[]
+[
+  {
+    "id": "ann-amgm-oq02-oq03-oq03-overview",
+    "proofId": "amgm-inequality-oq-02-oq-03-oq-03",
+    "range": { "startLine": 1, "endLine": 28 },
+    "type": "context",
+    "title": "Three-Tier Maclaurin Hierarchy: Step → Newton Proof → Full Chain",
+    "content": "This file is the third tier in a three-part formalization hierarchy. The parent `AmgmInequalityOQ02.lean` axiomatizes `maclaurin_step` (adjacent inequality Mₖ ≥ Mₖ₊₁). The sibling `AmgmInequalityOQ02OQ03.lean` proves `maclaurin_step_proved` from Newton's log-concavity (e_k² ≥ e_{k-1}·e_{k+1}). This file assembles the full chain M₁ ≥ M₂ ≥ ... ≥ Mₙ from adjacent steps by induction. The design is modular: the chain proof works regardless of which source supplies the step — axiomatic or Newton-derived.",
+    "mathContext": "The full chain $M_1 \\geq M_2 \\geq \\cdots \\geq M_n$ decomposes into $n-1$ adjacent inequalities. The induction strategy: to prove $M_j \\geq M_{j+d}$, build the chain $M_j \\geq M_{j+1} \\geq \\cdots \\geq M_{j+d}$ via $d$ applications of `maclaurin_step`. This reduces the $O(n^2)$ pairwise comparisons to $O(n)$ adjacent steps.",
+    "significance": "context",
+    "relatedConcepts": ["Maclaurin inequalities", "AM-GM inequality", "elementary symmetric polynomials", "induction"],
+    "prerequisites": ["Maclaurin means definition", "maclaurin_step axiom", "adjacent inequality"]
+  },
+  {
+    "id": "ann-amgm-oq02-oq03-oq03-setup",
+    "proofId": "amgm-inequality-oq-02-oq-03-oq-03",
+    "range": { "startLine": 30, "endLine": 38 },
+    "type": "context",
+    "title": "Imports and Setup: Inheriting from AmgmInequalityOQ02",
+    "content": "The file imports `Proofs.AmgmInequalityOQ02`, which provides `maclaurinMean` (the definition of $M_k$) and `maclaurin_step` (the axiomatic adjacent inequality). By opening the parent namespace, the chain proof can directly invoke `maclaurin_step` without re-axiomatizing. The variable `{n : ℕ}` is implicit throughout — the chain is proved for arbitrary n.",
+    "mathContext": "The variable `{n : ℕ}` declared at line 37 is implicit in all theorems. `maclaurinMean k x` is the k-th Maclaurin mean of the vector `x : Fin n → ℝ`. The import chain is: AmgmInequalityOQ02 → AmgmInequalityOQ02OQ03OQ03 (this file does NOT import OQ03, so the proved step is not used here — only the axiomatic step from OQ02 is available).",
+    "significance": "supporting",
+    "relatedConcepts": ["Lean 4 imports", "namespace inheritance", "implicit variables", "maclaurinMean"],
+    "prerequisites": ["AmgmInequalityOQ02 definitions", "Lean 4 module system"]
+  },
+  {
+    "id": "ann-amgm-oq02-oq03-oq03-aux-lemma",
+    "proofId": "amgm-inequality-oq-02-oq-03-oq-03",
+    "range": { "startLine": 39, "endLine": 52 },
+    "type": "technique",
+    "title": "Inductive Auxiliary Lemma: Mⱼ ≥ Mⱼ₊ₐ by Gap Induction",
+    "content": "`maclaurin_chain_aux` is the technical core: it proves Mⱼ ≥ Mⱼ₊ₐ for arbitrary gap d by induction on d. Base case (d=0): `simp` since Mⱼ ≥ Mⱼ is reflexivity. Inductive case: assume Mⱼ ≥ Mⱼ₊ₘ (inductive hypothesis), then apply `maclaurin_step` to get Mⱼ₊ₘ ≥ Mⱼ₊ₘ₊₁, and close by `calc` transitivity. The auxiliary omega goals (j+m ≤ n, j+m+1 ≤ n, 0 < j+m) are discharged by `omega` from the hypotheses.",
+    "mathContext": "The `calc` block at lines 49-52 chains: $M_j \\geq M_{j+m}$ (ih) followed by $M_{j+m} \\geq M_{j+m+1}$ (maclaurin_step). The `private` qualifier keeps this lemma internal — only the public `maclaurin_full_chain` and `maclaurin_m1_ge_mn` are exported. The omega arithmetic: `hjm_le : j + m ≤ n` follows from `hjn : j + (m+1) ≤ n` since `m+1 ≤ m+1+1`.",
+    "significance": "key",
+    "relatedConcepts": ["induction on natural numbers", "calc transitivity", "omega tactic", "Nat.succ induction"],
+    "prerequisites": ["maclaurin_step axiom", "induction tactic", "calc blocks in Lean 4"]
+  },
+  {
+    "id": "ann-amgm-oq02-oq03-oq03-main-theorem",
+    "proofId": "amgm-inequality-oq-02-oq-03-oq-03",
+    "range": { "startLine": 54, "endLine": 59 },
+    "type": "technique",
+    "title": "Full Maclaurin Chain: Nat.exists_eq_add_of_le Bridges Gap to Auxiliary",
+    "content": "`maclaurin_full_chain` is the main exported theorem: for 0 < j ≤ k ≤ n, the j-th Maclaurin mean dominates the k-th. The proof uses `Nat.exists_eq_add_of_le hjk` to extract d such that k = j + d (converting the ≤ relation into an explicit gap), then applies `maclaurin_chain_aux` with that gap. This is the standard Lean pattern for converting between `j ≤ k` and `∃ d, k = j + d`.",
+    "mathContext": "`obtain ⟨d, rfl⟩ := Nat.exists_eq_add_of_le hjk` rewrites k as j+d in-place (using `rfl` to substitute). After this, the goal becomes `maclaurinMean j x ≥ maclaurinMean (j + d) x`, exactly the conclusion of `maclaurin_chain_aux`. The `by omega` closes `j + d ≤ n` from `hkn : j + d ≤ n`.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.exists_eq_add_of_le", "obtain pattern", "gap induction", "Maclaurin chain"],
+    "prerequisites": ["maclaurin_chain_aux", "Nat.exists_eq_add_of_le", "obtain tactic"]
+  },
+  {
+    "id": "ann-amgm-oq02-oq03-oq03-corollary",
+    "proofId": "amgm-inequality-oq-02-oq-03-oq-03",
+    "range": { "startLine": 61, "endLine": 64 },
+    "type": "concept",
+    "title": "M₁ ≥ Mₙ: Arithmetic Mean Dominates the n-th Maclaurin Mean",
+    "content": "`maclaurin_m1_ge_mn` specializes the full chain to its extreme cases: j=1 and k=n. The proof is a one-liner delegating to `maclaurin_full_chain` with `Nat.one_pos` (1 > 0), `hn : 1 ≤ n`, and `le_refl n`. This corollary is important because M₁ = arithmetic mean and Mₙ = (e_n/1)^{1/n} = (x₁·x₂·...·xₙ)^{1/n} = geometric mean (when normalized). So M₁ ≥ Mₙ is precisely AM ≥ GM for non-negative reals.",
+    "mathContext": "$M_1 = \\frac{e_1(x)}{\\binom{n}{1}} = \\frac{x_1 + \\cdots + x_n}{n}$ is the arithmetic mean. $M_n = \\left(\\frac{e_n(x)}{\\binom{n}{n}}\\right)^{1/n} = (x_1 \\cdots x_n)^{1/n}$ is the geometric mean. The chain $M_1 \\geq M_2 \\geq \\cdots \\geq M_n$ strictly strengthens AM ≥ GM by providing $n-1$ intermediate means that interpolate between AM and GM.",
+    "significance": "key",
+    "relatedConcepts": ["AM-GM inequality", "arithmetic mean", "geometric mean", "Maclaurin means", "interpolation"],
+    "prerequisites": ["maclaurin_full_chain", "Nat.one_pos", "le_refl"]
+  }
+]

--- a/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03/meta.json
@@ -23,34 +23,90 @@
     ]
   },
   "overview": {
-    "historicalContext": "The Maclaurin inequalities, established by Colin Maclaurin in the 18th century, relate the elementary symmetric means of non-negative reals. They generalize the AM-GM inequality to a full chain of n-1 consecutive inequalities between consecutive symmetric means.",
+    "historicalContext": "Colin Maclaurin (1698–1746) stated the inequality chain $M_1 \\geq M_2 \\geq \\cdots \\geq M_n$ in his 1729 'Treatise of Algebra', building on Newton's 1707 observation (Arithmetica Universalis) that the elementary symmetric polynomials satisfy $e_k^2 \\geq e_{k-1} e_{k+1}$ (log-concavity). The chain interpolates between the arithmetic mean ($M_1$) and geometric mean ($M_n$), giving an n-1 step strengthening of AM ≥ GM. Hardy, Littlewood, and Pólya systematized the Maclaurin inequalities in their landmark book 'Inequalities' (1934), §2.22, establishing the modern proof via the power inequality $a_k^{k+1} \\geq a_{k+1}^k$ where $a_k = e_k/\\binom{n}{k}$. The Lean formalization uses a modular three-tier architecture: the axiomatic step (AmgmInequalityOQ02), the Newton proof of the step (AmgmInequalityOQ02OQ03), and this file assembling the full chain from adjacent steps by induction on the index gap. The induction reduces $O(n^2)$ pairwise comparisons to $O(n)$ adjacent applications of maclaurin_step, matching the classical proof structure.",
     "problemStatement": "Given the Maclaurin means Mₖ = (eₖ(x)/C(n,k))^{1/k} for non-negative reals x₁,...,xₙ, prove the full chain M₁ ≥ M₂ ≥ ... ≥ Mₙ by establishing Mⱼ ≥ Mₖ for all 0 < j ≤ k ≤ n.",
-    "proofStrategy": "The proof proceeds by induction on the gap d = k - j. The base case d = 0 is trivial. The inductive step reduces to a single adjacent inequality Mⱼ₊ₘ ≥ Mⱼ₊ₘ₊₁, which is supplied by the parent's `maclaurin_step` axiom. Transitivity closes the chain.",
+    "proofStrategy": "The proof proceeds by induction on the gap d = k - j. The base case d = 0 is trivial (reflexivity). The inductive step: assume Mⱼ ≥ Mⱼ₊ₘ (IH) and apply maclaurin_step to get Mⱼ₊ₘ ≥ Mⱼ₊ₘ₊₁; transitivity via `calc` closes the goal. The main theorem `maclaurin_full_chain` converts j ≤ k to an explicit gap using `Nat.exists_eq_add_of_le`, then invokes the auxiliary. The AM ≥ GM corollary is a direct specialization to j=1, k=n.",
     "keyInsights": [
-      "The chain inequality reduces to n-1 adjacent steps by induction",
-      "Each adjacent step Mₖ ≥ Mₖ₊₁ is logically independent and supplied axioomatically",
-      "The special case M₁ ≥ Mₙ recovers AM ≥ geometric-power mean as a corollary"
+      "Induction on the gap d = k - j reduces n² pairwise Maclaurin comparisons to n-1 adjacent steps — each step is used exactly once per application of the chain theorem",
+      "`Nat.exists_eq_add_of_le hjk` is the key bridging lemma: it converts `j ≤ k` into `∃ d, k = j + d`, enabling the `obtain ⟨d, rfl⟩` pattern that substitutes k = j+d throughout the goal",
+      "The private/public split is deliberate: `maclaurin_chain_aux` is `private` (an implementation detail) while `maclaurin_full_chain` is the public interface — this is the standard Lean modularity pattern for inductive helpers",
+      "The corollary `maclaurin_m1_ge_mn` recovers AM ≥ GM: $M_1 = \\text{arithmetic mean}$, $M_n = \\text{geometric mean}$, so $M_1 \\geq M_n$ is precisely AM ≥ GM for n non-negative reals",
+      "The file works conditionally on the `maclaurin_step` axiom from AmgmInequalityOQ02 — but the chain proof itself is unconditional given the step; substituting `maclaurin_step_proved` from AmgmInequalityOQ02OQ03 would make the entire chain axiom-free"
     ],
     "prerequisites": [
       "Elementary symmetric polynomials and Maclaurin means",
       "AM-GM inequality",
-      "Newton's inequalities relating consecutive elementary symmetric polynomials"
+      "Newton's inequalities relating consecutive elementary symmetric polynomials",
+      "Lean 4 induction tactics and calc blocks"
     ]
   },
-  "sections": [],
+  "sections": [
+    {
+      "id": "header",
+      "title": "Module Header: Three-Tier Architecture",
+      "startLine": 1,
+      "endLine": 28,
+      "summary": "Documents the three-tier Maclaurin formalization hierarchy: AmgmInequalityOQ02 (axiomatic step), AmgmInequalityOQ02OQ03 (Newton-proved step), and this file (full chain from steps). Lists the three main results: `maclaurin_chain_aux`, `maclaurin_full_chain`, `maclaurin_m1_ge_mn`.",
+      "mathContext": "The chain $M_1 \\geq M_2 \\geq \\cdots \\geq M_n$ is built from $n-1$ applications of the step $M_k \\geq M_{k+1}$. The modular design allows the chain to be verified regardless of how the step is proved."
+    },
+    {
+      "id": "imports",
+      "title": "Imports and Namespace Setup",
+      "startLine": 30,
+      "endLine": 38,
+      "summary": "Imports AmgmInequalityOQ02 (providing `maclaurinMean` and `maclaurin_step`). Opens Finset and Real. Declares implicit variable `{n : ℕ}` for all theorems.",
+      "mathContext": "The import makes `maclaurinMean : ℕ → (Fin n → ℝ) → ℝ` and `maclaurin_step` available. Note: AmgmInequalityOQ02OQ03 is NOT imported — the proved step is not used here, only the axiomatic one."
+    },
+    {
+      "id": "aux-lemma",
+      "title": "maclaurin_chain_aux: Induction on Gap",
+      "startLine": 39,
+      "endLine": 52,
+      "summary": "Private lemma: Mⱼ ≥ Mⱼ₊ₐ for arbitrary gap d, proved by induction on d. Base case: reflexivity. Inductive case: apply IH then maclaurin_step, close by calc transitivity.",
+      "mathContext": "$M_j \\geq M_{j+d}$ by induction: base $M_j \\geq M_j$ trivial; step uses IH $M_j \\geq M_{j+m}$ and maclaurin_step $M_{j+m} \\geq M_{j+m+1}$, combined by transitivity."
+    },
+    {
+      "id": "main-theorem",
+      "title": "maclaurin_full_chain: Full Chain Theorem",
+      "startLine": 54,
+      "endLine": 59,
+      "summary": "Main exported theorem: for 0 < j ≤ k ≤ n, Mⱼ ≥ Mₖ. Uses Nat.exists_eq_add_of_le to extract the gap d from j ≤ k, then delegates to maclaurin_chain_aux.",
+      "mathContext": "`Nat.exists_eq_add_of_le hjk` gives `d` with `k = j + d`. The `obtain ⟨d, rfl⟩` pattern rewrites k everywhere. The omega call closes `j + d ≤ n` from `hkn`."
+    },
+    {
+      "id": "corollary",
+      "title": "maclaurin_m1_ge_mn: AM ≥ GM Corollary",
+      "startLine": 61,
+      "endLine": 64,
+      "summary": "Specializes maclaurin_full_chain to j=1, k=n. One-liner proof: three library lemmas (Nat.one_pos, hn, le_refl). This recovers AM ≥ GM for non-negative reals.",
+      "mathContext": "$M_1 = \\frac{1}{n}\\sum x_i$ (arithmetic mean), $M_n = (\\prod x_i)^{1/n}$ (geometric mean). So $M_1 \\geq M_n$ is AM ≥ GM. The Maclaurin chain gives $n-1$ intermediate means between them."
+    }
+  ],
   "conclusion": {
-    "summary": "The full Maclaurin chain M₁ ≥ M₂ ≥ ... ≥ Mₙ is proved in Lean 4 by induction on the index gap, assuming one axiomatic step. The proof is conditionally complete: replacing the axiom with the proved Newton log-concavity step yields a fully verified chain.",
-    "implications": "This completes the Maclaurin inequality hierarchy in the gallery. Combined with the parent entries, it provides a three-tier formalization: the axiomatic step, the Newton proof of the step, and the full chain derived from either.",
+    "summary": "The full Maclaurin chain M₁ ≥ M₂ ≥ ... ≥ Mₙ is proved in Lean 4 by induction on the index gap, using the axiomatic `maclaurin_step` from AmgmInequalityOQ02. The proof is conditionally complete: replacing the axiom with `maclaurin_step_proved` from AmgmInequalityOQ02OQ03 yields a fully verified chain with 0 axioms.",
+    "implications": "This completes the Maclaurin inequality hierarchy in the gallery. The three-tier design (axiomatic step → Newton proof of step → full chain) demonstrates a modular proof architecture: each tier is independently useful, and the chain works with either source of the step. The corollary M₁ ≥ Mₙ gives AM ≥ GM as a special case, showing that the Maclaurin inequalities strictly subsume the classical AM-GM inequality.",
     "openQuestions": [
-      "Can `maclaurin_step` be proved from Mathlib's existing symmetric function library without the Newton log-concavity route?",
-      "Extension to complex or abstract ordered fields?"
+      "Can `maclaurin_step` be proved from Mathlib's existing symmetric function library (e.g., `Mathlib.RingTheory.MvPolynomial.NewtonIdentities`) without the Newton log-concavity route?",
+      "The chain theorem `maclaurin_full_chain` is stated for non-negative reals. Does it extend to `NNReal` or `ENNReal` with suitable Maclaurin mean definitions?",
+      "Can the Maclaurin chain be generalized to power means (L^p norms), giving the power mean inequality M_p ≥ M_q for p ≤ q?",
+      "Is there a proof using convexity/Schur-convexity that would be shorter than the Newton log-concavity induction?"
     ]
   },
   "crossReferences": [
     {
-      "slug": "amgm-inequality-oq-02-oq-03",
-      "title": "Maclaurin Step via Newton Log-Concavity",
-      "relationship": "extends"
+      "targetId": "amgm-inequality-oq-02-oq-03",
+      "relationship": "extends",
+      "description": "Parent formalization providing maclaurin_step_proved via Newton log-concavity; substituting it for the axiom makes this chain fully verified"
+    },
+    {
+      "targetId": "amgm-inequality-oq-02",
+      "relationship": "derives-from",
+      "description": "Grandparent formalization providing the axiomatic maclaurin_step and maclaurinMean definition used by this chain proof"
+    },
+    {
+      "targetId": "amgm-inequality",
+      "relationship": "related",
+      "description": "Base AM-GM inequality; the corollary maclaurin_m1_ge_mn recovers AM ≥ GM as the special case j=1, k=n of the Maclaurin chain"
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Summary

- Added 5 annotations to empty `annotations.json`: context overview (three-tier hierarchy), imports/setup, inductive auxiliary lemma, main chain theorem, AM≥GM corollary
- Added complete 5-section `sections` array to `meta.json` (was empty)
- Expanded `historicalContext` from ~100 to ~800 chars (Maclaurin 1729, Newton 1707, Hardy-Littlewood-Pólya 1934)
- Added 2 more `keyInsights` (3→5): `Nat.exists_eq_add_of_le` bridge pattern, private/public split rationale
- Expanded `openQuestions` from 2 to 4 (Mathlib symmetric functions, NNReal extension, power mean generalization)
- Fixed `crossReferences`: `slug` → `targetId`, added parent (oq-02) and grandparent (amgm-inequality) references

## Test plan
- [x] `pnpm run annotations:build` — no errors for this target
- [x] All annotation ranges within file bounds (67 lines)
- [x] Annotation types compatible with Lean constructs at specified lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)