### PR TITLE
fix(meta): correct stale lineCount for 32 gallery proofs

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-04/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-04-05",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
-    "lineCount": 220,
+    "lineCount": 219,
     "theoremCount": 2,
     "definitionCount": 1,
     "originalContributions": [
@@ -59,7 +59,7 @@
     "imports": ["Mathlib"],
     "opens": ["Real", "Filter", "Finset"],
     "namespace": "AmgmOQ03OQ02OQ04",
-    "lineCount": 220,
+    "lineCount": 219,
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/AmgmInequalityOQ03OQ02OQ04.lean",

--- a/src/data/proofs/amgm-inequality-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04/meta.json
@@ -22,7 +22,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 3,
-    "lineCount": 307,
+    "lineCount": 316,
     "assumptions": "3 axioms: ellipticK (function), ellipticK_zero, agm_ellipticK (Gauss's theorem connecting AGM to elliptic integrals). All convergence results are proved from Mathlib's monotone convergence theorem.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01/meta.json
@@ -74,7 +74,7 @@
         "relationship": "Parent of this entry, providing the surface area formulation that this entry integrates"
       }
     ],
-    "lineCount": 284,
+    "lineCount": 290,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0"
   },
@@ -223,7 +223,7 @@
       "MeasureTheory"
     ],
     "namespace": "NDimVolumeIntegral",
-    "lineCount": 284,
+    "lineCount": 290,
     "axiomCount": 0,
     "theoremCount": 25,
     "definitionCount": 3,

--- a/src/data/proofs/area-of-circle-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01/meta.json
@@ -42,7 +42,7 @@
     ],
     "dateAdded": "2026-02-14",
     "axiomCount": 0,
-    "lineCount": 163,
+    "lineCount": 162,
     "prerequisites": [
       "Differentiation of real functions (HasDerivAt)",
       "Area of circle (pi*r^2) and circumference (2*pi*r)",

--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-04-05",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
-    "lineCount": 125,
+    "lineCount": 130,
     "theoremCount": 6,
     "definitionCount": 0,
     "originalContributions": [
@@ -68,7 +68,7 @@
       "Finset"
     ],
     "namespace": "BallotProblemLGVGeneral",
-    "lineCount": 125,
+    "lineCount": 130,
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/BallotProblemOQ03OQ01OQ01.lean",

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. All results from Mathlib's UniqueFactorizationMonoid typeclasses.",
     "dateAdded": "2026-04-04",
-    "lineCount": 130,
+    "lineCount": 127,
     "theoremCount": 14,
     "definitionCount": 0,
     "mathlibDependencies": [
@@ -183,7 +183,7 @@
     "imports": ["Mathlib"],
     "opens": ["Polynomial", "MvPolynomial", "UniqueFactorizationMonoid"],
     "namespace": "BezoutIdentityMultivarPoly",
-    "lineCount": 130,
+    "lineCount": 127,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 0

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. Uses native_decide for concrete norm primality checks (standard Lean 4 kernel verification). All structural results follow from Mathlib's GaussianInt and Zsqrtd APIs.",
-    "lineCount": 194,
+    "lineCount": 193,
     "theoremCount": 14,
     "definitionCount": 0,
     "mathlibDependencies": [

--- a/src/data/proofs/bezout-identity-oq-03/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03/meta.json
@@ -54,7 +54,7 @@
     ],
     "dateAdded": "2026-02-21",
     "axiomCount": 0,
-    "lineCount": 284,
+    "lineCount": 276,
     "assumptions": "0 axioms, 0 sorries. CRT construction derived from Mathlib's Int.gcd_eq_gcd_ab (Bézout's identity) and IsCoprime.mul_dvd.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -50,7 +50,7 @@
       }
     ],
     "leanFile": {
-      "lineCount": 7422,
+      "lineCount": 7430,
       "structureCount": 92,
       "axiomCount": 19,
       "theoremCount": 254,
@@ -108,7 +108,7 @@
     "dateAdded": "2025-12-29",
     "millenniumProblem": "bsd",
     "proofRepoPath": "Proofs/BirchSwinnertonDyer.lean",
-    "lineCount": 7422,
+    "lineCount": 7430,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -681,7 +681,7 @@
       "ComplexConjugate"
     ],
     "namespace": "BirchSwinnertonDyer",
-    "lineCount": 7422,
+    "lineCount": 7430,
     "axiomCount": 19,
     "theoremCount": 254,
     "definitionCount": 143,

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01/meta.json
@@ -18,7 +18,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 139,
+    "lineCount": 138,
     "theoremCount": 9,
     "defCount": 1,
     "assumptions": "1 axiom: buDim_le_formula (the open conjecture: buDim(n,d) ≤ max_{p|n} buDim(p,d)). Lower bound direction proved from buDim_mono in parent file. Specific cases n=4,6,9 proved. buDim function and known results axiomatized in parent file BorsukUlamOQ02OQ01.lean.",

