### PR TITLE
Enrich CRT for commutative rings & Legendre's formula: deepen history, full annotations

### DIFF
--- a/src/data/proofs/bezout-identity-oq-03-oq-04-oq-01/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-04-oq-01/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-module-preamble",
+    "proofId": "bezout-identity-oq-03-oq-04-oq-01",
+    "range": { "startLine": 1, "endLine": 27 },
+    "type": "context",
+    "title": "Module Setup and Motivating Question",
+    "content": "The file imports `Mathlib.RingTheory.Coprime.Basic` (providing `IsCoprime` and `IsCoprime.mul_dvd`) and the general tactic library. The module docstring poses the open question from the parent entry: can the integer-specific `crtDirect` be lifted to arbitrary commutative rings? The answer — yes, with `IsCoprime` as the sole hypothesis — sets the agenda for the file. The namespace `BezoutIdentityOQ03OQ04OQ01` scopes all definitions to avoid name collisions with the integer-specific versions in the parent file.",
+    "mathContext": "The import `Mathlib.RingTheory.Coprime.Basic` brings in the definition `IsCoprime (a b : R) := \\exists s t, s \\cdot a + t \\cdot b = 1` and the key lemma `IsCoprime.mul_dvd`: if $\\gcd(m,n) = 1$ and $m \\mid d$ and $n \\mid d$ then $mn \\mid d$. These are the only Mathlib ingredients the proof needs.",
+    "significance": "context",
+    "relatedConcepts": ["Mathlib imports", "namespace scoping in Lean 4", "IsCoprime definition"],
+    "prerequisites": ["Lean 4 module system", "Mathlib library structure"]
+  },
+  {
     "id": "ann-crt-ring-def",
     "proofId": "bezout-identity-oq-03-oq-04-oq-01",
     "range": { "startLine": 29, "endLine": 37 },
@@ -58,5 +70,17 @@
     "significance": "technical",
     "relatedConcepts": ["bezout-identity-oq-03-oq-04", "Int.gcdA", "Int.gcdB", "extended Euclidean algorithm", "specialization of ring theorems"],
     "prerequisites": ["integer arithmetic in Lean 4", "ring theory specialization"]
+  },
+  {
+    "id": "ann-summary-instances",
+    "proofId": "bezout-identity-oq-03-oq-04-oq-01",
+    "range": { "startLine": 99, "endLine": 129 },
+    "type": "context",
+    "title": "Concrete Ring Instances and Exported API",
+    "content": "The summary block catalogues the rings where `crtRing` applies: $\\mathbb{Z}$ (the original case), polynomial rings $k[X]$ over a field (where CRT gives Lagrange interpolation), Gaussian integers $\\mathbb{Z}[i]$ (a Euclidean domain, hence IsBezout), any field (trivially coprime non-zero elements), and any PID. The `#check` commands at the end serve as a documentation aid, printing the full type signatures of the five exported theorems — confirming that `crtRing`, `crtRing_mod_m`, `crtRing_mod_n`, `crtRing_unique`, and `crtRing_exists` all carry the polymorphic `{R : Type*} [CommRing R]` signature.",
+    "mathContext": "Key instance: for $k[X]$ with $\\gcd(p, q) = 1$, the CRT solution $b \\cdot s \\cdot p + a \\cdot t \\cdot q$ is exactly the Lagrange interpolation polynomial through prescribed remainders modulo $p$ and $q$. This connection makes `crtRing` a verified building block for polynomial interpolation algorithms.",
+    "significance": "supporting",
+    "relatedConcepts": ["Lagrange interpolation", "Gaussian integers", "principal ideal domain", "polynomial ring", "Lean 4 #check command"],
+    "prerequisites": ["field theory", "polynomial arithmetic", "Euclidean domains"]
   }
 ]

