### PR TITLE
Seeker: select binary-gcd-oq-01-oq-04-oq-01 — exact worst-case analysis of Binary GCD

### DIFF
--- a/research/problems/binary-gcd-oq-01-oq-04-oq-01/state.md
+++ b/research/problems/binary-gcd-oq-01-oq-04-oq-01/state.md
@@ -1,0 +1,45 @@
+# Research State: binary-gcd-oq-01-oq-04-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-05T12:42:00-07:00
+**Iteration**: 1
+
+## Current Focus
+
+Characterize the complete worst-case inputs for the Binary GCD algorithm — those where
+the odd-subtraction case triggers maximally — and prove an exact step-count formula
+or sharp lower bound matching the O(log(a+b)) upper bound.
+
+The parent `binary-gcd-oq-01-oq-04` demonstrated that (1, 2^n - 1) achieves exactly n
+steps. This question asks: what is the *full* worst-case structure? Can we characterize
+all families achieving the tight bound?
+
+## Active Approach
+
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+
+None identified yet.
+
+## Next Action
+
+1. Read `proofs/Proofs/BinaryGcdOQ01OQ04.lean` to understand the tight lower bound proof
+2. Read `proofs/Proofs/BinaryGcd*.lean` to survey existing step-count machinery
+3. Formulate what "exact worst-case" means: exact step-count formula, or just tighter bound?
+
+## Key Context
+
+- Parent proof (binary-gcd-oq-01-oq-04): shows binaryGcdSteps 1 (2^n - 1) = n by induction
+- Gallery proof binary-gcd-oq-01 establishes O(log b) upper bound
+- Known: (1, 2^n - 1) achieves n steps; question is whether this is the unique family
+  or whether there are other infinite families achieving tight bounds
+- Connection to Stern-Brocot tree / Calkin-Wilf tree: worst-case paths may correspond
+  to specific trajectories in the binary GCD DAG


### PR DESCRIPTION
## Selection Report

**Date**: 2026-04-05
**Mode**: SELECT
**Pool Status**: 8 available, 340 in-progress, 1222 completed

## Selected Problem

- **ID**: binary-gcd-oq-01-oq-04-oq-01
- **Name**: Exact worst-case analysis of Binary GCD algorithm
- **Tier**: C
- **Significance**: 5/10
- **Tractability**: 6/10
- **Knowledge Score**: 0 (EMPTY)
- **Status**: available

## Selection Rationale

1. Highest composite score (65) among all available problems excluding `minkowski-theorem-oq-02-oq-01` which was selected in the immediately preceding seeker run
2. All 8 available problems have EMPTY knowledge tier (score=0); differentiation falls to tractability×10 + significance
3. Tractability 6 reflects that parent proof infrastructure is in place — the step-counting machinery exists in `BinaryGcdOQ01OQ04.lean`

## Rejection Summary

- **Candidates considered**: 8
- **Candidates rejected**: 7
  - minkowski-theorem-oq-02-oq-01: skip (selected in last seeker run, avoid duplication)
  - erdos-{490,179,1033}-incomplete-01, hilbert-3-oq-04: composite 57 < 65
  - hilbert-10-oq-03, hilbert-3-oq-02: composite 48 < 65
- **Confidence**: medium (several Erdős incomplete problems close behind at 57)

## Related Gallery Proofs

- `binary-gcd-oq-01-oq-04`: tight lower bound — (1, 2^n-1) takes exactly n steps
- `binary-gcd-oq-01`: O(log b) upper bound and step-count comparisons
- `binary-gcd`: Stein's algorithm correctness formalization

## Suggested First Steps

1. Read `proofs/Proofs/BinaryGcdOQ01OQ04.lean` to understand the existing step-count induction
2. Scout for literature on Binary GCD worst-case characterization (Calkin-Wilf / Stern-Brocot connections)
3. Decide if the question is (a) prove the exact step-count formula, (b) characterize all tight families, or (c) prove a matching lower bound for a general class

## Pool Summary After Selection

| Status | Count |
|--------|-------|
| Available | 8 |
| In Progress | 340 |
| Completed | 1222 |
| Graduated | 1 |

Pool depth: adequate (8 ≥ threshold of 5). Next replenishment recommended when pool drops below 5.