### PR TITLE
fix(meta): basel-problem-oq-01-oq-03 status formalized→verified

### DIFF
--- a/src/data/proofs/basel-problem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Ap%C3%A9ry%27s_theorem",
     "date": "2026-04-04",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/BaselProblemOQ01OQ03.lean",
     "tags": [
       "number-theory",
@@ -15,7 +15,7 @@
       "open-problem",
       "irrationality"
     ],
-    "badge": "formalized",
+    "badge": "verified",
     "sorries": 0,
     "assumptions": "0 sorries, 0 axioms. All theorems are fully proved. The main results — apery_criterion, geometric_decay_tendsto, and all conditional theorems — contain no mathematical assumptions beyond the hypotheses stated.",
     "dateAdded": "2026-04-04",


### PR DESCRIPTION
## Fix

Upgrade `basel-problem-oq-01-oq-03` status from `formalized` to `verified` and badge from `formalized` to `verified`.

## Evidence

**Before**: `status=formalized`, `badge=formalized`
**After**: `status=verified`, `badge=verified`

**Lean source** (`Proofs/BaselProblemOQ01OQ03.lean`): machine-checked theorems including `apery_criterion`, `geometric_decay_tendsto`, and conditional irrationality results. 0 sorries, 0 axioms, 0 structure-encoded assumptions.

Per gallery policy: `formalized` requires sorries remaining. With 0 sorries and 0 axioms, the correct status is `verified`. The open problem (constructing Apéry-type sequences for ζ(5)) is documented in a `def` (Prop declaration), not asserted as a theorem — so it does not affect the verified status.

---
Automated fix by lean-mechanic agent.