### PR TITLE
fix: correct leanFile.lineCount in 8 gallery meta.json files

### DIFF
--- a/src/data/proofs/erdos-107/meta.json
+++ b/src/data/proofs/erdos-107/meta.json
@@ -62,7 +62,7 @@
       "HappyEndingConjecture as Prop (correctly open)"
     ],
     "leanFile": {
-      "lineCount": 285,
+      "lineCount": 516,
       "structureCount": 0,
       "axiomCount": 6,
       "theoremCount": 9,

--- a/src/data/proofs/erdos-1091/meta.json
+++ b/src/data/proofs/erdos-1091/meta.json
@@ -59,7 +59,7 @@
       "erdos_1091_summary: verified combined result"
     ],
     "leanFile": {
-      "lineCount": 208,
+      "lineCount": 195,
       "structureCount": 2,
       "axiomCount": 7,
       "theoremCount": 4,

--- a/src/data/proofs/furstenberg-correspondence-oq-02/meta.json
+++ b/src/data/proofs/furstenberg-correspondence-oq-02/meta.json
@@ -56,7 +56,7 @@
     ],
     "dateAdded": "2026-03-30",
     "leanFile": {
-      "lineCount": 290,
+      "lineCount": 413,
       "structures": 0,
       "axioms": 0,
       "theorems": 4,

--- a/src/data/proofs/napoleons-theorem/meta.json
+++ b/src/data/proofs/napoleons-theorem/meta.json
@@ -44,7 +44,7 @@
     ],
     "dateAdded": "2026-03-30",
     "leanFile": {
-      "lineCount": 310,
+      "lineCount": 354,
       "structures": 0,
       "axioms": 0,
       "theorems": 14,

--- a/src/data/proofs/pascals-hexagon/meta.json
+++ b/src/data/proofs/pascals-hexagon/meta.json
@@ -46,7 +46,7 @@
     ],
     "dateAdded": "2025-12-29",
     "leanFile": {
-      "lineCount": 581,
+      "lineCount": 712,
       "structures": 1,
       "axioms": 1,
       "theorems": 26,

--- a/src/data/proofs/picks-theorem-oq-03/meta.json
+++ b/src/data/proofs/picks-theorem-oq-03/meta.json
@@ -64,7 +64,7 @@
     ],
     "dateAdded": "2026-03-06",
     "leanFile": {
-      "lineCount": 437,
+      "lineCount": 710,
       "structures": 2,
       "axioms": 2,
       "theorems": 34,

--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -79,7 +79,7 @@
         "Pointwise"
       ],
       "namespace": "ShapleyFolkman",
-      "lineCount": 237,
+      "lineCount": 318,
       "axiomCount": 0,
       "theoremCount": 6,
       "definitionCount": 2

--- a/src/data/proofs/szemeredi-hypergraph-core-oq-01/meta.json
+++ b/src/data/proofs/szemeredi-hypergraph-core-oq-01/meta.json
@@ -41,7 +41,7 @@
     ],
     "dateAdded": "2026-04-04",
     "axiomCount": 1,
-    "lineCount": 280,
+    "lineCount": 267,
     "assumptions": "hypergraph_regularity_lemma (Gowers 2007, Rödl–Skokan 2004): the existence of a regular partition is stated as a sorry pending the full formalization."
   },
   "overview": {
@@ -130,7 +130,7 @@
     ],
     "opens": ["Classical"],
     "namespace": "Szemeredi.Hypergraph",
-    "lineCount": 280,
+    "lineCount": 267,
     "axiomCount": 1,
     "theoremCount": 10,
     "substantiveTheoremCount": 7,


### PR DESCRIPTION
## Fix

Corrects stale `leanFile.lineCount` values in 8 gallery meta.json files where the nested `leanFile.lineCount` diverged from the actual Lean source file line count.

## Evidence

| Proof | Field | Before | After | Actual |
|-------|-------|--------|-------|--------|
| picks-theorem-oq-03 | leanFile.lineCount | 437 | 710 | 710 |
| erdos-107 | leanFile.lineCount | 285 | 516 | 516 |
| pascals-hexagon | leanFile.lineCount | 581 | 712 | 712 |
| furstenberg-correspondence-oq-02 | leanFile.lineCount | 290 | 413 | 413 |
| shapley-folkman | leanFile.lineCount | 237 | 318 | 318 |
| napoleons-theorem | leanFile.lineCount | 310 | 354 | 354 |
| erdos-1091 | leanFile.lineCount | 208 | 195 | 195 |
| szemeredi-hypergraph-core-oq-01 | lineCount (both) | 280 | 267 | 267 |

In most cases the top-level `meta.lineCount` was already correct; only the nested `leanFile.lineCount` was stale (not updated when the Lean file grew).

---
Automated fix by lean-mechanic agent.