### PR TITLE
Enrich erdos-544 and vietas-formulas-oq-03-oq-05

### DIFF
--- a/src/data/proofs/vietas-formulas-oq-03-oq-05/annotations.json
+++ b/src/data/proofs/vietas-formulas-oq-03-oq-05/annotations.json
@@ -1,1 +1,193 @@
-[]
+[
+  {
+    "id": "vf-oq05-context",
+    "proofId": "vietas-formulas-oq-03-oq-05",
+    "type": "context",
+    "range": { "startLine": 1, "endLine": 47 },
+    "title": "Ferrari's Quartic Formula: Problem Context",
+    "content": "This file extends the discriminant theory of VietasFormulasOQ03 to degree 4, addressing the open question OQ-05 from that entry. The main goals are: (1) prove the 16-term quartic discriminant formula in elementary symmetric polynomials; (2) formalize Ferrari's algebraic decomposition of the quartic; (3) prove the central structural result $\\Delta_{\\text{res}} = 64 \\cdot \\Delta_4$ connecting the resolvent cubic to the quartic. All 11 theorems are proved over arbitrary commutative rings with 0 sorries from 0 new axioms.",
+    "mathContext": "The quartic discriminant $\\Delta_4 = \\prod_{i<j}(r_i - r_j)^2$ is a degree-12 polynomial in 4 roots, expressible as a 16-term polynomial in the elementary symmetric polynomials $e_1, e_2, e_3, e_4$. Ferrari's resolvent cubic $8y^3 - 4py^2 - 8ry + (4pr - q^2)$ has discriminant exactly $64\\Delta_4$, so both vanish simultaneously — a quartic has a repeated root iff its resolvent cubic does.",
+    "significance": "key",
+    "relatedConcepts": [
+      "elementary symmetric polynomials",
+      "discriminant",
+      "resolvent cubic",
+      "Ferrari's method"
+    ],
+    "prerequisites": [
+      "polynomial algebra",
+      "commutative ring theory",
+      "Vieta's formulas"
+    ]
+  },
+  {
+    "id": "vf-oq05-vieta",
+    "proofId": "vietas-formulas-oq-03-oq-05",
+    "type": "technique",
+    "range": { "startLine": 56, "endLine": 76 },
+    "title": "Vieta's Formula for the Quartic",
+    "content": "**vieta_quartic** proves that $(x - r_1)(x - r_2)(x - r_3)(x - r_4) = x^4 - e_1 x^3 + e_2 x^2 - e_3 x + e_4$ where $e_k$ are the elementary symmetric polynomials. The proof is a single `ring` call — the identity is a formal polynomial equality over any commutative ring $R$, quantified universally over all $x \\in R$.",
+    "mathContext": "The elementary symmetric polynomials for 4 variables: $e_1 = r_1 + r_2 + r_3 + r_4$, $e_2 = \\sum_{i<j} r_i r_j$ (6 terms), $e_3 = \\sum_{i<j<k} r_i r_j r_k$ (4 terms), $e_4 = r_1 r_2 r_3 r_4$. The alternating signs $-e_1, +e_2, -e_3, +e_4$ reflect Newton's symmetric function relations. The quartic case adds $e_4 = r_1 r_2 r_3 r_4$ as a new elementary symmetric polynomial absent in the cubic.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "elementary symmetric polynomials",
+      "Vieta's formulas",
+      "ring tactic"
+    ],
+    "prerequisites": [
+      "commutative ring theory",
+      "polynomial expansion"
+    ]
+  },
+  {
+    "id": "vf-oq05-discriminant-full",
+    "proofId": "vietas-formulas-oq-03-oq-05",
+    "type": "insight",
+    "range": { "startLine": 78, "endLine": 119 },
+    "title": "The 16-Term Quartic Discriminant",
+    "content": "**discriminant_quartic** proves the quartic discriminant formula: $\\prod_{i<j}(r_i - r_j)^2$ equals a 16-term polynomial in $e_1, e_2, e_3, e_4$. The leading term is $256e_4^3$ and the pure-$e_3$ term is $-27e_3^4$ (analogous to the $-27e_3^2$ term in the cubic discriminant). The proof uses `simp only []` to unfold Lean `let` bindings, then `ring` for the degree-12 polynomial identity.",
+    "mathContext": "$\\Delta_4 = 256e_4^3 - 192e_1 e_3 e_4^2 - 128e_2^2 e_4^2 + 144e_2 e_3^2 e_4 - 27e_3^4 + 144e_1^2 e_2 e_4^2 - 6e_1^2 e_3^2 e_4 - 80e_1 e_2^2 e_3 e_4 + 18e_1 e_2 e_3^3 + 16e_2^4 e_4 - 4e_2^3 e_3^2 - 27e_1^4 e_4^2 + 18e_1^3 e_2 e_3 e_4 - 4e_1^3 e_3^3 - 4e_1^2 e_2^3 e_4 + e_1^2 e_2^2 e_3^2$. The cubic discriminant has 5 terms; the quartic has 16. The `ring` tactic verifies this degree-12 identity by normalizing both sides to a canonical polynomial form.",
+    "significance": "key",
+    "relatedConcepts": [
+      "discriminant",
+      "elementary symmetric polynomials",
+      "degree-12 polynomial identity",
+      "ring tactic"
+    ],
+    "prerequisites": [
+      "symmetric function theory",
+      "polynomial algebra"
+    ]
+  },
+  {
+    "id": "vf-oq05-depressed",
+    "proofId": "vietas-formulas-oq-03-oq-05",
+    "type": "insight",
+    "range": { "startLine": 122, "endLine": 157 },
+    "title": "Depressed Quartic: 16 Terms Collapse to 6",
+    "content": "**discriminant_depressed** proves that for roots summing to zero (depressed quartic $x^4 + px^2 + qx + r$, equivalently $e_1 = 0$), the discriminant collapses from 16 terms to 6: $\\Delta = 256r^3 - 128p^2 r^2 + 144pq^2 r - 27q^4 + 16p^4 r - 4p^3 q^2$. The Lean proof parametrizes the fourth root as $r_4 = -r_1 - r_2 - r_3$. The **depressedDiscriminant** function packages this 6-term formula as a function of the coefficients $p, q, r$.",
+    "mathContext": "Setting $e_1 = 0$ eliminates 10 of the 16 terms — all terms containing $e_1$. The surviving terms use $p = e_2$ (sum of products of pairs), $q = -e_3$ (negative sum of triple products), $r = e_4$ (product of all roots). This 6-term formula is central to the discriminant connection: $\\Delta_{\\text{res}} = 64 \\cdot \\Delta_4(p,q,r)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "depressed polynomial",
+      "Tschirnhaus transformation",
+      "discriminant simplification"
+    ],
+    "prerequisites": [
+      "symmetric functions",
+      "polynomial algebra"
+    ]
+  },
+  {
+    "id": "vf-oq05-symmetry",
+    "proofId": "vietas-formulas-oq-03-oq-05",
+    "type": "technique",
+    "range": { "startLine": 159, "endLine": 164 },
+    "title": "Discriminant is Even in q",
+    "content": "**depressedDiscriminant_neg_q** proves $\\Delta(p, -q, r) = \\Delta(p, q, r)$: the depressed quartic discriminant is even in $q$. This reflects the substitution $x \\mapsto -x$ which sends $x^4 + px^2 + qx + r$ to $x^4 + px^2 - qx + r$ — conjugate polynomials with the same discriminant. Proof: single `ring` call, since $q$ appears only as $q^2$ and $q^4$ in the formula.",
+    "mathContext": "The 6-term formula $256r^3 - 128p^2 r^2 + 144pq^2 r - 27q^4 + 16p^4 r - 4p^3 q^2$ contains $q$ only in even powers ($q^2, q^4$), so $\\Delta(p, -q, r) = \\Delta(p, q, r)$ is immediate. This is a sanity check that the discriminant is well-defined as a function of polynomial coefficients — independent of sign conventions for $q$.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "polynomial symmetry",
+      "discriminant invariance"
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "vf-oq05-ferrari-identity",
+    "proofId": "vietas-formulas-oq-03-oq-05",
+    "type": "definition",
+    "range": { "startLine": 168, "endLine": 187 },
+    "title": "Ferrari's Algebraic Identity (1545)",
+    "content": "**ferrari_identity** is the algebraic heart of Ferrari's quartic formula. It states that for any $y$: $(x^2 + y)^2 - ((2y - p)x^2 - qx + (y^2 - r)) = x^4 + px^2 + qx + r$. This decomposes the quartic into a perfect square $(x^2 + y)^2$ minus a quadratic in $x$. If that quadratic can be made a perfect square $(ax - b)^2$ by choosing $y$ appropriately, the quartic factors into two quadratics. Proof: `ring`.",
+    "mathContext": "The idea: introducing the auxiliary parameter $y$ rewrites $x^4 + px^2 + qx + r = (x^2+y)^2 - ((2y-p)x^2 - qx + (y^2-r))$. The inner quadratic $(2y-p)x^2 - qx + (y^2-r)$ is a perfect square $(ax-b)^2$ when its discriminant vanishes: $q^2 - 4(2y-p)(y^2-r) = 0$. Expanding gives the resolvent cubic. Ferrari's insight was that reducing a quartic to a cubic is always possible this way.",
+    "significance": "key",
+    "relatedConcepts": [
+      "completing the square",
+      "Ferrari's method",
+      "resolvent cubic",
+      "quadratic formula"
+    ],
+    "prerequisites": [
+      "algebra",
+      "quadratic equations"
+    ]
+  },
+  {
+    "id": "vf-oq05-resolvent-condition",
+    "proofId": "vietas-formulas-oq-03-oq-05",
+    "type": "insight",
+    "range": { "startLine": 189, "endLine": 213 },
+    "title": "The Resolvent Cubic: Deriving the Condition on y",
+    "content": "**resolvent_cubic_condition** proves that if the inner quadratic $(2y-p)x^2 - qx + (y^2-r)$ in Ferrari's identity is a perfect square $(ax-b)^2$, then $y$ satisfies the **resolvent cubic** $8y^3 - 4py^2 - 8ry + (4pr - q^2) = 0$. The proof: from $a^2 = 2y-p$, $2ab = q$, $b^2 = y^2-r$, compute $q^2 = 4a^2 b^2 = 4(2y-p)(y^2-r)$, then use `linear_combination` to derive the cubic. The **resolventCubic** function packages $y \\mapsto 8y^3 - 4py^2 - 8ry + (4pr - q^2)$.",
+    "mathContext": "The key step: $q^2 = (2ab)^2 = 4a^2 b^2 = 4(2y-p)(y^2-r)$. Expanding the RHS: $4(2y^3 - 2ry - py^2 + pr) = 8y^3 - 4py^2 - 8ry + 4pr$. So $8y^3 - 4py^2 - 8ry + (4pr - q^2) = 0$. The `linear_combination` tactic handles this by expressing the cubic as a linear combination of the hypotheses. The resolvent cubic has three roots $y_1, y_2, y_3$; each gives a valid Ferrari factorization, and the three factorizations produce the same set of four roots $r_1, r_2, r_3, r_4$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "resolvent cubic",
+      "perfect square condition",
+      "linear_combination tactic",
+      "Cardano's formula"
+    ],
+    "prerequisites": [
+      "polynomial algebra",
+      "quadratic equations"
+    ]
+  },
+  {
+    "id": "vf-oq05-cubic-discriminant",
+    "proofId": "vietas-formulas-oq-03-oq-05",
+    "type": "definition",
+    "range": { "startLine": 232, "endLine": 238 },
+    "title": "Cubic Discriminant Formula",
+    "content": "**cubicDiscriminant a b c d** defines the discriminant of the general cubic $ay^3 + by^2 + cy + d$ as $18abcd - 4b^3 d + b^2 c^2 - 4ac^3 - 27a^2 d^2$. This 5-term formula vanishes iff the cubic has a repeated root. It is used to compute the discriminant of Ferrari's resolvent $8y^3 - 4py^2 - 8ry + (4pr - q^2)$ by substituting $a=8, b=-4p, c=-8r, d=4pr-q^2$.",
+    "mathContext": "The cubic discriminant $\\Delta_3 = 18abcd - 4b^3 d + b^2 c^2 - 4ac^3 - 27a^2 d^2$. For the depressed cubic $t^3 + pt + q$ ($a=1, b=0, c=p, d=q$): $\\Delta_3 = -4p^3 - 27q^2$, the Cardano discriminant. For the monic cubic $t^3 + pt^2 + qt + r$ ($a=1$): $\\Delta_3 = p^2 q^2 - 4q^3 - 4p^3 r + 18pqr - 27r^2$, the standard form analogous to the quadratic formula's $b^2 - 4ac$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "cubic discriminant",
+      "Cardano's formula",
+      "resultant"
+    ],
+    "prerequisites": [
+      "polynomial theory",
+      "discriminant theory"
+    ]
+  },
+  {
+    "id": "vf-oq05-discriminant-connection",
+    "proofId": "vietas-formulas-oq-03-oq-05",
+    "type": "insight",
+    "range": { "startLine": 240, "endLine": 258 },
+    "title": "Central Result: Δ_res = 64 · Δ₄",
+    "content": "**resolvent_discriminant_eq** is the main theorem: the discriminant of Ferrari's resolvent cubic $8y^3 - 4py^2 - 8ry + (4pr - q^2)$ equals exactly $64 \\cdot \\Delta_4(p, q, r)$. Consequence: **the depressed quartic has a repeated root iff its resolvent cubic has a repeated root** — both discriminants vanish simultaneously. Proof: `unfold cubicDiscriminant depressedDiscriminant; ring`. The companion theorem **resolvent_discriminant_formula** gives the explicit 6-term expanded form of $\\Delta_{\\text{res}}$.",
+    "mathContext": "$\\Delta_{\\text{res}} = 1024p^4 r - 256p^3 q^2 - 8192p^2 r^2 + 9216pq^2 r + 16384r^3 - 1728q^4 = 64 \\cdot (256r^3 - 128p^2 r^2 + 144pq^2 r - 27q^4 + 16p^4 r - 4p^3 q^2) = 64\\Delta_4$. The factor 64 arises from the leading coefficient 8 of the resolvent cubic: the cubic discriminant formula scales as $a^2 \\cdot (\\text{monic part})$, so the non-monic leading coefficient 8 contributes $8^2 / 1 = 64$ compared to a monic resolvent cubic.",
+    "significance": "key",
+    "relatedConcepts": [
+      "discriminant scaling",
+      "resolvent cubic",
+      "Ferrari's method",
+      "repeated roots"
+    ],
+    "prerequisites": [
+      "cubic discriminant",
+      "depressed quartic"
+    ]
+  },
+  {
+    "id": "vf-oq05-summary",
+    "proofId": "vietas-formulas-oq-03-oq-05",
+    "type": "context",
+    "range": { "startLine": 262, "endLine": 304 },
+    "title": "Summary: The Degeneration Chain",
+    "content": "The summary section states the main chain of equivalences: (quartic has repeated root) $\\iff \\Delta_4 = 0 \\iff \\Delta_{\\text{res}} = 0$ [since $\\Delta_{\\text{res}} = 64\\Delta_4$] $\\iff$ (resolvent cubic has a repeated root) $\\iff$ (Ferrari's factorization degenerates). **discriminant_scaling_summary** restates the 64× connection as a named corollary. **ferrari_decomposition_valid** reconfirms the algebraic identity for any $x, y$. The `#check` lines at the end validate that all main theorems are well-typed.",
+    "mathContext": "The chain shows that degenerate quartics (repeated roots) are exactly those whose resolvent cubic is also degenerate. When the resolvent cubic has a repeated root $y_0$, the quadratic $(2y_0-p)x^2 - qx + (y_0^2-r)$ in Ferrari's decomposition is a perfect square, and the quartic splits into a product of two quadratics sharing a common root — the geometric manifestation of the algebraic degeneracy.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "discriminant chain",
+      "degenerate polynomials",
+      "Ferrari's factorization"
+    ],
+    "prerequisites": [
+      "all previous sections"
+    ]
+  }
+]

