### PR TITLE
fix(meta): sync leanFile.sorries with meta.sorries for 7 proofs

### DIFF
--- a/src/data/proofs/bezout-identity-oq-04-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-01/meta.json
@@ -195,7 +195,7 @@
     "theoremCount": 11,
     "definitionCount": 5,
     "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -16,7 +16,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 19,
-    "assumptions": "19 axiom declarations encoding: (1) L-function analytic continuation and functional equation, (2) Hasse bound a_p^2 <= 4p, (3) BSD conjecture proven cases (Kolyvagin rank 0, Gross-Zagier+Kolyvagin rank 1), (4) parity conjecture (Dokchitsers), (5) L-values and ranks for specific curves, (6) Sha structure, (7) Elkies rank record, (8) Greenberg-Stevens theorem, (9) regulator positivity. Previously 21 axioms: BSD_CM_rank_zero was proved redundant (subsumed by Kolyvagin general result), gross_zagier_formula_detail was dead code (captured by GrossZagierData structure). 0 sorries: regulator_rank_one_is_height proved by constructing CanonicalHeight h with h.height x = R\u00b7x\u00b2 and generator g = 1.",
+    "assumptions": "19 axiom declarations encoding: (1) L-function analytic continuation and functional equation, (2) Hasse bound a_p^2 <= 4p, (3) BSD conjecture proven cases (Kolyvagin rank 0, Gross-Zagier+Kolyvagin rank 1), (4) parity conjecture (Dokchitsers), (5) L-values and ranks for specific curves, (6) Sha structure, (7) Elkies rank record, (8) Greenberg-Stevens theorem, (9) regulator positivity. Previously 21 axioms: BSD_CM_rank_zero was proved redundant (subsumed by Kolyvagin general result), gross_zagier_formula_detail was dead code (captured by GrossZagierData structure). 0 sorries: regulator_rank_one_is_height proved by constructing CanonicalHeight h with h.height x = R·x² and generator g = 1.",
     "mathlibDependencies": [
       {
         "theorem": "WeierstrassCurve",
@@ -686,7 +686,7 @@
     "theoremCount": 254,
     "definitionCount": 143,
     "path": "Proofs/BirchSwinnertonDyer.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
@@ -132,6 +132,6 @@
     "lineCount": 267,
     "path": "Proofs/CayleyHamiltonReductionOQ02OQ01.lean",
     "axiomCount": 0,
-    "sorries": 3
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1100/meta.json
+++ b/src/data/proofs/erdos-1100/meta.json
@@ -276,6 +276,6 @@
       }
     ],
     "path": "Proofs/Stubs/Erdos1100Problem.lean",
-    "sorries": 2
+    "sorries": 3
   }
 }

--- a/src/data/proofs/erdos-647/meta.json
+++ b/src/data/proofs/erdos-647/meta.json
@@ -153,7 +153,7 @@
     "theoremCount": 25,
     "definitionCount": 11,
     "path": "Proofs/Erdos647Problem.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-895/meta.json
+++ b/src/data/proofs/erdos-895/meta.json
@@ -158,7 +158,7 @@
     "axiomCount": 0,
     "theoremCount": 13,
     "definitionCount": 11,
-    "sorries": 11,
+    "sorries": 7,
     "path": "Proofs/Erdos895Problem.lean"
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-991/meta.json
+++ b/src/data/proofs/erdos-991/meta.json
@@ -201,7 +201,7 @@
     "theoremCount": 5,
     "definitionCount": 11,
     "path": "Proofs/Erdos991Problem.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Corrects stale `leanFile.sorries` fields that were not updated when `meta.sorries` was previously fixed by PRs #9780 and #9787, plus additional proofs where sorries were resolved but the leanFile field wasn't synced.

## Evidence

| Proof | leanFile.sorries (before) | meta.sorries (correct) | Source |
|-------|--------------------------|----------------------|--------|
| `erdos-895` | 11 | 7 | PR #9787 fixed meta but not leanFile |
| `cayley-hamilton-reduction-oq-02-oq-01` | 3 | 0 | PR #9780 fixed meta; leanFile not updated |
| `bezout-identity-oq-04-oq-01` | 1 | 0 | 0 actual sorries in Lean source |
| `birch-swinnerton-dyer` | 1 | 0 | "sorry" appears only in a comment (line 2684) |
| `erdos-1100` | 2 | 3 | Lean source has 3 sorries at lines 77, 204, 229 |
| `erdos-647` | 1 | 0 | 0 actual sorries in Lean source |
| `erdos-991` | 1 | 0 | 0 actual sorries in Lean source |

All `meta.sorries` values were verified correct by direct grep of the Lean source files.

`pnpm build` passes ✓

---
Automated fix by lean-mechanic agent.