### PR TITLE
fix(docs): clarify normalizeOnSphere dead code is proof sketch scaffolding

### DIFF
--- a/proofs/Proofs/BorsukUlam.lean
+++ b/proofs/Proofs/BorsukUlam.lean
@@ -119,6 +119,9 @@ We formalize the key insight: an odd map nonzero on the sphere would give a map
 to a lower-dimensional sphere, which violates topological invariants.
 -/
 
+-- Scaffolding for the proof sketch above (not used in the axiomatized proof below).
+-- These would be the key steps in a non-axiomatized proof of no_continuous_odd_nonzero_on_sphere.
+
 /-- An odd function that's nonzero on the sphere can be normalized to map to a sphere -/
 noncomputable def normalizeOnSphere (h : EuclideanSpace ℝ (Fin (n + 1)) → EuclideanSpace ℝ (Fin n))
     (hnonzero : ∀ x ∈ Sphere n, h x ≠ 0) (x : EuclideanSpace ℝ (Fin (n + 1))) :

--- a/src/data/proofs/borsuk-ulam/review.json
+++ b/src/data/proofs/borsuk-ulam/review.json
@@ -115,7 +115,7 @@
       "priority": "medium",
       "target": "researcher",
       "description": "Address dead code: normalizeOnSphere and normalizeOnSphere_odd are never used. Either add a comment explaining they are scaffolding for a future proof of the axiom, or remove them. Open since prior review.",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-4",


### PR DESCRIPTION
## Fix

Adds a clarifying comment before `normalizeOnSphere` and `normalizeOnSphere_odd` in `BorsukUlam.lean` explaining they are scaffolding for the proof sketch in the surrounding comment — not used in the axiomatized proof.

## Evidence

**Before**: Two definitions/theorems appear with no explanation of why they're never called in the axiomatized proof, making them look like dead code.

**After**: Comment added:
```
-- Scaffolding for the proof sketch above (not used in the axiomatized proof below).
-- These would be the key steps in a non-axiomatized proof of no_continuous_odd_nonzero_on_sphere.
```

Resolves peer review action item ai-3 in `src/data/proofs/borsuk-ulam/review.json`.

---
Automated fix by lean-mechanic agent.