### PR TITLE
fix(meta): correct sorry counts for 3 proofs

### DIFF
--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -13,10 +13,10 @@
       "tournaments"
     ],
     "badge": "wip",
-    "sorries": 5,
+    "sorries": 2,
     "axiomCount": 0,
     "lineCount": 1277,
-    "assumptions": "0 axioms. 1 sorry: ghouila_houri (full proof needs longest-path argument ~200 lines tracking both in- and out-degrees). hamiltonian_of_few_missing_arcs and directed_hamiltonian_threshold are now fully proved: the fiber counting lemma hBadFor_bound (∀ p ∈ Missing, |BadFor p| ≤ n*(n-2)!) was proved via fiber decomposition + injection into Perm(Fin(n-2)) using Finset.orderIsoOfFin. Moon-Moser theorem and Rédei are also fully proved.",
+    "assumptions": "0 axioms. 2 sorries: (1) ghouila_houri — full proof needs longest-path argument tracking in- and out-degrees; (2) perm_arc_bad_card_le — auxiliary lemma bounding permutation count for arc pairs. Moon-Moser theorem (sc_tournament_has_cycle, grow_cycle_to_hamiltonian) and Rédei theorem (tournament_full_path_list) are fully proved.",
     "dateAdded": "2026-03-30"
   },
   "overview": {

--- a/src/data/proofs/erdos-895/meta.json
+++ b/src/data/proofs/erdos-895/meta.json
@@ -18,7 +18,7 @@
       "computational"
     ],
     "badge": "wip",
-    "sorries": 11,
+    "sorries": 7,
     "erdosNumber": 895,
     "erdosUrl": "https://erdosproblems.com/895",
     "erdosProblemStatus": "solved",
@@ -158,7 +158,7 @@
     "axiomCount": 0,
     "theoremCount": 13,
     "definitionCount": 11,
-    "sorries": 11,
+    "sorries": 7,
     "path": "Proofs/Erdos895Problem.lean"
   },
   "crossReferences": [

--- a/src/data/proofs/shannon-channel-coding-oq-03/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-03/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 7,
     "mathlibDependencies": [
       {
         "theorem": "Finset.le_sup'",


### PR DESCRIPTION
## Fix

Corrects stale `sorries` counts in three gallery proof entries where the Lean source has been updated but the metadata was not.

## Evidence

| Proof | Claimed | Actual | Δ | Notes |
|-------|---------|--------|---|-------|
| `erdos-895` | 11 | 7 | −4 | 4 sorries were resolved; verified by grep of `Proofs/Erdos895Problem.lean` |
| `erdos-1012-oq-03` | 5 | 2 | −3 | Moon-Moser and Rédei theorems fully proved; 2 remain (`ghouila_houri` + `perm_arc_bad_card_le`) |
| `shannon-channel-coding-oq-03` | 5 | 7 | +2 | 2 additional sorries found: `hmap_nn` inline `by sorry` (line 243) and final block sorry (line 248) |

Also updates the `assumptions` text for `erdos-1012-oq-03` to accurately name the 2 remaining sorries.

## Verification

Each fix verified by direct count of standalone `sorry` statements in the Lean source file (excluding comment occurrences):
- `erdos-895`: lines 78, 90, 154, 170, 179, 237, 245 = 7 sorries ✓
- `erdos-1012-oq-03`: lines 300, 970 = 2 sorries ✓
- `shannon-channel-coding-oq-03`: lines 61, 120, 166, 191, 209, 243(inline), 248 = 7 sorries ✓

`pnpm build` passes ✓

Note: `birthday-problem-oq-03-oq-01-oq-02` and `cayley-hamilton-reduction-oq-02-oq-01` are handled by PR #9780.

---
Automated fix by lean-mechanic agent.