### PR TITLE
fix(meta): correct 5 remaining invalid badge values (verified → mathlib)

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-02/meta.json
@@ -164,7 +164,7 @@
   },
   "sorryCount": 0,
   "status": "verified",
-  "badge": "verified",
+  "badge": "mathlib",
   "leanFile": {
     "imports": [
       "Mathlib"

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-03/meta.json
@@ -154,7 +154,7 @@
   },
   "sorryCount": 0,
   "status": "verified",
-  "badge": "verified",
+  "badge": "mathlib",
   "leanFile": {
     "imports": [
       "Mathlib",

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05/meta.json
@@ -185,7 +185,7 @@
   },
   "sorryCount": 0,
   "status": "verified",
-  "badge": "verified",
+  "badge": "mathlib",
   "leanFile": {
     "imports": [
       "Mathlib"

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-01/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-01/meta.json
@@ -21,7 +21,7 @@
   },
   "sorryCount": 0,
   "status": "verified",
-  "badge": "verified",
+  "badge": "mathlib",
   "crossReferences": [
     {
       "targetId": "solution-of-cubic-oq-03",

--- a/src/data/proofs/solution-of-cubic-oq-03/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03/meta.json
@@ -156,7 +156,7 @@
   },
   "sorryCount": 0,
   "status": "verified",
-  "badge": "verified",
+  "badge": "mathlib",
   "leanFile": {
     "imports": [
       "Mathlib.Analysis.SpecialFunctions.Pow.Complex",


### PR DESCRIPTION
## Fix

5 proofs used `badge: "verified"` (invalid ProofBadgeType) at the top level, causing the `ProofBadge` UI component to silently render nothing. Complements PR #9860 which fixed 8 similar cases (but missed these 5).

## Evidence

**Valid ProofBadge types** (`src/types/proof.ts`):
`'original' | 'mathlib' | 'pedagogical' | 'from-axioms' | 'fallacy' | 'wip' | 'ai-solved' | 'axiom' | 'infrastructure'`

**Before → After:**

| Proof | Old `badge` | New `badge` | `meta.badge` | sorries | axioms |
|-------|------------|------------|-------------|---------|--------|
| `cayley-hamilton-minpoly-oq-05-oq-01-oq-03` | `verified` | `mathlib` | `mathlib` | 0 | 0 |
| `cayley-hamilton-minpoly-oq-05-oq-01-oq-02` | `verified` | `mathlib` | `mathlib` | 0 | 0 |
| `cayley-hamilton-minpoly-oq-05` | `verified` | `mathlib` | `mathlib` | 0 | 0 |
| `solution-of-cubic-oq-03-oq-01` | `verified` | `mathlib` | `mathlib` | 0 | 0 |
| `solution-of-cubic-oq-03` | `verified` | `mathlib` | `mathlib` | 0 | 0 |

The new badge value matches the existing `meta.badge` for each proof.

---
Automated fix by lean-mechanic agent.