### PR TITLE
fix: correct lineCount in 30 gallery meta.json files (batch 2)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03/meta.json
@@ -116,7 +116,7 @@
   ],
   "leanFile": {
     "namespace": "AmgmInequalityOQ02OQ03OQ03",
-    "lineCount": 67,
+    "lineCount": 66,
     "axiomCount": 0,
     "theoremCount": 2,
     "definitionCount": 0

--- a/src/data/proofs/denumerability-rationals-oq-04/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-04/meta.json
@@ -140,7 +140,7 @@
       "Mathlib"
     ],
     "namespace": "DenumerabilityOQ04",
-    "lineCount": 141,
+    "lineCount": 142,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 1

--- a/src/data/proofs/derangements-convergence/meta.json
+++ b/src/data/proofs/derangements-convergence/meta.json
@@ -126,7 +126,7 @@
   ],
   "leanFile": {
     "namespace": "global (noncomputable section)",
-    "lineCount": 284,
+    "lineCount": 283,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 4

--- a/src/data/proofs/dissection-of-cubes-oq-02-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02-oq-02/meta.json
@@ -250,7 +250,7 @@
       "Real"
     ],
     "namespace": "DehnSydler",
-    "lineCount": 410,
+    "lineCount": 413,
     "axiomCount": 1,
     "theoremCount": 14,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-1049/meta.json
+++ b/src/data/proofs/erdos-1049/meta.json
@@ -276,7 +276,7 @@
       "Real"
     ],
     "namespace": null,
-    "lineCount": 327,
+    "lineCount": 329,
     "axiomCount": 2,
     "theoremCount": 26,
     "substantiveTheoremCount": 22,

--- a/src/data/proofs/erdos-1077/meta.json
+++ b/src/data/proofs/erdos-1077/meta.json
@@ -216,7 +216,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos1077",
-    "lineCount": 144,
+    "lineCount": 145,
     "axiomCount": 0,
     "theoremCount": 2,
     "definitionCount": 4

--- a/src/data/proofs/erdos-1081/meta.json
+++ b/src/data/proofs/erdos-1081/meta.json
@@ -272,7 +272,7 @@
       "Finset"
     ],
     "namespace": "Erdos1081",
-    "lineCount": 333,
+    "lineCount": 335,
     "axiomCount": 1,
     "theoremCount": 9,
     "definitionCount": 7

--- a/src/data/proofs/erdos-1165/meta.json
+++ b/src/data/proofs/erdos-1165/meta.json
@@ -170,7 +170,7 @@
       "MeasureTheory"
     ],
     "namespace": "Erdos1165",
-    "lineCount": 182,
+    "lineCount": 183,
     "axiomCount": 5,
     "theoremCount": 5,
     "definitionCount": 2,

--- a/src/data/proofs/erdos-181/meta.json
+++ b/src/data/proofs/erdos-181/meta.json
@@ -156,7 +156,7 @@
     ],
     "opens": [],
     "namespace": "Erdos181",
-    "lineCount": 382,
+    "lineCount": 385,
     "axiomCount": 3,
     "theoremCount": 11,
     "definitionCount": 2

--- a/src/data/proofs/erdos-220/meta.json
+++ b/src/data/proofs/erdos-220/meta.json
@@ -96,7 +96,7 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 241,
+    "lineCount": 226,
     "axiomCount": 4,
     "theoremCount": 0,
     "definitionCount": 0

--- a/src/data/proofs/erdos-277/meta.json
+++ b/src/data/proofs/erdos-277/meta.json
@@ -274,7 +274,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos277",
-    "lineCount": 283,
+    "lineCount": 275,
     "axiomCount": 1,
     "theoremCount": 12,
     "definitionCount": 22

--- a/src/data/proofs/erdos-290/meta.json
+++ b/src/data/proofs/erdos-290/meta.json
@@ -197,7 +197,7 @@
       "Real"
     ],
     "namespace": "Erdos290",
-    "lineCount": 244,
+    "lineCount": 263,
     "axiomCount": 2,
     "theoremCount": 7,
     "definitionCount": 21

--- a/src/data/proofs/erdos-318/meta.json
+++ b/src/data/proofs/erdos-318/meta.json
@@ -176,7 +176,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos318",
-    "lineCount": 318,
+    "lineCount": 321,
     "axiomCount": 5,
     "theoremCount": 6,
     "definitionCount": 14

--- a/src/data/proofs/erdos-396/meta.json
+++ b/src/data/proofs/erdos-396/meta.json
@@ -107,7 +107,7 @@
       "Nat"
     ],
     "namespace": null,
-    "lineCount": 79,
+    "lineCount": 78,
     "axiomCount": 1,
     "theoremCount": 0,
     "definitionCount": 0

--- a/src/data/proofs/erdos-435/meta.json
+++ b/src/data/proofs/erdos-435/meta.json
@@ -193,7 +193,7 @@
     ],
     "opens": [],
     "namespace": "Erdos435",
-    "lineCount": 228,
+    "lineCount": 233,
     "axiomCount": 2,
     "theoremCount": 2,
     "definitionCount": 7

--- a/src/data/proofs/erdos-606-oq-03/meta.json
+++ b/src/data/proofs/erdos-606-oq-03/meta.json
@@ -93,7 +93,7 @@
       "Mathlib"
     ],
     "namespace": "Erdos606OQ03",
-    "lineCount": 98,
+    "lineCount": 99,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 0

