### PR TITLE
Enrich 5 proofs: derangements, kummer, feuerbachs, e-transcendental, cauchy-schwarz

### DIFF
--- a/src/data/proofs/feuerbachs-theorem-oq-05/annotations.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-05/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-feuer05-aux-lemmas",
+    "proofId": "feuerbachs-theorem-oq-05",
+    "range": { "startLine": 40, "endLine": 66 },
+    "type": "technique",
+    "title": "Auxiliary Lemmas: Bridging dist2 and dist2_sq Representations",
+    "content": "The proof uses two representations of distance: `dist2 P Q = sqrt(dist2_sq P Q)` (the actual Euclidean distance) and `dist2_sq P Q = (P.1-Q.1)^2 + (P.2-Q.2)^2` (the squared distance, avoiding sqrt for algebraic manipulations). Three private lemmas provide bridges: `dist2_sq_comm` (symmetry), `dist2_sqrt_eq` (unfolds the definition), and `dist2_sq_of_dist2_eq` (converts a `dist2` equality to a `dist2_sq` equality via `Real.sq_sqrt`). The helper `feuerbach_NI_sqrt` extracts the NI distance in raw sqrt form from the parent's Feuerbach distance theorem, needed for the algebraic form used in the Feuerbach point proofs.",
+    "mathContext": "The key algebraic bridge: if $\\mathrm{dist2}(P,Q) = r$ (a non-negative real), then $\\mathrm{dist2\\_sq}(P,Q) = r^2$. This uses $\\mathrm{dist2\\_sq}(P,Q) = (\\sqrt{\\mathrm{dist2\\_sq}(P,Q)})^2 = \\mathrm{dist2}(P,Q)^2 = r^2$ via `Real.sq_sqrt` (which requires $\\mathrm{dist2\\_sq} \\geq 0$, guaranteed by `positivity`).",
+    "significance": "technical",
+    "relatedConcepts": ["Real.sq_sqrt", "positivity tactic", "squared distance", "Euclidean distance"],
+    "prerequisites": ["Real.sqrt properties", "dist2/dist2_sq definitions from FeuerbachsTheorem"]
+  },
+  {
+    "id": "ann-feuer05-point-def",
+    "proofId": "feuerbachs-theorem-oq-05",
+    "range": { "startLine": 79, "endLine": 82 },
+    "type": "definition",
+    "title": "The Feuerbach Point: Coordinate Definition on Ray N→I",
+    "content": "The Feuerbach point F is defined as the unique point on the ray from nine-point center N through incenter I at distance R_9 (ninePointRadius) from N. In coordinates: F = N + (R_9/d) * (I-N) where d = R_9 - r (the NI distance, which is positive by hypothesis r < R_9). The scaling factor R_9/d ensures |F-N| = R_9: since |I-N| = d, scaling (I-N) by R_9/d gives a vector of length R_9. The definition is `noncomputable` (in a noncomputable section) because real arithmetic is noncomputable in Lean.",
+    "mathContext": "Geometrically, $F$ divides the segment $NI$ externally in the ratio $R_9 : r$ from $N$: $F = N + \\frac{R_9}{R_9 - r}(I - N)$. Since $R_9/(R_9-r) > 1$, $F$ lies beyond $I$ on the ray $N \\to I$. The distances are: $|NF| = R_9$ (on nine-point circle), $|IF| = |F - I| = |(R_9/d - 1)(I-N)| = (r/d)|I-N| = r$ (on incircle). So $F$ is the internal tangency point.",
+    "significance": "key",
+    "relatedConcepts": ["Feuerbach point", "nine-point circle", "incircle", "internal tangency", "triangle centers X(11)"],
+    "prerequisites": ["ninePointRadius definition", "inradius definition", "coordinate geometry in ℝ²"]
+  },
+  {
+    "id": "ann-feuer05-circle-membership",
+    "proofId": "feuerbachs-theorem-oq-05",
+    "range": { "startLine": 85, "endLine": 119 },
+    "type": "insight",
+    "title": "F Lies on Both Circles: Scaling the NI Vector",
+    "content": "Both membership theorems use the same algebraic template. For `feuerbachPoint_on_ninePointCircle`: F-N = (R_9/d)*(I-N), so |F-N|² = (R_9/d)² * |I-N|². With |I-N| = d (from feuerbach_NI_sqrt), |F-N|² = R_9² and |F-N| = R_9. For `feuerbachPoint_on_incircle`: F-I = (R_9/d - 1)*(I-N) = (r/d)*(I-N), so |F-I|² = (r/d)² * d² = r². Both proofs use `Real.sqrt_mul` and `Real.sqrt_sq` to handle the sqrt, followed by `field_simp` and `feuerbach_NI_sqrt` to substitute the NI distance.",
+    "mathContext": "For the nine-point circle: $|F - N|^2 = \\left(\\frac{R_9}{d}\\right)^2 |I-N|^2 = \\frac{R_9^2}{d^2} \\cdot d^2 = R_9^2$. For the incircle: $F - I = \\frac{R_9}{d}(I-N) - (I-N) = \\frac{R_9 - d}{d}(I-N) = \\frac{r}{d}(I-N)$ (since $R_9 - d = R_9 - (R_9-r) = r$), giving $|F - I|^2 = \\frac{r^2}{d^2} \\cdot d^2 = r^2$.",
+    "significance": "key",
+    "relatedConcepts": ["internal tangency point", "nine-point circle", "incircle", "distance ratios"],
+    "prerequisites": ["feuerbach_NI_sqrt", "Real.sqrt_mul", "Real.sqrt_sq", "field_simp"]
+  },
+  {
+    "id": "ann-feuer05-inversion",
+    "proofId": "feuerbachs-theorem-oq-05",
+    "range": { "startLine": 128, "endLine": 130 },
+    "type": "definition",
+    "title": "Planar Inversion: The Conformal Reflection in a Circle",
+    "content": "The `invertPoint O k P` definition formalizes planar inversion centered at O with radius k: P maps to Q = O + k²/|OP|² · (P-O). Geometrically, Q lies on the ray OP at distance k²/|OP| from O, so |OQ| · |OP| = k². When P is on the circle of radius k, |OP| = k so Q = P (fixed points on the inversion circle). When P → O, Q → ∞ (inversion at the center is undefined). The formula uses `dist2_sq O P = |OP|²` in the denominator; when P = O this is zero, making the result degenerate. The hypothesis `dist2_sq P O ≠ 0` in subsequent theorems excludes this case.",
+    "mathContext": "Planar inversion with center $O$ and radius $k$ is the map $\\iota: \\mathbb{R}^2 \\setminus \\{O\\} \\to \\mathbb{R}^2 \\setminus \\{O\\}$ defined by $\\iota(P) = O + \\frac{k^2}{|P-O|^2}(P-O)$. Key properties: (1) $\\iota \\circ \\iota = \\mathrm{id}$ (involution); (2) circles/lines through $O$ map to lines; (3) circles/lines not through $O$ map to circles not through $O$; (4) inversion is conformal (angle-preserving). These properties make it the key tool for reducing tangency to parallelism.",
+    "significance": "key",
+    "relatedConcepts": ["Möbius transformation", "circle inversion", "conformal map", "inversive geometry", "inversion center"],
+    "prerequisites": ["coordinate geometry", "dist2_sq definition", "real division in Lean"]
+  },
+  {
+    "id": "ann-feuer05-circle-to-line",
+    "proofId": "feuerbachs-theorem-oq-05",
+    "range": { "startLine": 136, "endLine": 167 },
+    "type": "insight",
+    "title": "Circle-to-Line Theorem: The Core Algebraic Identity",
+    "content": "The private lemma `dot_identity_of_circle` is the algebraic heart of the theorem: if O and P both lie on a circle centered at C with radius ρ, then |P-O|² = 2·(P-O)·(C-O). This is proved by `linear_combination hPC - hOC`, a one-line proof subtracting the two circle equations. The main `circle_to_line` theorem then computes: image Q = O + k²/|OP|² · (P-O), so 2·(Q-O)·(C-O) = (k²/|OP|²)·2·(P-O)·(C-O) = (k²/|OP|²)·|P-O|² = k². The crucial simplification uses `hkey'` to replace the dot product with |OP|², then `field_simp [hOP_ne]` to cancel.",
+    "mathContext": "The algebraic identity: $|P-C|^2 = \\rho^2$ and $|O-C|^2 = \\rho^2$ gives $|P-C|^2 - |O-C|^2 = 0$. Expanding: $|P|^2 - 2P\\cdot C + |C|^2 - |O|^2 + 2O\\cdot C - |C|^2 = 0$, which rearranges to $|P-O|^2 - 2(P-O)\\cdot(C-O) = 0$. The image line equation $2(Q-O)\\cdot(C-O) = k^2$ means $Q$ lies on a line perpendicular to $OC$ (the line through $O$ in direction $C-O$, at signed distance $k^2/(2\\rho)$ from $O$).",
+    "significance": "key",
+    "relatedConcepts": ["circle inversion", "line equation", "dot product", "linear_combination tactic", "conformal geometry"],
+    "prerequisites": ["dot_identity_of_circle", "invertPoint definition", "field_simp with nonzero denominators"]
+  },
+  {
+    "id": "ann-feuer05-parallel-lines",
+    "proofId": "feuerbachs-theorem-oq-05",
+    "range": { "startLine": 215, "endLine": 234 },
+    "type": "insight",
+    "title": "Parallel Image Lines: Collinearity Implies Proportional Normals",
+    "content": "The theorem `feuerbach_normals_proportional` proves N-F = -(R_9/r)·(I-F) componentwise. This follows directly from the definition: F = N + (R_9/d)·(I-N). Then N-F = -(R_9/d)·(I-N) and I-F = I - N - (R_9/d)·(I-N) = (1 - R_9/d)·(I-N) = (-r/d)·(I-N). So (N-F)/(I-F) = (-(R_9/d))/((-r/d)) = -(R_9/r). The proof is `constructor <;> (field_simp; ring)` — pure algebraic simplification. The packaging theorem `feuerbach_inversive_parallel_lines` witnesses the proportionality with λ = -(R_9/r), showing the two perpendicular lines are parallel.",
+    "mathContext": "The two image lines after inversion at $F$: (Line 1) $2(Q-F)\\cdot(I-F) = k^2$ (from incircle) and (Line 2) $2(Q-F)\\cdot(N-F) = k^2$ (from nine-point circle). Line 1 is perpendicular to $\\vec{FI} = I-F$; Line 2 is perpendicular to $\\vec{FN} = N-F$. Since $N-F = \\lambda(I-F)$ for $\\lambda \\neq 0$, both normals are parallel, so the two lines are parallel. The ratio $\\lambda = -(R_9/r) < 0$ is negative because $F$ lies between $N$ and $I$ extended (beyond $I$), so $N-F$ and $I-F$ point in opposite directions.",
+    "significance": "key",
+    "relatedConcepts": ["parallel lines", "normal directions", "collinearity", "inversive proof of Feuerbach", "Feuerbach point geometry"],
+    "prerequisites": ["feuerbach_normals_proportional", "incircle_maps_to_line", "ninePointCircle_maps_to_line", "field_simp; ring"]
+  }
+]

