### PR TITLE
fix(meta): add missing leanFile.path and sorries to 198 gallery proofs (batch 2)

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions/meta.json
@@ -63,7 +63,9 @@
     "lineCount": 534,
     "axiomCount": 0,
     "theoremCount": 57,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -94,28 +96,36 @@
   ],
   "references": [
     {
-      "authors": ["N. H. Abel"],
+      "authors": [
+        "N. H. Abel"
+      ],
       "title": "Beweis der Unmöglichkeit algebraische Gleichungen von höheren als dem vierten Grade allgemein aufzulösen",
       "year": "1824",
       "venue": "Journal für die reine und angewandte Mathematik",
       "note": "Abel's original proof of quintic unsolvability — the paper that motivated the group-theoretic approach"
     },
     {
-      "authors": ["É. Galois"],
+      "authors": [
+        "É. Galois"
+      ],
       "title": "Mémoire sur les conditions de résolubilité des équations par radicaux",
       "year": "1846",
       "venue": "Journal de Mathématiques Pures et Appliquées",
       "note": "Posthumous foundational work: polynomial solvable by radicals iff Galois group is solvable"
     },
     {
-      "authors": ["I. Stewart"],
+      "authors": [
+        "I. Stewart"
+      ],
       "title": "Galois Theory",
       "year": "2015",
       "venue": "Chapman and Hall/CRC, 4th edition",
       "note": "Chapter 12-13: complete proof that S_n is solvable iff n ≤ 4, including the Klein four-group and A₅ simplicity arguments"
     },
     {
-      "authors": ["J. J. Rotman"],
+      "authors": [
+        "J. J. Rotman"
+      ],
       "title": "An Introduction to the Theory of Groups",
       "year": "1995",
       "venue": "Springer GTM 148, 4th edition",

--- a/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
@@ -363,7 +363,8 @@
         "description": "S_5 is realizable as a Galois group over Q"
       }
     ],
-    "sorries": 0
+    "sorries": 0,
+    "path": "Proofs/AbelRuffiniOQ04OQ01.lean"
   },
   "references": [
     {

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-03/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-03/meta.json
@@ -85,7 +85,9 @@
     "lineCount": 104,
     "axiomCount": 0,
     "theoremCount": 4,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/AbelRuffiniOQ04OQ02OQ03.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/abel-ruffini-oq-04-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02/meta.json
@@ -120,7 +120,9 @@
     "lineCount": 154,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/AbelRuffiniOQ04OQ02.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/abel-ruffini-oq-04-oq-03/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-03/meta.json
@@ -33,7 +33,9 @@
     "lineCount": 165,
     "axiomCount": 1,
     "theoremCount": 7,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/AbelRuffiniOQ04OQ03.lean",
+    "sorries": 0
   },
   "overview": {
     "historicalContext": "Évariste Galois (1811–1832) developed the foundations of what became Galois theory in a memoir written the night before his fatal duel on May 30, 1832 — at the age of 20. His central insight was to associate to each polynomial a group (now called the Galois group) encoding the symmetries among its roots. Galois's criterion — that a polynomial is solvable by radicals if and only if its Galois group is solvable — is the capstone of this theory and provides the complete algebraic characterization of radical solvability. The work resolved centuries of effort to find explicit root formulas generalizing the quadratic formula. The Abel-Ruffini theorem (Ruffini 1799, Abel 1824) had established that the general quintic polynomial has no radical formula, but Galois identified the exact obstruction: the Galois group must be a solvable group. The very concept of a solvable group originates in this theorem. Galois's memoir was published posthumously by Liouville in 1846 and fundamentally transformed algebra from the study of equations to the study of symmetry and group theory.",

--- a/src/data/proofs/abel-ruffini-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04/meta.json
@@ -224,7 +224,9 @@
     "theoremCount": 8,
     "substantiveTheoremCount": 2,
     "trivialSpecializations": 6,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/AbelRuffiniOQ04.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -192,7 +192,9 @@
         "description": "Contrapositive of galois_bridge: non-solvable Gal(q) implies α not solvable by radicals",
         "leanType": "(α : E) → (q : Polynomial F) → Irreducible q → aeval α q = 0 → ¬ IsSolvable q.Gal → ¬ IsSolvableByRad F α"
       }
-    ]
+    ],
+    "path": "Proofs/AbelRuffini.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/amgm-inequality-oq-02-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01/meta.json
@@ -31,11 +31,10 @@
     ]
   },
   "overview": {
-    "historicalContext": "Newton's power sum identities and Girard's symmetric function relations are classical results in algebra. The identity p₂ = e₁² - 2·e₂ (where p₂ = Σxᵢ², e₁ = Σxᵢ, e₂ = Σ_{i<j} xᵢxⱼ) is the simplest non-trivial Newton-Girard relation. This formalization works over any CommRing with an arbitrary Finset, generalizing from specific numbers to arbitrary algebraic structures.",
+    "historicalContext": "Isaac Newton discovered the power sum recurrences (Newton's identities) around 1666, connecting the elementary symmetric polynomials $e_k = \\sum_{i_1 < \\cdots < i_k} x_{i_1} \\cdots x_{i_k}$ to the power sums $p_k = \\sum x_i^k$. Albert Girard independently stated the recurrences in 1629. The simplest non-trivial identity is $p_2 = e_1^2 - 2e_2$, which is just $(\\sum x_i)^2 = \\sum x_i^2 + 2\\sum_{i < j} x_i x_j$. This identity is ancient — it generalizes the algebraic identity $(a+b)^2 = a^2 + 2ab + b^2$ to $n$ variables and underpins multiple inequalities: AM-GM (the off-diagonal sum is non-negative by $(a-b)^2 \\geq 0$), Cauchy-Schwarz (via the Lagrange identity), and Maclaurin's inequalities for symmetric means. The Finset-based generalization here works over any commutative ring, making it applicable to formal power series and polynomial coefficient arithmetic.",
     "problemStatement": "Prove that (Σ_{i∈s} xᵢ)² = Σ_{i∈s} xᵢ² + Σ_{i∈s} Σ_{j∈s,j≠i} xᵢxⱼ for any Finset s and function f: s → R in a CommRing R.",
     "text": "The key theorem sq_sum_eq_diag_plus_offdiag decomposes the double sum into diagonal and off-diagonal parts. The proof uses sq_sum_eq_double_sum (rewriting (Σf)² as a double sum via Finset.sum_mul_sum), then for each i, splits the sum over s into the i-th term (the diagonal f(i)² = f(i)*f(i)) plus the rest s.erase i (the off-diagonal). This uses Finset.add_sum_erase. The off-diagonal Σ_{i≠j} xᵢxⱼ equals 2·e₂ = 2·Σ_{i<j} xᵢxⱼ by a symmetry argument (pairing (i,j) with (j,i)), though this final step is left as a remark.",
     "proofStrategy": "sq_sum_eq_double_sum: rw [sq, Finset.sum_mul_sum]. sq_sum_eq_diag_plus_offdiag: rewrite double sum via sq_sum_eq_double_sum, then sum_add_distrib splits diagonal from off-diagonal, and Finset.add_sum_erase identifies the diagonal term f(i)² at each i.",
-    "historicalContext": "Isaac Newton discovered the power sum recurrences (Newton's identities) around 1666, connecting the elementary symmetric polynomials $e_k = \\sum_{i_1 < \\cdots < i_k} x_{i_1} \\cdots x_{i_k}$ to the power sums $p_k = \\sum x_i^k$. Albert Girard independently stated the recurrences in 1629. The simplest non-trivial identity is $p_2 = e_1^2 - 2e_2$, which is just $(\\sum x_i)^2 = \\sum x_i^2 + 2\\sum_{i < j} x_i x_j$. This identity is ancient — it generalizes the algebraic identity $(a+b)^2 = a^2 + 2ab + b^2$ to $n$ variables and underpins multiple inequalities: AM-GM (the off-diagonal sum is non-negative by $(a-b)^2 \\geq 0$), Cauchy-Schwarz (via the Lagrange identity), and Maclaurin's inequalities for symmetric means. The Finset-based generalization here works over any commutative ring, making it applicable to formal power series and polynomial coefficient arithmetic.",
     "keyInsights": [
       "$(\\sum f)^2 = \\sum_i \\sum_j f(i)f(j)$ is the key bridge: squaring a sum produces a double sum of all cross-products, proved in one line by `Finset.sum_mul_sum`",
       "Diagonal/off-diagonal split: the $n^2$ cross-product terms decompose into $n$ diagonal terms $f(i)^2$ and $n^2 - n$ off-diagonal terms $f(i)f(j)$ with $i \\neq j$, via `Finset.add_sum_erase`",
@@ -62,7 +61,9 @@
     "lineCount": 88,
     "axiomCount": 0,
     "theoremCount": 5,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/AmgmInequalityOQ02OQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -83,14 +84,18 @@
   ],
   "references": [
     {
-      "authors": ["I. Newton"],
+      "authors": [
+        "I. Newton"
+      ],
       "title": "Arithmetica Universalis",
       "year": "1707",
       "venue": "Cambridge",
       "note": "Newton's power sum identities connecting elementary symmetric polynomials to power sums $p_k = e_1 p_{k-1} - e_2 p_{k-2} + \\cdots$"
     },
     {
-      "authors": ["A. Girard"],
+      "authors": [
+        "A. Girard"
+      ],
       "title": "Invention nouvelle en l'algèbre",
       "year": "1629",
       "venue": "Amsterdam",

--- a/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03/meta.json
@@ -119,6 +119,8 @@
     "lineCount": 66,
     "axiomCount": 0,
     "theoremCount": 2,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
@@ -128,7 +128,9 @@
     "lineCount": 226,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -301,7 +301,9 @@
     "privateHelperCount": 6,
     "axiomDeclCount": 2,
     "lemmaCount": 0,
-    "defCount": 3
+    "defCount": 3,
+    "path": "Proofs/AmgmInequalityOQ02.lean",
+    "sorries": 1
   },
   "references": [
     {

--- a/src/data/proofs/amgm-inequality-oq-03-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-01/meta.json
@@ -54,7 +54,10 @@
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
     "lineCount": 372,
-    "focusedRange": {"startLine": 220, "endLine": 343},
+    "focusedRange": {
+      "startLine": 220,
+      "endLine": 343
+    },
     "assumptions": "0 axioms, 0 sorries. Core building blocks (Jensen, rpow arithmetic) from Mathlib; original proofs for duality identity and negative-exponent monotonicity.",
     "mathlib_version": "4.26.0"
   },
@@ -151,7 +154,9 @@
     "axiomCount": 0,
     "theoremCount": 13,
     "lemmaCount": 0,
-    "defCount": 3
+    "defCount": 3,
+    "path": "Proofs/AmgmInequalityOQ03.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/amgm-inequality-oq-03-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02/meta.json
@@ -264,53 +264,72 @@
         "type": "supporting",
         "description": "GM = exp(∑ wᵢ log zᵢ)"
       }
-    ]
+    ],
+    "path": "Proofs/PowerMeanLimitOQ.lean",
+    "sorries": 0
   },
   "references": [
     {
-      "authors": ["Hardy, G.H.", "Littlewood, J.E.", "Pólya, G."],
+      "authors": [
+        "Hardy, G.H.",
+        "Littlewood, J.E.",
+        "Pólya, G."
+      ],
       "title": "Inequalities",
       "year": "1934",
       "venue": "Cambridge University Press",
       "note": "Section 2.9: the geometric mean as the limit of power means, proved via exp/log representation"
     },
     {
-      "authors": ["Bullen, P.S."],
+      "authors": [
+        "Bullen, P.S."
+      ],
       "title": "Handbook of Means and Their Inequalities",
       "year": "2003",
       "venue": "Kluwer Academic Publishers",
       "note": "Section III.1: comprehensive treatment of power mean continuity and limit cases"
     },
     {
-      "authors": ["Rényi, Alfréd"],
+      "authors": [
+        "Rényi, Alfréd"
+      ],
       "title": "On Measures of Entropy and Information",
       "year": "1961",
       "venue": "Proceedings of the Fourth Berkeley Symposium on Mathematical Statistics and Probability, vol. 1, pp. 547-561",
       "note": "Introduces Rényi entropy H_α = (1/(1-α)) log ∑ pᵢ^α, whose limit α→1 gives Shannon entropy by the same derivative-at-singular-point technique used in this power mean limit proof"
     },
     {
-      "authors": ["Steele, J. Michael"],
+      "authors": [
+        "Steele, J. Michael"
+      ],
       "title": "The Cauchy-Schwarz Master Class: An Introduction to the Art of Mathematical Inequalities",
       "year": "2004",
       "venue": "Cambridge University Press, MAA Problem Books Series",
       "note": "Chapter 3 covers power mean inequalities and the geometric mean as a limit, with exercises on the exp/log proof technique used in this formalization"
     },
     {
-      "authors": ["Beckenbach, E.F.", "Bellman, R."],
+      "authors": [
+        "Beckenbach, E.F.",
+        "Bellman, R."
+      ],
       "title": "Inequalities",
       "year": "1961",
       "venue": "Springer, Ergebnisse der Mathematik und ihrer Grenzgebiete, Band 30",
       "note": "Chapter 2: comprehensive treatment of means and their inequalities, including the power mean family and its continuity properties at r = 0"
     },
     {
-      "authors": ["Kolmogorov, A.N."],
+      "authors": [
+        "Kolmogorov, A.N."
+      ],
       "title": "Sur la notion de la moyenne",
       "year": "1930",
       "venue": "Atti della Reale Accademia Nazionale dei Lincei, Rendiconti, Classe di Scienze Fisiche, Matematiche e Naturali, ser. 6, vol. 12, pp. 388–391",
       "note": "Independently of Nagumo, characterized the power mean family as the unique class of quasi-arithmetic means satisfying continuity, strict monotonicity, and homogeneity. The r→0 limit proved in this formalization is the continuity condition at the singular point that makes the power mean family a smooth one-parameter family from min to max"
     },
     {
-      "authors": ["Nagumo, Mitio"],
+      "authors": [
+        "Nagumo, Mitio"
+      ],
       "title": "Über eine Klasse der Mittelwerte",
       "year": "1930",
       "venue": "Japanese Journal of Mathematics, vol. 7, pp. 71–79",

--- a/src/data/proofs/amgm-inequality-oq-03-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-03/meta.json
@@ -73,6 +73,8 @@
   },
   "leanFile": {
     "axiomCount": 0,
-    "lineCount": 65
+    "lineCount": 65,
+    "path": "Proofs/AmgmInequalityOQ03OQ03.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/amgm-inequality-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03/meta.json
@@ -214,7 +214,9 @@
     "lineCount": 372,
     "axiomCount": 0,
     "theoremCount": 13,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/AmgmInequalityOQ03.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/amgm-inequality-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04/meta.json
@@ -119,12 +119,20 @@
     }
   ],
   "leanFile": {
-    "imports": ["Mathlib"],
-    "opens": ["Filter", "Set", "Real"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Filter",
+      "Set",
+      "Real"
+    ],
     "namespace": "AmgmInequalityOQ04",
     "lineCount": 307,
     "axiomCount": 3,
     "theoremCount": 22,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/AmgmInequalityOQ04.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/amgm-inequality/meta.json
+++ b/src/data/proofs/amgm-inequality/meta.json
@@ -305,7 +305,9 @@
     "theoremCount": 8,
     "substantiveTheoremCount": 3,
     "mathlibWrappers": 5,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/AMGMInequality.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/angle-trisection-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-01/meta.json
@@ -71,7 +71,9 @@
     "lineCount": 366,
     "axiomCount": 0,
     "theoremCount": 40,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/AngleTrisectionOQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -139,28 +141,36 @@
   ],
   "references": [
     {
-      "authors": ["Wantzel, Pierre Laurent"],
+      "authors": [
+        "Wantzel, Pierre Laurent"
+      ],
       "title": "Recherches sur les moyens de reconnaître si un problème de géométrie peut se résoudre avec la règle et le compas",
       "year": "1837",
       "venue": "Journal de Mathématiques Pures et Appliquées, vol. 2, pp. 366–372",
       "note": "Original proof of the three classical impossibilities via minimal polynomial degrees"
     },
     {
-      "authors": ["Gauss, Carl Friedrich"],
+      "authors": [
+        "Gauss, Carl Friedrich"
+      ],
       "title": "Disquisitiones Arithmeticae",
       "year": "1801",
       "venue": "Fleischer, Leipzig",
       "note": "Section VII: proves the regular 17-gon and generally n-gons with φ(n) a power of 2 are constructible"
     },
     {
-      "authors": ["Stewart, Ian"],
+      "authors": [
+        "Stewart, Ian"
+      ],
       "title": "Galois Theory",
       "year": "2015",
       "venue": "Chapman and Hall/CRC, 4th edition",
       "note": "Chapter 17: ruler-and-compass constructions, the Gauss-Wantzel theorem, and Fermat primes"
     },
     {
-      "authors": ["Cox, David A."],
+      "authors": [
+        "Cox, David A."
+      ],
       "title": "Galois Theory",
       "year": "2012",
       "venue": "Wiley, 2nd edition",

--- a/src/data/proofs/angle-trisection-oq-02-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01/meta.json
@@ -145,35 +145,46 @@
   },
   "references": [
     {
-      "authors": ["P. L. Wantzel"],
+      "authors": [
+        "P. L. Wantzel"
+      ],
       "title": "Recherches sur les moyens de reconnaître si un Problème de Géométrie peut se résoudre avec la règle et le compas",
       "year": "1837",
       "venue": "Journal de Mathématiques Pures et Appliquées",
       "note": "First rigorous proof that trisection, doubling the cube, and constructing regular n-gons are impossible for most cases — established the degree criterion"
     },
     {
-      "authors": ["É. Galois", "J. Liouville (ed.)"],
+      "authors": [
+        "É. Galois",
+        "J. Liouville (ed.)"
+      ],
       "title": "Mémoire sur les conditions de résolubilité des équations par radicaux",
       "year": "1846",
       "venue": "Journal de Mathématiques Pures et Appliquées",
       "note": "Posthumous foundational work introducing group theory and the Galois group, providing the deeper characterization of constructibility via 2-groups"
     },
     {
-      "authors": ["I. Stewart"],
+      "authors": [
+        "I. Stewart"
+      ],
       "title": "Galois Theory",
       "year": "2015",
       "venue": "Chapman and Hall/CRC (4th edition)",
       "note": "Modern treatment of the Wantzel-Galois constructibility criterion using the tower law, paralleling this formalization's approach"
     },
     {
-      "authors": ["P. Morandi"],
+      "authors": [
+        "P. Morandi"
+      ],
       "title": "Field and Galois Theory",
       "year": "1996",
       "venue": "Springer GTM 167",
       "note": "Chapter 4: tower law for field extensions and its applications to degree computations — the exact technique used in natDegree_dvd_card_gal"
     },
     {
-      "authors": ["D. A. Cox"],
+      "authors": [
+        "D. A. Cox"
+      ],
       "title": "Galois Theory",
       "year": "2012",
       "venue": "Wiley, 2nd edition",
@@ -275,6 +286,8 @@
         "line": 97,
         "significance": "Bridge theorem connecting OQ-02's Galois-theoretic approach to OQ-01's degree-theoretic approach to constructibility"
       }
-    ]
+    ],
+    "path": "Proofs/AngleTrisectionOQ02OQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/angle-trisection-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-03-oq-01/meta.json
@@ -266,6 +266,8 @@
         "description": "For k coprime to n, cos(2k*pi/n) is a root of minpoly(Q, cos(2pi/n)) — the Galois conjugates result",
         "leanType": "(hn : 3 ≤ n) → (k : ℕ) → (hk : k < n) → (hc : Nat.Coprime k n) → Polynomial.aeval (Real.cos (2 * ↑k * Real.pi / ↑n)) (minpoly ℚ (Real.cos (2 * Real.pi / ↑n))) = 0"
       }
-    ]
+    ],
+    "path": "Proofs/AngleTrisectionOQ02OQ03OQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/angle-trisection-oq-02-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-03/meta.json
@@ -347,7 +347,9 @@
     "lineCount": 1799,
     "axiomCount": 0,
     "theoremCount": 158,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/AngleTrisectionOQ02OQ03.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/angle-trisection-oq-02-oq-04/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-04/meta.json
@@ -101,7 +101,9 @@
     "lineCount": 163,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/AngleTrisectionOQ02OQ04.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/angle-trisection-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02/meta.json
@@ -313,7 +313,9 @@
         "description": "Contrapositive: non-2-group Galois group implies non-constructibility",
         "leanType": "(α : ℝ) → (hα : IsIntegral ℚ α) → ¬ IsPGroup 2 (minpoly ℚ α).Gal → ¬ IsConstructibleFromQ α"
       }
