### PR TITLE
fix(meta): add missing leanFile.path and sorries to 250 gallery proofs (batch 6)

### DIFF
--- a/src/data/proofs/erdos-41/meta.json
+++ b/src/data/proofs/erdos-41/meta.json
@@ -214,6 +214,8 @@
     "lineCount": 164,
     "axiomCount": 2,
     "theoremCount": 6,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos41Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-410/meta.json
+++ b/src/data/proofs/erdos-410/meta.json
@@ -184,7 +184,9 @@
     "lineCount": 371,
     "axiomCount": 2,
     "theoremCount": 42,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos410Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-412/meta.json
+++ b/src/data/proofs/erdos-412/meta.json
@@ -196,7 +196,9 @@
     "lineCount": 213,
     "axiomCount": 0,
     "theoremCount": 12,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos412Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-413/meta.json
+++ b/src/data/proofs/erdos-413/meta.json
@@ -218,7 +218,9 @@
     "lineCount": 1115,
     "axiomCount": 1,
     "theoremCount": 122,
-    "definitionCount": 17
+    "definitionCount": 17,
+    "path": "Proofs/Erdos413Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-414/meta.json
+++ b/src/data/proofs/erdos-414/meta.json
@@ -199,7 +199,9 @@
       "Mathlib.Data.Nat.Basic",
       "Mathlib.Tactic"
     ],
-    "opens": []
+    "opens": [],
+    "path": "Proofs/Erdos414Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-417/meta.json
+++ b/src/data/proofs/erdos-417/meta.json
@@ -182,6 +182,8 @@
     "lineCount": 315,
     "axiomCount": 1,
     "theoremCount": 17,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos417Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-418/meta.json
+++ b/src/data/proofs/erdos-418/meta.json
@@ -160,7 +160,9 @@
     "lineCount": 227,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos418Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-42/meta.json
+++ b/src/data/proofs/erdos-42/meta.json
@@ -154,7 +154,9 @@
     "lineCount": 165,
     "axiomCount": 0,
     "theoremCount": 1,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos42Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-420/meta.json
+++ b/src/data/proofs/erdos-420/meta.json
@@ -176,7 +176,9 @@
     "lineCount": 278,
     "axiomCount": 4,
     "theoremCount": 5,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos420Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-421/meta.json
+++ b/src/data/proofs/erdos-421/meta.json
@@ -190,7 +190,9 @@
     "lineCount": 579,
     "axiomCount": 1,
     "theoremCount": 25,
-    "definitionCount": 20
+    "definitionCount": 20,
+    "path": "Proofs/Erdos421Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-422/meta.json
+++ b/src/data/proofs/erdos-422/meta.json
@@ -130,7 +130,9 @@
     "lineCount": 93,
     "axiomCount": 0,
     "theoremCount": 7,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos422Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-423/meta.json
+++ b/src/data/proofs/erdos-423/meta.json
@@ -198,6 +198,8 @@
     "lineCount": 409,
     "axiomCount": 3,
     "theoremCount": 38,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos423Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-424/meta.json
+++ b/src/data/proofs/erdos-424/meta.json
@@ -131,7 +131,9 @@
     "lineCount": 151,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos424Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-425/meta.json
+++ b/src/data/proofs/erdos-425/meta.json
@@ -186,6 +186,8 @@
     "lineCount": 264,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos425Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-426/meta.json
+++ b/src/data/proofs/erdos-426/meta.json
@@ -145,7 +145,9 @@
     "lineCount": 255,
     "axiomCount": 4,
     "theoremCount": 2,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos426Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-427/meta.json
+++ b/src/data/proofs/erdos-427/meta.json
@@ -176,7 +176,9 @@
     "lineCount": 284,
     "axiomCount": 3,
     "theoremCount": 7,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos427Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-429/meta.json
+++ b/src/data/proofs/erdos-429/meta.json
@@ -147,7 +147,9 @@
     "lineCount": 171,
     "axiomCount": 3,
     "theoremCount": 3,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos429Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-43/meta.json
+++ b/src/data/proofs/erdos-43/meta.json
@@ -284,6 +284,8 @@
     "lineCount": 312,
     "axiomCount": 3,
     "theoremCount": 6,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Stubs/Erdos43Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-430/meta.json
+++ b/src/data/proofs/erdos-430/meta.json
@@ -140,7 +140,9 @@
     "lineCount": 249,
     "axiomCount": 1,
     "theoremCount": 5,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos430Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-431/meta.json
+++ b/src/data/proofs/erdos-431/meta.json
@@ -188,7 +188,9 @@
     "lineCount": 213,
     "axiomCount": 3,
     "theoremCount": 5,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos431Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-432/meta.json
+++ b/src/data/proofs/erdos-432/meta.json
@@ -220,7 +220,9 @@
       "Mathlib.Data.Finset.Basic",
       "Mathlib.Tactic"
     ],
-    "namespace": "Erdos432"
+    "namespace": "Erdos432",
+    "path": "Proofs/Erdos432Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-433/meta.json
+++ b/src/data/proofs/erdos-433/meta.json
@@ -189,7 +189,9 @@
     "lineCount": 398,
     "axiomCount": 4,
     "theoremCount": 6,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos433Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-435/meta.json
+++ b/src/data/proofs/erdos-435/meta.json
@@ -196,6 +196,8 @@
     "lineCount": 233,
     "axiomCount": 2,
     "theoremCount": 2,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos435Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-436/meta.json
+++ b/src/data/proofs/erdos-436/meta.json
@@ -169,7 +169,9 @@
     "lineCount": 686,
     "axiomCount": 9,
     "theoremCount": 49,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos436Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-438/meta.json
+++ b/src/data/proofs/erdos-438/meta.json
@@ -199,7 +199,9 @@
     "lineCount": 111,
     "axiomCount": 3,
     "theoremCount": 2,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos438Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-439/meta.json
+++ b/src/data/proofs/erdos-439/meta.json
@@ -197,6 +197,8 @@
     "lineCount": 218,
     "axiomCount": 3,
     "theoremCount": 2,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos439Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-44/meta.json
+++ b/src/data/proofs/erdos-44/meta.json
@@ -139,7 +139,9 @@
     "lineCount": 346,
     "axiomCount": 1,
     "theoremCount": 8,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/Erdos44Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-440/meta.json
+++ b/src/data/proofs/erdos-440/meta.json
@@ -146,7 +146,9 @@
     "lineCount": 200,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos440Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-442/meta.json
+++ b/src/data/proofs/erdos-442/meta.json
@@ -201,7 +201,9 @@
     "lineCount": 255,
     "axiomCount": 2,
     "theoremCount": 8,
-    "definitionCount": 12
+    "definitionCount": 12,
+    "path": "Proofs/Erdos442Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-443/meta.json
+++ b/src/data/proofs/erdos-443/meta.json
@@ -155,7 +155,9 @@
     "lineCount": 181,
     "axiomCount": 2,
     "theoremCount": 5,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos443Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-444/meta.json
+++ b/src/data/proofs/erdos-444/meta.json
@@ -205,7 +205,9 @@
       "Mathlib.Data.Set.Basic"
     ],
     "namespace": "Erdos444",
-    "opens": []
+    "opens": [],
+    "path": "Proofs/Erdos444Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-445/meta.json
+++ b/src/data/proofs/erdos-445/meta.json
@@ -151,7 +151,9 @@
     "lineCount": 141,
     "axiomCount": 5,
     "theoremCount": 3,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos445Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-446/meta.json
+++ b/src/data/proofs/erdos-446/meta.json
@@ -136,7 +136,9 @@
     "lineCount": 139,
     "axiomCount": 4,
     "theoremCount": 2,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos446Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-449/meta.json
+++ b/src/data/proofs/erdos-449/meta.json
@@ -158,7 +158,9 @@
     "lineCount": 154,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos449Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-45/meta.json
+++ b/src/data/proofs/erdos-45/meta.json
@@ -136,7 +136,9 @@
     "lineCount": 142,
     "axiomCount": 3,
     "theoremCount": 3,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos45Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-450/meta.json
+++ b/src/data/proofs/erdos-450/meta.json
@@ -172,6 +172,8 @@
     "lineCount": 226,
     "axiomCount": 3,
     "theoremCount": 16,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos450Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-451/meta.json
+++ b/src/data/proofs/erdos-451/meta.json
@@ -125,7 +125,9 @@
     "lineCount": 185,
     "axiomCount": 3,
     "theoremCount": 8,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos451Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-452/meta.json
+++ b/src/data/proofs/erdos-452/meta.json
@@ -210,6 +210,8 @@
     "lineCount": 175,
     "axiomCount": 4,
     "theoremCount": 1,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos452Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-453-oq-02/meta.json
+++ b/src/data/proofs/erdos-453-oq-02/meta.json
@@ -82,7 +82,9 @@
     "lineCount": 226,
     "axiomCount": 2,
     "theoremCount": 8,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos453OQ02.lean",
+    "sorries": 4
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-453/meta.json
+++ b/src/data/proofs/erdos-453/meta.json
@@ -73,7 +73,9 @@
     "lineCount": 364,
     "axiomCount": 2,
     "theoremCount": 14,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos453Problem.lean",
+    "sorries": 1
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-456/meta.json
+++ b/src/data/proofs/erdos-456/meta.json
@@ -201,7 +201,9 @@
     "lineCount": 275,
     "axiomCount": 0,
     "theoremCount": 16,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos456Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-457/meta.json
+++ b/src/data/proofs/erdos-457/meta.json
@@ -181,7 +181,9 @@
     "lineCount": 181,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos457Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-459/meta.json
+++ b/src/data/proofs/erdos-459/meta.json
@@ -180,7 +180,9 @@
     "lineCount": 231,
     "axiomCount": 6,
     "theoremCount": 9,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos459Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-46/meta.json
+++ b/src/data/proofs/erdos-46/meta.json
@@ -156,7 +156,9 @@
     "lineCount": 84,
     "axiomCount": 0,
     "theoremCount": 3,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos46Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-460/meta.json
+++ b/src/data/proofs/erdos-460/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-460",
-  "title": "Erd\u0151s Problem #460: Greedy Coprime Sieve Reciprocals",
+  "title": "Erdős Problem #460: Greedy Coprime Sieve Reciprocals",
   "slug": "erdos-460",
   "description": "Let $a_0 = 0$, $a_1 = 1$. Define $a_k$ as the least integer $> a_{k-1}$ with $\\gcd(n - a_k, n - a_i) = 1$ for all $i < k$. Does $\\sum_{0 < a_i < n} \\frac{1}{a_i} \\to \\infty$ as $n \\to \\infty$? OPEN.",
   "meta": {
-    "author": "Erd\u0151s",
+    "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/460",
     "date": "1977",
     "status": "axiomatized",
@@ -50,9 +50,9 @@
     "originalContributions": [
       "Axiomatic definition of the greedy coprime sieve sequence with initial values and greedy selection property",
       "Formal statement of ErdosProblem460 as divergence of reciprocal sums",
-      "Formalization of the Eggleton-Erd\u0151s-Selfridge bound a_k < k^{2+o(1)} and the conjectured a_k \u226a k log k",
+      "Formalization of the Eggleton-Erdős-Selfridge bound a_k < k^{2+o(1)} and the conjectured a_k ≪ k log k",
       "Definition of the least-prime-factor filtered sum f(n) and its sufficiency axiom",
-      "Splitting into smallPrimeDivisibleSum and largePrimeSum with Erd\u0151s's question about individual divergence"
+      "Splitting into smallPrimeDivisibleSum and largePrimeSum with Erdős's question about individual divergence"
     ],
     "axiomCount": 2,
     "lineCount": 274,
@@ -72,7 +72,9 @@
     "lineCount": 274,
     "axiomCount": 2,
     "theoremCount": 9,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos460Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -97,15 +99,15 @@
     }
   ],
   "overview": {
-    "historicalContext": "Erd\u0151s posed this problem in 1977 (p.64) and it appears in Erd\u0151s-Graham (1980, p.91). Given n, one greedily selects a_0 = 0, a_1 = 1, and each a_k as the smallest integer exceeding a_{k-1} with n - a_k coprime to all previous n - a_i. The resulting shifted values {n - a_k} are pairwise coprime.\n\nEggleton, Erd\u0151s, and Selfridge proved a_k < k^{2+o(1)} and conjectured the stronger bound a_k \u226a k log k. The quadratic bound alone is insufficient for reciprocal sum divergence since \u03a3 1/k^{2+\u03b5} converges, but the conjectured k log k bound would imply divergence since \u03a3 1/(k log k) diverges by the integral test.\n\nThe problem connects greedy algorithms in multiplicative number theory to reciprocal sum divergence, a theme appearing across many Erd\u0151s problems. The least-prime-factor sufficient condition links it to smooth number distribution.",
+    "historicalContext": "Erdős posed this problem in 1977 (p.64) and it appears in Erdős-Graham (1980, p.91). Given n, one greedily selects a_0 = 0, a_1 = 1, and each a_k as the smallest integer exceeding a_{k-1} with n - a_k coprime to all previous n - a_i. The resulting shifted values {n - a_k} are pairwise coprime.\n\nEggleton, Erdős, and Selfridge proved a_k < k^{2+o(1)} and conjectured the stronger bound a_k ≪ k log k. The quadratic bound alone is insufficient for reciprocal sum divergence since Σ 1/k^{2+ε} converges, but the conjectured k log k bound would imply divergence since Σ 1/(k log k) diverges by the integral test.\n\nThe problem connects greedy algorithms in multiplicative number theory to reciprocal sum divergence, a theme appearing across many Erdős problems. The least-prime-factor sufficient condition links it to smooth number distribution.",
     "problemStatement": "Let $a_0 = 0$, $a_1 = 1$, and $a_k$ the least integer $> a_{k-1}$ with $\\gcd(n - a_k, n - a_i) = 1$ for all $i < k$. Does $\\sum_{0 < a_i < n} \\frac{1}{a_i} \\to \\infty$ as $n \\to \\infty$?",
     "text": "Let $a_0 = 0$, $a_1 = 1$. Define $a_k$ as the least integer $> a_{k-1}$ with $\\gcd(n - a_k, n - a_i) = 1$ for all $i < k$. Does $\\sum_{0 < a_i < n} \\frac{1}{a_i} \\to \\infty$ as $n \\to \\infty$? OPEN.",
-    "proofStrategy": "The formalization defines greedyCoprimeSieve axiomatically as a function \u2115 \u2192 \u2115 \u2192 \u2115, with sieve_initial and sieve_greedy capturing the initial conditions and the greedy minimality property. The reciprocal sum sieveReciprocalSum is defined via Finset.range and conditional summation. ErdosProblem460 states that for every M > 0, there exists N\u2080 such that \u03a3 1/a_i > M for all n \u2265 N\u2080. The known growth bound and conjectured bound are axiomatized. A key structural insight is the least-prime-factor sufficient condition: if f(n) = \u03a3_{a < n, P\u207b(n-a) > a} 1/a \u2192 \u221e, then the full sum diverges. The formalization also splits the sum into small-prime and large-prime components.",
+    "proofStrategy": "The formalization defines greedyCoprimeSieve axiomatically as a function ℕ → ℕ → ℕ, with sieve_initial and sieve_greedy capturing the initial conditions and the greedy minimality property. The reciprocal sum sieveReciprocalSum is defined via Finset.range and conditional summation. ErdosProblem460 states that for every M > 0, there exists N₀ such that Σ 1/a_i > M for all n ≥ N₀. The known growth bound and conjectured bound are axiomatized. A key structural insight is the least-prime-factor sufficient condition: if f(n) = Σ_{a < n, P⁻(n-a) > a} 1/a → ∞, then the full sum diverges. The formalization also splits the sum into small-prime and large-prime components.",
     "keyInsights": [
       "The greedy sieve produces a sequence whose shifted values n - a_k are pairwise coprime, connecting coprimality structure to sequence growth",
-      "Eggleton-Erd\u0151s-Selfridge: a_k < k^{2+o(1)}, conjectured a_k \u226a k log k; the quadratic bound alone is insufficient to prove divergence via comparison",
-      "The least-prime-factor filtered sum f(n) = \u03a3_{a < n, P\u207b(n-a) > a} 1/a provides a sufficient condition \u2014 its divergence implies Problem 460",
-      "Erd\u0151s asked whether the smallPrimeDivisibleSum and largePrimeSum each individually diverge, which would independently imply the conjecture",
+      "Eggleton-Erdős-Selfridge: a_k < k^{2+o(1)}, conjectured a_k ≪ k log k; the quadratic bound alone is insufficient to prove divergence via comparison",
+      "The least-prime-factor filtered sum f(n) = Σ_{a < n, P⁻(n-a) > a} 1/a provides a sufficient condition — its divergence implies Problem 460",
+      "Erdős asked whether the smallPrimeDivisibleSum and largePrimeSum each individually diverge, which would independently imply the conjecture",
       "The problem sits at the intersection of sieve theory, smooth number distribution, and additive combinatorics of coprime sets"
     ],
     "prerequisites": [
@@ -140,14 +142,14 @@
       "title": "The Conjecture",
       "startLine": 67,
       "endLine": 80,
-      "summary": "ErdosProblem460: divergence of reciprocal sums in \u03b5-N form"
+      "summary": "ErdosProblem460: divergence of reciprocal sums in ε-N form"
     },
     {
       "id": "known-bounds",
       "title": "Known Bounds",
       "startLine": 81,
       "endLine": 97,
-      "summary": "Eggleton-Erd\u0151s-Selfridge k^{2+o(1)} bound and conjectured k log k bound"
+      "summary": "Eggleton-Erdős-Selfridge k^{2+o(1)} bound and conjectured k log k bound"
     },
     {
       "id": "least-prime-factor",
@@ -165,11 +167,11 @@
     }
   ],
   "conclusion": {
-    "summary": "Erd\u0151s Problem 460 asks whether the reciprocal sum of a greedy coprime sieve sequence diverges. The formalization captures the complete problem structure: axiomatic sieve definition, the known k^{2+o(1)} growth bound (which is too weak to resolve divergence), the conjectured k log k bound, a sufficient condition via least-prime-factor filtered sums, and Erd\u0151s's further question about restricted sum divergence.",
-    "implications": "Resolution would connect greedy coprime selection with reciprocal sum divergence, bridging sieve theory, smooth number distribution, and additive combinatorics. The sufficient condition via P\u207b(n-a) > a links the problem to the distribution of smooth numbers in arithmetic progressions.",
+    "summary": "Erdős Problem 460 asks whether the reciprocal sum of a greedy coprime sieve sequence diverges. The formalization captures the complete problem structure: axiomatic sieve definition, the known k^{2+o(1)} growth bound (which is too weak to resolve divergence), the conjectured k log k bound, a sufficient condition via least-prime-factor filtered sums, and Erdős's further question about restricted sum divergence.",
+    "implications": "Resolution would connect greedy coprime selection with reciprocal sum divergence, bridging sieve theory, smooth number distribution, and additive combinatorics. The sufficient condition via P⁻(n-a) > a links the problem to the distribution of smooth numbers in arithmetic progressions.",
     "openQuestions": [
-      "Does \u03a3_{0 < a_i < n} 1/a_i \u2192 \u221e as n \u2192 \u221e?",
-      "Is a_k \u226a k log k (stronger than the known k^{2+o(1)} bound)?",
+      "Does Σ_{0 < a_i < n} 1/a_i → ∞ as n → ∞?",
+      "Is a_k ≪ k log k (stronger than the known k^{2+o(1)} bound)?",
       "Do the restricted sums (smallPrimeDivisibleSum and largePrimeSum) individually diverge?",
       "Does the least-prime-factor filtered sum f(n) diverge?"
     ]
@@ -178,21 +180,21 @@
     {
       "key": "erdos1977",
       "title": "Problems and results in combinatorial number theory",
-      "author": "P. Erd\u0151s",
+      "author": "P. Erdős",
       "year": "1977",
       "pages": "p.64"
     },
     {
       "key": "erdosgraham1980",
       "title": "Old and New Problems and Results in Combinatorial Number Theory",
-      "author": "P. Erd\u0151s, R.L. Graham",
+      "author": "P. Erdős, R.L. Graham",
       "year": "1980",
       "pages": "p.91"
     },
     {
       "key": "eggleton-erdos-selfridge",
       "title": "Growth bound for greedy coprime sieve sequences",
-      "author": "R.B. Eggleton, P. Erd\u0151s, J.L. Selfridge"
+      "author": "R.B. Eggleton, P. Erdős, J.L. Selfridge"
     }
   ]
 }