--- a/src/data/proofs/borsuk-ulam/meta.json
+++ b/src/data/proofs/borsuk-ulam/meta.json
@@ -40,7 +40,7 @@
       "Modular proof structure suitable for completing when Mathlib gains covering space theory"
     ],
     "dateAdded": "2025-12-22",
-    "lineCount": 265,
+    "lineCount": 267,
     "axiomCount": 1,
     "prerequisites": [
       "Algebraic topology: fundamental groups and covering spaces",

--- a/src/data/proofs/cauchy-schwarz-oq-03/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-03/meta.json
@@ -52,7 +52,7 @@
     ],
     "dateAdded": "2026-02-26",
     "axiomCount": 0,
-    "lineCount": 242,
+    "lineCount": 244,
     "assumptions": "0 axioms, 0 sorries. Core Hölder inequality derived from Mathlib's NNReal.inner_le_Lp_mul_Lq and ENNReal.lintegral_mul_le_Lp_mul_Lq. Lagrange identity proof of Cauchy-Schwarz is independent.",
     "mathlib_version": "4.26.0"
   },
@@ -154,7 +154,7 @@
       "ENNReal"
     ],
     "namespace": null,
-    "lineCount": 242,
+    "lineCount": 244,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 0,

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04/meta.json
@@ -20,7 +20,7 @@
     "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 262,
+    "lineCount": 268,
     "assumptions": "0 axioms. 1 sorry: main theorem nonderogatory_has_cyclic_vector_any_field (needs structure theorem for f.g. modules over PID, not in Mathlib).",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [

--- a/src/data/proofs/chebyshev-bounds/meta.json
+++ b/src/data/proofs/chebyshev-bounds/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
-    "lineCount": 445,
+    "lineCount": 439,
     "theoremCount": 18,
     "definitionCount": 3,
     "originalContributions": [

--- a/src/data/proofs/continuum-hypothesis/meta.json
+++ b/src/data/proofs/continuum-hypothesis/meta.json
@@ -40,7 +40,7 @@
     "dateAdded": "2025-12-29",
     "axiomCount": 4,
     "assumptions": "4 axiom declarations: L_exists (constructible universe L exists as ZFC model), L_satisfies_CH (L satisfies CH), forcing_extension_exists (Cohen forcing extension exists), forcing_violates_CH (forcing model violates CH). Previously 6 axioms; ch_implies_no_intermediate and no_intermediate_implies_ch are now proved from Mathlib cardinal arithmetic.",
-    "lineCount": 396,
+    "lineCount": 395,
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/derangements-convergence-oq-01/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-01/meta.json
@@ -23,7 +23,7 @@
     "axiomCount": 0,
     "assumptions": "No assumptions. All theorems are fully machine-checked. The derangements_rate lemma delegates to derangements_convergence_rate from DerangementsConvergence.lean, which proves |D(n)/n! - e⁻¹| ≤ 1/(n+1)! via the alternating series estimation theorem.",
     "dateAdded": "2026-04-04",
-    "lineCount": 151,
+    "lineCount": 152,
     "theoremCount": 7,
     "definitionCount": 1,
     "originalContributions": [

--- a/src/data/proofs/dissection-of-cubes-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02/meta.json
@@ -39,7 +39,7 @@
       "polygon_dehn_zero: 2D Bolyai-Gerwien analog (all polygons have zero Dehn invariant)",
       "Conditional Hilbert's Third Problem: cube and tetrahedron not scissors congruent, assuming Dehn's theorem as hypothesis"
     ],
-    "lineCount": 381,
+    "lineCount": 379,
     "axiomCount": 0,
     "assumptions": "No axiom declarations. Dehn's theorem is encoded as an explicit hypothesis (not an axiom) in hilbert_third_problem. ScissorsCongruent uses a simplified placeholder definition. The core number-theoretic result (arccos(1/3)/π is irrational) is fully proved.",
     "mathlib_version": "4.26.0"
@@ -176,7 +176,7 @@
       "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
     ],
     "namespace": "DissectionOfCubesOQ02",
-    "lineCount": 381,
+    "lineCount": 379,
     "axiomCount": 0,
     "theoremCount": 18,
     "definitionCount": 5,

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 178,
+    "lineCount": 168,
     "theoremCount": 11,
     "defCount": 0,
     "assumptions": "1 axiom: gauss_sum_sq (the squared Gauss sum identity τ² = (-1)^{(p-1)/2}·p, requiring cyclotomic field orthogonality — not in Mathlib 4.26). All three QR pathways proved using legendreSym.quadratic_reciprocity from Mathlib.",

--- a/src/data/proofs/erdos-1000/meta.json
+++ b/src/data/proofs/erdos-1000/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/1000",
     "erdosProblemStatus": "solved",
     "axiomCount": 2,
-    "lineCount": 1119,
+    "lineCount": 1124,
     "assumptions": "Two deep axioms: erdos_dichotomy (liminf=0 implies limsup=1, via Euler product for φ(n)/n), haight_resolution (vanishing Cesàro average exists, via highly composite construction). erdos_no_zero_limit is now PROVED from erdos_dichotomy (convergence to 0 contradicts dichotomy via frequently-vs-eventually). cassels_liminf_zero is PROVED from haight_resolution. Infrastructure: complement formula, growth bounds, multiplicity bounds, double-counting vocabulary, growth constraints from low density, deficit counting bounds.",
     "mathlib_version": "4.26.0"
   },
