### PR TITLE
Add Aristotle companion for FairGamesTheoremOQ03 (martingale optional stopping)

### DIFF
--- a/proofs/Proofs/FairGamesTheoremOQ03Aristotle.lean
+++ b/proofs/Proofs/FairGamesTheoremOQ03Aristotle.lean
@@ -1,0 +1,121 @@
+/-
+  Aristotle targets for FairGamesTheoremOQ03
+  (Martingale Application Theorems: Optional Stopping, Doob's Inequality)
+  Routine supporting lemmas for automated proof search.
+  See FairGamesTheoremOQ03.lean for the main formalization.
+
+  These lemmas provide building blocks for:
+  - stoppedValue and IsStoppingTime properties with ℕ∞
+  - Optional stopping theorem helpers (submartingale direction)
+  - NNReal to real conversion for measure-theoretic bounds
+  - Doob's maximal inequality real-valued formulation
+  - Integral monotonicity and equality helpers
+-/
+import Mathlib
+
+open MeasureTheory
+
+namespace FairGamesOQ03.Aristotle
+
+/-
+  ## Section 1: stoppedValue Properties
+-/
+
+/-- stoppedValue at a constant stopping time equals the process at that time -/
+lemma stoppedValue_const {Ω : Type*} {m : MeasurableSpace Ω}
+    (f : ℕ → Ω → ℝ) (n : ℕ) (ω : Ω) :
+    stoppedValue f (fun _ => (n : ℕ∞)) ω = f n ω := by
+  sorry
+
+/-- stoppedValue at min(τ, N) equals stoppedValue at τ when τ ≤ N -/
+lemma stoppedValue_eq_of_le {Ω : Type*} {m : MeasurableSpace Ω}
+    (f : ℕ → Ω → ℝ) (τ : Ω → ℕ∞) (N : ℕ) (ω : Ω) (h : τ ω ≤ N) :
+    stoppedValue f τ ω = stoppedValue f (fun ω' => min (τ ω') N) ω := by
+  sorry
+
+/-- Measurability of stoppedValue for adapted processes -/
+lemma stoppedValue_measurable {Ω : Type*} {m : MeasurableSpace Ω}
+    {ℱ : Filtration ℕ m} (f : ℕ → Ω → ℝ) (τ : Ω → ℕ∞)
+    (hf : Adapted ℱ f) (hτ : IsStoppingTime ℱ τ) (N : ℕ) (hτN : ∀ ω, τ ω ≤ N) :
+    Measurable (stoppedValue f τ) := by
+  sorry
+
+/-
+  ## Section 2: IsStoppingTime Helpers for ℕ∞
+-/
+
+/-- The constant function N is a ℕ∞-stopping time -/
+lemma isStoppingTime_const {Ω : Type*} {m : MeasurableSpace Ω}
+    {ℱ : Filtration ℕ m} (N : ℕ∞) :
+    IsStoppingTime ℱ (fun _ : Ω => N) := by
+  sorry
+
+/-- min of two stopping times is a stopping time -/
+lemma isStoppingTime_min {Ω : Type*} {m : MeasurableSpace Ω}
+    {ℱ : Filtration ℕ m} (τ π : Ω → ℕ∞)
+    (hτ : IsStoppingTime ℱ τ) (hπ : IsStoppingTime ℱ π) :
+    IsStoppingTime ℱ (fun ω => min (τ ω) (π ω)) := by
+  sorry
+
+/-- A stopped ℕ∞-stopping time bounded by N gives integrability -/
+lemma stoppedValue_integrable {Ω : Type*} {m : MeasurableSpace Ω}
+    {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {ℱ : Filtration ℕ m} (f : ℕ → Ω → ℝ) (τ : Ω → ℕ∞)
+    (hf : ∀ n, Integrable (f n) μ) (N : ℕ) (hτN : ∀ ω, τ ω ≤ N) :
+    Integrable (stoppedValue f τ) μ := by
+  sorry
+
+/-
+  ## Section 3: Optional Stopping Integral Helpers
+-/
+
+/-- For a martingale and bounded ℕ∞-stopping time τ ≤ π ≤ N:
+    ∫ stoppedValue f τ = ∫ stoppedValue f π (via submartingale iff) -/
+lemma martingale_stopped_integral_eq {Ω : Type*} {m : MeasurableSpace Ω}
+    {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {ℱ : Filtration ℕ m} (f : ℕ → Ω → ℝ)
+    (hf : Martingale f ℱ μ)
+    (τ π : Ω → ℕ∞) (hτ : IsStoppingTime ℱ τ) (hπ : IsStoppingTime ℱ π)
+    (hτπ : τ ≤ π) (N : ℕ) (hπN : ∀ ω, π ω ≤ N) :
+    ∫ ω, stoppedValue f τ ω ∂μ = ∫ ω, stoppedValue f π ω ∂μ := by
+  sorry
+
+/-- For a martingale, ∫ stoppedValue f τ = ∫ f 0 when τ ≤ N -/
+lemma martingale_stopped_eq_initial {Ω : Type*} {m : MeasurableSpace Ω}
+    {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {ℱ : Filtration ℕ m} (f : ℕ → Ω → ℝ)
+    (hf : Martingale f ℱ μ)
+    (τ : Ω → ℕ∞) (hτ : IsStoppingTime ℱ τ) (N : ℕ) (hτN : ∀ ω, τ ω ≤ N) :
+    ∫ ω, stoppedValue f τ ω ∂μ = ∫ ω, f 0 ω ∂μ := by
+  sorry
+
+/-
+  ## Section 4: NNReal to Real Conversion Helpers
+-/
+
+/-- ENNReal.toReal of a probability measure of a set is ≤ 1 -/
+lemma measure_toReal_le_one {Ω : Type*} {m : MeasurableSpace Ω}
+    {μ : Measure Ω} [IsProbabilityMeasure μ] (s : Set Ω) :
+    (μ s).toReal ≤ 1 := by
+  sorry
+
+/-- thresh * (μ s).toReal ≤ integral bound from Doob's maximal ineq via NNReal -/
+lemma doob_maximal_real_of_nnreal {Ω : Type*} {m : MeasurableSpace Ω}
+    {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {ℱ : Filtration ℕ m} (f : ℕ → Ω → ℝ)
+    (hf : Submartingale f ℱ μ) (hpos : ∀ n ω, 0 ≤ f n ω)
+    (N : ℕ) (thresh : ℝ) (hthresh : 0 < thresh)
+    (s : Set Ω) (hs : s = {ω | ∃ n ≤ N, thresh ≤ f n ω}) :
+    thresh * (μ s).toReal ≤ ∫ ω, f N ω ∂μ := by
+  sorry
+
+/-- The set {ω | ∃ n ≤ N, thresh ≤ f n ω} is measurable for adapted f -/
+lemma maximal_set_measurable {Ω : Type*} {m : MeasurableSpace Ω}
+    {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {ℱ : Filtration ℕ m} (f : ℕ → Ω → ℝ)
+    (hf : Submartingale f ℱ μ)
+    (N : ℕ) (thresh : ℝ) :
+    MeasurableSet {ω | ∃ n ≤ N, thresh ≤ f n ω} := by
+  sorry
+
+end FairGamesOQ03.Aristotle


### PR DESCRIPTION
## Fix

Adds Aristotle companion file with routine supporting lemmas for automated proof search.

## Pre-submission checklist
- [x] No `def ... := sorry` (definition sorries)
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections
- [x] No open conjectures

---
Automated fix by lean-mechanic agent.