### PR TITLE
Research: erdos-414 metadata + erdos-1012-oq-03 GH fix

### DIFF
--- a/proofs/Proofs/Erdos1012OQ03.lean
+++ b/proofs/Proofs/Erdos1012OQ03.lean
@@ -53,10 +53,14 @@ Survey + proof infrastructure. Rédei proved modulo 2 infrastructure lemmas.
 - [x] list_cycle_to_hamiltonian (cycle list → equivalence)
 - [x] grow_cycle_to_hamiltonian (induction on deficit)
 - [x] Moon-Moser proved modulo 2 infrastructure sorries
-- [ ] sc_tournament_has_cycle (cycle existence in SC tournament)
-- [ ] tournament_cycle_extendable (longest-cycle extension)
-- [ ] Ghouila-Houri proof
-- [ ] Directed threshold proof
+- [x] sc_tournament_has_cycle (cycle existence in SC tournament)
+- [x] tournament_cycle_extendable (longest-cycle extension)
+- [x] Directed threshold proof (0 sorries)
+- [ ] Ghouila-Houri proof (structured: 2 helper sorries, main proved)
+  - [ ] sc_degree_has_cycle (cycle existence in SC high-degree digraph)
+  - [ ] ghouila_houri_cycle_extendable (cycle extension under GH conditions)
+  - [x] grow_cycle_gh (well-founded recursion, proved)
+  - [x] ghouila_houri (delegates to helpers, proved)
 -/
 
 namespace Erdos1012OQ03
@@ -286,18 +290,83 @@ lemma list_path_to_hamiltonian (D : Digraph V) (l : List V)
 PART III: GHOUILA-HOURI'S THEOREM
 ═══════════════════════════════════════════════════════════════════════════════ -/
 
+/-! The degree condition uses CEILING division ⌈n/2⌉ = (n+1)/2 in Lean's Nat division.
+Floor division n/2 is insufficient: for n=3, ⌊3/2⌋=1 allows SC digraphs without HC.
+Counterexample: V={a,b,c}, arcs={a→b, b→a, a→c, c→a}, min in/out-deg=1, SC but no HC. -/
+
+/-- Out-degree as a Finset cardinality (decidable version needed for counting). -/
+private noncomputable def Digraph.outNeighbors (D : Digraph V) (v : V) : Finset V :=
+  Finset.univ.filter (fun u => D.arc v u)
+
+/-- In-degree as a Finset cardinality (decidable version needed for counting). -/
+private noncomputable def Digraph.inNeighbors (D : Digraph V) (v : V) : Finset V :=
+  Finset.univ.filter (fun u => D.arc u v)
+
+/-- An SC digraph with ⌈n/2⌉ minimum degree has a directed cycle.
+Every vertex has out-degree ≥ 2 (for n ≥ 3), so a walk must revisit a vertex. -/
+private lemma sc_degree_has_cycle (D : Digraph V) (hn : 3 ≤ Fintype.card V)
+    (hsc : D.IsStronglyConnected)
+    (hout : ∀ v : V, (Fintype.card V + 1) / 2 ≤ D.outDegree v) :
+    ∃ l : List V, IsDirectedCycleList D l := by
+  -- Since (n+1)/2 ≥ 2 for n ≥ 3, every vertex has out-degree ≥ 2.
+  -- Take any two distinct vertices with an arc, use SC to close a cycle.
+  sorry
+
+/-- In an SC digraph with Ghouila-Houri conditions, any directed cycle
+shorter than n can be extended to a longer cycle.
+
+**Proof strategy for the case k = n-1** (one vertex missing):
+The unique non-cycle vertex v has ALL its neighbors on C (only v is off C).
+So |N⁺(v)∩C| + |N⁻(v)∩C| = out-deg(v) + in-deg(v) ≥ (n+1)/2 + (n+1)/2 ≥ n+1 > n-1 = k.
+By the shifted-disjointness argument, a non-insertable vertex satisfies
+|N⁺∩C| + |N⁻∩C| ≤ k. Since n+1 > n-1, v must be insertable.
+
+**For general k < n-1**: Uses SC to find arc paths through non-cycle vertices.
+When no single vertex is insertable, the S⁻/S⁺ partition argument
+(adapted from tournament_cycle_extendable) derives contradiction with SC. -/
+private lemma ghouila_houri_cycle_extendable (D : Digraph V)
+    (hn : 3 ≤ Fintype.card V) (hsc : D.IsStronglyConnected)
+    (hout : ∀ v : V, (Fintype.card V + 1) / 2 ≤ D.outDegree v)
+    (hin : ∀ v : V, (Fintype.card V + 1) / 2 ≤ D.inDegree v)
+    (l : List V) (hc : IsDirectedCycleList D l) (hl : l.length < Fintype.card V) :
+    ∃ l' : List V, IsDirectedCycleList D l' ∧ l.length < l'.length := by
+  sorry
+
+/-- Grow a cycle to Hamiltonian using GH conditions. -/
+private noncomputable def grow_cycle_gh (D : Digraph V)
+    (hn : 3 ≤ Fintype.card V) (hsc : D.IsStronglyConnected)
+    (hout : ∀ v : V, (Fintype.card V + 1) / 2 ≤ D.outDegree v)
+    (hin : ∀ v : V, (Fintype.card V + 1) / 2 ≤ D.inDegree v)
+    (l : List V) (hc : IsDirectedCycleList D l) :
+    D.HasHamiltonianCycle := by
+  by_cases hm : l.length = Fintype.card V
+  · exact list_cycle_to_hamiltonian D l hc hm
+  · have hle : l.length ≤ Fintype.card V := nodup_length_le_card l hc.1
+    obtain ⟨l', hc', hl'⟩ :=
+      ghouila_houri_cycle_extendable D hn hsc hout hin l hc (by omega)
+    have hle' : l'.length ≤ Fintype.card V := nodup_length_le_card l' hc'.1
+    exact grow_cycle_gh D hn hsc hout hin l' hc'
+termination_by Fintype.card V - l.length
+decreasing_by omega
+
 /-- **Ghouila-Houri's Theorem (1960)**
 
 A strongly connected digraph on n ≥ 3 vertices where every vertex has
