### PR TITLE
Enrich 3 proofs: Erdős #848 OQ-01, Pólya enumeration, and more

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-polya-zmod-action",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
+    "range": { "startLine": 62, "endLine": 103 },
+    "type": "insight",
+    "title": "ZMod-Indexed Colorings: The Axiom-Free Group Action",
+    "content": "The critical design choice: `ZColoring n k = ZMod n → Fin k` uses ZMod n indices instead of Fin n. This makes rotation `r +ᵥ c = fun i => c(i−r)` trivially an action: the law `(r+s) +ᵥ c = r +ᵥ (s +ᵥ c)` reduces to `c(i−(r+s)) = c((i−r)−s)`, which is just `sub_sub` in ZMod. No modular arithmetic lemmas are needed. With Fin n indices, the same action would require `Fin.sub_def` and careful case splitting on overflow. The `IsRotFixed` predicate captures fixed colorings: r +ᵥ c = c, i.e., c(i−r) = c(i) for all positions i.",
+    "mathContext": "Group action: $\\text{ZMod}\\,n \\curvearrowright (\\text{ZMod}\\,n \\to \\text{Fin}\\,k)$ by $(r +_v c)(i) = c(i - r)$. Action axiom: $c(i-(r+s)) = c((i-r)-s)$ by `sub_sub` in $\\mathbb{Z}/n\\mathbb{Z}$.",
+    "significance": "key",
+    "relatedConcepts": ["group action", "ZMod subtraction", "sub_sub lemma", "AddAction typeclass", "axiom-free proofs"],
+    "prerequisites": ["group actions in Lean 4", "ZMod arithmetic", "AddAction vs MulAction distinction"]
+  },
+  {
+    "id": "ann-polya-fixed-points",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
+    "range": { "startLine": 105, "endLine": 157 },
+    "type": "technique",
+    "title": "Fixed-Point Counts via native_decide",
+    "content": "The fixed-point cardinalities are computed by `native_decide`, which runs compiled Lean code: Lean compiles the `Fintype.card` computation and evaluates it at compile time. Fix(0) = 16 is derived differently — via an explicit equivalence between {c : ZColoring 4 2 | IsRotFixed 4 2 0 c} and ZColoring 4 2 (since 0 fixes everything), then applying `zcoloring_4_2_card`. Fix(1) = 2 reflects that only constant colorings are fixed by 90° rotation (c(i−1) = c(i) for all i means c is constant). Fix(2) = 4 reflects period-2 colorings: c₀ = c₂ and c₁ = c₃, giving 2 free binary choices = 4 options. Fix(3) = 2 by symmetry with Fix(1) (270° ≡ −90° rotation).",
+    "mathContext": "$|\\text{Fix}(r)| = k^{\\gcd(r, n)}$ for rotation by $r$ in $\\mathbb{Z}/n\\mathbb{Z}$. For $n=4, k=2$: $|\\text{Fix}(0)| = 2^4 = 16$; $|\\text{Fix}(1)| = 2^{\\gcd(1,4)} = 2^1 = 2$; $|\\text{Fix}(2)| = 2^{\\gcd(2,4)} = 2^2 = 4$; $|\\text{Fix}(3)| = 2^{\\gcd(3,4)} = 2^1 = 2$.",
+    "significance": "supporting",
+    "relatedConcepts": ["native_decide tactic", "Fintype.card", "fixed-point sets", "periodic colorings", "cycle structure theorem"],
+    "prerequisites": ["native_decide in Lean 4", "fixed points of group actions", "periodic sequences"]
+  },
+  {
+    "id": "ann-polya-burnside",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
+    "range": { "startLine": 159, "endLine": 197 },
+    "type": "insight",
+    "title": "Burnside's Lemma: 6 Binary 4-Necklaces",
+    "content": "The central computation applies `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group` from Mathlib. This abstract lemma states: |Orbits| × |G| = Σ_{g∈G} |Fix(g)|. For ZMod 4 on binary 4-colorings: |Orbits| × 4 = 24, so |Orbits| = 6. The technical subtlety is the `Eq.trans` trick: Burnside's statement uses `∑ a`, but the fixed-point computation uses `∑ g`. A direct `rw` fails due to bound variable name mismatch, but `hb.symm.trans h1` chains the equalities without naming the bound variable. The orbit quotient `orbitRel.Quotient (Multiplicative (ZMod 4)) (ZColoring 4 2)` is the Lean type of distinct necklaces.",
+    "mathContext": "Burnside's lemma: $|X/G| = \\frac{1}{|G|} \\sum_{g \\in G} |\\text{Fix}(g)|$. For $G = C_4$, $X = \\{0,1\\}^4$: $|\\text{Necklaces}| = \\frac{16+2+4+2}{4} = \\frac{24}{4} = 6$.",
+    "significance": "key",
+    "relatedConcepts": ["Burnside's lemma", "orbitRel.Quotient", "MulAction.fixedBy", "Eq.trans technique", "Multiplicative ZMod"],
+    "prerequisites": ["Burnside's lemma", "orbit-stabilizer theorem", "Mathlib GroupAction.Quotient module"]
+  },
+  {
+    "id": "ann-polya-formula-verification",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
+    "range": { "startLine": 199, "endLine": 279 },
+    "type": "technique",
+    "title": "Pólya Formula: Verifying the Divisor Sum",
+    "content": "The Pólya formula `n · |Necklaces(n,k)| = Σ_{d|n} φ(d) · k^{n/d}` is verified for n=2,3,4,6 with k=2. Each case is a `norm_num` computation after establishing the totient values by `native_decide` (φ(1)=1, φ(2)=1, φ(3)=2, φ(4)=2, φ(6)=2). For n=4: 4·6 = φ(1)·2^4 + φ(2)·2^2 + φ(4)·2^1 = 16+4+4 = 24. The helper `necklace_via_burnside` applies Burnside abstractly given the fixed-point sum; it uses `Nat.mul_right_cancel` to extract the necklace count. This gives a clean reusable template for all n values.",
+    "mathContext": "$\\text{Pólya formula:} \\quad n \\cdot |\\text{Necklaces}(n,k)| = \\sum_{d \\mid n} \\varphi(d) \\cdot k^{n/d}$. Derivation: group the Burnside sum $\\sum_{r=0}^{n-1} k^{\\gcd(r,n)}$ by gcd value — there are $\\varphi(n/d)$ values of $r$ with $\\gcd(r,n) = d$, contributing $\\varphi(n/d) \\cdot k^d = \\varphi(d') \\cdot k^{n/d'}$ where $d' = n/d$.",
+    "significance": "key",
+    "relatedConcepts": ["Euler's totient function", "divisor sum", "Pólya enumeration theorem", "norm_num tactic", "cycle index"],
+    "prerequisites": ["Euler's totient φ(n)", "divisors of n", "Burnside's lemma", "norm_num in Lean 4"]
+  },
+  {
+    "id": "ann-polya-sorry",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
+    "range": { "startLine": 281, "endLine": 324 },
+    "type": "context",
+    "title": "The 1 Sorry: Cycle Structure Theorem for Cyclic Actions",
+    "content": "The general Pólya theorem `polya_enumeration_theorem_CN` is stated but left with 1 sorry. The docstring explains the three-step proof outline: (1) Burnside: n·|Orbits| = Σ_{r: ZMod n} |Fix(r)|; (2) cycle structure: |Fix(r)| = k^{gcd(r.val,n)} — a coloring is fixed by rotation r iff it has period gcd(r,n), i.e., it is determined by its values on gcd(r,n) positions; (3) grouping: Σ_{r: ZMod n} k^{gcd(r,n)} = Σ_{d|n} (number of r with gcd(r,n)=d) · k^d = Σ_{d|n} φ(n/d)·k^d = Σ_{d'|n} φ(d')·k^{n/d'} (substituting d' = n/d). Step (2) is the key missing formalization in Mathlib 4.26.",
+    "mathContext": "Missing key: $|\\{c \\in (\\mathbb{Z}/n\\mathbb{Z} \\to \\text{Fin}\\,k) : c(i-r) = c(i)\\, \\forall i\\}| = k^{\\gcd(r,n)}$. The fixed colorings are exactly those periodic with period $\\gcd(r,n)$, determined by their values on any $\\gcd(r,n)$ consecutive positions.",
+    "significance": "context",
+    "relatedConcepts": ["sorry in Lean 4", "cycle structure of permutations", "periodic colorings", "gcd and cycles", "Mathlib TODO"],
+    "prerequisites": ["permutation cycle structure", "periodic sequences", "gcd arithmetic"]
+  },
+  {
+    "id": "ann-polya-sequence",
+    "proofId": "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
+    "range": { "startLine": 326, "endLine": 365 },
+    "type": "context",
+    "title": "OEIS A000029: Binary Necklace Sequence",
+    "content": "The generating function section defines `necklaceSeq = [2,3,4,6,8,14]` and proves it matches `necklaceCount n 2` for n=1,...,6. This sequence appears in OEIS A000029 (necklaces with n beads of 2 colors, turning over not allowed). The connection to generating functions and cyclotomic polynomials is noted as an open question: the cycle index of Cₙ has a product form Z(Cₙ;x) = (1/n)Σ_{d|n} φ(d)·x^d, and the full bivariate generating function Σ_{n≥1} |Necklaces(n,k)|·x^n has a closed form involving Möbius inversion.",
+    "mathContext": "Binary necklace counts: $|\\text{Necklaces}(n,2)|$ for $n=1,2,3,4,5,6$ is $[2,3,4,6,8,14]$. Asymptotically: $|\\text{Necklaces}(n,2)| \\sim 2^n/(2n)$ as $n \\to \\infty$.",
+    "significance": "supporting",
+    "relatedConcepts": ["OEIS A000029", "generating functions", "cyclotomic polynomials", "Möbius inversion", "necklace polynomials"],
+    "prerequisites": ["combinatorial sequences", "generating functions", "OEIS"]
+  }
+]

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/meta.json
@@ -53,46 +53,83 @@
       "Key proof technique: use Eq.trans to avoid binder-name mismatch in Burnside sum"
     ]
   },
