### PR TITLE
fix(meta): add missing leanFile.path and sorries to 200 gallery proofs (batch 5)

### DIFF
--- a/src/data/proofs/erdos-200/meta.json
+++ b/src/data/proofs/erdos-200/meta.json
@@ -165,7 +165,9 @@
     "lineCount": 151,
     "axiomCount": 1,
     "theoremCount": 6,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos200Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-201/meta.json
+++ b/src/data/proofs/erdos-201/meta.json
@@ -145,7 +145,9 @@
     "lineCount": 351,
     "axiomCount": 1,
     "theoremCount": 21,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos201Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-203/meta.json
+++ b/src/data/proofs/erdos-203/meta.json
@@ -165,7 +165,9 @@
     "lineCount": 350,
     "axiomCount": 0,
     "theoremCount": 36,
-    "definitionCount": 14
+    "definitionCount": 14,
+    "path": "Proofs/Erdos203Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-205/meta.json
+++ b/src/data/proofs/erdos-205/meta.json
@@ -214,7 +214,9 @@
     "lineCount": 444,
     "axiomCount": 6,
     "theoremCount": 44,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos205Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-206/meta.json
+++ b/src/data/proofs/erdos-206/meta.json
@@ -168,7 +168,9 @@
     "lineCount": 194,
     "axiomCount": 4,
     "theoremCount": 3,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos206Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-209/meta.json
+++ b/src/data/proofs/erdos-209/meta.json
@@ -143,7 +143,9 @@
     "lineCount": 241,
     "axiomCount": 1,
     "theoremCount": 2,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos209Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-21/meta.json
+++ b/src/data/proofs/erdos-21/meta.json
@@ -169,7 +169,9 @@
     "lineCount": 273,
     "axiomCount": 9,
     "theoremCount": 2,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos21Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-210/meta.json
+++ b/src/data/proofs/erdos-210/meta.json
@@ -182,7 +182,9 @@
     "lineCount": 196,
     "axiomCount": 9,
     "theoremCount": 4,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos210Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-212/meta.json
+++ b/src/data/proofs/erdos-212/meta.json
@@ -125,7 +125,9 @@
     "lineCount": 139,
     "axiomCount": 4,
     "theoremCount": 2,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos212Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-213/meta.json
+++ b/src/data/proofs/erdos-213/meta.json
@@ -134,7 +134,9 @@
     "lineCount": 145,
     "axiomCount": 4,
     "theoremCount": 4,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos213Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-215/meta.json
+++ b/src/data/proofs/erdos-215/meta.json
@@ -160,7 +160,9 @@
     "lineCount": 187,
     "axiomCount": 1,
     "theoremCount": 5,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos215Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-216/meta.json
+++ b/src/data/proofs/erdos-216/meta.json
@@ -212,7 +212,9 @@
     "lineCount": 233,
     "axiomCount": 9,
     "theoremCount": 6,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos216Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-217/meta.json
+++ b/src/data/proofs/erdos-217/meta.json
@@ -139,7 +139,9 @@
     "lineCount": 91,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos217Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-218/meta.json
+++ b/src/data/proofs/erdos-218/meta.json
@@ -174,7 +174,9 @@
     "lineCount": 418,
     "axiomCount": 2,
     "theoremCount": 25,
-    "definitionCount": 12
+    "definitionCount": 12,
+    "path": "Proofs/Erdos218Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-219/meta.json
+++ b/src/data/proofs/erdos-219/meta.json
@@ -135,7 +135,9 @@
     "lineCount": 148,
     "axiomCount": 1,
     "theoremCount": 4,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos219Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-22/meta.json
+++ b/src/data/proofs/erdos-22/meta.json
@@ -150,7 +150,9 @@
     "lineCount": 182,
     "axiomCount": 6,
     "theoremCount": 4,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos22Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-221/meta.json
+++ b/src/data/proofs/erdos-221/meta.json
@@ -261,7 +261,9 @@
     "lineCount": 239,
     "axiomCount": 4,
     "theoremCount": 6,
-    "definitionCount": 13
+    "definitionCount": 13,
+    "path": "Proofs/Erdos221Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-222/meta.json
+++ b/src/data/proofs/erdos-222/meta.json
@@ -184,7 +184,9 @@
     "lineCount": 147,
     "axiomCount": 3,
     "theoremCount": 2,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos222Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-223/meta.json
+++ b/src/data/proofs/erdos-223/meta.json
@@ -216,6 +216,8 @@
     "lineCount": 214,
     "axiomCount": 3,
     "theoremCount": 4,
-    "definitionCount": 14
+    "definitionCount": 14,
+    "path": "Proofs/Erdos223Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-224/meta.json
+++ b/src/data/proofs/erdos-224/meta.json
@@ -158,7 +158,9 @@
     "lineCount": 277,
     "axiomCount": 1,
     "theoremCount": 3,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos224Problem.lean",
+    "sorries": 0
   },
   "references": [
     "Danzer, Grünbaum (1962): 'Über zwei Probleme bezüglich konvexer Körper von P. Erdős und von V. L. Klee', Mathematische Zeitschrift 79, 95–99",

--- a/src/data/proofs/erdos-226/meta.json
+++ b/src/data/proofs/erdos-226/meta.json
@@ -196,7 +196,9 @@
     "lineCount": 268,
     "axiomCount": 1,
     "theoremCount": 6,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos226Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-228/meta.json
+++ b/src/data/proofs/erdos-228/meta.json
@@ -149,7 +149,9 @@
     "lineCount": 162,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos228Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-229/meta.json
+++ b/src/data/proofs/erdos-229/meta.json
@@ -135,7 +135,9 @@
     "lineCount": 137,
     "axiomCount": 1,
     "theoremCount": 2,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos229Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-23/meta.json
+++ b/src/data/proofs/erdos-23/meta.json
@@ -168,7 +168,9 @@
     "lineCount": 216,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos23Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-231/meta.json
+++ b/src/data/proofs/erdos-231/meta.json
@@ -167,7 +167,8 @@
     "axiomCount": 1,
     "sorries": 0,
     "theoremCount": 3,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos231Problem.lean"
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-232/meta.json
+++ b/src/data/proofs/erdos-232/meta.json
@@ -216,7 +216,9 @@
     "lineCount": 346,
     "axiomCount": 2,
     "theoremCount": 12,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos232Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-233/meta.json
+++ b/src/data/proofs/erdos-233/meta.json
@@ -156,7 +156,9 @@
     "lineCount": 147,
     "axiomCount": 1,
     "theoremCount": 1,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos233Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-234/meta.json
+++ b/src/data/proofs/erdos-234/meta.json
@@ -186,7 +186,9 @@
     "lineCount": 512,
     "axiomCount": 3,
     "theoremCount": 28,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos234Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-235/meta.json
+++ b/src/data/proofs/erdos-235/meta.json
@@ -204,7 +204,9 @@
     "lineCount": 329,
     "axiomCount": 1,
     "theoremCount": 8,
-    "definitionCount": 14
+    "definitionCount": 14,
+    "path": "Proofs/Erdos235Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-236/meta.json
+++ b/src/data/proofs/erdos-236/meta.json
@@ -131,7 +131,9 @@
     "lineCount": 175,
     "axiomCount": 0,
     "theoremCount": 8,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos236Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-237/meta.json
+++ b/src/data/proofs/erdos-237/meta.json
@@ -195,7 +195,9 @@
     "lineCount": 255,
     "axiomCount": 1,
     "theoremCount": 3,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos237Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-238/meta.json
+++ b/src/data/proofs/erdos-238/meta.json
@@ -227,6 +227,8 @@
     "lineCount": 345,
     "axiomCount": 2,
     "theoremCount": 12,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos238Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-239/meta.json
+++ b/src/data/proofs/erdos-239/meta.json
@@ -197,7 +197,9 @@
     "lineCount": 275,
     "axiomCount": 6,
     "theoremCount": 10,
-    "definitionCount": 13
+    "definitionCount": 13,
+    "path": "Proofs/Erdos239Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-24/meta.json
+++ b/src/data/proofs/erdos-24/meta.json
@@ -153,7 +153,9 @@
     "lineCount": 245,
     "axiomCount": 4,
     "theoremCount": 4,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos24Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-241/meta.json
+++ b/src/data/proofs/erdos-241/meta.json
@@ -145,7 +145,9 @@
     "lineCount": 123,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos241Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-242/meta.json
+++ b/src/data/proofs/erdos-242/meta.json
@@ -232,7 +232,9 @@
     "lineCount": 590,
     "axiomCount": 1,
     "theoremCount": 50,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos242Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-243/meta.json
+++ b/src/data/proofs/erdos-243/meta.json
@@ -134,7 +134,9 @@
     "lineCount": 128,
     "axiomCount": 2,
     "theoremCount": 8,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos243Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-244/meta.json
+++ b/src/data/proofs/erdos-244/meta.json
@@ -172,7 +172,9 @@
     "lineCount": 233,
     "axiomCount": 2,
     "theoremCount": 9,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos244Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-245/meta.json
+++ b/src/data/proofs/erdos-245/meta.json
@@ -118,7 +118,9 @@
     "lineCount": 187,
     "axiomCount": 3,
     "theoremCount": 4,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos245Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-246/meta.json
+++ b/src/data/proofs/erdos-246/meta.json
@@ -174,7 +174,9 @@
     "lineCount": 186,
     "axiomCount": 4,
     "theoremCount": 3,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos246Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-247-oq-01/meta.json
+++ b/src/data/proofs/erdos-247-oq-01/meta.json
@@ -66,7 +66,9 @@
     "lineCount": 506,
     "axiomCount": 1,
     "theoremCount": 22,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos247Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-247/meta.json
+++ b/src/data/proofs/erdos-247/meta.json
@@ -136,7 +136,9 @@
     "lineCount": 506,
     "axiomCount": 1,
     "theoremCount": 22,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos247Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-248/meta.json
+++ b/src/data/proofs/erdos-248/meta.json
@@ -130,7 +130,9 @@
     "lineCount": 133,
     "axiomCount": 1,
     "theoremCount": 11,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos248Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-249-oq-01/meta.json
+++ b/src/data/proofs/erdos-249-oq-01/meta.json
@@ -124,6 +124,8 @@
     "lineCount": 225,
     "axiomCount": 0,
     "theoremCount": 13,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/Erdos249OQ01.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-249/meta.json
+++ b/src/data/proofs/erdos-249/meta.json
@@ -181,7 +181,9 @@
     "lineCount": 192,
     "axiomCount": 0,
     "theoremCount": 13,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos249Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-25/meta.json
+++ b/src/data/proofs/erdos-25/meta.json
@@ -152,7 +152,9 @@
     "lineCount": 166,
     "axiomCount": 0,
     "theoremCount": 8,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos25Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-250/meta.json
+++ b/src/data/proofs/erdos-250/meta.json
@@ -126,7 +126,9 @@
     "lineCount": 188,
     "axiomCount": 2,
     "theoremCount": 9,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos250Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-251/meta.json
+++ b/src/data/proofs/erdos-251/meta.json
@@ -176,7 +176,9 @@
     "lineCount": 201,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos251Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-253/meta.json
+++ b/src/data/proofs/erdos-253/meta.json
@@ -132,7 +132,9 @@
     "lineCount": 114,
     "axiomCount": 1,
     "theoremCount": 4,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos253Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-254/meta.json
+++ b/src/data/proofs/erdos-254/meta.json
@@ -144,7 +144,9 @@
     "lineCount": 185,
     "axiomCount": 4,
     "theoremCount": 1,
-    "definitionCount": 13
+    "definitionCount": 13,
+    "path": "Proofs/Erdos254Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-255/meta.json
+++ b/src/data/proofs/erdos-255/meta.json
@@ -176,7 +176,9 @@
     "lineCount": 163,
     "axiomCount": 3,
     "theoremCount": 2,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos255Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-256/meta.json
+++ b/src/data/proofs/erdos-256/meta.json
@@ -199,7 +199,9 @@
       "Complex",
       "scoped",
       "BigOperators"
-    ]
+    ],
+    "path": "Proofs/Erdos256Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-257/meta.json
+++ b/src/data/proofs/erdos-257/meta.json
@@ -136,7 +136,9 @@
     "lineCount": 123,
     "axiomCount": 3,
     "theoremCount": 1,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos257Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-258/meta.json
+++ b/src/data/proofs/erdos-258/meta.json
@@ -128,7 +128,9 @@
     "lineCount": 108,
     "axiomCount": 0,
     "theoremCount": 9,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos258Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-259/meta.json
