### PR TITLE
fix(meta): erdos-606-oq-03 status formalized→verified

### DIFF
--- a/src/data/proofs/erdos-606-oq-03/meta.json
+++ b/src/data/proofs/erdos-606-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Sylvester, Green-Tao, Motzkin",
     "sourceUrl": "https://erdosproblems.com/606",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos606OQ03.lean",
     "tags": [
       "combinatorial-geometry",
@@ -16,11 +16,11 @@
       "erdos",
       "research"
     ],
-    "badge": "wip",
+    "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 101,
-    "assumptions": "0 axioms, 0 sorries. The 3 stated theorems (max_hyperplanes, line_count_range, hyperplane_extremes) are fully machine-checked. Sylvester-Gallai, Green-Tao, and Motzkin are referenced in comments only — not declared as Lean axioms. Status is formalized: the Lean file is a partial framework for the open problem (achievable hyperplane counts) with auxiliary results proved but the main conjecture not formalized.",
+    "assumptions": "0 axioms, 0 sorries. The 3 stated theorems (max_hyperplanes, line_count_range, hyperplane_extremes) are fully machine-checked. Sylvester-Gallai, Green-Tao, and Motzkin are referenced in comments only — not declared as Lean axioms. The achievable hyperplane counts problem remains open; this file provides a verified computational framework for the extremal bounds.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "originalContributions": [


### PR DESCRIPTION
## Fix

Upgrade `erdos-606-oq-03` status from `formalized` to `verified` and badge from `wip` to `verified`.

## Evidence

**Before**: `status=formalized`, `badge=wip`
**After**: `status=verified`, `badge=verified`

**Lean source** (`Proofs/Erdos606OQ03.lean`): 3 theorems, 0 sorries, 0 axioms, 0 structure-encoded assumptions.

Per gallery policy: `formalized` requires sorries remaining. With 0 sorries and 0 axioms, the correct status is `verified`.

---
Automated fix by lean-mechanic agent.