### PR TITLE
fix(meta): remove 12 broken cross-references to non-existent proofs

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-03/meta.json
@@ -161,11 +161,6 @@
       "targetId": "binomial-theorem-oq-02",
       "relationship": "extends",
       "description": "The q-multinomial theorem is the quantum generalization of the classical multinomial theorem proved in OQ-02"
-    },
-    {
-      "targetId": "combinations-formula-oq-03",
-      "relationship": "foundational",
-      "description": "Depends on q-binomial coefficients and q-factorials defined in CombinationsFormulaOQ03"
     }
   ],
   "references": [

--- a/src/data/proofs/binomial-theorem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-03/meta.json
@@ -133,11 +133,6 @@
       "targetId": "binomial-theorem-oq-04-oq-02",
       "relationship": "related",
       "description": "Algebraic proof via coefficient comparison — the q-analog uses a different technique (q-Pascal induction)"
-    },
-    {
-      "targetId": "combinations-formula-oq-03",
-      "relationship": "uses",
-      "description": "q-binomial coefficient infrastructure (qBinom, qNumber, qFactorial, q-Pascal recurrence) is defined and proved here"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/collatz-cycles/meta.json
+++ b/src/data/proofs/collatz-cycles/meta.json
@@ -111,11 +111,6 @@
     }
   ],
   "crossReferences": [
-    {
-      "targetId": "collatz-stopping-times",
-      "relationship": "related",
-      "description": "Collatz stopping time bounds and Terras density results \u2014 related work on the forward orbit structure"
-    }
   ],
   "leanFile": {
     "lineCount": 256,

--- a/src/data/proofs/cramers-rule-oq-01-oq-04/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-04/meta.json
@@ -131,11 +131,6 @@
       "targetId": "cramers-rule",
       "relationship": "related",
       "description": "Cramer's Rule parent; the adjugate identity underlies both Cayley-Hamilton and the Newton large-k recurrence"
-    },
-    {
-      "targetId": "vietasformulas-oq-03-oq-01",
-      "relationship": "sibling",
-      "description": "VietasFormulasOQ03OQ01.lean proves Newton identities for MvPolynomial; this file applies the same theory to matrices"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-1-oq-03/meta.json
+++ b/src/data/proofs/erdos-1-oq-03/meta.json
@@ -117,11 +117,6 @@
       "targetId": "erdos-1",
       "relationship": "extends",
       "description": "Extends the Erdos #1 formalization with the Conway-Guy construction and optimality"
-    },
-    {
-      "targetId": "erdos-1-oq-01",
-      "relationship": "related",
-      "description": "OQ-01 studies the Dubroff-Fox-Xu lower bound; this studies the Conway-Guy upper bound"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-1162/meta.json
+++ b/src/data/proofs/erdos-1162/meta.json
@@ -157,11 +157,6 @@
   },
   "crossReferences": [
     {
-      "targetId": "lagranges-theorem",
-      "relationship": "foundational",
-      "description": "Lagrange's theorem constrains possible subgroup orders to divisors of n!, which is fundamental to the enumeration problem"
-    },
-    {
       "targetId": "sylow-theorem",
       "relationship": "foundational",
       "description": "Sylow's theorems give the structure of p-subgroups of S_n; the dominance of 2-subgroups in the count connects to Sylow 2-subgroups"

--- a/src/data/proofs/four-color-theorem-oq-01/meta.json
+++ b/src/data/proofs/four-color-theorem-oq-01/meta.json
@@ -125,11 +125,6 @@
       "targetId": "four-color-theorem",
       "relationship": "parent",
       "description": "This open question investigates the proof methodology of the Four Color Theorem. The main entry axiomatizes the 4CT; this entry explores whether the axiom could be replaced by a human-verifiable proof."
-    },
-    {
-      "targetId": "five-color-theorem",
-      "relationship": "related",
-      "description": "The Five Color Theorem IS the human-readable version of 4CT's proof strategy. It succeeds because one Kempe chain swap suffices, while 4CT would need two (which can interfere)."
     }
   ],
   "references": [

--- a/src/data/proofs/konigsberg-oq-03-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-03-oq-02/meta.json
@@ -107,11 +107,6 @@
       "targetId": "konigsberg",
       "relationship": "grandparent",
       "description": "Root Königsberg bridges entry: finite Eulerian circuit conditions. This entry generalizes to infinite graphs."
-    },
-    {
-      "targetId": "konigsberg-oq-03-oq-01",
-      "relationship": "sibling",
-      "description": "Sibling: Erdős-Grünwald-Weiszfeld theorem — characterization of one-way Euler paths. Uses the InfiniteWalk definition from this entry."
     }
   ]
 }

