### PR TITLE
Enrich spherical-law-of-cosines: 6 annotations, 6 sections

### DIFF
--- a/src/data/proofs/spherical-law-of-cosines/annotations.json
+++ b/src/data/proofs/spherical-law-of-cosines/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-slc-unit-vectors",
+    "proofId": "spherical-law-of-cosines",
+    "range": { "startLine": 45, "endLine": 69 },
+    "type": "definition",
+    "title": "IsUnitVec and Inner Product Bounds for Unit Vectors",
+    "content": "IsUnitVec v asserts ‖v‖ = 1, establishing the unit sphere S² as the ambient space. Three theorems follow immediately: inner_unit_self (⟨v,v⟩ = 1), inner_unit_le_one (|⟨u,v⟩| ≤ 1), and inner_unit_ge_neg_one (-1 ≤ ⟨u,v⟩). These bounds are essential for arccos to be well-defined: arccos is only defined on [-1, 1], so the proof that |⟨u,v⟩| ≤ 1 for unit u, v is not mere bookkeeping — it is the mathematical precondition that makes arc length well-defined. The proofs use abs_real_inner_le_norm and the Cauchy-Schwarz inequality via Mathlib's norm bounds.",
+    "mathContext": "$\\|v\\| = 1 \\Rightarrow |\\langle u, v \\rangle| \\leq \\|u\\|\\|v\\| = 1$ by Cauchy-Schwarz, so $\\langle u, v \\rangle \\in [-1, 1]$ and $\\arccos(\\langle u, v \\rangle)$ is well-defined.",
+    "significance": "supporting",
+    "relatedConcepts": ["Cauchy-Schwarz inequality", "unit sphere S²", "EuclideanSpace", "inner product space"],
+    "prerequisites": ["abs_real_inner_le_norm", "real_inner_self_eq_norm_mul_norm", "IsUnitVec"]
+  },
+  {
+    "id": "ann-slc-arc-length",
+    "proofId": "spherical-law-of-cosines",
+    "range": { "startLine": 81, "endLine": 110 },
+    "type": "definition",
+    "title": "Arc Length as Arccos of Inner Product: The Geodesic Distance on S²",
+    "content": "arcLength u v = Real.arccos ⟨u, v⟩ defines the geodesic distance on the unit sphere. The key theorem cos_arcLength recovers the inner product from the arc length: cos(arcLength u v) = ⟨u, v⟩. This is the bridge between the linear algebra world (inner products) and the trigonometric world (cosines of angles). It requires both bounds from the unit vector lemmas: Real.cos_arccos requires -1 ≤ ⟨u,v⟩ ≤ 1. The symmetry arcLength_comm follows from real_inner_comm. The self-distance arcLength_self = 0 uses arccos(1) = 0.",
+    "mathContext": "$d(u, v) = \\arccos(\\langle u, v \\rangle) \\in [0, \\pi]$. Recovery: $\\cos(d(u,v)) = \\langle u, v \\rangle$, valid since $\\langle u, v \\rangle \\in [-1,1]$ for unit vectors. This identifies arc length with the angle between vectors in $\\mathbb{R}^3$.",
+    "significance": "key",
+    "relatedConcepts": ["Real.arccos", "geodesic distance", "cos_arccos", "Riemannian geometry"],
+    "prerequisites": ["inner_unit_le_one", "inner_unit_ge_neg_one", "Real.cos_arccos", "Real.arccos_nonneg"]
+  },
+  {
+    "id": "ann-slc-inner-decomposition",
+    "proofId": "spherical-law-of-cosines",
+    "range": { "startLine": 193, "endLine": 201 },
+    "type": "theorem",
+    "title": "inner_decomposition: The Core Algebraic Identity",
+    "content": "inner_decomposition is the mathematical heart of the spherical law of cosines. For any unit vector n and arbitrary u, v: ⟨u,v⟩ = ⟨u,n⟩⟨v,n⟩ + ⟨proj⊥(u,n), proj⊥(v,n)⟩. This is just the Gram-Schmidt expansion: write u = ⟨u,n⟩·n + proj⊥(u,n) and v = ⟨v,n⟩·n + proj⊥(v,n), then expand the inner product using bilinearity. The cross terms ⟨⟨u,n⟩·n, proj⊥(v,n)⟩ vanish because proj⊥(v,n) ⊥ n by construction. The Lean proof uses simp with inner lemmas and closes with ring. The theorem holds for any three vectors — not just a specific triangle — making it maximally reusable.",
+    "mathContext": "$u = \\langle u,n \\rangle n + \\text{proj}_{n^\\perp}(u)$, so $\\langle u, v \\rangle = \\langle u,n \\rangle\\langle v,n \\rangle + \\langle \\text{proj}_{n^\\perp}(u), \\text{proj}_{n^\\perp}(v) \\rangle$ since $\\langle n, \\text{proj}_{n^\\perp}(v) \\rangle = 0$.",
+    "significance": "key",
+    "relatedConcepts": ["Gram-Schmidt decomposition", "orthogonal complement", "inner product bilinearity", "projectPerp"],
+    "prerequisites": ["inner_sub_left", "inner_sub_right", "inner_smul_right", "real_inner_self_eq_norm_mul_norm"]
+  },
+  {
+    "id": "ann-slc-projection-sin",
+    "proofId": "spherical-law-of-cosines",
+    "range": { "startLine": 228, "endLine": 238 },
+    "type": "theorem",
+    "title": "norm_projectPerp_eq_sin: Projection Norm via Pythagorean Identity and nlinarith",
+    "content": "norm_projectPerp_eq_sin proves ‖proj⊥(u,n)‖ = sin(arcLength(u,n)) for unit vectors. The path is: (1) norm_projectPerp_sq gives ‖proj⊥(u,n)‖² = 1 - ⟨u,n⟩²; (2) sin²(arcLength) = 1 - cos²(arcLength) = 1 - ⟨u,n⟩² by the Pythagorean identity and cos_arcLength; (3) both sides are nonneg, so their squares match. Step 3 requires extracting a nonneg square root from a square equality, which Lean cannot do with simp alone. The proof uses nlinarith with hints [sq_nonneg(‖proj⊥‖ - sin), sq_nonneg(‖proj⊥‖ + sin)] — a standard trick: (a-b)² ≥ 0 and (a+b)² ≥ 0 together with a² = b² and a,b ≥ 0 force a = b.",
+    "mathContext": "$\\|\\text{proj}_{n^\\perp}(u)\\|^2 = 1 - \\langle u,n\\rangle^2 = 1 - \\cos^2(d(u,n)) = \\sin^2(d(u,n))$. Since $\\|\\cdot\\| \\geq 0$ and $\\sin(d) \\geq 0$ for $d \\in [0,\\pi]$, taking nonneg square roots gives $\\|\\text{proj}_{n^\\perp}(u)\\| = \\sin(d(u,n))$.",
+    "significance": "key",
+    "relatedConcepts": ["Pythagorean identity", "Real.sin_sq", "nlinarith", "nonneg square root"],
+    "prerequisites": ["norm_projectPerp_sq", "Real.sin_sq", "cos_arcLength", "Real.sin_nonneg_of_nonneg_of_le_pi"]
+  },
+  {
+    "id": "ann-slc-algebraic",
+    "proofId": "spherical-law-of-cosines",
+    "range": { "startLine": 249, "endLine": 253 },
+    "type": "theorem",
+    "title": "spherical_law_of_cosines_algebraic: The Main Theorem via inner_decomposition",
+    "content": "spherical_law_of_cosines_algebraic is a one-line corollary of inner_decomposition: given unit A, B, C, it expresses ⟨A,B⟩ = ⟨A,C⟩⟨B,C⟩ + ⟨proj⊥(A,C), proj⊥(B,C)⟩. The Lean proof is literally 'exact inner_decomposition A B C hC'. The mathematical content: the inner product ⟨A,B⟩ = cos(c), the term ⟨A,C⟩⟨B,C⟩ = cos(b)·cos(a), and ⟨proj⊥(A,C), proj⊥(B,C)⟩ = ‖proj⊥(A,C)‖‖proj⊥(B,C)‖cos(C) = sin(b)·sin(a)·cos(C). This gives cos(c) = cos(a)cos(b) + sin(a)sin(b)cos(C) in the non-degenerate case.",
+    "mathContext": "$\\langle A, B \\rangle = \\langle A, C \\rangle \\langle B, C \\rangle + \\langle \\text{proj}_{C^\\perp}(A), \\text{proj}_{C^\\perp}(B) \\rangle$. Translating: $\\cos c = \\cos b \\cos a + \\sin b \\sin a \\cos C$.",
+    "significance": "key",
+    "relatedConcepts": ["inner_decomposition", "spherical triangle", "dihedral angle", "cos-c formula"],
+    "prerequisites": ["inner_decomposition", "IsUnitVec", "projectPerp"]
+  },
+  {
+    "id": "ann-slc-trig",
+    "proofId": "spherical-law-of-cosines",
+    "range": { "startLine": 262, "endLine": 267 },
+    "type": "theorem",
+    "title": "spherical_law_of_cosines_trig: The Theorem with SphericalTriangle Structure",
+    "content": "spherical_law_of_cosines_trig is the version using the SphericalTriangle structure, expressing cos(t.sideC) = cos(t.sideB) * cos(t.sideA) + ⟨proj⊥(A,C), proj⊥(B,C)⟩. It rewrites the sides using cos_sideA/B/C (which reduce to cos_arcLength) and then applies inner_decomposition. The statement uses the SphericalTriangle's field accessors rather than bare unit vectors, providing the interface intended for the gallery. The inner product cross term is left unexpanded — fully expanding to sin(a)·sin(b)·cos(C) would require the non-degeneracy condition ‖proj⊥(A,C)‖ ≠ 0 and ‖proj⊥(B,C)‖ ≠ 0, i.e., A ≠ C and B ≠ C, which is handled by the angleC definition's conditional.",
+    "mathContext": "$\\cos c = \\cos b \\cdot \\cos a + \\langle \\text{proj}_{C^\\perp}(A), \\text{proj}_{C^\\perp}(B) \\rangle$. In the non-degenerate case, the last term equals $\\sin b \\cdot \\sin a \\cdot \\cos C$ where $C$ is the dihedral angle.",
+    "significance": "key",
+    "relatedConcepts": ["SphericalTriangle", "cos_sideA", "dihedral angle", "spherical_law_of_cosines_algebraic"],
+    "prerequisites": ["cos_sideA", "cos_sideB", "cos_sideC", "inner_decomposition"]
+  }
+]