+++ b/src/data/proofs/erdos-259/meta.json
@@ -127,7 +127,9 @@
     "lineCount": 239,
     "axiomCount": 2,
     "theoremCount": 14,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos259Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-26/meta.json
+++ b/src/data/proofs/erdos-26/meta.json
@@ -166,7 +166,9 @@
     "lineCount": 202,
     "axiomCount": 2,
     "theoremCount": 4,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos26Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-261/meta.json
+++ b/src/data/proofs/erdos-261/meta.json
@@ -115,7 +115,9 @@
     "lineCount": 388,
     "axiomCount": 0,
     "theoremCount": 18,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos261Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-262/meta.json
+++ b/src/data/proofs/erdos-262/meta.json
@@ -159,7 +159,9 @@
     "lineCount": 177,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos262Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-264/meta.json
+++ b/src/data/proofs/erdos-264/meta.json
@@ -141,7 +141,9 @@
     "lineCount": 137,
     "axiomCount": 1,
     "theoremCount": 1,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/Erdos264Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-265/meta.json
+++ b/src/data/proofs/erdos-265/meta.json
@@ -151,7 +151,9 @@
     "lineCount": 233,
     "axiomCount": 2,
     "theoremCount": 5,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos265Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-266/meta.json
+++ b/src/data/proofs/erdos-266/meta.json
@@ -138,7 +138,9 @@
     "lineCount": 150,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/Erdos266Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-267/meta.json
+++ b/src/data/proofs/erdos-267/meta.json
@@ -203,7 +203,9 @@
     "lineCount": 224,
     "axiomCount": 0,
     "theoremCount": 12,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos267Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-268/meta.json
+++ b/src/data/proofs/erdos-268/meta.json
@@ -215,6 +215,7 @@
     "axiomCount": 1,
     "theoremCount": 15,
     "definitionCount": 14,
-    "sorries": 8
+    "sorries": 8,
+    "path": "Proofs/Erdos268Problem.lean"
   }
 }

