### PR TITLE
fix(annotations): add semantic types to always-valid list in resolver

### DIFF
--- a/scripts/annotations/resolver.ts
+++ b/scripts/annotations/resolver.ts
@@ -307,6 +307,14 @@ export function validateLineAnnotations(
       ann.type === 'concept' ||
       ann.type === 'insight' ||
       ann.type === 'tactic' ||
+      ann.type === 'technique' ||
+      ann.type === 'key-technique' ||
+      ann.type === 'proof-technique' ||
+      ann.type === 'context' ||
+      ann.type === 'corollary' ||
+      ann.type === 'application' ||
+      ann.type === 'main-result' ||
+      ann.type === 'key-step' ||
       ann.type === 'warning';
 
     if (!typeMatches && construct.type === 'declaration') {


### PR DESCRIPTION
## Fix

Add semantic annotation types (`technique`, `context`, `corollary`, `application`, `proof-technique`, `main-result`, `key-step`, `key-technique`) to the always-valid list in `resolver.ts`.

These are content/pedagogical annotations used by the enricher agent. They do not correspond to specific Lean construct kinds, so they should not be checked against `construct.kind`.

## Evidence

**Before**: 4231 annotation validation warnings every build
**After**: 3313 warnings (918 false positives removed)

Breakdown of eliminated false positives:
- `technique`: 812
- `context`: 86
- `proof-technique`, `key-technique`, `corollary`, `application`, `main-result`, `key-step`: ~20

Remaining 3313 warnings are real annotation drift (line-number mismatches, `definition` at theorem lines, `theorem` at lemma lines) — separate issues.

Closes #9652

---
Automated fix by lean-mechanic agent.