### PR TITLE
Enrich Multinomial Kummer: add missing date field

### DIFF
--- a/src/data/proofs/kummer-theorem-oq-01/meta.json
+++ b/src/data/proofs/kummer-theorem-oq-01/meta.json
@@ -6,6 +6,7 @@
   "meta": {
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Kummer%27s_theorem",
+    "date": "Kummer 1852; multinomial extension formalized 2026",
     "status": "verified",
     "tags": [
       "combinatorics",


### PR DESCRIPTION
## Enrichment pass for kummer-theorem-oq-01

Minor fix for an already high-quality entry (96/100):
- Added missing `date` field: "Kummer 1852; multinomial extension formalized 2026"

**Axiom integrity:** Verified — 0 axioms, 0 sorries. `status: "verified"`, `badge: "mathlib"` correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)