### PR TITLE
Fix: remove false-positive axiom overcount in auditor script

### DIFF
--- a/research/problems/binomial-theorem-oq-02-oq-01-oq-03/problem.md
+++ b/research/problems/binomial-theorem-oq-02-oq-01-oq-03/problem.md
@@ -1,0 +1,71 @@
+# Problem: Multinomial Covariance — Cov(Xi, Xj) = −n·pi·pj
+
+## Statement
+
+### Plain Language
+
+If (X₁, …, Xₖ) ~ Multinomial(n; p₁, …, pₖ), prove that for i ≠ j:
+
+  Cov(Xᵢ, Xⱼ) = −n · pᵢ · pⱼ
+
+This is the off-diagonal covariance of the multinomial distribution. The result
+follows from Var(Σ Xᵢ) = 0 combined with marginal variances Var(Xᵢ) = n·pᵢ·(1−pᵢ).
+
+### Formal Statement
+
+```lean
+-- Prerequisite: binomial-theorem-oq-02-oq-01 provides PMF.multinomial
+-- Goal: prove the off-diagonal covariance formula
+
+theorem multinomial_cov (n : ℕ) (p : Fin k → ℝ) (hp : ∑ i, p i = 1)
+    (hpos : ∀ i, 0 ≤ p i) (i j : Fin k) (hij : i ≠ j)
+    (X : Fin k → Ω → ℝ) (hX : IsMultinomial n p X) :
+    covariance (X i) (X j) = -↑n * p i * p j := by
+  sorry
+```
+
+Proof strategy:
+1. Var(X₁ + … + Xₖ) = Var(n) = 0 (constant sum)
+2. Expand: Σᵢ Var(Xᵢ) + 2 Σᵢ<ⱼ Cov(Xᵢ,Xⱼ) = 0
+3. Marginal Xᵢ ~ Bin(n, pᵢ), so Var(Xᵢ) = n·pᵢ·(1−pᵢ)
+4. By symmetry and Σpᵢ = 1, solve for Cov(Xᵢ,Xⱼ)
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 7
+tags:
+  - probability
+  - statistics
+  - multinomial-distribution
+  - covariance
+  - mathlib
+```
+
+**Significance**: 6/10 — Standard probability result, important for statistics
+**Tractability**: 7/10 — Clear proof path via variance decomposition
+
+## Origin
+
+- **Source proof**: `binomial-theorem-oq-02-oq-01` — Multinomial Distribution and MGF
+- **Open question**: OQ-03 — "Can the variance-covariance matrix Cov(Xi, Xj) = -n*pi*pj be proved?"
+
+## Why This Matters
+
+1. **Completes the multinomial toolkit** — covariance is essential for any statistical
+   analysis using multinomial distributions
+2. **Connects to CLT for multinomials** — covariance structure underlies the multivariate
+   CLT for sample proportions
+3. **Mathlib gap** — this off-diagonal covariance formula may be missing from Mathlib's
+   `ProbabilityTheory` namespace
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| `binomial-theorem-oq-02-oq-01` | Parent: Multinomial PMF and MGF |
+| `binomial-theorem-oq-02` | Multinomial theorem (algebraic) |
+| `central-limit-theorem-oq-01` | CLT requires covariance structure |
+| `shannon-entropy-oq-01` | Information theory uses multinomial distribution |

--- a/research/problems/binomial-theorem-oq-02-oq-01-oq-03/state.md
+++ b/research/problems/binomial-theorem-oq-02-oq-01-oq-03/state.md
@@ -1,0 +1,27 @@
+# Research State: binomial-theorem-oq-02-oq-01-oq-03
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-05T04:31:00Z
+**Iteration**: 1
+
+## Current Focus
+Prove Cov(Xᵢ, Xⱼ) = −n·pᵢ·pⱼ for the multinomial distribution in Lean 4.
+Start by reading the parent proof (binomial-theorem-oq-02-oq-01) for available infrastructure.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+1. Read `src/data/proofs/binomial-theorem-oq-02-oq-01/` for Lean infrastructure
+2. Search Mathlib for `covariance`, `PMF.multinomial`, `Binomial`
+3. Formalize the proof via variance decomposition: Var(Σ Xᵢ) = 0

--- a/scripts/auditor/find-targets.ts
+++ b/scripts/auditor/find-targets.ts
@@ -216,14 +216,14 @@ function detectIssues(target: AuditTarget): string[] {
     issues.push(`sorry mismatch: claims ${target.meta.claimedSorries}, actual ${target.actual.sorryCount}`)
   }
 
-  // Axiom count mismatch -- check both directions.
-  // Note: structure-encoded assumptions should still be counted in meta.axiomCount per policy.
-  if (target.meta.claimedAxioms >= 0 && target.actual.axiomCount !== target.meta.claimedAxioms) {
-    if (target.actual.axiomCount > target.meta.claimedAxioms) {
-      issues.push(`axiom undercount: claims ${target.meta.claimedAxioms}, actual declarations ${target.actual.axiomCount}`)
-    } else {
-      issues.push(`axiom overcount: claims ${target.meta.claimedAxioms}, actual declarations ${target.actual.axiomCount}`)
-    }
+  // Axiom count mismatch -- only flag undercounts (meta claims fewer than detected).
+  // Per Axiom Integrity Policy, meta.axiomCount must include ALL assumptions: direct
+  // axiom declarations + structure-encoded assumptions + axioms inherited via imports.
+  // The script only counts direct declarations, so meta.axiomCount may legitimately be
+  // higher than detected (e.g., when axioms are inherited via import statements).
+  // Flagging overcounts causes false positives and is not actionable. See Issue #9642.
+  if (target.meta.claimedAxioms >= 0 && target.actual.axiomCount > target.meta.claimedAxioms) {
+    issues.push(`axiom undercount: claims ${target.meta.claimedAxioms}, actual declarations ${target.actual.axiomCount}`)
   }
 
   // Verified with sorries

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-03.json
@@ -1,0 +1,234 @@
+{
+  "slug": "binomial-theorem-oq-02-oq-01-oq-03",
+  "title": "Prove variance-covariance Cov(Xi,Xj) = -n*pi*pj in Lean",
+  "phase": "NEW",
+  "status": "active",
+  "tier": "B",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "\\text{(formal statement to be added)}",
+    "plain": "Formal investigation in probability theory: Prove variance-covariance Cov(Xi,Xj) = -n*pi*pj in Lean.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "NEW",
+    "since": "2026-04-05T03:58:33.672Z",
+    "iteration": 1,
+    "focus": "Initial exploration of the problem.",
+    "blockers": [],
+    "nextAction": "Begin problem exploration.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": []
+  },
+  "tags": [
+    "probability",
+    "statistics"
+  ],
+  "relatedProofs": [
+    "binomial-theorem",
+    "binomial-theorem-oq-01",
+    "binomial-theorem-oq-01-oq-01",
+    "binomial-theorem-oq-02",
+    "binomial-theorem-oq-02-oq-01",
+    "binomial-theorem-oq-02-oq-01-oq-02",
+    "binomial-theorem-oq-02-oq-02",
+    "binomial-theorem-oq-02-oq-03",
+    "binomial-theorem-oq-03",
+    "binomial-theorem-oq-03-oq-02",
+    "binomial-theorem-oq-04",
+    "binomial-theorem-oq-04-oq-01",
+    "binomial-theorem-oq-04-oq-02",
+    "binomial-theorem-oq-04-oq-03"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-04-05T03:59:25.465Z",
+  "lastUpdate": "2026-04-05T03:59:25.465Z",
+  "significance": 6,
+  "tractability": 7,
+  "leanFiles": [
+    {
+      "path": "Proofs/BinomialTheorem.lean",
+      "filename": "BinomialTheorem.lean",
+      "lineCount": 177,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheorem.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ01.lean",
+      "filename": "BinomialTheoremOQ01.lean",
+      "lineCount": 265,
+      "theoremCount": 17,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ01.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ01Aristotle.lean",
+      "filename": "BinomialTheoremOQ01Aristotle.lean",
+      "lineCount": 112,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ01Aristotle.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ01OQ01.lean",
+      "filename": "BinomialTheoremOQ01OQ01.lean",
+      "lineCount": 221,
+      "theoremCount": 17,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ02.lean",
+      "filename": "BinomialTheoremOQ02.lean",
+      "lineCount": 281,
+      "theoremCount": 17,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ02OQ01.lean",
+      "filename": "BinomialTheoremOQ02OQ01.lean",
+      "lineCount": 223,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ02OQ01OQ02.lean",
+      "filename": "BinomialTheoremOQ02OQ01OQ02.lean",
+      "lineCount": 338,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ02OQ02.lean",
+      "filename": "BinomialTheoremOQ02OQ02.lean",
+      "lineCount": 180,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ02OQ03.lean",
+      "filename": "BinomialTheoremOQ02OQ03.lean",
+      "lineCount": 270,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ03.lean",
+      "filename": "BinomialTheoremOQ03.lean",
+      "lineCount": 589,
+      "theoremCount": 33,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ03OQ02.lean",
+      "filename": "BinomialTheoremOQ03OQ02.lean",
+      "lineCount": 216,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ04.lean",
+      "filename": "BinomialTheoremOQ04.lean",
+      "lineCount": 196,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ04.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ04OQ01.lean",
+      "filename": "BinomialTheoremOQ04OQ01.lean",
+      "lineCount": 300,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ04OQ02.lean",
+      "filename": "BinomialTheoremOQ04OQ02.lean",
+      "lineCount": 112,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ04OQ02.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ04OQ03.lean",
+      "filename": "BinomialTheoremOQ04OQ03.lean",
+      "lineCount": 191,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ04OQ03.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Fix

Remove false-positive "axiom overcount" detection from `find-targets.ts`.

## Evidence

**Before**: Script flagged `erdos-1059-oq-04` with `axiom overcount: claims 1, actual declarations 0`. The meta.json correctly claims 1 axiom (inherited via `import Proofs.Erdos1059OQ01`), but the script only scans direct `^axiom` declarations in the file itself.

**After**: Script only flags undercounts (`actual > claimed`), which represent real disclosure failures where meta.json hides existing assumptions. Overcounts are not flagged since meta.json legitimately includes axioms from imports per the Axiom Integrity Policy.

**Root cause**: The Axiom Integrity Policy requires `meta.json axiomCount` to reflect ALL assumptions including those inherited via imports. The detection script cannot follow transitive imports for non-Aristotle sibling files (by design, to avoid counting unrelated gallery entries). This mismatch caused false positives when meta.json correctly counted imported axioms.

Closes #9642

---
Automated fix by lean-mechanic agent.