### PR TITLE
fix(meta): add missing leanFile.path and sorries to 200 gallery proofs (batch 4)

### DIFF
--- a/src/data/proofs/erdos-1083/meta.json
+++ b/src/data/proofs/erdos-1083/meta.json
@@ -270,6 +270,8 @@
     "lineCount": 86,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/Erdos1083Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1084-oq-01/meta.json
+++ b/src/data/proofs/erdos-1084-oq-01/meta.json
@@ -162,7 +162,9 @@
     "theoremCount": 20,
     "substantiveTheoremCount": 16,
     "sorryTheorems": 0,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos1084OQ01.lean",
+    "sorries": 1
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/erdos-1084/meta.json
+++ b/src/data/proofs/erdos-1084/meta.json
@@ -151,7 +151,9 @@
     "theoremCount": 7,
     "substantiveTheoremCount": 7,
     "sorryTheorems": 0,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos1084Problem.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/erdos-1085/meta.json
+++ b/src/data/proofs/erdos-1085/meta.json
@@ -243,6 +243,8 @@
     "lineCount": 126,
     "axiomCount": 1,
     "theoremCount": 0,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos1085Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1086/meta.json
+++ b/src/data/proofs/erdos-1086/meta.json
@@ -240,6 +240,8 @@
     "lineCount": 150,
     "axiomCount": 4,
     "theoremCount": 2,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos1086Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1088/meta.json
+++ b/src/data/proofs/erdos-1088/meta.json
@@ -233,6 +233,8 @@
     "lineCount": 86,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/Erdos1088Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1089/meta.json
+++ b/src/data/proofs/erdos-1089/meta.json
@@ -252,7 +252,9 @@
       "Set",
       "Finset"
     ],
-    "namespace": null
+    "namespace": null,
+    "path": "Proofs/Erdos1089Problem.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/erdos-109/meta.json
+++ b/src/data/proofs/erdos-109/meta.json
@@ -245,6 +245,8 @@
     "lineCount": 438,
     "axiomCount": 1,
     "theoremCount": 13,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos109Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1091/meta.json
+++ b/src/data/proofs/erdos-1091/meta.json
@@ -196,6 +196,8 @@
     "lineCount": 195,
     "axiomCount": 4,
     "theoremCount": 4,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos1091Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1093/meta.json
+++ b/src/data/proofs/erdos-1093/meta.json
@@ -226,6 +226,8 @@
     "lineCount": 167,
     "axiomCount": 1,
     "theoremCount": 25,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos1093Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1094/meta.json
+++ b/src/data/proofs/erdos-1094/meta.json
@@ -175,7 +175,9 @@
     "lineCount": 248,
     "axiomCount": 0,
     "theoremCount": 38,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos1094Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-1095-oq-01/meta.json
+++ b/src/data/proofs/erdos-1095-oq-01/meta.json
@@ -149,7 +149,9 @@
     "lineCount": 475,
     "axiomCount": 0,
     "theoremCount": 17,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos1095OQ01Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1095/meta.json
+++ b/src/data/proofs/erdos-1095/meta.json
@@ -181,7 +181,9 @@
     "lineCount": 475,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos1095OQ01Problem.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/erdos-1096/meta.json
+++ b/src/data/proofs/erdos-1096/meta.json
@@ -168,7 +168,9 @@
     "lineCount": 424,
     "axiomCount": 5,
     "theoremCount": 14,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos1096Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1097-oq-01/meta.json
