### PR TITLE
fix(borsuk-ulam-oq-02-oq-01): correct stale lineCount (146→144)

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01/meta.json
@@ -17,7 +17,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 4,
-    "lineCount": 146,
+    "lineCount": 144,
     "assumptions": "buDim function, classical BU (Z/2), Yang-Borsuk (Z/p prime), monotonicity, open conjecture for composite groups.",
     "originalContributions": [
       "Abstract buDim framework for cyclic group BU dimensions",
@@ -110,7 +110,7 @@
     ],
     "opens": [],
     "namespace": "BorsukUlamOQ02OQ01",
-    "lineCount": 146,
+    "lineCount": 144,
     "axiomCount": 4,
     "theoremCount": 6,
     "definitionCount": 0


### PR DESCRIPTION
## Fix

`BorsukUlamOQ02OQ01.lean` was recently modified (see commit history), shrinking the file by 2 lines. Both `lineCount` fields in `meta.json` were not updated.

## Evidence

**Before**: `"lineCount": 146` (both in `meta` and `leanFile` sections)
**After**: `"lineCount": 144` (matches actual file: `wc -l` → 144 lines)

---
Automated fix by lean-mechanic agent.