### PR TITLE
fix(erdos-1091): correct leanFile.axiomCount (7→4) and stale assumptions text

### DIFF
--- a/src/data/proofs/erdos-1091/meta.json
+++ b/src/data/proofs/erdos-1091/meta.json
@@ -61,7 +61,7 @@
     "leanFile": {
       "lineCount": 208,
       "structureCount": 2,
-      "axiomCount": 7,
+      "axiomCount": 4,
       "theoremCount": 4,
       "defCount": 8,
       "imports": [
@@ -74,7 +74,7 @@
     "dateAdded": "2026-01-26",
     "axiomCount": 4,
     "lineCount": 195,
-    "assumptions": "7 axioms: larson_one_diagonal, bollobas_erdos_conjecture, voss_two_diagonals, and 4 more. See Lean source for complete statements."
+    "assumptions": "4 axioms: voss_two_diagonals (Voss 1982 main result), pentagonal_wheel_K4_free, pentagonal_wheel_chi_4, pentagonal_wheel_max_2_diagonals. 0 sorries."
   },
   "overview": {
     "historicalContext": "Erdos Problem #1091 concerns the structure of odd cycles in graphs that are K4-free (contain no complete graph on 4 vertices) but have high chromatic number. The problem has its roots in the broader question of how clique-freeness constrains graph structure when the chromatic number is large.\n\nThe Bollobas-Erdos conjecture proposed that K4-free graphs without odd cycles having diagonals must have very restricted structure: they are bipartite, have a cut vertex, or have a low-degree vertex. Larson (1979) proved this conjecture and established that every K4-free graph with chi >= 4 must contain an odd cycle with at least one diagonal.\n\nVoss (1982) significantly strengthened Larson's result by proving that at least TWO diagonals are guaranteed. This answered the specific question of Problem #1091 affirmatively. The pentagonal wheel W5 (a 5-cycle with a central hub vertex) serves as an extremal counterexample: it is K4-free with chi = 4, but every odd cycle has at most 2 diagonals, showing that 3 diagonals cannot be universally guaranteed and making Voss's bound tight.\n\nThe problem connects to Mycielski's classical construction, which shows that triangle-free (and hence K4-free) graphs can have arbitrarily high chromatic number. The general open question asks whether there exists f(r) -> infinity such that graphs with chi >= 4 that are locally 3-colorable (every subgraph on <= r vertices has chi <= 3) must contain odd cycles with >= f(r) diagonals. This remains one of the open parts of the problem.",


### PR DESCRIPTION
## Fix

Corrects stale `leanFile.axiomCount` in `erdos-1091/meta.json` and updates the `assumptions` text to match the actual Lean source.

## Evidence

**Lean source** (`Erdos1091Problem.lean`) contains exactly 4 `axiom` declarations:
```
axiom voss_two_diagonals
axiom pentagonal_wheel_K4_free
axiom pentagonal_wheel_chi_4
axiom pentagonal_wheel_max_2_diagonals
```

**Before**:
- `leanFile.axiomCount`: 7 (wrong)
- `assumptions`: "7 axioms: larson_one_diagonal, bollobas_erdos_conjecture, voss_two_diagonals, and 4 more" (references non-existent axioms from a prior file version)

**After**:
- `leanFile.axiomCount`: 4 (matches actual)
- `assumptions`: correctly names the 4 actual axioms

Note: `meta.axiomCount` was already correct at 4.

---
Automated fix by lean-mechanic agent.