### PR TITLE
fix: correct lineCount in 2 recently-added gallery proofs

### DIFF
--- a/src/data/proofs/binary-gcd-oq-01-oq-04/meta.json
+++ b/src/data/proofs/binary-gcd-oq-01-oq-04/meta.json
@@ -20,7 +20,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 162,
+    "lineCount": 157,
     "dateAdded": "2026-04-04",
     "mathlibDependencies": [
       {
@@ -112,7 +112,7 @@
       "id": "verifications",
       "title": "Computational Verification",
       "startLine": 150,
-      "endLine": 160,
+      "endLine": 157,
       "summary": "native_decide confirms binaryGcdSteps 1 (2^n-1) = n for n=1,2,3,4,6,8 and log₂(2^4-1)=3, log₂(2^8-1)=7.",
       "mathContext": "Concrete numerical checks validating the theorem for small cases."
     }
@@ -141,7 +141,7 @@
     ],
     "opens": ["BinaryGcdOQ01", "Nat"],
     "namespace": "BinaryGcdOQ01OQ04",
-    "lineCount": 162,
+    "lineCount": 157,
     "axiomCount": 0,
     "theoremCount": 8,
     "substantiveTheoremCount": 5,

--- a/src/data/proofs/divisibility-rules-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-01-oq-01-oq-01/meta.json
@@ -60,7 +60,7 @@
     ],
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
-    "lineCount": 170,
+    "lineCount": 167,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
   },
   "overview": {
@@ -153,7 +153,7 @@
     ],
     "opens": [],
     "namespace": "DivisibilityRulesOQ01OQ01OQ01",
-    "lineCount": 170,
+    "lineCount": 167,
     "axiomCount": 0,
     "theoremCount": 10,
     "substantiveTheoremCount": 8,


### PR DESCRIPTION
## Fix

Correct inflated `lineCount` values in 2 gallery meta.json files that were added with incorrect counts.

## Evidence

| Proof | Field | Before | After |
|-------|-------|--------|-------|
| `binary-gcd-oq-01-oq-04` | `meta.lineCount` | 162 | 157 |
| `binary-gcd-oq-01-oq-04` | `leanFile.lineCount` | 162 | 157 |
| `binary-gcd-oq-01-oq-04` | "Computational Verification" section endLine | 160 | 157 |
| `divisibility-rules-oq-01-oq-01-oq-01` | `meta.lineCount` | 170 | 167 |
| `divisibility-rules-oq-01-oq-01-oq-01` | `leanFile.lineCount` | 170 | 167 |

**Before**: lineCount claims 162/170 lines
**After**: lineCount matches actual Lean source (157/167 lines respectively)

Build: pnpm build passes.

---
Automated fix by lean-mechanic agent.