### PR TITLE
fix(meta): correct stale assumptions text for 10 gallery proofs (batch 27)

### DIFF
--- a/src/data/proofs/erdos-495/meta.json
+++ b/src/data/proofs/erdos-495/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-495",
-  "title": "Erdős Problem #495: The Littlewood Conjecture",
+  "title": "Erd\u0151s Problem #495: The Littlewood Conjecture",
   "slug": "erdos-495",
-  "description": "For all real α, β, is lim inf n·‖nα‖·‖nβ‖ = 0? The Littlewood conjecture on multiplicative Diophantine approximation, open since c. 1930.",
+  "description": "For all real \u03b1, \u03b2, is lim inf n\u00b7\u2016n\u03b1\u2016\u00b7\u2016n\u03b2\u2016 = 0? The Littlewood conjecture on multiplicative Diophantine approximation, open since c. 1930.",
   "meta": {
-    "author": "Littlewood (c. 1930 conjecture), Erdős [Er61]",
+    "author": "Littlewood (c. 1930 conjecture), Erd\u0151s [Er61]",
     "sourceUrl": "https://erdosproblems.com/495",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos495Problem.lean",
@@ -48,9 +48,9 @@
     "originalContributions": [
       "distInt definition: distance to nearest integer |x - round(x)|",
       "distInt_nonneg and distInt_le_half: basic properties",
-      "littlewoodProduct definition: n · ‖nα‖ · ‖nβ‖",
+      "littlewoodProduct definition: n \u00b7 \u2016n\u03b1\u2016 \u00b7 \u2016n\u03b2\u2016",
       "LittlewoodConjecture: infinitely-often formulation of the conjecture",
-      "littlewood_rational_case: conjecture holds for rational α",
+      "littlewood_rational_case: conjecture holds for rational \u03b1",
       "cassels_swinnerton_dyer_cubic: conjecture holds for cubic irrationals",
       "ekl_hausdorff_dimension_zero: EKL theorem (2006)",
       "PAdicLittlewood: p-adic variant definition",
@@ -58,19 +58,19 @@
     ],
     "axiomCount": 2,
     "lineCount": 178,
-    "assumptions": "7 axioms: distInt_nonneg, distInt_le_half, littlewoodProduct_nonneg, and 4 more. See Lean source for complete statements."
+    "assumptions": "2 axioms: littlewood_rational_case, ekl_countable_exceptions. 0 sorries."
   },
   "overview": {
-    "historicalContext": "The Littlewood conjecture, posed around 1930 by John Edensor Littlewood, is one of the most famous open problems in Diophantine approximation. It asks whether every pair of real numbers can be simultaneously well-approximated by rationals in a multiplicative sense: for all α, β ∈ ℝ, is lim inf n·‖nα‖·‖nβ‖ = 0?\n\nThe conjecture sits at the intersection of number theory, dynamical systems, and ergodic theory. Early progress came from Cassels and Swinnerton-Dyer (1955), who proved it for pairs of numbers in the same cubic number field. The problem was featured in Erdős's collection as Problem #495, referenced in [Er61].\n\nThe most dramatic breakthrough was by Einsiedler, Katok, and Lindenstrauss (2006), who proved that the set of counterexamples — if any exist — has Hausdorff dimension zero. Their proof, using the classification of invariant measures for diagonal actions on SL(3,ℝ)/SL(3,ℤ), earned Elon Lindenstrauss the 2010 Fields Medal. Despite this, the conjecture remains fully open: no single pair of algebraically independent reals has been verified.",
+    "historicalContext": "The Littlewood conjecture, posed around 1930 by John Edensor Littlewood, is one of the most famous open problems in Diophantine approximation. It asks whether every pair of real numbers can be simultaneously well-approximated by rationals in a multiplicative sense: for all \u03b1, \u03b2 \u2208 \u211d, is lim inf n\u00b7\u2016n\u03b1\u2016\u00b7\u2016n\u03b2\u2016 = 0?\n\nThe conjecture sits at the intersection of number theory, dynamical systems, and ergodic theory. Early progress came from Cassels and Swinnerton-Dyer (1955), who proved it for pairs of numbers in the same cubic number field. The problem was featured in Erd\u0151s's collection as Problem #495, referenced in [Er61].\n\nThe most dramatic breakthrough was by Einsiedler, Katok, and Lindenstrauss (2006), who proved that the set of counterexamples \u2014 if any exist \u2014 has Hausdorff dimension zero. Their proof, using the classification of invariant measures for diagonal actions on SL(3,\u211d)/SL(3,\u2124), earned Elon Lindenstrauss the 2010 Fields Medal. Despite this, the conjecture remains fully open: no single pair of algebraically independent reals has been verified.",
     "problemStatement": "Let $\\alpha, \\beta \\in \\mathbb{R}$. Is it true that\n$$\\liminf_{n \\to \\infty} n \\| n\\alpha \\| \\| n\\beta \\| = 0$$\nwhere $\\|x\\|$ denotes the distance from $x$ to the nearest integer?\n\n**Status: OPEN.** No counterexample is known, but the full conjecture has not been proved.",
-    "text": "For all real α, β, is lim inf n·‖nα‖·‖nβ‖ = 0? The Littlewood conjecture on multiplicative Diophantine approximation, open since c. 1930.",
-    "proofStrategy": "We formalize the Littlewood conjecture and its key partial results using axioms, since the conjecture is open and the known partial results rely on deep ergodic-theoretic and number-theoretic machinery beyond Mathlib.\n\n1. **Definitions:** We define distInt (distance to nearest integer) and the Littlewood product L(n, α, β) = n · ‖nα‖ · ‖nβ‖.\n\n2. **The Conjecture:** Stated as an infinitely-often condition — for every ε > 0 and every N, there exists n ≥ N with L(n, α, β) < ε.\n\n3. **Special Cases:** The rational case (trivial: ‖qα‖ = 0 when α = p/q) and Cassels–Swinnerton-Dyer (cubic number fields) are axiomatized.\n\n4. **The EKL Theorem:** Axiomatized as the statement that counterexamples have Hausdorff dimension zero.\n\n5. **p-adic Variant:** The de Mathan–Teulié conjecture and Badziahin–Velani partial result.",
+    "text": "For all real \u03b1, \u03b2, is lim inf n\u00b7\u2016n\u03b1\u2016\u00b7\u2016n\u03b2\u2016 = 0? The Littlewood conjecture on multiplicative Diophantine approximation, open since c. 1930.",
+    "proofStrategy": "We formalize the Littlewood conjecture and its key partial results using axioms, since the conjecture is open and the known partial results rely on deep ergodic-theoretic and number-theoretic machinery beyond Mathlib.\n\n1. **Definitions:** We define distInt (distance to nearest integer) and the Littlewood product L(n, \u03b1, \u03b2) = n \u00b7 \u2016n\u03b1\u2016 \u00b7 \u2016n\u03b2\u2016.\n\n2. **The Conjecture:** Stated as an infinitely-often condition \u2014 for every \u03b5 > 0 and every N, there exists n \u2265 N with L(n, \u03b1, \u03b2) < \u03b5.\n\n3. **Special Cases:** The rational case (trivial: \u2016q\u03b1\u2016 = 0 when \u03b1 = p/q) and Cassels\u2013Swinnerton-Dyer (cubic number fields) are axiomatized.\n\n4. **The EKL Theorem:** Axiomatized as the statement that counterexamples have Hausdorff dimension zero.\n\n5. **p-adic Variant:** The de Mathan\u2013Teuli\u00e9 conjecture and Badziahin\u2013Velani partial result.",
     "keyInsights": [
       "**Multiplicative vs Additive:** The Littlewood conjecture concerns multiplicative simultaneous approximation, which is much harder than the additive version (Dirichlet's theorem)",
-      "**Rational Case:** If α = p/q is rational, then ‖nα‖ = 0 whenever q | n, so the product vanishes — the conjecture is trivially true",
-      "**Cassels–Swinnerton-Dyer (1955):** The first non-trivial case: the conjecture holds when α and β lie in the same cubic number field (e.g., α = ∛2, β = (∛2)²)",
-      "**EKL Theorem (2006):** The set of counterexamples has Hausdorff dimension zero, proved via ergodic theory on homogeneous spaces — a Fields Medal result",
-      "**p-adic Extension:** The de Mathan–Teulié conjecture (2004) replaces one ‖·‖ factor with a p-adic valuation, also open"
+      "**Rational Case:** If \u03b1 = p/q is rational, then \u2016n\u03b1\u2016 = 0 whenever q | n, so the product vanishes \u2014 the conjecture is trivially true",
+      "**Cassels\u2013Swinnerton-Dyer (1955):** The first non-trivial case: the conjecture holds when \u03b1 and \u03b2 lie in the same cubic number field (e.g., \u03b1 = \u221b2, \u03b2 = (\u221b2)\u00b2)",
+      "**EKL Theorem (2006):** The set of counterexamples has Hausdorff dimension zero, proved via ergodic theory on homogeneous spaces \u2014 a Fields Medal result",
+      "**p-adic Extension:** The de Mathan\u2013Teuli\u00e9 conjecture (2004) replaces one \u2016\u00b7\u2016 factor with a p-adic valuation, also open"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -83,42 +83,42 @@
       "title": "Part I: Distance to Nearest Integer",
       "startLine": 39,
       "endLine": 57,
-      "summary": "Defines distInt x = |x - round(x)| and axiomatizes non-negativity and the bound distInt x ≤ 1/2."
+      "summary": "Defines distInt x = |x - round(x)| and axiomatizes non-negativity and the bound distInt x \u2264 1/2."
     },
     {
       "id": "littlewood-product",
       "title": "Part II: The Littlewood Product",
       "startLine": 58,
       "endLine": 72,
-      "summary": "Defines the Littlewood product L(n, α, β) = n · ‖nα‖ · ‖nβ‖ and axiomatizes non-negativity."
+      "summary": "Defines the Littlewood product L(n, \u03b1, \u03b2) = n \u00b7 \u2016n\u03b1\u2016 \u00b7 \u2016n\u03b2\u2016 and axiomatizes non-negativity."
     },
     {
       "id": "conjecture",
       "title": "Part III: The Littlewood Conjecture",
       "startLine": 73,
       "endLine": 87,
-      "summary": "States the Littlewood conjecture: for all α, β and ε > 0, infinitely many n satisfy L(n, α, β) < ε."
+      "summary": "States the Littlewood conjecture: for all \u03b1, \u03b2 and \u03b5 > 0, infinitely many n satisfy L(n, \u03b1, \u03b2) < \u03b5."
     },
     {
       "id": "special-cases",
       "title": "Part IV: Special Cases",
       "startLine": 88,
       "endLine": 112,
-      "summary": "Axiomatizes the rational case and Cassels–Swinnerton-Dyer (1955) for cubic irrationals."
+      "summary": "Axiomatizes the rational case and Cassels\u2013Swinnerton-Dyer (1955) for cubic irrationals."
     },
     {
       "id": "ekl-theorem",
       "title": "Part V: The EKL Theorem",
       "startLine": 113,
       "endLine": 137,
-      "summary": "Einsiedler–Katok–Lindenstrauss (2006): counterexamples are countable for each fixed α."
+      "summary": "Einsiedler\u2013Katok\u2013Lindenstrauss (2006): counterexamples are countable for each fixed \u03b1."
     },
     {
       "id": "padic",
       "title": "Part VI: The p-adic Littlewood Conjecture",
       "startLine": 138,
       "endLine": 164,
-      "summary": "Defines the p-adic Littlewood conjecture (de Mathan–Teulié 2004) and Badziahin–Velani (2014) partial result."
+      "summary": "Defines the p-adic Littlewood conjecture (de Mathan\u2013Teuli\u00e9 2004) and Badziahin\u2013Velani (2014) partial result."
     },
     {
       "id": "summary",
@@ -129,12 +129,12 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #495 is the Littlewood conjecture (c. 1930): for all α, β ∈ ℝ, lim inf n·‖nα‖·‖nβ‖ = 0. The conjecture is known for rationals (trivially), cubic irrationals (Cassels–Swinnerton-Dyer 1955), and almost all pairs (Einsiedler–Katok–Lindenstrauss 2006, Hausdorff dimension zero exceptions). It remains open in full generality — one of the great unsolved problems in number theory.",
-    "implications": "Resolution of the Littlewood conjecture would have profound consequences for simultaneous Diophantine approximation and our understanding of the interplay between additive and multiplicative number theory. The methods developed for partial results — particularly the EKL ergodic-theoretic approach — have already transformed the field of homogeneous dynamics and led to breakthroughs on other problems in number theory.",
+    "summary": "Erd\u0151s Problem #495 is the Littlewood conjecture (c. 1930): for all \u03b1, \u03b2 \u2208 \u211d, lim inf n\u00b7\u2016n\u03b1\u2016\u00b7\u2016n\u03b2\u2016 = 0. The conjecture is known for rationals (trivially), cubic irrationals (Cassels\u2013Swinnerton-Dyer 1955), and almost all pairs (Einsiedler\u2013Katok\u2013Lindenstrauss 2006, Hausdorff dimension zero exceptions). It remains open in full generality \u2014 one of the great unsolved problems in number theory.",
+    "implications": "Resolution of the Littlewood conjecture would have profound consequences for simultaneous Diophantine approximation and our understanding of the interplay between additive and multiplicative number theory. The methods developed for partial results \u2014 particularly the EKL ergodic-theoretic approach \u2014 have already transformed the field of homogeneous dynamics and led to breakthroughs on other problems in number theory.",
     "openQuestions": [
-      "Does there exist any explicit pair (α, β) of algebraically independent reals for which the conjecture can be verified?",
+      "Does there exist any explicit pair (\u03b1, \u03b2) of algebraically independent reals for which the conjecture can be verified?",
       "Can the EKL Hausdorff-dimension-zero result be strengthened to prove the full conjecture?",
-      "Is the p-adic Littlewood conjecture (de Mathan–Teulié) true for all primes p and all reals α?",
+      "Is the p-adic Littlewood conjecture (de Mathan\u2013Teuli\u00e9) true for all primes p and all reals \u03b1?",
       "What is the relationship between the Littlewood conjecture and the theory of continued fractions for pairs of reals?"
     ]
   },
@@ -160,17 +160,17 @@
     {
       "targetId": "erdos-254",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: diophantine-approximation, number-theory, open"
+      "description": "Related Erd\u0151s problem sharing themes: diophantine-approximation, number-theory, open"
     },
     {
       "targetId": "erdos-997",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: diophantine-approximation, number-theory, open"
+      "description": "Related Erd\u0151s problem sharing themes: diophantine-approximation, number-theory, open"
     },
     {
       "targetId": "erdos-1000",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: diophantine-approximation, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: diophantine-approximation, number-theory"
     }
   ]
 }

--- a/src/data/proofs/erdos-502/meta.json
+++ b/src/data/proofs/erdos-502/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-502",
-  "title": "Erdős Problem #502: Two-Distance Sets in Euclidean Space",
+  "title": "Erd\u0151s Problem #502: Two-Distance Sets in Euclidean Space",
   "slug": "erdos-502",
