### PR TITLE
fix(meta): correct stale assumptions text for 10 gallery proofs (batch 29)

### DIFF
--- a/src/data/proofs/erdos-166/meta.json
+++ b/src/data/proofs/erdos-166/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-166",
-  "title": "Erdős Problem #166: Ramsey Number R(4,k) Lower Bound",
+  "title": "Erd\u0151s Problem #166: Ramsey Number R(4,k) Lower Bound",
   "slug": "erdos-166",
-  "description": "Prove that R(4,k) >> k³/(log k)^O(1). SOLVED by Mattheus-Verstraete (2023): R(4,k) >> k³/(log k)⁴, earning the $250 Erdős prize.",
+  "description": "Prove that R(4,k) >> k\u00b3/(log k)^O(1). SOLVED by Mattheus-Verstraete (2023): R(4,k) >> k\u00b3/(log k)\u2074, earning the $250 Erd\u0151s prize.",
   "meta": {
-    "author": "Erdős, Spencer, Ajtai, Komlós, Szemerédi, Mattheus, Verstraete",
+    "author": "Erd\u0151s, Spencer, Ajtai, Koml\u00f3s, Szemer\u00e9di, Mattheus, Verstraete",
     "sourceUrl": "https://erdosproblems.com/166",
     "date": "2023",
     "status": "axiomatized",
@@ -62,31 +62,31 @@
       "ramsey_one_left: Verified proof R(1,t) = 1 by singleton witness construction",
       "ramsey_two_left: Verified proof R(2,t) = t via edge-case analysis and le_antisymm",
       "spencer_lower_bound: Axiom encoding Spencer's 1977 probabilistic bound (k log k)^{5/2}",
-      "aks_upper_bound: Axiom encoding AKS 1980 greedy coloring bound k³/(log k)²",
-      "mattheus_verstraete: Axiom encoding the 2023 solution k³/(log k)⁴",
+      "aks_upper_bound: Axiom encoding AKS 1980 greedy coloring bound k\u00b3/(log k)\u00b2",
+      "mattheus_verstraete: Axiom encoding the 2023 solution k\u00b3/(log k)\u2074",
       "Erdos166Statement: Formal problem statement as existential over constants",
       "erdos_166_solved: Verified proof the problem is solved (instantiates A=4)",
       "current_bounds: Combined sandwich inequality packaging both bounds",
-      "logarithmic_gap: Verified analysis of remaining gap in log k exponent (2 ≤ α ≤ 4)"
+      "logarithmic_gap: Verified analysis of remaining gap in log k exponent (2 \u2264 \u03b1 \u2264 4)"
     ],
     "dateAdded": "2026-01-19",
     "axiomCount": 2,
     "lineCount": 269,
-    "assumptions": "7 axioms: ramsey_3_3, ramsey_4_4, ramsey_4_5, and 4 more. See Lean source for complete statements.",
+    "assumptions": "2 axioms: aks_upper_bound, mattheus_verstraete. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Erdős offered $250 for proving that $R(4,k)$ grows like $k^3$ up to polylogarithmic factors. Spencer (1977) gave the first non-trivial lower bound $R(4,k) \\geq c(k \\log k)^{5/2}$ using the probabilistic method with dependent random choices. Ajtai, Komlós, and Szemerédi (1980) established the complementary upper bound $R(4,k) \\leq Ck^3/(\\log k)^2$ using a greedy algorithm, confirming that $R(4,k) = \\Theta(k^3/(\\log k)^\\alpha)$ for some $\\alpha$. For 43 years, closing this gap—improving the lower bound exponent from $5/2$ on $(k\\log k)$ to cubic in $k$—resisted all probabilistic approaches. The breakthrough came in 2023 when Sam Mattheus and Jacques Verstraete proved $R(4,k) \\geq ck^3/(\\log k)^4$ using algebraic constructions from finite geometry: $K_4$-free graphs built from incidence structures of classical polar spaces over $\\mathbb{F}_q$. This earned them the $250 Erdős prize and demonstrated that algebraic methods can succeed where probabilistic ones plateau.",
+    "historicalContext": "Erd\u0151s offered $250 for proving that $R(4,k)$ grows like $k^3$ up to polylogarithmic factors. Spencer (1977) gave the first non-trivial lower bound $R(4,k) \\geq c(k \\log k)^{5/2}$ using the probabilistic method with dependent random choices. Ajtai, Koml\u00f3s, and Szemer\u00e9di (1980) established the complementary upper bound $R(4,k) \\leq Ck^3/(\\log k)^2$ using a greedy algorithm, confirming that $R(4,k) = \\Theta(k^3/(\\log k)^\\alpha)$ for some $\\alpha$. For 43 years, closing this gap\u2014improving the lower bound exponent from $5/2$ on $(k\\log k)$ to cubic in $k$\u2014resisted all probabilistic approaches. The breakthrough came in 2023 when Sam Mattheus and Jacques Verstraete proved $R(4,k) \\geq ck^3/(\\log k)^4$ using algebraic constructions from finite geometry: $K_4$-free graphs built from incidence structures of classical polar spaces over $\\mathbb{F}_q$. This earned them the $250 Erd\u0151s prize and demonstrated that algebraic methods can succeed where probabilistic ones plateau.",
     "problemStatement": "Prove that $R(4,k) \\gg k^3/(\\log k)^{O(1)}$, where $R(4,k)$ is the Ramsey number representing the minimum $N$ such that any 2-coloring of $K_N$ contains either a monochromatic $K_4$ or a monochromatic $K_k$.",