+++ b/src/data/proofs/erdos-1097-oq-01/meta.json
@@ -1,165 +1,167 @@
 {
-    "id": "erdos-1097-oq-01",
-    "title": "Common Differences in k-Term Arithmetic Progressions",
-    "slug": "erdos-1097-oq-01",
-    "description": "Generalizes Erdős #1097 from 3-term to k-term APs. Defines D_k(A) and proves anti-monotonicity in k, containment D_k ⊆ D_3 for k ≥ 3, symmetry, and the O(n²) upper bound. Asks for the growth exponent α(k).",
-    "meta": {
-        "author": "Erdős (generalized)",
-        "sourceUrl": "https://erdosproblems.com/1097",
-        "status": "verified",
-        "proofRepoPath": "Proofs/Erdos1097OQ01.lean",
-        "tags": [
-            "erdos",
-            "additive combinatorics",
-            "arithmetic progressions",
-            "k-AP",
-            "open question"
-        ],
-        "badge": "original",
-        "sorries": 0,
-        "erdosNumber": 1097,
-        "erdosUrl": "https://erdosproblems.com/1097",
-        "erdosProblemStatus": "open",
-        "mathlib_version": "4.26.0",
-        "axiomCount": 0,
-        "assumptions": "No axioms. All 17 theorems are fully proved from Mathlib. The main open question (growth exponent α(k) for k ≥ 4) is stated as a definition, not an axiom.",
-        "lineCount": 207,
-        "relatedProblems": [
-            {
-                "id": "erdos-1097",
-                "relationship": "Parent problem: 3-term AP common differences"
-            }
-        ]
-    },
-    "overview": {
-        "text": "A formalization generalizing Erdős Problem #1097 from 3-term to k-term arithmetic progressions. Defines IsKAP (k-term AP predicate), D_k(A) (common differences of k-APs), and proves 17 theorems without any axioms or sorries. Key results: D_k is anti-monotone in k (more terms demanded → fewer common differences), D_k(A) ⊆ D_3(A) for k ≥ 3, negation symmetry, subset monotonicity, and the quadratic upper bound |D_k(A)| ≤ |A|². Also proves the connection to the k=3 case via an iff characterizing IsKAP with k=3. States the open question: what is the growth exponent α(k) such that max_{|A|=n} |D_k(A)| = Θ(n^{α(k)})?",
-        "historicalContext": "Erdős #1097 asks about 3-term APs in ℤ: how large can D_3(A) be for an n-element set A? The natural generalization to k-term APs connects to several major threads in additive combinatorics. Szemerédi's theorem (1975) guarantees that any positive-density subset of ℤ contains k-term APs for every k, but says nothing about quantitative bounds on D_k. Gowers (2001) developed higher-order Fourier analysis ('uniformity norms') to give quantitative bounds on k-AP counts, and the resulting tools have been extended to study common difference distributions. For k=3, the exponent α(3) is bounded: the lower bound Ω(n^{1.778}) comes from explicit constructions (related to Behrend's construction for 3-AP-free sets), while the Katz-Tao upper bound gives O(n^{11/6}). For k ≥ 4, k-APs impose more constraints (a k-AP is also a 3-AP, and the additional terms constrain d further), so α(k) ≤ α(3). Whether α(k) is strictly decreasing, or whether α(k) → 1 as k → ∞, are open questions connecting AP theory to higher-order uniformity.",
-        "problemStatement": "For $k \\geq 3$ and $A \\subseteq \\mathbb{Z}$ with $|A| = n$, define $D_k(A) = \\{d : \\exists a,\\; a, a+d, \\ldots, a+(k-1)d \\in A\\}$. What is the growth rate of $\\max_{|A|=n} |D_k(A)|$ as a function of $n$ and $k$?",
-        "proofStrategy": "Define IsKAP as a universal quantifier over indices (∀ i < k, a + i*d ∈ A), which naturally supports induction on k. Prove anti-monotonicity by weakening the universal quantifier. Symmetry via the reversed AP base a + (k-1)d. The quadratic bound follows from D_k(A) ⊆ A - A.",
-        "keyInsights": [
-            "D_k is anti-monotone in k: demanding longer APs can only reduce the set of valid common differences, giving |D_{k+1}(A)| ≤ |D_k(A)|",
-            "The optimal growth exponent α(k) is non-increasing in k, with α(3) ∈ [1.778, 11/6] from Erdős #1097",
-            "For k > n, D_k(A) = {0} since only trivial APs fit, giving α(k) → 0 as k → ∞ for fixed n",
-            "The connection to k=3 is exact: IsKAP with k=3 is equivalent to the IsThreeAP predicate from the parent formalization",
-            "All 17 theorems are axiom-free, including the monotonicity of the growth question across k values",
-            "The negation symmetry d ∈ D_k(A) → -d ∈ D_k(A) uses a reversed AP base b = a+(k-1)d — requiring only omega+ring to verify the index algebra over ℤ, showcasing how cast-free formulations simplify proofs"
-        ],
-        "prerequisites": [
-            "Combinatorics (counting, extremal problems)",
-            "Number theory (arithmetic progressions)"
-        ]
-    },
-    "sections": [
-        {
-            "id": "definitions",
-            "title": "Core Definitions",
-            "startLine": 27,
-            "endLine": 45,
-            "summary": "Defines IsKAP (k-term AP predicate), commonDiffK (set-level D_k), commonDiffKFinset (finite version), and numCommonDiffK (cardinality count).",
-            "mathContext": "$\\text{IsKAP}(A, k, a, d) \\iff \\forall i < k,\\; a + id \\in A$. $D_k(A) = \\{d : \\exists a,\\; \\text{IsKAP}(A, k, a, d)\\}$."
-        },
-        {
-            "id": "infrastructure",
-            "title": "Infrastructure Lemmas",
-            "startLine": 47,
-            "endLine": 140,
-            "summary": "Proves 13 structural results: base membership, trivial AP (d=0), zero membership, anti-monotonicity in k, containment D_k ⊆ D_3, subset monotonicity, negation symmetry, degenerate cases (k=0, k=1), and the quadratic upper bound.",
-            "mathContext": "$D_{k+1}(A) \\subseteq D_k(A)$ (anti-monotonicity). $D_k(A) \\subseteq D_3(A)$ for $k \\geq 3$. $|D_k(A)| \\leq |A|^2$. $D_0(A) = \\mathbb{Z}$, $D_1(A) = \\mathbb{Z}$ (for nonempty $A$)."
-        },
-        {
-            "id": "connection",
-            "title": "Connection to 3-AP Case",
-            "startLine": 142,
-            "endLine": 155,
-            "summary": "Proves isKAP_three_iff: IsKAP with k=3 is equivalent to the triple membership condition a ∈ A ∧ a+d ∈ A ∧ a+2d ∈ A, linking to the parent formalization.",
-            "mathContext": "$\\text{IsKAP}(A, 3, a, d) \\iff a \\in A \\land (a+d) \\in A \\land (a+2d) \\in A$."
-        },
-        {
-            "id": "open-question",
-            "title": "Main Open Question",
-            "startLine": 157,
-            "endLine": 185,
-            "summary": "States the growth question kAP_growth_question as a definition. Proves kAP_growth_mono: if D_k has growth exponent α, then D_{k+1} has growth exponent at most α.",
-            "mathContext": "Open: $\\exists \\alpha(k)$ such that $\\max_{|A|=n} |D_k(A)| = \\Theta(n^{\\alpha(k)})$? Is $\\alpha(k)$ strictly decreasing in $k$?"
-        }
+  "id": "erdos-1097-oq-01",
+  "title": "Common Differences in k-Term Arithmetic Progressions",
+  "slug": "erdos-1097-oq-01",
+  "description": "Generalizes Erdős #1097 from 3-term to k-term APs. Defines D_k(A) and proves anti-monotonicity in k, containment D_k ⊆ D_3 for k ≥ 3, symmetry, and the O(n²) upper bound. Asks for the growth exponent α(k).",
+  "meta": {
+    "author": "Erdős (generalized)",
+    "sourceUrl": "https://erdosproblems.com/1097",
+    "status": "verified",
+    "proofRepoPath": "Proofs/Erdos1097OQ01.lean",
+    "tags": [
+      "erdos",
+      "additive combinatorics",
+      "arithmetic progressions",
+      "k-AP",
+      "open question"
     ],
-    "conclusion": {
-        "summary": "A self-contained, axiom-free formalization of the k-term AP common differences problem. All 17 theorems are proved from Mathlib alone. The central open question — determining the growth exponent α(k) for k ≥ 4 — connects to Szemerédi's theorem and the broader program of quantitative arithmetic combinatorics.",
-        "implications": "The anti-monotonicity theorem (|D_{k+1}| ≤ |D_k|) means bounds for k=3 from Erdős #1097 automatically yield upper bounds for all k ≥ 3. Conversely, lower bounds for large k would give information about the structure of sets with many common differences. This framework provides the foundation for Lean-based investigation of quantitative AP problems beyond the classical k=3 case.",
-        "openQuestions": [
-            "What is the growth exponent α(4)? Is it strictly less than α(3) ∈ [1.778, 11/6]?",
-            "Does α(k) → 0 as k → ∞, and if so at what rate?"
-        ]
-    },
-    "crossReferences": [
-        {
-            "targetId": "erdos-1097",
-            "relationship": "parent",
-            "description": "The k=3 case: Erdős Problem #1097 on common differences in 3-term APs with bounds Ω(n^{1.778}) to O(n^{11/6})"
-        },
-        {
-            "targetId": "szemeredi-theorem",
-            "relationship": "related",
-            "description": "Szemerédi's theorem guarantees k-APs in dense sets; this asks about the common differences of those k-APs"
-        }
-    ],
-    "leanFile": {
-        "lineCount": 207,
-        "structureCount": 0,
-        "axiomCount": 0,
-        "theoremCount": 17,
-        "lemmaCount": 0,
-        "defCount": 6,
-        "imports": [
-            "Mathlib.Tactic",
-            "Mathlib.Data.Finset.Basic"
-        ],
-        "opens": [
-            "Finset"
-        ],
-        "namespace": null
-    },
-    "mainTheorems": [
-        {
-            "name": "commonDiffK_anti",
-            "type": "proved",
-            "description": "D_{k+1}(A) ⊆ D_k(A) (anti-monotonicity in AP length)"
-        },
-        {
-            "name": "commonDiffK_subset_diff3",
-            "type": "proved",
-            "description": "D_k(A) ⊆ D_3(A) for k ≥ 3 (containment in 3-AP differences)"
-        },
-        {
-            "name": "neg_mem_commonDiffK",
-            "type": "proved",
-            "description": "d ∈ D_k(A) → -d ∈ D_k(A) (negation symmetry)"
-        },
-        {
-            "name": "isKAP_three_iff",
-            "type": "proved",
-            "description": "IsKAP with k=3 ↔ IsThreeAP (connection to parent formalization)"
-        },
-        {
-            "name": "kAP_growth_mono",
-            "type": "proved",
-            "description": "Growth exponent for D_k bounds D_{k+1} (monotonicity of optimal exponent)"
-        }
-    ],
-    "references": [
-        {
-            "authors": "Katz, Nets Hawk; Tao, Terence",
-            "title": "Bounds on arithmetic projections, and applications to the Kakeya conjecture",
-            "year": "2002",
-            "venue": "Mathematical Research Letters 6, pp. 625-630",
-            "note": "O(n^{11/6}) upper bound for k=3, providing an upper bound for all k ≥ 3 via anti-monotonicity"
-        },
-        {
-            "authors": "Szemerédi, Endre",
-            "title": "On sets of integers containing no k elements in arithmetic progression",
-            "year": "1975",
-            "venue": "Acta Arithmetica 27, pp. 199-245",
-            "note": "Guarantees k-APs in dense sets; the existence result underlying the common differences question"
-        }
+    "badge": "original",
+    "sorries": 0,
+    "erdosNumber": 1097,
+    "erdosUrl": "https://erdosproblems.com/1097",
+    "erdosProblemStatus": "open",
+    "mathlib_version": "4.26.0",
+    "axiomCount": 0,
+    "assumptions": "No axioms. All 17 theorems are fully proved from Mathlib. The main open question (growth exponent α(k) for k ≥ 4) is stated as a definition, not an axiom.",
+    "lineCount": 207,
+    "relatedProblems": [
+      {
+        "id": "erdos-1097",
+        "relationship": "Parent problem: 3-term AP common differences"
+      }
     ]
+  },
+  "overview": {
+    "text": "A formalization generalizing Erdős Problem #1097 from 3-term to k-term arithmetic progressions. Defines IsKAP (k-term AP predicate), D_k(A) (common differences of k-APs), and proves 17 theorems without any axioms or sorries. Key results: D_k is anti-monotone in k (more terms demanded → fewer common differences), D_k(A) ⊆ D_3(A) for k ≥ 3, negation symmetry, subset monotonicity, and the quadratic upper bound |D_k(A)| ≤ |A|². Also proves the connection to the k=3 case via an iff characterizing IsKAP with k=3. States the open question: what is the growth exponent α(k) such that max_{|A|=n} |D_k(A)| = Θ(n^{α(k)})?",
+    "historicalContext": "Erdős #1097 asks about 3-term APs in ℤ: how large can D_3(A) be for an n-element set A? The natural generalization to k-term APs connects to several major threads in additive combinatorics. Szemerédi's theorem (1975) guarantees that any positive-density subset of ℤ contains k-term APs for every k, but says nothing about quantitative bounds on D_k. Gowers (2001) developed higher-order Fourier analysis ('uniformity norms') to give quantitative bounds on k-AP counts, and the resulting tools have been extended to study common difference distributions. For k=3, the exponent α(3) is bounded: the lower bound Ω(n^{1.778}) comes from explicit constructions (related to Behrend's construction for 3-AP-free sets), while the Katz-Tao upper bound gives O(n^{11/6}). For k ≥ 4, k-APs impose more constraints (a k-AP is also a 3-AP, and the additional terms constrain d further), so α(k) ≤ α(3). Whether α(k) is strictly decreasing, or whether α(k) → 1 as k → ∞, are open questions connecting AP theory to higher-order uniformity.",
+    "problemStatement": "For $k \\geq 3$ and $A \\subseteq \\mathbb{Z}$ with $|A| = n$, define $D_k(A) = \\{d : \\exists a,\\; a, a+d, \\ldots, a+(k-1)d \\in A\\}$. What is the growth rate of $\\max_{|A|=n} |D_k(A)|$ as a function of $n$ and $k$?",
+    "proofStrategy": "Define IsKAP as a universal quantifier over indices (∀ i < k, a + i*d ∈ A), which naturally supports induction on k. Prove anti-monotonicity by weakening the universal quantifier. Symmetry via the reversed AP base a + (k-1)d. The quadratic bound follows from D_k(A) ⊆ A - A.",
+    "keyInsights": [
+      "D_k is anti-monotone in k: demanding longer APs can only reduce the set of valid common differences, giving |D_{k+1}(A)| ≤ |D_k(A)|",
+      "The optimal growth exponent α(k) is non-increasing in k, with α(3) ∈ [1.778, 11/6] from Erdős #1097",
+      "For k > n, D_k(A) = {0} since only trivial APs fit, giving α(k) → 0 as k → ∞ for fixed n",
+      "The connection to k=3 is exact: IsKAP with k=3 is equivalent to the IsThreeAP predicate from the parent formalization",
+      "All 17 theorems are axiom-free, including the monotonicity of the growth question across k values",
+      "The negation symmetry d ∈ D_k(A) → -d ∈ D_k(A) uses a reversed AP base b = a+(k-1)d — requiring only omega+ring to verify the index algebra over ℤ, showcasing how cast-free formulations simplify proofs"
+    ],
+    "prerequisites": [
+      "Combinatorics (counting, extremal problems)",
+      "Number theory (arithmetic progressions)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Core Definitions",
+      "startLine": 27,
+      "endLine": 45,
+      "summary": "Defines IsKAP (k-term AP predicate), commonDiffK (set-level D_k), commonDiffKFinset (finite version), and numCommonDiffK (cardinality count).",
+      "mathContext": "$\\text{IsKAP}(A, k, a, d) \\iff \\forall i < k,\\; a + id \\in A$. $D_k(A) = \\{d : \\exists a,\\; \\text{IsKAP}(A, k, a, d)\\}$."
+    },
+    {
+      "id": "infrastructure",
+      "title": "Infrastructure Lemmas",
+      "startLine": 47,
+      "endLine": 140,
+      "summary": "Proves 13 structural results: base membership, trivial AP (d=0), zero membership, anti-monotonicity in k, containment D_k ⊆ D_3, subset monotonicity, negation symmetry, degenerate cases (k=0, k=1), and the quadratic upper bound.",
+      "mathContext": "$D_{k+1}(A) \\subseteq D_k(A)$ (anti-monotonicity). $D_k(A) \\subseteq D_3(A)$ for $k \\geq 3$. $|D_k(A)| \\leq |A|^2$. $D_0(A) = \\mathbb{Z}$, $D_1(A) = \\mathbb{Z}$ (for nonempty $A$)."
+    },
+    {
+      "id": "connection",
+      "title": "Connection to 3-AP Case",
+      "startLine": 142,
+      "endLine": 155,
+      "summary": "Proves isKAP_three_iff: IsKAP with k=3 is equivalent to the triple membership condition a ∈ A ∧ a+d ∈ A ∧ a+2d ∈ A, linking to the parent formalization.",
+      "mathContext": "$\\text{IsKAP}(A, 3, a, d) \\iff a \\in A \\land (a+d) \\in A \\land (a+2d) \\in A$."
+    },
+    {
+      "id": "open-question",
+      "title": "Main Open Question",
+      "startLine": 157,
+      "endLine": 185,
+      "summary": "States the growth question kAP_growth_question as a definition. Proves kAP_growth_mono: if D_k has growth exponent α, then D_{k+1} has growth exponent at most α.",
+      "mathContext": "Open: $\\exists \\alpha(k)$ such that $\\max_{|A|=n} |D_k(A)| = \\Theta(n^{\\alpha(k)})$? Is $\\alpha(k)$ strictly decreasing in $k$?"
+    }
+  ],
+  "conclusion": {
+    "summary": "A self-contained, axiom-free formalization of the k-term AP common differences problem. All 17 theorems are proved from Mathlib alone. The central open question — determining the growth exponent α(k) for k ≥ 4 — connects to Szemerédi's theorem and the broader program of quantitative arithmetic combinatorics.",
+    "implications": "The anti-monotonicity theorem (|D_{k+1}| ≤ |D_k|) means bounds for k=3 from Erdős #1097 automatically yield upper bounds for all k ≥ 3. Conversely, lower bounds for large k would give information about the structure of sets with many common differences. This framework provides the foundation for Lean-based investigation of quantitative AP problems beyond the classical k=3 case.",
+    "openQuestions": [
+      "What is the growth exponent α(4)? Is it strictly less than α(3) ∈ [1.778, 11/6]?",
+      "Does α(k) → 0 as k → ∞, and if so at what rate?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1097",
+      "relationship": "parent",
+      "description": "The k=3 case: Erdős Problem #1097 on common differences in 3-term APs with bounds Ω(n^{1.778}) to O(n^{11/6})"
+    },
+    {
+      "targetId": "szemeredi-theorem",
+      "relationship": "related",
+      "description": "Szemerédi's theorem guarantees k-APs in dense sets; this asks about the common differences of those k-APs"
+    }
+  ],
+  "leanFile": {
+    "lineCount": 207,
+    "structureCount": 0,
+    "axiomCount": 0,
+    "theoremCount": 17,
+    "lemmaCount": 0,
+    "defCount": 6,
+    "imports": [
+      "Mathlib.Tactic",
+      "Mathlib.Data.Finset.Basic"
+    ],
+    "opens": [
+      "Finset"
+    ],
+    "namespace": null,
+    "path": "Proofs/Erdos1097OQ01.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "commonDiffK_anti",
+      "type": "proved",
+      "description": "D_{k+1}(A) ⊆ D_k(A) (anti-monotonicity in AP length)"
+    },
+    {
+      "name": "commonDiffK_subset_diff3",
+      "type": "proved",
+      "description": "D_k(A) ⊆ D_3(A) for k ≥ 3 (containment in 3-AP differences)"
+    },
+    {
+      "name": "neg_mem_commonDiffK",
+      "type": "proved",
+      "description": "d ∈ D_k(A) → -d ∈ D_k(A) (negation symmetry)"
+    },
+    {
+      "name": "isKAP_three_iff",
+      "type": "proved",
+      "description": "IsKAP with k=3 ↔ IsThreeAP (connection to parent formalization)"
+    },
+    {
+      "name": "kAP_growth_mono",
+      "type": "proved",
+      "description": "Growth exponent for D_k bounds D_{k+1} (monotonicity of optimal exponent)"
+    }
+  ],
+  "references": [
+    {
+      "authors": "Katz, Nets Hawk; Tao, Terence",
+      "title": "Bounds on arithmetic projections, and applications to the Kakeya conjecture",
+      "year": "2002",
+      "venue": "Mathematical Research Letters 6, pp. 625-630",
+      "note": "O(n^{11/6}) upper bound for k=3, providing an upper bound for all k ≥ 3 via anti-monotonicity"
+    },
+    {
+      "authors": "Szemerédi, Endre",
+      "title": "On sets of integers containing no k elements in arithmetic progression",
+      "year": "1975",
+      "venue": "Acta Arithmetica 27, pp. 199-245",
+      "note": "Guarantees k-APs in dense sets; the existence result underlying the common differences question"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-1097/meta.json
+++ b/src/data/proofs/erdos-1097/meta.json
@@ -205,7 +205,9 @@
     "opens": [
       "Finset"
     ],
-    "namespace": null
+    "namespace": null,
+    "path": "Proofs/Erdos1097Problem.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/erdos-1098-oq-01/meta.json
+++ b/src/data/proofs/erdos-1098-oq-01/meta.json
@@ -123,14 +123,23 @@
     }
   ],
   "leanFile": {
-    "imports": ["Mathlib.GroupTheory.Subgroup.Basic", "Mathlib.GroupTheory.Subgroup.Center", "Mathlib.Data.Nat.Basic", "Mathlib.Tactic"],
-    "opens": ["Subgroup"],
+    "imports": [
+      "Mathlib.GroupTheory.Subgroup.Basic",
+      "Mathlib.GroupTheory.Subgroup.Center",
+      "Mathlib.Data.Nat.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Subgroup"
+    ],
     "namespace": "Erdos1098OQ01",
     "lineCount": 122,
     "axiomCount": 0,
     "theoremCount": 8,
     "substantiveTheoremCount": 8,
     "sorryTheorems": 0,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos1098OQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1098/meta.json
+++ b/src/data/proofs/erdos-1098/meta.json
@@ -108,7 +108,9 @@
     "lineCount": 348,
     "axiomCount": 1,
     "theoremCount": 12,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos1098Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1099/meta.json
+++ b/src/data/proofs/erdos-1099/meta.json
@@ -321,6 +321,8 @@
     "lineCount": 654,
     "axiomCount": 0,
     "theoremCount": 36,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos1099Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-11/meta.json
+++ b/src/data/proofs/erdos-11/meta.json
@@ -185,7 +185,9 @@
     "lineCount": 113,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos11Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-110-oq-03/meta.json
+++ b/src/data/proofs/erdos-110-oq-03/meta.json
@@ -208,6 +208,8 @@
     "lineCount": 261,
     "axiomCount": 1,
     "theoremCount": 9,
-    "definitionCount": 12
+    "definitionCount": 12,
+    "path": "Proofs/Erdos110HigherCardinals.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-110/meta.json
+++ b/src/data/proofs/erdos-110/meta.json
@@ -254,6 +254,8 @@
     "lineCount": 273,
     "axiomCount": 3,
     "theoremCount": 9,
-    "definitionCount": 13
+    "definitionCount": 13,
+    "path": "Proofs/Erdos110Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1101/meta.json
+++ b/src/data/proofs/erdos-1101/meta.json
@@ -226,6 +226,8 @@
     "lineCount": 123,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos1101Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1102/meta.json
+++ b/src/data/proofs/erdos-1102/meta.json
@@ -202,6 +202,8 @@
     "lineCount": 154,
     "axiomCount": 1,
     "theoremCount": 2,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos1102Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1103/meta.json
+++ b/src/data/proofs/erdos-1103/meta.json
@@ -171,7 +171,9 @@
     "lineCount": 162,
     "axiomCount": 1,
     "theoremCount": 9,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos1103Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-1104/meta.json
+++ b/src/data/proofs/erdos-1104/meta.json
@@ -151,7 +151,9 @@
     "lineCount": 196,
     "axiomCount": 3,
     "theoremCount": 10,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos1104Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-1105/meta.json
+++ b/src/data/proofs/erdos-1105/meta.json
@@ -294,6 +294,8 @@
     "lineCount": 378,
     "axiomCount": 1,
     "theoremCount": 3,
-    "definitionCount": 25
+    "definitionCount": 25,
+    "path": "Proofs/Erdos1105Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1106/meta.json
+++ b/src/data/proofs/erdos-1106/meta.json
@@ -242,6 +242,8 @@
     "lineCount": 246,
     "axiomCount": 4,
     "theoremCount": 9,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos1106Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1107/meta.json
+++ b/src/data/proofs/erdos-1107/meta.json
@@ -1,6 +1,6 @@
 {
   "id": "erdos-1107",
-  "title": "Erd\u0151s Problem #1107: Sums of r-Powerful Numbers",
+  "title": "Erdős Problem #1107: Sums of r-Powerful Numbers",
   "slug": "erdos-1107",
   "description": "Is every sufficiently large integer expressible as the sum of at most r+1 many r-powerful numbers?",
   "meta": {
@@ -46,16 +46,16 @@
     "theoremCount": 12
   },
   "overview": {
-    "historicalContext": "A natural number n is called r-powerful (or r-full) if for every prime p dividing n, the r-th power p^r also divides n. For r=2, these are the squareful numbers: 1, 4, 8, 9, 16, 25, 27, 32, 36, ... The concept generalizes perfect powers to numbers where each prime factor appears with sufficient multiplicity.\n\nErd\u0151s Problem #1107 was posed by Erd\u0151s and Ivi\u0107 in the 1986 Oberwolfach problem book. It asks whether every sufficiently large integer can be written as a sum of at most r+1 many r-powerful numbers.\n\nThe case r=2 was resolved by D.R. Heath-Brown in 1988 using the theory of ternary quadratic forms. He proved that every sufficiently large integer is the sum of at most three squareful numbers. The general case for r > 2 remains open.",
+    "historicalContext": "A natural number n is called r-powerful (or r-full) if for every prime p dividing n, the r-th power p^r also divides n. For r=2, these are the squareful numbers: 1, 4, 8, 9, 16, 25, 27, 32, 36, ... The concept generalizes perfect powers to numbers where each prime factor appears with sufficient multiplicity.\n\nErdős Problem #1107 was posed by Erdős and Ivić in the 1986 Oberwolfach problem book. It asks whether every sufficiently large integer can be written as a sum of at most r+1 many r-powerful numbers.\n\nThe case r=2 was resolved by D.R. Heath-Brown in 1988 using the theory of ternary quadratic forms. He proved that every sufficiently large integer is the sum of at most three squareful numbers. The general case for r > 2 remains open.",
     "problemStatement": "Let $r \\geq 2$. A positive integer $n$ is **$r$-powerful** (or **$r$-full**) if for every prime $p$ dividing $n$, we have $p^r \\mid n$.\n\n**Question**: Is every sufficiently large integer the sum of at most $r + 1$ many $r$-powerful numbers?\n\n**Status**:\n- **OPEN** for general $r \\geq 2$\n- **SOLVED** for $r = 2$ by Heath-Brown (1988)",
     "text": "Is every sufficiently large integer expressible as the sum of at most r+1 many r-powerful numbers?",
     "proofStrategy": "We formalize:\n\n1. The definition of r-powerful numbers using prime factorization\n2. The general conjecture as an axiom (open problem)\n3. Heath-Brown's theorem for r=2 as a separate axiom\n\nThe proof for r=2 uses deep results about ternary quadratic forms and is beyond current Mathlib formalization. We verify concrete examples computationally.",
     "keyInsights": [
-      "**r-Powerful numbers**: A number is r-powerful if every prime in its factorization appears at least r times. For example, 72 = 2^3 \u00b7 3^2 is 2-powerful since both 2^2 and 3^2 divide 72.",
-      "**Why r+1 terms?**: With r+1 terms, we have enough flexibility. With only r terms, not all large integers can be represented (see related Erd\u0151s Problem #940).",
+      "**r-Powerful numbers**: A number is r-powerful if every prime in its factorization appears at least r times. For example, 72 = 2^3 · 3^2 is 2-powerful since both 2^2 and 3^2 divide 72.",
+      "**Why r+1 terms?**: With r+1 terms, we have enough flexibility. With only r terms, not all large integers can be represented (see related Erdős Problem #940).",
       "**Heath-Brown's breakthrough**: For r=2, the problem reduces to understanding which integers are represented by sums of three squareful numbers. This connects to classical questions about quadratic forms.",
       "**Verified examples**: We prove 13 = 4 + 9 (two squareful numbers) and 17 = 8 + 9, demonstrating that the conjecture holds for small cases.",
-      "**Density argument**: Squareful numbers have density $\\sum_{p} p^{-2} \\approx 0.6$ among integers, so their sumsets should eventually cover all large numbers \u2014 the challenge is making 'eventually' effective"
+      "**Density argument**: Squareful numbers have density $\\sum_{p} p^{-2} \\approx 0.6$ among integers, so their sumsets should eventually cover all large numbers — the challenge is making 'eventually' effective"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -114,12 +114,12 @@
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erd\u0151s Problem #1107 about sums of r-powerful numbers. The general conjecture remains open, but Heath-Brown proved the r=2 case in 1988. We provide formal definitions, state both theorems as axioms, and verify concrete computational examples.",
+    "summary": "We formalize Erdős Problem #1107 about sums of r-powerful numbers. The general conjecture remains open, but Heath-Brown proved the r=2 case in 1988. We provide formal definitions, state both theorems as axioms, and verify concrete computational examples.",
     "implications": "This problem connects additive number theory with multiplicative structure. Understanding which integers are sums of powerful numbers reveals deep connections between prime factorization patterns and additive decomposition.",
     "openQuestions": [
       "Can Heath-Brown's methods for r=2 be extended to r=3 or larger?",
       "What is the smallest N such that all integers n > N are sums of three squareful numbers?",
-      "Is there a unified approach that works for all r \u2265 2?"
+      "Is there a unified approach that works for all r ≥ 2?"
     ]
   },
   "crossReferences": [
@@ -131,12 +131,12 @@
     {
       "targetId": "erdos-940",
       "relationship": "companion",
-      "description": "Problem #940 asks the complementary density question: does the set of sums of r r-powerful numbers (the diagonal case) have density 0 for r \u2265 3? Problem #1107 asks for the universal representation threshold (r+1 summands). Together they characterize the additive structure of r-powerful numbers."
+      "description": "Problem #940 asks the complementary density question: does the set of sums of r r-powerful numbers (the diagonal case) have density 0 for r ≥ 3? Problem #1107 asks for the universal representation threshold (r+1 summands). Together they characterize the additive structure of r-powerful numbers."
     },
     {
       "targetId": "erdos-1081",
       "relationship": "related",
-      "description": "Problem #1081 studies the counting function A(x) for integers expressible as sums of two squarefull numbers, disproving Erd\u0151s's conjectured asymptotic. The correct exponent \u03b1 = 1 - 2^(-1/3) \u2248 0.206 reflects how squarefull sums cluster \u2014 directly relevant to understanding the density arguments for Problem #1107."
+      "description": "Problem #1081 studies the counting function A(x) for integers expressible as sums of two squarefull numbers, disproving Erdős's conjectured asymptotic. The correct exponent α = 1 - 2^(-1/3) ≈ 0.206 reflects how squarefull sums cluster — directly relevant to understanding the density arguments for Problem #1107."
     },
     {
       "targetId": "erdos-935",
@@ -146,12 +146,12 @@
     {
       "targetId": "fundamental-arithmetic",
       "relationship": "foundational",
-      "description": "The definition of r-powerful numbers is rooted in the prime factorization guaranteed by the Fundamental Theorem of Arithmetic: n is r-powerful iff every prime p in its factorization appears with exponent \u2265 r. The Lean formalization uses Nat.primeFactors and the factorization API directly."
+      "description": "The definition of r-powerful numbers is rooted in the prime factorization guaranteed by the Fundamental Theorem of Arithmetic: n is r-powerful iff every prime p in its factorization appears with exponent ≥ r. The Lean formalization uses Nat.primeFactors and the factorization API directly."
     }
   ],
   "references": [
     {
-      "authors": "Erd\u0151s, Paul; Ivi\u0107, Aleksandar",
+      "authors": "Erdős, Paul; Ivić, Aleksandar",
       "title": "Problems in analytic number theory (Oberwolfach Problem Book)",
       "year": "1986",
       "venue": "Mathematisches Forschungsinstitut Oberwolfach",
@@ -161,22 +161,22 @@
       "authors": "Heath-Brown, D. R.",
       "title": "Ternary quadratic forms and sums of three square-full numbers",
       "year": "1988",
-      "venue": "Acta Arithmetica 50(2), 163\u2013173",
+      "venue": "Acta Arithmetica 50(2), 163–173",
       "note": "Resolves the r=2 case of Problem #1107: every sufficiently large integer is the sum of at most three squarefull (2-powerful) numbers, using the theory of ternary quadratic forms and the Hasse principle."
     },
     {
-      "authors": "Baker, Roger C.; Br\u00fcdern, J\u00f6rg",
+      "authors": "Baker, Roger C.; Brüdern, Jörg",
       "title": "Sums of two squarefull numbers",
       "year": "1994",
-      "venue": "Acta Arithmetica 66(4), 369\u2013376",
+      "venue": "Acta Arithmetica 66(4), 369–376",
       "note": "Proves the complementary density-0 result: integers representable as sums of at most two squarefull numbers form a set of natural density 0 (Problem #940). Establishes the sharp 2-to-3 phase transition."
     },
     {
       "authors": "Golomb, Solomon W.",
       "title": "Powerful numbers",
       "year": "1970",
-      "venue": "American Mathematical Monthly 77(8), 848\u2013852",
-      "note": "Introduces and names 'powerful numbers' (squarefull numbers), proves the characterization n is powerful iff n = a\u00b2b\u00b3, and initiates their systematic study. The term 'powerful number' comes from this paper."
+      "venue": "American Mathematical Monthly 77(8), 848–852",
+      "note": "Introduces and names 'powerful numbers' (squarefull numbers), proves the characterization n is powerful iff n = a²b³, and initiates their systematic study. The term 'powerful number' comes from this paper."
     },
     {
       "authors": "Hardy, G. H.; Wright, E. M.",
@@ -200,6 +200,8 @@
     "lineCount": 172,
     "axiomCount": 1,
     "theoremCount": 12,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos1107Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1108/meta.json
+++ b/src/data/proofs/erdos-1108/meta.json
@@ -254,6 +254,8 @@
     "lineCount": 171,
     "axiomCount": 0,
     "theoremCount": 13,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos1108Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1109/meta.json
+++ b/src/data/proofs/erdos-1109/meta.json
@@ -273,6 +273,8 @@
     "lineCount": 3713,
     "axiomCount": 2,
     "theoremCount": 151,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos1109Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-111/meta.json
+++ b/src/data/proofs/erdos-111/meta.json
@@ -308,6 +308,8 @@
     "lineCount": 320,
     "axiomCount": 4,
     "theoremCount": 2,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos111Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1110/meta.json
+++ b/src/data/proofs/erdos-1110/meta.json
@@ -262,6 +262,8 @@
     "lineCount": 265,
     "axiomCount": 2,
     "theoremCount": 5,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos1110Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1111/meta.json
+++ b/src/data/proofs/erdos-1111/meta.json
@@ -238,6 +238,8 @@
     "lineCount": 224,
     "axiomCount": 6,
     "theoremCount": 2,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos1111Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1112/meta.json
+++ b/src/data/proofs/erdos-1112/meta.json
@@ -262,6 +262,8 @@
     "lineCount": 207,
     "axiomCount": 5,
     "theoremCount": 4,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos1112Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1113/meta.json
+++ b/src/data/proofs/erdos-1113/meta.json
@@ -198,7 +198,9 @@
     "lineCount": 172,
     "axiomCount": 1,
     "theoremCount": 5,
-    "definitionCount": 14
+    "definitionCount": 14,
+    "path": "Proofs/Erdos1113Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-1114/meta.json
+++ b/src/data/proofs/erdos-1114/meta.json
@@ -245,6 +245,8 @@
     "lineCount": 171,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos1114Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1115/meta.json
+++ b/src/data/proofs/erdos-1115/meta.json
@@ -200,6 +200,8 @@
     "lineCount": 102,
     "axiomCount": 3,
     "theoremCount": 1,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos1115Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1116/meta.json
+++ b/src/data/proofs/erdos-1116/meta.json
@@ -252,6 +252,8 @@
     "lineCount": 379,
     "axiomCount": 2,
     "theoremCount": 10,
-    "definitionCount": 13
+    "definitionCount": 13,
+    "path": "Proofs/Erdos1116Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1117/meta.json
+++ b/src/data/proofs/erdos-1117/meta.json
@@ -181,6 +181,8 @@
     "lineCount": 83,
     "axiomCount": 0,
     "theoremCount": 3,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/Erdos1117Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1118-oq-02/meta.json
+++ b/src/data/proofs/erdos-1118-oq-02/meta.json
@@ -91,6 +91,8 @@
     "lineCount": 103,
     "axiomCount": 0,
     "theoremCount": 3,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/Erdos1118OQ02.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1118/meta.json
+++ b/src/data/proofs/erdos-1118/meta.json
@@ -269,6 +269,8 @@
     "lineCount": 234,
     "axiomCount": 3,
     "theoremCount": 7,
-    "definitionCount": 13
+    "definitionCount": 13,
+    "path": "Proofs/Erdos1118Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1119/meta.json
+++ b/src/data/proofs/erdos-1119/meta.json
@@ -245,6 +245,8 @@
     "lineCount": 133,
     "axiomCount": 3,
     "theoremCount": 2,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos1119Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-112/meta.json
+++ b/src/data/proofs/erdos-112/meta.json
@@ -202,6 +202,8 @@
       "Mathlib.Data.Finset.Basic",
       "Mathlib.Tactic"
     ],
-    "opens": []
+    "opens": [],
+    "path": "Proofs/Erdos112Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1120/meta.json
+++ b/src/data/proofs/erdos-1120/meta.json
@@ -225,6 +225,8 @@
     "lineCount": 183,
     "axiomCount": 2,
     "theoremCount": 13,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos1120Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1121/meta.json
+++ b/src/data/proofs/erdos-1121/meta.json
@@ -213,6 +213,8 @@
     "lineCount": 218,
     "axiomCount": 1,
     "theoremCount": 1,
-    "definitionCount": 12
+    "definitionCount": 12,
+    "path": "Proofs/Erdos1121Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1122/meta.json
+++ b/src/data/proofs/erdos-1122/meta.json
@@ -102,7 +102,9 @@
     "lineCount": 208,
     "axiomCount": 3,
     "theoremCount": 7,
-    "definitionCount": 14
+    "definitionCount": 14,
+    "path": "Proofs/Erdos1122Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1123/meta.json
+++ b/src/data/proofs/erdos-1123/meta.json
@@ -199,6 +199,8 @@
     "lineCount": 110,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos1123Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1124-oq-01/meta.json
+++ b/src/data/proofs/erdos-1124-oq-01/meta.json
@@ -200,6 +200,8 @@
     "lineCount": 454,
     "axiomCount": 5,
     "theoremCount": 22,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos1124OQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1124/meta.json
+++ b/src/data/proofs/erdos-1124/meta.json
@@ -261,6 +261,8 @@
     "lineCount": 190,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 15
+    "definitionCount": 15,
+    "path": "Proofs/Erdos1124Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1125/meta.json
+++ b/src/data/proofs/erdos-1125/meta.json
@@ -231,6 +231,8 @@
     "lineCount": 174,
     "axiomCount": 3,
     "theoremCount": 8,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos1125Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1126/meta.json
+++ b/src/data/proofs/erdos-1126/meta.json
@@ -174,6 +174,8 @@
     "lineCount": 157,
     "axiomCount": 4,
     "theoremCount": 4,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos1126Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1127/meta.json
+++ b/src/data/proofs/erdos-1127/meta.json
@@ -235,6 +235,8 @@
     "lineCount": 279,
     "axiomCount": 5,
     "theoremCount": 3,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos1127Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1128/meta.json
+++ b/src/data/proofs/erdos-1128/meta.json
@@ -216,6 +216,8 @@
     "lineCount": 166,
     "axiomCount": 4,
     "theoremCount": 3,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos1128Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1129/meta.json
+++ b/src/data/proofs/erdos-1129/meta.json
@@ -280,6 +280,8 @@
     "lineCount": 454,
     "axiomCount": 5,
     "theoremCount": 6,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos1129Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-113/meta.json
+++ b/src/data/proofs/erdos-113/meta.json
@@ -246,6 +246,8 @@
     "lineCount": 303,
     "axiomCount": 7,
     "theoremCount": 5,
-    "definitionCount": 14
+    "definitionCount": 14,
+    "path": "Proofs/Erdos113Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1130/meta.json
+++ b/src/data/proofs/erdos-1130/meta.json
@@ -163,7 +163,9 @@
     "lineCount": 154,
     "axiomCount": 1,
     "theoremCount": 5,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos1130Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-1131-oq-01/meta.json
+++ b/src/data/proofs/erdos-1131-oq-01/meta.json
@@ -134,7 +134,8 @@
         "type": "headline",
         "description": "Named wrapper for the strict lower bound theorem"
       }
-    ]
+    ],
+    "path": "Proofs/Erdos1131OQ01.lean"
   },
   "overview": {
     "title": "Variance Decomposition and Strict Lower Bound",

--- a/src/data/proofs/erdos-1131/meta.json
+++ b/src/data/proofs/erdos-1131/meta.json
@@ -203,6 +203,7 @@
     "axiomCount": 1,
     "theoremCount": 31,
     "definitionCount": 6,
-    "sorries": 2
+    "sorries": 2,
+    "path": "Proofs/Erdos1131Problem.lean"
   }
 }

--- a/src/data/proofs/erdos-1132/meta.json
+++ b/src/data/proofs/erdos-1132/meta.json
@@ -243,6 +243,8 @@
     "lineCount": 297,
     "axiomCount": 2,
     "theoremCount": 5,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos1132Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1133/meta.json
+++ b/src/data/proofs/erdos-1133/meta.json
@@ -282,6 +282,8 @@
     "lineCount": 195,
     "axiomCount": 1,
     "theoremCount": 2,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos1133Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1134/meta.json
+++ b/src/data/proofs/erdos-1134/meta.json
@@ -261,6 +261,8 @@
     "lineCount": 272,
     "axiomCount": 4,
     "theoremCount": 9,
-    "definitionCount": 15
+    "definitionCount": 15,
+    "path": "Proofs/Erdos1134Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1135/meta.json
+++ b/src/data/proofs/erdos-1135/meta.json
@@ -188,6 +188,8 @@
       "Mathlib.Tactic",
       "Mathlib.Data.Nat.Basic"
     ],
-    "opens": []
+    "opens": [],
+    "path": "Proofs/Erdos1135Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1138-oq-03/meta.json
+++ b/src/data/proofs/erdos-1138-oq-03/meta.json
@@ -178,7 +178,9 @@
     "lineCount": 228,
     "axiomCount": 1,
     "theoremCount": 12,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos1138OQ03.lean",
+    "sorries": 2
   },
   "references": [
     {

--- a/src/data/proofs/erdos-1138/meta.json
+++ b/src/data/proofs/erdos-1138/meta.json
@@ -190,6 +190,8 @@
     "lineCount": 227,
     "axiomCount": 0,
     "theoremCount": 20,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos1138Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1139/meta.json
+++ b/src/data/proofs/erdos-1139/meta.json
@@ -155,7 +155,9 @@
     "lineCount": 192,
     "axiomCount": 2,
     "theoremCount": 16,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos1139Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-114-oq-01/meta.json
+++ b/src/data/proofs/erdos-114-oq-01/meta.json
@@ -266,6 +266,8 @@
         "type": "proved",
         "description": "n ≤ 2 resolved"
       }
-    ]
+    ],
+    "path": "Proofs/Erdos114OQ01Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-114-oq-04/meta.json
+++ b/src/data/proofs/erdos-114-oq-04/meta.json
@@ -8,13 +8,26 @@
     "sourceUrl": "https://erdosproblems.com/114",
     "date": "1958 (Erdős; formalized 2026)",
     "status": "axiomatized",