-    ]
+    ],
+    "path": "Proofs/AngleTrisectionOQ02.lean",
+    "sorries": 1
   },
   "references": [
     {

--- a/src/data/proofs/angle-trisection-oq-05-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-05-oq-01/meta.json
@@ -167,12 +167,16 @@
       "Mathlib.NumberTheory.PrimeCounting",
       "Mathlib.Tactic"
     ],
-    "opens": ["Nat"],
+    "opens": [
+      "Nat"
+    ],
     "namespace": "AngleTrisectionOQ05OQ01",
     "lineCount": 294,
     "axiomCount": 0,
     "theoremCount": 24,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/AngleTrisectionOQ05OQ01.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/angle-trisection-oq-05/meta.json
+++ b/src/data/proofs/angle-trisection-oq-05/meta.json
@@ -87,7 +87,9 @@
     "theoremCount": 30,
     "lemmaCount": 0,
     "defCount": 15,
-    "definitionCount": 15
+    "definitionCount": 15,
+    "path": "Proofs/AngleTrisectionOQ05.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/angle-trisection/meta.json
+++ b/src/data/proofs/angle-trisection/meta.json
@@ -103,7 +103,9 @@
     "theoremCount": 23,
     "lemmaCount": 0,
     "defCount": 6,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/AngleTrisection.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "area-of-circle-oq-01-oq-02-oq-01-oq-01",
   "title": "Recursive Computation of Unit Ball Volumes",
   "slug": "area-of-circle-oq-01-oq-02-oq-01-oq-01",
-  "description": "Proves the recurrence \u03c9_{n+2} = (2\u03c0/(n+2))\u00b7\u03c9_n for computing unit n-ball volumes from base cases \u03c9_0 = 1 and \u03c9_1 = 2, using the Gamma function identity \u0393(z+1) = z\u00b7\u0393(z).",
+  "description": "Proves the recurrence ω_{n+2} = (2π/(n+2))·ω_n for computing unit n-ball volumes from base cases ω_0 = 1 and ω_1 = 2, using the Gamma function identity Γ(z+1) = z·Γ(z).",
   "meta": {
     "author": "Classical (Gamma function theory)",
     "status": "verified",
@@ -19,35 +19,35 @@
     "mathlibDependencies": [
       {
         "theorem": "Gamma_add_one",
-        "description": "\u0393(z+1) = z\u00b7\u0393(z) for z \u2260 0, the key identity driving the recurrence",
+        "description": "Γ(z+1) = z·Γ(z) for z ≠ 0, the key identity driving the recurrence",
         "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
       },
       {
         "theorem": "rpow_add",
-        "description": "x^(y+z) = x^y \u00b7 x^z for x > 0, splits \u03c0^((n+2)/2) = \u03c0 \u00b7 \u03c0^(n/2)",
+        "description": "x^(y+z) = x^y · x^z for x > 0, splits π^((n+2)/2) = π · π^(n/2)",
         "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
       },
       {
         "theorem": "Gamma_one_half_eq",
-        "description": "\u0393(1/2) = \u221a\u03c0, used to compute \u03c9_1 = 2",
+        "description": "Γ(1/2) = √π, used to compute ω_1 = 2",
         "module": "Mathlib.Analysis.SpecialFunctions.Gamma.Basic"
       }
     ],
     "originalContributions": [
-      "Proved the unit ball volume recurrence \u03c9_{n+2} = (2\u03c0/(n+2))\u00b7\u03c9_n from Gamma function identity",
-      "Verified base cases \u03c9_0 = 1 and \u03c9_1 = 2 from Gamma function evaluation",
-      "Computed \u03c9_2 through \u03c9_5 purely via the recurrence to demonstrate computability",
-      "Established positivity \u03c9_n > 0 for all n"
+      "Proved the unit ball volume recurrence ω_{n+2} = (2π/(n+2))·ω_n from Gamma function identity",
+      "Verified base cases ω_0 = 1 and ω_1 = 2 from Gamma function evaluation",
+      "Computed ω_2 through ω_5 purely via the recurrence to demonstrate computability",
+      "Established positivity ω_n > 0 for all n"
     ],
     "axiomCount": 0,
     "lineCount": 150,
-    "assumptions": "None \u2014 fully verified from Mathlib",
+    "assumptions": "None — fully verified from Mathlib",
     "mathlib_version": "4.26.0"
   },
   "overview": {
     "historicalContext": "The volume of the unit $n$-ball $\\omega_n = \\pi^{n/2}/\\Gamma(n/2 + 1)$ is a fundamental constant whose formula dates to Dirichlet's 1839 work on multi-dimensional integrals, later refined by Schläfli (1852) in his studies of higher-dimensional geometry. The Gamma function $\\Gamma(z+1) = z\\cdot\\Gamma(z)$, discovered by Euler in 1729 as an extension of the factorial to non-integer arguments, provides the key structural identity. The two-step recurrence $\\omega_{n+2} = (2\\pi/(n+2))\\cdot\\omega_n$ is a folklore result that appears in various forms in analysis textbooks (e.g., Folland's 'Introduction to Partial Differential Equations', Stein and Shakarchi's 'Real Analysis'). A notable feature of the volume sequence is that $\\omega_n \\to 0$ as $n \\to \\infty$ — the unit ball becomes negligible in high dimensions, a phenomenon known as the 'curse of dimensionality' in statistics and machine learning.",
     "problemStatement": "Can the unit ball volumes $\\omega_n$ be computed for all $n$ via a recursive formula?",
-    "text": "Proves the recurrence \u03c9_{n+2} = (2\u03c0/(n+2))\u00b7\u03c9_n for computing unit n-ball volumes.",
+    "text": "Proves the recurrence ω_{n+2} = (2π/(n+2))·ω_n for computing unit n-ball volumes.",
     "proofStrategy": "The proof unfolds $\\omega_{n+2}$ and $\\omega_n$ by definition, uses `push_cast` and `ring` for cast arithmetic, `rpow_add` to factor $\\pi^{(n+2)/2}$ into $\\pi \\cdot \\pi^{n/2}$, and `Gamma_add_one` to factor $\\Gamma(n/2+2)$ into $(n/2+1)\\cdot\\Gamma(n/2+1)$. Finally `field_simp` and `ring` close the algebraic identity.",
     "keyInsights": [
       "The recurrence $\\omega_{n+2} = (2\\pi/(n+2))\\cdot\\omega_n$ reduces to the Gamma function identity $\\Gamma(z+1) = z\\cdot\\Gamma(z)$ applied at $z = n/2 + 1$",
@@ -107,12 +107,12 @@
     {
       "targetId": "area-of-circle-oq-01-oq-02-oq-01",
       "relationship": "parent",
-      "description": "Parent OQ defining unitBallVolume and proving V_n(r) = \u222b\u2080\u02b3 S_n(\u03c1) d\u03c1"
+      "description": "Parent OQ defining unitBallVolume and proving V_n(r) = ∫₀ʳ S_n(ρ) dρ"
     },
     {
       "targetId": "area-of-circle",
       "relationship": "ancestor",
-      "description": "Root proof: A = \u03c0r\u00b2 for the circle, the starting point of this OQ chain"
+      "description": "Root proof: A = πr² for the circle, the starting point of this OQ chain"
     }
   ],
   "leanFile": {
@@ -126,6 +126,8 @@
     "lineCount": 150,
     "axiomCount": 0,
     "theoremCount": 9,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01/meta.json
@@ -226,7 +226,9 @@
     "lineCount": 290,
     "axiomCount": 0,
     "theoremCount": 26,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/AreaOfCircleOq01Oq02Oq01.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "area-of-circle-oq-01-oq-02-oq-02-oq-01",
   "title": "Isoperimetric Inequality from IBP + Wirtinger + Parseval (Hurwitz 1901)",
   "slug": "area-of-circle-oq-01-oq-02-oq-02-oq-01",
-  "description": "Clean formalization of Hurwitz's 1901 Fourier-analytic proof of the isoperimetric inequality C\u00b2 \u2265 4\u03c0A. Chains three analytical ingredients: integration by parts for Fourier coefficients, Parseval's identity, and Wirtinger's inequality. The arithmetic kernel (from Wirtinger bounds to 4\u03c0A \u2264 L\u00b2) is fully proved. Concrete examples verify C\u00b2 = 4\u03c0A for circles and C\u00b2 > 4\u03c0A for squares.",
+  "description": "Clean formalization of Hurwitz's 1901 Fourier-analytic proof of the isoperimetric inequality C² ≥ 4πA. Chains three analytical ingredients: integration by parts for Fourier coefficients, Parseval's identity, and Wirtinger's inequality. The arithmetic kernel (from Wirtinger bounds to 4πA ≤ L²) is fully proved. Concrete examples verify C² = 4πA for circles and C² > 4πA for squares.",
   "meta": {
     "author": "Hurwitz (1901); formalized 2026",
     "sourceUrl": "https://en.wikipedia.org/wiki/Isoperimetric_inequality",
@@ -36,39 +36,39 @@
       },
       {
         "theorem": "Int.one_le_abs",
-        "description": "For nonzero integers, |n| \u2265 1",
+        "description": "For nonzero integers, |n| ≥ 1",
         "module": "Mathlib.Data.Int.Order"
       }
     ],
     "originalContributions": [
       "FourierDecomp structure: clean packaging of Fourier decomposition properties",
-      "wirtinger_inequality: Wirtinger from Fourier decomposition (pointwise n\u00b2 \u2265 1 argument)",
-      "isoperimetric_arithmetic_kernel: purely algebraic deduction 4\u03c0A \u2264 L\u00b2 from Wirtinger bounds",
+      "wirtinger_inequality: Wirtinger from Fourier decomposition (pointwise n² ≥ 1 argument)",
+      "isoperimetric_arithmetic_kernel: purely algebraic deduction 4πA ≤ L² from Wirtinger bounds",
       "isoperimetric_inequality: full statement with reparametrization + Wirtinger chain",
-      "cross_product_sq_le: 2D algebraic Cauchy\u2013Schwarz",
+      "cross_product_sq_le: 2D algebraic Cauchy–Schwarz",
       "circle_isoperimetric_ratio: I(circle) = 1",
-      "square_isoperimetric_strict: C\u00b2 > 4\u03c0A for squares (via \u03c0 < 4)"
+      "square_isoperimetric_strict: C² > 4πA for squares (via π < 4)"
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 5,
     "lineCount": 419,
-    "assumptions": "Five axioms: (1) fourier_decomp_exists (Fourier decomposition for periodic C\u00b9 functions), (2) exists_nice_reparam (arc-length reparametrization with zero mean), (3) wirtinger_sum_bound (Wirtinger applied to coordinate functions), (4) area_cauchy_schwarz_bound (Green\u2019s theorem + Cauchy\u2013Schwarz), (5) integral_cauchy_schwarz_sq (L\u00b2 Cauchy\u2013Schwarz). Of these, #1 and #3 are proved in AreaOfCircleOQ01OQ03.lean.",
+    "assumptions": "Five axioms: (1) fourier_decomp_exists (Fourier decomposition for periodic C¹ functions), (2) exists_nice_reparam (arc-length reparametrization with zero mean), (3) wirtinger_sum_bound (Wirtinger applied to coordinate functions), (4) area_cauchy_schwarz_bound (Green’s theorem + Cauchy–Schwarz), (5) integral_cauchy_schwarz_sq (L² Cauchy–Schwarz). Of these, #1 and #3 are proved in AreaOfCircleOQ01OQ03.lean.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The isoperimetric inequality C\u00b2 \u2265 4\u03c0A states that among all simple closed curves of given circumference, the circle encloses the maximum area. Known since antiquity, the first rigorous proof was given by Weierstrass (1870s). Hurwitz (1901) gave an elegant proof using Fourier analysis: the key insight is that Wirtinger\u2019s inequality (itself a consequence of Parseval + IBP) provides the analytical bound that, combined with Cauchy\u2013Schwarz, yields the geometric inequality.",
-    "problemStatement": "**Theorem (Isoperimetric Inequality)**: For any smooth closed plane curve with circumference $C$ and enclosed area $A$:\n$$C^2 \\geq 4\\pi A$$\nwith equality if and only if the curve is a circle.\n\n**Proof chain**: Parseval + IBP \u2192 Wirtinger \u2192 Arithmetic kernel \u2192 Isoperimetric inequality.",
-    "text": "Clean formalization of Hurwitz's 1901 Fourier-analytic proof of the isoperimetric inequality C\u00b2 \u2265 4\u03c0A. The proof chains IBP for Fourier coefficients, Parseval\u2019s identity, and Wirtinger\u2019s inequality through an arithmetic kernel to the geometric conclusion.",
-    "proofStrategy": "**Layer 1 (Analytical)**: Wirtinger\u2019s inequality from Fourier analysis. For a mean-zero 2\u03c0-periodic $C^1$ function $f$: $\\int_0^{2\\pi} f^2 \\leq \\int_0^{2\\pi} (f')^2$. Proof: from Parseval, $\\int f^2 = \\sum c_n^2$ and $\\int (f')^2 = \\sum n^2 c_n^2$. Mean zero gives $c_0 = 0$. For $n \\neq 0$, $n^2 \\geq 1$, so $n^2 c_n^2 \\geq c_n^2$.\n\n**Layer 2 (Algebraic)**: The arithmetic kernel. Given bounds from Wirtinger ($S_{xy} \\leq 2\\pi c^2$), Cauchy\u2013Schwarz ($S^2 \\leq 2\\pi S_{xy}$, $2A \\leq cS$), chain: $S \\leq 2\\pi c$, $2A \\leq 2\\pi c^2$, $4\\pi A \\leq (2\\pi c)^2 = L^2$.\n\n**Layer 3 (Geometric)**: Reparametrize to constant speed, subtract means, apply Layers 1+2.",
+    "historicalContext": "The isoperimetric inequality C² ≥ 4πA states that among all simple closed curves of given circumference, the circle encloses the maximum area. Known since antiquity, the first rigorous proof was given by Weierstrass (1870s). Hurwitz (1901) gave an elegant proof using Fourier analysis: the key insight is that Wirtinger’s inequality (itself a consequence of Parseval + IBP) provides the analytical bound that, combined with Cauchy–Schwarz, yields the geometric inequality.",
+    "problemStatement": "**Theorem (Isoperimetric Inequality)**: For any smooth closed plane curve with circumference $C$ and enclosed area $A$:\n$$C^2 \\geq 4\\pi A$$\nwith equality if and only if the curve is a circle.\n\n**Proof chain**: Parseval + IBP → Wirtinger → Arithmetic kernel → Isoperimetric inequality.",
+    "text": "Clean formalization of Hurwitz's 1901 Fourier-analytic proof of the isoperimetric inequality C² ≥ 4πA. The proof chains IBP for Fourier coefficients, Parseval’s identity, and Wirtinger’s inequality through an arithmetic kernel to the geometric conclusion.",
+    "proofStrategy": "**Layer 1 (Analytical)**: Wirtinger’s inequality from Fourier analysis. For a mean-zero 2π-periodic $C^1$ function $f$: $\\int_0^{2\\pi} f^2 \\leq \\int_0^{2\\pi} (f')^2$. Proof: from Parseval, $\\int f^2 = \\sum c_n^2$ and $\\int (f')^2 = \\sum n^2 c_n^2$. Mean zero gives $c_0 = 0$. For $n \\neq 0$, $n^2 \\geq 1$, so $n^2 c_n^2 \\geq c_n^2$.\n\n**Layer 2 (Algebraic)**: The arithmetic kernel. Given bounds from Wirtinger ($S_{xy} \\leq 2\\pi c^2$), Cauchy–Schwarz ($S^2 \\leq 2\\pi S_{xy}$, $2A \\leq cS$), chain: $S \\leq 2\\pi c$, $2A \\leq 2\\pi c^2$, $4\\pi A \\leq (2\\pi c)^2 = L^2$.\n\n**Layer 3 (Geometric)**: Reparametrize to constant speed, subtract means, apply Layers 1+2.",
     "keyInsights": [
-      "Wirtinger\u2019s inequality reduces to n\u00b2 \u2265 1 for nonzero integers via Fourier decomposition",
-      "The arithmetic kernel is purely algebraic \u2014 no integrals or measures",
-      "The circle\u2019s optimality comes from equality in Wirtinger (only n = \u00b11 terms)",
+      "Wirtinger’s inequality reduces to n² ≥ 1 for nonzero integers via Fourier decomposition",
+      "The arithmetic kernel is purely algebraic — no integrals or measures",
+      "The circle’s optimality comes from equality in Wirtinger (only n = ±1 terms)",
       "Five axioms isolate the analytical infrastructure; the logical structure is fully verified",
-      "The square\u2019s strict inequality C\u00b2 > 4\u03c0A reduces to \u03c0 < 4"
+      "The square’s strict inequality C² > 4πA reduces to π < 4"
     ],
     "prerequisites": [
-      "Fourier analysis (Parseval\u2019s identity, Fourier coefficients)",
+      "Fourier analysis (Parseval’s identity, Fourier coefficients)",
       "Real analysis (integration, differentiation, periodic functions)",
       "Elementary geometry (area, circumference)"
     ]
@@ -79,15 +79,15 @@
       "title": "Part I: Fourier Decomposition",
       "startLine": 51,
       "endLine": 90,
-      "summary": "FourierDecomp structure packaging real Fourier coefficients with Parseval identities for f and f\u2019. Axiom: every 2\u03c0-periodic C\u00b9 function admits such a decomposition.",
+      "summary": "FourierDecomp structure packaging real Fourier coefficients with Parseval identities for f and f’. Axiom: every 2π-periodic C¹ function admits such a decomposition.",
       "mathContext": "Fourier decomposition: $\\int f^2 = \\sum c_n^2$, $\\int (f')^2 = \\sum n^2 c_n^2$, $c_0 = \\frac{1}{\\sqrt{2\\pi}}\\int f$."
     },
     {
       "id": "part-ii",
-      "title": "Part II: Wirtinger\u2019s Inequality",
+      "title": "Part II: Wirtinger’s Inequality",
       "startLine": 92,
       "endLine": 136,
-      "summary": "Wirtinger\u2019s inequality: \u222bf\u00b2 \u2264 \u222b(f\u2019)\u00b2 for mean-zero periodic C\u00b9 functions. Proved from Fourier decomposition via pointwise bound n\u00b2c\u2099\u00b2 \u2265 c\u2099\u00b2.",
+      "summary": "Wirtinger’s inequality: ∫f² ≤ ∫(f’)² for mean-zero periodic C¹ functions. Proved from Fourier decomposition via pointwise bound n²cₙ² ≥ cₙ².",
       "mathContext": "For mean-zero $f$: $c_0 = 0$, so $\\sum n^2 c_n^2 \\geq \\sum c_n^2$ since $n^2 \\geq 1$ for $n \\neq 0$."
     },
     {
@@ -95,15 +95,15 @@
       "title": "Part III: Arithmetic Kernel",
       "startLine": 138,
       "endLine": 190,
-      "summary": "Purely algebraic deduction: from Wirtinger bounds + Cauchy\u2013Schwarz, deduce 4\u03c0A \u2264 L\u00b2. Chain: S\u00b2 \u2264 (2\u03c0c)\u00b2 \u2192 S \u2264 2\u03c0c \u2192 2A \u2264 2\u03c0c\u00b2 \u2192 4\u03c0A \u2264 L\u00b2.",
+      "summary": "Purely algebraic deduction: from Wirtinger bounds + Cauchy–Schwarz, deduce 4πA ≤ L². Chain: S² ≤ (2πc)² → S ≤ 2πc → 2A ≤ 2πc² → 4πA ≤ L².",
       "mathContext": "Arithmetic kernel: $S^2 \\leq 2\\pi \\cdot 2\\pi c^2 = (2\\pi c)^2$, so $S \\leq 2\\pi c$, giving $2A \\leq c \\cdot 2\\pi c = 2\\pi c^2$ and $4\\pi A \\leq (2\\pi c)^2 = L^2$."
     },
     {
       "id": "part-iv-v",
-      "title": "Parts IV\u2013V: Curve Structure and Circle Equality",
+      "title": "Parts IV–V: Curve Structure and Circle Equality",
       "startLine": 192,
       "endLine": 258,
-      "summary": "SmoothClosedCurve structure, circumference and area definitions, circle C\u00b2 = 4\u03c0A equality, isoperimetric ratio I(circle) = 1.",
+      "summary": "SmoothClosedCurve structure, circumference and area definitions, circle C² = 4πA equality, isoperimetric ratio I(circle) = 1.",
       "mathContext": "Circle: $C = 2\\pi r$, $A = \\pi r^2$, $C^2 = 4\\pi^2 r^2 = 4\\pi A$. Isoperimetric ratio: $I(\\gamma) = C^2/(4\\pi A)$, $I(\\text{circle}) = 1$."
     },
     {
@@ -111,7 +111,7 @@
       "title": "Part VI: Non-Circular Strict Inequality",
       "startLine": 260,
       "endLine": 306,
-      "summary": "Square: C\u00b2 > 4\u03c0A (via \u03c0 < 4), I(square) = 4/\u03c0. Equilateral triangle ratio.",
+      "summary": "Square: C² > 4πA (via π < 4), I(square) = 4/π. Equilateral triangle ratio.",
       "mathContext": "Square (side $s$): $C = 4s$, $A = s^2$, $C^2/(4\\pi A) = 16/(4\\pi) = 4/\\pi > 1$."
     },
     {
@@ -119,25 +119,25 @@
       "title": "Part VII: The Full Isoperimetric Inequality",
       "startLine": 308,
       "endLine": 395,
-      "summary": "Full isoperimetric theorem C\u00b2 \u2265 4\u03c0A via reparametrization (axiom) + Wirtinger chain + arithmetic kernel. Five analytical axioms.",
-      "mathContext": "For smooth closed $\\gamma$ with $C > 0$: reparametrize to constant speed $c = C/(2\\pi)$ with zero mean, apply Wirtinger + Cauchy\u2013Schwarz, feed into arithmetic kernel to get $4\\pi A \\leq C^2$."
+      "summary": "Full isoperimetric theorem C² ≥ 4πA via reparametrization (axiom) + Wirtinger chain + arithmetic kernel. Five analytical axioms.",
+      "mathContext": "For smooth closed $\\gamma$ with $C > 0$: reparametrize to constant speed $c = C/(2\\pi)$ with zero mean, apply Wirtinger + Cauchy–Schwarz, feed into arithmetic kernel to get $4\\pi A \\leq C^2$."
     }
   ],
   "conclusion": {
-    "summary": "The isoperimetric inequality C\u00b2 \u2265 4\u03c0A is formalized following Hurwitz (1901) with 5 axioms, 0 sorries, 11 theorems. The Wirtinger inequality and arithmetic kernel are fully proved; axioms isolate the Fourier decomposition, reparametrization, and integral bounds.",
-    "implications": "**Mathematical Significance**:\n\n**1. Clean Proof Architecture**: The three-layer structure (Analytical \u2192 Algebraic \u2192 Geometric) makes the logical dependencies explicit.\n\n**2. Wirtinger from Fourier**: The pointwise argument n\u00b2 \u2265 1 for n \u2260 0 gives a transparent proof of Wirtinger\u2019s inequality.\n\n**3. Arithmetic Kernel**: The purely algebraic core is reusable for any isoperimetric-type inequality that reduces to the same bound structure.\n\n**4. Axiom Roadmap**: The 5 axioms provide a precise specification of what Mathlib infrastructure would eliminate them: Fourier decomposition (#1), inverse function theorem for arc-length (#2), Wirtinger application (#3), Green\u2019s theorem (#4), L\u00b2 Cauchy\u2013Schwarz (#5).",
+    "summary": "The isoperimetric inequality C² ≥ 4πA is formalized following Hurwitz (1901) with 5 axioms, 0 sorries, 11 theorems. The Wirtinger inequality and arithmetic kernel are fully proved; axioms isolate the Fourier decomposition, reparametrization, and integral bounds.",
+    "implications": "**Mathematical Significance**:\n\n**1. Clean Proof Architecture**: The three-layer structure (Analytical → Algebraic → Geometric) makes the logical dependencies explicit.\n\n**2. Wirtinger from Fourier**: The pointwise argument n² ≥ 1 for n ≠ 0 gives a transparent proof of Wirtinger’s inequality.\n\n**3. Arithmetic Kernel**: The purely algebraic core is reusable for any isoperimetric-type inequality that reduces to the same bound structure.\n\n**4. Axiom Roadmap**: The 5 axioms provide a precise specification of what Mathlib infrastructure would eliminate them: Fourier decomposition (#1), inverse function theorem for arc-length (#2), Wirtinger application (#3), Green’s theorem (#4), L² Cauchy–Schwarz (#5).",
     "openQuestions": [
       "Prove the reparametrization axiom from the inverse function theorem in Mathlib",
-      "Formalize Green\u2019s theorem for smooth closed curves to eliminate axiom #4",
-      "The equality condition: C\u00b2 = 4\u03c0A iff curve is a circle (requires Wirtinger equality characterization)",
-      "Higher-dimensional isoperimetric inequalities via Brunn\u2013Minkowski"
+      "Formalize Green’s theorem for smooth closed curves to eliminate axiom #4",
+      "The equality condition: C² = 4πA iff curve is a circle (requires Wirtinger equality characterization)",
+      "Higher-dimensional isoperimetric inequalities via Brunn–Minkowski"
     ]
   },
   "crossReferences": [
     {
       "targetId": "area-of-circle-oq-01-oq-02-oq-02",
       "relationship": "extends",
-      "description": "Parent: IBP lemma \u0109\u2099(f\u2019) = in\u00b7\u0109\u2099(f) for Fourier coefficients. This file uses IBP as an ingredient in the Wirtinger \u2192 Isoperimetric chain."
+      "description": "Parent: IBP lemma ĉₙ(f’) = in·ĉₙ(f) for Fourier coefficients. This file uses IBP as an ingredient in the Wirtinger → Isoperimetric chain."
     },
     {
       "targetId": "area-of-circle-oq-01-oq-03",
@@ -147,15 +147,15 @@
     {
       "targetId": "area-of-circle",
       "relationship": "foundational",
-      "description": "Root ancestor: A = \u03c0r\u00b2. The isoperimetric inequality characterizes the circle as the area-maximizing shape."
+      "description": "Root ancestor: A = πr². The isoperimetric inequality characterizes the circle as the area-maximizing shape."
     }
   ],
   "references": [
     {
       "authors": "Hurwitz, A.",
-      "title": "Sur le probl\u00e8me des isop\u00e9rim\u00e8tres",
+      "title": "Sur le problème des isopérimètres",
       "year": "1901",
-      "venue": "Comptes Rendus de l'Acad\u00e9mie des Sciences, Paris, 132:401\u2013403",
+      "venue": "Comptes Rendus de l'Académie des Sciences, Paris, 132:401–403",
       "note": "First Fourier-analytic proof of the isoperimetric inequality"
     },
     {
@@ -167,10 +167,10 @@
     },
     {
       "authors": "Wirtinger, W.",
-      "title": "\u00dcber eine Minimumaufgabe im Gebiete der analytischen Funktionen",
+      "title": "Über eine Minimumaufgabe im Gebiete der analytischen Funktionen",
       "year": "1904",
-      "venue": "Monatsh. Math. Phys. 15:169\u2013172",
-      "note": "Original statement of Wirtinger\u2019s inequality for periodic functions"
+      "venue": "Monatsh. Math. Phys. 15:169–172",
+      "note": "Original statement of Wirtinger’s inequality for periodic functions"
     }
   ],
   "leanFile": {
@@ -190,6 +190,8 @@
     "lineCount": 419,
     "axiomCount": 5,
     "theoremCount": 11,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/AreaOfCircleOQ01OQ02OQ02OQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-02/meta.json
@@ -192,7 +192,9 @@
     "lineCount": 82,
     "axiomCount": 0,
     "theoremCount": 2,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/AreaOfCircleOQ01OQ02OQ02.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/area-of-circle-oq-01-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02/meta.json
@@ -177,7 +177,9 @@
     "lineCount": 146,
     "axiomCount": 0,
     "theoremCount": 11,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/AreaFromCircumferenceIntegral.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -307,6 +307,8 @@
         "statement": "Fourier decomposition with Parseval + derivative identity for periodic C¹ functions",
         "line": 526
       }
-    ]
+    ],
+    "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
+    "sorries": 1
   }
 }

--- a/src/data/proofs/area-of-circle-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01/meta.json
@@ -196,7 +196,9 @@
     "lineCount": 163,
     "axiomCount": 0,
     "theoremCount": 18,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/CircumferenceFromArea.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/area-of-circle-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-02/meta.json
@@ -96,7 +96,9 @@
     "lineCount": 211,
     "axiomCount": 1,
     "theoremCount": 16,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/AreaOfCircleOQ02.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/area-of-circle-oq-03-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-01/meta.json
@@ -104,7 +104,9 @@
     "lineCount": 232,
     "axiomCount": 0,
     "theoremCount": 9,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/AreaOfCircleOQ03OQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/area-of-circle-oq-03-oq-02-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02-oq-02/meta.json
@@ -164,7 +164,9 @@
       "dalzell_integrand_decomposition",
       "dalzell_niven_integral",
       "pi_lt_twentytwo_over_seven"
