### PR TITLE
feat(enrichment): enrich 3 gallery entries: div-by-3-oq-02, vietas-oq-05, erdos-1155-oq-06

### DIFF
--- a/src/data/proofs/erdos-1155-oq-01-oq-06/annotations.json
+++ b/src/data/proofs/erdos-1155-oq-01-oq-06/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-e1155-oq06-turan-bound",
+    "proofId": "erdos-1155-oq-01-oq-06",
+    "range": { "startLine": 54, "endLine": 70 },
+    "type": "definition",
+    "title": "Turán Bound: Maximum Triangle-Free Edges",
+    "content": "`turanBound(n) = n²/4` represents the maximum number of edges in a triangle-free graph on $n$ vertices, achieved uniquely by the balanced complete bipartite graph $K_{\\lfloor n/2 \\rfloor, \\lceil n/2 \\rceil}$ (Mantel 1907, Turán 1941). The theorem `triangleRemoval_le_turan` delegates to `triangleRemoval_mantel_bound` from the parent file — the terminal graph is triangle-free by construction, so Mantel applies immediately. This section establishes the upper-bound reference against which all structural results measure.",
+    "mathContext": "$\\mathrm{turanBound}(n) = \\frac{n^2}{4}$; $\\quad f(n) \\le \\frac{n^2}{4}$ by Mantel's theorem",
+    "significance": "context",
+    "relatedConcepts": ["Mantel's theorem", "Turán's theorem", "complete bipartite graph", "triangle-free graph"],
+    "prerequisites": ["Mantel's theorem (1907)", "Turán's theorem (1941)", "triangleRemoval_mantel_bound axiom"]
+  },
+  {
+    "id": "ann-e1155-oq06-turan-ratio",
+    "proofId": "erdos-1155-oq-01-oq-06",
+    "range": { "startLine": 75, "endLine": 93 },
+    "type": "definition",
+    "title": "The Turán Ratio as a Structural Proximity Measure",
+    "content": "`turanRatio(n) = triangleRemovalEdges(n) / turanBound(n)` measures how close the terminal graph is to achieving the maximum triangle-free edge density. A ratio of 1 would mean the terminal graph is exactly as dense as the Turán extremal graph; a ratio of 0 would mean it is asymptotically edge-free. `turanRatio_nonneg` and `turanRatio_le_one` bound it in $[0, 1]$. The main theorem will show the ratio actually converges to 0, placing the terminal graph at the 'sparse' extreme of the triangle-free graph spectrum.",
+    "mathContext": "$\\mathrm{turanRatio}(n) = \\frac{f(n)}{n^2/4} \\in [0, 1]$",
+    "significance": "key",
+    "relatedConcepts": ["edge density", "Turán density", "extremal graph theory", "triangle-free graphs"],
+    "prerequisites": ["turanBound definition", "triangleRemovalEdges_nonneg", "triangleRemoval_le_turan"]
+  },
+  {
+    "id": "ann-e1155-oq06-sub-turan",
+    "proofId": "erdos-1155-oq-01-oq-06",
+    "range": { "startLine": 98, "endLine": 154 },
+    "type": "technique",
+    "title": "Proof: BFL + Power Arithmetic → Sub-Turán Bound",
+    "content": "The proof of `terminal_sub_turan` is the technical core. Strategy: (1) Apply BFL with $\\varepsilon = 1/4$ to get $f(n) \\le n^{7/4}$ eventually. (2) Show $n^{7/4} \\le \\delta \\cdot n^2/4$ for $n \\ge (4/\\delta)^4$. Step (2) uses two algebraic decompositions via `Real.rpow_add`: $n^{7/4} = n^{1/4} \\cdot n^{3/2}$ and $n^2 = n^{1/4} \\cdot n^{7/4}$. This lets one write $\\delta \\cdot n^2/4 = (\\delta \\cdot n^{1/4}/4) \\cdot n^{7/4}$, so the bound reduces to $1 \\le \\delta \\cdot n^{1/4}/4$, i.e., $n^{1/4} \\ge 4/\\delta$ — which holds when $n \\ge (4/\\delta)^4$ by monotonicity of real powers (`Real.rpow_le_rpow`).",
+    "mathContext": "BFL: $f(n) \\le n^{3/2+1/4} = n^{7/4}$ eventually; $\\;n^{7/4} \\le \\delta \\cdot n^2/4$ when $n^{1/4} \\ge 4/\\delta$, i.e., $n \\ge (4/\\delta)^4$",
+    "significance": "key",
+    "relatedConcepts": ["BFL bound", "Real.rpow_add", "filter arithmetic", "eventually-true predicates"],
+    "prerequisites": ["bfl_upper_bound axiom", "Real.rpow_add", "Real.rpow_le_rpow", "Filter.eventually_atTop"]
+  },
+  {
+    "id": "ann-e1155-oq06-turan-ratio-zero",
+    "proofId": "erdos-1155-oq-01-oq-06",
+    "range": { "startLine": 156, "endLine": 181 },
+    "type": "insight",
+    "title": "Main Theorem: Turán Ratio Converges to Zero",
+    "content": "`turanRatio_tendsto_zero` is the headline result: $f(n)/(n^2/4) \\to 0$ in the $\\varepsilon$-$N$ sense. The proof uses `Metric.tendsto_atTop` to convert the topological convergence statement to a quantitative threshold. For a given $\\varepsilon > 0$: apply `terminal_sub_turan` with $\\delta = \\varepsilon/2$ to get a threshold $N$; for $n \\ge \\max(N, 1)$, compute $|\\mathrm{turanRatio}(n) - 0| = f(n)/\\mathrm{turanBound}(n) < \\varepsilon/2 < \\varepsilon$. The strict inequality (not just $\\le$) requires the factor $\\varepsilon/2$ rather than $\\varepsilon$ in the sub-turan application.",
+    "mathContext": "$\\lim_{n \\to \\infty} \\frac{f(n)}{n^2/4} = 0$; proof: $\\forall \\varepsilon > 0, \\exists N, \\forall n \\ge N: f(n)/(n^2/4) < \\varepsilon$",
+    "significance": "key",
+    "relatedConcepts": ["filter convergence", "nhds 0", "Metric.tendsto_atTop", "Turán density"],
+    "prerequisites": ["terminal_sub_turan", "Metric.tendsto_atTop", "turanBound_pos", "turanRatio_nonneg"]
+  },
+  {
+    "id": "ann-e1155-oq06-exponent-gap",
+    "proofId": "erdos-1155-oq-01-oq-06",
+    "range": { "startLine": 186, "endLine": 207 },
+    "type": "concept",
+    "title": "The 3/2 vs 2 Exponent Gap",
+    "content": "Section §4 provides the exponent-level perspective on the structural gap. `turan_exponent_gap` is the trivial fact $3/2 < 2$, stated as a named theorem to give the exponent gap a formal presence. `terminal_sub_power` generalizes: for any $\\alpha > 3/2$, $f(n) \\le n^\\alpha$ eventually — proved by direct delegation to `bfl_exponent_is_three_halves`. `terminal_not_turan_optimal` uses $\\delta = 1/2$ in `terminal_sub_turan` to get $f(n) \\le n^2/8 < n^2/4$ eventually — the terminal graph is asymptotically strictly below the Turán extremum.",
+    "mathContext": "$3/2 < 2$; $\\;\\forall \\alpha > 3/2: f(n) \\le n^\\alpha$ eventually; $\\;f(n) < n^2/4$ eventually",
+    "significance": "supporting",
+    "relatedConcepts": ["exponent gap", "BFL bound", "Turán density", "extremal graph theory"],
+    "prerequisites": ["bfl_exponent_is_three_halves axiom", "terminal_sub_turan with δ = 1/2"]
+  },
+  {
+    "id": "ann-e1155-oq06-no-lower-bound",
+    "proofId": "erdos-1155-oq-01-oq-06",
+    "range": { "startLine": 213, "endLine": 246 },
+    "type": "technique",
+    "title": "No Positive Turán Lower Bound: Proof by Contradiction",
+    "content": "`terminal_not_positive_turan_density` proves by contradiction: assume $\\exists c > 0$ with $c \\le \\mathrm{turanRatio}(n)$ eventually. Then from `turanRatio_tendsto_zero`, $\\mathrm{turanRatio}(n) < c/2$ eventually. Combining these two eventually-true statements (using `Filter.Eventually.and` implicitly via `(hlo.and hsmall).exists`) produces a specific $n$ where both hold simultaneously, giving $c \\le \\mathrm{turanRatio}(n) < c$ — a contradiction. `bipartite_cannot_be_turan_dense` then repackages this: no $c$ gives $c \\cdot n^2/4 \\le f(n)$ eventually, i.e., the terminal graph cannot be bounded below by any constant Turán fraction.",
+    "mathContext": "$\\nexists c > 0: c \\le \\mathrm{turanRatio}(n)$ eventually; equivalently, $\\nexists c > 0: c \\cdot (n^2/4) \\le f(n)$ eventually",
+    "significance": "key",
+    "relatedConcepts": ["proof by contradiction", "filter eventually", "Turán density lower bound", "sparse triangle-free graphs"],
+    "prerequisites": ["turanRatio_tendsto_zero", "Filter.Eventually.and", "le_div_iff₀"]
+  },
+  {
+    "id": "ann-e1155-oq06-open-questions",
+    "proofId": "erdos-1155-oq-01-oq-06",
+    "range": { "startLine": 251, "endLine": 292 },
+    "type": "concept",
+    "title": "Formalized Open Questions and Summary",
+    "content": "Section §6 takes the unusual step of defining the open questions as Lean `Prop` terms. `bipartitenessQuestion` formalizes 'the terminal graph is eventually bipartite' as a Filter statement: eventually $\\exists (A, B)$ partitioning $[n]$ such that all edges go between $A$ and $B$ and $f(n) \\le |A|\\cdot|B|$. `turanRatioMonotoneQuestion` asks whether $\\mathrm{turanRatio}$ is eventually monotone decreasing. Neither is proved — they remain open conjectures captured as formal Lean types. The `structural_summary` theorem bundles the three proved results (ratio $\\to 0$, exponent gap, no Turán lower bound) into a single conjunction.",
+    "mathContext": "$\\mathrm{bipartitenessQuestion}: \\exists^\\infty n, \\exists A, B \\subseteq [n]: A \\sqcup B = [n] \\land f(n) \\le |A|\\cdot|B|$",
+    "significance": "supporting",
+    "relatedConcepts": ["open question formalization", "bipartite graph", "chromatic number", "structural_summary"],
+    "prerequisites": ["Finset.univ", "Filter.atTop", "bipartite graph definition"]
+  }
+]

