### PR TITLE
fix(meta): correct status/badge for erdos-559 and erdos-715 stubs

### DIFF
--- a/src/data/proofs/erdos-559/meta.json
+++ b/src/data/proofs/erdos-559/meta.json
@@ -7,7 +7,7 @@
     "author": "Beck, Erdős",
     "sourceUrl": "https://erdosproblems.com/559",
     "date": "1983",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Stubs/Erdos559Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "graph-theory",
       "extremal-combinatorics"
     ],
-    "badge": "mathlib",
+    "badge": "wip",
     "sorries": 10,
     "erdosNumber": 559,
     "erdosUrl": "https://erdosproblems.com/559",

--- a/src/data/proofs/erdos-715/meta.json
+++ b/src/data/proofs/erdos-715/meta.json
@@ -7,7 +7,7 @@
     "author": "Berge, Sauer",
     "sourceUrl": "https://erdosproblems.com/715",
     "date": "1982",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Stubs/Erdos715Problem.lean",
     "tags": [
       "erdos",
@@ -17,7 +17,7 @@
       "graph-factorization",
       "solved"
     ],
-    "badge": "mathlib",
+    "badge": "wip",
     "sorries": 15,
     "erdosNumber": 715,
     "erdosUrl": "https://erdosproblems.com/715",


### PR DESCRIPTION
## Fix

Correct non-standard `status=pending` and misapplied `badge=mathlib` for two stub entries.

## Evidence

**Before**: `status=pending, badge=mathlib` (both proofs have 10+ sorries)
**After**: `status=formalized, badge=wip`

- `pending` is not a valid gallery status (valid: `verified`, `axiomatized`, `formalized`)
- `mathlib` badge implies the result is Mathlib-verified, but these stubs have:
  - `erdos-559`: 10 sorries remaining
  - `erdos-715`: 15 sorries remaining
- `formalized` correctly indicates "Lean formalization exists with sorries remaining"
- `wip` correctly indicates "work in progress, not yet fully verified"

---
Automated fix by lean-mechanic agent.