### PR TITLE
Seeker: select burnside-counting-oq-03-oq-03 — interface Burnside's Lemma with Mathlib MulAction

### DIFF
--- a/research/problems/burnside-counting-oq-03-oq-03/knowledge.md
+++ b/research/problems/burnside-counting-oq-03-oq-03/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: burnside-counting-oq-03-oq-03
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/burnside-counting-oq-03-oq-03/literature/README.md
+++ b/research/problems/burnside-counting-oq-03-oq-03/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for burnside-counting-oq-03-oq-03
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/burnside-counting-oq-03-oq-03/problem.md
+++ b/research/problems/burnside-counting-oq-03-oq-03/problem.md
@@ -1,0 +1,142 @@
+# Problem: Interface Burnside's Lemma with Mathlib MulAction Framework
+
+**Slug**: burnside-counting-oq-03-oq-03
+**Created**: 2026-04-05
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+The gallery proof `BurnsideCounting.lean` uses `AddAction (ZMod n)` for cyclic rotation
+of colorings, but Mathlib's orbit-counting theorem operates on `MulAction`. The goal is
+to build a proper `MulAction (ZMod n).toMultiplicativeGroup (Coloring n k)` instance
+(or equivalent bridge) so that all 5 current axioms collapse to `native_decide` or
+Mathlib lemmas:
+
+1. `rotatedIndex_add` — modular arithmetic composition law for rotations
+2. `fixed_point_sum_binary_4` — computed fixed-point sum = 24
+3. `coloringSetoid` — orbit equivalence relation
+4. `coloringQuotientFintype` — Fintype instance for quotient
+5. `binary_necklaces_4` — 6 distinct binary 4-necklaces
+
+### Plain Language
+
+The current Burnside's lemma formalization axiomatizes 5 facts that "should" be decidable
+or follow from Mathlib's group theory library. The missing bridge is a group homomorphism
+from (ℤ/nℤ, +) to (Sym(Coloring n k), ∘) that expresses cyclic rotation as a `MulAction`.
+Once this bridge exists, `coloringSetoid` and `coloringQuotientFintype` can be derived from
+Mathlib's `orbitRel`, `rotatedIndex_add` becomes a `decide`-able modular identity, and
+`fixed_point_sum_binary_4` reduces to `native_decide`.
+
+### Why This Matters
+
+Removing these 5 axioms would change the gallery proof from `badge: "axiom"` to potentially
+`badge: "verified"`. It also provides a reusable pattern for any future necklace/orbit
+counting problem in Lean 4 that uses cyclic group actions.
+
+## Known Results
+
+### What's Already Proven
+
+- `burnside_lemma` — wraps `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group`
+- `binary_4_colorings_count` — `Coloring 4 2` has 16 elements (fully proved)
+- `constant_coloring_count` — exactly k constant colorings (fully proved)
+- `period2_count` — 4 binary colorings of length 4 with period dividing 2 (fully proved)
+- `rotateColoring` — ZMod n acts on colorings by cyclic rotation (definition)
+- `cyclicAddActionOnColorings` — `AddAction (ZMod n) (Coloring n k)` instance
+
+### What's Still Open
+
+- Bridge `AddAction (ZMod n)` → `MulAction` for orbit-counting API
+- Formal proof that cyclic rotation forms a valid group action (rotatedIndex_add)
+- Decision procedure for the fixed-point sum (fixed_point_sum_binary_4)
+- Quotient structure for the orbit equivalence (coloringSetoid, coloringQuotientFintype)
+
+### Our Goal
+
+Eliminate all 5 axioms by:
+1. Proving `rotatedIndex_add` via modular arithmetic lemmas in Mathlib
+2. Using `native_decide` or `decide` for `fixed_point_sum_binary_4` and `binary_necklaces_4`
+3. Building a `MulAction` instance from the `AddAction` and deriving `coloringSetoid`/`coloringQuotientFintype` from `orbitRel`
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| burnside-counting | Parent proof — the axioms to eliminate | Group actions, ZMod, necklaces |
+| burnside-counting-oq-03 | Sibling OQ extending to Pólya enumeration | Pólya cycle index |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **ZMod-to-MulAction bridge via `MonoidHom`**:
+   - Define `φ : ZMod n →+ Equiv.Perm (Coloring n k)` sending rotation `r` to the permutation `c ↦ rotateColoring r c`
+   - Use `AddMonoidHom.toMulAction` or similar to extract a `MulAction`
+   - Risk: Lean 4's `AddAction` and `MulAction` are not directly interchangeable; need careful instance derivation
+
+2. **Direct `rotatedIndex_add` proof**:
+   - `rotatedIndex i r := (i + n - r) % n`
+   - Show `rotatedIndex (rotatedIndex i r₁) r₂ = rotatedIndex i (r₁ + r₂)` (mod n)
+   - This is elementally provable by `omega` or `ZMod` arithmetic lemmas
+   - Risk: Low — standard modular arithmetic
+
+3. **`native_decide` for finite computations**:
+   - `fixed_point_sum_binary_4` is a finite sum over 4 group elements, each fixed-point count decidable
+   - `binary_necklaces_4` is a finite cardinality claim
+   - Both should yield to `native_decide` once the action is properly defined
+
+### Key Difficulties
+
+- Bridging `AddAction (ZMod n)` to `MulAction` requires finding the right Mathlib API path
+- `coloringSetoid` and `coloringQuotientFintype` depend on proper orbit equivalence; needs `orbitRel` from Mathlib
+- Lean 4 definitional equality issues may arise with `ZMod` modular reduction
+
+### What Would a Proof Need?
+
+- Key lemma 1: `rotatedIndex_add` via `Nat.add_mod`, `Nat.sub_mod`, or `omega`
+- Key lemma 2: `MonoidHom` from `(ZMod n).toMultiplicativeGroup` to `Equiv.Perm (Coloring n k)`
+- Key lemma 3: Derivation of `orbitRel (ZMod n) (Coloring n k)` from Mathlib's `MulAction.orbitRel`
+- Technical: `Fintype` instance for `Quotient (orbitRel (ZMod n) (Coloring n k))`
+
+## Tractability Assessment
+
+**Difficulty**: Low-Medium
+
+**Justification**:
+- `rotatedIndex_add` is pure modular arithmetic — provable with `omega` or existing `Nat.mod` lemmas
+- `native_decide` handles the finite computation axioms
+- The MulAction bridge is the main challenge, but Mathlib has `ZMod` group structures and `Equiv.Perm` MulAction instances
+
+**Estimated Effort**:
+- Exploration: 1-2 days (finding the right Mathlib API)
+- If tractable: 2-4 days to eliminate all 5 axioms
+
+## References
+
+### Mathlib
+- `Mathlib.GroupTheory.GroupAction.Basic` — `MulAction`, `orbitRel`, `sum_card_fixedBy_eq_card_orbits_mul_card_group`
+- `Mathlib.Data.ZMod.Basic` — `ZMod` as `CommRing`, `AddCommGroup`
+- `Mathlib.GroupTheory.Perm.Basic` — `Equiv.Perm` as `MulAction` on the base type
+- `Mathlib.Algebra.Group.Hom.Basic` — `MonoidHom`, `AddMonoidHom.toMulAction`
+
+## Metadata
+
+```yaml
+tags:
+  - combinatorics
+  - algebra
+  - group-theory
+  - mathlib-integration
+  - necklace-counting
+  - burnside
+  - connection
+related_proofs:
+  - burnside-counting
+  - burnside-counting-oq-03
+difficulty: low-medium
+source: gallery-gap
+created: 2026-04-05
+```