--- a/src/data/proofs/spherical-law-of-cosines/meta.json
+++ b/src/data/proofs/spherical-law-of-cosines/meta.json
@@ -30,7 +30,7 @@
     ]
   },
   "overview": {
-    "historicalContext": "The spherical law of cosines has been known since antiquity in the context of spherical trigonometry, which was developed for astronomical calculations. It appears in the work of Al-Battani (9th century) and was systematically treated by Regiomontanus (15th century). Isaac Todhunter's 1886 textbook 'Spherical Trigonometry' provides a comprehensive classical treatment. The theorem is the spherical analogue of the planar law of cosines (Wiedijk #94), reducing to it in the small-angle limit via the Taylor approximations cos θ ≈ 1 - θ²/2 and sin θ ≈ θ.",
+    "historicalContext": "The spherical law of cosines has been known since antiquity in the context of spherical trigonometry, which was developed for astronomical calculations. It appears in the work of Al-Battani (9th century CE), who used it for astronomical observations, and was systematically treated by Regiomontanus (15th century) in 'De Triangulis Omnimodis' (1464). Isaac Todhunter's 1886 textbook 'Spherical Trigonometry' provides a comprehensive classical treatment.\n\nThe theorem is the spherical analogue of the planar law of cosines (Wiedijk #94), reducing to it in the small-angle limit via the Taylor approximations cos θ ≈ 1 - θ²/2 and sin θ ≈ θ. In differential geometry, it is a special case of the Gauss equation for surfaces with constant Gaussian curvature K = 1.\n\nThe inner product formulation used here — ⟨A,B⟩ = ⟨A,C⟩⟨B,C⟩ + ⟨proj⊥(A,C), proj⊥(B,C)⟩ — is the modern algebraic perspective: the spherical law of cosines is really a statement about Gram-Schmidt decomposition in ℝ³ that happens to have a beautiful geometric interpretation on the unit sphere.",
     "problemStatement": "For a spherical triangle on the unit sphere S² with vertices A, B, C (unit vectors in ℝ³), let a = arcLength(B, C), b = arcLength(A, C), c = arcLength(A, B) be the arc-length sides, and let C denote the dihedral angle at vertex C between the planes OAC and OBC. Prove:\n\n  cos(c) = cos(a)·cos(b) + sin(a)·sin(b)·cos(C)\n\nIn the inner product formulation: ⟨A, B⟩ = ⟨A, C⟩⟨B, C⟩ + ⟨proj⊥(A, C), proj⊥(B, C)⟩.",
     "proofStrategy": "The core proof decomposes the inner product ⟨A, B⟩ using the unit vector C as a reference direction. Any vector u can be written as u = ⟨u, C⟩·C + proj⊥(u, C), where proj⊥(u, C) = u - ⟨u, C⟩·C is orthogonal to C. Then ⟨u, v⟩ = ⟨u, C⟩⟨v, C⟩ + ⟨proj⊥(u,C), proj⊥(v,C)⟩. The proof that ‖proj⊥(u, n)‖ = sin(arcLength(u, n)) uses the Pythagorean identity sin²θ + cos²θ = 1 and a nonlinear arithmetic argument via nlinarith. The trigonometric form then follows from cos(arcLength) = inner product for unit vectors.",
     "keyInsights": [
@@ -38,7 +38,8 @@
       "The perpendicular projection proj⊥(u, n) = u - ⟨u, n⟩·n is the standard Gram-Schmidt orthogonalization step; its norm equals sin(arcLength(u, n)) by the Pythagorean identity",
       "The inner_decomposition theorem is the key algebraic lemma: it holds for any unit vector n, not just C, making the proof modular and reusable",
       "The degenerate case (A = C, i.e., b = 0) is handled gracefully: proj⊥(C, C) = 0, so the cross term vanishes and the formula reduces to cos(c) = cos(a)·1 = cos(a), consistent with b = 0",
-      "The planar law of cosines emerges in the small-angle limit via Taylor expansion: 1 - c²/2 ≈ (1 - b²/2)(1 - a²/2) + ab·cos(C) simplifies to c² ≈ a² + b² - 2ab·cos(C)"
+      "The planar law of cosines emerges in the small-angle limit via Taylor expansion: 1 - c²/2 ≈ (1 - b²/2)(1 - a²/2) + ab·cos(C) simplifies to c² ≈ a² + b² - 2ab·cos(C)",
+      "The nlinarith tactic closes the norm = sin step by providing hints sq_nonneg(‖proj⊥‖ - sin) and sq_nonneg(‖proj⊥‖ + sin): from a² = b² and a,b ≥ 0, these hints let nlinarith infer (a-b)(a+b) = 0 with a+b > 0 unless both are 0, forcing a = b"
     ],
     "prerequisites": [
       "Inner product spaces and EuclideanSpace in Mathlib",
@@ -57,7 +58,50 @@
       "Connect to differential geometry: the spherical law of cosines as a special case of the Gauss equation for surfaces of constant curvature K = 1"
     ]
   },
