### PR TITLE
fix(meta): correct stale assumptions text for 10 gallery proofs (batch 23)

### DIFF
--- a/src/data/proofs/erdos-1081/meta.json
+++ b/src/data/proofs/erdos-1081/meta.json
@@ -61,7 +61,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 335,
-    "assumptions": "7 axioms: squarefull_equiv, squarefull_count_asymptotic, odoni_disproof, and 4 more. See Lean source for complete statements."
+    "assumptions": "1 axiom: odoni_disproof. 0 sorries."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #1081: Sums of Two Squarefull Numbers**\n\nThis problem concerns the asymptotic behavior of integers expressible as sums of two squarefull (powerful) numbers.\n\n**Key History:**\n- Erdős (1976): Conjectured A(x) ~ c·x/√(log x) for some constant c > 0\n- Odoni (1981): Disproved the conjecture, showing A(x) grows faster\n- Baker-Brüdern (1994): Improved bounds\n- Blomer (2004): Further refinements using quadratic forms\n- Blomer-Granville (2006): Determined the correct exponent α = 1 - 2^(-1/3) ≈ 0.206\n\n**Mathematical Setting:**\nA squarefull number m is one where every prime divisor p satisfies p² | m. Equivalently, m can be written as a²b³ for positive integers a, b. The sequence begins: 1, 4, 8, 9, 16, 25, 27, 32, 36, 49, ...",

--- a/src/data/proofs/erdos-1105/meta.json
+++ b/src/data/proofs/erdos-1105/meta.json
@@ -61,7 +61,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 378,
-    "assumptions": "7 axiom(s) and 0 sorry(s). See the Lean source for details."
+    "assumptions": "1 axiom: ar_triangle. 0 sorries."
   },
   "overview": {
     "historicalContext": "Erdős, Simonovits, and Sós introduced anti-Ramsey theory in their 1975 paper, asking for the maximum number of colors in an edge-coloring of K_n that avoids a rainbow (all-distinct-colors) copy of a given graph G.\n\nThe problem connects Ramsey theory (which minimizes colors to force monochromatic subgraphs) with extremal graph theory. While classical Ramsey theory asks 'how many colors before monochromatic H?', anti-Ramsey asks 'how many colors while avoiding rainbow H?'\n\nThe case AR(n, C_3) = n - 1 was proven in the original paper. The general cycle formula remains open, while the path formula has seen recent progress with Yuan's 2021 announcement.",

--- a/src/data/proofs/erdos-111/meta.json
+++ b/src/data/proofs/erdos-111/meta.json
@@ -69,7 +69,7 @@
     ],
     "axiomCount": 4,
     "lineCount": 320,
-    "assumptions": "10 axioms: edgesToRemoveForBipartite, edgeDeletionFunction, chromaticNumber, and 7 more. See Lean source for complete statements."
+    "assumptions": "4 axioms: edgeDeletionFunction, cardinalChromaticNumber, h_at_least_linear, ehs_upper_bound. 0 sorries."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #111: Edge Deletion and Chromatic Number**\n\nThis problem explores the structure of graphs with uncountable chromatic number through the lens of bipartiteness. It was posed by Erdős, Hajnal, and Szemerédi in their 1982 paper \"On almost bipartite large chromatic graphs.\"\n\n**Key History:**\n- Erdős-Hajnal-Szemerédi (1982): Established that graphs with χ(G) = ℵ₁ satisfy h_G(n) ≫ n (they contain uncountably many vertex-disjoint odd cycles)\n- Erdős-Hajnal-Szemerédi (1982): Constructed a graph with χ = ℵ₁ where h_G(n) ≪ n^(3/2)\n- Erdős (1981): Conjectured this upper bound can be improved to n^(1+ε) for any ε > 0\n\n**Mathematical Setting:**\n- h_G(n) measures how \"far from bipartite\" the densest n-vertex subgraphs of G are\n- The chromatic number ℵ₁ is the smallest uncountable cardinal\n- Such graphs cannot be properly colored with countably many colors\n\nThe problem lies at the intersection of graph theory, combinatorics, and set theory, involving infinite structures that cannot be resolved by finite computation.",

--- a/src/data/proofs/erdos-146/meta.json
+++ b/src/data/proofs/erdos-146/meta.json
@@ -57,7 +57,7 @@
     "dateAdded": "2026-01-19",
     "axiomCount": 1,
     "lineCount": 215,