--- a/src/data/proofs/erdos-461/meta.json
+++ b/src/data/proofs/erdos-461/meta.json
@@ -148,6 +148,8 @@
     "lineCount": 281,
     "axiomCount": 1,
     "theoremCount": 18,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos461Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-463/meta.json
+++ b/src/data/proofs/erdos-463/meta.json
@@ -173,7 +173,9 @@
     "lineCount": 118,
     "axiomCount": 0,
     "theoremCount": 9,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/Erdos463Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-464/meta.json
+++ b/src/data/proofs/erdos-464/meta.json
@@ -141,7 +141,9 @@
     "lineCount": 83,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos464Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-465/meta.json
+++ b/src/data/proofs/erdos-465/meta.json
@@ -187,7 +187,9 @@
     "lineCount": 270,
     "axiomCount": 3,
     "theoremCount": 7,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos465Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-466/meta.json
+++ b/src/data/proofs/erdos-466/meta.json
@@ -135,7 +135,9 @@
     "lineCount": 79,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos466Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-467/meta.json
+++ b/src/data/proofs/erdos-467/meta.json
@@ -146,7 +146,9 @@
     "lineCount": 250,
     "axiomCount": 1,
     "theoremCount": 23,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos467Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-468/meta.json
+++ b/src/data/proofs/erdos-468/meta.json
@@ -156,21 +156,29 @@
   ],
   "references": [
     {
-      "authors": ["P. Erdős", "R. L. Graham"],
+      "authors": [
+        "P. Erdős",
+        "R. L. Graham"
+      ],
       "title": "Old and New Problems and Results in Combinatorial Number Theory",
       "year": "1980",
       "venue": "L'Enseignement Mathématique, Monographie 28, Geneva",
       "notes": "Original source of Problem #468 on partial divisor sums; appears in the context of the additive structure of divisor sets"
     },
     {
-      "authors": ["OEIS Foundation"],
+      "authors": [
+        "OEIS Foundation"
+      ],
       "title": "A387502: First appearances of n as a partial sum of divisors",
       "year": "2024",
       "venue": "The On-Line Encyclopedia of Integer Sequences, oeis.org/A387502",
       "notes": "Tabulates the first-appearance function f(N) for small N; related sequences A167485 and A387503 track other aspects of the partial divisor sum structure"
     },
     {
-      "authors": ["G. L. Cohen", "H. J. J. te Riele"],
+      "authors": [
+        "G. L. Cohen",
+        "H. J. J. te Riele"
+      ],
       "title": "Iterating the sum-of-divisors function",
       "year": "1996",
       "venue": "Experimental Mathematics 5(2):91–100",
@@ -190,6 +198,8 @@
     "lineCount": 56,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos468Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-469/meta.json
+++ b/src/data/proofs/erdos-469/meta.json
@@ -104,7 +104,9 @@
     "imports": [
       "Mathlib"
     ],
-    "opens": []
+    "opens": [],
+    "path": "Proofs/Erdos469Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-47/meta.json
+++ b/src/data/proofs/erdos-47/meta.json
@@ -231,6 +231,8 @@
     "lineCount": 132,
     "axiomCount": 1,
     "theoremCount": 1,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos47Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-470/meta.json
+++ b/src/data/proofs/erdos-470/meta.json
@@ -164,7 +164,9 @@
     "lineCount": 630,
     "axiomCount": 3,
     "theoremCount": 35,
-    "definitionCount": 14
+    "definitionCount": 14,
+    "path": "Proofs/Erdos470Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-471/meta.json
+++ b/src/data/proofs/erdos-471/meta.json
@@ -164,7 +164,9 @@
     "lineCount": 274,
     "axiomCount": 2,
     "theoremCount": 7,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos471Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-472/meta.json
+++ b/src/data/proofs/erdos-472/meta.json
@@ -147,7 +147,9 @@
     "lineCount": 263,
     "axiomCount": 1,
     "theoremCount": 19,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos472Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-473/meta.json
+++ b/src/data/proofs/erdos-473/meta.json
@@ -145,7 +145,9 @@
     "lineCount": 245,
     "axiomCount": 5,
     "theoremCount": 2,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos473Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-474/meta.json
+++ b/src/data/proofs/erdos-474/meta.json
@@ -201,7 +201,9 @@
     "lineCount": 277,
     "axiomCount": 3,
     "theoremCount": 2,
-    "definitionCount": 12
+    "definitionCount": 12,
+    "path": "Proofs/Erdos474Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-475/meta.json
+++ b/src/data/proofs/erdos-475/meta.json
@@ -185,7 +185,9 @@
     "lineCount": 195,
     "axiomCount": 3,
     "theoremCount": 3,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos475Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-477/meta.json
+++ b/src/data/proofs/erdos-477/meta.json
@@ -132,7 +132,9 @@
     "lineCount": 261,
     "axiomCount": 0,
     "theoremCount": 22,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos477Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-478/meta.json
+++ b/src/data/proofs/erdos-478/meta.json
@@ -174,7 +174,9 @@
     "lineCount": 165,
     "axiomCount": 0,
     "theoremCount": 6,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos478Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-479/meta.json
+++ b/src/data/proofs/erdos-479/meta.json
@@ -164,7 +164,9 @@
     "lineCount": 230,
     "axiomCount": 2,
     "theoremCount": 4,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos479Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-48/meta.json
+++ b/src/data/proofs/erdos-48/meta.json
@@ -299,6 +299,8 @@
     "lineCount": 479,
     "axiomCount": 3,
     "theoremCount": 40,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos48Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-480/meta.json
+++ b/src/data/proofs/erdos-480/meta.json
@@ -171,7 +171,9 @@
     "lineCount": 215,
     "axiomCount": 4,
     "theoremCount": 10,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos480Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-481/meta.json
+++ b/src/data/proofs/erdos-481/meta.json
@@ -172,6 +172,8 @@
     "lineCount": 164,
     "axiomCount": 1,
     "theoremCount": 2,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos481Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-482/meta.json
+++ b/src/data/proofs/erdos-482/meta.json
@@ -133,7 +133,9 @@
     "lineCount": 128,
     "axiomCount": 2,
     "theoremCount": 2,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos482Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-483/meta.json
+++ b/src/data/proofs/erdos-483/meta.json
@@ -204,6 +204,8 @@
     "lineCount": 343,
     "axiomCount": 5,
     "theoremCount": 17,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos483Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-484/meta.json
+++ b/src/data/proofs/erdos-484/meta.json
@@ -145,7 +145,9 @@
     "lineCount": 261,
     "axiomCount": 3,
     "theoremCount": 4,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos484Problem.lean",
+    "sorries": 0
   },
   "references": [
     "Roth, K.F.: Original conjecture on monochromatic sums in finite colorings",

--- a/src/data/proofs/erdos-485-oq-01/meta.json
+++ b/src/data/proofs/erdos-485-oq-01/meta.json
@@ -146,7 +146,9 @@
     "lineCount": 451,
     "axiomCount": 3,
     "theoremCount": 7,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos485OQ01.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-485-oq-02/meta.json
+++ b/src/data/proofs/erdos-485-oq-02/meta.json
@@ -169,7 +169,9 @@
     "lineCount": 327,
     "axiomCount": 0,
     "theoremCount": 9,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos485OQ02.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-485/meta.json
+++ b/src/data/proofs/erdos-485/meta.json
@@ -118,7 +118,9 @@
     "lineCount": 226,
     "axiomCount": 1,
     "theoremCount": 10,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos485Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-486/meta.json
+++ b/src/data/proofs/erdos-486/meta.json
@@ -151,7 +151,9 @@
     "lineCount": 108,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos486Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-487/meta.json
+++ b/src/data/proofs/erdos-487/meta.json
@@ -161,6 +161,8 @@
     "lineCount": 350,
     "axiomCount": 3,
     "theoremCount": 6,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos487Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-488/meta.json
+++ b/src/data/proofs/erdos-488/meta.json
@@ -128,7 +128,9 @@
     "lineCount": 322,
     "axiomCount": 0,
     "theoremCount": 12,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos488Problem.lean",
+    "sorries": 0
   },
   "references": [
     "Erdős (1961): original formulation (with likely typo)",

--- a/src/data/proofs/erdos-489/meta.json
+++ b/src/data/proofs/erdos-489/meta.json
@@ -147,7 +147,9 @@
     "lineCount": 190,
     "axiomCount": 2,
     "theoremCount": 2,
-    "definitionCount": 12
+    "definitionCount": 12,
+    "path": "Proofs/Erdos489Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-49/meta.json
+++ b/src/data/proofs/erdos-49/meta.json
@@ -180,6 +180,8 @@
     "lineCount": 73,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos49Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-490-oq-01/meta.json
+++ b/src/data/proofs/erdos-490-oq-01/meta.json
@@ -133,7 +133,9 @@
     "lineCount": 215,
     "axiomCount": 3,
     "theoremCount": 9,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos490OQ01.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-491/meta.json
+++ b/src/data/proofs/erdos-491/meta.json
@@ -166,7 +166,9 @@
     "lineCount": 182,
     "axiomCount": 3,
     "theoremCount": 6,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos491Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-493/meta.json
+++ b/src/data/proofs/erdos-493/meta.json
@@ -169,6 +169,8 @@
     "lineCount": 93,
     "axiomCount": 0,
     "theoremCount": 4,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos493Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-494/meta.json
+++ b/src/data/proofs/erdos-494/meta.json
@@ -173,7 +173,9 @@
     "lineCount": 207,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos494Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-495/meta.json
+++ b/src/data/proofs/erdos-495/meta.json
@@ -152,7 +152,9 @@
     "lineCount": 178,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos495Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-496/meta.json
+++ b/src/data/proofs/erdos-496/meta.json
@@ -121,7 +121,9 @@
     "lineCount": 94,
     "axiomCount": 0,
     "theoremCount": 2,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos496Problem.lean",
+    "sorries": 0
   },
   "references": [
     "Oppenheim (1929): original conjecture on indefinite quadratic forms",

--- a/src/data/proofs/erdos-498/meta.json
+++ b/src/data/proofs/erdos-498/meta.json
@@ -108,7 +108,9 @@
     "lineCount": 70,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos498Problem.lean",
+    "sorries": 0
   },
   "references": [
     "Littlewood & Offord (1943): original problem on real polynomials",

--- a/src/data/proofs/erdos-499/meta.json
+++ b/src/data/proofs/erdos-499/meta.json
@@ -186,7 +186,9 @@
     "lineCount": 284,
     "axiomCount": 4,
     "theoremCount": 5,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos499Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-5-prime-gaps/meta.json
+++ b/src/data/proofs/erdos-5-prime-gaps/meta.json
@@ -72,7 +72,9 @@
     "lineCount": 572,
     "axiomCount": 3,
     "theoremCount": 29,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos5PrimeGaps.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-5/meta.json
+++ b/src/data/proofs/erdos-5/meta.json
@@ -1,180 +1,182 @@
 {
-    "id": "erdos-5",
-    "title": "Erdős Problem #5: Limit Points of Normalized Prime Gaps",
-    "slug": "erdos-5",
-    "description": "Is the set S of limit points of (p_{n+1} - p_n)/log(p_n) equal to [0, ∞)? Known: 0 ∈ S (GPY), ∞ ∈ S (Westzynthius), S has positive measure (Erdős–Ricci), at least 1/3 coverage (Merikoski). Open.",
-    "meta": {
-        "author": "Erdős",
-        "sourceUrl": "https://erdosproblems.com/5",
-        "status": "axiomatized",
-        "proofRepoPath": "Proofs/Erdos5PrimeGaps.lean",
-        "tags": [
-            "erdos",
-            "number-theory",
-            "prime-gaps",
-            "analytic-number-theory",
-            "open"
-        ],
-        "badge": "axiom",
-        "sorries": 0,
-        "erdosNumber": 5,
-        "erdosUrl": "https://erdosproblems.com/5",
-        "erdosProblemStatus": "open",
-        "axiomCount": 3,
-        "lineCount": 572,
-        "assumptions": "3 axioms: westzynthius_large_gaps (∞ ∈ S, 1931), zhang_bounded_gaps (bounded prime gaps, 2013), hildebrand_maier_large_limit_points (arbitrarily large finite limit points, 1988). 0 sorries. Proves 22 theorems including: zhang_implies_zero_limit, twin_prime_implies_zero_limit, limitPointSet_isClosed, limitPointSet_unbounded, erdos_5_from_dense_values (reduction to distributional density).",
-        "mathlib_version": "4.26.0"
-    },
-    "overview": {
-        "historicalContext": "Erdős studied the distribution of prime gaps normalized by log(p_n) throughout his career, building on the prime number theorem's prediction that the average gap is ~log(p_n). The question of which values arise as limit points of g(n) = (p_{n+1} − p_n)/log(p_n) captures the full range of prime gap fluctuations. Westzynthius (1931) first showed the gaps can be arbitrarily large (∞ ∈ S). The landmark GPY theorem (2009) proved lim inf g(n) = 0, establishing 0 ∈ S and initiating the chain of breakthroughs: Zhang (2013, first finite bound on gap), Maynard-Tao (2013, gap ≤ 600), Polymath 8 (gap ≤ 246). For the interior of S, Erdős and Ricci showed S has positive Lebesgue measure, Banks-Freiberg-Maynard improved this to ≥ 12.5%, and Merikoski (2020) reached ≥ 1/3 of [0, ∞). The conjecture S = [0, ∞) remains one of the most fundamental open problems about prime distribution, closely related to the Hardy-Littlewood prime k-tuples conjecture and Cramér's probabilistic model of primes.",
-        "problemStatement": "Is the set S of all limit points of (p_{n+1} - p_n)/log(p_n) equal to [0, ∞)? Equivalently, for every C ≥ 0, does there exist an infinite sequence of indices n_i with g(n_i) → C?",
-        "text": "Is the set S of limit points of (p_{n+1} - p_n)/log(p_n) equal to [0, ∞)? Known: 0 ∈ S (GPY), ∞ ∈ S (Westzynthius), S has positive measure (Erdős–Ricci), at least 1/3 coverage (Merikoski). Open.",
-        "proofStrategy": "The main formalization (Erdos5PrimeGaps.lean) uses Mathlib's Nat.nth for prime enumeration, defines normalizedGap g(n) = primeGap(n)/log(n), and characterizes limit points via subsequential convergence (Filter/Tendsto). Three axioms encode deep results: Westzynthius (∞ ∈ S), Zhang (bounded gaps), and Merikoski (S has bounded gaps). From these, 19 theorems are proved including: 0 ∈ S derived from Zhang, S is unbounded (from Merikoski), gaps exceed any bound infinitely often (from Westzynthius), and the conjecture reduces to showing all C ≥ 0 are limit points.",
-        "keyInsights": [
-            "**PNT normalization**: Dividing by log(p_n) gives average value 1 by the prime number theorem, so the question is about the full fluctuation spectrum",
-            "**GPY breakthrough**: The proof that 0 ∈ S (2009) used a novel combination of Bombieri-Vinogradov and Selberg sieve, later leading to bounded gaps proofs",
-            "**Asymmetric progress**: The extremes 0 and ∞ are well-understood, but filling in the interior of S is much harder—requiring simultaneous control of both small and large gaps",
-            "**Density approach**: The improving density bounds (positive measure → 12.5% → 1/3) suggest S might be dense, but the jump from 1/3 to full coverage requires fundamentally new ideas",
-            "**Cramér's model predicts S = [0, ∞)**: Under the probabilistic model where primes behave like random integers with density 1/ln(x), all gap ratios would occur as limit points"
-        ],
-        "prerequisites": [
-            "Combinatorics and number theory",
-            "Number theory (primes, divisibility)"
-        ]
-    },
-    "sections": [
-        {
-            "id": "definitions",
-            "title": "Part I: Basic Definitions",
-            "startLine": 46,
-            "endLine": 59,
-            "summary": "nthPrime via Nat.nth, primeGap = p_{n+1} - p_n, normalizedGap = gap/log(n)",
-            "mathContext": "Mathematical content: nthPrime via Nat.nth, primeGap = p_{n+1} - p_n, normalizedGap = gap/log(n)"
-        },
-        {
-            "id": "limit-points",
-            "title": "Part II: The Set of Limit Points",
-            "startLine": 60,
-            "endLine": 73,
-            "summary": "IsLimitPoint via subsequential convergence, limitPointSet, InfinityIsLimitPoint",
-            "mathContext": "Mathematical content: IsLimitPoint via subsequential convergence, limitPointSet, InfinityIsLimitPoint"
-        },
-        {
-            "id": "conjecture",
-            "title": "Part III: The Main Conjecture",
-            "startLine": 74,
-            "endLine": 82,
-            "summary": "erdos_5: every C ≥ 0 is a limit point ∧ ∞ is a limit point",
-            "mathContext": "erdos_5: every C $\\geq$ 0 is a limit point ∧ ∞ is a limit point"
-        },
-        {
-            "id": "known-results",
-            "title": "Part IV: Known Results (Axioms)",
-            "startLine": 83,
-            "endLine": 105,
-            "summary": "Westzynthius (∞ ∈ S), Erdős-Ricci (positive measure, noted), Merikoski (bounded gaps in S)",
-            "mathContext": "Bound: Westzynthius (∞ ∈ S), Erdős-Ricci (positive measure, noted), Merikoski (bounded gaps in S)"
-        },
-        {
-            "id": "basic-properties",
-            "title": "Part V: Basic Properties",
-            "startLine": 106,
-            "endLine": 166,
-            "summary": "nthPrime values, primeGap positivity, strict monotonicity, growth bounds",
-            "mathContext": "Bound: nthPrime values, primeGap positivity, strict monotonicity, growth bounds"
-        },
-        {
-            "id": "gap-distribution",
-            "title": "Part VI: Gap Distribution",
-            "startLine": 167,
-            "endLine": 177,
-            "summary": "averageGap, Cramér's conjecture definition",
-            "mathContext": "Formal definition: averageGap, Cramér's conjecture definition"
-        },
-        {
-            "id": "connections",
-            "title": "Part VII: Connections",
-            "startLine": 178,
-            "endLine": 340,
-            "summary": "strictly_increasing_from_frequently, twin_prime_implies_zero_limit, zhang_implies_zero_limit, GPY derived from Zhang",
-            "mathContext": "Mathematical content: strictly_increasing_from_frequently, twin_prime_implies_zero_limit, zhang_implies_zero_limit, GPY derived from Zhang"
-        },
-        {
-            "id": "structural",
-            "title": "Part VIII: Structural Results",
-            "startLine": 341,
-            "endLine": 380,
-            "summary": "westzynthius_implies_frequently_large, limitPointSet_nonempty, limitPointSet_unbounded, erdos5_from_full, erdos5_known_partial",
-            "mathContext": "Bound: westzynthius_implies_frequently_large, limitPointSet_nonempty, limitPointSet_unbounded, erdos5_from_full, erdos5_known_partial"
-        }
+  "id": "erdos-5",
+  "title": "Erdős Problem #5: Limit Points of Normalized Prime Gaps",
+  "slug": "erdos-5",
+  "description": "Is the set S of limit points of (p_{n+1} - p_n)/log(p_n) equal to [0, ∞)? Known: 0 ∈ S (GPY), ∞ ∈ S (Westzynthius), S has positive measure (Erdős–Ricci), at least 1/3 coverage (Merikoski). Open.",
+  "meta": {
+    "author": "Erdős",
+    "sourceUrl": "https://erdosproblems.com/5",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Erdos5PrimeGaps.lean",
+    "tags": [
+      "erdos",
+      "number-theory",
+      "prime-gaps",
+      "analytic-number-theory",
+      "open"
     ],
-    "conclusion": {
-        "summary": "Erdős Problem #5 asks whether every non-negative real number is a limit point of normalized prime gaps. This formalization proves 22 theorems from 3 axioms with 0 sorries. The extremes are settled: 0 ∈ S (derived from Zhang's bounded gaps) and ∞ ∈ S (Westzynthius). Key structural results: S is nonempty, closed, unbounded, and contained in [0, ∞). The reduction theorem erdos_5_from_dense_values shows the conjecture follows from normalizedGap values being distributionally dense on [0, ∞).",
-        "implications": "Resolution would provide a complete understanding of prime gap fluctuations at the logarithmic scale, confirming the prediction of Cramér's probabilistic model. It connects to the Hardy-Littlewood prime k-tuples conjecture (which would imply S = [0, ∞)), sieve methods (the GPY-Maynard-Tao framework), and the distribution of primes in short intervals.",
-        "openQuestions": [
-            "Is every C ≥ 0 a limit point of (p_{n+1} - p_n)/log(p_n)?",
-            "Is the set S connected (i.e., is S an interval)?",
-            "Can the Merikoski 1/3 density bound be improved toward full coverage?",
-            "What is the Hausdorff dimension of the complement [0,∞) \\ S?",
-            "Does the Elliott-Halberstam conjecture imply S = [0, ∞)?"
-        ]
-    },
-    "crossReferences": [
-        {
-            "targetId": "erdos-4",
-            "relationship": "complementary",
-            "description": "Problem #4 studies the maximum growth rate of prime gaps ($\\limsup g_n / f(n) = \\infty$), while #5 studies the full set of limit points of the normalized gaps $g_n / \\log p_n$. Together they characterize both extremal and distributional behavior of prime gaps"
-        },
-        {
-            "targetId": "bounded-prime-gaps",
-            "relationship": "related",
-            "description": "The GPY/Maynard result on bounded prime gaps proves $0 \\in S$ (the set of limit points), establishing the lower extreme. This is one of the two solved endpoints of Problem #5"
-        },
-        {
-            "targetId": "prime-number-theorem",
-            "relationship": "foundational",
-            "description": "PNT gives the average prime gap $\\sim \\log p_n$, motivating the normalization $g_n / \\log p_n$. Problem #5 asks whether the normalized gaps achieve every non-negative real as a limit point"
-        },
-        {
-            "targetId": "bertrands-postulate",
-            "relationship": "related",
-            "description": "Bertrand's postulate gives $g_n < p_n$, so $g_n / \\log p_n < p_n / \\log p_n$. This provides a weak upper bound on the set S, while the conjecture $S = [0, \\infty)$ says S is unbounded"
-        },
-        {
-            "targetId": "infinitude-primes",
-            "relationship": "foundational",
-            "description": "The infinitude of primes ensures the sequence of prime gaps is infinite, making the question of limit points well-defined"
-        }
+    "badge": "axiom",
+    "sorries": 0,
+    "erdosNumber": 5,
+    "erdosUrl": "https://erdosproblems.com/5",
+    "erdosProblemStatus": "open",
+    "axiomCount": 3,
+    "lineCount": 572,
+    "assumptions": "3 axioms: westzynthius_large_gaps (∞ ∈ S, 1931), zhang_bounded_gaps (bounded prime gaps, 2013), hildebrand_maier_large_limit_points (arbitrarily large finite limit points, 1988). 0 sorries. Proves 22 theorems including: zhang_implies_zero_limit, twin_prime_implies_zero_limit, limitPointSet_isClosed, limitPointSet_unbounded, erdos_5_from_dense_values (reduction to distributional density).",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Erdős studied the distribution of prime gaps normalized by log(p_n) throughout his career, building on the prime number theorem's prediction that the average gap is ~log(p_n). The question of which values arise as limit points of g(n) = (p_{n+1} − p_n)/log(p_n) captures the full range of prime gap fluctuations. Westzynthius (1931) first showed the gaps can be arbitrarily large (∞ ∈ S). The landmark GPY theorem (2009) proved lim inf g(n) = 0, establishing 0 ∈ S and initiating the chain of breakthroughs: Zhang (2013, first finite bound on gap), Maynard-Tao (2013, gap ≤ 600), Polymath 8 (gap ≤ 246). For the interior of S, Erdős and Ricci showed S has positive Lebesgue measure, Banks-Freiberg-Maynard improved this to ≥ 12.5%, and Merikoski (2020) reached ≥ 1/3 of [0, ∞). The conjecture S = [0, ∞) remains one of the most fundamental open problems about prime distribution, closely related to the Hardy-Littlewood prime k-tuples conjecture and Cramér's probabilistic model of primes.",
+    "problemStatement": "Is the set S of all limit points of (p_{n+1} - p_n)/log(p_n) equal to [0, ∞)? Equivalently, for every C ≥ 0, does there exist an infinite sequence of indices n_i with g(n_i) → C?",
+    "text": "Is the set S of limit points of (p_{n+1} - p_n)/log(p_n) equal to [0, ∞)? Known: 0 ∈ S (GPY), ∞ ∈ S (Westzynthius), S has positive measure (Erdős–Ricci), at least 1/3 coverage (Merikoski). Open.",
+    "proofStrategy": "The main formalization (Erdos5PrimeGaps.lean) uses Mathlib's Nat.nth for prime enumeration, defines normalizedGap g(n) = primeGap(n)/log(n), and characterizes limit points via subsequential convergence (Filter/Tendsto). Three axioms encode deep results: Westzynthius (∞ ∈ S), Zhang (bounded gaps), and Merikoski (S has bounded gaps). From these, 19 theorems are proved including: 0 ∈ S derived from Zhang, S is unbounded (from Merikoski), gaps exceed any bound infinitely often (from Westzynthius), and the conjecture reduces to showing all C ≥ 0 are limit points.",
+    "keyInsights": [
+      "**PNT normalization**: Dividing by log(p_n) gives average value 1 by the prime number theorem, so the question is about the full fluctuation spectrum",
+      "**GPY breakthrough**: The proof that 0 ∈ S (2009) used a novel combination of Bombieri-Vinogradov and Selberg sieve, later leading to bounded gaps proofs",
+      "**Asymmetric progress**: The extremes 0 and ∞ are well-understood, but filling in the interior of S is much harder—requiring simultaneous control of both small and large gaps",
+      "**Density approach**: The improving density bounds (positive measure → 12.5% → 1/3) suggest S might be dense, but the jump from 1/3 to full coverage requires fundamentally new ideas",
+      "**Cramér's model predicts S = [0, ∞)**: Under the probabilistic model where primes behave like random integers with density 1/ln(x), all gap ratios would occur as limit points"
     ],
-    "leanFile": {
-        "imports": [
-            "Mathlib.Data.Nat.Prime.Nth",
-            "Mathlib.Data.Real.Basic",
-            "Mathlib.Analysis.SpecialFunctions.Log.Basic",
-            "Mathlib.Order.Filter.Basic",
-            "Mathlib.Topology.Basic",
-            "Mathlib.Topology.MetricSpace.Basic",
-            "Mathlib.Tactic"
-        ],
-        "opens": [
-            "Filter",
-            "Real",
-            "Topology"
-        ],
-        "namespace": "Erdos5",
-        "lineCount": 572,
-        "axiomCount": 3,
-        "theoremCount": 22,
-        "definitionCount": 9
-    },
-    "references": [
-        "Goldston–Pintz–Yıldırım: 0 ∈ S (2009)",
-        "Westzynthius: ∞ ∈ S (1931)",
-        "Erdős–Ricci: S has positive Lebesgue measure",
-        "Hildebrand–Maier: arbitrarily large finite limit points",
-        "Merikoski: at least 1/3 of [0,∞) in S (2020)",
-        "Ford–Green–Konyagin–Maynard–Tao: improved large gap bounds (2018)",
-        "Zhang: bounded gaps between primes (2013)",
-        "Maynard–Tao: multiple bounded gaps (2013)"
+    "prerequisites": [
+      "Combinatorics and number theory",
+      "Number theory (primes, divisibility)"
     ]
+  },
+  "sections": [
+    {
+      "id": "definitions",
+      "title": "Part I: Basic Definitions",
+      "startLine": 46,
+      "endLine": 59,
+      "summary": "nthPrime via Nat.nth, primeGap = p_{n+1} - p_n, normalizedGap = gap/log(n)",
+      "mathContext": "Mathematical content: nthPrime via Nat.nth, primeGap = p_{n+1} - p_n, normalizedGap = gap/log(n)"
+    },
+    {
+      "id": "limit-points",
+      "title": "Part II: The Set of Limit Points",
+      "startLine": 60,
+      "endLine": 73,
+      "summary": "IsLimitPoint via subsequential convergence, limitPointSet, InfinityIsLimitPoint",
+      "mathContext": "Mathematical content: IsLimitPoint via subsequential convergence, limitPointSet, InfinityIsLimitPoint"
+    },
+    {
+      "id": "conjecture",
+      "title": "Part III: The Main Conjecture",
+      "startLine": 74,
+      "endLine": 82,
+      "summary": "erdos_5: every C ≥ 0 is a limit point ∧ ∞ is a limit point",
+      "mathContext": "erdos_5: every C $\\geq$ 0 is a limit point ∧ ∞ is a limit point"
+    },
+    {
+      "id": "known-results",
+      "title": "Part IV: Known Results (Axioms)",
+      "startLine": 83,
+      "endLine": 105,
+      "summary": "Westzynthius (∞ ∈ S), Erdős-Ricci (positive measure, noted), Merikoski (bounded gaps in S)",
+      "mathContext": "Bound: Westzynthius (∞ ∈ S), Erdős-Ricci (positive measure, noted), Merikoski (bounded gaps in S)"
+    },
+    {
+      "id": "basic-properties",
+      "title": "Part V: Basic Properties",
+      "startLine": 106,
+      "endLine": 166,
+      "summary": "nthPrime values, primeGap positivity, strict monotonicity, growth bounds",
+      "mathContext": "Bound: nthPrime values, primeGap positivity, strict monotonicity, growth bounds"
+    },
+    {
+      "id": "gap-distribution",
+      "title": "Part VI: Gap Distribution",
+      "startLine": 167,
+      "endLine": 177,
+      "summary": "averageGap, Cramér's conjecture definition",
+      "mathContext": "Formal definition: averageGap, Cramér's conjecture definition"
+    },
+    {
+      "id": "connections",
+      "title": "Part VII: Connections",
+      "startLine": 178,
+      "endLine": 340,
+      "summary": "strictly_increasing_from_frequently, twin_prime_implies_zero_limit, zhang_implies_zero_limit, GPY derived from Zhang",
+      "mathContext": "Mathematical content: strictly_increasing_from_frequently, twin_prime_implies_zero_limit, zhang_implies_zero_limit, GPY derived from Zhang"
+    },
+    {
+      "id": "structural",
+      "title": "Part VIII: Structural Results",
+      "startLine": 341,
+      "endLine": 380,
+      "summary": "westzynthius_implies_frequently_large, limitPointSet_nonempty, limitPointSet_unbounded, erdos5_from_full, erdos5_known_partial",
+      "mathContext": "Bound: westzynthius_implies_frequently_large, limitPointSet_nonempty, limitPointSet_unbounded, erdos5_from_full, erdos5_known_partial"
+    }
+  ],
+  "conclusion": {
+    "summary": "Erdős Problem #5 asks whether every non-negative real number is a limit point of normalized prime gaps. This formalization proves 22 theorems from 3 axioms with 0 sorries. The extremes are settled: 0 ∈ S (derived from Zhang's bounded gaps) and ∞ ∈ S (Westzynthius). Key structural results: S is nonempty, closed, unbounded, and contained in [0, ∞). The reduction theorem erdos_5_from_dense_values shows the conjecture follows from normalizedGap values being distributionally dense on [0, ∞).",
+    "implications": "Resolution would provide a complete understanding of prime gap fluctuations at the logarithmic scale, confirming the prediction of Cramér's probabilistic model. It connects to the Hardy-Littlewood prime k-tuples conjecture (which would imply S = [0, ∞)), sieve methods (the GPY-Maynard-Tao framework), and the distribution of primes in short intervals.",
+    "openQuestions": [
+      "Is every C ≥ 0 a limit point of (p_{n+1} - p_n)/log(p_n)?",
+      "Is the set S connected (i.e., is S an interval)?",
+      "Can the Merikoski 1/3 density bound be improved toward full coverage?",
+      "What is the Hausdorff dimension of the complement [0,∞) \\ S?",
+      "Does the Elliott-Halberstam conjecture imply S = [0, ∞)?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-4",
+      "relationship": "complementary",
+      "description": "Problem #4 studies the maximum growth rate of prime gaps ($\\limsup g_n / f(n) = \\infty$), while #5 studies the full set of limit points of the normalized gaps $g_n / \\log p_n$. Together they characterize both extremal and distributional behavior of prime gaps"
+    },
+    {
+      "targetId": "bounded-prime-gaps",
+      "relationship": "related",
+      "description": "The GPY/Maynard result on bounded prime gaps proves $0 \\in S$ (the set of limit points), establishing the lower extreme. This is one of the two solved endpoints of Problem #5"
+    },
+    {
+      "targetId": "prime-number-theorem",
+      "relationship": "foundational",
+      "description": "PNT gives the average prime gap $\\sim \\log p_n$, motivating the normalization $g_n / \\log p_n$. Problem #5 asks whether the normalized gaps achieve every non-negative real as a limit point"
+    },
+    {
+      "targetId": "bertrands-postulate",
+      "relationship": "related",
+      "description": "Bertrand's postulate gives $g_n < p_n$, so $g_n / \\log p_n < p_n / \\log p_n$. This provides a weak upper bound on the set S, while the conjecture $S = [0, \\infty)$ says S is unbounded"
+    },
+    {
+      "targetId": "infinitude-primes",
+      "relationship": "foundational",
+      "description": "The infinitude of primes ensures the sequence of prime gaps is infinite, making the question of limit points well-defined"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Data.Nat.Prime.Nth",
+      "Mathlib.Data.Real.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Log.Basic",
+      "Mathlib.Order.Filter.Basic",
+      "Mathlib.Topology.Basic",
+      "Mathlib.Topology.MetricSpace.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "Filter",
+      "Real",
+      "Topology"
+    ],
+    "namespace": "Erdos5",
+    "lineCount": 572,
+    "axiomCount": 3,
+    "theoremCount": 22,
+    "definitionCount": 9,
+    "path": "Proofs/Erdos5PrimeGaps.lean",
+    "sorries": 0
+  },
+  "references": [
+    "Goldston–Pintz–Yıldırım: 0 ∈ S (2009)",
+    "Westzynthius: ∞ ∈ S (1931)",
+    "Erdős–Ricci: S has positive Lebesgue measure",
+    "Hildebrand–Maier: arbitrarily large finite limit points",
+    "Merikoski: at least 1/3 of [0,∞) in S (2020)",
+    "Ford–Green–Konyagin–Maynard–Tao: improved large gap bounds (2018)",
+    "Zhang: bounded gaps between primes (2013)",
+    "Maynard–Tao: multiple bounded gaps (2013)"
+  ]
 }

--- a/src/data/proofs/erdos-500/meta.json
+++ b/src/data/proofs/erdos-500/meta.json
@@ -207,6 +207,8 @@
     "lineCount": 58,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos500Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-502/meta.json
+++ b/src/data/proofs/erdos-502/meta.json
@@ -122,7 +122,9 @@
     "lineCount": 82,
     "axiomCount": 2,
     "theoremCount": 2,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos502Problem.lean",
+    "sorries": 0
   },
   "references": [
     "Erdős (1961): original problem, posed by Coxeter",

--- a/src/data/proofs/erdos-503/meta.json
+++ b/src/data/proofs/erdos-503/meta.json
@@ -155,7 +155,9 @@
     "lineCount": 127,
     "axiomCount": 6,
     "theoremCount": 2,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/Erdos503Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-504/meta.json
+++ b/src/data/proofs/erdos-504/meta.json
@@ -18,7 +18,9 @@
     "lineCount": 217,
     "axiomCount": 5,
     "theoremCount": 1,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos504Problem.lean",
+    "sorries": 0
   },
   "meta": {
     "author": "Erdős",

--- a/src/data/proofs/erdos-505/meta.json
+++ b/src/data/proofs/erdos-505/meta.json
@@ -95,7 +95,9 @@
     "lineCount": 60,
     "axiomCount": 1,
     "theoremCount": 0,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos505Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-506/meta.json
+++ b/src/data/proofs/erdos-506/meta.json
@@ -123,7 +123,9 @@
     "lineCount": 97,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos506Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-507/meta.json
+++ b/src/data/proofs/erdos-507/meta.json
@@ -161,7 +161,9 @@
     "lineCount": 83,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos507Problem.lean",
+    "sorries": 0
   },
   "references": [
     "Heilbronn: original problem (1940s)",

--- a/src/data/proofs/erdos-508/meta.json
+++ b/src/data/proofs/erdos-508/meta.json
@@ -129,7 +129,9 @@
     "lineCount": 45,
     "axiomCount": 1,
     "theoremCount": 0,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/Erdos508Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-509/meta.json
+++ b/src/data/proofs/erdos-509/meta.json
@@ -158,7 +158,9 @@
     "lineCount": 199,
     "axiomCount": 2,
     "theoremCount": 5,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos509Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-510/meta.json
+++ b/src/data/proofs/erdos-510/meta.json
@@ -114,7 +114,9 @@
     "lineCount": 64,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos510Problem.lean",
+    "sorries": 0
   },
   "references": [
     "Chowla, S.: Original cosine problem — conjectured min_θ ∑ cos(nθ) < −c√N for |A| = N",

--- a/src/data/proofs/erdos-511/meta.json
+++ b/src/data/proofs/erdos-511/meta.json
@@ -182,7 +182,9 @@
     "lineCount": 285,
     "axiomCount": 2,
     "theoremCount": 4,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos511Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-513/meta.json
+++ b/src/data/proofs/erdos-513/meta.json
@@ -130,7 +130,9 @@
     "lineCount": 159,
     "axiomCount": 6,
     "theoremCount": 5,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos513Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-514/meta.json
+++ b/src/data/proofs/erdos-514/meta.json
@@ -188,7 +188,9 @@
     "lineCount": 318,
     "axiomCount": 1,
     "theoremCount": 3,
-    "definitionCount": 14
+    "definitionCount": 14,
+    "path": "Proofs/Erdos514Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-515/meta.json
+++ b/src/data/proofs/erdos-515/meta.json
@@ -184,7 +184,9 @@
     "lineCount": 285,
     "axiomCount": 3,
     "theoremCount": 3,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos515Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-517/meta.json
+++ b/src/data/proofs/erdos-517/meta.json
@@ -148,7 +148,9 @@
     "lineCount": 176,
     "axiomCount": 1,
     "theoremCount": 3,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos517Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-518/meta.json
+++ b/src/data/proofs/erdos-518/meta.json
@@ -199,7 +199,9 @@
     "lineCount": 286,
     "axiomCount": 4,
     "theoremCount": 5,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos518Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-519/meta.json
+++ b/src/data/proofs/erdos-519/meta.json
@@ -183,7 +183,9 @@
     "lineCount": 287,
     "axiomCount": 2,
     "theoremCount": 6,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos519Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-52/meta.json
+++ b/src/data/proofs/erdos-52/meta.json
@@ -148,7 +148,9 @@
     "lineCount": 157,
     "axiomCount": 0,
     "theoremCount": 4,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos52Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-521/meta.json
+++ b/src/data/proofs/erdos-521/meta.json
@@ -153,7 +153,9 @@
     "lineCount": 174,
     "axiomCount": 5,
     "theoremCount": 1,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos521Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-522/meta.json
+++ b/src/data/proofs/erdos-522/meta.json
@@ -182,7 +182,9 @@
     "lineCount": 276,
     "axiomCount": 1,
     "theoremCount": 8,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos522Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-523/meta.json
+++ b/src/data/proofs/erdos-523/meta.json
@@ -204,7 +204,9 @@
     "lineCount": 241,
     "axiomCount": 0,
     "theoremCount": 7,
-    "definitionCount": 21
+    "definitionCount": 21,
+    "path": "Proofs/Erdos523Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-524/meta.json
+++ b/src/data/proofs/erdos-524/meta.json
@@ -146,7 +146,9 @@
     "lineCount": 317,
     "axiomCount": 0,
     "theoremCount": 22,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos524Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-525-oq-02/meta.json
+++ b/src/data/proofs/erdos-525-oq-02/meta.json
@@ -112,6 +112,8 @@
     "lineCount": 144,
     "axiomCount": 1,
     "theoremCount": 4,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos525OQ02.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-525/meta.json
+++ b/src/data/proofs/erdos-525/meta.json
@@ -195,7 +195,9 @@
     "lineCount": 202,
     "axiomCount": 5,
     "theoremCount": 3,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos525Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-526/meta.json
+++ b/src/data/proofs/erdos-526/meta.json
@@ -162,7 +162,9 @@
     "lineCount": 242,
     "axiomCount": 4,
     "theoremCount": 2,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos526Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-527/meta.json
+++ b/src/data/proofs/erdos-527/meta.json
@@ -167,7 +167,9 @@
     "lineCount": 136,
     "axiomCount": 3,
     "theoremCount": 3,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos527Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-528/meta.json
+++ b/src/data/proofs/erdos-528/meta.json
@@ -192,7 +192,9 @@
     "lineCount": 200,
     "axiomCount": 7,
     "theoremCount": 3,
-    "definitionCount": 12
+    "definitionCount": 12,
+    "path": "Proofs/Erdos528Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-529/meta.json
+++ b/src/data/proofs/erdos-529/meta.json
@@ -227,7 +227,9 @@
     "lineCount": 306,
     "axiomCount": 7,
     "theoremCount": 6,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos529Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-53/meta.json
+++ b/src/data/proofs/erdos-53/meta.json
@@ -125,7 +125,9 @@
     "lineCount": 116,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos53Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-530/meta.json
+++ b/src/data/proofs/erdos-530/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-530",
-  "title": "Erd\u0151s Problem #530: Maximum Sidon Subsets of Finite Sets",
+  "title": "Erdős Problem #530: Maximum Sidon Subsets of Finite Sets",
   "slug": "erdos-530",
-  "description": "For a finite set A of size N, what is the maximum size \u2113(N) of a Sidon subset? Koml\u00f3s\u2013Sulyok\u2013Szemer\u00e9di: N^{1/2} \u226a \u2113(N) \u2264 (1+o(1))N^{1/2}. Conjectured: \u2113(N) ~ N^{1/2}. OPEN.",
+  "description": "For a finite set A of size N, what is the maximum size ℓ(N) of a Sidon subset? Komlós–Sulyok–Szemerédi: N^{1/2} ≪ ℓ(N) ≤ (1+o(1))N^{1/2}. Conjectured: ℓ(N) ~ N^{1/2}. OPEN.",
   "meta": {
-    "author": "Erd\u0151s, Riddell",
+    "author": "Erdős, Riddell",
     "sourceUrl": "https://erdosproblems.com/530",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos530Problem.lean",
@@ -27,14 +27,14 @@
     "theoremCount": 16
   },
   "overview": {
-    "historicalContext": "Originally posed by Riddell in 1969 and studied extensively by Erd\u0151s, this problem asks for the order of growth of $\\ell(N)$, the maximum size of a Sidon subset of any $N$-element set. A Sidon set (also called a $B_2$-set) has all pairwise sums distinct, a property introduced by Simon Sidon in the 1930s in connection with Fourier analysis. Erd\u0151s first proved the lower bound $\\ell(N) \\geq c N^{1/3}$ using a greedy argument. Koml\u00f3s, Sulyok, and Szemer\u00e9di then improved this to $\\ell(N) \\geq c \\sqrt{N}$ using a probabilistic deletion method. The upper bound $\\ell(N) \\leq (1+o(1))\\sqrt{N}$ follows from the observation that a Sidon set of size $k$ produces $k(k+1)/2$ distinct pairwise sums, which must fit within the ambient sumset. Together these give $\\sqrt{N} \\ll \\ell(N) \\leq (1+o(1))\\sqrt{N}$, so the order of growth is determined but the exact leading constant remains open. Alon and Erd\u0151s also conjectured a dual result: any $N$-element set can be partitioned into $O(\\sqrt{N})$ Sidon sets. The problem connects to the broader theory of $B_h$-sets, sum-free sets, and additive bases, and has applications in coding theory (error-correcting codes with good distance properties) and harmonic analysis (thin sets of integers with good Fourier properties).",
+    "historicalContext": "Originally posed by Riddell in 1969 and studied extensively by Erdős, this problem asks for the order of growth of $\\ell(N)$, the maximum size of a Sidon subset of any $N$-element set. A Sidon set (also called a $B_2$-set) has all pairwise sums distinct, a property introduced by Simon Sidon in the 1930s in connection with Fourier analysis. Erdős first proved the lower bound $\\ell(N) \\geq c N^{1/3}$ using a greedy argument. Komlós, Sulyok, and Szemerédi then improved this to $\\ell(N) \\geq c \\sqrt{N}$ using a probabilistic deletion method. The upper bound $\\ell(N) \\leq (1+o(1))\\sqrt{N}$ follows from the observation that a Sidon set of size $k$ produces $k(k+1)/2$ distinct pairwise sums, which must fit within the ambient sumset. Together these give $\\sqrt{N} \\ll \\ell(N) \\leq (1+o(1))\\sqrt{N}$, so the order of growth is determined but the exact leading constant remains open. Alon and Erdős also conjectured a dual result: any $N$-element set can be partitioned into $O(\\sqrt{N})$ Sidon sets. The problem connects to the broader theory of $B_h$-sets, sum-free sets, and additive bases, and has applications in coding theory (error-correcting codes with good distance properties) and harmonic analysis (thin sets of integers with good Fourier properties).",
     "problemStatement": "For a finite set $A \\subset \\mathbb{R}$ of size $N$, let $\\ell(N)$ denote the maximum size of a Sidon subset. Determine the order of growth of $\\ell(N)$. It is conjectured that $\\ell(N) \\sim N^{1/2}$.",
-    "text": "For a finite set A of size N, what is the maximum size \u2113(N) of a Sidon subset? Koml\u00f3s\u2013Sulyok\u2013Szemer\u00e9di: N^{1/2} \u226a \u2113(N) \u2264 (1+o(1))N^{1/2}. Conjectured: \u2113(N) ~ N^{1/2}. OPEN.",
-    "proofStrategy": "The formalization defines Sidon sets and maxSidonSize, then proves the corrected Erd\u0151s Problem 530 (\\ell(N) = \\Theta(\\sqrt{N})) from two ingredients: (1) the KSS lower bound \\ell(A)^2 \\geq c|A| (axiomatized), and (2) a new upper bound for interval sets: any Sidon subset of \\{1,...,N\\} has |S|^2 \\leq 4N, proved via sum counting (k(k+1)/2 distinct sums fit in \\{1,...,2N\\}). A key correction: the original universal upper bound (\\forall A) was false (powers of 2 are entirely Sidon); the correct formulation uses an existential upper bound (\\exists A).",
+    "text": "For a finite set A of size N, what is the maximum size ℓ(N) of a Sidon subset? Komlós–Sulyok–Szemerédi: N^{1/2} ≪ ℓ(N) ≤ (1+o(1))N^{1/2}. Conjectured: ℓ(N) ~ N^{1/2}. OPEN.",
+    "proofStrategy": "The formalization defines Sidon sets and maxSidonSize, then proves the corrected Erdős Problem 530 (\\ell(N) = \\Theta(\\sqrt{N})) from two ingredients: (1) the KSS lower bound \\ell(A)^2 \\geq c|A| (axiomatized), and (2) a new upper bound for interval sets: any Sidon subset of \\{1,...,N\\} has |S|^2 \\leq 4N, proved via sum counting (k(k+1)/2 distinct sums fit in \\{1,...,2N\\}). A key correction: the original universal upper bound (\\forall A) was false (powers of 2 are entirely Sidon); the correct formulation uses an existential upper bound (\\exists A).",
     "keyInsights": [
       "A Sidon set of size $k$ produces $k(k+1)/2$ distinct pairwise sums, giving the upper bound $\\ell(N) \\leq O(\\sqrt{N})$ via pigeonhole",
-      "Koml\u00f3s-Sulyok-Szemer\u00e9di's probabilistic deletion: randomly sample, remove elements creating repeated sums, expected survivor size $\\Omega(\\sqrt{N})$",
-      "The Alon-Erd\u0151s partition conjecture ($O(\\sqrt{N})$ Sidon parts) is dual: maximum independent set vs. chromatic number of the 'repeated sum' graph",
+      "Komlós-Sulyok-Szemerédi's probabilistic deletion: randomly sample, remove elements creating repeated sums, expected survivor size $\\Omega(\\sqrt{N})$",
+      "The Alon-Erdős partition conjecture ($O(\\sqrt{N})$ Sidon parts) is dual: maximum independent set vs. chromatic number of the 'repeated sum' graph",
       "The gap between lower and upper bounds is only in the leading constant, making this an unusually tight open problem",
       "Sidon sets connect to $B_h$-sets (distinct $h$-fold sums), error-correcting codes, and Fourier analysis on $\\mathbb{Z}$"
     ],
@@ -56,39 +56,39 @@
       "title": "Sidon Set Definition",
       "startLine": 23,
       "endLine": 51,
-      "summary": "Defines IsSidon (distinct pairwise sums) and proves the empty set and singletons are Sidon \u2014 the only proved theorems in the file."
+      "summary": "Defines IsSidon (distinct pairwise sums) and proves the empty set and singletons are Sidon — the only proved theorems in the file."
     },
     {
       "id": "max-sidon-size",
       "title": "Maximum Sidon Subset Size",
       "startLine": 52,
       "endLine": 62,
-      "summary": "Defines maxSidonSize A as the supremum of card over Sidon subsets of A, representing \u2113(A)."
+      "summary": "Defines maxSidonSize A as the supremum of card over Sidon subsets of A, representing ℓ(A)."
     },
     {
       "id": "known-bounds",
       "title": "Known Bounds",
       "startLine": 63,
       "endLine": 92,
-      "summary": "Axioms: Erd\u0151s's N^{1/3} lower bound, Koml\u00f3s-Sulyok-Szemer\u00e9di's N^{1/2} lower bound, and the trivial N^{1/2} upper bound."
+      "summary": "Axioms: Erdős's N^{1/3} lower bound, Komlós-Sulyok-Szemerédi's N^{1/2} lower bound, and the trivial N^{1/2} upper bound."
     },
     {
       "id": "main-conjecture",
-      "title": "Main Conjecture: \u2113(N) = \u0398(\u221aN)",
+      "title": "Main Conjecture: ℓ(N) = Θ(√N)",
       "startLine": 93,
       "endLine": 107,
-      "summary": "Defines ErdosProblem530 as a Prop: existence of constants c\u2081, c\u2082 with c\u2081|A| \u2264 \u2113(A)\u00b2 \u2264 c\u2082|A|."
+      "summary": "Defines ErdosProblem530 as a Prop: existence of constants c₁, c₂ with c₁|A| ≤ ℓ(A)² ≤ c₂|A|."
     },
     {
       "id": "partition-conjecture",
-      "title": "Alon-Erd\u0151s Partition Conjecture",
+      "title": "Alon-Erdős Partition Conjecture",
       "startLine": 108,
       "endLine": 128,
-      "summary": "Defines IsSidonPartition and states the conjecture: any N-element set can be partitioned into O(\u221aN) Sidon sets."
+      "summary": "Defines IsSidonPartition and states the conjecture: any N-element set can be partitioned into O(√N) Sidon sets."
     },
     {
       "id": "b2-connection",
-      "title": "Connection to B\u2082-Sets",
+      "title": "Connection to B₂-Sets",
       "startLine": 129,
       "endLine": 148,
       "summary": "Commentary connecting Sidon sets to $B_2$-sets in additive combinatorics. Defines `ErdosProblem530` as a Prop: $\\exists c_1, c_2 \\geq 1, \\forall A, |A| \\geq 4 \\Rightarrow c_1 |A| \\leq \\ell(A)^2 \\leq c_2 |A|$."
@@ -99,7 +99,7 @@
       "startLine": 150,
       "endLine": 169,
       "summary": "Defines `IsSidonPartition A parts` (all parts are Sidon, cover $A$, pairwise disjoint). Axiomatizes `alon_erdos_partition_conjecture`: $\\exists c \\geq 1, \\forall A, \\exists$ partition into $\\leq c\\sqrt{|A|}$ Sidon parts.",
-      "mathContext": "The Alon-Erd\u0151s conjecture is the dual of Problem #530: instead of finding the largest Sidon subset, partition into the fewest Sidon sets. The chromatic number of the 'repeated sum' graph equals the partition number, which is conjectured to be $\\Theta(\\sqrt{N})$."
+      "mathContext": "The Alon-Erdős conjecture is the dual of Problem #530: instead of finding the largest Sidon subset, partition into the fewest Sidon sets. The chromatic number of the 'repeated sum' graph equals the partition number, which is conjectured to be $\\Theta(\\sqrt{N})$."
     },
     {
       "id": "sum-injectivity",
@@ -134,8 +134,8 @@
     }
   ],
   "conclusion": {
-    "summary": "The corrected formalization proves \u2113(N) = \u0398(\u221aN) from the KSS lower bound (axiom) and a new interval upper bound: any Sidon subset of {1,...,N} has |S|\u00b2 \u2264 4N (fully proved via sum counting). The original problem statement had an incorrect universal upper bound; powers of 2 provide a counterexample. Only the leading constant remains open.",
-    "implications": "Resolving the exact asymptotics of \u2113(N) would advance additive combinatorics and connect to the partition problem of Alon and Erd\u0151s. Sidon sets have applications in error-correcting codes, compressed sensing, and Fourier analysis, where sets with distinct pairwise sums provide good frequency separation.",
+    "summary": "The corrected formalization proves ℓ(N) = Θ(√N) from the KSS lower bound (axiom) and a new interval upper bound: any Sidon subset of {1,...,N} has |S|² ≤ 4N (fully proved via sum counting). The original problem statement had an incorrect universal upper bound; powers of 2 provide a counterexample. Only the leading constant remains open.",
+    "implications": "Resolving the exact asymptotics of ℓ(N) would advance additive combinatorics and connect to the partition problem of Alon and Erdős. Sidon sets have applications in error-correcting codes, compressed sensing, and Fourier analysis, where sets with distinct pairwise sums provide good frequency separation.",
     "openQuestions": [
       "Is $\\ell(N) = (1+o(1))\\sqrt{N}$ for all finite sets of size $N$? What is the optimal constant?",
       "Can every $N$-element integer set be partitioned into $(1+o(1))\\sqrt{N}$ Sidon sets?",
@@ -158,23 +158,25 @@
     "lineCount": 381,
     "axiomCount": 2,
     "theoremCount": 16,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos530Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {
       "targetId": "erdos-10",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: additive combinatorics, number theory"
+      "description": "Related Erdős problem sharing themes: additive combinatorics, number theory"
     },
     {
       "targetId": "erdos-477",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: additive combinatorics, number theory"
+      "description": "Related Erdős problem sharing themes: additive combinatorics, number theory"
     },
     {
       "targetId": "erdos-53",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: additive combinatorics, number theory"
+      "description": "Related Erdős problem sharing themes: additive combinatorics, number theory"
     }
   ]
 }

--- a/src/data/proofs/erdos-532/meta.json
+++ b/src/data/proofs/erdos-532/meta.json
@@ -183,7 +183,9 @@
     "lineCount": 303,
     "axiomCount": 2,
     "theoremCount": 6,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos532Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-533/meta.json
+++ b/src/data/proofs/erdos-533/meta.json
@@ -146,7 +146,9 @@
     "lineCount": 366,
     "axiomCount": 4,
     "theoremCount": 15,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos533Problem.lean",
+    "sorries": 0
   },
   "references": [
     "Erdős–Hajnal–Simonovits–Sós–Szemerédi: δ > 1/16 case",

--- a/src/data/proofs/erdos-534/meta.json
+++ b/src/data/proofs/erdos-534/meta.json
@@ -153,7 +153,9 @@
     "lineCount": 133,
     "axiomCount": 3,
     "theoremCount": 1,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos534Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-535/meta.json
+++ b/src/data/proofs/erdos-535/meta.json
@@ -154,7 +154,9 @@
     "lineCount": 211,
     "axiomCount": 2,
     "theoremCount": 2,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos535Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-536/meta.json
+++ b/src/data/proofs/erdos-536/meta.json
@@ -136,7 +136,9 @@
     "lineCount": 83,
     "axiomCount": 1,
     "theoremCount": 0,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos536Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-537/meta.json
+++ b/src/data/proofs/erdos-537/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-537",
-  "title": "Erd\u0151s Problem #537: Three Numbers with Equal Prime Products",
+  "title": "Erdős Problem #537: Three Numbers with Equal Prime Products",
   "slug": "erdos-537",
-  "description": "Let \u03b5 > 0 and N be large. If A \u2286 {1,...,N} has |A| \u2265 \u03b5N, must there exist a\u2081,a\u2082,a\u2083 \u2208 A and distinct primes p\u2081,p\u2082,p\u2083 with a\u2081p\u2081 = a\u2082p\u2082 = a\u2083p\u2083? NO, disproved by Ruzsa's counterexample.",
+  "description": "Let ε > 0 and N be large. If A ⊆ {1,...,N} has |A| ≥ εN, must there exist a₁,a₂,a₃ ∈ A and distinct primes p₁,p₂,p₃ with a₁p₁ = a₂p₂ = a₃p₃? NO, disproved by Ruzsa's counterexample.",
   "meta": {
-    "author": "Ruzsa (counterexample), described by Erd\u0151s",
+    "author": "Ruzsa (counterexample), described by Erdős",
     "sourceUrl": "https://erdosproblems.com/537",
     "date": "",
     "status": "axiomatized",
@@ -58,16 +58,16 @@
     "assumptions": "3 axiom(s) and 0 sorry(s). See the Lean source for details."
   },
   "overview": {
-    "historicalContext": "**Erd\u0151s Problem #537: Three Equal Prime Products**\n\nThis problem originates from Erd\u0151s's investigations into multiplicative structure within dense sets, first appearing in [Er73]. The question asks whether positive density in $\\{1,\\ldots,N\\}$ forces the existence of three numbers $a_1, a_2, a_3$ and distinct primes $p_1, p_2, p_3$ with $a_1 p_1 = a_2 p_2 = a_3 p_3$.\n\n**Historical Context:** Erd\u0151s posed this as a stepping stone toward Problem #536, which asks an analogous question for two numbers with equal prime products. A positive answer to #537 would have implied #536 by a pigeonhole argument. The problem connects to the broader program of understanding multiplicative coincidences in dense sets, initiated by Erd\u0151s and Tur\u00e1n in the 1930s and continued by Erd\u0151s-Graham (1980).\n\n**Resolution:** Imre Z. Ruzsa, a leading figure in additive combinatorics (known for the Ruzsa covering lemma and sumset estimates), constructed a decisive counterexample. His construction uses **lacunary squarefree numbers**: integers $n$ where if $p < q$ are consecutive prime divisors of $n$, then $q > 2p$. This ingenious set has positive lower density but the lacunary gap condition prevents any triple of equal prime products.\n\n**Technique:** The proof exploits an interval constraint: restricting to $(N/2, N)$, any ratio $a_i/a_j$ lies in $(1, 2)$, which is incompatible with the gap condition $q > 2p$ for consecutive primes. This pigeonhole-style argument is characteristic of Ruzsa's economical proof style.",
+    "historicalContext": "**Erdős Problem #537: Three Equal Prime Products**\n\nThis problem originates from Erdős's investigations into multiplicative structure within dense sets, first appearing in [Er73]. The question asks whether positive density in $\\{1,\\ldots,N\\}$ forces the existence of three numbers $a_1, a_2, a_3$ and distinct primes $p_1, p_2, p_3$ with $a_1 p_1 = a_2 p_2 = a_3 p_3$.\n\n**Historical Context:** Erdős posed this as a stepping stone toward Problem #536, which asks an analogous question for two numbers with equal prime products. A positive answer to #537 would have implied #536 by a pigeonhole argument. The problem connects to the broader program of understanding multiplicative coincidences in dense sets, initiated by Erdős and Turán in the 1930s and continued by Erdős-Graham (1980).\n\n**Resolution:** Imre Z. Ruzsa, a leading figure in additive combinatorics (known for the Ruzsa covering lemma and sumset estimates), constructed a decisive counterexample. His construction uses **lacunary squarefree numbers**: integers $n$ where if $p < q$ are consecutive prime divisors of $n$, then $q > 2p$. This ingenious set has positive lower density but the lacunary gap condition prevents any triple of equal prime products.\n\n**Technique:** The proof exploits an interval constraint: restricting to $(N/2, N)$, any ratio $a_i/a_j$ lies in $(1, 2)$, which is incompatible with the gap condition $q > 2p$ for consecutive primes. This pigeonhole-style argument is characteristic of Ruzsa's economical proof style.",
     "problemStatement": "**Problem Statement (Disproved)**\n\nLet $\\epsilon > 0$ and $N$ be sufficiently large. If $A \\subseteq \\{1,\\ldots,N\\}$ has $|A| \\geq \\epsilon N$, must there exist $a_1, a_2, a_3 \\in A$ and distinct primes $p_1, p_2, p_3$ such that\n$$a_1 p_1 = a_2 p_2 = a_3 p_3?$$\n\n**Answer: NO**\n\nRuzsa constructed a counterexample: the lacunary squarefree numbers (where consecutive prime factors satisfy $p_{i+1} > 2p_i$) have positive density but contain no such triple.",
-    "text": "Let \u03b5 > 0 and N be large. If A \u2286 {1,...,N} has |A| \u2265 \u03b5N, must there exist a\u2081,a\u2082,a\u2083 \u2208 A and distinct primes p\u2081,p\u2082,p\u2083 with a\u2081p\u2081 = a\u2082p\u2082 = a\u2083p\u2083? NO, disproved by Ruzsa's counterexample.",
+    "text": "Let ε > 0 and N be large. If A ⊆ {1,...,N} has |A| ≥ εN, must there exist a₁,a₂,a₃ ∈ A and distinct primes p₁,p₂,p₃ with a₁p₁ = a₂p₂ = a₃p₃? NO, disproved by Ruzsa's counterexample.",
     "proofStrategy": "**Formalization Approach**\n\n1. **Density Definitions:** Define $\\underline{d}(A) = \\liminf_{N \\to \\infty} |A \\cap [1,N]|/N > 0$ and $\\text{IsDenseSubset}(A, \\epsilon, N)$ for $|A \\cap [1,N]| \\geq \\epsilon N$.\n\n2. **Conjecture Formalization:** State $\\text{Erdos537Conjecture}$ as $\\forall \\epsilon > 0, \\exists N_0, \\forall N \\geq N_0$, every dense $A$ has three equal prime products.\n\n3. **Ruzsa's Construction:** Define $\\text{IsLacunarySquarefree}(n)$: squarefree and for consecutive prime divisors $p < q$, $q > 2p$. The $\\text{RuzsaSet}(N)$ restricts to $[1,N]$.\n\n4. **Key Properties:** Axiomatize that the Ruzsa set has positive density and that the lacunary condition prevents the triple pattern.\n\n5. **Interval Argument:** For $a_2, a_3 \\in (N/2, N)$ prove $1 < a_2/a_3 < 2$, contradicting $q/p > 2$.\n\n6. **Disproof Assembly:** Combine density, no-triple, and contradiction to negate the conjecture.",
     "keyInsights": [
       "**Lacunary Squarefree Numbers:** The set $\\{n \\in \\mathbb{N} : n$ squarefree, consecutive prime divisors satisfy $q > 2p\\}$ has positive lower density $\\underline{d} > 0$ despite the exponential gap condition",
       "**Interval-Gap Incompatibility:** For $a_2, a_3 \\in (N/2, N)$, the ratio $a_2/a_3 \\in (1, 2)$ while the lacunary condition forces $p_3/p_2 > 2$, giving the contradiction $a_2 p_2 \\neq a_3 p_3$",
       "**Counterexample Strategy:** Rather than proving the conjecture false for all dense sets, Ruzsa exhibits one specific dense set $A$ with $\\underline{d}(A) > 0$ that avoids the pattern entirely",
       "**Implication for Problem #536:** A positive answer to #537 would have implied #536 (two equal prime products). Ruzsa's counterexample blocks this approach but does not resolve #536 itself",
-      "**Multiplicative vs. Additive:** Dense sets must contain additive patterns (Szemer\u00e9di's theorem) but need NOT contain all multiplicative patterns \u2014 the prime factorization structure allows escape"
+      "**Multiplicative vs. Additive:** Dense sets must contain additive patterns (Szemerédi's theorem) but need NOT contain all multiplicative patterns — the prime factorization structure allows escape"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -102,7 +102,7 @@
     },
     {
       "id": "conjecture",
-      "title": "The Erd\u0151s #537 Conjecture",
+      "title": "The Erdős #537 Conjecture",
       "summary": "Formalizes the conjecture: $\\forall \\epsilon > 0, \\exists N_0, \\forall N \\geq N_0$, every $\\epsilon$-dense subset has three equal prime products (FALSE)",
       "startLine": 64,
       "endLine": 76,
@@ -143,10 +143,10 @@
     {
       "id": "connections",
       "title": "Connection to Related Problems",
-      "summary": "Link to Erd\u0151s #536 (two equal prime products): #537 was proposed as a stepping stone. Also connects to multiplicative Szemer\u00e9di-type questions and the Erd\u0151s multiplicative functions program",
+      "summary": "Link to Erdős #536 (two equal prime products): #537 was proposed as a stepping stone. Also connects to multiplicative Szemerédi-type questions and the Erdős multiplicative functions program",
       "startLine": 227,
       "endLine": 246,
-      "mathContext": "Mathematical content: Link to Erd\u0151s #536 (two equal prime products): #537 was proposed as a stepping stone. Also connects to multiplicative Szemer\u00e9di-type questions and the Erd\u0151s multiplicative functions program"
+      "mathContext": "Mathematical content: Link to Erdős #536 (two equal prime products): #537 was proposed as a stepping stone. Also connects to multiplicative Szemerédi-type questions and the Erdős multiplicative functions program"
     },
     {
       "id": "main-results",
@@ -158,8 +158,8 @@
     }
   ],
   "conclusion": {
-    "summary": "Erd\u0151s Problem #537 is DISPROVED. The conjecture asked whether dense subsets of {1,...,N} must contain three numbers a\u2081,a\u2082,a\u2083 and distinct primes p\u2081,p\u2082,p\u2083 with a\u2081p\u2081 = a\u2082p\u2082 = a\u2083p\u2083. Ruzsa's construction of lacunary squarefree numbers (where consecutive prime factors satisfy q > 2p) provides a counterexample: these numbers have positive lower density but the lacunary gap property, combined with an interval constraint on ratios, prevents the required pattern.",
-    "implications": "**Theoretical Significance**: **Number-Theoretic Significance**\n\n1. **Multiplicative Structure Gap:** Positive density forces additive patterns (Szemer\u00e9di) but not all multiplicative patterns \u2014 the prime factorization structure provides an escape mechanism.\n\n2. **Lacunary Squarefree Sets:** Ruzsa's construction reveals that controlling the gap between consecutive prime divisors creates sets with rigid multiplicative structure despite having positive density.\n\n**3. Blocked Implication:** The intended pathway from #537 to #536 is broken. Problem #536 requires a different approach.\n\n4. **Sieve-Theoretic Density:** The positive density of lacunary squarefree numbers is established via sieve methods, connecting this problem to the Selberg-Brun sieve tradition.",
+    "summary": "Erdős Problem #537 is DISPROVED. The conjecture asked whether dense subsets of {1,...,N} must contain three numbers a₁,a₂,a₃ and distinct primes p₁,p₂,p₃ with a₁p₁ = a₂p₂ = a₃p₃. Ruzsa's construction of lacunary squarefree numbers (where consecutive prime factors satisfy q > 2p) provides a counterexample: these numbers have positive lower density but the lacunary gap property, combined with an interval constraint on ratios, prevents the required pattern.",
+    "implications": "**Theoretical Significance**: **Number-Theoretic Significance**\n\n1. **Multiplicative Structure Gap:** Positive density forces additive patterns (Szemerédi) but not all multiplicative patterns — the prime factorization structure provides an escape mechanism.\n\n2. **Lacunary Squarefree Sets:** Ruzsa's construction reveals that controlling the gap between consecutive prime divisors creates sets with rigid multiplicative structure despite having positive density.\n\n**3. Blocked Implication:** The intended pathway from #537 to #536 is broken. Problem #536 requires a different approach.\n\n4. **Sieve-Theoretic Density:** The positive density of lacunary squarefree numbers is established via sieve methods, connecting this problem to the Selberg-Brun sieve tradition.",
     "openQuestions": [
       "What is the exact lower density of the lacunary squarefree numbers? Sieve bounds give estimates but the precise asymptotic is unknown.",
       "Can Ruzsa's construction be adapted to disprove analogous problems with k > 3 equal prime products?",
@@ -172,12 +172,12 @@
     {
       "targetId": "erdos-536",
       "relationship": "related",
-      "description": "Erd\u0151s #536 asks whether dense sets contain two numbers with equal prime products. Problem #537 was posed as a stepping stone \u2014 a positive answer would have implied #536. Ruzsa's counterexample blocks this approach."
+      "description": "Erdős #536 asks whether dense sets contain two numbers with equal prime products. Problem #537 was posed as a stepping stone — a positive answer would have implied #536. Ruzsa's counterexample blocks this approach."
     },
     {
       "targetId": "fundamental-arithmetic",
       "relationship": "foundational",
-      "description": "The Fundamental Theorem of Arithmetic (unique prime factorization) is the foundation for Problem #537's question about when three distinct integers can have identical sets of prime factors. The multiplicative structure of \u2124 governs which prime products can coincide"
+      "description": "The Fundamental Theorem of Arithmetic (unique prime factorization) is the foundation for Problem #537's question about when three distinct integers can have identical sets of prime factors. The multiplicative structure of ℤ governs which prime products can coincide"
     }
   ],
   "leanFile": {
@@ -192,6 +192,8 @@
     "lineCount": 292,
     "axiomCount": 3,
     "theoremCount": 5,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos537Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-538/meta.json
+++ b/src/data/proofs/erdos-538/meta.json
@@ -166,7 +166,9 @@
     "lineCount": 504,
     "axiomCount": 1,
     "theoremCount": 17,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos538Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-54/meta.json
+++ b/src/data/proofs/erdos-54/meta.json
@@ -154,7 +154,9 @@
     "lineCount": 78,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos54Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-540/meta.json
+++ b/src/data/proofs/erdos-540/meta.json
@@ -170,7 +170,9 @@
     "lineCount": 160,
     "axiomCount": 2,
     "theoremCount": 5,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos540Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-541/meta.json
+++ b/src/data/proofs/erdos-541/meta.json
@@ -145,7 +145,9 @@
     "lineCount": 167,
     "axiomCount": 1,
     "theoremCount": 2,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos541Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-542/meta.json
+++ b/src/data/proofs/erdos-542/meta.json
@@ -160,7 +160,9 @@
     "lineCount": 97,
     "axiomCount": 0,
     "theoremCount": 3,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos542Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-543/meta.json
+++ b/src/data/proofs/erdos-543/meta.json
@@ -172,7 +172,9 @@
     "lineCount": 173,
     "axiomCount": 2,
     "theoremCount": 6,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos543Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-544/meta.json
+++ b/src/data/proofs/erdos-544/meta.json
@@ -97,6 +97,8 @@
     "lineCount": 65,
     "axiomCount": 3,
     "theoremCount": 1,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos544Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-547/meta.json
+++ b/src/data/proofs/erdos-547/meta.json
@@ -172,6 +172,8 @@
     "lineCount": 132,
     "axiomCount": 3,
     "theoremCount": 1,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos547Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-549/meta.json
+++ b/src/data/proofs/erdos-549/meta.json
@@ -192,7 +192,8 @@
     "axiomCount": 0,
     "theoremCount": 16,
     "definitionCount": 14,
-    "sorries": 14
+    "sorries": 14,
+    "path": "Proofs/Erdos549Problem.lean"
   },
   "references": [
     {

--- a/src/data/proofs/erdos-55/meta.json
+++ b/src/data/proofs/erdos-55/meta.json
@@ -157,7 +157,9 @@
     "lineCount": 181,
     "axiomCount": 2,
     "theoremCount": 2,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos55Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-550/meta.json
+++ b/src/data/proofs/erdos-550/meta.json
@@ -170,7 +170,9 @@
     "lineCount": 211,
     "axiomCount": 5,
     "theoremCount": 1,
-    "definitionCount": 15
+    "definitionCount": 15,
+    "path": "Proofs/Erdos550Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-551/meta.json
+++ b/src/data/proofs/erdos-551/meta.json
@@ -179,7 +179,8 @@
     "axiomCount": 0,
     "theoremCount": 26,
     "definitionCount": 14,
-    "sorries": 22
+    "sorries": 22,
+    "path": "Proofs/Erdos551Problem.lean"
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-554/meta.json
+++ b/src/data/proofs/erdos-554/meta.json
@@ -133,7 +133,9 @@
     "lineCount": 128,
     "axiomCount": 3,
     "theoremCount": 2,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos554Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-555/meta.json
+++ b/src/data/proofs/erdos-555/meta.json
@@ -94,7 +94,9 @@
     "lineCount": 71,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos555Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-556/meta.json
+++ b/src/data/proofs/erdos-556/meta.json
@@ -177,7 +177,9 @@
     "lineCount": 189,
     "axiomCount": 4,
     "theoremCount": 3,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos556Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-557/meta.json
+++ b/src/data/proofs/erdos-557/meta.json
@@ -109,7 +109,9 @@
     ],
     "opens": [
       "SimpleGraph"
-    ]
+    ],
+    "path": "Proofs/Erdos557Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-558/meta.json
+++ b/src/data/proofs/erdos-558/meta.json
@@ -158,7 +158,9 @@
     "lineCount": 194,
     "axiomCount": 5,
     "theoremCount": 2,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos558Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-56/meta.json
+++ b/src/data/proofs/erdos-56/meta.json
@@ -141,7 +141,9 @@
     "lineCount": 134,
     "axiomCount": 1,
     "theoremCount": 7,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos56Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-560/meta.json
+++ b/src/data/proofs/erdos-560/meta.json
@@ -169,7 +169,9 @@
     "lineCount": 265,
     "axiomCount": 5,
     "theoremCount": 3,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos560Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-561/meta.json
+++ b/src/data/proofs/erdos-561/meta.json
@@ -180,7 +180,9 @@
     "lineCount": 227,
     "axiomCount": 5,
     "theoremCount": 3,
-    "definitionCount": 16
+    "definitionCount": 16,
+    "path": "Proofs/Erdos561Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-562/meta.json
+++ b/src/data/proofs/erdos-562/meta.json
@@ -131,7 +131,9 @@
       "Mathlib.Data.Nat.Basic",
       "Mathlib.Tactic"
     ],
-    "opens": []
+    "opens": [],
+    "path": "Proofs/Erdos562Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-566/meta.json
+++ b/src/data/proofs/erdos-566/meta.json
@@ -130,7 +130,9 @@
       "Mathlib.Data.Real.Basic",
       "Mathlib.Tactic"
     ],
-    "opens": []
+    "opens": [],
+    "path": "Proofs/Erdos566Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-567/meta.json
+++ b/src/data/proofs/erdos-567/meta.json
@@ -137,7 +137,9 @@
       "Mathlib.Data.Nat.Basic",
       "Mathlib.Data.Finset.Basic"
     ],
-    "opens": []
+    "opens": [],
+    "path": "Proofs/Erdos567Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-568/meta.json
+++ b/src/data/proofs/erdos-568/meta.json
@@ -137,7 +137,9 @@
       "Mathlib.Data.Nat.Basic",
       "Mathlib.Data.Real.Basic"
     ],
-    "opens": []
+    "opens": [],
+    "path": "Proofs/Erdos568Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-569/meta.json
+++ b/src/data/proofs/erdos-569/meta.json
@@ -156,7 +156,9 @@
     "lineCount": 167,
     "axiomCount": 3,
     "theoremCount": 3,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos569Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-570/meta.json
+++ b/src/data/proofs/erdos-570/meta.json
@@ -151,7 +151,9 @@
     "lineCount": 148,
     "axiomCount": 1,
     "theoremCount": 2,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos570Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-571/meta.json
+++ b/src/data/proofs/erdos-571/meta.json
@@ -146,7 +146,9 @@
     "lineCount": 180,
     "axiomCount": 3,
     "theoremCount": 1,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos571Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-572/meta.json
+++ b/src/data/proofs/erdos-572/meta.json
@@ -159,7 +159,9 @@
     "lineCount": 307,
     "axiomCount": 3,
     "theoremCount": 8,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos572Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-573/meta.json
+++ b/src/data/proofs/erdos-573/meta.json
@@ -175,7 +175,9 @@
     "lineCount": 177,
     "axiomCount": 5,
     "theoremCount": 2,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos573Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-574/meta.json
+++ b/src/data/proofs/erdos-574/meta.json
@@ -104,7 +104,9 @@
       "Mathlib.Data.Finset.Basic",
       "Mathlib.Tactic"
     ],
-    "opens": []
+    "opens": [],
+    "path": "Proofs/Erdos574Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-575/meta.json
+++ b/src/data/proofs/erdos-575/meta.json
@@ -103,7 +103,9 @@
     "lineCount": 89,
     "axiomCount": 0,
     "theoremCount": 1,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos575Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-576/meta.json
+++ b/src/data/proofs/erdos-576/meta.json
@@ -137,7 +137,9 @@
     "lineCount": 223,
     "axiomCount": 2,
     "theoremCount": 8,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos576Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-577/meta.json
+++ b/src/data/proofs/erdos-577/meta.json
@@ -171,7 +171,9 @@
     "lineCount": 197,
     "axiomCount": 1,
     "theoremCount": 3,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos577Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-578/meta.json
+++ b/src/data/proofs/erdos-578/meta.json
@@ -202,6 +202,8 @@
     "lineCount": 151,
     "axiomCount": 2,
     "theoremCount": 2,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos578Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-579/meta.json
+++ b/src/data/proofs/erdos-579/meta.json
@@ -104,7 +104,9 @@
     "lineCount": 72,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos579Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-58/meta.json
+++ b/src/data/proofs/erdos-58/meta.json
@@ -125,7 +125,9 @@
     "lineCount": 152,
     "axiomCount": 3,
     "theoremCount": 4,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos58Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-580/meta.json
+++ b/src/data/proofs/erdos-580/meta.json
@@ -209,7 +209,9 @@
     "lineCount": 236,
     "axiomCount": 1,
     "theoremCount": 2,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos580Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-581/meta.json
+++ b/src/data/proofs/erdos-581/meta.json
@@ -171,7 +171,9 @@
     "lineCount": 261,
     "axiomCount": 3,
     "theoremCount": 5,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos581Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-582/meta.json
+++ b/src/data/proofs/erdos-582/meta.json
@@ -193,7 +193,9 @@
     "lineCount": 317,
     "axiomCount": 3,
     "theoremCount": 5,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos582Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-583/meta.json
+++ b/src/data/proofs/erdos-583/meta.json
@@ -203,7 +203,9 @@
     "lineCount": 232,
     "axiomCount": 3,
     "theoremCount": 4,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos583Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-584/meta.json
+++ b/src/data/proofs/erdos-584/meta.json
@@ -161,7 +161,9 @@
     "lineCount": 205,
     "axiomCount": 3,
     "theoremCount": 1,
-    "definitionCount": 18
+    "definitionCount": 18,
+    "path": "Proofs/Erdos584Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-585/meta.json
+++ b/src/data/proofs/erdos-585/meta.json
@@ -120,7 +120,9 @@
     "lineCount": 80,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos585Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-586/meta.json
+++ b/src/data/proofs/erdos-586/meta.json
@@ -140,7 +140,9 @@
     "lineCount": 165,
     "axiomCount": 3,
     "theoremCount": 1,
-    "definitionCount": 12
+    "definitionCount": 12,
+    "path": "Proofs/Erdos586Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-587/meta.json
+++ b/src/data/proofs/erdos-587/meta.json
@@ -126,7 +126,9 @@
     "lineCount": 160,
     "axiomCount": 2,
     "theoremCount": 6,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos587Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-588/meta.json
+++ b/src/data/proofs/erdos-588/meta.json
@@ -155,7 +155,9 @@
     "lineCount": 87,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/Erdos588Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-59/meta.json
+++ b/src/data/proofs/erdos-59/meta.json
@@ -173,7 +173,9 @@
     "lineCount": 337,
     "axiomCount": 5,
     "theoremCount": 7,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos59Problem.lean",
+    "sorries": 0
   },
   "references": [
     "Erdős-Frankl-Rödl (1986): 'The asymptotic number of graphs not containing a fixed subgraph'",

--- a/src/data/proofs/erdos-590/meta.json
+++ b/src/data/proofs/erdos-590/meta.json
@@ -170,7 +170,9 @@
     "lineCount": 238,
     "axiomCount": 5,
     "theoremCount": 14,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "path": "Proofs/Erdos590Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-591/meta.json
+++ b/src/data/proofs/erdos-591/meta.json
@@ -141,7 +141,9 @@
     "lineCount": 175,
     "axiomCount": 2,
     "theoremCount": 6,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/Erdos591Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-592/meta.json
+++ b/src/data/proofs/erdos-592/meta.json
@@ -161,7 +161,9 @@
       "Mathlib.SetTheory.Cardinal.Basic",
       "Mathlib.Tactic"
     ],
