### PR TITLE
fix(meta): correct stale assumptions text for 10 gallery proofs (batch 24)

### DIFF
--- a/src/data/proofs/erdos-870/meta.json
+++ b/src/data/proofs/erdos-870/meta.json
@@ -65,7 +65,7 @@
       "Set theory (subsets, cardinality, Zorn's lemma for minimality)"
     ],
     "lineCount": 303,
-    "assumptions": "7 axiom(s) and 2 sorry(s). See the Lean source for details."
+    "assumptions": "2 axioms: hartter_nathanson_existence, erdos_nathanson_k2. 0 sorries."
   },
   "overview": {
     "historicalContext": "This problem asks about additive bases — sets A ⊆ N where every large integer is a sum of at most k elements from A. A minimal basis has no proper subset that is also a basis. Erdős and Nathanson (1979) proved that for k = 2, if representations grow logarithmically, the basis contains a minimal basis. Härtter (1956) and Nathanson (1974) showed that without growth conditions, bases may contain no minimal bases. The theory of additive bases originates with Waring's problem (1770) and Goldbach's conjecture (1742); Lagrange's four-square theorem (1770) shows the squares form a basis of order 4. The distinction between bases and minimal bases captures a fundamental redundancy phenomenon: most natural bases (squares, cubes, primes) are far from minimal.",

--- a/src/data/proofs/erdos-904/meta.json
+++ b/src/data/proofs/erdos-904/meta.json
@@ -69,7 +69,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 171,
-    "assumptions": "6 axioms: turan_triangle, edwards_1978, complete_bipartite_triangle_free, and 3 more. See Lean source for complete statements."
+    "assumptions": "1 axiom: edwards_1978. 0 sorries."
   },
   "overview": {
     "historicalContext": "Turán's theorem (1941) is the cornerstone of extremal graph theory: the maximum number of edges in a triangle-free graph on $n$ vertices is $\\lfloor n^2/4 \\rfloor$, achieved uniquely by the complete bipartite graph $K_{\\lfloor n/2 \\rfloor, \\lceil n/2 \\rceil}$. Any graph exceeding this threshold must contain a triangle.\n\nBéla Bollobás and Paul Erdős asked a deeper question: can we find not just ANY triangle, but one whose vertices have high combined degree? Specifically, they conjectured that any graph with $n$ vertices and more than $n^2/4$ edges contains a triangle $\\{x, y, z\\}$ with $d(x) + d(y) + d(z) \\geq \\frac{3}{2}n$. C.S. Edwards (1978) [Ed78] proved this conjecture using degree counting arguments and careful vertex selection.\n\nThe constant $\\frac{3}{2}$ is optimal: for any $\\varepsilon > 0$ and large $n$, there exist dense graphs where some triangle has degree sum below $(\\frac{3}{2}+\\varepsilon)n$. The result is an early example of 'structured extremal' results—not just proving existence of a subgraph, but finding one with additional properties. It prefigures modern supersaturation and stability results in extremal combinatorics.",

--- a/src/data/proofs/erdos-911/meta.json
+++ b/src/data/proofs/erdos-911/meta.json
@@ -53,7 +53,7 @@
     ],
     "axiomCount": 3,
     "lineCount": 238,
-    "assumptions": "8 axiom(s) and 0 sorry(s). Axioms: sizeRamseyNumber, sizeRamseyNumber_spec, sizeRamseyNumber_minimal, beck_path_size_ramsey, bounded_degree_linear_size_ramsey, complete_graph_size_ramsey, vertex_ramsey_number, size_ramsey_upper_bound."
+    "assumptions": "3 axioms: sizeRamseyNumber, sizeRamseyNumber_spec, vertex_ramsey_number. 0 sorries."
   },
   "overview": {
     "historicalContext": "Erdős posed this problem in 1982 [Er82e, p.78]. Size Ramsey numbers, introduced by Erdős, Faudree, Rousseau, and Schelp in 1978, measure the minimum edge complexity of Ramsey graphs.\n\nMajor results include:\n- Beck (1983): Paths have linear size Ramsey numbers R̂(Pₙ) = O(n)\n- Rödl-Szemerédi (2000): Complete graphs have R̂(Kₙ) = Θ(n²)\n- Kohayakawa-Rödl-Schacht-Szemerédi (2011): Bounded degree graphs have linear R̂\n\nThe question asks whether edge density forces additional Ramsey complexity. The motivation is that complete graphs K_n have Θ(n²) edges and R̂(K_n) = Θ(n²), giving R̂(G)/e(G) bounded — so no superlinear factor emerges even for the densest graphs. Erdős asked whether some dense family must exhibit superlinear R̂/e(G) growth, distinguishing density-driven complexity from degree-driven complexity established by the KRSS theorem.",

--- a/src/data/proofs/erdos-921/meta.json
+++ b/src/data/proofs/erdos-921/meta.json
@@ -56,7 +56,7 @@
     ],
     "axiomCount": 4,
     "lineCount": 169,