-in-degree and out-degree at least n/2 has a directed Hamiltonian cycle.
+in-degree and out-degree at least ⌈n/2⌉ has a directed Hamiltonian cycle.
 
-This is the directed analogue of Dirac's theorem (1952) for undirected graphs. -/
+This is the directed analogue of Dirac's theorem (1952) for undirected graphs.
+
+**Note**: The degree bound uses CEILING division (n+1)/2, not floor n/2.
+For n=3, ⌈3/2⌉=2 requires each vertex to have degree 2 in both directions
+(i.e., the digraph is complete). Floor division ⌊3/2⌋=1 is insufficient:
+counterexample exists with SC + min-degree 1 but no HC. -/
 theorem ghouila_houri (D : Digraph V) (hn : 3 ≤ Fintype.card V)
     (hsc : D.IsStronglyConnected)
-    (hout : ∀ v : V, Fintype.card V / 2 ≤ D.outDegree v)
-    (hin : ∀ v : V, Fintype.card V / 2 ≤ D.inDegree v) :
+    (hout : ∀ v : V, (Fintype.card V + 1) / 2 ≤ D.outDegree v)
+    (hin : ∀ v : V, (Fintype.card V + 1) / 2 ≤ D.inDegree v) :
     D.HasHamiltonianCycle := by
-  sorry
+  obtain ⟨l₀, hc₀⟩ := sc_degree_has_cycle D hn hsc hout
+  exact grow_cycle_gh D hn hsc hout hin l₀ hc₀
 
 /-! ═══════════════════════════════════════════════════════════════════════════════
 PART IV: MOON-MOSER THEOREM FOR TOURNAMENTS
@@ -1187,11 +1256,20 @@ Decomposed via counting/probabilistic method:
 
 Remaining sorries: none (directed_hamiltonian_threshold is fully proved, 0 sorries)
 
