### PR TITLE
fix(proof): remove duplicate four_always_suffices from LagrangeFourSquares.lean

### DIFF
--- a/proofs/Proofs/LagrangeFourSquares.lean
+++ b/proofs/Proofs/LagrangeFourSquares.lean
@@ -181,11 +181,6 @@ axiom legendre_three_squares :
 theorem six_is_three_squares : IsSumOfThreeSquares 6 := by
   exact ⟨1, 1, 2, by norm_num⟩
 
-/-- Four squares always works, even when three squares fail -/
-theorem four_always_suffices (n : ℕ) :
-    ∃ a b c d : ℕ, a ^ 2 + b ^ 2 + c ^ 2 + d ^ 2 = n :=
-  lagrange_four_squares n
-
 /-- Numbers of the form 8k+7 always need four squares -/
 theorem form_8k7_needs_four (k : ℕ) : IsObstructed (8 * k + 7) := by
   exact ⟨0, k, by ring⟩

--- a/src/data/proofs/lagrange-four-squares/meta.json
+++ b/src/data/proofs/lagrange-four-squares/meta.json
@@ -171,7 +171,7 @@
     "namespace": "LagrangeFourSquares",
     "lineCount": 422,
     "axiomCount": 8,
-    "theoremCount": 16,
+    "theoremCount": 15,
     "definitionCount": 8,
     "path": "Proofs/LagrangeFourSquares.lean",
     "sorries": 0

--- a/src/data/proofs/lagrange-four-squares/review.json
+++ b/src/data/proofs/lagrange-four-squares/review.json
@@ -157,7 +157,8 @@
       "priority": "low",
       "target": "researcher",
       "description": "Remove the redundant four_always_suffices theorem (line 184) which is identical to lagrange_four_squares.",
-      "status": "open"
+      "status": "resolved",
+      "resolution": "Removed four_always_suffices (one-line wrapper of lagrange_four_squares: identical statement and trivial proof). Updated theoremCount."
     }
   ],
   "qualityScores": {


### PR DESCRIPTION
## Fix

Removes `four_always_suffices` — a one-liner `lagrange_four_squares n` with the same statement as `lagrange_four_squares`. Zero mathematical content beyond the main theorem.

**Before**: `theorem four_always_suffices (n : ℕ) : ∃ a b c d, ... := lagrange_four_squares n`
**After**: Removed.

Updates `theoremCount` from 16 to 15. Marks ai-8 (low priority) resolved in review.json.

---
Automated fix by lean-mechanic agent.