--- a/src/data/proofs/erdos-1155-oq-01-oq-06/index.ts
+++ b/src/data/proofs/erdos-1155-oq-01-oq-06/index.ts
@@ -1,0 +1,38 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/Erdos1155OQ01OQ06.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const erdos1155OQ01OQ06Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const erdos1155OQ01OQ06Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const erdos1155OQ01OQ06Data: ProofData = {
+  proof: erdos1155OQ01OQ06Proof,
+  annotations: erdos1155OQ01OQ06Annotations,
+}
+
+export default erdos1155OQ01OQ06Data

--- a/src/data/proofs/erdos-1155-oq-01-oq-06/meta.json
+++ b/src/data/proofs/erdos-1155-oq-01-oq-06/meta.json
@@ -1,0 +1,170 @@
+{
+  "id": "erdos-1155-oq-01-oq-06",
+  "title": "Erdős #1155 OQ-01-OQ-06: Terminal Graph Structure",
+  "slug": "erdos-1155-oq-01-oq-06",
+  "description": "Formalizes the structural distance of the terminal graph from the Turán optimum in the triangle removal process. The key result: the Turán ratio f(n)/(n²/4) → 0, proving the terminal graph is NOT asymptotically Turán-like despite being triangle-free. Proves 11 theorems (0 sorries) from 0 new axioms, including the vanishing Turán density theorem, the terminal graph's strict sub-Turán character, and formal open questions about bipartiteness.",
+  "meta": {
+    "author": "Formalized in Lean 4 (Mathlib)",
+    "sourceUrl": "https://erdosproblems.com/1155",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos1155OQ01OQ06.lean",
+    "dateAdded": "2026-04-04",
+    "tags": [
+      "erdos",
+      "triangle-removal",
+      "random-graphs",
+      "graph-structure",
+      "turan",
+      "combinatorics",
+      "graph-theory",
+      "extension",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.rpow_add",
+        "description": "Addition of real exponents: x^(p+q) = x^p * x^q for x > 0.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.rpow_le_rpow",
+        "description": "Monotonicity of real power: 0 ≤ x ≤ y → x^r ≤ y^r for r ≥ 0.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Real.rpow_natCast",
+        "description": "Compatibility: x^(n:ℝ) = x^n for natural number exponents.",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      },
+      {
+        "theorem": "Filter.Eventually.and",
+        "description": "Combine two eventually-true predicates.",
+        "module": "Mathlib.Order.Filter.Basic"
+      },
+      {
+        "theorem": "Metric.tendsto_atTop",
+        "description": "Characterize convergence via ε-N metric definition.",
+        "module": "Mathlib.Topology.MetricSpace.Basic"
+      }
+    ]
+  },
+  "sections": [
+    {
+      "id": "turan-framework",
+      "title": "The Turán Density Framework",
+      "summary": "Defines the Turán bound turanBound(n) = n²/4 (Mantel's extremal number for triangle-free graphs) and the Turán ratio turanRatio(n) = f(n)/(n²/4). The ratio measures how Turán-like the terminal graph is. Shows turanBound is positive for n ≥ 1 and turanRatio ≤ 1 (from the Mantel bound).",
+      "theorems": [
+        "turanBound_pos",
+        "triangleRemoval_le_turan",
+        "turanRatio_nonneg",
+        "turanRatio_le_one"
+      ]
+    },
+    {
+      "id": "main-structural-result",
+      "title": "Main Result: Terminal Graph Is Not Turán-Like",
+      "summary": "Proves the main structural theorem: for any δ > 0, eventually f(n) ≤ δ·(n²/4), and consequently turanRatio(n) → 0. The proof uses BFL (ε=1/4) to get f(n) ≤ n^{7/4}, then shows n^{7/4} ≤ δ·n²/4 for n ≥ (4/δ)^4, via the estimate n^{1/4} ≥ 4/δ.",
+      "theorems": [
+        "terminal_sub_turan",
+        "turanRatio_tendsto_zero"
+      ],
+      "mathContext": "Key identity: n^{7/4} = n^{1/4} · n^{3/2} and n² = n^{1/4} · n^{7/4} (both via Real.rpow_add). From (4/δ)^4 ≤ n, monotonicity gives n^{1/4} ≥ 4/δ, hence δ·n^{1/4}/4 ≥ 1, so n^{7/4} ≤ (δ·n^{1/4}/4)·n^{7/4} = δ·n²/4."
+    },
+    {
+      "id": "exponent-gap",
+      "title": "Exponent Gap: 3/2 vs 2",
+      "summary": "Formalizes the exponent-level distinction: the terminal graph has exponent 3/2 (BFL) while the Turán maximum has exponent 2 (Mantel). For any α ∈ (3/2, 2), eventually f(n) ≤ n^α. The terminal graph eventually has strictly fewer edges than the Turán bound.",
+      "theorems": [
+        "turan_exponent_gap",
+        "terminal_sub_power",
+        "terminal_not_turan_optimal"
+      ]
+    },
+    {
+      "id": "no-lower-bound",
+      "title": "No Positive Turán Fraction from Below",
+      "summary": "Proves that no constant c > 0 satisfies c·(n²/4) ≤ f(n) eventually. This is the contrapositive of Turán-likeness: the terminal graph cannot be bounded below by any fixed fraction of the Turán density. Equivalently, the turanRatio has no positive lower limit.",
+      "theorems": [
+        "terminal_not_positive_turan_density",
+        "bipartite_cannot_be_turan_dense"
+      ]
+    },
+    {
+      "id": "open-questions",
+      "title": "Open Questions: Bipartiteness and Structure",
+      "summary": "Formally states the bipartiteness question (Is the terminal graph bipartite?) and the Turán ratio monotonicity question. Being bipartite is compatible with the BFL scaling — a sparse bipartite graph can have n^{3/2} edges. The question is whether the random process produces bipartite graphs.",
+      "theorems": [
+        "structural_summary"
+      ]
+    }
+  ],
+  "overview": {
+    "background": "The triangle removal process on K_n terminates with a triangle-free graph G_∞. By Mantel's theorem (1907), any triangle-free graph has at most n²/4 edges, achieved by the complete bipartite Turán graph T(n,2) = K_{n/2,n/2}. The BFL result (2015) shows the terminal graph has only n^{3/2+o(1)} edges — much less than the Turán maximum.",
+    "mainResult": "The Turán ratio f(n)/(n²/4) → 0. This means the terminal graph achieves only a vanishing fraction of the maximum possible triangle-free edge density. Qualitatively: the random greedy triangle removal process does NOT produce Turán-like triangle-free graphs.",
+    "historicalContext": "The extremal theory of triangle-free graphs has roots in Mantel's 1907 theorem — the first Turán-type result — which showed the maximum number of edges in a triangle-free graph on $n$ vertices is $\\lfloor n^2/4 \\rfloor$, achieved uniquely by the balanced complete bipartite graph $K_{\\lfloor n/2 \\rfloor, \\lceil n/2 \\rceil}$. Turán (1941) generalized this to $K_{r+1}$-free graphs. The triangle removal process was introduced and studied by Bollobás, Erdős, and others in the context of random greedy graph processes. The decisive breakthrough came with Bohman, Frieze, and Lubetzky (BFL, 2015), who proved $f(n) = n^{3/2+o(1)}$ — far below the Turán maximum $n^2/4$. This entry formalizes the qualitative consequence: the random process terminates far from the Turán extremal structure, ruling out any notion of approximate bipartiteness at the Turán scale.",
+    "proofStrategy": "The main theorem `turanRatio_tendsto_zero` follows from `terminal_sub_turan`, which uses the BFL axiom with $\\varepsilon = 1/4$ to get $f(n) \\le n^{7/4}$ eventually, then proves $n^{7/4} \\le \\delta \\cdot n^2/4$ for $n \\ge (4/\\delta)^4$ via real power arithmetic: $n^{7/4} = n^{1/4} \\cdot n^{3/2}$ and $n^2 = n^{1/4} \\cdot n^{7/4}$ (both from `Real.rpow_add`), so the bound reduces to showing $n^{1/4} \\ge 4/\\delta$, which holds when $n \\ge (4/\\delta)^4$ by `Real.rpow_le_rpow`. The tendsto proof uses the $\\varepsilon$-$N$ characterization via `Metric.tendsto_atTop`.",
+    "keyInsights": [
+      "The BFL bound $f(n) \\le n^{3/2+\\varepsilon}$ combined with Mantel's bound $f(n) \\le n^2/4$ gives a dramatic exponent gap: $3/2$ versus $2$. The ratio $n^{3/2}/n^2 = n^{-1/2}$ goes to zero, explaining why the Turán ratio vanishes",
+      "The proof of `terminal_sub_turan` uses the algebraic decomposition $n^{7/4} = n^{1/4} \\cdot n^{3/2}$ and $n^2 = n^{1/4} \\cdot n^{7/4}$ to isolate the $n^{1/4}$ factor that can be made large, reducing the bound to a threshold estimate $n^{1/4} \\ge 4/\\delta$",
+      "The negative result `terminal_not_positive_turan_density` is proved by contradiction: if some $c > 0$ gave $c \\le \\mathrm{turanRatio}(n)$ eventually, that would contradict `turanRatio_tendsto_zero` (which gives turanRatio $< c/2$ eventually) — producing two eventually-true statements that eventually have opposite truth values",
+      "The file formally defines two still-open questions as Lean Prop terms (`bipartitenessQuestion`, `turanRatioMonotoneQuestion`), making them machine-checkable specifications that could in principle be proved or refuted in future work",
+      "All proved results are consequences of 5 axioms in the parent file (Erdos1155Problem.lean), notably the BFL bound. The 0-sorry count reflects that all derivable structural consequences are fully formalized — only the open questions remain as axioms"
+    ],
+    "significance": "This resolves the structural question of Turán-proximity in the negative. The terminal graph is 'sparse triangle-free' rather than 'dense triangle-free'. Any complete answer to the structural question (bipartiteness, chromatic number, degree distribution) must be consistent with this extreme sparsity relative to Turán.",
+    "openQuestion": "Whether the terminal graph is bipartite, approximately bipartite, or has some other specific structural property remains open. The vanishing Turán ratio is the principal structural fact currently known."
+  },
+  "conclusion": {
+    "summary": "294-line formalization proving 11 theorems (0 sorries) from 0 new axioms. The main result — Turán ratio f(n)/(n²/4) → 0 — is machine-verified using BFL bounds and real power arithmetic.",
+    "openQuestions": [
+      "Is the terminal graph of the triangle removal process bipartite (with high probability as n → ∞)?",
+      "What is the chromatic number of the terminal graph?",
+      "Is the Turán ratio f(n)/(n²/4) monotone decreasing in n?",
+      "Does the terminal graph have a specific degree distribution (e.g., approximately regular)?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "id": "erdos-1155",
+      "title": "Erdős #1155: Triangle Removal Process",
+      "relationship": "parent"
+    },
+    {
+      "id": "erdos-1155-oq-01",
+      "title": "Exact Asymptotics (Erdős Conjecture)",
+      "relationship": "sibling"
+    },
+    {
+      "id": "erdos-1155-oq-01-oq-01",
+      "title": "Convergence of f(n)/n^{3/2}",
+      "relationship": "sibling"
+    },
+    {
+      "id": "erdos-1155-oq-01-oq-07",
+      "title": "K_r-Removal Generalization",
+      "relationship": "sibling"
+    }
+  ],
+  "references": [
+    {
+      "authors": ["T. Bohman", "A. Frieze", "E. Lubetzky"],
+      "title": "Random triangle removal",
+      "year": "2015",
+      "note": "BFL result: f(n) = n^{3/2+o(1)}, the primary asymptotic input"
+    },
+    {
+      "authors": ["W. Mantel"],
+      "title": "Problem 28",
+      "year": "1907",
+      "note": "Mantel's theorem: triangle-free graphs have at most n²/4 edges"
+    },
+    {
+      "authors": ["P. Turán"],
+      "title": "On an extremal problem in graph theory",
+      "year": "1941",
+      "note": "Turán's theorem generalizing Mantel: K_{r+1}-free graphs have at most (1-1/(r))n²/2 edges"
+    }
+  ]
+}


