### PR TITLE
fix(meta): add missing leanFile.path and sorries to 200 gallery proofs (batch 3)

### DIFF
--- a/src/data/proofs/central-limit-theorem/meta.json
+++ b/src/data/proofs/central-limit-theorem/meta.json
@@ -323,7 +323,9 @@
       "Mathlib.Analysis.Calculus.Taylor",
       "Mathlib.Tactic"
     ],
-    "opens": []
+    "opens": [],
+    "path": "Proofs/CentralLimitTheorem.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/cevas-theorem-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-01/meta.json
@@ -70,7 +70,9 @@
     "lineCount": 907,
     "axiomCount": 0,
     "theoremCount": 39,
-    "definitionCount": 20
+    "definitionCount": 20,
+    "path": "Proofs/CevasTheoremOQ01.lean",
+    "sorries": 1
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cevas-theorem-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-02-oq-01-oq-02/meta.json
@@ -68,7 +68,9 @@
     "lineCount": 301,
     "axiomCount": 0,
     "theoremCount": 13,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/CevasTheoremOQ02OQ01OQ02.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cevas-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-02-oq-01/meta.json
@@ -194,6 +194,8 @@
     "lineCount": 262,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CevasTheoremOQ02OQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/cevas-theorem-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-02-oq-02/meta.json
@@ -158,7 +158,9 @@
     "lineCount": 320,
     "axiomCount": 0,
     "theoremCount": 17,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/CevasTheoremOQ02OQ02.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cevas-theorem-oq-02/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-02/meta.json
@@ -154,7 +154,9 @@
     "lineCount": 501,
     "axiomCount": 0,
     "theoremCount": 22,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/CevasTheoremOQ02.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cevas-theorem-oq-04/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-04/meta.json
@@ -149,7 +149,9 @@
     "lineCount": 242,
     "axiomCount": 0,
     "theoremCount": 22,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/CevasTheoremOQ04.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cevas-theorem/meta.json
+++ b/src/data/proofs/cevas-theorem/meta.json
@@ -144,7 +144,9 @@
     "lineCount": 263,
     "axiomCount": 0,
     "theoremCount": 8,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/CevasTheorem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/chinese-remainder-constructive-oq-04-oq-03/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-04-oq-03/meta.json
@@ -145,7 +145,9 @@
     "lineCount": 216,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/ChineseRemainderNonCoprimeList.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/chinese-remainder-constructive-oq-04/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-04/meta.json
@@ -166,7 +166,9 @@
     "lineCount": 156,
     "axiomCount": 0,
     "theoremCount": 5,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/ChineseRemainderConstructiveOQ04.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/chinese-remainder-constructive/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive/meta.json
@@ -185,7 +185,9 @@
     "lineCount": 416,
     "axiomCount": 0,
     "theoremCount": 17,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/ChineseRemainderConstructive.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -241,42 +243,55 @@
   ],
   "references": [
     {
-      "authors": ["Sun Tzu (Sunzi)"],
+      "authors": [
+        "Sun Tzu (Sunzi)"
+      ],
       "title": "Sunzi Suanjing (The Mathematical Classic of Sun Tzu)",
       "year": "~400 CE",
       "venue": "China",
       "note": "Earliest known statement of the Chinese Remainder Theorem: 'There are certain things whose number is unknown. Repeatedly divided by 3, the remainder is 2; by 5 the remainder is 3; and by 7 the remainder is 2. What will be the number?' Answer: 23"
     },
     {
-      "authors": ["Gauss, Carl Friedrich"],
+      "authors": [
+        "Gauss, Carl Friedrich"
+      ],
       "title": "Disquisitiones Arithmeticae",
       "year": "1801",
       "venue": "Leipzig: Gerhard Fleischer",
       "note": "Section 36 gives the general formulation of CRT for pairwise coprime moduli, establishing the modern algebraic framework"
     },
     {
-      "authors": ["Ireland, Kenneth", "Rosen, Michael"],
+      "authors": [
+        "Ireland, Kenneth",
+        "Rosen, Michael"
+      ],
       "title": "A Classical Introduction to Modern Number Theory",
       "year": "1990",
       "venue": "Springer GTM 84, 2nd edition",
       "note": "Chapter 3 presents CRT as a ring isomorphism, with applications to quadratic residues and the structure of (Z/nZ)*"
     },
     {
-      "authors": ["Shoup, Victor"],
+      "authors": [
+        "Shoup, Victor"
+      ],
       "title": "A Computational Introduction to Number Theory and Algebra",
       "year": "2009",
       "venue": "Cambridge University Press, 2nd edition",
       "note": "Algorithmic perspective on CRT: the constructive Bezout-based formula, its complexity, and applications to RSA-CRT and residue number systems"
     },
     {
-      "authors": ["Sun Zi"],
+      "authors": [
+        "Sun Zi"
+      ],
       "title": "Sunzi Suanjing (The Mathematical Classic of Sun Zi)",
       "year": "~400 CE",
       "venue": "Chinese mathematical treatise",
       "note": "Earliest known statement of the Chinese Remainder Theorem as a concrete problem"
     },
     {
-      "authors": ["O. Ore"],
+      "authors": [
+        "O. Ore"
+      ],
       "title": "The general Chinese remainder theorem",
       "year": "1952",
       "venue": "Amer. Math. Monthly, 59(6), 365-370",

--- a/src/data/proofs/chinese-remainder-non-coprime-oq-01/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-01/meta.json
@@ -174,7 +174,9 @@
     "lineCount": 308,
     "axiomCount": 0,
     "theoremCount": 17,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/ChineseRemainderNonCoprimeOQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/chinese-remainder-non-coprime-oq-02/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-02/meta.json
@@ -72,7 +72,9 @@
     "lineCount": 705,
     "axiomCount": 0,
     "theoremCount": 55,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/ChineseRemainderNonCoprimeOQ02.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/chinese-remainder-non-coprime-oq-03/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-03/meta.json
@@ -67,7 +67,9 @@
     "lineCount": 391,
     "axiomCount": 0,
     "theoremCount": 7,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/ChineseRemainderNonCoprimeOQ03.lean",
+    "sorries": 1
   },
   "crossReferences": [
     {

--- a/src/data/proofs/chinese-remainder-non-coprime-oq-04/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-04/meta.json
@@ -184,7 +184,9 @@
     ],
     "opens": [
       "Real"
-    ]
+    ],
+    "path": "Proofs/ChineseRemainderNonCoprimeOQ04.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/chinese-remainder-non-coprime/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime/meta.json
@@ -148,28 +148,38 @@
   },
   "references": [
     {
-      "authors": ["O. Ore"],
+      "authors": [
+        "O. Ore"
+      ],
       "title": "The general Chinese remainder theorem",
       "year": "1952",
       "venue": "Amer. Math. Monthly, 59(6), 365-370",
       "note": "Systematic treatment of CRT for non-coprime moduli with the gcd divisibility criterion"
     },
     {
-      "authors": ["C. F. Gauss"],
+      "authors": [
+        "C. F. Gauss"
+      ],
       "title": "Disquisitiones Arithmeticae",
       "year": "1801",
       "venue": "Leipzig: Gerh. Fleischer",
       "note": "Sections 32-36: CRT for coprime moduli; the non-coprime case is implicit in the theory of simultaneous congruences"
     },
     {
-      "authors": ["K. Ireland", "M. Rosen"],
+      "authors": [
+        "K. Ireland",
+        "M. Rosen"
+      ],
       "title": "A Classical Introduction to Modern Number Theory",
       "year": "1990",
       "venue": "Springer GTM 84, Chapter 3",
       "note": "Presents both coprime and non-coprime CRT with ring-theoretic perspective"
     },
     {
-      "authors": ["G. H. Hardy", "E. M. Wright"],
+      "authors": [
+        "G. H. Hardy",
+        "E. M. Wright"
+      ],
       "title": "An Introduction to the Theory of Numbers",
       "year": "1979",
       "venue": "Oxford University Press, 5th ed., Chapter 5",
@@ -218,7 +228,9 @@
     "lineCount": 305,
     "axiomCount": 0,
     "theoremCount": 16,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/ChineseRemainderNonCoprime.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/collatz-structured-oq-02-oq-01/meta.json
+++ b/src/data/proofs/collatz-structured-oq-02-oq-01/meta.json
@@ -138,6 +138,8 @@
     "namespace": "CollatzCyclesOQ01",
     "lineCount": 213,
     "axiomCount": 1,
-    "theoremCount": 14
+    "theoremCount": 14,
+    "path": "Proofs/CollatzStructuredOQ02OQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/collatz-structured-oq-02/meta.json
+++ b/src/data/proofs/collatz-structured-oq-02/meta.json
@@ -187,7 +187,9 @@
     "imports": [
       "Mathlib.Tactic"
     ],
-    "opens": []
+    "opens": [],
+    "path": "Proofs/CollatzCycles.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/collatz-structured/meta.json
+++ b/src/data/proofs/collatz-structured/meta.json
@@ -167,7 +167,9 @@
     "lineCount": 207,
     "axiomCount": 1,
     "theoremCount": 16,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/CollatzStructured.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/combinations-formula-oq-01/meta.json
+++ b/src/data/proofs/combinations-formula-oq-01/meta.json
@@ -66,7 +66,9 @@
     "lineCount": 185,
     "axiomCount": 0,
     "theoremCount": 8,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CombinationsFormulaOQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/combinations-formula/meta.json
+++ b/src/data/proofs/combinations-formula/meta.json
@@ -128,7 +128,9 @@
     "lineCount": 400,
     "axiomCount": 0,
     "theoremCount": 25,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/CombinationsFormula.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/continuum-hypothesis-oq-01/meta.json
+++ b/src/data/proofs/continuum-hypothesis-oq-01/meta.json
@@ -175,7 +175,9 @@
     "lineCount": 317,
     "axiomCount": 10,
     "theoremCount": 20,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/ContinuumHypothesisOQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/continuum-hypothesis-oq-02/meta.json
+++ b/src/data/proofs/continuum-hypothesis-oq-02/meta.json
@@ -182,7 +182,9 @@
     "lineCount": 584,
     "axiomCount": 2,
     "theoremCount": 32,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/ContinuumHypothesisOQ02.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/continuum-hypothesis/meta.json
+++ b/src/data/proofs/continuum-hypothesis/meta.json
@@ -126,7 +126,9 @@
     "lineCount": 396,
     "axiomCount": 4,
     "theoremCount": 9,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/ContinuumHypothesis.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cramers-rule-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-02/meta.json
@@ -156,7 +156,9 @@
     "lineCount": 462,
     "axiomCount": 0,
     "theoremCount": 28,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/CramersRuleOQ01OQ02.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/cramers-rule-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-03/meta.json
@@ -163,6 +163,8 @@
         "type": "proved",
         "description": "Gaussian elimination is O(n³)"
       }
-    ]
+    ],
+    "path": "Proofs/CramersRuleOQ01OQ03.lean",
+    "sorries": 1
   }
 }

--- a/src/data/proofs/cramers-rule-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01/meta.json
@@ -181,7 +181,9 @@
     "lineCount": 282,
     "axiomCount": 0,
     "theoremCount": 13,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CramersRuleOQ01.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/cramers-rule-oq-02/meta.json
+++ b/src/data/proofs/cramers-rule-oq-02/meta.json
@@ -164,7 +164,9 @@
     "lineCount": 207,
     "axiomCount": 0,
     "theoremCount": 16,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/CramersRuleOQ02.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/cramers-rule-oq-03/meta.json
+++ b/src/data/proofs/cramers-rule-oq-03/meta.json
@@ -148,7 +148,9 @@
     "lineCount": 175,
     "axiomCount": 0,
     "theoremCount": 8,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/CramersRuleOQ03.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/cramers-rule-oq-04/meta.json
+++ b/src/data/proofs/cramers-rule-oq-04/meta.json
@@ -65,7 +65,9 @@
     "lineCount": 175,
     "axiomCount": 0,
     "theoremCount": 11,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CramersRuleOQ04.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cramers-rule/meta.json
+++ b/src/data/proofs/cramers-rule/meta.json
@@ -213,7 +213,9 @@
     "lineCount": 161,
     "axiomCount": 0,
     "theoremCount": 9,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/CramersRule.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/cube-root-2-irrational/meta.json
+++ b/src/data/proofs/cube-root-2-irrational/meta.json
@@ -61,7 +61,9 @@
     "lineCount": 91,
     "axiomCount": 0,
     "theoremCount": 5,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/CubeRoot2Irrational.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/de-moivre-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-01/meta.json
@@ -170,7 +170,9 @@
     "lineCount": 231,
     "axiomCount": 0,
     "theoremCount": 19,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/DeMoivreOQ01.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/de-moivre-oq-02/meta.json
+++ b/src/data/proofs/de-moivre-oq-02/meta.json
@@ -170,7 +170,9 @@
     "lineCount": 157,
     "axiomCount": 0,
     "theoremCount": 16,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/DeMoivreOQ02.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/de-moivre-oq-03-oq-01/meta.json
+++ b/src/data/proofs/de-moivre-oq-03-oq-01/meta.json
@@ -67,7 +67,9 @@
         "status": "proved",
         "description": "The map θ ↦ exp(iαθ) is continuous for any real α"
       }
-    ]
+    ],
+    "path": "Proofs/DeMoivreOQ03OQ01.lean",
+    "sorries": 0
   },
   "overview": {
     "historicalContext": "Abraham de Moivre stated his famous theorem around 1707, though a full proof appeared later in Euler's 1748 work *Introductio in analysin infinitorum*. Euler's formula e^{iθ} = cos θ + i sin θ reframes De Moivre as the elementary identity (e^{iθ})^n = e^{inθ}. The natural extension to real and complex exponents requires the complex logarithm and its branch structure — a subtlety invisible in the integer case. For irrational exponents, Hermann Weyl's 1916 equidistribution theorem revealed a deep connection to ergodic theory: the orbit {e^{2πiαn} : n ∈ ℤ} is dense in the unit circle precisely when α is irrational. This connects De Moivre's geometric insight to Fourier analysis and the mixing properties of irrational rotations.",

--- a/src/data/proofs/de-moivre-oq-03/meta.json
+++ b/src/data/proofs/de-moivre-oq-03/meta.json
@@ -207,7 +207,9 @@
     "lineCount": 275,
     "axiomCount": 0,
     "theoremCount": 14,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/DeMoivreOQ03.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/de-moivre/meta.json
+++ b/src/data/proofs/de-moivre/meta.json
@@ -177,7 +177,9 @@
     "lineCount": 239,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/DeMoivre.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/denumerability-rationals-oq-02/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-02/meta.json
@@ -64,7 +64,9 @@
     "lineCount": 237,
     "axiomCount": 0,
     "theoremCount": 18,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/DenumerabilityRationalsOQ02.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/denumerability-rationals-oq-03/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-03/meta.json
@@ -195,7 +195,9 @@
     "lineCount": 600,
     "axiomCount": 0,
     "theoremCount": 30,
-    "definitionCount": 12
+    "definitionCount": 12,
+    "path": "Proofs/DenumerabilityRationalsOQ03.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/denumerability-rationals-oq-04/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-04/meta.json
@@ -143,6 +143,8 @@
     "lineCount": 142,
     "axiomCount": 0,
     "theoremCount": 5,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/DenumerabilityRationalsOQ04.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/denumerability-rationals/meta.json
+++ b/src/data/proofs/denumerability-rationals/meta.json
@@ -101,7 +101,9 @@
     "lineCount": 191,
     "axiomCount": 0,
     "theoremCount": 9,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/DenumerabilityRationals.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/derangements-convergence/meta.json
+++ b/src/data/proofs/derangements-convergence/meta.json
@@ -129,6 +129,8 @@
     "lineCount": 283,
     "axiomCount": 0,
     "theoremCount": 8,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/DerangementsConvergence.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/derangements-oq-02-oq-01/meta.json
+++ b/src/data/proofs/derangements-oq-02-oq-01/meta.json
@@ -219,6 +219,8 @@
     "lineCount": 123,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/DerangementsOQ02OQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/derangements-oq-02-oq-02/meta.json
+++ b/src/data/proofs/derangements-oq-02-oq-02/meta.json
@@ -8,7 +8,14 @@
     "date": "2026-04-04",
     "status": "verified",
     "proofRepoPath": "Proofs/DerangementsOQ02OQ02.lean",
-    "tags": ["combinatorics", "permutations", "derangements", "burnside", "probability", "generating-functions"],
+    "tags": [
+      "combinatorics",
+      "permutations",
+      "derangements",
+      "burnside",
+      "probability",
+      "generating-functions"
+    ],
     "badge": "original",
     "sorries": 0,
     "dateAdded": "2026-04-04",
@@ -115,6 +122,8 @@
     "lineCount": 250,
     "axiomCount": 0,
     "theoremCount": 13,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/DerangementsOQ02OQ02.lean",
+    "sorries": 2
   }
 }

--- a/src/data/proofs/derangements-oq-02/meta.json
+++ b/src/data/proofs/derangements-oq-02/meta.json
@@ -178,7 +178,9 @@
     "lineCount": 357,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/DerangementsOQ02.lean",
+    "sorries": 1
   },
   "references": [
     {

--- a/src/data/proofs/derangements-oq-03-oq-01/meta.json
+++ b/src/data/proofs/derangements-oq-03-oq-01/meta.json
@@ -194,7 +194,9 @@
         "type": "proved",
         "description": "(-1)^{2n+1}/(2n+2)! ≤ 0"
       }
-    ]
+    ],
+    "path": "Proofs/DerangementsOQ03OQ01.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/derangements-oq-03/meta.json
+++ b/src/data/proofs/derangements-oq-03/meta.json
@@ -182,7 +182,9 @@
     "lineCount": 405,
     "axiomCount": 0,
     "theoremCount": 22,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/DerangementsOQ03.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/derangements/meta.json
+++ b/src/data/proofs/derangements/meta.json
@@ -248,7 +248,9 @@
     "lineCount": 227,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/Derangements.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/desargues-theorem-oq-01/meta.json
+++ b/src/data/proofs/desargues-theorem-oq-01/meta.json
@@ -156,7 +156,9 @@
     "lineCount": 285,
     "axiomCount": 0,
     "theoremCount": 16,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/DesarguesTheoremOQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/desargues-theorem-oq-02/meta.json
+++ b/src/data/proofs/desargues-theorem-oq-02/meta.json
@@ -148,7 +148,9 @@
     "lineCount": 332,
     "axiomCount": 0,
     "theoremCount": 37,
-    "definitionCount": 21
+    "definitionCount": 21,
+    "path": "Proofs/DesarguesTheoremOQ02.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/desargues-theorem-oq-04/meta.json
+++ b/src/data/proofs/desargues-theorem-oq-04/meta.json
@@ -31,13 +31,13 @@
     "mathlibDependencies": [
       {
         "theorem": "Matrix.det_fin_three",
-        "description": "Explicit 3\u00d73 determinant expansion, used for all algebraic ring proofs.",
+        "description": "Explicit 3×3 determinant expansion, used for all algebraic ring proofs.",
         "module": "Mathlib.LinearAlgebra.Matrix.Determinant.Basic"
       }
     ],
     "originalContributions": [
       "Proof that collinear = concurrent in homogeneous coordinates (rfl)",
-      "Dual configuration definition (vertices \u2194 sides)",
+      "Dual configuration definition (vertices ↔ sides)",
       "dual_perspFromPoint_eq_perspFromLine: duality converts point perspective to line perspective (rfl)",
       "Desargues identity reproduced and proved over any CommRing K",
       "perspFromPoint_swap: perspectivity is symmetric in the two triangles",
@@ -46,7 +46,7 @@
       "Algebraic converse over integral domains via zero-product property",
       "swap_swap: double swap is identity (rfl)"
     ],
