### PR TITLE
fix(meta): correct stale/missing leanFile metadata (3 proofs)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-07/meta.json
@@ -22,6 +22,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 2,
+    "lineCount": 377,
     "assumptions": "Two axioms: (1) bringJerrard_reduction — the full Bring-Jerrard reduction eliminating x³ and x² terms via quadratic/cubic Tschirnhaus substitutions (requires polynomial resultant theory not in Mathlib); (2) bringRadical_not_in_radicals — the Bring radical is not expressible in radicals (follows from Abel-Ruffini but requires connecting the generic Galois group argument). The linear Tschirnhaus transform (depressed quintic) and all Bring radical properties are fully proved.",
     "dateAdded": "2026-04-03",
     "mathlibDependencies": [

--- a/src/data/proofs/erdos-1100/meta.json
+++ b/src/data/proofs/erdos-1100/meta.json
@@ -239,7 +239,7 @@
       "Finset"
     ],
     "namespace": "Erdos1100",
-    "lineCount": 329,
+    "lineCount": 328,
     "axiomCount": 4,
     "theoremCount": 6,
     "definitionCount": 7,

--- a/src/data/proofs/erdos-647/meta.json
+++ b/src/data/proofs/erdos-647/meta.json
@@ -153,7 +153,7 @@
     "theoremCount": 25,
     "definitionCount": 11,
     "path": "Proofs/Erdos647Problem.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Three secondary metadata fixes in gallery proof entries:

1. **erdos-647**: `leanFile.sorries = 1` → `0`
   - The Lean source has 0 real sorries (previous sorry was closed)
   - The top-level `meta.sorries` was already correct at 0

2. **erdos-1100**: `leanFile.lineCount = 329` → `328`
   - Actual file has 328 lines; 1-line off in secondary section
   - The top-level `meta.lineCount` was already correct at 328

3. **abel-ruffini-oq-04-oq-07**: Add missing `meta.lineCount = 377`
   - The `meta` section was missing the `lineCount` field entirely
   - The `leanFile` section already had `lineCount: 377` which matches the actual file

## Validation

`pnpm build` passes cleanly for PR #9926 (same metadata path).

---
Automated fix by lean-mechanic agent.