### PR TITLE
fix(gallery): register 9 new proofs in listings and sync leanFile metadata

### DIFF
--- a/src/data/proofs/listings.json
+++ b/src/data/proofs/listings.json
@@ -122,7 +122,7 @@
     "dateAdded": "2026-04-02",
     "mathlibCount": 4,
     "sorries": 0,
-    "annotationCount": 6
+    "annotationCount": 7
   },
   {
     "id": "abel-ruffini-oq-04-oq-03",
@@ -488,7 +488,7 @@
     "dateAdded": "2026-03-30",
     "mathlibCount": 3,
     "sorries": 0,
-    "annotationCount": 6
+    "annotationCount": 7
   },
   {
     "id": "angle-trisection-oq-02-oq-02",
@@ -832,7 +832,7 @@
     "dateAdded": "2026-04-04",
     "mathlibCount": 8,
     "sorries": 0,
-    "annotationCount": 13
+    "annotationCount": 16
   },
   {
     "id": "area-of-circle-oq-01-oq-03",
@@ -1900,6 +1900,26 @@
     "annotationCount": 7
   },
   {
+    "id": "binary-gcd-oq-01-oq-04",
+    "title": "Binary GCD Tight Lower Bound: The Family (1, 2^n - 1) Takes Exactly n Steps",
+    "slug": "binary-gcd-oq-01-oq-04",
+    "description": "Proves the tight lower bound for Binary GCD: the family (1, 2^n - 1) achieves exactly n steps, showing the O(log b) upper bound is asymptotically tight. The key identity binaryGcdSteps 1 (2^n - 1) = n is proved by induction using a one-step lemma for odd inputs.",
+    "status": "verified",
+    "badge": "original",
+    "tags": [
+      "algorithms",
+      "number-theory",
+      "gcd",
+      "complexity",
+      "tight-bounds",
+      "intermediate"
+    ],
+    "dateAdded": "2026-04-04",
+    "mathlibCount": 5,
+    "sorries": 0,
+    "annotationCount": 7
+  },
+  {
     "id": "binomial-theorem",
     "title": "The Binomial Theorem",
     "slug": "binomial-theorem",
@@ -2171,7 +2191,7 @@
     "dateAdded": "2026-03-30",
     "mathlibCount": 1,
     "sorries": 0,
-    "annotationCount": 4
+    "annotationCount": 5
   },
   {
     "id": "birch-swinnerton-dyer",
@@ -2384,6 +2404,26 @@
     ],
     "sorries": 0,
     "annotationCount": 6
+  },
+  {
+    "id": "borsuk-ulam-oq-02-oq-01-oq-03",
+    "title": "Borsuk-Ulam for Non-Cyclic Groups: Dihedral and Symmetric Lower Bounds",
+    "slug": "borsuk-ulam-oq-02-oq-01-oq-03",
+    "description": "Extends the equivariant Borsuk-Ulam dimension framework from cyclic groups Z/n to dihedral groups D_n and symmetric groups S_n. Lower bounds follow from prime subgroup structure: D_n contains Z/2 and Z/p for odd primes p|n; S_n contains Z/p for all primes p≤n. Axiomatized with 0 sorries.",
+    "status": "axiomatized",
+    "badge": "axiom",
+    "tags": [
+      "topology",
+      "borsuk-ulam",
+      "equivariant",
+      "dihedral-groups",
+      "symmetric-groups",
+      "advanced"
+    ],
+    "dateAdded": "2026-04-04",
+    "mathlibCount": 4,
+    "sorries": 0,
+    "annotationCount": 0
   },
   {
     "id": "borsuk-ulam-oq-02-oq-01-oq-04",
@@ -6366,6 +6406,26 @@
     "annotationCount": 9
   },
   {
+    "id": "divisibility-by-three-oq-02-oq-01",
+    "title": "Repunit Divisibility: Complete Order-of-10 Characterization",
+    "slug": "divisibility-by-three-oq-02-oq-01",
+    "description": "A complete biconditional for repunit divisibility: d ∣ R(k) if and only if the multiplicative order of 10 modulo d divides k, provided gcd(d,9)=1. Proves the open question from DivisibilityByThreeOQ02 via a clean ZMod ring identity.",
+    "status": "verified",
+    "badge": "original",
+    "tags": [
+      "number-theory",
+      "modular-arithmetic",
+      "divisibility",
+      "repunit",
+      "order-theory",
+      "intermediate"
+    ],
+    "dateAdded": "2026-04-04",
+    "mathlibCount": 3,
+    "sorries": 0,
+    "annotationCount": 5
+  },
+  {
     "id": "divisibility-rules",
     "title": "Divisibility Rules: A Comprehensive Formal Collection",
     "slug": "divisibility-rules",
@@ -6398,6 +6458,46 @@
       "extensions"
     ],
     "dateAdded": "2026-04-04",