-    "tags": ["complex-analysis", "polynomials", "lemniscates", "erdos"],
+    "tags": [
+      "complex-analysis",
+      "polynomials",
+      "lemniscates",
+      "erdos"
+    ],
     "proofRepoPath": "Proofs/Erdos114OQ04Problem.lean",
     "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
-      {"theorem": "Polynomial.eval", "description": "Polynomial evaluation", "module": "Mathlib.Algebra.Polynomial.Eval.Defs"},
-      {"theorem": "norm_eq_zero / norm_nonneg", "description": "Norm properties on ℂ", "module": "Mathlib.Analysis.Complex.Basic"}
+      {
+        "theorem": "Polynomial.eval",
+        "description": "Polynomial evaluation",
+        "module": "Mathlib.Algebra.Polynomial.Eval.Defs"
+      },
+      {
+        "theorem": "norm_eq_zero / norm_nonneg",
+        "description": "Norm properties on ℂ",
+        "module": "Mathlib.Analysis.Complex.Basic"
+      }
     ],
     "originalContributions": [
       "lemniscateSet: proper definition using Polynomial.eval and ‖·‖",
@@ -97,7 +110,34 @@
       "The main conjecture of Erdős #114 — that $z^n-1$ maximizes the arc length among monic degree-$n$ polynomials — remains unproved. Is there a variational or symmetry-based argument that could be formalized in Lean 4?"
     ]
   },