-    "opens": []
+    "opens": [],
+    "path": "Proofs/Erdos592Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-593/meta.json
+++ b/src/data/proofs/erdos-593/meta.json
@@ -112,7 +112,9 @@
     "lineCount": 110,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos593Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-594/meta.json
+++ b/src/data/proofs/erdos-594/meta.json
@@ -170,7 +170,9 @@
     "lineCount": 245,
     "axiomCount": 3,
     "theoremCount": 4,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos594Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-595/meta.json
+++ b/src/data/proofs/erdos-595/meta.json
@@ -179,6 +179,8 @@
     "lineCount": 229,
     "axiomCount": 3,
     "theoremCount": 2,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos595Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-596/meta.json
+++ b/src/data/proofs/erdos-596/meta.json
@@ -255,6 +255,8 @@
     "lineCount": 142,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos596Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-597/meta.json
+++ b/src/data/proofs/erdos-597/meta.json
@@ -146,7 +146,9 @@
     "lineCount": 183,
     "axiomCount": 6,
     "theoremCount": 1,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos597Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-598/meta.json
+++ b/src/data/proofs/erdos-598/meta.json
@@ -119,7 +119,9 @@
     "lineCount": 84,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos598Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-599/meta.json
+++ b/src/data/proofs/erdos-599/meta.json
@@ -151,7 +151,9 @@
     "lineCount": 230,
     "axiomCount": 1,
     "theoremCount": 2,
