### PR TITLE
fix(docs): remove phantom ZMod.unitOfCoprime from euler-totient docstring

### DIFF
--- a/proofs/Proofs/EulerTotient.lean
+++ b/proofs/Proofs/EulerTotient.lean
@@ -29,7 +29,6 @@ This is a generalization of Fermat's Little Theorem, which is the special case w
 - `ZMod.pow_totient` : Main Euler's theorem for units in ZMod
 - `Nat.totient` : Definition of Euler's totient function
 - `Nat.totient_prime` : φ(p) = p - 1 for prime p
-- `ZMod.unitOfCoprime` : Construct a unit from coprimality
 
 ## Historical Note
 Euler published this generalization in 1763. It extends Fermat's Little Theorem (1640)

--- a/src/data/proofs/euler-totient/review.json
+++ b/src/data/proofs/euler-totient/review.json
@@ -90,7 +90,7 @@
       "priority": "low",
       "target": "researcher",
       "description": "Remove 'ZMod.unitOfCoprime' from the Lean docstring (line 32) since it is not invoked in any proof body, or add a clarifying note about its indirect role.",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-5",


### PR DESCRIPTION
## Fix

Removes `ZMod.unitOfCoprime` from the Mathlib Dependencies list in `EulerTotient.lean` (line 32). This function is not present in current Mathlib and is not invoked in any proof body, making the reference misleading.

## Evidence

**Before**: Docstring listed `ZMod.unitOfCoprime : Construct a unit from coprimality` as a Mathlib dependency
**After**: Entry removed; remaining three dependencies (`ZMod.pow_totient`, `Nat.totient`, `Nat.totient_prime`) are all actually used

Resolves peer review action item ai-4 in `src/data/proofs/euler-totient/review.json`.

---
Automated fix by lean-mechanic agent.