-  "description": "What is the maximum size f(n) of a set A ⊆ ℝⁿ with exactly two distinct pairwise distances? Bannai–Bannai–Stanton proved f(n) ≤ C(n+2,2); a projection construction gives f(n) ≥ C(n+1,2). Status: SOLVED.",
+  "description": "What is the maximum size f(n) of a set A \u2286 \u211d\u207f with exactly two distinct pairwise distances? Bannai\u2013Bannai\u2013Stanton proved f(n) \u2264 C(n+2,2); a projection construction gives f(n) \u2265 C(n+1,2). Status: SOLVED.",
   "meta": {
-    "author": "Erdős, Coxeter",
+    "author": "Erd\u0151s, Coxeter",
     "sourceUrl": "https://erdosproblems.com/502",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos502Problem.lean",
@@ -21,7 +21,7 @@
     "erdosProblemStatus": "solved",
     "axiomCount": 2,
     "lineCount": 82,
-    "assumptions": "7 axioms: binary_two_distances, lower_bound_basic, lower_bound_improved, and 4 more. See Lean source for complete statements.",
+    "assumptions": "2 axioms: lower_bound_improved, upper_bound_bbs. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "sections": [
@@ -46,8 +46,8 @@
       "title": "The Binary Vector Construction",
       "startLine": 37,
       "endLine": 50,
-      "summary": "Constructs `binaryTwoVec n i j` — indicator vectors $e_i + e_j \\in \\{0,1\\}^n$ — forming a two-distance set with distances $\\sqrt{2}$ (one shared coordinate) and $2$ (disjoint supports), giving $\\binom{n}{2}$ points.",
-      "mathContext": "Constructs `binaryTwoVec n i j` — indicator vectors $e_i + e_j \\in \\{0,1\\}^n$ — forming a two-distance set with distances $\\sqrt{2}$ (one shared coordinate) and $2$ (disjoint supports), giving $\\binom{n}{2}$ points."
+      "summary": "Constructs `binaryTwoVec n i j` \u2014 indicator vectors $e_i + e_j \\in \\{0,1\\}^n$ \u2014 forming a two-distance set with distances $\\sqrt{2}$ (one shared coordinate) and $2$ (disjoint supports), giving $\\binom{n}{2}$ points.",
+      "mathContext": "Constructs `binaryTwoVec n i j` \u2014 indicator vectors $e_i + e_j \\in \\{0,1\\}^n$ \u2014 forming a two-distance set with distances $\\sqrt{2}$ (one shared coordinate) and $2$ (disjoint supports), giving $\\binom{n}{2}$ points."
     },
     {
       "id": "lower-bound",
@@ -59,7 +59,7 @@
     },
     {
       "id": "upper-bound",
-      "title": "Upper Bound — Bannai–Bannai–Stanton",
+      "title": "Upper Bound \u2014 Bannai\u2013Bannai\u2013Stanton",
       "startLine": 61,
       "endLine": 68,
       "summary": "The BBS theorem: $f(n) \\leq \\binom{n+2}{2}$. The proof associates to each point a polynomial vanishing on the other distance, bounding the dimension of the resulting polynomial space by $\\binom{n+2}{2}$.",
@@ -83,16 +83,16 @@
     }
   ],
   "overview": {
-    "historicalContext": "H.S.M. Coxeter posed this problem to Erdős around 1961, asking whether the maximum size of a two-distance set in $\\mathbb{R}^n$ is polynomial in $n$. Erdős initially believed he could prove $f(n) \\leq n^{O(1)}$ but discovered an error, leaving only exponential bounds. The question remained open until Bannai, Bannai, and Stanton (1983) proved $f(n) \\leq \\binom{n+2}{2}$ using the polynomial method: for a two-distance set with distances $d_1, d_2$, the polynomials $p_a(x) = (\\|x-a\\|^2 - d_1^2)(\\|x-a\\|^2 - d_2^2)$ are linearly independent in a space of dimension $\\binom{n+2}{2}$, yielding the bound. Blokhuis (1984) simplified the argument using linear algebra over the Gram matrix. In 2021, Petrov and Pohoata gave an even simpler proof leveraging the Croot–Lev–Pach polynomial method from additive combinatorics. For the lower bound, the binary vector construction $\\{e_i + e_j : i < j\\}$ gives $\\binom{n}{2}$ points; a clever projection into $\\mathbb{R}^n$ from $\\mathbb{R}^{n+1}$ improves this to $\\binom{n+1}{2}$. The exact value $f(n)$ is known only for small $n$: Kelly (1947) showed $f(2) = 5$ (regular pentagon), and $f(3) = 6$ is classical.",
-    "problemStatement": "Given n, find the maximum cardinality f(n) of a finite set A ⊆ ℝⁿ such that the set of pairwise distances {|x-y| : x ≠ y ∈ A} has exactly two elements.",
-    "text": "What is the maximum size f(n) of a set A ⊆ ℝⁿ with exactly two distinct pairwise distances? Bannai–Bannai–Stanton proved f(n) ≤ C(n+2,2); a projection construction gives f(n) ≥ C(n+1,2). Status: SOLVED.",
-    "proofStrategy": "The formalization defines the two-distance set property, constructs binary vectors as witnesses for the lower bound, and states the Bannai–Bannai–Stanton upper bound. The main theorem combines both into the sandwich $\\binom{n+1}{2} \\leq f(n) \\leq \\binom{n+2}{2}$. Small cases $f(2) = 5$ and $f(3) = 6$ are axiomatized. Coxeter's polynomial growth question is resolved as a direct corollary of BBS.",
+    "historicalContext": "H.S.M. Coxeter posed this problem to Erd\u0151s around 1961, asking whether the maximum size of a two-distance set in $\\mathbb{R}^n$ is polynomial in $n$. Erd\u0151s initially believed he could prove $f(n) \\leq n^{O(1)}$ but discovered an error, leaving only exponential bounds. The question remained open until Bannai, Bannai, and Stanton (1983) proved $f(n) \\leq \\binom{n+2}{2}$ using the polynomial method: for a two-distance set with distances $d_1, d_2$, the polynomials $p_a(x) = (\\|x-a\\|^2 - d_1^2)(\\|x-a\\|^2 - d_2^2)$ are linearly independent in a space of dimension $\\binom{n+2}{2}$, yielding the bound. Blokhuis (1984) simplified the argument using linear algebra over the Gram matrix. In 2021, Petrov and Pohoata gave an even simpler proof leveraging the Croot\u2013Lev\u2013Pach polynomial method from additive combinatorics. For the lower bound, the binary vector construction $\\{e_i + e_j : i < j\\}$ gives $\\binom{n}{2}$ points; a clever projection into $\\mathbb{R}^n$ from $\\mathbb{R}^{n+1}$ improves this to $\\binom{n+1}{2}$. The exact value $f(n)$ is known only for small $n$: Kelly (1947) showed $f(2) = 5$ (regular pentagon), and $f(3) = 6$ is classical.",
+    "problemStatement": "Given n, find the maximum cardinality f(n) of a finite set A \u2286 \u211d\u207f such that the set of pairwise distances {|x-y| : x \u2260 y \u2208 A} has exactly two elements.",
+    "text": "What is the maximum size f(n) of a set A \u2286 \u211d\u207f with exactly two distinct pairwise distances? Bannai\u2013Bannai\u2013Stanton proved f(n) \u2264 C(n+2,2); a projection construction gives f(n) \u2265 C(n+1,2). Status: SOLVED.",
+    "proofStrategy": "The formalization defines the two-distance set property, constructs binary vectors as witnesses for the lower bound, and states the Bannai\u2013Bannai\u2013Stanton upper bound. The main theorem combines both into the sandwich $\\binom{n+1}{2} \\leq f(n) \\leq \\binom{n+2}{2}$. Small cases $f(2) = 5$ and $f(3) = 6$ are axiomatized. Coxeter's polynomial growth question is resolved as a direct corollary of BBS.",
     "keyInsights": [
       "**Binary vector construction**: Vectors $e_i + e_j \\in \\{0,1\\}^n$ give distances $\\sqrt{2}$ (shared coordinate) or $2$ (disjoint), yielding $\\binom{n}{2}$ points; projection improves this to $\\binom{n+1}{2}$",
       "**Polynomial method for upper bound**: For distances $d_1, d_2$, the polynomials $p_a(x) = (\\|x-a\\|^2 - d_1^2)(\\|x-a\\|^2 - d_2^2)$ are linearly independent in $\\mathbb{R}[x_1,\\ldots,x_n]_{\\leq 2}$, whose dimension is $\\binom{n+2}{2}$",
-      "**Tight quadratic growth**: The gap $\\binom{n+2}{2} - \\binom{n+1}{2} = n+1$ is small, so $f(n) = \\frac{n^2}{2} + O(n)$ — the answer is known up to a linear correction",
+      "**Tight quadratic growth**: The gap $\\binom{n+2}{2} - \\binom{n+1}{2} = n+1$ is small, so $f(n) = \\frac{n^2}{2} + O(n)$ \u2014 the answer is known up to a linear correction",
       "**Exceptional small cases**: $f(2) = 5$ (regular pentagon, beating $\\binom{3}{2} = 3$) shows the lower bound is not always tight; by $n = 3$, $f(3) = 6 = \\binom{4}{2}$ matches the lower bound exactly",
-      "**Evolution of proof techniques**: From Erdős's failed polynomial attempt (1961) through BBS's Gram matrix method (1983) to Petrov–Pohoata's Croot–Lev–Pach approach (2021) — each generation simplified the argument using new algebraic tools"
+      "**Evolution of proof techniques**: From Erd\u0151s's failed polynomial attempt (1961) through BBS's Gram matrix method (1983) to Petrov\u2013Pohoata's Croot\u2013Lev\u2013Pach approach (2021) \u2014 each generation simplified the argument using new algebraic tools"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -100,12 +100,12 @@
     ]
   },
   "conclusion": {
-    "summary": "Erdős Problem #502 asks for the maximum two-distance set in $\\mathbb{R}^n$. The answer is $\\Theta(n^2)$: the Bannai–Bannai–Stanton upper bound $\\binom{n+2}{2}$ and the projection lower bound $\\binom{n+1}{2}$ sandwich $f(n)$ with an additive gap of $n+1$. The formalization captures both bounds, the binary vector construction, exact small-case values, and the historical resolution of Coxeter's polynomial growth question.",
-    "implications": "**Theoretical Significance**: The polynomial method, first applied here by Bannai–Bannai–Stanton, became one of the most powerful tools in combinatorial geometry.\n\nIts descendant, the Croot–Lev–Pach method (2016), resolved the cap set problem and led to Petrov–Pohoata's simplified proof. The two-distance problem is a prototype for the general $k$-distance problem, where the polynomial method gives $f_k(n) \\leq \\binom{n+k}{k}$.",
+    "summary": "Erd\u0151s Problem #502 asks for the maximum two-distance set in $\\mathbb{R}^n$. The answer is $\\Theta(n^2)$: the Bannai\u2013Bannai\u2013Stanton upper bound $\\binom{n+2}{2}$ and the projection lower bound $\\binom{n+1}{2}$ sandwich $f(n)$ with an additive gap of $n+1$. The formalization captures both bounds, the binary vector construction, exact small-case values, and the historical resolution of Coxeter's polynomial growth question.",
+    "implications": "**Theoretical Significance**: The polynomial method, first applied here by Bannai\u2013Bannai\u2013Stanton, became one of the most powerful tools in combinatorial geometry.\n\nIts descendant, the Croot\u2013Lev\u2013Pach method (2016), resolved the cap set problem and led to Petrov\u2013Pohoata's simplified proof. The two-distance problem is a prototype for the general $k$-distance problem, where the polynomial method gives $f_k(n) \\leq \\binom{n+k}{k}$.",
     "openQuestions": [
       "Is $f(n) = \\binom{n+1}{2}$ for all sufficiently large $n$? This would close the linear gap between upper and lower bounds",
       "What is the structure of extremal two-distance sets? Are they related to strongly regular graphs or spherical designs?",
-      "For $k$-distance sets ($k \\geq 3$), the gap between lower and upper bounds widens — can it be narrowed?",
+      "For $k$-distance sets ($k \\geq 3$), the gap between lower and upper bounds widens \u2014 can it be narrowed?",
       "Does the answer change for two-distance sets on the sphere $S^{n-1}$ versus all of $\\mathbb{R}^n$?"
     ]
   },
@@ -127,28 +127,28 @@
     "sorries": 0
   },
   "references": [
-    "Erdős (1961): original problem, posed by Coxeter",
+    "Erd\u0151s (1961): original problem, posed by Coxeter",
     "Kelly (1947): early two-distance results in the plane",
-    "Bannai–Bannai–Stanton (1983): upper bound C(n+2,2) via polynomial method",
+    "Bannai\u2013Bannai\u2013Stanton (1983): upper bound C(n+2,2) via polynomial method",
     "Blokhuis (1984): simplified BBS proof using linear algebra",
-    "Petrov–Pohoata (2021): simpler proof via Croot–Lev–Pach polynomial method",
+    "Petrov\u2013Pohoata (2021): simpler proof via Croot\u2013Lev\u2013Pach polynomial method",
     "https://erdosproblems.com/502"
   ],
   "crossReferences": [
     {
       "targetId": "erdos-103",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: distances, geometry"
+      "description": "Related Erd\u0151s problem sharing themes: distances, geometry"
     },
     {
       "targetId": "erdos-1127",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: distances, geometry"
+      "description": "Related Erd\u0151s problem sharing themes: distances, geometry"
     },
     {
       "targetId": "erdos-217",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: distances, geometry"
+      "description": "Related Erd\u0151s problem sharing themes: distances, geometry"
     }
   ]
 }

--- a/src/data/proofs/erdos-512/meta.json
+++ b/src/data/proofs/erdos-512/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-512",
-  "title": "Erdős Problem #512: Littlewood's Conjecture on Exponential Sums",
+  "title": "Erd\u0151s Problem #512: Littlewood's Conjecture on Exponential Sums",
   "slug": "erdos-512",
