### PR TITLE
fix: remove 66 phantom sections in 54 gallery meta.json files

### DIFF
--- a/src/data/proofs/erdos-10/meta.json
+++ b/src/data/proofs/erdos-10/meta.json
@@ -110,14 +110,6 @@
       "endLine": 94,
       "summary": "Axiomatizes `infinitely_many_exceptions_k2`: $\\{n \\text{ even}\\} \\setminus S_2$ is infinite (proved via covering congruences), and `infinitely_many_exceptions_k3`: $\\{n \\text{ even}\\} \\setminus S_3$ is infinite (conjectured).",
       "mathContext": "Erdős's covering congruence argument: infinitely many even integers are not in $S_2 = \\{p + 2^a + 2^b\\}$. Extension to $S_3$ remains open."
-    },
-    {
-      "id": "romanoff",
-      "title": "Romanoff's Theorem",
-      "startLine": 103,
-      "endLine": 109,
-      "summary": "Axiomatizes `romanoff_positive_density`: $\\underline{d}(S_1) > 0$. Romanoff (1934) showed a positive proportion of integers are $p + 2^a$, using sieve methods. One of the earliest results on prime-plus-lacunary bases.",
-      "mathContext": "Romanoff (1934): $\\underline{d}(S_1) > 0$ via sieve methods — a positive proportion of integers have the form $p + 2^a$."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-1042/meta.json
+++ b/src/data/proofs/erdos-1042/meta.json
@@ -118,14 +118,6 @@
       "startLine": 126,
       "endLine": 132,
       "mathContext": "Key counterexample: $d(\\overline{\\mathbb{D}}_{1/2}) = 1/2 = d([-1,1])$, but the disc always gives 1 component while $[-1,1]$ can give $\\lfloor n/2 \\rfloor$ components. This proves the answer depends on the geometry of $F$, not just $d(F)$."
-    },
-    {
-      "id": "summary",
-      "title": "Summary",
-      "summary": "erdos_1042_summary theorem combining key results",
-      "startLine": 139,
-      "endLine": 151,
-      "mathContext": "`erdos_1042_summary` packages the two main GR results into a single proved conjunction: the $(1-c)n$ bound for $d < 1$ and the $n$-component result for $d = 1$. Proved by `exact ⟨ghosh_ramachandran_small_diameter, ghosh_ramachandran_diameter_one_examples⟩`."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-1104/meta.json
+++ b/src/data/proofs/erdos-1104/meta.json
@@ -81,14 +81,6 @@
       "endLine": 196,
       "summary": "Classical triangle-free graphs M_k with χ(M_k) = k on 3·2^{k−2} − 1 vertices. Gives weak f(n) ≥ Ω(log n) bound.",
       "mathContext": "Classical triangle-free graphs M_k with χ(M_k) = k on 3·$$2^{{k−2}$}$ − 1 vertices. Gives weak f(n) $\\geq$ Ω($\\log n$) bound."
-    },
-    {
-      "id": "summary",
-      "title": "Bounds Summary",
-      "startLine": 203,
-      "endLine": 212,
-      "summary": "Combined bounds_summary theorem: (1−ε)√(n/log n) ≤ f(n) ≤ (2+ε)√(n/log n) for large n.",
-      "mathContext": "Combined bounds_summary theorem: (1−ε)√(n/$\\log n$) $\\leq$ f(n) $\\leq$ (2+ε)√(n/$\\log n$) for large n."
     }
   ],
   "overview": {

--- a/src/data/proofs/erdos-1121/meta.json
+++ b/src/data/proofs/erdos-1121/meta.json
@@ -117,14 +117,6 @@
       "endLine": 218,
       "summary": "Ball structure in ℝⁿ and generalization axiom.",
       "mathContext": "Ball structure in ℝⁿ and generalization axiom."
-    },
-    {
-      "id": "summary",
-      "title": "Part VII: Summary",
-      "startLine": 219,
-      "endLine": 234,
-      "summary": "erdos_1121_summary: ErdosConjecture1121 := goodman_goodman_theorem.",
-      "mathContext": "erdos_1121_summary: ErdosConjecture1121 := goodman_goodman_theorem."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-1123/meta.json
+++ b/src/data/proofs/erdos-1123/meta.json
@@ -115,14 +115,6 @@
       "endLine": 110,
       "summary": "σ-ideal closure, finite sets have density zero",
       "mathContext": "σ-ideal closure, finite sets have density zero"
-    },
-    {
-      "id": "summary",
-      "title": "Summary",
-      "startLine": 111,
-      "endLine": 126,
-      "summary": "Proved conjunction of density implication and strict containment",
-      "mathContext": "Proved conjunction of density implication and strict containment"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-117/meta.json
+++ b/src/data/proofs/erdos-117/meta.json
@@ -98,13 +98,6 @@
       "startLine": 53,
       "endLine": 62,
       "summary": "Axiomatizes two key results. `pyber_1987`: exponential bounds $c_1^n \\leq h(n) \\leq c_2^n$ for constants $c_2 > c_1 > 1$, using $\\leq$ rather than strict inequalities. `isaacs_lower`: the independent exponential lower bound $c^n \\leq h(n)$ for some $c > 1$, established before Pyber's comprehensive treatment."
-    },
-    {
-      "id": "observations",
-      "title": "Observations and Open Questions",
-      "startLine": 68,
-      "endLine": 79,
-      "summary": "Axiomatizes the trivial case $h(1) = 1$ (the 1-commuting property forces $G$ to be Abelian). Comments note the connection to Ramsey theory and the central open question: whether $h(n) = \\Theta(c^n)$ for a single constant $c$."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-119/meta.json
+++ b/src/data/proofs/erdos-119/meta.json
@@ -98,14 +98,6 @@
       "endLine": 97,
       "summary": "Proves base cases ($p_0 = 1$, $p_1 = w - z_0$) and states $M_n \\geq 1$ for $n \\geq 1$ and nonnegativity of $M_n$.",
       "mathContext": "Verified: Proves base cases ($p_0 = 1$, $p_1 = w - z_0$) and states $M_n \\geq 1$ for $n \\geq 1$ and nonnegativity of $M_n$."
-    },
-    {
-      "id": "implications",
-      "title": "Implication Chain",
-      "startLine": 100,
-      "endLine": 115,
-      "summary": "States Part 3 $\\implies$ Part 2 $\\implies$ Part 1 as axioms, formalizing the strict hierarchy of the three conjectures.",
-      "mathContext": "Axiomatized: States Part 3 $\\implies$ Part 2 $\\implies$ Part 1 as axioms, formalizing the strict hierarchy of the three conjectures."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-136/meta.json
+++ b/src/data/proofs/erdos-136/meta.json
@@ -119,13 +119,6 @@
       "startLine": 168,
       "endLine": 185,
       "summary": "small_values axiom and f_nondecreasing"
-    },
-    {
-      "id": "summary",
-      "title": "Summary",
-      "startLine": 188,
-      "endLine": 205,
-      "summary": "erdos_136 proved theorem combining asymptotic and bounds"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-14/meta.json
+++ b/src/data/proofs/erdos-14/meta.json
@@ -106,14 +106,6 @@
       "endLine": 85,
       "summary": "For $A \\subseteq \\{1,\\ldots,N\\}$, $\\exists A$ with $f_A(N) < 2^{3/2}\\sqrt{N}$. The constant $2\\sqrt{2}$ may be optimal.",
       "mathContext": "For $A \\subseteq \\{1,\\ldots,N\\}$, $\\exists A$ with $f_A(N) < $$2^{{3/2}$}$\\sqrt{N}$. The constant $2\\sqrt{2}$ may be optimal."
-    },
-    {
-      "id": "structural",
-      "title": "Structural Observations",
-      "startLine": 90,
-      "endLine": 103,
-      "summary": "Sidon sets give $f_A(N) \\geq N/2$ (perfect uniqueness, poor coverage). Monotonicity: $M \\leq N \\implies f_A(M) \\leq f_A(N)$.",
-      "mathContext": "Mathematical content: Sidon sets give $f_A(N) \\geq N/2$ (perfect uniqueness, poor coverage). Monotonicity: $M \\leq N \\implies f_A(M) \\leq f_A(N)$."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-187/meta.json
+++ b/src/data/proofs/erdos-187/meta.json
@@ -73,20 +73,6 @@
       "startLine": 53,
       "endLine": 58,
       "summary": "Axiom: ∃ C, D₀, ∀ d ≥ D₀, f(d) ≤ C · (log₂ d + 1). Beck (1980) constructs a low-discrepancy 2-coloring limiting monochromatic AP length to O(log d)."
-    },
-    {
-      "id": "sqrt2-coloring",
-      "title": "Part IV: Erdős's √2-Coloring",
-      "startLine": 61,
-      "endLine": 67,
-      "summary": "Axiom: ∃ a Diophantine coloring achieving f(d) ≪ d. The coloring χ(n) = ⌊√2·n⌋ mod 2 uses equidistribution of {√2·nd} to limit monochromatic AP lengths."
-    },
-    {
-      "id": "open-question",
-      "title": "Part V: The Open Question",
-      "startLine": 68,
-      "endLine": 78,
-      "summary": "ErdosProblem187: is f(d) = Θ(log d)? Formalized as existence of c, C, D₀ with c·log₂ d ≤ f(d) ≤ C·log₂ d for all d ≥ D₀. Upper bound known (Beck); lower bound open."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-215/meta.json
+++ b/src/data/proofs/erdos-215/meta.json
@@ -134,14 +134,6 @@
       "endLine": 187,
       "summary": "Noncomputable steinhausSelector extracts unique lattice point from congruent copies; steinhausSelector_mem and steinhausSelector_unique theorems proved from ∃! API",
       "mathContext": "Verified: Noncomputable steinhausSelector extracts unique lattice point from congruent copies; steinhausSelector_mem and steinhausSelector_unique theorems proved from ∃! API"
-    },
-    {
-      "id": "higher-dim",
-      "title": "Part VII: Higher Dimensions",
-      "startLine": 194,
-      "endLine": 201,
-      "summary": "Defines HigherDimensionalSteinhaus n for ℤⁿ ⊂ ℝⁿ; axiom jackson_mauldin_general: true for n ≥ 2",
-      "mathContext": "Defines HigherDimensionalSteinhaus n for ℤⁿ ⊂ ℝⁿ; axiom jackson_mauldin_general: true for n $\\geq$ 2"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-258/meta.json
+++ b/src/data/proofs/erdos-258/meta.json
@@ -102,13 +102,6 @@
       "startLine": 95,
       "endLine": 108,
       "summary": "Statement of the general open conjecture without the monotonicity assumption."
-    },
-    {
-      "id": "properties",
-      "title": "Properties of τ",
-      "startLine": 111,
-      "endLine": 119,
-      "summary": "Verified properties showing τ(n) is always positive for n ≥ 1."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-276/meta.json
+++ b/src/data/proofs/erdos-276/meta.json
@@ -126,14 +126,6 @@
       "startLine": 65,
       "endLine": 78,
       "mathContext": "$\\exists S \\subseteq \\{\\text{primes}\\},\\; \\forall a,\\; \\text{IsLucas}(a) \\wedge \\gcd(a_0,a_1)=1 \\wedge \\text{Primefree}(a) \\Rightarrow \\forall k,\\, \\exists p \\in S,\\, p \\mid a_k$. The Lucas sequence is periodic mod $p$ with Pisano period $\\pi(p)$."
-    },
-    {
-      "id": "further-results",
-      "title": "Further Results and Open Questions",
-      "summary": "Comments on Vsemirnov's (2004) record-small starting values ($a_0 = 106276436867$) and the central open question: are covering congruences the only mechanism for primefree Lucas sequences?",
-      "startLine": 79,
-      "endLine": 87,
-      "mathContext": "Current record: $a_0 = 106276436867$, $a_1 = 35256392432$ (Vsemirnov 2004). Open: is every primefree coprime Lucas sequence explained by a covering system?"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-295/meta.json
+++ b/src/data/proofs/erdos-295/meta.json
@@ -132,14 +132,6 @@
       "endLine": 153,
       "summary": "Verified Egyptian fraction identities, significance of e-1, and e-1 positivity proof.",
       "mathContext": "Verified: Verified Egyptian fraction identities, significance of e-1, and e-1 positivity proof."
-    },
-    {
-      "id": "summary",
-      "title": "Summary",
-      "startLine": 158,
-      "endLine": 171,
-      "summary": "Summary theorem combining Erdős-Straus bounds with e-1 positivity.",
-      "mathContext": "Verified: Summary theorem combining Erdős-Straus bounds with e-1 positivity."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-330/meta.json
+++ b/src/data/proofs/erdos-330/meta.json
@@ -48,22 +48,6 @@
       "endLine": 65,
       "summary": "Minimal bases have infinitely many unrep. integers upon removal; minimal bases with positive density exist (Härtter-Stöhr).",
       "mathContext": "Known hierarchy: (1) minimal basis exists for all $h \\geq 2$ (elementary), (2) minimal basis with $\\bar{d}(A) > 0$ exists (Härtter 1956, Stöhr 1955), (3) minimal basis with quantitative criticality (Problem #330, open). Each level strengthens the notion of how 'essential' individual elements are."
-    },
-    {
-      "id": "open-question",
-      "title": "The Open Question",
-      "startLine": 74,
-      "endLine": 84,
-      "summary": "Does a minimal basis with positive density exist where each element's removal leaves a positive-density set unrepresentable?",
-      "mathContext": "$\\exists A, h : \\text{IsMinimalBasis}(A, h) \\wedge \\bar{d}(A) > 0 \\wedge \\forall n \\in A,\\; \\bar{d}(\\{m : m \\notin h\\text{-sumset}(A \\setminus \\{n\\})\\}) > 0$. Axiomatized since the problem remains open — no construction or impossibility proof is known."
-    },
-    {
-      "id": "implications",
-      "title": "Implications and Context",
-      "startLine": 84,
-      "endLine": 84,
-      "summary": "Connection to Erdős-Nathanson theory, quantitative minimality, and broader additive combinatorics.",
-      "mathContext": "The problem connects to Schnirelmann's theorem (every set with $\\sigma(A) > 0$ is an additive basis), the Erdős-Ginzburg-Ziv theorem, and the broader theory of how density interacts with additive structure in $\\mathbb{N}$."
     }
   ],
   "overview": {

--- a/src/data/proofs/erdos-339/meta.json
+++ b/src/data/proofs/erdos-339/meta.json
@@ -152,14 +152,6 @@
       "summary": "Sidon sets, B_h sets",
       "startLine": 202,
       "endLine": 215
-    },
-    {
-      "id": "summary",
-      "title": "Summary",
-      "summary": "erdos_339_solved, erdos_339_summary",
-      "startLine": 218,
-      "endLine": 231,
-      "mathContext": "Mathematical content: erdos_339_solved, erdos_339_summary"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-349/meta.json
+++ b/src/data/proofs/erdos-349/meta.json
@@ -147,14 +147,6 @@
       "endLine": 83,
       "summary": "Notes the link to Waring's problem: the Ideal Waring formula $g(k) = 2^k + \\lfloor (3/2)^k \\rfloor - 2$ depends on the same exponential floor values that appear in Problem #349.",
       "mathContext": "$g(k) = 2^k + \\lfloor (3/2)^k \\rfloor - 2$ when $\\{(3/2)^k\\} \\leq 1 - (3/4)^k$. This condition holds for all verified $k \\leq 471{,}600{,}000$ (Kubina-Wunderlich). If it fails for some $k$, then $g(k) = 2^k + \\lfloor (3/2)^k \\rfloor - 1$."
-    },
-    {
-      "id": "fibonacci-observation",
-      "title": "Fibonacci Threshold Explanation",
-      "startLine": 85,
-      "endLine": 88,
-      "summary": "Explains why $\\varphi$ is the natural boundary: for $\\alpha > \\varphi$, eventually $a_{n+1} > 2a_n$, creating gaps too large for completeness. The Fibonacci sequence ($\\alpha = \\varphi$) is the extremal complete case.",
-      "mathContext": "For $\\alpha > \\varphi$: $a_{n+1}/a_n \\to \\alpha > \\varphi > 1 + 1/\\varphi$, so eventually $a_{n+1} > a_n(1 + 1/\\varphi) > a_n + a_{n-1} + \\cdots + a_0$. This makes it impossible to represent $a_{n+1} - 1$ as a sum of distinct earlier terms. The Fibonacci recurrence $F_{n+2} = F_{n+1} + F_n$ is exactly at the boundary where this gap condition is avoided."
     }
   ],
   "overview": {

--- a/src/data/proofs/erdos-386/meta.json
+++ b/src/data/proofs/erdos-386/meta.json
@@ -93,14 +93,6 @@
       "endLine": 139,
       "summary": "For k = 2, C(n,2) = n(n-1)/2 must be a primorial quotient. Known example: C(21,2) = 210.",
       "mathContext": "For $k=2$: $\\binom{n}{2} = n(n-1)/2 = \\text{cpp}(a,b)$. This asks when a triangular number $T_n = n(n-1)/2$ equals a primorial quotient. Known: $T_{21} = 210 = 2 \\cdot 3 \\cdot 5 \\cdot 7$."
-    },
-    {
-      "id": "erdos-graham-connection",
-      "title": "Connection to Erdős–Graham (1980)",
-      "startLine": 142,
-      "endLine": 158,
-      "summary": "Context from the 1980 monograph, largest prime factor bound, and connections to Problems 384, 385, 387.",
-      "mathContext": "Axiom `choose_largest_prime_le`: $p \\mid \\binom{n}{k} \\Rightarrow p \\le n$ (from $\\binom{n}{k} = n!/(k!(n-k)!)$). Context: Problems 384 (largest prime $> n/2$ by Sylvester-Schur), 385 (smooth numbers in products of consecutive integers), 387 (divisors in $(cn, n]$). All from Erdős-Graham (1980), p. 74."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-393/meta.json
+++ b/src/data/proofs/erdos-393/meta.json
@@ -140,14 +140,6 @@
       "startLine": 167,
       "endLine": 177,
       "mathContext": "Verified: Density zero and sparse values theorems"
-    },
-    {
-      "id": "summary",
-      "title": "Summary",
-      "summary": "Complete status of Problem #393",
-      "startLine": 180,
-      "endLine": 194,
-      "mathContext": "Mathematical content: Complete status of Problem #393"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-396/meta.json
+++ b/src/data/proofs/erdos-396/meta.json
@@ -84,13 +84,6 @@
       "startLine": 70,
       "endLine": 78,
       "summary": "Axiomatizes a smallest-witness function with validity, referencing OEIS A375077."
-    },
-    {
-      "id": "strengthening",
-      "title": "Infinitely Many Witnesses",
-      "startLine": 81,
-      "endLine": 83,
-      "summary": "States the natural strengthening: for each $k$, infinitely many $n$ satisfy the full descending factorial divisibility."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-416/meta.json
+++ b/src/data/proofs/erdos-416/meta.json
@@ -84,13 +84,6 @@
       "startLine": 119,
       "endLine": 148,
       "summary": "Part (i): $V(2x)/V(x) \\to 2$? Part (ii): $\\exists\\, f,\\; V(x)/f(x) \\to 1$? Both remain OPEN. Formalized as `Prop` definitions using `Tendsto`."
-    },
-    {
-      "id": "related-results",
-      "title": "Related Results",
-      "startLine": 150,
-      "endLine": 158,
-      "summary": "Proves 3 is not a totient value ($\\nexists\\, m,\\; \\varphi(m) = 3$) since $\\varphi(m)$ is even for $m > 2$."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-422/meta.json
+++ b/src/data/proofs/erdos-422/meta.json
@@ -106,13 +106,6 @@
       "startLine": 77,
       "endLine": 93,
       "summary": "Axiomatizes four open questions: `erdos_422_well_defined` ($\\forall n, \\text{IsWellDefined}(n)$), `erdos_422_misses_infinitely` ($\\{m > 0 : \\forall n, f(n) \\neq m\\}$ is infinite via `Set.Infinite`), `erdos_422_not_surjective` ($f$ restricted to $\\mathbb{N}^+$ is not surjective via $\\neg$`Function.Surjective`), and `erdos_422_growth` ($f(n) \\leq (1+\\varepsilon)n$ for large $n$)."
-    },
-    {
-      "id": "observations",
-      "title": "Observations",
-      "startLine": 97,
-      "endLine": 106,
-      "summary": "Comments (not formal declarations) on three aspects: Hofstadter's origin and communication to Erdős, the fundamental difficulty posed by self-referential indexing that defeats standard inductive techniques, and the open question of whether $f$ is eventually constant."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-466/meta.json
+++ b/src/data/proofs/erdos-466/meta.json
@@ -77,14 +77,6 @@
       "endLine": 79,
       "summary": "**sarkozy_polynomial_bound**: For small δ > 0 and large X, N(X, δ) > X^{1/2 − δ^{1/7}}. An exponential leap from Graham's logarithmic bound to nearly √X points, using analytic number theory. The nested quantifier structure ∃ δ₀, ∀ δ < δ₀, ∀ᶠ X captures the statement precisely.",
       "mathContext": "Sárközy (1978): for small $\\delta > 0$ and large $X$, $N(X, \\delta) > X^{1/3}$. A polynomial bound via Weyl sum estimates."
-    },
-    {
-      "id": "structural",
-      "title": "Structural Properties",
-      "startLine": 81,
-      "endLine": 95,
-      "summary": "**fracDist_bound**: ‖x‖ ≤ 1/2 always (so δ > 1/2 is trivially impossible). **maxSeparatedPoints_mono**: N non-decreasing in X (larger disks accommodate more points). **maxSeparatedPoints_anti**: N non-increasing in δ (stricter separation reduces count). These establish the monotone structure of the extremal function.",
-      "mathContext": "$\\|x\\| \\leq 1/2$ always, so $\\delta > 1/2$ forces $N(X, \\delta) = 1$ trivially. The interesting regime is $0 < \\delta \\ll 1$."
     }
   ],
   "overview": {

--- a/src/data/proofs/erdos-49/meta.json
+++ b/src/data/proofs/erdos-49/meta.json
@@ -98,14 +98,6 @@
       "endLine": 73,
       "summary": "The weaker result: $\\text{maxIncTotientSize}(N) = o(N)$. Follows from Tao's bound and the PNT ($\\pi(N) \\sim N/\\ln N = o(N)$).",
       "mathContext": "The weaker result: $\\text{maxIncTotientSize}(N) = o(N)$. Follows from Tao's bound and the PNT ($\\$\\pi$(N) \\sim N/\\ln N = o(N)$)."
-    },
-    {
-      "id": "totient-properties",
-      "title": "Basic Totient Properties",
-      "startLine": 80,
-      "endLine": 87,
-      "summary": "States $\\varphi(p) = p - 1$ for primes and $\\varphi(n) \\leq n$ for all $n$. These are fundamental properties used throughout the formalization.",
-      "mathContext": "Mathematical content: States $\\varphi(p) = p - 1$ for primes and $\\varphi(n) \\leq n$ for all $n$. These are fundamental properties used throughout the formalization."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-498/meta.json
+++ b/src/data/proofs/erdos-498/meta.json
@@ -66,13 +66,6 @@
       "startLine": 69,
       "endLine": 70,
       "summary": "Axiom `erdos_complex_weak`: before Kleitman, Erdős showed the count is $O(2^n / \\sqrt{n})$, weaker than the sharp $\\binom{n}{\\lfloor n/2 \\rfloor} \\sim 2^n / \\sqrt{\\pi n/2}$ by a constant."
-    },
-    {
-      "id": "generalizations",
-      "title": "Generalizations and Connections",
-      "startLine": 77,
-      "endLine": 89,
-      "summary": "Comments recording Kleitman's 1970 Hilbert space generalization, the connection to Sperner's theorem ($\\binom{n}{\\lfloor n/2 \\rfloor}$ = max antichain in $2^{[n]}$), and the related Erdős Problem #395."
     }
   ],
   "overview": {

--- a/src/data/proofs/erdos-502/meta.json
+++ b/src/data/proofs/erdos-502/meta.json
@@ -80,14 +80,6 @@
       "endLine": 82,
       "summary": "Exact values: $f(2) = 5$ (vertices of a regular pentagon) and $f(3) = 6$. These match the lower bound $\\binom{3}{2} = 3$ and $\\binom{4}{2} = 6$ respectively, with the planar case being exceptional.",
       "mathContext": "Bound: Exact values: $f(2) = 5$ (vertices of a regular pentagon) and $f(3) = 6$. These match the lower bound $\\binom{3}{2} = 3$ and $\\binom{4}{2} = 6$ respectively, with the planar case being exceptional."
-    },
-    {
-      "id": "coxeter-question",
-      "title": "Coxeter's Original Question and Historical Context",
-      "startLine": 85,
-      "endLine": 97,
-      "summary": "Coxeter's question — is $f(n)$ polynomial? — answered affirmatively by BBS. Erdős's original weaker bound $f(n) \\leq n!$ (exponential) is stated as a historical record of the pre-BBS state of knowledge.",
-      "mathContext": "Coxeter's question — is $f(n)$ polynomial? Erdős's original weaker bound $f(n) \\leq n!$ (exponential) is stated as a historical record of the pre-BBS state of knowledge."
     }
   ],
   "overview": {

--- a/src/data/proofs/erdos-506/meta.json
+++ b/src/data/proofs/erdos-506/meta.json
@@ -98,14 +98,6 @@
       "endLine": 97,
       "summary": "Axiom: existence of a lower bound function f(n) for 4 ≤ n ≤ 393, the unresolved range.",
       "mathContext": "Axiom: existence of a lower bound function f(n) for 4 $\\leq$ n $\\leq$ 393, the unresolved range."
-    },
-    {
-      "id": "sylvester-gallai",
-      "title": "Sylvester-Gallai Analogy",
-      "startLine": 107,
-      "endLine": 115,
-      "summary": "Axiom: n non-collinear points with n ≥ 3 determine at least n circles, analogous to the Sylvester-Gallai theorem for lines.",
-      "mathContext": "Axiom: n non-collinear points with n $\\geq$ 3 determine at least n circles, analogous to the Sylvester-Gallai theorem for lines."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-507/meta.json
+++ b/src/data/proofs/erdos-507/meta.json
@@ -135,22 +135,6 @@
       "endLine": 83,
       "summary": "Axiomatizes the Cohen–Pohoata–Zakharov breakthrough: $\\alpha(n) \\leq C/n^{7/6+o(1)}$, improving the KPS exponent via incidence geometry and the polynomial partitioning method.",
       "mathContext": "Axiomatizes the Cohen–Pohoata–Zakharov breakthrough: $\\$\\alpha$(n) \\leq C/n^{7/6+o(1)}$, improving the KPS exponent via incidence geometry and the polynomial partitioning method."
-    },
-    {
-      "id": "exponent-range",
-      "title": "Exponent Range $7/6 \\leq \\beta \\leq 2$",
-      "startLine": 87,
-      "endLine": 96,
-      "summary": "States that the true exponent $\\beta$ in $\\alpha(n) = n^{-\\beta+o(1)}$ satisfies $7/6 \\leq \\beta \\leq 2$, combining the CPZ upper bound and KPS lower bound.",
-      "mathContext": "States that the true exponent $\\$\\beta$$ in $\\$\\alpha$(n) = n^{-\\$\\beta$+o(1)}$ satisfies $7/6 \\leq \\$\\beta$ \\leq 2$, combining the CPZ upper bound and KPS lower bound."
-    },
-    {
-      "id": "higher-dim",
-      "title": "Higher-Dimensional Analog",
-      "startLine": 97,
-      "endLine": 103,
-      "summary": "Axiomatizes the $d$-dimensional generalization: $c/n^d \\leq \\alpha_d(n) \\leq C/n$ for the minimum-volume simplex among $n$ points in the unit ball $B^d$.",
-      "mathContext": "Axiomatized: Axiomatizes the $d$-dimensional generalization: $c/n^d \\leq \\alpha_d(n) \\leq C/n$ for the minimum-volume simplex among $n$ points in the unit ball $B^d$."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-510/meta.json
+++ b/src/data/proofs/erdos-510/meta.json
@@ -71,13 +71,6 @@
       "startLine": 59,
       "endLine": 64,
       "summary": "Axiom **sidon_optimality**: For any ε > 0, ∃ A with min cosine sum > −(1+ε)√|A|. Proved via Sidon difference sets A = B−B, showing √N is the exact threshold."
-    },
-    {
-      "id": "observations",
-      "title": "Observations",
-      "startLine": 68,
-      "endLine": 79,
-      "summary": "Comments on the additive combinatorics connection (additive energy, Wiener-Khintchine), Green's Problem 81, and the 2025 polynomial progress by Bedert and Jin-Milojević-Tomon-Zhang."
     }
   ],
   "overview": {

--- a/src/data/proofs/erdos-54/meta.json
+++ b/src/data/proofs/erdos-54/meta.json
@@ -119,14 +119,6 @@
       "endLine": 78,
       "summary": "**ErdosProblem54**: conjunction of both bounds, capturing $\\Theta((\\log N)^2)$ as the minimum growth rate. Solved by Conlon–Fox–Pham (2021).",
       "mathContext": "$\\Theta((\\log N)^2)$: $\\exists c_1, c_2 > 0$ such that the minimum counting function of a Ramsey 2-complete set satisfies $c_1 (\\log N)^2 \\le f(N) \\le c_2 (\\log N)^2$."
-    },
-    {
-      "id": "earlier-upper",
-      "title": "Earlier Upper Bound",
-      "startLine": 81,
-      "endLine": 94,
-      "summary": "**burr_erdos_upper**: $\\exists A$ Ramsey 2-complete with $|A \\cap [1,N]| < (2\\log_2 N)^3$. Original cubic bound, superseded by quadratic.",
-      "mathContext": "$|A \\cap [1,N]| \\le (2 \\log_2 N)^3$ (Burr-Erdős, 1985). Original cubic upper bound, improved to quadratic by Conlon-Fox-Pham."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-543/meta.json
+++ b/src/data/proofs/erdos-543/meta.json
@@ -143,14 +143,6 @@
       "startLine": 164,
       "endLine": 173,
       "mathContext": "Mathematical content: cyclic_spanning_characterization, prime_full_spanning"
-    },
-    {
-      "id": "summary",
-      "title": "Summary",
-      "summary": "erdos_543_summary: ErdosCounterConjecture ∧ ¬LittleOConjecture",
-      "startLine": 176,
-      "endLine": 192,
-      "mathContext": "Mathematical content: erdos_543_summary: ErdosCounterConjecture ∧ ¬LittleOConjecture"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-547/meta.json
+++ b/src/data/proofs/erdos-547/meta.json
@@ -111,46 +111,6 @@
       "startLine": 105,
       "endLine": 132,
       "mathContext": "IsPath (Δ $\\leq$ 2), IsStar (one center), IsCaterpillar (path after leaf removal); inclusion proofs and degree axioms."
-    },
-    {
-      "id": "specific-ramsey",
-      "title": "Exact Ramsey Numbers: Paths and Stars",
-      "summary": "R(P_n) = n (paths, minimum among trees) and R(S_n) = 2n - 2 (stars, maximum among trees).",
-      "startLine": 138,
-      "endLine": 138,
-      "mathContext": "Mathematical content: R(P_n) = n (paths, minimum among trees) and R(S_n) = 2n - 2 (stars, maximum among trees)."
-    },
-    {
-      "id": "chvatal",
-      "title": "Chvátal's Theorem (1977)",
-      "summary": "R(T) ≤ (Δ-1)(n-1) + 1; tight for paths (chvatal_tight_for_paths). Analysis: weak for high-degree trees.",
-      "startLine": 138,
-      "endLine": 138,
-      "mathContext": "R(T) $\\leq$ (Δ-1)(n-1) + 1; tight for paths (chvatal_tight_for_paths). Analysis: weak for high-degree trees."
-    },
-    {
-      "id": "main-conjecture",
-      "title": "Erdős-Burr Conjecture: R(T) ≤ 2n - 2",
-      "summary": "Universal bound tree_ramsey_bound; tightness via bound_achieved_by_stars; proved for large n by regularity method.",
-      "startLine": 138,
-      "endLine": 138,
-      "mathContext": "Bound: Universal bound tree_ramsey_bound; tightness via bound_achieved_by_stars; proved for large n by regularity method."
-    },
-    {
-      "id": "comparison",
-      "title": "Bound Comparison: Chvátal vs 2n-2",
-      "summary": "chvatal_vs_main: Chvátal beats 2n-2 iff Δ ∈ {1, 2}, so only for paths.",
-      "startLine": 138,
-      "endLine": 138,
-      "mathContext": "Mathematical content: chvatal_vs_main: Chvátal beats 2n-2 iff Δ ∈ {1, 2}, so only for paths."
-    },
-    {
-      "id": "main-results",
-      "title": "Main Results: erdos_547 and Ordering",
-      "summary": "erdos_547 theorem, tightness (erdos_547_tight), and tree_ramsey_ordering: n ≤ R(T) ≤ 2n - 2.",
-      "startLine": 138,
-      "endLine": 138,
-      "mathContext": "erdos_547 theorem, tightness (erdos_547_tight), and tree_ramsey_ordering: n $\\leq$ R(T) $\\leq$ 2n - 2."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-562/meta.json
+++ b/src/data/proofs/erdos-562/meta.json
@@ -80,22 +80,6 @@
       "startLine": 82,
       "endLine": 85,
       "mathContext": "$R_r(n) \\geq \\mathrm{twr}_{r-1}(cn)$: tower height is exactly $r-1$, with gap in argument ($n$ vs $$n^{2}$$)"
-    },
-    {
-      "id": "main-conjecture",
-      "title": "The Tower Growth Conjecture",
-      "summary": "Erdős-Hajnal-Rado (1965): $R_r(n) = \\mathrm{twr}_{r-1}(\\Theta(n))$ — the iterated logarithm is linear in $n$",
-      "startLine": 88,
-      "endLine": 98,
-      "mathContext": "Mathematical content: Erdős-Hajnal-Rado (1965): $R_r(n) = \\mathrm{twr}_{r-1}(\\Theta(n))$ — the iterated logarithm is linear in $n$"
-    },
-    {
-      "id": "small-cases",
-      "title": "Small Cases",
-      "summary": "Exact value $R_3(4) = 13$, one of very few known hypergraph Ramsey numbers",
-      "startLine": 100,
-      "endLine": 103,
-      "mathContext": "Mathematical content: Exact value $R_3(4) = 13$, one of very few known hypergraph Ramsey numbers"
     }
   ],
   "overview": {

--- a/src/data/proofs/erdos-564/meta.json
+++ b/src/data/proofs/erdos-564/meta.json
@@ -139,14 +139,6 @@
       "endLine": 207,
       "summary": "Evidence from the 4-colour doubly exponential result",
       "mathContext": "Mathematical content: Evidence from the 4-colour doubly exponential result"
-    },
-    {
-      "id": "gap",
-      "title": "Why the Problem is Hard",
-      "startLine": 214,
-      "endLine": 227,
-      "summary": "Illustration of the enormous gap between known bounds",
-      "mathContext": "Bound: Illustration of the enormous gap between known bounds"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-567/meta.json
+++ b/src/data/proofs/erdos-567/meta.json
@@ -87,14 +87,6 @@
       "endLine": 89,
       "summary": "States the three axioms: $Q_3$, $K_{3,3}$, and $H_5$ are Ramsey size linear. Each is open — axiom form reflects the conjectural status.",
       "mathContext": "Axiomatized: States the three axioms: $Q_3$, $K_{3,3}$, and $H_5$ are Ramsey size linear. Each is open — axiom form reflects the conjectural status."
-    },
-    {
-      "id": "partial-results",
-      "title": "Partial Results",
-      "startLine": 91,
-      "endLine": 103,
-      "summary": "Records Bradač–Gishboliner–Sudakov ($K_4$-subdivisions with $\\ge 6$ vertices are linear) and EFRS ($\\le n+1$ edges implies linearity). Both fall short of resolving the three specific cases.",
-      "mathContext": "Mathematical content: Records Bradač–Gishboliner–Sudakov ($K_4$-subdivisions with $\\ge 6$ vertices are linear) and EFRS ($\\le n+1$ edges implies linearity). Both fall short of resolving the three specific cases."
     }
   ],
   "overview": {

--- a/src/data/proofs/erdos-574/meta.json
+++ b/src/data/proofs/erdos-574/meta.json
@@ -52,13 +52,6 @@
       "startLine": 63,
       "endLine": 78,
       "summary": "Axiomatized known results: the even cycle Turán number $\\text{ex}(n; C_{2k}) = \\Theta(n^{1+1/k})$, the Bondy–Simonovits upper bound $\\text{ex}(n; C_{2k}) \\le c \\cdot n^{1+1/k}$, and the special case $k=2$ relating to Problem #573."
-    },
-    {
-      "id": "observations",
-      "title": "Observations and Constructions",
-      "startLine": 86,
-      "endLine": 95,
-      "summary": "Commentary on why the conjecture is plausible: forbidding $C_{2k-1}$ should be 'free' because algebraic constructions from finite geometry (incidence graphs of projective planes and generalized polygons) naturally avoid both $C_{2k-1}$ and $C_{2k}$."
     }
   ],
   "overview": {

--- a/src/data/proofs/erdos-585/meta.json
+++ b/src/data/proofs/erdos-585/meta.json
@@ -94,14 +94,6 @@
       "endLine": 80,
       "summary": "States both bounds together as a single axiom capturing the current state of knowledge: Ω(n log log n) ≤ f(n) ≤ O(n(log n)^C).",
       "mathContext": "$\\Omega(n \\log\\log n) \\leq f(n) \\leq O(n (\\log n)^C)$. The gap between these bounds is the central open problem."
-    },
-    {
-      "id": "k-cycles",
-      "title": "k-Cycle Generalization",
-      "startLine": 91,
-      "endLine": 99,
-      "summary": "The CJMM generalization: for any k ≥ 2, graphs exceeding the O(n(log n)^C) threshold must contain k pairwise edge-disjoint cycles on some common vertex set.",
-      "mathContext": "CJMM generalization: $\\forall k \\geq 2$, graphs with $> C_k n (\\log n)^{\\alpha_k}$ edges contain $k$ pairwise edge-disjoint cycles on a common vertex set."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-588/meta.json
+++ b/src/data/proofs/erdos-588/meta.json
@@ -131,13 +131,6 @@
       "summary": "Axiomatizes `lower_bound_k4`: $f_4(n) \\ge n^{2 - c/\\sqrt{\\log n}}$ (Solymosi-Stojaković 2013). Axiomatizes `erdos_conjecture_k4`: the $\\varepsilon$-$N$ formulation of $f_k(n) = o(n^2)$ for $k \\ge 4$.",
       "startLine": 62,
       "endLine": 79
-    },
-    {
-      "id": "main-theorem",
-      "title": "Part IV: Main Theorem",
-      "summary": "`erdos_588` restates `sylvester_k3` as the proved result. The $k \\ge 4$ conjecture remains **OPEN**. Prize: $\\$100$.",
-      "startLine": 91,
-      "endLine": 96
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-593/meta.json
+++ b/src/data/proofs/erdos-593/meta.json
@@ -86,13 +86,6 @@
       "startLine": 99,
       "endLine": 110,
       "summary": "Defines Is2Colorable and axiomatizes that 2-colorable hypergraphs are unavoidable. Identifies K₄³ (chromatic number 3, not 2-colorable) as the key test case."
-    },
-    {
-      "id": "egh-framework",
-      "title": "Erdős–Galvin–Hajnal Framework",
-      "startLine": 118,
-      "endLine": 127,
-      "summary": "Axiomatizes the Erdős–Galvin–Hajnal result: 2-colorable implies unavoidable for 3-uniform hypergraphs, restating the sufficient condition within their general framework."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-655/meta.json
+++ b/src/data/proofs/erdos-655/meta.json
@@ -98,14 +98,6 @@
       "endLine": 122,
       "summary": "Axiomatizes Hunter's result: equally-spaced circle points disprove the original conjecture.",
       "mathContext": "Axiomatized: Axiomatizes Hunter's result: equally-spaced circle points disprove the original conjecture."
-    },
-    {
-      "id": "corrected-conjecture",
-      "title": "Corrected Erdős–Pach Conjecture",
-      "startLine": 124,
-      "endLine": 133,
-      "summary": "States the corrected Problem 655 with NoFourConcyclic: ≥ (1+c)n/2 distinct distances.",
-      "mathContext": "States the corrected Problem 655 with NoFourConcyclic: $\\geq$ (1+c)n/2 distinct distances."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-661/meta.json
+++ b/src/data/proofs/erdos-661/meta.json
@@ -80,14 +80,6 @@
       "endLine": 164,
       "summary": "Formalizes and verifies Lenz's construction in $\\mathbb{R}^4$. Defines $\\text{Point4} = (\\mathbb{R}^2) \\times (\\mathbb{R}^2)$, squared distance $d_4^2$, and two orthogonal unit circles $C_1(\\theta) = (\\cos\\theta, \\sin\\theta, 0, 0)$, $C_2(\\phi) = (0, 0, \\cos\\phi, \\sin\\phi)$. Proves $d_4^2(C_1(\\theta), C_2(\\phi)) = 2$ for all $\\theta, \\phi$ (so all bipartite distances equal $\\sqrt{2}$, giving $F_4(2n) = 1$). Also proves both circles have unit norm. All 3 theorems fully verified (0 sorries).",
       "mathContext": "Verified: Lenz's theorem that two orthogonal unit circles in $\\mathbb{R}^4$ produce constant bipartite distance $\\sqrt{2}$. Proof uses the Pythagorean identity $\\sin^2\\theta + \\cos^2\\theta = 1$."
-    },
-    {
-      "id": "observations",
-      "title": "Part VIII: Observations and Connections",
-      "startLine": 169,
-      "endLine": 178,
-      "summary": "Notes the connection to Erdős Problem #89 (general distinct distances) and the dimension gap: $F_4(2n) = 1$ (verified) vs the conjectured $F_2(2n) = o(n/\\sqrt{\\log n})$ in $\\mathbb{R}^2$.",
-      "mathContext": "Mathematical content: connection to Problem #89, dimension gap between ℝ² and ℝ⁴."
     }
   ],
   "overview": {

--- a/src/data/proofs/erdos-669/meta.json
+++ b/src/data/proofs/erdos-669/meta.json
@@ -117,13 +117,6 @@
       "summary": "optimal_configs_exist",
       "startLine": 123,
       "endLine": 128
-    },
-    {
-      "id": "summary",
-      "title": "Summary",
-      "summary": "erdos_669_summary theorem",
-      "startLine": 132,
-      "endLine": 146
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-704/meta.json
+++ b/src/data/proofs/erdos-704/meta.json
@@ -140,14 +140,6 @@
       "startLine": 140,
       "endLine": 154,
       "mathContext": "Bound: How lower and upper bounds are proved"
-    },
-    {
-      "id": "main-results",
-      "title": "Main Results",
-      "summary": "erdos_704_solved combining both bounds",
-      "startLine": 157,
-      "endLine": 163,
-      "mathContext": "Bound: erdos_704_solved combining both bounds"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-725/meta.json
+++ b/src/data/proofs/erdos-725/meta.json
@@ -176,14 +176,6 @@
       "startLine": 138,
       "endLine": 150,
       "mathContext": "Defines `GeneralAsymptotic`: existence of $f(k,n)$ with $L(k,n)/f(k,n) \\to 1$ for all $k \\leq n$. Defines `ExtendedConjecture`: the Erdős-Kaplansky formula holds when $k/n \\to c \\in (0,1)$. Both remain **OPEN** beyond $k = o(n^{6/7})$."
-    },
-    {
-      "id": "main-results",
-      "title": "Main Results Summary",
-      "summary": "Theorem `erdos_725_summary` combines $L(1,n) = n!$ and Godsil-McKay bounds into a single result, proved by exact term `⟨L_1_n, godsil_mckay_bounds⟩`. Demonstrates that the formalization captures both exact values and asymptotic bounds.",
-      "startLine": 156,
-      "endLine": 169,
-      "mathContext": "Theorem `erdos_725_summary` combines $L(1,n) = n!$ and Godsil-McKay bounds into a single result, proved by exact term `⟨L_1_n, godsil_mckay_bounds⟩`."
     }
   ],
   "crossReferences": [

--- a/src/data/proofs/erdos-728/meta.json
+++ b/src/data/proofs/erdos-728/meta.json
@@ -136,14 +136,6 @@
       "startLine": 227,
       "endLine": 246,
       "mathContext": "Mathematical content: Connection to Problem #729"
-    },
-    {
-      "id": "summary",
-      "title": "Summary",
-      "summary": "erdos_728_summary theorem",
-      "startLine": 252,
-      "endLine": 258,
-      "mathContext": "Verified: erdos_728_summary theorem"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-812/meta.json
+++ b/src/data/proofs/erdos-812/meta.json
@@ -151,14 +151,6 @@
       "endLine": 145,
       "summary": "Six `norm_num` proofs: $R(3)/R(2) = 3$, $R(4)/R(3) = 3$, differences $4$ and $12$, BEFS values $0$, $4$, $8$.",
       "mathContext": "Verified: Six `norm_num` proofs: $R(3)/R(2) = 3$, $R(4)/R(3) = 3$, differences $4$ and $12$, BEFS values $0$, $4$, $8$."
-    },
-    {
-      "id": "summary",
-      "title": "Summary Theorem (Proved)",
-      "startLine": 165,
-      "endLine": 173,
-      "summary": "`erdos_812_summary` packages BEFS + Problem #165 bounds as a conjunction. **Verified proof** by `exact ⟨BEFS_theorem, problem_165_bound⟩`.",
-      "mathContext": "Verified: `erdos_812_summary` packages BEFS + Problem #165 bounds as a conjunction. **Verified proof** by `exact ⟨BEFS_theorem, problem_165_bound⟩`."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-839/meta.json
+++ b/src/data/proofs/erdos-839/meta.json
@@ -121,13 +121,6 @@
       "startLine": 152,
       "endLine": 255,
       "summary": "Key axiom elimination: `liminf_finite` proved from `freud_density` via counting argument. Positive upper density forces a(n)/(n+1) < 4 infinitely often. Includes helper lemmas: `countRatio_isCoboundedUnder` (Filter coboundedness), `frequently_lt_of_lt_limsup` (contrapositive extraction), and `term_le_of_count_gt` (counting function bounds terms by contradiction on monotonicity)."
-    },
-    {
-      "id": "main-questions",
-      "title": "Main Open Questions",
-      "startLine": 258,
-      "endLine": 265,
-      "summary": "Both questions axiomatized as open: `erdos_839_question1` ($\\limsup$ growth) and `erdos_839_question2` (vanishing logarithmic density). These reflect the OPEN status of Problem #839."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-855/meta.json
+++ b/src/data/proofs/erdos-855/meta.json
@@ -117,13 +117,6 @@
       "summary": "StrausConjecture, ErdosWeakerConjecture definitions",
       "startLine": 155,
       "endLine": 172
-    },
-    {
-      "id": "main-results",
-      "title": "Main Results",
-      "summary": "erdos_855 summary theorem",
-      "startLine": 182,
-      "endLine": 186
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-886/meta.json
+++ b/src/data/proofs/erdos-886/meta.json
@@ -160,14 +160,6 @@
       "startLine": 153,
       "endLine": 154,
       "mathContext": "Bound: trivial_bound (proved), divisor_count_bound"
-    },
-    {
-      "id": "summary",
-      "title": "Summary",
-      "summary": "erdos_886_summary theorem combining trivial_bound and Erdős-Rosenfeld",
-      "startLine": 167,
-      "endLine": 170,
-      "mathContext": "Verified: erdos_886_summary theorem combining trivial_bound and Erdős-Rosenfeld"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-942/meta.json
+++ b/src/data/proofs/erdos-942/meta.json
@@ -142,46 +142,6 @@
       "endLine": 144,
       "summary": "HasDensity, delta, density_sum_one, density_h_eq_1 axioms.",
       "mathContext": "Density of {n : h(n) = k} exists for each k, and sum delta_k = 1."
-    },
-    {
-      "id": "dekoninck-luca",
-      "title": "De Koninck-Luca Lower Bound (2004)",
-      "startLine": 150,
-      "endLine": 150,
-      "summary": "The (log n / log log n)^{1/3} lower bound infinitely often.",
-      "mathContext": "De Koninck-Luca: h(n) >= c(log n / log log n)^{1/3} infinitely often."
-    },
-    {
-      "id": "properties",
-      "title": "Properties of Powerful Numbers",
-      "startLine": 150,
-      "endLine": 150,
-      "summary": "Closure under multiplication, squares and cubes are powerful.",
-      "mathContext": "Powerful numbers closed under multiplication. Every square and cube is powerful."
-    },
-    {
-      "id": "interval",
-      "title": "The Square Interval",
-      "startLine": 150,
-      "endLine": 150,
-      "summary": "Properties of [n², (n+1)²): length 2n+1, endpoint membership.",
-      "mathContext": "Interval [n^2, (n+1)^2) has length 2n+1. Contains n^2 (always powerful)."
-    },
-    {
-      "id": "small-examples",
-      "title": "Small Examples",
-      "startLine": 150,
-      "endLine": 150,
-      "summary": "Computed values: h(1)=1, h(2)=2, h(3)=1.",
-      "mathContext": "h(1)=1, h(2)=2, h(3)=1."
-    },
-    {
-      "id": "summary",
-      "title": "Summary",
-      "startLine": 150,
-      "endLine": 150,
-      "summary": "Problem summary and erdos_942_status theorem.",
-      "mathContext": "OPEN. Known: h(n) unbounded, h(n) >= c(log n/log log n)^{1/3} i.o."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-947/meta.json
+++ b/src/data/proofs/erdos-947/meta.json
@@ -116,13 +116,6 @@
       "startLine": 157,
       "endLine": 183,
       "summary": "Axiomatizes `covering_systems_exist` (ordinary coverings with distinct moduli $> 1$ exist) and `erdos_covering_example` (specific system with moduli $\\{2, 3, 4, 6, 12\\}$). *Verifies* `exactCoveringWithRepeats`: the construction $\\{0 \\pmod{2}, 1 \\pmod{2}\\}$ with proved nonemptiness, positive moduli, and coverage via case split on $x \\bmod 2$."
-    },
-    {
-      "id": "summary",
-      "title": "Summary",
-      "startLine": 195,
-      "endLine": 208,
-      "summary": "*Proves* `erdos_947_summary`: the conjunction of (1) no exact covering with distinct moduli and (2) existence of ordinary coverings with distinct moduli. Proof extracts components from axiomatized results."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-953/meta.json
+++ b/src/data/proofs/erdos-953/meta.json
@@ -153,14 +153,6 @@
       "startLine": 257,
       "endLine": 291,
       "mathContext": "Axiomatizes the conjectured asymptotic $C_1 r^{\\alpha} \\leq M(r) \\leq C_2 r^{\\alpha}$ for some $\\alpha \\in (0,1]$ and the existence of a limiting function $f(r)$ with $M(r) = f(r)$ satisfying $f(r) / r^{\\alpha} \\to 1$."
-    },
-    {
-      "id": "summary-theorem",
-      "title": "Summary Theorem",
-      "summary": "The `erdos_953_summary` theorem combines the upper bound axiom and lower bound axiom into one statement, proved by pairing `trivial_upper_bound` and `kovac_lower_bound`. Confirms the state of knowledge on Problem #953.",
-      "startLine": 292,
-      "endLine": 306,
-      "mathContext": "The `erdos_953_summary` theorem combines the upper bound axiom and lower bound axiom into one statement, proved by pairing `trivial_upper_bound` and `kovac_lower_bound`. Confirms the state of knowledge on Problem #953."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-999/meta.json
+++ b/src/data/proofs/erdos-999/meta.json
@@ -143,14 +143,6 @@
       "endLine": 147,
       "summary": "The 1924 result for monotone functions and the limsup set.",
       "mathContext": "Mathematical content: The 1924 result for monotone functions and the limsup set."
-    },
-    {
-      "id": "summary",
-      "title": "Summary",
-      "startLine": 150,
-      "endLine": 166,
-      "summary": "Proved conjunction of main results.",
-      "mathContext": "Mathematical content: Proved conjunction of main results."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/shannon-source-coding/meta.json
+++ b/src/data/proofs/shannon-source-coding/meta.json
@@ -108,14 +108,6 @@
       "endLine": 32,
       "summary": "Rates above entropy are achievable: encode typical sequences with $n(H+\\varepsilon)$ bits. Placeholder.",
       "mathContext": "For $R > H(X)$: $P_e^{(n)} \\to 0$ as $n \\to \\infty$ by typical set coding."
-    },
-    {
-      "id": "converse",
-      "title": "Source Coding Converse",
-      "startLine": 36,
-      "endLine": 44,
-      "summary": "Rates below entropy are impossible: error probability bounded away from 0. Placeholder.",
-      "mathContext": "For $R < H(X)$: $P_e \\geq 1 - 2^{n(R-H+\\varepsilon)} \\to 1$."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Fix

Removes 66 sections from 54 gallery proof meta.json files where the section's \`startLine\` exceeds the actual line count of the Lean source file.

These phantom sections are artifacts from earlier enrichment passes that appended section metadata without verifying file boundaries. Each removed section references lines that do not exist in the corresponding Lean file.

## Evidence

**Before**: Sections with \`startLine\` beyond \`lineCount\` — e.g., \`erdos-564\` has 207 lines but a section starting at line 214.
**After**: All sections reference valid line ranges within the actual file.

54 proofs affected, 66 phantom sections removed. All were wholly beyond the file end (startLine > lineCount), so removal is correct.

Examples of removed phantom sections:
- \`erdos-942\`: 5 sections all starting at line 150 (file has 144 lines)
- \`erdos-547\`: 5 sections all starting at line 138 (file has 132 lines)
- \`erdos-507\`: 2 sections starting at lines 87 and 97 (file has 83 lines)

---
Automated fix by lean-mechanic agent.