### PR TITLE
Enrich Gaussian Lévy-Khintchine: 5 annotations, section fields, mathContext

### DIFF
--- a/src/data/proofs/central-limit-theorem-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-02-oq-01/annotations.json
@@ -1,1 +1,62 @@
-[]
+[
+  {
+    "id": "ann-clt-header",
+    "proofId": "central-limit-theorem-oq-01-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 38 },
+    "type": "context",
+    "title": "Gaussian Lévy-Khintchine Exponent: Setup and Imports",
+    "content": "The Lévy-Khintchine theorem (1934-1937) characterizes all infinitely divisible probability distributions via their characteristic function logarithm ψ(t). For the Gaussian N(μ,σ²), ψ(t) = iμt − σ²t²/2. This module derives the Complex arithmetic properties of ψ explicitly, complementing the parent entry (CentralLimitTheoremOQ01OQ02) which uses `simp` to prove ψ(0)=0. The open statement `open Complex CentralLimitTheoremOQ01OQ02` gives direct access to the Lean definition `gaussianExponent μ σ_sq t = ↑(μ*t) * I − ↑(σ_sq * t²/2)`.",
+    "mathContext": "$\\psi(t) = i\\mu t - \\frac{\\sigma^2 t^2}{2}$ in Lean: `gaussianExponent μ σ_sq t = ↑(μ*t) * I − ↑(σ_sq * t² / 2)`. Re$(\\psi(t)) = -\\sigma^2 t^2/2$ (damping), Im$(\\psi(t)) = \\mu t$ (drift).",
+    "significance": "context",
+    "relatedConcepts": ["Lévy-Khintchine representation", "characteristic function", "infinitely divisible distributions", "CentralLimitTheoremOQ01OQ02"],
+    "prerequisites": ["Complex number arithmetic in Lean 4", "gaussianExponent definition", "Complex.I, Complex.ofReal"]
+  },
+  {
+    "id": "ann-clt-re-im",
+    "proofId": "central-limit-theorem-oq-01-oq-02-oq-01",
+    "range": { "startLine": 43, "endLine": 69 },
+    "type": "technique",
+    "title": "Extracting Re and Im via Complex.simp Lemmas",
+    "content": "gaussianExponent_re and gaussianExponent_im extract the real and imaginary parts of ψ(t) using a standard `simp only` toolkit: Complex.sub_re/im (linearity of Re/Im), Complex.mul_re/im (product rule), Complex.I_re = 0, Complex.I_im = 1, Complex.ofReal_re = id, Complex.ofReal_im = 0. After simp unfolds, `ring` closes the arithmetic. This pattern — simp only [all relevant Complex lemmas] + ring — is the idiomatic way to compute Re/Im of Complex expressions in Lean 4 Mathlib.",
+    "mathContext": "Re$(a \\cdot I - b) = a \\cdot \\text{Re}(I) - b \\cdot \\text{Re}(1) = a \\cdot 0 - b = -b$ (for real $a,b$). Im$(a \\cdot I - b) = a \\cdot \\text{Im}(I) - b \\cdot \\text{Im}(1) = a \\cdot 1 - 0 = a$.",
+    "significance": "key",
+    "relatedConcepts": ["Complex.sub_re", "Complex.mul_re", "Complex.I_re", "Complex.ofReal_re", "simp + ring pattern"],
+    "prerequisites": ["Complex.re/im field accessors", "Lean 4 simp only tactic", "Complex.I definition"]
+  },
+  {
+    "id": "ann-clt-pure-imaginary",
+    "proofId": "central-limit-theorem-oq-01-oq-02-oq-01",
+    "range": { "startLine": 71, "endLine": 84 },
+    "type": "insight",
+    "title": "Pure Imaginary Case: σ²=0 Means Pure Rotation",
+    "content": "When σ²=0, the Gaussian distribution degenerates to a point mass at μ (a Dirac delta), and its characteristic function is e^{iμt} — a pure rotation on the complex unit circle with no decay. The Lévy-Khintchine exponent becomes ψ(t) = iμt with zero real part. gaussianExponent_pure_imaginary proves ψ μ 0 t = (μ*t)·I directly by simp. gaussianExponent_zero_sigma_re then follows immediately: Re(iμt) = 0. This case is the boundary between the Dirac delta (σ=0) and the true Gaussian (σ>0) regimes.",
+    "mathContext": "$\\psi_{\\sigma=0}(t) = i\\mu t$, so $e^{\\psi(t)} = e^{i\\mu t}$ — the characteristic function of the point mass $\\delta_\\mu$. Re$(\\psi) = 0$ means the characteristic function stays on the unit circle for all $t$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Dirac delta characteristic function", "unit circle", "degenerate Gaussian", "Pure imaginary complex numbers"],
+    "prerequisites": ["gaussianExponent definition", "simp with ofReal_zero", "σ²=0 specialization"]
+  },
+  {
+    "id": "ann-clt-symmetry",
+    "proofId": "central-limit-theorem-oq-01-oq-02-oq-01",
+    "range": { "startLine": 86, "endLine": 100 },
+    "type": "insight",
+    "title": "Even/Odd Symmetry: Conjugate Symmetry of Real-Valued RVs",
+    "content": "gaussianExponent_re_even (Re(ψ(−t)) = Re(ψ(t))) and gaussianExponent_im_odd (Im(ψ(−t)) = −Im(ψ(t))) together imply ψ(−t) = conj(ψ(t)), which means exp(ψ(−t)) = conj(exp(ψ(t))). This is the conjugate symmetry property φ(−t) = conj(φ(t)) that characterizes characteristic functions of real-valued random variables. The proofs are 2-line: `simp only [gaussianExponent_re]; ring` using (−t)² = t². This symmetry is fundamental in Fourier analysis and probability theory.",
+    "mathContext": "Re$(\\psi(-t)) = -\\sigma^2(-t)^2/2 = -\\sigma^2 t^2/2 = $ Re$(\\psi(t))$ (even). Im$(\\psi(-t)) = \\mu(-t) = -\\mu t = -$Im$(\\psi(t))$ (odd). Combined: $\\psi(-t) = \\overline{\\psi(t)}$, so $\\varphi(-t) = \\overline{\\varphi(t)}$.",
+    "significance": "key",
+    "relatedConcepts": ["conjugate symmetry of characteristic functions", "real-valued random variables", "Fourier transform symmetry", "even/odd functions"],
+    "prerequisites": ["gaussianExponent_re", "gaussianExponent_im", "ring for polynomial symmetry"]
+  },
+  {
+    "id": "ann-clt-char-fn-zero",
+    "proofId": "central-limit-theorem-oq-01-oq-02-oq-01",
+    "range": { "startLine": 102, "endLine": 112 },
+    "type": "insight",
+    "title": "gaussianCharFn_at_zero: Normalization Condition",
+    "content": "Every characteristic function φ(t) = E[e^{itX}] satisfies φ(0) = E[e^0] = E[1] = 1. This normalization is proved here as exp(ψ(0)) = exp(0) = 1 via Complex.exp_zero. The proof chain: `rw [gaussianExponent_zero]` uses ψ(0) = 0 (proved in parent entry), then `exact Complex.exp_zero`. This is a fundamental sanity check for the Lévy-Khintchine formula and is needed in any CLT proof to verify the normalization condition.",
+    "mathContext": "$\\varphi(0) = \\exp(\\psi(0)) = \\exp(0) = 1$. In general: $\\varphi(t) = \\exp(\\psi(t))$ where $\\psi(0) = i\\mu \\cdot 0 - \\sigma^2 \\cdot 0^2/2 = 0$.",
+    "significance": "supporting",
+    "relatedConcepts": ["characteristic function normalization", "Complex.exp_zero", "gaussianExponent_zero (parent entry)", "Lévy continuity theorem"],
+    "prerequisites": ["gaussianExponent_zero (CentralLimitTheoremOQ01OQ02)", "Complex.exp_zero", "Complex arithmetic"]
+  }
+]

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-02-oq-01/meta.json
@@ -56,8 +56,8 @@
       "title": "Real and Imaginary Parts of ψ",
       "summary": "Re(ψ(t)) = −σ²t²/2 and Im(ψ(t)) = μt proved via Complex arithmetic lemmas",
       "content": "gaussianExponent_re uses Complex.sub_re + Complex.mul_re + I_re/im + ofReal_re/im then ring. gaussianExponent_im uses Complex.sub_im + Complex.mul_im + I_re/im + ofReal_re/im then ring.",