-    ]
+    ],
+    "path": "Proofs/AreaOfCircleOQ03OQ02OQ02.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02/meta.json
@@ -179,7 +179,9 @@
       "archimedes_bounds",
       "inscribed_half_perimeter_lt_pi",
       "archimedes_verified"
-    ]
+    ],
+    "path": "Proofs/AreaOfCircleOQ03OQ02.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/area-of-circle-oq-03-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-03/meta.json
@@ -105,7 +105,9 @@
     "lineCount": 190,
     "axiomCount": 0,
     "theoremCount": 14,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/AreaOfCircleOQ03OQ03.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/area-of-circle-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03/meta.json
@@ -188,7 +188,9 @@
     "lineCount": 366,
     "axiomCount": 0,
     "theoremCount": 17,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/ArchimedesMethodOfExhaustion.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/area-of-circle/meta.json
+++ b/src/data/proofs/area-of-circle/meta.json
@@ -231,7 +231,9 @@
         "description": "Lebesgue measure of a closed ball in C equals r^2 * pi",
         "leanType": "(center : ℂ) → (r : ℝ) → volume (closedBall center r) = ENNReal.ofReal r ^ 2 * ↑NNReal.pi"
       }
-    ]
+    ],
+    "path": "Proofs/AreaOfCircle.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/arithmetic-series-oq-02-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-01/meta.json
@@ -61,7 +61,9 @@
     "lineCount": 173,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/ArithmeticSeriesOQ02OQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-01/meta.json
@@ -101,7 +101,9 @@
     "lineCount": 165,
     "axiomCount": 0,
     "theoremCount": 8,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03/meta.json
@@ -179,6 +179,8 @@
     "lineCount": 207,
     "axiomCount": 0,
     "theoremCount": 11,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ03.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02/meta.json
@@ -188,7 +188,9 @@
         "type": "original",
         "description": "1D hockey stick identity: Σ_{i=0}^n C(i+k,k) = C(n+k+1,k+1), proved by induction with Pascal's recurrence"
       }
-    ]
+    ],
+    "path": "Proofs/ArithmeticSeriesOQ02OQ02.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01/meta.json
@@ -127,6 +127,8 @@
     "lineCount": 169,
     "axiomCount": 0,
     "theoremCount": 11,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04/meta.json
@@ -188,7 +188,9 @@
         "type": "original",
         "description": "k! divides ascFactorial(n+1, k) -- divisibility corollary"
       }
-    ]
+    ],
+    "path": "Proofs/ArithmeticSeriesOQ02OQ04.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/arithmetic-series-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02/meta.json
@@ -231,7 +231,9 @@
         "description": "Tetrahedral number closed form: S_3(n) * 6 = (n+1)(n+2)(n+3)",
         "leanType": "(n : ℕ) → simplicial 3 n * 6 = (n + 1) * (n + 2) * (n + 3)"
       }
-    ]
+    ],
+    "path": "Proofs/ArithmeticSeriesOQ02.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/arithmetic-series-oq-04/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-04/meta.json
@@ -175,7 +175,9 @@
         "description": "Bernoulli polynomial form of Faulhaber's formula",
         "leanType": "(n p : ℕ) → (p+1 : ℚ) * ∑ k ∈ range n, (k:ℚ)^p = (Polynomial.bernoulli p.succ).eval (n:ℚ) - bernoulli p.succ"
       }
-    ]
+    ],
+    "path": "Proofs/ArithmeticSeriesOQ04.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/arithmetic-series/meta.json
+++ b/src/data/proofs/arithmetic-series/meta.json
@@ -147,7 +147,9 @@
     "lineCount": 180,
     "axiomCount": 0,
     "theoremCount": 11,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/ArithmeticSeries.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-01/meta.json
@@ -181,7 +181,9 @@
     "theoremCount": 3,
     "substantiveTheoremCount": 1,
     "trivialPlaceholders": 2,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/BallotProblemOQ01OQ01.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/ballot-problem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02/meta.json
@@ -71,7 +71,9 @@
     "lineCount": 934,
     "axiomCount": 1,
     "theoremCount": 36,
-    "definitionCount": 18
+    "definitionCount": 18,
+    "path": "Proofs/BallotProblemOQ01OQ02.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/ballot-problem-oq-01-oq-04/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-04/meta.json
@@ -165,7 +165,9 @@
     "theoremCount": 8,
     "substantiveTheoremCount": 7,
     "trivialPlaceholders": 0,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/BallotProblemOQ01OQ04.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/ballot-problem-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01/meta.json
@@ -314,6 +314,8 @@
         "statement": "(l.take i).sum = (l.take i).count 1 - (k : ℤ) * (l.take i).count (-(k : ℤ))",
         "description": "The lattice path height at step i equals the count of A-votes minus k times the count of B-votes up to that point"
       }
-    ]
+    ],
+    "path": "Proofs/BallotProblemOQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/ballot-problem-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-02/meta.json
@@ -261,6 +261,8 @@
     ],
     "axiomCount": 2,
     "theoremCount": 8,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/BallotProblemOQ02.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/ballot-problem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01/meta.json
@@ -73,7 +73,9 @@
     "lineCount": 2878,
     "axiomCount": 0,
     "theoremCount": 138,
-    "definitionCount": 31
+    "definitionCount": 31,
+    "path": "Proofs/BallotProblemOQ03.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
@@ -289,6 +289,8 @@
     "lineCount": 2314,
     "axiomCount": 0,
     "theoremCount": 82,
-    "definitionCount": 29
+    "definitionCount": 29,
+    "path": "Proofs/BallotProblemOQ03OQ02.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/ballot-problem-oq-03/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03/meta.json
@@ -373,6 +373,8 @@
         "statement": "0 <= lgvDet(m, a1, b1, a2, b2) under proper ordering",
         "description": "Non-negativity of the LGV determinant follows from the LGV lemma since it counts non-intersecting path pairs."
       }
-    ]
+    ],
+    "path": "Proofs/BallotProblemOQ03.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/ballot-problem/meta.json
+++ b/src/data/proofs/ballot-problem/meta.json
@@ -256,7 +256,9 @@
     "lineCount": 251,
     "axiomCount": 0,
     "theoremCount": 7,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/BallotProblem.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/basel-problem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01/meta.json
@@ -110,7 +110,9 @@
     "lineCount": 144,
     "axiomCount": 0,
     "theoremCount": 7,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/BaselProblemOQ01OQ01.lean",
+    "sorries": 0
   },
   "references": []
 }

--- a/src/data/proofs/basel-problem-oq-01/meta.json
+++ b/src/data/proofs/basel-problem-oq-01/meta.json
@@ -206,7 +206,9 @@
     "lineCount": 244,
     "axiomCount": 3,
     "theoremCount": 15,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/ZetaFiveIrrationality.lean",
+    "sorries": 1
   },
   "references": [
     {

--- a/src/data/proofs/basel-problem-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-02/meta.json
@@ -225,7 +225,9 @@
     "lineCount": 274,
     "axiomCount": 2,
     "theoremCount": 10,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/BaselProblemOQ02.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/basel-problem-oq-05/meta.json
+++ b/src/data/proofs/basel-problem-oq-05/meta.json
@@ -158,6 +158,8 @@
     "theoremCount": 9,
     "substantiveTheoremCount": 3,
     "trueStubs": 1,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/BaselProblemOQ05.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/basel-problem/meta.json
+++ b/src/data/proofs/basel-problem/meta.json
@@ -346,7 +346,9 @@
         "description": "General formula ζ(2k) = (-1)^(k+1) · 2^(2k-1) · π^(2k) · B_{2k} / (2k)! for k ≠ 0",
         "leanType": "(k : ℕ) → k ≠ 0 → HasSum (fun n : ℕ => 1 / (↑n : ℝ) ^ (2 * k)) ((-1)^(k+1) * 2^(2*k-1) * π^(2*k) * bernoulli (2*k) / (2*k).factorial)"
       }
-    ]
+    ],
+    "path": "Proofs/BaselProblem.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/bertrands-postulate-oq-03/meta.json
+++ b/src/data/proofs/bertrands-postulate-oq-03/meta.json
@@ -289,6 +289,8 @@
         "type": "axiom",
         "description": "Legendre's conjecture: a prime exists between n² and (n+1)² for all n ≥ 1"
       }
-    ]
+    ],
+    "path": "Proofs/BertrandsPostulateOQ03.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/bertrands-postulate/meta.json
+++ b/src/data/proofs/bertrands-postulate/meta.json
@@ -203,7 +203,9 @@
     "lineCount": 165,
     "axiomCount": 0,
     "theoremCount": 7,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/BertrandsPostulate.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/bezout-identity-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01/meta.json
@@ -61,7 +61,9 @@
     "lineCount": 208,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/BezoutIdentityOQ01.lean",
+    "sorries": 1
   },
   "crossReferences": [
     {

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01/meta.json
@@ -8,7 +8,14 @@
     "date": "2026-04-04",
     "status": "verified",
     "proofRepoPath": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
-    "tags": ["algebra", "polynomial-rings", "unique-factorization", "bezout", "euclids-lemma", "number-theory"],
+    "tags": [
+      "algebra",
+      "polynomial-rings",
+      "unique-factorization",
+      "bezout",
+      "euclids-lemma",
+      "number-theory"
+    ],
     "badge": "original",
     "sorries": 0,
     "dateAdded": "2026-04-04",
@@ -128,21 +135,28 @@
   ],
   "references": [
     {
-      "authors": ["Gauss, C.F."],
+      "authors": [
+        "Gauss, C.F."
+      ],
       "title": "Disquisitiones Arithmeticae",
       "year": "1801",
       "venue": "Gerh. Fleischer Jun., Leipzig",
       "note": "Contains foundational work on factorization; the polynomial ring analogy was developed in later works"
     },
     {
-      "authors": ["Lang, S."],
+      "authors": [
+        "Lang, S."
+      ],
       "title": "Algebra",
       "year": "2002",
       "venue": "Springer, Graduate Texts in Mathematics 211, 3rd edition",
       "note": "Chapter II: UFDs and PIDs; Chapter V: polynomial rings and Gauss's lemma"
     },
     {
-      "authors": ["Zariski, O.", "Samuel, P."],
+      "authors": [
+        "Zariski, O.",
+        "Samuel, P."
+      ],
       "title": "Commutative Algebra, Vol. I",
       "year": "1958",
       "venue": "D. Van Nostrand, Princeton",
@@ -154,6 +168,8 @@
     "lineCount": 152,
     "axiomCount": 0,
     "theoremCount": 11,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/bezout-identity-oq-02-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01/meta.json
@@ -214,6 +214,8 @@
     "lineCount": 257,
     "axiomCount": 0,
     "theoremCount": 11,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-01/meta.json
@@ -172,6 +172,8 @@
     "lineCount": 182,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02-oq-01/meta.json
@@ -302,6 +302,8 @@
     "lineCount": 200,
     "axiomCount": 0,
     "theoremCount": 11,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/bezout-identity-oq-02-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-02/meta.json
@@ -213,6 +213,8 @@
     "lineCount": 285,
     "axiomCount": 0,
     "theoremCount": 14,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/bezout-identity-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02/meta.json
@@ -214,6 +214,8 @@
     "lineCount": 192,
     "axiomCount": 0,
     "theoremCount": 4,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/BezoutIdentityOQ02.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/bezout-identity-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -174,7 +174,9 @@
     "lineCount": 160,
     "axiomCount": 0,
     "theoremCount": 9,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/bezout-identity-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-01-oq-01/meta.json
@@ -185,7 +185,9 @@
     "lineCount": 249,
     "axiomCount": 0,
     "theoremCount": 14,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/bezout-identity-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-01-oq-02/meta.json
@@ -61,7 +61,9 @@
     "lineCount": 227,
     "axiomCount": 0,
     "theoremCount": 12,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/bezout-identity-oq-03-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-01/meta.json
@@ -219,6 +219,8 @@
     "lineCount": 315,
     "axiomCount": 0,
     "theoremCount": 25,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/bezout-identity-oq-03-oq-04/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-04/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "bezout-identity-oq-03-oq-04",
-  "title": "Efficient Verified CRT via Direct B\u00e9zout",
+  "title": "Efficient Verified CRT via Direct Bézout",
   "slug": "bezout-identity-oq-03-oq-04",
-  "description": "Efficient CRT computation using direct B\u00e9zout coefficients without modular reduction. Proves correctness and uniqueness. 8 theorems, 0 axioms.",
+  "description": "Efficient CRT computation using direct Bézout coefficients without modular reduction. Proves correctness and uniqueness. 8 theorems, 0 axioms.",
   "meta": {
     "author": "Lean Genius",
     "status": "verified",
@@ -10,7 +10,7 @@
     "tags": [
       "number theory",
       "CRT",
-      "B\u00e9zout",
+      "Bézout",
       "algorithms"
     ],
     "badge": "mathlib",
@@ -26,7 +26,9 @@
     "lineCount": 142,
     "axiomCount": 0,
     "theoremCount": 8,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/BezoutIdentityOQ03OQ04.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/bezout-identity-oq-03/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03/meta.json
@@ -253,6 +253,8 @@
     "lineCount": 284,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/BezoutIdentityOQ03.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/bezout-identity-oq-04/meta.json
+++ b/src/data/proofs/bezout-identity-oq-04/meta.json
@@ -195,7 +195,9 @@
     "lineCount": 349,
     "axiomCount": 0,
     "theoremCount": 8,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/BezoutIdentityOQ04.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/bezout-identity/meta.json
+++ b/src/data/proofs/bezout-identity/meta.json
@@ -220,7 +220,9 @@
     "lineCount": 237,
     "axiomCount": 0,
     "theoremCount": 8,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/BezoutIdentity.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/binary-gcd-oq-01-oq-04/meta.json
+++ b/src/data/proofs/binary-gcd-oq-01-oq-04/meta.json
@@ -140,13 +140,18 @@
       "Mathlib.Tactic",
       "Proofs.BinaryGcdOQ01"
     ],
-    "opens": ["BinaryGcdOQ01", "Nat"],
+    "opens": [
+      "BinaryGcdOQ01",
+      "Nat"
+    ],
     "namespace": "BinaryGcdOQ01OQ04",
     "lineCount": 157,
     "axiomCount": 0,
     "theoremCount": 8,
     "substantiveTheoremCount": 5,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/BinaryGcdOQ01OQ04.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/binary-gcd-oq-01/meta.json
+++ b/src/data/proofs/binary-gcd-oq-01/meta.json
@@ -156,6 +156,8 @@
     "lineCount": 215,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/BinaryGcdOQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/binary-gcd/meta.json
+++ b/src/data/proofs/binary-gcd/meta.json
@@ -100,7 +100,9 @@
     "lineCount": 177,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/GcdAlgorithmOQ02.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/binomial-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-01-oq-01/meta.json
@@ -181,7 +181,9 @@
     "lineCount": 220,
     "axiomCount": 0,
     "theoremCount": 17,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/BinomialTheoremOQ01OQ01.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/binomial-theorem-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-01/meta.json
@@ -187,6 +187,8 @@
     "lineCount": 264,
     "axiomCount": 0,
     "theoremCount": 19,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/BinomialTheoremOQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01/meta.json
@@ -1,123 +1,125 @@
 {
-    "id": "binomial-theorem-oq-02-oq-01",
-    "title": "Multinomial Distribution and Moment-Generating Function",
-    "slug": "binomial-theorem-oq-02-oq-01",
-    "description": "Formalizes the multinomial distribution PMF and shows its moment-generating function follows directly from the multinomial theorem. Proves normalization, MGF formula, and connection to binomial distribution.",
-    "meta": {
-        "author": "Lean Genius",
-        "status": "verified",
-        "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ01.lean",
-        "tags": [
-            "probability",
-            "multinomial distribution",
-            "moment-generating function",
-            "binomial theorem",
-            "combinatorics"
-        ],
-        "badge": "mathlib",
-        "sorries": 0,
-        "axiomCount": 0,
-        "lineCount": 222,
-        "assumptions": "None. All results proved from Mathlib's multinomial theorem.",
-        "theoremCount": 12,
-        "mathlib_version": "4.26.0"
-    },
-    "overview": {
-        "historicalContext": "The multinomial distribution generalizes the binomial to $k \\geq 2$ outcome categories. It was implicit in the work of Jacob Bernoulli and Abraham de Moivre in the early 18th century, and explicitly formalized by Laplace in his *Théorie Analytique des Probabilités* (1812). The multinomial theorem itself is much older: Newton and later Johann Bernoulli established the $k$-variable expansion $(x_1 + \\cdots + x_k)^n = \\sum \\binom{n}{j_1,\\ldots,j_k} x_1^{j_1} \\cdots x_k^{j_k}$. Moment-generating functions (MGFs) were systematized in the 19th–20th centuries: for random variable $X$, $M_X(t) = \\mathbb{E}[e^{tX}]$ encodes all moments as derivatives at $t=0$. For the multinomial, the joint MGF $(\\sum p_i e^{t_i})^n$ follows immediately from the multinomial theorem — illustrating that the same algebraic identity underlies combinatorics, probability, and generating functions. This formalization reveals that the `CommSemiring` structure is the correct level of abstraction: `multinomial_mgf_factored` holds over *any* commutative semiring, making it applicable to formal power series, tropical semirings, and polynomials simultaneously.",
-        "problemStatement": "Can the multinomial distribution and its moment-generating function be formalized in Lean 4 using the multinomial theorem?",
-        "text": "Formalizes the multinomial distribution PMF, proves normalization from the multinomial theorem, derives the MGF formula, and shows the binomial distribution is the 2-outcome special case.",
-        "proofStrategy": "The key insight is that the multinomial theorem directly provides both the normalization proof and the MGF formula. Setting sum p(i) = 1 in the multinomial theorem gives normalization. Applying the theorem with f(i) = p(i)*g(i) gives the general weighted expectation formula, which specializes to the MGF when g(i) = exp(t(i)).",
-        "keyInsights": [
-            "The multinomial theorem `Finset.sum_pow_eq_sum_piAntidiag` directly *is* the normalization proof: setting $x_i = p(i)$ and using $\\sum p(i) = 1$ gives $\\sum P(k) = 1^n = 1$ in a single rewrite",
-            "The MGF formula follows from the *same* theorem with $x_i = p(i) \\cdot g(i)$: `multinomial_weighted_sum` delegates entirely to `sum_pow_eq_sum_piAntidiag`. No extra work needed beyond the theorem application",
-            "`multinomial_mgf_factored` holds over any `CommSemiring`, making it applicable to formal power series, polynomial rings, and tropical semirings — not just $\\mathbb{R}$. The probability interpretation is a semantic layer on top of the algebraic identity",
-            "The `piAntidiag s n` finset encodes exactly the valid outcome distributions (functions $k : \\alpha \\to \\mathbb{N}$ with $\\sum k(i) = n$). Both `normalization` and `MGF` proofs rely on summing over this same index set, connecting the combinatorial and probabilistic interpretations",
-            "`multinomial_count` gives $|s|^n = \\sum_k \\binom{n}{k}$ (multinomial analog of $2^n = \\sum \\binom{n}{j}$), proved by the theorem with $f \\equiv 1$. This is a purely combinatorial identity: it counts functions $\\text{Fin}\\, n \\to s$ both globally and by outcome distribution"
-        ],
-        "prerequisites": [
-            "Multinomial theorem (Mathlib)",
-            "Multinomial coefficients (Mathlib)",
-            "Basic probability concepts"
-        ]
-    },
-    "sections": [
-        {
-            "id": "definition",
-            "title": "Multinomial Distribution Definition",
-            "startLine": 1,
-            "endLine": 65,
-            "summary": "Defines the multinomial probability mass function and proves nonnegativity."
-        },
-        {
-            "id": "normalization",
-            "title": "Normalization via Multinomial Theorem",
-            "startLine": 67,
-            "endLine": 83,
-            "summary": "Proves sum of probabilities equals 1 using the multinomial theorem with sum p(i) = 1."
-        },
-        {
-            "id": "mgf",
-            "title": "Moment-Generating Function",
-            "startLine": 85,
-            "endLine": 130,
-            "summary": "Derives the MGF formula by applying the multinomial theorem with f(i) = p(i)*g(i). Shows factorization of probability and weight terms."
-        },
-        {
-            "id": "binomial-connection",
-            "title": "Connection to Binomial Distribution",
-            "startLine": 140,
-            "endLine": 170,
-            "summary": "Shows the binomial distribution is the 2-outcome (Bool-indexed) special case of the multinomial distribution."
-        },
-        {
-            "id": "examples",
-            "title": "Concrete Calculations",
-            "startLine": 172,
-            "endLine": 204,
-            "summary": "Concrete examples including fair coin flips and counting identities."
-        }
+  "id": "binomial-theorem-oq-02-oq-01",
+  "title": "Multinomial Distribution and Moment-Generating Function",
+  "slug": "binomial-theorem-oq-02-oq-01",
+  "description": "Formalizes the multinomial distribution PMF and shows its moment-generating function follows directly from the multinomial theorem. Proves normalization, MGF formula, and connection to binomial distribution.",
+  "meta": {
+    "author": "Lean Genius",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ01.lean",
+    "tags": [
+      "probability",
+      "multinomial distribution",
+      "moment-generating function",
+      "binomial theorem",
+      "combinatorics"
     ],
-    "conclusion": {
-        "summary": "The answer to the open question is YES: the multinomial distribution and its MGF are naturally formalized via the multinomial theorem. The normalization proof is just the multinomial theorem evaluated at sum p(i) = 1, and the MGF is the theorem applied to weighted variables.",
-        "implications": "This formalization reveals the deep structural connection between combinatorial algebra and probability theory: the multinomial theorem simultaneously serves as the algebraic expansion formula, the normalization proof, and the MGF derivation.",
-        "openQuestions": [
-            "Can the full PMF.multinomial be integrated into Mathlib's PMF framework?",
-            "Can marginal distributions be formally derived as binomials?",
-            "Can the variance-covariance matrix Cov(Xi, Xj) = -n*pi*pj be proved?"
-        ]
-    },
-    "leanFile": {
-        "imports": [
-            "Mathlib.Data.Nat.Choose.Multinomial",
-            "Mathlib.Data.Nat.Choose.Sum",
-            "Mathlib.Algebra.BigOperators.Ring.Finset",
-            "Mathlib.Tactic"
-        ],
-        "opens": [
-            "Finset",
-            "BigOperators"
-        ],
-        "namespace": "BinomialTheoremOQ02OQ01",
-        "lineCount": 222,
-        "axiomCount": 0,
-        "theoremCount": 12,
-        "definitionCount": 1
-    },
-    "crossReferences": [
-        {
-            "targetId": "binomial-theorem-oq-02",
-            "relationship": "extends",
-            "description": "Answers open question from the multinomial theorem generalization proof"
-        },
-        {
-            "targetId": "binomial-theorem-oq-03",
-            "relationship": "related",
-            "description": "BinomialTheoremOQ03 formalizes binomial PMF properties; this extends to multinomial"
-        },
-        {
-            "targetId": "binomial-theorem",
-            "relationship": "related",
-            "description": "The binomial theorem is the 2-variable special case"
-        }
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 222,
+    "assumptions": "None. All results proved from Mathlib's multinomial theorem.",
+    "theoremCount": 12,
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The multinomial distribution generalizes the binomial to $k \\geq 2$ outcome categories. It was implicit in the work of Jacob Bernoulli and Abraham de Moivre in the early 18th century, and explicitly formalized by Laplace in his *Théorie Analytique des Probabilités* (1812). The multinomial theorem itself is much older: Newton and later Johann Bernoulli established the $k$-variable expansion $(x_1 + \\cdots + x_k)^n = \\sum \\binom{n}{j_1,\\ldots,j_k} x_1^{j_1} \\cdots x_k^{j_k}$. Moment-generating functions (MGFs) were systematized in the 19th–20th centuries: for random variable $X$, $M_X(t) = \\mathbb{E}[e^{tX}]$ encodes all moments as derivatives at $t=0$. For the multinomial, the joint MGF $(\\sum p_i e^{t_i})^n$ follows immediately from the multinomial theorem — illustrating that the same algebraic identity underlies combinatorics, probability, and generating functions. This formalization reveals that the `CommSemiring` structure is the correct level of abstraction: `multinomial_mgf_factored` holds over *any* commutative semiring, making it applicable to formal power series, tropical semirings, and polynomials simultaneously.",
+    "problemStatement": "Can the multinomial distribution and its moment-generating function be formalized in Lean 4 using the multinomial theorem?",
+    "text": "Formalizes the multinomial distribution PMF, proves normalization from the multinomial theorem, derives the MGF formula, and shows the binomial distribution is the 2-outcome special case.",
+    "proofStrategy": "The key insight is that the multinomial theorem directly provides both the normalization proof and the MGF formula. Setting sum p(i) = 1 in the multinomial theorem gives normalization. Applying the theorem with f(i) = p(i)*g(i) gives the general weighted expectation formula, which specializes to the MGF when g(i) = exp(t(i)).",
+    "keyInsights": [
+      "The multinomial theorem `Finset.sum_pow_eq_sum_piAntidiag` directly *is* the normalization proof: setting $x_i = p(i)$ and using $\\sum p(i) = 1$ gives $\\sum P(k) = 1^n = 1$ in a single rewrite",
+      "The MGF formula follows from the *same* theorem with $x_i = p(i) \\cdot g(i)$: `multinomial_weighted_sum` delegates entirely to `sum_pow_eq_sum_piAntidiag`. No extra work needed beyond the theorem application",
+      "`multinomial_mgf_factored` holds over any `CommSemiring`, making it applicable to formal power series, polynomial rings, and tropical semirings — not just $\\mathbb{R}$. The probability interpretation is a semantic layer on top of the algebraic identity",
+      "The `piAntidiag s n` finset encodes exactly the valid outcome distributions (functions $k : \\alpha \\to \\mathbb{N}$ with $\\sum k(i) = n$). Both `normalization` and `MGF` proofs rely on summing over this same index set, connecting the combinatorial and probabilistic interpretations",
+      "`multinomial_count` gives $|s|^n = \\sum_k \\binom{n}{k}$ (multinomial analog of $2^n = \\sum \\binom{n}{j}$), proved by the theorem with $f \\equiv 1$. This is a purely combinatorial identity: it counts functions $\\text{Fin}\\, n \\to s$ both globally and by outcome distribution"
+    ],
+    "prerequisites": [
+      "Multinomial theorem (Mathlib)",
+      "Multinomial coefficients (Mathlib)",
+      "Basic probability concepts"
     ]
+  },
+  "sections": [
+    {
+      "id": "definition",
+      "title": "Multinomial Distribution Definition",
+      "startLine": 1,
+      "endLine": 65,
+      "summary": "Defines the multinomial probability mass function and proves nonnegativity."
+    },
+    {
+      "id": "normalization",
+      "title": "Normalization via Multinomial Theorem",
+      "startLine": 67,
+      "endLine": 83,
+      "summary": "Proves sum of probabilities equals 1 using the multinomial theorem with sum p(i) = 1."
+    },
+    {
+      "id": "mgf",
+      "title": "Moment-Generating Function",
+      "startLine": 85,
+      "endLine": 130,
+      "summary": "Derives the MGF formula by applying the multinomial theorem with f(i) = p(i)*g(i). Shows factorization of probability and weight terms."
+    },
+    {
+      "id": "binomial-connection",
+      "title": "Connection to Binomial Distribution",
+      "startLine": 140,
+      "endLine": 170,
+      "summary": "Shows the binomial distribution is the 2-outcome (Bool-indexed) special case of the multinomial distribution."
+    },
+    {
+      "id": "examples",
+      "title": "Concrete Calculations",
+      "startLine": 172,
+      "endLine": 204,
+      "summary": "Concrete examples including fair coin flips and counting identities."
+    }
+  ],
+  "conclusion": {
+    "summary": "The answer to the open question is YES: the multinomial distribution and its MGF are naturally formalized via the multinomial theorem. The normalization proof is just the multinomial theorem evaluated at sum p(i) = 1, and the MGF is the theorem applied to weighted variables.",
+    "implications": "This formalization reveals the deep structural connection between combinatorial algebra and probability theory: the multinomial theorem simultaneously serves as the algebraic expansion formula, the normalization proof, and the MGF derivation.",
+    "openQuestions": [
+      "Can the full PMF.multinomial be integrated into Mathlib's PMF framework?",
+      "Can marginal distributions be formally derived as binomials?",
+      "Can the variance-covariance matrix Cov(Xi, Xj) = -n*pi*pj be proved?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Choose.Multinomial",
+      "Mathlib.Data.Nat.Choose.Sum",
+      "Mathlib.Algebra.BigOperators.Ring.Finset",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset",
+      "BigOperators"
+    ],
+    "namespace": "BinomialTheoremOQ02OQ01",
+    "lineCount": 222,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 1,
+    "path": "Proofs/BinomialTheoremOQ02OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "binomial-theorem-oq-02",
+      "relationship": "extends",
+      "description": "Answers open question from the multinomial theorem generalization proof"
+    },
+    {
+      "targetId": "binomial-theorem-oq-03",
+      "relationship": "related",
+      "description": "BinomialTheoremOQ03 formalizes binomial PMF properties; this extends to multinomial"
+    },
+    {
+      "targetId": "binomial-theorem",
+      "relationship": "related",
+      "description": "The binomial theorem is the 2-variable special case"
+    }
+  ]
 }

--- a/src/data/proofs/binomial-theorem-oq-02-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-02/meta.json
@@ -114,13 +114,20 @@
     ]
   },
   "leanFile": {
-    "imports": ["Mathlib"],
-    "opens": ["Finset", "Nat"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "Nat"
+    ],
     "namespace": "VandermondeMult",
     "lineCount": 179,
     "axiomCount": 0,
     "theoremCount": 11,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/BinomialTheoremOQ02OQ02.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/binomial-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-03/meta.json
@@ -206,6 +206,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 12,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/BinomialTheoremOQ02OQ03.lean"
   }
 }

--- a/src/data/proofs/binomial-theorem-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02/meta.json
@@ -263,6 +263,8 @@
     "lineCount": 280,
     "axiomCount": 0,
     "theoremCount": 17,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/BinomialTheoremOQ02.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/binomial-theorem-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-03/meta.json
@@ -229,7 +229,9 @@
     "lineCount": 588,
     "axiomCount": 0,
     "theoremCount": 33,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/BinomialTheoremOQ03.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/binomial-theorem-oq-04-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-01/meta.json
@@ -64,7 +64,9 @@
     "lineCount": 299,
     "theoremCount": 14,
     "axiomCount": 0,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/BinomialTheoremOQ04OQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/binomial-theorem-oq-04-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-02/meta.json
@@ -163,7 +163,9 @@
     "lineCount": 111,
     "axiomCount": 0,
     "theoremCount": 9,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/BinomialTheoremOQ04OQ02.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/binomial-theorem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-03/meta.json
@@ -154,7 +154,9 @@
     "lineCount": 190,
     "axiomCount": 0,
     "theoremCount": 9,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/BinomialTheoremOQ04OQ03.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/binomial-theorem-oq-04/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04/meta.json
@@ -201,7 +201,9 @@
     "lineCount": 195,
     "axiomCount": 0,
     "theoremCount": 11,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/BinomialTheoremOQ04.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/binomial-theorem/meta.json
+++ b/src/data/proofs/binomial-theorem/meta.json
@@ -310,7 +310,9 @@
     "theoremCount": 9,
     "lemmaCount": 0,
     "defCount": 0,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/BinomialTheorem.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/birthday-problem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-02-oq-01/meta.json
@@ -107,6 +107,8 @@
     "lineCount": 229,
     "axiomCount": 0,
     "theoremCount": 8,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/BirthdayProblemOQ02OQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/birthday-problem-oq-02/meta.json
+++ b/src/data/proofs/birthday-problem-oq-02/meta.json
@@ -246,6 +246,8 @@
     ],
     "opens": [
       "Real"
-    ]
+    ],
+    "path": "Proofs/BirthdayProblemOQ02.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/birthday-problem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01/meta.json
@@ -118,13 +118,20 @@
     ]
   },
   "leanFile": {
-    "imports": ["Mathlib"],
-    "opens": ["Finset", "Fintype"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "Fintype"
+    ],
     "namespace": "BirthdayKWayThreshold",
     "lineCount": 245,
     "axiomCount": 0,
     "theoremCount": 15,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/BirthdayProblemOQ03OQ01.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/birthday-problem-oq-03-oq-03/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-03/meta.json
@@ -139,7 +139,9 @@
     ]
   },
   "leanFile": {
-    "imports": ["Mathlib"],
+    "imports": [
+      "Mathlib"
+    ],
     "opens": [],
     "namespace": "BirthdayScaling",
     "lineCount": 241,
@@ -147,12 +149,34 @@
     "theoremCount": 20,
     "definitionCount": 2,
     "mainTheorems": [
-      {"name": "scalingExponent_mono", "type": "proved", "description": "Scaling exponent (k-1)/k is strictly increasing"},
-      {"name": "scalingExponent_lt_one", "type": "proved", "description": "(k-1)/k < 1 for all k ≥ 1"},
-      {"name": "thresholdPower_mono_d", "type": "proved", "description": "Threshold monotone in d"},
-      {"name": "thresholdPower_mono_k", "type": "proved", "description": "Threshold monotone in k"},
-      {"name": "exponent_approaches_one", "type": "proved", "description": "(k-1)/k → 1 as k → ∞"}
-    ]
+      {
+        "name": "scalingExponent_mono",
+        "type": "proved",
+        "description": "Scaling exponent (k-1)/k is strictly increasing"
+      },
+      {
+        "name": "scalingExponent_lt_one",
+        "type": "proved",
+        "description": "(k-1)/k < 1 for all k ≥ 1"
+      },
+      {
+        "name": "thresholdPower_mono_d",
+        "type": "proved",
+        "description": "Threshold monotone in d"
+      },
+      {
+        "name": "thresholdPower_mono_k",
+        "type": "proved",
+        "description": "Threshold monotone in k"
+      },
+      {
+        "name": "exponent_approaches_one",
+        "type": "proved",
+        "description": "(k-1)/k → 1 as k → ∞"
+      }
+    ],
+    "path": "Proofs/BirthdayProblemOQ03OQ03.lean",
+    "sorries": 0
   },
   "references": [
     {
@@ -164,6 +188,10 @@
     }
   ],
   "mainTheorems": [
-    {"name": "kway_birthday_scaling", "type": "core", "description": "k-way birthday threshold scaling: n_k ~ (k!·d^{k-1})^{1/k}"}
+    {
+      "name": "kway_birthday_scaling",
+      "type": "core",
+      "description": "k-way birthday threshold scaling: n_k ~ (k!·d^{k-1})^{1/k}"
+    }
   ]
 }