+  "overview": {
+    "historicalContext": "Pólya's enumeration theorem was published by George Pólya in 1937 ('Kombinatorische Anzahlbestimmungen für Gruppen, Graphen und chemische Verbindungen', Acta Mathematica 68). It gave a systematic method for counting combinatorial objects up to symmetry, with applications ranging from necklace counting to chemical isomer enumeration. The theorem generalizes Burnside's lemma (1897, also called the Cauchy-Frobenius lemma) from counting orbits to counting orbits weighted by color frequencies. Pólya's insight was the 'cycle index' of a group action: Z(G; x₁,...,xₖ) = (1/|G|) Σ_{g∈G} ∏_j xⱼ^{cⱼ(g)}, where cⱼ(g) counts j-cycles in the permutation g. Setting all variables to k gives the number of distinct k-colorings.",
+    "problemStatement": "**Open Question (OQ-01):** Can the generating function approach from the parallel Vandermonde entry be extended to prove Pólya's enumeration theorem?\n\nSpecifically, formalize that for the cyclic group Cₙ acting on n-bead necklaces:\n$$n \\cdot |\\text{Necklaces}(n, k)| = \\sum_{d|n} \\varphi(d) \\cdot k^{n/d}$$",
+    "proofStrategy": "**Step 1 — Group action** (§1): Define ZColoring n k = ZMod n → Fin k and the rotation action r +ᵥ c = fun i => c(i−r). The action law follows from `sub_sub` in ZMod n, requiring no axioms.\n\n**Step 2 — Fixed-point counts** (§2): For ZMod 4 acting on binary 4-colorings, compute |Fix(r)| for each r ∈ {0,1,2,3} by `native_decide`: Fix(0)=16, Fix(1)=2, Fix(2)=4, Fix(3)=2. Sum = 24.\n\n**Step 3 — Burnside** (§3): Apply `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group` to get |Orbits|·4 = 24, so |Orbits| = 6. The orbit quotient is exactly the necklace count.\n\n**Step 4 — Pólya formula** (§4): Verify n·|Necklaces(n,2)| = Σ_{d|n} φ(d)·2^{n/d} for n=2,3,4,6 by `norm_num` after computing totient values.\n\n**Step 5 — General theorem** (§5): The general Pólya theorem (1 sorry) requires the cycle structure theorem: rotation by r has gcd(r.val, n) cycles.",
+    "keyInsights": [
+      "ZMod n → Fin k colorings (instead of Fin n → Fin k) give a clean axiom-free group action: the law (r+s)+ᵥc = r+ᵥ(s+ᵥc) reduces to `sub_sub` in ZMod, a single one-line algebraic identity.",
+      "Burnside's lemma is applied through the chain: fixed-point sum 24 = |Orbits|×4, so |Orbits| = 6. The key technique `hb.symm.trans h1` avoids a binder-name mismatch that would prevent `rw` from working directly.",
+      "The Pólya formula Σ_{d|n} φ(d)·k^{n/d} arises from grouping the Burnside sum Σ_{r∈ZMod n} k^{gcd(r,n)} by gcd value: the number of r ∈ [0,n) with gcd(r,n) = n/d is exactly φ(d).",
+      "Rotation by r on an n-bead necklace acts as a permutation with gcd(r.val,n) cycles each of length n/gcd(r.val,n). This cycle structure theorem (left as 1 sorry) is the key missing piece for the general Pólya theorem.",
+      "The necklace sequence [2,3,4,6,8,14] for n=1,...,6 with 2 colors appears in OEIS A000029 (necklaces of n beads of 2 colors). The values grow approximately as 2^n/(2n) for large n by the Burnside-Pólya formula."
+    ],
+    "prerequisites": [
+      "ZMod n arithmetic and subtraction in Lean 4",
+      "Burnside's lemma (MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group)",
+      "Euler's totient function φ(n)",
+      "orbitRel.Quotient for orbit counting in Mathlib"
+    ]
+  },
   "sections": [
     {
       "id": "cyclic-action",
-      "title": "Clean Group Action via ZMod Subtraction",
-      "summary": "Defines ZColoring n k = ZMod n → Fin k and the rotation action r +ᵥ c = fun i => c (i - r). The action laws follow immediately from ZMod algebra (sub_sub), requiring no axioms.",
+      "title": "§1: Clean Group Action via ZMod Subtraction",
+      "startLine": 62,
+      "endLine": 103,
+      "summary": "Defines ZColoring n k = ZMod n → Fin k and the rotation action r +ᵥ c = fun i => c(i−r). The action laws (zero_vadd, add_vadd) follow immediately from ZMod algebra (`sub_sub`), requiring no axioms.",
+      "mathContext": "The rotation action: $(r +_v c)(i) = c(i - r)$. Action law: $(r + s) +_v c = r +_v (s +_v c)$ because $c(i - (r+s)) = c((i-s)-r)$ by `sub_sub` in $\\mathbb{Z}/n\\mathbb{Z}$.",
       "theorems": ["cyclicAction"]
     },
     {
       "id": "fixed-point-counts",
-      "title": "Fixed-Point Counts for ZMod 4 on Binary Colorings",
-      "summary": "Computes |Fix(r)| for each r ∈ ZMod 4 acting on ZMod 4 → Fin 2: Fix(0)=16 (all), Fix(1)=2 (constant), Fix(2)=4 (period-2), Fix(3)=2 (constant). Sum = 24.",
+      "title": "§2: Fixed-Point Counts for ZMod 4 on Binary Colorings",
+      "startLine": 105,
+      "endLine": 157,
+      "summary": "Computes |Fix(r)| for each r ∈ ZMod 4 acting on ZMod 4 → Fin 2: Fix(0)=16 (all), Fix(1)=2 (constant), Fix(2)=4 (period-2), Fix(3)=2 (constant). Sum = 24. Fixed-point counts use native_decide.",
+      "mathContext": "$|\\text{Fix}(0)| = 2^4 = 16$; $|\\text{Fix}(1)| = 2$ (only constant colorings survive 90° rotation); $|\\text{Fix}(2)| = 4$ (period divides 2: $c_0=c_2, c_1=c_3$); $|\\text{Fix}(3)| = 2$. Total $= 24$.",
       "theorems": ["zcoloring_4_2_card", "fix_0_card", "fix_1_card", "fix_2_card", "fix_3_card", "fixed_point_sum_4_2"]
     },
     {
       "id": "burnside-application",
-      "title": "Burnside's Lemma: 6 Binary Necklaces of Length 4",
-      "summary": "Applies Burnside's lemma from Mathlib to conclude |Necklaces(4,2)| = 24/4 = 6. The orbit quotient orbitRel.Quotient (Multiplicative (ZMod 4)) (ZColoring 4 2) has cardinality 6.",
+      "title": "§3: Burnside's Lemma — 6 Distinct Binary 4-Necklaces",
+      "startLine": 159,
+      "endLine": 197,
+      "summary": "Applies Burnside's lemma to conclude |Necklaces(4,2)| = 24/4 = 6. Uses MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group. The Eq.trans technique avoids a binder-name mismatch with the Burnside sum.",
+      "mathContext": "|\\text{Necklaces}(4,2)| = \\frac{1}{4}(16+2+4+2) = \\frac{24}{4} = 6$. Formally: $|\\text{Orbits}| \\times |G| = \\sum_g |\\text{Fix}(g)|$, so $|\\text{Orbits}| \\times 4 = 24$.",
       "theorems": ["binary_4_necklace_count"]
     },
     {
       "id": "polya-formula",
-      "title": "Pólya Formula Verification for 2-Colorings",
-      "summary": "Verifies n·|Necklaces(n,2)| = Σ_{d|n} φ(d)·2^{n/d} for n=2,3,4,6 using computed totient values. Also computes necklaceCount n 2 for n=1,...,6 via Burnside's helper.",
+      "title": "§4: Pólya Formula Verification for 2-Colorings",
+      "startLine": 199,
+      "endLine": 279,
+      "summary": "Verifies n·|Necklaces(n,2)| = Σ_{d|n} φ(d)·2^{n/d} for n=2,3,4,6 by norm_num after native_decide totient values. Defines necklaceCount and proves values [2,3,4,6,8,14] for n=1,...,6.",
+      "mathContext": "Sample: $4 \\cdot 6 = \\varphi(1) \\cdot 2^4 + \\varphi(2) \\cdot 2^2 + \\varphi(4) \\cdot 2^1 = 1\\cdot 16 + 1\\cdot 4 + 2\\cdot 2 = 24$. Verified by norm_num.",
       "theorems": ["polya_C2_2colors", "polya_C3_2colors", "polya_C4_2colors", "polya_C6_2colors", "necklaces_2_2", "necklaces_3_2", "necklaces_4_2", "necklaces_5_2", "necklaces_6_2"]
     },
     {
       "id": "general-statement",
-      "title": "General Pólya Theorem (1 sorry)",
-      "summary": "States the general Pólya enumeration theorem: n · necklaceCount n k = Σ_{d|n} φ(d) · k^{n/d}. Proof requires the cycle structure theorem (|Fix(r)| = k^{gcd(r.val,n)}) connecting Burnside to the divisor sum. Left as 1 sorry.",
+      "title": "§5: General Pólya Theorem (1 sorry)",
+      "startLine": 281,
+      "endLine": 324,
+      "summary": "States polya_enumeration_theorem_CN: n · necklaceCount n k = Σ_{d|n} φ(d) · k^{n/d}. The proof outline is given (Burnside + cycle structure + totient grouping) but requires the cycle structure theorem |Fix(r)| = k^{gcd(r.val,n)}, left as 1 sorry.",
+      "mathContext": "$n \\cdot |\\text{Necklaces}(n,k)| = \\sum_{d|n} \\varphi(d) \\cdot k^{n/d}$. Proof gap: need $|\\text{Fix}(r)| = k^{\\gcd(r,n)}$ for all $r \\in \\mathbb{Z}/n\\mathbb{Z}$.",
       "theorems": ["polya_enumeration_theorem_CN"]
+    },
+    {
+      "id": "generating-function-connection",
+      "title": "§6: Connection to Generating Functions",
+      "startLine": 326,
+      "endLine": 365,
+      "summary": "Defines necklaceSeq = [2,3,4,6,8,14] and proves it matches necklaceCount 1..6 2. Discusses the open question of connecting Pólya enumeration to generating functions and cyclotomic polynomials.",
+      "mathContext": "The generating function $P(x) = \\sum_{n \\geq 1} |\\text{Necklaces}(n,2)| \\cdot x^n = 2x + 3x^2 + 4x^3 + 6x^4 + \\cdots$ (OEIS A000029). Connection to cyclotomic polynomials: the cycle index of $C_n$ has product formula $Z(C_n) = \\frac{1}{n}\\sum_{d|n} \\varphi(d) \\cdot x_d^{n/d}$.",
+      "theorems": ["necklaceSeq_matches"]
     }
   ],
