### PR TITLE
fix: correct stale lineCount in 4 gallery meta.json files

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-03-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03-oq-01/meta.json
@@ -29,7 +29,7 @@
     ],
     "dateAdded": "2026-03-21",
     "axiomCount": 5,
-    "lineCount": 383,
+    "lineCount": 389,
     "assumptions": "5 axioms total: 2 own (minAdmissibleDiameter_50 — minimum diameter of admissible 50-tuple, diameter_upper_bound_exists — existence of diameter upper bound) + 3 inherited from BoundedPrimeGaps.lean (maynard_tao_m_tuples, maynard_tao_sieve, maynard_tao_sieve_eh). 0 sorries.",
     "mathlib_version": "4.26.0"
   },
@@ -141,7 +141,7 @@
       "BoundedPrimeGaps"
     ],
     "namespace": "BoundedPrimeGapsOQ03OQ01",
-    "lineCount": 383,
+    "lineCount": 389,
     "axiomCount": 2,
     "theoremCount": 24,
     "definitionCount": 5

--- a/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
     "assumptions": "diagInter_isUnbounded (the diagonal intersection of clubs is unbounded). This is expressed as a sorry (1 sorry total) rather than an axiom declaration. The proof sketch is given in full in the sorry docstring. The closed part of the diagonal intersection is fully proved.",
-    "lineCount": 280,
+    "lineCount": 314,
     "theoremCount": 9,
     "definitionCount": 5,
     "originalContributions": [
@@ -64,7 +64,7 @@
   },
   "leanFile": {
     "namespace": "FodorLemma",
-    "lineCount": 280,
+    "lineCount": 314,
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-1059-oq-01/meta.json
+++ b/src/data/proofs/erdos-1059-oq-01/meta.json
@@ -82,7 +82,7 @@
       "Finset operations for counting",
       "Floor binary logarithm (Nat.log) and its monotonicity properties"
     ],
-    "lineCount": 471,
+    "lineCount": 456,
     "relatedProblems": [
       {
         "id": "erdos-1059",

--- a/src/data/proofs/erdos-448/meta.json
+++ b/src/data/proofs/erdos-448/meta.json
@@ -59,7 +59,7 @@
       "erdos_448 theorem: the conjecture is false"
     ],
     "axiomCount": 2,
-    "lineCount": 307,
+    "lineCount": 298,
     "assumptions": "12 axiom(s) and 1 sorry(s). See the Lean source for details."
   },
   "overview": {


### PR DESCRIPTION
## Fix

Correct stale `lineCount` values in 4 gallery `meta.json` files where the recorded count diverged from the actual Lean source file length.

## Evidence

| Proof | Field | Before | After |
|-------|-------|--------|-------|
| `cantor-diagonalization-oq-02-oq-03-oq-02` | `meta.lineCount` | 280 | 314 |
| `cantor-diagonalization-oq-02-oq-03-oq-02` | `leanFile.lineCount` | 280 | 314 |
| `erdos-1059-oq-01` | `meta.lineCount` | 471 | 456 |
| `erdos-448` | `meta.lineCount` | 307 | 298 |
| `bounded-prime-gaps-oq-03-oq-01` | `meta.lineCount` | 383 | 389 |
| `bounded-prime-gaps-oq-03-oq-01` | `leanFile.lineCount` | 383 | 389 |

Verified by counting `readlines()` on each Lean file against the recorded value.

---
Automated fix by lean-mechanic agent.