### PR TITLE
fix(meta): sync sorryCount for 106 Lean files in research problem metadata

### DIFF
--- a/src/data/research/problems/amgm-inequality-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-01.json
@@ -63,7 +63,7 @@
       "theoremCount": 16,
       "axiomCount": 2,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02.lean"
     },
@@ -74,7 +74,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
@@ -63,7 +63,7 @@
       "theoremCount": 16,
       "axiomCount": 2,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02.lean"
     },
@@ -74,7 +74,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
@@ -46,7 +46,7 @@
       "theoremCount": 16,
       "axiomCount": 2,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02.lean"
     },
@@ -57,7 +57,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
@@ -74,7 +74,7 @@
       "theoremCount": 16,
       "axiomCount": 2,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02.lean"
     },
@@ -85,7 +85,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
@@ -86,7 +86,7 @@
       "theoremCount": 16,
       "axiomCount": 2,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02.lean"
     },
@@ -97,7 +97,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
@@ -77,7 +77,7 @@
       "theoremCount": 16,
       "axiomCount": 2,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02.lean"
     },
@@ -88,7 +88,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02.json
@@ -71,7 +71,7 @@
       "theoremCount": 16,
       "axiomCount": 2,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02.lean"
     },
@@ -82,7 +82,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
@@ -71,7 +71,7 @@
       "theoremCount": 16,
       "axiomCount": 2,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02.lean"
     },
@@ -82,7 +82,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
@@ -86,7 +86,7 @@
       "theoremCount": 16,
       "axiomCount": 2,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02.lean"
     },
@@ -97,7 +97,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
@@ -71,7 +71,7 @@
       "theoremCount": 16,
       "axiomCount": 2,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02.lean"
     },
@@ -82,7 +82,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
@@ -68,7 +68,7 @@
       "theoremCount": 16,
       "axiomCount": 2,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02.lean"
     },
@@ -79,7 +79,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
@@ -72,7 +72,7 @@
       "theoremCount": 16,
       "axiomCount": 2,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02.lean"
     },
@@ -83,7 +83,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
@@ -24,7 +24,7 @@
       "theoremCount": 16,
       "axiomCount": 2,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02.lean"
     },
@@ -35,7 +35,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03.json
@@ -72,7 +72,7 @@
       "theoremCount": 16,
       "axiomCount": 2,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02.lean"
     },
@@ -83,7 +83,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
@@ -66,7 +66,7 @@
       "theoremCount": 16,
       "axiomCount": 2,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02.lean"
     },
@@ -77,7 +77,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
@@ -66,7 +66,7 @@
       "theoremCount": 16,
       "axiomCount": 2,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02.lean"
     },
@@ -77,7 +77,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
@@ -66,7 +66,7 @@
       "theoremCount": 16,
       "axiomCount": 2,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02.lean"
     },
@@ -77,7 +77,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04.json
@@ -85,7 +85,7 @@
       "theoremCount": 16,
       "axiomCount": 2,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02.lean"
     },
@@ -96,7 +96,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02Aristotle.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-01-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-01-oq-03.json
@@ -124,7 +124,7 @@
       "theoremCount": 15,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-01-oq-04.json
+++ b/src/data/research/problems/angle-trisection-oq-01-oq-04.json
@@ -128,7 +128,7 @@
       "theoremCount": 15,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-01.json
@@ -125,7 +125,7 @@
       "theoremCount": 15,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01.json
@@ -88,7 +88,7 @@
       "theoremCount": 15,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-02.json
@@ -140,7 +140,7 @@
       "theoremCount": 15,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01.json
@@ -150,7 +150,7 @@
       "theoremCount": 15,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-02.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-02.json
@@ -135,7 +135,7 @@
       "theoremCount": 15,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-03-oq-01.json
@@ -138,7 +138,7 @@
       "theoremCount": 15,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-03-oq-03.json
@@ -129,7 +129,7 @@
       "theoremCount": 15,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-03.json
@@ -134,7 +134,7 @@
       "theoremCount": 15,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-04-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-04-oq-01.json
@@ -93,7 +93,7 @@
       "theoremCount": 15,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-04.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-04.json
@@ -140,7 +140,7 @@
       "theoremCount": 15,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02.json
+++ b/src/data/research/problems/angle-trisection-oq-02.json
@@ -132,7 +132,7 @@
       "theoremCount": 15,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-03-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-03-oq-03.json
@@ -133,7 +133,7 @@
       "theoremCount": 15,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-03.json
@@ -132,7 +132,7 @@
       "theoremCount": 15,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-05-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-05-oq-01.json
@@ -97,7 +97,7 @@
       "theoremCount": 15,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-05.json
+++ b/src/data/research/problems/angle-trisection-oq-05.json
@@ -138,7 +138,7 @@
       "theoremCount": 15,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01.json
@@ -141,7 +141,7 @@
       "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03.lean"
     },
@@ -174,7 +174,7 @@
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },
@@ -207,7 +207,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01.json
@@ -150,7 +150,7 @@
       "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03.lean"
     },
@@ -183,7 +183,7 @@
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },
@@ -216,7 +216,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01.json
@@ -107,7 +107,7 @@
       "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03.lean"
     },
@@ -140,7 +140,7 @@
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },
@@ -173,7 +173,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
@@ -98,7 +98,7 @@
       "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03.lean"
     },
@@ -131,7 +131,7 @@
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },
@@ -164,7 +164,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03.json
@@ -185,7 +185,7 @@
       "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03.lean"
     },
@@ -218,7 +218,7 @@
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },
@@ -251,7 +251,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02.json
@@ -150,7 +150,7 @@
       "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03.lean"
     },
@@ -183,7 +183,7 @@
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },
@@ -216,7 +216,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01.json
@@ -167,7 +167,7 @@
       "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03.lean"
     },
@@ -200,7 +200,7 @@
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },
@@ -233,7 +233,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
@@ -174,7 +174,7 @@
       "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03.lean"
     },
@@ -207,7 +207,7 @@
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },
@@ -240,7 +240,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03.json
@@ -143,7 +143,7 @@
       "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03.lean"
     },
@@ -176,7 +176,7 @@
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },
@@ -209,7 +209,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01.json
@@ -137,7 +137,7 @@
       "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03.lean"
     },
@@ -170,7 +170,7 @@
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },
@@ -203,7 +203,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-02-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-02-oq-04.json
@@ -140,7 +140,7 @@
       "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03.lean"
     },
@@ -173,7 +173,7 @@
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },
@@ -206,7 +206,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-02.json
@@ -140,7 +140,7 @@
       "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03.lean"
     },
@@ -173,7 +173,7 @@
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },
@@ -206,7 +206,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-01.json
@@ -147,7 +147,7 @@
       "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03.lean"
     },
@@ -180,7 +180,7 @@
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },
@@ -213,7 +213,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-01.json
@@ -138,7 +138,7 @@
       "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03.lean"
     },
@@ -171,7 +171,7 @@
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },
@@ -204,7 +204,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02.json
@@ -153,7 +153,7 @@
       "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03.lean"
     },
@@ -186,7 +186,7 @@
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },
@@ -219,7 +219,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02.json
@@ -170,7 +170,7 @@
       "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03.lean"
     },
@@ -203,7 +203,7 @@
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },
@@ -236,7 +236,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-03-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-03.json
@@ -149,7 +149,7 @@
       "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03.lean"
     },
@@ -182,7 +182,7 @@
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },
@@ -215,7 +215,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03.json
@@ -142,7 +142,7 @@
       "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03.lean"
     },
@@ -175,7 +175,7 @@
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },
@@ -208,7 +208,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-04.json
@@ -140,7 +140,7 @@
       "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03.lean"
     },
@@ -173,7 +173,7 @@
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },
@@ -206,7 +206,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-05.json
+++ b/src/data/research/problems/area-of-circle-oq-05.json
@@ -147,7 +147,7 @@
       "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03.lean"
     },
@@ -180,7 +180,7 @@
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },
@@ -213,7 +213,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ03OQ02.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-01.json
@@ -129,7 +129,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ04OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02.json
@@ -146,7 +146,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ04OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01.json
@@ -130,7 +130,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ04OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01.json
@@ -122,7 +122,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ04OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02.json
@@ -97,7 +97,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ04OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-04-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-04-oq-01.json
@@ -152,7 +152,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ04OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-04.json
@@ -136,7 +136,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ04OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01.json
@@ -125,7 +125,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ04OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-02-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-02-oq-02.json
@@ -121,7 +121,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ04OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-02.json
@@ -126,7 +126,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ04OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01.json
@@ -127,7 +127,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ04OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01.json
@@ -97,7 +97,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ04OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-03-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-02.json
@@ -156,7 +156,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ04OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-03-oq-03.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-03.json
@@ -133,7 +133,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ04OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-03.json
+++ b/src/data/research/problems/ballot-problem-oq-03.json
@@ -132,7 +132,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ04OQ01.lean"
     },

--- a/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02.json
@@ -96,7 +96,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ02Aristotle.lean"
     },

--- a/src/data/research/problems/basel-problem-oq-01-oq-01.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-01.json
@@ -92,7 +92,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ02Aristotle.lean"
     },

--- a/src/data/research/problems/basel-problem-oq-01-oq-02.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-02.json
@@ -92,7 +92,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ02Aristotle.lean"
     },

--- a/src/data/research/problems/basel-problem-oq-01-oq-03.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-03.json
@@ -97,7 +97,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ02Aristotle.lean"
     },

--- a/src/data/research/problems/basel-problem-oq-01.json
+++ b/src/data/research/problems/basel-problem-oq-01.json
@@ -104,7 +104,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ02Aristotle.lean"
     },

--- a/src/data/research/problems/basel-problem-oq-02.json
+++ b/src/data/research/problems/basel-problem-oq-02.json
@@ -131,7 +131,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ02Aristotle.lean"
     },

--- a/src/data/research/problems/basel-problem-oq-04.json
+++ b/src/data/research/problems/basel-problem-oq-04.json
@@ -95,7 +95,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ02Aristotle.lean"
     },

--- a/src/data/research/problems/basel-problem-oq-05-oq-01.json
+++ b/src/data/research/problems/basel-problem-oq-05-oq-01.json
@@ -106,7 +106,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ02Aristotle.lean"
     },

--- a/src/data/research/problems/basel-problem-oq-05-oq-02.json
+++ b/src/data/research/problems/basel-problem-oq-05-oq-02.json
@@ -96,7 +96,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ02Aristotle.lean"
     },

--- a/src/data/research/problems/basel-problem-oq-05.json
+++ b/src/data/research/problems/basel-problem-oq-05.json
@@ -108,7 +108,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ02Aristotle.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01.json
@@ -88,7 +88,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },
@@ -176,7 +176,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },
@@ -275,7 +275,7 @@
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ04OQ01.lean"
     }

--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -84,7 +84,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },
@@ -172,7 +172,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },
@@ -271,7 +271,7 @@
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ04OQ01.lean"
     }

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
@@ -91,7 +91,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },
@@ -179,7 +179,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },
@@ -278,7 +278,7 @@
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ04OQ01.lean"
     }

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
@@ -89,7 +89,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },
@@ -177,7 +177,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },
@@ -276,7 +276,7 @@
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ04OQ01.lean"
     }

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
@@ -87,7 +87,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },
@@ -175,7 +175,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },
@@ -274,7 +274,7 @@
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ04OQ01.lean"
     }

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
@@ -89,7 +89,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },
@@ -177,7 +177,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },
@@ -276,7 +276,7 @@
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ04OQ01.lean"
     }

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01.json
@@ -93,7 +93,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },
@@ -181,7 +181,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },
@@ -280,7 +280,7 @@
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ04OQ01.lean"
     }

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
@@ -88,7 +88,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },
@@ -176,7 +176,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },
@@ -275,7 +275,7 @@
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ04OQ01.lean"
     }

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
@@ -90,7 +90,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },
@@ -178,7 +178,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },
@@ -277,7 +277,7 @@
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ04OQ01.lean"
     }

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02.json
@@ -90,7 +90,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },
@@ -178,7 +178,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },
@@ -277,7 +277,7 @@
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ04OQ01.lean"
     }

