### PR TITLE
Add Aristotle companion for Erdős #695 (prime chain growth)

### DIFF
--- a/proofs/Proofs/Erdos695Aristotle.lean
+++ b/proofs/Proofs/Erdos695Aristotle.lean
@@ -1,0 +1,101 @@
+/-
+  Aristotle targets for Erdos695 (Prime Chain Growth)
+  Routine supporting lemmas for automated proof search.
+  See Erdos695Problem.lean for the main formalization.
+
+  These lemmas provide building blocks for prime chain analysis:
+  - IsPrimeChain and ChainDivisibility basic properties
+  - Prime chain monotonicity and lower bounds
+  - Real.rpow helpers for p_k^(1/k) → ∞
+  - Dirichlet's theorem consequence (prime congruent to 1)
+  - Arithmetic in prime chains
+-/
+import Mathlib
+
+open Filter Finset Real
+
+namespace Erdos695.Aristotle
+
+/-
+  ## Section 1: IsPrimeChain Properties
+-/
+
+def IsPrimeChain (p : ℕ → ℕ) : Prop :=
+  StrictMono p ∧ (∀ i, (p i).Prime) ∧ (∀ i, p (i + 1) % p i = 1)
+
+/-- Prime chains are strictly increasing -/
+lemma primeChain_strictMono (p : ℕ → ℕ) (h : IsPrimeChain p) : StrictMono p := by
+  sorry
+
+/-- All elements of a prime chain are prime -/
+lemma primeChain_all_prime (p : ℕ → ℕ) (h : IsPrimeChain p) (i : ℕ) : (p i).Prime := by
+  sorry
+
+/-- All elements of a prime chain are ≥ 2 -/
+lemma primeChain_ge_two (p : ℕ → ℕ) (h : IsPrimeChain p) (i : ℕ) : p i ≥ 2 := by
+  sorry
+
+/-- p(i+1) > p(i) in a prime chain -/
+lemma primeChain_next_gt (p : ℕ → ℕ) (h : IsPrimeChain p) (i : ℕ) : p (i + 1) > p i := by
+  sorry
+
+/-- p(i+1) ≥ p(i) + p(i) = 2*p(i) in a prime chain (since p(i) | p(i+1)-1) -/
+lemma primeChain_next_ge_double (p : ℕ → ℕ) (h : IsPrimeChain p) (i : ℕ) :
+    p (i + 1) ≥ p i + 1 := by
+  sorry
+
+/-
+  ## Section 2: ChainDivisibility
+-/
+
+def ChainDivisibility (p : ℕ → ℕ) : Prop :=
+  ∀ i, p i ∣ (p (i + 1) - 1)
+
+/-- If p(i+1) % p(i) = 1 then p(i) | p(i+1) - 1 -/
+lemma mod_one_implies_dvd (p q : ℕ) (h : q % p = 1) (hq : q ≥ 1) : p ∣ q - 1 := by
+  sorry
+
+/-- Chain congruence implies divisibility -/
+lemma chain_cong_to_dvd (p : ℕ → ℕ) (hprime : ∀ i, (p i).Prime)
+    (hcong : ∀ i, p (i + 1) % p i = 1) : ChainDivisibility p := by
+  sorry
+
+/-
+  ## Section 3: Real.rpow Helpers for Growth Rate
+-/
+
+/-- p^(1/k) → ∞ iff p grows super-exponentially -/
+lemma rpow_tendsto_atTop_iff (p : ℕ → ℕ) :
+    Filter.Tendsto (fun k => (p k : ℝ) ^ (1 / (k : ℝ))) Filter.atTop Filter.atTop ↔
+    ∀ c : ℝ, c > 1 → ∀ᶠ k in Filter.atTop, (p k : ℝ) > c ^ k := by
+  sorry
+
+/-- For c > 1, c^k → ∞ -/
+lemma pow_tendsto_atTop (c : ℝ) (hc : c > 1) :
+    Filter.Tendsto (fun k : ℕ => c ^ k) Filter.atTop Filter.atTop := by
+  sorry
+
+/-- rpow is monotone: if a ≤ b and r ≥ 0 then a^r ≤ b^r -/
+lemma rpow_mono (a b : ℝ) (r : ℝ) (ha : 0 ≤ a) (hr : 0 ≤ r) (h : a ≤ b) :
+    a ^ r ≤ b ^ r := by
+  sorry
+
+/-- (p k : ℝ)^(1/k) ≥ 2 for k ≥ 1 when p k ≥ 2^k -/
+lemma rpow_ge_two_of_exp_bound (p : ℕ → ℕ) (k : ℕ) (hk : k ≥ 1)
+    (h : p k ≥ 2 ^ k) : (p k : ℝ) ^ (1 / (k : ℝ)) ≥ 2 := by
+  sorry
+
+/-
+  ## Section 4: Dirichlet Consequence
+-/
+
+/-- For any prime p, there exists a prime q with q ≡ 1 (mod p) -/
+lemma prime_cong_one_exists (p : ℕ) (hp : p.Prime) : ∃ q : ℕ, q.Prime ∧ q % p = 1 := by
+  sorry
+
+/-- The smallest prime ≡ 1 (mod p) is > p -/
+lemma smallest_cong_prime_gt (p : ℕ) (hp : p.Prime) (q : ℕ) (hq : q.Prime)
+    (hmod : q % p = 1) : q > p := by
+  sorry
+
+end Erdos695.Aristotle


### PR DESCRIPTION
## Fix

Adds Aristotle companion file with routine supporting lemmas for automated proof search.

## Pre-submission checklist
- [x] No `def ... := sorry` (definition sorries)
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections
- [x] No open conjectures

---
Automated fix by lean-mechanic agent.