### PR TITLE
chore(data): sync leanFiles metadata for 303 research problem files

### DIFF
--- a/src/data/research/problems/abel-ruffini-oq-04-oq-07.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-07.json
@@ -78,7 +78,8 @@
     "abel-ruffini-oq-04-oq-01",
     "abel-ruffini-oq-04-oq-02",
     "abel-ruffini-oq-04-oq-02-oq-03",
-    "abel-ruffini-oq-04-oq-03"
+    "abel-ruffini-oq-04-oq-03",
+    "abel-ruffini-oq-04-oq-07"
   ],
   "references": {
     "papers": [],
@@ -91,9 +92,86 @@
   "tractability": 5,
   "leanFiles": [
     {
+      "path": "Proofs/AbelRuffini.lean",
+      "filename": "AbelRuffini.lean",
+      "lineCount": 186,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffini.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
+      "filename": "AbelRuffiniGaloisExtensions.lean",
+      "lineCount": 535,
+      "theoremCount": 57,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensions.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ04.lean",
+      "filename": "AbelRuffiniOQ04.lean",
+      "lineCount": 164,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ04OQ01.lean",
+      "filename": "AbelRuffiniOQ04OQ01.lean",
+      "lineCount": 1602,
+      "theoremCount": 42,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ04OQ02.lean",
+      "filename": "AbelRuffiniOQ04OQ02.lean",
+      "lineCount": 155,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ02.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ04OQ02OQ03.lean",
+      "filename": "AbelRuffiniOQ04OQ02OQ03.lean",
+      "lineCount": 105,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/AbelRuffiniOQ04OQ03.lean",
+      "filename": "AbelRuffiniOQ04OQ03.lean",
+      "lineCount": 166,
+      "theoremCount": 6,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniOQ04OQ03.lean"
+    },
+    {
       "path": "Proofs/AbelRuffiniOQ04OQ07.lean",
       "filename": "AbelRuffiniOQ04OQ07.lean",
-      "lineCount": 280,
+      "lineCount": 378,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 4,

--- a/src/data/research/problems/algebraic-numbers-countable-oq-01.json
+++ b/src/data/research/problems/algebraic-numbers-countable-oq-01.json
@@ -44,7 +44,8 @@
     "field-theory"
   ],
   "relatedProofs": [
-    "algebraic-numbers-countable"
+    "algebraic-numbers-countable",
+    "algebraic-numbers-countable-oq-02"
   ],
   "references": {
     "papers": [],
@@ -76,6 +77,17 @@
       "sorryCount": 5,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AlgebraicNumbersCountableAristotle.lean"
+    },
+    {
+      "path": "Proofs/AlgebraicNumbersCountableOQ02.lean",
+      "filename": "AlgebraicNumbersCountableOQ02.lean",
+      "lineCount": 193,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AlgebraicNumbersCountableOQ02.lean"
     }
   ]
 }

--- a/src/data/research/problems/amgm-inequality-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-01.json
@@ -134,6 +134,28 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03.lean"
     },
     {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
+      "lineCount": 187,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ04.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ04.lean",
+      "lineCount": 161,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ04.lean"
+    },
+    {
       "path": "Proofs/AmgmInequalityOQ03OQ03.lean",
       "filename": "AmgmInequalityOQ03OQ03.lean",
       "lineCount": 66,
@@ -147,13 +169,35 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 308,
+      "lineCount": 317,
       "theoremCount": 21,
       "axiomCount": 3,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
+      "filename": "AmgmInequalityOQ04OQ01.lean",
+      "lineCount": 186,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
+      "filename": "AmgmInequalityPowerMeanLimits.lean",
+      "lineCount": 273,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityPowerMeanLimits.lean"
     }
   ]
 }

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
@@ -134,6 +134,28 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03.lean"
     },
     {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
+      "lineCount": 187,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ04.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ04.lean",
+      "lineCount": 161,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ04.lean"
+    },
+    {
       "path": "Proofs/AmgmInequalityOQ03OQ03.lean",
       "filename": "AmgmInequalityOQ03OQ03.lean",
       "lineCount": 66,
@@ -147,13 +169,35 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 308,
+      "lineCount": 317,
       "theoremCount": 21,
       "axiomCount": 3,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
+      "filename": "AmgmInequalityOQ04OQ01.lean",
+      "lineCount": 186,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
+      "filename": "AmgmInequalityPowerMeanLimits.lean",
+      "lineCount": 273,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityPowerMeanLimits.lean"
     }
   ]
 }

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
@@ -117,6 +117,28 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03.lean"
     },
     {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
+      "lineCount": 187,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ04.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ04.lean",
+      "lineCount": 161,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ04.lean"
+    },
+    {
       "path": "Proofs/AmgmInequalityOQ03OQ03.lean",
       "filename": "AmgmInequalityOQ03OQ03.lean",
       "lineCount": 66,
@@ -130,13 +152,35 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 308,
+      "lineCount": 317,
       "theoremCount": 21,
       "axiomCount": 3,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
+      "filename": "AmgmInequalityOQ04OQ01.lean",
+      "lineCount": 186,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
+      "filename": "AmgmInequalityPowerMeanLimits.lean",
+      "lineCount": 273,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityPowerMeanLimits.lean"
     }
   ],
   "relatedProofs": [

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
@@ -145,6 +145,28 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03.lean"
     },
     {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
+      "lineCount": 187,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ04.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ04.lean",
+      "lineCount": 161,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ04.lean"
+    },
+    {
       "path": "Proofs/AmgmInequalityOQ03OQ03.lean",
       "filename": "AmgmInequalityOQ03OQ03.lean",
       "lineCount": 66,
@@ -158,13 +180,35 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 308,
+      "lineCount": 317,
       "theoremCount": 21,
       "axiomCount": 3,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
+      "filename": "AmgmInequalityOQ04OQ01.lean",
+      "lineCount": 186,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
+      "filename": "AmgmInequalityPowerMeanLimits.lean",
+      "lineCount": 273,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityPowerMeanLimits.lean"
     }
   ]
 }

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
@@ -157,6 +157,28 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03.lean"
     },
     {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
+      "lineCount": 187,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ04.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ04.lean",
+      "lineCount": 161,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ04.lean"
+    },
+    {
       "path": "Proofs/AmgmInequalityOQ03OQ03.lean",
       "filename": "AmgmInequalityOQ03OQ03.lean",
       "lineCount": 66,
@@ -170,13 +192,35 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 308,
+      "lineCount": 317,
       "theoremCount": 21,
       "axiomCount": 3,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
+      "filename": "AmgmInequalityOQ04OQ01.lean",
+      "lineCount": 186,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
+      "filename": "AmgmInequalityPowerMeanLimits.lean",
+      "lineCount": 273,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityPowerMeanLimits.lean"
     }
   ]
 }

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
@@ -148,6 +148,28 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03.lean"
     },
     {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
+      "lineCount": 187,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ04.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ04.lean",
+      "lineCount": 161,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ04.lean"
+    },
+    {
       "path": "Proofs/AmgmInequalityOQ03OQ03.lean",
       "filename": "AmgmInequalityOQ03OQ03.lean",
       "lineCount": 66,
@@ -161,13 +183,35 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 308,
+      "lineCount": 317,
       "theoremCount": 21,
       "axiomCount": 3,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
+      "filename": "AmgmInequalityOQ04OQ01.lean",
+      "lineCount": 186,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
+      "filename": "AmgmInequalityPowerMeanLimits.lean",
+      "lineCount": 273,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityPowerMeanLimits.lean"
     }
   ]
 }

--- a/src/data/research/problems/amgm-inequality-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02.json
@@ -142,6 +142,28 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03.lean"
     },
     {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
+      "lineCount": 187,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ04.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ04.lean",
+      "lineCount": 161,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ04.lean"
+    },
+    {
       "path": "Proofs/AmgmInequalityOQ03OQ03.lean",
       "filename": "AmgmInequalityOQ03OQ03.lean",
       "lineCount": 66,
@@ -155,13 +177,35 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 308,
+      "lineCount": 317,
       "theoremCount": 21,
       "axiomCount": 3,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
+      "filename": "AmgmInequalityOQ04OQ01.lean",
+      "lineCount": 186,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
+      "filename": "AmgmInequalityPowerMeanLimits.lean",
+      "lineCount": 273,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityPowerMeanLimits.lean"
     }
   ]
 }

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
@@ -142,6 +142,28 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03.lean"
     },
     {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
+      "lineCount": 187,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ04.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ04.lean",
+      "lineCount": 161,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ04.lean"
+    },
+    {
       "path": "Proofs/AmgmInequalityOQ03OQ03.lean",
       "filename": "AmgmInequalityOQ03OQ03.lean",
       "lineCount": 66,
@@ -155,13 +177,35 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 308,
+      "lineCount": 317,
       "theoremCount": 21,
       "axiomCount": 3,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
+      "filename": "AmgmInequalityOQ04OQ01.lean",
+      "lineCount": 186,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
+      "filename": "AmgmInequalityPowerMeanLimits.lean",
+      "lineCount": 273,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityPowerMeanLimits.lean"
     }
   ]
 }

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
@@ -157,6 +157,28 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03.lean"
     },
     {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
+      "lineCount": 187,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ04.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ04.lean",
+      "lineCount": 161,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ04.lean"
+    },
+    {
       "path": "Proofs/AmgmInequalityOQ03OQ03.lean",
       "filename": "AmgmInequalityOQ03OQ03.lean",
       "lineCount": 66,
@@ -170,13 +192,35 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 308,
+      "lineCount": 317,
       "theoremCount": 21,
       "axiomCount": 3,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
+      "filename": "AmgmInequalityOQ04OQ01.lean",
+      "lineCount": 186,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
+      "filename": "AmgmInequalityPowerMeanLimits.lean",
+      "lineCount": 273,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityPowerMeanLimits.lean"
     }
   ]
 }

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
@@ -52,6 +52,7 @@
     "amgm-inequality-oq-03",
     "amgm-inequality-oq-03-oq-01",
     "amgm-inequality-oq-03-oq-02",
+    "amgm-inequality-oq-03-oq-02-oq-01",
     "amgm-inequality-oq-03-oq-03",
     "amgm-inequality-oq-04"
   ],
@@ -142,6 +143,28 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03.lean"
     },
     {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
+      "lineCount": 187,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ04.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ04.lean",
+      "lineCount": 161,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ04.lean"
+    },
+    {
       "path": "Proofs/AmgmInequalityOQ03OQ03.lean",
       "filename": "AmgmInequalityOQ03OQ03.lean",
       "lineCount": 66,
@@ -155,13 +178,35 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 308,
+      "lineCount": 317,
       "theoremCount": 21,
       "axiomCount": 3,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
+      "filename": "AmgmInequalityOQ04OQ01.lean",
+      "lineCount": 186,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
+      "filename": "AmgmInequalityPowerMeanLimits.lean",
+      "lineCount": 273,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityPowerMeanLimits.lean"
     }
   ]
 }

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
@@ -139,6 +139,28 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03.lean"
     },
     {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
+      "lineCount": 187,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ04.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ04.lean",
+      "lineCount": 161,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ04.lean"
+    },
+    {
       "path": "Proofs/AmgmInequalityOQ03OQ03.lean",
       "filename": "AmgmInequalityOQ03OQ03.lean",
       "lineCount": 66,
@@ -152,13 +174,35 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 308,
+      "lineCount": 317,
       "theoremCount": 21,
       "axiomCount": 3,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
+      "filename": "AmgmInequalityOQ04OQ01.lean",
+      "lineCount": 186,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
+      "filename": "AmgmInequalityPowerMeanLimits.lean",
+      "lineCount": 273,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityPowerMeanLimits.lean"
     }
   ]
 }

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
@@ -51,6 +51,7 @@
     "amgm-inequality-oq-03",
     "amgm-inequality-oq-03-oq-01",
     "amgm-inequality-oq-03-oq-02",
+    "amgm-inequality-oq-03-oq-02-oq-01",
     "amgm-inequality-oq-03-oq-03",
     "amgm-inequality-oq-04"
   ],
@@ -143,6 +144,28 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03.lean"
     },
     {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
+      "lineCount": 187,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ04.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ04.lean",
+      "lineCount": 161,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ04.lean"
+    },
+    {
       "path": "Proofs/AmgmInequalityOQ03OQ03.lean",
       "filename": "AmgmInequalityOQ03OQ03.lean",
       "lineCount": 66,
@@ -156,13 +179,35 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 308,
+      "lineCount": 317,
       "theoremCount": 21,
       "axiomCount": 3,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
+      "filename": "AmgmInequalityOQ04OQ01.lean",
+      "lineCount": 186,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
+      "filename": "AmgmInequalityPowerMeanLimits.lean",
+      "lineCount": 273,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityPowerMeanLimits.lean"
     }
   ]
 }

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
@@ -95,6 +95,28 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03.lean"
     },
     {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
+      "lineCount": 187,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ04.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ04.lean",
+      "lineCount": 161,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ04.lean"
+    },
+    {
       "path": "Proofs/AmgmInequalityOQ03OQ03.lean",
       "filename": "AmgmInequalityOQ03OQ03.lean",
       "lineCount": 66,
@@ -108,13 +130,35 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 308,
+      "lineCount": 317,
       "theoremCount": 21,
       "axiomCount": 3,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
+      "filename": "AmgmInequalityOQ04OQ01.lean",
+      "lineCount": 186,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
+      "filename": "AmgmInequalityPowerMeanLimits.lean",
+      "lineCount": 273,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityPowerMeanLimits.lean"
     }
   ],
   "relatedProofs": [

--- a/src/data/research/problems/amgm-inequality-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03.json
@@ -51,6 +51,7 @@
     "amgm-inequality-oq-03",
     "amgm-inequality-oq-03-oq-01",
     "amgm-inequality-oq-03-oq-02",
+    "amgm-inequality-oq-03-oq-02-oq-01",
     "amgm-inequality-oq-03-oq-03",
     "amgm-inequality-oq-04"
   ],
@@ -143,6 +144,28 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03.lean"
     },
     {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
+      "lineCount": 187,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ04.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ04.lean",
+      "lineCount": 161,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ04.lean"
+    },
+    {
       "path": "Proofs/AmgmInequalityOQ03OQ03.lean",
       "filename": "AmgmInequalityOQ03OQ03.lean",
       "lineCount": 66,
@@ -156,13 +179,35 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 308,
+      "lineCount": 317,
       "theoremCount": 21,
       "axiomCount": 3,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
+      "filename": "AmgmInequalityOQ04OQ01.lean",
+      "lineCount": 186,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
+      "filename": "AmgmInequalityPowerMeanLimits.lean",
+      "lineCount": 273,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityPowerMeanLimits.lean"
     }
   ]
 }

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
@@ -137,6 +137,28 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03.lean"
     },
     {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
+      "lineCount": 187,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ04.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ04.lean",
+      "lineCount": 161,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ04.lean"
+    },
+    {
       "path": "Proofs/AmgmInequalityOQ03OQ03.lean",
       "filename": "AmgmInequalityOQ03OQ03.lean",
       "lineCount": 66,
@@ -150,13 +172,35 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 308,
+      "lineCount": 317,
       "theoremCount": 21,
       "axiomCount": 3,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
+      "filename": "AmgmInequalityOQ04OQ01.lean",
+      "lineCount": 186,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
+      "filename": "AmgmInequalityPowerMeanLimits.lean",
+      "lineCount": 273,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityPowerMeanLimits.lean"
     }
   ]
 }

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
@@ -137,6 +137,28 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03.lean"
     },
     {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
+      "lineCount": 187,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ04.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ04.lean",
+      "lineCount": 161,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ04.lean"
+    },
+    {
       "path": "Proofs/AmgmInequalityOQ03OQ03.lean",
       "filename": "AmgmInequalityOQ03OQ03.lean",
       "lineCount": 66,
@@ -150,13 +172,35 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 308,
+      "lineCount": 317,
       "theoremCount": 21,
       "axiomCount": 3,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
+      "filename": "AmgmInequalityOQ04OQ01.lean",
+      "lineCount": 186,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
+      "filename": "AmgmInequalityPowerMeanLimits.lean",
+      "lineCount": 273,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityPowerMeanLimits.lean"
     }
   ]
 }

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
@@ -137,6 +137,28 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03.lean"
     },
     {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
+      "lineCount": 187,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ04.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ04.lean",
+      "lineCount": 161,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ04.lean"
+    },
+    {
       "path": "Proofs/AmgmInequalityOQ03OQ03.lean",
       "filename": "AmgmInequalityOQ03OQ03.lean",
       "lineCount": 66,
@@ -150,13 +172,35 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 308,
+      "lineCount": 317,
       "theoremCount": 21,
       "axiomCount": 3,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
+      "filename": "AmgmInequalityOQ04OQ01.lean",
+      "lineCount": 186,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
+      "filename": "AmgmInequalityPowerMeanLimits.lean",
+      "lineCount": 273,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityPowerMeanLimits.lean"
     }
   ]
 }

--- a/src/data/research/problems/amgm-inequality-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04.json
@@ -156,6 +156,28 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03.lean"
     },
     {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
+      "lineCount": 187,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ03OQ02OQ04.lean",
+      "filename": "AmgmInequalityOQ03OQ02OQ04.lean",
+      "lineCount": 161,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ03OQ02OQ04.lean"
+    },
+    {
       "path": "Proofs/AmgmInequalityOQ03OQ03.lean",
       "filename": "AmgmInequalityOQ03OQ03.lean",
       "lineCount": 66,
@@ -169,13 +191,35 @@
     {
       "path": "Proofs/AmgmInequalityOQ04.lean",
       "filename": "AmgmInequalityOQ04.lean",
-      "lineCount": 308,
+      "lineCount": 317,
       "theoremCount": 21,
       "axiomCount": 3,
       "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
+      "filename": "AmgmInequalityOQ04OQ01.lean",
+      "lineCount": 186,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
+      "filename": "AmgmInequalityPowerMeanLimits.lean",
+      "lineCount": 273,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityPowerMeanLimits.lean"
     }
   ]
 }