-    "definitionCount": 14
+    "definitionCount": 14,
+    "path": "Proofs/Erdos599Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-6/meta.json
+++ b/src/data/proofs/erdos-6/meta.json
@@ -146,7 +146,9 @@
     "lineCount": 191,
     "axiomCount": 2,
     "theoremCount": 10,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos6Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-60/meta.json
+++ b/src/data/proofs/erdos-60/meta.json
@@ -185,7 +185,9 @@
     "lineCount": 386,
     "axiomCount": 8,
     "theoremCount": 10,
-    "definitionCount": 12
+    "definitionCount": 12,
+    "path": "Proofs/Erdos60Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-600/meta.json
+++ b/src/data/proofs/erdos-600/meta.json
@@ -241,7 +241,9 @@
     "lineCount": 167,
     "axiomCount": 3,
     "theoremCount": 2,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos600Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-601/meta.json
+++ b/src/data/proofs/erdos-601/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-601",
-  "title": "Erd\u0151s #601: Infinite Paths and Independent Sets in Ordinal Graphs",
+  "title": "Erdős #601: Infinite Paths and Independent Sets in Ordinal Graphs",
   "slug": "erdos-601",
-  "description": "For which limit ordinals \u03b1 must every graph on \u03b1 have infinite path OR independent set of order type \u03b1? Known for \u03b1 < \u03c9\u2081^{\u03c9+2}. Prize: $500.",
+  "description": "For which limit ordinals α must every graph on α have infinite path OR independent set of order type α? Known for α < ω₁^{ω+2}. Prize: $500.",
   "meta": {
-    "author": "Paul Erd\u0151s, Andr\u00e1s Hajnal, Eric Milner, Jean Larson",
+    "author": "Paul Erdős, András Hajnal, Eric Milner, Jean Larson",
     "sourceUrl": "https://erdosproblems.com/601",
     "date": "1970",
     "status": "axiomatized",
@@ -52,7 +52,7 @@
       "IsIndependent: independence predicate",
       "HasOrderType: order type of vertex subsets",
       "PropertyP: path-vs-independent-set dichotomy",
-      "criticalOrdinal: \u03c9\u2081^{\u03c9+2} definition",
+      "criticalOrdinal: ω₁^{ω+2} definition",
       "erdos_hajnal_milner: main theorem (1970)",
       "CriticalCaseConjecture: $250 prize problem",
       "MartinsAxiom: set-theoretic axiom",
@@ -107,7 +107,7 @@
     },
     {
       "id": "ehm",
-      "title": "Erd\u0151s-Hajnal-Milner Theorem (1970)",
+      "title": "Erdős-Hajnal-Milner Theorem (1970)",
       "summary": "Defines `criticalOrdinal` $= \\omega_1^{\\omega+2}$ and axiomatizes the main result: $P(\\alpha)$ holds for all $\\alpha < \\omega_1^{\\omega+2}$. The proof uses transfinite induction on Cantor normal form.",
       "startLine": 88,
       "endLine": 101,
@@ -116,10 +116,10 @@
     {
       "id": "critical",
       "title": "The Critical Case: $\\omega_1^{\\omega+2}$ ($250)",
-      "summary": "States the `CriticalCaseConjecture`: does $P(\\omega_1^{\\omega+2})$ hold? This is the exact boundary where the Erd\u0151s-Hajnal-Milner induction breaks down. \\$250 prize.",
+      "summary": "States the `CriticalCaseConjecture`: does $P(\\omega_1^{\\omega+2})$ hold? This is the exact boundary where the Erdős-Hajnal-Milner induction breaks down. \\$250 prize.",
       "startLine": 102,
       "endLine": 116,
-      "mathContext": "Bound: States the `CriticalCaseConjecture`: does $P(\\omega_1^{\\omega+2})$ hold? This is the exact boundary where the Erd\u0151s-Hajnal-Milner induction breaks down. \\$250 prize."
+      "mathContext": "Bound: States the `CriticalCaseConjecture`: does $P(\\omega_1^{\\omega+2})$ hold? This is the exact boundary where the Erdős-Hajnal-Milner induction breaks down. \\$250 prize."
     },
     {
       "id": "martins-axiom",
@@ -140,10 +140,10 @@
     {
       "id": "graph-tools",
       "title": "Graph-Theoretic Tools",
-      "summary": "States K\u00f6nig's lemma (infinite finitely-branching trees have rays) and ordinal Ramsey partition regularity for large ordinals.",
+      "summary": "States König's lemma (infinite finitely-branching trees have rays) and ordinal Ramsey partition regularity for large ordinals.",
       "startLine": 152,
       "endLine": 165,
-      "mathContext": "Mathematical content: States K\u00f6nig's lemma (infinite finitely-branching trees have rays) and ordinal Ramsey partition regularity for large ordinals."
+      "mathContext": "Mathematical content: States König's lemma (infinite finitely-branching trees have rays) and ordinal Ramsey partition regularity for large ordinals."
     },
     {
       "id": "independence",
@@ -163,13 +163,13 @@
     }
   ],
   "overview": {
-    "historicalContext": "**Infinite Graph Theory and Ordinal Dichotomies (1970-1990)**\n\n**Erd\u0151s, Hajnal, and Milner** posed this problem around 1970 as part of their systematic study of infinite graphs on ordinal vertex sets. The question asks whether every graph on a limit ordinal $\\alpha$ must exhibit a fundamental dichotomy: either it contains an **infinite path** (ray) or an **independent set of order type $\\alpha$**. This connects graph theory with set theory and ordinal arithmetic.\n\nThe landmark result is the **Erd\u0151s-Hajnal-Milner theorem (1970)**: Property $P(\\alpha)$ holds for all $\\alpha < \\omega_1^{\\omega+2}$. The proof uses transfinite induction on the Cantor normal form of $\\alpha$, with the inductive step becoming increasingly difficult as the ordinal exponent grows. The boundary $\\omega_1^{\\omega+2}$ marks the point where the induction breaks down.\n\n**Larson (1990)** extended the result under **Martin's Axiom**: assuming MA, $P(\\alpha)$ holds for all $\\alpha$ with cardinality $< 2^{\\aleph_0}$. This showed the problem has deep connections to set-theoretic axioms beyond ZFC. The critical case $P(\\omega_1^{\\omega+2})$ carries a $250 prize, and the general conjecture carries $500.",
-    "problemStatement": "**Open Problem ($500 Prize)**\n\nFor which limit ordinals $\\alpha$ is it true that every graph with vertex set $\\alpha$ must have either an infinite path or an independent set of order type $\\alpha$? The conjecture is that this holds for **all** limit ordinals.\n\nThe critical test case is $\\alpha = \\omega_1^{\\omega+2}$ ($250 prize), the exact boundary of the Erd\u0151s-Hajnal-Milner theorem.",
-    "text": "For which limit ordinals \u03b1 must every graph on \u03b1 have infinite path OR independent set of order type \u03b1? Known for \u03b1 < \u03c9\u2081^{\u03c9+2}. Prize: $500.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Core definitions:** Define ordinal graphs, infinite paths, independent sets with order types, and the property $P(\\alpha)$.\n2. **Base cases:** Prove $P(n)$ for finite $n$ (trivial) and $P(\\omega)$ (via Ramsey's theorem).\n3. **Main theorem:** Axiomatize the Erd\u0151s-Hajnal-Milner theorem for $\\alpha < \\omega_1^{\\omega+2}$.\n4. **Critical case:** State the $250 conjecture at $\\omega_1^{\\omega+2}$.\n5. **Martin's Axiom:** Axiomatize MA and Larson's extension to $|\\alpha| < 2^{\\aleph_0}$.\n6. **General conjecture:** State the $500 conjecture for all limit ordinals.\n7. **Supporting tools:** Ordinal hierarchy, K\u00f6nig's lemma, independence number, transfinite induction.",
+    "historicalContext": "**Infinite Graph Theory and Ordinal Dichotomies (1970-1990)**\n\n**Erdős, Hajnal, and Milner** posed this problem around 1970 as part of their systematic study of infinite graphs on ordinal vertex sets. The question asks whether every graph on a limit ordinal $\\alpha$ must exhibit a fundamental dichotomy: either it contains an **infinite path** (ray) or an **independent set of order type $\\alpha$**. This connects graph theory with set theory and ordinal arithmetic.\n\nThe landmark result is the **Erdős-Hajnal-Milner theorem (1970)**: Property $P(\\alpha)$ holds for all $\\alpha < \\omega_1^{\\omega+2}$. The proof uses transfinite induction on the Cantor normal form of $\\alpha$, with the inductive step becoming increasingly difficult as the ordinal exponent grows. The boundary $\\omega_1^{\\omega+2}$ marks the point where the induction breaks down.\n\n**Larson (1990)** extended the result under **Martin's Axiom**: assuming MA, $P(\\alpha)$ holds for all $\\alpha$ with cardinality $< 2^{\\aleph_0}$. This showed the problem has deep connections to set-theoretic axioms beyond ZFC. The critical case $P(\\omega_1^{\\omega+2})$ carries a $250 prize, and the general conjecture carries $500.",
+    "problemStatement": "**Open Problem ($500 Prize)**\n\nFor which limit ordinals $\\alpha$ is it true that every graph with vertex set $\\alpha$ must have either an infinite path or an independent set of order type $\\alpha$? The conjecture is that this holds for **all** limit ordinals.\n\nThe critical test case is $\\alpha = \\omega_1^{\\omega+2}$ ($250 prize), the exact boundary of the Erdős-Hajnal-Milner theorem.",
+    "text": "For which limit ordinals α must every graph on α have infinite path OR independent set of order type α? Known for α < ω₁^{ω+2}. Prize: $500.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Core definitions:** Define ordinal graphs, infinite paths, independent sets with order types, and the property $P(\\alpha)$.\n2. **Base cases:** Prove $P(n)$ for finite $n$ (trivial) and $P(\\omega)$ (via Ramsey's theorem).\n3. **Main theorem:** Axiomatize the Erdős-Hajnal-Milner theorem for $\\alpha < \\omega_1^{\\omega+2}$.\n4. **Critical case:** State the $250 conjecture at $\\omega_1^{\\omega+2}$.\n5. **Martin's Axiom:** Axiomatize MA and Larson's extension to $|\\alpha| < 2^{\\aleph_0}$.\n6. **General conjecture:** State the $500 conjecture for all limit ordinals.\n7. **Supporting tools:** Ordinal hierarchy, König's lemma, independence number, transfinite induction.",
     "keyInsights": [
-      "**Erd\u0151s-Hajnal-Milner (1970):** $P(\\alpha)$ holds for all $\\alpha < \\omega_1^{\\omega+2}$ via transfinite induction on Cantor normal form",
-      "**Critical boundary:** The induction breaks at $\\omega_1^{\\omega+2}$ due to the complexity of the exponent $\\omega + 2$ \u2014 new techniques are needed",
+      "**Erdős-Hajnal-Milner (1970):** $P(\\alpha)$ holds for all $\\alpha < \\omega_1^{\\omega+2}$ via transfinite induction on Cantor normal form",
+      "**Critical boundary:** The induction breaks at $\\omega_1^{\\omega+2}$ due to the complexity of the exponent $\\omega + 2$ — new techniques are needed",
       "**Larson (1990):** Under Martin's Axiom, $P(\\alpha)$ extends to all $\\alpha$ with $|\\alpha| < 2^{\\aleph_0}$, showing set-theoretic dependence",
       "**Ramsey-type dichotomy:** The problem generalizes the infinite Ramsey theorem from $\\omega$ to arbitrary ordinals with order type requirements",
       "**Two-tier prize:** $250 for the critical case $P(\\omega_1^{\\omega+2})$, $500 for the full generalization to all limit ordinals"
@@ -181,13 +181,13 @@
     ]
   },
   "conclusion": {
-    "summary": "This formalization captures Erd\u0151s Problem #601 on the path-vs-independent-set dichotomy for ordinal graphs. The Erd\u0151s-Hajnal-Milner theorem (1970) establishes $P(\\alpha)$ for $\\alpha < \\omega_1^{\\omega+2}$, and Larson (1990) extends this under Martin's Axiom. The critical case $\\alpha = \\omega_1^{\\omega+2}$ and the general conjecture for all limit ordinals remain open, with $250 and $500 prizes respectively.",
-    "implications": "**Theoretical Significance**: **Implications**\n\n1. **Infinite combinatorics:** Resolution would illuminate the structure of infinite graphs on ordinal vertex sets and the role of ordinal arithmetic in graph theory.\n**2. Set theory connections:** Larson's result suggests the answer may depend on set-theoretic axioms \u2014 the problem may be independent of ZFC.\n3. **Partition calculus:** The techniques connect to the broader Erd\u0151s-Rado partition calculus and ordinal Ramsey theory.\n4. **Structural graph theory:** Would establish a fundamental dichotomy principle for infinite graphs, analogous to finite Ramsey theory.",
+    "summary": "This formalization captures Erdős Problem #601 on the path-vs-independent-set dichotomy for ordinal graphs. The Erdős-Hajnal-Milner theorem (1970) establishes $P(\\alpha)$ for $\\alpha < \\omega_1^{\\omega+2}$, and Larson (1990) extends this under Martin's Axiom. The critical case $\\alpha = \\omega_1^{\\omega+2}$ and the general conjecture for all limit ordinals remain open, with $250 and $500 prizes respectively.",
+    "implications": "**Theoretical Significance**: **Implications**\n\n1. **Infinite combinatorics:** Resolution would illuminate the structure of infinite graphs on ordinal vertex sets and the role of ordinal arithmetic in graph theory.\n**2. Set theory connections:** Larson's result suggests the answer may depend on set-theoretic axioms — the problem may be independent of ZFC.\n3. **Partition calculus:** The techniques connect to the broader Erdős-Rado partition calculus and ordinal Ramsey theory.\n4. **Structural graph theory:** Would establish a fundamental dichotomy principle for infinite graphs, analogous to finite Ramsey theory.",
     "openQuestions": [
-      "Does P(\u03c9\u2081^{\u03c9+2}) hold? ($250 \u2014 the critical boundary case)",
-      "Does P(\u03b1) hold for all limit ordinals \u03b1? ($500 \u2014 the general conjecture)",
+      "Does P(ω₁^{ω+2}) hold? ($250 — the critical boundary case)",
+      "Does P(α) hold for all limit ordinals α? ($500 — the general conjecture)",
       "Is the answer independent of ZFC (provable under MA but not in ZFC alone)?",
-      "Can the Erd\u0151s-Hajnal-Milner bound \u03c9\u2081^{\u03c9+2} be improved in ZFC?",
+      "Can the Erdős-Hajnal-Milner bound ω₁^{ω+2} be improved in ZFC?",
       "What happens for singular cardinals and their ordinal powers?"
     ]
   },
@@ -209,22 +209,23 @@
     "axiomCount": 3,
     "theoremCount": 19,
     "definitionCount": 13,
-    "sorries": 10
+    "sorries": 10,
+    "path": "Proofs/Erdos601Problem.lean"
   },
   "references": [
     {
       "key": "EHM70",
-      "citation": "Erd\u0151s, Paul, Hajnal, Andr\u00e1s, and Milner, Eric C., On sets of almost disjoint subsets of a set, Acta Math. Acad. Sci. Hungar. 19 (1968/1970), 209-218.",
+      "citation": "Erdős, Paul, Hajnal, András, and Milner, Eric C., On sets of almost disjoint subsets of a set, Acta Math. Acad. Sci. Hungar. 19 (1968/1970), 209-218.",
       "type": "paper"
     },
     {
       "key": "La90",
-      "citation": "Larson, Jean A., A short proof of a partition theorem for the ordinal \u03c9^\u03c9, Ann. Pure Appl. Logic 48 (1990), 253-255.",
+      "citation": "Larson, Jean A., A short proof of a partition theorem for the ordinal ω^ω, Ann. Pure Appl. Logic 48 (1990), 253-255.",
       "type": "paper"
     },
     {
       "key": "EH77",
-      "citation": "Erd\u0151s, Paul and Hajnal, Andr\u00e1s, Unsolved problems in set theory, Proc. Sympos. Pure Math. 13 (1977), 17-48.",
+      "citation": "Erdős, Paul and Hajnal, András, Unsolved problems in set theory, Proc. Sympos. Pure Math. 13 (1977), 17-48.",
       "type": "paper"
     },
     {
@@ -234,7 +235,7 @@
     },
     {
       "key": "EP",
-      "citation": "Erd\u0151s Problems, Problem #601, https://erdosproblems.com/601.",
+      "citation": "Erdős Problems, Problem #601, https://erdosproblems.com/601.",
       "type": "website"
     }
   ],
