### PR TITLE
Enrich solution-of-cubic-oq-03-oq-05 and erdos-114

### DIFF
--- a/src/data/proofs/erdos-114/meta.json
+++ b/src/data/proofs/erdos-114/meta.json
@@ -73,18 +73,32 @@
   },
   "sections": [
     {
+      "id": "file-header",
+      "title": "Problem Statement and History",
+      "startLine": 1,
+      "endLine": 21,
+      "summary": "Block comment surveying the 50-year history of Problem #114: from Dolzhenko's first bound (1961) through Borwein, Eremenko-Hayman (n=2 solved), Danchenko, Fryntov-Nazarov (local optimality), and Tao (2025, large-n global optimality). Lists the $250 Erdős bounty and references."
+    },
+    {
+      "id": "imports",
+      "title": "Library Imports",
+      "startLine": 22,
+      "endLine": 25,
+      "summary": "Imports for complex number arithmetic, real numbers, polynomial ring theory, and tactic automation. Complex line integrals needed for `lemniscateLength` are not yet available in Mathlib, motivating the axiomatized approach."
+    },
+    {
       "id": "core-definitions",
       "title": "Core Definitions",
       "startLine": 27,
-      "endLine": 46,
-      "summary": "Defines `MonicPoly` as a structure with coefficient function $\\text{Fin}(n) \\to \\mathbb{C}$, axiomatizes `lemniscateLength` $L(p) = \\oint_{|p(z)|=1} |dz|$, defines `maxLemniscateLength` $f(n) = \\sup_p L(p)$, and constructs `extremalPoly` $z^n - 1$ with $a_0 = -1$, $a_k = 0$ for $k \\geq 1$."
+      "endLine": 40,
+      "summary": "Defines `MonicPoly n` as a Lean structure holding a coefficient function `Fin n → ℂ`. Comment stubs mark axiomatized definitions for `lemniscateLength` and `maxLemniscateLength`. Constructs `znMinus1 n hn` (the extremal candidate $z^n - 1$) via `coeffs i = if i.val = 0 then -1 else 0`."
     },
     {
       "id": "upper-bounds",
-      "title": "Upper Bounds",
-      "startLine": 47,
+      "title": "Upper Bounds and Conjecture Stubs",
+      "startLine": 41,
       "endLine": 49,
-      "summary": "Three progressively tighter upper bounds: Dolzhenko's $f(n) \\leq 4\\pi n$ (1961, argument variation), Danchenko's $f(n) \\leq 2\\pi n$ (2007, potential theory), and Fryntov-Nazarov's $f(n) \\leq 2n + C \\cdot n^{7/8}$ (2009, variational methods). Each is axiomatized."
+      "summary": "Section header stubs marking the formalization roadmap: Upper Bounds (Dolzhenko/Danchenko/Fryntov-Nazarov), Lower Bound from $z^n-1$, Main Conjecture (Tao/Eremenko-Hayman results), and Lemniscate Geometry (Gamma-function length formula). These are empty, awaiting Mathlib integration theory."
     }
   ],
   "conclusion": {
@@ -99,28 +113,34 @@
   },
   "crossReferences": [
     {
-      "relationship": "Direct companion problem: erdos-115 asks for bounds on |p'(z)| on connected lemniscates (Eremenko-Lempert, Chebyshev extremals), while erdos-114 asks which monic polynomial maximizes the lemniscate arc length; both are solved for special cases and share the Eremenko authorship",
-      "targetId": "erdos-115"
+      "targetId": "erdos-115",
+      "relationship": "companion-problem",
+      "description": "Erdős #115 asks for bounds on |p'(z)| on connected lemniscates (Eremenko-Lempert, Chebyshev extremals), while #114 asks which monic polynomial maximizes lemniscate arc length. Both are solved for special cases and share Eremenko as a key contributor."
     },
     {
-      "relationship": "Closely parallel extremal question: erdos-1044 asks for the infimum of the maximum boundary length of connected components of {|f(z)| < 1}, the complementary minimization problem to erdos-114's maximization of total arc length of {|p(z)| = 1}",
-      "targetId": "erdos-1044"
+      "targetId": "erdos-1044",
+      "relationship": "complementary",
+      "description": "Erdős #1044 asks for the infimum of the maximum boundary length of connected components of {|f(z)| < 1}—the complementary minimization problem to #114's maximization of total arc length of {|p(z)| = 1}."
     },
     {
-      "relationship": "erdos-1042 studies the number of connected components of polynomial lemniscates {|f(z)| < 1} as a function of transfinite diameter; understanding lemniscate topology (connected vs. disconnected) is prerequisite to the length maximization in erdos-114",
-      "targetId": "erdos-1042"
+      "targetId": "erdos-1042",
+      "relationship": "prerequisite",
+      "description": "Erdős #1042 studies the number of connected components of polynomial lemniscates {|f(z)| < 1} as a function of transfinite diameter. Understanding lemniscate topology (connected vs. disconnected) is prerequisite to the length maximization in #114."
     },
     {
-      "relationship": "erdos-1046 (Pommerenke 1959) proves that connected lemniscates {|f(z)| < 1} are contained in a disc of radius 2; this containment result constrains the geometry of the extremal lemniscate in erdos-114 and uses the same potential-theoretic techniques",
-      "targetId": "erdos-1046"
+      "targetId": "erdos-1046",
+      "relationship": "related",
+      "description": "Erdős #1046 (Pommerenke 1959) proves that connected lemniscates {|f(z)| < 1} are contained in a disc of radius 2. This containment result constrains the extremal geometry and uses the same potential-theoretic techniques as #114."
     },
     {
-      "relationship": "erdos-509 asks whether {|f(z)| ≤ 1} can be covered by discs with total radius ≤ 2 (Cartan: 2e; Pommerenke: 2); the disc-covering and arc-length problems are dual perspectives on lemniscate size, both central to the Erdős-Herzog-Piranian program",
-      "targetId": "erdos-509"
+      "targetId": "erdos-509",
+      "relationship": "related",
+      "description": "Erdős #509 asks whether {|f(z)| ≤ 1} can be covered by discs with total radius ≤ 2. The disc-covering and arc-length problems are dual perspectives on lemniscate size, both central to the Erdős-Herzog-Piranian program."
     },
     {
-      "relationship": "erdos-114 is an isoperimetric-type problem for polynomial lemniscates: among all monic degree-n polynomials, find the one whose level set has maximum arc length. The classical isoperimetric theorem (circle maximizes area for fixed perimeter) provides the philosophical template and suggests symmetric (z^n-1) extremizers",
-      "targetId": "isoperimetric-theorem"
+      "targetId": "isoperimetric-theorem",
+      "relationship": "isoperimetric-analogy",
+      "description": "The classical isoperimetric theorem (circle maximizes area for fixed perimeter) provides the philosophical template for #114. Both problems find a symmetric extremizer—circle for the classical case, z^n-1 (with D_n symmetry) for the polynomial lemniscate case."
     }
   ],
   "references": [

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-05/annotations.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-05/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-setup",
+    "proofId": "solution-of-cubic-oq-03-oq-05",
+    "range": { "startLine": 1, "endLine": 20 },
+    "type": "context",
+    "title": "Setup: CommRing Generality and Namespace",
+    "content": "The file header declares that `variable {R : Type*} [CommRing R]` — all theorems are proved over an arbitrary commutative ring, not just over ℂ or ℝ. The namespace `VietaCubic` groups the six theorems. The single import `Mathlib` pulls in everything, including `Mathlib.RingTheory.Polynomial.Basic` (Polynomial API) and `Mathlib.Tactic` (`ring`, `simp`, `linarith`).",
+    "mathContext": "A commutative ring $R$ satisfies: addition and multiplication are both associative and commutative, multiplication distributes over addition, there are additive and multiplicative identities, and every element has an additive inverse. Fields ($\\mathbb{Q}, \\mathbb{R}, \\mathbb{C}$) and rings ($\\mathbb{Z}, \\mathbb{Z}/n\\mathbb{Z}$, polynomial rings) all qualify. The Vieta proofs require no division, so the commutative ring axioms suffice.",
+    "significance": "context",
+    "relatedConcepts": ["CommRing", "type class", "Lean namespace", "Mathlib import"],
+    "prerequisites": ["Lean 4 type classes", "ring theory basics"]
+  },
+  {
     "id": "ann-factor-expansion",
     "proofId": "solution-of-cubic-oq-03-oq-05",
     "range": { "startLine": 28, "endLine": 35 },
@@ -22,6 +34,30 @@
     "significance": "supporting",
     "relatedConcepts": ["first elementary symmetric polynomial", "coefficient extraction", "congr_arg", "linarith"],
     "prerequisites": ["polynomial coefficients", "Lean ring tactics"]
+  },
+  {
+    "id": "ann-vieta-sigma2",
+    "proofId": "solution-of-cubic-oq-03-oq-05",
+    "range": { "startLine": 54, "endLine": 65 },
+    "type": "insight",
+    "title": "Second Vieta Formula: Sum of Products of Pairs",
+    "content": "vieta_sigma2 extracts the degree-1 coefficient. The proof mirrors vieta_sigma1 exactly, with `Polynomial.coeff p 1` instead of `Polynomial.coeff p 2`. The second elementary symmetric polynomial $\\sigma_2 = r_1 r_2 + r_1 r_3 + r_2 r_3$ has no sign change: the coefficient `b` equals $\\sigma_2$ directly, because the degree-1 term in the expansion has a positive sign.",
+    "mathContext": "$b = r_1 r_2 + r_1 r_3 + r_2 r_3 = \\sigma_2$. No sign change: expanding $(x-r_1)(x-r_2)(x-r_3)$, the $x$ coefficient is $+(r_1 r_2 + r_1 r_3 + r_2 r_3)$. The sign pattern for degree-$n$ Vieta's formulas is $(-1)^k \\sigma_k$, so degree-1 gets $(−1)^{n−1} = (−1)^2 = +1$ for $n=3$.",
+    "significance": "supporting",
+    "relatedConcepts": ["second elementary symmetric polynomial", "coefficient extraction", "sign pattern"],
+    "prerequisites": ["vieta_sigma1", "polynomial coefficients"]
+  },
+  {
+    "id": "ann-vieta-sigma3",
+    "proofId": "solution-of-cubic-oq-03-oq-05",
+    "range": { "startLine": 67, "endLine": 78 },
+    "type": "insight",
+    "title": "Third Vieta Formula: Product of All Roots",
+    "content": "vieta_sigma3 extracts the degree-0 (constant) coefficient. The product of all roots $r_1 r_2 r_3 = \\sigma_3 = -c$ (with a sign change). This is also the value of the polynomial at $x=0$: substituting gives $0^3 + a \\cdot 0^2 + b \\cdot 0 + c = c = -(r_1 r_2 r_3)$. For integer polynomials with rational roots, this is the basis of the rational root theorem: any rational root $p/q$ must have $p \\mid c$ and $q \\mid$ the leading coefficient.",
+    "mathContext": "$c = -r_1 r_2 r_3 = -\\sigma_3$. Extracting `Polynomial.coeff p 0` from both sides of the factorization gives the constant term. The sign: expanding $(x-r_1)(x-r_2)(x-r_3)$ yields $+(-r_1)(-r_2)(-r_3) = -r_1 r_2 r_3$ as the constant term.",
+    "significance": "supporting",
+    "relatedConcepts": ["third elementary symmetric polynomial", "constant term", "rational root theorem", "product of roots"],
+    "prerequisites": ["vieta_sigma1", "vieta_sigma2", "polynomial evaluation at 0"]
   },
   {
     "id": "ann-vieta-combined",

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-05/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-05/meta.json
@@ -40,9 +40,27 @@
     "keyInsights": [
       "**Polynomial coefficient extraction**: the proof technique — apply `congr_arg (Polynomial.coeff · k)` to a polynomial equality — extracts the coefficient at each degree, reducing a polynomial identity to a ring identity. This is the canonical Lean approach to proving results about polynomial coefficients",
       "**Generality over CommRing**: the formulas hold over any commutative ring, not just fields or ℂ. This covers e.g. polynomials over ℤ (integer roots, integer coefficients) or ℤ/pℤ (finite field roots), making the results applicable in modular arithmetic and number theory",
-      "**Elementary symmetric polynomials**: Vieta's formulas are the isomorphism σ: roots → coefficients via e₁, e₂, e₃. The Newton-Girard identities (expressing power sums p_k = Σ rᵢᵏ in terms of eₖ) follow from Vieta's, connecting the formulas to generating functions and partition theory"
+      "**Elementary symmetric polynomials**: Vieta's formulas are the isomorphism σ: roots → coefficients via e₁, e₂, e₃. The Newton-Girard identities (expressing power sums p_k = Σ rᵢᵏ in terms of eₖ) follow from Vieta's, connecting the formulas to generating functions and partition theory",
+      "**Connection to Galois theory**: the Galois group of the cubic acts by permuting the roots r₁, r₂, r₃. Since the coefficients a, b, c are symmetric functions of the roots (Vieta's formulas), they are fixed by the entire Galois group — this is why coefficients live in the base field even when roots do not. The discriminant Δ = (r₁-r₂)²(r₁-r₃)²(r₂-r₃)², also symmetric, determines whether the Galois group is ℤ/3 (Δ a perfect square) or S₃ (Δ not a perfect square)"
     ]
   },