--- a/src/data/proofs/birthday-problem-oq-03/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03/meta.json
@@ -240,6 +240,8 @@
     "imports": [
       "Mathlib"
     ],
-    "opens": []
+    "opens": [],
+    "path": "Proofs/BirthdayProblemOQ03.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/birthday-problem/meta.json
+++ b/src/data/proofs/birthday-problem/meta.json
@@ -253,7 +253,9 @@
     "theoremCount": 27,
     "lemmaCount": 0,
     "defCount": 0,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/BirthdayProblem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03/meta.json
@@ -142,13 +142,18 @@
       "Mathlib.Tactic",
       "Proofs.BorsukUlamOQ02OQ01"
     ],
-    "opens": ["BorsukUlamOQ02OQ01", "Nat"],
+    "opens": [
+      "BorsukUlamOQ02OQ01",
+      "Nat"
+    ],
     "namespace": "BorsukUlamNonCyclic",
     "lineCount": 212,
     "axiomCount": 8,
     "theoremCount": 14,
     "substantiveTheoremCount": 10,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-04/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-04/meta.json
@@ -161,6 +161,8 @@
   ],
   "leanFile": {
     "axiomCount": 0,
-    "lineCount": 251
+    "lineCount": 251,
+    "path": "Proofs/BorsukUlamOQ02OQ01OQ04.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01/meta.json
@@ -113,7 +113,9 @@
     "lineCount": 144,
     "axiomCount": 4,
     "theoremCount": 6,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/BorsukUlamOQ02OQ01.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-02/meta.json
@@ -18,33 +18,33 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 160,
-    "assumptions": "The main theorem EquivariantBorsukUlam is a True placeholder \u2014 the full equivariant Borsuk-Ulam for compact Lie groups requires ~2000 lines of equivariant topology infrastructure not yet in Mathlib (G-CW complexes, equivariant cohomology, equivariant degree theory). The 7 supporting lemmas about equivariant map algebra and fixed-point subspaces are fully verified.",
+    "assumptions": "The main theorem EquivariantBorsukUlam is a True placeholder — the full equivariant Borsuk-Ulam for compact Lie groups requires ~2000 lines of equivariant topology infrastructure not yet in Mathlib (G-CW complexes, equivariant cohomology, equivariant degree theory). The 7 supporting lemmas about equivariant map algebra and fixed-point subspaces are fully verified.",
     "theoremCount": 7,
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Karol Borsuk proved the antipodal theorem in 1933 (a problem Stanis\u0142aw Ulam posed), establishing that every continuous f: S\u207f \u2192 \u211d\u207f has a point with f(x) = f(-x). The \u2124/2 antipodal action was soon recognized as a special case of equivariant topology. C.T. Yang (1954) generalized Borsuk-Ulam to free \u2124/p-actions on spheres. The program of extending BU to arbitrary compact Lie groups gained momentum through the development of equivariant cohomology by Borel (1960), Quillen (1971), and Atiyah-Segal (1969). Their localization theorem \u2014 relating equivariant cohomology of a G-space to that of its fixed-point set \u2014 is the engine behind the dimensional reduction principle for compact Lie group actions. The specific question for SO(n) and U(n) arises naturally in equivariant degree theory (Ize-Vignoli, 2003) and appears in surveys of Borsuk-Ulam variants by Marzantowicz and Wasserman. This file represents the frontier of what is currently formalizable: the equivariant algebra is elementary and provable from Mathlib primitives, but the topological heart of the theorem requires infrastructure that does not yet exist in Lean 4.",
+    "historicalContext": "Karol Borsuk proved the antipodal theorem in 1933 (a problem Stanisław Ulam posed), establishing that every continuous f: Sⁿ → ℝⁿ has a point with f(x) = f(-x). The ℤ/2 antipodal action was soon recognized as a special case of equivariant topology. C.T. Yang (1954) generalized Borsuk-Ulam to free ℤ/p-actions on spheres. The program of extending BU to arbitrary compact Lie groups gained momentum through the development of equivariant cohomology by Borel (1960), Quillen (1971), and Atiyah-Segal (1969). Their localization theorem — relating equivariant cohomology of a G-space to that of its fixed-point set — is the engine behind the dimensional reduction principle for compact Lie group actions. The specific question for SO(n) and U(n) arises naturally in equivariant degree theory (Ize-Vignoli, 2003) and appears in surveys of Borsuk-Ulam variants by Marzantowicz and Wasserman. This file represents the frontier of what is currently formalizable: the equivariant algebra is elementary and provable from Mathlib primitives, but the topological heart of the theorem requires infrastructure that does not yet exist in Lean 4.",
     "problemStatement": "For compact Lie groups $G$ (specifically $\\mathrm{SO}(n)$, $\\mathrm{U}(n)$) and $G$-representations $V$, $W$: does every continuous $G$-equivariant map $f: S(V) \\to W$ vanish somewhere when $\\dim V > \\dim W$? More precisely: does $\\dim V^G < \\dim W^G$ force any equivariant $f: S(V) \\to W$ to have a zero?",
     "text": "Surveys the equivariant Borsuk-Ulam generalization for compact Lie groups.",
-    "proofStrategy": "The file proceeds in layers. Parts 1\u20132 establish the equivariant algebra that is immediately formalizable: the definition of equivariant maps and their closure under identity and composition, the fixed-point set functor, and the key lemma that equivariant maps restrict to fixed-point subspaces. Part 3 states the dimension-reduction principle informally \u2014 the statement can be written but not proved, as the proof requires the Borel construction EG \u00d7_G X and either equivariant cohomology or equivariant degree theory. Part 4 audits the ~2000 lines of Mathlib infrastructure that would be needed: G-CW complexes, irreducible representation decomposition, equivariant cohomology rings, and equivariant degree. The def EquivariantBorsukUlam := True serves as an honest placeholder acknowledging this gap.",
+    "proofStrategy": "The file proceeds in layers. Parts 1–2 establish the equivariant algebra that is immediately formalizable: the definition of equivariant maps and their closure under identity and composition, the fixed-point set functor, and the key lemma that equivariant maps restrict to fixed-point subspaces. Part 3 states the dimension-reduction principle informally — the statement can be written but not proved, as the proof requires the Borel construction EG ×_G X and either equivariant cohomology or equivariant degree theory. Part 4 audits the ~2000 lines of Mathlib infrastructure that would be needed: G-CW complexes, irreducible representation decomposition, equivariant cohomology rings, and equivariant degree. The def EquivariantBorsukUlam := True serves as an honest placeholder acknowledging this gap.",
     "keyInsights": [
-      "Equivariant maps preserve fixed-point subspaces: f: V \u2192 W equivariant implies f(V^G) \u2286 W^G, providing a linear shadow of the topological dimension-reduction principle",
-      "The composition theorem shows equivariant maps form a category (G-Set), and the fixed-point assignment V \u21a6 V^G is a functor \u2014 functoriality is the conceptual core of the BU generalization",
+      "Equivariant maps preserve fixed-point subspaces: f: V → W equivariant implies f(V^G) ⊆ W^G, providing a linear shadow of the topological dimension-reduction principle",
+      "The composition theorem shows equivariant maps form a category (G-Set), and the fixed-point assignment V ↦ V^G is a functor — functoriality is the conceptual core of the BU generalization",
       "The constant-map characterization reveals the tight link between equivariance and fixed points: the only equivariant constant maps land on fixed points of the action",
-      "The Borel construction is the missing piece: equivariant cohomology H*_G(X) = H*(EG \u00d7_G X) turns the equivariant topology into ordinary cohomology of a (non-equivariant) space, enabling dimension counts",
+      "The Borel construction is the missing piece: equivariant cohomology H*_G(X) = H*(EG ×_G X) turns the equivariant topology into ordinary cohomology of a (non-equivariant) space, enabling dimension counts",
       "The ~2000-line infrastructure gap is typical of frontier formalization: the mathematical community solved this problem decades ago, but Lean 4 / Mathlib must still build the scaffolding from first principles",
-      "Yang's theorem (\u2124/p case) is a potential intermediate target \u2014 it requires less equivariant machinery than the full compact Lie group case and may be provable with Smith theory via existing Mathlib cohomology tools"
+      "Yang's theorem (ℤ/p case) is a potential intermediate target — it requires less equivariant machinery than the full compact Lie group case and may be provable with Smith theory via existing Mathlib cohomology tools"
     ]
   },
   "conclusion": {
     "summary": "This file formalizes the tractable equivariant algebra for the compact Lie group Borsuk-Ulam question: equivariant map composition, fixed-point preservation, and the structural connection between equivariant maps and fixed-point subspaces. The full dimension-reduction theorem for SO(n) and U(n) is beyond current Mathlib, requiring approximately 2000 lines of equivariant topology infrastructure not yet available in Lean 4.",
     "openQuestions": [
       "Can equivariant cohomology H*_G(X) be built in Lean 4 on top of Mathlib's existing singular cohomology and classifying space machinery?",
-      "Is Yang's theorem (equivariant Borsuk-Ulam for \u2124/p) provable in Mathlib via Smith theory without requiring the full equivariant cohomology stack?",
+      "Is Yang's theorem (equivariant Borsuk-Ulam for ℤ/p) provable in Mathlib via Smith theory without requiring the full equivariant cohomology stack?",
       "Does an equivariant K-theory approach (Atiyah-Segal completion theorem) offer a shorter path to the compact Lie group case?",
       "Which compact Lie groups admit the weakest form of the dimension-reduction principle, and can those cases be isolated for earlier formalization?"
     ],
-    "implications": "The equivariant Borsuk-Ulam program illustrates a recurring pattern in formal mathematics: elementary aspects of deep theorems (categorical structure, basic properties) are immediately formalizable, while the topological heart requires substantial infrastructure investment. The infrastructure audit in this file \u2014 identifying exactly which Mathlib components are missing \u2014 serves as a roadmap for future Lean 4 development in equivariant topology. Progress here would directly enable formalization of other results in equivariant homotopy theory, including the Atiyah-Segal completion theorem and equivariant versions of the Lefschetz fixed-point theorem."
+    "implications": "The equivariant Borsuk-Ulam program illustrates a recurring pattern in formal mathematics: elementary aspects of deep theorems (categorical structure, basic properties) are immediately formalizable, while the topological heart requires substantial infrastructure investment. The infrastructure audit in this file — identifying exactly which Mathlib components are missing — serves as a roadmap for future Lean 4 development in equivariant topology. Progress here would directly enable formalization of other results in equivariant homotopy theory, including the Atiyah-Segal completion theorem and equivariant versions of the Lefschetz fixed-point theorem."
   },
   "leanFile": {
     "imports": [
@@ -58,7 +58,8 @@
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 7,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/BorsukUlamOQ02OQ02.lean"
   },
   "crossReferences": [
     {
@@ -78,28 +79,28 @@
       "title": "Mathematical Background and Survey Overview",
       "startLine": 1,
       "endLine": 46,
-      "summary": "Imports, module docstring, and background on the three tiers of Borsuk-Ulam generalizations: classical \u2124/2 (Borsuk 1933), \u2124/p (Yang 1954), and compact Lie groups. Lists what the file formalizes vs. what remains open."
+      "summary": "Imports, module docstring, and background on the three tiers of Borsuk-Ulam generalizations: classical ℤ/2 (Borsuk 1933), ℤ/p (Yang 1954), and compact Lie groups. Lists what the file formalizes vs. what remains open."
     },
     {
       "id": "equivariant-maps",
       "title": "Part 1: Equivariant Map Algebra",
       "startLine": 48,
       "endLine": 79,
-      "summary": "Defines IsEquivariant (f(g \u2022 x) = g \u2022 f(x)) and proves that equivariant maps are closed under identity and composition (making them morphisms in G-Set). Characterizes constant equivariant maps as exactly those landing on fixed points."
+      "summary": "Defines IsEquivariant (f(g • x) = g • f(x)) and proves that equivariant maps are closed under identity and composition (making them morphisms in G-Set). Characterizes constant equivariant maps as exactly those landing on fixed points."
     },
     {
       "id": "fixed-point-subspaces",
       "title": "Part 2: Fixed-Point Subspaces",
       "startLine": 81,
       "endLine": 97,
-      "summary": "Defines fixedPoints G \u03b1 = {x | \u2200 g, g \u2022 x = x} and proves the key structural lemma: equivariant maps send fixed points to fixed points, establishing the functoriality of the fixed-point assignment."
+      "summary": "Defines fixedPoints G α = {x | ∀ g, g • x = x} and proves the key structural lemma: equivariant maps send fixed points to fixed points, establishing the functoriality of the fixed-point assignment."
     },
     {
       "id": "dimension-bounds",
       "title": "Part 3: Representation-Theoretic Dimension Bounds",
       "startLine": 99,
       "endLine": 116,
-      "summary": "States informally the dimension-reduction principle (dim V > dim W implies equivariant maps S(V) \u2192 W vanish) and explains why the proof requires equivariant cohomology or degree theory. The placeholder def EquivariantBorsukUlam := True marks the current formalization boundary."
+      "summary": "States informally the dimension-reduction principle (dim V > dim W implies equivariant maps S(V) → W vanish) and explains why the proof requires equivariant cohomology or degree theory. The placeholder def EquivariantBorsukUlam := True marks the current formalization boundary."
     },
     {
       "id": "infrastructure-survey",

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-03/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-03/meta.json
@@ -126,6 +126,8 @@
   "openQuestions": [],
   "leanFile": {
     "axiomCount": 5,
-    "lineCount": 251
+    "lineCount": 251,
+    "path": "Proofs/BorsukUlamOQ02OQ03.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/borsuk-ulam-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02/meta.json
@@ -232,7 +232,9 @@
     "lineCount": 389,
     "axiomCount": 1,
     "theoremCount": 18,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/BorsukUlamOQ02.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/borsuk-ulam-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-03-oq-01-oq-01/meta.json
@@ -169,7 +169,9 @@
     "lineCount": 434,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/BorsukUlamOQ03OQ01OQ01.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/borsuk-ulam-oq-03-oq-01/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-03-oq-01/meta.json
@@ -191,7 +191,9 @@
     "lineCount": 1163,
     "axiomCount": 1,
     "theoremCount": 47,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/BorsukUlamOQ03OQ01.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/borsuk-ulam-oq-03-oq-03/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-03-oq-03/meta.json
@@ -200,7 +200,9 @@
     "lineCount": 2633,
     "axiomCount": 1,
     "theoremCount": 107,
-    "definitionCount": 30
+    "definitionCount": 30,
+    "path": "Proofs/BorsukUlamOQ03OQ03.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/borsuk-ulam-oq-03/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-03/meta.json
@@ -202,7 +202,9 @@
     "lineCount": 5139,
     "axiomCount": 1,
     "theoremCount": 233,
-    "definitionCount": 35
+    "definitionCount": 35,
+    "path": "Proofs/BorsukUlamOQ03.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/borsuk-ulam-oq-04/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-04/meta.json
@@ -140,6 +140,8 @@
     "lineCount": 300,
     "axiomCount": 0,
     "theoremCount": 4,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/BorsukUlamOQ04.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/borsuk-ulam/meta.json
+++ b/src/data/proofs/borsuk-ulam/meta.json
@@ -272,7 +272,9 @@
     "lineCount": 265,
     "axiomCount": 1,
     "theoremCount": 9,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/BorsukUlam.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/bounded-prime-gaps-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-01/meta.json
@@ -71,7 +71,9 @@
     "lineCount": 438,
     "axiomCount": 0,
     "theoremCount": 26,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/BoundedPrimeGapsOQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-04/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03-oq-01-oq-04/meta.json
@@ -51,56 +51,6 @@
   },
   "sections": [
     {
-      "id": "sec-imports-doc",
-      "title": "Imports and Mathematical Background",
-      "startLine": 1,
-      "endLine": 53,
-      "summary": "Imports Mathlib, BoundedPrimeGaps (admissibility infrastructure), and BoundedPrimeGapsOQ03OQ01 (D(2)=2, D(3)=6 results). The documentation block explains the OEIS A008407 context and the two-part proof strategy for D(4)=8."
-    },
-    {
-      "id": "sec-not-admissible-ap4",
-      "title": "Part I: Even 4-Term AP is Not Admissible",
-      "startLine": 55,
-      "endLine": 69,
-      "summary": "Proves not_admissible_even_ap4: {a,a+2,a+4,a+6} is not admissible for any a. Uses admissible_subset to reduce to the non-admissible triple {a,a+2,a+4}, then applies not_admissible_ap_diff2 from the parent file."
-    },
-    {
-      "id": "sec-lower-bound",
-      "title": "Part II: Lower Bound — Every Admissible 4-Tuple Has Diameter ≥ 8",
-      "startLine": 71,
-      "endLine": 125,
-      "summary": "Proves admissible_quad_diam_ge_8 by contradiction. Splits on parity: mixed-parity sets are eliminated by the p=2 admissibility condition; same-parity sets with diameter ≤ 6 are forced into an even AP of step 2, which Part I showed is not admissible."
-    },
-    {
-      "id": "sec-main-result",
-      "title": "Part III: Main Result — D(4) = 8",
-      "startLine": 127,
-      "endLine": 148,
-      "summary": "Proves minAdmissibleDiameter_4 via le_antisymm. Upper bound: csInf_le with the witness {0,2,6,8}. Lower bound: le_csInf dispatches to admissible_quad_diam_ge_8."
-    },
-    {
-      "id": "sec-consequences",
-      "title": "Part IV: Consequences and Monotonicity",
-      "startLine": 150,
-      "endLine": 187,
-      "summary": "Four corollaries: D2_lt_D3_lt_D4 (strict chain 2 < 6 < 8), D4_achieved_by_0268 (optimal tuple is {0,2,6,8}), D4_minus_D3 (gap = 2), prime_quadruple_span_ge_8 (plain-language restatement of the lower bound)."
-    }
-  ],
-  "conclusion": {
-    "summary": "Proved $D(4)=8$: every admissible 4-tuple has diameter $\\geq 8$, witnessed by $\\{0,2,6,8\\}$. The proof uses the parity constraint + forced AP structure argument, reducing to the non-admissible triple result proved in the parent file. 187 lines, 5 theorems, 0 sorries, 0 axioms. Also repaired pre-existing Mathlib API issues in BoundedPrimeGapsOQ03OQ01.",
-    "implications": "With $D(2)=2$, $D(3)=6$, $D(4)=8$ now all machine-verified, the smallest prime constellation diameters are formally established in Lean 4. The proof infrastructure — parity filtration, subset contamination, forced-AP structure — is reusable for $D(5)=12$ and beyond. Under the Elliott–Halberstam conjecture, these $D(k)$ values give exact predicted gaps for prime $k$-tuples: the prime quadruple conjecture predicts infinitely many $n$ with $n,n+2,n+6,n+8$ all prime.",
-    "openQuestions": [
-      "Prove $D(5)=12$ by the same layered approach: $\\{0,2,6,8,12\\}$ is admissible and the lower bound argument adds a mod-5 obstruction on top of the mod-2 and mod-3 ones used here.",
-      "Automate $D(k)$ proofs for small $k$ via a decidability argument: $D(k)$ is computable for fixed $k$, so in principle a single native_decide call with a suitably stated minimality theorem could certify $D(k)$ for $k \\leq 10$."
-    ],
-    "crossReferences": [
-      "bounded-prime-gaps",
-      "bounded-prime-gaps-oq-03-oq-01",
-      "bounded-prime-gaps-oq-03"
-    ]
-  },
-  "sections": [
-    {
       "id": "sec-prime-gaps-header",
       "title": "Header and Proof Strategy Documentation",
       "startLine": 1,
@@ -136,6 +86,19 @@
       "summary": "Proves D2_lt_D3_lt_D4 (strictly increasing chain 2 < 6 < 8), D4_achieved_by_0268, D4_minus_D3 = 2, and prime_quadruple_span_ge_8 (universal lower bound on admissible 4-tuple diameters)."
     }
   ],
+  "conclusion": {
+    "summary": "Proved $D(4)=8$: every admissible 4-tuple has diameter $\\geq 8$, witnessed by $\\{0,2,6,8\\}$. The proof uses the parity constraint + forced AP structure argument, reducing to the non-admissible triple result proved in the parent file. 187 lines, 5 theorems, 0 sorries, 0 axioms. Also repaired pre-existing Mathlib API issues in BoundedPrimeGapsOQ03OQ01.",
+    "implications": "With $D(2)=2$, $D(3)=6$, $D(4)=8$ now all machine-verified, the smallest prime constellation diameters are formally established in Lean 4. The proof infrastructure — parity filtration, subset contamination, forced-AP structure — is reusable for $D(5)=12$ and beyond. Under the Elliott–Halberstam conjecture, these $D(k)$ values give exact predicted gaps for prime $k$-tuples: the prime quadruple conjecture predicts infinitely many $n$ with $n,n+2,n+6,n+8$ all prime.",
+    "openQuestions": [
+      "Prove $D(5)=12$ by the same layered approach: $\\{0,2,6,8,12\\}$ is admissible and the lower bound argument adds a mod-5 obstruction on top of the mod-2 and mod-3 ones used here.",
+      "Automate $D(k)$ proofs for small $k$ via a decidability argument: $D(k)$ is computable for fixed $k$, so in principle a single native_decide call with a suitably stated minimality theorem could certify $D(k)$ for $k \\leq 10$."
+    ],
+    "crossReferences": [
+      "bounded-prime-gaps",
+      "bounded-prime-gaps-oq-03-oq-01",
+      "bounded-prime-gaps-oq-03"
+    ]
+  },
   "crossReferences": [
     {
       "slug": "bounded-prime-gaps",
@@ -153,6 +116,8 @@
     "lineCount": 187,
     "axiomCount": 0,
     "theoremCount": 5,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/BoundedPrimeGapsOQ03OQ01OQ04.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/bounded-prime-gaps-oq-03-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03-oq-01/meta.json
@@ -144,7 +144,9 @@
     "lineCount": 389,
     "axiomCount": 2,
     "theoremCount": 24,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/BoundedPrimeGapsOQ03OQ01.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/bounded-prime-gaps-oq-03/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03/meta.json
@@ -231,6 +231,8 @@
     "lineCount": 279,
     "axiomCount": 1,
     "theoremCount": 21,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/BoundedPrimeGapsOQ03.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/bounded-prime-gaps-oq-04/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04/meta.json
@@ -193,6 +193,8 @@
     "lineCount": 366,
     "axiomCount": 1,
     "theoremCount": 15,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/BoundedPrimeGapsOQ04.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/bounded-prime-gaps/meta.json
+++ b/src/data/proofs/bounded-prime-gaps/meta.json
@@ -298,7 +298,9 @@
     "lineCount": 2017,
     "axiomCount": 3,
     "theoremCount": 128,
-    "definitionCount": 17
+    "definitionCount": 17,
+    "path": "Proofs/BoundedPrimeGaps.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/brouwer-fixed-point-oq-01/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01/meta.json
@@ -61,7 +61,11 @@
       "content": "brouwer_1d applies exists_mem_Icc_isFixedPt_of_mapsTo directly. brouwer_1d_via_ivt makes the g(x) = f(x) - x sign-change argument explicit: g(a) ≥ 0, g(b) ≤ 0, IVT gives zero.",
       "lineStart": 64,
       "lineEnd": 117,
-      "theorems": ["brouwer_1d", "brouwer_1d_via_ivt", "brouwer_1d_unit_interval"]
+      "theorems": [
+        "brouwer_1d",
+        "brouwer_1d_via_ivt",
+        "brouwer_1d_unit_interval"
+      ]
     },
     {
       "id": "no-retraction-1d",
@@ -70,7 +74,10 @@
       "content": "no_retraction_1d: if r is continuous, maps to {0,1}, r(0)=0, r(1)=1, IVT gives a point where r = 1/2, contradicting the discrete image.",
       "lineStart": 119,
       "lineEnd": 159,
-      "theorems": ["no_retraction_1d", "connected_interval_no_discrete_surjection"]
+      "theorems": [
+        "no_retraction_1d",
+        "connected_interval_no_discrete_surjection"
+      ]
     },
     {
       "id": "borsuk-ulam-1d",
@@ -79,7 +86,11 @@
       "content": "borsuk_ulam_1d: g(1) = -g(-1) forces a sign change; IVT gives a zero of g, i.e., f(x) = f(-x). Three cases: g(-1) = 0 (endpoint), g(-1) < 0 < g(1), g(-1) > 0 > g(1).",
       "lineStart": 161,
       "lineEnd": 229,
-      "theorems": ["borsuk_ulam_1d", "borsuk_ulam_1d_existence", "borsuk_ulam_1d_antipodal"]
+      "theorems": [
+        "borsuk_ulam_1d",
+        "borsuk_ulam_1d_existence",
+        "borsuk_ulam_1d_antipodal"
+      ]
     },
     {
       "id": "banach-contraction",
@@ -88,7 +99,11 @@
       "content": "banach_contraction_fixed_point wraps Mathlib's ContractingWith to give existence and uniqueness. banach_fixed_point_unique derives uniqueness from the existsUnique conclusion.",
       "lineStart": 231,
       "lineEnd": 278,
-      "theorems": ["banach_contraction_fixed_point", "banach_fixed_point_unique", "contraction_1d_unique_fixed_point"]
+      "theorems": [
+        "banach_contraction_fixed_point",
+        "banach_fixed_point_unique",
+        "contraction_1d_unique_fixed_point"
+      ]
     },
     {
       "id": "brouwer-non-uniqueness",
@@ -97,7 +112,10 @@
       "content": "brouwer_nonunique: id has every point as a fixed point (exhibits x=0, y=1 both fixed). constant_map_fixed_point: constant map fun _ => c has exactly c as its unique fixed point.",
       "lineStart": 280,
       "lineEnd": 310,
-      "theorems": ["brouwer_nonunique", "constant_map_fixed_point"]
+      "theorems": [
+        "brouwer_nonunique",
+        "constant_map_fixed_point"
+      ]
     },
     {
       "id": "brouwer-vs-banach",
@@ -106,7 +124,10 @@
       "content": "banach_implies_brouwer_1d: uses LipschitzWith.continuous to get continuity from Lipschitz, then applies brouwer_1d_unit_interval. The comparison table (compact convex vs complete metric, continuous vs contracting, existence vs existence+uniqueness) is documented in comments.",
       "lineStart": 312,
       "lineEnd": 354,
-      "theorems": ["banach_implies_brouwer_1d", "contraction_on_interval_unique_fixed_point"]
+      "theorems": [
+        "banach_implies_brouwer_1d",
+        "contraction_on_interval_unique_fixed_point"
+      ]
     },
     {
       "id": "dimensional-gap",
@@ -115,7 +136,9 @@
       "content": "Section documents why IVT suffices in 1D (discrete boundary {0,1}) but not n≥2 (connected sphere S^{n-1}). No-Retraction in n≥2 requires H_{n-1}(S^{n-1}) = Z ≠ H_{n-1}(B^n) = 0. Available approaches: Sperner's Lemma (combinatorial), degree theory, simplicial homology. Mathlib gap noted.",
       "lineStart": 355,
       "lineEnd": 392,
-      "theorems": ["dimension_gap"]
+      "theorems": [
+        "dimension_gap"
+      ]
     }
   ],
   "conclusion": {
@@ -149,6 +172,8 @@
     "lineCount": 402,
     "axiomCount": 0,
     "theoremCount": 16,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/BrouwerFixedPointOQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/brouwer-fixed-point-oq-02-oq-02/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-02-oq-02/meta.json
@@ -196,6 +196,8 @@
     "lineCount": 268,
     "axiomCount": 0,
     "theoremCount": 15,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/BrouwerFixedPointOQ02OQ02.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/brouwer-fixed-point-oq-02/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-02/meta.json
@@ -220,6 +220,8 @@
     "lineCount": 391,
     "axiomCount": 0,
     "theoremCount": 12,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/BrouwerFixedPointOQ02.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-03/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-03/meta.json
@@ -58,7 +58,9 @@
         "status": "placeholder",
         "description": "Trivially proved via IsNashEquilibrium = True stub; not a real Nash equilibrium result"
       }
-    ]
+    ],
+    "path": "Proofs/BrouwerFixedPointOQ04OQ03.lean",
+    "sorries": 0
   },
   "overview": {
     "historicalContext": "L.E.J. Brouwer proved in 1911 that every continuous self-map of a compact convex subset of ℝⁿ has a fixed point. Jules Schauder extended this to infinite-dimensional locally convex spaces in 1930. Shizuo Kakutani's 1941 generalization replaced single-valued maps with set-valued (multi-valued) maps, requiring upper hemicontinuity with nonempty, closed, convex values — the precise conditions that make the proof work via degree theory. John Nash applied Kakutani's theorem in 1950 to prove that every finite strategic-form game has a Nash equilibrium in mixed strategies, establishing a cornerstone of game theory. Ky Fan (1952) and Irving Glicksberg (1952) independently extended Kakutani's theorem to locally convex topological vector spaces (Fan-Glicksberg theorem), providing the foundation for Arrow-Debreu general equilibrium theory (1954).",

--- a/src/data/proofs/brouwer-fixed-point-oq-04/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04/meta.json
@@ -207,7 +207,9 @@
     "lineCount": 473,
     "axiomCount": 1,
     "theoremCount": 23,
-    "definitionCount": 15
+    "definitionCount": 15,
+    "path": "Proofs/BrouwerFixedPointOQ04.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/brouwer-fixed-point/meta.json
+++ b/src/data/proofs/brouwer-fixed-point/meta.json
@@ -358,7 +358,9 @@
         "description": "A self-map without fixed points yields a retraction via ray-casting (wraps axiom)",
         "leanType": "(n : ℕ) → (f : SelfMap n) → ¬HasFixedPoint n f → Retraction n"
       }
