### PR TITLE
fix(meta): sync stale sorryCount for 86 research problem leanFiles entries

### DIFF
--- a/src/data/research/problems/amgm-inequality-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-01.json
@@ -184,7 +184,7 @@
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
@@ -184,7 +184,7 @@
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
@@ -167,7 +167,7 @@
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
@@ -195,7 +195,7 @@
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
@@ -207,7 +207,7 @@
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
@@ -198,7 +198,7 @@
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02.json
@@ -192,7 +192,7 @@
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
@@ -192,7 +192,7 @@
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
@@ -207,7 +207,7 @@
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
@@ -193,7 +193,7 @@
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
@@ -189,7 +189,7 @@
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
@@ -194,7 +194,7 @@
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
@@ -145,7 +145,7 @@
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03.json
@@ -194,7 +194,7 @@
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
@@ -187,7 +187,7 @@
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
@@ -187,7 +187,7 @@
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
@@ -187,7 +187,7 @@
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04.json
@@ -206,7 +206,7 @@
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ04OQ01.lean"
     },

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-02.json
@@ -192,7 +192,7 @@
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ01OQ04OQ01.lean"
     },

--- a/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02.json
@@ -86,7 +86,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ03.lean"
     },

--- a/src/data/research/problems/basel-problem-oq-01-oq-01.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-01.json
@@ -82,7 +82,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ03.lean"
     },

--- a/src/data/research/problems/basel-problem-oq-01-oq-02.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-02.json
@@ -82,7 +82,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ03.lean"
     },

--- a/src/data/research/problems/basel-problem-oq-01-oq-03.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-03.json
@@ -87,7 +87,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ03.lean"
     },

--- a/src/data/research/problems/basel-problem-oq-01.json
+++ b/src/data/research/problems/basel-problem-oq-01.json
@@ -94,7 +94,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ03.lean"
     },

--- a/src/data/research/problems/basel-problem-oq-02.json
+++ b/src/data/research/problems/basel-problem-oq-02.json
@@ -121,7 +121,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ03.lean"
     },

--- a/src/data/research/problems/basel-problem-oq-04.json
+++ b/src/data/research/problems/basel-problem-oq-04.json
@@ -85,7 +85,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ03.lean"
     },

--- a/src/data/research/problems/basel-problem-oq-05-oq-01.json
+++ b/src/data/research/problems/basel-problem-oq-05-oq-01.json
@@ -96,7 +96,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ03.lean"
     },

--- a/src/data/research/problems/basel-problem-oq-05-oq-02.json
+++ b/src/data/research/problems/basel-problem-oq-05-oq-02.json
@@ -86,7 +86,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ03.lean"
     },

--- a/src/data/research/problems/basel-problem-oq-05.json
+++ b/src/data/research/problems/basel-problem-oq-05.json
@@ -98,7 +98,7 @@
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BaselProblemOQ01OQ03.lean"
     },

--- a/src/data/research/problems/bertrands-postulate-oq-03-oq-01.json
+++ b/src/data/research/problems/bertrands-postulate-oq-03-oq-01.json
@@ -116,7 +116,7 @@
       "theoremCount": 6,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 3,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BertrandsPostulateOQ03OQ04.lean"
     }

--- a/src/data/research/problems/bertrands-postulate-oq-03-oq-04.json
+++ b/src/data/research/problems/bertrands-postulate-oq-03-oq-04.json
@@ -94,7 +94,7 @@
       "theoremCount": 6,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 3,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BertrandsPostulateOQ03OQ04.lean"
     }

--- a/src/data/research/problems/bertrands-postulate-oq-03.json
+++ b/src/data/research/problems/bertrands-postulate-oq-03.json
@@ -88,7 +88,7 @@
       "theoremCount": 6,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 3,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BertrandsPostulateOQ03OQ04.lean"
     }

--- a/src/data/research/problems/bertrands-postulate-oq-04.json
+++ b/src/data/research/problems/bertrands-postulate-oq-04.json
@@ -91,7 +91,7 @@
       "theoremCount": 6,
       "axiomCount": 1,
       "defCount": 2,
-      "sorryCount": 3,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BertrandsPostulateOQ03OQ04.lean"
     }

--- a/src/data/research/problems/birthday-problem-oq-02-oq-01.json
+++ b/src/data/research/problems/birthday-problem-oq-02-oq-01.json
@@ -174,7 +174,7 @@
       "theoremCount": 18,
       "axiomCount": 1,
       "defCount": 3,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"
     },
@@ -185,7 +185,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02Aristotle.lean"
     },

