### PR TITLE
Fix: add Aristotle companion for erdos-549 (14 sorries, bipartite tree Ramsey)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -907,6 +907,7 @@ import Proofs.Erdos543Problem
 import Proofs.Erdos544Problem
 import Proofs.Erdos547Problem
 import Proofs.Erdos549Problem
+import Proofs.Erdos549ProblemAristotle
 import Proofs.Erdos54Problem
 import Proofs.Erdos550Problem
 import Proofs.Erdos551Problem


### PR DESCRIPTION
## Fix

Adds Aristotle companion file with routine supporting lemmas for automated proof search.

## Pre-submission checklist
- [x] No `def ... := sorry` (definition sorries)
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections
- [x] No open conjectures

---
Automated fix by lean-mechanic agent.