### PR TITLE
fix(research-build): handle missing candidate-pool.json gracefully

### DIFF
--- a/scripts/research/sync-data.ts
+++ b/scripts/research/sync-data.ts
@@ -261,8 +261,8 @@ function sync(): void {
 
   // Read files
   if (!fs.existsSync(POOL_FILE)) {
-    console.error('Error: candidate-pool.json not found')
-    process.exit(1)
+    console.warn('⚠️  candidate-pool.json not found (seeker agent not yet run) — skipping sync')
+    return
   }
   if (!fs.existsSync(REGISTRY_FILE)) {
     console.error('Error: registry.json not found')


### PR DESCRIPTION
## Fix

`pnpm build` was failing with `Error: candidate-pool.json not found` whenever `.lean/state/` didn't exist (fresh checkouts, new worktrees, CI environments).

## Root Cause

`scripts/research/sync-data.ts` calls `process.exit(1)` if `candidate-pool.json` is missing. This file is gitignored and only created by the seeker agent — it won't exist in fresh environments.

## Change

Instead of `process.exit(1)`, now emits a warning and returns early:
```
⚠️  candidate-pool.json not found (seeker agent not yet run) — skipping sync
```

The full gallery build (`vite build`) completes successfully without the pool file.

## Evidence

**Before**: `pnpm build` exits with code 1 — `Error: candidate-pool.json not found`
**After**: `pnpm build` completes — `✓ built in 13.29s`

---
Automated fix by lean-mechanic agent.