--- a/src/data/proofs/erdos-269/meta.json
+++ b/src/data/proofs/erdos-269/meta.json
@@ -1,226 +1,228 @@
 {
-    "id": "erdos-269",
-    "title": "Erdos Problem #269: LCM Series Irrationality",
-    "slug": "erdos-269",
-    "description": "For P a finite set of primes with |P|>=2, let {a_n} be the P-smooth numbers and L_n=[a_0,...,a_{n-1}]. Is the sum 1/L_1 + 1/L_2 + ... irrational? OPEN for finite P. Solved (always irrational) for infinite P.",
-    "meta": {
-        "author": "Erdos (1973)",
-        "sourceUrl": "https://erdosproblems.com/269",
-        "date": "1973",
-        "status": "axiomatized",
-        "proofRepoPath": "Proofs/Erdos269Problem.lean",
-        "tags": [
-            "erdos",
-            "number-theory",
-            "irrationality",
-            "lcm",
-            "smooth-numbers",
-            "series",
-            "open-problem"
-        ],
-        "badge": "axiom",
-        "sorries": 0,
-        "erdosNumber": 269,
-        "erdosUrl": "https://erdosproblems.com/269",
-        "erdosProblemStatus": "open",
-        "dateAdded": "2026-01-25",
-        "mathlib_version": "4.26.0",
-        "mathlibDependencies": [
-            {
-                "theorem": "Nat.Prime",
-                "description": "Prime number predicate",
-                "module": "Mathlib.Data.Nat.Prime.Basic"
-            },
-            {
-                "theorem": "Finset.lcm",
-                "description": "LCM over finite sets",
-                "module": "Mathlib.Data.Finset.Lattice"
-            },
-            {
-                "theorem": "Irrational",
-                "description": "Irrationality predicate for reals",
-                "module": "Mathlib.Data.Real.Irrational"
-            },
-            {
-                "theorem": "tsum",
-                "description": "Infinite series summation",
-                "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
-            },
-            {
-                "theorem": "Nat.padicValNat",
-                "description": "P-adic valuation of natural numbers",
-                "module": "Mathlib.NumberTheory.Padics.PadicVal"
-            }
-        ],
-        "originalContributions": [
-            "IsPSmooth definition: n has all prime divisors in P",
-            "smoothSeq definition: enumeration of P-smooth numbers",
-            "partialLcm definition: L_n = [a_0,...,a_{n-1}]",
-            "lcmSeries definition: sum of 1/L_n",
-            "erdos_269 axiom: series is irrational for finite P (OPEN)",
-            "erdos_269_infinite axiom: series is irrational for infinite P (SOLVED)",
-            "erdos_269_distinct axiom: distinct-term series is irrational",
-            "twoThreeSmooth example: P = {2,3}",
-            "lcmPadicVal definition: p-adic valuation of L_n",
-            "distinctLcmSeries definition: series without duplicate terms"
-        ],
-        "axiomCount": 3,
-        "lineCount": 287,
-        "assumptions": "3 axiom(s): erdos_269 (main conjecture, OPEN), erdos_269_infinite (infinite P case), erdos_269_distinct (distinct LCM case). Former axiom smoothSeq_zero now proved."
-    },
-    "overview": {
-        "historicalContext": "**Erdos Problem #269: LCM Series Irrationality**\n\nThis problem was posed by Erdos in a letter to the editor of the Fibonacci Quarterly (January 1, 1973), published in Vol. 12 (1974), p. 335.\n\n**Key History:**\n- Erdos (1973): Original problem statement\n- [ErGr80, p.65]: Referenced in Erdos-Graham collaboration\n- [Er88c, p.106]: Further discussion\n\n**The Setting:**\nP-smooth numbers (or P-friable numbers) are integers whose prime factors all come from a fixed set P. When P = {2,3}, these are the 3-smooth numbers: 1, 2, 3, 4, 6, 8, 9, 12, 16, 18, 24, 27, ...\n\nThe series sums reciprocals of successive LCMs of these numbers.",
-        "problemStatement": "**Problem Statement**\n\nLet P be a finite set of primes with |P| >= 2.\nLet {a_1 < a_2 < ...} be the set of positive integers whose prime divisors are all in P.\nLet L_n = [a_1, ..., a_n] be the LCM of the first n such integers.\n\n**Question:** Is the sum $\\sum_{n=1}^{\\infty} \\frac{1}{L_n}$ irrational?\n\n**Status:**\n- Finite P: OPEN\n- Infinite P: SOLVED (always irrational, 'simple exercise' per Erdos)\n- Finite P, distinct terms only: SOLVED (irrational)",
-        "text": "For P a finite set of primes with |P|>=2, let {a_n} be the P-smooth numbers and L_n=[a_0,...,a_{n-1}]. Is the sum 1/L_1 + 1/L_2 + ... irrational? OPEN for finite P. Solved (always irrational) for infinite P.",
-        "proofStrategy": "**Formalization Approach**\n\n1. **P-smooth Numbers:** Define IsPSmooth P n predicate\n\n2. **Enumeration:** Define smoothSeq P as the sequence of P-smooth numbers\n\n3. **Partial LCM:** Define L_n = lcm(a_0, ..., a_{n-1})\n\n4. **The Series:** Define lcmSeries P = sum of 1/L_n\n\n5. **Main Conjecture:** State erdos_269 as axiom for finite P\n\n6. **Infinite Case:** State erdos_269_infinite as axiom (SOLVED)\n\n7. **P-adic Analysis:** Key to understanding LCM growth patterns\n\n8. **Examples:** Work through P = {2,3} case explicitly",
-        "keyInsights": [
-            "**P-smooth Numbers:** Integers with all prime factors in P; for P={2,3} these are 3-smooth: 1,2,3,4,6,8,9,...",
-            "**LCM Growth:** L_n grows when a new prime power enters the sequence; stays constant otherwise",
-            "**Infinite P Case:** 'Simple exercise' - infinitely many primes ensure irrationality",
-            "**Duplicate Terms:** When a_n | L_{n-1}, we get L_n = L_{n-1}, creating duplicates",
-            "**Distinct Terms:** Removing duplicates makes the series provably irrational",
-            "**P-adic Valuation:** v_p(L_n) increases in discrete jumps at powers of p",
-            "**The Difficulty:** For finite P, pattern of duplicates is hard to analyze"
-        ],
-        "prerequisites": [
-            "Smooth numbers ($P$-smooth: all prime factors in $P$)",
-            "LCM of integer sequences",
-            "Irrationality criteria (e.g., Erdos-Straus)",
-            "$p$-adic valuations and arithmetic functions",
-            "Diophantine approximation"
-        ]
-    },
-    "sections": [
-        {
-            "id": "psmooth",
-            "title": "P-smooth Numbers",
-            "summary": "IsPSmooth definition, basic properties",
-            "startLine": 34,
-            "endLine": 73,
-            "mathContext": "$n$ is $P$-smooth if all prime factors of $n$ are in $P$. Example: $P = \\\\{2,3\\\\}$, smooth numbers are $\\\\{1, 2, 3, 4, 6, 8, 9, \\\\ldots\\\\}$."
-        },
-        {
-            "id": "sequence",
-            "title": "The P-smooth Sequence",
-            "summary": "smoothSeq enumeration and properties",
-            "startLine": 74,
-            "endLine": 93,
-            "mathContext": "$(a_n)$: the $P$-smooth numbers in increasing order. $a_0 = 1, a_1 = \\\\min P, \\\\ldots$"
-        },
-        {
-            "id": "partial-lcm",
-            "title": "Partial LCM",
-            "summary": "L_n = [a_0,...,a_{n-1}] definition and properties",
-            "startLine": 94,
-            "endLine": 129,
-            "mathContext": "$L_n = \\\\text{lcm}(a_0, a_1, \\\\ldots, a_{n-1})$: partial LCM of the first $n$ smooth numbers."
-        },
-        {
-            "id": "series",
-            "title": "The Series",
-            "summary": "lcmSeries definition, convergence, positivity",
-            "startLine": 130,
-            "endLine": 152,
-            "mathContext": "$\\\\sum_{n=0}^\\\\infty 1/L_n$: converges (since $L_n$ grows super-exponentially). The sum is a well-defined positive real."
-        },
-        {
-            "id": "main-conjecture",
-            "title": "The Main Conjecture (OPEN)",
-            "summary": "erdos_269 axiom for finite P",
-            "startLine": 153,
-            "endLine": 176,
-            "mathContext": "OPEN: $\\\\sum 1/L_n$ is irrational for all finite $P$ with $|P| \\\\geq 2$. Connects smooth number LCMs to irrationality."
-        },
-        {
-            "id": "infinite-case",
-            "title": "The Infinite Case (SOLVED)",
-            "summary": "erdos_269_infinite axiom",
-            "startLine": 177,
-            "endLine": 193,
-            "mathContext": "When $P$ is the set of all primes: $L_n = \\\\text{lcm}(1,\\\\ldots,n)$ and $\\\\sum 1/\\\\text{lcm}(1,\\\\ldots,n)$ is known to be irrational."
-        },
-        {
-            "id": "examples",
-            "title": "Part VII: Examples",
-            "summary": "P = {2,3} worked examples",
-            "startLine": 180,
-            "endLine": 195,
-            "mathContext": "$P = \\\\{2,3\\\\}$: smooth numbers 1,2,3,4,6,8,9,12,... LCMs: 1,2,6,12,12,24,..."
-        },
-        {
-            "id": "padic",
-            "title": "Part VIII: Structural Properties",
-            "summary": "P-adic valuation analysis",
-            "startLine": 196,
-            "endLine": 209,
-            "mathContext": "$p$-adic valuation $v_p(L_n) = \\\\max v_p(a_i)$ for $i < n$. Controls the growth of $L_n$."
-        },
-        {
-            "id": "difficulty",
-            "title": "Part IX: Why It's Hard",
-            "summary": "Analysis of the finite P difficulty",
-            "startLine": 210,
-            "endLine": 223,
-            "mathContext": "For finite $P$: the structure of $L_n$ depends on how primes in $P$ interleave. Harder than the all-primes case."
-        },
-        {
-            "id": "partial-result",
-            "title": "Part X: Known Partial Result",
-            "summary": "Distinct terms case is solved (distinctLcmTerms, erdos_269_distinct axiom)",
-            "startLine": 224,
-            "endLine": 241,
-            "mathContext": "Distinct terms case solved: when all $L_n$ are distinct, irrationality follows from standard criteria."
-        },
-        {
-            "id": "summary",
-            "title": "Part XI: Summary",
-            "summary": "erdos_269_summary theorem, erdos_269_conjecture restating the main open problem",
-            "startLine": 242,
-            "endLine": 275,
-            "mathContext": "OPEN for finite $P$ with $|P| \\\\geq 2$. Solved for $P$ = all primes. Partial: distinct-LCM case."
-        }
+  "id": "erdos-269",
+  "title": "Erdos Problem #269: LCM Series Irrationality",
+  "slug": "erdos-269",
+  "description": "For P a finite set of primes with |P|>=2, let {a_n} be the P-smooth numbers and L_n=[a_0,...,a_{n-1}]. Is the sum 1/L_1 + 1/L_2 + ... irrational? OPEN for finite P. Solved (always irrational) for infinite P.",
+  "meta": {
+    "author": "Erdos (1973)",
+    "sourceUrl": "https://erdosproblems.com/269",
+    "date": "1973",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos269Problem.lean",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "irrationality",
+      "lcm",
+      "smooth-numbers",
+      "series",
+      "open-problem"
     ],
-    "conclusion": {
-        "summary": "Erdos Problem #269 asks whether the sum of reciprocals of successive LCMs of P-smooth numbers is irrational, for finite sets P of primes with |P|>=2. The infinite P case is solved (always irrational). The finite P case with distinct terms removed is also solved. The full finite P case remains OPEN.",
-        "implications": "**Theoretical Significance**: **Number-Theoretic Connections**\n\n1. **Smooth Numbers:** Understanding P-smooth number distribution is key to many algorithms (integer factorization, number field sieve)\n\n2. **Irrationality Theory:** Connects to general irrationality of series questions\n\n**3. P-adic Analysis:** The p-adic structure of LCMs reveals arithmetic patterns\n\n4. **Fibonacci Connection:** Problem appeared in Fibonacci Quarterly, linking to recurrence relations\n\n5. **Multiplicative Structure:** P-smooth numbers form a multiplicative semigroup.",
-        "openQuestions": [
-            "Is the series irrational for any specific finite P with |P| >= 2?",
-            "Can the duplicate pattern be characterized precisely?",
-            "What is the exact growth rate of L_n for various P?",
-            "Is there a closed form for the series for simple P like {2,3}?",
-            "Can transcendence methods be applied to this series?"
-        ]
-    },
-    "leanFile": {
-        "imports": [
-            "Mathlib"
-        ],
-        "opens": [
-            "Nat",
-            "BigOperators",
-            "Finset"
-        ],
-        "namespace": "Erdos269",
-        "lineCount": 287,
-        "axiomCount": 3,
-        "theoremCount": 14,
-        "definitionCount": 9
-    },
-    "crossReferences": [
-        {
-            "targetId": "erdos-1049",
-            "relationship": "related",
-            "description": "Related Erdős problem sharing themes: irrationality, number-theory, series"
-        },
-        {
-            "targetId": "erdos-1050",
-            "relationship": "related",
-            "description": "Related Erdős problem sharing themes: irrationality, number-theory, series"
-        },
-        {
-            "targetId": "erdos-1051",
-            "relationship": "related",
-            "description": "Related Erdős problem sharing themes: irrationality, number-theory, series"
-        }
+    "badge": "axiom",
+    "sorries": 0,
+    "erdosNumber": 269,
+    "erdosUrl": "https://erdosproblems.com/269",
+    "erdosProblemStatus": "open",
+    "dateAdded": "2026-01-25",
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.Prime",
+        "description": "Prime number predicate",
+        "module": "Mathlib.Data.Nat.Prime.Basic"
+      },
+      {
+        "theorem": "Finset.lcm",
+        "description": "LCM over finite sets",
+        "module": "Mathlib.Data.Finset.Lattice"
+      },
+      {
+        "theorem": "Irrational",
+        "description": "Irrationality predicate for reals",
+        "module": "Mathlib.Data.Real.Irrational"
+      },
+      {
+        "theorem": "tsum",
+        "description": "Infinite series summation",
+        "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
+      },
+      {
+        "theorem": "Nat.padicValNat",
+        "description": "P-adic valuation of natural numbers",
+        "module": "Mathlib.NumberTheory.Padics.PadicVal"
+      }
+    ],
+    "originalContributions": [
+      "IsPSmooth definition: n has all prime divisors in P",
+      "smoothSeq definition: enumeration of P-smooth numbers",
+      "partialLcm definition: L_n = [a_0,...,a_{n-1}]",
+      "lcmSeries definition: sum of 1/L_n",
+      "erdos_269 axiom: series is irrational for finite P (OPEN)",
+      "erdos_269_infinite axiom: series is irrational for infinite P (SOLVED)",
+      "erdos_269_distinct axiom: distinct-term series is irrational",
+      "twoThreeSmooth example: P = {2,3}",
+      "lcmPadicVal definition: p-adic valuation of L_n",
+      "distinctLcmSeries definition: series without duplicate terms"
+    ],
+    "axiomCount": 3,
+    "lineCount": 287,
+    "assumptions": "3 axiom(s): erdos_269 (main conjecture, OPEN), erdos_269_infinite (infinite P case), erdos_269_distinct (distinct LCM case). Former axiom smoothSeq_zero now proved."
+  },
+  "overview": {
+    "historicalContext": "**Erdos Problem #269: LCM Series Irrationality**\n\nThis problem was posed by Erdos in a letter to the editor of the Fibonacci Quarterly (January 1, 1973), published in Vol. 12 (1974), p. 335.\n\n**Key History:**\n- Erdos (1973): Original problem statement\n- [ErGr80, p.65]: Referenced in Erdos-Graham collaboration\n- [Er88c, p.106]: Further discussion\n\n**The Setting:**\nP-smooth numbers (or P-friable numbers) are integers whose prime factors all come from a fixed set P. When P = {2,3}, these are the 3-smooth numbers: 1, 2, 3, 4, 6, 8, 9, 12, 16, 18, 24, 27, ...\n\nThe series sums reciprocals of successive LCMs of these numbers.",
+    "problemStatement": "**Problem Statement**\n\nLet P be a finite set of primes with |P| >= 2.\nLet {a_1 < a_2 < ...} be the set of positive integers whose prime divisors are all in P.\nLet L_n = [a_1, ..., a_n] be the LCM of the first n such integers.\n\n**Question:** Is the sum $\\sum_{n=1}^{\\infty} \\frac{1}{L_n}$ irrational?\n\n**Status:**\n- Finite P: OPEN\n- Infinite P: SOLVED (always irrational, 'simple exercise' per Erdos)\n- Finite P, distinct terms only: SOLVED (irrational)",
+    "text": "For P a finite set of primes with |P|>=2, let {a_n} be the P-smooth numbers and L_n=[a_0,...,a_{n-1}]. Is the sum 1/L_1 + 1/L_2 + ... irrational? OPEN for finite P. Solved (always irrational) for infinite P.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **P-smooth Numbers:** Define IsPSmooth P n predicate\n\n2. **Enumeration:** Define smoothSeq P as the sequence of P-smooth numbers\n\n3. **Partial LCM:** Define L_n = lcm(a_0, ..., a_{n-1})\n\n4. **The Series:** Define lcmSeries P = sum of 1/L_n\n\n5. **Main Conjecture:** State erdos_269 as axiom for finite P\n\n6. **Infinite Case:** State erdos_269_infinite as axiom (SOLVED)\n\n7. **P-adic Analysis:** Key to understanding LCM growth patterns\n\n8. **Examples:** Work through P = {2,3} case explicitly",
+    "keyInsights": [
+      "**P-smooth Numbers:** Integers with all prime factors in P; for P={2,3} these are 3-smooth: 1,2,3,4,6,8,9,...",
+      "**LCM Growth:** L_n grows when a new prime power enters the sequence; stays constant otherwise",
+      "**Infinite P Case:** 'Simple exercise' - infinitely many primes ensure irrationality",
+      "**Duplicate Terms:** When a_n | L_{n-1}, we get L_n = L_{n-1}, creating duplicates",
+      "**Distinct Terms:** Removing duplicates makes the series provably irrational",
+      "**P-adic Valuation:** v_p(L_n) increases in discrete jumps at powers of p",
+      "**The Difficulty:** For finite P, pattern of duplicates is hard to analyze"
+    ],
+    "prerequisites": [
+      "Smooth numbers ($P$-smooth: all prime factors in $P$)",
+      "LCM of integer sequences",
+      "Irrationality criteria (e.g., Erdos-Straus)",
+      "$p$-adic valuations and arithmetic functions",
+      "Diophantine approximation"
     ]
+  },
+  "sections": [
+    {
+      "id": "psmooth",
+      "title": "P-smooth Numbers",
+      "summary": "IsPSmooth definition, basic properties",
+      "startLine": 34,
+      "endLine": 73,
+      "mathContext": "$n$ is $P$-smooth if all prime factors of $n$ are in $P$. Example: $P = \\\\{2,3\\\\}$, smooth numbers are $\\\\{1, 2, 3, 4, 6, 8, 9, \\\\ldots\\\\}$."
+    },
+    {
+      "id": "sequence",
+      "title": "The P-smooth Sequence",
+      "summary": "smoothSeq enumeration and properties",
+      "startLine": 74,
+      "endLine": 93,
+      "mathContext": "$(a_n)$: the $P$-smooth numbers in increasing order. $a_0 = 1, a_1 = \\\\min P, \\\\ldots$"
+    },
+    {
+      "id": "partial-lcm",
+      "title": "Partial LCM",
+      "summary": "L_n = [a_0,...,a_{n-1}] definition and properties",
+      "startLine": 94,
+      "endLine": 129,
+      "mathContext": "$L_n = \\\\text{lcm}(a_0, a_1, \\\\ldots, a_{n-1})$: partial LCM of the first $n$ smooth numbers."
+    },
+    {
+      "id": "series",
+      "title": "The Series",
+      "summary": "lcmSeries definition, convergence, positivity",
+      "startLine": 130,
+      "endLine": 152,
+      "mathContext": "$\\\\sum_{n=0}^\\\\infty 1/L_n$: converges (since $L_n$ grows super-exponentially). The sum is a well-defined positive real."
+    },
+    {
+      "id": "main-conjecture",
+      "title": "The Main Conjecture (OPEN)",
+      "summary": "erdos_269 axiom for finite P",
+      "startLine": 153,
+      "endLine": 176,
+      "mathContext": "OPEN: $\\\\sum 1/L_n$ is irrational for all finite $P$ with $|P| \\\\geq 2$. Connects smooth number LCMs to irrationality."
+    },
+    {
+      "id": "infinite-case",
+      "title": "The Infinite Case (SOLVED)",
+      "summary": "erdos_269_infinite axiom",
+      "startLine": 177,
+      "endLine": 193,
+      "mathContext": "When $P$ is the set of all primes: $L_n = \\\\text{lcm}(1,\\\\ldots,n)$ and $\\\\sum 1/\\\\text{lcm}(1,\\\\ldots,n)$ is known to be irrational."
+    },
+    {
+      "id": "examples",
+      "title": "Part VII: Examples",
+      "summary": "P = {2,3} worked examples",
+      "startLine": 180,
+      "endLine": 195,
+      "mathContext": "$P = \\\\{2,3\\\\}$: smooth numbers 1,2,3,4,6,8,9,12,... LCMs: 1,2,6,12,12,24,..."
+    },
+    {
+      "id": "padic",
+      "title": "Part VIII: Structural Properties",
+      "summary": "P-adic valuation analysis",
+      "startLine": 196,
+      "endLine": 209,
+      "mathContext": "$p$-adic valuation $v_p(L_n) = \\\\max v_p(a_i)$ for $i < n$. Controls the growth of $L_n$."
+    },
+    {
+      "id": "difficulty",
+      "title": "Part IX: Why It's Hard",
+      "summary": "Analysis of the finite P difficulty",
+      "startLine": 210,
+      "endLine": 223,
+      "mathContext": "For finite $P$: the structure of $L_n$ depends on how primes in $P$ interleave. Harder than the all-primes case."
+    },
+    {
+      "id": "partial-result",
+      "title": "Part X: Known Partial Result",
+      "summary": "Distinct terms case is solved (distinctLcmTerms, erdos_269_distinct axiom)",
+      "startLine": 224,
+      "endLine": 241,
+      "mathContext": "Distinct terms case solved: when all $L_n$ are distinct, irrationality follows from standard criteria."
+    },
+    {
+      "id": "summary",
+      "title": "Part XI: Summary",
+      "summary": "erdos_269_summary theorem, erdos_269_conjecture restating the main open problem",
+      "startLine": 242,
+      "endLine": 275,
+      "mathContext": "OPEN for finite $P$ with $|P| \\\\geq 2$. Solved for $P$ = all primes. Partial: distinct-LCM case."
+    }
+  ],
+  "conclusion": {
+    "summary": "Erdos Problem #269 asks whether the sum of reciprocals of successive LCMs of P-smooth numbers is irrational, for finite sets P of primes with |P|>=2. The infinite P case is solved (always irrational). The finite P case with distinct terms removed is also solved. The full finite P case remains OPEN.",
+    "implications": "**Theoretical Significance**: **Number-Theoretic Connections**\n\n1. **Smooth Numbers:** Understanding P-smooth number distribution is key to many algorithms (integer factorization, number field sieve)\n\n2. **Irrationality Theory:** Connects to general irrationality of series questions\n\n**3. P-adic Analysis:** The p-adic structure of LCMs reveals arithmetic patterns\n\n4. **Fibonacci Connection:** Problem appeared in Fibonacci Quarterly, linking to recurrence relations\n\n5. **Multiplicative Structure:** P-smooth numbers form a multiplicative semigroup.",
+    "openQuestions": [
+      "Is the series irrational for any specific finite P with |P| >= 2?",
+      "Can the duplicate pattern be characterized precisely?",
+      "What is the exact growth rate of L_n for various P?",
+      "Is there a closed form for the series for simple P like {2,3}?",
+      "Can transcendence methods be applied to this series?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat",
+      "BigOperators",
+      "Finset"
+    ],
+    "namespace": "Erdos269",
+    "lineCount": 287,
+    "axiomCount": 3,
+    "theoremCount": 14,
+    "definitionCount": 9,
+    "path": "Proofs/Erdos269Problem.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-1049",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: irrationality, number-theory, series"
+    },
+    {
+      "targetId": "erdos-1050",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: irrationality, number-theory, series"
+    },
+    {
+      "targetId": "erdos-1051",
+      "relationship": "related",
+      "description": "Related Erdős problem sharing themes: irrationality, number-theory, series"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-270/meta.json
+++ b/src/data/proofs/erdos-270/meta.json
@@ -171,7 +171,9 @@
     "lineCount": 254,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos270Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-271/meta.json
+++ b/src/data/proofs/erdos-271/meta.json
@@ -176,7 +176,9 @@
     "lineCount": 336,
     "axiomCount": 3,
     "theoremCount": 3,
-    "definitionCount": 14
+    "definitionCount": 14,
+    "path": "Proofs/Erdos271Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-272/meta.json
+++ b/src/data/proofs/erdos-272/meta.json
@@ -153,7 +153,9 @@
     "lineCount": 135,
     "axiomCount": 3,
     "theoremCount": 3,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos272Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-273/meta.json
+++ b/src/data/proofs/erdos-273/meta.json
@@ -183,7 +183,9 @@
         "type": "original",
         "description": "Upper bound on coverage density achievable by any single residue class mod (p−1) for p ≥ 5"
       }