+    "sorries": 0,
+    "annotationCount": 7
+  },
+  {
+    "id": "divisibility-rules-oq-01-oq-01",
+    "title": "General Divisibility Rule Existence for Any d Coprime to 10",
+    "slug": "divisibility-rules-oq-01-oq-01",
+    "description": "Proves that for every d > 1 coprime to 10, there exists k > 0 such that d ∣ n ↔ d ∣ (sum of digits of n in base 10^k). The witness k = φ(d) is given by Euler's theorem: 10^φ(d) ≡ 1 (mod d). This generalizes the parent proof's specific divisibility rules (d = 3, 9, 11, 37, ...) to all d coprime to 10.",
+    "status": "verified",
+    "badge": "original",
+    "tags": [
+      "number-theory",
+      "divisibility",
+      "modular-arithmetic",
+      "Euler-theorem",
+      "generalization",
+      "open-question"
+    ],
+    "dateAdded": "2026-04-04",
+    "mathlibCount": 4,
+    "sorries": 0,
+    "annotationCount": 5
+  },
+  {
+    "id": "divisibility-rules-oq-01-oq-01-oq-01",
+    "title": "Minimal Period for Digit-Block Divisibility Rules: orderOf Characterization",
+    "slug": "divisibility-rules-oq-01-oq-01-oq-01",
+    "description": "The digit-block divisibility rule d ∣ n ↔ d ∣ sum_of_k_digit_blocks(n) holds for period k if and only if 10^k ≡ 1 (mod d) if and only if orderOf(10 : ZMod d) ∣ k. The minimal positive period is exactly orderOf(10 : ZMod d). Generalizes to any base b with gcd(d,b)=1.",
+    "status": "verified",
+    "badge": "original",
+    "tags": [
+      "number-theory",
+      "divisibility",
+      "modular-arithmetic",
+      "order-theory",
+      "digit-rules",
+      "intermediate"
+    ],
+    "dateAdded": "2026-04-04",
+    "mathlibCount": 6,
     "sorries": 0,
     "annotationCount": 7
   },
@@ -6751,7 +6851,7 @@
     ],
     "dateAdded": "2026-03-30",
     "sorries": 1,
-    "annotationCount": 4
+    "annotationCount": 8
   },
   {
     "id": "erdos-1-oq-03",
@@ -6844,7 +6944,7 @@
     ],
     "dateAdded": "2026-03-30",
     "sorries": 2,
-    "annotationCount": 4
+    "annotationCount": 5
   },
   {
     "id": "erdos-100-oq-02",
@@ -8750,7 +8850,7 @@
     "erdosNumber": 1059,
     "mathlibCount": 4,
     "sorries": 0,
-    "annotationCount": 4
+    "annotationCount": 5
   },
   {
     "id": "erdos-1059-oq-05",
@@ -10884,7 +10984,7 @@
     "erdosNumber": 114,
     "mathlibCount": 3,
     "sorries": 0,
-    "annotationCount": 14
+    "annotationCount": 11
   },
   {
     "id": "erdos-114-oq-01",
@@ -12688,7 +12788,7 @@
     ],
     "erdosNumber": 152,
     "sorries": 0,
-    "annotationCount": 5
+    "annotationCount": 6
   },
   {
     "id": "erdos-153",
@@ -16272,7 +16372,7 @@
     ],
     "dateAdded": "2026-03-30",
     "sorries": 0,
-    "annotationCount": 6
+    "annotationCount": 7
   },
   {
     "id": "erdos-308",
@@ -32049,6 +32149,25 @@
     "annotationCount": 7
   },
   {
+    "id": "euler-identity-oq-01-oq-01",
+    "title": "Axiom-Free Euler's Identity via Taylor Series",
+    "slug": "euler-identity-oq-01-oq-01",
+    "description": "Eliminates all 3 axioms from the Taylor-series proof of Euler's identity by proving tsum_even_add_odd, cos_eq_tsum, and sin_eq_tsum as theorems from Mathlib, yielding a fully axiom-free, sorry-free formalization.",
+    "status": "verified",
+    "badge": "original",
+    "tags": [
+      "analysis",
+      "complex-analysis",
+      "taylor-series",
+      "euler-formula",
+      "axiom-elimination"
+    ],
+    "dateAdded": "2026-04-04",
+    "mathlibCount": 5,
+    "sorries": 0,
+    "annotationCount": 8
+  },
+  {
     "id": "euler-polyhedral-formula",
     "title": "Euler's Polyhedral Formula",
     "slug": "euler-polyhedral-formula",
@@ -32121,7 +32240,7 @@
       "coloring"
     ],
     "sorries": 0,
-    "annotationCount": 4
+    "annotationCount": 5
   },
   {
     "id": "euler-polyhedral-formula-oq-02",
@@ -32257,7 +32376,7 @@
     "dateAdded": "2026-03-30",
     "mathlibCount": 3,
     "sorries": 0,
-    "annotationCount": 7
+    "annotationCount": 11
   },
   {
     "id": "factor-remainder-nullstellensatz-oq-01",
@@ -32759,7 +32878,7 @@
     ],
     "dateAdded": "2026-03-30",
     "sorries": 0,
