### PR TITLE
chore(audit): mark 2 proofs as audited (both clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11925,8 +11925,8 @@
       "issues": []
     },
     "elementary-quadratic-reciprocity-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-05T13:39:57Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-05T13:47:24Z",
       "result": "clean",
       "issues": []
     },
@@ -11934,6 +11934,12 @@
       "auditCount": 1,
       "lastAudited": "2026-04-05T13:39:57Z",
       "result": "issues-fixed",
+      "issues": []
+    },
+    "leibniz-pi-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-05T13:49:13Z",
+      "result": "clean",
       "issues": []
     }
   },


### PR DESCRIPTION
## Audit Results

Audited 2 gallery proofs in this iteration. Both clean.

### elementary-quadratic-reciprocity-oq-01-oq-01 (re-audit, auditCount→2)

| Check | meta.json | Actual | Status |
|-------|-----------|--------|--------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 1 | 1 (`axiom gauss_sum_sq`) | ✓ |
| True stubs | — | 0 | ✓ |
| status | axiomatized | 1 axiom present | ✓ |
| badge | axiom | Correct | ✓ |

All three "pathways" correctly described as calling `legendreSym.quadratic_reciprocity` — no delegation opacity issue.

### leibniz-pi-oq-03 (first audit)

| Check | meta.json | Actual | Status |
|-------|-----------|--------|--------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| True stubs | — | 0 | ✓ |
| lineCount | 274 | 274 | ✓ |
| theoremCount | 15 | 15 (public) | ✓ |
| status | verified | 0 sorries, 0 axioms | ✓ |
| badge | original | Core results independently proved | ✓ |

Mathlib deps (`Real.tendsto_sum_pi_div_four`, `hasDerivAt_arctan`, `integral_tsum`) are foundational prerequisites and general tools — not shortcuts for the specific acceleration method results being claimed. `verified`/`original` badge is appropriate.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)