--- a/src/data/research/problems/angle-trisection-oq-01-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-01-oq-03.json
@@ -40,6 +40,7 @@
   "relatedProofs": [
     "angle-trisection",
     "angle-trisection-cos-20-gal",
+    "angle-trisection-cos-20-gal-oq-01",
     "angle-trisection-oq-01",
     "angle-trisection-oq-02",
     "angle-trisection-oq-02-oq-01",
@@ -94,6 +95,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
+      "filename": "AngleTrisectionCos20GalOQ01.lean",
+      "lineCount": 417,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"
     },
     {
       "path": "Proofs/AngleTrisectionEmbedding.lean",

--- a/src/data/research/problems/angle-trisection-oq-01-oq-04.json
+++ b/src/data/research/problems/angle-trisection-oq-01-oq-04.json
@@ -44,6 +44,7 @@
   "relatedProofs": [
     "angle-trisection",
     "angle-trisection-cos-20-gal",
+    "angle-trisection-cos-20-gal-oq-01",
     "angle-trisection-oq-01",
     "angle-trisection-oq-02",
     "angle-trisection-oq-02-oq-01",
@@ -98,6 +99,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
+      "filename": "AngleTrisectionCos20GalOQ01.lean",
+      "lineCount": 417,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"
     },
     {
       "path": "Proofs/AngleTrisectionEmbedding.lean",

--- a/src/data/research/problems/angle-trisection-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-01.json
@@ -40,6 +40,7 @@
   "relatedProofs": [
     "angle-trisection",
     "angle-trisection-cos-20-gal",
+    "angle-trisection-cos-20-gal-oq-01",
     "angle-trisection-oq-01",
     "angle-trisection-oq-02",
     "angle-trisection-oq-02-oq-01",
@@ -95,6 +96,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
+      "filename": "AngleTrisectionCos20GalOQ01.lean",
+      "lineCount": 417,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"
     },
     {
       "path": "Proofs/AngleTrisectionEmbedding.lean",

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01.json
@@ -60,6 +60,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"
     },
     {
+      "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
+      "filename": "AngleTrisectionCos20GalOQ01.lean",
+      "lineCount": 417,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"
+    },
+    {
       "path": "Proofs/AngleTrisectionEmbedding.lean",
       "filename": "AngleTrisectionEmbedding.lean",
       "lineCount": 175,
@@ -228,6 +239,7 @@
   "relatedProofs": [
     "angle-trisection",
     "angle-trisection-cos-20-gal",
+    "angle-trisection-cos-20-gal-oq-01",
     "angle-trisection-oq-01",
     "angle-trisection-oq-02",
     "angle-trisection-oq-02-oq-01",

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-02.json
@@ -54,6 +54,7 @@
   "relatedProofs": [
     "angle-trisection",
     "angle-trisection-cos-20-gal",
+    "angle-trisection-cos-20-gal-oq-01",
     "angle-trisection-oq-01",
     "angle-trisection-oq-02",
     "angle-trisection-oq-02-oq-01",
@@ -110,6 +111,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
+      "filename": "AngleTrisectionCos20GalOQ01.lean",
+      "lineCount": 417,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"
     },
     {
       "path": "Proofs/AngleTrisectionEmbedding.lean",

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01.json
@@ -64,6 +64,7 @@
   "relatedProofs": [
     "angle-trisection",
     "angle-trisection-cos-20-gal",
+    "angle-trisection-cos-20-gal-oq-01",
     "angle-trisection-oq-01",
     "angle-trisection-oq-02",
     "angle-trisection-oq-02-oq-01",
@@ -120,6 +121,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
+      "filename": "AngleTrisectionCos20GalOQ01.lean",
+      "lineCount": 417,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"
     },
     {
       "path": "Proofs/AngleTrisectionEmbedding.lean",

--- a/src/data/research/problems/angle-trisection-oq-02-oq-02.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-02.json
@@ -49,6 +49,7 @@
   "relatedProofs": [
     "angle-trisection",
     "angle-trisection-cos-20-gal",
+    "angle-trisection-cos-20-gal-oq-01",
     "angle-trisection-oq-01",
     "angle-trisection-oq-02",
     "angle-trisection-oq-02-oq-01",
@@ -105,6 +106,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
+      "filename": "AngleTrisectionCos20GalOQ01.lean",
+      "lineCount": 417,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"
     },
     {
       "path": "Proofs/AngleTrisectionEmbedding.lean",

--- a/src/data/research/problems/angle-trisection-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-03-oq-01.json
@@ -51,6 +51,7 @@
   "relatedProofs": [
     "angle-trisection",
     "angle-trisection-cos-20-gal",
+    "angle-trisection-cos-20-gal-oq-01",
     "angle-trisection-oq-01",
     "angle-trisection-oq-02",
     "angle-trisection-oq-02-oq-01",
@@ -108,6 +109,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
+      "filename": "AngleTrisectionCos20GalOQ01.lean",
+      "lineCount": 417,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"
     },
     {
       "path": "Proofs/AngleTrisectionEmbedding.lean",

--- a/src/data/research/problems/angle-trisection-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-03-oq-03.json
@@ -43,6 +43,7 @@
   "relatedProofs": [
     "angle-trisection",
     "angle-trisection-cos-20-gal",
+    "angle-trisection-cos-20-gal-oq-01",
     "angle-trisection-oq-01",
     "angle-trisection-oq-02",
     "angle-trisection-oq-02-oq-01",
@@ -99,6 +100,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
+      "filename": "AngleTrisectionCos20GalOQ01.lean",
+      "lineCount": 417,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"
     },
     {
       "path": "Proofs/AngleTrisectionEmbedding.lean",

--- a/src/data/research/problems/angle-trisection-oq-02-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-03.json
@@ -47,6 +47,7 @@
   "relatedProofs": [
     "angle-trisection",
     "angle-trisection-cos-20-gal",
+    "angle-trisection-cos-20-gal-oq-01",
     "angle-trisection-oq-01",
     "angle-trisection-oq-02",
     "angle-trisection-oq-02-oq-01",
@@ -104,6 +105,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
+      "filename": "AngleTrisectionCos20GalOQ01.lean",
+      "lineCount": 417,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"
     },
     {
       "path": "Proofs/AngleTrisectionEmbedding.lean",

--- a/src/data/research/problems/angle-trisection-oq-02-oq-04-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-04-oq-01.json
@@ -65,6 +65,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"
     },
     {
+      "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
+      "filename": "AngleTrisectionCos20GalOQ01.lean",
+      "lineCount": 417,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"
+    },
+    {
       "path": "Proofs/AngleTrisectionEmbedding.lean",
       "filename": "AngleTrisectionEmbedding.lean",
       "lineCount": 175,
@@ -233,6 +244,7 @@
   "relatedProofs": [
     "angle-trisection",
     "angle-trisection-cos-20-gal",
+    "angle-trisection-cos-20-gal-oq-01",
     "angle-trisection-oq-01",
     "angle-trisection-oq-02",
     "angle-trisection-oq-02-oq-01",

--- a/src/data/research/problems/angle-trisection-oq-02-oq-04.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-04.json
@@ -56,6 +56,7 @@
   "relatedProofs": [
     "angle-trisection",
     "angle-trisection-cos-20-gal",
+    "angle-trisection-cos-20-gal-oq-01",
     "angle-trisection-oq-01",
     "angle-trisection-oq-02",
     "angle-trisection-oq-02-oq-01",
@@ -110,6 +111,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
+      "filename": "AngleTrisectionCos20GalOQ01.lean",
+      "lineCount": 417,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"
     },
     {
       "path": "Proofs/AngleTrisectionEmbedding.lean",

--- a/src/data/research/problems/angle-trisection-oq-02.json
+++ b/src/data/research/problems/angle-trisection-oq-02.json
@@ -45,6 +45,7 @@
   "relatedProofs": [
     "angle-trisection",
     "angle-trisection-cos-20-gal",
+    "angle-trisection-cos-20-gal-oq-01",
     "angle-trisection-oq-01",
     "angle-trisection-oq-02",
     "angle-trisection-oq-02-oq-01",
@@ -102,6 +103,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
+      "filename": "AngleTrisectionCos20GalOQ01.lean",
+      "lineCount": 417,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"
     },
     {
       "path": "Proofs/AngleTrisectionEmbedding.lean",

--- a/src/data/research/problems/angle-trisection-oq-03-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-03-oq-03.json
@@ -48,6 +48,7 @@
   "relatedProofs": [
     "angle-trisection",
     "angle-trisection-cos-20-gal",
+    "angle-trisection-cos-20-gal-oq-01",
     "angle-trisection-oq-01",
     "angle-trisection-oq-02",
     "angle-trisection-oq-02-oq-01",
@@ -103,6 +104,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
+      "filename": "AngleTrisectionCos20GalOQ01.lean",
+      "lineCount": 417,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"
     },
     {
       "path": "Proofs/AngleTrisectionEmbedding.lean",

--- a/src/data/research/problems/angle-trisection-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-03.json
@@ -46,6 +46,7 @@
   "relatedProofs": [
     "angle-trisection",
     "angle-trisection-cos-20-gal",
+    "angle-trisection-cos-20-gal-oq-01",
     "angle-trisection-oq-01",
     "angle-trisection-oq-02",
     "angle-trisection-oq-02-oq-01",
@@ -102,6 +103,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
+      "filename": "AngleTrisectionCos20GalOQ01.lean",
+      "lineCount": 417,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"
     },
     {
       "path": "Proofs/AngleTrisectionEmbedding.lean",

--- a/src/data/research/problems/angle-trisection-oq-05-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-05-oq-01.json
@@ -69,6 +69,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"
     },
     {
+      "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
+      "filename": "AngleTrisectionCos20GalOQ01.lean",
+      "lineCount": 417,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"
+    },
+    {
       "path": "Proofs/AngleTrisectionEmbedding.lean",
       "filename": "AngleTrisectionEmbedding.lean",
       "lineCount": 175,
@@ -237,6 +248,7 @@
   "relatedProofs": [
     "angle-trisection",
     "angle-trisection-cos-20-gal",
+    "angle-trisection-cos-20-gal-oq-01",
     "angle-trisection-oq-01",
     "angle-trisection-oq-02",
     "angle-trisection-oq-02-oq-01",

--- a/src/data/research/problems/angle-trisection-oq-05.json
+++ b/src/data/research/problems/angle-trisection-oq-05.json
@@ -52,6 +52,7 @@
   "relatedProofs": [
     "angle-trisection",
     "angle-trisection-cos-20-gal",
+    "angle-trisection-cos-20-gal-oq-01",
     "angle-trisection-oq-01",
     "angle-trisection-oq-02",
     "angle-trisection-oq-02-oq-01",
@@ -108,6 +109,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"
+    },
+    {
+      "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
+      "filename": "AngleTrisectionCos20GalOQ01.lean",
+      "lineCount": 417,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"
     },
     {
       "path": "Proofs/AngleTrisectionEmbedding.lean",

--- a/src/data/research/problems/arithmetic-series-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-01.json
@@ -44,11 +44,14 @@
     "arithmetic-series",
     "arithmetic-series-oq-02",
     "arithmetic-series-oq-02-oq-01",
+    "arithmetic-series-oq-02-oq-01-oq-01",
     "arithmetic-series-oq-02-oq-02",
     "arithmetic-series-oq-02-oq-02-oq-01",
     "arithmetic-series-oq-02-oq-02-oq-03",
+    "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
     "arithmetic-series-oq-02-oq-04",
     "arithmetic-series-oq-02-oq-04-oq-01",
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-03",
     "arithmetic-series-oq-04"
   ],
   "references": {
@@ -96,6 +99,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "lineCount": 191,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ02OQ02.lean",
       "filename": "ArithmeticSeriesOQ02OQ02.lean",
       "lineCount": 155,
@@ -129,6 +143,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "lineCount": 366,
+      "theoremCount": 27,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ02OQ04.lean",
       "filename": "ArithmeticSeriesOQ02OQ04.lean",
       "lineCount": 159,
@@ -149,6 +174,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "filename": "ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "lineCount": 79,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean"
     },
     {
       "path": "Proofs/ArithmeticSeriesOQ04.lean",

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-01-oq-01.json
@@ -70,10 +70,26 @@
     ],
     "markdown": "# Knowledge Base: arithmetic-series-oq-02-oq-01-oq-01\n\nSee research/problems/arithmetic-series-oq-02-oq-01-oq-01/knowledge.md for full history.\n\n## Summary\n\nq-Vandermonde identity proof by induction on m. Key lemmas (partA_exp, partA_eq, partB_eq_ih) proved. 2 sorries remain: sum_split_pascal and main inductive assembly. Root cause of sum_split_pascal sorry: Finset.sum_add_sum_compl requires Fintype, unavailable for ℕ.\n"
   },
-  "tags": ["combinatorics", "q-analogs", "gaussian-binomial", "vandermonde", "quantum-calculus"],
+  "tags": [
+    "combinatorics",
+    "q-analogs",
+    "gaussian-binomial",
+    "vandermonde",
+    "quantum-calculus"
+  ],
   "relatedProofs": [
-    "arithmetic-series-oq-02-oq-01",
+    "arithmetic-series",
     "arithmetic-series-oq-02",
+    "arithmetic-series-oq-02-oq-01",
+    "arithmetic-series-oq-02-oq-01-oq-01",
+    "arithmetic-series-oq-02-oq-02",
+    "arithmetic-series-oq-02-oq-02-oq-01",
+    "arithmetic-series-oq-02-oq-02-oq-03",
+    "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
+    "arithmetic-series-oq-02-oq-04",
+    "arithmetic-series-oq-02-oq-04-oq-01",
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-03",
+    "arithmetic-series-oq-04",
     "binomial-theorem-oq-04"
   ],
   "references": {
@@ -89,15 +105,136 @@
   "significance": 7,
   "leanFiles": [
     {
+      "path": "Proofs/ArithmeticSeries.lean",
+      "filename": "ArithmeticSeries.lean",
+      "lineCount": 181,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeries.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02.lean",
+      "filename": "ArithmeticSeriesOQ02.lean",
+      "lineCount": 210,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ01.lean",
+      "lineCount": 174,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean",
       "filename": "ArithmeticSeriesOQ02OQ01OQ01.lean",
-      "lineCount": 190,
+      "lineCount": 191,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ02.lean",
+      "filename": "ArithmeticSeriesOQ02OQ02.lean",
+      "lineCount": 155,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ02OQ01.lean",
+      "lineCount": 166,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ03.lean",
+      "filename": "ArithmeticSeriesOQ02OQ02OQ03.lean",
+      "lineCount": 208,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "lineCount": 366,
+      "theoremCount": 27,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ04.lean",
+      "filename": "ArithmeticSeriesOQ02OQ04.lean",
+      "lineCount": 159,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ04OQ01.lean",
+      "lineCount": 170,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "filename": "ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "lineCount": 79,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ04.lean",
+      "filename": "ArithmeticSeriesOQ04.lean",
+      "lineCount": 198,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ04.lean"
     }
   ]
 }

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-01.json
@@ -54,11 +54,14 @@
     "arithmetic-series",
     "arithmetic-series-oq-02",
     "arithmetic-series-oq-02-oq-01",
+    "arithmetic-series-oq-02-oq-01-oq-01",
     "arithmetic-series-oq-02-oq-02",
     "arithmetic-series-oq-02-oq-02-oq-01",
     "arithmetic-series-oq-02-oq-02-oq-03",
+    "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
     "arithmetic-series-oq-02-oq-04",
     "arithmetic-series-oq-02-oq-04-oq-01",
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-03",
     "arithmetic-series-oq-04"
   ],
   "references": {
@@ -105,6 +108,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "lineCount": 191,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ02OQ02.lean",
       "filename": "ArithmeticSeriesOQ02OQ02.lean",
       "lineCount": 155,
@@ -138,6 +152,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "lineCount": 366,
+      "theoremCount": 27,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ02OQ04.lean",
       "filename": "ArithmeticSeriesOQ02OQ04.lean",
       "lineCount": 159,
@@ -158,6 +183,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "filename": "ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "lineCount": 79,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean"
     },
     {
       "path": "Proofs/ArithmeticSeriesOQ04.lean",

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-01.json
@@ -62,6 +62,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "lineCount": 191,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ02OQ02.lean",
       "filename": "ArithmeticSeriesOQ02OQ02.lean",
       "lineCount": 155,
@@ -95,6 +106,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "lineCount": 366,
+      "theoremCount": 27,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ02OQ04.lean",
       "filename": "ArithmeticSeriesOQ02OQ04.lean",
       "lineCount": 159,
@@ -117,6 +139,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "filename": "ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "lineCount": 79,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ04.lean",
       "filename": "ArithmeticSeriesOQ04.lean",
       "lineCount": 198,
@@ -132,11 +165,14 @@
     "arithmetic-series",
     "arithmetic-series-oq-02",
     "arithmetic-series-oq-02-oq-01",
+    "arithmetic-series-oq-02-oq-01-oq-01",
     "arithmetic-series-oq-02-oq-02",
     "arithmetic-series-oq-02-oq-02-oq-01",
     "arithmetic-series-oq-02-oq-02-oq-03",
+    "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
     "arithmetic-series-oq-02-oq-04",
     "arithmetic-series-oq-02-oq-04-oq-01",
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-03",
     "arithmetic-series-oq-04"
   ],
   "tags": [],

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03-oq-01.json
@@ -61,11 +61,14 @@
     "arithmetic-series",
     "arithmetic-series-oq-02",
     "arithmetic-series-oq-02-oq-01",
+    "arithmetic-series-oq-02-oq-01-oq-01",
     "arithmetic-series-oq-02-oq-02",
     "arithmetic-series-oq-02-oq-02-oq-01",
     "arithmetic-series-oq-02-oq-02-oq-03",
+    "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
     "arithmetic-series-oq-02-oq-04",
     "arithmetic-series-oq-02-oq-04-oq-01",
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-03",
     "arithmetic-series-oq-04"
   ],
   "references": {
@@ -112,6 +115,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "lineCount": 191,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ02OQ02.lean",
       "filename": "ArithmeticSeriesOQ02OQ02.lean",
       "lineCount": 155,
@@ -145,6 +159,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "lineCount": 366,
+      "theoremCount": 27,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ02OQ04.lean",
       "filename": "ArithmeticSeriesOQ02OQ04.lean",
       "lineCount": 159,
@@ -167,6 +192,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "filename": "ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "lineCount": 79,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ04.lean",
       "filename": "ArithmeticSeriesOQ04.lean",
       "lineCount": 198,
@@ -176,17 +212,6 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ04.lean"
-    },
-    {
-      "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
-      "filename": "ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
-      "lineCount": 365,
-      "theoremCount": 23,
-      "axiomCount": 0,
-      "defCount": 4,
-      "sorryCount": 1,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean"
     }
   ]
 }

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03-oq-02.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03-oq-02.json
@@ -44,11 +44,14 @@
     "arithmetic-series",
     "arithmetic-series-oq-02",
     "arithmetic-series-oq-02-oq-01",
+    "arithmetic-series-oq-02-oq-01-oq-01",
     "arithmetic-series-oq-02-oq-02",
     "arithmetic-series-oq-02-oq-02-oq-01",
     "arithmetic-series-oq-02-oq-02-oq-03",
+    "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
     "arithmetic-series-oq-02-oq-04",
     "arithmetic-series-oq-02-oq-04-oq-01",
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-03",
     "arithmetic-series-oq-04"
   ],
   "references": {
@@ -95,6 +98,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "lineCount": 191,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ02OQ02.lean",
       "filename": "ArithmeticSeriesOQ02OQ02.lean",
       "lineCount": 155,
@@ -128,6 +142,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "lineCount": 366,
+      "theoremCount": 27,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ02OQ04.lean",
       "filename": "ArithmeticSeriesOQ02OQ04.lean",
       "lineCount": 159,
@@ -148,6 +173,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "filename": "ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "lineCount": 79,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean"
     },
     {
       "path": "Proofs/ArithmeticSeriesOQ04.lean",

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03-oq-04.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03-oq-04.json
@@ -44,11 +44,14 @@
     "arithmetic-series",
     "arithmetic-series-oq-02",
     "arithmetic-series-oq-02-oq-01",
+    "arithmetic-series-oq-02-oq-01-oq-01",
     "arithmetic-series-oq-02-oq-02",
     "arithmetic-series-oq-02-oq-02-oq-01",
     "arithmetic-series-oq-02-oq-02-oq-03",
+    "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
     "arithmetic-series-oq-02-oq-04",
     "arithmetic-series-oq-02-oq-04-oq-01",
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-03",
     "arithmetic-series-oq-04"
   ],
   "references": {
@@ -95,6 +98,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "lineCount": 191,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ02OQ02.lean",
       "filename": "ArithmeticSeriesOQ02OQ02.lean",
       "lineCount": 155,
@@ -128,6 +142,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "lineCount": 366,
+      "theoremCount": 27,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ02OQ04.lean",
       "filename": "ArithmeticSeriesOQ02OQ04.lean",
       "lineCount": 159,
@@ -148,6 +173,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "filename": "ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "lineCount": 79,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean"
     },
     {
       "path": "Proofs/ArithmeticSeriesOQ04.lean",

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03.json
@@ -41,11 +41,14 @@
     "arithmetic-series",
     "arithmetic-series-oq-02",
     "arithmetic-series-oq-02-oq-01",
+    "arithmetic-series-oq-02-oq-01-oq-01",
     "arithmetic-series-oq-02-oq-02",
     "arithmetic-series-oq-02-oq-02-oq-01",
     "arithmetic-series-oq-02-oq-02-oq-03",
+    "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
     "arithmetic-series-oq-02-oq-04",
     "arithmetic-series-oq-02-oq-04-oq-01",
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-03",
     "arithmetic-series-oq-04"
   ],
   "references": {
@@ -90,6 +93,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "lineCount": 191,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ02OQ02.lean",
       "filename": "ArithmeticSeriesOQ02OQ02.lean",
       "lineCount": 155,
@@ -123,6 +137,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "lineCount": 366,
+      "theoremCount": 27,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ02OQ04.lean",
       "filename": "ArithmeticSeriesOQ02OQ04.lean",
       "lineCount": 159,
@@ -143,6 +168,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "filename": "ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "lineCount": 79,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean"
     },
     {
       "path": "Proofs/ArithmeticSeriesOQ04.lean",

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-04.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-04.json
@@ -41,11 +41,14 @@
     "arithmetic-series",
     "arithmetic-series-oq-02",
     "arithmetic-series-oq-02-oq-01",
+    "arithmetic-series-oq-02-oq-01-oq-01",
     "arithmetic-series-oq-02-oq-02",
     "arithmetic-series-oq-02-oq-02-oq-01",
     "arithmetic-series-oq-02-oq-02-oq-03",
+    "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
     "arithmetic-series-oq-02-oq-04",
     "arithmetic-series-oq-02-oq-04-oq-01",
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-03",
     "arithmetic-series-oq-04"
   ],
   "references": {
@@ -90,6 +93,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "lineCount": 191,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ02OQ02.lean",
       "filename": "ArithmeticSeriesOQ02OQ02.lean",
       "lineCount": 155,
@@ -123,6 +137,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "lineCount": 366,
+      "theoremCount": 27,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ02OQ04.lean",
       "filename": "ArithmeticSeriesOQ02OQ04.lean",
       "lineCount": 159,
@@ -143,6 +168,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "filename": "ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "lineCount": 79,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean"
     },
     {
       "path": "Proofs/ArithmeticSeriesOQ04.lean",

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02.json
@@ -70,6 +70,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "lineCount": 191,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ02OQ02.lean",
       "filename": "ArithmeticSeriesOQ02OQ02.lean",
       "lineCount": 155,
@@ -103,6 +114,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "lineCount": 366,
+      "theoremCount": 27,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ02OQ04.lean",
       "filename": "ArithmeticSeriesOQ02OQ04.lean",
       "lineCount": 159,
@@ -125,6 +147,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "filename": "ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "lineCount": 79,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ04.lean",
       "filename": "ArithmeticSeriesOQ04.lean",
       "lineCount": 198,
@@ -140,11 +173,14 @@
     "arithmetic-series",
     "arithmetic-series-oq-02",
     "arithmetic-series-oq-02-oq-01",
+    "arithmetic-series-oq-02-oq-01-oq-01",
     "arithmetic-series-oq-02-oq-02",
     "arithmetic-series-oq-02-oq-02-oq-01",
     "arithmetic-series-oq-02-oq-02-oq-03",
+    "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
     "arithmetic-series-oq-02-oq-04",
     "arithmetic-series-oq-02-oq-04-oq-01",
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-03",
     "arithmetic-series-oq-04"
   ]
 }

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03.json
@@ -62,9 +62,19 @@
     "binomial-coefficients"
   ],
   "relatedProofs": [
+    "arithmetic-series",
+    "arithmetic-series-oq-02",
+    "arithmetic-series-oq-02-oq-01",
+    "arithmetic-series-oq-02-oq-01-oq-01",
+    "arithmetic-series-oq-02-oq-02",
+    "arithmetic-series-oq-02-oq-02-oq-01",
+    "arithmetic-series-oq-02-oq-02-oq-03",
+    "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
+    "arithmetic-series-oq-02-oq-04",
     "arithmetic-series-oq-02-oq-04-oq-01",
-    "binomial-theorem-oq-03",
-    "arithmetic-series-oq-02-oq-01-oq-01"
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-03",
+    "arithmetic-series-oq-04",
+    "binomial-theorem-oq-03"
   ],
   "references": {
     "papers": [],
@@ -75,15 +85,136 @@
   "lastUpdate": "2026-04-05T06:55:50.103Z",
   "leanFiles": [
     {
+      "path": "Proofs/ArithmeticSeries.lean",
+      "filename": "ArithmeticSeries.lean",
+      "lineCount": 181,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeries.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02.lean",
+      "filename": "ArithmeticSeriesOQ02.lean",
+      "lineCount": 210,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ01.lean",
+      "lineCount": 174,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "lineCount": 191,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ02.lean",
+      "filename": "ArithmeticSeriesOQ02OQ02.lean",
+      "lineCount": 155,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ02OQ01.lean",
+      "lineCount": 166,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ03.lean",
+      "filename": "ArithmeticSeriesOQ02OQ02OQ03.lean",
+      "lineCount": 208,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "lineCount": 366,
+      "theoremCount": 27,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ04.lean",
+      "filename": "ArithmeticSeriesOQ02OQ04.lean",
+      "lineCount": 159,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ04OQ01.lean",
+      "lineCount": 170,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
       "filename": "ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
-      "lineCount": 78,
+      "lineCount": 79,
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ04.lean",
+      "filename": "ArithmeticSeriesOQ04.lean",
+      "lineCount": 198,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ04.lean"
     }
   ]
 }

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01.json
@@ -58,11 +58,14 @@
     "arithmetic-series",
     "arithmetic-series-oq-02",
     "arithmetic-series-oq-02-oq-01",
+    "arithmetic-series-oq-02-oq-01-oq-01",
     "arithmetic-series-oq-02-oq-02",
     "arithmetic-series-oq-02-oq-02-oq-01",
     "arithmetic-series-oq-02-oq-02-oq-03",
+    "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
     "arithmetic-series-oq-02-oq-04",
     "arithmetic-series-oq-02-oq-04-oq-01",
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-03",
     "arithmetic-series-oq-04"
   ],
   "references": {
@@ -109,6 +112,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "lineCount": 191,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ02OQ02.lean",
       "filename": "ArithmeticSeriesOQ02OQ02.lean",
       "lineCount": 155,
@@ -142,6 +156,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "lineCount": 366,
+      "theoremCount": 27,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ02OQ04.lean",
       "filename": "ArithmeticSeriesOQ02OQ04.lean",
       "lineCount": 159,
@@ -162,6 +187,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "filename": "ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "lineCount": 79,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean"
     },
     {
       "path": "Proofs/ArithmeticSeriesOQ04.lean",

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-04.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-04.json
@@ -44,11 +44,14 @@
     "arithmetic-series",
     "arithmetic-series-oq-02",
     "arithmetic-series-oq-02-oq-01",
+    "arithmetic-series-oq-02-oq-01-oq-01",
     "arithmetic-series-oq-02-oq-02",
     "arithmetic-series-oq-02-oq-02-oq-01",
     "arithmetic-series-oq-02-oq-02-oq-03",
+    "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
     "arithmetic-series-oq-02-oq-04",
     "arithmetic-series-oq-02-oq-04-oq-01",
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-03",
     "arithmetic-series-oq-04"
   ],
   "references": {
@@ -96,6 +99,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "lineCount": 191,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ02OQ02.lean",
       "filename": "ArithmeticSeriesOQ02OQ02.lean",
       "lineCount": 155,
@@ -129,6 +143,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "lineCount": 366,
+      "theoremCount": 27,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ02OQ04.lean",
       "filename": "ArithmeticSeriesOQ02OQ04.lean",
       "lineCount": 159,
@@ -149,6 +174,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "filename": "ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "lineCount": 79,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean"
     },
     {
       "path": "Proofs/ArithmeticSeriesOQ04.lean",

--- a/src/data/research/problems/arithmetic-series-oq-02.json
+++ b/src/data/research/problems/arithmetic-series-oq-02.json
@@ -47,11 +47,14 @@
     "arithmetic-series",
     "arithmetic-series-oq-02",
     "arithmetic-series-oq-02-oq-01",
+    "arithmetic-series-oq-02-oq-01-oq-01",
     "arithmetic-series-oq-02-oq-02",
     "arithmetic-series-oq-02-oq-02-oq-01",
     "arithmetic-series-oq-02-oq-02-oq-03",
+    "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
     "arithmetic-series-oq-02-oq-04",
     "arithmetic-series-oq-02-oq-04-oq-01",
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-03",
     "arithmetic-series-oq-04"
   ],
   "references": {
@@ -99,6 +102,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "lineCount": 191,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ02OQ02.lean",
       "filename": "ArithmeticSeriesOQ02OQ02.lean",
       "lineCount": 155,
@@ -132,6 +146,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "lineCount": 366,
+      "theoremCount": 27,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ02OQ04.lean",
       "filename": "ArithmeticSeriesOQ02OQ04.lean",
       "lineCount": 159,
@@ -152,6 +177,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "filename": "ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "lineCount": 79,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean"
     },
     {
       "path": "Proofs/ArithmeticSeriesOQ04.lean",

--- a/src/data/research/problems/arithmetic-series-oq-03.json
+++ b/src/data/research/problems/arithmetic-series-oq-03.json
@@ -44,11 +44,14 @@
     "arithmetic-series",
     "arithmetic-series-oq-02",
     "arithmetic-series-oq-02-oq-01",
+    "arithmetic-series-oq-02-oq-01-oq-01",
     "arithmetic-series-oq-02-oq-02",
     "arithmetic-series-oq-02-oq-02-oq-01",
     "arithmetic-series-oq-02-oq-02-oq-03",
+    "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
     "arithmetic-series-oq-02-oq-04",
     "arithmetic-series-oq-02-oq-04-oq-01",
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-03",
     "arithmetic-series-oq-04"
   ],
   "references": {
@@ -95,6 +98,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "lineCount": 191,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ02OQ02.lean",
       "filename": "ArithmeticSeriesOQ02OQ02.lean",
       "lineCount": 155,
@@ -128,6 +142,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "lineCount": 366,
+      "theoremCount": 27,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ02OQ04.lean",
       "filename": "ArithmeticSeriesOQ02OQ04.lean",
       "lineCount": 159,
@@ -148,6 +173,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "filename": "ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "lineCount": 79,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean"
     },
     {
       "path": "Proofs/ArithmeticSeriesOQ04.lean",

--- a/src/data/research/problems/arithmetic-series-oq-04.json
+++ b/src/data/research/problems/arithmetic-series-oq-04.json
@@ -56,11 +56,14 @@
     "arithmetic-series",
     "arithmetic-series-oq-02",
     "arithmetic-series-oq-02-oq-01",
+    "arithmetic-series-oq-02-oq-01-oq-01",
     "arithmetic-series-oq-02-oq-02",
     "arithmetic-series-oq-02-oq-02-oq-01",
     "arithmetic-series-oq-02-oq-02-oq-03",
+    "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
     "arithmetic-series-oq-02-oq-04",
     "arithmetic-series-oq-02-oq-04-oq-01",
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-03",
     "arithmetic-series-oq-04"
   ],
   "references": {
@@ -107,6 +110,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ01OQ01.lean",
+      "lineCount": 191,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ02OQ02.lean",
       "filename": "ArithmeticSeriesOQ02OQ02.lean",
       "lineCount": 155,
@@ -140,6 +154,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03.lean"
     },
     {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "filename": "ArithmeticSeriesOQ02OQ02OQ03OQ01.lean",
+      "lineCount": 366,
+      "theoremCount": 27,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean"
+    },
+    {
       "path": "Proofs/ArithmeticSeriesOQ02OQ04.lean",
       "filename": "ArithmeticSeriesOQ02OQ04.lean",
       "lineCount": 159,
@@ -160,6 +185,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "filename": "ArithmeticSeriesOQ02OQ04OQ01OQ03.lean",
+      "lineCount": 79,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03.lean"
     },
     {
       "path": "Proofs/ArithmeticSeriesOQ04.lean",

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-01.json
@@ -112,6 +112,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02.lean"
     },
     {
+      "path": "Proofs/BallotProblemOQ01OQ02OQ02.lean",
+      "filename": "BallotProblemOQ01OQ02OQ02.lean",
+      "lineCount": 261,
+      "theoremCount": 15,
+      "axiomCount": 2,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02OQ02.lean"
+    },
+    {
       "path": "Proofs/BallotProblemOQ01OQ04.lean",
       "filename": "BallotProblemOQ01OQ04.lean",
       "lineCount": 188,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02.json
@@ -129,6 +129,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02.lean"
     },
     {
+      "path": "Proofs/BallotProblemOQ01OQ02OQ02.lean",
+      "filename": "BallotProblemOQ01OQ02OQ02.lean",
+      "lineCount": 261,
+      "theoremCount": 15,
+      "axiomCount": 2,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02OQ02.lean"
+    },
+    {
       "path": "Proofs/BallotProblemOQ01OQ04.lean",
       "filename": "BallotProblemOQ01OQ04.lean",
       "lineCount": 188,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01.json
@@ -113,6 +113,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02.lean"
     },
     {
+      "path": "Proofs/BallotProblemOQ01OQ02OQ02.lean",
+      "filename": "BallotProblemOQ01OQ02OQ02.lean",
+      "lineCount": 261,
+      "theoremCount": 15,
+      "axiomCount": 2,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02OQ02.lean"
+    },
+    {
       "path": "Proofs/BallotProblemOQ01OQ04.lean",
       "filename": "BallotProblemOQ01OQ04.lean",
       "lineCount": 188,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01.json
@@ -105,6 +105,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02.lean"
     },
     {
+      "path": "Proofs/BallotProblemOQ01OQ02OQ02.lean",
+      "filename": "BallotProblemOQ01OQ02OQ02.lean",
+      "lineCount": 261,
+      "theoremCount": 15,
+      "axiomCount": 2,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02OQ02.lean"
+    },
+    {
       "path": "Proofs/BallotProblemOQ01OQ04.lean",
       "filename": "BallotProblemOQ01OQ04.lean",
       "lineCount": 188,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-02.json
@@ -91,8 +91,14 @@
   "relatedProofs": [
     "ballot-problem",
     "ballot-problem-oq-01",
+    "ballot-problem-oq-01-oq-01",
     "ballot-problem-oq-01-oq-02",
-    "ballot-problem-oq-01-oq-02-oq-01"
+    "ballot-problem-oq-01-oq-02-oq-01",
+    "ballot-problem-oq-01-oq-04",
+    "ballot-problem-oq-02",
+    "ballot-problem-oq-03",
+    "ballot-problem-oq-03-oq-01",
+    "ballot-problem-oq-03-oq-02"
   ],
   "references": {
     "papers": [
@@ -114,15 +120,136 @@
   "tractability": 6,
   "leanFiles": [
     {
+      "path": "Proofs/BallotProblem.lean",
+      "filename": "BallotProblem.lean",
+      "lineCount": 252,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblem.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ01.lean",
+      "filename": "BallotProblemOQ01.lean",
+      "lineCount": 790,
+      "theoremCount": 44,
+      "axiomCount": 0,
+      "defCount": 8,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ01OQ01.lean",
+      "filename": "BallotProblemOQ01OQ01.lean",
+      "lineCount": 152,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ01OQ02.lean",
+      "filename": "BallotProblemOQ01OQ02.lean",
+      "lineCount": 935,
+      "theoremCount": 36,
+      "axiomCount": 1,
+      "defCount": 18,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02.lean"
+    },
+    {
       "path": "Proofs/BallotProblemOQ01OQ02OQ02.lean",
       "filename": "BallotProblemOQ01OQ02OQ02.lean",
-      "lineCount": 240,
-      "theoremCount": 13,
+      "lineCount": 261,
+      "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ01OQ04.lean",
+      "filename": "BallotProblemOQ01OQ04.lean",
+      "lineCount": 188,
+      "theoremCount": 9,
+      "axiomCount": 1,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ04.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ01OQ04OQ01.lean",
+      "filename": "BallotProblemOQ01OQ04OQ01.lean",
+      "lineCount": 1102,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ04OQ01.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ02.lean",
+      "filename": "BallotProblemOQ02.lean",
+      "lineCount": 340,
+      "theoremCount": 8,
+      "axiomCount": 2,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ02.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ02OQ02.lean",
+      "filename": "BallotProblemOQ02OQ02.lean",
+      "lineCount": 186,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ02OQ02.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ03.lean",
+      "filename": "BallotProblemOQ03.lean",
+      "lineCount": 2879,
+      "theoremCount": 119,
+      "axiomCount": 0,
+      "defCount": 31,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ03OQ02.lean",
+      "filename": "BallotProblemOQ03OQ02.lean",
+      "lineCount": 2315,
+      "theoremCount": 28,
+      "axiomCount": 0,
+      "defCount": 23,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/BallotProblemOQ03OQ03.lean",
+      "filename": "BallotProblemOQ03OQ03.lean",
+      "lineCount": 188,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ03.lean"
     }
   ]
 }

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02.json
@@ -80,6 +80,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02.lean"
     },
     {
+      "path": "Proofs/BallotProblemOQ01OQ02OQ02.lean",
+      "filename": "BallotProblemOQ01OQ02OQ02.lean",
+      "lineCount": 261,
+      "theoremCount": 15,
+      "axiomCount": 2,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02OQ02.lean"
+    },
+    {
       "path": "Proofs/BallotProblemOQ01OQ04.lean",
       "filename": "BallotProblemOQ01OQ04.lean",
       "lineCount": 188,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-04-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-04-oq-01.json
@@ -135,6 +135,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02.lean"
     },
     {
+      "path": "Proofs/BallotProblemOQ01OQ02OQ02.lean",
+      "filename": "BallotProblemOQ01OQ02OQ02.lean",
+      "lineCount": 261,
+      "theoremCount": 15,
+      "axiomCount": 2,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02OQ02.lean"
+    },
+    {
       "path": "Proofs/BallotProblemOQ01OQ04.lean",
       "filename": "BallotProblemOQ01OQ04.lean",
       "lineCount": 188,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-04.json
@@ -119,6 +119,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02.lean"
     },
     {
+      "path": "Proofs/BallotProblemOQ01OQ02OQ02.lean",
+      "filename": "BallotProblemOQ01OQ02OQ02.lean",
+      "lineCount": 261,
+      "theoremCount": 15,
+      "axiomCount": 2,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02OQ02.lean"
+    },
+    {
       "path": "Proofs/BallotProblemOQ01OQ04.lean",
       "filename": "BallotProblemOQ01OQ04.lean",
       "lineCount": 188,

--- a/src/data/research/problems/ballot-problem-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01.json
@@ -108,6 +108,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02.lean"
     },
     {
+      "path": "Proofs/BallotProblemOQ01OQ02OQ02.lean",
+      "filename": "BallotProblemOQ01OQ02OQ02.lean",
+      "lineCount": 261,
+      "theoremCount": 15,
+      "axiomCount": 2,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02OQ02.lean"
+    },
+    {
       "path": "Proofs/BallotProblemOQ01OQ04.lean",
       "filename": "BallotProblemOQ01OQ04.lean",
       "lineCount": 188,

--- a/src/data/research/problems/ballot-problem-oq-02-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-02-oq-02.json
@@ -104,6 +104,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02.lean"
     },
     {
+      "path": "Proofs/BallotProblemOQ01OQ02OQ02.lean",
+      "filename": "BallotProblemOQ01OQ02OQ02.lean",
+      "lineCount": 261,
+      "theoremCount": 15,
+      "axiomCount": 2,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02OQ02.lean"
+    },
+    {
       "path": "Proofs/BallotProblemOQ01OQ04.lean",
       "filename": "BallotProblemOQ01OQ04.lean",
       "lineCount": 188,

--- a/src/data/research/problems/ballot-problem-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-02.json
@@ -109,6 +109,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02.lean"
     },
     {
+      "path": "Proofs/BallotProblemOQ01OQ02OQ02.lean",
+      "filename": "BallotProblemOQ01OQ02OQ02.lean",
+      "lineCount": 261,
+      "theoremCount": 15,
+      "axiomCount": 2,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02OQ02.lean"
+    },
+    {
       "path": "Proofs/BallotProblemOQ01OQ04.lean",
       "filename": "BallotProblemOQ01OQ04.lean",
       "lineCount": 188,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01.json
@@ -110,6 +110,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02.lean"
     },
     {
+      "path": "Proofs/BallotProblemOQ01OQ02OQ02.lean",
+      "filename": "BallotProblemOQ01OQ02OQ02.lean",
+      "lineCount": 261,
+      "theoremCount": 15,
+      "axiomCount": 2,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02OQ02.lean"
+    },
+    {
       "path": "Proofs/BallotProblemOQ01OQ04.lean",
       "filename": "BallotProblemOQ01OQ04.lean",
       "lineCount": 188,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01.json
@@ -80,6 +80,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02.lean"
     },
     {
+      "path": "Proofs/BallotProblemOQ01OQ02OQ02.lean",
+      "filename": "BallotProblemOQ01OQ02OQ02.lean",
+      "lineCount": 261,
+      "theoremCount": 15,
+      "axiomCount": 2,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02OQ02.lean"
+    },
+    {
       "path": "Proofs/BallotProblemOQ01OQ04.lean",
       "filename": "BallotProblemOQ01OQ04.lean",
       "lineCount": 188,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-02.json
@@ -139,6 +139,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02.lean"
     },
     {
+      "path": "Proofs/BallotProblemOQ01OQ02OQ02.lean",
+      "filename": "BallotProblemOQ01OQ02OQ02.lean",
+      "lineCount": 261,
+      "theoremCount": 15,
+      "axiomCount": 2,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02OQ02.lean"
+    },
+    {
       "path": "Proofs/BallotProblemOQ01OQ04.lean",
       "filename": "BallotProblemOQ01OQ04.lean",
       "lineCount": 188,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-03.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-03.json
@@ -116,6 +116,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02.lean"
     },
     {
+      "path": "Proofs/BallotProblemOQ01OQ02OQ02.lean",
+      "filename": "BallotProblemOQ01OQ02OQ02.lean",
+      "lineCount": 261,
+      "theoremCount": 15,
+      "axiomCount": 2,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02OQ02.lean"
+    },
+    {
       "path": "Proofs/BallotProblemOQ01OQ04.lean",
       "filename": "BallotProblemOQ01OQ04.lean",
       "lineCount": 188,

--- a/src/data/research/problems/ballot-problem-oq-03.json
+++ b/src/data/research/problems/ballot-problem-oq-03.json
@@ -115,6 +115,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02.lean"
     },
     {
+      "path": "Proofs/BallotProblemOQ01OQ02OQ02.lean",
+      "filename": "BallotProblemOQ01OQ02OQ02.lean",
+      "lineCount": 261,
+      "theoremCount": 15,
+      "axiomCount": 2,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ02OQ02.lean"
+    },
+    {
       "path": "Proofs/BallotProblemOQ01OQ04.lean",
       "filename": "BallotProblemOQ01OQ04.lean",
       "lineCount": 188,

--- a/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02.json
@@ -45,6 +45,7 @@
     "basel-problem",
     "basel-problem-oq-01",
     "basel-problem-oq-01-oq-01",
+    "basel-problem-oq-01-oq-03",
     "basel-problem-oq-02",
     "basel-problem-oq-05"
   ],
@@ -77,6 +78,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ03.lean",
+      "filename": "BaselProblemOQ01OQ03.lean",
+      "lineCount": 214,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ03.lean"
     },
     {
       "path": "Proofs/BaselProblemOQ02.lean",

--- a/src/data/research/problems/basel-problem-oq-01-oq-01.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-01.json
@@ -41,6 +41,7 @@
     "basel-problem",
     "basel-problem-oq-01",
     "basel-problem-oq-01-oq-01",
+    "basel-problem-oq-01-oq-03",
     "basel-problem-oq-02",
     "basel-problem-oq-05"
   ],
@@ -73,6 +74,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ03.lean",
+      "filename": "BaselProblemOQ01OQ03.lean",
+      "lineCount": 214,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ03.lean"
     },
     {
       "path": "Proofs/BaselProblemOQ02.lean",

--- a/src/data/research/problems/basel-problem-oq-01-oq-02.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-02.json
@@ -41,6 +41,7 @@
     "basel-problem",
     "basel-problem-oq-01",
     "basel-problem-oq-01-oq-01",
+    "basel-problem-oq-01-oq-03",
     "basel-problem-oq-02",
     "basel-problem-oq-05"
   ],
@@ -73,6 +74,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ03.lean",
+      "filename": "BaselProblemOQ01OQ03.lean",
+      "lineCount": 214,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ03.lean"
     },
     {
       "path": "Proofs/BaselProblemOQ02.lean",

--- a/src/data/research/problems/basel-problem-oq-01-oq-03.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-03.json
@@ -44,6 +44,7 @@
     "basel-problem",
     "basel-problem-oq-01",
     "basel-problem-oq-01-oq-01",
+    "basel-problem-oq-01-oq-03",
     "basel-problem-oq-02",
     "basel-problem-oq-05"
   ],
@@ -78,6 +79,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ03.lean",
+      "filename": "BaselProblemOQ01OQ03.lean",
+      "lineCount": 214,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ03.lean"
     },
     {
       "path": "Proofs/BaselProblemOQ02.lean",

--- a/src/data/research/problems/basel-problem-oq-01.json
+++ b/src/data/research/problems/basel-problem-oq-01.json
@@ -50,6 +50,7 @@
     "basel-problem",
     "basel-problem-oq-01",
     "basel-problem-oq-01-oq-01",
+    "basel-problem-oq-01-oq-03",
     "basel-problem-oq-02",
     "basel-problem-oq-05"
   ],
@@ -85,6 +86,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ03.lean",
+      "filename": "BaselProblemOQ01OQ03.lean",
+      "lineCount": 214,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ03.lean"
     },
     {
       "path": "Proofs/BaselProblemOQ02.lean",

--- a/src/data/research/problems/basel-problem-oq-02.json
+++ b/src/data/research/problems/basel-problem-oq-02.json
@@ -78,6 +78,7 @@
   "relatedProofs": [
     "basel-problem",
     "basel-problem-oq-01-oq-01",
+    "basel-problem-oq-01-oq-03",
     "basel-problem-oq-02",
     "basel-problem-oq-05"
   ],
@@ -112,6 +113,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ03.lean",
+      "filename": "BaselProblemOQ01OQ03.lean",
+      "lineCount": 214,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ03.lean"
     },
     {
       "path": "Proofs/BaselProblemOQ02.lean",

--- a/src/data/research/problems/basel-problem-oq-04.json
+++ b/src/data/research/problems/basel-problem-oq-04.json
@@ -44,6 +44,7 @@
   "relatedProofs": [
     "basel-problem",
     "basel-problem-oq-01-oq-01",
+    "basel-problem-oq-01-oq-03",
     "basel-problem-oq-02",
     "basel-problem-oq-05"
   ],
@@ -76,6 +77,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ03.lean",
+      "filename": "BaselProblemOQ01OQ03.lean",
+      "lineCount": 214,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ03.lean"
     },
     {
       "path": "Proofs/BaselProblemOQ02.lean",

--- a/src/data/research/problems/basel-problem-oq-05-oq-01.json
+++ b/src/data/research/problems/basel-problem-oq-05-oq-01.json
@@ -55,6 +55,7 @@
   "relatedProofs": [
     "basel-problem",
     "basel-problem-oq-01-oq-01",
+    "basel-problem-oq-01-oq-03",
     "basel-problem-oq-02",
     "basel-problem-oq-05"
   ],
@@ -87,6 +88,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ03.lean",
+      "filename": "BaselProblemOQ01OQ03.lean",
+      "lineCount": 214,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ03.lean"
     },
     {
       "path": "Proofs/BaselProblemOQ02.lean",

--- a/src/data/research/problems/basel-problem-oq-05-oq-02.json
+++ b/src/data/research/problems/basel-problem-oq-05-oq-02.json
@@ -43,6 +43,7 @@
   "relatedProofs": [
     "basel-problem",
     "basel-problem-oq-01-oq-01",
+    "basel-problem-oq-01-oq-03",
     "basel-problem-oq-02",
     "basel-problem-oq-05"
   ],
@@ -77,6 +78,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ03.lean",
+      "filename": "BaselProblemOQ01OQ03.lean",
+      "lineCount": 214,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ03.lean"
     },
     {
       "path": "Proofs/BaselProblemOQ02.lean",

--- a/src/data/research/problems/basel-problem-oq-05.json
+++ b/src/data/research/problems/basel-problem-oq-05.json
@@ -55,6 +55,7 @@
   "relatedProofs": [
     "basel-problem",
     "basel-problem-oq-01-oq-01",
+    "basel-problem-oq-01-oq-03",
     "basel-problem-oq-02",
     "basel-problem-oq-05"
   ],
@@ -89,6 +90,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BaselProblemOQ01OQ03.lean",
+      "filename": "BaselProblemOQ01OQ03.lean",
+      "lineCount": 214,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ03.lean"
     },
     {
       "path": "Proofs/BaselProblemOQ02.lean",

--- a/src/data/research/problems/bertrands-postulate-oq-03-oq-01.json
+++ b/src/data/research/problems/bertrands-postulate-oq-03-oq-01.json
@@ -69,7 +69,8 @@
   ],
   "relatedProofs": [
     "bertrands-postulate",
-    "bertrands-postulate-oq-03"
+    "bertrands-postulate-oq-03",
+    "bertrands-postulate-oq-03-oq-04"
   ],
   "references": {
     "papers": [
@@ -89,7 +90,7 @@
     {
       "path": "Proofs/BertrandsPostulate.lean",
       "filename": "BertrandsPostulate.lean",
-      "lineCount": 165,
+      "lineCount": 166,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
@@ -100,13 +101,24 @@
     {
       "path": "Proofs/BertrandsPostulateOQ03.lean",
       "filename": "BertrandsPostulateOQ03.lean",
-      "lineCount": 308,
+      "lineCount": 309,
       "theoremCount": 12,
       "axiomCount": 3,
       "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BertrandsPostulateOQ03.lean"
+    },
+    {
+      "path": "Proofs/BertrandsPostulateOQ03OQ04.lean",
+      "filename": "BertrandsPostulateOQ03OQ04.lean",
+      "lineCount": 324,
+      "theoremCount": 6,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 3,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BertrandsPostulateOQ03OQ04.lean"
     }
   ]
 }

--- a/src/data/research/problems/bertrands-postulate-oq-03-oq-04.json
+++ b/src/data/research/problems/bertrands-postulate-oq-03-oq-04.json
@@ -52,7 +52,8 @@
   ],
   "relatedProofs": [
     "bertrands-postulate",
-    "bertrands-postulate-oq-03"
+    "bertrands-postulate-oq-03",
+    "bertrands-postulate-oq-03-oq-04"
   ],
   "references": {
     "papers": [],
@@ -85,6 +86,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BertrandsPostulateOQ03.lean"
+    },
+    {
+      "path": "Proofs/BertrandsPostulateOQ03OQ04.lean",
+      "filename": "BertrandsPostulateOQ03OQ04.lean",
+      "lineCount": 324,
+      "theoremCount": 6,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 3,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BertrandsPostulateOQ03OQ04.lean"
     }
   ]
 }

--- a/src/data/research/problems/bertrands-postulate-oq-03.json
+++ b/src/data/research/problems/bertrands-postulate-oq-03.json
@@ -45,7 +45,8 @@
   ],
   "relatedProofs": [
     "bertrands-postulate",
-    "bertrands-postulate-oq-03"
+    "bertrands-postulate-oq-03",
+    "bertrands-postulate-oq-03-oq-04"
   ],
   "references": {
     "papers": [],
@@ -79,6 +80,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BertrandsPostulateOQ03.lean"
+    },
+    {
+      "path": "Proofs/BertrandsPostulateOQ03OQ04.lean",
+      "filename": "BertrandsPostulateOQ03OQ04.lean",
+      "lineCount": 324,
+      "theoremCount": 6,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 3,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BertrandsPostulateOQ03OQ04.lean"
     }
   ]
 }

