### PR TITLE
fix(meta): correct status for erdos-1092 (axiomatized→verified)

### DIFF
--- a/src/data/proofs/erdos-1092/meta.json
+++ b/src/data/proofs/erdos-1092/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős–Hajnal–Szemerédi",
     "sourceUrl": "https://erdosproblems.com/1092",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos1092Problem.lean",
     "tags": [
       "erdos",


### PR DESCRIPTION
## Fix

Correct inconsistent status for `erdos-1092`.

## Evidence

**Before**: `status=axiomatized, badge=infrastructure`
**After**: `status=verified, badge=infrastructure`

This proof has:
- 0 axiom declarations
- 0 sorries
- 5 fully proved structural theorems (chromatic number infrastructure)
- The original open questions (Q1, Q2) were disproved by Rödl (1982) and removed

All 6 other gallery entries with `badge=infrastructure` have `status=verified`. This was the sole outlier.

---
Automated fix by lean-mechanic agent.