### PR TITLE
chore(audit): cycle 46 tracker — 2 proofs missing Lean source

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11692,6 +11692,12 @@
       "lastAudited": "2026-04-05T01:35:11Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-1059-oq-04": {
+      "auditCount": 2,
+      "lastAudited": "2026-04-05T02:52:54Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11698,6 +11698,18 @@
       "lastAudited": "2026-04-05T02:52:54Z",
       "result": "clean",
       "issues": []
+    },
+    "divisibility-rules-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-05T03:00:58Z",
+      "result": "issues-found",
+      "issues": []
+    },
+    "subset-count-multiset-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-05T03:01:47Z",
+      "result": "issues-found",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Audit Cycle 46

### Issues Found (2)

| Proof | Claim | Reality | Issue |
|-------|-------|---------|-------|
| `divisibility-rules-oq-01-oq-01` | verified/original, 0 sorries | `DivisibilityRulesOQ01OQ01.lean` missing | #9647 |
| `subset-count-multiset-oq-01` | verified/original, 0 sorries | `SubsetCountMultisetOQ01.lean` missing | #9648 |

Both proofs claim `"status": "verified"` with `"badge": "original"` and 0 sorries/axioms, but neither has a corresponding Lean source file in `proofs/Proofs/`.

### Stats After Cycle
- Total proofs: 1938
- Audited: 1937 (previously 1935)
- Remaining unaudited: 1 (`erdos-1059-oq-04`, claimed by another auditor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)