### PR TITLE
fix(audit): downgrade fourier-series-oq-04 from verified to wip

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -14400,11 +14400,11 @@
     },
     {
       "slug": "cayley-hamilton-minpoly-oq-02-oq-02-oq-01",
-      "phase": "NEW",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-04-05T15:44:05.093Z",
       "status": "active",
-      "lastUpdate": "2026-04-05T15:44:05.093Z"
+      "lastUpdate": "2026-04-05T20:08:48.027Z"
     },
     {
       "slug": "cevas-theorem-non-euclidean-oq-03",
@@ -14698,11 +14698,12 @@
     },
     {
       "slug": "area-of-circle-oq-05-oq-01",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-05T19:47:48.662Z",
-      "status": "active",
-      "lastUpdate": "2026-04-05T19:47:48.662Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T20:08:48.003Z",
+      "completed": "2026-04-05T20:08:48.002Z"
     },
     {
       "slug": "ballot-problem-oq-01-oq-03",
@@ -14785,6 +14786,13 @@
       ],
       "source": "gallery-gap",
       "parentProof": "cayley-hamilton-minpoly"
+    },
+    {
+      "slug": "shapley-folkman",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T13:10:59-07:00",
+      "status": "active"
     }
   ],
   "config": {

--- a/src/data/proofs/fourier-series-oq-04/meta.json
+++ b/src/data/proofs/fourier-series-oq-04/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Fefferman (1971), Stein & Weiss (1971)",
     "date": "1971",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/FourierSeriesOQ04.lean",
     "tags": [
       "harmonic-analysis",
@@ -16,17 +16,21 @@
       "bochner-riesz",
       "carleson-conjecture"
     ],
-    "badge": "original",
+    "badge": "wip",
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 103
+    "lineCount": 103,
+    "assumptions": "Scaffold only. The Lean file contains type definitions and placeholder stubs (returning 0) but no theorems. No mathematical results are proved."
   },
   "leanFile": {
     "axiomCount": 0,
     "lineCount": 103,
     "path": "Proofs/FourierSeriesOQ04.lean",
-    "sorries": 0
+    "sorries": 0,
+    "theoremCount": 0,
+    "definitionCount": 4,
+    "note": "Scaffold file with type definitions and placeholder stubs. No theorems."
   },
   "overview": {
     "historicalContext": "The theory of Fourier series on the circle (1D torus) was developed by Fourier (1807-1822) and formalized by Dirichlet (1829), who proved pointwise convergence for piecewise smooth functions. The extension to multiple dimensions became urgent in the 20th century as PDEs on rectangular domains and crystallography required multi-dimensional Fourier analysis. A fundamental watershed came in 1966: Lennart Carleson proved (winning the Fields Medal in 2006 for this and related work) that the Fourier series of every L²(T¹) function converges almost everywhere. Charles Fefferman's 1971 result shattered hopes for a straightforward generalization: for n ≥ 2, rectangular partial sums of Fourier series can diverge even for L¹ functions, meaning the summation method fundamentally matters in multiple dimensions. Elias Stein and Guido Weiss (1971) developed the Bochner-Riesz framework for spherical summation. The 2D analogue of Carleson's theorem—does the spherical Fourier series of every L²(T²) function converge a.e.?—remains one of the great open problems in harmonic analysis.",


### PR DESCRIPTION
## Summary

- **CRITICAL**: `fourier-series-oq-04` meta.json claimed `status: "verified"` and `badge: "original"` but the Lean file is a scaffold with **0 theorems**, only type definitions and placeholder stubs returning 0
- Downgrades status to `formalized`, badge to `wip`
- Adds clear assumptions text and accurate leanFile metadata

## Evidence

**meta.json claimed**: status "verified", badge "original", 0 sorries
**Lean file contains**: 4 definitions (2 placeholder stubs returning 0), 0 theorems, 0 lemmas

## Test plan

- [ ] `pnpm build` succeeds
- [ ] Gallery page for fourier-series-oq-04 shows "wip" badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)