### PR TITLE
fix(erdos-1017): correct stale proofRepoPath and lineCount (1→696)

### DIFF
--- a/src/data/proofs/erdos-1017/meta.json
+++ b/src/data/proofs/erdos-1017/meta.json
@@ -8,7 +8,7 @@
     "sourceUrl": "https://erdosproblems.com/1017",
     "date": "1966",
     "status": "axiomatized",
-    "proofRepoPath": "Proofs/Erdos1017Problem.lean",
+    "proofRepoPath": "Proofs/Erdos1017OQ01.lean",
     "tags": [
       "graph-theory",
       "extremal-combinatorics",
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "open",
     "relatedProblems": [],
     "axiomCount": 3,
-    "lineCount": 1,
+    "lineCount": 696,
     "assumptions": "3 axioms inherited from Erdos1017OQ01.lean: egp_theorem (Erdős-Gallai-type partitioning theorem), gyori_keszegh_triangles (Győri-Keszegh triangle counting result), k4free_partition_number (K₄-free partition number bound). 0 own axioms. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
@@ -187,7 +187,7 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 1,
+    "lineCount": 696,
     "axiomCount": 0,
     "theoremCount": 0,
     "definitionCount": 0


### PR DESCRIPTION
## Fix

`erdos-1017/meta.json` references `Erdos1017Problem.lean`, which was refactored into a 1-line import stub after the proof content was moved to `Erdos1017OQ01.lean`. This caused all 5 sections to claim line ranges that far exceed the 1-line file.

## Evidence

**Before**:
- `meta.proofRepoPath: Proofs/Erdos1017Problem.lean` (1-line file: `import Proofs.Erdos1017OQ01`)
- `meta.lineCount: 1` / `leanFile.lineCount: 1`
- Sections reference lines 65–696 (all beyond end-of-file)

**After**:
- `meta.proofRepoPath: Proofs/Erdos1017OQ01.lean` (696-line file with the actual proof)
- `meta.lineCount: 696` / `leanFile.lineCount: 696`
- Sections 65–696 are now valid

Verified: `wc -l proofs/Proofs/Erdos1017OQ01.lean` → 696

---
Automated fix by lean-mechanic agent.