-  "crossReferences": [{"targetId": "erdos-114", "relationship": "extends", "description": "Parent proof with axiomatized lemniscate definitions"}],
-  "leanFile": {"imports": ["Mathlib.Analysis.Complex.Basic", "Mathlib.Algebra.Polynomial.Basic", "Mathlib.Algebra.Polynomial.Eval.Defs", "Mathlib.Tactic"], "namespace": "Erdos114OQ04", "lineCount": 177, "axiomCount": 1, "theoremCount": 10, "definitionCount": 5},
-  "references": [{"authors": "Erdős, Herzog, Piranian", "title": "Metric properties of polynomials", "year": "1958", "venue": "Journal d'Analyse Mathématique 6, pp. 125-148"}]
+  "crossReferences": [
+    {
+      "targetId": "erdos-114",
+      "relationship": "extends",
+      "description": "Parent proof with axiomatized lemniscate definitions"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Analysis.Complex.Basic",
+      "Mathlib.Algebra.Polynomial.Basic",
+      "Mathlib.Algebra.Polynomial.Eval.Defs",
+      "Mathlib.Tactic"
+    ],
+    "namespace": "Erdos114OQ04",
+    "lineCount": 177,
+    "axiomCount": 1,
+    "theoremCount": 10,
+    "definitionCount": 5,
+    "path": "Proofs/Erdos114OQ04Problem.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "Erdős, Herzog, Piranian",
+      "title": "Metric properties of polynomials",
+      "year": "1958",
+      "venue": "Journal d'Analyse Mathématique 6, pp. 125-148"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-114/meta.json
+++ b/src/data/proofs/erdos-114/meta.json
@@ -224,6 +224,8 @@
     "lineCount": 49,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/Erdos114Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1140/meta.json
+++ b/src/data/proofs/erdos-1140/meta.json
@@ -233,6 +233,8 @@
     "lineCount": 227,
     "axiomCount": 2,
     "theoremCount": 19,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos1140Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1141/meta.json
+++ b/src/data/proofs/erdos-1141/meta.json
@@ -277,6 +277,8 @@
     "lineCount": 202,
     "axiomCount": 1,
     "theoremCount": 35,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos1141Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1142/meta.json
+++ b/src/data/proofs/erdos-1142/meta.json
@@ -224,6 +224,8 @@
     "lineCount": 192,
     "axiomCount": 0,
     "theoremCount": 16,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos1142Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1143/meta.json
+++ b/src/data/proofs/erdos-1143/meta.json
@@ -166,7 +166,9 @@
     "lineCount": 299,
     "axiomCount": 2,
     "theoremCount": 11,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos1143Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-1144/meta.json
+++ b/src/data/proofs/erdos-1144/meta.json
@@ -214,6 +214,8 @@
     "lineCount": 226,
     "axiomCount": 1,
     "theoremCount": 16,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos1144Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1145/meta.json
+++ b/src/data/proofs/erdos-1145/meta.json
@@ -190,6 +190,8 @@
     "lineCount": 682,
     "axiomCount": 1,
     "theoremCount": 21,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos1145Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1146/meta.json
+++ b/src/data/proofs/erdos-1146/meta.json
@@ -232,6 +232,8 @@
     "lineCount": 287,
     "axiomCount": 2,
     "theoremCount": 13,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos1146Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1147/meta.json
+++ b/src/data/proofs/erdos-1147/meta.json
@@ -175,7 +175,9 @@
     "lineCount": 234,
     "axiomCount": 4,
     "theoremCount": 8,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos1147Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1148/meta.json
+++ b/src/data/proofs/erdos-1148/meta.json
@@ -215,6 +215,8 @@
     "lineCount": 355,
     "axiomCount": 1,
     "theoremCount": 31,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos1148Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1149/meta.json
+++ b/src/data/proofs/erdos-1149/meta.json
@@ -237,7 +237,8 @@
     "axiomCount": 2,
     "theoremCount": 16,
     "definitionCount": 5,
-    "sorries": 0
+    "sorries": 0,
+    "path": "Proofs/Erdos1149Problem.lean"
   },
   "references": [
     {

--- a/src/data/proofs/erdos-115-oq-01/meta.json
+++ b/src/data/proofs/erdos-115-oq-01/meta.json
@@ -107,6 +107,8 @@
   },
   "leanFile": {
     "axiomCount": 11,
-    "lineCount": 176
+    "lineCount": 176,
+    "path": "Proofs/Erdos115OQ01Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-115/meta.json
+++ b/src/data/proofs/erdos-115/meta.json
@@ -134,7 +134,9 @@
     "lineCount": 64,
     "axiomCount": 6,
     "theoremCount": 1,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/Erdos115Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-1150/meta.json
+++ b/src/data/proofs/erdos-1150/meta.json
@@ -168,7 +168,9 @@
     "lineCount": 342,
     "axiomCount": 2,
     "theoremCount": 8,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos1150Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1151/meta.json
+++ b/src/data/proofs/erdos-1151/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-1151",
-  "title": "Erd\u0151s Problem #1151: Limit Points of Lagrange Interpolation at Chebyshev Nodes",
+  "title": "Erdős Problem #1151: Limit Points of Lagrange Interpolation at Chebyshev Nodes",
   "slug": "erdos-1151",
   "description": "For Lagrange interpolation at Chebyshev nodes, prove that for any closed set A in [-1,1], there exists a continuous function f such that A is the set of limit points of the interpolation values.",
   "meta": {
-    "author": "Erd\u0151s (1941), V\u00e9rtesi (1999)",
+    "author": "Erdős (1941), Vértesi (1999)",
     "sourceUrl": "https://erdosproblems.com/1151",
     "date": "1941",
     "status": "axiomatized",
@@ -35,14 +35,14 @@
       }
     ],
     "originalContributions": [
-      "Formalization of Chebyshev nodes as cos((2k+1)\u03c0/(2n))",
+      "Formalization of Chebyshev nodes as cos((2k+1)π/(2n))",
       "Proof that Chebyshev nodes lie in [-1,1]",
       "Lagrange interpolation operator using basis polynomials",
       "Definition of limit point sets for sequences",
       "Formal statement of the full conjecture with special cases derived"
     ],
     "axiomCount": 2,
-    "assumptions": "2 axioms: erdos_1941_divergence (Erd\u0151s 1941 result on divergence at rational cosines), erdos_1151_conjecture (the open problem).",
+    "assumptions": "2 axioms: erdos_1941_divergence (Erdős 1941 result on divergence at rational cosines), erdos_1151_conjecture (the open problem).",
     "lineCount": 184,
     "prerequisites": [
       "Polynomial interpolation (Lagrange basis)",
@@ -52,7 +52,7 @@
   },
   "overview": {
     "historicalContext": "Lagrange interpolation has a troubled history: Runge (1901) famously showed that interpolation at equally-spaced nodes for f(x) = 1/(1+25x²) diverges as n → ∞, despite f being analytic. Chebyshev nodes were introduced precisely to avoid this: by placing nodes at the roots of the Chebyshev polynomials, the interpolation error for smooth functions is dramatically reduced. Chebyshev (1854) showed these nodes minimize the ∞-norm of the Lebesgue function among all choices of n nodes. However, Erdős (1941) proved something deeper and disturbing: even at Chebyshev nodes, Lagrange interpolation can diverge for continuous (not just analytic) functions. Specifically, for x = cos(πp/q) with odd p, q, there exists a continuous f whose interpolation values diverge to ∞. Erdős (1943) then claimed — without proof — that the limit-point behavior is completely flexible: any closed subset of [−1, 1] can arise as the set of limit points of 𝓛ⁿf(x) for some continuous f. This conjecture was listed as open by Vértesi in his 1999 problem compilation [Va99, Problem 2.41]. As of 2026, it remains unresolved.",
-    "problemStatement": "Prove that for any closed A \u2286 [-1,1] and suitable x, there exists continuous f such that A is the set of limit points of \ud835\udcdb\u207ff(x).",
+    "problemStatement": "Prove that for any closed A ⊆ [-1,1] and suitable x, there exists continuous f such that A is the set of limit points of 𝓛ⁿf(x).",
     "text": "We formalize the problem, defining Chebyshev nodes, Lagrange interpolation, and limit point sets.",
     "proofStrategy": "Define the mathematical objects and state the conjecture. Derive special cases from it.",
     "keyInsights": [
@@ -130,12 +130,12 @@
   "references": [
     {
       "key": "Er41",
-      "citation": "P. Erd\u0151s, On divergence properties of the Lagrange interpolation parabolas, Ann. of Math. 42 (1941), 309-315.",
+      "citation": "P. Erdős, On divergence properties of the Lagrange interpolation parabolas, Ann. of Math. 42 (1941), 309-315.",
       "url": ""
     },
     {
       "key": "Va99",
-      "citation": "P. V\u00e9rtesi, Problems on interpolation, Problem 2.41, 1999.",
+      "citation": "P. Vértesi, Problems on interpolation, Problem 2.41, 1999.",
       "url": ""
     }
   ],
@@ -155,6 +155,8 @@
     "lineCount": 184,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos1151Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1153/meta.json
+++ b/src/data/proofs/erdos-1153/meta.json
@@ -131,7 +131,9 @@
     "lineCount": 175,
     "axiomCount": 2,
     "theoremCount": 6,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos1153Problem.lean",
+    "sorries": 0
   },
   "references": [
     "Bernstein (1931): On the distribution of zeros of Lagrange interpolation polynomials",

--- a/src/data/proofs/erdos-1155-oq-01-oq-07/meta.json
+++ b/src/data/proofs/erdos-1155-oq-01-oq-07/meta.json
@@ -160,6 +160,8 @@
   ],
   "leanFile": {
     "axiomCount": 3,
-    "lineCount": 355
+    "lineCount": 355,
+    "path": "Proofs/Erdos1155OQ01OQ07.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1155-oq-01/meta.json
+++ b/src/data/proofs/erdos-1155-oq-01/meta.json
@@ -349,7 +349,9 @@
       "Filter",
       "SimpleGraph",
       "Finset"
-    ]
+    ],
+    "path": "Proofs/Erdos1155OQ01.lean",
+    "sorries": 0
   },
   "conclusion": {
     "summary": "This 489-line formalization fully proves 20 structural theorems (0 sorries) from 5 axioms, dissecting the precise gap between Bohman-Frieze-Lubetzky's $n^{3/2+o(1)}$ result and Erdős's conjectured $\\Theta(n^{3/2})$ for the triangle removal process. The central insight is that the conjecture is a compactness condition on the ratio $f(n)/n^{3/2}$: it holds if and only if this sequence has all its accumulation points in a bounded interval $(c_1, c_2) \\subset (0, \\infty)$, a topological reformulation more revealing than the original asymptotic statement. The decomposition into independent $O(n^{3/2})$ and $\\Omega(n^{3/2})$ bounds provides a practical research roadmap — proving either one-sided bound constitutes concrete progress toward the full conjecture. The strict hierarchy Conjecture $\\Rightarrow$ BFL $\\Rightarrow$ Grable quantifies how each known result relaxes multiplicative constant control, while the exact critical exponent characterization ($3/2 = \\inf\\{\\alpha : f(n) = O(n^\\alpha)\\}$) confirms BFL pinpointed the right scaling.",

--- a/src/data/proofs/erdos-1155/meta.json
+++ b/src/data/proofs/erdos-1155/meta.json
@@ -134,7 +134,9 @@
     "lineCount": 224,
     "axiomCount": 6,
     "theoremCount": 7,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos1155Problem.lean",
+    "sorries": 0
   },
   "references": [
     "Erdős: original problem",

--- a/src/data/proofs/erdos-1157/meta.json
+++ b/src/data/proofs/erdos-1157/meta.json
@@ -176,6 +176,8 @@
     "lineCount": 378,
     "axiomCount": 2,
     "theoremCount": 27,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos1157Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1158/meta.json
+++ b/src/data/proofs/erdos-1158/meta.json
@@ -181,7 +181,9 @@
     "lineCount": 306,
     "axiomCount": 2,
     "theoremCount": 7,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos1158Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1159/meta.json
+++ b/src/data/proofs/erdos-1159/meta.json
@@ -142,6 +142,8 @@
     "lineCount": 144,
     "axiomCount": 1,
     "theoremCount": 7,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos1159Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-116/meta.json
+++ b/src/data/proofs/erdos-116/meta.json
@@ -122,7 +122,9 @@
     "lineCount": 74,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos116Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1160/meta.json
+++ b/src/data/proofs/erdos-1160/meta.json
@@ -170,6 +170,8 @@
   ],
   "leanFile": {
     "lineCount": 329,
-    "axiomCount": 10
+    "axiomCount": 10,
+    "path": "Proofs/Erdos1160Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1161/meta.json
+++ b/src/data/proofs/erdos-1161/meta.json
@@ -146,7 +146,9 @@
     "lineCount": 324,
     "axiomCount": 0,
     "theoremCount": 14,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos1161Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-1162/meta.json
+++ b/src/data/proofs/erdos-1162/meta.json
@@ -208,6 +208,8 @@
     "lineCount": 221,
     "axiomCount": 1,
     "theoremCount": 4,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos1162Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1165/meta.json
+++ b/src/data/proofs/erdos-1165/meta.json
@@ -174,6 +174,7 @@
     "axiomCount": 5,
     "theoremCount": 5,
     "definitionCount": 2,
-    "sorries": 0
+    "sorries": 0,
+    "path": "Proofs/Erdos1165Problem.lean"
   }
 }

--- a/src/data/proofs/erdos-1166/meta.json
+++ b/src/data/proofs/erdos-1166/meta.json
@@ -211,7 +211,9 @@
     "lineCount": 547,
     "axiomCount": 3,
     "theoremCount": 23,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/Erdos1166Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1167/meta.json
+++ b/src/data/proofs/erdos-1167/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-1167",
-  "title": "Erd\u0151s Problem #1167: Stepping-Down Partition Relations",
+  "title": "Erdős Problem #1167: Stepping-Down Partition Relations",
   "slug": "erdos-1167",
