### PR TITLE
fix(proof): remove duplicate theorems from PtolemysTheorem.lean

### DIFF
--- a/proofs/Proofs/PtolemysTheorem.lean
+++ b/proofs/Proofs/PtolemysTheorem.lean
@@ -58,9 +58,6 @@ open EuclideanGeometry
 variable {V : Type*} [NormedAddCommGroup V] [InnerProductSpace ℝ V]
 variable {P : Type*} [MetricSpace P] [NormedAddTorsor V P]
 
--- For the Euclidean plane specifically
-abbrev Vec2 := EuclideanSpace ℝ (Fin 2)
-
 -- ============================================================
 -- PART 2: Ptolemy's Theorem from Mathlib
 -- ============================================================
@@ -89,15 +86,6 @@ theorem ptolemys_theorem {a b c d p : P}
 -- PART 3: Alternative Formulations
 -- ============================================================
 
-/-- Ptolemy's theorem can be stated with distances in different order.
-    This version emphasizes the diagonal products on the right side. -/
-theorem ptolemys_theorem_diagonals {a b c d p : P}
-    (h : Cospherical ({a, b, c, d} : Set P))
-    (hapc : ∠ a p c = π)
-    (hbpd : ∠ b p d = π) :
-    dist a b * dist c d + dist b c * dist d a = dist a c * dist b d :=
-  ptolemys_theorem h hapc hbpd
-
 /-- The symmetric form: the diagonal product equals the sum of opposite side products -/
 theorem ptolemys_theorem_symmetric {a b c d p : P}
     (h : Cospherical ({a, b, c, d} : Set P))
@@ -115,20 +103,7 @@ theorem ptolemys_theorem_rearranged {a b c d p : P}
   rw [mul_comm, ptolemys_theorem h hapc hbpd]
 
 -- ============================================================
--- PART 4: Corollaries and Special Cases
--- ============================================================
-
-/-- For a cyclic quadrilateral, the diagonal product can be computed
-    from the side lengths. -/
-theorem diagonal_product_from_sides {a b c d p : P}
-    (h : Cospherical ({a, b, c, d} : Set P))
-    (hapc : ∠ a p c = π)
-    (hbpd : ∠ b p d = π) :
-    dist a c * dist b d = dist a b * dist c d + dist b c * dist d a :=
-  ptolemys_theorem_symmetric h hapc hbpd
-
--- ============================================================
--- PART 5: Connection to Other Theorems
+-- PART 4: Connection to Other Theorems
 -- ============================================================
 
 /-!
@@ -261,7 +236,5 @@ the 100 most important theorems in mathematics (Wiedijk's list #95).
 -- ============================================================
 
 #check @ptolemys_theorem
-#check @ptolemys_theorem_diagonals
 #check @ptolemys_theorem_symmetric
 #check @ptolemys_theorem_rearranged
-#check @diagonal_product_from_sides

--- a/src/data/proofs/ptolemys-theorem/meta.json
+++ b/src/data/proofs/ptolemys-theorem/meta.json
@@ -85,16 +85,16 @@
       "title": "Alternative Formulations",
       "startLine": 88,
       "endLine": 116,
-      "summary": "Three formulations: `ptolemys_theorem_diagonals` (exact duplicate of main theorem), `ptolemys_theorem_symmetric` (sides swapped to LHS via `rw`), and `ptolemys_theorem_rearranged` (via `mul_comm`). Note: `ptolemys_theorem_diagonals` is character-for-character identical to `ptolemys_theorem` and should be removed.",
-      "mathContext": "Only two unique reformulations beyond the main theorem: symmetric ($AC \\cdot BD = AB \\cdot CD + BC \\cdot DA$, sides on LHS) and rearranged (commutativity variant). The 'diagonals' form is an exact duplicate."
+      "summary": "Two alternative formulations: `ptolemys_theorem_symmetric` (diagonal product on LHS via `rw`) and `ptolemys_theorem_rearranged` (commutativity variant via `mul_comm`).",
+      "mathContext": "Two unique reformulations beyond the main theorem: symmetric ($AC \\cdot BD = AB \\cdot CD + BC \\cdot DA$, sides on LHS) and rearranged (commutativity variant)."
     },
     {
       "id": "corollaries",
       "title": "Corollaries and Special Cases",
       "startLine": 117,
       "endLine": 129,
-      "summary": "Diagonal product corollary: `diagonal_product_from_sides` is a duplicate of `ptolemys_theorem_symmetric` (same statement and hypotheses). Despite the name, the Cospherical and angle conditions are not eliminated.",
-      "mathContext": "The statement $AC \\cdot BD = AB \\cdot CD + BC \\cdot DA$ is identical to the symmetric form. The file contains 5 theorem declarations but only 3 unique statements (2 are exact duplicates)."
+      "summary": "Discussion of connections to Law of Cosines, power of a point, complex number identity, and applications in trigonometry, astronomy, optics, and architecture.",
+      "mathContext": "Mathematical content: Discussion of connections to Law of Cosines, power of a point, complex number identity, and applications in trigonometry, astronomy, optics, and architecture."
     },
     {
       "id": "connections",
@@ -125,8 +125,8 @@
       "title": "Historical Context: The Almagest",
       "startLine": 233,
       "endLine": 267,
-      "summary": "Historical discussion of chord tables ($\\text{chord}(\\theta) = d\\sin(\\theta/2)$), the equivalence to the sine addition formula $\\sin(\\alpha+\\beta) = \\sin\\alpha\\cos\\beta + \\cos\\alpha\\sin\\beta$, Ptolemy's legacy in astronomy (al-Khwarizmi, al-Biruni), and `#check` verification of all five exported theorems.",
-      "mathContext": "Historical discussion of chord tables ($\\text{chord}(\\theta) = d\\sin(\\theta/2)$), the equivalence to the sine addition formula $\\sin(\\alpha+\\beta) = \\sin\\alpha\\cos\\beta + \\cos\\alpha\\sin\\beta$, Ptolemy's legacy in astronomy (al-Khwarizmi, al-Biruni), and `#check` verification of all five exported theorems."
+      "summary": "Historical discussion of chord tables ($\\text{chord}(\\theta) = d\\sin(\\theta/2)$), the equivalence to the sine addition formula $\\sin(\\alpha+\\beta) = \\sin\\alpha\\cos\\beta + \\cos\\alpha\\sin\\beta$, Ptolemy's legacy in astronomy (al-Khwarizmi, al-Biruni), and `#check` verification of all three exported theorems.",
+      "mathContext": "Historical discussion of chord tables ($\\text{chord}(\\theta) = d\\sin(\\theta/2)$), the equivalence to the sine addition formula $\\sin(\\alpha+\\beta) = \\sin\\alpha\\cos\\beta + \\cos\\alpha\\sin\\beta$, Ptolemy's legacy in astronomy (al-Khwarizmi, al-Biruni), and `#check` verification of all three exported theorems."
     }
   ],
   "crossReferences": [
@@ -171,11 +171,9 @@
       "EuclideanGeometry"
     ],
     "namespace": null,
