### PR TITLE
fix(audit): correct badge and axiomCount for cantor-diagonalization-oq-03-oq-01-oq-03

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-03/meta.json
@@ -16,11 +16,11 @@
       "provability-logic",
       "abstract-logic"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-04",
-    "axiomCount": 7,
-    "assumptions": "GodelModel axiomatizes the essentials of a Peano-strength formal system as structure fields: point-surjective evaluation (diagonal lemma), formal negation, consistency, reflection principle, and D1 axiom of provability logic. StrongGodelModel additionally axiomatizes double-negation elimination for the strong incompleteness result. These are mathematical hypotheses, not global Lean axioms.",
+    "axiomCount": 5,
+    "assumptions": "GodelModel axiomatizes the essentials of a Peano-strength formal system as structure fields: point-surjective evaluation (diagonal lemma / h_diag), consistency (h_consistent), reflection principle (h_reflection), and D1 axiom of provability logic (h_D1) — 4 Prop-typed assumptions. StrongGodelModel additionally axiomatizes double-negation elimination (h_dne) — 1 more. Total: 5 structure-encoded mathematical assumptions. These are hypotheses, not global Lean axioms.",
     "lineCount": 256,
     "theoremCount": 6,
     "definitionCount": 5,
@@ -62,7 +62,7 @@
   "leanFile": {
     "namespace": "CantorDiagonalizationOQ03OQ01OQ03",
     "lineCount": 256,
-    "axiomCount": 7,
+    "axiomCount": 5,
     "theoremCount": 6,
     "definitionCount": 5
   }


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: `cantor-diagonalization-oq-03-oq-01-oq-03`

### Issues Found

**1. Badge mismatch (MEDIUM)**
- meta.json claims `"badge": "original"`
- But `"status": "axiomatized"` — proof depends on 5 structure-encoded assumptions
- Per gallery rules: axiomatized proofs must use `"badge": "axiom"`

**2. Axiom count overcounted (LOW)**
- meta.json claimed `"axiomCount": 7`
- Actual Prop-typed structure fields: 5
  - `GodelModel`: h_diag, h_consistent, h_reflection, h_D1 (4 assumptions)
  - `StrongGodelModel`: h_dne (1 more)
- The count of 7 incorrectly included uninterpreted functions `Neg` and `PrSent`, which are model components, not axioms

### Fix Applied
- `"badge": "original"` → `"badge": "axiom"`
- `"axiomCount": 7` → `"axiomCount": 5` (both in `meta` and `leanFile` sections)
- Updated `assumptions` description to enumerate the 5 Prop-typed fields explicitly

---
Discovered during gallery integrity audit (cycle 47).