-    "historicalContext": "Girard Desargues stated his theorem in the 1639 'Brouillon project,' but his cryptic notation delayed its recognition until rediscovery by Poncelet (1822). Projective duality \u2014 systematically developed by Poncelet and Gergonne in the 1820s \u2014 states that every theorem in projective geometry has a dual, obtained by interchanging 'point' and 'line'. Desargues's theorem is the premier example of a self-dual theorem: its dual is its own converse. Hilbert's 'Grundlagen der Geometrie' (1899) showed that Desargues's theorem characterizes Desarguesian planes (those embeddable in projective 3-space), establishing a deep connection between incidence geometry and coordinatization by division rings. Moulton's non-Desarguesian plane (1902) demonstrated that Desargues's theorem is genuinely independent of the other projective axioms in dimension 2.",
+    "historicalContext": "Girard Desargues stated his theorem in the 1639 'Brouillon project,' but his cryptic notation delayed its recognition until rediscovery by Poncelet (1822). Projective duality — systematically developed by Poncelet and Gergonne in the 1820s — states that every theorem in projective geometry has a dual, obtained by interchanging 'point' and 'line'. Desargues's theorem is the premier example of a self-dual theorem: its dual is its own converse. Hilbert's 'Grundlagen der Geometrie' (1899) showed that Desargues's theorem characterizes Desarguesian planes (those embeddable in projective 3-space), establishing a deep connection between incidence geometry and coordinatization by division rings. Moulton's non-Desarguesian plane (1902) demonstrated that Desargues's theorem is genuinely independent of the other projective axioms in dimension 2.",
     "dateAdded": "2026-03-12",
     "axiomCount": 0,
     "relatedProblems": [
@@ -71,7 +71,7 @@
     {
       "id": "setup",
       "title": "Cross Product and Determinant Setup",
-      "summary": "Defines `cross3` (K\u00b3 cross product), `threeVecMat` (3\u00d73 row matrix), and the explicit determinant expansion. All over an arbitrary `CommRing K`.",
+      "summary": "Defines `cross3` (K³ cross product), `threeVecMat` (3×3 row matrix), and the explicit determinant expansion. All over an arbitrary `CommRing K`.",
       "mathContext": "$\\det(u,v,w) = u_0(v_1 w_2 - v_2 w_1) - u_1(v_0 w_2 - v_2 w_0) + u_2(v_0 w_1 - v_1 w_0)$",
       "startLine": 37,
       "endLine": 73
@@ -95,7 +95,7 @@
     {
       "id": "dual-theorem",
       "title": "Self-Duality Theorem",
-      "summary": "The central result: `dual_perspFromPoint_eq_perspFromLine` proves that 'perspective from a point' of the dual configuration IS 'perspective from a line' of the original \u2014 proved by `rfl` (definitional equality).",
+      "summary": "The central result: `dual_perspFromPoint_eq_perspFromLine` proves that 'perspective from a point' of the dual configuration IS 'perspective from a line' of the original — proved by `rfl` (definitional equality).",
       "startLine": 126,
       "endLine": 141,
       "mathContext": "$\\text{dual}(\\text{perspFromPoint}) = \\text{perspFromLine}$ by `rfl`. The joining lines of dual vertex pairs are the intersection points of original sides."
@@ -135,7 +135,7 @@
     {
       "id": "forward-swap",
       "title": "Forward Direction for Swapped Configuration",
-      "summary": "Desargues's theorem for both orderings: the forward direction holds for both (A,B,C)\u2192(A',B',C') and (A',B',C')\u2192(A,B,C). The self-duality chain `desargues_forward_both_orders` packages both.",
+      "summary": "Desargues's theorem for both orderings: the forward direction holds for both (A,B,C)→(A',B',C') and (A',B',C')→(A,B,C). The self-duality chain `desargues_forward_both_orders` packages both.",
       "startLine": 305,
       "endLine": 324,
       "mathContext": "Desargues forward for both orderings: $\\text{perspFromPoint}(\\Delta, \\Delta') \\implies \\text{perspFromLine}(\\Delta, \\Delta')$ and $\\text{perspFromPoint}(\\Delta', \\Delta) \\implies \\text{perspFromLine}(\\Delta', \\Delta)$."
@@ -159,7 +159,7 @@
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "Comprehensive summary of all 14 results across definitional duality (2 rfl proofs), algebraic duality (Desargues identity and its symmetry), forward/converse directions, and structural lemmas \u2014 all with 0 sorries.",
+      "summary": "Comprehensive summary of all 14 results across definitional duality (2 rfl proofs), algebraic duality (Desargues identity and its symmetry), forward/converse directions, and structural lemmas — all with 0 sorries.",
       "startLine": 364,
       "endLine": 415,
       "mathContext": "14 results, 0 sorries: 2 definitional duality proofs (`rfl`), Desargues identity + symmetry, forward + converse directions, swap invariance, and full biconditional over integral domains."
@@ -167,15 +167,15 @@
   ],
   "overview": {
     "summary": "Desargues's theorem is self-dual in projective geometry: the dual statement (swapping 'point' and 'line') is again Desargues's theorem. This formalization proves self-duality over arbitrary commutative rings using homogeneous coordinates, where collinearity and concurrence are definitionally the same predicate.",
-    "historicalContext": "Girard Desargues published his theorem on perspective triangles in the 1639 *Brouillon project d'une atteinte aux \u00e9v\u00e9nemens des rencontres du cone avec un plan*, though his cryptic notation delayed wider recognition. Projective duality was systematically developed by Jean-Victor Poncelet in his 1822 *Trait\u00e9 des propri\u00e9t\u00e9s projectives des figures* and by Joseph Diaz Gergonne, who formulated the principle that every theorem about points, lines, and incidence has a dual obtained by interchanging 'point' and 'line'. Desargues's theorem is the premier example of a self-dual result: its dual statement is its own converse. David Hilbert's *Grundlagen der Geometrie* (1899) revealed the deep foundational significance: Desargues's theorem characterizes Desarguesian planes \u2014 those coordinatizable by a division ring. Moulton's 1902 non-Desarguesian plane demonstrated that the theorem is genuinely independent of the other projective axioms in dimension 2.",
+    "historicalContext": "Girard Desargues published his theorem on perspective triangles in the 1639 *Brouillon project d'une atteinte aux événemens des rencontres du cone avec un plan*, though his cryptic notation delayed wider recognition. Projective duality was systematically developed by Jean-Victor Poncelet in his 1822 *Traité des propriétés projectives des figures* and by Joseph Diaz Gergonne, who formulated the principle that every theorem about points, lines, and incidence has a dual obtained by interchanging 'point' and 'line'. Desargues's theorem is the premier example of a self-dual result: its dual statement is its own converse. David Hilbert's *Grundlagen der Geometrie* (1899) revealed the deep foundational significance: Desargues's theorem characterizes Desarguesian planes — those coordinatizable by a division ring. Moulton's 1902 non-Desarguesian plane demonstrated that the theorem is genuinely independent of the other projective axioms in dimension 2.",
     "text": "Formalizes the self-duality of Desargues's theorem in projective geometry over arbitrary commutative rings. Shows that collinearity and concurrence are the same predicate in homogeneous coordinates (rfl), that the dual configuration's perspective-from-a-point equals the original's perspective-from-a-line (rfl), and that the Desargues identity is symmetric in the two triangles. Includes algebraic converse over integral domains.",
-    "proofStrategy": "The formalization works in homogeneous coordinates over a CommRing K, where points and lines are both K\u00b3 vectors. The proof of self-duality has two layers: (1) Definitional: collinear = concurrent and dual's perspFromPoint = original's perspFromLine, both by rfl. (2) Algebraic: the Desargues identity det(P,Q,R) = det(AA',BB',CC') \u00b7 det(ABC) \u00b7 det(A'B'C') is manifestly symmetric in the two triangles, with the perspectivity and collinearity determinants negating under swap but preserving the zero condition.",
-    "keyIdea": "In homogeneous coordinates, projective duality is not a deep theorem but a definitional triviality: points and lines are the same type (K\u00b3), and collinearity and concurrence are the same predicate (det = 0). The self-duality of Desargues's theorem follows immediately from this observation.",
+    "proofStrategy": "The formalization works in homogeneous coordinates over a CommRing K, where points and lines are both K³ vectors. The proof of self-duality has two layers: (1) Definitional: collinear = concurrent and dual's perspFromPoint = original's perspFromLine, both by rfl. (2) Algebraic: the Desargues identity det(P,Q,R) = det(AA',BB',CC') · det(ABC) · det(A'B'C') is manifestly symmetric in the two triangles, with the perspectivity and collinearity determinants negating under swap but preserving the zero condition.",
+    "keyIdea": "In homogeneous coordinates, projective duality is not a deep theorem but a definitional triviality: points and lines are the same type (K³), and collinearity and concurrence are the same predicate (det = 0). The self-duality of Desargues's theorem follows immediately from this observation.",
     "keyInsights": [
-      "**collinear = concurrent by rfl**: In homogeneous coordinates, both predicates are `(threeVecMat u v w).det = 0`. No proof needed \u2014 they are definitionally identical.",
+      "**collinear = concurrent by rfl**: In homogeneous coordinates, both predicates are `(threeVecMat u v w).det = 0`. No proof needed — they are definitionally identical.",
       "**Dual's perspFromPoint = original's perspFromLine by rfl**: The joining lines of the dual configuration's vertex pairs are the intersection points of the original's corresponding sides. This is a definitional equality, not an algebraic computation.",
-      "**The Desargues identity is symmetric**: det(P,Q,R) = det(AA',BB',CC') \u00b7 det(ABC) \u00b7 det(A'B'C') has the two triangle determinants as a commutative product, making the identity invariant under triangle swap.",
-      "**Anticommutativity gives neg, but det=0 is preserved**: Under swap, each cross product row negates, giving an overall factor of (-1)\u00b3 = -1 in the determinant. Since -0 = 0, the zero condition is preserved.",
+      "**The Desargues identity is symmetric**: det(P,Q,R) = det(AA',BB',CC') · det(ABC) · det(A'B'C') has the two triangle determinants as a commutative product, making the identity invariant under triangle swap.",
+      "**Anticommutativity gives neg, but det=0 is preserved**: Under swap, each cross product row negates, giving an overall factor of (-1)³ = -1 in the determinant. Since -0 = 0, the zero condition is preserved.",
       "**Integral domains give the converse**: The forward direction works over any CommRing, but the converse requires IsDomain to apply the zero-product property. Over rings with zero divisors, non-degenerate triangles can be in perspective from a line without being in perspective from a point."
     ],
     "prerequisites": [
@@ -187,8 +187,8 @@
     "problemStatement": "See the description field for the problem statement."
   },
   "conclusion": {
-    "summary": "We formalize the self-duality of Desargues's theorem with 28 theorems and 0 sorries. The key results \u2014 collinear = concurrent and dual(perspFromPoint) = perspFromLine \u2014 are both proved by rfl, showing that self-duality is a definitional consequence of working in homogeneous coordinates.",
-    "implications": "**Theoretical Significance**: This formalization shows that projective duality, far from being a mysterious principle, is a trivial consequence of the representation choice.\n\nIn homogeneous coordinates, points and lines are the same type and the fundamental predicates are identical. The 'deep' content is not the duality but the Desargues identity itself \u2014 an algebraic identity in 18 variables that holds over any commutative ring.",
+    "summary": "We formalize the self-duality of Desargues's theorem with 28 theorems and 0 sorries. The key results — collinear = concurrent and dual(perspFromPoint) = perspFromLine — are both proved by rfl, showing that self-duality is a definitional consequence of working in homogeneous coordinates.",
+    "implications": "**Theoretical Significance**: This formalization shows that projective duality, far from being a mysterious principle, is a trivial consequence of the representation choice.\n\nIn homogeneous coordinates, points and lines are the same type and the fundamental predicates are identical. The 'deep' content is not the duality but the Desargues identity itself — an algebraic identity in 18 variables that holds over any commutative ring.",
     "openQuestions": [
       "Can axiomatic projective planes be formalized in Lean 4, distinguishing Desarguesian from non-Desarguesian planes?",
       "Can the equivalence between Desargues's theorem and embeddability in projective 3-space be formalized?",
@@ -207,7 +207,9 @@
     "lineCount": 415,
     "axiomCount": 0,
     "theoremCount": 23,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/DesarguesTheoremOQ04.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -229,14 +231,14 @@
   "references": [
     {
       "authors": "Girard Desargues",
-      "title": "Brouillon project d'une atteinte aux \u00e9v\u00e9nemens des rencontres du C\u00f4ne avec un Plan",
+      "title": "Brouillon project d'une atteinte aux événemens des rencontres du Cône avec un Plan",
       "year": "1639",
       "venue": "Self-published",
       "note": "Original statement of the theorem"
     },
     {
       "authors": "Jean-Victor Poncelet",
-      "title": "Trait\u00e9 des propri\u00e9t\u00e9s projectives des figures",
+      "title": "Traité des propriétés projectives des figures",
       "year": "1822",
       "venue": "Bachelier, Paris",
       "note": "Systematic development of projective duality"

--- a/src/data/proofs/desargues-theorem/meta.json
+++ b/src/data/proofs/desargues-theorem/meta.json
@@ -176,7 +176,9 @@
     "lineCount": 447,
     "axiomCount": 0,
     "theoremCount": 14,
-    "definitionCount": 14
+    "definitionCount": 14,
+    "path": "Proofs/DesarguesTheorem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-01/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-01/meta.json
@@ -99,7 +99,9 @@
     "lineCount": 154,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/DescartesRuleOfSignsOQ01OQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-02/meta.json
@@ -185,7 +185,9 @@
         "type": "proved",
         "description": "Complete parity for degree 2"
       }
-    ]
+    ],
+    "path": "Proofs/DescartesRuleOfSignsOQ01OQ02.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/descartes-rule-of-signs-oq-01/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01/meta.json
@@ -166,7 +166,9 @@
     "lineCount": 1074,
     "axiomCount": 1,
     "theoremCount": 48,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/DescartesRuleOfSignsOQ01.lean",
+    "sorries": 1
   },
   "crossReferences": [
     {

--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01/meta.json
@@ -81,7 +81,8 @@
         "type": "placeholder",
         "description": "Inductive step framework (proves True — documents the induction architecture)"
       }
-    ]
+    ],
+    "path": "Proofs/DescartesRuleOfSignsOQ02OQ01.lean"
   },
   "sections": [
     {

--- a/src/data/proofs/descartes-rule-of-signs-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02/meta.json
@@ -241,6 +241,8 @@
   ],
   "leanFile": {
     "lineCount": 698,
-    "axiomCount": 3
+    "axiomCount": 3,
+    "path": "Proofs/DescartesRuleOfSignsOQ02.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/descartes-rule-of-signs-oq-03/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-03/meta.json
@@ -66,7 +66,9 @@
     "lineCount": 440,
     "axiomCount": 0,
     "theoremCount": 24,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/DescartesRuleOfSignsOQ03.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/descartes-rule-of-signs-oq-04/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-04/meta.json
@@ -192,7 +192,9 @@
     "lineCount": 495,
     "axiomCount": 0,
     "theoremCount": 23,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/DescartesRuleOfSignsOQ04.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/descartes-rule-of-signs/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs/meta.json
@@ -195,7 +195,9 @@
     "lineCount": 576,
     "axiomCount": 8,
     "theoremCount": 35,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/DescartesRuleOfSigns.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/dirichlets-theorem-oq-01/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-01/meta.json
@@ -178,7 +178,9 @@
     "lineCount": 705,
     "axiomCount": 5,
     "theoremCount": 31,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/DirichletsTheoremOQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/dirichlets-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02-oq-01/meta.json
@@ -210,6 +210,8 @@
   ],
   "leanFile": {
     "lineCount": 366,
-    "axiomCount": 4
+    "axiomCount": 4,
+    "path": "Proofs/DirichletsTheoremOQ02OQ01.lean",
+    "sorries": 1
   }
 }

--- a/src/data/proofs/dirichlets-theorem/meta.json
+++ b/src/data/proofs/dirichlets-theorem/meta.json
@@ -204,7 +204,9 @@
     "lineCount": 313,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/DirichletsTheorem.lean",
+    "sorries": 0
   },
   "references": [
     {
@@ -241,14 +243,6 @@
       "year": "2004",
       "venue": "AMS Colloquium Publications 53",
       "note": "Comprehensive modern reference covering Dirichlet L-functions, the Generalized Riemann Hypothesis for L(s,χ), Siegel-Walfisz theorem, and the Bombieri-Vinogradov theorem — the quantitative refinements of Dirichlet's equidistribution that underlie the bounded prime gaps theorem"
-    }
-  ],
-  "mainTheorems": [
-    {
-      "name": "dirichlet_arithmetic_progression",
-      "type": "core",
-      "description": "There are infinitely many primes in any arithmetic progression a, a+d, a+2d, ... with gcd(a,d)=1",
-      "leanType": "Nat.Coprime a d -> Set.Infinite {p | Nat.Prime p and p % d = a % d}"
     }
   ],
   "mainTheorems": [

--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-01/meta.json
@@ -144,7 +144,9 @@
     "lineCount": 328,
     "axiomCount": 0,
     "theoremCount": 7,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/DissectionOfCubesOQ01OQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/dissection-of-cubes-oq-01/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01/meta.json
@@ -142,7 +142,9 @@
     "lineCount": 274,
     "axiomCount": 0,
     "theoremCount": 5,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/DissectionOfCubesOQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/dissection-of-cubes-oq-02-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02-oq-02/meta.json
@@ -285,7 +285,9 @@
         "type": "proved",
         "description": "Any polyhedron with rational-×-π dihedral angles has D = 0"
       }
-    ]
+    ],
+    "path": "Proofs/DissectionOfCubesOQ02OQ02.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/dissection-of-cubes-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02/meta.json
@@ -182,7 +182,9 @@
     "definitionCount": 5,
     "opens": [
       "Real"
-    ]
+    ],
+    "path": "Proofs/DissectionOfCubesOQ02.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/dissection-of-cubes/meta.json
+++ b/src/data/proofs/dissection-of-cubes/meta.json
@@ -157,7 +157,9 @@
     "lineCount": 366,
     "axiomCount": 2,
     "theoremCount": 7,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/DissectionOfCubes.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/divisibility-by-3-oq-01/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-01/meta.json
@@ -184,7 +184,9 @@
     "lineCount": 550,
     "axiomCount": 0,
     "theoremCount": 56,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/DivisibilityByThreeOQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/divisibility-by-3-oq-02/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-02/meta.json
@@ -231,6 +231,8 @@
         "description": "15 | n ↔ 15 | hex_digit_sum(n)",
         "leanType": "(n : ℕ) → 15 ∣ n ↔ 15 ∣ (Nat.digits 16 n).sum"
       }
-    ]
+    ],
+    "path": "Proofs/DivisibilityBy3OQ02.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/divisibility-by-3-oq-03/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-03/meta.json
@@ -141,6 +141,8 @@
     "axiomCount": 0,
     "theoremCount": 15,
     "sorryTheorems": 0,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/DivisibilityBy3OQ03.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/divisibility-by-3-oq-04-oq-02/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-04-oq-02/meta.json
@@ -212,6 +212,8 @@
     "lineCount": 228,
     "axiomCount": 0,
     "theoremCount": 22,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/DivisibilityBy3OQ04OQ02.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/divisibility-by-3-oq-04/meta.json
+++ b/src/data/proofs/divisibility-by-3-oq-04/meta.json
@@ -205,6 +205,8 @@
     "lineCount": 229,
     "axiomCount": 0,
     "theoremCount": 17,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/DivisibilityBy3OQ04.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/divisibility-by-3/meta.json
+++ b/src/data/proofs/divisibility-by-3/meta.json
@@ -187,7 +187,9 @@
     "lineCount": 235,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/DivisibilityBy3.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/divisibility-by-three-oq-02-oq-01/meta.json
+++ b/src/data/proofs/divisibility-by-three-oq-02-oq-01/meta.json
@@ -136,7 +136,9 @@
     "theoremCount": 2,
     "substantiveTheoremCount": 1,
     "duplicateTheorems": 0,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/DivisibilityByThreeOQ02OQ01.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/divisibility-rules-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-01-oq-01-oq-01/meta.json
@@ -175,7 +175,9 @@
     "theoremCount": 10,
     "substantiveTheoremCount": 8,
     "duplicateTheorems": 0,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/DivisibilityRulesOQ01OQ01OQ01.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/divisibility-rules-oq-01-oq-01/meta.json
