### PR TITLE
fix(audit): add leanFile section to erdos-1059-oq-04 meta.json

### DIFF
--- a/src/data/proofs/erdos-1059-oq-04/meta.json
+++ b/src/data/proofs/erdos-1059-oq-04/meta.json
@@ -62,6 +62,12 @@
       }
     ]
   },
+  "leanFile": {
+    "lineCount": 147,
+    "axiomCount": 0,
+    "sorryCount": 0,
+    "note": "axiomCount=0 reflects declarations in this file only; meta.axiomCount=1 counts the inherited axiom from Proofs.Erdos1059OQ01 (density_one_conjecture)"
+  },
   "overview": {
     "historicalContext": "Erdős Problem #1059 asks whether infinitely many primes $p$ exist such that $p - k!$ is composite for every $k$ with $k! < p$. OQ-01 formalizes the natural density formulation: the density of qualifying primes among all primes should be 1. OQ-02 proves the conclusion from a Selberg sieve axiom. This file (OQ-04) gives a second independent route: the density-1 conjecture of OQ-01 directly implies the infinitude conclusion of OQ-02.",
     "problemStatement": "**Erdős Problem #1059 (Open):** Are there infinitely many primes $p$ such that $p - k!$ is composite for every $k$ with $1 \\leq k! < p$?\n\n**OQ-04 (this file):** Prove that density_one_conjecture (OQ-01's axiom) implies the infinitude of qualifying primes — connecting the density formulation of OQ-01 to the existence formulation of OQ-02.",


### PR DESCRIPTION
## Summary

- Adds a top-level `leanFile` section to `src/data/proofs/erdos-1059-oq-04/meta.json`
- The section records `axiomCount: 0` (declarations in this file only) alongside `meta.axiomCount: 1` (which counts the inherited axiom from `Proofs.Erdos1059OQ01`)
- Resolves a false positive "axiom overcount" error in the audit system: `find-targets.ts` was comparing the imported-axiom count (1) against the raw declaration count in the file (0) because there was no `leanFile` section to signal the intended split

## Test plan

- [ ] Verify the audit tracker no longer flags `erdos-1059-oq-04` as an axiom overcount false positive
- [ ] Confirm JSON is valid (no parse errors)
- [ ] Confirm `leanFile.axiomCount=0` matches the actual Lean source (`Proofs/Erdos1059OQ04.lean` has 0 `axiom` declarations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)