-    "lineCount": 267,
+    "lineCount": 242,
     "axiomCount": 0,
-    "theoremCount": 5,
-    "substantiveTheoremCount": 3,
-    "duplicateTheorems": 2,
+    "theoremCount": 3,
     "definitionCount": 0,
     "path": "Proofs/PtolemysTheorem.lean",
     "sorries": 0

--- a/src/data/proofs/ptolemys-theorem/review.json
+++ b/src/data/proofs/ptolemys-theorem/review.json
@@ -101,7 +101,8 @@
       "priority": "high",
       "target": "researcher",
       "description": "Remove duplicate theorems from Lean file: ptolemys_theorem_diagonals (lines 94-99, identical to ptolemys_theorem) and diagonal_product_from_sides (lines 123-128, identical to ptolemys_theorem_symmetric). Remove the corresponding #check lines (263, 267). NOTE: Lean file modifications are outside enricher scope; reassigned to researcher. Metadata and annotations have been updated to flag the duplicates.",
-      "status": "deferred"
+      "status": "resolved",
+      "resolution": "Removed ptolemys_theorem_diagonals and diagonal_product_from_sides from PtolemysTheorem.lean; updated #check section; corrected theoremCount from 5 to 3 in meta.json."
     },
     {
       "id": "ai-2",
@@ -129,7 +130,8 @@
       "priority": "low",
       "target": "researcher",
       "description": "Remove unused Vec2 abbreviation (line 62) from Lean source, or add a concrete ℝ² example using specific points. NOTE: Lean file modification; reassigned to researcher.",
-      "status": "deferred"
+      "status": "resolved",
+      "resolution": "Removed unused Vec2 abbreviation from PtolemysTheorem.lean."
     },
     {
       "id": "ai-6",


### PR DESCRIPTION
## Fix

Removes two theorems from `PtolemysTheorem.lean` that were character-for-character duplicates of existing ones, as identified in the peer review.

## Evidence

**Removed `ptolemys_theorem_diagonals`** (lines 94-99): identical signature and conclusion to `ptolemys_theorem`; proof was `ptolemys_theorem h hapc hbpd`.

**Removed `diagonal_product_from_sides`** (lines 123-128): identical statement to `ptolemys_theorem_symmetric`; proof was `ptolemys_theorem_symmetric h hapc hbpd`.

**Removed `Vec2` abbreviation** (line 62): declared but never used anywhere in the file.

**Before**: 5 theorem declarations, 2 exact duplicates; `theoremCount: 5`
**After**: 3 theorem declarations, all unique; `theoremCount: 3`

Addresses peer review action items ai-1 (high priority) and ai-5 (low priority) from `src/data/proofs/ptolemys-theorem/review.json`.

---
Automated fix by lean-mechanic agent.