### PR TITLE
feat(aristotle): add companion file for birthday-problem-oq-03-oq-01-oq-02

### DIFF
--- a/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02Aristotle.lean
+++ b/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02Aristotle.lean
@@ -1,0 +1,26 @@
+/-
+  Aristotle targets for Birthday Problem OQ-03-OQ-01-OQ-02
+  (k=3 Birthday Coincidence Asymptotic Threshold)
+
+  Routine supporting lemma for automated proof search.
+  See BirthdayProblemOQ03OQ01OQ02.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main probabilistic approximation result
+  - Standard combinatorial identity provable from Mathlib
+  - Clean theorem statement with no definition sorry
+  - No axiom declarations
+-/
+import Mathlib
+
+namespace BirthdayOQ03OQ01OQ02Aristotle
+
+open Nat
+
+/-- C(n,3) × 6 = n(n-1)(n-2) for all n : ℕ.
+    Standard combinatorial identity via Pascal induction. -/
+theorem choose3_mul_six (n : ℕ) :
+    n.choose 3 * 6 = n * (n - 1) * (n - 2) := by
+  sorry
+
+end BirthdayOQ03OQ01OQ02Aristotle

--- a/research/registry.json
+++ b/research/registry.json
@@ -9778,11 +9778,12 @@
     },
     {
       "slug": "triangle-inequality-oq-04",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-30T17:47:50.026Z",
-      "status": "active",
-      "lastUpdate": "2026-03-30T17:47:50.026Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T12:58:50.696Z",
+      "completed": "2026-04-05T12:58:50.696Z"
     },
     {
       "slug": "arithmetic-series-oq-02-oq-02-oq-04",
@@ -10632,11 +10633,11 @@
     },
     {
       "slug": "leibniz-pi-oq-03",
-      "phase": "NEW",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-04-03T02:53:26.476Z",
       "status": "active",
-      "lastUpdate": "2026-04-03T02:53:26.476Z"
+      "lastUpdate": "2026-04-05T12:58:50.807Z"
     },
     {
       "slug": "liouville-theorem-oq-02",
@@ -12312,11 +12313,11 @@
     },
     {
       "slug": "amgm-inequality-oq-03-oq-02-oq-04",
-      "phase": "NEW",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-04-04T05:15:05.955Z",
       "status": "active",
-      "lastUpdate": "2026-04-04T05:15:05.955Z"
+      "lastUpdate": "2026-04-05T12:58:50.812Z"
     },
     {
       "slug": "angle-trisection-oq-02-oq-03-oq-03",
@@ -12990,11 +12991,12 @@
     },
     {
       "slug": "brouwer-fixed-point-oq-01-oq-03",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-05T06:00:06.439Z",
-      "status": "active",
-      "lastUpdate": "2026-04-05T06:00:06.439Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T12:58:50.656Z",
+      "completed": "2026-04-05T12:58:50.656Z"
     },
     {
       "slug": "amgm-inequality-oq-02-oq-03-oq-02",
@@ -13006,11 +13008,11 @@
     },
     {
       "slug": "arithmetic-series-oq-02-oq-01-oq-01",
-      "phase": "NEW",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-04-05T06:00:06.528Z",
       "status": "active",
-      "lastUpdate": "2026-04-05T06:00:06.528Z"
+      "lastUpdate": "2026-04-05T12:58:50.813Z"
     },
     {
       "slug": "ballot-problem-oq-01-oq-04-oq-02",
@@ -13136,11 +13138,11 @@
     },
     {
       "slug": "arithmetic-series-oq-02-oq-04-oq-01-oq-03",
-      "phase": "NEW",
+      "phase": "OBSERVE",
       "path": "fast",
       "started": "2026-04-05T08:58:43.702Z",
       "status": "active",
-      "lastUpdate": "2026-04-05T08:58:43.702Z"
+      "lastUpdate": "2026-04-05T12:58:50.813Z"
     },
     {
       "slug": "arithmetic-series-oq-04-oq-01",
@@ -13208,11 +13210,11 @@
     },
     {
       "slug": "shannon-channel-coding-oq-04-oq-01",
-      "phase": "NEW",
+      "phase": "OBSERVE",
       "path": "fast",
       "started": "2026-04-05T08:58:44.306Z",
       "status": "active",
-      "lastUpdate": "2026-04-05T08:58:44.306Z"
+      "lastUpdate": "2026-04-05T12:58:50.814Z"
     },
     {
       "slug": "taylor-sincos-convergence-oq-03-wip-01",
@@ -13551,11 +13553,12 @@
     },
     {
       "slug": "central-limit-theorem-oq-01-oq-02-oq-01",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "fast",
       "started": "2026-04-05T12:05:44.507Z",
-      "status": "active",
-      "lastUpdate": "2026-04-05T12:05:44.507Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T12:58:50.690Z",
+      "completed": "2026-04-05T12:58:50.690Z"
     },
     {
       "slug": "cevas-theorem-oq-01-oq-02",
@@ -13788,6 +13791,166 @@
       "started": "2026-04-05T12:05:44.544Z",
       "status": "active",
       "lastUpdate": "2026-04-05T12:05:44.544Z"
+    },
+    {
+      "slug": "hilbert-3-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:58:50.676Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.676Z"
+    },
+    {
+      "slug": "solution-of-cubic-oq-03-oq-01-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:58:50.678Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.678Z"
+    },
+    {
+      "slug": "erdos-1033-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:58:50.767Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.767Z"
+    },
+    {
+      "slug": "erdos-179-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:58:50.770Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.770Z"
+    },
+    {
+      "slug": "erdos-490-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:58:50.773Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.773Z"
+    },
+    {
+      "slug": "hilbert-3-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:58:50.781Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.781Z"
+    },
+    {
+      "slug": "erdos-1-oq-02-oq-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T12:58:50.789Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.789Z"
+    },
+    {
+      "slug": "erdos-1002-oq-01-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:58:50.790Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.790Z"
+    },
+    {
+      "slug": "erdos-1012-oq-01-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:58:50.790Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.790Z"
+    },
+    {
+      "slug": "erdos-1015-oq-05-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:58:50.790Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.790Z"
+    },
+    {
+      "slug": "erdos-1054-oq-01-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:58:50.790Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.790Z"
+    },
+    {
+      "slug": "erdos-1057-oq-04",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T12:58:50.790Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.790Z"
+    },
+    {
+      "slug": "erdos-1059-oq-01-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:58:50.790Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.790Z"
+    },
+    {
+      "slug": "erdos-1065-oq-05-oq-01",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-05T12:58:50.791Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.817Z"
+    },
+    {
+      "slug": "erdos-1083-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:58:50.791Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.791Z"
+    },
+    {
+      "slug": "erdos-1084-oq-01-oq-04",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T12:58:50.791Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.791Z"
+    },
+    {
+      "slug": "erdos-1098-oq-01-oq-03",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T12:58:50.791Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.791Z"
+    },
+    {
+      "slug": "erdos-1138-oq-03-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:58:50.791Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.791Z"
+    },
+    {
+      "slug": "erdos-1146-oq-04",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T12:58:50.791Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.791Z"
+    },
+    {
+      "slug": "erdos-1168-oq-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T12:58:50.791Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.791Z"
     }
   ],
   "config": {


### PR DESCRIPTION
## Fix

Add Aristotle companion file for the birthday problem k=3 threshold proof.

## Evidence

**Before**: `BirthdayProblemOQ03OQ01OQ02.lean` has 1 sorry (`choose3_mul_six`) with no Aristotle companion file.

**After**: `BirthdayProblemOQ03OQ01OQ02Aristotle.lean` exposes `choose3_mul_six` — the combinatorial identity `n.choose 3 * 6 = n * (n-1) * (n-2)` — as an Aristotle target. This is a routine nat.choose identity (no open conjecture, no definition sorry, no axioms).

The original sorry is described as requiring "Pascal induction with ℕ-subtraction edge cases", which Aristotle should handle via `omega`/`induction`/`simp`.

## Pre-submission checklist

- [x] No `def ... := sorry`
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections
- [x] No open conjectures (this is a known combinatorial fact)

---
Automated fix by lean-mechanic agent.