### PR TITLE
fix(audit): add missing axiomCount=6 to erdos-1155-oq-01-oq-06

### DIFF
--- a/src/data/proofs/erdos-1155-oq-01-oq-06/meta.json
+++ b/src/data/proofs/erdos-1155-oq-01-oq-06/meta.json
@@ -23,6 +23,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
+    "axiomCount": 6,
     "mathlibDependencies": [
       {
         "theorem": "Real.rpow_add",


### PR DESCRIPTION
## Audit Fix

**Proof**: `erdos-1155-oq-01-oq-06`
**Issue**: `axiomCount` field missing from meta.json

## Evidence

**meta.json**: `axiomCount` field was absent

**Lean source chain**:
- `Erdos1155OQ01OQ06.lean` imports `Erdos1155OQ01.lean` → imports `Erdos1155Problem.lean`
- `Erdos1155Problem.lean` declares 6 `axiom` statements:
  - `triangleRemovalEdges`
  - `triangleRemovalEdges_nonneg`
  - `triangleRemovalEdges_le_complete`
  - `bfl_upper_bound`
  - `bfl_lower_bound`
  - `triangleRemoval_mantel_bound`
- The OQ-06 file itself adds 0 new axioms

**Total axiom count**: 6 (all inherited)

## Fix

Added `"axiomCount": 6` to meta.json per gallery integrity policy (CLAUDE.md: axiomCount must reflect ALL assumptions including inherited ones).

**Verified**: Status (`axiomatized`), badge (`axiom`), and sorries (`0`) are all correct.

**Comparable**: `erdos-1155-oq-01-oq-07` (sibling) correctly has `axiomCount: 9` = 3 own + 6 inherited.

---
Discovered during gallery integrity audit (cycle 46).

🤖 Generated with [Claude Code](https://claude.com/claude-code)