-    "annotationCount": 4
+    "annotationCount": 5
   },
   {
     "id": "friendship-theorem",
@@ -32859,7 +32978,7 @@
     ],
     "dateAdded": "2026-03-30",
     "sorries": 0,
-    "annotationCount": 4
+    "annotationCount": 5
   },
   {
     "id": "fundamental-arithmetic-oq-02",
@@ -33360,7 +33479,7 @@
     "dateAdded": "2026-04-04",
     "mathlibCount": 5,
     "sorries": 0,
-    "annotationCount": 11
+    "annotationCount": 9
   },
   {
     "id": "greens-theorem-oq-03",
@@ -33475,7 +33594,7 @@
       "logarithmic"
     ],
     "sorries": 0,
-    "annotationCount": 4
+    "annotationCount": 5
   },
   {
     "id": "harmonic-divergence-oq-04",
@@ -33935,7 +34054,7 @@
     ],
     "dateAdded": "2026-03-30",
     "sorries": 0,
-    "annotationCount": 4
+    "annotationCount": 5
   },
   {
     "id": "hilbert-23",
@@ -34305,7 +34424,7 @@
     ],
     "dateAdded": "2026-03-30",
     "sorries": 0,
-    "annotationCount": 4
+    "annotationCount": 5
   },
   {
     "id": "inverse-galois",
@@ -34944,7 +35063,7 @@
     ],
     "dateAdded": "2026-03-30",
     "sorries": 0,
-    "annotationCount": 4
+    "annotationCount": 5
   },
   {
     "id": "laws-of-large-numbers",
@@ -35087,7 +35206,7 @@
     ],
     "dateAdded": "2026-03-30",
     "sorries": 0,
-    "annotationCount": 4
+    "annotationCount": 5
   },
   {
     "id": "legendre-partial",
@@ -35323,7 +35442,7 @@
     "dateAdded": "2026-03-30",
     "mathlibCount": 2,
     "sorries": 0,
-    "annotationCount": 4
+    "annotationCount": 5
   },
   {
     "id": "mean-value-theorem-oq-03",
@@ -35863,8 +35982,8 @@
     "title": "Pell Equation: Size of the Fundamental Solution",
     "slug": "pell-equation-oq-01",
     "description": "Investigation of the Pell regulator R(D) = log(x₁ + y₁√D) for the fundamental solution to x² - Dy² = 1. States the heuristic conjecture R(D) = O(√D log D), proves basic bounds, and formalizes connections to class numbers and computational complexity.",
-    "status": "verified",
-    "badge": "mathlib",
+    "status": "axiomatized",
+    "badge": "axiom",
     "tags": [
       "number-theory",
       "diophantine-equations",
@@ -36344,7 +36463,26 @@
     "dateAdded": "2026-03-30",
     "mathlibCount": 2,
     "sorries": 0,
-    "annotationCount": 7
+    "annotationCount": 9
+  },
+  {
+    "id": "ptolemys-complex-proof-oq-01",
+    "title": "Ptolemy's Equality: Complete Characterization via Same Ray",
+    "slug": "ptolemys-complex-proof-oq-01",
+    "description": "Ptolemy's equality holds for four complex numbers if and only if the two opposite-side products lie on the same ray in ℂ (as ℝ-module): they are zero or positively proportional. This completes the biconditional characterization begun in PtolemysComplexProof.lean.",
+    "status": "verified",
+    "badge": "original",
+    "tags": [
+      "geometry",
+      "complex-analysis",
+      "ptolemy",
+      "strictly-convex-spaces",
+      "intermediate"
+    ],
+    "dateAdded": "2026-04-04",
+    "mathlibCount": 3,
+    "sorries": 0,
+    "annotationCount": 0
   },
   {
     "id": "ptolemys-theorem",
@@ -37262,7 +37400,7 @@
     ],
     "dateAdded": "2026-03-28",
     "sorries": 0,
-    "annotationCount": 4
+    "annotationCount": 7
   },
   {
     "id": "sophie-germain",
@@ -37573,6 +37711,26 @@
     "mathlibCount": 2,
     "sorries": 0,
     "annotationCount": 5
+  },
+  {
+    "id": "subset-count-multiset-oq-01",
+    "title": "Distinct Submultiset Count: ∏(mᵢ + 1)",
+    "slug": "subset-count-multiset-oq-01",
+    "description": "Formalizes the distinct submultiset count formula: the number of distinct submultisets of a multiset s equals ∏ᵢ(mᵢ + 1), where mᵢ is the multiplicity of the i-th distinct element. Proved via an explicit bijection with a product of finite sets.",
+    "status": "verified",
+    "badge": "original",
+    "tags": [
+      "combinatorics",
+      "multiset",
+      "counting",
+      "distinct-submultisets",
+      "bijection",
+      "open-question"
+    ],
+    "dateAdded": "2026-04-04",
+    "mathlibCount": 4,
+    "sorries": 0,
+    "annotationCount": 6
   },
   {
     "id": "subset-count-oq-02",
@@ -37893,6 +38051,26 @@
     "dateAdded": "2026-03-30",
     "mathlibCount": 3,
     "sorries": 0,
+    "annotationCount": 5
+  },
+  {
+    "id": "szemeredi-hypergraph-core-oq-01",
+    "title": "Simplicial Complex Infrastructure for Gowers Hypergraph Regularity",
+    "slug": "szemeredi-hypergraph-core-oq-01",
+    "description": "Defines SimplicialComplex, CompleteKLinks, relativeDensity, and IsGowersRegular — the core structures for Gowers (2007) hypergraph regularity. Fills the infrastructure gap in SzemerediHypergraphCore.lean and opens the path to formalizing the multidimensional Szemerédi theorem.",
+    "status": "axiomatized",
+    "badge": "axiom",
+    "tags": [
+      "combinatorics",
+      "szemeredi",
+      "hypergraph-theory",
+      "regularity",
+      "simplicial-complexes",
+      "advanced"
+    ],
+    "dateAdded": "2026-04-04",
+    "mathlibCount": 2,
+    "sorries": 1,
     "annotationCount": 5
   },
   {

--- a/src/data/research/problems/binary-gcd-oq-01-oq-01.json
+++ b/src/data/research/problems/binary-gcd-oq-01-oq-01.json
@@ -44,7 +44,8 @@
   ],
   "relatedProofs": [
     "binary-gcd",
-    "binary-gcd-oq-01"
+    "binary-gcd-oq-01",
+    "binary-gcd-oq-01-oq-04"
   ],
   "references": {
     "papers": [],
@@ -66,6 +67,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ01.lean"
+    },
+    {
+      "path": "Proofs/BinaryGcdOQ01OQ04.lean",
+      "filename": "BinaryGcdOQ01OQ04.lean",
+      "lineCount": 158,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ01OQ04.lean"
     }
   ]
 }

