### PR TITLE
fix(meta): replace invalid badge values with valid ProofBadge types

### DIFF
--- a/src/data/proofs/basel-problem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Ap%C3%A9ry%27s_theorem",
     "date": "2026-04-04",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/BaselProblemOQ01OQ03.lean",
     "tags": [
       "number-theory",
@@ -15,7 +15,7 @@
       "open-problem",
       "irrationality"
     ],
-    "badge": "formalized",
+    "badge": "original",
     "sorries": 0,
     "assumptions": "0 sorries, 0 axioms. All theorems are fully proved. The main results — apery_criterion, geometric_decay_tendsto, and all conditional theorems — contain no mathematical assumptions beyond the hypotheses stated.",
     "dateAdded": "2026-04-04",
@@ -123,7 +123,9 @@
   },
   "references": [
     {
-      "authors": ["Apéry, R."],
+      "authors": [
+        "Apéry, R."
+      ],
       "title": "Irrationalité de ζ(2) et ζ(3)",
       "venue": "Astérisque",
       "year": "1979",
@@ -131,7 +133,9 @@
       "note": "Apéry's original paper; the proof that ζ(3) is irrational, using the 3-term recurrence and integer sequence argument"
     },
     {
-      "authors": ["van der Poorten, A."],
+      "authors": [
+        "van der Poorten, A."
+      ],
       "title": "A proof that Euler missed — Apéry's proof of the irrationality of ζ(3)",
       "venue": "The Mathematical Intelligencer",
       "year": "1979",
@@ -139,7 +143,10 @@
       "note": "Accessible reconstruction of Apéry's proof; explains the recurrence and why the integer sequences work"
     },
     {
-      "authors": ["Ball, K.", "Rivoal, T."],
+      "authors": [
+        "Ball, K.",
+        "Rivoal, T."
+      ],
       "title": "Irrationalité d'une infinité de valeurs de la fonction zêta aux entiers impairs",
       "venue": "Inventiones Mathematicae",
       "year": "2001",
@@ -147,7 +154,9 @@
       "note": "Proves infinitely many odd zeta values are irrational; a different method from Apéry's"
     },
     {
-      "authors": ["Zudilin, W."],
+      "authors": [
+        "Zudilin, W."
+      ],
       "title": "One of the numbers ζ(5), ζ(7), ζ(9), ζ(11) is irrational",
       "venue": "Russian Mathematical Surveys",
       "year": "2001",
@@ -155,7 +164,9 @@
       "note": "Proves at least one specific odd zeta value (among ζ(5),ζ(7),ζ(9),ζ(11)) is irrational without identifying which"
     },
     {
-      "authors": ["Beukers, F."],
+      "authors": [
+        "Beukers, F."
+      ],
       "title": "A note on the irrationality of ζ(2) and ζ(3)",
       "venue": "Bulletin of the London Mathematical Society",
       "year": "1979",

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-02/meta.json
@@ -15,7 +15,7 @@
       "marginal distribution",
       "combinatorics"
     ],
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 337,

--- a/src/data/proofs/binomial-theorem-oq-03-oq-02-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-03-oq-02-oq-03/meta.json
@@ -17,7 +17,7 @@
       "logarithm",
       "research"
     ],
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-02/meta.json
@@ -39,7 +39,7 @@
       "intermediate"
     ],
     "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ05OQ02.lean",
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
       {

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03/meta.json
@@ -2,7 +2,7 @@
   "id": "elementary-quadratic-reciprocity-oq-03",
   "title": "Jacobi Symbol and QR for Composite Moduli",
   "slug": "elementary-quadratic-reciprocity-oq-03",
-  "description": "Extends quadratic reciprocity from the Legendre symbol (prime moduli) to the Jacobi symbol (composite odd moduli), formalizing the generalized reciprocity law J(m,n)\u00b7J(n,m) = (-1)^((m-1)/2\u00b7(n-1)/2) for coprime odd m,n.",
+  "description": "Extends quadratic reciprocity from the Legendre symbol (prime moduli) to the Jacobi symbol (composite odd moduli), formalizing the generalized reciprocity law J(m,n)·J(n,m) = (-1)^((m-1)/2·(n-1)/2) for coprime odd m,n.",
   "category": "number-theory",
   "status": "verified",
   "badge": "mathlib",
@@ -40,7 +40,7 @@
       "intermediate"
     ],
     "proofRepoPath": "Proofs/ElementaryQuadraticReciprocityOQ03.lean",
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -68,7 +68,7 @@
       "Jacobi-Legendre agreement theorem for prime moduli",
       "Multiplicativity of Jacobi symbol in the bottom argument (partial)",
       "First supplement J(-1,n) = (-1)^((n-1)/2) for odd n (statement)",
-      "Second supplement J(2,n) = (-1)^((n\u00b2-1)/8) for odd n (statement)",
+      "Second supplement J(2,n) = (-1)^((n²-1)/8) for odd n (statement)",
       "Generalized QR for Jacobi symbol (statement)",
       "Non-residue detection: J(a,n) = -1 implies non-residuacity (proved)",
       "Residuacity for primes: J(a,p) = 1 implies QR for prime p (proved)"