-    ]
+    ],
+    "path": "Proofs/BrouwerFixedPoint.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "buffons-needle-oq-01-oq-01",
   "title": "Buffon-Barbier: Angular Average and the Smooth Curve Formula",
   "slug": "buffons-needle-oq-01-oq-01",
-  "description": "Proves the Buffon-Barbier smooth curve theorem (E[crossings] = 2L/(\u03c0d)) from first principles using the angular average identity \u222b_0^\u03c0 |a sin \u03b8 + b cos \u03b8| d\u03b8 = 2\u221a(a\u00b2+b\u00b2). This resolves the open question in buffons-needle-oq-01 by replacing the axiomatic smooth case with a concrete verified proof.",
+  "description": "Proves the Buffon-Barbier smooth curve theorem (E[crossings] = 2L/(πd)) from first principles using the angular average identity ∫_0^π |a sin θ + b cos θ| dθ = 2√(a²+b²). This resolves the open question in buffons-needle-oq-01 by replacing the axiomatic smooth case with a concrete verified proof.",
   "meta": {
     "author": "Barbier (1860); Lean formalization 2026",
     "sourceUrl": "https://en.wikipedia.org/wiki/Buffon%27s_noodle",
@@ -25,7 +25,7 @@
     "mathlibDependencies": [
       {
         "theorem": "intervalIntegral.integral_comp_add_right",
-        "description": "Change of variables u = \u03b8 + c in interval integrals",
+        "description": "Change of variables u = θ + c in interval integrals",
         "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral"
       },
       {
@@ -35,7 +35,7 @@
       },
       {
         "theorem": "intervalIntegral.integral_symm",
-        "description": "Symmetry of interval integrals: \u222b_a^b = -\u222b_b^a",
+        "description": "Symmetry of interval integrals: ∫_a^b = -∫_b^a",
         "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral"
       },
       {
@@ -45,25 +45,25 @@
       },
       {
         "theorem": "Real.sin_nonneg_of_mem_Icc",
-        "description": "sin \u03b8 \u2265 0 for \u03b8 \u2208 [0, \u03c0]",
+        "description": "sin θ ≥ 0 for θ ∈ [0, π]",
         "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
       },
       {
         "theorem": "Complex.cos_arg",
-        "description": "cos(arg z) = z.re / \u2016z\u2016, used to define the rotation angle \u03c6",
+        "description": "cos(arg z) = z.re / ‖z‖, used to define the rotation angle φ",
         "module": "Mathlib.Analysis.SpecialFunctions.Complex.Arg"
       },
       {
         "theorem": "Complex.sin_arg",
-        "description": "sin(arg z) = z.im / \u2016z\u2016, used to define the rotation angle \u03c6",
+        "description": "sin(arg z) = z.im / ‖z‖, used to define the rotation angle φ",
         "module": "Mathlib.Analysis.SpecialFunctions.Complex.Arg"
       }
     ],
     "originalContributions": [
-      "integral_sin_zero_pi: \u222b_0^\u03c0 sin \u03b8 d\u03b8 = 2 (proved via FTC)",
-      "integral_abs_sin_zero_pi: \u222b_0^\u03c0 |sin \u03b8| d\u03b8 = 2 (using sin \u2265 0 on [0, \u03c0])",
-      "integral_abs_sin_shift: \u222b_0^\u03c0 |sin(\u03b8 + c)| d\u03b8 = 2 for any c (change of variables + periodicity)",
-      "angular_average: \u222b_0^\u03c0 |a sin \u03b8 + b cos \u03b8| d\u03b8 = 2\u221a(a\u00b2+b\u00b2) (via Complex.arg for the rotation angle)",
+      "integral_sin_zero_pi: ∫_0^π sin θ dθ = 2 (proved via FTC)",
+      "integral_abs_sin_zero_pi: ∫_0^π |sin θ| dθ = 2 (using sin ≥ 0 on [0, π])",
+      "integral_abs_sin_shift: ∫_0^π |sin(θ + c)| dθ = 2 for any c (change of variables + periodicity)",
+      "angular_average: ∫_0^π |a sin θ + b cos θ| dθ = 2√(a²+b²) (via Complex.arg for the rotation angle)",
       "concreteSmoothExpectedCrossings: concrete double integral definition of expected crossings",
       "buffon_smooth_concrete: main theorem with explicit Fubini hypothesis",
       "hFubini_from_angular_average: proves the Fubini hypothesis from angular_average",
@@ -75,14 +75,14 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "In buffons-needle-oq-01 (Buffon's Noodle), the smooth curve case of the Buffon-Barbier theorem was left as an open question, formalized as an axiom. The question was: can the axiom `buffon_noodle_smooth_eq` be derived from Mathlib's arc length theory?\n\nThis file answers YES. The key insight is the **angular average identity**:\n  \u222b_0^\u03c0 |a sin \u03b8 + b cos \u03b8| d\u03b8 = 2\u221a(a\u00b2 + b\u00b2)\n\nThis is the fundamental reason why the crossing probability depends only on arc length and not on the shape of the curve. For any direction (a, b) representing the tangent vector \u03b3'(t), the integral of |crossings contribution| over all angles \u03b8 gives exactly 2\u2016\u03b3'(t)\u2016. Integrating over t gives 2L/(\u03c0d).\n\nThe proof uses Complex.arg to find the rotation angle \u03c6 such that a sin \u03b8 + b cos \u03b8 = \u221a(a\u00b2+b\u00b2) \u00b7 sin(\u03b8 + \u03c6), then applies the rotation-invariant identity \u222b_0^\u03c0 |sin(\u03b8 + c)| d\u03b8 = 2.",
-    "problemStatement": "**Open Question from buffons-needle-oq-01**: Can the smooth curve axiom\n  `buffon_noodle_smooth_eq : smoothExpectedCrossings \u03b3 a b d = 2 * arcLength(\u03b3) / (\u03c0 * d)`\nbe proved from Mathlib's arc length theory?\n\n**Theorem (Buffon-Barbier, 1860)**: For any smooth planar curve \u03b3 : [a,b] \u2192 \u211d\u00b2 with arc length L, when dropped randomly on a floor with parallel lines (spacing d), the expected number of crossings is:\n  E[crossings] = 2L / (\u03c0d)\n\n**Answer**: YES \u2014 proved here using the angular average theorem and Fubini's theorem.",
-    "text": "Proves the Buffon-Barbier smooth curve theorem (E[crossings] = 2L/(\u03c0d)) from first principles using the angular average identity \u222b_0^\u03c0 |a sin \u03b8 + b cos \u03b8| d\u03b8 = 2\u221a(a\u00b2+b\u00b2). This resolves the open question in buffons-needle-oq-01 by replacing the axiomatic smooth case with a concrete verified proof.",
-    "proofStrategy": "**Key Identity**: \u222b_0^\u03c0 |a sin \u03b8 + b cos \u03b8| d\u03b8 = 2\u221a(a\u00b2 + b\u00b2)\n\n**Why this works**:\n- The vector (a sin \u03b8 + b cos \u03b8) measures how much the tangent direction (a, b) contributes to crossings for angle \u03b8\n- Averaging over all angles \u03b8 \u2208 [0, \u03c0] gives exactly 2\u2016(a,b)\u2016 = 2 times the speed\n- The formula 2L/(\u03c0d) follows by integrating over the curve and normalizing by \u03c0d\n\n**Proof of angular average** (the heart of the proof):\n1. For (a, b) = (0, 0): both sides = 0 \u2713\n2. For (a, b) \u2260 (0, 0): Let r = \u221a(a\u00b2+b\u00b2) and \u03c6 = arg(a + bi)\n   - Then cos \u03c6 = a/r and sin \u03c6 = b/r\n   - So a sin \u03b8 + b cos \u03b8 = r(sin \u03b8 cos \u03c6 + cos \u03b8 sin \u03c6) = r sin(\u03b8 + \u03c6)\n   - Therefore: \u222b_0^\u03c0 |a sin \u03b8 + b cos \u03b8| d\u03b8 = r \u222b_0^\u03c0 |sin(\u03b8 + \u03c6)| d\u03b8 = r \u00b7 2 = 2r \u2713\n\n**Rotation invariance**: \u222b_0^\u03c0 |sin(\u03b8 + c)| d\u03b8 = 2\n- Change variables u = \u03b8 + c: \u222b_c^{c+\u03c0} |sin u| du\n- Split and use |sin(u+\u03c0)| = |sin u| to show \u222b_c^{c+\u03c0} = \u222b_0^\u03c0\n- Equals 2 by the basic integral \u2713",
+    "historicalContext": "In buffons-needle-oq-01 (Buffon's Noodle), the smooth curve case of the Buffon-Barbier theorem was left as an open question, formalized as an axiom. The question was: can the axiom `buffon_noodle_smooth_eq` be derived from Mathlib's arc length theory?\n\nThis file answers YES. The key insight is the **angular average identity**:\n  ∫_0^π |a sin θ + b cos θ| dθ = 2√(a² + b²)\n\nThis is the fundamental reason why the crossing probability depends only on arc length and not on the shape of the curve. For any direction (a, b) representing the tangent vector γ'(t), the integral of |crossings contribution| over all angles θ gives exactly 2‖γ'(t)‖. Integrating over t gives 2L/(πd).\n\nThe proof uses Complex.arg to find the rotation angle φ such that a sin θ + b cos θ = √(a²+b²) · sin(θ + φ), then applies the rotation-invariant identity ∫_0^π |sin(θ + c)| dθ = 2.",
+    "problemStatement": "**Open Question from buffons-needle-oq-01**: Can the smooth curve axiom\n  `buffon_noodle_smooth_eq : smoothExpectedCrossings γ a b d = 2 * arcLength(γ) / (π * d)`\nbe proved from Mathlib's arc length theory?\n\n**Theorem (Buffon-Barbier, 1860)**: For any smooth planar curve γ : [a,b] → ℝ² with arc length L, when dropped randomly on a floor with parallel lines (spacing d), the expected number of crossings is:\n  E[crossings] = 2L / (πd)\n\n**Answer**: YES — proved here using the angular average theorem and Fubini's theorem.",
+    "text": "Proves the Buffon-Barbier smooth curve theorem (E[crossings] = 2L/(πd)) from first principles using the angular average identity ∫_0^π |a sin θ + b cos θ| dθ = 2√(a²+b²). This resolves the open question in buffons-needle-oq-01 by replacing the axiomatic smooth case with a concrete verified proof.",
+    "proofStrategy": "**Key Identity**: ∫_0^π |a sin θ + b cos θ| dθ = 2√(a² + b²)\n\n**Why this works**:\n- The vector (a sin θ + b cos θ) measures how much the tangent direction (a, b) contributes to crossings for angle θ\n- Averaging over all angles θ ∈ [0, π] gives exactly 2‖(a,b)‖ = 2 times the speed\n- The formula 2L/(πd) follows by integrating over the curve and normalizing by πd\n\n**Proof of angular average** (the heart of the proof):\n1. For (a, b) = (0, 0): both sides = 0 ✓\n2. For (a, b) ≠ (0, 0): Let r = √(a²+b²) and φ = arg(a + bi)\n   - Then cos φ = a/r and sin φ = b/r\n   - So a sin θ + b cos θ = r(sin θ cos φ + cos θ sin φ) = r sin(θ + φ)\n   - Therefore: ∫_0^π |a sin θ + b cos θ| dθ = r ∫_0^π |sin(θ + φ)| dθ = r · 2 = 2r ✓\n\n**Rotation invariance**: ∫_0^π |sin(θ + c)| dθ = 2\n- Change variables u = θ + c: ∫_c^{c+π} |sin u| du\n- Split and use |sin(u+π)| = |sin u| to show ∫_c^{c+π} = ∫_0^π\n- Equals 2 by the basic integral ✓",
     "keyInsights": [
-      "The angular average \u222b_0^\u03c0 |a sin \u03b8 + b cos \u03b8| d\u03b8 = 2\u221a(a\u00b2+b\u00b2) is the KEY INSIGHT explaining why shape doesn't matter in Buffon's noodle",
-      "The rotation angle \u03c6 = arg(a+bi) works uniformly for all cases including a=0 using Complex.arg from Mathlib",
-      "The identity |sin(x+\u03c0)| = |sin x| (\u03c0-periodicity of |sin|) is what makes the rotation invariance proof work",
+      "The angular average ∫_0^π |a sin θ + b cos θ| dθ = 2√(a²+b²) is the KEY INSIGHT explaining why shape doesn't matter in Buffon's noodle",
+      "The rotation angle φ = arg(a+bi) works uniformly for all cases including a=0 using Complex.arg from Mathlib",
+      "The identity |sin(x+π)| = |sin x| (π-periodicity of |sin|) is what makes the rotation invariance proof work",
       "The proof avoids the co-area formula by using Fubini's theorem as an explicit hypothesis",
       "The hFubini hypothesis is exactly angular_average applied pointwise, so the full theorem follows automatically",
       "This resolves the open question in BuffonsNoodle.lean: the axiomatic smooth case can be replaced by this concrete proof"
@@ -99,21 +99,21 @@
       "title": "The Fundamental Angular Integral",
       "startLine": 59,
       "endLine": 82,
-      "summary": "integral_sin_zero_pi: \u222b_0^\u03c0 sin \u03b8 d\u03b8 = 2 via FTC. integral_abs_sin_zero_pi: \u222b_0^\u03c0 |sin \u03b8| d\u03b8 = 2 using sin \u2265 0 on [0, \u03c0]."
+      "summary": "integral_sin_zero_pi: ∫_0^π sin θ dθ = 2 via FTC. integral_abs_sin_zero_pi: ∫_0^π |sin θ| dθ = 2 using sin ≥ 0 on [0, π]."
     },
     {
       "id": "rotation-invariance",
       "title": "Rotation Invariance",
       "startLine": 83,
       "endLine": 141,
-      "summary": "integral_abs_sin_shift: \u222b_0^\u03c0 |sin(\u03b8+c)| d\u03b8 = 2 for any c. Uses change of variables and \u03c0-periodicity of |sin|."
+      "summary": "integral_abs_sin_shift: ∫_0^π |sin(θ+c)| dθ = 2 for any c. Uses change of variables and π-periodicity of |sin|."
     },
     {
       "id": "angular-average",
       "title": "The Angular Average Theorem",
       "startLine": 142,
       "endLine": 232,
-      "summary": "angular_average: \u222b_0^\u03c0 |a sin \u03b8 + b cos \u03b8| d\u03b8 = 2\u221a(a\u00b2+b\u00b2). Uses Complex.arg to find the rotation angle \u03c6 = arg(a+bi)."
+      "summary": "angular_average: ∫_0^π |a sin θ + b cos θ| dθ = 2√(a²+b²). Uses Complex.arg to find the rotation angle φ = arg(a+bi)."
     },
     {
       "id": "concrete-crossings",
@@ -139,10 +139,10 @@
   ],
   "conclusion": {
     "summary": "The Buffon-Barbier smooth curve theorem is proved from first principles using the angular average identity. The open question from BuffonsNoodle.lean is resolved: the axiomatic smooth case is not needed. The proof requires only Fubini's theorem (as an explicit hypothesis), not the full co-area formula.",
-    "implications": "**Mathematical Significance**:\n\n**1. Angular Average as the Central Identity**\nThe formula \u222b_0^\u03c0 |a sin \u03b8 + b cos \u03b8| d\u03b8 = 2\u221a(a\u00b2+b\u00b2) is the heart of integral geometry. It explains WHY the crossing probability depends only on length: every arc element contributes proportionally to its length, independent of direction.\n\n**2. The Cauchy-Crofton Connection**\nThis proof is a special case of the Cauchy-Crofton formula:\n   measure(lines meeting curve C) = 2 \u00b7 length(C)\nOur proof gives an elementary verification using only Fubini and the angular average.\n\n**3. Eliminating Axioms**\nThe axiomatic treatment in BuffonsNoodle.lean used:\n  `noncomputable axiom smoothExpectedCrossings`\n  `axiom buffon_noodle_smooth_eq`\nThis file replaces both with proved theorems, improving the formalization.\n\n**4. Technique: Complex.arg for Rotation**\nUsing Complex.arg to find the rotation angle \u03c6 = arg(a+bi) is an elegant approach that handles all cases (a=0, a<0, a>0) uniformly through Mathlib's existing arg theory.",
+    "implications": "**Mathematical Significance**:\n\n**1. Angular Average as the Central Identity**\nThe formula ∫_0^π |a sin θ + b cos θ| dθ = 2√(a²+b²) is the heart of integral geometry. It explains WHY the crossing probability depends only on length: every arc element contributes proportionally to its length, independent of direction.\n\n**2. The Cauchy-Crofton Connection**\nThis proof is a special case of the Cauchy-Crofton formula:\n   measure(lines meeting curve C) = 2 · length(C)\nOur proof gives an elementary verification using only Fubini and the angular average.\n\n**3. Eliminating Axioms**\nThe axiomatic treatment in BuffonsNoodle.lean used:\n  `noncomputable axiom smoothExpectedCrossings`\n  `axiom buffon_noodle_smooth_eq`\nThis file replaces both with proved theorems, improving the formalization.\n\n**4. Technique: Complex.arg for Rotation**\nUsing Complex.arg to find the rotation angle φ = arg(a+bi) is an elegant approach that handles all cases (a=0, a<0, a>0) uniformly through Mathlib's existing arg theory.",
     "openQuestions": [
       "Fully integrate with BuffonsNoodle.lean by removing the axioms and using concreteSmoothExpectedCrossings",
-      "Prove the integrability hypothesis (hInnerInt) from smoothness of \u03b3",
+      "Prove the integrability hypothesis (hInnerInt) from smoothness of γ",
       "Formalize the Cauchy-Crofton formula in full generality",
       "Higher-dimensional Cauchy-Crofton: expected crossings with hyperplane arrangements",
       "Prove the co-area formula in Mathlib to eliminate the Fubini hypothesis"
@@ -167,8 +167,8 @@
   ],
   "references": [
     {
-      "title": "Note sur un probl\u00e8me de calcul des probabilit\u00e9s",
-      "author": "Barbier, \u00c9.",
+      "title": "Note sur un problème de calcul des probabilités",
+      "author": "Barbier, É.",
       "year": "1860",
       "description": "Original generalization of Buffon's needle to arbitrary smooth curves, proving E[crossings] = 2L/(pi*d)"
     },
@@ -180,7 +180,7 @@
     },
     {
       "title": "Integral Geometry and Geometric Probability",
-      "author": "Santal\u00f3, L. A.",
+      "author": "Santaló, L. A.",
       "year": "1976",
       "description": "Foundational text on integral geometry; the angular average identity used here is a special case of the Cauchy-Crofton formula"
     }
@@ -198,6 +198,8 @@
     "lineCount": 390,
     "axiomCount": 0,
     "theoremCount": 9,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/BuffonsNeedleOQ01OQ01.lean",
+    "sorries": 4
   }
 }

--- a/src/data/proofs/buffons-needle-oq-01-oq-02/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-02/meta.json
@@ -177,7 +177,9 @@
     "lineCount": 325,
     "axiomCount": 0,
     "theoremCount": 19,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/BuffonsNeedleOQ01OQ02.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -198,21 +200,28 @@
   ],
   "references": [
     {
-      "authors": ["Cauchy, Augustin-Louis"],
+      "authors": [
+        "Cauchy, Augustin-Louis"
+      ],
       "title": "Note sur divers théorèmes relatifs à la rectification des courbes",
       "year": "1850",
       "venue": "Comptes Rendus de l'Académie des Sciences 31, 344-346",
       "note": "Established the integral-geometric framework connecting random intersections to geometric invariants"
     },
     {
-      "authors": ["Bonnesen, T.", "Fenchel, W."],
+      "authors": [
+        "Bonnesen, T.",
+        "Fenchel, W."
+      ],
       "title": "Theorie der konvexen Körper",
       "year": "1934",
       "venue": "Springer, Berlin",
       "note": "Systematic treatment of mean width, support functions, and the Cauchy-Crofton formula for convex bodies in ℝⁿ"
     },
     {
-      "authors": ["Santaló, Lluís"],
+      "authors": [
+        "Santaló, Lluís"
+      ],
       "title": "Integral Geometry and Geometric Probability",
       "year": "1976",
       "venue": "Cambridge University Press",

--- a/src/data/proofs/buffons-needle-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01/meta.json
@@ -218,6 +218,8 @@
     "lineCount": 250,
     "axiomCount": 0,
     "theoremCount": 12,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/BuffonsNeedleOQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/buffons-needle-oq-02-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-01/meta.json
@@ -162,7 +162,9 @@
     "lineCount": 309,
     "axiomCount": 0,
     "theoremCount": 20,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/BuffonsNeedleOQ02OQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/buffons-needle-oq-02-oq-02/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-02/meta.json
@@ -230,6 +230,8 @@
     "lineCount": 376,
     "axiomCount": 2,
     "theoremCount": 15,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/BuffonsNeedleOQ02OQ02.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/buffons-needle-oq-02/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02/meta.json
@@ -224,6 +224,8 @@
     "lineCount": 262,
     "axiomCount": 0,
     "theoremCount": 16,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/BuffonsNeedleOQ02.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/buffons-needle/meta.json
+++ b/src/data/proofs/buffons-needle/meta.json
@@ -217,7 +217,9 @@
     "lineCount": 266,
     "axiomCount": 0,
     "theoremCount": 12,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/BuffonsNeedle.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/burnside-counting/meta.json
+++ b/src/data/proofs/burnside-counting/meta.json
@@ -70,7 +70,9 @@
     "lineCount": 255,
     "axiomCount": 5,
     "theoremCount": 6,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/BurnsideCounting.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cantor-diagonalization-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01/meta.json
@@ -228,6 +228,8 @@
     "lineCount": 442,
     "axiomCount": 2,
     "theoremCount": 27,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/CantorDiagonalizationOQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/cantor-diagonalization-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02-oq-01/meta.json
@@ -175,7 +175,9 @@
     "lineCount": 130,
     "axiomCount": 0,
     "theoremCount": 15,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CantorDiagonalizationOQ02OQ01.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02/meta.json
@@ -69,7 +69,8 @@
     "theoremCount": 9,
     "definitionCount": 5,
     "mainTheorem": "fodors_pressing_down",
-    "sorries": 1
+    "sorries": 1,
+    "path": "Proofs/CantorDiagonalizationOQ02OQ03OQ02.lean"
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cantor-diagonalization-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02-oq-03/meta.json
@@ -63,7 +63,9 @@
     "lineCount": 142,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CantorDiagonalizationOQ02OQ03.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cantor-diagonalization-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02/meta.json
@@ -198,7 +198,9 @@
     "lineCount": 272,
     "axiomCount": 0,
     "theoremCount": 16,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/CantorDiagonalizationOQ02.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-02/meta.json
@@ -101,6 +101,8 @@
     "lineCount": 275,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/CantorDiagonalizationOQ03OQ01OQ02.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-oq-03/meta.json
@@ -109,6 +109,8 @@
     "lineCount": 256,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/CantorDiagonalizationOQ03OQ01OQ03.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01/meta.json
@@ -136,13 +136,18 @@
     }
   ],
   "leanFile": {
-    "imports": ["Mathlib.Logic.Function.Basic", "Mathlib.Tactic"],
+    "imports": [
+      "Mathlib.Logic.Function.Basic",
+      "Mathlib.Tactic"
+    ],
     "opens": [],
     "namespace": "CantorDiagonalizationOQ03OQ01",
     "lineCount": 303,
     "axiomCount": 0,
     "theoremCount": 14,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/CantorDiagonalizationOQ03OQ01.lean",
+    "sorries": 1
   },
   "references": [
     {

--- a/src/data/proofs/cantor-diagonalization-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03/meta.json
@@ -184,7 +184,9 @@
     "lineCount": 149,
     "axiomCount": 0,
     "theoremCount": 9,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CantorDiagonalizationOQ03.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/cantor-diagonalization-oq-04/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-04/meta.json
@@ -209,7 +209,9 @@
     "lineCount": 304,
     "axiomCount": 0,
     "theoremCount": 15,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/CantorDiagonalizationOQ04.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/cantor-diagonalization/meta.json
+++ b/src/data/proofs/cantor-diagonalization/meta.json
@@ -284,7 +284,9 @@
     "lineCount": 175,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/CantorDiagonalization.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/cantors-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-01-oq-01/meta.json
@@ -141,6 +141,8 @@
     "lineCount": 171,
     "axiomCount": 0,
     "theoremCount": 11,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/CantorsTheoremOQ01OQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/cantors-theorem-oq-01/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-01/meta.json
@@ -232,6 +232,8 @@
     "lineCount": 272,
     "axiomCount": 0,
     "theoremCount": 17,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/CantorsTheoremOQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/cantors-theorem-oq-02/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-02/meta.json
@@ -229,6 +229,8 @@
     "lineCount": 281,
     "axiomCount": 0,
     "theoremCount": 15,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CantorsTheoremOQ02.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/cantors-theorem-oq-03/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-03/meta.json
@@ -194,6 +194,8 @@
     ],
     "opens": [
       "Function"
-    ]
+    ],
+    "path": "Proofs/CantorsTheoremOQ03.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/cantors-theorem/meta.json
+++ b/src/data/proofs/cantors-theorem/meta.json
@@ -144,7 +144,9 @@
     "lineCount": 157,
     "axiomCount": 0,
     "theoremCount": 7,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/CantorsTheorem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -168,6 +168,8 @@
     "lineCount": 217,
     "axiomCount": 0,
     "theoremCount": 11,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-01/meta.json
