### PR TITLE
fix(szemeredi-hypergraph-core-oq-01): correct axiomCount (1→0)

### DIFF
--- a/src/data/proofs/szemeredi-hypergraph-core-oq-01/meta.json
+++ b/src/data/proofs/szemeredi-hypergraph-core-oq-01/meta.json
@@ -40,7 +40,7 @@
       "Basic properties: relativeDensity_nonneg, relativeDensity_le_one, isGowersRegular_empty"
     ],
     "dateAdded": "2026-04-04",
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 267,
     "assumptions": "hypergraph_regularity_lemma (Gowers 2007, Rödl–Skokan 2004): the existence of a regular partition is stated as a sorry pending the full formalization."
   },
@@ -131,7 +131,7 @@
     "opens": ["Classical"],
     "namespace": "Szemeredi.Hypergraph",
     "lineCount": 267,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 10,
     "substantiveTheoremCount": 7,
     "duplicateTheorems": 0,


### PR DESCRIPTION
## Fix

`axiomCount` was 1 but the file has 0 axiom declarations.

## Evidence

**File**: `proofs/Proofs/SzemerediHypergraphCoreOQ01.lean`
**Explicit `axiom` declarations**: 0 (verified via grep + comment stripping)
**Actual sorry count**: 1 (`hypergraph_regularity_lemma`)

The `sorries: 1` field correctly accounts for the unproven theorem. Per the Axiom Integrity Policy, `axiomCount` tracks `axiom` declarations and structure-encoded assumptions — not sorries. The sorry was being double-counted as an axiom.

| Field | Before | After |
|-------|--------|-------|
| `meta.axiomCount` | 1 | 0 |
| `leanFile.axiomCount` | 1 | 0 |

---
Automated fix by lean-mechanic agent.