### PR TITLE
fix: correct leanFile.lineCount in 3 gallery meta.json files

### DIFF
--- a/src/data/proofs/divisibility-rules-oq-01-oq-01/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-01-oq-01/meta.json
@@ -99,7 +99,7 @@
       "id": "examples",
       "title": "Concrete Witnesses",
       "startLine": 73,
-      "endLine": 110,
+      "endLine": 108,
       "summary": "Six concrete examples (d = 3, 7, 11, 13, 37, 41) with optimal or near-optimal k.",
       "mathContext": "Each verified via native_decide."
     }
@@ -150,7 +150,7 @@
       "BigOperators"
     ],
     "namespace": "DivisibilityRulesOQ01OQ01",
-    "lineCount": 110,
+    "lineCount": 108,
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 0

--- a/src/data/proofs/ptolemys-complex-proof-oq-01/meta.json
+++ b/src/data/proofs/ptolemys-complex-proof-oq-01/meta.json
@@ -43,7 +43,7 @@
     ],
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
-    "lineCount": 136,
+    "lineCount": 135,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
   },
   "overview": {

--- a/src/data/proofs/subset-count-multiset-oq-01/meta.json
+++ b/src/data/proofs/subset-count-multiset-oq-01/meta.json
@@ -153,7 +153,7 @@
       "BigOperators"
     ],
     "namespace": "SubsetCountMultisetOQ01",
-    "lineCount": 224,
+    "lineCount": 226,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 2


### PR DESCRIPTION
## Fix

Correct `leanFile.lineCount` mismatches between the `leanFile` section and actual Lean source file lengths in 3 gallery entries.

## Evidence

| Proof | Field | Before | After | Actual Lines |
|-------|-------|--------|-------|-------------|
| `divisibility-rules-oq-01-oq-01` | `leanFile.lineCount` | 110 | 108 | 108 |
| `divisibility-rules-oq-01-oq-01` | section `examples.endLine` | 110 | 108 | 108 (phantom section boundary) |
| `subset-count-multiset-oq-01` | `leanFile.lineCount` | 224 | 226 | 226 |
| `ptolemys-complex-proof-oq-01` | `meta.lineCount` | 136 | 135 | 135 |

All three proofs had `meta.lineCount` and `leanFile.lineCount` inconsistencies. In each case, the corrected value matches the actual `wc -l` count of the corresponding `.lean` file.

The `divisibility-rules-oq-01-oq-01` fix also corrects a phantom section boundary (section `examples` claimed to extend to line 110, but the file ends at line 108).

---
Automated fix by lean-mechanic agent.