--- a/src/data/research/problems/birthday-problem-oq-02-oq-03.json
+++ b/src/data/research/problems/birthday-problem-oq-02-oq-03.json
@@ -150,7 +150,7 @@
       "theoremCount": 18,
       "axiomCount": 1,
       "defCount": 3,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"
     },
@@ -161,7 +161,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02Aristotle.lean"
     },

--- a/src/data/research/problems/birthday-problem-oq-02.json
+++ b/src/data/research/problems/birthday-problem-oq-02.json
@@ -128,7 +128,7 @@
       "theoremCount": 18,
       "axiomCount": 1,
       "defCount": 3,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"
     },
@@ -139,7 +139,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02Aristotle.lean"
     },

--- a/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-01.json
@@ -156,7 +156,7 @@
       "theoremCount": 18,
       "axiomCount": 1,
       "defCount": 3,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"
     },
@@ -167,7 +167,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02Aristotle.lean"
     },

--- a/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02.json
@@ -210,7 +210,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02Aristotle.lean"
     },

--- a/src/data/research/problems/birthday-problem-oq-03-oq-01.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-01.json
@@ -165,7 +165,7 @@
       "theoremCount": 18,
       "axiomCount": 1,
       "defCount": 3,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"
     },
@@ -176,7 +176,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02Aristotle.lean"
     },

--- a/src/data/research/problems/birthday-problem-oq-03-oq-03.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-03.json
@@ -162,7 +162,7 @@
       "theoremCount": 18,
       "axiomCount": 1,
       "defCount": 3,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"
     },
@@ -173,7 +173,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02Aristotle.lean"
     },

--- a/src/data/research/problems/birthday-problem-oq-03.json
+++ b/src/data/research/problems/birthday-problem-oq-03.json
@@ -191,7 +191,7 @@
       "theoremCount": 18,
       "axiomCount": 1,
       "defCount": 3,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"
     },
@@ -202,7 +202,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02Aristotle.lean"
     },

--- a/src/data/research/problems/birthday-problem-oq-04.json
+++ b/src/data/research/problems/birthday-problem-oq-04.json
@@ -156,7 +156,7 @@
       "theoremCount": 18,
       "axiomCount": 1,
       "defCount": 3,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"
     },
@@ -167,7 +167,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02Aristotle.lean"
     },

--- a/src/data/research/problems/cramers-rule-oq-01-oq-01.json
+++ b/src/data/research/problems/cramers-rule-oq-01-oq-01.json
@@ -120,7 +120,7 @@
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 10,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRuleOQ01OQ03.lean"
     },

--- a/src/data/research/problems/cramers-rule-oq-01-oq-02.json
+++ b/src/data/research/problems/cramers-rule-oq-01-oq-02.json
@@ -153,7 +153,7 @@
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 10,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRuleOQ01OQ03.lean"
     },

--- a/src/data/research/problems/cramers-rule-oq-01-oq-04.json
+++ b/src/data/research/problems/cramers-rule-oq-01-oq-04.json
@@ -102,7 +102,7 @@
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 10,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRuleOQ01OQ03.lean"
     },

--- a/src/data/research/problems/cramers-rule-oq-01.json
+++ b/src/data/research/problems/cramers-rule-oq-01.json
@@ -106,7 +106,7 @@
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 10,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRuleOQ01OQ03.lean"
     },

--- a/src/data/research/problems/cramers-rule-oq-02-oq-01.json
+++ b/src/data/research/problems/cramers-rule-oq-02-oq-01.json
@@ -96,7 +96,7 @@
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 10,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRuleOQ01OQ03.lean"
     },

--- a/src/data/research/problems/cramers-rule-oq-02.json
+++ b/src/data/research/problems/cramers-rule-oq-02.json
@@ -103,7 +103,7 @@
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 10,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRuleOQ01OQ03.lean"
     },

--- a/src/data/research/problems/cramers-rule-oq-03.json
+++ b/src/data/research/problems/cramers-rule-oq-03.json
@@ -114,7 +114,7 @@
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 10,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRuleOQ01OQ03.lean"
     },

--- a/src/data/research/problems/cramers-rule-oq-04.json
+++ b/src/data/research/problems/cramers-rule-oq-04.json
@@ -75,7 +75,7 @@
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 10,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CramersRuleOQ01OQ03.lean"
     },

--- a/src/data/research/problems/derangements-convergence-oq-01.json
+++ b/src/data/research/problems/derangements-convergence-oq-01.json
@@ -77,7 +77,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 5,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ01.lean"
     }

--- a/src/data/research/problems/derangements-oq-01.json
+++ b/src/data/research/problems/derangements-oq-01.json
@@ -92,7 +92,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 5,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ01.lean"
     },

