### PR TITLE
fix(proof): remove 7 #check statements from BezoutIdentityOQ03.lean

### DIFF
--- a/proofs/Proofs/BezoutIdentityOQ03.lean
+++ b/proofs/Proofs/BezoutIdentityOQ03.lean
@@ -273,12 +273,4 @@ The key algebraic insight is that bezout_int and IsCoprime are two faces of the
 same coin: IsCoprime m n ↔ ∃ u v, u*m + v*n = 1 (Bézout with gcd = 1).
 -/
 
-#check crt_exists_via_bezout
-#check crt_unique_via_bezout
-#check crt_via_bezout
-#check crt_iscop
-#check crtInt
-#check crtInt_mod_left
-#check crtInt_mod_right
-
 end BezoutIdentityOQ03

--- a/src/data/proofs/bezout-identity-oq-03/review.json
+++ b/src/data/proofs/bezout-identity-oq-03/review.json
@@ -3,7 +3,6 @@
   "proofId": "bezout-identity-oq-03",
   "reviewDate": "2026-03-25T16:00:00Z",
   "reviewer": "peer-reviewer",
-
   "overallAssessment": {
     "grade": "B+",
     "oneLiner": "A well-structured, fully verified CRT formalization with genuine algebraic reasoning via linear_combination — the explicit formula x = a*n*v + b*m*u is elegantly proved from Bézout coefficients, with minor metadata inconsistencies.",
@@ -27,7 +26,6 @@
       "assessment": "All theorems fully proved with 0 axioms and 0 sorries. The CRT proof chain from Bézout to existence+uniqueness involves genuine algebraic reasoning via linear_combination. The IsCoprime parallel formulations are slightly redundant but provide a cleaner API for downstream use. bezout_int is a Mathlib wrapper serving as a named entry point for the chain."
     }
   },
-
   "findings": [
     {
       "severity": "positive",
@@ -79,7 +77,6 @@
       "recommendation": "Change annotation type from 'definition' to 'concept' or 'technique'."
     }
   ],
-
   "actionItems": [
     {
       "id": "ai-1",
@@ -100,10 +97,10 @@
       "priority": "low",
       "target": "researcher",
       "description": "Remove 7 #check statements at end of BezoutIdentityOQ03.lean (lines 276-282) — development artifacts with no formal purpose.",
-      "status": "open"
+      "status": "resolved",
+      "resolution": "Removed all 7 #check statements (development artifacts) from the end of BezoutIdentityOQ03.lean."
     }
   ],
-
   "qualityScores": {
     "mathematicalSubstance": 8,
     "originalityAccuracy": 8,
@@ -114,6 +111,5 @@
     "epistemicCoherence": 9,
     "overall": 8.1
   },
-
   "suggestedBestFraming": "A fully verified formalization of the Chinese Remainder Theorem over ℤ using Bézout coefficients: given coprime m, n with mu + nv = 1, the explicit solution x = a·n·v + b·m·u satisfies both congruences, proved via linear_combination. Includes existence, uniqueness, a computable CRT function with correctness proofs, and four worked examples."
 }


### PR DESCRIPTION
## Fix

Removes 7 `#check` statements (development artifacts) from the end of `BezoutIdentityOQ03.lean`. These are typical development-time verification artifacts that should not remain in gallery proofs.

Marks ai-3 (low priority) resolved in `src/data/proofs/bezout-identity-oq-03/review.json`.

---
Automated fix by lean-mechanic agent.