### PR TITLE
fix(audit): correct sorry counts for erdos-892 (+2) and q-Vandermonde (0)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8427,9 +8427,9 @@
     },
     "erdos-892": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:20:32Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-05T17:13:15Z",
+      "result": "issues-fixed"
     },
     "erdos-893": {
       "agentId": "auditor-cycle-20-batch",
@@ -11923,8 +11923,8 @@
       "issues": []
     },
     "arithmetic-series-oq-02-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-05T12:55:01Z",
+      "auditCount": 2,
+      "lastAudited": "2026-04-05T17:13:15Z",
       "result": "issues-fixed",
       "issues": []
     },

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2227,9 +2227,9 @@
       "result": "clean"
     },
     "erdos-1059-oq-05": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-05T17:42:47Z",
       "result": "clean"
     },
     "erdos-106": {
@@ -2281,9 +2281,9 @@
       "result": "clean"
     },
     "erdos-1065-oq-05": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-05T17:42:19Z",
       "result": "clean"
     },
     "erdos-1066": {
@@ -2293,9 +2293,9 @@
       "result": "clean"
     },
     "erdos-1066-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-05T17:42:28Z",
       "result": "clean"
     },
     "erdos-1067": {
@@ -2551,9 +2551,9 @@
       "result": "clean"
     },
     "erdos-110-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-05T17:42:10Z",
       "result": "clean"
     },
     "erdos-1100": {
@@ -2677,9 +2677,9 @@
       "result": "clean"
     },
     "erdos-1118-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-05T17:42:02Z",
       "result": "clean"
     },
     "erdos-1119": {
@@ -2857,9 +2857,9 @@
       "result": "clean"
     },
     "erdos-114-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-05T17:41:53Z",
       "result": "clean"
     },
     "erdos-1140": {
@@ -3375,9 +3375,9 @@
       "result": "clean"
     },
     "erdos-152-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-05T17:41:44Z",
       "result": "clean"
     },
     "erdos-153": {
@@ -4448,9 +4448,9 @@
       "result": "clean"
     },
     "erdos-307-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-05T17:41:35Z",
       "result": "clean"
     },
     "erdos-308": {
@@ -5446,9 +5446,9 @@
       "result": "clean"
     },
     "erdos-453-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-05T17:41:19Z",
       "result": "clean"
     },
     "erdos-454": {
@@ -5955,9 +5955,9 @@
       "result": "issues-fixed"
     },
     "erdos-525-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-05T17:40:47Z",
       "result": "clean"
     },
     "erdos-526": {
@@ -6501,10 +6501,10 @@
       "result": "clean"
     },
     "erdos-606-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
-      "result": "clean"
+      "lastAudited": "2026-04-05T17:40:29Z",
+      "result": "issues-found"
     },
     "erdos-607": {
       "agentId": "auditor-cycle-20-batch",
@@ -7449,14 +7449,14 @@
       "result": "clean"
     },
     "erdos-746": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [
         "PR #6440: sorry count 3\u21924",
         "Issue #6441: 9 vacuous True stubs",
         "https://github.com/rjwalters/lean-genius/pull/8651"
       ],
-      "lastAudited": "2026-04-03T05:20:33Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-05T17:39:21Z",
+      "result": "clean"
     },
     "erdos-747": {
       "agentId": "auditor-cycle-20-batch",
@@ -11943,6 +11943,18 @@
     "leibniz-pi-oq-03": {
       "auditCount": 1,
       "lastAudited": "2026-04-05T13:49:13Z",
+      "result": "clean",
+      "issues": []
+    },
+    "amgm-inequality-oq-03-oq-02-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-05T17:38:44Z",
+      "result": "clean",
+      "issues": []
+    },
+    "shannon-channel-coding-oq-04-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-05T17:39:00Z",
       "result": "clean",
       "issues": []
     }

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1799,10 +1799,10 @@
       "result": "clean"
     },
     "erdos-1008": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T21:47:53Z",
-      "result": "clean"
+      "lastAudited": "2026-04-05T17:37:19Z",
+      "result": "issues-fixed"
     },
     "erdos-1008-oq-01": {
       "auditCount": 2,


### PR DESCRIPTION
## Summary

- **erdos-892**: meta.json claimed `sorries: 0` but Lean file (`Erdos892Problem.lean`) has 2 sorries in `linear_growth_no_primitive_dominator` (lines 310, 315: Cauchy condensation divergence proof and guard simplification). Also fixes stale `lineCount` (282→318), axiom narrative (3→1 actual `axiom` declaration), and section line ranges.
- **arithmetic-series-oq-02-oq-01-oq-01**: meta.json claimed `sorries: 2` but Lean file has 0 (`sum_split_pascal` was fully proved via Finset case analysis). Upgrades `status: formalized → verified`, `badge: wip → original`, `lineCount: 190→217`, removes stale sorry references from description, conclusion, and section summaries.

## Audit Details

**erdos-892**:
- 1 `axiom` declaration: `primitive_reciprocal_log_convergent` (Erdős 1935 convergence)
- ESS 1967 and primitive counting bound are in comments only (not axiomatized)
- 2 sorries in example theorem `linear_growth_no_primitive_dominator`
- Main theorem `erdos_1935_necessary` is fully proved (0 sorries)

**arithmetic-series-oq-02-oq-01-oq-01**:
- 0 axioms, 0 sorries confirmed in source
- Parent file `ArithmeticSeriesOQ02OQ01.lean` also 0 sorries, 0 axioms
- `qBinom` defined locally (not wrapping a Mathlib theorem), so `badge: original` is correct

## Test plan

- [ ] `npx tsx scripts/auditor/find-targets.ts --issues` shows 0 issues for these two proofs after tracker update
- [ ] meta.json values match Lean source file counts

🤖 Generated with [Claude Code](https://claude.ai/claude-code)