### PR TITLE
fix(meta): correct leanFile.path prefix in 3 meta.json files

### DIFF
--- a/src/data/proofs/erdos-1126-oq-01/meta.json
+++ b/src/data/proofs/erdos-1126-oq-01/meta.json
@@ -182,7 +182,7 @@
     ]
   },
   "leanFile": {
-    "path": "proofs/Proofs/Erdos1126OQ01Problem.lean",
+    "path": "Proofs/Erdos1126OQ01Problem.lean",
     "filename": "Erdos1126OQ01Problem.lean",
     "lineCount": 472,
     "axiomCount": 7

--- a/src/data/proofs/furstenberg-correspondence-oq-01/meta.json
+++ b/src/data/proofs/furstenberg-correspondence-oq-01/meta.json
@@ -146,7 +146,7 @@
     ]
   },
   "leanFile": {
-    "path": "proofs/Proofs/FurstenbergCorrespondenceOQ01.lean",
+    "path": "Proofs/FurstenbergCorrespondenceOQ01.lean",
     "filename": "FurstenbergCorrespondenceOQ01.lean",
     "lineCount": 285
   },

--- a/src/data/proofs/hilbert-13-oq-04/meta.json
+++ b/src/data/proofs/hilbert-13-oq-04/meta.json
@@ -159,7 +159,7 @@
     ]
   },
   "leanFile": {
-    "path": "proofs/Proofs/Hilbert13GeneralSpaces.lean",
+    "path": "Proofs/Hilbert13GeneralSpaces.lean",
     "filename": "Hilbert13GeneralSpaces.lean",
     "axiomCount": 6,
     "lineCount": 406


### PR DESCRIPTION
## Fix

Correct spurious `proofs/` prefix in `leanFile.path` for 3 gallery entries.

## Evidence

**Before**: `"path": "proofs/Proofs/Erdos1126OQ01Problem.lean"` (double `proofs/`)
**After**: `"path": "Proofs/Erdos1126OQ01Problem.lean"` (matches all other entries)

The incorrect prefix breaks any tooling that resolves the path relative to the `proofs/` directory root (e.g., the annotation builder at `scripts/annotations/build.ts`).

## Affected proofs

- `erdos-1126-oq-01` → `Proofs/Erdos1126OQ01Problem.lean`
- `hilbert-13-oq-04` → `Proofs/Hilbert13GeneralSpaces.lean`
- `furstenberg-correspondence-oq-01` → `Proofs/FurstenbergCorrespondenceOQ01.lean`

All 3 Lean files exist at the corrected paths.

---
Automated fix by lean-mechanic agent.