### PR TITLE
Fix: add Aristotle companion for Erdős #632 (a,b)-choosability lemmas

### DIFF
--- a/proofs/Proofs/Erdos632Aristotle.lean
+++ b/proofs/Proofs/Erdos632Aristotle.lean
@@ -1,0 +1,118 @@
+/-
+  Aristotle targets for Erdős Problem #632: (a,b)-Choosability Scaling Conjecture
+
+  Routine supporting lemmas for automated proof search.
+  See Erdos632Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main disproof (Dvořák-Hu-Sereni counterexample)
+  - Routine properties of the IsChoosable definition
+  - Basic monotonicity and boundary conditions
+  - No definition sorries, no axioms
+-/
+import Mathlib
+
+namespace Erdos632.Aristotle
+
+open Finset Function SimpleGraph
+
+variable {V : Type*}
+
+/-
+  ## Shared Definitions (mirrored from Erdos632Problem.lean)
+  Reproduced here so Aristotle can work with them directly.
+-/
+
+def ColorAssignment (V : Type*) (a : ℕ) := V → Finset (Fin a)
+def ColorSelection (V : Type*) (a : ℕ) := V → Finset (Fin a)
+
+def IsValidAssignment (L : ColorAssignment V a) : Prop :=
+  ∀ v : V, (L v).card = a
+
+def IsValidSelection (L : ColorAssignment V a) (S : ColorSelection V a) (b : ℕ) : Prop :=
+  ∀ v : V, (S v) ⊆ (L v) ∧ (S v).card = b
+
+def SelectionsDisjoint (G : SimpleGraph V) (S : ColorSelection V a) : Prop :=
+  ∀ u v : V, G.Adj u v → Disjoint (S u) (S v)
+
+def IsChoosable (G : SimpleGraph V) (a b : ℕ) : Prop :=
+  ∀ L : ColorAssignment V a, IsValidAssignment L →
+    ∃ S : ColorSelection V a, IsValidSelection L S b ∧ SelectionsDisjoint G S
+
+/-
+  ## Section 1: Necessary Conditions
+
+  The most basic constraint: you cannot pick more colors than are available.
+-/
+
+-- Routine: If b > a, no valid selection exists (can't pick b elements from a set of size a)
+theorem choosable_requires_b_le_a (G : SimpleGraph V) (a b : ℕ) (hb : b > a) :
+    ¬IsChoosable G a b := by
+  sorry
+
+-- Routine: IsChoosable G a 0 always holds (trivially pick empty selection)
+theorem choosable_b_zero (G : SimpleGraph V) (a : ℕ) :
+    IsChoosable G a 0 := by
+  sorry
+
+-- Routine: Subset of b elements from a Finset of card a when b ≤ a
+theorem finset_card_a_has_b_subset (s : Finset (Fin a)) (hs : s.card = a) (b : ℕ) (hb : b ≤ a) :
+    ∃ t : Finset (Fin a), t ⊆ s ∧ t.card = b := by
+  sorry
+
+/-
+  ## Section 2: Monotonicity
+
+  Core monotonicity properties of (a,b)-choosability.
+-/
+
+-- Routine: Anti-monotonicity in b — fewer colors to select makes it easier
+theorem choosable_mono_b (G : SimpleGraph V) (a b₁ b₂ : ℕ) (h : b₁ ≥ b₂) :
+    IsChoosable G a b₁ → IsChoosable G a b₂ := by
+  sorry
+
+-- Routine: Monotonicity in a — more colors available makes it easier
+theorem choosable_mono_a (G : SimpleGraph V) (a₁ a₂ b : ℕ) (h : a₁ ≤ a₂) :
+    IsChoosable G a₁ b → IsChoosable G a₂ b := by
+  sorry
+
+/-
+  ## Section 3: Special Graphs
+
+  Choosability for degenerate graph cases.
+-/
+
+-- Routine: The empty graph (no edges) is always (a,b)-choosable when b ≤ a
+theorem empty_graph_choosable (a b : ℕ) (h : b ≤ a) :
+    IsChoosable (⊥ : SimpleGraph V) a b := by
+  sorry
+
+-- Routine: SelectionsDisjoint holds trivially on the empty graph
+theorem empty_graph_disjoint (S : ColorSelection V a) :
+    SelectionsDisjoint (⊥ : SimpleGraph V) S := by
+  intro u v hadj
+  exact absurd hadj (SimpleGraph.not_adj_bot u v)
+
+-- Routine: A complete graph K₁ (single vertex) is (a,b)-choosable for any b ≤ a
+theorem complete_one_choosable (a b : ℕ) (h : b ≤ a) :
+    IsChoosable (⊤ : SimpleGraph (Fin 1)) a b := by
+  sorry
+
+/-
+  ## Section 4: Trivial Parameter Cases
+
+  Choosability at the boundary values.
+-/
+
+-- Routine: IsChoosable G 0 0 always holds
+theorem choosable_zero_zero (G : SimpleGraph V) :
+    IsChoosable G 0 0 := by
+  intro L _
+  exact ⟨fun _ => ∅, fun v => ⟨Finset.empty_subset _, by simp⟩, fun u v _ => by simp⟩
+
+-- Routine: IsChoosable G a a holds when V has at most one vertex (no edges forced)
+theorem choosable_a_a_singleton (a : ℕ) (v : Fin 1) :
+    IsChoosable (⊥ : SimpleGraph (Fin 1)) a a := by
+  exact empty_graph_choosable a a le_rfl
+
+end Erdos632.Aristotle


### PR DESCRIPTION
## Fix

Adds `Erdos632Aristotle.lean` with 10 routine supporting lemmas targeting the 5 sorries in `Erdos632Problem.lean`.

## Evidence

**Before**: `Erdos632Problem.lean` has 5 routine structural sorries with no Aristotle companion:
- `choosable_requires_b_le_a` (b > a is impossible)
- `choosable_mono_b` (anti-monotonicity in selection count)
- `choosable_mono_a` (monotonicity in list size)
- `empty_graph_choosable` (empty graph always choosable)

**After**: Companion file exposes these as Aristotle targets plus additional helper lemmas:
- Necessary condition: `choosable_requires_b_le_a`, `choosable_b_zero`
- Monotonicity: `choosable_mono_b`, `choosable_mono_a`
- Special graphs: `empty_graph_choosable`, `empty_graph_disjoint`, `complete_one_choosable`
- Boundary cases: `choosable_zero_zero`, `choosable_a_a_singleton`
- Helper: `finset_card_a_has_b_subset`

**Pre-submission checklist**:
- [x] No `def ... := sorry` (definition sorries)
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections
- [x] No open conjectures

---
Automated fix by lean-mechanic agent.