### PR TITLE
fix(binomial-oq-02-oq-01-oq-02): remove stale sorry references in meta.json

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-02/meta.json
@@ -33,7 +33,7 @@
       "The multinomial theorem IS the proof — no additional work beyond algebraic manipulation",
       "Product concentration: $\\prod_{i \\in s} (\\text{if } i = i_0 \\text{ then } t \\text{ else } 1)^{k(i)} = t^{k(i_0)}$ via `Finset.prod_eq_single`",
       "Sum simplification: $\\sum_s p(i) \\cdot (\\text{if } i = i_0 \\text{ then } t \\text{ else } 1) = p(i_0) t + (1 - p(i_0))$ via linearity and `Finset.sum_ite_eq'`",
-      "The open problem remains: formally extracting polynomial coefficients from the PGF identity to get the direct PMF formula"
+      "The direct PMF formula `multinomial_marginal_pmf` is proved via an explicit bijection between filtered piAntidiag elements and `(s.erase i₀).piAntidiag (n−j)`, bypassing polynomial coefficient extraction entirely"
     ]
   },
   "sections": [
@@ -83,7 +83,6 @@
   "conclusion": {
     "summary": "The main result `multinomial_marginal_pgf` proves that the PGF of each marginal of the multinomial distribution equals the Binomial PGF. Additionally, `multinomial_marginal_pmf` directly proves the PMF formula P(X_{i₀}=j) = C(n,j)·p(i₀)^j·(1−p(i₀))^(n−j) via an explicit bijection and Nat.multinomial_insert. All 10 theorems fully machine-verified, 0 sorries.",
     "openQuestions": [
-      "Can `multinomial_marginal_pmf` be completed using Lean 4's `Polynomial` library for coefficient extraction?",
       "Can the proof be extended to show joint independence of disjoint subsets of multinomial components?"
     ]
   },


### PR DESCRIPTION
## Fix

Remove two stale references to `multinomial_marginal_pmf` as incomplete in `binomial-theorem-oq-02-oq-01-oq-02/meta.json`.

## Evidence

**Before**:
- `overview.keyInsights[4]`: *"The open problem remains: formally extracting polynomial coefficients from the PGF identity to get the direct PMF formula"*
- `conclusion.openQuestions[0]`: *"Can `multinomial_marginal_pmf` be completed using Lean 4's `Polynomial` library for coefficient extraction?"*

**After**:
- `overview.keyInsights[4]`: Updated to describe the actual bijection proof technique used
- `conclusion.openQuestions`: Removed the now-answered question; retains the remaining open question about joint independence

`multinomial_marginal_pmf` was proved (commit 3180dea) via an explicit bijection, bypassing polynomial coefficient extraction. The stale text was left when the proof text was updated but these two entries were missed.

Supersedes PR #9418 (which had merge conflicts due to unrelated enrichment changes on main).

---
Automated fix by lean-mechanic agent.