-### Ghouila-Houri (~200 lines, still open)
-The proof follows the same structure as Dirac's theorem:
-1. Start with a longest directed path P in D
-2. Show P must be Hamiltonian (degree conditions prevent extension if k < n)
-3. Close P into a cycle using degree conditions on first/last vertices
+### Ghouila-Houri (structured, 2 sorries remain in helpers)
+**Bug fixed**: degree condition changed from floor(n/2) to ceil(n/2) = (n+1)/2.
+Floor division is insufficient for n=3 (counterexample: SC digraph with min-deg 1, no HC).
+
+Proof structure (grow-cycle approach):
+1. `sc_degree_has_cycle` (sorry): SC + high degree → initial directed cycle
+2. `ghouila_houri_cycle_extendable` (sorry): cycle of length k < n → longer cycle
+   - k = n-1: degree counting forces insertion (|N⁺∩C|+|N⁻∩C| ≥ n+1 > n-1 = k)
+   - k < n-1: SC + S⁻/S⁺ partition argument (adapted from tournament case)
+3. `grow_cycle_gh` (proved): well-founded recursion using 2
+4. `ghouila_houri` (proved): delegates to 1 + 3
+
+**Note**: directed path rotation does NOT close directed paths into cycles
+(can't reverse path segments). The grow-cycle approach is correct for directed graphs.
 
 ### Rédei (DONE)
 Proved by induction via tournament insertion lemma.

--- a/proofs/Proofs/ShannonChannelCodingOQ03.lean
+++ b/proofs/Proofs/ShannonChannelCodingOQ03.lean
@@ -21,14 +21,14 @@
   3. [PROVED]  formula_pe_ge_map_pe  — P_e^{MAP} ≤ P_e^{formula}
   4. [PROVED]  gibbs_inequality      — H(p) ≤ -∑ p·log q (KL divergence ≥ 0)
   5. [PROVED]  fano_per_element      — per-y Fano via Gibbs with bimodal reference
-  6. [SORRY]   fano_map_bound        — H(X|Y) ≤ h(P_e^{MAP}) + P_e^{MAP}·log(n-1)
+  6. [PROVED]  fano_map_bound        — H(X|Y) ≤ h(P_e^{MAP}) + P_e^{MAP}·log(n-1)
   7. [PROVED]  fano_func_mono        — monotonicity of h(p) + p·log(c)
   7.5 [PROVED] cauchy_schwarz_sum    — (∑f)² ≤ n·∑f²
   7.6 [PROVED] per_slice_bound       — ∑f²/s ≥ s/n
-  8. Main:     fano_theorem (hpe_bound PROVED)
+  8. Main:     fano_theorem (ALL PROVED)
 
   Claude Shannon (1948) — Fano (1952)
-  Sorries: 1 (fano_map_bound)
+  Sorries: 0
 -/
 import Mathlib
 import Proofs.ShannonChannelCodingOQ04
@@ -319,10 +319,10 @@ lemma fano_per_element {α : Type*} [Fintype α] [DecidableEq α] [Nonempty α]
 -- Section 7: Conditional Entropy Fano Bound — MAP Version (SORRY)
 -- ============================================================
 
-/-- **[SORRY]**: H(X|Y) ≤ h(P_e^{MAP}) + P_e^{MAP} · log(|X| - 1)
+/-- **[PROVED]**: H(X|Y) ≤ h(P_e^{MAP}) + P_e^{MAP} · log(|X| - 1)
 
-    Proof sketch: Decompose H(X|Y) = ∑_y P(Y=y)·H(X|Y=y), apply
-    fano_per_element per slice, then Jensen for concave h. -/
+    Proof: Decompose H(X|Y) = ∑_y P(Y=y)·H(X|Y=y), apply fano_per_element
+    per slice, then Jensen (ConcaveOn.le_map_sum) for concave h. -/
 lemma fano_map_bound {α β : Type*} [Fintype α] [Fintype β]
     [DecidableEq α] [DecidableEq β] [Nonempty α]
     (hn : 1 < Fintype.card α)
@@ -330,7 +330,142 @@ lemma fano_map_bound {α β : Type*} [Fintype α] [Fintype β]
     conditionalEntropy pXY ≤
       h (mapErrorProb pXY) +
       mapErrorProb pXY * Real.log ((Fintype.card α : ℝ) - 1) := by
-  sorry
+  set n := (Fintype.card α : ℝ) with hn_def
+  have hn1 : (1 : ℝ) < n := by rw [hn_def]; exact_mod_cast hn
+  -- Per-y marginal P(Y=y)
+  set Py : β → ℝ := fun y => ∑ x : α, pXY (x, y) with hPy_def
+  have hPy_nn : ∀ y, 0 ≤ Py y := fun y => Finset.sum_nonneg (fun x _ => hp (x, y))
+  have hPy_sum : ∑ y : β, Py y = 1 := by
+    have h' := hsum; rw [Fintype.sum_prod_type] at h'; rwa [← Finset.sum_comm] at h'
+  -- Per-y error probability: pe(y) = 1 - max_x pXY(x,y) / P(Y=y)
+  set pe : β → ℝ := fun y =>
+    if Py y = 0 then 0 else 1 - maxProb (fun x => pXY (x, y)) / Py y with hpe_def
+  -- Helper: maxProb ≤ Py for each y
+  have hmaxle : ∀ y, maxProb (fun x => pXY (x, y)) ≤ Py y := fun y =>
+    Finset.sup'_le _ _ (fun x _ =>
+      Finset.single_le_sum (fun x _ => hp (x, y)) (Finset.mem_univ x))
+  -- pe ∈ [0, 1]
+  have hpe_nn : ∀ y, 0 ≤ pe y := by
+    intro y; simp only [hpe_def]; split_ifs with hsy
+    · exact le_refl 0
+    · have hsy_pos : 0 < Py y := (hPy_nn y).lt_of_ne' hsy
+      rw [sub_nonneg, div_le_one₀ hsy_pos]; exact hmaxle y
+  have hpe_le1 : ∀ y, pe y ≤ 1 := by
+    intro y; simp only [hpe_def]; split_ifs with hsy
+    · exact zero_le_one
+    · have hsy_pos : 0 < Py y := (hPy_nn y).lt_of_ne' hsy
+      have : 0 ≤ maxProb (fun x => pXY (x, y)) :=
+        le_trans (hp (Classical.arbitrary α, y))
+          (Finset.le_sup' (fun x => pXY (x, y)) (Finset.mem_univ _))
+      linarith [div_nonneg this (le_of_lt hsy_pos)]
+  -- Key: ∑ Py * pe = mapErrorProb
+  have hpe_sum : ∑ y : β, Py y * pe y = mapErrorProb pXY := by
+    unfold mapErrorProb
+    -- mapErrorProb = 1 - ∑ maxProb = ∑(Py - maxProb) = ∑ Py * pe
+    rw [show (1 : ℝ) - ∑ y : β, maxProb (fun x => pXY (x, y)) =
+        ∑ y : β, (Py y - maxProb (fun x => pXY (x, y))) from by
+      rw [Finset.sum_sub_distrib, hPy_sum]]
+    apply Finset.sum_congr rfl; intro y _
+    simp only [hpe_def]; split_ifs with hsy
+    · -- Py = 0 ⟹ maxProb = 0
+      have : maxProb (fun x => pXY (x, y)) = 0 :=
+        le_antisymm (hsy ▸ hmaxle y)
+          (le_trans (hp (Classical.arbitrary α, y))
+            (Finset.le_sup' (fun x => pXY (x, y)) (Finset.mem_univ _)))
+      rw [hsy, zero_mul]; linarith
+    · have hsy_pos : 0 < Py y := (hPy_nn y).lt_of_ne' hsy; field_simp
+  -- Step 1: Per-y Fano bound
+  -- For each y, -(∑_x term) ≤ Py * (h(pe) + pe * log(n-1))
+  have hper_y : ∀ y : β,
+      -(∑ x : α, if pXY (x, y) = 0 then 0
+        else pXY (x, y) * Real.log (pXY (x, y) / Py y)) ≤
+      Py y * (h (pe y) + pe y * Real.log (n - 1)) := by
+    intro y
+    by_cases hsy : Py y = 0
+    · have hall : ∀ x, pXY (x, y) = 0 := fun x =>
+        le_antisymm ((Finset.single_le_sum (fun x _ => hp (x, y))
+          (Finset.mem_univ x)).trans_eq hsy) (hp (x, y))
+      simp [hall, hsy, hpe_def]
+    · have hsy_pos : 0 < Py y := (hPy_nn y).lt_of_ne' hsy
+      set q := fun x => pXY (x, y) / Py y with hq_def
+      have hq_nn : ∀ x, 0 ≤ q x := fun x => div_nonneg (hp (x, y)) (le_of_lt hsy_pos)
+      have hq_sum : ∑ x, q x = 1 := by
+        simp only [hq_def, ← Finset.sum_div]; exact div_self (ne_of_gt hsy_pos)
+      -- Decompose: -(∑ pXY*log(pXY/Py)) = Py * shannonEntropy q
+      have hrel : -(∑ x : α, if pXY (x, y) = 0 then 0
+          else pXY (x, y) * Real.log (pXY (x, y) / Py y)) =
+          Py y * shannonEntropy q := by
+        unfold shannonEntropy
+        -- LHS = -(∑ term_x), RHS = Py * (-(∑ term'_x)) = -(Py * ∑ term'_x)
+        rw [mul_neg]; congr 1
+        rw [Finset.mul_sum]
+        apply Finset.sum_congr rfl; intro x _
+        by_cases hpx : pXY (x, y) = 0
+        · have hqx : q x = 0 := by show pXY (x, y) / Py y = 0; rw [hpx, zero_div]
+          simp [hpx, hqx]
+        · have hqx_ne : q x ≠ 0 := by
+            show pXY (x, y) / Py y ≠ 0; exact div_ne_zero hpx (ne_of_gt hsy_pos)
+          simp only [hpx, hqx_ne, ↓reduceIte]
+          show pXY (x, y) * Real.log (pXY (x, y) / Py y) =
+            Py y * (q x * Real.log (q x))
+          rw [show q x = pXY (x, y) / Py y from rfl]; field_simp
+      rw [hrel]
+      -- Apply fano_per_element
+      have hfano := fano_per_element hn hq_nn hq_sum
+      -- maxProb q = maxProb(pXY(·,y)) / Py
+      have hmax_q : maxProb q = maxProb (fun x => pXY (x, y)) / Py y := by
+        -- sup'(f/c) = sup'(f)/c for c > 0: technical lemma
+        unfold maxProb; apply le_antisymm
+        · exact Finset.sup'_le _ _ (fun x _ =>
+            div_le_div_of_nonneg_right
+              (Finset.le_sup' (fun x => pXY (x, y)) (Finset.mem_univ x))
+              (le_of_lt hsy_pos))
+        · rw [div_le_iff₀ hsy_pos]
+          exact Finset.sup'_le _ _ (fun x hx => by
+            have hle : pXY (x, y) / Py y ≤ Finset.sup' Finset.univ Finset.univ_nonempty
+                (fun x => pXY (x, y) / Py y) :=
+              Finset.le_sup' (fun x => pXY (x, y) / Py y) hx
+            have hmul := mul_le_mul_of_nonneg_left hle (le_of_lt hsy_pos)
+            have heq : Py y * (pXY (x, y) / Py y) = pXY (x, y) := by
+              field_simp [ne_of_gt hsy_pos]
+            linarith)
+      have hpe_eq : 1 - maxProb q = pe y := by
+        simp only [hpe_def, if_neg hsy, hmax_q]
+      rw [hpe_eq] at hfano
+      exact mul_le_mul_of_nonneg_left hfano (le_of_lt hsy_pos)
+  -- Step 2: Conditional entropy ≤ ∑ per-y bounds
+  have hCE_bound : conditionalEntropy pXY ≤
+      ∑ y : β, Py y * (h (pe y) + pe y * Real.log (n - 1)) := by
+    unfold conditionalEntropy
+    -- Swap ∑_x ∑_y to ∑_y ∑_x, negate, and apply per-y bounds
+    have hswap : -(∑ x : α, ∑ y : β, if pXY (x, y) = 0 then 0
+        else pXY (x, y) * Real.log (pXY (x, y) / (∑ x', pXY (x', y)))) =
+        ∑ y : β, -(∑ x : α, if pXY (x, y) = 0 then 0
+        else pXY (x, y) * Real.log (pXY (x, y) / Py y)) := by
+      rw [← Finset.sum_comm, ← Finset.sum_neg_distrib]
+    rw [hswap]
+    exact Finset.sum_le_sum (fun y _ => hper_y y)
+  -- Step 3: Split and apply Jensen
+  have hsplit : ∑ y : β, Py y * (h (pe y) + pe y * Real.log (n - 1)) =
+      ∑ y, Py y * h (pe y) + (∑ y, Py y * pe y) * Real.log (n - 1) := by
+    simp only [mul_add, Finset.sum_add_distrib]
+    congr 1
+    have : ∀ y ∈ (Finset.univ : Finset β),
+        Py y * (pe y * Real.log (n - 1)) = (Py y * pe y) * Real.log (n - 1) :=
+      fun y _ => by ring
+    rw [Finset.sum_congr rfl this, ← Finset.sum_mul]
+  rw [hsplit, hpe_sum] at hCE_bound
+  -- Jensen: ∑ Py * h(pe) ≤ h(∑ Py * pe) = h(mapErrorProb)
+  have hJensen : ∑ y : β, Py y * h (pe y) ≤ h (mapErrorProb pXY) := by
+    rw [← hpe_sum]
+    -- Apply Jensen: ConcaveOn.le_map_sum with h_concaveOn
+    -- Need to convert between • and * (in ℝ, smul = mul)
+    have hjm := h_concaveOn.le_map_sum
+      (fun y (_ : y ∈ Finset.univ) => hPy_nn y)
+      (by convert hPy_sum using 1)
+      (fun y _ => Set.mem_Icc.mpr ⟨hpe_nn y, hpe_le1 y⟩)
+    convert hjm using 1
+  linarith
 
 -- ============================================================
 -- Section 7.5: Cauchy-Schwarz for Sums (Helper)

--- a/src/data/proofs/erdos-414/meta.json
+++ b/src/data/proofs/erdos-414/meta.json
@@ -49,11 +49,9 @@
     ],
     "axiomCount": 1,
     "assumptions": [
-      "erdos_414_conjecture: ∀ m, n ≥ 1, ∃ i, j: h^i(m) = h^j(n) — all orbits eventually merge (main open question)",
-      "single_eventual_orbit: equivalent formulation — there exists a single sequence S that all orbits eventually follow",
-      "orbits_get_close: ∀ m, n ≥ 1, ∀ D, ∃ i, j: |h^i(m) - h^j(n)| < D — weaker proximity statement (also open)"
+      "erdos_414_conjecture: ∀ m, n ≥ 1, ∃ i, j: h^i(m) = h^j(n) — all orbits eventually merge (main open question)"
     ],
-    "lineCount": 301
+    "lineCount": 302
   },
   "sections": [
     {
@@ -85,7 +83,7 @@
       "title": "The Merging Conjecture (OPEN)",
       "startLine": 98,
       "endLine": 112,
-      "summary": "**erdos_414_conjecture**: ∀ m, n ≥ 1, ∃ i, j with h^i(m) = h^j(n). Equivalently, **single_eventual_orbit**: all orbits merge into one trajectory. The directed graph n → h(n) is conjectured to be a tree with a single trunk.",
+      "summary": "**erdos_414_conjecture** (sole axiom): ∀ m, n ≥ 1, ∃ i, j with h^i(m) = h^j(n). **single_eventual_orbit** and **orbits_get_close** are proved as consequences. **hOrbit_continuation**: once orbits meet, they stay merged forever (key lemma, fully proved by induction).",
       "mathContext": "$\\forall m, n \\geq 1, \\exists i, j \\in \\mathbb{N}: h^i(m) = h^j(n)$. Equivalently, the directed graph $n \\to h(n)$ has a single connected component."
     },
     {
@@ -101,7 +99,7 @@
       "title": "Growth Rate and Heuristic Analysis",
       "startLine": 127,
       "endLine": 155,
-      "summary": "**average_divisor_count**: Dirichlet's theorem gives average τ(n) ∼ log n. **orbit_linear_lower**: h^k(n) ≥ n + k. **orbits_get_close**: any two orbits eventually come within distance D (a weaker unproven statement). The heuristic: orbit spacing ∼ log V near value V, so collision probability ∼ 1/(log V)², and Σ 1/(log V)² diverges.",
+      "summary": "**divisors_card_le_two_sqrt**: τ(n) ≤ 2√n (fully proved via small/large divisor splitting). **h_upper_sqrt**: h(n) ≤ n + 2√n. **orbit_linear_lower**: h^k(n) ≥ n + k. **orbit_linear_lower_ge2**: h^k(n) ≥ n + 2k for n ≥ 2. **orbits_get_close**: proved from the conjecture — once orbits meet, distance is 0. Extended merge computations for orbits 2–10.",
       "mathContext": "Dirichlet: $\\sum_{k \\leq n} \\tau(k) \\sim n \\log n$. Hence $h^k(n) \\approx n + k \\log n$ on average. Collision probability per step $\\sim 1/(\\log V)^2$; $\\sum 1/(\\log V)^2 = \\infty$."
     }
   ],