--- a/src/data/proofs/bezout-identity-oq-03-oq-04-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-03-oq-04-oq-01/meta.json
@@ -44,22 +44,30 @@
     "assumptions": "0 axioms. 0 sorries."
   },
   "overview": {
-    "historicalContext": "The Chinese Remainder Theorem (CRT) holds in any commutative ring where the moduli are coprime (IsCoprime). The integer version uses extended GCD algorithms; the ring version replaces integer-specific lemmas with ring-theoretic ones. The IsBezout typeclass (every finitely-generated ideal is principal) covers rings like polynomial rings k[X] over a field, Gaussian integers ℤ[i], and any PID.",
+    "historicalContext": "The Chinese Remainder Theorem traces to Sun Zi's Suanjing (3rd–5th century CE), where the problem of simultaneous integer congruences first appeared. Qin Jiushao gave a constructive algorithm (Da Yan Qiu Yi Shu) in 1247. Euler (1734) and Gauss (Disquisitiones Arithmeticae, 1801) cast the result in modular arithmetic over $\\mathbb{Z}$. The leap to arbitrary commutative rings came with Dedekind (1871), who introduced ideals, and Emmy Noether (1920s), whose abstract ring theory provided the language of coprimality in general rings. In modern commutative algebra, the CRT is stated for coprime ideals $I + J = R$; the formulation here, using Mathlib's `IsCoprime` predicate ($\\exists s,t,\\, sm + tn = 1$), is the element-level equivalent. This generalization matters because it applies uniformly to polynomial rings $k[X]$ (where CRT yields Lagrange interpolation), Gaussian integers $\\mathbb{Z}[i]$, and any principal ideal domain.",
     "problemStatement": "Can crtDirect (from BezoutIdentityOQ03OQ04) be generalized to arbitrary commutative rings where Bézout's identity holds? Lean's type class system should support this via IsBezout or GCDMonoid.",
     "proofStrategy": "Replace ℤ-specific lemmas with ring-theoretic equivalents: (1) linarith becomes linear_combination for the correctness proofs; (2) Int.Coprime.mul_dvd_of_dvd_of_dvd becomes IsCoprime.mul_dvd for uniqueness; (3) Int.gcd and Int.gcdA/gcdB become IsCoprime witnesses. The construction crtRing = b·s·m + a·t·n works identically over any CommRing.",
     "keyInsights": [
       "The key realization: the CRT correctness proofs in BezoutIdentityOQ03OQ04.lean use only ring arithmetic (linear_combination / linarith). The integer case uses linarith only because the arithmetic is over ℤ. For a general CommRing, linear_combination handles the same algebraic identities.",
       "IsBezout is not needed for the core theorems — IsCoprime (∃ s t, s * m + t * n = 1) suffices. IsBezout only matters when you need to compute Bézout coefficients algorithmically. For existential statements, IsCoprime is the right assumption.",
       "The Mathlib lemma IsCoprime.mul_dvd directly replaces Int.Coprime.mul_dvd_of_dvd_of_dvd: if IsCoprime m n and m ∣ x-y and n ∣ x-y, then m*n ∣ x-y. This works in any CommRing without additional assumptions.",
-      "The proof crtRing_mod_m a b s t m n hbez = ⟨b * s - a * s, by unfold crtRing; linear_combination a * hbez⟩ is a complete one-liner. The linear_combination certificate a * hbez encodes: a * (s*m + t*n) - a*1 = 0."
+      "The proof crtRing_mod_m a b s t m n hbez = ⟨b * s - a * s, by unfold crtRing; linear_combination a * hbez⟩ is a complete one-liner. The linear_combination certificate a * hbez encodes: a * (s*m + t*n) - a*1 = 0.",
+      "The progression from crtDirect (ℤ-specific) to crtRing (any CommRing) mirrors a recurring pattern in formalization: first prove a concrete special case, then observe that the proof uses only ring axioms, and finally re-state with the minimal typeclass constraint. This is the formal analogue of Noether's philosophy — stating theorems at their natural level of generality — and Lean's typeclass system makes the generalization essentially free."
     ]
   },
   "sections": [
     {
+      "id": "sec-preamble",
+      "title": "Imports and Module Documentation",
+      "startLine": 1,
+      "endLine": 27,
+      "summary": "Imports Mathlib's coprimality theory (RingTheory.Coprime.Basic) and tactic library. The module docstring states the open question — whether crtDirect generalizes beyond ℤ — and answers it affirmatively: only IsCoprime is needed, not IsBezout."
+    },
+    {
       "id": "sec-def",
       "title": "Part 1: CRT Construction",
-      "startLine": 27,
-      "endLine": 35,
+      "startLine": 28,
+      "endLine": 37,
       "summary": "crtRing over CommRing: b*s*m + a*t*n"
     },
     {
@@ -82,6 +90,13 @@
       "startLine": 112,
       "endLine": 125,
       "summary": "crtInt_from_ring: the integer case is a special case of crtRing"
+    },
+    {
+      "id": "sec-summary",
+      "title": "Summary and Type Signatures",
+      "startLine": 99,
+      "endLine": 129,
+      "summary": "Recaps the answer to OQ-01: crtDirect generalizes to any CommRing, with IsCoprime as the minimal hypothesis. Lists concrete ring instances (ℤ, k[X], ℤ[i], fields, PIDs). The #check commands confirm the exported signatures."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/wilsons-theorem-oq-03/annotations.json
+++ b/src/data/proofs/wilsons-theorem-oq-03/annotations.json
@@ -2,57 +2,97 @@
   {
     "id": "ann-legendre-digit-sum",
     "proofId": "wilsons-theorem-oq-03",
-    "range": { "startLine": 60, "endLine": 65 },
+    "range": { "startLine": 60, "endLine": 68 },
+    "type": "theorem",
     "title": "Legendre's Formula (Digit-Sum Form)",
-    "body": "The central theorem: (p-1) * ν_p(n!) = n - S_p(n), where S_p(n) is the sum of base-p digits. This is a direct re-export of Mathlib's `sub_one_mul_padicValNat_factorial`. The formula is 'lossless' — knowing n and S_p(n) determines ν_p(n!) exactly.",
-    "type": "theorem"
+    "content": "The central theorem: $(p-1) \\cdot \\nu_p(n!) = n - S_p(n)$, where $S_p(n)$ is the sum of base-$p$ digits. This is a direct re-export of Mathlib's `sub_one_mul_padicValNat_factorial`. The formula is 'lossless' — knowing $n$ and $S_p(n)$ determines $\\nu_p(n!)$ exactly. The proof is a single line: the Lean term `sub_one_mul_padicValNat_factorial n` provides everything.",
+    "mathContext": "$(p - 1) \\cdot \\nu_p(n!) = n - S_p(n)$ where $S_p(n) = \\sum_i d_i$ for $n = \\sum_i d_i p^i$. This arises from the telescoping identity $\\sum_{i \\geq 1} \\lfloor n/p^i \\rfloor = \\sum_k d_k \\cdot \\frac{p^k - 1}{p - 1} = \\frac{n - S_p(n)}{p - 1}$.",
+    "significance": "key",
+    "relatedConcepts": ["p-adic valuation", "digit sum", "Legendre's formula", "sub_one_mul_padicValNat_factorial"],
+    "prerequisites": ["p-adic valuations", "base-p digit representations", "factorials"]
   },
   {
     "id": "ann-legendre-sum",
     "proofId": "wilsons-theorem-oq-03",
-    "range": { "startLine": 67, "endLine": 74 },
+    "range": { "startLine": 70, "endLine": 76 },
+    "type": "theorem",
     "title": "Legendre's Formula (Finset Sum Form)",
-    "body": "The equivalent sum formula ν_p(n!) = Σ ⌊n/pⁱ⌋ over i = 1 to b-1, valid for any b > log_p(n). This is Mathlib's `padicValNat_factorial`. The sum is finite because ⌊n/pⁱ⌋ = 0 once pⁱ > n.",
-    "type": "theorem"
+    "content": "The equivalent sum formula $\\nu_p(n!) = \\sum_{i=1}^{b-1} \\lfloor n/p^i \\rfloor$, valid for any $b > \\log_p(n)$. This is Mathlib's `padicValNat_factorial`. The sum is finite because $\\lfloor n/p^i \\rfloor = 0$ once $p^i > n$. The bound parameter $b$ is computationally convenient: it lets the sum be a `Finset.Ico` rather than an infinite series.",
+    "mathContext": "$\\nu_p(n!) = \\sum_{i=1}^{\\infty} \\lfloor n/p^i \\rfloor = \\lfloor n/p \\rfloor + \\lfloor n/p^2 \\rfloor + \\cdots$. Each term $\\lfloor n/p^i \\rfloor$ counts multiples of $p^i$ in $\\{1, \\ldots, n\\}$, and each such multiple contributes one extra factor of $p$ to $n!$.",
+    "significance": "key",
+    "relatedConcepts": ["Finset.Ico", "padicValNat_factorial", "floor function", "geometric series"],
+    "prerequisites": ["summation over finite sets in Lean 4", "integer division"]
   },
   {
     "id": "ann-digits-pred",
     "proofId": "wilsons-theorem-oq-03",
-    "range": { "startLine": 79, "endLine": 87 },
+    "range": { "startLine": 80, "endLine": 91 },
+    "type": "technique",
     "title": "Key Lemma: p-1 is a One-Digit Number in Base p",
-    "body": "For prime p ≥ 2, we have 0 < p-1 < p, so p-1 is a single digit in base p: p.digits (p-1) = [p-1]. Proved via Nat.digits_def' and modular arithmetic: (p-1) % p = p-1 and (p-1) / p = 0. This lemma is the bridge to Wilson's theorem.",
-    "type": "lemma"
+    "content": "For prime $p \\geq 2$, we have $0 < p-1 < p$, so $p-1$ is a single digit in base $p$: `p.digits (p-1) = [p-1]`. Proved via `Nat.digits_def'` and modular arithmetic: $(p-1) \\bmod p = p-1$ and $(p-1) / p = 0$. The companion `digit_sum_pred_prime` immediately gives $S_p(p-1) = p-1$. This lemma is the bridge connecting Legendre's formula to Wilson's theorem.",
+    "mathContext": "In base $p$, any integer $d$ with $0 \\leq d < p$ has digit representation $[d]$. Since $p \\geq 2$ for any prime, $p - 1$ satisfies $0 < p - 1 < p$, giving $\\text{digits}_p(p-1) = [p-1]$ and $S_p(p-1) = p - 1$.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.digits_def'", "base-p representation", "modular arithmetic", "Nat.mod_eq_of_lt"],
+    "prerequisites": ["natural number digit representation in Lean 4", "Euclidean division"]
   },
   {
     "id": "ann-legendre-wilson",
     "proofId": "wilsons-theorem-oq-03",
-    "range": { "startLine": 100, "endLine": 115 },
-    "title": "Wilson's Theorem via Legendre: ν_p((p-1)!) = 0",
-    "body": "The key connection: substituting n = p-1 in Legendre's formula gives (p-1) * ν_p((p-1)!) = (p-1) - (p-1) = 0. Since p-1 ≥ 1, we get ν_p((p-1)!) = 0. This is an algebraic proof of Wilson's non-divisibility, bypassing the group-theoretic pairing argument.",
-    "type": "theorem"
+    "range": { "startLine": 95, "endLine": 116 },
+    "type": "insight",
+    "title": "Wilson's Theorem via Legendre: Algebraic Proof of p ∤ (p-1)!",
+    "content": "The key connection: substituting $n = p-1$ in Legendre's formula gives $(p-1) \\cdot \\nu_p((p-1)!) = (p-1) - (p-1) = 0$. Since $p-1 \\geq 1$, we get $\\nu_p((p-1)!) = 0$. This is an algebraic proof of Wilson's non-divisibility, bypassing the group-theoretic pairing argument entirely. The `legendre_wilson` theorem proves $\\nu_p((p-1)!) = 0$ in about 5 lines by rewriting with `digit_sum_pred_prime` and resolving the zero-product. The companion `prime_not_dvd_factorial_pred` gives the logically equivalent $p \\nmid (p-1)!$ directly from `dvd_factorial`.",
+    "mathContext": "Legendre at $n = p-1$: $(p-1) \\cdot \\nu_p((p-1)!) = (p-1) - S_p(p-1) = (p-1) - (p-1) = 0$. Since $p - 1 \\neq 0$ (as $p \\geq 2$), we conclude $\\nu_p((p-1)!) = 0$, i.e., $p \\nmid (p-1)!$. Wilson's full theorem states $(p-1)! \\equiv -1 \\pmod{p}$; this proves the non-divisibility half.",
+    "significance": "key",
+    "relatedConcepts": ["Wilson's theorem", "zero-product property", "Nat.mul_eq_zero", "group-theoretic Wilson proof"],
+    "prerequisites": ["Wilson's theorem statement", "p-adic valuation semantics", "zero-product in ℕ"]
   },
   {
     "id": "ann-padic-p-factorial",
     "proofId": "wilsons-theorem-oq-03",
-    "range": { "startLine": 123, "endLine": 140 },
-    "title": "ν_p(p!) = 1",
-    "body": "The factorial p! is divisible by p exactly once. Proof: p! = p * (p-1)!, and padicValNat is multiplicative, so ν_p(p!) = ν_p(p) + ν_p((p-1)!) = 1 + 0 = 1. The Nat.factorial_succ identity and Nat.sub_add_cancel handle the natural number arithmetic carefully.",
-    "type": "theorem"
+    "range": { "startLine": 118, "endLine": 137 },
+    "type": "technique",
+    "title": "ν_p(p!) = 1 via Multiplicativity",
+    "content": "The factorial $p!$ is divisible by $p$ exactly once. The proof factors $p! = p \\cdot (p-1)!$ using `Nat.factorial_succ`, then applies `padicValNat.mul` (multiplicativity for nonzero arguments) to get $\\nu_p(p!) = \\nu_p(p) + \\nu_p((p-1)!) = 1 + 0 = 1$. The value $\\nu_p(p) = 1$ comes from `padicValNat.prime_pow` instantiated at exponent 1. This approach is more transparent than directly applying Legendre's sum.",
+    "mathContext": "$p! = p \\cdot (p-1)!$ and $\\nu_p$ is completely multiplicative on coprime factors: $\\nu_p(ab) = \\nu_p(a) + \\nu_p(b)$ for $a, b \\neq 0$. Therefore $\\nu_p(p!) = \\nu_p(p) + \\nu_p((p-1)!) = 1 + 0 = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": ["padicValNat.mul", "padicValNat.prime_pow", "Nat.factorial_succ", "multiplicativity of valuations"],
+    "prerequisites": ["multiplicative properties of p-adic valuations", "factorial recursion"]
   },
   {
     "id": "ann-upper-bound",
     "proofId": "wilsons-theorem-oq-03",
-    "range": { "startLine": 149, "endLine": 160 },
+    "range": { "startLine": 138, "endLine": 155 },
+    "type": "technique",
     "title": "Upper Bound: ν_p(n!) ≤ n/(p-1)",
-    "body": "Since S_p(n) ≥ 0, Legendre's formula gives (p-1) * ν_p(n!) ≤ n, hence ν_p(n!) ≤ n/(p-1). The bound is tight for n = p^k: S_p(p^k) = 1, giving ν_p((p^k)!) = (p^k - 1)/(p-1). This uses Nat.le_div_iff_mul_le to convert the multiplication bound to a division bound.",
-    "type": "observation"
+    "content": "Since $S_p(n) \\geq 0$, Legendre's formula gives $(p-1) \\cdot \\nu_p(n!) \\leq n$, hence $\\nu_p(n!) \\leq n/(p-1)$. The bound is tight for $n = p^k$: $S_p(p^k) = 1$, giving $\\nu_p((p^k)!) = (p^k - 1)/(p-1)$. The proof uses `Nat.le_div_iff_mul_le` to convert the multiplication bound to a division bound, and `mul_comm` to match Lean's argument order.",
+    "mathContext": "From $(p-1) \\cdot \\nu_p(n!) = n - S_p(n) \\leq n$ (since $S_p(n) \\geq 0$), dividing both sides by $p - 1 > 0$ gives $\\nu_p(n!) \\leq \\lfloor n/(p-1) \\rfloor$. Asymptotically, $\\nu_p(n!) \\sim n/(p-1)$ as $n \\to \\infty$, since $S_p(n) = O(\\log n)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.le_div_iff_mul_le", "asymptotic analysis", "Stirling's approximation", "digit sum bounds"],
+    "prerequisites": ["natural number division in Lean 4", "inequalities"]
   },
   {
     "id": "ann-zero-iff",
     "proofId": "wilsons-theorem-oq-03",
-    "range": { "startLine": 162, "endLine": 183 },
+    "range": { "startLine": 157, "endLine": 185 },
+    "type": "theorem",
     "title": "Characterization: ν_p(n!) = 0 ↔ n < p",
-    "body": "The p-adic valuation of n! is zero iff none of {1,...,n} are divisible by p, iff n < p. Forward: if n ≥ p, then p ∣ n! (by dvd_factorial) so ν_p(n!) ≥ 1 (by padicValNat.le_of_dvd with k=1). Backward: if n < p then p ∤ n! (dvd_factorial again) so ν_p(n!) = 0 (eq_zero_of_not_dvd).",
-    "type": "theorem"
+    "content": "The $p$-adic valuation of $n!$ is zero iff none of $\\{1, \\ldots, n\\}$ are divisible by $p$, iff $n < p$. Forward direction: if $n \\geq p$, then $p \\mid n!$ (by `dvd_factorial`), so $\\nu_p(n!) \\geq 1$. This uses an explicit factorization $n! = p \\cdot k$ to deduce $\\nu_p(n!) \\geq \\nu_p(p) = 1$. Backward: if $n < p$ then $p \\nmid n!$, so $\\nu_p(n!) = 0$ by `eq_zero_of_not_dvd`. This characterization subsumes the Wilson connection as the special case $n = p - 1 < p$.",
+    "mathContext": "$\\nu_p(n!) = 0 \\iff n < p$. Equivalently, $p \\mid n! \\iff p \\leq n$ (since the smallest multiple of $p$ in $\\{1, \\ldots, n\\}$ is $p$ itself). This is `Nat.Prime.dvd_factorial` in Mathlib.",
+    "significance": "supporting",
+    "relatedConcepts": ["Nat.Prime.dvd_factorial", "padicValNat.eq_zero_of_not_dvd", "padicValNat.le_of_dvd", "contraposition"],
+    "prerequisites": ["prime divisibility of factorials", "by_contra in Lean 4"]
+  },
+  {
+    "id": "ann-concrete-computations",
+    "proofId": "wilsons-theorem-oq-03",
+    "range": { "startLine": 186, "endLine": 220 },
+    "type": "context",
+    "title": "Concrete Computations via native_decide",
+    "content": "Eight verified examples demonstrate the formula: $\\nu_2(10!) = 8$ (digit sum of $10 = 1010_2$ is 2, so $1 \\cdot 8 = 10 - 2$), $\\nu_3(9!) = 4$ ($9 = 100_3$, digit sum 1), $\\nu_5(25!) = 6$ ($25 = 100_5$, digit sum 1), and $\\nu_7(49!) = 8$ ($49 = 100_7$). Four Wilson checks confirm $\\nu_p((p-1)!) = 0$ for $p = 5, 7, 11, 13$. All proofs use `native_decide`, which compiles the computation to native code for efficiency — evaluating large factorials and their prime factorizations would be infeasible with kernel reduction alone.",
+    "mathContext": "Examples: $\\nu_2(10!) = (10 - 2)/1 = 8$; $\\nu_3(9!) = (9 - 1)/2 = 4$; $\\nu_5(25!) = (25 - 1)/4 = 6$; $\\nu_7(49!) = (49 - 1)/6 = 8$. Wilson checks: $\\nu_5(4!) = 0$, $\\nu_7(6!) = 0$, $\\nu_{11}(10!) = 0$, $\\nu_{13}(12!) = 0$.",
+    "significance": "context",
+    "relatedConcepts": ["native_decide", "kernel computation vs native code", "decidable propositions in Lean 4"],
+    "prerequisites": ["Lean 4 native_decide tactic", "base-p digit computation"]
   }
 ]