--- a/src/data/research/problems/bertrands-postulate-oq-04.json
+++ b/src/data/research/problems/bertrands-postulate-oq-04.json
@@ -49,7 +49,8 @@
   ],
   "relatedProofs": [
     "bertrands-postulate",
-    "bertrands-postulate-oq-03"
+    "bertrands-postulate-oq-03",
+    "bertrands-postulate-oq-03-oq-04"
   ],
   "references": {
     "papers": [],
@@ -82,6 +83,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BertrandsPostulateOQ03.lean"
+    },
+    {
+      "path": "Proofs/BertrandsPostulateOQ03OQ04.lean",
+      "filename": "BertrandsPostulateOQ03OQ04.lean",
+      "lineCount": 324,
+      "theoremCount": 6,
+      "axiomCount": 1,
+      "defCount": 2,
+      "sorryCount": 3,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BertrandsPostulateOQ03OQ04.lean"
     }
   ]
 }

--- a/src/data/research/problems/bezout-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01.json
@@ -46,7 +46,9 @@
     "bezout-identity-oq-02",
     "bezout-identity-oq-02-oq-01",
     "bezout-identity-oq-02-oq-01-oq-01",
+    "bezout-identity-oq-02-oq-01-oq-01-oq-01",
     "bezout-identity-oq-02-oq-01-oq-02",
+    "bezout-identity-oq-02-oq-01-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02-oq-01",
     "bezout-identity-oq-02-oq-02-oq-01-oq-01",
@@ -104,6 +106,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01Aristotle.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ01OQ01.lean",
+      "lineCount": 189,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
       "lineCount": 193,
@@ -137,6 +150,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "lineCount": 128,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
       "lineCount": 68,
@@ -146,6 +170,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "lineCount": 194,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean"
     },
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
@@ -271,7 +306,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 336,
+      "lineCount": 408,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -43,7 +43,9 @@
     "bezout-identity-oq-02",
     "bezout-identity-oq-02-oq-01",
     "bezout-identity-oq-02-oq-01-oq-01",
+    "bezout-identity-oq-02-oq-01-oq-01-oq-01",
     "bezout-identity-oq-02-oq-01-oq-02",
+    "bezout-identity-oq-02-oq-01-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02-oq-01",
     "bezout-identity-oq-02-oq-02-oq-01-oq-01",
@@ -100,6 +102,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01Aristotle.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ01OQ01.lean",
+      "lineCount": 189,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
       "lineCount": 193,
@@ -133,6 +146,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "lineCount": 128,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
       "lineCount": 68,
@@ -142,6 +166,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "lineCount": 194,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean"
     },
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
@@ -267,7 +302,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 336,
+      "lineCount": 408,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
@@ -50,7 +50,9 @@
     "bezout-identity-oq-02",
     "bezout-identity-oq-02-oq-01",
     "bezout-identity-oq-02-oq-01-oq-01",
+    "bezout-identity-oq-02-oq-01-oq-01-oq-01",
     "bezout-identity-oq-02-oq-01-oq-02",
+    "bezout-identity-oq-02-oq-01-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02-oq-01",
     "bezout-identity-oq-02-oq-02-oq-01-oq-01",
@@ -107,6 +109,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01Aristotle.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ01OQ01.lean",
+      "lineCount": 189,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
       "lineCount": 193,
@@ -140,6 +153,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "lineCount": 128,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
       "lineCount": 68,
@@ -149,6 +173,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "lineCount": 194,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean"
     },
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
@@ -274,7 +309,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 336,
+      "lineCount": 408,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
@@ -47,7 +47,9 @@
     "bezout-identity-oq-02",
     "bezout-identity-oq-02-oq-01",
     "bezout-identity-oq-02-oq-01-oq-01",
+    "bezout-identity-oq-02-oq-01-oq-01-oq-01",
     "bezout-identity-oq-02-oq-01-oq-02",
+    "bezout-identity-oq-02-oq-01-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02-oq-01",
     "bezout-identity-oq-02-oq-02-oq-01-oq-01",
@@ -105,6 +107,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01Aristotle.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ01OQ01.lean",
+      "lineCount": 189,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
       "lineCount": 193,
@@ -138,6 +151,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "lineCount": 128,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
       "lineCount": 68,
@@ -147,6 +171,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "lineCount": 194,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean"
     },
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
@@ -272,7 +307,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 336,
+      "lineCount": 408,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
@@ -47,7 +47,9 @@
     "bezout-identity-oq-02",
     "bezout-identity-oq-02-oq-01",
     "bezout-identity-oq-02-oq-01-oq-01",
+    "bezout-identity-oq-02-oq-01-oq-01-oq-01",
     "bezout-identity-oq-02-oq-01-oq-02",
+    "bezout-identity-oq-02-oq-01-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02-oq-01",
     "bezout-identity-oq-02-oq-02-oq-01-oq-01",
@@ -103,6 +105,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01Aristotle.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ01OQ01.lean",
+      "lineCount": 189,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
       "lineCount": 193,
@@ -136,6 +149,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "lineCount": 128,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
       "lineCount": 68,
@@ -145,6 +169,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "lineCount": 194,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean"
     },
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
@@ -270,7 +305,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 336,
+      "lineCount": 408,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
@@ -47,7 +47,9 @@
     "bezout-identity-oq-02",
     "bezout-identity-oq-02-oq-01",
     "bezout-identity-oq-02-oq-01-oq-01",
+    "bezout-identity-oq-02-oq-01-oq-01-oq-01",
     "bezout-identity-oq-02-oq-01-oq-02",
+    "bezout-identity-oq-02-oq-01-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02-oq-01",
     "bezout-identity-oq-02-oq-02-oq-01-oq-01",
@@ -105,6 +107,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01Aristotle.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ01OQ01.lean",
+      "lineCount": 189,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
       "lineCount": 193,
@@ -138,6 +151,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "lineCount": 128,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
       "lineCount": 68,
@@ -147,6 +171,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "lineCount": 194,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean"
     },
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
@@ -272,7 +307,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 336,
+      "lineCount": 408,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01.json
@@ -50,7 +50,9 @@
     "bezout-identity-oq-02",
     "bezout-identity-oq-02-oq-01",
     "bezout-identity-oq-02-oq-01-oq-01",
+    "bezout-identity-oq-02-oq-01-oq-01-oq-01",
     "bezout-identity-oq-02-oq-01-oq-02",
+    "bezout-identity-oq-02-oq-01-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02-oq-01",
     "bezout-identity-oq-02-oq-02-oq-01-oq-01",
@@ -109,6 +111,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01Aristotle.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ01OQ01.lean",
+      "lineCount": 189,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
       "lineCount": 193,
@@ -142,6 +155,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "lineCount": 128,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
       "lineCount": 68,
@@ -151,6 +175,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "lineCount": 194,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean"
     },
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
@@ -276,7 +311,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 336,
+      "lineCount": 408,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
@@ -46,7 +46,9 @@
     "bezout-identity-oq-02",
     "bezout-identity-oq-02-oq-01",
     "bezout-identity-oq-02-oq-01-oq-01",
+    "bezout-identity-oq-02-oq-01-oq-01-oq-01",
     "bezout-identity-oq-02-oq-01-oq-02",
+    "bezout-identity-oq-02-oq-01-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02-oq-01",
     "bezout-identity-oq-02-oq-02-oq-01-oq-01",
@@ -104,6 +106,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01Aristotle.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ01OQ01.lean",
+      "lineCount": 189,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
       "lineCount": 193,
@@ -137,6 +150,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "lineCount": 128,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
       "lineCount": 68,
@@ -146,6 +170,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "lineCount": 194,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean"
     },
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
@@ -271,7 +306,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 336,
+      "lineCount": 408,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
@@ -47,7 +47,9 @@
     "bezout-identity-oq-02",
     "bezout-identity-oq-02-oq-01",
     "bezout-identity-oq-02-oq-01-oq-01",
+    "bezout-identity-oq-02-oq-01-oq-01-oq-01",
     "bezout-identity-oq-02-oq-01-oq-02",
+    "bezout-identity-oq-02-oq-01-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02-oq-01",
     "bezout-identity-oq-02-oq-02-oq-01-oq-01",
@@ -106,6 +108,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01Aristotle.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ01OQ01.lean",
+      "lineCount": 189,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
       "lineCount": 193,
@@ -139,6 +152,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "lineCount": 128,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
       "lineCount": 68,
@@ -148,6 +172,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "lineCount": 194,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean"
     },
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
@@ -273,7 +308,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 336,
+      "lineCount": 408,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02.json
@@ -47,7 +47,9 @@
     "bezout-identity-oq-02",
     "bezout-identity-oq-02-oq-01",
     "bezout-identity-oq-02-oq-01-oq-01",
+    "bezout-identity-oq-02-oq-01-oq-01-oq-01",
     "bezout-identity-oq-02-oq-01-oq-02",
+    "bezout-identity-oq-02-oq-01-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02-oq-01",
     "bezout-identity-oq-02-oq-02-oq-01-oq-01",
@@ -106,6 +108,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01Aristotle.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ01OQ01.lean",
+      "lineCount": 189,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
       "lineCount": 193,
@@ -139,6 +152,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "lineCount": 128,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
       "lineCount": 68,
@@ -148,6 +172,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "lineCount": 194,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean"
     },
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
@@ -273,7 +308,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 336,
+      "lineCount": 408,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-03.json
@@ -45,7 +45,9 @@
     "bezout-identity-oq-02",
     "bezout-identity-oq-02-oq-01",
     "bezout-identity-oq-02-oq-01-oq-01",
+    "bezout-identity-oq-02-oq-01-oq-01-oq-01",
     "bezout-identity-oq-02-oq-01-oq-02",
+    "bezout-identity-oq-02-oq-01-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02-oq-01",
     "bezout-identity-oq-02-oq-02-oq-01-oq-01",
@@ -103,6 +105,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01Aristotle.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ01OQ01.lean",
+      "lineCount": 189,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
       "lineCount": 193,
@@ -136,6 +149,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "lineCount": 128,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
       "lineCount": 68,
@@ -145,6 +169,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "lineCount": 194,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean"
     },
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
@@ -270,7 +305,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 336,
+      "lineCount": 408,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02.json
@@ -49,7 +49,9 @@
     "bezout-identity-oq-02",
     "bezout-identity-oq-02-oq-01",
     "bezout-identity-oq-02-oq-01-oq-01",
+    "bezout-identity-oq-02-oq-01-oq-01-oq-01",
     "bezout-identity-oq-02-oq-01-oq-02",
+    "bezout-identity-oq-02-oq-01-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02-oq-01",
     "bezout-identity-oq-02-oq-02-oq-01-oq-01",
@@ -108,6 +110,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01Aristotle.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ01OQ01.lean",
+      "lineCount": 189,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
       "lineCount": 193,
@@ -141,6 +154,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "lineCount": 128,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
       "lineCount": 68,
@@ -150,6 +174,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "lineCount": 194,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean"
     },
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
@@ -275,7 +310,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 336,
+      "lineCount": 408,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -61,6 +61,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01Aristotle.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ01OQ01.lean",
+      "lineCount": 189,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
       "lineCount": 193,
@@ -94,6 +105,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "lineCount": 128,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
       "lineCount": 68,
@@ -103,6 +125,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "lineCount": 194,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean"
     },
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
@@ -228,7 +261,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 336,
+      "lineCount": 408,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,
@@ -243,7 +276,9 @@
     "bezout-identity-oq-02",
     "bezout-identity-oq-02-oq-01",
     "bezout-identity-oq-02-oq-01-oq-01",
+    "bezout-identity-oq-02-oq-01-oq-01-oq-01",
     "bezout-identity-oq-02-oq-01-oq-02",
+    "bezout-identity-oq-02-oq-01-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02-oq-01",
     "bezout-identity-oq-02-oq-02-oq-01-oq-01",

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
@@ -68,7 +68,9 @@
     "bezout-identity-oq-02",
     "bezout-identity-oq-02-oq-01",
     "bezout-identity-oq-02-oq-01-oq-01",
+    "bezout-identity-oq-02-oq-01-oq-01-oq-01",
     "bezout-identity-oq-02-oq-01-oq-02",
+    "bezout-identity-oq-02-oq-01-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02-oq-01",
     "bezout-identity-oq-02-oq-02-oq-01-oq-01",
@@ -126,6 +128,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01Aristotle.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ01OQ01.lean",
+      "lineCount": 189,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
       "lineCount": 193,
@@ -159,6 +172,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "lineCount": 128,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
       "lineCount": 68,
@@ -168,6 +192,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "lineCount": 194,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean"
     },
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
@@ -293,7 +328,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 336,
+      "lineCount": 408,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -69,6 +69,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01Aristotle.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ01OQ01.lean",
+      "lineCount": 189,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
       "lineCount": 193,
@@ -102,6 +113,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "lineCount": 128,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
       "lineCount": 68,
@@ -111,6 +133,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "lineCount": 194,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean"
     },
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
@@ -236,7 +269,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 336,
+      "lineCount": 408,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,
@@ -251,7 +284,9 @@
     "bezout-identity-oq-02",
     "bezout-identity-oq-02-oq-01",
     "bezout-identity-oq-02-oq-01-oq-01",
+    "bezout-identity-oq-02-oq-01-oq-01-oq-01",
     "bezout-identity-oq-02-oq-01-oq-02",
+    "bezout-identity-oq-02-oq-01-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02-oq-01",
     "bezout-identity-oq-02-oq-02-oq-01-oq-01",

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01.json
@@ -49,7 +49,9 @@
     "bezout-identity-oq-02",
     "bezout-identity-oq-02-oq-01",
     "bezout-identity-oq-02-oq-01-oq-01",
+    "bezout-identity-oq-02-oq-01-oq-01-oq-01",
     "bezout-identity-oq-02-oq-01-oq-02",
+    "bezout-identity-oq-02-oq-01-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02-oq-01",
     "bezout-identity-oq-02-oq-02-oq-01-oq-01",
@@ -108,6 +110,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01Aristotle.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ01OQ01.lean",
+      "lineCount": 189,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
       "lineCount": 193,
@@ -141,6 +154,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "lineCount": 128,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
       "lineCount": 68,
@@ -150,6 +174,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "lineCount": 194,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean"
     },
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
@@ -275,7 +310,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 336,
+      "lineCount": 408,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
@@ -47,7 +47,9 @@
     "bezout-identity-oq-02",
     "bezout-identity-oq-02-oq-01",
     "bezout-identity-oq-02-oq-01-oq-01",
+    "bezout-identity-oq-02-oq-01-oq-01-oq-01",
     "bezout-identity-oq-02-oq-01-oq-02",
+    "bezout-identity-oq-02-oq-01-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02-oq-01",
     "bezout-identity-oq-02-oq-02-oq-01-oq-01",
@@ -103,6 +105,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01Aristotle.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ01OQ01.lean",
+      "lineCount": 189,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
       "lineCount": 193,
@@ -136,6 +149,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "lineCount": 128,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
       "lineCount": 68,
