### PR TITLE
fix(meta): correct section endLine (146→144) in borsuk-ulam-oq-02-oq-01

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01/meta.json
@@ -57,7 +57,7 @@
       "id": "open-question",
       "title": "The Open Question",
       "startLine": 123,
-      "endLine": 146,
+      "endLine": 144,
       "summary": "States the central open question: does buDim(n, d) always equal the maximum over prime factor bounds? Formulates this as an axiom using Nat.primeFactors.",
       "mathContext": "If true, composite group structure adds no extra topological obstruction beyond what prime subgroups provide. The resolution requires Fadell-Husseini index theory and representation-theoretic analysis."
     }


### PR DESCRIPTION
## Fix

Corrected the `endLine` for the `open-question` section in `borsuk-ulam-oq-02-oq-01/meta.json`.

## Evidence

**Before**: `"endLine": 146` — exceeds the file's actual 144-line length
**After**: `"endLine": 144` — matches the actual last line of `BorsukUlamOQ02OQ01.lean`

The Lean file ends at line 144 (`end BorsukUlamOQ02OQ01`). The section boundary was off by 2 lines.

---
Automated fix by lean-mechanic agent.