### PR TITLE
Enrich 6 entries: schema migration and new annotations

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-03/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-03/annotations.json
@@ -1,9 +1,11 @@
 [
   {
     "id": "binom-pmf",
-    "line": 28,
+    "proofId": "binomial-theorem-oq-03",
+    "range": { "startLine": 28, "endLine": 43 },
     "type": "definition",
-    "content": "**binomPMF**: The binomial probability mass function $P(X=k) = \\binom{n}{k} p^k (1-p)^{n-k}$. Defined as a real-valued function on $\\mathbb{N}$, not a measure-theoretic probability. This algebraic approach avoids sigma-algebras while capturing all combinatorial identities. Returns 0 for $k > n$ since $\\binom{n}{k} = 0$.",
+    "title": "binomPMF: Algebraic PMF Avoiding Measure Theory",
+    "content": "`binomPMF`: The binomial probability mass function $P(X=k) = \\binom{n}{k} p^k (1-p)^{n-k}$. Defined as a real-valued function on $\\mathbb{N}$, not a measure-theoretic probability. This algebraic approach avoids sigma-algebras while capturing all combinatorial identities. Returns 0 for $k > n$ since $\\binom{n}{k} = 0$.",
     "mathContext": "For $X \\sim \\text{Bin}(n,p)$: $P(X=k) = \\binom{n}{k} p^k (1-p)^{n-k}$, $k = 0, 1, \\ldots, n$. The boundary values $P(0) = (1-p)^n$ and $P(n) = p^n$ follow from $\\binom{n}{0} = \\binom{n}{n} = 1$. Non-negativity holds for $p \\in [0,1]$ since all three factors are non-negative.",
     "significance": "key",
     "relatedConcepts": [
@@ -15,18 +17,15 @@
     "prerequisites": [
       "Nat.choose (binomial coefficients)",
       "Real-valued powers"
-    ],
-    "proofId": "binomial-theorem-oq-03",
-    "range": {
-      "startLine": 28,
-      "endLine": 43
-    }
+    ]
   },
   {
     "id": "binomial-expansion",
-    "line": 48,
-    "type": "technique",
-    "content": "**binomial_expansion**: The algebraic binomial theorem $(p+q)^n = \\sum_{k=0}^{n} \\binom{n}{k} p^k q^{n-k}$, proved by rewriting Mathlib's `add_pow`. This is the foundational identity from which every property of the binomial distribution follows.",
+    "proofId": "binomial-theorem-oq-03",
+    "range": { "startLine": 48, "endLine": 63 },
+    "type": "theorem",
+    "title": "binomial_expansion: (p+q)^n = Σ C(n,k) p^k q^(n−k)",
+    "content": "`binomial_expansion`: The algebraic binomial theorem $(p+q)^n = \\sum_{k=0}^{n} \\binom{n}{k} p^k q^{n-k}$, proved by rewriting Mathlib's `add_pow`. This is the foundational identity from which every property of the binomial distribution follows.",
     "mathContext": "Mathlib's `add_pow` gives $(p+q)^n = \\sum_k \\binom{n}{k} p^k q^{n-k}$ using `Commute.add_pow`. The proof rewrites this into the desired summation form with a `congr` and `ring` step.",
     "significance": "key",
     "relatedConcepts": [
@@ -35,20 +34,17 @@
       "polynomial identity"
     ],
     "prerequisites": [
-      "Mathlib's Commute.add_pow",
+      "Mathlib Commute.add_pow",
       "ring tactic"
-    ],
-    "proofId": "binomial-theorem-oq-03",
-    "range": {
-      "startLine": 48,
-      "endLine": 63
-    }
+    ]
   },
   {
     "id": "normalization",
-    "line": 53,
-    "type": "technique",
-    "content": "**binomPMF_sum_eq_one**: The PMF sums to 1. The proof is a one-line consequence of the binomial theorem: substitute $q = 1-p$ to get $(p + (1-p))^n = 1^n = 1$. This is the heart of the OQ-03 answer — the binomial theorem IS normalization.",
+    "proofId": "binomial-theorem-oq-03",
+    "range": { "startLine": 53, "endLine": 63 },
+    "type": "theorem",
+    "title": "binomPMF_sum_eq_one: The OQ-03 Answer — Binomial Theorem IS Normalization",
+    "content": "`binomPMF_sum_eq_one`: The PMF sums to 1. The proof is a one-line consequence of the binomial theorem: substitute $q = 1-p$ to get $(p + (1-p))^n = 1^n = 1$. This is the heart of the OQ-03 answer — the binomial theorem IS normalization.",
     "mathContext": "Setting $q = 1-p$ in $(p+q)^n = \\sum \\binom{n}{k} p^k q^{n-k}$: $1^n = \\sum_{k=0}^{n} \\binom{n}{k} p^k (1-p)^{n-k} = \\sum_{k=0}^{n} \\text{PMF}(k)$. The `add_sub_cancel` lemma gives $p + (1-p) = 1$.",
     "significance": "key",
     "relatedConcepts": [
@@ -59,18 +55,15 @@
     "prerequisites": [
       "binomial_expansion",
       "add_sub_cancel"
-    ],
-    "proofId": "binomial-theorem-oq-03",
-    "range": {
-      "startLine": 53,
-      "endLine": 63
-    }
+    ]
   },
   {
     "id": "absorption",
-    "line": 77,
-    "type": "technique",
-    "content": "**absorption**: The absorption identity $(k+1)\\binom{n+1}{k+1} = (n+1)\\binom{n}{k}$. This is the key algebraic tool for computing the mean: it converts each weighted term $k \\cdot \\text{PMF}(k)$ into $(n+1)p$ times a degree-$(n-1)$ binomial term, reducing the moment calculation to normalization.",
+    "proofId": "binomial-theorem-oq-03",
+    "range": { "startLine": 77, "endLine": 82 },
+    "type": "theorem",
+    "title": "absorption: (k+1)·C(n+1,k+1) = (n+1)·C(n,k)",
+    "content": "`absorption`: The absorption identity $(k+1)\\binom{n+1}{k+1} = (n+1)\\binom{n}{k}$. This is the key algebraic tool for computing the mean: it converts each weighted term $k \\cdot \\text{PMF}(k)$ into $(n+1)p$ times a degree-$(n-1)$ binomial term, reducing the moment calculation to normalization.",
     "mathContext": "The absorption identity is equivalent to $k\\binom{n}{k} = n\\binom{n-1}{k-1}$ (shift indices by 1). It arises from the factorial representation: $k \\cdot \\frac{n!}{k!(n-k)!} = n \\cdot \\frac{(n-1)!}{(k-1)!(n-k)!}$. Proved from Mathlib's `Nat.add_one_mul_choose_eq` with `linarith`.",
     "significance": "key",
     "relatedConcepts": [
@@ -81,18 +74,15 @@
     "prerequisites": [
       "Nat.choose definition",
       "factorial identities"
-    ],
-    "proofId": "binomial-theorem-oq-03",
-    "range": {
-      "startLine": 77,
-      "endLine": 82
-    }
+    ]
   },
   {
     "id": "binomial-mean",
-    "line": 83,
-    "type": "technique",
-    "content": "**binomial_mean**: $E[X] = np$ for $n \\geq 1$. The proof strips the $k=0$ term (which vanishes), applies absorption to convert each $(k+1) \\cdot \\text{PMF}(k+1)$ into $(n+1)p \\cdot [\\text{degree-}(n-1) \\text{ binomial term}]$, factors out $np$, and uses normalization on the remaining sum.",
+    "proofId": "binomial-theorem-oq-03",
+    "range": { "startLine": 83, "endLine": 127 },
+    "type": "theorem",
+    "title": "binomial_mean: E[X] = np via Absorption + Normalization",
+    "content": "`binomial_mean`: $E[X] = np$ for $n \\geq 1$. The proof strips the $k=0$ term (which vanishes), applies absorption to convert each $(k+1) \\cdot \\text{PMF}(k+1)$ into $(n+1)p \\cdot [\\text{degree-}(n-1) \\text{ binomial term}]$, factors out $np$, and uses normalization on the remaining sum.",
     "mathContext": "$E[X] = \\sum_{k=0}^{n} k \\cdot \\binom{n}{k} p^k (1-p)^{n-k} = np \\sum_{j=0}^{n-1} \\binom{n-1}{j} p^j (1-p)^{n-1-j} = np \\cdot 1 = np$. The index shift $j = k-1$ and absorption $k\\binom{n}{k} = n\\binom{n-1}{k-1}$ are the two key steps.",
     "significance": "key",
     "relatedConcepts": [
@@ -104,18 +94,15 @@
     "prerequisites": [
       "absorption identity",
       "binomPMF_sum_eq_one (normalization)"
-    ],
-    "proofId": "binomial-theorem-oq-03",
-    "range": {
-      "startLine": 83,
-      "endLine": 127
-    }
+    ]
   },
   {
     "id": "fair-coin",
-    "line": 132,
-    "type": "technique",
-    "content": "**binomPMF_fair_coin**: When $p = 1/2$, $P(k) = \\binom{n}{k}/2^n$. The proof uses $(1/2)^k \\cdot (1/2)^{n-k} = (1/2)^n = 1/2^n$. This is the classical equi-probable model: each of the $2^n$ binary sequences has equal probability, and $\\binom{n}{k}$ of them have exactly $k$ ones.",
+    "proofId": "binomial-theorem-oq-03",
+    "range": { "startLine": 132, "endLine": 162 },
+    "type": "theorem",
+    "title": "binomPMF_fair_coin: P(X=k) = C(n,k)/2^n for p = 1/2",
+    "content": "`binomPMF_fair_coin`: When $p = 1/2$, $P(k) = \\binom{n}{k}/2^n$. The proof uses $(1/2)^k \\cdot (1/2)^{n-k} = (1/2)^n = 1/2^n$. This is the classical equi-probable model: each of the $2^n$ binary sequences has equal probability, and $\\binom{n}{k}$ of them have exactly $k$ ones.",
     "mathContext": "For the fair coin: $P(X=k) = \\binom{n}{k} (1/2)^k (1/2)^{n-k} = \\binom{n}{k} / 2^n$. The $2^n$ denominator appears because there are $2^n$ equally likely outcomes in $n$ tosses, and $\\binom{n}{k}$ of these have exactly $k$ heads.",
     "significance": "supporting",
     "relatedConcepts": [
@@ -126,18 +113,15 @@
     "prerequisites": [
       "binomPMF definition",
       "arithmetic with 1/2"
-    ],
-    "proofId": "binomial-theorem-oq-03",
-    "range": {
-      "startLine": 132,
-      "endLine": 162
-    }
+    ]
   },
   {
     "id": "binomial-pgf",
-    "line": 181,
-    "type": "technique",
-    "content": "**binomial_pgf**: The probability generating function $E[t^X] = (pt + 1-p)^n$. Proved by replacing $p$ with $pt$ in the binomial expansion — each term $t^k \\cdot \\text{PMF}(k) = \\binom{n}{k} (pt)^k (1-p)^{n-k}$. The PGF encodes the entire distribution: setting $t=1$ gives normalization, differentiating at $t=1$ gives the mean.",
+    "proofId": "binomial-theorem-oq-03",
+    "range": { "startLine": 181, "endLine": 197 },
+    "type": "theorem",
+    "title": "binomial_pgf: E[t^X] = (pt + 1−p)^n via Binomial Theorem",
+    "content": "`binomial_pgf`: The probability generating function $E[t^X] = (pt + 1-p)^n$. Proved by replacing $p$ with $pt$ in the binomial expansion — each term $t^k \\cdot \\text{PMF}(k) = \\binom{n}{k} (pt)^k (1-p)^{n-k}$. The PGF encodes the entire distribution: setting $t=1$ gives normalization, differentiating at $t=1$ gives the mean.",
     "mathContext": "The PGF $G(t) = E[t^X] = \\sum_{k=0}^{n} t^k \\binom{n}{k} p^k (1-p)^{n-k} = (pt + (1-p))^n$ by the binomial theorem. $G(1) = 1$ (normalization), $G'(1) = np$ (mean), $G''(1) + G'(1) - (G'(1))^2 = np(1-p)$ (variance). The PGF completely characterizes any distribution on $\\mathbb{N}$.",
     "significance": "key",
     "relatedConcepts": [
@@ -148,18 +132,15 @@
     "prerequisites": [
       "binomial_expansion",
       "ring tactic"
-    ],
-    "proofId": "binomial-theorem-oq-03",
-    "range": {
-      "startLine": 181,
-      "endLine": 197
-    }
+    ]
   },
   {
     "id": "double-absorption",
-    "line": 203,
-    "type": "technique",
-    "content": "**double_absorption**: $(k+2)(k+1)\\binom{n+2}{k+2} = (n+2)(n+1)\\binom{n}{k}$. Two applications of the absorption identity. This gives the second factorial moment $E[X(X-1)] = n(n-1)p^2$, from which the variance formula $\\text{Var}(X) = np(1-p)$ follows algebraically.",
+    "proofId": "binomial-theorem-oq-03",
+    "range": { "startLine": 203, "endLine": 253 },
+    "type": "theorem",
+    "title": "double_absorption: (k+2)(k+1)·C(n+2,k+2) = (n+2)(n+1)·C(n,k)",
+    "content": "`double_absorption`: $(k+2)(k+1)\\binom{n+2}{k+2} = (n+2)(n+1)\\binom{n}{k}$. Two applications of the absorption identity. This gives the second factorial moment $E[X(X-1)] = n(n-1)p^2$, from which the variance formula $\\text{Var}(X) = np(1-p)$ follows algebraically.",
     "mathContext": "Apply absorption twice: $(k+2)\\binom{n+2}{k+2} = (n+2)\\binom{n+1}{k+1}$, then $(k+1)\\binom{n+1}{k+1} = (n+1)\\binom{n}{k}$. Multiplying: $(k+2)(k+1)\\binom{n+2}{k+2} = (n+2)(n+1)\\binom{n}{k}$. Proved via `nlinarith` from two instances of the single absorption identity.",
     "significance": "key",
     "relatedConcepts": [
@@ -170,18 +151,15 @@
     "prerequisites": [
       "absorption identity (single)",
       "Nat.choose"
-    ],
-    "proofId": "binomial-theorem-oq-03",
-    "range": {
-      "startLine": 203,
-      "endLine": 253
-    }
+    ]
   },
   {
     "id": "binomial-variance",
-    "line": 255,
-    "type": "technique",
-    "content": "**binomial_variance**: $\\text{Var}(X) = np(1-p)$ for $n \\geq 2$. Uses the identity $\\text{Var}(X) = E[X^2] - (E[X])^2 = (E[X(X-1)] + E[X]) - (E[X])^2 = n(n-1)p^2 + np - n^2p^2 = np(1-p)$. The second factorial moment avoids the $E[X^2]$ computation directly.",
+    "proofId": "binomial-theorem-oq-03",
+    "range": { "startLine": 255, "endLine": 268 },
+    "type": "theorem",
+    "title": "binomial_variance: Var(X) = np(1−p) via Falling Factorial Moments",
+    "content": "`binomial_variance`: $\\text{Var}(X) = np(1-p)$ for $n \\geq 2$. Uses the identity $\\text{Var}(X) = E[X^2] - (E[X])^2 = (E[X(X-1)] + E[X]) - (E[X])^2 = n(n-1)p^2 + np - n^2p^2 = np(1-p)$. The second factorial moment avoids the $E[X^2]$ computation directly.",
     "mathContext": "$\\text{Var}(X) = E[X(X-1)] + E[X] - (E[X])^2 = n(n-1)p^2 + np - (np)^2 = np - np^2 = np(1-p)$. The detour through $E[X(X-1)]$ instead of $E[X^2]$ is standard because the falling factorial $k(k-1)$ pairs naturally with the double absorption identity.",
     "significance": "key",
     "relatedConcepts": [
@@ -193,18 +171,15 @@
     "prerequisites": [
       "binomial_second_factorial_moment",
       "binomial_mean"
-    ],
-    "proofId": "binomial-theorem-oq-03",
-    "range": {
-      "startLine": 255,
-      "endLine": 268
-    }
+    ]
   },
   {
     "id": "vandermonde-convolution",
-    "line": 283,
-    "type": "technique",
-    "content": "**binomPMF_convolution**: The reproductive property $\\sum_j \\text{PMF}_n(j) \\cdot \\text{PMF}_m(k-j) = \\text{PMF}_{n+m}(k)$. The sum of independent $\\text{Bin}(n,p)$ and $\\text{Bin}(m,p)$ has distribution $\\text{Bin}(n+m,p)$. Proved by factoring out $p^k(1-p)^{n+m-k}$ and applying Vandermonde's identity.",
+    "proofId": "binomial-theorem-oq-03",
+    "range": { "startLine": 273, "endLine": 328 },
+    "type": "theorem",
+    "title": "binomPMF_convolution: Reproductive Property via Vandermonde's Identity",
+    "content": "`binomPMF_convolution`: The reproductive property $\\sum_j \\text{PMF}_n(j) \\cdot \\text{PMF}_m(k-j) = \\text{PMF}_{n+m}(k)$. The sum of independent $\\text{Bin}(n,p)$ and $\\text{Bin}(m,p)$ has distribution $\\text{Bin}(n+m,p)$. Proved by factoring out $p^k(1-p)^{n+m-k}$ and applying Vandermonde's identity.",
     "mathContext": "Vandermonde: $\\binom{n+m}{k} = \\sum_{j=0}^{k} \\binom{n}{j}\\binom{m}{k-j}$. Each convolution term: $\\binom{n}{j}p^j(1-p)^{n-j} \\cdot \\binom{m}{k-j}p^{k-j}(1-p)^{m-k+j} = \\binom{n}{j}\\binom{m}{k-j} \\cdot p^k(1-p)^{n+m-k}$. Summing over $j$ gives $\\binom{n+m}{k} p^k (1-p)^{n+m-k}$.",
     "significance": "key",
     "relatedConcepts": [
@@ -217,73 +192,63 @@
       "vandermonde_range",
       "binomPMF definition",
       "power laws"
-    ],
-    "proofId": "binomial-theorem-oq-03",
-    "range": {
-      "startLine": 273,
-      "endLine": 328
-    }
+    ]
   },
   {
     "id": "compound-interest-limit",
-    "line": 335,
-    "type": "technique",
-    "content": "**tendsto_one_plus_div_pow_exp**: The classical limit $(1 + x/n)^n \\to e^x$, proved from first principles. The strategy: (A) $\\text{HasDerivAt}(\\log(1+t), 1, 0)$ gives $\\log(1+h)/h \\to 1$ as $h \\to 0$; (B) compose with $h = x/n \\to 0$ to get $n\\log(1+x/n) \\to x$; (C) continuity of $\\exp$ gives $\\exp(n\\log(1+x/n)) = (1+x/n)^n \\to e^x$. This result was not in Mathlib v4.26.0.",
-    "mathContext": "The limit $(1+x/n)^n \\to e^x$ is the foundation of compound interest ($x > 0$) and the Poisson limit ($x = -r < 0$). The proof uses the characterization $e^x = \\lim_{n\\to\\infty}(1+x/n)^n$, which is equivalent to $\\exp = $ the unique solution of $f' = f$, $f(0) = 1$. The key analytic inputs are `Real.hasDerivAt_log` and `Real.continuous_exp`.",
+    "proofId": "binomial-theorem-oq-03",
+    "range": { "startLine": 335, "endLine": 409 },
+    "type": "theorem",
+    "title": "tendsto_one_plus_div_pow_exp: (1 + x/n)^n → e^x (First Principles)",
+    "content": "`tendsto_one_plus_div_pow_exp`: The classical limit $(1 + x/n)^n \\to e^x$, proved from first principles. Strategy: (A) `HasDerivAt(log(1+t), 1, 0)` gives $\\log(1+h)/h \\to 1$ as $h \\to 0$; (B) compose with $h = x/n \\to 0$ to get $n\\log(1+x/n) \\to x$; (C) continuity of `exp` gives $\\exp(n\\log(1+x/n)) = (1+x/n)^n \\to e^x$. This result was not in Mathlib v4.26.0.",
+    "mathContext": "The limit $(1+x/n)^n \\to e^x$ is the foundation of compound interest ($x > 0$) and the Poisson limit ($x = -r < 0$). The proof uses the characterization $e^x = \\lim_{n\\to\\infty}(1+x/n)^n$, equivalent to $\\exp = $ the unique solution of $f' = f$, $f(0) = 1$. Key analytic inputs: `Real.hasDerivAt_log` and `Real.continuous_exp`.",
     "significance": "key",
     "relatedConcepts": [
       "compound interest",
       "exponential function",
       "HasDerivAt",
-      "slope",
-      "nhdsWithin",
-      "Filter.Tendsto"
+      "Filter.Tendsto",
+      "Real.hasDerivAt_log"
     ],
     "prerequisites": [
       "Real.hasDerivAt_log",
       "Real.continuous_exp",
       "tendsto_const_div_atTop_nhds_zero_nat"
-    ],
-    "proofId": "binomial-theorem-oq-03",
-    "range": {
-      "startLine": 335,
-      "endLine": 409
-    }
+    ]
   },
   {
     "id": "poisson-pmf",
-    "line": 411,
+    "proofId": "binomial-theorem-oq-03",
+    "range": { "startLine": 411, "endLine": 428 },
     "type": "definition",
-    "content": "**poissonPMF**: The Poisson probability mass function $P(X=k) = e^{-r} r^k / k!$. This is the limiting distribution of $\\text{Bin}(n, r/n)$ as $n \\to \\infty$, modeling the count of rare events occurring at rate $r$.",
-    "mathContext": "For $X \\sim \\text{Poi}(r)$: $P(X=k) = e^{-r} r^k / k!$ for $k = 0, 1, 2, \\ldots$. The Poisson family is also reproductive ($\\text{Poi}(r_1) * \\text{Poi}(r_2) = \\text{Poi}(r_1+r_2)$) and is the unique distribution whose PGF is $e^{r(t-1)}$. The recurrence $P(k+1) = P(k) \\cdot r/(k+1)$ is used in the inductive proof.",
+    "title": "poissonPMF: P(X=k) = e^{−r} r^k / k! as Limiting Distribution",
+    "content": "`poissonPMF`: The Poisson probability mass function $P(X=k) = e^{-r} r^k / k!$. This is the limiting distribution of $\\text{Bin}(n, r/n)$ as $n \\to \\infty$, modeling the count of rare events occurring at rate $r$.",
+    "mathContext": "For $X \\sim \\text{Poi}(r)$: $P(X=k) = e^{-r} r^k / k!$ for $k = 0, 1, 2, \\ldots$. The Poisson family is reproductive ($\\text{Poi}(r_1) * \\text{Poi}(r_2) = \\text{Poi}(r_1+r_2)$) and is the unique distribution whose PGF is $e^{r(t-1)}$. The recurrence $P(k+1) = P(k) \\cdot r/(k+1)$ is used in the inductive proof of the Poisson limit.",
     "significance": "key",
     "relatedConcepts": [
       "Poisson distribution",
       "law of rare events",
       "exponential function",
-      "factorial"
+      "Nat.factorial"
     ],
     "prerequisites": [
       "Real.exp",
       "Nat.factorial"
-    ],
-    "proofId": "binomial-theorem-oq-03",
-    "range": {
-      "startLine": 411,
-      "endLine": 428
-    }
+    ]
   },
   {
     "id": "poisson-limit",
-    "line": 527,
-    "type": "technique",
-    "content": "**poisson_limit**: For each fixed $k$ and $r > 0$, $\\text{Bin}(n, r/n)(k) \\to \\text{Poi}(r)(k)$ as $n \\to \\infty$. Proved by induction on $k$: the base case $(1-r/n)^n \\to e^{-r}$ is the compound interest limit; the inductive step uses the PMF ratio $\\text{PMF}(k+1)/\\text{PMF}(k) = (n-k)(r/n)/((k+1)(1-r/n)) \\to r/(k+1)$, matching the Poisson recurrence.",
+    "proofId": "binomial-theorem-oq-03",
+    "range": { "startLine": 527, "endLine": 558 },
+    "type": "theorem",
+    "title": "poisson_limit: Bin(n, r/n)(k) → Poi(r)(k) as n → ∞",
+    "content": "`poisson_limit`: For each fixed $k$ and $r > 0$, $\\text{Bin}(n, r/n)(k) \\to \\text{Poi}(r)(k)$ as $n \\to \\infty$. Proved by induction on $k$: the base case $(1-r/n)^n \\to e^{-r}$ is the compound interest limit; the inductive step uses the PMF ratio $\\text{PMF}(k+1)/\\text{PMF}(k) = (n-k)(r/n)/((k+1)(1-r/n)) \\to r/(k+1)$, matching the Poisson recurrence.",
     "mathContext": "The Poisson limit theorem: if $n \\to \\infty$ and $np_n \\to r$, then $\\binom{n}{k}p_n^k(1-p_n)^{n-k} \\to e^{-r}r^k/k!$ for each fixed $k$. Here $p_n = r/n$. The inductive proof avoids Stirling's approximation by using the ratio $P(k+1)/P(k) = (n-k)p/((k+1)(1-p))$, which converges to $r/(k+1)$ by `poisson_ratio_tendsto`.",
     "significance": "key",
     "relatedConcepts": [
       "Poisson approximation",
       "law of rare events",
-      "induction",
+      "induction on k",
       "Filter.Tendsto.mul"
     ],
     "prerequisites": [
@@ -291,32 +256,24 @@
       "poissonPMF_succ",
       "binomPMF_succ_eq",
       "poisson_ratio_tendsto"
-    ],
-    "proofId": "binomial-theorem-oq-03",
-    "range": {
-      "startLine": 527,
-      "endLine": 558
-    }
+    ]
   },
   {
     "id": "summary-theorem",
-    "line": 564,
-    "type": "technique",
-    "content": "**binomial_oq03_extended_summary**: A single conjunction theorem packaging all seven main results: normalization ($\\sum \\text{PMF} = 1$), mean ($np$), variance ($np(1-p)$), PGF ($(pt+1-p)^n$), fair coin ($\\binom{n}{k}/2^n$), convolution (Vandermonde), and the Poisson limit. This serves as the machine-checkable answer to OQ-03.",
-    "mathContext": "The theorem statement is a 7-tuple conjunction, proved by applying each individual theorem. It demonstrates that every listed property of $\\text{Bin}(n,p)$ follows from the algebraic binomial theorem with 0 sorries and 0 axioms.",
+    "proofId": "binomial-theorem-oq-03",
+    "range": { "startLine": 564, "endLine": 580 },
+    "type": "theorem",
+    "title": "binomial_oq03_extended_summary: All 7 Properties as a Single Conjunction",
+    "content": "`binomial_oq03_extended_summary`: A single conjunction theorem packaging all seven main results: normalization ($\\sum \\text{PMF} = 1$), mean ($np$), variance ($np(1-p)$), PGF ($(pt+1-p)^n$), fair coin ($\\binom{n}{k}/2^n$), convolution (Vandermonde), and the Poisson limit. This serves as the machine-checkable answer to OQ-03.",
+    "mathContext": "The theorem statement is a 7-tuple conjunction, proved by applying each individual theorem. It demonstrates that every listed property of $\\text{Bin}(n,p)$ follows from the algebraic binomial theorem with 0 sorries and 0 axioms. The conjunction type in Lean is `And` (right-associative `∧`).",
     "significance": "key",
     "relatedConcepts": [
       "conjunction",
       "proof summary",
-      "research question"
+      "And.intro"
     ],
     "prerequisites": [
       "All preceding theorems in the file"
-    ],
-    "proofId": "binomial-theorem-oq-03",
-    "range": {
-      "startLine": 564,
-      "endLine": 580
-    }
+    ]
   }
 ]