### PR DESCRIPTION
Batch enrichment pass covering three unenriched gallery entries.

## Entry 1: divisibility-by-three-oq-02
- **10 annotations** covering all 8 parts (alternating block sums, repunits, palindromes)
- **8 sections** added (was empty)
- Highlights: 1001=7×11×13 insight, multiplicative order connection, digital root termination

## Entry 2: vietas-formulas-oq-03-oq-05 (Ferrari's Quartic)
- **7 annotations** covering all 6 parts (Vieta, 16-term discriminant, depressed quartic, Ferrari decomposition, 64× scaling, summary)
- **historicalContext**: Ferrari (1522–1565), Ars Magna (1545), Lagrange (1770), Abel–Ruffini
- **proofStrategy**: ring tactic for polynomial identities, linear_combination for resolvent condition
- **5 keyInsights** including 16→6 term collapse, Ferrari decomposition logic, 64× factor origin

## Entry 3: erdos-1155-oq-01-oq-06 (Terminal Graph Structure)
- **7 annotations** covering all 7 sections (Turán bound, ratio, main theorem, exponent gap, no lower bound, open questions)
- **historicalContext**: Mantel 1907, Turán 1941, BFL 2015
- **proofStrategy**: BFL + Real.rpow_add power arithmetic approach
- **5 keyInsights** including 3/2 vs 2 exponent gap, rpow decomposition trick, formalized open questions