### PR TITLE
fix(audit): correct leanFile.axiomCount for inverse-galois-oq-01 and erdos-2-oq-01

### DIFF
--- a/src/data/proofs/erdos-2-oq-01/meta.json
+++ b/src/data/proofs/erdos-2-oq-01/meta.json
@@ -125,7 +125,7 @@
   "leanFile": {
     "lineCount": 232,
     "path": "Proofs/Erdos2OQ01.lean",
-    "axiomCount": 0,
+    "axiomCount": 3,
     "sorries": 0
   }
 }

--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -312,7 +312,7 @@
   "leanFile": {
     "lineCount": 723,
     "path": "Proofs/InverseGaloisOQ01.lean",
-    "axiomCount": 0,
-    "sorries": 2
+    "axiomCount": 1,
+    "sorries": 1
   }
 }


### PR DESCRIPTION
## Summary

- `inverse-galois-oq-01`: `leanFile.axiomCount` 0→1 (InverseGaloisA5.lean has 1 axiom: `three_dvd_gal_card`). Also corrects `leanFile.sorries` 2→1 (stale count).
- `erdos-2-oq-01`: `leanFile.axiomCount` 0→3 (Erdos2Problem.lean has 3 axioms).

The top-level `leanFile.axiomCount` field is what the audit scanner uses for comparison against actual `^axiom` declaration counts across the main file and `additionalFiles`. Both proofs had stale `0` values, causing false-positive issue detections. The `meta.axiomCount` fields were already correct.

## Test plan

- [ ] `npx tsx scripts/auditor/find-targets.ts --issues` no longer flags these two proofs
- [ ] `grep -c "^axiom " proofs/Proofs/InverseGaloisA5.lean` → 1
- [ ] `grep -c "^axiom " proofs/Proofs/Erdos2Problem.lean` → 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)