### PR TITLE
fix(naming): rename dehn_theorem_simplified to dehn_invariant_modus_ponens

### DIFF
--- a/proofs/Proofs/DissectionOfCubesOQ02.lean
+++ b/proofs/Proofs/DissectionOfCubesOQ02.lean
@@ -264,13 +264,11 @@ theorem tetrahedron_dehn_nonzero :
 -- Part IV: Dehn's Theorem (Invariance Under Dissection)
 -- ========================================================================
 
-/-- **Dehn's Theorem** (simplified): If scissors congruence preserves the
-boolean Dehn invariant (all dihedral angles rational multiples of π),
-then zero Dehn of P implies zero Dehn of Q. The hypothesis
-`h_dehn_preserved` encodes the topological content of Dehn's theorem
-(invariant additivity under polyhedral decomposition) for a specific
-pair of polyhedra. -/
-theorem dehn_theorem_simplified (angles_P angles_Q : List ℝ)
+/-- **Modus ponens on the Dehn invariant**: If a hypothesis encodes that the
+Dehn invariant is preserved from P to Q, and P has zero Dehn invariant,
+then Q also has zero Dehn invariant. This is propositional logic (modus ponens)
+applied to `dehnInvariantZero`; it does not prove Dehn's theorem itself. -/
+theorem dehn_invariant_modus_ponens (angles_P angles_Q : List ℝ)
     (h_dehn_preserved : dehnInvariantZero angles_P → dehnInvariantZero angles_Q)
     (h_dehn_P : dehnInvariantZero angles_P) :
     dehnInvariantZero angles_Q :=

--- a/src/data/proofs/dissection-of-cubes-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02/meta.json
@@ -100,7 +100,7 @@
       "title": "Dehn's Theorem (Invariance Under Dissection)",
       "startLine": 114,
       "endLine": 127,
-      "summary": "Dehn's theorem (scissors congruent polyhedra have equal Dehn invariant) is encoded as an explicit hypothesis rather than proved. The dehn_theorem_simplified wrapper is modus ponens applying this hypothesis.",
+      "summary": "Dehn's theorem (scissors congruent polyhedra have equal Dehn invariant) is encoded as an explicit hypothesis rather than proved. The dehn_invariant_modus_ponens wrapper is propositional modus ponens applying this hypothesis — it does not prove Dehn's theorem.",
       "mathContext": "Dehn's theorem: $P \\sim_{\\mathrm{sc}} Q \\Rightarrow D(P) = D(Q)$. Assumed as an explicit hypothesis in the formalization; proving additivity of the Dehn invariant under polyhedral decomposition remains open."
     },
     {

--- a/src/data/proofs/dissection-of-cubes-oq-02/review.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02/review.json
@@ -164,7 +164,7 @@
       "priority": "medium",
       "target": "researcher",
       "description": "Remove dehn_sydler_statement (proves True) or convert to an explicit axiom with proper documentation. Remove dehn_theorem_simplified (modus ponens) or rename to avoid claiming it is Dehn's theorem.",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-7",


### PR DESCRIPTION
## Fix

Renames `dehn_theorem_simplified` to `dehn_invariant_modus_ponens` in `DissectionOfCubesOQ02.lean` and updates the docstring to accurately describe what it does.

## Evidence

**Before**: Named `dehn_theorem_simplified` with docstring claiming it is Dehn's Theorem (simplified). The proof body is `h_dehn_preserved h_dehn_P` — literally modus ponens.

**After**: Named `dehn_invariant_modus_ponens` with docstring clarifying it is propositional logic (modus ponens) applied to `dehnInvariantZero`, not a proof of Dehn's theorem.

Note: `dehn_sydler_statement` (proves `True`) had already been converted to a comment in a prior commit, addressing that part of the action item.

Resolves peer review action item ai-6 in `src/data/proofs/dissection-of-cubes-oq-02/review.json`.

---
Automated fix by lean-mechanic agent.