--- a/src/data/proofs/vietas-formulas-oq-03-oq-05/meta.json
+++ b/src/data/proofs/vietas-formulas-oq-03-oq-05/meta.json
@@ -44,13 +44,19 @@
     {
       "id": "vieta-quartic",
       "title": "Vieta's Formula for the Quartic",
+      "startLine": 56,
+      "endLine": 76,
       "summary": "Proves that (x − r₁)(x − r₂)(x − r₃)(x − r₄) = x⁴ − e₁x³ + e₂x² − e₃x + e₄, where e₁–e₄ are the elementary symmetric polynomials in the four roots. This is the quartic analogue of the cubic Vieta formula in VietasFormulasOQ03.",
+      "mathContext": "$e_1 = \\sum r_i$, $e_2 = \\sum_{i<j} r_i r_j$, $e_3 = \\sum_{i<j<k} r_i r_j r_k$, $e_4 = r_1 r_2 r_3 r_4$. The alternating signs in $x^4 - e_1 x^3 + e_2 x^2 - e_3 x + e_4$ reflect Newton's relations. Proved by `ring`.",
       "theorems": ["vieta_quartic"]
     },
     {
       "id": "quartic-discriminant",
-      "title": "The 16-Term Quartic Discriminant",
-      "summary": "Proves the quartic discriminant formula: ∏_{i<j}(rᵢ−rⱼ)² = 16-term polynomial in e₁,e₂,e₃,e₄. The 16 terms include 256e₄³ (leading), −27e₃⁴ (analogous to −27e₃² in the cubic), and e₁²e₂²e₃² (highest in e₁). This degree-12 polynomial identity is verified by the ring tactic. Also proves the q→−q symmetry of the depressed discriminant.",
+      "title": "The 16-Term Quartic Discriminant and Depressed Form",
+      "startLine": 78,
+      "endLine": 166,
+      "summary": "Proves the quartic discriminant formula: ∏_{i<j}(rᵢ−rⱼ)² = 16-term polynomial in e₁,e₂,e₃,e₄. The 16 terms include 256e₄³ (leading), −27e₃⁴ (analogous to −27e₃² in the cubic), and e₁²e₂²e₃². Also proves the depressed form (6 terms when e₁=0) and q→−q symmetry.",
+      "mathContext": "$\\Delta_4 = 256e_4^3 - 192e_1 e_3 e_4^2 - \\cdots + e_1^2 e_2^2 e_3^2$ (16 terms). For $e_1=0$: $\\Delta_4 = 256r^3 - 128p^2 r^2 + 144pq^2 r - 27q^4 + 16p^4 r - 4p^3 q^2$. All proved by `ring`.",
       "theorems": [
         "discriminant_quartic",
         "discriminant_depressed",
@@ -60,7 +66,10 @@
     {
       "id": "ferrari-resolvent",
       "title": "Ferrari's Algebraic Identity and Resolvent Cubic",
+      "startLine": 168,
+      "endLine": 215,
       "summary": "Proves Ferrari's decomposition: x⁴ + px² + qx + r = (x² + y)² − ((2y−p)x² − qx + (y²−r)). The inner quadratic is a perfect square (ax−b)² when a² = 2y−p, 2ab = q, b² = y²−r — conditions that force 8y³ − 4py² − 8ry + (4pr − q²) = 0. This resolvent cubic is Ferrari's key reduction of the quartic to a cubic.",
+      "mathContext": "From the perfect square conditions: $q^2 = 4a^2 b^2 = 4(2y-p)(y^2-r)$, giving $8y^3 - 4py^2 - 8ry + (4pr - q^2) = 0$. Proved using `ring` and `linear_combination`.",
       "theorems": [
         "ferrari_identity",
         "resolvent_cubic_condition",
@@ -71,16 +80,28 @@
     {
       "id": "discriminant-connection",
       "title": "Discriminant Connection: Δ_res = 64 · Δ_quartic",
+      "startLine": 217,
+      "endLine": 304,
       "summary": "Proves the central structural result: the discriminant of Ferrari's resolvent cubic 8y³ − 4py² − 8ry + (4pr − q²) equals exactly 64 times the depressed quartic discriminant. Consequence: the quartic has a repeated root if and only if its resolvent cubic has a repeated root — both discriminants vanish together. This is a pure ring identity verified by ring.",
+      "mathContext": "For the resolvent cubic $a=8, b=-4p, c=-8r, d=4pr-q^2$: the cubic discriminant $18abcd - 4b^3 d + b^2 c^2 - 4ac^3 - 27a^2 d^2$ evaluates to $1024p^4 r - 256p^3 q^2 - 8192p^2 r^2 + 9216pq^2 r + 16384r^3 - 1728q^4 = 64 \\cdot \\Delta_4$.",
       "theorems": [
         "resolvent_discriminant_eq",
         "resolvent_discriminant_formula",
         "discriminant_scaling_summary"
-      ],
-      "mathContext": "For the resolvent cubic ay³ + by² + cy + d with a=8, b=−4p, c=−8r, d=4pr−q², the cubic discriminant formula 18abcd − 4b³d + b²c² − 4ac³ − 27a²d² evaluates to 1024p⁴r − 256p³q² − 8192p²r² + 9216pq²r + 16384r³ − 1728q⁴ = 64·(256r³ − 128p²r² + 144pq²r − 27q⁴ + 16p⁴r − 4p³q²) = 64·Δ₄."
+      ]
     }
   ],
   "overview": {
+    "historicalContext": "Lodovico Ferrari (1522–1565), a student of Girolamo Cardano, discovered the method for solving quartic equations in 1540 and published it (with Cardano's permission) in Cardano's *Ars Magna* (1545). Ferrari's key insight was to introduce an auxiliary parameter $y$ — now called the resolvent — that reduces the quartic to a cubic, which Cardano had already solved. The discriminant of the quartic was systematically studied by Lagrange in his 1770 *Réflexions*, who placed all polynomial solubility in a unified framework. The connection $\\Delta_{\\text{res}} = 64 \\cdot \\Delta_4$ formalised here is a classical 19th-century result from the theory of invariants, connecting the degeneration conditions of the quartic and its resolvent. Van der Waerden's *Moderne Algebra* (1930) presented discriminant theory in the modern ring-theoretic language used here.",
+    "problemStatement": "Prove the 16-term quartic discriminant formula $\\Delta_4 = \\prod_{i<j}(r_i - r_j)^2$ in terms of elementary symmetric polynomials $e_1, e_2, e_3, e_4$. Formalize Ferrari's decomposition $x^4 + px^2 + qx + r = (x^2+y)^2 - ((2y-p)x^2 - qx + (y^2-r))$ and the resolvent cubic $8y^3 - 4py^2 - 8ry + (4pr-q^2) = 0$. Prove the discriminant connection $\\Delta_{\\text{res}}(p,q,r) = 64 \\cdot \\Delta_4(p,q,r)$.",
+    "proofStrategy": "The file proceeds in five parts: (I) Vieta's formula for 4 roots by ring; (II) the 16-term quartic discriminant identity by ring over arbitrary commutative rings; (III) the depressed quartic (6-term) discriminant by specializing to e₁=0, and the q→−q symmetry; (IV) Ferrari's identity (ring) and the resolvent cubic condition (linear_combination from the three square-root conditions); (V) the central discriminant connection Δ_res = 64·Δ₄ by ring after unfolding definitions. Every theorem holds over an arbitrary commutative ring R, with no field assumptions needed.",
+    "keyInsights": [
+      "The 16-term quartic discriminant reduces to 6 terms for the depressed quartic (e₁=0), eliminating all 10 terms containing e₁ — this is why working with depressed polynomials is algorithmically cleaner",
+      "Ferrari's decomposition works for any y, but the resolvent cubic constraint forces the inner quadratic to be a perfect square — the auxiliary parameter y carries all the solvability information",
+      "The factor 64 = 8² in Δ_res = 64·Δ₄ comes from the leading coefficient 8 of the resolvent cubic: cubic discriminants scale quadratically in the leading coefficient",
+      "All theorems hold over arbitrary commutative rings, not just ℂ or ℝ — the discriminant is a purely algebraic notion requiring no topology or ordering",
+      "The q→−q symmetry of the depressed discriminant reflects the substitution x↦−x, which swaps the two quartics x⁴+px²+qx+r and x⁴+px²−qx+r — they have the same set of roots up to sign"
+    ],
     "background": "Newton's identities (VietasFormulasOQ03) compute power sums from elementary symmetric polynomials and prove the cubic discriminant Δ = e₁²e₂² − 4e₂³ − 4e₁³e₃ + 18e₁e₂e₃ − 27e₃². This entry extends to degree 4, addressing OQ-05 from that gallery entry.",
     "mainResult": "The quartic discriminant has 16 terms in e₁, e₂, e₃, e₄ (vs 5 for the cubic). For the depressed quartic (e₁=0), this collapses to 6 terms. Ferrari's resolvent cubic has discriminant exactly 64 times larger — both vanish simultaneously.",
     "significance": "Ferrari's 1545 quartic formula (the last purely algebraic formula before Abel–Ruffini) reduces to the resolvent cubic. The discriminant connection proved here is why: a degenerate quartic (repeated root, Δ₄=0) produces a degenerate resolvent (repeated root, Δ_res=0). The factor of 64 arises from the leading coefficient 8 of the resolvent cubic (64 = 8^(discriminant degree formula)).",
@@ -88,6 +109,7 @@
   },
   "conclusion": {
     "summary": "304-line formalization proving 11 theorems (0 sorries) from 0 new axioms. The main results — the 16-term quartic discriminant formula and the 64× resolvent discriminant connection — are machine-verified polynomial identities over arbitrary commutative rings.",
+    "implications": "The discriminant connection $\\Delta_{\\text{res}} = 64 \\cdot \\Delta_4$ is the algebraic reason Ferrari's method works: solvability (or degeneracy) of the quartic is equivalent to solvability (or degeneracy) of a cubic. This reduces degree-4 problems to degree-3 ones — a complete and rigorous formalization of a cornerstone of classical algebra. Extending to Galois theory (checking whether the discriminant is a perfect square) would formalize the solvability criterion $\\mathrm{Gal}(f) \\subseteq A_4$ for quartic polynomials.",
     "openQuestions": [
       "Formalize the Galois solvability criterion: Gal(f) ⊆ A₄ iff the quartic discriminant is a perfect square in the base field.",
       "Prove Abel-Ruffini for the general quartic: connect Ferrari's resolvent to the fact that quartics (but not quintics) are solvable by radicals.",
@@ -97,19 +119,19 @@
   },
   "crossReferences": [
     {
-      "id": "vietas-formulas-oq-03",
-      "title": "Newton's Identities (cubic discriminant)",
-      "relationship": "parent"
+      "targetId": "vietas-formulas-oq-03",
+      "relationship": "foundational",
+      "description": "Parent entry: Newton's identities and cubic discriminant. This file extends those results to degree 4, addressing OQ-05 from that gallery page."
     },
     {
-      "id": "vietas-formulas-oq-03-oq-01",
-      "title": "Generalized Newton's Identities via MvPolynomial",
-      "relationship": "sibling"
+      "targetId": "vietas-formulas-oq-03-oq-01",
+      "relationship": "related",
+      "description": "Sibling entry: generalized Newton's identities via MvPolynomial. Both extend the cubic discriminant work from VietasFormulasOQ03."
     },
     {
-      "id": "vietas-formulas",
-      "title": "Vieta's Formulas",
-      "relationship": "grandparent"
+      "targetId": "vietas-formulas",
+      "relationship": "foundational",
+      "description": "Grandparent entry: Vieta's formulas for relating polynomial roots to coefficients — the foundation for the elementary symmetric polynomial framework used throughout."
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass covering two gallery entries.

## erdos-544: Fix stale metadata and annotation line ranges

- Fixed stale `assumptions` field: was "11 axiom(s)" but file has 3 (`ramsey3`, `ramsey3_mono`, `ramsey3_val_3`)
- Fixed `proofStrategy`: was claiming known values k=3–9 and asymptotic axioms that don't exist in the current file
- Added LaTeX to `problemStatement`
- Fixed all annotation line ranges (were off by ~30+ lines from a previous version of the file)
- Added new annotation for `ramsey3_ge_six` theorem (lines 38–42) — the only proved theorem, previously unannotated
- Revised known-values annotation: only R(3,3)=6 is formalized, not all 7 values
- Pointed kim-lower/shearer-upper annotations at header lines where bounds are discussed

## vietas-formulas-oq-03-oq-05: Add full annotation coverage

Quality was 18 (annotations.json was empty `[]`).

- 10 new annotations covering all 6 proof sections with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`
- Added `overview.historicalContext` (Ferrari 1545 → Lagrange 1770 → van der Waerden 1930)
- Added `overview.problemStatement` with LaTeX, `proofStrategy`, and 5 `keyInsights`
- Added `conclusion.implications` (Galois solvability criterion connection)
- Fixed all 4 sections to include `startLine`/`endLine`
- Fixed `crossReferences` to use `targetId` (standard format)

**No axiom integrity issues in either entry.**