### PR TITLE
Enrich subset-count-multiset-oq-01: add annotations, expand history

### DIFF
--- a/src/data/proofs/subset-count-multiset-oq-01/annotations.json
+++ b/src/data/proofs/subset-count-multiset-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-scm-oq01-header",
+    "proofId": "subset-count-multiset-oq-01",
+    "range": {"startLine": 1, "endLine": 39},
+    "type": "context",
+    "title": "File Context: OQ-01 Follow-Up and the Product Formula Problem",
+    "content": "This file is an OQ-01 follow-up to the parent proof SubsetCountOQ02, which counted powerset elements with multiplicity (giving 2^n). The distinct count problem is harder: two submultisets that contain the same elements with the same multiplicities are not double-counted. The key insight announced in the file header is the bijection-based proof strategy: encode each submultiset t ≤ s by its count function on distinct elements, landing in a product of finite ranges Fin(count a + 1). The example {a,a,b} → 6 = 3×2 grounds the abstract formula. The namespace SubsetCountMultisetOQ01 and `open Multiset BigOperators` make multiset API and Σ/Π notation available throughout.",
+    "mathContext": "$|\\{t : \\text{Multiset}\\,\\alpha \\mid t \\leq s\\}| = \\prod_{a \\in s.\\text{toFinset}} (s.\\text{count}\\,a + 1)$. The bijection: $t \\mapsto (a \\mapsto t.\\text{count}\\,a) : \\{t \\mid t \\leq s\\} \\xrightarrow{\\sim} \\prod_{a \\in s.\\text{toFinset}} \\text{Fin}(s.\\text{count}\\,a + 1)$.",
+    "significance": "context",
+    "relatedConcepts": ["subset-count-multiset", "Multiset.powerset", "submultiset", "product formula", "bijection"],
+    "prerequisites": ["Multiset basics (count, le, toFinset)", "Fintype.card and bijection-based counting", "BigOperators notation"]
+  },
+  {
+    "id": "ann-scm-oq01-definitions",
+    "proofId": "subset-count-multiset-oq-01",
+    "range": {"startLine": 43, "endLine": 63},
+    "type": "definition",
+    "title": "distinctSubMultisets: Definition and Basic Lemmas",
+    "content": "distinctSubMultisets s is defined as s.powerset.toFinset — converting the multiset of all submultisets (with multiplicity in the powerset) to a Finset (removing duplicates). The three simp lemmas establish: (1) membership iff t ≤ s (via mem_powerset); (2) the empty multiset has exactly one submultiset (itself); (3) every multiset is a submultiset of itself (by le_rfl). These simp lemmas are used throughout the proof to avoid unfolding the definition.",
+    "mathContext": "Multiset.powerset s contains every t ≤ s, but may list the same t multiple times. Multiset.toFinset deduplicates. Thus distinctSubMultisets s is exactly $\\{t : \\text{Multiset}\\,\\alpha \\mid t \\leq s\\}$ as a Finset. Membership: $t \\in \\text{distinctSubMultisets}\\,s \\iff t \\leq s$ (via Multiset.mem_toFinset and Multiset.mem_powerset).",
+    "significance": "supporting",
+    "relatedConcepts": ["Multiset.powerset", "Multiset.toFinset", "Multiset.mem_powerset", "Finset membership"],
+    "prerequisites": ["Multiset.powerset definition", "Multiset.toFinset and deduplication", "Multiset ordering (t ≤ s = pointwise count inequality)"]
+  },
+  {
+    "id": "ann-scm-oq01-helpers",
+    "proofId": "subset-count-multiset-oq-01",
+    "range": {"startLine": 65, "endLine": 113},
+    "type": "technique",
+    "title": "Helper Lemmas: Count Distribution and Replicate Sum Properties",
+    "content": "Three key private lemmas support the bijection. (1) count_finset_sum_distrib: count commutes with Finset.sum — proved by Finset.induction_on, using count_add at each step. (2) count_finsetSum_replicate: the count of element a in Σ_b replicate(f b)(b) equals f a — proved by distributing count (lemma 1), using count_replicate (returning n if a=b, else 0), converting the Subtype equality ↑b = ↑a to b = a via Subtype.val_inj, then using Finset.sum_ite_eq'. (3) count_finsetSum_replicate_not_mem: if a ∉ s.toFinset then the replicate sum has count 0 at a, via Finset.sum_eq_zero with the membership contradiction. Lemmas (2) and (3) jointly characterize the replicate sum's count function.",
+    "mathContext": "count_finset_sum_distrib: $\\text{count}\\,a\\,(\\sum_{b \\in F} g\\,b) = \\sum_{b \\in F} \\text{count}\\,a\\,(g\\,b)$ (additivity of count). count_finsetSum_replicate: $(\\sum_{b : \\uparrow s.\\text{toFinset}} \\text{replicate}\\,(f\\,b)\\,b).\\text{count}\\,(\\uparrow a) = f\\,a$, using $\\text{count}\\,a\\,(\\text{replicate}\\,n\\,b) = $ if $a=b$ then $n$ else $0$.",
+    "significance": "technical",
+    "relatedConcepts": ["Finset.induction_on", "Multiset.count_replicate", "Multiset.count_add", "Finset.sum_ite_eq'", "Subtype.val_inj"],
+    "prerequisites": ["Multiset.count definition and additivity", "Multiset.replicate and its count property", "Finset.induction for sum properties"]
+  },
+  {
+    "id": "ann-scm-oq01-bijection",
+    "proofId": "subset-count-multiset-oq-01",
+    "range": {"startLine": 129, "endLine": 147},
+    "type": "insight",
+    "title": "The Main Bijection: submultisetEquiv",
+    "content": "submultisetEquiv constructs the explicit equivalence {t // t ≤ s} ≃ ∀ a : ↑s.toFinset, Fin (s.count ↑a + 1). The forward map sends ⟨t, ht⟩ to the count function a ↦ t.count ↑a, with the Fin bound certified by Nat.lt_succ_of_le (since t ≤ s implies t.count ≤ s.count). The inverse sends f to the multiset ∑ a, replicate (f a) a, with the ≤ s bound certified by finsetSum_replicate_le. The left_inv uses submultiset_eq_finsetSum_replicate (every t ≤ s is the replicate-sum of its own counts). The right_inv uses count_finsetSum_replicate (the count of b in the replicate-sum is exactly f b). Both inverses use ext / Fin.mk.injEq for extensionality.",
+    "mathContext": "Forward map: $t \\mapsto (a \\mapsto t.\\text{count}\\,a)$, certified in $\\text{Fin}(s.\\text{count}\\,a+1)$ by $t \\leq s \\Rightarrow t.\\text{count}\\,a \\leq s.\\text{count}\\,a < s.\\text{count}\\,a+1$. Inverse: $f \\mapsto \\sum_{a \\in s.\\text{toFinset}} \\text{replicate}\\,(f\\,a)\\,a$. The key identity for left_inv: $\\sum_{a} \\text{replicate}(t.\\text{count}\\,a)(a) = t$ for any $t \\leq s$ (submultiset_eq_finsetSum_replicate).",
+    "significance": "key",
+    "relatedConcepts": ["Equiv", "submultiset_eq_finsetSum_replicate", "finsetSum_replicate_le", "count_finsetSum_replicate", "Multiset.replicate"],
+    "prerequisites": ["Equiv (bidirectional bijection) in Lean 4", "Multiset.le_iff_count (t ≤ s iff pointwise count)", "submultiset_eq_finsetSum_replicate helper lemma"]
+  },
+  {
+    "id": "ann-scm-oq01-main-theorem",
+    "proofId": "subset-count-multiset-oq-01",
+    "range": {"startLine": 149, "endLine": 174},
+    "type": "insight",
+    "title": "Main Theorem: Fintype.card Chain via the Bijection",
+    "content": "card_distinctSubMultisets uses a calc chain with three Fintype.card equalities: (1) card(distinctSubMultisets s) = Fintype.card {t | t ∈ distinctSubMultisets s} via Fintype.card_coe; (2) = Fintype.card {t | t ≤ s} via Fintype.card_congr with Equiv.subtypeEquivRight (membership ↔ ≤ s); (3) = Fintype.card (∀ a : ↑s.toFinset, Fin (s.count a + 1)) via Fintype.card_congr with submultisetEquiv; (4) = s.toFinset.prod (fun a => s.count a + 1) via Fintype.card_pi, Fintype.card_fin, and Finset.prod_coe_sort. The two explicit Fintype instances (instMem, instLE) are provided via haveI to avoid typeclass synthesis failures.",
+    "mathContext": "The full calc chain: $|\\text{distinctSubMultisets}\\,s| \\overset{(1)}{=} \\text{Fintype.card}\\{t \\mid t \\in \\ldots\\} \\overset{(2)}{=} \\text{Fintype.card}\\{t \\mid t \\leq s\\} \\overset{(3)}{=} \\text{Fintype.card}(\\prod_a \\text{Fin}(c_a+1)) \\overset{(4)}{=} \\prod_{a \\in s.\\text{toFinset}} (s.\\text{count}\\,a+1)$. Step (4) uses $\\text{Fintype.card}(\\prod_i F_i) = \\prod_i |F_i|$ (Fintype.card_pi) with $|\\text{Fin}\\,n| = n$ (Fintype.card_fin) and Finset.prod_coe_sort to convert the product over the subtype to a product over the finset.",
+    "significance": "key",
+    "relatedConcepts": ["Fintype.card_coe", "Fintype.card_congr", "Fintype.card_pi", "Fintype.card_fin", "Finset.prod_coe_sort", "submultisetEquiv"],
+    "prerequisites": ["Fintype.card and card_congr", "Fintype.card_pi (product type cardinality)", "Finset.prod_coe_sort (index conversion)"]
+  },
+  {
+    "id": "ann-scm-oq01-corollaries",
+    "proofId": "subset-count-multiset-oq-01",
+    "range": {"startLine": 176, "endLine": 226},
+    "type": "context",
+    "title": "Corollaries and Numerical Examples",
+    "content": "Five corollaries and examples verify the formula: (1) empty multiset → 1 submultiset (empty product = 1); (2) singleton {a} → 2 submultisets ({} and {a}); (3)–(5) native_decide verifies the product formula for {1,1,2} → 6, {1,1,1} → 4, {1,1,2,2,2} → 12, {1,2,3,4} → 16. The nodup_card_eq_two_pow theorem is the most interesting corollary: for nodup multisets (all counts ≤ 1), every count is exactly 1, so the product ∏(1+1) = 2^n. The proof uses nodup_iff_count_le_one, count_pos (for elements in toFinset), and omega to pin each count to exactly 1. Then Finset.prod_const and toFinset_card_of_nodup convert the product to 2^n.",
+    "mathContext": "nodup_card_eq_two_pow: for $s$ with $s.\\text{Nodup}$, $\\forall a \\in s.\\text{toFinset}, s.\\text{count}\\,a = 1$, so $\\prod (s.\\text{count}\\,a + 1) = \\prod 2 = 2^{|s.\\text{toFinset}|} = 2^{|s|}$ (using Multiset.toFinset_card_of_nodup). This specializes to the parent proof's 2^n formula for multisets with no repeated elements.",
+    "significance": "supporting",
+    "relatedConcepts": ["nodup_iff_count_le_one", "Finset.prod_const", "Multiset.toFinset_card_of_nodup", "native_decide", "subset-count-multiset"],
+    "prerequisites": ["Multiset.Nodup definition", "Multiset.count_pos (element membership)", "Finset.prod_const and prod_congr"]
+  }
+]