--- a/src/data/proofs/erdos-631/meta.json
+++ b/src/data/proofs/erdos-631/meta.json
@@ -203,7 +203,7 @@
       "Nat"
     ],
     "namespace": "Erdos631",
-    "lineCount": 270,
+    "lineCount": 269,
     "axiomCount": 16,
     "theoremCount": 7,
     "definitionCount": 9

--- a/src/data/proofs/erdos-649/meta.json
+++ b/src/data/proofs/erdos-649/meta.json
@@ -163,7 +163,7 @@
       "Finset"
     ],
     "namespace": "Erdos649",
-    "lineCount": 359,
+    "lineCount": 364,
     "axiomCount": 4,
     "theoremCount": 14,
     "definitionCount": 1

--- a/src/data/proofs/erdos-671/meta.json
+++ b/src/data/proofs/erdos-671/meta.json
@@ -103,7 +103,7 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 269,
+    "lineCount": 249,
     "axiomCount": 3,
     "theoremCount": 0,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-698/meta.json
+++ b/src/data/proofs/erdos-698/meta.json
@@ -218,7 +218,7 @@
       "Nat"
     ],
     "namespace": "Erdos698",
-    "lineCount": 289,
+    "lineCount": 293,
     "axiomCount": 2,
     "theoremCount": 7,
     "definitionCount": 6

--- a/src/data/proofs/erdos-755/meta.json
+++ b/src/data/proofs/erdos-755/meta.json
@@ -165,7 +165,7 @@
       "Real"
     ],
     "namespace": "Erdos755",
-    "lineCount": 258,
+    "lineCount": 259,
     "axiomCount": 1,
     "theoremCount": 3,
     "definitionCount": 7

--- a/src/data/proofs/erdos-978/meta.json
+++ b/src/data/proofs/erdos-978/meta.json
@@ -166,7 +166,7 @@
       "Polynomial"
     ],
     "namespace": "Erdos978",
-    "lineCount": 280,
+    "lineCount": 282,
     "axiomCount": 3,
     "theoremCount": 6,
     "definitionCount": 7

--- a/src/data/proofs/fair-games-theorem/meta.json
+++ b/src/data/proofs/fair-games-theorem/meta.json
@@ -187,7 +187,7 @@
     ],
     "opens": [],
     "namespace": "FairGamesTheorem",
-    "lineCount": 476,
+    "lineCount": 475,
     "axiomCount": 1,
     "theoremCount": 11,
     "substantiveTheoremCount": 5,

--- a/src/data/proofs/hilbert-11/meta.json
+++ b/src/data/proofs/hilbert-11/meta.json
@@ -205,7 +205,7 @@
       "Matrix"
     ],
     "namespace": "Hilbert11QuadraticForms",
-    "lineCount": 496,
+    "lineCount": 494,
     "axiomCount": 5,
     "theoremCount": 7,
     "definitionCount": 17

--- a/src/data/proofs/hilbert-23/meta.json
+++ b/src/data/proofs/hilbert-23/meta.json
@@ -137,7 +137,7 @@
   },
   "leanFile": {
     "path": "Proofs/Hilbert23CalculusVariations.lean",
-    "lineCount": 335,
+    "lineCount": 328,
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 4,

--- a/src/data/proofs/lebesgue-measure-oq-03/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-03/meta.json
@@ -117,7 +117,7 @@
       "Mathlib"
     ],
     "namespace": "LebesgueMeasureOQ03",
-    "lineCount": 132,
+    "lineCount": 136,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 0

--- a/src/data/proofs/pac-learning-bounds/meta.json
+++ b/src/data/proofs/pac-learning-bounds/meta.json
@@ -202,7 +202,7 @@
       "BigOperators"
     ],
     "namespace": "LearningTheory",
-    "lineCount": 104,
+    "lineCount": 108,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 1

--- a/src/data/proofs/prob-method-applications/meta.json
+++ b/src/data/proofs/prob-method-applications/meta.json
@@ -211,7 +211,7 @@
     ],
     "opens": [],
     "namespace": "ProbMethod.Applications",
-    "lineCount": 51,
+    "lineCount": 53,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0

--- a/src/data/proofs/ptolemys-complex-proof-oq-01/meta.json
+++ b/src/data/proofs/ptolemys-complex-proof-oq-01/meta.json
@@ -125,7 +125,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 136,
+    "lineCount": 135,
     "axiomCount": 0,
     "theoremCount": 4,
     "substantiveTheoremCount": 3,

--- a/src/data/proofs/wilsons-theorem-oq-04-oq-02/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-04-oq-02/meta.json
@@ -128,7 +128,7 @@
   },
   "leanFile": {
     "namespace": "WilsonsTheoremOQ04OQ02",
-    "lineCount": 235,
+    "lineCount": 234,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0


### PR DESCRIPTION
## Fix

Batch 2 of `leanFile.lineCount` corrections. Follows the same pattern as #9662.

Each `leanFile.lineCount` field was out of sync with its actual Lean source file length (due to edits since the field was last set).

## Evidence

**Before/After** (selected examples):
- `erdos-220`: 241 → 226 (Lean file was shortened)
- `erdos-290`: 244 → 263 (Lean file was extended)
- `erdos-671`: 269 → 249 (Lean file was shortened)
- `lebesgue-measure-oq-03`: 132 → 136 (Lean file was extended)
- `pac-learning-bounds`: 104 → 108

30 files corrected total.

---
Automated fix by lean-mechanic agent.