+++ b/src/data/proofs/divisibility-rules-oq-01-oq-01/meta.json
@@ -169,6 +169,8 @@
     "lineCount": 108,
     "axiomCount": 0,
     "theoremCount": 9,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/DivisibilityRulesOQ01OQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/divisibility-truncation-general-oq-01/meta.json
+++ b/src/data/proofs/divisibility-truncation-general-oq-01/meta.json
@@ -180,7 +180,9 @@
     "lineCount": 159,
     "axiomCount": 0,
     "theoremCount": 9,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/DivisibilityTruncationGeneralOQ01.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/divisibility-truncation-general/meta.json
+++ b/src/data/proofs/divisibility-truncation-general/meta.json
@@ -135,7 +135,9 @@
     "lineCount": 255,
     "axiomCount": 0,
     "theoremCount": 15,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/DivisibilityTruncationGeneral.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/e-transcendental-oq-01-oq-01/meta.json
+++ b/src/data/proofs/e-transcendental-oq-01-oq-01/meta.json
@@ -8,7 +8,14 @@
     "date": "2026-04-04",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/ETranscendentalOQ01OQ01.lean",
-    "tags": ["number-theory", "transcendence", "nesterenko", "schanuel", "pi", "e"],
+    "tags": [
+      "number-theory",
+      "transcendence",
+      "nesterenko",
+      "schanuel",
+      "pi",
+      "e"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-04",
@@ -110,6 +117,8 @@
     "lineCount": 341,
     "axiomCount": 1,
     "theoremCount": 9,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/ETranscendentalOQ01OQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/e-transcendental-oq-01/meta.json
+++ b/src/data/proofs/e-transcendental-oq-01/meta.json
@@ -212,7 +212,9 @@
     "lineCount": 538,
     "axiomCount": 1,
     "theoremCount": 18,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/ETranscendentalOQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/e-transcendental-oq-03/meta.json
+++ b/src/data/proofs/e-transcendental-oq-03/meta.json
@@ -153,7 +153,9 @@
     "lineCount": 219,
     "axiomCount": 2,
     "theoremCount": 4,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/ETranscendentalOQ03.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/e-transcendental/meta.json
+++ b/src/data/proofs/e-transcendental/meta.json
@@ -210,7 +210,9 @@
     "lineCount": 304,
     "axiomCount": 1,
     "theoremCount": 9,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/eTranscendental.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01/meta.json
@@ -198,7 +198,9 @@
     "lineCount": 628,
     "axiomCount": 0,
     "theoremCount": 31,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/ElementaryQuadraticReciprocityOQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-02/meta.json
@@ -66,7 +66,9 @@
     "lineCount": 175,
     "axiomCount": 1,
     "theoremCount": 7,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/ElementaryQuadraticReciprocityOQ02.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-01-oq-02/meta.json
@@ -34,7 +34,7 @@
   "overview": {
     "historicalContext": "The Jacobi symbol extends the Legendre symbol to composite moduli and can be computed efficiently via a generalized Euclidean algorithm using quadratic reciprocity, the supplements, and modular reduction.",
     "problemStatement": "Can the verified Euclidean reduction steps from the parent proof be assembled into a certified computation function in Lean 4?",
-    "text": "We show that YES: the reduction, extraction, reciprocity, and supplement steps compose into a certified O(log\u00b2 n) computation algorithm for the Jacobi symbol.",
+    "text": "We show that YES: the reduction, extraction, reciprocity, and supplement steps compose into a certified O(log² n) computation algorithm for the Jacobi symbol.",
     "proofStrategy": "Define reusable reduction lemmas, then compose them into certified computation chains that prove specific Jacobi symbol values step by step. Define helper functions (extractTwos, recipSign) and prove the one-step reduction theorem that enables recursive certified computation.",
     "keyInsights": [
       "The Jacobi symbol $J(a, n)$ extends the Legendre symbol from prime moduli to arbitrary odd positive integers $n$: it is defined as the product of Legendre symbols over the prime factors of $n$. While $J(a, n) = 0$ iff $\\gcd(a, n) > 1$, and $J(a, n) = 1$ when $a$ is a quadratic residue mod $n$, the converse fails — $J(a, n) = 1$ does NOT imply $a$ is a QR mod $n$ (it can be a non-residue mod each prime factor that cancel in the product). This is why the Jacobi symbol is useful for efficient computation but must be used carefully for primality testing.",
@@ -54,7 +54,9 @@
     "lineCount": 189,
     "axiomCount": 0,
     "theoremCount": 18,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ01OQ02.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
@@ -99,7 +99,9 @@
     "lineCount": 223,
     "axiomCount": 0,
     "theoremCount": 13,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-03/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-03/meta.json
@@ -31,7 +31,9 @@
   "badge": "axiom",
   "leanFile": {
     "lineCount": 102,
-    "axiomCount": 1
+    "axiomCount": 1,
+    "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ03.lean",
+    "sorries": 0
   },
   "overview": {
     "historicalContext": "Quadratic reciprocity was first stated by Euler and Legendre, then proved by Gauss (1796, first of his six proofs). The Hilbert symbol (a,b)_v was introduced by Hilbert (1897) in his Zahlbericht as a unified language for local quadratic solubility. The product formula ∏_v (a,b)_v = 1 (over all places v, including the real place) was recognized as the local-global formulation of quadratic reciprocity by Hilbert and later placed in the framework of class field theory by Artin and Tate. The Jacobi symbol J(a,n) = ∏(a/pᵢ) (product of Legendre symbols over the prime factorization of n) was introduced by Jacobi (1837) as a computational tool, useful for primality testing and cryptography. Mathlib 4 formalizes legendreSym and jacobiSym through the Zmod framework; the Hilbert symbol and full class field theory await future Mathlib development.",

--- a/src/data/proofs/elementary-quadratic-reciprocity/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity/meta.json
@@ -169,7 +169,9 @@
     "lineCount": 357,
     "axiomCount": 0,
     "theoremCount": 11,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/ElementaryQuadraticReciprocity.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1/meta.json
+++ b/src/data/proofs/erdos-1/meta.json
@@ -223,6 +223,8 @@
     "lineCount": 143,
     "axiomCount": 0,
     "theoremCount": 3,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/Erdos1Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-10-oq-01/meta.json
+++ b/src/data/proofs/erdos-10-oq-01/meta.json
@@ -149,6 +149,8 @@
     "namespace": "Erdos10OQ01",
     "lineCount": 316,
     "axiomCount": 3,
-    "theoremCount": 12
+    "theoremCount": 12,
+    "path": "Proofs/Erdos10OQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-100-oq-02/meta.json
+++ b/src/data/proofs/erdos-100-oq-02/meta.json
@@ -116,7 +116,9 @@
     "lineCount": 60,
     "axiomCount": 0,
     "theoremCount": 2,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/Erdos100OQ02.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/erdos-100/meta.json
+++ b/src/data/proofs/erdos-100/meta.json
@@ -262,6 +262,8 @@
     "lineCount": 482,
     "axiomCount": 2,
     "theoremCount": 14,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos100Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1000/meta.json
+++ b/src/data/proofs/erdos-1000/meta.json
@@ -205,6 +205,8 @@
     "lineCount": 1119,
     "axiomCount": 2,
     "theoremCount": 56,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos1000Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1001-oq-02/meta.json
+++ b/src/data/proofs/erdos-1001-oq-02/meta.json
@@ -160,12 +160,18 @@
     "lineCount": 296,
     "axiomCount": 3,
     "theoremCount": 6,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos1001OQ02.lean",
+    "sorries": 0
   },
   "references": [
     {
       "key": "EST58",
-      "authors": ["P. Erdős", "P. Szüsz", "P. Turán"],
+      "authors": [
+        "P. Erdős",
+        "P. Szüsz",
+        "P. Turán"
+      ],
       "title": "On some applications of the metric theory of diophantine approximation",
       "venue": "Acta Mathematica Hungarica",
       "year": "1958",
@@ -173,7 +179,10 @@
     },
     {
       "key": "KS66",
-      "authors": ["H. Kesten", "V.T. Sós"],
+      "authors": [
+        "H. Kesten",
+        "V.T. Sós"
+      ],
       "title": "On two problems of Erdős and a problem of Turán concerning rational approximations",
       "venue": "Acta Arithmetica",
       "year": "1966",

--- a/src/data/proofs/erdos-1001/meta.json
+++ b/src/data/proofs/erdos-1001/meta.json
@@ -220,7 +220,9 @@
     "lineCount": 249,
     "axiomCount": 2,
     "theoremCount": 10,
-    "definitionCount": 12
+    "definitionCount": 12,
+    "path": "Proofs/Erdos1001Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-1002-oq-01/meta.json
+++ b/src/data/proofs/erdos-1002-oq-01/meta.json
@@ -21,7 +21,9 @@
     "erdosNumber": 1002,
     "erdosUrl": "https://erdosproblems.com/1002",
     "erdosProblemStatus": "open",
-    "relatedProblems": ["erdos-1002"],
+    "relatedProblems": [
+      "erdos-1002"
+    ],
     "axiomCount": 0,
     "lineCount": 140,
     "assumptions": "No axioms. All results proved from Mathlib: Cauchy CDF validity via arctan monotonicity and limits, inner sum periodicity via fractional part invariance under integer shifts."
@@ -120,7 +122,9 @@
   ],
   "references": [
     {
-      "authors": ["H. Kesten"],
+      "authors": [
+        "H. Kesten"
+      ],
       "title": "On a conjecture of Erdős and Szüsz related to uniform distribution mod 1",
       "venue": "Acta Arithmetica",
       "year": "1960",
@@ -129,7 +133,9 @@
       "notes": "The foundational result for Erdős #1002: proves the inner sum S(α,n)/log(n) has Cauchy limit distribution. The two axioms proved in this file are prerequisites for the companion approach toward formalizing Kesten's theorem."
     },
     {
-      "authors": ["H. Weyl"],
+      "authors": [
+        "H. Weyl"
+      ],
       "title": "Über die Gleichverteilung von Zahlen mod. Eins",
       "venue": "Mathematische Annalen",
       "year": "1916",
@@ -138,7 +144,9 @@
       "notes": "Weyl's equidistribution theorem: {kα} is uniformly distributed mod 1 for irrational α. The periodicity of the inner sum for rational α proved here is the counterpart: for rational α the sum is periodic rather than equidistributed."
     },
     {
-      "authors": ["J. Beck"],
+      "authors": [
+        "J. Beck"
+      ],
       "title": "Probabilistic Diophantine approximation: randomness in lattice point counting",
       "venue": "Springer Monographs in Mathematics",
       "year": "2014",
@@ -146,12 +154,19 @@
     }
   ],
   "leanFile": {
-    "imports": ["Mathlib"],
-    "opens": ["Real", "Filter"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "Filter"
+    ],
     "namespace": "Erdos1002OQ01",
     "lineCount": 140,
     "axiomCount": 0,
     "theoremCount": 2,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos1002OQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1002/meta.json
+++ b/src/data/proofs/erdos-1002/meta.json
@@ -242,6 +242,8 @@
     "lineCount": 189,
     "axiomCount": 1,
     "theoremCount": 2,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos1002Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1003/meta.json
+++ b/src/data/proofs/erdos-1003/meta.json
@@ -268,6 +268,8 @@
     "lineCount": 261,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos1003Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1004/meta.json
+++ b/src/data/proofs/erdos-1004/meta.json
@@ -260,6 +260,8 @@
     "lineCount": 609,
     "axiomCount": 3,
     "theoremCount": 24,
-    "definitionCount": 15
+    "definitionCount": 15,
+    "path": "Proofs/Erdos1004Problem.lean",
+    "sorries": 1
   }
 }

--- a/src/data/proofs/erdos-1005/meta.json
+++ b/src/data/proofs/erdos-1005/meta.json
@@ -195,6 +195,8 @@
     "lineCount": 140,
     "axiomCount": 1,
     "theoremCount": 0,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/Erdos1005Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1006-oq-01/meta.json
+++ b/src/data/proofs/erdos-1006-oq-01/meta.json
@@ -116,7 +116,9 @@
     "lineCount": 277,
     "axiomCount": 3,
     "theoremCount": 6,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/Erdos1006OQ01.lean",
+    "sorries": 1
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1006-oq-02-oq-03/meta.json
+++ b/src/data/proofs/erdos-1006-oq-02-oq-03/meta.json
@@ -180,6 +180,8 @@
     "lineCount": 247,
     "axiomCount": 0,
     "theoremCount": 7,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos1006OQ03.lean",
+    "sorries": 1
   }
 }

--- a/src/data/proofs/erdos-1006-oq-02/meta.json
+++ b/src/data/proofs/erdos-1006-oq-02/meta.json
@@ -178,6 +178,8 @@
     "lineCount": 469,
     "axiomCount": 1,
     "theoremCount": 17,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos1006OQ02.lean",
+    "sorries": 1
   }
 }

--- a/src/data/proofs/erdos-1006/meta.json
+++ b/src/data/proofs/erdos-1006/meta.json
@@ -194,6 +194,8 @@
     "lineCount": 141,
     "axiomCount": 3,
     "theoremCount": 1,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos1006Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1007-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1007-oq-01-oq-01/meta.json
@@ -166,7 +166,9 @@
     "lineCount": 388,
     "axiomCount": 0,
     "theoremCount": 32,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos1007OQ01OQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1007-oq-01/meta.json
+++ b/src/data/proofs/erdos-1007-oq-01/meta.json
@@ -226,7 +226,9 @@
     "lineCount": 1337,
     "axiomCount": 0,
     "theoremCount": 89,
-    "definitionCount": 13
+    "definitionCount": 13,
+    "path": "Proofs/Erdos1007OQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1007-oq-05/meta.json
+++ b/src/data/proofs/erdos-1007-oq-05/meta.json
@@ -128,7 +128,9 @@
     "lineCount": 141,
     "axiomCount": 0,
     "theoremCount": 5,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/Erdos1007OQ05.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/erdos-1007/meta.json
+++ b/src/data/proofs/erdos-1007/meta.json
@@ -119,7 +119,9 @@
     "lineCount": 129,
     "axiomCount": 4,
     "theoremCount": 3,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos1007Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1008-oq-01/meta.json
+++ b/src/data/proofs/erdos-1008-oq-01/meta.json
@@ -143,6 +143,8 @@
     "lineCount": 374,
     "axiomCount": 1,
     "theoremCount": 15,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos1008OQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1009/meta.json
+++ b/src/data/proofs/erdos-1009/meta.json
@@ -235,6 +235,8 @@
     "lineCount": 239,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos1009Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-101/meta.json
+++ b/src/data/proofs/erdos-101/meta.json
@@ -247,6 +247,8 @@
     "lineCount": 757,
     "axiomCount": 0,
     "theoremCount": 23,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos101Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1010-oq-02/meta.json
+++ b/src/data/proofs/erdos-1010-oq-02/meta.json
@@ -209,6 +209,8 @@
     "lineCount": 200,
     "axiomCount": 3,
     "theoremCount": 0,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos1010OQ02Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1010/meta.json
+++ b/src/data/proofs/erdos-1010/meta.json
@@ -213,6 +213,8 @@
     "lineCount": 93,
     "axiomCount": 2,
     "theoremCount": 0,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos1010Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1011/meta.json
+++ b/src/data/proofs/erdos-1011/meta.json
@@ -219,6 +219,8 @@
     "lineCount": 168,
     "axiomCount": 5,
     "theoremCount": 0,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos1011Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1012-oq-01/meta.json
+++ b/src/data/proofs/erdos-1012-oq-01/meta.json
@@ -65,7 +65,9 @@
     "lineCount": 312,
     "axiomCount": 4,
     "theoremCount": 37,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos1012OQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1012-oq-02/meta.json
+++ b/src/data/proofs/erdos-1012-oq-02/meta.json
@@ -64,7 +64,9 @@
     "lineCount": 389,
     "axiomCount": 2,
     "theoremCount": 12,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos1012OQ02.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1012/meta.json
+++ b/src/data/proofs/erdos-1012/meta.json
@@ -211,6 +211,8 @@
     "lineCount": 353,
     "axiomCount": 4,
     "theoremCount": 34,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos1012Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1013/meta.json
+++ b/src/data/proofs/erdos-1013/meta.json
@@ -262,6 +262,8 @@
     "lineCount": 201,
     "axiomCount": 1,
     "theoremCount": 12,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos1013Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1014-oq-01/meta.json
+++ b/src/data/proofs/erdos-1014-oq-01/meta.json
@@ -125,13 +125,23 @@
     ]
   },
   "leanFile": {
-    "imports": ["Mathlib", "Proofs.RamseysTheorem"],
-    "opens": ["Real", "RamseysTheorem", "Finset", "Classical"],
+    "imports": [
+      "Mathlib",
+      "Proofs.RamseysTheorem"
+    ],
+    "opens": [
+      "Real",
+      "RamseysTheorem",
+      "Finset",
+      "Classical"
+    ],
     "namespace": "Erdos1014OQ01",
     "lineCount": 365,
     "axiomCount": 1,
     "theoremCount": 11,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/Erdos1014OQ01.lean",
+    "sorries": 0
   },
   "references": [
     "Erdős [Er71], Problem 1014",

--- a/src/data/proofs/erdos-1014-oq-02/meta.json
+++ b/src/data/proofs/erdos-1014-oq-02/meta.json
@@ -170,7 +170,9 @@
         "description": "Summary corollary combining the rate bound and comparison",
         "leanType": "(rate bound) ∧ (log l/l < 1/log l)"
       }
-    ]
+    ],
+    "path": "Proofs/Erdos1014OQ02.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-1014/meta.json
+++ b/src/data/proofs/erdos-1014/meta.json
@@ -219,7 +219,9 @@
         "description": "R(k,k) ≥ k for k ≥ 2, from R(2,k) = k and monotonicity",
         "leanType": "(k : ℕ) → k ≥ 2 → k ≤ ramseyNumber k k"
       }