--- a/src/data/research/problems/binary-gcd-oq-01-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-01-oq-02.json
@@ -55,7 +55,8 @@
   ],
   "relatedProofs": [
     "binary-gcd",
-    "binary-gcd-oq-01"
+    "binary-gcd-oq-01",
+    "binary-gcd-oq-01-oq-04"
   ],
   "references": {
     "papers": [],
@@ -77,6 +78,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ01.lean"
+    },
+    {
+      "path": "Proofs/BinaryGcdOQ01OQ04.lean",
+      "filename": "BinaryGcdOQ01OQ04.lean",
+      "lineCount": 158,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ01OQ04.lean"
     }
   ]
 }

--- a/src/data/research/problems/binary-gcd-oq-01-oq-03.json
+++ b/src/data/research/problems/binary-gcd-oq-01-oq-03.json
@@ -42,7 +42,8 @@
   ],
   "relatedProofs": [
     "binary-gcd",
-    "binary-gcd-oq-01"
+    "binary-gcd-oq-01",
+    "binary-gcd-oq-01-oq-04"
   ],
   "references": {
     "papers": [],
@@ -64,6 +65,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ01.lean"
+    },
+    {
+      "path": "Proofs/BinaryGcdOQ01OQ04.lean",
+      "filename": "BinaryGcdOQ01OQ04.lean",
+      "lineCount": 158,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ01OQ04.lean"
     }
   ]
 }

--- a/src/data/research/problems/binary-gcd-oq-01.json
+++ b/src/data/research/problems/binary-gcd-oq-01.json
@@ -58,7 +58,8 @@
   "tags": [],
   "relatedProofs": [
     "binary-gcd",
-    "binary-gcd-oq-01"
+    "binary-gcd-oq-01",
+    "binary-gcd-oq-01-oq-04"
   ],
   "references": {
     "papers": [],
@@ -78,6 +79,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ01.lean"
+    },
+    {
+      "path": "Proofs/BinaryGcdOQ01OQ04.lean",
+      "filename": "BinaryGcdOQ01OQ04.lean",
+      "lineCount": 158,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ01OQ04.lean"
     }
   ]
 }

--- a/src/data/research/problems/binary-gcd-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-02.json
@@ -43,7 +43,8 @@
   ],
   "relatedProofs": [
     "binary-gcd",
-    "binary-gcd-oq-01"
+    "binary-gcd-oq-01",
+    "binary-gcd-oq-01-oq-04"
   ],
   "references": {
     "papers": [],
@@ -65,6 +66,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ01.lean"
+    },
+    {
+      "path": "Proofs/BinaryGcdOQ01OQ04.lean",
+      "filename": "BinaryGcdOQ01OQ04.lean",
+      "lineCount": 158,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ01OQ04.lean"
     }
   ]
 }

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01.json
@@ -45,6 +45,7 @@
     "borsuk-ulam",
     "borsuk-ulam-oq-02",
     "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",
     "borsuk-ulam-oq-02-oq-03",
