### PR TITLE
feat(enrichment): enrich 5 gallery proofs with annotations and sections

### DIFF
--- a/src/data/proofs/fundamental-arithmetic-oq-01/annotations.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-preamble",
+    "proofId": "fundamental-arithmetic-oq-01",
+    "range": { "startLine": 1, "endLine": 33 },
+    "type": "context",
+    "title": "Module Preamble: Imports and Mathematical Context",
+    "content": "The file opens with a docblock summarising the mathematical content: for coprime m, n the p-adic valuations satisfy v_p(mn) = v_p(m) + v_p(n), and coprimality means the factorizations have disjoint support. Three Mathlib imports are used: Nat.Factorization.Basic (providing Nat.factorization and Nat.factorization_mul), Nat.GCD.Basic (providing Nat.Coprime and Nat.coprime_iff_disjoint), and Tactic (providing the tactic infrastructure). The namespace FundamentalArithmeticOQ01 isolates all declarations from the global namespace.",
+    "mathContext": "The key Mathlib definitions: \\texttt{Nat.factorization : ℕ → Finsupp ℕ ℕ} is the prime factorization as a finite-support function; \\texttt{Nat.factorization\\_mul (hm : m ≠ 0) (hn : n ≠ 0)} is the core multiplicativity lemma; \\texttt{Nat.Coprime m n} is defined as \\texttt{Nat.gcd m n = 1}; \\texttt{Nat.coprime\\_iff\\_disjoint} gives the Finsupp support characterization of coprimality.",
+    "significance": "context",
+    "relatedConcepts": ["Nat.factorization", "Finsupp ℕ ℕ", "Nat.Coprime", "Mathlib.Data.Nat.Factorization.Basic"],
+    "prerequisites": ["Lean 4 import system", "Mathlib library structure", "namespace declarations in Lean 4"]
+  },
+  {
     "id": "ann-factorization-mul",
     "proofId": "fundamental-arithmetic-oq-01",
     "range": { "startLine": 34, "endLine": 41 },

--- a/src/data/proofs/fundamental-arithmetic-oq-01/meta.json
+++ b/src/data/proofs/fundamental-arithmetic-oq-01/meta.json
@@ -46,6 +46,14 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Imports and Module Setup",
+      "startLine": 1,
+      "endLine": 23,
+      "summary": "Docblock describing the mathematical goal; imports Nat.Factorization.Basic, Nat.GCD.Basic, and Tactic from Mathlib; opens FundamentalArithmeticOQ01 namespace.",
+      "mathContext": "Three Mathlib imports supply the machinery: \\texttt{Nat.Factorization.Basic} provides \\texttt{Nat.factorization} (the Finsupp-valued prime factorization) and \\texttt{Nat.factorization\\_mul}; \\texttt{Nat.GCD.Basic} supplies \\texttt{Nat.Coprime} and \\texttt{Nat.coprime\\_iff\\_disjoint}; \\texttt{Tactic} enables \\texttt{by\\_contra}, \\texttt{push\\_neg}, \\texttt{simp}, and \\texttt{native\\_decide}."
+    },
+    {
       "id": "multiplicativity",
       "title": "Multiplicativity of Factorization",
       "startLine": 34,
@@ -93,6 +101,16 @@
       "targetId": "fundamental-arithmetic",
       "relationship": "extends",
       "description": "Parent entry proving the Fundamental Theorem of Arithmetic; this entry proves the multiplicative property as a corollary"
+    },
+    {
+      "targetId": "fundamental-arithmetic-oq-02",
+      "relationship": "contrasts",
+      "description": "Non-unique factorization in ℤ[√(-5)]: shows that unique factorization fails when moving beyond ℕ, highlighting that the multiplicative property proved here is special to UFDs"
+    },
+    {
+      "targetId": "binary-gcd",
+      "relationship": "foundational",
+      "description": "Stein's binary GCD algorithm computes the gcd underlying Nat.Coprime; the coprimality condition gcd(m,n)=1 is the hypothesis for the disjoint support theorems proved here"
     }
   ],
   "references": [


### PR DESCRIPTION
## Summary

Enrichment pass adding annotations, sections, and enhanced mathematical context to 5 gallery proofs:

- **cantor-diagonalization-oq-03-oq-01-oq-02** (Rice's Theorem as Lawvere Instance): 6 annotations, 5 sections — EvalStructure, lawvere_fpt, abstract_rice, SemanticProperty/HasFlipProgram, HaltingModel, classical Rice via Kleene
- **cauchy-schwarz-integral-oq-02-oq-02-oq-01** (ENNReal rpow Cancellation): 5 annotations — abstract-then-instantiate design pattern, rpow_add factoring, concrete p=2/p=3 examples
- **collatz-cycles** (Non-Existence of Small Cycles): 8 annotations, 7 sections — Collatz def, no fixed points, no 2-cycles, period-3 uniqueness, 3/4 contraction, 2^M>3^j halving constraints, verified n≤20
- **cantor-diagonalization-oq-02-oq-03-oq-02** (Fodor's Pressing-Down Lemma): 7 annotations, 7 sections — club sets, stationary sets, diagonal intersection, closed/unbounded parts, Fodor's main theorem

All annotations validated with `pnpm annotations:build` (0 errors).

## Test plan
- [x] `pnpm annotations:build` passes with no errors for all enriched proofs
- [x] Commits pushed to feature/enricher-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)