-    ]
+    ],
+    "path": "Proofs/Erdos1014Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-1015-oq-01/meta.json
+++ b/src/data/proofs/erdos-1015-oq-01/meta.json
@@ -143,13 +143,21 @@
     ]
   },
   "leanFile": {
-    "imports": ["Mathlib"],
-    "opens": ["Real", "Filter", "Topology"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Real",
+      "Filter",
+      "Topology"
+    ],
     "namespace": "Erdos1015OQ01",
     "lineCount": 282,
     "axiomCount": 12,
     "theoremCount": 25,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/Erdos1015OQ01.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-1015-oq-05/meta.json
+++ b/src/data/proofs/erdos-1015-oq-05/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-1015-oq-05",
-  "title": "Erd\u0151s #1015 OQ5: Axiom Elimination via Erd\u0151s-Szekeres Bound",
+  "title": "Erdős #1015 OQ5: Axiom Elimination via Erdős-Szekeres Bound",
   "slug": "erdos-1015-oq-05",
-  "description": "Investigates which of the 8 axioms in the Erd\u0151s #1015 formalization can be proved from Mathlib. Eliminates 2: replaces the axiomatized ramseyNumber with a proper definition via Nat.find, and proves R(t,t) \u2264 4^t via the Erd\u0151s-Szekeres bound R(r,s) \u2264 C(r+s-2, r-1).",
+  "description": "Investigates which of the 8 axioms in the Erdős #1015 formalization can be proved from Mathlib. Eliminates 2: replaces the axiomatized ramseyNumber with a proper definition via Nat.find, and proves R(t,t) ≤ 4^t via the Erdős-Szekeres bound R(r,s) ≤ C(r+s-2, r-1).",
   "meta": {
-    "author": "Erd\u0151s-Szekeres (1935)",
+    "author": "Erdős-Szekeres (1935)",
     "erdosNumber": 1015,
     "status": "verified",
     "proofRepoPath": "Proofs/Erdos1015OQ05.lean",
@@ -30,56 +30,56 @@
     {
       "targetId": "erdos-1015",
       "relationship": "extends",
-      "description": "This file eliminates 2 of the 8 axioms from the parent Erd\u0151s #1015 formalization by proving them from the Ramsey theorem formalized in RamseysTheorem.lean."
+      "description": "This file eliminates 2 of the 8 axioms from the parent Erdős #1015 formalization by proving them from the Ramsey theorem formalized in RamseysTheorem.lean."
     },
     {
       "targetId": "ramseys-theorem",
       "relationship": "depends",
-      "description": "Imports the Ramsey theorem (Wiedijk #31) to define ramseyNumber via Nat.find and prove the Erd\u0151s-Szekeres bound R(r,s) \u2264 C(r+s-2, r-1) by induction."
+      "description": "Imports the Ramsey theorem (Wiedijk #31) to define ramseyNumber via Nat.find and prove the Erdős-Szekeres bound R(r,s) ≤ C(r+s-2, r-1) by induction."
     }
   ],
   "overview": {
     "problemStatement": "Can any of the 8 axioms in Erdos1015Problem.lean (Moon's theorem, Ramsey bounds, BES formula, asymptotics) be proved from Mathlib?",
-    "text": "We eliminate 2 of the 8 axioms: (1) ramseyNumber is replaced with a proper definition via Nat.find, and (2) ramsey_upper_bound (R(t,t) \u2264 4^t) is proved via the Erd\u0151s-Szekeres bound. The remaining 6 axioms are deep results requiring substantial Ramsey-theoretic machinery beyond Mathlib.",
-    "proofStrategy": "The proof proceeds in four stages: (1) Define ramseyNumber as the minimum n with the Ramsey property via Nat.find. (2) Prove HasRamseyProperty monotonicity for embedding arguments. (3) Prove HasRamseyProperty at the binomial coefficient bound C(r+s-2, r-1) by strong induction on r+s, using Pascal's rule for the bound recurrence and the pigeonhole argument from RamseysTheorem.lean. (4) Chain R(t,t) \u2264 C(2t-2, t-1) \u2264 2^(2t-2) = 4^(t-1) \u2264 4^t.",
-    "historicalContext": "Paul Erd\u0151s (1935, jointly with George Szekeres) proved the first explicit Ramsey bound: $R(r, s) \\leq \\binom{r+s-2}{r-1}$. This was the founding result of Ramsey theory as a quantitative discipline. The bound arises from a simple pigeonhole induction: for any vertex $v$ in a complete graph on $N = \\binom{r+s-2}{r-1}$ vertices, either $v$ has at least $\\binom{r+s-3}{r-2}$ red neighbors (giving an $(r-1, s)$ subproblem) or at least $\\binom{r+s-3}{r-1}$ blue neighbors (giving an $(r, s-1)$ subproblem). Pascal's rule closes the induction. The diagonal bound $R(t,t) \\leq 4^{t-1}$ follows immediately. This file revisits the Erd\u0151s #1015 formalization (which axiomatized the Ramsey number and the upper bound) and eliminates these 2 of the 8 axioms by proving them from first principles.",
+    "text": "We eliminate 2 of the 8 axioms: (1) ramseyNumber is replaced with a proper definition via Nat.find, and (2) ramsey_upper_bound (R(t,t) ≤ 4^t) is proved via the Erdős-Szekeres bound. The remaining 6 axioms are deep results requiring substantial Ramsey-theoretic machinery beyond Mathlib.",
+    "proofStrategy": "The proof proceeds in four stages: (1) Define ramseyNumber as the minimum n with the Ramsey property via Nat.find. (2) Prove HasRamseyProperty monotonicity for embedding arguments. (3) Prove HasRamseyProperty at the binomial coefficient bound C(r+s-2, r-1) by strong induction on r+s, using Pascal's rule for the bound recurrence and the pigeonhole argument from RamseysTheorem.lean. (4) Chain R(t,t) ≤ C(2t-2, t-1) ≤ 2^(2t-2) = 4^(t-1) ≤ 4^t.",
+    "historicalContext": "Paul Erdős (1935, jointly with George Szekeres) proved the first explicit Ramsey bound: $R(r, s) \\leq \\binom{r+s-2}{r-1}$. This was the founding result of Ramsey theory as a quantitative discipline. The bound arises from a simple pigeonhole induction: for any vertex $v$ in a complete graph on $N = \\binom{r+s-2}{r-1}$ vertices, either $v$ has at least $\\binom{r+s-3}{r-2}$ red neighbors (giving an $(r-1, s)$ subproblem) or at least $\\binom{r+s-3}{r-1}$ blue neighbors (giving an $(r, s-1)$ subproblem). Pascal's rule closes the induction. The diagonal bound $R(t,t) \\leq 4^{t-1}$ follows immediately. This file revisits the Erdős #1015 formalization (which axiomatized the Ramsey number and the upper bound) and eliminates these 2 of the 8 axioms by proving them from first principles.",
     "keyInsights": [
-      "The `ramseyNumber` axiom in the parent proof is a *definition placeholder* \u2014 it assumes a function $R: \\mathbb{N} \\times \\mathbb{N} \\to \\mathbb{N}$ satisfying the Ramsey property, without defining it. This file replaces it with `Nat.find` on the Ramsey existence theorem: `ramseyNumber r s = min n. HasRamseyProperty (Fin n) r s`. This is the canonical constructive definition.",
-      "The Erd\u0151s-Szekeres bound `ramseyBound_HasRamseyProperty` proves $\\binom{r+s-2}{r-1}$ has the Ramsey property by strong induction on $r + s$. The key recurrence is Pascal's rule: $\\binom{r+s-2}{r-1} = \\binom{r+s-3}{r-2} + \\binom{r+s-3}{r-1}$, which matches the recursive structure of the pigeonhole argument. The `HasRamseyProperty_of_add` lemma captures this addition structure.",
+      "The `ramseyNumber` axiom in the parent proof is a *definition placeholder* — it assumes a function $R: \\mathbb{N} \\times \\mathbb{N} \\to \\mathbb{N}$ satisfying the Ramsey property, without defining it. This file replaces it with `Nat.find` on the Ramsey existence theorem: `ramseyNumber r s = min n. HasRamseyProperty (Fin n) r s`. This is the canonical constructive definition.",
+      "The Erdős-Szekeres bound `ramseyBound_HasRamseyProperty` proves $\\binom{r+s-2}{r-1}$ has the Ramsey property by strong induction on $r + s$. The key recurrence is Pascal's rule: $\\binom{r+s-2}{r-1} = \\binom{r+s-3}{r-2} + \\binom{r+s-3}{r-1}$, which matches the recursive structure of the pigeonhole argument. The `HasRamseyProperty_of_add` lemma captures this addition structure.",
       "The inequality $\\binom{n}{k} \\leq 2^n$ bridges the combinatorial bound $R(t,t) \\leq \\binom{2t-2}{t-1}$ to the exponential bound $R(t,t) \\leq 4^t$. Combined with $4^{t-1} \\leq 4^t$, this chain: $R(t,t) \\leq \\binom{2t-2}{t-1} \\leq 2^{2t-2} = 4^{t-1} \\leq 4^t$.",
       "The `HasRamseyProperty_mono` lemma establishes that if $n$ has the Ramsey property for $(r, s)$, so does any $m \\geq n$. This is needed to derive `ramseyNumber r s \\leq ramseyBound r s` from `HasRamseyProperty ramseyBound` and uses `Finset.card_le_card` with embeddings.",
-      "The 6 remaining axioms from the parent proof \u2014 Moon's theorem (1966), Erd\u0151s's $f(t) < R(t,t)$, the Burr-Erd\u0151s-Spencer formula for $f(t)$, the root limit $f(t)^{1/t} \\to c$, and superlinear growth \u2014 require either specific extremal graph constructions or deep analytic arguments (entropy, concentration) not yet in Mathlib."
+      "The 6 remaining axioms from the parent proof — Moon's theorem (1966), Erdős's $f(t) < R(t,t)$, the Burr-Erdős-Spencer formula for $f(t)$, the root limit $f(t)^{1/t} \\to c$, and superlinear growth — require either specific extremal graph constructions or deep analytic arguments (entropy, concentration) not yet in Mathlib."
     ]
   },
   "sections": [
     {
       "id": "ramsey-number-def",
-      "title": "\u00a71. Ramsey Number: Proper Definition",
+      "title": "§1. Ramsey Number: Proper Definition",
       "startLine": 37,
       "endLine": 108,
       "summary": "Replaces the axiomatized ramseyNumber with a proper Nat.find definition. Proves ramseyNumber_spec (Ramsey property holds), ramseyNumber_le_of (minimality), and HasRamseyProperty_mono (monotonicity: Ramsey property propagates to larger vertex sets via Finset embeddings)."
     },
     {
       "id": "ramsey-of-add",
-      "title": "\u00a72. HasRamseyProperty_of_add",
+      "title": "§2. HasRamseyProperty_of_add",
       "startLine": 109,
       "endLine": 217,
-      "summary": "Key lemma: if HasRamseyProperty n\u2081 (r-1) s and HasRamseyProperty n\u2082 r (s-1), then HasRamseyProperty (n\u2081+n\u2082) r s. This is the inductive step of the Erd\u0151s-Szekeres bound, implementing the pigeonhole argument."
+      "summary": "Key lemma: if HasRamseyProperty n₁ (r-1) s and HasRamseyProperty n₂ r (s-1), then HasRamseyProperty (n₁+n₂) r s. This is the inductive step of the Erdős-Szekeres bound, implementing the pigeonhole argument."
     },
     {
       "id": "ramsey-bound",
-      "title": "\u00a73. Erd\u0151s-Szekeres Bound and Upper Bound Proof",
+      "title": "§3. Erdős-Szekeres Bound and Upper Bound Proof",
       "startLine": 218,
       "endLine": 353,
-      "summary": "Defines ramseyBound r s = C(r+s-2, r-1). Proves ramseyBound_pascal (Pascal's rule for the recurrence), ramseyBound_HasRamseyProperty (the bound satisfies the Ramsey property), ramseyBound_le_four_pow (C(2t-2,t-1) \u2264 4^t), and ramsey_upper_bound (R(t,t) \u2264 4^t)."
+      "summary": "Defines ramseyBound r s = C(r+s-2, r-1). Proves ramseyBound_pascal (Pascal's rule for the recurrence), ramseyBound_HasRamseyProperty (the bound satisfies the Ramsey property), ramseyBound_le_four_pow (C(2t-2,t-1) ≤ 4^t), and ramsey_upper_bound (R(t,t) ≤ 4^t)."
     }
   ],
   "conclusion": {
-    "summary": "The two eliminated axioms \u2014 `ramseyNumber` definition and `ramsey_upper_bound` \u2014 are now proved from the parent `RamseysTheorem.lean`. The Erd\u0151s-Szekeres 1935 bound $R(t,t) \\leq 4^t$ is formally verified. The remaining 6 axioms stand as open problems requiring deeper Ramsey-theoretic machinery.",
-    "implications": "Axiom elimination is a measurable proxy for proof completeness. Each eliminated axiom increases the proof's trustworthiness by grounding it in more fundamental principles. The approach \u2014 identify which axioms are really definitions or standard bounds, then prove them \u2014 is a template for reducing axiom counts in other heavily-axiomatized formalizations. Starting from 8 axioms and eliminating 2, the pattern suggests further reduction is possible with Ramsey lower bounds and combinatorial construction lemmas.",
+    "summary": "The two eliminated axioms — `ramseyNumber` definition and `ramsey_upper_bound` — are now proved from the parent `RamseysTheorem.lean`. The Erdős-Szekeres 1935 bound $R(t,t) \\leq 4^t$ is formally verified. The remaining 6 axioms stand as open problems requiring deeper Ramsey-theoretic machinery.",
+    "implications": "Axiom elimination is a measurable proxy for proof completeness. Each eliminated axiom increases the proof's trustworthiness by grounding it in more fundamental principles. The approach — identify which axioms are really definitions or standard bounds, then prove them — is a template for reducing axiom counts in other heavily-axiomatized formalizations. Starting from 8 axioms and eliminating 2, the pattern suggests further reduction is possible with Ramsey lower bounds and combinatorial construction lemmas.",
     "openQuestions": [
       "Can `moon_f3` (Moon's 1966 theorem on a specific Ramsey-type combinatorial identity) be proved in Lean? Moon's result involves binomial coefficient identities that may be accessible via Mathlib's `Nat.choose` API.",
-      "Can the Burr-Erd\u0151s-Spencer formula `f(t) = \u230at\u00b2/4\u230b + 1` be formalized? This requires constructing specific extremal graphs, which demands explicit Lean graph construction lemmas.",
+      "Can the Burr-Erdős-Spencer formula `f(t) = ⌊t²/4⌋ + 1` be formalized? This requires constructing specific extremal graphs, which demands explicit Lean graph construction lemmas.",
       "Can the probabilistic lower bound $R(t,t) \\geq c \\cdot t \\cdot 2^{t/2}$ be formalized? This would require formalizing random graph theory, specifically the first-moment method for edge-coloring.",
       "Is the Ramsey multiplicity formula (minimum number of monochromatic $K_r$'s in any 2-coloring of $K_n$) formalizable via Goodman's formula? This is a quantitative strengthening of Ramsey's theorem."
     ]
@@ -97,6 +97,8 @@
     "lineCount": 353,
     "axiomCount": 0,
     "theoremCount": 12,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/Erdos1015OQ05.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1015/meta.json
+++ b/src/data/proofs/erdos-1015/meta.json
@@ -210,6 +210,8 @@
     "lineCount": 149,
     "axiomCount": 2,
     "theoremCount": 0,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos1015Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1016/meta.json
+++ b/src/data/proofs/erdos-1016/meta.json
@@ -235,6 +235,8 @@
     "lineCount": 158,
     "axiomCount": 0,
     "theoremCount": 4,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos1016Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1017/meta.json
+++ b/src/data/proofs/erdos-1017/meta.json
@@ -190,6 +190,8 @@
     "lineCount": 696,
     "axiomCount": 3,
     "theoremCount": 0,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/Erdos1017OQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1019/meta.json
+++ b/src/data/proofs/erdos-1019/meta.json
@@ -279,7 +279,9 @@
     "lineCount": 441,
     "axiomCount": 4,
     "theoremCount": 9,
-    "definitionCount": 19
+    "definitionCount": 19,
+    "path": "Proofs/Erdos1019Problem.lean",
+    "sorries": 0
   },
   "mathlibDependencies": [
     "Mathlib.Combinatorics.SimpleGraph.Basic",

--- a/src/data/proofs/erdos-102/meta.json
+++ b/src/data/proofs/erdos-102/meta.json
@@ -216,6 +216,8 @@
     "lineCount": 173,
     "axiomCount": 1,
     "theoremCount": 5,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos102Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1020/meta.json
+++ b/src/data/proofs/erdos-1020/meta.json
@@ -187,7 +187,9 @@
     "lineCount": 326,
     "axiomCount": 6,
     "theoremCount": 4,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos1020Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-1022-oq-01/meta.json
+++ b/src/data/proofs/erdos-1022-oq-01/meta.json
@@ -120,7 +120,9 @@
     "opens": [
       "Finset"
     ],
-    "namespace": "Erdos1022OQ01"
+    "namespace": "Erdos1022OQ01",
+    "path": "Proofs/Erdos1022OQ01.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/erdos-1022/meta.json
+++ b/src/data/proofs/erdos-1022/meta.json
@@ -244,12 +244,21 @@
     }
   ],
   "leanFile": {
-    "imports": ["Mathlib.Data.Finset.Basic", "Mathlib.Data.Finset.Powerset", "Mathlib.Data.Fintype.Basic", "Mathlib.Tactic"],
-    "opens": ["Finset"],
+    "imports": [
+      "Mathlib.Data.Finset.Basic",
+      "Mathlib.Data.Finset.Powerset",
+      "Mathlib.Data.Fintype.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Finset"
+    ],
     "namespace": "Erdos1022",
     "lineCount": 522,
     "axiomCount": 1,
     "theoremCount": 26,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos1022Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1023-oq-01/meta.json
+++ b/src/data/proofs/erdos-1023-oq-01/meta.json
@@ -66,7 +66,9 @@
     "lineCount": 458,
     "axiomCount": 2,
     "theoremCount": 36,
-    "definitionCount": 20
+    "definitionCount": 20,
+    "path": "Proofs/Erdos1023OQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1023/meta.json
+++ b/src/data/proofs/erdos-1023/meta.json
@@ -238,6 +238,8 @@
     "lineCount": 366,
     "axiomCount": 5,
     "theoremCount": 17,
-    "definitionCount": 14
+    "definitionCount": 14,
+    "path": "Proofs/Erdos1023Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1024/meta.json
+++ b/src/data/proofs/erdos-1024/meta.json
@@ -239,6 +239,8 @@
     "lineCount": 227,
     "axiomCount": 4,
     "theoremCount": 4,
-    "definitionCount": 13
+    "definitionCount": 13,
+    "path": "Proofs/Erdos1024Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1025/meta.json
+++ b/src/data/proofs/erdos-1025/meta.json
@@ -231,6 +231,8 @@
     "lineCount": 246,
     "axiomCount": 4,
     "theoremCount": 6,
-    "definitionCount": 12
+    "definitionCount": 12,
+    "path": "Proofs/Erdos1025Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1026/meta.json
+++ b/src/data/proofs/erdos-1026/meta.json
@@ -265,6 +265,8 @@
     "lineCount": 283,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos1026Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1027/meta.json
+++ b/src/data/proofs/erdos-1027/meta.json
@@ -190,6 +190,8 @@
     "lineCount": 355,
     "axiomCount": 1,
     "theoremCount": 10,
-    "definitionCount": 14
+    "definitionCount": 14,
+    "path": "Proofs/Erdos1027Problem.lean",
+    "sorries": 1
   }
 }

--- a/src/data/proofs/erdos-1028/meta.json
+++ b/src/data/proofs/erdos-1028/meta.json
@@ -241,6 +241,8 @@
     "lineCount": 311,
     "axiomCount": 2,
     "theoremCount": 7,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos1028Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1029/meta.json
+++ b/src/data/proofs/erdos-1029/meta.json
@@ -212,6 +212,8 @@
     "lineCount": 211,
     "axiomCount": 4,
     "theoremCount": 4,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos1029Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-103-oq-01/meta.json
+++ b/src/data/proofs/erdos-103-oq-01/meta.json
@@ -234,6 +234,8 @@
     "lineCount": 367,
     "axiomCount": 3,
     "theoremCount": 23,
-    "definitionCount": 14
+    "definitionCount": 14,
+    "path": "Proofs/Erdos103OQ01.lean",
+    "sorries": 1
   }
 }

--- a/src/data/proofs/erdos-103/meta.json
+++ b/src/data/proofs/erdos-103/meta.json
@@ -263,6 +263,8 @@
     "lineCount": 253,
     "axiomCount": 0,
     "theoremCount": 5,
-    "definitionCount": 17
+    "definitionCount": 17,
+    "path": "Proofs/Erdos103Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1030/meta.json
+++ b/src/data/proofs/erdos-1030/meta.json
@@ -252,6 +252,8 @@
     "lineCount": 312,
     "axiomCount": 7,
     "theoremCount": 8,
-    "definitionCount": 16
+    "definitionCount": 16,
+    "path": "Proofs/Erdos1030Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1032/meta.json
+++ b/src/data/proofs/erdos-1032/meta.json
@@ -226,6 +226,8 @@
     "lineCount": 77,
     "axiomCount": 4,
     "theoremCount": 0,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos1032Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1033/meta.json
+++ b/src/data/proofs/erdos-1033/meta.json
@@ -307,6 +307,7 @@
     "axiomCount": 3,
     "theoremCount": 16,
     "definitionCount": 17,
-    "sorries": 7
+    "sorries": 7,
+    "path": "Proofs/Erdos1033Problem.lean"
   }
 }

--- a/src/data/proofs/erdos-1035/meta.json
+++ b/src/data/proofs/erdos-1035/meta.json
@@ -215,6 +215,8 @@
     "lineCount": 255,
     "axiomCount": 0,
     "theoremCount": 3,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos1035Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1036/meta.json
