### PR TITLE
Enrich divisibility-by-three-oq-01: 6 annotations, 8 sections

### DIFF
--- a/src/data/proofs/divisibility-by-three-oq-01/annotations.json
+++ b/src/data/proofs/divisibility-by-three-oq-01/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-div3oq1-master-theorem",
+    "proofId": "divisibility-by-three-oq-01",
+    "range": { "startLine": 37, "endLine": 48 },
+    "type": "theorem",
+    "title": "The Master Theorem: d ∣ n ↔ d ∣ (n mod M) When d ∣ M",
+    "content": "dvd_iff_dvd_mod is the foundational theorem that unifies all 'last k digits' divisibility rules. The proof proceeds by Euclidean division: write n = M·(n/M) + (n mod M). If d | M, then d divides M·(n/M), so d | n iff d | (n mod M). The two directions are handled separately: for the forward direction, d | n combined with d | M·(n/M) gives d | (n mod M) by subtraction; for the reverse, d | (n mod M) combined with d | M·(n/M) gives d | n by addition (Nat.dvd_add). Every specific rule (2 via M=10, 4 via M=100, 8 via M=1000, 5 via M=10, etc.) is a one-line corollary with a concrete witness for d | M.",
+    "mathContext": "$d \\mid M \\Rightarrow (d \\mid n \\iff d \\mid (n \\bmod M))$. Proof: $n = M \\cdot \\lfloor n/M \\rfloor + (n \\bmod M)$, so $d \\mid n \\iff d \\mid (n \\bmod M)$ since $d \\mid M \\cdot \\lfloor n/M \\rfloor$.",
+    "significance": "key",
+    "relatedConcepts": ["Euclidean division", "Nat.dvd_add", "last-k-digit rule", "modular arithmetic"],
+    "prerequisites": ["Nat.div_add_mod", "Nat.dvd_of_mod_eq_zero", "dvd_mul_right"]
+  },
+  {
+    "id": "ann-div3oq1-power-families",
+    "proofId": "divisibility-by-three-oq-01",
+    "range": { "startLine": 113, "endLine": 118 },
+    "type": "theorem",
+    "title": "Infinite Power Families: 2^k and 5^k Divisibility Rules",
+    "content": "pow2_dvd_last_k and pow5_dvd_last_k capture infinite families of divisibility rules in single universally quantified statements. They follow from the factorization 10 = 2 × 5: since 10^k = (2×5)^k = 2^k × 5^k, both 2^k | 10^k and 5^k | 10^k hold. The master theorem then gives: 2^k | n ↔ 2^k | (n mod 10^k) and 5^k | n ↔ 5^k | (n mod 10^k). This simultaneously proves the k=1 (2 | last digit), k=2 (4 | last 2 digits), k=3 (8 | last 3 digits), and all higher cases as special instances of a single parametric theorem.",
+    "mathContext": "$2^k \\mid 10^k$ and $5^k \\mid 10^k$ follow from $10 = 2 \\times 5$, giving $10^k = 2^k \\cdot 5^k$. Hence $\\forall k, n.\\ 2^k \\mid n \\iff 2^k \\mid (n \\bmod 10^k)$, and similarly for $5^k$.",
+    "significance": "key",
+    "relatedConcepts": ["pow2_dvd_pow10", "pow5_dvd_pow10", "dvd_iff_dvd_mod", "parametric divisibility"],
+    "prerequisites": ["dvd_iff_dvd_mod", "mul_pow", "dvd_mul_right", "dvd_mul_left"]
+  },
+  {
+    "id": "ann-div3oq1-thirteen",
+    "proofId": "divisibility-by-three-oq-01",
+    "range": { "startLine": 129, "endLine": 148 },
+    "type": "theorem",
+    "title": "Divisibility by 13 via Truncation and IsCoprime",
+    "content": "thirteen_dvd_truncation proves the 'add 4 times the last digit' rule for 13: 13 | n ↔ 13 | (n/10 + 4·(n%10)). The key algebraic identity is 10(q + 4r) = n + 39r where n = 10q + r. The two directions use the same identity: in the forward direction, 13 | n and 13 | 39r (since 39 = 3·13) give 13 | 10(q+4r), then IsCoprime (13, 10) cancels the 10 factor. The coprimality argument (IsCoprime.dvd_of_dvd_mul_left) is the key tool: since gcd(13, 10) = 1, if 13 | 10·x then 13 | x. The proof works over ℤ to handle the subtraction cleanly.",
+    "mathContext": "$10(q + 4r) = 10q + 40r = n - r + 40r = n + 39r \\equiv n \\pmod{13}$ since $13 \\mid 39 = 3 \\times 13$. So $13 \\mid n \\iff 13 \\mid 10(q+4r) \\iff 13 \\mid (q+4r)$ by $\\gcd(13,10)=1$.",
+    "significance": "key",
+    "relatedConcepts": ["IsCoprime", "truncation method", "osculator", "push_cast", "omega"],
+    "prerequisites": ["IsCoprime.dvd_of_dvd_mul_left", "Euclidean division", "Int.dvd_sub"]
+  },
+  {
+    "id": "ann-div3oq1-digit-sum",
+    "proofId": "divisibility-by-three-oq-01",
+    "range": { "startLine": 161, "endLine": 163 },
+    "type": "theorem",
+    "title": "digitSum_dvd_iff: Unified Digit-Sum Framework via Mathlib",
+    "content": "digitSum_dvd_iff is the helper that unifies all digit-sum divisibility rules: d | n ↔ d | (digits b n).sum whenever b ≡ 1 (mod d). The proof uses Nat.modEq_digits_sum from Mathlib, which establishes n ≡ (digits b n).sum (mod d) when b ≡ 1 (mod d). The condition b ≡ 1 (mod d) makes each digit contribute with weight 1 in the position-value expansion: n = Σ aᵢ · bⁱ ≡ Σ aᵢ · 1ⁱ = Σ aᵢ (mod d). This theorem instantiates to: 37 (b=1000, since 1000 ≡ 1 mod 37), 99 (b=100), 999 (b=1000), 27 (b=1000), 7 in octal (b=8, 8 ≡ 1 mod 7), and more.",
+    "mathContext": "If $b \\equiv 1 \\pmod{d}$, then $b^k \\equiv 1 \\pmod{d}$ for all $k$, so $n = \\sum_k a_k b^k \\equiv \\sum_k a_k \\pmod{d}$ where $a_k$ are the base-$b$ digits of $n$. Hence $d \\mid n \\iff d \\mid \\sum_k a_k$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.modEq_digits_sum", "digit sum", "base representation", "Nat.digits", "ModEq"],
+    "prerequisites": ["Nat.ModEq.dvd_iff", "Nat.modEq_digits_sum", "native_decide for b%d=1"]
+  },
+  {
+    "id": "ann-div3oq1-digital-root",
+    "proofId": "divisibility-by-three-oq-01",
+    "range": { "startLine": 277, "endLine": 318 },
+    "type": "definition",
+    "title": "Digital Root: Definition and Complete Characterization",
+    "content": "digitalRoot n is defined as 0 if n = 0, 9 if n > 0 and 9 | n, and n mod 9 otherwise. This captures the iterative digit-summing process: repeatedly summing digits of any positive integer eventually reaches a single-digit value, which equals n mod 9 (except when 9 | n, in which case the sum converges to 9, not 0). The characterization theorem digitalRoot_eq_9_iff proves the equivalence with 9-divisibility. The connection to 3-divisibility (digitalRoot_mod3) shows that 3 | n iff 3 | digitalRoot n, since n mod 3 = digitalRoot n mod 3. The Lean proofs use split_ifs and omega for the case analysis.",
+    "mathContext": "$\\text{digitalRoot}(n) = \\begin{cases} 0 & n = 0 \\\\ 9 & 9 \\mid n,\\ n > 0 \\\\ n \\bmod 9 & \\text{otherwise} \\end{cases}$. For $n > 0$: $\\text{digitalRoot}(n) = 9 \\iff 9 \\mid n$; $\\text{digitalRoot}(n) \\bmod 3 = n \\bmod 3$.",
+    "significance": "supporting",
+    "relatedConcepts": ["digit sum", "modular arithmetic mod 9", "casting out nines", "recreational mathematics"],
+    "prerequisites": ["Nat.mod_eq_zero_of_dvd", "split_ifs tactic", "omega tactic"]
+  },
+  {
+    "id": "ann-div3oq1-coprime",
+    "proofId": "divisibility-by-three-oq-01",
+    "range": { "startLine": 337, "endLine": 373 },
+    "type": "theorem",
+    "title": "Coprime Factorization: Composite Divisibility via CRT",
+    "content": "coprime_mul_dvd_iff proves the general fact: if gcd(d₁, d₂) = 1, then d₁ × d₂ | n iff d₁ | n and d₂ | n. The forward direction is immediate from transitivity; the reverse uses Nat.Coprime.mul_dvd_of_dvd_of_dvd (the CRT direction). This theorem gives all composite rules as one-line corollaries: 6 = 2×3 (gcd=1), 12 = 4×3, 15 = 3×5, 18 = 2×9, 36 = 4×9, 45 = 9×5, 60 = 4×15, 90 = 9×10. The coprimality conditions are verified by native_decide — a pattern that handles the rote verification automatically while keeping the general theorem as the logical core.",
+    "mathContext": "$\\gcd(d_1, d_2) = 1 \\Rightarrow (d_1 d_2 \\mid n \\iff d_1 \\mid n \\land d_2 \\mid n)$. Chinese Remainder Theorem: coprime divisibility conditions combine multiplicatively. Example: $6 \\mid n \\iff 2 \\mid n \\land 3 \\mid n$ since $\\gcd(2,3)=1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Chinese Remainder Theorem", "Nat.Coprime", "native_decide", "composite divisibility"],
+    "prerequisites": ["Nat.Coprime.mul_dvd_of_dvd_of_dvd", "dvd_trans", "dvd_mul_right", "dvd_mul_left"]
+  }
+]

