### PR TITLE
fix(meta): erdos-606-oq-03 status axiomatized→formalized (0 axioms)

### DIFF
--- a/src/data/proofs/erdos-606-oq-03/meta.json
+++ b/src/data/proofs/erdos-606-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Sylvester, Green-Tao, Motzkin",
     "sourceUrl": "https://erdosproblems.com/606",
     "date": "2026",
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos606OQ03.lean",
     "tags": [
       "combinatorial-geometry",
@@ -20,7 +20,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 99,
-    "assumptions": "0 axioms, 0 sorries. general_position_count True stub was converted to a block comment. 3 remaining theorems (max_hyperplanes, line_count_range, hyperplane_extremes) are fully proved. Sylvester-Gallai, Green-Tao, and Motzkin are referenced in comments only. Classified axiomatized: main research question (achievable hyperplane counts) is open.",
+    "assumptions": "0 axioms, 0 sorries. The 3 stated theorems (max_hyperplanes, line_count_range, hyperplane_extremes) are fully machine-checked. Sylvester-Gallai, Green-Tao, and Motzkin are referenced in comments only — not declared as Lean axioms. Status is formalized: the Lean file is a partial framework for the open problem (achievable hyperplane counts) with auxiliary results proved but the main conjecture not formalized.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "originalContributions": [


### PR DESCRIPTION
## Fix

Change `status` from `axiomatized` to `formalized` for erdos-606-oq-03.

## Evidence

**Before**: `status=axiomatized`, `axiomCount=0` — inconsistent: `axiomatized` requires axiom declarations per gallery policy.

**After**: `status=formalized`, `axiomCount=0` — consistent: the Lean file has 3 fully proved auxiliary theorems (max_hyperplanes, line_count_range, hyperplane_extremes) with 0 axioms and 0 sorries. Sylvester-Gallai, Green-Tao, and Motzkin are referenced in comments only, not as Lean axiom declarations. Badge remains `wip` (honest: main open problem not formalized).

Closes #9911

---
Automated fix by lean-mechanic agent.