### PR TITLE
Enrich 3 proofs: power mean, Glivenko-Cantelli, Lawvere FPT, Königsberg paths

### DIFF
--- a/src/data/proofs/konigsberg-oq-03-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-03-oq-02/meta.json
@@ -96,9 +96,11 @@
   ],
   "conclusion": {
     "summary": "The ℕ-indexed InfiniteWalk provides a clean, sorry-free foundation for infinite Euler paths in Lean 4. The definitions are ready for use in the Erdős-Grünwald-Weiszfeld theorem formalization. Key simplifications: ℕ over Stream', split Euler condition, undirected edges via sameEdge without Sym2.",
+    "implications": "This file resolves a conceptual bottleneck in the formalization of infinite graph theory in Lean 4: how to represent an infinite walk without coinductive complications. The solution — `ℕ → V` with `∀ n, adj (vertex n) (vertex (n+1))` — is elementary but consequential. It enables the Erdős-Grünwald-Weiszfeld theorem to be stated precisely in Lean 4 (since `HasOneWayInfiniteEulerPath` is now a proper mathematical definition, not a stub). The architectural lesson generalizes: in Lean 4, coinductive (Stream') and function-based (ℕ → V) formulations of sequential data are definitionally equal, so one can always choose the more computationally convenient representation without mathematical loss. The BiInfiniteWalk over ℤ similarly avoids coinductive issues by using integer arithmetic directly.",
     "openQuestions": [
-      "Prove the Erdős-Grünwald-Weiszfeld theorem: G has a one-way Euler path iff (1) at most 2 vertices of odd degree and (2) every finite subgraph has even edge parity. This is the main application of these definitions.",
-      "Connect InfiniteWalk to Mathlib's SimpleGraph.Walk API: is there a coercion or embedding from finite Walk to InfiniteWalk (by appending a trivial 'tail')?"
+      "Prove the Erdős-Grünwald-Weiszfeld theorem: G has a one-way Euler path iff (1) at most 2 vertices of odd degree and (2) for every finite vertex set S, G−S has at most 2 infinite connected components.",
+      "Connect InfiniteWalk to Mathlib's SimpleGraph.Walk API: is there a coercion or embedding from finite Walk to InfiniteWalk (e.g., by repeating the last vertex indefinitely)?",
+      "Develop a `Stream'`-to-`InfiniteWalk` coercion as a simp lemma, so that proofs using Mathlib's coinductive stream API can be automatically translated to the ℕ-indexed formulation used here."
     ]
   },
   "crossReferences": [


### PR DESCRIPTION
Enrichment pass for 4 gallery entries.

## Entries enriched

### 1. `cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01` — Full Power Mean Monotonicity
- Created annotations.json (6 annotations: imports, unified theorem, rcases case split, classical corollaries, transitivity, full chain HM≤GM≤AM≤QM)
- Expanded historicalContext: Cauchy 1821, Jensen 1906, Hardy-Littlewood-Pólya 1934
- Added 5th keyInsight: uniform norm_num corollary pattern
- Expanded openQuestions to 3 (measure-theoretic extension)

### 2. `laws-of-large-numbers-oq-04` — Glivenko-Cantelli Theorem
- Created annotations.json (7 annotations: definitions, basic identities, i.i.d. transfer, axioms, pointwise convergence, uniform convergence, structural properties)
- Expanded historicalContext: simultaneous 1933 discovery, KS test, Donsker 1952, VC 1971
- Added 6th keyInsight: compositional structure g_x ∘ X_i pattern
- Deepened conclusion.implications

### 3. `cantor-diagonalization-oq-03-oq-01-oq-01` — Categorical Lawvere FPT
- Added 2 missing annotations: no_surjection_abstract, cantor_recovery
- Added 7-section sections array
- Expanded historicalContext: Lawvere 1969 unification of Cantor/Russell/Halting/Gödel
- Added 4th and 5th keyInsights
- Added conclusion.implications

### 4. `konigsberg-oq-03-oq-02` — Infinite Paths in Graphs
- Added conclusion.implications: definitional Stream'/ℕ equivalence significance
- Added 3rd openQuestion: Stream' coercion as simp lemma

## Axiom integrity
All 4 entries verified: power mean (0 axioms, verified), Glivenko-Cantelli (3 axioms, axiomatized), Lawvere (0 axioms, verified), Königsberg (0 axioms, verified).