### PR TITLE
fix(audit): correct sorry counts for erdos-1012-oq-03 and erdos-204

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1847,9 +1847,9 @@
       "result": "clean"
     },
     "erdos-1012-oq-03": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-04-04T19:24:10Z",
+      "lastAudited": "2026-04-05T12:29:11Z",
       "result": "issues-fixed"
     },
     "erdos-1013": {
@@ -3736,8 +3736,8 @@
     },
     "erdos-204": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-05T05:16:26Z",
+      "auditCount": 5,
+      "lastAudited": "2026-04-05T12:29:12Z",
       "result": "issues-fixed",
       "issues": [
         "sorries field was 0 but file has 1 sorry (MaxCoverableDensity def); proofStrategy said 253-line but file is 189 lines; examples section listed non-existent n6_fails/n12_fails axioms"

--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -13,7 +13,7 @@
       "tournaments"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 5,
     "axiomCount": 0,
     "lineCount": 1277,
     "assumptions": "0 axioms. 1 sorry: ghouila_houri (full proof needs longest-path argument ~200 lines tracking both in- and out-degrees). hamiltonian_of_few_missing_arcs and directed_hamiltonian_threshold are now fully proved: the fiber counting lemma hBadFor_bound (∀ p ∈ Missing, |BadFor p| ≤ n*(n-2)!) was proved via fiber decomposition + injection into Perm(Fin(n-2)) using Finset.orderIsoOfFin. Moon-Moser theorem and Rédei are also fully proved.",

--- a/src/data/proofs/erdos-204/meta.json
+++ b/src/data/proofs/erdos-204/meta.json
@@ -17,7 +17,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 204,
     "erdosUrl": "https://erdosproblems.com/204",
     "erdosProblemStatus": "solved",
@@ -201,7 +201,7 @@
     "theoremCount": 5,
     "definitionCount": 12,
     "path": "Proofs/Erdos204Problem.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "references": [
     {


### PR DESCRIPTION
## Summary

Two gallery proofs had stale `sorries` counts:

- **erdos-1012-oq-03**: `sorries` 1→5. Lean file has 5 actual sorry statements (lines 787, 795, 815, 825, 963): four private lemma scaffolds for the directed cycle construction plus one API compatibility sorry.
- **erdos-204**: `sorries` 1→0. The sorry was converted to `axiom adenwalla_2025 : ErdosGrahamConjecture`. The `axiomCount` was already correctly set to 1.

Also updates audit tracker entries for both proofs.

## Test plan

- [ ] `npx tsx scripts/auditor/find-targets.ts --issues` returns 0 after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)