@@ -109,14 +107,14 @@
     "historicalContext": "Erdős and Graham posed Problem #414 in their 1980 monograph *Old and New Problems and Results in Combinatorial Number Theory* (p. 82), alongside the related Problems #412 ($n + \\sigma(n)$) and #413 ($n - \\varphi(n)$). The problem belongs to **arithmetic dynamics** — iteration of number-theoretic functions as discrete dynamical systems, a field that also includes the Collatz conjecture and aliquot sequences.\n\nThe function $h(n) = n + \\tau(n)$ is strictly increasing ($\\tau(n) \\geq 1$), ruling out cycles. Orbits march strictly upward, so the question is purely about *merging*. Despite strong computational evidence (all orbits from 1 to $10^6$ merge within ~20 steps), the problem remains OPEN. The difficulty: proving exact collision $h^i(m) = h^j(n)$ requires controlling the cumulative irregularity of $\\tau$ along two trajectories. Dirichlet gives $\\sum_{k \\leq n} \\tau(k) \\sim n \\log n$ on average, but $\\tau$ fluctuates wildly: from 2 at primes to $\\tau(n) \\gg n^\\varepsilon$ at highly composite numbers.",
     "problemStatement": "Let h(n) = n + τ(n) where τ(n) counts the divisors of n. For any m, n ≥ 1, do there exist i, j ∈ ℕ such that h^i(m) = h^j(n)?",
     "text": "Erdős Problem #414 studies the iteration h(n) = n + τ(n), where τ(n) counts divisors. Since h is strictly increasing, orbits march upward without cycles. The open question: do all orbits eventually merge? For any m, n ≥ 1, Erdős and Graham conjectured there exist i, j with h^i(m) = h^j(n). Computational evidence is strong (all orbits from 1 to 10^6 merge within ~20 steps), but the irregularity of τ along trajectories makes rigorous proof elusive.",