-    ]
+    ],
+    "path": "Proofs/Erdos273Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-274/meta.json
+++ b/src/data/proofs/erdos-274/meta.json
@@ -143,7 +143,9 @@
     "lineCount": 130,
     "axiomCount": 1,
     "theoremCount": 3,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos274Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-275/meta.json
+++ b/src/data/proofs/erdos-275/meta.json
@@ -193,6 +193,8 @@
     "lineCount": 172,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos275Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-276/meta.json
+++ b/src/data/proofs/erdos-276/meta.json
@@ -151,7 +151,9 @@
     "lineCount": 78,
     "axiomCount": 0,
     "theoremCount": 1,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos276Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-277/meta.json
+++ b/src/data/proofs/erdos-277/meta.json
@@ -277,6 +277,8 @@
     "lineCount": 275,
     "axiomCount": 1,
     "theoremCount": 12,
-    "definitionCount": 22
+    "definitionCount": 22,
+    "path": "Proofs/Erdos277Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-278/meta.json
+++ b/src/data/proofs/erdos-278/meta.json
@@ -201,7 +201,9 @@
         "type": "original",
         "description": "Coverage density of a single residue class mod n is exactly 1/n"
       }
-    ]
+    ],
+    "path": "Proofs/Erdos278Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-279/meta.json
+++ b/src/data/proofs/erdos-279/meta.json
@@ -120,7 +120,9 @@
     "lineCount": 85,
     "axiomCount": 2,
     "theoremCount": 0,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos279Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-28-additive-bases/meta.json
+++ b/src/data/proofs/erdos-28-additive-bases/meta.json
@@ -67,7 +67,9 @@
     "lineCount": 647,
     "axiomCount": 2,
     "theoremCount": 15,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos28AdditiveBases.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-28/meta.json
+++ b/src/data/proofs/erdos-28/meta.json
@@ -310,6 +310,8 @@
     "lineCount": 647,
     "axiomCount": 2,
     "theoremCount": 14,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos28AdditiveBases.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-280/meta.json
+++ b/src/data/proofs/erdos-280/meta.json
@@ -148,7 +148,9 @@
     "lineCount": 113,
     "axiomCount": 1,
     "theoremCount": 3,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos280Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-281/meta.json
+++ b/src/data/proofs/erdos-281/meta.json
@@ -137,7 +137,9 @@
     "lineCount": 250,
     "axiomCount": 1,
     "theoremCount": 13,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos281Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-282/meta.json
+++ b/src/data/proofs/erdos-282/meta.json
@@ -149,7 +149,9 @@
     "lineCount": 179,
     "axiomCount": 1,
     "theoremCount": 8,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos282Problem.lean",
+    "sorries": 0
   },
   "references": [
     "Fibonacci (1202): 'Liber Abaci', greedy algorithm for Egyptian fractions",

--- a/src/data/proofs/erdos-283/meta.json
+++ b/src/data/proofs/erdos-283/meta.json
@@ -171,7 +171,9 @@
     "lineCount": 157,
     "axiomCount": 2,
     "theoremCount": 7,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos283Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-284/meta.json
+++ b/src/data/proofs/erdos-284/meta.json
@@ -159,7 +159,9 @@
     "lineCount": 183,
     "axiomCount": 3,
     "theoremCount": 2,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos284Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-285/meta.json
+++ b/src/data/proofs/erdos-285/meta.json
@@ -134,7 +134,9 @@
     "lineCount": 374,
     "axiomCount": 1,
     "theoremCount": 21,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos285Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-286/meta.json
+++ b/src/data/proofs/erdos-286/meta.json
@@ -165,7 +165,9 @@
     "lineCount": 236,
     "axiomCount": 2,
     "theoremCount": 7,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos286Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-287/meta.json
+++ b/src/data/proofs/erdos-287/meta.json
@@ -200,7 +200,9 @@
     "lineCount": 85,
     "axiomCount": 1,
     "theoremCount": 1,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos287Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-288/meta.json
+++ b/src/data/proofs/erdos-288/meta.json
@@ -180,7 +180,9 @@
     "lineCount": 215,
     "axiomCount": 1,
     "theoremCount": 8,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos288Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-289/meta.json
+++ b/src/data/proofs/erdos-289/meta.json
@@ -120,6 +120,8 @@
     "lineCount": 135,
     "axiomCount": 0,
     "theoremCount": 4,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos289Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-29-oq-02/meta.json
+++ b/src/data/proofs/erdos-29-oq-02/meta.json
@@ -9,12 +9,24 @@
     "date": "2026-03-30",
     "status": "verified",
     "proofRepoPath": "Proofs/Erdos29OQ02.lean",
-    "tags": ["number-theory", "combinatorics", "additive-combinatorics"],
+    "tags": [
+      "number-theory",
+      "combinatorics",
+      "additive-combinatorics"
+    ],
     "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
-      {"theorem": "Finset.card_image_le", "description": "Image of a Finset has at most as many elements", "module": "Mathlib.Data.Finset.Image"},
-      {"theorem": "Real.sqrt_le_left", "description": "Square root comparison", "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"}
+      {
+        "theorem": "Finset.card_image_le",
+        "description": "Image of a Finset has at most as many elements",
+        "module": "Mathlib.Data.Finset.Image"
+      },
+      {
+        "theorem": "Real.sqrt_le_left",
+        "description": "Square root comparison",
+        "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
+      }
     ],
     "originalContributions": [
       "Corrected lower bound: |A ∩ [0,N]|² ≥ N+1 for any additive basis A",
@@ -26,7 +38,11 @@
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
     "lineCount": 157,
-    "prerequisites": ["Additive bases", "Sumsets", "Finset cardinality"],
+    "prerequisites": [
+      "Additive bases",
+      "Sumsets",
+      "Finset cardinality"
+    ],
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -40,7 +56,11 @@
       "The proof is structured as a clean calc chain: N+1 = |range(N+1)| ≤ |pairSumImage(basisRestriction)| ≤ |basisRestriction|². Each step is a single named lemma, making the proof transparent to read.",
       "The real-valued form √(N+1) ≤ |A∩[0,N]| requires routing through Real.sqrt_le_left and exact_mod_cast for the ℕ-to-ℝ conversion, illustrating a common Lean 4 pattern for translating between integer and real inequalities."
     ],
-    "prerequisites": ["Additive bases", "Sumsets", "Finset cardinality"]
+    "prerequisites": [
+      "Additive bases",
+      "Sumsets",
+      "Finset cardinality"
+    ]
   },
   "sections": [
     {
@@ -102,17 +122,35 @@
     ]
   },
   "leanFile": {
-    "imports": ["Mathlib"],
+    "imports": [
+      "Mathlib"
+    ],
     "namespace": "Erdos29OQ02",
     "lineCount": 157,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 4,
     "mainTheorems": [
-      {"name": "basis_size_squared_lower_bound", "type": "proved", "description": "N+1 ≤ |A ∩ [0,N]|²"},
-      {"name": "basis_size_lower_bound_correct", "type": "proved", "description": "√(N+1) ≤ |A ∩ [0,N]|"}
-    ]
+      {
+        "name": "basis_size_squared_lower_bound",
+        "type": "proved",
+        "description": "N+1 ≤ |A ∩ [0,N]|²"
+      },
+      {
+        "name": "basis_size_lower_bound_correct",
+        "type": "proved",
+        "description": "√(N+1) ≤ |A ∩ [0,N]|"
+      }
+    ],
+    "path": "Proofs/Erdos29OQ02.lean",
+    "sorries": 0
   },
   "references": [],