--- a/src/data/proofs/erdos-1143/annotations.json
+++ b/src/data/proofs/erdos-1143/annotations.json
@@ -1,9 +1,11 @@
 [
   {
     "id": "covered-in-interval",
-    "line": 39,
+    "proofId": "erdos-1143",
+    "range": { "startLine": 39, "endLine": 43 },
     "type": "definition",
-    "content": "**coveredInInterval**: The set of integers in $[a, a+k)$ divisible by at least one prime in the given set. Defined by filtering `Finset.Ico a (a+k)` with the existential divisibility predicate. This is the fundamental counting object: its cardinality varies with the starting position $a$, and the covering function minimizes over all $a$.",
+    "title": "coveredInInterval: Integers in [a, a+k) Divisible by at Least One Prime",
+    "content": "`coveredInInterval`: The set of integers in $[a, a+k)$ divisible by at least one prime in the given set. Defined by filtering `Finset.Ico a (a+k)` with the existential divisibility predicate. This is the fundamental counting object: its cardinality varies with the starting position $a$, and the covering function minimizes over all $a$.",
     "mathContext": "For primes $\\{p_1, \\ldots, p_u\\}$ and interval $[a, a+k)$: $\\text{covered}(a,k) = \\{n \\in [a, a+k) : \\exists p_i \\mid n\\}$. By the Chinese Remainder Theorem, as $k \\to \\infty$, $|\\text{covered}(a,k)| / k \\to 1 - \\prod(1 - 1/p_i)$ for most $a$.",
     "significance": "key",
     "relatedConcepts": [
@@ -15,14 +17,15 @@
     "prerequisites": [
       "Finset.Ico half-open intervals",
       "existential quantification over Finset"
-    ],
-    "proofId": "erdos-1143"
+    ]
   },
   {
     "id": "covering-function",
-    "line": 44,
+    "proofId": "erdos-1143",
+    "range": { "startLine": 44, "endLine": 48 },
     "type": "definition",
-    "content": "**coveringFunction** $F_k$: The infimum over all starting positions $a$ of the cardinality of `coveredInInterval`. This captures the *worst-case* covering: the starting position that minimizes the number of covered integers. Defined as a `iInf` over $\\mathbb{N}$, making it noncomputable.",
+    "title": "coveringFunction F_k: Worst-Case (Infimum) Covering Count",
+    "content": "`coveringFunction` $F_k$: The infimum over all starting positions $a$ of the cardinality of `coveredInInterval`. This captures the *worst-case* covering: the starting position that minimizes the number of covered integers. Defined as a `iInf` over $\\mathbb{N}$, making it noncomputable.",
     "mathContext": "$F_k(p_1, \\ldots, p_u) = \\inf_{a \\in \\mathbb{N}} |\\{n \\in [a, a+k) : \\exists p_i \\mid n\\}|$. The infimum is achieved because the covering pattern repeats with period $\\text{lcm}(p_1, \\ldots, p_u)$, so only finitely many starting positions matter modulo the LCM.",
     "significance": "key",
     "relatedConcepts": [
@@ -34,14 +37,15 @@
     "prerequisites": [
       "Lattice infimum iInf",
       "coveredInInterval definition"
-    ],
-    "proofId": "erdos-1143"
+    ]
   },
   {
     "id": "expected-density",
-    "line": 49,
+    "proofId": "erdos-1143",
+    "range": { "startLine": 49, "endLine": 56 },
     "type": "definition",
-    "content": "**expectedDensity**: The proportion $1 - \\prod_{p \\in S}(1 - 1/p)$ of integers divisible by at least one prime in $S$. This is the inclusion-exclusion density, equivalent to the probability that a random integer is divisible by some $p_i$ when the primes are treated as independent sieves. The product form arises from Möbius inversion.",
+    "title": "expectedDensity: 1 − ∏(1 − 1/p) via Inclusion-Exclusion",
+    "content": "`expectedDensity`: The proportion $1 - \\prod_{p \\in S}(1 - 1/p)$ of integers divisible by at least one prime in $S$. This is the inclusion-exclusion density, equivalent to the probability that a random integer is divisible by some $p_i$ when the primes are treated as independent sieves. The product form arises from Möbius inversion.",
     "mathContext": "By inclusion-exclusion: $d(S) = \\sum_{\\emptyset \\neq T \\subseteq S} (-1)^{|T|+1} \\prod_{p \\in T} 1/p = 1 - \\prod_{p \\in S}(1 - 1/p)$. For $S = \\{2,3\\}$: $d = 1 - (1/2)(2/3) = 2/3$. For $S = \\{2,3,5\\}$: $d = 1 - (1/2)(2/3)(4/5) = 11/15$.",
     "significance": "key",
     "relatedConcepts": [
@@ -53,31 +57,34 @@
     "prerequisites": [
       "Finset.prod (big operators)",
       "real arithmetic"
-    ],
-    "proofId": "erdos-1143"
+    ]
   },
   {
     "id": "covering-le-k",
-    "line": 57,
-    "type": "technique",
-    "content": "**Trivial upper bound**: $F_k \\leq k$. At most $k$ integers in an interval of $k$ consecutive integers can be divisible by anything. This is the starting point for non-trivial estimates.",
+    "proofId": "erdos-1143",
+    "range": { "startLine": 57, "endLine": 68 },
+    "type": "theorem",
+    "title": "covering_le_k: Trivial Upper Bound F_k ≤ k",
+    "content": "`covering_le_k`: At most $k$ integers in an interval of $k$ consecutive integers can be divisible by anything. This is the starting point for non-trivial estimates. Proved via `Finset.card_filter_le` and `ciInf_le_of_le` with the constant 0 as the starting position.",
     "mathContext": "Since $\\text{covered}(a,k) \\subseteq [a, a+k)$ and $|[a,a+k)| = k$, we have $|\\text{covered}(a,k)| \\leq k$ for all $a$, hence $\\inf_a |\\text{covered}(a,k)| \\leq k$.",
     "significance": "supporting",
     "relatedConcepts": [
       "Finset.card_le_card",
-      "Finset.filter_subset"
+      "Finset.filter_subset",
+      "ciInf_le_of_le"
     ],
     "prerequisites": [
       "coveredInInterval definition",
       "coveringFunction definition"
-    ],
-    "proofId": "erdos-1143"
+    ]
   },
   {
     "id": "single-prime-bounds",
-    "line": 64,
-    "type": "technique",
-    "content": "**Single prime sandwich**: For a single prime $p$, $\\lfloor k/p \\rfloor \\leq F_k(\\{p\\}) \\leq \\lfloor k/p \\rfloor + 1$. In any $k$ consecutive integers, there are either $\\lfloor k/p \\rfloor$ or $\\lfloor k/p \\rfloor + 1$ multiples of $p$, depending on the starting position modulo $p$.",
+    "proofId": "erdos-1143",
+    "range": { "startLine": 69, "endLine": 163 },
+    "type": "theorem",
+    "title": "single_prime_lower/upper: ⌊k/p⌋ ≤ F_k({p}) ≤ ⌊k/p⌋ + 1",
+    "content": "**Single prime sandwich**: For a single prime $p$, $\\lfloor k/p \\rfloor \\leq F_k(\\{p\\}) \\leq \\lfloor k/p \\rfloor + 1$. In any $k$ consecutive integers, there are either $\\lfloor k/p \\rfloor$ or $\\lfloor k/p \\rfloor + 1$ multiples of $p$, depending on the starting position modulo $p$.\n\nThe lower bound proof constructs an explicit injection from `Finset.range (k/p)` into the filtered interval using the map $i \\mapsto (\\lceil a/p \\rceil + i) \\cdot p$, verified to land in $[a, a+k)$ by ceiling arithmetic.",
     "mathContext": "Among $k$ consecutive integers starting at $a$, the multiples of $p$ are $\\{a + r, a + r + p, \\ldots\\}$ where $r = p - (a \\bmod p)$. The count is $\\lfloor(k - r)/p\\rfloor + 1$ if $r \\leq k$, else $\\lfloor k/p \\rfloor$. The minimum over $a$ is $\\lfloor k/p \\rfloor$.",
     "significance": "key",
     "relatedConcepts": [
@@ -90,14 +97,15 @@
       "Nat.Prime",
       "coveringFunction definition",
       "division with remainder"
-    ],
-    "proofId": "erdos-1143"
+    ]
   },
   {
     "id": "density-positivity",
-    "line": 77,
-    "type": "technique",
-    "content": "**Density is positive**: $0 < d(S) < 1$ for any nonempty set of primes. Each factor $(1 - 1/p) \\in (0,1)$ for primes $p \\geq 2$, so their product is in $(0,1)$, making $d = 1 - \\prod(1-1/p) \\in (0,1)$. This ensures the covering function grows linearly in $k$.",
+    "proofId": "erdos-1143",
+    "range": { "startLine": 165, "endLine": 194 },
+    "type": "theorem",
+    "title": "expectedDensity_pos/lt_one: Density is Strictly in (0, 1)",
+    "content": "**Density is positive**: $0 < d(S) < 1$ for any nonempty set of primes. Each factor $(1 - 1/p) \\in (0,1)$ for primes $p \\geq 2$, so their product is in $(0,1)$, making $d = 1 - \\prod(1-1/p) \\in (0,1)$. This ensures the covering function grows linearly in $k$.\n\nBoth `expectedDensity_pos` and `expectedDensity_lt_one` use the auxiliary `prod_one_sub_inv_pos` which bounds each factor via `Finset.prod_pos`.",
     "mathContext": "For primes $p \\geq 2$: $0 < 1 - 1/p \\leq 1/2 < 1$, so $0 < \\prod_{p \\in S}(1 - 1/p) < 1$ when $S \\neq \\emptyset$. Hence $0 < 1 - \\prod(1-1/p) < 1$. The density approaches 1 as more primes are included (by Mertens' theorem, $\\prod_{p \\leq x}(1-1/p) \\sim 2e^{-\\gamma}/\\ln x$).",
     "significance": "key",
     "relatedConcepts": [
@@ -108,14 +116,15 @@
     "prerequisites": [
       "Nat.Prime implies p >= 2",
       "Finset.prod over (0,1) factors"
-    ],
-    "proofId": "erdos-1143"
+    ]
   },
   {
     "id": "covering-asymptotic",
-    "line": 92,
-    "type": "technique",
-    "content": "**Asymptotic density axiom**: $|F_k - k \\cdot d(S)| \\leq C$ for a constant $C$ depending only on the prime set, not on $k$. This says the covering function is well-approximated by the density prediction, with bounded error. Axiomatized because the proof requires CRT-based equidistribution in residue classes.",
+    "proofId": "erdos-1143",
+    "range": { "startLine": 196, "endLine": 207 },
+    "type": "concept",
+    "title": "covering_asymptotic Axiom: |F_k − k·d(S)| ≤ C (CRT Equidistribution)",
+    "content": "**Asymptotic density axiom** (`axiom covering_asymptotic`): $|F_k - k \\cdot d(S)| \\leq C$ for a constant $C$ depending only on the prime set, not on $k$. This says the covering function is well-approximated by the density prediction, with bounded error. Axiomatized because the proof requires CRT-based equidistribution in residue classes.",
     "mathContext": "The covering count in $[a, a+k)$ decomposes by residue classes modulo $\\text{lcm}(p_1, \\ldots, p_u)$. The deviation from $k \\cdot d$ comes from incomplete periods at the interval boundaries, contributing at most $O(\\text{lcm})$ error. The constant $C$ can be taken as $\\prod p_i$.",
     "significance": "key",
     "relatedConcepts": [
@@ -128,14 +137,15 @@
       "expectedDensity definition",
       "coveringFunction definition",
       "CRT for coprime moduli"
-    ],
-    "proofId": "erdos-1143"
+    ]
   },
   {
     "id": "erdos-selfridge-exact",
-    "line": 102,
-    "type": "technique",
-    "content": "**Erdős-Selfridge axiom** ($2 < \\alpha < 3$): When $k = \\alpha p_u$ with $\\alpha \\in (2,3)$, an exact value of $F_k$ exists. This is one of the 'lost results' in combinatorial number theory — Erdős and Selfridge reportedly found the formula, but the paper has never been located. Axiomatized as a placeholder for a known but unavailable result.",
+    "proofId": "erdos-1143",
+    "range": { "startLine": 208, "endLine": 228 },
+    "type": "theorem",
+    "title": "erdos_selfridge_exact: Exact F_k for k = αp_u with α ∈ (2,3) (Lost Result)",
+    "content": "**Erdős-Selfridge exact formula** for $\\alpha \\in (2,3)$: When $k = \\alpha p_u$ with $\\alpha \\in (2,3)$, an exact value of $F_k$ exists. This is one of the 'lost results' in combinatorial number theory — Erdős and Selfridge reportedly found the formula, but the paper has never been located. Axiomatized as a placeholder for a known but unavailable result.",
     "mathContext": "When $\\alpha \\in (2,3)$, the interval $[a, a+k)$ contains exactly 2 or 3 multiples of $p_u$, creating a constrained optimization. The exact formula likely involves the precise residue class structure modulo $p_u$ combined with covering by smaller primes. The axiom states $\\exists v, F_k = v$ without specifying $v$.",
     "significance": "key",
     "relatedConcepts": [
@@ -148,14 +158,15 @@
       "coveringFunction definition",
       "Nat.floor",
       "Finset.max'"
-    ],
-    "proofId": "erdos-1143"
+    ]
   },
   {
     "id": "alpha-gt-3-open",
-    "line": 110,
-    "type": "technique",
-    "content": "**Open regime axiom** ($\\alpha > 3$): For $k = \\alpha p_u$ with $\\alpha > 3$, the covering function satisfies density-type bounds: $k(d-1) \\leq F_k \\leq kd + u$. This is essentially the density approximation plus/minus terms depending on the number of primes. Very little beyond these bounds is known.",
+    "proofId": "erdos-1143",
+    "range": { "startLine": 236, "endLine": 252 },
+    "type": "theorem",
+    "title": "alpha_gt_3_open: Density Bounds k(d−1) ≤ F_k ≤ kd + u for α > 3",
+    "content": "**Open regime bounds** ($\\alpha > 3$): For $k = \\alpha p_u$ with $\\alpha > 3$, the covering function satisfies density-type bounds: $k(d-1) \\leq F_k \\leq kd + u$. This is essentially the density approximation plus/minus terms depending on the number of primes. Very little beyond these bounds is known.",
     "mathContext": "The upper bound $F_k \\leq kd + u$ adds at most one extra covered integer per prime (boundary effects). The lower bound $F_k \\geq k(d-1)$ is a weak form; the interesting question is whether $F_k \\geq k(d - \\epsilon)$ for small $\\epsilon$. Progress here would constrain Jacobsthal's function from above.",
     "significance": "key",
     "relatedConcepts": [
@@ -168,15 +179,16 @@
       "coveringFunction definition",
       "expectedDensity definition",
       "Finset.card (number of primes)"
-    ],
-    "proofId": "erdos-1143"
+    ]
   },
   {
     "id": "density-two-three",
-    "line": 125,
-    "type": "technique",
+    "proofId": "erdos-1143",
+    "range": { "startLine": 253, "endLine": 258 },
+    "type": "theorem",
+    "title": "density_two_three: d({2,3}) = 2/3, the Simplest Non-Trivial Case",
     "content": "**Concrete example**: $d(\\{2,3\\}) = 1 - (1-1/2)(1-1/3) = 1 - 1/3 = 2/3$. In any 6 consecutive integers, exactly 4 are divisible by 2 or 3 (and the minimum over starting positions is also 4). This is the simplest non-trivial case of the covering problem.",
-    "mathContext": "The 6-element pattern modulo $\\text{lcm}(2,3) = 6$ is: positions $\\{0,2,3,4\\}$ are covered (0 by both, 2 by 2, 3 by 3, 4 by 2), positions $\\{1,5\\}$ are uncovered (both coprime to 6). So $F_6(\\{2,3\\}) = 4 = 6 \\cdot 2/3$.",
+    "mathContext": "The 6-element pattern modulo $\\text{lcm}(2,3) = 6$ is: positions $\\{0,2,3,4\\}$ are covered (0 by both, 2 by 2, 3 by 3, 4 by 2), positions $\\{1,5\\}$ are uncovered. So $F_6(\\{2,3\\}) = 4 = 6 \\cdot 2/3$. Proved by `norm_num` with `Finset.prod_pair`.",
     "significance": "supporting",
     "relatedConcepts": [
       "Finset.prod computation",
@@ -186,13 +198,14 @@
     "prerequisites": [
       "expectedDensity definition",
       "rational arithmetic in Lean"
-    ],
-    "proofId": "erdos-1143"
+    ]
   },
   {
     "id": "density-two-three-five",
-    "line": 131,
-    "type": "technique",
+    "proofId": "erdos-1143",
+    "range": { "startLine": 259, "endLine": 265 },
+    "type": "theorem",
+    "title": "density_two_three_five: d({2,3,5}) = 11/15 via Euler's Totient",
     "content": "**Three-prime example**: $d(\\{2,3,5\\}) = 1 - (1/2)(2/3)(4/5) = 1 - 4/15 = 11/15 \\approx 0.733$. Among 30 consecutive integers (one full period of $\\text{lcm}(2,3,5) = 30$), exactly 22 are divisible by 2, 3, or 5. The 8 coprime elements are $\\{1,7,11,13,17,19,23,29\\}$ — the totatives of 30.",
     "mathContext": "Euler's totient: $\\phi(30) = 30 \\cdot (1-1/2)(1-1/3)(1-1/5) = 8$, so 22 out of 30 are covered. The density $11/15$ is exact by CRT periodicity. Adding more primes increases coverage: $d(\\{2,3,5,7\\}) = 1 - (1/2)(2/3)(4/5)(6/7) = 209/210$.",
     "significance": "supporting",
@@ -205,15 +218,16 @@
     "prerequisites": [
       "expectedDensity definition",
       "Finset.prod with three elements"
-    ],
-    "proofId": "erdos-1143"
+    ]
   },
   {
     "id": "jacobsthal-connection",
-    "line": 147,
-    "type": "concept",
+    "proofId": "erdos-1143",
+    "range": { "startLine": 253, "endLine": 265 },
+    "type": "insight",
+    "title": "Jacobsthal Duality: Covered vs. Coprime (Erdős #1143 ↔ #970)",
     "content": "**Jacobsthal duality**: Erdős #970 asks for Jacobsthal's function $h(k)$: the minimal interval length guaranteeing an element coprime to $p_1 \\cdots p_u$. The relationship: uncovered $= k - F_k$, so minimizing covered (this problem) and maximizing coprime-free intervals (Jacobsthal) are dual. If $h(u)$ is the Jacobsthal value, then $F_{h(u)-1} = h(u)-1$ (all covered). Iwaniec proved $h(k) = O(k^{0.735})$.",
-    "mathContext": "Jacobsthal's function: $h(n) = \\min\\{m : \\text{every } m \\text{ consecutive integers contain one coprime to } n\\}$. For $n = p_1 \\cdots p_u$: $h(n) - 1 = \\max_a |\\{x \\in [a,a+h(n)-1) : \\gcd(x,n) > 1\\}| = h(n)-1$, i.e., $F_{h(n)-1} = h(n)-1$. This means $F_k < k$ for $k \\geq h(n)$.",
+    "mathContext": "Jacobsthal's function: $h(n) = \\min\\{m : \\text{every } m \\text{ consecutive integers contain one coprime to } n\\}$. For $n = p_1 \\cdots p_u$: $F_{h(u)-1} = h(u) - 1$ — the interval of length $h(u)-1$ starting at the worst position has all elements covered. Iwaniec's bound: $h(p\\#) = O((\\log p\\#)^{0.735})$ where $p\\# = \\prod_{q \\leq p} q$.",
     "significance": "key",
     "relatedConcepts": [
       "Jacobsthal's function",
@@ -226,7 +240,6 @@
       "coveringFunction definition",
       "complement counting",
       "GCD and coprimality"
-    ],
-    "proofId": "erdos-1143"
+    ]
   }
 ]

