### PR TITLE
Fix: shannon-channel-coding-oq-03 — correct sorry count 7→3, add Aristotle companion

### DIFF
--- a/proofs/Proofs/ShannonChannelCodingOQ03Aristotle.lean
+++ b/proofs/Proofs/ShannonChannelCodingOQ03Aristotle.lean
@@ -1,0 +1,104 @@
+/-
+  Aristotle targets for Fano's Inequality (ShannonChannelCodingOQ03)
+  Routine supporting lemmas for automated proof search.
+  See ShannonChannelCodingOQ03.lean for the main formalization.
+
+  Targets:
+  - fano_func_mono: monotonicity of h(p) + p·log(c) on [0, c/(1+c)] for c ≥ 1
+  - collision_prob_lower_bound: ∑ q(x)² ≥ 1/n for any prob. dist. on Fin n (Cauchy-Schwarz)
+  - pe_upper_bound: the formula P_e ≤ (n-1)/n (from collision bound)
+  - fano_map_bound: H(X|Y) ≤ h(P_e^{MAP}) + P_e^{MAP}·log(|X|-1) (Jensen + per-slice Fano)
+
+  NOT included:
+  - fano_theorem (main open channel coding result — assembles the above)
+  - fano_per_element (already proved in main file)
+  - gibbs_inequality (already proved in main file)
+-/
+import Mathlib
+
+open Real Finset InformationTheory.BinaryEntropy
+
+namespace ShannonChannelCodingOQ03Aristotle
+
+-- ============================================================
+-- Local definitions (matching ShannonChannelCodingOQ03.lean)
+-- ============================================================
+
+noncomputable def shannonEntropy' {α : Type*} [Fintype α] [DecidableEq α]
+    (p : α → ℝ) : ℝ :=
+  -∑ x : α, if p x = 0 then 0 else p x * Real.log (p x)
+
+noncomputable def conditionalEntropy' {α β : Type*} [Fintype α] [Fintype β]
+    [DecidableEq α] [DecidableEq β]
+    (pXY : α × β → ℝ) : ℝ :=
+  -(∑ x : α, ∑ y : β,
+    if pXY (x, y) = 0 then 0
+    else pXY (x, y) * Real.log (pXY (x, y) / (∑ x' : α, pXY (x', y))))
+
+noncomputable abbrev maxProb' {α : Type*} [Fintype α] [Nonempty α] (q : α → ℝ) : ℝ :=
+  Finset.sup' Finset.univ Finset.univ_nonempty q
+
+noncomputable def mapErrorProb' {α β : Type*} [Fintype α] [Fintype β] [Nonempty α]
+    (pXY : α × β → ℝ) : ℝ :=
+  1 - ∑ y : β, maxProb' (fun x => pXY (x, y))
+
+-- ============================================================
+-- Target 1: Monotonicity of Fano function
+-- ============================================================
+
+/-- For c ≥ 1, f(p) = h(p) + p·log c is non-decreasing on [0, c/(1+c)].
+    Proof sketch: f'(p) = -log p + log(1-p) + log c = log(c(1-p)/p) ≥ 0
+    iff c(1-p)/p ≥ 1 iff p ≤ c/(1+c). So f is increasing on [0, c/(1+c)]. -/
+theorem fano_func_mono {c : ℝ} (hc : 1 ≤ c) {p₁ p₂ : ℝ}
+    (hp₁ : 0 ≤ p₁) (hp₂ : p₂ ≤ c / (1 + c)) (hpp : p₁ ≤ p₂) :
+    h p₁ + p₁ * Real.log c ≤ h p₂ + p₂ * Real.log c := by
+  sorry
+
+-- ============================================================
+-- Target 2: Cauchy-Schwarz lower bound on collision probability
+-- ============================================================
+
+/-- For any probability distribution q on a Fintype α with n = |α| elements,
+    ∑_x q(x)² ≥ 1/n.
+    Proof: by Cauchy-Schwarz, (∑ q(x))² ≤ n · ∑ q(x)², so 1 ≤ n · ∑ q(x)². -/
+theorem collision_prob_lower_bound {α : Type*} [Fintype α] [Nonempty α]
+    {q : α → ℝ} (hq : ∀ x, 0 ≤ q x) (hqsum : ∑ x, q x = 1) :
+    1 / (Fintype.card α : ℝ) ≤ ∑ x, q x ^ 2 := by
+  sorry
+
+-- ============================================================
+-- Target 3: Formula P_e ≤ (n-1)/n upper bound
+-- ============================================================
+
+/-- For a valid joint distribution pXY on α × β with |α| = n ≥ 2:
+    1 - ∑_y ∑_x pXY(x,y)²/P(Y=y) ≤ (n-1)/n
+    Proof: by collision_prob_lower_bound, each ∑_x P(X=x|Y=y)² ≥ 1/n,
+    hence ∑_y P(Y=y)·(∑_x P(X=x|Y=y)²) ≥ 1/n, so P_e ≤ 1-1/n = (n-1)/n. -/
+theorem pe_upper_bound {α β : Type*} [Fintype α] [Fintype β] [Nonempty α]
+    (hn : 1 < Fintype.card α)
+    {pXY : α × β → ℝ} (hp : ∀ x, 0 ≤ pXY x) (hsum : ∑ x, pXY x = 1) :
+    1 - ∑ y : β, ∑ x : α, pXY (x, y) ^ 2 / (∑ x' : α, pXY (x', y)) ≤
+      ((Fintype.card α : ℝ) - 1) / (1 + ((Fintype.card α : ℝ) - 1)) := by
+  sorry
+
+-- ============================================================
+-- Target 4: Conditional entropy MAP Fano bound
+-- ============================================================
+
+/-- H(X|Y) ≤ h(P_e^{MAP}) + P_e^{MAP} · log(|X| - 1).
+    Proof sketch:
+    1. Decompose H(X|Y) = ∑_y P(Y=y) · H(X|Y=y)
+    2. For each y, H(X|Y=y) ≤ h(1 - max_x P(X=x|Y=y)) + (1 - max_x P(X=x|Y=y)) · log(n-1)
+       (per-slice Fano: fano_per_element from main file)
+    3. P_e^{MAP} = 1 - ∑_y max_x P(X=x,Y=y) = ∑_y P(Y=y) · (1 - max_x P(X=x|Y=y))
+    4. Apply Jensen (or direct linearity) with concavity of h. -/
+theorem fano_map_bound {α β : Type*} [Fintype α] [Fintype β]
+    [DecidableEq α] [DecidableEq β] [Nonempty α]
+    (hn : 1 < Fintype.card α)
+    (pXY : α × β → ℝ) (hp : ∀ x, 0 ≤ pXY x) (hsum : ∑ x, pXY x = 1) :
+    conditionalEntropy' pXY ≤
+      h (mapErrorProb' pXY) +
+      mapErrorProb' pXY * Real.log ((Fintype.card α : ℝ) - 1) := by
+  sorry
+
+end ShannonChannelCodingOQ03Aristotle

--- a/src/data/proofs/shannon-channel-coding-oq-03/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-03/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "wip",
-    "sorries": 7,
+    "sorries": 3,
     "mathlibDependencies": [
       {
         "theorem": "Finset.le_sup'",
@@ -47,7 +47,7 @@
       "fano_theorem: complete proof structure connecting MAP Fano → monotonicity → formula P_e version",
       "Identified that ShannonEntropy.lean has a pre-existing build issue in strong_subadditivity (linarith failure at line 811)"
     ],
-    "assumptions": "7 sorries: gibbs_inequality, slice_sq_le_max, fano_per_element, fano_map_bound, fano_func_mono, and 2 inline sorries in fano_theorem (hmap_nn non-negativity, monotonicity step). No axioms.",
+    "assumptions": "3 sorries: fano_map_bound (H(X|Y) ≤ h(P_e^{MAP}) + P_e^{MAP}·log(n-1), requires Jensen for concave h), fano_func_mono (monotonicity of h(p)+p·log(c) on [0,c/(1+c)], requires calculus), and hpe_bound (inline: P_e ≤ (n-1)/n, requires Cauchy-Schwarz). All 5 earlier sorries (gibbs_inequality, slice_sq_le_max, fano_per_element, formula_pe_ge_map_pe, and hmap_nn) are now proved. Aristotle companion: ShannonChannelCodingOQ03Aristotle.lean. No axioms.",
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
     "lineCount": 255,
@@ -190,7 +190,7 @@
     "namespace": "FanoInequality",
     "lineCount": 256,
     "axiomCount": 0,
-    "sorries": 7,
+    "sorries": 3,
     "path": "Proofs/ShannonChannelCodingOQ03.lean",
     "theoremCount": 8,
     "definitionCount": 4


### PR DESCRIPTION
## Fix

Two changes to `shannon-channel-coding-oq-03`:
1. Correct the sorry count in `meta.json` from 7 to 3
2. Add `ShannonChannelCodingOQ03Aristotle.lean` for automated proof search

## Evidence

**Before**: `sorries: 7` in meta.json; description listed 7 sorries including gibbs_inequality, slice_sq_le_max, fano_per_element, etc.

**After**: `sorries: 3` — only the actual code sorries (fano_map_bound, fano_func_mono, hpe_bound inline in fano_theorem). The other 4 lemmas (gibbs_inequality, slice_sq_le_max, fano_per_element, formula_pe_ge_map_pe) are fully proved in the current `ShannonChannelCodingOQ03.lean` file (lines 130-296, no sorry).

## Aristotle Companion

`ShannonChannelCodingOQ03Aristotle.lean` exposes 4 Aristotle targets:
- `fano_func_mono` — monotonicity of h(p)+p·log(c) on [0, c/(1+c)]
- `collision_prob_lower_bound` — ∑q(x)² ≥ 1/n (Cauchy-Schwarz)
- `pe_upper_bound` — formula P_e ≤ (n-1)/n
- `fano_map_bound` — H(X|Y) ≤ h(P_e^{MAP}) + P_e^{MAP}·log(n-1)

Pre-submission checklist: no def sorries, no axioms, no True placeholders, no `/-!` blocks.

---
Automated fix by lean-mechanic agent.