### PR TITLE
Enrich erdos-563, fix arithmetic-series meta, fix erdos-330/508/547/bertrands annotations

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-prod-rpow-comm",
+    "proofId": "amgm-inequality-oq-03-oq-02-oq-01",
+    "range": { "startLine": 63, "endLine": 86 },
+    "type": "technique",
+    "title": "Finset rpow Distributivity: The Algebraic Bridge",
+    "content": "Two key helper lemmas establish how rpow distributes over Finset products. finset_prod_rpow proves (∏ᵢ fᵢ)^r = ∏ᵢ fᵢ^r by Finset induction, using Real.mul_rpow at each step. prod_rpow_comm then derives (∏ᵢ zᵢ^wᵢ)^r = ∏ᵢ (zᵢ^r)^wᵢ: both sides equal ∏ᵢ zᵢ^(r·wᵢ) via rpow_mul. This identity is the algebraic bridge that allows the geometric mean (∏ zᵢ^wᵢ) to connect to the AM-GM inequality applied at the values zᵢ^r. Without this identity, the proof would require significantly more bookkeeping.",
+    "mathContext": "$(\\prod_i z_i^{w_i})^r = \\prod_i (z_i^r)^{w_i}$. Both sides equal $\\prod_i z_i^{r w_i}$ via $\\text{rpow\\_mul}$: $(z_i^{w_i})^r = z_i^{w_i r} = (z_i^r)^{w_i}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["rpow distributivity", "Finset induction", "geometric mean", "power mean"],
+    "prerequisites": ["Real.rpow_mul", "Real.mul_rpow", "Finset.induction_on"]
+  },
+  {
+    "id": "ann-core-inequality",
+    "proofId": "amgm-inequality-oq-03-oq-02-oq-01",
+    "range": { "startLine": 92, "endLine": 108 },
+    "type": "insight",
+    "title": "Core Inequality: GM^r ≤ ∑ wᵢzᵢ^r for All r",
+    "content": "The central lemma geomMean_rpow_le_weightedSum_rpow states that for any r ∈ ℝ (positive, negative, or zero), (∏ᵢ zᵢ^wᵢ)^r ≤ ∑ᵢ wᵢ · zᵢ^r. The proof is a single application of Real.geom_mean_le_arith_mean_weighted (AM-GM from Mathlib) applied to the substituted values pᵢ = zᵢ^r: this gives ∏ᵢ (zᵢ^r)^wᵢ ≤ ∑ᵢ wᵢ · zᵢ^r. Then prod_rpow_comm identifies the LHS as GM^r. The elegant insight is that substituting zᵢ^r into AM-GM yields an inequality valid for ALL r at once — there is no case split on the sign of r at this stage.",
+    "mathContext": "$\\text{GM}(z,w)^r = (\\prod_i z_i^{w_i})^r = \\prod_i (z_i^r)^{w_i} \\leq \\sum_i w_i z_i^r$ by AM-GM applied to $(p_i) = (z_i^r)$.",
+    "significance": "key",
+    "relatedConcepts": ["AM-GM inequality", "weighted geometric mean", "weighted power mean", "rpow substitution"],
+    "prerequisites": ["Real.geom_mean_le_arith_mean_weighted", "weighted geometric mean definition", "prod_rpow_comm"]
+  },
+  {
+    "id": "ann-gm-le-pos",
+    "proofId": "amgm-inequality-oq-03-oq-02-oq-01",
+    "range": { "startLine": 113, "endLine": 133 },
+    "type": "technique",
+    "title": "GM ≤ M_r for r > 0: Raising to Positive Power",
+    "content": "For r > 0, GM ≤ M_r follows from the core inequality by raising both sides to the positive exponent 1/r. The proof first rewrites GM = (GM^r)^(1/r) using rpow_mul and mul_one_div_cancel. Then the monotonicity of x ↦ x^(1/r) (rpow_le_rpow for non-negative base and positive exponent) lifts the inequality: (GM^r)^(1/r) ≤ (∑ wᵢzᵢ^r)^(1/r) = M_r. This extends the result from OQ03 (which only proved r ≥ 1) to all r > 0 using the same argument.",
+    "mathContext": "For $r > 0$: $\\text{GM} = (\\text{GM}^r)^{1/r} \\leq (\\sum_i w_i z_i^r)^{1/r} = M_r$. Uses: $x \\leq y \\Rightarrow x^{1/r} \\leq y^{1/r}$ for $1/r > 0$.",
+    "significance": "key",
+    "relatedConcepts": ["power mean monotonicity", "rpow monotonicity", "GM-AM inequality", "weighted power mean"],
+    "prerequisites": ["core inequality GM^r ≤ ∑ wᵢzᵢ^r", "Real.rpow_le_rpow", "Real.rpow_mul"]
+  },
+  {
+    "id": "ann-inversion-technique",
+    "proofId": "amgm-inequality-oq-03-oq-02-oq-01",
+    "range": { "startLine": 139, "endLine": 188 },
+    "type": "technique",
+    "title": "M_r ≤ GM for r < 0: The Inversion Technique",
+    "content": "For r < 0, the exponent 1/r is negative, so raising both sides of GM^r ≤ ∑ wᵢzᵢ^r to 1/r would reverse the inequality — but Lean's rpow_le_rpow only handles non-negative exponents directly. The proof avoids this by reformulating: x^(1/r) = (x^(-(1/r)))⁻¹ for x > 0. Then since -(1/r) > 0, the core inequality A ≤ B (where A = GM^r, B = ∑) is lifted positively to A^(-(1/r)) ≤ B^(-(1/r)). The final step inverts: if A ≤ B then B⁻¹ ≤ A⁻¹, proved algebraically using 1 = A·A⁻¹ ≤ B·A⁻¹, then multiplying by B⁻¹. This algebraic inversion avoids any lemma about inv_le_inv.",
+    "mathContext": "For $r < 0$: $-(1/r) > 0$, so $\\text{GM}^r \\leq \\sum w_i z_i^r$ lifts to $(\\text{GM}^r)^{-(1/r)} \\leq (\\sum)^{-(1/r)}$. Inverting: $M_r = (\\sum)^{1/r} = ((\\sum)^{-(1/r)})^{-1} \\leq ((\\text{GM}^r)^{-(1/r)})^{-1} = \\text{GM}$.",
+    "significance": "key",
+    "relatedConcepts": ["power mean with negative exponent", "order reversal", "inversion inequality", "algebraic manipulation"],
+    "prerequisites": ["core inequality GM^r ≤ ∑ wᵢzᵢ^r", "Real.rpow monotonicity", "multiplicative inverse order"]
+  },
+  {
+    "id": "ann-crossing-zero",
+    "proofId": "amgm-inequality-oq-03-oq-02-oq-01",
+    "range": { "startLine": 194, "endLine": 211 },
+    "type": "insight",
+    "title": "Main Result: M_r ≤ M_s by Transitivity Through GM",
+    "content": "The main theorem power_mean_monotone_crossing_zero is the two-line proof M_r ≤ GM ≤ M_s, combined by le_trans. For r < 0, §4 gives M_r ≤ GM; for s > 0, §3 gives GM ≤ M_s. The geometric mean plays the role of a universal intermediary: every power mean of negative order lies below GM, and every power mean of positive order lies above GM. This gives M_r ≤ M_s for all r < 0 < s without ever directly comparing M_r to M_s. Combined with the same-sign cases from AmgmInequalityOQ03, the full chain M_{-∞} ≤ ... ≤ HM ≤ GM ≤ AM ≤ ... ≤ M_{+∞} is established.",
+    "mathContext": "$M_r \\leq \\text{GM} \\leq M_s$ for $r < 0 < s$. The full chain: $\\min \\leq M_{-\\infty} \\leq \\cdots \\leq M_{-1} = \\text{HM} \\leq M_0 = \\text{GM} \\leq M_1 = \\text{AM} \\leq \\cdots \\leq M_{\\infty} \\leq \\max$.",
+    "significance": "key",
+    "relatedConcepts": ["power mean chain", "HM-GM-AM inequality", "mean inequalities", "monotone sequence of means"],
+    "prerequisites": ["power_mean_le_geom_mean_neg", "geom_mean_le_power_mean_pos", "le_trans"]
+  },
+  {
+    "id": "ann-hm-gm-am",
+    "proofId": "amgm-inequality-oq-03-oq-02-oq-01",
+    "range": { "startLine": 213, "endLine": 224 },
+    "type": "context",
+    "title": "HM ≤ GM ≤ AM: The Classical Triple Inequality",
+    "content": "The theorem hm_le_gm_le_am_via_power_means instantiates crossing-zero monotonicity at r = -1 and s = 1 to recover the classical triple inequality HM ≤ GM ≤ AM. The harmonic mean M_{-1} = n/(Σ 1/zᵢ) lies below the geometric mean ∏ zᵢ^(1/n), which lies below the arithmetic mean (Σ zᵢ)/n. This ancient result (known to the Pythagoreans) now appears as a two-line consequence of the general power mean framework. The weighted version proved here subsumes all classical forms: unweighted (wᵢ = 1/n), pairwise (n = 2), and the standard AMGM inequality (HM ≤ GM ≤ AM).",
+    "mathContext": "$M_{-1} = \\text{HM} = \\left(\\frac{\\sum_i w_i}{z_i}\\right)^{-1} \\leq \\text{GM} = \\prod_i z_i^{w_i} \\leq \\sum_i w_i z_i = \\text{AM} = M_1$.",
+    "significance": "context",
+    "relatedConcepts": ["harmonic mean", "geometric mean", "arithmetic mean", "HM-GM-AM inequality", "classical inequalities"],
+    "prerequisites": ["power mean at r=-1 is HM", "power mean at r=1 is AM", "crossing-zero monotonicity"]
+  }
+]

--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01/meta.json
@@ -60,7 +60,8 @@
       "The core inequality GM^r ≤ ∑ wᵢ zᵢ^r is a single AM-GM application that handles ALL values of r simultaneously — positive, negative, and zero.",
       "The crossing-zero case reduces to inverting a monotone inequality: A ≤ B → B⁻¹ ≤ A⁻¹ (for positive A, B). This is proved algebraically without invoking inv_le_inv_of_le directly.",
       "The algebraic identity (∏ zᵢ^wᵢ)^r = ∏ (zᵢ^r)^wᵢ (proved by Finset induction via mul_rpow) is the key structural bridge connecting GM^r to the AM-GM form.",
