### PR TITLE
fix: guard against undefined notes in isStatusPlaceholder

### DIFF
--- a/scripts/research/sync-data.ts
+++ b/scripts/research/sync-data.ts
@@ -96,7 +96,8 @@ const STATUS_PREFIXES = ['AVAILABLE', 'IN-PROGRESS', 'IN PROGRESS', 'COMPLETED',
 /**
  * Check if a candidate's notes field is just a status placeholder
  */
-function isStatusPlaceholder(notes: string): boolean {
+function isStatusPlaceholder(notes: string | undefined | null): boolean {
+  if (!notes) return true
   const trimmed = notes.trim().replace(/\.$/, '').trim()
   if (!trimmed) return true
   const upper = trimmed.toUpperCase()


### PR DESCRIPTION
## Summary
- `isStatusPlaceholder` crashed with `TypeError: Cannot read properties of undefined (reading 'trim')` when candidates have no `notes` field
- Added null/undefined guard at the start of the function (returns `true` — treated as placeholder)

## Root cause
15 candidates in `candidate-pool.json` have `notes: undefined`. The TypeScript type said `string` but runtime data was nullable.

🤖 Generated by deployer agent