### PR TITLE
fix(audit): correct leanFile.axiomCount for cantor-diagonalization-oq-02-oq-03-oq-02

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02/meta.json
@@ -64,7 +64,7 @@
   "leanFile": {
     "namespace": "FodorLemma",
     "lineCount": 280,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 5,
     "sorryCount": 1,


### PR DESCRIPTION
## Summary
- `leanFile.axiomCount` was set to 1 but the Lean file has 0 `axiom` declarations
- `find-targets.ts` uses `leanFile.axiomCount` when present (not `meta.axiomCount`)
- A prior fix (#9525) corrected `meta.axiomCount` but this field was missed

## Evidence
- `proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02.lean`: 0 lines matching `^axiom`
- `leanFile.axiomCount: 1` was incorrect — the 1 sorry is captured in `sorryCount: 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)