--- a/research/problems/burnside-counting-oq-03-oq-03/state.md
+++ b/research/problems/burnside-counting-oq-03-oq-03/state.md
@@ -1,0 +1,25 @@
+# Research State: burnside-counting-oq-03-oq-03
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-05T13:40:39-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/szemeredi-core-oq-01/knowledge.md
+++ b/research/problems/szemeredi-core-oq-01/knowledge.md
@@ -41,3 +41,71 @@ the refinement increases energy by at least ε^5.
    - Quantify: need |A|·|B| ≥ ε·n² (from equipartition) and d-deviation > ε
 2. Alternative: submit `energy_increment_step` to Aristotle as HARD sorry
    - The algebraic steps are clear; the Finset sum manipulation may be automatable
+
+---
+
+## Session 2026-04-05 (Session 2) — Infrastructure Discovery & partitionEnergy_mono
+
+**Mode**: REVISIT
+**Outcome**: progress
+
+### What I Did
+
+- Discovered the main file had been significantly extended since Session 1:
+  - `four_subpair_edge_count_identity`: PROVED (double weighted average identity)
+  - `four_subpair_deviation_identity`: PROVED (variance decomposition equality)
+  - `four_subpair_excess_lb`: PROVED (variance bound: 4-pair excess ≥ |A₁||B₁|(d₁₁-d)²)
+  - `energy_increment_step` already updated to claim `eps^6` (corrected from ε^5)
+  - `hcore` is already derived: `A'.card * B'.card * dev² > eps^6 * n²`
+- Proved `partitionEnergy_mono` in SzemerediCoreOQ01Aristotle.lean:
+  - P ⊆ Q (as Finsets of parts) → partitionEnergy G Q ≥ partitionEnergy G P
+  - Proof: Finset.sum_le_sum_of_subset_of_nonneg with Finset.product_subset_product
+- Documented the complete block decomposition strategy for the main sorry
+
+### Key Findings
+
+1. **ε^5 vs ε^6 clarification**: The correct bound for a SINGLE irregular pair with
+   hypothesis `hpart_size: P.card ≥ eps*n` is ε^6, not ε^5. The ε^5 standard result
+   sums over ≥ ε*k² irregular pairs, each contributing ~ε^4/k². One pair → ε^6.
+   The theorem statement was already corrected to ε^6 in the main file.
+
+2. **Block decomposition strategy** (completely worked out mathematically):
+   Refactored partition: parts' = S ∪ T, parts = S ∪ {A,B}
+   where S = parts\{A,B}, T = {A', A\A', B', B\B'}
+   Energy comparison via Finset.sum_union:
+   - S×S block: equal
+   - S×T ≥ S×{A,B}: density_sq_convex per C∈S
+   - T×S ≥ {A,B}×S: same by edgeDensity_symm
+   - T×T ≥ {A,B}×{A,B} + eps^6:
+     * A-self, B-self: sub4pair_energy_lower_bound (≥0)
+     * A×B cross: four_subpair_excess_lb + hcore → ≥ eps^6
+     * B×A cross: symmetry → ≥ eps^6 (total ≥ 2*eps^6)
+
+3. **Key Lean challenge**: S∩T disjointness requires A', A\A', B', B\B' ∉ S.
+   This holds since S = (parts.erase B).erase A contains only other parts, and
+   A', A\A' are strict subsets of A (not equal to any other part). But formalizing
+   this requires showing that the other parts in S are disjoint from A (by hdisjoint),
+   hence no other part equals A' (since A' ⊆ A). This is the remaining formalization gap.
+
+### Files Modified
+
+- `proofs/Proofs/SzemerediCoreOQ01Aristotle.lean`:
+  - Proved `partitionEnergy_mono`
+  - Added `partitionEnergy_term_nonneg` (inline proof)
+  - Cleaned up redundant lemmas (double_weighted_avg, four_subpair_excess_lb were in main)
+  - Documented complete block decomposition strategy in `energy_increment_packaging_ari` comments
+
+### Next Steps
+
+1. **Prove disjointness**: Show S ∩ T = ∅, i.e., A', A\A', B', B\B' ∉ S
+   - Use: ∀ C ∈ S, C is disjoint from A and B (from hdisjoint)
+   - A' ⊆ A, so A' ∩ C = ∅ implies A' ≠ C for any C ∈ S
+   - Key Lean lemma needed: `Finset.disjoint_of_subset_left` + contradiction
+2. **Implement the block decomposition**:
+   - Use Finset.sum_union for disjoint S and T
+   - Use Finset.product_union_right/left
+   - Apply density_sq_convex for S×T and T×S blocks
+   - Apply four_subpair_excess_lb + hcore for T×T block
+3. **Alternative**: Submit the packaging sorry to Aristotle
+   - The goal is well-typed, hypotheses are concrete
+   - Aristotle might handle the Finset.sum manipulation

