### PR TITLE
Fix: add Aristotle companion for erdos-715 (5 routine lemma targets)

### DIFF
--- a/proofs/Proofs/Stubs/Erdos715Aristotle.lean
+++ b/proofs/Proofs/Stubs/Erdos715Aristotle.lean
@@ -1,0 +1,77 @@
+/-
+  Aristotle targets for Erdős Problem #715
+  Routine supporting lemmas for automated proof search.
+  See Erdos715Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main results (Tashkinov, AFK — deep graph theory)
+  - Routine supporting facts: degree bounds, edge counting, specific small graphs
+  - No definition sorries
+  - No axioms
+-/
+import Mathlib
+
+namespace Erdos715Aristotle
+
+open Finset Fintype
+
+/-- A simple graph represented by adjacency -/
+structure SimpleGraph' (V : Type*) where
+  adj : V → V → Prop
+  symm : ∀ u v, adj u v → adj v u
+  loopless : ∀ v, ¬adj v v
+
+/-- The degree of a vertex -/
+def degree {V : Type*} [Fintype V] [DecidableEq V]
+    (G : SimpleGraph' V) [DecidableRel G.adj] (v : V) : ℕ :=
+  (Finset.filter (fun u => G.adj v u) Finset.univ).card
+
+/-- A graph is r-regular if every vertex has degree r -/
+def IsRegular {V : Type*} [Fintype V] [DecidableEq V]
+    (G : SimpleGraph' V) [DecidableRel G.adj] (r : ℕ) : Prop :=
+  ∀ v : V, degree G v = r
+
+/-- H is a subgraph of G -/
+def IsSubgraph {V : Type*} (H G : SimpleGraph' V) : Prop :=
+  ∀ u v, H.adj u v → G.adj u v
+
+/-- The complete graph K_4 -/
+def K4 : SimpleGraph' (Fin 4) where
+  adj u v := u ≠ v
+  symm _ _ h := h.symm
+  loopless _ h := h rfl
+
+-- Routine: K4 is 3-regular.
+-- Each vertex in K4 is adjacent to the 3 other vertices.
+theorem K4_is_3_regular : IsRegular K4 3 := by
+  sorry
+
+-- Routine: The degree of a vertex is at most |V| - 1.
+-- A vertex can be adjacent to at most all other vertices.
+theorem degree_le_card_sub_one {V : Type*} [Fintype V] [DecidableEq V]
+    (G : SimpleGraph' V) [DecidableRel G.adj] (v : V) :
+    degree G v ≤ Fintype.card V - 1 := by
+  sorry
+
+-- Routine: In any r-regular graph, rn must be even (handshaking).
+-- The sum of all degrees equals twice the number of edges.
+theorem regular_parity {V : Type*} [Fintype V] [DecidableEq V]
+    (G : SimpleGraph' V) [DecidableRel G.adj] (r : ℕ) (hG : IsRegular G r) :
+    Even (r * Fintype.card V) := by
+  sorry
+
+-- Routine: Subgraph degree is at most supergraph degree.
+-- Every edge in H is also an edge in G.
+theorem subgraph_degree_le {V : Type*} [Fintype V] [DecidableEq V]
+    (H G : SimpleGraph' V) [DecidableRel H.adj] [DecidableRel G.adj]
+    (hSub : IsSubgraph H G) (v : V) :
+    degree H v ≤ degree G v := by
+  sorry
+
+-- Routine: In a r-regular graph, every vertex has degree exactly r.
+-- This is the definition unfolded.
+theorem regular_degree_eq {V : Type*} [Fintype V] [DecidableEq V]
+    (G : SimpleGraph' V) [DecidableRel G.adj] (r : ℕ) (hG : IsRegular G r) (v : V) :
+    degree G v = r := hG v
+
+end Erdos715Aristotle


### PR DESCRIPTION
## Fix

Adds Aristotle companion file with routine supporting lemmas for automated proof search.

## Pre-submission checklist
- [x] No `def ... := sorry` (definition sorries)
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections
- [x] No open conjectures

---
Automated fix by lean-mechanic agent.