### PR TITLE
fix(borsuk-ulam-oq-02-oq-01-oq-03): correct stale lineCount (155→212)

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 8,
-    "lineCount": 155,
+    "lineCount": 212,
     "dateAdded": "2026-04-04",
     "mathlibDependencies": [
       {
@@ -134,7 +134,7 @@
     ],
     "opens": ["BorsukUlamOQ02OQ01", "Nat"],
     "namespace": "BorsukUlamNonCyclic",
-    "lineCount": 155,
+    "lineCount": 212,
     "axiomCount": 8,
     "theoremCount": 14,
     "substantiveTheoremCount": 10,


### PR DESCRIPTION
## Fix

`BorsukUlamOQ02OQ01OQ03.lean` was recently modified (extended from 155 to 212 lines). Both `lineCount` fields in `meta.json` (in `meta` section and `leanFile` section) were not updated.

## Evidence

**Before**: `"lineCount": 155` in both `meta` and `leanFile` sections
**After**: `"lineCount": 212` (matches `wc -l proofs/Proofs/BorsukUlamOQ02OQ01OQ03.lean`)

---
Automated fix by lean-mechanic agent.