--- a/src/data/research/problems/bezout-identity-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-03.json
@@ -87,7 +87,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },
@@ -175,7 +175,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },
@@ -274,7 +274,7 @@
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ04OQ01.lean"
     }

--- a/src/data/research/problems/bezout-identity-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02.json
@@ -92,7 +92,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },
@@ -180,7 +180,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },
@@ -279,7 +279,7 @@
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ04OQ01.lean"
     }

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -45,7 +45,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },
@@ -133,7 +133,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },
@@ -232,7 +232,7 @@
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ04OQ01.lean"
     }

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
@@ -110,7 +110,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },
@@ -198,7 +198,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },
@@ -297,7 +297,7 @@
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ04OQ01.lean"
     }

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -53,7 +53,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },
@@ -141,7 +141,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },
@@ -240,7 +240,7 @@
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ04OQ01.lean"
     }

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01.json
@@ -92,7 +92,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },
@@ -180,7 +180,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },
@@ -279,7 +279,7 @@
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ04OQ01.lean"
     }

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
@@ -87,7 +87,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },
@@ -175,7 +175,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },
@@ -274,7 +274,7 @@
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ04OQ01.lean"
     }

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -94,7 +94,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },
@@ -182,7 +182,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },
@@ -281,7 +281,7 @@
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ04OQ01.lean"
     }

--- a/src/data/research/problems/bezout-identity-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03.json
@@ -92,7 +92,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },
@@ -180,7 +180,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },
@@ -279,7 +279,7 @@
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ04OQ01.lean"
     }

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
@@ -108,7 +108,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },
@@ -196,7 +196,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },
@@ -295,7 +295,7 @@
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ04OQ01.lean"
     }

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -57,7 +57,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },
@@ -145,7 +145,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },
@@ -244,7 +244,7 @@
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ04OQ01.lean"
     }

--- a/src/data/research/problems/bezout-identity-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-04.json
@@ -92,7 +92,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },
@@ -180,7 +180,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },
@@ -279,7 +279,7 @@
       "theoremCount": 12,
       "axiomCount": 2,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ04OQ01.lean"
     }

--- a/src/data/research/problems/binomial-theorem-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-01-oq-01-oq-01.json
@@ -98,7 +98,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-01-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-01-oq-01.json
@@ -109,7 +109,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-01-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-01-oq-02.json
@@ -101,7 +101,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-01.json
@@ -99,7 +99,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01.json
@@ -109,7 +109,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-02.json
@@ -114,7 +114,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-03.json
@@ -94,7 +94,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01.json
@@ -109,7 +109,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-02.json
@@ -95,7 +95,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-03.json
@@ -108,7 +108,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-04.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-04.json
@@ -90,7 +90,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-02.json
@@ -98,7 +98,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-03-oq-02-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-03-oq-02-oq-03.json
@@ -97,7 +97,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-03-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-03-oq-02.json
@@ -135,7 +135,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-03.json
@@ -98,7 +98,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-04-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-04-oq-01.json
@@ -102,7 +102,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-04-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-04-oq-02.json
@@ -102,7 +102,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-04-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-04-oq-03.json
@@ -109,7 +109,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-04.json
+++ b/src/data/research/problems/binomial-theorem-oq-04.json
@@ -98,7 +98,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/birch-swinnerton-dyer-oq-01.json
+++ b/src/data/research/problems/birch-swinnerton-dyer-oq-01.json
@@ -84,7 +84,7 @@
       "theoremCount": 253,
       "axiomCount": 19,
       "defCount": 143,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirchSwinnertonDyer.lean"
     },

--- a/src/data/research/problems/birch-swinnerton-dyer-oq-03.json
+++ b/src/data/research/problems/birch-swinnerton-dyer-oq-03.json
@@ -82,7 +82,7 @@
       "theoremCount": 253,
       "axiomCount": 19,
       "defCount": 143,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirchSwinnertonDyer.lean"
     },

--- a/src/data/research/problems/birch-swinnerton-dyer-oq-06.json
+++ b/src/data/research/problems/birch-swinnerton-dyer-oq-06.json
@@ -62,7 +62,7 @@
       "theoremCount": 253,
       "axiomCount": 19,
       "defCount": 143,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirchSwinnertonDyer.lean"
     },

--- a/src/data/research/problems/birch-swinnerton-dyer.json
+++ b/src/data/research/problems/birch-swinnerton-dyer.json
@@ -151,7 +151,7 @@
       "theoremCount": 253,
       "axiomCount": 19,
       "defCount": 143,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirchSwinnertonDyer.lean"
     },

--- a/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02.json
@@ -111,7 +111,7 @@
       "theoremCount": 18,
       "axiomCount": 1,
       "defCount": 3,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"
     }

--- a/src/data/research/problems/bounded-prime-gaps-oq-01.json
+++ b/src/data/research/problems/bounded-prime-gaps-oq-01.json
@@ -134,7 +134,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 8,
+      "sorryCount": 5,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BoundedPrimeGapsOQ04OQ01.lean"
     },
@@ -156,7 +156,7 @@
       "theoremCount": 10,
       "axiomCount": 6,
       "defCount": 8,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BoundedPrimeGapsOQ04OQ02.lean"
     },

--- a/src/data/research/problems/bounded-prime-gaps-oq-03-oq-01-oq-04.json
+++ b/src/data/research/problems/bounded-prime-gaps-oq-03-oq-01-oq-04.json
@@ -131,7 +131,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 8,
+      "sorryCount": 5,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BoundedPrimeGapsOQ04OQ01.lean"
     },
@@ -153,7 +153,7 @@
       "theoremCount": 10,
       "axiomCount": 6,
       "defCount": 8,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BoundedPrimeGapsOQ04OQ02.lean"
     },

--- a/src/data/research/problems/bounded-prime-gaps-oq-03.json
+++ b/src/data/research/problems/bounded-prime-gaps-oq-03.json
@@ -135,7 +135,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 8,
+      "sorryCount": 5,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BoundedPrimeGapsOQ04OQ01.lean"
     },
@@ -157,7 +157,7 @@
       "theoremCount": 10,
       "axiomCount": 6,
       "defCount": 8,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BoundedPrimeGapsOQ04OQ02.lean"
     },

--- a/src/data/research/problems/bounded-prime-gaps-oq-04-oq-01.json
+++ b/src/data/research/problems/bounded-prime-gaps-oq-04-oq-01.json
@@ -149,7 +149,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 8,
+      "sorryCount": 5,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BoundedPrimeGapsOQ04OQ01.lean"
     },
@@ -171,7 +171,7 @@
       "theoremCount": 10,
       "axiomCount": 6,
       "defCount": 8,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BoundedPrimeGapsOQ04OQ02.lean"
     },

--- a/src/data/research/problems/bounded-prime-gaps-oq-04-oq-02.json
+++ b/src/data/research/problems/bounded-prime-gaps-oq-04-oq-02.json
@@ -152,7 +152,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 8,
+      "sorryCount": 5,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BoundedPrimeGapsOQ04OQ01.lean"
     },
@@ -174,7 +174,7 @@
       "theoremCount": 10,
       "axiomCount": 6,
       "defCount": 8,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BoundedPrimeGapsOQ04OQ02.lean"
     },

--- a/src/data/research/problems/bounded-prime-gaps-oq-04.json
+++ b/src/data/research/problems/bounded-prime-gaps-oq-04.json
@@ -170,7 +170,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 8,
+      "sorryCount": 5,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BoundedPrimeGapsOQ04OQ01.lean"
     },
@@ -192,7 +192,7 @@
       "theoremCount": 10,
       "axiomCount": 6,
       "defCount": 8,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BoundedPrimeGapsOQ04OQ02.lean"
     },

--- a/src/data/research/problems/bounded-prime-gaps.json
+++ b/src/data/research/problems/bounded-prime-gaps.json
@@ -123,7 +123,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 8,
+      "sorryCount": 5,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BoundedPrimeGapsOQ04OQ01.lean"
     },
@@ -145,7 +145,7 @@
       "theoremCount": 10,
       "axiomCount": 6,
       "defCount": 8,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BoundedPrimeGapsOQ04OQ02.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-01.json
@@ -97,7 +97,7 @@
       "theoremCount": 7,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 5,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-02.json
@@ -84,7 +84,7 @@
       "theoremCount": 7,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 5,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-03.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-03.json
@@ -89,7 +89,7 @@
       "theoremCount": 7,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 5,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-01-oq-01.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-01.json
@@ -91,7 +91,7 @@
       "theoremCount": 7,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 5,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-02-oq-01.json
@@ -88,7 +88,7 @@
       "theoremCount": 7,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 5,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-01-oq-02.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-02.json
@@ -126,7 +126,7 @@
       "theoremCount": 7,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 5,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-01-oq-03.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-03.json
@@ -89,7 +89,7 @@
       "theoremCount": 7,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 5,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-01.json
+++ b/src/data/research/problems/buffons-needle-oq-01.json
@@ -95,7 +95,7 @@
       "theoremCount": 7,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 5,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-02-oq-01.json
+++ b/src/data/research/problems/buffons-needle-oq-02-oq-01.json
@@ -47,7 +47,7 @@
       "theoremCount": 7,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 5,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-02-oq-02.json
+++ b/src/data/research/problems/buffons-needle-oq-02-oq-02.json
@@ -67,7 +67,7 @@
       "theoremCount": 7,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 5,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-02.json
+++ b/src/data/research/problems/buffons-needle-oq-02.json
@@ -91,7 +91,7 @@
       "theoremCount": 7,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 5,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-03.json
+++ b/src/data/research/problems/buffons-needle-oq-03.json
@@ -99,7 +99,7 @@
       "theoremCount": 7,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 5,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01.lean"
     },

--- a/src/data/research/problems/cantor-diagonalization-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-01-oq-01-oq-02.json
@@ -166,7 +166,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 6,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02.lean"
     },
@@ -177,7 +177,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 6,
+      "sorryCount": 2,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02Aristotle.lean"
     },
@@ -199,7 +199,7 @@
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ03OQ01.lean"
     },
@@ -210,7 +210,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 7,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ03OQ01Incomplete01.lean"
     },

--- a/src/data/research/problems/cantor-diagonalization-oq-01-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-01-oq-01.json
@@ -164,7 +164,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 6,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02.lean"
     },
@@ -175,7 +175,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 6,
+      "sorryCount": 2,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02Aristotle.lean"
     },
@@ -197,7 +197,7 @@
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ03OQ01.lean"
     },
@@ -208,7 +208,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 7,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ03OQ01Incomplete01.lean"
     },

--- a/src/data/research/problems/cantor-diagonalization-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-01.json
@@ -157,7 +157,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 6,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02.lean"
     },
@@ -168,7 +168,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 6,
+      "sorryCount": 2,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02Aristotle.lean"
     },
@@ -190,7 +190,7 @@
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ03OQ01.lean"
     },
@@ -201,7 +201,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 7,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ03OQ01Incomplete01.lean"
     },

--- a/src/data/research/problems/cantor-diagonalization-oq-02-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-02-oq-01.json
@@ -165,7 +165,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 6,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02.lean"
     },
@@ -176,7 +176,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 6,
+      "sorryCount": 2,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02Aristotle.lean"
     },
@@ -198,7 +198,7 @@
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ03OQ01.lean"
     },
@@ -209,7 +209,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 7,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ03OQ01Incomplete01.lean"
     },

--- a/src/data/research/problems/cantor-diagonalization-oq-02-oq-03-oq-02.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-02-oq-03-oq-02.json
@@ -150,7 +150,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 6,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02.lean"
     },
@@ -161,7 +161,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 6,
+      "sorryCount": 2,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02Aristotle.lean"
     },
@@ -183,7 +183,7 @@
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ03OQ01.lean"
     },
@@ -194,7 +194,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 7,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ03OQ01Incomplete01.lean"
     },

--- a/src/data/research/problems/cantor-diagonalization-oq-02-oq-03.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-02-oq-03.json
@@ -171,7 +171,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 6,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02.lean"
     },
@@ -182,7 +182,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 6,
+      "sorryCount": 2,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02Aristotle.lean"
     },