-    "proofStrategy": "The formalization defines h(n) = n + τ(n) using Lean's `Nat.divisors.card` and the orbit sequence hOrbit by recursion. Basic properties (strict monotonicity, upper bound h(n) ≤ 2n, behavior at primes) are axiomatized. The main conjecture and its equivalent single-orbit formulation are stated. Concrete orbit computations demonstrate the merge of orbits from 1 and 3 at value 7. Growth rate analysis includes Dirichlet's average order of τ, linear orbit lower bounds, and the weaker 'orbits get close' statement. No sorries remain — all deep statements are correctly axiomatized as open conjectures.",
+    "proofStrategy": "The formalization defines h(n) = n + τ(n) using Lean's `Nat.divisors.card` and the orbit sequence hOrbit by recursion. Basic properties are fully proved: strict monotonicity (h(n) > n for n ≥ 1), upper bounds (h(n) ≤ 2n and the tighter h(n) ≤ n + 2√n via a proved τ(n) ≤ 2√n bound), lower bounds (h(n) ≥ n + 2 for n ≥ 2), and behavior at primes (h(p) = p + 2). The main conjecture is the sole axiom. Two consequences (single_eventual_orbit and orbits_get_close) are proved FROM the conjecture. Orbit computations verify all merges for starting values 1–10 via native_decide.",
     "keyInsights": [
       "**Strict monotonicity eliminates cycles**: h(n) > n always, so orbits march strictly upward — no Collatz-like cycle-hunting needed",
       "**Two-speed dynamics**: primes advance by 2 (minimum), highly composite numbers jump by τ ≫ log n — this irregular spacing creates the orbit structure",
       "**Collision mechanism**: h(a) = h(b) when a + τ(a) = b + τ(b), i.e., b − a = τ(a) − τ(b). The divisor function's irregularity makes these collisions common but unpredictable",
       "**Heuristic for merging**: orbit spacing ∼ log V at value V, so collision probability ∼ 1/(log V)² per step. Since Σ 1/(log V)² diverges, infinitely many collisions are expected — but this heuristic is not rigorous",
       "**Even the weak form is open**: proving that orbits merely get arbitrarily close (without exact collision) is already unproven",
-      "**Proof structure**: The file uses 3 `axiom` declarations for genuinely open statements (erdos_414_conjecture, single_eventual_orbit, orbits_get_close). All other statements are either `theorem` (proved) or `def` (defined). The `average_divisor_count : True` theorem is a Dirichlet-average placeholder — it states only `True` and could be replaced by a real asymptotic statement using `Filter.Tendsto`. The basic properties `h_strictly_increasing`, `orbit_strictly_increasing`, `h_upper`, and `h_prime` are all proved in full Lean detail."
+      "**Proof structure**: The file has 1 `axiom` declaration (erdos_414_conjecture, the main open question). Two consequences (single_eventual_orbit and orbits_get_close) are proved as theorems from this axiom. The divisor bound τ(n) ≤ 2√n is proved in full Lean detail via a small/large divisor splitting argument. All 34 theorems are fully proved with no sorries."
     ],
     "prerequisites": [
       "Number theory: divisor functions and multiplicative functions",
@@ -177,7 +175,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This 178-line formalization captures the OPEN Erdős Problem #414: do all orbits of the iteration $h(n) = n + \\tau(n)$ eventually merge, where $\\tau(n)$ is the divisor count function? The formalization defines the orbit structure, proves basic properties (e.g., $h(n) > n$ so orbits are strictly increasing), axiomatizes the coalescence conjecture, and verifies small-case mergers computationally. The problem's difficulty is irreducibility: the divisor function $\\tau(n) = \\prod(e_i + 1)$ fluctuates wildly with the prime factorization of $n$, and proving two trajectories $h^i(m), h^j(n)$ eventually collide requires controlling cumulative irregularities across arbitrarily many steps. The heuristic that $\\tau(n)$ averages $\\ln n$ suggests orbits grow like $n + c \\cdot n\\ln n$ and should merge, but the gap between average behavior and pointwise control of specific trajectories remains unbridged.",
+    "summary": "This 302-line formalization captures the OPEN Erdős Problem #414: do all orbits of the iteration $h(n) = n + \\tau(n)$ eventually merge? The sole axiom is the conjecture itself; all 34 theorems are proved. The formalization proves basic properties ($h(n) > n$, $h(n) \\leq n + 2\\sqrt{n}$ via a fully proved $\\tau(n) \\leq 2\\sqrt{n}$ bound, $h(p) = p+2$ for primes), derives consequences of the conjecture (single eventual orbit, orbits get close), and verifies orbit merges for all starting values 1–10 computationally.",
     "implications": "A resolution would advance the theory of arithmetic dynamics — understanding when simple number-theoretic iterations have universal limiting behavior. The problem connects divisor function regularity (Dirichlet divisor problem), additive combinatorics (collision conditions), and discrete dynamical systems (orbit coalescence). Techniques developed for this problem could apply to the broader family of 'n + f(n)' iterations for multiplicative arithmetic functions f. The collision mechanism h(a) = h(b) when τ(a) - τ(b) = b - a connects to the distribution of values of τ, a classical topic in multiplicative number theory",
     "openQuestions": [
       "Does the merging conjecture hold? Can any pair of orbits be shown to collide?",
@@ -188,7 +186,7 @@
     ]
   },
   "leanFile": {
-    "lineCount": 301,
+    "lineCount": 302,
     "structureCount": 0,
     "axiomCount": 1,
     "theoremCount": 34,

--- a/src/data/research/problems/erdos-1012-oq-03.json
+++ b/src/data/research/problems/erdos-1012-oq-03.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ACT: directed_hamiltonian_threshold now FULLY PROVED via complete probabilistic counting argument. Only hBadFor_bound sorry remains inside hamiltonian_of_few_missing_arcs (fiber counting: |BadFor(a,b)| ≤ n*(n-2)!, suitable for Aristotle). ghouila_houri still sorry. 2 total sorries remain.",
+    "progressSummary": "ACT: Fixed ghouila_houri statement (floor→ceiling division bug). Restructured proof: main theorem proved via grow-cycle, 2 helper sorries remain (sc_degree_has_cycle, ghouila_houri_cycle_extendable).",
     "builtItems": [
       "Digraph structure with loopless axiom",
       "In-degree, out-degree, tournament, strong connectivity definitions",
@@ -53,7 +53,12 @@
       "hAllBad_lt proof: |AllBad| < n! via union bound + factorial chain + nlinarith (fully proved)",
       "hne proof: consecutive cycle entries are distinct, using rcases Nat.lt_or_ge for mod arithmetic (fully proved)",
       "Good permutation extraction + Hamiltonian cycle construction (fully proved)",
-      "directed_hamiltonian_threshold: (n-1)² < arcCount ∧ SC → HC (fully proved given hBadFor_bound)"
+      "directed_hamiltonian_threshold: (n-1)² < arcCount ∧ SC → HC (fully proved given hBadFor_bound)",
+      "Fixed ghouila_houri: changed n/2 to (n+1)/2 (ceiling division) — floor is wrong for n=3",
+      "grow_cycle_gh: well-founded recursion growing cycles to Hamiltonian (proved)",
+      "ghouila_houri: main theorem proved by delegating to sc_degree_has_cycle + grow_cycle_gh",
+      "sc_degree_has_cycle: cycle existence stub (sorry, needs SC + pigeonhole)",
+      "ghouila_houri_cycle_extendable: cycle extension stub (sorry, key case k=n-1 documented)"
     ],
     "insights": [
       "Ghouila-Houri (1960) is the directed Dirac theorem: min in/out-degree ≥ n/2 + strong connectivity → HC",
@@ -73,12 +78,17 @@
       "Finset.card_sdiff API changed: old form took a subset proof h, new form is (s\\t).card = s.card - (t∩s).card; fix: rw [Finset.card_sdiff, Finset.inter_univ]",
       "Variable modular arithmetic (i.val+1)%n: omega cannot handle — requires rcases Nat.lt_or_ge + Nat.mod_eq_of_lt / Nat.mod_self case split",
       "hBadFor_bound (|BadFor(a,b)| ≤ n*(n-2)!): fiber counting — for each position k, fixing σ(k)=α⁻¹(a) and σ((k+1)%n)=α⁻¹(b) leaves (n-2)! choices; n positions give n*(n-2)! total",
-      "arcCount synthesis: Fintype.card {p : V×V // P p} requires DecidablePred; fix via haveI := Classical.decPred _ + filter.card definition"
+      "arcCount synthesis: Fintype.card {p : V×V // P p} requires DecidablePred; fix via haveI := Classical.decPred _ + filter.card definition",
+      "CRITICAL BUG: floor(n/2) is insufficient for GH theorem. Counterexample: n=3, arcs={a↔b, a↔c}, SC with min-deg 1 but no HC",
+      "Directed path rotation (Dirac-style) does NOT work for directed graphs — cannot reverse path segments",
+      "Grow-cycle approach is correct for directed GH: get initial cycle from SC, extend using degree conditions",
+      "k=n-1 case is clean: |N⁺∩C|+|N⁻∩C| ≥ n+1 > n-1 forces insertability",
+      "k<n-1 case requires SC+S⁻/S⁺ partition argument (similar to tournament_cycle_extendable Case 2b)"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Submit hBadFor_bound to Aristotle: prove |BadFor(a,b)| ≤ n*(n-2)! via fiber counting argument",
-      "Prove ghouila_houri: directed analogue of Dirac's theorem (SC + min in/out-degree ≥ n/2). Requires full Hamiltonian extension machinery (~200 lines)."
+      "Prove sc_degree_has_cycle: SC + out-deg≥2 → directed cycle exists (pigeonhole on walks)",
+      "Prove ghouila_houri_cycle_extendable: key cases are k=n-1 (counting) and k<n-1 (SC partition)"
     ]
   },
   "tags": [

--- a/src/data/research/problems/erdos-414.json
+++ b/src/data/research/problems/erdos-414.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 19T/1A/0S (was 13T). Added h_lower_bound_ge2, h_four/five, orbit_linear_lower_ge2, orbit_5_merges_with_1.",
+    "progressSummary": "COMPLETE: 34T/1A/0S. 1 axiom is the main open conjecture. All supporting theory proved. Metadata cleaned.",
     "builtItems": [
       "Proved h_strictly_increasing, orbit_strictly_increasing, h_prime, h_one, h_two, h_three",
       "Proved orbit_1_start, orbit_3_merges_with_1 via native_decide",
@@ -39,7 +39,8 @@
       "h_lower_bound_ge2: h(n) ≥ n+2 for n ≥ 2 via {1,n} ⊆ divisors",
       "h_four=7, h_five=7: 4 and 5 merge at 7 under h",
       "orbit_linear_lower_ge2: h^k(n) ≥ n+2k for n ≥ 2",
-      "orbit_5_merges_with_1: orbit of 5 meets orbit of 1 at value 7"
+      "orbit_5_merges_with_1: orbit of 5 meets orbit of 1 at value 7",
+      "Fixed stale metadata: assumptions, keyInsights, proofStrategy — was claiming 3 axioms, now correctly reflects 1"
     ],
     "insights": [
       "10 of 14 axioms proved from definitions and Mathlib",
@@ -51,14 +52,11 @@
       "single_eventual_orbit is a formal consequence of erdos_414_conjecture + orbit determinism",
       "Orbit continuation: hOrbit a (i+d) = hOrbit b (j+d) when hOrbit a i = hOrbit b j",
       "h(4)=h(5)=7 is an immediate merge (both map to 7 in one step)",
-      "For n ≥ 2, τ(n) ≥ 2 via {1,n} ⊆ divisors; gives orbit growth ≥ n+2k"
+      "For n ≥ 2, τ(n) ≥ 2 via {1,n} ⊆ divisors; gives orbit growth ≥ n+2k",
+      "All prior nextSteps completed: divisor bound proved (divisors_card_le_two_sqrt), orbit merges extended to 10, average_divisor_count placeholder removed"
     ],
     "mathlibGaps": [],
-    "nextSteps": [
-      "Replace average_divisor_count placeholder (True := trivial) with a real bound",
-      "Extend orbit computations to show more merge points",
-      "Add τ(n) ≤ 2√n bound from Mathlib"
-    ],
+    "nextSteps": [],
     "markdown": "# Erdős #414 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $h_1(n)=h(n)=n+\\tau(n)$ (where $\\tau(n)$ counts the number of divisors of $n$) and $h_k(n)=h(h_{k-1}(n))$. Is it true, for any $m,n$, there exist $i$ and $j$ such that $h_i(m)=h_j(n)$?\n\n\n\nAsked by Spiro. That is, there is (eventually) only one possible sequence that the iterations of $n\\mapsto h(n)$ can settle on. Erd\\H{o}s and Graham believed the answer is yes. Similar questions can be asked by the iterates of many other functions. See also [412] and [413].\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #412\n- Problem #413\n- Problem #415\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary
- Fixed stale metadata for erdos-414 (assumptions count 3→1)
- Fixed Ghouila-Houri theorem statement bug (floor→ceiling division)
- Restructured GH proof: main theorem proved, 2 helper sorries remain

## Changes
### erdos-414
- Corrected assumptions list: only erdos_414_conjecture is an axiom
- Updated proofStrategy, keyInsights to reflect actual proof state

### erdos-1012-oq-03
- Bug: degree condition used floor(n/2), counterexample at n=3
- Fixed to ceiling (n+1)/2
- Proved main theorem + grow_cycle_gh via delegation
- 2 helper sorries: sc_degree_has_cycle, ghouila_houri_cycle_extendable

## Status
**Outcome**: progress
**Next**: Prove the 2 remaining helper lemmas

Generated by researcher-10