-    "assumptions": "7 axioms: turanNumber, aks_theorem, aks_special_case, and 4 more. See Lean source for complete statements."
+    "assumptions": "1 axiom: turanNumber. 0 sorries."
   },
   "overview": {
     "historicalContext": "Erdős and Simonovits conjectured in 1984 that the Turán number for any bipartite r-degenerate graph H satisfies ex(n;H) ≪ n^{2-1/r}. A graph is r-degenerate if every induced subgraph has a vertex of degree at most r. This elegant conjecture predicts that the extremal exponent depends only on the degeneracy parameter r, regardless of other structural properties of H. Erdős considered this problem important enough to offer a $500 prize for its resolution.\n\nThe best partial result was obtained by Alon, Krivelevich, and Sudakov (AKS) in 2003, who proved the weaker bound ex(n;H) ≪ n^{2-1/4r} using the dependent random choice technique. They also showed that the full conjectured bound holds in the special case where the maximum degree in one part of the bipartition equals r, which subsumes the classical Kővári-Sós-Turán theorem for complete bipartite graphs K_{r,s}.\n\nDespite decades of effort, the conjecture remains open even for r=2, where there is a substantial gap between the conjectured exponent 3/2 and the AKS bound 15/8. The difficulty lies in bridging local structure (degeneracy is a property of induced subgraphs) and global extremal behavior (Turán numbers depend on the entire graph). The problem is considered one of the most important open questions in extremal graph theory.",

--- a/src/data/proofs/erdos-161/meta.json
+++ b/src/data/proofs/erdos-161/meta.json
@@ -53,7 +53,7 @@
     ],
     "axiomCount": 4,
     "lineCount": 158,
-    "assumptions": "10 axioms: F, F_spec, erdos_hajnal_rado_conjecture, and 7 more. See Lean source for complete statements.",
+    "assumptions": "4 axioms: F, erdos_spencer_lower_bound, F3_characterization, one_jump_for_t3. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-309/meta.json
+++ b/src/data/proofs/erdos-309/meta.json
@@ -68,7 +68,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 339,
-    "assumptions": "7 axiom(s) and 3 sorry(s). See the Lean source for details."
+    "assumptions": "1 axiom: yokota_lower_bound_1997. 0 sorries."
   },
   "overview": {
     "historicalContext": "**Egyptian Fractions and Erdős's Question**\n\nThis problem concerns a fundamental question about **Egyptian fractions** - sums of distinct unit fractions 1/n. The ancient Egyptians represented all fractions this way.\n\n**The Question:** Given denominators from {1, ..., N}, how many integers can be represented as such sums? Specifically, is this count o(log N) (sublogarithmic)?\n\n**The Answer:** NO. The count F(N) grows like log N + γ, where γ ≈ 0.5772 is the Euler-Mascheroni constant.\n\n**Key Contributors:**\n- Yokota (1997): First logarithmic lower bound\n- Croot (1999): Exact threshold for representability\n- Yokota (2002): Refined bounds with (log log N)² correction\n\n**The harmonic number H_N = 1 + 1/2 + ... + 1/N ~ log N + γ** is central to understanding this problem, as representable integers are bounded by H_N.",

--- a/src/data/proofs/erdos-314/meta.json
+++ b/src/data/proofs/erdos-314/meta.json
@@ -57,7 +57,7 @@
     ],
     "axiomCount": 4,
     "lineCount": 222,
-    "assumptions": "10 axiom(s) and 1 sorry(s). See the Lean source for details."
+    "assumptions": "4 axioms: m_of_n, m_of_n_minimal, m_of_n_achieves, lim_steinerberger_theorem. 0 sorries."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #314: Harmonic Sum Error Term**\n\nThis problem from Erdős-Graham (1980) studies partial harmonic sums. Given n, let m(n) be the minimal integer such that the harmonic sum from n to m reaches at least 1. The error ε(n) is how much the sum overshoots 1.\n\n**Historical Development:**\n- **Erdős-Graham (1980):** Posed the question: is lim inf n²ε(n) = 0?\n- **Lim-Steinerberger (2024):** Proved YES with explicit bounds.\n\n**Key Insight:** Since harmonic sums grow like log(m/n), we have m(n) ≈ e·n. The question asks how precisely the sum can hit 1.",