@@ -82,13 +82,13 @@
   "overview": {
     "historicalContext": "Carl Gustav Jacob Jacobi introduced the Jacobi symbol in 1837 as a natural extension of the Legendre symbol to composite odd moduli. Where the Legendre symbol $(a/p)$ is defined only for prime $p$, the Jacobi symbol $J(a,n) = \\prod_i (a/p_i)^{e_i}$ extends the definition to any odd $n = \\prod p_i^{e_i}$. This generalization proved essential for computational number theory: the Jacobi symbol can be computed efficiently via a generalized Euclidean algorithm without knowing the factorization of $n$, making it central to primality testing algorithms like Solovay-Strassen (1977) and the Miller-Rabin test.\n\nThe key theoretical result is that quadratic reciprocity extends: for coprime odd integers $m, n > 1$, we have $J(m,n) \\cdot J(n,m) = (-1)^{(m-1)/2 \\cdot (n-1)/2}$. The proof reduces to the prime case via the multiplicative structure of the Jacobi symbol. This generalization was implicit in Jacobi's work and made explicit by Eisenstein and later Kronecker.",
     "problemStatement": "**Quadratic Reciprocity for the Jacobi Symbol**:\n\nFor coprime odd integers $m, n > 1$:\n\n$$J(m, n) \\cdot J(n, m) = (-1)^{\\frac{m-1}{2} \\cdot \\frac{n-1}{2}}$$\n\nwhere $J(a, n) = \\prod_{i} \\left(\\frac{a}{p_i}\\right)^{e_i}$ for $n = \\prod p_i^{e_i}$.\n\n**Supplements**:\n- First: $J(-1, n) = (-1)^{(n-1)/2}$ for odd $n > 1$\n- Second: $J(2, n) = (-1)^{(n^2-1)/8}$ for odd $n > 1$\n\n**Residuacity criterion**: $J(a,n) = -1$ guarantees $a$ is a non-residue mod $n$, but $J(a,n) = 1$ for composite $n$ does NOT guarantee $a$ is a quadratic residue.",
-    "text": "Extends quadratic reciprocity from the Legendre symbol (prime moduli) to the Jacobi symbol (composite odd moduli), formalizing the generalized reciprocity law J(m,n)\u00b7J(n,m) = (-1)^((m-1)/2\u00b7(n-1)/2) for coprime odd m,n.",
+    "text": "Extends quadratic reciprocity from the Legendre symbol (prime moduli) to the Jacobi symbol (composite odd moduli), formalizing the generalized reciprocity law J(m,n)·J(n,m) = (-1)^((m-1)/2·(n-1)/2) for coprime odd m,n.",
     "proofStrategy": "The formalization proceeds in three parts:\n\n1. **Basic Properties** (Part I): Establish that the Jacobi symbol agrees with the Legendre symbol for prime moduli via `jacobiSym.prime_eq_legendreSym`. Prove multiplicativity in the bottom argument: $J(a, mn) = J(a,m) \\cdot J(a,n)$ for odd $m, n$. State the first and second supplements.\n\n2. **Generalized QR** (Part II): State the main reciprocity law $J(m,n) \\cdot J(n,m) = (-1)^{(m-1)/2 \\cdot (n-1)/2}$ for coprime odd $m, n > 1$. The proof strategy is reduction to the prime case: factor $m$ and $n$ into primes, apply multiplicativity of the Jacobi symbol, then invoke classical QR for each prime pair.\n\n3. **Applications** (Part III): Derive residuacity criteria. Prove that $J(a,n) = -1$ implies $a$ is a non-residue (via `jacobiSym.sq_eq_one_of_isSquare` showing squares map to 1). For primes, prove the converse: $J(a,p) = 1$ with $a \\not\\equiv 0$ implies $a$ is a QR, using the Legendre symbol equivalence.",
     "keyInsights": [
-      "The Jacobi symbol J(a,n) = \u220f(a/p\u1d62)^e\u1d62 generalizes the Legendre symbol to composite odd moduli, preserving multiplicativity but losing the 'QR iff symbol = 1' equivalence.",
-      "Quadratic reciprocity J(m,n)\u00b7J(n,m) = (-1)^((m-1)/2\u00b7(n-1)/2) holds for all coprime odd m,n > 1, not just primes \u2014 the proof reduces to the prime case via multiplicativity.",
-      "J(a,n) = -1 guarantees a is a non-residue mod n, but J(a,n) = 1 for composite n does NOT guarantee a is a QR \u2014 this asymmetry is critical for primality testing algorithms.",
-      "The Jacobi symbol can be computed in O(log\u00b2 n) time via a generalized Euclidean algorithm, without factoring n \u2014 making it the computational backbone of Solovay-Strassen primality testing.",
+      "The Jacobi symbol J(a,n) = ∏(a/pᵢ)^eᵢ generalizes the Legendre symbol to composite odd moduli, preserving multiplicativity but losing the 'QR iff symbol = 1' equivalence.",
+      "Quadratic reciprocity J(m,n)·J(n,m) = (-1)^((m-1)/2·(n-1)/2) holds for all coprime odd m,n > 1, not just primes — the proof reduces to the prime case via multiplicativity.",
+      "J(a,n) = -1 guarantees a is a non-residue mod n, but J(a,n) = 1 for composite n does NOT guarantee a is a QR — this asymmetry is critical for primality testing algorithms.",
+      "The Jacobi symbol can be computed in O(log² n) time via a generalized Euclidean algorithm, without factoring n — making it the computational backbone of Solovay-Strassen primality testing.",
       "The supplements J(-1,n) and J(2,n) follow from their Legendre symbol analogues via multiplicativity over the prime factorization of n."
     ],
     "prerequisites": [
@@ -119,15 +119,15 @@
       "title": "Part II: Quadratic Reciprocity for the Jacobi Symbol",
       "startLine": 54,
       "endLine": 69,
-      "summary": "States and formalizes the generalized reciprocity law: J(m,n)\u00b7J(n,m) = (-1)^((m-1)/2\u00b7(n-1)/2) for coprime odd m, n > 1. The proof uses reduction to the prime case.",
+      "summary": "States and formalizes the generalized reciprocity law: J(m,n)·J(n,m) = (-1)^((m-1)/2·(n-1)/2) for coprime odd m, n > 1. The proof uses reduction to the prime case.",
       "mathContext": "Generalized reciprocity: $\\left(\\frac{m}{n}\\right)\\left(\\frac{n}{m}\\right) = (-1)^{(m-1)/2 \\cdot (n-1)/2}$ for odd coprime $m, n > 0$. Same form as the Legendre case but works for composite moduli."
     },
     {
       "id": "applications",
-      "title": "Part III: Applications \u2014 Quadratic Residuacity Criteria",
+      "title": "Part III: Applications — Quadratic Residuacity Criteria",
       "startLine": 70,
       "endLine": 90,
-      "summary": "Derives two key residuacity results: (1) J(a,n) = -1 implies non-residuacity (fully proved via contradiction with `sq_eq_one_of_isSquare`), and (2) for primes, J(a,p) = 1 with a \u2260 0 implies QR (proved by reducing to the Legendre symbol).",
+      "summary": "Derives two key residuacity results: (1) J(a,n) = -1 implies non-residuacity (fully proved via contradiction with `sq_eq_one_of_isSquare`), and (2) for primes, J(a,p) = 1 with a ≠ 0 implies QR (proved by reducing to the Legendre symbol).",
       "mathContext": "Key application: $\\left(\\frac{a}{n}\\right) = -1 \\Rightarrow a$ is a quadratic non-residue mod $n$. The converse fails for composite $n$: $\\left(\\frac{a}{n}\\right) = 1$ does not guarantee $a$ is a QR mod $n$."
     },
     {
@@ -158,22 +158,22 @@
     {
       "targetId": "euler-totient",
       "relationship": "foundational",
-      "description": "Euler's totient \u03c6(n) = |(\u2124/n\u2124)*| counts units modulo n, the domain of the Jacobi symbol. The CRT decomposition (\u2124/n\u2124)* \u2245 \u220f(\u2124/p\u1d62\u1d49\u2071\u2124)* connects the Jacobi symbol's multiplicativity to unit group structure"
+      "description": "Euler's totient φ(n) = |(ℤ/nℤ)*| counts units modulo n, the domain of the Jacobi symbol. The CRT decomposition (ℤ/nℤ)* ≅ ∏(ℤ/pᵢᵉⁱℤ)* connects the Jacobi symbol's multiplicativity to unit group structure"
     },
     {
       "targetId": "primitive-roots",
       "relationship": "foundational",
-      "description": "Primitive roots establish that (\u2124/p\u2124)* is cyclic, fundamental to the Legendre symbol: a is a QR mod p iff a^((p-1)/2) \u2261 1 (Euler's criterion)"
+      "description": "Primitive roots establish that (ℤ/pℤ)* is cyclic, fundamental to the Legendre symbol: a is a QR mod p iff a^((p-1)/2) ≡ 1 (Euler's criterion)"
     },
     {
       "targetId": "wilsons-theorem",
       "relationship": "related",
-      "description": "Wilson's theorem (p-1)! \u2261 -1 (mod p) connects to the first supplement of QR: (-1/p) = (-1)^((p-1)/2). Both characterize the multiplicative structure of (\u2124/p\u2124)*"
+      "description": "Wilson's theorem (p-1)! ≡ -1 (mod p) connects to the first supplement of QR: (-1/p) = (-1)^((p-1)/2). Both characterize the multiplicative structure of (ℤ/pℤ)*"
     },
     {
       "targetId": "fermat-two-squares",
       "relationship": "related",
-      "description": "Fermat's two-squares theorem (p = a\u00b2 + b\u00b2 iff p \u2261 1 mod 4) follows from (-1/p) = 1 iff p \u2261 1 mod 4, the first supplement extended by this formalization"
+      "description": "Fermat's two-squares theorem (p = a² + b² iff p ≡ 1 mod 4) follows from (-1/p) = 1 iff p ≡ 1 mod 4, the first supplement extended by this formalization"
     }
   ],
   "references": [
@@ -207,8 +207,8 @@
     "jacobi-symbol"
   ],
   "conclusion": {
-    "summary": "Complete verification of quadratic reciprocity for the Jacobi symbol in Lean 4. All 7 theorems fully proved with 0 sorries: Jacobi-Legendre agreement, multiplicativity, first supplement J(-1,n)=(-1)^(n/2), second supplement J(2,n)=(-1)^((n\u00b2-1)/8) via case analysis on n mod 8, main QR law J(m,n)\u00b7J(n,m)=(-1)^((m-1)/2\u00b7(n-1)/2), and both residuacity criteria.",
-    "implications": "**Theoretical Significance**: 1. **Computational number theory**: The Jacobi symbol's efficient computability (without factoring) makes this generalization practically essential for algorithms like Solovay-Strassen primality testing.\n**2. Proof architecture**: Demonstrates how composite-modulus results reduce to the prime case via multiplicativity \u2014 a pattern that recurs throughout algebraic number theory.\n3. **Formalization pathway**: The 4 sorries are routine Mathlib API calls, making this file a strong candidate for Aristotle automated proof search.\n4. **QR proof family**: Together with the Eisenstein (lattice point) and Zolotarev (permutation) proofs in the gallery, this provides a third perspective on quadratic reciprocity \u2014 the multiplicative extension to composite moduli.",
+    "summary": "Complete verification of quadratic reciprocity for the Jacobi symbol in Lean 4. All 7 theorems fully proved with 0 sorries: Jacobi-Legendre agreement, multiplicativity, first supplement J(-1,n)=(-1)^(n/2), second supplement J(2,n)=(-1)^((n²-1)/8) via case analysis on n mod 8, main QR law J(m,n)·J(n,m)=(-1)^((m-1)/2·(n-1)/2), and both residuacity criteria.",
+    "implications": "**Theoretical Significance**: 1. **Computational number theory**: The Jacobi symbol's efficient computability (without factoring) makes this generalization practically essential for algorithms like Solovay-Strassen primality testing.\n**2. Proof architecture**: Demonstrates how composite-modulus results reduce to the prime case via multiplicativity — a pattern that recurs throughout algebraic number theory.\n3. **Formalization pathway**: The 4 sorries are routine Mathlib API calls, making this file a strong candidate for Aristotle automated proof search.\n4. **QR proof family**: Together with the Eisenstein (lattice point) and Zolotarev (permutation) proofs in the gallery, this provides a third perspective on quadratic reciprocity — the multiplicative extension to composite moduli.",
     "openQuestions": [
       "Can the Jacobi symbol reciprocity proof be completed by finding the right Mathlib API calls for multiplicativity reduction?",
       "Can the Kronecker symbol (extending Jacobi to even moduli and arbitrary integers) be formalized as a further generalization?",

--- a/src/data/proofs/erdos-1092/meta.json
+++ b/src/data/proofs/erdos-1092/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-1092",
-  "title": "Erd\u0151s Problem #1092: Chromatic Decomposition Threshold",
+  "title": "Erdős Problem #1092: Chromatic Decomposition Threshold",
   "slug": "erdos-1092",
-  "description": "Let f_r(n) be max edges removable from each subgraph to reduce chromatic number to \u2264 r while forcing \u03c7(G) \u2264 r+1. Is f\u2082(n) \u226b n? R\u00f6dl (1982) gives f\u2082(n) = O(n\u00b7polylog). Open.",
+  "description": "Let f_r(n) be max edges removable from each subgraph to reduce chromatic number to ≤ r while forcing χ(G) ≤ r+1. Is f₂(n) ≫ n? Rödl (1982) gives f₂(n) = O(n·polylog). Open.",
   "meta": {
-    "author": "Erd\u0151s\u2013Hajnal\u2013Szemer\u00e9di",
+    "author": "Erdős–Hajnal–Szemerédi",
     "sourceUrl": "https://erdosproblems.com/1092",
     "status": "verified",
     "proofRepoPath": "Proofs/Erdos1092Problem.lean",
@@ -15,33 +15,33 @@
       "extremal-graph-theory",
       "open"
     ],
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "erdosNumber": 1092,
     "erdosUrl": "https://erdosproblems.com/1092",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
     "lineCount": 160,
-    "assumptions": "0 axioms, 0 sorries. 5 structural theorems fully proved. 2 True-stub documentation markers for disproved claims (Q1, Q2 refuted by R\u00f6dl 1982). Main conjectures removed; file is primarily graph coloring infrastructure.",
+    "assumptions": "0 axioms, 0 sorries. 5 structural theorems fully proved. 2 True-stub documentation markers for disproved claims (Q1, Q2 refuted by Rödl 1982). Main conjectures removed; file is primarily graph coloring infrastructure.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Erd\u0151s, Hajnal, and Szemer\u00e9di introduced this problem as part of their investigation into when local chromatic structure forces global coloring bounds. The function $f_r(n)$ captures a 'local-to-global' threshold: if every subgraph of an $n$-vertex graph can be made $r$-colorable by deleting at most $k$ edges, what is the largest $k$ that still forces $\\chi(G) \\leq r+1$? R\u00f6dl's 1982 construction provided a crucial upper bound, showing $f_2(n) = O(n \\cdot (\\log n)^2)$ via probabilistic and algebraic techniques. Tang subsequently observed that R\u00f6dl's construction directly addresses Question 1, providing evidence that $f_2(n) \\gg n$ may be false. The problem connects to broader themes in extremal graph theory: the interplay between local substructure (each piece is nearly $r$-colorable) and global properties (the whole graph has bounded chromatic number). Similar local-to-global phenomena appear in Szemer\u00e9di's regularity lemma, Brooks' theorem ($\\chi \\leq \\Delta + 1$ from local degree bounds), and Johansson's theorem ($\\chi = O(\\Delta/\\log \\Delta)$ for triangle-free graphs). The problem also relates to Erd\u0151s Problem #744, which considers variant chromatic decomposition thresholds.",
+    "historicalContext": "Erdős, Hajnal, and Szemerédi introduced this problem as part of their investigation into when local chromatic structure forces global coloring bounds. The function $f_r(n)$ captures a 'local-to-global' threshold: if every subgraph of an $n$-vertex graph can be made $r$-colorable by deleting at most $k$ edges, what is the largest $k$ that still forces $\\chi(G) \\leq r+1$? Rödl's 1982 construction provided a crucial upper bound, showing $f_2(n) = O(n \\cdot (\\log n)^2)$ via probabilistic and algebraic techniques. Tang subsequently observed that Rödl's construction directly addresses Question 1, providing evidence that $f_2(n) \\gg n$ may be false. The problem connects to broader themes in extremal graph theory: the interplay between local substructure (each piece is nearly $r$-colorable) and global properties (the whole graph has bounded chromatic number). Similar local-to-global phenomena appear in Szemerédi's regularity lemma, Brooks' theorem ($\\chi \\leq \\Delta + 1$ from local degree bounds), and Johansson's theorem ($\\chi = O(\\Delta/\\log \\Delta)$ for triangle-free graphs). The problem also relates to Erdős Problem #744, which considers variant chromatic decomposition thresholds.",
     "problemStatement": "Let $f_r(n)$ be the maximum $k$ such that if every $m$-vertex subgraph of an $n$-vertex graph $G$ can have its chromatic number reduced to $\\leq r$ by removing $\\leq k$ edges, then $\\chi(G) \\leq r+1$. Is $f_2(n) \\gg n$? More generally, is $f_r(n) \\gg_r rn$?",
-    "text": "Let f_r(n) be max edges removable from each subgraph to reduce chromatic number to \u2264 r while forcing \u03c7(G) \u2264 r+1. Is f\u2082(n) \u226b n? R\u00f6dl (1982) gives f\u2082(n) = O(n\u00b7polylog). Open.",
-    "proofStrategy": "The formalization builds custom graph infrastructure (`SGraph`, `edgeCount`, `hasColoring`, `chromaticNum`) and defines chromatic reduction via edge deletion (`CanReduceChromatic`). The threshold function `fThreshold r n` is defined as a supremum via `sSup`. Both main questions were removed (disproved by R\u00f6dl). Previously axiomatized claims (questions 1 & 2, trivial lower bound, monotonicity in r) were all found to be false and removed with documented counterexamples. The file now contains 0 axioms: only definitions and 5 proved structural theorems remain.",
+    "text": "Let f_r(n) be max edges removable from each subgraph to reduce chromatic number to ≤ r while forcing χ(G) ≤ r+1. Is f₂(n) ≫ n? Rödl (1982) gives f₂(n) = O(n·polylog). Open.",
+    "proofStrategy": "The formalization builds custom graph infrastructure (`SGraph`, `edgeCount`, `hasColoring`, `chromaticNum`) and defines chromatic reduction via edge deletion (`CanReduceChromatic`). The threshold function `fThreshold r n` is defined as a supremum via `sSup`. Both main questions were removed (disproved by Rödl). Previously axiomatized claims (questions 1 & 2, trivial lower bound, monotonicity in r) were all found to be false and removed with documented counterexamples. The file now contains 0 axioms: only definitions and 5 proved structural theorems remain.",
     "keyInsights": [
-      "The function $f_r(n)$ is a Tur\u00e1n-type extremal quantity for chromatic properties rather than subgraph avoidance: it measures the critical edge-deletion budget separating local reducibility from global colorability failure",
-      "R\u00f6dl's 1982 construction gives the upper bound $f_2(n) = O(n \\log^2 n)$, the only nontrivial bound known",
-      "The claimed trivial lower bound $f_r(n) \\geq n - 1$ is FALSE: K\u2083 + isolated vertex on 4 vertices satisfies local 1-reducibility with budget 3 but has $\\chi = 3 > 2$. The flaw in the tree argument is that fThreshold quantifies over ALL graphs, not just trees",
+      "The function $f_r(n)$ is a Turán-type extremal quantity for chromatic properties rather than subgraph avoidance: it measures the critical edge-deletion budget separating local reducibility from global colorability failure",
+      "Rödl's 1982 construction gives the upper bound $f_2(n) = O(n \\log^2 n)$, the only nontrivial bound known",
+      "The claimed trivial lower bound $f_r(n) \\geq n - 1$ is FALSE: K₃ + isolated vertex on 4 vertices satisfies local 1-reducibility with budget 3 but has $\\chi = 3 > 2$. The flaw in the tree argument is that fThreshold quantifies over ALL graphs, not just trees",
       "Monotonicity in $r$ ($f_r(n) \\leq f_{r+1}(n)$) fails in this formalization because sSup on $\\mathbb{N}$ returns 0 for unbounded sets: when $r+1 \\geq n$, the defining set is all of $\\mathbb{N}$ and fThreshold collapses to 0",
       "The local-to-global nature of the problem connects to a rich hierarchy: Brooks' theorem (degree $\\to$ chromatic number), Johansson's theorem (girth $\\to$ chromatic bound), regularity methods (approximate structure $\\to$ global properties), and this problem (approximate colorability $\\to$ global colorability)",
-      "A negative answer to Question 1 (which R\u00f6dl's evidence suggests) would mean that local near-bipartiteness does not strongly constrain global 3-colorability, revealing a fundamental limit of local-to-global reasoning in graph coloring"
+      "A negative answer to Question 1 (which Rödl's evidence suggests) would mean that local near-bipartiteness does not strongly constrain global 3-colorability, revealing a fundamental limit of local-to-global reasoning in graph coloring"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
       "Graph theory (vertices, edges, colorings)",
-      "Extremal graph theory (Tur\u00e1n-type problems)"
+      "Extremal graph theory (Turán-type problems)"
     ]
   },
   "sections": [
@@ -50,8 +50,8 @@
       "title": "Problem Statement and Imports",
       "startLine": 1,
       "endLine": 19,
-      "summary": "Docstring establishing Erd\u0151s Problem #1092 from Erd\u0151s\u2013Hajnal\u2013Szemer\u00e9di, with Tang's observation connecting R\u00f6dl's 1982 construction. Imports SimpleGraph.Basic, Finset.Basic, Nat.Basic, and Tactic.",
-      "mathContext": "Docstring establishing Erd\u0151s Problem #1092 from Erd\u0151s\u2013Hajnal\u2013Szemer\u00e9di, with Tang's observation connecting R\u00f6dl's 1982 construction. Imports SimpleGraph.Basic, Finset.Basic, Nat.Basic, and Tactic."
+      "summary": "Docstring establishing Erdős Problem #1092 from Erdős–Hajnal–Szemerédi, with Tang's observation connecting Rödl's 1982 construction. Imports SimpleGraph.Basic, Finset.Basic, Nat.Basic, and Tactic.",
+      "mathContext": "Docstring establishing Erdős Problem #1092 from Erdős–Hajnal–Szemerédi, with Tang's observation connecting Rödl's 1982 construction. Imports SimpleGraph.Basic, Finset.Basic, Nat.Basic, and Tactic."
     },
     {
       "id": "definitions",
@@ -82,35 +82,35 @@
       "title": "The Main Conjectures",
       "startLine": 64,
       "endLine": 75,
-      "summary": "Question 1: $f_2(n) \\gg n$ (super-linear growth for $r = 2$). Question 2: $f_r(n) \\gg_r rn$ for general $r \\geq 2$. Both disproved by R\u00f6dl (1982) and removed; only `True`-valued documentation notes remain.",
-      "mathContext": "Question 1: $f_2(n) \\gg n$ (super-linear growth for $r = 2$). Question 2: $f_r(n) \\gg_r rn$ for general $r \\geq 2$. Both disproved by R\u00f6dl (1982) and removed; only `True`-valued documentation notes remain."
+      "summary": "Question 1: $f_2(n) \\gg n$ (super-linear growth for $r = 2$). Question 2: $f_r(n) \\gg_r rn$ for general $r \\geq 2$. Both disproved by Rödl (1982) and removed; only `True`-valued documentation notes remain.",
+      "mathContext": "Question 1: $f_2(n) \\gg n$ (super-linear growth for $r = 2$). Question 2: $f_r(n) \\gg_r rn$ for general $r \\geq 2$. Both disproved by Rödl (1982) and removed; only `True`-valued documentation notes remain."
     },
     {
       "id": "rodl-bounds",
-      "title": "R\u00f6dl's Construction and Structural Properties",
+      "title": "Rödl's Construction and Structural Properties",
       "startLine": 94,
       "endLine": 160,
-      "summary": "Proved structural theorems: coloring self/monotonicity, CanReduceChromatic monotonicity in edges and colors. Documents removed unsound axioms (f_trivial_lower, erdos_744_connection, R\u00f6dl upper bound) with counterexamples. No axioms remain.",
-      "mathContext": "Proved structural theorems: coloring self/monotonicity, CanReduceChromatic monotonicity in edges and colors. Documents removed unsound axioms (f_trivial_lower, erdos_744_connection, R\u00f6dl upper bound) with counterexamples. No axioms remain."
+      "summary": "Proved structural theorems: coloring self/monotonicity, CanReduceChromatic monotonicity in edges and colors. Documents removed unsound axioms (f_trivial_lower, erdos_744_connection, Rödl upper bound) with counterexamples. No axioms remain.",
+      "mathContext": "Proved structural theorems: coloring self/monotonicity, CanReduceChromatic monotonicity in edges and colors. Documents removed unsound axioms (f_trivial_lower, erdos_744_connection, Rödl upper bound) with counterexamples. No axioms remain."
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erd\u0151s Problem #1092, an open question about the threshold for local-to-global chromatic number reduction. The function $f_r(n)$ measures the maximum edge-deletion budget under which local $r$-reducibility forces global $(r+1)$-colorability. R\u00f6dl's 1982 upper bound $O(n \\log^2 n)$ is the sole remaining axiom. Two previously axiomatized claims were found to be false: the trivial lower bound $f_r(n) \\geq n-1$ (counterexample: K\u2083 + isolated for r=1, n=4) and monotonicity in r (sSup pathology for unbounded sets).",
-    "implications": "**Theoretical Significance**: Resolution would clarify the fundamental limits of local-to-global reasoning in graph coloring.\n\nA positive answer would establish that local near-$r$-colorability strongly constrains global chromatic number, extending the philosophy behind Brooks' theorem and the regularity lemma. A negative answer (supported by R\u00f6dl's evidence) would show that local chromatic structure is insufficient to control global coloring, delineating a boundary for structural graph theory techniques.",
+    "summary": "This formalization captures Erdős Problem #1092, an open question about the threshold for local-to-global chromatic number reduction. The function $f_r(n)$ measures the maximum edge-deletion budget under which local $r$-reducibility forces global $(r+1)$-colorability. Rödl's 1982 upper bound $O(n \\log^2 n)$ is the sole remaining axiom. Two previously axiomatized claims were found to be false: the trivial lower bound $f_r(n) \\geq n-1$ (counterexample: K₃ + isolated for r=1, n=4) and monotonicity in r (sSup pathology for unbounded sets).",
+    "implications": "**Theoretical Significance**: Resolution would clarify the fundamental limits of local-to-global reasoning in graph coloring.\n\nA positive answer would establish that local near-$r$-colorability strongly constrains global chromatic number, extending the philosophy behind Brooks' theorem and the regularity lemma. A negative answer (supported by Rödl's evidence) would show that local chromatic structure is insufficient to control global coloring, delineating a boundary for structural graph theory techniques.",
     "openQuestions": [
       "Is $f_2(n) = \\Theta(n)$, or does it grow as $\\Theta(n \\log^\\alpha n)$ for some $\\alpha \\in (0, 2]$?",
-      "Does R\u00f6dl's construction generalize to $r \\geq 3$, or does the threshold behavior change for higher chromatic targets?",
+      "Does Rödl's construction generalize to $r \\geq 3$, or does the threshold behavior change for higher chromatic targets?",
       "Is there a spectral or algebraic characterization of graphs that are locally $r$-reducible but globally not $(r+1)$-colorable?",
-      "What is the relationship between $f_r(n)$ and the Lov\u00e1sz theta function or Ramsey numbers $R(r+1, r+1)$?"
+      "What is the relationship between $f_r(n)$ and the Lovász theta function or Ramsey numbers $R(r+1, r+1)$?"
     ]
   },
   "crossReferences": [
     {
-      "relationship": "Erd\u0151s Problem #744 studies a closely related edge-deletion threshold for k-critical bipartite graphs; R\u00f6dl and Tuza's disproof (1985) of #744 uses constructions directly relevant to Problem #1092",
+      "relationship": "Erdős Problem #744 studies a closely related edge-deletion threshold for k-critical bipartite graphs; Rödl and Tuza's disproof (1985) of #744 uses constructions directly relevant to Problem #1092",
       "targetId": "erdos-744"
     },
     {
-      "relationship": "Problem #58 (chromatic number vs. odd cycle lengths, solved by Gy\u00e1rf\u00e1s 1992) illustrates another dimension of local-to-global chromatic reasoning \u2014 cycle structure forcing \u03c7 \u2014 that complements the edge-deletion threshold approach of #1092",
+      "relationship": "Problem #58 (chromatic number vs. odd cycle lengths, solved by Gyárfás 1992) illustrates another dimension of local-to-global chromatic reasoning — cycle structure forcing χ — that complements the edge-deletion threshold approach of #1092",
       "targetId": "erdos-58"
     },
     {
@@ -118,7 +118,7 @@
       "targetId": "erdos-1091"
     },
     {
-      "relationship": "The Szemer\u00e9di Regularity Lemma is the canonical example of local approximate structure (\u03b5-regular pairs) controlling global graph properties; Problem #1092 asks an analogous local-to-global question for chromatic reducibility",
+      "relationship": "The Szemerédi Regularity Lemma is the canonical example of local approximate structure (ε-regular pairs) controlling global graph properties; Problem #1092 asks an analogous local-to-global question for chromatic reducibility",
       "targetId": "szemeredi-regularity"
     },
     {
@@ -129,9 +129,9 @@
   "references": [
     {
       "authors": [
-        "Erd\u0151s, P.",
+        "Erdős, P.",
         "Hajnal, A.",
-        "Szemer\u00e9di, E."
+        "Szemerédi, E."
       ],
       "title": "On almost bipartite large chromatic graphs",
       "venue": "Annals of Discrete Mathematics",
@@ -140,24 +140,24 @@
     },
     {
       "authors": [
-        "R\u00f6dl, V."
+        "Rödl, V."
       ],
       "title": "On the chromatic number of subgraphs of a given graph",
       "venue": "Proceedings of the American Mathematical Society",
       "volume": 64,
       "year": "1977",
-      "note": "R\u00f6dl's construction establishing the upper bound f_2(n) = O(n\u00b7(log n)^2), the key nontrivial bound for Problem #1092"
+      "note": "Rödl's construction establishing the upper bound f_2(n) = O(n·(log n)^2), the key nontrivial bound for Problem #1092"
     },
     {
       "authors": [
-        "R\u00f6dl, V.",
+        "Rödl, V.",
         "Tuza, Zs."
       ],
       "title": "Double-critical graph conjecture",
       "venue": "Graphs and Combinatorics",
       "volume": 8,
       "year": "1985",
-      "note": "Disproves Erd\u0151s Problem #744 using constructions related to edge-deletion thresholds; the methods are cited in the context of Problem #1092"
+      "note": "Disproves Erdős Problem #744 using constructions related to edge-deletion thresholds; the methods are cited in the context of Problem #1092"
     },
     {
       "authors": [
@@ -167,8 +167,8 @@
       "venue": "Mathematical Proceedings of the Cambridge Philosophical Society",
       "volume": 37,
       "year": "1941",
-      "pages": "194\u2013197",
-      "note": "Brooks' theorem (\u03c7(G) \u2264 \u0394(G) + 1) is the classical local-to-global coloring result; f_r(n) can be viewed as a quantitative variant of this local-degree-to-chromatic-number philosophy"
+      "pages": "194–197",
+      "note": "Brooks' theorem (χ(G) ≤ Δ(G) + 1) is the classical local-to-global coloring result; f_r(n) can be viewed as a quantitative variant of this local-degree-to-chromatic-number philosophy"
     },
     {
       "authors": [
@@ -177,13 +177,13 @@
       "title": "Asymptotic choice number for triangle free graphs",
       "venue": "DIMACS Technical Report",
       "year": "1996",
-      "note": "Johansson's theorem (\u03c7 = O(\u0394/log \u0394) for triangle-free graphs) is another landmark local-to-global chromatic bound; mentioned in the key insights as part of the broader hierarchy"
+      "note": "Johansson's theorem (χ = O(Δ/log Δ) for triangle-free graphs) is another landmark local-to-global chromatic bound; mentioned in the key insights as part of the broader hierarchy"
     },
-    "Erd\u0151s, Hajnal & Szemer\u00e9di: original question on chromatic decomposition thresholds",
-    "R\u00f6dl (1982), graph constructions with high chromatic number and local bipartiteness",
-    "Tang: observation connecting R\u00f6dl's construction to Problem #1092",
-    "Related to Erd\u0151s Problem #744 on chromatic decomposition",
-    "Brooks (1941), coloring theorem: \u03c7(G) \u2264 \u0394(G) + 1",
+    "Erdős, Hajnal & Szemerédi: original question on chromatic decomposition thresholds",
+    "Rödl (1982), graph constructions with high chromatic number and local bipartiteness",
+    "Tang: observation connecting Rödl's construction to Problem #1092",
+    "Related to Erdős Problem #744 on chromatic decomposition",
+    "Brooks (1941), coloring theorem: χ(G) ≤ Δ(G) + 1",
     "https://erdosproblems.com/1092"
   ],
   "leanFile": {

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-03/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-03/meta.json
@@ -44,7 +44,7 @@
       "intermediate"
     ],
     "proofRepoPath": "Proofs/SolutionOfCubicOQ03OQ03.lean",
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -77,7 +77,7 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
   },
   "overview": {
-    "historicalContext": "Lodovico Ferrari (1522-1565), a student of Gerolamo Cardano, discovered the method for solving quartic equations around 1540 by reducing them to a cubic resolvent. Cardano published both Ferrari's quartic solution and his own cubic formula in *Ars Magna* (1545). The chain of reductions \u2014 quartic \u2192 resolvent cubic \u2192 depressed cubic \u2192 radicals \u2014 represents one of the great algebraic achievements of the Renaissance. The key insight of this file: Ferrari's resolvent cubic is not in Cardano's depressed form by default, but the Tschirnhaus-style substitution m = t \u2212 5p/6 transforms it exactly. The primitive cube roots of unity \u03c9 = exp(2\u03c0i/3), satisfying \u03c9\u00b3=1 and 1+\u03c9+\u03c9\u00b2=0, are essential for expressing all three Cardano roots of the depressed resolvent, corresponding to the three solutions of the original quartic.",
+    "historicalContext": "Lodovico Ferrari (1522-1565), a student of Gerolamo Cardano, discovered the method for solving quartic equations around 1540 by reducing them to a cubic resolvent. Cardano published both Ferrari's quartic solution and his own cubic formula in *Ars Magna* (1545). The chain of reductions — quartic → resolvent cubic → depressed cubic → radicals — represents one of the great algebraic achievements of the Renaissance. The key insight of this file: Ferrari's resolvent cubic is not in Cardano's depressed form by default, but the Tschirnhaus-style substitution m = t − 5p/6 transforms it exactly. The primitive cube roots of unity ω = exp(2πi/3), satisfying ω³=1 and 1+ω+ω²=0, are essential for expressing all three Cardano roots of the depressed resolvent, corresponding to the three solutions of the original quartic.",
     "problemStatement": "**Does the resolvent cubic reduce to Cardano's depressed form?**\n\nThe resolvent cubic 8m^3 + 20pm^2 + (16p^2 - 8r)m + (4p^3 - 4pr - q^2) = 0 arises from Ferrari's method for the depressed quartic y^4 + py^2 + qy + r = 0.\n\n**Answer**: YES. The substitution m = t - 5p/6 transforms it into t^3 + At + B = 0 where A = -p^2/12 - r and B = -p^3/108 + pr/3 - q^2/8.",
     "text": "Proves that Ferrari's resolvent cubic for the quartic equation reduces to a depressed cubic solvable by Cardano's formula.",
     "proofStrategy": "The proof has three main parts: (1) Prove the ring identity that the resolvent at m = t - 5p/6 equals 8 times the depressed cubic, verified by ring. (2) Use mul_eq_zero to convert between the two forms (since 8 != 0). (3) Verify that Cardano roots of the depressed cubic give valid Ferrari parameters.",

--- a/src/data/proofs/triangle-inequality-oq-04/meta.json
+++ b/src/data/proofs/triangle-inequality-oq-04/meta.json
@@ -18,7 +18,7 @@
       "topology"
     ],
     "proofRepoPath": "Proofs/TriangleInequalityOQ04.lean",
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 284,


### PR DESCRIPTION
## Fix

8 proofs used badge values (`"verified"`, `"formalized"`) that are not defined in the `ProofBadgeType` TypeScript union type. This causes the `ProofBadge` UI component to silently render nothing (due to `if (!info) return null` in `src/components/ui/proof-badge.tsx:23`).

## Evidence

**Valid ProofBadge types** (`src/types/proof.ts`):
`'original' | 'mathlib' | 'pedagogical' | 'from-axioms' | 'fallacy' | 'wip' | 'ai-solved' | 'axiom' | 'infrastructure'`

**Before → After:**

| Proof | Old badge | New badge | Old status | New status |
|-------|-----------|-----------|------------|------------|
| `elementary-quadratic-reciprocity-oq-03` | `verified` | `original` | verified | verified |
| `cayley-hamilton-minpoly-oq-05-oq-02` | `verified` | `original` | verified | verified |
| `triangle-inequality-oq-04` | `verified` | `original` | verified | verified |
| `binomial-theorem-oq-03-oq-02-oq-03` | `verified` | `original` | verified | verified |
| `solution-of-cubic-oq-03-oq-03` | `verified` | `original` | verified | verified |
| `erdos-1092` | `verified` | `original` | verified | verified |
| `binomial-theorem-oq-02-oq-01-oq-02` | `verified` | `original` | verified | verified |
| `basel-problem-oq-01-oq-03` | `formalized` | `original` | formalized | **verified** |

The last proof (`basel-problem-oq-01-oq-03`) also had `status=formalized` despite having 0 sorries and 0 axioms. Updated to `verified`.

Build: passes (`pnpm build` ✓)

---
Automated fix by lean-mechanic agent.