### PR TITLE
Fix: add Aristotle companion files for Erdős #860 and #900

### DIFF
--- a/proofs/Proofs/Stubs/Erdos860Aristotle.lean
+++ b/proofs/Proofs/Stubs/Erdos860Aristotle.lean
@@ -1,0 +1,73 @@
+/-
+  Aristotle targets for Erdős Problem #860
+  Routine supporting lemmas for automated proof search.
+  See Erdos860Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT linear_lower_bound (requires non-trivial application of erdos_selfridge axiom)
+  - NOT subquadratic_upper_bound (requires non-trivial application of erdos_pomerance axiom)
+  - NOT h(n) definition (definition sorry — Aristotle skips)
+  - Routine: PrimeCovering structure properties, AdmitsCovering monotonicity, base cases
+  - No definition sorries
+  - No axioms
+-/
+import Mathlib
+
+namespace Erdos860Aristotle
+
+/-- The n-th prime number (1-indexed, so nthPrime 1 = 2). -/
+noncomputable def nthPrime (n : ℕ) : ℕ := Nat.nth Nat.Prime n
+
+/-- A prime covering assignment for the interval (m, m+L]:
+    distinct integers a_i where p_i | a_i. -/
+structure PrimeCovering (m : ℕ) (L : ℕ) (k : ℕ) where
+  assignment : Fin k → ℕ
+  in_interval : ∀ i, m < assignment i ∧ assignment i ≤ m + L
+  distinct : ∀ i j, i ≠ j → assignment i ≠ assignment j
+  divisibility : ∀ i, (nthPrime (i.val + 1)) ∣ assignment i
+
+/-- The interval (m, m+L] admits a prime covering for the first k primes. -/
+def AdmitsCovering (m L k : ℕ) : Prop :=
+  Nonempty (PrimeCovering m L k)
+
+-- Routine: Each assignment value is bounded above by m + L.
+theorem covering_le_upper {m L k : ℕ} (c : PrimeCovering m L k) (i : Fin k) :
+    c.assignment i ≤ m + L :=
+  (c.in_interval i).2
+
+-- Routine: Each assignment value strictly exceeds m.
+theorem covering_gt_lower {m L k : ℕ} (c : PrimeCovering m L k) (i : Fin k) :
+    m < c.assignment i :=
+  (c.in_interval i).1
+
+-- Routine: Each assignment value is positive when m = 0.
+theorem covering_pos_of_zero_base {L k : ℕ} (c : PrimeCovering 0 L k) (i : Fin k) :
+    0 < c.assignment i := by
+  exact (c.in_interval i).1
+
+-- Routine: The empty covering is admitted for any m and L (k = 0).
+-- Fin 0 is empty so all conditions are vacuously satisfied.
+theorem admits_covering_zero (m L : ℕ) : AdmitsCovering m L 0 :=
+  ⟨{ assignment := fun i => i.elim0
+     in_interval := fun i => i.elim0
+     distinct := fun i => i.elim0
+     divisibility := fun i => i.elim0 }⟩
+
+-- Routine: AdmitsCovering is monotone in L.
+-- If (m, m+L₁] can cover k primes and L₁ ≤ L₂, then (m, m+L₂] can too.
+theorem admits_covering_mono {m L₁ L₂ k : ℕ} (hL : L₁ ≤ L₂)
+    (hc : AdmitsCovering m L₁ k) : AdmitsCovering m L₂ k := by
+  obtain ⟨c⟩ := hc
+  exact ⟨⟨c.assignment,
+    fun i => ⟨(c.in_interval i).1,
+              (c.in_interval i).2.trans (Nat.add_le_add_left hL m)⟩,
+    c.distinct,
+    c.divisibility⟩⟩
+
+-- Routine: For m ≥ 1, any covering assignment value is at least 2.
+theorem covering_ge_two {m L k : ℕ} (hm : 1 ≤ m) (c : PrimeCovering m L k) (i : Fin k) :
+    2 ≤ c.assignment i := by
+  have h := (c.in_interval i).1
+  omega
+
+end Erdos860Aristotle

