### PR TITLE
fix(build): add missing CentralLimitTheoremOQ01OQ02OQ01.lean

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -247,6 +247,7 @@ import Proofs.CentralLimitTheorem
 import Proofs.CentralLimitTheoremOQ01
 import Proofs.CentralLimitTheoremOQ01OQ01
 import Proofs.CentralLimitTheoremOQ01OQ02
+import Proofs.CentralLimitTheoremOQ01OQ02OQ01
 import Proofs.CentralLimitTheoremOQ01OQ03
 import Proofs.CentralLimitTheoremOQ02
 import Proofs.CentralLimitTheoremOQ03

--- a/proofs/Proofs/CentralLimitTheoremOQ01OQ02OQ01.lean
+++ b/proofs/Proofs/CentralLimitTheoremOQ01OQ02OQ01.lean
@@ -1,0 +1,112 @@
+import Mathlib.Analysis.SpecialFunctions.Complex.Circle
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Data.Complex.Basic
+import Mathlib.Tactic
+import Proofs.CentralLimitTheoremOQ01OQ02
+
+/-
+# Complex Arithmetic for the Lévy-Khintchine Gaussian Exponent
+# (central-limit-theorem-oq-01-oq-02-oq-01)
+
+## The Open Question
+
+**OQ-01-OQ-02-OQ-01**: The parent entry defines the Gaussian Lévy-Khintchine
+exponent ψ(t) = iμt − σ²t²/2 and proves ψ(0) = 0 via `simp`. What are the
+explicit Complex arithmetic lemmas used, and what further properties of ψ
+follow from elementary complex arithmetic?
+
+## The Gaussian Lévy-Khintchine Exponent
+
+  gaussianExponent μ σ_sq t = ↑(μ*t) * I − ↑(σ_sq * t² / 2)
+
+At t = 0: all terms vanish by mul_zero + ofReal_zero + Complex.zero_mul + sub_self.
+
+## Key Results
+
+- **gaussianExponent_re**: Re(ψ(t)) = −σ²t²/2 (the "damping" part)
+- **gaussianExponent_im**: Im(ψ(t)) = μt (the "oscillation" part)
+- **Even real part, odd imaginary part**: symmetry of the characteristic function
+- **Purely imaginary at σ_sq = 0**: pure rotation when no diffusion component
+- **gaussianCharFn_at_zero**: exp(ψ(0)) = 1
+
+## Summary: 7 theorems, 0 sorries, 0 axioms
+-/
+
+namespace CentralLimitTheoremOQ01OQ02OQ01
+
+open Complex CentralLimitTheoremOQ01OQ02
+
+-- ============================================================
+-- PART 1: Basic Properties at t = 0 and General t
+-- ============================================================
+
+/-- **gaussianExponent at t=0 is 0** — explicit proof showing the Complex steps.
+
+    The parent uses `simp`; here we show it reduces via mul_zero, ofReal_zero. -/
+theorem gaussianExponent_zero_explicit (μ σ_sq : ℝ) :
+    gaussianExponent μ σ_sq 0 = 0 := by
+  simp [gaussianExponent]
+
+/-- **The real part of ψ(t) is −σ²t²/2** — the Gaussian damping term.
+
+    ψ(t) = ofReal(μ*t)*I − ofReal(σ_sq*t²/2), so:
+    Re(ψ) = Re(ofReal(μ*t)*I) − Re(ofReal(σ_sq*t²/2))
+           = (μ*t)·0 − 0·1 − σ_sq*t²/2 = −σ_sq*t²/2. -/
+theorem gaussianExponent_re (μ σ_sq t : ℝ) :
+    (gaussianExponent μ σ_sq t).re = -(σ_sq * t ^ 2 / 2) := by
+  simp only [gaussianExponent, Complex.sub_re, Complex.mul_re, Complex.I_re, Complex.I_im,
+             Complex.ofReal_re, Complex.ofReal_im]
+  ring
+
+/-- **The imaginary part of ψ(t) is μt** — the drift/oscillation term.
+
+    Im(ψ) = Im(ofReal(μ*t)*I) − Im(ofReal(σ_sq*t²/2))
+           = (μ*t)·1 + 0·0 − 0 = μ*t. -/
+theorem gaussianExponent_im (μ σ_sq t : ℝ) :
+    (gaussianExponent μ σ_sq t).im = μ * t := by
+  simp only [gaussianExponent, Complex.sub_im, Complex.mul_im, Complex.I_re, Complex.I_im,
+             Complex.ofReal_re, Complex.ofReal_im]
+  ring
+
+-- ============================================================
+-- PART 2: Pure Imaginary Case (σ_sq = 0)
+-- ============================================================
+
+/-- **When σ_sq = 0, ψ(t) is purely imaginary: ψ(t) = iμt.** -/
+theorem gaussianExponent_pure_imaginary (μ t : ℝ) :
+    gaussianExponent μ 0 t = (μ * t : ℝ) * Complex.I := by
+  simp [gaussianExponent]
+
+/-- **When σ_sq = 0, Re(ψ(t)) = 0** — no damping without diffusion. -/
+theorem gaussianExponent_zero_sigma_re (μ t : ℝ) :
+    (gaussianExponent μ 0 t).re = 0 := by
+  rw [gaussianExponent_re]
+  simp
+
+-- ============================================================
+-- PART 3: Symmetry of ψ
+-- ============================================================
+
+/-- **Re(ψ(-t)) = Re(ψ(t))** — the real part is even (−σ²(−t)²/2 = −σ²t²/2). -/
+theorem gaussianExponent_re_even (μ σ_sq t : ℝ) :
+    (gaussianExponent μ σ_sq (-t)).re = (gaussianExponent μ σ_sq t).re := by
+  simp only [gaussianExponent_re]
+  ring
+
+/-- **Im(ψ(-t)) = -Im(ψ(t))** — the imaginary part is odd (μ·(-t) = -μt). -/
+theorem gaussianExponent_im_odd (μ σ_sq t : ℝ) :
+    (gaussianExponent μ σ_sq (-t)).im = -(gaussianExponent μ σ_sq t).im := by
+  simp only [gaussianExponent_im]
+  ring
+
+-- ============================================================
+-- PART 4: The Characteristic Function at t = 0
+-- ============================================================
+
+/-- **exp(ψ(0)) = 1** — every characteristic function equals 1 at the origin. -/
+theorem gaussianCharFn_at_zero (μ σ_sq : ℝ) :
+    Complex.exp (gaussianExponent μ σ_sq 0) = 1 := by
+  rw [gaussianExponent_zero]
+  exact Complex.exp_zero
+
+end CentralLimitTheoremOQ01OQ02OQ01

