### PR TITLE
fix(proof): remove power_mean_interpolation_summary filler

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ03.lean
+++ b/proofs/Proofs/AmgmInequalityOQ03.lean
@@ -369,4 +369,4 @@ Key proved relationships:
 - [✓] M_r ≤ M_s for 0 < r ≤ s  (`power_mean_monotone_pos` — proved here)
 - [✓] M_r ≤ M_s for r ≤ s < 0  (`power_mean_monotone_neg` — proved here via dual argument)
 - [axiom] Mixed-sign case (r < 0 < s, crossing the geometric mean limit) -/
-theorem power_mean_interpolation_summary : (1 : ℕ) + 1 = 2 := rfl
+-- Summary above; see individual theorems for formal proofs.

--- a/src/data/proofs/amgm-inequality-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03/meta.json
@@ -213,7 +213,7 @@
     "namespace": null,
     "lineCount": 372,
     "axiomCount": 0,
-    "theoremCount": 13,
+    "theoremCount": 12,
     "definitionCount": 3,
     "path": "Proofs/AmgmInequalityOQ03.lean",
     "sorries": 0

--- a/src/data/proofs/amgm-inequality-oq-03/review.json
+++ b/src/data/proofs/amgm-inequality-oq-03/review.json
@@ -3,14 +3,12 @@
   "proofId": "amgm-inequality-oq-03",
   "reviewDate": "2026-03-24T12:00:00Z",
   "reviewer": "peer-reviewer",
-
   "overallAssessment": {
     "grade": "B+",
     "oneLiner": "Genuinely substantive formalization of power mean monotonicity with clever original proofs (HM <= GM via inversion, duality for negative exponents), slightly undermined by a stale header comment and an underselling badge.",
     "tier": "B",
     "tierJustification": "Four multi-step original proofs (~130 lines) built on Mathlib's Jensen and AM-GM base cases. The original duality technique and HM <= GM proof via GM(z^{-1}) * GM(z) = 1 go well beyond wrapping Mathlib. Sits at the top of Tier B: Mathlib provides the foundations, this file provides genuine mathematical extensions."
   },
-
   "findings": [
     {
       "severity": "positive",
@@ -69,7 +67,6 @@
       "recommendation": "Rewrite to: 'The mixed-sign case M_r <= M_s for r < 0 < s (including HM <= GM as r=-1, s=0) requires the r=0 geometric mean limit and remains open in both this file and Mathlib4. Same-sign negative monotonicity is proved here via duality.'"
     }
   ],
-
   "actionItems": [
     {
       "id": "ai-1",
@@ -97,7 +94,8 @@
       "priority": "low",
       "target": "researcher",
       "description": "Replace power_mean_interpolation_summary (line 372, proves 1+1=2) with either a genuine summary theorem or a regular comment block. The current filler theorem slightly undermines the file's otherwise strong quality.",
-      "status": "open"
+      "status": "resolved",
+      "resolution": "Removed power_mean_interpolation_summary (proved (1:ℕ)+1=2 via rfl). Replaced with a plain comment. The summary information is preserved in the preceding docstring comment block."
     },
     {
       "id": "ai-5",
@@ -107,7 +105,6 @@
       "status": "deferred"
     }
   ],
-
   "qualityScores": {
     "mathematicalSubstance": 8,
     "originalityAccuracy": 9,
@@ -117,6 +114,5 @@
     "internalConsistency": 7,
     "overall": 8.0
   },
-
   "suggestedBestFraming": "Lean 4 formalization of weighted power mean monotonicity M_r <= M_s for same-sign exponents, featuring original proofs of HM <= GM (via AM-GM on inverse values) and both positive and negative monotonicity (via Jensen and a duality identity M_r(z) = M_{-r}(z^{-1})^{-1}), building on Mathlib's Jensen and AM-GM infrastructure."
 }


### PR DESCRIPTION
## Fix

Removes `power_mean_interpolation_summary` from `AmgmInequalityOQ03.lean`. The theorem appeared after a detailed docstring summarizing the AM-GM/power mean hierarchy but its body was `(1:ℕ)+1=2 := rfl`.

**Before**: `theorem power_mean_interpolation_summary : (1 : ℕ) + 1 = 2 := rfl`
**After**: `-- Summary above; see individual theorems for formal proofs.`

Updates `theoremCount` from 13 to 12. Marks ai-4 (low priority) resolved in review.json.

---
Automated fix by lean-mechanic agent.