--- a/src/data/proofs/subset-count-multiset-oq-01/meta.json
+++ b/src/data/proofs/subset-count-multiset-oq-01/meta.json
@@ -1,0 +1,181 @@
+{
+  "id": "subset-count-multiset-oq-01",
+  "title": "Distinct Submultiset Count: ∏(mᵢ + 1)",
+  "slug": "subset-count-multiset-oq-01",
+  "description": "Formalizes the distinct submultiset count formula: the number of distinct submultisets of a multiset s equals ∏ᵢ(mᵢ + 1), where mᵢ is the multiplicity of the i-th distinct element. Proved via an explicit bijection with a product of finite sets.",
+  "meta": {
+    "author": "Formalized in Lean 4",
+    "date": "2026-04-04",
+    "status": "verified",
+    "proofRepoPath": "Proofs/SubsetCountMultisetOQ01.lean",
+    "parentProofId": "subset-count-multiset",
+    "tags": [
+      "combinatorics",
+      "multiset",
+      "counting",
+      "distinct-submultisets",
+      "bijection",
+      "open-question"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "assumptions": "0 axioms, 0 sorries. All theorems fully proved using Mathlib's Fintype.card machinery and an explicit bijection.",
+    "mathlibDependencies": [
+      {
+        "theorem": "Fintype.card_pi",
+        "description": "Cardinality of a dependent product type is the product of cardinalities",
+        "module": "Mathlib.Data.Fintype.Card"
+      },
+      {
+        "theorem": "Fintype.card_congr",
+        "description": "Cardinality is preserved by equivalence",
+        "module": "Mathlib.Data.Fintype.Card"
+      },
+      {
+        "theorem": "Finset.prod_coe_sort",
+        "description": "Product over a finset subtype equals product over the finset",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Multiset.le_iff_count",
+        "description": "Multiset ordering ↔ pointwise count inequality",
+        "module": "Mathlib.Data.Multiset.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Bijection submultisetEquiv: {t // t ≤ s} ≃ ∀ a : ↑s.toFinset, Fin (s.count a + 1)",
+      "Main theorem: card(distinctSubMultisets s) = ∏ a ∈ s.toFinset, (s.count a + 1)",
+      "Corollary: for nodup multisets, the formula reduces to 2^n",
+      "Numerical examples: {1,1,2} → 6, {1,1,1} → 4, {1,1,2,2,2} → 12, {1,2,3,4} → 16"
+    ],
+    "dateAdded": "2026-04-04",
+    "lineCount": 226,
+    "theoremCount": 8,
+    "definitionCount": 2,
+    "prerequisites": [
+      "Multiset basics, count, toFinset",
+      "Fintype.card and bijections",
+      "Finite products over finsets"
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The formula for counting distinct submultisets is a classical result in enumerative combinatorics. For a multiset with distinct elements e₁,…,eₖ of multiplicities m₁,…,mₖ, the number of distinct submultisets (sub-multisets counted once regardless of how many ways they can be embedded) is (m₁+1)(m₂+1)⋯(mₖ+1). This product formula follows from independent choice: for each element eᵢ, independently choose how many copies to include (0, 1, …, or mᵢ), giving mᵢ+1 choices per element.\n\nThe formula generalizes several classical counting results. When all multiplicities are 1 (a set), it gives 2^n (the number of subsets of an n-element set). When s has one element with multiplicity m, it gives m+1 (the submultisets {}, {a}, {a,a}, …, {a,⋯m times⋯a}). The generating function perspective: the number of distinct submultisets is the constant term of ∏ᵢ (1 + x + x² + ⋯ + x^{mᵢ}) evaluated at x = 1, which equals ∏ᵢ(mᵢ+1).\n\nThis formalization (OQ-01) answers the open question from the parent proof SubsetCountOQ02, which counted powerset elements with multiplicity (giving 2^n for any multiset). The key new element is the explicit bijection between submultisets and count-bounded functions, proved via Mathlib's Fintype.card machinery.",
+    "problemStatement": "Given a multiset s over a type with decidable equality, prove that |{t : Multiset α | t ≤ s}| = ∏ a ∈ s.toFinset, (s.count a + 1).",
+    "text": "The number of distinct submultisets of a multiset s equals the product over distinct elements of (multiplicity + 1).",
+    "proofStrategy": "Construct an explicit bijection between the subtype {t // t ≤ s} and the dependent product type ∀ a : ↑s.toFinset, Fin (s.count a + 1). The forward map sends t to its count function; the backward map reconstructs t from given counts using replicate and sum. The cardinality equation follows from Fintype.card_pi and Finset.prod_coe_sort.",
+    "keyInsights": [
+      "A submultiset t ≤ s is uniquely determined by its count function a ↦ t.count a restricted to s.toFinset",
+      "Each such count is bounded: t.count a ≤ s.count a, so it lives in Fin (s.count a + 1)",
+      "The reconstruction t = ∑ a ∈ s.toFinset, replicate (f a) a uniquely recovers t from counts",
+      "Elements outside s.toFinset have count 0 in any t ≤ s, so no information is lost",
+      "The nodup corollary (2^n formula) follows since all counts are exactly 1 for nodup multisets"
+    ],
+    "prerequisites": [
+      "Multiset count, ordering, toFinset",
+      "Fintype.card and bijections (Equiv)",
+      "BigOperators: Finset.prod"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Definitions",
+      "startLine": 44,
+      "endLine": 63,
+      "summary": "Defines distinctSubMultisets and proves basic membership and simp lemmas.",
+      "mathContext": "distinctSubMultisets s = s.powerset.toFinset, membership iff t ≤ s."
+    },
+    {
+      "id": "helpers",
+      "title": "Key Helper Lemmas",
+      "startLine": 65,
+      "endLine": 127,
+      "summary": "Proves count distributes over finset sums of multisets, and the reconstruction lemma.",
+      "mathContext": "count_finset_sum_distrib, count_finsetSum_replicate, finsetSum_replicate_le, submultiset_eq_finsetSum_replicate."
+    },
+    {
+      "id": "bijection",
+      "title": "The Main Bijection",
+      "startLine": 129,
+      "endLine": 147,
+      "summary": "Constructs submultisetEquiv: {t // t ≤ s} ≃ ∀ a : ↑s.toFinset, Fin (s.count a + 1).",
+      "mathContext": "Explicit forward/backward maps with left_inv and right_inv."
+    },
+    {
+      "id": "main",
+      "title": "Main Theorem",
+      "startLine": 149,
+      "endLine": 184,
+      "summary": "card_distinctSubMultisets: Fintype.card chain via the bijection gives the product formula.",
+      "mathContext": "Uses Fintype.card_congr, Fintype.card_pi, Finset.prod_coe_sort."
+    },
+    {
+      "id": "corollaries",
+      "title": "Corollaries and Examples",
+      "startLine": 186,
+      "endLine": 224,
+      "summary": "Corollaries for empty, singleton, nodup cases; numerical examples via native_decide.",
+      "mathContext": "nodup_card_eq_two_pow: for nodup multisets, the product is 2^n."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "subset-count-multiset",
+      "relationship": "follow-up",
+      "description": "Answers the open question from the parent: count distinct (not with-multiplicity) submultisets"
+    },
+    {
+      "targetId": "subset-count-oq-02",
+      "relationship": "sibling",
+      "description": "OQ-02 proves 2^n (with multiplicity); this proves ∏(mᵢ+1) (distinct)"
+    }
+  ],
+  "conclusion": {
+    "summary": "A complete formalization of the distinct submultiset count formula ∏(mᵢ+1), proved via an explicit bijection. 8 theorems, 0 sorries, 0 axioms.",
+    "implications": "Provides the sharp count of distinct submultisets, complementing the 2^n formula for submultisets counted with multiplicity.",
+    "openQuestions": [
+      "Can the formula be extended to multisets over infinite types using finsupp?",
+      "Is there a generating function proof that connects this to formal power series?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Multiset.Basic",
+      "Mathlib.Data.Multiset.Powerset",
+      "Mathlib.Data.Fintype.Card",
+      "Mathlib.Data.Fin.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Multiset",
+      "BigOperators"
+    ],
+    "namespace": "SubsetCountMultisetOQ01",
+    "lineCount": 224,
+    "axiomCount": 0,
+    "theoremCount": 8,
+    "definitionCount": 2
+  },
+  "mainTheorems": [
+    {
+      "name": "card_distinctSubMultisets",
+      "type": "core",
+      "description": "The number of distinct submultisets equals the product of (count a + 1) over distinct elements",
+      "leanType": "(s : Multiset α) → (distinctSubMultisets s).card = ∏ a ∈ s.toFinset, (s.count a + 1)"
+    },
+    {
+      "name": "submultisetEquiv",
+      "type": "core",
+      "description": "Bijection between submultisets of s and count-bounded functions on s.toFinset",
+      "leanType": "(s : Multiset α) → {t // t ≤ s} ≃ ∀ a : ↑s.toFinset, Fin (s.count a + 1)"
+    },
+    {
+      "name": "nodup_card_eq_two_pow",
+      "type": "corollary",
+      "description": "For nodup multisets, the distinct submultiset count is 2^n",
+      "leanType": "(hn : s.Nodup) → (distinctSubMultisets s).card = 2 ^ s.card"
+    }
+  ]
+}


### PR DESCRIPTION
Enrichment pass for `subset-count-multiset-oq-01` (Distinct Submultiset Count: ∏(mᵢ + 1)).

## Quality improvements

**annotations.json (new — 6 annotations)**
- File header: OQ-01 context vs parent proof, bijection strategy preview, example {a,a,b}→6
- Definitions (distinctSubMultisets): deduplication via toFinset, simp lemmas
- Helper lemmas (lines 65-113): count_finset_sum_distrib (count commutes with Finset.sum), count_finsetSum_replicate, count_finsetSum_replicate_not_mem
- Main bijection (submultisetEquiv): forward map (count function), inverse (replicate sum), left_inv/right_inv proofs
- Main theorem (card_distinctSubMultisets): full Fintype.card calc chain — card_coe → card_congr (membership↔≤) → card_congr (bijection) → card_pi + card_fin + prod_coe_sort
- Corollaries/examples: native_decide examples, nodup_card_eq_two_pow proof strategy

All 6 annotations have `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.

**meta.json improvements**
- `historicalContext`: Expanded from 438 to 1236 chars. Added: independent-choice argument, 2^n and m+1 specializations, generating function perspective, OQ-01 context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)