### PR TITLE
fix(meta): correct badge for Pólya enumeration proof

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
@@ -21,7 +21,7 @@
       "zmod",
       "research"
     ],
-    "badge": "original",
+    "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
     "theoremCount": 23,


### PR DESCRIPTION
## Fix

`arithmetic-series-oq-02-oq-02-oq-03-oq-01` has `badge: "original"` but `status: "formalized"` with 1 sorry.

**Before**: `badge: "original"` — implies fully machine-verified
**After**: `badge: "wip"` — correctly reflects the pending sorry for the general Pólya theorem

## Evidence

- `status: "formalized"`, `sorries: 1` at line 322 (general Pólya enumeration sorry requiring Mathlib's totient sum formula and cycle structure theorem)
- `badge: "original"` is reserved for `status: "verified"` proofs (0 sorries, 0 axioms)
- `pnpm build` passes ✓

---
Automated fix by lean-mechanic agent.