-      "Combined with power_mean_monotone_pos and power_mean_monotone_neg from AmgmInequalityOQ03, this completes the full monotonicity theorem: M_r ≤ M_s for all r ≤ s (excluding 0)."
+      "Combined with power_mean_monotone_pos and power_mean_monotone_neg from AmgmInequalityOQ03, this completes the full monotonicity theorem: M_r ≤ M_s for all r ≤ s (excluding 0).",
+      "The inversion step (A ≤ B → B⁻¹ ≤ A⁻¹) is proved purely algebraically — starting from 1 = A·A⁻¹ ≤ B·A⁻¹ and multiplying by B⁻¹ — avoiding any specialized inv_le_inv lemma and demonstrating that elementary algebraic manipulation can substitute for inequality library lookups."
     ],
     "prerequisites": [
       "AmgmInequalityOQ03 (Proofs/AmgmInequalityOQ03.lean): weightedPowerMean, weightedGeomMean definitions and same-sign monotonicity",
@@ -121,6 +122,23 @@
       "endLine": 222,
       "summary": "hm_le_gm_le_am_via_power_means: M_{-1} ≤ GM ≤ M_1, i.e., HM ≤ GM ≤ AM. Special case r=-1, s=1.",
       "mathContext": "Direct application of §4 (r=-1) and §3 (s=1). The HM-GM-AM chain is a classical consequence."
+    }
+  ],
+  "crossReferences": [
+    {
+      "id": "amgm-inequality-oq-03",
+      "title": "Weighted Power Mean Monotonicity: Same-Sign Cases",
+      "relationship": "parent"
+    },
+    {
+      "id": "amgm-inequality-oq-03-oq-02",
+      "title": "Geometric Mean as Limit of Power Means (r → 0)",
+      "relationship": "sibling"
+    },
+    {
+      "id": "amgm-inequality",
+      "title": "AM-GM Inequality",
+      "relationship": "foundational"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/annotations.json
@@ -1,1 +1,98 @@
-[]
+[
+  {
+    "id": "ann-zcoloring-type",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
+    "range": { "startLine": 73, "endLine": 79 },
+    "type": "definition",
+    "title": "ZMod-Indexed Coloring Type: The Architectural Key",
+    "content": "ZColoring n k abbreviates ZMod n → Fin k: a coloring assigns one of k colors to each of the n bead positions, where positions are indexed by ZMod n rather than Fin n. This choice is the central architectural decision of the formalization. With Fin n indexing, the rotation action requires modular arithmetic (computing (i + 1) mod n), leading to messy proofs. With ZMod n indexing, subtraction is already defined modulo n, making the rotation action immediately a clean algebraic operation. The rotateZColoring function is correspondingly simple: the rotated coloring at position i uses the color from position i − r in the original.",
+    "mathContext": "$\\text{ZColoring}(n, k) = (\\mathbb{Z}/n\\mathbb{Z} \\to \\text{Fin}(k))$. Rotation by $r$: $(r +\\!\\!ᵥ\\, c)(i) = c(i - r)$.",
+    "significance": "key",
+    "relatedConcepts": ["ZMod arithmetic", "function type", "group action", "coloring"],
+    "prerequisites": ["ZMod type in Mathlib", "Fin type", "function types in Lean 4"]
+  },
+  {
+    "id": "ann-cyclic-action",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
+    "range": { "startLine": 83, "endLine": 93 },
+    "type": "technique",
+    "title": "Axiom-Free Group Action via sub_sub",
+    "content": "The cyclicAction instance establishes that ZMod n is an AddAction on ZColoring n k. The two action laws are: (1) zero_vadd: rotating by 0 is the identity, proved by simp since i − 0 = i in ZMod. (2) add_vadd: rotating by r then s equals rotating by r + s, proved by the single lemma sub_sub which states i − (r + s) = (i − r) − s in any additive group. No modular arithmetic lemmas are needed. The entire proof of the action laws reduces to algebraic identities already in Mathlib's ZMod library. This is a paradigmatic example of how type choice eliminates proof complexity.",
+    "mathContext": "Action law: $c(i - (r + s)) = c((i - r) - s)$, which is `sub_sub` in $\\mathbb{Z}/n\\mathbb{Z}$. Compare with Fin n approach requiring: $(i + 1) \\bmod n \\equiv (i \\bmod n + 1) \\bmod n$.",
+    "significance": "key",
+    "relatedConcepts": ["AddAction", "sub_sub lemma", "ZMod algebra", "group action axioms"],
+    "prerequisites": ["additive group theory", "ZMod arithmetic in Lean 4", "typeclass instances"]
+  },
+  {
+    "id": "ann-fixed-point-counts",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
+    "range": { "startLine": 105, "endLine": 157 },
+    "type": "concept",
+    "title": "Fixed-Point Analysis: Why Burnside Gives 6",
+    "content": "For the cyclic group ZMod 4 acting on binary 4-colorings (ZColoring 4 2), a coloring c is fixed by rotation r if and only if c has period dividing gcd(r, 4). Rotation by 0 (identity) fixes all 2^4 = 16 colorings. Rotation by 1 (90°) requires c to have period 1, meaning all beads identical — only 2 constant colorings. Rotation by 2 (180°) requires period dividing 2, so positions 0,2 and 1,3 must be equal — 2^2 = 4 choices. Rotation by 3 (270°) behaves like rotation by 1 (both generate a period-4 orbit) — 2 colorings. Total fixed points: 16 + 2 + 4 + 2 = 24. By Burnside's lemma: |Necklaces| = 24 ÷ 4 = 6. The counts for r = 1, 2, 3 are proved by native_decide, which uses Lean's kernel evaluator to verify the computation directly.",
+    "mathContext": "$|\\text{Fix}(r)| = k^{\\gcd(r, n)}$. For $n=4, k=2$: $|\\text{Fix}(0)|=16, |\\text{Fix}(1)|=2, |\\text{Fix}(2)|=4, |\\text{Fix}(3)|=2$. Sum $= 24 = 6 \\times 4$.",
+    "significance": "key",
+    "relatedConcepts": ["fixed-point set", "periodic coloring", "gcd and orbits", "native_decide tactic", "cycle structure"],
+    "prerequisites": ["Burnside's lemma", "periodic functions", "decidability in Lean 4"]
+  },
+  {
+    "id": "ann-burnside-application",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
+    "range": { "startLine": 159, "endLine": 196 },
+    "type": "technique",
+    "title": "Applying Burnside's Lemma: The Eq.trans Trick",
+    "content": "The binary_4_necklace_count theorem applies Burnside's lemma from Mathlib: MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group. The necklace set is the orbit quotient orbitRel.Quotient (Multiplicative (ZMod 4)) (ZColoring 4 2). A key technical challenge arises: Burnside's Mathlib statement uses bound variable name ∑ a, while the local hypothesis h1 uses ∑ g. A naive `rw [h1]` fails with a binder-name mismatch. The solution uses Eq.trans: `hb.symm.trans h1` chains the equations without rewriting, bypassing the binder issue entirely. This technique (using .trans instead of rw for summation equalities) is documented in comments and represents a useful pattern for Lean 4 proof engineering.",
+    "mathContext": "Burnside: $|X/G| \\cdot |G| = \\sum_{g \\in G} |\\text{Fix}(g)|$. Applied: $|\\text{Necklaces}(4,2)| \\cdot 4 = 24$, so $|\\text{Necklaces}(4,2)| = 6$.",
+    "significance": "key",
+    "relatedConcepts": ["orbit quotient", "Burnside's lemma", "Eq.trans", "orbitRel.Quotient", "MulAction"],
+    "prerequisites": ["group theory", "orbit-stabilizer theorem", "Mathlib's GroupAction.Quotient", "Lean 4 rewrite tactics"]
+  },
+  {
+    "id": "ann-polya-formula",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
+    "range": { "startLine": 199, "endLine": 241 },
+    "type": "concept",
+    "title": "The Pólya Divisor-Sum Formula",
+    "content": "The Pólya formula for cyclic group C_n acting on k-colorings is n · |Necklaces(n, k)| = Σ_{d|n} φ(d) · k^(n/d), where φ is Euler's totient function. The formula arises from Burnside's lemma by grouping rotations by their gcd with n: for each divisor d of n, exactly φ(n/d) rotations r satisfy gcd(r, n) = d, and each such rotation fixes k^d colorings. Substituting m = n/d re-indexes the sum. For 2-colorings, the formula is verified for n = 2, 3, 4, 6 by computing totient values (φ(1)=1, φ(2)=1, φ(3)=2, φ(4)=2, φ(6)=2) and checking the arithmetic with norm_num. The totient values themselves are proved by native_decide.",
+    "mathContext": "$n \\cdot |\\text{Necklaces}(n,k)| = \\sum_{d|n} \\varphi(d) \\cdot k^{n/d}$. For $n=4, k=2$: $4 \\cdot 6 = \\varphi(1)\\cdot 16 + \\varphi(2)\\cdot 4 + \\varphi(4)\\cdot 2 = 16 + 4 + 4 = 24$.",
+    "significance": "key",
+    "relatedConcepts": ["Euler totient function", "divisor sum", "Pólya enumeration theorem", "cycle index"],
+    "prerequisites": ["Euler's totient function", "divisor theory", "Burnside's lemma", "norm_num tactic"]
+  },
+  {
+    "id": "ann-necklace-count-helper",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
+    "range": { "startLine": 245, "endLine": 277 },
+    "type": "technique",
+    "title": "Burnside Helper: Uniform Necklace Count Proofs",
+    "content": "The necklace_via_burnside private lemma captures the common pattern: if Burnside's fixed-point sum equals c · n and the group has order n, then necklaceCount n k = c. This abstraction allows necklace count theorems for n = 2, 3, 5, 6 to be proved by a single call with two native_decide subproofs (one for the fixed-point sum, one for the group order). The Eq.trans technique (hb.symm.trans hfp) appears again here for the same binder-name mismatch reason. The necklaceCount 4 2 = 6 theorem reuses binary_4_necklace_count from Part III rather than going through the helper, demonstrating how to avoid duplicating proofs. The resulting sequence [2, 3, 4, 6, 8, 14] for n = 1,...,6 matches OEIS A000029.",
+    "mathContext": "$|\\text{Necklaces}(n,k)| = \\frac{1}{n}\\sum_{r \\in \\mathbb{Z}/n\\mathbb{Z}} |\\text{Fix}(r)|$. Values: $[2, 3, 4, 6, 8, 14]$ for $n=1,\\ldots,6$ with $k=2$ (OEIS A000029).",
+    "significance": "supporting",
+    "relatedConcepts": ["Burnside's lemma", "OEIS A000029", "necklace counting", "native_decide"],
+    "prerequisites": ["Burnside's lemma", "Fintype.card", "Nat.mul_right_cancel"]
+  },
+  {
+    "id": "ann-general-theorem-sorry",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
+    "range": { "startLine": 293, "endLine": 323 },
+    "type": "insight",
+    "title": "The Remaining Sorry: Cycle Structure Theorem",
+    "content": "The general Pólya enumeration theorem for cyclic groups (polya_enumeration_theorem_CN) states n · necklaceCount n k = Σ_{d|n} φ(d) · k^(n/d) for arbitrary n and k. The proof outline is documented in comments: (1) Burnside gives n · |Orbits| = Σ_{r : ZMod n} |Fix(r)|; (2) the cycle structure theorem gives |Fix(r)| = k^(gcd(r.val, n)); (3) regrouping by gcd value d gives Σ_{d|n} φ(n/d) · k^d = Σ_{d|n} φ(d) · k^(n/d). Step (2) is the missing piece: proving that a coloring is fixed by rotation r if and only if it has period gcd(r, n), requiring a bijection between fixed colorings and (ZMod(n/gcd) → Fin k) colorings. The companion sibling proof burnside-counting-oq-03 fills this gap via an explicit bijection.",
+    "mathContext": "Key missing lemma: $|\\text{Fix}(r)| = k^{\\gcd(r.\\text{val},\\, n)}$ for rotation $r \\in \\mathbb{Z}/n\\mathbb{Z}$ acting on $\\mathbb{Z}/n\\mathbb{Z} \\to \\text{Fin}(k)$. This requires a bijection $\\text{Fix}(r) \\cong (\\mathbb{Z}/\\gcd(r,n)\\mathbb{Z} \\to \\text{Fin}(k))$.",
+    "significance": "key",
+    "relatedConcepts": ["cycle structure theorem", "gcd and periods", "Pólya enumeration theorem", "sorry in Lean"],
+    "prerequisites": ["Burnside's lemma", "orbit counting", "gcd of integers", "bijections in Lean 4"]
+  },
+  {
+    "id": "ann-generating-function-connection",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
+    "range": { "startLine": 326, "endLine": 357 },
+    "type": "context",
+    "title": "Necklace Sequence and Generating Function Connection",
+    "content": "The necklaceSeq definition [2, 3, 4, 6, 8, 14] records the binary necklace counts for n = 1,...,6. The theorem necklaceSeq_matches verifies this matches the values from necklaceCount. This section connects the formalization back to its parent question in ArithmeticSeriesOQ02OQ02OQ03: can the generating function approach extend to Pólya enumeration? The generating function for binary necklaces is P(x) = Σ_{n≥1} |Necklaces(n,2)| · x^n. The Pólya cycle index for C_n has a product formula over cyclotomic polynomials, connecting the Pólya enumeration theorem to the generating function theory of the parent entry. This connection remains formalized only partially: the sequence is verified, but the generating function identity is left as an open question.",
+    "mathContext": "$P(x) = 2x + 3x^2 + 4x^3 + 6x^4 + 8x^5 + 14x^6 + \\cdots$. Closed form: $\\sum_{n\\geq 1} \\frac{1}{n}\\sum_{d|n} \\varphi(d) \\cdot 2^{n/d} \\cdot x^n$ (OEIS A000029).",
+    "significance": "context",
+    "relatedConcepts": ["generating functions", "OEIS A000029", "cycle index", "cyclotomic polynomials", "power series"],
+    "prerequisites": ["formal power series", "generating function theory", "Pólya cycle index"]
+  }
+]

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
@@ -57,60 +57,63 @@
     {
       "id": "cyclic-action",
       "title": "Clean Group Action via ZMod Subtraction",
+      "startLine": 62,
+      "endLine": 103,
       "summary": "Defines ZColoring n k = ZMod n → Fin k and the rotation action r +ᵥ c = fun i => c (i - r). The action laws follow immediately from ZMod algebra (sub_sub), requiring no axioms.",
-      "startLine": 69,
-      "endLine": 117,
       "theorems": ["cyclicAction"]
     },
     {
       "id": "fixed-point-counts",
       "title": "Fixed-Point Counts for ZMod 4 on Binary Colorings",
+      "startLine": 105,
+      "endLine": 157,
       "summary": "Computes |Fix(r)| for each r ∈ ZMod 4 acting on ZMod 4 → Fin 2: Fix(0)=16 (all), Fix(1)=2 (constant), Fix(2)=4 (period-2), Fix(3)=2 (constant). Sum = 24.",
-      "startLine": 118,
-      "endLine": 167,
       "theorems": ["zcoloring_4_2_card", "fix_0_card", "fix_1_card", "fix_2_card", "fix_3_card", "fixed_point_sum_4_2"]
     },
     {
       "id": "burnside-application",
       "title": "Burnside's Lemma: 6 Binary Necklaces of Length 4",
+      "startLine": 159,
+      "endLine": 197,
       "summary": "Applies Burnside's lemma from Mathlib to conclude |Necklaces(4,2)| = 24/4 = 6. The orbit quotient orbitRel.Quotient (Multiplicative (ZMod 4)) (ZColoring 4 2) has cardinality 6.",
-      "startLine": 168,
-      "endLine": 207,
       "theorems": ["binary_4_necklace_count"]
     },
     {
       "id": "polya-formula",
       "title": "Pólya Formula Verification for 2-Colorings",
+      "startLine": 199,
+      "endLine": 279,
       "summary": "Verifies n·|Necklaces(n,2)| = Σ_{d|n} φ(d)·2^{n/d} for n=2,3,4,6 using computed totient values. Also computes necklaceCount n 2 for n=1,...,6 via Burnside's helper.",
-      "startLine": 208,
-      "endLine": 292,
       "theorems": ["polya_C2_2colors", "polya_C3_2colors", "polya_C4_2colors", "polya_C6_2colors", "necklaces_2_2", "necklaces_3_2", "necklaces_4_2", "necklaces_5_2", "necklaces_6_2"]
     },
     {
       "id": "general-statement",
       "title": "General Pólya Theorem (1 sorry)",
-      "summary": "States the general Pólya enumeration theorem: n · necklaceCount n k = Σ_{d|n} φ(d) · k^{n/d}. Proof requires the cycle structure theorem (|Fix(r)| = k^{gcd(r.val,n)}) connecting Burnside to the divisor sum. Left as 1 sorry.",
-      "startLine": 293,
+      "startLine": 281,
       "endLine": 365,
+      "summary": "States the general Pólya enumeration theorem: n · necklaceCount n k = Σ_{d|n} φ(d) · k^{n/d}. Proof requires the cycle structure theorem (|Fix(r)| = k^{gcd(r.val,n)}) connecting Burnside to the divisor sum. Left as 1 sorry.",
       "theorems": ["polya_enumeration_theorem_CN"]
     }
   ],
   "overview": {
-    "historicalContext": "George Pólya (1937) and John Howard Redfield (1927) independently developed the enumeration theorem bearing Pólya's name. It generalizes Burnside's lemma to count combinatorial structures up to group symmetry. This entry extends the generating function work of ArithmeticSeriesOQ02OQ02OQ03 to the group action setting.",
-    "problemStatement": "Can Burnside's lemma and Pólya's enumeration theorem for cyclic groups be formalized in Lean 4 using Mathlib's group action infrastructure? Specifically, can the rotation action on necklaces be set up axiom-free using ZMod arithmetic?",
-    "proofStrategy": "Use ZMod n → Fin k as the coloring type so that rotation by r is simply c(i-r). Apply Mathlib's orbitRel.Quotient to count orbits via Burnside. Verify the Pólya divisor-sum formula for small n by direct computation with native_decide.",
+    "historicalContext": "Pólya's enumeration theorem (1937) is a fundamental result in combinatorics that counts the number of distinct colorings of a set under group symmetries. It generalizes Burnside's lemma (1897) from counting orbits to a weighted counting with the cycle index. For necklaces under cyclic group actions, the formula gives n · |Necklaces(n,k)| = Σ_{d|n} φ(d) · k^{n/d} where φ is Euler's totient. This entry arose from the ArithmeticSeriesOQ02OQ02OQ03 entry on Vandermonde's identity, which asked whether generating functions could be extended to Pólya's theorem.",
+    "problemStatement": "Formalize Burnside's lemma and the Pólya enumeration theorem for cyclic groups acting on bead necklaces. Specifically: (1) prove there are exactly 6 distinct binary 4-necklaces via Burnside; (2) verify the Pólya formula n·|Necklaces(n,2)| = Σ_{d|n} φ(d)·2^{n/d} for n=2,3,4,6; (3) compute explicit necklace counts for n=1,...,6.",
+    "proofStrategy": "Key architectural insight: use ZMod n → Fin k (ZMod-indexed colorings) instead of Fin n → Fin k. The rotation action r +ᵥ c = fun i => c(i-r) is then trivially a group action (the law follows from sub_sub in ZMod), requiring no modular arithmetic. Burnside's lemma from Mathlib (MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group) then applies directly. Fixed-point counts are computed by decide for each rotation.",
     "keyInsights": [
-      "ZMod-indexed colorings make the rotation action trivial: group axioms follow from ZMod algebra with no extra lemmas",
-      "Burnside's lemma in Mathlib counts orbits abstractly; packaging the cyclic group action correctly gives concrete necklace counts",
-      "The general Pólya theorem requires the cycle structure theorem: |Fix(r)| = k^{gcd(r.val,n)}, which is the missing piece for the 1 remaining sorry"
+      "ZMod subtraction makes the rotation action axiom-free: the proof of smul_smul reduces to ring equations in ZMod",
+      "Burnside's lemma gives |orbits| = (Σ |Fix(r)|) / |G| = 24/4 = 6 for binary 4-necklaces",
+      "The Pólya formula n·|Necklaces(n,2)| = Σ_{d|n} φ(d)·2^{n/d} is verified for n=2,3,4,6 by decide",
+      "The general Pólya theorem requires the cycle structure theorem: |Fix(r)| = k^{gcd(r.val,n)} — left as 1 sorry"
     ]
   },
   "conclusion": {
-    "summary": "365-line formalization proving 23 theorems (1 sorry) from 0 axioms. Burnside's lemma is used to count necklaces; the Pólya divisor-sum formula is verified for small n.",
-    "implications": "ZMod-indexed colorings sidestep modular arithmetic complications entirely. The cycle structure theorem is the key remaining piece for the complete Pólya theorem.",
+    "summary": "365-line formalization proving 23 theorems (1 sorry) from 0 axioms. Burnside's lemma is used to count necklaces; the Pólya divisor-sum formula is verified for small n. The general Pólya theorem remains as 1 sorry pending the cycle structure theorem.",
+    "implications": "The ZMod-indexed coloring approach (ZMod n → Fin k) is a reusable design pattern for cyclic group actions in Lean 4 — it eliminates all modular arithmetic bookkeeping. The formalization demonstrates that Burnside's abstract orbit theorem (from Mathlib's GroupTheory.GroupAction.Quotient) directly yields concrete combinatorial results. The Pólya formula verification for small n establishes the technique before attempting the general sorry.",
     "openQuestions": [
-      "Prove the cycle structure theorem: for rotation by r in ZMod n, the number of fixed-point colorings is k^{gcd(r.val, n)}.",
-      "Extend to arbitrary finite groups: Pólya's theorem for non-cyclic groups requires the full cycle index formalism."
+      "Prove the cycle structure theorem: for rotation by r in ZMod n acting on ZMod n → Fin k, the number of fixed-point colorings is k^{gcd(r.val, n)}. This would close the 1 sorry and complete the general Pólya theorem.",
+      "Extend to arbitrary finite groups: Pólya's theorem for non-cyclic groups (e.g., dihedral groups D_n for unoriented necklaces) requires the full cycle index formalism.",
+      "Multivariate Pólya: The full theorem counts colorings with prescribed color frequencies, not just total colorings. Formalize the generating function form Z(G; x_1, ..., x_k).",
+      "Connect to the generating function approach: the cycle index of C_n has a product formula related to cyclotomic polynomials. Formalize this connection."
     ]
   },
   "crossReferences": [

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
@@ -96,24 +96,29 @@
     }
   ],
   "overview": {
-    "historicalContext": "Pólya's enumeration theorem (1937) is a fundamental result in combinatorics that counts the number of distinct colorings of a set under group symmetries. It generalizes Burnside's lemma (1897) from counting orbits to a weighted counting with the cycle index. For necklaces under cyclic group actions, the formula gives n · |Necklaces(n,k)| = Σ_{d|n} φ(d) · k^{n/d} where φ is Euler's totient. This entry arose from the ArithmeticSeriesOQ02OQ02OQ03 entry on Vandermonde's identity, which asked whether generating functions could be extended to Pólya's theorem.",
-    "problemStatement": "Formalize Burnside's lemma and the Pólya enumeration theorem for cyclic groups acting on bead necklaces. Specifically: (1) prove there are exactly 6 distinct binary 4-necklaces via Burnside; (2) verify the Pólya formula n·|Necklaces(n,2)| = Σ_{d|n} φ(d)·2^{n/d} for n=2,3,4,6; (3) compute explicit necklace counts for n=1,...,6.",
-    "proofStrategy": "Key architectural insight: use ZMod n → Fin k (ZMod-indexed colorings) instead of Fin n → Fin k. The rotation action r +ᵥ c = fun i => c(i-r) is then trivially a group action (the law follows from sub_sub in ZMod), requiring no modular arithmetic. Burnside's lemma from Mathlib (MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group) then applies directly. Fixed-point counts are computed by decide for each rotation.",
+    "background": "The parallel Vandermonde entry (ArithmeticSeriesOQ02OQ02OQ03) asked whether generating functions could be extended to Pólya's enumeration theorem. This entry answers the question by formalizing the cyclic group case of Pólya's theorem.",
+    "mainResult": "Burnside's lemma from Mathlib gives 6 distinct binary 4-necklaces. The Pólya formula n·|Necklaces(n,2)| = Σ_{d|n} φ(d)·2^{n/d} is verified for n=2,3,4,6. Necklace counts [2,3,4,6,8,14] for n=1,...,6 are proved.",
+    "significance": "The key architectural insight is using ZMod n → Fin k (ZMod-indexed colorings) instead of Fin n → Fin k. This makes the rotation action r +ᵥ c = fun i => c(i-r) trivially an action (the law follows from sub_sub in ZMod), requiring no modular arithmetic lemmas. The proof connects Burnside's abstract orbit-counting theorem to concrete necklace combinatorics.",
+    "openQuestion": "The remaining sorry is the general Pólya theorem: n · necklaceCount n k = Σ_{d|n} φ(d) · k^{n/d}. This requires proving |Fix(r)| = k^{gcd(r.val,n)} for all r, which is the cycle structure theorem for cyclic group actions.",
+    "historicalContext": "Pólya's enumeration theorem was introduced in the landmark 1937 paper 'Kombinatorische Anzahlbestimmungen für Gruppen, Graphen und chemische Verbindungen' (Acta Mathematica 68, 145–254), where George Pólya developed the cycle index formalism to count non-equivalent colorings under group symmetry. The underlying orbit-counting principle, now called Burnside's lemma, was actually discovered independently by Cauchy (1845) and Frobenius (1887); Burnside's 1897 book 'Theory of Groups of Finite Order' popularized it without crediting the earlier work. A historical irony: Burnside himself did not claim the result, attributing it to Frobenius, yet the lemma bears his name. Pólya's contribution was the systematic cycle index Z(G; x_1, ..., x_k), which packages the fixed-point information into a generating function. The theorem found immediate applications in chemistry — counting structural isomers of organic molecules — and later in graph enumeration (counting non-isomorphic graphs on n vertices), switching function enumeration in circuit design, and combinatorics broadly. The special case of cyclic groups counting necklaces is the most classical application, with the sequence |Necklaces(n,2)| = [2,3,4,6,8,14,...] (OEIS A000029) appearing in recreational mathematics.",
+    "problemStatement": "For the cyclic group $C_n = \\mathbb{Z}/n\\mathbb{Z}$ acting on $k$-colorings of an $n$-bead necklace by rotation, how many distinct necklaces (equivalence classes under rotation) exist? The Pólya formula gives: $n \\cdot |\\text{Necklaces}(n,k)| = \\sum_{d|n} \\varphi(d) \\cdot k^{n/d}$, where $\\varphi$ is Euler's totient function.",
+    "proofStrategy": "The proof proceeds in five stages, building from algebraic setup through concrete computation to abstract verification. (1) Algebraic setup: colorings are indexed by ZMod n (not Fin n), making the rotation action r ↦ (c ↦ λi, c(i−r)) an immediate AddAction — the axiom (r+s +ᵥ c) = r +ᵥ (s +ᵥ c) reduces to the single lemma sub_sub in ZMod, requiring no modular arithmetic. (2) Fixed-point counts: for ZMod 4 acting on binary colorings, |Fix(r)| for each r ∈ {0,1,2,3} is computed by native_decide, yielding 16+2+4+2=24 total fixed points. (3) Burnside application: the Mathlib lemma MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group converts the sum 24 to orbit count 6, with the Eq.trans technique avoiding binder-name rewrite failures. (4) Pólya formula verification: totient values φ(1)=1, φ(2)=1, φ(3)=2, φ(4)=2, φ(6)=2 are computed by native_decide; the formula n·|Necklaces(n,2)| = Σ φ(d)·2^{n/d} is verified for n=2,3,4,6 by norm_num. (5) Necklace sequence: a Burnside helper lemma captures the common pattern, yielding necklace counts [2,3,4,6,8,14] for n=1,...,6 by native_decide.",
     "keyInsights": [
-      "ZMod subtraction makes the rotation action axiom-free: the proof of smul_smul reduces to ring equations in ZMod",
-      "Burnside's lemma gives |orbits| = (Σ |Fix(r)|) / |G| = 24/4 = 6 for binary 4-necklaces",
-      "The Pólya formula n·|Necklaces(n,2)| = Σ_{d|n} φ(d)·2^{n/d} is verified for n=2,3,4,6 by decide",
-      "The general Pólya theorem requires the cycle structure theorem: |Fix(r)| = k^{gcd(r.val,n)} — left as 1 sorry"
+      "The architectural choice of ZMod n → Fin k (instead of Fin n → Fin k) makes the rotation action axiom-free: c(i−(r+s)) = c((i−r)−s) follows directly from sub_sub in ZMod algebra, requiring no modular arithmetic lemmas — a paradigmatic example of how type choice eliminates proof complexity.",
+      "Burnside's lemma bridges abstract orbit counting to concrete fixed-point computation: the 6 distinct binary 4-necklaces arise from total fixed points 16+2+4+2=24 across the 4 rotations, where each count reflects the periodic structure |Fix(r)| = 2^gcd(r,4).",
+      "The Pólya divisor-sum formula n·|Necklaces(n,k)| = Σ_{d|n} φ(d)·k^(n/d) arises by regrouping the Burnside sum: exactly φ(n/d) rotations r satisfy gcd(r,n)=d, and each fixes k^d colorings — the totient function naturally counts rotations by their gcd class.",
+      "The Eq.trans technique (hb.symm.trans hfp) elegantly avoids a common Lean 4 pitfall where rw fails due to binder name mismatches in summation expressions, a pattern useful throughout Mathlib-heavy proofs.",
+      "The remaining sorry (cycle structure theorem: |Fix(r)| = k^gcd(r.val,n)) is the combinatorial heart of the theorem — it requires constructing an explicit bijection between fixed colorings and (ZMod(n/gcd) → Fin k), which the sibling proof burnside-counting-oq-03 fills in."
     ]
   },
   "conclusion": {
     "summary": "365-line formalization proving 23 theorems (1 sorry) from 0 axioms. Burnside's lemma is used to count necklaces; the Pólya divisor-sum formula is verified for small n. The general Pólya theorem remains as 1 sorry pending the cycle structure theorem.",
-    "implications": "The ZMod-indexed coloring approach (ZMod n → Fin k) is a reusable design pattern for cyclic group actions in Lean 4 — it eliminates all modular arithmetic bookkeeping. The formalization demonstrates that Burnside's abstract orbit theorem (from Mathlib's GroupTheory.GroupAction.Quotient) directly yields concrete combinatorial results. The Pólya formula verification for small n establishes the technique before attempting the general sorry.",
+    "implications": "This formalization establishes reusable infrastructure for Pólya enumeration in Lean 4. The clean ZMod-action architecture (AddAction via sub_sub) is immediately applicable to any cyclic group acting on function spaces. The verified necklace sequence [2,3,4,6,8,14] matches OEIS A000029, connecting the machine-checked proofs to established combinatorial literature. The divisibility theorems (n | Σ_{d|n} φ(d)·k^(n/d)) are consequences of the formalized Burnside lemma, yielding machine-verified proofs of number-theoretic identities as a byproduct. Closing the remaining sorry (the cycle structure theorem) would yield the first complete Lean 4 formalization of the Pólya enumeration theorem for cyclic groups, enabling downstream applications such as counting non-isomorphic graphs (as axiomatized in erdos-426) and chemical isomer enumeration.",
     "openQuestions": [
-      "Prove the cycle structure theorem: for rotation by r in ZMod n acting on ZMod n → Fin k, the number of fixed-point colorings is k^{gcd(r.val, n)}. This would close the 1 sorry and complete the general Pólya theorem.",
-      "Extend to arbitrary finite groups: Pólya's theorem for non-cyclic groups (e.g., dihedral groups D_n for unoriented necklaces) requires the full cycle index formalism.",
-      "Multivariate Pólya: The full theorem counts colorings with prescribed color frequencies, not just total colorings. Formalize the generating function form Z(G; x_1, ..., x_k).",
-      "Connect to the generating function approach: the cycle index of C_n has a product formula related to cyclotomic polynomials. Formalize this connection."
+      "Prove the cycle structure theorem: for rotation by r in ZMod n acting on ZMod n → Fin k, the number of fixed-point colorings is k^{gcd(r.val, n)}. This would close the 1 sorry and complete the general Pólya theorem. The sibling proof burnside-counting-oq-03 provides an explicit bijection approach.",
+      "Extend to dihedral groups D_n for unoriented necklaces: the dihedral group has order 2n and includes reflections. Its cycle index has additional terms φ contributions from reflections, giving |Bracelets(n,k)| — the OEIS A000116 sequence.",
+      "Formalize the multivariate Pólya theorem: the full theorem counts colorings with prescribed color frequency vectors using the cycle index Z(G; x_1, ..., x_k) as a polynomial. This generating function form subsumes the counting formula proved here.",
+      "Connect to cyclotomic polynomials: the cycle index of C_n satisfies a product formula Z(C_n; k) = (1/n) Σ_{d|n} φ(d) · k^(n/d), which relates to evaluations of cyclotomic polynomials at k. Formalizing this connection would bridge the Pólya enumeration and generating function approaches from the parent entry."
     ]
   },
   "crossReferences": [
@@ -126,6 +131,26 @@
       "id": "arithmetic-series-oq-02-oq-02",
       "title": "2D Hockey Stick Identity",
       "relationship": "grandparent"
+    },
+    {
+      "id": "burnside-counting-oq-03",
+      "title": "Pólya Enumeration Theorem for Cyclic Groups",
+      "relationship": "parallel"
+    },
+    {
+      "id": "burnside-counting",
+      "title": "Burnside's Lemma and Necklace Counting",
+      "relationship": "extends"
+    },
+    {
+      "id": "lagrange-theorem-oq-05",
+      "title": "Burnside Counting Lemma from Orbit-Stabilizer",
+      "relationship": "foundational"
+    },
+    {
+      "id": "euler-totient-oq-02",
+      "title": "Multiplicativity of Euler's Totient Function",
+      "relationship": "uses"
     }
   ]
 }

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02/annotations.json
@@ -1,0 +1,92 @@
+[
+  {
+    "id": "ann-bezout-oq02-oq01-oq02-oq02-header",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 31
+    },
+    "type": "context",
+    "title": "Module Header: Gaussian Integers as Euclidean Domain",
+    "content": "Lines 1-3: imports `GaussianInt`, `EuclideanDomain`, `Tactic`. Lines 5-26: module docstring explaining the open question (Is there a gallery proof of UFD + Gaussian prime classification in ℤ[i]?) and the affirmative answer. Lines 28-30: `namespace GaussianIntEuclidean` and `open GaussianInt Zsqrtd`.\n\nThe docstring outlines the three-way Gaussian prime classification: (1) norm-2 primes (1+i, ramified above 2); (2) split primes (norm = p ≡ 1 mod 4); (3) inert primes (p ≡ 3 mod 4). Line 30 opens `GaussianInt` and `Zsqrtd` so that `norm`, `norm_mul`, etc. are accessible without qualification.",
+    "mathContext": "$\\mathbb{Z}[i] = \\{a + bi : a,b \\in \\mathbb{Z}\\}$ is the ring of Gaussian integers, formalized as `GaussianInt = Zsqrtd (-1)` in Mathlib. The norm $N(a+bi) = a^2+b^2$ is a Euclidean function making $\\mathbb{Z}[i]$ a Euclidean domain — and hence a UFD by the standard algebra chain.",
+    "significance": "context",
+    "relatedConcepts": ["GaussianInt", "Zsqrtd", "EuclideanDomain", "Gaussian primes"],
+    "prerequisites": ["Mathlib.NumberTheory.Zsqrtd.GaussianInt", "EuclideanDomain"]
+  },
+  {
+    "id": "ann-bezout-oq02-oq01-oq02-oq02-instances",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 32,
+      "endLine": 41
+    },
+    "type": "technique",
+    "title": "Part 1: ℤ[i] as Euclidean Domain and UFD via inferInstance",
+    "content": "Lines 34-36: three `example` declarations using `inferInstance` to confirm `EuclideanDomain GaussianInt`, `UniqueFactorizationMonoid GaussianInt`, and `IsPrincipalIdealRing GaussianInt`. These are not named theorems — they just confirm the instances exist in Mathlib's typeclass hierarchy.\n\nLines 38-40: `example (z : GaussianInt) : Irreducible z ↔ Prime z := UniqueFactorizationMonoid.irreducible_iff_prime`. In a UFD, irreducible ↔ prime, so the distinction collapses. This lets all subsequent proofs use `Prime` freely.",
+    "mathContext": "The Euclidean function for $\\mathbb{Z}[i]$ is $N(z) = z.\\text{re}^2 + z.\\text{im}^2$. The chain: Euclidean domain → GCD monoid → UFD → IsPrincipalIdealRing. All instances are automatic via Mathlib's `GaussianInt.instEuclideanDomain`. The identity `Irreducible ↔ Prime` in a UFD (from `UniqueFactorizationMonoid.irreducible_iff_prime`) is the key algebraic fact used in all subsequent primality proofs.",
+    "significance": "key",
+    "relatedConcepts": ["inferInstance", "UniqueFactorizationMonoid", "irreducible_iff_prime", "EuclideanDomain"],
+    "prerequisites": ["GaussianInt.instEuclideanDomain", "UFD instance chain"]
+  },
+  {
+    "id": "ann-bezout-oq02-oq01-oq02-oq02-norm",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 42,
+      "endLine": 59
+    },
+    "type": "definition",
+    "title": "Part 2: Norm Function — Four Core Lemmas",
+    "content": "**gaussian_norm_formula** (lines 45-47): `z.norm = z.re * z.re + z.im * z.im`, proved by `unfold Zsqrtd.norm; ring`. The Mathlib norm is defined differently internally; `ring` closes the gap.\n\n**norm_mul_eq** (lines 49-50): `(z * w).norm = z.norm * w.norm`, directly from `Zsqrtd.norm_mul`. The Brahmagupta-Fibonacci identity $(a^2+b^2)(c^2+d^2) = (ac-bd)^2 + (ad+bc)^2$.\n\n**is_unit_iff_norm_one** (lines 52-54): `IsUnit z ↔ z.norm.natAbs = 1`, from `Zsqrtd.norm_eq_one_iff.symm`. Units are $\\{\\pm 1, \\pm i\\}$, all of norm 1.\n\n**norm_conj_eq** (lines 56-58): `(star z).norm = z.norm`, proved by `simp` + `ring`. Conjugation $\\overline{a+bi} = a-bi$ preserves $a^2+b^2$.",
+    "mathContext": "In `Zsqrtd`, `norm (⟨a,b⟩ : Zsqrtd d) = a^2 - d*b^2`. For $d = -1$: `norm (a+bi) = a^2 - (-1)*b^2 = a^2 + b^2`. The `.natAbs` coercion is needed throughout because `Zsqrtd.norm` returns `ℤ`, but primality predicates on `ℕ` (`.Prime` is `Nat.Prime`).",
+    "significance": "key",
+    "relatedConcepts": ["Zsqrtd.norm", "Zsqrtd.norm_mul", "Zsqrtd.norm_eq_one_iff", "Brahmagupta-Fibonacci identity"],
+    "prerequisites": ["GaussianInt", "Zsqrtd.norm", "Int.natAbs"]
+  },
+  {
+    "id": "ann-bezout-oq02-oq01-oq02-oq02-prime-norm",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 62,
+      "endLine": 79
+    },
+    "type": "technique",
+    "title": "prime_of_prime_natAbs_norm: Prime Norm Implies Prime Element",
+    "content": "**Statement** (lines 64-65): If `z.norm.natAbs` is a rational prime, then `z` is prime in $\\mathbb{Z}[i]$. This covers two cases of the classification: norm-2 primes (1+i, norm = 2) and split primes (norm = p for p ≡ 1 mod 4).\n\n**Proof structure** (lines 66-78):\n1. Reduce `Prime z` to `Irreducible z` via `irreducible_iff_prime`\n2. `Irreducible z` requires: (a) z is not a unit, (b) in any factorization z = a*b, one factor is a unit\n3. For (a): norm.natAbs is prime → ≠ 1 → z is not a unit\n4. For (b): norm(a)*norm(b) = norm(z) = prime. So `h.eq_one_or_self_of_dvd` forces one norm to be 1 (unit)\n5. The cancellation step at line 77 uses `Nat.eq_of_mul_eq_mul_left` with positivity of norm",
+    "mathContext": "The key algebraic argument: if $N(z) = p$ is prime and $z = ab$, then $N(a) \\cdot N(b) = p$. Since $p$ is prime, either $N(a) = 1$ (so $a$ is a unit) or $N(a) = p$ (so $N(b) = 1$ by $N(a) \\cdot N(b) = p$, making $b$ a unit). `Nat.Prime.eq_one_or_self_of_dvd` formalizes this divisibility argument.",
+    "significance": "key",
+    "relatedConcepts": ["Irreducible", "Prime", "Nat.Prime.eq_one_or_self_of_dvd", "norm-based primality"],
+    "prerequisites": ["is_unit_iff_norm_one", "norm_mul_eq", "Nat.eq_of_mul_eq_mul_left"]
+  },
+  {
+    "id": "ann-bezout-oq02-oq01-oq02-oq02-inert",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 80,
+      "endLine": 154
+    },
+    "type": "technique",
+    "title": "inert_prime: Rational Primes p ≡ 3 (mod 4) Stay Prime in ℤ[i]",
+    "content": "**Statement** (lines 84-85): For rational prime `p` with `p % 4 = 3`, the element `↑p : GaussianInt` is prime.\n\n**Key steps**:\n1. **Norm of ↑p** (line 87-88): `(↑p).norm = p²` since the imaginary part is 0.\n2. **Not a unit** (lines 90-93): norm = p² ≥ 4 > 1, contradiction with norm_eq_one_iff\n3. **Irreducibility** (lines 94-153): If `↑p = a*b`, then `N(a)*N(b) = p²`. Divisors of p² are {1, p, p²} (via `Nat.dvd_prime_pow`). The key steps:\n   - Case N(a) = 1: a is a unit, done\n   - Case N(b) = 1: b is a unit, done\n   - Case N(a) = p²: forces N(b) = 1, contradicts assumption b is non-unit\n   - Case N(a) = p: **impossible** — p ≡ 3 (mod 4) cannot be a sum of two squares\n4. **Sum-of-squares obstruction** (lines 144-153): Cast to ZMod 4. Squares mod 4 ∈ {0,1}, so x²+y² ∈ {0,1,2}, never 3. Proved by `decide : ∀ x y : ZMod 4, x^2 + y^2 ≠ 3`.",
+    "mathContext": "The decisive fact: $a^2 + b^2 \\not\\equiv 3 \\pmod{4}$ for any integers $a, b$. This is because $a^2 \\equiv 0$ or $1 \\pmod 4$, so $a^2 + b^2 \\equiv 0, 1,$ or $2 \\pmod 4$, never 3. The `interval_cases k` tactic at line 128 splits the cases $k \\in \\{0,1,2\\}$ in `a.norm.natAbs = p^k`.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.dvd_prime_pow", "ZMod 4", "sum-of-squares obstruction", "decide", "interval_cases"],
+    "prerequisites": ["gaussian_norm_formula", "Nat.dvd_prime_pow", "ZMod.natCast_eq_natCast_iff"]
+  },
+  {
+    "id": "ann-bezout-oq02-oq01-oq02-oq02-examples",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-02-oq-02",
+    "range": {
+      "startLine": 155,
+      "endLine": 193
+    },
+    "type": "context",
+    "title": "Part 4: Concrete Examples — All Three Ramification Types",
+    "content": "**Norm-prime examples** (lines 158-167): `one_add_I_prime` (1+i, norm 2), `two_add_I_prime` (2+i, norm 5), `two_add_3I_prime` (2+3i, norm 13) — all via `prime_of_prime_natAbs_norm (by native_decide)`. The `native_decide` checks primality of the norm value in the kernel.\n\n**Inert examples** (lines 170-175): `three_is_inert_prime` and `seven_is_inert_prime` — via `inert_prime (by decide) (by decide)`, checking primality and residue mod 4 by computation.\n\n**Factorization examples** (lines 178-187): `two_ramifies` (2 = -i·(1+i)²), `five_splits` (5 = (2+i)·(2-i)), `thirteen_splits` (13 = (2+3i)·(2-3i)) — all proved by `decide`.\n\n**Check commands** (lines 189-191): Three `#check` commands on key Mathlib lemmas used throughout (for documentation/reference).",
+    "mathContext": "The three ramification types of a rational prime $p$ in $\\mathbb{Z}[i]$: (1) **ramification**: $p = 2$, $2 = -i(1+i)^2$, so $(1+i)$ is the unique Gaussian prime above 2; (2) **splitting**: $p \\equiv 1 \\pmod 4$, $p = \\pi \\bar{\\pi}$ for conjugate Gaussian primes $\\pi, \\bar{\\pi}$; (3) **inertness**: $p \\equiv 3 \\pmod 4$, $p$ itself is prime in $\\mathbb{Z}[i]$.",
+    "significance": "supporting",
+    "relatedConcepts": ["native_decide", "decide", "ramification", "splitting", "inertness", "Fermat two-square theorem"],
+    "prerequisites": ["prime_of_prime_natAbs_norm", "inert_prime"]
+  }
+]

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02/meta.json
@@ -102,6 +102,7 @@
   ],
   "conclusion": {
     "summary": "ℤ[i] is formalized as a Euclidean domain and UFD via Mathlib's instance chain. The backward direction of Gaussian prime classification is proved: elements with rational prime norms are prime (covers norm-2 and split cases), and rational primes p ≡ 3 (mod 4) are inert. The sum-of-squares obstruction mod 4 is mechanically verified by `decide` in ZMod 4. Concrete examples demonstrate all three ramification types.",
+    "implications": "This formalization demonstrates the power of Mathlib's instance chain for algebraic structures: EuclideanDomain → GCDMonoid → UniqueFactorizationMonoid is automatic, requiring only `inferInstance`. The `decide`-based verification of the sum-of-squares obstruction (`∀ x y : ZMod 4, x^2 + y^2 ≠ 3`) is a clean application of finite decidable quantifiers. The pattern — norm-based primality via `prime_of_prime_natAbs_norm` — is reusable for other quadratic integer rings ℤ[√d].",
     "openQuestions": [
       "The forward direction of Gaussian prime classification: if z is prime in ℤ[i], then norm(z) is a rational prime power (either p or p²). Completing both directions gives the full equivalence. Does Mathlib have this forward direction, or does it need a short proof?",
       "Fermat's two-square theorem follows directly: p is a sum of two squares iff p = 2 or p ≡ 1 (mod 4). The Gaussian integer proof is: p = N(a+bi) for some Gaussian prime a+bi above p. Can this be formalized as a short corollary of the prime classification?"

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-bu-dim-formula",
+    "proofId": "borsuk-ulam-oq-02-oq-01-oq-01",
+    "range": { "startLine": 28, "endLine": 35 },
+    "type": "definition",
+    "title": "buDimFormula: Supremum Over Prime Factors",
+    "content": "buDimFormula(n, d) is defined as the Finset supremum of buDim(p, d) over all prime divisors p of n: Nat.primeFactors(n).sup (fun p => buDim p d). The use of Finset.sup with the lattice structure on ℕ handles the max naturally. For n=1, primeFactors(1)=∅ and sup of empty finset is 0. For prime p, primeFactors(p)={p} and the sup is buDim(p,d). For n=4=2², primeFactors(4)={2} and the formula gives buDim(2,d). For n=6=2·3, primeFactors(6)={2,3} and the formula gives max(buDim(2,d), buDim(3,d)). The definition packages the prime factorization structure into a single natural number via the BU dimension function.",
+    "mathContext": "$\\text{buDimFormula}(n,d) = \\sup_{p \\in \\text{primeFactors}(n)} \\text{buDim}(p,d) = \\max\\{\\text{buDim}(p,d) \\mid p \\text{ prime}, p \\mid n\\}$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.primeFactors", "Finset.sup", "BU dimension", "prime factorization"],
+    "prerequisites": ["Borsuk-Ulam dimension (buDim) from parent file", "Nat.primeFactors in Mathlib", "Finset.sup with Nat lattice"]
+  },
+  {
+    "id": "ann-lower-bound",
+    "proofId": "borsuk-ulam-oq-02-oq-01-oq-01",
+    "range": { "startLine": 37, "endLine": 46 },
+    "type": "technique",
+    "title": "Lower Bound: Finset.sup_le + Restriction Monotonicity",
+    "content": "The theorem buDimFormula_le proves buDimFormula(n,d) ≤ buDim(n,d) in four lines. Finset.sup_le reduces the sup inequality to pointwise inequalities: for each prime p|n, show buDim(p,d) ≤ buDim(n,d). This follows from buDim_mono in the parent file BorsukUlamOQ02OQ01.lean: if p divides n, then Z/p is a subgroup of Z/n, and any Z/n-equivariant map restricts to a Z/p-equivariant map. The equivariant dimension can only increase when passing to a larger group (Z/n), so buDim(p,d) ≤ buDim(n,d). This is the easy direction of the conjecture — the hard direction requires constructing equivariant maps, not just restricting them.",
+    "mathContext": "$p \\mid n \\Rightarrow \\mathbb{Z}/p \\hookrightarrow \\mathbb{Z}/n \\Rightarrow \\text{buDim}(p,d) \\leq \\text{buDim}(n,d)$. By $\\text{Finset.sup\\_le}$: $\\sup_p \\text{buDim}(p,d) \\leq \\text{buDim}(n,d)$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sup_le", "restriction of equivariant maps", "subgroup monotonicity", "buDim_mono"],
+    "prerequisites": ["buDim_mono from BorsukUlamOQ02OQ01.lean", "Nat.mem_primeFactors", "Finset.sup_le"]
+  },
+  {
+    "id": "ann-open-conjecture",
+    "proofId": "borsuk-ulam-oq-02-oq-01-oq-01",
+    "range": { "startLine": 48, "endLine": 68 },
+    "type": "insight",
+    "title": "The Open Conjecture: Composite Groups Add No Extra Constraint",
+    "content": "The axiom buDim_le_formula states that for n ≥ 2, buDim(n,d) ≤ buDimFormula(n,d): the BU dimension of Z/n never exceeds the maximum over its prime subgroups. This is the hard direction — it requires constructing actual equivariant maps, not merely restricting them. The evidence for the conjecture includes: (1) Smith theory implies buDim(p^k,d) = buDim(p,d) for prime powers; (2) Yang-Borsuk lifting works for standard complex representations. But for arbitrary d-dimensional representations of composite groups, the precise constraint from each prime factor and how they combine is unknown. The theorem buDim_eq_formula then gives the equivalence by le_antisymm.",
+    "mathContext": "OPEN CONJECTURE: $\\text{buDim}(n,d) \\leq \\max_{p|n, p \\text{ prime}} \\text{buDim}(p,d)$. Would imply: for $n=p^k$, $\\text{buDim}(p^k,d) = \\text{buDim}(p,d)$ (confirmed by Smith theory).",
+    "significance": "key",
+    "relatedConcepts": ["axiom in Lean 4", "Fadell-Husseini index", "Smith theory", "equivariant maps", "open conjecture"],
+    "prerequisites": ["buDim definition", "equivariant topology", "Smith theory for prime powers"]
+  },
+  {
+    "id": "ann-concrete-cases",
+    "proofId": "borsuk-ulam-oq-02-oq-01-oq-01",
+    "range": { "startLine": 90, "endLine": 118 },
+    "type": "concept",
+    "title": "Concrete Cases: n=4,6,9 via native_decide",
+    "content": "Three concrete consequences of the formula theorem are derived. buDim(4,d) = buDim(2,d): primeFactors(4)={2} computed by native_decide, so the sup is a singleton. buDim(6,d) = max(buDim(2,d), buDim(3,d)): primeFactors(6)={2,3}, and Finset.sup_insert + sup_singleton reduce the two-element sup to a binary max. buDim(9,d) = buDim(3,d): primeFactors(9)={3}, singleton again. The pattern: prime powers n=p^k inherit only from their single prime p; semisimple composites n=pq inherit from each distinct prime factor. Each proof follows a uniform template: apply buDim_eq_formula, compute primeFactors by native_decide, simplify the Finset.sup.",
+    "mathContext": "$\\text{buDim}(4,d) = \\text{buDim}(2,d)$; $\\text{buDim}(6,d) = \\text{buDim}(2,d) \\sqcup \\text{buDim}(3,d)$; $\\text{buDim}(9,d) = \\text{buDim}(3,d)$. Prime factors: $4=2^2 \\to \\{2\\}$, $6=2\\cdot 3 \\to \\{2,3\\}$, $9=3^2 \\to \\{3\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["prime factorization", "Nat.primeFactors", "native_decide", "Smith theory for prime powers"],
+    "prerequisites": ["buDim_eq_formula", "native_decide for Nat.primeFactors", "Finset.sup simplification"]
+  },
+  {
+    "id": "ann-six-even",
+    "proofId": "borsuk-ulam-oq-02-oq-01-oq-01",
+    "range": { "startLine": 127, "endLine": 136 },
+    "type": "insight",
+    "title": "buDim(6, 2n) = 2n-1: Z/2 and Z/3 Bounds Coincide",
+    "content": "The theorem buDim_six_even shows buDim(6, 2n) = 2n-1 for n ≥ 1. By buDim_six_eq_max, this reduces to max(buDim(2, 2n), buDim(3, 2n)) = 2n-1. Both prime factor bounds agree: buDim(2, 2n) = 2n-1 by the Yang-Borsuk theorem for Z/2 (from the parent file's buDim_two), and buDim(3, 2n) = 2n-1 by Yang-Borsuk for Z/3 (buDim_prime 3 n). When both bounds agree, the maximum is their common value. This is an instance where composite structure truly reduces to prime structure, confirming the conjecture for this specific family. The result says: for even-dimensional targets, Z/6-equivariant maps are no harder to construct than Z/2- or Z/3-equivariant maps.",
+    "mathContext": "$\\text{buDim}(2, 2n) = 2n-1$ (Yang-Borsuk for $\\mathbb{Z}/2$) and $\\text{buDim}(3, 2n) = 2n-1$ (Yang-Borsuk for $\\mathbb{Z}/3$), so $\\text{buDim}(6, 2n) = \\max(2n-1, 2n-1) = 2n-1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Yang-Borsuk theorem", "Z/6-equivariant maps", "even-dimensional targets", "buDim_two", "buDim_prime"],
+    "prerequisites": ["Yang-Borsuk theorem for prime cyclic groups", "buDim_six_eq_max", "buDim values for p=2 and p=3"]
+  }
+]

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01/index.ts
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01/index.ts
@@ -1,0 +1,39 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BorsukUlamOQ02OQ01OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const borsukUlamOq02Oq01Oq01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections,
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const borsukUlamOq02Oq01Oq01Annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const borsukUlamOq02Oq01Oq01Data: ProofData = {
+  proof: borsukUlamOq02Oq01Oq01Proof,
+  annotations: borsukUlamOq02Oq01Oq01Annotations,
+  tacticStates: [],
+}
+
+export default borsukUlamOq02Oq01Oq01Data

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01/meta.json
@@ -88,14 +88,14 @@
   },
   "crossReferences": [
     {
-      "targetId": "borsuk-ulam-oq-02-oq-01",
-      "relationship": "extends",
-      "description": "Extends the parent file's abstract BU dimension framework with the conjectured formula and its consequences"
+      "id": "borsuk-ulam-oq-02-oq-01",
+      "title": "Borsuk-Ulam for General Cyclic Groups",
+      "relationship": "parent"
     },
     {
-      "targetId": "borsuk-ulam-oq-02-oq-01-oq-04",
-      "relationship": "related",
-      "description": "The Fadell-Husseini index theory provides the main theoretical tool for proving the open conjecture axiomatized here"
+      "id": "borsuk-ulam-oq-02",
+      "title": "Borsuk-Ulam Theorem",
+      "relationship": "foundational"
     }
   ],
   "references": [

--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -1146,8 +1146,18 @@
     },
     "erdos-563": {
       "passes": 1,
-      "lastEnriched": "2026-04-05T12:25:00Z",
+      "lastEnriched": "2026-04-05T12:33:31Z",
+      "quality": 93
+    },
+    "erdos-547": {
+      "passes": 1,
+      "lastEnriched": "2026-04-05T12:28:09Z",
       "quality": 96
+    },
+    "arithmetic-series-oq-02-oq-02-oq-03-oq-01": {
+      "passes": 1,
+      "lastEnriched": "2026-04-05T12:33:31Z",
+      "quality": 88
     }
   },
   "elementary-quadratic-reciprocity-oq-03-oq-03": {

--- a/src/data/proofs/enrichment-tracker.json
+++ b/src/data/proofs/enrichment-tracker.json
@@ -1158,6 +1158,11 @@
       "passes": 1,
       "lastEnriched": "2026-04-05T12:33:31Z",
       "quality": 88
+    },
+    "bezout-identity-oq-02-oq-01-oq-02-oq-02": {
+      "passes": 1,
+      "lastEnriched": "2026-04-05T12:36:33Z",
+      "quality": 94
     }
   },
   "elementary-quadratic-reciprocity-oq-03-oq-03": {

--- a/src/data/proofs/erdos-563/annotations.json
+++ b/src/data/proofs/erdos-563/annotations.json
@@ -1,25 +1,33 @@
 [
   {
+    "id": "erdos-563-preamble",
+    "proofId": "erdos-563",
+    "type": "context",
+    "range": {
+      "startLine": 1,
+      "endLine": 20
+    },
+    "title": "Problem Overview: Balanced 2-Colorings with Logarithmic Threshold",
+    "content": "**Erdős Problem #563**: Let $F(n, \\alpha)$ be the smallest $m$ such that there exists a 2-coloring of $K_n$ where every subset $X$ with $|X| \\geq m$ has $> \\alpha \\cdot \\binom{|X|}{2}$ edges of each color.\n\n**Key results** (lines 9-12):\n- **Conjecture**: $F(n, \\alpha) \\sim c_\\alpha \\cdot \\log n$ for $0 \\leq \\alpha < 1/2$\n- **Known**: $F(n, \\alpha) = \\Theta_\\alpha(\\log n)$ by the probabilistic method\n- **$\\alpha = 0$**: reduces to classical Ramsey theory (no monochromatic clique of size $m$)\n- **$\\alpha = 1/2$**: impossible (some color must have $\\leq$ half the edges by pigeonhole)\n\nReference: Erdős [Er90b, p. 21]; see also Problem #161 (hypergraph generalization).",
+    "mathContext": "$F(n, \\alpha)$ measures how 'balanced' a coloring must be when restricted to large subsets. For $\\alpha = 0$: $F(n, 0)$ relates to Ramsey numbers. For $0 < \\alpha < 1/2$: $F(n, \\alpha) = \\Theta(\\log n)$ by probabilistic method. The conjecture asks for the precise constant $c_\\alpha$.",
+    "significance": "context",
+    "relatedConcepts": ["balanced colorings", "Ramsey theory", "probabilistic method", "Erdős #161"],
+    "prerequisites": ["complete graph K_n", "edge density", "Ramsey theory basics"]
+  },
+  {
     "id": "erdos-563-imports",
     "proofId": "erdos-563",
     "type": "context",
     "range": {
       "startLine": 21,
-      "endLine": 25
+      "endLine": 27
     },
-    "title": "Mathlib Imports",
-    "content": "Imports SimpleGraph.Basic for graph structure, Finset.Basic for finite set operations (product, filter, card), and general tactics. The Finset product and filter operations are used throughout for counting edges in subsets.",
-    "mathContext": "Requires $\\text{Finset.card}$, $\\text{Finset.product}$, $\\text{Finset.filter}$ for edge counting in subsets of $\\text{Fin}\\,n$.",
+    "title": "Imports, Open Finset, and Definitions Header",
+    "content": "Lines 21-23: imports `SimpleGraph.Basic`, `Finset.Basic`, and `Tactic`. Line 25: `open Finset` brings `filter`, `card`, `×ˢ` notation into scope. Line 27: `/-## Core Definitions -/` section header.",
+    "mathContext": "`open Finset` allows writing `filter` and `card` instead of `Finset.filter` and `Finset.card`. The `×ˢ` notation for `Finset.product` is used in edge-counting expressions like `(X ×ˢ X).filter (fun p => p.1 < p.2)`.",
     "significance": "supporting",
-    "relatedConcepts": [
-      "finite sets",
-      "product sets",
-      "cardinality"
-    ],
-    "prerequisites": [
-      "Lean 4 basics",
-      "Mathlib Finset"
-    ]
+    "relatedConcepts": ["Finset.filter", "Finset.card", "open Finset"],
+    "prerequisites": ["Lean 4 basics", "Mathlib Finset"]
   },
   {
     "id": "erdos-563-coloring-edges",
@@ -29,20 +37,12 @@
       "startLine": 29,
       "endLine": 43
     },
-    "title": "Edge Colorings and Edge Counts",
-    "content": "EdgeColoring n is a function $\\text{Fin}\\,n \\to \\text{Fin}\\,n \\to \\text{Bool}$ representing a red/blue coloring of $K_n$. edgeCount counts edges in a subset $X$ as ordered pairs $(i,j)$ with $i < j$, giving $\\binom{|X|}{2}$. redEdgeCount and blueEdgeCount count edges of each color in $X$ using the same ordering convention. The $i < j$ convention ensures each edge is counted exactly once.",
-    "mathContext": "$\\text{edgeCount}(X) = |\\{(i,j) \\in X \\times X : i < j\\}| = \\binom{|X|}{2}$; $\\text{redEdgeCount}(X) = |\\{(i,j) : i < j \\wedge c(i,j) = \\text{true}\\}|$",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "edge counting",
-      "graph coloring",
-      "binomial coefficient"
-    ],
-    "prerequisites": [
-      "Finset.product",
-      "Finset.filter",
-      "Fin"
-    ]
+    "title": "EdgeColoring, edgeCount, redEdgeCount, blueEdgeCount",
+    "content": "`EdgeColoring n = Fin n → Fin n → Bool`: a red/blue coloring of $K_n$ edges. The pair $(i,j)$ with $i < j$ encodes each edge exactly once.\n\n`edgeCount n X = ((X ×ˢ X).filter (p.1 < p.2)).card`: counts $\\binom{|X|}{2}$ edges in subset $X$.\n\n`redEdgeCount n c X` and `blueEdgeCount n c X`: count edges of each color using the same $i < j$ ordering convention.",
+    "mathContext": "$\\text{edgeCount}(X) = |\\{(i,j) \\in X^2 : i < j\\}| = \\binom{|X|}{2}$. `redEdgeCount(X) + blueEdgeCount(X) = edgeCount(X)` (partition of edges by color). The $i < j$ constraint uses the natural order on `Fin n`.",
+    "significance": "key",
+    "relatedConcepts": ["edge density", "Finset.filter", "graph coloring"],
+    "prerequisites": ["Fin n", "Finset.product ×ˢ", "Bool"]
   },
   {
     "id": "erdos-563-balanced",
@@ -52,106 +52,26 @@
       "startLine": 45,
       "endLine": 57
     },
