### PR TITLE
fix(naming): rename cauchy_schwarz_from_holder to cauchy_schwarz_finite'

### DIFF
--- a/proofs/Proofs/CauchySchwarzOQ03.lean
+++ b/proofs/Proofs/CauchySchwarzOQ03.lean
@@ -125,9 +125,11 @@ theorem cauchy_schwarz_finite {ι : Type*} (s : Finset ι) (f g : ι → ℝ) :
     congr 1; ext i; congr 1; ext j; ring
   rw [ha, hc, hb]; ring
 
-/-- Cauchy-Schwarz is the p = q = 2 special case of Holder's inequality.
-    When p = q = 2, Holder reduces to: (sum f_i*g_i)^2 <= (sum f_i^2)(sum g_i^2). -/
-theorem cauchy_schwarz_from_holder {ι : Type*} (s : Finset ι) (f g : ι → ℝ) :
+/-- Alias for `cauchy_schwarz_finite` with hypothesis-free statement.
+    Note: the name 'from_holder' is a misnomer — this proof does not derive
+    Cauchy-Schwarz from Hölder's inequality; it simply calls cauchy_schwarz_finite
+    directly. For a Hölder-based derivation, one would use holder_nnreal at p=q=2. -/
+theorem cauchy_schwarz_finite' {ι : Type*} (s : Finset ι) (f g : ι → ℝ) :
     (∑ i ∈ s, f i * g i) ^ 2 ≤ (∑ i ∈ s, f i ^ 2) * (∑ i ∈ s, g i ^ 2) :=
   cauchy_schwarz_finite s f g
 
@@ -228,7 +230,7 @@ Theorems Proved (0 sorries):
 1. holder_nnreal: General Holder for NNReal (Mathlib NNReal.inner_le_Lp_mul_Lq)
 2. holder_normalized: Holder for unit-norm inputs (1 line from holder_nnreal)
 3. cauchy_schwarz_finite: CS via Lagrange's identity (elementary double-sum argument)
-4. cauchy_schwarz_from_holder: CS as p=q=2 special case of Holder
+4. cauchy_schwarz_finite': alias for cauchy_schwarz_finite (renamed from cauchy_schwarz_from_holder)
 5. holder_real: Holder for real-valued functions via NNReal lift
 6. holder_lintegral: Integral Holder for measure spaces (Mathlib ENNReal.lintegral_mul_le_Lp_mul_Lq)
 7. cauchy_schwarz_inner: Abstract inner product CS (Mathlib abs_real_inner_le_norm)