@@ -145,6 +169,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "lineCount": 194,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean"
     },
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
@@ -270,7 +305,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 336,
+      "lineCount": 408,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -54,7 +54,9 @@
     "bezout-identity-oq-02",
     "bezout-identity-oq-02-oq-01",
     "bezout-identity-oq-02-oq-01-oq-01",
+    "bezout-identity-oq-02-oq-01-oq-01-oq-01",
     "bezout-identity-oq-02-oq-01-oq-02",
+    "bezout-identity-oq-02-oq-01-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02-oq-01",
     "bezout-identity-oq-02-oq-02-oq-01-oq-01",
@@ -110,6 +112,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01Aristotle.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ01OQ01.lean",
+      "lineCount": 189,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
       "lineCount": 193,
@@ -143,6 +156,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "lineCount": 128,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
       "lineCount": 68,
@@ -152,6 +176,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "lineCount": 194,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean"
     },
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
@@ -277,7 +312,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 336,
+      "lineCount": 408,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03.json
@@ -49,7 +49,9 @@
     "bezout-identity-oq-02",
     "bezout-identity-oq-02-oq-01",
     "bezout-identity-oq-02-oq-01-oq-01",
+    "bezout-identity-oq-02-oq-01-oq-01-oq-01",
     "bezout-identity-oq-02-oq-01-oq-02",
+    "bezout-identity-oq-02-oq-01-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02-oq-01",
     "bezout-identity-oq-02-oq-02-oq-01-oq-01",
@@ -108,6 +110,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01Aristotle.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ01OQ01.lean",
+      "lineCount": 189,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
       "lineCount": 193,
@@ -141,6 +154,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "lineCount": 128,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
       "lineCount": 68,
@@ -150,6 +174,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "lineCount": 194,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean"
     },
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
@@ -275,7 +310,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 336,
+      "lineCount": 408,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
@@ -66,7 +66,9 @@
     "bezout-identity-oq-02",
     "bezout-identity-oq-02-oq-01",
     "bezout-identity-oq-02-oq-01-oq-01",
+    "bezout-identity-oq-02-oq-01-oq-01-oq-01",
     "bezout-identity-oq-02-oq-01-oq-02",
+    "bezout-identity-oq-02-oq-01-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02-oq-01",
     "bezout-identity-oq-02-oq-02-oq-01-oq-01",
@@ -124,6 +126,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01Aristotle.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ01OQ01.lean",
+      "lineCount": 189,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
       "lineCount": 193,
@@ -157,6 +170,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "lineCount": 128,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
       "lineCount": 68,
@@ -166,6 +190,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "lineCount": 194,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean"
     },
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
@@ -291,7 +326,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 336,
+      "lineCount": 408,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -73,6 +73,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01Aristotle.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ01OQ01.lean",
+      "lineCount": 189,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
       "lineCount": 193,
@@ -106,6 +117,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "lineCount": 128,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
       "lineCount": 68,
@@ -115,6 +137,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "lineCount": 194,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean"
     },
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
@@ -240,7 +273,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 336,
+      "lineCount": 408,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,
@@ -255,7 +288,9 @@
     "bezout-identity-oq-02",
     "bezout-identity-oq-02-oq-01",
     "bezout-identity-oq-02-oq-01-oq-01",
+    "bezout-identity-oq-02-oq-01-oq-01-oq-01",
     "bezout-identity-oq-02-oq-01-oq-02",
+    "bezout-identity-oq-02-oq-01-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02-oq-01",
     "bezout-identity-oq-02-oq-02-oq-01-oq-01",

--- a/src/data/research/problems/bezout-identity-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-04.json
@@ -49,7 +49,9 @@
     "bezout-identity-oq-02",
     "bezout-identity-oq-02-oq-01",
     "bezout-identity-oq-02-oq-01-oq-01",
+    "bezout-identity-oq-02-oq-01-oq-01-oq-01",
     "bezout-identity-oq-02-oq-01-oq-02",
+    "bezout-identity-oq-02-oq-01-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02",
     "bezout-identity-oq-02-oq-02-oq-01",
     "bezout-identity-oq-02-oq-02-oq-01-oq-01",
@@ -108,6 +110,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01Aristotle.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ01OQ01.lean",
+      "lineCount": 189,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
       "lineCount": 193,
@@ -141,6 +154,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01.lean"
     },
     {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
+      "lineCount": 128,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
       "lineCount": 68,
@@ -150,6 +174,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
+      "lineCount": 194,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean"
     },
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
@@ -275,7 +310,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ01.lean",
       "filename": "BezoutIdentityOQ04OQ01.lean",
-      "lineCount": 336,
+      "lineCount": 408,
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/binary-gcd-oq-01-oq-01.json
+++ b/src/data/research/problems/binary-gcd-oq-01-oq-01.json
@@ -69,6 +69,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ01.lean"
     },
     {
+      "path": "Proofs/BinaryGcdOQ01OQ03.lean",
+      "filename": "BinaryGcdOQ01OQ03.lean",
+      "lineCount": 226,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ01OQ03.lean"
+    },
+    {
       "path": "Proofs/BinaryGcdOQ01OQ04.lean",
       "filename": "BinaryGcdOQ01OQ04.lean",
       "lineCount": 158,

--- a/src/data/research/problems/binary-gcd-oq-01-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-01-oq-02.json
@@ -80,6 +80,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ01.lean"
     },
     {
+      "path": "Proofs/BinaryGcdOQ01OQ03.lean",
+      "filename": "BinaryGcdOQ01OQ03.lean",
+      "lineCount": 226,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ01OQ03.lean"
+    },
+    {
       "path": "Proofs/BinaryGcdOQ01OQ04.lean",
       "filename": "BinaryGcdOQ01OQ04.lean",
       "lineCount": 158,

--- a/src/data/research/problems/binary-gcd-oq-01-oq-03.json
+++ b/src/data/research/problems/binary-gcd-oq-01-oq-03.json
@@ -67,6 +67,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ01.lean"
     },
     {
+      "path": "Proofs/BinaryGcdOQ01OQ03.lean",
+      "filename": "BinaryGcdOQ01OQ03.lean",
+      "lineCount": 226,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ01OQ03.lean"
+    },
+    {
       "path": "Proofs/BinaryGcdOQ01OQ04.lean",
       "filename": "BinaryGcdOQ01OQ04.lean",
       "lineCount": 158,

--- a/src/data/research/problems/binary-gcd-oq-01.json
+++ b/src/data/research/problems/binary-gcd-oq-01.json
@@ -81,6 +81,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ01.lean"
     },
     {
+      "path": "Proofs/BinaryGcdOQ01OQ03.lean",
+      "filename": "BinaryGcdOQ01OQ03.lean",
+      "lineCount": 226,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ01OQ03.lean"
+    },
+    {
       "path": "Proofs/BinaryGcdOQ01OQ04.lean",
       "filename": "BinaryGcdOQ01OQ04.lean",
       "lineCount": 158,

--- a/src/data/research/problems/binary-gcd-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-02.json
@@ -68,6 +68,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ01.lean"
     },
     {
+      "path": "Proofs/BinaryGcdOQ01OQ03.lean",
+      "filename": "BinaryGcdOQ01OQ03.lean",
+      "lineCount": 226,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ01OQ03.lean"
+    },
+    {
       "path": "Proofs/BinaryGcdOQ01OQ04.lean",
       "filename": "BinaryGcdOQ01OQ04.lean",
       "lineCount": 158,

--- a/src/data/research/problems/binomial-theorem-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-01-oq-01-oq-01.json
@@ -54,6 +54,7 @@
     "binomial-theorem-oq-02-oq-03",
     "binomial-theorem-oq-03",
     "binomial-theorem-oq-03-oq-02",
+    "binomial-theorem-oq-03-oq-02-oq-03",
     "binomial-theorem-oq-04",
     "binomial-theorem-oq-04-oq-01",
     "binomial-theorem-oq-04-oq-02",
@@ -189,6 +190,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ03OQ02OQ03.lean",
+      "filename": "BinomialTheoremOQ03OQ02OQ03.lean",
+      "lineCount": 209,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02OQ03.lean"
     },
     {
       "path": "Proofs/BinomialTheoremOQ04.lean",

--- a/src/data/research/problems/binomial-theorem-oq-01-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-01-oq-01.json
@@ -65,6 +65,7 @@
     "binomial-theorem-oq-02-oq-03",
     "binomial-theorem-oq-03",
     "binomial-theorem-oq-03-oq-02",
+    "binomial-theorem-oq-03-oq-02-oq-03",
     "binomial-theorem-oq-04",
     "binomial-theorem-oq-04-oq-01",
     "binomial-theorem-oq-04-oq-02",
@@ -200,6 +201,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ03OQ02OQ03.lean",
+      "filename": "BinomialTheoremOQ03OQ02OQ03.lean",
+      "lineCount": 209,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02OQ03.lean"
     },
     {
       "path": "Proofs/BinomialTheoremOQ04.lean",

--- a/src/data/research/problems/binomial-theorem-oq-01-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-01-oq-02.json
@@ -57,6 +57,7 @@
     "binomial-theorem-oq-02-oq-03",
     "binomial-theorem-oq-03",
     "binomial-theorem-oq-03-oq-02",
+    "binomial-theorem-oq-03-oq-02-oq-03",
     "binomial-theorem-oq-04",
     "binomial-theorem-oq-04-oq-01",
     "binomial-theorem-oq-04-oq-02",
@@ -192,6 +193,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ03OQ02OQ03.lean",
+      "filename": "BinomialTheoremOQ03OQ02OQ03.lean",
+      "lineCount": 209,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02OQ03.lean"
     },
     {
       "path": "Proofs/BinomialTheoremOQ04.lean",

--- a/src/data/research/problems/binomial-theorem-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-01.json
@@ -54,6 +54,7 @@
     "binomial-theorem-oq-02-oq-03",
     "binomial-theorem-oq-03",
     "binomial-theorem-oq-03-oq-02",
+    "binomial-theorem-oq-03-oq-02-oq-03",
     "binomial-theorem-oq-04",
     "binomial-theorem-oq-04-oq-01",
     "binomial-theorem-oq-04-oq-02",
@@ -190,6 +191,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ03OQ02OQ03.lean",
+      "filename": "BinomialTheoremOQ03OQ02OQ03.lean",
+      "lineCount": 209,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02OQ03.lean"
     },
     {
       "path": "Proofs/BinomialTheoremOQ04.lean",

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01.json
@@ -65,6 +65,7 @@
     "binomial-theorem-oq-02-oq-03",
     "binomial-theorem-oq-03",
     "binomial-theorem-oq-03-oq-02",
+    "binomial-theorem-oq-03-oq-02-oq-03",
     "binomial-theorem-oq-04",
     "binomial-theorem-oq-04-oq-01",
     "binomial-theorem-oq-04-oq-02",
@@ -200,6 +201,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ03OQ02OQ03.lean",
+      "filename": "BinomialTheoremOQ03OQ02OQ03.lean",
+      "lineCount": 209,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02OQ03.lean"
     },
     {
       "path": "Proofs/BinomialTheoremOQ04.lean",

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-02.json
@@ -70,6 +70,7 @@
     "binomial-theorem-oq-02-oq-03",
     "binomial-theorem-oq-03",
     "binomial-theorem-oq-03-oq-02",
+    "binomial-theorem-oq-03-oq-02-oq-03",
     "binomial-theorem-oq-04",
     "binomial-theorem-oq-04-oq-01",
     "binomial-theorem-oq-04-oq-02",
@@ -205,6 +206,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ03OQ02OQ03.lean",
+      "filename": "BinomialTheoremOQ03OQ02OQ03.lean",
+      "lineCount": 209,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02OQ03.lean"
     },
     {
       "path": "Proofs/BinomialTheoremOQ04.lean",

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-03.json
@@ -50,6 +50,7 @@
     "binomial-theorem-oq-02-oq-03",
     "binomial-theorem-oq-03",
     "binomial-theorem-oq-03-oq-02",
+    "binomial-theorem-oq-03-oq-02-oq-03",
     "binomial-theorem-oq-04",
     "binomial-theorem-oq-04-oq-01",
     "binomial-theorem-oq-04-oq-02",
@@ -185,6 +186,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ03OQ02OQ03.lean",
+      "filename": "BinomialTheoremOQ03OQ02OQ03.lean",
+      "lineCount": 209,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02OQ03.lean"
     },
     {
       "path": "Proofs/BinomialTheoremOQ04.lean",

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01.json
@@ -67,6 +67,7 @@
     "binomial-theorem-oq-02-oq-03",
     "binomial-theorem-oq-03",
     "binomial-theorem-oq-03-oq-02",
+    "binomial-theorem-oq-03-oq-02-oq-03",
     "binomial-theorem-oq-04",
     "binomial-theorem-oq-04-oq-01",
     "binomial-theorem-oq-04-oq-02",
@@ -200,6 +201,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ03OQ02OQ03.lean",
+      "filename": "BinomialTheoremOQ03OQ02OQ03.lean",
+      "lineCount": 209,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02OQ03.lean"
     },
     {
       "path": "Proofs/BinomialTheoremOQ04.lean",

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-02.json
@@ -51,6 +51,7 @@
     "binomial-theorem-oq-02-oq-03",
     "binomial-theorem-oq-03",
     "binomial-theorem-oq-03-oq-02",
+    "binomial-theorem-oq-03-oq-02-oq-03",
     "binomial-theorem-oq-04",
     "binomial-theorem-oq-04-oq-01",
     "binomial-theorem-oq-04-oq-02",
@@ -186,6 +187,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ03OQ02OQ03.lean",
+      "filename": "BinomialTheoremOQ03OQ02OQ03.lean",
+      "lineCount": 209,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02OQ03.lean"
     },
     {
       "path": "Proofs/BinomialTheoremOQ04.lean",

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-03.json
@@ -64,6 +64,7 @@
     "binomial-theorem-oq-02-oq-03",
     "binomial-theorem-oq-03",
     "binomial-theorem-oq-03-oq-02",
+    "binomial-theorem-oq-03-oq-02-oq-03",
     "binomial-theorem-oq-04",
     "binomial-theorem-oq-04-oq-01",
     "binomial-theorem-oq-04-oq-02",
@@ -199,6 +200,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ03OQ02OQ03.lean",
+      "filename": "BinomialTheoremOQ03OQ02OQ03.lean",
+      "lineCount": 209,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02OQ03.lean"
     },
     {
       "path": "Proofs/BinomialTheoremOQ04.lean",

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-04.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-04.json
@@ -48,6 +48,7 @@
     "binomial-theorem-oq-02-oq-03",
     "binomial-theorem-oq-03",
     "binomial-theorem-oq-03-oq-02",
+    "binomial-theorem-oq-03-oq-02-oq-03",
     "binomial-theorem-oq-04",
     "binomial-theorem-oq-04-oq-01",
     "binomial-theorem-oq-04-oq-02",
@@ -181,6 +182,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ03OQ02OQ03.lean",
+      "filename": "BinomialTheoremOQ03OQ02OQ03.lean",
+      "lineCount": 209,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02OQ03.lean"
     },
     {
       "path": "Proofs/BinomialTheoremOQ04.lean",

--- a/src/data/research/problems/binomial-theorem-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-02.json
@@ -53,6 +53,7 @@
     "binomial-theorem-oq-02-oq-03",
     "binomial-theorem-oq-03",
     "binomial-theorem-oq-03-oq-02",
+    "binomial-theorem-oq-03-oq-02-oq-03",
     "binomial-theorem-oq-04",
     "binomial-theorem-oq-04-oq-01",
     "binomial-theorem-oq-04-oq-02",
@@ -189,6 +190,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ03OQ02OQ03.lean",
+      "filename": "BinomialTheoremOQ03OQ02OQ03.lean",
+      "lineCount": 209,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02OQ03.lean"
     },
     {
       "path": "Proofs/BinomialTheoremOQ04.lean",

--- a/src/data/research/problems/binomial-theorem-oq-03-oq-02-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-03-oq-02-oq-03.json
@@ -53,6 +53,7 @@
     "binomial-theorem-oq-02-oq-03",
     "binomial-theorem-oq-03",
     "binomial-theorem-oq-03-oq-02",
+    "binomial-theorem-oq-03-oq-02-oq-03",
     "binomial-theorem-oq-04",
     "binomial-theorem-oq-04-oq-01",
     "binomial-theorem-oq-04-oq-02",
@@ -188,6 +189,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ03OQ02OQ03.lean",
+      "filename": "BinomialTheoremOQ03OQ02OQ03.lean",
+      "lineCount": 209,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02OQ03.lean"
     },
     {
       "path": "Proofs/BinomialTheoremOQ04.lean",

--- a/src/data/research/problems/binomial-theorem-oq-03-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-03-oq-02.json
@@ -85,6 +85,7 @@
     "binomial-theorem-oq-02-oq-03",
     "binomial-theorem-oq-03",
     "binomial-theorem-oq-03-oq-02",
+    "binomial-theorem-oq-03-oq-02-oq-03",
     "binomial-theorem-oq-04",
     "binomial-theorem-oq-04-oq-01",
     "binomial-theorem-oq-04-oq-02",
@@ -226,6 +227,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ03OQ02OQ03.lean",
+      "filename": "BinomialTheoremOQ03OQ02OQ03.lean",
+      "lineCount": 209,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02OQ03.lean"
     },
     {
       "path": "Proofs/BinomialTheoremOQ04.lean",

--- a/src/data/research/problems/binomial-theorem-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-03.json
@@ -53,6 +53,7 @@
     "binomial-theorem-oq-02-oq-03",
     "binomial-theorem-oq-03",
     "binomial-theorem-oq-03-oq-02",
+    "binomial-theorem-oq-03-oq-02-oq-03",
     "binomial-theorem-oq-04",
     "binomial-theorem-oq-04-oq-01",
     "binomial-theorem-oq-04-oq-02",
@@ -189,6 +190,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ03OQ02OQ03.lean",
+      "filename": "BinomialTheoremOQ03OQ02OQ03.lean",
+      "lineCount": 209,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02OQ03.lean"
     },
     {
       "path": "Proofs/BinomialTheoremOQ04.lean",

--- a/src/data/research/problems/binomial-theorem-oq-04-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-04-oq-01.json
@@ -58,6 +58,7 @@
     "binomial-theorem-oq-02-oq-03",
     "binomial-theorem-oq-03",
     "binomial-theorem-oq-03-oq-02",
+    "binomial-theorem-oq-03-oq-02-oq-03",
     "binomial-theorem-oq-04",
     "binomial-theorem-oq-04-oq-01",
     "binomial-theorem-oq-04-oq-02",
@@ -193,6 +194,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ03OQ02OQ03.lean",
+      "filename": "BinomialTheoremOQ03OQ02OQ03.lean",
+      "lineCount": 209,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02OQ03.lean"
     },
     {
       "path": "Proofs/BinomialTheoremOQ04.lean",

--- a/src/data/research/problems/binomial-theorem-oq-04-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-04-oq-02.json
@@ -58,6 +58,7 @@
     "binomial-theorem-oq-02-oq-03",
     "binomial-theorem-oq-03",
     "binomial-theorem-oq-03-oq-02",
+    "binomial-theorem-oq-03-oq-02-oq-03",
     "binomial-theorem-oq-04",
     "binomial-theorem-oq-04-oq-01",
     "binomial-theorem-oq-04-oq-02",
@@ -193,6 +194,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ03OQ02OQ03.lean",
+      "filename": "BinomialTheoremOQ03OQ02OQ03.lean",
+      "lineCount": 209,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02OQ03.lean"
     },
     {
       "path": "Proofs/BinomialTheoremOQ04.lean",

--- a/src/data/research/problems/binomial-theorem-oq-04-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-04-oq-03.json
@@ -65,6 +65,7 @@
     "binomial-theorem-oq-02-oq-03",
     "binomial-theorem-oq-03",
     "binomial-theorem-oq-03-oq-02",
+    "binomial-theorem-oq-03-oq-02-oq-03",
     "binomial-theorem-oq-04",
     "binomial-theorem-oq-04-oq-01",
     "binomial-theorem-oq-04-oq-02",
@@ -200,6 +201,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ03OQ02OQ03.lean",
+      "filename": "BinomialTheoremOQ03OQ02OQ03.lean",
+      "lineCount": 209,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02OQ03.lean"
     },
     {
       "path": "Proofs/BinomialTheoremOQ04.lean",

--- a/src/data/research/problems/binomial-theorem-oq-04.json
+++ b/src/data/research/problems/binomial-theorem-oq-04.json
@@ -53,6 +53,7 @@
     "binomial-theorem-oq-02-oq-03",
     "binomial-theorem-oq-03",
     "binomial-theorem-oq-03-oq-02",
+    "binomial-theorem-oq-03-oq-02-oq-03",
     "binomial-theorem-oq-04",
     "binomial-theorem-oq-04-oq-01",
     "binomial-theorem-oq-04-oq-02",
@@ -189,6 +190,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02.lean"
+    },
+    {
+      "path": "Proofs/BinomialTheoremOQ03OQ02OQ03.lean",
+      "filename": "BinomialTheoremOQ03OQ02OQ03.lean",
+      "lineCount": 209,
+      "theoremCount": 12,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ03OQ02OQ03.lean"
     },
     {
       "path": "Proofs/BinomialTheoremOQ04.lean",

--- a/src/data/research/problems/birthday-problem-oq-02-oq-01.json
+++ b/src/data/research/problems/birthday-problem-oq-02-oq-01.json
@@ -66,6 +66,7 @@
     "birthday-problem-oq-03",
     "birthday-problem-oq-03-oq-01",
     "birthday-problem-oq-03-oq-01-oq-01",
+    "birthday-problem-oq-03-oq-01-oq-02",
     "birthday-problem-oq-03-oq-03"
   ],
   "references": {
@@ -165,6 +166,28 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
+      "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
+      "lineCount": 388,
+      "theoremCount": 18,
+      "axiomCount": 1,
+      "defCount": 3,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ03OQ01OQ02Aristotle.lean",
+      "filename": "BirthdayProblemOQ03OQ01OQ02Aristotle.lean",
+      "lineCount": 27,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02Aristotle.lean"
     },
     {
       "path": "Proofs/BirthdayProblemOQ03OQ03.lean",

--- a/src/data/research/problems/birthday-problem-oq-02-oq-03.json
+++ b/src/data/research/problems/birthday-problem-oq-02-oq-03.json
@@ -44,6 +44,7 @@
     "birthday-problem-oq-03",
     "birthday-problem-oq-03-oq-01",
     "birthday-problem-oq-03-oq-01-oq-01",
+    "birthday-problem-oq-03-oq-01-oq-02",
     "birthday-problem-oq-03-oq-03"
   ],
   "references": {
@@ -141,6 +142,28 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
+      "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
+      "lineCount": 388,
+      "theoremCount": 18,
+      "axiomCount": 1,
+      "defCount": 3,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ03OQ01OQ02Aristotle.lean",
+      "filename": "BirthdayProblemOQ03OQ01OQ02Aristotle.lean",
+      "lineCount": 27,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02Aristotle.lean"
     },
     {
       "path": "Proofs/BirthdayProblemOQ03OQ03.lean",

--- a/src/data/research/problems/birthday-problem-oq-02.json
+++ b/src/data/research/problems/birthday-problem-oq-02.json
@@ -122,6 +122,28 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ01.lean"
     },
     {
+      "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
+      "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
+      "lineCount": 388,
+      "theoremCount": 18,
+      "axiomCount": 1,
+      "defCount": 3,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ03OQ01OQ02Aristotle.lean",
+      "filename": "BirthdayProblemOQ03OQ01OQ02Aristotle.lean",
+      "lineCount": 27,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02Aristotle.lean"
+    },
+    {
       "path": "Proofs/BirthdayProblemOQ03OQ03.lean",
       "filename": "BirthdayProblemOQ03OQ03.lean",
       "lineCount": 242,
@@ -140,6 +162,7 @@
     "birthday-problem-oq-03",
     "birthday-problem-oq-03-oq-01",
     "birthday-problem-oq-03-oq-01-oq-01",
+    "birthday-problem-oq-03-oq-01-oq-02",
     "birthday-problem-oq-03-oq-03"
   ],
   "tags": [],

--- a/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-01.json
@@ -48,6 +48,7 @@
     "birthday-problem-oq-03",
     "birthday-problem-oq-03-oq-01",
     "birthday-problem-oq-03-oq-01-oq-01",
+    "birthday-problem-oq-03-oq-01-oq-02",
     "birthday-problem-oq-03-oq-03"
   ],
   "references": {
@@ -147,6 +148,28 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
+      "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
+      "lineCount": 388,
+      "theoremCount": 18,
+      "axiomCount": 1,
+      "defCount": 3,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ03OQ01OQ02Aristotle.lean",
+      "filename": "BirthdayProblemOQ03OQ01OQ02Aristotle.lean",
+      "lineCount": 27,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02Aristotle.lean"
     },
     {
       "path": "Proofs/BirthdayProblemOQ03OQ03.lean",

--- a/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02.json
@@ -105,15 +105,125 @@
   "tractability": 6,
   "leanFiles": [
     {
+      "path": "Proofs/BirthdayProblem.lean",
+      "filename": "BirthdayProblem.lean",
+      "lineCount": 403,
+      "theoremCount": 24,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblem.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemAsymptotics.lean",
+      "filename": "BirthdayProblemAsymptotics.lean",
+      "lineCount": 85,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemAsymptotics.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ01.lean",
+      "filename": "BirthdayProblemOQ01.lean",
+      "lineCount": 514,
+      "theoremCount": 53,
+      "axiomCount": 0,
+      "defCount": 7,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ01.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ02.lean",
+      "filename": "BirthdayProblemOQ02.lean",
+      "lineCount": 301,
+      "theoremCount": 18,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ02.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ02OQ01.lean",
+      "filename": "BirthdayProblemOQ02OQ01.lean",
+      "lineCount": 230,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ03.lean",
+      "filename": "BirthdayProblemOQ03.lean",
+      "lineCount": 369,
+      "theoremCount": 19,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ03OQ01.lean",
+      "filename": "BirthdayProblemOQ03OQ01.lean",
+      "lineCount": 246,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ03OQ01OQ01.lean",
+      "filename": "BirthdayProblemOQ03OQ01OQ01.lean",
+      "lineCount": 244,
+      "theoremCount": 30,
+      "axiomCount": 2,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 387,
+      "lineCount": 388,
       "theoremCount": 18,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ03OQ01OQ02Aristotle.lean",
+      "filename": "BirthdayProblemOQ03OQ01OQ02Aristotle.lean",
+      "lineCount": 27,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02Aristotle.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ03OQ03.lean",
+      "filename": "BirthdayProblemOQ03OQ03.lean",
+      "lineCount": 242,
+      "theoremCount": 20,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ03.lean"
     }
   ]
 }

--- a/src/data/research/problems/birthday-problem-oq-03-oq-01.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-01.json
@@ -57,6 +57,7 @@
     "birthday-problem-oq-03",
     "birthday-problem-oq-03-oq-01",
     "birthday-problem-oq-03-oq-01-oq-01",