--- a/src/data/proofs/leibniz-pi-oq-03/meta.json
+++ b/src/data/proofs/leibniz-pi-oq-03/meta.json
@@ -100,11 +100,6 @@
       "targetId": "leibniz-pi-oq-01",
       "relationship": "sibling",
       "description": "Machin's formula: a different acceleration method using two arctan evaluations"
-    },
-    {
-      "targetId": "leibniz-pi-oq-02",
-      "relationship": "sibling",
-      "description": "Richardson extrapolation method for the Leibniz series"
     }
   ],
   "references": [

--- a/src/data/proofs/roth-theorem-k3-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-01/meta.json
@@ -129,11 +129,6 @@
       "targetId": "szemeredi-regularity",
       "relationship": "related",
       "description": "Szemerédi regularity is the key tool for extending Roth's qualitative theorem to k-APs (Szemerédi's theorem)"
-    },
-    {
-      "targetId": "cap-set-problem",
-      "relationship": "related",
-      "description": "The cap set problem is the analogous question for 3-AP-free sets in (ℤ/3ℤ)ⁿ, solved by Ellenberg-Gijswijt (2016) using polynomial methods that later influenced Kelley-Meka"
     }
   ],
   "conclusion": {

--- a/src/data/proofs/sperner-ndim-oq-03/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-03/meta.json
@@ -118,11 +118,6 @@
       "description": "Uses the Sperner's lemma infrastructure (Vertex, Coloring, IsSperner, FSimplex, IsFC) and takes sperner_ndim as a hypothesis"
     },
     {
-      "targetId": "brouwer-fixed-point-oq-02-oq-01",
-      "relationship": "generalizes",
-      "description": "Generalizes the 2D displacement coloring and Sperner condition proof from BrouwerFixedPointOQ02OQ01.lean to arbitrary dimension d"
-    },
-    {
       "targetId": "brouwer-fixed-point",
       "relationship": "related",
       "description": "Provides an alternative, axiom-free path to Brouwer's FPT via combinatorics rather than algebraic topology"

--- a/src/data/proofs/stirling-formula-oq-02/meta.json
+++ b/src/data/proofs/stirling-formula-oq-02/meta.json
@@ -97,11 +97,6 @@
       "targetId": "area-of-circle-oq-02",
       "relationship": "related",
       "description": "n-ball volume uses Gamma function; Stirling bounds give asymptotic ball volumes"
-    },
-    {
-      "targetId": "wallis-product",
-      "relationship": "related",
-      "description": "Wallis product π/2 = ∏ 4k²/(4k²-1) is equivalent to stirlingSeq → √π, the key limit underlying the Stirling constant"
     }
   ],
   "sections": [


### PR DESCRIPTION
## Fix

Removed 12 `crossReference` entries that point to proof IDs which do not
exist in the gallery. These were stale references to proofs that were
never created, renamed, or deleted after the cross-reference was written.

## Broken references removed

| Source proof | Broken target | Notes |
|---|---|---|
| leibniz-pi-oq-03 | leibniz-pi-oq-02 | oq-02 was never created |
| four-color-theorem-oq-01 | five-color-theorem | not in gallery |
| cramers-rule-oq-01-oq-04 | vietasformulas-oq-03-oq-01 | not in gallery |
| konigsberg-oq-03-oq-02 | konigsberg-oq-03-oq-01 | not in gallery |
| binomial-theorem-oq-02-oq-03 | combinations-formula-oq-03 | oq-03 not created |
| collatz-cycles | collatz-stopping-times | not in gallery |
| binomial-theorem-oq-04-oq-03 | combinations-formula-oq-03 | oq-03 not created |
| stirling-formula-oq-02 | wallis-product | not in gallery |
| sperner-ndim-oq-03 | brouwer-fixed-point-oq-02-oq-01 | not in gallery |
| roth-theorem-k3-oq-01 | cap-set-problem | not in gallery |
| erdos-1162 | lagranges-theorem | not in gallery |
| erdos-1-oq-03 | erdos-1-oq-01 | oq-01 was never created |

## Impact

- No valid cross-references were removed
- Each source proof retains all other cross-references intact
- The JSON for all 12 files validates cleanly

---
Automated fix by lean-mechanic agent.