@@ -204,7 +204,7 @@
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ03OQ01.lean"
     },
@@ -215,7 +215,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 7,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ03OQ01Incomplete01.lean"
     },

--- a/src/data/research/problems/cantor-diagonalization-oq-02.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-02.json
@@ -153,7 +153,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 6,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02.lean"
     },
@@ -164,7 +164,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 6,
+      "sorryCount": 2,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02Aristotle.lean"
     },
@@ -186,7 +186,7 @@
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ03OQ01.lean"
     },
@@ -197,7 +197,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 7,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ03OQ01Incomplete01.lean"
     },

--- a/src/data/research/problems/cantor-diagonalization-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-03-oq-01-oq-01.json
@@ -150,7 +150,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 6,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02.lean"
     },
@@ -161,7 +161,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 6,
+      "sorryCount": 2,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02Aristotle.lean"
     },
@@ -183,7 +183,7 @@
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ03OQ01.lean"
     },
@@ -194,7 +194,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 7,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ03OQ01Incomplete01.lean"
     },

--- a/src/data/research/problems/cantor-diagonalization-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-03-oq-01-oq-02.json
@@ -150,7 +150,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 6,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02.lean"
     },
@@ -161,7 +161,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 6,
+      "sorryCount": 2,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02Aristotle.lean"
     },
@@ -183,7 +183,7 @@
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ03OQ01.lean"
     },
@@ -194,7 +194,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 7,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ03OQ01Incomplete01.lean"
     },

--- a/src/data/research/problems/cantor-diagonalization-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-03-oq-01-oq-03.json
@@ -150,7 +150,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 6,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02.lean"
     },
@@ -161,7 +161,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 6,
+      "sorryCount": 2,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02Aristotle.lean"
     },
@@ -183,7 +183,7 @@
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ03OQ01.lean"
     },
@@ -194,7 +194,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 7,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ03OQ01Incomplete01.lean"
     },

--- a/src/data/research/problems/cantor-diagonalization-oq-03-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-03-oq-01.json
@@ -120,7 +120,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 6,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02.lean"
     },
@@ -131,7 +131,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 6,
+      "sorryCount": 2,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02Aristotle.lean"
     },
@@ -153,7 +153,7 @@
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ03OQ01.lean"
     },
@@ -164,7 +164,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 7,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ03OQ01Incomplete01.lean"
     },

--- a/src/data/research/problems/cantor-diagonalization-oq-03.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-03.json
@@ -157,7 +157,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 6,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02.lean"
     },
@@ -168,7 +168,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 6,
+      "sorryCount": 2,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02Aristotle.lean"
     },
@@ -190,7 +190,7 @@
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ03OQ01.lean"
     },
@@ -201,7 +201,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 7,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ03OQ01Incomplete01.lean"
     },

--- a/src/data/research/problems/cantor-diagonalization-oq-04-oq-03.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-04-oq-03.json
@@ -162,7 +162,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 6,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02.lean"
     },
@@ -173,7 +173,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 6,
+      "sorryCount": 2,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02Aristotle.lean"
     },
@@ -195,7 +195,7 @@
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ03OQ01.lean"
     },
@@ -206,7 +206,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 7,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ03OQ01Incomplete01.lean"
     },

--- a/src/data/research/problems/cantor-diagonalization-oq-04.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-04.json
@@ -150,7 +150,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 6,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02.lean"
     },
@@ -161,7 +161,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 6,
+      "sorryCount": 2,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02Aristotle.lean"
     },
@@ -183,7 +183,7 @@
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ03OQ01.lean"
     },
@@ -194,7 +194,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 7,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CantorDiagonalizationOQ03OQ01Incomplete01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-01.json
@@ -158,7 +158,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean"
     },
@@ -191,7 +191,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean"
     },
@@ -235,7 +235,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-02.json
@@ -162,7 +162,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean"
     },
@@ -195,7 +195,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean"
     },
@@ -239,7 +239,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-01.json
@@ -165,7 +165,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean"
     },
@@ -198,7 +198,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean"
     },
@@ -242,7 +242,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01.json
@@ -163,7 +163,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean"
     },
@@ -196,7 +196,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean"
     },
@@ -240,7 +240,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01.json
@@ -167,7 +167,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean"
     },
@@ -200,7 +200,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean"
     },
@@ -244,7 +244,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-02.json
@@ -161,7 +161,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean"
     },
@@ -194,7 +194,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean"
     },
@@ -238,7 +238,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02.json
@@ -200,7 +200,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean"
     },
@@ -233,7 +233,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean"
     },
@@ -277,7 +277,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-03.json
@@ -168,7 +168,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean"
     },
@@ -201,7 +201,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean"
     },
@@ -245,7 +245,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02.json
@@ -171,7 +171,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean"
     },
@@ -204,7 +204,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean"
     },
@@ -248,7 +248,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-03.json
@@ -214,7 +214,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean"
     },
@@ -247,7 +247,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean"
     },
@@ -291,7 +291,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-04.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-04.json
@@ -171,7 +171,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean"
     },
@@ -204,7 +204,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean"
     },
@@ -248,7 +248,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-01.json
@@ -182,7 +182,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean"
     },
@@ -215,7 +215,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean"
     },
@@ -259,7 +259,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-02.json
@@ -195,7 +195,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean"
     },
@@ -228,7 +228,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean"
     },
@@ -272,7 +272,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-03.json
@@ -204,7 +204,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean"
     },
@@ -237,7 +237,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean"
     },
@@ -281,7 +281,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-04.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-04.json
@@ -206,7 +206,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean"
     },
@@ -239,7 +239,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean"
     },
@@ -283,7 +283,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01.json
@@ -163,7 +163,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean"
     },
@@ -196,7 +196,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean"
     },
@@ -240,7 +240,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-02.json
@@ -196,7 +196,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean"
     },
@@ -229,7 +229,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean"
     },
@@ -273,7 +273,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05.json
@@ -128,7 +128,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean"
     },
@@ -161,7 +161,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean"
     },
@@ -205,7 +205,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-oq-01-oq-01.json
@@ -180,7 +180,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean"
     },
@@ -213,7 +213,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean"
     },
@@ -257,7 +257,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean"
     },
@@ -323,7 +323,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-oq-01.json
@@ -176,7 +176,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean"
     },
@@ -209,7 +209,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean"
     },
@@ -253,7 +253,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean"
     },
@@ -319,7 +319,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-oq-02.json
@@ -181,7 +181,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean"
     },
@@ -214,7 +214,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean"
     },
@@ -258,7 +258,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean"
     },
@@ -324,7 +324,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-oq-03.json
@@ -179,7 +179,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean"
     },
@@ -212,7 +212,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean"
     },
@@ -256,7 +256,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean"
     },
@@ -322,7 +322,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-reduction-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-reduction-oq-01-oq-01.json
@@ -81,7 +81,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-reduction-oq-01-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-reduction-oq-01-oq-02.json
@@ -81,7 +81,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-reduction-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-reduction-oq-01.json
@@ -92,7 +92,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-reduction-oq-02-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-reduction-oq-02-oq-01.json
@@ -110,7 +110,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-reduction-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-reduction-oq-02.json
@@ -46,7 +46,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-reduction-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-reduction-oq-03.json
@@ -85,7 +85,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01.lean"
     },

--- a/src/data/research/problems/central-limit-theorem-oq-01-oq-01.json
+++ b/src/data/research/problems/central-limit-theorem-oq-01-oq-01.json
@@ -124,7 +124,7 @@
       "theoremCount": 19,
       "axiomCount": 1,
       "defCount": 11,
-      "sorryCount": 4,
+      "sorryCount": 3,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ02.lean"
     },

--- a/src/data/research/problems/central-limit-theorem-oq-01-oq-02.json
+++ b/src/data/research/problems/central-limit-theorem-oq-01-oq-02.json
@@ -149,7 +149,7 @@
       "theoremCount": 19,
       "axiomCount": 1,
       "defCount": 11,
-      "sorryCount": 4,
+      "sorryCount": 3,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ02.lean"
     },

--- a/src/data/research/problems/central-limit-theorem-oq-01-oq-03.json
+++ b/src/data/research/problems/central-limit-theorem-oq-01-oq-03.json
@@ -127,7 +127,7 @@
       "theoremCount": 19,
       "axiomCount": 1,
       "defCount": 11,
-      "sorryCount": 4,
+      "sorryCount": 3,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ02.lean"
     },

--- a/src/data/research/problems/central-limit-theorem-oq-01-oq-04.json
+++ b/src/data/research/problems/central-limit-theorem-oq-01-oq-04.json
@@ -117,7 +117,7 @@
       "theoremCount": 19,
       "axiomCount": 1,
       "defCount": 11,
-      "sorryCount": 4,
+      "sorryCount": 3,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ02.lean"
     },

--- a/src/data/research/problems/central-limit-theorem-oq-01.json
+++ b/src/data/research/problems/central-limit-theorem-oq-01.json
@@ -132,7 +132,7 @@
       "theoremCount": 19,
       "axiomCount": 1,
       "defCount": 11,
-      "sorryCount": 4,
+      "sorryCount": 3,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ02.lean"
     },

--- a/src/data/research/problems/central-limit-theorem-oq-02.json
+++ b/src/data/research/problems/central-limit-theorem-oq-02.json
@@ -124,7 +124,7 @@
       "theoremCount": 19,
       "axiomCount": 1,
       "defCount": 11,
-      "sorryCount": 4,
+      "sorryCount": 3,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ02.lean"
     },

--- a/src/data/research/problems/central-limit-theorem-oq-03-oq-01.json
+++ b/src/data/research/problems/central-limit-theorem-oq-03-oq-01.json
@@ -122,7 +122,7 @@
       "theoremCount": 19,
       "axiomCount": 1,
       "defCount": 11,
-      "sorryCount": 4,
+      "sorryCount": 3,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ02.lean"
     },

--- a/src/data/research/problems/central-limit-theorem-oq-03.json
+++ b/src/data/research/problems/central-limit-theorem-oq-03.json
@@ -123,7 +123,7 @@
       "theoremCount": 19,
       "axiomCount": 1,
       "defCount": 11,
-      "sorryCount": 4,
+      "sorryCount": 3,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ02.lean"
     },

--- a/src/data/research/problems/central-limit-theorem-oq-04.json
+++ b/src/data/research/problems/central-limit-theorem-oq-04.json
@@ -165,7 +165,7 @@
       "theoremCount": 19,
       "axiomCount": 1,
       "defCount": 11,
-      "sorryCount": 4,
+      "sorryCount": 3,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CentralLimitTheoremOQ02.lean"
     },

--- a/src/data/research/problems/cevas-theorem-oq-01.json
+++ b/src/data/research/problems/cevas-theorem-oq-01.json
@@ -86,7 +86,7 @@
       "theoremCount": 39,
       "axiomCount": 0,
       "defCount": 22,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CevasTheoremOQ01.lean"
     },

--- a/src/data/research/problems/cevas-theorem-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/cevas-theorem-oq-02-oq-01-oq-02.json
@@ -83,7 +83,7 @@
       "theoremCount": 39,
       "axiomCount": 0,
       "defCount": 22,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CevasTheoremOQ01.lean"
     },

--- a/src/data/research/problems/cevas-theorem-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/cevas-theorem-oq-02-oq-01-oq-03.json
@@ -131,7 +131,7 @@
       "theoremCount": 39,
       "axiomCount": 0,
       "defCount": 22,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CevasTheoremOQ01.lean"
     },

--- a/src/data/research/problems/cevas-theorem-oq-02-oq-01.json
+++ b/src/data/research/problems/cevas-theorem-oq-02-oq-01.json
@@ -92,7 +92,7 @@
       "theoremCount": 39,
       "axiomCount": 0,
       "defCount": 22,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CevasTheoremOQ01.lean"
     },

--- a/src/data/research/problems/cevas-theorem-oq-02-oq-02.json
+++ b/src/data/research/problems/cevas-theorem-oq-02-oq-02.json
@@ -98,7 +98,7 @@
       "theoremCount": 39,
       "axiomCount": 0,
       "defCount": 22,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CevasTheoremOQ01.lean"
     },

