### PR TITLE
feat(leibniz-pi-oq-03): prove Euler transform identity via integral_tsum

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1914,6 +1914,7 @@ import Proofs.LebesgueMeasureOQ03
 import Proofs.LegendrePartial
 import Proofs.LeibnizPi
 import Proofs.LeibnizPiOQ01OQ01
+import Proofs.LeibnizPiOQ03
 import Proofs.LiouvilleTheorem
 import Proofs.LovaszLocalLemma
 import Proofs.MachinFromAddition

--- a/proofs/Proofs/LeibnizPiOQ03.lean
+++ b/proofs/Proofs/LeibnizPiOQ03.lean
@@ -16,7 +16,7 @@ Key identity: for t ∈ [0,1], Σ_{n≥0} (1/2)^{n+1}(1-t²)^n = 1/(1+t²).
 Integrating: Σ_{n≥0} (1/2)^{n+1} ∫₀¹(1-t²)^n dt = ∫₀¹ 1/(1+t²) dt = π/4.
 The Euler series converges geometrically (each term ≤ (1/2)^{n+1}).
 
-**Status**: Part I complete (0 sorries). Part II: 1 sorry (sum-integral exchange).
+**Status**: Part I complete (0 sorries). Part II complete (0 sorries).
 -/
 
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Arctan
@@ -217,12 +217,58 @@ theorem arctan_integral : ∫ t in (0 : ℝ)..1, 1 / (1 + t ^ 2) = π / 4 := by
   rw [integral_eq_sub_of_hasDerivAt hderiv hint]
   simp [arctan_one, arctan_zero]
 
-/-- **The Euler Transform Identity** (1 sorry): π/4 = Σ (1/2)^{n+1} ∫₀¹(1-t²)^n dt.
+/-- **The Euler Transform Identity**: π/4 = Σ (1/2)^{n+1} ∫₀¹(1-t²)^n dt.
 
     The exchange of Σ and ∫ is justified by dominated convergence:
     (1/2)^{n+1}(1-t²)^n ≤ (1/2)^{n+1} uniformly, with summable dominating function. -/
 theorem euler_transform_eq :
     ∑' n, ((1 / 2 : ℝ) ^ (n + 1) * ∫ t in (0 : ℝ)..1, (1 - t ^ 2) ^ n) = π / 4 := by