--- a/src/data/research/problems/derangements-oq-02-oq-01.json
+++ b/src/data/research/problems/derangements-oq-02-oq-01.json
@@ -94,7 +94,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 5,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ01.lean"
     },

--- a/src/data/research/problems/derangements-oq-02-oq-02.json
+++ b/src/data/research/problems/derangements-oq-02-oq-02.json
@@ -111,7 +111,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 5,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ01.lean"
     },

--- a/src/data/research/problems/derangements-oq-02.json
+++ b/src/data/research/problems/derangements-oq-02.json
@@ -92,7 +92,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 5,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ01.lean"
     },

--- a/src/data/research/problems/derangements-oq-03-oq-01.json
+++ b/src/data/research/problems/derangements-oq-03-oq-01.json
@@ -97,7 +97,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 5,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ01.lean"
     },

--- a/src/data/research/problems/derangements-oq-03-oq-02.json
+++ b/src/data/research/problems/derangements-oq-03-oq-02.json
@@ -97,7 +97,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 5,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ01.lean"
     },

--- a/src/data/research/problems/derangements-oq-03.json
+++ b/src/data/research/problems/derangements-oq-03.json
@@ -92,7 +92,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 5,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ01.lean"
     },

--- a/src/data/research/problems/erdos-1-oq-01.json
+++ b/src/data/research/problems/erdos-1-oq-01.json
@@ -815,7 +815,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03Aristotle.lean"
     },

--- a/src/data/research/problems/erdos-1-oq-02.json
+++ b/src/data/research/problems/erdos-1-oq-02.json
@@ -430,7 +430,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03Aristotle.lean"
     },

--- a/src/data/research/problems/erdos-1-oq-03.json
+++ b/src/data/research/problems/erdos-1-oq-03.json
@@ -835,7 +835,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03Aristotle.lean"
     },

--- a/src/data/research/problems/erdos-1-oq-04.json
+++ b/src/data/research/problems/erdos-1-oq-04.json
@@ -812,7 +812,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03Aristotle.lean"
     },

--- a/src/data/research/problems/erdos-10-oq-01.json
+++ b/src/data/research/problems/erdos-10-oq-01.json
@@ -629,7 +629,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03Aristotle.lean"
     },

--- a/src/data/research/problems/erdos-10.json
+++ b/src/data/research/problems/erdos-10.json
@@ -615,7 +615,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03Aristotle.lean"
     },

--- a/src/data/research/problems/erdos-1004-oq-04.json
+++ b/src/data/research/problems/erdos-1004-oq-04.json
@@ -101,7 +101,7 @@
       "theoremCount": 22,
       "axiomCount": 3,
       "defCount": 15,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1004Problem.lean"
     }

--- a/src/data/research/problems/erdos-101-oq-04.json
+++ b/src/data/research/problems/erdos-101-oq-04.json
@@ -147,7 +147,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03Aristotle.lean"
     },

--- a/src/data/research/problems/erdos-101.json
+++ b/src/data/research/problems/erdos-101.json
@@ -149,7 +149,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03Aristotle.lean"
     },

--- a/src/data/research/problems/erdos-1012-oq-01.json
+++ b/src/data/research/problems/erdos-1012-oq-01.json
@@ -95,7 +95,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03Aristotle.lean"
     },

--- a/src/data/research/problems/erdos-1012-oq-02.json
+++ b/src/data/research/problems/erdos-1012-oq-02.json
@@ -106,7 +106,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03Aristotle.lean"
     },

--- a/src/data/research/problems/erdos-1012-oq-03.json
+++ b/src/data/research/problems/erdos-1012-oq-03.json
@@ -145,7 +145,7 @@
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1012OQ03Aristotle.lean"
     },

--- a/src/data/research/problems/euler-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/euler-identity-oq-01-oq-01.json
@@ -95,7 +95,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerIdentityOQ01OQ01.lean"
     }

--- a/src/data/research/problems/euler-identity-oq-01.json
+++ b/src/data/research/problems/euler-identity-oq-01.json
@@ -91,7 +91,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerIdentityOQ01OQ01.lean"
     }

--- a/src/data/research/problems/euler-identity-oq-02.json
+++ b/src/data/research/problems/euler-identity-oq-02.json
@@ -79,7 +79,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerIdentityOQ01OQ01.lean"
     }

--- a/src/data/research/problems/euler-identity-oq-03.json
+++ b/src/data/research/problems/euler-identity-oq-03.json
@@ -83,7 +83,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerIdentityOQ01OQ01.lean"
     }