@@ -242,17 +243,17 @@
     {
       "targetId": "erdos-111",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: graph-theory, open, set-theory"
+      "description": "Related Erdős problem sharing themes: graph-theory, open, set-theory"
     },
     {
       "targetId": "erdos-1169",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: graph-theory, open, set-theory"
+      "description": "Related Erdős problem sharing themes: graph-theory, open, set-theory"
     },
     {
       "targetId": "erdos-1174",
       "relationship": "related",
-      "description": "Related Erd\u0151s problem sharing themes: graph-theory, open, set-theory"
+      "description": "Related Erdős problem sharing themes: graph-theory, open, set-theory"
     }
   ]
 }

--- a/src/data/proofs/erdos-602/meta.json
+++ b/src/data/proofs/erdos-602/meta.json
@@ -185,7 +185,9 @@
     "lineCount": 299,
     "axiomCount": 0,
     "theoremCount": 4,
-    "definitionCount": 22
+    "definitionCount": 22,
+    "path": "Proofs/Erdos602Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-603/meta.json
+++ b/src/data/proofs/erdos-603/meta.json
@@ -207,6 +207,8 @@
     "lineCount": 287,
     "axiomCount": 1,
     "theoremCount": 6,
-    "definitionCount": 19
+    "definitionCount": 19,
+    "path": "Proofs/Erdos603Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-605/meta.json
+++ b/src/data/proofs/erdos-605/meta.json
@@ -194,7 +194,9 @@
     "lineCount": 250,
     "axiomCount": 1,
     "theoremCount": 1,
