### PR TITLE
fix(meta): correct leanFile.sorries for erdos-1100 stub file

### DIFF
--- a/src/data/proofs/erdos-1100/meta.json
+++ b/src/data/proofs/erdos-1100/meta.json
@@ -276,6 +276,6 @@
       }
     ],
     "path": "Proofs/Stubs/Erdos1100Problem.lean",
-    "sorries": 3
+    "sorries": 2
   }
 }

--- a/src/data/proofs/erdos-1100/meta.json
+++ b/src/data/proofs/erdos-1100/meta.json
@@ -239,7 +239,7 @@
       "Finset"
     ],
     "namespace": "Erdos1100",
-    "lineCount": 328,
+    "lineCount": 255,
     "axiomCount": 4,
     "theoremCount": 13,
     "definitionCount": 7,


### PR DESCRIPTION
## Fix

Correct `leanFile.sorries` from 3 to 2 for `erdos-1100`.

## Evidence

**Before**: `leanFile.sorries: 3`
**After**: `leanFile.sorries: 2`

The stub file `Proofs/Stubs/Erdos1100Problem.lean` contains exactly 2 actual `sorry` proof terms:
- Line 175: `sorry -- Requires the limit statement` (inside `g_exponential_growth`)
- Line 177: `sorry -- From hupper` (inside `g_exponential_growth`)

The 3 entries in `mainTheorems` with `"type": "sorry"` (`tau_perp_lower_bound`, `erdos_hall_max_lower_bound`, `erdos_simonovits_bounds`) are `axiom` declarations in the Lean source, not sorry-proofs — they are already correctly accounted for in `leanFile.axiomCount: 4` (fixed by #9804).

The top-level `meta.sorries: 3` correctly reflects the companion `Proofs/Erdos1100ProblemProvable.lean` which has 3 actual sorries, so that field is unchanged.

---
Automated fix by lean-mechanic agent.