--- a/src/data/research/problems/leibniz-pi-oq-01-oq-01.json
+++ b/src/data/research/problems/leibniz-pi-oq-01-oq-01.json
@@ -110,7 +110,7 @@
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LeibnizPiOQ03.lean"
     }

--- a/src/data/research/problems/leibniz-pi-oq-01.json
+++ b/src/data/research/problems/leibniz-pi-oq-01.json
@@ -85,7 +85,7 @@
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LeibnizPiOQ03.lean"
     }

--- a/src/data/research/problems/leibniz-pi-oq-02.json
+++ b/src/data/research/problems/leibniz-pi-oq-02.json
@@ -102,7 +102,7 @@
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LeibnizPiOQ03.lean"
     }

--- a/src/data/research/problems/leibniz-pi-oq-03.json
+++ b/src/data/research/problems/leibniz-pi-oq-03.json
@@ -97,7 +97,7 @@
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LeibnizPiOQ03.lean"
     }

--- a/src/data/research/problems/shannon-channel-coding-oq-01.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-01.json
@@ -82,7 +82,7 @@
       "theoremCount": 3,
       "axiomCount": 2,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ02OQ01.lean"
     },
@@ -93,7 +93,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 9,
+      "sorryCount": 7,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ03.lean"
     },

--- a/src/data/research/problems/shannon-channel-coding-oq-02-oq-01.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-02-oq-01.json
@@ -116,7 +116,7 @@
       "theoremCount": 3,
       "axiomCount": 2,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ02OQ01.lean"
     },
@@ -127,7 +127,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 9,
+      "sorryCount": 7,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ03.lean"
     },

--- a/src/data/research/problems/shannon-channel-coding-oq-02.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-02.json
@@ -103,7 +103,7 @@
       "theoremCount": 3,
       "axiomCount": 2,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ02OQ01.lean"
     },
@@ -114,7 +114,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 9,
+      "sorryCount": 7,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ03.lean"
     },

--- a/src/data/research/problems/shannon-channel-coding-oq-04-oq-01.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-04-oq-01.json
@@ -57,7 +57,7 @@
       "theoremCount": 3,
       "axiomCount": 2,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ02OQ01.lean"
     },
@@ -68,7 +68,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 9,
+      "sorryCount": 7,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ03.lean"
     },

--- a/src/data/research/problems/shannon-channel-coding-oq-04.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-04.json
@@ -82,7 +82,7 @@
       "theoremCount": 3,
       "axiomCount": 2,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ02OQ01.lean"
     },
@@ -93,7 +93,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 9,
+      "sorryCount": 7,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ03.lean"
     },

--- a/src/data/research/problems/shannon-channel-coding.json
+++ b/src/data/research/problems/shannon-channel-coding.json
@@ -92,7 +92,7 @@
       "theoremCount": 3,
       "axiomCount": 2,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ02OQ01.lean"
     },
@@ -103,7 +103,7 @@
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 9,
+      "sorryCount": 7,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ShannonChannelCodingOQ03.lean"
     },

--- a/src/data/research/problems/szemeredi-core-oq-01.json
+++ b/src/data/research/problems/szemeredi-core-oq-01.json
@@ -82,7 +82,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediCoreOQ01.lean"
     },

--- a/src/data/research/problems/szemeredi-core-oq-03.json
+++ b/src/data/research/problems/szemeredi-core-oq-03.json
@@ -48,7 +48,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediCoreOQ01.lean"
     },


### PR DESCRIPTION
## Fix

Batch correction of stale `sorryCount` values in 86 research problem JSON `leanFiles` entries.

## Evidence

**Before**: 86 research problem JSON files had stale `sorryCount` values in their `leanFiles` entries — sorries had been proved (by Aristotle or researchers) but the count was not updated.

**After**: All `sorryCount` values match actual sorry counts in Lean source files.

Key corrections:
| Lean file | Was | Now | Notes |
|-----------|-----|-----|-------|
| DerangementsConvergenceOQ01.lean | 5 | 0 | All sorries proved |
| LeibnizPiOQ03.lean | 3 | 0 | All sorries proved |
| SzemerediCoreOQ01.lean | 4 | 1 | 3 sorries proved |
| ShannonChannelCodingOQ03.lean | 9 | 7 | 2 resolved |
| ShannonChannelCodingOQ02OQ01.lean | 3 | 1 | 2 resolved |
| EulerIdentityOQ01OQ01.lean | 1 | 0 | |
| Erdos1012OQ03Aristotle.lean | 1 | 0 | |
| Plus 8 more single-sorry corrections | | | |

---
Automated fix by lean-mechanic agent.