### PR TITLE
fix(audit): correct leanFile.axiomCount for 3 proofs + cantor badge

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03/meta.json
@@ -112,7 +112,7 @@
   "leanFile": {
     "namespace": "AmgmInequalityOQ02OQ03OQ03",
     "lineCount": 67,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 2,
     "definitionCount": 0
   }

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11653,6 +11653,18 @@
       "lastAudited": "2026-04-04T21:33:08Z",
       "result": "clean",
       "issues": []
+    },
+    "derangements-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:51Z",
+      "result": "clean",
+      "issues": []
+    },
+    "shannon-entropy-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:51Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11461,6 +11461,198 @@
       "lastAudited": "2026-04-04T21:30:40Z",
       "result": "issues-fixed",
       "issues": []
+    },
+    "algebraic-numbers-countable": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "angle-trisection-cos-20-gal": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "angle-trisection-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "arithmetic-series-oq-02-oq-04-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bezout-identity-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "birthday-problem-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bounded-prime-gaps-oq-03-oq-01-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-integral-oq-02-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-oq-04-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cevas-theorem-non-euclidean": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "chebyshev-bounds": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "collatz-cycles": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "derangements-convergence": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "derangements-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "divisibility-by-three-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "divisibility-by-three-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "divisibility-rules": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "divisibility-rules-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-249-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "feuerbachs-theorem-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "harmonic-divergence-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "kummer-theorem-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lagrange-four-squares-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lagrange-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lovasz-local-lemma": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "minkowski-fundamental-theorem": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "prob-method-second-moment-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "product-of-segments-of-chords-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "spherical-law-of-cosines": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sylow-theorem": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sylow-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sylow-theorem-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:33:08Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11449,6 +11449,18 @@
       "lastAudited": "2026-04-04T20:26:25Z",
       "result": "clean",
       "issues": []
+    },
+    "amgm-inequality-oq-02-oq-03-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:30:40Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "e-transcendental-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-04T21:30:40Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-03/meta.json
@@ -16,11 +16,11 @@
       "provability-logic",
       "abstract-logic"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-04",
-    "axiomCount": 7,
-    "assumptions": "GodelModel axiomatizes the essentials of a Peano-strength formal system as structure fields: point-surjective evaluation (diagonal lemma), formal negation, consistency, reflection principle, and D1 axiom of provability logic. StrongGodelModel additionally axiomatizes double-negation elimination for the strong incompleteness result. These are mathematical hypotheses, not global Lean axioms.",
+    "axiomCount": 5,
+    "assumptions": "GodelModel axiomatizes the essentials of a Peano-strength formal system as structure fields: point-surjective evaluation (diagonal lemma / h_diag), consistency (h_consistent), reflection principle (h_reflection), and D1 axiom of provability logic (h_D1) — 4 Prop-typed assumptions. StrongGodelModel additionally axiomatizes double-negation elimination (h_dne) — 1 more. Total: 5 structure-encoded mathematical assumptions. These are hypotheses, not global Lean axioms.",
     "lineCount": 256,
     "theoremCount": 6,
     "definitionCount": 5,
@@ -62,7 +62,7 @@
   "leanFile": {
     "namespace": "CantorDiagonalizationOQ03OQ01OQ03",
     "lineCount": 256,
-    "axiomCount": 7,
+    "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 5
   }

--- a/src/data/proofs/e-transcendental-oq-01-oq-01/meta.json
+++ b/src/data/proofs/e-transcendental-oq-01-oq-01/meta.json
@@ -63,7 +63,7 @@
   "leanFile": {
     "namespace": "Real (open)",
     "lineCount": 341,
-    "axiomCount": 2,
+    "axiomCount": 1,
     "theoremCount": 9,
     "definitionCount": 0
   }


### PR DESCRIPTION
## Gallery Integrity Fixes (Cycle 48)

This PR corrects `leanFile.axiomCount` values and fixes a badge inconsistency found during gallery auditing.

### Key Finding

`leanFile.axiomCount` must count only `^axiom` declarations **in the file itself** — not axioms inherited via imports or encoded in structure fields. The `meta.axiomCount` field (top-level) accounts for ALL assumptions (declared + inherited + structure-encoded).

The `find-targets.ts` auditor script uses `leanFile.axiomCount` for comparison against detected `^axiom` declarations, so overcounts here generate false-positive audit flags.

### Fixes

| Proof | Field | Before | After | Reason |
|-------|-------|--------|-------|--------|
| `amgm-inequality-oq-02-oq-03-oq-03` | `leanFile.axiomCount` | 1 | 0 | `maclaurin_step` axiom is in `AmgmInequalityOQ02` (imported), not declared here |
| `e-transcendental-oq-01-oq-01` | `leanFile.axiomCount` | 2 | 1 | `nesterenko_algebraic_independence` is in parent file; only `schanuel_for_e_pi` declared here |
| `cantor-diagonalization-oq-03-oq-01-oq-03` | `leanFile.axiomCount` | 7 | 0 | No `^axiom` declarations; all 5 assumptions are `GodelModel`/`StrongGodelModel` structure fields |
| `cantor-diagonalization-oq-03-oq-01-oq-03` | `meta.axiomCount` | 7 | 5 | Correctly counts 5 Prop-typed structure fields; previous count of 7 included uninterpreted functions `Neg`/`PrSent` |
| `cantor-diagonalization-oq-03-oq-01-oq-03` | `badge` | `original` | `axiom` | Status is `axiomatized` — badge must be `axiom` per gallery rules |

Note: supersedes PR #9505 (which only fixed cantor badge/axiomCount partially).

---
Discovered during gallery integrity audit cycle 48.