--- a/proofs/Proofs/Stubs/Erdos900Aristotle.lean
+++ b/proofs/Proofs/Stubs/Erdos900Aristotle.lean
@@ -1,0 +1,77 @@
+/-
+  Aristotle targets for Erdős Problem #900
+  Routine supporting lemmas for automated proof search.
+  See Erdos900Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT aks_theorem (main result — open problem)
+  - NOT large_c_almost_hamiltonian (depends on undefined pathLengthFunction)
+  - NOT probHasProperty (definition sorry — Aristotle skips)
+  - Routine: path properties, graph connectivity basics, length calculations
+  - No definition sorries
+  - No axioms
+-/
+import Mathlib
+
+namespace Erdos900Aristotle
+
+open Finset Function
+
+/-- A simple graph on n vertices. -/
+abbrev Graph (n : ℕ) := SimpleGraph (Fin n)
+
+/-- A path in a graph: a list of distinct vertices with consecutive adjacency. -/
+def IsPath (G : Graph n) (vs : List (Fin n)) : Prop :=
+  vs.Nodup ∧ ∀ i : ℕ, i + 1 < vs.length →
+    G.Adj (vs.get ⟨i, by omega⟩) (vs.get ⟨i + 1, by omega⟩)
+
+/-- The length of a path is the number of edges (= vertices - 1). -/
+def pathLength (vs : List α) : ℕ := vs.length - 1
+
+/-- A graph has a path of length at least k. -/
+def HasPathOfLength (G : Graph n) (k : ℕ) : Prop :=
+  ∃ vs : List (Fin n), IsPath G vs ∧ pathLength vs ≥ k
+
+-- Routine: The empty list is a valid path in any graph.
+theorem isPath_nil (G : Graph n) : IsPath G [] := by
+  constructor
+  · exact List.nodup_nil
+  · intro i hi; simp at hi
+
+-- Routine: A single-vertex list is a valid path.
+theorem isPath_singleton (G : Graph n) (v : Fin n) : IsPath G [v] := by
+  constructor
+  · exact List.nodup_singleton v
+  · intro i hi; simp at hi
+
+-- Routine: The length of an empty path is 0.
+theorem pathLength_nil : pathLength ([] : List α) = 0 := by
+  simp [pathLength]
+
+-- Routine: The length of a singleton path is 0.
+theorem pathLength_singleton (v : α) : pathLength [v] = 0 := by
+  simp [pathLength]
+
+-- Routine: The length of a two-element list is 1.
+theorem pathLength_pair (u v : α) : pathLength [u, v] = 1 := by
+  simp [pathLength]
+
+-- Routine: Every graph has a path of length 0 (the empty path).
+theorem has_path_zero (G : Graph n) : HasPathOfLength G 0 :=
+  ⟨[], isPath_nil G, le_refl 0⟩
+
+-- Routine: pathLength is monotone with respect to list length.
+theorem pathLength_le_length (vs : List α) : pathLength vs ≤ vs.length := by
+  simp [pathLength]; omega
+
+-- Routine: If HasPathOfLength G k and k' ≤ k, then HasPathOfLength G k'.
+theorem has_path_mono (G : Graph n) {k k' : ℕ} (hk : k' ≤ k)
+    (h : HasPathOfLength G k) : HasPathOfLength G k' := by
+  obtain ⟨vs, hvs, hlen⟩ := h
+  exact ⟨vs, hvs, hk.trans hlen⟩
+
+-- Routine: A path of length 0 exists whenever the vertex type is nonempty.
+theorem has_path_zero_nonempty [Nonempty (Fin n)] (G : Graph n) : HasPathOfLength G 0 :=
+  has_path_zero G
+
+end Erdos900Aristotle


### PR DESCRIPTION
## Fix

Adds the two missing Aristotle companion files for the only Stubs that lacked them.

## Evidence

**Before**: `Erdos860Problem.lean` and `Erdos900Problem.lean` had no companion files (all other ~150 stubs have companions).

**After**:
- `Erdos860Aristotle.lean`: Extracts routine PrimeCovering structure properties and AdmitsCovering monotonicity/base cases, explicitly excluding the axiom-dependent `linear_lower_bound` and `subquadratic_upper_bound` sorries and the definition sorry in `h(n)`
- `Erdos900Aristotle.lean`: Extracts routine IsPath, pathLength, and HasPathOfLength lemmas, explicitly excluding the `aks_theorem` open conjecture and the `probHasProperty` definition sorry

**Pre-submission checklist**:
- [x] No `def ... := sorry`
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections
- [x] No open conjectures

---
Automated fix by lean-mechanic agent.