-  "overview": {
-    "background": "The parallel Vandermonde entry (ArithmeticSeriesOQ02OQ02OQ03) asked whether generating functions could be extended to Pólya's enumeration theorem. This entry answers the question by formalizing the cyclic group case of Pólya's theorem.",
-    "mainResult": "Burnside's lemma from Mathlib gives 6 distinct binary 4-necklaces. The Pólya formula n·|Necklaces(n,2)| = Σ_{d|n} φ(d)·2^{n/d} is verified for n=2,3,4,6. Necklace counts [2,3,4,6,8,14] for n=1,...,6 are proved.",
-    "significance": "The key architectural insight is using ZMod n → Fin k (ZMod-indexed colorings) instead of Fin n → Fin k. This makes the rotation action r +ᵥ c = fun i => c(i-r) trivially an action (the law follows from sub_sub in ZMod), requiring no modular arithmetic lemmas. The proof connects Burnside's abstract orbit-counting theorem to concrete necklace combinatorics.",
-    "openQuestion": "The remaining sorry is the general Pólya theorem: n · necklaceCount n k = Σ_{d|n} φ(d) · k^{n/d}. This requires proving |Fix(r)| = k^{gcd(r.val,n)} for all r, which is the cycle structure theorem for cyclic group actions."
-  },
   "conclusion": {
     "summary": "365-line formalization proving 23 theorems (1 sorry) from 0 axioms. Burnside's lemma is used to count necklaces; the Pólya divisor-sum formula is verified for small n. The general Pólya theorem remains as 1 sorry pending the cycle structure theorem.",
+    "implications": "Pólya's enumeration theorem is the foundational tool for counting combinatorial objects up to symmetry. The formalization demonstrates that Burnside's lemma from Mathlib is powerful enough to count necklaces concretely, and that ZMod-indexed colorings provide a particularly clean Lean 4 approach. The cycle structure theorem (each rotation by r has gcd(r,n) orbits on n positions) is the key missing ingredient for the general theorem — it connects the abstract Burnside sum to the totient-weighted divisor sum. The sequence [2,3,4,6,8,14] (binary necklaces for n=1–6) appears in OEIS A000029 and has applications in chemistry (molecular isomers), music theory (necklace rhythms), and coding theory (cyclic codes).",
     "openQuestions": [
       "Prove the cycle structure theorem: for rotation by r in ZMod n acting on ZMod n → Fin k, the number of fixed-point colorings is k^{gcd(r.val, n)}. This would close the 1 sorry and complete the general Pólya theorem.",
       "Extend to arbitrary finite groups: Pólya's theorem for non-cyclic groups (e.g., dihedral groups D_n for unoriented necklaces) requires the full cycle index formalism.",
@@ -102,14 +139,14 @@
   },
   "crossReferences": [
     {
-      "id": "arithmetic-series-oq-02-oq-02-oq-03",
-      "title": "Parallel Vandermonde via Generating Functions",
-      "relationship": "parent"
+      "targetId": "arithmetic-series-oq-02-oq-02-oq-03",
+      "relationship": "parent",
+      "description": "Parent: parallel Vandermonde via generating functions — OQ-01 from that entry motivated this Pólya formalization"
     },
     {
-      "id": "arithmetic-series-oq-02-oq-02",
-      "title": "2D Hockey Stick Identity",
-      "relationship": "grandparent"
+      "targetId": "arithmetic-series-oq-02-oq-02",
+      "relationship": "grandparent",
+      "description": "Grandparent: 2D Hockey Stick Identity in the arithmetic series hierarchy"
     }
   ]
 }

