### PR TITLE
fix(proof): remove hilbert4_summary filler from Hilbert4Geodesics.lean

### DIFF
--- a/proofs/Proofs/Hilbert4Geodesics.lean
+++ b/proofs/Proofs/Hilbert4Geodesics.lean
@@ -445,7 +445,8 @@ PART IX: SUMMARY AND CONCLUSIONS
    The theory continues to be refined in terms of regularity
    conditions and extensions to manifolds.
 -/
-theorem hilbert4_summary : (1 : ℕ) + 1 = 2 := rfl
+-- Summary: See individual theorems above for the formalization of Hilbert's 4th Problem.
+-- Key results: minkowski_geodesics_are_straight, busemann_classification, hamel_theorem_2d.
 
 #check MinkowskiGeometry
 #check HilbertGeometry

--- a/src/data/proofs/hilbert-4/meta.json
+++ b/src/data/proofs/hilbert-4/meta.json
@@ -172,7 +172,7 @@
     "namespace": "Hilbert4Geodesics",
     "lineCount": 457,
     "axiomCount": 6,
-    "theoremCount": 3,
+    "theoremCount": 2,
     "definitionCount": 13,
     "path": "Proofs/Hilbert4Geodesics.lean",
     "sorries": 0

--- a/src/data/proofs/hilbert-4/review.json
+++ b/src/data/proofs/hilbert-4/review.json
@@ -150,7 +150,8 @@
       "priority": "medium",
       "target": "researcher",
       "description": "Remove filler theorem hilbert4_summary (line 448) and optionally replace with a substantive connecting theorem.",
-      "status": "open"
+      "status": "resolved",
+      "resolution": "Removed hilbert4_summary filler theorem (proved (1:ℕ)+1=2). Replaced with plain comment directing readers to the individual theorems."
     },
     {
       "id": "ai-5",


### PR DESCRIPTION
## Fix

Removes \`hilbert4_summary\` from \`Hilbert4Geodesics.lean\`. The theorem proved \`(1:ℕ)+1=2 := rfl\` with no mathematical content.

**Before**: \`theorem hilbert4_summary : (1 : ℕ) + 1 = 2 := rfl\`
**After**: Plain comment directing readers to the individual theorems above.

Updates \`theoremCount\` from 3 to 2. Marks ai-4 (medium priority) resolved in review.json.

---
Automated fix by lean-mechanic agent.