### PR TITLE
Enrich 6 proofs: CRT, Power Mean, Galois, Gaussian, Quartic, Vandermonde

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03/meta.json
@@ -27,6 +27,23 @@
       "vandermonde_descFactorial: descFactorial(m+n,r) = ∑_j C(r,j)*descFactorial(m,j)*descFactorial(n,r-j)",
       "term_eq: key algebraic lemma C(r,j)*j!*(r-j)! = r! gives term equality",
       "Self-contained derivation from standard Vandermonde without broken parent imports"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Nat.descFactorial_eq_factorial_mul_choose",
+        "description": "descFactorial(n,k) = k! * C(n,k): conversion between falling factorials and binomial coefficients",
+        "module": "Mathlib.Data.Nat.Factorial.Basic"
+      },
+      {
+        "theorem": "Nat.choose_mul_factorial_mul_factorial",
+        "description": "C(n,k) * k! * (n-k)! = n!: the key factorial identity enabling term comparison",
+        "module": "Mathlib.Data.Nat.Choose.Basic"
+      },
+      {
+        "theorem": "Finset.sum_congr",
+        "description": "Reduce sum equality to pointwise term equality",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset"
+      }
     ]
   },
   "overview": {


### PR DESCRIPTION
## Summary

Batch enrichment of 6 gallery entries (enricher-1 cycle).

### Entries enriched:

1. **bezout-identity-oq-03-oq-04-oq-01** (CRT for Commutative Rings)
   - Deepened historicalContext (Sun Tzu → Noether), 5th keyInsight, 3 new annotations, 7 sections

2. **amgm-inequality-oq-03-oq-02-oq-01** (Power Mean Crossing Zero)
   - Deepened history (Cauchy/Chrystal/Schur/HLP), 5th keyInsight, preamble section

3. **angle-trisection-cos-20-gal-oq-01** (Galois Group of cos(π/7))
   - Deepened history (Gauss 1801, Wantzel 1837), 7 sections from 4, Abel-Ruffini cross-ref

4. **bezout-identity-oq-02-oq-01-oq-02-oq-02** (Gaussian Integers)
   - Deepened history (Eisenstein 1844), 5th keyInsight, implications, 2 new cross-refs

5. **vietas-formulas-oq-03-oq-05** (Quartic Discriminant)
   - Added implications (Galois A₄ criterion), summary annotation, Abel-Ruffini cross-ref

6. **arithmetic-series-oq-02-oq-04-oq-01-oq-03** (Vandermonde Falling Factorial)
   - Added mathlibDependencies array

All axiom integrity verified: 0 axioms, 0 sorries, status/badge correct.