--- a/src/data/proofs/feuerbachs-theorem-oq-05/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-05/meta.json
@@ -25,35 +25,96 @@
     ]
   },
   "overview": {
-    "historicalContext": "Feuerbach's theorem (1822) states that the nine-point circle of a triangle is internally tangent to the incircle and externally tangent to each of the three excircles. The classical inversive proof, using inversion centered at the tangency point (Feuerbach point), elegantly transforms circles to lines and reduces the tangency question to parallelism.",
-    "problemStatement": "Develop the inversive geometry framework for Feuerbach's theorem: define the Feuerbach point, prove it lies on both circles, define planar inversion, prove the Circle-to-Line theorem, and show the two image lines are parallel.",
-    "proofStrategy": "The Feuerbach point F is defined as the point on the ray N→I (nine-point center to incenter) at distance R/2 from N, where R/2 is the nine-point radius. Feuerbach's incircle distance theorem (dist(N,I) = R/2 - r) guarantees F lies on both circles. Inversion at F sends each circle (passing through F) to a line. The proportionality N-F = -(R/2/r)·(I-F) follows from the collinearity F, N, I, making the image lines parallel.",
+    "historicalContext": "Karl Wilhelm Feuerbach (1800–1834) published his theorem in 1822 at the age of 22, in a short paper that was initially ignored and only later recognized as a profound result in triangle geometry. His original proof was purely algebraic and computational; the elegant inversive geometry proof came later.\n\nThe nine-point circle itself was discovered independently by multiple mathematicians around 1820: Brianchon and Poncelet (1820) proved it passes through the midpoints of the sides, the feet of the altitudes, and the midpoints of the segments from vertex to orthocenter. Feuerbach's additional discovery — that this circle is tangent to all four tritangent circles — elevated the nine-point circle to a central place in classical Euclidean geometry.\n\nThe inversive geometry approach used here was developed in the 19th century as the theory of circle inversion matured (Möbius, Kelvin, Poincaré). The key insight: if two circles are tangent, they share a common point, and an inversion centered at that point maps both tangent circles to parallel lines. This reduces the tangency question to a parallelism question, which is much easier to verify computationally. This is exactly the framework formalized here.\n\nFeuerbach's theorem was generalized by many 19th-century geometers, and it continues to be a source of elegant results in modern triangle geometry (see Kimberling's Encyclopedia of Triangle Centers, where the Feuerbach point is triangle center X(11)).",
+    "problemStatement": "Develop the inversive geometry framework for Feuerbach's theorem. Specifically: (1) define the Feuerbach point $F$ as the point on the ray from nine-point center $N$ through incenter $I$ at distance $R_9$ from $N$ (where $R_9 = R/2$ is the nine-point radius); (2) prove $F$ lies on both circles; (3) define planar inversion $P \\mapsto O + k^2/|OP|^2 \\cdot (P-O)$; (4) prove the Circle-to-Line theorem; (5) prove the image lines of both circles under inversion at $F$ are parallel.",
+    "proofStrategy": "The Feuerbach point $F$ is defined explicitly in coordinates as the point on ray $N \\to I$ at distance $R_9$ from $N$: $F = N + (R_9/d) \\cdot (I-N)$ where $d = R_9 - r$ is the NI distance (Feuerbach's distance theorem gives $|NI| = R_9 - r$ for the incircle). This guarantees $|NF| = R_9$ (on nine-point circle) and $|IF| = r$ (on incircle) by the same ratio.\n\nThe Circle-to-Line theorem uses a key algebraic identity: if $O$ and $P$ both lie on a circle centered at $C$ with radius $\\rho$, then $|OP|^2 = 2(P-O)\\cdot(C-O)$ (proved by subtracting the circle equations $|P-C|^2 = |O-C|^2 = \\rho^2$). After inversion, $Q = O + k^2/|OP|^2 \\cdot (P-O)$, the inner product $2(Q-O)\\cdot(C-O) = k^2$ is a linear equation in $Q$ — a line perpendicular to $OC$.\n\nThe parallel-lines result follows algebraically: since $F = N + (R_9/d)(I-N)$, the vectors $N-F$ and $I-F$ are proportional with ratio $-(R_9/r)$, so the perpendicular lines (perpendicular to $N-F$ and $I-F$ respectively) are parallel.",
     "keyInsights": [
-      "The Feuerbach point exists only for non-equilateral triangles (inradius < ninePointRadius)",
-      "Circle-to-Line theorem: the image of a circle through the inversion center is always a line",
-      "Key identity: |P-O|² = 2(P-O)·(C-O) for P, O on a circle centered at C — eliminates the center from the inversion computation",
-      "The collinearity F, N, I directly implies the image normals are proportional, hence the lines are parallel"
+      "The Feuerbach point $F$ exists only for non-equilateral triangles: the condition $r < R_9$ (inradius strictly less than nine-point radius) fails only for equilateral triangles where $r = R_9$ and the two circles coincide",
+      "The Circle-to-Line theorem reduces to a single algebraic identity $|PO|^2 = 2(P-O)\\cdot(C-O)$ (obtained by subtracting $|P-C|^2 = |O-C|^2$), which then makes the inversion computation trivially linear",
+      "The collinearity of $F$, $N$, $I$ (by definition: $F$ is on ray $N \\to I$) directly implies that the image normals $N-F$ and $I-F$ are proportional with explicit ratio $-(R_9/r)$, making parallelism a pure algebraic computation",
+      "Inversion is not defined at the center $O$ itself, so the hypothesis $\\mathrm{dist2\\_sq}(P, F) \\neq 0$ (i.e., $P \\neq F$) is required in each theorem — a careful treatment of this edge case in the formal proof",
+      "This file establishes the geometric framework (two parallel lines after inversion) but does not yet complete the excircle tangency — the final step would show each excircle maps to a circle between the two parallel lines, establishing external tangency"
     ],
     "prerequisites": [
-      "Feuerbach's incircle distance theorem from parent FeuerbachsTheorem",
-      "Coordinate geometry and dist2/dist2_sq definitions",
-      "Real.sqrt and norm calculations in ℝ²"
+      "Feuerbach's incircle distance theorem from parent FeuerbachsTheorem (|NI| = R_9 - r)",
+      "Coordinate geometry: dist2, dist2_sq definitions for ℝ²",
+      "Real.sqrt properties and field_simp for algebraic simplification",
+      "Planar inversion basics (Möbius geometry)"
     ]
   },