--- a/src/data/proofs/wilsons-theorem-oq-03/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-03/meta.json
@@ -23,7 +23,7 @@
     "axiomCount": 0,
     "assumptions": "None. All theorems are fully proved using Mathlib's sub_one_mul_padicValNat_factorial and supporting lemmas.",
     "dateAdded": "2026-04-05",
-    "lineCount": 185,
+    "lineCount": 222,
     "mathlibDependencies": [
       {
         "theorem": "sub_one_mul_padicValNat_factorial",
@@ -84,61 +84,62 @@
       "id": "header",
       "title": "Imports and Documentation",
       "startLine": 1,
-      "endLine": 55,
-      "description": "File header with mathematical background, Wilson connection, and Mathlib dependencies."
+      "endLine": 56,
+      "summary": "File header with mathematical background, the Wilson connection via digit sums, and a complete list of Mathlib dependencies. Documents the open question answered: 'What is the exact power of p dividing n!?'"
     },
     {
       "id": "legendre-main",
       "title": "Legendre's Formula — Main Theorems",
-      "startLine": 57,
-      "endLine": 80,
-      "description": "The two forms of Legendre's formula: digit-sum form and Finset sum form, both wrapping Mathlib theorems."
+      "startLine": 58,
+      "endLine": 76,
+      "summary": "The two forms of Legendre's formula: digit-sum form (p-1)·ν_p(n!) = n − S_p(n) and Finset sum form ν_p(n!) = Σ ⌊n/pⁱ⌋, both wrapping Mathlib theorems directly."
     },
     {
       "id": "digit-lemma",
       "title": "Digit Representation of (p-1)",
-      "startLine": 82,
-      "endLine": 95,
-      "description": "Proof that p.digits (p-1) = [p-1] for prime p: the number p-1 is a single digit in base p."
+      "startLine": 78,
+      "endLine": 91,
+      "summary": "Proves p.digits(p-1) = [p-1] for prime p via Nat.digits_def' and modular arithmetic. The companion digit_sum_pred_prime gives S_p(p-1) = p-1. This is the bridge to Wilson's theorem."
     },
     {
       "id": "wilson-connection",
       "title": "Wilson's Theorem via Legendre",
-      "startLine": 97,
-      "endLine": 120,
-      "description": "Key result: ν_p((p-1)!) = 0 proved algebraically via Legendre's formula. Also proves p ∤ (p-1)! directly."
+      "startLine": 93,
+      "endLine": 116,
+      "summary": "Key result: ν_p((p-1)!) = 0 proved algebraically by substituting n = p-1 into Legendre's formula. Also proves p ∤ (p-1)! via dvd_factorial as a standalone corollary."
     },
     {
       "id": "padic-p-factorial",
       "title": "ν_p(p!) = 1",
-      "startLine": 122,
-      "endLine": 145,
-      "description": "Proves the factorial p! is divisible by p exactly once, using p! = p·(p-1)! and multiplicativity."
+      "startLine": 118,
+      "endLine": 137,
+      "summary": "Proves p! is divisible by p exactly once using the factorization p! = p·(p-1)! and multiplicativity of padicValNat: ν_p(p) + ν_p((p-1)!) = 1 + 0 = 1."
     },
     {
       "id": "upper-bound",
       "title": "Upper Bound on ν_p(n!)",
-      "startLine": 147,
-      "endLine": 165,
-      "description": "Proves ν_p(n!) ≤ n/(p-1) from the digit-sum form of Legendre's formula."
+      "startLine": 138,
+      "endLine": 155,
+      "summary": "Proves ν_p(n!) ≤ n/(p-1) from the digit-sum form, since S_p(n) ≥ 0 implies (p-1)·ν_p(n!) ≤ n. Uses Nat.le_div_iff_mul_le for the division step."
     },
     {
       "id": "zero-characterization",
       "title": "Zero Characterization",
-      "startLine": 167,
+      "startLine": 157,
       "endLine": 185,
-      "description": "Proves ν_p(n!) = 0 ↔ n < p using dvd_factorial and padicValNat.le_of_dvd."
+      "summary": "Proves ν_p(n!) = 0 ↔ n < p via contraposition: n ≥ p implies p ∣ n! (by dvd_factorial), hence ν_p(n!) ≥ 1. Subsumes the Wilson connection as n = p-1 < p."
     },
     {
       "id": "examples",
       "title": "Concrete Computations",
-      "startLine": 187,
-      "endLine": 220,
-      "description": "Verified examples: ν₂(10!) = 8, ν₃(9!) = 4, ν₅(25!) = 6, ν₇(49!) = 8, and Wilson checks."
+      "startLine": 186,
+      "endLine": 222,
+      "summary": "Eight native_decide examples verifying the formula: ν₂(10!) = 8, ν₃(9!) = 4, ν₅(25!) = 6, ν₇(49!) = 8, plus Wilson checks for p = 5, 7, 11, 13."
     }
   ],
   "conclusion": {
     "summary": "Legendre's formula fully characterizes the p-adic valuation of factorials. The digit-sum form $(p-1)\\nu_p(n!) = n - S_p(n)$ gives an efficient recursive computation and yields Wilson's non-divisibility as a direct algebraic consequence.",
+    "implications": "This formalization demonstrates that Wilson's theorem can be proved purely through arithmetic counting (Legendre's formula) rather than group theory (pairing elements with their inverses mod $p$). The digit-sum approach generalizes: Kummer's theorem on $\\nu_p(\\binom{m+n}{m})$ as a carry count is an immediate corollary, and the upper bound $\\nu_p(n!) \\leq n/(p-1)$ gives explicit bounds on prime powers in factorial factorizations, relevant to algorithms for computing binomial coefficients mod $p^k$.",
     "openQuestions": [
       "Can Legendre's formula be generalized to multinomial coefficients $n!/(n_1! \\cdot n_2! \\cdots n_k!)$?",
       "Does Kummer's theorem (OQ: count carries when adding in base p) follow cleanly from Legendre in Lean?"
@@ -146,19 +147,24 @@
   },
   "crossReferences": [
     {
-      "proofId": "wilsons-theorem",
+      "targetId": "wilsons-theorem",
       "relationship": "parent",
-      "description": "Wilson's theorem (p-1)! ≡ -1 (mod p) — Legendre's formula proves the non-divisibility direction"
+      "description": "Wilson's theorem (p-1)! ≡ -1 (mod p) — Legendre's formula proves the non-divisibility direction algebraically"
     },
     {
-      "proofId": "wilsons-theorem-oq-01",
+      "targetId": "wilsons-theorem-oq-01",
       "relationship": "sibling",
       "description": "Wilson for non-prime moduli — shares the factorial arithmetic setting"
     },
     {
-      "proofId": "wilsons-theorem-oq-02",
+      "targetId": "wilsons-theorem-oq-02",
       "relationship": "sibling",
-      "description": "Gauss-Wilson theorem — product of units mod n"
+      "description": "Gauss-Wilson theorem — product of units mod n, a multiplicative generalization"
+    },
+    {
+      "targetId": "kummer-theorem-oq-01",
+      "relationship": "extends",
+      "description": "Kummer's theorem on ν_p(C(m+n,m)) = number of base-p carries follows directly from Legendre's digit-sum formula applied to (m+n)!/(m!·n!)"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Enrichment pass for 2 gallery proofs, improving annotation schema compliance, historical depth, and cross-references.

### bezout-identity-oq-03-oq-04-oq-01 (quality 93 → improved)
- Deepened historicalContext with Sun Zi (3rd c. CE), Qin Jiushao (1247), Euler, Gauss, Dedekind, Noether
- Added 5th keyInsight on Noether's philosophy realized in Lean's typeclass system
- Added 2 sections (preamble, summary) and 2 annotations for full file coverage (7 total)

### wilsons-theorem-oq-03 (quality 65 → improved)
- Upgraded all 7 annotations from old schema (body/type:theorem) to full schema with mathContext, significance, relatedConcepts, prerequisites
- Added 8th annotation covering concrete computations (native_decide examples)
- Fixed all section field names (description → summary) and corrected line ranges to match actual Lean source
- Added conclusion.implications connecting arithmetic vs group-theoretic Wilson proofs
- Fixed crossReferences field names (proofId → targetId), added Kummer theorem cross-ref
- Fixed lineCount: 185 → 222

🤖 Generated with [Claude Code](https://claude.com/claude-code)