+++ b/src/data/proofs/erdos-1036/meta.json
@@ -127,6 +127,8 @@
     "lineCount": 201,
     "axiomCount": 2,
     "theoremCount": 9,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/Erdos1036Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1037/meta.json
+++ b/src/data/proofs/erdos-1037/meta.json
@@ -178,6 +178,8 @@
     "lineCount": 324,
     "axiomCount": 3,
     "theoremCount": 12,
-    "definitionCount": 20
+    "definitionCount": 20,
+    "path": "Proofs/Erdos1037Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1038/meta.json
+++ b/src/data/proofs/erdos-1038/meta.json
@@ -220,6 +220,8 @@
     "lineCount": 93,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos1038Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-104/meta.json
+++ b/src/data/proofs/erdos-104/meta.json
@@ -146,7 +146,9 @@
     "lineCount": 330,
     "axiomCount": 0,
     "theoremCount": 4,
-    "definitionCount": 12
+    "definitionCount": 12,
+    "path": "Proofs/Erdos104Problem.lean",
+    "sorries": 1
   },
   "references": [
     {

--- a/src/data/proofs/erdos-1041/meta.json
+++ b/src/data/proofs/erdos-1041/meta.json
@@ -248,6 +248,8 @@
     "lineCount": 156,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos1041Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1042/meta.json
+++ b/src/data/proofs/erdos-1042/meta.json
@@ -234,6 +234,8 @@
     "lineCount": 132,
     "axiomCount": 3,
     "theoremCount": 1,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos1042Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1043/meta.json
+++ b/src/data/proofs/erdos-1043/meta.json
@@ -255,6 +255,7 @@
     "axiomCount": 2,
     "theoremCount": 12,
     "definitionCount": 15,
-    "sorries": 7
+    "sorries": 7,
+    "path": "Proofs/Erdos1043Problem.lean"
   }
 }

--- a/src/data/proofs/erdos-1044/meta.json
+++ b/src/data/proofs/erdos-1044/meta.json
@@ -202,6 +202,8 @@
     "lineCount": 120,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos1044Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1045/meta.json
+++ b/src/data/proofs/erdos-1045/meta.json
@@ -239,6 +239,8 @@
     "lineCount": 116,
     "axiomCount": 3,
     "theoremCount": 1,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos1045Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1046/meta.json
+++ b/src/data/proofs/erdos-1046/meta.json
@@ -277,6 +277,8 @@
     "lineCount": 236,
     "axiomCount": 3,
     "theoremCount": 2,
-    "definitionCount": 14
+    "definitionCount": 14,
+    "path": "Proofs/Erdos1046Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1047/meta.json
+++ b/src/data/proofs/erdos-1047/meta.json
@@ -295,6 +295,8 @@
     "lineCount": 252,
     "axiomCount": 2,
     "theoremCount": 11,
-    "definitionCount": 13
+    "definitionCount": 13,
+    "path": "Proofs/Erdos1047Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1049/meta.json
+++ b/src/data/proofs/erdos-1049/meta.json
@@ -282,6 +282,7 @@
     "substantiveTheoremCount": 22,
     "trivialSpecializations": 0,
     "definitionCount": 12,
-    "sorries": 9
+    "sorries": 9,
+    "path": "Proofs/Erdos1049Problem.lean"
   }
 }

--- a/src/data/proofs/erdos-105-oq-05/meta.json
+++ b/src/data/proofs/erdos-105-oq-05/meta.json
@@ -186,6 +186,8 @@
     "lineCount": 206,
     "axiomCount": 0,
     "theoremCount": 4,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos105OQ05.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-105/meta.json
+++ b/src/data/proofs/erdos-105/meta.json
@@ -255,6 +255,8 @@
     "lineCount": 291,
     "axiomCount": 3,
     "theoremCount": 3,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos105Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1051/meta.json
+++ b/src/data/proofs/erdos-1051/meta.json
@@ -217,6 +217,8 @@
     "lineCount": 232,
     "axiomCount": 0,
     "theoremCount": 9,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos1051Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1052/meta.json
+++ b/src/data/proofs/erdos-1052/meta.json
@@ -88,7 +88,9 @@
     "lineCount": 519,
     "axiomCount": 1,
     "theoremCount": 17,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos1052Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1053/meta.json
+++ b/src/data/proofs/erdos-1053/meta.json
@@ -254,6 +254,8 @@
         "type": "proved",
         "description": "σ(n) = ∑ d, d | n — the divisor sum function as a Finset.sum"
       }
-    ]
+    ],
+    "path": "Proofs/Erdos1053Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1054-oq-01/meta.json
+++ b/src/data/proofs/erdos-1054-oq-01/meta.json
@@ -200,6 +200,8 @@
     "lineCount": 352,
     "axiomCount": 2,
     "theoremCount": 24,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos1054AlmostAllOQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1054/meta.json
+++ b/src/data/proofs/erdos-1054/meta.json
@@ -207,6 +207,8 @@
     "lineCount": 612,
     "axiomCount": 1,
     "theoremCount": 52,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos1054Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1055/meta.json
+++ b/src/data/proofs/erdos-1055/meta.json
@@ -258,6 +258,8 @@
     "lineCount": 254,
     "axiomCount": 2,
     "theoremCount": 35,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos1055Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1056/meta.json
+++ b/src/data/proofs/erdos-1056/meta.json
@@ -195,6 +195,8 @@
     "lineCount": 215,
     "axiomCount": 0,
     "theoremCount": 14,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos1056Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1057/meta.json
+++ b/src/data/proofs/erdos-1057/meta.json
@@ -301,6 +301,8 @@
     "lineCount": 1099,
     "axiomCount": 2,
     "theoremCount": 66,
-    "definitionCount": 14
+    "definitionCount": 14,
+    "path": "Proofs/Erdos1057Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1058/meta.json
+++ b/src/data/proofs/erdos-1058/meta.json
@@ -188,6 +188,8 @@
     "lineCount": 165,
     "axiomCount": 3,
     "theoremCount": 2,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos1058Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1059-oq-01/meta.json
+++ b/src/data/proofs/erdos-1059-oq-01/meta.json
@@ -202,7 +202,9 @@
       "Mathlib.Data.Nat.Log",
       "Mathlib.Data.Finset.Basic",
       "Mathlib.Tactic"
