### PR TITLE
fix(meta): correct sorry count for erdos-1012-oq-03 (1→2)

### DIFF
--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -13,10 +13,10 @@
       "tournaments"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 2,
     "axiomCount": 0,
-    "lineCount": 1205,
-    "assumptions": "0 axioms. 1 sorry: ghouila_houri (full proof needs longest-path argument ~200 lines tracking both in- and out-degrees). directed_hamiltonian_threshold is now fully proved (0 sorries): perm_arc_bad_card_le (≤ n*(n-2)! perms use any given arc) proved via Aristotle. Moon-Moser theorem and Rédei are also fully proved.",
+    "lineCount": 1283,
+    "assumptions": "0 axioms. 2 sorries in Ghouila-Houri helper lemmas: sc_degree_has_cycle (SC + high degree → initial directed cycle) and ghouila_houri_cycle_extendable (cycle of length k < n → longer cycle). The main ghouila_houri theorem is proved by delegating to these helpers. directed_hamiltonian_threshold is fully proved (0 sorries). Moon-Moser theorem and Rédei are also fully proved.",
     "dateAdded": "2026-03-30",
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Hamiltonian_path_problem#Directed_graphs",
@@ -123,9 +123,9 @@
       "Finset"
     ],
     "namespace": "Erdos1012OQ03",
-    "lineCount": 1205,
+    "lineCount": 1283,
     "axiomCount": 0,
-    "sorries": 1,
+    "sorries": 2,
     "path": "Proofs/Erdos1012OQ03.lean",
     "theoremCount": 20,
     "definitionCount": 10


### PR DESCRIPTION
## Summary

- Corrected `sorries` from 1 to 2 in both `meta` and `leanFile` sections of meta.json
- Updated `lineCount` from 1205 to 1283 to match actual Lean file
- Rewrote `assumptions` text to accurately identify the 2 sorry-carrying helper lemmas: `sc_degree_has_cycle` and `ghouila_houri_cycle_extendable`

## Evidence

The Lean file has sorry at lines 313 and 333. The main `ghouila_houri` theorem is proved by delegation to these two helpers. The file's own docstring (line 59) correctly documents "2 helper sorries" but meta.json was out of sync.

## Test plan

- [x] Verified sorry count by grep of Lean source
- [x] Confirmed line count with `wc -l`
- [x] No axioms or True stubs found

🤖 Generated with [Claude Code](https://claude.com/claude-code)