### PR TITLE
Enrich Infinite Paths: fill annotation gaps, add cross-refs

### DIFF
--- a/src/data/proofs/konigsberg-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/konigsberg-oq-03-oq-02/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-konigsb-oq03-oq02-header",
+    "proofId": "konigsberg-oq-03-oq-02",
+    "range": { "startLine": 1, "endLine": 35 },
+    "type": "context",
+    "title": "Module Header: Infinite Paths Formalization for Erdős-Grünwald-Weiszfeld",
+    "content": "Imports Stream' definitions from Mathlib (used only for the `ofStream` equivalence proof) and opens the `KonigsbergOQ03OQ02` namespace. The module docstring frames the open question: how to formalize 'infinite path' in Lean 4 for the Erdős-Grünwald-Weiszfeld theorem. The answer: ℕ-indexed functions, avoiding coinductive complexity. The file is self-contained — it re-defines InfiniteGraph rather than importing from KonigsbergOQ03 to avoid transitive compilation issues. This architectural decision prioritizes build reliability over code reuse.",
+    "mathContext": "The Erdős-Grünwald-Weiszfeld theorem (1936) characterizes one-way infinite Euler paths in countable graphs. Its formalization requires a precise definition of 'infinite walk' — a sequence $(v_0, v_1, v_2, \\ldots)$ with $v_n \\sim v_{n+1}$ for all $n$.",
+    "significance": "context",
+    "relatedConcepts": ["Erdős-Grünwald-Weiszfeld theorem", "module architecture", "self-contained definitions"],
+    "prerequisites": ["Mathlib.Data.Stream.Defs", "graph theory basics"]
+  },
+  {
     "id": "ann-infinite-graph",
     "proofId": "konigsberg-oq-03-oq-02",
     "range": { "startLine": 36, "endLine": 43 },
@@ -82,5 +94,17 @@
     "significance": "key",
     "relatedConcepts": ["Stream' in Mathlib", "coinduction vs. ordinary induction", "definitional equality in Lean 4", "codata"],
     "prerequisites": ["Lean 4 coinductive types", "Stream' definition", "definitional equality"]
+  },
+  {
+    "id": "ann-konigsb-oq03-oq02-summary",
+    "proofId": "konigsberg-oq-03-oq-02",
+    "range": { "startLine": 150, "endLine": 184 },
+    "type": "context",
+    "title": "Summary and API Surface",
+    "content": "The summary comment (lines 153-176) recaps the design decisions: ℕ → V over codata, split Euler condition, and Prop-level encodings avoiding decidability. The `#check` commands (lines 178-182) document the public API: InfiniteWalk, IsEulerWalk, HasOneWayInfiniteEulerPath, BiInfiniteWalk, and step_ne. These are the entry points for downstream formalizations, particularly the Erdős-Grünwald-Weiszfeld theorem. The summary serves as inline documentation — readers can understand the module's contribution without reading the implementation.",
+    "mathContext": "The module exports 5 key definitions: $\\text{InfiniteWalk}(G)$ ($\\mathbb{N}$-indexed walk), $\\text{IsEulerWalk}(G, w)$ (covers all edges, edge-injective), $\\text{HasOneWayInfiniteEulerPath}(G)$ (existential wrapper), $\\text{BiInfiniteWalk}(G)$ ($\\mathbb{Z}$-indexed walk), and $\\text{step\\_ne}$ (adjacent vertices are distinct).",
+    "significance": "context",
+    "relatedConcepts": ["API design in Lean 4", "inline documentation", "module interface"],
+    "prerequisites": ["all prior definitions in this module"]
   }
 ]

--- a/src/data/proofs/konigsberg-oq-03-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-03-oq-02/meta.json
@@ -48,7 +48,8 @@
       "The key design choice: ℕ → V (functions) vs. Stream' V (codata). The ℕ-indexed approach works with standard induction and avoids the coinductive eliminator. Both are definitionally equivalent since Stream' V = ℕ → V in Lean 4's type theory.",
       "The 'exactly once' encoding: split into (a) CoversEdge = at least once, (b) IsEdgeInjective = at most once. This decomposition avoids the ∃! n quantifier which requires decidability in some contexts. Both halves of the conjunction are classical Prop.",
       "SameEdge handles undirected edges: step m and step n traverse the same edge if (vertex m = vertex n ∧ vertex (m+1) = vertex (n+1)) OR (vertex m = vertex (n+1) ∧ vertex (m+1) = vertex n). No Sym2 needed.",
-      "BiInfiniteWalk uses ℤ → V for Erdős-Grünwald-Weiszfeld: some formulations require a bi-infinite path starting at -∞. The structure mirrors InfiniteWalk but with ℤ indexing and Int.add for the step condition."
+      "BiInfiniteWalk uses ℤ → V for Erdős-Grünwald-Weiszfeld: some formulations require a bi-infinite path starting at -∞. The structure mirrors InfiniteWalk but with ℤ indexing and Int.add for the step condition.",
+      "The self-containment decision (re-defining InfiniteGraph instead of importing from KonigsbergOQ03) is a pragmatic formalization choice: it sacrifices DRY in exchange for build independence. In a large Lean 4 project with many inter-dependent proof files, isolating definitions prevents compilation cascades where one broken file blocks all downstream work."
     ]
   },
   "sections": [
@@ -86,6 +87,13 @@
       "startLine": 127,
       "endLine": 155,
       "summary": "step_is_adj, step_ne (endpoints distinct), covers/injective projections, ofStream (Stream' equivalence)."
+    },
+    {
+      "id": "sec-summary",
+      "title": "Part 5: Summary and API Surface",
+      "startLine": 150,
+      "endLine": 184,
+      "summary": "Module summary comment recapping design choices. #check commands documenting the public API: InfiniteWalk, IsEulerWalk, HasOneWayInfiniteEulerPath, BiInfiniteWalk, step_ne."
     }
   ],
   "conclusion": {
@@ -107,6 +115,16 @@
       "targetId": "konigsberg",
       "relationship": "grandparent",
       "description": "Root Königsberg bridges entry: finite Eulerian circuit conditions. This entry generalizes to infinite graphs."
+    },
+    {
+      "targetId": "konigsberg-oq-01",
+      "relationship": "related",
+      "description": "Eulerian circuits in concrete finite graph families — the finite counterpart to infinite Euler paths"
+    },
+    {
+      "targetId": "konigsberg-oq-02",
+      "relationship": "related",
+      "description": "Directed Euler paths via in-degree/out-degree — analogous characterization in the directed setting"
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass for konigsberg-oq-03-oq-02.

**Quality improvements:**
- Added 2 new annotations covering previously uncovered sections (header lines 1-35, summary lines 150-184)
- Added Part 5 section entry for summary/API documentation
- Added 5th keyInsight about self-containment as pragmatic formalization architecture choice
- Added cross-references to konigsberg-oq-01 (finite Euler circuits) and konigsberg-oq-02 (directed Euler paths)

All 9 annotations now have mathContext, significance, relatedConcepts, prerequisites. Full line coverage of the 184-line Lean file.