### PR TITLE
Enrich Vandermonde Falling Factorial: add cross-refs, deepen history

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03/meta.json
@@ -53,7 +53,7 @@
     ]
   },
   "overview": {
-    "historicalContext": "Alexandre-Théophile Vandermonde presented his convolution identity $\\binom{m+n}{r} = \\sum_j \\binom{m}{j}\\binom{n}{r-j}$ in his 1772 paper 'Mémoire sur des irrationnelles de différents ordres avec une application au cercle' — though the result was anticipated by Chu Shih-Chieh in 1303 (the Chu-Vandermonde identity). Vandermonde's work focused on combinatorial manipulation of determinants, and his identity can be seen as a coefficient extraction from the identity $(1+x)^m(1+x)^n = (1+x)^{m+n}$ — matching coefficients of $x^r$ gives the convolution.\n\nThe falling factorial form $n^{\\underline{r}} = \\sum_j \\binom{r}{j} m^{\\underline{j}} n^{\\underline{r-j}}$ is natural in the umbral calculus and in the theory of finite differences, where falling factorials play the role that monomials play in ordinary calculus — they are the 'eigenfunctions' of the forward difference operator $\\Delta$. This form also connects to the formula for iterated differentiation: $(d/dx)^r x^n = n^{\\underline{r}} x^{n-r}$, showing how falling factorials encode derivative counts.\n\nIn computer science, this identity appears in the analysis of random binary search trees and in the computation of moments of hypergeometric distributions. The Lean 4 formalization takes the algebraic route: derive the falling factorial form from the standard binomial form by the conversion $n^{\\underline{k}} = k! \\binom{n}{k}$.",
+    "historicalContext": "Alexandre-Théophile Vandermonde presented his convolution identity $\\binom{m+n}{r} = \\sum_j \\binom{m}{j}\\binom{n}{r-j}$ in his 1772 paper 'Mémoire sur des irrationnelles de différents ordres avec une application au cercle' — though the result was anticipated by Chu Shih-Chieh in 1303 (the Chu-Vandermonde identity). Vandermonde's work focused on combinatorial manipulation of determinants, and his identity can be seen as a coefficient extraction from the identity $(1+x)^m(1+x)^n = (1+x)^{m+n}$ — matching coefficients of $x^r$ gives the convolution.\n\nThe falling factorial form $n^{\\underline{r}} = \\sum_j \\binom{r}{j} m^{\\underline{j}} n^{\\underline{r-j}}$ is natural in the umbral calculus and in the theory of finite differences, where falling factorials play the role that monomials play in ordinary calculus — they are the 'eigenfunctions' of the forward difference operator $\\Delta$. This form also connects to the formula for iterated differentiation: $(d/dx)^r x^n = n^{\\underline{r}} x^{n-r}$, showing how falling factorials encode derivative counts.\n\nIn computer science, this identity appears in the analysis of random binary search trees and in the computation of moments of hypergeometric distributions. Graham, Knuth, and Patashnik's *Concrete Mathematics* (1994) features the falling factorial Vandermonde as Table 174 and emphasizes its role as the 'natural' form of the identity. The Lean 4 formalization takes the algebraic route: derive the falling factorial form from the standard binomial form by the conversion $n^{\\underline{k}} = k! \\binom{n}{k}$.",
     "problemStatement": "Prove Vandermonde's identity in falling factorial form: $(m+n)^{\\underline{r}} = \\sum_{j=0}^{r} \\binom{r}{j} \\cdot m^{\\underline{j}} \\cdot n^{\\underline{r-j}}$, where $n^{\\underline{k}} = n(n-1)\\cdots(n-k+1)$ is the falling factorial. This generalizes the standard Vandermonde convolution $\\binom{m+n}{r} = \\sum_j \\binom{m}{j}\\binom{n}{r-j}$ by multiplying both sides by $r!$.",
     "text": "The falling (descending) factorial is descFactorial(n,k) = n*(n-1)*...*(n-k+1). It satisfies descFactorial(n,k) = k! * C(n,k) (Mathlib: Nat.descFactorial_eq_factorial_mul_choose). The proof converts the identity to the standard binomial form by substituting descFactorial = k!*C(n,k), applies vandermonde_range from BinomialTheoremOQ03, then verifies term equality using C(r,j)*j!*(r-j)! = r! from Nat.choose_mul_factorial_mul_factorial.",
     "proofStrategy": "Convert descFactorials via simp_rw [Nat.descFactorial_eq_factorial_mul_choose], apply BinomialTheoremOQ03.vandermonde_range to rewrite C(m+n,r) as a sum, use Finset.mul_sum to distribute r!, then verify each term by ring + Nat.choose_mul_factorial_mul_factorial.",
@@ -110,6 +110,16 @@
       "targetId": "arithmetic-series-oq-02-oq-01-oq-01",
       "relationship": "related",
       "description": "q-Vandermonde identity — q-deformation of this result"
+    },
+    {
+      "targetId": "binomial-theorem-oq-04",
+      "relationship": "related",
+      "description": "Standard Vandermonde identity C(m+n,r) = Σ C(m,k)·C(n,r-k) — the binomial form from which the falling factorial version derives"
+    },
+    {
+      "targetId": "combinations-formula",
+      "relationship": "related",
+      "description": "Formula for C(n,k) — foundational identity underlying the descFactorial-choose conversion"
     }
   ],
   "sections": [


### PR DESCRIPTION
Enrichment pass for arithmetic-series-oq-02-oq-04-oq-01-oq-03.

**Quality improvements:**
- Added cross-references to binomial-theorem-oq-04 (standard Vandermonde) and combinations-formula (C(n,k) foundation)
- Added Graham-Knuth-Patashnik *Concrete Mathematics* reference to historicalContext