### PR TITLE
fix(erdos-1113): correct stale leanFile.axiomCount (9→1) and assumptions text

### DIFF
--- a/src/data/proofs/erdos-1113/meta.json
+++ b/src/data/proofs/erdos-1113/meta.json
@@ -62,7 +62,7 @@
     "leanFile": {
       "lineCount": 172,
       "structureCount": 0,
-      "axiomCount": 9,
+      "axiomCount": 1,
       "theoremCount": 5,
       "defCount": 14,
       "imports": [
@@ -74,7 +74,7 @@
     },
     "axiomCount": 1,
     "lineCount": 172,
-    "assumptions": "9 axioms: covering_set_implies_sierpinski, selfridge_78557, covering_78557, and 6 more. See Lean source for complete statements."
+    "assumptions": "1 axiom: `izotov_is_sierpinski` — Izotov (1995) proved that m = 734110615000775^4 is a Sierpinski number. The 8 axioms present in an earlier file version (covering_set_implies_sierpinski, selfridge_78557, covering_78557, and 5 others) have since been eliminated from the Lean source."
   },
   "overview": {
     "historicalContext": "In 1960, Waclaw Sierpinski proved a striking result: there exist infinitely many odd positive integers m such that 2^k * m + 1 is composite for every k >= 0. His proof relied on covering systems -- finite sets of primes whose modular periodicities 'cover' all residue classes of k, guaranteeing that some prime in the set always divides 2^k * m + 1. John Selfridge later identified 78557 as a Sierpinski number with covering set {3, 5, 7, 13, 19, 37, 73}, and it is conjectured (but not yet proven) to be the smallest Sierpinski number. The 'Seventeen or Bust' distributed computing project has been working since 2002 to verify this, reducing the candidates to just a few remaining values.\n\nErdos and Graham (1980) posed a deeper question: must every Sierpinski number have a finite covering set, or can Sierpinski numbers exist for 'non-periodic' reasons? This is Problem #1113 in the Erdos collection. The question probes whether covering systems are the only mechanism producing Sierpinski numbers, or whether other number-theoretic phenomena (such as the algebraic structure of perfect powers) can also force universal compositeness. The answer has profound implications: if ALL Sierpinski numbers have covering sets, then a classical argument shows infinitely many Fermat primes must exist -- a conclusion considered extremely unlikely given that only five Fermat primes ($F_0$ through $F_4$) are known.\n\nIn 1995, Izotov proposed the candidate $m = 734110615000775^4$, a Sierpinski number conjectured to have no finite covering set. Notably, this candidate is a perfect 4th power. This observation led Filaseta, Finch, and Kozek (2008) to formulate the FFK Conjecture: every Sierpinski number is either a perfect power ($m = n^k$ for some $k \\geq 2$) or has a finite covering set. This elegant refinement suggests that uncovered Sierpinski numbers, if they exist, must arise from the multiplicative structure of perfect powers rather than from arbitrary number-theoretic coincidences.\n\nThe connection to Fermat primes provides the strongest indirect evidence that uncovered Sierpinski numbers exist. Setting $m = 1$ in the Sierpinski sequence gives $2^k + 1$, whose prime values are exactly the Fermat primes. If every Sierpinski number has a covering set, then covering-system arguments can be bootstrapped to show infinitely many Fermat primes exist. Since $F_5 = 4294967297 = 641 \\times 6700417$ is composite and no Fermat prime beyond $F_4 = 65537$ has been found, the mathematical community strongly suspects that only finitely many Fermat primes exist -- making the affirmative answer to Problem #1113 highly likely.",


### PR DESCRIPTION
## Fix

Corrects stale `leanFile.axiomCount` in `erdos-1113/meta.json` and updates the `assumptions` text to match the actual Lean source.

## Evidence

**Lean source** (`Erdos1113Problem.lean`) contains exactly **1** `axiom` declaration:
```lean
axiom izotov_is_sierpinski : IsSierpinskiNumber izotovCandidate
```

**Before**:
- `leanFile.axiomCount`: 9 (wrong — from an earlier file version with 8 additional axioms)
- `assumptions`: "9 axioms: covering_set_implies_sierpinski, selfridge_78557, covering_78557, and 6 more..." (stale)

**After**:
- `leanFile.axiomCount`: 1 (matches actual bare axiom count)
- `assumptions`: describes the single remaining axiom accurately

Note: `meta.axiomCount` was already correct at 1.

---
Automated fix by lean-mechanic agent.