### PR TITLE
feat(aristotle): Erdős #671 Lagrange interpolation companion file

### DIFF
--- a/proofs/Proofs/Erdos671ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos671ProblemAristotle.lean
@@ -1,0 +1,78 @@
+/-
+  Aristotle targets for Erdős Problem #671: Lagrange Interpolation Convergence
+  Routine supporting lemmas for automated proof search.
+  See Erdos671Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open questions (Question1, Question2, MainConjecture)
+  - NOT the deep analysis results (Bernstein 1931, Erdős-Vértesi 1980, Faber)
+  - NOT the convergence/divergence theorems (equidistant_diverges, lebesgueConstant_growth)
+  - Routine polynomial evaluation lemmas (basis at nodes)
+  - Logical implication between question formulations
+  - No axioms, no definition sorries, no open conjectures
+  - No /- ! docstring sections (use /- instead)
+-/
+import Proofs.Erdos671Problem
+import Mathlib
+
+namespace Erdos671Aristotle
+
+open Erdos671 Polynomial Finset
+
+/-
+## Section 1: Lagrange Basis Evaluation at Nodes
+
+The Lagrange basis polynomial p_i^n, when evaluated at an interpolation
+node, satisfies the cardinal property: p_i(a_i) = 1 and p_i(a_j) = 0 for j ≠ i.
+-/
+
+/-- The Lagrange basis polynomial evaluates to 0 at any node other than its own.
+The key: when j ≠ i, the j-th factor (X - a_j) vanishes at x = a_j, making the product 0. -/
+theorem lagrangeBasis_other_ari {n : ℕ} (pts : InterpolationPoints n)
+    (i j : Fin n) (hij : i ≠ j) :
+    (lagrangeBasis pts i).eval (pts.points j) = 0 := by
+  sorry
+
+/-- The Lagrange basis polynomial evaluates to 1 at its own node.
+Each factor C(1/(a_i - a_k)) * (a_i - a_k) = 1 by distinctness, so the product is 1. -/
+theorem lagrangeBasis_self_ari {n : ℕ} (pts : InterpolationPoints n) (i : Fin n) :
+    (lagrangeBasis pts i).eval (pts.points i) = 1 := by
+  sorry
+
+/-
+## Section 2: Interpolation at Nodes
+
+The Lagrange interpolant L^n f recovers the function values exactly at the nodes.
+-/
+
+/-- The Lagrange interpolant equals f at each node: L^n f(a_i) = f(a_i).
+Follows from the cardinal property: the basis sum collapses to a single term. -/
+theorem lagrangeInterp_at_node_ari {n : ℕ} (pts : InterpolationPoints n)
+    (f : ℝ → ℝ) (i : Fin n) :
+    lagrangeInterp pts f (pts.points i) = f (pts.points i) := by
+  sorry
+
+/-
+## Section 3: Lebesgue Function at Nodes
+
+The Lebesgue function λ_n(x) = Σ|p_i(x)| equals 1 at interpolation nodes.
+-/
+
+/-- The Lebesgue function equals 1 at each interpolation node.
+At a_i: |p_i(a_i)| = 1 and |p_k(a_i)| = 0 for k ≠ i, so the sum is 1. -/
+theorem lebesgueFunction_at_node_ari {n : ℕ} (pts : InterpolationPoints n) (i : Fin n) :
+    lebesgueFunction pts (pts.points i) = 1 := by
+  sorry
+
+/-
+## Section 4: Logical Implications Between Questions
+
+The two open questions are related: Question 2 is a stronger requirement than Question 1.
+-/
+
+/-- Question 2 implies Question 1: a point sequence with λ_n(x) → ∞ for ALL x
+(and some convergence for each f) is also a witness for Question 1's weaker requirement. -/
+theorem q2_implies_q1_ari : Question2 → Question1 := by
+  sorry
+
+end Erdos671Aristotle


### PR DESCRIPTION
## Fix

Adds an Aristotle companion file for Erdős Problem #671 (Lagrange interpolation convergence), exposing 5 routine supporting lemmas for automated proof search.

## Aristotle Targets

| Theorem | Description | Approach |
|---------|-------------|----------|
| `lagrangeBasis_other_ari` | Basis = 0 at wrong node | Product contains zero factor at j-th term |
| `lagrangeBasis_self_ari` | Basis = 1 at own node | Each factor `(a_i - a_k)/(a_i - a_k) = 1` by distinctness |
| `lagrangeInterp_at_node_ari` | Interpolant = f at nodes | Sum collapses via basis cardinal property |
| `lebesgueFunction_at_node_ari` | Lebesgue fn = 1 at nodes | Follows from basis self/other |
| `q2_implies_q1_ari` | Q2 → Q1 | Existential witness from Q2 serves Q1 |

## Excluded (not Aristotle targets)

- `bernstein`, `erdos_vertesi`, `faber`: Deep 20th-century analysis theorems
- `lebesgueConstant_growth`, `equidistant_diverges`: Quantitative bounds requiring non-trivial analysis
- `question1_open`, `question2_open`: Open conjectures (axioms)

## Pre-Submission Checklist

- [x] No `def ... := sorry` (definition sorries)
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections
- [x] No open conjectures

---
Automated fix by lean-mechanic agent.