-    "assumptions": "9 axioms: chromaticNumber, oddGirth, f, and 6 more. See Lean source for complete statements."
+    "assumptions": "4 axioms: f, kierstead_szemeredi_trotter, gallai_lower_bound, erdos_upper_bound. 0 sorries."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #921**\n\nThis problem, posed jointly by Erdős and Gallai, explores the fundamental tension between a graph's chromatic number and its odd cycle structure.\n\n**Key History:**\n- **Gallai (1963):** Initiated the study by proving f_4(n) ≫ n^{1/2}, constructing explicit 4-chromatic graphs with large odd girth\n- **Erdős (unpublished):** Proved the matching upper bound f_4(n) ≪ n^{1/2}, showing the k=4 case is completely characterized\n- **Kierstead-Szemerédi-Trotter (1984):** Resolved the full conjecture for all k ≥ 4, proving f_k(n) ≍ n^{1/(k-2)}\n\n**Mathematical Significance:**\nThe result quantifies a deep principle: high chromatic number forces short odd cycles. A bipartite graph (χ = 2) has no odd cycles at all. As chromatic number increases, some odd cycles must appear, and this problem determines exactly how short they must be.",

--- a/src/data/proofs/erdos-922/meta.json
+++ b/src/data/proofs/erdos-922/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "solved",
     "axiomCount": 2,
     "lineCount": 220,
-    "assumptions": "7 axiom(s) and 4 sorry(s). Sorries: chromaticNumber' definition (line 65), folkman_zero_implies_bipartite (line 103), bipartite_chromatic_le_two (line 108), folkman_density_bound (line 165).",
+    "assumptions": "2 axioms: folkman_theorem, folkman_bound_tight. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-939/meta.json
+++ b/src/data/proofs/erdos-939/meta.json
@@ -44,7 +44,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 213,
-    "assumptions": "6 axioms: erdos939_existence, erdos939_infinite, nitaj_threepowerful_infinite, and 3 more. See Lean source for complete statements."
+    "assumptions": "1 axiom: cambie_r5_example. 0 sorries."
   },
   "overview": {
     "historicalContext": "An integer n is **r-powerful** (or r-full) if whenever a prime p divides n, we have p^r also divides n. For example, 8 = 2³ is 3-powerful since its only prime factor 2 appears with exponent 3.\n\nErdős posed a fascinating question about sums of r-powerful numbers: for r ≥ 4, can r-2 coprime r-powerful numbers sum to another r-powerful number? This connects to Euler's 1769 conjecture that k-1 k-th powers cannot sum to a k-th power.\n\nThe Euler conjecture was dramatically disproved in 1967 when Lander and Parkin found 27^5 + 84^5 + 110^5 + 133^5 = 144^5 by computer search. Since perfect k-th powers are trivially k-powerful, this inspired investigation of the more general r-powerful case.\n\nCambie found explicit examples for r = 5, 7, and 8, but whether such solutions exist for all r ≥ 4 remains open.",

--- a/src/data/proofs/erdos-956/meta.json
+++ b/src/data/proofs/erdos-956/meta.json
@@ -63,7 +63,7 @@
       "szemeredi-theorem"
     ],
     "axiomCount": 2,
