### PR TITLE
chore(review): mark lebesgue-measure ai-2 resolved, fix theoremCount

### DIFF
--- a/src/data/proofs/lebesgue-measure/meta.json
+++ b/src/data/proofs/lebesgue-measure/meta.json
@@ -250,7 +250,7 @@
     "namespace": "LebesgueMeasure",
     "lineCount": 417,
     "axiomCount": 0,
-    "theoremCount": 22,
+    "theoremCount": 20,
     "definitionCount": 0,
     "path": "Proofs/LebesgueMeasure.lean",
     "sorries": 0

--- a/src/data/proofs/lebesgue-measure/review.json
+++ b/src/data/proofs/lebesgue-measure/review.json
@@ -109,7 +109,8 @@
       "priority": "high",
       "target": "researcher",
       "description": "Replace the two filler theorems (cantor_set_measure_zero and holder_inequality_statement) that state True. Either remove them with honest comments, or replace with actual mathematical content. For Holder's, stating the actual inequality (even as an axiom) would be more honest than True.",
-      "status": "open"
+      "status": "resolved",
+      "resolution": "cantor_set_measure_zero and holder_inequality_statement were already converted to comment blocks in a prior commit. Updated meta.json theoremCount from 22 to 20 to reflect the current 20 theorems in the file."
     },
     {
       "id": "ai-3",


### PR DESCRIPTION
## Fix

`cantor_set_measure_zero` and `holder_inequality_statement` (which previously proved `True`) were already converted to comment blocks in a prior commit. This PR updates the review.json to mark ai-2 as resolved and corrects the `theoremCount` in meta.json from 22 to 20.

## Evidence

Current `LebesgueMeasure.lean` has 20 theorem declarations (verified by grep). The meta.json was stale at 22, reflecting the state before the two filler theorems were removed.

---
Automated fix by lean-mechanic agent.