-    "definitionCount": 13
+    "definitionCount": 13,
+    "path": "Proofs/Erdos605Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-606-oq-03/meta.json
+++ b/src/data/proofs/erdos-606-oq-03/meta.json
@@ -96,6 +96,8 @@
     "lineCount": 99,
     "axiomCount": 0,
     "theoremCount": 4,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "path": "Proofs/Erdos606OQ03.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-608/meta.json
+++ b/src/data/proofs/erdos-608/meta.json
@@ -206,7 +206,8 @@
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 15,
-    "sorries": 13
+    "sorries": 13,
+    "path": "Proofs/Erdos608Problem.lean"
   },
   "references": [
     {

--- a/src/data/proofs/erdos-61/meta.json
+++ b/src/data/proofs/erdos-61/meta.json
@@ -147,7 +147,9 @@
     "lineCount": 137,
     "axiomCount": 0,
     "theoremCount": 0,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos61Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-615/meta.json
+++ b/src/data/proofs/erdos-615/meta.json
@@ -181,7 +181,9 @@
     "lineCount": 285,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos615Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-616/meta.json
+++ b/src/data/proofs/erdos-616/meta.json
@@ -215,7 +215,9 @@
     "lineCount": 281,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos616Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-617/meta.json
+++ b/src/data/proofs/erdos-617/meta.json
@@ -165,7 +165,9 @@
     "lineCount": 210,
     "axiomCount": 5,
     "theoremCount": 2,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos617Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-618/meta.json
+++ b/src/data/proofs/erdos-618/meta.json
@@ -153,7 +153,9 @@
     "lineCount": 250,
     "axiomCount": 2,
     "theoremCount": 2,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos618Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-619/meta.json
+++ b/src/data/proofs/erdos-619/meta.json
@@ -165,7 +165,9 @@
     "lineCount": 209,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos619Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-62/meta.json
+++ b/src/data/proofs/erdos-62/meta.json
@@ -199,7 +199,9 @@
         "type": "proved",
         "description": "Colorability transfers to subgraphs under embedding"
       }
-    ]
+    ],
+    "path": "Proofs/Erdos62Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-621/meta.json
+++ b/src/data/proofs/erdos-621/meta.json
@@ -167,7 +167,9 @@
     "lineCount": 335,
     "axiomCount": 6,
     "theoremCount": 15,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "path": "Proofs/Erdos621Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-622/meta.json
