### PR TITLE
fix(erdos-468): correct section question-2 line range (57-100 → 46-56)

### DIFF
--- a/src/data/proofs/erdos-468/meta.json
+++ b/src/data/proofs/erdos-468/meta.json
@@ -115,8 +115,8 @@
     {
       "id": "question-2",
       "title": "Question 2: First Appearance Function",
-      "startLine": 57,
-      "endLine": 100,
+      "startLine": 46,
+      "endLine": 56,
       "summary": "Defines firstAppearance f(N) = sInf{n : N ∈ D_n}, states the main conjecture f(N) = o(N), the almost-all weakening, and concrete examples D_6 and D_12.",
       "mathContext": "Main conjecture: $f(N) = o(N)$, i.e., $\\forall \\varepsilon > 0,\\; \\exists N_0,\\; \\forall N \\geq N_0: f(N)/N < \\varepsilon$. Boundary: $\\min(D_n) = \\text{minFac}(n)$, $\\max(D_n) = \\sigma(n) - 1$. Examples: $D_6 = \\{2, 5, 11\\}$ (divisors $> 1$: 2, 3, 6), $D_{12} = \\{2, 5, 9, 15, 27\\}$ (divisors $> 1$: 2, 3, 4, 6, 12)."
     }


### PR DESCRIPTION
## Fix

Section `question-2` in `erdos-468/meta.json` claimed `startLine=57, endLine=100`, but the file only has 56 lines. The `firstAppearance` definition starts at line 46.

## Evidence

**Before**: section `question-2` → `startLine: 57, endLine: 100`
- File has only 56 lines (both out of bounds)

**After**: section `question-2` → `startLine: 46, endLine: 56`
- Line 46: `/- ## Question 2: The f(N) Function -/` comment
- Lines 49-50: `firstAppearance` definition
- Line 56: last line of file

---
Automated fix by lean-mechanic agent.