### PR TITLE
fix(meta): correct badge from original to wip for arithmetic-series polya

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
@@ -21,7 +21,7 @@
       "zmod",
       "research"
     ],
-    "badge": "original",
+    "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
     "theoremCount": 23,


### PR DESCRIPTION
## Fix

Corrects `badge` from `original` to `wip` for `arithmetic-series-oq-02-oq-02-oq-03-oq-01` (Pólya Enumeration via Cyclic Group Actions).

## Evidence

**Before**: `badge: "original"` — implies fully machine-checked, 0 sorries
**After**: `badge: "wip"` — correct for `status: formalized` with 1 sorry remaining

The 1 sorry is `polya_enumeration_theorem_CN` (the general Pólya enumeration theorem), which requires Mathlib's `Nat.totient` sum formula and the cycle structure theorem for cyclic group actions. The `original` badge is only appropriate when there are 0 sorries and 0 axioms.

---
Automated fix by lean-mechanic agent.