### PR TITLE
Enrich prob-method-second-moment-oq-01: add sections, crossRefs, 4 annotations

### DIFF
--- a/src/data/proofs/prob-method-second-moment-oq-01/annotations.json
+++ b/src/data/proofs/prob-method-second-moment-oq-01/annotations.json
@@ -1,1 +1,50 @@
-[]
+[
+  {
+    "id": "ann-pz-cauchy-schwarz",
+    "proofId": "prob-method-second-moment-oq-01",
+    "range": { "startLine": 37, "endLine": 52 },
+    "type": "insight",
+    "title": "Private Cauchy-Schwarz: (∑f)² ≤ |s|·∑f²",
+    "content": "The private lemma `sq_sum_le` proves $(\\sum_{a \\in s} f(a))^2 \\leq |s| \\cdot \\sum_{a \\in s} f(a)^2$ by induction on the Finset. The inductive step on `insert a s` uses the non-negativity of $\\sum_b (f(a) - f(b))^2$, expanded via `sub_sq` and `Finset.mul_sum`, closing with `nlinarith` after `push_cast`. This is the 'sum of squares' proof: $(n+1)\\sum f_i^2 - (\\sum f_i)^2 = \\sum_{i < j}(f_i - f_j)^2 \\geq 0$. The `private` qualifier keeps the namespace clean — the parent already exports a similar lemma.",
+    "mathContext": "$(\\sum_{i=1}^n a_i)^2 \\leq n \\cdot \\sum_{i=1}^n a_i^2$ — Cauchy-Schwarz with constant second vector: $\\langle f, \\mathbf{1} \\rangle^2 \\leq \\|f\\|^2 \\cdot \\|\\mathbf{1}\\|^2 = (\\sum f_i^2) \\cdot n$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Cauchy-Schwarz", "Finset.induction_on", "sq_nonneg", "nlinarith", "sub_sq"],
+    "prerequisites": ["Finset.sum_insert", "Finset.sum_nonneg", "Nat.cast"]
+  },
+  {
+    "id": "ann-pz-main-theorem",
+    "proofId": "prob-method-second-moment-oq-01",
+    "range": { "startLine": 62, "endLine": 119 },
+    "type": "theorem",
+    "title": "Paley-Zygmund Quantitative: (1-θ)²·(∑f)² ≤ |above|·∑f²",
+    "content": "The main theorem proves $(1-\\theta)^2 (\\sum f)^2 \\leq |\\text{above}| \\cdot \\sum f^2$ where `above = {a ∈ s : f(a) > θ·μ}`. The 6-step proof: (1) decompose $\\sum_s f = \\sum_{\\text{above}} f + \\sum_{\\text{below}} f$ via `Finset.sum_filter_add_sum_filter_not`; (2) bound $\\sum_{\\text{below}} f \\leq \\theta \\cdot \\sum_s f$ since each below element has $f(a) \\leq \\theta\\mu$; (3) derive $\\sum_{\\text{above}} f \\geq (1-\\theta)\\sum_s f$ by subtraction; (4) apply `sq_sum_le` to `above`: $(\\sum_{\\text{above}} f)^2 \\leq |\\text{above}| \\cdot \\sum_{\\text{above}} f^2$; (5) extend to full set by filter-subset monotonicity; (6) combine with `sq_le_sq'` to close.",
+    "mathContext": "$(1-\\theta)^2 (\\sum f)^2 \\leq (\\sum_{\\text{above}} f)^2 \\leq |\\text{above}| \\cdot \\sum_{\\text{above}} f^2 \\leq |\\text{above}| \\cdot \\sum_s f^2$. Classically: $P[X > \\theta E[X]] \\geq (1-\\theta)^2 E[X]^2/E[X^2]$.",
+    "significance": "key",
+    "relatedConcepts": ["Paley-Zygmund inequality", "second moment method", "sq_sum_le", "Finset.sum_filter_add_sum_filter_not", "sq_le_sq'"],
+    "prerequisites": ["sq_sum_le", "Finset.sum_le_sum", "mul_le_mul_of_nonneg_left"]
+  },
+  {
+    "id": "ann-pz-probability-form",
+    "proofId": "prob-method-second-moment-oq-01",
+    "range": { "startLine": 124, "endLine": 131 },
+    "type": "theorem",
+    "title": "Probability Form: |above|/|s| ≥ (1-θ)²·(mean)²/E[f²]",
+    "content": "`paley_zygmund_probability` divides the counting form by $\\sum f^2$: $(1-\\theta)^2 (\\sum f)^2 / \\sum f^2 \\leq |\\text{above}|$. The proof uses `div_le_iff hf2_pos` to convert division to multiplication, then applies `paley_zygmund_quantitative`. The hypothesis `hf2_pos : 0 < ∑f²` is needed for safe division. This is the classical 'probability form' matching $P[X > \\theta E[X]] \\geq (1-\\theta)^2 E[X]^2/E[X^2]$.",
+    "mathContext": "Dividing both sides by $\\sum f^2$: $|\\text{above}| \\geq (1-\\theta)^2 (\\sum f)^2 / \\sum f^2$. Normalizing by $|s|^2$: $|\\text{above}|/|s| \\geq (1-\\theta)^2 E[f]^2 / E[f^2]$.",
+    "significance": "supporting",
+    "relatedConcepts": ["div_le_iff", "paley_zygmund_quantitative", "probability form", "Paley-Zygmund"],
+    "prerequisites": ["paley_zygmund_quantitative", "div_le_iff"]
+  },
+  {
+    "id": "ann-pz-at-zero",
+    "proofId": "prob-method-second-moment-oq-01",
+    "range": { "startLine": 135, "endLine": 146 },
+    "type": "insight",
+    "title": "θ=0 Special Case: Recovers Qualitative Second Moment Method",
+    "content": "`paley_zygmund_at_zero` sets $\\theta = 0$, recovering $(\\sum f)^2 \\leq |\\{f > 0\\}| \\cdot \\sum f^2$. The proof applies `paley_zygmund_quantitative` with `θ = 0`, then `simp` reduces $(1-0)^2 = 1$ and $0 \\cdot \\mu = 0$. The `convert` tactic handles the filter predicate change from `0·μ < f a` to `0 < f a`. This shows that the quantitative Paley-Zygmund subsumes the qualitative second moment: $|\\text{supp}(f)| \\geq (\\sum f)^2 / \\sum f^2$, i.e., $P[X>0] \\geq E[X]^2/E[X^2]$.",
+    "mathContext": "$P[X > 0] \\geq E[X]^2/E[X^2]$ (second moment lower bound on support). Implies $P[X > 0] > 0$ when $E[X] > 0$. Tightness: equality iff $X$ is essentially constant on its support.",
+    "significance": "key",
+    "relatedConcepts": ["second moment method", "paley_zygmund_quantitative", "convert tactic", "support lower bound"],
+    "prerequisites": ["paley_zygmund_quantitative", "qualitative second moment method"]
+  }
+]