-  "mainTheorems": [{"name": "basis_size_lower_bound_correct", "type": "core", "description": "Corrected basis lower bound: √(N+1) ≤ |A ∩ [0,N]|"}]
+  "mainTheorems": [
+    {
+      "name": "basis_size_lower_bound_correct",
+      "type": "core",
+      "description": "Corrected basis lower bound: √(N+1) ≤ |A ∩ [0,N]|"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-29/meta.json
+++ b/src/data/proofs/erdos-29/meta.json
@@ -174,7 +174,9 @@
     "lineCount": 524,
     "axiomCount": 5,
     "theoremCount": 10,
-    "definitionCount": 12
+    "definitionCount": 12,
+    "path": "Proofs/Erdos29Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-290/meta.json
+++ b/src/data/proofs/erdos-290/meta.json
@@ -200,7 +200,9 @@
     "lineCount": 263,
     "axiomCount": 2,
     "theoremCount": 7,
-    "definitionCount": 21
+    "definitionCount": 21,
+    "path": "Proofs/Erdos290Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-291/meta.json
+++ b/src/data/proofs/erdos-291/meta.json
@@ -174,7 +174,9 @@
     "lineCount": 932,
     "axiomCount": 2,
     "theoremCount": 84,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos291Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-292/meta.json
+++ b/src/data/proofs/erdos-292/meta.json
@@ -163,7 +163,9 @@
     "lineCount": 150,
     "axiomCount": 3,
     "theoremCount": 5,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos292Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-293/meta.json
+++ b/src/data/proofs/erdos-293/meta.json
@@ -145,7 +145,9 @@
     "lineCount": 121,
     "axiomCount": 3,
     "theoremCount": 2,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos293Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-294/meta.json
+++ b/src/data/proofs/erdos-294/meta.json
@@ -148,7 +148,9 @@
     "lineCount": 306,
     "axiomCount": 4,
     "theoremCount": 2,
-    "definitionCount": 16
+    "definitionCount": 16,
+    "path": "Proofs/Erdos294Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-295/meta.json
+++ b/src/data/proofs/erdos-295/meta.json
@@ -162,7 +162,9 @@
     "lineCount": 153,
     "axiomCount": 2,
     "theoremCount": 5,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/Erdos295Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-296/meta.json
+++ b/src/data/proofs/erdos-296/meta.json
@@ -175,7 +175,9 @@
     "lineCount": 160,
     "axiomCount": 2,
     "theoremCount": 2,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos296Problem.lean",
+    "sorries": 0
   },
   "references": [
     "Erdős, Graham (1980): 'Old and New Problems and Results in Combinatorial Number Theory', Monographies de l'Enseignement Mathématique 28",

--- a/src/data/proofs/erdos-297/meta.json
+++ b/src/data/proofs/erdos-297/meta.json
@@ -199,7 +199,8 @@
     "axiomCount": 3,
     "sorries": 0,
     "theoremCount": 4,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos297Problem.lean"
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-298/meta.json
+++ b/src/data/proofs/erdos-298/meta.json
@@ -194,7 +194,9 @@
     "lineCount": 227,
     "axiomCount": 4,
     "theoremCount": 3,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos298Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-299/meta.json
+++ b/src/data/proofs/erdos-299/meta.json
@@ -173,7 +173,9 @@
     "lineCount": 387,
     "axiomCount": 1,
     "theoremCount": 10,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos299Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-300/meta.json
+++ b/src/data/proofs/erdos-300/meta.json
@@ -169,7 +169,9 @@
     "lineCount": 265,
     "axiomCount": 4,
     "theoremCount": 4,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos300Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-301/meta.json
+++ b/src/data/proofs/erdos-301/meta.json
@@ -110,7 +110,9 @@
     "lineCount": 158,
     "axiomCount": 0,
     "theoremCount": 2,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos301Problem.lean",
+    "sorries": 0
   },
   "references": [
     "Erdős, P. (1950s): original problem on Egyptian fraction avoidance",

--- a/src/data/proofs/erdos-302/meta.json
+++ b/src/data/proofs/erdos-302/meta.json
@@ -237,7 +237,9 @@
     "lineCount": 414,
     "axiomCount": 3,
     "theoremCount": 18,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos302Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-303/meta.json
+++ b/src/data/proofs/erdos-303/meta.json
@@ -147,7 +147,9 @@
     "lineCount": 259,
     "axiomCount": 2,
     "theoremCount": 8,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos303Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-304/meta.json
+++ b/src/data/proofs/erdos-304/meta.json
@@ -172,7 +172,9 @@
     "lineCount": 192,
     "axiomCount": 5,
     "theoremCount": 1,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos304Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-306/meta.json
+++ b/src/data/proofs/erdos-306/meta.json
@@ -155,7 +155,9 @@
     "lineCount": 242,
     "axiomCount": 2,
     "theoremCount": 2,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos306Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-307-oq-02/meta.json
+++ b/src/data/proofs/erdos-307-oq-02/meta.json
@@ -117,6 +117,8 @@
     "lineCount": 298,
     "axiomCount": 0,
     "theoremCount": 4,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos307OQ02.lean",
+    "sorries": 6
   }
 }

--- a/src/data/proofs/erdos-308/meta.json
+++ b/src/data/proofs/erdos-308/meta.json
@@ -202,6 +202,8 @@
     "lineCount": 277,
     "axiomCount": 3,
     "theoremCount": 3,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos308Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-31/meta.json
+++ b/src/data/proofs/erdos-31/meta.json
@@ -158,7 +158,9 @@
     "lineCount": 786,
     "axiomCount": 1,
     "theoremCount": 28,
-    "definitionCount": 14
+    "definitionCount": 14,
+    "path": "Proofs/Erdos31Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-310/meta.json
+++ b/src/data/proofs/erdos-310/meta.json
@@ -195,7 +195,9 @@
     "lineCount": 308,
     "axiomCount": 1,
     "theoremCount": 12,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos310Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-311/meta.json
+++ b/src/data/proofs/erdos-311/meta.json
@@ -147,7 +147,9 @@
     "lineCount": 103,
     "axiomCount": 0,
     "theoremCount": 3,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos311Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-312/meta.json
+++ b/src/data/proofs/erdos-312/meta.json
@@ -148,7 +148,9 @@
     "lineCount": 718,
     "axiomCount": 1,
     "theoremCount": 58,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos312Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-313/meta.json
+++ b/src/data/proofs/erdos-313/meta.json
@@ -146,7 +146,9 @@
     "lineCount": 122,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos313Problem.lean",
+    "sorries": 0
   },
   "references": [
     "Erdős, Graham (1980): 'Old and New Problems and Results in Combinatorial Number Theory', Monographies de l'Enseignement Mathématique 28, p.30",

--- a/src/data/proofs/erdos-315/meta.json
+++ b/src/data/proofs/erdos-315/meta.json
@@ -211,7 +211,9 @@
     "lineCount": 258,
     "axiomCount": 4,
     "theoremCount": 13,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos315Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-316/meta.json
+++ b/src/data/proofs/erdos-316/meta.json
@@ -176,7 +176,9 @@
     "lineCount": 116,
     "axiomCount": 1,
     "theoremCount": 4,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/Erdos316Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-317/meta.json
+++ b/src/data/proofs/erdos-317/meta.json
@@ -153,7 +153,9 @@
     "lineCount": 192,
     "axiomCount": 0,
     "theoremCount": 8,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos317Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-319/meta.json
+++ b/src/data/proofs/erdos-319/meta.json
@@ -132,7 +132,9 @@
     "lineCount": 191,
     "axiomCount": 2,
     "theoremCount": 2,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos319Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-32/meta.json
+++ b/src/data/proofs/erdos-32/meta.json
@@ -186,7 +186,9 @@
     "lineCount": 264,
     "axiomCount": 3,
     "theoremCount": 3,
-    "definitionCount": 12
+    "definitionCount": 12,
+    "path": "Proofs/Erdos32Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-320/meta.json
+++ b/src/data/proofs/erdos-320/meta.json
@@ -211,7 +211,9 @@
     "lineCount": 232,
     "axiomCount": 2,
     "theoremCount": 9,
-    "definitionCount": 15
+    "definitionCount": 15,
+    "path": "Proofs/Erdos320Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-321/meta.json
+++ b/src/data/proofs/erdos-321/meta.json
@@ -194,7 +194,9 @@
         "type": "tautology",
         "description": "Tautological existence: ∃ f, R(N) = f(N), proved by rfl — the real content is the axiomatized Bleicher–Erdős bounds"
       }
-    ]
+    ],
+    "path": "Proofs/Erdos321Problem.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/erdos-322/meta.json
+++ b/src/data/proofs/erdos-322/meta.json
@@ -168,7 +168,9 @@
     "lineCount": 182,
     "axiomCount": 3,
     "theoremCount": 2,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos322Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-323/meta.json