@@ -98,13 +99,24 @@
     {
       "path": "Proofs/BorsukUlamOQ02OQ01.lean",
       "filename": "BorsukUlamOQ02OQ01.lean",
-      "lineCount": 147,
+      "lineCount": 145,
       "theoremCount": 6,
       "axiomCount": 4,
       "defCount": 0,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ03.lean",
+      "lineCount": 213,
+      "theoremCount": 14,
+      "axiomCount": 9,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ03.lean"
     },
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ04.lean",

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-02.json
@@ -44,6 +44,7 @@
     "borsuk-ulam",
     "borsuk-ulam-oq-02",
     "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",
     "borsuk-ulam-oq-02-oq-03",
@@ -99,13 +100,24 @@
     {
       "path": "Proofs/BorsukUlamOQ02OQ01.lean",
       "filename": "BorsukUlamOQ02OQ01.lean",
-      "lineCount": 147,
+      "lineCount": 145,
       "theoremCount": 6,
       "axiomCount": 4,
       "defCount": 0,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ03.lean",
+      "lineCount": 213,
+      "theoremCount": 14,
+      "axiomCount": 9,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ03.lean"
     },
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ04.lean",

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-04.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-04.json
@@ -70,13 +70,24 @@
     {
       "path": "Proofs/BorsukUlamOQ02OQ01.lean",
       "filename": "BorsukUlamOQ02OQ01.lean",
-      "lineCount": 147,
+      "lineCount": 145,
       "theoremCount": 6,
       "axiomCount": 4,
       "defCount": 0,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ03.lean",
+      "lineCount": 213,
+      "theoremCount": 14,
+      "axiomCount": 9,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ03.lean"
     },
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ04.lean",
@@ -171,6 +182,7 @@
     "borsuk-ulam",
     "borsuk-ulam-oq-02",
     "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",
     "borsuk-ulam-oq-02-oq-03",

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01.json
@@ -57,6 +57,7 @@
     "borsuk-ulam",
     "borsuk-ulam-oq-02",
     "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",
     "borsuk-ulam-oq-02-oq-03",
@@ -112,13 +113,24 @@
     {
       "path": "Proofs/BorsukUlamOQ02OQ01.lean",
       "filename": "BorsukUlamOQ02OQ01.lean",
-      "lineCount": 147,
+      "lineCount": 145,
       "theoremCount": 6,
       "axiomCount": 4,
       "defCount": 0,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ03.lean",
+      "lineCount": 213,
+      "theoremCount": 14,
+      "axiomCount": 9,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ03.lean"
     },
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ04.lean",

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-02-oq-01.json
@@ -47,6 +47,7 @@
     "borsuk-ulam",
     "borsuk-ulam-oq-02",
     "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",
     "borsuk-ulam-oq-02-oq-03",
@@ -102,13 +103,24 @@
     {
       "path": "Proofs/BorsukUlamOQ02OQ01.lean",
       "filename": "BorsukUlamOQ02OQ01.lean",
-      "lineCount": 147,
+      "lineCount": 145,
       "theoremCount": 6,
       "axiomCount": 4,
       "defCount": 0,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ03.lean",
+      "lineCount": 213,
+      "theoremCount": 14,
+      "axiomCount": 9,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ03.lean"
     },
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ04.lean",

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-02.json
@@ -53,6 +53,7 @@
     "borsuk-ulam",
     "borsuk-ulam-oq-02",
     "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",
     "borsuk-ulam-oq-02-oq-03",
@@ -106,13 +107,24 @@
     {
       "path": "Proofs/BorsukUlamOQ02OQ01.lean",
       "filename": "BorsukUlamOQ02OQ01.lean",
-      "lineCount": 147,
+      "lineCount": 145,
       "theoremCount": 6,
       "axiomCount": 4,
       "defCount": 0,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ03.lean",
+      "lineCount": 213,
+      "theoremCount": 14,
+      "axiomCount": 9,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ03.lean"
     },
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ04.lean",

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-03.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-03.json
@@ -41,6 +41,7 @@
     "borsuk-ulam",
     "borsuk-ulam-oq-02",
     "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",
     "borsuk-ulam-oq-02-oq-03",
@@ -95,13 +96,24 @@
     {
       "path": "Proofs/BorsukUlamOQ02OQ01.lean",
       "filename": "BorsukUlamOQ02OQ01.lean",
-      "lineCount": 147,
+      "lineCount": 145,
       "theoremCount": 6,
       "axiomCount": 4,
       "defCount": 0,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ03.lean",
+      "lineCount": 213,
+      "theoremCount": 14,
+      "axiomCount": 9,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ03.lean"
     },
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ04.lean",

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-04.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-04.json
@@ -41,6 +41,7 @@
     "borsuk-ulam",
     "borsuk-ulam-oq-02",
     "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",
     "borsuk-ulam-oq-02-oq-03",