+  "crossReferences": [
+    {
+      "targetId": "solution-of-cubic-oq-03",
+      "relationship": "extends",
+      "description": "solution-of-cubic-oq-03 proves Vieta's formulas for the depressed cubic (no x² term). This file extends those results to the general cubic x³ + ax² + bx + c."
+    },
+    {
+      "targetId": "solution-of-cubic",
+      "relationship": "related",
+      "description": "solution-of-cubic proves the Cardano formula giving explicit radical expressions for the roots of a cubic. Vieta's formulas (this file) describe the coefficients in terms of those roots."
+    },
+    {
+      "targetId": "vietas-formulas",
+      "relationship": "specialization",
+      "description": "vietas-formulas proves the general Vieta's theorem for degree-n polynomials. This file specializes to degree 3 and works over any CommRing, not just algebraically closed fields."
+    }
+  ],
   "sorryCount": 0,
   "status": "verified",
   "badge": "original",


### PR DESCRIPTION
Enrichment pass covering two proofs.

## solution-of-cubic-oq-03-oq-05 (quality 89 → improved)

**annotations.json** (4 → 7 annotations):
- `ann-setup` (1–20): CommRing generality, namespace VietaCubic, import rationale with LaTeX ring axiom context
- `ann-vieta-sigma2` (54–65): second Vieta formula with sign-pattern insight ($(-1)^k \sigma_k$)
- `ann-vieta-sigma3` (67–78): third Vieta formula with rational root theorem connection

**meta.json**:
- Added **4th keyInsight**: connection to Galois theory — Galois group permutes roots but fixes symmetric coefficients; discriminant determines Galois group (ℤ/3 vs S₃)
- Added **crossReferences** to 3 gallery proofs: `solution-of-cubic-oq-03`, `solution-of-cubic`, `vietas-formulas`

## erdos-114 (quality 94, cleanup pass)

- **Fixed 6 crossReferences**: split long `relationship` strings into short type + `description` field (companion-problem, complementary, prerequisite, related, isoperimetric-analogy)
- **Expanded sections from 2 → 4** for complete file coverage: file-header (1–21), imports (22–25), core-definitions (27–40), upper-bounds (41–49)