### PR TITLE
Enrich strict monotonicity of (1+1/n)^n: deepen history, fix refs

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-03-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-03-oq-02-oq-03/annotations.json
@@ -36,6 +36,18 @@
     "prerequisites": ["strictAntiOn_of_deriv_neg", "log_div_continuousOn", "log_div_deriv_neg"]
   },
   {
+    "id": "ann-nlog-bridge",
+    "proofId": "binomial-theorem-oq-03-oq-02-oq-03",
+    "range": { "startLine": 128, "endLine": 147 },
+    "type": "technique",
+    "title": "Bridge Lemma: n·log(1+1/n) = g(1/n) is Strictly Increasing",
+    "content": "nlog_strictMono converts the discrete monotonicity problem to continuous analysis. The key rewrite: n·log(1+1/n) = log(1+1/n)/(1/n), which equals g(1/n) where g(t) = log(1+t)/t. Since g is strictly decreasing (Part III) and 1/n < 1/m for m < n, we get g(1/n) > g(1/m), hence n·log(1+1/n) > m·log(1+1/m). The field_simp tactic handles the algebraic rewrite m·log(1+1/m) = log(1+1/m)/(1/m), and one_div_lt_one_div_of_lt converts m < n to 1/n < 1/m.",
+    "mathContext": "$n \\cdot \\log(1+1/n) = \\frac{\\log(1+1/n)}{1/n} = g(1/n)$. Since $g$ is strictly decreasing and $1/n < 1/m$ when $m < n$: $g(1/n) > g(1/m)$, i.e., $n \\cdot \\log(1+1/n) > m \\cdot \\log(1+1/m)$.",
+    "significance": "key",
+    "relatedConcepts": ["field_simp", "one_div_lt_one_div_of_lt", "log_div_strictAntiOn", "variable substitution"],
+    "prerequisites": ["log_div_strictAntiOn from Part III", "field_simp tactic for algebraic rewrites"]
+  },
+  {
     "id": "ann-main-theorem",
     "proofId": "binomial-theorem-oq-03-oq-02-oq-03",
     "range": { "startLine": 147, "endLine": 159 },

--- a/src/data/proofs/binomial-theorem-oq-03-oq-02-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-03-oq-02-oq-03/meta.json
@@ -28,7 +28,7 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The strict monotonicity of the sequence (1+1/n)^n — together with its convergence to e — provides one of the most elegant proofs of the existence of Euler's number. Establishing that the sequence is bounded (< 3) and increasing immediately gives convergence without computing the limit explicitly. The key tool is the logarithm inequality log(1+t) > t/(1+t) for t > 0, which follows from the strict convexity of exp.",
+    "historicalContext": "Euler introduced the constant e in 1748 in Introductio in analysin infinitorum, defining it as the limit of (1 + 1/n)^n. The monotonicity of this sequence was known to Jacob Bernoulli (1690s), who discovered the compound interest limit while studying the problem of continuous compounding: if interest is compounded n times at rate 1/n, the growth factor (1 + 1/n)^n increases with n. The bounded monotone convergence approach — showing 2 < (1 + 1/n)^n < 3 and strict increase — provides a clean existence proof without series or integrals, and appears in most modern analysis textbooks (e.g., Rudin's Principles, Theorem 3.31). The key analytical tool here is the inequality log(1+t) > t/(1+t) for t > 0, which is equivalent to strict convexity of exp and was known to Hermite and Hadamard in the context of convex function theory. This formalization in Lean 4 uses Mathlib's strictAntiOn_of_deriv_neg (essentially the mean value theorem) as the bridge between the pointwise derivative condition and global monotonicity.",
     "problemStatement": "**Open Question (OQ-03-OQ-02-OQ-03):** Prove that (1+1/n)^n is strictly increasing: for 1 ≤ m < n, (1+1/m)^m < (1+1/n)^n.\n\n**Strategy**: The function g(t) = log(1+t)/t is strictly decreasing on (0,∞). Since (1+1/n)^n = exp(n·log(1+1/n)) = exp(g(1/n)) and 1/n is decreasing in n, we get g(1/n) is increasing in n.",
     "text": "Proves strict monotonicity of (1+1/n)^n via log analysis. Part I establishes log(1+t) > t/(1+t) for t > 0 via Real.add_one_lt_exp. Part II computes the derivative of g(t) = log(1+t)/t and shows it is negative. Part III uses strictAntiOn_of_deriv_neg to get StrictAntiOn for g. Part IV applies the monotonicity to conclude the sequence is strictly increasing.",
     "proofStrategy": "The proof proceeds in four parts:\n\n1. **Key inequality** (Part I): For t > 0, t/(1+t) < log(1+t). Apply `Real.add_one_lt_exp` to x = -t/(1+t) ≠ 0: 1/(1+t) < exp(-t/(1+t)). Take log: -log(1+t) < -t/(1+t).\n\n2. **Negative derivative** (Part II): g(t) = log(1+t)/t has derivative (t/(1+t) - log(1+t))/t² < 0 by Part I.\n\n3. **Strict anti-monotonicity** (Part III): Apply `strictAntiOn_of_deriv_neg` to g on (0,∞), using continuity of g and the negative derivative.\n\n4. **Main theorem** (Part IV): n·log(1+1/n) = g(1/n). Since g is strictly decreasing and 1/n > 1/(n+1), g(1/n) < g(1/(n+1)). Then (1+1/n)^n = exp(g(1/n)) < exp(g(1/(n+1))) = (1+1/(n+1))^(n+1) by strict monotonicity of exp.",
@@ -36,7 +36,8 @@
       "The central insight is that strict monotonicity of (1+1/n)^n reduces to strict anti-monotonicity of g(t) = log(1+t)/t, which is a smooth analysis problem.",
       "The key inequality log(1+t) > t/(1+t) follows immediately from Real.add_one_lt_exp (the strict form x ≠ 0 → 1+x < exp(x)) by substitution x = -t/(1+t).",
       "The upper bound (1+1/n)^n < 3 follows from (1+1/n)^n ≤ exp(1) (via the Bernoulli inequality (1+x/n)^n ≤ exp(x)) and Real.exp_one_lt_d9 (exp(1) < 2.72 < 3).",
-      "The lower bound (1+1/n)^n > 2 for n ≥ 2 follows from the base case (1+1/1)^1 = 2 and strict monotonicity."
+      "The lower bound (1+1/n)^n > 2 for n ≥ 2 follows from the base case (1+1/1)^1 = 2 and strict monotonicity.",
+      "The variable substitution g(1/n) = n·log(1+1/n) converts the discrete sequence problem into a continuous analysis problem: strict anti-monotonicity of g on (0,∞) is proved via the mean value theorem (strictAntiOn_of_deriv_neg), avoiding any combinatorial or binomial argument."
     ],
     "prerequisites": [
       "Real.add_one_lt_exp (strict form: x ≠ 0 → 1+x < exp(x))",
@@ -46,6 +47,13 @@
     ]
   },
   "sections": [
+    {
+      "id": "sec-header",
+      "title": "Module Header, Imports, and Namespace",
+      "startLine": 1,
+      "endLine": 35,
+      "summary": "Docstring documenting the four-part proof strategy: key inequality → negative derivative → strict anti-monotonicity → main theorem. Imports Mathlib and opens Real/Filter/Finset namespaces. Variables and namespace declarations."
+    },
     {
       "id": "part-i-key-inequality",
       "title": "Part I: Key Inequality log(1+t) > t/(1+t)",
@@ -90,13 +98,18 @@
   "crossReferences": [
     {
       "id": "binomial-theorem-oq-03-oq-02",
-      "relationship": "parent",
-      "description": "Parent: the classical limit (1+1/n)^n → e"
+      "title": "Classical Limit: (1+1/n)^n → e",
+      "relationship": "parent"
     },
     {
       "id": "binomial-theorem-oq-03",
-      "relationship": "ancestor",
-      "description": "Ancestor: the Poisson limit theorem using the exponential limit"
+      "title": "Poisson Limit Theorem via Exponential Limit",
+      "relationship": "foundational"
+    },
+    {
+      "id": "binomial-theorem",
+      "title": "Binomial Theorem",
+      "relationship": "foundational"
     }
   ],
   "leanFile": {


### PR DESCRIPTION
Enrichment pass for `binomial-theorem-oq-03-oq-02-oq-03` (Strict Monotonicity: (1+1/n)^n is Strictly Increasing).

## Changes
- **Deeper historicalContext**: Euler (1748), Jacob Bernoulli (1690s) compound interest problem, Rudin's Principles reference, Hermite-Hadamard convexity context
- **Fixed cross-references**: added `title` fields, added binomial theorem foundational reference
- **Header section**: lines 1-35 now covered (was starting at line 36)
- **1 new annotation**: bridge lemma nlog_strictMono (lines 128-147) — the key conversion from discrete to continuous monotonicity
- **5th keyInsight**: variable substitution g(1/n) converts discrete sequence to continuous analysis problem

Total: 6 annotations (was 5), 5 sections (was 4), 3 cross-references (was 2).