### PR TITLE
Batch enrichment: König, Quasideterminants, Erdős #28, #485

### DIFF
--- a/src/data/proofs/erdos-485-oq-02/meta.json
+++ b/src/data/proofs/erdos-485-oq-02/meta.json
@@ -54,6 +54,7 @@
     "dateAdded": "2026-03-29",
     "axiomCount": 0,
     "lineCount": 327,
+    "theoremCount": 10,
     "assumptions": "0 axioms. 0 sorries. Fully verified.",
     "mathlib_version": "4.26.0"
   },
@@ -154,6 +155,11 @@
       "targetId": "erdos-485-oq-01",
       "relationship": "sibling",
       "description": "Sibling OQ: exact growth rate of f(k). Shares definitions and infrastructure."
+    },
+    {
+      "targetId": "erdos-28-additive-bases",
+      "relationship": "related",
+      "description": "Both concern additive combinatorics of integer sets: #28 studies representation functions and asymptotic bases, #485 studies support-size growth under polynomial squaring. The sumset machinery is shared."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Batch enrichment for multiple entries

### cantor-diagonalization-oq-01-oq-01-oq-02 (König's Cofinality)
- Added cross-reference to `continuum-hypothesis-oq-02`

### cramers-rule-oq-01-oq-02 (Quasideterminant Theory)
- Fixed `meta.theoremCount` 28 → 26
- Added missing `dateAdded` and `date` fields

### erdos-28-additive-bases (Erdős-Turán Conjecture)
- Fixed `meta.theoremCount` 15 → 19
- Added cross-references to `erdos-340` and `erdos-340-greedy-sidon`

### erdos-485-oq-02 (Combinatorial f(k) → ∞)
- Added missing `meta.theoremCount: 10`
- Added cross-reference to `erdos-28-additive-bases`

All entries verified for axiom integrity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)