--- a/src/data/proofs/erdos-848-oq-01/annotations.json
+++ b/src/data/proofs/erdos-848-oq-01/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-e848-context",
+    "proofId": "erdos-848-oq-01",
+    "range": { "startLine": 1, "endLine": 27 },
+    "type": "context",
+    "title": "Why {7, 18} mod 25? The Quadratic Residue Answer",
+    "content": "The docstring frames the core insight: the extremal sets for Erdős #848 are exactly the mod-25 classes of the square roots of -1 in ℤ/25ℤ. For a ≡ b ≡ x (mod 25), we have ab+1 ≡ x²+1 (mod 25). For this to be divisible by 25, we need x² ≡ -1 (mod 25). The file proves this analysis is exhaustive: only x = 7 and x = 18 work (and 18 = -7 mod 25, so these are the ±√(-1) pair). The docstring also states the incompatibility: mixing the two classes gives ab+1 ≡ 127 ≡ 2 (mod 25), so the cross-pair never has 5 | ab+1.",
+    "mathContext": "For $a \\equiv b \\equiv x \\pmod{25}$: $ab + 1 \\equiv x^2 + 1 \\pmod{25}$. This is $\\equiv 0 \\pmod{25}$ iff $x^2 \\equiv -1 \\pmod{25}$. Solutions: $x = 7$ (since $7^2 = 49 = 2 \\cdot 25 - 1$) and $x = 18$ (since $18 = -7$ in $\\mathbb{Z}/25\\mathbb{Z}$).",
+    "significance": "context",
+    "relatedConcepts": ["quadratic residues mod p²", "square roots of -1", "Erdős #848", "extremal sets"],
+    "prerequisites": ["modular arithmetic", "quadratic residues", "squarefree integers"]
+  },
+  {
+    "id": "ann-e848-sqrt-neg1",
+    "proofId": "erdos-848-oq-01",
+    "range": { "startLine": 29, "endLine": 53 },
+    "type": "insight",
+    "title": "7 and 18 Are the Unique Square Roots of -1 in ℤ/25ℤ",
+    "content": "Five theorems establish the complete algebraic foundation. `seven_sq_eq_neg_one_mod25` and `eighteen_sq_eq_neg_one_mod25` verify the two square roots by `decide` (Lean's exhaustive finite computation). `seven_eq_neg_eighteen_mod25` identifies 18 = -7 in ℤ/25ℤ — the ±√(-1) symmetry. The key theorem `sq_neg_one_iff_seven_or_eighteen` proves UNIQUENESS: ∀ x : ZMod 25, x² = -1 ↔ x = 7 ∨ x = 18, again by `decide`. The elementary ℕ form `mod25_sq_succ_dvd_iff` translates to: ∀ r : Fin 25, 25 | r·r+1 ↔ r = 7 ∨ r = 18. Together, these prove there are exactly two mod-25 residue classes that give 5² | ab+1 for same-class pairs.",
+    "mathContext": "In $\\mathbb{Z}/25\\mathbb{Z}$: $x^2 = -1 \\Leftrightarrow x \\in \\{7, 18\\}$. Note $7^2 = 49 \\equiv -1$ and $18^2 = 324 = 13 \\cdot 25 - 1 \\equiv -1 \\pmod{25}$. Uniqueness follows since $\\mathbb{Z}/25\\mathbb{Z}$ is a $\\mathbb{Z}/p^2\\mathbb{Z}$ ring: by Hensel's lemma, $\\pm\\sqrt{-1}$ are the only solutions when $p \\equiv 1 \\pmod{4}$.",
+    "significance": "key",
+    "relatedConcepts": ["ZMod 25", "decide tactic", "quadratic residues mod p²", "Hensel's lemma", "±√(-1) pair"],
+    "prerequisites": ["ZMod in Mathlib", "quadratic residues", "finite field arithmetic", "Lean 4 decide tactic"]
+  },
+  {
+    "id": "ann-e848-cross-residue",
+    "proofId": "erdos-848-oq-01",
+    "range": { "startLine": 55, "endLine": 89 },
+    "type": "technique",
+    "title": "Cross-Residue Incompatibility: The Two Classes Cannot Be Combined",
+    "content": "`cross_residue_five_sq_fails` proves that if a ≡ 7 (mod 25) and b ≡ 18 (mod 25), then 5² ∤ ab+1. The proof extracts witnesses m,n via `obtain ⟨m, rfl⟩` using the `omega`-based division, then uses `ring` to expand ab+1 = 25*(25mn+18m+7n+5)+2. The remainder 2 is non-zero mod 25, so `omega` closes. The `ring` computation is the key: it explicitly shows how the cross-term 7·18 = 126 gives remainder 127 mod 25 = 2. The symmetric version `cross_residue_five_sq_fails'` redirects via `mul_comm`. The theorem `mixed_set_needs_other_prime` packages this: a set with both a mod-7 and a mod-18 element must use some prime p ≠ 5 for the cross-pair's non-squarefree property.",
+    "mathContext": "For $a = 25m+7$, $b = 25n+18$: $ab+1 = (25m+7)(25n+18)+1 = 25(25mn+18m+7n+5)+127 = 25(25mn+18m+7n+5)+2 + 125 = 25(\\ldots)+2$. So $25 \\nmid ab+1$, hence $5^2 \\nmid ab+1$.",
+    "significance": "key",
+    "relatedConcepts": ["omega tactic", "ring tactic", "mod arithmetic witnesses", "non-squarefree products", "HasNonSqfreeProductProp"],
+    "prerequisites": ["modular arithmetic witnesses", "ring expansion", "squarefree numbers"]
+  },
+  {
+    "id": "ann-e848-classification",
+    "proofId": "erdos-848-oq-01",
+    "range": { "startLine": 91, "endLine": 114 },
+    "type": "technique",
+    "title": "Complete Classification: Only r = 7 and r = 18 Work mod 25",
+    "content": "`non_extremal_class_five_sq_fails` proves the negative direction: for r < 25, r ≠ 7, r ≠ 18, we have 5² ∤ r·r+1. The proof uses `interval_cases r` — Lean's finite case analysis over all integers in [0, 25) — followed by `omega` for each concrete case. This is a brute-force exhaustive check over all 23 non-extremal residues. `extremal_iff_five_sq_divides` combines this with the positive direction (direct witnesses: 5²|7·7+1 = 50 = 2·25 and 5²|18·18+1 = 325 = 13·25) into a complete biconditional characterization. The `interval_cases` approach is typical for Lean proofs over bounded natural numbers.",
+    "mathContext": "For each $r \\in \\{0,1,\\ldots,24\\} \\setminus \\{7,18\\}$: $r^2 + 1 \\not\\equiv 0 \\pmod{25}$. The two positive witnesses: $7 \\cdot 7 + 1 = 50 = 2 \\cdot 25$ and $18 \\cdot 18 + 1 = 325 = 13 \\cdot 25$.",
+    "significance": "key",
+    "relatedConcepts": ["interval_cases tactic", "finite case analysis", "biconditional characterization", "exhaustive verification"],
+    "prerequisites": ["finite case analysis", "interval_cases in Mathlib", "natural number arithmetic"]
+  },
+  {
+    "id": "ann-e848-mod18-lower-bound",
+    "proofId": "erdos-848-oq-01",
+    "range": { "startLine": 116, "endLine": 160 },
+    "type": "technique",
+    "title": "Mod-18 Lower Bound: An Independent Witness for N/25",
+    "content": "`mod18Set N` is defined as {n ∈ [1,N] | n ≡ 18 (mod 25)}. The lower bound proof `lower_bound_via_mod18` injects Finset.range(N/25) into mod18Set via the function k ↦ 25k+18. `hf_mem` verifies the injection lands in mod18Set, `hf_inj` verifies injectivity (from 25k+18 = 25k'+18 → k = k' via omega). `Finset.card_le_card_of_injOn` then gives |mod18Set| ≥ N/25. The final `Finset.le_sup` step uses that mod18Set achieves its cardinality in the powerset of [1,N] filtered by the non-squarefree property. This entire proof mirrors the parent file's mod-7 lower bound structurally, confirming both classes give the same N/25 count.",
+    "mathContext": "The injection $k \\mapsto 25k + 18$ from $\\{0,\\ldots,\\lfloor N/25\\rfloor - 1\\}$ into mod18Set gives $|\\text{mod18Set}(N)| \\geq N/25$. Combined with `mod18Set_prop` (the set has the non-squarefree product property), this gives $N/25 \\leq \\text{maxNonSqfreeSet}(N)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset injection", "Finset.card_le_card_of_injOn", "Finset.le_sup", "lower bound witnesses", "mod-25 residue sets"],
+    "prerequisites": ["Finset API in Mathlib", "injective functions", "supremum over finsets", "extremal combinatorics"]
+  }
+]