-    "assumptions": "7 axiom declarations: f_upper_bound (SST n^(4/3) point bound), f_lower_bound (superlinear point lower bound), erdos_pach_upper_bound (translate n^(4/3) bound), erdos_pach_general (general convex n^(7/5) bound), lattice_construction (lattice unit distances), grid_construction (grid log factor construction), segment_case (line segment translate bound)",
+    "assumptions": "2 axioms: erdos_pach_upper_bound, grid_construction. 0 sorries.",
     "lineCount": 309
   },
   "overview": {

--- a/src/data/proofs/erdos-969/meta.json
+++ b/src/data/proofs/erdos-969/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "open",
     "axiomCount": 2,
     "lineCount": 229,
-    "assumptions": "7 axiom(s) and 0 sorry(s). Axioms encode mathematical hypotheses; sorries mark incomplete proofs.",
+    "assumptions": "2 axioms: elementary_upper_bound, evelyn_linfoot_lower_bound. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-978/meta.json
+++ b/src/data/proofs/erdos-978/meta.json
@@ -56,7 +56,7 @@
     ],
     "axiomCount": 3,
     "lineCount": 282,
-    "assumptions": "8 axioms: f_example_irreducible, erdos_1953_infinitely_many, hooley_1967_positive_density, and 5 more. See Lean source for complete statements."
+    "assumptions": "3 axioms: hooley_1967_positive_density, browning_2011, n4_plus_2_cubefree. 0 sorries."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #978: Power-Free Values of Polynomials**\n\nThis problem concerns the density of integers n for which f(n) avoids having high prime powers as divisors.\n\n**Key History:**\n- Erdős (1953): Infinitely many (d-1)-power-free values exist\n- Hooley (1967): Proved positive density for (d-1)-power-free with asymptotics\n- Heath-Brown (2006): Proved (d-2)-power-free result for d ≥ 10\n- Browning (2011): Extended to d ≥ 9 with asymptotic formula\n\n**Mathematical Setting:**\nA number n is k-power-free if no prime p satisfies p^k | n. Squarefree = 2-power-free, cubefree = 3-power-free. The question asks how often polynomial values are power-free.",

--- a/src/data/proofs/erdos-982/meta.json
+++ b/src/data/proofs/erdos-982/meta.json
@@ -67,7 +67,7 @@
     ],
     "axiomCount": 4,
     "lineCount": 337,
-    "assumptions": "9 axiom(s) and 4 sorry(s). See the Lean source for details."
+    "assumptions": "4 axioms: moser_bound, nppz_bound, regular_polygon_distances, stronger_conjecture_is_false. 0 sorries."
   },
   "overview": {
     "historicalContext": "**Erdos Problem #982** is a fundamental question in discrete geometry about the structure of convex polygons.\n\n**Historical Development:**\n- **1946**: Erdos posed the original problem in \"On sets of distances of n points\"\n- **1952**: Moser proved the first lower bound f(n) >= ceil(n/3)\n- **1994**: Erdos and Fishburn improved this to f(n) >= floor(n/3 + 1)\n- **2006**: Dumitrescu pushed the bound to approximately 0.361n\n- **2013**: Nivasch, Pach, Pinchasi, and Zerbib achieved f(n) >= (13/36 + 1/22701)n - O(1)\n\n**Related Conjectures:**\nErdos originally conjectured something stronger: that every convex polygon has a vertex with no three equidistant vertices. This was disproved (see Problem #97). He also conjectured a continuous version for convex curves, which Barany and Roldan-Pensado showed is false as stated (acute triangle boundaries are counterexamples).",


### PR DESCRIPTION
## Fix

Corrects stale `assumptions` text in 10 gallery proof `meta.json` files.

## Evidence

| Proof | Old count (text) | New count (actual) | Key axioms |
|-------|-----------------|-------------------|------------|
| erdos-870 | 7 | 2 | hartter_nathanson_existence, erdos_nathanson_k2 |
| erdos-904 | 6 | 1 | edwards_1978 |
| erdos-911 | 8 | 3 | sizeRamseyNumber, sizeRamseyNumber_spec, vertex_ramsey_number |
| erdos-921 | 9 | 4 | f, kierstead_szemeredi_trotter, gallai_lower_bound, erdos_upper_bound |
| erdos-922 | 7 | 2 | folkman_theorem, folkman_bound_tight |
| erdos-939 | 6 | 1 | cambie_r5_example |
| erdos-956 | 7 | 2 | erdos_pach_upper_bound, grid_construction |
| erdos-969 | 7 | 2 | elementary_upper_bound, evelyn_linfoot_lower_bound |
| erdos-978 | 8 | 3 | hooley_1967_positive_density, browning_2011, n4_plus_2_cubefree |
| erdos-982 | 9 | 4 | moser_bound, nppz_bound, regular_polygon_distances, stronger_conjecture_is_false |

---
Automated fix by lean-mechanic agent.