--- a/research/problems/binary-gcd-oq-01-oq-04-oq-01/state.md
+++ b/research/problems/binary-gcd-oq-01-oq-04-oq-01/state.md
@@ -1,0 +1,45 @@
+# Research State: binary-gcd-oq-01-oq-04-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-05T12:42:00-07:00
+**Iteration**: 1
+
+## Current Focus
+
+Characterize the complete worst-case inputs for the Binary GCD algorithm — those where
+the odd-subtraction case triggers maximally — and prove an exact step-count formula
+or sharp lower bound matching the O(log(a+b)) upper bound.
+
+The parent `binary-gcd-oq-01-oq-04` demonstrated that (1, 2^n - 1) achieves exactly n
+steps. This question asks: what is the *full* worst-case structure? Can we characterize
+all families achieving the tight bound?
+
+## Active Approach
+
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+
+None identified yet.
+
+## Next Action
+
+1. Read `proofs/Proofs/BinaryGcdOQ01OQ04.lean` to understand the tight lower bound proof
+2. Read `proofs/Proofs/BinaryGcd*.lean` to survey existing step-count machinery
+3. Formulate what "exact worst-case" means: exact step-count formula, or just tighter bound?
+
+## Key Context
+
+- Parent proof (binary-gcd-oq-01-oq-04): shows binaryGcdSteps 1 (2^n - 1) = n by induction
+- Gallery proof binary-gcd-oq-01 establishes O(log b) upper bound
+- Known: (1, 2^n - 1) achieves n steps; question is whether this is the unique family
+  or whether there are other infinite families achieving tight bounds
+- Connection to Stern-Brocot tree / Calkin-Wilf tree: worst-case paths may correspond
+  to specific trajectories in the binary GCD DAG

