### PR TITLE
fix(meta): correct stale assumptions text for 10 gallery proofs (batch 22)

### DIFF
--- a/src/data/proofs/erdos-336/meta.json
+++ b/src/data/proofs/erdos-336/meta.json
@@ -54,7 +54,7 @@
     ],
     "axiomCount": 6,
     "lineCount": 161,
-    "assumptions": "12 axioms: erdos_graham_lower_1980, erdos_graham_upper_1980, grekos_lower_1988, and 9 more. See Lean source for complete statements."
+    "assumptions": "6 axioms: grekos_lower_1988, nash_upper_1993, h_2, h_3, example_order_2, example_exact_order_3. 0 sorries."
   },
   "overview": {
     "historicalContext": "This problem was introduced by Erdős and Graham in their 1980 paper 'On bases with an exact order'. A set A ⊆ ℕ is a basis of order r if every large integer can be written as a sum of at most r elements from A. It has exact order k if every large integer is a sum of exactly k elements. The function h(r) measures the maximum achievable exact order for a basis of order r.\n\nOrder and exact order can differ dramatically: the example A = ∪_{k≥0}(2^{2k}, 2^{2k+1}] has order 2 but exact order 3. Erdős-Graham established the initial bounds 1/4 ≤ lim h(r)/r² ≤ 5/4 and proved that A has exact order if and only if its consecutive differences are coprime.\n\nGrekos (1988) improved the lower bound to 1/3, and Nash (1993) improved the upper bound to 1/2. Plagne (2004) refined the lower-order terms. The exact value of the limit remains unknown, making this one of the longstanding open problems in additive combinatorics.",

--- a/src/data/proofs/erdos-368/meta.json
+++ b/src/data/proofs/erdos-368/meta.json
@@ -68,7 +68,7 @@
       }
     ],
     "lineCount": 353,
-    "assumptions": "11 axioms: primeFactors_product_coprime, F_eq_max, polya_theorem, and 8 more. See Lean source for complete statements."
+    "assumptions": "5 axioms: F_eq_max, polya_theorem, mahler_bound, schinzel_upper, pasten_bound. 0 sorries."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #368: Prime Factors of Consecutive Products**\n\nThis problem investigates the growth rate of the largest prime factor of products of consecutive integers n(n+1).\n\n**Key History:**\n- Pólya (1918): First proved F(n) → ∞ as n → ∞\n- Mahler (1935): Established F(n) ≫ log log n, the first quantitative bound\n- Schinzel (1967): Showed the upper bound F(n) ≤ n^(O(1/log log log n)) infinitely often\n- Erdős (1976): Conjectured F(n) ≈ (log n)² captures the true behavior\n- Pasten (2024): Proved F(n) ≫ (log log n)²/(log log log n), the strongest known lower bound\n\n**Mathematical Setting:**\nThe function F(n) = gpf(n(n+1)) captures how large prime factors must appear in products of consecutive integers. Since gcd(n, n+1) = 1, the prime factors of n(n+1) are the union of prime factors of n and n+1.",

--- a/src/data/proofs/erdos-375/meta.json
+++ b/src/data/proofs/erdos-375/meta.json
@@ -60,7 +60,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 308,
-    "assumptions": "7 axiom(s) and 5 sorry(s). See the Lean source for details."
+    "assumptions": "1 axiom: ramachandra_shorey_tijdeman. 0 sorries."
   },
   "overview": {
     "historicalContext": "**Erdos Problem #375: Grimm's Conjecture**\n\nThis conjecture was originally posed by C.A. Grimm in 1969 in the American Mathematical Monthly. It connects prime factorization with combinatorial matching theory.\n\n**The Core Question:**\nGiven any interval of k consecutive composite numbers (a 'prime gap'), can we always assign a distinct prime divisor to each composite?\n\n**Historical Progress:**\n- 1969: Grimm poses conjecture, proves k << log n / log log n\n- 1970s: Erdos-Selfridge extend to k <= (1+o(1)) log n\n- 1975: Ramachandra-Shorey-Tijdeman prove k << (log n / log log n)^3\n\n**Significance:**\nThis is listed as problem B32 in Guy's Unsolved Problems in Number Theory. It remains one of the most intriguing open problems connecting prime gaps to matching theory.",

--- a/src/data/proofs/erdos-391/meta.json
+++ b/src/data/proofs/erdos-391/meta.json
@@ -61,7 +61,7 @@
     ],
     "axiomCount": 5,
     "lineCount": 227,