+    "birthday-problem-oq-03-oq-01-oq-02",
     "birthday-problem-oq-03-oq-03"
   ],
   "references": {
@@ -156,6 +157,28 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
+      "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
+      "lineCount": 388,
+      "theoremCount": 18,
+      "axiomCount": 1,
+      "defCount": 3,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ03OQ01OQ02Aristotle.lean",
+      "filename": "BirthdayProblemOQ03OQ01OQ02Aristotle.lean",
+      "lineCount": 27,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02Aristotle.lean"
     },
     {
       "path": "Proofs/BirthdayProblemOQ03OQ03.lean",

--- a/src/data/research/problems/birthday-problem-oq-03-oq-03.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-03.json
@@ -56,6 +56,7 @@
     "birthday-problem-oq-03",
     "birthday-problem-oq-03-oq-01",
     "birthday-problem-oq-03-oq-01-oq-01",
+    "birthday-problem-oq-03-oq-01-oq-02",
     "birthday-problem-oq-03-oq-03"
   ],
   "references": {
@@ -153,6 +154,28 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
+      "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
+      "lineCount": 388,
+      "theoremCount": 18,
+      "axiomCount": 1,
+      "defCount": 3,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ03OQ01OQ02Aristotle.lean",
+      "filename": "BirthdayProblemOQ03OQ01OQ02Aristotle.lean",
+      "lineCount": 27,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02Aristotle.lean"
     },
     {
       "path": "Proofs/BirthdayProblemOQ03OQ03.lean",

--- a/src/data/research/problems/birthday-problem-oq-03.json
+++ b/src/data/research/problems/birthday-problem-oq-03.json
@@ -79,6 +79,7 @@
     "birthday-problem-oq-03",
     "birthday-problem-oq-03-oq-01",
     "birthday-problem-oq-03-oq-01-oq-01",
+    "birthday-problem-oq-03-oq-01-oq-02",
     "birthday-problem-oq-03-oq-03"
   ],
   "references": {
@@ -182,6 +183,28 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
+      "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
+      "lineCount": 388,
+      "theoremCount": 18,
+      "axiomCount": 1,
+      "defCount": 3,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ03OQ01OQ02Aristotle.lean",
+      "filename": "BirthdayProblemOQ03OQ01OQ02Aristotle.lean",
+      "lineCount": 27,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02Aristotle.lean"
     },
     {
       "path": "Proofs/BirthdayProblemOQ03OQ03.lean",

--- a/src/data/research/problems/birthday-problem-oq-04.json
+++ b/src/data/research/problems/birthday-problem-oq-04.json
@@ -47,6 +47,7 @@
     "birthday-problem-oq-03",
     "birthday-problem-oq-03-oq-01",
     "birthday-problem-oq-03-oq-01-oq-01",
+    "birthday-problem-oq-03-oq-01-oq-02",
     "birthday-problem-oq-03-oq-03"
   ],
   "references": {
@@ -147,6 +148,28 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
+      "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
+      "lineCount": 388,
+      "theoremCount": 18,
+      "axiomCount": 1,
+      "defCount": 3,
+      "sorryCount": 2,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ03OQ01OQ02Aristotle.lean",
+      "filename": "BirthdayProblemOQ03OQ01OQ02Aristotle.lean",
+      "lineCount": 27,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 2,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02Aristotle.lean"
     },
     {
       "path": "Proofs/BirthdayProblemOQ03OQ03.lean",

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01.json
@@ -45,6 +45,7 @@
     "borsuk-ulam",
     "borsuk-ulam-oq-02",
     "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-01",
     "borsuk-ulam-oq-02-oq-01-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",
@@ -106,6 +107,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ01.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ01.lean",
+      "lineCount": 139,
+      "theoremCount": 9,
+      "axiomCount": 1,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ01.lean"
     },
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-02.json
@@ -44,6 +44,7 @@
     "borsuk-ulam",
     "borsuk-ulam-oq-02",
     "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-01",
     "borsuk-ulam-oq-02-oq-01-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",
@@ -107,6 +108,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ01.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ01.lean",
+      "lineCount": 139,
+      "theoremCount": 9,
+      "axiomCount": 1,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ01.lean"
     },
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-04.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-04.json
@@ -79,6 +79,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
     },
     {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ01.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ01.lean",
+      "lineCount": 139,
+      "theoremCount": 9,
+      "axiomCount": 1,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",
       "filename": "BorsukUlamOQ02OQ01OQ03.lean",
       "lineCount": 213,
@@ -182,6 +193,7 @@
     "borsuk-ulam",
     "borsuk-ulam-oq-02",
     "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-01",
     "borsuk-ulam-oq-02-oq-01-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01.json
@@ -57,6 +57,7 @@
     "borsuk-ulam",
     "borsuk-ulam-oq-02",
     "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-01",
     "borsuk-ulam-oq-02-oq-01-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",
@@ -120,6 +121,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ01.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ01.lean",
+      "lineCount": 139,
+      "theoremCount": 9,
+      "axiomCount": 1,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ01.lean"
     },
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-02-oq-01.json
@@ -47,6 +47,7 @@
     "borsuk-ulam",
     "borsuk-ulam-oq-02",
     "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-01",
     "borsuk-ulam-oq-02-oq-01-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",
@@ -110,6 +111,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ01.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ01.lean",
+      "lineCount": 139,
+      "theoremCount": 9,
+      "axiomCount": 1,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ01.lean"
     },
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-02.json
@@ -53,6 +53,7 @@
     "borsuk-ulam",
     "borsuk-ulam-oq-02",
     "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-01",
     "borsuk-ulam-oq-02-oq-01-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",
@@ -114,6 +115,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ01.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ01.lean",
+      "lineCount": 139,
+      "theoremCount": 9,
+      "axiomCount": 1,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ01.lean"
     },
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-03.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-03.json
@@ -41,6 +41,7 @@
     "borsuk-ulam",
     "borsuk-ulam-oq-02",
     "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-01",
     "borsuk-ulam-oq-02-oq-01-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",
@@ -103,6 +104,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ01.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ01.lean",
+      "lineCount": 139,
+      "theoremCount": 9,
+      "axiomCount": 1,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ01.lean"
     },
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-04.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-04.json
@@ -41,6 +41,7 @@
     "borsuk-ulam",
     "borsuk-ulam-oq-02",
     "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-01",
     "borsuk-ulam-oq-02-oq-01-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",
@@ -102,6 +103,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ01.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ01.lean",
+      "lineCount": 139,
+      "theoremCount": 9,
+      "axiomCount": 1,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ01.lean"
     },
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",

--- a/src/data/research/problems/borsuk-ulam-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02.json
@@ -45,6 +45,7 @@
     "borsuk-ulam",
     "borsuk-ulam-oq-02",
     "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-01",
     "borsuk-ulam-oq-02-oq-01-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",
@@ -109,6 +110,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ01.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ01.lean",
+      "lineCount": 139,
+      "theoremCount": 9,
+      "axiomCount": 1,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ01.lean"
     },
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",

--- a/src/data/research/problems/borsuk-ulam-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03-oq-01-oq-01.json
@@ -92,6 +92,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
     },
     {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ01.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ01.lean",
+      "lineCount": 139,
+      "theoremCount": 9,
+      "axiomCount": 1,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",
       "filename": "BorsukUlamOQ02OQ01OQ03.lean",
       "lineCount": 213,
@@ -195,6 +206,7 @@
     "borsuk-ulam",
     "borsuk-ulam-oq-02",
     "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-01",
     "borsuk-ulam-oq-02-oq-01-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",

--- a/src/data/research/problems/borsuk-ulam-oq-03-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03-oq-01.json
@@ -47,6 +47,7 @@
     "borsuk-ulam",
     "borsuk-ulam-oq-02",
     "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-01",
     "borsuk-ulam-oq-02-oq-01-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",
@@ -111,6 +112,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ01.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ01.lean",
+      "lineCount": 139,
+      "theoremCount": 9,
+      "axiomCount": 1,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ01.lean"
     },
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",

--- a/src/data/research/problems/borsuk-ulam-oq-03-oq-03.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03-oq-03.json
@@ -54,6 +54,7 @@
     "borsuk-ulam",
     "borsuk-ulam-oq-02",
     "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-01",
     "borsuk-ulam-oq-02-oq-01-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",
@@ -117,6 +118,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ01.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ01.lean",
+      "lineCount": 139,
+      "theoremCount": 9,
+      "axiomCount": 1,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ01.lean"
     },
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",

--- a/src/data/research/problems/borsuk-ulam-oq-03.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03.json
@@ -269,6 +269,7 @@
     "borsuk-ulam",
     "borsuk-ulam-oq-02",
     "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-01",
     "borsuk-ulam-oq-02-oq-01-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",
@@ -333,6 +334,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ01.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ01.lean",
+      "lineCount": 139,
+      "theoremCount": 9,
+      "axiomCount": 1,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ01.lean"
     },
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",

--- a/src/data/research/problems/borsuk-ulam-oq-04-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-04-oq-01.json
@@ -41,6 +41,7 @@
     "borsuk-ulam",
     "borsuk-ulam-oq-02",
     "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-01",
     "borsuk-ulam-oq-02-oq-01-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",
@@ -102,6 +103,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ01.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ01.lean",
+      "lineCount": 139,
+      "theoremCount": 9,
+      "axiomCount": 1,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ01.lean"
     },
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",

--- a/src/data/research/problems/borsuk-ulam-oq-04.json
+++ b/src/data/research/problems/borsuk-ulam-oq-04.json
@@ -69,6 +69,7 @@
     "borsuk-ulam",
     "borsuk-ulam-oq-02",
     "borsuk-ulam-oq-02-oq-01",
+    "borsuk-ulam-oq-02-oq-01-oq-01",
     "borsuk-ulam-oq-02-oq-01-oq-03",
     "borsuk-ulam-oq-02-oq-01-oq-04",
     "borsuk-ulam-oq-02-oq-02",
