### PR TITLE
fix(proof): remove unused import from CircumferenceFromArea.lean

### DIFF
--- a/proofs/Proofs/CircumferenceFromArea.lean
+++ b/proofs/Proofs/CircumferenceFromArea.lean
@@ -1,7 +1,6 @@
 import Mathlib.Analysis.Calculus.Deriv.Basic
 import Mathlib.Analysis.Calculus.Deriv.Pow
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
-import Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls
 import Mathlib.Tactic
 
 /-

--- a/src/data/proofs/area-of-circle-oq-01/review.json
+++ b/src/data/proofs/area-of-circle-oq-01/review.json
@@ -3,7 +3,6 @@
   "proofId": "area-of-circle-oq-01",
   "reviewDate": "2026-03-24T18:30:00Z",
   "reviewer": "peer-reviewer",
-
   "overallAssessment": {
     "grade": "B",
     "oneLiner": "A well-crafted pedagogical entry that honestly applies Mathlib's power rule to connect area differentiation with circumference, with excellent historical context and thorough annotations, though padded with trivial corollaries.",
@@ -27,7 +26,6 @@
       "assessment": "All 18 theorems are fully proved with no axioms or sorries. However, only the main theorem and second derivative involve multi-step reasoning; the remaining 16 are one-liners or unfold+ring tautologies, making the theorem count a misleading measure of substance."
     }
   },
-
   "findings": [
     {
       "severity": "positive",
@@ -93,7 +91,6 @@
       "recommendation": "Remove this item or downgrade to: 'Convenience lemma: C² = 4πA algebraic identity for circles.'"
     }
   ],
-
   "actionItems": [
     {
       "id": "ai-1",
@@ -121,10 +118,10 @@
       "priority": "low",
       "target": "researcher",
       "description": "Remove unused import Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls from CircumferenceFromArea.lean, or implement the planned connection to the measure-theoretic area formulation.",
-      "status": "open"
+      "status": "resolved",
+      "resolution": "Removed unused import Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls from CircumferenceFromArea.lean."
     }
   ],
-
   "qualityScores": {
     "mathematicalSubstance": 5,
     "originalityAccuracy": 7,
@@ -135,6 +132,5 @@
     "epistemicCoherence": 8,
     "overall": 7.3
   },
-
   "suggestedBestFraming": "A pedagogical formalization that applies Mathlib's power rule to derive C = 2πr from A = πr², with corollaries for differentiability, monotonicity, scaling, and the algebraic identity C² = 4πA."
 }


### PR DESCRIPTION
## Fix

Removes unused import `Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls` from `CircumferenceFromArea.lean`. The import is never referenced in the file.

Marks ai-4 (low priority) resolved in `src/data/proofs/area-of-circle-oq-01/review.json`.

---
Automated fix by lean-mechanic agent.