### PR TITLE
Add Aristotle companion for Newton's inequality inductive step

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1921,6 +1921,7 @@ import Proofs.NavierStokes
 import Proofs.NewtonIndStep2
 import Proofs.NewtonInductiveStep
 import Proofs.NewtonInductiveStepOQ01
+import Proofs.NewtonInductiveStepOQ01Aristotle
 import Proofs.NewtonLogConcavity
 import Proofs.NthRootIrrational
 import Proofs.NthRootIrrationalOQ01

--- a/proofs/Proofs/NewtonInductiveStepOQ01Aristotle.lean
+++ b/proofs/Proofs/NewtonInductiveStepOQ01Aristotle.lean
@@ -1,0 +1,45 @@
+/-
+  Aristotle targets for NewtonInductiveStepOQ01 (Newton's Inequality for lists)
+  Routine algebraic lemma for automated proof search.
+  See NewtonInductiveStepOQ01.lean for the main formalization.
+
+  Status: 1 sorry remaining — newton_inequality_binomial
+
+  Newton's inequality for nonneg reals:
+    C(n,k-1) · C(n,k+1) · e_k² ≥ C(n,k)² · e_{k-1} · e_{k+1}
+
+  where e_k = esymm xs k is the k-th elementary symmetric polynomial of xs.
+
+  Proof strategy (induction on xs):
+  - Base case (nil or singleton): immediate from nonneg assumptions.
+  - Inductive step (x :: xs of length n+1):
+    Let E_k = esymm xs k, F_k = esymm (x::xs) k = E_k + x·E_{k-1}.
+    Key recurrences (esymm_cons_succ):
+      F_k = E_k + x·E_{k-1}
+      F_{k-1} = E_{k-1} + x·E_{k-2}
+      F_{k+1} = E_{k+1} + x·E_k
+    Need: C(n+1,k-1)·C(n+1,k+1)·F_k² ≥ C(n+1,k)²·F_{k-1}·F_{k+1}
+    Expand both sides using the recurrences, apply:
+      IH at k: C(n,k-1)·C(n,k+1)·E_k² ≥ C(n,k)²·E_{k-1}·E_{k+1}
+      IH at k-1: C(n,k-2)·C(n,k)·E_{k-1}² ≥ C(n,k-1)²·E_{k-2}·E_k
+      binom_log_concave: C(n,k)² ≥ C(n,k-1)·C(n,k+1)
+    The cross terms are non-negative (x ≥ 0, all E_k ≥ 0).
+-/
+import Mathlib
+import Proofs.NewtonInductiveStepOQ01
+
+namespace NewtonInductiveStepOQ01Aristotle
+
+open Nat Finset List
+
+/-- Newton's inequality (binomial form): for nonneg reals,
+    C(n,k-1)·C(n,k+1)·e_k² ≥ C(n,k)²·e_{k-1}·e_{k+1}. -/
+theorem newton_inequality_binomial_ari (xs : List ℝ)
+    (hxs : ∀ x ∈ xs, (0 : ℝ) ≤ x) (k : ℕ) (hk : 1 ≤ k) (hkn : k + 1 ≤ xs.length) :
+    (Nat.choose xs.length (k - 1) : ℝ) * (Nat.choose xs.length (k + 1) : ℝ) *
+    esymm xs k ^ 2 ≥
+    (Nat.choose xs.length k : ℝ) ^ 2 *
+    (esymm xs (k - 1) * esymm xs (k + 1)) := by
+  sorry
+
+end NewtonInductiveStepOQ01Aristotle


### PR DESCRIPTION
## Fix

Adds `NewtonInductiveStepOQ01Aristotle.lean` companion file to expose
the remaining sorry in the Newton's inequality formalization.

## Evidence

**Before**: `NewtonInductiveStepOQ01.lean` had 1 remaining sorry
(`newton_inequality_binomial`) with no Aristotle companion.

**After**: Exposed as `newton_inequality_binomial_ari` with full proof
strategy notes:
- Induction on list `xs` using `esymm_cons_succ` recurrence
- Apply induction hypothesis at both k and k-1
- Use `binom_log_concave` (already proved in parent file)
- Cross terms are non-negative (all x ≥ 0, all e_k ≥ 0)

This is a pure algebraic induction with all necessary lemmas already
in scope, making it a strong Aristotle candidate.

---
Automated fix by lean-mechanic agent.