### PR TITLE
Enrich Bessel Inequality: add cross-ref to fourier-series

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-01-oq-04/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-01-oq-04/meta.json
@@ -79,6 +79,11 @@
   },
   "crossReferences": [
     {
+      "targetId": "fourier-series",
+      "relationship": "related",
+      "description": "Fourier series formalization — Bessel's inequality and Parseval's identity are the core convergence results for Fourier analysis"
+    },
+    {
       "targetId": "cauchy-schwarz-oq-01",
       "relationship": "extends",
       "description": "Generalizes Cauchy-Schwarz to orthonormal systems via Bessel's inequality"


### PR DESCRIPTION
Enrichment pass for cauchy-schwarz-oq-01-oq-04.

**Quality improvements:**
- Added cross-reference to fourier-series entry (Bessel and Parseval are core convergence results for Fourier analysis)