@@ -94,13 +95,24 @@
     {
       "path": "Proofs/BorsukUlamOQ02OQ01.lean",
       "filename": "BorsukUlamOQ02OQ01.lean",
-      "lineCount": 147,
+      "lineCount": 145,
       "theoremCount": 6,
       "axiomCount": 4,
       "defCount": 0,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ03.lean",
+      "lineCount": 213,
+      "theoremCount": 14,
+      "axiomCount": 9,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ03.lean"
     },
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ04.lean",

--- a/src/data/research/problems/borsuk-ulam-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02.json
@@ -45,6 +45,7 @@
     "borsuk-ulam",
     "borsuk-ulam-oq-02",
     "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",
     "borsuk-ulam-oq-02-oq-03",
@@ -101,13 +102,24 @@
     {
       "path": "Proofs/BorsukUlamOQ02OQ01.lean",
       "filename": "BorsukUlamOQ02OQ01.lean",
-      "lineCount": 147,
+      "lineCount": 145,
       "theoremCount": 6,
       "axiomCount": 4,
       "defCount": 0,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ03.lean",
+      "lineCount": 213,
+      "theoremCount": 14,
+      "axiomCount": 9,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ03.lean"
     },
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ04.lean",

--- a/src/data/research/problems/borsuk-ulam-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03-oq-01-oq-01.json
@@ -83,13 +83,24 @@
     {
       "path": "Proofs/BorsukUlamOQ02OQ01.lean",
       "filename": "BorsukUlamOQ02OQ01.lean",
-      "lineCount": 147,
+      "lineCount": 145,
       "theoremCount": 6,
       "axiomCount": 4,
       "defCount": 0,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ03.lean",
+      "lineCount": 213,
+      "theoremCount": 14,
+      "axiomCount": 9,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ03.lean"
     },
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ04.lean",
@@ -184,6 +195,7 @@
     "borsuk-ulam",
     "borsuk-ulam-oq-02",
     "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",
     "borsuk-ulam-oq-02-oq-03",

--- a/src/data/research/problems/borsuk-ulam-oq-03-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03-oq-01.json
@@ -47,6 +47,7 @@
     "borsuk-ulam",
     "borsuk-ulam-oq-02",
     "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",
     "borsuk-ulam-oq-02-oq-03",
@@ -103,13 +104,24 @@
     {
       "path": "Proofs/BorsukUlamOQ02OQ01.lean",
       "filename": "BorsukUlamOQ02OQ01.lean",
-      "lineCount": 147,
+      "lineCount": 145,
       "theoremCount": 6,
       "axiomCount": 4,
       "defCount": 0,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ03.lean",
+      "lineCount": 213,
+      "theoremCount": 14,
+      "axiomCount": 9,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ03.lean"
     },
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ04.lean",

--- a/src/data/research/problems/borsuk-ulam-oq-03-oq-03.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03-oq-03.json
@@ -54,6 +54,7 @@
     "borsuk-ulam",
     "borsuk-ulam-oq-02",
     "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",
     "borsuk-ulam-oq-02-oq-03",
@@ -109,13 +110,24 @@
     {
       "path": "Proofs/BorsukUlamOQ02OQ01.lean",
       "filename": "BorsukUlamOQ02OQ01.lean",
-      "lineCount": 147,
+      "lineCount": 145,
       "theoremCount": 6,
       "axiomCount": 4,
       "defCount": 0,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ03.lean",
+      "lineCount": 213,
+      "theoremCount": 14,
+      "axiomCount": 9,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ03.lean"
     },
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ04.lean",

--- a/src/data/research/problems/borsuk-ulam-oq-03.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03.json
@@ -269,6 +269,7 @@
     "borsuk-ulam",
     "borsuk-ulam-oq-02",
     "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",
     "borsuk-ulam-oq-02-oq-03",
@@ -325,13 +326,24 @@
     {
       "path": "Proofs/BorsukUlamOQ02OQ01.lean",
       "filename": "BorsukUlamOQ02OQ01.lean",
-      "lineCount": 147,
+      "lineCount": 145,
       "theoremCount": 6,
       "axiomCount": 4,
       "defCount": 0,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ03.lean",
+      "lineCount": 213,
+      "theoremCount": 14,
+      "axiomCount": 9,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ03.lean"
     },
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ04.lean",

--- a/src/data/research/problems/borsuk-ulam-oq-04-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-04-oq-01.json
@@ -41,6 +41,7 @@
     "borsuk-ulam",
     "borsuk-ulam-oq-02",
     "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",
     "borsuk-ulam-oq-02-oq-03",
@@ -94,13 +95,24 @@
     {
       "path": "Proofs/BorsukUlamOQ02OQ01.lean",
       "filename": "BorsukUlamOQ02OQ01.lean",
-      "lineCount": 147,
+      "lineCount": 145,
       "theoremCount": 6,
       "axiomCount": 4,
       "defCount": 0,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ03.lean",
+      "lineCount": 213,
+      "theoremCount": 14,
+      "axiomCount": 9,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ03.lean"
     },
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ04.lean",

