### PR TITLE
fix(meta): correct leanFile section for amgm-inequality-oq-03-oq-02-oq-01

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01/meta.json
@@ -152,17 +152,19 @@
   },
   "leanFile": {
     "imports": [
-      "Proofs.AmgmInequalityOQ03"
+      "Proofs.AmgmInequalityOQ03",
+      "Mathlib.Tactic"
     ],
     "opens": [
+      "Real",
       "Finset"
     ],
-    "namespace": "AmgmInequalityOQ03OQ02OQ01",
-    "lineCount": 187,
+    "namespace": "PowerMeanCrossZero",
+    "lineCount": 225,
     "axiomCount": 0,
     "sorries": 0,
-    "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
-    "theoremCount": 7,
+    "path": "Proofs/PowerMeanCrossZeroOQ.lean",
+    "theoremCount": 4,
     "definitionCount": 0
   }
 }


### PR DESCRIPTION
## Fix

The `leanFile` section in `amgm-inequality-oq-03-oq-02-oq-01/meta.json` referenced the old proof file (`Proofs/AmgmInequalityOQ03OQ02OQ01.lean`) instead of the current proof file (`Proofs/PowerMeanCrossZeroOQ.lean`) referenced by `meta.proofRepoPath`. Two separate implementations existed; the newer `PowerMeanCrossZeroOQ.lean` is the canonical one.

## Evidence

**Before** (leanFile section):
- `path`: "Proofs/AmgmInequalityOQ03OQ02OQ01.lean" (old file)
- `namespace`: "AmgmInequalityOQ03OQ02OQ01"
- `imports`: ["Proofs.AmgmInequalityOQ03"]
- `opens`: ["Finset"]
- `lineCount`: 187
- `theoremCount`: 7

**After** (leanFile section — matches PowerMeanCrossZeroOQ.lean):
- `path`: "Proofs/PowerMeanCrossZeroOQ.lean"
- `namespace`: "PowerMeanCrossZero"
- `imports`: ["Proofs.AmgmInequalityOQ03", "Mathlib.Tactic"]
- `opens`: ["Real", "Finset"]
- `lineCount`: 225
- `theoremCount`: 4

Build: passes (`pnpm build` ✓)

---
Automated fix by lean-mechanic agent.