### PR DESCRIPTION
## Summary

Enrichment pass for 3 gallery entries:

### 1. `erdos-848-oq-01` — Erdős #848 OQ-01: Why {7, 18} mod 25?
- Created `annotations.json` (was missing): 5 annotations covering context, √(-1) mod 25 uniqueness proof, cross-residue incompatibility ring expansion, complete interval_cases classification, and mod-18 lower bound via Finset injection

### 2. `arithmetic-series-oq-02-oq-02-oq-03-oq-01` — Pólya Enumeration via Cyclic Group Actions
- Added `overview.historicalContext`, `proofStrategy`, `keyInsights` (5), `problemStatement` — all were missing (entry used non-standard `background` field)
- Added `conclusion.implications`
- Fixed all 6 sections: added `startLine`/`endLine`/`mathContext`; added §6 generating-function-connection (lines 326–365)
- Created `annotations.json` with 6 annotations: ZMod action design choice, native_decide fixed-point counts, Burnside Eq.trans technique, Pólya formula verification, 1-sorry gap (cycle structure theorem), OEIS A000029 connection

**Axiom integrity:**
- `erdos-848-oq-01`: `axiomCount: 0`, `status: verified` — correct
- `arithmetic-series-oq-02-oq-02-oq-03-oq-01`: `axiomCount: 0`, `sorries: 1`, `badge: wip` — correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)