### PR TITLE
fix(meta): correct stale lineCount for erdos-1012-oq-03

### DIFF
--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -15,7 +15,7 @@
     "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 1277,
+    "lineCount": 1205,
     "assumptions": "0 axioms. 1 sorry: ghouila_houri (full proof needs longest-path argument ~200 lines tracking both in- and out-degrees). directed_hamiltonian_threshold is now fully proved (0 sorries): perm_arc_bad_card_le (≤ n*(n-2)! perms use any given arc) proved via Aristotle. Moon-Moser theorem and Rédei are also fully proved.",
     "dateAdded": "2026-03-30"
   },
@@ -110,7 +110,7 @@
       "Finset"
     ],
     "namespace": "Erdos1012OQ03",
-    "lineCount": 1170,
+    "lineCount": 1205,
     "axiomCount": 0,
     "sorries": 1,
     "path": "Proofs/Erdos1012OQ03.lean",


### PR DESCRIPTION
## Fix

Corrects two stale `lineCount` fields in `erdos-1012-oq-03/meta.json` that diverged from the actual Lean source file.

## Evidence

**Before**:
- `meta.lineCount`: 1277
- `leanFile.lineCount`: 1170

**After**:
- `meta.lineCount`: 1205
- `leanFile.lineCount`: 1205

Actual file: `wc -l proofs/Proofs/Erdos1012OQ03.lean` = 1205 lines.

The `sorries` count (1: `ghouila_houri`) was already correct in both fields — no change needed there.

Closes #9885

---
Automated fix by lean-mechanic agent.