-    "assumptions": "11 axioms: easy_upper_bound, acrstuv_theorem, limit_is_one_over_e, and 8 more. See Lean source for complete statements."
+    "assumptions": "5 axioms: easy_upper_bound, limit_is_one_over_e, second_order_correction, upper_bound_explicit, lower_bound_explicit. 0 sorries."
   },
   "overview": {
     "historicalContext": "Erdős Problem #391 asks about the most balanced way to write n! as a product of exactly n positive integers. Define t(n) as the maximum over all such factorizations of the minimum factor. The central question is: what is the asymptotic behavior of t(n)/n? It is easy to show that lim sup t(n)/n ≤ 1/e using Stirling's approximation, and Erdős asked whether the limit equals 1/e and whether a second-order correction of the form c/log(n) exists.\n\nThe problem has a remarkable history. Erdős, Selfridge, and Straus claimed to have proved lim t(n)/n = 1/e, and Straus was tasked with writing up the proof. However, Straus died suddenly and no trace of his notes was ever found. Erdős and Selfridge could never reconstruct the proof, so the result reverted to conjecture status. The problem also appears as B22 in Guy's \"Unsolved Problems in Number Theory\" and was studied by Guy and Selfridge (1998), who made explicit conjectures about upper and lower bounds.\n\nIn 2025, Alexeev, Conway, Rosenfeld, Sutherland, Tao, Uhr, and Ventullo resolved both questions completely. They proved t(n)/n = 1/e - c₀/log(n) + O(1/(log n)^{1+c}), where c₀ ≈ 0.3044 is an explicit constant. They also verified Guy-Selfridge conjectures: t(n) ≤ n/e for all n except 1, 2, and 4, and t(n) ≥ n/3 for n ≥ 43632, with 43632 being the optimal threshold.",

--- a/src/data/proofs/erdos-393/meta.json
+++ b/src/data/proofs/erdos-393/meta.json
@@ -56,7 +56,7 @@
     ],
     "axiomCount": 4,
     "lineCount": 177,
-    "assumptions": "10 axioms: f_exists, f_eq_one_iff_consecutive, berend_osgood_1992, and 7 more. See Lean source for complete statements."
+    "assumptions": "4 axioms: f_exists, berend_osgood_1992, bpz_2023, luca_2002. 0 sorries."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #393** concerns how factorials can be expressed as products of distinct integers.\n\n**Historical Development:**\n- **Erdős-Graham:** Posed the question, noted they didn't even know if f(n) = 1 infinitely often.\n- **1992 (Berend-Osgood):** Proved F_m(N) = o(N) for each fixed m.\n- **2002 (Luca):** Showed f(n) → ∞ conditionally on ABC conjecture.\n- **2023 (Bui-Pratt-Zaharescu):** Proved power saving F_m(N) ≪ N^{33/34}.\n\nThe problem connects to polynomial-factorial equations and the ABC conjecture.",

--- a/src/data/proofs/erdos-459/meta.json
+++ b/src/data/proofs/erdos-459/meta.json
@@ -60,7 +60,7 @@
     ],
     "axiomCount": 6,
     "lineCount": 231,