--- a/src/data/research/problems/cevas-theorem-oq-02-oq-04.json
+++ b/src/data/research/problems/cevas-theorem-oq-02-oq-04.json
@@ -85,7 +85,7 @@
       "theoremCount": 39,
       "axiomCount": 0,
       "defCount": 22,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CevasTheoremOQ01.lean"
     },

--- a/src/data/research/problems/cevas-theorem-oq-03.json
+++ b/src/data/research/problems/cevas-theorem-oq-03.json
@@ -96,7 +96,7 @@
       "theoremCount": 39,
       "axiomCount": 0,
       "defCount": 22,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CevasTheoremOQ01.lean"
     },

--- a/src/data/research/problems/cevas-theorem-oq-04.json
+++ b/src/data/research/problems/cevas-theorem-oq-04.json
@@ -93,7 +93,7 @@
       "theoremCount": 39,
       "axiomCount": 0,
       "defCount": 22,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CevasTheoremOQ01.lean"
     },

--- a/src/data/research/problems/chinese-remainder-non-coprime-oq-01.json
+++ b/src/data/research/problems/chinese-remainder-non-coprime-oq-01.json
@@ -114,7 +114,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ChineseRemainderNonCoprimeOQ03.lean"
     },
@@ -125,7 +125,7 @@
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ChineseRemainderNonCoprimeOQ03Aristotle.lean"
     },

--- a/src/data/research/problems/chinese-remainder-non-coprime-oq-02.json
+++ b/src/data/research/problems/chinese-remainder-non-coprime-oq-02.json
@@ -110,7 +110,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ChineseRemainderNonCoprimeOQ03.lean"
     },
@@ -121,7 +121,7 @@
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ChineseRemainderNonCoprimeOQ03Aristotle.lean"
     },

--- a/src/data/research/problems/chinese-remainder-non-coprime-oq-03.json
+++ b/src/data/research/problems/chinese-remainder-non-coprime-oq-03.json
@@ -108,7 +108,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ChineseRemainderNonCoprimeOQ03.lean"
     },
@@ -119,7 +119,7 @@
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ChineseRemainderNonCoprimeOQ03Aristotle.lean"
     },

--- a/src/data/research/problems/chinese-remainder-non-coprime-oq-04.json
+++ b/src/data/research/problems/chinese-remainder-non-coprime-oq-04.json
@@ -116,7 +116,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ChineseRemainderNonCoprimeOQ03.lean"
     },
@@ -127,7 +127,7 @@
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ChineseRemainderNonCoprimeOQ03Aristotle.lean"
     },

--- a/src/data/research/problems/derangements-oq-01.json
+++ b/src/data/research/problems/derangements-oq-01.json
@@ -91,7 +91,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsOQ02.lean"
     },
@@ -113,7 +113,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsOQ02OQ02.lean"
     },

--- a/src/data/research/problems/derangements-oq-02-oq-01.json
+++ b/src/data/research/problems/derangements-oq-02-oq-01.json
@@ -93,7 +93,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsOQ02.lean"
     },
@@ -115,7 +115,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsOQ02OQ02.lean"
     },

--- a/src/data/research/problems/derangements-oq-02-oq-02.json
+++ b/src/data/research/problems/derangements-oq-02-oq-02.json
@@ -110,7 +110,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsOQ02.lean"
     },
@@ -132,7 +132,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsOQ02OQ02.lean"
     },

--- a/src/data/research/problems/derangements-oq-02.json
+++ b/src/data/research/problems/derangements-oq-02.json
@@ -91,7 +91,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsOQ02.lean"
     },
@@ -113,7 +113,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsOQ02OQ02.lean"
     },

--- a/src/data/research/problems/derangements-oq-03-oq-01.json
+++ b/src/data/research/problems/derangements-oq-03-oq-01.json
@@ -96,7 +96,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsOQ02.lean"
     },
@@ -118,7 +118,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsOQ02OQ02.lean"
     },

--- a/src/data/research/problems/derangements-oq-03-oq-02.json
+++ b/src/data/research/problems/derangements-oq-03-oq-02.json
@@ -96,7 +96,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsOQ02.lean"
     },
@@ -118,7 +118,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsOQ02OQ02.lean"
     },

--- a/src/data/research/problems/derangements-oq-03.json
+++ b/src/data/research/problems/derangements-oq-03.json
@@ -91,7 +91,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsOQ02.lean"
     },
@@ -113,7 +113,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsOQ02OQ02.lean"
     },

--- a/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-01.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-01.json
@@ -84,7 +84,7 @@
       "theoremCount": 30,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ01.lean"
     },

--- a/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-02.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-02.json
@@ -85,7 +85,7 @@
       "theoremCount": 30,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ01.lean"
     },

--- a/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-03.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-03.json
@@ -80,7 +80,7 @@
       "theoremCount": 30,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ01.lean"
     },

--- a/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-04.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-04.json
@@ -73,7 +73,7 @@
       "theoremCount": 30,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ01.lean"
     },

--- a/src/data/research/problems/descartes-rule-of-signs-oq-01.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-01.json
@@ -82,7 +82,7 @@
       "theoremCount": 30,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ01.lean"
     },

--- a/src/data/research/problems/descartes-rule-of-signs-oq-02-oq-01.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-02-oq-01.json
@@ -85,7 +85,7 @@
       "theoremCount": 30,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ01.lean"
     },

--- a/src/data/research/problems/descartes-rule-of-signs-oq-02.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-02.json
@@ -139,7 +139,7 @@
       "theoremCount": 30,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ01.lean"
     },

--- a/src/data/research/problems/descartes-rule-of-signs-oq-03.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-03.json
@@ -79,7 +79,7 @@
       "theoremCount": 30,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ01.lean"
     },

--- a/src/data/research/problems/descartes-rule-of-signs-oq-04.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-04.json
@@ -100,7 +100,7 @@
       "theoremCount": 30,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ01.lean"
     },

--- a/src/data/research/problems/descartes-rule-oq-01-oq-01.json
+++ b/src/data/research/problems/descartes-rule-oq-01-oq-01.json
@@ -78,7 +78,7 @@
       "theoremCount": 30,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DescartesRuleOfSignsOQ01.lean"
     },

--- a/src/data/research/problems/dirichlets-theorem-oq-01.json
+++ b/src/data/research/problems/dirichlets-theorem-oq-01.json
@@ -95,7 +95,7 @@
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DirichletsTheoremOQ02.lean"
     },
@@ -106,7 +106,7 @@
       "theoremCount": 16,
       "axiomCount": 4,
       "defCount": 9,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DirichletsTheoremOQ02OQ01.lean"
     },
@@ -128,7 +128,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 6,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DirichletsTheoremOQ03Incomplete01.lean"
     }

--- a/src/data/research/problems/dirichlets-theorem-oq-02.json
+++ b/src/data/research/problems/dirichlets-theorem-oq-02.json
@@ -107,7 +107,7 @@
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DirichletsTheoremOQ02.lean"
     },
@@ -118,7 +118,7 @@
       "theoremCount": 16,
       "axiomCount": 4,
       "defCount": 9,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DirichletsTheoremOQ02OQ01.lean"
     },
@@ -140,7 +140,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 6,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DirichletsTheoremOQ03Incomplete01.lean"
     }

--- a/src/data/research/problems/dissection-of-cubes-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/dissection-of-cubes-oq-01-oq-01-oq-01.json
@@ -119,7 +119,7 @@
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 6,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DissectionOfCubesOQ03.lean"
     }

--- a/src/data/research/problems/dissection-of-cubes-oq-01-oq-01.json
+++ b/src/data/research/problems/dissection-of-cubes-oq-01-oq-01.json
@@ -115,7 +115,7 @@
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 6,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DissectionOfCubesOQ03.lean"
     }

--- a/src/data/research/problems/dissection-of-cubes-oq-01.json
+++ b/src/data/research/problems/dissection-of-cubes-oq-01.json
@@ -132,7 +132,7 @@
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 6,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DissectionOfCubesOQ03.lean"
     }

--- a/src/data/research/problems/dissection-of-cubes-oq-02-oq-02.json
+++ b/src/data/research/problems/dissection-of-cubes-oq-02-oq-02.json
@@ -122,7 +122,7 @@
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 6,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DissectionOfCubesOQ03.lean"
     }

--- a/src/data/research/problems/dissection-of-cubes-oq-02.json
+++ b/src/data/research/problems/dissection-of-cubes-oq-02.json
@@ -103,7 +103,7 @@
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 6,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DissectionOfCubesOQ03.lean"
     }

--- a/src/data/research/problems/dissection-of-cubes-oq-03.json
+++ b/src/data/research/problems/dissection-of-cubes-oq-03.json
@@ -129,7 +129,7 @@
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 6,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DissectionOfCubesOQ03.lean"
     }

--- a/src/data/research/problems/dissection-of-cubes-oq-05.json
+++ b/src/data/research/problems/dissection-of-cubes-oq-05.json
@@ -141,7 +141,7 @@
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 6,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DissectionOfCubesOQ03.lean"
     }

--- a/src/data/research/problems/dissection-of-cubes-oq-06.json
+++ b/src/data/research/problems/dissection-of-cubes-oq-06.json
@@ -119,7 +119,7 @@
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 6,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DissectionOfCubesOQ03.lean"
     }

--- a/src/data/research/problems/erdos-1-oq-01.json
+++ b/src/data/research/problems/erdos-1-oq-01.json
@@ -507,7 +507,7 @@
       "theoremCount": 22,
       "axiomCount": 3,
       "defCount": 15,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1004Problem.lean"
     },
@@ -540,7 +540,7 @@
       "theoremCount": 6,
       "axiomCount": 3,
       "defCount": 12,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ01.lean"
     },
@@ -551,7 +551,7 @@
       "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 8,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ02.lean"
     },
@@ -562,7 +562,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ03.lean"
     },
@@ -793,7 +793,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 9,
-      "sorryCount": 4,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03.lean"
     },
@@ -804,7 +804,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03Aristotle.lean"
     },
@@ -947,7 +947,7 @@
       "theoremCount": 11,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 21,
+      "sorryCount": 5,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1018OQ04Incomplete01.lean"
     },
@@ -991,7 +991,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021Aristotle.lean"
     },
@@ -1002,7 +1002,7 @@
       "theoremCount": 8,
       "axiomCount": 2,
       "defCount": 2,
-      "sorryCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021OQ01.lean"
     },
@@ -1134,7 +1134,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1027Aristotle.lean"
     },
@@ -1145,7 +1145,7 @@
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 13,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1027Problem.lean"
     },
@@ -1321,7 +1321,7 @@
       "theoremCount": 22,
       "axiomCount": 3,
       "defCount": 12,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos103OQ01.lean"
     },
@@ -1343,7 +1343,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 7,
-      "sorryCount": 4,
+      "sorryCount": 3,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1040Aristotle.lean"
     },
@@ -1519,7 +1519,7 @@
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos104Problem.lean"
     },
@@ -2146,7 +2146,7 @@
       "theoremCount": 20,
       "axiomCount": 4,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1084OQ01.lean"
     },
@@ -2509,7 +2509,7 @@
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1105Aristotle.lean"
     },
@@ -2806,7 +2806,7 @@
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1126OQ01Aristotle.lean"
     },
@@ -2916,7 +2916,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1132Aristotle.lean"
     },
@@ -2982,7 +2982,7 @@
       "theoremCount": 20,
       "axiomCount": 1,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1137Problem.lean"
     },
@@ -2993,7 +2993,7 @@
       "theoremCount": 12,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1138OQ03.lean"
     },
@@ -3136,7 +3136,7 @@
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1149Aristotle.lean"
     },
@@ -3807,7 +3807,7 @@
       "theoremCount": 20,
       "axiomCount": 2,
       "defCount": 6,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos131Problem.lean"
     },
@@ -4445,7 +4445,7 @@
       "theoremCount": 8,
       "axiomCount": 2,
       "defCount": 14,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos183Problem.lean"
     },
