### PR TITLE
Enrich 10 gallery proofs: deepen history, fix line ranges, add cross-refs

### DIFF
--- a/src/data/proofs/vietas-formulas-oq-03-oq-05/meta.json
+++ b/src/data/proofs/vietas-formulas-oq-03-oq-05/meta.json
@@ -116,6 +116,7 @@
   },
   "conclusion": {
     "summary": "304-line formalization proving 11 theorems (0 sorries) from 0 new axioms. The main results — the 16-term quartic discriminant formula and the 64× resolvent discriminant connection — are machine-verified polynomial identities over arbitrary commutative rings.",
+    "implications": "The discriminant connection $\\Delta_{\\text{res}} = 64 \\cdot \\Delta_4$ has direct consequences for Galois theory: the Galois group of a quartic $f$ is contained in $A_4$ (the alternating group) if and only if $\\Delta_4$ is a perfect square in the base field. Since the resolvent cubic's Galois group determines $f$'s group, and both discriminants vanish simultaneously, the resolvent method cleanly reduces quartic Galois group computation to the cubic case. This is the algebraic mechanism behind Ferrari's formula: solving the quartic reduces to solving a cubic, which Cardano's formula handles. The formalization over arbitrary CommRing means these identities hold in finite fields, $p$-adic fields, and function fields — not just over $\\mathbb{Q}$ or $\\mathbb{R}$.",
     "openQuestions": [
       "Formalize the Galois solvability criterion: Gal(f) ⊆ A₄ iff the quartic discriminant is a perfect square in the base field.",
       "Prove Abel-Ruffini for the general quartic: connect Ferrari's resolvent to the fact that quartics (but not quintics) are solvable by radicals.",


### PR DESCRIPTION
## Summary

Enrichment batch for 10 gallery proofs, improving historical context depth, fixing section/annotation line ranges, adding cross-references, and filling missing fields.

### Entries enriched:
1. **amgm-inequality-oq-03-oq-02-oq-01** — Schlömilch (1858), HLP Theorem 16, 5th keyInsight, 2 new cross-refs
2. **bezout-identity-oq-03-oq-04-oq-01** — Sun Zi, Āryabhaṭa, Noether/Krull, 5th keyInsight, 2 new cross-refs
3. **angle-trisection-cos-20-gal-oq-01** — Gauss (1801), Wantzel (1837), 1 new cross-ref
4. **bezout-identity-oq-02-oq-01-oq-02-oq-02** — Added implications, 5th keyInsight, 3 new cross-refs
5. **arithmetic-series-oq-02-oq-04-oq-01-oq-03** — Fixed section/annotation line ranges
6. **central-limit-theorem-oq-01-oq-02-oq-01** — 5th keyInsight, 1 new cross-ref
7. **kummer-theorem-oq-01** — Added author/sourceUrl, 2 new cross-refs
8. **vietas-formulas-oq-03-oq-01** — 4th keyInsight on characteristic-free proof
9. **vietas-formulas-oq-03-oq-05** — Added implications for Galois theory
10. Skipped 2 entries at quality 97 (complete)

### Common improvements:
- Section and annotation line ranges corrected to match actual Lean source files
- Historical context deepened with specific dates, mathematicians, and mathematical connections
- Cross-references added to related gallery entries
- Missing metadata fields (author, sourceUrl, implications) filled in