+++ b/src/data/proofs/erdos-622/meta.json
@@ -185,6 +185,8 @@
     "lineCount": 171,
     "axiomCount": 3,
     "theoremCount": 0,
-    "definitionCount": 13
+    "definitionCount": 13,
+    "path": "Proofs/Erdos622Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-624/meta.json
+++ b/src/data/proofs/erdos-624/meta.json
@@ -175,7 +175,9 @@
     "lineCount": 219,
     "axiomCount": 5,
     "theoremCount": 4,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos624Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-625/meta.json
+++ b/src/data/proofs/erdos-625/meta.json
@@ -148,7 +148,8 @@
     "axiomCount": 2,
     "theoremCount": 0,
     "definitionCount": 0,
-    "sorries": 20
+    "sorries": 20,
+    "path": "Proofs/Erdos625Problem.lean"
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-629/meta.json
+++ b/src/data/proofs/erdos-629/meta.json
@@ -179,7 +179,8 @@
     "axiomCount": 0,
     "theoremCount": 37,
     "definitionCount": 14,
-    "sorries": 7
+    "sorries": 7,
+    "path": "Proofs/Erdos629Problem.lean"
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-63/meta.json
+++ b/src/data/proofs/erdos-63/meta.json
@@ -147,7 +147,9 @@
     "lineCount": 224,
     "axiomCount": 1,
     "theoremCount": 4,
-    "definitionCount": 13
+    "definitionCount": 13,
+    "path": "Proofs/Erdos63Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-633/meta.json
+++ b/src/data/proofs/erdos-633/meta.json
@@ -136,7 +136,8 @@
     "axiomCount": 0,
     "theoremCount": 0,
     "definitionCount": 0,