--- a/src/data/proofs/prob-method-second-moment-oq-01/meta.json
+++ b/src/data/proofs/prob-method-second-moment-oq-01/meta.json
@@ -16,45 +16,115 @@
     "lineCount": 147,
     "theoremCount": 3,
     "definitionCount": 0,
-    "assumptions": "None.",
+    "assumptions": "None. 0 axioms, 0 sorries. Fully verified in Lean 4 with Mathlib.",
     "originalContributions": [
-      "Quantitative Paley-Zygmund inequality over finite sets (counting form)",
-      "Probability form: explicit lower bound on fraction of elements exceeding θ·mean",
-      "Recovery of qualitative second moment method as the θ=0 special case"
-    ]
+      "paley_zygmund_quantitative: (1-θ)²·(∑f)² ≤ |{a : f(a) > θ·mean}| · ∑f² (counting form)",
+      "paley_zygmund_probability: (1-θ)²·(∑f)²/∑f² ≤ |above| (probability form)",
+      "paley_zygmund_at_zero: θ=0 recovers the qualitative second moment method"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_filter_add_sum_filter_not",
+        "description": "Decompose a sum over a Finset into above-threshold and below-threshold parts",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Finset.sum_le_sum_of_subset_of_nonneg",
+        "description": "Sum over a subset is ≤ sum over the full set when the function is non-negative",
+        "module": "Mathlib.Algebra.BigOperators.Order"
+      },
+      {
+        "theorem": "sq_le_sq'",
+        "description": "If -b ≤ a ≤ b then a² ≤ b² — used to square the above-sum lower bound",
+        "module": "Mathlib.Algebra.Order.Ring.Lemmas"
+      }
+    ],
+    "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The Paley-Zygmund inequality (1932) provides a quantitative lower bound on the probability that a non-negative random variable exceeds a fraction θ of its mean. It strengthens the qualitative second moment method (which only says P[X > 0] > 0) by giving an explicit probability bound involving the ratio E[X]²/E[X²]. This is a fundamental tool in probabilistic combinatorics (see Alon-Spencer, 'The Probabilistic Method', Chapter 4).",
-    "problemStatement": "For non-negative f on a finite set s with positive sum, and threshold 0 ≤ θ < 1, prove: (1-θ)²·(∑f)² ≤ |{a ∈ s : f(a) > θ·mean}| · ∑f². This is the finite/discrete version of P[X > θ·E[X]] ≥ (1-θ)²·E[X]²/E[X²].",
-    "proofStrategy": "Decompose s into 'above' (elements exceeding θ·mean) and 'below'. Bound the below-sum by θ·(∑f), giving above-sum ≥ (1-θ)·(∑f). Apply Cauchy-Schwarz to the above set: (∑_{above} f)² ≤ |above|·∑_{above} f². Extend to ∑_s f² by monotonicity. Combine the above-sum lower bound with Cauchy-Schwarz.",
+    "historicalContext": "The Paley-Zygmund inequality was proved by Raymond Paley and Antoni Zygmund in 1932 in their study of lacunary trigonometric series. It provides a quantitative lower bound on the probability that a non-negative random variable $X$ exceeds a fraction $\\theta$ of its mean: $P[X > \\theta E[X]] \\geq (1-\\theta)^2 E[X]^2/E[X^2]$. This strengthens the qualitative second moment method (which gives only $P[X > 0] > 0$ when $E[X] > 0$) by providing an explicit probability bound. The inequality is a fundamental tool in probabilistic combinatorics: it appears in proofs of lower bounds for Ramsey numbers, clique numbers in random graphs, and the independence number. The formalization uses the finite discrete setting (Finset over ℚ) consistent with the parent second-moment entry, making the proof elementary and avoiding measure theory.",
+    "problemStatement": "For non-negative $f$ on a Finset $s$ with positive sum, and threshold $0 \\leq \\theta < 1$, prove the quantitative Paley-Zygmund inequality: $(1-\\theta)^2 \\cdot (\\sum_s f)^2 \\leq |\\{a \\in s : f(a) > \\theta \\cdot \\mu\\}| \\cdot \\sum_s f^2$, where $\\mu = (\\sum f)/|s|$ is the mean.",
+    "text": "Proves the quantitative Paley-Zygmund inequality over finite sets, extending the second moment method with an explicit threshold. The proof is elementary: above/below decomposition, Cauchy-Schwarz, and monotonicity.",
+    "proofStrategy": "Decompose $s$ into `above` (elements exceeding $\\theta \\cdot \\mu$) and `below`. The below sum is bounded by $\\theta \\cdot \\sum f$ (each term $\\leq \\theta\\mu$, and there are at most $|s|$ terms). This gives $\\sum_{\\text{above}} f \\geq (1-\\theta) \\sum f$. Apply Cauchy-Schwarz `sq_sum_le` to the above set: $(\\sum_{\\text{above}} f)^2 \\leq |\\text{above}| \\cdot \\sum_{\\text{above}} f^2 \\leq |\\text{above}| \\cdot \\sum_s f^2$. Combine via `sq_le_sq'`.",
     "keyInsights": [
-      "The above/below decomposition reduces the problem to bounding the below-sum by θ times the total",
-      "Cauchy-Schwarz on the above set provides the bridge between the first and second moments",
-      "The θ=0 case recovers the standard qualitative second moment: P[X>0]·E[X²] ≥ E[X]²"
+      "**Above/below decomposition**: Splitting $s$ by the threshold $\\theta\\mu$ converts the 'fraction exceeding threshold' into a counting problem. The below sum bounds the above sum from below: $\\sum_{\\text{below}} f \\leq \\theta \\cdot |s| \\cdot \\mu = \\theta \\cdot \\sum f$, so $\\sum_{\\text{above}} f \\geq (1-\\theta) \\sum f$.",
+      "**Cauchy-Schwarz bridges first and second moments**: The private `sq_sum_le` lemma converts $\\sum_{\\text{above}} f \\geq (1-\\theta)\\sum f$ (first moment bound) into $(1-\\theta)^2 (\\sum f)^2 \\leq |\\text{above}| \\cdot \\sum f^2$ (first-second moment relationship). This is the core of the second moment method.",
+      "**θ=0 recovers the qualitative method**: Setting $\\theta = 0$ gives $|\\{f > 0\\}| \\geq (\\sum f)^2 / \\sum f^2$, which implies $|\\{f > 0\\}| > 0$ when $\\sum f > 0$. This is the qualitative second moment principle, recovered as a special case.",
+      "**Finite discrete setting avoids measure theory**: By working over ℚ-valued functions on Finsets, all inequalities reduce to elementary algebra over ℚ. The `hpos : 0 < ∑f` and `hnn : ∀ a, 0 ≤ f a` hypotheses replace σ-algebra measurability. This makes the proof accessible without MeasureTheory.Lp.",
+      "**Three formulations for different uses**: The counting form (`paley_zygmund_quantitative`) is best for combinatorial applications. The probability form (`paley_zygmund_probability`) matches the classical statement. The θ=0 form connects to the parent. Together they cover the main uses of Paley-Zygmund in the probabilistic method."
     ],
     "prerequisites": [
-      "Cauchy-Schwarz inequality for finite sums",
-      "Basic combinatorics of Finset in Mathlib",
-      "Second moment method (parent entry)"
+      "Cauchy-Schwarz inequality for finite sums (sq_sum_le)",
+      "Finset sum decomposition (Finset.sum_filter_add_sum_filter_not)",
+      "Second moment method (parent entry: ProbMethodSecondMoment)"
     ]
   },
