### PR TITLE
chore: sync research listings and data

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -12499,11 +12499,12 @@
     },
     {
       "slug": "cantor-diagonalization-oq-02-oq-03-oq-02",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-04T09:42:47.007Z",
-      "status": "active",
-      "lastUpdate": "2026-04-04T09:42:47.023Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T22:29:37.263Z",
+      "completed": "2026-04-04T22:29:37.262Z"
     },
     {
       "slug": "cantor-diagonalization-oq-03-oq-01-oq-01",


### PR DESCRIPTION
Auto-generated sync from deployer agent.

Updates `research/registry.json` with latest iteration counts.

🤖 Generated by deployer agent