### PR TITLE
fix(meta): correct leanFile.axiomCount for erdos-1100 stub file

### DIFF
--- a/src/data/proofs/erdos-1100/meta.json
+++ b/src/data/proofs/erdos-1100/meta.json
@@ -240,7 +240,7 @@
     ],
     "namespace": "Erdos1100",
     "lineCount": 328,
-    "axiomCount": 0,
+    "axiomCount": 4,
     "theoremCount": 13,
     "definitionCount": 7,
     "mainTheorems": [


### PR DESCRIPTION
## Fix

Corrects `leanFile.axiomCount` from 0 to 4 for the `erdos-1100` proof.

## Evidence

**Before**: `leanFile.axiomCount: 0`
**After**: `leanFile.axiomCount: 4`

The stub file `Proofs/Stubs/Erdos1100Problem.lean` (tracked by `leanFile.path`) contains 4 `axiom` declarations:
- `tau_perp_lower_bound` (line 77)
- `tau_perp_equality_infinitely_often` (line 83)
- `erdos_hall_max_lower_bound` (line 127)
- `erdos_simonovits_bounds` (line 149)

Note: `meta.axiomCount: 0` and `meta.sorries: 3` correctly track the main proof file `Proofs/Erdos1100ProblemProvable.lean` (via `meta.proofRepoPath`), which has 0 axioms and 3 theorem sorries. Those fields are unaffected by this fix.

---
Automated fix by lean-mechanic agent.