@@ -166,7 +166,9 @@
     "lineCount": 183,
     "axiomCount": 0,
     "theoremCount": 13,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02/meta.json
@@ -102,7 +102,9 @@
     }
   ],
   "leanFile": {
-    "imports": ["Mathlib"],
+    "imports": [
+      "Mathlib"
+    ],
     "lineCount": 151,
     "axiomCount": 1,
     "theoremCount": 8,
@@ -123,6 +125,8 @@
         "type": "key",
         "description": "L2 inner product equals integral of pointwise product"
       }
-    ]
+    ],
+    "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01/meta.json
@@ -212,6 +212,8 @@
     "lineCount": 153,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-02/meta.json
@@ -205,7 +205,9 @@
     "lineCount": 600,
     "axiomCount": 2,
     "theoremCount": 29,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01/meta.json
@@ -187,7 +187,9 @@
     "lineCount": 228,
     "axiomCount": 0,
     "theoremCount": 9,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-01/meta.json
@@ -210,7 +210,9 @@
         "description": "Proportionality implies CS equality: ‖f‖•g = ‖g‖•f → ⟪f,g⟫ = ‖f‖·‖g‖",
         "leanType": "(f g : E) → ‖f‖ • g = ‖g‖ • f → ⟪f, g⟫_ℝ = ‖f‖ * ‖g‖"
       }
-    ]
+    ],
+    "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-02-oq-01/meta.json
@@ -8,7 +8,12 @@
     "date": "2026-04-04",
     "status": "verified",
     "proofRepoPath": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-    "tags": ["analysis", "lp-spaces", "minkowski-inequality", "ennreal"],
+    "tags": [
+      "analysis",
+      "lp-spaces",
+      "minkowski-inequality",
+      "ennreal"
+    ],
     "badge": "original",
     "sorries": 0,
     "dateAdded": "2026-04-04",
