### PR TITLE
Enrich 9 gallery proofs: metadata, cross-refs, implications

### DIFF
--- a/src/data/proofs/central-limit-theorem-oq-02/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-02/meta.json
@@ -4,9 +4,11 @@
   "slug": "central-limit-theorem-oq-02",
   "description": "Formalizes the CLT beyond i.i.d. sequences to dependent random variables via two generalizations: the Martingale CLT (McLeish 1974) for martingale difference arrays with Lindeberg condition, and the α-mixing CLT (Ibragimov 1962) for stationary mixing sequences. Proves Lyapunov implies Lindeberg, i.i.d. variance convergence, and classical CLT recovery. 19 theorems, 1 axiom, 3 sorries.",
   "meta": {
-    "author": "Lean Genius",
-    "date": "2026-03-06",
+    "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Martingale_central_limit_theorem",
+    "date": "Classical (McLeish 1974, Ibragimov 1962); formalized 2026",
     "status": "axiomatized",
+    "mathlib_version": "4.26.0",
     "proofRepoPath": "Proofs/CentralLimitTheoremOQ02.lean",
     "tags": [
       "probability",
@@ -59,7 +61,7 @@
   },
   "conclusion": {
     "summary": "The CLT for dependent variables is formally developed: MDA structure, Lindeberg and Lyapunov conditions, α-mixing coefficients, and the classical recovery. Lyapunov implies Lindeberg is fully proved. The Martingale CLT (McLeish 1974) is axiomatized as the deep core result. 19 theorems, 6 definitions, 729 lines, 1 axiom, 3 sorries.",
-    "implications": "This formalization provides the foundational infrastructure for proving CLT-type results for stochastic processes in Lean 4. The MDA framework covers time series, Markov chains, and ergodic processes. Completing the sorries (particularly the Lindeberg condition for i.i.d. via DCT) would give a fully verified dependent CLT framework.",
+    "implications": "**Stochastic process infrastructure**: This formalization provides the foundational infrastructure for proving CLT-type results for stochastic processes in Lean 4. The MDA framework covers time series (ARMA, GARCH), Markov chains (via martingale approximation), and ergodic processes.\n\n**Financial mathematics**: The martingale CLT is the theoretical foundation for the Black-Scholes model: stock price increments form a martingale difference sequence, and the CLT gives the Gaussian limit underlying geometric Brownian motion. The mixing CLT applies to high-frequency trading data where temporal dependence decays.\n\n**Statistical estimation**: The dependent CLT is essential for proving asymptotic normality of estimators from dependent data. Maximum likelihood estimators for time series models, kernel density estimators for mixing processes, and sample means of Markov chains all require CLTs beyond the i.i.d. setting.\n\n**Completion path**: Completing the 3 sorries (i.i.d. Lindeberg via DCT, i.i.d. Lyapunov via rpow moment decay, and nested ciSup for independence) would give a fully verified dependent CLT framework. The hardest remaining piece is the axiomatized martingale_clt itself, which requires characteristic function methods and conditional expectation products not yet in Mathlib.",
     "openQuestions": [
       "Prove martingale_clt: formalize McLeish 1974 via characteristic function method",
       "Complete i.i.d. Lindeberg condition: DCT for truncated moment convergence",


### PR DESCRIPTION
Batch enrichment of 9 gallery proofs with quality improvements.

## Entries Enriched
1. **cauchy-schwarz-oq-02**: Added metadata, 3 cross-references
2. **cayley-hamilton-minpoly-oq-05-oq-02**: Tower annotation, verification section, expanded implications
3. **cauchy-schwarz-oq-01-oq-04** (Bessel): Metadata, header section, cross-references, expanded implications
4. **cauchy-schwarz-integral-oq-02-oq-02** (Hölder): Assembly section, expanded implications
5. **cantor-diagonalization-oq-01-oq-01-oq-02** (König): Header annotation, expanded implications
6. **kummer-theorem-oq-01** (Multinomial): Metadata, cross-references, split sections
7. **arithmetic-series-oq-02-oq-04-oq-01-oq-03** (Vandermonde): Fixed annotation range, added theorem statement
8. **central-limit-theorem-oq-02** (Dependent CLT): Metadata, expanded implications
9. **konigsberg-oq-03-oq-02** (Infinite Paths): Deepened context, fixed sections, cross-refs (PR #9990)

## Common improvements
- Added missing `sourceUrl`, `mathlib_version`, `author`, `date` fields
- Added cross-references between related proofs
- Expanded thin `conclusion.implications` with mathematical depth
- Added annotations for uncovered code sections
- Fixed section overlaps and line range inaccuracies