-  "sections": [],
+  "sections": [
+    {
+      "id": "cauchy-schwarz",
+      "title": "Private Cauchy-Schwarz Lemma",
+      "startLine": 36,
+      "endLine": 52,
+      "summary": "Private lemma sq_sum_le: (∑f)² ≤ |s|·∑f². Proved by Finset induction using non-negativity of ∑(f(a)-f(b))². Used in Step 4 of the main proof.",
+      "mathContext": "$(\\sum f_i)^2 \\leq n \\cdot \\sum f_i^2$ — equivalent to $\\sum_{i<j}(f_i-f_j)^2 \\geq 0$."
+    },
+    {
+      "id": "main-paley-zygmund",
+      "title": "Main Paley-Zygmund Inequality (Counting Form)",
+      "startLine": 54,
+      "endLine": 119,
+      "summary": "paley_zygmund_quantitative: 6-step proof via above/below decomposition, below-sum bound, Cauchy-Schwarz on above, filter-subset monotonicity, and sq_le_sq' to close.",
+      "mathContext": "$(1-\\theta)^2(\\sum f)^2 \\leq |\\text{above}| \\cdot \\sum f^2$ where above = {f > θμ}."
+    },
+    {
+      "id": "corollaries",
+      "title": "Corollaries: Probability Form and θ=0 Recovery",
+      "startLine": 121,
+      "endLine": 146,
+      "summary": "paley_zygmund_probability: divides by ∑f² to give the ratio form. paley_zygmund_at_zero: θ=0 recovers (∑f)² ≤ |{f>0}|·∑f², the qualitative second moment.",
+      "mathContext": "Probability form: $P[X > \\theta E[X]] \\geq (1-\\theta)^2 E[X]^2/E[X^2]$. At $\\theta=0$: $P[X>0] \\geq E[X]^2/E[X^2]$."
+    }
+  ],
   "conclusion": {
-    "summary": "A complete Lean 4 formalization of the quantitative Paley-Zygmund inequality over finite sets, with 3 theorems and 0 axioms. The proof is fully elementary, using only Cauchy-Schwarz and sum decomposition.",
-    "implications": "Provides the quantitative backbone for the second moment method in the gallery. Applications include proving lower bounds on clique numbers, independent sets, and other combinatorial quantities where the second moment method applies.",
+    "summary": "A complete Lean 4 formalization of the quantitative Paley-Zygmund inequality over finite sets, with 3 theorems and 0 axioms. The proof is elementary: above/below decomposition, Cauchy-Schwarz on the above set, and filter-subset monotonicity.",
+    "implications": "Provides the quantitative backbone for the second moment method in the gallery. Applications include lower bounds on clique numbers in random graphs, independent sets, and Ramsey numbers. The three-formulation design covers combinatorial (counting), probabilistic (ratio), and qualitative uses.",
     "openQuestions": [
-      "Can this be generalized to a measure-theoretic setting (MeasureTheory.Lp)?",
-      "What is the tight threshold θ for specific combinatorial applications like Ramsey or random graph cliques?"
+      "Can this be generalized to the measure-theoretic MeasureTheory.Lp setting?",
+      "What is the tight threshold θ for Ramsey or random graph clique applications?",
+      "Can the Paley-Zygmund inequality be added to Mathlib?"
     ]
   },
   "crossReferences": [
     {
-      "slug": "prob-method-second-moment",
-      "title": "Probabilistic Method: Second Moment",
-      "relationship": "extends"
+      "targetId": "prob-method-second-moment",
+      "relationship": "extends",
+      "description": "Parent proof of the qualitative second moment method — this file adds the quantitative Paley-Zygmund threshold, recovering the qualitative result at θ=0."
+    },
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "related",
+      "description": "Cauchy-Schwarz inequality is the key bridge in the proof — applied to the above-threshold subset to convert the first-moment bound into the second-moment bound."
+    }
+  ],
+  "references": [
+    {
+      "authors": ["Paley, R.E.A.C.", "Zygmund, A."],
+      "title": "On some series of functions",
+      "year": "1932",
+      "venue": "Proceedings of the Cambridge Philosophical Society 26, pp. 337-357",
+      "note": "Original Paley-Zygmund inequality proved in the context of lacunary trigonometric series"
+    },
+    {
+      "authors": ["Alon, N.", "Spencer, J.H."],
+      "title": "The Probabilistic Method",
+      "year": "2016",
+      "venue": "Wiley, 4th edition",
+      "note": "Chapter 4: Second moment method and Paley-Zygmund inequality with combinatorial applications"
     }
   ],
   "leanFile": {
+    "imports": ["Mathlib", "Proofs.ProbMethodSecondMoment"],
+    "opens": [],
     "namespace": "ProbMethod.SecondMoment",
     "lineCount": 147,
     "axiomCount": 0,


### PR DESCRIPTION
## Summary
- Added 3 sections: `cauchy-schwarz` (36–52), `main-paley-zygmund` (54–119), `corollaries` (121–146)
- Added 4 annotations covering the private Cauchy-Schwarz lemma, the main Paley-Zygmund theorem, the probability form corollary, and the θ=0 recovery of the qualitative second moment method
- Fixed `crossReferences` format (slug/title → targetId/relationship/description); added cross-ref to `cauchy-schwarz`
- Added `mathlibDependencies` (3 Mathlib theorems), `references` (Paley-Zygmund 1932, Alon-Spencer 2016)
- Expanded `historicalContext` with Paley-Zygmund 1932 lacunary series context and combinatorial applications
- Added 5 `keyInsights`: above/below decomposition, Cauchy-Schwarz bridge, θ=0 recovery, finite discrete setting, three formulations

## Test plan
- [ ] `pnpm annotations:build` passes with no errors for this proof
- [ ] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)