--- a/src/data/proofs/euler-polyhedral-formula-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-02-oq-01/annotations.json
@@ -1,320 +1,373 @@
 [
   {
     "id": "ann-compact-surface",
-    "line": 47,
+    "proofId": "euler-polyhedral-formula-oq-02-oq-01",
+    "range": { "startLine": 47, "endLine": 61 },
     "type": "definition",
-    "content": "Axiomatic structure encoding a compact orientable Riemannian 2-manifold: Euler characteristic χ(M), total Gaussian curvature ∫_M K dA, area ∫_M dA > 0, and the Gauss-Bonnet axiom ∫_M K dA = 2πχ. This is a minimal axiomatization — one axiom captures the entire Gauss-Bonnet theorem.",
-    "mathContext": "The structure encodes: $\\chi(M) \\in \\mathbb{Z}$, $\\int_M K\\,dA \\in \\mathbb{R}$, $\\text{Area}(M) > 0$, and the axiom $\\int_M K\\,dA = 2\\pi\\chi(M)$. Mathlib v4.26.0 lacks Riemannian metrics, so this axiomatization substitutes for the full differential-geometric proof.",
+    "title": "CompactRiemannianSurface: Minimal Axiomatization of Gauss-Bonnet",
+    "content": "Axiomatic structure encoding a compact orientable Riemannian 2-manifold: Euler characteristic χ(M), total Gaussian curvature ∫_M K dA, area ∫_M dA > 0, and the Gauss-Bonnet axiom ∫_M K dA = 2πχ. This is a minimal axiomatization — one axiom captures the entire Gauss-Bonnet theorem.\n\nMathlib v4.26.0 lacks Riemannian metrics and curvature tensors, so this axiomatization substitutes for the full differential-geometric proof. The structure requires area > 0 explicitly to enable division in average curvature computations.",
+    "mathContext": "The structure encodes: $\\chi(M) \\in \\mathbb{Z}$, $\\int_M K\\,dA \\in \\mathbb{R}$, $\\text{Area}(M) > 0$, and the axiom $\\int_M K\\,dA = 2\\pi\\chi(M)$. This is the smooth Gauss-Bonnet theorem — the discrete version (angular deficiency) appears in the parent proof EulerPolyhedralOQ02.lean.",
     "significance": "key",
     "relatedConcepts": [
       "Riemannian manifold",
       "Gaussian curvature",
       "Euler characteristic",
+      "Gauss-Bonnet theorem",
       "Theorema Egregium"
     ],
     "prerequisites": [
       "Real.pi_pos",
-      "basic structure syntax"
-    ],
-    "proofId": "euler-polyhedral-formula-oq-02-oq-01"
+      "basic structure syntax",
+      "Int (for chi)",
+      "Real (for curvature)"
+    ]
   },
   {
     "id": "ann-orientable-surface",
-    "line": 63,
+    "proofId": "euler-polyhedral-formula-oq-02-oq-01",
+    "range": { "startLine": 63, "endLine": 75 },
     "type": "definition",
-    "content": "Extends CompactRiemannianSurface with genus g ∈ ℕ and the topological relation χ = 2 - 2g. This encodes the classification of orientable closed surfaces: the genus (number of handles) uniquely determines the Euler characteristic.",
-    "mathContext": "For an orientable closed surface of genus $g$: $\\chi(M) = 2 - 2g$. This follows from the Betti numbers: $b_0 = 1$, $b_1 = 2g$, $b_2 = 1$, giving $\\chi = 1 - 2g + 1 = 2 - 2g$.",
+    "title": "OrientableClosedSurface: Genus Extension and χ = 2 − 2g",
+    "content": "Extends CompactRiemannianSurface with genus g ∈ ℕ and the topological relation χ = 2 − 2g. This encodes the classification of orientable closed surfaces: the genus (number of handles) uniquely determines the Euler characteristic.\n\n`total_curvature_genus` immediately follows: substituting χ = 2−2g into Gauss-Bonnet gives ∫K dA = 2π(2−2g) = 4π(1−g). `genus_from_total_curvature` inverts this, showing the genus is uniquely determined by total curvature.",
+    "mathContext": "For an orientable closed surface of genus $g$: $\\chi(M) = 2 - 2g$. This follows from the Betti numbers: $b_0 = 1$, $b_1 = 2g$, $b_2 = 1$, giving $\\chi = 1 - 2g + 1 = 2 - 2g$. The genus counts the number of handles: $g=0$ (sphere), $g=1$ (torus), $g=2$ (double torus).",
     "significance": "key",
     "relatedConcepts": [
       "genus",
       "classification of surfaces",
       "Betti numbers",
-      "handle decomposition"
+      "handle decomposition",
+      "chi_genus"
     ],
     "prerequisites": [
-      "CompactRiemannianSurface"
-    ],
-    "proofId": "euler-polyhedral-formula-oq-02-oq-01"
+      "CompactRiemannianSurface",
+      "Nat (for genus)"
+    ]
   },
   {
     "id": "ann-gauss-bonnet",
-    "line": 89,
-    "type": "technique",
-    "content": "States the Gauss-Bonnet theorem as a theorem (unwrapping the structure axiom): ∫_M K dA = 2πχ(M). This is the central result connecting local geometry to global topology — changing the Riemannian metric changes K pointwise but not the integral.",
-    "mathContext": "$$\\int_M K\\,dA = 2\\pi\\chi(M)$$\nThe proof for embedded surfaces uses Stokes' theorem applied to the connection form; Chern's intrinsic proof uses the Pfaffian of the curvature 2-form. Here it is simply the structure axiom `S.gauss_bonnet`.",
+    "proofId": "euler-polyhedral-formula-oq-02-oq-01",
+    "range": { "startLine": 89, "endLine": 98 },
+    "type": "theorem",
+    "title": "Gauss-Bonnet: ∫K dA = 2πχ Connecting Geometry to Topology",
+    "content": "States the Gauss-Bonnet theorem as a theorem (unwrapping the structure axiom): ∫_M K dA = 2πχ(M). This is the central result connecting local geometry to global topology — changing the Riemannian metric changes K pointwise but not the integral.\n\nThe proof for embedded surfaces uses Stokes' theorem applied to the connection form; Chern's intrinsic proof uses the Pfaffian of the curvature 2-form. Here it is simply `S.gauss_bonnet`, the structure axiom. The theorem statement also establishes `total_curvature_topological_invariant` and `curvature_metric_independent` as immediate consequences.",
+    "mathContext": "$$\\int_M K\\,dA = 2\\pi\\chi(M)$$\nFor the sphere ($\\chi = 2$): $\\int K\\,dA = 4\\pi$. For the torus ($\\chi = 0$): $\\int K\\,dA = 0$ — so the total curvature of the flat and round tori are identical, even though pointwise curvatures differ. This metric independence is the profound content of Gauss-Bonnet.",
     "significance": "key",
     "relatedConcepts": [
       "Gauss-Bonnet theorem",
       "topological invariant",
       "Stokes' theorem",
-      "curvature form"
+      "connection form",
+      "curvature 2-form"
     ],
     "prerequisites": [
-      "CompactRiemannianSurface"
-    ],
-    "proofId": "euler-polyhedral-formula-oq-02-oq-01"
+      "CompactRiemannianSurface",
+      "Real.pi_pos"
+    ]
   },
   {
     "id": "ann-topological-invariance",
-    "line": 95,
-    "type": "technique",
-    "content": "Total curvature is a topological invariant: surfaces with the same Euler characteristic have the same total curvature, regardless of which Riemannian metric they carry. This is the profound content of Gauss-Bonnet — geometry is constrained by topology.",
-    "mathContext": "If $\\chi(S_1) = \\chi(S_2)$, then $\\int_{S_1} K_1\\,dA_1 = \\int_{S_2} K_2\\,dA_2$. The metrics on $S_1, S_2$ can be completely different; only the topology matters.",
+    "proofId": "euler-polyhedral-formula-oq-02-oq-01",
+    "range": { "startLine": 95, "endLine": 109 },
+    "type": "theorem",
+    "title": "Total Curvature as Topological Invariant: Metric Independence",
+    "content": "Total curvature is a topological invariant: surfaces with the same Euler characteristic have the same total curvature, regardless of which Riemannian metric they carry. `total_curvature_topological_invariant` and `curvature_metric_independent` both follow immediately from substituting ∫K dA = 2πχ.\n\nThis is the profound content of Gauss-Bonnet — geometry is constrained by topology. One can freely deform the metric without changing the total curvature, as long as the topology is preserved.",
+    "mathContext": "If $\\chi(S_1) = \\chi(S_2)$, then $\\int_{S_1} K_1\\,dA_1 = \\int_{S_2} K_2\\,dA_2$. The metrics on $S_1, S_2$ can be completely different; only the topology matters. Proof: both sides equal $2\\pi\\chi$ by Gauss-Bonnet.",
     "significance": "key",
     "relatedConcepts": [
       "topological invariant",
       "metric independence",
-      "deformation invariance"
+      "deformation invariance",
+      "Riemannian metric"
     ],
     "prerequisites": [
       "gauss_bonnet_theorem"
-    ],
-    "proofId": "euler-polyhedral-formula-oq-02-oq-01"
+    ]
   },
   {
     "id": "ann-curvature-sign",
-    "line": 112,
-    "type": "technique",
-    "content": "Three fundamental curvature-topology constraints: positive total curvature implies χ > 0, negative implies χ < 0, zero implies χ = 0. Each proof substitutes ∫K dA = 2πχ and uses nlinarith with π > 0 to derive the sign of χ from the sign of the integral.",
-    "mathContext": "$\\int K\\,dA > 0 \\Rightarrow \\chi > 0$, $\\int K\\,dA < 0 \\Rightarrow \\chi < 0$, $\\int K\\,dA = 0 \\Rightarrow \\chi = 0$. Since $\\int K\\,dA = 2\\pi\\chi$ and $\\pi > 0$, the sign of $\\chi$ matches the sign of $\\int K\\,dA$.",
+    "proofId": "euler-polyhedral-formula-oq-02-oq-01",
+    "range": { "startLine": 112, "endLine": 136 },
+    "type": "theorem",
+    "title": "Curvature Sign ↔ Euler Characteristic Sign (Three Cases)",
+    "content": "Three fundamental curvature-topology constraints: positive total curvature implies χ > 0, negative implies χ < 0, zero implies χ = 0. Each proof substitutes ∫K dA = 2πχ and uses `nlinarith` with π > 0 to derive the sign of χ from the sign of the integral.\n\nThese sign constraints are the first level of topological classification: a surface with ∫K > 0 must be topologically a sphere (χ > 0 → g = 0), ∫K = 0 must be a torus (g = 1), and ∫K < 0 must have genus ≥ 2.",
+    "mathContext": "$\\int K\\,dA > 0 \\Rightarrow \\chi > 0$, $\\int K\\,dA < 0 \\Rightarrow \\chi < 0$, $\\int K\\,dA = 0 \\Rightarrow \\chi = 0$. Since $\\int K\\,dA = 2\\pi\\chi$ and $\\pi > 0$, the sign of $\\chi$ matches the sign of $\\int K\\,dA$. Proofs use `nlinarith [Real.pi_pos, S.gauss_bonnet]`.",
     "significance": "key",
     "relatedConcepts": [
       "sign of curvature",
       "topology constraints",
-      "nlinarith tactic"
+      "nlinarith tactic",
+      "classification of surfaces"
     ],
     "prerequisites": [
       "gauss_bonnet_theorem",
-      "Real.pi_pos"
-    ],
-    "proofId": "euler-polyhedral-formula-oq-02-oq-01"
+      "Real.pi_pos",
+      "nlinarith"
+    ]
   },
   {
     "id": "ann-special-surfaces",
-    "line": 140,
-    "type": "technique",
-    "content": "Computes total curvature for each genus: sphere (g=0) gives 4π, torus (g=1) gives 0, double torus (g=2) gives -4π. The general formula ∫K dA = 4π(1-g) follows from 2π(2-2g) = 4π(1-g). Proved by substituting the genus into total_curvature_genus and using linarith.",
-    "mathContext": "Genus $0$: $\\int K\\,dA = 4\\pi$. Genus $1$: $\\int K\\,dA = 0$. Genus $2$: $\\int K\\,dA = -4\\pi$. General: $\\int K\\,dA = 4\\pi(1 - g)$. Each step more negative by $4\\pi$ per handle added.",
+    "proofId": "euler-polyhedral-formula-oq-02-oq-01",
+    "range": { "startLine": 140, "endLine": 172 },
+    "type": "theorem",
+    "title": "Total Curvature by Genus: 4π, 0, −4π, and 4π(1−g) General",
+    "content": "Computes total curvature for each genus: sphere (g=0) gives 4π, torus (g=1) gives 0, double torus (g=2) gives −4π. The general formula ∫K dA = 4π(1−g) follows from 2π(2−2g) = 4π(1−g). Each theorem is proved by substituting the genus into `total_curvature_genus` and using `linarith`.\n\nEach additional handle reduces the total curvature by 4π. The genus uniquely determines total curvature: adding one handle means adding a negatively-curved region that exactly cancels 4π of positive curvature.",
+    "mathContext": "Genus $0$: $\\int K\\,dA = 4\\pi$. Genus $1$: $\\int K\\,dA = 0$. Genus $2$: $\\int K\\,dA = -4\\pi$. General: $\\int K\\,dA = 4\\pi(1 - g)$. Each step more negative by $4\\pi$ per handle added. Derived from $\\int K = 2\\pi\\chi = 2\\pi(2-2g) = 4\\pi(1-g)$.",
     "significance": "supporting",
     "relatedConcepts": [
       "sphere",
       "torus",
       "genus formula",
-      "handle addition"
+      "handle addition",
+      "4π per handle"
     ],
     "prerequisites": [
       "total_curvature_genus",
       "OrientableClosedSurface"
-    ],
-    "proofId": "euler-polyhedral-formula-oq-02-oq-01"
+    ]
   },
   {
     "id": "ann-genus-determination",
-    "line": 175,
-    "type": "technique",
-    "content": "Complete classification from curvature sign: ∫K dA > 0 forces genus 0 (sphere), = 0 forces genus 1 (torus), < 0 forces genus ≥ 2. The negative case uses by_contra and omega to eliminate g = 0 (where ∫K = 4π > 0, contradicting ∫K < 0) and g = 1 (where ∫K = 0, also contradicting).",
-    "mathContext": "$\\int K > 0 \\Rightarrow g = 0$ (sphere), $\\int K = 0 \\Rightarrow g = 1$ (torus), $\\int K < 0 \\Rightarrow g \\geq 2$ (hyperbolic). This is the topological content of the **uniformization theorem**: every closed surface admits constant curvature $+1, 0, -1$ matching its genus.",
+    "proofId": "euler-polyhedral-formula-oq-02-oq-01",
+    "range": { "startLine": 175, "endLine": 200 },
+    "type": "theorem",
+    "title": "Curvature Sign Determines Topology: Sphere/Torus/Hyperbolic Classification",
+    "content": "Complete classification from curvature sign: ∫K dA > 0 forces genus 0 (sphere), = 0 forces genus 1 (torus), < 0 forces genus ≥ 2. The negative case uses `by_contra` and `omega` to eliminate g = 0 (where ∫K = 4π > 0, contradicting ∫K < 0) and g = 1 (where ∫K = 0, also contradicting).\n\nThis is the topological content of the **uniformization theorem**: every closed surface admits a metric of constant curvature +1, 0, or −1 matching its genus class.",
+    "mathContext": "$\\int K > 0 \\Rightarrow g = 0$ (sphere), $\\int K = 0 \\Rightarrow g = 1$ (torus), $\\int K < 0 \\Rightarrow g \\geq 2$ (hyperbolic). The uniformization theorem guarantees a round metric (K≡1) for genus 0, a flat metric (K≡0) for genus 1, and a hyperbolic metric (K≡−1) for genus ≥ 2.",
     "significance": "key",
     "relatedConcepts": [
       "uniformization theorem",
       "classification of surfaces",
       "constant curvature metrics",
-      "Thurston geometrization"
+      "Thurston geometrization",
+      "by_contra + omega"
     ],
     "prerequisites": [
       "positive_curvature_positive_chi",
       "zero_curvature_zero_chi",
-      "negative_curvature_negative_chi"
-    ],
-    "proofId": "euler-polyhedral-formula-oq-02-oq-01"
+      "negative_curvature_negative_chi",
+      "omega"
+    ]
   },
   {
     "id": "ann-average-curvature",
-    "line": 203,
+    "proofId": "euler-polyhedral-formula-oq-02-oq-01",
+    "range": { "startLine": 203, "endLine": 238 },
     "type": "definition",
-    "content": "Average Gaussian curvature K_avg = ∫K dA / Area(M). By Gauss-Bonnet, K_avg = 2πχ / Area. Verified concretely: unit sphere (area 4π) has K_avg = 1, flat torus has K_avg = 0. The average curvature is always determined by topology and area.",
-    "mathContext": "$K_{\\text{avg}} = \\frac{\\int_M K\\,dA}{\\text{Area}(M)} = \\frac{2\\pi\\chi(M)}{\\text{Area}(M)}$. For the unit sphere: $K_{\\text{avg}} = 4\\pi / 4\\pi = 1$. For any flat torus: $K_{\\text{avg}} = 0/\\text{Area} = 0$.",
+    "title": "Average Gaussian Curvature: K_avg = 2πχ / Area",
+    "content": "Average Gaussian curvature K_avg = ∫K dA / Area(M). By Gauss-Bonnet, K_avg = 2πχ / Area. Verified concretely: unit sphere (area 4π) has K_avg = 1, flat torus has K_avg = 0. The average curvature is always determined by topology and area.\n\nThe `averageCurvature` def requires `area_pos` in CompactRiemannianSurface to make division safe. The Lean proof of `unit_sphere_curvature` uses `simp [averageCurvature, standardSphere]` — the key is that 4π/4π reduces to 1 via `div_self`.",
+    "mathContext": "$K_{\\text{avg}} = \\frac{\\int_M K\\,dA}{\\text{Area}(M)} = \\frac{2\\pi\\chi(M)}{\\text{Area}(M)}$. For the unit sphere: $K_{\\text{avg}} = 4\\pi / 4\\pi = 1$. For any flat torus: $K_{\\text{avg}} = 0/\\text{Area} = 0$. The average curvature captures the 'intrinsic roundness' normalized by size.",
     "significance": "supporting",
     "relatedConcepts": [
       "average curvature",
       "scalar curvature",
-      "area normalization"
+      "area normalization",
+      "div_self"
     ],
     "prerequisites": [
       "gauss_bonnet_theorem",
-      "CompactRiemannianSurface.area_pos"
-    ],
-    "proofId": "euler-polyhedral-formula-oq-02-oq-01"
+      "CompactRiemannianSurface.area_pos",
+      "Real.div_def"
+    ]
   },
   {
     "id": "ann-area-bound",
-    "line": 262,
-    "type": "technique",
-    "content": "Bonnet-type area bound: for a sphere (g=0) with K ≥ K_min > 0 everywhere, Area ≤ 4π/K_min. The proof uses K_min · Area ≤ ∫K dA = 4π. This is the 2D analogue of Bonnet's theorem (diameter ≤ π/√K_min), connecting curvature lower bounds to compactness.",
-    "mathContext": "If $K \\geq K_{\\min} > 0$ on a sphere: $\\text{Area}(M) \\leq \\frac{4\\pi}{K_{\\min}}$. Equality holds for the round sphere of radius $r = 1/\\sqrt{K_{\\min}}$ with area $4\\pi r^2 = 4\\pi/K_{\\min}$.",
+    "proofId": "euler-polyhedral-formula-oq-02-oq-01",
+    "range": { "startLine": 262, "endLine": 281 },
+    "type": "theorem",
+    "title": "Bonnet-Type Area Bound: Area ≤ 4π/K_min for Positive Curvature",
+    "content": "Bonnet-type area bound: for a sphere (g=0) with K ≥ K_min > 0 everywhere, Area ≤ 4π/K_min. The proof uses K_min · Area ≤ ∫K dA = 4π. This is the 2D analogue of Bonnet's theorem (diameter ≤ π/√K_min), connecting curvature lower bounds to compactness.\n\n`bonnet_genus_zero` combines this with the genus constraint: a surface with everywhere-positive curvature must be a sphere. The proof combines `area_bound_positive_curvature` with `positive_curvature_is_sphere`.",
+    "mathContext": "If $K \\geq K_{\\min} > 0$ on a sphere: $\\text{Area}(M) \\leq \\frac{4\\pi}{K_{\\min}}$. Equality holds for the round sphere of radius $r = 1/\\sqrt{K_{\\min}}$ with area $4\\pi r^2 = 4\\pi/K_{\\min}$. The Lean proof: $K_{\\min} \\cdot \\text{Area} \\leq \\int K\\,dA = 4\\pi$ by monotone integration, then `div_le_iff`.",
     "significance": "key",
     "relatedConcepts": [
       "Bonnet's theorem",
       "Myers' theorem",
       "diameter bounds",
-      "comparison geometry"
+      "comparison geometry",
+      "le_div_iff"
     ],
     "prerequisites": [
       "sphere_total_curvature",
-      "le_div_iff"
-    ],
-    "proofId": "euler-polyhedral-formula-oq-02-oq-01"
+      "le_div_iff",
+      "positive_curvature_is_sphere"
+    ]
   },
   {
     "id": "ann-discrete-connection",
-    "line": 297,
-    "type": "technique",
-    "content": "Proves smooth and discrete Gauss-Bonnet agree: both give 2πχ as total curvature. The smooth version uses K (Gaussian curvature), the discrete uses δ(v) = 2π - Σθ (angular deficiency). As a triangulation refines (mesh → 0), Σ_v δ(v) → ∫_M K dA, justifying finite element methods in geometric computing.",
-    "mathContext": "Smooth: $\\int_M K\\,dA = 2\\pi\\chi(M)$. Discrete: $\\sum_v \\delta(v) = 2\\pi\\chi(M)$. Both yield $4\\pi$ for $S^2$, $0$ for $T^2$, $-4\\pi$ for genus $2$. The discrete-to-smooth limit is: $\\lim_{\\text{mesh} \\to 0} \\sum_v \\delta(v) = \\int_M K\\,dA$.",
+    "proofId": "euler-polyhedral-formula-oq-02-oq-01",
+    "range": { "startLine": 297, "endLine": 313 },
+    "type": "theorem",
+    "title": "Smooth = Discrete: Both Yield 2πχ as Total Curvature",
+    "content": "Proves smooth and discrete Gauss-Bonnet agree: both give 2πχ as total curvature. The smooth version uses K (Gaussian curvature), the discrete uses δ(v) = 2π − Σθ (angular deficiency). As a triangulation refines (mesh → 0), Σ_v δ(v) → ∫_M K dA, justifying finite element methods in geometric computing.\n\nThe theorems `sphere_agreement`, `torus_agreement`, and `double_torus_agreement` compute numerically: $2\\pi \\cdot 2 = 4\\pi$, $2\\pi \\cdot 0 = 0$, $2\\pi \\cdot (-2) = -4\\pi$, proved by `push_cast; ring`.",
+    "mathContext": "Smooth: $\\int_M K\\,dA = 2\\pi\\chi(M)$. Discrete: $\\sum_v \\delta(v) = 2\\pi\\chi(M)$. Both yield $4\\pi$ for $S^2$, $0$ for $T^2$, $-4\\pi$ for genus $2$. The discrete-to-smooth limit: $\\lim_{\\text{mesh} \\to 0} \\sum_v \\delta(v) = \\int_M K\\,dA$. This limit is not formalized here but motivates the connection.",
     "significance": "key",
     "relatedConcepts": [
       "discrete differential geometry",
       "angular deficiency",
       "finite element methods",
-      "mesh refinement"
+      "mesh refinement",
+      "EulerPolyhedralOQ02.lean"
     ],
     "prerequisites": [
       "gauss_bonnet_theorem",
-      "EulerPolyhedralOQ02.lean"
-    ],
-    "proofId": "euler-polyhedral-formula-oq-02-oq-01"
+      "push_cast",
+      "ring"
+    ]
   },
   {
     "id": "ann-chern-generalization",
-    "line": 331,
+    "proofId": "euler-polyhedral-formula-oq-02-oq-01",
+    "range": { "startLine": 331, "endLine": 352 },
     "type": "definition",
-    "content": "Axiomatizes the Chern-Gauss-Bonnet theorem for compact oriented 2n-manifolds: ∫_M Pf(Ω) = (2π)^n χ(M), where Pf(Ω) is the Pfaffian of the curvature 2-form. Proves the n=1 (surface) case reduces to classical Gauss-Bonnet via (2π)^1 · χ = 2πχ.",
-    "mathContext": "For compact oriented $2n$-manifolds: $\\int_M \\text{Pf}(\\Omega) = (2\\pi)^n \\chi(M)$. For surfaces ($n=1$): $\\text{Pf}(\\Omega) = K\\,dA / (2\\pi)$, recovering $\\int K\\,dA = 2\\pi\\chi$. Full formalization needs exterior algebra and Pfaffians beyond current Mathlib.",
+    "title": "Chern-Gauss-Bonnet for 2n-Manifolds: ∫Pf(Ω) = (2π)^n χ",
+    "content": "Axiomatizes the Chern-Gauss-Bonnet theorem for compact oriented 2n-manifolds: ∫_M Pf(Ω) = (2π)^n χ(M), where Pf(Ω) is the Pfaffian of the curvature 2-form. Proves the n=1 (surface) case reduces to classical Gauss-Bonnet via (2π)^1 · χ = 2πχ.\n\nThe `ChernGaussBonnetManifold` structure encodes dimension n, Pfaffian integral, and Euler characteristic with the axiom. `chern_gb_surface` specializes to n=1 and shows the formula matches `CompactRiemannianSurface.gauss_bonnet` up to the factor (2π)^1 = 2π.",
+    "mathContext": "For compact oriented $2n$-manifolds: $\\int_M \\text{Pf}(\\Omega) = (2\\pi)^n \\chi(M)$. For surfaces ($n=1$): $\\text{Pf}(\\Omega) = K\\,dA / (2\\pi)$, recovering $\\int K\\,dA = 2\\pi\\chi$. Full formalization requires exterior algebra and Pfaffians beyond current Mathlib scope. The n=4 case is relevant to the Atiyah-Singer index theorem.",
     "significance": "key",
     "relatedConcepts": [
       "Chern-Gauss-Bonnet theorem",
       "Pfaffian",
       "curvature form",
-      "Atiyah-Singer index theorem"
+      "Atiyah-Singer index theorem",
+      "higher-dimensional manifolds"
     ],
     "prerequisites": [
       "CompactRiemannianSurface",
+      "Nat.pow",
       "exterior algebra (not yet in Mathlib)"
-    ],
-    "proofId": "euler-polyhedral-formula-oq-02-oq-01"
+    ]
   },
   {
     "id": "ann-hairy-ball",
-    "line": 357,
-    "type": "technique",
-    "content": "The sphere has χ = 2, which by Poincaré-Hopf implies every tangent vector field on S² has zeros (sum of indices = χ = 2 ≠ 0). The torus has χ = 0 and admits nowhere-vanishing vector fields. These are topological applications of the Gauss-Bonnet computation.",
-    "mathContext": "Sphere: $\\chi(S^2) = 2 - 2 \\cdot 0 = 2$. By **Poincaré-Hopf**: $\\sum_p \\text{ind}_p(X) = \\chi(M)$. Since $\\chi(S^2) = 2 \\neq 0$, every vector field on $S^2$ has zeros — the **hairy ball theorem**. Torus: $\\chi(T^2) = 0$, so nowhere-vanishing fields exist.",
+    "proofId": "euler-polyhedral-formula-oq-02-oq-01",
+    "range": { "startLine": 357, "endLine": 383 },
+    "type": "theorem",
+    "title": "Hairy Ball: χ = 2 for Sphere Forces Every Vector Field to Vanish",
+    "content": "The sphere has χ = 2, which by Poincaré-Hopf implies every tangent vector field on S² has zeros (sum of indices = χ = 2 ≠ 0). The torus has χ = 0 and admits nowhere-vanishing vector fields. These are topological applications of the Gauss-Bonnet computation.\n\nTheorems proved here: `sphere_chi_two` (g=0 → χ=2), `torus_chi_zero` (g=1 → χ=0), `chi_from_genus` (general χ=2−2g), `same_genus_same_chi` (isomorphic genera → same χ), `same_genus_same_curvature` (same genus → same ∫K dA).",
+    "mathContext": "Sphere: $\\chi(S^2) = 2 - 2 \\cdot 0 = 2$. By **Poincaré-Hopf**: $\\sum_p \\text{ind}_p(X) = \\chi(M)$. Since $\\chi(S^2) = 2 \\neq 0$, every vector field on $S^2$ must vanish somewhere — the **hairy ball theorem**. Torus: $\\chi(T^2) = 0$, so nowhere-vanishing fields exist (e.g., a constant-direction flow).",
     "significance": "supporting",
     "relatedConcepts": [
       "hairy ball theorem",
       "Poincaré-Hopf theorem",
       "vector field index",
-      "tangent bundle"
+      "tangent bundle",
+      "chi_from_genus"
     ],
     "prerequisites": [
-      "sphere_chi_two",
-      "torus_chi_zero",
-      "Poincaré-Hopf (not formalized)"
-    ],
-    "proofId": "euler-polyhedral-formula-oq-02-oq-01"
+      "OrientableClosedSurface",
+      "chi_genus",
+      "Poincaré-Hopf (not formalized here)"
+    ]
   },
   {
     "id": "ann-concrete-examples",
-    "line": 390,
+    "proofId": "euler-polyhedral-formula-oq-02-oq-01",
+    "range": { "startLine": 390, "endLine": 432 },
     "type": "definition",
-    "content": "Three concrete OrientableClosedSurface instances: (1) standardSphere (area 4π, K_avg = 1), (2) flatTorus with parameters a,b > 0 (area ab, K_avg = 0), (3) hyperbolicGenus2 (area 4π, K_avg = -1). All verify Gauss-Bonnet via `ring` and chi_genus via `norm_num`.",
-    "mathContext": "Standard sphere: $\\text{Area} = 4\\pi$, $K = 1$ constant, $\\int K\\,dA = 4\\pi = 2\\pi \\cdot 2$. Flat torus: $\\text{Area} = ab$, $K = 0$, $\\int K\\,dA = 0 = 2\\pi \\cdot 0$. Hyperbolic genus 2: $\\text{Area} = 4\\pi$ (by Gauss-Bonnet, since $K = -1$), $\\int K\\,dA = -4\\pi = 2\\pi \\cdot (-2)$.",
+    "title": "Concrete Surface Instances: standardSphere, flatTorus, hyperbolicGenus2",
+    "content": "Three concrete OrientableClosedSurface instances: (1) standardSphere (area 4π, K_avg = 1), (2) flatTorus with parameters a,b > 0 (area ab, K_avg = 0), (3) hyperbolicGenus2 (area 4π, K_avg = −1). All verify Gauss-Bonnet via `ring` and chi_genus via `norm_num`.\n\nVerification theorems: `standardSphere_avg_curvature` (K_avg = 1), `flatTorus_avg_curvature` (K_avg = 0), `hyperbolicGenus2_avg_curvature` (K_avg = −1). These serve as sanity checks that the structure axioms are satisfied.",
+    "mathContext": "Standard sphere: $\\text{Area} = 4\\pi$, $K = 1$ constant, $\\int K\\,dA = 4\\pi = 2\\pi \\cdot 2$. Flat torus: $\\text{Area} = ab$, $K = 0$, $\\int K\\,dA = 0 = 2\\pi \\cdot 0$. Hyperbolic genus 2: $\\text{Area} = 4\\pi$ (normalized so $K = -1$ gives $\\int K\\,dA = -4\\pi = 2\\pi \\cdot (-2)$). Gauss-Bonnet: `by ring` in all three cases.",
     "significance": "supporting",
     "relatedConcepts": [
       "round sphere",
       "flat torus",
       "hyperbolic surface",
-      "constant curvature"
+      "constant curvature",
+      "averageCurvature"
     ],
     "prerequisites": [
       "OrientableClosedSurface",
-      "averageCurvature"
-    ],
-    "proofId": "euler-polyhedral-formula-oq-02-oq-01"
+      "averageCurvature",
+      "ring tactic",
+      "norm_num"
+    ]
   },
   {
     "id": "ann-boundary-gauss-bonnet",
-    "line": 468,
+    "proofId": "euler-polyhedral-formula-oq-02-oq-01",
+    "range": { "startLine": 452, "endLine": 469 },
     "type": "definition",
-    "content": "CompactSurfaceWithBoundary extends the Gauss-Bonnet framework to surfaces with boundary: ∫_M K dA + ∫_∂M κ_g ds = 2πχ(M). The boundary geodesic curvature term captures how the boundary curves relative to the surface.",
-    "mathContext": "$$\\int_M K\\,dA + \\int_{\\partial M} \\kappa_g\\,ds = 2\\pi\\chi(M)$$\nFor a disk ($\\chi = 1$): $\\int K\\,dA + \\int \\kappa_g\\,ds = 2\\pi$. For geodesic boundary ($\\kappa_g = 0$): recovers the closed Gauss-Bonnet.",
+    "title": "Gauss-Bonnet with Boundary: ∫K dA + ∫κ_g ds = 2πχ",
+    "content": "CompactSurfaceWithBoundary extends the Gauss-Bonnet framework to surfaces with boundary: ∫_M K dA + ∫_∂M κ_g ds = 2πχ(M). The boundary geodesic curvature term captures how the boundary curves relative to the surface.\n\n`closed_surface_from_boundary` shows that when boundary geodesic curvature is zero (geodesic boundary), the formula reduces to the closed Gauss-Bonnet. Special cases: disk (χ=1) gives ∫K + ∫κ_g = 2π; flat surface (K=0) gives ∫κ_g = 2πχ (the 'turning tangents' theorem).",
+    "mathContext": "$$\\int_M K\\,dA + \\int_{\\partial M} \\kappa_g\\,ds = 2\\pi\\chi(M)$$\nFor a disk ($\\chi = 1$): $\\int K\\,dA + \\int \\kappa_g\\,ds = 2\\pi$. For geodesic boundary ($\\kappa_g = 0$): recovers the closed Gauss-Bonnet. The half-disk: ∫K dA = 0 (flat), ∫κ_g ds = π (half-circle) + 0 (diameter geodesic) = π, and 2πχ = 2π·1 = 2π — wait, that's π ≠ 2π. The corners contribute π at the two right-angle corners.",
     "significance": "key",
     "relatedConcepts": [
       "geodesic curvature",
       "boundary term",
       "surfaces with boundary",
-      "turning tangents"
+      "turning tangents theorem",
+      "corner angle contribution"
     ],
     "prerequisites": [
-      "CompactRiemannianSurface"
-    ],
-    "proofId": "euler-polyhedral-formula-oq-02-oq-01"
+      "CompactRiemannianSurface",
+      "gauss_bonnet_theorem"
+    ]
   },
   {
     "id": "ann-girard-formula",
-    "line": 548,
-    "type": "technique",
-    "content": "Girard's formula (1629): on a surface of constant curvature K, a geodesic triangle has Area = (α + β + γ - π)/K. On the unit sphere: Area = α + β + γ - π (the spherical excess). This directly follows from the polygon Gauss-Bonnet with χ = 1.",
-    "mathContext": "For a geodesic triangle on a surface of constant curvature $K$:\n$$K \\cdot \\text{Area} = \\alpha + \\beta + \\gamma - \\pi$$\nThis gives the famous trichotomy: $K > 0$ (spherical geometry, angle excess), $K = 0$ (Euclidean, angle sum $= \\pi$), $K < 0$ (hyperbolic, angle deficit).",
+    "proofId": "euler-polyhedral-formula-oq-02-oq-01",
+    "range": { "startLine": 525, "endLine": 598 },
+    "type": "definition",
+    "title": "Girard's Formula (1629): K·Area = α + β + γ − π for Geodesic Triangles",
+    "content": "Girard's formula (1629): on a surface of constant curvature K, a geodesic triangle has K·Area = (α + β + γ − π). On the unit sphere: Area = α + β + γ − π (the spherical excess). This directly follows from the polygon Gauss-Bonnet with χ = 1.\n\nRelated theorems proved: `unit_sphere_triangle_area`, `positive_curvature_angle_excess` (α+β+γ > π), `flat_angle_sum_pi` (K=0 recovers Euclidean), `negative_curvature_angle_deficit` (K<0 gives α+β+γ < π), `hyperbolic_triangle_area_bound` (0 < Area < π for K=−1).",
+    "mathContext": "For a geodesic triangle on a surface of constant curvature $K$:\n$$K \\cdot \\text{Area} = \\alpha + \\beta + \\gamma - \\pi$$\nTrichotomy: $K > 0$ (spherical, angle excess), $K = 0$ (Euclidean, angle sum $= \\pi$), $K < 0$ (hyperbolic, angle deficit). The `GeodesicTriangle` structure (line 525) packages the angles, area, curvature, and the Girard axiom. Proofs use `linarith`.",
     "significance": "key",
     "relatedConcepts": [
       "spherical excess",
       "angular deficit",
       "Girard's theorem",
-      "non-Euclidean geometry"
+      "non-Euclidean geometry",
+      "GeodesicTriangle structure"
     ],
     "prerequisites": [
       "GeodesicTriangle",
-      "gauss_bonnet_triangle"
-    ],
-    "proofId": "euler-polyhedral-formula-oq-02-oq-01"
+      "girard_formula",
+      "linarith",
+      "gauss_bonnet_boundary"
+    ]
   },
   {
     "id": "ann-poincare-hopf",
-    "line": 635,
-    "type": "technique",
-    "content": "The Poincaré-Hopf index theorem: for a vector field on a compact surface with isolated zeros, Σ index(p_i) = χ(M). The hairy ball theorem follows immediately: a nowhere-vanishing field has total index 0, so χ must be 0 — impossible for S² (χ = 2).",
-    "mathContext": "$$\\sum_i \\text{index}(V, p_i) = \\chi(M)$$\nThe hairy ball theorem: every continuous tangent vector field on $S^2$ must vanish somewhere, since $\\chi(S^2) = 2 \\neq 0$. Only the torus ($\\chi = 0$) and Klein bottle support non-vanishing fields.",
+    "proofId": "euler-polyhedral-formula-oq-02-oq-01",
+    "range": { "startLine": 630, "endLine": 685 },
+    "type": "definition",
+    "title": "Poincaré-Hopf: Σ index(V,p_i) = χ; Hairy Ball as Corollary",
+    "content": "The Poincaré-Hopf index theorem: for a vector field on a compact surface with isolated zeros, Σ index(p_i) = χ(M). The `hairy_ball` theorem (line 644) axiomatizes this: if V has no zeros, then χ = 0. `sphere_no_nonvanishing_field` and `torus_admits_nonvanishing_field` follow as immediate corollaries.\n\n`nonvanishing_iff_chi_zero` gives the complete classification: only surfaces with χ = 0 (torus and Klein bottle) can support nowhere-vanishing vector fields. The proof: `hairy_ball V` directly for the forward direction.",
+    "mathContext": "$$\\sum_i \\text{index}(V, p_i) = \\chi(M)$$\nThe hairy ball theorem: every continuous tangent vector field on $S^2$ must vanish somewhere, since $\\chi(S^2) = 2 \\neq 0$. Only the torus ($\\chi = 0$) and Klein bottle ($\\chi = 0$) support non-vanishing fields. The `VectorFieldOnSurface` structure (line 630) records the surface, zero-ness predicate, and the index-sum axiom.",
     "significance": "key",
     "relatedConcepts": [
       "Poincaré-Hopf theorem",
       "hairy ball theorem",
       "vector field index",
-      "fixed point theory"
+      "fixed point theory",
+      "VectorFieldOnSurface"
     ],
     "prerequisites": [
       "CompactRiemannianSurface",
-      "VectorFieldOnSurface"
-    ],
-    "proofId": "euler-polyhedral-formula-oq-02-oq-01"
+      "VectorFieldOnSurface",
+      "sphere_chi_two",
+      "torus_chi_zero"
+    ]
   },
   {
     "id": "ann-morse-theory",
-    "line": 700,
-    "type": "technique",
-    "content": "Morse theory relates critical points of smooth functions to topology: χ(M) = #minima - #saddles + #maxima. For S² (χ = 2): every Morse function needs #min + #max ≥ 2 + #saddles. For T² (χ = 0): at least 2 saddles needed.",
-    "mathContext": "The weak Morse inequality: $\\chi(M) = \\sum_{k} (-1)^k c_k$ where $c_k$ is the number of index-$k$ critical points. For surfaces: $\\chi = c_0 - c_1 + c_2$. The strong Morse inequalities further constrain individual Betti numbers.",
+    "proofId": "euler-polyhedral-formula-oq-02-oq-01",
+    "range": { "startLine": 701, "endLine": 746 },
+    "type": "definition",
+    "title": "Morse Theory: χ = #min − #saddles + #max via Critical Points",
+    "content": "Morse theory relates critical points of smooth functions to topology: χ(M) = #minima − #saddles + #maxima. For S² (χ = 2): every Morse function needs #min + #max ≥ 2 + #saddles. For T² (χ = 0): at least 2 saddles needed whenever min,max ≥ 1.\n\nThe `MorseFunctionOnSurface` structure (line 701) encodes the surface, critical point counts, and the Morse relation as an axiom. `sphere_height_function` and `torus_standard_morse` give the minimal examples. `genus_g_morse_bound` gives the general constraint: min + max − saddles = 2 − 2g.",
+    "mathContext": "The weak Morse inequality: $\\chi(M) = \\sum_{k} (-1)^k c_k$ where $c_k$ is the number of index-$k$ critical points. For surfaces: $\\chi = c_0 - c_1 + c_2$. Sphere: $1 - 0 + 1 = 2$ (height function). Torus: $1 - 2 + 1 = 0$ (standard embedding). The Morse inequalities further constrain individual Betti numbers: $c_k \\geq b_k$.",
     "significance": "key",
     "relatedConcepts": [
       "Morse function",
       "critical points",
       "Morse inequalities",
-      "handle decomposition"
+      "handle decomposition",
+      "MorseFunctionOnSurface"
     ],
     "prerequisites": [
       "CompactRiemannianSurface",
-      "MorseFunctionOnSurface"
-    ],
-    "proofId": "euler-polyhedral-formula-oq-02-oq-01"
+      "MorseFunctionOnSurface",
+      "omega",
+      "OrientableClosedSurface"
+    ]
   }
 ]

