### PR TITLE
Add Aristotle companion for Erdős Problem 35 (Plünnecke support)

### DIFF
--- a/proofs/Proofs/Erdos35ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos35ProblemAristotle.lean
@@ -1,0 +1,34 @@
+/-
+  Aristotle targets for Erdos35Problem
+  (Schnirelmann Density and Additive Bases: Plünnecke Inequality Support)
+  Routine supporting lemmas for automated proof search.
+  See Erdos35Problem.lean for the main formalization.
+
+  These lemmas provide building blocks for:
+  - The key algebraic bridge from Plünnecke's inequality to the Erdős conjecture
+  - Real-power monotonicity on the unit interval [0, 1]
+-/
+import Mathlib
+
+namespace Erdos35.Aristotle
+
+open Real
+
+/-- For α ∈ [0,1] and r ∈ [0,1], α^r ≥ α.
+    This holds because x ↦ α^x is decreasing when α ≤ 1 (log α ≤ 0),
+    so r ≤ 1 implies α^r ≥ α^1 = α. -/
+theorem rpow_ge_self_of_le_one (α : ℝ) (r : ℝ) (hα0 : 0 ≤ α) (hα1 : α ≤ 1)
+    (hr0 : 0 ≤ r) (hr1 : r ≤ 1) :
+    α ^ r ≥ α := by
+  sorry
+
+/-- Key algebraic step in deriving the Erdős conjecture from Plünnecke's inequality:
+    for α ∈ [0,1] and k ≥ 1, α^{1-1/k} ≥ α + α(1-α)/k.
+    This is a calculus exercise following from concavity of x ↦ x^r (r ∈ [0,1))
+    on [0,1], using the tangent-line bound at x = 1. -/
+theorem power_bound_implies_erdos_ari (α : ℝ) (k : ℕ) (hk : k ≥ 1)
+    (hα0 : 0 ≤ α) (hα1 : α ≤ 1) :
+    α ^ (1 - 1 / (k : ℝ)) ≥ α + α * (1 - α) / k := by
+  sorry
+
+end Erdos35.Aristotle


### PR DESCRIPTION
## Fix

Adds `Erdos35ProblemAristotle.lean` with 2 sorry targets for Aristotle automated proof search, supporting the Plünnecke inequality chain in `Erdos35Problem.lean`.

## Evidence

**Targets**:
- `rpow_ge_self_of_le_one`: For α ∈ [0,1] and r ∈ [0,1], α^r ≥ α. Follows from the fact that x ↦ α^x is decreasing when α ≤ 1 (log α ≤ 0), so r ≤ 1 implies α^r ≥ α^1 = α.
- `power_bound_implies_erdos_ari`: For α ∈ [0,1] and k ≥ 1, α^{1-1/k} ≥ α + α(1-α)/k. A calculus exercise using concavity of x^r on [0,1] for r ∈ [0,1).

**Pre-submission checklist** ✓:
- No `def ... := sorry`
- No `axiom` declarations
- No `theorem ... : True` placeholders
- No `/-!` docstring sections
- No open conjectures

---
Automated fix by lean-mechanic agent.