-      "lineStart": 47,
-      "lineEnd": 67,
+      "startLine": 47,
+      "endLine": 67,
       "theorems": [
         "gaussianExponent_zero_explicit",
         "gaussianExponent_re",
@@ -69,8 +69,8 @@
       "title": "Pure Imaginary Case (σ² = 0)",
       "summary": "When σ² = 0, ψ(t) = iμt is purely imaginary — pure rotation with no damping",
       "content": "gaussianExponent_pure_imaginary proves ψ μ 0 t = (μ*t)*I directly by simp. gaussianExponent_zero_sigma_re derives Re = 0 from gaussianExponent_re.",
-      "lineStart": 69,
-      "lineEnd": 83,
+      "startLine": 69,
+      "endLine": 83,
       "theorems": [
         "gaussianExponent_pure_imaginary",
         "gaussianExponent_zero_sigma_re"
@@ -81,8 +81,8 @@
       "title": "Even/Odd Symmetry of ψ",
       "summary": "Re(ψ(−t)) = Re(ψ(t)) (even) and Im(ψ(−t)) = −Im(ψ(t)) (odd)",
       "content": "gaussianExponent_re_even: simp [gaussianExponent_re] then ring, using (−t)² = t². gaussianExponent_im_odd: simp [gaussianExponent_im] then ring, using μ(−t) = −μt.",
-      "lineStart": 85,
-      "lineEnd": 97,
+      "startLine": 85,
+      "endLine": 97,
       "theorems": [
         "gaussianExponent_re_even",
         "gaussianExponent_im_odd"
@@ -93,8 +93,8 @@
       "title": "Characteristic Function at t = 0",
       "summary": "exp(ψ(0)) = 1 — every characteristic function is normalized to 1 at the origin",
       "content": "gaussianCharFn_at_zero: rw [gaussianExponent_zero] reduces to exp(0) = 1, then Complex.exp_zero.",
-      "lineStart": 99,
-      "lineEnd": 107,
+      "startLine": 99,
+      "endLine": 107,
       "theorems": [
         "gaussianCharFn_at_zero"
       ]


### PR DESCRIPTION
Enriches `central-limit-theorem-oq-01-oq-02-oq-01` (Gaussian Lévy-Khintchine Exponent: Complex Arithmetic Properties).

## Changes
- **annotations.json**: Added 5 annotations covering all 7 theorems:
  - Header context (lines 1–38): Lévy-Khintchine theorem, σ² damping vs μ drift
  - `simp+ring` pattern for Re/Im (lines 43–69): key technique annotation
  - Pure imaginary case σ²=0 (lines 71–84): Dirac delta characteristic function insight
  - Even/odd symmetry (lines 86–100): conjugate symmetry φ(−t) = conj(φ(t)) insight
  - Normalization φ(0)=1 (lines 102–112): fundamental normalization condition
- **meta.json**: Fixed section field names `lineStart`/`lineEnd` → `startLine`/`endLine` (standard schema)

## Mathematical Content
All annotations include `mathContext` with LaTeX formulas and Lean 4 code cross-references.

🤖 enricher-2 autonomous enrichment