### PR TITLE
fix(meta): acknowledge True-stub theorems and fix line count (bsd, weak-goldbach)

### DIFF
--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -16,7 +16,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 19,
-    "assumptions": "19 axiom declarations encoding: (1) L-function analytic continuation and functional equation, (2) Hasse bound a_p^2 <= 4p, (3) BSD conjecture proven cases (Kolyvagin rank 0, Gross-Zagier+Kolyvagin rank 1), (4) parity conjecture (Dokchitsers), (5) L-values and ranks for specific curves, (6) Sha structure, (7) Elkies rank record, (8) Greenberg-Stevens theorem, (9) regulator positivity. Previously 21 axioms: BSD_CM_rank_zero was proved redundant (subsumed by Kolyvagin general result), gross_zagier_formula_detail was dead code (captured by GrossZagierData structure). 0 sorries: regulator_rank_one_is_height proved by constructing CanonicalHeight h with h.height x = R·x² and generator g = 1.",
+    "assumptions": "19 axiom declarations encoding: (1) L-function analytic continuation and functional equation, (2) Hasse bound a_p^2 <= 4p, (3) BSD conjecture proven cases (Kolyvagin rank 0, Gross-Zagier+Kolyvagin rank 1), (4) parity conjecture (Dokchitsers), (5) L-values and ranks for specific curves, (6) Sha structure, (7) Elkies rank record, (8) Greenberg-Stevens theorem, (9) regulator positivity. Previously 21 axioms: BSD_CM_rank_zero was proved redundant (subsumed by Kolyvagin general result), gross_zagier_formula_detail was dead code (captured by GrossZagierData structure). 0 sorries: regulator_rank_one_is_height proved by constructing CanonicalHeight h with h.height x = R·x² and generator g = 1. Also: 3 definitions vacuously return Prop := True (p_adic_L_function, HeegnerPointExists, p_adic_height_pairing) — these concepts await rigorous formalization.",
     "mathlibDependencies": [
       {
         "theorem": "WeierstrassCurve",
@@ -50,7 +50,7 @@
       }
     ],
     "leanFile": {
-      "lineCount": 7422,
+      "lineCount": 7430,
       "structureCount": 92,
       "axiomCount": 19,
       "theoremCount": 254,
@@ -108,7 +108,7 @@
     "dateAdded": "2025-12-29",
     "millenniumProblem": "bsd",
     "proofRepoPath": "Proofs/BirchSwinnertonDyer.lean",
-    "lineCount": 7422,
+    "lineCount": 7430,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -681,7 +681,7 @@
       "ComplexConjugate"
     ],
     "namespace": "BirchSwinnertonDyer",
-    "lineCount": 7422,
+    "lineCount": 7430,
     "axiomCount": 19,
     "theoremCount": 254,
     "definitionCount": 143,

--- a/src/data/proofs/weak-goldbach/meta.json
+++ b/src/data/proofs/weak-goldbach/meta.json
@@ -19,7 +19,7 @@
     "sorries": 0,
     "dateAdded": "2026-04-02",
     "axiomCount": 9,
-    "assumptions": "9 axioms for deep analytic number theory results: vinogradov_ternary_goldbach (Vinogradov 1937: every sufficiently large odd number is sum of 3 primes), helfgott_weak_goldbach (Helfgott 2013: proved unconditionally for all odd n>5), circle_method_asymptotic (circle method asymptotic formula for ternary representations), schnirelmann_basis_theorem (every dense enough set is an additive basis), ramare_six_primes (Ramare 1995: every even n > 1 is sum of ≤ 6 primes), tao_five_primes (Tao 2012: every odd n > 1 is sum of ≤ 5 primes), chen_theorem (Chen 1973: every sufficiently large even n = p + P₂), binary_goldbach_verified (verified for n ≤ 4·10¹⁸), helfgott_explicit_bound (Helfgott's explicit bound).",
+    "assumptions": "9 axioms for deep analytic number theory results: vinogradov_ternary_goldbach (Vinogradov 1937: every sufficiently large odd number is sum of 3 primes), helfgott_weak_goldbach (Helfgott 2013: proved unconditionally for all odd n>5), circle_method_asymptotic (circle method asymptotic formula for ternary representations), schnirelmann_basis_theorem (every dense enough set is an additive basis), ramare_six_primes (Ramare 1995: every even n > 1 is sum of ≤ 6 primes), tao_five_primes (Tao 2012: every odd n > 1 is sum of ≤ 5 primes), chen_theorem (Chen 1973: every sufficiently large even n = p + P₂), binary_goldbach_verified (verified for n ≤ 4·10¹⁸), helfgott_explicit_bound (Helfgott's explicit bound). Also: 2 theorem-level True stubs (vinogradov_minor_arc_bound, linnik_goldbach_representations) — placeholder theorems proving True pending formalization of analytic bounds.",
     "lineCount": 480,
     "theoremCount": 24,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Addresses two auditor-filed gallery integrity issues.

## Changes

**weak-goldbach** (issue #9870):
- Adds to `assumptions`: "2 theorem-level True stubs (vinogradov_minor_arc_bound, linnik_goldbach_representations) — placeholder theorems proving True pending formalization of analytic bounds"

**birch-swinnerton-dyer** (issue #9869):
- Updates `lineCount` from 7422 → 7430 in 3 locations (leanFile, meta, and the duplicate field)
- Adds to `assumptions`: "3 definitions vacuously return Prop := True (p_adic_L_function, HeegnerPointExists, p_adic_height_pairing) — these concepts await rigorous formalization"

## Evidence

Both proofs retain correct `status: axiomatized` / `badge: axiom` — no overclaiming detected. These are transparency improvements only.

Closes #9869
Closes #9870

---
Automated fix by lean-mechanic agent.