@@ -4687,7 +4687,7 @@
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1OQ02.lean"
     },

--- a/src/data/research/problems/erdos-1-oq-02.json
+++ b/src/data/research/problems/erdos-1-oq-02.json
@@ -122,7 +122,7 @@
       "theoremCount": 22,
       "axiomCount": 3,
       "defCount": 15,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1004Problem.lean"
     },
@@ -155,7 +155,7 @@
       "theoremCount": 6,
       "axiomCount": 3,
       "defCount": 12,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ01.lean"
     },
@@ -166,7 +166,7 @@
       "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 8,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ02.lean"
     },
@@ -177,7 +177,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ03.lean"
     },
@@ -408,7 +408,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 9,
-      "sorryCount": 4,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03.lean"
     },
@@ -419,7 +419,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03Aristotle.lean"
     },
@@ -562,7 +562,7 @@
       "theoremCount": 11,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 21,
+      "sorryCount": 5,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1018OQ04Incomplete01.lean"
     },
@@ -606,7 +606,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021Aristotle.lean"
     },
@@ -617,7 +617,7 @@
       "theoremCount": 8,
       "axiomCount": 2,
       "defCount": 2,
-      "sorryCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021OQ01.lean"
     },
@@ -749,7 +749,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1027Aristotle.lean"
     },
@@ -760,7 +760,7 @@
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 13,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1027Problem.lean"
     },
@@ -936,7 +936,7 @@
       "theoremCount": 22,
       "axiomCount": 3,
       "defCount": 12,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos103OQ01.lean"
     },
@@ -958,7 +958,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 7,
-      "sorryCount": 4,
+      "sorryCount": 3,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1040Aristotle.lean"
     },
@@ -1134,7 +1134,7 @@
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos104Problem.lean"
     },
@@ -1761,7 +1761,7 @@
       "theoremCount": 20,
       "axiomCount": 4,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1084OQ01.lean"
     },
@@ -2124,7 +2124,7 @@
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1105Aristotle.lean"
     },
@@ -2421,7 +2421,7 @@
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1126OQ01Aristotle.lean"
     },
@@ -2531,7 +2531,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1132Aristotle.lean"
     },
@@ -2597,7 +2597,7 @@
       "theoremCount": 20,
       "axiomCount": 1,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1137Problem.lean"
     },
@@ -2608,7 +2608,7 @@
       "theoremCount": 12,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1138OQ03.lean"
     },
@@ -2751,7 +2751,7 @@
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1149Aristotle.lean"
     },
@@ -3422,7 +3422,7 @@
       "theoremCount": 20,
       "axiomCount": 2,
       "defCount": 6,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos131Problem.lean"
     },
@@ -4060,7 +4060,7 @@
       "theoremCount": 8,
       "axiomCount": 2,
       "defCount": 14,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos183Problem.lean"
     },
@@ -4302,7 +4302,7 @@
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1OQ02.lean"
     },

--- a/src/data/research/problems/erdos-1-oq-03.json
+++ b/src/data/research/problems/erdos-1-oq-03.json
@@ -527,7 +527,7 @@
       "theoremCount": 22,
       "axiomCount": 3,
       "defCount": 15,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1004Problem.lean"
     },
@@ -560,7 +560,7 @@
       "theoremCount": 6,
       "axiomCount": 3,
       "defCount": 12,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ01.lean"
     },
@@ -571,7 +571,7 @@
       "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 8,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ02.lean"
     },
@@ -582,7 +582,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ03.lean"
     },
@@ -813,7 +813,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 9,
-      "sorryCount": 4,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03.lean"
     },
@@ -824,7 +824,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03Aristotle.lean"
     },
@@ -967,7 +967,7 @@
       "theoremCount": 11,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 21,
+      "sorryCount": 5,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1018OQ04Incomplete01.lean"
     },
@@ -1011,7 +1011,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021Aristotle.lean"
     },
@@ -1022,7 +1022,7 @@
       "theoremCount": 8,
       "axiomCount": 2,
       "defCount": 2,
-      "sorryCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021OQ01.lean"
     },
@@ -1154,7 +1154,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1027Aristotle.lean"
     },
@@ -1165,7 +1165,7 @@
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 13,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1027Problem.lean"
     },
@@ -1341,7 +1341,7 @@
       "theoremCount": 22,
       "axiomCount": 3,
       "defCount": 12,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos103OQ01.lean"
     },
@@ -1363,7 +1363,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 7,
-      "sorryCount": 4,
+      "sorryCount": 3,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1040Aristotle.lean"
     },
@@ -1539,7 +1539,7 @@
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos104Problem.lean"
     },
@@ -2166,7 +2166,7 @@
       "theoremCount": 20,
       "axiomCount": 4,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1084OQ01.lean"
     },
@@ -2529,7 +2529,7 @@
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1105Aristotle.lean"
     },
@@ -2826,7 +2826,7 @@
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1126OQ01Aristotle.lean"
     },
@@ -2936,7 +2936,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1132Aristotle.lean"
     },
@@ -3002,7 +3002,7 @@
       "theoremCount": 20,
       "axiomCount": 1,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1137Problem.lean"
     },
@@ -3013,7 +3013,7 @@
       "theoremCount": 12,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1138OQ03.lean"
     },
@@ -3156,7 +3156,7 @@
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1149Aristotle.lean"
     },
@@ -3827,7 +3827,7 @@
       "theoremCount": 20,
       "axiomCount": 2,
       "defCount": 6,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos131Problem.lean"
     },
@@ -4465,7 +4465,7 @@
       "theoremCount": 8,
       "axiomCount": 2,
       "defCount": 14,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos183Problem.lean"
     },
@@ -4707,7 +4707,7 @@
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1OQ02.lean"
     },

--- a/src/data/research/problems/erdos-1-oq-04.json
+++ b/src/data/research/problems/erdos-1-oq-04.json
@@ -504,7 +504,7 @@
       "theoremCount": 22,
       "axiomCount": 3,
       "defCount": 15,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1004Problem.lean"
     },
@@ -537,7 +537,7 @@
       "theoremCount": 6,
       "axiomCount": 3,
       "defCount": 12,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ01.lean"
     },
@@ -548,7 +548,7 @@
       "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 8,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ02.lean"
     },
@@ -559,7 +559,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ03.lean"
     },
@@ -790,7 +790,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 9,
-      "sorryCount": 4,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03.lean"
     },
@@ -801,7 +801,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03Aristotle.lean"
     },
@@ -944,7 +944,7 @@
       "theoremCount": 11,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 21,
+      "sorryCount": 5,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1018OQ04Incomplete01.lean"
     },
@@ -988,7 +988,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021Aristotle.lean"
     },
@@ -999,7 +999,7 @@
       "theoremCount": 8,
       "axiomCount": 2,
       "defCount": 2,
-      "sorryCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021OQ01.lean"
     },
@@ -1131,7 +1131,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1027Aristotle.lean"
     },
@@ -1142,7 +1142,7 @@
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 13,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1027Problem.lean"
     },
@@ -1318,7 +1318,7 @@
       "theoremCount": 22,
       "axiomCount": 3,
       "defCount": 12,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos103OQ01.lean"
     },
@@ -1340,7 +1340,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 7,
-      "sorryCount": 4,
+      "sorryCount": 3,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1040Aristotle.lean"
     },
@@ -1516,7 +1516,7 @@
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos104Problem.lean"
     },
@@ -2143,7 +2143,7 @@
       "theoremCount": 20,
       "axiomCount": 4,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1084OQ01.lean"
     },
@@ -2506,7 +2506,7 @@
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1105Aristotle.lean"
     },
@@ -2803,7 +2803,7 @@
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1126OQ01Aristotle.lean"
     },
@@ -2913,7 +2913,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1132Aristotle.lean"
     },
@@ -2979,7 +2979,7 @@
       "theoremCount": 20,
       "axiomCount": 1,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1137Problem.lean"
     },
@@ -2990,7 +2990,7 @@
       "theoremCount": 12,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1138OQ03.lean"
     },
@@ -3133,7 +3133,7 @@
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1149Aristotle.lean"
     },
@@ -3804,7 +3804,7 @@
       "theoremCount": 20,
       "axiomCount": 2,
       "defCount": 6,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos131Problem.lean"
     },
@@ -4442,7 +4442,7 @@
       "theoremCount": 8,
       "axiomCount": 2,
       "defCount": 14,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos183Problem.lean"
     },
@@ -4684,7 +4684,7 @@
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1OQ02.lean"
     },

--- a/src/data/research/problems/erdos-10-oq-01.json
+++ b/src/data/research/problems/erdos-10-oq-01.json
@@ -321,7 +321,7 @@
       "theoremCount": 22,
       "axiomCount": 3,
       "defCount": 15,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1004Problem.lean"
     },
@@ -354,7 +354,7 @@
       "theoremCount": 6,
       "axiomCount": 3,
       "defCount": 12,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ01.lean"
     },
@@ -365,7 +365,7 @@
       "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 8,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ02.lean"
     },
@@ -376,7 +376,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ03.lean"
     },
@@ -607,7 +607,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 9,
-      "sorryCount": 4,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03.lean"
     },
@@ -618,7 +618,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03Aristotle.lean"
     },
@@ -761,7 +761,7 @@
       "theoremCount": 11,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 21,
+      "sorryCount": 5,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1018OQ04Incomplete01.lean"
     },
@@ -805,7 +805,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021Aristotle.lean"
     },
@@ -816,7 +816,7 @@
       "theoremCount": 8,
       "axiomCount": 2,
       "defCount": 2,
-      "sorryCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021OQ01.lean"
     },
@@ -948,7 +948,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1027Aristotle.lean"
     },
@@ -959,7 +959,7 @@
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 13,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1027Problem.lean"
     },
@@ -1135,7 +1135,7 @@
       "theoremCount": 22,
       "axiomCount": 3,
       "defCount": 12,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos103OQ01.lean"
     },
@@ -1157,7 +1157,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 7,
-      "sorryCount": 4,
+      "sorryCount": 3,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1040Aristotle.lean"
     },
@@ -1333,7 +1333,7 @@
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos104Problem.lean"
     },
@@ -1960,7 +1960,7 @@
       "theoremCount": 20,
       "axiomCount": 4,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1084OQ01.lean"
     },

--- a/src/data/research/problems/erdos-10.json
+++ b/src/data/research/problems/erdos-10.json
@@ -307,7 +307,7 @@
       "theoremCount": 22,
       "axiomCount": 3,
       "defCount": 15,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1004Problem.lean"
     },
@@ -340,7 +340,7 @@
       "theoremCount": 6,
       "axiomCount": 3,
       "defCount": 12,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ01.lean"
     },
@@ -351,7 +351,7 @@
       "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 8,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ02.lean"
     },
@@ -362,7 +362,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ03.lean"
     },
@@ -593,7 +593,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 9,
-      "sorryCount": 4,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03.lean"
     },
@@ -604,7 +604,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03Aristotle.lean"
     },
@@ -747,7 +747,7 @@
       "theoremCount": 11,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 21,
+      "sorryCount": 5,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1018OQ04Incomplete01.lean"
     },
@@ -791,7 +791,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021Aristotle.lean"
     },
@@ -802,7 +802,7 @@
       "theoremCount": 8,
       "axiomCount": 2,
       "defCount": 2,
-      "sorryCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021OQ01.lean"
     },
@@ -934,7 +934,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1027Aristotle.lean"
     },
@@ -945,7 +945,7 @@
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 13,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1027Problem.lean"
     },
@@ -1121,7 +1121,7 @@
       "theoremCount": 22,
       "axiomCount": 3,
       "defCount": 12,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos103OQ01.lean"
     },
@@ -1143,7 +1143,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 7,
-      "sorryCount": 4,
+      "sorryCount": 3,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1040Aristotle.lean"
     },
@@ -1319,7 +1319,7 @@
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos104Problem.lean"
     },
@@ -1946,7 +1946,7 @@
       "theoremCount": 20,
       "axiomCount": 4,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1084OQ01.lean"
     },

