### PR TITLE
fix(filler): remove heron_product_expand_alt duplicate theorem

### DIFF
--- a/proofs/Proofs/HeronsFormula.lean
+++ b/proofs/Proofs/HeronsFormula.lean
@@ -138,13 +138,6 @@ theorem heron_product_expand (a b c : ℝ) :
   unfold heron_product semiperimeter
   ring
 
-/-- Alternative expansion using the difference of squares -/
-theorem heron_product_expand_alt (a b c : ℝ) :
-    heron_product a b c =
-    ((a + b + c) * (a + b - c) * (a - b + c) * (-a + b + c)) / 16 := by
-  unfold heron_product semiperimeter
-  ring
-
 -- ============================================================
 -- PART 5: Specific Examples
 -- ============================================================

--- a/src/data/proofs/herons-formula/meta.json
+++ b/src/data/proofs/herons-formula/meta.json
@@ -33,7 +33,7 @@
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 57,
     "axiomCount": 0,
-    "lineCount": 275,
+    "lineCount": 268,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0"
   },
@@ -92,9 +92,9 @@
       "id": "algebraic",
       "title": "Algebraic Expansion",
       "startLine": 131,
-      "endLine": 151,
-      "summary": "Proves $s(s-a)(s-b)(s-c) = \\frac{(a+b+c)(-a+b+c)(a-b+c)(a+b-c)}{16}$ and an alternative ordering, both via `ring`. This expansion avoids computing $s$ and is numerically more stable.",
-      "mathContext": "Verified: Proves $s(s-a)(s-b)(s-c) = \\frac{(a+b+c)(-a+b+c)(a-b+c)(a+b-c)}{16}$ and an alternative ordering, both via `ring`. This expansion avoids computing $s$ and is numerically more stable."
+      "endLine": 141,
+      "summary": "Proves $s(s-a)(s-b)(s-c) = \\frac{(a+b+c)(-a+b+c)(a-b+c)(a+b-c)}{16}$ via `ring`. This expansion avoids computing $s$ and is numerically more stable.",
+      "mathContext": "Verified: Proves $s(s-a)(s-b)(s-c) = \\frac{(a+b+c)(-a+b+c)(a-b+c)(a+b-c)}{16}$ via `ring`. This expansion avoids computing $s$ and is numerically more stable."
     },
     {
       "id": "examples",
@@ -166,9 +166,9 @@
       "Real"
     ],
     "namespace": "HeronsFormula",
-    "lineCount": 275,
+    "lineCount": 268,
     "axiomCount": 0,
-    "theoremCount": 11,
+    "theoremCount": 10,
     "definitionCount": 3,
     "path": "Proofs/HeronsFormula.lean",
     "sorries": 0

--- a/src/data/proofs/herons-formula/review.json
+++ b/src/data/proofs/herons-formula/review.json
@@ -108,7 +108,7 @@
       "priority": "low",
       "target": "researcher",
       "description": "Consider removing heron_product_expand_alt (commutative reordering of heron_product_expand) or replacing it with a genuinely different algebraic form, such as the expanded polynomial form 2a^2b^2 + 2b^2c^2 + 2c^2a^2 - a^4 - b^4 - c^4.",
-      "status": "open"
+      "status": "resolved"
     }
   ],
   "qualityScores": {


### PR DESCRIPTION
## Fix

Removes `heron_product_expand_alt` from `HeronsFormula.lean`. This theorem proved the same algebraic identity as `heron_product_expand` but with the four factors in a different commutative order — zero new mathematical content.

## Evidence

**Before**: Two theorems with identical mathematical content (commutativity of multiplication)
```lean
theorem heron_product_expand ...
    heron_product a b c = (a + b + c) * (-a + b + c) * (a - b + c) * (a + b - c) / 16

theorem heron_product_expand_alt ...
    heron_product a b c = ((a + b + c) * (a + b - c) * (a - b + c) * (-a + b + c)) / 16
```

**After**: Only `heron_product_expand` remains; `theoremCount` updated 11→10, `lineCount` 275→268.

Resolves peer review action item ai-5 in `src/data/proofs/herons-formula/review.json`.

---
Automated fix by lean-mechanic agent.