+++ b/src/data/proofs/erdos-323/meta.json
@@ -1,174 +1,176 @@
 {
-    "id": "erdos-323",
-    "title": "Erdős Problem #323: Sums of k-th Powers Counting Function",
-    "slug": "erdos-323",
-    "description": "How many integers ≤ x are sums of m nonneg k-th powers? Conjectured: f_{k,k}(x) ≫ x^{1-ε} and f_{k,m}(x) ≫ x^{m/k} for m < k.",
-    "meta": {
-        "author": "Erdős–Graham, Landau (1908, k=2)",
-        "sourceUrl": "https://erdosproblems.com/323",
-        "date": "1980",
-        "status": "axiomatized",
-        "proofRepoPath": "Proofs/Erdos323Problem.lean",
-        "tags": [
-            "erdos",
-            "number-theory",
-            "waring-problem",
-            "sums-of-powers",
-            "counting-functions",
-            "open"
-        ],
-        "badge": "axiom",
-        "sorries": 0,
-        "erdosNumber": 323,
-        "erdosUrl": "https://erdosproblems.com/323",
-        "erdosProblemStatus": "open",
-        "dateAdded": "2026-01-19",
-        "prerequisites": [
-            "Waring's problem and sums of powers",
-            "Counting representations r_k(n)",
-            "Asymptotic analysis and Filter.atTop",
-            "Finset.card for counting"
-        ],
-        "mathlib_version": "4.26.0",
-        "mathlibDependencies": [
-            {
-                "theorem": "Finset.filter",
-                "description": "Filtering finite sets by predicate",
-                "module": "Mathlib.Data.Finset.Basic"
-            },
-            {
-                "theorem": "Finset.sum",
-                "description": "Summation over finite sets",
-                "module": "Mathlib.Algebra.BigOperators.Group.Finset"
-            }
-        ],
-        "originalContributions": [
-            "IsSumOfPowers predicate",
-            "powerSumCount (f_{k,m}(x)) counting function",
-            "first_power_count and power_sum_count_mono axioms",
-            "landau_two_squares axiom",
-            "ErdosProblem323_part1 and ErdosProblem323_part2 definitions",
-            "DensityQuestion definition"
-        ],
-        "axiomCount": 1,
-        "lineCount": 105,
-        "assumptions": "3 axiom(s): first_power_count, power_sum_count_mono, landau_two_squares. See Lean source for complete statements."
-    },
-    "overview": {
-        "historicalContext": "Erdős and Graham posed this problem in their 1980 monograph, asking about the counting function f_{k,m}(x) of integers representable as sums of m nonnegative k-th powers. The question is rooted in the classical Waring problem (every integer is a sum of g(k) k-th powers, proved by Hilbert 1909), but shifts focus from representation of all integers to counting how many integers have representations with fewer summands. Landau (1908) completely resolved k = 2 by showing f_{2,2}(x) ~ c·x/√(log x), where c is the Landau-Ramanujan constant arising from the multiplicative structure of sums of two squares (Fermat's theorem). For k > 2, the situation is dramatically different: even whether f_{k,k}(x) = o(x) (zero density) is unknown. The circle method of Hardy-Littlewood-Vinogradov is the primary tool for Waring's problem, but it gives asymptotic formulas only when the number of summands exceeds k. Erdős described the regime m ≤ k as 'unattackable by the methods at our disposal.'",
-        "problemStatement": "Is f_{k,k}(x) ≫_ε x^{1-ε}? For m < k, is f_{k,m}(x) ≫ x^{m/k}?",
-        "text": "How many integers ≤ x are sums of m nonneg k-th powers? Conjectured: f_{k,k}(x) ≫ x^{1-ε} and f_{k,m}(x) ≫ x^{m/k} for m < k.",
-        "proofStrategy": "The formalization builds from the predicate IsSumOfPowers (using Fin m → ℕ tuples and Finset.sum) to the counting function powerSumCount via Finset filtering. Two structural axioms establish the degenerate case (k = 1) and monotonicity in summand count. Landau's deep analytic result is axiomatized as an existence statement for the Landau-Ramanujan constant. The two main conjectures are encoded as Prop definitions with explicit ε-quantifier structure, and a separate DensityQuestion captures the strictly weaker open problem about zero density for k > 2.",
-        "keyInsights": [
-            "f_{k,m}(x) counts integers ≤ x that are sums of m k-th powers, shifting Waring's problem from universality to density",
-            "Landau's 1908 theorem f_{2,2}(x) ~ c·x/√(log x) resolves k = 2, with the √(log x) correction arising from the multiplicative criterion for sums of two squares (Fermat's theorem)",
-            "For k > 2, it is unknown whether f_{k,k}(x) has positive density — the Hardy-Littlewood circle method fails when the number of summands equals the power",
-            "The conjectured lower bounds x^{1-ε} (m = k) and x^{m/k} (m < k) reflect a dimensional heuristic: m summands each up to x^{1/k} should produce ~x^{m/k} distinct sums, but controlling collisions is the key difficulty",
-            "The two parts have different quantifier structures: Part 1 requires an ε-dependent bound (near-density), while Part 2 gives a clean power law x^{m/k}, reflecting their fundamentally different mathematical characters"
-        ],
-        "prerequisites": [
-            "Waring's problem and sums of powers",
-            "Counting representations r_k(n)",
-            "Asymptotic analysis and Filter.atTop",
-            "Finset.card for counting"
-        ]
-    },
-    "sections": [
-        {
-            "id": "sums-of-powers",
-            "title": "Sums of k-th Powers",
-            "startLine": 24,
-            "endLine": 36,
-            "summary": "Defines `IsSumOfPowers(n,k,m)` ($\\exists x_1,\\ldots,x_m: n = \\sum x_i^k$) and `powerSumCount` ($f_{k,m}(x) = |\\{n \\le x : \\text{IsSumOfPowers}(n,k,m)\\}|$).",
-            "mathContext": "$\\text{IsSumOfPowers}(n, k, m) \\iff \\exists x_1, \\ldots, x_m \\in \\mathbb{N}: n = \\sum_{i=1}^{m} x_i^k$. $f_{k,m}(x) = |\\{n \\le x : \\text{IsSumOfPowers}(n,k,m)\\}|$."
-        },
-        {
-            "id": "basic-properties",
-            "title": "Basic Properties",
-            "startLine": 37,
-            "endLine": 45,
-            "summary": "Trivial case $k=1$: $f_{1,m}(x) \\ge m$. Monotonicity: $f_{k,m}(x) \\le f_{k,m+1}(x)$ via zero-padding ($0^k = 0$).",
-            "mathContext": "$f_{1,m}(x) \\ge m$ (trivial for first powers). $f_{k,m}(x) \\le f_{k,m+1}(x)$ (monotonicity via zero-padding)."
-        },
-        {
-            "id": "landau",
-            "title": "Landau's Theorem",
-            "startLine": 46,
-            "endLine": 53,
-            "summary": "Landau's theorem: $f_{2,2}(x) \\sim c \\cdot x / \\sqrt{\\log x}$ where $c \\approx 0.7642$ is the Landau–Ramanujan constant. Resolves $k = 2$.",
-            "mathContext": "$f_{2,2}(x) \\sim \\frac{c \\cdot x}{\\sqrt{\\log x}}$ where $c = \\frac{1}{\\sqrt{2}} \\prod_{p \\equiv 3 \\pmod{4}} \\frac{1}{\\sqrt{1 - p^{-2}}}$ (Landau-Ramanujan constant). An integer is a sum of two squares iff every prime $p \\equiv 3 \\pmod{4}$ divides it to an even power."
-        },
-        {
-            "id": "main-conjectures",
-            "title": "Main Conjectures",
-            "startLine": 54,
-            "endLine": 76,
-            "summary": "Part 1: $f_{k,k}(x) \\gg_{\\varepsilon} x^{1-\\varepsilon}$ (near-full density). Part 2: $f_{k,m}(x) \\gg x^{m/k}$ for $m < k$ (dimensional lower bound). Combined as `ErdosProblem323`.",
-            "mathContext": "Part 1: $\\forall k \\ge 2,\\, \\forall \\varepsilon > 0,\\, \\exists c > 0,\\, x_0: f_{k,k}(x) \\ge c \\cdot x^{1-\\varepsilon}$ for $x \\ge x_0$. Part 2: $\\forall 1 \\le m < k,\\, k \\ge 2,\\, \\exists c > 0,\\, x_0: f_{k,m}(x) \\ge c \\cdot x^{m/k}$ for $x \\ge x_0$."
-        },
-        {
-            "id": "density-question",
-            "title": "Density Question",
-            "startLine": 77,
-            "endLine": 84,
-            "summary": "Open: is $f_{k,k}(x) = o(x)$ for $k > 2$? Known for $k = 2$ (Landau). `DensityQuestion(k)` formalizes $\\lim f_{k,k}(x)/x = 0$.",
-            "mathContext": "$\\text{DensityQuestion}(k) \\iff \\forall \\varepsilon > 0,\\, \\exists x_0: f_{k,k}(x) < \\varepsilon \\cdot x$ for $x \\ge x_0$. Equivalently, $f_{k,k}(x) = o(x)$. Known for $k = 2$ (Landau), open for $k > 2$."
-        }
+  "id": "erdos-323",
+  "title": "Erdős Problem #323: Sums of k-th Powers Counting Function",
+  "slug": "erdos-323",
+  "description": "How many integers ≤ x are sums of m nonneg k-th powers? Conjectured: f_{k,k}(x) ≫ x^{1-ε} and f_{k,m}(x) ≫ x^{m/k} for m < k.",
+  "meta": {
+    "author": "Erdős–Graham, Landau (1908, k=2)",
+    "sourceUrl": "https://erdosproblems.com/323",
+    "date": "1980",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos323Problem.lean",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "waring-problem",
+      "sums-of-powers",
+      "counting-functions",
+      "open"
     ],
-    "conclusion": {
-        "summary": "The formalization captures both conjectures of Erdős Problem 323 about the growth of sums-of-powers counting functions, together with Landau's resolved k = 2 case and the open density question for k > 2.",
-        "implications": "Resolving these conjectures would require fundamentally new techniques beyond the Hardy-Littlewood circle method, which needs m >> k summands for sharp results. Progress would illuminate the transition between the 'easy' regime (m large, full density by Waring's theorem) and the 'hard' regime (m ≤ k, unknown density), a frontier of additive number theory.",
-        "openQuestions": [
-            "Is f_{k,k}(x) = o(x) for k > 2? Even this weaker zero-density question remains open.",
-            "Is f_{k,k}(x) ≫ x^{1-ε} for all ε > 0? This would place sums-of-powers density just below full density.",
-            "Is f_{k,m}(x) ≫ x^{m/k} for m < k? The dimensional heuristic predicts yes, but collision bounds are missing.",
-            "What is the exact asymptotic of f_{k,m}(x) for k > 2? Can Landau's product formula approach generalize?",
-            "Can the Landau-Ramanujan constant's infinite product structure be extended to k > 2, or does the absence of a multiplicative characterization for sums of higher powers preclude this?"
-        ]
-    },
-    "crossReferences": [
-        {
-            "relationship": "related-problem",
-            "description": "Both involve counting integers with specific additive representations: #323 counts sums of k-th powers, #362 counts subsets with a given sum",
-            "targetId": "erdos-362"
-        },
-        {
-            "relationship": "foundation",
-            "description": "Fermat's theorem on sums of two squares provides the multiplicative criterion underlying Landau's asymptotic for f_{2,2}(x)",
-            "targetId": "fermat-two-squares"
-        },
-        {
-            "relationship": "technique",
-            "description": "The prime number theorem underlies the analytic number theory techniques used in Landau's proof of f_{2,2}(x) ~ c·x/√(log x)",
-            "targetId": "prime-number-theorem"
-        }
+    "badge": "axiom",
+    "sorries": 0,
+    "erdosNumber": 323,
+    "erdosUrl": "https://erdosproblems.com/323",
+    "erdosProblemStatus": "open",
+    "dateAdded": "2026-01-19",
+    "prerequisites": [
+      "Waring's problem and sums of powers",
+      "Counting representations r_k(n)",
+      "Asymptotic analysis and Filter.atTop",
+      "Finset.card for counting"
     ],
-    "leanFile": {
-        "imports": [
-            "Mathlib.Data.Nat.Basic",
-            "Mathlib.Data.Finset.Basic",
-            "Mathlib.Data.Rat.Basic",
-            "Mathlib.Tactic"
-        ],
-        "opens": [],
-        "namespace": null,
-        "lineCount": 105,
-        "axiomCount": 1,
-        "theoremCount": 0,
-        "definitionCount": 6
-    },
-    "references": [
-        {
-            "title": "Über die Einteilung der positiven ganzen Zahlen in vier Klassen",
-            "year": "1908",
-            "authors": "Landau 1908",
-            "note": "Proved f_{2,2}(x) ~ c·x/√(log x), resolving k = 2"
-        },
-        {
-            "title": "Old and New Problems and Results in Combinatorial Number Theory",
-            "year": "1980",
-            "authors": "Erdős–Graham 1980",
-            "note": "Original source of both conjectures"
-        }
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.filter",
+        "description": "Filtering finite sets by predicate",
+        "module": "Mathlib.Data.Finset.Basic"
+      },
+      {
+        "theorem": "Finset.sum",
+        "description": "Summation over finite sets",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset"
+      }
+    ],
+    "originalContributions": [
+      "IsSumOfPowers predicate",
+      "powerSumCount (f_{k,m}(x)) counting function",
+      "first_power_count and power_sum_count_mono axioms",
+      "landau_two_squares axiom",
+      "ErdosProblem323_part1 and ErdosProblem323_part2 definitions",
+      "DensityQuestion definition"
+    ],
+    "axiomCount": 1,
+    "lineCount": 105,
+    "assumptions": "3 axiom(s): first_power_count, power_sum_count_mono, landau_two_squares. See Lean source for complete statements."
+  },
+  "overview": {
+    "historicalContext": "Erdős and Graham posed this problem in their 1980 monograph, asking about the counting function f_{k,m}(x) of integers representable as sums of m nonnegative k-th powers. The question is rooted in the classical Waring problem (every integer is a sum of g(k) k-th powers, proved by Hilbert 1909), but shifts focus from representation of all integers to counting how many integers have representations with fewer summands. Landau (1908) completely resolved k = 2 by showing f_{2,2}(x) ~ c·x/√(log x), where c is the Landau-Ramanujan constant arising from the multiplicative structure of sums of two squares (Fermat's theorem). For k > 2, the situation is dramatically different: even whether f_{k,k}(x) = o(x) (zero density) is unknown. The circle method of Hardy-Littlewood-Vinogradov is the primary tool for Waring's problem, but it gives asymptotic formulas only when the number of summands exceeds k. Erdős described the regime m ≤ k as 'unattackable by the methods at our disposal.'",
+    "problemStatement": "Is f_{k,k}(x) ≫_ε x^{1-ε}? For m < k, is f_{k,m}(x) ≫ x^{m/k}?",
+    "text": "How many integers ≤ x are sums of m nonneg k-th powers? Conjectured: f_{k,k}(x) ≫ x^{1-ε} and f_{k,m}(x) ≫ x^{m/k} for m < k.",
+    "proofStrategy": "The formalization builds from the predicate IsSumOfPowers (using Fin m → ℕ tuples and Finset.sum) to the counting function powerSumCount via Finset filtering. Two structural axioms establish the degenerate case (k = 1) and monotonicity in summand count. Landau's deep analytic result is axiomatized as an existence statement for the Landau-Ramanujan constant. The two main conjectures are encoded as Prop definitions with explicit ε-quantifier structure, and a separate DensityQuestion captures the strictly weaker open problem about zero density for k > 2.",
+    "keyInsights": [
+      "f_{k,m}(x) counts integers ≤ x that are sums of m k-th powers, shifting Waring's problem from universality to density",
+      "Landau's 1908 theorem f_{2,2}(x) ~ c·x/√(log x) resolves k = 2, with the √(log x) correction arising from the multiplicative criterion for sums of two squares (Fermat's theorem)",
+      "For k > 2, it is unknown whether f_{k,k}(x) has positive density — the Hardy-Littlewood circle method fails when the number of summands equals the power",
+      "The conjectured lower bounds x^{1-ε} (m = k) and x^{m/k} (m < k) reflect a dimensional heuristic: m summands each up to x^{1/k} should produce ~x^{m/k} distinct sums, but controlling collisions is the key difficulty",
+      "The two parts have different quantifier structures: Part 1 requires an ε-dependent bound (near-density), while Part 2 gives a clean power law x^{m/k}, reflecting their fundamentally different mathematical characters"
+    ],
+    "prerequisites": [
+      "Waring's problem and sums of powers",
+      "Counting representations r_k(n)",
+      "Asymptotic analysis and Filter.atTop",
+      "Finset.card for counting"
     ]
+  },
+  "sections": [
+    {
+      "id": "sums-of-powers",
+      "title": "Sums of k-th Powers",
+      "startLine": 24,
+      "endLine": 36,
+      "summary": "Defines `IsSumOfPowers(n,k,m)` ($\\exists x_1,\\ldots,x_m: n = \\sum x_i^k$) and `powerSumCount` ($f_{k,m}(x) = |\\{n \\le x : \\text{IsSumOfPowers}(n,k,m)\\}|$).",
+      "mathContext": "$\\text{IsSumOfPowers}(n, k, m) \\iff \\exists x_1, \\ldots, x_m \\in \\mathbb{N}: n = \\sum_{i=1}^{m} x_i^k$. $f_{k,m}(x) = |\\{n \\le x : \\text{IsSumOfPowers}(n,k,m)\\}|$."
+    },
+    {
+      "id": "basic-properties",
+      "title": "Basic Properties",
+      "startLine": 37,
+      "endLine": 45,
+      "summary": "Trivial case $k=1$: $f_{1,m}(x) \\ge m$. Monotonicity: $f_{k,m}(x) \\le f_{k,m+1}(x)$ via zero-padding ($0^k = 0$).",
+      "mathContext": "$f_{1,m}(x) \\ge m$ (trivial for first powers). $f_{k,m}(x) \\le f_{k,m+1}(x)$ (monotonicity via zero-padding)."
+    },
+    {
+      "id": "landau",
+      "title": "Landau's Theorem",
+      "startLine": 46,
+      "endLine": 53,
+      "summary": "Landau's theorem: $f_{2,2}(x) \\sim c \\cdot x / \\sqrt{\\log x}$ where $c \\approx 0.7642$ is the Landau–Ramanujan constant. Resolves $k = 2$.",
+      "mathContext": "$f_{2,2}(x) \\sim \\frac{c \\cdot x}{\\sqrt{\\log x}}$ where $c = \\frac{1}{\\sqrt{2}} \\prod_{p \\equiv 3 \\pmod{4}} \\frac{1}{\\sqrt{1 - p^{-2}}}$ (Landau-Ramanujan constant). An integer is a sum of two squares iff every prime $p \\equiv 3 \\pmod{4}$ divides it to an even power."
+    },
+    {
+      "id": "main-conjectures",
+      "title": "Main Conjectures",
+      "startLine": 54,
+      "endLine": 76,
+      "summary": "Part 1: $f_{k,k}(x) \\gg_{\\varepsilon} x^{1-\\varepsilon}$ (near-full density). Part 2: $f_{k,m}(x) \\gg x^{m/k}$ for $m < k$ (dimensional lower bound). Combined as `ErdosProblem323`.",
+      "mathContext": "Part 1: $\\forall k \\ge 2,\\, \\forall \\varepsilon > 0,\\, \\exists c > 0,\\, x_0: f_{k,k}(x) \\ge c \\cdot x^{1-\\varepsilon}$ for $x \\ge x_0$. Part 2: $\\forall 1 \\le m < k,\\, k \\ge 2,\\, \\exists c > 0,\\, x_0: f_{k,m}(x) \\ge c \\cdot x^{m/k}$ for $x \\ge x_0$."
+    },
+    {
+      "id": "density-question",
+      "title": "Density Question",
+      "startLine": 77,
+      "endLine": 84,
+      "summary": "Open: is $f_{k,k}(x) = o(x)$ for $k > 2$? Known for $k = 2$ (Landau). `DensityQuestion(k)` formalizes $\\lim f_{k,k}(x)/x = 0$.",
+      "mathContext": "$\\text{DensityQuestion}(k) \\iff \\forall \\varepsilon > 0,\\, \\exists x_0: f_{k,k}(x) < \\varepsilon \\cdot x$ for $x \\ge x_0$. Equivalently, $f_{k,k}(x) = o(x)$. Known for $k = 2$ (Landau), open for $k > 2$."
+    }
+  ],
+  "conclusion": {
+    "summary": "The formalization captures both conjectures of Erdős Problem 323 about the growth of sums-of-powers counting functions, together with Landau's resolved k = 2 case and the open density question for k > 2.",
+    "implications": "Resolving these conjectures would require fundamentally new techniques beyond the Hardy-Littlewood circle method, which needs m >> k summands for sharp results. Progress would illuminate the transition between the 'easy' regime (m large, full density by Waring's theorem) and the 'hard' regime (m ≤ k, unknown density), a frontier of additive number theory.",
+    "openQuestions": [
+      "Is f_{k,k}(x) = o(x) for k > 2? Even this weaker zero-density question remains open.",
+      "Is f_{k,k}(x) ≫ x^{1-ε} for all ε > 0? This would place sums-of-powers density just below full density.",
+      "Is f_{k,m}(x) ≫ x^{m/k} for m < k? The dimensional heuristic predicts yes, but collision bounds are missing.",
+      "What is the exact asymptotic of f_{k,m}(x) for k > 2? Can Landau's product formula approach generalize?",
+      "Can the Landau-Ramanujan constant's infinite product structure be extended to k > 2, or does the absence of a multiplicative characterization for sums of higher powers preclude this?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "relationship": "related-problem",
+      "description": "Both involve counting integers with specific additive representations: #323 counts sums of k-th powers, #362 counts subsets with a given sum",
+      "targetId": "erdos-362"
+    },
+    {
+      "relationship": "foundation",
+      "description": "Fermat's theorem on sums of two squares provides the multiplicative criterion underlying Landau's asymptotic for f_{2,2}(x)",
+      "targetId": "fermat-two-squares"
+    },
+    {
+      "relationship": "technique",
+      "description": "The prime number theorem underlies the analytic number theory techniques used in Landau's proof of f_{2,2}(x) ~ c·x/√(log x)",
+      "targetId": "prime-number-theorem"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Basic",
+      "Mathlib.Data.Finset.Basic",
+      "Mathlib.Data.Rat.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [],
+    "namespace": null,
+    "lineCount": 105,
+    "axiomCount": 1,
+    "theoremCount": 0,
+    "definitionCount": 6,
+    "path": "Proofs/Erdos323Problem.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "title": "Über die Einteilung der positiven ganzen Zahlen in vier Klassen",
+      "year": "1908",
+      "authors": "Landau 1908",
+      "note": "Proved f_{2,2}(x) ~ c·x/√(log x), resolving k = 2"
+    },
+    {
+      "title": "Old and New Problems and Results in Combinatorial Number Theory",
+      "year": "1980",
+      "authors": "Erdős–Graham 1980",
+      "note": "Original source of both conjectures"
+    }
+  ]
 }

