### PR TITLE
Fix: add Aristotle companion for erdos-552 (5 routine graph theory targets)

### DIFF
--- a/proofs/Proofs/Stubs/Erdos552Aristotle.lean
+++ b/proofs/Proofs/Stubs/Erdos552Aristotle.lean
@@ -1,0 +1,66 @@
+/-
+  Aristotle targets for Erdős Problem #552
+  Routine supporting lemmas for automated proof search.
+  See Erdos552Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main results (Parsons, BEFRS bounds — deep graph theory)
+  - Routine supporting facts: degree counts for specific graphs, basic graph properties
+  - No definition sorries
+  - No axioms
+-/
+import Mathlib
+
+namespace Erdos552Aristotle
+
+open SimpleGraph Finset
+
+/-- The cycle graph C_n. -/
+def cycleGraph (n : ℕ) : SimpleGraph (Fin n) where
+  Adj := fun i j => (i.val + 1) % n = j.val ∨ (j.val + 1) % n = i.val
+  symm := by intro i j h; cases h <;> [right; left] <;> assumption
+  loopless := by intro i h; cases h with | inl h => simp at h; omega | inr h => simp at h; omega
+
+/-- C4 is the 4-cycle. -/
+def C4 : SimpleGraph (Fin 4) := cycleGraph 4
+
+/-- The star graph K_{1,n}: center at 0, leaves at 1..n. -/
+def starGraph (n : ℕ) : SimpleGraph (Fin (n + 1)) where
+  Adj := fun i j => (i.val = 0 ∧ j.val ≠ 0) ∨ (j.val = 0 ∧ i.val ≠ 0)
+  symm := by intro i j h; cases h with | inl h => right; exact ⟨h.1, h.2⟩ | inr h => left; exact ⟨h.1, h.2⟩
+  loopless := by intro i h; cases h <;> omega
+
+/-- The complement of a graph. -/
+def complement {V : Type*} (G : SimpleGraph V) : SimpleGraph V where
+  Adj := fun u v => u ≠ v ∧ ¬G.Adj u v
+  symm := by intro u v ⟨hne, hadj⟩; exact ⟨hne.symm, fun h => hadj (G.symm h)⟩
+  loopless := by intro v ⟨hne, _⟩; exact hne rfl
+
+-- Routine: C4 is 2-regular: every vertex in the 4-cycle has degree 2.
+theorem C4_is_2_regular : ∀ v : Fin 4, (C4.neighborFinset v).card = 2 := by
+  sorry
+
+-- Routine: The center of S_n has degree n.
+-- Vertex 0 is adjacent to all n leaf vertices 1, ..., n.
+theorem starGraph_center_degree (n : ℕ) :
+    ((starGraph n).neighborFinset ⟨0, Nat.zero_lt_succ n⟩).card = n := by
+  sorry
+
+-- Routine: Each leaf of S_n has degree 1.
+-- Each non-center vertex is adjacent only to vertex 0.
+theorem starGraph_leaf_degree (n : ℕ) (i : Fin (n + 1)) (hi : i.val ≠ 0) :
+    ((starGraph n).neighborFinset i).card = 1 := by
+  sorry
+
+-- Routine: The complement graph is symmetric.
+-- If u ≠ v and G.Adj u v is false, then v ≠ u and G.Adj v u is false.
+theorem complement_symm {V : Type*} (G : SimpleGraph V) (u v : V)
+    (h : (complement G).Adj u v) : (complement G).Adj v u := by
+  sorry
+
+-- Routine: Cyclegraph on n ≥ 1 vertices is nonempty (has at least one vertex).
+-- Fin n is nonempty when n ≥ 1.
+theorem cycleGraph_nonempty (n : ℕ) (hn : n ≥ 1) : Nonempty (Fin n) := by
+  sorry
+
+end Erdos552Aristotle


### PR DESCRIPTION
## Fix

Adds Aristotle companion file with routine supporting lemmas for automated proof search.

## Pre-submission checklist
- [x] No `def ... := sorry` (definition sorries)
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections
- [x] No open conjectures

---
Automated fix by lean-mechanic agent.