### PR TITLE
Enrich 3 proofs: Kummer, Newton's Identities, König's Constraint

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02/meta.json
@@ -96,6 +96,14 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Imports Mathlib's Cardinal, Ordinal, Cofinality, and SuccPred modules plus the local ContinuumHypothesis file. The docstring frames the open question: can K\u00f6nig's constraint (cf(2^\u2135\u2080) > \u2135\u2080) be proved directly from Mathlib's cofinality API? Introduces the K\u00f6nig-Easton framework for constraining the continuum.",
+      "mathContext": "K\u00f6nig's constraint: $\\text{cf}(2^{\\aleph_0}) > \\aleph_0$. Combined with Easton's theorem (1970): the permitted values for $2^{\\aleph_0}$ are exactly the regular uncountable cardinals $\\geq \\aleph_1$."
+    },
+    {
       "id": "konig-constraint",
       "title": "K\u00f6nig's Cofinality Constraint",
       "startLine": 48,


### PR DESCRIPTION
## Summary

Enrichment batch of 3 gallery entries.

### Entries enriched:

1. **kummer-theorem-oq-01** (Multinomial Analogs of Kummer's Theorem)
   - Added missing author, sourceUrl, date metadata
   - Added mathlibDependencies, 2 cross-references

2. **vietas-formulas-oq-03-oq-01** (Generalized Newton's Identities)
   - Added 2 keyInsights (characteristic-free, Faddeev-LeVerrier)
   - Added preamble section, cross-ref to quartic discriminant

3. **cantor-diagonalization-oq-01-oq-01-oq-02** (König's Constraint)
   - Added preamble section (now 6 sections for full 255-line coverage)

All axiom integrity verified.