### PR TITLE
Enrich angle-trisection-cos-20-gal: Galois group of cos(20°)

### DIFF
--- a/src/data/proofs/angle-trisection-cos-20-gal/annotations.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-cos20-root-images",
+    "proofId": "angle-trisection-cos-20-gal",
+    "range": { "startLine": 40, "endLine": 62 },
+    "type": "theorem",
+    "title": "Algebraic Root Images: All Three Roots Expressible in α",
+    "content": "The three theorems root_image_beta, root_image_gamma, and quadratic_cofactor_root are pure ring identities verifiable by `ring`. They establish the key algebraic fact: if α satisfies 8α³ − 6α − 1 = 0, then β = 2α² − α − 1 and γ = 1 − 2α² are also roots of the same polynomial. The proofs have a uniform structure: expand the target expression algebraically to show it factors as (some polynomial) × (8a³ − 6a − 1), then substitute the hypothesis ha to get 0. This technique — expressing one polynomial relation as a multiple of another using `ring` — is the backbone of the entire splitting field argument.",
+    "mathContext": "Identities: $8(2\\alpha^2 - \\alpha - 1)^3 - 6(2\\alpha^2 - \\alpha - 1) - 1 = (8\\alpha^3 - 12\\alpha^2 + 3)(8\\alpha^3 - 6\\alpha - 1)$ and $8(1 - 2\\alpha^2)^3 - 6(1 - 2\\alpha^2) - 1 = (-8\\alpha^3 + 6\\alpha - 1)(8\\alpha^3 - 6\\alpha - 1)$. Both vanish when $8\\alpha^3 - 6\\alpha - 1 = 0$.",
+    "significance": "key",
+    "relatedConcepts": ["triple-angle formula", "polynomial factorization", "ring tactic", "root conjugates"],
+    "prerequisites": ["CommRing", "ring tactic in Lean 4", "cos(20°), cos(100°), cos(220°) as roots"]
+  },
+  {
+    "id": "ann-cos20-eisenstein",
+    "proofId": "angle-trisection-cos-20-gal",
+    "range": { "startLine": 111, "endLine": 149 },
+    "type": "theorem",
+    "title": "Eisenstein Criterion and Gauss's Lemma for Irreducibility",
+    "content": "The irreducibility proof proceeds in two steps. First, q_eis_int_irreducible applies the Eisenstein criterion to q = X³ − 6X² + 9X − 3 ∈ ℤ[X] at the prime p = 3: the lower coefficients (−6, 9, −3) are divisible by 3, the constant term (−3) is not divisible by 9, and the leading coefficient (1) is not divisible by 3. Mathlib's `Polynomial.irreducible_of_eisenstein_criterion` packages these conditions into a single application. Then q_eis_rat_irreducible lifts to ℚ[X] via `IsPrimitive.Int.irreducible_iff_irreducible_map_cast` — a formalization of Gauss's lemma: a primitive polynomial irreducible over ℤ is irreducible over ℚ.",
+    "mathContext": "Eisenstein at $p=3$: $q = X^3 - 6X^2 + 9X - 3$ satisfies $3 \\mid -6, 3 \\mid 9, 3 \\mid -3$; $9 \\nmid -3$; $3 \\nmid 1$. Hence $q$ is irreducible over $\\mathbb{Z}$. Gauss's lemma: $q$ is primitive (monic) so irreducibility transfers to $\\mathbb{Q}[X]$.",
+    "significance": "key",
+    "relatedConcepts": ["Eisenstein criterion", "Gauss's lemma", "Polynomial.irreducible_of_eisenstein_criterion", "IsPrimitive"],
+    "prerequisites": ["Ideal.span", "Polynomial.Irreducible", "Int.prime_iff_natAbs_prime"]
+  },
+  {
+    "id": "ann-cos20-irreducibility-transfer",
+    "proofId": "angle-trisection-cos-20-gal",
+    "range": { "startLine": 170, "endLine": 237 },
+    "type": "theorem",
+    "title": "Irreducibility Transfers Through Invertible Linear Substitution",
+    "content": "p_irreducible proves p = 8X³ − 6X − 1 is irreducible by reducing to irreducibility of q via the substitution ℓ: X ↦ 2X+2 (with inverse ℓ⁻¹: X ↦ X/2−1). The proof uses the definition of irreducibility directly (not a Mathlib lemma for substitution invariance): if p = a*b, then q = q.comp(ℓ.comp(ℓ⁻¹)) = q.comp(id) = q, and composing the factoring hab with ℓ⁻¹ gives q = (a.comp(ℓ⁻¹)) * (b.comp(ℓ⁻¹)), a factoring of q. Since q is irreducible, one factor is a unit, and the same unit lifts back to a or b via the inverse substitution. Both the ℓ.comp(ℓ⁻¹) = X and ℓ⁻¹.comp(ℓ) = X identities are checked by interval_cases on the coefficient index.",
+    "mathContext": "If $\\ell = 2X+2$ and $\\ell^{-1} = \\frac{X-2}{2}$, then $p = q \\circ \\ell$. Any factoring $p = ab$ gives $q = q \\circ (\\ell \\circ \\ell^{-1}) = (a \\circ \\ell^{-1}) \\cdot (b \\circ \\ell^{-1})$. Since $q$ is irreducible, one of $a \\circ \\ell^{-1}$, $b \\circ \\ell^{-1}$ is a unit constant $C(c)$, and composing back with $\\ell$ gives $a = C(c)$ or $b = C(c)$, hence a unit.",
+    "significance": "key",
+    "relatedConcepts": ["Polynomial.comp", "Polynomial.comp_assoc", "Polynomial.mul_comp", "invertible substitution"],
+    "prerequisites": ["q_eis_rat_irreducible", "q_comp_eq_p", "Polynomial.isUnit_iff"]
+  },
+  {
+    "id": "ann-cos20-gal-bounds",
+    "proofId": "angle-trisection-cos-20-gal",
+    "range": { "startLine": 290, "endLine": 311 },
+    "type": "theorem",
+    "title": "Divisibility Bounds: 3 ∣ |Gal| and |Gal| ∣ 6",
+    "content": "Two divisibility bounds pin |Gal| = 3 from above and below. The lower bound three_dvd_gal_card uses Polynomial.Gal.prime_degree_dvd_card: since p is irreducible of prime degree 3, the Galois group has order divisible by 3 (the degree equals the size of a Gal-orbit on roots, and the orbit size divides |Gal|). The upper bound gal_card_dvd_six uses the injective Galois action on roots: the rootSet has 3 elements (by card_rootSet_eq_natDegree applied to the separable degree-3 polynomial), so Gal embeds into Sym₃ = S₃ with |S₃| = 6. Together: 3 ∣ |Gal| and |Gal| ∣ 6, which with the degree-3 splitting field (proved separately) gives |Gal| = 3.",
+    "mathContext": "By Galois theory: $|\\text{Gal}(p/\\mathbb{Q})| = [\\text{SplittingField}(p) : \\mathbb{Q}]$ for separable $p$. Also $|\\text{Gal}| \\mid n! = 6$ (permutations of 3 roots) and $3 \\mid |\\text{Gal}|$ (irreducible of prime degree 3). Once $[\\text{SplittingField}:\\mathbb{Q}] = 3$ is established, $|\\text{Gal}| = 3$ follows directly.",
+    "significance": "supporting",
+    "relatedConcepts": ["Polynomial.Gal.prime_degree_dvd_card", "Polynomial.Gal.galActionHom_injective", "rootSet cardinality", "Sym₃"],
+    "prerequisites": ["p_irreducible", "p_separable", "Polynomial.card_rootSet_eq_natDegree", "Subgroup.card_dvd_of_injective"]
+  },
+  {
+    "id": "ann-cos20-splitting-field",
+    "proofId": "angle-trisection-cos-20-gal",
+    "range": { "startLine": 396, "endLine": 444 },
+    "type": "theorem",
+    "title": "Splitting Field Equals ℚ(α): Root Containment and Degree 3",
+    "content": "rootSet_subset_adjoin proves every root of p in the splitting field lies in ℚ(α). Given a root r, the factored form 8r³−6r−1 = 8(r−α)(r−β)(r−γ) (from factored_eval_eq) combined with r being a root gives 8(r−α)(r−β)(r−γ) = 0. Since the splitting field is a domain and 8 ≠ 0, one factor r−α, r−β, r−γ must be zero, so r ∈ {α, β, γ} ⊆ ℚ(α). Then adjoin_root_eq_top shows ℚ(α) = ⊤ (the whole splitting field) using Polynomial.SplittingField.adjoin_rootSet: the splitting field is generated by all roots, each of which is in ℚ(α). Combining with adjoin_finrank gives [SplittingField : ℚ] = 3.",
+    "mathContext": "The key fact: $\\{\\text{roots of } p\\} \\subseteq \\mathbb{Q}(\\alpha)$, so $\\mathbb{Q}(\\alpha) \\supseteq \\text{SplittingField}(p)$. But $\\mathbb{Q}(\\alpha) \\subseteq \\text{SplittingField}(p)$ always, so $\\mathbb{Q}(\\alpha) = \\text{SplittingField}(p)$ and $[\\text{SplittingField}:\\mathbb{Q}] = [\\mathbb{Q}(\\alpha):\\mathbb{Q}] = \\deg(\\text{minpoly}(\\alpha)) = 3$.",
+    "significance": "key",
+    "relatedConcepts": ["IntermediateField.adjoin", "SplittingField.adjoin_rootSet", "factored_eval_eq", "module finrank"],
+    "prerequisites": ["beta_in_adjoin", "gamma_in_adjoin", "factored_eval_eq", "minpoly_natDegree", "Polynomial.SplittingField"]
+  },
+  {
+    "id": "ann-cos20-main-theorem",
+    "proofId": "angle-trisection-cos-20-gal",
+    "range": { "startLine": 462, "endLine": 474 },
+    "type": "theorem",
+    "title": "Main Theorem: |Gal(8X³-6X-1/ℚ)| = 3",
+    "content": "The main theorem cos20_gal_card assembles all prior results. It invokes Polynomial.Gal.card_of_separable, which says |Gal(p/K)| = [SplittingField : K] for separable p. After converting Nat.card to Fintype.card, it rewrites with splitting_finrank to conclude |Gal| = 3. The companion theorem trisection_poly_irreducible exposes p_irreducible as a public interface. Together these eliminate the `cos20_gal_order` axiom that had been assumed in AngleTrisectionOQ02.lean, upgrading that result from axiomatized to verified.",
+    "mathContext": "For separable $p$: $|\\text{Gal}(p/\\mathbb{Q})| = [\\text{SplittingField}(p) : \\mathbb{Q}] = 3$. Since $\\text{Gal}(\\mathbb{Q}(\\cos 20°)/\\mathbb{Q}) \\cong \\mathbb{Z}/3\\mathbb{Z}$ has prime order, it is cyclic — there are no proper subgroups and no proper intermediate fields, confirming the extension $\\mathbb{Q} \\subset \\mathbb{Q}(\\cos 20°)$ is minimal.",
+    "significance": "key",
+    "relatedConcepts": ["Polynomial.Gal.card_of_separable", "cos20_gal_order axiom elimination", "AngleTrisectionOQ02", "ℤ/3ℤ Galois group"],
+    "prerequisites": ["splitting_finrank", "p_separable", "Nat.card_eq_fintype_card", "Polynomial.Gal.card_of_separable"]
+  }
+]