--- a/src/data/proofs/greens-theorem-oq-02/annotations.json
+++ b/src/data/proofs/greens-theorem-oq-02/annotations.json
@@ -1,101 +1,202 @@
 [
   {
-    "line": 4,
+    "id": "greens-oq02-overview",
+    "proofId": "greens-theorem-oq-02",
+    "range": { "startLine": 90, "endLine": 103 },
+    "type": "definition",
+    "title": "LipschitzClosedCurve: Minimal Regularity Framework for Whitney's Green's Theorem",
+    "content": "`LipschitzClosedCurve` captures the minimal regularity condition under which Green's theorem ∮_C(P dx + Q dy) = ∬_Ω(∂Q/∂x − ∂P/∂y) dA remains valid. Classical proofs require C¹ boundary curves and C¹ fields. Whitney (1957) proved that Lipschitz boundaries + L¹ curl suffice — a dramatic weakening that covers polygons, squares, and any piecewise-smooth domain.\n\nThe structure fields: `T : ℝ` (period), `γ : ℝ → ℝ × ℝ` (curve map), `hT : 0 < T` (positive period), `K : ℝ≥0` (Lipschitz constant), `hLip : LipschitzWith K γ`, `isClosed : γ(0) = γ(T)`. This file: 19 theorems + 1 axiom (Whitney's theorem), 0 sorries.",
+    "mathContext": "The regularity hierarchy: $C^\\infty \\subset C^1 \\subset \\text{Lipschitz} \\subset \\text{Absolutely Continuous} \\subset BV$. OQ-01 uses $C^1$ (via `HasDerivAt`); OQ-03 uses $C^1$ TypeI domains; OQ-02 descends to the Lipschitz/$L^1$ level. The key enabling theorem is Rademacher (1919): every Lipschitz function is differentiable at Lebesgue-a.e. point, so line integrals over Lipschitz curves are well-defined. **Corner examples**: The boundary of a square has 4 corners where γ' has jump discontinuities — Lipschitz with K=1 (arc-length) but NOT C¹.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Rademacher's theorem",
+      "Whitney's theorem",
+      "Lipschitz domains",
+      "L¹ spaces",
+      "geometric measure theory",
+      "LipschitzWith"
+    ],
+    "prerequisites": [
+      "LipschitzWith",
+      "NNReal",
+      "closed curve",
+      "bounded variation"
+    ]
+  },
+  {
+    "id": "lipschitz-dist-bound",
+    "proofId": "greens-theorem-oq-02",
+    "range": { "startLine": 115, "endLine": 130 },
+    "type": "theorem",
+    "title": "lipschitz_dist_bound: dist(γ(t), γ(s)) ≤ K·dist(t,s) in Metric Form",
+    "content": "`lipschitz_dist_bound`: dist(γ(t), γ(s)) ≤ K · dist(t, s). The foundational Lipschitz property in metric form, derived directly from `C.hLip.dist_le_mul`. The companion `lipschitz_dist_bound'` reformulates using |t-s| via `Real.dist_eq`.\n\nAll subsequent lemmas (average speed, diameter, and ultimately line integral bounds) derive from this fundamental inequality.",
+    "mathContext": "In Lean, `LipschitzWith K f` states $\\text{edist}(f(x), f(y)) \\leq K \\cdot \\text{edist}(x,y)$ using extended non-negative reals (`ENNReal`). The theorem `LipschitzWith.dist_le_mul` converts this to the standard metric: `dist(f(t), f(s)) ≤ ↑K · dist(t,s)`. For $\\mathbb{R}$, `dist t s = |t - s|` (via `Real.dist_eq`).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "LipschitzWith.dist_le_mul",
+      "edist",
+      "ENNReal",
+      "Real.dist_eq"
+    ],
+    "prerequisites": [
+      "LipschitzWith",
+      "NNReal coercion to ℝ",
+      "Real.dist_eq"
+    ]
+  },
+  {
+    "id": "lipschitz-curve-diameter",
+    "proofId": "greens-theorem-oq-02",
+    "range": { "startLine": 171, "endLine": 181 },
+    "type": "theorem",
+    "title": "lipschitz_curve_diameter: Any Two Points Are ≤ K·T Apart",
+    "content": "`lipschitz_curve_diameter`: For s, t ∈ [0, T], dist(γ(t), γ(s)) ≤ K · T. The curve fits inside a ball of radius K·T centered at any of its points. Proof: dist ≤ K·|t-s| ≤ K·T using |t-s| ≤ T for s,t ∈ [0,T].\n\nThe diameter bound confirms that line integrals over Lipschitz curves are over bounded domains, which is needed for integrability. For the unit circle with K=1 and T=2π, the bound gives diameter ≤ 2π ≈ 6.28 (loose; actual diameter is 2).",
+    "mathContext": "The bound is: $|\\gamma(t) - \\gamma(s)| \\leq K|t-s| \\leq KT$ for $s,t \\in [0,T]$. The key step is `abs_le` plus `linarith` to show $|t-s| \\leq T$ from $0 \\leq s \\leq T$ and $0 \\leq t \\leq T$. Any Lipschitz curve of finite period is automatically bounded.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "diameter bound",
+      "bounded curve",
+      "line integral domain",
+      "abs_le"
+    ],
+    "prerequisites": [
+      "lipschitz_dist_bound",
+      "linarith"
+    ]
+  },
+  {
+    "id": "lipschitz-line-integral",
+    "proofId": "greens-theorem-oq-02",
+    "range": { "startLine": 205, "endLine": 233 },
+    "type": "definition",
+    "title": "lipschitzLineIntegral: Line Integral Using a.e. Derivative via Rademacher",
+    "content": "`lipschitzLineIntegral`: The line integral ∫_C(P dx + Q dy) = ∫₀ᵀ [P(γ(t))·γ₁'(t) + Q(γ(t))·γ₂'(t)] dt, defined using Lean's `deriv` for the a.e. derivative of γ. At non-differentiable points (corners), `deriv` returns 0 — correct because such points form a null set (Rademacher).\n\nAlso included: `lineIntegral_zero_field` (integral vanishes for zero field), `lineIntegral_smul` (scaling), `lineIntegral_neg` (negation). These verify linearity before Whitney's theorem is applied.",
+    "mathContext": "The integral uses `intervalIntegral` over $[0,T]$. For a corner at time $t_0$, `deriv` returns 0, but this point contributes measure 0 to the integral. For smooth curves, `deriv` equals the classical derivative everywhere. Using `deriv` (which returns 0 at non-differentiable points) rather than a weak derivative makes the definition computable and consistent with Lean's analysis library.",
+    "significance": "key",
+    "relatedConcepts": [
+      "intervalIntegral",
+      "deriv",
+      "Rademacher's theorem",
+      "a.e. derivative",
+      "null set"
+    ],
+    "prerequisites": [
+      "LipschitzClosedCurve",
+      "intervalIntegral",
+      "MeasureTheory"
+    ]
+  },
+  {
+    "id": "l1-curl-field",
+    "proofId": "greens-theorem-oq-02",
+    "range": { "startLine": 261, "endLine": 309 },
+    "type": "definition",
+    "title": "L1CurlField: Vector Fields with L¹-Integrable Curl (Sobolev W^{1,1})",
+    "content": "`L1CurlField` structure: A vector field (P, Q) with an L¹-integrable curl function ω = ∂Q/∂x − ∂P/∂y. The curl is stored explicitly as a field to allow approximate partial derivatives — weaker than requiring `HasDerivAt` (pointwise C¹). The integrability uses `MeasureTheory.Integrable`.\n\nAlso: `zeroL1CurlField` (zero field has L¹ curl), `c1_compact_l1_curl` (C¹ fields with compact support have L¹ curl), `curl_continuous_implies_l1` (continuous curl on compact rectangle is L¹).",
+    "mathContext": "A vector field $(P,Q)$ has **$L^1$ curl** if the weak partial derivatives exist a.e. and $\\omega = \\partial Q/\\partial x - \\partial P/\\partial y \\in L^1(\\Omega)$. This is equivalent to the Sobolev condition $(P,Q) \\in W^{1,1}(\\Omega)$. L¹ curl is the minimal field condition for Whitney's theorem — much weaker than `HasDerivAt` (pointwise differentiability in OQ-01/03).",
+    "significance": "key",
+    "relatedConcepts": [
+      "MeasureTheory.Integrable",
+      "weak partial derivative",
+      "Sobolev space W^{1,1}",
+      "L¹ space",
+      "HasDerivAt comparison"
+    ],
+    "prerequisites": [
+      "MeasureTheory.Integrable",
+      "MeasureTheory.volume",
+      "LipschitzClosedCurve"
+    ]
+  },
+  {
+    "id": "greens-theorem-l1curl",
+    "proofId": "greens-theorem-oq-02",
+    "range": { "startLine": 350, "endLine": 364 },
     "type": "concept",
-    "content": "**Minimal Regularity for Green's Theorem**: This file investigates the minimal conditions under which Green's theorem ∮_C(P dx + Q dy) = ∬_Ω(∂Q/∂x - ∂P/∂y) dA remains valid. Classical proofs require C¹ boundary curves and C¹ fields. Whitney (1957) proved that Lipschitz boundaries + L¹ curl suffice — a dramatic weakening that covers polygons, squares, and any piecewise-smooth domain.",
-    "mathContext": "The regularity hierarchy: $C^\\infty \\subset C^1 \\subset \\text{Lipschitz} \\subset \\text{Absolutely Continuous} \\subset BV$. OQ-01 uses $C^1$ (via `HasDerivAt`); OQ-03 uses $C^1$ TypeI domains; OQ-02 descends to the Lipschitz/$L^1$ level. The key enabling theorem is Rademacher (1919): every Lipschitz function is differentiable at Lebesgue-a.e. point, so line integrals over Lipschitz curves are well-defined as Lebesgue integrals.",
-    "significance": "This file answers a fundamental question in geometric measure theory: how little regularity is needed for the divergence theorem? Whitney's answer — Lipschitz domains + L¹ derivatives — is optimal and covers all practically relevant domains including polytopes and domains with corners.",
-    "relatedConcepts": ["Rademacher's theorem", "Whitney's theorem", "Lipschitz domains", "L¹ spaces", "geometric measure theory"],
-    "difficulty": "advanced"
+    "title": "greens_theorem_l1curl Axiom: Whitney's Theorem (Geometric Measure Theory Frontier)",
+    "content": "**Whitney's theorem** (`axiom greens_theorem_l1curl`): For a Lipschitz closed curve C traversing ∂Ω with L¹ curl F on Ω, ∮_C(P dx + Q dy) = ∬_Ω curl_F dA. The proof would require geometric measure theory machinery: sets of finite perimeter, BV functions, Federer's trace theorem — not yet assembled in Mathlib.\n\nWhitney's proof (1957, §IV.8): (1) approximate Ω by smooth domains Ω_ε; (2) apply smooth Green's theorem to each; (3) line integrals converge by Rademacher + dominated convergence; (4) double integrals converge by L¹ convergence. Federer's *Geometric Measure Theory* (1969, §4.5.9) gives the Gauss-Green formula for sets of finite perimeter, which implies Whitney.",
+    "mathContext": "Whitney's theorem is the state of the art for minimal regularity Green's theorem. Its formalization in Lean would require formalizing: sets of finite perimeter (Caccioppoli sets), the coarea formula, and Federer's trace theorem — a multi-year project. A sharper version was proved by Melas (1993). This axiom has `axiomCount = 1` in the proof's meta.json.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Whitney 1957",
+      "geometric measure theory",
+      "sets of finite perimeter",
+      "BV functions",
+      "Federer trace theorem"
+    ],
+    "prerequisites": [
+      "L1CurlField",
+      "LipschitzClosedCurve",
+      "MeasureTheory.integral"
+    ]
   },
   {
-    "line": 90,
-    "type": "definition",
-    "content": "**LipschitzClosedCurve structure**: Captures a closed Lipschitz curve γ : ℝ → ℝ² with period T, Lipschitz constant K : NNReal (so LipschitzWith K γ), and closure condition γ(0) = γ(T). The use of NNReal for K matches Lean's LipschitzWith typeclass.",
-    "mathContext": "A curve $\\gamma : [0,T] \\to \\mathbb{R}^2$ is **Lipschitz** if $\\|\\gamma(t) - \\gamma(s)\\| \\leq K|t-s|$ for all $s,t$ (Lean: `LipschitzWith K γ`). Equivalently, $\\gamma$ has bounded variation with $|\\gamma'(t)| \\leq K$ a.e. by Rademacher. The NNReal type for $K$ (non-negative reals) avoids sign issues in coercions when combining with `edist`.",
-    "significance": "The structure packages the three essential properties: Lipschitz bound (for line integral well-definedness), positive period (for integration domain), and closure (for Green's theorem to apply — the boundary must be a closed loop). Corner examples: squares, polygons, any piecewise-linear closed curve.",
-    "relatedConcepts": ["LipschitzWith", "NNReal", "closed curve", "Rademacher's theorem", "bounded variation"],
-    "difficulty": "intermediate"
-  },
-  {
-    "line": 115,
+    "id": "line-integral-zero-curl",
+    "proofId": "greens-theorem-oq-02",
+    "range": { "startLine": 378, "endLine": 394 },
     "type": "theorem",
-    "content": "**lipschitz_dist_bound**: dist(γ(t), γ(s)) ≤ K · dist(t, s). The foundational Lipschitz property in metric form, derived directly from C.hLip.dist_le_mul. The companion lipschitz_dist_bound' reformulates using |t-s| via Real.dist_eq.",
-    "mathContext": "In Lean, `LipschitzWith K f` states $\\text{edist}(f(x), f(y)) \\leq K \\cdot \\text{edist}(x,y)$ using extended non-negative reals (`ENNReal`). The theorem `LipschitzWith.dist_le_mul` converts this to the standard metric: `dist(f(t), f(s)) ≤ ↑K · dist(t,s)`. For $\\mathbb{R}$, `dist t s = |t - s|$ (via `Real.dist_eq`).",
-    "significance": "This is the direct translation from the abstract LipschitzWith predicate to a concrete distance bound. All subsequent lemmas (average speed, diameter, and ultimately line integral bounds) derive from this fundamental inequality.",
-    "relatedConcepts": ["LipschitzWith.dist_le_mul", "edist", "ENNReal", "Real.dist_eq"],
-    "difficulty": "introductory"
+    "title": "lineIntegral_zero_curl: Zero Curl ⇒ Zero Circulation (Cauchy-Goursat for Lipschitz)",
+    "content": "`lineIntegral_zero_curl`: If curl ≡ 0 a.e. inside Ω, then ∮_C(P dx + Q dy) = 0 for any Lipschitz C = ∂Ω. This generalizes the Cauchy-Goursat theorem to Lipschitz boundaries: conservative fields and holomorphic functions have zero circulation even along non-smooth curves.\n\nThe proof applies `greens_theorem_l1curl` with zero curl, then uses `simp` to evaluate ∬_Ω 0 dA = 0. `filter_upwards` handles the a.e. version.",
+    "mathContext": "Special cases: if $P = \\partial f/\\partial x$, $Q = \\partial f/\\partial y$ (conservative field), then curl $\\equiv 0$; if $(P,Q)$ satisfies Cauchy-Riemann equations, then curl $\\equiv 0$. This justifies using Green's theorem on domains with corners (like squares) in complex analysis — holomorphic functions integrate to 0 over ANY Lipschitz closed curve.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cauchy-Goursat theorem",
+      "conservative field",
+      "zero circulation",
+      "filter_upwards",
+      "holomorphic functions"
+    ],
+    "prerequisites": [
+      "greens_theorem_l1curl",
+      "filter_upwards",
+      "MeasureTheory.integral_zero"
+    ]
   },
   {
-    "line": 165,
+    "id": "greens-oq1-reduction",
+    "proofId": "greens-theorem-oq-02",
+    "range": { "startLine": 420, "endLine": 439 },
     "type": "theorem",
-    "content": "**lipschitz_curve_diameter**: For s, t ∈ [0, T], dist(γ(t), γ(s)) ≤ K · T. The curve fits inside a ball of radius K·T centered at any of its points. Proof: dist ≤ K·|t-s| ≤ K·T using |t-s| ≤ T for s,t ∈ [0,T].",
-    "mathContext": "The bound is: $|\\gamma(t) - \\gamma(s)| \\leq K|t-s| \\leq KT$ for $s,t \\in [0,T]$. The key step is `abs_le` plus `linarith` to show $|t-s| \\leq T$ from the hypotheses $0 \\leq s \\leq T$ and $0 \\leq t \\leq T$. For the unit circle with $K=1$ and $T=2\\pi$, the bound gives diameter $\\leq 2\\pi \\approx 6.28$, which is a loose bound (the actual diameter is 2).",
-    "significance": "The diameter bound is used to confirm that line integrals over Lipschitz curves are over bounded domains, which is needed for integrability. It also shows that any Lipschitz curve of finite length is automatically bounded.",
-    "relatedConcepts": ["diameter bound", "bounded curve", "line integral domain", "abs_le"],
-    "difficulty": "introductory"
+    "title": "greens_oq1_from_l1curl: C¹ Conditions Imply L¹ Conditions (Consistency Check)",
+    "content": "`greens_oq1_from_l1curl`: Under OQ-01-style `HasDerivAt` conditions (pointwise C¹), Whitney's theorem reduces to the same conclusion as OQ-01. This shows the two approaches are consistent: C¹ ⟹ L¹, so OQ-01's stronger hypotheses imply OQ-02's weaker ones.\n\nThe proof applies `greens_theorem_l1curl` directly, using `filter_upwards` to convert the a.e. equality from `hCurlAE`. The key implication: `HasDerivAt f f' x` implies `deriv f x = f'` (via `HasDerivAt.deriv`), making the a.e. curl formula trivially hold.",
+    "mathContext": "The hypothesis relaxation chain: OQ-01 (strongest: `HasDerivAt`, proved 0 axioms) → OQ-03 (TypeI regions: `HasDerivAt`, 1 axiom) → OQ-02 (weakest: L¹ curl, 1 axiom). The theorem shows that relaxing to L¹ curl doesn't change the conclusion — it just applies in more cases.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "HasDerivAt",
+      "filter_upwards",
+      "consistency",
+      "hypothesis relaxation",
+      "OQ-01 compatibility"
+    ],
+    "prerequisites": [
+      "greens_theorem_l1curl",
+      "HasDerivAt.deriv",
+      "filter_upwards"
+    ]
   },
   {
-    "line": 205,
-    "type": "definition",
-    "content": "**lipschitzLineIntegral**: The line integral ∫_C(P dx + Q dy) = ∫₀ᵀ [P(γ(t))·γ₁'(t) + Q(γ(t))·γ₂'(t)] dt, defined using Lean's `deriv` for the a.e. derivative of γ. At non-differentiable points (corners), `deriv` returns 0 — correct because such points form a null set (Rademacher).",
-    "mathContext": "The integral uses `intervalIntegral` over $[0,T]$. The derivatives `deriv (fun τ => (C.γ τ).1) t` and `deriv (fun τ => (C.γ τ).2) t` compute the components of $\\gamma'(t)$. For a corner at time $t_0$, `deriv` returns 0, but this point contributes measure 0 to the integral, so the value is unaffected. For smooth curves, `deriv` equals the classical derivative everywhere.",
-    "significance": "Using `deriv` (which returns 0 at non-differentiable points) rather than a weak derivative or Dini derivative makes the definition computable and consistent with Lean's analysis library, while Rademacher's theorem ensures mathematical correctness at a.e.-differentiable points.",
-    "relatedConcepts": ["intervalIntegral", "deriv", "Rademacher's theorem", "a.e. derivative", "null set"],
-    "difficulty": "intermediate"
-  },
-  {
-    "line": 261,
-    "type": "definition",
-    "content": "**L1CurlField structure**: A vector field (P, Q) with an L¹-integrable curl function ω = ∂Q/∂x - ∂P/∂y. The curl is stored explicitly as a field to allow approximate partial derivatives — weaker than requiring HasDerivAt (pointwise C¹). The integrability uses MeasureTheory.Integrable.",
-    "mathContext": "A vector field $(P,Q)$ has **$L^1$ curl** if the weak partial derivatives exist a.e. and $\\omega = \\partial Q/\\partial x - \\partial P/\\partial y \\in L^1(\\Omega)$. This is equivalent to the Sobolev condition $(P,Q) \\in W^{1,1}(\\Omega)$. The `MeasureTheory.Integrable curl volume` condition states $\\int_{\\mathbb{R}^2} |\\omega| \\, dA < \\infty$.",
-    "significance": "L¹ curl is the minimal field condition for Whitney's theorem. Compared to OQ-01/03's `HasDerivAt` (pointwise differentiability), L¹ curl only requires integrable weak derivatives — a much weaker hypothesis that still allows corners and non-smooth behavior at measure-zero sets.",
-    "relatedConcepts": ["MeasureTheory.Integrable", "weak partial derivative", "Sobolev space W^{1,1}", "L¹ space"],
-    "difficulty": "advanced"
-  },
-  {
-    "line": 350,
-    "type": "axiom",
-    "content": "**greens_theorem_l1curl** (Whitney's theorem, axiomatized): For a Lipschitz closed curve C traversing ∂Ω with L¹ curl F on Ω, ∮_C(P dx + Q dy) = ∬_Ω curl_F dA. The proof would require geometric measure theory machinery: sets of finite perimeter, BV functions, Federer's trace theorem — not yet assembled in Mathlib.",
-    "mathContext": "Whitney's proof (1957, §IV.8): (1) approximate the Lipschitz domain $\\Omega$ by smooth domains $\\Omega_\\epsilon$; (2) apply smooth Green's theorem to each $\\Omega_\\epsilon$; (3) the line integrals converge by Rademacher + dominated convergence; (4) the double integrals converge by $L^1$ convergence of the curl. A sharper version was proved by Melas (1993). Federer's *Geometric Measure Theory* (1969, §4.5.9) gives the Gauss-Green formula for sets of finite perimeter, which implies Whitney.",
-    "significance": "This axiom captures the deepest analytic result in the file. Whitney's theorem is the state of the art for minimal regularity Green's theorem. Its formalization in Lean would require formalizing: sets of finite perimeter (Caccioppoli sets), the coarea formula, and Federer's trace theorem — a multi-year project.",
-    "relatedConcepts": ["Whitney 1957", "geometric measure theory", "sets of finite perimeter", "BV functions", "Federer trace theorem"],
-    "difficulty": "research"
-  },
-  {
-    "line": 378,
+    "id": "unit-circle-lipschitz",
+    "proofId": "greens-theorem-oq-02",
+    "range": { "startLine": 466, "endLine": 490 },
     "type": "theorem",
-    "content": "**lineIntegral_zero_curl**: If curl ≡ 0 a.e. inside Ω, then ∮_C(P dx + Q dy) = 0 for any Lipschitz C = ∂Ω. This generalizes the Cauchy-Goursat theorem to Lipschitz boundaries: conservative fields and holomorphic functions have zero circulation even along non-smooth curves.",
-    "mathContext": "The proof applies `greens_theorem_l1curl` with the constant-zero curl function, then uses `simp` to evaluate $\\iint_\\Omega 0 \\, dA = 0$. The `filter_upwards` tactic handles the a.e. version of the curl-zero hypothesis. Special cases: if $P = \\partial f/\\partial x$, $Q = \\partial f/\\partial y$ (conservative field), then curl $\\equiv 0$; if $(P,Q)$ satisfies Cauchy-Riemann equations, then curl $\\equiv 0$.",
-    "significance": "This is the Lipschitz generalization of Cauchy's theorem in complex analysis: holomorphic functions integrate to 0 over ANY Lipschitz closed curve, not just smooth ones. This justifies using Green's theorem on domains with corners (like squares) in complex analysis.",
-    "relatedConcepts": ["Cauchy-Goursat theorem", "conservative field", "zero circulation", "filter_upwards", "holomorphic functions"],
-    "difficulty": "intermediate"
-  },
-  {
-    "line": 420,
-    "type": "theorem",
-    "content": "**greens_oq1_from_l1curl**: Under OQ-01-style HasDerivAt conditions (pointwise C¹), Whitney's theorem reduces to the same conclusion as OQ-01. This shows the two approaches are consistent: C¹ ⟹ L¹, so OQ-01's stronger hypotheses imply OQ-02's weaker ones.",
-    "mathContext": "The proof applies `greens_theorem_l1curl` directly, using `filter_upwards` to convert the a.e. equality from the `hCurlAE` hypothesis. The key implication is: `HasDerivAt f f' x` implies `deriv f x = f'` (via `HasDerivAt.deriv`), so pointwise C¹ derivatives are also the Lean `deriv` values, making the a.e. curl formula trivially hold.",
-    "significance": "This consistency check validates the axiom hierarchy: OQ-01 (strongest hypotheses, proved) → OQ-02 (weakest hypotheses, axiom). The theorem shows that relaxing to L¹ curl doesn't change the conclusion — it just applies in more cases.",
-    "relatedConcepts": ["HasDerivAt", "filter_upwards", "consistency", "hypothesis relaxation", "OQ-01 reduction"],
-    "difficulty": "intermediate"
-  },
-  {
-    "line": 466,
-    "type": "theorem",
-    "content": "**unitCircle_lipschitz**: γ(t) = (cos t, sin t) is LipschitzWith 1. Proof: edist in ℝ² (product metric) is the sup of component edists; cos and sin are each Lipschitz-1 (Mathlib: lipschitzWith_cos, lipschitzWith_sin); so sup ≤ edist(t,s) by sup_le.",
-    "mathContext": "The **product metric** on $\\mathbb{R}^2$: $\\text{edist}((a,b),(c,d)) = \\text{edist}(a,c) \\sqcup \\text{edist}(b,d)$ (supremum in `ENNReal`). The Lean goal becomes `edist(cos x, cos y) ⊔ edist(sin x, sin y) ≤ edist(x,y)`, handled by `sup_le hcos hsin`. The unit circle is actually $C^\\infty$ (infinitely differentiable), so it's a special case where OQ-01/02/03 all apply — but the Lipschitz formalization is needed for OQ-02's framework.",
-    "significance": "This example grounds the abstract theory: the canonical smooth curve (unit circle) fits perfectly into the Lipschitz framework with K=1. The proof technique (edist product metric via sup_le) is the correct Lean 4 idiom for proving LipschitzWith for product-valued functions.",
-    "relatedConcepts": ["LipschitzWith", "lipschitzWith_cos", "lipschitzWith_sin", "sup_le", "ENNReal product metric"],
-    "difficulty": "intermediate"
-  },
-  {
-    "line": 479,
-    "type": "theorem",
-    "content": "**unitCircle_closed**: γ(0) = γ(2π) — the unit circle closes up at period 2π. Proved by simp using Real.cos_two_pi and Real.sin_two_pi (both evaluate to 1 and 0 respectively).",
-    "mathContext": "The closure condition $\\gamma(0) = \\gamma(2\\pi)$: $(\\cos 0, \\sin 0) = (1, 0)$ and $(\\cos 2\\pi, \\sin 2\\pi) = (1, 0)$. Lean's `Real.cos_two_pi : Real.cos (2 * π) = 1` and `Real.sin_two_pi : Real.sin (2 * π) = 0` are the key simp lemmas. The `unitCircleCurve` instance assembles all five fields: T = 2π, γ = unitCircle, hT = positivity, K = 1, hLip = unitCircle_lipschitz, isClosed = unitCircle_closed.",
-    "significance": "This completes the unit circle example, verifying that the abstract LipschitzClosedCurve structure can be instantiated concretely. The example shows the theory is non-vacuous: there exist non-trivial Lipschitz closed curves (in fact, C^∞ ones) to which Whitney's theorem applies.",
-    "relatedConcepts": ["Real.cos_two_pi", "Real.sin_two_pi", "unitCircleCurve instance", "2π periodicity"],
-    "difficulty": "introductory"
+    "title": "unitCircle_lipschitz: γ(t) = (cos t, sin t) is LipschitzWith 1",
+    "content": "`unitCircle_lipschitz`: γ(t) = (cos t, sin t) is `LipschitzWith 1`. Proof: edist in ℝ² (product metric) is the sup of component edists; cos and sin are each Lipschitz-1 (`lipschitzWith_cos`, `lipschitzWith_sin`); so sup ≤ edist(t,s) by `sup_le`.\n\n`unitCircle_closed`: γ(0) = γ(2π), proved by `simp` using `Real.cos_two_pi` and `Real.sin_two_pi`. `unitCircleCurve` assembles the complete `LipschitzClosedCurve` instance.",
+    "mathContext": "The **product metric** on $\\mathbb{R}^2$: $\\text{edist}((a,b),(c,d)) = \\text{edist}(a,c) \\sqcup \\text{edist}(b,d)$ (supremum in `ENNReal`). The Lean goal becomes `edist(cos x, cos y) ⊔ edist(sin x, sin y) ≤ edist(x,y)`, handled by `sup_le hcos hsin`. The unit circle is $C^\\infty$ — a special case where OQ-01/02/03 all apply. The Lipschitz formalization is needed for OQ-02's framework.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "LipschitzWith",
+      "lipschitzWith_cos",
+      "lipschitzWith_sin",
+      "sup_le",
+      "ENNReal product metric",
+      "unitCircleCurve"
+    ],
+    "prerequisites": [
+      "lipschitzWith_cos",
+      "lipschitzWith_sin",
+      "ENNReal.sup",
+      "Real.cos_two_pi",
+      "Real.sin_two_pi"
+    ]
   }
 ]

