### PR TITLE
fix: remove duplicate decAllFact entry in OQ-01 meta.json

### DIFF
--- a/src/data/proofs/erdos-1059-oq-01/meta.json
+++ b/src/data/proofs/erdos-1059-oq-01/meta.json
@@ -58,7 +58,6 @@
     ],
     "originalContributions": [
       "decAllFact: Decidable instance for AllFactorialSubtractionsComposite via bounded quantifier over Finset.range n",
-      "decAllFact: Decidable instance for AllFactorialSubtractionsComposite via bounded quantifier over Finset.range n",
       "witness_461, witness_557, witness_673: three level-5 verified prime witnesses (p ∈ (120, 720))",
       "witness_769: first level-6 verified prime witness (p = 769 ∈ (720, 5040))",
       "witness_5209, witness_5573: first level-7 verified prime witnesses (p ∈ (5040, 40320))",


### PR DESCRIPTION
## Summary
- Removes a duplicated `decAllFact` entry from `originalContributions` in `erdos-1059-oq-01/meta.json`

This duplicate was introduced when the meta.json was updated to add 8 witnesses and level-7 data. The array element `"decAllFact: ..."` appeared twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)