-    "title": "Balanced Coloring and Threshold $F(n, \\alpha)$",
-    "content": "IsBalanced n c m $\\alpha$ holds when every subset $X \\subseteq \\text{Fin}\\,n$ with $|X| \\geq m$ has $> \\alpha \\cdot \\binom{|X|}{2}$ edges of each color. This captures the 'no large monochromatic bias' condition. balancedThreshold n $\\alpha$ = $F(n, \\alpha)$ is the smallest such $m$, defined via Nat.find when a balanced coloring exists (0 otherwise). The use of strict inequality ($>$ rather than $\\geq$) and rational $\\alpha$ gives a clean formalization.",
-    "mathContext": "$\\text{IsBalanced}(c, m, \\alpha) \\iff \\forall X,\\; |X| \\geq m \\implies \\text{red}(X) > \\alpha \\cdot \\binom{|X|}{2} \\wedge \\text{blue}(X) > \\alpha \\cdot \\binom{|X|}{2}$; $F(n, \\alpha) = \\min\\{m : \\exists c,\\; \\text{IsBalanced}(c, m, \\alpha)\\}$",
+    "title": "IsBalanced and balancedThreshold F(n, α)",
+    "content": "`IsBalanced n c m α`: every subset $X$ of size $\\geq m$ has strictly more than $\\alpha$ fraction of its edges in each color. Uses `ℚ` for $\\alpha$ to avoid real number complications.\n\n`balancedThreshold n α = F(n, \\alpha)`: the smallest $m$ admitting an $(m, \\alpha)$-balanced coloring, via `Nat.find`. Returns 0 if none exists (e.g., $\\alpha \\geq 1/2$).\n\nStrict inequality `>` is natural and avoids edge cases at equality.",
+    "mathContext": "$\\text{IsBalanced}(c, m, \\alpha) \\iff \\forall X : |X| \\geq m \\Rightarrow \\text{red}(X)/\\binom{|X|}{2} > \\alpha \\wedge \\text{blue}(X)/\\binom{|X|}{2} > \\alpha$. `balancedThreshold` uses `Nat.find h` where `h : ∃ m, ∃ c, IsBalanced n c m α`. The `if h : ∃ ...` pattern makes this `noncomputable`.",
     "significance": "key",