-    "assumptions": "12 axioms: f_lower_bound, f_upper_bound, f_prime, and 9 more. See Lean source for complete statements."
+    "assumptions": "6 axioms: f_lower_bound, f_upper_bound, f_prime, f_minimal_case, infinitely_many_minimal, infinitely_many_maximal. 0 sorries."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #459: Smooth Number Gaps**\n\nThis problem from Erdős-Graham (1980) asks to estimate f(u), where f(u) is the largest v such that no integer in (u, v) is 'smooth' with respect to u (i.e., composed only of primes dividing u).\n\n**Key History:**\n- Erdős-Graham (1980): Original problem in 'Old and new problems and results in combinatorial number theory'\n- Cambie (recent): Comprehensive observations settling the main questions\n- OEIS A289280: Sequence of f(n) values\n\n**Mathematical Setting:**\nA number m is 'smooth' with respect to n if all prime factors of m divide n. The function f(u) captures the gap until the next such smooth number after u.",

--- a/src/data/proofs/erdos-521/meta.json
+++ b/src/data/proofs/erdos-521/meta.json
@@ -58,7 +58,7 @@
     "dateAdded": "2026-01-19",
     "axiomCount": 5,
     "lineCount": 174,
-    "assumptions": "11 axioms: realRootCount, realRootCountInUnit, kac_constant_pos, and 8 more. See Lean source for complete statements."
+    "assumptions": "5 axioms: realRootCount, kac_constant_pos, varianceRealRoots, variance_bound, real_root_bound. 0 sorries."
   },
   "overview": {
     "historicalContext": "The study of real roots of random polynomials began with Bloch and Pólya (1932) and was revolutionized by Kac's 1943 integral formula, which computes E[Rₙ] as an explicit integral of a root density function. For Gaussian coefficients, Kac showed E[Rₙ] = (2/π + o(1))log n, where the logarithmic growth comes from the root density ρ_n(x) ≈ 1/(π|1-x²|^{1/2}) near x = ±1.\n\nErdős and Offord (1956) extended Kac's result to discrete ±1 coefficients, proving E[Rₙ] = (2/π + o(1))log n for random Littlewood polynomials f_n(z) = Σ εₖ z^k. Their proof uses combinatorial counting arguments rather than Kac's analytic integral. The natural follow-up question, attributed to Erdős, asks whether Rₙ/log n → 2/π holds almost surely (for almost every coefficient sequence), not just in expectation.\n\nDo (2024) made breakthrough progress by proving the almost sure result for roots in [-1,1]: a.s. lim Rₙ[-1,1]/log n = 1/π. Since asymptotically half the real roots lie in [-1,1] and half outside, this resolves exactly half the problem. The full conjecture — a.s. convergence for all real roots — remains open, requiring new techniques to handle roots near ±∞.",

--- a/src/data/proofs/erdos-543/meta.json
+++ b/src/data/proofs/erdos-543/meta.json
@@ -66,7 +66,7 @@
     ],
     "axiomCount": 2,
     "lineCount": 173,
-    "assumptions": "8 axioms: f, f_le_card, empty_spanning_iff, and 5 more. See Lean source for complete statements."
+    "assumptions": "2 axioms: f, chatgpt_tang_disproof. 0 sorries."
   },
   "overview": {
     "historicalContext": "Erdős and Rényi introduced this question in 1965 while developing probabilistic methods in group theory. They proved that f(N) ≤ log₂ N + O(log log N), where f(N) is the minimal random subset size needed to span an abelian group of size N via subset sums with probability at least 1/2. Erdős asked whether the O(log log N) term could be improved to o(log log N), but believed the answer was no.\n\nIn 1978, Erdős and Hall showed that the bound cannot even be improved to o(log log log N), providing evidence that the log log N term is inherent. This intermediate result foreshadowed the full resolution.\n\nThe conjecture was ultimately disproved by ChatGPT and Tang, who confirmed Erdős's prediction: the O(log log N) term in the Erdős-Rényi bound is optimal and cannot be improved to o(log log N). For sufficiently large primes p, a random subset of F_p of the prescribed size fails to generate all elements under subset sums. This resolves the problem in the negative.",

--- a/src/data/proofs/erdos-564/meta.json
+++ b/src/data/proofs/erdos-564/meta.json
@@ -47,7 +47,7 @@
     ],
     "axiomCount": 3,
     "lineCount": 207,
