### PR TITLE
fix(filler): remove bertrand alias and exists_prime_between wrapper

### DIFF
--- a/proofs/Proofs/BertrandsPostulate.lean
+++ b/proofs/Proofs/BertrandsPostulate.lean
@@ -60,19 +60,7 @@ namespace BertrandsPostulate
 theorem bertrand_postulate (n : ℕ) (hn : 0 < n) : ∃ p, Nat.Prime p ∧ n < p ∧ p ≤ 2 * n :=
   Nat.exists_prime_lt_and_le_two_mul n (Nat.pos_iff_ne_zero.mp hn)
 
-/-- **Bertrand's Postulate (Alternative Name)**
-
-    An alias for the main theorem using Mathlib's naming convention. -/
-theorem bertrand (n : ℕ) (hn : 0 < n) : ∃ p, Nat.Prime p ∧ n < p ∧ p ≤ 2 * n :=
-  Nat.bertrand n (Nat.pos_iff_ne_zero.mp hn)
-
 /-! ## Corollaries -/
-
-/-- **Existence of primes in intervals**
-
-    For n ≥ 1, there's a prime between n and 2n (exclusive on left, inclusive on right). -/
-theorem exists_prime_between (n : ℕ) (hn : 1 ≤ n) : ∃ p, Nat.Prime p ∧ n < p ∧ p ≤ 2 * n := by
-  exact bertrand_postulate n hn
 
 /-- **Prime gaps are bounded**
 
@@ -156,8 +144,6 @@ distribution of primes in such intervals. -/
 /-! ## Key Theorems Summary -/
 
 #check bertrand_postulate
-#check bertrand
-#check exists_prime_between
 #check prime_gap_bounded
 #check primes_infinite_via_bertrand
 #check no_largest_prime_via_bertrand

--- a/src/data/proofs/bertrands-postulate/meta.json
+++ b/src/data/proofs/bertrands-postulate/meta.json
@@ -40,7 +40,7 @@
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 43,
     "axiomCount": 0,
-    "lineCount": 165,
+    "lineCount": 151,
     "relatedProblems": [
       {
         "id": "bertrands-postulate-oq-03",
@@ -200,9 +200,9 @@
     ],
     "opens": [],
     "namespace": "BertrandsPostulate",
-    "lineCount": 165,
+    "lineCount": 151,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 5,
     "definitionCount": 0,
     "path": "Proofs/BertrandsPostulate.lean",
     "sorries": 0

--- a/src/data/proofs/bertrands-postulate/review.json
+++ b/src/data/proofs/bertrands-postulate/review.json
@@ -132,7 +132,7 @@
       "priority": "medium",
       "target": "researcher",
       "description": "Consider removing the filler theorem 'bertrand' (line 66-67, pure alias) and 'exists_prime_between' (line 74-75, wrapper of wrapper with identical conclusion). These inflate the theorem count without adding value. Alternatively, add concrete example theorems (e.g., verifying Bertrand for specific n values using decide/norm_num) to replace the filler.",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-5",


### PR DESCRIPTION
## Fix

Removes two redundant theorems from `BertrandsPostulate.lean`:
- `bertrand`: an alias calling `Nat.bertrand` — same conclusion as `bertrand_postulate`, no downstream usage
- `exists_prime_between`: a wrapper calling `bertrand_postulate` — identical conclusion with `1 ≤ n` vs `0 < n` (equivalent for `ℕ`)

## Evidence

**Before**: 7 theorems — `bertrand_postulate`, `bertrand`, `exists_prime_between`, `prime_gap_bounded`, `primes_infinite_via_bertrand`, `no_largest_prime_via_bertrand`, `bertrand_large`

**After**: 5 theorems — the three aliases/wrappers removed, `theoremCount` 7→5, `lineCount` 165→151.

Resolves peer review action item ai-4 in `src/data/proofs/bertrands-postulate/review.json`.

---
Automated fix by lean-mechanic agent.