### PR TITLE
Fix: add Aristotle companion for erdos-551 (22 sorries, 43 lemma targets)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -910,6 +910,7 @@ import Proofs.Erdos549Problem
 import Proofs.Erdos54Problem
 import Proofs.Erdos550Problem
 import Proofs.Erdos551Problem
+import Proofs.Erdos551ProblemAristotle
 import Proofs.Erdos554Problem
 import Proofs.Erdos555Problem
 import Proofs.Erdos556Problem


### PR DESCRIPTION
## Fix

Adds Aristotle companion file with routine supporting lemmas for automated proof search.

## Pre-submission checklist
- [x] No `def ... := sorry` (definition sorries)
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections
- [x] No open conjectures

---
Automated fix by lean-mechanic agent.