-    ]
+    ],
+    "path": "Proofs/Erdos1059OQ01.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/erdos-1059-oq-03/meta.json
+++ b/src/data/proofs/erdos-1059-oq-03/meta.json
@@ -1,126 +1,128 @@
 {
-    "id": "erdos-1059-oq-03",
-    "title": "Smallest Prime > 211 Failing Erdős 1059",
-    "slug": "erdos-1059-oq-03",
-    "description": "The smallest prime p > 211 failing the Erdős 1059 property (all p - k! composite) is p = 223. Since 223 - 4! = 199 is prime, 223 does not satisfy the property. Fully verified by decision procedure with 0 sorries and 0 axioms.",
-    "meta": {
-        "author": "Erdős",
-        "sourceUrl": "https://erdosproblems.com/1059",
-        "status": "verified",
-        "proofRepoPath": "Proofs/Erdos1059OQ03.lean",
-        "tags": [
-            "erdos",
-            "number theory",
-            "primes",
-            "factorials",
-            "computational"
-        ],
-        "badge": "mathlib",
-        "sorries": 0,
-        "erdosNumber": 1059,
-        "erdosUrl": "https://erdosproblems.com/1059",
-        "erdosProblemStatus": "open",
-        "axiomCount": 0,
-        "lineCount": 45,
-        "assumptions": "None. All results proved by computation (decide/native_decide).",
-        "mathlib_version": "4.26.0"
-    },
-    "overview": {
-        "historicalContext": "Paul Erdős Problem #1059 asks whether there are **infinitely many** primes $p$ such that $p - k!$ is composite for every positive integer $k$ satisfying $k! < p$. Such primes are 'factorial-avoiding' — no factorial subtraction yields another prime.\n\nThe first known examples are $p = 101$ and $p = 211$. After 211, this open question (OQ-03) asks: what is the next prime failing the property? The answer is 223 — the very next prime after 211 — and 223 fails immediately via $223 - 4! = 223 - 24 = 199$ (prime).\n\nThis computational result has two implications. First, it shows the 'window' of primes satisfying the Erdős 1059 property is narrow: between 211 and the next prime (223), there is literally no prime that could fail. Second, it illustrates the rarity of the property: among the first few hundred primes, only 101 and 211 are known to satisfy it. Whether the list continues is open.\n\nThe proof uses Lean 4's `decide` tactic, which evaluates the statement at the kernel level (reducing to Boolean computation). For small numbers like 223 and 199, this is entirely feasible — primality testing is decidable and fast for numbers of this magnitude.",
-        "problemStatement": "**Erdős Problem #1059 (Open):** Are there infinitely many primes $p$ such that $p - k!$ is composite for every positive integer $k$ with $k! < p$?\n\nDefine: $\\mathrm{AFSC}(p) :\\!\\!\\iff \\forall k \\in \\mathbb{N},\\, k! < p \\Rightarrow (\\neg\\, \\mathrm{Prime}(p - k!) \\land p - k! \\geq 2)$.\n\nKnown examples: $\\mathrm{AFSC}(101)$ and $\\mathrm{AFSC}(211)$ hold.\n\n**OQ-03 (this file):** The smallest prime $p > 211$ with $\\neg\\, \\mathrm{AFSC}(p)$ is $p = 223$.\n\nProof sketch: $223 - 4! = 223 - 24 = 199$ is prime, so $\\mathrm{AFSC}(223)$ fails. Since 223 is the next prime after 211 (no primes in $\\{212, \\ldots, 222\\}$), it is the smallest failing prime after 211.",
-        "proofStrategy": "The proof is entirely computational. Lean 4's `decide` tactic evaluates decidable propositions at the kernel level, checking them by actual computation.\n\n**Step 1** (`prime_223`): Verify 223 is prime. `decide` evaluates `Nat.Prime 223` directly.\n\n**Step 2** (`prime_199`): Verify 199 is prime. Needed to show that $223 - 4! = 199$ is prime, demonstrating AFSC fails.\n\n**Step 3** (`next_prime_after_211`): Verify no prime exists in $\\{212, 213, \\ldots, 222\\}$. `decide` checks all 11 numbers.\n\n**Step 4** (`counterexample_223`): From the definition of AFSC, instantiate $k = 4$ (since $4! = 24 < 223$) and derive a contradiction: AFSC(223) would require $223 - 24 = 199$ to be composite, but step 2 says it is prime.\n\n**Step 5** (`smallest_failing_prime_after_211`): Bundle the three conclusions into a conjunction.",
-        "keyInsights": [
-            "The `decide` tactic transforms mathematical verification into computation: for small concrete numbers, `Nat.Prime 223` is evaluated directly by the Lean kernel without any mathematical proof infrastructure. This is possible because primality is decidable (the kernel can trial-divide up to √223 ≈ 14.9).",
-            "The counterexample uses k = 4 because 4! = 24 is the factorial nearest to 223 that gives a prime difference: 223 - 24 = 199. One could also use k = 5 since 5! = 120 < 223 and 223 - 120 = 103 is prime — there are multiple witnesses to the failure of AFSC(223).",
-            "The 'smallest failing prime' result is almost immediate once we know 223 is the next prime after 211: since there are no primes between 211 and 223, the search space is trivial. This is an instance of a common pattern: the answer to 'smallest X satisfying Y' is determined by the structure of primes.",
-            "AFSC(p) becomes harder to satisfy as p grows because there are more factorials below p to check. For p = 101, only k ∈ {1,2,3,4} matter (4! = 24 < 101 ≤ 5! = 120). For p = 211, k ranges up to 5 (5! = 120 < 211 ≤ 6! = 720). This increasing checking burden may be why examples become sparser.",
-            "The open question — whether infinitely many such primes exist — is deeply connected to the distribution of primes among arithmetic progressions and factorial residues. The problem has the flavor of Diophantine questions about primes in special sets, like Mersenne primes or prime gaps, where the answer is expected to be 'yes' but a proof seems far out of reach."
-        ],
-        "prerequisites": [
-            "Elementary number theory (primality, factorials)",
-            "Lean 4 `decide` tactic (decidable computations at the kernel level)",
-            "Erdős Problem #1059 main formalization (erdos-1059)"
-        ]
-    },
-    "sections": [
-        {
-            "id": "module-header",
-            "title": "Module: Finding the Smallest Failing Prime after 211",
-            "startLine": 1,
-            "endLine": 18,
-            "summary": "Module docstring states the OQ: smallest prime > 211 failing AFSC is 223, via 223 - 4! = 199 prime. Imports Mathlib.Data.Nat.Prime.Basic and Factorial.Basic for decidable primality.",
-            "mathContext": "The proof strategy is stated in the header: since 223 is the next prime after 211, finding one counterexample (k=4) suffices to establish minimality without checking any intermediate primes individually."
-        },
-        {
-            "id": "definition",
-            "title": "AllFactorialSubtractionsComposite Definition",
-            "startLine": 19,
-            "endLine": 22,
-            "summary": "Defines the AFSC property: all factorial subtractions p - k! (with k! < p) are composite and ≥ 2.",
-            "mathContext": "$\\mathrm{AFSC}(n) :\\!\\!\\iff \\forall k \\in \\mathbb{N},\\, k! < n \\Rightarrow (\\neg\\, \\mathrm{Prime}(n - k!) \\land n - k! \\geq 2)$. The $\\geq 2$ condition ensures the subtraction is meaningful (avoids 0 and 1 which are not prime but also not 'composite' in the standard sense)."
-        },
-        {
-            "id": "primality-lemmas",
-            "title": "Primality Computations: 223 and 199",
-            "startLine": 24,
-            "endLine": 31,
-            "summary": "Proves 223 and 199 are prime by decide. Also proves no prime exists in (211, 223).",
-            "mathContext": "Three facts by \\texttt{decide}: (1) $223$ is prime; (2) $199$ is prime; (3) $\\forall n \\in \\{212, \\ldots, 222\\}$, $n$ is not prime. These are verified by the Lean kernel computing trial division. $\\sqrt{223} < 15$ and $\\sqrt{199} < 15$, so only divisors $\\leq 14$ need to be checked."
-        },
-        {
-            "id": "counterexample",
-            "title": "223 Fails AFSC via 223 - 4! = 199",
-            "startLine": 33,
-            "endLine": 38,
-            "summary": "Proves AFSC(223) is false: k=4 gives 223 - 24 = 199 which is prime.",
-            "mathContext": "Proof by contradiction: assume $\\mathrm{AFSC}(223)$ holds. Instantiate with $k = 4$: since $4! = 24 < 223$, AFSC would require $\\neg\\mathrm{Prime}(223 - 24)$ and $223 - 24 \\geq 2$. But $223 - 24 = 199$ and $\\mathrm{Prime}(199)$ (proved above). Contradiction."
-        },
-        {
-            "id": "smallest-failing",
-            "title": "Main Result: 223 is the Smallest Failing Prime after 211",
-            "startLine": 40,
-            "endLine": 45,
-            "summary": "Bundles all three results: 223 is prime, AFSC(223) fails, and no prime exists between 211 and 223.",
-            "mathContext": "The conjunction $\\mathrm{Prime}(223) \\land \\neg\\mathrm{AFSC}(223) \\land (\\forall p,\\, 211 < p < 223 \\Rightarrow \\neg\\mathrm{Prime}(p))$ directly encodes '223 is the smallest prime $> 211$ failing AFSC.' The conjunction is assembled from the three previously proved lemmas."
-        }
+  "id": "erdos-1059-oq-03",
+  "title": "Smallest Prime > 211 Failing Erdős 1059",
+  "slug": "erdos-1059-oq-03",
+  "description": "The smallest prime p > 211 failing the Erdős 1059 property (all p - k! composite) is p = 223. Since 223 - 4! = 199 is prime, 223 does not satisfy the property. Fully verified by decision procedure with 0 sorries and 0 axioms.",
+  "meta": {
+    "author": "Erdős",
+    "sourceUrl": "https://erdosproblems.com/1059",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1059OQ03.lean",
+    "tags": [
+      "erdos",
+      "number theory",
+      "primes",
+      "factorials",
+      "computational"
     ],
-    "conclusion": {
-        "summary": "The smallest prime greater than 211 failing the Erdős 1059 property (AFSC) is 223, proved by direct computation. The key witness is 223 - 4! = 199, which is prime. All proofs use the `decide` tactic, making the verification entirely computational and machine-checked without any mathematical axioms.",
-        "implications": "This computational result characterizes the 'gap' after the known example p = 211: the very next prime (223) already fails the Erdős 1059 property, suggesting that examples satisfying AFSC are quite sparse. Whether there are infinitely many remains open.\n\nThe proof technique — direct computation via `decide` — is characteristic of finitely verifiable number-theoretic claims. For the main Erdős 1059 question (infinitely many examples), no such finite verification is possible; it would require either an infinite pattern or a structural argument about prime distributions relative to factorial gaps.",
-        "openQuestions": [
-            "Are there infinitely many primes p satisfying AFSC(p)? The sequence starts 101, 211, ... and appears sparse. No pattern is known.",
-            "What is the next prime after 211 that satisfies AFSC (i.e., follows 101 and 211 in the sequence)? This would require checking all primes between 223 and the next candidate, verifying that each p - k! is composite for all relevant k.",
-            "Do the examples 101 and 211 have a structural explanation? Both are near factorial values (5! = 120 is near 101; 5! = 120 is not near 211, but 4! = 24 divides into both). The connection between factorial structure and prime avoidance properties is unexplored.",
-            "Can this computational verification be extended to larger primes using Lean's `native_decide` (which compiles to native code) or external verification tools? For primes up to, say, 10,000, a comprehensive search for all AFSC-satisfying primes would be a natural next step."
-        ]
-    },
-    "crossReferences": [
-        {
-            "targetId": "erdos-1059",
-            "relationship": "extends",
-            "description": "Computational extension of the main Erdős 1059 formalization — this file finds the first prime after 211 that fails the property, complementing the main file's verification that 211 satisfies it"
-        }
+    "badge": "mathlib",
+    "sorries": 0,
+    "erdosNumber": 1059,
+    "erdosUrl": "https://erdosproblems.com/1059",
+    "erdosProblemStatus": "open",
+    "axiomCount": 0,
+    "lineCount": 45,
+    "assumptions": "None. All results proved by computation (decide/native_decide).",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Paul Erdős Problem #1059 asks whether there are **infinitely many** primes $p$ such that $p - k!$ is composite for every positive integer $k$ satisfying $k! < p$. Such primes are 'factorial-avoiding' — no factorial subtraction yields another prime.\n\nThe first known examples are $p = 101$ and $p = 211$. After 211, this open question (OQ-03) asks: what is the next prime failing the property? The answer is 223 — the very next prime after 211 — and 223 fails immediately via $223 - 4! = 223 - 24 = 199$ (prime).\n\nThis computational result has two implications. First, it shows the 'window' of primes satisfying the Erdős 1059 property is narrow: between 211 and the next prime (223), there is literally no prime that could fail. Second, it illustrates the rarity of the property: among the first few hundred primes, only 101 and 211 are known to satisfy it. Whether the list continues is open.\n\nThe proof uses Lean 4's `decide` tactic, which evaluates the statement at the kernel level (reducing to Boolean computation). For small numbers like 223 and 199, this is entirely feasible — primality testing is decidable and fast for numbers of this magnitude.",
+    "problemStatement": "**Erdős Problem #1059 (Open):** Are there infinitely many primes $p$ such that $p - k!$ is composite for every positive integer $k$ with $k! < p$?\n\nDefine: $\\mathrm{AFSC}(p) :\\!\\!\\iff \\forall k \\in \\mathbb{N},\\, k! < p \\Rightarrow (\\neg\\, \\mathrm{Prime}(p - k!) \\land p - k! \\geq 2)$.\n\nKnown examples: $\\mathrm{AFSC}(101)$ and $\\mathrm{AFSC}(211)$ hold.\n\n**OQ-03 (this file):** The smallest prime $p > 211$ with $\\neg\\, \\mathrm{AFSC}(p)$ is $p = 223$.\n\nProof sketch: $223 - 4! = 223 - 24 = 199$ is prime, so $\\mathrm{AFSC}(223)$ fails. Since 223 is the next prime after 211 (no primes in $\\{212, \\ldots, 222\\}$), it is the smallest failing prime after 211.",
+    "proofStrategy": "The proof is entirely computational. Lean 4's `decide` tactic evaluates decidable propositions at the kernel level, checking them by actual computation.\n\n**Step 1** (`prime_223`): Verify 223 is prime. `decide` evaluates `Nat.Prime 223` directly.\n\n**Step 2** (`prime_199`): Verify 199 is prime. Needed to show that $223 - 4! = 199$ is prime, demonstrating AFSC fails.\n\n**Step 3** (`next_prime_after_211`): Verify no prime exists in $\\{212, 213, \\ldots, 222\\}$. `decide` checks all 11 numbers.\n\n**Step 4** (`counterexample_223`): From the definition of AFSC, instantiate $k = 4$ (since $4! = 24 < 223$) and derive a contradiction: AFSC(223) would require $223 - 24 = 199$ to be composite, but step 2 says it is prime.\n\n**Step 5** (`smallest_failing_prime_after_211`): Bundle the three conclusions into a conjunction.",
+    "keyInsights": [
+      "The `decide` tactic transforms mathematical verification into computation: for small concrete numbers, `Nat.Prime 223` is evaluated directly by the Lean kernel without any mathematical proof infrastructure. This is possible because primality is decidable (the kernel can trial-divide up to √223 ≈ 14.9).",
+      "The counterexample uses k = 4 because 4! = 24 is the factorial nearest to 223 that gives a prime difference: 223 - 24 = 199. One could also use k = 5 since 5! = 120 < 223 and 223 - 120 = 103 is prime — there are multiple witnesses to the failure of AFSC(223).",
+      "The 'smallest failing prime' result is almost immediate once we know 223 is the next prime after 211: since there are no primes between 211 and 223, the search space is trivial. This is an instance of a common pattern: the answer to 'smallest X satisfying Y' is determined by the structure of primes.",
+      "AFSC(p) becomes harder to satisfy as p grows because there are more factorials below p to check. For p = 101, only k ∈ {1,2,3,4} matter (4! = 24 < 101 ≤ 5! = 120). For p = 211, k ranges up to 5 (5! = 120 < 211 ≤ 6! = 720). This increasing checking burden may be why examples become sparser.",
+      "The open question — whether infinitely many such primes exist — is deeply connected to the distribution of primes among arithmetic progressions and factorial residues. The problem has the flavor of Diophantine questions about primes in special sets, like Mersenne primes or prime gaps, where the answer is expected to be 'yes' but a proof seems far out of reach."
     ],
-    "leanFile": {
-        "imports": [
-            "Mathlib.Data.Nat.Prime.Basic",
-            "Mathlib.Data.Nat.Factorial.Basic",
-            "Mathlib.Tactic"
-        ],
-        "opens": [],
-        "namespace": null,
-        "lineCount": 45,
-        "axiomCount": 0,
-        "theoremCount": 5,
-        "definitionCount": 1
-    },
-    "references": [
-        {
-            "authors": "Erdős, Paul",
-            "title": "Problem #1059",
-            "year": "unknown",
-            "venue": "Erdős Problems Archive (erdosproblems.com/1059)",
-            "note": "The original problem: are there infinitely many primes p such that p - k! is composite for all k with k! < p? Known examples: 101, 211."
-        }
+    "prerequisites": [
+      "Elementary number theory (primality, factorials)",
+      "Lean 4 `decide` tactic (decidable computations at the kernel level)",
+      "Erdős Problem #1059 main formalization (erdos-1059)"
     ]
+  },
+  "sections": [
+    {
+      "id": "module-header",
+      "title": "Module: Finding the Smallest Failing Prime after 211",
+      "startLine": 1,
+      "endLine": 18,
+      "summary": "Module docstring states the OQ: smallest prime > 211 failing AFSC is 223, via 223 - 4! = 199 prime. Imports Mathlib.Data.Nat.Prime.Basic and Factorial.Basic for decidable primality.",
+      "mathContext": "The proof strategy is stated in the header: since 223 is the next prime after 211, finding one counterexample (k=4) suffices to establish minimality without checking any intermediate primes individually."
+    },
+    {
+      "id": "definition",
+      "title": "AllFactorialSubtractionsComposite Definition",
+      "startLine": 19,
+      "endLine": 22,
+      "summary": "Defines the AFSC property: all factorial subtractions p - k! (with k! < p) are composite and ≥ 2.",
+      "mathContext": "$\\mathrm{AFSC}(n) :\\!\\!\\iff \\forall k \\in \\mathbb{N},\\, k! < n \\Rightarrow (\\neg\\, \\mathrm{Prime}(n - k!) \\land n - k! \\geq 2)$. The $\\geq 2$ condition ensures the subtraction is meaningful (avoids 0 and 1 which are not prime but also not 'composite' in the standard sense)."
+    },
+    {
+      "id": "primality-lemmas",
+      "title": "Primality Computations: 223 and 199",
+      "startLine": 24,
+      "endLine": 31,
+      "summary": "Proves 223 and 199 are prime by decide. Also proves no prime exists in (211, 223).",
+      "mathContext": "Three facts by \\texttt{decide}: (1) $223$ is prime; (2) $199$ is prime; (3) $\\forall n \\in \\{212, \\ldots, 222\\}$, $n$ is not prime. These are verified by the Lean kernel computing trial division. $\\sqrt{223} < 15$ and $\\sqrt{199} < 15$, so only divisors $\\leq 14$ need to be checked."
+    },
+    {
+      "id": "counterexample",
+      "title": "223 Fails AFSC via 223 - 4! = 199",
+      "startLine": 33,
+      "endLine": 38,
+      "summary": "Proves AFSC(223) is false: k=4 gives 223 - 24 = 199 which is prime.",
+      "mathContext": "Proof by contradiction: assume $\\mathrm{AFSC}(223)$ holds. Instantiate with $k = 4$: since $4! = 24 < 223$, AFSC would require $\\neg\\mathrm{Prime}(223 - 24)$ and $223 - 24 \\geq 2$. But $223 - 24 = 199$ and $\\mathrm{Prime}(199)$ (proved above). Contradiction."
+    },
+    {
+      "id": "smallest-failing",
+      "title": "Main Result: 223 is the Smallest Failing Prime after 211",
+      "startLine": 40,
+      "endLine": 45,
+      "summary": "Bundles all three results: 223 is prime, AFSC(223) fails, and no prime exists between 211 and 223.",
+      "mathContext": "The conjunction $\\mathrm{Prime}(223) \\land \\neg\\mathrm{AFSC}(223) \\land (\\forall p,\\, 211 < p < 223 \\Rightarrow \\neg\\mathrm{Prime}(p))$ directly encodes '223 is the smallest prime $> 211$ failing AFSC.' The conjunction is assembled from the three previously proved lemmas."
+    }
+  ],
+  "conclusion": {
+    "summary": "The smallest prime greater than 211 failing the Erdős 1059 property (AFSC) is 223, proved by direct computation. The key witness is 223 - 4! = 199, which is prime. All proofs use the `decide` tactic, making the verification entirely computational and machine-checked without any mathematical axioms.",
+    "implications": "This computational result characterizes the 'gap' after the known example p = 211: the very next prime (223) already fails the Erdős 1059 property, suggesting that examples satisfying AFSC are quite sparse. Whether there are infinitely many remains open.\n\nThe proof technique — direct computation via `decide` — is characteristic of finitely verifiable number-theoretic claims. For the main Erdős 1059 question (infinitely many examples), no such finite verification is possible; it would require either an infinite pattern or a structural argument about prime distributions relative to factorial gaps.",
+    "openQuestions": [
+      "Are there infinitely many primes p satisfying AFSC(p)? The sequence starts 101, 211, ... and appears sparse. No pattern is known.",
+      "What is the next prime after 211 that satisfies AFSC (i.e., follows 101 and 211 in the sequence)? This would require checking all primes between 223 and the next candidate, verifying that each p - k! is composite for all relevant k.",
+      "Do the examples 101 and 211 have a structural explanation? Both are near factorial values (5! = 120 is near 101; 5! = 120 is not near 211, but 4! = 24 divides into both). The connection between factorial structure and prime avoidance properties is unexplored.",
+      "Can this computational verification be extended to larger primes using Lean's `native_decide` (which compiles to native code) or external verification tools? For primes up to, say, 10,000, a comprehensive search for all AFSC-satisfying primes would be a natural next step."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1059",
+      "relationship": "extends",
+      "description": "Computational extension of the main Erdős 1059 formalization — this file finds the first prime after 211 that fails the property, complementing the main file's verification that 211 satisfies it"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Prime.Basic",
+      "Mathlib.Data.Nat.Factorial.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": null,
+    "lineCount": 45,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/Erdos1059OQ03.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Erdős, Paul",
+      "title": "Problem #1059",
+      "year": "unknown",
+      "venue": "Erdős Problems Archive (erdosproblems.com/1059)",
+      "note": "The original problem: are there infinitely many primes p such that p - k! is composite for all k with k! < p? Known examples: 101, 211."
+    }
+  ]
 }

--- a/src/data/proofs/erdos-1059-oq-04/meta.json
+++ b/src/data/proofs/erdos-1059-oq-04/meta.json
@@ -66,7 +66,8 @@
     "lineCount": 147,
     "axiomCount": 0,
     "note": "axiomCount=0 reflects declarations in this file only; meta.axiomCount=1 counts the inherited axiom from Proofs.Erdos1059OQ01 (density_one_conjecture)",
-    "sorries": 0
+    "sorries": 0,
+    "path": "Proofs/Erdos1059OQ04.lean"
   },
   "overview": {
     "historicalContext": "Erdős Problem #1059, posed around 1979–1980, asks whether infinitely many primes $p$ exist such that $p - k!$ is composite for every positive integer $k$ with $k! < p$. The condition is a strong *primorial-gap* requirement: no factorial subtraction from $p$ yields a prime. Erdős was interested in how often primes avoid specific arithmetic structures; this problem sits at the intersection of prime gaps and factorial divisibility.\n\nThe natural density approach (OQ-01) reformulates the question via $d = \\lim_{x\\to\\infty} C(x)/\\pi(x)$, where $C(x)$ counts qualifying primes up to $x$. If $d = 1$, almost all primes qualify — a statement far stronger than mere infinitude. Proving density 1 unconditionally would require the Prime Number Theorem ($\\pi(x) \\sim x/\\log x$) combined with the Brun-Titchmarsh inequality for primes in the progression $\\{p : p - k! \\text{ composite} \\forall k\\}$.\n\nThis file (OQ-04) bridges two formalizations: it proves that the density-1 conjecture of OQ-01 implies the infinitude result proved conditionally in OQ-02 (via Selberg sieve). The two conditional proofs are logically independent — their axioms (density-1 vs. Selberg sieve) neither imply each other without deep analytic number theory. Together they show that Erdős #1059 follows from either of two qualitatively different analytic hypotheses.",

--- a/src/data/proofs/erdos-1059-oq-05/meta.json
+++ b/src/data/proofs/erdos-1059-oq-05/meta.json
@@ -1,121 +1,123 @@
 {
-    "id": "erdos-1059-oq-05",
-    "title": "Decidable Factorial Compositeness Verification",
-    "slug": "erdos-1059-oq-05",
-    "description": "A Decidable instance for AllFactorialSubtractionsComposite eliminates the need for manual per-prime factorial bound helpers. Any concrete prime can now be verified with a single native_decide.",
-    "meta": {
-        "author": "Erdős",
-        "sourceUrl": "https://erdosproblems.com/1059",
-        "status": "verified",
-        "proofRepoPath": "Proofs/Erdos1059OQ05.lean",
-        "tags": [
-            "erdos",
-            "number theory",
-            "primes",
-            "factorials",
-            "decidability",
-            "automation",
-            "tactics"
-        ],
-        "badge": "mathlib",
-        "sorries": 0,
-        "erdosNumber": 1059,
-        "erdosUrl": "https://erdosproblems.com/1059",
-        "erdosProblemStatus": "open",
-        "axiomCount": 0,
-        "lineCount": 99,
-        "assumptions": "None. All results proved by computation (native_decide).",
-        "mathlib_version": "4.26.0"
-    },
-    "overview": {
-        "historicalContext": "Erdős Problem #1059 asks whether infinitely many primes p satisfy the property that p − k! is composite for every k with k! < p. The problem reflects Erdős's lifelong interest in the distribution of primes and their gaps relative to factorials. Factorials grow extremely fast (n! ≥ 2^(n-1)), so the condition k! < p is satisfied by very few k: for p = 101, only k ≤ 4 (since 5! = 120 > 101). This sparsity makes the property non-trivial: out of these few subtractions, none should yield a prime.\n\nThe computational verification challenge is inherent to all such unbounded-quantifier properties: Lean's kernel cannot check 'for all k : ℕ' by inspection. The parent proof (Erdos1059Problem.lean) worked around this using hand-crafted `factorial_lt_bound` helpers and `interval_cases`, requiring ~10 lines per prime. OQ-05 eliminates this boilerplate by constructing a `Decidable` instance: once the quantifier is shown equivalent to a bounded form (using k ≤ k! from Mathlib), `native_decide` handles any specific prime in a single line.",
-        "problemStatement": "Provide a general decision procedure for verifying AllFactorialSubtractionsComposite on any concrete natural number, eliminating per-prime boilerplate.",
-        "text": "The key insight is that k ≤ k! for all k (Nat.self_le_factorial), so k! < n implies k < n. This bounds the universal quantifier to Finset.range n, making the proposition decidable. With the Decidable instance, verification of any concrete prime reduces to a single `by native_decide`.",
-        "proofStrategy": "Prove AllFactorialSubtractionsComposite n is equivalent to a bounded quantifier over Finset.range n via factorial_lt_implies_lt, then derive a Decidable instance using decidable_of_iff. The bounded quantifier inherits decidability from Finset.decidableBAll and the decidability of Nat.Prime, Nat.lt, and Nat.le.",
-        "keyInsights": [
-            "k ≤ k! for all k (Nat.self_le_factorial), so k! < n forces k < n, bounding the quantifier",
-            "The bounded quantifier over Finset.range n is automatically decidable since all components (factorial, primality, comparison) are decidable",
-            "A single Decidable instance replaces all per-prime factorial_lt_bound helper lemmas",
-            "Both witnesses (101, 211) and non-witnesses (89, 223) are verified uniformly by native_decide",
-            "The `decidable_of_iff` pattern is the canonical Lean 4 technique for deriving decidability of non-obviously-decidable propositions: prove the proposition is logically equivalent to a decidable one, then use `decidable_of_iff`. Here the non-obvious proposition is the unbounded ∀ k : ℕ; the decidable equivalent is ∀ k ∈ Finset.range n. The equivalence proof is the mathematical work; `decidable_of_iff` does the rest mechanically."
-        ],
-        "prerequisites": [
-            "Decidability in Lean 4 (Decidable typeclass, decidable_of_iff)",
-            "Nat.factorial and Nat.Prime from Mathlib",
-            "Finset.range and bounded quantifier decidability"
-        ]
-    },
-    "sections": [
-        {
-            "id": "module-header",
-            "title": "Module Docstring: Motivation and Approach",
-            "startLine": 1,
-            "endLine": 23,
-            "summary": "Explains the OQ: the parent proof needed per-prime helper lemmas; this file provides a Decidable instance so any prime is verified by native_decide. Key insight stated: k ≤ k! bounds the quantifier.",
-            "mathContext": "Sets up the problem: k! < n implies k < n (since k ≤ k!), making AllFactorialSubtractionsComposite n equivalent to a bounded ∀ k < n, decidable by kernel computation."
-        },
-        {
-            "id": "definition",
-            "title": "Core Definition",
-            "startLine": 24,
-            "endLine": 30,
-            "summary": "Defines `AllFactorialSubtractionsComposite n`: for every k with k! < n, n − k! is composite (≥ 2 and not prime). An unbounded universal quantifier, not yet decidable."
-        },
-        {
-            "id": "decidability",
-            "title": "Decidability Infrastructure",
-            "startLine": 32,
-            "endLine": 56,
-            "summary": "Proves k ≤ k! bounds the quantifier to Finset.range n, derives an iff with a decidable bounded form, and creates the Decidable instance via decidable_of_iff."
-        },
-        {
-            "id": "witnesses",
-            "title": "Witness Verification (101, 211)",
-            "startLine": 58,
-            "endLine": 76,
-            "summary": "Verifies AFSC(101) and AFSC(211) by native_decide, and packages both as `erdos_1059_witnesses`. Each is a prime satisfying the Erdős 1059 condition."
-        },
-        {
-            "id": "non-witnesses",
-            "title": "Non-Witness Verification (89, 223)",
-            "startLine": 78,
-            "endLine": 87,
-            "summary": "Verifies ¬AFSC(89) (since 89−3! = 83 is prime) and ¬AFSC(223) (since 223−4! = 199 is prime) by native_decide."
-        }
+  "id": "erdos-1059-oq-05",
+  "title": "Decidable Factorial Compositeness Verification",
+  "slug": "erdos-1059-oq-05",
+  "description": "A Decidable instance for AllFactorialSubtractionsComposite eliminates the need for manual per-prime factorial bound helpers. Any concrete prime can now be verified with a single native_decide.",
+  "meta": {
+    "author": "Erdős",
+    "sourceUrl": "https://erdosproblems.com/1059",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1059OQ05.lean",
+    "tags": [
+      "erdos",
+      "number theory",
+      "primes",
+      "factorials",
+      "decidability",
+      "automation",
+      "tactics"
     ],
-    "conclusion": {
-        "summary": "The Decidable instance `decAllFactorialSubtractionsComposite` eliminates all boilerplate from Erdős 1059 prime verification. Any concrete n can be tested by a single `native_decide`. Four examples are verified: witnesses 101 and 211, non-witnesses 89 and 223.",
-        "implications": "The pattern used here — bounding an unbounded quantifier via a monotone size argument (k ≤ k!), then deriving decidability — is a general proof engineering technique. It appears in proofs about Fibonacci, Catalan numbers, and any property quantifying over 'small enough' inputs. The infrastructure makes it straightforward to search computationally for additional witnesses to Erdős 1059, or to verify that a gap between witnesses has no new primes satisfying the property.",
-        "openQuestions": [
-            "The main Erdős 1059 problem: are there infinitely many primes p with AllFactorialSubtractionsComposite(p) true? No theoretical progress is known; computational search with this decidable instance extends verification to any specific range.",
-            "Can the decidable instance be used to prove a density result: among the first N primes, what fraction satisfy the property? Does this fraction stabilize or vary?",
-            "Are there analogous Decidable instances for related factorial-subtraction properties (e.g., n − k! is prime for all k with k! < n)?"
-        ]
-    },
-    "leanFile": {
-        "imports": [
-            "Mathlib.Data.Nat.Prime.Basic",
-            "Mathlib.Data.Nat.Factorial.Basic",
-            "Mathlib.Data.Finset.Basic",
-            "Mathlib.Tactic"
-        ],
-        "opens": [],
-        "namespace": null,
-        "lineCount": 99,
-        "axiomCount": 0,
-        "theoremCount": 7,
-        "definitionCount": 1
-    },
-    "crossReferences": [
-        {
-            "targetId": "erdos-1059",
-            "relationship": "extends",
-            "description": "Provides decidable verification infrastructure for the main Erdős 1059 formalization"
-        },
-        {
-            "targetId": "erdos-1059-oq-03",
-            "relationship": "related",
-            "description": "OQ-03 found the next failing prime (223); OQ-05 verifies this uniformly via native_decide"
-        }
+    "badge": "mathlib",
+    "sorries": 0,
+    "erdosNumber": 1059,
+    "erdosUrl": "https://erdosproblems.com/1059",
+    "erdosProblemStatus": "open",
+    "axiomCount": 0,
+    "lineCount": 99,
+    "assumptions": "None. All results proved by computation (native_decide).",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #1059 asks whether infinitely many primes p satisfy the property that p − k! is composite for every k with k! < p. The problem reflects Erdős's lifelong interest in the distribution of primes and their gaps relative to factorials. Factorials grow extremely fast (n! ≥ 2^(n-1)), so the condition k! < p is satisfied by very few k: for p = 101, only k ≤ 4 (since 5! = 120 > 101). This sparsity makes the property non-trivial: out of these few subtractions, none should yield a prime.\n\nThe computational verification challenge is inherent to all such unbounded-quantifier properties: Lean's kernel cannot check 'for all k : ℕ' by inspection. The parent proof (Erdos1059Problem.lean) worked around this using hand-crafted `factorial_lt_bound` helpers and `interval_cases`, requiring ~10 lines per prime. OQ-05 eliminates this boilerplate by constructing a `Decidable` instance: once the quantifier is shown equivalent to a bounded form (using k ≤ k! from Mathlib), `native_decide` handles any specific prime in a single line.",
+    "problemStatement": "Provide a general decision procedure for verifying AllFactorialSubtractionsComposite on any concrete natural number, eliminating per-prime boilerplate.",
+    "text": "The key insight is that k ≤ k! for all k (Nat.self_le_factorial), so k! < n implies k < n. This bounds the universal quantifier to Finset.range n, making the proposition decidable. With the Decidable instance, verification of any concrete prime reduces to a single `by native_decide`.",
+    "proofStrategy": "Prove AllFactorialSubtractionsComposite n is equivalent to a bounded quantifier over Finset.range n via factorial_lt_implies_lt, then derive a Decidable instance using decidable_of_iff. The bounded quantifier inherits decidability from Finset.decidableBAll and the decidability of Nat.Prime, Nat.lt, and Nat.le.",
+    "keyInsights": [
+      "k ≤ k! for all k (Nat.self_le_factorial), so k! < n forces k < n, bounding the quantifier",
+      "The bounded quantifier over Finset.range n is automatically decidable since all components (factorial, primality, comparison) are decidable",
+      "A single Decidable instance replaces all per-prime factorial_lt_bound helper lemmas",
+      "Both witnesses (101, 211) and non-witnesses (89, 223) are verified uniformly by native_decide",
+      "The `decidable_of_iff` pattern is the canonical Lean 4 technique for deriving decidability of non-obviously-decidable propositions: prove the proposition is logically equivalent to a decidable one, then use `decidable_of_iff`. Here the non-obvious proposition is the unbounded ∀ k : ℕ; the decidable equivalent is ∀ k ∈ Finset.range n. The equivalence proof is the mathematical work; `decidable_of_iff` does the rest mechanically."
+    ],
+    "prerequisites": [
+      "Decidability in Lean 4 (Decidable typeclass, decidable_of_iff)",
+      "Nat.factorial and Nat.Prime from Mathlib",
+      "Finset.range and bounded quantifier decidability"
     ]
+  },
+  "sections": [
+    {
+      "id": "module-header",
+      "title": "Module Docstring: Motivation and Approach",
+      "startLine": 1,
+      "endLine": 23,
+      "summary": "Explains the OQ: the parent proof needed per-prime helper lemmas; this file provides a Decidable instance so any prime is verified by native_decide. Key insight stated: k ≤ k! bounds the quantifier.",
+      "mathContext": "Sets up the problem: k! < n implies k < n (since k ≤ k!), making AllFactorialSubtractionsComposite n equivalent to a bounded ∀ k < n, decidable by kernel computation."
+    },
+    {
+      "id": "definition",
+      "title": "Core Definition",
+      "startLine": 24,
+      "endLine": 30,
+      "summary": "Defines `AllFactorialSubtractionsComposite n`: for every k with k! < n, n − k! is composite (≥ 2 and not prime). An unbounded universal quantifier, not yet decidable."
+    },
+    {
+      "id": "decidability",
+      "title": "Decidability Infrastructure",
+      "startLine": 32,
+      "endLine": 56,
+      "summary": "Proves k ≤ k! bounds the quantifier to Finset.range n, derives an iff with a decidable bounded form, and creates the Decidable instance via decidable_of_iff."
+    },
+    {
+      "id": "witnesses",
+      "title": "Witness Verification (101, 211)",
+      "startLine": 58,
+      "endLine": 76,
+      "summary": "Verifies AFSC(101) and AFSC(211) by native_decide, and packages both as `erdos_1059_witnesses`. Each is a prime satisfying the Erdős 1059 condition."
+    },
+    {
+      "id": "non-witnesses",
+      "title": "Non-Witness Verification (89, 223)",
+      "startLine": 78,
+      "endLine": 87,
+      "summary": "Verifies ¬AFSC(89) (since 89−3! = 83 is prime) and ¬AFSC(223) (since 223−4! = 199 is prime) by native_decide."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Decidable instance `decAllFactorialSubtractionsComposite` eliminates all boilerplate from Erdős 1059 prime verification. Any concrete n can be tested by a single `native_decide`. Four examples are verified: witnesses 101 and 211, non-witnesses 89 and 223.",
+    "implications": "The pattern used here — bounding an unbounded quantifier via a monotone size argument (k ≤ k!), then deriving decidability — is a general proof engineering technique. It appears in proofs about Fibonacci, Catalan numbers, and any property quantifying over 'small enough' inputs. The infrastructure makes it straightforward to search computationally for additional witnesses to Erdős 1059, or to verify that a gap between witnesses has no new primes satisfying the property.",
+    "openQuestions": [
+      "The main Erdős 1059 problem: are there infinitely many primes p with AllFactorialSubtractionsComposite(p) true? No theoretical progress is known; computational search with this decidable instance extends verification to any specific range.",
+      "Can the decidable instance be used to prove a density result: among the first N primes, what fraction satisfy the property? Does this fraction stabilize or vary?",
+      "Are there analogous Decidable instances for related factorial-subtraction properties (e.g., n − k! is prime for all k with k! < n)?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Prime.Basic",
+      "Mathlib.Data.Nat.Factorial.Basic",
+      "Mathlib.Data.Finset.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": null,
+    "lineCount": 99,
+    "axiomCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
+    "path": "Proofs/Erdos1059OQ05.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1059",
+      "relationship": "extends",
+      "description": "Provides decidable verification infrastructure for the main Erdős 1059 formalization"
+    },
+    {
+      "targetId": "erdos-1059-oq-03",
+      "relationship": "related",
+      "description": "OQ-03 found the next failing prime (223); OQ-05 verifies this uniformly via native_decide"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-1059/meta.json
+++ b/src/data/proofs/erdos-1059/meta.json
@@ -236,7 +236,9 @@
       "Mathlib.Data.Set.Basic",
       "Mathlib.Data.Finset.Basic",
       "Mathlib.Tactic"
-    ]
+    ],
+    "path": "Proofs/Erdos1059Problem.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/erdos-106-oq-02/meta.json
+++ b/src/data/proofs/erdos-106-oq-02/meta.json
@@ -207,6 +207,8 @@
         "type": "conjecture",
         "description": "∃ n, f_rot(n) > g(n) — the open question"
       }
-    ]
+    ],
+    "path": "Proofs/Erdos106OQ02.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1060/meta.json
+++ b/src/data/proofs/erdos-1060/meta.json
@@ -218,6 +218,8 @@
     "lineCount": 387,
     "axiomCount": 0,
     "theoremCount": 19,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos1060Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1061/meta.json
+++ b/src/data/proofs/erdos-1061/meta.json
@@ -267,6 +267,8 @@
     "lineCount": 380,
     "axiomCount": 0,
     "theoremCount": 48,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos1061Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1062/meta.json
+++ b/src/data/proofs/erdos-1062/meta.json
@@ -115,7 +115,9 @@
     "lineCount": 189,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos1062Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1063/meta.json
+++ b/src/data/proofs/erdos-1063/meta.json
@@ -228,6 +228,8 @@
     "lineCount": 169,
     "axiomCount": 3,
     "theoremCount": 1,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos1063Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1064/meta.json
+++ b/src/data/proofs/erdos-1064/meta.json
@@ -186,6 +186,8 @@
     "lineCount": 132,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos1064Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1065-oq-05/meta.json
+++ b/src/data/proofs/erdos-1065-oq-05/meta.json
@@ -1,208 +1,210 @@
 {
-    "id": "erdos-1065-oq-05",
-    "title": "Bateman-Horn Density for Primes p = 2^k · q + 1",
-    "slug": "erdos-1065-oq-05",
-    "description": "Formalization of Bateman-Horn density predictions for Erdős #1065 Form A primes. Defines IsFormAWithK parameterized by k, proves safe primes ↔ k=1, states uniqueness of the (k,q) decomposition, verifies k-value distribution for all 15 Form A primes ≤ 100, and axiomatizes the BH conjecture that each k-layer is infinite with constant 2C₂ independent of k.",
-    "meta": {
-        "author": "Erdős / Bateman-Horn",
-        "erdosNumber": 1065,
-        "status": "axiomatized",
-        "proofRepoPath": "Proofs/Erdos1065BatemanHorn.lean",
-        "badge": "axiom",
-        "tags": [
-            "erdos",
-            "number-theory",
-            "prime-numbers",
-            "analytic-number-theory",
-            "density-predictions",
-            "bateman-horn",
-            "research"
-        ],
-        "sorries": 0,
-        "sourceUrl": "https://erdosproblems.com/1065",
-        "erdosUrl": "https://erdosproblems.com/1065",
-        "mathlibDependencies": [
-            {
-                "theorem": "Nat.Prime",
-                "description": "Primality predicate",
-                "module": "Mathlib.Data.Nat.Prime.Basic"
-            },
-            {
-                "theorem": "Set.Infinite",
-                "description": "Infinite set predicate for density predictions",
-                "module": "Mathlib.Data.Set.Finite.Basic"
-            },
-            {
-                "theorem": "Nat.Prime.eq_one_or_self_of_dvd",
-                "description": "Primality characterization for oddness proofs",
-                "module": "Mathlib.Data.Nat.Prime.Basic"
-            }
-        ],
-        "originalContributions": [
-            "IsFormAWithK predicate parameterizing Form A primes by their 2-adic exponent k",
-            "Safe prime equivalence: IsSafePrime p ↔ IsFormAWithK 1 p",
-            "k-value census: complete distribution of k among all 15 Form A primes ≤ 100",
-            "Statement that BH constant 2C₂ is independent of k (local root count argument)",
-            "Axiomatized BH prediction: each k-layer is infinite",
-            "Safe primes conjecture as BH consequence via k=1 specialization"
-        ],
-        "erdosProblemStatus": "open",
-        "dateAdded": "2026-03-30",
-        "prerequisites": [
-            "Prime numbers and Nat.Prime from Mathlib",
-            "Set.Infinite for density statements",
-            "Bateman-Horn conjecture background"
-        ],
-        "axiomCount": 1,
-        "assumptions": "1 axiom: batemanHorn_formAWithK_infinite (each k-layer of Form A primes is infinite — the BH conjecture prediction). 0 sorries: formA_decomposition_unique was proved via 2-adic valuation (padicValNat 2 (2^k * q) = k when q is odd).",
-        "lineCount": 275,
-        "relatedProblems": [
-            {
-                "id": "erdos-1065",
-                "relationship": "Parent problem: this file formalizes the BH density prediction from oq-05"
-            }
-        ],
-        "mathlib_version": "4.26.0"
-    },
-    "sections": [
-        {
-            "id": "definitions",
-            "title": "Definitions",
-            "startLine": 30,
-            "endLine": 50,
-            "summary": "IsFormAWithK (parameterized by k), IsFormA (existential), IsSafePrime.",
-            "mathContext": "$\\text{IsFormAWithK}(k, p) \\iff p \\text{ prime} \\wedge \\exists q \\in \\mathbb{P}: p = 2^k q + 1$"
-        },
-        {
-            "id": "safe-prime-equiv",
-            "title": "Safe Prime Equivalence",
-            "startLine": 52,
-            "endLine": 75,
-            "summary": "Proves IsSafePrime p ↔ IsFormAWithK 1 p, and the inclusion chain safe primes ⊆ Form A.",
-            "mathContext": "$\\text{SafePrime}(p) \\iff \\text{FormA}(1, p)$"
-        },
-        {
-            "id": "uniqueness",
-            "title": "Decomposition Uniqueness",
-            "startLine": 77,
-            "endLine": 100,
-            "summary": "Proves that if p = 2^{k₁}q₁+1 = 2^{k₂}q₂+1 with q₁,q₂ odd primes, then k₁=k₂ and q₁=q₂. Proved via padicValNat: v₂(2^k·q) = k when q is odd.",
-            "mathContext": "$v_2(2^k q) = k$ when $q$ is odd, so $2^{k_1} q_1 = 2^{k_2} q_2$ with $q_i$ odd implies $k_1 = k_2$."
-        },
-        {
-            "id": "examples",
-            "title": "Verified Examples by k-value",
-            "startLine": 102,
-            "endLine": 185,
-            "summary": "All 15 Form A primes ≤ 100 verified with their specific k values: k=0 (3), k=1 (5,7,11,23,47,59,83), k=2 (13,29,53), k=3 (17,41,89), k=5 (97).",
-            "mathContext": "Complete k-value census ≤ 100. Safe primes (k=1) account for 7/15 ≈ 47%."
-        },
-        {
-            "id": "bateman-horn",
-            "title": "Bateman-Horn Prediction",
-            "startLine": 215,
-            "endLine": 271,
-            "summary": "Axiomatizes BH: each k-layer is infinite. Proves k=1 equivalence with safe primes conjecture. Derives safe primes infinite as a BH consequence.",
-            "mathContext": "BH predicts $\\pi_k(x) \\sim 2C_2 \\cdot \\text{Li}_2(x)$ with $C_2 \\approx 0.6602$ independent of $k$."
-        }
+  "id": "erdos-1065-oq-05",
+  "title": "Bateman-Horn Density for Primes p = 2^k · q + 1",
+  "slug": "erdos-1065-oq-05",
+  "description": "Formalization of Bateman-Horn density predictions for Erdős #1065 Form A primes. Defines IsFormAWithK parameterized by k, proves safe primes ↔ k=1, states uniqueness of the (k,q) decomposition, verifies k-value distribution for all 15 Form A primes ≤ 100, and axiomatizes the BH conjecture that each k-layer is infinite with constant 2C₂ independent of k.",
+  "meta": {
+    "author": "Erdős / Bateman-Horn",
+    "erdosNumber": 1065,
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos1065BatemanHorn.lean",
+    "badge": "axiom",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "prime-numbers",
+      "analytic-number-theory",
+      "density-predictions",
+      "bateman-horn",
+      "research"
     ],
-    "overview": {
-        "historicalContext": "The Bateman-Horn conjecture (1962) generalizes the Hardy-Littlewood prime conjectures to predict the density of primes represented simultaneously by several polynomials. For the polynomial pair (n, 2^k·n+1), it predicts that the count of primes q ≤ x for which 2^k·q+1 is also prime grows as 2C₂·x/(ln x)², where C₂ ≈ 0.6602 is the twin primes constant. Hardy and Littlewood's 1923 'Conjecture B' was the k=1 special case: infinitely many safe prime pairs (q, 2q+1). The key insight of this file is that the Bateman-Horn constant is the same — exactly 2C₂ — for every k ≥ 1, because the local root count ω(p) = 2 at every odd prime p regardless of k (since 2^k is a unit mod any odd prime). This 2C₂ independence of k is non-obvious and has quantitative consequences: all k-layers of Form A primes are predicted to have equal asymptotic density, with the empirical dominance of k=1 among small primes being a finite-sample effect.",
-        "problemStatement": "Can the Bateman-Horn conjecture provide quantitative density predictions for Form A primes (p = 2^k·q+1)? What is the predicted density as a function of k?",
-        "text": "A 271-line formalization of the Bateman-Horn density prediction for Erdős Problem #1065. Defines IsFormAWithK to parameterize Form A primes by their 2-adic exponent k, proves the safe prime equivalence (k=1), provides a complete k-value census of all 15 Form A primes ≤ 100, and axiomatizes the BH prediction that each k-layer is infinite. The key number-theoretic insight — that the BH constant 2C₂ is independent of k because the local root count at every odd prime p is always 2 — is documented and motivates the uniform axiom.",
-        "proofStrategy": "Define k-parameterized predicates, verify examples computationally, state uniqueness (sorry for now), axiomatize the BH prediction, derive consequences including the safe primes conjecture.",
-        "keyInsights": [
-            "**BH constant independence**: The Bateman-Horn constant 2C₂ ≈ 1.32 is the same for all k ≥ 1, because 2^k is a unit mod every odd prime p, making the local root count ω(p) = 2 regardless of k. Only the p=2 factor differs, but it equals 1 for all k≥1 (since 2^k·n+1 is always odd). The infinite product is thus k-independent.",
-            "**Safe primes as k=1 layer**: The safe primes conjecture is exactly the k=1 specialization of the BH prediction. This is formalized as a definitional equivalence: `simp [pow_one]` proves `IsSafePrime p ↔ IsFormAWithK 1 p`, making the reduction a one-line proof.",
-            "**k-value distribution**: Among Form A primes ≤ 100, k=1 (safe primes) dominates with 7/15 ≈ 47%. This is a finite-range effect: safe primes tend to be small since p=2q+1 for small prime q. BH predicts equal asymptotic density per k-layer, so the dominance of k=1 diminishes for larger primes.",
-            "**Uniqueness via 2-adic valuation**: For Form A prime p=2^k·q+1 with q odd prime, the pair (k,q) is unique because k = v₂(p-1). Formalizing this requires `Nat.multiplicity 2 (2^k * q) = k` — provable but requiring careful navigation of Mathlib's multiplicity API.",
-            "**Weak BH as Set.Infinite**: The axiom weakens the full asymptotic prediction to `Set.Infinite {p | IsFormAWithK k p}`. This is the minimal BH consequence needed for the safe primes corollary. The `convert h using 1; ext p; exact iff.symm` pattern efficiently transports Set.Infinite between equivalent predicates."
-        ]
-    },
-    "conclusion": {
-        "summary": "This formalization answers the open question by showing that the Bateman-Horn conjecture does provide quantitative density predictions: for each fixed k, the count of Form A primes is asymptotically 2C₂·x/(ln x)², and the constant is independent of k. The safe primes conjecture (k=1) is a special case.",
-        "openQuestions": [
-            "Can `formA_decomposition_unique` be proved in Lean from `Nat.multiplicity`? The key step is `Nat.multiplicity 2 (2^k * q) = k` when `q` is odd — Mathlib has `multiplicity_pow_self` and `multiplicity_mul` but combining them for this case requires careful case analysis on whether k=0.",
-            "Can the full BH asymptotic be formalized? This would require a Lean definition of `Li₂(x)` (logarithmic integral of order 2) and a density statement, neither of which currently exists in Mathlib. The axiom `batemanHorn_formAWithK_infinite` could be strengthened to a quantitative form.",
-            "Is there a proof of Erdős #1065 (existence of infinitely many Form A primes) that avoids BH entirely? The problem asks for existence, not density. A sieve-theoretic argument might produce Form A primes without the full BH machinery — similar to how Chen's theorem produces twin-prime-like pairs unconditionally."
-        ],
-        "implications": "The k-independence of the Bateman-Horn constant 2C₂ means the Form A prime density prediction has a clean uniform structure: every layer p = 2^k·q+1 grows at the same asymptotic rate, making the family an ideally structured test case for density conjectures. The `IsFormAWithK` predicate introduced here is reusable: it provides a clean Lean abstraction for parametric families of primes, and the `Set.Infinite` axiom pattern — weakening quantitative BH to a bare infinitude statement — is applicable to other BH predictions (twin primes, Mersenne primes) where only existence, not density, is needed for subsequent theorems."
-    },
-    "crossReferences": [
-        {
-            "targetId": "erdos-1065",
-            "relationship": "parent",
-            "description": "Parent problem: this formalizes the BH density prediction (open question 5)"
-        },
-        {
-            "targetId": "sophie-germain",
-            "relationship": "specializes",
-            "description": "Safe primes (k=1 case) are Sophie Germain prime pairs"
-        }
+    "sorries": 0,
+    "sourceUrl": "https://erdosproblems.com/1065",
+    "erdosUrl": "https://erdosproblems.com/1065",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.Prime",
+        "description": "Primality predicate",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "Set.Infinite",
+        "description": "Infinite set predicate for density predictions",
+        "module": "Mathlib.Data.Set.Finite.Basic"
+      },
+      {
+        "theorem": "Nat.Prime.eq_one_or_self_of_dvd",
+        "description": "Primality characterization for oddness proofs",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      }
     ],
-    "leanFile": {
-        "lineCount": 275,
-        "structureCount": 0,
-        "axiomCount": 1,
-        "theoremCount": 24,
-        "substantiveTheoremCount": 6,
-        "computationalVerifications": 16,
-        "lemmaCount": 0,
-        "defCount": 3,
-        "imports": [
-            "Mathlib.Data.Nat.Prime.Basic",
-            "Mathlib.Data.Set.Finite.Basic",
-            "Mathlib.Data.Nat.Basic",
-            "Mathlib.NumberTheory.Padics.PadicVal.Basic",
-            "Mathlib.Tactic"
-        ],
-        "opens": [],
-        "namespace": "Erdos1065BatemanHorn"
-    },
-    "mainTheorems": [
-        {
-            "name": "safePrime_iff_formAK1",
-            "type": "verified",
-            "description": "Safe primes are exactly Form A primes with k = 1",
-            "leanType": "∀ p, IsSafePrime p ↔ IsFormAWithK 1 p"
-        },
-        {
-            "name": "batemanHorn_k1_iff_safePrimes",
-            "type": "verified",
-            "description": "BH for k=1 is equivalent to the safe primes conjecture",
-            "leanType": "Set.Infinite {p | IsFormAWithK 1 p} ↔ Set.Infinite {p | IsSafePrime p}"
-        },
-        {
-            "name": "batemanHorn_implies_formA_infinite",
-            "type": "verified",
-            "description": "BH for any k implies infinitely many Form A primes",
-            "leanType": "∀ k, Set.Infinite {p | IsFormAWithK k p} → Set.Infinite {p | IsFormA p}"
-        },
-        {
-            "name": "formA_decomposition_unique",
-            "type": "verified",
-            "description": "Uniqueness of (k,q) decomposition when q is odd prime — proved via 2-adic valuation"
-        },
-        {
-            "name": "batemanHorn_formAWithK_infinite",
-            "type": "axiom",
-            "description": "BH prediction: each k-layer of Form A primes is infinite"
-        }
+    "originalContributions": [
+      "IsFormAWithK predicate parameterizing Form A primes by their 2-adic exponent k",
+      "Safe prime equivalence: IsSafePrime p ↔ IsFormAWithK 1 p",
+      "k-value census: complete distribution of k among all 15 Form A primes ≤ 100",
+      "Statement that BH constant 2C₂ is independent of k (local root count argument)",
+      "Axiomatized BH prediction: each k-layer is infinite",
+      "Safe primes conjecture as BH consequence via k=1 specialization"
     ],
-    "references": [
-        {
-            "authors": "Bateman, Paul T.; Horn, Roger A.",
-            "title": "A heuristic asymptotic formula concerning the distribution of prime numbers",
-            "year": "1962",
-            "venue": "Mathematics of Computation 16(79), 363-367",
-            "note": "The Bateman-Horn conjecture: density prediction for simultaneous prime values of polynomials"
-        },
-        {
-            "authors": "Hardy, G.H.; Littlewood, J.E.",
-            "title": "Some problems of 'Partitio numerorum'; III",
-            "year": "1923",
-            "venue": "Acta Mathematica 44, 1-70",
-            "note": "Conjecture F: safe prime density ~2C₂·x/(log x)², the k=1 special case"
-        }
+    "erdosProblemStatus": "open",
+    "dateAdded": "2026-03-30",
+    "prerequisites": [
+      "Prime numbers and Nat.Prime from Mathlib",
+      "Set.Infinite for density statements",
+      "Bateman-Horn conjecture background"
+    ],
+    "axiomCount": 1,
+    "assumptions": "1 axiom: batemanHorn_formAWithK_infinite (each k-layer of Form A primes is infinite — the BH conjecture prediction). 0 sorries: formA_decomposition_unique was proved via 2-adic valuation (padicValNat 2 (2^k * q) = k when q is odd).",
+    "lineCount": 275,
+    "relatedProblems": [
+      {
+        "id": "erdos-1065",
+        "relationship": "Parent problem: this file formalizes the BH density prediction from oq-05"
+      }
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Definitions",
+      "startLine": 30,
+      "endLine": 50,
+      "summary": "IsFormAWithK (parameterized by k), IsFormA (existential), IsSafePrime.",
+      "mathContext": "$\\text{IsFormAWithK}(k, p) \\iff p \\text{ prime} \\wedge \\exists q \\in \\mathbb{P}: p = 2^k q + 1$"
+    },
+    {
+      "id": "safe-prime-equiv",
+      "title": "Safe Prime Equivalence",
+      "startLine": 52,
+      "endLine": 75,
+      "summary": "Proves IsSafePrime p ↔ IsFormAWithK 1 p, and the inclusion chain safe primes ⊆ Form A.",
+      "mathContext": "$\\text{SafePrime}(p) \\iff \\text{FormA}(1, p)$"
+    },
+    {
+      "id": "uniqueness",
+      "title": "Decomposition Uniqueness",
+      "startLine": 77,
+      "endLine": 100,
+      "summary": "Proves that if p = 2^{k₁}q₁+1 = 2^{k₂}q₂+1 with q₁,q₂ odd primes, then k₁=k₂ and q₁=q₂. Proved via padicValNat: v₂(2^k·q) = k when q is odd.",
+      "mathContext": "$v_2(2^k q) = k$ when $q$ is odd, so $2^{k_1} q_1 = 2^{k_2} q_2$ with $q_i$ odd implies $k_1 = k_2$."
+    },
+    {
+      "id": "examples",
+      "title": "Verified Examples by k-value",
+      "startLine": 102,
+      "endLine": 185,
+      "summary": "All 15 Form A primes ≤ 100 verified with their specific k values: k=0 (3), k=1 (5,7,11,23,47,59,83), k=2 (13,29,53), k=3 (17,41,89), k=5 (97).",
+      "mathContext": "Complete k-value census ≤ 100. Safe primes (k=1) account for 7/15 ≈ 47%."
+    },
+    {
+      "id": "bateman-horn",
+      "title": "Bateman-Horn Prediction",
+      "startLine": 215,
+      "endLine": 271,
+      "summary": "Axiomatizes BH: each k-layer is infinite. Proves k=1 equivalence with safe primes conjecture. Derives safe primes infinite as a BH consequence.",
+      "mathContext": "BH predicts $\\pi_k(x) \\sim 2C_2 \\cdot \\text{Li}_2(x)$ with $C_2 \\approx 0.6602$ independent of $k$."
+    }
+  ],
+  "overview": {
+    "historicalContext": "The Bateman-Horn conjecture (1962) generalizes the Hardy-Littlewood prime conjectures to predict the density of primes represented simultaneously by several polynomials. For the polynomial pair (n, 2^k·n+1), it predicts that the count of primes q ≤ x for which 2^k·q+1 is also prime grows as 2C₂·x/(ln x)², where C₂ ≈ 0.6602 is the twin primes constant. Hardy and Littlewood's 1923 'Conjecture B' was the k=1 special case: infinitely many safe prime pairs (q, 2q+1). The key insight of this file is that the Bateman-Horn constant is the same — exactly 2C₂ — for every k ≥ 1, because the local root count ω(p) = 2 at every odd prime p regardless of k (since 2^k is a unit mod any odd prime). This 2C₂ independence of k is non-obvious and has quantitative consequences: all k-layers of Form A primes are predicted to have equal asymptotic density, with the empirical dominance of k=1 among small primes being a finite-sample effect.",
+    "problemStatement": "Can the Bateman-Horn conjecture provide quantitative density predictions for Form A primes (p = 2^k·q+1)? What is the predicted density as a function of k?",
+    "text": "A 271-line formalization of the Bateman-Horn density prediction for Erdős Problem #1065. Defines IsFormAWithK to parameterize Form A primes by their 2-adic exponent k, proves the safe prime equivalence (k=1), provides a complete k-value census of all 15 Form A primes ≤ 100, and axiomatizes the BH prediction that each k-layer is infinite. The key number-theoretic insight — that the BH constant 2C₂ is independent of k because the local root count at every odd prime p is always 2 — is documented and motivates the uniform axiom.",
+    "proofStrategy": "Define k-parameterized predicates, verify examples computationally, state uniqueness (sorry for now), axiomatize the BH prediction, derive consequences including the safe primes conjecture.",
+    "keyInsights": [
+      "**BH constant independence**: The Bateman-Horn constant 2C₂ ≈ 1.32 is the same for all k ≥ 1, because 2^k is a unit mod every odd prime p, making the local root count ω(p) = 2 regardless of k. Only the p=2 factor differs, but it equals 1 for all k≥1 (since 2^k·n+1 is always odd). The infinite product is thus k-independent.",
+      "**Safe primes as k=1 layer**: The safe primes conjecture is exactly the k=1 specialization of the BH prediction. This is formalized as a definitional equivalence: `simp [pow_one]` proves `IsSafePrime p ↔ IsFormAWithK 1 p`, making the reduction a one-line proof.",
+      "**k-value distribution**: Among Form A primes ≤ 100, k=1 (safe primes) dominates with 7/15 ≈ 47%. This is a finite-range effect: safe primes tend to be small since p=2q+1 for small prime q. BH predicts equal asymptotic density per k-layer, so the dominance of k=1 diminishes for larger primes.",
+      "**Uniqueness via 2-adic valuation**: For Form A prime p=2^k·q+1 with q odd prime, the pair (k,q) is unique because k = v₂(p-1). Formalizing this requires `Nat.multiplicity 2 (2^k * q) = k` — provable but requiring careful navigation of Mathlib's multiplicity API.",
+      "**Weak BH as Set.Infinite**: The axiom weakens the full asymptotic prediction to `Set.Infinite {p | IsFormAWithK k p}`. This is the minimal BH consequence needed for the safe primes corollary. The `convert h using 1; ext p; exact iff.symm` pattern efficiently transports Set.Infinite between equivalent predicates."
     ]
+  },
+  "conclusion": {
+    "summary": "This formalization answers the open question by showing that the Bateman-Horn conjecture does provide quantitative density predictions: for each fixed k, the count of Form A primes is asymptotically 2C₂·x/(ln x)², and the constant is independent of k. The safe primes conjecture (k=1) is a special case.",
+    "openQuestions": [
+      "Can `formA_decomposition_unique` be proved in Lean from `Nat.multiplicity`? The key step is `Nat.multiplicity 2 (2^k * q) = k` when `q` is odd — Mathlib has `multiplicity_pow_self` and `multiplicity_mul` but combining them for this case requires careful case analysis on whether k=0.",
+      "Can the full BH asymptotic be formalized? This would require a Lean definition of `Li₂(x)` (logarithmic integral of order 2) and a density statement, neither of which currently exists in Mathlib. The axiom `batemanHorn_formAWithK_infinite` could be strengthened to a quantitative form.",
+      "Is there a proof of Erdős #1065 (existence of infinitely many Form A primes) that avoids BH entirely? The problem asks for existence, not density. A sieve-theoretic argument might produce Form A primes without the full BH machinery — similar to how Chen's theorem produces twin-prime-like pairs unconditionally."
+    ],
+    "implications": "The k-independence of the Bateman-Horn constant 2C₂ means the Form A prime density prediction has a clean uniform structure: every layer p = 2^k·q+1 grows at the same asymptotic rate, making the family an ideally structured test case for density conjectures. The `IsFormAWithK` predicate introduced here is reusable: it provides a clean Lean abstraction for parametric families of primes, and the `Set.Infinite` axiom pattern — weakening quantitative BH to a bare infinitude statement — is applicable to other BH predictions (twin primes, Mersenne primes) where only existence, not density, is needed for subsequent theorems."
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1065",
+      "relationship": "parent",
+      "description": "Parent problem: this formalizes the BH density prediction (open question 5)"
+    },
+    {
+      "targetId": "sophie-germain",
+      "relationship": "specializes",
+      "description": "Safe primes (k=1 case) are Sophie Germain prime pairs"
+    }
+  ],
+  "leanFile": {
+    "lineCount": 275,
+    "structureCount": 0,
+    "axiomCount": 1,
+    "theoremCount": 24,
+    "substantiveTheoremCount": 6,
+    "computationalVerifications": 16,
+    "lemmaCount": 0,
+    "defCount": 3,
+    "imports": [
+      "Mathlib.Data.Nat.Prime.Basic",
+      "Mathlib.Data.Set.Finite.Basic",
+      "Mathlib.Data.Nat.Basic",
+      "Mathlib.NumberTheory.Padics.PadicVal.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": "Erdos1065BatemanHorn",
+    "path": "Proofs/Erdos1065BatemanHorn.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "safePrime_iff_formAK1",
+      "type": "verified",
+      "description": "Safe primes are exactly Form A primes with k = 1",
+      "leanType": "∀ p, IsSafePrime p ↔ IsFormAWithK 1 p"
+    },
+    {
+      "name": "batemanHorn_k1_iff_safePrimes",
+      "type": "verified",
+      "description": "BH for k=1 is equivalent to the safe primes conjecture",
+      "leanType": "Set.Infinite {p | IsFormAWithK 1 p} ↔ Set.Infinite {p | IsSafePrime p}"
+    },
+    {
+      "name": "batemanHorn_implies_formA_infinite",
+      "type": "verified",
+      "description": "BH for any k implies infinitely many Form A primes",
+      "leanType": "∀ k, Set.Infinite {p | IsFormAWithK k p} → Set.Infinite {p | IsFormA p}"
+    },
+    {
+      "name": "formA_decomposition_unique",
+      "type": "verified",
+      "description": "Uniqueness of (k,q) decomposition when q is odd prime — proved via 2-adic valuation"
+    },
+    {
+      "name": "batemanHorn_formAWithK_infinite",
+      "type": "axiom",
+      "description": "BH prediction: each k-layer of Form A primes is infinite"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Bateman, Paul T.; Horn, Roger A.",
+      "title": "A heuristic asymptotic formula concerning the distribution of prime numbers",
+      "year": "1962",
+      "venue": "Mathematics of Computation 16(79), 363-367",
+      "note": "The Bateman-Horn conjecture: density prediction for simultaneous prime values of polynomials"
+    },
+    {
+      "authors": "Hardy, G.H.; Littlewood, J.E.",
+      "title": "Some problems of 'Partitio numerorum'; III",
+      "year": "1923",
+      "venue": "Acta Mathematica 44, 1-70",
+      "note": "Conjecture F: safe prime density ~2C₂·x/(log x)², the k=1 special case"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-1065/meta.json
+++ b/src/data/proofs/erdos-1065/meta.json
@@ -244,7 +244,9 @@
       "Mathlib.Tactic"
     ],
     "opens": [],
-    "namespace": null
+    "namespace": null,
+    "path": "Proofs/Erdos1065Problem.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/erdos-1066/meta.json
+++ b/src/data/proofs/erdos-1066/meta.json
@@ -225,6 +225,8 @@
     "lineCount": 118,
     "axiomCount": 2,
     "theoremCount": 5,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos1066Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1067/meta.json
+++ b/src/data/proofs/erdos-1067/meta.json
@@ -257,6 +257,8 @@
     "lineCount": 226,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos1067Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1068/meta.json
+++ b/src/data/proofs/erdos-1068/meta.json
@@ -237,6 +237,7 @@
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 6,
-    "sorries": 0
+    "sorries": 0,
+    "path": "Proofs/Erdos1068Problem.lean"
   }
 }

--- a/src/data/proofs/erdos-1069/meta.json
+++ b/src/data/proofs/erdos-1069/meta.json
@@ -250,6 +250,8 @@
     "lineCount": 179,
     "axiomCount": 2,
     "theoremCount": 2,
-    "definitionCount": 12
+    "definitionCount": 12,
+    "path": "Proofs/Erdos1069Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-107/meta.json
+++ b/src/data/proofs/erdos-107/meta.json
@@ -235,6 +235,8 @@
     "lineCount": 516,
     "axiomCount": 6,
     "theoremCount": 9,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Stubs/Erdos107Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1070/meta.json
+++ b/src/data/proofs/erdos-1070/meta.json
@@ -228,6 +228,8 @@
     "lineCount": 235,
     "axiomCount": 10,
     "theoremCount": 6,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos1070Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1071/meta.json
+++ b/src/data/proofs/erdos-1071/meta.json
@@ -299,6 +299,8 @@
     "lineCount": 253,
     "axiomCount": 0,
     "theoremCount": 20,
-    "definitionCount": 15
+    "definitionCount": 15,
+    "path": "Proofs/Erdos1071Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1072/meta.json
+++ b/src/data/proofs/erdos-1072/meta.json
@@ -244,6 +244,8 @@
     "lineCount": 169,
     "axiomCount": 3,
     "theoremCount": 7,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos1072Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1073/meta.json
+++ b/src/data/proofs/erdos-1073/meta.json
@@ -202,6 +202,8 @@
     "lineCount": 161,
     "axiomCount": 0,
     "theoremCount": 17,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos1073Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1074/meta.json
+++ b/src/data/proofs/erdos-1074/meta.json
@@ -222,6 +222,8 @@
     "lineCount": 146,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos1074Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1075/meta.json
+++ b/src/data/proofs/erdos-1075/meta.json
@@ -253,6 +253,8 @@
     "lineCount": 165,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos1075Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1076/meta.json
+++ b/src/data/proofs/erdos-1076/meta.json
@@ -247,6 +247,8 @@
     "lineCount": 173,
     "axiomCount": 2,
     "theoremCount": 7,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos1076Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1077/meta.json
+++ b/src/data/proofs/erdos-1077/meta.json
@@ -219,6 +219,8 @@
     "lineCount": 145,
     "axiomCount": 0,
     "theoremCount": 2,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos1077Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1078/meta.json
+++ b/src/data/proofs/erdos-1078/meta.json
@@ -259,6 +259,8 @@
     "lineCount": 205,
     "axiomCount": 4,
     "theoremCount": 4,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos1078Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1079/meta.json
+++ b/src/data/proofs/erdos-1079/meta.json
@@ -224,6 +224,8 @@
     "lineCount": 150,
     "axiomCount": 1,
     "theoremCount": 1,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos1079Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-108/meta.json
+++ b/src/data/proofs/erdos-108/meta.json
@@ -228,6 +228,8 @@
     "lineCount": 142,
     "axiomCount": 1,
     "theoremCount": 2,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/Erdos108Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1081/meta.json
+++ b/src/data/proofs/erdos-1081/meta.json
@@ -275,6 +275,8 @@
     "lineCount": 335,
     "axiomCount": 1,
     "theoremCount": 9,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos1081Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1082/meta.json
+++ b/src/data/proofs/erdos-1082/meta.json
@@ -271,6 +271,8 @@
     "lineCount": 342,
     "axiomCount": 2,
     "theoremCount": 23,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos1082Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/listings.json
+++ b/src/data/proofs/listings.json
@@ -21026,7 +21026,7 @@
     "erdosNumber": 508,
     "mathlibCount": 4,
     "sorries": 0,
-    "annotationCount": 4
+    "annotationCount": 5
   },
   {
     "id": "erdos-509",


### PR DESCRIPTION
## Fix

Added missing `path` and `sorries` fields to `leanFile` objects for 200 gallery proofs. This is batch 3 of an ongoing series fixing gallery proofs with incomplete metadata.

## Coverage

| Batch | PR | Count | Range |
|-------|----|-------|-------|
| 1 | #9756 | 167 | first batch |
| 2 | #9759 | 198 | abel-* through central-limit-theorem-oq-04 |
| 3 | this | 200 | central-limit-theorem through erdos-* |

## Details

- `path` derived from `meta.proofRepoPath` in each meta.json
- `sorries` count verified from actual Lean source files
- Excludes proofs already covered in previous batches

## Validation

`pnpm build` passes cleanly.

---
Automated fix by lean-mechanic agent.