-  "description": "For finite r \u2265 2, infinite cardinal \u03bb, and cardinals \u03ba_\u03b1 (for all \u03b1 < \u03b3), does 2^\u03bb \u2192 (\u03ba_\u03b1 + 1)^{r+1}_{\u03b1 < \u03b3} imply \u03bb \u2192 (\u03ba_\u03b1)^r_{\u03b1 < \u03b3}? A fundamental open question in infinitary combinatorics about transferring partition properties from higher to lower exponents.",
+  "description": "For finite r ≥ 2, infinite cardinal λ, and cardinals κ_α (for all α < γ), does 2^λ → (κ_α + 1)^{r+1}_{α < γ} imply λ → (κ_α)^r_{α < γ}? A fundamental open question in infinitary combinatorics about transferring partition properties from higher to lower exponents.",
   "meta": {
-    "author": "Erd\u0151s",
+    "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/1167",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1167Problem.lean",
@@ -26,7 +26,7 @@
     "mathlibDependencies": [
       {
         "theorem": "Cardinal.Basic",
-        "description": "Cardinal arithmetic including \u2135\u2080, cardinal addition, and Order.succ for successor cardinals",
+        "description": "Cardinal arithmetic including ℵ₀, cardinal addition, and Order.succ for successor cardinals",
         "module": "Mathlib.SetTheory.Cardinal.Basic"
       },
       {
@@ -73,13 +73,13 @@
     "assumptions": "2 axiom(s): erdos_1167_conjecture (OPEN), erdos_rado_theorem. The infinite Ramsey theorem (previously axiomatized) is now FULLY PROVED by induction on r using Ramsey's diagonal argument."
   },
   "overview": {
-    "historicalContext": "The partition calculus was founded by Erd\u0151s and Rado in their landmark 1956 paper 'A partition calculus in set theory', which systematized the study of Ramsey-type properties for infinite sets. The central achievement was the Erd\u0151s-Rado theorem: (2^\u03ba)\u207a \u2192 (\u03ba\u207a)\u00b2_\u03ba for infinite \u03ba, establishing that exponentially larger cardinals satisfy partition relations at the next level. This 'stepping-up' lemma \u2014 going from exponent r to r+1 \u2014 became a core technique.\n\nProblem #1167 asks the reverse question: can partition properties be 'stepped down' from exponent r+1 to r? Specifically, if 2^\u03bb \u2192 (\u03ba_\u03b1 + 1)^{r+1}_{\u03b1<\u03b3} holds, does \u03bb \u2192 (\u03ba_\u03b1)^r_{\u03b1<\u03b3} follow? The '+1' in the hypothesis accounts for the possibility of finite targets, where \u03ba+1 > \u03ba (for infinite \u03ba, \u03ba+1 = \u03ba by cardinal absorption). This question was posed by Erd\u0151s, Hajnal, and Rado in their foundational work, reflecting their deep interest in understanding the exact relationship between partition relations at different exponents.\n\nThe problem remains open nearly 70 years later. While the stepping-up direction is well understood, stepping down is fundamentally harder because it requires extracting structure from colorings of smaller subsets \u2014 a process that generally loses information. The problem is catalogued as [Va99, 7.79] in Vaughan's survey and connects to the broader program of understanding the partition calculus hierarchy, including problems #1169 and #1171 on ordinal partition relations.",
-    "problemStatement": "**Erd\u0151s Problem #1167** (Erd\u0151s-Hajnal-Rado):\n\nFor finite $r \\geq 2$, infinite cardinal $\\lambda$, and cardinals $\\kappa_\\alpha$ (for all $\\alpha < \\gamma$), does\n$$2^\\lambda \\to (\\kappa_\\alpha + 1)^{r+1}_{\\alpha < \\gamma}$$\nimply\n$$\\lambda \\to (\\kappa_\\alpha)^r_{\\alpha < \\gamma}?$$\n\nThe notation $\\kappa \\to (\\lambda_\\alpha)^r_{\\alpha < \\gamma}$ means: for every $\\gamma$-coloring of $r$-element subsets of $\\kappa$, there exist $\\alpha < \\gamma$ and $H \\subseteq \\kappa$ with $|H| \\geq \\lambda_\\alpha$ such that all $r$-element subsets of $H$ receive color $\\alpha$.\n\n**Status**: Open.",
-    "text": "For finite r \u2265 2, infinite cardinal \u03bb, and cardinals \u03ba_\u03b1 (for all \u03b1 < \u03b3), does 2^\u03bb \u2192 (\u03ba_\u03b1 + 1)^{r+1}_{\u03b1 < \u03b3} imply \u03bb \u2192 (\u03ba_\u03b1)^r_{\u03b1 < \u03b3}? A fundamental open question in infinitary combinatorics about transferring partition properties from higher to lower exponents.",
-    "proofStrategy": "The formalization builds partition relation infrastructure from scratch in 594 lines of Lean 4 code. It defines RSubset, Coloring, IsMonochromatic, PartitionRelation, and IndexedPartitionRelation using Lean's dependent types and Mathlib's cardinal/ordinal API. Five structural lemmas are fully proved. Cardinal arithmetic lemmas clarify the role of '+1'. The infinite Ramsey theorem (\u2135\u2080 \u2192 (\u2135\u2080)^r_k for all finite r, k) is FULLY PROVED by induction on r: base cases r=0 (unique 0-subset) and r=1 (infinite pigeonhole) are established first, then the inductive step uses Ramsey's diagonal argument \u2014 fixing a vertex, applying the IH to a reduced coloring on an infinite subset, iterating to build a sequence, and extracting an infinite monochromatic subsequence via pigeonhole. The key technical challenge is lifting between subtypes and the ambient type when applying the IH to subsets. The conjecture and Erd\u0151s-Rado theorem remain as the only 2 axioms.",
+    "historicalContext": "The partition calculus was founded by Erdős and Rado in their landmark 1956 paper 'A partition calculus in set theory', which systematized the study of Ramsey-type properties for infinite sets. The central achievement was the Erdős-Rado theorem: (2^κ)⁺ → (κ⁺)²_κ for infinite κ, establishing that exponentially larger cardinals satisfy partition relations at the next level. This 'stepping-up' lemma — going from exponent r to r+1 — became a core technique.\n\nProblem #1167 asks the reverse question: can partition properties be 'stepped down' from exponent r+1 to r? Specifically, if 2^λ → (κ_α + 1)^{r+1}_{α<γ} holds, does λ → (κ_α)^r_{α<γ} follow? The '+1' in the hypothesis accounts for the possibility of finite targets, where κ+1 > κ (for infinite κ, κ+1 = κ by cardinal absorption). This question was posed by Erdős, Hajnal, and Rado in their foundational work, reflecting their deep interest in understanding the exact relationship between partition relations at different exponents.\n\nThe problem remains open nearly 70 years later. While the stepping-up direction is well understood, stepping down is fundamentally harder because it requires extracting structure from colorings of smaller subsets — a process that generally loses information. The problem is catalogued as [Va99, 7.79] in Vaughan's survey and connects to the broader program of understanding the partition calculus hierarchy, including problems #1169 and #1171 on ordinal partition relations.",
+    "problemStatement": "**Erdős Problem #1167** (Erdős-Hajnal-Rado):\n\nFor finite $r \\geq 2$, infinite cardinal $\\lambda$, and cardinals $\\kappa_\\alpha$ (for all $\\alpha < \\gamma$), does\n$$2^\\lambda \\to (\\kappa_\\alpha + 1)^{r+1}_{\\alpha < \\gamma}$$\nimply\n$$\\lambda \\to (\\kappa_\\alpha)^r_{\\alpha < \\gamma}?$$\n\nThe notation $\\kappa \\to (\\lambda_\\alpha)^r_{\\alpha < \\gamma}$ means: for every $\\gamma$-coloring of $r$-element subsets of $\\kappa$, there exist $\\alpha < \\gamma$ and $H \\subseteq \\kappa$ with $|H| \\geq \\lambda_\\alpha$ such that all $r$-element subsets of $H$ receive color $\\alpha$.\n\n**Status**: Open.",
+    "text": "For finite r ≥ 2, infinite cardinal λ, and cardinals κ_α (for all α < γ), does 2^λ → (κ_α + 1)^{r+1}_{α < γ} imply λ → (κ_α)^r_{α < γ}? A fundamental open question in infinitary combinatorics about transferring partition properties from higher to lower exponents.",
+    "proofStrategy": "The formalization builds partition relation infrastructure from scratch in 594 lines of Lean 4 code. It defines RSubset, Coloring, IsMonochromatic, PartitionRelation, and IndexedPartitionRelation using Lean's dependent types and Mathlib's cardinal/ordinal API. Five structural lemmas are fully proved. Cardinal arithmetic lemmas clarify the role of '+1'. The infinite Ramsey theorem (ℵ₀ → (ℵ₀)^r_k for all finite r, k) is FULLY PROVED by induction on r: base cases r=0 (unique 0-subset) and r=1 (infinite pigeonhole) are established first, then the inductive step uses Ramsey's diagonal argument — fixing a vertex, applying the IH to a reduced coloring on an infinite subset, iterating to build a sequence, and extracting an infinite monochromatic subsequence via pigeonhole. The key technical challenge is lifting between subtypes and the ambient type when applying the IH to subsets. The conjecture and Erdős-Rado theorem remain as the only 2 axioms.",
     "keyInsights": [
-      "**Stepping up vs stepping down**: The Erd\u0151s-Rado theorem steps UP from exponent r to r+1, gaining a factor of 2^\u03ba in the source. The conjecture asks whether the reverse direction holds \u2014 stepping DOWN from r+1 to r while shrinking the source from 2^\u03bb to \u03bb. Stepping up is constructive (transfinite recursion builds the monochromatic set); stepping down requires showing that structure in (r+1)-colorings implies structure in r-colorings.",
-      "**The +1 dichotomy**: For infinite \u03ba_\u03b1, the '+1' is absorbed (\u03ba + 1 = \u03ba), so the conjecture reduces to whether 2^\u03bb \u2192 (\u03ba_\u03b1)^{r+1} implies \u03bb \u2192 (\u03ba_\u03b1)^r. For finite targets, \u03ba_\u03b1 + 1 > \u03ba_\u03b1 genuinely strengthens the hypothesis. The formalization explicitly proves this dichotomy with infinite_card_add_one and finite_card_add_one.",
+      "**Stepping up vs stepping down**: The Erdős-Rado theorem steps UP from exponent r to r+1, gaining a factor of 2^κ in the source. The conjecture asks whether the reverse direction holds — stepping DOWN from r+1 to r while shrinking the source from 2^λ to λ. Stepping up is constructive (transfinite recursion builds the monochromatic set); stepping down requires showing that structure in (r+1)-colorings implies structure in r-colorings.",
+      "**The +1 dichotomy**: For infinite κ_α, the '+1' is absorbed (κ + 1 = κ), so the conjecture reduces to whether 2^λ → (κ_α)^{r+1} implies λ → (κ_α)^r. For finite targets, κ_α + 1 > κ_α genuinely strengthens the hypothesis. The formalization explicitly proves this dichotomy with infinite_card_add_one and finite_card_add_one.",
       "**Building partition calculus in Lean 4**: The formalization constructs the full partition relation machinery from Finset and Cardinal, using dependent subtypes for r-element subsets and universal quantification over types to handle cardinal arithmetic in a universe-polymorphic way.",
       "**Full proof of the infinite Ramsey theorem**: The infinite Ramsey theorem is proved from first principles by induction on r, using Ramsey's diagonal argument in the inductive step. The proof constructs a sequence of vertices and colors by iteratively fixing a vertex, reducing the coloring, and applying the IH. Pigeonhole on the color sequence extracts an infinite monochromatic subsequence. The key challenge is the subtype lifting: applying the IH to infinite subsets requires embedding the reduced coloring on a subtype, applying the IH, and then transferring the monochromatic set back to the ambient type.",
       "**70 years unsolved**: Posed in 1956, this is among the longest-standing open problems in infinite combinatorics. The difficulty reflects the fundamental asymmetry between stepping up (constructive) and stepping down (requires information-theoretic arguments about colorings)."
@@ -97,14 +97,14 @@
       "title": "Problem Statement and Imports",
       "startLine": 1,
       "endLine": 52,
-      "summary": "Documentation header describing the stepping-down conjecture, its background in partition calculus, known partial results (Erd\u0151s-Rado, infinite Ramsey), and imports from Mathlib for cardinal/ordinal theory and tactics."
+      "summary": "Documentation header describing the stepping-down conjecture, its background in partition calculus, known partial results (Erdős-Rado, infinite Ramsey), and imports from Mathlib for cardinal/ordinal theory and tactics."
     },
     {
       "id": "core-defs",
       "title": "Core Definitions",
       "startLine": 53,
       "endLine": 91,
-      "summary": "Defines RSubset (r-element subsets), Coloring (functions from r-subsets to colors), IsMonochromatic (uniformity of color), PartitionRelation (uniform \u03ba \u2192 (\u03bb)^r_\u03b3), and IndexedPartitionRelation (indexed \u03ba \u2192 (\u03ba_i)^r_{i<\u03b3})."
+      "summary": "Defines RSubset (r-element subsets), Coloring (functions from r-subsets to colors), IsMonochromatic (uniformity of color), PartitionRelation (uniform κ → (λ)^r_γ), and IndexedPartitionRelation (indexed κ → (κ_i)^r_{i<γ})."
     },
     {
       "id": "structural-props",
@@ -118,21 +118,21 @@
       "title": "Cardinal Arithmetic for Partition Relations",
       "startLine": 162,
       "endLine": 209,
-      "summary": "Proves infinite_card_add_one (\u03ba+1=\u03ba for infinite \u03ba), finite_card_add_one (n+1 genuinely larger), conjecture_simplifies_infinite_targets (+1 absorbed for infinite targets), and two_pow_infinite (2^\u03bb \u2265 \u2135\u2080)."
+      "summary": "Proves infinite_card_add_one (κ+1=κ for infinite κ), finite_card_add_one (n+1 genuinely larger), conjecture_simplifies_infinite_targets (+1 absorbed for infinite targets), and two_pow_infinite (2^λ ≥ ℵ₀)."
     },
     {
       "id": "conjecture-and-results",
       "title": "The Conjecture and Known Results",
       "startLine": 210,
       "endLine": 245,
-      "summary": "States the open conjecture as an axiom (erdos_1167_conjecture). Axiomatizes the infinite Ramsey theorem (\u2135\u2080 \u2192 (\u2135\u2080)^r_k) and the Erd\u0151s-Rado theorem ((2^\u03ba)\u207a \u2192 (\u03ba\u207a)\u00b2_\u03ba) as reference points."
+      "summary": "States the open conjecture as an axiom (erdos_1167_conjecture). Axiomatizes the infinite Ramsey theorem (ℵ₀ → (ℵ₀)^r_k) and the Erdős-Rado theorem ((2^κ)⁺ → (κ⁺)²_κ) as reference points."
     },
     {
       "id": "consequences",
       "title": "Consequences and Consistency Checks",
       "startLine": 246,
       "endLine": 289,
-      "summary": "Proves the r=2 case instantiation, general r case, consistency with Ramsey (pairs, triples), and Erd\u0151s-Rado weakening via target monotonicity."
+      "summary": "Proves the r=2 case instantiation, general r case, consistency with Ramsey (pairs, triples), and Erdős-Rado weakening via target monotonicity."
     },
     {
       "id": "provable-ramsey",
@@ -143,14 +143,14 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erd\u0151s Problem #1167 \u2014 the stepping-down conjecture for partition relations \u2014 in 594 lines of Lean 4 code with only 2 axioms (the OPEN conjecture and the Erd\u0151s-Rado theorem) and 19 theorems. The infinite Ramsey theorem (\u2135\u2080 \u2192 (\u2135\u2080)^r_k for all finite r, k) is FULLY PROVED by induction on r using Ramsey's diagonal argument, eliminating the previous axiom. This is a significant advancement: the formalization now proves a major classical result of infinite combinatorics from first principles.",
+    "summary": "This formalization captures Erdős Problem #1167 — the stepping-down conjecture for partition relations — in 594 lines of Lean 4 code with only 2 axioms (the OPEN conjecture and the Erdős-Rado theorem) and 19 theorems. The infinite Ramsey theorem (ℵ₀ → (ℵ₀)^r_k for all finite r, k) is FULLY PROVED by induction on r using Ramsey's diagonal argument, eliminating the previous axiom. This is a significant advancement: the formalization now proves a major classical result of infinite combinatorics from first principles.",
     "implications": "Resolving this conjecture would establish a fundamental duality in partition calculus: the stepping-up lemma and a stepping-down lemma would together give a complete picture of how partition properties transfer between consecutive exponents. A positive resolution would provide a powerful tool for deriving partition relations at lower exponents from known results at higher exponents, potentially simplifying many arguments in infinite combinatorics.",
     "openQuestions": [
       "Does the stepping-down implication hold in ZFC, or is it independent of the standard axioms?",
-      "Can the conjecture be proved for the special case r=2, \u03b3=2 (two colors, pairs-to-triples)?",
-      "What is the relationship between this conjecture and the stepping-up lemma \u2014 is there a formal duality?",
-      "Can the Erd\u0151s-Rado theorem ((2^\u03ba)\u207a \u2192 (\u03ba\u207a)\u00b2_\u03ba) be proved in Lean 4? This is the only remaining axiomatized known result, requiring a formalization of transfinite recursion on ordinals.",
-      "Does a counterexample exist for specific choices of \u03bb, r, \u03b3, and targets?"
+      "Can the conjecture be proved for the special case r=2, γ=2 (two colors, pairs-to-triples)?",
+      "What is the relationship between this conjecture and the stepping-up lemma — is there a formal duality?",
+      "Can the Erdős-Rado theorem ((2^κ)⁺ → (κ⁺)²_κ) be proved in Lean 4? This is the only remaining axiomatized known result, requiring a formalization of transfinite recursion on ordinals.",
+      "Does a counterexample exist for specific choices of λ, r, γ, and targets?"
     ]
   },
   "leanFile": {
@@ -167,12 +167,14 @@
     "lineCount": 594,
     "axiomCount": 2,
     "theoremCount": 19,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos1167Problem.lean",
+    "sorries": 0
   },
   "references": [
-    "Erd\u0151s, Hajnal, Rado (1956): A partition calculus in set theory \u2014 original problem formulation",
-    "Ramsey (1929): On a problem of formal logic \u2014 finite Ramsey theorem",
-    "Erd\u0151s, Rado (1956): (2^\u03ba)\u207a \u2192 (\u03ba\u207a)\u00b2_\u03ba \u2014 the classical stepping-up result",
+    "Erdős, Hajnal, Rado (1956): A partition calculus in set theory — original problem formulation",
+    "Ramsey (1929): On a problem of formal logic — finite Ramsey theorem",
+    "Erdős, Rado (1956): (2^κ)⁺ → (κ⁺)²_κ — the classical stepping-up result",
     "[Va99, 7.79]: Vaughan's survey cataloguing the problem",
     "https://erdosproblems.com/1167"
   ],
@@ -180,17 +182,17 @@
     {
       "targetId": "erdos-1169",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: combinatorics, open, ramsey-theory, set-theory"
+      "description": "Related Erdős problem sharing themes: combinatorics, open, ramsey-theory, set-theory"
     },
     {
       "targetId": "erdos-1171",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: combinatorics, open, ramsey-theory, set-theory"
+      "description": "Related Erdős problem sharing themes: combinatorics, open, ramsey-theory, set-theory"
     },
     {
       "targetId": "erdos-1172",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: combinatorics, open, ramsey-theory, set-theory"
+      "description": "Related Erdős problem sharing themes: combinatorics, open, ramsey-theory, set-theory"
     }
   ]
 }

--- a/src/data/proofs/erdos-1168/meta.json
+++ b/src/data/proofs/erdos-1168/meta.json
@@ -90,6 +90,8 @@
   },
   "leanFile": {
     "lineCount": 153,
-    "axiomCount": 1
+    "axiomCount": 1,
+    "path": "Proofs/Erdos1168Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1169/meta.json
+++ b/src/data/proofs/erdos-1169/meta.json
@@ -1,214 +1,216 @@
 {
-    "id": "erdos-1169",
-    "title": "Erdős Problem #1169: Partition Relations for ω₁²",
-    "slug": "erdos-1169",
-    "description": "Does ω₁² → (ω₁², 3)² hold (in ZFC)?",
-    "meta": {
-        "author": "Erdős",
-        "sourceUrl": "https://erdosproblems.com/1169",
-        "status": "axiomatized",
-        "proofRepoPath": "Proofs/Erdos1169Problem.lean",
-        "tags": [
-            "erdos",
-            "set-theory",
-            "combinatorics",
-            "ramsey-theory",
-            "graph-theory",
-            "open"
-        ],
-        "badge": "axiom",
-        "sorries": 0,
-        "erdosNumber": 1169,
-        "erdosUrl": "https://erdosproblems.com/1169",
-        "erdosProblemStatus": "open",
-        "mathlib_version": "4.26.0",
-        "mathlibDependencies": [
-            {
-                "theorem": "Arithmetic",
-                "description": "From Mathlib.SetTheory.Ordinal.Arithmetic",
-                "module": "Mathlib.SetTheory.Ordinal.Arithmetic"
-            },
-            {
-                "theorem": "Basic",
-                "description": "From Mathlib.SetTheory.Cardinal.Basic",
-                "module": "Mathlib.SetTheory.Cardinal.Basic"
-            },
-            {
-                "theorem": "Ordinal",
-                "description": "From Mathlib.SetTheory.Cardinal.Ordinal",
-                "module": "Mathlib.SetTheory.Cardinal.Ordinal"
-            },
-            {
-                "theorem": "Tactic",
-                "description": "From Mathlib.Tactic",
-                "module": "Mathlib.Tactic"
-            }
-        ],
-        "originalContributions": [
-            "ordinalPartitionRel",
-            "negPartitionRel",
-            "omega1",
-            "omega1Sq",
-            "omega1_uncountable",
-            "omega1Sq_card",
-            "erdos_1169_statement",
-            "CH",
-            "hajnal_ch_implies_partition",
-            "erdos_1169_under_ch",
-            "erdos_1169_not_disprovable",
-            "erdos_1169_open_in_zfc",
-            "partition_monotone_clique",
-            "partition_monotone_ordinal",
-            "erdos_1169_implies_pairs"
-        ],
-        "axiomCount": 1,
-        "lineCount": 225,
-        "assumptions": "1 axiom: hajnal_ch_implies_partition (CH implies ω₁²→(ω₁²,3)²). ordinalPartitionRel and partition_monotone_clique are now proved definitions/theorems."
-    },
-    "overview": {
-        "historicalContext": "Erdős Problem #1169 belongs to the partition calculus, a branch of combinatorial set theory developed by Erdős and Hajnal starting in the 1950s. The partition calculus extends Ramsey's theorem (1930) — which concerns finite colorings of finite sets — to the transfinite setting, asking when colorings of pairs from infinite well-ordered sets must contain large homogeneous subsets.\n\nThe specific question $\\omega_1^2 \\to (\\omega_1^2, 3)^2$ asks: must every 2-coloring of pairs from a set of order type $\\omega_1^2$ (where $\\omega_1$ is the first uncountable ordinal) contain either a monochromatic subset of the same order type $\\omega_1^2$ or a monochromatic triangle? This is a natural question in the hierarchy of ordinal partition relations, sitting between the well-understood countable case and the general uncountable theory.\n\nThe key partial result is due to András Hajnal, who proved the partition relation holds under the Continuum Hypothesis (CH). Hajnal's proof uses the diamond principle $\\Diamond$ (a combinatorial consequence of CH established by Jensen) to construct the required homogeneous sets. Remarkably, Hajnal proves the stronger result $\\omega_1^2 \\to (\\omega_1^2, k)^2$ for ALL finite $k$, not just $k = 3$. Since CH is consistent with ZFC (Gödel 1940), this shows the negative relation cannot be proved from ZFC alone. However, it remains open whether the positive relation is provable from ZFC without assuming CH.\n\nThe problem connects to several other Erdős problems: #592 asks the countable analogue (for which countable $\\beta$ does $\\omega^\\beta \\to (\\omega^\\beta, 3)^2$ hold?), and #118 asks whether $\\alpha \\to (\\alpha, 3)^2$ implies $\\alpha \\to (\\alpha, n)^2$ for all $n$ (disproved by Schipperus and Darby in 1999, though Hajnal's result shows this implication holds for $\\omega_1^2$ under CH). The problem is referenced as [Va99, 7.85].",
-        "problemStatement": "Does $\\omega_1^2 \\to (\\omega_1^2, 3)^2$ hold in ZFC? That is, for every 2-coloring $f: [\\omega_1^2]^2 \\to \\{0, 1\\}$, must there exist either a subset $H \\subseteq \\omega_1^2$ of order type $\\omega_1^2$ with $f''[H]^2 = \\{0\\}$, or a set $K \\subseteq \\omega_1^2$ with $|K| = 3$ and $f''[K]^2 = \\{1\\}$?",
-        "text": "Does ω₁² → (ω₁², 3)² hold (in ZFC)?",
-        "proofStrategy": "The formalization axiomatizes the ordinal partition relation $\\alpha \\to (\\beta, k)^2$ and builds the problem statement from the key ordinals $\\omega_1 = \\mathrm{ord}(\\aleph_1)$ and $\\omega_1^2 = \\omega_1 \\cdot \\omega_1$. The core result is Hajnal's CH-conditional theorem, axiomatized as `hajnal_ch_implies_partition`, from which `erdos_1169_under_ch` derives the specific $k = 3$ case via `norm_num`. Monotonicity properties are axiomatized to derive consequences (e.g., the relation for pairs follows from triangles). The metamathematical status is captured via `erdos_1169_not_disprovable` (consistency with ZFC) and `erdos_1169_open_in_zfc` (excluded middle, encoding that the ZFC status is unresolved).",
-        "keyInsights": [
-            "The problem is **solved under CH but open in ZFC**: Hajnal proved $\\omega_1^2 \\to (\\omega_1^2, k)^2$ for all finite $k$ assuming CH, using the diamond principle $\\Diamond$. This gives consistency but not provability from ZFC alone.",
-            "Hajnal's result is **stronger than needed**: it proves the partition relation for ALL finite clique sizes $k \\geq 2$, not just $k = 3$. This answers the analogue of Problem #118 positively for $\\omega_1^2$ under CH.",
-            "The **diamond principle** $\\Diamond$ (Jensen, from CH) is the key set-theoretic tool: it provides a 'prediction' sequence that guides the construction of homogeneous sets in the partition argument.",
-            "The ordinal $\\omega_1^2$ has **richer order structure** than $\\omega_1$ despite having the same cardinality $\\aleph_1$. It consists of $\\omega_1$-many copies of $\\omega_1$ in sequence, and this structure is essential for the partition relation to potentially hold.",
-            "The problem sits at the **boundary of independence**: results that hold under CH but whose ZFC status is open often turn out to be independent. Whether $\\omega_1^2 \\to (\\omega_1^2, 3)^2$ is independent of ZFC (like the Continuum Hypothesis itself) is a major open question."
-        ],
-        "prerequisites": [
-            "Combinatorics and number theory",
-            "Set theory and cardinality",
-            "Combinatorics (counting, extremal problems)",
-            "Ramsey theory (partition regularity)",
-            "Graph theory (vertices, edges, colorings)"
-        ]
-    },
-    "sections": [
-        {
-            "id": "header-and-imports",
-            "title": "Problem Statement and Imports",
-            "startLine": 1,
-            "endLine": 37,
-            "summary": "Documents the problem, known results (Hajnal under CH, consistency, open in ZFC), related problems (#592, #118), and imports Mathlib ordinal/cardinal modules.",
-            "mathContext": "Mathematical content: Documents the problem, known results (Hajnal under CH, consistency, open in ZFC), related problems (#592, #118), and imports Mathlib ordinal/cardinal modules."
-        },
-        {
-            "id": "partition-relations",
-            "title": "Ordinal Partition Relations",
-            "startLine": 38,
-            "endLine": 56,
-            "summary": "Axiomatizes the ordinal partition relation $\\alpha \\to (\\beta, k)^2$ and defines its negation $\\alpha \\not\\to (\\beta, k)^2$.",
-            "mathContext": "Axiomatizes the ordinal partition relation $\\$\\alpha$ \\to (\\$\\beta$, k)^2$ and defines its negation $\\$\\alpha$ \\not\\to (\\$\\beta$, k)^2$."
-        },
-        {
-            "id": "key-ordinals",
-            "title": "Key Ordinals: $\\omega_1$ and $\\omega_1^2$",
-            "startLine": 57,
-            "endLine": 73,
-            "summary": "Defines $\\omega_1 = \\mathrm{ord}(\\aleph_1)$ and $\\omega_1^2 = \\omega_1 \\cdot \\omega_1$, with axioms for uncountability and cardinality.",
-            "mathContext": "Formal definition: Defines $\\omega_1 = \\mathrm{ord}(\\aleph_1)$ and $\\omega_1^2 = \\omega_1 \\cdot \\omega_1$, with axioms for uncountability and cardinality."
-        },
-        {
-            "id": "problem-statement",
-            "title": "The Main Problem Statement",
-            "startLine": 74,
-            "endLine": 85,
-            "summary": "Defines `erdos_1169_statement` as the partition relation $\\omega_1^2 \\to (\\omega_1^2, 3)^2$.",
-            "mathContext": "Formal definition: Defines `erdos_1169_statement` as the partition relation $\\omega_1^2 \\to (\\omega_1^2, 3)^2$."
-        },
-        {
-            "id": "hajnal-ch",
-            "title": "Hajnal's CH-Conditional Result",
-            "startLine": 86,
-            "endLine": 106,
-            "summary": "Defines CH ($2^{\\aleph_0} = \\aleph_1$), axiomatizes Hajnal's theorem that CH implies $\\omega_1^2 \\to (\\omega_1^2, k)^2$ for all $k$, and derives the $k = 3$ case.",
-            "mathContext": "Defines CH ($$$2^{{\\aleph_0}$}$ = \\aleph_1$), axiomatizes Hajnal's theorem that CH implies $\\omega_1^2 \\to (\\omega_1^2, k)^2$ for all $k$, and derives the $k = 3$ case."
-        },
-        {
-            "id": "independence",
-            "title": "Independence and Consistency",
-            "startLine": 107,
-            "endLine": 123,
-            "summary": "Captures the metamathematical status: the problem is not disprovable (consistent via CH models) and the ZFC status remains open.",
-            "mathContext": "Mathematical content: Captures the metamathematical status: the problem is not disprovable (consistent via CH models) and the ZFC status remains open."
-        },
-        {
-            "id": "monotonicity",
-            "title": "Monotonicity Properties",
-            "startLine": 124,
-            "endLine": 145,
-            "summary": "Axiomatizes monotonicity in the clique and ordinal parameters, and derives that the partition relation for pairs follows from triangles.",
-            "mathContext": "Axiomatized: Axiomatizes monotonicity in the clique and ordinal parameters, and derives that the partition relation for pairs follows from triangles."
-        },
-        {
-            "id": "connections",
-            "title": "Connections to Problems #592 and #118",
-            "startLine": 146,
-            "endLine": 165,
-            "summary": "Links to Problem #592 (countable analogue via Specker's theorem) and Problem #118 (clique extension, disproved in general but true for $\\omega_1^2$ under CH).",
-            "mathContext": "Verified: Links to Problem #592 (countable analogue via Specker's theorem) and Problem #118 (clique extension, disproved in general but true for $\\omega_1^2$ under CH)."
-        },
-        {
-            "id": "omega1-properties",
-            "title": "Basic Properties of $\\omega_1$",
-            "startLine": 166,
-            "endLine": 178,
-            "summary": "Axiomatizes that $\\omega_1$ is a limit ordinal, $\\omega < \\omega_1$, and $\\omega_1$ is regular (cofinality equals itself).",
-            "mathContext": "Axiomatized: Axiomatizes that $\\omega_1$ is a limit ordinal, $\\omega < \\omega_1$, and $\\omega_1$ is regular (cofinality equals itself)."
-        },
-        {
-            "id": "summary",
-            "title": "Summary of Formalization",
-            "startLine": 179,
-            "endLine": 218,
-            "summary": "Recaps the formalization: 12 axioms, 3 proved theorems, open in ZFC, solved under CH, and connections to related problems.",
-            "mathContext": "Verified: Recaps the formalization: 12 axioms, 3 proved theorems, open in ZFC, solved under CH, and connections to related problems."
-        }
+  "id": "erdos-1169",
+  "title": "Erdős Problem #1169: Partition Relations for ω₁²",
+  "slug": "erdos-1169",
+  "description": "Does ω₁² → (ω₁², 3)² hold (in ZFC)?",
+  "meta": {
+    "author": "Erdős",
+    "sourceUrl": "https://erdosproblems.com/1169",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos1169Problem.lean",
+    "tags": [
+      "erdos",
+      "set-theory",
+      "combinatorics",
+      "ramsey-theory",
+      "graph-theory",
+      "open"
     ],
-    "conclusion": {
-        "summary": "This formalization captures the full structure of Erdős Problem #1169, an open problem in ordinal partition calculus asking whether $\\omega_1^2 \\to (\\omega_1^2, 3)^2$ holds in ZFC. The formalization includes the problem statement, Hajnal's CH-conditional proof, the metamathematical independence status, monotonicity consequences, and connections to related Erdős problems (#592, #118).",
-        "implications": "The formalization demonstrates how open problems at the boundary of set-theoretic independence can be precisely captured in Lean 4. The axiomatization cleanly separates what is known (Hajnal's CH result, consistency) from what is open (the ZFC status), and the proof of `erdos_1169_under_ch` from `hajnal_ch_implies_partition` shows how conditional results can be formally derived.",
-        "openQuestions": [
-            "Is $\\omega_1^2 \\to (\\omega_1^2, 3)^2$ provable from ZFC alone, or is it independent?",
-            "Does the negation $\\omega_1^2 \\not\\to (\\omega_1^2, 3)^2$ hold in some model of ZFC + $\\neg$CH?",
-            "Can Hajnal's proof be carried out without the full strength of CH — does Martin's Axiom or PFA suffice?",
-            "Can the ordinal partition relation be fully formalized in Lean 4 using Mathlib's ordinal and coloring theory, replacing the axiomatization?"
-        ]
-    },
-    "leanFile": {
-        "imports": [
-            "Mathlib.SetTheory.Ordinal.Arithmetic",
-            "Mathlib.SetTheory.Cardinal.Basic",
-            "Mathlib.SetTheory.Cardinal.Ordinal",
-            "Mathlib.Tactic"
-        ],
-        "opens": [
-            "Cardinal",
-            "Ordinal"
-        ],
-        "namespace": null,
-        "lineCount": 225,
-        "axiomCount": 1,
-        "theoremCount": 3,
-        "definitionCount": 5
-    },
-    "crossReferences": [
-        {
-            "targetId": "erdos-1174",
-            "relationship": "related",
-            "description": "Related Erdős problem sharing themes: combinatorics, graph-theory, open, ramsey-theory, set-theory"
-        },
-        {
-            "targetId": "erdos-1176",
-            "relationship": "related",
-            "description": "Related Erdős problem sharing themes: combinatorics, graph-theory, open, ramsey-theory, set-theory"
-        },
-        {
-            "targetId": "erdos-1014",
-            "relationship": "related",
-            "description": "Related Erdős problem sharing themes: combinatorics, graph-theory, open, ramsey-theory"
-        }
+    "badge": "axiom",
+    "sorries": 0,
+    "erdosNumber": 1169,
+    "erdosUrl": "https://erdosproblems.com/1169",
+    "erdosProblemStatus": "open",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Arithmetic",
+        "description": "From Mathlib.SetTheory.Ordinal.Arithmetic",
+        "module": "Mathlib.SetTheory.Ordinal.Arithmetic"
+      },
+      {
+        "theorem": "Basic",
+        "description": "From Mathlib.SetTheory.Cardinal.Basic",
+        "module": "Mathlib.SetTheory.Cardinal.Basic"
+      },
+      {
+        "theorem": "Ordinal",
+        "description": "From Mathlib.SetTheory.Cardinal.Ordinal",
+        "module": "Mathlib.SetTheory.Cardinal.Ordinal"
+      },
+      {
+        "theorem": "Tactic",
+        "description": "From Mathlib.Tactic",
+        "module": "Mathlib.Tactic"
+      }
+    ],
+    "originalContributions": [
+      "ordinalPartitionRel",
+      "negPartitionRel",
+      "omega1",
+      "omega1Sq",
+      "omega1_uncountable",
+      "omega1Sq_card",
+      "erdos_1169_statement",
+      "CH",
+      "hajnal_ch_implies_partition",
+      "erdos_1169_under_ch",
+      "erdos_1169_not_disprovable",
+      "erdos_1169_open_in_zfc",
+      "partition_monotone_clique",
+      "partition_monotone_ordinal",
+      "erdos_1169_implies_pairs"
+    ],
+    "axiomCount": 1,
+    "lineCount": 225,
+    "assumptions": "1 axiom: hajnal_ch_implies_partition (CH implies ω₁²→(ω₁²,3)²). ordinalPartitionRel and partition_monotone_clique are now proved definitions/theorems."
+  },
+  "overview": {
+    "historicalContext": "Erdős Problem #1169 belongs to the partition calculus, a branch of combinatorial set theory developed by Erdős and Hajnal starting in the 1950s. The partition calculus extends Ramsey's theorem (1930) — which concerns finite colorings of finite sets — to the transfinite setting, asking when colorings of pairs from infinite well-ordered sets must contain large homogeneous subsets.\n\nThe specific question $\\omega_1^2 \\to (\\omega_1^2, 3)^2$ asks: must every 2-coloring of pairs from a set of order type $\\omega_1^2$ (where $\\omega_1$ is the first uncountable ordinal) contain either a monochromatic subset of the same order type $\\omega_1^2$ or a monochromatic triangle? This is a natural question in the hierarchy of ordinal partition relations, sitting between the well-understood countable case and the general uncountable theory.\n\nThe key partial result is due to András Hajnal, who proved the partition relation holds under the Continuum Hypothesis (CH). Hajnal's proof uses the diamond principle $\\Diamond$ (a combinatorial consequence of CH established by Jensen) to construct the required homogeneous sets. Remarkably, Hajnal proves the stronger result $\\omega_1^2 \\to (\\omega_1^2, k)^2$ for ALL finite $k$, not just $k = 3$. Since CH is consistent with ZFC (Gödel 1940), this shows the negative relation cannot be proved from ZFC alone. However, it remains open whether the positive relation is provable from ZFC without assuming CH.\n\nThe problem connects to several other Erdős problems: #592 asks the countable analogue (for which countable $\\beta$ does $\\omega^\\beta \\to (\\omega^\\beta, 3)^2$ hold?), and #118 asks whether $\\alpha \\to (\\alpha, 3)^2$ implies $\\alpha \\to (\\alpha, n)^2$ for all $n$ (disproved by Schipperus and Darby in 1999, though Hajnal's result shows this implication holds for $\\omega_1^2$ under CH). The problem is referenced as [Va99, 7.85].",
+    "problemStatement": "Does $\\omega_1^2 \\to (\\omega_1^2, 3)^2$ hold in ZFC? That is, for every 2-coloring $f: [\\omega_1^2]^2 \\to \\{0, 1\\}$, must there exist either a subset $H \\subseteq \\omega_1^2$ of order type $\\omega_1^2$ with $f''[H]^2 = \\{0\\}$, or a set $K \\subseteq \\omega_1^2$ with $|K| = 3$ and $f''[K]^2 = \\{1\\}$?",
+    "text": "Does ω₁² → (ω₁², 3)² hold (in ZFC)?",
+    "proofStrategy": "The formalization axiomatizes the ordinal partition relation $\\alpha \\to (\\beta, k)^2$ and builds the problem statement from the key ordinals $\\omega_1 = \\mathrm{ord}(\\aleph_1)$ and $\\omega_1^2 = \\omega_1 \\cdot \\omega_1$. The core result is Hajnal's CH-conditional theorem, axiomatized as `hajnal_ch_implies_partition`, from which `erdos_1169_under_ch` derives the specific $k = 3$ case via `norm_num`. Monotonicity properties are axiomatized to derive consequences (e.g., the relation for pairs follows from triangles). The metamathematical status is captured via `erdos_1169_not_disprovable` (consistency with ZFC) and `erdos_1169_open_in_zfc` (excluded middle, encoding that the ZFC status is unresolved).",
+    "keyInsights": [
+      "The problem is **solved under CH but open in ZFC**: Hajnal proved $\\omega_1^2 \\to (\\omega_1^2, k)^2$ for all finite $k$ assuming CH, using the diamond principle $\\Diamond$. This gives consistency but not provability from ZFC alone.",
+      "Hajnal's result is **stronger than needed**: it proves the partition relation for ALL finite clique sizes $k \\geq 2$, not just $k = 3$. This answers the analogue of Problem #118 positively for $\\omega_1^2$ under CH.",
+      "The **diamond principle** $\\Diamond$ (Jensen, from CH) is the key set-theoretic tool: it provides a 'prediction' sequence that guides the construction of homogeneous sets in the partition argument.",
+      "The ordinal $\\omega_1^2$ has **richer order structure** than $\\omega_1$ despite having the same cardinality $\\aleph_1$. It consists of $\\omega_1$-many copies of $\\omega_1$ in sequence, and this structure is essential for the partition relation to potentially hold.",
+      "The problem sits at the **boundary of independence**: results that hold under CH but whose ZFC status is open often turn out to be independent. Whether $\\omega_1^2 \\to (\\omega_1^2, 3)^2$ is independent of ZFC (like the Continuum Hypothesis itself) is a major open question."
+    ],
+    "prerequisites": [
+      "Combinatorics and number theory",
+      "Set theory and cardinality",
+      "Combinatorics (counting, extremal problems)",
+      "Ramsey theory (partition regularity)",
+      "Graph theory (vertices, edges, colorings)"
     ]
+  },
+  "sections": [
+    {
+      "id": "header-and-imports",
+      "title": "Problem Statement and Imports",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "Documents the problem, known results (Hajnal under CH, consistency, open in ZFC), related problems (#592, #118), and imports Mathlib ordinal/cardinal modules.",
+      "mathContext": "Mathematical content: Documents the problem, known results (Hajnal under CH, consistency, open in ZFC), related problems (#592, #118), and imports Mathlib ordinal/cardinal modules."
+    },
+    {
+      "id": "partition-relations",
+      "title": "Ordinal Partition Relations",
+      "startLine": 38,
+      "endLine": 56,
+      "summary": "Axiomatizes the ordinal partition relation $\\alpha \\to (\\beta, k)^2$ and defines its negation $\\alpha \\not\\to (\\beta, k)^2$.",
+      "mathContext": "Axiomatizes the ordinal partition relation $\\$\\alpha$ \\to (\\$\\beta$, k)^2$ and defines its negation $\\$\\alpha$ \\not\\to (\\$\\beta$, k)^2$."
+    },
+    {
+      "id": "key-ordinals",
+      "title": "Key Ordinals: $\\omega_1$ and $\\omega_1^2$",
+      "startLine": 57,
+      "endLine": 73,
+      "summary": "Defines $\\omega_1 = \\mathrm{ord}(\\aleph_1)$ and $\\omega_1^2 = \\omega_1 \\cdot \\omega_1$, with axioms for uncountability and cardinality.",
+      "mathContext": "Formal definition: Defines $\\omega_1 = \\mathrm{ord}(\\aleph_1)$ and $\\omega_1^2 = \\omega_1 \\cdot \\omega_1$, with axioms for uncountability and cardinality."
+    },
+    {
+      "id": "problem-statement",
+      "title": "The Main Problem Statement",
+      "startLine": 74,
+      "endLine": 85,
+      "summary": "Defines `erdos_1169_statement` as the partition relation $\\omega_1^2 \\to (\\omega_1^2, 3)^2$.",
+      "mathContext": "Formal definition: Defines `erdos_1169_statement` as the partition relation $\\omega_1^2 \\to (\\omega_1^2, 3)^2$."
+    },
+    {
+      "id": "hajnal-ch",
+      "title": "Hajnal's CH-Conditional Result",
+      "startLine": 86,
+      "endLine": 106,
+      "summary": "Defines CH ($2^{\\aleph_0} = \\aleph_1$), axiomatizes Hajnal's theorem that CH implies $\\omega_1^2 \\to (\\omega_1^2, k)^2$ for all $k$, and derives the $k = 3$ case.",
+      "mathContext": "Defines CH ($$$2^{{\\aleph_0}$}$ = \\aleph_1$), axiomatizes Hajnal's theorem that CH implies $\\omega_1^2 \\to (\\omega_1^2, k)^2$ for all $k$, and derives the $k = 3$ case."
+    },
+    {
+      "id": "independence",
+      "title": "Independence and Consistency",
+      "startLine": 107,
+      "endLine": 123,
+      "summary": "Captures the metamathematical status: the problem is not disprovable (consistent via CH models) and the ZFC status remains open.",
+      "mathContext": "Mathematical content: Captures the metamathematical status: the problem is not disprovable (consistent via CH models) and the ZFC status remains open."
+    },
+    {
+      "id": "monotonicity",
+      "title": "Monotonicity Properties",
+      "startLine": 124,
+      "endLine": 145,
+      "summary": "Axiomatizes monotonicity in the clique and ordinal parameters, and derives that the partition relation for pairs follows from triangles.",
+      "mathContext": "Axiomatized: Axiomatizes monotonicity in the clique and ordinal parameters, and derives that the partition relation for pairs follows from triangles."
+    },
+    {
+      "id": "connections",
+      "title": "Connections to Problems #592 and #118",
+      "startLine": 146,
+      "endLine": 165,
+      "summary": "Links to Problem #592 (countable analogue via Specker's theorem) and Problem #118 (clique extension, disproved in general but true for $\\omega_1^2$ under CH).",
+      "mathContext": "Verified: Links to Problem #592 (countable analogue via Specker's theorem) and Problem #118 (clique extension, disproved in general but true for $\\omega_1^2$ under CH)."
+    },
+    {
+      "id": "omega1-properties",
+      "title": "Basic Properties of $\\omega_1$",
+      "startLine": 166,
+      "endLine": 178,
+      "summary": "Axiomatizes that $\\omega_1$ is a limit ordinal, $\\omega < \\omega_1$, and $\\omega_1$ is regular (cofinality equals itself).",
+      "mathContext": "Axiomatized: Axiomatizes that $\\omega_1$ is a limit ordinal, $\\omega < \\omega_1$, and $\\omega_1$ is regular (cofinality equals itself)."
+    },
+    {
+      "id": "summary",
+      "title": "Summary of Formalization",
+      "startLine": 179,
+      "endLine": 218,
+      "summary": "Recaps the formalization: 12 axioms, 3 proved theorems, open in ZFC, solved under CH, and connections to related problems.",
+      "mathContext": "Verified: Recaps the formalization: 12 axioms, 3 proved theorems, open in ZFC, solved under CH, and connections to related problems."
+    }
+  ],
+  "conclusion": {
+    "summary": "This formalization captures the full structure of Erdős Problem #1169, an open problem in ordinal partition calculus asking whether $\\omega_1^2 \\to (\\omega_1^2, 3)^2$ holds in ZFC. The formalization includes the problem statement, Hajnal's CH-conditional proof, the metamathematical independence status, monotonicity consequences, and connections to related Erdős problems (#592, #118).",
+    "implications": "The formalization demonstrates how open problems at the boundary of set-theoretic independence can be precisely captured in Lean 4. The axiomatization cleanly separates what is known (Hajnal's CH result, consistency) from what is open (the ZFC status), and the proof of `erdos_1169_under_ch` from `hajnal_ch_implies_partition` shows how conditional results can be formally derived.",
+    "openQuestions": [
+      "Is $\\omega_1^2 \\to (\\omega_1^2, 3)^2$ provable from ZFC alone, or is it independent?",
+      "Does the negation $\\omega_1^2 \\not\\to (\\omega_1^2, 3)^2$ hold in some model of ZFC + $\\neg$CH?",
+      "Can Hajnal's proof be carried out without the full strength of CH — does Martin's Axiom or PFA suffice?",
+      "Can the ordinal partition relation be fully formalized in Lean 4 using Mathlib's ordinal and coloring theory, replacing the axiomatization?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.SetTheory.Ordinal.Arithmetic",
+      "Mathlib.SetTheory.Cardinal.Basic",
+      "Mathlib.SetTheory.Cardinal.Ordinal",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Cardinal",
+      "Ordinal"
+    ],
+    "namespace": null,
+    "lineCount": 225,
+    "axiomCount": 1,
+    "theoremCount": 3,
+    "definitionCount": 5,
+    "path": "Proofs/Erdos1169Problem.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1174",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: combinatorics, graph-theory, open, ramsey-theory, set-theory"
+    },
+    {
+      "targetId": "erdos-1176",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: combinatorics, graph-theory, open, ramsey-theory, set-theory"
+    },
+    {
+      "targetId": "erdos-1014",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: combinatorics, graph-theory, open, ramsey-theory"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-117/meta.json
+++ b/src/data/proofs/erdos-117/meta.json
@@ -123,7 +123,9 @@
     "lineCount": 62,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos117Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-1170/meta.json
+++ b/src/data/proofs/erdos-1170/meta.json
@@ -159,7 +159,9 @@
     "lineCount": 186,
     "axiomCount": 1,
     "theoremCount": 7,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos1170Problem.lean",
+    "sorries": 0
   },
   "references": [
     "Erdős: original problem formulation",

--- a/src/data/proofs/erdos-1171/meta.json
+++ b/src/data/proofs/erdos-1171/meta.json
@@ -216,7 +216,9 @@
     "lineCount": 433,
     "axiomCount": 2,
     "theoremCount": 21,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos1171Problem.lean",
+    "sorries": 0
   },
   "references": [
     "Erdős: original problem formulation",

--- a/src/data/proofs/erdos-1172/meta.json
+++ b/src/data/proofs/erdos-1172/meta.json
@@ -205,7 +205,9 @@
     "lineCount": 246,
     "axiomCount": 3,
     "theoremCount": 17,
-    "definitionCount": 13
+    "definitionCount": 13,
+    "path": "Proofs/Erdos1172Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1173/meta.json
+++ b/src/data/proofs/erdos-1173/meta.json
@@ -175,6 +175,8 @@
     "lineCount": 217,
     "axiomCount": 0,
     "theoremCount": 7,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos1173Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1174/meta.json
+++ b/src/data/proofs/erdos-1174/meta.json
@@ -166,7 +166,9 @@
     "lineCount": 232,
     "axiomCount": 0,
     "theoremCount": 1,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos1174Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1175/meta.json
+++ b/src/data/proofs/erdos-1175/meta.json
@@ -161,6 +161,8 @@
     "lineCount": 186,
     "axiomCount": 2,
     "theoremCount": 2,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos1175Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1176/meta.json
+++ b/src/data/proofs/erdos-1176/meta.json
@@ -179,7 +179,9 @@
     "lineCount": 225,
     "axiomCount": 1,
     "theoremCount": 6,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos1176Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1177/meta.json
+++ b/src/data/proofs/erdos-1177/meta.json
@@ -145,6 +145,8 @@
     "lineCount": 206,
     "axiomCount": 5,
     "theoremCount": 4,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos1177Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1178/meta.json
+++ b/src/data/proofs/erdos-1178/meta.json
@@ -261,6 +261,8 @@
     "lineCount": 260,
     "axiomCount": 2,
     "theoremCount": 10,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos1178Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1179/meta.json
+++ b/src/data/proofs/erdos-1179/meta.json
@@ -215,6 +215,8 @@
     "lineCount": 316,
     "axiomCount": 3,
     "theoremCount": 10,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos1179Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-118/meta.json
+++ b/src/data/proofs/erdos-118/meta.json
@@ -105,7 +105,9 @@
     "lineCount": 143,
     "axiomCount": 4,
     "theoremCount": 4,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos118Problem.lean",
+    "sorries": 0
   },
   "references": [
     "Erdős–Hajnal: original conjecture",

--- a/src/data/proofs/erdos-1181/meta.json
+++ b/src/data/proofs/erdos-1181/meta.json
@@ -187,7 +187,9 @@
     "lineCount": 292,
     "axiomCount": 1,
     "theoremCount": 7,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos1181Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1183/meta.json
+++ b/src/data/proofs/erdos-1183/meta.json
@@ -219,6 +219,8 @@
     "lineCount": 280,
     "axiomCount": 0,
     "theoremCount": 15,
-    "definitionCount": 12
+    "definitionCount": 12,
+    "path": "Proofs/Erdos1183Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-119/meta.json
+++ b/src/data/proofs/erdos-119/meta.json
@@ -127,7 +127,9 @@
     "lineCount": 97,
     "axiomCount": 0,
     "theoremCount": 2,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos119Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-12/meta.json
+++ b/src/data/proofs/erdos-12/meta.json
@@ -212,7 +212,9 @@
     "lineCount": 280,
     "axiomCount": 0,
     "theoremCount": 7,
-    "definitionCount": 13
+    "definitionCount": 13,
+    "path": "Proofs/Erdos12Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-120/meta.json
+++ b/src/data/proofs/erdos-120/meta.json
@@ -154,7 +154,9 @@
     "lineCount": 333,
     "axiomCount": 2,
     "theoremCount": 4,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos120Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-121/meta.json
+++ b/src/data/proofs/erdos-121/meta.json
@@ -94,7 +94,9 @@
     "lineCount": 75,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos121Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-122/meta.json
+++ b/src/data/proofs/erdos-122/meta.json
@@ -127,7 +127,9 @@
     "lineCount": 157,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos122Problem.lean",
+    "sorries": 0
   },
   "references": [
     "Erdős–Pomerance–Sárközy (1997): On the distribution of the values of f(n) + g(n)",

--- a/src/data/proofs/erdos-123/meta.json
+++ b/src/data/proofs/erdos-123/meta.json
@@ -119,7 +119,9 @@
     "lineCount": 318,
     "axiomCount": 3,
     "theoremCount": 22,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos123Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-124-complete-sequences/meta.json
+++ b/src/data/proofs/erdos-124-complete-sequences/meta.json
@@ -159,7 +159,9 @@
     "lineCount": 507,
     "axiomCount": 0,
     "theoremCount": 18,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos124CompleteSequences.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-124/meta.json
+++ b/src/data/proofs/erdos-124/meta.json
@@ -140,7 +140,9 @@
     "lineCount": 79,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos124Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-125/meta.json
+++ b/src/data/proofs/erdos-125/meta.json
@@ -134,7 +134,9 @@
     "lineCount": 92,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos125Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-126/meta.json
+++ b/src/data/proofs/erdos-126/meta.json
@@ -173,7 +173,9 @@
     "lineCount": 152,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos126Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-127/meta.json
+++ b/src/data/proofs/erdos-127/meta.json
@@ -111,7 +111,9 @@
     "lineCount": 78,
     "axiomCount": 1,
     "theoremCount": 0,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos127Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-128/meta.json
+++ b/src/data/proofs/erdos-128/meta.json
@@ -124,7 +124,9 @@
       "Mathlib.Data.Finset.Basic",
       "Mathlib.Combinatorics.SimpleGraph.Basic"
     ],
-    "opens": []
+    "opens": [],
+    "path": "Proofs/Erdos128Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-129/meta.json
+++ b/src/data/proofs/erdos-129/meta.json
@@ -128,7 +128,9 @@
     "lineCount": 84,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos129Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-13/meta.json
+++ b/src/data/proofs/erdos-13/meta.json
@@ -171,7 +171,9 @@
     "lineCount": 248,
     "axiomCount": 1,
     "theoremCount": 4,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos13Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-130/meta.json
+++ b/src/data/proofs/erdos-130/meta.json
@@ -130,7 +130,9 @@
     "lineCount": 103,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos130Problem.lean",
+    "sorries": 0
   },
   "references": [
     "Andrásfai & Erdős (1997): original problem [Er97b]",

--- a/src/data/proofs/erdos-131-oq-01/meta.json
+++ b/src/data/proofs/erdos-131-oq-01/meta.json
@@ -65,7 +65,9 @@
     "lineCount": 556,
     "axiomCount": 2,
     "theoremCount": 20,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos131Problem.lean",
+    "sorries": 1
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-131/meta.json
+++ b/src/data/proofs/erdos-131/meta.json
@@ -176,7 +176,9 @@
     "lineCount": 556,
     "axiomCount": 2,
     "theoremCount": 26,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos131Problem.lean",
+    "sorries": 1
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-132/meta.json
+++ b/src/data/proofs/erdos-132/meta.json
@@ -209,7 +209,9 @@
     "lineCount": 204,
     "axiomCount": 4,
     "theoremCount": 3,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos132Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-133/meta.json
+++ b/src/data/proofs/erdos-133/meta.json
@@ -144,7 +144,9 @@
     "lineCount": 110,
     "axiomCount": 3,
     "theoremCount": 1,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos133Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-134/meta.json
+++ b/src/data/proofs/erdos-134/meta.json
@@ -97,7 +97,9 @@
     "lineCount": 270,
     "axiomCount": 2,
     "theoremCount": 2,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos134Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-136/meta.json
+++ b/src/data/proofs/erdos-136/meta.json
@@ -144,7 +144,9 @@
     "lineCount": 185,
     "axiomCount": 4,
     "theoremCount": 3,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos136Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-137/meta.json
+++ b/src/data/proofs/erdos-137/meta.json
@@ -128,7 +128,9 @@
     "lineCount": 225,
     "axiomCount": 2,
     "theoremCount": 9,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos137Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-14-unique-sums/meta.json
+++ b/src/data/proofs/erdos-14-unique-sums/meta.json
@@ -65,7 +65,9 @@
     "lineCount": 443,
     "axiomCount": 3,
     "theoremCount": 6,
-    "definitionCount": 13
+    "definitionCount": 13,
+    "path": "Proofs/Erdos14UniqueSums.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-14/meta.json
+++ b/src/data/proofs/erdos-14/meta.json
@@ -133,7 +133,9 @@
     "lineCount": 85,
     "axiomCount": 0,
     "theoremCount": 1,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos14Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-140/meta.json
+++ b/src/data/proofs/erdos-140/meta.json
@@ -186,7 +186,9 @@
     "lineCount": 313,
     "axiomCount": 1,
     "theoremCount": 7,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos140Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-141/meta.json
+++ b/src/data/proofs/erdos-141/meta.json
@@ -135,7 +135,9 @@
     "lineCount": 169,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos141Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-143/meta.json
+++ b/src/data/proofs/erdos-143/meta.json
@@ -222,6 +222,8 @@
     "lineCount": 120,
     "axiomCount": 3,
     "theoremCount": 1,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos143Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-144/meta.json
+++ b/src/data/proofs/erdos-144/meta.json
@@ -204,7 +204,9 @@
     "lineCount": 188,
     "axiomCount": 5,
     "theoremCount": 2,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos144Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-145/meta.json
+++ b/src/data/proofs/erdos-145/meta.json
@@ -133,7 +133,9 @@
     "lineCount": 133,
     "axiomCount": 2,
     "theoremCount": 6,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos145Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-146/meta.json
+++ b/src/data/proofs/erdos-146/meta.json
@@ -167,7 +167,9 @@
     "lineCount": 215,
     "axiomCount": 1,
     "theoremCount": 4,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos146Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-147/meta.json
+++ b/src/data/proofs/erdos-147/meta.json
@@ -149,7 +149,9 @@
     "lineCount": 101,
     "axiomCount": 3,
     "theoremCount": 1,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/Erdos147Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-148/meta.json
+++ b/src/data/proofs/erdos-148/meta.json
@@ -174,7 +174,9 @@
     "lineCount": 232,
     "axiomCount": 3,
     "theoremCount": 1,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos148Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-149/meta.json
+++ b/src/data/proofs/erdos-149/meta.json
@@ -156,7 +156,9 @@
     "lineCount": 144,
     "axiomCount": 3,
     "theoremCount": 2,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos149Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-15/meta.json
+++ b/src/data/proofs/erdos-15/meta.json
@@ -142,7 +142,8 @@
     "axiomCount": 1,
     "sorries": 0,
     "theoremCount": 0,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos15Problem.lean"
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-150/meta.json
+++ b/src/data/proofs/erdos-150/meta.json
@@ -203,7 +203,9 @@
     "lineCount": 334,
     "axiomCount": 5,
     "theoremCount": 10,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos150Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-151/meta.json
+++ b/src/data/proofs/erdos-151/meta.json
@@ -138,7 +138,9 @@
     "lineCount": 173,
     "axiomCount": 11,
     "theoremCount": 5,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos151Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-152-oq-01/meta.json
+++ b/src/data/proofs/erdos-152-oq-01/meta.json
@@ -102,7 +102,9 @@
     "lineCount": 319,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/Erdos152OQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-152/meta.json
+++ b/src/data/proofs/erdos-152/meta.json
@@ -133,7 +133,9 @@
     "lineCount": 470,
     "axiomCount": 0,
     "theoremCount": 8,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos152Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-153/meta.json
+++ b/src/data/proofs/erdos-153/meta.json
@@ -142,7 +142,9 @@
     "lineCount": 494,
     "axiomCount": 1,
     "theoremCount": 18,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos153Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-154/meta.json
+++ b/src/data/proofs/erdos-154/meta.json
@@ -149,7 +149,9 @@
     "lineCount": 96,
     "axiomCount": 1,
     "theoremCount": 1,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos154Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-155/meta.json
+++ b/src/data/proofs/erdos-155/meta.json
@@ -137,7 +137,9 @@
     "lineCount": 199,
     "axiomCount": 1,
     "theoremCount": 7,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/Erdos155Problem.lean",
+    "sorries": 0
   },
   "references": [
     "Erdős–Turán (1941): On a problem of Sidon in additive number theory",

--- a/src/data/proofs/erdos-157/meta.json
+++ b/src/data/proofs/erdos-157/meta.json
@@ -162,7 +162,9 @@
     "lineCount": 536,
     "axiomCount": 3,
     "theoremCount": 5,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos157Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-158/meta.json
+++ b/src/data/proofs/erdos-158/meta.json
@@ -141,7 +141,9 @@
     "lineCount": 125,
     "axiomCount": 2,
     "theoremCount": 2,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos158Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-159/meta.json
+++ b/src/data/proofs/erdos-159/meta.json
@@ -168,7 +168,9 @@
     "lineCount": 282,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos159Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-16/meta.json
+++ b/src/data/proofs/erdos-16/meta.json
@@ -190,7 +190,9 @@
     "lineCount": 203,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos16Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-161/meta.json
+++ b/src/data/proofs/erdos-161/meta.json
@@ -159,7 +159,9 @@
     "lineCount": 158,
     "axiomCount": 4,
     "theoremCount": 2,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos161Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-162/meta.json
+++ b/src/data/proofs/erdos-162/meta.json
@@ -126,7 +126,9 @@
     "lineCount": 237,
     "axiomCount": 4,
     "theoremCount": 4,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos162Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-163/meta.json
+++ b/src/data/proofs/erdos-163/meta.json
@@ -174,7 +174,9 @@
     "lineCount": 198,
     "axiomCount": 1,
     "theoremCount": 3,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos163Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-164/meta.json
+++ b/src/data/proofs/erdos-164/meta.json
@@ -143,7 +143,9 @@
     "lineCount": 153,
     "axiomCount": 4,
     "theoremCount": 5,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos164Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-165/meta.json
+++ b/src/data/proofs/erdos-165/meta.json
@@ -176,7 +176,9 @@
     "lineCount": 187,
     "axiomCount": 4,
     "theoremCount": 2,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Stubs/Erdos165Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-166/meta.json
+++ b/src/data/proofs/erdos-166/meta.json
@@ -185,7 +185,9 @@
     "lineCount": 269,
     "axiomCount": 2,
     "theoremCount": 7,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos166Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-167/meta.json
+++ b/src/data/proofs/erdos-167/meta.json
@@ -139,7 +139,9 @@
     "lineCount": 275,
     "axiomCount": 1,
     "theoremCount": 4,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos167Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-168/meta.json
+++ b/src/data/proofs/erdos-168/meta.json
@@ -144,7 +144,9 @@
     "lineCount": 181,
     "axiomCount": 2,
     "theoremCount": 4,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos168Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-169/meta.json
+++ b/src/data/proofs/erdos-169/meta.json
@@ -165,7 +165,9 @@
     "lineCount": 279,
     "axiomCount": 2,
     "theoremCount": 2,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos169Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-17/meta.json
+++ b/src/data/proofs/erdos-17/meta.json
@@ -210,7 +210,9 @@
     "lineCount": 218,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos17Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-170/meta.json
+++ b/src/data/proofs/erdos-170/meta.json
@@ -164,7 +164,9 @@
     "lineCount": 146,
     "axiomCount": 3,
     "theoremCount": 4,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos170Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-171/meta.json
+++ b/src/data/proofs/erdos-171/meta.json
@@ -200,7 +200,9 @@
     "lineCount": 303,
     "axiomCount": 2,
     "theoremCount": 7,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos171Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-172/meta.json
+++ b/src/data/proofs/erdos-172/meta.json
@@ -158,7 +158,9 @@
     "lineCount": 145,
     "axiomCount": 3,
     "theoremCount": 4,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos172Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-173/meta.json
+++ b/src/data/proofs/erdos-173/meta.json
@@ -167,7 +167,9 @@
     "lineCount": 234,
     "axiomCount": 4,
     "theoremCount": 3,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos173Problem.lean",
+    "sorries": 0
   },
   "references": [
     "Erdős [Er75f, Er83c]: original problem statement",

--- a/src/data/proofs/erdos-174/meta.json
+++ b/src/data/proofs/erdos-174/meta.json
@@ -198,7 +198,9 @@
     "lineCount": 247,
     "axiomCount": 5,
     "theoremCount": 5,
-    "definitionCount": 18
+    "definitionCount": 18,
+    "path": "Proofs/Erdos174Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-177-oq-04/meta.json
+++ b/src/data/proofs/erdos-177-oq-04/meta.json
@@ -63,7 +63,9 @@
     "lineCount": 282,
     "axiomCount": 3,
     "theoremCount": 12,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos177OQ04.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-177/meta.json
+++ b/src/data/proofs/erdos-177/meta.json
@@ -161,7 +161,9 @@
     "lineCount": 163,
     "axiomCount": 1,
     "theoremCount": 9,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos177Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-178/meta.json
+++ b/src/data/proofs/erdos-178/meta.json
@@ -210,7 +210,9 @@
     "lineCount": 165,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos178Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-18/meta.json
+++ b/src/data/proofs/erdos-18/meta.json
@@ -249,7 +249,9 @@
     "lineCount": 187,
     "axiomCount": 0,
     "theoremCount": 2,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos18Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-180/meta.json
+++ b/src/data/proofs/erdos-180/meta.json
@@ -177,7 +177,9 @@
     "lineCount": 116,
     "axiomCount": 3,
     "theoremCount": 1,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos180Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-181/meta.json
+++ b/src/data/proofs/erdos-181/meta.json
@@ -159,7 +159,9 @@
     "lineCount": 385,
     "axiomCount": 3,
     "theoremCount": 11,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos181Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-182/meta.json
+++ b/src/data/proofs/erdos-182/meta.json
@@ -171,7 +171,9 @@
     "lineCount": 148,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos182Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-183/meta.json
+++ b/src/data/proofs/erdos-183/meta.json
@@ -187,7 +187,9 @@
     "lineCount": 568,
     "axiomCount": 2,
     "theoremCount": 15,
-    "definitionCount": 13
+    "definitionCount": 13,
+    "path": "Proofs/Erdos183Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-184/meta.json
+++ b/src/data/proofs/erdos-184/meta.json
@@ -175,7 +175,9 @@
     "lineCount": 242,
     "axiomCount": 5,
     "theoremCount": 8,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos184Problem.lean",
+    "sorries": 0
   },
   "references": [
     "Erdős–Gallai (1966): original conjecture and O(n log n) bound",

--- a/src/data/proofs/erdos-185/meta.json
+++ b/src/data/proofs/erdos-185/meta.json
@@ -207,7 +207,9 @@
     "lineCount": 1104,
     "axiomCount": 2,
     "theoremCount": 73,
-    "definitionCount": 29
+    "definitionCount": 29,
+    "path": "Proofs/Erdos185Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-186/meta.json
+++ b/src/data/proofs/erdos-186/meta.json
@@ -163,7 +163,9 @@
     "lineCount": 243,
     "axiomCount": 2,
     "theoremCount": 6,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos186Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-187/meta.json
+++ b/src/data/proofs/erdos-187/meta.json
@@ -96,7 +96,9 @@
     "lineCount": 58,
     "axiomCount": 2,
     "theoremCount": 0,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos187Problem.lean",
+    "sorries": 0
   },
   "references": [
     "Erdős (1973): original problem",

--- a/src/data/proofs/erdos-188/meta.json
+++ b/src/data/proofs/erdos-188/meta.json
@@ -199,7 +199,9 @@
     "lineCount": 188,
     "axiomCount": 2,
     "theoremCount": 5,
-    "definitionCount": 13
+    "definitionCount": 13,
+    "path": "Proofs/Erdos188Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-189/meta.json
+++ b/src/data/proofs/erdos-189/meta.json
@@ -117,7 +117,9 @@
     "lineCount": 145,
     "axiomCount": 1,
     "theoremCount": 1,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos189Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-19-oq-01/meta.json
+++ b/src/data/proofs/erdos-19-oq-01/meta.json
@@ -139,6 +139,8 @@
   },
   "leanFile": {
     "axiomCount": 3,
-    "lineCount": 394
+    "lineCount": 394,
+    "path": "Proofs/Erdos19OQ01Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-19/meta.json
+++ b/src/data/proofs/erdos-19/meta.json
@@ -252,6 +252,8 @@
     "lineCount": 255,
     "axiomCount": 4,
     "theoremCount": 2,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos19Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-190/meta.json
+++ b/src/data/proofs/erdos-190/meta.json
@@ -148,7 +148,9 @@
     "lineCount": 348,
     "axiomCount": 3,
     "theoremCount": 7,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos190Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-192/meta.json
+++ b/src/data/proofs/erdos-192/meta.json
@@ -135,7 +135,9 @@
     "lineCount": 107,
     "axiomCount": 3,
     "theoremCount": 1,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos192Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-193/meta.json
+++ b/src/data/proofs/erdos-193/meta.json
@@ -162,7 +162,9 @@
     "lineCount": 403,
     "axiomCount": 1,
     "theoremCount": 17,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos193Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-194/meta.json
+++ b/src/data/proofs/erdos-194/meta.json
@@ -185,7 +185,9 @@
     "lineCount": 296,
     "axiomCount": 2,
     "theoremCount": 4,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos194Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-195/meta.json
+++ b/src/data/proofs/erdos-195/meta.json
@@ -156,7 +156,9 @@
     "lineCount": 149,
     "axiomCount": 3,
     "theoremCount": 4,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos195Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-196/meta.json
+++ b/src/data/proofs/erdos-196/meta.json
@@ -138,7 +138,9 @@
     "lineCount": 155,
     "axiomCount": 0,
     "theoremCount": 4,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos196Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-197/meta.json
+++ b/src/data/proofs/erdos-197/meta.json
@@ -186,7 +186,9 @@
     "lineCount": 307,
     "axiomCount": 2,
     "theoremCount": 7,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos197Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-198/meta.json
+++ b/src/data/proofs/erdos-198/meta.json
@@ -127,7 +127,9 @@
     "lineCount": 151,
     "axiomCount": 2,
     "theoremCount": 2,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos198Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-199/meta.json
+++ b/src/data/proofs/erdos-199/meta.json
@@ -146,7 +146,9 @@
     "lineCount": 174,
     "axiomCount": 1,
     "theoremCount": 3,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos199Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-2/meta.json
+++ b/src/data/proofs/erdos-2/meta.json
@@ -253,6 +253,8 @@
     "lineCount": 267,
     "axiomCount": 3,
     "theoremCount": 9,
-    "definitionCount": 17
+    "definitionCount": 17,
+    "path": "Proofs/Erdos2Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-20/meta.json
+++ b/src/data/proofs/erdos-20/meta.json
@@ -185,7 +185,9 @@
     "lineCount": 168,
     "axiomCount": 1,
     "theoremCount": 2,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos20Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/listings.json
+++ b/src/data/proofs/listings.json
@@ -21026,7 +21026,7 @@
     "erdosNumber": 508,
     "mathlibCount": 4,
     "sorries": 0,
-    "annotationCount": 4
+    "annotationCount": 5
   },
   {
     "id": "erdos-509",


### PR DESCRIPTION
## Fix

Batch 4 of gallery metadata completion: adds missing `path` and `sorries` to `leanFile` objects.

| Batch | PR | Count | Range |
|-------|----|-------|-------|
| 1 | #9756 | 167 | first batch |
| 2 | #9759 | 198 | abel-* through central-limit-theorem-oq-04 |
| 3 | #9761 | 200 | central-limit-theorem through erdos-* |
| 4 | this | 200 | erdos-1083 through erdos-20 |

`pnpm build` passes cleanly.

---
Automated fix by lean-mechanic agent.