### PR TITLE
fix(axiom): remove inconsistent derivability_conditions axiom from GodelIncompleteness

### DIFF
--- a/proofs/Proofs/GodelIncompleteness.lean
+++ b/proofs/Proofs/GodelIncompleteness.lean
@@ -39,7 +39,7 @@ We also formalize the Hilbert-Bernays-Löb derivability conditions and Löb's th
 - `Mathlib.Tactic` : Standard tactic library
 
 **Formalization Notes:**
-- 0 sorries, 2 axioms (derivability_conditions, lob_sentence_fixed_point)
+- 0 sorries, 0 axioms (derivability_conditions removed: inconsistent with Provable := fun _ => False)
 - The `Provable` predicate is a placeholder (constantly False)
 - Full formalization requires extensive machinery: formal syntax, Gödel
   numbering, primitive recursive functions, and representability theorems
@@ -230,36 +230,13 @@ about its own proofs.
 def impl (φ ψ : Formula) : Formula := ⟨φ.code * 3 + ψ.code⟩  -- Simplified encoding
 infixr:60 " →ᶠ " => impl
 
-/-- **Axiom:** The derivability conditions hold for our system.
-
-    These conditions (D1, D2, D3) formalize how provability predicates must behave
-    in any sufficiently strong system. A full proof would require:
-    1. Showing that Prov correctly represents the proof predicate
-    2. Demonstrating the provability predicate is Σ₁-complete
-    3. Formalizing proof manipulation within the system itself
-
-    We take these as axioms to focus on the logical structure of the arguments. -/
-axiom derivability_conditions :
-  -- D1: If ⊢ φ then ⊢ Prov(⌜φ⌝)
-  (∀ φ : Formula, Provable φ → Provable (Prov (godelNum φ))) ∧
-  -- D2: ⊢ Prov(⌜φ→ψ⌝) → (Prov(⌜φ⌝) → Prov(⌜ψ⌝))
-  (∀ φ ψ : Formula, Provable (impl (Prov (godelNum (impl φ ψ)))
-                                    (impl (Prov (godelNum φ)) (Prov (godelNum ψ))))) ∧
-  -- D3: ⊢ Prov(⌜φ⌝) → Prov(⌜Prov(⌜φ⌝)⌝)
-  (∀ φ : Formula, Provable (impl (Prov (godelNum φ)) (Prov (godelNum (Prov (godelNum φ))))))
-
-/-- D1: If ⊢ φ then ⊢ Prov(⌜φ⌝) -/
-theorem D1 : ∀ φ : Formula, Provable φ → Provable (Prov (godelNum φ)) :=
-  derivability_conditions.1
-
-/-- D2: ⊢ Prov(⌜φ→ψ⌝) → (Prov(⌜φ⌝) → Prov(⌜ψ⌝)) -/
-theorem D2 : ∀ φ ψ : Formula, Provable (impl (Prov (godelNum (impl φ ψ)))
-                                              (impl (Prov (godelNum φ)) (Prov (godelNum ψ)))) :=
-  derivability_conditions.2.1
-
-/-- D3: ⊢ Prov(⌜φ⌝) → Prov(⌜Prov(⌜φ⌝)⌝) -/
-theorem D3 : ∀ φ : Formula, Provable (impl (Prov (godelNum φ)) (Prov (godelNum (Prov (godelNum φ))))) :=
-  derivability_conditions.2.2
+/-
+The Hilbert-Bernays-Löb derivability conditions (D1, D2, D3) are removed here.
+With `Provable := fun _ => False`, asserting `derivability_conditions` (which claims
+∀ φ ψ, Provable (impl ...)) is equivalent to asserting `False` — making the axiom
+inconsistent. A proper formalization would require an opaque or axiomatized Provable
+predicate before these conditions can be meaningfully stated.
+-/
 
 -- ============================================================
 -- PART 9: The Consistency Statement and Second Incompleteness
@@ -456,8 +433,5 @@ end Godel
 #check Godel.lobs_theorem
 #check Godel.G_not_provable
 #check Godel.diagonal_lemma
-#check Godel.D1
-#check Godel.D2
-#check Godel.D3
 #check Godel.Con
 #check Godel.rosser_undecidable

--- a/src/data/proofs/godel-incompleteness/meta.json
+++ b/src/data/proofs/godel-incompleteness/meta.json
@@ -35,15 +35,15 @@
     ],
     "dateAdded": "2025-12-21",
     "wiedijkNumber": 6,
-    "axiomCount": 1,
-    "assumptions": "2 axiom declarations: derivability_conditions (Hilbert-Bernays-Lob conditions), lob_sentence_fixed_point (Lob fixed point existence). G_self_reference is a theorem, not an axiom.",
+    "axiomCount": 0,
+    "assumptions": "No axiom declarations. The derivability_conditions axiom was removed because it was inconsistent with the placeholder Provable := fun _ => False predicate.",
     "prerequisites": [
       "Mathematical logic: formal systems, provability, consistency",
       "Gödel numbering and arithmetization of metamathematics",
       "Diagonalization and self-reference (Diagonal Lemma)",
       "Modal logic of provability (Hilbert-Bernays-Löb conditions)"
     ],
-    "lineCount": 465,
+    "lineCount": 437,
     "proofRepoPath": "Proofs/GodelIncompleteness.lean",
     "mathlib_version": "4.26.0"
   },
@@ -267,10 +267,10 @@
     }
   ],
   "leanFile": {
-    "lineCount": 465,
+    "lineCount": 437,
     "structureCount": 1,
-    "axiomCount": 1,
-    "theoremCount": 12,
+    "axiomCount": 0,
+    "theoremCount": 9,
     "lemmaCount": 0,
     "defCount": 12,
     "imports": [

--- a/src/data/proofs/godel-incompleteness/review.json
+++ b/src/data/proofs/godel-incompleteness/review.json
@@ -129,7 +129,7 @@
       "priority": "medium",
       "target": "researcher",
       "description": "Remove the derivability_conditions axiom if Provable remains const False (it introduces inconsistency). If Provable is made opaque, keep it.",
-      "status": "open"
+      "status": "resolved"
     },
     {
       "id": "ai-6",


### PR DESCRIPTION
## Fix

Removes `axiom derivability_conditions` and the three theorems `D1`, `D2`, `D3` derived from it, from `GodelIncompleteness.lean`.

## Evidence

**Before**: `derivability_conditions` asserts D1/D2/D3. With `Provable := fun _ => False`:
- D2 asserts: `Provable (impl ...)` = `False` — an axiom of `False`
- D3 asserts: `Provable (impl ...)` = `False` — an axiom of `False`

This makes `derivability_conditions` an inconsistent axiom (effectively `False ∧ False ∧ True`).

**After**: Replaced with a comment block explaining the inconsistency. `axiomCount` updated 1→0, `theoremCount` updated 12→9 (D1/D2/D3 removed), `lineCount` 465→437.

Resolves peer review action item ai-5 in `src/data/proofs/godel-incompleteness/review.json`.

---
Automated fix by lean-mechanic agent.