--- a/src/data/proofs/angle-trisection-cos-20-gal/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal/meta.json
@@ -33,7 +33,7 @@
     ]
   },
   "overview": {
-    "historicalContext": "The polynomial 8X³ − 6X − 1 arises from the triple-angle formula cos(3θ) = 4cos³θ − 3cosθ with θ = 20°, giving 4cos³(20°) − 3cos(20°) = cos(60°) = 1/2. Clearing denominators yields 8x³ − 6x − 1. The three roots are cos(20°), cos(100°), and cos(220°), corresponding to the three angles satisfying 3θ ≡ 60° (mod 360°). Since these three roots are the conjugates of a degree-3 irreducible over ℚ, the Galois group is a transitive subgroup of S₃ of order divisible by 3, hence it is the cyclic group ℤ/3ℤ of order 3. Wantzel (1837) used the irreducibility of this polynomial to prove that 60° cannot be trisected by compass and straightedge.",
+    "historicalContext": "The polynomial 8X³ − 6X − 1 arises from the triple-angle formula cos(3θ) = 4cos³θ − 3cosθ with θ = 20°: setting θ = 20° gives 4cos³(20°) − 3cos(20°) = cos(60°) = 1/2, and clearing denominators yields 8x³ − 6x − 1. The three roots cos(20°), cos(100°), cos(220°) correspond to the three angles 3θ ≡ 60° (mod 360°).\n\nPierre Wantzel (1837) was the first to prove rigorously that trisecting a 60° angle is impossible with compass and straightedge. His argument: a real number is constructible iff its minimal polynomial over ℚ has degree a power of 2. Since 8x³ − 6x − 1 is irreducible over ℚ (degree 3, not a power of 2), cos(20°) is not constructible, and 20° cannot be obtained from 60° by ruler-and-compass construction.\n\nÉvariste Galois (1832, published posthumously 1846) developed the theory connecting polynomial irreducibility to symmetry groups. The Galois group of 8x³ − 6x − 1 over ℚ is ℤ/3ℤ: cyclic of order 3, confirming the three roots are all conjugate and the extension ℚ ⊂ ℚ(cos 20°) has no proper intermediate fields. This file provides a complete Lean 4 machine-checked proof, eliminating the cos20_gal_order axiom previously assumed in AngleTrisectionOQ02.lean.",
     "problemStatement": "Determine |Gal(8X³ − 6X − 1 / ℚ)|. The key steps are: (1) prove 8X³ − 6X − 1 is irreducible over ℚ; (2) show all three roots lie in ℚ(α) for any root α, so the splitting field equals ℚ(α); (3) conclude [SplittingField : ℚ] = [ℚ(α) : ℚ] = 3 and hence |Gal| = 3.",
     "proofStrategy": "Irreducibility is proved by shifting: the substitution Y = 2X + 2 transforms 8X³ − 6X − 1 into X³ − 6X² + 9X − 3, which is Eisenstein at p = 3 (coefficients −6, 9, −3 divisible by 3; constant term −3 not divisible by 9; leading coefficient 1 not divisible by 3). Irreducibility transfers back via the invertible linear change of variables. For the Galois group: the key algebraic identities show that if α is a root then β = 2α² − α − 1 and γ = 1 − 2α² are also roots (verified by ring). Since all roots are polynomial expressions in α, adjoin(α) splits p, giving [SplittingField : ℚ] = 3. From this, |Gal| = 3 follows from Mathlib's Polynomial.Gal.card_of_separable.",
     "keyInsights": [
@@ -60,7 +60,43 @@
       "How does the Galois group structure change for the generalizations to other classical construction problems?"
     ]
   },
