### PR TITLE
fix(meta): correct stale assumptions text for erdos-1181

### DIFF
--- a/src/data/proofs/erdos-1181/meta.json
+++ b/src/data/proofs/erdos-1181/meta.json
@@ -77,7 +77,7 @@
       "conjectures_compatible theorem stub: compatibility of #457 and #1181"
     ],
     "axiomCount": 1,
-    "assumptions": "4 axioms: trivial_upper_bound (primorial/PNT), erdos_1181 (main open conjecture), pnt_chebyshev (PNT for Chebyshev function), primorial_divides_bound (primorial divides product). 1 sorry remaining. Properties of q(n,k) proved constructively."
+    "assumptions": "1 axiom: erdos_1181 (main open conjecture, Erdős 1979, remains open). 0 sorries. Properties of q(n,k) proved constructively from Mathlib."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #1181** appears in Erdős [Er79d, p.78] and asks for an upper bound on q(n, log n), the least prime not dividing a product of consecutive integers. The trivial upper bound q(n, log n) ≤ (1+o(1))(log n)² follows from the primorial argument combined with the Prime Number Theorem. The conjecture asks whether the constant can be improved from (1+o(1)) to (1-c) for some fixed c > 0.\n\nThis is the companion upper bound question to Erdős Problem #457, which asks about lower bounds. Together they aim to pin down the growth rate of q(n, log n) between Ω(log n) and O((log n)²). Probabilistic heuristics described by Tao in the context of Problem #457 suggest a much stronger bound of q(n, log n) ≪ (log log n / log log log n) · log n.",


### PR DESCRIPTION
## Fix

The `erdos-1181` gallery entry had an `assumptions` field claiming "4 axioms" and "1 sorry remaining", but both are wrong.

## Evidence

**Before**: `"4 axioms: trivial_upper_bound (primorial/PNT), erdos_1181 (main open conjecture), pnt_chebyshev (PNT for Chebyshev function), primorial_divides_bound (primorial divides product). 1 sorry remaining. Properties of q(n,k) proved constructively."`

**After**: `"1 axiom: erdos_1181 (main open conjecture, Erdős 1979, remains open). 0 sorries. Properties of q(n,k) proved constructively from Mathlib."`

Verified in `proofs/Proofs/Erdos1181Problem.lean`:
- Only 1 explicit `axiom` declaration: `axiom erdos_1181 : erdos1181_conjecture` (line 108)
- `trivial_upper_bound`, `pnt_chebyshev`, `primorial_divides_bound` do not appear anywhere in the file
- 0 `sorry` occurrences outside comments

The `leanFile.axiomCount: 1` and `meta.sorries: 0` were already correct; only the `assumptions` text was stale.

---
Automated fix by lean-mechanic agent.