### PR TITLE
Enrich 2 entries: FundamentalArithmetic OQ-01 + Erdős #152 OQ-01

### DIFF
--- a/src/data/proofs/hilbert-22-oq-01/annotations.json
+++ b/src/data/proofs/hilbert-22-oq-01/annotations.json
@@ -1,9 +1,21 @@
 [
   {
+    "id": "ann-preamble",
+    "proofId": "hilbert-22-oq-01",
+    "range": { "startLine": 1, "endLine": 26 },
+    "type": "context",
+    "title": "Module Preamble: Mathematical Context and Framework",
+    "content": "The file opens with `import Mathlib` and a rich docblock articulating the four frameworks for higher-dimensional uniformization: (1) the Kodaira-Enriques classification for dim 2 algebraic surfaces, (2) Yau's theorem on Kähler-Einstein metrics (Calabi conjecture), (3) Kobayashi hyperbolicity as the higher-dimensional 'hyperbolic type', and (4) the Minimal Model Program (Mori theory) for birational classification. The single namespace `Hilbert22OQ01` groups all definitions. This file is unusual in using `decide` as the main theorem tactic — the mathematical content lives primarily in the definitions and docstrings rather than in proved theorems.",
+    "mathContext": "The uniformization analogy in higher dimensions: dimension 1 gives $\\{S^2, \\mathbb{C}, \\mathbb{D}\\}$ corresponding to $(\\kappa = -\\infty, \\kappa = 0, \\kappa = 1)$. Dimension 2: the Enriques-Kodaira classification gives exactly 8 surface classes. Dimension $\\ge 3$: no finite classification; instead one uses the Minimal Model Program to reduce to a minimal model (with the Mori cone and flip operations), and Kobayashi hyperbolicity as a geometric invariant.",
+    "significance": "context",
+    "relatedConcepts": ["Hilbert's 22nd problem", "Kodaira dimension", "Kähler-Einstein metrics", "Minimal Model Program"],
+    "prerequisites": ["Riemann surface uniformization theorem", "complex manifold basics", "canonical bundle and Chern classes"]
+  },
+  {
     "id": "ann-kodaira-dimension-type",
     "proofId": "hilbert-22-oq-01",
     "range": { "startLine": 39, "endLine": 52 },
-    "type": "definition",
+    "type": "concept",
     "title": "Kodaira Dimension as an Inductive Type",
     "content": "The `KodairaDimension` inductive type encodes the classification invariant introduced by Kunihiko Kodaira in the 1960s. The two constructors capture the two qualitatively different regimes: `negInfty` for rational/ruled manifolds (where the canonical bundle has negative self-intersection) and `finite k` for manifolds where the pluricanonical maps are non-trivial up to dimension k. The `riemann_surface_kodaira` function explicitly maps the classical trichotomy {S², ℂ, 𝔻} to Kodaira dimensions {-∞, 0, 1}, making the analogy between 1D uniformization and higher-dimensional classification machine-checkable.",
     "mathContext": "$\\kappa(X) = \\limsup_{m\\to\\infty} \\frac{\\log \\dim H^0(X, K_X^{\\otimes m})}{\\log m} \\in \\{-\\infty, 0, 1, \\ldots, \\dim X\\}$",

--- a/src/data/proofs/hilbert-22-oq-01/meta.json
+++ b/src/data/proofs/hilbert-22-oq-01/meta.json
@@ -41,18 +41,28 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Import, Docblock, and Namespace",
+      "startLine": 1,
+      "endLine": 26,
+      "summary": "Imports all of Mathlib; docblock describing the four frameworks (Kodaira-Enriques, Yau's theorem, Kobayashi hyperbolicity, Minimal Model Program) for higher-dimensional uniformization; opens Hilbert22OQ01 namespace.",
+      "mathContext": "The docblock frames the research problem: the 1D uniformization trichotomy $\\{S^2, \\mathbb{C}, \\mathbb{D}\\}$ corresponds to $(\\kappa = -\\infty, \\kappa = 0, \\kappa = 1)$ by Kodaira dimension. Dimension 2: Enriques-Kodaira gives exactly 8 classes. Dimension $\\ge 3$: infinite classification via Mori theory and birational geometry. Yau's 1977 theorem (Calabi conjecture proof) provides Kähler-Einstein metrics for $c_1 \\le 0$, the higher-dimensional Poincaré metric analogue."
+    },
+    {
       "id": "kodaira",
       "title": "Kodaira Dimension",
       "startLine": 28,
       "endLine": 55,
-      "summary": "Defines `KodairaDimension` as {-∞, finite k} and maps the 1D uniformization trichotomy {S², ℂ, 𝔻} to Kodaira dimensions {-∞, 0, 1}."
+      "summary": "Defines `KodairaDimension` as {-∞, finite k} and maps the 1D uniformization trichotomy {S², ℂ, 𝔻} to Kodaira dimensions {-∞, 0, 1}.",
+      "mathContext": "\\texttt{KodairaDimension} has two constructors: \\texttt{negInfty} ($\\kappa = -\\infty$, rational/ruled) and \\texttt{finite k} ($\\kappa = k$, general). The function \\texttt{riemann\\_surface\\_kodaira : Fin 3 → KodairaDimension} maps: 0 $\\mapsto$ \\texttt{negInfty} ($S^2$), 1 $\\mapsto$ \\texttt{finite 0} ($\\mathbb{C}$), 2 $\\mapsto$ \\texttt{finite 1} ($\\mathbb{D}$). This encodes the heuristic: $\\kappa = -\\infty$ is 'positive curvature' (rational), $\\kappa = 0$ is 'flat' (Calabi-Yau/abelian), $\\kappa = \\dim$ is 'negative curvature' (general type/hyperbolic)."
     },
     {
       "id": "surfaces",
       "title": "Enriques-Kodaira Surface Classification",
       "startLine": 57,
       "endLine": 82,
-      "summary": "Encodes the 8-class Enriques-Kodaira classification of compact complex surfaces with `SurfaceClass` and assigns each class its Kodaira dimension via `surfaceKodaira`."
+      "summary": "Encodes the 8-class Enriques-Kodaira classification of compact complex surfaces with `SurfaceClass` and assigns each class its Kodaira dimension via `surfaceKodaira`.",
+      "mathContext": "The 8 surface classes: $\\kappa = -\\infty$: \\texttt{rational}, \\texttt{ruled}; $\\kappa = 0$: \\texttt{K3}, \\texttt{Enriques}, \\texttt{abelian}, \\texttt{hyperelliptic}; $\\kappa = 1$: \\texttt{elliptic}; $\\kappa = 2$: \\texttt{generalType}. The \\texttt{surfaceKodaira} function is a total match expression with 8 cases. This is the unique complete classification of compact complex manifolds in dimension $> 1$ — in dimension $\\ge 3$ no analogous finite list exists."
     },
     {
       "id": "yau-kobayashi",
@@ -81,7 +91,13 @@
   "crossReferences": [
     {
       "targetId": "hilbert-22",
-      "relationship": "parent-problem"
+      "relationship": "extends",
+      "description": "Parent problem: the Koebe-Poincaré uniformization theorem for Riemann surfaces (dim 1); this entry explores how that trichotomy generalizes to higher dimensions via Kodaira dimension"
+    },
+    {
+      "targetId": "hilbert-11",
+      "relationship": "related",
+      "description": "Hilbert's 11th problem on quadratic forms over algebraic number fields; like uniformization, it concerns classification of geometric objects — quadratic forms rather than complex manifolds — by invariants"
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for 4 entries (quality 93, passes 0 each).

## fundamental-arithmetic-oq-01 — Multiplicative Property of Prime Factorization

- Added preamble annotation (lines 1-33) + preamble section with mathContext for Mathlib imports
- Cross-references: fundamental-arithmetic-oq-02, binary-gcd

## erdos-152-oq-01 — Two Isolated Elements in Sidon Sumsets

- Added preamble annotation (lines 1-23) + preamble section
- Fixed sections startLine for endpoint-lemmas (18→25)
- Fixed crossReferences to standard format; added erdos-340-greedy-sidon, erdos-28-additive-bases

## harmonic-divergence-oq-02 — Divergence of the Log-Harmonic Series

- Added preamble annotation (lines 1-31) + preamble section
- Added divergence-rate section (lines 143-156) for log(log N) asymptotic commentary
- Fixed duplicate mathContext field; added mathContext to not-summable section
- Cross-reference: harmonic-divergence-oq-01 (Euler-Mascheroni analogy)

## hilbert-22-oq-01 — Higher-Dimensional Uniformization

- Added preamble annotation (lines 1-26) covering the 4-framework docblock
- Added preamble section with mathContext; added mathContext to kodaira and surfaces sections
- Fixed annotation type: ann-kodaira-dimension-type definition→concept (matches inductive)
- Fixed crossReferences: added description to hilbert-22; added hilbert-11 cross-reference

## Axiom integrity

All four entries: status verified, axiomCount 0, no axiom declarations or assumption-carrying structures.