--- a/src/data/proofs/erdos-33/meta.json
+++ b/src/data/proofs/erdos-33/meta.json
@@ -29,7 +29,7 @@
       "Waring's problem for squares",
       "Asymptotic density"
     ],
-    "assumptions": "7 axioms: erdos_existence_result, moser_lower_bound, cilleruelo_habsieger_lower_bound, and 4 more. See Lean source for complete statements.",
+    "assumptions": "1 axiom: cilleruelo_habsieger_lower_bound. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-330/meta.json
+++ b/src/data/proofs/erdos-330/meta.json
@@ -19,7 +19,7 @@
     "erdosUrl": "https://erdosproblems.com/330",
     "axiomCount": 1,
     "badge": "axiom",
-    "assumptions": "7 axioms: upperDensity, upperDensity_nonneg, upperDensity_le_one, and 4 more. See Lean source for complete statements.",
+    "assumptions": "1 axiom: upperDensity. 0 sorries.",
     "proofRepoPath": "Proofs/Erdos330Problem.lean",
     "mathlib_version": "4.26.0",
     "lineCount": 65

--- a/src/data/proofs/erdos-996/meta.json
+++ b/src/data/proofs/erdos-996/meta.json
@@ -80,7 +80,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 350,
-    "assumptions": "6 axiom(s). Known results (Raikov, KSZ, Erdős, Matsuyama, Parseval, Weyl) axiomatized. All provable theorems verified."
+    "assumptions": "1 axiom: matsuyama_1966. 0 sorries."
   },
   "overview": {
     "historicalContext": "Erdős Problem #996 sits at the intersection of harmonic analysis, probability theory, and ergodic theory. It concerns the strong law of large numbers for sequences evaluated along lacunary (exponentially growing) subsequences.\n\n**Origins in Weyl's Equidistribution (1916)**\n\nThe problem traces back to Weyl's theorem: for irrational α, the sequence {α}, {2α}, {3α}, ... is equidistributed mod 1. The natural question is what happens when we sample only at lacunary times n₁, n₂, ...\n\n**The Problem's Historical Progression**\n\nThe decay conditions required for the strong law were progressively weakened:\n- **Raikov**: Proved the strong law for geometric sequences nₖ = aᵏ unconditionally — no Fourier decay condition needed at all\n- **Kac-Salem-Zygmund (1948)**: First general result for lacunary sequences, requiring Fourier error ‖f - fₙ‖₂ = O(1/(log n)^c) for c > 1. The proof uses a Borel-Cantelli argument.\n- **Erdős (1949)**: Improved to O(1/(log log n)^c) for c > 1 — replacing log with log log, a dramatic weakening of the regularity assumption\n- **Matsuyama (1966)**: Further improved the exponent from c > 1 to c > 1/2 for log log decay. The exponent 1/2 is suggestive of the central limit theorem.\n\nThe open question asks whether we can push to log log log decay — adding yet another level of iterated logarithm to the hierarchy. The pattern of improvements suggests it might work, but current techniques cannot bridge the gap.",


### PR DESCRIPTION
## Fix

Corrects stale `assumptions` text in 10 gallery proof `meta.json` files.

## Evidence

| Proof | Old count (text) | New count (actual) | Key axioms |
|-------|-----------------|-------------------|------------|
| erdos-33 | 7 | 1 | cilleruelo_habsieger_lower_bound |
| erdos-111 | 10 | 4 | edgeDeletionFunction, cardinalChromaticNumber, h_at_least_linear, ehs_upper_bound |
| erdos-146 | 7 | 1 | turanNumber |
| erdos-161 | 10 | 4 | F, erdos_spencer_lower_bound, F3_characterization, one_jump_for_t3 |
| erdos-309 | 7 | 1 | yokota_lower_bound_1997 |
| erdos-314 | 10 | 4 | m_of_n, m_of_n_minimal, m_of_n_achieves, lim_steinerberger_theorem |
| erdos-330 | 7 | 1 | upperDensity |
| erdos-996 | 6 | 1 | matsuyama_1966 |
| erdos-1081 | 7 | 1 | odoni_disproof |
| erdos-1105 | 7 | 1 | ar_triangle |

---
Automated fix by lean-mechanic agent.