-  "sections": [],
+  "sections": [
+    {
+      "id": "imports-setup",
+      "title": "Imports, Namespace, and Auxiliary Lemmas",
+      "startLine": 1,
+      "endLine": 66,
+      "summary": "File header explaining the inversive proof strategy. Imports from FeuerbachsTheorem (parent). Three private auxiliary lemmas: dist2_sq_comm (symmetry), dist2_sqrt_eq (definition unfolding), dist2_sq_of_dist2_eq (bridge between dist2 and dist2_sq), and feuerbach_NI_sqrt (the NI distance in sqrt form, derived from the parent's incircle distance theorem)"
+    },
+    {
+      "id": "feuerbach-point",
+      "title": "Part II: The Feuerbach Point — Definition and Circle Membership",
+      "startLine": 68,
+      "endLine": 119,
+      "summary": "Defines Triangle.feuerbachPoint as the point on ray N→I at distance R_9 from N: F = N + (R_9/d)·(I-N) where d = R_9 - r. Proves feuerbachPoint_on_ninePointCircle (dist2(N,F) = R_9) and feuerbachPoint_on_incircle (dist2(I,F) = r). Both proofs use feuerbach_NI_sqrt and field_simp/ring for the algebraic calculations"
+    },
+    {
+      "id": "inversion-definition",
+      "title": "Part III: Planar Inversion and the Circle-to-Line Theorem",
+      "startLine": 121,
+      "endLine": 167,
+      "summary": "Defines invertPoint O k P = O + k²/dist2_sq(O,P) · (P-O). Private lemma dot_identity_of_circle proves the key algebraic identity |PO|² = 2(P-O)·(C-O) for P, O on a common circle. The main theorem circle_to_line applies this to show the inversion image Q of any P≠O satisfies the linear equation 2(Q-O)·(C-O) = k² — the equation of a line"
+    },
+    {
+      "id": "image-lines",
+      "title": "Part IV: Both Circles Map to Lines under Inversion at F",
+      "startLine": 169,
+      "endLine": 205,
+      "summary": "Two theorems apply circle_to_line specifically to the Feuerbach point context. incircle_maps_to_line: for P on the incircle (P≠F), the image Q satisfies 2(Q-F)·(I-F) = k² (line perpendicular to FI). ninePointCircle_maps_to_line: for P on the nine-point circle (P≠F), image Q satisfies 2(Q-F)·(N-F) = k² (line perpendicular to FN)"
+    },
+    {
+      "id": "parallel-lines",
+      "title": "Part V: The Image Lines are Parallel",
+      "startLine": 207,
+      "endLine": 234,
+      "summary": "feuerbach_normals_proportional proves N-F = -(R_9/r)·(I-F) componentwise, using field_simp and ring on the feuerbachPoint definition. feuerbach_inversive_parallel_lines packages this as ∃ λ ≠ 0, N-F = λ·(I-F) — the existence witness being λ = -(R_9/r)"
+    },
+    {
+      "id": "summary",
+      "title": "Summary and Proof Map",
+      "startLine": 236,
+      "endLine": 266,
+      "summary": "Closing comment cataloging the 10 theorems proved in this file with their geometric meaning, and explaining the overall inversive proof strategy connecting to the excircle tangency (the next step not formalized here)"
+    }
+  ],
   "conclusion": {
-    "summary": "This file proves 10 theorems (plus 2 private lemmas) with 0 sorries and 0 axioms, building the complete inversive framework: Feuerbach point definition and membership in both circles, Circle-to-Line theorem, and parallel image lines.",
-    "implications": "The inversive framework established here is the foundation for the full proof that excircles are also tangent to the nine-point circle. The parallel line result encodes the essential geometric content: after inversion, the problem reduces to showing that parallel-translated circles (between two parallel lines) are tangent to the original circles.",
+    "summary": "This file proves 10 theorems plus 2 auxiliary lemmas (12 total) with 0 sorries and 0 axioms, formalizing the inversive geometry framework. The Feuerbach point is defined and shown to lie on both circles; the Circle-to-Line theorem is proved; and the parallel-image-lines result establishes the core geometric content of the inversive proof strategy.",
+    "implications": "The inversive framework established here is the foundation for the full proof that excircles are also tangent to the nine-point circle. The parallel line result — that inversion at F maps both circles to parallel lines — means any circle tangent to both original circles maps to a circle between the two parallel lines, automatically tangent to both lines and hence to both original circles. This reduces the excircle tangency to the simpler problem of finding circles between two parallel lines. The `circle_to_line` theorem and `invertPoint` definition are reusable for other inversive geometry arguments.",
     "openQuestions": [
-      "Complete the proof that each excircle is tangent to the nine-point circle using this inversive framework",
-      "Formalize the full Feuerbach theorem including all three excircles"
+      "Complete the inversive proof by showing each excircle maps under inversion at $F$ to a circle between the two parallel lines, establishing external tangency of each excircle to the nine-point circle",
+      "Formalize Feuerbach's theorem using Mathlib's projective geometry or complex plane approach (where inversion is Möbius transformation and the computation is more algebraically streamlined via complex multiplication)",
+      "Extend the framework to other tangency results in triangle geometry: the Soddy circles, mixtilinear incircles, or the Apollonius circle — all of which use inversive methods"
     ]
   },
   "crossReferences": [
     {
       "slug": "feuerbachs-theorem",
       "relationship": "extends",
-      "description": "Parent file providing the Feuerbach incircle distance theorem and triangle geometry definitions"
+      "description": "Parent file providing the Feuerbach incircle distance theorem (|NI| = R_9 - r), triangle geometry definitions, and inradius/nine-point-radius calculations"
+    },
+    {
+      "slug": "feuerbachs-theorem-oq-01",
+      "relationship": "related",
+      "description": "Sibling open question on Feuerbach's theorem, developing another aspect of the theory"
+    },
+    {
+      "slug": "feuerbachs-theorem-oq-02",
+      "relationship": "related",
+      "description": "Sibling open question on Feuerbach's theorem"
+    },
+    {
+      "slug": "ptolemys-theorem",
+      "relationship": "related",
+      "description": "Ptolemy's theorem is proved via inversive geometry — inversion maps circles to lines in both theorems; the technique is the same"
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Five enrichment passes consolidated on feature/enricher-2.

All proofs: 0→annotations, 0→sections, expanded history/insights.

1. **derangements-oq-02-oq-02**: Burnside/Cauchy-Frobenius history, E[#fixed]=1, 7 annotations, 7 sections
2. **kummer-theorem-oq-03**: Sierpiński fractal, Lucas theorem, Frobenius endomorphism, 6 annotations, 6 sections
3. **feuerbachs-theorem-oq-05**: Feuerbach (1822), inversive proof framework, X(11) triangle center, 6 annotations, 6 sections
4. **e-transcendental-oq-01-oq-01**: Nesterenko (1996), polynomial-lifting, Schanuel's Conjecture, Gel'fond e^π, 6 annotations, 8 sections
5. **cauchy-schwarz-integral-oq-02-oq-02-oq-01**: Minkowski ENNReal cancellation, rpow factoring, 3 annotations, 3 sections