### PR TITLE
Add Aristotle companion for Erdős #138 (van der Waerden numbers growth rate)

### DIFF
--- a/proofs/Proofs/Stubs/Erdos138Aristotle.lean
+++ b/proofs/Proofs/Stubs/Erdos138Aristotle.lean
@@ -1,0 +1,99 @@
+/-
+  Aristotle targets for Erdos138 (Van der Waerden Numbers Growth Rate)
+  Routine supporting lemmas for automated proof search.
+  See Erdos138Problem.lean for the main formalization.
+
+  These lemmas provide building blocks for van der Waerden number analysis:
+  - Finset.Icc membership helpers for arithmetic progressions
+  - W(1) = 1 and W(2) = 3 small value proofs
+  - Filter/Tendsto helpers for the growth rate conjecture
+  - Arithmetic progression basic properties
+-/
+import Mathlib
+
+open Nat Filter Finset
+
+namespace Erdos138.Aristotle
+
+/-
+  ## Section 1: Finset.Icc Membership Helpers
+-/
+
+/-- 1 ∈ Finset.Icc 1 N for N ≥ 1 -/
+lemma one_mem_Icc (N : ℕ) (hN : N ≥ 1) : 1 ∈ Finset.Icc 1 N := by
+  sorry
+
+/-- a ∈ Finset.Icc 1 N when 1 ≤ a ≤ N -/
+lemma mem_Icc_of_bounds (a N : ℕ) (h1 : 1 ≤ a) (h2 : a ≤ N) : a ∈ Finset.Icc 1 N := by
+  sorry
+
+/-- Finset.Icc 1 N has cardinality N -/
+lemma Icc_card (N : ℕ) : (Finset.Icc 1 N).card = N := by
+  sorry
+
+/-- a + i * d ≤ N when a = 1, i < k, d = 1, k ≤ N -/
+lemma ap_mem_range (i k N : ℕ) (hi : i < k) (hk : k ≤ N) : 1 + i * 1 ≤ N := by
+  sorry
+
+/-
+  ## Section 2: GuaranteeSet Properties
+-/
+
+/-- The GuaranteeSet is nonempty for r ≥ 1, k ≥ 1 (by van der Waerden) -/
+lemma guaranteeSet_nonempty (r k : ℕ) (hr : r ≥ 1) (hk : k ≥ 1)
+    (vdw : ∀ r k : ℕ, r ≥ 1 → k ≥ 1 → ∃ N : ℕ, ∀ (c : Finset.Icc 1 N → Fin r), True) :
+    ∃ N : ℕ, N ≥ 1 := by
+  sorry
+
+/-- If N ≤ M and a set is monochromatic under any coloring of {1..N}, likewise for {1..M} -/
+lemma icc_mono_coloring (N M : ℕ) (hNM : N ≤ M) :
+    Finset.Icc 1 N ⊆ Finset.Icc 1 M := by
+  sorry
+
+/-
+  ## Section 3: W(1) and W(2) Helpers
+-/
+
+/-- Any element is a 1-term AP (trivial: d = 1, just the element itself) -/
+lemma one_term_ap_trivial (x : ℕ) (hx : x ≥ 1) : ∃ a d : ℕ, d > 0 ∧
+    (∀ i : Fin 1, a + i.val * d = x) := by
+  sorry
+
+/-- sInf of a nonempty set of naturals bounded below is in the set -/
+lemma sInf_mem_of_nonempty (S : Set ℕ) (hne : S.Nonempty) (hbdd : ∃ N, N ∈ S) :
+    Nat.sInf S ∈ S := by
+  sorry
+
+/-- sInf {N | ...} ≥ 1 when the property requires at least one element -/
+lemma sInf_ge_one (S : Set ℕ) (h : ∀ n ∈ S, n ≥ 1) (hne : S.Nonempty) :
+    Nat.sInf S ≥ 1 := by
+  sorry
+
+/-- Pigeonhole: a 2-coloring of 3 elements must have two with same color -/
+lemma pigeonhole_two_colors_three_elements (f : Fin 3 → Fin 2) :
+    ∃ i j : Fin 3, i ≠ j ∧ f i = f j := by
+  sorry
+
+/-
+  ## Section 4: Tendsto/Filter Helpers for Growth Rate
+-/
+
+/-- If (f k)^(1/k) → ∞, then for any c > 0, eventually f k > c^k -/
+lemma tendsto_rpow_atTop_implies_super_exp (f : ℕ → ℝ) (hf : Filter.Tendsto
+    (fun k => f k ^ (1 / (k : ℝ))) Filter.atTop Filter.atTop)
+    (c : ℝ) (hc : c > 0) :
+    ∀ᶠ k in Filter.atTop, c ^ k < f k := by
+  sorry
+
+/-- Exponential divergence: (c^k / 2^k) → ∞ for c > 2 -/
+lemma exp_ratio_diverges (c : ℝ) (hc : c > 2) :
+    Filter.Tendsto (fun k : ℕ => (c : ℝ) ^ k / 2 ^ k) Filter.atTop Filter.atTop := by
+  sorry
+
+/-- (W k : ℚ) / 2^k → ∞ follows from W(k)^(1/k) → ∞ -/
+lemma wpow_to_expodiv (W : ℕ → ℕ) (hW : Filter.Tendsto
+    (fun k => (W k : ℝ) ^ (1 / (k : ℝ))) Filter.atTop Filter.atTop) :
+    Filter.Tendsto (fun k => ((W k : ℚ) / (2 ^ k))) Filter.atTop Filter.atTop := by
+  sorry
+
+end Erdos138.Aristotle


### PR DESCRIPTION
## Fix

Adds Aristotle companion file with routine supporting lemmas for automated proof search.

## Pre-submission checklist
- [x] No `def ... := sorry` (definition sorries)
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections
- [x] No open conjectures

---
Automated fix by lean-mechanic agent.