-  sorry -- Requires: MeasureTheory.integral_tsum + dominated convergence
+  -- Convert each term: c * ∫_[0,1] g = ∫_Ioc g via interval→Bochner + const factoring
+  have hstep : ∀ n : ℕ, (1/2:ℝ)^(n+1) * ∫ t in (0:ℝ)..1, (1-t^2)^n =
+      ∫ t in Set.Ioc (0:ℝ) 1, (1/2:ℝ)^(n+1) * (1-t^2)^n := by
+    intro n
+    rw [intervalIntegral.integral_of_le (by norm_num : (0:ℝ) ≤ 1)]
+    exact (MeasureTheory.integral_const_mul ((1/2:ℝ)^(n+1)) (fun t => (1-t^2)^n)).symm
+  simp_rw [hstep]
+  -- Set up the swap ∑' ↔ ∫ via integral_tsum
+  set f : ℕ → ℝ → ℝ := fun n t => (1/2:ℝ)^(n+1) * (1-t^2)^n
+  have hf_meas : ∀ n, AEStronglyMeasurable (f n) (volume.restrict (Set.Ioc (0:ℝ) 1)) :=
+    fun n => ((continuous_const.mul
+      ((continuous_const.sub (continuous_id.pow 2)).pow n)).aestronglyMeasurable).restrict
+  have hf_bound : ∑' n, ∫⁻ t in Set.Ioc (0:ℝ) 1, ‖f n t‖ₑ ≠ ⊤ := by
+    apply ne_of_lt
+    have hbound : ∀ n : ℕ, ∫⁻ t in Set.Ioc (0:ℝ) 1,
+        ‖f n t‖ₑ ≤ ENNReal.ofReal ((1/2:ℝ)^(n+1)) := by
+      intro n
+      calc ∫⁻ t in Set.Ioc (0:ℝ) 1, ‖f n t‖ₑ
+          ≤ ∫⁻ _ in Set.Ioc (0:ℝ) 1, ENNReal.ofReal ((1/2:ℝ)^(n+1)) := by
+            apply MeasureTheory.lintegral_mono_ae
+            filter_upwards [MeasureTheory.ae_restrict_mem measurableSet_Ioc] with t ht
+            show ‖(1/2:ℝ)^(n+1) * (1-t^2)^n‖ₑ ≤ ENNReal.ofReal ((1/2:ℝ)^(n+1))
+            rw [enorm_of_nonneg (mul_nonneg (pow_nonneg (by norm_num) _)
+                  (pow_nonneg (by nlinarith [ht.1.le, ht.2]) _))]
+            exact ENNReal.ofReal_le_ofReal
+              (mul_le_of_le_one_right (pow_nonneg (by norm_num) _)
+                (one_sub_sq_pow_le t ht.1.le ht.2 n))
+        _ = ENNReal.ofReal ((1/2:ℝ)^(n+1)) := by
+            rw [MeasureTheory.lintegral_const,
+                MeasureTheory.Measure.restrict_apply_univ, volume_Ioc]
+            simp
+    calc ∑' n, ∫⁻ t in Set.Ioc (0:ℝ) 1, ‖f n t‖ₑ
+        ≤ ∑' n, ENNReal.ofReal ((1/2:ℝ)^(n+1)) := ENNReal.tsum_le_tsum hbound
+      _ < ⊤ :=
+          lt_top_iff_ne_top.mpr (Summable.tsum_ofReal_ne_top
+            (((summable_geometric_of_lt_one (by norm_num : (0:ℝ) ≤ 1/2)
+                (by norm_num : (1/2:ℝ) < 1)).mul_left (1/2:ℝ)).congr
+              (fun n => by rw [pow_succ]; ring)))
+  -- Swap: ∑' n, ∫ f n = ∫ ∑' n, f n
+  rw [show ∑' n, ∫ t in Set.Ioc (0:ℝ) 1, f n t =
+      ∫ t in Set.Ioc (0:ℝ) 1, ∑' n, f n t from
+    (MeasureTheory.integral_tsum hf_meas hf_bound).symm]
+  -- Replace ∑' with 1/(1+t²) a.e. on Ioc 0 1, then use arctan_integral
+  rw [MeasureTheory.integral_congr_ae (by
+    filter_upwards [MeasureTheory.ae_restrict_mem measurableSet_Ioc] with t ht
+    exact (geometric_series_eq t ht.1.le ht.2).tsum_eq)]
+  rw [← arctan_integral, intervalIntegral.integral_of_le (by norm_num : (0:ℝ) ≤ 1)]
 
 end LeibnizPiOQ03

