### PR TITLE
Fix: update stale assumptions fields referencing removed True stubs

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
@@ -44,7 +44,8 @@
     ],
     "originalContributions": [
       "ballot_discrete_ivt: for {+1,-k}-lists, if prefix sum v is achieved and the final sum exceeds v, then some strict prefix also achieves v (proved via Finset.max' of the set of positions with prefix sum ≤ v)",
-      "Detailed proof sketches in docstrings for the cycle lemma lower bound and rightmost-is-good arguments (not yet formalized — the corresponding theorem declarations are trivial placeholders)"
+      "cycle_lemma_lower_bound_via_ivt: lower bound |goodRotations| ≥ a - k*b proved via goodRotations_card_ge",
+      "rightmost_is_good_rotation: rightmost position at each prefix sum level is a good rotation, proved via rightmostAtLevel_good"
     ],
     "dateAdded": "2026-02-23",
     "prerequisites": [
@@ -66,7 +67,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 151,
-    "assumptions": "0 axioms, 0 sorries. 2 trivial placeholder theorems (1+1=2) remain for cycle_lemma_lower_bound_via_ivt and rightmost_is_good_sketch.",
+    "assumptions": "0 axioms, 0 sorries. All theorems fully proved: ballot_discrete_ivt (via Finset.max' argument), cycle_lemma_lower_bound_via_ivt (via goodRotations_card_ge), and rightmost_is_good_rotation (via rightmostAtLevel_good). No placeholders remain.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/lebesgue-measure-oq-03/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-03/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Gross (1967), Wiener",
     "date": "2026",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/LebesgueMeasureOQ03.lean",
     "tags": [
       "measure-theory",
@@ -18,7 +18,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 132,
-    "assumptions": "0 axioms, 0 sorries. 2 True-stub placeholder theorems: ball_volume_vanishes (line 103) and concentration_sketch (line 112, both prove True := trivial). Orthonormal separation and framework theorems fully proved.",
+    "assumptions": "0 axioms, 0 sorries. Orthonormal separation lemmas fully proved (orthonormal_dist, orthonormal_balls_disjoint). Impossibility proof sketch, Gaussian existence, and Wiener construction remain as comments pending future formalization. Classified axiomatized per CLAUDE.md policy: main research question (infinite-dimensional Lebesgue generalization) is open.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "originalContributions": [

--- a/src/data/proofs/pac-learning-bounds/meta.json
+++ b/src/data/proofs/pac-learning-bounds/meta.json
@@ -7,7 +7,7 @@
     "author": "Vapnik-Chervonenkis (1971), Valiant (1984), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Vapnik%E2%80%93Chervonenkis_dimension",
     "date": "1984",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/PACLearning.lean",
     "tags": [
       "learning-theory",
@@ -40,7 +40,7 @@
       "sauer_shelah_bound: \u2211 C(n,i) \u2264 (n+1)^d via binomial theorem",
       "pac_sample_complexity: sample size bound statement (trivial existence witness)",
       "NOTE: growthFunction is a placeholder (returns 0), making sauer_shelah trivially true",
-      "NOTE: fundamental_theorem_stat_learning is a True stub placeholder"
+      "NOTE: fundamental_theorem_stat_learning is a block comment placeholder (removed as True stub)"
     ],
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
@@ -52,7 +52,7 @@
       "Concentration inequalities (Hoeffding, Chernoff)",
       "Uniform convergence and generalization bounds"
     ],
-    "assumptions": "growthFunction defined as constant 0 (stub). fundamental_theorem_stat_learning is an explicit True placeholder. sauer_shelah_bound and pac_sample_complexity contain real proofs.",
+    "assumptions": "0 axioms, 0 sorries. growthFunction defined as placeholder (constant 0); sauer_shelah proves trivially. sauer_shelah_bound and pac_sample_complexity fully proved. Fundamental theorem of statistical learning (PAC learnable ↔ finite VC dimension) remains in a block comment pending full formalization. Classified axiomatized: main equivalence not yet formalized.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/prob-method-applications/meta.json
+++ b/src/data/proofs/prob-method-applications/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdos and collaborators, formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Probabilistic_method",
     "date": "1947",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ProbMethodApplications.lean",
     "tags": [
       "probabilistic-method",
@@ -76,7 +76,7 @@
       }
     ],
     "lineCount": 51,
-    "assumptions": "high_girth_high_chromatic is a True stub (Erdos 1959 probabilistic existence not formalized). Other theorems prove trivial lower bounds rather than full probabilistic existence results.",
+    "assumptions": "0 axioms, 0 sorries. Five theorems proved with trivial or near-trivial proofs (existential witnesses, positivity). High-girth-high-chromatic existence result (Erdős 1959) remains as a comment pending probabilistic graph formalization. Classified axiomatized: main probabilistic existence results are not yet formalized.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Fix

Four `meta.json` files had stale `assumptions` fields referencing True-stub placeholder theorems that were converted to block comments in commit `1d8e1b94ec` (PR #9397: "Fix: convert True-stub theorems to comments in 6 more proofs").

## Evidence

**lebesgue-measure-oq-03**: `status: formalized` → `axiomatized`; `assumptions` removed references to `ball_volume_vanishes` and `concentration_sketch` (both removed as True stubs).

**prob-method-applications**: `status: formalized` → `axiomatized`; `assumptions` removed reference to `high_girth_high_chromatic` True stub (now a block comment).

**pac-learning-bounds**: `status: formalized` → `axiomatized`; `assumptions` updated to reflect `fundamental_theorem_stat_learning` is a block comment, not a True stub.

**ballot-problem-oq-01-oq-01**: `status: verified` (unchanged); `assumptions` updated to reflect that `cycle_lemma_lower_bound_via_ivt` and `rightmost_is_good_rotation` now have real proofs (no longer trivial placeholders); `originalContributions` updated accordingly.

The `formalized → axiomatized` reclassifications follow CLAUDE.md policy: when the main research question is open (infinite-dimensional Lebesgue generalization, probabilistic existence results, PAC learning equivalence), the entry is `axiomatized` not `formalized`.

---
Automated fix by lean-mechanic agent.