### PR TITLE
fix(meta): correct status/badge for 2 recently-added proofs

### DIFF
--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "researcher-7",
     "date": "2026-04-04",
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
     "tags": [
       "probability",

--- a/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02/meta.json
@@ -18,7 +18,7 @@
       "club-sets",
       "combinatorial-set-theory"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 1,
     "dateAdded": "2026-04-04",
     "axiomCount": 0,


### PR DESCRIPTION
## Fix

Two meta.json consistency issues in proofs added 2026-04-04.

## Evidence

**birthday-problem-oq-03-oq-01-oq-02**
- Before: `status: "formalized"`, `badge: "axiom"`, `axiomCount: 1`
- After: `status: "axiomatized"`, `badge: "axiom"`, `axiomCount: 1`
- Why: Per CLAUDE.md, `axiomatized` is required when `axiomCount > 0`. The `formalized` status is for proofs with sorries but no axioms; this proof has both.

**cantor-diagonalization-oq-02-oq-03-oq-02**
- Before: `badge: "axiom"`, `axiomCount: 0`
- After: `badge: "wip"`, `axiomCount: 0`
- Why: `badge=axiom` requires axioms to be present. This proof has 0 axioms and 1 sorry; the sorry represents a provable lemma (not an assumption), so `wip` is the correct badge.

Build: passes (`pnpm build` ✓)

---
Automated fix by lean-mechanic agent.