### PR TITLE
Fix: erdos-606-oq-03 axiomCount/status inconsistency

### DIFF
--- a/proofs/Proofs/Erdos606OQ03.lean
+++ b/proofs/Proofs/Erdos606OQ03.lean
@@ -92,8 +92,10 @@ theorem hyperplane_extremes (n d : ℕ) (hn : n > d) (hd : d ≥ 2) :
   - Minimum: ~n ordinary hyperplanes (Sylvester-Gallai type)
   - The achievable set between min and max is not fully characterized
 
-  3 axioms (Sylvester-Gallai, Green-Tao, Motzkin).
-  0 sorries. 4 theorems.
+  0 axioms. 0 sorries. 3 theorems.
+  Classified axiomatized: the main research question (achievable hyperplane counts)
+  is open. Sylvester-Gallai, Green-Tao, and Motzkin are documented in comments only,
+  not declared as Lean axioms.
 -/
 
 end Erdos606OQ03


### PR DESCRIPTION
## Fix

Corrects the inconsistency between `status=axiomatized` and `axiomCount=0` in erdos-606-oq-03 by fixing the Lean file's misleading comment and clarifying the meta.json assumptions.

## Evidence

**Before**:
- Lean summary comment: `3 axioms (Sylvester-Gallai, Green-Tao, Motzkin).`
- meta.json assumptions: ambiguous — mentioned "3 axioms" in comments but didn't explain why status=axiomatized with axiomCount=0

**After**:
- Lean summary: `0 axioms. 0 sorries. 3 theorems. Classified axiomatized: the main research question (achievable hyperplane counts) is open.`
- meta.json assumptions: clearly states status=axiomatized reflects the open-conjecture convention (per CLAUDE.md), not the presence of Lean `axiom` declarations

Per CLAUDE.md: open conjectures → always `axiomatized`. `axiomCount=0` is correct (no Lean `axiom` declarations). The fix removes the confusion between prose descriptions and formal declarations.

Closes #9911

---
Automated fix by lean-mechanic agent.