### PR TITLE
fix(meta): correct stale lineCount for erdos-1145 and erdos-647

### DIFF
--- a/src/data/proofs/erdos-1145/meta.json
+++ b/src/data/proofs/erdos-1145/meta.json
@@ -187,7 +187,7 @@
       "Pointwise"
     ],
     "namespace": "Erdos1145",
-    "lineCount": 682,
+    "lineCount": 737,
     "axiomCount": 1,
     "theoremCount": 21,
     "definitionCount": 9,

--- a/src/data/proofs/erdos-647/meta.json
+++ b/src/data/proofs/erdos-647/meta.json
@@ -51,7 +51,7 @@
       "Machine-verified proof that τ(m) ≥ 2^ω(m) for all m ≥ 1, using Nat.card_divisors from Mathlib and Finset.prod_le_prod'"
     ],
     "axiomCount": 1,
-    "lineCount": 300,
+    "lineCount": 324,
     "assumptions": "1 axiom(s) and 0 sorry(s). The axiom `large_n_fail` encodes the open conjecture that no n > 24 satisfies the Erdős condition."
   },
   "overview": {
@@ -148,7 +148,7 @@
       "Finset"
     ],
     "namespace": "Erdos647",
-    "lineCount": 300,
+    "lineCount": 324,
     "axiomCount": 1,
     "theoremCount": 25,
     "definitionCount": 11,


### PR DESCRIPTION
## Fix

Correct stale `lineCount` in gallery metadata for 2 proofs.

## Evidence

| Proof | Field | Before | After |
|-------|-------|--------|-------|
| erdos-1145 | `leanFile.lineCount` | 682 | 737 |
| erdos-647 | `meta.lineCount` + `leanFile.lineCount` | 300 | 324 |

`erdos-1145`: The `meta.lineCount` was already correct at 737 (updated during enrichment). Only `leanFile.lineCount` lagged behind at 682.

`erdos-647`: Both the `meta` section and `leanFile` section had stale 300-line counts.

---
Automated fix by lean-mechanic agent.