### PR TITLE
feat(aristotle): companion file for BertrandsPostulateOQ03OQ04 limit algebra

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -89,6 +89,7 @@ import Proofs.BaselProblemOQ05
 import Proofs.BertrandsPostulate
 import Proofs.BertrandsPostulateOQ03
 import Proofs.BertrandsPostulateOQ03OQ04
+import Proofs.BertrandsPostulateOQ03OQ04Aristotle
 import Proofs.BezoutIdentity
 import Proofs.BezoutIdentityOQ01
 import Proofs.BezoutIdentityOQ02

--- a/proofs/Proofs/BertrandsPostulateOQ03OQ04Aristotle.lean
+++ b/proofs/Proofs/BertrandsPostulateOQ03OQ04Aristotle.lean
@@ -1,0 +1,83 @@
+/-
+  Aristotle targets for Bertrand's Postulate OQ-03 OQ-04 (Prime Density in Short Intervals)
+  Routine filter/limit algebra lemmas for automated proof search.
+  See BertrandsPostulateOQ03OQ04.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open conjecture (ShortIntervalPNT for θ < 1 unconditionally)
+  - Routine limit algebra from Mathlib Filter API
+  - Clean theorem statements with no definition sorries
+  - No axiom declarations
+
+  Status: 2 sorries in long_interval_density_from_pnt:
+  (1) pnt_1c_logx_tendsto: Combining pnt_1c and log_ratio via Filter.Tendsto.mul + congr
+  (2) long_interval_density_from_pnt': Algebraic combination of step 1 and PNT via Tendsto.sub
+-/
+import Mathlib.NumberTheory.PrimeCounting
+import Mathlib.Analysis.SpecificLimits.Basic
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
+import Mathlib.Order.Filter.Basic
+import Mathlib.Tactic
+import Proofs.PrimeNumberTheorem
+import Proofs.BertrandsPostulateOQ03
+
+open Filter Topology Real
+open PrimeNumberTheorem (primePi primeApprox primeNumberTheorem)
+
+namespace BertrandsPostulateOQ03OQ04Aristotle
+
+noncomputable section
+
+/-- Helper (proved): log(x) / log((1+c)*x) → 1 as x → ∞ for any fixed c > 0.
+
+    Proof: log((1+c)*x) = log(1+c) + log(x), so
+    log(x)/log((1+c)*x) = 1/(1 + log(1+c)/log(x)) → 1/(1+0) = 1 -/
+lemma log_ratio_tendsto_one (c : ℝ) (hc : c > 0) :
+    Tendsto (fun x : ℝ => Real.log x / Real.log ((1 + c) * x)) atTop (𝓝 1) := by
+  have h1c_pos : (1 + c) > 0 := by linarith
+  have hsimp : ∀ᶠ x in atTop, Real.log x / Real.log ((1 + c) * x) =
+      1 / (1 + Real.log (1 + c) / Real.log x) := by
+    filter_upwards [eventually_gt_atTop (1 : ℝ)] with x hx
+    have hx_pos : (0 : ℝ) < x := by linarith
+    have hlogx : Real.log x ≠ 0 := ne_of_gt (Real.log_pos hx)
+    rw [Real.log_mul (ne_of_gt h1c_pos) (ne_of_gt hx_pos)]
+    field_simp; ring
+  have hdiv_zero : Tendsto (fun x : ℝ => Real.log (1 + c) / Real.log x) atTop (𝓝 0) :=
+    tendsto_const_nhds.div_atTop Real.tendsto_log_atTop
+  have hadd_one : Tendsto (fun x : ℝ => 1 + Real.log (1 + c) / Real.log x) atTop (𝓝 1) := by
+    simpa using tendsto_const_nhds.add hdiv_zero
+  have hdiv_one : Tendsto (fun x : ℝ => (1:ℝ) / (1 + Real.log (1 + c) / Real.log x)) atTop (𝓝 1) := by
+    have h : Tendsto (fun x : ℝ => (1:ℝ) / (1 + Real.log (1 + c) / Real.log x)) atTop
+        (𝓝 (1 / 1)) := tendsto_const_nhds.div hadd_one one_ne_zero
+    simp only [div_one] at h; exact h
+  rw [Filter.tendsto_congr' hsimp]
+  exact hdiv_one
+
+/-- Aristotle target: Combining PNT for (1+c)x with log ratio gives π((1+c)x)*log(x)/((1+c)x) → 1.
+
+    Key steps:
+    - pnt_1c: Tendsto (π((1+c)x) * log((1+c)x) / ((1+c)x)) → 1 (PNT composed with scaling)
+    - log_ratio_tendsto_one: Tendsto (log x / log((1+c)x)) → 1
+    - Multiply: product → 1*1 = 1, and log((1+c)x) cancels algebraically
+    - Use filter_upwards to handle log((1+c)x) ≠ 0 for large x -/
+lemma pnt_1c_logx_tendsto (c : ℝ) (hc : c > 0) :
+    Tendsto (fun x : ℝ =>
+      (primePi ((1 + c) * x) : ℝ) * Real.log x / ((1 + c) * x)) atTop (𝓝 1) := by
+  sorry
+
+/-- Aristotle target: Density asymptotic for intervals of length cx from PNT.
+
+    Key steps:
+    - pnt_1c_logx: Tendsto (π((1+c)x) * logx / ((1+c)x)) → 1
+    - pnt_x = primeNumberTheorem: Tendsto (π(x) * logx / x) → 1
+    - Rewrite goal as: (1+c)/c * pnt_1c_logx_term - 1/c * pnt_x_term
+    - Apply Tendsto.sub + Tendsto.const_mul: → (1+c)/c * 1 - 1/c * 1 = 1 -/
+lemma long_interval_density_from_pnt' (c : ℝ) (hc : c > 0) :
+    Tendsto (fun x : ℝ =>
+      ((primePi ((1 + c) * x) : ℝ) - (primePi x : ℝ)) * Real.log x / (c * x))
+      atTop (𝓝 1) := by
+  sorry
+
+end
+
+end BertrandsPostulateOQ03OQ04Aristotle


### PR DESCRIPTION
## Fix

Creates `BertrandsPostulateOQ03OQ04Aristotle.lean` to give Aristotle 2 targets for the filter/limit algebra sorries in `long_interval_density_from_pnt`.

## Evidence

**Before**: `BertrandsPostulateOQ03OQ04.lean` has 2 sorries in `long_interval_density_from_pnt`:
- `pnt_1c_logx`: combining PNT at (1+c)x with log ratio to get π((1+c)x)*logx/((1+c)x) → 1
- Final combination to prove density asymptotic

**After**: Aristotle companion file provides:
1. `log_ratio_tendsto_one` (proved): public copy of private lemma for Aristotle to use as scaffolding
2. `pnt_1c_logx_tendsto` (sorry): target for Filter.Tendsto.mul + algebraic telescoping
3. `long_interval_density_from_pnt'` (sorry): target for Tendsto.sub + Tendsto.const_mul linear combination

Both targets are routine filter algebra provable via Mathlib's `Filter.Tendsto` API:
- `Tendsto.mul`, `Tendsto.sub`, `Tendsto.const_mul`
- `filter_upwards` for handling log nonzero eventually
- `field_simp; ring` for algebraic simplification

## Source

Gallery proof: `bertrands-postulate-oq-03-oq-04` (sorries: 2 → target 0 if Aristotle succeeds)

---
Automated fix by lean-mechanic agent.