--- a/research/registry.json
+++ b/research/registry.json
@@ -14793,6 +14793,13 @@
       "path": "full",
       "started": "2026-04-05T13:10:59-07:00",
       "status": "active"
+    },
+    {
+      "slug": "burnside-counting-oq-03-oq-03",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T13:40:39-07:00",
+      "status": "active"
     }
   ],
   "config": {

--- a/src/data/research/problems/szemeredi-core-oq-01.json
+++ b/src/data/research/problems/szemeredi-core-oq-01.json
@@ -29,26 +29,32 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 5 algebraic lemmas proved in SzemerediCoreOQ01.lean, 1 sorry remains (energy_increment_step Finset sum)",
+    "progressSummary": "PROGRESS: All algebraic lemmas proved; partitionEnergy_mono proved; block decomposition strategy documented; one sorry remains (Finset sum packaging)",
     "builtItems": [
       "edgeDensity_symm: d(A,B)=d(B,A) via swap bijection (SzemerediCoreOQ01.lean:49)",
       "density_sq_convex_right: convexity for second argument via edgeDensity_symm (SzemerediCoreOQ01.lean:63)",
       "sub4pair_energy_lower_bound: 4-subpair energy ≥ original pair (SzemerediCoreOQ01.lean:80)",
       "edgeDensity_union_weighted_avg: weighted average identity proved (SzemerediCoreOQ01.lean:139)",
-      "energy_excess_A_split: exact excess = |A₁|·|A₂|/|A|·(d₁-d₂)² (SzemerediCoreOQ01.lean:209)"
+      "energy_excess_A_split: exact excess = |A₁|·|A₂|/|A|·(d₁-d₂)² (SzemerediCoreOQ01.lean:209)",
+      "partitionEnergy_mono in SzemerediCoreOQ01Aristotle.lean: proved via Finset.sum_le_sum_of_subset_of_nonneg"
     ],
     "insights": [
       "partitionEnergy uses n² normalization (n=total vertices), not k² (k=parts count)",
       "card_mul_edgeDensity and edge_count_union in SzemerediRegularity.lean are private — must inline",
       "edgeDensity_union_weighted_avg: case split on B empty, then weighted average via inlined helpers",
       "For Finset.card_bij: use .mp/.mpr not ⟨...⟩ for membership; Prod.ext for injectivity; Prod.eta for surjectivity",
-      "After set a₁ : ℚ := (A₁.card : ℚ), no further simp [show ...] needed as cast already done"
+      "After set a₁ : ℚ := (A₁.card : ℚ), no further simp [show ...] needed as cast already done",
+      "Correct energy increment bound for single irregular pair is eps^6 (not eps^5); eps^5 is for total over all irregular pairs",
+      "Block decomposition strategy: S×S equal, S×T≥S×{A,B} by density_sq_convex, T×T≥{A,B}×{A,B}+eps^6 by four_subpair_excess_lb",
+      "Key Lean challenge: S∩T disjointness requires A-prime not in S, follows from hdisjoint + A-prime ⊂ A"
     ],
     "mathlibGaps": [],
     "nextSteps": [
       "Prove energy_increment_step: sum excess over all pairs in refined partition",
       "Key: need |A|·|B| ≥ ε·n² (equipartition size bound) to get ε^5 quantitative bound",
-      "Alternative: submit energy_increment_step sorry to Aristotle"
+      "Alternative: submit energy_increment_step sorry to Aristotle",
+      "Prove S∩T disjointness using hdisjoint + subset containment",
+      "Implement Finset.sum_union decomposition for the packaging sorry"
     ],
     "markdown": "# Knowledge Base: szemeredi-core-oq-01\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },


### PR DESCRIPTION
## Summary

- Selects `burnside-counting-oq-03-oq-03` as next research problem
- Goal: eliminate all 5 axioms in `BurnsideCounting.lean` by bridging `AddAction (ZMod n)` to Mathlib's `MulAction` API
- Composite score: 76 (tractability=7, significance=6, knowledge=EMPTY)

## Selection Rationale

**Problem**: Interface Burnside's Lemma with Mathlib MulAction Framework
**Score**: 76 | Tier B | Sig 6/10 | Tract 7/10 | Knowledge: EMPTY
**Domain**: Algebra / Group Theory (diverse from recent number theory / analysis selections)

The current `BurnsideCounting.lean` axiomatizes 5 facts that should be decidable:
- `rotatedIndex_add`: modular arithmetic composition (provable with `omega`)
- `fixed_point_sum_binary_4`: finite computation (provable with `native_decide`)
- `coloringSetoid`, `coloringQuotientFintype`, `binary_necklaces_4`: orbit structure (derivable from Mathlib's `orbitRel` once `MulAction` bridge exists)

**Previous selections rejected**: `divisibility-by-three-oq-01-oq-02` was already selected 3× (quality gate: repeated selection).

## Pool Status After Selection

| Status | Count |
|--------|-------|
| Available | 14 |
| In Progress | 1138 |
| Completed | 545 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)