-  "sections": [],
+  "sections": [
+    {
+      "id": "unit-vectors",
+      "title": "Part I: Unit Vectors in ℝ³",
+      "startLine": 37,
+      "endLine": 69,
+      "summary": "Defines Vec3 (EuclideanSpace ℝ (Fin 3)) and IsUnitVec (‖v‖ = 1). Establishes inner_unit_self (⟨v,v⟩ = 1), inner_unit_le_one (|⟨u,v⟩| ≤ 1), and inner_unit_ge_neg_one (-1 ≤ ⟨u,v⟩). These bounds are the domain preconditions for Real.arccos and are proved via abs_real_inner_le_norm (Cauchy-Schwarz)."
+    },
+    {
+      "id": "arc-length",
+      "title": "Part II: Arc Length on the Sphere",
+      "startLine": 71,
+      "endLine": 110,
+      "summary": "Defines arcLength u v = Real.arccos ⟨u,v⟩. Proves: nonneg, le_pi, cos_arcLength (cos(arcLength u v) = ⟨u,v⟩), arcLength_self = 0, and arcLength_comm. The key theorem cos_arcLength is the bridge between inner products and trigonometry, used throughout the rest of the file."
+    },
+    {
+      "id": "spherical-triangle",
+      "title": "Part III: Spherical Triangle Structure",
+      "startLine": 112,
+      "endLine": 153,
+      "summary": "Defines SphericalTriangle with unit vertices A, B, C and noncomputable sides sideA = arcLength B C, sideB = arcLength A C, sideC = arcLength A B. Proves cos_sideA/B/C reducing each to cos_arcLength. These accessors connect the geometric (triangle) language to the algebraic (inner product) calculations."
+    },
+    {
+      "id": "dihedral-angle",
+      "title": "Part IV: Perpendicular Projection and Dihedral Angle",
+      "startLine": 155,
+      "endLine": 174,
+      "summary": "Defines projectPerp v n = v - ⟨v,n⟩·n (the Gram-Schmidt orthogonalization step). Defines SphericalTriangle.angleC as the arccos of the normalized inner product of projA and projB, with a degenerate case (projections zero → angle 0). The dihedral angle at C is the angle in the plane perpendicular to C between the half-great-circles to A and B."
+    },
+    {
+      "id": "main-theorems",
+      "title": "Part V: The Spherical Law of Cosines",
+      "startLine": 176,
+      "endLine": 267,
+      "summary": "The mathematical core. inner_decomposition proves the key bilinear identity: ⟨u,v⟩ = ⟨u,n⟩⟨v,n⟩ + ⟨proj⊥(u,n),proj⊥(v,n)⟩. norm_projectPerp_eq_sin proves ‖proj⊥(u,n)‖ = sin(arcLength(u,n)) via nlinarith. spherical_law_of_cosines_algebraic and spherical_law_of_cosines_trig give the main theorem in inner-product and SphericalTriangle notation respectively."
+    },
+    {
+      "id": "properties-degenerate",
+      "title": "Part VI–VII: Properties, Degenerate Cases, and Small-Angle Limit",
+      "startLine": 269,
+      "endLine": 341,
+      "summary": "Covers symmetry of the decomposition (inner_decomposition_comm), degenerate triangle handling (projectPerp_self shows proj⊥(C,C) = 0, degenerate_triangle_sideB_zero), and the planar_law_of_cosines statement as documentation of the small-angle limit cos(c) = cos(a)cos(b) + sin(a)sin(b)cos(C) → c² = a² + b² - 2ab·cos(C) via Taylor approximation."
+    }
+  ],
   "crossReferences": [
     {
       "targetId": "law-of-cosines",


### PR DESCRIPTION
## Summary

- Adds 6 annotations covering: unit vector inner product bounds (Cauchy-Schwarz), arc length as arccos of inner product, `inner_decomposition` (core Gram-Schmidt bilinear identity), `norm_projectPerp_eq_sin` (nlinarith proof via sq_nonneg hints), and both algebraic + trigonometric forms of the main theorem
- Adds 6 sections mapping the full 341-line proof: unit vectors, arc length, spherical triangle structure, dihedral angle, main theorems, and degenerate cases/small-angle limit
- Expands `historicalContext` with Al-Battani (9th century), Regiomontanus (1464), and the modern inner product perspective on Gram-Schmidt decomposition

## Test plan

- [x] `pnpm annotations:build` — no errors for `spherical-law-of-cosines`
- [x] All 6 annotations point to valid Lean construct lines (def/theorem declarations)
- [x] `mathContext`, `significance`, `relatedConcepts`, `prerequisites` fields populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)