--- a/src/data/research/problems/erdos-100-oq-01.json
+++ b/src/data/research/problems/erdos-100-oq-01.json
@@ -114,7 +114,7 @@
       "theoremCount": 22,
       "axiomCount": 3,
       "defCount": 15,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1004Problem.lean"
     },
@@ -147,7 +147,7 @@
       "theoremCount": 6,
       "axiomCount": 3,
       "defCount": 12,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ01.lean"
     },
@@ -158,7 +158,7 @@
       "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 8,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ02.lean"
     },
@@ -169,7 +169,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ03.lean"
     },

--- a/src/data/research/problems/erdos-100-oq-04.json
+++ b/src/data/research/problems/erdos-100-oq-04.json
@@ -172,7 +172,7 @@
       "theoremCount": 22,
       "axiomCount": 3,
       "defCount": 15,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1004Problem.lean"
     },
@@ -205,7 +205,7 @@
       "theoremCount": 6,
       "axiomCount": 3,
       "defCount": 12,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ01.lean"
     },
@@ -216,7 +216,7 @@
       "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 8,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ02.lean"
     },
@@ -227,7 +227,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ03.lean"
     },

--- a/src/data/research/problems/erdos-100.json
+++ b/src/data/research/problems/erdos-100.json
@@ -214,7 +214,7 @@
       "theoremCount": 22,
       "axiomCount": 3,
       "defCount": 15,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1004Problem.lean"
     },
@@ -247,7 +247,7 @@
       "theoremCount": 6,
       "axiomCount": 3,
       "defCount": 12,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ01.lean"
     },
@@ -258,7 +258,7 @@
       "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 8,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ02.lean"
     },
@@ -269,7 +269,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ03.lean"
     },

--- a/src/data/research/problems/erdos-1004-oq-02.json
+++ b/src/data/research/problems/erdos-1004-oq-02.json
@@ -64,7 +64,7 @@
       "theoremCount": 22,
       "axiomCount": 3,
       "defCount": 15,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1004Problem.lean"
     }

--- a/src/data/research/problems/erdos-1006-oq-01.json
+++ b/src/data/research/problems/erdos-1006-oq-01.json
@@ -62,7 +62,7 @@
       "theoremCount": 6,
       "axiomCount": 3,
       "defCount": 12,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ01.lean"
     },
@@ -73,7 +73,7 @@
       "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 8,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ02.lean"
     },
@@ -84,7 +84,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ03.lean"
     },

--- a/src/data/research/problems/erdos-1006-oq-02-oq-01.json
+++ b/src/data/research/problems/erdos-1006-oq-02-oq-01.json
@@ -67,7 +67,7 @@
       "theoremCount": 6,
       "axiomCount": 3,
       "defCount": 12,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ01.lean"
     },
@@ -78,7 +78,7 @@
       "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 8,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ02.lean"
     },
@@ -89,7 +89,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ03.lean"
     },

--- a/src/data/research/problems/erdos-1006-oq-02-oq-03.json
+++ b/src/data/research/problems/erdos-1006-oq-02-oq-03.json
@@ -70,7 +70,7 @@
       "theoremCount": 6,
       "axiomCount": 3,
       "defCount": 12,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ01.lean"
     },
@@ -81,7 +81,7 @@
       "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 8,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ02.lean"
     },
@@ -92,7 +92,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ03.lean"
     },

--- a/src/data/research/problems/erdos-1006-oq-02.json
+++ b/src/data/research/problems/erdos-1006-oq-02.json
@@ -69,7 +69,7 @@
       "theoremCount": 6,
       "axiomCount": 3,
       "defCount": 12,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ01.lean"
     },
@@ -80,7 +80,7 @@
       "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 8,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ02.lean"
     },
@@ -91,7 +91,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ03.lean"
     },

--- a/src/data/research/problems/erdos-1006-oq-03.json
+++ b/src/data/research/problems/erdos-1006-oq-03.json
@@ -71,7 +71,7 @@
       "theoremCount": 6,
       "axiomCount": 3,
       "defCount": 12,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ01.lean"
     },
@@ -82,7 +82,7 @@
       "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 8,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ02.lean"
     },
@@ -93,7 +93,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ03.lean"
     },

--- a/src/data/research/problems/erdos-1006-oq-04.json
+++ b/src/data/research/problems/erdos-1006-oq-04.json
@@ -73,7 +73,7 @@
       "theoremCount": 6,
       "axiomCount": 3,
       "defCount": 12,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ01.lean"
     },
@@ -84,7 +84,7 @@
       "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 8,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ02.lean"
     },
@@ -95,7 +95,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ03.lean"
     },

--- a/src/data/research/problems/erdos-101-oq-04.json
+++ b/src/data/research/problems/erdos-101-oq-04.json
@@ -136,7 +136,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 9,
-      "sorryCount": 4,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03.lean"
     },
@@ -147,7 +147,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03Aristotle.lean"
     },
@@ -290,7 +290,7 @@
       "theoremCount": 11,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 21,
+      "sorryCount": 5,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1018OQ04Incomplete01.lean"
     },

--- a/src/data/research/problems/erdos-101.json
+++ b/src/data/research/problems/erdos-101.json
@@ -138,7 +138,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 9,
-      "sorryCount": 4,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03.lean"
     },
@@ -149,7 +149,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03Aristotle.lean"
     },
@@ -292,7 +292,7 @@
       "theoremCount": 11,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 21,
+      "sorryCount": 5,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1018OQ04Incomplete01.lean"
     },

--- a/src/data/research/problems/erdos-1012-oq-01.json
+++ b/src/data/research/problems/erdos-1012-oq-01.json
@@ -84,7 +84,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 9,
-      "sorryCount": 4,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03.lean"
     },
@@ -95,7 +95,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03Aristotle.lean"
     },

--- a/src/data/research/problems/erdos-1012-oq-02.json
+++ b/src/data/research/problems/erdos-1012-oq-02.json
@@ -95,7 +95,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 9,
-      "sorryCount": 4,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03.lean"
     },
@@ -106,7 +106,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03Aristotle.lean"
     },

--- a/src/data/research/problems/erdos-1012-oq-03-incomplete-01.json
+++ b/src/data/research/problems/erdos-1012-oq-03-incomplete-01.json
@@ -86,7 +86,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 8,
-      "sorryCount": 4,
+      "sorryCount": 2,
       "isAristotle": false
     }
   ]

--- a/src/data/research/problems/erdos-1012-oq-03.json
+++ b/src/data/research/problems/erdos-1012-oq-03.json
@@ -134,7 +134,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 9,
-      "sorryCount": 4,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03.lean"
     },
@@ -145,7 +145,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03Aristotle.lean"
     },

--- a/src/data/research/problems/erdos-1018-oq-04.json
+++ b/src/data/research/problems/erdos-1018-oq-04.json
@@ -71,7 +71,7 @@
       "theoremCount": 11,
       "axiomCount": 1,
       "defCount": 1,
-      "sorryCount": 21,
+      "sorryCount": 5,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1018OQ04Incomplete01.lean"
     }

--- a/src/data/research/problems/erdos-102-oq-03.json
+++ b/src/data/research/problems/erdos-102-oq-03.json
@@ -127,7 +127,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021Aristotle.lean"
     },
@@ -138,7 +138,7 @@
       "theoremCount": 8,
       "axiomCount": 2,
       "defCount": 2,
-      "sorryCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021OQ01.lean"
     },
@@ -270,7 +270,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1027Aristotle.lean"
     },
@@ -281,7 +281,7 @@
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 13,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1027Problem.lean"
     },

--- a/src/data/research/problems/erdos-1021-oq-01.json
+++ b/src/data/research/problems/erdos-1021-oq-01.json
@@ -83,7 +83,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021Aristotle.lean"
     },
@@ -94,7 +94,7 @@
       "theoremCount": 8,
       "axiomCount": 2,
       "defCount": 2,
-      "sorryCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021OQ01.lean"
     },

--- a/src/data/research/problems/erdos-1027-oq-02.json
+++ b/src/data/research/problems/erdos-1027-oq-02.json
@@ -65,7 +65,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1027Aristotle.lean"
     },
@@ -76,7 +76,7 @@
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 13,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1027Problem.lean"
     }

--- a/src/data/research/problems/erdos-1027-oq-03.json
+++ b/src/data/research/problems/erdos-1027-oq-03.json
@@ -62,7 +62,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1027Aristotle.lean"
     },
@@ -73,7 +73,7 @@
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 13,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1027Problem.lean"
     }

--- a/src/data/research/problems/erdos-103-oq-01.json
+++ b/src/data/research/problems/erdos-103-oq-01.json
@@ -229,7 +229,7 @@
       "theoremCount": 22,
       "axiomCount": 3,
       "defCount": 12,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos103OQ01.lean"
     },

--- a/src/data/research/problems/erdos-1040-oq-05.json
+++ b/src/data/research/problems/erdos-1040-oq-05.json
@@ -122,7 +122,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 7,
-      "sorryCount": 4,
+      "sorryCount": 3,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1040Aristotle.lean"
     },

--- a/src/data/research/problems/erdos-1084-oq-01.json
+++ b/src/data/research/problems/erdos-1084-oq-01.json
@@ -113,7 +113,7 @@
       "theoremCount": 20,
       "axiomCount": 4,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1084OQ01.lean"
     },

--- a/src/data/research/problems/erdos-1084.json
+++ b/src/data/research/problems/erdos-1084.json
@@ -63,7 +63,7 @@
       "theoremCount": 20,
       "axiomCount": 4,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1084OQ01.lean"
     },

--- a/src/data/research/problems/erdos-11-oq-03.json
+++ b/src/data/research/problems/erdos-11-oq-03.json
@@ -229,7 +229,7 @@
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1105Aristotle.lean"
     },
@@ -526,7 +526,7 @@
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1126OQ01Aristotle.lean"
     },
@@ -636,7 +636,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1132Aristotle.lean"
     },
@@ -702,7 +702,7 @@
       "theoremCount": 20,
       "axiomCount": 1,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1137Problem.lean"
     },
@@ -713,7 +713,7 @@
       "theoremCount": 12,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1138OQ03.lean"
     },
@@ -856,7 +856,7 @@
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1149Aristotle.lean"
     },

--- a/src/data/research/problems/erdos-110-oq-03.json
+++ b/src/data/research/problems/erdos-110-oq-03.json
@@ -183,7 +183,7 @@
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1105Aristotle.lean"
     },

--- a/src/data/research/problems/erdos-1105.json
+++ b/src/data/research/problems/erdos-1105.json
@@ -75,7 +75,7 @@
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1105Aristotle.lean"
     },

--- a/src/data/research/problems/erdos-1126-oq-01-oq-04.json
+++ b/src/data/research/problems/erdos-1126-oq-01-oq-04.json
@@ -104,7 +104,7 @@
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1126OQ01Aristotle.lean"
     },

--- a/src/data/research/problems/erdos-1126-oq-01.json
+++ b/src/data/research/problems/erdos-1126-oq-01.json
@@ -91,7 +91,7 @@
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1126OQ01Aristotle.lean"
     },

--- a/src/data/research/problems/erdos-113-oq-01.json
+++ b/src/data/research/problems/erdos-113-oq-01.json
@@ -121,7 +121,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1132Aristotle.lean"
     },
@@ -187,7 +187,7 @@
       "theoremCount": 20,
       "axiomCount": 1,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1137Problem.lean"
     },
@@ -198,7 +198,7 @@
       "theoremCount": 12,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1138OQ03.lean"
     },

--- a/src/data/research/problems/erdos-1132-oq-01.json
+++ b/src/data/research/problems/erdos-1132-oq-01.json
@@ -86,7 +86,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1132Aristotle.lean"
     },

--- a/src/data/research/problems/erdos-1137.json
+++ b/src/data/research/problems/erdos-1137.json
@@ -119,7 +119,7 @@
       "theoremCount": 20,
       "axiomCount": 1,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1137Problem.lean"
     }

--- a/src/data/research/problems/erdos-1138-oq-03.json
+++ b/src/data/research/problems/erdos-1138-oq-03.json
@@ -65,7 +65,7 @@
       "theoremCount": 12,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1138OQ03.lean"
     },

