### PR TITLE
Add Aristotle companion for Fodor's pressing-down lemma

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -177,6 +177,7 @@ import Proofs.CantorDiagonalizationOQ02
 import Proofs.CantorDiagonalizationOQ02OQ01
 import Proofs.CantorDiagonalizationOQ02OQ03
 import Proofs.CantorDiagonalizationOQ02OQ03OQ02
+import Proofs.CantorDiagonalizationOQ02OQ03OQ02Aristotle
 import Proofs.CantorDiagonalizationOQ03
 import Proofs.CantorDiagonalizationOQ03OQ01
 import Proofs.CantorDiagonalizationOQ03OQ01Incomplete01

--- a/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02Aristotle.lean
+++ b/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02Aristotle.lean
@@ -1,0 +1,48 @@
+/-
+  Aristotle targets for CantorDiagonalizationOQ02OQ03OQ02 (Fodor's Pressing-Down Lemma)
+  Routine supporting lemmas for automated proof search.
+  See CantorDiagonalizationOQ02OQ03OQ02.lean for the main formalization.
+
+  Status: 1 sorry remaining — diagInter_isUnbounded
+
+  The sorry is the "unbounded" half of: the diagonal intersection of a
+  κ-indexed family of clubs is a club. The "closed" half is already proved.
+
+  Proof strategy for diagInter_isUnbounded:
+    Given α₀ < κ.ord, find β ∈ diagInter f with α₀ < β < κ.ord.
+    Build an ω-sequence by induction:
+      α_{n+1} ∈ ⋂_{β ≤ α_n} f(β) with α_n < α_{n+1} < κ.ord
+    Let α_ω = iSup(n, α_n). Then:
+    (a) α_ω < κ.ord: ℕ-many terms, each < κ.ord, and κ is regular
+        → Ordinal.iSup_lt_ord applies
+    (b) α_ω ∈ diagInter f: for any β < α_ω, pick n with β ≤ α_n;
+        then α_m for m > n are all in f(β) and increase to α_ω;
+        since f(β) is closed and α_ω is their limit, α_ω ∈ f(β).
+
+  Helper lemmas:
+  1. isClub_inter: finite intersection of clubs is a club
+  2. diagInter_isUnbounded_ari: the main sorry (exposed for Aristotle)
+-/
+import Mathlib
+import Proofs.CantorDiagonalizationOQ02OQ03OQ02
+
+namespace FodorLemmaAristotle
+
+open FodorLemma Cardinal Ordinal
+
+/-- The intersection of two clubs below κ.ord is itself a club.
+    Both components (unbounded and closed) pass to the intersection. -/
+lemma isClub_inter {κ : Cardinal} (hκ : κ.IsRegular) (hκ_unc : ℵ₀ < κ)
+    {C₁ C₂ : Set Ordinal}
+    (hC₁ : IsClub κ C₁) (hC₂ : IsClub κ C₂) :
+    IsClub κ (C₁ ∩ C₂) := by
+  sorry
+
+/-- The diagonal intersection of a κ-indexed family of clubs is unbounded
+    below κ.ord. This is the main sorry in the parent file. -/
+lemma diagInter_isUnbounded_ari {κ : Cardinal} (hκ : κ.IsRegular) (hκ_unc : ℵ₀ < κ)
+    {f : Ordinal → Set Ordinal} (hf : ∀ β, β < κ.ord → IsClub κ (f β)) :
+    IsUnboundedBelow κ (diagInter f) := by
+  sorry
+
+end FodorLemmaAristotle


### PR DESCRIPTION
## Fix

Adds `CantorDiagonalizationOQ02OQ03OQ02Aristotle.lean` companion file to expose
the remaining sorry in Fodor's Pressing-Down Lemma formalization.

## Evidence

**Before**: `CantorDiagonalizationOQ02OQ03OQ02.lean` had 1 remaining sorry
(`diagInter_isUnbounded`) with no Aristotle companion.

**After**: Two lemmas exposed to Aristotle:
- `isClub_inter` — the intersection of two clubs is a club (ping-pong argument)
- `diagInter_isUnbounded_ari` — the diagonal intersection of κ-many clubs is
  unbounded (uses `Ordinal.iSup_lt_ord` + regularity + club closedness)

The closed half of the diagonal intersection (`diagInter_isClosedBelow`) is
already proved. Completing `diagInter_isUnbounded` would close the last
gap before Fodor's lemma is fully machine-checked.

---
Automated fix by lean-mechanic agent.