### PR TITLE
fix(registry): rename id→slug for cayley-hamilton-minpoly-oq-02-oq-02-oq-01

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -14769,7 +14769,7 @@
       "lastUpdate": "2026-04-05T19:47:48.667Z"
     },
     {
-      "id": "cayley-hamilton-minpoly-oq-02-oq-02-oq-01",
+      "slug": "cayley-hamilton-minpoly-oq-02-oq-02-oq-01",
       "title": "Rational Canonical Form Determines Similarity Class",
       "status": "active",
       "tier": "A",


### PR DESCRIPTION
Seeker created a registry entry with `id` field instead of `slug`, causing `sync-data.ts` to crash with `ERR_INVALID_ARG_TYPE` in `path.join(PROBLEMS_DIR, undefined, 'meta.json')`.

**Root cause**: Seeker agent used `id` as the field name; registry entries use `slug`.

**Fix**: Rename `id` → `slug` for the affected entry.