--- a/src/data/proofs/mean-value-theorem-oq-03/annotations.json
+++ b/src/data/proofs/mean-value-theorem-oq-03/annotations.json
@@ -1,163 +1,183 @@
 [
   {
     "id": "ann-namespace-setup",
-    "line": 47,
+    "proofId": "mean-value-theorem-oq-03",
+    "range": { "startLine": 47, "endLine": 74 },
     "type": "concept",
-    "content": "**Normed Space Framework**: The entire development is parameterized over an arbitrary normed space $E$ over $\\mathbb{R}$ via type class constraints `[NormedAddCommGroup E] [NormedSpace ℝ E]`. This means all results apply simultaneously to $\\mathbb{R}^n$, sequence spaces $\\ell^p$, and function spaces $L^p$ — any complete normed space is a Banach space where these theorems hold.",
-    "mathContext": "A normed space $E$ over $\\mathbb{R}$ satisfies $\\|\\alpha x\\| = |\\alpha| \\|x\\|$ and the triangle inequality $\\|x + y\\| \\leq \\|x\\| + \\|y\\|$. The type class inference system automatically provides these properties for any concrete normed space.",
+    "title": "Normed Space Framework: All Results Parameterized over Arbitrary E",
+    "content": "The entire development is parameterized over an arbitrary normed space $E$ over $\\mathbb{R}$ via type class constraints `[NormedAddCommGroup E] [NormedSpace ℝ E]`. This means all results apply simultaneously to $\\mathbb{R}^n$, sequence spaces $\\ell^p$, and function spaces $L^p$ — any complete normed space is a Banach space where these theorems hold.\n\nThe namespace setup also declares a second normed space `F` for Banach-to-Banach maps in the later sections. Variables are declared once and automatically inferred throughout.",
+    "mathContext": "A normed space $E$ over $\\mathbb{R}$ satisfies $\\|\\alpha x\\| = |\\alpha| \\|x\\|$ and the triangle inequality $\\|x + y\\| \\leq \\|x\\| + \\|y\\|$. The type class inference system automatically provides these properties for any concrete normed space. Lean's universe polymorphism ensures `E` can be finite or infinite-dimensional.",
     "significance": "supporting",
     "relatedConcepts": [
       "normed space",
       "Banach space",
       "type class inference",
-      "universe polymorphism"
+      "NormedAddCommGroup",
+      "NormedSpace"
     ],
     "prerequisites": [
       "NormedAddCommGroup",
       "NormedSpace"
-    ],
-    "proofId": "mean-value-theorem-oq-03"
+    ]
   },
   {
     "id": "ann-core-inequality",
-    "line": 76,
-    "type": "technique",
-    "content": "**Mean Value Inequality** (core theorem): For $f : \\mathbb{R} \\to E$ with $\\|f'(x)\\| \\leq C$ on $[a,b]$, we have $\\|f(x) - f(a)\\| \\leq C(x-a)$ for all $x \\in [a,b]$. This is the central result — all other theorems either specialize it, provide counterexamples to strengthening it, or derive consequences. The one-line proof delegates to Mathlib's `norm_image_sub_le_of_norm_deriv_le_segment'`.",
+    "proofId": "mean-value-theorem-oq-03",
+    "range": { "startLine": 76, "endLine": 97 },
+    "type": "theorem",
+    "title": "Mean Value Inequality: ‖f(x) − f(a)‖ ≤ C(x−a) for Bounded Derivative",
+    "content": "For $f : \\mathbb{R} \\to E$ with $\\|f'(x)\\| \\leq C$ on $[a,b]$, we have $\\|f(x) - f(a)\\| \\leq C(x-a)$ for all $x \\in [a,b]$. This is the central result — all other theorems either specialize it, provide counterexamples to strengthening it, or derive consequences. The one-line proof delegates to Mathlib's `norm_image_sub_le_of_norm_deriv_le_segment'`.",
     "mathContext": "The proof uses a partition argument: divide $[a,x]$ into subintervals, apply the triangle inequality $\\|f(x) - f(a)\\| \\leq \\sum \\|f(t_{i+1}) - f(t_i)\\|$, use differentiability to bound each term by $C(t_{i+1} - t_i)$, and sum to get $C(x-a)$. This avoids the intermediate value theorem entirely, which is why it works for vectors.",
     "significance": "key",
     "relatedConcepts": [
       "mean value theorem",
       "Lipschitz continuity",
       "triangle inequality",
-      "derivative bounds"
+      "derivative bounds",
+      "norm_image_sub_le_of_norm_deriv_le_segment'"
     ],
     "prerequisites": [
       "HasDerivWithinAt",
       "norm_image_sub_le_of_norm_deriv_le_segment'"
-    ],
-    "proofId": "mean-value-theorem-oq-03"
+    ]
   },
   {
     "id": "ann-scalar-inequality",
-    "line": 99,
-    "type": "technique",
-    "content": "**Scalar specialization**: When $E = \\mathbb{R}$, the vector inequality becomes $|f(x) - f(a)| \\leq C(x-a)$. Lean's type unification automatically specializes, so the proof is simply `mean_value_inequality hf hC`. This is strictly weaker than the classical scalar MVT which gives exact equality at some point $c$.",
-    "mathContext": "For $\\mathbb{R}$-valued functions, $\\|f(x) - f(a)\\| = |f(x) - f(a)|$ since the norm on $\\mathbb{R}$ is the absolute value. The inequality loses the sign information: it cannot distinguish $f(b) > f(a)$ from $f(b) < f(a)$.",
+    "proofId": "mean-value-theorem-oq-03",
+    "range": { "startLine": 99, "endLine": 106 },
+    "type": "theorem",
+    "title": "Scalar Specialization: |f(x) − f(a)| ≤ C(x−a) for ℝ-Valued Functions",
+    "content": "When $E = \\mathbb{R}$, the vector inequality becomes $|f(x) - f(a)| \\leq C(x-a)$. Lean's type unification automatically specializes, so the proof is simply `mean_value_inequality hf hC`. This is strictly weaker than the classical scalar MVT which gives exact equality at some point $c$.",
+    "mathContext": "For $\\mathbb{R}$-valued functions, $\\|f(x) - f(a)\\| = |f(x) - f(a)|$ since the norm on $\\mathbb{R}$ is the absolute value. The inequality loses the sign information: it cannot distinguish $f(b) > f(a)$ from $f(b) < f(a)$. The classical equality is proved separately in `classical_mvt_gives_equality`.",
     "significance": "supporting",
     "relatedConcepts": [
       "type specialization",
       "absolute value as norm",
-      "information loss"
+      "information loss",
+      "scalar MVT"
     ],
     "prerequisites": [
       "mean_value_inequality"
-    ],
-    "proofId": "mean-value-theorem-oq-03"
+    ]
   },
   {
     "id": "ann-classical-equality",
-    "line": 108,
-    "type": "technique",
-    "content": "**Classical MVT equality**: For $f : \\mathbb{R} \\to \\mathbb{R}$ continuous on $[a,b]$ and differentiable on $(a,b)$, $\\exists c \\in (a,b)$ with $f'(c) = \\frac{f(b)-f(a)}{b-a}$. Uses Mathlib's `exists_deriv_eq_slope`. This relies on the **intermediate value theorem** applied to $g(x) = f(x) - \\lambda x$ (reducing to Rolle's theorem), which is why it has no vector analogue.",
+    "proofId": "mean-value-theorem-oq-03",
+    "range": { "startLine": 108, "endLine": 133 },
+    "type": "theorem",
+    "title": "Classical MVT Equality: ∃c ∈ (a,b) with f'(c) = (f(b)−f(a))/(b−a)",
+    "content": "For $f : \\mathbb{R} \\to \\mathbb{R}$ continuous on $[a,b]$ and differentiable on $(a,b)$, $\\exists c \\in (a,b)$ with $f'(c) = \\frac{f(b)-f(a)}{b-a}$. Uses Mathlib's `exists_deriv_eq_slope`. This relies on the **intermediate value theorem** applied to $g(x) = f(x) - \\lambda x$ (reducing to Rolle's theorem), which is why it has no vector analogue.",
     "mathContext": "Proof sketch: define $g(x) = f(x) - \\frac{f(b)-f(a)}{b-a} x$. Then $g(a) = g(b)$, so by Rolle's theorem $\\exists c, g'(c) = 0$, giving $f'(c) = \\frac{f(b)-f(a)}{b-a}$. Rolle's theorem itself uses the extreme value theorem (continuous function on $[a,b]$ attains its extrema) and the definition of derivative at an extremum.",
     "significance": "key",
     "relatedConcepts": [
       "Rolle's theorem",
       "intermediate value theorem",
       "Lagrange's MVT",
-      "extreme value theorem"
+      "extreme value theorem",
+      "exists_deriv_eq_slope"
     ],
     "prerequisites": [
       "ContinuousOn",
       "DifferentiableOn",
       "exists_deriv_eq_slope"
-    ],
-    "proofId": "mean-value-theorem-oq-03"
+    ]
   },
   {
     "id": "ann-counterexample",
-    "line": 135,
+    "proofId": "mean-value-theorem-oq-03",
+    "range": { "startLine": 135, "endLine": 160 },
     "type": "insight",
-    "content": "**Circular motion counterexample**: $f(t) = (\\cos t, \\sin t)$ on $[0, 2\\pi]$ shows MVT equality is impossible for vector functions. Net displacement: $f(2\\pi) - f(0) = (0,0)$, yet $\\|f'(t)\\| = 1$ everywhere. The 'slope' would be $(0,0)/(2\\pi) = (0,0)$, requiring $f'(c) = 0$ for some $c$, but $f'(t) = (-\\sin t, \\cos t)$ never vanishes. The obstruction is topological: the image traces a closed curve with winding number 1.",
-    "mathContext": "For $f(t) = (\\cos t, \\sin t)$: $f(2\\pi) - f(0) = (0,0)$ but $\\|f'(t)\\| = \\sqrt{\\sin^2 t + \\cos^2 t} = 1$ for all $t$. The MVT inequality gives $0 \\leq 1 \\cdot 2\\pi$ (trivially true), which is correct but not sharp.",
+    "title": "Circular Motion: Why MVT Equality Fails for Vector Functions",
+    "content": "Circular motion counterexample: $f(t) = (\\cos t, \\sin t)$ on $[0, 2\\pi]$ shows MVT equality is impossible for vector functions. Net displacement: $f(2\\pi) - f(0) = (0,0)$, yet $\\|f'(t)\\| = 1$ everywhere. The 'slope' would be $(0,0)/(2\\pi) = (0,0)$, requiring $f'(c) = 0$ for some $c$, but $f'(t) = (-\\sin t, \\cos t)$ never vanishes. The obstruction is topological: the image traces a closed curve with winding number 1.\n\n`circular_counterexample` proves $f(2\\pi) - f(0) = (0,0)$ and `circular_derivative_norm` proves $\\|f'(t)\\| = 1$.",
+    "mathContext": "For $f(t) = (\\cos t, \\sin t)$: $f(2\\pi) - f(0) = (0,0)$ but $\\|f'(t)\\| = \\sqrt{\\sin^2 t + \\cos^2 t} = 1$ for all $t$. The MVT inequality gives $0 \\leq 1 \\cdot 2\\pi$ (trivially true), which is correct but not sharp. The topological reason: the map $S^1 \\to \\mathbb{R}^2 \\setminus \\{0\\}$ has winding number 1, so no null-homotopy exists.",
     "significance": "key",
     "relatedConcepts": [
       "circular motion",
       "winding number",
-      "IVT failure in R^n",
-      "topology"
+      "IVT failure in ℝⁿ",
+      "topology",
+      "Real.sin_sq_add_cos_sq"
     ],
     "prerequisites": [
       "Real.cos_two_pi",
       "Real.sin_two_pi",
       "Real.sin_sq_add_cos_sq"
-    ],
-    "proofId": "mean-value-theorem-oq-03"
+    ]
   },
   {
     "id": "ann-lipschitz",
-    "line": 163,
-    "type": "technique",
-    "content": "**Derivative bound implies Lipschitz**: If $\\|Df(x)\\|_{\\text{op}} \\leq L$ on a convex set $S$, then $f$ is $L$-Lipschitz on $S$. Uses NNReal for the Lipschitz constant. Convexity is essential: for any $x, y \\in S$, the segment $[x,y] \\subseteq S$, so MVT applies along it. On non-convex domains, derivative bounds do not imply Lipschitz.",
-    "mathContext": "If $\\|Df(x)\\|_{\\text{op}} \\leq L$ for all $x \\in S$ (convex), then $\\|f(x) - f(y)\\| \\leq L \\|x - y\\|$ for all $x, y \\in S$. This bridges pointwise derivative information and global regularity, and is the key to proving that smooth maps between manifolds are locally Lipschitz.",
+    "proofId": "mean-value-theorem-oq-03",
+    "range": { "startLine": 163, "endLine": 185 },
+    "type": "theorem",
+    "title": "Derivative Bound ⇒ Lipschitz: ‖Df‖_op ≤ L on Convex Set",
+    "content": "If $\\|Df(x)\\|_{\\text{op}} \\leq L$ on a convex set $S$, then $f$ is $L$-Lipschitz on $S$. Uses NNReal for the Lipschitz constant. Convexity is essential: for any $x, y \\in S$, the segment $[x,y] \\subseteq S$, so MVT applies along it. On non-convex domains, derivative bounds do not imply Lipschitz.\n\n`constant_of_deriv_zero_vector` (line 173) follows immediately: zero derivative ($L=0$) gives 0-Lipschitz, meaning $f$ is constant.",
+    "mathContext": "If $\\|Df(x)\\|_{\\text{op}} \\leq L$ for all $x \\in S$ (convex), then $\\|f(x) - f(y)\\| \\leq L \\|x - y\\|$ for all $x, y \\in S$. This bridges pointwise derivative information and global regularity, and is the key to proving that smooth maps between manifolds are locally Lipschitz. NNReal is used for $L$ since Lipschitz constants are non-negative.",
     "significance": "key",
     "relatedConcepts": [
       "Lipschitz continuity",
       "Fréchet derivative",
       "operator norm",
       "convex sets",
-      "NNReal"
+      "NNReal",
+      "LipschitzOnWith"
     ],
     "prerequisites": [
       "Convex",
       "DifferentiableOn",
       "fderivWithin",
       "LipschitzOnWith"
-    ],
-    "proofId": "mean-value-theorem-oq-03"
+    ]
   },
   {
     "id": "ann-zero-deriv-constant",
-    "line": 173,
-    "type": "technique",
-    "content": "**Zero derivative implies constant** (vector version): If $f'(x) = 0$ for all $x \\in [a,b)$, then $f(b) = f(a)$. The proof is a beautiful application of MVT with $C = 0$: $\\|f(b) - f(a)\\| \\leq 0 \\cdot (b-a) = 0$, and $\\|f(b) - f(a)\\| \\geq 0$ (norm non-negativity), so by `le_antisymm`: $\\|f(b) - f(a)\\| = 0$, hence $f(b) = f(a)$ by `norm_eq_zero`.",
-    "mathContext": "This cannot be proved via the scalar MVT for vector functions — it genuinely requires the vector inequality. The key steps: (1) $\\|0\\| = 0 \\leq 0$, (2) $0 \\cdot (b-a) = 0$, (3) antisymmetry, (4) `norm_eq_zero` and `sub_eq_zero`.",
+    "proofId": "mean-value-theorem-oq-03",
+    "range": { "startLine": 173, "endLine": 202 },
+    "type": "theorem",
+    "title": "Zero Derivative ⇒ Constant (Vector Version): ‖f(b)−f(a)‖ ≤ 0",
+    "content": "If $f'(x) = 0$ for all $x \\in [a,b)$, then $f(b) = f(a)$. The proof is a beautiful application of MVT with $C = 0$: $\\|f(b) - f(a)\\| \\leq 0 \\cdot (b-a) = 0$, and $\\|f(b) - f(a)\\| \\geq 0$ (norm non-negativity), so by `le_antisymm`: $\\|f(b) - f(a)\\| = 0$, hence $f(b) = f(a)$ by `norm_eq_zero`.\n\nThis cannot be proved via the scalar MVT for vector functions — it genuinely requires the vector inequality.",
+    "mathContext": "Key steps: (1) $\\|0\\| = 0 \\leq 0$, (2) $0 \\cdot (b-a) = 0$, (3) antisymmetry of $\\leq$ with norm non-negativity, (4) `norm_eq_zero` gives $f(b) - f(a) = 0$, (5) `sub_eq_zero` gives $f(b) = f(a)$. The vector version is strictly more powerful than the scalar: it works for any normed space $E$.",
     "significance": "key",
     "relatedConcepts": [
       "constant function theorem",
       "le_antisymm",
       "norm_eq_zero",
-      "sub_eq_zero"
+      "sub_eq_zero",
+      "norm_nonneg"
     ],
     "prerequisites": [
       "mean_value_inequality",
-      "norm_nonneg"
-    ],
-    "proofId": "mean-value-theorem-oq-03"
+      "norm_nonneg",
+      "le_antisymm",
+      "norm_eq_zero"
+    ]
   },
   {
     "id": "ann-contraction-bound",
-    "line": 205,
-    "type": "technique",
-    "content": "**Contraction bound from derivative**: If $\\|T'(x)\\| \\leq q$ on $[a,b]$, then $\\|T(x) - T(a)\\| \\leq q(x-a)$. Exactly the MVT inequality in contraction mapping language. When $q < 1$, $T$ is a strict contraction, enabling Banach's fixed-point theorem: the Picard iteration $T^n(x_0)$ converges to a unique fixed point.",
-    "mathContext": "In the Banach fixed-point theorem, one needs $\\|T(x) - T(y)\\| \\leq q\\|x-y\\|$ with $q < 1$. The MVT inequality provides this when $\\|DT\\|_{\\text{op}} \\leq q < 1$. For ODEs, the Picard operator $\\Phi(u)(t) = x_0 + \\int_0^t F(s, u(s))ds$ is a contraction when $F$ is Lipschitz.",
+    "proofId": "mean-value-theorem-oq-03",
+    "range": { "startLine": 205, "endLine": 226 },
+    "type": "theorem",
+    "title": "Contraction Bound: ‖T'‖ ≤ q Implies ‖T(x)−T(a)‖ ≤ q(x−a)",
+    "content": "If $\\|T'(x)\\| \\leq q$ on $[a,b]$, then $\\|T(x) - T(a)\\| \\leq q(x-a)$. Exactly the MVT inequality in contraction mapping language. When $q < 1$, $T$ is a strict contraction, enabling Banach's fixed-point theorem: the Picard iteration $T^n(x_0)$ converges to a unique fixed point.",
+    "mathContext": "In the Banach fixed-point theorem, one needs $\\|T(x) - T(y)\\| \\leq q\\|x-y\\|$ with $q < 1$. The MVT inequality provides this when $\\|DT\\|_{\\text{op}} \\leq q < 1$. For ODEs, the Picard operator $\\Phi(u)(t) = x_0 + \\int_0^t F(s, u(s))\\,ds$ is a contraction when $F$ is Lipschitz in the second argument.",
     "significance": "supporting",
     "relatedConcepts": [
       "contraction mapping",
       "Banach fixed-point theorem",
-      "Picard iteration"
+      "Picard iteration",
+      "ODE existence"
     ],
     "prerequisites": [
       "mean_value_inequality"
-    ],
-    "proofId": "mean-value-theorem-oq-03"
+    ]
   },
   {
     "id": "ann-displacement-bound",
-    "line": 229,
-    "type": "technique",
-    "content": "**Displacement bound**: For $f : \\mathbb{R} \\to \\mathbb{R}$ with $\\|f'\\| \\leq C$ on $[0,T]$: $\\|f(T) - f(0)\\| \\leq CT$. The simplest 'derivative controls displacement' principle. The proof specializes MVT to the endpoint $T$ and simplifies. This is the constant-coefficient case of Gronwall's inequality, which generalizes to $y'(t) \\leq \\alpha y(t) + \\beta$.",
-    "mathContext": "Gronwall's inequality: if $y'(t) \\leq \\alpha y(t) + \\beta$ and $y(0) = y_0$, then $y(t) \\leq (y_0 + \\beta/\\alpha)e^{\\alpha t} - \\beta/\\alpha$. The displacement bound is the $\\alpha = 0$ case: $y'(t) \\leq C$ gives $y(t) - y(0) \\leq Ct$.",
+    "proofId": "mean-value-theorem-oq-03",
+    "range": { "startLine": 229, "endLine": 262 },
+    "type": "theorem",
+    "title": "Displacement Bound: ‖f(T)−f(0)‖ ≤ CT (Constant-Coefficient Gronwall)",
+    "content": "For $f : \\mathbb{R} \\to \\mathbb{R}$ with $\\|f'\\| \\leq C$ on $[0,T]$: $\\|f(T) - f(0)\\| \\leq CT$. The simplest 'derivative controls displacement' principle. The proof specializes MVT to the endpoint $T$ and simplifies. This is the constant-coefficient case of Gronwall's inequality, which generalizes to $y'(t) \\leq \\alpha y(t) + \\beta$.",
+    "mathContext": "Gronwall's inequality: if $y'(t) \\leq \\alpha y(t) + \\beta$ and $y(0) = y_0$, then $y(t) \\leq (y_0 + \\beta/\\alpha)e^{\\alpha t} - \\beta/\\alpha$. The displacement bound is the $\\alpha = 0$ case: $y'(t) \\leq C$ gives $y(t) - y(0) \\leq Ct$. Used to bound solution growth in ODEs.",
     "significance": "supporting",
     "relatedConcepts": [
       "displacement",
@@ -168,107 +188,116 @@
     "prerequisites": [
       "mean_value_inequality",
       "Icc membership"
-    ],
-    "proofId": "mean-value-theorem-oq-03"
+    ]
   },
   {
     "id": "ann-banach-general",
-    "line": 265,
-    "type": "technique",
-    "content": "**Banach space MVT**: The most general form — for $f : E \\to F$ between arbitrary normed spaces, differentiable on a convex set with $\\|Df(x)\\|_{\\text{op}} \\leq C$: $\\|f(b) - f(a)\\| \\leq C\\|b - a\\|$. Uses `fderivWithin` (Fréchet derivative within a set). This is the foundation for the implicit function theorem, inverse function theorem, and Nash-Moser iteration in infinite dimensions.",
-    "mathContext": "The Fréchet derivative $Df(x) : E \\to_L F$ is a bounded linear map. Its operator norm $\\|Df(x)\\|_{\\text{op}} = \\sup_{\\|h\\|=1} \\|Df(x)(h)\\|$ measures the maximum infinitesimal stretching. The inequality says $f$ cannot stretch distances more than $C$-fold globally.",
+    "proofId": "mean-value-theorem-oq-03",
+    "range": { "startLine": 265, "endLine": 291 },
+    "type": "theorem",
+    "title": "Banach Space MVT: ‖f(b)−f(a)‖ ≤ C‖b−a‖ for Fréchet Differentiable Maps",
+    "content": "The most general form — for $f : E \\to F$ between arbitrary normed spaces, differentiable on a convex set with $\\|Df(x)\\|_{\\text{op}} \\leq C$: $\\|f(b) - f(a)\\| \\leq C\\|b - a\\|$. Uses `fderivWithin` (Fréchet derivative within a set). This is the foundation for the implicit function theorem, inverse function theorem, and Nash-Moser iteration in infinite dimensions.",
+    "mathContext": "The Fréchet derivative $Df(x) : E \\to_L F$ is a bounded linear map. Its operator norm $\\|Df(x)\\|_{\\text{op}} = \\sup_{\\|h\\|=1} \\|Df(x)(h)\\|$ measures the maximum infinitesimal stretching. The inequality says $f$ cannot stretch distances more than $C$-fold globally. Mathlib's `Convex.norm_image_sub_le_of_norm_fderivWithin_le` provides the core bound.",
     "significance": "key",
     "relatedConcepts": [
       "Banach space",
       "Fréchet derivative",
       "operator norm",
       "implicit function theorem",
-      "inverse function theorem"
+      "inverse function theorem",
+      "Convex.norm_image_sub_le_of_norm_fderivWithin_le"
     ],
     "prerequisites": [
       "Convex",
       "DifferentiableOn",
       "fderivWithin",
       "Convex.norm_image_sub_le_of_norm_fderivWithin_le"
-    ],
-    "proofId": "mean-value-theorem-oq-03"
+    ]
   },
   {
     "id": "ann-ode-uniqueness",
-    "line": 294,
-    "type": "technique",
-    "content": "**ODE difference bound via MVT**: If $f(a) = g(a)$ and $\\|f'(t) - g'(t)\\| \\leq q$ on $[a,b)$, then $\\|(f(x)-g(x)) - (f(a)-g(a))\\| \\leq q(x-a)$. The proof constructs $h = f - g$ using `HasDerivWithinAt.sub`, then applies Mathlib's MVT. This is the core of Picard-Lindelöf uniqueness: two ODE solutions with close derivatives remain close.",
-    "mathContext": "For the ODE $x' = F(t,x)$ with $L$-Lipschitz $F$: if $x_1, x_2$ are solutions with $x_1(a) = x_2(a)$, then $\\|(x_1-x_2)'\\| = \\|F(t,x_1)-F(t,x_2)\\| \\leq L\\|x_1-x_2\\|$. Combined with Gronwall, this gives uniqueness: $x_1 = x_2$.",
+    "proofId": "mean-value-theorem-oq-03",
+    "range": { "startLine": 294, "endLine": 329 },
+    "type": "theorem",
+    "title": "ODE Difference Bound: ‖(f−g)(x)‖ ≤ q(x−a) when f(a)=g(a)",
+    "content": "If $f(a) = g(a)$ and $\\|f'(t) - g'(t)\\| \\leq q$ on $[a,b)$, then $\\|(f(x)-g(x)) - (f(a)-g(a))\\| \\leq q(x-a)$. The proof constructs $h = f - g$ using `HasDerivWithinAt.sub`, then applies Mathlib's MVT. This is the core of Picard-Lindelöf uniqueness: two ODE solutions with close derivatives remain close.",
+    "mathContext": "For the ODE $x' = F(t,x)$ with $L$-Lipschitz $F$: if $x_1, x_2$ are solutions with $x_1(a) = x_2(a)$, then $\\|(x_1-x_2)'\\| = \\|F(t,x_1)-F(t,x_2)\\| \\leq L\\|x_1-x_2\\|$. Combined with Gronwall, this gives uniqueness: $x_1 = x_2$. The `difference_bound_for_odes` theorem establishes the key bound.",
     "significance": "key",
     "relatedConcepts": [
       "Picard-Lindelöf theorem",
       "ODE uniqueness",
       "Gronwall inequality",
-      "contraction mapping"
+      "contraction mapping",
+      "HasDerivWithinAt.sub"
     ],
     "prerequisites": [
       "HasDerivWithinAt.sub",
       "norm_image_sub_le_of_norm_deriv_le_segment'"
-    ],
-    "proofId": "mean-value-theorem-oq-03"
+    ]
   },
   {
     "id": "ann-strict-mono",
-    "line": 331,
-    "type": "technique",
-    "content": "**Strict monotonicity from positive derivative**: $f' > 0$ on $(a,b)$ with $f$ continuous on $[a,b]$ implies $f(a) < f(b)$. This *cannot* be proved from the vector inequality — it genuinely needs the scalar MVT equality. Proof: get $c$ via `exists_deriv_eq_slope`, observe $f'(c) > 0$, substitute $f'(c) = \\frac{f(b)-f(a)}{b-a}$, use $b-a > 0$ and `div_mul_cancel₀` to get $f(b)-f(a) > 0$.",
-    "mathContext": "The vector inequality only gives $|f(b)-f(a)| \\leq C(b-a)$ — non-negative, unable to determine the sign of $f(b)-f(a)$. The equality $f'(c) = \\frac{f(b)-f(a)}{b-a} > 0$ preserves sign information. This is why the scalar MVT retains independent value alongside the vector inequality.",
+    "proofId": "mean-value-theorem-oq-03",
+    "range": { "startLine": 331, "endLine": 345 },
+    "type": "theorem",
+    "title": "Strict Monotonicity from Positive Derivative (Requires Scalar MVT Equality)",
+    "content": "Strict monotonicity: $f' > 0$ on $(a,b)$ with $f$ continuous on $[a,b]$ implies $f(a) < f(b)$. This *cannot* be proved from the vector inequality — it genuinely needs the scalar MVT equality. Proof: get $c$ via `exists_deriv_eq_slope`, observe $f'(c) > 0$, substitute $f'(c) = \\frac{f(b)-f(a)}{b-a}$, use $b-a > 0$ and `div_mul_cancel₀` to get $f(b)-f(a) > 0$.",
+    "mathContext": "The vector inequality only gives $|f(b)-f(a)| \\leq C(b-a)$ — non-negative, unable to determine the sign of $f(b)-f(a)$. The equality $f'(c) = \\frac{f(b)-f(a)}{b-a} > 0$ preserves sign information. This is why the scalar MVT equality retains independent value alongside the vector inequality.",
     "significance": "key",
     "relatedConcepts": [
       "monotone functions",
       "first derivative test",
       "div_mul_cancel₀",
-      "sign preservation"
+      "sign preservation",
+      "strict_mono_of_deriv_pos"
     ],
     "prerequisites": [
       "exists_deriv_eq_slope",
       "sub_pos",
       "mul_pos"
-    ],
-    "proofId": "mean-value-theorem-oq-03"
+    ]
   },
   {
     "id": "ann-antiderivative",
-    "line": 347,
-    "type": "technique",
-    "content": "**Antiderivative uniqueness**: If $f' = g'$ on $[a,b)$, then $f(x) - g(x) = f(a) - g(a)$ for all $x \\in [a,b]$. Proof: set $h = f - g$, show $h' = 0$ via `sub_eq_zero`, apply MVT with $C = 0$ (reusing the constant_of_deriv_zero_vector technique). Uses vector machinery even for a scalar result, showing the vector approach subsumes the scalar case.",
-    "mathContext": "This is the uniqueness part of the fundamental theorem of calculus: if $F' = G'$ then $F - G$ is constant. The constant of integration $f(a) - g(a)$ is the only degree of freedom. In Lean, the proof chain is: `sub_eq_zero` → `norm_le_zero` → `le_antisymm` → `norm_eq_zero` → `sub_eq_zero`.",
+    "proofId": "mean-value-theorem-oq-03",
+    "range": { "startLine": 347, "endLine": 363 },
+    "type": "theorem",
+    "title": "Antiderivative Uniqueness: f' = g' ⇒ f − g is Constant",
+    "content": "If $f' = g'$ on $[a,b)$, then $f(x) - g(x) = f(a) - g(a)$ for all $x \\in [a,b]$. Proof: set $h = f - g$, show $h' = 0$ via `sub_eq_zero`, apply MVT with $C = 0$ (reusing the constant_of_deriv_zero_vector technique). Uses vector machinery even for a scalar result, showing the vector approach subsumes the scalar case.\n\nThis is the uniqueness part of the fundamental theorem of calculus: the constant of integration $f(a) - g(a)$ is the only degree of freedom.",
+    "mathContext": "In Lean, the proof chain is: $f' - g' = 0$ → apply `constant_of_deriv_zero_vector` to $h = f - g$ → $h(b) = h(a)$ → $f(b) - g(b) = f(a) - g(a)$. The uniqueness statement can also be written as: the kernel of the differentiation operator is exactly the constant functions.",
     "significance": "key",
     "relatedConcepts": [
       "fundamental theorem of calculus",
       "constant of integration",
-      "antiderivative uniqueness"
+      "antiderivative uniqueness",
+      "sub_eq_zero"
     ],
     "prerequisites": [
       "HasDerivWithinAt.sub",
       "mean_value_inequality",
       "norm_eq_zero"
-    ],
-    "proofId": "mean-value-theorem-oq-03"
+    ]
   },
   {
     "id": "ann-banach-fderiv-zero",
-    "line": 429,
-    "type": "technique",
-    "content": "**Banach constant-function theorem**: If the Fréchet derivative $Df = 0$ on a convex set $S \\subseteq E$, then $f$ is constant on $S$. Full Banach space generalization of `constant_of_deriv_zero_vector`. The proof mirrors the $\\mathbb{R} \\to E$ version: set $C = 0$ in the Banach MVT, use $\\|0\\|_{\\text{op}} = 0 \\leq 0$, then antisymmetry.",
-    "mathContext": "For $f : E \\to F$ with $Df(x) = 0$ (the zero operator) for all $x \\in S$: $\\|f(b) - f(a)\\| \\leq 0 \\cdot \\|b-a\\| = 0$. This generalizes to: if $Df = Dg$ on a connected open set, then $f - g$ is constant. Connectedness is needed because the convexity argument works locally.",
+    "proofId": "mean-value-theorem-oq-03",
+    "range": { "startLine": 429, "endLine": 441 },
+    "type": "theorem",
+    "title": "Banach Constant-Function Theorem: Df = 0 on Convex S ⇒ f Constant",
+    "content": "If the Fréchet derivative $Df = 0$ on a convex set $S \\subseteq E$, then $f$ is constant on $S$. Full Banach space generalization of `constant_of_deriv_zero_vector`. The proof mirrors the $\\mathbb{R} \\to E$ version: set $C = 0$ in the Banach MVT, use $\\|0\\|_{\\text{op}} = 0 \\leq 0$, then antisymmetry.\n\nAlso in this section: `banach_mvt_differentiableAt` (line 407) and `banach_mvt_hasFDerivWithinAt` (line 418) provide alternative hypotheses for the Banach MVT — differentiability at a point vs. `hasFDerivWithinAt`.",
+    "mathContext": "For $f : E \\to F$ with $Df(x) = 0$ (the zero operator) for all $x \\in S$: $\\|f(b) - f(a)\\| \\leq 0 \\cdot \\|b-a\\| = 0$. This generalizes to: if $Df = Dg$ on a connected open set, then $f - g$ is constant. Connectedness is needed; convexity is sufficient because the MVT applies along line segments.",
     "significance": "key",
     "relatedConcepts": [
       "constant function",
       "connected domain",
       "Fréchet derivative",
-      "zero operator"
+      "zero operator",
+      "banach_mean_value_inequality"
     ],
     "prerequisites": [
       "banach_mean_value_inequality",
       "norm_eq_zero",
       "le_antisymm"
-    ],
-    "proofId": "mean-value-theorem-oq-03"
+    ]
   }
 ]