@@ -202,7 +202,7 @@
       "Topology"
     ],
     "namespace": "Erdos1000",
-    "lineCount": 1119,
+    "lineCount": 1124,
     "axiomCount": 2,
     "theoremCount": 60,
     "definitionCount": 8,

--- a/src/data/proofs/erdos-1008/meta.json
+++ b/src/data/proofs/erdos-1008/meta.json
@@ -23,7 +23,7 @@
     "erdosUrl": "https://erdosproblems.com/1008",
     "erdosProblemStatus": "solved",
     "axiomCount": 1,
-    "lineCount": 607,
+    "lineCount": 698,
     "assumptions": "1 axiom: Conlon-Fox-Sudakov main theorem (Ω(m^{2/3}) C₄-free subgraph). Proved: Kővári-Sós-Turán C₄-case (cherry counting+CS), K₂₂↔C₄ equivalence, C₄-freeness hereditary/monotone, common neighbor uniqueness, few-edges C₄-free, Folkman ratio, bipartite KST (cherry counting on K_{n,n²}), exponent 2/3 optimality.",
     "mathlib_version": "4.26.0"
   },
@@ -131,7 +131,7 @@
       "Finset"
     ],
     "namespace": "Erdos1008",
-    "lineCount": 607,
+    "lineCount": 698,
     "axiomCount": 1,
     "theoremCount": 26,
     "definitionCount": 8,

--- a/src/data/proofs/erdos-204/meta.json
+++ b/src/data/proofs/erdos-204/meta.json
@@ -54,7 +54,7 @@
       "MaxCoverableDensity: related optimization problem (sorry — incomplete definition)"
     ],
     "axiomCount": 1,
-    "lineCount": 189,
+    "lineCount": 185,
     "assumptions": "1 axiom (adenwalla_2025) and 1 sorry (MaxCoverableDensity definition). See the Lean source for details."
   },
   "overview": {

--- a/src/data/proofs/erdos-448/meta.json
+++ b/src/data/proofs/erdos-448/meta.json
@@ -59,7 +59,7 @@
       "erdos_448 theorem: the conjecture is false"
     ],
     "axiomCount": 2,
-    "lineCount": 298,
+    "lineCount": 307,
     "assumptions": "12 axiom(s) and 1 sorry(s). See the Lean source for details."
   },
   "overview": {

--- a/src/data/proofs/erdos-606-oq-03/meta.json
+++ b/src/data/proofs/erdos-606-oq-03/meta.json
@@ -19,7 +19,7 @@
     "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 99,
+    "lineCount": 101,
     "assumptions": "0 axioms, 0 sorries. The 3 stated theorems (max_hyperplanes, line_count_range, hyperplane_extremes) are fully machine-checked. Sylvester-Gallai, Green-Tao, and Motzkin are referenced in comments only — not declared as Lean axioms. Status is formalized: the Lean file is a partial framework for the open problem (achievable hyperplane counts) with auxiliary results proved but the main conjecture not formalized.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
@@ -93,7 +93,7 @@
       "Mathlib"
     ],
     "namespace": "Erdos606OQ03",
-    "lineCount": 99,
+    "lineCount": 101,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 0,

--- a/src/data/proofs/euler-totient/meta.json
+++ b/src/data/proofs/euler-totient/meta.json
@@ -55,7 +55,7 @@
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 10,
     "axiomCount": 0,
-    "lineCount": 136,
+    "lineCount": 135,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/geometric-series-oq-03/meta.json
+++ b/src/data/proofs/geometric-series-oq-03/meta.json
@@ -62,7 +62,7 @@
     ],
     "dateAdded": "2026-04-05",
     "axiomCount": 0,
-    "lineCount": 235,
+    "lineCount": 215,
     "theoremCount": 15,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0"

