### PR TITLE
Enrich gallery proofs: annotations for 5 entries

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02/annotations.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02/annotations.json
@@ -1,1 +1,133 @@
-[]
+[
+  {
+    "id": "cantor-context",
+    "proofId": "algebraic-numbers-countable-oq-02",
+    "type": "context",
+    "range": { "startLine": 1, "endLine": 58 },
+    "title": "Cantor 1874: ℝ is Uncountable — Completing the Gallery Proof",
+    "content": "This file proves $\\neg\\text{Countable}\\, \\mathbb{R}$ (Cantor's 1874 result), completing the gallery's treatment of Cantor's paper. Combined with the parent proof (`AlgebraicNumbersCountable`) that algebraic reals are countable, this establishes Cantor's full conclusion: 'almost all' real numbers are transcendental — yet without explicitly naming any transcendental. The abstract diagonal argument is $\\aleph_0 < 2^{\\aleph_0} = \\mathfrak{c} = \\#\\mathbb{R}$.",
+    "mathContext": "Cantor's 1874 paper proved two results: (1) algebraic numbers are countable; (2) real numbers are uncountable. The implication: algebraic ∪ transcendental = ℝ, algebraic is countable, ℝ is uncountable, so transcendental must be uncountable. In Lean, the uncountability of ℝ uses `Cardinal.mk_real : #ℝ = 𝔠` and `Cardinal.aleph0_lt_continuum : ℵ₀ < 𝔠`, while `Cardinal.cantor : κ < 2^κ` abstracts the diagonal argument to all cardinals. The 1874 proof used nested intervals rather than the 1891 explicit diagonal construction, but both achieve the same contradiction.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cantor's diagonal argument",
+      "uncountability",
+      "transcendental numbers",
+      "cardinal arithmetic",
+      "1874 paper"
+    ],
+    "prerequisites": [
+      "set theory",
+      "cardinal arithmetic",
+      "countability"
+    ]
+  },
+  {
+    "id": "cantor-cardinal",
+    "proofId": "algebraic-numbers-countable-oq-02",
+    "type": "technique",
+    "range": { "startLine": 67, "endLine": 79 },
+    "title": "Cardinal Facts: #ℝ = 𝔠 > ℵ₀",
+    "content": "**card_real_eq_continuum** proves $\\#\\mathbb{R} = \\mathfrak{c}$ as a one-line application of `Cardinal.mk_real`. **aleph0_lt_card_real** derives $\\aleph_0 < \\#\\mathbb{R}$ by rewriting through `card_real_eq_continuum` and applying `Cardinal.aleph0_lt_continuum`. These two cardinal facts are the only mathematical content needed — all subsequent proofs are logical consequences.",
+    "mathContext": "In Mathlib, $\\mathfrak{c} = 2^{\\aleph_0} = \\#(\\mathbb{N} \\to \\mathrm{Bool})$ is the cardinality of the continuum, and `Cardinal.mk_real` provides the cardinality equality $\\#\\mathbb{R} = \\mathfrak{c}$. `Cardinal.aleph0_lt_continuum` instantiates `Cardinal.cantor \\aleph_0 : \\aleph_0 < 2^{\\aleph_0}` (Cantor's abstract theorem). The `Cardinal.{0}` universe annotation handles Lean's universe polymorphism for cardinals at the `Type 0` level.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cardinal.mk_real",
+      "Cardinal.aleph0_lt_continuum",
+      "Cardinal.cantor",
+      "continuum",
+      "𝔠 = 2^ℵ₀"
+    ],
+    "prerequisites": [
+      "cardinal arithmetic",
+      "Mathlib Cardinal API"
+    ]
+  },
+  {
+    "id": "cantor-uncountable",
+    "proofId": "algebraic-numbers-countable-oq-02",
+    "type": "technique",
+    "range": { "startLine": 84, "endLine": 101 },
+    "title": "Main Theorem: ℝ is Not Countable",
+    "content": "**reals_not_countable** proves $\\neg\\text{Countable}\\, \\mathbb{R}$ by contradiction: assume `Countable ℝ`, use `Cardinal.mk_le_aleph0` to get $\\#\\mathbb{R} \\leq \\aleph_0$, then derive a contradiction with `aleph0_lt_card_real`. The proof uses `haveI := h` to install the countability assumption as a typeclass instance so `mk_le_aleph0` can discharge it automatically.",
+    "mathContext": "`Cardinal.mk_le_aleph0` has signature `[Countable α] → #α ≤ ℵ₀`, requiring `Countable α` as a typeclass instance rather than an explicit term. The `haveI := h` idiom promotes the proof term `h : Countable ℝ` to an instance. Then `not_le.mpr aleph0_lt_card_real : ¬ (#ℝ ≤ ℵ₀)` combined with `absurd hle` yields `False`. The alias `reals_uncountable` is a synonym anticipating that the primary name might vary across file versions.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Cardinal.mk_le_aleph0",
+      "not_le",
+      "absurd",
+      "haveI",
+      "Countable typeclass"
+    ],
+    "prerequisites": [
+      "cardinal arithmetic",
+      "Lean instance inference",
+      "proof by contradiction"
+    ]
+  },
+  {
+    "id": "cantor-surjection",
+    "proofId": "algebraic-numbers-countable-oq-02",
+    "type": "concept",
+    "range": { "startLine": 106, "endLine": 125 },
+    "title": "No Surjection ℕ → ℝ: Direct Statement of the Diagonal",
+    "content": "**no_surjection_nat_to_real** proves $\\nexists\\, f : \\mathbb{N} \\to \\mathbb{R}$, `Surjective f` in one line: any surjection would make ℝ countable via `Function.Surjective.countable`, contradicting `reals_not_countable`. **exists_not_in_range** gives the constructive reformulation: for any $f : \\mathbb{N} \\to \\mathbb{R}$, there exists $x \\notin \\mathrm{range}(f)$.",
+    "mathContext": "`hf.countable` applies `Function.Surjective.countable : Surjective f → Countable β` where `f : ℕ → ℝ` and ℕ is countable. The `exists_not_in_range` proof: `by_contra h; push_neg at h` converts `¬(∃ x, x ∉ range f)` to `∀ x, x ∈ range f`, then `fun x => h x` gives `Surjective f`, and `no_surjection_nat_to_real ⟨f, this⟩` derives contradiction. These are two formulations of the same fact: 'no enumeration of ℝ is complete' = 'any function ℕ → ℝ misses some value'.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Function.Surjective.countable",
+      "Set.range",
+      "by_contra",
+      "push_neg",
+      "enumeration"
+    ],
+    "prerequisites": [
+      "countability",
+      "function surjectivity",
+      "Lean logic tactics"
+    ]
+  },
+  {
+    "id": "cantor-transcendental",
+    "proofId": "algebraic-numbers-countable-oq-02",
+    "type": "insight",
+    "range": { "startLine": 132, "endLine": 156 },
+    "title": "Transcendental Reals are Uncountable: Cantor's Corollary",
+    "content": "**transcendentalReals** $= \\{x : \\mathbb{R} \\mid \\neg\\text{IsAlgebraic}\\, \\mathbb{Q}\\, x\\}$. **transcendentals_uncountable** proves uncountability via the union argument: algebraic $\\cup$ transcendental $= \\mathbb{R}$ (by `Classical.em`), both countable would give `Set.Countable Set.univ` (via `Set.Countable.union`), which converts to `Countable ℝ` (via `Set.countable_univ_iff`), contradicting `reals_not_countable`.",
+    "mathContext": "The `Classical.em (IsAlgebraic ℚ x)` covers the dichotomy without deciding whether any specific $x$ is algebraic. `h_alg := AlgebraicNumbersCountable.algebraic_reals_countable` imports the parent proof's result. `h_alg.union h_trans : Set.Countable (algebraic ∪ transcendental)`. Then `h_cover : algebraic ∪ transcendental = Set.univ` (proved by `ext x; simp ... exact Classical.em _`) gives `h_univ`. Finally `Set.countable_univ_iff.mp h_univ : Countable ℝ` is the bridge from set-countability to type-countability.",
+    "significance": "key",
+    "relatedConcepts": [
+      "IsAlgebraic",
+      "Set.Countable.union",
+      "Set.countable_univ_iff",
+      "Classical.em",
+      "transcendental numbers"
+    ],
+    "prerequisites": [
+      "algebraic numbers",
+      "classical logic",
+      "set countability API"
+    ]
+  },
+  {
+    "id": "cantor-diagonal-connection",
+    "proofId": "algebraic-numbers-countable-oq-02",
+    "type": "concept",
+    "range": { "startLine": 162, "endLine": 192 },
+    "title": "Abstract vs Concrete Diagonal: Unifying the Gallery",
+    "content": "The final section connects the three forms of Cantor's diagonal: (1) **abstract** — `Cardinal.cantor ℵ₀ : ℵ₀ < 2^ℵ₀`; (2) **concrete** — `CantorDiagonalization.no_surjection_nat_to_binary : ¬∃ f : ℕ → BinarySeq, Surjective f`; (3) **real-valued** — `reals_not_countable`. **reals_uncountable_summary** packages the full 1874 dichotomy as a single conjunction.",
+    "mathContext": "`Cardinal.cantor κ : κ < 2^κ` is Cantor's general theorem (the diagonal argument for any set). At $\\kappa = \\aleph_0$: no surjection $\\mathbb{N} \\to 2^{\\mathbb{N}}$ exists. Identifying $2^{\\mathbb{N}} \\cong \\mathrm{BinarySeq} = (\\mathbb{N} \\to \\mathrm{Bool})$, this matches `CantorDiagonalization.no_surjection_nat_to_binary`. The identification $\\#\\mathbb{R} = \\mathfrak{c} = 2^{\\aleph_0}$ links all three: the gap $\\aleph_0 < 2^{\\aleph_0}$ is why ℝ is uncountable.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Cardinal.cantor",
+      "BinarySeq",
+      "CantorDiagonalization",
+      "no_surjection_nat_to_binary",
+      "𝔠 = 2^ℵ₀"
+    ],
+    "prerequisites": [
+      "cardinal arithmetic",
+      "Cantor's theorem",
+      "binary sequences"
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- `angle-trisection-cos-20-gal-oq-01`: 8 annotations — cos(π/7) Galois group, Eisenstein at p=7, splitting field
- `bezout-identity-oq-02-oq-01-oq-02-oq-02`: 6 annotations — Gaussian prime classification, ZMod 4 obstruction
- `cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01`: 4 annotations — power mean monotonicity, HM≤GM≤AM≤QM
- `bezout-identity-oq-02-oq-01-oq-01-oq-01`: 5 annotations — multivariate UFD, Gauss's lemma induction
- `algebraic-numbers-countable-oq-02`: 6 annotations — Cantor 1874, cardinal diagonal, transcendentals uncountable

All entries had empty or missing `annotations.json`; now have full coverage with LaTeX mathContext, significance ratings, relatedConcepts, prerequisites.

Labels: enrichment