--- a/src/data/proofs/divisibility-by-three-oq-01/meta.json
+++ b/src/data/proofs/divisibility-by-three-oq-01/meta.json
@@ -55,7 +55,64 @@
       "Generalize casting out nines to arbitrary moduli: digit-sum mod d is preserved under addition and multiplication whenever b ≡ 1 (mod d)"
     ]
   },
-  "sections": [],
+  "sections": [
+    {
+      "id": "last-k-digits",
+      "title": "Part I: General Last-k-Digits Theorem",
+      "startLine": 24,
+      "endLine": 95,
+      "summary": "Establishes dvd_iff_dvd_mod — the master theorem unifying all last-k-digit divisibility rules. If d | M, then d | n iff d | (n mod M). Every specific rule (2 via M=10, 4 via M=100, 5 via M=10, 25 via M=100, etc.) is a one-line corollary. The proof uses Euclidean division n = M·(n/M) + (n mod M) and Nat.dvd_add."
+    },
+    {
+      "id": "power-families",
+      "title": "Part II: Infinite Power Families (2^k and 5^k)",
+      "startLine": 97,
+      "endLine": 118,
+      "summary": "Proves pow2_dvd_pow10 and pow5_dvd_pow10 (both 2^k | 10^k and 5^k | 10^k), then applies dvd_iff_dvd_mod to get the universally quantified pow2_dvd_last_k and pow5_dvd_last_k: for all k and n, 2^k | n iff 2^k | (n mod 10^k), and similarly for 5^k. One theorem simultaneously covers all rules for 2, 4, 8, 16, 32, 5, 25, 125."
+    },
+    {
+      "id": "divisibility-13",
+      "title": "Part III: Divisibility by 13 — Truncation Method",
+      "startLine": 120,
+      "endLine": 153,
+      "summary": "Proves thirteen_dvd_truncation: 13 | n iff 13 | (n/10 + 4·(n%10)). The algebraic key is 10(q + 4r) = n + 39r where n = 10q + r, so 13 | 10(q+4r) iff 13 | n. IsCoprime (13, 10) cancels the 10 factor: gcd(13,10) = 1 implies 13 | 10·x → 13 | x. The proof works over ℤ to handle signed subtraction cleanly."
+    },
+    {
+      "id": "digit-sum-rules",
+      "title": "Part IV: Digit-Sum Rules via Mathlib",
+      "startLine": 155,
+      "endLine": 216,
+      "summary": "Introduces digitSum_dvd_iff (d | n iff d | (digits b n).sum when b ≡ 1 mod d) using Nat.modEq_digits_sum. Applies to: 3 and 9 (base 10), 37 (base 1000 since 1000 ≡ 1 mod 37), 99 (base 100), 999 (base 1000), 27 (base 1000 since 27 | 999), and 7 in base 8 (8 ≡ 1 mod 7). Each rule collapses to a one-line native_decide verification of the base congruence."
+    },
+    {
+      "id": "casting-out-nines",
+      "title": "Part V: Casting Out Nines and Threes",
+      "startLine": 218,
+      "endLine": 268,
+      "summary": "Establishes casting_out_nines_add and casting_out_nines_mul: digit sums are preserved modulo 9 (and 3) under addition and multiplication. The general digit_sum_add_modEq and digit_sum_mul_modEq work for any base b and any d with b ≡ 1 (mod d). This formalizes the schoolroom error-detection technique: if digit_sum(a × b) ≢ digit_sum(a) × digit_sum(b) (mod 9), the multiplication is wrong."
+    },
+    {
+      "id": "digital-root",
+      "title": "Part VI: Digital Root Theory",
+      "startLine": 270,
+      "endLine": 330,
+      "summary": "Defines digitalRoot n (0 if n=0; 9 if n>0 and 9|n; n mod 9 otherwise) and proves its complete characterization: digitalRoot_le_9, digitalRoot_zero, digitalRoot_pos, digitalRoot_eq_9_iff (9 | n ↔ digitalRoot n = 9), and digitalRoot_mod3 (3 | n ↔ 3 | digitalRoot n). The implementation captures the fixed point of the digit-summing iteration without needing well-founded recursion."
+    },
+    {
+      "id": "coprime-factorization",
+      "title": "Part VII: Composite Rules via Coprime Factorization",
+      "startLine": 332,
+      "endLine": 373,
+      "summary": "Proves coprime_mul_dvd_iff: if gcd(d₁, d₂) = 1 then d₁ × d₂ | n iff d₁ | n and d₂ | n. Applies this via native_decide coprimality checks to give iff rules for 6=2×3, 12=4×3, 15=3×5, 18=2×9, 36=4×9, 45=5×9, 60=4×15, 90=9×10. Nat.Coprime.mul_dvd_of_dvd_of_dvd is the Mathlib tool for the Chinese Remainder direction."
+    },
+    {
+      "id": "truncation-7-11",
+      "title": "Part VIII: Truncation Methods for 7 and 11",
+      "startLine": 375,
+      "endLine": 550,
+      "summary": "Extends the truncation method beyond 13 to divisibility by 7 and 11. For 7: the osculator is −2 (subtract 2× last digit), proved via 10q + r → 7 | q − 2r iff 7 | 10q + r using IsCoprime (7, 10). For 11: the alternating digit sum rule uses 10 ≡ −1 (mod 11), so digits contribute with alternating ±1 weights. Includes combined rules using coprime factorization for products involving 7, such as 14, 21, and 77."
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "divisibility-rules",


### PR DESCRIPTION
## Summary

- Adds 6 annotations to `divisibility-by-three-oq-01` covering the master `dvd_iff_dvd_mod` theorem (last-k-digits unification), infinite 2^k/5^k power families, 13-truncation via `IsCoprime`, Mathlib digit-sum framework (`digitSum_dvd_iff`), digital root characterization, and CRT composite rules
- Adds 8 sections to `meta.json` mapping the full structure of the 550-line, 56-theorem proof: general last-k-digits, power families, divisibility by 13, digit-sum rules, casting out nines, digital root theory, coprime factorization, and truncation methods for 7 and 11

## Test plan

- [x] `pnpm annotations:build` — no errors for `divisibility-by-three-oq-01`
- [x] Annotations point to valid Lean construct lines (theorem/definition declarations)
- [x] All `mathContext`, `significance`, `relatedConcepts`, `prerequisites` fields populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)