@@ -122,14 +127,19 @@
   ],
   "references": [
     {
-      "authors": ["Minkowski, H."],
+      "authors": [
+        "Minkowski, H."
+      ],
       "title": "Geometrie der Zahlen",
       "year": "1910",
       "venue": "Teubner, Leipzig",
       "note": "Original statement and proof of the Lp triangle inequality via Hölder's inequality"
     },
     {
-      "authors": ["Lieb, E.H.", "Loss, M."],
+      "authors": [
+        "Lieb, E.H.",
+        "Loss, M."
+      ],
       "title": "Analysis",
       "year": "2001",
       "venue": "American Mathematical Society, Graduate Studies in Mathematics vol. 14",
@@ -146,11 +156,16 @@
       "Mathlib.Analysis.MeanInequalitiesPow",
       "Mathlib.Tactic"
     ],
-    "opens": ["MeasureTheory", "ENNReal"],
+    "opens": [
+      "MeasureTheory",
+      "ENNReal"
+    ],
     "namespace": "CancellationStep",
     "lineCount": 117,
     "axiomCount": 0,
     "theoremCount": 3,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/cauchy-schwarz-integral-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-02/meta.json
@@ -171,7 +171,9 @@
     "lineCount": 263,
     "axiomCount": 0,
     "theoremCount": 9,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cauchy-schwarz-integral-oq-03/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-03/meta.json
@@ -162,7 +162,9 @@
     "lineCount": 181,
     "axiomCount": 0,
     "theoremCount": 20,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cauchy-schwarz-integral/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral/meta.json
@@ -190,7 +190,9 @@
     "lineCount": 118,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CauchySchwarzIntegral.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-01/meta.json
@@ -152,7 +152,9 @@
     "lineCount": 185,
     "axiomCount": 0,
     "theoremCount": 9,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CauchySchwarzOQ01OQ01.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-02/meta.json
@@ -139,7 +139,9 @@
     "lineCount": 262,
     "axiomCount": 0,
     "theoremCount": 14,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/CauchySchwarzOQ01OQ02.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-03/meta.json
@@ -84,7 +84,9 @@
     "lineCount": 138,
     "axiomCount": 0,
     "theoremCount": 7,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CauchySchwarzOQ01OQ03.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-04/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-04/meta.json
@@ -73,7 +73,9 @@
     "lineCount": 198,
     "axiomCount": 0,
     "theoremCount": 11,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CauchySchwarzOQ01OQ04.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cauchy-schwarz-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01/meta.json
@@ -152,7 +152,9 @@
     "lineCount": 138,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CauchySchwarzOQ01.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-01/meta.json
@@ -63,7 +63,8 @@
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 10,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CauchySchwarzOQ02OQ01.lean"
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cauchy-schwarz-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02/meta.json
@@ -8,7 +8,13 @@
     "date": "2026-02-15",
     "status": "verified",
     "proofRepoPath": "Proofs/CauchySchwarzOQ02.lean",
-    "tags": ["analysis","cauchy-schwarz","holder-inequality","l2-spaces","measure-theory"],
+    "tags": [
+      "analysis",
+      "cauchy-schwarz",
+      "holder-inequality",
+      "l2-spaces",
+      "measure-theory"
+    ],
     "badge": "original",
     "sorries": 0,
     "dateAdded": "2026-04-02",
@@ -61,7 +67,9 @@
     "lineCount": 335,
     "axiomCount": 0,
     "theoremCount": 18,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CauchySchwarzOQ02.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cauchy-schwarz-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-03-oq-01/meta.json
@@ -202,7 +202,9 @@
     "lineCount": 835,
     "axiomCount": 0,
     "theoremCount": 29,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/CauchySchwarzOQ03OQ01.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/cauchy-schwarz-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-03-oq-02/meta.json
@@ -156,7 +156,9 @@
     "lineCount": 257,
     "axiomCount": 0,
     "theoremCount": 11,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CauchySchwarzOQ03OQ02.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/cauchy-schwarz-oq-03/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-03/meta.json
@@ -157,7 +157,9 @@
     "lineCount": 242,
     "axiomCount": 0,
     "theoremCount": 8,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CauchySchwarzOQ03.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/cauchy-schwarz-oq-04-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-04-oq-01/meta.json
@@ -8,7 +8,13 @@
     "date": "2026-04-04",
     "status": "verified",
     "proofRepoPath": "Proofs/CauchySchwarzOQ04OQ01.lean",
-    "tags": ["inequalities", "combinatorics", "cauchy-schwarz", "weighted-sums", "olympiad"],
+    "tags": [
+      "inequalities",
+      "combinatorics",
+      "cauchy-schwarz",
+      "weighted-sums",
+      "olympiad"
+    ],
     "badge": "original",
     "sorries": 0,
     "dateAdded": "2026-04-04",
@@ -114,6 +120,8 @@
     "lineCount": 150,
     "axiomCount": 0,
     "theoremCount": 4,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CauchySchwarzOQ04OQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/cauchy-schwarz-oq-04/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-04/meta.json
@@ -218,7 +218,9 @@
     "lineCount": 288,
     "axiomCount": 0,
     "theoremCount": 17,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/CauchySchwarzOQ04.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/cauchy-schwarz/meta.json
+++ b/src/data/proofs/cauchy-schwarz/meta.json
@@ -246,28 +246,36 @@
   },
   "references": [
     {
-      "authors": ["A.-L. Cauchy"],
+      "authors": [
+        "A.-L. Cauchy"
+      ],
       "title": "Cours d'Analyse de l'École Royale Polytechnique",
       "year": "1821",
       "venue": "Paris",
       "note": "First proof of the discrete (finite sum) version of the inequality"
     },
     {
-      "authors": ["V. Y. Bunyakovsky"],
+      "authors": [
+        "V. Y. Bunyakovsky"
+      ],
       "title": "Sur quelques inégalités concernant les intégrales ordinaires et les intégrales aux différences finies",
       "year": "1859",
       "venue": "Mémoires de l'Académie Impériale des Sciences de St.-Pétersbourg",
       "note": "Extension to integrals"
     },
     {
-      "authors": ["H. A. Schwarz"],
+      "authors": [
+        "H. A. Schwarz"
+      ],
       "title": "Über ein die Flächen kleinsten Flächeninhalts betreffendes Problem der Variationsrechnung",
       "year": "1885",
       "venue": "Acta Societatis Scientiarum Fennicae",
       "note": "Independent proof of the integral version"
     },
     {
-      "authors": ["J. M. Steele"],
+      "authors": [
+        "J. M. Steele"
+      ],
       "title": "The Cauchy-Schwarz Master Class",
       "year": "2004",
       "venue": "Cambridge University Press",
@@ -286,7 +294,9 @@
     "lineCount": 231,
     "axiomCount": 0,
     "theoremCount": 9,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CauchySchwarz.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "cayley-hamilton-minpoly-oq-01",
   "title": "Jordan Canonical Form and the Minimal Polynomial",
   "slug": "cayley-hamilton-minpoly-oq-01",
-  "description": "Characterizes the minimal polynomial of a linear endomorphism via eigenvalues and Jordan block structure. Proves eigenvalues \u2194 roots of minpoly, minpoly | charpoly, semisimple \u2194 squarefree minpoly, nilpotent \u2194 minpoly = X^k. Axiomatizes the JCF product formula: minpoly = \u03a0 (X-\u03bc)^{e_\u03bc} where e_\u03bc = size of largest Jordan block for eigenvalue \u03bc. 20 theorems, 0 definitions, 3 axioms.",
+  "description": "Characterizes the minimal polynomial of a linear endomorphism via eigenvalues and Jordan block structure. Proves eigenvalues ↔ roots of minpoly, minpoly | charpoly, semisimple ↔ squarefree minpoly, nilpotent ↔ minpoly = X^k. Axiomatizes the JCF product formula: minpoly = Π (X-μ)^{e_μ} where e_μ = size of largest Jordan block for eigenvalue μ. 20 theorems, 0 definitions, 3 axioms.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
@@ -20,31 +20,31 @@
     "sorries": 0,
     "dateAdded": "2026-04-02",
     "axiomCount": 3,
-    "assumptions": "3 axioms: jordan_normal_form_basis (over algebraically closed field, V decomposes into Jordan blocks), minpoly_product_formula (minpoly K f = \u03a0 (X-\u03bc)^{maxGenEigenspaceIndex f \u03bc}), maxGenEigenspaceIndex_exact (the exponent equals exactly the size of the largest Jordan block).",
+    "assumptions": "3 axioms: jordan_normal_form_basis (over algebraically closed field, V decomposes into Jordan blocks), minpoly_product_formula (minpoly K f = Π (X-μ)^{maxGenEigenspaceIndex f μ}), maxGenEigenspaceIndex_exact (the exponent equals exactly the size of the largest Jordan block).",
     "lineCount": 307,
     "theoremCount": 20,
     "definitionCount": 0,
     "originalContributions": [
-      "eigenvalue_iff_root_minpoly: f.HasEigenvalue \u03bc \u2194 (minpoly K f).IsRoot \u03bc",
-      "eigenvalue_linear_factor_dvd_minpoly: \u03bc eigenvalue \u2192 (X-C \u03bc) | minpoly",
-      "minpoly_dvd_charpoly: minpoly K A \u2223 A.charpoly",
-      "isSemisimple_iff_squarefree_minpoly: semisimple \u2194 minpoly squarefree",
-      "isNilpotent_iff_minpoly_pow: nilpotent \u2194 minpoly = X^k",
-      "genEigenspace_nilpotent_restriction: (f - \u03bcI) restricted to genEigenspace is nilpotent"
+      "eigenvalue_iff_root_minpoly: f.HasEigenvalue μ ↔ (minpoly K f).IsRoot μ",
+      "eigenvalue_linear_factor_dvd_minpoly: μ eigenvalue → (X-C μ) | minpoly",
+      "minpoly_dvd_charpoly: minpoly K A ∣ A.charpoly",
+      "isSemisimple_iff_squarefree_minpoly: semisimple ↔ minpoly squarefree",
+      "isNilpotent_iff_minpoly_pow: nilpotent ↔ minpoly = X^k",
+      "genEigenspace_nilpotent_restriction: (f - μI) restricted to genEigenspace is nilpotent"
     ]
   },
   "overview": {
-    "historicalContext": "The Jordan canonical form theorem (Camille Jordan, Traité des substitutions, 1870) states that every endomorphism over an algebraically closed field is similar to a block-diagonal matrix with Jordan blocks. The minimal polynomial was studied by Weierstrass in his theory of matrix pencils (1868) and by Frobenius (1878), who established minpoly | charpoly and characterized semisimplicity via squarefree minpoly. The JCF-minpoly product formula minpoly = \u03a0(X-\u03bc)^{e_\u03bc} — where e_\u03bc is the largest Jordan block size for eigenvalue \u03bc — unifies these perspectives. The Jordan-Chevalley decomposition (Chevalley, 1951) f = s + n with s semisimple, n nilpotent, [s,n] = 0 follows from JCF and is now in Mathlib 4.26.0. The rational canonical form (Frobenius, 1879), which requires no algebraic closure, gives companion matrix blocks indexed by invariant factors. Mathlib 4.26.0 formalizes triangularizability, Jordan-Chevalley, and generalized eigenspaces, but not the explicit Jordan block matrix with labeled basis vectors \u2014 the gap between classical and formally verified.",
-    "problemStatement": "Prove the relationship between Jordan canonical form and the minimal polynomial: minpoly = \u03a0 (X-\u03bc)^{e_\u03bc}. Prove semisimple \u2194 squarefree minpoly and nilpotent \u2194 minpoly = X^k.",
-    "text": "For f : Module.End K V over algebraically closed K: eigenvalues are exactly the roots of minpoly. The minimal polynomial divides the characteristic polynomial. An endomorphism is semisimple (diagonalizable) iff its minimal polynomial is squarefree (no repeated roots). It is nilpotent iff minpoly = X^k for some k. The full JCF theorem: minpoly = \u03a0 (X-\u03bc)^{maxGenEigenspaceIndex f \u03bc} \u2014 the exponent records the largest Jordan block size.",
+    "historicalContext": "The Jordan canonical form theorem (Camille Jordan, Traité des substitutions, 1870) states that every endomorphism over an algebraically closed field is similar to a block-diagonal matrix with Jordan blocks. The minimal polynomial was studied by Weierstrass in his theory of matrix pencils (1868) and by Frobenius (1878), who established minpoly | charpoly and characterized semisimplicity via squarefree minpoly. The JCF-minpoly product formula minpoly = Π(X-μ)^{e_μ} — where e_μ is the largest Jordan block size for eigenvalue μ — unifies these perspectives. The Jordan-Chevalley decomposition (Chevalley, 1951) f = s + n with s semisimple, n nilpotent, [s,n] = 0 follows from JCF and is now in Mathlib 4.26.0. The rational canonical form (Frobenius, 1879), which requires no algebraic closure, gives companion matrix blocks indexed by invariant factors. Mathlib 4.26.0 formalizes triangularizability, Jordan-Chevalley, and generalized eigenspaces, but not the explicit Jordan block matrix with labeled basis vectors — the gap between classical and formally verified.",
+    "problemStatement": "Prove the relationship between Jordan canonical form and the minimal polynomial: minpoly = Π (X-μ)^{e_μ}. Prove semisimple ↔ squarefree minpoly and nilpotent ↔ minpoly = X^k.",
+    "text": "For f : Module.End K V over algebraically closed K: eigenvalues are exactly the roots of minpoly. The minimal polynomial divides the characteristic polynomial. An endomorphism is semisimple (diagonalizable) iff its minimal polynomial is squarefree (no repeated roots). It is nilpotent iff minpoly = X^k for some k. The full JCF theorem: minpoly = Π (X-μ)^{maxGenEigenspaceIndex f μ} — the exponent records the largest Jordan block size.",
     "proofStrategy": "Prove eigenvalue characterization, minpoly | charpoly, and semisimple/nilpotent characterizations from Mathlib's semisimple and eigenspace theory. The nilpotent direction uses a UFD argument: minpoly | X^n with X prime forces minpoly ~ X^j; monic + associated = equal. Axiomatize the JCF product formula and maxGenEigenspaceIndex exactness (not yet in Mathlib).",
     "keyInsights": [
       "Eigenvalues = roots of minpoly: the bridge between linear algebra and polynomial algebra",
-      "Semisimple \u2194 squarefree minpoly: diagonalizability is captured by polynomial squarefreeness",
-      "Nilpotent \u2194 minpoly = X^k: all eigenvalues are 0, proved via UFD structure of K[X]",
+      "Semisimple ↔ squarefree minpoly: diagonalizability is captured by polynomial squarefreeness",
+      "Nilpotent ↔ minpoly = X^k: all eigenvalues are 0, proved via UFD structure of K[X]",
       "JCF product formula: exponents record the largest Jordan block per eigenvalue",
       "UFD argument for nilpotent minpoly: X prime in K[X], so divisors of X^n are X^j; monic + associated forces equality",
-      "Semisimple + nilpotent = 0: squarefree \u2229 pure-power forces minpoly = X (1\u00d71 block), the uniqueness core of Jordan-Chevalley"
+      "Semisimple + nilpotent = 0: squarefree ∩ pure-power forces minpoly = X (1×1 block), the uniqueness core of Jordan-Chevalley"
     ],
     "prerequisites": [
       "Eigenspaces and generalized eigenspaces: Module.End.HasEigenvalue, genEigenspace",
@@ -53,13 +53,13 @@
     ]
   },
   "conclusion": {
-    "summary": "Jordan-minpoly relationship formalized: eigenvalue \u2194 root, minpoly|charpoly, semisimple \u2194 squarefree, nilpotent \u2194 X^k, JCF product formula axiomatized. 20 theorems, 307 lines, 3 axioms. The nilpotent characterization uses a UFD argument for monic divisors of X^n in K[X].",
-    "implications": "The JCF-minpoly connection is central to spectral theory, functional calculus, and representation theory. The axiomatized results reflect the current state of Mathlib: generalized eigenspaces and Jordan-Chevalley exist but the full JNF block matrix is not yet formalized. The semisimple \u2194 squarefree result enables algorithmic diagonalizability testing via GCD computation on the minimal polynomial.",
+    "summary": "Jordan-minpoly relationship formalized: eigenvalue ↔ root, minpoly|charpoly, semisimple ↔ squarefree, nilpotent ↔ X^k, JCF product formula axiomatized. 20 theorems, 307 lines, 3 axioms. The nilpotent characterization uses a UFD argument for monic divisors of X^n in K[X].",
+    "implications": "The JCF-minpoly connection is central to spectral theory, functional calculus, and representation theory. The axiomatized results reflect the current state of Mathlib: generalized eigenspaces and Jordan-Chevalley exist but the full JNF block matrix is not yet formalized. The semisimple ↔ squarefree result enables algorithmic diagonalizability testing via GCD computation on the minimal polynomial.",
     "openQuestions": [
       "Prove the JCF product formula in Lean when Mathlib adds Jordan block matrix decomposition with explicit basis indexing",
       "Prove the Jordan-Chevalley decomposition: f = s + n with s semisimple, n nilpotent, [s,n] = 0, both polynomials in f",
       "Formalize the rational canonical form (companion matrix decomposition over non-algebraically-closed fields via invariant factors)",
-      "Prove the rank-nullity tower: dim(genEigenspace \u03bc k) - dim(genEigenspace \u03bc k-1) = number of Jordan blocks of size \u2265 k for eigenvalue \u03bc"
+      "Prove the rank-nullity tower: dim(genEigenspace μ k) - dim(genEigenspace μ k-1) = number of Jordan blocks of size ≥ k for eigenvalue μ"
     ]
   },
   "leanFile": {
@@ -67,7 +67,9 @@
     "lineCount": 307,
     "axiomCount": 3,
     "theoremCount": 20,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CayleyHamiltonMinpolyOQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -86,37 +88,37 @@
       "title": "Part I: Eigenvalues and the Minimal Polynomial",
       "startLine": 52,
       "endLine": 91,
-      "summary": "eigenvalue_iff_root_minpoly wraps hasEigenvalue_iff_isRoot: eigenvalue \u2194 root of minpoly. eigenvalue_linear_factor_dvd_minpoly: (X - C \u03bc) | minpoly via dvd_iff_isRoot. minpoly_dvd_charpoly wraps Matrix.minpoly_dvd_charpoly. finite_eigenvalues: eigenvalue set is finite. minpoly_annihilates: aeval f (minpoly K f) = 0. minpoly_monic: minpoly is monic. Note: degree bound natDegree \u2264 finrank K V not proved here due to whnf timeout in Lean 4.26.0 when computing finrank K (End K V)."
+      "summary": "eigenvalue_iff_root_minpoly wraps hasEigenvalue_iff_isRoot: eigenvalue ↔ root of minpoly. eigenvalue_linear_factor_dvd_minpoly: (X - C μ) | minpoly via dvd_iff_isRoot. minpoly_dvd_charpoly wraps Matrix.minpoly_dvd_charpoly. finite_eigenvalues: eigenvalue set is finite. minpoly_annihilates: aeval f (minpoly K f) = 0. minpoly_monic: minpoly is monic. Note: degree bound natDegree ≤ finrank K V not proved here due to whnf timeout in Lean 4.26.0 when computing finrank K (End K V)."
     },
     {
       "title": "Part II: Generalized Eigenspace Structure",
       "startLine": 93,
       "endLine": 124,
-      "summary": "generalized_eigenspaces_span_top: over algebraically closed K, \u2a06 (genEigenspace \u03bc k) = \u22a4, proved via iSup_genEigenspace_eq + iSup_maxGenEigenspace_eq_top. disjoint_generalized_eigenspaces: distinct eigenvalues give disjoint genEigenspaces (disjoint_genEigenspace). nilpotent_shift_on_genEigenspace: (f - \u03bcI) restricted to genEigenspace \u03bc k is nilpotent (isNilpotent_restrict_sub_algebraMap). genEigenspace_stabilizes: the chain stabilizes at maxGenEigenspaceIndex (genEigenspace_eq_genEigenspace_maxUnifEigenspaceIndex_of_le)."
+      "summary": "generalized_eigenspaces_span_top: over algebraically closed K, ⨆ (genEigenspace μ k) = ⊤, proved via iSup_genEigenspace_eq + iSup_maxGenEigenspace_eq_top. disjoint_generalized_eigenspaces: distinct eigenvalues give disjoint genEigenspaces (disjoint_genEigenspace). nilpotent_shift_on_genEigenspace: (f - μI) restricted to genEigenspace μ k is nilpotent (isNilpotent_restrict_sub_algebraMap). genEigenspace_stabilizes: the chain stabilizes at maxGenEigenspaceIndex (genEigenspace_eq_genEigenspace_maxUnifEigenspaceIndex_of_le)."
     },
     {
       "title": "Part III: Nilpotent Endomorphisms and the Minimal Polynomial",
       "startLine": 126,
       "endLine": 194,
-      "summary": "eigenvalue_zero_of_nilpotent: nilpotent f has only eigenvalue 0 (proof: \u03bc^k\u2022v = f^k(v) = 0, v\u22600, so \u03bc^k = 0, so \u03bc = 0 in a field). minpoly_dvd_pow_of_nilpotent: f^n = 0 \u21d2 minpoly | X^n via minpoly.dvd. minpoly_pow_X_of_nilpotent: nilpotent \u21d2 minpoly = X^j by UFD: X is prime, dvd_prime_pow, Associated monic polynomials are equal. nilpotent_of_minpoly_pow_X: converse via aeval f (X^k) = f^k = 0. nilpotent_iff_minpoly_pow_X: full iff combining both directions."
+      "summary": "eigenvalue_zero_of_nilpotent: nilpotent f has only eigenvalue 0 (proof: μ^k•v = f^k(v) = 0, v≠0, so μ^k = 0, so μ = 0 in a field). minpoly_dvd_pow_of_nilpotent: f^n = 0 ⇒ minpoly | X^n via minpoly.dvd. minpoly_pow_X_of_nilpotent: nilpotent ⇒ minpoly = X^j by UFD: X is prime, dvd_prime_pow, Associated monic polynomials are equal. nilpotent_of_minpoly_pow_X: converse via aeval f (X^k) = f^k = 0. nilpotent_iff_minpoly_pow_X: full iff combining both directions."
     },
     {
       "title": "Part IV: Diagonalizability and the Minimal Polynomial",
       "startLine": 196,
       "endLine": 217,
-      "summary": "minpoly_squarefree_of_semisimple: IsSemisimple f \u21d2 Squarefree (minpoly K f) via IsSemisimple.minpoly_squarefree. isSemisimple_iff_squarefree_minpoly: full iff, backward direction uses isSemisimple_of_squarefree_aeval_eq_zero. semisimple_nilpotent_eq_zero: semisimple + nilpotent = 0 (eq_zero_of_isNilpotent_isSemisimple) \u2014 the uniqueness core of Jordan-Chevalley."
+      "summary": "minpoly_squarefree_of_semisimple: IsSemisimple f ⇒ Squarefree (minpoly K f) via IsSemisimple.minpoly_squarefree. isSemisimple_iff_squarefree_minpoly: full iff, backward direction uses isSemisimple_of_squarefree_aeval_eq_zero. semisimple_nilpotent_eq_zero: semisimple + nilpotent = 0 (eq_zero_of_isNilpotent_isSemisimple) — the uniqueness core of Jordan-Chevalley."
     },
     {
       "title": "Part V: Jordan Normal Form (Axiomatic)",
       "startLine": 218,
       "endLine": 257,
-      "summary": "Three axioms for JCF results not yet in Mathlib 4.26.0. jordan_normal_form_basis: existence of a Jordan basis (sigma-indexed family with Jordan block action). minpoly_product_formula: minpoly K f = \u03a0_{\u03bc\u2208s} (X - C \u03bc)^(maxGenEigenspaceIndex f \u03bc). maxGenEigenspaceIndex_exact: the exponent is tight \u2014 there exists v in maxGenEigenspace \u03bc with (f - \u03bc)^{e-1}(v) \u2260 0. The placeholder condition LinearMap.ker (LinearMap.id - f) \u2264 \u22a4 in jordan_normal_form_basis acknowledges the sigma-family linear independence encoding challenge."
+      "summary": "Three axioms for JCF results not yet in Mathlib 4.26.0. jordan_normal_form_basis: existence of a Jordan basis (sigma-indexed family with Jordan block action). minpoly_product_formula: minpoly K f = Π_{μ∈s} (X - C μ)^(maxGenEigenspaceIndex f μ). maxGenEigenspaceIndex_exact: the exponent is tight — there exists v in maxGenEigenspace μ with (f - μ)^{e-1}(v) ≠ 0. The placeholder condition LinearMap.ker (LinearMap.id - f) ≤ ⊤ in jordan_normal_form_basis acknowledges the sigma-family linear independence encoding challenge."
     },
     {
       "title": "Part VI: Corollaries and Summary",
       "startLine": 258,
       "endLine": 307,
-      "summary": "jordan_block_power_dvd_minpoly: (X - C \u03bc)^{e_\u03bc} | minpoly K f by Finset.dvd_prod_of_mem applied to the product formula. diagonalizable_iff_squarefree_minpoly: alias of isSemisimple_iff_squarefree_minpoly. Summary docstring synthesizes the four key equivalences and the two-tier structure (Parts I-IV fully verified, Part V axiomatized pending Mathlib JNF block matrix)."
+      "summary": "jordan_block_power_dvd_minpoly: (X - C μ)^{e_μ} | minpoly K f by Finset.dvd_prod_of_mem applied to the product formula. diagonalizable_iff_squarefree_minpoly: alias of isSemisimple_iff_squarefree_minpoly. Summary docstring synthesizes the four key equivalences and the two-tier structure (Parts I-IV fully verified, Part V axiomatized pending Mathlib JNF block matrix)."
     }
   ]
 }

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-01/meta.json
@@ -204,7 +204,9 @@
     "lineCount": 570,
     "axiomCount": 0,
     "theoremCount": 26,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/SkolemNoetherMatrixAut.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01/meta.json
@@ -152,7 +152,9 @@
     "lineCount": 217,
     "axiomCount": 0,
     "theoremCount": 9,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-02/meta.json
@@ -138,7 +138,9 @@
     "lineCount": 390,
     "axiomCount": 0,
     "theoremCount": 16,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ02.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-03/meta.json
@@ -112,6 +112,8 @@
     "lineCount": 136,
     "axiomCount": 0,
     "theoremCount": 3,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ03.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02/meta.json
@@ -169,7 +169,9 @@
     "lineCount": 131,
     "axiomCount": 0,
     "theoremCount": 7,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/CayleyHamiltonMinpolyOQ02.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-04/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-04/meta.json
@@ -19,26 +19,26 @@
     "sorries": 0,
     "dateAdded": "2026-04-02",
     "axiomCount": 1,