-  "sections": [],
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Background: Triple-Angle Formula and Proof Strategy",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "Module-level comment explaining that p = 8X³−6X−1 is the minimal polynomial of cos(20°), arising from cos(3×20°) = 1/2. States the two key algebraic identities showing β = 2α²−α−1 and γ = 1−2α² are the other roots. Cites Wantzel (1837) and describes how once all roots are in ℚ(α), the Galois group has order 3."
+    },
+    {
+      "id": "root-images",
+      "title": "Part I: Algebraic Identities — Root Images of α",
+      "startLine": 39,
+      "endLine": 62,
+      "summary": "Proves three ring identities (root_image_beta, root_image_gamma, quadratic_cofactor_root) establishing that if α is a root of 8x³−6x−1, then β = 2α²−α−1 and γ = 1−2α² are also roots. All proofs use the ring tactic to factor the identity as a product involving 8a³−6a−1, then substitute the root hypothesis."
+    },
+    {
+      "id": "polynomial-irred",
+      "title": "Parts II and II-B: Polynomial Properties and Irreducibility",
+      "startLine": 64,
+      "endLine": 237,
+      "summary": "Defines p = 8X³−6X−1 and proves its basic properties (degree, non-zero). The Eisenstein shift q = X³−6X²+9X−3 is introduced and proved irreducible over ℤ by Eisenstein's criterion at p=3, then over ℚ by Gauss's lemma. The substitution q(2X+2) = p is verified, and irreducibility transfers to p via the invertible linear change of variables (with explicit inverse X ↦ X/2−1 composed through comp_assoc)."
+    },
+    {
+      "id": "splitting-field",
+      "title": "Parts III–V: Splitting Field Analysis",
+      "startLine": 239,
+      "endLine": 455,
+      "summary": "Constructs root_in_sf (a root of p in the splitting field), verifies β and γ lie in ℚ(α) (as polynomial expressions), and proves the factored form 8a³−6a−1 = 8(a−α)(a−β)(a−γ). Uses this to show all roots of p are in ℚ(α) (rootSet_subset_adjoin), hence ℚ(α) = SplittingField (adjoin_root_eq_top). The finrank equals 3 because the minpoly of α has degree 3 (since p is irreducible and p(α) = 0). Also establishes the divisibility bounds 3 ∣ |Gal| ∣ 6."
+    },
+    {
+      "id": "main-theorem",
+      "title": "Part VI: Main Result — |Gal| = 3",
+      "startLine": 457,
+      "endLine": 474,
+      "summary": "cos20_gal_card: applies Polynomial.Gal.card_of_separable to conclude |Gal(8X³−6X−1/ℚ)| = [SplittingField:ℚ] = 3. Also exposes trisection_poly_irreducible as a public interface for the irreducibility of p. These results eliminate the cos20_gal_order axiom from AngleTrisectionOQ02.lean."
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "angle-trisection",


### PR DESCRIPTION
Enrichment pass for `angle-trisection-cos-20-gal` (|Gal(8X³-6X-1/ℚ)| = 3).

## Quality improvements

- **6 annotations** added covering all major parts of the 474-line proof:
  - Part I: Root image algebraic identities (β = 2α²−α−1, γ = 1−2α²)
  - Part II-B: Eisenstein criterion for q = X³−6X²+9X−3 at p=3 + Gauss's lemma
  - Irreducibility transfer through invertible linear substitution X ↦ 2X+2
  - Divisibility bounds 3 ∣ |Gal| and |Gal| ∣ 6
  - Splitting field = ℚ(α): root containment proof via factored form
  - Main theorem: cos20_gal_card via Polynomial.Gal.card_of_separable
- **5 sections** covering the full file structure
- **Expanded historicalContext** with Wantzel (1837), Galois (1832/1846), and axiom elimination context
- All annotations validated (0 errors for this proof)