--- a/research/problems/erdos-606-oq-03-oq-03/knowledge.md
+++ b/research/problems/erdos-606-oq-03-oq-03/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: erdos-606-oq-03-oq-03
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/erdos-606-oq-03-oq-03/literature/README.md
+++ b/research/problems/erdos-606-oq-03-oq-03/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for erdos-606-oq-03-oq-03
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/erdos-606-oq-03-oq-03/problem.md
+++ b/research/problems/erdos-606-oq-03-oq-03/problem.md
@@ -1,0 +1,113 @@
+# Problem: Formalize Sylvester-Gallai Theorem in Lean
+
+**Slug**: erdos-606-oq-03-oq-03
+**Created**: 2026-04-05T06:26:11-07:00
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+**Sylvester-Gallai Theorem**: Given $n \geq 3$ non-collinear points in $\mathbb{R}^2$, there exists a line passing through exactly 2 of the points (an "ordinary line").
+
+In Lean 4:
+```lean
+theorem sylvester_gallai (S : Finset (ℝ × ℝ)) (hn : 3 ≤ S.card)
+    (hncol : ¬ Collinear ℝ (S : Set (ℝ × ℝ))) :
+    ∃ p q ∈ S, p ≠ q ∧ ∀ r ∈ S, r ≠ p → r ≠ q →
+      ¬ Collinear ℝ ({p, q, r} : Set (ℝ × ℝ)) := sorry
+```
+
+### Plain Language
+
+Given any finite set of points in the plane (at least 3, not all on one line), you can always find a line that passes through exactly 2 of the points.
+
+### Why This Matters
+
+- Sylvester-Gallai is a foundational result in combinatorial geometry
+- The parent proof (`erdos-606-oq-03`, Hyperplane Determination in Higher Dimensions) currently lacks this formalization
+- Kelly's 1948 proof is elementary and a natural candidate for Lean formalization
+- No complete Lean formalization of this theorem appears in Mathlib
+
+## Known Results
+
+### What's Already Proven
+
+- Mathlib has `Collinear` predicate for `ℝ`-vector spaces
+- Mathlib has `EuclideanGeometry` and metric space infrastructure
+- Kelly's proof reduces to: among all (point, line) pairs where point is off the line, find the pair minimizing distance; then show the foot of perpendicular is an ordinary line
+
+### Kelly's Proof Sketch
+
+1. Among all pairs (p, L) where p ∈ S, L is a line through ≥ 2 points of S, p ∉ L — pick the pair minimizing dist(p, L)
+2. The line L, going through points a, b (∈ S), has at most 1 point of S between the foot F of the perpendicular from p to L and either a or b
+3. If ≥ 2 points of S are on the same side of F on L, swapping gives a closer (point, line) pair — contradiction
+4. Therefore L contains exactly 2 points of S
+
+### Our Goal
+
+Formalize the Sylvester-Gallai theorem in Lean 4, preferably using Kelly's elementary metric proof.
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| erdos-606-oq-03 | Parent: Hyperplane Determination |
+| erdos-606 | Grandparent: Sylvester-Gallai directions |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Kelly's metric proof** (most tractable):
+   - Formalize dist(p, L) for points and lines in ℝ²
+   - Use `Finset.exists_min_image` for the minimum distance pair
+   - Case analysis using `Mathlib.Analysis.InnerProductSpace.PiL2`
+   - Risk: Distance from point to line API in Mathlib may be thin
+
+2. **Projective geometry approach**:
+   - Use projective duality: ordinary lines ↔ interior points of convex hull
+   - Mathlib has some projective geometry but likely insufficient
+   - Risk: More infrastructure required
+
+3. **Contradiction approach via collinearity**:
+   - Assume all lines pass through ≥ 3 points
+   - Derive contradiction using finite intersection counting
+   - Risk: Hard to formalize the counting argument cleanly
+
+### Key Mathlib Lemmas to Find
+
+- `EuclideanGeometry.dist_sq_smul_dist_left` or distance to line
+- `Finset.exists_min_image` — for finding minimum distance pair
+- `Collinear` API — `collinear_iff_exists_forall_eq_smul_vadd`
+- Inner product space projection lemmas
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- Kelly's proof is elementary in mathematics, but requires real analysis in Lean
+- Mathlib has the building blocks (Euclidean geometry, metric spaces, Finset)
+- Main challenge: distance from point to line in ℝ²
+- Alternative: find a purely combinatorial formulation that avoids metric arguments
+
+**Estimated Effort**: 1-2 weeks
+
+## Metadata
+
+```yaml
+tags:
+  - geometry
+  - incidence-geometry
+  - combinatorics
+  - lean-mathlib
+  - collinearity
+related_proofs:
+  - erdos-606-oq-03
+  - erdos-606
+difficulty: medium
+source: gallery-gap
+created: 2026-04-05T06:26:11-07:00
+```

