### PR TITLE
fix(meta): q-Vandermonde — upgrade to verified (0 sorries, 217 lines)

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-01-oq-01/meta.json
@@ -2,11 +2,11 @@
   "id": "arithmetic-series-oq-02-oq-01-oq-01",
   "title": "q-Vandermonde Identity",
   "slug": "arithmetic-series-oq-02-oq-01-oq-01",
-  "description": "Proves the q-Vandermonde identity: [m+n choose r]_q = ∑_{k=0}^{r} q^{k*(m+k-r)} * [m choose r-k]_q * [n choose k]_q, which generalizes the classical Vandermonde convolution C(m+n,r) = ∑_k C(m,k)*C(n,r-k) to q-binomial coefficients. Proof by induction on m using q-Pascal on LHS and Pascal expansion on RHS. 6 lemmas/theorems, 0 axioms, 2 sorries (sum decomposition infrastructure).",
+  "description": "Proves the q-Vandermonde identity: [m+n choose r]_q = ∑_{k=0}^{r} q^{k*(m+k-r)} * [m choose r-k]_q * [n choose k]_q, which generalizes the classical Vandermonde convolution C(m+n,r) = ∑_k C(m,k)*C(n,r-k) to q-binomial coefficients. Proof by induction on m using q-Pascal on LHS and Pascal expansion on RHS. 6 lemmas/theorems, 0 axioms, 0 sorries.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean",
     "tags": [
       "combinatorics",
@@ -15,12 +15,12 @@
       "vandermonde",
       "quantum-calculus"
     ],
-    "badge": "wip",
-    "sorries": 2,
+    "badge": "verified",
+    "sorries": 0,
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
-    "assumptions": "None beyond 2 sorries: sum_split_pascal (Pascal expansion of sum) and the main inductive case.",
-    "lineCount": 190,
+    "assumptions": "None. Axiom-free and sorry-free.",
+    "lineCount": 217,
     "theoremCount": 6,
     "definitionCount": 0,
     "originalContributions": [
@@ -49,10 +49,9 @@
     ]
   },
   "conclusion": {
-    "summary": "q-Vandermonde identity [m+n choose r]_q = ∑_k q^{k*(m+k-r)} [m choose r-k]_q [n choose k]_q proved by induction on m. Works in any CommRing. Key infrastructure: Part A exponent identity (zify+ring) and Part B ℕ subtraction alignment (omega). 2 sorries remain for sum decomposition infrastructure.",
+    "summary": "q-Vandermonde identity [m+n choose r]_q = ∑_k q^{k*(m+k-r)} [m choose r-k]_q [n choose k]_q proved by induction on m. Works in any CommRing. Key infrastructure: Part A exponent identity (zify+ring) and Part B ℕ subtraction alignment (omega). Fully verified: 0 axioms, 0 sorries.",
     "implications": "The q-Vandermonde identity is a fundamental identity in quantum calculus with applications to q-hypergeometric series and representation theory of quantum groups. Connects the Gaussian binomial convolution structure to classical Vandermonde via q=1 specialization.",
     "openQuestions": [
-      "Eliminate the 2 sorries: prove sum_split_pascal by direct Finset manipulation using Pascal expansion of qBinom q (m+1) (r+1-k)",
       "Extend to the full q-Chu-Vandermonde identity with non-integer q-exponents"
     ]
   },
@@ -65,9 +64,9 @@
       "GaussianBinomial"
     ],
     "namespace": "qVandermondeProof",
-    "lineCount": 190,
+    "lineCount": 217,
     "axiomCount": 0,
-    "sorries": 2,
+    "sorries": 0,
     "path": "Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean",
     "theoremCount": 6,
     "definitionCount": 0
@@ -127,17 +126,17 @@
     },
     {
       "id": "sec-pascal-split",
-      "title": "Pascal Split of Sum (sorry)",
+      "title": "Pascal Split of Sum",
       "startLine": 111,
-      "endLine": 130,
-      "summary": "Asserts that splitting qBinom q (m+1) (r+1-k) via Pascal rule decomposes S(m+1,n,r+1) into Part A + Part B. Currently sorry — requires careful Finset sum manipulation."
+      "endLine": 160,
+      "summary": "Proves that splitting qBinom q (m+1) (r+1-k) via Pascal rule decomposes S(m+1,n,r+1) into Part A + Part B. Uses by_cases on k ≤ r, Finset.sum_congr with expand lemma, then Finset.sum_add_distrib."
     },
     {
       "id": "sec-main-theorem",
       "title": "Main Theorem: q-Vandermonde Identity",
-      "startLine": 131,
-      "endLine": 191,
-      "summary": "Proves qVandermonde by induction on m. Base m=0: Finset.sum_eq_single at k=r, other terms vanish. Inductive step: q-Pascal on LHS, IH twice, ℕ exponent identity via simp_rw, then sorry for the Pascal split + Part A/B assembly."
+      "startLine": 161,
+      "endLine": 217,
+      "summary": "Proves qVandermonde by induction on m. Base m=0: Finset.sum_eq_single at k=r, other terms vanish. Inductive step: q-Pascal on LHS, IH twice, ℕ exponent identity via simp_rw, then sum_split_pascal + partA_eq for the Pascal split and Part A/B assembly."
     }
   ]
 }


### PR DESCRIPTION
## Fix

Update `arithmetic-series-oq-02-oq-01-oq-01/meta.json` to reflect the completed q-Vandermonde proof.

## Evidence

PR #9808 resolved both sorries in `ArithmeticSeriesOQ02OQ01OQ01.lean` (replacing `sorry` with full Lean proofs), but `meta.json` was not updated:

**Before** (stale):
- `sorries: 2`, `status: formalized`, `badge: wip`, `lineCount: 190`
- `assumptions`: "None beyond 2 sorries: sum_split_pascal..."

**After** (correct):
- `sorries: 0`, `status: verified`, `badge: verified`, `lineCount: 217`
- `assumptions`: "None. Axiom-free and sorry-free."
- `conclusion` and `sections` updated to remove sorry references

---
Automated fix by lean-mechanic agent.