--- a/src/data/research/problems/borsuk-ulam-oq-04.json
+++ b/src/data/research/problems/borsuk-ulam-oq-04.json
@@ -69,6 +69,7 @@
     "borsuk-ulam",
     "borsuk-ulam-oq-02",
     "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",
     "borsuk-ulam-oq-02-oq-03",
@@ -124,13 +125,24 @@
     {
       "path": "Proofs/BorsukUlamOQ02OQ01.lean",
       "filename": "BorsukUlamOQ02OQ01.lean",
-      "lineCount": 147,
+      "lineCount": 145,
       "theoremCount": 6,
       "axiomCount": 4,
       "defCount": 0,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ03.lean",
+      "lineCount": 213,
+      "theoremCount": 14,
+      "axiomCount": 9,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ03.lean"
     },
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ04.lean",

--- a/src/data/research/problems/divisibility-rules-oq-01.json
+++ b/src/data/research/problems/divisibility-rules-oq-01.json
@@ -45,7 +45,9 @@
   ],
   "relatedProofs": [
     "divisibility-rules",
-    "divisibility-rules-oq-01"
+    "divisibility-rules-oq-01",
+    "divisibility-rules-oq-01-oq-01",
+    "divisibility-rules-oq-01-oq-01-oq-01"
   ],
   "references": {
     "papers": [],
@@ -77,6 +79,28 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DivisibilityRulesOQ01.lean"
+    },
+    {
+      "path": "Proofs/DivisibilityRulesOQ01OQ01.lean",
+      "filename": "DivisibilityRulesOQ01OQ01.lean",
+      "lineCount": 109,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DivisibilityRulesOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/DivisibilityRulesOQ01OQ01OQ01.lean",
+      "filename": "DivisibilityRulesOQ01OQ01OQ01.lean",
+      "lineCount": 168,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DivisibilityRulesOQ01OQ01OQ01.lean"
     }
   ]
 }

--- a/src/data/research/problems/euler-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/euler-identity-oq-01-oq-01.json
@@ -53,7 +53,8 @@
   ],
   "relatedProofs": [
     "euler-identity",
-    "euler-identity-oq-01"
+    "euler-identity-oq-01",
+    "euler-identity-oq-01-oq-01"
   ],
   "references": {
     "papers": [],
@@ -86,6 +87,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerIdentityOQ01.lean"
+    },
+    {
+      "path": "Proofs/EulerIdentityOQ01OQ01.lean",
+      "filename": "EulerIdentityOQ01OQ01.lean",
+      "lineCount": 143,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerIdentityOQ01OQ01.lean"
     }
   ]
 }

--- a/src/data/research/problems/euler-identity-oq-01.json
+++ b/src/data/research/problems/euler-identity-oq-01.json
@@ -51,7 +51,8 @@
   "tags": [],
   "relatedProofs": [
     "euler-identity",
-    "euler-identity-oq-01"
+    "euler-identity-oq-01",
+    "euler-identity-oq-01-oq-01"
   ],
   "references": {
     "papers": [],
@@ -82,6 +83,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerIdentityOQ01.lean"
+    },
+    {
+      "path": "Proofs/EulerIdentityOQ01OQ01.lean",
+      "filename": "EulerIdentityOQ01OQ01.lean",
+      "lineCount": 143,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerIdentityOQ01OQ01.lean"
     }
   ]
 }

--- a/src/data/research/problems/euler-identity-oq-02.json
+++ b/src/data/research/problems/euler-identity-oq-02.json
@@ -39,7 +39,8 @@
   "tags": [],
   "relatedProofs": [
     "euler-identity",
-    "euler-identity-oq-01"
+    "euler-identity-oq-01",
+    "euler-identity-oq-01-oq-01"
   ],
   "references": {
     "papers": [],
@@ -70,6 +71,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerIdentityOQ01.lean"
+    },
+    {
+      "path": "Proofs/EulerIdentityOQ01OQ01.lean",
+      "filename": "EulerIdentityOQ01OQ01.lean",
+      "lineCount": 143,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerIdentityOQ01OQ01.lean"
     }
   ]
 }

--- a/src/data/research/problems/euler-identity-oq-03.json
+++ b/src/data/research/problems/euler-identity-oq-03.json
@@ -41,7 +41,8 @@
   ],
   "relatedProofs": [
     "euler-identity",
-    "euler-identity-oq-01"
+    "euler-identity-oq-01",
+    "euler-identity-oq-01-oq-01"
   ],
   "references": {
     "papers": [],
@@ -74,6 +75,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerIdentityOQ01.lean"
+    },
+    {
+      "path": "Proofs/EulerIdentityOQ01OQ01.lean",
+      "filename": "EulerIdentityOQ01OQ01.lean",
+      "lineCount": 143,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerIdentityOQ01OQ01.lean"
     }
   ]
 }

