### PR TITLE
fix(meta): correct stale lineCount for 6 gallery proofs

### DIFF
--- a/src/data/proofs/central-limit-theorem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-02-oq-01/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-04-05",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified using only Mathlib's Complex arithmetic.",
-    "lineCount": 98,
+    "lineCount": 112,
     "theoremCount": 7,
     "definitionCount": 0,
     "originalContributions": [
@@ -122,7 +122,7 @@
   ],
   "leanFile": {
     "namespace": "CentralLimitTheoremOQ01OQ02OQ01",
-    "lineCount": 98,
+    "lineCount": 112,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-1059-oq-01/meta.json
+++ b/src/data/proofs/erdos-1059-oq-01/meta.json
@@ -82,7 +82,7 @@
       "Finset operations for counting",
       "Floor binary logarithm (Nat.log) and its monotonicity properties"
     ],
-    "lineCount": 346,
+    "lineCount": 566,
     "relatedProblems": [
       {
         "id": "erdos-1059",
@@ -186,7 +186,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 346,
+    "lineCount": 566,
     "namespace": "Erdos1059OQ01",
     "opens": [],
     "structureCount": 0,

--- a/src/data/proofs/erdos-647/meta.json
+++ b/src/data/proofs/erdos-647/meta.json
@@ -51,7 +51,7 @@
       "Machine-verified proof that τ(m) ≥ 2^ω(m) for all m ≥ 1, using Nat.card_divisors from Mathlib and Finset.prod_le_prod'"
     ],
     "axiomCount": 1,
-    "lineCount": 300,
+    "lineCount": 324,
     "assumptions": "1 axiom(s) and 0 sorry(s). The axiom `large_n_fail` encodes the open conjecture that no n > 24 satisfies the Erdős condition."
   },
   "overview": {
@@ -148,7 +148,7 @@
       "Finset"
     ],
     "namespace": "Erdos647",
-    "lineCount": 300,
+    "lineCount": 324,
     "axiomCount": 1,
     "theoremCount": 25,
     "definitionCount": 11,

--- a/src/data/proofs/fair-games-theorem/meta.json
+++ b/src/data/proofs/fair-games-theorem/meta.json
@@ -55,7 +55,7 @@
     "dateAdded": "2025-12-29",
     "axiomCount": 1,
     "assumptions": "1 axiom declaration: `submartingale_of_stoppedValue_mono` (converse of submartingale characterization via stopped values). This axiom is used ONLY in the supplementary `submartingale_characterization` theorem, NOT in the main result. The main theorem (`fair_games_theorem` / Optional Stopping Theorem) and its corollary are fully proved from Mathlib with 0 axioms and 0 sorries.",
-    "lineCount": 475,
+    "lineCount": 417,
     "prerequisites": [
       "Martingales, submartingales, and supermartingales",
       "Probability theory: integration and expectation on measure spaces",

--- a/src/data/proofs/ptolemys-theorem/meta.json
+++ b/src/data/proofs/ptolemys-theorem/meta.json
@@ -33,7 +33,7 @@
     "dateAdded": "2025-12-27",
     "wiedijkNumber": 95,
     "axiomCount": 0,
-    "lineCount": 267,
+    "lineCount": 240,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/triangle-angle-sum-oq-01/meta.json
+++ b/src/data/proofs/triangle-angle-sum-oq-01/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 4,
-    "lineCount": 230,
+    "lineCount": 260,
     "assumptions": "saccheri_legendre (angle sum ≤ π in neutral geometry), defect_transitivity_axiom (zero defect propagates), angle_sum_pi_implies_playfair (main characterization), parallel_implies_angle_sum (forward direction). All are classical theorems of neutral geometry requiring ~1000 lines of infrastructure not yet in Mathlib.",
     "mathlib_version": "4.26.0"
   },


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` (and `leanFile.lineCount` where set) to match actual `wc -l` output for 6 proofs where the metadata had drifted from the Lean source:

| Proof | meta before | actual | Direction |
|-------|-------------|--------|-----------|
| erdos-647 | 300 | 324 | grew |
| ptolemys-theorem | 267 | 240 | shrank |
| erdos-1059-oq-01 | 346 | 566 | grew |
| triangle-angle-sum-oq-01 | 230 | 260 | grew |
| fair-games-theorem | 475 | 417 | shrank |
| central-limit-theorem-oq-01-oq-02-oq-01 | 98 | 112 | grew |

No sorry counts, status, or badge changes — lineCount only.

---
Automated fix by lean-mechanic agent.