--- a/src/data/research/problems/erdos-1138.json
+++ b/src/data/research/problems/erdos-1138.json
@@ -72,7 +72,7 @@
       "theoremCount": 12,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1138OQ03.lean"
     },

--- a/src/data/research/problems/erdos-114-oq-04.json
+++ b/src/data/research/problems/erdos-114-oq-04.json
@@ -143,7 +143,7 @@
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1149Aristotle.lean"
     },

--- a/src/data/research/problems/erdos-1149.json
+++ b/src/data/research/problems/erdos-1149.json
@@ -79,7 +79,7 @@
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1149Aristotle.lean"
     },

--- a/src/data/research/problems/erdos-131-oq-01.json
+++ b/src/data/research/problems/erdos-131-oq-01.json
@@ -69,7 +69,7 @@
       "theoremCount": 20,
       "axiomCount": 2,
       "defCount": 6,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos131Problem.lean"
     }

--- a/src/data/research/problems/erdos-183.json
+++ b/src/data/research/problems/erdos-183.json
@@ -81,7 +81,7 @@
       "theoremCount": 8,
       "axiomCount": 2,
       "defCount": 14,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos183Problem.lean"
     }

--- a/src/data/research/problems/erdos-268-oq-01.json
+++ b/src/data/research/problems/erdos-268-oq-01.json
@@ -105,7 +105,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 8,
-      "sorryCount": 11,
+      "sorryCount": 10,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos268ProblemAristotle.lean"
     }

--- a/src/data/research/problems/erdos-307-oq-02.json
+++ b/src/data/research/problems/erdos-307-oq-02.json
@@ -38,7 +38,7 @@
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 6,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos307OQ02.lean"
     },

--- a/src/data/research/problems/erdos-40.json
+++ b/src/data/research/problems/erdos-40.json
@@ -99,7 +99,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos400Problem.lean"
     },
@@ -121,7 +121,7 @@
       "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 5,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos402Problem.lean"
     },

--- a/src/data/research/problems/erdos-400.json
+++ b/src/data/research/problems/erdos-400.json
@@ -84,7 +84,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos400Problem.lean"
     }

--- a/src/data/research/problems/erdos-402-incomplete-01.json
+++ b/src/data/research/problems/erdos-402-incomplete-01.json
@@ -101,7 +101,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 5,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos402Problem.lean"
     }

--- a/src/data/research/problems/erdos-44.json
+++ b/src/data/research/problems/erdos-44.json
@@ -204,7 +204,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos44Aristotle.lean"
     },

--- a/src/data/research/problems/erdos-453-oq-02.json
+++ b/src/data/research/problems/erdos-453-oq-02.json
@@ -80,7 +80,7 @@
       "theoremCount": 6,
       "axiomCount": 2,
       "defCount": 3,
-      "sorryCount": 4,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos453OQ02.lean"
     },
@@ -91,7 +91,7 @@
       "theoremCount": 16,
       "axiomCount": 2,
       "defCount": 7,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos453Problem.lean"
     }

--- a/src/data/research/problems/erdos-453-oq-04.json
+++ b/src/data/research/problems/erdos-453-oq-04.json
@@ -68,7 +68,7 @@
       "theoremCount": 6,
       "axiomCount": 2,
       "defCount": 3,
-      "sorryCount": 4,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos453OQ02.lean"
     },
@@ -79,7 +79,7 @@
       "theoremCount": 16,
       "axiomCount": 2,
       "defCount": 7,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos453Problem.lean"
     }

--- a/src/data/research/problems/erdos-456.json
+++ b/src/data/research/problems/erdos-456.json
@@ -93,7 +93,7 @@
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos456Aristotle.lean"
     },

--- a/src/data/research/problems/erdos-5.json
+++ b/src/data/research/problems/erdos-5.json
@@ -229,7 +229,7 @@
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos501Aristotle.lean"
     },

--- a/src/data/research/problems/erdos-614.json
+++ b/src/data/research/problems/erdos-614.json
@@ -76,7 +76,7 @@
       "theoremCount": 5,
       "axiomCount": 2,
       "defCount": 7,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos614Problem.lean"
     }

--- a/src/data/research/problems/erdos-667.json
+++ b/src/data/research/problems/erdos-667.json
@@ -100,7 +100,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 4,
+      "sorryCount": 2,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos667Aristotle.lean"
     },

--- a/src/data/research/problems/erdos-761.json
+++ b/src/data/research/problems/erdos-761.json
@@ -108,7 +108,7 @@
       "theoremCount": 6,
       "axiomCount": 2,
       "defCount": 6,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos761Problem.lean"
     }

--- a/src/data/research/problems/erdos-780-oq-01.json
+++ b/src/data/research/problems/erdos-780-oq-01.json
@@ -36,7 +36,7 @@
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos780Aristotle.lean"
     },

--- a/src/data/research/problems/erdos-8-oq-01.json
+++ b/src/data/research/problems/erdos-8-oq-01.json
@@ -276,7 +276,7 @@
       "theoremCount": 2,
       "axiomCount": 4,
       "defCount": 7,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos809Problem.lean"
     },
@@ -958,7 +958,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos863Aristotle.lean"
     },
@@ -1002,7 +1002,7 @@
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos866Aristotle.lean"
     },
@@ -1013,7 +1013,7 @@
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos866Problem.lean"
     },
@@ -1365,7 +1365,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos892Aristotle.lean"
     },
@@ -1420,7 +1420,7 @@
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 11,
+      "sorryCount": 7,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos895Problem.lean"
     },

--- a/src/data/research/problems/erdos-863.json
+++ b/src/data/research/problems/erdos-863.json
@@ -89,7 +89,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos863Aristotle.lean"
     },

--- a/src/data/research/problems/erdos-892.json
+++ b/src/data/research/problems/erdos-892.json
@@ -71,7 +71,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos892Aristotle.lean"
     },

--- a/src/data/research/problems/fair-games-theorem-oq-01.json
+++ b/src/data/research/problems/fair-games-theorem-oq-01.json
@@ -98,7 +98,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 8,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FairGamesTheoremOQ03.lean"
     },

--- a/src/data/research/problems/fair-games-theorem-oq-02.json
+++ b/src/data/research/problems/fair-games-theorem-oq-02.json
@@ -109,7 +109,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 8,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FairGamesTheoremOQ03.lean"
     },

--- a/src/data/research/problems/fair-games-theorem-oq-03.json
+++ b/src/data/research/problems/fair-games-theorem-oq-03.json
@@ -108,7 +108,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 8,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FairGamesTheoremOQ03.lean"
     },

--- a/src/data/research/problems/feuerbachs-theorem-oq-01.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-01.json
@@ -100,7 +100,7 @@
       "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FeuerbachsTheoremOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/feuerbachs-theorem-oq-02.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-02.json
@@ -69,7 +69,7 @@
       "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FeuerbachsTheoremOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/feuerbachs-theorem-oq-03.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-03.json
@@ -93,7 +93,7 @@
       "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FeuerbachsTheoremOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/feuerbachs-theorem-oq-05.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-05.json
@@ -125,7 +125,7 @@
       "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FeuerbachsTheoremOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/friendship-theorem-oq-01-oq-01.json
+++ b/src/data/research/problems/friendship-theorem-oq-01-oq-01.json
@@ -72,7 +72,7 @@
       "theoremCount": 74,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 4,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FriendshipTheoremOQ01.lean"
     },

--- a/src/data/research/problems/friendship-theorem-oq-01.json
+++ b/src/data/research/problems/friendship-theorem-oq-01.json
@@ -200,7 +200,7 @@
       "theoremCount": 74,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 4,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FriendshipTheoremOQ01.lean"
     },

--- a/src/data/research/problems/fundamental-theorem-calculus-oq-01-oq-02.json
+++ b/src/data/research/problems/fundamental-theorem-calculus-oq-01-oq-02.json
@@ -96,7 +96,7 @@
       "theoremCount": 5,
       "axiomCount": 2,
       "defCount": 1,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FundamentalTheoremCalculusLebesgue.lean"
     },

--- a/src/data/research/problems/fundamental-theorem-calculus-oq-01.json
+++ b/src/data/research/problems/fundamental-theorem-calculus-oq-01.json
@@ -49,7 +49,7 @@
       "theoremCount": 5,
       "axiomCount": 2,
       "defCount": 1,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FundamentalTheoremCalculusLebesgue.lean"
     },

--- a/src/data/research/problems/fundamental-theorem-calculus-oq-02.json
+++ b/src/data/research/problems/fundamental-theorem-calculus-oq-02.json
@@ -125,7 +125,7 @@
       "theoremCount": 5,
       "axiomCount": 2,
       "defCount": 1,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FundamentalTheoremCalculusLebesgue.lean"
     },

--- a/src/data/research/problems/fundamental-theorem-calculus-oq-04.json
+++ b/src/data/research/problems/fundamental-theorem-calculus-oq-04.json
@@ -71,7 +71,7 @@
       "theoremCount": 5,
       "axiomCount": 2,
       "defCount": 1,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FundamentalTheoremCalculusLebesgue.lean"
     },

--- a/src/data/research/problems/hilbert-11-oq-01.json
+++ b/src/data/research/problems/hilbert-11-oq-01.json
@@ -81,7 +81,7 @@
       "theoremCount": 6,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Hilbert11OQ01.lean"
     },

--- a/src/data/research/problems/hodge-conjecture.json
+++ b/src/data/research/problems/hodge-conjecture.json
@@ -191,7 +191,7 @@
       "theoremCount": 430,
       "axiomCount": 49,
       "defCount": 80,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/HodgeConjecture.lean"
     }

--- a/src/data/research/problems/inverse-galois-oq-01.json
+++ b/src/data/research/problems/inverse-galois-oq-01.json
@@ -103,7 +103,7 @@
       "theoremCount": 106,
       "axiomCount": 4,
       "defCount": 1,
-      "sorryCount": 11,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGalois.lean"
     },
@@ -147,7 +147,7 @@
       "theoremCount": 0,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisA5ResultantDet.lean"
     },
@@ -180,7 +180,7 @@
       "theoremCount": 40,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisOQ01.lean"
     },
@@ -191,7 +191,7 @@
       "theoremCount": 18,
       "axiomCount": 3,
       "defCount": 0,
-      "sorryCount": 7,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisOQ02.lean"
     },

--- a/src/data/research/problems/inverse-galois-oq-02.json
+++ b/src/data/research/problems/inverse-galois-oq-02.json
@@ -64,7 +64,7 @@
       "theoremCount": 106,
       "axiomCount": 4,
       "defCount": 1,
-      "sorryCount": 11,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGalois.lean"
     },
@@ -108,7 +108,7 @@
       "theoremCount": 0,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisA5ResultantDet.lean"
     },
@@ -141,7 +141,7 @@
       "theoremCount": 40,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisOQ01.lean"
     },
@@ -152,7 +152,7 @@
       "theoremCount": 18,
       "axiomCount": 3,
       "defCount": 0,
-      "sorryCount": 7,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisOQ02.lean"
     },

--- a/src/data/research/problems/inverse-galois-oq-04.json
+++ b/src/data/research/problems/inverse-galois-oq-04.json
@@ -63,7 +63,7 @@
       "theoremCount": 106,
       "axiomCount": 4,
       "defCount": 1,
-      "sorryCount": 11,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGalois.lean"
     },
@@ -107,7 +107,7 @@
       "theoremCount": 0,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisA5ResultantDet.lean"
     },
@@ -140,7 +140,7 @@
       "theoremCount": 40,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisOQ01.lean"
     },
@@ -151,7 +151,7 @@
       "theoremCount": 18,
       "axiomCount": 3,
       "defCount": 0,
-      "sorryCount": 7,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisOQ02.lean"
     },

--- a/src/data/research/problems/inverse-galois-oq-06-oq-01.json
+++ b/src/data/research/problems/inverse-galois-oq-06-oq-01.json
@@ -80,7 +80,7 @@
       "theoremCount": 106,
       "axiomCount": 4,
       "defCount": 1,
