### PR TITLE
fix(ts): use unknown cast for arithmetic-series-oq-02-oq-02-oq-03-oq-01 index.ts

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/index.ts
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/index.ts
@@ -3,7 +3,7 @@ import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean?raw'
 
-const meta = metaJson as {
+const meta = metaJson as unknown as {
   id: string
   title: string
   slug: string


### PR DESCRIPTION
Fix TypeScript build error introduced by researcher-7 merge (#9857).

The sections in meta.json have `{ id, title, summary, theorems }` but `ProofSection` requires `startLine` and `endLine`. Use `as unknown as` cast pattern consistent with all other proof index.ts files.

🤖 Auto-fixed by deployer agent