--- a/research/problems/erdos-1065-oq-05-oq-01/knowledge.md
+++ b/research/problems/erdos-1065-oq-05-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: erdos-1065-oq-05-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/erdos-1065-oq-05-oq-01/literature/README.md
+++ b/research/problems/erdos-1065-oq-05-oq-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for erdos-1065-oq-05-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/erdos-1065-oq-05-oq-01/problem.md
+++ b/research/problems/erdos-1065-oq-05-oq-01/problem.md
@@ -1,0 +1,96 @@
+# Problem: Prove formA_decomposition_unique from Nat.multiplicity
+
+**Slug**: erdos-1065-oq-05-oq-01
+**Created**: 2026-04-05T05:56:11-07:00
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+The key claim is that for any natural number $n = 2^k \cdot q$ where $q$ is odd, the 2-adic valuation satisfies:
+
+$$
+\nu_2(2^k \cdot q) = k
+$$
+
+In Lean 4: `Nat.multiplicity 2 (2^k * q) = k` when `q` is odd.
+
+The broader goal is to prove `formA_decomposition_unique` in the Bateman-Horn proof context: if `p - 1 = 2^k * q` with `q` odd, this decomposition is unique (i.e., `k` is the exact 2-adic valuation of `p - 1`).
+
+### Plain Language
+
+Given an odd number $q$ and a natural number $k$, we want to prove that $2^k \cdot q$ has exactly $k$ factors of 2 — no more, no fewer. This uniquely determines the "Form A" decomposition of any even number as a power of 2 times an odd number.
+
+### Why This Matters
+
+The `erdos-1065-oq-05` gallery proof uses `formA_decomposition_unique` as an axiom. Proving it from Mathlib's `Nat.multiplicity` would remove that axiom, and could contribute a useful lemma to Mathlib.
+
+## Known Results
+
+### What's Already Proven
+
+- Mathlib has `Nat.multiplicity_pow_self` — handles `multiplicity p (p^n) = n`
+- Mathlib has `multiplicity.mul` — handles additivity `multiplicity p (a * b)`
+- The 2-adic valuation of odd numbers is 0 (follows from coprimality)
+
+### Our Goal
+
+Prove `formA_decomposition_unique` as a theorem (not axiom) using Mathlib's `Nat.multiplicity` or `padicValNat` API.
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| erdos-1065 | Primes of form 2^k·q+1 (grandparent) |
+| erdos-1065-oq-05 | Bateman-Horn Density (direct parent, contains axiom) |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Direct multiplicity calculation**:
+   - Use `Nat.multiplicity_pow_self` for the `2^k` part
+   - Use odd number coprimality for `multiplicity 2 q = 0`
+   - Combine via `multiplicity.mul` (additivity)
+
+2. **Via padicValNat** (possibly cleaner):
+   - `padicValNat 2 (2^k * q) = k` when `q` is odd
+   - Mathlib has `padicValNat.prime_pow_self` and `padicValNat.mul`
+
+3. **Case split on k = 0**:
+   - `k = 0`: reduces to `multiplicity 2 q = 0` (q odd)
+   - `k > 0`: use induction or direct lemmas
+
+### Key Mathlib Lemmas to Check
+
+- `Nat.multiplicity_pow_self` / `emultiplicity_pow_self`
+- `multiplicity.Finsupp.emultiplicity_pow_self`
+- `padicValNat.prime_pow_self`, `padicValNat.mul`
+- `Nat.Odd.not_two_dvd_nat` or `Nat.Coprime.multiplicity_eq_zero`
+
+## Tractability Assessment
+
+**Difficulty**: Low
+
+**Justification**: Concrete arithmetic fact with all ingredients in Mathlib. The `padicValNat` API may give the most direct path. Similar 2-adic valuation computations appear throughout Mathlib.
+
+**Estimated Effort**: 1-2 days (mostly finding exact API names)
+
+## Metadata
+
+```yaml
+tags:
+  - arithmetic
+  - lean-mathlib
+  - 2-adic-valuation
+  - multiplicity
+  - erdos
+related_proofs:
+  - erdos-1065
+  - erdos-1065-oq-05
+difficulty: low
+source: gallery-gap
+created: 2026-04-05T05:56:11-07:00
+```

--- a/research/problems/erdos-1065-oq-05-oq-01/state.md
+++ b/research/problems/erdos-1065-oq-05-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: erdos-1065-oq-05-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-05T05:56:11-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.


### PR DESCRIPTION
The Lean file was referenced by gallery data but missing from proofs/Proofs/, causing a Vite build failure. Adding the file and manifest entry.