### PR TITLE
fix(auditor): remove false-positive axiom overcount detection

### DIFF
--- a/scripts/auditor/find-targets.ts
+++ b/scripts/auditor/find-targets.ts
@@ -216,14 +216,13 @@ function detectIssues(target: AuditTarget): string[] {
     issues.push(`sorry mismatch: claims ${target.meta.claimedSorries}, actual ${target.actual.sorryCount}`)
   }
 
-  // Axiom count mismatch -- check both directions.
-  // Note: structure-encoded assumptions should still be counted in meta.axiomCount per policy.
-  if (target.meta.claimedAxioms >= 0 && target.actual.axiomCount !== target.meta.claimedAxioms) {
-    if (target.actual.axiomCount > target.meta.claimedAxioms) {
-      issues.push(`axiom undercount: claims ${target.meta.claimedAxioms}, actual declarations ${target.actual.axiomCount}`)
-    } else {
-      issues.push(`axiom overcount: claims ${target.meta.claimedAxioms}, actual declarations ${target.actual.axiomCount}`)
-    }
+  // Axiom count mismatch -- only flag undercounts (meta claims fewer than actual).
+  // Overcounts are NOT flagged: meta.axiomCount may legitimately exceed direct `axiom`
+  // declarations because it must count imported axioms and structure-encoded assumptions
+  // per the Axiom Integrity Policy. The script cannot follow transitive imports beyond
+  // Aristotle companion files, so overcounting by meta is expected and correct.
+  if (target.meta.claimedAxioms >= 0 && target.actual.axiomCount > target.meta.claimedAxioms) {
+    issues.push(`axiom undercount: claims ${target.meta.claimedAxioms}, actual declarations ${target.actual.axiomCount}`)
   }
 
   // Verified with sorries


### PR DESCRIPTION
## Fix

Removes the "axiom overcount" detection from `scripts/auditor/find-targets.ts` to eliminate false positives for proofs with inherited axioms.

## Evidence

**Before**: `erdos-1059-oq-04` flagged as ❌ `axiom overcount: claims 1, actual declarations 0`

**Root cause**: `resolveAllLeanFiles` only follows Aristotle companion imports (not sibling gallery entries). When `Erdos1059OQ04.lean` imports `Proofs.Erdos1059OQ01`, the script cannot see the `axiom density_one_conjecture` declaration there. Meta.json correctly counts `axiomCount: 1` (per Axiom Integrity Policy), but the script found 0 direct declarations → false "overcount" alert.

**After**: Only axiom **undercounts** are flagged (where meta.json claims *fewer* axioms than the script can find). Overcounts are silently accepted because:
- Meta.json must count imported axioms per the Axiom Integrity Policy
- Meta.json must count structure-encoded assumptions (which grep also cannot detect)
- The script's scan is intentionally limited to avoid false positives from shared libraries

Closes #9642

---
Automated fix by lean-mechanic agent.