-    "relatedConcepts": [
-      "discrepancy theory",
-      "balanced colorings",
-      "threshold functions"
-    ],
-    "prerequisites": [
-      "edgeCount",
-      "redEdgeCount",
-      "blueEdgeCount"
-    ]
+    "relatedConcepts": ["discrepancy theory", "balanced colorings", "Nat.find", "noncomputable def"],
+    "prerequisites": ["edgeCount", "redEdgeCount", "blueEdgeCount", "ℚ"]
   },
   {
-    "id": "erdos-563-conjecture",
+    "id": "erdos-563-stubs",
     "proofId": "erdos-563",
-    "type": "definition",
+    "type": "context",
     "range": {
       "startLine": 59,
-      "endLine": 67
+      "endLine": 65
     },
-    "title": "Erdos Problem 563: $F(n, \\alpha) \\sim c_\\alpha \\log n$",
-    "content": "The main conjecture: for every $0 \\leq \\alpha < 1/2$, there exists a constant $c_\\alpha > 0$ such that $F(n, \\alpha) / \\log n \\to c_\\alpha$ as $n \\to \\infty$. The axiom is simplified to $\\exists c > 0$ with a placeholder True body, since the full asymptotic statement requires filter-based limits. The conjecture asks not just for the order of growth (known to be $\\Theta(\\log n)$) but for the exact constant.",
-    "mathContext": "$\\forall \\alpha \\in [0, 1/2),\\; \\exists c_\\alpha > 0,\\; F(n, \\alpha) \\sim c_\\alpha \\cdot \\log n$ as $n \\to \\infty$",
-    "significance": "key",
-    "relatedConcepts": [
-      "asymptotic constants",
-      "precise asymptotics",
-      "logarithmic growth"
-    ],
-    "prerequisites": [
-      "balancedThreshold",
-      "Real.log"
-    ]
-  },
-  {
-    "id": "erdos-563-bounds",
-    "proofId": "erdos-563",
-    "type": "insight",
-    "range": {
-      "startLine": 69,
-      "endLine": 83
-    },
-    "title": "Known Bounds: $F(n, \\alpha) = \\Theta(\\log n)$",
-    "content": "Two axioms establish the order of growth. The upper bound $F(n, \\alpha) \\leq C \\cdot \\log n$ comes from the probabilistic method: a random 2-coloring of $K_n$ is $(m, \\alpha)$-balanced for $m = O(\\log n)$ with high probability, by Chernoff-type concentration on the edge distribution in random subsets. The lower bound $F(n, \\alpha) \\geq c \\cdot \\log n$ (for $\\alpha > 0$) follows from a counting argument: too few vertices cannot guarantee balance across all subsets. Together they give $F(n, \\alpha) = \\Theta_\\alpha(\\log n)$.",
-    "mathContext": "$\\exists C > 0,\\; F(n, \\alpha) \\leq C \\cdot \\log n$; $\\exists c > 0,\\; F(n, \\alpha) \\geq c \\cdot \\log n$ for $\\alpha > 0$",
-    "significance": "key",
-    "relatedConcepts": [
-      "probabilistic method",
-      "Chernoff bounds",
-      "concentration inequalities"
-    ],
-    "prerequisites": [
-      "balancedThreshold",
-      "Real.log"
-    ]
-  },
-  {
-    "id": "erdos-563-special-cases",
-    "proofId": "erdos-563",
-    "type": "technique",
-    "range": {
-      "startLine": 85,
-      "endLine": 103
-    },
-    "title": "Special Cases: $\\alpha = 0$ (Ramsey) and $\\alpha = 1/2$ (Impossible)",
-    "content": "Three axioms cover boundary behavior. (1) $\\alpha = 0$: the balanced condition becomes 'every $m$-subset has $> 0$ edges of each color', i.e., no monochromatic $m$-clique. This connects to diagonal Ramsey numbers $R(m, m)$, with $F(n, 0) \\sim (1/2) \\log_2 n$ by Erdos's probabilistic lower bound. (2) $\\alpha = 1/2$: impossible \u2014 by pigeonhole, some color class has $\\leq \\binom{m}{2}/2$ edges, so the strict inequality $> (1/2) \\cdot \\binom{m}{2}$ fails. (3) The color partition identity: $\\text{red}(X) + \\text{blue}(X) = \\text{total}(X)$, the fundamental constraint linking the two color classes.",
-    "mathContext": "$F(n, 0) \\sim \\frac{1}{2} \\log_2 n$ (Ramsey); $\\alpha = 1/2$ is impossible by pigeonhole; $\\text{red}(X) + \\text{blue}(X) = \\binom{|X|}{2}$",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "diagonal Ramsey numbers",
-      "pigeonhole principle",
-      "partition identity"
-    ],
-    "prerequisites": [
-      "balancedThreshold",
-      "IsBalanced"
-    ]
-  },
-  {
-    "id": "erdos-563-monotonicity",
-    "proofId": "erdos-563",
-    "type": "technique",
-    "range": {
-      "startLine": 105,
-      "endLine": 114
-    },
-    "title": "Monotonicity Properties",
-    "content": "Two monotonicity axioms: (1) $F(n, \\alpha) \\leq F(n, \\beta)$ for $\\alpha \\leq \\beta < 1/2$ \u2014 stricter balance requirements need larger subsets; (2) $F(m, \\alpha) \\leq F(n, \\alpha)$ for $m \\leq n$ \u2014 more vertices means harder to avoid imbalanced subsets, so the threshold grows. These structural properties constrain the shape of $F$ as a function of both arguments.",
-    "mathContext": "$\\alpha \\leq \\beta \\implies F(n, \\alpha) \\leq F(n, \\beta)$; $m \\leq n \\implies F(m, \\alpha) \\leq F(n, \\alpha)$",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "monotone functions",
-      "threshold growth",
-      "parameter dependence"
-    ],
-    "prerequisites": [
-      "balancedThreshold"
-    ]
+    "title": "Section Stubs: Conjecture, Bounds, Special Cases, Monotonicity",
+    "content": "Lines 59-65 contain four section header stubs with no Lean declarations:\n\n- **Line 59**: `/- ## Main Conjecture -/` — stub for $F(n, \\alpha) \\sim c_\\alpha \\log n$\n- **Line 61**: `/- ## Known Bounds -/` — stub for $F(n, \\alpha) = \\Theta(\\log n)$ (probabilistic method)\n- **Line 63**: `/- ## Special Cases -/` — stub for $\\alpha=0$ (Ramsey) and $\\alpha=1/2$ (impossible)\n- **Line 65**: `/- ## Monotonicity -/` — stub for $\\alpha_1 < \\alpha_2 \\Rightarrow F(n,\\alpha_1) \\leq F(n,\\alpha_2)$\n\nThe mathematical content is described in the module docstring (lines 1-19). The core definitions are fully formalized; the open problem and supporting results are planned but not yet implemented.",
+    "mathContext": "**Known**: $F(n, \\alpha) = \\Theta(\\log n)$ by probabilistic method. **Special cases**: $F(n, 0)$ relates to Ramsey bounds; $F(n, 1/2)$ is impossible since $\\text{red}(X) + \\text{blue}(X) = \\text{edge}(X)$. **Monotonicity**: $\\alpha_1 < \\alpha_2 \\Rightarrow F(n, \\alpha_1) \\leq F(n, \\alpha_2)$ (stricter balance is harder).",
+    "significance": "context",
+    "relatedConcepts": ["probabilistic method", "Ramsey theory", "discrepancy theory", "monotonicity"],
+    "prerequisites": ["balancedThreshold", "IsBalanced"]
   }
 ]