--- a/research/registry.json
+++ b/research/registry.json
@@ -13138,11 +13138,12 @@
     },
     {
       "slug": "arithmetic-series-oq-02-oq-04-oq-01-oq-03",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "fast",
       "started": "2026-04-05T08:58:43.702Z",
-      "status": "active",
-      "lastUpdate": "2026-04-05T12:58:50.813Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T14:51:46.062Z",
+      "completed": "2026-04-05T14:51:46.062Z"
     },
     {
       "slug": "arithmetic-series-oq-04-oq-01",
@@ -13951,6 +13952,366 @@
       "started": "2026-04-05T12:58:50.791Z",
       "status": "active",
       "lastUpdate": "2026-04-05T12:58:50.791Z"
+    },
+    {
+      "slug": "yang-mills-lattice-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:45.975Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:45.975Z"
+    },
+    {
+      "slug": "erdos-12-wip-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.027Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.027Z"
+    },
+    {
+      "slug": "hilbert-23-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.027Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.027Z"
+    },
+    {
+      "slug": "kepler-conjecture-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.027Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.027Z"
+    },
+    {
+      "slug": "kroneckers-jugendtraum-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.027Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.027Z"
+    },
+    {
+      "slug": "perfect-numbers-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.027Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.027Z"
+    },
+    {
+      "slug": "twin-primes-special-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.027Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.027Z"
+    },
+    {
+      "slug": "erdos-1012-oq-03-oq-02",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.128Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.128Z"
+    },
+    {
+      "slug": "erdos-1018-oq-04-incomplete-01-oq-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.129Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.129Z"
+    },
+    {
+      "slug": "erdos-1066-oq-04-oq-03",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.132Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.132Z"
+    },
+    {
+      "slug": "erdos-1179-oq-01-oq-02",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.135Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.135Z"
+    },
+    {
+      "slug": "erdos-129-oq-04",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.135Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.135Z"
+    },
+    {
+      "slug": "erdos-247-oq-01-oq-02",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.137Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.137Z"
+    },
+    {
+      "slug": "erdos-277-oq-02",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.137Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.137Z"
+    },
+    {
+      "slug": "erdos-279-oq-04",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.137Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.137Z"
+    },
+    {
+      "slug": "erdos-286-oq-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.137Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.137Z"
+    },
+    {
+      "slug": "erdos-307-oq-02-oq-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.139Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.139Z"
+    },
+    {
+      "slug": "erdos-357-oq-04",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.140Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.140Z"
+    },
+    {
+      "slug": "erdos-396-oq-04",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.140Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.140Z"
+    },
+    {
+      "slug": "erdos-435-oq-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.141Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.141Z"
+    },
+    {
+      "slug": "erdos-453-oq-02-oq-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.141Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.141Z"
+    },
+    {
+      "slug": "erdos-458-oq-02",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.141Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.141Z"
+    },
+    {
+      "slug": "erdos-458-oq-05",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.141Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.141Z"
+    },
+    {
+      "slug": "erdos-57-oq-04",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.142Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.142Z"
+    },
+    {
+      "slug": "erdos-606-oq-03-oq-03",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.143Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.185Z"
+    },
+    {
+      "slug": "erdos-622-oq-04",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.143Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.143Z"
+    },
+    {
+      "slug": "erdos-659-oq-05",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.144Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.144Z"
+    },
+    {
+      "slug": "erdos-770-oq-04",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.146Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.146Z"
+    },
+    {
+      "slug": "erdos-799-oq-05",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.146Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.146Z"
+    },
+    {
+      "slug": "erdos-823-oq-05",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.147Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.147Z"
+    },
+    {
+      "slug": "erdos-841-oq-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.147Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.147Z"
+    },
+    {
+      "slug": "erdos-909-oq-01-oq-02",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.148Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.148Z"
+    },
+    {
+      "slug": "erdos-1038-wip-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.162Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.162Z"
+    },
+    {
+      "slug": "erdos-1074-wip-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.162Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.162Z"
+    },
+    {
+      "slug": "erdos-1077-wip-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.162Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.162Z"
+    },
+    {
+      "slug": "erdos-112-wip-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.162Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.162Z"
+    },
+    {
+      "slug": "erdos-227-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.162Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.162Z"
+    },
+    {
+      "slug": "erdos-230-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.162Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.162Z"
+    },
+    {
+      "slug": "erdos-240-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.162Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.162Z"
+    },
+    {
+      "slug": "erdos-309-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.162Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.162Z"
+    },
+    {
+      "slug": "erdos-318-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.162Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.162Z"
+    },
+    {
+      "slug": "halting-problem-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.162Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.162Z"
+    },
+    {
+      "slug": "sophie-germain-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.162Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.162Z"
+    },
+    {
+      "slug": "spherical-law-of-sines-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.162Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.186Z"
+    },
+    {
+      "slug": "primitive-roots-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.167Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.167Z"
     }
   ],
   "config": {

--- a/src/data/proofs/cauchy-schwarz-oq-03/review.json
+++ b/src/data/proofs/cauchy-schwarz-oq-03/review.json
@@ -69,7 +69,7 @@
       "priority": "medium",
       "target": "researcher",
       "description": "Fix cauchy_schwarz_from_holder: either rename to cauchy_schwarz_finite' (honest alias) or implement an actual Hölder-based derivation (derive squared form from holder_nnreal at p=q=2).",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-2",


### PR DESCRIPTION
## Fix

Renames `cauchy_schwarz_from_holder` to `cauchy_schwarz_finite'` in `CauchySchwarzOQ03.lean`.

## Evidence

**Before**: Named `cauchy_schwarz_from_holder` with docstring claiming it proves CS as a special case of Hölder. Proof body: `cauchy_schwarz_finite s f g` — does not use Hölder at all.

**After**: Named `cauchy_schwarz_finite'` (standard Lean prime suffix for a variant/alias) with docstring clarifying it is an alias for `cauchy_schwarz_finite` and noting that the old name was a misnomer.

Resolves peer review action item ai-1 in `src/data/proofs/cauchy-schwarz-oq-03/review.json`.

---
Automated fix by lean-mechanic agent.