### PR TITLE
fix(meta): correct stale lineCount for 4 gallery proofs

### DIFF
--- a/src/data/proofs/bezout-identity-oq-04-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-01/meta.json
@@ -52,7 +52,7 @@
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 2,
-    "lineCount": 335,
+    "lineCount": 407,
     "assumptions": "Two axioms: snf_exists (every integer matrix has a Smith Normal Form) and snf_solvability_criterion (system Ax=b solvable iff invariant factors divide transformed RHS). Both are well-known theorems; constructive proofs would require implementing the full row/column reduction algorithm for ℤ-matrices.",
     "mathlib_version": "4.26.0"
   },
@@ -190,7 +190,7 @@
       "Matrix"
     ],
     "namespace": "BezoutIdentityOQ04OQ01",
-    "lineCount": 335,
+    "lineCount": 407,
     "axiomCount": 2,
     "theoremCount": 11,
     "definitionCount": 5,

--- a/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
@@ -40,7 +40,7 @@
     ],
     "dateAdded": "2026-03-30",
     "leanFile": {
-      "lineCount": 267,
+      "lineCount": 396,
       "structures": 0,
       "axioms": 0,
       "theorems": 7,
@@ -48,7 +48,7 @@
       "instances": 0
     },
     "axiomCount": 0,
-    "lineCount": 267,
+    "lineCount": 396,
     "assumptions": "0 axioms, 0 sorries. All three key theorems fully proved: aeval_companionMatrix (orbit argument), charpoly_companionMatrix, and minpoly_companionMatrix. Uses Mathlib supporting lemmas.",
     "mathlib_version": "4.26.0"
   },
@@ -129,7 +129,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 267,
+    "lineCount": 396,
     "path": "Proofs/CayleyHamiltonReductionOQ02OQ01.lean",
     "axiomCount": 0,
     "sorries": 0

--- a/src/data/proofs/erdos-1059-oq-01/meta.json
+++ b/src/data/proofs/erdos-1059-oq-01/meta.json
@@ -82,7 +82,7 @@
       "Finset operations for counting",
       "Floor binary logarithm (Nat.log) and its monotonicity properties"
     ],
-    "lineCount": 456,
+    "lineCount": 346,
     "relatedProblems": [
       {
         "id": "erdos-1059",
@@ -186,7 +186,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 456,
+    "lineCount": 346,
     "namespace": "Erdos1059OQ01",
     "opens": [],
     "structureCount": 0,

--- a/src/data/proofs/erdos-895/meta.json
+++ b/src/data/proofs/erdos-895/meta.json
@@ -46,7 +46,7 @@
       "Formalization of Hajnal's open generalization"
     ],
     "axiomCount": 0,
-    "lineCount": 187,
+    "lineCount": 260,
     "assumptions": "No axioms. 11 sorries(s) remain in the formalization.",
     "mathlib_version": "4.26.0"
   },
@@ -154,7 +154,7 @@
       "SimpleGraph"
     ],
     "namespace": null,
-    "lineCount": 187,
+    "lineCount": 260,
     "axiomCount": 0,
     "theoremCount": 13,
     "definitionCount": 11,


### PR DESCRIPTION
## Fix

Correct stale `lineCount` in `leanFile` metadata for 4 gallery proofs.

## Evidence

| Proof | Before | After | Change |
|-------|--------|-------|--------|
| cayley-hamilton-reduction-oq-02-oq-01 | 267 | 396 | +129 |
| bezout-identity-oq-04-oq-01 | 335 | 407 | +72 |
| erdos-895 | 187 | 260 | +73 |
| erdos-1059-oq-01 | 456 | 346 | -110 |

**Method**: `wc -l` on each Lean file. All `lineCount` fields in the affected `meta.json` files updated.

Note: `erdos-1059-oq-01` shrank by 110 lines, likely due to code cleanup since the metadata was last set.

---
Automated fix by lean-mechanic agent.