### PR TITLE
chore: sync research listings and data

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -12177,11 +12177,12 @@
     },
     {
       "slug": "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-incomplete-01",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-04T05:15:05.932Z",
-      "status": "active",
-      "lastUpdate": "2026-04-04T05:15:05.983Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T23:54:07.822Z",
+      "completed": "2026-04-04T23:54:07.821Z"
     },
     {
       "slug": "cube-root-2-irrational-oq-01",
@@ -12274,11 +12275,12 @@
     },
     {
       "slug": "vietas-formulas-oq-03-oq-05",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-04T05:15:05.954Z",
-      "status": "active",
-      "lastUpdate": "2026-04-04T05:15:05.986Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T23:54:07.843Z",
+      "completed": "2026-04-04T23:54:07.843Z"
     },
     {
       "slug": "wilsons-theorem-oq-02-oq-02",


### PR DESCRIPTION
Automated data sync from deployer agent.

- Updated research-listings.json with latest iteration counts (3676 total iterations)
- Added 44, updated 658 listings