### PR TITLE
fix(geometric-series-oq-03): correct conclusion schema

### DIFF
--- a/src/data/proofs/geometric-series-oq-03/meta.json
+++ b/src/data/proofs/geometric-series-oq-03/meta.json
@@ -130,7 +130,8 @@
     }
   ],
   "conclusion": {
-    "significance": "This proof makes explicit the connection between the elementary geometric series formula and the deep Euler product identity for ζ(s). The geometric series is not just analogously similar to the Euler product — each Euler factor IS a geometric series. This bridges the most elementary infinite series formula with one of the central objects of analytic number theory.",
+    "summary": "This proof makes explicit the connection between the elementary geometric series formula and the deep Euler product identity for ζ(s). The geometric series is not just analogously similar to the Euler product — each Euler factor IS a geometric series. This bridges the most elementary infinite series formula with one of the central objects of analytic number theory.",
+    "implications": "Each Euler factor (1 - p^{-s})^{-1} is literally a geometric series ∑_k p^{-ks}, so the Euler product is a product of geometric series. This establishes a direct algebraic bridge between elementary calculus and analytic number theory, formalized in Lean using Mathlib's LSeries and EulerProduct libraries.",
     "openQuestions": [
       "Can the geometric series / Euler product connection be extended to Dirichlet L-functions L(s, χ) = ∏_p (1 - χ(p)p^{-s})^{-1}? The same norm bound applies since |χ(p)p^{-s}| = p^{-Re(s)} < 1 for Re(s) > 1 and Dirichlet characters are bounded by 1.",
       "Can a similar geometric series decomposition be given for the completed zeta function ξ(s), which includes the Γ-factor and satisfies the functional equation ξ(s) = ξ(1-s)?"


### PR DESCRIPTION
Fixes TypeScript build error: ProofConclusion requires 'summary' and 'implications' fields, but the proof had 'significance' and missing 'implications'.