-    "sorries": 8
+    "sorries": 8,
+    "path": "Proofs/Erdos633Problem.lean"
   },
   "references": [
     {

--- a/src/data/proofs/erdos-634/meta.json
+++ b/src/data/proofs/erdos-634/meta.json
@@ -197,7 +197,8 @@
     "axiomCount": 3,
     "theoremCount": 16,
     "definitionCount": 15,
-    "sorries": 7
+    "sorries": 7,
+    "path": "Proofs/Erdos634Problem.lean"
   },
   "references": [
     {

--- a/src/data/proofs/erdos-635/meta.json
+++ b/src/data/proofs/erdos-635/meta.json
@@ -185,7 +185,9 @@
     "lineCount": 369,
     "axiomCount": 1,
     "theoremCount": 13,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos635Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-637/meta.json
+++ b/src/data/proofs/erdos-637/meta.json
@@ -203,6 +203,7 @@
     "axiomCount": 0,
     "theoremCount": 18,
     "definitionCount": 16,
-    "sorries": 10
+    "sorries": 10,
+    "path": "Proofs/Erdos637Problem.lean"
   }
 }

--- a/src/data/proofs/erdos-638/meta.json
+++ b/src/data/proofs/erdos-638/meta.json
@@ -112,7 +112,9 @@
     "lineCount": 242,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos638Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-639/meta.json
+++ b/src/data/proofs/erdos-639/meta.json
@@ -165,7 +165,9 @@
     "lineCount": 202,
     "axiomCount": 3,
     "theoremCount": 3,
-    "definitionCount": 15
+    "definitionCount": 15,
+    "path": "Proofs/Erdos639Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-64/meta.json
+++ b/src/data/proofs/erdos-64/meta.json
@@ -271,6 +271,8 @@
     "lineCount": 205,
     "axiomCount": 0,
     "theoremCount": 3,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos64Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-640/meta.json
+++ b/src/data/proofs/erdos-640/meta.json
@@ -130,7 +130,9 @@
     "lineCount": 291,
     "axiomCount": 2,
     "theoremCount": 11,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos640Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-642/meta.json
+++ b/src/data/proofs/erdos-642/meta.json
@@ -196,7 +196,8 @@
     "axiomCount": 2,
     "theoremCount": 12,
     "definitionCount": 14,
-    "sorries": 6
+    "sorries": 6,
+    "path": "Proofs/Erdos642Problem.lean"
   },
   "references": [
     {

--- a/src/data/proofs/erdos-644/meta.json
+++ b/src/data/proofs/erdos-644/meta.json
@@ -150,7 +150,8 @@
     "axiomCount": 3,
     "theoremCount": 0,
     "definitionCount": 0,
-    "sorries": 18
+    "sorries": 18,
+    "path": "Proofs/Erdos644Problem.lean"
   },
   "references": [
     {

--- a/src/data/proofs/erdos-645/meta.json
+++ b/src/data/proofs/erdos-645/meta.json
@@ -173,7 +173,9 @@
     "lineCount": 251,
     "axiomCount": 1,
     "theoremCount": 3,
-    "definitionCount": 12
+    "definitionCount": 12,
+    "path": "Proofs/Erdos645Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-646/meta.json
+++ b/src/data/proofs/erdos-646/meta.json
@@ -214,6 +214,8 @@
     "lineCount": 350,
     "axiomCount": 2,
     "theoremCount": 9,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos646Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-648/meta.json
+++ b/src/data/proofs/erdos-648/meta.json
@@ -228,7 +228,9 @@
     "lineCount": 378,
     "axiomCount": 3,
     "theoremCount": 33,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos648Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-649/meta.json
+++ b/src/data/proofs/erdos-649/meta.json
@@ -166,7 +166,9 @@
     "lineCount": 364,
     "axiomCount": 4,
     "theoremCount": 14,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "path": "Proofs/Erdos649Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-650/meta.json
+++ b/src/data/proofs/erdos-650/meta.json
@@ -153,7 +153,9 @@
     "lineCount": 92,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "path": "Proofs/Erdos650Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-651/meta.json
+++ b/src/data/proofs/erdos-651/meta.json
@@ -171,7 +171,9 @@
     "lineCount": 211,
     "axiomCount": 4,
     "theoremCount": 4,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos651Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-652/meta.json
+++ b/src/data/proofs/erdos-652/meta.json
@@ -210,7 +210,9 @@
     "lineCount": 177,
     "axiomCount": 3,
     "theoremCount": 3,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos652Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-653/meta.json
+++ b/src/data/proofs/erdos-653/meta.json
@@ -203,7 +203,9 @@
     "lineCount": 253,
     "axiomCount": 3,
     "theoremCount": 2,
-    "definitionCount": 13
+    "definitionCount": 13,
+    "path": "Proofs/Erdos653Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-654/meta.json
+++ b/src/data/proofs/erdos-654/meta.json
@@ -154,7 +154,9 @@
       "Mathlib.Data.Real.Basic",
       "Mathlib.Tactic"
     ],
-    "opens": []
+    "opens": [],
+    "path": "Proofs/Erdos654Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-655/meta.json
+++ b/src/data/proofs/erdos-655/meta.json
@@ -123,7 +123,9 @@
     "lineCount": 122,
     "axiomCount": 0,
     "theoremCount": 2,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos655Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-656/meta.json
+++ b/src/data/proofs/erdos-656/meta.json
@@ -150,7 +150,9 @@
     "lineCount": 185,
     "axiomCount": 4,
     "theoremCount": 1,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "path": "Proofs/Erdos656Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-657/meta.json
+++ b/src/data/proofs/erdos-657/meta.json
@@ -191,7 +191,8 @@
     "axiomCount": 1,
     "sorries": 0,
     "theoremCount": 6,
-    "definitionCount": 16
+    "definitionCount": 16,
+    "path": "Proofs/Erdos657Problem.lean"
   },
   "references": [
     {

--- a/src/data/proofs/erdos-658/meta.json
+++ b/src/data/proofs/erdos-658/meta.json
@@ -170,7 +170,9 @@
     "lineCount": 299,
     "axiomCount": 2,
     "theoremCount": 6,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos658Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-66/meta.json
+++ b/src/data/proofs/erdos-66/meta.json
@@ -167,7 +167,9 @@
     "lineCount": 187,
     "axiomCount": 0,
     "theoremCount": 1,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos66Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-660/meta.json
+++ b/src/data/proofs/erdos-660/meta.json
@@ -140,7 +140,8 @@
     "axiomCount": 0,
     "theoremCount": 0,
     "definitionCount": 0,
-    "sorries": 10
+    "sorries": 10,
+    "path": "Proofs/Erdos660Problem.lean"
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-661/meta.json
+++ b/src/data/proofs/erdos-661/meta.json
@@ -122,7 +122,9 @@
     "lineCount": 164,
     "axiomCount": 0,
     "theoremCount": 10,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos661Problem.lean",
+    "sorries": 0
   },
   "references": [
     "Erdős–Pach (1990): bipartite distinct distances problem",

--- a/src/data/proofs/erdos-662/meta.json
+++ b/src/data/proofs/erdos-662/meta.json
@@ -167,7 +167,9 @@
     "opens": [
       "Finset",
       "Classical"
-    ]
+    ],
+    "path": "Proofs/Erdos662Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-663/meta.json
+++ b/src/data/proofs/erdos-663/meta.json
@@ -131,7 +131,9 @@
     "lineCount": 179,
     "axiomCount": 0,
     "theoremCount": 11,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos663Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-664/meta.json
+++ b/src/data/proofs/erdos-664/meta.json
@@ -200,7 +200,9 @@
     "lineCount": 236,
     "axiomCount": 2,
     "theoremCount": 4,
-    "definitionCount": 18
+    "definitionCount": 18,
+    "path": "Proofs/Erdos664Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-665/meta.json
+++ b/src/data/proofs/erdos-665/meta.json
@@ -136,7 +136,9 @@
     "lineCount": 170,
     "axiomCount": 5,
     "theoremCount": 1,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos665Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-667/meta.json
+++ b/src/data/proofs/erdos-667/meta.json
@@ -196,7 +196,9 @@
     "lineCount": 515,
     "axiomCount": 4,
     "theoremCount": 36,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "path": "Proofs/Erdos667Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-668/meta.json
+++ b/src/data/proofs/erdos-668/meta.json
@@ -203,6 +203,8 @@
     "lineCount": 282,
     "axiomCount": 3,
     "theoremCount": 10,
-    "definitionCount": 12
+    "definitionCount": 12,
+    "path": "Proofs/Erdos668Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-669/meta.json
+++ b/src/data/proofs/erdos-669/meta.json
@@ -146,7 +146,9 @@
     "lineCount": 128,
     "axiomCount": 1,
     "theoremCount": 3,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "path": "Proofs/Erdos669Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-67/meta.json
+++ b/src/data/proofs/erdos-67/meta.json
@@ -236,6 +236,8 @@
     "lineCount": 187,
     "axiomCount": 1,
     "theoremCount": 2,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos67Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-670/meta.json
+++ b/src/data/proofs/erdos-670/meta.json
@@ -227,6 +227,8 @@
     "lineCount": 157,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 15
+    "definitionCount": 15,
+    "path": "Proofs/Erdos670Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-671/meta.json
+++ b/src/data/proofs/erdos-671/meta.json
@@ -148,7 +148,8 @@
     "axiomCount": 3,
     "theoremCount": 0,
     "definitionCount": 0,
-    "sorries": 23
+    "sorries": 23,
+    "path": "Proofs/Erdos671Problem.lean"
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-672/meta.json
+++ b/src/data/proofs/erdos-672/meta.json
@@ -174,7 +174,9 @@
     "lineCount": 214,
     "axiomCount": 5,
     "theoremCount": 4,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos672Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-673/meta.json
+++ b/src/data/proofs/erdos-673/meta.json
@@ -203,7 +203,8 @@
     "axiomCount": 0,
     "theoremCount": 21,
     "definitionCount": 8,
-    "sorries": 20
+    "sorries": 20,
+    "path": "Proofs/Erdos673Problem.lean"
   },
   "references": [
     {

--- a/src/data/proofs/erdos-674/meta.json
+++ b/src/data/proofs/erdos-674/meta.json
@@ -177,7 +177,8 @@
     "axiomCount": 0,
     "theoremCount": 25,
     "definitionCount": 12,
-    "sorries": 22
+    "sorries": 22,
+    "path": "Proofs/Erdos674Problem.lean"
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-675/meta.json
+++ b/src/data/proofs/erdos-675/meta.json
@@ -132,7 +132,9 @@
     "lineCount": 134,
     "axiomCount": 1,
     "theoremCount": 0,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos675Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-676/meta.json
+++ b/src/data/proofs/erdos-676/meta.json
@@ -168,7 +168,9 @@
     "lineCount": 225,
     "axiomCount": 1,
     "theoremCount": 4,
-    "definitionCount": 13
+    "definitionCount": 13,
+    "path": "Proofs/Erdos676Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-677/meta.json
+++ b/src/data/proofs/erdos-677/meta.json
@@ -115,7 +115,9 @@
     "lineCount": 195,
     "axiomCount": 1,
     "theoremCount": 17,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "path": "Proofs/Erdos677Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-678/meta.json
+++ b/src/data/proofs/erdos-678/meta.json
@@ -170,6 +170,7 @@
     "axiomCount": 0,
     "theoremCount": 0,
     "definitionCount": 0,
-    "sorries": 7
+    "sorries": 7,
+    "path": "Proofs/Erdos678Problem.lean"
   }
 }

--- a/src/data/proofs/erdos-679/meta.json
+++ b/src/data/proofs/erdos-679/meta.json
@@ -282,6 +282,7 @@
     "axiomCount": 0,
     "theoremCount": 16,
     "definitionCount": 18,
-    "sorries": 10
+    "sorries": 10,
+    "path": "Proofs/Erdos679Problem.lean"
   }
 }

--- a/src/data/proofs/erdos-68/meta.json
+++ b/src/data/proofs/erdos-68/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-68",
-  "title": "Erd\u0151s Problem #68: Irrationality of Factorial Sum",
+  "title": "Erdős Problem #68: Irrationality of Factorial Sum",
   "slug": "erdos-68",
-  "description": "Is the sum \u03a3_{n\u22652} 1/(n!-1) irrational? Erd\u0151s conjectured more broadly that \u03a3 1/(n!+t) is transcendental for every integer t.",
+  "description": "Is the sum Σ_{n≥2} 1/(n!-1) irrational? Erdős conjectured more broadly that Σ 1/(n!+t) is transcendental for every integer t.",
   "meta": {
-    "author": "Erd\u0151s",
+    "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/68",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos68Problem.lean",
@@ -46,13 +46,13 @@
       }
     ],
     "originalContributions": [
-      "factorialSum definition: \u03a3 1/(n!-1)",
+      "factorialSum definition: Σ 1/(n!-1)",
       "summand definition: individual terms",
       "summand_pos theorem: positivity of terms",
       "factorialSum_summable axiom: convergence",
       "weisenberg_identity axiom: double sum reformulation",
       "ErdosConjecture68 definition: main irrationality conjecture",
-      "generalizedFactorialSum definition: \u03a3 1/(n!+t)",
+      "generalizedFactorialSum definition: Σ 1/(n!+t)",
       "erdosTranscendenceConjecture definition: broader conjecture",
       "problem_68_is_special_case theorem: t=-1 case",
       "first_term through fourth_term: explicit calculations",
@@ -71,15 +71,15 @@
     "assumptions": "1 axiom: erdos_68 (OPEN conjecture). Previously had perturbation_difference axiom, now proved via exp(1) bounds + factorialSum bounds."
   },
   "overview": {
-    "historicalContext": "Erd\u0151s Problem #68 asks whether \u03a3_{n\u22652} 1/(n!-1) is irrational. The problem appears in Erd\u0151s's papers from 1968, 1988, 1990, and 1997.\n\nDesmond Weisenberg observed that the sum can be rewritten as a double sum: \u03a3 1/(n!-1) = \u03a3_n \u03a3_k 1/(n!)^k, using the geometric series 1/(x-1) = \u03a3 x^{-k}.\n\nErd\u0151s actually conjectured something stronger: that \u03a3 1/(n!+t) is transcendental for every integer t. The t=-1 case is this problem.\n\nThe decimal expansion is OEIS sequence A331373: 1.25349875... The difficulty contrasts sharply with the number e = \u03a3 1/n!, whose irrationality has been known since Euler (1737) and transcendence since Hermite (1873). The small perturbation of replacing n! with n!-1 disrupts the telescoping and algebraic identities that make e accessible, placing this problem beyond current methods in transcendence theory.",
-    "problemStatement": "**Problem Statement (OPEN)**\n\nIs the sum\n$$\\sum_{n=2}^{\\infty} \\frac{1}{n!-1}$$\nirrational?\n\n**Weisenberg's Observation:**\n$$\\sum_{n=2}^{\\infty} \\frac{1}{n!-1} = \\sum_{n=2}^{\\infty} \\sum_{k=1}^{\\infty} \\frac{1}{(n!)^k}$$\n\n**Erd\u0151s's Broader Conjecture:**\n\u03a3 1/(n!+t) is transcendental for every integer t.",
+    "historicalContext": "Erdős Problem #68 asks whether Σ_{n≥2} 1/(n!-1) is irrational. The problem appears in Erdős's papers from 1968, 1988, 1990, and 1997.\n\nDesmond Weisenberg observed that the sum can be rewritten as a double sum: Σ 1/(n!-1) = Σ_n Σ_k 1/(n!)^k, using the geometric series 1/(x-1) = Σ x^{-k}.\n\nErdős actually conjectured something stronger: that Σ 1/(n!+t) is transcendental for every integer t. The t=-1 case is this problem.\n\nThe decimal expansion is OEIS sequence A331373: 1.25349875... The difficulty contrasts sharply with the number e = Σ 1/n!, whose irrationality has been known since Euler (1737) and transcendence since Hermite (1873). The small perturbation of replacing n! with n!-1 disrupts the telescoping and algebraic identities that make e accessible, placing this problem beyond current methods in transcendence theory.",
+    "problemStatement": "**Problem Statement (OPEN)**\n\nIs the sum\n$$\\sum_{n=2}^{\\infty} \\frac{1}{n!-1}$$\nirrational?\n\n**Weisenberg's Observation:**\n$$\\sum_{n=2}^{\\infty} \\frac{1}{n!-1} = \\sum_{n=2}^{\\infty} \\sum_{k=1}^{\\infty} \\frac{1}{(n!)^k}$$\n\n**Erdős's Broader Conjecture:**\nΣ 1/(n!+t) is transcendental for every integer t.",
     "text": "A 506-line formalization of Erdos Problem #68 with 2 axioms and 0 sorries. Defines `factorialSum` as $\\sum_{n \\geq 2} 1/(n! - 1)$ and proves convergence, positivity, and Weisenberg's double-sum identity. The main conjecture `ErdosConjecture68` (irrationality of `factorialSum`) is axiomatized as OPEN. The generalized family `generalizedFactorialSum t` for integer $t$ formalizes Erdos's broader transcendence conjecture, with `problem_68_is_special_case` proving the $t = -1$ reduction. Explicit term computations, OEIS connection, and the transcendence-implies-irrationality hierarchy are established.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Sum Definition:** factorialSum using tsum with index shift\n\n2. **Convergence:** summand_pos, factorialSum_summable\n\n3. **Weisenberg Identity:** Double sum reformulation\n\n4. **Main Conjecture:** ErdosConjecture68 as Irrational factorialSum\n\n5. **Generalization:** generalizedFactorialSum for Erd\u0151s's broader conjecture\n\n6. **Explicit Values:** Compute first few terms (1, 1/5, 1/23, 1/119)\n\n7. **Context:** Connection to e and transcendence theory",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Sum Definition:** factorialSum using tsum with index shift\n\n2. **Convergence:** summand_pos, factorialSum_summable\n\n3. **Weisenberg Identity:** Double sum reformulation\n\n4. **Main Conjecture:** ErdosConjecture68 as Irrational factorialSum\n\n5. **Generalization:** generalizedFactorialSum for Erdős's broader conjecture\n\n6. **Explicit Values:** Compute first few terms (1, 1/5, 1/23, 1/119)\n\n7. **Context:** Connection to e and transcendence theory",
     "keyInsights": [
-      "**Weisenberg Identity:** 1/(n!-1) = \u03a3_k (1/n!)^k using geometric series",
+      "**Weisenberg Identity:** 1/(n!-1) = Σ_k (1/n!)^k using geometric series",
       "**OEIS A331373:** The sum is approximately 1.25349875...",
-      "**Connection to e:** \u03a3 1/n! = e, so \u03a3 1/(n!-1) is a perturbation",
-      "**Transcendence Hierarchy:** Erd\u0151s actually conjectured transcendence, not just irrationality",
+      "**Connection to e:** Σ 1/n! = e, so Σ 1/(n!-1) is a perturbation",
+      "**Transcendence Hierarchy:** Erdős actually conjectured transcendence, not just irrationality",
       "**The -1 Perturbation:** This breaks the nice factorial structure that makes e tractable"
     ],
     "prerequisites": [
@@ -125,7 +125,7 @@
     },
     {
       "id": "broader-conjecture",
-      "title": "Erd\u0151s's Broader Conjecture",
+      "title": "Erdős's Broader Conjecture",
       "summary": "generalizedFactorialSum, erdosTranscendenceConjecture, problem_68_is_special_case",
       "startLine": 108,
       "endLine": 148,
@@ -173,12 +173,12 @@
     }
   ],
   "conclusion": {
-    "summary": "Erd\u0151s Problem #68 asks whether \u03a3_{n\u22652} 1/(n!-1) is irrational. The sum converges to approximately 1.25349875... (OEIS A331373). Weisenberg showed it equals \u03a3_n \u03a3_k 1/(n!)^k. The problem remains OPEN, part of Erd\u0151s's broader conjecture that \u03a3 1/(n!+t) is transcendental for all integers t.",
-    "implications": "Resolution would advance our understanding of irrationality proofs for perturbed factorial sums. The -1 perturbation breaks the nice structure that makes e = \u03a3 1/n! tractable.",
+    "summary": "Erdős Problem #68 asks whether Σ_{n≥2} 1/(n!-1) is irrational. The sum converges to approximately 1.25349875... (OEIS A331373). Weisenberg showed it equals Σ_n Σ_k 1/(n!)^k. The problem remains OPEN, part of Erdős's broader conjecture that Σ 1/(n!+t) is transcendental for all integers t.",
+    "implications": "Resolution would advance our understanding of irrationality proofs for perturbed factorial sums. The -1 perturbation breaks the nice structure that makes e = Σ 1/n! tractable.",
     "openQuestions": [
-      "Is \u03a3 1/(n!-1) irrational?",
-      "Is \u03a3 1/(n!-1) transcendental?",
-      "Does Erd\u0151s's transcendence conjecture hold for all integer t?",
+      "Is Σ 1/(n!-1) irrational?",
+      "Is Σ 1/(n!-1) transcendental?",
+      "Does Erdős's transcendence conjecture hold for all integer t?",
       "What techniques could handle perturbed factorial sums?"
     ]
   },
@@ -245,6 +245,8 @@
     "lineCount": 680,
     "axiomCount": 1,
     "theoremCount": 33,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos68Problem.lean",
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-680/meta.json
+++ b/src/data/proofs/erdos-680/meta.json
@@ -210,7 +210,9 @@
     "lineCount": 233,
     "axiomCount": 1,
     "theoremCount": 8,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "path": "Proofs/Erdos680Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-681/meta.json
+++ b/src/data/proofs/erdos-681/meta.json
@@ -149,7 +149,9 @@
     "lineCount": 362,
     "axiomCount": 0,
     "theoremCount": 27,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos681Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-682/meta.json
+++ b/src/data/proofs/erdos-682/meta.json
@@ -215,7 +215,9 @@
     "lineCount": 357,
     "axiomCount": 2,
     "theoremCount": 8,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "path": "Proofs/Erdos682Problem.lean",
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-683/meta.json
+++ b/src/data/proofs/erdos-683/meta.json
@@ -212,7 +212,9 @@
     "lineCount": 253,
     "axiomCount": 2,
     "theoremCount": 3,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "path": "Proofs/Erdos683Problem.lean",
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/listings.json
+++ b/src/data/proofs/listings.json
@@ -21026,7 +21026,7 @@
     "erdosNumber": 508,
     "mathlibCount": 4,
     "sorries": 0,
-    "annotationCount": 4
+    "annotationCount": 5
   },
   {
     "id": "erdos-509",


### PR DESCRIPTION
## Fix

Batch 6 of gallery metadata completion: erdos-41 through erdos-683 (250 proofs).

| Batch | PR | Count |
|-------|----|-------|
| 1 | #9756 | 167 |
| 2 | #9759 | 198 |
| 3 | #9761 | 200 |
| 4 | #9762 | 200 |
| 5 | #9763 | 200 |
| 6 | this | 250 |

`pnpm build` passes cleanly.

---
Automated fix by lean-mechanic agent.