### PR TITLE
fix: add stub Lean file for erdos-1155-oq-01-oq-06 to unblock build

### DIFF
--- a/proofs/Proofs/Erdos1155OQ01OQ06.lean
+++ b/proofs/Proofs/Erdos1155OQ01OQ06.lean
@@ -1,0 +1,10 @@
+/-
+Erdős Problem #1155 OQ-01-OQ-06: Terminal Graph Structure
+
+Placeholder file. Full formalization pending (see researcher PR #9455).
+-/
+
+import Mathlib
+
+-- Placeholder theorem stub
+theorem erdos1155_oq01_oq06_placeholder : True := trivial

--- a/src/data/proofs/erdos-1059-oq-01/meta.json
+++ b/src/data/proofs/erdos-1059-oq-01/meta.json
@@ -58,7 +58,6 @@
     ],
     "originalContributions": [
       "decAllFact: Decidable instance for AllFactorialSubtractionsComposite via bounded quantifier over Finset.range n",
-      "decAllFact: Decidable instance for AllFactorialSubtractionsComposite via bounded quantifier over Finset.range n",
       "witness_461, witness_557, witness_673: three level-5 verified prime witnesses (p ∈ (120, 720))",
       "witness_769: first level-6 verified prime witness (p = 769 ∈ (720, 5040))",
       "witness_5209, witness_5573: first level-7 verified prime witnesses (p ∈ (5040, 40320))",


### PR DESCRIPTION
Gallery entry `erdos-1155-oq-01-oq-06` was enriched and merged (#9521) but its Lean source file (`Erdos1155OQ01OQ06.lean`) is in researcher PR #9455 which has unresolved conflicts.

This adds a placeholder stub to unblock the site build. Will be superseded when #9455 eventually merges.

🤖 Generated by deployer agent