### PR TITLE
fix(meta): correct axiomCount (1→16) for yang-mills

### DIFF
--- a/src/data/proofs/yang-mills/meta.json
+++ b/src/data/proofs/yang-mills/meta.json
@@ -57,8 +57,8 @@
     ],
     "dateAdded": "2025-12-29",
     "millenniumProblem": "yang-mills",
-    "axiomCount": 1,
-    "assumptions": "16 total assumptions: 1 explicit axiom (gaugeTransform) + 15 structure-encoded: CompactSimpleGaugeGroup (compact, connected, simple — 3), GaugeLieAlgebra (bracket_anticomm, bracket_jacobi — 2), FieldStrength (antisymmetric — 1), YangMillsAction (coupling_pos, action_nonneg — 2), WightmanQFT (vacuum_normalized, energy_bounded_below, vacuum_lowest_energy — 3), QuantumYangMillsTheory (nontrivial — 1), Instanton (action_formula — 1), EnergyMomentumTensor (symmetric, energy_density_nonneg — 2). 1 sorry (coupling_controlled in Exploration.lean, Mathlib drift). The Yang-Mills 4D mass gap conjecture remains OPEN.",
+    "axiomCount": 16,
+    "assumptions": "16 total assumptions: 1 explicit axiom (gaugeTransform) + 15 structure-encoded: CompactSimpleGaugeGroup (compact, connected, simple — 3), GaugeLieAlgebra (bracket_anticomm, bracket_jacobi — 2), FieldStrength (antisymmetric — 1), YangMillsAction (coupling_pos, action_nonneg — 2), WightmanQFT (vacuum_normalized, energy_bounded_below, vacuum_lowest_energy — 3), QuantumYangMillsTheory (nontrivial — 1), Instanton (action_formula — 1), EnergyMomentumTensor (symmetric, energy_density_nonneg — 2). The Yang-Mills 4D mass gap conjecture remains OPEN.",
     "lineCount": 48,
     "mathlib_version": "4.26.0"
   },
@@ -196,7 +196,7 @@
     ],
     "namespace": "YangMillsMassGap",
     "lineCount": 48,
-    "axiomCount": 1,
+    "axiomCount": 16,
     "theoremCount": 1787,
     "definitionCount": 260
   },


### PR DESCRIPTION
## Fix

The `yang-mills` gallery entry had `axiomCount: 1` in both `meta.axiomCount` and `leanFile.axiomCount`, counting only the single explicit `axiom gaugeTransform` declaration in `YangMills/Classical.lean`.

Per the Axiom Integrity Policy, `axiomCount` must reflect ALL assumptions including structure-encoded hypotheses.

## Evidence

**Before**: `axiomCount: 1`

**After**: `axiomCount: 16`

The `YangMillsMassGap.lean` file header explicitly documents the correct count:
```
## Axiom Count: 16

1 explicit `axiom` declaration (gaugeTransform — definitional).
~15 structure-encoded assumptions in CompactSimpleGaugeGroup, GaugeLieAlgebra,
WightmanQFT, YangMillsAction, FieldStrength, Instanton, EnergyMomentumTensor.
```

The `meta.assumptions` field had already been correctly updated to say "16 total assumptions" — this PR aligns `axiomCount` with that documented truth.

Also removes a stale sentence from `assumptions`: "1 sorry (coupling_controlled in Exploration.lean, Mathlib drift)" — `coupling_controlled` is now a fully proved theorem (0 sorries in the YangMills modules).

---
Automated fix by lean-mechanic agent.