### PR TITLE
Enrich 6 proofs: Vandermonde, Borsuk-Ulam, Glivenko-Cantelli, Euler, Kummer, Roth Quantitative

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-03/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-03/meta.json
@@ -35,14 +35,15 @@
     ]
   },
   "overview": {
-    "historicalContext": "The Borsuk-Ulam theorem (Karol Borsuk, 1933) states that every continuous map f: Sⁿ → ℝⁿ has an antipodal pair: ∃x ∈ Sⁿ: f(x) = f(-x). The 1D case follows from the Intermediate Value Theorem (as shown in BrouwerFixedPointOQ01.lean). For n ≥ 2, the proof requires degree theory or covering spaces. The Ham Sandwich theorem (Stone-Tukey, 1942) is a direct corollary. The theorem is equivalent to the No-Retraction theorem and to the Brouwer Fixed Point theorem, forming a fundamental equivalence chain.",
+    "historicalContext": "The Borsuk-Ulam theorem (Karol Borsuk, 1933) states that every continuous map f: S^n -> R^n has an antipodal pair: there exists x in S^n with f(x) = f(-x). The 1D case is the intermediate value theorem: a continuous real function on [-1,1] that changes sign must vanish. For n >= 2, the general proof requires algebraic topology (degree theory or covering spaces). The Ham Sandwich theorem (Stone and Tukey, 1942) follows as a corollary: any n bounded measurable bodies in R^n can be simultaneously bisected by one hyperplane, proved by applying BU to the volume-difference map. The Borsuk-Ulam theorem is equivalent to the No-Retraction theorem and to the Brouwer Fixed Point theorem, forming a fundamental equivalence chain in algebraic topology. Lovasz (1978) applied BU via the Kneser graph coloring theorem, connecting combinatorics to topology. The Lusternik-Schnirelmann theorem, another BU consequence, gives lower bounds on covering numbers of spheres. The theorem has become one of the most applied results in combinatorial topology and computational geometry.",
     "problemStatement": "OQ-01-OQ-03: The parent entry OQ-01 proved the 1D Borsuk-Ulam theorem via IVT. How does this generalize to n dimensions, and what is the relationship between the n-dimensional Borsuk-Ulam theorem and the Brouwer Fixed Point Theorem?",
     "proofStrategy": "Import BorsukUlam.lean (which axiomatizes the core degree-theory step). Derive: (1) antipodal collapse for odd maps; (2) no odd map to unit sphere; (3) BU implies no-retraction. Axiomatize the Ham Sandwich theorem. Assemble the full equivalence chain.",
     "keyInsights": [
       "Odd functions force sign changes: if f is odd and continuous, f(x) = f(-x) = -f(x) gives 2f(x) = 0",
       "The equivalence BU ↔ No-Odd-Map ↔ No-Retraction ↔ BFP all follow from the same algebraic topology",
       "1D case is elementary (IVT); n ≥ 2 requires degree theory — the BorsukUlam.lean axiom captures exactly this gap",
-      "Ham Sandwich theorem: a beautiful BU corollary requiring Lebesgue measure continuity"
+      "Ham Sandwich theorem: a beautiful BU corollary requiring Lebesgue measure continuity",
+      "The 1D case (IVT) and the n >= 2 case (degree theory) are not just analogs but instances of the same phenomenon: the degree of the map g(x) = f(x) - f(-x) on S^n is 2 (since g(-x) = -g(x) and -1 has degree (-1)^{n+1}), so g cannot be null-homotopic. At n=1, this is precisely IVT's sign-change argument. The axiom no_continuous_odd_nonzero_on_sphere in BorsukUlam.lean captures exactly this degree-theoretic obstruction for all n >= 2."
     ]
   },
   "sections": [

--- a/src/data/proofs/euler-identity-oq-01-oq-01/meta.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-01/meta.json
@@ -85,28 +85,60 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header: Problem Statement and Proof Strategy",
+      "startLine": 1,
+      "endLine": 38,
+      "summary": "Docstring documents the 3 axioms from the parent proof and the strategy for eliminating each. Imports bring in the specific Mathlib modules needed: Trigonometric.Series for cos/sin Taylor series, InfiniteSum.NatInt for tsum_even_add_odd, InfiniteSum.Ring for tsum_mul_right.",
+      "mathContext": "Three axioms to eliminate: (1) $\\sum_n a_n = \\sum_k a_{2k} + \\sum_k a_{2k+1}$; (2) $\\cos x = \\sum_k \\text{evenTerm}(x,k)$; (3) $\\sin x \\cdot i = \\sum_k \\text{oddTerm}(x,k)$. All eliminated via Mathlib's `Complex.cos_eq_tsum`, `Complex.sin_eq_tsum`, and `tsum_even_add_odd`."
+    },
+    {
       "id": "power-series-terms",
-      "title": "Power Series Terms and Algebraic Identities",
-      "startLine": 43,
-      "endLine": 83,
-      "summary": "Reuses the expTerm/evenTerm/oddTerm definitions and algebraic identities for powers of i from the parent proof. Adds expSeries_summable using NormedSpace.expSeries_summable.",
-      "mathContext": "$e^z = \\sum_{n=0}^\\infty \\frac{z^n}{n!}$. Parity split: $i^{2k} = (-1)^k$ and $i^{2k+1} = i(-1)^k$. So $(ix)^{2k}/(2k)! = (-1)^k x^{2k}/(2k)! = \\text{evenTerm}(x,k)$ and $(ix)^{2k+1}/(2k+1)! = i(-1)^k x^{2k+1}/(2k+1)! = \\text{oddTerm}(x,k)$. `expSeries_summable` from `NormedSpace.expSeries_summable`."
+      "title": "Power Series Terms: expTerm, evenTerm, oddTerm",
+      "startLine": 40,
+      "endLine": 52,
+      "summary": "Three noncomputable defs: expTerm z n = z^n/n! (general exponential term), evenTerm x k = (-1)^k x^{2k}/(2k)! (cosine series term), oddTerm x k = i(-1)^k x^{2k+1}/(2k+1)! (sine series term with factor i).",
+      "mathContext": "$e^{ix} = \\sum_n (ix)^n/n!$ splits as $\\sum_k (ix)^{2k}/(2k)! + \\sum_k (ix)^{2k+1}/(2k+1)! = \\cos(x) + i\\sin(x)$ after simplification of powers of $i$."
     },
     {
-      "id": "axiom-elimination",
-      "title": "Axiom Elimination: Three Theorems from Mathlib",
-      "startLine": 85,
-      "endLine": 124,
-      "summary": "Proves the three former axioms as theorems: tsum_even_add_odd_of_summable (via Summable.comp_injective), cos_eq_tsum_thm (via Complex.cos_eq_tsum + ofReal_cos), sin_eq_tsum_thm (via Complex.sin_eq_tsum + ofReal_sin).",
-      "mathContext": "(1) $\\sum_n f(n) = \\sum_k f(2k) + \\sum_k f(2k+1)$ via `Summable.comp_injective` + `tsum_even_add_odd`. (2) $\\cos x = \\sum_k \\frac{(-1)^k x^{2k}}{(2k)!}$: lift from `Complex.cos_eq_tsum` via `ofReal_cos`. (3) $i\\sin x = \\sum_k \\frac{i(-1)^k x^{2k+1}}{(2k+1)!}$: factor $i$ via `tsum_mul_right`."
+      "id": "algebraic-identities",
+      "title": "Algebraic Infrastructure: Powers of i and Series Term Identification",
+      "startLine": 53,
+      "endLine": 82,
+      "summary": "Private lemmas I_pow_even and I_pow_odd compute i^{2k} = (-1)^k and i^{2k+1} = i·(-1)^k. Public theorems expTerm_even and expTerm_odd rewrite (ix)^{2k}/... as evenTerm and (ix)^{2k+1}/... as oddTerm. expSeries_summable derives convergence from NormedSpace.expSeries_summable.",
+      "mathContext": "$i^{2k} = (i^2)^k = (-1)^k$; $i^{2k+1} = i\\cdot(-1)^k$. Summability: $\\sum_n |z^n/n!| < \\infty$ for all $z \\in \\mathbb{C}$ via `NormedSpace.expSeries_summable`."
     },
     {
-      "id": "main-theorems",
-      "title": "Euler's Formula and Identity",
-      "startLine": 126,
+      "id": "axiom1-tsum-split",
+      "title": "Step 1: tsum_even_add_odd_of_summable (Former Axiom 1)",
+      "startLine": 84,
+      "endLine": 97,
+      "summary": "Proves summable series splits into even/odd parts. Strategy: apply Summable.comp_injective to injective maps k↦2k and k↦2k+1 to get subseries summability, then apply Mathlib's tsum_even_add_odd.symm.",
+      "mathContext": "$\\sum_n a_n = \\sum_k a_{2k} + \\sum_k a_{2k+1}$ for summable $(a_n)$. `Summable.comp_injective`: $f$ summable + $g$ injective $\\Rightarrow$ $f \\circ g$ summable. Both $k\\mapsto 2k$ and $k\\mapsto 2k+1$ are injective (proved by `omega`)."
+    },
+    {
+      "id": "axiom2-cos-series",
+      "title": "Step 2: cos_eq_tsum_thm (Former Axiom 2)",
+      "startLine": 99,
+      "endLine": 109,
+      "summary": "Proves cos(x) = ∑_k evenTerm(x,k) for real x. Lifts Complex.cos_eq_tsum from ℂ to ℝ via ofReal_cos, then matches terms via tsum_congr + simp.",
+      "mathContext": "$\\cos(x) = \\sum_k \\frac{(-1)^k x^{2k}}{(2k)!}$. Proof: `rw [ofReal_cos, Complex.cos_eq_tsum]` + `tsum_congr` to match evenTerm definitions. Single `simp` closes each term."
+    },
+    {
+      "id": "axiom3-sin-series",
+      "title": "Step 3: sin_eq_tsum_thm (Former Axiom 3)",
+      "startLine": 110,
+      "endLine": 121,
+      "summary": "Proves sin(x)·i = ∑_k oddTerm(x,k) for real x. Lifts Complex.sin_eq_tsum via ofReal_sin, factors i out of sum via ← tsum_mul_right, then ring closes each term.",
+      "mathContext": "$\\sin(x) \\cdot i = \\sum_k i(-1)^k x^{2k+1}/(2k+1)!$. `rw [← tsum_mul_right]` factors $i$: $(\\sum_k f_k) \\cdot i = \\sum_k (f_k \\cdot i)$. `ring` closes each oddTerm identification."
+    },
+    {
+      "id": "main-results",
+      "title": "Corollary: Axiom-Free Euler Formula and Identity",
+      "startLine": 123,
       "endLine": 142,
-      "summary": "euler_formula: e^(ix) = cos(x) + i*sin(x) via Complex.exp_mul_I. euler_identity: e^(iπ)+1=0 via cos(π)=-1, sin(π)=0.",
-      "mathContext": "$e^{ix} = \\cos x + i\\sin x$ via `Complex.exp_mul_I`. $e^{i\\pi} + 1 = 0$: substitute $x=\\pi$, use $\\cos(\\pi)=-1$ and $\\sin(\\pi)=0$. Both proofs: 0 axioms, 0 sorries. Note: `Complex.exp_mul_I` bridges `NormedSpace.exp` and `Complex.exp`, the subtle gap in the fully-from-scratch Taylor proof."
+      "summary": "euler_formula: e^(ix) = cos(x) + i*sin(x) via Complex.exp_mul_I (1-line proof). euler_identity: e^(iπ)+1=0 via cos(π)=-1, sin(π)=0, push_cast + ring.",
+      "mathContext": "`Complex.exp_mul_I x : Complex.exp (↑x * I) = ↑(cos x) + ↑(sin x) * I`. The NormedSpace.exp/Complex.exp identification is handled inside Mathlib. $e^{i\\pi}+1 = (-1)+1 = 0$ from $\\cos(\\pi)=-1$, $\\sin(\\pi)=0$."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/four-color-theorem-oq-02/annotations.json
+++ b/src/data/proofs/four-color-theorem-oq-02/annotations.json
@@ -14,7 +14,7 @@
   {
     "id": "ann-fct02-birkhoff-diamond",
     "proofId": "four-color-theorem-oq-02",
-    "range": { "startLine": 60, "endLine": 65 },
+    "range": { "startLine": 61, "endLine": 65 },
     "type": "insight",
     "title": "Birkhoff Diamond: First Reducible Configuration (1913)",
     "content": "The Birkhoff diamond (ringSize=6, interiorSize=4) is the simplest non-trivial reducible configuration, discovered by George Birkhoff in 1913. It consists of a hexagonal ring with 4 interior vertices forming a diamond shape. Birkhoff showed that any 4-coloring of the 6-vertex ring can be extended to the 4 interior vertices, which was a key step toward the eventual proof of the Four Color Theorem. The diamond has the smallest ring size of any known reducible configuration.",

--- a/src/data/proofs/four-color-theorem-oq-02/meta.json
+++ b/src/data/proofs/four-color-theorem-oq-02/meta.json
@@ -42,28 +42,44 @@
   },
   "sections": [
     {
-      "id": "background",
-      "title": "Background and Historical Progression",
+      "id": "header",
+      "title": "Module Header: Configuration Theory Overview",
       "startLine": 1,
       "endLine": 22,
-      "summary": "Documents the Four Color Theorem proof strategy (unavoidable + reducible), the historical reduction from 1936 to 1476 to 633 configurations (Appel-Haken 1977, RSST 1997), and the open question about the minimum set size.",
-      "mathContext": "Proof strategy: find unavoidable set $S$ (every planar graph contains a member) + reducible set (each member's ring coloring extends to interior). Counts: $|S| = 1936$ (Appel-Haken 1977) $\\to 1476 \\to 633$ (RSST 1997). Gonthier's Coq proof (2008): first formal verification."
+      "summary": "Docstring presents the open question (minimum unavoidable set size) and the historical progression: Appel-Haken 1977 (1936 configs) → revised (1476) → Robertson-Sanders-Seymour-Thomas 1997 (633 configs). Sets up the two-part structure.",
+      "mathContext": "4CT proof structure: (1) find unavoidable set $S$ (every planar graph contains a member of $S$), (2) prove each member is reducible (4-coloring extends through it). Size of $S$: 1936 → 1476 → 633. Minimum possible size unknown."
     },
     {
-      "id": "configuration-theory",
-      "title": "Configuration Structure and Definitions",
-      "startLine": 24,
+      "id": "configuration-definitions",
+      "title": "Part I: Configuration, IsReducible, IsUnavoidable",
+      "startLine": 28,
+      "endLine": 46,
+      "summary": "Configuration structure: ringSize and interiorSize (positive). IsReducible (currently True stub): any 4-coloring of the ring extends through the interior. IsUnavoidable (True stub): every minimum-degree-5 planar graph contains a member.",
+      "mathContext": "A configuration is a planar subgraph with a ring of $r$ boundary vertices and $k$ interior vertices. Reducible: for any 4-coloring of the ring, some recoloring extends to the interior. Unavoidable: $\\forall G$ planar, $G \\supseteq C$ for some $C \\in S$."
+    },
+    {
+      "id": "unavoidable-sets",
+      "title": "Part II: RSST Set and Birkhoff Diamond",
+      "startLine": 52,
       "endLine": 65,
-      "summary": "Defines Configuration structure (ringSize, interiorSize, ring_ge ≥ 2). IsReducible and IsUnavoidable are stubbed as True. Instantiates birkhoffDiamond (ringSize=6, interiorSize=4), the first historically discovered reducible configuration.",
-      "mathContext": "A configuration $C = (G, \\gamma)$: ring $\\gamma$ of size $r \\ge 2$, interior vertices. `IsReducible C`: every proper 4-coloring of $\\gamma$ extends to $G$ (stub: True). Birkhoff diamond: $r = 6$, $\\text{interior} = 4$ — smallest known reducible configuration. Reducibility check: $\\le 3^r/r$ distinct ring colorings."
+      "summary": "small_ring_not_needed: no configuration with ring size <= 3 is needed (trivial proof). birkhoffDiamond definition: ring size 6, interior size 4 — the first reducible configuration (Birkhoff 1913).",
+      "mathContext": "The Birkhoff diamond: 6-ring, 4 interior vertices, smallest known essential configuration. `small_ring_not_needed`: ring size $\\leq 3$ configurations are vacuously unnecessary (True stub proving the formal statement)."
     },
     {
-      "id": "bounds-and-tradeoffs",
-      "title": "Known Bounds and Computational Obstacles",
+      "id": "lower-bound",
+      "title": "Lower Bound: At Least 10 Configurations Needed",
       "startLine": 67,
-      "endLine": 93,
-      "summary": "Documents the three obstacles to reducing below 633: exponential reducibility checking cost (ring size), discharging rule adjustment for unavoidability, and the size/ring-size trade-off. Heuristic lower bound ~200-400.",
-      "mathContext": "Discharging: assign charge $6 - \\deg(v)$ to each vertex; by Euler's formula $\\sum_v (6-\\deg v) = 12 > 0$. Reducibility cost: $O(3^r)$ for ring size $r$. RSST uses rings up to size 11. Minimum $|S|$ unknown; heuristic estimates: $200 \\le |S_{\\min}| \\le 400$."
+      "endLine": 69,
+      "summary": "Documents the lower bound: any unavoidable reducible set needs >= 10 configurations. Follows from density arguments — each configuration appears in at most 1/10 of faces in some planar graph.",
+      "mathContext": "$|S| \\geq 10$ for any unavoidable reducible $S$. Argument: for some planar graph $G$, each $C\\in S$ appears in $\\leq |F(G)|/10$ faces of $G$. But $|S|$ must cover all faces, forcing $|S| \\geq 10$."
+    },
+    {
+      "id": "open-question-discussion",
+      "title": "Open Question: Can 633 Be Reduced Further?",
+      "startLine": 70,
+      "endLine": 91,
+      "summary": "Analysis of obstacles to reducing below 633 configurations: (1) computational constraint — reducibility checking grows exponentially with ring size; (2) unavoidability constraint — removing configs requires new discharging rules; (3) inherent trade-off — fewer configs typically means larger ring sizes.",
+      "mathContext": "Minimum set size: lower bound ~10 (theoretical), heuristic lower bound ~200-400, current best 633 (RSST). The trade-off: fewer configurations $\\Rightarrow$ larger ring sizes $\\Rightarrow$ harder reducibility checking (exponential in ring size)."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/kummer-theorem-oq-01/meta.json
+++ b/src/data/proofs/kummer-theorem-oq-01/meta.json
@@ -43,25 +43,52 @@
   },
   "sections": [
     {
-      "id": "setup",
-      "title": "Module Header and Mathematical Overview",
+      "id": "header",
+      "title": "Module Header: Imports and Mathematical Overview",
       "startLine": 1,
-      "endLine": 22,
-      "summary": "Imports Mathlib and provides a detailed docstring explaining the open question (can Kummer's theorem extend to multinomials?), the iterated binomial decomposition identity, and the key results to be proved."
+      "endLine": 31,
+      "summary": "Imports Mathlib and the Aristotle companion file KummerTheoremOQ01Aristotle. Docstring explains the open question (can Kummer extend to multinomials?), the iterated binomial decomposition identity, and the three key results.",
+      "mathContext": "$v_p\\binom{n}{k} = $ carries adding $k$ and $n-k$ in base $p$ (Kummer 1852). Extension: $v_p\\binom{n}{k_1,\\ldots,k_m} = $ total carries adding $k_1,\\ldots,k_m$ in base $p$ via the telescoping product $\\prod_i\\binom{S_i}{k_i}$."
     },
     {
       "id": "definition",
-      "title": "Multinomial Coefficient Definition",
-      "startLine": 24,
-      "endLine": 33,
-      "summary": "Defines `multinomial (ks : List ℕ) : ℕ` as `(ks.sum).factorial / (ks.map Nat.factorial).prod` — i.e., n! / (k₁! · k₂! · ... · kₘ!). Marked `noncomputable` due to natural number division."
+      "title": "Multinomial Coefficient: n! / (k₁! · ... · kₘ!)",
+      "startLine": 33,
+      "endLine": 36,
+      "summary": "Defines multinomial (ks : List ℕ) : ℕ as (ks.sum).factorial / (ks.map Nat.factorial).prod. Marked noncomputable because Lean's kernel does not evaluate natural number division with classical logic.",
+      "mathContext": "$\\binom{n}{k_1,\\ldots,k_m} = \\frac{n!}{k_1! \\cdots k_m!}$ where $n = \\sum k_i$. Lean: `(ks.sum).factorial / (ks.map Nat.factorial).prod` using List.sum and List.prod."
     },
     {
-      "id": "decomposition",
-      "title": "Binomial Factorization and Pair/Triple Cases",
-      "startLine": 35,
-      "endLine": 68,
-      "summary": "Three theorems, all proved: (1) `multinomial_eq_prod_choose` — general decomposition via scanl/zip, proved by importing companion file `KummerTheoremOQ01Aristotle.lean`; (2) `multinomial_pair` — binomial case proved via `Nat.choose_mul_factorial_mul_factorial`; (3) `multinomial_triple` — trinomial case proved via two applications of `choose_mul_factorial_mul_factorial`. Plus `kummer_multinomial_statement` stub returning True (p-adic valuation statement, open)."
+      "id": "general-decomposition",
+      "title": "multinomial_eq_prod_choose: General Factorization via scanl/zip",
+      "startLine": 38,
+      "endLine": 50,
+      "summary": "Proves the general decomposition: multinomial ks = product over (acc, k) pairs in (scanl(+,0,ks).zip(ks)).tail of C(acc+k, k). Delegates to KummerTheoremOQ01Aristotle companion file (proved by backward list induction).",
+      "mathContext": "$\\binom{n}{k_1,\\ldots,k_m} = \\prod_{i=1}^{m}\\binom{k_1+\\cdots+k_i}{k_i}$. scanl $(+)$ 0 $[k_1,k_2,k_3]$ = $[0,k_1,k_1+k_2,k_1+k_2+k_3]$; tail of zip with $ks$ gives pairs $(k_1,k_2), (k_1+k_2,k_3)$, etc."
+    },
+    {
+      "id": "pair-case",
+      "title": "multinomial_pair: Binomial Case is Nat.choose",
+      "startLine": 52,
+      "endLine": 69,
+      "summary": "Proves multinomial [a, b] = Nat.choose (a+b) a. Key step: choose_mul_factorial_mul_factorial gives C(a+b,a)·a!·b! = (a+b)!, then Nat.mul_div_cancel converts factorial division to Nat.choose.",
+      "mathContext": "$\\binom{a+b}{a,b} = \\binom{a+b}{a}$. From $\\binom{a+b}{a}\\cdot a!\\cdot b! = (a+b)!$: $\\frac{(a+b)!}{a!\\cdot b!} = \\binom{a+b}{a}$ by `Nat.mul_div_cancel`."
+    },
+    {
+      "id": "triple-case",
+      "title": "multinomial_triple: Trinomial is Product of Two Binomials",
+      "startLine": 71,
+      "endLine": 99,
+      "summary": "Proves multinomial [a, b, c] = C(a+b,a) * C(a+b+c,a+b). Uses choose_mul_factorial_mul_factorial twice in a calc block: both sides times (a!·b!·c!) equal (a+b+c)!, then Nat.mul_div_cancel concludes.",
+      "mathContext": "$\\binom{a+b+c}{a,b,c} = \\binom{a+b}{a}\\binom{a+b+c}{a+b}$. Proof: $\\binom{a+b}{a}\\binom{a+b+c}{a+b}\\cdot a!b!c! = \\binom{a+b+c}{a+b}\\cdot(a+b)!\\cdot c! = (a+b+c)!$ by chaining the two applications of `choose_mul_factorial_mul_factorial`."
+    },
+    {
+      "id": "kummer-statement",
+      "title": "kummer_multinomial_statement: Honest Placeholder for Open Theorem",
+      "startLine": 101,
+      "endLine": 108,
+      "summary": "Returns True — an honest placeholder documenting the p-adic valuation statement (v_p of multinomial = total carries in base-p addition) without proof, since base-p carry formalism is not in Mathlib.",
+      "mathContext": "Open formalization: $v_p\\binom{n}{k_1,\\ldots,k_m} = \\sum_{i=1}^{m} c(k_i, k_1+\\cdots+k_{i-1};p)$ where $c(a,b;p)$ counts carries when adding $a$ and $b$ in base $p$. Would follow from $v_p(\\prod_i\\binom{S_i}{k_i}) = \\sum_i v_p\\binom{S_i}{k_i}$ and Kummer's theorem for each factor."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/laws-of-large-numbers-oq-04/annotations.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-04/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-gc-definitions",
+    "proofId": "laws-of-large-numbers-oq-04",
+    "range": { "startLine": 46, "endLine": 56 },
+    "type": "definition",
+    "title": "Three Core Definitions: empiricalCDF, trueCDF, thresholdIndicator",
+    "content": "The formalization rests on three noncomputable definitions. `empiricalCDF X n x ω` = (1/n) * Σᵢ₌₀ⁿ⁻¹ 1_{Xᵢ(ω) ≤ x} — the fraction of the first n samples falling at or below threshold x. `trueCDF X μ x` = (μ{ω | X 0 ω ≤ x}).toReal — the true probability mass below x. `thresholdIndicator X x i ω` = 1_{Xᵢ(ω) ≤ x} — the individual indicator for sample i at threshold x.\n\nThe key design choice: thresholdIndicator is defined as Set.indicator (Set.Iic x) (fun _ => 1) ∘ X i, making it a composition. This composition form is exactly what iIndepFun.comp and IdentDistrib.comp require to transfer i.i.d. structure from X to the indicators — it lets SLLN be applied directly.",
+    "mathContext": "$\\hat{F}_n(x, \\omega) = \\frac{1}{n}\\sum_{i=0}^{n-1} \\mathbf{1}_{X_i(\\omega) \\leq x}$; $F(x) = \\mu\\{\\omega : X_0(\\omega) \\leq x\\}$; $\\phi_x(v) = \\mathbf{1}_{v \\leq x}$ so $\\hat{F}_n(x) = \\frac{1}{n}\\sum_i \\phi_x \\circ X_i$",
+    "significance": "key",
+    "relatedConcepts": ["empirical distribution function", "indicator function", "Set.Iic", "thresholdIndicator composition"],
+    "prerequisites": ["measure theory", "probability spaces in Lean 4", "Set.indicator", "noncomputable definitions"]
+  },
+  {
+    "id": "ann-gc-basic-identities",
+    "proofId": "laws-of-large-numbers-oq-04",
+    "range": { "startLine": 60, "endLine": 68 },
+    "type": "technique",
+    "title": "Bridge Theorems: empiricalCDF as Sample Mean, thresholdIndicator as Composition",
+    "content": "`empiricalCDF_eq_mean` proves that empiricalCDF X n x ω equals the sum-over-range form divided by n. This bridges the definition (which uses a multiplicative (1/n) factor) to the standard form that strong_law_ae_real expects (sum divided by n). The `ring` tactic closes it in one step.\n\n`thresholdIndicator_eq_comp` proves that thresholdIndicator X x i equals the pointwise composition Set.indicator(Iic x) ∘ X i. This 'unwrapping' is essential for applying iIndepFun.comp and IdentDistrib.comp — those Mathlib lemmas require the composition form explicitly.",
+    "mathContext": "$\\text{empiricalCDF}(X, n, x, \\omega) = \\frac{\\sum_{i < n} \\text{thresholdIndicator}(X, x, i, \\omega)}{n}$; $\\text{thresholdIndicator}(X, x, i) = (\\mathbf{1}_{\\cdot \\leq x}) \\circ X_i$",
+    "significance": "supporting",
+    "relatedConcepts": ["ring tactic", "function composition", "strong_law_ae_real API", "iIndepFun.comp precondition"],
+    "prerequisites": ["Lean 4 ring tactic", "function extensionality", "Set.indicator"]
+  },
+  {
+    "id": "ann-gc-iid-structure",
+    "proofId": "laws-of-large-numbers-oq-04",
+    "range": { "startLine": 79, "endLine": 96 },
+    "type": "insight",
+    "title": "I.I.D. Transfer via Composition: From X to Threshold Indicators",
+    "content": "This is the conceptual core of the pointwise convergence proof. To apply SLLN to the threshold indicators 1_{Xᵢ ≤ x}, we need them to be (a) identically distributed and (b) pairwise independent.\n\n`thresholdIndicator_identDistrib` deduces (a) from IdentDistrib of the X i: since X i and X 0 have the same law, any measurable function of them does too. The proof is (hident i).comp (measurable_iic_indicator x) — a single term.\n\n`thresholdIndicator_pairwise_indep` deduces (b) from iIndepFun X μ: first apply hX_iid.comp to get iIndepFun for the indicators (using measurability of 1_{· ≤ x}), then extract pairwise independence via indepFun. The Lean 4 version of this is: first get the full mutual independence of the indicators, then project to pairwise independence.\n\nThis composition pattern — g_x ∘ X_i inherits i.i.d. from X_i for any measurable g_x — is the fundamental transfer lemma for empirical process theory.",
+    "mathContext": "$\\text{IdentDistrib}(X_i, X_0) \\Rightarrow \\text{IdentDistrib}(\\phi_x \\circ X_i, \\phi_x \\circ X_0)$ (via `.comp`); $\\text{iIndepFun}(X) \\Rightarrow \\text{iIndepFun}(\\phi_x \\circ X)$ (via `.comp`) $\\Rightarrow$ pairwise independence",
+    "significance": "key",
+    "relatedConcepts": ["IdentDistrib.comp", "iIndepFun.comp", "iIndepFun.indepFun", "composition of i.i.d. random variables"],
+    "prerequisites": ["probability theory — i.i.d.", "Mathlib.Probability.Independence.Basic", "Mathlib.Probability.IdentDistrib"]
+  },
+  {
+    "id": "ann-gc-axioms",
+    "proofId": "laws-of-large-numbers-oq-04",
+    "range": { "startLine": 100, "endLine": 111 },
+    "type": "concept",
+    "title": "Integration Axioms: Integrability and E[1_{X₀ ≤ x}] = F(x)",
+    "content": "`thresholdIndicator_integrable` states that 1_{X₀ ≤ x} is integrable on a probability space. This is a standard fact: a bounded measurable function on a finite-measure space is integrable. The proof would use that |1_{X₀ ≤ x}| ≤ 1 (bounded) and the space has finite measure (IsProbabilityMeasure). Axiomatized because navigating Mathlib's MeasureTheory.Integrable API for indicator functions requires significant boilerplate.\n\n`integral_thresholdIndicator_eq_cdf` is the key identity: ∫ 1_{X₀ ≤ x} dμ = μ{X₀ ≤ x} = F(x). This follows from integral_indicator_const and measurability of {ω | X₀ ω ≤ x}. It connects the SLLN output (which gives the integral as the limit) to the trueCDF definition. Together these two axioms bridge measure-theoretic integration and probabilistic CDF notation.",
+    "mathContext": "$\\int_\\Omega \\mathbf{1}_{X_0(\\omega) \\leq x}\\,d\\mu(\\omega) = \\mu\\{\\omega : X_0(\\omega) \\leq x\\} = F(x)$ (via integral_indicator_const and measurability of the preimage set)",
+    "significance": "supporting",
+    "relatedConcepts": ["integral_indicator_const", "MeasureTheory.Integrable", "IsProbabilityMeasure", "preimage measurability"],
+    "prerequisites": ["measure theory — Lebesgue integration", "Mathlib.MeasureTheory.Integral.Bochner", "bounded functions on finite-measure spaces"]
+  },
+  {
+    "id": "ann-gc-slln-application",
+    "proofId": "laws-of-large-numbers-oq-04",
+    "range": { "startLine": 115, "endLine": 136 },
+    "type": "technique",
+    "title": "Pointwise Convergence: Orchestrating SLLN for Threshold Indicators",
+    "content": "This is the fully proved centerpiece. The proof orchestrates four ingredients:\n1. `thresholdIndicator_integrable` → the Y_i = 1_{Xᵢ ≤ x} are integrable\n2. `thresholdIndicator_pairwise_indep` → the Y_i are pairwise independent\n3. `thresholdIndicator_identDistrib` → the Y_i are identically distributed\n4. `strong_law_ae_real` → (Σᵢ Y_i)/n → E[Y_0] a.s.\n\nThen `integral_thresholdIndicator_eq_cdf` identifies E[Y_0] = F(x), so the limit is trueCDF X μ x. The final steps use `filter_upwards` + `convert` to match the form of the SLLN output to empiricalCDF_eq_mean.\n\nThe `rw [integral_thresholdIndicator_eq_cdf hX_meas x] at hslln` is the critical rewrite — it transforms the abstract 'converges to its expectation' statement into 'converges to trueCDF X μ x'.",
+    "mathContext": "`strong_law_ae_real` gives: $\\frac{1}{n}\\sum_{i=0}^{n-1} \\mathbf{1}_{X_i \\leq x} \\xrightarrow{a.s.} \\mathbb{E}[\\mathbf{1}_{X_0 \\leq x}] = F(x)$. Rewrites via `integral_thresholdIndicator_eq_cdf` then `filter_upwards` + `convert`.",
+    "significance": "key",
+    "relatedConcepts": ["strong_law_ae_real", "filter_upwards", "Filter.Tendsto", "almost sure convergence", "Mathlib.Probability.StrongLaw"],
+    "prerequisites": ["Mathlib.Probability.StrongLaw", "filter_upwards tactic", "Filter.Tendsto in Lean 4"]
+  },
+  {
+    "id": "ann-gc-uniform",
+    "proofId": "laws-of-large-numbers-oq-04",
+    "range": { "startLine": 140, "endLine": 157 },
+    "type": "insight",
+    "title": "Glivenko-Cantelli Axiom: The Bracketing Argument for Uniform Convergence",
+    "content": "The uniform convergence step — sup_x |Fₙ(x) - F(x)| → 0 a.s. — is axiomatized because the finite bracketing argument requires infrastructure not available in Mathlib 4.26.\n\nThe classical proof: for ε > 0, choose continuity points q₁ < ... < qₖ of F that form an ε-dense partition (F(qⱼ₊₁) - F(qⱼ) < ε). Each continuity point satisfies |Fₙ(qⱼ) - F(qⱼ)| → 0 a.s. by pointwise convergence. The finite intersection of these a.s. events is still a.s., so for large enough n, all grid errors are < ε. For any x ∈ [qⱼ, qⱼ₊₁), monotonicity of both Fₙ and F gives |Fₙ(x) - F(x)| ≤ max_j |Fₙ(qⱼ) - F(qⱼ)| + ε.\n\nThe Lean gap: formalizing the finite covering argument requires Mathlib lemmas about continuity points of monotone functions and their density, which are not yet in Mathlib 4.26.",
+    "mathContext": "For $j \\leq x < q_{j+1}$: $F_n(x) - F(x) \\leq F_n(q_{j+1}) - F(q_j) \\leq (F_n(q_{j+1}) - F(q_{j+1})) + \\varepsilon$; similarly $F(x) - F_n(x) \\leq (F(q_j) - F_n(q_j)) + \\varepsilon$. So $\\sup_x|F_n - F| \\leq \\max_j|F_n(q_j) - F(q_j)| + \\varepsilon \\to \\varepsilon$ a.s.",
+    "significance": "key",
+    "relatedConcepts": ["bracketing number", "epsilon-net argument", "uniformly consistent estimator", "sup norm convergence", "VC theory"],
+    "prerequisites": ["uniform convergence", "monotone function continuity points", "finite intersection of a.s. events"]
+  },
+  {
+    "id": "ann-gc-monotonicity",
+    "proofId": "laws-of-large-numbers-oq-04",
+    "range": { "startLine": 161, "endLine": 207 },
+    "type": "concept",
+    "title": "Structural Properties: Monotonicity, Non-negativity, and Pointwise Error Decay",
+    "content": "Four structural theorems establish properties needed for the bracketing argument. `empiricalCDF_mono` and `trueCDF_mono` prove that both CDFs are non-decreasing in x — this is exactly the monotonicity used in the uniform convergence bracketing. For empiricalCDF, the proof applies Finset.sum_le_sum + Set.indicator_le_indicator_of_subset with Iic_subset_Iic.mpr hxy. For trueCDF, it uses ENNReal.toReal_mono + measure_mono.\n\n`empiricalCDF_nonneg` and `trueCDF_nonneg` establish that CDF values lie in [0,1). The nonneg bounds are needed to ensure |Fₙ(x) - F(x)| is a well-formed absolute value.\n\n`empiricalCDF_error_vanishes` packages the pointwise convergence result into the form 'Fₙ(x) - F(x) → 0 a.s.', which is useful for the bracketing step: once the centered error vanishes, taking sup over a finite grid is straightforward.",
+    "mathContext": "$0 \\leq F_n(x) \\leq 1$, $0 \\leq F(x) \\leq 1$; $x \\leq y \\Rightarrow F_n(x) \\leq F_n(y)$ and $F(x) \\leq F(y)$. `empiricalCDF_error_vanishes`: $F_n(x, \\omega) - F(x) \\to 0$ a.s., derived from `empiricalCDF_pointwise_convergence` via `.sub_const`.",
+    "significance": "supporting",
+    "relatedConcepts": ["ENNReal.toReal_mono", "measure_mono", "Set.Iic_subset_Iic", "Finset.sum_le_sum", "indicator_le_indicator_of_subset"],
+    "prerequisites": ["monotone functions", "ENNReal in Lean 4", "Finset.sum_le_sum API"]
+  }
+]

--- a/src/data/proofs/laws-of-large-numbers-oq-04/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-04/meta.json
@@ -45,7 +45,7 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The Glivenko-Cantelli theorem, proved independently by Valery Glivenko and Francesco Cantelli in 1933, establishes the fundamental statistical fact that the empirical distribution function is a uniformly consistent estimator of the true distribution function. This result is foundational for nonparametric statistics, as it guarantees that the empirical CDF—the most natural nonparametric estimator—converges to the true CDF not just at each individual point, but uniformly over all thresholds simultaneously. The theorem is often called the 'fundamental theorem of statistics'. It was later substantially generalized by Vapnik and Chervonenkis (1971) to classes of sets beyond half-lines, leading to VC theory and statistical learning theory.",
+    "historicalContext": "The Glivenko-Cantelli theorem was proved independently by Valery Glivenko ('Sulla determinazione empirica delle leggi di probabilita', 1933) and Francesco Cantelli (same journal, same year) — a remarkable simultaneous discovery. It establishes that the empirical distribution function is a uniformly consistent estimator: for any i.i.d. sequence, the empirical CDF converges to the true CDF not pointwise but uniformly over all thresholds simultaneously. The theorem is often called the 'fundamental theorem of statistics'. The pointwise version (for each fixed x) follows immediately from the Strong Law of Large Numbers applied to Bernoulli indicators; the uniform step requires the additional argument that a monotone function converging pointwise on a dense grid converges uniformly everywhere — a finite bracketing argument using continuity points of F.\n\nThe theorem was substantially generalized by Vapnik and Chervonenkis (1971) to arbitrary classes of measurable sets with finite VC dimension, founding statistical learning theory and PAC learning. The Donsker (1952) invariance principle gives the quantitative refinement: √n(Fₙ - F) converges weakly to a Brownian bridge process, providing rates of convergence and underpinning the Kolmogorov-Smirnov test. The Glivenko-Cantelli theorem is thus the gateway to empirical process theory.",
     "problemStatement": "For i.i.d. real-valued random variables X₁, X₂, ... from distribution F, define the empirical CDF Fₙ(x) = (1/n)|{i ≤ n : Xᵢ ≤ x}|. Then sup_{x∈ℝ} |Fₙ(x) - F(x)| → 0 almost surely as n → ∞.",
     "text": "The empirical CDF converges uniformly to the true CDF almost surely for any i.i.d. sequence.",
     "proofStrategy": "The formalization proceeds in two stages. Stage 1 (proved): For each fixed threshold x, the indicators 1_{Xᵢ ≤ x} are i.i.d. Bernoulli(F(x)) random variables. Applying Mathlib's `strong_law_ae_real` gives Fₙ(x) → F(x) a.s. for each x. Stage 2 (axiomatized): For ε > 0, choose finitely many continuity points q₁,...,qₖ of F partitioning ℝ with F-mass < ε per interval. Pointwise convergence holds simultaneously on the finite grid a.s. (finite intersection). For any x between grid points, monotonicity gives |Fₙ(x) - F(x)| ≤ max_j |Fₙ(qⱼ) - F(qⱼ)| + ε, establishing uniform convergence. The bracketing argument is axiomatized as `glivenko_cantelli_uniform` since the finite covering infrastructure is not available in Mathlib 4.26.",
@@ -65,43 +65,59 @@
   "sections": [
     {
       "id": "definitions",
-      "title": "Empirical and True CDF Definitions",
+      "title": "Definitions: empiricalCDF, trueCDF, thresholdIndicator",
       "startLine": 44,
       "endLine": 56,
-      "summary": "Defines empiricalCDF as the sample mean of threshold indicators, trueCDF as μ{ω | X₀(ω) ≤ x}.toReal, and thresholdIndicator as the composition of X_i with the Iic indicator function.",
-      "mathContext": "empiricalCDF X n x ω = (1/n) * Σᵢ 1_{Xᵢ(ω) ≤ x}; trueCDF X μ x = (μ{ω | X₀(ω) ≤ x}).toReal"
+      "summary": "Defines empiricalCDF as the sample mean of threshold indicators, trueCDF as μ{ω | X₀(ω) ≤ x}.toReal, and thresholdIndicator as Set.indicator(Iic x) ∘ X i.",
+      "mathContext": "$\\hat{F}_n(x, \\omega) = \\frac{1}{n}\\sum_{i<n}\\mathbf{1}_{X_i(\\omega)\\leq x}$; $F(x) = \\mu\\{X_0 \\leq x\\}$; composition form enables iIndepFun.comp."
     },
     {
-      "id": "measurability",
-      "title": "Measurability of Indicator Functions",
+      "id": "basic-identities",
+      "title": "Bridge Identities: empiricalCDF as Mean, Indicator as Composition",
+      "startLine": 58,
+      "endLine": 68,
+      "summary": "empiricalCDF_eq_mean links the definition form to the sum/n form needed by SLLN. thresholdIndicator_eq_comp exposes the composition structure for iIndepFun.comp.",
+      "mathContext": "$\\hat{F}_n(x,\\omega) = \\frac{1}{n}\\sum_{i<n}\\phi_x(X_i(\\omega))$ where $\\phi_x = \\mathbf{1}_{\\cdot\\leq x}$; both proved by ring/ext + simp."
+    },
+    {
+      "id": "measurability-and-iid",
+      "title": "Measurability, I.D., and Independence of Threshold Indicators",
       "startLine": 70,
-      "endLine": 75,
-      "summary": "Proves measurability of x ↦ 1_{v ≤ x} as a real-valued Borel function, using measurable_const.indicator measurableSet_Iic.",
-      "mathContext": "The composition structure thresholdIndicator X x i = (1_{· ≤ x}) ∘ X i is key for applying iIndepFun.comp."
+      "endLine": 96,
+      "summary": "Three lemmas: measurable_iic_indicator (Borel measurability of v ↦ 1_{v ≤ x}), thresholdIndicator_identDistrib (IdentDistrib.comp transfers equal laws), thresholdIndicator_pairwise_indep (iIndepFun.comp + indepFun gives pairwise independence).",
+      "mathContext": "$\\phi_x: \\mathbb{R}\\to\\mathbb{R}$ measurable; $X_i \\sim X_0 \\Rightarrow \\phi_x\\circ X_i \\sim \\phi_x\\circ X_0$; $\\text{iIndepFun}(X) \\Rightarrow \\text{iIndepFun}(\\phi_x\\circ X) \\Rightarrow$ pairwise indep."
     },
     {
-      "id": "iid-structure",
-      "title": "I.I.D. Structure of Threshold Indicators",
-      "startLine": 77,
-      "endLine": 96,
-      "summary": "Proves identical distribution via IdentDistrib.comp, and pairwise independence via iIndepFun.comp + iIndepFun.indepFun. These are the two key hypotheses for SLLN.",
-      "mathContext": "If X_i ~ X₀ (IdentDistrib) and X_i are iIndepFun, then 1_{Xᵢ ≤ x} ~ 1_{X₀ ≤ x} and are pairwise independent."
+      "id": "axioms",
+      "title": "Integration Axioms: Integrability and E[1_{X₀ ≤ x}] = F(x)",
+      "startLine": 98,
+      "endLine": 111,
+      "summary": "thresholdIndicator_integrable: bounded measurable function on probability space is integrable. integral_thresholdIndicator_eq_cdf: E[1_{X₀ ≤ x}] = μ{X₀ ≤ x} = F(x). Both axiomatized due to Mathlib 4.26 API gaps.",
+      "mathContext": "$\\int_\\Omega \\mathbf{1}_{X_0(\\omega)\\leq x}\\,d\\mu = \\mu\\{X_0 \\leq x\\} = F(x)$; both follow from integral_indicator_const + measurability."
     },
     {
       "id": "pointwise-convergence",
-      "title": "Pointwise Convergence via SLLN",
+      "title": "Pointwise Convergence: SLLN Applied to Threshold Indicators",
       "startLine": 113,
       "endLine": 136,
-      "summary": "PROVED: For each fixed x, Fₙ(x) → F(x) a.s. Applies strong_law_ae_real to threshold indicators, then uses integral_thresholdIndicator_eq_cdf to identify the limit as trueCDF.",
-      "mathContext": "strong_law_ae_real gives (Σᵢ 1_{Xᵢ ≤ x})/n → E[1_{X₀ ≤ x}] = F(x) a.s. Requires pairwise independence and identical distribution."
+      "summary": "PROVED: For each fixed x, Fₙ(x) → F(x) a.s. Orchestrates the three i.i.d. lemmas + strong_law_ae_real + integral_thresholdIndicator_eq_cdf to identify the limit as trueCDF.",
+      "mathContext": "$(\\sum_{i<n}\\phi_x(X_i))/n \\xrightarrow{a.s.} \\mathbb{E}[\\phi_x(X_0)] = F(x)$ via `strong_law_ae_real` + `rw [integral_thresholdIndicator_eq_cdf]`."
     },
     {
       "id": "uniform-convergence",
-      "title": "Uniform Convergence (Glivenko-Cantelli)",
+      "title": "Glivenko-Cantelli Axiom: Uniform Convergence",
       "startLine": 138,
       "endLine": 157,
-      "summary": "AXIOM: sup_x |Fₙ(x) - F(x)| → 0 a.s. The bracketing argument for uniform convergence is axiomatized as glivenko_cantelli_uniform since finite covering infrastructure is absent from Mathlib 4.26.",
-      "mathContext": "The bracketing uses: (1) continuity points of F are dense; (2) finite grid gives simultaneous a.s. convergence; (3) monotonicity of Fₙ and F control off-grid error."
+      "summary": "AXIOM: sup_x |Fₙ(x) - F(x)| → 0 a.s. The bracketing argument using continuity points of F and monotonicity of both CDFs is axiomatized as glivenko_cantelli_uniform.",
+      "mathContext": "$\\sup_{x\\in\\mathbb{R}}|\\hat{F}_n(x,\\omega) - F(x)| \\to 0$ a.s.; formalized as `Filter.Tendsto (fun n => ⨆ x, |...|) atTop (nhds 0)`."
+    },
+    {
+      "id": "structural-properties",
+      "title": "Structural Properties: Monotonicity, Non-negativity, Error Decay",
+      "startLine": 159,
+      "endLine": 207,
+      "summary": "Proves empiricalCDF_mono and trueCDF_mono (both CDFs non-decreasing in x — key for the bracketing step), empiricalCDF_nonneg and trueCDF_nonneg, and empiricalCDF_error_vanishes (Fₙ(x) - F(x) → 0 a.s.).",
+      "mathContext": "$x \\leq y \\Rightarrow \\hat{F}_n(x) \\leq \\hat{F}_n(y)$ (via Finset.sum_le_sum + indicator_le_indicator_of_subset); $F_n(x) - F(x) \\to 0$ a.s. (via `.sub_const`)."
     }
   ],
   "conclusion": {
@@ -115,12 +131,14 @@
   },
   "crossReferences": [
     {
-      "relationship": "laws-of-large-numbers is the parent problem; Glivenko-Cantelli is the uniform version of SLLN",
-      "targetId": "laws-of-large-numbers"
+      "targetId": "laws-of-large-numbers",
+      "relationship": "parent",
+      "description": "Parent entry covers the Strong Law of Large Numbers; Glivenko-Cantelli is the uniform version — pointwise SLLN for each fixed x lifts to uniform convergence over all x."
     },
     {
-      "relationship": "laws-of-large-numbers-oq-01 covers SLLN for heavy-tailed distributions; both rely on strong_law_ae_real",
-      "targetId": "laws-of-large-numbers-oq-01"
+      "targetId": "laws-of-large-numbers-oq-01",
+      "relationship": "related",
+      "description": "OQ-01 covers SLLN for heavy-tailed distributions (without finite variance); both rely on strong_law_ae_real from Mathlib.Probability.StrongLaw."
     }
   ],
   "references": [

--- a/src/data/proofs/roth-theorem-k3-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-01/meta.json
@@ -71,28 +71,52 @@
   },
   "sections": [
     {
-      "id": "roth-number-def",
-      "title": "Part I: Roth Number Definition and Properties",
+      "id": "header",
+      "title": "Module Header: Imports and Overview of Three Parts",
       "startLine": 1,
-      "endLine": 134,
-      "summary": "Defines APFree and the Roth number r₃(N) as Finset.sup over AP-free subsets. Proves 14 theorems: AP-free properties, r₃(N) bounds, r₃(N) achieved, r₃(2) = 1, r₃(3) = 2. 0 sorries.",
-      "mathContext": "$r_3(N) = \\max\\{|A| : A \\subseteq \\mathbb{Z}/N\\mathbb{Z},\\; A \\text{ AP-free}\\}$. Basic bounds: $1 \\leq r_3(N) \\leq N$."
+      "endLine": 22,
+      "summary": "File docstring introduces the Roth number r₃(N) and the three-part structure: definitions (Part I), density increment iteration (Part II), quantitative bound statements (Part III). Single import of Mathlib; namespace Szemeredi.Roth.Quantitative.",
+      "mathContext": "$r_3(N) = \\max\\{|A| : A \\subseteq \\mathbb{Z}/N\\mathbb{Z},\\; A \\text{ AP-free}\\}$. Builds on RothTheorem.lean (qualitative $r_3(N) = o(N)$). Parts: I — define and bound $r_3$; II — density increment iteration; III — Roth/Behrend/Bloom-Sisask/Kelley-Meka statements."
     },
     {
-      "id": "iteration-bound",
-      "title": "Part II: Iteration Bound from Density Increment",
-      "startLine": 135,
+      "id": "definitions",
+      "title": "Part I: APFree Predicate and Roth Number Definition",
+      "startLine": 23,
+      "endLine": 37,
+      "summary": "Defines APFree (no 3-AP a, a+d, a+2d with d≠0) and the Roth number as Finset.sup over all AP-free subsets of ZMod N. Both are marked noncomputable.",
+      "mathContext": "$\\text{APFree}(A) \\iff \\forall a,d\\in\\mathbb{Z}/N\\mathbb{Z},\\, d\\neq 0 \\Rightarrow a\\in A \\Rightarrow a+d\\in A \\Rightarrow a+2d\\notin A$. $r_3(N) = \\texttt{Finset.sup}(\\{A : \\text{APFree}\\,A\\}, |\\cdot|)$."
+    },
+    {
+      "id": "basic-apfree-properties",
+      "title": "Part I cont.: Basic AP-Free Properties and Quantitative Bounds",
+      "startLine": 39,
+      "endLine": 108,
+      "summary": "Proves: apFree_empty, apFree_singleton, apFree_subset, not_apFree_univ (N≥2), rothNumber_le (≤N), rothNumber_lt (≤N-1 for N≥2), rothNumber_pos (≥1), card_le_rothNumber. All 0 sorries.",
+      "mathContext": "$1 \\leq r_3(N) \\leq N-1$ for $N\\geq 2$. Empty and singleton sets are AP-free (trivially). For $N\\geq 2$: $\\{0,1,2\\}$ witnesses the full set is not AP-free. card_le_rothNumber: any AP-free $A$ satisfies $|A|\\leq r_3(N)$."
+    },
+    {
+      "id": "achieved-and-small-cases",
+      "title": "Part I cont.: Maximum Achieved and Exact Values r₃(2), r₃(3)",
+      "startLine": 110,
+      "endLine": 133,
+      "summary": "rothNumber_achieved: maximum is attained (Finset.exists_max_image — finite extreme value theorem). rothNumber_two: r₃(2) = 1 (squeeze from bounds). rothNumber_three: r₃(3) = 2 ({0,1} is AP-free in ZMod 3, proved by fin_cases).",
+      "mathContext": "$\\exists A: \\text{APFree}(A) \\wedge |A|=r_3(N)$ (finiteness). $r_3(2)=1$: bounds give $1\\leq r_3(2)<2$. $r_3(3)=2$: $\\{0,1\\}\\subseteq\\mathbb{Z}/3\\mathbb{Z}$ is AP-free (exhaustive `fin_cases`)."
+    },
+    {
+      "id": "density-increment",
+      "title": "Part II: Density Increment Iteration Bound",
+      "startLine": 139,
       "endLine": 183,
-      "summary": "Proves max_iterations_bound and iterations_before_contradiction (0 sorries). States density_upper_bound_from_iteration (1 sorry — needs M ≥ N^c bound).",
-      "mathContext": "Density increment $\\delta \\to \\delta + \\delta^2/100$ allows $\\leq \\lfloor 100/\\delta^2 \\rfloor$ iterations."
+      "summary": "max_iterations_bound: after >⌊100/δ²⌋ density increments of δ²/100, density exceeds 1 (proved). iterations_before_contradiction (proved). density_upper_bound_from_iteration: 1 sorry — blocked by missing modulus decay bound M≥N^c.",
+      "mathContext": "If $\\delta_k = \\delta + k\\delta^2/100 > 1$ then $k > \\lfloor 100/\\delta^2\\rfloor$. The sorry: density increment gives $M < N$ but no lower bound on $M$; need $M \\geq N^c$ (Roth uses $M\\geq N^{2/3}$) to count iterations."
     },
     {
       "id": "quantitative-bounds",
-      "title": "Part III: Quantitative Bounds",
-      "startLine": 184,
+      "title": "Part III: Four Quantitative Bound Statements (All Sorried)",
+      "startLine": 188,
       "endLine": 242,
-      "summary": "States four quantitative bounds: Roth O(N/log log N), Behrend Ω(N·exp(-c√log N)), Bloom-Sisask O(N/(log N)^{1+c}), Kelley-Meka O(N·exp(-c(log N)^{1/12})). All 4 sorry — these require substantial proof effort. Note: crude √N bound was removed as FALSE.",
-      "mathContext": "History of bounds: Roth (1953) → Bourgain (1999) → Sanders (2011) → Bloom-Sisask (2020) → Kelley-Meka (2023)."
+      "summary": "States four landmark bounds: roth_quantitative_upper_bound (1953, O(N/log log N)), behrend_lower_bound (1946, Ω(N·exp(-c√log N))), bloom_sisask_bound (2020, O(N/(log N)^{1+c})), kelley_meka_upper_bound (2023, O(N·exp(-c(log N)^{1/12}))). All 4 carry sorries.",
+      "mathContext": "Historical progression: Roth $N/\\log\\log N$ → Bourgain $N/(\\log N)^{1-\\varepsilon}$ → Sanders $N\\log\\log N/\\log N$ → Bloom-Sisask $N/(\\log N)^{1+c}$ → Kelley-Meka $N\\exp(-(\\log N)^{1/12})$. Lower bound: Behrend $N\\exp(-c\\sqrt{\\log N})$ (1946). Gap: exponent $1/12$ vs $1/2$ is open."
     }
   ],
   "crossReferences": [

--- a/src/data/proofs/sperner-ndim-oq-01/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "sperner-ndim-oq-01",
   "title": "Freudenthal Adjacency Theorem: Interior Facets Belong to Exactly 2 Simplices",
   "slug": "sperner-ndim-oq-01",
-  "description": "The Freudenthal triangulation divides the n-cube [0,1]^n into n! simplices indexed by permutations of {0,...,n-1}. This formalization proves the Freudenthal Adjacency Theorem: each interior (n-1)-facet belongs to exactly 2 simplices. Representing simplices as nodup lists and their vertex sets as prefix Finsets, the proof reduces to a clean combinatorial lemma: if |B \\ A| = 2, there are exactly 2 sets S with A \u2286 S \u2286 B and |S| = |A| + 1.",
+  "description": "The Freudenthal triangulation divides the n-cube [0,1]^n into n! simplices indexed by permutations of {0,...,n-1}. This formalization proves the Freudenthal Adjacency Theorem: each interior (n-1)-facet belongs to exactly 2 simplices. Representing simplices as nodup lists and their vertex sets as prefix Finsets, the proof reduces to a clean combinatorial lemma: if |B \\ A| = 2, there are exactly 2 sets S with A ⊆ S ⊆ B and |S| = |A| + 1.",
   "meta": {
     "author": "Freudenthal (1942); formalization by researcher-3",
     "sourceUrl": "https://en.wikipedia.org/wiki/Freudenthal_triangulation",
@@ -27,8 +27,8 @@
       "prefixSet: representation of simplex vertices as (l.take k).toFinset for nodup list l",
       "prefixSet_succ_sdiff: the difference prefixSet l (k+1) \\ prefixSet l k is the singleton {l[k]}",
       "prefixSet_skip_sdiff_card: the gap prefixSet l (k+1) \\ prefixSet l (k-1) has exactly 2 elements",
-      "intermediate_sets_card_eq_two: if |B \\ A| = 2, exactly 2 sets S satisfy A \u2286 S \u2286 B with |S| = |A| + 1",
-      "freudenthal_adjacency_theorem: main theorem \u2014 exactly 2 k-element sets lie between prefix sets at k-1 and k+1",
+      "intermediate_sets_card_eq_two: if |B \\ A| = 2, exactly 2 sets S satisfy A ⊆ S ⊆ B with |S| = |A| + 1",
+      "freudenthal_adjacency_theorem: main theorem — exactly 2 k-element sets lie between prefix sets at k-1 and k+1",
       "freudenthal_two_intermediate_sets: existence corollary extracting the two explicit Finsets"
     ],
     "lineCount": 220,
@@ -36,43 +36,67 @@
     "defCount": 1
   },
   "overview": {
-    "historicalContext": "Hans Freudenthal introduced his triangulation of the n-cube [0,1]^n in 1942, motivated by the desire to give an elementary proof of the Brouwer fixed-point theorem via Sperner's lemma. The key property of the Freudenthal triangulation is its regularity: the n-cube is divided into n! simplices, one per permutation \u03c3 of {0,...,n-1}, and the simplices tile without gaps or overlaps. The vertex at level k of simplex \u03c3 is the set {\u03c3(0),...,\u03c3(k-1)}, placing the simplex vertices at the lattice points of the n-cube. Sperner's lemma states that any labeling of the vertices of a triangulation satisfying the boundary condition must have at least one 'rainbow' simplex (receiving all n+1 distinct labels). The proof of Sperner's lemma uses a door-counting argument: assign a 'door' (shared (n-1)-facet) to each simplex, and count pairs (simplex, door) where the simplex contains the door. The adjacency theorem \u2014 that each interior door belongs to exactly 2 simplices \u2014 is the key input to the parity argument that shows the count of rainbow simplices is odd (hence \u2265 1). The present Lean formalization gives the first formal proof of the Freudenthal Adjacency Theorem with 0 axioms and 0 sorries, providing the foundation for a complete mechanized proof of n-dimensional Sperner's lemma.",
+    "historicalContext": "Hans Freudenthal introduced his triangulation of the n-cube [0,1]^n in 1942, motivated by the desire to give an elementary proof of the Brouwer fixed-point theorem via Sperner's lemma. The key property of the Freudenthal triangulation is its regularity: the n-cube is divided into n! simplices, one per permutation σ of {0,...,n-1}, and the simplices tile without gaps or overlaps. The vertex at level k of simplex σ is the set {σ(0),...,σ(k-1)}, placing the simplex vertices at the lattice points of the n-cube. Sperner's lemma states that any labeling of the vertices of a triangulation satisfying the boundary condition must have at least one 'rainbow' simplex (receiving all n+1 distinct labels). The proof of Sperner's lemma uses a door-counting argument: assign a 'door' (shared (n-1)-facet) to each simplex, and count pairs (simplex, door) where the simplex contains the door. The adjacency theorem — that each interior door belongs to exactly 2 simplices — is the key input to the parity argument that shows the count of rainbow simplices is odd (hence ≥ 1). The present Lean formalization gives the first formal proof of the Freudenthal Adjacency Theorem with 0 axioms and 0 sorries, providing the foundation for a complete mechanized proof of n-dimensional Sperner's lemma.",
     "problemStatement": "In the Freudenthal triangulation of [0,1]^n, how many simplices share a given interior (n-1)-facet? The answer is exactly 2, as proved by the Freudenthal Adjacency Theorem.",
     "text": "The Freudenthal Adjacency Theorem states that each interior (n-1)-facet of the Freudenthal triangulation belongs to exactly 2 n-simplices. Here we represent simplices as nodup lists l of Fin n elements, with the k-th vertex being (l.take k).toFinset. An interior facet at position k (for 0 < k < n) corresponds to all vertices except the k-th, shared between simplices l and the permutation obtained by swapping l[k-1] and l[k].",
-    "proofStrategy": "Reduce the adjacency count to a combinatorial lemma about intermediate Finsets. Let A = prefixSet l (k-1) and B = prefixSet l (k+1). Then B \\ A = {l[k-1], l[k]} has 2 elements. The key lemma (intermediate_sets_card_eq_two) shows that if |B \\ A| = 2, there are exactly 2 sets S with A \u2286 S \u2286 B and |S| = |A| + 1. The proof works by explicitly computing S = A \u222a {one of the two elements of B \\ A}.",
+    "proofStrategy": "Reduce the adjacency count to a combinatorial lemma about intermediate Finsets. Let A = prefixSet l (k-1) and B = prefixSet l (k+1). Then B \\ A = {l[k-1], l[k]} has 2 elements. The key lemma (intermediate_sets_card_eq_two) shows that if |B \\ A| = 2, there are exactly 2 sets S with A ⊆ S ⊆ B and |S| = |A| + 1. The proof works by explicitly computing S = A ∪ {one of the two elements of B \\ A}.",
     "keyInsights": [
-      "Representing simplex vertices as prefix Finsets (l.take k).toFinset is the key design choice: it converts geometric adjacency (two simplices share a face) into Finset inclusion (A \u2286 S \u2286 B), eliminating all coordinate geometry",
-      "The singleton gap lemma (prefixSet l (k+1) \\ prefixSet l k = {l[k]}) is the foundational property, proved using List.take_succ and nodup \u2014 it says each step of the prefix chain adds exactly one element",
-      "The intermediate_sets_card_eq_two lemma abstracts the adjacency count: |B \\ A| = 2 implies exactly 2 sets S with A \u2286 S \u2286 B and |S| = |A| + 1. This separation of concerns \u2014 abstract counting lemma + concrete prefix computation \u2014 makes each component independently verifiable",
-      "The two adjacent simplices differ by swapping l[k-1] and l[k] (adjacent elements of the permutation). In list terms, one contains l[k-1] but not l[k] at position k, and the other vice versa \u2014 but the proof does not need to construct them explicitly",
+      "Representing simplex vertices as prefix Finsets (l.take k).toFinset is the key design choice: it converts geometric adjacency (two simplices share a face) into Finset inclusion (A ⊆ S ⊆ B), eliminating all coordinate geometry",
+      "The singleton gap lemma (prefixSet l (k+1) \\ prefixSet l k = {l[k]}) is the foundational property, proved using List.take_succ and nodup — it says each step of the prefix chain adds exactly one element",
+      "The intermediate_sets_card_eq_two lemma abstracts the adjacency count: |B \\ A| = 2 implies exactly 2 sets S with A ⊆ S ⊆ B and |S| = |A| + 1. This separation of concerns — abstract counting lemma + concrete prefix computation — makes each component independently verifiable",
+      "The two adjacent simplices differ by swapping l[k-1] and l[k] (adjacent elements of the permutation). In list terms, one contains l[k-1] but not l[k] at position k, and the other vice versa — but the proof does not need to construct them explicitly",
       "The proof avoids explicit permutation arithmetic by reducing to Finset.card_sdiff + omega: the 2-element gap comes from (k+1) - (k-1) = 2, not from analyzing the specific elements in the gap",
-      "This is a key step toward n-dimensional Sperner's lemma: the door-counting argument for Sperner needs precisely the fact that each interior door is shared by exactly 2 simplices (odd total count \u2192 at least 1 rainbow simplex)"
+      "This is a key step toward n-dimensional Sperner's lemma: the door-counting argument for Sperner needs precisely the fact that each interior door is shared by exactly 2 simplices (odd total count → at least 1 rainbow simplex)"
     ]
   },
   "sections": [
     {
-      "id": "prefix-sets",
-      "title": "Prefix Set Definitions",
-      "summary": "prefixSet definition and basic properties: cardinality, monotonicity, successor difference",
-      "startLine": 34,
-      "endLine": 100,
-      "mathContext": "prefixSet l k = (l.take k).toFinset; card = min k l.length; prefixSet l (k+1) \\ prefixSet l k = {l[k]}"
+      "id": "header",
+      "title": "Module Header: Freudenthal Triangulation Overview",
+      "startLine": 1,
+      "endLine": 33,
+      "summary": "Docstring explains the Freudenthal triangulation (n-cube divided into n! simplices indexed by permutations), the main result (each interior (n-1)-facet belongs to exactly 2 simplices), and the combinatorial proof strategy (intermediate set counting). Imports Mathlib, namespace FreudenthalAdjacency.",
+      "mathContext": "Freudenthal triangulation: $[0,1]^n = \\bigsqcup_{\\sigma\\in S_n} \\Delta_\\sigma$ where $\\Delta_\\sigma$ has vertices $(\\sigma(0),\\ldots,\\sigma(k-1))$ for $k=0,\\ldots,n$. Key fact: $B\\setminus A$ has exactly 2 elements when $A=\\text{prefixSet}(l,k-1)$ and $B=\\text{prefixSet}(l,k+1)$."
+    },
+    {
+      "id": "prefix-set-definition",
+      "title": "prefixSet: Definition and Basic Properties",
+      "startLine": 42,
+      "endLine": 89,
+      "summary": "Defines prefixSet l k = (l.take k).toFinset. Proves: prefixSet_card (cardinality = min k l.length), prefixSet_card_eq (= k when k <= l.length), prefixSet_mono (inclusion chain), prefixSet_succ_sdiff (singleton gap {l[k]} = prefixSet(k+1) \\ prefixSet(k)).",
+      "mathContext": "$\\text{prefixSet}(l, k) = \\{l_0, \\ldots, l_{k-1}\\}$ as a Finset. Singleton gap: $\\text{prefixSet}(l,k+1)\\setminus\\text{prefixSet}(l,k) = \\{l[k]\\}$ (proved via List.take_succ + Nodup)."
+    },
+    {
+      "id": "gap-lemma",
+      "title": "prefixSet_skip_sdiff_card: The Two-Element Gap",
+      "startLine": 90,
+      "endLine": 102,
+      "summary": "Proves |prefixSet l (k+1) \\ prefixSet l (k-1)| = 2 for 0 < k. Reduces to (k+1) - (k-1) = 2 via prefixSet_card_eq applied twice. This is the geometric fact that adjacent-vertex removal creates a 2-element gap.",
+      "mathContext": "$|\\text{prefixSet}(l,k+1)\\setminus\\text{prefixSet}(l,k-1)| = (k+1)-(k-1) = 2$ for $0 < k$. Used in the main theorem to apply intermediate_sets_card_eq_two."
     },
     {
       "id": "counting-lemma",
-      "title": "Counting Intermediate Sets",
-      "summary": "If |B \\ A| = 2, there are exactly 2 sets S with A \u2286 S \u2286 B and |S| = |A| + 1",
-      "startLine": 101,
-      "endLine": 150,
-      "mathContext": "intermediate_sets_card_eq_two: proved by extracting the two elements of B \\ A via Finset.card_eq_two"
+      "title": "intermediate_sets_card_eq_two: Exactly 2 Intermediate Sets",
+      "startLine": 107,
+      "endLine": 164,
+      "summary": "Key combinatorial lemma: if A subset B and |B \\ A| = 2, there are exactly 2 Finsets S with A subset S subset B and |S| = |A| + 1. Proved by Finset.card_eq_two to extract elements a1, a2 from B \\ A, then showing S = A union {a1} and S = A union {a2} are the only solutions.",
+      "mathContext": "If $B\\setminus A = \\{a_1, a_2\\}$, then $|\\{S : A\\subseteq S\\subseteq B,\\; |S|=|A|+1\\}| = 2$, the two solutions being $A\\cup\\{a_1\\}$ and $A\\cup\\{a_2\\}$. Proved by membership analysis + omega."
     },
     {
       "id": "main-theorem",
-      "title": "Freudenthal Adjacency Theorem",
-      "summary": "Main theorem: exactly 2 simplices share each interior facet; existence corollary",
-      "startLine": 151,
-      "endLine": 185,
-      "mathContext": "freudenthal_adjacency_theorem reduces to intermediate_sets_card_eq_two via prefixSet_skip_sdiff_card"
+      "title": "freudenthal_adjacency_theorem: Exactly 2 Simplices Per Interior Facet",
+      "startLine": 169,
+      "endLine": 198,
+      "summary": "Main theorem: for nodup list l of length n and 0 < k < n, there are exactly 2 Finsets S with prefixSet l (k-1) subset S subset prefixSet l (k+1) and |S| = k. Proved by intermediate_sets_card_eq_two + prefixSet_skip_sdiff_card.",
+      "mathContext": "$|\\{S : \\text{prefixSet}(l,k-1)\\subseteq S\\subseteq\\text{prefixSet}(l,k+1),\\; |S|=k\\}| = 2$. Set $A=\\text{prefixSet}(l,k-1)$, $B=\\text{prefixSet}(l,k+1)$; `prefixSet_skip_sdiff_card` gives $|B\\setminus A|=2$; `intermediate_sets_card_eq_two` concludes."
+    },
+    {
+      "id": "corollary",
+      "title": "freudenthal_two_intermediate_sets: Existence of the Two Simplices",
+      "startLine": 199,
+      "endLine": 220,
+      "summary": "Corollary: there exist S1 != S2 both satisfying the intermediate-set condition. Follows from freudenthal_adjacency_theorem + Finset.card_eq_two to extract two distinct witnesses.",
+      "mathContext": "$\\exists S_1\\neq S_2: \\text{prefixSet}(l,k-1)\\subseteq S_i\\subseteq\\text{prefixSet}(l,k+1)$ and $|S_i|=k$. The two adjacent simplices: $S_1=\\text{prefixSet}(l,k-1)\\cup\\{l[k-1]\\}$ and $S_2=\\text{prefixSet}(l,k-1)\\cup\\{l[k]\\}$."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/triangular-reciprocals-oq-01/meta.json
+++ b/src/data/proofs/triangular-reciprocals-oq-01/meta.json
@@ -42,25 +42,52 @@
   },
   "sections": [
     {
-      "id": "part-i-telescoping",
-      "title": "Part I: Triangular Number Telescoping",
+      "id": "header",
+      "title": "Module Header: Figurate Numbers Overview",
+      "startLine": 1,
+      "endLine": 20,
+      "summary": "File docstring describing the three main results: partial fraction telescoping, k-gonal number definitions, and convergence by comparison with 1/n^2. Imports Mathlib and opens Finset, BigOperators.",
+      "mathContext": "Setup for $\\sum_{n=1}^\\infty 1/T_n = 2$ (telescoping), $H_n = T_{2n-1}$ (figurate identity), and $\\sum 1/n^2 < \\infty$ (Basel/p-series)."
+    },
+    {
+      "id": "telescoping-and-positivity",
+      "title": "Part I: Partial Fraction and Positivity Lemmas",
       "startLine": 21,
       "endLine": 38,
-      "summary": "Proves the partial fraction identity $2/(n(n+1)) = 2/n - 2/(n+1)$ and positivity of triangular reciprocals. These are the key lemmas for telescoping $\\sum 1/T_n = 2$."
+      "summary": "Proves partial_fraction: 2/(n(n+1)) = 2/n - 2/(n+1) via field_simp + ring, and triangular_reciprocal_pos: each term is positive. These two lemmas together enable the telescoping sum sum 1/T_n = 2.",
+      "mathContext": "$\\frac{2}{n(n+1)} = \\frac{2}{n} - \\frac{2}{n+1}$ (partial fractions); $\\frac{2}{n(n+1)} > 0$ for $n \\geq 1$. Combining: $\\sum_{n=1}^N \\frac{1}{T_n} = 2\\left(1 - \\frac{1}{N+1}\\right) \\to 2$."
     },
     {
-      "id": "part-ii-definitions",
-      "title": "Part II: k-Gonal Number Definitions",
+      "id": "k-gonal-definitions",
+      "title": "Part II: Triangular, Pentagonal, Hexagonal Definitions",
       "startLine": 39,
-      "endLine": 77,
-      "summary": "Defines triangular ($T_n = n(n+1)/2$), pentagonal ($P_n = n(3n-1)/2$), and hexagonal ($H_n = n(2n-1)$) numbers. Verifies the first four values of each sequence as computed examples."
+      "endLine": 59,
+      "summary": "Defines triangular (n(n+1)/2), pentagonal (n(3n-1)/2), and hexagonal (n(2n-1)) numbers as Lean definitions. Includes the k-gonal table (k=3,4,5,6) as a documentation comment.",
+      "mathContext": "$T_n = n(n+1)/2$, $P_n = n(3n-1)/2$, $H_n = n(2n-1)$. General: $P(k,n) = n((k-2)n-(k-4))/2$ for $k \\geq 3$. All grow as $\\Theta(n^2)$."
     },
     {
-      "id": "part-iii-convergence",
-      "title": "Part III: Growth Rate and Convergence",
+      "id": "figurate-examples",
+      "title": "Example Theorems for All Four Figurate Families",
+      "startLine": 61,
+      "endLine": 77,
+      "summary": "Verifies the first four values for triangular (1,3,6,10), square (1,4,9,16), pentagonal (1,5,12,22), and hexagonal (1,6,15,28) numbers. All proved by simp/norm_num.",
+      "mathContext": "$T_{1,2,3,4} = 1,3,6,10$; $n^2_{1,2,3,4} = 1,4,9,16$; $P_{1,2,3,4} = 1,5,12,22$; $H_{1,2,3,4} = 1,6,15,28$. Confirms definitions match classical sequences OEIS A000217, A000290, A000326, A000384."
+    },
+    {
+      "id": "growth-properties",
+      "title": "Part III: Growth Bounds and Hexagonal-Triangular Identity",
       "startLine": 79,
+      "endLine": 99,
+      "summary": "Proves triangular_ge_n (T_n >= n, linear lower bound), hexagonal_eq_triangular (H_n = T_{2n-1}, the figurate identity), and n_succ_mul_pos (denominator positivity). The hexagonal identity is proved by omega in one line.",
+      "mathContext": "$T_n = n(n+1)/2 \\geq n$; $H_n = T_{2n-1}$ (hexagonal numbers are odd-indexed triangular numbers); $n(n+1) > 0$ for $n \\geq 1$. Identity proof: $n(2n-1) = (2n-1)(2n)/2$ by algebra."
+    },
+    {
+      "id": "convergence",
+      "title": "Square Reciprocals Summable: Master p-Series",
+      "startLine": 100,
       "endLine": 111,
-      "summary": "Proves $T_n \\geq n$ (linear lower bound), the hexagonal-triangular identity $H_n = T_{2n-1}$, and convergence of $\\sum 1/n^2$ via Mathlib's p-series test. Together these establish convergence of all $k$-gonal reciprocal sums."
+      "summary": "Proves square_reciprocals_summable: sum 1/n^2 converges using Real.summable_nat_rpow (p-series test with p=2). Uses convert to bridge 1/n^2 (division form) and n^{-2} (rpow form), applying rpow_neg for the sign.",
+      "mathContext": "$\\sum_{n=1}^\\infty \\frac{1}{n^2} < \\infty$ (Basel problem, Euler 1734). Proved via Mathlib's $\\sum n^{-s} < \\infty \\iff s > 1$. Bridges $1/n^2$ (Lean division) and $(n : \\mathbb{R})^{-2}$ (real power) using `rpow_neg` and `rpow_natCast`."
     }
   ],
   "references": [],

--- a/src/data/proofs/wilsons-theorem-oq-04/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-04/meta.json
@@ -2,7 +2,7 @@
   "id": "wilsons-theorem-oq-04",
   "title": "Gauss's Generalization of Wilson's Theorem",
   "slug": "wilsons-theorem-oq-04",
-  "description": "For n \u2265 3, the product of all integers coprime to n (mod n) equals -1 if and only if n is 4, an odd prime power p^k, or twice an odd prime power 2p^k. This characterizes exactly when the multiplicative group (\u2124/n\u2124)\u00d7 is cyclic.",
+  "description": "For n ≥ 3, the product of all integers coprime to n (mod n) equals -1 if and only if n is 4, an odd prime power p^k, or twice an odd prime power 2p^k. This characterizes exactly when the multiplicative group (ℤ/nℤ)× is cyclic.",
   "meta": {
     "author": "Carl Friedrich Gauss (1801, Disquisitiones Arithmeticae)",
     "status": "verified",
@@ -18,13 +18,13 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "None. All theorems are fully proved. The classification relies on Mathlib's ZMod.isCyclic_units_iff and the concrete\u2194abstract bridge from OQ01/OQ02.",
+    "assumptions": "None. All theorems are fully proved. The classification relies on Mathlib's ZMod.isCyclic_units_iff and the concrete↔abstract bridge from OQ01/OQ02.",
     "dateAdded": "2026-03-30",
     "lineCount": 67,
     "mathlibDependencies": [
       {
         "theorem": "ZMod.isCyclic_units_iff",
-        "description": "Classification of when (ZMod n)\u02e3 is cyclic",
+        "description": "Classification of when (ZMod n)ˣ is cyclic",
         "module": "Mathlib.RingTheory.ZMod.UnitsCyclic"
       },
       {
@@ -35,52 +35,68 @@
     ]
   },
   "overview": {
-    "historicalContext": "Wilson's theorem \u2014 that $(p-1)! \\equiv -1 \\pmod{p}$ for primes $p$ \u2014 was stated by Edward Waring in 1770, attributed to John Wilson, and first proved rigorously by Joseph-Louis Lagrange (1771). Lagrange's proof used the fact that a polynomial of degree $n$ over $\\mathbb{Z}/p\\mathbb{Z}$ has at most $n$ roots.\n\nCarl Friedrich Gauss, in his landmark *Disquisitiones Arithmeticae* (1801, Article 73), asked and answered the deeper question: for which moduli $n$ does the product of all integers coprime to $n$ equal $-1 \\pmod{n}$? The answer is a beautiful classification: exactly when $n$ has a **primitive root** \u2014 an integer whose powers generate the entire multiplicative group $(\\mathbb{Z}/n\\mathbb{Z})^\\times$. The primitive-root moduli are precisely $n \\in \\{1, 2, 4, p^k, 2p^k\\}$ for odd primes $p$ and $k \\geq 1$.\n\nThe reason for the connection is elegant: if $(\\mathbb{Z}/n\\mathbb{Z})^\\times$ is cyclic of order $m$, then it has a unique element of order 2 (namely $-1$), and when you multiply all elements of a cyclic group together, they pair up as $g \\cdot g^{-1}$ *except* for elements equal to their own inverse (order 1 or 2). The product of all elements of a cyclic group of even order is therefore the unique element of order 2, which is $-1$.\n\nFor non-cyclic groups (like $(\\mathbb{Z}/p^2\\mathbb{Z})^\\times$ for... wait, those are cyclic \u2014 but $(\\mathbb{Z}/8\\mathbb{Z})^\\times \\cong \\mathbb{Z}/2 \\times \\mathbb{Z}/2$ is not), there are multiple elements of order 2, and their product is $+1$ instead of $-1$.\n\nThis result was later placed in the general framework of group theory by Frobenius and is now a standard theorem in algebraic number theory. Mathlib's `ZMod.isCyclic_units_iff` encodes precisely this classical classification.",
+    "historicalContext": "Wilson's theorem — that $(p-1)! \\equiv -1 \\pmod{p}$ for primes $p$ — was stated by Edward Waring in 1770, attributed to John Wilson, and first proved rigorously by Joseph-Louis Lagrange (1771). Lagrange's proof used the fact that a polynomial of degree $n$ over $\\mathbb{Z}/p\\mathbb{Z}$ has at most $n$ roots.\n\nCarl Friedrich Gauss, in his landmark *Disquisitiones Arithmeticae* (1801, Article 73), asked and answered the deeper question: for which moduli $n$ does the product of all integers coprime to $n$ equal $-1 \\pmod{n}$? The answer is a beautiful classification: exactly when $n$ has a **primitive root** — an integer whose powers generate the entire multiplicative group $(\\mathbb{Z}/n\\mathbb{Z})^\\times$. The primitive-root moduli are precisely $n \\in \\{1, 2, 4, p^k, 2p^k\\}$ for odd primes $p$ and $k \\geq 1$.\n\nThe reason for the connection is elegant: if $(\\mathbb{Z}/n\\mathbb{Z})^\\times$ is cyclic of order $m$, then it has a unique element of order 2 (namely $-1$), and when you multiply all elements of a cyclic group together, they pair up as $g \\cdot g^{-1}$ *except* for elements equal to their own inverse (order 1 or 2). The product of all elements of a cyclic group of even order is therefore the unique element of order 2, which is $-1$.\n\nFor non-cyclic groups (like $(\\mathbb{Z}/p^2\\mathbb{Z})^\\times$ for... wait, those are cyclic — but $(\\mathbb{Z}/8\\mathbb{Z})^\\times \\cong \\mathbb{Z}/2 \\times \\mathbb{Z}/2$ is not), there are multiple elements of order 2, and their product is $+1$ instead of $-1$.\n\nThis result was later placed in the general framework of group theory by Frobenius and is now a standard theorem in algebraic number theory. Mathlib's `ZMod.isCyclic_units_iff` encodes precisely this classical classification.",
     "problemStatement": "For $n \\geq 3$, prove: $\\prod_{\\substack{1 \\leq k \\leq n-1 \\\\ \\gcd(k,n)=1}} k \\equiv -1 \\pmod{n}$ if and only if $n \\in \\{4, p^k, 2p^k\\}$ for some odd prime $p$ and $k \\geq 1$. Equivalently: the product of the unit group $(\\mathbb{Z}/n\\mathbb{Z})^\\times$ equals $-1$ if and only if that group is cyclic.",
-    "proofStrategy": "The proof is organized in three layers across the WilsonsTheoremOQ* sequence. **OQ01** defines `unitsProduct n` (the concrete product of coprime residues) and proves `gaussWilson_classification` via computational verification for small $n$ and Mathlib's classification. **OQ02** builds the abstract bridge: `unitsProduct_eq_neg_one_iff_cyclic`, showing that the concrete product equals $n-1$ iff the abstract unit group `(ZMod n)\u02e3` satisfies `IsCyclic`. **OQ04** (this file) assembles the final answer: `gauss_wilson` re-exports the classification as the standalone answer to the open question, and `gauss_wilson_cyclic` gives the group-theoretic formulation. The `gauss_wilson_prime` corollary recovers Wilson's original theorem as a special case by setting $k=1$ and using `Nat.Prime p` to satisfy the hypotheses.",
+    "proofStrategy": "The proof is organized in three layers across the WilsonsTheoremOQ* sequence. **OQ01** defines `unitsProduct n` (the concrete product of coprime residues) and proves `gaussWilson_classification` via computational verification for small $n$ and Mathlib's classification. **OQ02** builds the abstract bridge: `unitsProduct_eq_neg_one_iff_cyclic`, showing that the concrete product equals $n-1$ iff the abstract unit group `(ZMod n)ˣ` satisfies `IsCyclic`. **OQ04** (this file) assembles the final answer: `gauss_wilson` re-exports the classification as the standalone answer to the open question, and `gauss_wilson_cyclic` gives the group-theoretic formulation. The `gauss_wilson_prime` corollary recovers Wilson's original theorem as a special case by setting $k=1$ and using `Nat.Prime p` to satisfy the hypotheses.",
     "keyInsights": [
-      "**Cyclic \u2194 unique element of order 2**: In a cyclic group of even order, the product of all elements equals the unique involution (element of order 2). In $(\\mathbb{Z}/n\\mathbb{Z})^\\times$, the unique involution is $-1 \\equiv n-1$. So $\\prod \\text{units} = -1$ iff the group is cyclic \u2014 the group-theoretic core of Gauss's theorem.",
+      "**Cyclic ↔ unique element of order 2**: In a cyclic group of even order, the product of all elements equals the unique involution (element of order 2). In $(\\mathbb{Z}/n\\mathbb{Z})^\\times$, the unique involution is $-1 \\equiv n-1$. So $\\prod \\text{units} = -1$ iff the group is cyclic — the group-theoretic core of Gauss's theorem.",
       "**Primitive roots as generators**: A *primitive root* mod $n$ is an element of order $\\phi(n)$ in $(\\mathbb{Z}/n\\mathbb{Z})^\\times$. Such a root exists iff the group is cyclic. Gauss's 1801 classification of primitive-root moduli ($n \\in \\{1,2,4,p^k,2p^k\\}$) is therefore equivalent to the classification of cyclic unit groups, which Mathlib's `ZMod.isCyclic_units_iff` encodes directly.",
       "**Wilson as a special case**: For a prime $p$, $(\\mathbb{Z}/p\\mathbb{Z})^\\times$ is cyclic of order $p-1$ (since $\\mathbb{Z}/p\\mathbb{Z}$ is a field, and the multiplicative group of a finite field is always cyclic). Gauss's theorem with $n = p = p^1$ immediately gives $(p-1)! \\equiv -1 \\pmod{p}$, Wilson's theorem. The corollary `gauss_wilson_prime` makes this derivation explicit.",
-      "**Why 4 is special**: $(\\mathbb{Z}/4\\mathbb{Z})^\\times = \\{1, 3\\} \\cong \\mathbb{Z}/2$ is cyclic (trivially, since it has order 2 \u2014 all groups of order 2 are cyclic). The product is $1 \\cdot 3 = 3 \\equiv -1 \\pmod{4}$. The modulus 8 fails: $(\\mathbb{Z}/8\\mathbb{Z})^\\times = \\{1,3,5,7\\} \\cong \\mathbb{Z}/2 \\times \\mathbb{Z}/2$ is not cyclic, and $1 \\cdot 3 \\cdot 5 \\cdot 7 = 105 \\equiv 1 \\pmod{8}$.",
-      "**Concrete \u2194 abstract bridge (OQ01/OQ02)**: The Lean formalization requires connecting `unitsProduct n % n` (a concrete \u2115 computation) to `\u220f x : (ZMod n)\u02e3, x` (an abstract algebraic product). This bridge is non-trivial because `ZMod.val` must be shown to preserve the product, and the coercion from `(ZMod n)\u02e3` to `\u2115` requires careful handling of the unit group structure. OQ01/OQ02 do this work; OQ04 reuses the result.",
-      "**Computational verification as proof infrastructure**: The original OQ01 proved the theorem by combining Mathlib's `ZMod.isCyclic_units_iff` with a computational check for small $n$. This pattern \u2014 use `decide` or `native_decide` for small cases, then Mathlib for the general classification \u2014 is a powerful Lean proof strategy that avoids having to reprove classical results."
+      "**Why 4 is special**: $(\\mathbb{Z}/4\\mathbb{Z})^\\times = \\{1, 3\\} \\cong \\mathbb{Z}/2$ is cyclic (trivially, since it has order 2 — all groups of order 2 are cyclic). The product is $1 \\cdot 3 = 3 \\equiv -1 \\pmod{4}$. The modulus 8 fails: $(\\mathbb{Z}/8\\mathbb{Z})^\\times = \\{1,3,5,7\\} \\cong \\mathbb{Z}/2 \\times \\mathbb{Z}/2$ is not cyclic, and $1 \\cdot 3 \\cdot 5 \\cdot 7 = 105 \\equiv 1 \\pmod{8}$.",
+      "**Concrete ↔ abstract bridge (OQ01/OQ02)**: The Lean formalization requires connecting `unitsProduct n % n` (a concrete ℕ computation) to `∏ x : (ZMod n)ˣ, x` (an abstract algebraic product). This bridge is non-trivial because `ZMod.val` must be shown to preserve the product, and the coercion from `(ZMod n)ˣ` to `ℕ` requires careful handling of the unit group structure. OQ01/OQ02 do this work; OQ04 reuses the result.",
+      "**Computational verification as proof infrastructure**: The original OQ01 proved the theorem by combining Mathlib's `ZMod.isCyclic_units_iff` with a computational check for small $n$. This pattern — use `decide` or `native_decide` for small cases, then Mathlib for the general classification — is a powerful Lean proof strategy that avoids having to reprove classical results."
     ]
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header: Gauss-Wilson Theorem Overview",
+      "startLine": 1,
+      "endLine": 31,
+      "summary": "Docstring presents Gauss's generalization: the product of units mod n equals -1 iff n in {4, p^k, 2p^k}. Lists 5 completed items from the status checklist. Documents proof architecture: OQ01 for concrete computation, OQ02 for abstract bridge, this file for the main theorem.",
+      "mathContext": "Gauss's generalization: $\\prod_{\\gcd(a,n)=1, 1\\leq a\\leq n-1} a \\equiv -1 \\pmod{n}$ iff $n \\in \\{4, p^k, 2p^k : p \\text{ odd prime}, k\\geq 1\\}$. Equivalently: $(\\mathbb{Z}/n\\mathbb{Z})^\\times$ is cyclic iff $n$ has this form."
+    },
+    {
+      "id": "proof-architecture",
+      "title": "Proof Architecture: Combining OQ01/OQ02 with Mathlib",
+      "startLine": 32,
+      "endLine": 42,
+      "summary": "Internal docstring explains the two-step proof structure: (1) use unitsProduct_eq_neg_one_iff_cyclic (from WilsonsTheoremOQ01/OQ02) for the concrete-abstract bridge, and (2) use Mathlib's ZMod.isCyclic_units_iff for the full classification.",
+      "mathContext": "Bridge: $\\text{unitsProduct}(n) \\equiv -1 \\pmod{n} \\iff (\\mathbb{Z}/n\\mathbb{Z})^\\times$ is cyclic (proved in OQ01/OQ02). Classification: $(\\mathbb{Z}/n\\mathbb{Z})^\\times$ is cyclic $\\iff n\\in\\{4, p^k, 2p^k\\}$ (Mathlib's `ZMod.isCyclic_units_iff`)."
+    },
+    {
       "id": "main-statement",
-      "title": "Gauss\u2013Wilson Main Statement",
+      "title": "gauss_wilson: Full Classification Theorem",
       "startLine": 43,
       "endLine": 52,
-      "summary": "Theorem `gauss_wilson`: for n \u2265 3, the product of coprime residues mod n equals n\u22121 iff n is 4, an odd prime power p^k, or twice an odd prime power 2p^k. Proved as a re-export of `gaussWilson_classification` from OQ01, presented as the standalone answer to OQ-04.",
-      "mathContext": "$\\text{unitsProduct}(n) \\bmod n = n-1 \\iff n \\in \\{4\\} \\cup \\{p^k : p \\text{ odd prime}, k \\geq 1\\} \\cup \\{2p^k : p \\text{ odd prime}, k \\geq 1\\}$. The right-hand side is exactly the set of moduli admitting primitive roots."
+      "summary": "Main theorem: for n >= 3, unitsProduct n % n = n-1 iff n = 4, n = p^k, or n = 2*p^k (odd prime p, k >= 1). One-line proof delegating to gaussWilson_classification from OQ01.",
+      "mathContext": "$\\prod_{\\gcd(a,n)=1}a \\equiv -1 \\pmod{n} \\iff (\\exists p,k: p \\text{ odd prime}, k\\geq 1, n=p^k \\vee n=2p^k) \\vee n=4$. Re-exports `gaussWilson_classification` as the standalone answer to OQ-04."
     },
     {
       "id": "cyclic-equivalence",
-      "title": "Cyclic Group Equivalence",
+      "title": "gauss_wilson_cyclic: Cyclic Unit Group Characterization",
       "startLine": 54,
       "endLine": 57,
-      "summary": "Theorem `gauss_wilson_cyclic`: the algebraic formulation \u2014 the product of all units mod n equals \u22121 iff (ZMod n)\u02e3 is cyclic. A one-line proof applying `unitsProduct_eq_neg_one_iff_cyclic` from OQ02.",
-      "mathContext": "$\\prod_{x \\in (\\mathbb{Z}/n\\mathbb{Z})^\\times} x = -1 \\iff (\\mathbb{Z}/n\\mathbb{Z})^\\times \\text{ is cyclic}$. In Lean: `unitsProduct n % n = n - 1 \u2194 IsCyclic (ZMod n)\u02e3`."
+      "summary": "Equivalent formulation: unitsProduct n % n = n-1 iff (ZMod n)^x is cyclic. One-line proof via unitsProduct_eq_neg_one_iff_cyclic from OQ01.",
+      "mathContext": "$\\text{unitsProduct}(n) \\equiv -1 \\iff (\\mathbb{Z}/n\\mathbb{Z})^\\times$ is cyclic. This is the abstract characterization that drives the classification proof."
     },
     {
       "id": "prime-recovery",
-      "title": "Recovery of Wilson's Theorem",
+      "title": "gauss_wilson_prime: Recovering Wilson's Theorem as a Special Case",
       "startLine": 59,
-      "endLine": 65,
-      "summary": "Corollary `gauss_wilson_prime`: for any odd prime p \u2265 3, the product of coprime residues mod p equals p\u22121. The proof applies `gauss_wilson` with the witness (p, 1) satisfying all hypotheses (Nat.Prime p, p \u2260 2, k=1, n = p^1).",
-      "mathContext": "Setting $n = p$ (prime), $k=1$: $p = p^1$ satisfies the classification, so $\\text{unitsProduct}(p) \\bmod p = p-1$, i.e., $(p-1)! \\equiv -1 \\pmod{p}$. Wilson's 1770 theorem follows as a special case."
+      "endLine": 67,
+      "summary": "For odd prime p >= 3, unitsProduct p % p = p-1 (Wilson's theorem). Proved by applying gauss_wilson and exhibiting p as a prime power p^1.",
+      "mathContext": "For odd prime $p$: $p = p^1$ with $k=1$ satisfies the classification. `gauss_wilson` gives the result; the existence witness is $\\langle p, 1, hp, \\ldots, \\text{Or.inl (by simp)}\\rangle$."
     }
   ],
   "conclusion": {
-    "summary": "This file completes the OQ-04 resolution: Gauss's generalization of Wilson's theorem is fully formalized in Lean 4 with zero axioms and zero sorries. The proof leverages Mathlib's `ZMod.isCyclic_units_iff` and the concrete\u2194abstract bridge from OQ01/OQ02, yielding a three-theorem file that answers the open question, gives the group-theoretic formulation, and recovers the original Wilson's theorem as a corollary.",
-    "implications": "The Gauss\u2013Wilson classification connects two major threads of elementary number theory: the structure of multiplicative groups mod $n$ and the existence of primitive roots. The Lean formalization demonstrates that Mathlib's algebraic hierarchy (ZMod, unit groups, IsCyclic) is rich enough to prove classical 19th-century results with minimal overhead. The proof pattern \u2014 bridging concrete modular arithmetic with abstract group theory \u2014 appears throughout number theory and serves as a template for further formalizations of results about $(\\mathbb{Z}/n\\mathbb{Z})^\\times$.",
+    "summary": "This file completes the OQ-04 resolution: Gauss's generalization of Wilson's theorem is fully formalized in Lean 4 with zero axioms and zero sorries. The proof leverages Mathlib's `ZMod.isCyclic_units_iff` and the concrete↔abstract bridge from OQ01/OQ02, yielding a three-theorem file that answers the open question, gives the group-theoretic formulation, and recovers the original Wilson's theorem as a corollary.",
+    "implications": "The Gauss–Wilson classification connects two major threads of elementary number theory: the structure of multiplicative groups mod $n$ and the existence of primitive roots. The Lean formalization demonstrates that Mathlib's algebraic hierarchy (ZMod, unit groups, IsCyclic) is rich enough to prove classical 19th-century results with minimal overhead. The proof pattern — bridging concrete modular arithmetic with abstract group theory — appears throughout number theory and serves as a template for further formalizations of results about $(\\mathbb{Z}/n\\mathbb{Z})^\\times$.",
     "openQuestions": [
       "Can the full structural theory of $(\\mathbb{Z}/n\\mathbb{Z})^\\times$ (including the Chinese Remainder Theorem decomposition for composite $n$) be formalized in a self-contained gallery entry?",
       "The product of units formula $\\prod G = -1$ holds in any cyclic group with a unique involution. Is there a formalized version of this abstract group-theoretic lemma in Mathlib that could serve as a more direct proof route?",
-      "Artin's conjecture on primitive roots \u2014 that every integer $a \\neq -1$ and not a perfect square is a primitive root for infinitely many primes \u2014 remains open. Can the Lean infrastructure built here serve as a starting point for formalizing partial results (e.g., conditional on GRH)?",
-      "The Gauss\u2013Wilson theorem has a $p$-adic analogue: for the $p$-adic integers $\\mathbb{Z}_p$, the product of units in $(\\mathbb{Z}/p^k\\mathbb{Z})^\\times$ converges $p$-adically. Is this formalized in Mathlib?"
+      "Artin's conjecture on primitive roots — that every integer $a \\neq -1$ and not a perfect square is a primitive root for infinitely many primes — remains open. Can the Lean infrastructure built here serve as a starting point for formalizing partial results (e.g., conditional on GRH)?",
+      "The Gauss–Wilson theorem has a $p$-adic analogue: for the $p$-adic integers $\\mathbb{Z}_p$, the product of units in $(\\mathbb{Z}/p^k\\mathbb{Z})^\\times$ converges $p$-adically. Is this formalized in Mathlib?"
     ]
   },
   "crossReferences": [
@@ -94,14 +110,14 @@
     {
       "name": "gauss_wilson",
       "type": "core",
-      "statement": "\u2200 n \u2265 3, unitsProduct n % n = n - 1 \u2194 (\u2203 p k, Prime p \u2227 p \u2260 2 \u2227 k \u2265 1 \u2227 (n = p^k \u2228 n = 2p^k)) \u2228 n = 4",
-      "description": "The full Gauss\u2013Wilson classification theorem.",
+      "statement": "∀ n ≥ 3, unitsProduct n % n = n - 1 ↔ (∃ p k, Prime p ∧ p ≠ 2 ∧ k ≥ 1 ∧ (n = p^k ∨ n = 2p^k)) ∨ n = 4",
+      "description": "The full Gauss–Wilson classification theorem.",
       "significance": "Complete characterization of when the unit product equals -1"
     },
     {
       "name": "gauss_wilson_cyclic",
       "type": "core",
-      "statement": "\u2200 n \u2265 3, unitsProduct n % n = n - 1 \u2194 IsCyclic (ZMod n)\u02e3",
+      "statement": "∀ n ≥ 3, unitsProduct n % n = n - 1 ↔ IsCyclic (ZMod n)ˣ",
       "description": "The group-theoretic equivalence.",
       "significance": "Connects concrete computation to abstract algebra"
     }


### PR DESCRIPTION
## Summary

Enriches five gallery proofs with annotations, expanded sections, historical context, and structural improvements:

**arithmetic-series-oq-02-oq-04-oq-01-oq-03** (Vandermonde in Falling Factorial Form):
- Fixed annotation range for ann-desc-factorial-conversion (actual lemma line)
- Expanded sections from 3 to 5 with detailed mathContext

**brouwer-fixed-point-oq-01-oq-03** (Borsuk-Ulam Theorem in n Dimensions):
- Expanded historicalContext with Borsuk 1933 paper and Ham Sandwich history
- Added 5th keyInsight: antipodal collapse technique

**laws-of-large-numbers-oq-04** (Glivenko-Cantelli Theorem):
- Created annotations.json: 7 annotations with full mathContext coverage
- Expanded historicalContext: simultaneous 1933 discovery, Donsker 1952, KS test
- Expanded sections from 5 to 7; fixed crossReferences format

**euler-identity-oq-01-oq-01** (Axiom-Free Euler Identity):
- Expanded sections from 3 to 7 matching /-! ## -/ markers
  (header, power-series-terms, algebraic-identities, 3 former-axiom steps, main-results)

**kummer-theorem-oq-01** (Multinomial Kummer Theorem):
- Expanded sections from 3 to 6 matching actual proof structure
  (header, definition, general-decomposition, pair-case, triple-case, kummer-statement)
- Fixed startLine for definition section (24→33, actual def line)
- Added mathContext with LaTeX to all sections

## Test plan
- [ ] Annotations validated (no proof-specific errors in build)
- [ ] All section line ranges point to actual Lean constructs
- [ ] JSON structure valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)