--- a/src/data/research/problems/ptolemys-complex-proof-oq-01.json
+++ b/src/data/research/problems/ptolemys-complex-proof-oq-01.json
@@ -44,7 +44,8 @@
     "intermediate"
   ],
   "relatedProofs": [
-    "ptolemys-complex-proof"
+    "ptolemys-complex-proof",
+    "ptolemys-complex-proof-oq-01"
   ],
   "references": {
     "papers": [],
@@ -65,6 +66,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PtolemysComplexProof.lean"
+    },
+    {
+      "path": "Proofs/PtolemysComplexProofOQ01.lean",
+      "filename": "PtolemysComplexProofOQ01.lean",
+      "lineCount": 136,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PtolemysComplexProofOQ01.lean"
     }
   ]
 }

--- a/src/data/research/problems/subset-count-multiset-oq-01.json
+++ b/src/data/research/problems/subset-count-multiset-oq-01.json
@@ -28,5 +28,18 @@
     "subset-count",
     "subset-count-multiset",
     "subset-count-multiset-oq-01"
+  ],
+  "leanFiles": [
+    {
+      "path": "Proofs/SubsetCountMultisetOQ01.lean",
+      "filename": "SubsetCountMultisetOQ01.lean",
+      "lineCount": 227,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SubsetCountMultisetOQ01.lean"
+    }
   ]
 }

--- a/src/data/research/problems/subset-count-oq-02.json
+++ b/src/data/research/problems/subset-count-oq-02.json
@@ -40,6 +40,7 @@
   "relatedProofs": [
     "subset-count",
     "subset-count-multiset",
+    "subset-count-multiset-oq-01",
     "subset-count-oq-02"
   ],
   "references": {
@@ -60,6 +61,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SubsetCount.lean"
+    },
+    {
+      "path": "Proofs/SubsetCountMultisetOQ01.lean",
+      "filename": "SubsetCountMultisetOQ01.lean",
+      "lineCount": 227,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SubsetCountMultisetOQ01.lean"
     },
     {
       "path": "Proofs/SubsetCountOQ02.lean",

--- a/src/data/research/problems/subset-count-oq-03.json
+++ b/src/data/research/problems/subset-count-oq-03.json
@@ -45,6 +45,7 @@
   "relatedProofs": [
     "subset-count",
     "subset-count-multiset",
+    "subset-count-multiset-oq-01",
     "subset-count-oq-02"
   ],
   "references": {
@@ -67,6 +68,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SubsetCount.lean"
+    },
+    {
+      "path": "Proofs/SubsetCountMultisetOQ01.lean",
+      "filename": "SubsetCountMultisetOQ01.lean",
+      "lineCount": 227,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SubsetCountMultisetOQ01.lean"
     },
     {
       "path": "Proofs/SubsetCountOQ02.lean",

--- a/src/data/research/problems/szemeredi-hypergraph-core-oq-01.json
+++ b/src/data/research/problems/szemeredi-hypergraph-core-oq-01.json
@@ -44,7 +44,8 @@
     "infrastructure"
   ],
   "relatedProofs": [
-    "szemeredi-hypergraph-core"
+    "szemeredi-hypergraph-core",
+    "szemeredi-hypergraph-core-oq-01"
   ],
   "references": {
     "papers": [],
@@ -65,6 +66,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediHypergraphCore.lean"
+    },
+    {
+      "path": "Proofs/SzemerediHypergraphCoreOQ01.lean",
+      "filename": "SzemerediHypergraphCoreOQ01.lean",
+      "lineCount": 268,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 8,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediHypergraphCoreOQ01.lean"
     }
   ]
 }


### PR DESCRIPTION
## Fix

Registers 9 proof pages that exist in the repository but were missing from `listings.json`, and syncs `leanFile` metadata in research problem JSONs.

## Evidence

**New proofs added to listings.json:**
- `binary-gcd-oq-01-oq-04` — Binary GCD Tight Lower Bound
- `borsuk-ulam-oq-02-oq-01-oq-03` — Borsuk-Ulam variant
- `divisibility-by-three-oq-02-oq-01`, `divisibility-rules-oq-01-oq-01`, `divisibility-rules-oq-01-oq-01-oq-01`
- `euler-identity-oq-01-oq-01` — Axiom-Free Euler's Identity via Taylor Series (sorries: 0)
- `ptolemys-complex-proof-oq-01`, `subset-count-multiset-oq-01`, `szemeredi-hypergraph-core-oq-01`

**Metadata corrected:**
- `EulerIdentityOQ01OQ01.lean`: scan incorrectly counted `sorryCount: 1` because "sorry-free" appears in a comment on line 12; corrected to `sorryCount: 0`
- Annotation counts updated for recently-enriched proofs

**Build**: `pnpm build` passes (✓ built in 4m 59s)

---
Automated fix by lean-mechanic agent.