-    "text": "Prove that R(4,k) >> k³/(log k)^O(1). SOLVED by Mattheus-Verstraete (2023): R(4,k) >> k³/(log k)⁴, earning the $250 Erdős prize.",
-    "proofStrategy": "The formalization defines $R(s,t)$ as $\\inf\\{N : \\forall c : \\text{Sym2}(\\text{Fin}\\,N) \\to \\text{Bool},\\, \\exists K_s^{\\text{red}} \\lor K_t^{\\text{blue}}\\}$ and verifies fundamental properties from scratch: symmetry via color complementation, $R(1,t) = 1$ by singleton witness, and $R(2,t) = t$ by a detailed $\\text{le\\_antisymm}$ argument with edge-case analysis. Known exact values ($R(3,3) = 6$, $R(4,4) = 18$, $R(4,5) = 25$) and asymptotic bounds ($R(3,k) = \\Theta(k^2/\\log k)$) are axiomatized. The historical bounds—Spencer's $(k \\log k)^{5/2}$, AKS's $k^3/(\\log k)^2$, and Mattheus-Verstraete's $k^3/(\\log k)^4$—are axiomatized and combined into the resolution `erdos_166_solved` (instantiating $A = 4$), a sandwich `current_bounds`, and a `logarithmic_gap` analysis showing $2 \\leq \\alpha \\leq 4$.",
+    "text": "Prove that R(4,k) >> k\u00b3/(log k)^O(1). SOLVED by Mattheus-Verstraete (2023): R(4,k) >> k\u00b3/(log k)\u2074, earning the $250 Erd\u0151s prize.",
+    "proofStrategy": "The formalization defines $R(s,t)$ as $\\inf\\{N : \\forall c : \\text{Sym2}(\\text{Fin}\\,N) \\to \\text{Bool},\\, \\exists K_s^{\\text{red}} \\lor K_t^{\\text{blue}}\\}$ and verifies fundamental properties from scratch: symmetry via color complementation, $R(1,t) = 1$ by singleton witness, and $R(2,t) = t$ by a detailed $\\text{le\\_antisymm}$ argument with edge-case analysis. Known exact values ($R(3,3) = 6$, $R(4,4) = 18$, $R(4,5) = 25$) and asymptotic bounds ($R(3,k) = \\Theta(k^2/\\log k)$) are axiomatized. The historical bounds\u2014Spencer's $(k \\log k)^{5/2}$, AKS's $k^3/(\\log k)^2$, and Mattheus-Verstraete's $k^3/(\\log k)^4$\u2014are axiomatized and combined into the resolution `erdos_166_solved` (instantiating $A = 4$), a sandwich `current_bounds`, and a `logarithmic_gap` analysis showing $2 \\leq \\alpha \\leq 4$.",
     "keyInsights": [
       "**Ramsey numbers $R(4,k)$ grow cubically in $k$:** Both the AKS upper bound $k^3/(\\log k)^2$ and the Mattheus-Verstraete lower bound $k^3/(\\log k)^4$ confirm $R(4,k) = \\Theta(k^3/(\\log k)^\\alpha)$ for $2 \\leq \\alpha \\leq 4$.",
       "**Algebraic constructions broke the probabilistic barrier:** For 43 years, probabilistic methods could not improve Spencer's $(k \\log k)^{5/2}$ to cubic. Mattheus-Verstraete used incidence graphs of polar spaces over $\\mathbb{F}_q$, achieving $q^3$ vertices, no $K_4$, and independence number $O(q)$.",
       "**The color-swap symmetry $R(s,t) = R(t,s)$ is fully verified:** The proof uses Boolean negation $c \\mapsto \\neg c$ with `congr!` and `aesop`, cleanly demonstrating Lean's automation on combinatorial symmetry arguments.",
-      "**$R(2,t) = t$ is a non-trivial verification:** Despite being elementary, the formal proof requires careful handling of `sInf`, `le_antisymm`, `Finset.card`, and case analysis on Boolean colorings—a good test of Lean's infrastructure.",
+      "**$R(2,t) = t$ is a non-trivial verification:** Despite being elementary, the formal proof requires careful handling of `sInf`, `le_antisymm`, `Finset.card`, and case analysis on Boolean colorings\u2014a good test of Lean's infrastructure.",
       "**The remaining gap is purely logarithmic:** After Mattheus-Verstraete, the open question reduces to determining the exact exponent of $\\log k$ in $R(4,k) \\sim k^3/(\\log k)^\\alpha$, with $2 \\leq \\alpha \\leq 4$.",
-      "**Prize problems drive mathematical progress:** Erdős's $250 bounty on this problem focused attention on a specific barrier, and the eventual algebraic solution opened new techniques applicable to other Ramsey problems."
+      "**Prize problems drive mathematical progress:** Erd\u0151s's $250 bounty on this problem focused attention on a specific barrier, and the eventual algebraic solution opened new techniques applicable to other Ramsey problems."
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -133,16 +133,16 @@
       "title": "AKS Upper Bound",
       "startLine": 170,
       "endLine": 181,
-      "summary": "Axiomatizes the Ajtai-Komlós-Szemerédi 1980 upper bound $R(4,k) \\leq Ck^3/(\\log k)^2$ from greedy coloring. Established the cubic benchmark for $R(4,k)$.",
-      "mathContext": "Axiomatized: Axiomatizes the Ajtai-Komlós-Szemerédi 1980 upper bound $R(4,k) \\leq Ck^3/(\\log k)^2$ from greedy coloring. Established the cubic benchmark for $R(4,k)$."
+      "summary": "Axiomatizes the Ajtai-Koml\u00f3s-Szemer\u00e9di 1980 upper bound $R(4,k) \\leq Ck^3/(\\log k)^2$ from greedy coloring. Established the cubic benchmark for $R(4,k)$.",
+      "mathContext": "Axiomatized: Axiomatizes the Ajtai-Koml\u00f3s-Szemer\u00e9di 1980 upper bound $R(4,k) \\leq Ck^3/(\\log k)^2$ from greedy coloring. Established the cubic benchmark for $R(4,k)$."
     },
     {
       "id": "section-6",
       "title": "The Solution: Mattheus-Verstraete 2023",
       "startLine": 184,
       "endLine": 195,
-      "summary": "Axiomatizes the breakthrough $R(4,k) \\geq ck^3/(\\log k)^4$ using algebraic constructions from finite geometry (polar spaces over $\\mathbb{F}_q$). Solved Erdős #166, earned \\$250 prize.",
-      "mathContext": "Axiomatized: Axiomatizes the breakthrough $R(4,k) \\geq ck^3/(\\log k)^4$ using algebraic constructions from finite geometry (polar spaces over $\\mathbb{F}_q$). Solved Erdős #166, earned \\$250 prize."
+      "summary": "Axiomatizes the breakthrough $R(4,k) \\geq ck^3/(\\log k)^4$ using algebraic constructions from finite geometry (polar spaces over $\\mathbb{F}_q$). Solved Erd\u0151s #166, earned \\$250 prize.",
+      "mathContext": "Axiomatized: Axiomatizes the breakthrough $R(4,k) \\geq ck^3/(\\log k)^4$ using algebraic constructions from finite geometry (polar spaces over $\\mathbb{F}_q$). Solved Erd\u0151s #166, earned \\$250 prize."
     },
     {
       "id": "section-7",
@@ -162,8 +162,8 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #166 was SOLVED by Mattheus and Verstraete in 2023, earning the $250 Erdős prize. The answer is YES: $R(4,k) \\geq c \\cdot k^3/(\\log k)^4$ for some $c > 0$. The formalization verifies three fundamental Ramsey properties from scratch (symmetry, $R(1,t)=1$, $R(2,t)=t$) and axiomatizes the three historical bounds that frame the problem's 46-year arc from Spencer to Mattheus-Verstraete.",
-    "implications": "**Theoretical Significance**: The Mattheus-Verstraete solution demonstrates the power of algebraic graph constructions from finite geometry in Ramsey theory.\n\nTheir technique—building $K_4$-free graphs from incidence structures of polar spaces over $\\mathbb{F}_q$—provides a new paradigm for constructing extremal graphs, potentially applicable to $R(s,k)$ for $s \\geq 5$ and to hypergraph Ramsey problems. The remaining polylogarithmic gap ($\\alpha \\in [2,4]$) is now the central open question.",
+    "summary": "Erd\u0151s Problem #166 was SOLVED by Mattheus and Verstraete in 2023, earning the $250 Erd\u0151s prize. The answer is YES: $R(4,k) \\geq c \\cdot k^3/(\\log k)^4$ for some $c > 0$. The formalization verifies three fundamental Ramsey properties from scratch (symmetry, $R(1,t)=1$, $R(2,t)=t$) and axiomatizes the three historical bounds that frame the problem's 46-year arc from Spencer to Mattheus-Verstraete.",
+    "implications": "**Theoretical Significance**: The Mattheus-Verstraete solution demonstrates the power of algebraic graph constructions from finite geometry in Ramsey theory.\n\nTheir technique\u2014building $K_4$-free graphs from incidence structures of polar spaces over $\\mathbb{F}_q$\u2014provides a new paradigm for constructing extremal graphs, potentially applicable to $R(s,k)$ for $s \\geq 5$ and to hypergraph Ramsey problems. The remaining polylogarithmic gap ($\\alpha \\in [2,4]$) is now the central open question.",
     "openQuestions": [
       "What is the exact exponent $\\alpha$ in $R(4,k) = \\Theta(k^3/(\\log k)^\\alpha)$? Is $\\alpha = 2$ (matching AKS) or $\\alpha = 4$ (matching Mattheus-Verstraete)?",
       "Can the Mattheus-Verstraete technique extend to prove $R(5,k) \\gg k^4/(\\log k)^{O(1)}$?",
@@ -193,17 +193,17 @@
     {
       "targetId": "erdos-165",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, graph-theory, probabilistic-method, ramsey-theory"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, graph-theory, probabilistic-method, ramsey-theory"
     },
     {
       "targetId": "erdos-812",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, graph-theory, probabilistic-method, ramsey-theory"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, graph-theory, probabilistic-method, ramsey-theory"
     },
     {
       "targetId": "erdos-1014",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, graph-theory, ramsey-theory"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, graph-theory, ramsey-theory"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-174/meta.json
+++ b/src/data/proofs/erdos-174/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-174",
-  "title": "Erdős Problem #174: Euclidean Ramsey Sets",
+  "title": "Erd\u0151s Problem #174: Euclidean Ramsey Sets",
   "slug": "erdos-174",
-  "description": "Characterize which finite sets in ℝⁿ are Ramsey: guaranteed to contain monochromatic copies under any k-coloring of high-dimensional space. Known: Ramsey implies spherical. OPEN: Is every spherical set Ramsey?",
+  "description": "Characterize which finite sets in \u211d\u207f are Ramsey: guaranteed to contain monochromatic copies under any k-coloring of high-dimensional space. Known: Ramsey implies spherical. OPEN: Is every spherical set Ramsey?",
   "meta": {
-    "author": "Erdős, Graham, Montgomery, Rothschild, Spencer, Straus (1973)",
+    "author": "Erd\u0151s, Graham, Montgomery, Rothschild, Spencer, Straus (1973)",
     "sourceUrl": "https://erdosproblems.com/174",
     "date": "1973",
     "status": "axiomatized",
@@ -56,7 +56,7 @@
     "references": [
       {
         "title": "Euclidean Ramsey theorems, I",
-        "authors": "P. Erdős, R. L. Graham, P. Montgomery, B. L. Rothschild, J. Spencer, E. G. Straus",
+        "authors": "P. Erd\u0151s, R. L. Graham, P. Montgomery, B. L. Rothschild, J. Spencer, E. G. Straus",
         "year": 1973,
         "venue": "Journal of Combinatorial Theory, Series A",
         "url": "https://doi.org/10.1016/0097-3165(73)90011-3",
@@ -64,7 +64,7 @@
       },
       {
         "title": "A partition property of simplices in Euclidean space",
-        "authors": "P. Frankl, V. Rödl",
+        "authors": "P. Frankl, V. R\u00f6dl",
         "year": 1990,
         "venue": "Journal of the American Mathematical Society",
         "url": "https://doi.org/10.2307/1990928",
@@ -79,18 +79,18 @@
         "description": "Proposes subtransitivity as the characterizing property for Euclidean Ramsey sets"
       }
     ],
-    "assumptions": "10 axioms: ramsey_implies_spherical, rectangle_is_ramsey, simplex_is_ramsey, and 7 more. See Lean source for complete statements."
+    "assumptions": "5 axioms: ramsey_implies_spherical, rectangle_is_ramsey, simplex_is_ramsey, trapezoid_is_ramsey, collinear_not_spherical. 0 sorries."
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #174: Euclidean Ramsey Sets**\n\nEuclidean Ramsey theory was founded by Erdős, Graham, Montgomery, Rothschild, Spencer, and Straus in their landmark 1973 paper. The theory extends classical combinatorial Ramsey theory into the geometric realm: which finite point configurations are guaranteed to appear monochromatically in any coloring of high-dimensional Euclidean space?\n\n**Key Developments:**\n- EGMRSS (1973): Proved the necessary condition — every Ramsey set must be spherical\n- Frankl-Rödl (1990): All non-degenerate simplices are Ramsey\n- Kříž (1991-92): Regular polygons, polyhedra, and trapezoids are Ramsey\n- Leader-Russell-Walters (2012): Proposed subtransitivity as the characterizing property\n\n**The Open Problem:**\nThe characterization question remains unsolved. Graham conjectures that every spherical set is Ramsey. The LRW conjecture offers an algebraic alternative: Ramsey iff subtransitive. Neither has been proved or disproved.",
-    "problemStatement": "A finite set A ⊂ ℝⁿ is called Ramsey if, for any k ≥ 1, there exists d = d(A,k) such that in any k-coloring of ℝᵈ there exists a monochromatic congruent copy of A. Characterize the Ramsey sets in ℝⁿ.",
-    "text": "Characterize which finite sets in ℝⁿ are Ramsey: guaranteed to contain monochromatic copies under any k-coloring of high-dimensional space. Known: Ramsey implies spherical. OPEN: Is every spherical set Ramsey?",
+    "historicalContext": "**Erd\u0151s Problem #174: Euclidean Ramsey Sets**\n\nEuclidean Ramsey theory was founded by Erd\u0151s, Graham, Montgomery, Rothschild, Spencer, and Straus in their landmark 1973 paper. The theory extends classical combinatorial Ramsey theory into the geometric realm: which finite point configurations are guaranteed to appear monochromatically in any coloring of high-dimensional Euclidean space?\n\n**Key Developments:**\n- EGMRSS (1973): Proved the necessary condition \u2014 every Ramsey set must be spherical\n- Frankl-R\u00f6dl (1990): All non-degenerate simplices are Ramsey\n- K\u0159\u00ed\u017e (1991-92): Regular polygons, polyhedra, and trapezoids are Ramsey\n- Leader-Russell-Walters (2012): Proposed subtransitivity as the characterizing property\n\n**The Open Problem:**\nThe characterization question remains unsolved. Graham conjectures that every spherical set is Ramsey. The LRW conjecture offers an algebraic alternative: Ramsey iff subtransitive. Neither has been proved or disproved.",
+    "problemStatement": "A finite set A \u2282 \u211d\u207f is called Ramsey if, for any k \u2265 1, there exists d = d(A,k) such that in any k-coloring of \u211d\u1d48 there exists a monochromatic congruent copy of A. Characterize the Ramsey sets in \u211d\u207f.",
+    "text": "Characterize which finite sets in \u211d\u207f are Ramsey: guaranteed to contain monochromatic copies under any k-coloring of high-dimensional space. Known: Ramsey implies spherical. OPEN: Is every spherical set Ramsey?",
     "proofStrategy": "The necessary condition (spherical) is proved via a contrapositive argument using distance-based colorings. The sufficient direction (characterizing which spherical sets are Ramsey) remains open, with Graham's conjecture and the Leader-Russell-Walters subtransitivity conjecture as the main candidates.",
     "keyInsights": [
-      "Every Ramsey set must be spherical — lie on the surface of some sphere",
+      "Every Ramsey set must be spherical \u2014 lie on the surface of some sphere",
       "Known Ramsey families: rectangles, simplices, trapezoids, regular polygons",
-      "Graham conjectures spherical ⟹ Ramsey (complete characterization)",
-      "LRW conjectures Ramsey ⟺ subtransitive (alternate characterization)",
+      "Graham conjectures spherical \u27f9 Ramsey (complete characterization)",
+      "LRW conjectures Ramsey \u27fa subtransitive (alternate characterization)",
       "The characterization problem cannot be resolved by finite computation"
     ],
     "prerequisites": [
@@ -174,7 +174,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #174 is OPEN. The necessary condition (spherical) is known, but the complete characterization of Ramsey sets remains elusive. Graham's conjecture and the LRW subtransitivity conjecture represent the two main candidate characterizations.",
+    "summary": "Erd\u0151s Problem #174 is OPEN. The necessary condition (spherical) is known, but the complete characterization of Ramsey sets remains elusive. Graham's conjecture and the LRW subtransitivity conjecture represent the two main candidate characterizations.",
     "implications": "A resolution would unify the known Ramsey constructions and potentially yield new algebraic or geometric criteria for the Ramsey property. It connects Ramsey theory, group actions, and Euclidean geometry.",
     "openQuestions": [
       "Is every spherical set Ramsey? (Graham's conjecture)",
@@ -204,8 +204,8 @@
   },
   "crossReferences": [
     {
-      "title": "Erdős Problem #171: Unit Distance Chromatic Number",
-      "relationship": "Both study chromatic/Ramsey properties of Euclidean space — #171 colors points to avoid unit distances, #174 colors points to avoid congruent copies of configurations",
+      "title": "Erd\u0151s Problem #171: Unit Distance Chromatic Number",
+      "relationship": "Both study chromatic/Ramsey properties of Euclidean space \u2014 #171 colors points to avoid unit distances, #174 colors points to avoid congruent copies of configurations",
       "targetId": "erdos-171"
     },
     {
@@ -214,7 +214,7 @@
       "targetId": "ramseys-theorem"
     },
     {
-      "title": "Erdős Problem #173: Monochromatic Triangles in Plane Colorings",
+      "title": "Erd\u0151s Problem #173: Monochromatic Triangles in Plane Colorings",
       "relationship": "Both ask about unavoidable monochromatic geometric configurations in colored Euclidean space",
       "targetId": "erdos-173"
     }

--- a/src/data/proofs/erdos-194/meta.json
+++ b/src/data/proofs/erdos-194/meta.json
@@ -65,7 +65,7 @@
     ],
     "axiomCount": 2,
     "lineCount": 296,
-    "assumptions": "7 axiom(s). No sorries."
+    "assumptions": "2 axioms: chaotic_ordering_rationals, chaotic_ordering_k_term. 0 sorries."
   },
   "overview": {
     "historicalContext": "**Erdos Problem #194**\n\nThis problem asks about the structure of orderings (enumerations) of the real numbers, specifically whether they must contain monotone arithmetic progressions.\n\n**The Question:**\nGiven any way of listing the real numbers in a sequence, must there exist three terms that form both an arithmetic progression and are monotone (increasing or decreasing) in the listing order?\n\n**Resolution:**\nArdal, Brown, and Jungic (2011) showed the surprising answer is NO. They constructed \"chaotic orderings\" of the rationals (and by extension, the reals) that contain no monotone 3-term arithmetic progressions. This disproves the natural intuition that dense sets must have such structures in any enumeration.",
@@ -193,17 +193,17 @@
     {
       "targetId": "erdos-645",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: arithmetic-progressions, combinatorics, ramsey-theory, solved"
+      "description": "Related Erd\u0151s problem sharing themes: arithmetic-progressions, combinatorics, ramsey-theory, solved"
     },
     {
       "targetId": "erdos-966",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: arithmetic-progressions, combinatorics, ramsey-theory, solved"
+      "description": "Related Erd\u0151s problem sharing themes: arithmetic-progressions, combinatorics, ramsey-theory, solved"
     },
     {
       "targetId": "erdos-1090",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, ramsey-theory, solved"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, ramsey-theory, solved"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-209/meta.json
+++ b/src/data/proofs/erdos-209/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-209",
-  "title": "Erdős Problem #209: Gallai Triangles in Line Arrangements",
+  "title": "Erd\u0151s Problem #209: Gallai Triangles in Line Arrangements",
   "slug": "erdos-209",
-  "description": "Must every line arrangement (d ≥ 4 lines, no parallels, no 4-concurrent) have a Gallai triangle? NO, disproved by Füredi-Palásti (1984) and Escudero (2016).",
+  "description": "Must every line arrangement (d \u2265 4 lines, no parallels, no 4-concurrent) have a Gallai triangle? NO, disproved by F\u00fcredi-Pal\u00e1sti (1984) and Escudero (2016).",
   "meta": {
-    "author": "Erdős (problem), Füredi-Palásti (1984), Escudero (2016)",
+    "author": "Erd\u0151s (problem), F\u00fcredi-Pal\u00e1sti (1984), Escudero (2016)",
     "sourceUrl": "https://erdosproblems.com/209",
     "date": "2016",
     "status": "axiomatized",
@@ -45,24 +45,24 @@
       "Is3RichPoint definition: 3+ lines meet",
       "IsGallaiTriangle definition: triangle with ordinary vertices",
       "sylvester_gallai axiom: ordinary points exist",
-      "furedi_palasti_1984 axiom: counterexamples for d not ≡ 0 (mod 9)",
-      "escudero_2016 axiom: counterexamples for all d ≥ 4",
+      "furedi_palasti_1984 axiom: counterexamples for d not \u2261 0 (mod 9)",
+      "escudero_2016 axiom: counterexamples for all d \u2265 4",
       "erdos_209 theorem: main disproof"
     ],
     "axiomCount": 1,
     "lineCount": 241,
-    "assumptions": "6 axioms: unique_intersection, sylvester_gallai, at_least_three_ordinary_points, and 3 more. See Lean source for complete statements."
+    "assumptions": "1 axiom: escudero_2016. 0 sorries."
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #209** is a question in incidence geometry about the structure of line arrangements. The classical Sylvester-Gallai theorem (1893) guarantees that any finite set of points not all collinear determines at least one \"ordinary line\" (containing exactly 2 points). Erdős asked: can we extend this to triangles?\n\n**Historical Development:**\n- **1893 (Sylvester-Gallai):** Ordinary points/lines must exist.\n- **1984 (Füredi-Palásti):** Disproved the conjecture for most d.\n- **2016 (Escudero):** Completed the disproof for ALL d ≥ 4.\n\n**Key Insight:** While ordinary points always exist, they can be positioned to avoid forming triangles with only ordinary vertices.",
-    "problemStatement": "**Problem Statement (Disproved)**\n\nLet $A$ be a finite collection of $d \\geq 4$ non-parallel lines in $\\mathbb{R}^2$ such that no point lies on 4 or more lines. Must there exist a **Gallai triangle** (or **ordinary triangle**): three lines from $A$ that form a triangle where each vertex involves exactly two lines?\n\n**Answer: NO!**\n\n**Resolution:**\n- Füredi-Palásti (1984): No for $d$ not divisible by 9\n- Escudero (2016): No for ALL $d \\geq 4$\n\n**Dual Formulation:** Given $n$ points with no 4 collinear, must there exist 3 points where each pair determines an ordinary line?",
-    "text": "Must every line arrangement (d ≥ 4 lines, no parallels, no 4-concurrent) have a Gallai triangle? NO, disproved by Füredi-Palásti (1984) and Escudero (2016).",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Lines and Arrangements:** Define lines via coefficients, parallel criterion, and line arrangements as finite sets.\n\n2. **Incidence Properties:** Define ordinary points (2 lines), 3-rich points (3+ lines), and Gallai triangles.\n\n3. **Sylvester-Gallai:** Axiomatize that ordinary points always exist.\n\n4. **Counterexamples:** Axiomatize Füredi-Palásti (1984) and Escudero (2016) constructions.\n\n5. **Main Result:** Prove the conjecture is false for all d ≥ 4.\n\n6. **Dual Problem:** Explain the point-line duality.",
+    "historicalContext": "**Erd\u0151s Problem #209** is a question in incidence geometry about the structure of line arrangements. The classical Sylvester-Gallai theorem (1893) guarantees that any finite set of points not all collinear determines at least one \"ordinary line\" (containing exactly 2 points). Erd\u0151s asked: can we extend this to triangles?\n\n**Historical Development:**\n- **1893 (Sylvester-Gallai):** Ordinary points/lines must exist.\n- **1984 (F\u00fcredi-Pal\u00e1sti):** Disproved the conjecture for most d.\n- **2016 (Escudero):** Completed the disproof for ALL d \u2265 4.\n\n**Key Insight:** While ordinary points always exist, they can be positioned to avoid forming triangles with only ordinary vertices.",
+    "problemStatement": "**Problem Statement (Disproved)**\n\nLet $A$ be a finite collection of $d \\geq 4$ non-parallel lines in $\\mathbb{R}^2$ such that no point lies on 4 or more lines. Must there exist a **Gallai triangle** (or **ordinary triangle**): three lines from $A$ that form a triangle where each vertex involves exactly two lines?\n\n**Answer: NO!**\n\n**Resolution:**\n- F\u00fcredi-Pal\u00e1sti (1984): No for $d$ not divisible by 9\n- Escudero (2016): No for ALL $d \\geq 4$\n\n**Dual Formulation:** Given $n$ points with no 4 collinear, must there exist 3 points where each pair determines an ordinary line?",
+    "text": "Must every line arrangement (d \u2265 4 lines, no parallels, no 4-concurrent) have a Gallai triangle? NO, disproved by F\u00fcredi-Pal\u00e1sti (1984) and Escudero (2016).",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Lines and Arrangements:** Define lines via coefficients, parallel criterion, and line arrangements as finite sets.\n\n2. **Incidence Properties:** Define ordinary points (2 lines), 3-rich points (3+ lines), and Gallai triangles.\n\n3. **Sylvester-Gallai:** Axiomatize that ordinary points always exist.\n\n4. **Counterexamples:** Axiomatize F\u00fcredi-Pal\u00e1sti (1984) and Escudero (2016) constructions.\n\n5. **Main Result:** Prove the conjecture is false for all d \u2265 4.\n\n6. **Dual Problem:** Explain the point-line duality.",
     "keyInsights": [
       "**Ordinary Points Exist:** Sylvester-Gallai guarantees at least one point where exactly 2 lines meet.",
       "**Triangles Blocked:** Ordinary points can be positioned so that every triangle has at least one 3-rich vertex.",
       "**Algebraic Constructions:** Counterexamples use special algebraic or projective configurations.",
-      "**Partial Result First:** Füredi-Palásti (1984) handled most d, then Escudero (2016) filled the gap.",
+      "**Partial Result First:** F\u00fcredi-Pal\u00e1sti (1984) handled most d, then Escudero (2016) filled the gap.",
       "**Point-Line Duality:** The problem has an equivalent dual formulation about point configurations.",
       "**Connection to #960:** Related questions about line arrangements and Gallai-type structures."
     ],
@@ -102,28 +102,28 @@
     },
     {
       "id": "disproof",
-      "title": "The Erdős Question and Its Disproof",
-      "summary": "Füredi-Palásti (1984) and Escudero (2016) counterexamples",
+      "title": "The Erd\u0151s Question and Its Disproof",
+      "summary": "F\u00fcredi-Pal\u00e1sti (1984) and Escudero (2016) counterexamples",
       "startLine": 178,
       "endLine": 223
     },
     {
       "id": "main-result",
       "title": "Main Result",
-      "summary": "erdos_209 theorem: disproved for all d ≥ 4 via Escudero",
+      "summary": "erdos_209 theorem: disproved for all d \u2265 4 via Escudero",
       "startLine": 224,
       "endLine": 241
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #209 asked whether every d-line arrangement (d ≥ 4, no parallels, no 4-concurrent) must contain a Gallai triangle. This was DISPROVED: Füredi-Palásti (1984) showed counterexamples exist for d not divisible by 9, and Escudero (2016) completed the proof for all d ≥ 4. While Sylvester-Gallai guarantees ordinary points exist, they can be positioned to avoid forming triangles.",
+    "summary": "Erd\u0151s Problem #209 asked whether every d-line arrangement (d \u2265 4, no parallels, no 4-concurrent) must contain a Gallai triangle. This was DISPROVED: F\u00fcredi-Pal\u00e1sti (1984) showed counterexamples exist for d not divisible by 9, and Escudero (2016) completed the proof for all d \u2265 4. While Sylvester-Gallai guarantees ordinary points exist, they can be positioned to avoid forming triangles.",
     "implications": "**Theoretical Significance**: **Implications for Incidence Geometry**\n\n1. **Limits of Sylvester-Gallai:** The theorem doesn't extend to triangular structures as hoped.\n\n**2. Algebraic Configurations:** Special line arrangements have surprising combinatorial properties.\n\n3. **Point-Line Duality:** The dual problem about points is equally interesting.\n\n4. **Constructive Methods:** Both counterexamples use explicit algebraic constructions.",
     "openQuestions": [
       "What is the minimum number of 3-rich points needed to block all Gallai triangles?",
       "Can the constructions be simplified or made more explicit?",
       "What happens in higher dimensions (hyperplane arrangements)?",
       "Are there natural restrictions under which Gallai triangles must exist?",
-      "What is the connection to other Erdős geometry problems?"
+      "What is the connection to other Erd\u0151s geometry problems?"
     ]
   },
   "leanFile": {
@@ -151,24 +151,24 @@
     {
       "targetId": "erdos-105",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: disproved, incidence-geometry"
+      "description": "Related Erd\u0151s problem sharing themes: disproved, incidence-geometry"
     },
     {
       "targetId": "erdos-1082",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: geometry, incidence-geometry"
+      "description": "Related Erd\u0151s problem sharing themes: geometry, incidence-geometry"
     },
     {
       "targetId": "erdos-1086",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: geometry, incidence-geometry"
+      "description": "Related Erd\u0151s problem sharing themes: geometry, incidence-geometry"
     }
   ],
   "references": [
     {
       "key": "SzT83",
       "authors": [
-        "E. Szemerédi",
+        "E. Szemer\u00e9di",
         "W.T. Trotter"
       ],
       "title": "Extremal problems in discrete geometry",

--- a/src/data/proofs/erdos-210/meta.json
+++ b/src/data/proofs/erdos-210/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-210",
-  "title": "Erdős Problem #210: Ordinary Lines",
+  "title": "Erd\u0151s Problem #210: Ordinary Lines",
   "slug": "erdos-210",
-  "description": "Let f(n) be the minimum number of ordinary lines (lines through exactly 2 points) for any n points not all collinear. Does f(n) → ∞? SOLVED: f(n) ≥ n/2 for large even n (Green-Tao, 2013) - TIGHT.",
+  "description": "Let f(n) be the minimum number of ordinary lines (lines through exactly 2 points) for any n points not all collinear. Does f(n) \u2192 \u221e? SOLVED: f(n) \u2265 n/2 for large even n (Green-Tao, 2013) - TIGHT.",
   "meta": {
-    "author": "Sylvester (conjecture), Gallai (f≥1), Motzkin (f→∞), Green-Tao (f≥n/2, 2013)",
+    "author": "Sylvester (conjecture), Gallai (f\u22651), Motzkin (f\u2192\u221e), Green-Tao (f\u2265n/2, 2013)",
     "sourceUrl": "https://erdosproblems.com/210",
     "date": "2013",
     "status": "axiomatized",
@@ -33,7 +33,7 @@
       },
       {
         "theorem": "EuclideanSpace",
-        "description": "Euclidean space ℝⁿ",
+        "description": "Euclidean space \u211d\u207f",
         "module": "Mathlib.Analysis.InnerProductSpace.EuclideanDist"
       },
       {
@@ -43,7 +43,7 @@
       }
     ],
     "originalContributions": [
-      "Point and PointSet definitions for ℝ²",
+      "Point and PointSet definitions for \u211d\u00b2",
       "Collinear, NotAllCollinear predicates",
       "Line structure, OnLine, IsOrdinaryLine predicates",
       "OrdinaryLineCount axiom, f axiom",
@@ -56,23 +56,23 @@
     ],
     "axiomCount": 9,
     "lineCount": 196,
-    "assumptions": "14 axioms: OrdinaryLineCount, f, sylvester_gallai, and 11 more. See Lean source for complete statements."
+    "assumptions": "9 axioms: OrdinaryLineCount, f, sylvester_gallai, motzkin_theorem, kelly_moser, csima_sawyer, green_tao_even, green_tao_odd, LiesOnCubic. 0 sorries."
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #210: Ordinary Lines**\n\nThis classic problem in discrete geometry asks about the minimum number of 'ordinary lines' (lines through exactly 2 points) in any point configuration.\n\n**Historical Timeline:**\n- 1893: Sylvester conjectured f(n) ≥ 1\n- 1933: Erdős rediscovered the problem\n- 1944: Gallai proved Sylvester-Gallai theorem (f(n) ≥ 1)\n- 1951: Motzkin proved f(n) → ∞\n- 1958: Kelly-Moser proved f(n) ≥ 3n/7\n- 1993: Csima-Sawyer improved to f(n) ≥ 6n/13\n- 2013: Green-Tao resolved asymptotic: f(n) ≥ n/2 for large even n (tight!)\n\n**The Problem:** How many ordinary lines must exist? The answer depends delicately on n's parity.",
-    "problemStatement": "**Problem Statement (Solved)**\n\nLet f(n) = minimum number of ordinary lines over all configurations of n points not all on one line.\n\n**Questions:**\n1. Does f(n) → ∞?\n2. How fast does it grow?\n\n**Complete Answer:**\n- f(n) ≥ 1 (Sylvester-Gallai)\n- f(n) → ∞ (Motzkin)\n- f(n) ≥ n/2 for large even n (Green-Tao, 2013) — TIGHT\n- f(n) ≥ 3⌊n/4⌋ for large odd n (Green-Tao, 2013)",
-    "text": "Let f(n) be the minimum number of ordinary lines (lines through exactly 2 points) for any n points not all collinear. Does f(n) → ∞? SOLVED: f(n) ≥ n/2 for large even n (Green-Tao, 2013) - TIGHT.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Basic Setup:** Define Point, PointSet, Collinear, NotAllCollinear\n\n2. **Ordinary Lines:** Define Line, OnLine, IsOrdinaryLine; axiomatize OrdinaryLineCount and f\n\n3. **Classical Results:** Axiomatize Sylvester-Gallai, Motzkin, Kelly-Moser, Csima-Sawyer\n\n4. **Green-Tao Resolution:** Axiomatize the n/2 bound for even n and 3⌊n/4⌋ for odd n\n\n5. **Structure Theory:** Axiomatize LiesOnCubic and the Green-Tao structure theorem\n\n6. **Summary:** Prove erdos_210 and erdos_210_summary combining key results",
+    "historicalContext": "**Erd\u0151s Problem #210: Ordinary Lines**\n\nThis classic problem in discrete geometry asks about the minimum number of 'ordinary lines' (lines through exactly 2 points) in any point configuration.\n\n**Historical Timeline:**\n- 1893: Sylvester conjectured f(n) \u2265 1\n- 1933: Erd\u0151s rediscovered the problem\n- 1944: Gallai proved Sylvester-Gallai theorem (f(n) \u2265 1)\n- 1951: Motzkin proved f(n) \u2192 \u221e\n- 1958: Kelly-Moser proved f(n) \u2265 3n/7\n- 1993: Csima-Sawyer improved to f(n) \u2265 6n/13\n- 2013: Green-Tao resolved asymptotic: f(n) \u2265 n/2 for large even n (tight!)\n\n**The Problem:** How many ordinary lines must exist? The answer depends delicately on n's parity.",
+    "problemStatement": "**Problem Statement (Solved)**\n\nLet f(n) = minimum number of ordinary lines over all configurations of n points not all on one line.\n\n**Questions:**\n1. Does f(n) \u2192 \u221e?\n2. How fast does it grow?\n\n**Complete Answer:**\n- f(n) \u2265 1 (Sylvester-Gallai)\n- f(n) \u2192 \u221e (Motzkin)\n- f(n) \u2265 n/2 for large even n (Green-Tao, 2013) \u2014 TIGHT\n- f(n) \u2265 3\u230an/4\u230b for large odd n (Green-Tao, 2013)",
+    "text": "Let f(n) be the minimum number of ordinary lines (lines through exactly 2 points) for any n points not all collinear. Does f(n) \u2192 \u221e? SOLVED: f(n) \u2265 n/2 for large even n (Green-Tao, 2013) - TIGHT.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Basic Setup:** Define Point, PointSet, Collinear, NotAllCollinear\n\n2. **Ordinary Lines:** Define Line, OnLine, IsOrdinaryLine; axiomatize OrdinaryLineCount and f\n\n3. **Classical Results:** Axiomatize Sylvester-Gallai, Motzkin, Kelly-Moser, Csima-Sawyer\n\n4. **Green-Tao Resolution:** Axiomatize the n/2 bound for even n and 3\u230an/4\u230b for odd n\n\n5. **Structure Theory:** Axiomatize LiesOnCubic and the Green-Tao structure theorem\n\n6. **Summary:** Prove erdos_210 and erdos_210_summary combining key results",
     "keyInsights": [
       "**Sylvester-Gallai:** Every non-collinear configuration has at least 1 ordinary line",
-      "**Parity Matters:** The bound for even n (n/2) differs from odd n (3⌊n/4⌋)",
-      "**Böröczky Tightness:** The n/2 bound is achieved by points on circle + points at infinity",
+      "**Parity Matters:** The bound for even n (n/2) differs from odd n (3\u230an/4\u230b)",
+      "**B\u00f6r\u00f6czky Tightness:** The n/2 bound is achieved by points on circle + points at infinity",
       "**Algebraic Structure:** Configurations with few ordinary lines must lie on cubic curves",
       "**Green-Tao Methods:** Resolution used additive combinatorics and algebraic geometry"
     ],
     "prerequisites": [
       "Algebraic geometry (algebraic curves, polynomial method)",
-      "Combinatorial geometry (incidence theorems, Szemerédi-Trotter)"
+      "Combinatorial geometry (incidence theorems, Szemer\u00e9di-Trotter)"
     ]
   },
   "sections": [
@@ -103,7 +103,7 @@
     {
       "id": "sylvester-gallai",
       "title": "Sylvester-Gallai Theorem",
-      "summary": "f(n) ≥ 1 for any non-collinear configuration",
+      "summary": "f(n) \u2265 1 for any non-collinear configuration",
       "startLine": 89,
       "endLine": 105,
       "mathContext": "f(n) $\\geq$ 1 for any non-collinear configuration"
@@ -111,15 +111,15 @@
     {
       "id": "motzkin",
       "title": "Motzkin's Theorem",
-      "summary": "f(n) → ∞, with f_tends_to_infinity proved",
+      "summary": "f(n) \u2192 \u221e, with f_tends_to_infinity proved",
       "startLine": 106,
       "endLine": 119,
-      "mathContext": "f(n) $\\to$ ∞, with f_tends_to_infinity proved"
+      "mathContext": "f(n) $\\to$ \u221e, with f_tends_to_infinity proved"
     },
     {
       "id": "kelly-moser-csima-sawyer",
       "title": "Kelly-Moser and Csima-Sawyer Bounds",
-      "summary": "f(n) ≥ 3n/7 and f(n) ≥ 6n/13 for n ≥ 8",
+      "summary": "f(n) \u2265 3n/7 and f(n) \u2265 6n/13 for n \u2265 8",
       "startLine": 120,
       "endLine": 131,
       "mathContext": "f(n) $\\geq$ 3n/7 and f(n) $\\geq$ 6n/13 for n $\\geq$ 8"
@@ -127,18 +127,18 @@
     {
       "id": "green-tao",
       "title": "Green-Tao Theorem",
-      "summary": "f(n) ≥ n/2 for large even n, f(n) ≥ 3⌊n/4⌋ for large odd n, tightness",
+      "summary": "f(n) \u2265 n/2 for large even n, f(n) \u2265 3\u230an/4\u230b for large odd n, tightness",
       "startLine": 132,
       "endLine": 149,
-      "mathContext": "f(n) $\\geq$ n/2 for large even n, f(n) $\\geq$ 3⌊n/4⌋ for large odd n, tightness"
+      "mathContext": "f(n) $\\geq$ n/2 for large even n, f(n) $\\geq$ 3\u230an/4\u230b for large odd n, tightness"
     },
     {
       "id": "extremal",
       "title": "Extremal Configurations",
-      "summary": "Böröczky construction, small n values",
+      "summary": "B\u00f6r\u00f6czky construction, small n values",
       "startLine": 150,
       "endLine": 169,
-      "mathContext": "Mathematical content: Böröczky construction, small n values"
+      "mathContext": "Mathematical content: B\u00f6r\u00f6czky construction, small n values"
     },
     {
       "id": "structure-theory",
@@ -158,8 +158,8 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #210 asked about the minimum number of ordinary lines in non-collinear point configurations. The problem has a rich history from Sylvester (1893) through Green-Tao (2013), who finally resolved the asymptotic behavior: f(n) ≥ n/2 for large even n (tight!) and f(n) ≥ 3⌊n/4⌋ for large odd n.",
-    "implications": "The resolution connects discrete geometry, projective geometry, algebraic geometry (cubic curves), and additive combinatorics (sum-product estimates). Extremal configurations use Böröczky-type constructions with points on circles and points at infinity.",
+    "summary": "Erd\u0151s Problem #210 asked about the minimum number of ordinary lines in non-collinear point configurations. The problem has a rich history from Sylvester (1893) through Green-Tao (2013), who finally resolved the asymptotic behavior: f(n) \u2265 n/2 for large even n (tight!) and f(n) \u2265 3\u230an/4\u230b for large odd n.",
+    "implications": "The resolution connects discrete geometry, projective geometry, algebraic geometry (cubic curves), and additive combinatorics (sum-product estimates). Extremal configurations use B\u00f6r\u00f6czky-type constructions with points on circles and points at infinity.",
     "openQuestions": [
       "Exact values of f(n) for all n?",
       "Higher-dimensional generalizations (ordinary hyperplanes)?",
@@ -190,24 +190,24 @@
     {
       "targetId": "erdos-605",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: discrete-geometry, incidence-geometry, solved"
+      "description": "Related Erd\u0151s problem sharing themes: discrete-geometry, incidence-geometry, solved"
     },
     {
       "targetId": "erdos-95",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: discrete-geometry, incidence-geometry, solved"
+      "description": "Related Erd\u0151s problem sharing themes: discrete-geometry, incidence-geometry, solved"
     },
     {
       "targetId": "erdos-105",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: discrete-geometry, incidence-geometry"
+      "description": "Related Erd\u0151s problem sharing themes: discrete-geometry, incidence-geometry"
     }
   ],
   "references": [
     {
       "key": "SzT83b",
       "authors": [
-        "E. Szemerédi",
+        "E. Szemer\u00e9di",
         "W.T. Trotter"
       ],
       "title": "Extremal problems in discrete geometry",

--- a/src/data/proofs/erdos-229/meta.json
+++ b/src/data/proofs/erdos-229/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-229",
-  "title": "Erdős Problem #229: Zeros of Derivatives of Entire Functions",
+  "title": "Erd\u0151s Problem #229: Zeros of Derivatives of Entire Functions",
   "slug": "erdos-229",
-  "description": "Given discrete sets (Sₙ) in ℂ, can we find a transcendental entire function whose derivatives vanish on each Sₙ? Answer: YES (Barth-Schneider 1972).",
+  "description": "Given discrete sets (S\u2099) in \u2102, can we find a transcendental entire function whose derivatives vanish on each S\u2099? Answer: YES (Barth-Schneider 1972).",
   "meta": {
     "author": "Barth-Schneider (1972)",
     "sourceUrl": "https://erdosproblems.com/229",
@@ -26,7 +26,7 @@
     "mathlibDependencies": [
       {
         "theorem": "Differentiable",
-        "description": "Differentiability on ℂ",
+        "description": "Differentiability on \u2102",
         "module": "Mathlib.Analysis.Calculus.FDeriv.Basic"
       },
       {
@@ -49,16 +49,16 @@
     ],
     "axiomCount": 1,
     "lineCount": 137,
-    "assumptions": "6 axioms: discrete_condition_necessary, barth_schneider_theorem, barth_schneider_explicit, and 3 more. See Lean source for complete statements."
+    "assumptions": "1 axiom: barth_schneider_theorem. 0 sorries."
   },
   "overview": {
-    "historicalContext": "This problem appears as Problem 2.30 in Hayman's 'Research problems in function theory: new problems' (1974), attributed to Erdős. It asks about the flexibility of entire transcendental functions in prescribing zeros of their derivatives.\n\nBarth and Schneider resolved the problem affirmatively in 1972, published in the Proceedings of the American Mathematical Society. Their construction shows that for any sequence of discrete sets, one can find a transcendental entire function whose successive derivatives vanish on these sets.\n\nThe key constraint is that each set must have no finite limit point (be discrete), which is necessary by the identity theorem for analytic functions.",
+    "historicalContext": "This problem appears as Problem 2.30 in Hayman's 'Research problems in function theory: new problems' (1974), attributed to Erd\u0151s. It asks about the flexibility of entire transcendental functions in prescribing zeros of their derivatives.\n\nBarth and Schneider resolved the problem affirmatively in 1972, published in the Proceedings of the American Mathematical Society. Their construction shows that for any sequence of discrete sets, one can find a transcendental entire function whose successive derivatives vanish on these sets.\n\nThe key constraint is that each set must have no finite limit point (be discrete), which is necessary by the identity theorem for analytic functions.",
     "problemStatement": "**Question**: Let $(S_n)_{n \\geq 1}$ be a sequence of sets of complex numbers, none of which have a finite limit point. Does there exist an entire transcendental function $f(z)$ such that for all $n \\geq 1$, there exists some $k_n \\geq 0$ with\n$$f^{(k_n)}(z) = 0 \\text{ for all } z \\in S_n?$$\n\n**Answer**: YES\n\nFor any such sequence of discrete sets, there exist a transcendental entire function $f$ and integers $(k_n)$ such that the $k_n$-th derivative of $f$ vanishes on all of $S_n$.",
-    "text": "Given discrete sets (Sₙ) in ℂ, can we find a transcendental entire function whose derivatives vanish on each Sₙ? Answer: YES (Barth-Schneider 1972).",
-    "proofStrategy": "We formalize:\n\n1. **HasNoFiniteLimitPoint**: A set with empty derived set (discrete)\n2. **IsEntireFunction**: A function differentiable everywhere on ℂ\n3. **IsTranscendental**: Entire but not a polynomial\n4. **Erdos229Question**: The main existence question\n5. **barth_schneider_theorem**: Axiomatized since the construction uses advanced function theory\n6. **Special cases**: Weierstrass factorization for zeros of f itself",
+    "text": "Given discrete sets (S\u2099) in \u2102, can we find a transcendental entire function whose derivatives vanish on each S\u2099? Answer: YES (Barth-Schneider 1972).",
+    "proofStrategy": "We formalize:\n\n1. **HasNoFiniteLimitPoint**: A set with empty derived set (discrete)\n2. **IsEntireFunction**: A function differentiable everywhere on \u2102\n3. **IsTranscendental**: Entire but not a polynomial\n4. **Erdos229Question**: The main existence question\n5. **barth_schneider_theorem**: Axiomatized since the construction uses advanced function theory\n6. **Special cases**: Weierstrass factorization for zeros of f itself",
     "keyInsights": [
-      "**No finite limit point**: The sets Sₙ must be discrete (no accumulation points). This is forced by the identity theorem.",
-      "**Entire function**: Differentiable everywhere on ℂ, equivalently holomorphic/analytic on all of ℂ.",
+      "**No finite limit point**: The sets S\u2099 must be discrete (no accumulation points). This is forced by the identity theorem.",
+      "**Entire function**: Differentiable everywhere on \u2102, equivalently holomorphic/analytic on all of \u2102.",
       "**Transcendental**: Not a polynomial - has infinitely many derivatives, all non-trivial.",
       "**Weierstrass connection**: The Weierstrass factorization theorem handles prescribing zeros of f itself; this extends to derivatives.",
       "**Flexibility of entire functions**: Despite seeming rigid, entire functions can be constructed with remarkable flexibility in their zero sets."
@@ -113,10 +113,10 @@
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erdős Problem #229 on prescribing zeros of derivatives of entire functions. The Barth-Schneider theorem (1972) proves the answer is YES: for any sequence of discrete sets, we can find a transcendental entire function whose derivatives vanish on these sets.",
+    "summary": "We formalize Erd\u0151s Problem #229 on prescribing zeros of derivatives of entire functions. The Barth-Schneider theorem (1972) proves the answer is YES: for any sequence of discrete sets, we can find a transcendental entire function whose derivatives vanish on these sets.",
     "implications": "**Theoretical Significance**: This result demonstrates the remarkable flexibility of transcendental entire functions.\n\nDespite being determined by their power series, they can be constructed to have prescribed zeros for different derivatives. This has applications in complex approximation theory and the study of differential equations in the complex plane.",
     "openQuestions": [
-      "What are effective bounds on the indices kₙ in terms of the sets Sₙ?",
+      "What are effective bounds on the indices k\u2099 in terms of the sets S\u2099?",
       "Can we achieve additional constraints (e.g., growth rate) simultaneously?",
       "What happens if we require the same derivative to vanish on multiple sets?",
       "Are there natural analogues for entire functions of several variables?"
@@ -143,17 +143,17 @@
     {
       "targetId": "erdos-906",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: complex-analysis, derivatives, entire-functions"
+      "description": "Related Erd\u0151s problem sharing themes: complex-analysis, derivatives, entire-functions"
     },
     {
       "targetId": "erdos-1115",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: complex-analysis, entire-functions"
+      "description": "Related Erd\u0151s problem sharing themes: complex-analysis, entire-functions"
     },
     {
       "targetId": "erdos-1116",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: complex-analysis, entire-functions"
+      "description": "Related Erd\u0151s problem sharing themes: complex-analysis, entire-functions"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-237/meta.json
+++ b/src/data/proofs/erdos-237/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-237",
-  "title": "Erdős Problem #237: Prime Plus Set Representations",
+  "title": "Erd\u0151s Problem #237: Prime Plus Set Representations",
   "slug": "erdos-237",
-  "description": "For A ⊆ ℕ with |A ∩ [1,N]| ≫ log(N), is limsup f(n) = ∞ where f(n) counts n = p + a? YES (Chen-Ding 2022), even for infinite A.",
+  "description": "For A \u2286 \u2115 with |A \u2229 [1,N]| \u226b log(N), is limsup f(n) = \u221e where f(n) counts n = p + a? YES (Chen-Ding 2022), even for infinite A.",
   "meta": {
-    "author": "Chen and Ding (2022 solution), Erdős (1950 special case)",
+    "author": "Chen and Ding (2022 solution), Erd\u0151s (1950 special case)",
     "sourceUrl": "https://erdosproblems.com/237",
     "date": "2022",
     "status": "axiomatized",
@@ -48,8 +48,8 @@
     ],
     "originalContributions": [
       "representationCount definition: counts n = p + a solutions",
-      "HasLogDensity predicate: |A ∩ [1,N]| ≥ c·log(N)",
-      "HasUnboundedLimsup predicate: limsup f(n) = ∞",
+      "HasLogDensity predicate: |A \u2229 [1,N]| \u2265 c\u00b7log(N)",
+      "HasUnboundedLimsup predicate: limsup f(n) = \u221e",
       "ErdosConjecture formulation: original question",
       "StrongerVersion formulation: infinite sets suffice",
       "powersOfTwo definition: A = {2^k}",
@@ -60,24 +60,24 @@
     ],
     "axiomCount": 1,
     "lineCount": 255,
-    "assumptions": "6 axiom(s) and 0 sorry(s). See the Lean source for details."
+    "assumptions": "1 axiom: chen_ding_2022. 0 sorries."
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #237: Prime Plus Set Representations**\n\nThis problem belongs to a rich tradition of additive number theory questions about representing integers as sums involving primes. The classical prototype is Goldbach's conjecture (1742): every even integer $\\ge 4$ is a sum of two primes. Problem #237 generalizes this by replacing one of the primes with an element from a structured set $A$.\n\n**Key History:**\n- 1742: Goldbach conjectures $n = p_1 + p_2$ for even $n$\n- 1934: Romanov proves a positive proportion of integers are $p + 2^k$\n- 1937: Vinogradov proves the ternary Goldbach conjecture using the circle method\n- 1950: Erdős proves the representation count is unbounded when $A = \\{2^k\\}$ (powers of two), using sieve methods. He observes that the values $n - 2^k$ lie in distinct residue classes mod small primes\n- 1950s: Erdős poses the general question for sets with logarithmic density $|A \\cap [1,N]| \\gg \\log N$\n- 2022: Chen and Ding prove a dramatically stronger result — **any** infinite set $A$ has unbounded representation count, completely removing the density hypothesis\n\n**Related**: Erdős Problem #236 concerns a related question about sumsets with primes.",
+    "historicalContext": "**Erd\u0151s Problem #237: Prime Plus Set Representations**\n\nThis problem belongs to a rich tradition of additive number theory questions about representing integers as sums involving primes. The classical prototype is Goldbach's conjecture (1742): every even integer $\\ge 4$ is a sum of two primes. Problem #237 generalizes this by replacing one of the primes with an element from a structured set $A$.\n\n**Key History:**\n- 1742: Goldbach conjectures $n = p_1 + p_2$ for even $n$\n- 1934: Romanov proves a positive proportion of integers are $p + 2^k$\n- 1937: Vinogradov proves the ternary Goldbach conjecture using the circle method\n- 1950: Erd\u0151s proves the representation count is unbounded when $A = \\{2^k\\}$ (powers of two), using sieve methods. He observes that the values $n - 2^k$ lie in distinct residue classes mod small primes\n- 1950s: Erd\u0151s poses the general question for sets with logarithmic density $|A \\cap [1,N]| \\gg \\log N$\n- 2022: Chen and Ding prove a dramatically stronger result \u2014 **any** infinite set $A$ has unbounded representation count, completely removing the density hypothesis\n\n**Related**: Erd\u0151s Problem #236 concerns a related question about sumsets with primes.",
     "problemStatement": "**Problem Statement (Solved)**\n\nLet $A \\subseteq \\mathbb{N}$ be a set such that $|A \\cap \\{1,\\ldots,N\\}| \\gg \\log N$ for all large $N$.\n\nLet $f(n)$ count the number of solutions to $n = p + a$ for $p$ prime and $a \\in A$.\n\n**Question:** Is it true that $\\limsup_{n \\to \\infty} f(n) = \\infty$?\n\n**Answer: YES** (Chen and Ding, 2022)\n\n**Stronger Result:** The logarithmic density condition can be replaced with just requiring $A$ to be infinite!",
-    "text": "For A ⊆ ℕ with |A ∩ [1,N]| ≫ log(N), is limsup f(n) = ∞ where f(n) counts n = p + a? YES (Chen-Ding 2022), even for infinite A.",
+    "text": "For A \u2286 \u2115 with |A \u2229 [1,N]| \u226b log(N), is limsup f(n) = \u221e where f(n) counts n = p + a? YES (Chen-Ding 2022), even for infinite A.",
     "proofStrategy": "**Formalization Approach**\n\n1. **Representation Count:** Define $f_A(n) = |\\{(p,a) : p \\text{ prime},\\; a \\in A,\\; p + a = n\\}|$ as Nat.card of the corresponding subtype\n\n2. **Density Conditions:** Formalize HasLogDensity using Nat.card of $A \\cap \\text{Set.Icc}\\;1\\;N$ and Real.log\n\n3. **Limsup Condition:** HasUnboundedLimsup is the $\\forall M,\\; \\exists n,\\; f(n) > M$ formulation\n\n4. **Two-Level Result:** Axiomatize Chen-Ding (StrongerVersion: infinite $\\implies$ unbounded) and derive ErdosConjecture (log-density $\\implies$ unbounded) by showing log-density implies infinite\n\n5. **The Derivation:** erdos_conjecture_true reduces the original conjecture to Chen-Ding, with one sorry for the log-density-implies-infinite technical lemma\n\n6. **Examples:** Powers of two, squares, and prime powers illustrate the theorem with concrete sets",
     "keyInsights": [
-      "**Hypothesis Collapse:** Erdős asked about logarithmic density ($|A \\cap [1,N]| \\ge c \\log N$), but Chen-Ding proved only infinitude of $A$ is needed. This is a dramatic weakening — an infinite set can be arbitrarily sparse (e.g., $A = \\{2^{2^{2^k}}\\}$ which grows faster than any tower)",
+      "**Hypothesis Collapse:** Erd\u0151s asked about logarithmic density ($|A \\cap [1,N]| \\ge c \\log N$), but Chen-Ding proved only infinitude of $A$ is needed. This is a dramatic weakening \u2014 an infinite set can be arbitrarily sparse (e.g., $A = \\{2^{2^{2^k}}\\}$ which grows faster than any tower)",
       "**Prime Density Does the Heavy Lifting:** The Prime Number Theorem guarantees $\\pi(n) \\sim n/\\log n$ primes below $n$. For any infinite $A$ with elements $a_1 < a_2 < \\cdots$, the sets $\\{n - a_i : a_i < n\\}$ eventually overlap primes often enough to make $f(n)$ unbounded",
-      "**Sieve Methods vs PNT:** Erdős's 1950 proof for powers of two used sieve methods (exploiting the multiplicative structure of $2^k$). Chen-Ding's proof works without any arithmetic structure in $A$, relying purely on the abundance of primes",
+      "**Sieve Methods vs PNT:** Erd\u0151s's 1950 proof for powers of two used sieve methods (exploiting the multiplicative structure of $2^k$). Chen-Ding's proof works without any arithmetic structure in $A$, relying purely on the abundance of primes",
       "**Limsup vs Limit:** The result only gives $\\limsup f(n) = \\infty$, not $f(n) \\to \\infty$. Indeed, $f(n)$ can be 0 for many values of $n$ (e.g., when $n$ is small relative to elements of $A$). The unboundedness manifests along a subsequence",
       "**Goldbach Generalization:** The framework $n = p + a$ with $a \\in A$ unifies many classical problems: Goldbach ($A = $ primes), Waring-Goldbach ($A = k$th powers), and Romanov's theorem ($A = \\{2^k\\}$)"
     ],
     "prerequisites": [
       "Additive number theory: representing integers as $p + a$ (prime plus set element)",
       "Prime Number Theorem and prime distribution: density of primes near $n$ is $\\sim 1/\\log n$",
-      "Sieve methods (Erdős 1950) and the circle method for binary additive problems",
+      "Sieve methods (Erd\u0151s 1950) and the circle method for binary additive problems",
       "Filter-based asymptotics in Lean 4 (for the limsup formulation)"
     ]
   },
@@ -88,12 +88,12 @@
       "startLine": 1,
       "endLine": 37,
       "summary": "Module docstring documenting the problem statement, background, and references; 4 Mathlib imports covering required modules; namespace `Erdos237`",
-      "mathContext": "Let A ⊆ ℕ be a set such that |A ∩ {1,...,N}| ≫ log(N) for all large N. Let f(n) count the number of solutions to n = p + a for p prime and a ∈ A. Is it true that limsup f(n) = ∞?"
+      "mathContext": "Let A \u2286 \u2115 be a set such that |A \u2229 {1,...,N}| \u226b log(N) for all large N. Let f(n) count the number of solutions to n = p + a for p prime and a \u2208 A. Is it true that limsup f(n) = \u221e?"
     },
     {
       "id": "basic-definitions",
       "title": "Basic Definitions",
-      "summary": "Defines representationCount f_A(n) as Nat.card of pairs (p, a) with p prime, a ∈ A, p + a = n. Defines HasLogDensity via |A ∩ [1,N]| ≥ c·log(N). Defines HasUnboundedLimsup as ∀ M, ∃ n, f(n) > M.",
+      "summary": "Defines representationCount f_A(n) as Nat.card of pairs (p, a) with p prime, a \u2208 A, p + a = n. Defines HasLogDensity via |A \u2229 [1,N]| \u2265 c\u00b7log(N). Defines HasUnboundedLimsup as \u2200 M, \u2203 n, f(n) > M.",
       "startLine": 38,
       "endLine": 59,
       "mathContext": "$f_A(n) = |\\{(p, a) : p + a = n, p \\text{ prime}, a \\in A\\}|$ = number of representations of $n$ as prime + element of $A$."
@@ -109,10 +109,10 @@
     {
       "id": "historical-results",
       "title": "Historical Results",
-      "summary": "Defines powersOfTwo = {2^k}. Axiomatizes Erdős's 1950 result for powers of two. Axiomatizes that powers of two have logarithmic density. Axiomatizes the arithmetic progression representation bound.",
+      "summary": "Defines powersOfTwo = {2^k}. Axiomatizes Erd\u0151s's 1950 result for powers of two. Axiomatizes that powers of two have logarithmic density. Axiomatizes the arithmetic progression representation bound.",
       "startLine": 82,
       "endLine": 113,
-      "mathContext": "Erdős (1950): proved for $A = \\{2^k\\}$ (powers of two). Uses sieve methods: PNT gives $\\sim n/\\log n$ primes $\\leq n$."
+      "mathContext": "Erd\u0151s (1950): proved for $A = \\{2^k\\}$ (powers of two). Uses sieve methods: PNT gives $\\sim n/\\log n$ primes $\\leq n$."
     },
     {
       "id": "chen-ding",
@@ -125,7 +125,7 @@
     {
       "id": "proof-strategy",
       "title": "Understanding the Proof Strategy",
-      "summary": "Comment sections explaining why infinite sets suffice: the PNT guarantees enough primes, the density-vs-cardinality gap between Erdős's hypothesis and Chen-Ding's, and the key role of the Prime Number Theorem.",
+      "summary": "Comment sections explaining why infinite sets suffice: the PNT guarantees enough primes, the density-vs-cardinality gap between Erd\u0151s's hypothesis and Chen-Ding's, and the key role of the Prime Number Theorem.",
       "startLine": 143,
       "endLine": 168,
       "mathContext": "PNT gives $\\pi(n) \\sim n/\\log n$ primes $\\leq n$. For each $n$, $f_A(n) = |\\{p \\leq n : n - p \\in A\\}|$."
@@ -133,7 +133,7 @@
     {
       "id": "examples",
       "title": "Examples and Special Cases",
-      "summary": "Defines squares = {k² : k ≥ 1} and primePowers = {p^k : p prime, k ≥ 1} as concrete infinite sets. Axiomatizes their unbounded representation counts as corollaries of Chen-Ding.",
+      "summary": "Defines squares = {k\u00b2 : k \u2265 1} and primePowers = {p^k : p prime, k \u2265 1} as concrete infinite sets. Axiomatizes their unbounded representation counts as corollaries of Chen-Ding.",
       "startLine": 169,
       "endLine": 197,
       "mathContext": "Examples: $A = \\{k^2\\}$ (squares), $A = \\{p^k\\}$ (prime powers). Both infinite, so Chen-Ding applies."
@@ -156,14 +156,14 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #237 asked whether sets A with logarithmic density force the representation count f(n) = |{(p,a) : p + a = n}| to have unbounded limsup. Chen and Ding (2022) proved YES, and showed an even stronger result: any infinite set A suffices, completely removing the density hypothesis. The formalization captures this two-level resolution in 244 lines of Lean 4, with the original conjecture derived from the stronger Chen-Ding theorem via a simple logical reduction.",
-    "implications": "**Theoretical Significance**: **Connections to Number Theory**\n\n1. **Prime Number Theorem:** The result is fundamentally powered by the density of primes. The PNT ensures that ~n/log(n) primes lie below n, providing enough 'targets' for the complements n - a to hit\n\n2. **Goldbach-type Problems:** The framework n = p + a with structured A encompasses many classical problems. The Chen-Ding result shows that the structure of A is irrelevant for the unboundedness question — only cardinality matters\n\n**3. Romanov's Theorem:** Romanov (1934) proved that a positive density of integers can be written as p + 2^k. Chen-Ding's result is complementary: it addresses the limsup rather than positive density, but applies to all infinite sets\n\n4. **Sieve Methods:** Erdős's 1950 proof pioneered the use of sieve methods for this type of problem. The Chen-Ding approach goes beyond sieves, using the PNT directly\n\n5. **Additive Combinatorics:** The result connects to the broader theme that sumsets P + A (primes plus a set) are large when A is infinite, paralleling results about sumsets in additive combinatorics (Freiman's theorem, Plünnecke-Ruzsa inequality).",
+    "summary": "Erd\u0151s Problem #237 asked whether sets A with logarithmic density force the representation count f(n) = |{(p,a) : p + a = n}| to have unbounded limsup. Chen and Ding (2022) proved YES, and showed an even stronger result: any infinite set A suffices, completely removing the density hypothesis. The formalization captures this two-level resolution in 244 lines of Lean 4, with the original conjecture derived from the stronger Chen-Ding theorem via a simple logical reduction.",
+    "implications": "**Theoretical Significance**: **Connections to Number Theory**\n\n1. **Prime Number Theorem:** The result is fundamentally powered by the density of primes. The PNT ensures that ~n/log(n) primes lie below n, providing enough 'targets' for the complements n - a to hit\n\n2. **Goldbach-type Problems:** The framework n = p + a with structured A encompasses many classical problems. The Chen-Ding result shows that the structure of A is irrelevant for the unboundedness question \u2014 only cardinality matters\n\n**3. Romanov's Theorem:** Romanov (1934) proved that a positive density of integers can be written as p + 2^k. Chen-Ding's result is complementary: it addresses the limsup rather than positive density, but applies to all infinite sets\n\n4. **Sieve Methods:** Erd\u0151s's 1950 proof pioneered the use of sieve methods for this type of problem. The Chen-Ding approach goes beyond sieves, using the PNT directly\n\n5. **Additive Combinatorics:** The result connects to the broader theme that sumsets P + A (primes plus a set) are large when A is infinite, paralleling results about sumsets in additive combinatorics (Freiman's theorem, Pl\u00fcnnecke-Ruzsa inequality).",
     "openQuestions": [
       "What is the growth rate of limsup f_A(n) as a function of the counting function of A? Is there a quantitative lower bound?",
-      "For which infinite sets A does f_A(n) → ∞ (not just limsup = ∞)? Is a positive lower density condition sufficient?",
-      "What about representations n = p₁ + p₂ + a involving two primes? Does the Goldbach-type machinery give stronger results?",
+      "For which infinite sets A does f_A(n) \u2192 \u221e (not just limsup = \u221e)? Is a positive lower density condition sufficient?",
+      "What about representations n = p\u2081 + p\u2082 + a involving two primes? Does the Goldbach-type machinery give stronger results?",
       "Can we characterize the set of n where f_A(n) = 0 for a given infinite A? What is the density of this exceptional set?",
-      "Does the analogous result hold for Gaussian primes and subsets of ℤ[i]?"
+      "Does the analogous result hold for Gaussian primes and subsets of \u2124[i]?"
     ]
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-239/meta.json
+++ b/src/data/proofs/erdos-239/meta.json
@@ -60,7 +60,7 @@
     ],
     "axiomCount": 6,
     "lineCount": 275,
-    "assumptions": "11 axioms: liouville_multiplicative, liouville_pm_one, completely_mult_pm_determined, and 8 more. See Lean source for complete statements."
+    "assumptions": "6 axioms: liouville_multiplicative, liouville_pm_one, wintner_renyi_counterexample, wirsing_theorem, halasz_characterization, liouville_mean_zero. 0 sorries."
   },
   "overview": {
     "historicalContext": "**The Mean Value Problem for Multiplicative Functions**\n\nErdos asked (1961, 1965, 1973) whether multiplicative functions taking values only in {-1, 1} always have convergent mean values. Wintner had observed that for complex-valued multiplicative functions on the unit circle, the limit need not exist - Renyi's example f(n) = n^i oscillates without converging.\n\n**Wirsing's Resolution (1967):**\nIn a landmark paper, Wirsing proved that the restriction to real values {-1, 1} forces convergence. The proof uses analytic methods involving Dirichlet series and careful estimates on sums over primes.\n\n**Halasz's Generalization (1968):**\nHalasz extended Wirsing's work to characterize exactly when the mean limit is zero versus non-zero, in terms of the sum sum_p (1 - f(p))/p over primes.",
@@ -205,17 +205,17 @@
     {
       "targetId": "erdos-4",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: analytic-number-theory, number-theory, solved"
+      "description": "Related Erd\u0151s problem sharing themes: analytic-number-theory, number-theory, solved"
     },
     {
       "targetId": "erdos-419",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: multiplicative-functions, number-theory, solved"
+      "description": "Related Erd\u0151s problem sharing themes: multiplicative-functions, number-theory, solved"
     },
     {
       "targetId": "erdos-682",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: analytic-number-theory, number-theory, solved"
+      "description": "Related Erd\u0151s problem sharing themes: analytic-number-theory, number-theory, solved"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-265/meta.json
+++ b/src/data/proofs/erdos-265/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-265",
-  "title": "Erdős Problem #265: Growth Rates of Sequences with Rational Sums",
+  "title": "Erd\u0151s Problem #265: Growth Rates of Sequences with Rational Sums",
   "slug": "erdos-265",
-  "description": "How fast can a sequence grow if both ∑ 1/aₙ and ∑ 1/(aₙ-1) are rational?",
+  "description": "How fast can a sequence grow if both \u2211 1/a\u2099 and \u2211 1/(a\u2099-1) are rational?",
   "meta": {
-    "author": "Erdős",
+    "author": "Erd\u0151s",
     "sourceUrl": "https://erdosproblems.com/265",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos265Problem.lean",
@@ -27,32 +27,32 @@
       },
       {
         "theorem": "tsum",
-        "description": "Infinite summation over ℕ",
+        "description": "Infinite summation over \u2115",
         "module": "Mathlib.Topology.Algebra.InfiniteSum.Basic"
       }
     ],
     "originalContributions": [
       "Formal definitions of valid sequences with dual rational sum constraints",
       "Growth rate hierarchy: single, double, and generalized exponential measures",
-      "Formal statement of Kovač-Tao (2024) doubly exponential result",
-      "Formal statement of irrationality threshold at β = 2"
+      "Formal statement of Kova\u010d-Tao (2024) doubly exponential result",
+      "Formal statement of irrationality threshold at \u03b2 = 2"
     ],
     "axiomCount": 2,
     "lineCount": 233,
-    "assumptions": "7 axioms. See Lean source for complete statements.",
+    "assumptions": "2 axioms: erdos_265_doubleExp_necessary, kovac_tao_theorem. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Georg Cantor discovered in the 19th century that the triangular numbers $a_n = \\binom{n}{2} = n(n-1)/2$ produce a sequence where both $\\sum 1/a_n$ and $\\sum 1/(a_n - 1)$ are rational. This elegant example grows only polynomially ($a_n \\sim n^2/2$), so $a_n^{1/n} \\to 1$. Erdős asked a deeper question: how fast can such sequences grow?\n\nErdős conjectured two things: (1) that sequences with $a_n^{1/n} \\to \\infty$ (super-exponential growth) exist, and (2) that $a_n^{1/2^n} \\to 1$ is necessary (double-exponential growth is the limit). The first conjecture was confirmed in a landmark 2024 paper by Vjekoslav Kovač and Terence Tao, who constructed sequences achieving doubly exponential growth $a_n^{1/\\beta^n} \\to \\infty$ for some $\\beta > 1$, published in the *Annals of Mathematics*.\n\nThe second conjecture — whether $\\beta = 2$ is a hard barrier — remains one of the most intriguing open problems at the intersection of number theory and analysis. A folklore result shows that if $a_n^{1/2^n} \\to c > 1$, then $\\sum 1/a_n$ is automatically irrational, suggesting $\\beta = 2$ is indeed special. The problem connects rationality of infinite series to growth rates via transcendence theory.",
+    "historicalContext": "Georg Cantor discovered in the 19th century that the triangular numbers $a_n = \\binom{n}{2} = n(n-1)/2$ produce a sequence where both $\\sum 1/a_n$ and $\\sum 1/(a_n - 1)$ are rational. This elegant example grows only polynomially ($a_n \\sim n^2/2$), so $a_n^{1/n} \\to 1$. Erd\u0151s asked a deeper question: how fast can such sequences grow?\n\nErd\u0151s conjectured two things: (1) that sequences with $a_n^{1/n} \\to \\infty$ (super-exponential growth) exist, and (2) that $a_n^{1/2^n} \\to 1$ is necessary (double-exponential growth is the limit). The first conjecture was confirmed in a landmark 2024 paper by Vjekoslav Kova\u010d and Terence Tao, who constructed sequences achieving doubly exponential growth $a_n^{1/\\beta^n} \\to \\infty$ for some $\\beta > 1$, published in the *Annals of Mathematics*.\n\nThe second conjecture \u2014 whether $\\beta = 2$ is a hard barrier \u2014 remains one of the most intriguing open problems at the intersection of number theory and analysis. A folklore result shows that if $a_n^{1/2^n} \\to c > 1$, then $\\sum 1/a_n$ is automatically irrational, suggesting $\\beta = 2$ is indeed special. The problem connects rationality of infinite series to growth rates via transcendence theory.",
     "problemStatement": "Let $1 \\leq a_1 < a_2 < \\cdots$ be strictly increasing integers. How fast can $a_n$ grow if both $\\sum_{n=1}^\\infty \\frac{1}{a_n}$ and $\\sum_{n=1}^\\infty \\frac{1}{a_n - 1}$ are rational?\n\nSpecifically: can $\\limsup a_n^{1/2^n} > 1$?",
-    "text": "How fast can a sequence grow if both ∑ 1/aₙ and ∑ 1/(aₙ-1) are rational?",
-    "proofStrategy": "The formalization introduces a hierarchy of definitions. First, valid sequences are characterized by positivity, strict monotonicity, and dual rationality of reciprocal sums. Then three growth measures are defined: single exponential $a_n^{1/n}$, double exponential $a_n^{1/2^n}$, and generalized $a_n^{1/\\beta^n}$. Cantor's triangular number example is defined with a proved monotonicity theorem. The main conjectures, Kovač-Tao's result, and the irrationality threshold are stated as axioms, since the proofs involve deep analytic number theory beyond current Mathlib capabilities.",
+    "text": "How fast can a sequence grow if both \u2211 1/a\u2099 and \u2211 1/(a\u2099-1) are rational?",
+    "proofStrategy": "The formalization introduces a hierarchy of definitions. First, valid sequences are characterized by positivity, strict monotonicity, and dual rationality of reciprocal sums. Then three growth measures are defined: single exponential $a_n^{1/n}$, double exponential $a_n^{1/2^n}$, and generalized $a_n^{1/\\beta^n}$. Cantor's triangular number example is defined with a proved monotonicity theorem. The main conjectures, Kova\u010d-Tao's result, and the irrationality threshold are stated as axioms, since the proofs involve deep analytic number theory beyond current Mathlib capabilities.",
     "keyInsights": [
       "**Cantor's triangular numbers are the prototype**: $a_n = n(n+1)/2$ gives polynomial growth with both sums rational. The telescoping identity $\\sum 2/(n(n+1)) = 2$ underlies the rationality",
       "**Higher polynomials work with shifted constraints**: Cubic sequences like $n^3 + 6n^2 + 5n$ can satisfy the dual rationality condition with a different shift constant, expanding the family of examples",
-      "**Kovač-Tao broke the exponential barrier**: Their 2024 Annals paper shows $\\exists \\beta > 1$ with valid sequences growing as $a_n \\sim \\beta^{\\beta^n}$, confirming Erdős's first conjecture that super-exponential growth is achievable",
-      "**The irrationality threshold at $\\beta = 2$**: A folklore result in transcendence theory shows that if $a_n^{1/2^n} \\to c > 1$ for a constant $c$, then $\\sum 1/a_n$ is irrational — providing a mechanism for why $\\beta = 2$ might be the hard limit",
-      "**The disjunction structure of the open problem**: Either (a) some valid sequence has $\\limsup a_n^{1/2^n} > 1$, disproving Erdős's second conjecture, or (b) all valid sequences satisfy $\\limsup a_n^{1/2^n} \\leq 1$, confirming it. This is formalized as a logical disjunction in Lean"
+      "**Kova\u010d-Tao broke the exponential barrier**: Their 2024 Annals paper shows $\\exists \\beta > 1$ with valid sequences growing as $a_n \\sim \\beta^{\\beta^n}$, confirming Erd\u0151s's first conjecture that super-exponential growth is achievable",
+      "**The irrationality threshold at $\\beta = 2$**: A folklore result in transcendence theory shows that if $a_n^{1/2^n} \\to c > 1$ for a constant $c$, then $\\sum 1/a_n$ is irrational \u2014 providing a mechanism for why $\\beta = 2$ might be the hard limit",
+      "**The disjunction structure of the open problem**: Either (a) some valid sequence has $\\limsup a_n^{1/2^n} > 1$, disproving Erd\u0151s's second conjecture, or (b) all valid sequences satisfy $\\limsup a_n^{1/2^n} \\leq 1$, confirming it. This is formalized as a logical disjunction in Lean"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -65,16 +65,16 @@
       "title": "Header and Imports",
       "startLine": 1,
       "endLine": 21,
-      "summary": "Module documentation describing the problem, Cantor's example, Erdős's conjectures, Kovač-Tao result, and the remaining open question. Imports Mathlib.",
-      "mathContext": "Mathematical content: Module documentation describing the problem, Cantor's example, Erdős's conjectures, Kovač-Tao result, and the remaining open question. Imports Mathlib."
+      "summary": "Module documentation describing the problem, Cantor's example, Erd\u0151s's conjectures, Kova\u010d-Tao result, and the remaining open question. Imports Mathlib.",
+      "mathContext": "Mathematical content: Module documentation describing the problem, Cantor's example, Erd\u0151s's conjectures, Kova\u010d-Tao result, and the remaining open question. Imports Mathlib."
     },
     {
       "id": "valid-sequences",
       "title": "Sequences with Rational Sums",
       "startLine": 22,
       "endLine": 47,
-      "summary": "Core definitions: positive integer sequences, strict monotonicity, reciprocal sum ∑ 1/aₙ, shifted reciprocal sum ∑ 1/(aₙ-1), and the combined rationality predicate hasBothRationalSums.",
-      "mathContext": "Formal definition: Core definitions: positive integer sequences, strict monotonicity, reciprocal sum ∑ 1/aₙ, shifted reciprocal sum ∑ 1/(aₙ-1), and the combined rationality predicate hasBothRationalSums."
+      "summary": "Core definitions: positive integer sequences, strict monotonicity, reciprocal sum \u2211 1/a\u2099, shifted reciprocal sum \u2211 1/(a\u2099-1), and the combined rationality predicate hasBothRationalSums.",
+      "mathContext": "Formal definition: Core definitions: positive integer sequences, strict monotonicity, reciprocal sum \u2211 1/a\u2099, shifted reciprocal sum \u2211 1/(a\u2099-1), and the combined rationality predicate hasBothRationalSums."
     },
     {
       "id": "cantor-example",
@@ -89,56 +89,56 @@
       "title": "Growth Rate Measures",
       "startLine": 72,
       "endLine": 90,
-      "summary": "Three growth measures: singleExpGrowth (aₙ^(1/n)), doubleExpGrowth (aₙ^(1/2ⁿ)), and genExpGrowth (aₙ^(1/βⁿ)) for parameterized β > 1.",
-      "mathContext": "Mathematical content: Three growth measures: singleExpGrowth (aₙ^(1/n)), doubleExpGrowth (aₙ^(1/2ⁿ)), and genExpGrowth (aₙ^(1/βⁿ)) for parameterized β > 1."
+      "summary": "Three growth measures: singleExpGrowth (a\u2099^(1/n)), doubleExpGrowth (a\u2099^(1/2\u207f)), and genExpGrowth (a\u2099^(1/\u03b2\u207f)) for parameterized \u03b2 > 1.",
+      "mathContext": "Mathematical content: Three growth measures: singleExpGrowth (a\u2099^(1/n)), doubleExpGrowth (a\u2099^(1/2\u207f)), and genExpGrowth (a\u2099^(1/\u03b2\u207f)) for parameterized \u03b2 > 1."
     },
     {
       "id": "erdos-conjectures",
-      "title": "Erdős's Conjectures",
+      "title": "Erd\u0151s's Conjectures",
       "startLine": 91,
       "endLine": 110,
-      "summary": "Two conjectures: (1) aₙ^(1/n) → ∞ is achievable (proved by Kovač-Tao), (2) aₙ^(1/2ⁿ) → 1 is necessary (still open).",
-      "mathContext": "Two conjectures: (1) aₙ^(1/n) $\\to$ ∞ is achievable (proved by Kovač-Tao), (2) aₙ^(1/2ⁿ) $\\to$ 1 is necessary (still open)."
+      "summary": "Two conjectures: (1) a\u2099^(1/n) \u2192 \u221e is achievable (proved by Kova\u010d-Tao), (2) a\u2099^(1/2\u207f) \u2192 1 is necessary (still open).",
+      "mathContext": "Two conjectures: (1) a\u2099^(1/n) $\\to$ \u221e is achievable (proved by Kova\u010d-Tao), (2) a\u2099^(1/2\u207f) $\\to$ 1 is necessary (still open)."
     },
     {
       "id": "kovac-tao",
-      "title": "Kovač-Tao Result and Open Question",
+      "title": "Kova\u010d-Tao Result and Open Question",
       "startLine": 111,
       "endLine": 132,
-      "summary": "Kovač-Tao theorem: ∃ β > 1 with aₙ^(1/βⁿ) → ∞ achievable. The remaining open question: can β = 2 work?",
-      "mathContext": "Kovač-Tao theorem: ∃ β > 1 with aₙ^(1/βⁿ) $\\to$ ∞ achievable. The remaining open question: can β = 2 work?"
+      "summary": "Kova\u010d-Tao theorem: \u2203 \u03b2 > 1 with a\u2099^(1/\u03b2\u207f) \u2192 \u221e achievable. The remaining open question: can \u03b2 = 2 work?",
+      "mathContext": "Kova\u010d-Tao theorem: \u2203 \u03b2 > 1 with a\u2099^(1/\u03b2\u207f) $\\to$ \u221e achievable. The remaining open question: can \u03b2 = 2 work?"
     },
     {
       "id": "irrationality",
       "title": "Irrationality Threshold",
       "startLine": 133,
       "endLine": 145,
-      "summary": "Folklore result: if aₙ^(1/2ⁿ) → c > 1, then ∑ 1/aₙ is irrational. This explains why β = 2 might be the natural barrier.",
-      "mathContext": "Folklore result: if aₙ^(1/2ⁿ) $\\to$ c > 1, then ∑ 1/aₙ is irrational. This explains why β = 2 might be the natural barrier."
+      "summary": "Folklore result: if a\u2099^(1/2\u207f) \u2192 c > 1, then \u2211 1/a\u2099 is irrational. This explains why \u03b2 = 2 might be the natural barrier.",
+      "mathContext": "Folklore result: if a\u2099^(1/2\u207f) $\\to$ c > 1, then \u2211 1/a\u2099 is irrational. This explains why \u03b2 = 2 might be the natural barrier."
     },
     {
       "id": "valid-set-poly",
       "title": "Valid Set and Polynomial Examples",
       "startLine": 146,
       "endLine": 173,
-      "summary": "Defines the set of valid sequences and states that higher-degree polynomial families (e.g., n³+6n²+5n with shift 12) can satisfy the constraint.",
-      "mathContext": "Formal definition: Defines the set of valid sequences and states that higher-degree polynomial families (e.g., n³+6n²+5n with shift 12) can satisfy the constraint."
+      "summary": "Defines the set of valid sequences and states that higher-degree polynomial families (e.g., n\u00b3+6n\u00b2+5n with shift 12) can satisfy the constraint.",
+      "mathContext": "Formal definition: Defines the set of valid sequences and states that higher-degree polynomial families (e.g., n\u00b3+6n\u00b2+5n with shift 12) can satisfy the constraint."
     },
     {
       "id": "main-open",
       "title": "Main Open Problem",
       "startLine": 174,
       "endLine": 205,
-      "summary": "The formal statement of Erdős #265 as a disjunction: either ∃ valid sequence with limsup aₙ^(1/2ⁿ) > 1, or all valid sequences have limsup ≤ 1.",
-      "mathContext": "The formal statement of Erdős #265 as a disjunction: either ∃ valid sequence with limsup aₙ^(1/2ⁿ) > 1, or all valid sequences have limsup $\\leq$ 1."
+      "summary": "The formal statement of Erd\u0151s #265 as a disjunction: either \u2203 valid sequence with limsup a\u2099^(1/2\u207f) > 1, or all valid sequences have limsup \u2264 1.",
+      "mathContext": "The formal statement of Erd\u0151s #265 as a disjunction: either \u2203 valid sequence with limsup a\u2099^(1/2\u207f) > 1, or all valid sequences have limsup $\\leq$ 1."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #265 concerns the maximum growth rate of sequences with two rational reciprocal sums. Cantor's triangular numbers give polynomial growth. Kovač and Tao (2024) achieved doubly exponential growth for some β > 1, confirming Erdős's first conjecture. The question of whether β = 2 is achievable remains the key open problem, formalized as a disjunction in Lean.",
-    "implications": "Resolution would sharpen our understanding of rationality criteria for infinite series and connect to transcendence theory. The irrationality threshold at β = 2 would establish a precise dividing line between rational and irrational behavior of reciprocal sums, with implications for the study of Liouville-type numbers and lacunary series.",
+    "summary": "Erd\u0151s Problem #265 concerns the maximum growth rate of sequences with two rational reciprocal sums. Cantor's triangular numbers give polynomial growth. Kova\u010d and Tao (2024) achieved doubly exponential growth for some \u03b2 > 1, confirming Erd\u0151s's first conjecture. The question of whether \u03b2 = 2 is achievable remains the key open problem, formalized as a disjunction in Lean.",
+    "implications": "Resolution would sharpen our understanding of rationality criteria for infinite series and connect to transcendence theory. The irrationality threshold at \u03b2 = 2 would establish a precise dividing line between rational and irrational behavior of reciprocal sums, with implications for the study of Liouville-type numbers and lacunary series.",
     "openQuestions": [
-      "Can limsup aₙ^(1/2ⁿ) > 1 be achieved while maintaining both sums rational?",
-      "What is the optimal β in Kovač-Tao's construction — how close to 2 can it get?",
+      "Can limsup a\u2099^(1/2\u207f) > 1 be achieved while maintaining both sums rational?",
+      "What is the optimal \u03b2 in Kova\u010d-Tao's construction \u2014 how close to 2 can it get?",
       "Are there explicit constructions (rather than existence proofs) achieving doubly exponential growth?"
     ]
   },
@@ -158,24 +158,24 @@
   "references": [
     {
       "key": "KoTa24",
-      "citation": "V. Kovač, T. Tao, 'Sequences with doubly exponential growth and rational sums', Annals of Mathematics (2024)"
+      "citation": "V. Kova\u010d, T. Tao, 'Sequences with doubly exponential growth and rational sums', Annals of Mathematics (2024)"
     }
   ],
   "crossReferences": [
     {
       "targetId": "erdos-260",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: irrationality, number-theory, sequences"
+      "description": "Related Erd\u0151s problem sharing themes: irrationality, number-theory, sequences"
     },
     {
       "targetId": "erdos-263",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: irrationality, number-theory, sequences"
+      "description": "Related Erd\u0151s problem sharing themes: irrationality, number-theory, sequences"
     },
     {
       "targetId": "erdos-264",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: irrationality, number-theory, sequences"
+      "description": "Related Erd\u0151s problem sharing themes: irrationality, number-theory, sequences"
     }
   ]
 }

--- a/src/data/proofs/erdos-306/meta.json
+++ b/src/data/proofs/erdos-306/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-306",
-  "title": "Erdős Problem #306: Egyptian Fractions with Semiprime Denominators",
+  "title": "Erd\u0151s Problem #306: Egyptian Fractions with Semiprime Denominators",
   "slug": "erdos-306",
-  "description": "Can every positive rational a/b with b squarefree be expressed as an Egyptian fraction where each denominator is a product of exactly 2 distinct primes? The 2-prime case is OPEN; the 3-prime case for integers was solved by Butler, Erdős, and Graham (2015).",
+  "description": "Can every positive rational a/b with b squarefree be expressed as an Egyptian fraction where each denominator is a product of exactly 2 distinct primes? The 2-prime case is OPEN; the 3-prime case for integers was solved by Butler, Erd\u0151s, and Graham (2015).",
   "meta": {
-    "author": "Erdős, Butler, Graham",
+    "author": "Erd\u0151s, Butler, Graham",
     "sourceUrl": "https://erdosproblems.com/306",
     "date": "",
     "status": "axiomatized",
@@ -27,12 +27,12 @@
     "mathlibDependencies": [
       {
         "theorem": "ArithmeticFunction.cardDistinctFactors",
-        "description": "ω(n) - count of distinct prime factors",
+        "description": "\u03c9(n) - count of distinct prime factors",
         "module": "Mathlib.NumberTheory.ArithmeticFunction.Defs"
       },
       {
         "theorem": "ArithmeticFunction.cardFactors",
-        "description": "Ω(n) - total count of prime factors with multiplicity",
+        "description": "\u03a9(n) - total count of prime factors with multiplicity",
         "module": "Mathlib.NumberTheory.ArithmeticFunction.Misc"
       },
       {
@@ -47,29 +47,29 @@
       }
     ],
     "originalContributions": [
-      "Definition of k-distinct-prime products using ω and Ω functions",
+      "Definition of k-distinct-prime products using \u03c9 and \u03a9 functions",
       "Structure for Egyptian fraction representations",
       "Statement of the main open conjecture for 2 distinct primes",
-      "Axiomatization of Butler-Erdős-Graham theorem for 3 distinct primes",
+      "Axiomatization of Butler-Erd\u0151s-Graham theorem for 3 distinct primes",
       "Verification of small examples using native_decide",
       "Discussion of density and asymptotic properties"
     ],
     "axiomCount": 2,
     "lineCount": 242,
-    "assumptions": "7 axioms: butler_erdos_graham_theorem, reduce_to_squarefree, twoPrimeProductCount, threePrimeProductCount, k_prime_product_density, erdos_306_open, greedy_egyptian_exists. See Lean source for complete statements."
+    "assumptions": "2 axioms: butler_erdos_graham_theorem, twoPrimeProductCount. 0 sorries."
   },
   "overview": {
-    "historicalContext": "Erdős Problem #306 asks about Egyptian fractions - a topic dating back to ancient Egypt, where fractions were typically expressed as sums of distinct unit fractions.\n\n**The Problem**: Can every positive rational a/b (with b squarefree) be written as 1/n₁ + ... + 1/nₖ where each nᵢ is a product of exactly 2 distinct primes?\n\n**Status**:\n- **2 distinct primes**: OPEN - the main conjecture\n- **3 distinct primes**: SOLVED for integers by Butler, Erdős, and Graham (2015)\n\n**Historical Note**: The Butler-Erdős-Graham paper appeared in 2015, 19 years after Erdős's death in 1996. It may be Erdős's last published paper, demonstrating his enduring influence on mathematics.\n\n**Key Example**: The integer 1 can be represented with 2-distinct-prime denominators:\n1/6 + 1/10 + 1/14 + 1/15 + 1/21 + 1/35 = 1\nwhere 6=2×3, 10=2×5, 14=2×7, 15=3×5, 21=3×7, 35=5×7.",
-    "problemStatement": "**Erdős Problem #306**: Let $a/b \\in \\mathbb{Q}_{>0}$ with $b$ squarefree. Are there integers $1 < n_1 < \\cdots < n_k$, each the product of two distinct primes, such that\n$$\\frac{a}{b} = \\frac{1}{n_1} + \\cdots + \\frac{1}{n_k}?$$\n\n**Status**: OPEN (for 2 distinct primes)\n\n**Related Result (SOLVED)**: For denominators that are products of THREE distinct primes, this is true when $b = 1$ (i.e., for positive integers). Proved by Butler, Erdős, and Graham (2015).\n\n**Examples of 2-distinct-prime products**: 6 = 2×3, 10 = 2×5, 14 = 2×7, 15 = 3×5, 21 = 3×7, ...\n\n**Examples of 3-distinct-prime products**: 30 = 2×3×5, 42 = 2×3×7, 66 = 2×3×11, ...",
-    "text": "Can every positive rational a/b with b squarefree be expressed as an Egyptian fraction where each denominator is a product of exactly 2 distinct primes? The 2-prime case is OPEN; the 3-prime case for integers was solved by Butler, Erdős, and Graham (2015).",
-    "proofStrategy": "The formalization captures both the open problem and the solved variant:\n\n1. **Prime Counting Functions**: Use Mathlib's ArithmeticFunction to define:\n   - `isProductOfKDistinctPrimes n k`: ω(n) = k and Ω(n) = k\n   - This ensures exactly k distinct primes, each appearing exactly once\n\n2. **Egyptian Representation**: Define `EgyptianRepr k` as a structure with:\n   - A sequence of k+1 denominators (with base = 1)\n   - Strictly increasing property\n   - Sum computed as ∑ 1/nᵢ\n\n3. **The Main Conjecture**: `erdos_306_conjecture` states every positive rational with squarefree denominator has a 2-prime Egyptian representation\n\n4. **Butler-Erdős-Graham**: Axiomatize the solved case for 3 distinct primes on positive integers\n\n5. **Examples**: Verify using native_decide that ω(6) = 2, Ω(6) = 2, ω(30) = 3, etc.",
+    "historicalContext": "Erd\u0151s Problem #306 asks about Egyptian fractions - a topic dating back to ancient Egypt, where fractions were typically expressed as sums of distinct unit fractions.\n\n**The Problem**: Can every positive rational a/b (with b squarefree) be written as 1/n\u2081 + ... + 1/n\u2096 where each n\u1d62 is a product of exactly 2 distinct primes?\n\n**Status**:\n- **2 distinct primes**: OPEN - the main conjecture\n- **3 distinct primes**: SOLVED for integers by Butler, Erd\u0151s, and Graham (2015)\n\n**Historical Note**: The Butler-Erd\u0151s-Graham paper appeared in 2015, 19 years after Erd\u0151s's death in 1996. It may be Erd\u0151s's last published paper, demonstrating his enduring influence on mathematics.\n\n**Key Example**: The integer 1 can be represented with 2-distinct-prime denominators:\n1/6 + 1/10 + 1/14 + 1/15 + 1/21 + 1/35 = 1\nwhere 6=2\u00d73, 10=2\u00d75, 14=2\u00d77, 15=3\u00d75, 21=3\u00d77, 35=5\u00d77.",
+    "problemStatement": "**Erd\u0151s Problem #306**: Let $a/b \\in \\mathbb{Q}_{>0}$ with $b$ squarefree. Are there integers $1 < n_1 < \\cdots < n_k$, each the product of two distinct primes, such that\n$$\\frac{a}{b} = \\frac{1}{n_1} + \\cdots + \\frac{1}{n_k}?$$\n\n**Status**: OPEN (for 2 distinct primes)\n\n**Related Result (SOLVED)**: For denominators that are products of THREE distinct primes, this is true when $b = 1$ (i.e., for positive integers). Proved by Butler, Erd\u0151s, and Graham (2015).\n\n**Examples of 2-distinct-prime products**: 6 = 2\u00d73, 10 = 2\u00d75, 14 = 2\u00d77, 15 = 3\u00d75, 21 = 3\u00d77, ...\n\n**Examples of 3-distinct-prime products**: 30 = 2\u00d73\u00d75, 42 = 2\u00d73\u00d77, 66 = 2\u00d73\u00d711, ...",
+    "text": "Can every positive rational a/b with b squarefree be expressed as an Egyptian fraction where each denominator is a product of exactly 2 distinct primes? The 2-prime case is OPEN; the 3-prime case for integers was solved by Butler, Erd\u0151s, and Graham (2015).",
+    "proofStrategy": "The formalization captures both the open problem and the solved variant:\n\n1. **Prime Counting Functions**: Use Mathlib's ArithmeticFunction to define:\n   - `isProductOfKDistinctPrimes n k`: \u03c9(n) = k and \u03a9(n) = k\n   - This ensures exactly k distinct primes, each appearing exactly once\n\n2. **Egyptian Representation**: Define `EgyptianRepr k` as a structure with:\n   - A sequence of k+1 denominators (with base = 1)\n   - Strictly increasing property\n   - Sum computed as \u2211 1/n\u1d62\n\n3. **The Main Conjecture**: `erdos_306_conjecture` states every positive rational with squarefree denominator has a 2-prime Egyptian representation\n\n4. **Butler-Erd\u0151s-Graham**: Axiomatize the solved case for 3 distinct primes on positive integers\n\n5. **Examples**: Verify using native_decide that \u03c9(6) = 2, \u03a9(6) = 2, \u03c9(30) = 3, etc.",
     "keyInsights": [
       "**Semiprime constraint**: Products of exactly 2 distinct primes (semiprimes with distinct factors) are sparser than products of 3 distinct primes, making the 2-prime case harder.",
       "**Why squarefree denominator?**: Every reduced fraction has squarefree denominator; this natural condition may be necessary for the representation to exist.",
       "**Density matters**: Products of k distinct primes have density roughly n(log log n)^(k-1)/((k-1)! log n), so more prime factors means more available denominators.",
-      "**The 19-year posthumous paper**: Butler-Erdős-Graham (2015) may be Erdős's last publication, showing that collaborative mathematics transcends a single lifetime.",
+      "**The 19-year posthumous paper**: Butler-Erd\u0151s-Graham (2015) may be Erd\u0151s's last publication, showing that collaborative mathematics transcends a single lifetime.",
       "**Connection to greedy algorithm**: The classical greedy algorithm for Egyptian fractions works but doesn't guarantee prime structure; constrained versions need new techniques.",
-      "**ω vs Ω**: Using both ω(n) = k (distinct primes) and Ω(n) = k (total factors) ensures each prime appears exactly once - the key constraint."
+      "**\u03c9 vs \u03a9**: Using both \u03c9(n) = k (distinct primes) and \u03a9(n) = k (total factors) ensures each prime appears exactly once - the key constraint."
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -82,7 +82,7 @@
       "title": "Module Documentation",
       "startLine": 1,
       "endLine": 19,
-      "summary": "Problem statement, status (2-prime open, 3-prime solved), and references including Butler-Erdős-Graham (2015)."
+      "summary": "Problem statement, status (2-prime open, 3-prime solved), and references including Butler-Erd\u0151s-Graham (2015)."
     },
     {
       "id": "egyptian-background",
@@ -96,7 +96,7 @@
       "title": "Semiprime Definitions",
       "startLine": 47,
       "endLine": 73,
-      "summary": "Definitions of products of k distinct primes using ω and Ω functions."
+      "summary": "Definitions of products of k distinct primes using \u03c9 and \u03a9 functions."
     },
     {
       "id": "conjecture",
@@ -107,7 +107,7 @@
     },
     {
       "id": "butler-erdos-graham",
-      "title": "Butler-Erdős-Graham Theorem",
+      "title": "Butler-Erd\u0151s-Graham Theorem",
       "startLine": 112,
       "endLine": 139,
       "summary": "The solved case for 3 distinct primes on positive integers."
@@ -128,11 +128,11 @@
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erdős Problem #306 on Egyptian fractions with semiprime denominators. The main conjecture - that every positive rational with squarefree denominator can be expressed with 2-distinct-prime denominators - remains OPEN. The variant for 3 distinct primes was solved by Butler, Erdős, and Graham in 2015 for positive integers.",
+    "summary": "We formalize Erd\u0151s Problem #306 on Egyptian fractions with semiprime denominators. The main conjecture - that every positive rational with squarefree denominator can be expressed with 2-distinct-prime denominators - remains OPEN. The variant for 3 distinct primes was solved by Butler, Erd\u0151s, and Graham in 2015 for positive integers.",
     "implications": "This problem connects ancient Egyptian mathematics (unit fractions), modern number theory (prime factorization and arithmetic functions), and combinatorics (subset selection). The difficulty increases as we restrict the number of prime factors in denominators, revealing deep structure in how rationals can be decomposed.",
     "openQuestions": [
       "Is the 2-distinct-prime conjecture true for all squarefree denominators?",
-      "Can the Butler-Erdős-Graham result be extended from integers to arbitrary rationals?",
+      "Can the Butler-Erd\u0151s-Graham result be extended from integers to arbitrary rationals?",
       "What is the minimum number of terms needed for specific rationals?",
       "Are there rationals that require exponentially many 2-distinct-prime terms?",
       "What algorithmic approach would find such representations efficiently?"
@@ -163,17 +163,17 @@
     {
       "targetId": "erdos-318",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: egyptian-fractions, number-theory, partially-solved"
+      "description": "Related Erd\u0151s problem sharing themes: egyptian-fractions, number-theory, partially-solved"
     },
     {
       "targetId": "erdos-1094",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: number-theory, prime-factorization"
+      "description": "Related Erd\u0151s problem sharing themes: number-theory, prime-factorization"
     },
     {
       "targetId": "erdos-137",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: number-theory, prime-factorization"
+      "description": "Related Erd\u0151s problem sharing themes: number-theory, prime-factorization"
     }
   ]
 }


### PR DESCRIPTION
## Fix

Corrects stale `assumptions` text in 10 gallery proof `meta.json` files where the human-readable description listed more axioms than the actual `axiomCount` field.

## Changes

| Proof | Old count | New count | Actual axioms |
|-------|-----------|-----------|---------------|
| erdos-306 | 7 | 2 | butler_erdos_graham_theorem, twoPrimeProductCount |
| erdos-265 | 7 | 2 | erdos_265_doubleExp_necessary, kovac_tao_theorem |
| erdos-239 | 11 | 6 | liouville_multiplicative, liouville_pm_one, wintner_renyi_counterexample, wirsing_theorem, halasz_characterization, liouville_mean_zero |
| erdos-237 | 6 | 1 | chen_ding_2022 |
| erdos-229 | 6 | 1 | barth_schneider_theorem |
| erdos-210 | 14 | 9 | OrdinaryLineCount, f, sylvester_gallai, motzkin_theorem, kelly_moser, csima_sawyer, green_tao_even, green_tao_odd, LiesOnCubic |
| erdos-209 | 6 | 1 | escudero_2016 |
| erdos-194 | 7 | 2 | chaotic_ordering_rationals, chaotic_ordering_k_term |
| erdos-174 | 10 | 5 | ramsey_implies_spherical, rectangle_is_ramsey, simplex_is_ramsey, trapezoid_is_ramsey, collinear_not_spherical |
| erdos-166 | 7 | 2 | aks_upper_bound, mattheus_verstraete |

---
Automated fix by lean-mechanic agent.