### PR TITLE
fix(proof): remove duplicate hilbert_15_statement

### DIFF
--- a/proofs/Proofs/Hilbert15SchubertCalculus.lean
+++ b/proofs/Proofs/Hilbert15SchubertCalculus.lean
@@ -452,8 +452,6 @@ This was achieved through intersection theory on Grassmannians, with:
 
 We verify the four lines number as a concrete example.
 -/
-theorem hilbert_15_statement : schubertNumber_FourLines = 2 := rfl
-
 end Hilbert15
 
 /-! ═══════════════════════════════════════════════════════════════════════════════
@@ -469,4 +467,4 @@ EXPORTS
 #check Hilbert15.SchubertClass
 #check Hilbert15.schubert_basis_theorem
 #check Hilbert15.littlewood_richardson_rule
-#check Hilbert15.hilbert_15_statement
+#check Hilbert15.four_lines_via_schubert

--- a/src/data/proofs/hilbert-15/meta.json
+++ b/src/data/proofs/hilbert-15/meta.json
@@ -181,7 +181,7 @@
     "namespace": "Hilbert15",
     "lineCount": 472,
     "axiomCount": 7,
-    "theoremCount": 4,
+    "theoremCount": 3,
     "definitionCount": 14,
     "path": "Proofs/Hilbert15SchubertCalculus.lean",
     "sorries": 0

--- a/src/data/proofs/hilbert-15/review.json
+++ b/src/data/proofs/hilbert-15/review.json
@@ -102,7 +102,8 @@
       "priority": "low",
       "target": "researcher",
       "description": "Remove duplicate theorem hilbert_15_statement (identical to four_lines_via_schubert). Consider whether either rfl theorem adds value beyond the constant definition.",
-      "status": "open"
+      "status": "resolved",
+      "resolution": "Removed hilbert_15_statement (identical to four_lines_via_schubert: same statement schubertNumber_FourLines = 2, same proof := rfl). Updated #check reference in EXPORTS."
     },
     {
       "id": "ai-5",


### PR DESCRIPTION
## Fix

Removes `hilbert_15_statement` from `Hilbert15SchubertCalculus.lean`. It is character-for-character identical to `four_lines_via_schubert`:

**Both**: `schubertNumber_FourLines = 2 := rfl`

Also updates the EXPORTS `#check` section to reference `four_lines_via_schubert` instead.

Updates `theoremCount` from 4 to 3. Marks ai-4 (low priority) resolved in review.json.

---
Automated fix by lean-mechanic agent.