-    "assumptions": "9 axiom(s) and 1 sorry(s). See the Lean source for details."
+    "assumptions": "3 axioms: R, erdos_hajnal_rado_upper, erdos_hajnal_rado_lower. 0 sorries."
   },
   "overview": {
     "historicalContext": "This problem sits at the heart of hypergraph Ramsey theory, a generalization of classical Ramsey theory to k-uniform hypergraphs (where edges connect exactly k vertices rather than 2). For graphs (k = 2), Erdős and Szekeres (1935) showed that Ramsey numbers grow exponentially: roughly 2^{n/2} < R(n) < 4^n.\n\nFor 3-uniform hypergraphs (edges are triples), growth is dramatically faster. Erdős, Hajnal, and Rado proved in 1965 that 2^{cn²} < R₃(n) < 2^{2^n}. The lower bound is singly exponential in n², while the upper bound is a tower of exponentials of height 2.\n\nThe central question (Problem #564) asks whether the lower bound can be improved to match the tower height of the upper bound. If true, it would show that hypergraph Ramsey numbers are fundamentally 'tower-type' — requiring iterated exponentiation to describe. Erdős offered $500 for a resolution.",

--- a/src/data/proofs/erdos-573/meta.json
+++ b/src/data/proofs/erdos-573/meta.json
@@ -51,7 +51,7 @@
     "dateAdded": "2026-01-19",
     "axiomCount": 5,
     "lineCount": 177,
-    "assumptions": "11 axioms: exC3C4, exC4, exC3C4_le_exC4, and 8 more. See Lean source for complete statements."
+    "assumptions": "5 axioms: exC3C4, exC4, exC3C4_le_exC4, exC4C5, exC3C4_lower_bound. 0 sorries."
   },
   "overview": {
     "historicalContext": "This problem was posed by Erdős and Simonovits and concerns the Turán-type extremal function for graphs forbidding both triangles (C₃) and 4-cycles (C₄). The celebrated Kővári-Sós-Turán theorem from 1954 established that ex(n; C₄) ~ (1/2)n^(3/2). Erdős and Simonovits proved that ex(n; {C₄, C₅}) = (n/2)^(3/2) + O(n). This problem asks whether forbidding triangles instead of 5-cycles gives the same (n/2)^(3/2) asymptotic.\n\nThe question is subtle: while ex(n; {C₃, C₄}) ≤ ex(n; C₄) trivially, the conjectured asymptotic (n/2)^(3/2) is smaller than (1/2)n^(3/2) by a factor of √2. This would mean the triangle-free constraint actually reduces the leading constant.",


### PR DESCRIPTION
## Fix

Corrects stale `assumptions` text in 10 gallery proof `meta.json` files.

## Evidence

| Proof | Old count (text) | New count (actual) | Key axioms |
|-------|-----------------|-------------------|------------|
| erdos-336 | 12 | 6 | grekos_lower_1988, nash_upper_1993, h_2, h_3, example_order_2, example_exact_order_3 |
| erdos-368 | 11 | 5 | F_eq_max, polya_theorem, mahler_bound, schinzel_upper, pasten_bound |
| erdos-375 | 7 | 1 | ramachandra_shorey_tijdeman |
| erdos-391 | 11 | 5 | easy_upper_bound, limit_is_one_over_e, second_order_correction, upper_bound_explicit, lower_bound_explicit |
| erdos-393 | 10 | 4 | f_exists, berend_osgood_1992, bpz_2023, luca_2002 |
| erdos-459 | 12 | 6 | f_lower_bound, f_upper_bound, f_prime, f_minimal_case, infinitely_many_minimal, infinitely_many_maximal |
| erdos-521 | 11 | 5 | realRootCount, kac_constant_pos, varianceRealRoots, variance_bound, real_root_bound |
| erdos-543 | 8 | 2 | f, chatgpt_tang_disproof |
| erdos-564 | 9 | 3 | R, erdos_hajnal_rado_upper, erdos_hajnal_rado_lower |
| erdos-573 | 11 | 5 | exC3C4, exC4, exC3C4_le_exC4, exC4C5, exC3C4_lower_bound |

---
Automated fix by lean-mechanic agent.