--- a/src/data/proofs/hilbert-15/meta.json
+++ b/src/data/proofs/hilbert-15/meta.json
@@ -44,7 +44,7 @@
     "hilbertNumber": 15,
     "proofRepoPath": "Proofs/Hilbert15SchubertCalculus.lean",
     "axiomCount": 7,
-    "lineCount": 472,
+    "lineCount": 470,
     "assumptions": "7 axioms: four_lines_theorem, transversal_count, schubert_basis_theorem, littlewoodRichardsonCoeff, littlewood_richardson_rule, pieris_rule, sigma1_fourth_power. linesMeet_iff_linesMeet' was proved from Mathlib's Grassmann dimension formula.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/hilbert-17/meta.json
+++ b/src/data/proofs/hilbert-17/meta.json
@@ -44,7 +44,7 @@
     "dateAdded": "2025-12-29",
     "hilbertNumber": 17,
     "axiomCount": 10,
-    "lineCount": 570,
+    "lineCount": 561,
     "assumptions": [
       "artin_hilbert17: Every PSD multivariate polynomial over R is a sum of squares of rational functions (Artin's theorem)",
       "artin_univariate_aux: Every PSD univariate polynomial is a sum of squares of rational functions",

--- a/src/data/proofs/hilbert-4/meta.json
+++ b/src/data/proofs/hilbert-4/meta.json
@@ -44,7 +44,7 @@
     "hilbertNumber": 4,
     "axiomCount": 6,
     "assumptions": "6 axiom declarations: minkowski_geodesics_are_straight (lines are geodesics in Minkowski), minkowski_straight_line_shortest (line is shortest path), hilbert_geodesics_are_straight (Hilbert metric geodesics), busemann_classification (exhaustive metric classification), hamel_theorem_2d (2D Minkowski characterization), funk_geodesics_straight (Funk metric geodesics). Some axioms are placeholder/vacuous pending proper formalization of metric geometry foundations.",
-    "lineCount": 457,
+    "lineCount": 458,
     "prerequisites": [
       "Metric spaces and geodesics",
       "Normed vector spaces and Minkowski geometry",

--- a/src/data/proofs/lagrange-four-squares/meta.json
+++ b/src/data/proofs/lagrange-four-squares/meta.json
@@ -35,7 +35,7 @@
     "dateAdded": "2025-12-26",
     "axiomCount": 8,
     "assumptions": "8 axiom declarations: legendre_three_squares (3-square obstruction criterion), jacobi_four_squares (r4(n) exact formula), hilbert_waring (g(k) exists for all k), wieferich_nine_cubes (g(3)=9), waring_general_formula (g(k) general formula), vinogradov_waring_bound (G(k) upper bound), hurwitz_quaternions_euclidean (Hurwitz integers Euclidean), hurwitz_representation_count (quaternion representation count). Previously axiomatized fermat_two_squares now proved via Mathlib Nat.Prime.sq_add_sq.",
-    "lineCount": 422,
+    "lineCount": 417,
     "prerequisites": [
       "Quaternion algebra and norm multiplicativity",
       "Euler's four-square identity",

--- a/src/data/proofs/leibniz-pi-oq-03/meta.json
+++ b/src/data/proofs/leibniz-pi-oq-03/meta.json
@@ -21,7 +21,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 274,
+    "lineCount": 277,
     "theoremCount": 15,
     "defCount": 2,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",

--- a/src/data/proofs/shannon-entropy/meta.json
+++ b/src/data/proofs/shannon-entropy/meta.json
@@ -44,7 +44,7 @@
     ],
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
-    "lineCount": 900,
+    "lineCount": 901,
     "prerequisites": [
       "Probability distributions and discrete random variables",
       "Logarithm and convexity (Jensen's inequality)",

--- a/src/data/proofs/spherical-law-of-sines/meta.json
+++ b/src/data/proofs/spherical-law-of-sines/meta.json
@@ -14,7 +14,7 @@
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
-    "lineCount": 330,
+    "lineCount": 323,
     "theoremCount": 18,
     "definitionCount": 6,
     "originalContributions": [


### PR DESCRIPTION
## Fix

Corrected stale `lineCount` values in 32 `meta.json` files where the Lean source files have grown since the count was last recorded.

## Evidence

**Before**: `lineCount` values reported in meta.json did not match actual line count of `.lean` files  
**After**: All 32 lineCount values match `wc -l` of the corresponding Lean source

Notable corrections:
- `erdos-1008`: 607 → 698 (+91 lines)
- `erdos-1000`: 1119 → 1124 (+5 lines)
- `elementary-quadratic-reciprocity-oq-01-oq-01`: 178 → 168 (-10 lines)
- `geometric-series-oq-03`: 235 → 215 (-20 lines)

These are metadata-only changes. No Lean source or gallery logic was modified.

---
Automated fix by lean-mechanic agent.