### PR TITLE
fix(docs): correct docstring: geometric series → p-series (p=2)

### DIFF
--- a/proofs/Proofs/TriangularNumberReciprocals.lean
+++ b/proofs/Proofs/TriangularNumberReciprocals.lean
@@ -21,7 +21,7 @@ This is Wiedijk's 100 Theorems #42.
 - **Partial Fractions**: The reciprocal 2/(n(n+1)) decomposes as 2(1/n - 1/(n+1))
 - **Telescoping Series**: The sum becomes 2(1 - 1/2 + 1/2 - 1/3 + 1/3 - ...) = 2·1 = 2
 - **Foundation (from Mathlib)**: We use Mathlib's infinite sum machinery and prove
-  convergence via comparison with the geometric series.
+  convergence via comparison with the p-series (p=2).
 
 ## Historical Context
 This beautiful identity connects the triangular numbers (known since antiquity) with

--- a/src/data/proofs/triangular-reciprocals/review.json
+++ b/src/data/proofs/triangular-reciprocals/review.json
@@ -87,7 +87,7 @@
       "priority": "medium",
       "target": "researcher",
       "description": "Fix the Lean file docstring at line 24: change 'comparison with the geometric series' to 'comparison with the p-series' to match the actual code (Real.summable_nat_rpow_inv at line 158).",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-3",


### PR DESCRIPTION
## Fix

Corrects a factual error in the `TriangularNumberReciprocals.lean` docstring (line 24): the convergence proof uses `Real.summable_nat_rpow_inv` (p-series with p=2), not a geometric series comparison. These are distinct convergence tests.

## Evidence

**Before**: `convergence via comparison with the geometric series.`
**After**: `convergence via comparison with the p-series (p=2).`

The actual code at line 158 uses `Real.summable_nat_rpow_inv`, confirming this is a p-series comparison (integral test), not a geometric series (ratio test).

Resolves peer review action item ai-2 in `src/data/proofs/triangular-reciprocals/review.json`.

---
Automated fix by lean-mechanic agent.