--- a/src/data/proofs/erdos-324/meta.json
+++ b/src/data/proofs/erdos-324/meta.json
@@ -204,6 +204,8 @@
     "lineCount": 272,
     "axiomCount": 1,
     "theoremCount": 12,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos324Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-325/meta.json
+++ b/src/data/proofs/erdos-325/meta.json
@@ -135,7 +135,9 @@
     "lineCount": 126,
     "axiomCount": 0,
     "theoremCount": 4,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos325Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-326/meta.json
+++ b/src/data/proofs/erdos-326/meta.json
@@ -134,7 +134,9 @@
     "lineCount": 139,
     "axiomCount": 0,
     "theoremCount": 1,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos326Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-327-oq-01/meta.json
+++ b/src/data/proofs/erdos-327-oq-01/meta.json
@@ -115,7 +115,9 @@
     "opens": [
       "Finset"
     ],
-    "namespace": null
+    "namespace": null,
+    "path": "Proofs/Erdos327OQ01.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/erdos-327/meta.json
+++ b/src/data/proofs/erdos-327/meta.json
@@ -148,7 +148,9 @@
     "lineCount": 198,
     "axiomCount": 1,
     "theoremCount": 7,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos327Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-328/meta.json
+++ b/src/data/proofs/erdos-328/meta.json
@@ -195,7 +195,9 @@
     "lineCount": 207,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos328Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-329/meta.json
+++ b/src/data/proofs/erdos-329/meta.json
@@ -185,7 +185,9 @@
     "lineCount": 198,
     "axiomCount": 2,
     "theoremCount": 5,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos329Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-33/meta.json
+++ b/src/data/proofs/erdos-33/meta.json
@@ -112,7 +112,9 @@
     "lineCount": 172,
     "axiomCount": 1,
     "theoremCount": 2,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos33Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-330/meta.json
+++ b/src/data/proofs/erdos-330/meta.json
@@ -104,7 +104,9 @@
     "lineCount": 65,
     "axiomCount": 1,
     "theoremCount": 0,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/Erdos330Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-331/meta.json
+++ b/src/data/proofs/erdos-331/meta.json
@@ -255,7 +255,9 @@
     "lineCount": 223,
     "axiomCount": 3,
     "theoremCount": 5,
-    "definitionCount": 17
+    "definitionCount": 17,
+    "path": "Proofs/Erdos331Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-332/meta.json
+++ b/src/data/proofs/erdos-332/meta.json
@@ -271,7 +271,9 @@
         "type": "original",
         "description": "0 ∈ D(A) for any infinite A: every element pairs with itself, giving infinitely many witness pairs"
       }
-    ]
+    ],
+    "path": "Proofs/Erdos332Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-333/meta.json
+++ b/src/data/proofs/erdos-333/meta.json
@@ -197,7 +197,9 @@
     "lineCount": 286,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 14
+    "definitionCount": 14,
+    "path": "Proofs/Erdos333Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-335/meta.json
+++ b/src/data/proofs/erdos-335/meta.json
@@ -190,7 +190,9 @@
     "lineCount": 319,
     "axiomCount": 3,
     "theoremCount": 31,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos335Problem.lean",
+    "sorries": 0
   },
   "references": [
     "Erdős, Graham (1980): 'Old and New Problems and Results in Combinatorial Number Theory', Monographies de l'Enseignement Mathématique 28, p. 51",

--- a/src/data/proofs/erdos-336/meta.json
+++ b/src/data/proofs/erdos-336/meta.json
@@ -162,7 +162,9 @@
     "lineCount": 161,
     "axiomCount": 6,
     "theoremCount": 4,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos336Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-337/meta.json
+++ b/src/data/proofs/erdos-337/meta.json
@@ -225,7 +225,9 @@
     "lineCount": 298,
     "axiomCount": 3,
     "theoremCount": 4,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos337Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-338/meta.json
+++ b/src/data/proofs/erdos-338/meta.json
@@ -184,7 +184,9 @@
     "lineCount": 363,
     "axiomCount": 11,
     "theoremCount": 10,
-    "definitionCount": 15
+    "definitionCount": 15,
+    "path": "Proofs/Erdos338Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-339/meta.json
+++ b/src/data/proofs/erdos-339/meta.json
@@ -182,7 +182,9 @@
     "lineCount": 215,
     "axiomCount": 3,
     "theoremCount": 7,
-    "definitionCount": 12
+    "definitionCount": 12,
+    "path": "Proofs/Erdos339Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-34/meta.json
+++ b/src/data/proofs/erdos-34/meta.json
@@ -144,7 +144,9 @@
     "lineCount": 209,
     "axiomCount": 0,
     "theoremCount": 2,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos34Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-340-greedy-sidon/meta.json
+++ b/src/data/proofs/erdos-340-greedy-sidon/meta.json
@@ -213,7 +213,9 @@
     "lineCount": 505,
     "axiomCount": 3,
     "theoremCount": 16,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos340GreedySidon.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-342/meta.json
+++ b/src/data/proofs/erdos-342/meta.json
@@ -151,7 +151,9 @@
     "lineCount": 221,
     "axiomCount": 3,
     "theoremCount": 19,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos342Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-343/meta.json
+++ b/src/data/proofs/erdos-343/meta.json
@@ -142,7 +142,9 @@
     "lineCount": 158,
     "axiomCount": 3,
     "theoremCount": 3,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos343Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-344/meta.json
+++ b/src/data/proofs/erdos-344/meta.json
@@ -164,7 +164,9 @@
     "lineCount": 207,
     "axiomCount": 2,
     "theoremCount": 2,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos344Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-345/meta.json
+++ b/src/data/proofs/erdos-345/meta.json
@@ -179,7 +179,9 @@
     "lineCount": 191,
     "axiomCount": 5,
     "theoremCount": 2,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos345Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-346/meta.json
+++ b/src/data/proofs/erdos-346/meta.json
@@ -132,7 +132,9 @@
     "lineCount": 80,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos346Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-347/meta.json
+++ b/src/data/proofs/erdos-347/meta.json
@@ -159,7 +159,9 @@
     "lineCount": 125,
     "axiomCount": 1,
     "theoremCount": 7,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos347Problem.lean",
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/erdos-348/meta.json
+++ b/src/data/proofs/erdos-348/meta.json
@@ -177,7 +177,9 @@
     "lineCount": 558,
     "axiomCount": 1,
     "theoremCount": 7,
-    "definitionCount": 14
+    "definitionCount": 14,
+    "path": "Proofs/Erdos348Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-349/meta.json
+++ b/src/data/proofs/erdos-349/meta.json
@@ -178,6 +178,8 @@
   },
   "leanFile": {
     "lineCount": 84,
-    "axiomCount": 0
+    "axiomCount": 0,
+    "path": "Proofs/Erdos349Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-350/meta.json
+++ b/src/data/proofs/erdos-350/meta.json
@@ -164,7 +164,9 @@
     "lineCount": 168,
     "axiomCount": 0,
     "theoremCount": 7,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos350Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-351/meta.json
+++ b/src/data/proofs/erdos-351/meta.json
@@ -129,7 +129,9 @@
     "lineCount": 107,
     "axiomCount": 0,
     "theoremCount": 8,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos351Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-354/meta.json
+++ b/src/data/proofs/erdos-354/meta.json
@@ -160,7 +160,9 @@
     "lineCount": 185,
     "axiomCount": 1,
     "theoremCount": 1,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos354Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-355/meta.json
+++ b/src/data/proofs/erdos-355/meta.json
@@ -150,7 +150,9 @@
     "lineCount": 392,
     "axiomCount": 2,
     "theoremCount": 14,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos355Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-356/meta.json
+++ b/src/data/proofs/erdos-356/meta.json
@@ -184,7 +184,9 @@
     "lineCount": 241,
     "axiomCount": 2,
     "theoremCount": 2,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos356Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-358/meta.json
+++ b/src/data/proofs/erdos-358/meta.json
@@ -170,7 +170,9 @@
     "lineCount": 422,
     "axiomCount": 1,
     "theoremCount": 8,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos358Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-359/meta.json
+++ b/src/data/proofs/erdos-359/meta.json
@@ -148,7 +148,9 @@
     "lineCount": 207,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos359Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-36/meta.json
+++ b/src/data/proofs/erdos-36/meta.json
@@ -91,7 +91,9 @@
     ],
     "opens": [],
     "namespace": "",
