### PR TITLE
fix(proof): remove easton_flexibility filler from ContinuumHypothesis.lean

### DIFF
--- a/proofs/Proofs/ContinuumHypothesis.lean
+++ b/proofs/Proofs/ContinuumHypothesis.lean
@@ -325,11 +325,10 @@ theorem cantor_theorem : (ℵ₀ : Cardinal.{0}) < continuum := by
   unfold continuum
   exact Cardinal.cantor ℵ₀
 
-/-- Easton's Theorem (1970): For regular cardinals, the function
-    κ ↦ 2^κ can be almost anything consistent with König's theorem.
-
-    This shows CH and GCH are just the "minimal" possibilities. -/
-theorem easton_flexibility : (1 : ℕ) + 1 = 2 := rfl
+-- Easton's Theorem (1970): For regular cardinals, the function κ ↦ 2^κ can be almost
+-- anything consistent with König's theorem (2^κ > κ and cf(2^κ) > κ). This shows CH
+-- and GCH are just the "minimal" possibilities. Formalizing this requires a model of
+-- ZFC with a custom class forcing poset — a significant undertaking beyond this file.
 
 -- ============================================================
 -- PART 8: Consequences and Philosophy

--- a/src/data/proofs/continuum-hypothesis/meta.json
+++ b/src/data/proofs/continuum-hypothesis/meta.json
@@ -125,7 +125,7 @@
     "namespace": "ContinuumHypothesis",
     "lineCount": 396,
     "axiomCount": 4,
-    "theoremCount": 9,
+    "theoremCount": 8,
     "definitionCount": 8,
     "path": "Proofs/ContinuumHypothesis.lean",
     "sorries": 0

--- a/src/data/proofs/continuum-hypothesis/review.json
+++ b/src/data/proofs/continuum-hypothesis/review.json
@@ -108,7 +108,8 @@
       "priority": "high",
       "target": "researcher",
       "description": "Remove or replace easton_flexibility (currently proves 1+1=2 while claiming to be Easton's Theorem). Either delete the theorem entirely, or replace with a genuine axiomatization of Easton's result about cardinal exponentiation.",
-      "status": "open"
+      "status": "resolved",
+      "resolution": "Removed easton_flexibility theorem (proved (1:ℕ)+1=2 via rfl). Replaced with a plain comment documenting Easton's theorem and noting that full formalization requires class forcing — a significant future undertaking. Updated theoremCount from 9 to 8."
     },
     {
       "id": "ai-3",


### PR DESCRIPTION
## Fix

Removes `easton_flexibility` from `ContinuumHypothesis.lean`. The theorem claimed to be Easton's Theorem (1970) but its body was `(1:ℕ)+1=2 := rfl` — no mathematical content.

## Evidence

**Before**:
```lean
/-- Easton's Theorem (1970): For regular cardinals, the function
    κ ↦ 2^κ can be almost anything consistent with König's theorem.
    This shows CH and GCH are just the "minimal" possibilities. -/
theorem easton_flexibility : (1 : ℕ) + 1 = 2 := rfl
```

**After**: Replaced with a plain comment documenting Easton's theorem and noting that full formalization requires class forcing — a significant future undertaking.

Updates `theoremCount` from 9 to 8 in meta.json. Marks ai-2 (high priority) resolved in review.json.

---
Automated fix by lean-mechanic agent.