### PR TITLE
fix(meta): correct stale assumptions text in 10 gallery proofs

### DIFF
--- a/src/data/proofs/erdos-1127/meta.json
+++ b/src/data/proofs/erdos-1127/meta.json
@@ -54,7 +54,7 @@
     ],
     "dateAdded": "2026-01-19",
     "axiomCount": 5,
-    "assumptions": "10 axiom declarations: erdos_kakutani_equivalence (CH iff countable Q-independent union), q_linear_independent_distinct_distances (Q-independence implies distinct distances), ch_implies_1d_image_distinct (CH implies 1D distinct distances), ch_implies_1d_union_cover (CH implies 1D countable cover), davies_theorem (CH implies 2D decomposition), kunen_theorem (CH implies all-n decomposition), erdos_hajnal_necessity (finite partition fails without CH), finite_partition_impossible_without_ch (4 values insufficient for 6 distances), countable_vs_finite_distinction (countable vs finite threshold), erdos_distinct_distances_lower_bound (n/sqrt(log n) distinct distances)",
+    "assumptions": "5 axiom declarations: erdos_kakutani_equivalence (CH iff countable Q-independent union), ch_implies_1d_image_distinct (CH implies 1D distinct distances), ch_implies_1d_union_cover (CH implies 1D countable cover), davies_theorem (CH implies 2D decomposition), kunen_theorem (CH implies all-n decomposition). Former axioms q_linear_independent_distinct_distances, erdos_hajnal_necessity, finite_partition_impossible_without_ch, countable_vs_finite_distinction, erdos_distinct_distances_lower_bound now proved as theorems or definitions.",
     "lineCount": 279
   },
   "overview": {

--- a/src/data/proofs/erdos-187/meta.json
+++ b/src/data/proofs/erdos-187/meta.json
@@ -22,7 +22,7 @@
       "open"
     ],
     "axiomCount": 2,
-    "assumptions": "7 axiom declarations: maxMonoAPLength (max monochromatic AP length function), maxMonoAPLength_pos (maxMonoAPLength >= 1 for positive d), optAPBound (optimal AP bound function f(d)), vanDerWaerden_implies_growth (f(d) tends to infinity), beck_upper_bound (f(d) <= C*log_2(d) for large d), erdos_sqrt2_construction (sqrt(2)-coloring limits AP length to O(d)), erdos_187_optimal_bound (f(d) = Theta(log d) conjecture)",
+    "assumptions": "2 axiom declarations: maxMonoAPLength (max monochromatic AP length function for a coloring and difference), optAPBound (optimal AP bound function f(d)). Former axioms maxMonoAPLength_pos, vanDerWaerden_implies_growth, beck_upper_bound, erdos_sqrt2_construction, erdos_187_optimal_bound now proved as theorems or definitions.",
     "lineCount": 58,
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/erdos-216/meta.json
+++ b/src/data/proofs/erdos-216/meta.json
@@ -76,7 +76,7 @@
       "g_exists_iff characterization theorem"
     ],
     "axiomCount": 9,
-    "assumptions": "18 axiom declarations: InGeneralPosition (no three collinear), IsConvexKGon (convex k-gon predicate), convexKGon_card (k-gon vertex count), IsEmptyConvexKGon (empty interior predicate), emptyConvexKGon_sub (vertices in point set), g_3 (g(3) = 3), g_4 (g(4) = 5), g_5 (g(5) = 10), g_6 (g(6) = 30), horton_sets_exist (arbitrary-size Horton sets), g_ge_7_not_exists (no g(k) for k >= 7), g_lower_bound (g(k) >= 2k-3), horton_recursive (recursive Horton construction), horton_has_empty_6 (Horton sets have empty hexagons), happy_ending_exists (non-empty variant exists), empty_implies_nonempty (g(k) >= g'(k)), g_6_lower_witness (29-point no-hexagon witness), g_6_upper (30 points forces hexagon)",
+    "assumptions": "9 axiom declarations: InGeneralPosition (no three collinear predicate), IsConvexKGon (convex k-gon predicate), IsEmptyConvexKGon (empty interior predicate), g_3 (g(3)=3), g_4 (g(4)=5), g_5 (g(5)=10), g_6 (g(6)=30, Heule-Scheucher 2024), horton_sets_exist (arbitrary-size Horton sets), g_ge_7_not_exists (no g(k) for k>=7). Former axioms convexKGon_card, emptyConvexKGon_sub, g_lower_bound, horton_recursive, horton_has_empty_6, happy_ending_exists, empty_implies_nonempty, g_6_lower_witness, g_6_upper now proved as theorems or definitions.",
     "lineCount": 233
   },
   "overview": {

--- a/src/data/proofs/erdos-294/meta.json
+++ b/src/data/proofs/erdos-294/meta.json
@@ -56,7 +56,7 @@
     "erdosUrl": "https://erdosproblems.com/294",
     "erdosProblemStatus": "solved",
     "axiomCount": 4,
-    "assumptions": "12 axiom declarations: egyptian_236 ({2,3,6} represents 1), t_func_exists (t(N) exists), t_func_characterization (t(N) minimality), t_2 (t(2)=2), t_6_lower (t(6)>2), harmonic_asymptotic (H_N ~ log N), erdos_graham_1980 (upper bound t(N) << N/log N), liu_sawhney_2024 (matching lower bound), almost_all_work (density interpretation), f_func_exists (f(n) exists for n>=6), t_f_relationship (t and f connection), greedy_terminates (greedy algorithm halts)",
+    "assumptions": "4 axiom declarations: t_func_exists (t(N) exists for all N), erdos_graham_1980 (upper bound t(N) << N/log N), liu_sawhney_2024 (matching lower bound pinning t(N) up to polylog factors), f_func_exists (f(n) exists for n>=6). Former axioms egyptian_236, t_func_characterization, t_2, t_6_lower, harmonic_asymptotic, almost_all_work, t_f_relationship, greedy_terminates now proved as theorems or definitions.",
     "lineCount": 306
   },
   "overview": {

--- a/src/data/proofs/erdos-592/meta.json
+++ b/src/data/proofs/erdos-592/meta.json
@@ -43,7 +43,7 @@
       "partition_ordinal_classification: complete classification summary"
     ],
     "axiomCount": 2,
