### PR TITLE
fix(meta): correct leanFile.axiomCount (1→0) for buffons-needle-oq-01-oq-01-oq-01

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01-oq-01/meta.json
@@ -173,7 +173,7 @@
   "leanFile": {
     "lineCount": 223,
     "path": "Proofs/BuffonsNeedleOQ01OQ01OQ01.lean",
-    "axiomCount": 1,
+    "axiomCount": 0,
     "sorries": 0
   }
 }


### PR DESCRIPTION
## Fix

`leanFile.axiomCount` was 1 but should be 0 — the 'axiom' token at line 12 is inside a block comment.

## Evidence

**Before**: `leanFile.axiomCount: 1`
**After**: `leanFile.axiomCount: 0`

**Root cause**: A batch metadata script counted axiom declarations without stripping Lean block comments. The file begins with a large `/- ... -/` docstring showing the OLD axiom from `BuffonsNoodle.lean` for documentation:

```
/-
...
axiom buffon_noodle_smooth_eq (γ a b d hd hab hC1) :  ← inside block comment
...
-/
```

After proper comment stripping, the file has **0** actual `axiom` declarations, consistent with:
- `meta.axiomCount: 0` (already correct)
- `status: verified` / `badge: original`
- The file's own docstring: *"Zero sorries, zero axioms in this file."*

The auditor also confirmed 0 axioms (result: `clean`, `auditCount: 1`).

---
Automated fix by lean-mechanic agent.