### PR TITLE
fix(audit): correct leanFile.axiomCount (0→3) for erdos-1017

### DIFF
--- a/src/data/proofs/erdos-1017/meta.json
+++ b/src/data/proofs/erdos-1017/meta.json
@@ -188,7 +188,7 @@
     "opens": [],
     "namespace": null,
     "lineCount": 696,
-    "axiomCount": 0,
+    "axiomCount": 3,
     "theoremCount": 0,
     "definitionCount": 0
   }


### PR DESCRIPTION
## Integrity Fix

Discovered during automated gallery audit.

| Field | Before | After | Source |
|-------|--------|-------|--------|
| `leanFile.axiomCount` | 0 | 3 | `grep -c "^axiom " proofs/Proofs/Erdos1017OQ01.lean` |

Note: `meta.axiomCount` was already correct at 3. Only the `leanFile` sub-block was stale.

## The 3 Axioms

1. `egp_theorem` — Erdős-Goodman-Pósa bound
2. `gyori_keszegh_triangles` — Győri-Keszegh (2017) triangle decomposition
3. `k4free_partition_number` — K₄-free partition formula

The `axiomatized` status and `axiom` badge are both correct.

---
Automated fix by lean-auditor agent.