-  "description": "For finite A ⊂ ℤ with |A| = N, is ∫₀¹ |∑_{n∈A} e(nθ)| dθ ≫ log N? SOLVED: YES (Konyagin 1981, McGehee-Pigno-Smith 1981).",
+  "description": "For finite A \u2282 \u2124 with |A| = N, is \u222b\u2080\u00b9 |\u2211_{n\u2208A} e(n\u03b8)| d\u03b8 \u226b log N? SOLVED: YES (Konyagin 1981, McGehee-Pigno-Smith 1981).",
   "meta": {
     "author": "Konyagin (1981), McGehee-Pigno-Smith (1981)",
     "sourceUrl": "https://erdosproblems.com/512",
@@ -27,17 +27,17 @@
     "mathlibDependencies": [
       {
         "theorem": "Complex.exp",
-        "description": "Complex exponential for e(x) = e^{2πix}, the fundamental character of ℝ/ℤ",
+        "description": "Complex exponential for e(x) = e^{2\u03c0ix}, the fundamental character of \u211d/\u2124",
         "module": "Mathlib.Data.Complex.Exponential"
       },
       {
         "theorem": "MeasureTheory.integral",
-        "description": "Bochner integration for the L¹ norm ∫₀¹ |S_A(θ)| dθ",
+        "description": "Bochner integration for the L\u00b9 norm \u222b\u2080\u00b9 |S_A(\u03b8)| d\u03b8",
         "module": "Mathlib.MeasureTheory.Integral.Bochner"
       },
       {
         "theorem": "Complex.abs",
-        "description": "Complex modulus for |∑ e(nθ)|, satisfying triangle inequality",
+        "description": "Complex modulus for |\u2211 e(n\u03b8)|, satisfying triangle inequality",
         "module": "Mathlib.Data.Complex.Exponential"
       },
       {
@@ -52,13 +52,13 @@
       }
     ],
     "originalContributions": [
-      "expTwoPiI: e(x) = e^{2πix} with proved periodicity, unit norm, and additivity",
-      "expSum, expSumNat, expSumNorm: exponential sum definitions for ℤ and ℕ",
-      "expSum_bound: triangle inequality |S_A(θ)| ≤ |A| (proved)",
-      "L1norm: Bochner integral ∫₀¹ |S_A(θ)| dθ with proved nonnegativity",
+      "expTwoPiI: e(x) = e^{2\u03c0ix} with proved periodicity, unit norm, and additivity",
+      "expSum, expSumNat, expSumNorm: exponential sum definitions for \u2124 and \u2115",
+      "expSum_bound: triangle inequality |S_A(\u03b8)| \u2264 |A| (proved)",
+      "L1norm: Bochner integral \u222b\u2080\u00b9 |S_A(\u03b8)| d\u03b8 with proved nonnegativity",
       "LittlewoodConjecture, LittlewoodConjecture': formal and asymptotic statements",
       "konyagin_theorem, mcgehee_pigno_smith_theorem: solution axioms",
-      "littlewoodConstant = 1/(4π): explicit constant",
+      "littlewoodConstant = 1/(4\u03c0): explicit constant",
       "littlewood_explicit: explicit lower bound axiom",
       "littlewood_sharpness: log N is optimal (axiom)",
       "geometricProgression, arithmetic_progression_bound: extremal example",
@@ -70,20 +70,20 @@
     ],
     "axiomCount": 2,
     "lineCount": 240,
-    "assumptions": "7 axiom(s) and 2 sorry(s). See the Lean source for details."
+    "assumptions": "2 axioms: konyagin_theorem, mcgehee_pigno_smith_theorem. 2 sorries."
   },
   "overview": {
-    "historicalContext": "Littlewood conjectured in the 1960s that the $L^1$ norm of any exponential sum with $N$ terms is at least $c \\log N$. Specifically, if $A \\subset \\mathbb{Z}$ is a finite set with $|A| = N$, then $\\int_0^1 |\\sum_{n \\in A} e^{2\\pi i n\\theta}|\\,d\\theta \\geq c \\log N$ for an absolute constant $c > 0$. This is a fundamental question about how \"flat\" a trigonometric polynomial with unit coefficients can be.\n\nThe conjecture was independently proved in 1981 by two groups. Konyagin gave an analytic proof using character sum estimates and concentration inequalities. McGehee, Pigno, and Smith gave an elegant proof based on Hardy's inequality for power series. The MPS approach is widely considered the more beautiful: they showed that Hardy's classical inequality $\\sum_{n=1}^\\infty \\frac{1}{n}(\\sum_{k=1}^n a_k)^2 \\leq 4\\sum a_n^2$ applied to the Fourier coefficients of $|S_A|$ directly yields the logarithmic lower bound via the harmonic series $\\sum_{k=1}^N 1/k \\sim \\log N$.\n\nThe bound is tight: the Dirichlet kernel $D_N(\\theta) = \\sum_{n=0}^{N-1} e^{2\\pi i n\\theta} = \\sin(N\\pi\\theta)/\\sin(\\pi\\theta)$ has $L^1$ norm $(4/\\pi^2)\\log N + O(1)$, which is the Lebesgue constant from classical Fourier analysis. This means arithmetic progressions are essentially the worst-case sets for Littlewood's bound.\n\nThe result connects to several areas: the flat polynomial problem (can $|P(z)|$ be nearly constant on $|z|=1$ for polynomials with $\\pm 1$ coefficients?), the Rudin-Shapiro construction, equidistribution theory via Weyl's criterion, and character sum bounds in analytic number theory. Erdős included it as Problem #512, emphasizing its role as a bridge between harmonic analysis and combinatorial number theory.",
-    "problemStatement": "**Problem Statement (Solved)**\n\nLet A ⊂ ℤ be a finite set with |A| = N, and let e(x) = e^{2πix}.\n\n**Question:** Is ∫₀¹ |∑_{n∈A} e(nθ)| dθ ≫ log N?\n\n**Answer: YES**\n\n- Konyagin (1981): First proof via analytic methods\n- McGehee-Pigno-Smith (1981): Independent proof via Hardy's inequality\n\nThere exists an absolute constant c > 0 (specifically c ≥ 1/(4π)) such that L¹ ≥ c log N for all finite A.",
-    "text": "For finite A ⊂ ℤ with |A| = N, is ∫₀¹ |∑_{n∈A} e(nθ)| dθ ≫ log N? SOLVED: YES (Konyagin 1981, McGehee-Pigno-Smith 1981).",
-    "proofStrategy": "The formalization builds from the ground up. First, the exponential function $e(x) = e^{2\\pi ix}$ is defined with its key properties proved: periodicity ($e(x+1) = e(x)$), unit norm ($|e(x)| = 1$), and multiplicativity ($e(x+y) = e(x)e(y)$). The exponential sum $S_A(\\theta)$ and its $L^1$ norm are then defined using Mathlib's Bochner integration.\n\nLittlewood's conjecture is formalized in two ways: the standard form ($\\exists c > 0$ with $L^1 \\geq c \\log N$) and an asymptotic form (constant approaching 1). Both solutions — Konyagin's and MPS's — are axiomatized with the explicit constant $c = 1/(4\\pi)$.\n\nThe sharpness section shows arithmetic progressions achieve $L^1 \\asymp \\log N$ (the Lebesgue constant). Hardy's discrete inequality is axiomatized and its role in the MPS proof noted. Parseval's theorem ($L^2 = \\sqrt{N}$), the flat polynomial connection, weighted generalizations, and applications to Diophantine approximation and number theory round out the formalization.",
+    "historicalContext": "Littlewood conjectured in the 1960s that the $L^1$ norm of any exponential sum with $N$ terms is at least $c \\log N$. Specifically, if $A \\subset \\mathbb{Z}$ is a finite set with $|A| = N$, then $\\int_0^1 |\\sum_{n \\in A} e^{2\\pi i n\\theta}|\\,d\\theta \\geq c \\log N$ for an absolute constant $c > 0$. This is a fundamental question about how \"flat\" a trigonometric polynomial with unit coefficients can be.\n\nThe conjecture was independently proved in 1981 by two groups. Konyagin gave an analytic proof using character sum estimates and concentration inequalities. McGehee, Pigno, and Smith gave an elegant proof based on Hardy's inequality for power series. The MPS approach is widely considered the more beautiful: they showed that Hardy's classical inequality $\\sum_{n=1}^\\infty \\frac{1}{n}(\\sum_{k=1}^n a_k)^2 \\leq 4\\sum a_n^2$ applied to the Fourier coefficients of $|S_A|$ directly yields the logarithmic lower bound via the harmonic series $\\sum_{k=1}^N 1/k \\sim \\log N$.\n\nThe bound is tight: the Dirichlet kernel $D_N(\\theta) = \\sum_{n=0}^{N-1} e^{2\\pi i n\\theta} = \\sin(N\\pi\\theta)/\\sin(\\pi\\theta)$ has $L^1$ norm $(4/\\pi^2)\\log N + O(1)$, which is the Lebesgue constant from classical Fourier analysis. This means arithmetic progressions are essentially the worst-case sets for Littlewood's bound.\n\nThe result connects to several areas: the flat polynomial problem (can $|P(z)|$ be nearly constant on $|z|=1$ for polynomials with $\\pm 1$ coefficients?), the Rudin-Shapiro construction, equidistribution theory via Weyl's criterion, and character sum bounds in analytic number theory. Erd\u0151s included it as Problem #512, emphasizing its role as a bridge between harmonic analysis and combinatorial number theory.",
+    "problemStatement": "**Problem Statement (Solved)**\n\nLet A \u2282 \u2124 be a finite set with |A| = N, and let e(x) = e^{2\u03c0ix}.\n\n**Question:** Is \u222b\u2080\u00b9 |\u2211_{n\u2208A} e(n\u03b8)| d\u03b8 \u226b log N?\n\n**Answer: YES**\n\n- Konyagin (1981): First proof via analytic methods\n- McGehee-Pigno-Smith (1981): Independent proof via Hardy's inequality\n\nThere exists an absolute constant c > 0 (specifically c \u2265 1/(4\u03c0)) such that L\u00b9 \u2265 c log N for all finite A.",
+    "text": "For finite A \u2282 \u2124 with |A| = N, is \u222b\u2080\u00b9 |\u2211_{n\u2208A} e(n\u03b8)| d\u03b8 \u226b log N? SOLVED: YES (Konyagin 1981, McGehee-Pigno-Smith 1981).",
+    "proofStrategy": "The formalization builds from the ground up. First, the exponential function $e(x) = e^{2\\pi ix}$ is defined with its key properties proved: periodicity ($e(x+1) = e(x)$), unit norm ($|e(x)| = 1$), and multiplicativity ($e(x+y) = e(x)e(y)$). The exponential sum $S_A(\\theta)$ and its $L^1$ norm are then defined using Mathlib's Bochner integration.\n\nLittlewood's conjecture is formalized in two ways: the standard form ($\\exists c > 0$ with $L^1 \\geq c \\log N$) and an asymptotic form (constant approaching 1). Both solutions \u2014 Konyagin's and MPS's \u2014 are axiomatized with the explicit constant $c = 1/(4\\pi)$.\n\nThe sharpness section shows arithmetic progressions achieve $L^1 \\asymp \\log N$ (the Lebesgue constant). Hardy's discrete inequality is axiomatized and its role in the MPS proof noted. Parseval's theorem ($L^2 = \\sqrt{N}$), the flat polynomial connection, weighted generalizations, and applications to Diophantine approximation and number theory round out the formalization.",
     "keyInsights": [
-      "**L¹ ≫ log N:** The lower bound is logarithmic — much smaller than the $L^2$ norm $\\sqrt{N}$ (Parseval) or the $L^\\infty$ norm $N$. This dramatic gap means exponential sums must concentrate: large near $\\theta = 0$ but experiencing deep cancellations elsewhere.",
+      "**L\u00b9 \u226b log N:** The lower bound is logarithmic \u2014 much smaller than the $L^2$ norm $\\sqrt{N}$ (Parseval) or the $L^\\infty$ norm $N$. This dramatic gap means exponential sums must concentrate: large near $\\theta = 0$ but experiencing deep cancellations elsewhere.",
       "**Sharpness via Dirichlet Kernel:** Arithmetic progressions $A = \\{0,\\ldots,N-1\\}$ achieve $\\|S_A\\|_1 = (4/\\pi^2)\\log N + O(1)$, the Lebesgue constant. This is the minimum possible, showing $\\log N$ is the exact growth rate.",
       "**Hardy's Inequality as the Key Tool:** The MPS proof reduces Littlewood's conjecture to Hardy's classical inequality. Applied to Fourier coefficients, it yields $\\|S_A\\|_1 \\geq \\sum_{n \\in A} 1/(|n|+1) \\geq c H_N \\sim c \\log N$ via the harmonic series.",
-      "**Independent Simultaneous Discovery:** Konyagin and MPS solved the conjecture in the same year (1981) using completely different methods — analytic concentration inequalities vs. classical inequalities. This illustrates mathematical ideas whose time has come.",
+      "**Independent Simultaneous Discovery:** Konyagin and MPS solved the conjecture in the same year (1981) using completely different methods \u2014 analytic concentration inequalities vs. classical inequalities. This illustrates mathematical ideas whose time has come.",
       "**No Flat Trigonometric Polynomials:** The result implies that no polynomial $P(z) = \\sum_{n \\in A} z^n$ with $|A| = N$ can have $|P(z)|$ nearly constant on $|z| = 1$. The $L^1$ norm must grow at least logarithmically.",
-      "**Explicit Constant c = 1/(4π):** The formalization includes an explicit constant. The optimal constant is believed to be close to $1/\\pi \\approx 0.318$, and improving it remains an active research topic."
+      "**Explicit Constant c = 1/(4\u03c0):** The formalization includes an explicit constant. The optimal constant is believed to be close to $1/\\pi \\approx 0.318$, and improving it remains an active research topic."
     ],
     "prerequisites": [
       "Fourier analysis on $\\\\mathbb{T}$ (exponential sums $e(n\\\\theta)$)",
@@ -105,7 +105,7 @@
     {
       "id": "exponential-functions",
       "title": "Exponential Functions",
-      "summary": "expTwoPiI definition e(x) = e^{2πix}; proved: periodicity (e(x+1) = e(x)), unit norm (|e(x)| = 1), multiplicativity (e(x+y) = e(x)e(y))",
+      "summary": "expTwoPiI definition e(x) = e^{2\u03c0ix}; proved: periodicity (e(x+1) = e(x)), unit norm (|e(x)| = 1), multiplicativity (e(x+y) = e(x)e(y))",
       "startLine": 37,
       "endLine": 60,
       "mathContext": "$e(x) = e^{2\\\\pi ix}$: periodic ($e(x+1)=e(x)$), unit modulus ($|e(x)|=1$), multiplicative ($e(x+y)=e(x)e(y)$). Foundation for Fourier analysis on $\\\\mathbb{T}$."
@@ -113,15 +113,15 @@
     {
       "id": "exponential-sums",
       "title": "Exponential Sums",
-      "summary": "expSum for ℤ and ℕ, expSumNorm modulus, expSum_bound (proved: triangle inequality |S_A| ≤ N)",
+      "summary": "expSum for \u2124 and \u2115, expSumNorm modulus, expSum_bound (proved: triangle inequality |S_A| \u2264 N)",
       "startLine": 61,
       "endLine": 85,
       "mathContext": "$S_A(\\\\theta) = \\\\sum_{n \\\\in A} e(n\\\\theta)$. Triangle inequality: $|S_A(\\\\theta)| \\\\leq N$. Equality iff all $e(n\\\\theta)$ are aligned (e.g. $\\\\theta=0$)."
     },
     {
       "id": "l1-norm",
-      "title": "The L¹ Norm",
-      "summary": "L1norm via Bochner integral on [0,1]; proved: nonnegativity; sorry: upper bound L¹ ≤ N",
+      "title": "The L\u00b9 Norm",
+      "summary": "L1norm via Bochner integral on [0,1]; proved: nonnegativity; sorry: upper bound L\u00b9 \u2264 N",
       "startLine": 86,
       "endLine": 105,
       "mathContext": "$\\\\|S_A\\\\|_1 = \\\\int_0^1 |\\\\sum_{n \\\\in A} e(n\\\\theta)| d\\\\theta$. The $L^1$ norm measures average cancellation. Non-negative, bounded above by $N$."
@@ -129,7 +129,7 @@
     {
       "id": "littlewood-conjecture",
       "title": "Littlewood's Conjecture",
-      "summary": "LittlewoodConjecture (∃c > 0, L¹ ≥ c log N) and asymptotic variant LittlewoodConjecture'",
+      "summary": "LittlewoodConjecture (\u2203c > 0, L\u00b9 \u2265 c log N) and asymptotic variant LittlewoodConjecture'",
       "startLine": 106,
       "endLine": 122,
       "mathContext": "Conjecture: $\\\\|S_A\\\\|_1 \\\\geq c\\\\log N$ for all $A$ with $|A|=N$. The logarithmic lower bound quantifies how much cancellation is inevitable."
@@ -137,7 +137,7 @@
     {
       "id": "solution",
       "title": "The Solution (1981)",
-      "summary": "konyagin_theorem and mcgehee_pigno_smith_theorem axioms; littlewoodConstant = 1/(4π); littlewood_explicit axiom",
+      "summary": "konyagin_theorem and mcgehee_pigno_smith_theorem axioms; littlewoodConstant = 1/(4\u03c0); littlewood_explicit axiom",
       "startLine": 123,
       "endLine": 141,
       "mathContext": "Konyagin (1981) and McGehee-Pigno-Smith (1981): $\\\\|S_A\\\\|_1 \\\\geq c\\\\log N$ with $c = 1/(8\\\\pi^2)$. Two independent proofs in the same year."
@@ -145,7 +145,7 @@
     {
       "id": "sharpness",
       "title": "Sharpness: log N is Optimal",
-      "summary": "littlewood_sharpness axiom; geometricProgression = {0,...,N-1}; arithmetic_progression_bound: L¹ ≍ log N for APs (Lebesgue constant)",
+      "summary": "littlewood_sharpness axiom; geometricProgression = {0,...,N-1}; arithmetic_progression_bound: L\u00b9 \u224d log N for APs (Lebesgue constant)",
       "startLine": 142,
       "endLine": 160,
       "mathContext": "Sharp: geometric progressions $A = \\\\{0,1,\\\\ldots,N-1\\\\}$ achieve $\\\\|S_A\\\\|_1 = \\\\Theta(\\\\log N)$. The Dirichlet kernel $\\\\sum_{n=0}^{N-1} e(n\\\\theta)$ has $L^1$ norm $\\\\sim (4/\\\\pi^2)\\\\log N$."
@@ -161,7 +161,7 @@
     {
       "id": "related-results",
       "title": "Related Results: Parseval, Flat Polynomials",
-      "summary": "L2_norm = √N (Parseval, sorry); L1 vs L2 comparison; flat polynomial problem connection",
+      "summary": "L2_norm = \u221aN (Parseval, sorry); L1 vs L2 comparison; flat polynomial problem connection",
       "startLine": 176,
       "endLine": 196,
       "mathContext": "$\\\\|S_A\\\\|_2 = \\\\sqrt{N}$ (Parseval). So $L^1 = \\\\Theta(\\\\log N) \\\\ll L^2 = \\\\sqrt{N}$: exponential sums have much more $L^1$ cancellation than $L^2$ suggests."
@@ -192,14 +192,14 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #512 (Littlewood's conjecture) asks whether ∫₀¹ |∑_{n∈A} e(nθ)| dθ ≫ log N for finite sets A with |A| = N. This was independently proved by Konyagin (1981, analytic methods) and McGehee-Pigno-Smith (1981, Hardy's inequality). The formalization captures the exponential function with proved properties, the L¹ norm via Bochner integration, both proofs as axioms, the explicit constant 1/(4π), sharpness via the Lebesgue constant for arithmetic progressions, and generalizations to weighted sums.",
+    "summary": "Erd\u0151s Problem #512 (Littlewood's conjecture) asks whether \u222b\u2080\u00b9 |\u2211_{n\u2208A} e(n\u03b8)| d\u03b8 \u226b log N for finite sets A with |A| = N. This was independently proved by Konyagin (1981, analytic methods) and McGehee-Pigno-Smith (1981, Hardy's inequality). The formalization captures the exponential function with proved properties, the L\u00b9 norm via Bochner integration, both proofs as axioms, the explicit constant 1/(4\u03c0), sharpness via the Lebesgue constant for arithmetic progressions, and generalizations to weighted sums.",
     "implications": "**Theoretical Significance**: Littlewood's conjecture is fundamental to harmonic analysis, establishing that trigonometric polynomials with unit coefficients cannot be flat on the circle.\n\nThe MPS proof established a deep connection between Hardy's classical inequality and modern Fourier analysis. The result has applications in Diophantine approximation (via Weyl's criterion), analytic number theory (character sum bounds), signal processing (spectral flatness), and the flat polynomial problem in complex analysis.",
     "openQuestions": [
-      "What is the exact value of the optimal constant c in ∫₀¹ |S_A| ≥ c log N? Best known: c ≥ 1/(4π), conjectured optimal: ~1/π.",
-      "Are there better lower bounds for structured sets — e.g., when A consists of primes or perfect squares?",
+      "What is the exact value of the optimal constant c in \u222b\u2080\u00b9 |S_A| \u2265 c log N? Best known: c \u2265 1/(4\u03c0), conjectured optimal: ~1/\u03c0.",
+      "Are there better lower bounds for structured sets \u2014 e.g., when A consists of primes or perfect squares?",
       "How do the bounds extend to weighted exponential sums with non-unit weights?",
-      "What are the precise asymptotics of min_A ‖S_A‖₁ for |A| = N? Is the second-order term known?",
-      "What are analogues of Littlewood's conjecture for exponential sums in higher dimensions over ℤ^d?"
+      "What are the precise asymptotics of min_A \u2016S_A\u2016\u2081 for |A| = N? Is the second-order term known?",
+      "What are analogues of Littlewood's conjecture for exponential sums in higher dimensions over \u2124^d?"
     ]
   },
   "leanFile": {
@@ -228,17 +228,17 @@
     {
       "targetId": "erdos-256",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: harmonic-analysis, solved"
+      "description": "Related Erd\u0151s problem sharing themes: harmonic-analysis, solved"
     },
     {
       "targetId": "erdos-484",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: fourier-analysis, solved"
+      "description": "Related Erd\u0151s problem sharing themes: fourier-analysis, solved"
     },
     {
       "targetId": "erdos-510",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: exponential-sums, harmonic-analysis"
+      "description": "Related Erd\u0151s problem sharing themes: exponential-sums, harmonic-analysis"
     }
   ]
 }

--- a/src/data/proofs/erdos-555/meta.json
+++ b/src/data/proofs/erdos-555/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-555",
-  "title": "Erdős Problem #555: Ramsey Numbers of Even Cycles",
+  "title": "Erd\u0151s Problem #555: Ramsey Numbers of Even Cycles",
   "slug": "erdos-555",
-  "description": "Determine R(C₂ₙ; k), the multicolor Ramsey number of even cycles. Erdős showed k^{1+1/(2n)} ≪ R(C₂ₙ; k) ≪ k^{1+1/(n-1)}. For C₄, Chung-Graham gave k²-k+1 < R(C₄;k) ≤ k²+k+1. The exact growth rate is open.",
+  "description": "Determine R(C\u2082\u2099; k), the multicolor Ramsey number of even cycles. Erd\u0151s showed k^{1+1/(2n)} \u226a R(C\u2082\u2099; k) \u226a k^{1+1/(n-1)}. For C\u2084, Chung-Graham gave k\u00b2-k+1 < R(C\u2084;k) \u2264 k\u00b2+k+1. The exact growth rate is open.",
   "meta": {
-    "author": "Erdős, Graham",
+    "author": "Erd\u0151s, Graham",
     "sourceUrl": "https://erdosproblems.com/555",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos555Problem.lean",
@@ -21,18 +21,18 @@
     "erdosProblemStatus": "open",
     "axiomCount": 0,
     "lineCount": 71,
-    "assumptions": "5 axiom(s). No sorries.",
+    "assumptions": "0 axioms. 0 sorries. All results formalized without axioms.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Erdős and Graham posed this problem asking for the precise growth rate of $R(C_{2n}; k)$, the multicolor Ramsey number of even cycles. For a fixed even cycle $C_{2n}$ and $k$ colors, $R(C_{2n}; k)$ is the minimum $m$ such that every $k$-coloring of $K_m$ contains a monochromatic $C_{2n}$. Erdős established the general bounds $k^{1+1/(2n)} \\ll R(C_{2n}; k) \\ll k^{1+1/(n-1)}$. The lower bound uses probabilistic or algebraic constructions (for $C_4$, the polarity graph of a finite projective plane provides the sharp construction). The upper bound relies on the Szemeredi regularity lemma or the dependent random choice technique to find long paths in dense monochromatic subgraphs. For the special case $C_4$ ($n = 2$), Chung and Graham (1975) proved the nearly tight bounds $k^2 - k + 1 < R(C_4; k) \\leq k^2 + k + 1$ when $k - 1$ is a prime power, connecting the problem to the existence of finite projective planes and the Zarankiewicz problem $z(m; 2, 2)$. The gap between the exponents $1/(2n)$ (lower) and $1/(n-1)$ (upper) represents one of the central open questions in Ramsey theory for sparse graphs. For $n = 2$, both exponents equal 1, so the $C_4$ case is resolved up to lower-order terms. For $n \\geq 3$, the gap is genuine and no improvements to either bound are known in general.",
+    "historicalContext": "Erd\u0151s and Graham posed this problem asking for the precise growth rate of $R(C_{2n}; k)$, the multicolor Ramsey number of even cycles. For a fixed even cycle $C_{2n}$ and $k$ colors, $R(C_{2n}; k)$ is the minimum $m$ such that every $k$-coloring of $K_m$ contains a monochromatic $C_{2n}$. Erd\u0151s established the general bounds $k^{1+1/(2n)} \\ll R(C_{2n}; k) \\ll k^{1+1/(n-1)}$. The lower bound uses probabilistic or algebraic constructions (for $C_4$, the polarity graph of a finite projective plane provides the sharp construction). The upper bound relies on the Szemeredi regularity lemma or the dependent random choice technique to find long paths in dense monochromatic subgraphs. For the special case $C_4$ ($n = 2$), Chung and Graham (1975) proved the nearly tight bounds $k^2 - k + 1 < R(C_4; k) \\leq k^2 + k + 1$ when $k - 1$ is a prime power, connecting the problem to the existence of finite projective planes and the Zarankiewicz problem $z(m; 2, 2)$. The gap between the exponents $1/(2n)$ (lower) and $1/(n-1)$ (upper) represents one of the central open questions in Ramsey theory for sparse graphs. For $n = 2$, both exponents equal 1, so the $C_4$ case is resolved up to lower-order terms. For $n \\geq 3$, the gap is genuine and no improvements to either bound are known in general.",
     "problemStatement": "Determine $R(C_{2n}; k)$: the minimum $m$ such that every $k$-coloring of the edges of $K_m$ yields a monochromatic copy of $C_{2n}$. In particular, determine the exact exponent $\\alpha_n$ such that $R(C_{2n}; k) = \\Theta(k^{1+\\alpha_n})$.",
-    "text": "Determine R(C₂ₙ; k), the multicolor Ramsey number of even cycles. Erdős showed k^{1+1/(2n)} ≪ R(C₂ₙ; k) ≪ k^{1+1/(n-1)}. For C₄, Chung-Graham gave k²-k+1 < R(C₄;k) ≤ k²+k+1. The exact growth rate is open.",
-    "proofStrategy": "The formalization defines cycle containment (via injective vertex sequences), multicolor edge colorings ($k$-colorings of $K_m$), and the monochromatic subgraph extraction. The Ramsey number $R(C_{2n}; k)$ is defined via Nat.find. Erdős's general bounds are stated as axioms. The Chung-Graham bounds for $C_4$ are axiomatized with the prime power condition on $k - 1$. The main open problem (existence of the exact exponent $\\alpha_n$) is stated as an axiom. The file has 1 sorry (symmetry of the coloring in the monochromatic subgraph construction).",
+    "text": "Determine R(C\u2082\u2099; k), the multicolor Ramsey number of even cycles. Erd\u0151s showed k^{1+1/(2n)} \u226a R(C\u2082\u2099; k) \u226a k^{1+1/(n-1)}. For C\u2084, Chung-Graham gave k\u00b2-k+1 < R(C\u2084;k) \u2264 k\u00b2+k+1. The exact growth rate is open.",
+    "proofStrategy": "The formalization defines cycle containment (via injective vertex sequences), multicolor edge colorings ($k$-colorings of $K_m$), and the monochromatic subgraph extraction. The Ramsey number $R(C_{2n}; k)$ is defined via Nat.find. Erd\u0151s's general bounds are stated as axioms. The Chung-Graham bounds for $C_4$ are axiomatized with the prime power condition on $k - 1$. The main open problem (existence of the exact exponent $\\alpha_n$) is stated as an axiom. The file has 1 sorry (symmetry of the coloring in the monochromatic subgraph construction).",
     "keyInsights": [
       "The lower bound $k^{1+1/(2n)}$ comes from algebraic/probabilistic constructions; for $C_4$, the polarity graph of $PG(2, k-1)$ is $C_4$-free with $k^2 - k + 1$ vertices",
       "The upper bound $k^{1+1/(n-1)}$ uses Szemeredi regularity or dependent random choice to find $C_{2n}$ in dense monochromatic subgraphs",
-      "For $C_4$ ($n = 2$), both exponent bounds give 1, so $R(C_4; k) \\sim k^2$ — the only resolved case",
+      "For $C_4$ ($n = 2$), both exponent bounds give 1, so $R(C_4; k) \\sim k^2$ \u2014 the only resolved case",
       "For $n \\geq 3$, the gap $1/(2n) < 1/(n-1)$ is genuine and closing it is a major open problem in extremal graph theory",
       "The connection to projective planes makes the $C_4$ case algebraic-geometric, while the general case remains purely combinatorial"
     ],
@@ -68,11 +68,11 @@
       "title": "Erdos General Bounds",
       "startLine": 58,
       "endLine": 71,
-      "summary": "Axioms: lower bound R(C_{2n}; k) ≥ c·k^{1+1/(2n)} and upper bound R(C_{2n}; k) ≤ C·k^{1+1/(n-1)} for n ≥ 2."
+      "summary": "Axioms: lower bound R(C_{2n}; k) \u2265 c\u00b7k^{1+1/(2n)} and upper bound R(C_{2n}; k) \u2264 C\u00b7k^{1+1/(n-1)} for n \u2265 2."
     }
   ],
   "conclusion": {
-    "summary": "The formalization captures Erdős Problem #555 on the exact growth rate of multicolor Ramsey numbers for even cycles. The Erdős bounds $k^{1+1/(2n)} \\ll R(C_{2n}; k) \\ll k^{1+1/(n-1)}$ and the sharp Chung-Graham bounds for $C_4$ are axiomatized. The central open question — determining $\\alpha_n$ for $n \\geq 3$ — is stated as an axiom. The single sorry is in the monochromatic subgraph symmetry proof.",
+    "summary": "The formalization captures Erd\u0151s Problem #555 on the exact growth rate of multicolor Ramsey numbers for even cycles. The Erd\u0151s bounds $k^{1+1/(2n)} \\ll R(C_{2n}; k) \\ll k^{1+1/(n-1)}$ and the sharp Chung-Graham bounds for $C_4$ are axiomatized. The central open question \u2014 determining $\\alpha_n$ for $n \\geq 3$ \u2014 is stated as an axiom. The single sorry is in the monochromatic subgraph symmetry proof.",
     "implications": "Resolving the exponent gap would advance the theory of Ramsey numbers for sparse graphs, with deep connections to finite geometry (projective planes for $C_4$), the regularity method, and the Zarankiewicz problem. The $C_4$ case illustrates how algebraic constructions can give sharp bounds, while the general case may require fundamentally new techniques.",
     "openQuestions": [
       "What is the exact exponent $\\alpha_n$ in $R(C_{2n}; k) = \\Theta(k^{1+\\alpha_n})$ for $n \\geq 3$?",
@@ -102,17 +102,17 @@
     {
       "targetId": "erdos-1013",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: Ramsey theory, graph theory"
+      "description": "Related Erd\u0151s problem sharing themes: Ramsey theory, graph theory"
     },
     {
       "targetId": "erdos-1177",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: Ramsey theory, graph theory"
+      "description": "Related Erd\u0151s problem sharing themes: Ramsey theory, graph theory"
     },
     {
       "targetId": "erdos-151",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: Ramsey theory, graph theory"
+      "description": "Related Erd\u0151s problem sharing themes: Ramsey theory, graph theory"
     }
   ]
 }

--- a/src/data/proofs/erdos-562/meta.json
+++ b/src/data/proofs/erdos-562/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-562",
-  "title": "Erdős Problem #562: Hypergraph Ramsey Number Tower Growth",
+  "title": "Erd\u0151s Problem #562: Hypergraph Ramsey Number Tower Growth",
   "slug": "erdos-562",
-  "description": "For r ≥ 3, prove that log_{r-1} R_r(n) ≍ n, where R_r(n) is the r-uniform hypergraph Ramsey number. Upper bound: twr_{r-1}(O(n²)) from Erdős–Rado. Lower: twr_{r-1}(Ω(n)). Status: OPEN.",
+  "description": "For r \u2265 3, prove that log_{r-1} R_r(n) \u224d n, where R_r(n) is the r-uniform hypergraph Ramsey number. Upper bound: twr_{r-1}(O(n\u00b2)) from Erd\u0151s\u2013Rado. Lower: twr_{r-1}(\u03a9(n)). Status: OPEN.",
   "meta": {
     "erdosNumber": 562,
     "status": "axiomatized",
@@ -19,7 +19,7 @@
     "erdosUrl": "https://erdosproblems.com/562",
     "axiomCount": 2,
     "badge": "axiom",
-    "assumptions": "7 axioms: erdos_szekeres_lower, erdos_szekeres_upper, erdos_rado_stepping_up, and 4 more. See Lean source for complete statements.",
+    "assumptions": "2 axioms: erdos_szekeres_lower, erdos_szekeres_upper. 0 sorries.",
     "proofRepoPath": "Proofs/Erdos562Problem.lean",
     "mathlib_version": "4.26.0",
     "lineCount": 85
@@ -52,22 +52,22 @@
     {
       "id": "graph-ramsey",
       "title": "Classical Graph Ramsey ($r = 2$)",
-      "summary": "Erdős-Szekeres bounds $2^{n/2} \\leq R(n,n) \\leq 4^n$ establishing exponential growth, combined into $R_2(n) = \\mathrm{twr}_1(\\Theta(n))$",
+      "summary": "Erd\u0151s-Szekeres bounds $2^{n/2} \\leq R(n,n) \\leq 4^n$ establishing exponential growth, combined into $R_2(n) = \\mathrm{twr}_1(\\Theta(n))$",
       "startLine": 51,
       "endLine": 64,
-      "mathContext": "Erdős-Szekeres bounds $$$2^{{n/2}$}$ \\leq R(n,n) \\leq $4^{n}$$ establishing exponential growth, combined into $R_2(n) = \\mathrm{twr}_1(\\Theta(n))$"
+      "mathContext": "Erd\u0151s-Szekeres bounds $$$2^{{n/2}$}$ \\leq R(n,n) \\leq $4^{n}$$ establishing exponential growth, combined into $R_2(n) = \\mathrm{twr}_1(\\Theta(n))$"
     },
     {
       "id": "stepping-up",
-      "title": "Erdős-Rado Stepping-Up Upper Bound",
-      "summary": "For $r \\geq 3$: $R_r(n) \\leq \\mathrm{twr}_{r-1}(c_r \\cdot n^2)$ — each uniformity increase adds one tower level with quadratic penalty",
+      "title": "Erd\u0151s-Rado Stepping-Up Upper Bound",
+      "summary": "For $r \\geq 3$: $R_r(n) \\leq \\mathrm{twr}_{r-1}(c_r \\cdot n^2)$ \u2014 each uniformity increase adds one tower level with quadratic penalty",
       "startLine": 66,
       "endLine": 72,
-      "mathContext": "For $r \\geq 3$: $R_r(n) \\leq \\mathrm{twr}_{r-1}(c_r \\cdot $n^{2}$)$ — each uniformity increase adds one tower level with quadratic penalty"
+      "mathContext": "For $r \\geq 3$: $R_r(n) \\leq \\mathrm{twr}_{r-1}(c_r \\cdot $n^{2}$)$ \u2014 each uniformity increase adds one tower level with quadratic penalty"
     },
     {
       "id": "r3-lower",
-      "title": "Erdős-Hajnal Lower Bound ($r = 3$)",
+      "title": "Erd\u0151s-Hajnal Lower Bound ($r = 3$)",
       "summary": "$R_3(n) \\geq \\mathrm{twr}_2(c \\cdot n^2) = 2^{2^{cn^2}}$, matching the upper bound tower height and resolving the $r=3$ case",
       "startLine": 74,
       "endLine": 80,
@@ -83,15 +83,15 @@
     }
   ],
   "overview": {
-    "historicalContext": "Erdős, Hajnal, and Rado formulated this conjecture in 1965 as the central question in hypergraph Ramsey theory. The story begins with the 1935 Erdős-Szekeres theorem establishing that graph Ramsey numbers R(n,n) grow exponentially — as a tower of height 1. The Erdős-Rado stepping-up lemma (1952) showed that each increase in uniformity r adds one tower level, giving R_r(n) ≤ twr_{r-1}(c·n²). For the lower bound, Erdős and Hajnal proved R_3(n) ≥ twr_2(c·n²), matching the upper bound for r=3. The general lower bound twr_{r-1}(Ω(n)) establishes the tower height as exactly r-1, but with a polynomial gap (linear vs quadratic) in the argument. The conjecture asks whether this gap can be closed to linear. For r=3, the answer is now known to be quadratic (Θ(n²)), so the strongest form of the linear conjecture is false. The problem remains open for r ≥ 4 and is considered one of the most fundamental challenges in combinatorics. Recent progress on graph Ramsey numbers by Campos-Griffiths-Morris-Sahasrabudhe (2023) has renewed interest in hypergraph analogues.",
-    "problemStatement": "For r ≥ 3, prove that the (r-1)-fold iterated logarithm of R_r(n) is Θ(n). Equivalently, R_r(n) = twr_{r-1}(Θ(n)).",
-    "text": "For r ≥ 3, prove that log_{r-1} R_r(n) ≍ n, where R_r(n) is the r-uniform hypergraph Ramsey number. Upper bound: twr_{r-1}(O(n²)) from Erdős–Rado. Lower: twr_{r-1}(Ω(n)). Status: OPEN.",
-    "proofStrategy": "We formalize the tower function twr(k,n) by recursion on k, define hypergraph Ramsey numbers R_r(n) via sInf over valid 2-colorings of r-uniform hypergraphs, state the Erdős-Szekeres graph bounds as axioms, prove their conjunction as a theorem, state the Erdős-Rado stepping-up upper bound and the Erdős-Hajnal lower bounds as axioms, and formalize the main conjecture as an axiom asserting the existence of constants c₁, c₂ bounding the tower argument.",
+    "historicalContext": "Erd\u0151s, Hajnal, and Rado formulated this conjecture in 1965 as the central question in hypergraph Ramsey theory. The story begins with the 1935 Erd\u0151s-Szekeres theorem establishing that graph Ramsey numbers R(n,n) grow exponentially \u2014 as a tower of height 1. The Erd\u0151s-Rado stepping-up lemma (1952) showed that each increase in uniformity r adds one tower level, giving R_r(n) \u2264 twr_{r-1}(c\u00b7n\u00b2). For the lower bound, Erd\u0151s and Hajnal proved R_3(n) \u2265 twr_2(c\u00b7n\u00b2), matching the upper bound for r=3. The general lower bound twr_{r-1}(\u03a9(n)) establishes the tower height as exactly r-1, but with a polynomial gap (linear vs quadratic) in the argument. The conjecture asks whether this gap can be closed to linear. For r=3, the answer is now known to be quadratic (\u0398(n\u00b2)), so the strongest form of the linear conjecture is false. The problem remains open for r \u2265 4 and is considered one of the most fundamental challenges in combinatorics. Recent progress on graph Ramsey numbers by Campos-Griffiths-Morris-Sahasrabudhe (2023) has renewed interest in hypergraph analogues.",
+    "problemStatement": "For r \u2265 3, prove that the (r-1)-fold iterated logarithm of R_r(n) is \u0398(n). Equivalently, R_r(n) = twr_{r-1}(\u0398(n)).",
+    "text": "For r \u2265 3, prove that log_{r-1} R_r(n) \u224d n, where R_r(n) is the r-uniform hypergraph Ramsey number. Upper bound: twr_{r-1}(O(n\u00b2)) from Erd\u0151s\u2013Rado. Lower: twr_{r-1}(\u03a9(n)). Status: OPEN.",
+    "proofStrategy": "We formalize the tower function twr(k,n) by recursion on k, define hypergraph Ramsey numbers R_r(n) via sInf over valid 2-colorings of r-uniform hypergraphs, state the Erd\u0151s-Szekeres graph bounds as axioms, prove their conjunction as a theorem, state the Erd\u0151s-Rado stepping-up upper bound and the Erd\u0151s-Hajnal lower bounds as axioms, and formalize the main conjecture as an axiom asserting the existence of constants c\u2081, c\u2082 bounding the tower argument.",
     "keyInsights": [
       "**Tower hierarchy**: Each increase in uniformity $r$ adds one level to the tower: $R_2(n) = 2^{\\Theta(n)}$, $R_3(n) = 2^{2^{\\Theta(n^2)}}$, and conjecturally $R_r(n) = \\mathrm{twr}_{r-1}(\\Theta(n^?))$",
-      "**Stepping-up penalty**: The Erdős-Rado lemma incurs a quadratic penalty $n \\mapsto cn^2$ at each step, which may or may not be inherent",
+      "**Stepping-up penalty**: The Erd\u0151s-Rado lemma incurs a quadratic penalty $n \\mapsto cn^2$ at each step, which may or may not be inherent",
       "**$r=3$ is resolved**: Both bounds give $\\mathrm{twr}_2(\\Theta(n^2))$, so the strongest linear conjecture is false for $r=3$",
-      "**Polynomial gap for $r \\geq 4$**: The remaining open question is the exact polynomial in $\\mathrm{twr}_{r-1}(n^?)$ — linear vs quadratic vs intermediate",
+      "**Polynomial gap for $r \\geq 4$**: The remaining open question is the exact polynomial in $\\mathrm{twr}_{r-1}(n^?)$ \u2014 linear vs quadratic vs intermediate",
       "**Very few exact values**: Only $R_3(4) = 13$ is known exactly; $R_3(5)$ is bounded between 43 and 48"
     ],
     "prerequisites": [
@@ -101,22 +101,22 @@
     ]
   },
   "references": [
-    "Erdős, P., Hajnal, A., and Rado, R. (1965). 'Partition relations for cardinal numbers.' Acta Math. Acad. Sci. Hungar., 16, 93–196.",
-    "Erdős, P. and Szekeres, G. (1935). 'A combinatorial problem in geometry.' Compositio Mathematica, 2, 463–470.",
-    "Erdős, P. and Rado, R. (1952). 'Combinatorial theorems on classifications of subsets of a given set.' Proc. London Math. Soc., 3(2), 417–439.",
-    "Erdős, P. (1947). 'Some remarks on the theory of graphs.' Bull. Amer. Math. Soc., 53, 292–294.",
+    "Erd\u0151s, P., Hajnal, A., and Rado, R. (1965). 'Partition relations for cardinal numbers.' Acta Math. Acad. Sci. Hungar., 16, 93\u2013196.",
+    "Erd\u0151s, P. and Szekeres, G. (1935). 'A combinatorial problem in geometry.' Compositio Mathematica, 2, 463\u2013470.",
+    "Erd\u0151s, P. and Rado, R. (1952). 'Combinatorial theorems on classifications of subsets of a given set.' Proc. London Math. Soc., 3(2), 417\u2013439.",
+    "Erd\u0151s, P. (1947). 'Some remarks on the theory of graphs.' Bull. Amer. Math. Soc., 53, 292\u2013294.",
     "Campos, M., Griffiths, S., Morris, R., and Sahasrabudhe, J. (2023). 'An exponential improvement for diagonal Ramsey.' arXiv:2303.09521.",
-    "Conlon, D., Fox, J., and Sudakov, B. (2015). 'Recent developments in graph Ramsey theory.' Surveys in Combinatorics, 49–118.",
+    "Conlon, D., Fox, J., and Sudakov, B. (2015). 'Recent developments in graph Ramsey theory.' Surveys in Combinatorics, 49\u2013118.",
     "https://erdosproblems.com/562"
   ],
   "conclusion": {
-    "summary": "This formalization captures the Erdős-Hajnal-Rado conjecture on hypergraph Ramsey number tower growth: R_r(n) should equal twr_{r-1}(Θ(n)). The tower function, hypergraph Ramsey numbers, Erdős-Szekeres graph bounds, the Erdős-Rado stepping-up upper bound, and known lower bounds are all formalized. The r=3 case is essentially resolved at twr_2(Θ(n²)), while the general case for r ≥ 4 remains one of the deepest open problems in combinatorics.",
+    "summary": "This formalization captures the Erd\u0151s-Hajnal-Rado conjecture on hypergraph Ramsey number tower growth: R_r(n) should equal twr_{r-1}(\u0398(n)). The tower function, hypergraph Ramsey numbers, Erd\u0151s-Szekeres graph bounds, the Erd\u0151s-Rado stepping-up upper bound, and known lower bounds are all formalized. The r=3 case is essentially resolved at twr_2(\u0398(n\u00b2)), while the general case for r \u2265 4 remains one of the deepest open problems in combinatorics.",
     "implications": "Resolving this conjecture would determine the fundamental complexity hierarchy of hypergraph Ramsey theory. It would reveal whether the quadratic penalty in the stepping-up lemma is inherent or can be eliminated, with implications for partition calculus, Hales-Jewett theory, and computational complexity lower bounds.",
     "openQuestions": [
-      "Can the Erdős-Rado stepping-up lemma be improved from O(n²) to o(n²) in the tower argument for r ≥ 4?",
-      "What is the exact polynomial exponent in twr_{r-1}(n^α) for each r?",
-      "Is R_3(5) equal to 43, 44, ... or 48? (Current best bounds: 43 ≤ R₃(5) ≤ 48)",
-      "Can algebraic or topological methods yield better hypergraph Ramsey lower bounds for r ≥ 4?"
+      "Can the Erd\u0151s-Rado stepping-up lemma be improved from O(n\u00b2) to o(n\u00b2) in the tower argument for r \u2265 4?",
+      "What is the exact polynomial exponent in twr_{r-1}(n^\u03b1) for each r?",
+      "Is R_3(5) equal to 43, 44, ... or 48? (Current best bounds: 43 \u2264 R\u2083(5) \u2264 48)",
+      "Can algebraic or topological methods yield better hypergraph Ramsey lower bounds for r \u2265 4?"
     ]
   },
   "leanFile": {
@@ -139,17 +139,17 @@
     {
       "targetId": "erdos-1014",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: graph-theory, open, ramsey-theory"
+      "description": "Related Erd\u0151s problem sharing themes: graph-theory, open, ramsey-theory"
     },
     {
       "targetId": "erdos-1105",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: graph-theory, open, ramsey-theory"
+      "description": "Related Erd\u0151s problem sharing themes: graph-theory, open, ramsey-theory"
     },
     {
       "targetId": "erdos-112",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: graph-theory, open, ramsey-theory"
+      "description": "Related Erd\u0151s problem sharing themes: graph-theory, open, ramsey-theory"
     }
   ]
 }

--- a/src/data/proofs/erdos-580/meta.json
+++ b/src/data/proofs/erdos-580/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-580",
-  "title": "Erdős Problem #580: The Loebl-Komlós-Sós Conjecture",
+  "title": "Erd\u0151s Problem #580: The Loebl-Koml\u00f3s-S\u00f3s Conjecture",
   "slug": "erdos-580",
   "description": "If a graph G on n vertices has at least n/2 vertices of degree at least n/2, must G contain every tree on at most n/2 vertices? YES for large n - proved by Zhao (2011).",
   "meta": {
-    "author": "Zhao (2011 proof), Erdős-Füredi-Loebl-Sós (conjecture)",
+    "author": "Zhao (2011 proof), Erd\u0151s-F\u00fcredi-Loebl-S\u00f3s (conjecture)",
     "sourceUrl": "https://erdosproblems.com/580",
     "date": "2011",
     "status": "axiomatized",
@@ -48,12 +48,12 @@
     ],
     "originalContributions": [
       "vertexDegree definition: degree of vertex in graph",
-      "highDegreeVertices definition: vertices with degree ≥ k",
+      "highDegreeVertices definition: vertices with degree \u2265 k",
       "Tree structure: k-vertex tree representation",
       "TreeEmbeds predicate: tree embedding in graph",
       "ContainsAllTreesUpTo predicate: all trees up to size k",
       "satisfiesLKS predicate: the n/2-n/2-n/2 condition",
-      "satisfiesGeneralizedLKS: Komlós-Sós generalization",
+      "satisfiesGeneralizedLKS: Koml\u00f3s-S\u00f3s generalization",
       "LKSConjecture: formal statement of conjecture",
       "KomlosSosConjecture: generalized conjecture",
       "AKS_theorem: asymptotic version (1995)",
@@ -64,17 +64,17 @@
     ],
     "axiomCount": 1,
     "lineCount": 236,
-    "assumptions": "6 axioms: cayley_formula, AKS_theorem, zhao_theorem, and 3 more. See Lean source for complete statements."
+    "assumptions": "1 axiom: zhao_theorem. 0 sorries."
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #580: The Loebl-Komlós-Sós Conjecture**\n\nThe Loebl-Komlós-Sós (LKS) conjecture, also known as the $(n/2, n/2, n/2)$ conjecture, is one of the central problems in extremal graph theory concerning forced tree embeddings under degree conditions.\n\n**Origins and Formulation:**\nThe conjecture was posed by Erdős, Füredi, Loebl, and Sós in their 1995 paper (EFLS95), growing out of earlier work by Loebl who conjectured a weaker version. The problem sits at the intersection of extremal graph theory and structural graph theory, asking how global degree conditions force the existence of all small tree subgraphs.\n\n**Progress Timeline:**\n- **1995**: Ajtai, Komlós, and Szemerédi proved an asymptotic version [AKS95], requiring $(1+\\varepsilon)n/2$ vertices of degree $\\geq (1+\\varepsilon)n/2$ for any $\\varepsilon > 0$. Their proof introduced key structural decomposition techniques.\n- **2000s**: Piguet and Stein proved special cases including spiders (caterpillar trees) and trees with bounded degree. Hladký and Piguet established the conjecture for dense graphs.\n- **2011**: Yi Zhao proved the full conjecture for all sufficiently large $n$ in the *Electronic Journal of Combinatorics* (Paper 27, 2011). Zhao's proof is a tour de force application of Szemerédi's Regularity Lemma combined with the blow-up technique and careful probabilistic arguments.\n- **2017**: Hladký, Komlós, Piguet, Simonovits, Stein, and Szemerédi announced a proof of the full (exact) conjecture for all $n$ sufficiently large, as part of a broader program resolving the Komlós-Sós conjecture.\n\n**Broader Context:**\nThe LKS conjecture belongs to a family of extremal problems asking what minimum degree or density conditions force specific subgraphs. Related milestones include the Erdős-Sós conjecture (if $G$ has average degree $> k-2$ then $G$ contains all trees on $k$ vertices), the Komlós-Sós generalization (decoupling tree size from the degree threshold), and the Bandwidth Theorem of Böttcher, Schacht, and Taraz. The regularity-based approach used in Zhao's proof has become a paradigmatic tool in modern combinatorics.",
-    "problemStatement": "**Problem Statement (Proved for large $n$)**\n\nLet $G$ be a graph on $n$ vertices such that at least $n/2$ vertices have degree at least $n/2$. Must $G$ contain every tree on at most $n/2$ vertices?\n\n**Answer: YES** for sufficiently large $n$ (Zhao, 2011)\n\n**Formal Statement:** $\\exists N_0 \\in \\mathbb{N}$ such that $\\forall n \\geq N_0$, if $G$ is a graph on $n$ vertices with $|\\{v : \\deg(v) \\geq n/2\\}| \\geq n/2$, then $G$ contains a copy of every tree $T$ with $|V(T)| \\leq n/2$.\n\n**Generalization (Komlós-Sós Conjecture):**\nIf at least $n/2$ vertices have degree at least $k$, then $G$ contains every tree on at most $k+1$ vertices. This decouples the tree size from the number of vertices.\n\n**Tightness:**\nThe condition is sharp: the disjoint union $K_{\\lfloor n/2 \\rfloor - 1} \\cup K_{\\lceil n/2 \\rceil + 1}$ has exactly $\\lfloor n/2 \\rfloor - 1$ vertices of degree $\\geq \\lfloor n/2 \\rfloor - 1$ and fails to contain certain paths spanning both components.",
+    "historicalContext": "**Erd\u0151s Problem #580: The Loebl-Koml\u00f3s-S\u00f3s Conjecture**\n\nThe Loebl-Koml\u00f3s-S\u00f3s (LKS) conjecture, also known as the $(n/2, n/2, n/2)$ conjecture, is one of the central problems in extremal graph theory concerning forced tree embeddings under degree conditions.\n\n**Origins and Formulation:**\nThe conjecture was posed by Erd\u0151s, F\u00fcredi, Loebl, and S\u00f3s in their 1995 paper (EFLS95), growing out of earlier work by Loebl who conjectured a weaker version. The problem sits at the intersection of extremal graph theory and structural graph theory, asking how global degree conditions force the existence of all small tree subgraphs.\n\n**Progress Timeline:**\n- **1995**: Ajtai, Koml\u00f3s, and Szemer\u00e9di proved an asymptotic version [AKS95], requiring $(1+\\varepsilon)n/2$ vertices of degree $\\geq (1+\\varepsilon)n/2$ for any $\\varepsilon > 0$. Their proof introduced key structural decomposition techniques.\n- **2000s**: Piguet and Stein proved special cases including spiders (caterpillar trees) and trees with bounded degree. Hladk\u00fd and Piguet established the conjecture for dense graphs.\n- **2011**: Yi Zhao proved the full conjecture for all sufficiently large $n$ in the *Electronic Journal of Combinatorics* (Paper 27, 2011). Zhao's proof is a tour de force application of Szemer\u00e9di's Regularity Lemma combined with the blow-up technique and careful probabilistic arguments.\n- **2017**: Hladk\u00fd, Koml\u00f3s, Piguet, Simonovits, Stein, and Szemer\u00e9di announced a proof of the full (exact) conjecture for all $n$ sufficiently large, as part of a broader program resolving the Koml\u00f3s-S\u00f3s conjecture.\n\n**Broader Context:**\nThe LKS conjecture belongs to a family of extremal problems asking what minimum degree or density conditions force specific subgraphs. Related milestones include the Erd\u0151s-S\u00f3s conjecture (if $G$ has average degree $> k-2$ then $G$ contains all trees on $k$ vertices), the Koml\u00f3s-S\u00f3s generalization (decoupling tree size from the degree threshold), and the Bandwidth Theorem of B\u00f6ttcher, Schacht, and Taraz. The regularity-based approach used in Zhao's proof has become a paradigmatic tool in modern combinatorics.",
+    "problemStatement": "**Problem Statement (Proved for large $n$)**\n\nLet $G$ be a graph on $n$ vertices such that at least $n/2$ vertices have degree at least $n/2$. Must $G$ contain every tree on at most $n/2$ vertices?\n\n**Answer: YES** for sufficiently large $n$ (Zhao, 2011)\n\n**Formal Statement:** $\\exists N_0 \\in \\mathbb{N}$ such that $\\forall n \\geq N_0$, if $G$ is a graph on $n$ vertices with $|\\{v : \\deg(v) \\geq n/2\\}| \\geq n/2$, then $G$ contains a copy of every tree $T$ with $|V(T)| \\leq n/2$.\n\n**Generalization (Koml\u00f3s-S\u00f3s Conjecture):**\nIf at least $n/2$ vertices have degree at least $k$, then $G$ contains every tree on at most $k+1$ vertices. This decouples the tree size from the number of vertices.\n\n**Tightness:**\nThe condition is sharp: the disjoint union $K_{\\lfloor n/2 \\rfloor - 1} \\cup K_{\\lceil n/2 \\rceil + 1}$ has exactly $\\lfloor n/2 \\rfloor - 1$ vertices of degree $\\geq \\lfloor n/2 \\rfloor - 1$ and fails to contain certain paths spanning both components.",
     "text": "If a graph G on n vertices has at least n/2 vertices of degree at least n/2, must G contain every tree on at most n/2 vertices? YES for large n - proved by Zhao (2011).",
-    "proofStrategy": "**Formalization Approach**\n\nThe Lean formalization captures the full statement hierarchy from definitions through the main theorem:\n\n1. **Graph Infrastructure:** Defines `vertexDegree` and `highDegreeVertices` using Mathlib's `SimpleGraph.neighborFinset`, providing a computable degree function and filterable high-degree set.\n\n2. **Tree Representation:** Introduces a `Tree k` structure carrying a vertex set, edge set, and cardinality proof. The collection `allTrees k` represents all trees on $k$ vertices.\n\n3. **Embedding Predicate:** `TreeEmbeds T G` asserts existence of an injective edge-preserving map $f: \\mathrm{Fin}\\, k \\to V$, formalizing graph homomorphism with injectivity (subgraph isomorphism for trees).\n\n4. **LKS Conditions:** `satisfiesLKS` captures the $(n/2, n/2, n/2)$ condition; `satisfiesGeneralizedLKS` captures the Komlós-Sós generalization with independent parameter $k$.\n\n5. **Axiomatized Deep Results:** The AKS asymptotic theorem and Zhao's exact theorem are axiomatized, since their proofs require the full Regularity Lemma machinery not yet in Mathlib.\n\n6. **Derived Main Result:** `erdos_580` follows directly from `zhao_theorem`, demonstrating the logical chain.\n\n7. **Special Cases and Tightness:** Path and star embedding under LKS are axiomatized as illustrative special cases, and `LKS_tightness` axiomatizes the sharpness construction.",
+    "proofStrategy": "**Formalization Approach**\n\nThe Lean formalization captures the full statement hierarchy from definitions through the main theorem:\n\n1. **Graph Infrastructure:** Defines `vertexDegree` and `highDegreeVertices` using Mathlib's `SimpleGraph.neighborFinset`, providing a computable degree function and filterable high-degree set.\n\n2. **Tree Representation:** Introduces a `Tree k` structure carrying a vertex set, edge set, and cardinality proof. The collection `allTrees k` represents all trees on $k$ vertices.\n\n3. **Embedding Predicate:** `TreeEmbeds T G` asserts existence of an injective edge-preserving map $f: \\mathrm{Fin}\\, k \\to V$, formalizing graph homomorphism with injectivity (subgraph isomorphism for trees).\n\n4. **LKS Conditions:** `satisfiesLKS` captures the $(n/2, n/2, n/2)$ condition; `satisfiesGeneralizedLKS` captures the Koml\u00f3s-S\u00f3s generalization with independent parameter $k$.\n\n5. **Axiomatized Deep Results:** The AKS asymptotic theorem and Zhao's exact theorem are axiomatized, since their proofs require the full Regularity Lemma machinery not yet in Mathlib.\n\n6. **Derived Main Result:** `erdos_580` follows directly from `zhao_theorem`, demonstrating the logical chain.\n\n7. **Special Cases and Tightness:** Path and star embedding under LKS are axiomatized as illustrative special cases, and `LKS_tightness` axiomatizes the sharpness construction.",
     "keyInsights": [
-      "**The $(n/2, n/2, n/2)$ Pattern:** The conjecture's elegant symmetry — at least $n/2$ vertices of degree $\\geq n/2$ forces all trees of size $\\leq n/2$ — makes it a natural extremal threshold problem where all three parameters coincide",
+      "**The $(n/2, n/2, n/2)$ Pattern:** The conjecture's elegant symmetry \u2014 at least $n/2$ vertices of degree $\\geq n/2$ forces all trees of size $\\leq n/2$ \u2014 makes it a natural extremal threshold problem where all three parameters coincide",
       "**Sharpness via Disjoint Cliques:** The condition cannot be weakened: $K_{n/2-1} \\cup K_{n/2+1}$ has only $n/2 - 1$ high-degree vertices and fails to embed a path of length $n/2 - 1$ spanning both components, showing the threshold is tight",
-      "**Regularity Lemma as Engine:** Zhao's proof applies Szemerédi's Regularity Lemma to decompose $G$ into a bounded number of pseudo-random bipartite pairs, then uses the blow-up lemma to embed trees into this regular structure — a paradigmatic application of the regularity method",
+      "**Regularity Lemma as Engine:** Zhao's proof applies Szemer\u00e9di's Regularity Lemma to decompose $G$ into a bounded number of pseudo-random bipartite pairs, then uses the blow-up lemma to embed trees into this regular structure \u2014 a paradigmatic application of the regularity method",
       "**Difficulty Hierarchy Among Trees:** Paths and stars embed easily under the LKS condition (greedy arguments suffice), but 'broom' trees (a path with a star attached) and caterpillar trees require the full regularity machinery, revealing a complexity gradient among tree structures",
       "**From Asymptotic to Exact:** The progression from the AKS result (needing $(1+\\varepsilon)n/2$) to Zhao's exact $n/2$ threshold illustrates how regularity-based proofs can be sharpened by careful analysis of the reduced graph structure"
     ],
@@ -119,10 +119,10 @@
     {
       "id": "lks-condition",
       "title": "The LKS Degree Condition",
-      "summary": "Defines `satisfiesLKS G` requiring $|\\{v : \\deg(v) \\geq n/2\\}| \\geq n/2$ and its generalization `satisfiesGeneralizedLKS G k` where the degree threshold $k$ is decoupled from $n/2$, capturing the Komlós-Sós generalization.",
+      "summary": "Defines `satisfiesLKS G` requiring $|\\{v : \\deg(v) \\geq n/2\\}| \\geq n/2$ and its generalization `satisfiesGeneralizedLKS G k` where the degree threshold $k$ is decoupled from $n/2$, capturing the Koml\u00f3s-S\u00f3s generalization.",
       "startLine": 112,
       "endLine": 133,
-      "mathContext": "Defines `satisfiesLKS G` requiring $|\\{v : \\deg(v) \\geq n/2\\}| \\geq n/2$ and its generalization `satisfiesGeneralizedLKS G k` where the degree threshold $k$ is decoupled from $n/2$, capturing the Komlós-Sós generalization."
+      "mathContext": "Defines `satisfiesLKS G` requiring $|\\{v : \\deg(v) \\geq n/2\\}| \\geq n/2$ and its generalization `satisfiesGeneralizedLKS G k` where the degree threshold $k$ is decoupled from $n/2$, capturing the Koml\u00f3s-S\u00f3s generalization."
     },
     {
       "id": "main-conjecture",
@@ -158,35 +158,35 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #580 formalizes the Loebl-Komlós-Sós $(n/2, n/2, n/2)$ conjecture: if a graph on $n$ vertices has at least $n/2$ vertices of degree $\\geq n/2$, it must contain every tree on $\\leq n/2$ vertices. The answer is YES for sufficiently large $n$, proved by Zhao (2011) via a deep application of Szemerédi's Regularity Lemma. The formalization captures the full logical chain from definitions through special cases to the main theorem, including the sharpness construction showing the degree threshold cannot be lowered.",
-    "implications": "**Theoretical Significance**: **Connections to Other Areas**\n\n1. **Szemerédi's Regularity Lemma:** Zhao's proof is one of the flagship applications of the Regularity Lemma in extremal graph theory, using the reduced graph to guide tree embedding into pseudo-random pairs.\n\n2. **Erdős-Sós Conjecture:** The closely related conjecture that average degree $> k-2$ forces all $k$-vertex trees (see erdos-548).\n\nThe LKS conjecture uses a median-type degree condition rather than average degree.\n\n3. **Ramsey Theory for Trees:** The tree Ramsey number $R(T_n, K_m) = (m-1)(n-1)+1$ (Chvátal's formula, see erdos-550) shows trees behave well in Ramsey-type problems, paralleling their embeddability under degree conditions.\n\n4. **Bandwidth Theorem:** Böttcher-Schacht-Taraz (2009) proved a broad generalization: high minimum degree forces all bounded-degree spanning subgraphs with small bandwidth, subsuming many tree embedding results.\n\n5. **Extremal Graph Theory:** Part of the broader program studying forced substructures, related to the Ruzsa-Szemerédi (6,3) problem (see erdos-716) and Turán-type density conditions (see erdos-579).",
+    "summary": "Erd\u0151s Problem #580 formalizes the Loebl-Koml\u00f3s-S\u00f3s $(n/2, n/2, n/2)$ conjecture: if a graph on $n$ vertices has at least $n/2$ vertices of degree $\\geq n/2$, it must contain every tree on $\\leq n/2$ vertices. The answer is YES for sufficiently large $n$, proved by Zhao (2011) via a deep application of Szemer\u00e9di's Regularity Lemma. The formalization captures the full logical chain from definitions through special cases to the main theorem, including the sharpness construction showing the degree threshold cannot be lowered.",
+    "implications": "**Theoretical Significance**: **Connections to Other Areas**\n\n1. **Szemer\u00e9di's Regularity Lemma:** Zhao's proof is one of the flagship applications of the Regularity Lemma in extremal graph theory, using the reduced graph to guide tree embedding into pseudo-random pairs.\n\n2. **Erd\u0151s-S\u00f3s Conjecture:** The closely related conjecture that average degree $> k-2$ forces all $k$-vertex trees (see erdos-548).\n\nThe LKS conjecture uses a median-type degree condition rather than average degree.\n\n3. **Ramsey Theory for Trees:** The tree Ramsey number $R(T_n, K_m) = (m-1)(n-1)+1$ (Chv\u00e1tal's formula, see erdos-550) shows trees behave well in Ramsey-type problems, paralleling their embeddability under degree conditions.\n\n4. **Bandwidth Theorem:** B\u00f6ttcher-Schacht-Taraz (2009) proved a broad generalization: high minimum degree forces all bounded-degree spanning subgraphs with small bandwidth, subsuming many tree embedding results.\n\n5. **Extremal Graph Theory:** Part of the broader program studying forced substructures, related to the Ruzsa-Szemer\u00e9di (6,3) problem (see erdos-716) and Tur\u00e1n-type density conditions (see erdos-579).",
     "openQuestions": [
-      "Prove the LKS conjecture for ALL $n$, not just sufficiently large $n$ — the Hladký-Komlós-Piguet-Simonovits-Stein-Szemerédi program announced results but full details are still being verified",
-      "Determine the exact threshold $N_0$ above which Zhao's proof works — current bounds from the Regularity Lemma are tower-type and far from practical",
-      "Resolve the full Komlós-Sós conjecture: if $\\geq n/2$ vertices have degree $\\geq k$, does $G$ contain every tree on $\\leq k+1$ vertices?",
-      "Find polynomial-time algorithms for tree embedding under the LKS condition — Zhao's proof is non-constructive via the Regularity Lemma",
+      "Prove the LKS conjecture for ALL $n$, not just sufficiently large $n$ \u2014 the Hladk\u00fd-Koml\u00f3s-Piguet-Simonovits-Stein-Szemer\u00e9di program announced results but full details are still being verified",
+      "Determine the exact threshold $N_0$ above which Zhao's proof works \u2014 current bounds from the Regularity Lemma are tower-type and far from practical",
+      "Resolve the full Koml\u00f3s-S\u00f3s conjecture: if $\\geq n/2$ vertices have degree $\\geq k$, does $G$ contain every tree on $\\leq k+1$ vertices?",
+      "Find polynomial-time algorithms for tree embedding under the LKS condition \u2014 Zhao's proof is non-constructive via the Regularity Lemma",
       "Extend to hypergraph tree embedding: what degree conditions on 3-uniform hypergraphs force all hypertrees of bounded size?"
     ],
     "crossReferences": [
       {
         "proofId": "erdos-548",
-        "relationship": "The Erdős-Sós conjecture uses average degree $> k-2$ (rather than a median-type condition) to force $k$-vertex trees — a complementary extremal condition for the same embedding problem"
+        "relationship": "The Erd\u0151s-S\u00f3s conjecture uses average degree $> k-2$ (rather than a median-type condition) to force $k$-vertex trees \u2014 a complementary extremal condition for the same embedding problem"
       },
       {
         "proofId": "erdos-550",
-        "relationship": "Chvátal's tree Ramsey formula $R(T_n, K_m) = (m-1)(n-1)+1$ demonstrates that trees are 'Ramsey-friendly', paralleling their embeddability under degree conditions in the LKS conjecture"
+        "relationship": "Chv\u00e1tal's tree Ramsey formula $R(T_n, K_m) = (m-1)(n-1)+1$ demonstrates that trees are 'Ramsey-friendly', paralleling their embeddability under degree conditions in the LKS conjecture"
       },
       {
         "proofId": "erdos-716",
-        "relationship": "The Ruzsa-Szemerédi (6,3) problem is another central application of the Regularity Lemma in extremal combinatorics, sharing the regularity-based methodology used in Zhao's proof"
+        "relationship": "The Ruzsa-Szemer\u00e9di (6,3) problem is another central application of the Regularity Lemma in extremal combinatorics, sharing the regularity-based methodology used in Zhao's proof"
       },
       {
         "proofId": "erdos-579",
-        "relationship": "Independent sets in $K_{2,2,2}$-free dense graphs study extremal graph theory under forbidden subgraph conditions, part of the same Turán-type framework as forced tree embedding"
+        "relationship": "Independent sets in $K_{2,2,2}$-free dense graphs study extremal graph theory under forbidden subgraph conditions, part of the same Tur\u00e1n-type framework as forced tree embedding"
       },
       {
         "proofId": "erdos-581",
-        "relationship": "Bipartite subgraphs of triangle-free graphs study forced substructures in extremal graphs — a sibling problem to forcing tree subgraphs under degree conditions"
+        "relationship": "Bipartite subgraphs of triangle-free graphs study forced substructures in extremal graphs \u2014 a sibling problem to forcing tree subgraphs under degree conditions"
       },
       {
         "proofId": "erdos-582",
@@ -217,17 +217,17 @@
     {
       "targetId": "erdos-1009",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: graph-theory, solved"
+      "description": "Related Erd\u0151s problem sharing themes: graph-theory, solved"
     },
     {
       "targetId": "erdos-1079",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: graph-theory, solved"
+      "description": "Related Erd\u0151s problem sharing themes: graph-theory, solved"
     },
     {
       "targetId": "erdos-134",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: graph-theory, solved"
+      "description": "Related Erd\u0151s problem sharing themes: graph-theory, solved"
     }
   ]
 }

--- a/src/data/proofs/erdos-581/meta.json
+++ b/src/data/proofs/erdos-581/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-581",
-  "title": "Erdős Problem #581: Bipartite Subgraphs of Triangle-Free Graphs",
+  "title": "Erd\u0151s Problem #581: Bipartite Subgraphs of Triangle-Free Graphs",
   "slug": "erdos-581",
-  "description": "Let f(m) be the maximal k such that every triangle-free graph with m edges contains a bipartite subgraph with k edges. Alon (1996) proved f(m) = m/2 + Θ(m^{4/5}).",
+  "description": "Let f(m) be the maximal k such that every triangle-free graph with m edges contains a bipartite subgraph with k edges. Alon (1996) proved f(m) = m/2 + \u0398(m^{4/5}).",
   "meta": {
-    "author": "Erdős, Alon",
+    "author": "Erd\u0151s, Alon",
     "sourceUrl": "https://erdosproblems.com/581",
     "date": "1996",
     "status": "axiomatized",
@@ -42,35 +42,35 @@
       }
     ],
     "originalContributions": [
-      "IsTriangleFree definition: no K₃ subgraph",
+      "IsTriangleFree definition: no K\u2083 subgraph",
       "IsBipartite definition: vertex 2-partition",
       "edgeCount: finite edge count",
       "maxBipartiteEdges axiom: supremum over bipartite subgraphs",
       "f axiom: guaranteed bipartite edges",
       "half_edges_bipartite axiom: trivial m/2 bound",
-      "alon_upper_bound axiom: f(m) ≤ m/2 + c₂·m^{4/5}",
-      "alon_lower_bound axiom: f(m) ≥ m/2 + c₁·m^{4/5}",
+      "alon_upper_bound axiom: f(m) \u2264 m/2 + c\u2082\u00b7m^{4/5}",
+      "alon_lower_bound axiom: f(m) \u2265 m/2 + c\u2081\u00b7m^{4/5}",
       "ThetaBound definition: big-Theta notation",
-      "alon_main_theorem: f(m) - m/2 = Θ(m^{4/5})",
-      "mantel_theorem axiom: ex(n, K₃) ≤ n²/4",
+      "alon_main_theorem: f(m) - m/2 = \u0398(m^{4/5})",
+      "mantel_theorem axiom: ex(n, K\u2083) \u2264 n\u00b2/4",
       "erdos_581 theorem: main result",
       "erdos_581_summary: combined summary"
     ],
     "axiomCount": 3,
     "lineCount": 261,
-    "assumptions": "8 axioms: maxBipartiteEdges, f, half_edges_bipartite, and 5 more. See Lean source for complete statements."
+    "assumptions": "3 axioms: f, alon_upper_bound, alon_lower_bound. 0 sorries."
   },
   "overview": {
-    "historicalContext": "Erdős Problem #581 asks: how many edges can we guarantee in a bipartite subgraph of any triangle-free graph with m edges? The function f(m) denotes the maximum k such that every triangle-free graph with m edges contains a bipartite subgraph with at least k edges. It is trivial that any graph with m edges has a bipartite subgraph with at least m/2 edges (by a random 2-coloring argument), so the real question is whether triangle-freeness provides an additional advantage.\n\nAlon (1996) resolved this problem completely, proving that f(m) = m/2 + Θ(m^{4/5}). Specifically, there exist constants c₁, c₂ > 0 such that m/2 + c₁·m^{4/5} ≤ f(m) ≤ m/2 + c₂·m^{4/5}. The lower bound uses probabilistic and algebraic methods to show that triangle-free graphs must have large bipartite subgraphs. The upper bound constructs specific triangle-free graphs where the maximum bipartite subgraph is bounded.\n\nThe result connects to classical extremal graph theory: Mantel's theorem (1907) shows triangle-free graphs on n vertices have at most n²/4 edges, and the Kővári-Sós-Turán theorem provides structural constraints. The 4/5 exponent arises from the interplay between these structural properties and probabilistic decomposition arguments. Alon's paper 'Bipartite subgraphs' in Combinatorica 16 (1996): 301-311 provides the full details.",
+    "historicalContext": "Erd\u0151s Problem #581 asks: how many edges can we guarantee in a bipartite subgraph of any triangle-free graph with m edges? The function f(m) denotes the maximum k such that every triangle-free graph with m edges contains a bipartite subgraph with at least k edges. It is trivial that any graph with m edges has a bipartite subgraph with at least m/2 edges (by a random 2-coloring argument), so the real question is whether triangle-freeness provides an additional advantage.\n\nAlon (1996) resolved this problem completely, proving that f(m) = m/2 + \u0398(m^{4/5}). Specifically, there exist constants c\u2081, c\u2082 > 0 such that m/2 + c\u2081\u00b7m^{4/5} \u2264 f(m) \u2264 m/2 + c\u2082\u00b7m^{4/5}. The lower bound uses probabilistic and algebraic methods to show that triangle-free graphs must have large bipartite subgraphs. The upper bound constructs specific triangle-free graphs where the maximum bipartite subgraph is bounded.\n\nThe result connects to classical extremal graph theory: Mantel's theorem (1907) shows triangle-free graphs on n vertices have at most n\u00b2/4 edges, and the K\u0151v\u00e1ri-S\u00f3s-Tur\u00e1n theorem provides structural constraints. The 4/5 exponent arises from the interplay between these structural properties and probabilistic decomposition arguments. Alon's paper 'Bipartite subgraphs' in Combinatorica 16 (1996): 301-311 provides the full details.",
     "problemStatement": "**Problem Statement (Solved)**\n\nLet $f(m)$ be the maximum $k$ such that every triangle-free graph with $m$ edges contains a bipartite subgraph with at least $k$ edges.\n\n**Question:** Determine $f(m)$.\n\n**Answer (Alon 1996):**\n$$f(m) = \\frac{m}{2} + \\Theta(m^{4/5})$$\n\nMore precisely, there exist constants $c_1, c_2 > 0$ such that:\n$$\\frac{m}{2} + c_1 m^{4/5} \\leq f(m) \\leq \\frac{m}{2} + c_2 m^{4/5}$$",
-    "text": "Let f(m) be the maximal k such that every triangle-free graph with m edges contains a bipartite subgraph with k edges. Alon (1996) proved f(m) = m/2 + Θ(m^{4/5}).",
+    "text": "Let f(m) be the maximal k such that every triangle-free graph with m edges contains a bipartite subgraph with k edges. Alon (1996) proved f(m) = m/2 + \u0398(m^{4/5}).",
     "proofStrategy": "**Formalization Approach**\n\n1. **Graph Definitions:** IsTriangleFree, IsBipartite predicates\n\n2. **Function f:** Axiomatized as the infimum over triangle-free graphs\n\n3. **Trivial Bound:** State that any graph has m/2 bipartite edges\n\n4. **Alon's Bounds:** Axiomatize both upper and lower bounds\n\n5. **Theta Notation:** Define ThetaBound for precise asymptotic statement\n\n6. **Related Results:** Include Mantel's theorem and KST bound",
     "keyInsights": [
-      "**Trivial Bound:** Any graph has a bipartite subgraph with ≥ m/2 edges",
-      "**Triangle-Free Bonus:** These graphs give Θ(m^{4/5}) extra edges",
+      "**Trivial Bound:** Any graph has a bipartite subgraph with \u2265 m/2 edges",
+      "**Triangle-Free Bonus:** These graphs give \u0398(m^{4/5}) extra edges",
       "**The Exponent 4/5:** Arises from extremal graph theory structure",
       "**Matching Bounds:** Both upper and lower bounds have the same exponent",
-      "**Connection to Mantel:** Triangle-free graphs have ≤ n²/4 edges",
+      "**Connection to Mantel:** Triangle-free graphs have \u2264 n\u00b2/4 edges",
       "**Probabilistic Methods:** Alon used probabilistic and algebraic techniques"
     ],
     "prerequisites": [
@@ -106,18 +106,18 @@
     {
       "id": "alon-upper",
       "title": "Alon's Upper Bound",
-      "summary": "f(m) ≤ m/2 + c₂·m^{4/5}, constant c₂",
+      "summary": "f(m) \u2264 m/2 + c\u2082\u00b7m^{4/5}, constant c\u2082",
       "startLine": 113,
       "endLine": 141,
-      "mathContext": "f(m) $\\leq$ m/2 + c₂·m^{4/5}, constant c₂"
+      "mathContext": "f(m) $\\leq$ m/2 + c\u2082\u00b7m^{4/5}, constant c\u2082"
     },
     {
       "id": "alon-lower",
       "title": "Alon's Lower Bound",
-      "summary": "f(m) ≥ m/2 + c₁·m^{4/5}, constant c₁",
+      "summary": "f(m) \u2265 m/2 + c\u2081\u00b7m^{4/5}, constant c\u2081",
       "startLine": 142,
       "endLine": 170,
-      "mathContext": "f(m) $\\geq$ m/2 + c₁·m^{4/5}, constant c₁"
+      "mathContext": "f(m) $\\geq$ m/2 + c\u2081\u00b7m^{4/5}, constant c\u2081"
     },
     {
       "id": "asymptotic",
@@ -130,10 +130,10 @@
     {
       "id": "related",
       "title": "Related Results",
-      "summary": "general_graph_bound, Mantel's theorem, Kővári-Sós-Turán",
+      "summary": "general_graph_bound, Mantel's theorem, K\u0151v\u00e1ri-S\u00f3s-Tur\u00e1n",
       "startLine": 197,
       "endLine": 234,
-      "mathContext": "Verified: general_graph_bound, Mantel's theorem, Kővári-Sós-Turán"
+      "mathContext": "Verified: general_graph_bound, Mantel's theorem, K\u0151v\u00e1ri-S\u00f3s-Tur\u00e1n"
     },
     {
       "id": "main-results",
@@ -145,11 +145,11 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #581 is SOLVED. Alon (1996) determined f(m) = m/2 + Θ(m^{4/5}), where f(m) is the guaranteed bipartite subgraph size in any triangle-free graph with m edges. This shows triangle-free graphs are 'more bipartite' than general graphs by a factor of m^{4/5}.",
-    "implications": "**Theoretical Significance**: **Graph-Theoretic Significance**\n\n1. **Structural Property:** Triangle-free graphs have inherent bipartite-like structure\n\n**2. Extremal Graph Theory:** Connects to Turán-type problems\n\n3. **Probabilistic Methods:** Alon's proof showcases powerful probabilistic techniques\n\n4. **Tight Bounds:** Both upper and lower bounds match, giving precise asymptotics.",
+    "summary": "Erd\u0151s Problem #581 is SOLVED. Alon (1996) determined f(m) = m/2 + \u0398(m^{4/5}), where f(m) is the guaranteed bipartite subgraph size in any triangle-free graph with m edges. This shows triangle-free graphs are 'more bipartite' than general graphs by a factor of m^{4/5}.",
+    "implications": "**Theoretical Significance**: **Graph-Theoretic Significance**\n\n1. **Structural Property:** Triangle-free graphs have inherent bipartite-like structure\n\n**2. Extremal Graph Theory:** Connects to Tur\u00e1n-type problems\n\n3. **Probabilistic Methods:** Alon's proof showcases powerful probabilistic techniques\n\n4. **Tight Bounds:** Both upper and lower bounds match, giving precise asymptotics.",
     "openQuestions": [
-      "What are explicit values for c₁ and c₂?",
-      "Does a similar result hold for K₄-free graphs?",
+      "What are explicit values for c\u2081 and c\u2082?",
+      "Does a similar result hold for K\u2084-free graphs?",
       "What is f(m) for graphs with other forbidden subgraphs?",
       "Can the constants be computed algorithmically?"
     ]
@@ -179,17 +179,17 @@
     {
       "targetId": "erdos-134",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: extremal-combinatorics, graph-theory, solved, triangle-free"
+      "description": "Related Erd\u0151s problem sharing themes: extremal-combinatorics, graph-theory, solved, triangle-free"
     },
     {
       "targetId": "erdos-23",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: bipartite-graphs, extremal-combinatorics, graph-theory, triangle-free"
+      "description": "Related Erd\u0151s problem sharing themes: bipartite-graphs, extremal-combinatorics, graph-theory, triangle-free"
     },
     {
       "targetId": "erdos-1021",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: bipartite-graphs, extremal-combinatorics, graph-theory"
+      "description": "Related Erd\u0151s problem sharing themes: bipartite-graphs, extremal-combinatorics, graph-theory"
     }
   ]
 }

--- a/src/data/proofs/erdos-618/meta.json
+++ b/src/data/proofs/erdos-618/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-618",
-  "title": "Erdős Problem #618: Decreasing Diameter of Triangle-Free Graphs",
+  "title": "Erd\u0151s Problem #618: Decreasing Diameter of Triangle-Free Graphs",
   "slug": "erdos-618",
-  "description": "For a triangle-free graph G, let h₂(G) be the minimum edges to add for diameter 2 while staying triangle-free. Proved: Δ = o(n^{1/2}) implies h₂(G) = o(n²).",
+  "description": "For a triangle-free graph G, let h\u2082(G) be the minimum edges to add for diameter 2 while staying triangle-free. Proved: \u0394 = o(n^{1/2}) implies h\u2082(G) = o(n\u00b2).",
   "meta": {
     "author": "Noga Alon (solver)",
     "sourceUrl": "https://erdosproblems.com/618",
@@ -43,32 +43,32 @@
     "originalContributions": [
       "IsTriangleFree: triangle-free via CliqueFree 3",
       "maxDegree: maximum degree of a graph",
-      "DiameterAtMostTwo: diameter ≤ 2 via common neighbors",
+      "DiameterAtMostTwo: diameter \u2264 2 via common neighbors",
       "ValidExtension structure: subgraph + triangle-free + diameter 2",
-      "h₂: minimum edges to add for valid extension",
-      "simonovits_example: high-degree graphs can need Θ(n²) edges",
+      "h\u2082: minimum edges to add for valid extension",
+      "simonovits_example: high-degree graphs can need \u0398(n\u00b2) edges",
       "bounded_degree_result: O(1) degree gives O(n log n) edges",
-      "alon_theorem: the main result Δ = o(√n) → h₂ = o(n²)",
+      "alon_theorem: the main result \u0394 = o(\u221an) \u2192 h\u2082 = o(n\u00b2)",
       "MainConjecture: formal asymptotic statement",
-      "threshold_is_sharp: √n threshold is optimal",
+      "threshold_is_sharp: \u221an threshold is optimal",
       "mantel_theorem: triangle-free edge bound",
       "erdos_618: summary combining main conjecture + threshold"
     ],
     "axiomCount": 2,
     "lineCount": 250,
-    "assumptions": "7 axioms: h₂_exists, simonovits_example, bounded_degree_result, and 4 more. See Lean source for complete statements."
+    "assumptions": "2 axioms: main_conjecture_proved, threshold_is_sharp. 0 sorries."
   },
   "overview": {
-    "historicalContext": "Erdős Problem #618 was posed by Erdős, Gyárfás, and Ruszinkó in their 1998 Combinatorica paper 'How to decrease the diameter of triangle-free graphs.' For a triangle-free graph G on n vertices, h₂(G) denotes the minimum number of edges that must be added so that the resulting graph has diameter at most 2 while remaining triangle-free. The authors proved that for bounded degree graphs (Δ = O(1)) with no isolated vertices, h₂(G) = O(n log n).\n\nSimonovits showed the complementary direction: there exist triangle-free graphs with maximum degree ≫ √n for which h₂(G) = Θ(n²). This established that √n is a critical threshold for the maximum degree. The central conjecture asked whether Δ = o(√n) always implies h₂(G) = o(n²). Noga Alon resolved this conjecture affirmatively, observing that the problem is essentially identical to Erdős Problem #134.\n\nThe √n threshold arises naturally from the interplay between Mantel's theorem (triangle-free graphs have at most n²/4 edges) and the structural requirements for diameter 2. A graph with degree ≈ √n has roughly n^{3/2} edges, which is the scale at which triangle-free diameter-2 graphs transition between sparse and dense behavior. Alon's proof uses probabilistic and extremal graph theory methods.",
-    "problemStatement": "For a triangle-free graph G on n vertices, let h₂(G) denote the minimum number of edges that must be added to G so that the resulting graph has diameter at most 2 while remaining triangle-free. The question asks: if G has maximum degree o(n^{1/2}), must h₂(G) = o(n²)?",
-    "text": "For a triangle-free graph G, let h₂(G) be the minimum edges to add for diameter 2 while staying triangle-free. Proved: Δ = o(n^{1/2}) implies h₂(G) = o(n²).",
-    "proofStrategy": "The formalization defines triangle-free graphs (via Mathlib's CliqueFree 3), diameter-2 condition, valid extensions, and the h₂ function as an infimum. Alon's theorem is axiomatized as: for any ε > 0, eventually all triangle-free graphs with Δ ≤ n^{1/2-ε} satisfy h₂ ≤ εn². The sharp threshold axiom captures both directions. The summary theorem combines these via exact ⟨main_conjecture_proved, threshold_is_sharp.1⟩.",
+    "historicalContext": "Erd\u0151s Problem #618 was posed by Erd\u0151s, Gy\u00e1rf\u00e1s, and Ruszink\u00f3 in their 1998 Combinatorica paper 'How to decrease the diameter of triangle-free graphs.' For a triangle-free graph G on n vertices, h\u2082(G) denotes the minimum number of edges that must be added so that the resulting graph has diameter at most 2 while remaining triangle-free. The authors proved that for bounded degree graphs (\u0394 = O(1)) with no isolated vertices, h\u2082(G) = O(n log n).\n\nSimonovits showed the complementary direction: there exist triangle-free graphs with maximum degree \u226b \u221an for which h\u2082(G) = \u0398(n\u00b2). This established that \u221an is a critical threshold for the maximum degree. The central conjecture asked whether \u0394 = o(\u221an) always implies h\u2082(G) = o(n\u00b2). Noga Alon resolved this conjecture affirmatively, observing that the problem is essentially identical to Erd\u0151s Problem #134.\n\nThe \u221an threshold arises naturally from the interplay between Mantel's theorem (triangle-free graphs have at most n\u00b2/4 edges) and the structural requirements for diameter 2. A graph with degree \u2248 \u221an has roughly n^{3/2} edges, which is the scale at which triangle-free diameter-2 graphs transition between sparse and dense behavior. Alon's proof uses probabilistic and extremal graph theory methods.",
+    "problemStatement": "For a triangle-free graph G on n vertices, let h\u2082(G) denote the minimum number of edges that must be added to G so that the resulting graph has diameter at most 2 while remaining triangle-free. The question asks: if G has maximum degree o(n^{1/2}), must h\u2082(G) = o(n\u00b2)?",
+    "text": "For a triangle-free graph G, let h\u2082(G) be the minimum edges to add for diameter 2 while staying triangle-free. Proved: \u0394 = o(n^{1/2}) implies h\u2082(G) = o(n\u00b2).",
+    "proofStrategy": "The formalization defines triangle-free graphs (via Mathlib's CliqueFree 3), diameter-2 condition, valid extensions, and the h\u2082 function as an infimum. Alon's theorem is axiomatized as: for any \u03b5 > 0, eventually all triangle-free graphs with \u0394 \u2264 n^{1/2-\u03b5} satisfy h\u2082 \u2264 \u03b5n\u00b2. The sharp threshold axiom captures both directions. The summary theorem combines these via exact \u27e8main_conjecture_proved, threshold_is_sharp.1\u27e9.",
     "keyInsights": [
-      "The √n degree threshold is sharp: below it h₂ = o(n²), above it h₂ can be Θ(n²)",
+      "The \u221an degree threshold is sharp: below it h\u2082 = o(n\u00b2), above it h\u2082 can be \u0398(n\u00b2)",
       "Triangle-free + diameter 2 severely constrains the graph structure",
-      "The problem is essentially identical to Erdős Problem #134",
-      "For bounded degree graphs, h₂(G) = O(n log n) (EGR98)",
-      "Alon's probabilistic argument shows that random triangle-free graphs near the √n threshold exhibit a phase transition in h₂ — a phenomenon typical of random graph thresholds but unusual for deterministic extremal problems"
+      "The problem is essentially identical to Erd\u0151s Problem #134",
+      "For bounded degree graphs, h\u2082(G) = O(n log n) (EGR98)",
+      "Alon's probabilistic argument shows that random triangle-free graphs near the \u221an threshold exhibit a phase transition in h\u2082 \u2014 a phenomenon typical of random graph thresholds but unusual for deterministic extremal problems"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -85,14 +85,14 @@
     },
     {
       "id": "h2-function",
-      "title": "The h₂ Function",
-      "summary": "Valid extension structure and h₂ as infimum",
+      "title": "The h\u2082 Function",
+      "summary": "Valid extension structure and h\u2082 as infimum",
       "startLine": 93,
       "endLine": 126
     },
     {
       "id": "egr-results",
-      "title": "Erdős-Gyárfás-Ruszinkó Results",
+      "title": "Erd\u0151s-Gy\u00e1rf\u00e1s-Ruszink\u00f3 Results",
       "summary": "Simonovits example and bounded degree result",
       "startLine": 127,
       "endLine": 159
@@ -100,7 +100,7 @@
     {
       "id": "alon-solution",
       "title": "Alon's Solution",
-      "summary": "Main theorem: Δ = o(√n) implies h₂ = o(n²)",
+      "summary": "Main theorem: \u0394 = o(\u221an) implies h\u2082 = o(n\u00b2)",
       "startLine": 160,
       "endLine": 179
     },
@@ -114,7 +114,7 @@
     {
       "id": "threshold",
       "title": "The Threshold",
-      "summary": "Sharp threshold at √n and Mantel's theorem",
+      "summary": "Sharp threshold at \u221an and Mantel's theorem",
       "startLine": 217,
       "endLine": 246
     },
@@ -127,12 +127,12 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #618 is SOLVED. Alon proved that for triangle-free graphs with maximum degree o(n^{1/2}), the function h₂(G) is o(n²). The √n threshold is sharp, as shown by Simonovits's examples.",
+    "summary": "Erd\u0151s Problem #618 is SOLVED. Alon proved that for triangle-free graphs with maximum degree o(n^{1/2}), the function h\u2082(G) is o(n\u00b2). The \u221an threshold is sharp, as shown by Simonovits's examples.",
     "implications": "The result characterizes the minimum edge augmentation needed for diameter reduction in sparse triangle-free graphs. It connects graph diameter, triangle-freeness, and degree constraints in a precise asymptotic relationship.",
     "openQuestions": [
       "What is the exact coefficient in the asymptotic for specific degree ranges?",
       "Can similar results be proved for diameter 3 or higher?",
-      "What about K₄-free or general Kr-free graphs?"
+      "What about K\u2084-free or general Kr-free graphs?"
     ]
   },
   "leanFile": {
@@ -161,17 +161,17 @@
     {
       "targetId": "erdos-133",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: diameter, graph-theory, triangle-free"
+      "description": "Related Erd\u0151s problem sharing themes: diameter, graph-theory, triangle-free"
     },
     {
       "targetId": "erdos-134",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: diameter, graph-theory, triangle-free"
+      "description": "Related Erd\u0151s problem sharing themes: diameter, graph-theory, triangle-free"
     },
     {
       "targetId": "erdos-619",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: diameter, graph-theory, triangle-free"
+      "description": "Related Erd\u0151s problem sharing themes: diameter, graph-theory, triangle-free"
     }
   ]
 }

--- a/src/data/proofs/erdos-619/meta.json
+++ b/src/data/proofs/erdos-619/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-619",
-  "title": "Erdős Problem #619: Decreasing Diameter of Triangle-Free Graphs",
+  "title": "Erd\u0151s Problem #619: Decreasing Diameter of Triangle-Free Graphs",
   "slug": "erdos-619",
-  "description": "Does there exist c > 0 such that h₄(G) < (1-c)n for triangle-free graphs G? Known: h₃ ≤ n, h₅ ≤ (n-1)/2. Status: OPEN.",
+  "description": "Does there exist c > 0 such that h\u2084(G) < (1-c)n for triangle-free graphs G? Known: h\u2083 \u2264 n, h\u2085 \u2264 (n-1)/2. Status: OPEN.",
   "meta": {
-    "author": "Erdős-Gyárfás-Ruszinkó (1998)",
+    "author": "Erd\u0151s-Gy\u00e1rf\u00e1s-Ruszink\u00f3 (1998)",
     "sourceUrl": "https://erdosproblems.com/619",
     "date": "1998",
     "status": "axiomatized",
@@ -45,35 +45,35 @@
       "diameter and HasDiameter definitions",
       "addEdges operation for edge addition with symm/loopless proofs",
       "h(G, r) function: min edges for diameter r while triangle-free",
-      "h3_upper_bound axiom: h₃(G) ≤ n (EGR 1998)",
-      "h3_lower_bound axiom: ∃ G with h₃(G) ≥ n - c (EGR 1998)",
-      "h5_upper_bound axiom: h₅(G) ≤ (n-1)/2 (EGR 1998)",
-      "erdos_619_question: the open h₄ question",
+      "h3_upper_bound axiom: h\u2083(G) \u2264 n (EGR 1998)",
+      "h3_lower_bound axiom: \u2203 G with h\u2083(G) \u2265 n - c (EGR 1998)",
+      "h5_upper_bound axiom: h\u2085(G) \u2264 (n-1)/2 (EGR 1998)",
+      "erdos_619_question: the open h\u2084 question",
       "without_triangle_free_constraint axiom: n/2 suffices without triangle-free (AGR 2000)",
       "pathGraph: concrete example with triangle-free and diameter proofs",
-      "h_monotone axiom: h_r ≥ h_{r+1}",
-      "erdos_619_partial_results theorem: combines h₃ and h₅ bounds"
+      "h_monotone axiom: h_r \u2265 h_{r+1}",
+      "erdos_619_partial_results theorem: combines h\u2083 and h\u2085 bounds"
     ],
     "axiomCount": 2,
     "lineCount": 209,
-    "assumptions": "7 axioms: h3_upper_bound, h3_lower_bound, h5_upper_bound, and 4 more. See Lean source for complete statements."
+    "assumptions": "2 axioms: h3_upper_bound, h5_upper_bound. 0 sorries."
   },
   "overview": {
-    "historicalContext": "This problem studies how to decrease graph diameter by adding edges while preserving triangle-freeness. Erdős, Gyárfás, and Ruszinkó (1998) introduced h_r(G) as the minimum number of edges needed to reduce the diameter of a connected triangle-free graph G to r, while maintaining the triangle-free property. They proved that h₃(G) ≤ n for all such graphs, and that this is essentially tight: there exist graphs requiring nearly n edges. They also showed the much smaller bound h₅(G) ≤ (n-1)/2.\n\nThe key open question is about the intermediate case h₄. The problem asks whether there exists a constant c > 0 such that h₄(G) < (1-c)n for all connected triangle-free G on n vertices — that is, whether one can always save a constant fraction of edges compared to h₃.\n\nWithout the triangle-free constraint, Alon, Gyárfás, and Ruszinkó (2000) proved that n/2 edges always suffice for diameter 4. The triangle-free requirement fundamentally changes the problem: it prevents using the most natural shortcut edges (which often create triangles), making diameter reduction much harder.",
-    "problemStatement": "**Question (OPEN):** Does there exist c > 0 such that h₄(G) < (1-c)n for all connected triangle-free graphs G on n vertices?\n\n**Known bounds:**\n- h₃(G) ≤ n (tight: some G have h₃(G) ≥ n - c)\n- h₄(G) ≤ ? (OPEN)\n- h₅(G) ≤ (n-1)/2",
-    "text": "Does there exist c > 0 such that h₄(G) < (1-c)n for triangle-free graphs G? Known: h₃ ≤ n, h₅ ≤ (n-1)/2. Status: OPEN.",
-    "proofStrategy": "The formalization defines the key concepts: TriangleFree (no K₃ subgraphs), graph diameter, addEdges (graph augmentation preserving simple graph properties), and h(G, r) as the minimum edges to achieve diameter ≤ r while staying triangle-free. Known bounds for h₃ and h₅ from Erdős-Gyárfás-Ruszinkó (1998) are axiomatized, as is the without-triangle-free result of Alon-Gyárfás-Ruszinkó (2000). The open h₄ question is stated as a formal proposition. The summary theorem combines the h₃ and h₅ bounds.",
+    "historicalContext": "This problem studies how to decrease graph diameter by adding edges while preserving triangle-freeness. Erd\u0151s, Gy\u00e1rf\u00e1s, and Ruszink\u00f3 (1998) introduced h_r(G) as the minimum number of edges needed to reduce the diameter of a connected triangle-free graph G to r, while maintaining the triangle-free property. They proved that h\u2083(G) \u2264 n for all such graphs, and that this is essentially tight: there exist graphs requiring nearly n edges. They also showed the much smaller bound h\u2085(G) \u2264 (n-1)/2.\n\nThe key open question is about the intermediate case h\u2084. The problem asks whether there exists a constant c > 0 such that h\u2084(G) < (1-c)n for all connected triangle-free G on n vertices \u2014 that is, whether one can always save a constant fraction of edges compared to h\u2083.\n\nWithout the triangle-free constraint, Alon, Gy\u00e1rf\u00e1s, and Ruszink\u00f3 (2000) proved that n/2 edges always suffice for diameter 4. The triangle-free requirement fundamentally changes the problem: it prevents using the most natural shortcut edges (which often create triangles), making diameter reduction much harder.",
+    "problemStatement": "**Question (OPEN):** Does there exist c > 0 such that h\u2084(G) < (1-c)n for all connected triangle-free graphs G on n vertices?\n\n**Known bounds:**\n- h\u2083(G) \u2264 n (tight: some G have h\u2083(G) \u2265 n - c)\n- h\u2084(G) \u2264 ? (OPEN)\n- h\u2085(G) \u2264 (n-1)/2",
+    "text": "Does there exist c > 0 such that h\u2084(G) < (1-c)n for triangle-free graphs G? Known: h\u2083 \u2264 n, h\u2085 \u2264 (n-1)/2. Status: OPEN.",
+    "proofStrategy": "The formalization defines the key concepts: TriangleFree (no K\u2083 subgraphs), graph diameter, addEdges (graph augmentation preserving simple graph properties), and h(G, r) as the minimum edges to achieve diameter \u2264 r while staying triangle-free. Known bounds for h\u2083 and h\u2085 from Erd\u0151s-Gy\u00e1rf\u00e1s-Ruszink\u00f3 (1998) are axiomatized, as is the without-triangle-free result of Alon-Gy\u00e1rf\u00e1s-Ruszink\u00f3 (2000). The open h\u2084 question is stated as a formal proposition. The summary theorem combines the h\u2083 and h\u2085 bounds.",
     "keyInsights": [
       "**Triangle-free constraint matters:** Without it, n/2 edges suffice for diameter 4 (AGR 2000). With it, the answer is unknown.",
-      "**Gap between h₃ and h₅:** h₃(G) ≤ n but h₅(G) ≤ (n-1)/2. The h₄ bound is the missing piece.",
-      "**Monotonicity:** h_r(G) ≥ h_{r+1}(G) — larger diameter is easier to achieve. So h₃ ≥ h₄ ≥ h₅.",
-      "**Tightness of h₃:** There exist triangle-free graphs needing nearly n edges for diameter 3.",
+      "**Gap between h\u2083 and h\u2085:** h\u2083(G) \u2264 n but h\u2085(G) \u2264 (n-1)/2. The h\u2084 bound is the missing piece.",
+      "**Monotonicity:** h_r(G) \u2265 h_{r+1}(G) \u2014 larger diameter is easier to achieve. So h\u2083 \u2265 h\u2084 \u2265 h\u2085.",
+      "**Tightness of h\u2083:** There exist triangle-free graphs needing nearly n edges for diameter 3.",
       "**The question:** Can we always save a constant fraction (cn edges) when targeting diameter 4 instead of 3?"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
       "Graph theory (vertices, edges, colorings)",
-      "Extremal graph theory (Turán-type problems)"
+      "Extremal graph theory (Tur\u00e1n-type problems)"
     ]
   },
   "sections": [
@@ -96,10 +96,10 @@
     {
       "id": "known-results",
       "title": "Known Results (1998)",
-      "summary": "h₃ ≤ n, h₃ ≥ n-c, h₅ ≤ (n-1)/2",
+      "summary": "h\u2083 \u2264 n, h\u2083 \u2265 n-c, h\u2085 \u2264 (n-1)/2",
       "startLine": 99,
       "endLine": 127,
-      "mathContext": "h₃ $\\leq$ n, h₃ $\\geq$ n-c, h₅ $\\leq$ (n-1)/2"
+      "mathContext": "h\u2083 $\\leq$ n, h\u2083 $\\geq$ n-c, h\u2085 $\\leq$ (n-1)/2"
     },
     {
       "id": "open-question",
@@ -112,10 +112,10 @@
     {
       "id": "without-constraint",
       "title": "Without Triangle-Free Constraint",
-      "summary": "Alon-Gyárfás-Ruszinkó 2000: n/2 suffices",
+      "summary": "Alon-Gy\u00e1rf\u00e1s-Ruszink\u00f3 2000: n/2 suffices",
       "startLine": 151,
       "endLine": 162,
-      "mathContext": "Mathematical content: Alon-Gyárfás-Ruszinkó 2000: n/2 suffices"
+      "mathContext": "Mathematical content: Alon-Gy\u00e1rf\u00e1s-Ruszink\u00f3 2000: n/2 suffices"
     },
     {
       "id": "examples",
@@ -128,7 +128,7 @@
     {
       "id": "monotonicity",
       "title": "Monotonicity Properties",
-      "summary": "h_monotone axiom: h_r ≥ h_{r+1}",
+      "summary": "h_monotone axiom: h_r \u2265 h_{r+1}",
       "startLine": 181,
       "endLine": 190,
       "mathContext": "h_monotone axiom: h_r $\\geq$ h_{r+1}"
@@ -143,13 +143,13 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #619 asks whether h₄(G) < (1-c)n for some c > 0 and all connected triangle-free graphs G. While h₃ ≤ n and h₅ ≤ (n-1)/2 are known (EGR 1998), the h₄ case remains OPEN. The triangle-free constraint is crucial — without it, n/2 edges always suffice for diameter 4.",
+    "summary": "Erd\u0151s Problem #619 asks whether h\u2084(G) < (1-c)n for some c > 0 and all connected triangle-free graphs G. While h\u2083 \u2264 n and h\u2085 \u2264 (n-1)/2 are known (EGR 1998), the h\u2084 case remains OPEN. The triangle-free constraint is crucial \u2014 without it, n/2 edges always suffice for diameter 4.",
     "implications": "The problem highlights the gap between diameter 3 and diameter 5 in the triangle-free setting, and connects to fundamental questions about how forbidden subgraph constraints affect diameter reduction in graphs.",
     "openQuestions": [
-      "What is the optimal bound for h₄(G) in triangle-free graphs?",
+      "What is the optimal bound for h\u2084(G) in triangle-free graphs?",
       "Are there triangle-free graphs requiring nearly n edges for diameter 4?",
       "Does the answer depend on graph structure (trees, bipartite, etc.)?",
-      "Can probabilistic methods help understand h₄?"
+      "Can probabilistic methods help understand h\u2084?"
     ]
   },
   "leanFile": {
@@ -172,12 +172,12 @@
   "references": [
     {
       "key": "EGR98",
-      "citation": "Erdős, P., Gyárfás, A., Ruszinkó, M. (1998)",
+      "citation": "Erd\u0151s, P., Gy\u00e1rf\u00e1s, A., Ruszink\u00f3, M. (1998)",
       "type": "paper"
     },
     {
       "key": "AGR00",
-      "citation": "Alon, N., Gyárfás, A., Ruszinkó, M. (2000)",
+      "citation": "Alon, N., Gy\u00e1rf\u00e1s, A., Ruszink\u00f3, M. (2000)",
       "type": "paper"
     }
   ],
@@ -185,17 +185,17 @@
     {
       "targetId": "erdos-128",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: extremal-graph-theory, graph-theory, triangle-free"
+      "description": "Related Erd\u0151s problem sharing themes: extremal-graph-theory, graph-theory, triangle-free"
     },
     {
       "targetId": "erdos-133",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: diameter, graph-theory, triangle-free"
+      "description": "Related Erd\u0151s problem sharing themes: diameter, graph-theory, triangle-free"
     },
     {
       "targetId": "erdos-134",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: diameter, graph-theory, triangle-free"
+      "description": "Related Erd\u0151s problem sharing themes: diameter, graph-theory, triangle-free"
     }
   ]
 }

--- a/src/data/proofs/erdos-634/meta.json
+++ b/src/data/proofs/erdos-634/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-634",
-  "title": "Erdős Problem #634: Triangle Dissection into Congruent Pieces",
+  "title": "Erd\u0151s Problem #634: Triangle Dissection into Congruent Pieces",
   "slug": "erdos-634",
-  "description": "Find all n such that some triangle can be cut into n congruent triangles. OPEN: k², 2k², 3k², k²+m² work; 7, 11 fail (Beeson); 19 unknown. $25 prize.",
+  "description": "Find all n such that some triangle can be cut into n congruent triangles. OPEN: k\u00b2, 2k\u00b2, 3k\u00b2, k\u00b2+m\u00b2 work; 7, 11 fail (Beeson); 19 unknown. $25 prize.",
   "meta": {
-    "author": "Erdős (problem), Beeson (negative results), Soifer (similar case), Snover-Waiveris-Williams, Zhang (2025)",
+    "author": "Erd\u0151s (problem), Beeson (negative results), Soifer (similar case), Snover-Waiveris-Williams, Zhang (2025)",
     "sourceUrl": "https://erdosproblems.com/634",
     "date": "ongoing",
     "status": "axiomatized",
@@ -43,7 +43,7 @@
     "originalContributions": [
       "Formal definition of triangle congruence via side length multisets",
       "Definition of triangle dissection and congruent dissection",
-      "Statement of known positive results (k², 2k², 3k², 6k², k²+m²)",
+      "Statement of known positive results (k\u00b2, 2k\u00b2, 3k\u00b2, 6k\u00b2, k\u00b2+m\u00b2)",
       "Axiomatization of Beeson's negative results (7, 11)",
       "Statement of the 4k+3 prime conjecture",
       "Soifer's theorem on similar dissections",
@@ -54,21 +54,21 @@
       "erdos-633"
     ],
     "axiomCount": 3,
-    "assumptions": "8 axiom declarations: seven_not_dissectable (Beeson: 7 fails), eleven_not_dissectable (Beeson: 11 fails), soifer_theorem (similar dissection complete), two_not_similar_dissectable (2 not similar-dissectable), three_not_similar_dissectable (3 not similar-dissectable), five_not_similar_dissectable (5 not similar-dissectable), sww_theorem (self-similar characterization), zhang_2025 (sufficient condition for large n)",
+    "assumptions": "3 axioms: seven_not_dissectable, eleven_not_dissectable, soifer_theorem. 7 sorries.",
     "lineCount": 298
   },
   "overview": {
-    "historicalContext": "**Triangle Dissection Problem — A Bridge Between Geometry and Number Theory**\n\nPaul Erdős posed this problem with a $25 prize, asking for a complete characterization of which positive integers $n$ allow some triangle to be dissected into $n$ congruent triangles. The problem appears in Erdős and Graham's 1980 monograph *Old and New Problems and Results in Combinatorial Number Theory*.\n\n**Known Positive Results**: The most natural construction uses **grid subdivision**: dividing each side of a triangle into $k$ equal parts produces $k^2$ congruent triangles. More sophisticated constructions yield $2k^2$ (via right triangle reflections), $3k^2$ (via equilateral triangle trisections), $6k^2$ (combining both), and $k^2 + m^2$ (via a two-scale grid). The special case $n = 27$ also works via an equilateral triangle construction that does not fit any of these parametric families.\n\n**Known Negative Results**: Michael Beeson proved in 2012 that no triangle can be dissected into exactly 7 or 11 congruent triangles, using exhaustive geometric case analysis of the possible edge-matching patterns at vertices. Both 7 and 11 are primes of the form $4k + 3$, which led to the conjecture that all such primes (except 3, which is $3 \\cdot 1^2$) are non-dissectable.\n\n**The Similar Case**: Alexander Soifer completely solved the analogous problem for *similar* (rather than congruent) triangles in his 1990 book *How Does One Cut a Triangle?*: all $n \\geq 1$ except 2, 3, and 5 admit similar dissections. The stark contrast between the similar and congruent cases highlights how rigidity (disallowing scaling) fundamentally changes the combinatorics.\n\n**Open**: The case $n = 19$ (the next prime of form $4k + 3$) remains unknown, and the complete characterization is still open with the $25 prize unclaimed.",
+    "historicalContext": "**Triangle Dissection Problem \u2014 A Bridge Between Geometry and Number Theory**\n\nPaul Erd\u0151s posed this problem with a $25 prize, asking for a complete characterization of which positive integers $n$ allow some triangle to be dissected into $n$ congruent triangles. The problem appears in Erd\u0151s and Graham's 1980 monograph *Old and New Problems and Results in Combinatorial Number Theory*.\n\n**Known Positive Results**: The most natural construction uses **grid subdivision**: dividing each side of a triangle into $k$ equal parts produces $k^2$ congruent triangles. More sophisticated constructions yield $2k^2$ (via right triangle reflections), $3k^2$ (via equilateral triangle trisections), $6k^2$ (combining both), and $k^2 + m^2$ (via a two-scale grid). The special case $n = 27$ also works via an equilateral triangle construction that does not fit any of these parametric families.\n\n**Known Negative Results**: Michael Beeson proved in 2012 that no triangle can be dissected into exactly 7 or 11 congruent triangles, using exhaustive geometric case analysis of the possible edge-matching patterns at vertices. Both 7 and 11 are primes of the form $4k + 3$, which led to the conjecture that all such primes (except 3, which is $3 \\cdot 1^2$) are non-dissectable.\n\n**The Similar Case**: Alexander Soifer completely solved the analogous problem for *similar* (rather than congruent) triangles in his 1990 book *How Does One Cut a Triangle?*: all $n \\geq 1$ except 2, 3, and 5 admit similar dissections. The stark contrast between the similar and congruent cases highlights how rigidity (disallowing scaling) fundamentally changes the combinatorics.\n\n**Open**: The case $n = 19$ (the next prime of form $4k + 3$) remains unknown, and the complete characterization is still open with the $25 prize unclaimed.",
     "problemStatement": "**Problem Statement**\n\nFind all positive integers $n$ such that there exists at least one triangle which can be dissected into $n$ congruent triangles.\n\n**Formally**: Characterize $\\{ n \\in \\mathbb{N} : \\exists \\, T, \\, T \\text{ can be partitioned into } n \\text{ congruent triangles} \\}$.\n\n**Status**: OPEN ($25 prize)\n\n**Known**: Works for $k^2$, $2k^2$, $3k^2$, $6k^2$, $k^2 + m^2$, and $27$. Fails for 7 and 11. Unknown for 19.",
-    "text": "Find all n such that some triangle can be cut into n congruent triangles. OPEN: k², 2k², 3k², k²+m² work; 7, 11 fail (Beeson); 19 unknown. $25 prize.",
-    "proofStrategy": "**The Formalization Strategy**\n\nThe formalization takes a **structural approach**, building up from basic geometric primitives to the full problem statement:\n\n1. **Triangle representation**: Triangles are defined by their three side lengths $(a, b, c)$ satisfying positivity and the triangle inequality, abstracting away coordinates\n2. **Congruence via multisets**: Two triangles are congruent if their side-length multisets $\\{a, b, c\\}$ agree — this elegantly handles all six orderings without explicit permutations\n3. **Dissection structure**: A dissection of $T$ into $n$ pieces is modeled as a function $\\text{Fin}\\, n \\to \\text{Triangle}$ with an area constraint\n4. **Separation of concerns**: Known results are stated as individual theorems with `sorry` (positive cases) or `axiom` (Beeson's negative results), cleanly separating what is constructive from what requires deep geometric arguments\n5. **The conjecture**: The $4k+3$ conjecture is stated as a Lean proposition, with the exception for $p = 3$ handled explicitly\n6. **Comparative analysis**: The formalization also covers Soifer's complete solution for similar dissections and the Snover–Waiveris–Williams characterization of self-similar dissections, providing context for the harder congruent case",
+    "text": "Find all n such that some triangle can be cut into n congruent triangles. OPEN: k\u00b2, 2k\u00b2, 3k\u00b2, k\u00b2+m\u00b2 work; 7, 11 fail (Beeson); 19 unknown. $25 prize.",
+    "proofStrategy": "**The Formalization Strategy**\n\nThe formalization takes a **structural approach**, building up from basic geometric primitives to the full problem statement:\n\n1. **Triangle representation**: Triangles are defined by their three side lengths $(a, b, c)$ satisfying positivity and the triangle inequality, abstracting away coordinates\n2. **Congruence via multisets**: Two triangles are congruent if their side-length multisets $\\{a, b, c\\}$ agree \u2014 this elegantly handles all six orderings without explicit permutations\n3. **Dissection structure**: A dissection of $T$ into $n$ pieces is modeled as a function $\\text{Fin}\\, n \\to \\text{Triangle}$ with an area constraint\n4. **Separation of concerns**: Known results are stated as individual theorems with `sorry` (positive cases) or `axiom` (Beeson's negative results), cleanly separating what is constructive from what requires deep geometric arguments\n5. **The conjecture**: The $4k+3$ conjecture is stated as a Lean proposition, with the exception for $p = 3$ handled explicitly\n6. **Comparative analysis**: The formalization also covers Soifer's complete solution for similar dissections and the Snover\u2013Waiveris\u2013Williams characterization of self-similar dissections, providing context for the harder congruent case",
     "keyInsights": [
       "**Multiset congruence** captures triangle congruence without coordinates: $\\{a, b, c\\} = \\{a', b', c'\\}$ naturally handles all six possible side orderings, making the equivalence relation trivially reflexive, symmetric, and transitive",
       "**Grid subdivision** is the fundamental positive construction: dividing each side of any triangle into $k$ equal segments yields $k^2$ congruent sub-triangles via barycentric coordinates, which is why perfect squares are always dissectable",
       "**The 4k+3 pattern** connects dissectability to quadratic residues: integers representable as sums of two squares are exactly those whose prime factorization has all $4k+3$ primes appearing to even powers (Fermat's theorem on sums of two squares), mirroring the structure of known dissectable values",
-      "**Congruence vs. similarity gap**: Soifer's complete answer ($n \\neq 2, 3, 5$) for similar dissections shows that scaling freedom eliminates most obstructions — the congruence constraint forces exact edge matching at every vertex, creating rigid combinatorial constraints",
-      "**27 as an outlier**: The dissectability of 27 = $3^3$ shows the problem is not purely about quadratic forms — this special equilateral construction does not fit the $k^2$, $2k^2$, $3k^2$, or $k^2 + m^2$ families, suggesting additional sufficient conditions may exist",
-      "**Self-similar vs. congruent**: The Snover–Waiveris–Williams theorem restricts self-similar dissections (pieces similar to the original) to $n \\in \\{k^2, k^2 + m^2, 3k^2\\}$ — a much tighter characterization than the general congruent case"
+      "**Congruence vs. similarity gap**: Soifer's complete answer ($n \\neq 2, 3, 5$) for similar dissections shows that scaling freedom eliminates most obstructions \u2014 the congruence constraint forces exact edge matching at every vertex, creating rigid combinatorial constraints",
+      "**27 as an outlier**: The dissectability of 27 = $3^3$ shows the problem is not purely about quadratic forms \u2014 this special equilateral construction does not fit the $k^2$, $2k^2$, $3k^2$, or $k^2 + m^2$ families, suggesting additional sufficient conditions may exist",
+      "**Self-similar vs. congruent**: The Snover\u2013Waiveris\u2013Williams theorem restricts self-similar dissections (pieces similar to the original) to $n \\in \\{k^2, k^2 + m^2, 3k^2\\}$ \u2014 a much tighter characterization than the general congruent case"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -79,10 +79,10 @@
     {
       "id": "header",
       "title": "Problem Header and Imports",
-      "summary": "Documentation of Erdős Problem #634 with known results, references, and Mathlib import for access to multisets, big operators, and primality.",
+      "summary": "Documentation of Erd\u0151s Problem #634 with known results, references, and Mathlib import for access to multisets, big operators, and primality.",
       "startLine": 1,
       "endLine": 35,
-      "mathContext": "Mathematical content: Documentation of Erdős Problem #634 with known results, references, and Mathlib import for access to multisets, big operators, and primality."
+      "mathContext": "Mathematical content: Documentation of Erd\u0151s Problem #634 with known results, references, and Mathlib import for access to multisets, big operators, and primality."
     },
     {
       "id": "triangles",
@@ -111,10 +111,10 @@
     {
       "id": "positive",
       "title": "Known Positive Results",
-      "summary": "Theorems asserting dissectability for $k^2$ (grid subdivision), $2k^2$, $3k^2$ (equilateral trisection), $6k^2$, $k^2 + m^2$ (two-scale grids), and the special case $27$ — all with `sorry` proofs pending geometric constructions.",
+      "summary": "Theorems asserting dissectability for $k^2$ (grid subdivision), $2k^2$, $3k^2$ (equilateral trisection), $6k^2$, $k^2 + m^2$ (two-scale grids), and the special case $27$ \u2014 all with `sorry` proofs pending geometric constructions.",
       "startLine": 103,
       "endLine": 133,
-      "mathContext": "Theorems asserting dissectability for $k^2$ (grid subdivision), $2k^2$, $3k^2$ (equilateral trisection), $6k^2$, $k^2 + m^2$ (two-scale grids), and the special case $27$ — all with `sorry` proofs pending geometric constructions."
+      "mathContext": "Theorems asserting dissectability for $k^2$ (grid subdivision), $2k^2$, $3k^2$ (equilateral trisection), $6k^2$, $k^2 + m^2$ (two-scale grids), and the special case $27$ \u2014 all with `sorry` proofs pending geometric constructions."
     },
     {
       "id": "beeson",
@@ -150,7 +150,7 @@
     },
     {
       "id": "self-similar",
-      "title": "Self-Similar Dissections (Snover–Waiveris–Williams)",
+      "title": "Self-Similar Dissections (Snover\u2013Waiveris\u2013Williams)",
       "summary": "Defines `IsSelfSimilarDissection` (pieces similar to the original) and axiomatizes the SWW characterization: $n$ is self-similar-dissectable iff $n \\in \\{k^2\\} \\cup \\{k^2 + m^2\\} \\cup \\{3k^2\\}$.",
       "startLine": 225,
       "endLine": 246,
@@ -166,7 +166,7 @@
     },
     {
       "id": "main-result",
-      "title": "Main Results — Erdős Problem #634",
+      "title": "Main Results \u2014 Erd\u0151s Problem #634",
       "summary": "The partial answer theorem `erdos_634_partial`: $\\forall k \\geq 1, \\text{IsDissectable}(k^2) \\wedge \\neg\\text{IsDissectable}\\, 7 \\wedge \\neg\\text{IsDissectable}\\, 11$, combining the grid subdivision theorem with Beeson's axioms.",
       "startLine": 265,
       "endLine": 298,
@@ -174,8 +174,8 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #634 asks for a complete characterization of which positive integers $n$ allow some triangle to be dissected into $n$ congruent triangles. The formalization captures the known positive results ($k^2$, $2k^2$, $3k^2$, $6k^2$, $k^2 + m^2$, 27), Beeson's impossibility proofs for 7 and 11, the $4k+3$ prime conjecture, Soifer's complete solution for similar dissections, and the Snover–Waiveris–Williams characterization of self-similar dissections.",
-    "implications": "1. **Geometry–Number Theory Bridge**: The pattern that non-dissectable values are primes of form $4k + 3$ connects dissection geometry to quadratic residues and Fermat's theorem on sums of two squares — integers not representable as $a^2 + b^2$ are exactly those with a $4k+3$ prime factor appearing to an odd power\n\n2. **Rigidity vs.\n\nFlexibility**: The contrast between the completely solved similar case (only 3 exceptions) and the wide-open congruent case demonstrates how removing even one degree of freedom (scaling) can transform a tractable problem into a deep open question\n\n3. **Constructive vs. Obstructive Arguments**: The positive results are constructive (explicit dissections), while the negative results require exhaustive case analysis — no unified obstruction theory exists\n\n4. **Computational Aspects**: Beeson's proofs for 7 and 11 use computer-assisted exhaustive search over vertex configurations — extending this to 19 would require significantly more computational resources.",
+    "summary": "Erd\u0151s Problem #634 asks for a complete characterization of which positive integers $n$ allow some triangle to be dissected into $n$ congruent triangles. The formalization captures the known positive results ($k^2$, $2k^2$, $3k^2$, $6k^2$, $k^2 + m^2$, 27), Beeson's impossibility proofs for 7 and 11, the $4k+3$ prime conjecture, Soifer's complete solution for similar dissections, and the Snover\u2013Waiveris\u2013Williams characterization of self-similar dissections.",
+    "implications": "1. **Geometry\u2013Number Theory Bridge**: The pattern that non-dissectable values are primes of form $4k + 3$ connects dissection geometry to quadratic residues and Fermat's theorem on sums of two squares \u2014 integers not representable as $a^2 + b^2$ are exactly those with a $4k+3$ prime factor appearing to an odd power\n\n2. **Rigidity vs.\n\nFlexibility**: The contrast between the completely solved similar case (only 3 exceptions) and the wide-open congruent case demonstrates how removing even one degree of freedom (scaling) can transform a tractable problem into a deep open question\n\n3. **Constructive vs. Obstructive Arguments**: The positive results are constructive (explicit dissections), while the negative results require exhaustive case analysis \u2014 no unified obstruction theory exists\n\n4. **Computational Aspects**: Beeson's proofs for 7 and 11 use computer-assisted exhaustive search over vertex configurations \u2014 extending this to 19 would require significantly more computational resources.",
     "openQuestions": [
       "Is 19 dissectable into congruent triangles? This is the smallest unknown case and the next prime of form $4k + 3$ after 7 and 11",
       "Is the $4k+3$ prime conjecture true? If so, it would give a clean number-theoretic characterization of non-dissectable primes",
@@ -208,22 +208,22 @@
     },
     {
       "key": "Soifer",
-      "citation": "Soifer, A. 'How Does One Cut a Triangle?' (1990, 2nd ed. 2009). Springer. Complete solution for similar triangle dissections: all n ≥ 1 except 2, 3, 5.",
+      "citation": "Soifer, A. 'How Does One Cut a Triangle?' (1990, 2nd ed. 2009). Springer. Complete solution for similar triangle dissections: all n \u2265 1 except 2, 3, 5.",
       "type": "book"
     },
     {
       "key": "SWW",
-      "citation": "Snover, S., Waiveris, C., and Williams, J. 'Rep-Tiling for Triangles.' Discrete Mathematics 91(2), 193–200 (1991). Characterizes which n allow dissection into n similar copies of the original triangle.",
+      "citation": "Snover, S., Waiveris, C., and Williams, J. 'Rep-Tiling for Triangles.' Discrete Mathematics 91(2), 193\u2013200 (1991). Characterizes which n allow dissection into n similar copies of the original triangle.",
       "type": "paper"
     },
     {
       "key": "Zhang2025",
-      "citation": "Zhang (2025). 'On sufficient conditions for triangle dissectability.' Establishes that for fixed aspect ratios, sufficiently large n²ab are dissectable.",
+      "citation": "Zhang (2025). 'On sufficient conditions for triangle dissectability.' Establishes that for fixed aspect ratios, sufficiently large n\u00b2ab are dissectable.",
       "type": "paper"
     },
     {
       "key": "ErdosGraham",
-      "citation": "Erdős, P. and Graham, R.L. 'Old and New Problems and Results in Combinatorial Number Theory.' L'Enseignement Mathématique, Monograph 28 (1980). Contains the original problem statement.",
+      "citation": "Erd\u0151s, P. and Graham, R.L. 'Old and New Problems and Results in Combinatorial Number Theory.' L'Enseignement Math\u00e9matique, Monograph 28 (1980). Contains the original problem statement.",
       "type": "book"
     }
   ],
@@ -231,12 +231,12 @@
     {
       "targetId": "erdos-633",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: dissection, geometry"
+      "description": "Related Erd\u0151s problem sharing themes: dissection, geometry"
     },
     {
       "targetId": "erdos-106",
       "relationship": "related",
-      "description": "Both concern geometric dissection/packing problems. Problem #106 studies square packing in the unit square, while #634 studies triangle dissection into congruent pieces — both ask about optimal decomposition of geometric shapes"
+      "description": "Both concern geometric dissection/packing problems. Problem #106 studies square packing in the unit square, while #634 studies triangle dissection into congruent pieces \u2014 both ask about optimal decomposition of geometric shapes"
     }
   ]
 }


### PR DESCRIPTION
## Fix

Corrects stale `assumptions` text in 10 gallery proof `meta.json` files where the human-readable description listed more axioms than the actual `axiomCount` field, reflecting pre-Aristotle state.

## Changes

| Proof | Old count | New count | Actual axioms |
|-------|-----------|-----------|---------------|
| erdos-634 | 8 | 3 | seven_not_dissectable, eleven_not_dissectable, soifer_theorem |
| erdos-619 | 7 | 2 | h3_upper_bound, h5_upper_bound |
| erdos-618 | 7 | 2 | main_conjecture_proved, threshold_is_sharp |
| erdos-581 | 8 | 3 | f, alon_upper_bound, alon_lower_bound |
| erdos-580 | 6 | 1 | zhao_theorem |
| erdos-562 | 7 | 2 | erdos_szekeres_lower, erdos_szekeres_upper |
| erdos-555 | 5 | 0 | (all axioms removed by Aristotle) |
| erdos-512 | 7 | 2 | konyagin_theorem, mcgehee_pigno_smith_theorem |
| erdos-502 | 7 | 2 | lower_bound_improved, upper_bound_bbs |
| erdos-495 | 7 | 2 | littlewood_rational_case, ekl_countable_exceptions |

## Verification

- `axiomCount` (numeric) was already correct in all files; only the text `assumptions` field needed updating
- Axiom names verified by `grep "^axiom "` on each Lean source file

---
Automated fix by lean-mechanic agent.