--- a/research/problems/erdos-606-oq-03-oq-03/state.md
+++ b/research/problems/erdos-606-oq-03-oq-03/state.md
@@ -1,0 +1,25 @@
+# Research State: erdos-606-oq-03-oq-03
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-05T06:30:18-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/leibniz-pi-oq-03/state.md
+++ b/research/problems/leibniz-pi-oq-03/state.md
@@ -1,27 +1,26 @@
-# Current State
+# Research State: leibniz-pi-oq-03
 
-**Phase**: NEW
-**Since**: 2026-03-30T22:19:31.123Z
+## Current State
+**Phase**: COMPLETE
+**Path**: full
+**Since**: 2026-04-05T00:00:00Z
 **Iteration**: 1
 
 ## Current Focus
-
-Initial exploration of the problem.
+Formalization complete. Proved: midpoint acceleration + Euler transform identity.
 
 ## Active Approach
+- Part I: Midpoint M(k) = (S(2k)+S(2k+1))/2 satisfies |M(k)-π/4| ≤ 1/(2(4k+1))
+- Part II: Euler identity Σ (1/2)^{n+1} ∫_[0,1] (1-t²)^n = π/4 via integral_tsum
+- Key: enorm_of_nonneg + Summable.tsum_ofReal_ne_top for finiteness
 
-None yet.
+## Attempt Count
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Blockers
-
-None.
+None. Build successful, 0 sorries, 0 axioms.
 
 ## Next Action
-
-Begin problem exploration.
-
-## Attempt Counts
-
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+Done. Committed.

