### PR TITLE
Fix: derangements-convergence-oq-01 — mark verified (sorries 1→0)

### DIFF
--- a/src/data/proofs/derangements-convergence-oq-01/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "researcher-7",
     "date": "2026-04-04",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/DerangementsConvergenceOQ01.lean",
     "tags": [
       "probability",
@@ -18,10 +18,10 @@
       "permutations",
       "research"
     ],
-    "badge": "axiom",
-    "sorries": 1,
+    "badge": "verified",
+    "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "1 sorry: derangements_rate — |D(n)/n! - e⁻¹| ≤ 1/(n+1)!. This is the alternating series estimation theorem applied to the Taylor series for e⁻¹. The parent file DerangementsConvergence.lean proves this result but has pre-existing Mathlib API issues (∑ k in vs ∑ k ∈ syntax) preventing import. The convergence result kFixed_tendsto is fully proved without this sorry, using Mathlib's numDerangements_tendsto_inv_e directly.",
+    "assumptions": "No assumptions. All theorems are fully machine-checked. The derangements_rate lemma delegates to derangements_convergence_rate from DerangementsConvergence.lean, which proves |D(n)/n! - e⁻¹| ≤ 1/(n+1)! via the alternating series estimation theorem.",
     "dateAdded": "2026-04-04",
     "lineCount": 151,
     "theoremCount": 7,


### PR DESCRIPTION
## Fix

Update `derangements-convergence-oq-01` metadata to reflect that the proof is fully machine-checked with 0 sorries.

## Evidence

**Before**: `status: "formalized"`, `sorries: 1`, `badge: "axiom"`, assumptions described a pending sorry for `derangements_rate`

**After**: `status: "verified"`, `sorries: 0`, `badge: "verified"`, assumptions state all theorems are fully machine-checked

## Root Cause

The `derangements_rate` lemma in `DerangementsConvergenceOQ01.lean` (line 90-93) is proved by:
```lean
derangements_convergence_rate n
```
This calls `derangements_convergence_rate` from the imported `Proofs.DerangementsConvergence`, which is a proven theorem (0 sorries in `DerangementsConvergence.lean`, `status: verified`). No sorry appears anywhere in the code of `DerangementsConvergenceOQ01.lean`.

The metadata was written assuming the parent file had a pre-existing syntax issue, but that issue was resolved. The OQ01 file already delegates correctly to the proved theorem.

---
Automated fix by lean-mechanic agent.