### PR TITLE
fix(meta): correct stale assumptions text in 2 gallery proofs

### DIFF
--- a/src/data/proofs/erdos-466/meta.json
+++ b/src/data/proofs/erdos-466/meta.json
@@ -26,7 +26,7 @@
     "date": "1970s-1976",
     "dateAdded": "2026-01-23",
     "axiomCount": 0,
-    "assumptions": "5 axiom declarations: erdos_466 (N(X,delta) tends to infinity), graham_logarithmic_bound (log X lower bound), sarkozy_polynomial_bound (polynomial improvement), maxSeparatedPoints_mono (monotone in X), maxSeparatedPoints_anti (anti-monotone in delta)",
+    "assumptions": "No axiom declarations. The main results (erdos_466, graham_logarithmic_bound, sarkozy_polynomial_bound, maxSeparatedPoints_mono, maxSeparatedPoints_anti) were previously axiomatized but have been removed from the Lean source. Only definitions and the fracDist_bound theorem remain.",
     "prerequisites": [
       "Diophantine approximation: fractional parts and distance to integers",
       "Discrete geometry: point configurations in disks and distance constraints",

--- a/src/data/proofs/liouville-theorem/meta.json
+++ b/src/data/proofs/liouville-theorem/meta.json
@@ -39,7 +39,7 @@
     ],
     "dateAdded": "2025-12-29",
     "axiomCount": 1,
-    "assumptions": "2 axiom declarations: liouville_approximation_theorem_axiom (algebraic approximation bound), roth_theorem (optimal exponent 2+epsilon). Previously axiomatized results now proved: liouville_uncountable_axiom (via Baire category), liouville_constant_irrational_axiom (via transcendence), liouville_add_rat_axiom (via LiouvilleWith.add_rat), liouville_mul_rat_axiom (via LiouvilleWith.rat_mul).",
+    "assumptions": "1 axiom declaration: roth_theorem (optimal exponent 2+epsilon). Previously axiomatized results now proved: liouville_approximation_theorem_axiom (via Mathlib's exists_pos_real_of_irrational_root + integer gap argument), liouville_uncountable_axiom (via Baire category), liouville_constant_irrational_axiom (via transcendence), liouville_add_rat_axiom (via LiouvilleWith.add_rat), liouville_mul_rat_axiom (via LiouvilleWith.rat_mul).",
     "lineCount": 528,
     "mathlib_version": "4.26.0"
   },


### PR DESCRIPTION
## Summary

- **erdos-466**: `assumptions` text claimed "5 axiom declarations" but the Lean source (`Proofs/Erdos466Problem.lean`) has 0 `axiom` declarations -- the axioms were removed and only definitions + `fracDist_bound` theorem remain. Updated text to match `axiomCount: 0`.
- **liouville-theorem**: `assumptions` text claimed "2 axiom declarations" but `liouville_approximation_theorem_axiom` is now a `theorem` (proved via Mathlib's `exists_pos_real_of_irrational_root`). Only `roth_theorem` remains as an axiom. Updated text to match `axiomCount: 1`.

Closes #N/A (mechanic maintenance task)

## Verification

- Counted `^axiom ` lines in both Lean source files
- Confirmed `axiomCount` values are already correct; only `assumptions` text was stale
- `pnpm build` passes

## Test plan

- [x] `grep -c "^axiom " proofs/Proofs/Erdos466Problem.lean` returns 0
- [x] `grep -c "^axiom " proofs/Proofs/LiouvilleTheorem.lean` returns 1
- [x] `pnpm build` succeeds
- [x] No axiomCount changes needed (values were already correct)

Generated with [Claude Code](https://claude.com/claude-code)