### PR TITLE
Fix: update stale assumptions and status for 6 more proof entries

### DIFF
--- a/src/data/proofs/central-limit-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-02/meta.json
@@ -41,7 +41,7 @@
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
     "lineCount": 322,
-    "assumptions": "1 True stub (1/19 theorems): stable_inf_divisible (line 208): proves True instead of infinite divisibility. stable_inf_divisible proves True (placeholder). 19/20 theorems fully proved; 1 True stub remains for α-stable infinite divisibility.",
+    "assumptions": "0 axioms, 0 sorries. All 19 theorems fully proved. stable_inf_divisible (α-stable infinite divisibility) was converted to a block comment; the remaining 19 theorems about Lévy triplets, Gaussian/Poisson instances, and Lévy-Itô decomposition are machine-verified.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/denumerability-rationals-oq-04/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-04/meta.json
@@ -19,7 +19,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 141,
-    "assumptions": "No axioms or sorries. Core argument uses Mathlib's FTA (Polynomial.setOf_isRoot_finite) and Set.countable_iUnion. 1 True stub (choiceless_note, documentation only).",
+    "assumptions": "0 axioms, 0 sorries. Core argument uses Mathlib's FTA (Polynomial.setOf_isRoot_finite) and Set.countable_iUnion. Fully constructive; choiceless_note documentation theorem was removed.",
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.setOf_isRoot_finite",

--- a/src/data/proofs/erdos-606-oq-03/meta.json
+++ b/src/data/proofs/erdos-606-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Sylvester, Green-Tao, Motzkin",
     "sourceUrl": "https://erdosproblems.com/606",
     "date": "2026",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos606OQ03.lean",
     "tags": [
       "combinatorial-geometry",
@@ -20,7 +20,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 98,
-    "assumptions": "0 axioms, 0 sorries. 1 True-stub placeholder theorem: general_position_count (line 42, proves True := trivial). Sylvester-Gallai, Green-Tao, and Motzkin are mentioned in docstring comments but not axiomatized — they do not contribute to axiomCount.",
+    "assumptions": "0 axioms, 0 sorries. general_position_count True stub was converted to a block comment. 3 remaining theorems (max_hyperplanes, line_count_range, hyperplane_extremes) are fully proved. Sylvester-Gallai, Green-Tao, and Motzkin are referenced in comments only. Classified axiomatized: main research question (achievable hyperplane counts) is open.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "originalContributions": [

--- a/src/data/proofs/hilbert-22/meta.json
+++ b/src/data/proofs/hilbert-22/meta.json
@@ -7,7 +7,7 @@
     "proofRepoPath": "Proofs/Hilbert22Uniformization.lean",
     "author": "Koebe, Poincare",
     "date": "1907",
-    "status": "formalized",
+    "status": "axiomatized",
     "tags": [
       "complex-analysis",
       "riemann-surfaces",
@@ -46,7 +46,7 @@
     "hilbertNumber": 22,
     "axiomCount": 0,
     "lineCount": 305,
-    "assumptions": "Main theorems are True stubs (e.g., hilbert_22_status proves existential True propositions, not real uniformization). Real uniformization infrastructure is partially formalized but the core mathematical content is not machine-verified.",
+    "assumptions": "Structure-encoded assumptions: isDiscrete : True in FuchsianGroup and HyperbolicDomain structures (proper discontinuity condition); def RiemannSurface.IsSimplyConnected : Prop := True (topological connectivity placeholder). The uniformization theorem itself remains in comments. Per CLAUDE.md: structure fields with True are counted as structure-encoded assumptions.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/hilbert-23/meta.json
+++ b/src/data/proofs/hilbert-23/meta.json
@@ -7,7 +7,7 @@
     "proofRepoPath": "Proofs/Hilbert23CalculusVariations.lean",
     "author": "Euler, Lagrange, Hilbert, Tonelli, Pontryagin, et al.",
     "date": "1744-present",
-    "status": "formalized",
+    "status": "axiomatized",
     "tags": [
       "analysis",
       "optimization",
@@ -46,7 +46,7 @@
     "hilbertNumber": 23,
     "axiomCount": 0,
     "lineCount": 328,
-    "assumptions": "Main theorems are True stubs (e.g., euler_lagrange_weak_form and hilbert_23_status prove vacuous existential True propositions, not actual variational results). The Euler-Lagrange equation is not genuinely formalized. Variational infrastructure (Lagrangian structures, action functionals) is defined but the core mathematical content is not machine-verified.",
+    "assumptions": "Structure-encoded assumption: smooth : True in Lagrangian structure (smoothness condition). euler_lagrange_weak_form and hilbert_23_status were converted to block comments. The calculus_of_variations_active theorem proves only (1:ℕ)+1=2. The Euler-Lagrange equation and Pontryagin maximum principle remain as comment documentation. Classified axiomatized: main variational results are not formalized.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/prob-method-alteration/meta.json
+++ b/src/data/proofs/prob-method-alteration/meta.json
@@ -37,7 +37,7 @@
     "originalContributions": [
       "alteration_principle: genuine proof by contradiction via Finset.sum_le_sum",
       "independent_set_bound: trivial existence witness (max, not graph-theoretic)",
-      "property_b_bound: True stub placeholder (needs hypergraph type)"
+      "property_b_bound: removed as block comment (needs hypergraph type for full formalization)"
     ],
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
@@ -49,7 +49,7 @@
       "Property B and hypergraph 2-colorability",
       "Optimization of probability parameters"
     ],
-    "assumptions": "1 True stub (1/3 theorems): property_b_bound (line 58): proves True instead of Property B bound. property_b_bound proves True (placeholder, needs hypergraph type). 2/3 theorems fully proved; 1 True stub remains.",
+    "assumptions": "0 axioms, 0 sorries. 2 theorems fully proved: alteration_principle and independent_set_bound. property_b_bound was converted to a block comment (needs hypergraph type for full formalization). All remaining theorems are machine-verified.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Fix

Six more `meta.json` files had stale `assumptions` fields referencing True-stub theorems converted to block comments (by commit `1d8e1b94ec`), or had `status: formalized` when the main theorem is open/unformalized.

## Changes

**Stale assumptions only (status already correct):**
- **central-limit-theorem-oq-01-oq-02** (`verified`): `stable_inf_divisible` True stub removed; update assumptions to say it was converted to a comment
- **denumerability-rationals-oq-04** (`verified`): `choiceless_note` True stub removed; update assumptions
- **prob-method-alteration** (`verified`): `property_b_bound` True stub removed; update assumptions and originalContributions

**Stale assumptions + status fix:**
- **erdos-606-oq-03**: `formalized` → `axiomatized`; `general_position_count` stub removed; update assumptions (main question about achievable hyperplane counts is open)
- **hilbert-22**: `formalized` → `axiomatized`; `hilbert_22_status` never existed; actual stubs are `isDiscrete : True` structure fields and `def RiemannSurface.IsSimplyConnected : Prop := True`
- **hilbert-23**: `formalized` → `axiomatized`; `euler_lagrange_weak_form`/`hilbert_23_status` never existed; actual stub is `smooth : True` in Lagrangian structure; Euler-Lagrange not formalized

The `formalized → axiomatized` reclassifications follow CLAUDE.md: "When in doubt, use 'axiomatized' — overclaiming 'verified' damages credibility." These are all cases where the main mathematical result is not formalized.

---
Automated fix by lean-mechanic agent.