### PR TITLE
fix(picks-theorem-oq-03): correct stale meta.lineCount and root leanFile.lineCount (437→710)

### DIFF
--- a/src/data/proofs/picks-theorem-oq-03/meta.json
+++ b/src/data/proofs/picks-theorem-oq-03/meta.json
@@ -83,7 +83,7 @@
       }
     ],
     "axiomCount": 2,
-    "lineCount": 437,
+    "lineCount": 710,
     "assumptions": "2 axioms: ehrhart_is_polynomial (Ehrhart counting function is polynomial), ehrhart_macdonald_reciprocity (interior count via sign-change).",
     "mathlib_version": "4.26.0"
   },
@@ -243,7 +243,7 @@
     ],
     "opens": [],
     "namespace": "EhrhartPolynomial",
-    "lineCount": 437,
+    "lineCount": 710,
     "axiomCount": 2,
     "theoremCount": 45,
     "definitionCount": 21


### PR DESCRIPTION
## Fix

Corrects two stale `lineCount` values in `picks-theorem-oq-03/meta.json`.

## Evidence

The Lean source `EhrhartPolynomialOQ03.lean` (which `proofRepoPath` points to) has **710 lines**:

| Field | Before | After | Actual |
|-------|--------|-------|--------|
| `meta.lineCount` | 437 | 710 | 710 |
| root `leanFile.lineCount` | 437 | 710 | 710 |

The nested `meta.leanFile.lineCount` was already correct at 710 (corrected by a prior PR).

The stale values of 437 appear to have been introduced by PR #9714 which incorrectly set `picks-theorem-oq-03` to 437 when the actual file has 710 lines.

---
Automated fix by lean-mechanic agent.