### PR TITLE
Add Aristotle companion for Erdős #117 OQ01 (exponential growth rate of h(n))

### DIFF
--- a/proofs/Proofs/Erdos117OQ01Aristotle.lean
+++ b/proofs/Proofs/Erdos117OQ01Aristotle.lean
@@ -1,0 +1,103 @@
+/-
+  Aristotle targets for Erdos117OQ01 (Exponential Growth Rate of h(n))
+  Routine supporting lemmas for automated proof search.
+  See Erdos117OQ01.lean for the main formalization.
+
+  These lemmas provide building blocks for growth rate analysis:
+  - Filter.liminf/limsup basic properties
+  - Subadditive sequence convergence (Fekete's lemma)
+  - Real.log and Real.exp growth helpers
+  - ExponentialBehavior structural properties
+  - growthRate monotonicity and limit helpers
+-/
+import Mathlib
+
+open Real Filter
+
+namespace Erdos117OQ01.Aristotle
+
+/-
+  ## Section 1: Filter.liminf/limsup Properties
+-/
+
+/-- liminf ≤ limsup for any bounded sequence -/
+lemma liminf_le_limsup (f : ℕ → ℝ) (hb : BoundedAtFilter atTop f) :
+    Filter.liminf f atTop ≤ Filter.limsup f atTop := by
+  sorry
+
+/-- liminf is the same as lim when the sequence converges -/
+lemma liminf_eq_lim_of_tendsto (f : ℕ → ℝ) (L : ℝ)
+    (h : Filter.Tendsto f atTop (nhds L)) :
+    Filter.liminf f atTop = L := by
+  sorry
+
+/-- limsup is the same as lim when the sequence converges -/
+lemma limsup_eq_lim_of_tendsto (f : ℕ → ℝ) (L : ℝ)
+    (h : Filter.Tendsto f atTop (nhds L)) :
+    Filter.limsup f atTop = L := by
+  sorry
+
+/-- If f → L then liminf f ≥ L - ε eventually implies liminf f ≥ L -/
+lemma liminf_ge_of_tendsto (f : ℕ → ℝ) (L : ℝ)
+    (h : Filter.Tendsto f atTop (nhds L)) : Filter.liminf f atTop ≥ L := by
+  sorry
+
+/-
+  ## Section 2: Subadditive Sequences (Fekete's Lemma)
+-/
+
+/-- Fekete's lemma: if a(m+n) ≤ a(m) + a(n), then a(n)/n → inf(a(n)/n) -/
+lemma fekete_subadditive (a : ℕ → ℝ) (hsub : ∀ m n : ℕ, a (m + n) ≤ a m + a n)
+    (hpos : ∀ n : ℕ, n ≥ 1 → a n / n ≥ 0) :
+    ∃ L : ℝ, Filter.Tendsto (fun n : ℕ => a n / n) atTop (nhds L) := by
+  sorry
+
+/-- log h is subadditive when h is submultiplicative -/
+lemma log_subadditive_of_submultiplicative (h : ℕ → ℕ)
+    (hsub : ∀ m n : ℕ, h (m + n) ≤ h m * h n) (hpos : ∀ n, h n ≥ 1) :
+    ∀ m n : ℕ, Real.log (h (m + n)) ≤ Real.log (h m) + Real.log (h n) := by
+  sorry
+
+/-- The Fekete limit exists for log h / n when h is submultiplicative -/
+lemma growth_rate_converges_of_submultiplicative (h : ℕ → ℕ)
+    (hsub : ∀ m n : ℕ, h (m + n) ≤ h m * h n) (hpos : ∀ n, h n ≥ 1) :
+    ∃ L : ℝ, Filter.Tendsto (fun n : ℕ => Real.log (h n) / n) atTop (nhds L) := by
+  sorry
+
+/-
+  ## Section 3: Real.exp and Real.log Helpers
+-/
+
+/-- log(c₁^n) = n * log c₁ -/
+lemma log_pow_c (c : ℝ) (hc : c > 0) (n : ℕ) :
+    Real.log (c ^ n) = n * Real.log c := by
+  sorry
+
+/-- log(c₁^n) / n = log c₁ for n ≥ 1 -/
+lemma log_pow_div (c : ℝ) (hc : c > 1) (n : ℕ) (hn : n ≥ 1) :
+    Real.log (c ^ n) / n = Real.log c := by
+  sorry
+
+/-- If c > 1 then log c > 0 -/
+lemma log_pos_of_gt_one (c : ℝ) (hc : c > 1) : Real.log c > 0 := by
+  sorry
+
+/-- exp is continuous at any point -/
+lemma exp_continuous_at (x : ℝ) : ContinuousAt Real.exp x := by
+  sorry
+
+/-
+  ## Section 4: ExponentialBehavior Helpers
+-/
+
+/-- If growth rate → L then exp(L) is the exponential base -/
+lemma tendsto_implies_exponential_base (h : ℕ → ℕ) (L : ℝ)
+    (hconv : Filter.Tendsto (fun n : ℕ => Real.log (h n) / n) atTop (nhds L)) :
+    ∀ ε > 0, ∀ᶠ n in atTop, (h n : ℝ) ≥ (Real.exp L - ε) ^ n := by
+  sorry
+
+/-- exp(log c) = c for c > 0 -/
+lemma exp_log_eq (c : ℝ) (hc : c > 0) : Real.exp (Real.log c) = c := by
+  sorry
+
+end Erdos117OQ01.Aristotle


### PR DESCRIPTION
## Fix

Adds Aristotle companion file with routine supporting lemmas for automated proof search.

## Pre-submission checklist
- [x] No `def ... := sorry` (definition sorries)
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections
- [x] No open conjectures

---
Automated fix by lean-mechanic agent.