### PR TITLE
Enrich Power Mean Crossing Zero: deepen history, fix line ranges, add cross-refs

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01/annotations.json
@@ -38,7 +38,7 @@
   {
     "id": "ann-pmcz-gm-le-pos",
     "proofId": "amgm-inequality-oq-03-oq-02-oq-01",
-    "range": { "startLine": 107, "endLine": 131 },
+    "range": { "startLine": 109, "endLine": 133 },
     "type": "technique",
     "title": "geom_mean_le_power_mean_pos: Raising to a Positive Power",
     "content": "For r > 0, the core inequality GM^r ≤ ∑ wᵢzᵢ^r becomes GM ≤ M_r after raising both sides to the power 1/r > 0. The key step: GM = (GM^r)^(1/r) (using Real.rpow_natCast and the inverse relationship), and (∑)^(1/r) = M_r by definition. This extends the r ≥ 1 case from AmgmInequalityOQ03 to all r > 0, including the important range 0 < r < 1.",
@@ -50,7 +50,7 @@
   {
     "id": "ann-pmcz-neg-le-gm",
     "proofId": "amgm-inequality-oq-03-oq-02-oq-01",
-    "range": { "startLine": 133, "endLine": 194 },
+    "range": { "startLine": 135, "endLine": 188 },
     "type": "insight",
     "title": "power_mean_le_geom_mean_neg: Inversion Reverses the Inequality",
     "content": "For r < 0, the core inequality GM^r ≤ ∑ wᵢzᵢ^r gives M_r ≤ GM by raising to the NEGATIVE power 1/r < 0 (which reverses ≤). The algebraic argument: since 1/r < 0, write 1/r = -(1/(-r)) where 1/(-r) > 0. Raising GM^r ≤ ∑ to the power -(1/(-r)) reverses: (GM^r)^(-(1/(-r))) ≥ (∑)^(-(1/(-r))). Inversion (A ≤ B and both positive → B⁻¹ ≤ A⁻¹) then gives M_r = (∑)^(1/r) ≤ (GM^r)^(1/r) = GM. This is the longest proof section (62 lines) due to the careful positivity bookkeeping in Lean.",
@@ -62,7 +62,7 @@
   {
     "id": "ann-pmcz-main-chain",
     "proofId": "amgm-inequality-oq-03-oq-02-oq-01",
-    "range": { "startLine": 196, "endLine": 225 },
+    "range": { "startLine": 190, "endLine": 225 },
     "type": "insight",
     "title": "Main Theorem and HM ≤ GM ≤ AM: Completing the Chain",
     "content": "power_mean_monotone_crossing_zero is a 3-line proof: M_r ≤ GM (from §4) and GM ≤ M_s (from §3), combined by le_trans. hm_le_gm_le_am_via_power_means is an immediate corollary at r=-1, s=1: it gives the classical HM ≤ GM ≤ AM chain as a special case. These two theorems, combined with power_mean_monotone_pos and power_mean_monotone_neg from AmgmInequalityOQ03, complete the full power mean monotonicity theorem: M_r ≤ M_s for all r ≤ s (r,s ≠ 0), which is then unified in PowerMeanMonotoneOQ.",

--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01/meta.json
@@ -53,14 +53,15 @@
     ]
   },
   "overview": {
-    "historicalContext": "The power mean inequality — that M_r(z,w) is monotone increasing in r — is a classical result in analysis, appearing in Hardy–Littlewood–Pólya (1934). The limiting case M_0 = GM requires L'Hôpital (proved in OQ-02). The monotonicity proof splits into three regions: r > 0 (via Jensen), r < 0 (via duality with inverse values), and the crossing-zero case r < 0 < s. This file closes the crossing-zero gap using a direct AM-GM argument.",
+    "historicalContext": "The power mean inequality — that $M_r(z,w)$ is monotone increasing in $r$ — traces to Cauchy's 1821 proof of the AM-GM case ($r = 1$ vs $r = 0$) in the *Cours d'analyse*. The full generalization to arbitrary exponents $r$ was established by Schur (1923) and popularized in Hardy, Littlewood, and Pólya's *Inequalities* (1934, Theorem 16). The classical proof uses Jensen's inequality for the convex function $x \\mapsto x^{s/r}$ when $r$ and $s$ have the same sign, but this approach breaks down when $r < 0 < s$ because the function changes convexity across zero. The limiting case $M_0 = \\text{GM}$ requires L'Hôpital's rule (proved in OQ-02). This file closes the crossing-zero gap using a direct AM-GM argument that avoids convexity entirely, instead reducing to the single universal inequality $\\text{GM}^r \\le \\sum w_i z_i^r$.",
     "problemStatement": "**Open Question (OQ-03-OQ-02-OQ-01):** Prove that M_r ≤ M_s whenever r < 0 < s, where M_r(z,w) = (∑ wᵢ zᵢ^r)^(1/r) is the weighted power mean of order r.\n\nThis is the crossing-zero case of the full power mean monotonicity theorem.",
     "proofStrategy": "**Core inequality** (§2): For any r ∈ ℝ, GM(z,w)^r ≤ ∑ wᵢ zᵢ^r. Proof: Apply AM-GM (Real.geom_mean_le_arith_mean_weighted) to the values zᵢ^r with weights wᵢ. The LHS equals GM^r via the algebraic identity (∏ zᵢ^wᵢ)^r = ∏ (zᵢ^r)^wᵢ.\n\n**GM ≤ M_s for s > 0** (§3): From GM^s ≤ ∑ wᵢ zᵢ^s (the core inequality), raise both sides to 1/s > 0: GM = (GM^s)^(1/s) ≤ (∑ wᵢ zᵢ^s)^(1/s) = M_s.\n\n**M_r ≤ GM for r < 0** (§4): From GM^r ≤ ∑ wᵢ zᵢ^r, write M_r = (∑)^(1/r) = ((∑)^(-(1/r)))⁻¹. Since -(1/r) > 0, raise GM^r ≤ ∑ to the positive power -(1/r): (GM^r)^(-(1/r)) ≤ (∑)^(-(1/r)). Invert (reverses inequality): ((∑)^(-(1/r)))⁻¹ ≤ ((GM^r)^(-(1/r)))⁻¹ = GM.\n\n**Crossing-zero** (§5): M_r ≤ GM ≤ M_s by transitivity.",
     "keyInsights": [
       "The core inequality GM^r ≤ ∑ wᵢ zᵢ^r is a single AM-GM application that handles ALL values of r simultaneously — positive, negative, and zero.",
       "The crossing-zero case reduces to inverting a monotone inequality: A ≤ B → B⁻¹ ≤ A⁻¹ (for positive A, B). This is proved algebraically without invoking inv_le_inv_of_le directly.",
       "The algebraic identity (∏ zᵢ^wᵢ)^r = ∏ (zᵢ^r)^wᵢ (proved by Finset induction via mul_rpow) is the key structural bridge connecting GM^r to the AM-GM form.",
-      "Combined with power_mean_monotone_pos and power_mean_monotone_neg from AmgmInequalityOQ03, this completes the full monotonicity theorem: M_r ≤ M_s for all r ≤ s (excluding 0)."
+      "Combined with power_mean_monotone_pos and power_mean_monotone_neg from AmgmInequalityOQ03, this completes the full monotonicity theorem: M_r ≤ M_s for all r ≤ s (excluding 0).",
+      "The HM ≤ GM ≤ AM corollary (r=-1, s=1) demonstrates that the classical harmonic-geometric-arithmetic mean chain is a single special case of the crossing-zero theorem — unifying three inequalities that are traditionally proved separately into one instantiation of power_mean_monotone_crossing_zero."
     ],
     "prerequisites": [
       "AmgmInequalityOQ03 (Proofs/AmgmInequalityOQ03.lean): weightedPowerMean, weightedGeomMean definitions and same-sign monotonicity",
@@ -77,48 +78,48 @@
     {
       "id": "helpers",
       "title": "§1: Helper Lemmas",
-      "startLine": 43,
-      "endLine": 84,
+      "startLine": 39,
+      "endLine": 86,
       "summary": "Three private lemmas: weightedSum_rpow_pos (∑ wᵢ zᵢ^r > 0), weightedGeomMean_pos (GM > 0), finset_prod_rpow ((∏ fᵢ)^r = ∏ fᵢ^r), prod_rpow_comm ((∏ zᵢ^wᵢ)^r = ∏ (zᵢ^r)^wᵢ).",
       "mathContext": "The prod_rpow_comm identity uses finset_prod_rpow (induction on Finset using Real.mul_rpow) and Real.rpow_mul to show (∏ zᵢ^wᵢ)^r = ∏ (zᵢ^(r·wᵢ)) = ∏ (zᵢ^r)^wᵢ."
     },
     {
       "id": "core-ineq",
       "title": "§2: Core Inequality GM^r ≤ ∑ wᵢ zᵢ^r",
-      "startLine": 86,
-      "endLine": 105,
+      "startLine": 88,
+      "endLine": 107,
       "summary": "geomMean_rpow_le_weightedSum_rpow: for any r, (∏ zᵢ^wᵢ)^r ≤ ∑ wᵢ zᵢ^r. Proved by AM-GM applied to zᵢ^r values.",
       "mathContext": "Real.geom_mean_le_arith_mean_weighted gives ∏ (zᵢ^r)^wᵢ ≤ ∑ wᵢ zᵢ^r. The LHS equals GM^r via prod_rpow_comm."
     },
     {
       "id": "gm-le-pos",
       "title": "§3: GM ≤ M_r for r > 0",
-      "startLine": 107,
-      "endLine": 131,
+      "startLine": 109,
+      "endLine": 133,
       "summary": "geom_mean_le_power_mean_pos: for r > 0, GM ≤ M_r. Extends the r ≥ 1 case from OQ03 to all r > 0.",
       "mathContext": "From GM^r ≤ ∑ wᵢ zᵢ^r: raise to 1/r > 0: GM = (GM^r)^(1/r) ≤ (∑ wᵢ zᵢ^r)^(1/r) = M_r."
     },
     {
       "id": "neg-le-gm",
       "title": "§4: M_r ≤ GM for r < 0",
-      "startLine": 133,
-      "endLine": 194,
+      "startLine": 135,
+      "endLine": 188,
       "summary": "power_mean_le_geom_mean_neg: for r < 0, M_r ≤ GM. Proved via inversion: ((∑)^(-(1/r)))⁻¹ ≤ ((GM^r)^(-(1/r)))⁻¹.",
       "mathContext": "Since -(1/r) > 0 for r < 0 and GM^r ≤ ∑, we get (GM^r)^(-(1/r)) ≤ (∑)^(-(1/r)). Inversion (A ≤ B → B⁻¹ ≤ A⁻¹, proved algebraically) gives M_r ≤ GM."
     },
     {
       "id": "crossing-zero",
       "title": "§5: Main Theorem — Crossing-Zero Monotonicity",
-      "startLine": 196,
-      "endLine": 210,
+      "startLine": 190,
+      "endLine": 211,
       "summary": "power_mean_monotone_crossing_zero: M_r ≤ M_s for r < 0 < s. Direct combination of §3 and §4.",
       "mathContext": "M_r ≤ GM (§4) and GM ≤ M_s (§3), so M_r ≤ M_s by transitivity (le_trans)."
     },
     {
       "id": "hm-gm-am",
       "title": "§6: HM ≤ GM ≤ AM as Special Case",
-      "startLine": 212,
-      "endLine": 222,
+      "startLine": 213,
+      "endLine": 225,
       "summary": "hm_le_gm_le_am_via_power_means: M_{-1} ≤ GM ≤ M_1, i.e., HM ≤ GM ≤ AM. Special case r=-1, s=1.",
       "mathContext": "Direct application of §4 (r=-1) and §3 (s=1). The HM-GM-AM chain is a classical consequence."
     }
@@ -138,6 +139,21 @@
       "targetId": "amgm-inequality-oq-03-oq-02",
       "relationship": "sibling",
       "description": "Sibling: M_r → GM as r → 0 (the limiting case r=0). Together they complete the full power mean story."
+    },
+    {
+      "targetId": "amgm-inequality-oq-03-oq-01",
+      "relationship": "sibling",
+      "description": "Sibling: negative monotonicity M_r ≤ M_s for r ≤ s < 0 (same-sign case). This entry supplies the crossing-zero bridge between the negative and positive regimes."
+    },
+    {
+      "targetId": "amgm-inequality-oq-03-oq-03",
+      "relationship": "related",
+      "description": "Related: extreme cases M_r → max/min as r → ±∞, extending the power mean chain to its full range."
+    },
+    {
+      "targetId": "amgm-inequality",
+      "relationship": "ancestor",
+      "description": "Ancestor: the base AM-GM inequality. The HM ≤ GM ≤ AM corollary in §6 is a direct generalization of the classical AM-GM."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for amgm-inequality-oq-03-oq-02-oq-01.

## Changes
- **historicalContext**: Deepened with Cauchy (1821 Cours d'analyse), Schur (1923), Hardy-Littlewood-Pólya (1934 Theorem 16), and explanation of why Jensen's approach fails at the crossing-zero boundary
- **keyInsights**: Added 5th insight on HM ≤ GM ≤ AM as a single instantiation of crossing-zero monotonicity
- **Section line ranges**: Fixed all 6 sections to match actual Lean file (were off by 2-6 lines)
- **Annotation line ranges**: Fixed 3 annotations — eliminated overlap at line 107 between §2 and §3, corrected §4 and §5 boundaries
- **Cross-references**: Added links to amgm-inequality-oq-03-oq-01 (negative monotonicity sibling), amgm-inequality-oq-03-oq-03 (extreme cases), and amgm-inequality (base AM-GM ancestor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)