-    "assumptions": "1 axiom: nonderogatory_has_cyclic_vector \u2014 the converse direction: if M is nonderogatory (minpoly = charpoly), then there exists a cyclic vector v with {v, Mv, ..., M^{n-1}v} a basis. This requires constructing the cyclic vector from the rational canonical form, which is not yet fully formalized in Mathlib.",
+    "assumptions": "1 axiom: nonderogatory_has_cyclic_vector — the converse direction: if M is nonderogatory (minpoly = charpoly), then there exists a cyclic vector v with {v, Mv, ..., M^{n-1}v} a basis. This requires constructing the cyclic vector from the rational canonical form, which is not yet fully formalized in Mathlib.",
     "lineCount": 316,
     "theoremCount": 8,
     "definitionCount": 0,
     "originalContributions": [
-      "IsCyclicVector: predicate \u2014 v is cyclic for M if {v,Mv,...,M^{n-1}v} spans K^n",
-      "IsNonderogatory: predicate \u2014 minpoly M = charpoly M",
-      "cyclic_implies_nonderogatory: forward direction \u2014 cyclic vector implies minpoly = charpoly (fully proved)",
+      "IsCyclicVector: predicate — v is cyclic for M if {v,Mv,...,M^{n-1}v} spans K^n",
+      "IsNonderogatory: predicate — minpoly M = charpoly M",
+      "cyclic_implies_nonderogatory: forward direction — cyclic vector implies minpoly = charpoly (fully proved)",
       "minpoly_eq_charpoly_of_natDegree_eq: natDeg(minpoly) = n implies minpoly = charpoly",
       "nonderogatory_iff_cyclic_vector: full iff characterization (modulo converse axiom)",
       "minpoly_natDegree_eq_dim_of_cyclic: cyclic vector implies natDeg(minpoly) = dim",
       "nonderogatory_iff_natDegree_eq: equivalent characterization via natDegree",
-      "derogatory_iff_natDegree_lt: derogatory \u2194 natDeg(minpoly) < n"
+      "derogatory_iff_natDegree_lt: derogatory ↔ natDeg(minpoly) < n"
     ]
   },
   "overview": {
-    "historicalContext": "The concept of a cyclic vector is classical in matrix theory and control theory. A matrix M \u2208 M_n(K) is nonderogatory (Frobenius, 1879) if its minimal and characteristic polynomials coincide; equivalently, it is similar to the companion matrix of its characteristic polynomial. The cyclic vector characterization connects to Krylov subspace methods (Krylov, 1931), now fundamental in numerical linear algebra (Lanczos, Arnoldi, GMRES). In control theory (Kalman, 1960s), the state matrix of a controllable linear system is nonderogatory, and the existence of a cyclic vector is equivalent to controllability from a single input. The Frobenius invariant factor decomposition establishes that nonderogatory matrices have a single invariant factor, while derogatory matrices have multiple. Mathlib 4.26.0 has the necessary minpoly and charpoly machinery but not the full structure theorem for f.g. modules over PIDs needed for the backward direction.",
-    "problemStatement": "Prove that a matrix M \u2208 M_n(K) is nonderogatory (minpoly = charpoly) if and only if it has a cyclic vector. Formalize both directions.",
+    "historicalContext": "The concept of a cyclic vector is classical in matrix theory and control theory. A matrix M ∈ M_n(K) is nonderogatory (Frobenius, 1879) if its minimal and characteristic polynomials coincide; equivalently, it is similar to the companion matrix of its characteristic polynomial. The cyclic vector characterization connects to Krylov subspace methods (Krylov, 1931), now fundamental in numerical linear algebra (Lanczos, Arnoldi, GMRES). In control theory (Kalman, 1960s), the state matrix of a controllable linear system is nonderogatory, and the existence of a cyclic vector is equivalent to controllability from a single input. The Frobenius invariant factor decomposition establishes that nonderogatory matrices have a single invariant factor, while derogatory matrices have multiple. Mathlib 4.26.0 has the necessary minpoly and charpoly machinery but not the full structure theorem for f.g. modules over PIDs needed for the backward direction.",
+    "problemStatement": "Prove that a matrix M ∈ M_n(K) is nonderogatory (minpoly = charpoly) if and only if it has a cyclic vector. Formalize both directions.",
     "text": "Forward direction: if v is cyclic for M, then the vector space K^n has a basis {v, Mv, ..., M^{n-1}v}. The minimal polynomial of M with respect to v is the unique monic polynomial p of minimal degree with p(M)v = 0. Since v is cyclic, this has degree n = deg(charpoly). Since minpoly | charpoly and both are monic of degree n, they are equal. Converse: if minpoly = charpoly, construct v as a suitable sum of basis vectors via rational canonical form (axiomatized).",
-    "proofStrategy": "Define IsCyclicVector and IsNonderogatory. Prove the forward direction via degree comparison: cyclic \u2192 natDeg(minpoly) = n \u2192 minpoly = charpoly (bridge lemma: equal-degree monic polynomials where one divides the other must be equal). Axiomatize the converse (rational canonical form / PID structure theorem argument). Prove equivalent characterizations via natDegree.",
+    "proofStrategy": "Define IsCyclicVector and IsNonderogatory. Prove the forward direction via degree comparison: cyclic → natDeg(minpoly) = n → minpoly = charpoly (bridge lemma: equal-degree monic polynomials where one divides the other must be equal). Axiomatize the converse (rational canonical form / PID structure theorem argument). Prove equivalent characterizations via natDegree.",
     "keyInsights": [
       "Cyclic vector gives natDeg(minpoly) = n: the annihilator polynomial of a cyclic vector has full degree",
       "minpoly | charpoly and equal degrees forces minpoly = charpoly (monic cofactor must be 1)",
@@ -54,13 +54,13 @@
     ]
   },
   "conclusion": {
-    "summary": "Nonderogatory matrices characterized via cyclic vectors: forward direction (cyclic \u2192 minpoly = charpoly) fully proved via degree bridge lemma, converse axiomatized (requires PID structure theorem). Equivalent natDegree characterizations proved. 8 theorems, 316 lines, 1 axiom.",
+    "summary": "Nonderogatory matrices characterized via cyclic vectors: forward direction (cyclic → minpoly = charpoly) fully proved via degree bridge lemma, converse axiomatized (requires PID structure theorem). Equivalent natDegree characterizations proved. 8 theorems, 316 lines, 1 axiom.",
     "implications": "The cyclic vector characterization is central to systems theory: a linear dynamical system is controllable from a single input iff its state matrix is nonderogatory. The bridge lemma (equal-degree monic polynomials where one divides the other are equal) is a reusable algebraic tool. Completing the converse would give a fully verified characterization useful in both pure and applied linear algebra.",
     "openQuestions": [
       "Prove nonderogatory_has_cyclic_vector: formalize the rational canonical form (invariant factor decomposition) for matrices over a field in Lean 4",
-      "Prove the simultaneous cyclic vector theorem: M\u2081, ..., M_k have a common cyclic vector iff they generate a cyclic algebra",
+      "Prove the simultaneous cyclic vector theorem: M₁, ..., M_k have a common cyclic vector iff they generate a cyclic algebra",
       "Extend to linear maps over infinite-dimensional spaces: cyclic vector theory for compact operators",
-      "Prove the Krylov basis theorem: IsCyclicVector M v \u2194 IsCyclicVectorLI M v (the annihilator and linear independence formulations are equivalent)"
+      "Prove the Krylov basis theorem: IsCyclicVector M v ↔ IsCyclicVectorLI M v (the annihilator and linear independence formulations are equivalent)"
     ]
   },
   "leanFile": {
@@ -68,7 +68,9 @@
     "lineCount": 316,
     "axiomCount": 1,
     "theoremCount": 8,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CayleyHamiltonMinpolyOQ04.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -88,37 +90,37 @@
       "title": "Part II: Bridge Lemma",
       "startLine": 89,
       "endLine": 133,
-      "summary": "minpoly_eq_charpoly_of_natDegree_eq: natDeg(minpoly) = natDeg(charpoly) \u21d2 minpoly = charpoly. Proof: write charpoly = minpoly * r via minpoly_dvd_charpoly; degree additivity forces natDeg(r) = 0; r is monic (leadingCoeff = 1 from charpoly monic and minpoly monic); monic degree-0 polynomial must be 1; so charpoly = minpoly * 1 = minpoly."
+      "summary": "minpoly_eq_charpoly_of_natDegree_eq: natDeg(minpoly) = natDeg(charpoly) ⇒ minpoly = charpoly. Proof: write charpoly = minpoly * r via minpoly_dvd_charpoly; degree additivity forces natDeg(r) = 0; r is monic (leadingCoeff = 1 from charpoly monic and minpoly monic); monic degree-0 polynomial must be 1; so charpoly = minpoly * 1 = minpoly."
     },
     {
-      "title": "Part III: Forward Direction (Cyclic \u2192 Nonderogatory)",
+      "title": "Part III: Forward Direction (Cyclic → Nonderogatory)",
       "startLine": 134,
       "endLine": 167,
-      "summary": "cyclic_implies_nonderogatory: applies bridge lemma after proving natDeg(minpoly) = n. Key steps: (1) natDeg(minpoly) \u2264 natDeg(charpoly) = n from minpoly | charpoly; (2) by contradiction assume natDeg(minpoly) < n; (3) minpoly.aeval gives (aeval M (minpoly K M)).mulVec v = 0; (4) IsCyclicVector forces minpoly = 0; (5) contradiction with Monic.ne_zero. Clean by_contra + omega proof."
+      "summary": "cyclic_implies_nonderogatory: applies bridge lemma after proving natDeg(minpoly) = n. Key steps: (1) natDeg(minpoly) ≤ natDeg(charpoly) = n from minpoly | charpoly; (2) by contradiction assume natDeg(minpoly) < n; (3) minpoly.aeval gives (aeval M (minpoly K M)).mulVec v = 0; (4) IsCyclicVector forces minpoly = 0; (5) contradiction with Monic.ne_zero. Clean by_contra + omega proof."
     },
     {
-      "title": "Part IV: Backward Direction (Nonderogatory \u2192 Cyclic, Axiomatized)",
+      "title": "Part IV: Backward Direction (Nonderogatory → Cyclic, Axiomatized)",
       "startLine": 169,
       "endLine": 206,
-      "summary": "Comment discusses three approaches: (1) PID structure theorem V \u2245 K[X]/(d\u2081) \u2295 ... \u2295 K[X]/(d_k), minpoly = charpoly forces k = 1; (2) Jordan Normal Form for alg. closed fields; (3) union of proper subspaces for infinite fields. axiom nonderogatory_has_cyclic_vector: IsNonderogatory M \u2192 \u2203 v, IsCyclicVector M v. Holds over ALL fields (finite included), ruling out Approach 3 for the general statement."
+      "summary": "Comment discusses three approaches: (1) PID structure theorem V ≅ K[X]/(d₁) ⊕ ... ⊕ K[X]/(d_k), minpoly = charpoly forces k = 1; (2) Jordan Normal Form for alg. closed fields; (3) union of proper subspaces for infinite fields. axiom nonderogatory_has_cyclic_vector: IsNonderogatory M → ∃ v, IsCyclicVector M v. Holds over ALL fields (finite included), ruling out Approach 3 for the general statement."
     },
     {
       "title": "Part V: Full Characterization",
       "startLine": 208,
       "endLine": 223,
-      "summary": "nonderogatory_iff_cyclic_vector: full iff combining the proved forward direction and the axiomatized backward direction. nonderogatory_has_cyclic_vector provides the \u2192 direction, cyclic_implies_nonderogatory provides the \u2190 direction."
+      "summary": "nonderogatory_iff_cyclic_vector: full iff combining the proved forward direction and the axiomatized backward direction. nonderogatory_has_cyclic_vector provides the → direction, cyclic_implies_nonderogatory provides the ← direction."
     },
     {
       "title": "Part VI: Corollaries",
       "startLine": 225,
       "endLine": 253,
-      "summary": "minpoly_natDegree_eq_dim_of_cyclic: cyclic \u2192 natDeg(minpoly) = n (repackages intermediate step from forward direction). nonderogatory_algebra_dim: nonderogatory \u2192 natDeg(minpoly) = n (same via IsNonderogatory). nonderogatory_minpoly_dvd_charpoly: minpoly | charpoly for nonderogatory M (trivially, since they're equal)."
+      "summary": "minpoly_natDegree_eq_dim_of_cyclic: cyclic → natDeg(minpoly) = n (repackages intermediate step from forward direction). nonderogatory_algebra_dim: nonderogatory → natDeg(minpoly) = n (same via IsNonderogatory). nonderogatory_minpoly_dvd_charpoly: minpoly | charpoly for nonderogatory M (trivially, since they're equal)."
     },
     {
       "title": "Part VII: Degree Characterization",
       "startLine": 254,
       "endLine": 284,
-      "summary": "nonderogatory_iff_natDegree_eq: IsNonderogatory M \u2194 natDeg(minpoly) = n. derogatory_iff_natDegree_lt: \u00acIsNonderogatory M \u2194 natDeg(minpoly) < n (requires Nontrivial hypothesis). Both proved cleanly by combining bridge lemma with charpoly_natDegree_eq_dim."
+      "summary": "nonderogatory_iff_natDegree_eq: IsNonderogatory M ↔ natDeg(minpoly) = n. derogatory_iff_natDegree_lt: ¬IsNonderogatory M ↔ natDeg(minpoly) < n (requires Nontrivial hypothesis). Both proved cleanly by combining bridge lemma with charpoly_natDegree_eq_dim."
     }
   ]
 }

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-01/meta.json
@@ -111,6 +111,8 @@
     "lineCount": 362,
     "axiomCount": 0,
     "theoremCount": 5,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-02/meta.json
@@ -179,7 +179,9 @@
     "lineCount": 270,
     "axiomCount": 0,
     "theoremCount": 8,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-03/meta.json
@@ -167,7 +167,9 @@
     "lineCount": 345,
     "axiomCount": 0,
     "theoremCount": 19,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ03.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
@@ -200,7 +200,9 @@
     "lineCount": 270,
     "axiomCount": 0,
     "theoremCount": 5,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean",
+    "sorries": 1
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05/meta.json
@@ -197,7 +197,9 @@
     "lineCount": 232,
     "axiomCount": 0,
     "theoremCount": 23,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cayley-hamilton-minpoly/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly/meta.json
@@ -223,7 +223,9 @@
     "lineCount": 447,
     "axiomCount": 0,
     "theoremCount": 30,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CayleyHamiltonOQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cayley-hamilton-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-01/meta.json
@@ -65,7 +65,9 @@
     "lineCount": 447,
     "axiomCount": 0,
     "theoremCount": 30,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CayleyHamiltonOQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cayley-hamilton-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-02/meta.json
@@ -65,7 +65,9 @@
     "lineCount": 358,
     "axiomCount": 0,
     "theoremCount": 20,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CayleyHamiltonOQ02.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cayley-hamilton-reduction-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-01/meta.json
@@ -146,7 +146,9 @@
     "lineCount": 304,
     "axiomCount": 0,
     "theoremCount": 14,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CayleyHamiltonReductionOQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cayley-hamilton-reduction-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02/meta.json
@@ -200,6 +200,8 @@
     "lineCount": 160,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CayleyHamiltonReductionOQ02.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/cayley-hamilton-reduction/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction/meta.json
@@ -153,7 +153,9 @@
     "lineCount": 358,
     "axiomCount": 0,
     "theoremCount": 20,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CayleyHamiltonOQ02.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cayley-hamilton/meta.json
+++ b/src/data/proofs/cayley-hamilton/meta.json
@@ -180,7 +180,9 @@
     "lineCount": 250,
     "axiomCount": 0,
     "theoremCount": 11,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CayleyHamilton.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-01/meta.json
@@ -244,7 +244,9 @@
     "lineCount": 1130,
     "axiomCount": 3,
     "theoremCount": 55,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/CentralLimitTheoremOQ01OQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-02/meta.json
@@ -174,7 +174,9 @@
     "lineCount": 322,
     "axiomCount": 0,
     "theoremCount": 19,
-    "definitionCount": 13
+    "definitionCount": 13,
+    "path": "Proofs/CentralLimitTheoremOQ01OQ02.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-03/meta.json
@@ -32,7 +32,9 @@
     "lineCount": 146,
     "axiomCount": 0,
     "theoremCount": 7,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/CentralLimitTheoremOQ01OQ03.lean",
+    "sorries": 0
   },
   "overview": {
     "historicalContext": "Classical probability theory, with the Central Limit Theorem (CLT) and Lévy's theory of stable distributions (1924), was extended to a non-commutative setting by Dan-Virgil Voiculescu in 1983. Voiculescu introduced 'free probability'—a framework where random variables are replaced by non-commutative operators and statistical independence by 'free independence'—motivated by the isomorphism problem for von Neumann algebras (specifically: are the free group factors L(Fₙ) isomorphic for different n?). The free CLT, proved by Voiculescu in 1985, shows that normalized sums of freely independent variables converge to the Wigner semicircle distribution, first introduced by Wigner (1955) in the context of random matrix eigenvalues. The Bercovici-Pata bijection (1999) established a systematic correspondence between all classical and free infinitely divisible distributions, preserving stability indices. This unified the classical Lévy-Khintchine theory with the free world and showed that free probability is not merely an analogy but a deep structural mirror of classical probability.",

--- a/src/data/proofs/central-limit-theorem-oq-01/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01/meta.json
@@ -162,7 +162,9 @@
     "lineCount": 313,
     "axiomCount": 0,
     "theoremCount": 12,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/CentralLimitTheoremOQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/central-limit-theorem-oq-03/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-03/meta.json
@@ -166,7 +166,9 @@
     "lineCount": 241,
     "axiomCount": 14,
     "theoremCount": 8,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/CentralLimitTheoremOQ03.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/central-limit-theorem-oq-04/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-04/meta.json
@@ -46,7 +46,7 @@
       "CLTStructure: abstract structure capturing the universal CLT pattern across all independence types",
       "Structural comparison theorems for classical vs free vs boolean CLT"
     ],
-    "historicalContext": "Voiculescu introduced free probability in 1985 to study von Neumann algebras of free groups. The Free CLT \u2014 that the semicircle distribution is the universal limit under free convolution \u2014 was the founding result. Speicher (1990) developed the combinatorial theory via non-crossing partitions, and Muraki (2003) classified all five universal independences, each with its own CLT and limit law.",
+    "historicalContext": "Voiculescu introduced free probability in 1985 to study von Neumann algebras of free groups. The Free CLT — that the semicircle distribution is the universal limit under free convolution — was the founding result. Speicher (1990) developed the combinatorial theory via non-crossing partitions, and Muraki (2003) classified all five universal independences, each with its own CLT and limit law.",
     "axiomCount": 9,
     "lineCount": 649,
     "assumptions": "9 axioms (free probability not in Mathlib). Core axioms: freeCumulant (3), freeConv + linearization + identity (3), cumulant_determines_distribution, semicircle_cumulant_higher, free_clt. PROVED: freeConv_comm, freeConv_assoc (from cumulant determinism), Rtransform_additive (from cumulant linearity). Rtransform defined as coefficient sequence.",
@@ -104,10 +104,10 @@
     {
       "id": "dilation",
       "title": "Dilation and Normalized Free Convolution",
-      "summary": "Axiomatizes dilation $D_c$ with cumulant scaling $\\kappa_n(D_c(\\mu)) = c^n \\kappa_n(\\mu)$ and R-transform scaling. Defines the normalized free convolution power $D_{1/\\sqrt{n}}(\\mu^{\\boxplus n})$ \u2014 the distribution of $(a_1 + \\cdots + a_n)/\\sqrt{n}$.",
+      "summary": "Axiomatizes dilation $D_c$ with cumulant scaling $\\kappa_n(D_c(\\mu)) = c^n \\kappa_n(\\mu)$ and R-transform scaling. Defines the normalized free convolution power $D_{1/\\sqrt{n}}(\\mu^{\\boxplus n})$ — the distribution of $(a_1 + \\cdots + a_n)/\\sqrt{n}$.",
       "startLine": 372,
       "endLine": 401,
-      "mathContext": "Axiomatizes dilation $D_c$ with cumulant scaling $\\kappa_n(D_c(\\mu)) = c^n \\kappa_n(\\mu)$ and R-transform scaling. Defines the normalized free convolution power $D_{1/\\sqrt{n}}(\\mu^{\\boxplus n})$ \u2014 the distribution of $(a_1 + \\cdots + a_n)/\\sqrt{n}$."
+      "mathContext": "Axiomatizes dilation $D_c$ with cumulant scaling $\\kappa_n(D_c(\\mu)) = c^n \\kappa_n(\\mu)$ and R-transform scaling. Defines the normalized free convolution power $D_{1/\\sqrt{n}}(\\mu^{\\boxplus n})$ — the distribution of $(a_1 + \\cdots + a_n)/\\sqrt{n}$."
     },
     {
       "id": "free-clt",
@@ -135,15 +135,15 @@
     }
   ],
   "overview": {
-    "historicalContext": "Free probability was invented by Dan-Virgil Voiculescu in 1985, motivated by problems in operator algebras \u2014 specifically, the isomorphism question for von Neumann algebras of free groups. The Free Central Limit Theorem was the founding result: if $a_1, a_2, \\ldots$ are freely independent, identically distributed non-commutative random variables with mean 0 and variance 1, then the normalized sums $(a_1 + \\cdots + a_n)/\\sqrt{n}$ converge in distribution to the semicircle (Wigner) distribution.\n\nRoland Speicher (1990) developed the combinatorial approach via non-crossing partitions, showing that free cumulants linearize free convolution \u2014 exactly paralleling how classical cumulants linearize classical convolution. Naofumi Muraki (2003) proved the remarkable classification theorem: there are exactly five universal notions of independence (classical, free, Boolean, monotone, anti-monotone), each with its own convolution, cumulants, partition lattice, and CLT limit law.",
+    "historicalContext": "Free probability was invented by Dan-Virgil Voiculescu in 1985, motivated by problems in operator algebras — specifically, the isomorphism question for von Neumann algebras of free groups. The Free Central Limit Theorem was the founding result: if $a_1, a_2, \\ldots$ are freely independent, identically distributed non-commutative random variables with mean 0 and variance 1, then the normalized sums $(a_1 + \\cdots + a_n)/\\sqrt{n}$ converge in distribution to the semicircle (Wigner) distribution.\n\nRoland Speicher (1990) developed the combinatorial approach via non-crossing partitions, showing that free cumulants linearize free convolution — exactly paralleling how classical cumulants linearize classical convolution. Naofumi Muraki (2003) proved the remarkable classification theorem: there are exactly five universal notions of independence (classical, free, Boolean, monotone, anti-monotone), each with its own convolution, cumulants, partition lattice, and CLT limit law.",
     "problemStatement": "**Open Question #4 from the CLT gallery:**\n\nHow does the topological perspective (renormalization flow, fixed points, attractors) extend to non-commutative probability, specifically to Voiculescu's free probability theory?\n\n**Answer:** The topological structure extends perfectly. In free probability:\n- Free convolution $\\boxplus$ replaces classical convolution $*$\n- The R-transform replaces the log-characteristic function\n- The semicircle distribution replaces the Gaussian\n- The semicircle is the unique fixed point and global attractor of the free renormalization flow\n\nMoreover, this pattern extends to all five universal independences classified by Muraki.",
-    "text": "This formalization shows that the topological perspective on the CLT \u2014 the Gaussian as a renormalization fixed point and global attractor \u2014 extends naturally to free (non-commutative) probability, where the semicircle distribution plays the role of the Gaussian. The formalization introduces a CLTStructure abstraction that captures the universal pattern.",
-    "proofStrategy": "The formalization builds the free probability analog in parallel to the classical CLT:\n\n1. **NC distributions** (\u00a71): Moment sequences with extensionality\n2. **Free independence** (\u00a72): Alternating centered products vanish\n3. **Free cumulants** (\u00a73): Via non-crossing partitions, with moment-cumulant bijection\n4. **Free convolution monoid** (\u00a74): Commutativity, associativity, identity, distribution law. Key proved result: `freeConvPow_cumulant` showing $\\kappa_k(\\mu^{\\boxplus n}) = n \\cdot \\kappa_k(\\mu)$\n5. **R-transform** (\u00a75): Linearizes free convolution (Voiculescu's key insight). Proved: `Rtransform_freeConvPow`\n6. **Semicircle** (\u00a76): Only $\\kappa_2 = 1$ nonzero; $R_w(z) = z$\n7. **Free CLT** (\u00a77\u20138): Semicircle is fixed point of $T(\\mu) = D_{1/\\sqrt{2}}(\\mu \\boxplus \\mu)$ and global attractor\n8. **Universal structure** (\u00a79): `CLTStructure` abstraction instantiated for free case, with structural verification theorems",
+    "text": "This formalization shows that the topological perspective on the CLT — the Gaussian as a renormalization fixed point and global attractor — extends naturally to free (non-commutative) probability, where the semicircle distribution plays the role of the Gaussian. The formalization introduces a CLTStructure abstraction that captures the universal pattern.",
+    "proofStrategy": "The formalization builds the free probability analog in parallel to the classical CLT:\n\n1. **NC distributions** (§1): Moment sequences with extensionality\n2. **Free independence** (§2): Alternating centered products vanish\n3. **Free cumulants** (§3): Via non-crossing partitions, with moment-cumulant bijection\n4. **Free convolution monoid** (§4): Commutativity, associativity, identity, distribution law. Key proved result: `freeConvPow_cumulant` showing $\\kappa_k(\\mu^{\\boxplus n}) = n \\cdot \\kappa_k(\\mu)$\n5. **R-transform** (§5): Linearizes free convolution (Voiculescu's key insight). Proved: `Rtransform_freeConvPow`\n6. **Semicircle** (§6): Only $\\kappa_2 = 1$ nonzero; $R_w(z) = z$\n7. **Free CLT** (§7–8): Semicircle is fixed point of $T(\\mu) = D_{1/\\sqrt{2}}(\\mu \\boxplus \\mu)$ and global attractor\n8. **Universal structure** (§9): `CLTStructure` abstraction instantiated for free case, with structural verification theorems",
     "keyInsights": [
       "The R-transform linearizes free convolution exactly as the log-characteristic function linearizes classical convolution: R(mu boxplus nu) = R(mu) + R(nu)",
       "The semicircle's R-transform is R_w(z) = z (linear), just as the Gaussian's log-characteristic function is -t^2/2 (quadratic). Both have only kappa_2 nonzero.",
       "The abstract CLTStructure shows the universal pattern: convolution monoid + cumulant linearization + renormalization = CLT. What varies across the five independences is only the partition lattice.",
-      "Free cumulant scaling (freeConvPow_cumulant): kappa_k(mu^{boxplus n}) = n * kappa_k(mu) \u2014 proved by induction from the linearization axiom and the Dirac identity trick",
+      "Free cumulant scaling (freeConvPow_cumulant): kappa_k(mu^{boxplus n}) = n * kappa_k(mu) — proved by induction from the linearization axiom and the Dirac identity trick",
       "Muraki's classification (2003): classical, free, Boolean, monotone, anti-monotone are the ONLY five universal independences. Each has its own limit law (Gaussian, semicircle, Bernoulli, arcsine, arcsine)."
     ],
     "prerequisites": [
@@ -154,7 +154,7 @@
   },
   "conclusion": {
     "summary": "This formalization answers the open question by showing that the topological perspective on the CLT extends naturally to non-commutative probability. The semicircle distribution is to free probability what the Gaussian is to classical probability: the unique fixed point and global attractor of the renormalization flow. The CLTStructure abstraction reveals this as a universal phenomenon across all five types of independence classified by Muraki. Key proved results include freeConvPow_add (distribution law), freeConvPow_cumulant (cumulant scaling), and Rtransform_freeConvPow (R-transform scaling).",
-    "implications": "**Theoretical significance**: The parallel between classical and free CLT is not a coincidence \u2014 it reflects a deep structural pattern. Muraki's classification shows exactly five universal independences, each producing a CLT with the same topological structure (renormalization fixed point + attractor). This suggests that the 'CLT phenomenon' is primarily about convolution monoid structure and cumulant linearization, not about the specific nature of independence.\n\n**Connections**: Free probability connects to random matrix theory (Wigner's semicircle law for eigenvalues of large random matrices), quantum information theory, and operator algebras. The R-transform is the main computational tool in free probability, analogous to Fourier analysis in classical probability.",
+    "implications": "**Theoretical significance**: The parallel between classical and free CLT is not a coincidence — it reflects a deep structural pattern. Muraki's classification shows exactly five universal independences, each producing a CLT with the same topological structure (renormalization fixed point + attractor). This suggests that the 'CLT phenomenon' is primarily about convolution monoid structure and cumulant linearization, not about the specific nature of independence.\n\n**Connections**: Free probability connects to random matrix theory (Wigner's semicircle law for eigenvalues of large random matrices), quantum information theory, and operator algebras. The R-transform is the main computational tool in free probability, analogous to Fourier analysis in classical probability.",
     "openQuestions": [
       "Can the Boolean CLT (convergence to the Bernoulli distribution) be formalized with the same CLTStructure framework?",
       "Can the moment-cumulant formula via non-crossing partitions be constructively implemented to reduce the axiom count?",
@@ -180,7 +180,9 @@
     "lineCount": 649,
     "axiomCount": 9,
     "theoremCount": 22,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/CentralLimitTheoremOQ04.lean",
+    "sorries": 0
   },
   "references": [
     {
@@ -231,12 +233,12 @@
     {
       "targetId": "central-limit-theorem-oq-01-oq-01",
       "relationship": "sibling",
-      "description": "Sibling: Gnedenko-Kolmogorov domain of attraction theorem \u2014 characterizes which distributions are attracted to each stable law via regular variation"
+      "description": "Sibling: Gnedenko-Kolmogorov domain of attraction theorem — characterizes which distributions are attracted to each stable law via regular variation"
     },
     {
       "targetId": "central-limit-theorem-oq-01-oq-02",
       "relationship": "sibling",
-      "description": "Sibling: L\u00e9vy-Khintchine representation for infinitely divisible distributions"
+      "description": "Sibling: Lévy-Khintchine representation for infinitely divisible distributions"
     }
   ]
 }

--- a/src/data/proofs/listings.json
+++ b/src/data/proofs/listings.json
@@ -21026,7 +21026,7 @@
     "erdosNumber": 508,
     "mathlibCount": 4,
     "sorries": 0,
-    "annotationCount": 4
+    "annotationCount": 5
   },
   {
     "id": "erdos-509",


### PR DESCRIPTION
## Fix

Added missing `path` and `sorries` fields to `leanFile` objects for 198 gallery proofs that were using an older metadata format. This is a continuation of the batch fix in #9756.

## Evidence

**Before**: `"leanFile": { "imports": ["Mathlib"], "lineCount": 534, "axiomCount": 0 }` — missing `path` and `sorries`

**After**: `"leanFile": { "imports": ["Mathlib"], "lineCount": 534, "axiomCount": 0, "path": "Proofs/AbelRuffiniGaloisExtensions.lean", "sorries": 0 }` — complete metadata

## Details

- 198 proofs with old-format `leanFile` (alphabetical range: abel-ruffini-* through central-limit-theorem-*)
- `path` derived from `meta.proofRepoPath` in each meta.json
- `sorries` count verified from actual Lean source files
- Excludes 2 proofs already covered in PR #9756

Also updates `listings.json` to reflect erdos-508 annotation count (4→5) from recent enrichment commit.

## Validation

`pnpm build` passes cleanly.

---
Automated fix by lean-mechanic agent.