--- a/src/data/proofs/leibniz-pi-oq-03/meta.json
+++ b/src/data/proofs/leibniz-pi-oq-03/meta.json
@@ -1,0 +1,133 @@
+{
+  "id": "leibniz-pi-oq-03",
+  "title": "Leibniz Series Acceleration: Midpoint and Euler Transforms",
+  "slug": "leibniz-pi-oq-03",
+  "description": "Formalizes two acceleration methods for the Leibniz series π/4 = 1 - 1/3 + 1/5 - ... Part I: The midpoint M(k) = (S(2k) + S(2k+1))/2 satisfies |M(k) - π/4| ≤ 1/(2(4k+1)), halving the error constant. Part II: The Euler transform identity Σ (1/2)^{n+1} ∫₀¹(1-t²)^n dt = π/4 is proved by swapping sum and integral via MeasureTheory.integral_tsum.",
+  "meta": {
+    "author": "Euler (1755), Richardson (1911)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Euler%27s_transform_(series)",
+    "date": "1755",
+    "status": "verified",
+    "proofRepoPath": "Proofs/LeibnizPiOQ03.lean",
+    "tags": [
+      "analysis",
+      "pi",
+      "series-acceleration",
+      "euler-transform",
+      "dominated-convergence",
+      "interval-integral",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 274,
+    "theoremCount": 15,
+    "defCount": 2,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The Leibniz series π/4 = 1 - 1/3 + 1/5 - ... converges at rate O(1/N), making direct computation impractical. Euler (1755) developed his series transformation, and Richardson (1911) introduced extrapolation methods, both designed to extract accurate values from slowly-convergent series. The Euler transform for the Leibniz series yields a geometrically convergent series where each term ≤ (1/2)^{n+1}.",
+    "problemStatement": "Formalize two series acceleration methods for π/4: (1) the midpoint bracket acceleration, and (2) the Euler transform identity Σ_{n≥0} (1/2)^{n+1} ∫₀¹(1-t²)^n dt = π/4.",
+    "text": "Two acceleration methods for the Leibniz series are formalized. Part I proves the midpoint M(k) = (S(2k) + S(2k+1))/2 satisfies |M(k) - π/4| ≤ 1/(2·(4k+1)), halving the error constant compared to the raw alternating series bound. Part II proves the Euler transform identity: the sum Σ (1/2)^{n+1} ∫₀¹(1-t²)^n dt = π/4 by swapping Σ and ∫ via dominated convergence (integral_tsum), using the geometric series Σ (1/2)^{n+1}(1-t²)^n = 1/(1+t²) and the arctan integral ∫₀¹ 1/(1+t²) dt = π/4.",
+    "proofStrategy": "Part I: The even partial sums S(2k) increase monotonically to π/4 from below, and the odd S(2k+1) decrease to π/4 from above. The midpoint lies between, with error bounded by half the bracket width S(2k+1) - S(2k) = 1/(4k+1).\n\nPart II: Convert ∫_[0,1] to Bochner integrals over Ioc 0 1, pull constants inside, then swap ∑' and ∫ using MeasureTheory.integral_tsum with dominating function (1/2)^{n+1}. The pointwise sum equals 1/(1+t²) by geometric_series_eq. The final integral = π/4 by arctan FTC.",
+    "keyInsights": [
+      "The midpoint M(k) = (S(2k) + S(2k+1))/2 halves the error: |M(k) - π/4| ≤ (S(2k+1)-S(2k))/2 = 1/(2(4k+1))",
+      "The geometric series identity: for t ∈ [0,1], Σ (1/2)^{n+1}(1-t²)^n = 1/(1+t²)",
+      "The sum-integral swap via MeasureTheory.integral_tsum requires: (1) AEStronglyMeasurable integrand, (2) Σ ∫ enorm ≠ ⊤. The dominating bound ‖f n t‖ₑ ≤ (1/2)^{n+1} on Ioc 0 1 gives Σ ≤ 1 < ⊤ via Summable.tsum_ofReal_ne_top",
+      "enorm_of_nonneg converts the pointwise bound to the ENNReal form required by lintegral_mono_ae",
+      "The final step: ∫_Ioc 1/(1+t²) = ∫_[0,1] 1/(1+t²) = π/4 via intervalIntegral.integral_of_le + arctan FTC"
+    ],
+    "prerequisites": [
+      "Alternating series theorem and monotone convergence",
+      "Geometric series (HasSum form)",
+      "Bochner integral and MeasureTheory.integral_tsum (dominated convergence for series)",
+      "Arctan FTC: ∫₀¹ 1/(1+t²) dt = arctan(1) - arctan(0) = π/4"
+    ]
+  },
+  "sections": [
+    {
+      "id": "foundations",
+      "title": "Leibniz Series Foundations",
+      "startLine": 33,
+      "endLine": 101,
+      "summary": "Defines S(n) = Σ_{k<n} (-1)^k/(2k+1), proves S_tendsto (to π/4), even_mono, odd_anti, even_le_pi_div_4, pi_div_4_le_odd.",
+      "mathContext": "S(2k) ≤ π/4 ≤ S(2k+1) for all k"
+    },
+    {
+      "id": "midpoint",
+      "title": "Part I: Midpoint Acceleration",
+      "startLine": 103,
+      "endLine": 146,
+      "summary": "Proves midpoint_tendsto, gap_eq (S(2k+1)-S(2k) = 1/(4k+1)), midpoint_error_bound (≤ 1/(2(4k+1))), midpoint_vs_raw (≤ (S(2k+1)-S(2k))/2).",
+      "mathContext": "|M(k) - π/4| ≤ 1/(2·(4k+1)) — halves the bracket width"
+    },
+    {
+      "id": "euler-geometry",
+      "title": "Geometric Series for Euler Transform",
+      "startLine": 149,
+      "endLine": 218,
+      "summary": "geometric_series_eq: HasSum (fun n => (1/2)^{n+1}*(1-t²)^n) (1/(1+t²)) for t ∈ [0,1]. euler_integral_nonneg, euler_term_le, euler_summable, arctan_integral.",
+      "mathContext": "Σ (1/2)^{n+1}(1-t²)^n = 1/(1+t²) via hasSum_geometric_of_lt_one"
+    },
+    {
+      "id": "euler-identity",
+      "title": "Part II: Euler Transform Identity",
+      "startLine": 220,
+      "endLine": 271,
+      "summary": "euler_transform_eq: Σ (1/2)^{n+1} ∫_[0,1] (1-t²)^n = π/4. Proved by integral_tsum (sum-integral swap) with dominated bound (1/2)^{n+1}, then arctan FTC.",
+      "mathContext": "Σ (1/2)^{n+1} ∫₀¹ (1-t²)^n = ∫₀¹ Σ (1/2)^{n+1}(1-t²)^n = ∫₀¹ 1/(1+t²) = π/4"
+    }
+  ],
+  "conclusion": {
+    "summary": "Two acceleration methods are formalized for the Leibniz series. Part I shows the midpoint bracket halves the error constant: |M(k) - π/4| ≤ 1/(2(4k+1)) vs. the raw 1/(4k+1). Part II proves the Euler transform identity via MeasureTheory.integral_tsum with the geometric series identity and arctan FTC. All 0 sorries, 0 axioms.",
+    "implications": "The Euler transform proof demonstrates that MeasureTheory.integral_tsum (dominated convergence for series/integrals) is directly usable in Lean 4 for geometric series with interval integrals. The key pattern — enorm bound via enorm_of_nonneg, then Summable.tsum_ofReal_ne_top for the finiteness condition — applies broadly to any series of bounded integrable functions.",
+    "openQuestions": [
+      "Can Richardson extrapolation (S_N + c * (S_N - S_{N/2})) be formally bounded in Lean 4?",
+      "Can the Euler transform be extended to acceleration of other alternating series (e.g., log 2 = 1 - 1/2 + 1/3 - ...)?",
+      "What is the optimal acceleration method for the Leibniz series in terms of convergence rate per term?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "leibniz-pi",
+      "relationship": "extends",
+      "description": "Parent proof: the Leibniz series π/4 = 1 - 1/3 + 1/5 - ..."
+    },
+    {
+      "targetId": "leibniz-pi-oq-01",
+      "relationship": "sibling",
+      "description": "Machin's formula: a different acceleration method using two arctan evaluations"
+    },
+    {
+      "targetId": "leibniz-pi-oq-02",
+      "relationship": "sibling",
+      "description": "Richardson extrapolation method for the Leibniz series"
+    }
+  ],
+  "references": [
+    {
+      "authors": ["Euler, L."],
+      "title": "Institutiones Calculi Differentialis",
+      "venue": "Academiae Scientiarum Petropolitanae",
+      "year": "1755",
+      "note": "Euler's original series transformation technique"
+    },
+    {
+      "authors": ["Richardson, L.F."],
+      "title": "The approximate arithmetical solution by finite differences of physical problems",
+      "venue": "Philosophical Transactions of the Royal Society A",
+      "year": "1911",
+      "note": "Richardson extrapolation for series acceleration"
+    },
+    {
+      "authors": ["Knopp, K."],
+      "title": "Theory and Application of Infinite Series",
+      "venue": "Blackie & Son",
+      "year": "1928",
+      "note": "Classical treatment of series transformation methods including Euler's transform"
+    }
+  ],
+  "leanFile": "Proofs/LeibnizPiOQ03.lean"
+}


### PR DESCRIPTION
## Summary

- Eliminates the 1 sorry in `euler_transform_eq` by swapping ∑' and ∫ using `MeasureTheory.integral_tsum`
- Proves midpoint acceleration: |M(k) - π/4| ≤ 1/(2·(4k+1))
- Proves Euler transform: ∑ (1/2)^{n+1} ∫₀¹(1-t²)^n dt = π/4
- 0 sorries, 0 axioms

## Key techniques

- `enorm_of_nonneg` + `lintegral_mono_ae` for the dominated convergence bound
- `Summable.tsum_ofReal_ne_top` for the finiteness condition
- `geometric_series_eq` pointwise applied via `ae_restrict_mem measurableSet_Ioc`
- `arctan_integral` for the final FTC step

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.LeibnizPiOQ03` passes with 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)