### PR TITLE
Add Aristotle companion for Glaisher bijection (PartitionTheoremOQ04)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1940,6 +1940,7 @@ import Proofs.PartitionTheorem
 import Proofs.PartitionTheoremOQ01
 import Proofs.PartitionTheoremOQ03
 import Proofs.PartitionTheoremOQ04
+import Proofs.PartitionTheoremOQ04Aristotle
 import Proofs.PascalsHexagon
 import Proofs.PellEquation
 import Proofs.PellEquationOQ01

--- a/proofs/Proofs/PartitionTheoremOQ04Aristotle.lean
+++ b/proofs/Proofs/PartitionTheoremOQ04Aristotle.lean
@@ -1,0 +1,46 @@
+/-
+  Aristotle targets for Glaisher Bijection (PartitionTheoremOQ04)
+  Routine bijectivity lemmas for automated proof search.
+  See PartitionTheoremOQ04.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT an open conjecture — Euler's Partition Theorem is classical (proved 1748)
+  - ROUTINE: the inverse property of the Glaisher maps follows from proved infrastructure
+  - Infrastructure already proved in PartitionTheoremOQ04.lean:
+      glaisherBwdStep_count_pow, testBit_sum_distinct_pow,
+      glaisherBwdStep_pow_two, glaisherFwdPart_parts_odd
+  - No axioms, no definition sorries
+
+  Target: glaisherBwd_glaisherFwd_ari
+    For any distinct positive multiset s:
+      glaisherBwd (glaisherFwd s) = s
+
+    Proof approach (count-based):
+    For each k ∈ s with a = padicValNat 2 k and b = k/2^a (odd part):
+      count k (glaisherBwd (glaisherFwd s))
+      = count k (glaisherBwdStep b (count b (glaisherFwd s)))
+        [only the b-thread contributes since 2^a*b = k uniquely]
+      = testBit (count b (glaisherFwd s)) a
+        [by glaisherBwdStep_count_pow]
+      = testBit (Σ_{k'∈s, oddPart k'=b} 2^(padicValNat 2 k')) a
+        [by count_bind and glaisherFwdPart definition]
+      = decide (k ∈ s)
+        [by testBit_sum_distinct_pow, since nodup guarantees distinct valuations]
+-/
+import Mathlib
+import Proofs.PartitionTheoremOQ04
+
+namespace GlaisherBijectionAristotle
+
+open GlaisherBijection Nat
+
+/-
+  The inverse property: backward ∘ forward = identity on distinct positive multisets.
+  Uses count characterization proved via glaisherBwdStep_count_pow and testBit_sum_distinct_pow.
+-/
+theorem glaisherBwd_glaisherFwd_ari {s : Multiset ℕ}
+    (hs_pos : ∀ k ∈ s, k ≠ 0) (hs_nodup : s.Nodup) :
+    glaisherBwd (glaisherFwd s) = s := by
+  sorry
+
+end GlaisherBijectionAristotle


### PR DESCRIPTION
## Fix

Creates Aristotle companion file for the Glaisher bijection proof, targeting the inverse property needed for Euler's Partition Theorem.

## Evidence

**Before**: `PartitionTheoremOQ04.lean` has 2 sorries with no Aristotle companion:
- `glaisherBwd_glaisherFwd` — inverse property: `glaisherBwd (glaisherFwd s) = s` for distinct positive multisets
- `glaisher_bijection_exists` — constructive bijection between distinct and odd partitions

**After**: `PartitionTheoremOQ04Aristotle.lean` provides the target theorem for Aristotle proof search with full proof strategy documentation. The infrastructure for the proof is already complete in the main file (`glaisherBwdStep_count_pow`, `testBit_sum_distinct_pow`, `glaisherBwdStep_pow_two`).

## Mathematical Context

The Glaisher bijection (1883) is the standard constructive proof of Euler's Partition Theorem (1748): the number of partitions into distinct parts equals the number into odd parts. The inverse property follows from a count-based argument using bit manipulation lemmas already proved.

## Pre-submission Checklist

- [x] No `def ... := sorry` (definition sorries)
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections
- [x] No open conjectures (Euler's Partition Theorem is classical)

---
Automated fix by lean-mechanic agent.