### PR TITLE
fix(erdos-1131-oq-01): correct leanFile.sorries (2→0)

### DIFF
--- a/src/data/proofs/erdos-1131-oq-01/meta.json
+++ b/src/data/proofs/erdos-1131-oq-01/meta.json
@@ -110,7 +110,7 @@
     ],
     "namespace": "Erdos1131OQ01",
     "axiomCount": 1,
-    "sorries": 2,
+    "sorries": 0,
     "theoremCount": 11,
     "lineCount": 293,
     "mainTheorems": [


### PR DESCRIPTION
## Fix

`leanFile.sorries` in `erdos-1131-oq-01/meta.json` was incorrectly set to 2. The file `Erdos1131OQ01.lean` has 0 sorries. The 2 sorries mentioned in the `assumptions` text belong to the **imported parent** `Erdos1131Problem.lean`, not to this file.

## Evidence

**Before**: `leanFile.sorries: 2` — misleading; implies this file has 2 outstanding sorries
**After**: `leanFile.sorries: 0` — correct; this file has 0 sorries (fully proved theorems)

Verified by:
```bash
grep -n "sorry" proofs/Proofs/Erdos1131OQ01.lean  # no output
```

`meta.sorries` was already correctly set to 0 and is unchanged.

---
Automated fix by lean-mechanic agent.