@@ -132,6 +133,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BorsukUlamOQ02OQ01OQ01.lean",
+      "filename": "BorsukUlamOQ02OQ01OQ01.lean",
+      "lineCount": 139,
+      "theoremCount": 9,
+      "axiomCount": 1,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BorsukUlamOQ02OQ01OQ01.lean"
     },
     {
       "path": "Proofs/BorsukUlamOQ02OQ01OQ03.lean",

--- a/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02.json
@@ -76,6 +76,7 @@
     "brouwer-fixed-point",
     "brouwer-fixed-point-oq-01",
     "brouwer-fixed-point-oq-01-oq-02",
+    "brouwer-fixed-point-oq-01-oq-03",
     "brouwer-fixed-point-oq-02",
     "brouwer-fixed-point-oq-02-oq-02",
     "brouwer-fixed-point-oq-04",
@@ -123,6 +124,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ01OQ03.lean",
+      "filename": "BrouwerFixedPointOQ01OQ03.lean",
+      "lineCount": 217,
+      "theoremCount": 6,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ03.lean"
     },
     {
       "path": "Proofs/BrouwerFixedPointOQ02.lean",
@@ -189,6 +201,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ04OQ01.lean",
+      "filename": "BrouwerFixedPointOQ04OQ01.lean",
+      "lineCount": 297,
+      "theoremCount": 8,
+      "axiomCount": 2,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04OQ01.lean"
     },
     {
       "path": "Proofs/BrouwerFixedPointOQ04OQ03.lean",

--- a/src/data/research/problems/brouwer-fixed-point-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01.json
@@ -45,6 +45,7 @@
     "brouwer-fixed-point",
     "brouwer-fixed-point-oq-01",
     "brouwer-fixed-point-oq-01-oq-02",
+    "brouwer-fixed-point-oq-01-oq-03",
     "brouwer-fixed-point-oq-02",
     "brouwer-fixed-point-oq-02-oq-02",
     "brouwer-fixed-point-oq-04",
@@ -93,6 +94,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ01OQ03.lean",
+      "filename": "BrouwerFixedPointOQ01OQ03.lean",
+      "lineCount": 217,
+      "theoremCount": 6,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ03.lean"
     },
     {
       "path": "Proofs/BrouwerFixedPointOQ02.lean",
@@ -159,6 +171,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ04OQ01.lean",
+      "filename": "BrouwerFixedPointOQ04OQ01.lean",
+      "lineCount": 297,
+      "theoremCount": 8,
+      "axiomCount": 2,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04OQ01.lean"
     },
     {
       "path": "Proofs/BrouwerFixedPointOQ04OQ03.lean",

--- a/src/data/research/problems/brouwer-fixed-point-oq-02-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-02-oq-01.json
@@ -113,6 +113,7 @@
     "brouwer-fixed-point",
     "brouwer-fixed-point-oq-01",
     "brouwer-fixed-point-oq-01-oq-02",
+    "brouwer-fixed-point-oq-01-oq-03",
     "brouwer-fixed-point-oq-02",
     "brouwer-fixed-point-oq-02-oq-02",
     "brouwer-fixed-point-oq-04",
@@ -160,6 +161,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ01OQ03.lean",
+      "filename": "BrouwerFixedPointOQ01OQ03.lean",
+      "lineCount": 217,
+      "theoremCount": 6,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ03.lean"
     },
     {
       "path": "Proofs/BrouwerFixedPointOQ02.lean",
@@ -226,6 +238,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ04OQ01.lean",
+      "filename": "BrouwerFixedPointOQ04OQ01.lean",
+      "lineCount": 297,
+      "theoremCount": 8,
+      "axiomCount": 2,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04OQ01.lean"
     },
     {
       "path": "Proofs/BrouwerFixedPointOQ04OQ03.lean",

--- a/src/data/research/problems/brouwer-fixed-point-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-02-oq-02-oq-01.json
@@ -41,6 +41,7 @@
     "brouwer-fixed-point",
     "brouwer-fixed-point-oq-01",
     "brouwer-fixed-point-oq-01-oq-02",
+    "brouwer-fixed-point-oq-01-oq-03",
     "brouwer-fixed-point-oq-02",
     "brouwer-fixed-point-oq-02-oq-02",
     "brouwer-fixed-point-oq-04",
@@ -86,6 +87,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ01OQ03.lean",
+      "filename": "BrouwerFixedPointOQ01OQ03.lean",
+      "lineCount": 217,
+      "theoremCount": 6,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ03.lean"
     },
     {
       "path": "Proofs/BrouwerFixedPointOQ02.lean",
@@ -152,6 +164,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ04OQ01.lean",
+      "filename": "BrouwerFixedPointOQ04OQ01.lean",
+      "lineCount": 297,
+      "theoremCount": 8,
+      "axiomCount": 2,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04OQ01.lean"
     },
     {
       "path": "Proofs/BrouwerFixedPointOQ04OQ03.lean",

--- a/src/data/research/problems/brouwer-fixed-point-oq-02-oq-02.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-02-oq-02.json
@@ -59,6 +59,7 @@
     "brouwer-fixed-point",
     "brouwer-fixed-point-oq-01",
     "brouwer-fixed-point-oq-01-oq-02",
+    "brouwer-fixed-point-oq-01-oq-03",
     "brouwer-fixed-point-oq-02",
     "brouwer-fixed-point-oq-02-oq-02",
     "brouwer-fixed-point-oq-04",
@@ -106,6 +107,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ01OQ03.lean",
+      "filename": "BrouwerFixedPointOQ01OQ03.lean",
+      "lineCount": 217,
+      "theoremCount": 6,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ03.lean"
     },
     {
       "path": "Proofs/BrouwerFixedPointOQ02.lean",
@@ -172,6 +184,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ04OQ01.lean",
+      "filename": "BrouwerFixedPointOQ04OQ01.lean",
+      "lineCount": 297,
+      "theoremCount": 8,
+      "axiomCount": 2,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04OQ01.lean"
     },
     {
       "path": "Proofs/BrouwerFixedPointOQ04OQ03.lean",

--- a/src/data/research/problems/brouwer-fixed-point-oq-02.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-02.json
@@ -46,6 +46,7 @@
     "brouwer-fixed-point",
     "brouwer-fixed-point-oq-01",
     "brouwer-fixed-point-oq-01-oq-02",
+    "brouwer-fixed-point-oq-01-oq-03",
     "brouwer-fixed-point-oq-02",
     "brouwer-fixed-point-oq-02-oq-02",
     "brouwer-fixed-point-oq-04",
@@ -94,6 +95,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ01OQ03.lean",
+      "filename": "BrouwerFixedPointOQ01OQ03.lean",
+      "lineCount": 217,
+      "theoremCount": 6,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ03.lean"
     },
     {
       "path": "Proofs/BrouwerFixedPointOQ02.lean",
@@ -160,6 +172,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ04OQ01.lean",
+      "filename": "BrouwerFixedPointOQ04OQ01.lean",
+      "lineCount": 297,
+      "theoremCount": 8,
+      "axiomCount": 2,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04OQ01.lean"
     },
     {
       "path": "Proofs/BrouwerFixedPointOQ04OQ03.lean",

--- a/src/data/research/problems/brouwer-fixed-point-oq-03.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-03.json
@@ -41,6 +41,7 @@
     "brouwer-fixed-point",
     "brouwer-fixed-point-oq-01",
     "brouwer-fixed-point-oq-01-oq-02",
+    "brouwer-fixed-point-oq-01-oq-03",
     "brouwer-fixed-point-oq-02",
     "brouwer-fixed-point-oq-02-oq-02",
     "brouwer-fixed-point-oq-04",
@@ -87,6 +88,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ01OQ03.lean",
+      "filename": "BrouwerFixedPointOQ01OQ03.lean",
+      "lineCount": 217,
+      "theoremCount": 6,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ03.lean"
     },
     {
       "path": "Proofs/BrouwerFixedPointOQ02.lean",
@@ -153,6 +165,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ04OQ01.lean",
+      "filename": "BrouwerFixedPointOQ04OQ01.lean",
+      "lineCount": 297,
+      "theoremCount": 8,
+      "axiomCount": 2,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04OQ01.lean"
     },
     {
       "path": "Proofs/BrouwerFixedPointOQ04OQ03.lean",

--- a/src/data/research/problems/brouwer-fixed-point-oq-04-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-04-oq-01.json
@@ -45,6 +45,7 @@
     "brouwer-fixed-point",
     "brouwer-fixed-point-oq-01",
     "brouwer-fixed-point-oq-01-oq-02",
+    "brouwer-fixed-point-oq-01-oq-03",
     "brouwer-fixed-point-oq-02",
     "brouwer-fixed-point-oq-02-oq-02",
     "brouwer-fixed-point-oq-04",
@@ -89,6 +90,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ01OQ03.lean",
+      "filename": "BrouwerFixedPointOQ01OQ03.lean",
+      "lineCount": 217,
+      "theoremCount": 6,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ03.lean"
     },
     {
       "path": "Proofs/BrouwerFixedPointOQ02.lean",
@@ -155,6 +167,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ04OQ01.lean",
+      "filename": "BrouwerFixedPointOQ04OQ01.lean",
+      "lineCount": 297,
+      "theoremCount": 8,
+      "axiomCount": 2,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04OQ01.lean"
     },
     {
       "path": "Proofs/BrouwerFixedPointOQ04OQ03.lean",

--- a/src/data/research/problems/brouwer-fixed-point-oq-04-oq-03.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-04-oq-03.json
@@ -56,6 +56,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ02.lean"
     },
     {
+      "path": "Proofs/BrouwerFixedPointOQ01OQ03.lean",
+      "filename": "BrouwerFixedPointOQ01OQ03.lean",
+      "lineCount": 217,
+      "theoremCount": 6,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ03.lean"
+    },
+    {
       "path": "Proofs/BrouwerFixedPointOQ02.lean",
       "filename": "BrouwerFixedPointOQ02.lean",
       "lineCount": 392,
@@ -122,6 +133,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04.lean"
     },
     {
+      "path": "Proofs/BrouwerFixedPointOQ04OQ01.lean",
+      "filename": "BrouwerFixedPointOQ04OQ01.lean",
+      "lineCount": 297,
+      "theoremCount": 8,
+      "axiomCount": 2,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04OQ01.lean"
+    },
+    {
       "path": "Proofs/BrouwerFixedPointOQ04OQ03.lean",
       "filename": "BrouwerFixedPointOQ04OQ03.lean",
       "lineCount": 157,
@@ -137,6 +159,7 @@
     "brouwer-fixed-point",
     "brouwer-fixed-point-oq-01",
     "brouwer-fixed-point-oq-01-oq-02",
+    "brouwer-fixed-point-oq-01-oq-03",
     "brouwer-fixed-point-oq-02",
     "brouwer-fixed-point-oq-02-oq-02",
     "brouwer-fixed-point-oq-04",

--- a/src/data/research/problems/brouwer-fixed-point-oq-04.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-04.json
@@ -66,6 +66,7 @@
     "brouwer-fixed-point",
     "brouwer-fixed-point-oq-01",
     "brouwer-fixed-point-oq-01-oq-02",
+    "brouwer-fixed-point-oq-01-oq-03",
     "brouwer-fixed-point-oq-02",
     "brouwer-fixed-point-oq-02-oq-02",
     "brouwer-fixed-point-oq-04",
@@ -113,6 +114,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ01OQ03.lean",
+      "filename": "BrouwerFixedPointOQ01OQ03.lean",
+      "lineCount": 217,
+      "theoremCount": 6,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ03.lean"
     },
     {
       "path": "Proofs/BrouwerFixedPointOQ02.lean",
@@ -179,6 +191,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ04OQ01.lean",
+      "filename": "BrouwerFixedPointOQ04OQ01.lean",
+      "lineCount": 297,
+      "theoremCount": 8,
+      "axiomCount": 2,
+      "defCount": 6,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04OQ01.lean"
     },
     {
       "path": "Proofs/BrouwerFixedPointOQ04OQ03.lean",

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
@@ -55,6 +55,7 @@
     "cauchy-schwarz-integral-oq-01-oq-01",
     "cauchy-schwarz-integral-oq-01-oq-01-oq-01",
     "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02",
+    "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01",
     "cauchy-schwarz-integral-oq-01-oq-01-oq-02",
     "cauchy-schwarz-integral-oq-01-oq-02",
     "cauchy-schwarz-integral-oq-02",

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
@@ -50,6 +50,7 @@
     "cauchy-schwarz-integral-oq-01-oq-01",
     "cauchy-schwarz-integral-oq-01-oq-01-oq-01",
     "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02",
+    "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01",
     "cauchy-schwarz-integral-oq-01-oq-01-oq-02",
     "cauchy-schwarz-integral-oq-01-oq-02",
     "cauchy-schwarz-integral-oq-02",

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
@@ -51,6 +51,7 @@
     "cauchy-schwarz-integral-oq-01-oq-01",
     "cauchy-schwarz-integral-oq-01-oq-01-oq-01",
     "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02",
+    "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01",
     "cauchy-schwarz-integral-oq-01-oq-01-oq-02",
     "cauchy-schwarz-integral-oq-01-oq-02",
     "cauchy-schwarz-integral-oq-02",

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-01.json
@@ -231,7 +231,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
-      "lineCount": 263,
+      "lineCount": 269,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-02.json
@@ -235,7 +235,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
-      "lineCount": 263,
+      "lineCount": 269,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-01.json
@@ -238,7 +238,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
-      "lineCount": 263,
+      "lineCount": 269,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01.json
@@ -236,7 +236,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
-      "lineCount": 263,
+      "lineCount": 269,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01.json
@@ -240,7 +240,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
-      "lineCount": 263,
+      "lineCount": 269,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-02.json
@@ -234,7 +234,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
-      "lineCount": 263,
+      "lineCount": 269,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02.json
@@ -273,7 +273,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
-      "lineCount": 263,
+      "lineCount": 269,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-03.json
@@ -241,7 +241,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
-      "lineCount": 263,
+      "lineCount": 269,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02.json
@@ -244,7 +244,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
-      "lineCount": 263,
+      "lineCount": 269,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-03.json
@@ -287,7 +287,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
-      "lineCount": 263,
+      "lineCount": 269,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-04.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-04.json
@@ -244,7 +244,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
-      "lineCount": 263,
+      "lineCount": 269,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-01.json
@@ -255,7 +255,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
-      "lineCount": 263,
+      "lineCount": 269,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-02.json
@@ -268,7 +268,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
-      "lineCount": 263,
+      "lineCount": 269,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-03.json
@@ -277,7 +277,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
-      "lineCount": 263,
+      "lineCount": 269,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-04.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-04.json
@@ -279,7 +279,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
-      "lineCount": 263,
+      "lineCount": 269,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01.json
@@ -236,7 +236,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
-      "lineCount": 263,
+      "lineCount": 269,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-02.json
@@ -269,7 +269,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
-      "lineCount": 263,
+      "lineCount": 269,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05.json
@@ -201,7 +201,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
-      "lineCount": 263,
+      "lineCount": 269,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cayley-hamilton-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-oq-01-oq-01.json
@@ -253,7 +253,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
-      "lineCount": 263,
+      "lineCount": 269,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
@@ -282,6 +282,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonOQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonOQ01OQ01.lean",
+      "filename": "CayleyHamiltonOQ01OQ01.lean",
+      "lineCount": 146,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonOQ01OQ01.lean"
     },
     {
       "path": "Proofs/CayleyHamiltonOQ02.lean",
@@ -319,7 +330,7 @@
     {
       "path": "Proofs/CayleyHamiltonReductionOQ02OQ01.lean",
       "filename": "CayleyHamiltonReductionOQ02OQ01.lean",
-      "lineCount": 268,
+      "lineCount": 397,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/cayley-hamilton-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-oq-01.json
@@ -249,7 +249,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
-      "lineCount": 263,
+      "lineCount": 269,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
@@ -278,6 +278,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonOQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonOQ01OQ01.lean",
+      "filename": "CayleyHamiltonOQ01OQ01.lean",
+      "lineCount": 146,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonOQ01OQ01.lean"
     },
     {
       "path": "Proofs/CayleyHamiltonOQ02.lean",
@@ -315,7 +326,7 @@
     {
       "path": "Proofs/CayleyHamiltonReductionOQ02OQ01.lean",
       "filename": "CayleyHamiltonReductionOQ02OQ01.lean",
-      "lineCount": 268,
+      "lineCount": 397,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/cayley-hamilton-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-oq-02.json
@@ -254,7 +254,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
-      "lineCount": 263,
+      "lineCount": 269,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
@@ -283,6 +283,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonOQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonOQ01OQ01.lean",
+      "filename": "CayleyHamiltonOQ01OQ01.lean",
+      "lineCount": 146,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonOQ01OQ01.lean"
     },
     {
       "path": "Proofs/CayleyHamiltonOQ02.lean",
@@ -320,7 +331,7 @@
     {
       "path": "Proofs/CayleyHamiltonReductionOQ02OQ01.lean",
       "filename": "CayleyHamiltonReductionOQ02OQ01.lean",
-      "lineCount": 268,
+      "lineCount": 397,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/cayley-hamilton-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-oq-03.json
@@ -252,7 +252,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
-      "lineCount": 263,
+      "lineCount": 269,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
@@ -281,6 +281,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonOQ01.lean"
+    },
+    {
+      "path": "Proofs/CayleyHamiltonOQ01OQ01.lean",
+      "filename": "CayleyHamiltonOQ01OQ01.lean",
+      "lineCount": 146,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonOQ01OQ01.lean"
     },
     {
       "path": "Proofs/CayleyHamiltonOQ02.lean",
@@ -318,7 +329,7 @@
     {
       "path": "Proofs/CayleyHamiltonReductionOQ02OQ01.lean",
       "filename": "CayleyHamiltonReductionOQ02OQ01.lean",
-      "lineCount": 268,
+      "lineCount": 397,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/cayley-hamilton-reduction-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-reduction-oq-01-oq-01.json
@@ -77,7 +77,7 @@
     {
       "path": "Proofs/CayleyHamiltonReductionOQ02OQ01.lean",
       "filename": "CayleyHamiltonReductionOQ02OQ01.lean",
-      "lineCount": 268,
+      "lineCount": 397,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/cayley-hamilton-reduction-oq-01-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-reduction-oq-01-oq-02.json
@@ -77,7 +77,7 @@
     {
       "path": "Proofs/CayleyHamiltonReductionOQ02OQ01.lean",
       "filename": "CayleyHamiltonReductionOQ02OQ01.lean",
-      "lineCount": 268,
+      "lineCount": 397,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/cayley-hamilton-reduction-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-reduction-oq-01.json
@@ -88,7 +88,7 @@
     {
       "path": "Proofs/CayleyHamiltonReductionOQ02OQ01.lean",
       "filename": "CayleyHamiltonReductionOQ02OQ01.lean",
-      "lineCount": 268,
+      "lineCount": 397,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/cayley-hamilton-reduction-oq-02-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-reduction-oq-02-oq-01.json
@@ -106,7 +106,7 @@
     {
       "path": "Proofs/CayleyHamiltonReductionOQ02OQ01.lean",
       "filename": "CayleyHamiltonReductionOQ02OQ01.lean",
-      "lineCount": 268,
+      "lineCount": 397,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/cayley-hamilton-reduction-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-reduction-oq-02.json
@@ -42,7 +42,7 @@
     {
       "path": "Proofs/CayleyHamiltonReductionOQ02OQ01.lean",
       "filename": "CayleyHamiltonReductionOQ02OQ01.lean",
-      "lineCount": 268,
+      "lineCount": 397,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/cayley-hamilton-reduction-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-reduction-oq-03.json
@@ -81,7 +81,7 @@
     {
       "path": "Proofs/CayleyHamiltonReductionOQ02OQ01.lean",
       "filename": "CayleyHamiltonReductionOQ02OQ01.lean",
-      "lineCount": 268,
+      "lineCount": 397,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/central-limit-theorem-oq-01-oq-01.json
+++ b/src/data/research/problems/central-limit-theorem-oq-01-oq-01.json
@@ -107,6 +107,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ02.lean"
     },
     {
+      "path": "Proofs/CentralLimitTheoremOQ01OQ02OQ01.lean",
+      "filename": "CentralLimitTheoremOQ01OQ02OQ01.lean",
+      "lineCount": 113,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ02OQ01.lean"
+    },
+    {
       "path": "Proofs/CentralLimitTheoremOQ01OQ03.lean",
       "filename": "CentralLimitTheoremOQ01OQ03.lean",
       "lineCount": 147,

--- a/src/data/research/problems/central-limit-theorem-oq-01-oq-02.json
+++ b/src/data/research/problems/central-limit-theorem-oq-01-oq-02.json
@@ -132,6 +132,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ02.lean"
     },
     {
+      "path": "Proofs/CentralLimitTheoremOQ01OQ02OQ01.lean",
+      "filename": "CentralLimitTheoremOQ01OQ02OQ01.lean",
+      "lineCount": 113,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ02OQ01.lean"
+    },
+    {
       "path": "Proofs/CentralLimitTheoremOQ01OQ03.lean",
       "filename": "CentralLimitTheoremOQ01OQ03.lean",
       "lineCount": 147,

--- a/src/data/research/problems/central-limit-theorem-oq-01-oq-03.json
+++ b/src/data/research/problems/central-limit-theorem-oq-01-oq-03.json
@@ -110,6 +110,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ02.lean"
     },
     {
+      "path": "Proofs/CentralLimitTheoremOQ01OQ02OQ01.lean",
+      "filename": "CentralLimitTheoremOQ01OQ02OQ01.lean",
+      "lineCount": 113,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ02OQ01.lean"
+    },
+    {
       "path": "Proofs/CentralLimitTheoremOQ01OQ03.lean",
       "filename": "CentralLimitTheoremOQ01OQ03.lean",
       "lineCount": 147,

--- a/src/data/research/problems/central-limit-theorem-oq-01-oq-04.json
+++ b/src/data/research/problems/central-limit-theorem-oq-01-oq-04.json
@@ -100,6 +100,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ02.lean"
     },
     {
+      "path": "Proofs/CentralLimitTheoremOQ01OQ02OQ01.lean",
+      "filename": "CentralLimitTheoremOQ01OQ02OQ01.lean",
+      "lineCount": 113,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ02OQ01.lean"
+    },
+    {
       "path": "Proofs/CentralLimitTheoremOQ01OQ03.lean",
       "filename": "CentralLimitTheoremOQ01OQ03.lean",
       "lineCount": 147,

--- a/src/data/research/problems/central-limit-theorem-oq-01.json
+++ b/src/data/research/problems/central-limit-theorem-oq-01.json
@@ -115,6 +115,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ02.lean"
     },
     {
+      "path": "Proofs/CentralLimitTheoremOQ01OQ02OQ01.lean",
+      "filename": "CentralLimitTheoremOQ01OQ02OQ01.lean",
+      "lineCount": 113,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ02OQ01.lean"
+    },
+    {
       "path": "Proofs/CentralLimitTheoremOQ01OQ03.lean",
       "filename": "CentralLimitTheoremOQ01OQ03.lean",
       "lineCount": 147,

--- a/src/data/research/problems/central-limit-theorem-oq-02.json
+++ b/src/data/research/problems/central-limit-theorem-oq-02.json
@@ -107,6 +107,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ02.lean"
     },
     {
+      "path": "Proofs/CentralLimitTheoremOQ01OQ02OQ01.lean",
+      "filename": "CentralLimitTheoremOQ01OQ02OQ01.lean",
+      "lineCount": 113,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ02OQ01.lean"
+    },
+    {
       "path": "Proofs/CentralLimitTheoremOQ01OQ03.lean",
       "filename": "CentralLimitTheoremOQ01OQ03.lean",
       "lineCount": 147,

--- a/src/data/research/problems/central-limit-theorem-oq-03-oq-01.json
+++ b/src/data/research/problems/central-limit-theorem-oq-03-oq-01.json
@@ -105,6 +105,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ02.lean"
     },
     {
+      "path": "Proofs/CentralLimitTheoremOQ01OQ02OQ01.lean",
+      "filename": "CentralLimitTheoremOQ01OQ02OQ01.lean",
+      "lineCount": 113,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ02OQ01.lean"
+    },
+    {
       "path": "Proofs/CentralLimitTheoremOQ01OQ03.lean",
       "filename": "CentralLimitTheoremOQ01OQ03.lean",
       "lineCount": 147,

--- a/src/data/research/problems/central-limit-theorem-oq-03.json
+++ b/src/data/research/problems/central-limit-theorem-oq-03.json
@@ -106,6 +106,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ02.lean"
     },
     {
+      "path": "Proofs/CentralLimitTheoremOQ01OQ02OQ01.lean",
+      "filename": "CentralLimitTheoremOQ01OQ02OQ01.lean",
+      "lineCount": 113,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ02OQ01.lean"
+    },
+    {
       "path": "Proofs/CentralLimitTheoremOQ01OQ03.lean",
       "filename": "CentralLimitTheoremOQ01OQ03.lean",
       "lineCount": 147,

--- a/src/data/research/problems/central-limit-theorem-oq-04.json
+++ b/src/data/research/problems/central-limit-theorem-oq-04.json
@@ -148,6 +148,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ02.lean"
     },
     {
+      "path": "Proofs/CentralLimitTheoremOQ01OQ02OQ01.lean",
+      "filename": "CentralLimitTheoremOQ01OQ02OQ01.lean",
+      "lineCount": 113,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ01OQ02OQ01.lean"
+    },
+    {
       "path": "Proofs/CentralLimitTheoremOQ01OQ03.lean",
       "filename": "CentralLimitTheoremOQ01OQ03.lean",
       "lineCount": 147,

--- a/src/data/research/problems/chebyshev-bounds-oq-01.json
+++ b/src/data/research/problems/chebyshev-bounds-oq-01.json
@@ -58,7 +58,7 @@
     {
       "path": "Proofs/ChebyshevBounds.lean",
       "filename": "ChebyshevBounds.lean",
-      "lineCount": 446,
+      "lineCount": 440,
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/combinations-formula-oq-01-oq-01.json
+++ b/src/data/research/problems/combinations-formula-oq-01-oq-01.json
@@ -1,0 +1,92 @@
+{
+  "slug": "combinations-formula-oq-01-oq-01",
+  "title": "Fibonacci Diagonal Sum Identity via Binomial Coefficients",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\sum_{j=0}^{\\lfloor n/2 \\rfloor} \\binom{n-j}{j} = F(n+1)",
+    "plain": "The sum of binomial coefficients along the \"diagonal\" of Pascal's triangle — specifically the terms $\\binom{n}{0} + \\binom{n-1}{1} + \\binom{n-2}{2} + \\cdots$ — equals the $(n+1)$-th Fibonacci number. Prove this by induction using the Fibonacci recurrence $F(n+2)=F(n+1)+F(n)$ and Pascal's rule $\\binom{n}{k} = \\binom{n-1}{k} + \\binom{n-1}{k-1}$.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-04-05T03:20:16-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [],
+    "markdown": "# Knowledge Base: combinations-formula-oq-01-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "combinatorics",
+    "fibonacci",
+    "binomial-coefficients",
+    "induction"
+  ],
+  "relatedProofs": [
+    "combinations-formula",
+    "combinations-formula-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-04-05T03:20:16-07:00",
+  "significance": 6,
+  "tractability": 7,
+  "leanFiles": [
+    {
+      "path": "Proofs/CombinationsFormula.lean",
+      "filename": "CombinationsFormula.lean",
+      "lineCount": 401,
+      "theoremCount": 25,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CombinationsFormula.lean"
+    },
+    {
+      "path": "Proofs/CombinationsFormulaOQ01.lean",
+      "filename": "CombinationsFormulaOQ01.lean",
+      "lineCount": 186,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CombinationsFormulaOQ01.lean"
+    },
+    {
+      "path": "Proofs/CombinationsFormulaOQ03.lean",
+      "filename": "CombinationsFormulaOQ03.lean",
+      "lineCount": 751,
+      "theoremCount": 24,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CombinationsFormulaOQ03.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/cramers-rule-oq-01-oq-01.json
+++ b/src/data/research/problems/cramers-rule-oq-01-oq-01.json
@@ -62,7 +62,13 @@
   ],
   "relatedProofs": [
     "cramers-rule",
-    "cramers-rule-oq-01"
+    "cramers-rule-oq-01",
+    "cramers-rule-oq-01-oq-02",
+    "cramers-rule-oq-01-oq-03",
+    "cramers-rule-oq-01-oq-04",
+    "cramers-rule-oq-02",
+    "cramers-rule-oq-03",
+    "cramers-rule-oq-04"
   ],
   "references": {
     "papers": [],
@@ -77,10 +83,10 @@
     {
       "path": "Proofs/CramersRule.lean",
       "filename": "CramersRule.lean",
-      "lineCount": 161,
+      "lineCount": 162,
       "theoremCount": 9,
       "axiomCount": 0,
-      "defCount": 2,
+      "defCount": 0,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRule.lean"
@@ -88,10 +94,10 @@
     {
       "path": "Proofs/CramersRuleOQ01.lean",
       "filename": "CramersRuleOQ01.lean",
-      "lineCount": 282,
+      "lineCount": 283,
       "theoremCount": 13,
       "axiomCount": 0,
-      "defCount": 3,
+      "defCount": 0,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRuleOQ01.lean"
@@ -99,10 +105,10 @@
     {
       "path": "Proofs/CramersRuleOQ01OQ02.lean",
       "filename": "CramersRuleOQ01OQ02.lean",
-      "lineCount": 462,
+      "lineCount": 463,
       "theoremCount": 26,
       "axiomCount": 0,
-      "defCount": 5,
+      "defCount": 6,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRuleOQ01OQ02.lean"
@@ -110,21 +116,21 @@
     {
       "path": "Proofs/CramersRuleOQ01OQ03.lean",
       "filename": "CramersRuleOQ01OQ03.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 11,
       "axiomCount": 0,
-      "defCount": 4,
-      "sorryCount": 0,
+      "defCount": 10,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRuleOQ01OQ03.lean"
     },
     {
       "path": "Proofs/CramersRuleOQ01OQ04.lean",
       "filename": "CramersRuleOQ01OQ04.lean",
-      "lineCount": 327,
+      "lineCount": 328,
       "theoremCount": 17,
       "axiomCount": 4,
-      "defCount": 3,
+      "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRuleOQ01OQ04.lean"
@@ -132,10 +138,10 @@
     {
       "path": "Proofs/CramersRuleOQ02.lean",
       "filename": "CramersRuleOQ02.lean",
-      "lineCount": 207,
-      "theoremCount": 7,
+      "lineCount": 208,
+      "theoremCount": 16,
       "axiomCount": 0,
-      "defCount": 2,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRuleOQ02.lean"
@@ -143,10 +149,10 @@
     {
       "path": "Proofs/CramersRuleOQ03.lean",
       "filename": "CramersRuleOQ03.lean",
-      "lineCount": 175,
+      "lineCount": 176,
       "theoremCount": 8,
       "axiomCount": 0,
-      "defCount": 2,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRuleOQ03.lean"
@@ -154,10 +160,10 @@
     {
       "path": "Proofs/CramersRuleOQ04.lean",
       "filename": "CramersRuleOQ04.lean",
-      "lineCount": 175,
+      "lineCount": 176,
       "theoremCount": 11,
       "axiomCount": 0,
-      "defCount": 2,
+      "defCount": 0,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRuleOQ04.lean"

--- a/src/data/research/problems/derangements-convergence-oq-01.json
+++ b/src/data/research/problems/derangements-convergence-oq-01.json
@@ -45,7 +45,8 @@
   ],
   "relatedProofs": [
     "derangements",
-    "derangements-convergence"
+    "derangements-convergence",
+    "derangements-convergence-oq-01"
   ],
   "references": {
     "papers": [],
@@ -68,6 +69,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergence.lean"
+    },
+    {
+      "path": "Proofs/DerangementsConvergenceOQ01.lean",
+      "filename": "DerangementsConvergenceOQ01.lean",
+      "lineCount": 152,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 5,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ01.lean"
     }
   ]
 }

--- a/src/data/research/problems/derangements-oq-01.json
+++ b/src/data/research/problems/derangements-oq-01.json
@@ -44,6 +44,7 @@
   "relatedProofs": [
     "derangements",
     "derangements-convergence",
+    "derangements-convergence-oq-01",
     "derangements-oq-02",
     "derangements-oq-02-oq-01",
     "derangements-oq-02-oq-02",
@@ -83,6 +84,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergence.lean"
+    },
+    {
+      "path": "Proofs/DerangementsConvergenceOQ01.lean",
+      "filename": "DerangementsConvergenceOQ01.lean",
+      "lineCount": 152,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 5,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ01.lean"
     },
     {
       "path": "Proofs/DerangementsOQ02.lean",

--- a/src/data/research/problems/derangements-oq-02-oq-01.json
+++ b/src/data/research/problems/derangements-oq-02-oq-01.json
@@ -46,6 +46,7 @@
   "relatedProofs": [
     "derangements",
     "derangements-convergence",
+    "derangements-convergence-oq-01",
     "derangements-oq-02",
     "derangements-oq-02-oq-01",
     "derangements-oq-02-oq-02",
@@ -85,6 +86,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergence.lean"
+    },
+    {
+      "path": "Proofs/DerangementsConvergenceOQ01.lean",
+      "filename": "DerangementsConvergenceOQ01.lean",
+      "lineCount": 152,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 5,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ01.lean"
     },
     {
       "path": "Proofs/DerangementsOQ02.lean",

--- a/src/data/research/problems/derangements-oq-02-oq-02.json
+++ b/src/data/research/problems/derangements-oq-02-oq-02.json
@@ -64,6 +64,7 @@
   "relatedProofs": [
     "derangements",
     "derangements-convergence",
+    "derangements-convergence-oq-01",
     "derangements-oq-02",
     "derangements-oq-02-oq-01",
     "derangements-oq-02-oq-02",
@@ -102,6 +103,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergence.lean"
+    },
+    {
+      "path": "Proofs/DerangementsConvergenceOQ01.lean",
+      "filename": "DerangementsConvergenceOQ01.lean",
+      "lineCount": 152,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 5,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ01.lean"
     },
     {
       "path": "Proofs/DerangementsOQ02.lean",

--- a/src/data/research/problems/derangements-oq-02.json
+++ b/src/data/research/problems/derangements-oq-02.json
@@ -44,6 +44,7 @@
   "relatedProofs": [
     "derangements",
     "derangements-convergence",
+    "derangements-convergence-oq-01",
     "derangements-oq-02",
     "derangements-oq-02-oq-01",
     "derangements-oq-02-oq-02",
@@ -83,6 +84,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergence.lean"
+    },
+    {
+      "path": "Proofs/DerangementsConvergenceOQ01.lean",
+      "filename": "DerangementsConvergenceOQ01.lean",
+      "lineCount": 152,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 5,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ01.lean"
     },
     {
       "path": "Proofs/DerangementsOQ02.lean",

--- a/src/data/research/problems/derangements-oq-03-oq-01.json
+++ b/src/data/research/problems/derangements-oq-03-oq-01.json
@@ -52,6 +52,7 @@
   "relatedProofs": [
     "derangements",
     "derangements-convergence",
+    "derangements-convergence-oq-01",
     "derangements-oq-02",
     "derangements-oq-02-oq-01",
     "derangements-oq-02-oq-02",
@@ -88,6 +89,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergence.lean"
+    },
+    {
+      "path": "Proofs/DerangementsConvergenceOQ01.lean",
+      "filename": "DerangementsConvergenceOQ01.lean",
+      "lineCount": 152,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 5,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ01.lean"
     },
     {
       "path": "Proofs/DerangementsOQ02.lean",

--- a/src/data/research/problems/derangements-oq-03-oq-02.json
+++ b/src/data/research/problems/derangements-oq-03-oq-02.json
@@ -52,6 +52,7 @@
   "relatedProofs": [
     "derangements",
     "derangements-convergence",
+    "derangements-convergence-oq-01",
     "derangements-oq-02",
     "derangements-oq-02-oq-01",
     "derangements-oq-02-oq-02",
@@ -88,6 +89,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergence.lean"
+    },
+    {
+      "path": "Proofs/DerangementsConvergenceOQ01.lean",
+      "filename": "DerangementsConvergenceOQ01.lean",
+      "lineCount": 152,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 5,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ01.lean"
     },
     {
       "path": "Proofs/DerangementsOQ02.lean",

--- a/src/data/research/problems/derangements-oq-03.json
+++ b/src/data/research/problems/derangements-oq-03.json
@@ -44,6 +44,7 @@
   "relatedProofs": [
     "derangements",
     "derangements-convergence",
+    "derangements-convergence-oq-01",
     "derangements-oq-02",
     "derangements-oq-02-oq-01",
     "derangements-oq-02-oq-02",
@@ -83,6 +84,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergence.lean"
+    },
+    {
+      "path": "Proofs/DerangementsConvergenceOQ01.lean",
+      "filename": "DerangementsConvergenceOQ01.lean",
+      "lineCount": 152,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 5,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ01.lean"
     },
     {
       "path": "Proofs/DerangementsOQ02.lean",

--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-01-oq-01.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-01-oq-01.json
@@ -40,6 +40,7 @@
   "relatedProofs": [
     "elementary-quadratic-reciprocity",
     "elementary-quadratic-reciprocity-oq-01",
+    "elementary-quadratic-reciprocity-oq-01-oq-01",
     "elementary-quadratic-reciprocity-oq-02",
     "elementary-quadratic-reciprocity-oq-03",
     "elementary-quadratic-reciprocity-oq-03-oq-01",
@@ -78,6 +79,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocityOQ01.lean"
+    },
+    {
+      "path": "Proofs/ElementaryQuadraticReciprocityOQ01OQ01.lean",
+      "filename": "ElementaryQuadraticReciprocityOQ01OQ01.lean",
+      "lineCount": 169,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ01.lean"
     },
     {
       "path": "Proofs/ElementaryQuadraticReciprocityOQ02.lean",

--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-01.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-01.json
@@ -44,6 +44,7 @@
   "relatedProofs": [
     "elementary-quadratic-reciprocity",
     "elementary-quadratic-reciprocity-oq-01",
+    "elementary-quadratic-reciprocity-oq-01-oq-01",
     "elementary-quadratic-reciprocity-oq-02",
     "elementary-quadratic-reciprocity-oq-03",
     "elementary-quadratic-reciprocity-oq-03-oq-01",
@@ -85,6 +86,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocityOQ01.lean"
+    },
+    {
+      "path": "Proofs/ElementaryQuadraticReciprocityOQ01OQ01.lean",
+      "filename": "ElementaryQuadraticReciprocityOQ01OQ01.lean",
+      "lineCount": 169,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ01.lean"
     },
     {
       "path": "Proofs/ElementaryQuadraticReciprocityOQ02.lean",

--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-02.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-02.json
@@ -50,6 +50,7 @@
   "relatedProofs": [
     "elementary-quadratic-reciprocity",
     "elementary-quadratic-reciprocity-oq-01",
+    "elementary-quadratic-reciprocity-oq-01-oq-01",
     "elementary-quadratic-reciprocity-oq-02",
     "elementary-quadratic-reciprocity-oq-03",
     "elementary-quadratic-reciprocity-oq-03-oq-01",
@@ -90,6 +91,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocityOQ01.lean"
+    },
+    {
+      "path": "Proofs/ElementaryQuadraticReciprocityOQ01OQ01.lean",
+      "filename": "ElementaryQuadraticReciprocityOQ01OQ01.lean",
+      "lineCount": 169,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ01.lean"
     },
     {
       "path": "Proofs/ElementaryQuadraticReciprocityOQ02.lean",

--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-01-oq-01-oq-04.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-01-oq-01-oq-04.json
@@ -44,6 +44,7 @@
   "relatedProofs": [
     "elementary-quadratic-reciprocity",
     "elementary-quadratic-reciprocity-oq-01",
+    "elementary-quadratic-reciprocity-oq-01-oq-01",
     "elementary-quadratic-reciprocity-oq-02",
     "elementary-quadratic-reciprocity-oq-03",
     "elementary-quadratic-reciprocity-oq-03-oq-01",
@@ -81,6 +82,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocityOQ01.lean"
+    },
+    {
+      "path": "Proofs/ElementaryQuadraticReciprocityOQ01OQ01.lean",
+      "filename": "ElementaryQuadraticReciprocityOQ01OQ01.lean",
+      "lineCount": 169,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ01.lean"
     },
     {
       "path": "Proofs/ElementaryQuadraticReciprocityOQ02.lean",

--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-01-oq-01.json
@@ -47,6 +47,7 @@
   "relatedProofs": [
     "elementary-quadratic-reciprocity",
     "elementary-quadratic-reciprocity-oq-01",
+    "elementary-quadratic-reciprocity-oq-01-oq-01",
     "elementary-quadratic-reciprocity-oq-02",
     "elementary-quadratic-reciprocity-oq-03",
     "elementary-quadratic-reciprocity-oq-03-oq-01",
@@ -88,6 +89,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocityOQ01.lean"
+    },
+    {
+      "path": "Proofs/ElementaryQuadraticReciprocityOQ01OQ01.lean",
+      "filename": "ElementaryQuadraticReciprocityOQ01OQ01.lean",
+      "lineCount": 169,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ01.lean"
     },
     {
       "path": "Proofs/ElementaryQuadraticReciprocityOQ02.lean",

--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-01-oq-02.json
@@ -47,6 +47,7 @@
   "relatedProofs": [
     "elementary-quadratic-reciprocity",
     "elementary-quadratic-reciprocity-oq-01",
+    "elementary-quadratic-reciprocity-oq-01-oq-01",
     "elementary-quadratic-reciprocity-oq-02",
     "elementary-quadratic-reciprocity-oq-03",
     "elementary-quadratic-reciprocity-oq-03-oq-01",
@@ -88,6 +89,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocityOQ01.lean"
+    },
+    {
+      "path": "Proofs/ElementaryQuadraticReciprocityOQ01OQ01.lean",
+      "filename": "ElementaryQuadraticReciprocityOQ01OQ01.lean",
+      "lineCount": 169,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ01.lean"
     },
     {
       "path": "Proofs/ElementaryQuadraticReciprocityOQ02.lean",

--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-01.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-01.json
@@ -72,6 +72,7 @@
   "relatedProofs": [
     "elementary-quadratic-reciprocity",
     "elementary-quadratic-reciprocity-oq-01",
+    "elementary-quadratic-reciprocity-oq-01-oq-01",
     "elementary-quadratic-reciprocity-oq-02",
     "elementary-quadratic-reciprocity-oq-03",
     "elementary-quadratic-reciprocity-oq-03-oq-01",
@@ -120,6 +121,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocityOQ01.lean"
+    },
+    {
+      "path": "Proofs/ElementaryQuadraticReciprocityOQ01OQ01.lean",
+      "filename": "ElementaryQuadraticReciprocityOQ01OQ01.lean",
+      "lineCount": 169,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ01.lean"
     },
     {
       "path": "Proofs/ElementaryQuadraticReciprocityOQ02.lean",

--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02-oq-01.json
@@ -62,6 +62,7 @@
   "relatedProofs": [
     "elementary-quadratic-reciprocity",
     "elementary-quadratic-reciprocity-oq-01",
+    "elementary-quadratic-reciprocity-oq-01-oq-01",
     "elementary-quadratic-reciprocity-oq-02",
     "elementary-quadratic-reciprocity-oq-03",
     "elementary-quadratic-reciprocity-oq-03-oq-01",
@@ -100,6 +101,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocityOQ01.lean"
+    },
+    {
+      "path": "Proofs/ElementaryQuadraticReciprocityOQ01OQ01.lean",
+      "filename": "ElementaryQuadraticReciprocityOQ01OQ01.lean",
+      "lineCount": 169,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ01.lean"
     },
     {
       "path": "Proofs/ElementaryQuadraticReciprocityOQ02.lean",

--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-02.json
@@ -46,6 +46,7 @@
   "relatedProofs": [
     "elementary-quadratic-reciprocity",
     "elementary-quadratic-reciprocity-oq-01",
+    "elementary-quadratic-reciprocity-oq-01-oq-01",
     "elementary-quadratic-reciprocity-oq-02",
     "elementary-quadratic-reciprocity-oq-03",
     "elementary-quadratic-reciprocity-oq-03-oq-01",
@@ -87,6 +88,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocityOQ01.lean"
+    },
+    {
+      "path": "Proofs/ElementaryQuadraticReciprocityOQ01OQ01.lean",
+      "filename": "ElementaryQuadraticReciprocityOQ01OQ01.lean",
+      "lineCount": 169,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ01.lean"
     },
     {
       "path": "Proofs/ElementaryQuadraticReciprocityOQ02.lean",

--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-03.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-03-oq-03.json
@@ -54,6 +54,7 @@
   "relatedProofs": [
     "elementary-quadratic-reciprocity",
     "elementary-quadratic-reciprocity-oq-01",
+    "elementary-quadratic-reciprocity-oq-01-oq-01",
     "elementary-quadratic-reciprocity-oq-02",
     "elementary-quadratic-reciprocity-oq-03",
     "elementary-quadratic-reciprocity-oq-03-oq-01",
@@ -89,6 +90,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocityOQ01.lean"
+    },
+    {
+      "path": "Proofs/ElementaryQuadraticReciprocityOQ01OQ01.lean",
+      "filename": "ElementaryQuadraticReciprocityOQ01OQ01.lean",
+      "lineCount": 169,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ01.lean"
     },
     {
       "path": "Proofs/ElementaryQuadraticReciprocityOQ02.lean",

--- a/src/data/research/problems/erdos-1-oq-01.json
+++ b/src/data/research/problems/erdos-1-oq-01.json
@@ -501,6 +501,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1003Problem.lean"
     },
     {
+      "path": "Proofs/Erdos1004OQ04.lean",
+      "filename": "Erdos1004OQ04.lean",
+      "lineCount": 134,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1004OQ04.lean"
+    },
+    {
       "path": "Proofs/Erdos1004Problem.lean",
       "filename": "Erdos1004Problem.lean",
       "lineCount": 610,
@@ -789,7 +800,7 @@
     {
       "path": "Proofs/Erdos1012OQ03.lean",
       "filename": "Erdos1012OQ03.lean",
-      "lineCount": 1373,
+      "lineCount": 1170,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 9,
@@ -800,8 +811,8 @@
     {
       "path": "Proofs/Erdos1012OQ03Aristotle.lean",
       "filename": "Erdos1012OQ03Aristotle.lean",
-      "lineCount": 53,
-      "theoremCount": 2,
+      "lineCount": 33,
+      "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 1,
@@ -1724,8 +1735,8 @@
     {
       "path": "Proofs/Erdos1059OQ01.lean",
       "filename": "Erdos1059OQ01.lean",
-      "lineCount": 457,
-      "theoremCount": 28,
+      "lineCount": 347,
+      "theoremCount": 32,
       "axiomCount": 1,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1-oq-02.json
+++ b/src/data/research/problems/erdos-1-oq-02.json
@@ -116,6 +116,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1003Problem.lean"
     },
     {
+      "path": "Proofs/Erdos1004OQ04.lean",
+      "filename": "Erdos1004OQ04.lean",
+      "lineCount": 134,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1004OQ04.lean"
+    },
+    {
       "path": "Proofs/Erdos1004Problem.lean",
       "filename": "Erdos1004Problem.lean",
       "lineCount": 610,
@@ -404,7 +415,7 @@
     {
       "path": "Proofs/Erdos1012OQ03.lean",
       "filename": "Erdos1012OQ03.lean",
-      "lineCount": 1373,
+      "lineCount": 1170,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 9,
@@ -415,8 +426,8 @@
     {
       "path": "Proofs/Erdos1012OQ03Aristotle.lean",
       "filename": "Erdos1012OQ03Aristotle.lean",
-      "lineCount": 53,
-      "theoremCount": 2,
+      "lineCount": 33,
+      "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 1,
@@ -1339,8 +1350,8 @@
     {
       "path": "Proofs/Erdos1059OQ01.lean",
       "filename": "Erdos1059OQ01.lean",
-      "lineCount": 457,
-      "theoremCount": 28,
+      "lineCount": 347,
+      "theoremCount": 32,
       "axiomCount": 1,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1-oq-03.json
+++ b/src/data/research/problems/erdos-1-oq-03.json
@@ -521,6 +521,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1003Problem.lean"
     },
     {
+      "path": "Proofs/Erdos1004OQ04.lean",
+      "filename": "Erdos1004OQ04.lean",
+      "lineCount": 134,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1004OQ04.lean"
+    },
+    {
       "path": "Proofs/Erdos1004Problem.lean",
       "filename": "Erdos1004Problem.lean",
       "lineCount": 610,
@@ -809,7 +820,7 @@
     {
       "path": "Proofs/Erdos1012OQ03.lean",
       "filename": "Erdos1012OQ03.lean",
-      "lineCount": 1373,
+      "lineCount": 1170,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 9,
@@ -820,8 +831,8 @@
     {
       "path": "Proofs/Erdos1012OQ03Aristotle.lean",
       "filename": "Erdos1012OQ03Aristotle.lean",
-      "lineCount": 53,
-      "theoremCount": 2,
+      "lineCount": 33,
+      "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 1,
@@ -1744,8 +1755,8 @@
     {
       "path": "Proofs/Erdos1059OQ01.lean",
       "filename": "Erdos1059OQ01.lean",
-      "lineCount": 457,
-      "theoremCount": 28,
+      "lineCount": 347,
+      "theoremCount": 32,
       "axiomCount": 1,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1-oq-04.json
+++ b/src/data/research/problems/erdos-1-oq-04.json
@@ -498,6 +498,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1003Problem.lean"
     },
     {
+      "path": "Proofs/Erdos1004OQ04.lean",
+      "filename": "Erdos1004OQ04.lean",
+      "lineCount": 134,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1004OQ04.lean"
+    },
+    {
       "path": "Proofs/Erdos1004Problem.lean",
       "filename": "Erdos1004Problem.lean",
       "lineCount": 610,
@@ -786,7 +797,7 @@
     {
       "path": "Proofs/Erdos1012OQ03.lean",
       "filename": "Erdos1012OQ03.lean",
-      "lineCount": 1373,
+      "lineCount": 1170,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 9,
@@ -797,8 +808,8 @@
     {
       "path": "Proofs/Erdos1012OQ03Aristotle.lean",
       "filename": "Erdos1012OQ03Aristotle.lean",
-      "lineCount": 53,
-      "theoremCount": 2,
+      "lineCount": 33,
+      "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 1,
@@ -1721,8 +1732,8 @@
     {
       "path": "Proofs/Erdos1059OQ01.lean",
       "filename": "Erdos1059OQ01.lean",
-      "lineCount": 457,
-      "theoremCount": 28,
+      "lineCount": 347,
+      "theoremCount": 32,
       "axiomCount": 1,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-10-oq-01.json
+++ b/src/data/research/problems/erdos-10-oq-01.json
@@ -315,6 +315,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1003Problem.lean"
     },
     {
+      "path": "Proofs/Erdos1004OQ04.lean",
+      "filename": "Erdos1004OQ04.lean",
+      "lineCount": 134,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1004OQ04.lean"
+    },
+    {
       "path": "Proofs/Erdos1004Problem.lean",
       "filename": "Erdos1004Problem.lean",
       "lineCount": 610,
@@ -603,7 +614,7 @@
     {
       "path": "Proofs/Erdos1012OQ03.lean",
       "filename": "Erdos1012OQ03.lean",
-      "lineCount": 1373,
+      "lineCount": 1170,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 9,
@@ -614,8 +625,8 @@
     {
       "path": "Proofs/Erdos1012OQ03Aristotle.lean",
       "filename": "Erdos1012OQ03Aristotle.lean",
-      "lineCount": 53,
-      "theoremCount": 2,
+      "lineCount": 33,
+      "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 1,
@@ -1538,8 +1549,8 @@
     {
       "path": "Proofs/Erdos1059OQ01.lean",
       "filename": "Erdos1059OQ01.lean",
-      "lineCount": 457,
-      "theoremCount": 28,
+      "lineCount": 347,
+      "theoremCount": 32,
       "axiomCount": 1,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-10.json
+++ b/src/data/research/problems/erdos-10.json
@@ -301,6 +301,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1003Problem.lean"
     },
     {
+      "path": "Proofs/Erdos1004OQ04.lean",
+      "filename": "Erdos1004OQ04.lean",
+      "lineCount": 134,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1004OQ04.lean"
+    },
+    {
       "path": "Proofs/Erdos1004Problem.lean",
       "filename": "Erdos1004Problem.lean",
       "lineCount": 610,
@@ -589,7 +600,7 @@
     {
       "path": "Proofs/Erdos1012OQ03.lean",
       "filename": "Erdos1012OQ03.lean",
-      "lineCount": 1373,
+      "lineCount": 1170,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 9,
@@ -600,8 +611,8 @@
     {
       "path": "Proofs/Erdos1012OQ03Aristotle.lean",
       "filename": "Erdos1012OQ03Aristotle.lean",
-      "lineCount": 53,
-      "theoremCount": 2,
+      "lineCount": 33,
+      "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 1,
@@ -1524,8 +1535,8 @@
     {
       "path": "Proofs/Erdos1059OQ01.lean",
       "filename": "Erdos1059OQ01.lean",
-      "lineCount": 457,
-      "theoremCount": 28,
+      "lineCount": 347,
+      "theoremCount": 32,
       "axiomCount": 1,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-100-oq-01.json
+++ b/src/data/research/problems/erdos-100-oq-01.json
@@ -108,6 +108,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1003Problem.lean"
     },
     {
+      "path": "Proofs/Erdos1004OQ04.lean",
+      "filename": "Erdos1004OQ04.lean",
+      "lineCount": 134,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1004OQ04.lean"
+    },
+    {
       "path": "Proofs/Erdos1004Problem.lean",
       "filename": "Erdos1004Problem.lean",
       "lineCount": 610,

--- a/src/data/research/problems/erdos-100-oq-04.json
+++ b/src/data/research/problems/erdos-100-oq-04.json
@@ -166,6 +166,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1003Problem.lean"
     },
     {
+      "path": "Proofs/Erdos1004OQ04.lean",
+      "filename": "Erdos1004OQ04.lean",
+      "lineCount": 134,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1004OQ04.lean"
+    },
+    {
       "path": "Proofs/Erdos1004Problem.lean",
       "filename": "Erdos1004Problem.lean",
       "lineCount": 610,

--- a/src/data/research/problems/erdos-100.json
+++ b/src/data/research/problems/erdos-100.json
@@ -208,6 +208,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1003Problem.lean"
     },
     {
+      "path": "Proofs/Erdos1004OQ04.lean",
+      "filename": "Erdos1004OQ04.lean",
+      "lineCount": 134,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1004OQ04.lean"
+    },
+    {
       "path": "Proofs/Erdos1004Problem.lean",
       "filename": "Erdos1004Problem.lean",
       "lineCount": 610,

--- a/src/data/research/problems/erdos-1004-oq-02.json
+++ b/src/data/research/problems/erdos-1004-oq-02.json
@@ -58,6 +58,17 @@
   "tractability": 5,
   "leanFiles": [
     {
+      "path": "Proofs/Erdos1004OQ04.lean",
+      "filename": "Erdos1004OQ04.lean",
+      "lineCount": 134,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1004OQ04.lean"
+    },
+    {
       "path": "Proofs/Erdos1004Problem.lean",
       "filename": "Erdos1004Problem.lean",
       "lineCount": 610,

--- a/src/data/research/problems/erdos-1004-oq-04.json
+++ b/src/data/research/problems/erdos-1004-oq-04.json
@@ -86,13 +86,24 @@
     {
       "path": "Proofs/Erdos1004OQ04.lean",
       "filename": "Erdos1004OQ04.lean",
-      "lineCount": 120,
+      "lineCount": 134,
       "theoremCount": 11,
-      "axiomCount": 3,
+      "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1004OQ04.lean"
+    },
+    {
+      "path": "Proofs/Erdos1004Problem.lean",
+      "filename": "Erdos1004Problem.lean",
+      "lineCount": 610,
+      "theoremCount": 22,
+      "axiomCount": 3,
+      "defCount": 15,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1004Problem.lean"
     }
   ]
 }

--- a/src/data/research/problems/erdos-101-oq-04.json
+++ b/src/data/research/problems/erdos-101-oq-04.json
@@ -132,7 +132,7 @@
     {
       "path": "Proofs/Erdos1012OQ03.lean",
       "filename": "Erdos1012OQ03.lean",
-      "lineCount": 1373,
+      "lineCount": 1170,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 9,
@@ -143,8 +143,8 @@
     {
       "path": "Proofs/Erdos1012OQ03Aristotle.lean",
       "filename": "Erdos1012OQ03Aristotle.lean",
-      "lineCount": 53,
-      "theoremCount": 2,
+      "lineCount": 33,
+      "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 1,

--- a/src/data/research/problems/erdos-101.json
+++ b/src/data/research/problems/erdos-101.json
@@ -134,7 +134,7 @@
     {
       "path": "Proofs/Erdos1012OQ03.lean",
       "filename": "Erdos1012OQ03.lean",
-      "lineCount": 1373,
+      "lineCount": 1170,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 9,
@@ -145,8 +145,8 @@
     {
       "path": "Proofs/Erdos1012OQ03Aristotle.lean",
       "filename": "Erdos1012OQ03Aristotle.lean",
-      "lineCount": 53,
-      "theoremCount": 2,
+      "lineCount": 33,
+      "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 1,

--- a/src/data/research/problems/erdos-1012-oq-01.json
+++ b/src/data/research/problems/erdos-1012-oq-01.json
@@ -80,7 +80,7 @@
     {
       "path": "Proofs/Erdos1012OQ03.lean",
       "filename": "Erdos1012OQ03.lean",
-      "lineCount": 1373,
+      "lineCount": 1170,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 9,
@@ -91,8 +91,8 @@
     {
       "path": "Proofs/Erdos1012OQ03Aristotle.lean",
       "filename": "Erdos1012OQ03Aristotle.lean",
-      "lineCount": 53,
-      "theoremCount": 2,
+      "lineCount": 33,
+      "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 1,

--- a/src/data/research/problems/erdos-1012-oq-02.json
+++ b/src/data/research/problems/erdos-1012-oq-02.json
@@ -91,7 +91,7 @@
     {
       "path": "Proofs/Erdos1012OQ03.lean",
       "filename": "Erdos1012OQ03.lean",
-      "lineCount": 1373,
+      "lineCount": 1170,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 9,
@@ -102,8 +102,8 @@
     {
       "path": "Proofs/Erdos1012OQ03Aristotle.lean",
       "filename": "Erdos1012OQ03Aristotle.lean",
-      "lineCount": 53,
-      "theoremCount": 2,
+      "lineCount": 33,
+      "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 1,

--- a/src/data/research/problems/erdos-1012-oq-03.json
+++ b/src/data/research/problems/erdos-1012-oq-03.json
@@ -130,7 +130,7 @@
     {
       "path": "Proofs/Erdos1012OQ03.lean",
       "filename": "Erdos1012OQ03.lean",
-      "lineCount": 1373,
+      "lineCount": 1170,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 9,
@@ -141,8 +141,8 @@
     {
       "path": "Proofs/Erdos1012OQ03Aristotle.lean",
       "filename": "Erdos1012OQ03Aristotle.lean",
-      "lineCount": 53,
-      "theoremCount": 2,
+      "lineCount": 33,
+      "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 1,

--- a/src/data/research/problems/erdos-105-oq-05.json
+++ b/src/data/research/problems/erdos-105-oq-05.json
@@ -291,8 +291,8 @@
     {
       "path": "Proofs/Erdos1059OQ01.lean",
       "filename": "Erdos1059OQ01.lean",
-      "lineCount": 457,
-      "theoremCount": 28,
+      "lineCount": 347,
+      "theoremCount": 32,
       "axiomCount": 1,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1059-oq-01.json
+++ b/src/data/research/problems/erdos-1059-oq-01.json
@@ -92,8 +92,8 @@
     {
       "path": "Proofs/Erdos1059OQ01.lean",
       "filename": "Erdos1059OQ01.lean",
-      "lineCount": 457,
-      "theoremCount": 28,
+      "lineCount": 347,
+      "theoremCount": 32,
       "axiomCount": 1,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1059-oq-02.json
+++ b/src/data/research/problems/erdos-1059-oq-02.json
@@ -66,8 +66,8 @@
     {
       "path": "Proofs/Erdos1059OQ01.lean",
       "filename": "Erdos1059OQ01.lean",
-      "lineCount": 457,
-      "theoremCount": 28,
+      "lineCount": 347,
+      "theoremCount": 32,
       "axiomCount": 1,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1059-oq-03.json
+++ b/src/data/research/problems/erdos-1059-oq-03.json
@@ -76,8 +76,8 @@
     {
       "path": "Proofs/Erdos1059OQ01.lean",
       "filename": "Erdos1059OQ01.lean",
-      "lineCount": 457,
-      "theoremCount": 28,
+      "lineCount": 347,
+      "theoremCount": 32,
       "axiomCount": 1,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1059-oq-05.json
+++ b/src/data/research/problems/erdos-1059-oq-05.json
@@ -79,8 +79,8 @@
     {
       "path": "Proofs/Erdos1059OQ01.lean",
       "filename": "Erdos1059OQ01.lean",
-      "lineCount": 457,
-      "theoremCount": 28,
+      "lineCount": 347,
+      "theoremCount": 32,
       "axiomCount": 1,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1059.json
+++ b/src/data/research/problems/erdos-1059.json
@@ -76,8 +76,8 @@
     {
       "path": "Proofs/Erdos1059OQ01.lean",
       "filename": "Erdos1059OQ01.lean",
-      "lineCount": 457,
-      "theoremCount": 28,
+      "lineCount": 347,
+      "theoremCount": 32,
       "axiomCount": 1,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1065-oq-05-oq-01.json
+++ b/src/data/research/problems/erdos-1065-oq-05-oq-01.json
@@ -1,0 +1,95 @@
+{
+  "slug": "erdos-1065-oq-05-oq-01",
+  "title": "Prove formA_decomposition_unique from Nat.multiplicity",
+  "phase": "OBSERVE",
+  "status": "active",
+  "tier": "C",
+  "path": "fast",
+  "problemStatement": {
+    "formal": "\\nu_2(2^k \\cdot q) = k",
+    "plain": "Given an odd number $q$ and a natural number $k$, we want to prove that $2^k \\cdot q$ has exactly $k$ factors of 2 — no more, no fewer. This uniquely determines the \"Form A\" decomposition of any even number as a power of 2 times an odd number.",
+    "whyMatters": []
+  },
+  "knownResults": {
+    "proven": [],
+    "open": [],
+    "goal": ""
+  },
+  "currentState": {
+    "phase": "OBSERVE",
+    "since": "2026-04-05T05:56:11-07:00",
+    "iteration": 1,
+    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "blockers": [],
+    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "",
+    "builtItems": [],
+    "insights": [],
+    "mathlibGaps": [],
+    "nextSteps": [],
+    "markdown": "# Knowledge Base: erdos-1065-oq-05-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
+  },
+  "tags": [
+    "arithmetic",
+    "lean-mathlib",
+    "2-adic-valuation",
+    "multiplicity",
+    "erdos"
+  ],
+  "relatedProofs": [
+    "erdos-1",
+    "erdos-10",
+    "erdos-106",
+    "erdos-1065",
+    "erdos-1065-oq-05"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-04-05T12:58:50.791Z",
+  "lastUpdate": "2026-04-05T12:58:50.817Z",
+  "leanFiles": [
+    {
+      "path": "Proofs/Erdos1065BatemanHorn.lean",
+      "filename": "Erdos1065BatemanHorn.lean",
+      "lineCount": 276,
+      "theoremCount": 24,
+      "axiomCount": 1,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1065BatemanHorn.lean"
+    },
+    {
+      "path": "Proofs/Erdos1065CunninghamChains.lean",
+      "filename": "Erdos1065CunninghamChains.lean",
+      "lineCount": 286,
+      "theoremCount": 24,
+      "axiomCount": 1,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1065CunninghamChains.lean"
+    },
+    {
+      "path": "Proofs/Erdos1065Problem.lean",
+      "filename": "Erdos1065Problem.lean",
+      "lineCount": 564,
+      "theoremCount": 54,
+      "axiomCount": 1,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1065Problem.lean"
+    }
+  ]
+}

--- a/src/data/research/problems/erdos-44.json
+++ b/src/data/research/problems/erdos-44.json
@@ -176,9 +176,20 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos447Problem.lean"
     },
     {
+      "path": "Proofs/Erdos448IncompleteOQ01.lean",
+      "filename": "Erdos448IncompleteOQ01.lean",
+      "lineCount": 123,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos448IncompleteOQ01.lean"
+    },
+    {
       "path": "Proofs/Erdos448Problem.lean",
       "filename": "Erdos448Problem.lean",
-      "lineCount": 299,
+      "lineCount": 308,
       "theoremCount": 9,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/erdos-8-oq-01.json
+++ b/src/data/research/problems/erdos-8-oq-01.json
@@ -767,7 +767,7 @@
     {
       "path": "Proofs/Erdos848Problem.lean",
       "filename": "Erdos848Problem.lean",
-      "lineCount": 290,
+      "lineCount": 309,
       "theoremCount": 15,
       "axiomCount": 3,
       "defCount": 3,
@@ -1416,7 +1416,7 @@
     {
       "path": "Proofs/Erdos895Problem.lean",
       "filename": "Erdos895Problem.lean",
-      "lineCount": 188,
+      "lineCount": 261,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 11,

--- a/src/data/research/problems/euler-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/euler-identity-oq-01-oq-01.json
@@ -95,7 +95,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 0,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerIdentityOQ01OQ01.lean"
     }

--- a/src/data/research/problems/euler-identity-oq-01.json
+++ b/src/data/research/problems/euler-identity-oq-01.json
@@ -91,7 +91,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 0,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerIdentityOQ01OQ01.lean"
     }

--- a/src/data/research/problems/euler-identity-oq-02.json
+++ b/src/data/research/problems/euler-identity-oq-02.json
@@ -79,7 +79,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 0,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerIdentityOQ01OQ01.lean"
     }

--- a/src/data/research/problems/euler-identity-oq-03.json
+++ b/src/data/research/problems/euler-identity-oq-03.json
@@ -83,7 +83,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 0,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerIdentityOQ01OQ01.lean"
     }

--- a/src/data/research/problems/feuerbachs-theorem-defs-oq-03.json
+++ b/src/data/research/problems/feuerbachs-theorem-defs-oq-03.json
@@ -79,9 +79,20 @@
   "tractability": 9,
   "leanFiles": [
     {
+      "path": "Proofs/FeuerbachsTheoremDefs.lean",
+      "filename": "FeuerbachsTheoremDefs.lean",
+      "lineCount": 688,
+      "theoremCount": 33,
+      "axiomCount": 0,
+      "defCount": 34,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FeuerbachsTheoremDefs.lean"
+    },
+    {
       "path": "Proofs/FeuerbachsTheoremDefsOQ03.lean",
       "filename": "FeuerbachsTheoremDefsOQ03.lean",
-      "lineCount": 250,
+      "lineCount": 251,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/feuerbachs-theorem-oq-01.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-01.json
@@ -83,6 +83,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FeuerbachsTheoremDefs.lean"
     },
     {
+      "path": "Proofs/FeuerbachsTheoremDefsOQ03.lean",
+      "filename": "FeuerbachsTheoremDefsOQ03.lean",
+      "lineCount": 251,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FeuerbachsTheoremDefsOQ03.lean"
+    },
+    {
       "path": "Proofs/FeuerbachsTheoremOQ01.lean",
       "filename": "FeuerbachsTheoremOQ01.lean",
       "lineCount": 1554,

--- a/src/data/research/problems/feuerbachs-theorem-oq-02.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-02.json
@@ -52,6 +52,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FeuerbachsTheoremDefs.lean"
     },
     {
+      "path": "Proofs/FeuerbachsTheoremDefsOQ03.lean",
+      "filename": "FeuerbachsTheoremDefsOQ03.lean",
+      "lineCount": 251,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FeuerbachsTheoremDefsOQ03.lean"
+    },
+    {
       "path": "Proofs/FeuerbachsTheoremOQ01.lean",
       "filename": "FeuerbachsTheoremOQ01.lean",
       "lineCount": 1554,

--- a/src/data/research/problems/feuerbachs-theorem-oq-03.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-03.json
@@ -76,6 +76,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FeuerbachsTheoremDefs.lean"
     },
     {
+      "path": "Proofs/FeuerbachsTheoremDefsOQ03.lean",
+      "filename": "FeuerbachsTheoremDefsOQ03.lean",
+      "lineCount": 251,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FeuerbachsTheoremDefsOQ03.lean"
+    },
+    {
       "path": "Proofs/FeuerbachsTheoremOQ01.lean",
       "filename": "FeuerbachsTheoremOQ01.lean",
       "lineCount": 1554,

--- a/src/data/research/problems/feuerbachs-theorem-oq-05.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-05.json
@@ -108,6 +108,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FeuerbachsTheoremDefs.lean"
     },
     {
+      "path": "Proofs/FeuerbachsTheoremDefsOQ03.lean",
+      "filename": "FeuerbachsTheoremDefsOQ03.lean",
+      "lineCount": 251,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FeuerbachsTheoremDefsOQ03.lean"
+    },
+    {
       "path": "Proofs/FeuerbachsTheoremOQ01.lean",
       "filename": "FeuerbachsTheoremOQ01.lean",
       "lineCount": 1554,

--- a/src/data/research/problems/herons-formula-oq-02.json
+++ b/src/data/research/problems/herons-formula-oq-02.json
@@ -44,7 +44,8 @@
   "relatedProofs": [
     "herons-formula",
     "herons-formula-oq-01",
-    "herons-formula-oq-03"
+    "herons-formula-oq-03",
+    "herons-formula-oq-04"
   ],
   "references": {
     "papers": [],
@@ -86,6 +87,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HeronsFormulaOQ03.lean"
+    },
+    {
+      "path": "Proofs/HeronsFormulaOQ04.lean",
+      "filename": "HeronsFormulaOQ04.lean",
+      "lineCount": 363,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HeronsFormulaOQ04.lean"
     }
   ]
 }

--- a/src/data/research/problems/herons-formula-oq-03.json
+++ b/src/data/research/problems/herons-formula-oq-03.json
@@ -44,7 +44,8 @@
   "relatedProofs": [
     "herons-formula",
     "herons-formula-oq-01",
-    "herons-formula-oq-03"
+    "herons-formula-oq-03",
+    "herons-formula-oq-04"
   ],
   "references": {
     "papers": [],
@@ -88,6 +89,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HeronsFormulaOQ03.lean"
+    },
+    {
+      "path": "Proofs/HeronsFormulaOQ04.lean",
+      "filename": "HeronsFormulaOQ04.lean",
+      "lineCount": 363,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HeronsFormulaOQ04.lean"
     }
   ]
 }

--- a/src/data/research/problems/herons-formula-oq-04.json
+++ b/src/data/research/problems/herons-formula-oq-04.json
@@ -44,7 +44,8 @@
   "relatedProofs": [
     "herons-formula",
     "herons-formula-oq-01",
-    "herons-formula-oq-03"
+    "herons-formula-oq-03",
+    "herons-formula-oq-04"
   ],
   "references": {
     "papers": [],
@@ -87,6 +88,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HeronsFormulaOQ03.lean"
+    },
+    {
+      "path": "Proofs/HeronsFormulaOQ04.lean",
+      "filename": "HeronsFormulaOQ04.lean",
+      "lineCount": 363,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HeronsFormulaOQ04.lean"
     }
   ]
 }

--- a/src/data/research/problems/inverse-galois-oq-01.json
+++ b/src/data/research/problems/inverse-galois-oq-01.json
@@ -205,6 +205,17 @@
       "sorryCount": 10,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisOQ02Aristotle.lean"
+    },
+    {
+      "path": "Proofs/InverseGaloisOQ06OQ01.lean",
+      "filename": "InverseGaloisOQ06OQ01.lean",
+      "lineCount": 256,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisOQ06OQ01.lean"
     }
   ]
 }

--- a/src/data/research/problems/inverse-galois-oq-02.json
+++ b/src/data/research/problems/inverse-galois-oq-02.json
@@ -166,6 +166,17 @@
       "sorryCount": 10,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisOQ02Aristotle.lean"
+    },
+    {
+      "path": "Proofs/InverseGaloisOQ06OQ01.lean",
+      "filename": "InverseGaloisOQ06OQ01.lean",
+      "lineCount": 256,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisOQ06OQ01.lean"
     }
   ]
 }

--- a/src/data/research/problems/inverse-galois-oq-04.json
+++ b/src/data/research/problems/inverse-galois-oq-04.json
@@ -165,6 +165,17 @@
       "sorryCount": 10,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisOQ02Aristotle.lean"
+    },
+    {
+      "path": "Proofs/InverseGaloisOQ06OQ01.lean",
+      "filename": "InverseGaloisOQ06OQ01.lean",
+      "lineCount": 256,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisOQ06OQ01.lean"
     }
   ]
 }

--- a/src/data/research/problems/inverse-galois-oq-06-oq-01.json
+++ b/src/data/research/problems/inverse-galois-oq-06-oq-01.json
@@ -182,6 +182,17 @@
       "sorryCount": 10,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisOQ02Aristotle.lean"
+    },
+    {
+      "path": "Proofs/InverseGaloisOQ06OQ01.lean",
+      "filename": "InverseGaloisOQ06OQ01.lean",
+      "lineCount": 256,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisOQ06OQ01.lean"
     }
   ]
 }

--- a/src/data/research/problems/inverse-galois-oq-06.json
+++ b/src/data/research/problems/inverse-galois-oq-06.json
@@ -182,6 +182,17 @@
       "sorryCount": 10,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisOQ02Aristotle.lean"
+    },
+    {
+      "path": "Proofs/InverseGaloisOQ06OQ01.lean",
+      "filename": "InverseGaloisOQ06OQ01.lean",
+      "lineCount": 256,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisOQ06OQ01.lean"
     }
   ],
   "lastUpdate": "2026-03-30T07:30:00Z"

--- a/src/data/research/problems/laws-of-large-numbers-oq-01.json
+++ b/src/data/research/problems/laws-of-large-numbers-oq-01.json
@@ -44,7 +44,8 @@
   ],
   "relatedProofs": [
     "laws-of-large-numbers",
-    "laws-of-large-numbers-oq-01"
+    "laws-of-large-numbers-oq-01",
+    "laws-of-large-numbers-oq-04"
   ],
   "references": {
     "papers": [],
@@ -100,6 +101,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ02.lean"
+    },
+    {
+      "path": "Proofs/LawsOfLargeNumbersOQ04.lean",
+      "filename": "LawsOfLargeNumbersOQ04.lean",
+      "lineCount": 209,
+      "theoremCount": 11,
+      "axiomCount": 3,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ04.lean"
     }
   ]
 }

--- a/src/data/research/problems/laws-of-large-numbers-oq-02.json
+++ b/src/data/research/problems/laws-of-large-numbers-oq-02.json
@@ -60,7 +60,8 @@
   "tags": [],
   "relatedProofs": [
     "laws-of-large-numbers",
-    "laws-of-large-numbers-oq-01"
+    "laws-of-large-numbers-oq-01",
+    "laws-of-large-numbers-oq-04"
   ],
   "references": {
     "papers": [],
@@ -113,6 +114,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ02.lean"
+    },
+    {
+      "path": "Proofs/LawsOfLargeNumbersOQ04.lean",
+      "filename": "LawsOfLargeNumbersOQ04.lean",
+      "lineCount": 209,
+      "theoremCount": 11,
+      "axiomCount": 3,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ04.lean"
     }
   ]
 }

--- a/src/data/research/problems/laws-of-large-numbers-oq-03.json
+++ b/src/data/research/problems/laws-of-large-numbers-oq-03.json
@@ -43,7 +43,8 @@
   ],
   "relatedProofs": [
     "laws-of-large-numbers",
-    "laws-of-large-numbers-oq-01"
+    "laws-of-large-numbers-oq-01",
+    "laws-of-large-numbers-oq-04"
   ],
   "references": {
     "papers": [],
@@ -98,6 +99,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ02.lean"
+    },
+    {
+      "path": "Proofs/LawsOfLargeNumbersOQ04.lean",
+      "filename": "LawsOfLargeNumbersOQ04.lean",
+      "lineCount": 209,
+      "theoremCount": 11,
+      "axiomCount": 3,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ04.lean"
     }
   ]
 }

--- a/src/data/research/problems/laws-of-large-numbers-oq-04.json
+++ b/src/data/research/problems/laws-of-large-numbers-oq-04.json
@@ -39,7 +39,8 @@
   "tags": [],
   "relatedProofs": [
     "laws-of-large-numbers",
-    "laws-of-large-numbers-oq-01"
+    "laws-of-large-numbers-oq-01",
+    "laws-of-large-numbers-oq-04"
   ],
   "references": {
     "papers": [],
@@ -92,6 +93,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ02.lean"
+    },
+    {
+      "path": "Proofs/LawsOfLargeNumbersOQ04.lean",
+      "filename": "LawsOfLargeNumbersOQ04.lean",
+      "lineCount": 209,
+      "theoremCount": 11,
+      "axiomCount": 3,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ04.lean"
     }
   ]
 }

--- a/src/data/research/problems/leibniz-pi-oq-01-oq-01.json
+++ b/src/data/research/problems/leibniz-pi-oq-01-oq-01.json
@@ -102,6 +102,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LeibnizPiOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/LeibnizPiOQ03.lean",
+      "filename": "LeibnizPiOQ03.lean",
+      "lineCount": 229,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 3,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LeibnizPiOQ03.lean"
     }
   ]
 }

--- a/src/data/research/problems/leibniz-pi-oq-01.json
+++ b/src/data/research/problems/leibniz-pi-oq-01.json
@@ -77,6 +77,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LeibnizPiOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/LeibnizPiOQ03.lean",
+      "filename": "LeibnizPiOQ03.lean",
+      "lineCount": 229,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 3,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LeibnizPiOQ03.lean"
     }
   ]
 }

--- a/src/data/research/problems/leibniz-pi-oq-02.json
+++ b/src/data/research/problems/leibniz-pi-oq-02.json
@@ -94,6 +94,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LeibnizPiOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/LeibnizPiOQ03.lean",
+      "filename": "LeibnizPiOQ03.lean",
+      "lineCount": 229,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 3,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LeibnizPiOQ03.lean"
     }
   ]
 }

--- a/src/data/research/problems/leibniz-pi-oq-03.json
+++ b/src/data/research/problems/leibniz-pi-oq-03.json
@@ -89,6 +89,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LeibnizPiOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/LeibnizPiOQ03.lean",
+      "filename": "LeibnizPiOQ03.lean",
+      "lineCount": 229,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 3,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LeibnizPiOQ03.lean"
     }
   ]
 }

--- a/src/data/research/problems/shannon-channel-coding-oq-01.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-01.json
@@ -40,7 +40,10 @@
   "relatedProofs": [
     "shannon-channel-coding",
     "shannon-channel-coding-oq-02",
-    "shannon-channel-coding-oq-04"
+    "shannon-channel-coding-oq-02-oq-01",
+    "shannon-channel-coding-oq-03",
+    "shannon-channel-coding-oq-04",
+    "shannon-channel-coding-oq-04-oq-01"
   ],
   "references": {
     "papers": [],
@@ -73,6 +76,28 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ02.lean"
     },
     {
+      "path": "Proofs/ShannonChannelCodingOQ02OQ01.lean",
+      "filename": "ShannonChannelCodingOQ02OQ01.lean",
+      "lineCount": 143,
+      "theoremCount": 3,
+      "axiomCount": 2,
+      "defCount": 0,
+      "sorryCount": 3,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/ShannonChannelCodingOQ03.lean",
+      "filename": "ShannonChannelCodingOQ03.lean",
+      "lineCount": 256,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 9,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ03.lean"
+    },
+    {
       "path": "Proofs/ShannonChannelCodingOQ04.lean",
       "filename": "ShannonChannelCodingOQ04.lean",
       "lineCount": 225,
@@ -82,6 +107,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ04.lean"
+    },
+    {
+      "path": "Proofs/ShannonChannelCodingOQ04OQ01.lean",
+      "filename": "ShannonChannelCodingOQ04OQ01.lean",
+      "lineCount": 127,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ04OQ01.lean"
     }
   ]
 }

--- a/src/data/research/problems/shannon-channel-coding-oq-02-oq-01.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-02-oq-01.json
@@ -64,12 +64,20 @@
     ],
     "markdown": "# Knowledge Base: shannon-channel-coding-oq-02-oq-01\n\nSee research/problems/shannon-channel-coding-oq-02-oq-01/knowledge.md for full history.\n\n## Summary\n\nBridge proof connecting OQ-03's Fano inequality to project standard conditional entropy. Key result: definitional equality proved by rfl. Main blocker: ShannonEntropy.lean line 811 sum order mismatch (fix identified).\n"
   },
-  "tags": ["information-theory", "entropy", "channel-coding", "fano", "bridge"],
+  "tags": [
+    "information-theory",
+    "entropy",
+    "channel-coding",
+    "fano",
+    "bridge"
+  ],
   "relatedProofs": [
     "shannon-channel-coding",
+    "shannon-channel-coding-oq-02",
+    "shannon-channel-coding-oq-02-oq-01",
     "shannon-channel-coding-oq-03",
     "shannon-channel-coding-oq-04",
-    "shannon-channel-coding-oq-02"
+    "shannon-channel-coding-oq-04-oq-01"
   ],
   "references": {
     "papers": [],
@@ -80,15 +88,70 @@
   "significance": 7,
   "leanFiles": [
     {
+      "path": "Proofs/ShannonChannelCoding.lean",
+      "filename": "ShannonChannelCoding.lean",
+      "lineCount": 229,
+      "theoremCount": 8,
+      "axiomCount": 4,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCoding.lean"
+    },
+    {
+      "path": "Proofs/ShannonChannelCodingOQ02.lean",
+      "filename": "ShannonChannelCodingOQ02.lean",
+      "lineCount": 298,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ02.lean"
+    },
+    {
       "path": "Proofs/ShannonChannelCodingOQ02OQ01.lean",
       "filename": "ShannonChannelCodingOQ02OQ01.lean",
-      "lineCount": 142,
+      "lineCount": 143,
       "theoremCount": 3,
-      "axiomCount": 1,
+      "axiomCount": 2,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 3,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/ShannonChannelCodingOQ03.lean",
+      "filename": "ShannonChannelCodingOQ03.lean",
+      "lineCount": 256,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 9,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ03.lean"
+    },
+    {
+      "path": "Proofs/ShannonChannelCodingOQ04.lean",
+      "filename": "ShannonChannelCodingOQ04.lean",
+      "lineCount": 225,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ04.lean"
+    },
+    {
+      "path": "Proofs/ShannonChannelCodingOQ04OQ01.lean",
+      "filename": "ShannonChannelCodingOQ04OQ01.lean",
+      "lineCount": 127,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ04OQ01.lean"
     }
   ]
 }

--- a/src/data/research/problems/shannon-channel-coding-oq-02.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-02.json
@@ -59,7 +59,10 @@
   "relatedProofs": [
     "shannon-channel-coding",
     "shannon-channel-coding-oq-02",
-    "shannon-channel-coding-oq-04"
+    "shannon-channel-coding-oq-02-oq-01",
+    "shannon-channel-coding-oq-03",
+    "shannon-channel-coding-oq-04",
+    "shannon-channel-coding-oq-04-oq-01"
   ],
   "references": {
     "papers": [],
@@ -94,6 +97,28 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ02.lean"
     },
     {
+      "path": "Proofs/ShannonChannelCodingOQ02OQ01.lean",
+      "filename": "ShannonChannelCodingOQ02OQ01.lean",
+      "lineCount": 143,
+      "theoremCount": 3,
+      "axiomCount": 2,
+      "defCount": 0,
+      "sorryCount": 3,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/ShannonChannelCodingOQ03.lean",
+      "filename": "ShannonChannelCodingOQ03.lean",
+      "lineCount": 256,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 9,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ03.lean"
+    },
+    {
       "path": "Proofs/ShannonChannelCodingOQ04.lean",
       "filename": "ShannonChannelCodingOQ04.lean",
       "lineCount": 225,
@@ -103,6 +128,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ04.lean"
+    },
+    {
+      "path": "Proofs/ShannonChannelCodingOQ04OQ01.lean",
+      "filename": "ShannonChannelCodingOQ04OQ01.lean",
+      "lineCount": 127,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ04OQ01.lean"
     }
   ]
 }

--- a/src/data/research/problems/shannon-channel-coding-oq-04-oq-01.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-04-oq-01.json
@@ -26,5 +26,81 @@
       "Extend to strict concavity of general entropy H(p₁,...,pₙ) = -∑ pᵢ·log(pᵢ) on the simplex",
       "Prove unique maximizer h(1/2) = log 2, giving capacity of binary symmetric channel"
     ]
-  }
+  },
+  "leanFiles": [
+    {
+      "path": "Proofs/ShannonChannelCoding.lean",
+      "filename": "ShannonChannelCoding.lean",
+      "lineCount": 229,
+      "theoremCount": 8,
+      "axiomCount": 4,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCoding.lean"
+    },
+    {
+      "path": "Proofs/ShannonChannelCodingOQ02.lean",
+      "filename": "ShannonChannelCodingOQ02.lean",
+      "lineCount": 298,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ02.lean"
+    },
+    {
+      "path": "Proofs/ShannonChannelCodingOQ02OQ01.lean",
+      "filename": "ShannonChannelCodingOQ02OQ01.lean",
+      "lineCount": 143,
+      "theoremCount": 3,
+      "axiomCount": 2,
+      "defCount": 0,
+      "sorryCount": 3,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/ShannonChannelCodingOQ03.lean",
+      "filename": "ShannonChannelCodingOQ03.lean",
+      "lineCount": 256,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 9,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ03.lean"
+    },
+    {
+      "path": "Proofs/ShannonChannelCodingOQ04.lean",
+      "filename": "ShannonChannelCodingOQ04.lean",
+      "lineCount": 225,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ04.lean"
+    },
+    {
+      "path": "Proofs/ShannonChannelCodingOQ04OQ01.lean",
+      "filename": "ShannonChannelCodingOQ04OQ01.lean",
+      "lineCount": 127,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ04OQ01.lean"
+    }
+  ],
+  "relatedProofs": [
+    "shannon-channel-coding",
+    "shannon-channel-coding-oq-02",
+    "shannon-channel-coding-oq-02-oq-01",
+    "shannon-channel-coding-oq-03",
+    "shannon-channel-coding-oq-04",
+    "shannon-channel-coding-oq-04-oq-01"
+  ]
 }

--- a/src/data/research/problems/shannon-channel-coding-oq-04.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-04.json
@@ -40,7 +40,10 @@
   "relatedProofs": [
     "shannon-channel-coding",
     "shannon-channel-coding-oq-02",
-    "shannon-channel-coding-oq-04"
+    "shannon-channel-coding-oq-02-oq-01",
+    "shannon-channel-coding-oq-03",
+    "shannon-channel-coding-oq-04",
+    "shannon-channel-coding-oq-04-oq-01"
   ],
   "references": {
     "papers": [],
@@ -73,6 +76,28 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ02.lean"
     },
     {
+      "path": "Proofs/ShannonChannelCodingOQ02OQ01.lean",
+      "filename": "ShannonChannelCodingOQ02OQ01.lean",
+      "lineCount": 143,
+      "theoremCount": 3,
+      "axiomCount": 2,
+      "defCount": 0,
+      "sorryCount": 3,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/ShannonChannelCodingOQ03.lean",
+      "filename": "ShannonChannelCodingOQ03.lean",
+      "lineCount": 256,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 9,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ03.lean"
+    },
+    {
       "path": "Proofs/ShannonChannelCodingOQ04.lean",
       "filename": "ShannonChannelCodingOQ04.lean",
       "lineCount": 225,
@@ -82,6 +107,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ04.lean"
+    },
+    {
+      "path": "Proofs/ShannonChannelCodingOQ04OQ01.lean",
+      "filename": "ShannonChannelCodingOQ04OQ01.lean",
+      "lineCount": 127,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ04OQ01.lean"
     }
   ]
 }

--- a/src/data/research/problems/shannon-channel-coding.json
+++ b/src/data/research/problems/shannon-channel-coding.json
@@ -47,7 +47,10 @@
   "relatedProofs": [
     "shannon-channel-coding",
     "shannon-channel-coding-oq-02",
-    "shannon-channel-coding-oq-04"
+    "shannon-channel-coding-oq-02-oq-01",
+    "shannon-channel-coding-oq-03",
+    "shannon-channel-coding-oq-04",
+    "shannon-channel-coding-oq-04-oq-01"
   ],
   "references": {
     "papers": [],
@@ -83,6 +86,28 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ02.lean"
     },
     {
+      "path": "Proofs/ShannonChannelCodingOQ02OQ01.lean",
+      "filename": "ShannonChannelCodingOQ02OQ01.lean",
+      "lineCount": 143,
+      "theoremCount": 3,
+      "axiomCount": 2,
+      "defCount": 0,
+      "sorryCount": 3,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/ShannonChannelCodingOQ03.lean",
+      "filename": "ShannonChannelCodingOQ03.lean",
+      "lineCount": 256,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 9,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ03.lean"
+    },
+    {
       "path": "Proofs/ShannonChannelCodingOQ04.lean",
       "filename": "ShannonChannelCodingOQ04.lean",
       "lineCount": 225,
@@ -92,6 +117,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ04.lean"
+    },
+    {
+      "path": "Proofs/ShannonChannelCodingOQ04OQ01.lean",
+      "filename": "ShannonChannelCodingOQ04OQ01.lean",
+      "lineCount": 127,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ04OQ01.lean"
     }
   ]
 }

--- a/src/data/research/problems/shannon-entropy-oq-01.json
+++ b/src/data/research/problems/shannon-entropy-oq-01.json
@@ -98,7 +98,7 @@
     {
       "path": "Proofs/ShannonEntropy.lean",
       "filename": "ShannonEntropy.lean",
-      "lineCount": 901,
+      "lineCount": 902,
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 8,

--- a/src/data/research/problems/shannon-entropy-oq-02.json
+++ b/src/data/research/problems/shannon-entropy-oq-02.json
@@ -75,7 +75,7 @@
     {
       "path": "Proofs/ShannonEntropy.lean",
       "filename": "ShannonEntropy.lean",
-      "lineCount": 901,
+      "lineCount": 902,
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 8,

--- a/src/data/research/problems/shannon-entropy-oq-03.json
+++ b/src/data/research/problems/shannon-entropy-oq-03.json
@@ -80,7 +80,7 @@
     {
       "path": "Proofs/ShannonEntropy.lean",
       "filename": "ShannonEntropy.lean",
-      "lineCount": 901,
+      "lineCount": 902,
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 8,

--- a/src/data/research/problems/shannon-entropy.json
+++ b/src/data/research/problems/shannon-entropy.json
@@ -130,7 +130,7 @@
     {
       "path": "Proofs/ShannonEntropy.lean",
       "filename": "ShannonEntropy.lean",
-      "lineCount": 901,
+      "lineCount": 902,
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 8,

--- a/src/data/research/problems/szemeredi-core-oq-01.json
+++ b/src/data/research/problems/szemeredi-core-oq-01.json
@@ -76,6 +76,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediCore.lean"
     },
     {
+      "path": "Proofs/SzemerediCoreOQ01.lean",
+      "filename": "SzemerediCoreOQ01.lean",
+      "lineCount": 263,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 4,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediCoreOQ01.lean"
+    },
+    {
       "path": "Proofs/SzemerediCoreOQ03.lean",
       "filename": "SzemerediCoreOQ03.lean",
       "lineCount": 186,

--- a/src/data/research/problems/szemeredi-core-oq-03.json
+++ b/src/data/research/problems/szemeredi-core-oq-03.json
@@ -42,6 +42,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediCore.lean"
     },
     {
+      "path": "Proofs/SzemerediCoreOQ01.lean",
+      "filename": "SzemerediCoreOQ01.lean",
+      "lineCount": 263,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 4,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediCoreOQ01.lean"
+    },
+    {
       "path": "Proofs/SzemerediCoreOQ03.lean",
       "filename": "SzemerediCoreOQ03.lean",
       "lineCount": 186,

--- a/src/data/research/problems/triangle-angle-sum-oq-01.json
+++ b/src/data/research/problems/triangle-angle-sum-oq-01.json
@@ -44,7 +44,8 @@
     "wiedijk-100"
   ],
   "relatedProofs": [
-    "triangle-angle-sum"
+    "triangle-angle-sum",
+    "triangle-angle-sum-oq-01"
   ],
   "references": {
     "papers": [],
@@ -65,6 +66,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TriangleAngleSum.lean"
+    },
+    {
+      "path": "Proofs/TriangleAngleSumOQ01.lean",
+      "filename": "TriangleAngleSumOQ01.lean",
+      "lineCount": 261,
+      "theoremCount": 5,
+      "axiomCount": 4,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TriangleAngleSumOQ01.lean"
     }
   ]
 }

--- a/src/data/research/problems/triangle-inequality-oq-01.json
+++ b/src/data/research/problems/triangle-inequality-oq-01.json
@@ -39,7 +39,8 @@
   "tags": [],
   "relatedProofs": [
     "triangle-inequality",
-    "triangle-inequality-oq-03"
+    "triangle-inequality-oq-03",
+    "triangle-inequality-oq-04"
   ],
   "references": {
     "papers": [],
@@ -61,6 +62,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TriangleInequality.lean"
     },
     {
+      "path": "Proofs/TriangleInequalityOQ02.lean",
+      "filename": "TriangleInequalityOQ02.lean",
+      "lineCount": 193,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TriangleInequalityOQ02.lean"
+    },
+    {
       "path": "Proofs/TriangleInequalityOQ03.lean",
       "filename": "TriangleInequalityOQ03.lean",
       "lineCount": 256,
@@ -70,6 +82,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TriangleInequalityOQ03.lean"
+    },
+    {
+      "path": "Proofs/TriangleInequalityOQ04.lean",
+      "filename": "TriangleInequalityOQ04.lean",
+      "lineCount": 285,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TriangleInequalityOQ04.lean"
     }
   ]
 }

--- a/src/data/research/problems/triangle-inequality-oq-02.json
+++ b/src/data/research/problems/triangle-inequality-oq-02.json
@@ -42,7 +42,8 @@
   ],
   "relatedProofs": [
     "triangle-inequality",
-    "triangle-inequality-oq-03"
+    "triangle-inequality-oq-03",
+    "triangle-inequality-oq-04"
   ],
   "references": {
     "papers": [],
@@ -66,6 +67,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TriangleInequality.lean"
     },
     {
+      "path": "Proofs/TriangleInequalityOQ02.lean",
+      "filename": "TriangleInequalityOQ02.lean",
+      "lineCount": 193,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TriangleInequalityOQ02.lean"
+    },
+    {
       "path": "Proofs/TriangleInequalityOQ03.lean",
       "filename": "TriangleInequalityOQ03.lean",
       "lineCount": 256,
@@ -75,6 +87,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TriangleInequalityOQ03.lean"
+    },
+    {
+      "path": "Proofs/TriangleInequalityOQ04.lean",
+      "filename": "TriangleInequalityOQ04.lean",
+      "lineCount": 285,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TriangleInequalityOQ04.lean"
     }
   ]
 }

--- a/src/data/research/problems/triangle-inequality-oq-03.json
+++ b/src/data/research/problems/triangle-inequality-oq-03.json
@@ -39,7 +39,8 @@
   "tags": [],
   "relatedProofs": [
     "triangle-inequality",
-    "triangle-inequality-oq-03"
+    "triangle-inequality-oq-03",
+    "triangle-inequality-oq-04"
   ],
   "references": {
     "papers": [],
@@ -61,6 +62,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TriangleInequality.lean"
     },
     {
+      "path": "Proofs/TriangleInequalityOQ02.lean",
+      "filename": "TriangleInequalityOQ02.lean",
+      "lineCount": 193,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TriangleInequalityOQ02.lean"
+    },
+    {
       "path": "Proofs/TriangleInequalityOQ03.lean",
       "filename": "TriangleInequalityOQ03.lean",
       "lineCount": 256,
@@ -70,6 +82,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TriangleInequalityOQ03.lean"
+    },
+    {
+      "path": "Proofs/TriangleInequalityOQ04.lean",
+      "filename": "TriangleInequalityOQ04.lean",
+      "lineCount": 285,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TriangleInequalityOQ04.lean"
     }
   ]
 }

--- a/src/data/research/problems/triangle-inequality-oq-04.json
+++ b/src/data/research/problems/triangle-inequality-oq-04.json
@@ -59,7 +59,8 @@
   ],
   "relatedProofs": [
     "triangle-inequality",
-    "triangle-inequality-oq-03"
+    "triangle-inequality-oq-03",
+    "triangle-inequality-oq-04"
   ],
   "references": {
     "papers": [],
@@ -72,17 +73,6 @@
   "tractability": 6,
   "leanFiles": [
     {
-      "path": "Proofs/TriangleInequalityOQ04.lean",
-      "filename": "TriangleInequalityOQ04.lean",
-      "lineCount": 284,
-      "theoremCount": 8,
-      "axiomCount": 0,
-      "defCount": 2,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TriangleInequalityOQ04.lean"
-    },
-    {
       "path": "Proofs/TriangleInequality.lean",
       "filename": "TriangleInequality.lean",
       "lineCount": 245,
@@ -94,6 +84,17 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TriangleInequality.lean"
     },
     {
+      "path": "Proofs/TriangleInequalityOQ02.lean",
+      "filename": "TriangleInequalityOQ02.lean",
+      "lineCount": 193,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TriangleInequalityOQ02.lean"
+    },
+    {
       "path": "Proofs/TriangleInequalityOQ03.lean",
       "filename": "TriangleInequalityOQ03.lean",
       "lineCount": 256,
@@ -103,6 +104,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TriangleInequalityOQ03.lean"
+    },
+    {
+      "path": "Proofs/TriangleInequalityOQ04.lean",
+      "filename": "TriangleInequalityOQ04.lean",
+      "lineCount": 285,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TriangleInequalityOQ04.lean"
     }
   ]
 }

--- a/src/data/research/problems/vietas-formulas-oq-03-oq-01.json
+++ b/src/data/research/problems/vietas-formulas-oq-03-oq-01.json
@@ -60,7 +60,8 @@
   "relatedProofs": [
     "vietas-formulas",
     "vietas-formulas-oq-03",
-    "vietas-formulas-oq-03-oq-01"
+    "vietas-formulas-oq-03-oq-01",
+    "vietas-formulas-oq-03-oq-05"
   ],
   "references": {
     "papers": [],
@@ -102,6 +103,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/VietasFormulasOQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/VietasFormulasOQ03OQ05.lean",
+      "filename": "VietasFormulasOQ03OQ05.lean",
+      "lineCount": 305,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/VietasFormulasOQ03OQ05.lean"
     }
   ]
 }

--- a/src/data/research/problems/vietas-formulas-oq-03-oq-05.json
+++ b/src/data/research/problems/vietas-formulas-oq-03-oq-05.json
@@ -29,24 +29,24 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: Proved quartic discriminant (16 terms), depressed quartic (6 terms), Ferrari identity, resolvent condition, and \u0394_res = 64\u00b7\u0394\u2084. All by ring or linear_combination.",
+    "progressSummary": "COMPLETE: Proved quartic discriminant (16 terms), depressed quartic (6 terms), Ferrari identity, resolvent condition, and Δ_res = 64·Δ₄. All by ring or linear_combination.",
     "builtItems": [
       "VietasFormulasOQ03OQ05.lean: vieta_quartic (ring proof)",
-      "VietasFormulasOQ03OQ05.lean: discriminant_quartic \u2014 16-term formula (ring, degree 12)",
-      "VietasFormulasOQ03OQ05.lean: discriminant_depressed \u2014 6-term formula for e\u2081=0 (ring)",
+      "VietasFormulasOQ03OQ05.lean: discriminant_quartic — 16-term formula (ring, degree 12)",
+      "VietasFormulasOQ03OQ05.lean: discriminant_depressed — 6-term formula for e₁=0 (ring)",
       "VietasFormulasOQ03OQ05.lean: depressedDiscriminant def + neg_q symmetry",
-      "VietasFormulasOQ03OQ05.lean: ferrari_identity \u2014 (x\u00b2+y)\u00b2 - inner = quartic (ring)",
-      "VietasFormulasOQ03OQ05.lean: resolvent_cubic_condition \u2014 from a\u00b2,2ab,b\u00b2 to resolvent vanishing (linear_combination)",
-      "VietasFormulasOQ03OQ05.lean: cubicDiscriminant def + resolvent_discriminant_eq: 64\u00d7 connection (ring)",
+      "VietasFormulasOQ03OQ05.lean: ferrari_identity — (x²+y)² - inner = quartic (ring)",
+      "VietasFormulasOQ03OQ05.lean: resolvent_cubic_condition — from a²,2ab,b² to resolvent vanishing (linear_combination)",
+      "VietasFormulasOQ03OQ05.lean: cubicDiscriminant def + resolvent_discriminant_eq: 64× connection (ring)",
       "Gallery: src/data/proofs/vietas-formulas-oq-03-oq-05/ (meta.json, annotations.json, index.ts)"
     ],
     "insights": [
-      "The quartic discriminant has exactly 16 terms in e\u2081,e\u2082,e\u2083,e\u2084 (degree 12 polynomial identity, proved by ring in Lean 4)",
-      "Setting e\u2081=0 (depressed quartic) reduces 16 terms to 6 terms \u2014 exactly the formula \u0394 = 256r\u00b3 - 128p\u00b2r\u00b2 + 144pq\u00b2r - 27q\u2074 + 16p\u2074r - 4p\u00b3q\u00b2",
-      "Ferrari decomposition: x\u2074+px\u00b2+qx+r = (x\u00b2+y)\u00b2 - ((2y-p)x\u00b2-qx+(y\u00b2-r)), proved by ring",
-      "The resolvent cubic arises from requiring (2y-p)x\u00b2-qx+(y\u00b2-r) to be a perfect square: conditions a\u00b2=2y-p, 2ab=q, b\u00b2=y\u00b2-r force 8y\u00b3-4py\u00b2-8ry+(4pr-q\u00b2)=0, proved via linear_combination",
-      "Key result: \u0394(resolvent cubic) = 64\u00b7\u0394(depressed quartic), a pure ring identity. Both vanish iff quartic has repeated root.",
-      "The factor 64 comes from the leading coefficient 8 of the resolvent cubic (8\u00b3=512 and 8\u00b2=64 interact in the cubic discriminant formula)"
+      "The quartic discriminant has exactly 16 terms in e₁,e₂,e₃,e₄ (degree 12 polynomial identity, proved by ring in Lean 4)",
+      "Setting e₁=0 (depressed quartic) reduces 16 terms to 6 terms — exactly the formula Δ = 256r³ - 128p²r² + 144pq²r - 27q⁴ + 16p⁴r - 4p³q²",
+      "Ferrari decomposition: x⁴+px²+qx+r = (x²+y)² - ((2y-p)x²-qx+(y²-r)), proved by ring",
+      "The resolvent cubic arises from requiring (2y-p)x²-qx+(y²-r) to be a perfect square: conditions a²=2y-p, 2ab=q, b²=y²-r force 8y³-4py²-8ry+(4pr-q²)=0, proved via linear_combination",
+      "Key result: Δ(resolvent cubic) = 64·Δ(depressed quartic), a pure ring identity. Both vanish iff quartic has repeated root.",
+      "The factor 64 comes from the leading coefficient 8 of the resolvent cubic (8³=512 and 8²=64 interact in the cubic discriminant formula)"
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -60,7 +60,8 @@
   "relatedProofs": [
     "vietas-formulas",
     "vietas-formulas-oq-03",
-    "vietas-formulas-oq-03-oq-01"
+    "vietas-formulas-oq-03-oq-01",
+    "vietas-formulas-oq-03-oq-05"
   ],
   "references": {
     "papers": [],
@@ -102,6 +103,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/VietasFormulasOQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/VietasFormulasOQ03OQ05.lean",
+      "filename": "VietasFormulasOQ03OQ05.lean",
+      "lineCount": 305,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/VietasFormulasOQ03OQ05.lean"
     }
   ]
 }

--- a/src/data/research/problems/vietas-formulas-oq-03.json
+++ b/src/data/research/problems/vietas-formulas-oq-03.json
@@ -40,7 +40,8 @@
   "relatedProofs": [
     "vietas-formulas",
     "vietas-formulas-oq-03",
-    "vietas-formulas-oq-03-oq-01"
+    "vietas-formulas-oq-03-oq-01",
+    "vietas-formulas-oq-03-oq-05"
   ],
   "references": {
     "papers": [],
@@ -82,6 +83,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/VietasFormulasOQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/VietasFormulasOQ03OQ05.lean",
+      "filename": "VietasFormulasOQ03OQ05.lean",
+      "lineCount": 305,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/VietasFormulasOQ03OQ05.lean"
     }
   ]
 }

--- a/src/data/research/problems/vietas-formulas.json
+++ b/src/data/research/problems/vietas-formulas.json
@@ -44,7 +44,8 @@
   "relatedProofs": [
     "vietas-formulas",
     "vietas-formulas-oq-03",
-    "vietas-formulas-oq-03-oq-01"
+    "vietas-formulas-oq-03-oq-01",
+    "vietas-formulas-oq-03-oq-05"
   ],
   "references": {
     "papers": [],
@@ -89,6 +90,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/VietasFormulasOQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/VietasFormulasOQ03OQ05.lean",
+      "filename": "VietasFormulasOQ03OQ05.lean",
+      "lineCount": 305,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/VietasFormulasOQ03OQ05.lean"
     }
   ]
 }


### PR DESCRIPTION
## Fix

Syncs `leanFiles` and cross-reference metadata in research problem JSON files for Lean proof files that were created by the researcher agent but not yet referenced in the data files.

## Evidence

**Before**: 303 research problem JSON files missing `leanFiles` entries for Lean proof files that exist in `proofs/Proofs/`

**After**: All referenced `.lean` files verified to exist. `relatedProofs` and `siblings` cross-references updated to match.

**Scope**: 303 modified files + 2 new research problem stubs (combinations-formula-oq-01-oq-01, erdos-1065-oq-05-oq-01)

---
Automated sync by lean-mechanic agent.