### PR TITLE
fix(meta): correct leanFile section for erdos-1100 to match provable file

### DIFF
--- a/src/data/proofs/erdos-1100/meta.json
+++ b/src/data/proofs/erdos-1100/meta.json
@@ -239,9 +239,9 @@
       "Finset"
     ],
     "namespace": "Erdos1100",
-    "lineCount": 255,
+    "lineCount": 329,
     "axiomCount": 4,
-    "theoremCount": 13,
+    "theoremCount": 6,
     "definitionCount": 7,
     "mainTheorems": [
       {
@@ -275,7 +275,7 @@
         "description": "Erdős-Simonovits bounds on g(k)"
       }
     ],
-    "path": "Proofs/Stubs/Erdos1100Problem.lean",
-    "sorries": 2
+    "path": "Proofs/Erdos1100ProblemProvable.lean",
+    "sorries": 3
   }
 }


### PR DESCRIPTION
## Fix

The `leanFile` section in `erdos-1100/meta.json` was pointing to the wrong file (`Proofs/Stubs/Erdos1100Problem.lean`) instead of the actual proof file (`Proofs/Erdos1100ProblemProvable.lean`) referenced by `meta.proofRepoPath`. This caused internal inconsistency with `meta.sorries`.

## Evidence

**Before**:
- `leanFile.path`: "Proofs/Stubs/Erdos1100Problem.lean" (stub file)
- `leanFile.sorries`: 2 (stub has 2 sorries)
- `leanFile.lineCount`: 255 (stub has 255 lines)
- `leanFile.theoremCount`: 13 (stub count)

**After**:
- `leanFile.path`: "Proofs/Erdos1100ProblemProvable.lean" (provable file)
- `leanFile.sorries`: 3 (matches `meta.sorries = 3` ✓)
- `leanFile.lineCount`: 329 (actual line count)
- `leanFile.theoremCount`: 6 (theorems in provable file)

Build: passes (`pnpm build` ✓)

---
Automated fix by lean-mechanic agent.