-    "assumptions": "10 axiom declarations: ordinalPartition, specker_beta_two, specker_finite_fail, chang_beta_omega, galvin_larson_necessary, cantorNFLength, schipperus_leq_two, schipperus_geq_four, erdos_592_open_case, partition_ordinal_classification",
+    "assumptions": "2 axiom declarations: ordinalPartition (ordinal Ramsey arrow alpha -> (alpha,k)^2 predicate), cantorNFLength (Cantor normal form length function). Former axioms specker_beta_two, specker_finite_fail, chang_beta_omega, galvin_larson_necessary, schipperus_leq_two, schipperus_geq_four, erdos_592_open_case, partition_ordinal_classification now proved as theorems or definitions.",
     "proofRepoPath": "Proofs/Erdos592Problem.lean",
     "lineCount": 65
   },

--- a/src/data/proofs/erdos-636/meta.json
+++ b/src/data/proofs/erdos-636/meta.json
@@ -65,7 +65,7 @@
       }
     ],
     "axiomCount": 2,
-    "assumptions": "9 axiom declarations: ramsey_graphs_exist (Ramsey graphs exist for n >= R(k,k)), erdos_faudree_sos (>= cn^{3/2} distinct signatures), kwan_sudakov (>= cn^{5/2} distinct signatures), signature_upper_bound (<= Cn^{5/2} signatures), ks_probabilistic_method (probabilistic argument), signature_distribution (signatures well-distributed), non_ramsey_smaller_bound (non-Ramsey can have fewer), ramsey_forces_complexity (Ramsey condition forces complexity), induced_path_count (counting induced paths/cycles)",
+    "assumptions": "2 axiom declarations: kwan_sudakov (Kwan-Sudakov 2021: Ramsey graphs have >= cn^{5/2} distinct signatures), signature_upper_bound (upper bound: <= Cn^{5/2} distinct signatures). Former axioms ramsey_graphs_exist, erdos_faudree_sos, ks_probabilistic_method, signature_distribution, non_ramsey_smaller_bound, ramsey_forces_complexity, induced_path_count now proved as theorems or definitions.",
     "lineCount": 261
   },
   "overview": {

--- a/src/data/proofs/erdos-736/meta.json
+++ b/src/data/proofs/erdos-736/meta.json
@@ -59,7 +59,7 @@
     ],
     "dateAdded": "2026-01-19",
     "axiomCount": 0,
-    "assumptions": "6 axiom declarations: komjath_shelah_consistency (ZFC-consistent counterexample), taylor_conjecture_independent (independent of ZFC), de_bruijn_erdos (finite chromatic compactness), chromatic_compactness (infinite chromatic compactness), chromatic_cardinal_interaction (cardinal arithmetic for chi), countable_case (countable chromatic number)",
+    "assumptions": "0 axiom declarations. All former axioms (komjath_shelah_consistency, taylor_conjecture_independent, de_bruijn_erdos, chromatic_compactness, chromatic_cardinal_interaction, countable_case) now proved as theorems or definitions. 1 sorry remains in finite_case.",
     "lineCount": 207,
     "theoremCount": 2,
     "prerequisites": [

--- a/src/data/proofs/erdos-867/meta.json
+++ b/src/data/proofs/erdos-867/meta.json
@@ -58,7 +58,7 @@
       "Connection to Problem 839 (infinite version)"
     ],
     "axiomCount": 1,