### PR DESCRIPTION
## Enrichment Summary

Schema migration and new annotations for 6 proof gallery entries.

### New Annotations

**cantor-diagonalization-oq-03-oq-01-oq-02** — 8 new annotations from scratch covering the Cantor→Lawvere→Rice chain, EvalStructure, abstract_rice, semantic properties, HaltingModel.

### Schema Migrations (line → range, technique → theorem)

**euler-polyhedral-formula-oq-02-oq-01** (17 annotations)
- `line` → `range` for all 17 annotations
- Types fixed: girard-formula, poincare-hopf, morse-theory → `definition` (startLine is a structure)
- Ranges cover CompactRiemannianSurface (47-61), Gauss-Bonnet (89-98), curvature signs (112-136), genus classification (175-200), concrete examples (390-432), boundary (452-469), Girard triangles (525-598), Poincaré-Hopf (630-685), Morse theory (701-746)

**mean-value-theorem-oq-03** (14 annotations)
- `line` → `range`; 5 types fixed from `technique` → `theorem`

**binomial-theorem-oq-03** (14 annotations)
- Removed stale `line` fields; 12 types fixed from `technique` → `theorem`

**erdos-1059-oq-04** (4 annotations) — `significance` enum fix + proofId

**knights-tour-oblique-oq-01** (8 annotations) — added header context, ClosedTourN, tour properties annotations; fixed misplaced Knuth context annotation

**elementary-quadratic-reciprocity-oq-03-oq-02-oq-01** (4 annotations) — `line`/`body` → `range`/`content`, significance enum fix

**erdos-1-oq-02** (4 annotations) — `line`/`body` → `range`/`content`, anticoncentration type fix (axiom→concept)

All entries pass `npx tsx scripts/annotations/build.ts` with zero errors.