--- a/src/data/proofs/triangle-inequality-oq-04/annotations.json
+++ b/src/data/proofs/triangle-inequality-oq-04/annotations.json
@@ -1,1 +1,62 @@
-[]
+[
+  {
+    "id": "ann-path-length-def",
+    "proofId": "triangle-inequality-oq-04",
+    "range": { "startLine": 68, "endLine": 80 },
+    "type": "definition",
+    "title": "Arc Length via Total Variation (eVariationOn)",
+    "content": "The pathLength of a continuous path γ : Path x y is defined as eVariationOn γ.extend (Icc 0 1) — the total variation of the extended path on [0,1]. The use of eVariationOn (with values in ℝ≥0∞) avoids needing the path to be rectifiable a priori: non-rectifiable paths simply get length +∞, and still satisfy the required inequalities. The pathLength_refl theorem shows a constant path has length 0: eVariationOn of a constant function is 0 by eVariationOn.eq_zero_iff, which reduces to edist(c,c) = 0 for any interval partition.",
+    "mathContext": "$\\text{pathLength}(\\gamma) = \\text{eVariationOn}(\\gamma.\\text{extend}, [0,1]) \\in [0, +\\infty]$. For smooth $\\gamma$: $\\text{pathLength}(\\gamma) = \\int_0^1 \\|\\gamma'(t)\\| \\, dt$.",
+    "significance": "key",
+    "relatedConcepts": ["eVariationOn", "total variation", "rectifiable path", "arc length", "ℝ≥0∞"],
+    "prerequisites": ["Mathlib.Analysis.BoundedVariation", "Path type", "eVariationOn definition"]
+  },
+  {
+    "id": "ann-concat-halves",
+    "proofId": "triangle-inequality-oq-04",
+    "range": { "startLine": 96, "endLine": 157 },
+    "type": "technique",
+    "title": "Path.trans Structure: Each Half is a Reparameterization",
+    "content": "The concatenated path Path.trans γ₁ γ₂ runs γ₁ on [0, 1/2] (at double speed: t ↦ γ₁(2t)) and γ₂ on [1/2, 1] (shifted: t ↦ γ₂(2t-1)). The helper lemmas eqOn_first and eqOn_second establish these equalities precisely on each half-interval. The tricky point at t = 1/2 (where both halves meet) requires checking that γ₁(1) = y = γ₂(0) — the shared endpoint — using Path.target and Path.extend_zero. These EqOn lemmas feed into eVariationOn.eq_of_eqOn to replace the concatenated path's variation with the reparameterized version.",
+    "mathContext": "$(\\gamma_1 * \\gamma_2)(t) = \\begin{cases} \\gamma_1(2t) & t \\in [0, 1/2] \\\\ \\gamma_2(2t-1) & t \\in [1/2, 1] \\end{cases}$. The two halves are monotone reparameterizations of $\\gamma_1$ and $\\gamma_2$ respectively.",
+    "significance": "supporting",
+    "relatedConcepts": ["Path.trans", "reparameterization", "EqOn", "eVariationOn.eq_of_eqOn"],
+    "prerequisites": ["Path.trans_apply", "Path.extend_apply", "unitInterval"]
+  },
+  {
+    "id": "ann-length-additivity",
+    "proofId": "triangle-inequality-oq-04",
+    "range": { "startLine": 159, "endLine": 196 },
+    "type": "insight",
+    "title": "Length Additivity: Three-Step Reparameterization Argument",
+    "content": "The theorem pathLength_trans proves length(γ₁ ∗ γ₂) = length(γ₁) + length(γ₂) in three steps. Step 1: Icc_add_Icc splits the total variation of [0,1] at 1/2 into the sum of variations on [0,1/2] and [1/2,1]. Step 2: The [0,1/2] variation of the concatenated path equals the [0,1] variation of γ₁ — by eqOn_first (the paths agree), then comp_eq_of_monotoneOn (reparameterization t ↦ 2t is monotone), then image_scale_half (the image of [0,1/2] under ×2 is [0,1]). Step 3: Symmetric argument for the [1/2,1] part and γ₂. The result follows by combining: split = first + second = length(γ₁) + length(γ₂).",
+    "mathContext": "$\\text{length}(\\gamma_1 * \\gamma_2) = \\text{eVar}[0,1/2] + \\text{eVar}[1/2,1] = \\text{length}(\\gamma_1) + \\text{length}(\\gamma_2)$. Key: $\\text{eVar}(f \\circ \\phi, I) = \\text{eVar}(f, \\phi(I))$ for monotone $\\phi$.",
+    "significance": "key",
+    "relatedConcepts": ["eVariationOn.Icc_add_Icc", "eVariationOn.comp_eq_of_monotoneOn", "reparameterization invariance"],
+    "prerequisites": ["eVariationOn splitting lemmas", "monotone reparameterization", "image of interval under linear map"]
+  },
+  {
+    "id": "ann-triangle-proof",
+    "proofId": "triangle-inequality-oq-04",
+    "range": { "startLine": 215, "endLine": 239 },
+    "type": "insight",
+    "title": "Triangle Inequality: Concatenation + Infimum Exchange",
+    "content": "The main theorem intrinsicDist_triangle is a seven-line proof using a calc chain. The first step bounds d_path(x,z) ≤ length(γ₁) + length(γ₂) for any fixed γ₁ : x→y and γ₂ : y→z, via iInf_le and pathLength_trans. The second step exchanges the double infimum with a sum of infima using ENNReal.iInf_add and ENNReal.add_iInf — these lemmas capture the independence of minimization over γ₁ and γ₂, valid in ℝ≥0∞ because infimums distribute over addition for non-negative extended reals. The geometric content: paths from x to y and y to z can be chosen independently to minimize their own lengths, and their concatenation gives an upper bound for d_path(x,z).",
+    "mathContext": "$d_{\\text{path}}(x,z) \\leq \\inf_{\\gamma_1} \\inf_{\\gamma_2} (\\text{len}(\\gamma_1) + \\text{len}(\\gamma_2)) = \\inf_{\\gamma_1} \\text{len}(\\gamma_1) + \\inf_{\\gamma_2} \\text{len}(\\gamma_2) = d_{\\text{path}}(x,y) + d_{\\text{path}}(y,z)$.",
+    "significance": "key",
+    "relatedConcepts": ["ENNReal.iInf_add", "ENNReal.add_iInf", "iInf_le", "path concatenation"],
+    "prerequisites": ["pathLength_trans", "iInf properties in ℝ≥0∞", "le_iInf"]
+  },
+  {
+    "id": "ann-sphere-riemannian",
+    "proofId": "triangle-inequality-oq-04",
+    "range": { "startLine": 241, "endLine": 284 },
+    "type": "context",
+    "title": "Sphere Instance and the Road to Full Riemannian Geometry",
+    "content": "The sphere example shows the proof applies immediately: the unit sphere in any inner product space is a PseudoMetricSpace, and intrinsicDist_triangle applies directly. The geodesic distance on S^(n-1) measures great-circle arc lengths, the longest case being π (the antipodal distance). The comment section describes exactly what would be needed to connect to full Riemannian geometry: (1) a Riemannian metric tensor g on a tangent bundle; (2) Riemannian arc length as ∫₀¹ ‖γ'(t)‖_g dt; (3) equivalence of this with eVariationOn for smooth paths. Once these are in Mathlib, our intrinsicDist_triangle becomes the triangle inequality for the geodesic distance on any complete Riemannian manifold — the setting of the original 1854 Riemann lecture.",
+    "mathContext": "Great-circle distance on $S^{n-1}$: $d(p,q) = \\arccos(\\langle p, q \\rangle)$, which is the geodesic arc length. The full Riemannian case requires $\\text{length}(\\gamma) = \\int_0^1 \\sqrt{g_{\\gamma(t)}(\\gamma'(t), \\gamma'(t))} \\, dt$.",
+    "significance": "context",
+    "relatedConcepts": ["Riemannian manifold", "geodesic distance", "great-circle distance", "tangent bundle"],
+    "prerequisites": ["Metric.sphere in Mathlib", "InnerProductSpace", "Riemannian metric tensor"]
+  }
+]