-    "mainTheorems": []
+    "mainTheorems": [],
+    "path": "Proofs/Erdos36Problem.lean",
+    "sorries": 0
   },
   "sections": [
     {

--- a/src/data/proofs/erdos-361/meta.json
+++ b/src/data/proofs/erdos-361/meta.json
@@ -161,7 +161,9 @@
     "lineCount": 140,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos361Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-362/meta.json
+++ b/src/data/proofs/erdos-362/meta.json
@@ -189,7 +189,9 @@
     "lineCount": 336,
     "axiomCount": 2,
     "theoremCount": 5,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos362Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-363/meta.json
+++ b/src/data/proofs/erdos-363/meta.json
@@ -198,7 +198,9 @@
     "lineCount": 293,
     "axiomCount": 3,
     "theoremCount": 5,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos363Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-364/meta.json
+++ b/src/data/proofs/erdos-364/meta.json
@@ -176,7 +176,9 @@
     "lineCount": 190,
     "axiomCount": 0,
     "theoremCount": 7,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/Erdos364Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-365/meta.json
+++ b/src/data/proofs/erdos-365/meta.json
@@ -174,7 +174,9 @@
     "lineCount": 181,
     "axiomCount": 3,
     "theoremCount": 4,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos365Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-366/meta.json
+++ b/src/data/proofs/erdos-366/meta.json
@@ -184,7 +184,9 @@
     "lineCount": 209,
     "axiomCount": 0,
     "theoremCount": 11,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos366Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-367/meta.json
+++ b/src/data/proofs/erdos-367/meta.json
@@ -237,6 +237,8 @@
     "lineCount": 415,
     "axiomCount": 2,
     "theoremCount": 8,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos367Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-368/meta.json
+++ b/src/data/proofs/erdos-368/meta.json
@@ -207,7 +207,9 @@
     "lineCount": 353,
     "axiomCount": 5,
     "theoremCount": 13,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos368Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-37/meta.json
+++ b/src/data/proofs/erdos-37/meta.json
@@ -228,7 +228,9 @@
     "lineCount": 368,
     "axiomCount": 6,
     "theoremCount": 6,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos37Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-372/meta.json
+++ b/src/data/proofs/erdos-372/meta.json
@@ -176,7 +176,9 @@
     "lineCount": 219,
     "axiomCount": 3,
     "theoremCount": 5,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos372Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-373/meta.json
+++ b/src/data/proofs/erdos-373/meta.json
@@ -156,7 +156,9 @@
     "lineCount": 168,
     "axiomCount": 0,
     "theoremCount": 5,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos373Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-374/meta.json
+++ b/src/data/proofs/erdos-374/meta.json
@@ -144,7 +144,9 @@
     "lineCount": 265,
     "axiomCount": 0,
     "theoremCount": 13,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos374Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-376/meta.json
+++ b/src/data/proofs/erdos-376/meta.json
@@ -165,7 +165,9 @@
     "lineCount": 126,
     "axiomCount": 1,
     "theoremCount": 6,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos376Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-377/meta.json
+++ b/src/data/proofs/erdos-377/meta.json
@@ -138,7 +138,9 @@
     "lineCount": 134,
     "axiomCount": 0,
     "theoremCount": 2,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos377Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-379/meta.json
+++ b/src/data/proofs/erdos-379/meta.json
@@ -158,7 +158,9 @@
     "lineCount": 178,
     "axiomCount": 3,
     "theoremCount": 7,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos379Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-38/meta.json
+++ b/src/data/proofs/erdos-38/meta.json
@@ -110,7 +110,9 @@
     "lineCount": 124,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos38Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-380/meta.json
+++ b/src/data/proofs/erdos-380/meta.json
@@ -152,7 +152,9 @@
     "lineCount": 396,
     "axiomCount": 1,
     "theoremCount": 17,
-    "definitionCount": 12
+    "definitionCount": 12,
+    "path": "Proofs/Erdos380Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-382/meta.json
+++ b/src/data/proofs/erdos-382/meta.json
@@ -207,7 +207,9 @@
     "lineCount": 661,
     "axiomCount": 1,
     "theoremCount": 11,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos382Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-383/meta.json
+++ b/src/data/proofs/erdos-383/meta.json
@@ -211,6 +211,8 @@
     "lineCount": 286,
     "axiomCount": 0,
     "theoremCount": 17,
-    "definitionCount": 12
+    "definitionCount": 12,
+    "path": "Proofs/Erdos383Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-384/meta.json
+++ b/src/data/proofs/erdos-384/meta.json
@@ -179,6 +179,8 @@
     "lineCount": 235,
     "axiomCount": 1,
     "theoremCount": 12,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos384Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-385/meta.json
+++ b/src/data/proofs/erdos-385/meta.json
@@ -198,7 +198,9 @@
     "lineCount": 196,
     "axiomCount": 0,
     "theoremCount": 5,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos385Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-386/meta.json
+++ b/src/data/proofs/erdos-386/meta.json
@@ -153,7 +153,9 @@
     "lineCount": 139,
     "axiomCount": 1,
     "theoremCount": 1,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos386Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-387/meta.json
+++ b/src/data/proofs/erdos-387/meta.json
@@ -123,7 +123,9 @@
     "lineCount": 103,
     "axiomCount": 1,
     "theoremCount": 2,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/Erdos387Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-388/meta.json
+++ b/src/data/proofs/erdos-388/meta.json
@@ -111,7 +111,9 @@
     "lineCount": 111,
     "axiomCount": 0,
     "theoremCount": 2,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos388Problem.lean",
+    "sorries": 0
   },
   "references": [
     "Erdős & Selfridge (1975): 'The product of consecutive integers is never a power', Illinois Journal of Mathematics 19, 292–301",

--- a/src/data/proofs/erdos-389/meta.json
+++ b/src/data/proofs/erdos-389/meta.json
@@ -115,7 +115,9 @@
     "lineCount": 121,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos389Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-39/meta.json
+++ b/src/data/proofs/erdos-39/meta.json
@@ -224,6 +224,8 @@
     "lineCount": 186,
     "axiomCount": 1,
     "theoremCount": 6,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos39Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-390/meta.json
+++ b/src/data/proofs/erdos-390/meta.json
@@ -109,7 +109,9 @@
     "lineCount": 538,
     "axiomCount": 1,
     "theoremCount": 12,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos390Problem.lean",
+    "sorries": 0
   },
   "references": [
     "Erdős & Graham (1980): 'Old and New Problems and Results in Combinatorial Number Theory'",

--- a/src/data/proofs/erdos-391/meta.json
+++ b/src/data/proofs/erdos-391/meta.json
@@ -182,7 +182,9 @@
     "lineCount": 227,
     "axiomCount": 5,
     "theoremCount": 3,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos391Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-393/meta.json
+++ b/src/data/proofs/erdos-393/meta.json
@@ -167,7 +167,9 @@
     "lineCount": 177,
     "axiomCount": 4,
     "theoremCount": 4,
-    "definitionCount": 12
+    "definitionCount": 12,
+    "path": "Proofs/Erdos393Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-394/meta.json
+++ b/src/data/proofs/erdos-394/meta.json
@@ -192,7 +192,9 @@
     "lineCount": 290,
     "axiomCount": 5,
     "theoremCount": 6,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos394Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-395/meta.json
+++ b/src/data/proofs/erdos-395/meta.json
@@ -142,7 +142,9 @@
     "lineCount": 186,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos395Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-396/meta.json
+++ b/src/data/proofs/erdos-396/meta.json
@@ -110,7 +110,9 @@
     "lineCount": 78,
     "axiomCount": 1,
     "theoremCount": 0,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/Erdos396Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-397/meta.json
+++ b/src/data/proofs/erdos-397/meta.json
@@ -125,7 +125,9 @@
     "lineCount": 122,
     "axiomCount": 2,
     "theoremCount": 8,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos397Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-398/meta.json
+++ b/src/data/proofs/erdos-398/meta.json
@@ -153,7 +153,9 @@
     "lineCount": 227,
     "axiomCount": 2,
     "theoremCount": 19,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos398Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-399/meta.json
+++ b/src/data/proofs/erdos-399/meta.json
@@ -124,7 +124,9 @@
     "lineCount": 123,
     "axiomCount": 0,
     "theoremCount": 16,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/Erdos399Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-40/meta.json
+++ b/src/data/proofs/erdos-40/meta.json
@@ -212,6 +212,8 @@
         "type": "equivalence",
         "description": "Equivalence of two formulations of asymptotic basis of order 2"
       }
-    ]
+    ],
+    "path": "Proofs/Erdos40Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-400/meta.json
+++ b/src/data/proofs/erdos-400/meta.json
@@ -178,7 +178,9 @@
     "lineCount": 171,
     "axiomCount": 0,
     "theoremCount": 5,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos400Problem.lean",
+    "sorries": 1
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-401/meta.json
+++ b/src/data/proofs/erdos-401/meta.json
@@ -202,7 +202,9 @@
     "lineCount": 319,
     "axiomCount": 3,
     "theoremCount": 20,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos401Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-403/meta.json
+++ b/src/data/proofs/erdos-403/meta.json
@@ -186,7 +186,9 @@
     "lineCount": 339,
     "axiomCount": 1,
     "theoremCount": 15,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos403Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-404/meta.json
+++ b/src/data/proofs/erdos-404/meta.json
@@ -205,6 +205,8 @@
     "lineCount": 291,
     "axiomCount": 2,
     "theoremCount": 10,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos404Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-405/meta.json
+++ b/src/data/proofs/erdos-405/meta.json
@@ -190,7 +190,9 @@
     "lineCount": 299,
     "axiomCount": 3,
     "theoremCount": 14,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos405Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-406/meta.json
+++ b/src/data/proofs/erdos-406/meta.json
@@ -87,7 +87,9 @@
     "lineCount": 179,
     "axiomCount": 1,
     "theoremCount": 12,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos406Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-407/meta.json
+++ b/src/data/proofs/erdos-407/meta.json
@@ -138,7 +138,9 @@
     "lineCount": 219,
     "axiomCount": 3,
     "theoremCount": 7,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos407Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-408/meta.json
+++ b/src/data/proofs/erdos-408/meta.json
@@ -185,7 +185,9 @@
     "lineCount": 396,
     "axiomCount": 5,
     "theoremCount": 14,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos408Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-409/meta.json
+++ b/src/data/proofs/erdos-409/meta.json
@@ -148,7 +148,9 @@
     "lineCount": 339,
     "axiomCount": 0,
     "theoremCount": 16,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos409Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/listings.json
+++ b/src/data/proofs/listings.json
@@ -21026,7 +21026,7 @@
     "erdosNumber": 508,
     "mathlibCount": 4,
     "sorries": 0,
-    "annotationCount": 4
+    "annotationCount": 5
   },
   {
     "id": "erdos-509",


### PR DESCRIPTION
## Fix

Batch 5 of gallery metadata completion: adds missing `path` and `sorries` to `leanFile` objects for 200 proofs (erdos-200 through erdos-409).

| Batch | PR | Count |
|-------|----|-------|
| 1 | #9756 | 167 |
| 2 | #9759 | 198 |
| 3 | #9761 | 200 |
| 4 | #9762 | 200 |
| 5 | this | 200 |

`pnpm build` passes cleanly.

---
Automated fix by lean-mechanic agent.