### PR TITLE
fix(meta): correct status=pending → formalized for 28 proofs with sorries

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "George Pólya / Ivan Vinogradov (1918)",
     "sourceUrl": "https://en.wikipedia.org/wiki/P%C3%B3lya%E2%80%93Vinogradov_inequality",
     "date": "1918",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/BoundedPrimeGapsOQ04OQ01.lean",
     "tags": [
       "analytic-number-theory",

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04/meta.json
@@ -7,7 +7,7 @@
     "author": "Classical linear algebra (invariant factor decomposition)",
     "sourceUrl": "",
     "date": "2026",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
     "tags": [
       "linear-algebra",

--- a/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Ferdinand Georg Frobenius (1878)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Frobenius_normal_form",
     "date": "1878",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/CayleyHamiltonReductionOQ02OQ01.lean",
     "tags": [
       "linear-algebra",

--- a/src/data/proofs/erdos-100-oq-01/meta.json
+++ b/src/data/proofs/erdos-100-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Guth–Katz (2015), Erdős (1986); analysis formalized 2026",
     "sourceUrl": "https://erdosproblems.com/100",
     "date": "2015",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos100OQ01.lean",
     "tags": [
       "discrete-geometry",

--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -4,7 +4,7 @@
   "slug": "erdos-1012-oq-03",
   "description": "Directed analogues of Hamiltonian cycle conditions: Ghouila-Houri, Moon-Moser, and Rédei theorems for digraphs and tournaments.",
   "meta": {
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1012OQ03.lean",
     "tags": [
       "graph-theory",

--- a/src/data/proofs/erdos-27/meta.json
+++ b/src/data/proofs/erdos-27/meta.json
@@ -8,7 +8,7 @@
     "sourceUrl": "https://erdosproblems.com/27",
     "erdosUrl": "https://erdosproblems.com/27",
     "date": "1950s",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Stubs/Erdos27Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-35/meta.json
+++ b/src/data/proofs/erdos-35/meta.json
@@ -7,7 +7,7 @@
     "author": "Helmut Plünnecke",
     "sourceUrl": "https://erdosproblems.com/35",
     "date": "1970",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos35Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-402/meta.json
+++ b/src/data/proofs/erdos-402/meta.json
@@ -7,7 +7,7 @@
     "author": "Graham (1970), solved by Balasubramanian–Soundararajan (1996)",
     "sourceUrl": "https://erdosproblems.com/402",
     "date": "1970",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos402Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-546/meta.json
+++ b/src/data/proofs/erdos-546/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, Benny Sudakov",
     "sourceUrl": "https://erdosproblems.com/546",
     "date": "1984-2011",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Stubs/Erdos546Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-549/meta.json
+++ b/src/data/proofs/erdos-549/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős, disproved by Norin-Sun-Zhao",
     "sourceUrl": "https://erdosproblems.com/549",
     "date": "",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos549Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-551/meta.json
+++ b/src/data/proofs/erdos-551/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, Bondy, Nikiforov, Keevash, Long, Skokan",
     "sourceUrl": "https://erdosproblems.com/551",
     "date": "1973-2021",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos551Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-553/meta.json
+++ b/src/data/proofs/erdos-553/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Sós, solved by Alon-Rödl",
     "sourceUrl": "https://erdosproblems.com/553",
     "date": "2005",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Stubs/Erdos553Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-608/meta.json
+++ b/src/data/proofs/erdos-608/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, Zoltán Füredi, Dániel Maleki, Andrzej Grzesik, Ping Hu, Jan Volec",
     "sourceUrl": "https://erdosproblems.com/608",
     "date": "2010s",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos608Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-637/meta.json
+++ b/src/data/proofs/erdos-637/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, Faudree, Sós, Bukh, Sudakov, Jenssen, Keevash, Long, Yepremyan",
     "sourceUrl": "https://erdosproblems.com/637",
     "date": "2007-2020",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos637Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-673/meta.json
+++ b/src/data/proofs/erdos-673/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, Terence Tao, Gérald Tenenbaum",
     "sourceUrl": "https://erdosproblems.com/673",
     "date": "1979-1982",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos673Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-674/meta.json
+++ b/src/data/proofs/erdos-674/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős, Chao Ko, Andrzej Schinzel, V.A. Dem'janenko, S. Uchiyama",
     "sourceUrl": "https://erdosproblems.com/674",
     "date": "1940-1984",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos674Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-795/meta.json
+++ b/src/data/proofs/erdos-795/meta.json
@@ -7,7 +7,7 @@
     "author": "Raghavan",
     "sourceUrl": "https://erdosproblems.com/795",
     "date": "2025",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Stubs/Erdos795Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-895/meta.json
+++ b/src/data/proofs/erdos-895/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős-Hajnal, solved by Barber",
     "sourceUrl": "https://erdosproblems.com/895",
     "date": "1995",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos895Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/erdos-94/meta.json
+++ b/src/data/proofs/erdos-94/meta.json
@@ -7,7 +7,7 @@
     "author": "Paul Erdős",
     "sourceUrl": "https://erdosproblems.com/94",
     "date": "1990s",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Stubs/Erdos94Problem.lean",
     "tags": [
       "erdos",

--- a/src/data/proofs/fair-games-theorem-oq-03/meta.json
+++ b/src/data/proofs/fair-games-theorem-oq-03/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Classical probability theory (Doob, 1953)",
     "date": "1953",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/FairGamesTheoremOQ03.lean",
     "tags": [
       "probability",

--- a/src/data/proofs/fundamental-theorem-calculus-oq-02/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Stokes (1854), Cartan (1945)",
     "date": "1854",
-    "status": "pending",
+    "status": "formalized",
     "tags": [
       "analysis",
       "calculus",

--- a/src/data/proofs/lhopital-oq-02/meta.json
+++ b/src/data/proofs/lhopital-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Johann Bernoulli / Guillaume de l'Hôpital (1696)",
     "sourceUrl": "https://en.wikipedia.org/wiki/L%27H%C3%B4pital%27s_rule",
     "date": "1696",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/LHopitalOQ02.lean",
     "tags": [
       "calculus",

--- a/src/data/proofs/newton-inductive-step-oq-01/meta.json
+++ b/src/data/proofs/newton-inductive-step-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Newton%27s_inequalities",
     "date": "2026",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/NewtonInductiveStepOQ01.lean",
     "tags": [
       "algebra",

--- a/src/data/proofs/roth-theorem-k3-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Roth (1953), Behrend (1946), Bloom-Sisask (2020), Kelley-Meka (2023)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Roth%27s_theorem_on_arithmetic_progressions",
     "date": "1953",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/RothTheoremQuantitative.lean",
     "tags": [
       "additive-combinatorics",

--- a/src/data/proofs/roth-theorem-k3-oq-02/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Ruzsa-Szemerédi (1978), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Ruzsa%E2%80%93Szemer%C3%A9di_problem",
     "date": "1978",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/RothTriangleRemoval.lean",
     "tags": [
       "additive-combinatorics",

--- a/src/data/proofs/shannon-entropy-oq-03/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-03/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lieb & Ruskai (1973)",
     "date": "1973",
-    "status": "pending",
+    "status": "formalized",
     "tags": [
       "information-theory",
       "analysis",

--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -7,7 +7,7 @@
     "author": "Shapley & Folkman (formalized in Lean 4)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Shapley%E2%80%93Folkman_lemma",
     "date": "1966",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/ShapleyFolkman.lean",
     "tags": [
       "convex-analysis",

--- a/src/data/proofs/stirling-formula-oq-01/meta.json
+++ b/src/data/proofs/stirling-formula-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Stirling (1730), de Moivre (1733)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Stirling%27s_approximation#Speed_of_convergence_and_error_estimates",
     "date": "1730",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/StirlingExpansion.lean",
     "tags": [
       "analysis",


### PR DESCRIPTION
## Fix

Batch-correct `status=pending` to `status=formalized` for 28 gallery proofs.

## Evidence

**Before**: `status=pending` (non-standard, not in gallery schema)
**After**: `status=formalized` (correct: Lean formalization exists with sorries remaining)

Valid gallery statuses: `verified`, `axiomatized`, `formalized`. The `pending` value was informally used as a placeholder but is not recognized by the schema.

All 28 affected proofs:
- Have `badge=wip` (already correct)
- Have confirmed sorries in their Lean source files (1-22 sorries each)
- Have consistent sorry counts between meta.json and actual Lean files

Zero-sorry `pending` entries (placeholder stubs like `theorem ...: True := trivial`) are excluded from this PR — they require separate analysis.

---
Automated fix by lean-mechanic agent.