--- a/src/data/proofs/triangle-inequality-oq-04/meta.json
+++ b/src/data/proofs/triangle-inequality-oq-04/meta.json
@@ -117,19 +117,19 @@
   ],
   "crossReferences": [
     {
-      "targetId": "triangle-inequality",
-      "relationship": "extends",
-      "description": "Extends the abstract triangle inequality to the geodesic/path metric setting, where distances are defined via path length infima"
+      "id": "triangle-inequality",
+      "title": "Triangle Inequality",
+      "relationship": "extends"
     },
     {
-      "targetId": "triangle-inequality-oq-03",
-      "relationship": "related",
-      "description": "The ultrametric (non-Archimedean) triangle inequality d(x,z) ≤ max(d(x,y), d(y,z)) is a strict strengthening. By contrast, geodesic distances in Riemannian geometry are Archimedean and satisfy only the standard triangle inequality."
+      "id": "triangle-inequality-oq-03",
+      "title": "Ultrametric Triangle Inequality",
+      "relationship": "related"
     },
     {
-      "targetId": "pythagorean-theorem",
-      "relationship": "related",
-      "description": "The Pythagorean theorem gives the Euclidean distance formula, which is the geodesic distance in flat Riemannian space ℝⁿ. Our theorem applies to curved spaces where no such closed-form formula exists."
+      "id": "pythagorean-theorem",
+      "title": "Pythagorean Theorem",
+      "relationship": "related"
     }
   ],
   "references": [


### PR DESCRIPTION
## Summary

- **erdos-563**: Rewrote 7 stale annotations (startLine > 65 on a 65-line file) to 5 accurate annotations covering preamble, imports, EdgeColoring/edgeCount definitions, IsBalanced/balancedThreshold definitions, and section stubs
- **erdos-330**: Fixed assumptions field (1 axiom, not 7), added missing leanFile fields, corrected known-results section range; fixed annotation ranges for imports and overlap issues
- **erdos-508**: Fixed stubs annotation endLine (46→45 to match 45-line file)
- **erdos-547**: Rewrote 12 annotations to 7 accurate ones matching the 132-line file; fixed assumptions field (3 axioms: ramseyNumber, IsTree, tree_ramsey_bound)
- **bertrands-postulate-oq-03-oq-04**: Added 9 comprehensive annotations covering all 323 lines; copied missing Lean source file from researcher-6 worktree
- **arithmetic-series-oq-02-oq-02-oq-03-oq-01**: Fixed pre-existing TS build error — added missing `startLine`/`endLine` to all 5 sections; fixed `overview` and `conclusion` to match interface requirements

## Test plan
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)