-    "assumptions": "9 axiom declarations: upperHalf_density (upper half achieves N/2), upperHalf_sumFree (upper half is sum-free), adenwalla_dyadic_bound (dyadic interval bound), adenwalla_upper_bound (2/3 + o(1) upper bound), freud_construction (19/36 density construction), coppersmith_phillips_lower (13/24 lower bound), coppersmith_phillips_upper (2/3 - 1/512 upper bound), problem_839_connection (infinite version bound), erdos_867_conjecture_false (N/2 conjecture disproved)",
+    "assumptions": "1 axiom declaration: coppersmith_phillips_lower (Coppersmith-Phillips 1996: maximum sum-free density >= 13/24). Former axioms upperHalf_density, upperHalf_sumFree, adenwalla_dyadic_bound, adenwalla_upper_bound, freud_construction, coppersmith_phillips_upper, problem_839_connection, erdos_867_conjecture_false now proved as theorems or definitions.",
     "lineCount": 288
   },
   "overview": {

--- a/src/data/proofs/erdos-928/meta.json
+++ b/src/data/proofs/erdos-928/meta.json
@@ -63,7 +63,7 @@
       "wang_conditional axiom: conditional on Elliott-Halberstam"
     ],
     "axiomCount": 4,
-    "assumptions": "14 axiom declarations: lpf_divides (largest prime divides n), lpf_prime (largest prime factor is prime), lpf_of_prime (P(p)=p for primes), dickman_function (Dickman rho function), dickman_at_one (rho(1)=1), dickman_at_two (rho(2) value), dickman_positive (rho positive), dickman_decreasing (rho decreasing), dickman_theorem (Psi asymptotic), infinitely_many_exist (Schinzel existence), teravainen_log_density (log density result), wang_conditional (natural density under EH), elliott_halberstam_conjecture (EH statement), schinzel_product (product smoothness)",
+    "assumptions": "4 axiom declarations: dickman_function (Dickman rho function definition), infinitely_many_exist (Schinzel/Meza: infinitely many consecutive smooth pairs exist), teravainen_log_density (Teravaeinen 2018: logarithmic density equals rho(1/alpha)*rho(1/beta)), wang_conditional (Wang 2021: natural density under Elliott-Halberstam conjecture). Former axioms lpf_divides, lpf_prime, lpf_of_prime, dickman_at_one, dickman_at_two, dickman_positive, dickman_decreasing, dickman_theorem, elliott_halberstam_conjecture, schinzel_product now proved as theorems or definitions.",
     "lineCount": 259
   },
   "overview": {

--- a/src/data/proofs/erdos-955/meta.json
+++ b/src/data/proofs/erdos-955/meta.json
@@ -65,7 +65,7 @@
     ],
     "dateAdded": "2026-01-19",
     "axiomCount": 2,
-    "assumptions": "13 axiom declarations: s_eq_s_alt (two s(n) definitions agree), six_perfect (6 is perfect), twentyeight_perfect (28 is perfect), forward_fails (forward density amplification), erdos_1973_empty_preimage (untouchable numbers exist), two_untouchable (2 is untouchable), five_untouchable (5 is untouchable), pollack_primes (primes preimage sparse), troupe_many_factors (many-factors preimage sparse), troupe_two_squares (sums-of-squares preimage sparse), ppt_bound (x^{1/2+o(1)} threshold), s_bound (s(n) growth bound), erdos_955_summary (combined partial results)",
+    "assumptions": "2 axiom declarations: ppt_bound (Pollack-Pomerance-Thompson 2018: if |A cap [1,x]| <= x^{1/2+o(1)} then s^{-1}(A) has density 0), erdos_955_summary (combined partial results: primes, sums of two squares, sparse sets). Former axioms s_eq_s_alt, six_perfect, twentyeight_perfect, forward_fails, erdos_1973_empty_preimage, two_untouchable, five_untouchable, pollack_primes, troupe_many_factors, troupe_two_squares, s_bound now proved as theorems or definitions.",
     "lineCount": 191
   },
   "overview": {


### PR DESCRIPTION
## Summary

- Corrected stale `assumptions` text in 10 gallery proof meta.json files where the text claimed axiom declarations that no longer exist in the Lean source (converted to theorems or definitions)
- The `axiomCount` field was already correct in all 10 cases; only the descriptive text was stale
- Each fix updates the count and lists only the axioms that actually exist as `axiom` declarations

**Affected proofs (old text count -> actual axiom count):**
- erdos-955: 13 -> 2
- erdos-928: 14 -> 4
- erdos-216: 18 -> 9
- erdos-294: 12 -> 4
- erdos-592: 10 -> 2
- erdos-867: 9 -> 1
- erdos-636: 9 -> 2
- erdos-736: 6 -> 0
- erdos-1127: 10 -> 5
- erdos-187: 7 -> 2

## Test plan

- [x] `pnpm build` passes
- [x] Each fix verified against actual `axiom` declarations in the Lean source
- [x] Only `assumptions` text field changed; `axiomCount` was already correct

Generated with [Claude Code](https://claude.com/claude-code)