### PR TITLE
fix: correct lineCount in 2 borsuk-ulam gallery meta.json files

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 8,
-    "lineCount": 155,
+    "lineCount": 212,
     "dateAdded": "2026-04-04",
     "mathlibDependencies": [
       {
@@ -134,7 +134,7 @@
     ],
     "opens": ["BorsukUlamOQ02OQ01", "Nat"],
     "namespace": "BorsukUlamNonCyclic",
-    "lineCount": 155,
+    "lineCount": 212,
     "axiomCount": 8,
     "theoremCount": 14,
     "substantiveTheoremCount": 10,

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01/meta.json
@@ -17,7 +17,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 4,
-    "lineCount": 146,
+    "lineCount": 144,
     "assumptions": "buDim function, classical BU (Z/2), Yang-Borsuk (Z/p prime), monotonicity, open conjecture for composite groups.",
     "originalContributions": [
       "Abstract buDim framework for cyclic group BU dimensions",
@@ -110,7 +110,7 @@
     ],
     "opens": [],
     "namespace": "BorsukUlamOQ02OQ01",
-    "lineCount": 146,
+    "lineCount": 144,
     "axiomCount": 4,
     "theoremCount": 6,
     "definitionCount": 0

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01/meta.json
@@ -57,7 +57,7 @@
       "id": "open-question",
       "title": "The Open Question",
       "startLine": 123,
-      "endLine": 146,
+      "endLine": 144,
       "summary": "States the central open question: does buDim(n, d) always equal the maximum over prime factor bounds? Formulates this as an axiom using Nat.primeFactors.",
       "mathContext": "If true, composite group structure adds no extra topological obstruction beyond what prime subgroups provide. The resolution requires Fadell-Husseini index theory and representation-theoretic analysis."
     }


### PR DESCRIPTION
## Fix

Two `lineCount` fields are stale in recently-added Borsuk-Ulam gallery entries.

## Evidence

| Proof | Before | After | Source |
|-------|--------|-------|--------|
| borsuk-ulam-oq-02-oq-01-oq-03 | 155 | 212 | `wc -l proofs/Proofs/BorsukUlamOQ02OQ01OQ03.lean` |
| borsuk-ulam-oq-02-oq-01 | 146 | 144 | `wc -l proofs/Proofs/BorsukUlamOQ02OQ01.lean` |

Both `meta.lineCount` and `leanFile.lineCount` updated in each file.

---
Automated fix by lean-mechanic agent.