-      "sorryCount": 11,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGalois.lean"
     },
@@ -124,7 +124,7 @@
       "theoremCount": 0,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisA5ResultantDet.lean"
     },
@@ -157,7 +157,7 @@
       "theoremCount": 40,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisOQ01.lean"
     },
@@ -168,7 +168,7 @@
       "theoremCount": 18,
       "axiomCount": 3,
       "defCount": 0,
-      "sorryCount": 7,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisOQ02.lean"
     },

--- a/src/data/research/problems/inverse-galois-oq-06.json
+++ b/src/data/research/problems/inverse-galois-oq-06.json
@@ -80,7 +80,7 @@
       "theoremCount": 106,
       "axiomCount": 4,
       "defCount": 1,
-      "sorryCount": 11,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGalois.lean"
     },
@@ -124,7 +124,7 @@
       "theoremCount": 0,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisA5ResultantDet.lean"
     },
@@ -157,7 +157,7 @@
       "theoremCount": 40,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisOQ01.lean"
     },
@@ -168,7 +168,7 @@
       "theoremCount": 18,
       "axiomCount": 3,
       "defCount": 0,
-      "sorryCount": 7,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InverseGaloisOQ02.lean"
     },

--- a/src/data/research/problems/konigsberg-oq-01.json
+++ b/src/data/research/problems/konigsberg-oq-01.json
@@ -88,7 +88,7 @@
       "theoremCount": 30,
       "axiomCount": 2,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ02.lean"
     },

--- a/src/data/research/problems/konigsberg-oq-02.json
+++ b/src/data/research/problems/konigsberg-oq-02.json
@@ -87,7 +87,7 @@
       "theoremCount": 30,
       "axiomCount": 2,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ02.lean"
     },

--- a/src/data/research/problems/konigsberg-oq-03-oq-01.json
+++ b/src/data/research/problems/konigsberg-oq-03-oq-01.json
@@ -86,7 +86,7 @@
       "theoremCount": 30,
       "axiomCount": 2,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ02.lean"
     },

--- a/src/data/research/problems/konigsberg-oq-03-oq-02.json
+++ b/src/data/research/problems/konigsberg-oq-03-oq-02.json
@@ -85,7 +85,7 @@
       "theoremCount": 30,
       "axiomCount": 2,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ02.lean"
     },

--- a/src/data/research/problems/konigsberg-oq-03.json
+++ b/src/data/research/problems/konigsberg-oq-03.json
@@ -46,7 +46,7 @@
       "theoremCount": 30,
       "axiomCount": 2,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ02.lean"
     },

--- a/src/data/research/problems/konigsberg-oq-04.json
+++ b/src/data/research/problems/konigsberg-oq-04.json
@@ -99,7 +99,7 @@
       "theoremCount": 30,
       "axiomCount": 2,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KonigsbergOQ02.lean"
     },

--- a/src/data/research/problems/laws-of-large-numbers-oq-01.json
+++ b/src/data/research/problems/laws-of-large-numbers-oq-01.json
@@ -86,7 +86,7 @@
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/laws-of-large-numbers-oq-02.json
+++ b/src/data/research/problems/laws-of-large-numbers-oq-02.json
@@ -99,7 +99,7 @@
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/laws-of-large-numbers-oq-03.json
+++ b/src/data/research/problems/laws-of-large-numbers-oq-03.json
@@ -84,7 +84,7 @@
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/laws-of-large-numbers-oq-04.json
+++ b/src/data/research/problems/laws-of-large-numbers-oq-04.json
@@ -78,7 +78,7 @@
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/navier-stokes-existence.json
+++ b/src/data/research/problems/navier-stokes-existence.json
@@ -212,7 +212,7 @@
       "theoremCount": 846,
       "axiomCount": 0,
       "defCount": 104,
-      "sorryCount": 23,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/NavierStokes.lean"
     }

--- a/src/data/research/problems/navier-stokes-oq-01-oq-01.json
+++ b/src/data/research/problems/navier-stokes-oq-01-oq-01.json
@@ -69,7 +69,7 @@
       "theoremCount": 846,
       "axiomCount": 0,
       "defCount": 104,
-      "sorryCount": 23,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/NavierStokes.lean"
     }

--- a/src/data/research/problems/newton-inductive-step-oq-01.json
+++ b/src/data/research/problems/newton-inductive-step-oq-01.json
@@ -76,7 +76,7 @@
       "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 3,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/NewtonInductiveStepOQ01.lean"
     },
@@ -87,7 +87,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/NewtonInductiveStepOQ01Aristotle.lean"
     }

--- a/src/data/research/problems/newton-inductive-step-oq-02.json
+++ b/src/data/research/problems/newton-inductive-step-oq-02.json
@@ -79,7 +79,7 @@
       "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 3,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/NewtonInductiveStepOQ01.lean"
     },
@@ -90,7 +90,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/NewtonInductiveStepOQ01Aristotle.lean"
     }

--- a/src/data/research/problems/partition-theorem-oq-01.json
+++ b/src/data/research/problems/partition-theorem-oq-01.json
@@ -99,7 +99,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 3,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PartitionTheoremOQ04.lean"
     },

--- a/src/data/research/problems/partition-theorem-oq-03.json
+++ b/src/data/research/problems/partition-theorem-oq-03.json
@@ -90,7 +90,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 3,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PartitionTheoremOQ04.lean"
     },

--- a/src/data/research/problems/partition-theorem-oq-04.json
+++ b/src/data/research/problems/partition-theorem-oq-04.json
@@ -136,7 +136,7 @@
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 3,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PartitionTheoremOQ04.lean"
     },

--- a/src/data/research/problems/pythagorean-triples-oq-01.json
+++ b/src/data/research/problems/pythagorean-triples-oq-01.json
@@ -90,7 +90,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PythagoreanTriplesOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/pythagorean-triples-oq-02-oq-01.json
+++ b/src/data/research/problems/pythagorean-triples-oq-02-oq-01.json
@@ -85,7 +85,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PythagoreanTriplesOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/pythagorean-triples-oq-02.json
+++ b/src/data/research/problems/pythagorean-triples-oq-02.json
@@ -89,7 +89,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PythagoreanTriplesOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/riemann-hypothesis.json
+++ b/src/data/research/problems/riemann-hypothesis.json
@@ -206,7 +206,7 @@
       "theoremCount": 358,
       "axiomCount": 32,
       "defCount": 38,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/RiemannHypothesis.lean"
     },

--- a/src/data/research/problems/schauder-fixed-point-oq-01.json
+++ b/src/data/research/problems/schauder-fixed-point-oq-01.json
@@ -65,7 +65,7 @@
       "theoremCount": 9,
       "axiomCount": 5,
       "defCount": 2,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SchauderFixedPoint.lean"
     },
@@ -76,7 +76,7 @@
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SchauderFixedPointOQ01.lean"
     },

--- a/src/data/research/problems/schauder-fixed-point-oq-02.json
+++ b/src/data/research/problems/schauder-fixed-point-oq-02.json
@@ -64,7 +64,7 @@
       "theoremCount": 9,
       "axiomCount": 5,
       "defCount": 2,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SchauderFixedPoint.lean"
     },
@@ -75,7 +75,7 @@
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SchauderFixedPointOQ01.lean"
     },

--- a/src/data/research/problems/schauder-fixed-point-oq-03.json
+++ b/src/data/research/problems/schauder-fixed-point-oq-03.json
@@ -61,7 +61,7 @@
       "theoremCount": 9,
       "axiomCount": 5,
       "defCount": 2,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SchauderFixedPoint.lean"
     },
@@ -72,7 +72,7 @@
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SchauderFixedPointOQ01.lean"
     },

--- a/src/data/research/problems/shannon-channel-coding-oq-03.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-03.json
@@ -93,7 +93,7 @@
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 5,
+      "sorryCount": 7,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ03.lean"
     },

--- a/src/data/research/problems/shannon-entropy-oq-01.json
+++ b/src/data/research/problems/shannon-entropy-oq-01.json
@@ -113,7 +113,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonEntropyAristotle.lean"
     },
@@ -124,7 +124,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonEntropyOQ01.lean"
     },
@@ -135,7 +135,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 3,
+      "sorryCount": 2,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonEntropyOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/shannon-entropy-oq-02.json
+++ b/src/data/research/problems/shannon-entropy-oq-02.json
@@ -90,7 +90,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonEntropyAristotle.lean"
     },
@@ -101,7 +101,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonEntropyOQ01.lean"
     },
@@ -112,7 +112,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 3,
+      "sorryCount": 2,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonEntropyOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/shannon-entropy-oq-03.json
+++ b/src/data/research/problems/shannon-entropy-oq-03.json
@@ -95,7 +95,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonEntropyAristotle.lean"
     },
@@ -106,7 +106,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonEntropyOQ01.lean"
     },
@@ -117,7 +117,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 3,
+      "sorryCount": 2,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonEntropyOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/shannon-entropy.json
+++ b/src/data/research/problems/shannon-entropy.json
@@ -145,7 +145,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonEntropyAristotle.lean"
     },
@@ -156,7 +156,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonEntropyOQ01.lean"
     },
@@ -167,7 +167,7 @@
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 3,
+      "sorryCount": 2,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonEntropyOQ01Aristotle.lean"
     },

--- a/src/data/research/problems/sum-of-divisors.json
+++ b/src/data/research/problems/sum-of-divisors.json
@@ -66,7 +66,7 @@
       "theoremCount": 81,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SumOfDivisors.lean"
     }

--- a/src/data/research/problems/wilsons-theorem-oq-01.json
+++ b/src/data/research/problems/wilsons-theorem-oq-01.json
@@ -80,7 +80,7 @@
       "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 9,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/WilsonsTheoremOQ01.lean"
     },
@@ -91,7 +91,7 @@
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 8,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/WilsonsTheoremOQ02.lean"
     },

--- a/src/data/research/problems/wilsons-theorem-oq-02-oq-02.json
+++ b/src/data/research/problems/wilsons-theorem-oq-02-oq-02.json
@@ -74,7 +74,7 @@
       "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 9,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/WilsonsTheoremOQ01.lean"
     },
@@ -85,7 +85,7 @@
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 8,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/WilsonsTheoremOQ02.lean"
     },

--- a/src/data/research/problems/wilsons-theorem-oq-02.json
+++ b/src/data/research/problems/wilsons-theorem-oq-02.json
@@ -76,7 +76,7 @@
       "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 9,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/WilsonsTheoremOQ01.lean"
     },
@@ -87,7 +87,7 @@
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 8,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/WilsonsTheoremOQ02.lean"
     },

--- a/src/data/research/problems/wilsons-theorem-oq-04-oq-02.json
+++ b/src/data/research/problems/wilsons-theorem-oq-04-oq-02.json
@@ -90,7 +90,7 @@
       "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 9,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/WilsonsTheoremOQ01.lean"
     },
@@ -101,7 +101,7 @@
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 8,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/WilsonsTheoremOQ02.lean"
     },

--- a/src/data/research/problems/wilsons-theorem-oq-04.json
+++ b/src/data/research/problems/wilsons-theorem-oq-04.json
@@ -78,7 +78,7 @@
       "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 9,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/WilsonsTheoremOQ01.lean"
     },
@@ -89,7 +89,7 @@
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 8,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/WilsonsTheoremOQ02.lean"
     },


### PR DESCRIPTION
## Fix

Corrects stale `sorryCount` fields in research problem JSON files. 106 unique Lean proof files had their sorries resolved (by Aristotle or manual work) but the sorryCount metadata was never updated.

## Evidence

**Before**: 106 Lean files with over-reported sorry counts across 352 research problem JSON files

**After**: All sorryCount values match actual `sorry` tactic occurrences in the Lean source files (excluding comment-only mentions)

**Most common correction**: `sorryCount: 1 → 0` (450 occurrences) — proofs fully completed by Aristotle after metadata was set

**Verification method**: Scan each `.lean` file with comment-stripping regex to count actual `sorry` tactics

Closes no specific issue — systematic metadata sync detected by mechanic audit scan.

---
Automated fix by lean-mechanic agent.