### PR TITLE
fix(meta): correct stale assumptions text for 10 gallery proofs (batch 31)

### DIFF
--- a/src/data/proofs/erdos-1013/meta.json
+++ b/src/data/proofs/erdos-1013/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "open",
     "axiomCount": 1,
     "lineCount": 201,
-    "assumptions": "6 axioms: lower_bound, upper_bound, graver_yackel_bound (known results), threshold_three (h₃(3)=5, C₅), threshold_four (h₃(4)=11, Grötzsch), mycielski_construction (existence). threshold_mono, threshold_one, threshold_two now proved. Open conjectures stated as Prop defs.",
+    "assumptions": "1 axiom: mycielski_construction. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -39,7 +39,7 @@
       "**Extremal graphs reveal structure**: $h_3(3) = 5$ (unique: $C_5$), $h_3(4) = 11$ (unique: Grotzsch graph), $h_3(5) = 22$; the extremal graphs become less structured as $k$ grows"
     ],
     "prerequisites": [
-      "Combinatorics (Turán's theorem, density bounds)",
+      "Combinatorics (Tur\u00e1n's theorem, density bounds)",
       "Combinatorics (extremal graph theory, Ramsey theory)",
       "Extremal graph theory (triangle-free graphs, Ramsey)",
       "Graph theory (chromatic number, cliques, matchings)"
@@ -131,8 +131,8 @@
       "title": "Structural Properties",
       "startLine": 130,
       "endLine": 188,
-      "summary": "Proves `threshold_mono` ($j \\leq k \\Rightarrow h_3(j) \\leq h_3(k)$, via `csInf_le_csInf`), `threshold_one` ($h_3(1) = 1$, single vertex is $K_3$-free with $\\chi \\geq 1$), `threshold_two` ($h_3(2) = 2$, complete graph $K_2$ is $K_3$-free with $\\chi = 2$, proved by `le_antisymm` with case analysis on $n \\in \\{0, 1\\}$). Axiomatizes `threshold_three` ($h_3(3) = 5$, cycle $C_5$) and `threshold_four` ($h_3(4) = 11$, Grötzsch graph).",
-      "mathContext": "$h_3(1) = 1$ (single vertex), $h_3(2) = 2$ ($K_2$), $h_3(3) = 5$ ($C_5$), $h_3(4) = 11$ (Grötzsch graph). The `threshold_two` proof is ~20 lines: shows $K_2 = (\\top : \\text{SimpleGraph}(\\text{Fin}\\ 2))$ is triangle-free and not 1-colorable, then shows any graph on $< 2$ vertices IS 1-colorable."
+      "summary": "Proves `threshold_mono` ($j \\leq k \\Rightarrow h_3(j) \\leq h_3(k)$, via `csInf_le_csInf`), `threshold_one` ($h_3(1) = 1$, single vertex is $K_3$-free with $\\chi \\geq 1$), `threshold_two` ($h_3(2) = 2$, complete graph $K_2$ is $K_3$-free with $\\chi = 2$, proved by `le_antisymm` with case analysis on $n \\in \\{0, 1\\}$). Axiomatizes `threshold_three` ($h_3(3) = 5$, cycle $C_5$) and `threshold_four` ($h_3(4) = 11$, Gr\u00f6tzsch graph).",
+      "mathContext": "$h_3(1) = 1$ (single vertex), $h_3(2) = 2$ ($K_2$), $h_3(3) = 5$ ($C_5$), $h_3(4) = 11$ (Gr\u00f6tzsch graph). The `threshold_two` proof is ~20 lines: shows $K_2 = (\\top : \\text{SimpleGraph}(\\text{Fin}\\ 2))$ is triangle-free and not 1-colorable, then shows any graph on $< 2$ vertices IS 1-colorable."
     },
     {
       "id": "proved-results",
@@ -150,23 +150,23 @@
       "What is the exact asymptotic constant $c$ in $h_3(k) \\sim c \\cdot k^2 \\log k$? Is $c = 1/2$ (matching the Ramsey lower bound)?",
       "Is $h_3(k+1)/h_3(k) \\to 1$? Can this be proved without determining the full asymptotic?",
       "What about the $K_r$-free generalization $h_r(k)$? (Related: Erdos Problem #920)",
-      "What is the structure of extremal triangle-free $k$-chromatic graphs for large $k$ — are they random-like or algebraically structured?"
+      "What is the structure of extremal triangle-free $k$-chromatic graphs for large $k$ \u2014 are they random-like or algebraically structured?"
     ]
   },
   "crossReferences": [
     {
       "relationship": "dual problem",
-      "note": "Erdős Problem #1104 asks for the maximum chromatic number $f(n)$ of a triangle-free graph on $n$ vertices — the inverse of $h_3(k)$. The two functions satisfy $h_3(f(n)) \\leq n < h_3(f(n)+1)$, so progress on one directly constrains the other. The known bound $f(n) = \\Theta(\\sqrt{n/\\log n})$ is equivalent to $h_3(k) = \\Theta(k^2 \\log k)$.",
+      "note": "Erd\u0151s Problem #1104 asks for the maximum chromatic number $f(n)$ of a triangle-free graph on $n$ vertices \u2014 the inverse of $h_3(k)$. The two functions satisfy $h_3(f(n)) \\leq n < h_3(f(n)+1)$, so progress on one directly constrains the other. The known bound $f(n) = \\Theta(\\sqrt{n/\\log n})$ is equivalent to $h_3(k) = \\Theta(k^2 \\log k)$.",
       "targetId": "erdos-1104"
     },
     {
       "relationship": "generalization",
-      "note": "Erdős Problem #920 concerns $h_r(k)$, the smallest $n$ such that a $K_r$-free graph on $n$ vertices can have chromatic number $k$. Problem #1013 is the $r = 3$ special case. The general problem requires understanding Ramsey numbers $R(r,k)$, making it considerably harder for $r \\geq 4$.",
+      "note": "Erd\u0151s Problem #920 concerns $h_r(k)$, the smallest $n$ such that a $K_r$-free graph on $n$ vertices can have chromatic number $k$. Problem #1013 is the $r = 3$ special case. The general problem requires understanding Ramsey numbers $R(r,k)$, making it considerably harder for $r \\geq 4$.",
       "targetId": "erdos-920"
     },
     {
       "relationship": "structural analogy",
-      "note": "Erdős Problem #1014 asks whether $R(k, l+1)/R(k, l) \\to 1$ as $l \\to \\infty$ for fixed $k$. The ratio convergence question here — whether $h_3(k+1)/h_3(k) \\to 1$ — is structurally identical and similarly open for $k = 3$. Both ask whether the relevant combinatorial threshold grows smoothly.",
+      "note": "Erd\u0151s Problem #1014 asks whether $R(k, l+1)/R(k, l) \\to 1$ as $l \\to \\infty$ for fixed $k$. The ratio convergence question here \u2014 whether $h_3(k+1)/h_3(k) \\to 1$ \u2014 is structurally identical and similarly open for $k = 3$. Both ask whether the relevant combinatorial threshold grows smoothly.",
       "targetId": "erdos-1014"
     },
     {
@@ -176,7 +176,7 @@
     },
     {
       "relationship": "proof technique",
-      "note": "The first-moment probabilistic method underlies the Graver–Yackel lower bound $h_3(k) \\gg k^2 \\log k / \\log \\log k$ (1968): a random graph on $n$ vertices with edge probability $p$ can be shown to have high chromatic number while containing few triangles, which are then deleted without destroying the chromatic number.",
+      "note": "The first-moment probabilistic method underlies the Graver\u2013Yackel lower bound $h_3(k) \\gg k^2 \\log k / \\log \\log k$ (1968): a random graph on $n$ vertices with edge probability $p$ can be shown to have high chromatic number while containing few triangles, which are then deleted without destroying the chromatic number.",
       "targetId": "prob-method-expectation"
     },
     {
@@ -194,7 +194,7 @@
       "venue": "Colloquium Mathematicum",
       "year": "1955",
       "volume": "3",
-      "pages": "161–162",
+      "pages": "161\u2013162",
       "note": "The foundational paper proving that triangle-free graphs of arbitrarily high chromatic number exist via the Mycielski inductive construction. Proves $h_3(k) < \\infty$ for all $k$."
     },
     {
@@ -206,7 +206,7 @@
       "year": "1983",
       "volume": "46",
       "issue": "1",
-      "pages": "83–87",
+      "pages": "83\u201387",
       "doi": "10.1016/0012-365X(83)90273-X",
       "note": "Proves $R(3,k) \\leq (1+o(1))k^2/(2\\log k)$ via an entropy argument, establishing the lower bound $h_3(k) \\geq (1/2 - o(1))k^2 \\log k$."
     },
@@ -220,7 +220,7 @@
       "year": "1968",
       "volume": "4",
       "issue": "2",
-      "pages": "125–175",
+      "pages": "125\u2013175",
       "doi": "10.1016/S0021-9800(68)80035-1",
       "note": "First quantitative lower bound on $h_3(k)$: proves $h_3(k) \\gg k^2 \\log k / \\log \\log k$ using probabilistic deletion, the predecessor to the sharper Ramsey-theoretic bound."
     },
@@ -237,14 +237,14 @@
     },
     {
       "authors": [
-        "Zdeněk Dvořák",
+        "Zden\u011bk Dvo\u0159\u00e1k",
         "Luke Postle"
       ],
       "title": "Correspondence coloring and its application to list-coloring planar graphs without cycles of lengths 4 to 8",
       "venue": "Journal of Combinatorial Theory, Series B",
       "year": "2018",
       "volume": "129",
-      "pages": "38–54",
+      "pages": "38\u201354",
       "doi": "10.1016/j.jctb.2017.09.001",
       "note": "Introduces correspondence (DP) coloring, a strengthening of list coloring that has become a key tool in studying chromatic thresholds for graph families defined by forbidden subgraphs, including triangle-free graphs."
     }

--- a/src/data/proofs/erdos-1025/meta.json
+++ b/src/data/proofs/erdos-1025/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-1025",
-  "title": "Erdős Problem #1025: Independent Sets in Pair Functions",
+  "title": "Erd\u0151s Problem #1025: Independent Sets in Pair Functions",
   "slug": "erdos-1025",
-  "description": "Let f map pairs from {1,...,n} to {1,...,n} with f(x,y) ≠ x,y. Let g(n) be the minimum guaranteed independent set size. Erdős-Hajnal (1958) proved n^(1/3) ≪ g(n) ≪ (n log n)^(1/2). Spencer (1972) and Conlon-Fox-Sudakov (2016) determined g(n) = Θ(n^(1/2)).",
+  "description": "Let f map pairs from {1,...,n} to {1,...,n} with f(x,y) \u2260 x,y. Let g(n) be the minimum guaranteed independent set size. Erd\u0151s-Hajnal (1958) proved n^(1/3) \u226a g(n) \u226a (n log n)^(1/2). Spencer (1972) and Conlon-Fox-Sudakov (2016) determined g(n) = \u0398(n^(1/2)).",
   "meta": {
-    "author": "Erdős-Hajnal (1958), Spencer (1972), Conlon-Fox-Sudakov (2016)",
+    "author": "Erd\u0151s-Hajnal (1958), Spencer (1972), Conlon-Fox-Sudakov (2016)",
     "sourceUrl": "https://erdosproblems.com/1025",
     "date": "2016",
     "status": "axiomatized",
@@ -24,20 +24,20 @@
     "relatedProblems": [],
     "axiomCount": 4,
     "lineCount": 246,
-    "assumptions": "9 axioms: g_spec, erdos_hajnal_lower, erdos_hajnal_upper, and 6 more. See Lean source for complete statements.",
+    "assumptions": "4 axioms: erdos_hajnal_lower, erdos_hajnal_upper, spencer_lower, cfs_upper. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "Erdős Problem #1025 concerns pair functions: functions f that assign to each unordered pair {x,y} from {1,...,n} an element f(x,y) ∈ {1,...,n} \\ {x,y}. A set X is independent if f(x,y) ∉ X whenever both x and y are in X. The question asks for g(n), the minimum over all valid pair functions of the maximum independent set size.\n\nErdős and Hajnal (1958) established initial bounds n^{1/3} ≪ g(n) ≪ (n log n)^{1/2}, leaving a significant gap. The lower bound used a greedy argument, while the upper bound came from connections to hypergraph coloring. Spencer (1972) improved the lower bound to n^{1/2} using the probabilistic method: randomly including each vertex with probability p ≈ n^{-1/2} and deleting vertices hit by pair images gives an independent set of expected size Ω(n^{1/2}).\n\nThe matching upper bound g(n) = O(n^{1/2}) was proved by Conlon, Fox, and Sudakov (2016), completing the determination g(n) = Θ(n^{1/2}) after 58 years. Their construction used algebraic methods to build pair functions with provably small independent sets. The problem is closely related to Erdős-Hajnal's theory of set mappings, where each element maps to a subset avoiding itself, and free sets are the analogue of independent sets.",
-    "problemStatement": "**Problem Statement**\n\nLet f be a function from all pairs {x,y} ⊆ {1,...,n} to {1,...,n} such that f(x,y) ≠ x and f(x,y) ≠ y. A set X ⊆ {1,...,n} is independent if f(x,y) ∉ X whenever x,y ∈ X.\n\nLet g(n) be such that every such function f has an independent set of size at least g(n). Estimate g(n).\n\n**Status**: SOLVED\n\n**Answer**: g(n) = Θ(n^(1/2))",
-    "text": "Let f map pairs from {1,...,n} to {1,...,n} with f(x,y) ≠ x,y. Let g(n) be the minimum guaranteed independent set size. Erdős-Hajnal (1958) proved n^(1/3) ≪ g(n) ≪ (n log n)^(1/2). Spencer (1972) and Conlon-Fox-Sudakov (2016) determined g(n) = Θ(n^(1/2)).",
-    "proofStrategy": "**Proof Approach**\n\n1. **Lower Bound (Probabilistic)**: Include each vertex with probability p. Expected independent set size is pn - C(n,2)p³. Optimize p ≈ n^(-1/2) to get Ω(n^(1/2)).\n\n2. **Upper Bound (Construction)**: Conlon-Fox-Sudakov constructed pair functions achieving small independent sets using algebraic methods.\n\n3. **Key Insight**: The constraint f(x,y) ∉ {x,y} limits how much the function can \"spread out\" pairs, but still allows constructions with O(n^(1/2)) maximum independent sets.",
+    "historicalContext": "Erd\u0151s Problem #1025 concerns pair functions: functions f that assign to each unordered pair {x,y} from {1,...,n} an element f(x,y) \u2208 {1,...,n} \\ {x,y}. A set X is independent if f(x,y) \u2209 X whenever both x and y are in X. The question asks for g(n), the minimum over all valid pair functions of the maximum independent set size.\n\nErd\u0151s and Hajnal (1958) established initial bounds n^{1/3} \u226a g(n) \u226a (n log n)^{1/2}, leaving a significant gap. The lower bound used a greedy argument, while the upper bound came from connections to hypergraph coloring. Spencer (1972) improved the lower bound to n^{1/2} using the probabilistic method: randomly including each vertex with probability p \u2248 n^{-1/2} and deleting vertices hit by pair images gives an independent set of expected size \u03a9(n^{1/2}).\n\nThe matching upper bound g(n) = O(n^{1/2}) was proved by Conlon, Fox, and Sudakov (2016), completing the determination g(n) = \u0398(n^{1/2}) after 58 years. Their construction used algebraic methods to build pair functions with provably small independent sets. The problem is closely related to Erd\u0151s-Hajnal's theory of set mappings, where each element maps to a subset avoiding itself, and free sets are the analogue of independent sets.",
+    "problemStatement": "**Problem Statement**\n\nLet f be a function from all pairs {x,y} \u2286 {1,...,n} to {1,...,n} such that f(x,y) \u2260 x and f(x,y) \u2260 y. A set X \u2286 {1,...,n} is independent if f(x,y) \u2209 X whenever x,y \u2208 X.\n\nLet g(n) be such that every such function f has an independent set of size at least g(n). Estimate g(n).\n\n**Status**: SOLVED\n\n**Answer**: g(n) = \u0398(n^(1/2))",
+    "text": "Let f map pairs from {1,...,n} to {1,...,n} with f(x,y) \u2260 x,y. Let g(n) be the minimum guaranteed independent set size. Erd\u0151s-Hajnal (1958) proved n^(1/3) \u226a g(n) \u226a (n log n)^(1/2). Spencer (1972) and Conlon-Fox-Sudakov (2016) determined g(n) = \u0398(n^(1/2)).",
+    "proofStrategy": "**Proof Approach**\n\n1. **Lower Bound (Probabilistic)**: Include each vertex with probability p. Expected independent set size is pn - C(n,2)p\u00b3. Optimize p \u2248 n^(-1/2) to get \u03a9(n^(1/2)).\n\n2. **Upper Bound (Construction)**: Conlon-Fox-Sudakov constructed pair functions achieving small independent sets using algebraic methods.\n\n3. **Key Insight**: The constraint f(x,y) \u2209 {x,y} limits how much the function can \"spread out\" pairs, but still allows constructions with O(n^(1/2)) maximum independent sets.",
     "keyInsights": [
       "Pair function: f maps pairs to elements, avoiding the pair itself",
-      "Independent set: f(x,y) ∉ X for all pairs in X",
-      "Erdős-Hajnal (1958): n^(1/3) ≪ g(n) ≪ (n log n)^(1/2)",
-      "Spencer (1972): g(n) ≫ n^(1/2) via probabilistic method",
-      "Conlon-Fox-Sudakov (2016): g(n) ≪ n^(1/2) via construction"
+      "Independent set: f(x,y) \u2209 X for all pairs in X",
+      "Erd\u0151s-Hajnal (1958): n^(1/3) \u226a g(n) \u226a (n log n)^(1/2)",
+      "Spencer (1972): g(n) \u226b n^(1/2) via probabilistic method",
+      "Conlon-Fox-Sudakov (2016): g(n) \u226a n^(1/2) via construction"
     ],
     "prerequisites": [
       "Combinatorics (counting, extremal problems)",
@@ -71,7 +71,7 @@
     },
     {
       "id": "erdos-hajnal",
-      "title": "Erdős-Hajnal Bounds (1958)",
+      "title": "Erd\u0151s-Hajnal Bounds (1958)",
       "summary": "erdos_hajnal_lower, erdos_hajnal_upper axioms, erdos_hajnal_bounds",
       "startLine": 92,
       "endLine": 117,
@@ -127,8 +127,8 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #1025 asked to estimate g(n), the minimum guaranteed independent set size in pair functions. After 58 years of progress, the answer is g(n) = Θ(n^(1/2)): Spencer (1972) proved the lower bound and Conlon-Fox-Sudakov (2016) matched it with the upper bound.",
-    "implications": "1. **Set Mappings**: Fundamental result on structure of set mappings\n\n**2. Extremal Combinatorics**: Clean Θ(n^(1/2)) answer after gap between n^(1/3) and (n log n)^(1/2)\n\n3. **Probabilistic Method**: Lower bound via random selection and optimization\n\n4. **Algebraic Constructions**: Upper bound via explicit constructions.",
+    "summary": "Erd\u0151s Problem #1025 asked to estimate g(n), the minimum guaranteed independent set size in pair functions. After 58 years of progress, the answer is g(n) = \u0398(n^(1/2)): Spencer (1972) proved the lower bound and Conlon-Fox-Sudakov (2016) matched it with the upper bound.",
+    "implications": "1. **Set Mappings**: Fundamental result on structure of set mappings\n\n**2. Extremal Combinatorics**: Clean \u0398(n^(1/2)) answer after gap between n^(1/3) and (n log n)^(1/2)\n\n3. **Probabilistic Method**: Lower bound via random selection and optimization\n\n4. **Algebraic Constructions**: Upper bound via explicit constructions.",
     "openQuestions": [
       "What are the exact constants in the asymptotic?",
       "Analogous problems for k-tuples instead of pairs?",
@@ -140,12 +140,12 @@
   "crossReferences": [
     {
       "slug": "erdos-1029",
-      "title": "Erdős Problem #1029: Ramsey Number Growth Rate",
+      "title": "Erd\u0151s Problem #1029: Ramsey Number Growth Rate",
       "relationship": "Both problems use the probabilistic method to obtain tight asymptotic bounds; #1029 bounds Ramsey numbers R(3,t) while #1025 bounds the independent set function g(n), with Spencer's argument in both cases relying on random vertex selection and deletion."
     },
     {
       "slug": "erdos-1028",
-      "title": "Erdős Problem #1028: Discrepancy of Sign Functions",
+      "title": "Erd\u0151s Problem #1028: Discrepancy of Sign Functions",
       "relationship": "Shares the extremal combinatorics setting of estimating a min-max function over combinatorial structures, with algebraic construction techniques (used in Conlon-Fox-Sudakov's upper bound) appearing in both problems."
     },
     {
@@ -160,29 +160,29 @@
     },
     {
       "slug": "erdos-1",
-      "title": "Erdős Problem #1: Distinct Subset Sums",
-      "relationship": "Archetypal Erdős extremal problem resolved after decades; both problems illustrate the pattern of establishing a bound with the probabilistic method and then matching it with an explicit construction."
+      "title": "Erd\u0151s Problem #1: Distinct Subset Sums",
+      "relationship": "Archetypal Erd\u0151s extremal problem resolved after decades; both problems illustrate the pattern of establishing a bound with the probabilistic method and then matching it with an explicit construction."
     }
   ],
   "references": [
     {
       "authors": [
-        "P. Erdős",
+        "P. Erd\u0151s",
         "A. Hajnal"
       ],
       "title": "On the structure of set-mappings",
       "venue": "Acta Mathematica Academiae Scientiarum Hungaricae",
       "year": "1958",
-      "description": "Original paper establishing n^{1/3} ≪ g(n) ≪ (n log n)^{1/2} for pair functions, founding the study of set mappings and free sets."
+      "description": "Original paper establishing n^{1/3} \u226a g(n) \u226a (n log n)^{1/2} for pair functions, founding the study of set mappings and free sets."
     },
     {
       "authors": [
         "J. Spencer"
       ],
-      "title": "Turán's theorem for k-graphs",
+      "title": "Tur\u00e1n's theorem for k-graphs",
       "venue": "Discrete Mathematics",
       "year": "1972",
-      "description": "Spencer improved the lower bound to g(n) ≫ n^{1/2} using the probabilistic deletion method, which became a template for extremal combinatorics."
+      "description": "Spencer improved the lower bound to g(n) \u226b n^{1/2} using the probabilistic deletion method, which became a template for extremal combinatorics."
     },
     {
       "authors": [
@@ -193,7 +193,7 @@
       "title": "An improved bound for the stepping-up lemma",
       "venue": "Discrete Applied Mathematics",
       "year": "2016",
-      "description": "Conlon, Fox, and Sudakov closed the 58-year gap by proving g(n) ≪ n^{1/2} via an algebraic construction, establishing g(n) = Θ(n^{1/2})."
+      "description": "Conlon, Fox, and Sudakov closed the 58-year gap by proving g(n) \u226a n^{1/2} via an algebraic construction, establishing g(n) = \u0398(n^{1/2})."
     },
     {
       "authors": [
@@ -207,13 +207,13 @@
     },
     {
       "authors": [
-        "P. Erdős",
+        "P. Erd\u0151s",
         "A. Hajnal"
       ],
       "title": "On chromatic number of graphs and set-systems",
       "venue": "Acta Mathematica Academiae Scientiarum Hungaricae",
       "year": "1966",
-      "description": "Follow-up paper deepening the connection between pair/set-mapping independent sets and hypergraph chromatic numbers, part of the Erdős-Hajnal program surrounding Problem #1025."
+      "description": "Follow-up paper deepening the connection between pair/set-mapping independent sets and hypergraph chromatic numbers, part of the Erd\u0151s-Hajnal program surrounding Problem #1025."
     }
   ],
   "leanFile": {

--- a/src/data/proofs/erdos-1053/meta.json
+++ b/src/data/proofs/erdos-1053/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-1053",
-  "title": "Erdős Problem #1053: Growth Rate of k-Perfect Numbers",
+  "title": "Erd\u0151s Problem #1053: Growth Rate of k-Perfect Numbers",
   "slug": "erdos-1053",
-  "description": "If σ(n) = k·n (n is k-perfect), must k = o(log log n)? Known: k ≤ 11 exists. Gronwall: σ(n)/n = O(log log n). Robin's inequality gives k = O(log log n) conditionally on RH. Status: OPEN.",
+  "description": "If \u03c3(n) = k\u00b7n (n is k-perfect), must k = o(log log n)? Known: k \u2264 11 exists. Gronwall: \u03c3(n)/n = O(log log n). Robin's inequality gives k = O(log log n) conditionally on RH. Status: OPEN.",
   "meta": {
-    "author": "Paul Erdős",
+    "author": "Paul Erd\u0151s",
     "erdosNumber": 1053,
     "erdosProblemStatus": "open",
     "status": "axiomatized",
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/1053",
     "dateAdded": "2025-01-15",
     "axiomCount": 1,
-    "assumptions": "6 axioms: euler_even_perfect, largest_known_k, erdos_1053_conjecture, gronwall_bound, robin_inequality_conditional, guy_finiteness_conjecture. 10 proved theorems including sigma_ge_self (σ(n)≥n), kperfect_k_ge_one, perfectMultiplicity_kperfect, IsKPerfect_one_iff, sigma_one, robin_gives_O_bound.",
+    "assumptions": "1 axiom: robin_inequality_conditional. 0 sorries.",
     "badge": "axiom",
     "proofRepoPath": "Proofs/Erdos1053Problem.lean",
     "mathlib_version": "4.26.0",
@@ -57,10 +57,10 @@
     },
     {
       "id": "core-definitions",
-      "title": "Core Definitions: σ(n) and k-Perfection",
+      "title": "Core Definitions: \u03c3(n) and k-Perfection",
       "startLine": 28,
       "endLine": 48,
-      "summary": "Defines the sum-of-divisors function σ(n), k-perfect numbers (σ(n) = kn), decidability instance, and the abundancy index σ(n)/n.",
+      "summary": "Defines the sum-of-divisors function \u03c3(n), k-perfect numbers (\u03c3(n) = kn), decidability instance, and the abundancy index \u03c3(n)/n.",
       "mathContext": "$\\sigma(n) = \\sum_{d \\mid n} d$; $\\text{IsKPerfect}(n, k) \\Leftrightarrow \\sigma(n) = k \\cdot n$; abundancy index $I(n) = \\sigma(n)/n$. For prime powers: $\\sigma(p^a) = (p^{a+1}-1)/(p-1)$."
     },
     {
@@ -73,7 +73,7 @@
     },
     {
       "id": "multiperfect",
-      "title": "Multiperfect Numbers (k ≥ 3)",
+      "title": "Multiperfect Numbers (k \u2265 3)",
       "startLine": 82,
       "endLine": 96,
       "summary": "Known triperfect examples (k=3) and the existence of 11-perfect numbers, the largest known multiplicity.",
@@ -84,7 +84,7 @@
       "title": "The Main Conjecture: k = o(log log n)",
       "startLine": 97,
       "endLine": 108,
-      "summary": "States Erdős's central question: must the perfection multiplicity k grow strictly slower than log log n?",
+      "summary": "States Erd\u0151s's central question: must the perfection multiplicity k grow strictly slower than log log n?",
       "mathContext": "Conjecture: $\\sigma(n) = kn \\implies k = o(\\log\\log n)$. Equivalently, $k / \\log\\log n \\to 0$ along the sequence of $k$-perfect numbers."
     },
     {
@@ -92,7 +92,7 @@
       "title": "Gronwall's Theorem and Robin's Inequality",
       "startLine": 109,
       "endLine": 123,
-      "summary": "Gronwall's 1913 result establishing e^γ · log log n as the natural scale, and Robin's 1984 conditional upper bound from the Riemann Hypothesis.",
+      "summary": "Gronwall's 1913 result establishing e^\u03b3 \u00b7 log log n as the natural scale, and Robin's 1984 conditional upper bound from the Riemann Hypothesis.",
       "mathContext": "Gronwall: $\\limsup \\sigma(n)/(n \\log\\log n) = e^\\gamma \\approx 1.781$. Robin (conditional on RH): $\\sigma(n) < e^\\gamma \\cdot n \\cdot \\log\\log n$ for $n \\geq 5041$, giving $k < e^\\gamma \\cdot \\log\\log n$."
     },
     {
@@ -100,21 +100,21 @@
       "title": "Guy's Finiteness Conjecture and Robin's Criterion",
       "startLine": 124,
       "endLine": 152,
-      "summary": "Guy's stronger conjecture (finitely many k-perfect numbers for each k ≥ 3) and the derivation of k = O(log log n) from Robin's criterion.",
+      "summary": "Guy's stronger conjecture (finitely many k-perfect numbers for each k \u2265 3) and the derivation of k = O(log log n) from Robin's criterion.",
       "mathContext": "Guy: $\\forall k \\geq 3, |\\{n : \\sigma(n) = kn\\}| < \\infty$. Robin's criterion derivation: $\\sigma(n) = kn < e^\\gamma n \\log\\log n \\implies k < e^\\gamma \\log\\log n = O(\\log\\log n)$."
     }
   ],
   "overview": {
-    "historicalContext": "The study of perfect numbers ($\\sigma(n) = 2n$) is among the oldest in mathematics, originating with Euclid's *Elements* (Book IX, Proposition 36, c. 300 BCE). The generalization to multiperfect numbers ($\\sigma(n) = kn$ for $k \\geq 3$) was explored by medieval and Renaissance mathematicians, with Robert Recorde noting 120 as triperfect in 1557. Systematic computational searches in the 20th century found multiperfect numbers up to $k = 11$. Thomas Gronwall's 1913 theorem established that $\\limsup \\sigma(n)/(n \\log\\log n) = e^\\gamma$, setting the natural scale. Guy Robin's 1984 breakthrough showed his inequality $\\sigma(n) < e^\\gamma \\cdot n \\cdot \\log\\log n$ (for $n \\geq 5041$) is equivalent to the Riemann Hypothesis, creating a deep connection between perfect number theory and the distribution of primes. Erdős's question asks whether the integers where $\\sigma(n)/n$ is exactly an integer are forced strictly below Gronwall's extremal growth rate.",
+    "historicalContext": "The study of perfect numbers ($\\sigma(n) = 2n$) is among the oldest in mathematics, originating with Euclid's *Elements* (Book IX, Proposition 36, c. 300 BCE). The generalization to multiperfect numbers ($\\sigma(n) = kn$ for $k \\geq 3$) was explored by medieval and Renaissance mathematicians, with Robert Recorde noting 120 as triperfect in 1557. Systematic computational searches in the 20th century found multiperfect numbers up to $k = 11$. Thomas Gronwall's 1913 theorem established that $\\limsup \\sigma(n)/(n \\log\\log n) = e^\\gamma$, setting the natural scale. Guy Robin's 1984 breakthrough showed his inequality $\\sigma(n) < e^\\gamma \\cdot n \\cdot \\log\\log n$ (for $n \\geq 5041$) is equivalent to the Riemann Hypothesis, creating a deep connection between perfect number theory and the distribution of primes. Erd\u0151s's question asks whether the integers where $\\sigma(n)/n$ is exactly an integer are forced strictly below Gronwall's extremal growth rate.",
     "problemStatement": "If $n$ is $k$-perfect ($\\sigma(n) = k \\cdot n$), must $k = o(\\log\\log n)$? That is, does the multiplicative perfection ratio grow strictly slower than $\\log\\log n$ along the sequence of $k$-perfect numbers?",
-    "text": "If σ(n) = k·n (n is k-perfect), must k = o(log log n)? Known: k ≤ 11 exists. Gronwall: σ(n)/n = O(log log n). Robin's inequality gives k = O(log log n) conditionally on RH. Status: OPEN.",
-    "proofStrategy": "The formalization axiomatizes the sum-of-divisors function $\\sigma(n)$, defines $k$-perfect numbers, catalogs known examples for $k = 1$ through $k = 11$, states the Euclid–Euler characterization for even perfect numbers, presents Gronwall's extremal bound and Robin's conditional inequality, and formally states the main $o(\\log\\log n)$ conjecture alongside Guy's stronger finiteness conjecture. The final section explicitly derives $k = O(\\log\\log n)$ from Robin's inequality.",
+    "text": "If \u03c3(n) = k\u00b7n (n is k-perfect), must k = o(log log n)? Known: k \u2264 11 exists. Gronwall: \u03c3(n)/n = O(log log n). Robin's inequality gives k = O(log log n) conditionally on RH. Status: OPEN.",
+    "proofStrategy": "The formalization axiomatizes the sum-of-divisors function $\\sigma(n)$, defines $k$-perfect numbers, catalogs known examples for $k = 1$ through $k = 11$, states the Euclid\u2013Euler characterization for even perfect numbers, presents Gronwall's extremal bound and Robin's conditional inequality, and formally states the main $o(\\log\\log n)$ conjecture alongside Guy's stronger finiteness conjecture. The final section explicitly derives $k = O(\\log\\log n)$ from Robin's inequality.",
     "keyInsights": [
       "The abundancy index $\\sigma(n)/n$ is a multiplicative function: for coprime $m,n$, $\\sigma(mn)/(mn) = (\\sigma(m)/m)(\\sigma(n)/n)$, so high abundancy requires many prime factors",
-      "Gronwall's theorem sets $e^\\gamma \\cdot \\log\\log n$ as the extremal growth rate for $\\sigma(n)/n$, achieved along primorial-type numbers — Erdős asks if $k$-perfect numbers can reach this ceiling",
+      "Gronwall's theorem sets $e^\\gamma \\cdot \\log\\log n$ as the extremal growth rate for $\\sigma(n)/n$, achieved along primorial-type numbers \u2014 Erd\u0151s asks if $k$-perfect numbers can reach this ceiling",
       "Robin's inequality is equivalent to the Riemann Hypothesis, connecting k-perfect number growth to the deepest conjecture in analytic number theory",
-      "The gap between $O(\\log\\log n)$ (conditional on RH) and $o(\\log\\log n)$ (Erdős's question) is the precise frontier: can $k$-perfect numbers approach the Gronwall bound?",
-      "Guy's finiteness conjecture (each $k \\geq 3$ has finitely many $k$-perfect numbers) is strictly stronger and would resolve Erdős's question trivially",
+      "The gap between $O(\\log\\log n)$ (conditional on RH) and $o(\\log\\log n)$ (Erd\u0151s's question) is the precise frontier: can $k$-perfect numbers approach the Gronwall bound?",
+      "Guy's finiteness conjecture (each $k \\geq 3$ has finitely many $k$-perfect numbers) is strictly stronger and would resolve Erd\u0151s's question trivially",
       "No $k = 12$ perfect number is known despite exhaustive search, suggesting the frontier of computability has been reached near $k = 11$"
     ],
     "prerequisites": [
@@ -126,10 +126,10 @@
     ]
   },
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #1053 and its mathematical context: the growth rate of the perfection multiplicity $k$ for $k$-perfect numbers. The key tension is between Gronwall's theorem (showing $\\sigma(n)/n$ can reach $\\sim e^\\gamma \\cdot \\log\\log n$) and the open question of whether $k$-perfect numbers — where $\\sigma(n)/n$ is exactly an integer — can saturate this bound. Robin's inequality gives $k = O(\\log\\log n)$ conditional on RH; the $o(\\log\\log n)$ question remains open.",
-    "implications": "**Theoretical Significance**:\n\n1. **EXACT vs APPROXIMATE EXTREMALITY**: A proof of $k = o(\\log\\log n)$ would demonstrate a fundamental gap between what $\\sigma(n)/n$ can achieve approximately (Gronwall: $\\limsup = e^\\gamma \\log\\log n$) and exactly (no $k$-perfect $n$ with $k$ approaching $e^\\gamma \\log\\log n$). This would reveal that the multiplicative structure required for $n \\mid \\sigma(n)$ imposes arithmetic constraints that prevent extremality.\n\n2. **RIEMANN HYPOTHESIS CONNECTION**: Robin's inequality $\\sigma(n) < e^\\gamma n \\log\\log n$ for $n \\geq 5041$ is equivalent to RH. The conditional bound $k = O(\\log\\log n)$ thus means Erdős's question is at least as hard as proving $k$ cannot reach the $O$-constant — progress would illuminate the boundary between the $O$ and $o$ regimes that RH controls.\n\n3. **SMOOTH NUMBER ANATOMY**: Colossally abundant numbers (which extremize $\\sigma(n)/n$) have specific prime factorization patterns with many small prime factors. Understanding whether $k$-perfect numbers can mimic these patterns connects to the distribution of smooth numbers and the anatomy of highly composite numbers.\n\n4. **FINITENESS CONJECTURE**: Guy's stronger conjecture (each $k \\geq 3$ has finitely many $k$-perfect numbers) would trivially resolve Erdős's question. Progress on finiteness for any specific $k \\geq 3$ would be a major advance in multiplicative number theory.",
+    "summary": "This formalization captures Erd\u0151s Problem #1053 and its mathematical context: the growth rate of the perfection multiplicity $k$ for $k$-perfect numbers. The key tension is between Gronwall's theorem (showing $\\sigma(n)/n$ can reach $\\sim e^\\gamma \\cdot \\log\\log n$) and the open question of whether $k$-perfect numbers \u2014 where $\\sigma(n)/n$ is exactly an integer \u2014 can saturate this bound. Robin's inequality gives $k = O(\\log\\log n)$ conditional on RH; the $o(\\log\\log n)$ question remains open.",
+    "implications": "**Theoretical Significance**:\n\n1. **EXACT vs APPROXIMATE EXTREMALITY**: A proof of $k = o(\\log\\log n)$ would demonstrate a fundamental gap between what $\\sigma(n)/n$ can achieve approximately (Gronwall: $\\limsup = e^\\gamma \\log\\log n$) and exactly (no $k$-perfect $n$ with $k$ approaching $e^\\gamma \\log\\log n$). This would reveal that the multiplicative structure required for $n \\mid \\sigma(n)$ imposes arithmetic constraints that prevent extremality.\n\n2. **RIEMANN HYPOTHESIS CONNECTION**: Robin's inequality $\\sigma(n) < e^\\gamma n \\log\\log n$ for $n \\geq 5041$ is equivalent to RH. The conditional bound $k = O(\\log\\log n)$ thus means Erd\u0151s's question is at least as hard as proving $k$ cannot reach the $O$-constant \u2014 progress would illuminate the boundary between the $O$ and $o$ regimes that RH controls.\n\n3. **SMOOTH NUMBER ANATOMY**: Colossally abundant numbers (which extremize $\\sigma(n)/n$) have specific prime factorization patterns with many small prime factors. Understanding whether $k$-perfect numbers can mimic these patterns connects to the distribution of smooth numbers and the anatomy of highly composite numbers.\n\n4. **FINITENESS CONJECTURE**: Guy's stronger conjecture (each $k \\geq 3$ has finitely many $k$-perfect numbers) would trivially resolve Erd\u0151s's question. Progress on finiteness for any specific $k \\geq 3$ would be a major advance in multiplicative number theory.",
     "openQuestions": [
-      "Must $k = o(\\log\\log n)$ for $k$-perfect numbers? (Erdős Problem #1053)",
+      "Must $k = o(\\log\\log n)$ for $k$-perfect numbers? (Erd\u0151s Problem #1053)",
       "Are there only finitely many $k$-perfect numbers for each $k \\geq 3$? (Guy's conjecture, strictly stronger)",
       "Does a $k = 12$ perfect number exist, or is $k = 11$ the absolute maximum?",
       "Do odd perfect numbers ($k = 2$, $n$ odd) exist? (Open since antiquity, known: if one exists, $n > 10^{1500}$)"
@@ -139,37 +139,37 @@
     {
       "targetId": "euler-totient",
       "relationship": "related",
-      "description": "Euler's totient φ(n) and the sum-of-divisors σ(n) are both fundamental multiplicative arithmetic functions. Their interplay governs the structure of perfect numbers: for primes p, σ(p) = p+1 while φ(p) = p−1, and highly composite numbers extremize both."
+      "description": "Euler's totient \u03c6(n) and the sum-of-divisors \u03c3(n) are both fundamental multiplicative arithmetic functions. Their interplay governs the structure of perfect numbers: for primes p, \u03c3(p) = p+1 while \u03c6(p) = p\u22121, and highly composite numbers extremize both."
     },
     {
       "targetId": "fundamental-arithmetic",
       "relationship": "depends-on",
-      "description": "The multiplicativity of σ — the key property σ(mn) = σ(m)σ(n) for gcd(m,n) = 1 — follows directly from the Fundamental Theorem of Arithmetic. This multiplicativity is what allows the abundancy index σ(n)/n to be analyzed prime-factor by prime-factor."
+      "description": "The multiplicativity of \u03c3 \u2014 the key property \u03c3(mn) = \u03c3(m)\u03c3(n) for gcd(m,n) = 1 \u2014 follows directly from the Fundamental Theorem of Arithmetic. This multiplicativity is what allows the abundancy index \u03c3(n)/n to be analyzed prime-factor by prime-factor."
     },
     {
       "targetId": "infinitude-primes",
       "relationship": "related",
-      "description": "Gronwall's extremal bound σ(n)/n ~ e^γ · log log n is achieved along primorial-type numbers (products of the first k primes). The infinitude of primes ensures this sequence grows without bound, setting the asymptotic ceiling that Erdős asks whether k-perfect numbers can approach."
+      "description": "Gronwall's extremal bound \u03c3(n)/n ~ e^\u03b3 \u00b7 log log n is achieved along primorial-type numbers (products of the first k primes). The infinitude of primes ensures this sequence grows without bound, setting the asymptotic ceiling that Erd\u0151s asks whether k-perfect numbers can approach."
     },
     {
       "targetId": "erdos-1054",
       "relationship": "related",
-      "description": "Erdős Problem #1054 concerns the distribution and density of multiply-perfect numbers, directly complementing the growth-rate question here. Together they form a two-part study of the k-perfect number sequence."
+      "description": "Erd\u0151s Problem #1054 concerns the distribution and density of multiply-perfect numbers, directly complementing the growth-rate question here. Together they form a two-part study of the k-perfect number sequence."
     },
     {
       "targetId": "erdos-1003",
       "relationship": "related",
-      "description": "Erdős Problem #1003 concerns the distribution of the abundancy index σ(n)/n over integers, studying when large values occur. The k-perfect numbers — where σ(n)/n is exactly an integer — are a special discrete sub-problem within this continuous distribution question."
+      "description": "Erd\u0151s Problem #1003 concerns the distribution of the abundancy index \u03c3(n)/n over integers, studying when large values occur. The k-perfect numbers \u2014 where \u03c3(n)/n is exactly an integer \u2014 are a special discrete sub-problem within this continuous distribution question."
     },
     {
       "targetId": "erdos-1004",
       "relationship": "related",
-      "description": "Erdős Problem #1004 studies the sum ∑ σ(n)/n over structured sets, connecting the local behavior of σ(n)/n at k-perfect numbers to global averaging results. Both problems probe the same extremal arithmetic landscape."
+      "description": "Erd\u0151s Problem #1004 studies the sum \u2211 \u03c3(n)/n over structured sets, connecting the local behavior of \u03c3(n)/n at k-perfect numbers to global averaging results. Both problems probe the same extremal arithmetic landscape."
     },
     {
       "targetId": "perfect-numbers",
       "relationship": "specialization",
-      "description": "Perfect numbers ($\\sigma(n) = 2n$, i.e., $k = 2$) are the foundational case of $k$-perfect numbers. Euclid proved even perfect numbers have the form $2^{p-1}(2^p - 1)$ when $2^p - 1$ is prime (Mersenne prime). Problem #1053 asks whether the sequence of $k$-perfect numbers for all $k \\geq 2$ grows fast enough — a generalization of the ancient question about the distribution of perfect numbers themselves"
+      "description": "Perfect numbers ($\\sigma(n) = 2n$, i.e., $k = 2$) are the foundational case of $k$-perfect numbers. Euclid proved even perfect numbers have the form $2^{p-1}(2^p - 1)$ when $2^p - 1$ is prime (Mersenne prime). Problem #1053 asks whether the sequence of $k$-perfect numbers for all $k \\geq 2$ grows fast enough \u2014 a generalization of the ancient question about the distribution of perfect numbers themselves"
     },
     {
       "targetId": "erdos-1060",
@@ -187,43 +187,43 @@
       "authors": "Gronwall, T. H.",
       "title": "Some asymptotic expressions in the theory of numbers",
       "year": "1913",
-      "venue": "Transactions of the American Mathematical Society, 14(1), 113–122",
-      "note": "Proves lim sup σ(n)/(n log log n) = e^γ, establishing the natural scale for the abundancy index and the ceiling that k-perfect numbers would have to approach."
+      "venue": "Transactions of the American Mathematical Society, 14(1), 113\u2013122",
+      "note": "Proves lim sup \u03c3(n)/(n log log n) = e^\u03b3, establishing the natural scale for the abundancy index and the ceiling that k-perfect numbers would have to approach."
     },
     {
       "authors": "Robin, G.",
-      "title": "Grandes valeurs de la fonction somme des diviseurs et hypothèse de Riemann",
+      "title": "Grandes valeurs de la fonction somme des diviseurs et hypoth\u00e8se de Riemann",
       "year": "1984",
-      "venue": "Journal de Mathématiques Pures et Appliquées, 63(2), 187–213",
-      "note": "Shows that σ(n) < e^γ · n · log log n for all n ≥ 5041 is equivalent to the Riemann Hypothesis, giving the conditional k = O(log log n) bound for k-perfect numbers."
+      "venue": "Journal de Math\u00e9matiques Pures et Appliqu\u00e9es, 63(2), 187\u2013213",
+      "note": "Shows that \u03c3(n) < e^\u03b3 \u00b7 n \u00b7 log log n for all n \u2265 5041 is equivalent to the Riemann Hypothesis, giving the conditional k = O(log log n) bound for k-perfect numbers."
     },
     {
-      "authors": "Alaoglu, L. and Erdős, P.",
+      "authors": "Alaoglu, L. and Erd\u0151s, P.",
       "title": "On highly composite and similar numbers",
       "year": "1944",
-      "venue": "Transactions of the American Mathematical Society, 56(3), 448–469",
-      "note": "Introduces colossally abundant numbers, characterizes the extremal behavior of σ(n)/n, and lays groundwork for understanding which integers can achieve large abundancy indices."
+      "venue": "Transactions of the American Mathematical Society, 56(3), 448\u2013469",
+      "note": "Introduces colossally abundant numbers, characterizes the extremal behavior of \u03c3(n)/n, and lays groundwork for understanding which integers can achieve large abundancy indices."
     },
     {
       "authors": "Guy, R. K.",
       "title": "Unsolved Problems in Number Theory, 3rd edition, Problem B2",
       "year": "2004",
       "venue": "Springer, New York",
-      "note": "Surveys the state of k-perfect numbers including the stronger conjecture that each k ≥ 3 has only finitely many k-perfect numbers, and catalogs known examples up to k = 11."
+      "note": "Surveys the state of k-perfect numbers including the stronger conjecture that each k \u2265 3 has only finitely many k-perfect numbers, and catalogs known examples up to k = 11."
     },
     {
       "authors": "Kanold, H.-J.",
-      "title": "Über mehrfach vollkommene Zahlen",
+      "title": "\u00dcber mehrfach vollkommene Zahlen",
       "year": "1956",
-      "venue": "Journal für die reine und angewandte Mathematik, 197, 82–96",
+      "venue": "Journal f\u00fcr die reine und angewandte Mathematik, 197, 82\u201396",
       "note": "Derives structural necessary conditions for multiply perfect numbers using prime factorization constraints, providing the best unconditional bounds on k available without RH."
     },
     {
       "authors": "Ramanujan, S.",
       "title": "Highly composite numbers",
       "year": "1915",
-      "venue": "Proceedings of the London Mathematical Society, 2(14), 347–409",
-      "note": "Extensive study of the extremal behavior of σ(n)/n, introducing highly composite numbers and establishing foundational results on the distribution of divisor sums."
+      "venue": "Proceedings of the London Mathematical Society, 2(14), 347\u2013409",
+      "note": "Extensive study of the extremal behavior of \u03c3(n)/n, introducing highly composite numbers and establishing foundational results on the distribution of divisor sums."
     }
   ],
   "leanFile": {
@@ -242,17 +242,17 @@
       {
         "name": "one_perfect_unique",
         "type": "proved",
-        "description": "The only 1-perfect number is 1 (σ(n) = n implies n = 1)"
+        "description": "The only 1-perfect number is 1 (\u03c3(n) = n implies n = 1)"
       },
       {
         "name": "robin_gives_O_bound",
         "type": "proved",
-        "description": "Robin's inequality (conditional on RH) implies k = O(log log n) for k-perfect n ≥ 5041"
+        "description": "Robin's inequality (conditional on RH) implies k = O(log log n) for k-perfect n \u2265 5041"
       },
       {
         "name": "sigma_def",
         "type": "proved",
-        "description": "σ(n) = ∑ d, d | n — the divisor sum function as a Finset.sum"
+        "description": "\u03c3(n) = \u2211 d, d | n \u2014 the divisor sum function as a Finset.sum"
       }
     ],
     "path": "Proofs/Erdos1053Problem.lean",

--- a/src/data/proofs/erdos-966/meta.json
+++ b/src/data/proofs/erdos-966/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-966",
-  "title": "Erdős Problem #966: Ramsey-Type Arithmetic Progressions",
+  "title": "Erd\u0151s Problem #966: Ramsey-Type Arithmetic Progressions",
   "slug": "erdos-966",
-  "description": "For k, r ≥ 2, does there exist a set A ⊆ ℕ with no (k+1)-term arithmetic progression, yet every r-coloring has a monochromatic k-term AP? YES, proved by Spencer (~1975).",
+  "description": "For k, r \u2265 2, does there exist a set A \u2286 \u2115 with no (k+1)-term arithmetic progression, yet every r-coloring has a monochromatic k-term AP? YES, proved by Spencer (~1975).",
   "meta": {
     "author": "Spencer (~1975)",
     "sourceUrl": "https://erdosproblems.com/966",
@@ -58,17 +58,17 @@
     ],
     "axiomCount": 6,
     "lineCount": 294,
-    "assumptions": "10 axioms: SpencerSet, spencer_AP_free, spencer_forces_mono_AP, and 7 more. See Lean source for complete statements."
+    "assumptions": "6 axioms: SpencerSet, spencer_AP_free, spencer_forces_mono_AP, spencer_theorem, upperDensity, spencer_zero_density. 0 sorries."
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #966**\n\nThis problem combines arithmetic progressions with Ramsey-type coloring questions, bridging additive combinatorics and Ramsey theory.\n\n**Key History:**\n- Van der Waerden (1927): Proved any r-coloring of ℕ contains arbitrarily long monochromatic APs\n- Erdős [Er75b] (1975): Posed this refined question about (k+1)-AP-free sets\n- Spencer (~1975): Proved the affirmative answer, as reported by Erdős\n\n**Mathematical Setting:**\nThe problem asks whether we can find sets that are \"barely\" AP-free: they avoid (k+1)-term progressions but still force k-term monochromatic progressions in any coloring. This is a delicate balance between structure and randomness.",
-    "problemStatement": "**Problem Statement (Proved)**\n\nLet $k, r \\geq 2$. Does there exist a set $A \\subseteq \\mathbb{N}$ such that:\n1. $A$ contains no non-trivial arithmetic progression of length $k+1$\n2. In any $r$-coloring of $A$, there exists a monochromatic arithmetic progression of length $k$\n\n**Answer: YES**\n\nSpencer showed (~1975) that such sets exist for all $k, r \\geq 2$. This is an arithmetic analogue of Folkman's theorem (Erdős Problem #924) about cliques in graphs.",
-    "text": "For k, r ≥ 2, does there exist a set A ⊆ ℕ with no (k+1)-term arithmetic progression, yet every r-coloring has a monochromatic k-term AP? YES, proved by Spencer (~1975).",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Arithmetic Progressions:** Define the set {a, a+d, ..., a+(k-1)d} as a Finset\n\n2. **AP-Free Sets:** A set is k-AP-free if it contains no arithmetic progression of length k with positive common difference\n\n3. **Colorings:** An r-coloring partitions elements into r color classes\n\n4. **Ramsey Property:** A set forces monochromatic k-APs if every r-coloring has some color class containing a k-AP\n\n5. **Main Axiom:** Spencer's theorem asserts existence of sets with both properties\n\n6. **Connections:** Van der Waerden's theorem, Roth's theorem, and Erdős #924",
+    "historicalContext": "**Erd\u0151s Problem #966**\n\nThis problem combines arithmetic progressions with Ramsey-type coloring questions, bridging additive combinatorics and Ramsey theory.\n\n**Key History:**\n- Van der Waerden (1927): Proved any r-coloring of \u2115 contains arbitrarily long monochromatic APs\n- Erd\u0151s [Er75b] (1975): Posed this refined question about (k+1)-AP-free sets\n- Spencer (~1975): Proved the affirmative answer, as reported by Erd\u0151s\n\n**Mathematical Setting:**\nThe problem asks whether we can find sets that are \"barely\" AP-free: they avoid (k+1)-term progressions but still force k-term monochromatic progressions in any coloring. This is a delicate balance between structure and randomness.",
+    "problemStatement": "**Problem Statement (Proved)**\n\nLet $k, r \\geq 2$. Does there exist a set $A \\subseteq \\mathbb{N}$ such that:\n1. $A$ contains no non-trivial arithmetic progression of length $k+1$\n2. In any $r$-coloring of $A$, there exists a monochromatic arithmetic progression of length $k$\n\n**Answer: YES**\n\nSpencer showed (~1975) that such sets exist for all $k, r \\geq 2$. This is an arithmetic analogue of Folkman's theorem (Erd\u0151s Problem #924) about cliques in graphs.",
+    "text": "For k, r \u2265 2, does there exist a set A \u2286 \u2115 with no (k+1)-term arithmetic progression, yet every r-coloring has a monochromatic k-term AP? YES, proved by Spencer (~1975).",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Arithmetic Progressions:** Define the set {a, a+d, ..., a+(k-1)d} as a Finset\n\n2. **AP-Free Sets:** A set is k-AP-free if it contains no arithmetic progression of length k with positive common difference\n\n3. **Colorings:** An r-coloring partitions elements into r color classes\n\n4. **Ramsey Property:** A set forces monochromatic k-APs if every r-coloring has some color class containing a k-AP\n\n5. **Main Axiom:** Spencer's theorem asserts existence of sets with both properties\n\n6. **Connections:** Van der Waerden's theorem, Roth's theorem, and Erd\u0151s #924",
     "keyInsights": [
       "**Ramsey Theory:** The problem blends Ramsey-type coloring results with AP-avoidance constraints",
-      "**Van der Waerden Connection:** While VdW says all of ℕ has monochromatic APs, this asks about restricted subsets",
-      "**Folkman Analogue:** Erdős #924 asks the same question for cliques in graphs instead of APs in sets",
+      "**Van der Waerden Connection:** While VdW says all of \u2115 has monochromatic APs, this asks about restricted subsets",
+      "**Folkman Analogue:** Erd\u0151s #924 asks the same question for cliques in graphs instead of APs in sets",
       "**Density Consideration:** Spencer's sets must have zero upper density (by Roth's theorem)",
       "**Constructive Challenge:** While existence is proved, explicit constructions remain computationally difficult"
     ],
@@ -106,7 +106,7 @@
     {
       "id": "main-theorem",
       "title": "Main Theorem",
-      "summary": "erdos_966: the answer is YES for all k, r ≥ 2",
+      "summary": "erdos_966: the answer is YES for all k, r \u2265 2",
       "startLine": 129,
       "endLine": 155,
       "mathContext": "erdos_966: the answer is YES for all k, r $\\geq$ 2"
@@ -121,7 +121,7 @@
     },
     {
       "id": "erdos-924",
-      "title": "Connection to Erdős #924",
+      "title": "Connection to Erd\u0151s #924",
       "summary": "Graph-theoretic analogue via Folkman's theorem",
       "startLine": 191,
       "endLine": 209,
@@ -161,12 +161,12 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #966 asked whether sets can avoid (k+1)-term arithmetic progressions while still forcing monochromatic k-term progressions in any r-coloring. Spencer proved YES (~1975). This elegant result lies at the intersection of Ramsey theory and additive combinatorics, demonstrating that AP-avoidance and Ramsey-type forcing can coexist.",
-    "implications": "**Theoretical Significance**: **Combinatorial Connections**\n\n1. **Ramsey Theory:** Demonstrates the robustness of Ramsey phenomena even in structured subsets\n\n2. **Additive Combinatorics:** Links AP-free sets to coloring problems\n\n**3. Van der Waerden Extension:** Shows VdW-type results hold for restricted domains\n\n4. **Folkman Analogy:** Erdős #924 (graph version) has the same affirmative answer\n\n5. **Density Bounds:** Spencer's sets must have zero density, connecting to Roth/Szemerédi.",
+    "summary": "Erd\u0151s Problem #966 asked whether sets can avoid (k+1)-term arithmetic progressions while still forcing monochromatic k-term progressions in any r-coloring. Spencer proved YES (~1975). This elegant result lies at the intersection of Ramsey theory and additive combinatorics, demonstrating that AP-avoidance and Ramsey-type forcing can coexist.",
+    "implications": "**Theoretical Significance**: **Combinatorial Connections**\n\n1. **Ramsey Theory:** Demonstrates the robustness of Ramsey phenomena even in structured subsets\n\n2. **Additive Combinatorics:** Links AP-free sets to coloring problems\n\n**3. Van der Waerden Extension:** Shows VdW-type results hold for restricted domains\n\n4. **Folkman Analogy:** Erd\u0151s #924 (graph version) has the same affirmative answer\n\n5. **Density Bounds:** Spencer's sets must have zero density, connecting to Roth/Szemer\u00e9di.",
     "openQuestions": [
       "Explicit constructions of Spencer's sets for small k, r",
       "Optimal size bounds for finite versions of the problem",
-      "Connections to Szemerédi's theorem for longer APs",
+      "Connections to Szemer\u00e9di's theorem for longer APs",
       "Computational complexity of finding such sets",
       "Generalizations to other patterns beyond APs"
     ]
@@ -194,17 +194,17 @@
     {
       "targetId": "erdos-645",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: arithmetic-progressions, combinatorics, ramsey-theory, solved, van-der-waerden"
+      "description": "Related Erd\u0151s problem sharing themes: arithmetic-progressions, combinatorics, ramsey-theory, solved, van-der-waerden"
     },
     {
       "targetId": "erdos-138",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: arithmetic-progressions, combinatorics, ramsey-theory, van-der-waerden"
+      "description": "Related Erd\u0151s problem sharing themes: arithmetic-progressions, combinatorics, ramsey-theory, van-der-waerden"
     },
     {
       "targetId": "erdos-176",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: arithmetic-progressions, combinatorics, ramsey-theory, van-der-waerden"
+      "description": "Related Erd\u0151s problem sharing themes: arithmetic-progressions, combinatorics, ramsey-theory, van-der-waerden"
     }
   ]
 }

--- a/src/data/proofs/erdos-970/meta.json
+++ b/src/data/proofs/erdos-970/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-970",
-  "title": "Erdős Problem #970: Jacobsthal's Function",
+  "title": "Erd\u0151s Problem #970: Jacobsthal's Function",
   "slug": "erdos-970",
-  "description": "Is h(k) = O(k²) where h(k) is the minimal m such that any m consecutive integers contain one coprime to any n with at most k prime factors? OPEN: Best upper bound is (k log k)² by Iwaniec (1978).",
+  "description": "Is h(k) = O(k\u00b2) where h(k) is the minimal m such that any m consecutive integers contain one coprime to any n with at most k prime factors? OPEN: Best upper bound is (k log k)\u00b2 by Iwaniec (1978).",
   "meta": {
-    "author": "Paul Erdős",
+    "author": "Paul Erd\u0151s",
     "sourceUrl": "https://erdosproblems.com/970",
     "date": "2018",
     "status": "axiomatized",
@@ -48,26 +48,26 @@
       "consecutiveInterval definition: interval [a, a+m)",
       "hasCoprimeElement predicate: interval contains coprime element",
       "h axiom: Jacobsthal's function with specification and minimality",
-      "jacobsthalConjecture definition: h(k) = O(k²)",
-      "iwaniec_upper_bound axiom: h(k) ≤ C(k log k)²",
+      "jacobsthalConjecture definition: h(k) = O(k\u00b2)",
+      "iwaniec_upper_bound axiom: h(k) \u2264 C(k log k)\u00b2",
       "fgkmt_lower_bound axiom: best known lower bound",
       "Small values h(1)=2 through h(5)=14",
       "small_values_consistent theorem combining known values"
     ],
     "axiomCount": 8,
-    "assumptions": "12 axiom declarations: h (Jacobsthal function definition), h_spec (h(k) specification property), h_minimal (h(k) minimality), iwaniec_upper_bound (h(k) <= C(k log k)^2), rankin_lower_bound (Rankin-type lower bound), fgkmt_lower_bound (FGKMT best lower bound), h_one (h(1)=2), h_two (h(2)=4), h_three (h(3)=6), h_four (h(4)=10), h_five (h(5)=14), jacobsthal_extremal_at_primorial (primorial extremal)",
+    "assumptions": "8 axioms: h, iwaniec_upper_bound, fgkmt_lower_bound, h_one, h_two, h_three, h_four, h_five. 0 sorries.",
     "lineCount": 157
   },
   "overview": {
-    "historicalContext": "Jacobsthal's function h(k) measures how long an interval of consecutive integers must be to guarantee an element coprime to any number with at most k prime factors. The function was introduced by Jacobsthal, who conjectured h(k) = O(k²). This remains one of the major open problems in multiplicative number theory.\n\nIwaniec (1978) proved the best known upper bound h(k) ≤ C(k log k)² using sieve methods. The lower bound was dramatically improved by Ford, Green, Konyagin, Maynard, and Tao (2018), who used their breakthrough results on prime gaps to show h(k) ≥ ck(log k)(log log log k)/(log log k)².\n\nThe gap between upper and lower bounds remains substantial, and closing it (or even reaching the conjectured k² bound) would be a major advance.",
+    "historicalContext": "Jacobsthal's function h(k) measures how long an interval of consecutive integers must be to guarantee an element coprime to any number with at most k prime factors. The function was introduced by Jacobsthal, who conjectured h(k) = O(k\u00b2). This remains one of the major open problems in multiplicative number theory.\n\nIwaniec (1978) proved the best known upper bound h(k) \u2264 C(k log k)\u00b2 using sieve methods. The lower bound was dramatically improved by Ford, Green, Konyagin, Maynard, and Tao (2018), who used their breakthrough results on prime gaps to show h(k) \u2265 ck(log k)(log log log k)/(log log k)\u00b2.\n\nThe gap between upper and lower bounds remains substantial, and closing it (or even reaching the conjectured k\u00b2 bound) would be a major advance.",
     "problemStatement": "Let $h(k)$ be Jacobsthal's function, defined as the minimal $m$ such that, if $n$ has at most $k$ prime factors, then in any set of $m$ consecutive integers there exists an integer coprime to $n$. Determine the order of magnitude of $h(k)$. In particular, is it true that $h(k) \\ll k^2$?\n\n**Answer: OPEN**",
-    "text": "Is h(k) = O(k²) where h(k) is the minimal m such that any m consecutive integers contain one coprime to any n with at most k prime factors? OPEN: Best upper bound is (k log k)² by Iwaniec (1978).",
-    "proofStrategy": "The formalization axiomatizes Jacobsthal's function h(k) with its defining property and minimality condition. Known upper and lower bounds are stated as axioms (Iwaniec 1978, FGKMT 2018). Small computed values h(1)=2 through h(5)=14 are recorded. The conjecture h(k) = O(k²) is formally defined but remains open.",
+    "text": "Is h(k) = O(k\u00b2) where h(k) is the minimal m such that any m consecutive integers contain one coprime to any n with at most k prime factors? OPEN: Best upper bound is (k log k)\u00b2 by Iwaniec (1978).",
+    "proofStrategy": "The formalization axiomatizes Jacobsthal's function h(k) with its defining property and minimality condition. Known upper and lower bounds are stated as axioms (Iwaniec 1978, FGKMT 2018). Small computed values h(1)=2 through h(5)=14 are recorded. The conjecture h(k) = O(k\u00b2) is formally defined but remains open.",
     "keyInsights": [
       "**Jacobsthal's function** measures coprimality in intervals: h(k) is the minimal m ensuring a coprime element exists",
-      "**Best upper bound:** h(k) ≤ C(k log k)² by Iwaniec (1978) using sieve methods",
-      "**Best lower bound:** h(k) ≥ ck log k log₃k/(log₂k)² by Ford-Green-Konyagin-Maynard-Tao (2018)",
-      "**Gap from k²** is roughly (log k)² — closing this is the main challenge",
+      "**Best upper bound:** h(k) \u2264 C(k log k)\u00b2 by Iwaniec (1978) using sieve methods",
+      "**Best lower bound:** h(k) \u2265 ck log k log\u2083k/(log\u2082k)\u00b2 by Ford-Green-Konyagin-Maynard-Tao (2018)",
+      "**Gap from k\u00b2** is roughly (log k)\u00b2 \u2014 closing this is the main challenge",
       "**Primorials maximize h(k):** the extremal numbers are products of the first k primes"
     ],
     "prerequisites": [
@@ -105,14 +105,14 @@
       "title": "Jacobsthal's Conjecture",
       "startLine": 77,
       "endLine": 82,
-      "summary": "jacobsthalConjecture: h(k) = O(k²)"
+      "summary": "jacobsthalConjecture: h(k) = O(k\u00b2)"
     },
     {
       "id": "upper-bounds",
       "title": "Known Upper Bounds",
       "startLine": 83,
       "endLine": 101,
-      "summary": "Iwaniec's theorem: h(k) ≤ C(k log k)²"
+      "summary": "Iwaniec's theorem: h(k) \u2264 C(k log k)\u00b2"
     },
     {
       "id": "lower-bounds",
@@ -137,10 +137,10 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #970 remains OPEN. Jacobsthal's Conjecture asks whether h(k) = O(k²). The best known upper bound is h(k) ≤ C(k log k)² by Iwaniec (1978), which has a (log k)² gap from the conjectured quadratic bound. The best known lower bound is h(k) ≥ ck log k log₃k/(log₂k)² by Ford-Green-Konyagin-Maynard-Tao (2018).",
+    "summary": "Erd\u0151s Problem #970 remains OPEN. Jacobsthal's Conjecture asks whether h(k) = O(k\u00b2). The best known upper bound is h(k) \u2264 C(k log k)\u00b2 by Iwaniec (1978), which has a (log k)\u00b2 gap from the conjectured quadratic bound. The best known lower bound is h(k) \u2265 ck log k log\u2083k/(log\u2082k)\u00b2 by Ford-Green-Konyagin-Maynard-Tao (2018).",
     "implications": "Resolving Jacobsthal's Conjecture would have implications for understanding coprimality in intervals, which connects to prime distribution. The techniques involved (sieve methods, prime gaps) are fundamental in analytic number theory.",
     "openQuestions": [
-      "Is h(k) = O(k²)? (The main conjecture)",
+      "Is h(k) = O(k\u00b2)? (The main conjecture)",
       "Can Iwaniec's bound be improved to remove log factors?",
       "What is the exact asymptotic of h(k)?",
       "What is h(k) for specific small values beyond k=5?"
@@ -170,17 +170,17 @@
     {
       "targetId": "erdos-1059",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: number-theory, primes"
+      "description": "Related Erd\u0151s problem sharing themes: number-theory, primes"
     },
     {
       "targetId": "erdos-1100",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: coprimality, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: coprimality, number-theory"
     },
     {
       "targetId": "erdos-1101",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: gaps, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: gaps, number-theory"
     }
   ]
 }

--- a/src/data/proofs/erdos-973/meta.json
+++ b/src/data/proofs/erdos-973/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-973",
-  "title": "Erdős Problem #973: Power Sums of Complex Numbers (Turán's Problem)",
+  "title": "Erd\u0151s Problem #973: Power Sums of Complex Numbers (Tur\u00e1n's Problem)",
   "slug": "erdos-973",
-  "description": "Does there exist C > 1 such that max|∑z_i^k| < C^{-n} for sequences with z₁ = 1 and |z_i| ≥ 1? OPEN for the original question; partial results known for unit disk (C ≈ 1.32) and unit circle (C ≈ 1.7455).",
+  "description": "Does there exist C > 1 such that max|\u2211z_i^k| < C^{-n} for sequences with z\u2081 = 1 and |z_i| \u2265 1? OPEN for the original question; partial results known for unit disk (C \u2248 1.32) and unit circle (C \u2248 1.7455).",
   "meta": {
-    "author": "Erdős, L. Erdős (1992), Turán",
+    "author": "Erd\u0151s, L. Erd\u0151s (1992), Tur\u00e1n",
     "sourceUrl": "https://erdosproblems.com/973",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos973Problem.lean",
@@ -41,18 +41,18 @@
       },
       {
         "theorem": "Real.exp",
-        "description": "Exponential function for Turán constant 2e",
+        "description": "Exponential function for Tur\u00e1n constant 2e",
         "module": "Mathlib.Analysis.SpecialFunctions.ExpDeriv"
       }
     ],
     "originalContributions": [
       "ComplexSeq, powerSum, HasFirstOne: sequence and power sum definitions",
       "AllModulusGeOne, AllOnUnitCircle, AllModulusLeOne: modulus constraints",
-      "maxPowerSum (axiom): max_{2≤k≤n+1} |∑ z_i^k| with specification axiom",
-      "ErdosQuestion973: formal problem statement for |z_i| ≥ 1 case",
-      "erdos_unit_disk_construction (axiom): C ≈ 1.32 for unit disk",
+      "maxPowerSum (axiom): max_{2\u2264k\u2264n+1} |\u2211 z_i^k| with specification axiom",
+      "ErdosQuestion973: formal problem statement for |z_i| \u2265 1 case",
+      "erdos_unit_disk_construction (axiom): C \u2248 1.32 for unit disk",
       "M2, l_erdos_1992_bounds (axiom): optimal constant for unit circle",
-      "turan_lower_bound (axiom): (2e)^{-(1+o(1))n} bound for |z_i| ≥ 1",
+      "turan_lower_bound (axiom): (2e)^{-(1+o(1))n} bound for |z_i| \u2265 1",
       "rootsOfUnitySequence, roots_on_circle (proved): extremal candidates",
       "dirichlet_power_sum_connection (axiom): link to L-functions",
       "erdos_973_unit_disk, erdos_973_turan_constrained (proved): derived results",
@@ -60,18 +60,18 @@
     ],
     "axiomCount": 4,
     "lineCount": 188,
-    "assumptions": "8 axioms: maxPowerSum, maxPowerSum_spec, erdos_unit_disk_construction, and 5 more. See Lean source for complete statements."
+    "assumptions": "4 axioms: maxPowerSum, erdos_unit_disk_construction, l_erdos_1992_bounds, turan_lower_bound. 0 sorries."
   },
   "overview": {
-    "historicalContext": "Erdős Problem #973 is part of Turán's power sum method, one of the most important tools in analytic number theory. The question asks whether, for sequences z_i with z₁ = 1 and |z_i| ≥ 1, the maximum of |∑ z_i^k| over 2 ≤ k ≤ n+1 can decay exponentially as C^{-n} for some universal C > 1. Hayman listed this as Problem 7.3 in his 1974 collection, attributing it to Erdős.\n\nThe answer depends critically on the modulus constraint. Erdős himself showed that for |z_i| ≤ 1 (the unit disk), such sequences exist with C ≈ 1.32. L. Erdős (1992) refined the picture for unit circle sequences (|z_i| = 1), proving tight bounds (1.746)^{-n} < M₂ < (1.745)^{-n} where M₂ is the optimal maximum power sum. For the original question with |z_i| ≥ 1, Turán's Theorem 6.1 gives a lower bound of (2e)^{-(1+o(1))n}, but the precise answer remains open.\n\nTurán's power sum method connects to Dirichlet polynomials, L-function zero-free regions, and equidistribution theory. The problem illustrates how the geometry of the constraint set (disk, circle, or exterior) fundamentally changes the extremal behavior of power sums.",
-    "problemStatement": "Does there exist a constant C > 1 such that for every n ≥ 2, one can find a sequence z₁, ..., z_n ∈ ℂ with z₁ = 1 and |z_i| ≥ 1 satisfying max_{2 ≤ k ≤ n+1} |∑_{i=1}^n z_i^k| < C^{-n}?\n\n**Status: OPEN** (for |z_i| ≥ 1)\n\nKnown partial results:\n- Unit disk (|z_i| ≤ 1): YES, C ≈ 1.32 (Erdős)\n- Unit circle (|z_i| = 1): optimal C ≈ 1.7455 (L. Erdős 1992)\n- Outside disk (|z_i| ≥ 1): Turán's bound (2e)^{-(1+o(1))n} constrains from below",
-    "text": "Does there exist C > 1 such that max|∑z_i^k| < C^{-n} for sequences with z₁ = 1 and |z_i| ≥ 1? OPEN for the original question; partial results known for unit disk (C ≈ 1.32) and unit circle (C ≈ 1.7455).",
-    "proofStrategy": "The formalization defines ComplexSeq as Fin n → ℂ, with powerSum computing ∑ z_i^k. The maxPowerSum function is axiomatized (since the supremum over a parametric range requires careful handling). Three key results are axiomatized: Erdős's unit disk construction (C ≈ 1.32), L. Erdős's unit circle bounds, and Turán's lower bound for |z_i| ≥ 1. The main theorem erdos_973 proves the AnswerSummary by composing these three axioms. Additional content includes roots of unity as extremal candidates (with a proved unit circle property) and the connection to Dirichlet polynomials.",
+    "historicalContext": "Erd\u0151s Problem #973 is part of Tur\u00e1n's power sum method, one of the most important tools in analytic number theory. The question asks whether, for sequences z_i with z\u2081 = 1 and |z_i| \u2265 1, the maximum of |\u2211 z_i^k| over 2 \u2264 k \u2264 n+1 can decay exponentially as C^{-n} for some universal C > 1. Hayman listed this as Problem 7.3 in his 1974 collection, attributing it to Erd\u0151s.\n\nThe answer depends critically on the modulus constraint. Erd\u0151s himself showed that for |z_i| \u2264 1 (the unit disk), such sequences exist with C \u2248 1.32. L. Erd\u0151s (1992) refined the picture for unit circle sequences (|z_i| = 1), proving tight bounds (1.746)^{-n} < M\u2082 < (1.745)^{-n} where M\u2082 is the optimal maximum power sum. For the original question with |z_i| \u2265 1, Tur\u00e1n's Theorem 6.1 gives a lower bound of (2e)^{-(1+o(1))n}, but the precise answer remains open.\n\nTur\u00e1n's power sum method connects to Dirichlet polynomials, L-function zero-free regions, and equidistribution theory. The problem illustrates how the geometry of the constraint set (disk, circle, or exterior) fundamentally changes the extremal behavior of power sums.",
+    "problemStatement": "Does there exist a constant C > 1 such that for every n \u2265 2, one can find a sequence z\u2081, ..., z_n \u2208 \u2102 with z\u2081 = 1 and |z_i| \u2265 1 satisfying max_{2 \u2264 k \u2264 n+1} |\u2211_{i=1}^n z_i^k| < C^{-n}?\n\n**Status: OPEN** (for |z_i| \u2265 1)\n\nKnown partial results:\n- Unit disk (|z_i| \u2264 1): YES, C \u2248 1.32 (Erd\u0151s)\n- Unit circle (|z_i| = 1): optimal C \u2248 1.7455 (L. Erd\u0151s 1992)\n- Outside disk (|z_i| \u2265 1): Tur\u00e1n's bound (2e)^{-(1+o(1))n} constrains from below",
+    "text": "Does there exist C > 1 such that max|\u2211z_i^k| < C^{-n} for sequences with z\u2081 = 1 and |z_i| \u2265 1? OPEN for the original question; partial results known for unit disk (C \u2248 1.32) and unit circle (C \u2248 1.7455).",
+    "proofStrategy": "The formalization defines ComplexSeq as Fin n \u2192 \u2102, with powerSum computing \u2211 z_i^k. The maxPowerSum function is axiomatized (since the supremum over a parametric range requires careful handling). Three key results are axiomatized: Erd\u0151s's unit disk construction (C \u2248 1.32), L. Erd\u0151s's unit circle bounds, and Tur\u00e1n's lower bound for |z_i| \u2265 1. The main theorem erdos_973 proves the AnswerSummary by composing these three axioms. Additional content includes roots of unity as extremal candidates (with a proved unit circle property) and the connection to Dirichlet polynomials.",
     "keyInsights": [
-      "**Three regimes:** The answer depends on the modulus constraint — unit disk, unit circle, and exterior give fundamentally different behavior",
-      "**Erdős's constant:** C ≈ 1.32 for unit disk sequences, proved constructively",
-      "**L. Erdős 1992:** Tight bounds (1.746)^{-n} < M₂ < (1.745)^{-n} for unit circle",
-      "**Turán's bound:** (2e)^{-(1+o(1))n} ≈ (5.44)^{-(1+o(1))n} for |z_i| ≥ 1",
+      "**Three regimes:** The answer depends on the modulus constraint \u2014 unit disk, unit circle, and exterior give fundamentally different behavior",
+      "**Erd\u0151s's constant:** C \u2248 1.32 for unit disk sequences, proved constructively",
+      "**L. Erd\u0151s 1992:** Tight bounds (1.746)^{-n} < M\u2082 < (1.745)^{-n} for unit circle",
+      "**Tur\u00e1n's bound:** (2e)^{-(1+o(1))n} \u2248 (5.44)^{-(1+o(1))n} for |z_i| \u2265 1",
       "**Dirichlet connection:** Power sums of n^{it} yield Dirichlet sums, linking to L-function theory"
     ],
     "prerequisites": [
@@ -90,34 +90,34 @@
     },
     {
       "id": "erdos-question",
-      "title": "Part II: The Erdős Question",
+      "title": "Part II: The Erd\u0151s Question",
       "startLine": 70,
       "endLine": 80,
-      "summary": "Formal statement ErdosQuestion973: ∃ C > 1 with max power sum < C^{-n} for |z_i| ≥ 1.",
-      "mathContext": "Formal statement ErdosQuestion973: ∃ C > 1 with max power sum < C^{-n} for |z_i| $\\geq$ 1."
+      "summary": "Formal statement ErdosQuestion973: \u2203 C > 1 with max power sum < C^{-n} for |z_i| \u2265 1.",
+      "mathContext": "Formal statement ErdosQuestion973: \u2203 C > 1 with max power sum < C^{-n} for |z_i| $\\geq$ 1."
     },
     {
       "id": "unit-disk",
-      "title": "Part III: Erdős's Construction (Unit Disk Case)",
+      "title": "Part III: Erd\u0151s's Construction (Unit Disk Case)",
       "startLine": 81,
       "endLine": 93,
-      "summary": "Axiom erdos_unit_disk_construction: C ≈ 1.32 works for |z_i| ≤ 1.",
-      "mathContext": "Axiom erdos_unit_disk_construction: C ≈ 1.32 works for |z_i| $\\leq$ 1."
+      "summary": "Axiom erdos_unit_disk_construction: C \u2248 1.32 works for |z_i| \u2264 1.",
+      "mathContext": "Axiom erdos_unit_disk_construction: C \u2248 1.32 works for |z_i| $\\leq$ 1."
     },
     {
       "id": "unit-circle",
-      "title": "Part IV: L. Erdős's Refinement (1992)",
+      "title": "Part IV: L. Erd\u0151s's Refinement (1992)",
       "startLine": 94,
       "endLine": 108,
-      "summary": "Defines M2 (infimum over unit circle sequences). Axiom l_erdos_1992_bounds: (1.746)^{-n} < M₂ < (1.745)^{-n}.",
-      "mathContext": "Formal definition: Defines M2 (infimum over unit circle sequences). Axiom l_erdos_1992_bounds: (1.746)^{-n} < M₂ < (1.745)^{-n}."
+      "summary": "Defines M2 (infimum over unit circle sequences). Axiom l_erdos_1992_bounds: (1.746)^{-n} < M\u2082 < (1.745)^{-n}.",
+      "mathContext": "Formal definition: Defines M2 (infimum over unit circle sequences). Axiom l_erdos_1992_bounds: (1.746)^{-n} < M\u2082 < (1.745)^{-n}."
     },
     {
       "id": "turan-bound",
-      "title": "Part V: Turán's Lower Bound",
+      "title": "Part V: Tur\u00e1n's Lower Bound",
       "startLine": 109,
       "endLine": 123,
-      "summary": "Axiom turan_lower_bound: for |z_i| ≥ 1, max power sum ≥ (2e)^{-(1+o(1))n}. Defines turanConstant = 2e.",
+      "summary": "Axiom turan_lower_bound: for |z_i| \u2265 1, max power sum \u2265 (2e)^{-(1+o(1))n}. Defines turanConstant = 2e.",
       "mathContext": "Axiom turan_lower_bound: for |z_i| $\\geq$ 1, max power sum $\\geq$ (2e)^{-(1+o(1))n}. Defines turanConstant = 2e."
     },
     {
@@ -154,13 +154,13 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #973 asks about minimizing power sums max|∑z_i^k| for sequences with z₁ = 1 and modulus constraints. The original question (|z_i| ≥ 1) remains open, but three partial results are formalized: Erdős's C ≈ 1.32 for the unit disk, L. Erdős's optimal C ≈ 1.7455 for the unit circle, and Turán's (2e)^{-n} lower bound for the exterior.",
-    "implications": "**Theoretical Significance**: Turán's power sum method is fundamental in analytic number theory.\n\nPower sum bounds directly relate to Dirichlet polynomial estimates, L-function zero-free regions, and equidistribution theory. The three-regime structure illustrates how geometry constrains extremal behavior.",
+    "summary": "Erd\u0151s Problem #973 asks about minimizing power sums max|\u2211z_i^k| for sequences with z\u2081 = 1 and modulus constraints. The original question (|z_i| \u2265 1) remains open, but three partial results are formalized: Erd\u0151s's C \u2248 1.32 for the unit disk, L. Erd\u0151s's optimal C \u2248 1.7455 for the unit circle, and Tur\u00e1n's (2e)^{-n} lower bound for the exterior.",
+    "implications": "**Theoretical Significance**: Tur\u00e1n's power sum method is fundamental in analytic number theory.\n\nPower sum bounds directly relate to Dirichlet polynomial estimates, L-function zero-free regions, and equidistribution theory. The three-regime structure illustrates how geometry constrains extremal behavior.",
     "openQuestions": [
-      "Does C > 1 exist for the original |z_i| ≥ 1 question?",
+      "Does C > 1 exist for the original |z_i| \u2265 1 question?",
       "Sharper bounds between 1.745 and 1.746 for unit circle?",
       "Explicit extremal sequences achieving the bounds?",
-      "Higher-dimensional generalizations of Turán's method?"
+      "Higher-dimensional generalizations of Tur\u00e1n's method?"
     ]
   },
   "leanFile": {
@@ -188,17 +188,17 @@
     {
       "targetId": "erdos-1117",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: complex-analysis, open"
+      "description": "Related Erd\u0151s problem sharing themes: complex-analysis, open"
     },
     {
       "targetId": "erdos-1137",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: analytic-number-theory, open"
+      "description": "Related Erd\u0151s problem sharing themes: analytic-number-theory, open"
     },
     {
       "targetId": "erdos-114",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: complex-analysis, open"
+      "description": "Related Erd\u0151s problem sharing themes: complex-analysis, open"
     }
   ]
 }

--- a/src/data/proofs/erdos-985/meta.json
+++ b/src/data/proofs/erdos-985/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-985",
-  "title": "Erdős Problem #985: Prime Primitive Roots",
+  "title": "Erd\u0151s Problem #985: Prime Primitive Roots",
   "slug": "erdos-985",
   "description": "Is it true that for every prime p, there is a prime q < p which is a primitive root modulo p?",
   "meta": {
-    "author": "Erdős (problem), Heath-Brown (1986, related result)",
+    "author": "Erd\u0151s (problem), Heath-Brown (1986, related result)",
     "sourceUrl": "https://erdosproblems.com/985",
     "date": "",
     "status": "axiomatized",
@@ -58,19 +58,19 @@
     ],
     "axiomCount": 2,
     "lineCount": 223,
-    "assumptions": "6 axioms: exists_primitive_root, zmod_units_cyclic, artin_conjecture_for_2, and 3 more. See Lean source for complete statements."
+    "assumptions": "2 axioms: heath_brown_theorem, erdos_985_conjecture. 0 sorries."
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #985: Prime Primitive Roots**\n\nThis problem asks whether every odd prime p admits a prime primitive root less than itself.\n\n**Key History:**\n- Artin (1927): Conjectured that any non-square integer is a primitive root for infinitely many primes\n- Hooley (1967): Proved Artin's conjecture assuming the Generalized Riemann Hypothesis\n- Heath-Brown (1986): Proved unconditionally that at least one of 2, 3, or 5 is a primitive root for infinitely many primes\n\n**Mathematical Setting:**\nA primitive root modulo p is an integer g whose multiplicative order equals p - 1. This means g generates the entire multiplicative group (ℤ/pℤ)×. Erdős's question asks specifically for PRIME primitive roots, a natural but difficult restriction.",
+    "historicalContext": "**Erd\u0151s Problem #985: Prime Primitive Roots**\n\nThis problem asks whether every odd prime p admits a prime primitive root less than itself.\n\n**Key History:**\n- Artin (1927): Conjectured that any non-square integer is a primitive root for infinitely many primes\n- Hooley (1967): Proved Artin's conjecture assuming the Generalized Riemann Hypothesis\n- Heath-Brown (1986): Proved unconditionally that at least one of 2, 3, or 5 is a primitive root for infinitely many primes\n\n**Mathematical Setting:**\nA primitive root modulo p is an integer g whose multiplicative order equals p - 1. This means g generates the entire multiplicative group (\u2124/p\u2124)\u00d7. Erd\u0151s's question asks specifically for PRIME primitive roots, a natural but difficult restriction.",
     "problemStatement": "**Problem Statement (OPEN)**\n\nIs it true that, for every prime p > 2, there is a prime q < p which is a primitive root modulo p?\n\n**Status: OPEN**\n\nThe conjecture has been verified computationally for many small primes, but no general proof or counterexample is known.\n\n**Related Result (Heath-Brown 1986):**\nAt least one of 2, 3, or 5 is a primitive root for infinitely many primes. This is the strongest unconditional result toward Artin's conjecture.",
     "text": "Is it true that for every prime p, there is a prime q < p which is a primitive root modulo p?",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Primitive Root Definition:** Define ord_p(g) = p - 1 using Mathlib's orderOf\n\n2. **Prime Primitive Root:** q is prime and a primitive root modulo p\n\n3. **Verified Examples:** Computationally verify the conjecture for p = 3, 5, 7, 11, 13, 23 using native_decide\n\n4. **Related Results:** Axiomatize Heath-Brown's theorem and Artin's conjecture\n\n5. **Main Conjecture:** State Erdős 985 as an axiom (open problem)\n\n6. **Connections:** Show how Artin's conjecture would imply Erdős 985",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Primitive Root Definition:** Define ord_p(g) = p - 1 using Mathlib's orderOf\n\n2. **Prime Primitive Root:** q is prime and a primitive root modulo p\n\n3. **Verified Examples:** Computationally verify the conjecture for p = 3, 5, 7, 11, 13, 23 using native_decide\n\n4. **Related Results:** Axiomatize Heath-Brown's theorem and Artin's conjecture\n\n5. **Main Conjecture:** State Erd\u0151s 985 as an axiom (open problem)\n\n6. **Connections:** Show how Artin's conjecture would imply Erd\u0151s 985",
     "keyInsights": [
-      "**Primitive Root**: An element g with ord_p(g) = p - 1 generates (ℤ/pℤ)×",
+      "**Primitive Root**: An element g with ord_p(g) = p - 1 generates (\u2124/p\u2124)\u00d7",
       "**Existence Guaranteed**: Every odd prime has primitive roots, but finding PRIME ones is harder",
       "**Heath-Brown's Breakthrough**: At least one of {2, 3, 5} works for infinitely many primes",
-      "**Artin's Conjecture**: If true, would imply Erdős 985 via density arguments",
-      "**Heuristic Argument**: φ(p-1)/log(p) prime primitive roots expected by PNT",
+      "**Artin's Conjecture**: If true, would imply Erd\u0151s 985 via density arguments",
+      "**Heuristic Argument**: \u03c6(p-1)/log(p) prime primitive roots expected by PNT",
       "**Computational Evidence**: Verified for all small primes tested"
     ],
     "prerequisites": [
@@ -105,7 +105,7 @@
     },
     {
       "id": "erdos-verification",
-      "title": "Verified Cases of Erdős 985",
+      "title": "Verified Cases of Erd\u0151s 985",
       "summary": "erdos985_for_3, erdos985_for_5, erdos985_for_7, erdos985_for_11, erdos985_for_13, erdos985_for_23",
       "startLine": 87,
       "endLine": 112,
@@ -153,12 +153,12 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #985 asks whether every odd prime p has a prime primitive root q < p. This elegant question remains OPEN. We verify the conjecture computationally for p = 3, 5, 7, 11, 13, 23, and formalize Heath-Brown's theorem that at least one of {2, 3, 5} is a primitive root for infinitely many primes.",
-    "implications": "**Theoretical Significance**: **Number-Theoretic Connections**\n\n1. **Artin's Conjecture:** If Artin's conjecture holds, Erdős 985 follows\n\n2. **Generalized Riemann Hypothesis:** Hooley's conditional result connects to GRH\n\n**3. Primitive Root Distribution:** Understanding which integers are primitive roots\n\n4. **Computational Number Theory:** Can test the conjecture for larger primes\n\n5. **Cyclic Group Structure:** Deep connection to (ℤ/pℤ)× being cyclic.",
+    "summary": "Erd\u0151s Problem #985 asks whether every odd prime p has a prime primitive root q < p. This elegant question remains OPEN. We verify the conjecture computationally for p = 3, 5, 7, 11, 13, 23, and formalize Heath-Brown's theorem that at least one of {2, 3, 5} is a primitive root for infinitely many primes.",
+    "implications": "**Theoretical Significance**: **Number-Theoretic Connections**\n\n1. **Artin's Conjecture:** If Artin's conjecture holds, Erd\u0151s 985 follows\n\n2. **Generalized Riemann Hypothesis:** Hooley's conditional result connects to GRH\n\n**3. Primitive Root Distribution:** Understanding which integers are primitive roots\n\n4. **Computational Number Theory:** Can test the conjecture for larger primes\n\n5. **Cyclic Group Structure:** Deep connection to (\u2124/p\u2124)\u00d7 being cyclic.",
     "openQuestions": [
       "Is there a prime p with no prime primitive root < p?",
       "What is the density of primes for which 2 is a primitive root?",
-      "Can we prove Erdős 985 for primes of special form?",
+      "Can we prove Erd\u0151s 985 for primes of special form?",
       "Relationship to least prime primitive root modulo p",
       "Computational verification for larger primes"
     ]
@@ -184,17 +184,17 @@
     {
       "targetId": "erdos-1056",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: modular-arithmetic, number-theory, open"
+      "description": "Related Erd\u0151s problem sharing themes: modular-arithmetic, number-theory, open"
     },
     {
       "targetId": "erdos-1113",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: number-theory, open, primes"
+      "description": "Related Erd\u0151s problem sharing themes: number-theory, open, primes"
     },
     {
       "targetId": "erdos-1141",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: number-theory, open, primes"
+      "description": "Related Erd\u0151s problem sharing themes: number-theory, open, primes"
     }
   ]
 }

--- a/src/data/proofs/erdos-989/meta.json
+++ b/src/data/proofs/erdos-989/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-989",
-  "title": "Erdős Problem #989: Circle Discrepancy",
+  "title": "Erd\u0151s Problem #989: Circle Discrepancy",
   "slug": "erdos-989",
-  "description": "For an infinite sequence A ⊂ ℝ², define f(r) = max_C |#(A∩C) - πr²| over circles of radius r. Beck (1987) proved f(r) ≫ r^{1/2} for all A (lower bound), and ∃A with f(r) ≪ (r log r)^{1/2} (upper bound). The optimal growth is Θ̃(√r).",
+  "description": "For an infinite sequence A \u2282 \u211d\u00b2, define f(r) = max_C |#(A\u2229C) - \u03c0r\u00b2| over circles of radius r. Beck (1987) proved f(r) \u226b r^{1/2} for all A (lower bound), and \u2203A with f(r) \u226a (r log r)^{1/2} (upper bound). The optimal growth is \u0398\u0303(\u221ar).",
   "meta": {
-    "author": "Beck, József",
+    "author": "Beck, J\u00f3zsef",
     "sourceUrl": "https://erdosproblems.com/989",
     "date": "1987",
     "status": "axiomatized",
@@ -25,17 +25,17 @@
     "mathlibDependencies": [
       {
         "theorem": "EuclideanSpace",
-        "description": "Type for points in ℝ²",
+        "description": "Type for points in \u211d\u00b2",
         "module": "Mathlib.Analysis.InnerProductSpace.PiL2"
       },
       {
         "theorem": "Real.pi",
-        "description": "The constant π for circle area calculations",
+        "description": "The constant \u03c0 for circle area calculations",
         "module": "Mathlib.Analysis.SpecialFunctions.Pi.Basic"
       },
       {
         "theorem": "Real.sqrt",
-        "description": "Square root function for √r bounds",
+        "description": "Square root function for \u221ar bounds",
         "module": "Mathlib.Analysis.SpecialFunctions.Pow.Real"
       },
       {
@@ -64,11 +64,11 @@
       },
       {
         "id": "erdos-987",
-        "relationship": "Exponential sums controlling equidistribution via the Erdős-Turán inequality, using related Fourier methods"
+        "relationship": "Exponential sums controlling equidistribution via the Erd\u0151s-Tur\u00e1n inequality, using related Fourier methods"
       },
       {
         "id": "erdos-990",
-        "relationship": "Angular discrepancy of polynomial roots on the unit circle via Erdős-Turán inequality"
+        "relationship": "Angular discrepancy of polynomial roots on the unit circle via Erd\u0151s-Tur\u00e1n inequality"
       },
       {
         "id": "erdos-992",
@@ -85,22 +85,22 @@
     ],
     "axiomCount": 2,
     "lineCount": 341,
-    "assumptions": "6 axioms: beck_lower_bound, beck_upper_bound, fourier_analysis_lower_bound, and 3 more. See Lean source for complete statements.",
+    "assumptions": "2 axioms: beck_lower_bound, beck_upper_bound. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "**Circle Discrepancy and Uniform Distribution**\n\nThis problem asks fundamental questions about how uniformly an infinite sequence of points can be distributed in the plane with respect to circles.\n\nFor a sequence A = {z₁, z₂, ...} ⊂ ℝ², define the circle discrepancy function:\n  f(r) = max_C |#(A ∩ C) - πr²|\nwhere the maximum is over all circles C of radius r.\n\nThe expected count in a circle of radius r (if points had density 1) is πr². The discrepancy measures the worst deviation from this expectation.\n\n**Historical Roots**\n\nThe study of discrepancy begins with Hermann Weyl's 1916 equidistribution theorem and was systematically developed by Klaus Roth, who proved in 1954 that the box discrepancy D(N) ≥ c√(log N) for points in [0,1]². Wolfgang Schmidt extended this to higher dimensions in 1972. The shift from boxes to curved test sets was pioneered by József Beck in the 1980s.\n\n**Beck's Complete Solution (1987)**\n\nBeck settled this problem in his landmark paper 'Irregularities of distribution I' (Acta Math. 159, 1987, pp. 1–49):\n\n1. **Lower Bound (Universal)**: For ALL sequences A, f(r) ≫ r^{1/2}\n   - No matter how carefully you place points, discrepancy grows at least like √r\n   - Proof uses Fourier analysis and properties of Bessel functions J₁\n   - The key insight is that the Fourier transform of a disk indicator is controlled by J₁, whose slow decay forces large discrepancy\n\n2. **Upper Bound (Existence)**: There EXISTS a sequence A with f(r) ≪ (r log r)^{1/2}\n   - Uses probabilistic construction: perturb the integer lattice ℤ² by small random displacements\n   - The log factor comes from union bounds over O(r²) possible circle centers\n   - This is a landmark application of the probabilistic method in geometric combinatorics\n\nThis shows the optimal growth rate is Θ̃(√r), with an open question about whether the logarithmic factor is necessary. The connection to the Gauss circle problem (lattice points in circles fluctuate by ~r^{1/4}) shows that circles present a fundamentally harder discrepancy problem than boxes or half-planes.",
-    "problemStatement": "**Problem Statement**\n\nLet A = {z₁, z₂, ...} ⊂ ℝ² be an infinite sequence of points. Define\n  f(r) = max_C |#(A ∩ C) - πr²|\nwhere the maximum is over all circles C of radius r.\n\n**Questions:**\n1. Is f(r) unbounded for every A?\n2. How fast does f(r) grow?\n\n**Answer (Beck 1987):**\n1. YES - f(r) is unbounded for every A\n2. The optimal growth rate is Θ̃(√r):\n   - Universal lower bound: f(r) ≥ c·√r for all A\n   - Existence upper bound: ∃A with f(r) ≤ C·√(r log r)\n\n**Status:** SOLVED",
-    "text": "For an infinite sequence A ⊂ ℝ², define f(r) = max_C |#(A∩C) - πr²| over circles of radius r. Beck (1987) proved f(r) ≫ r^{1/2} for all A (lower bound), and ∃A with f(r) ≪ (r log r)^{1/2} (upper bound). The optimal growth is Θ̃(√r).",
-    "proofStrategy": "**Beck's Approach**\n\n**Lower Bound (Fourier Analysis):**\n1. Express circle indicators via their Fourier transforms: $\\hat{\\mathbf{1}}_B(\\xi) = r J_1(2\\pi r|\\xi|)/|\\xi|$\n2. The Fourier transform of a disk involves Bessel functions J₁\n3. Key property: |J₁(x)| ~ √(2/(πx)) cos(x - 3π/4) for large x\n4. Apply Parseval's identity to relate L² discrepancy to Fourier coefficients\n5. The Bessel asymptotics force Ω(√r) growth since the Fourier coefficients decay too slowly\n\n**Upper Bound (Probabilistic Construction):**\n1. Start with the integer lattice ℤ² (density 1)\n2. Perturb each lattice point z by i.i.d. random displacement δ_z uniform on [-ε, ε]²\n3. For a single circle: Var[#(A ∩ C)] = O(r) from boundary contribution\n4. The union bound over O(r²) possible circle positions introduces the log factor\n5. Second moment method: E[sup_C D] = O(√(r log r))\n\n**Why √r is Natural:**\n- A circle of radius r has circumference 2πr\n- Points near the boundary can be in or out\n- Fluctuations of order √(boundary length) = √r\n- This is the same heuristic as the central limit theorem for independent boundary events",
+    "historicalContext": "**Circle Discrepancy and Uniform Distribution**\n\nThis problem asks fundamental questions about how uniformly an infinite sequence of points can be distributed in the plane with respect to circles.\n\nFor a sequence A = {z\u2081, z\u2082, ...} \u2282 \u211d\u00b2, define the circle discrepancy function:\n  f(r) = max_C |#(A \u2229 C) - \u03c0r\u00b2|\nwhere the maximum is over all circles C of radius r.\n\nThe expected count in a circle of radius r (if points had density 1) is \u03c0r\u00b2. The discrepancy measures the worst deviation from this expectation.\n\n**Historical Roots**\n\nThe study of discrepancy begins with Hermann Weyl's 1916 equidistribution theorem and was systematically developed by Klaus Roth, who proved in 1954 that the box discrepancy D(N) \u2265 c\u221a(log N) for points in [0,1]\u00b2. Wolfgang Schmidt extended this to higher dimensions in 1972. The shift from boxes to curved test sets was pioneered by J\u00f3zsef Beck in the 1980s.\n\n**Beck's Complete Solution (1987)**\n\nBeck settled this problem in his landmark paper 'Irregularities of distribution I' (Acta Math. 159, 1987, pp. 1\u201349):\n\n1. **Lower Bound (Universal)**: For ALL sequences A, f(r) \u226b r^{1/2}\n   - No matter how carefully you place points, discrepancy grows at least like \u221ar\n   - Proof uses Fourier analysis and properties of Bessel functions J\u2081\n   - The key insight is that the Fourier transform of a disk indicator is controlled by J\u2081, whose slow decay forces large discrepancy\n\n2. **Upper Bound (Existence)**: There EXISTS a sequence A with f(r) \u226a (r log r)^{1/2}\n   - Uses probabilistic construction: perturb the integer lattice \u2124\u00b2 by small random displacements\n   - The log factor comes from union bounds over O(r\u00b2) possible circle centers\n   - This is a landmark application of the probabilistic method in geometric combinatorics\n\nThis shows the optimal growth rate is \u0398\u0303(\u221ar), with an open question about whether the logarithmic factor is necessary. The connection to the Gauss circle problem (lattice points in circles fluctuate by ~r^{1/4}) shows that circles present a fundamentally harder discrepancy problem than boxes or half-planes.",
+    "problemStatement": "**Problem Statement**\n\nLet A = {z\u2081, z\u2082, ...} \u2282 \u211d\u00b2 be an infinite sequence of points. Define\n  f(r) = max_C |#(A \u2229 C) - \u03c0r\u00b2|\nwhere the maximum is over all circles C of radius r.\n\n**Questions:**\n1. Is f(r) unbounded for every A?\n2. How fast does f(r) grow?\n\n**Answer (Beck 1987):**\n1. YES - f(r) is unbounded for every A\n2. The optimal growth rate is \u0398\u0303(\u221ar):\n   - Universal lower bound: f(r) \u2265 c\u00b7\u221ar for all A\n   - Existence upper bound: \u2203A with f(r) \u2264 C\u00b7\u221a(r log r)\n\n**Status:** SOLVED",
+    "text": "For an infinite sequence A \u2282 \u211d\u00b2, define f(r) = max_C |#(A\u2229C) - \u03c0r\u00b2| over circles of radius r. Beck (1987) proved f(r) \u226b r^{1/2} for all A (lower bound), and \u2203A with f(r) \u226a (r log r)^{1/2} (upper bound). The optimal growth is \u0398\u0303(\u221ar).",
+    "proofStrategy": "**Beck's Approach**\n\n**Lower Bound (Fourier Analysis):**\n1. Express circle indicators via their Fourier transforms: $\\hat{\\mathbf{1}}_B(\\xi) = r J_1(2\\pi r|\\xi|)/|\\xi|$\n2. The Fourier transform of a disk involves Bessel functions J\u2081\n3. Key property: |J\u2081(x)| ~ \u221a(2/(\u03c0x)) cos(x - 3\u03c0/4) for large x\n4. Apply Parseval's identity to relate L\u00b2 discrepancy to Fourier coefficients\n5. The Bessel asymptotics force \u03a9(\u221ar) growth since the Fourier coefficients decay too slowly\n\n**Upper Bound (Probabilistic Construction):**\n1. Start with the integer lattice \u2124\u00b2 (density 1)\n2. Perturb each lattice point z by i.i.d. random displacement \u03b4_z uniform on [-\u03b5, \u03b5]\u00b2\n3. For a single circle: Var[#(A \u2229 C)] = O(r) from boundary contribution\n4. The union bound over O(r\u00b2) possible circle positions introduces the log factor\n5. Second moment method: E[sup_C D] = O(\u221a(r log r))\n\n**Why \u221ar is Natural:**\n- A circle of radius r has circumference 2\u03c0r\n- Points near the boundary can be in or out\n- Fluctuations of order \u221a(boundary length) = \u221ar\n- This is the same heuristic as the central limit theorem for independent boundary events",
     "keyInsights": [
-      "f(r) is unbounded for EVERY sequence A — discrepancy is an unavoidable consequence of placing points in the plane",
-      "The optimal growth rate is Θ̃(√r) — both lower and upper bounds match up to a √(log r) factor",
-      "The lower bound uses Fourier analysis on ℝ² with Bessel function J₁ asymptotics, connecting analytic number theory to combinatorial geometry",
+      "f(r) is unbounded for EVERY sequence A \u2014 discrepancy is an unavoidable consequence of placing points in the plane",
+      "The optimal growth rate is \u0398\u0303(\u221ar) \u2014 both lower and upper bounds match up to a \u221a(log r) factor",
+      "The lower bound uses Fourier analysis on \u211d\u00b2 with Bessel function J\u2081 asymptotics, connecting analytic number theory to combinatorial geometry",
       "The upper bound uses the probabilistic method: a randomly perturbed lattice achieves near-optimal discrepancy, a striking example of randomization beating deterministic constructions",
-      "The logarithmic gap between √r and √(r log r) remains open since 1987 — it is unknown whether the union bound introducing log r is tight or an artifact of the proof",
-      "Circles have strictly higher discrepancy than half-planes (√r ≫ r^{1/4}), reflecting how curvature amplifies irregularity by creating more 'boundary events'",
-      "The Gauss circle problem (counting ℤ² points in a circle) is a special case: the fluctuation r^{1/4} is less than √r because the lattice is highly structured"
+      "The logarithmic gap between \u221ar and \u221a(r log r) remains open since 1987 \u2014 it is unknown whether the union bound introducing log r is tight or an artifact of the proof",
+      "Circles have strictly higher discrepancy than half-planes (\u221ar \u226b r^{1/4}), reflecting how curvature amplifies irregularity by creating more 'boundary events'",
+      "The Gauss circle problem (counting \u2124\u00b2 points in a circle) is a special case: the fluctuation r^{1/4} is less than \u221ar because the lattice is highly structured"
     ],
     "prerequisites": [
       "Combinatorics (counting, extremal problems)",
@@ -111,42 +111,42 @@
     {
       "id": "basic-definitions",
       "title": "Basic Definitions",
-      "summary": "Defines Point (as EuclideanSpace ℝ (Fin 2)), Circle (center + positive radius), Circle.disk (closed ball), and circleArea (πr²). These are the geometric primitives for the discrepancy problem.",
+      "summary": "Defines Point (as EuclideanSpace \u211d (Fin 2)), Circle (center + positive radius), Circle.disk (closed ball), and circleArea (\u03c0r\u00b2). These are the geometric primitives for the discrepancy problem.",
       "startLine": 44,
       "endLine": 61,
-      "mathContext": "Defines Point (as EuclideanSpace $\\mathbb{R}$ (Fin 2)), Circle (center + positive radius), Circle.disk (closed ball), and circleArea (πr²). These are the geometric primitives for the discrepancy problem."
+      "mathContext": "Defines Point (as EuclideanSpace $\\mathbb{R}$ (Fin 2)), Circle (center + positive radius), Circle.disk (closed ball), and circleArea (\u03c0r\u00b2). These are the geometric primitives for the discrepancy problem."
     },
     {
       "id": "discrepancy-definitions",
       "title": "Point Sequences and Discrepancy",
-      "summary": "Defines PointSequence (ℕ → Point), countInCircle (filtering Finset.range n), localDiscrepancy (|count - πr²|), and the central object circleDiscrepancy (iSup over all circles of fixed radius and all prefix lengths).",
+      "summary": "Defines PointSequence (\u2115 \u2192 Point), countInCircle (filtering Finset.range n), localDiscrepancy (|count - \u03c0r\u00b2|), and the central object circleDiscrepancy (iSup over all circles of fixed radius and all prefix lengths).",
       "startLine": 62,
       "endLine": 87,
-      "mathContext": "Defines PointSequence (ℕ → Point), countInCircle (filtering Finset.range n), localDiscrepancy (|count - πr²|), and the central object circleDiscrepancy (iSup over all circles of fixed radius and all prefix lengths)."
+      "mathContext": "Defines PointSequence (\u2115 \u2192 Point), countInCircle (filtering Finset.range n), localDiscrepancy (|count - \u03c0r\u00b2|), and the central object circleDiscrepancy (iSup over all circles of fixed radius and all prefix lengths)."
     },
     {
       "id": "lower-bound",
       "title": "Beck's Lower Bound",
-      "summary": "States beck_lower_bound as an axiom (∃ c > 0, ∀ A, f(r) ≥ c√r eventually) and derives discrepancy_unbounded — one of the rare fully-proved theorems in the file, using calc chains with sqrt monotonicity.",
+      "summary": "States beck_lower_bound as an axiom (\u2203 c > 0, \u2200 A, f(r) \u2265 c\u221ar eventually) and derives discrepancy_unbounded \u2014 one of the rare fully-proved theorems in the file, using calc chains with sqrt monotonicity.",
       "startLine": 88,
       "endLine": 129,
-      "mathContext": "States beck_lower_bound as an axiom (∃ c > 0, ∀ A, f(r) ≥ c√r eventually) and derives discrepancy_unbounded — one of the rare fully-proved theorems in the file, using calc chains with sqrt monotonicity."
+      "mathContext": "States beck_lower_bound as an axiom (\u2203 c > 0, \u2200 A, f(r) \u2265 c\u221ar eventually) and derives discrepancy_unbounded \u2014 one of the rare fully-proved theorems in the file, using calc chains with sqrt monotonicity."
     },
     {
       "id": "upper-bound",
       "title": "Beck's Upper Bound",
-      "summary": "States beck_upper_bound as an axiom (∃ A, f(r) ≤ C√(r log r) eventually) and extracts beckOptimalSequence via Classical.choose — a non-constructive witness from the probabilistic existence proof.",
+      "summary": "States beck_upper_bound as an axiom (\u2203 A, f(r) \u2264 C\u221a(r log r) eventually) and extracts beckOptimalSequence via Classical.choose \u2014 a non-constructive witness from the probabilistic existence proof.",
       "startLine": 130,
       "endLine": 150,
-      "mathContext": "States beck_upper_bound as an axiom (∃ A, f(r) ≤ C√(r log r) eventually) and extracts beckOptimalSequence via Classical.choose — a non-constructive witness from the probabilistic existence proof."
+      "mathContext": "States beck_upper_bound as an axiom (\u2203 A, f(r) \u2264 C\u221a(r log r) eventually) and extracts beckOptimalSequence via Classical.choose \u2014 a non-constructive witness from the probabilistic existence proof."
     },
     {
       "id": "complete-answer",
       "title": "The Complete Answer",
-      "summary": "The erdos_989_solved theorem packages all three results as a conjunction: unboundedness, universal lower bound √r, and existence of near-optimal √(r log r) sequence. Proved by direct application of the preceding results.",
+      "summary": "The erdos_989_solved theorem packages all three results as a conjunction: unboundedness, universal lower bound \u221ar, and existence of near-optimal \u221a(r log r) sequence. Proved by direct application of the preceding results.",
       "startLine": 151,
       "endLine": 183,
-      "mathContext": "The erdos_989_solved theorem packages all three results as a conjunction: unboundedness, universal lower bound √r, and existence of near-optimal √(r log r) sequence. Proved by direct application of the preceding results."
+      "mathContext": "The erdos_989_solved theorem packages all three results as a conjunction: unboundedness, universal lower bound \u221ar, and existence of near-optimal \u221a(r log r) sequence. Proved by direct application of the preceding results."
     },
     {
       "id": "discrepancy-theory",
@@ -159,43 +159,43 @@
     {
       "id": "proof-techniques",
       "title": "Proof Techniques",
-      "summary": "Formalizes the two proof techniques as axioms: fourier_analysis_lower_bound (for any A and r > 1, some circle has discrepancy ≥ √r/10) and probabilistic_upper_bound_construction (existence of sequence with local discrepancy O(√(r log r))).",
+      "summary": "Formalizes the two proof techniques as axioms: fourier_analysis_lower_bound (for any A and r > 1, some circle has discrepancy \u2265 \u221ar/10) and probabilistic_upper_bound_construction (existence of sequence with local discrepancy O(\u221a(r log r))).",
       "startLine": 209,
       "endLine": 239,
-      "mathContext": "Formalizes the two proof techniques as axioms: fourier_analysis_lower_bound (for any A and r > 1, some circle has discrepancy ≥ √r/10) and probabilistic_upper_bound_construction (existence of sequence with local discrepancy O(√(r log r)))."
+      "mathContext": "Formalizes the two proof techniques as axioms: fourier_analysis_lower_bound (for any A and r > 1, some circle has discrepancy \u2265 \u221ar/10) and probabilistic_upper_bound_construction (existence of sequence with local discrepancy O(\u221a(r log r)))."
     },
     {
       "id": "open-questions",
       "title": "Open Questions",
-      "summary": "Formalizes three major open problems as Lean propositions: the logarithmic gap (is f(r) = O(√r) achievable?), explicit constructions (derandomization), and higher-dimensional balls (discrepancy in ℝ^d).",
+      "summary": "Formalizes three major open problems as Lean propositions: the logarithmic gap (is f(r) = O(\u221ar) achievable?), explicit constructions (derandomization), and higher-dimensional balls (discrepancy in \u211d^d).",
       "startLine": 240,
       "endLine": 283,
-      "mathContext": "Formalizes three major open problems as Lean propositions: the logarithmic gap (is f(r) = O(√r) achievable?), explicit constructions (derandomization), and higher-dimensional balls (discrepancy in ℝ^d)."
+      "mathContext": "Formalizes three major open problems as Lean propositions: the logarithmic gap (is f(r) = O(\u221ar) achievable?), explicit constructions (derandomization), and higher-dimensional balls (discrepancy in \u211d^d)."
     },
     {
       "id": "related-results",
       "title": "Related Results",
-      "summary": "States Schmidt's classical box discrepancy theorem (D(N) ≥ c log N for d=2) and Alexander's half-plane discrepancy theorem (D(N) ≥ cN^{1/4}) as axioms, providing context for why circle discrepancy (√r) is intermediate.",
+      "summary": "States Schmidt's classical box discrepancy theorem (D(N) \u2265 c log N for d=2) and Alexander's half-plane discrepancy theorem (D(N) \u2265 cN^{1/4}) as axioms, providing context for why circle discrepancy (\u221ar) is intermediate.",
       "startLine": 284,
       "endLine": 320,
-      "mathContext": "States Schmidt's classical box discrepancy theorem (D(N) ≥ c log N for d=2) and Alexander's half-plane discrepancy theorem (D(N) ≥ cN^{1/4}) as axioms, providing context for why circle discrepancy (√r) is intermediate."
+      "mathContext": "States Schmidt's classical box discrepancy theorem (D(N) \u2265 c log N for d=2) and Alexander's half-plane discrepancy theorem (D(N) \u2265 cN^{1/4}) as axioms, providing context for why circle discrepancy (\u221ar) is intermediate."
     },
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "The erdos_989_answers_both_questions theorem restates the key conjunction: f(r) is always unbounded AND f(r) ≥ c√r. The detailed docstring provides a complete narrative of the problem, solution, techniques, significance, and open problems.",
+      "summary": "The erdos_989_answers_both_questions theorem restates the key conjunction: f(r) is always unbounded AND f(r) \u2265 c\u221ar. The detailed docstring provides a complete narrative of the problem, solution, techniques, significance, and open problems.",
       "startLine": 321,
       "endLine": 341,
-      "mathContext": "The erdos_989_answers_both_questions theorem restates the key conjunction: f(r) is always unbounded AND f(r) ≥ c√r. The detailed docstring provides a complete narrative of the problem, solution, techniques, significance, and open problems."
+      "mathContext": "The erdos_989_answers_both_questions theorem restates the key conjunction: f(r) is always unbounded AND f(r) \u2265 c\u221ar. The detailed docstring provides a complete narrative of the problem, solution, techniques, significance, and open problems."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #989 asked whether the circle discrepancy f(r) is unbounded and how fast it grows. Beck (1987) completely settled this: f(r) ≫ √r for ALL sequences (using Fourier/Bessel analysis), and ∃ sequence with f(r) ≪ √(r log r) (using probabilistic construction). The optimal rate is Θ̃(√r).",
-    "implications": "1. **Discrepancy Theory**: Foundational result establishing the sharp growth rate for circle discrepancy, resolving the key open question in geometric equidistribution\n\n2. **Fourier Methods in Combinatorics**: Demonstrates the power of harmonic analysis for discrete geometry problems — the Bessel function connection shows deep interplay between analysis and combinatorics\n\n**3. Probabilistic Method**: The fact that a randomly perturbed lattice achieves near-optimal discrepancy is a striking example of the Erdős probabilistic method in geometry\n\n4. **Curvature and Discrepancy**: The comparison circles (√r) vs half-planes (r^{1/4}) reveals that boundary curvature κ = 1/r fundamentally amplifies discrepancy — a geometric insight with implications for all curved test set families\n\n5. **Connection to Number Theory**: The Gauss circle problem (lattice points in circles) is a special case where the highly structured lattice achieves r^{1/4} fluctuation, far below the √r universal lower bound.",
+    "summary": "Erd\u0151s Problem #989 asked whether the circle discrepancy f(r) is unbounded and how fast it grows. Beck (1987) completely settled this: f(r) \u226b \u221ar for ALL sequences (using Fourier/Bessel analysis), and \u2203 sequence with f(r) \u226a \u221a(r log r) (using probabilistic construction). The optimal rate is \u0398\u0303(\u221ar).",
+    "implications": "1. **Discrepancy Theory**: Foundational result establishing the sharp growth rate for circle discrepancy, resolving the key open question in geometric equidistribution\n\n2. **Fourier Methods in Combinatorics**: Demonstrates the power of harmonic analysis for discrete geometry problems \u2014 the Bessel function connection shows deep interplay between analysis and combinatorics\n\n**3. Probabilistic Method**: The fact that a randomly perturbed lattice achieves near-optimal discrepancy is a striking example of the Erd\u0151s probabilistic method in geometry\n\n4. **Curvature and Discrepancy**: The comparison circles (\u221ar) vs half-planes (r^{1/4}) reveals that boundary curvature \u03ba = 1/r fundamentally amplifies discrepancy \u2014 a geometric insight with implications for all curved test set families\n\n5. **Connection to Number Theory**: The Gauss circle problem (lattice points in circles) is a special case where the highly structured lattice achieves r^{1/4} fluctuation, far below the \u221ar universal lower bound.",
     "openQuestions": [
-      "Is the logarithmic factor necessary? Is the lower bound actually Ω(√(r log r))? This has been open since 1987.",
-      "Can we give explicit deterministic constructions achieving √(r log r)? Known low-discrepancy sequences (Halton, Niederreiter) apply to boxes, not circles.",
-      "What is the optimal discrepancy for balls in higher dimensions ℝ^d? The expected answer r^{(d-1)/2} up to logs is supported but not fully proved.",
+      "Is the logarithmic factor necessary? Is the lower bound actually \u03a9(\u221a(r log r))? This has been open since 1987.",
+      "Can we give explicit deterministic constructions achieving \u221a(r log r)? Known low-discrepancy sequences (Halton, Niederreiter) apply to boxes, not circles.",
+      "What is the optimal discrepancy for balls in higher dimensions \u211d^d? The expected answer r^{(d-1)/2} up to logs is supported but not fully proved.",
       "Are there natural sequences (lattice-based, number-theoretic) achieving near-optimal circle discrepancy without randomization?",
       "What about discrepancy for other families of curved sets (ellipses, convex sets of bounded curvature)?"
     ]
@@ -231,12 +231,12 @@
     {
       "targetId": "erdos-987",
       "relationship": "related",
-      "description": "Exponential sums controlling equidistribution via the Erdős-Turán inequality, using related Fourier methods"
+      "description": "Exponential sums controlling equidistribution via the Erd\u0151s-Tur\u00e1n inequality, using related Fourier methods"
     },
     {
       "targetId": "erdos-990",
       "relationship": "related",
-      "description": "Angular discrepancy of polynomial roots on the unit circle via Erdős-Turán inequality"
+      "description": "Angular discrepancy of polynomial roots on the unit circle via Erd\u0151s-Tur\u00e1n inequality"
     },
     {
       "targetId": "erdos-992",

--- a/src/data/proofs/erdos-99/meta.json
+++ b/src/data/proofs/erdos-99/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-99",
-  "title": "Erdős Problem #99: Equilateral Triangles in Minimal Diameter Sets",
+  "title": "Erd\u0151s Problem #99: Equilateral Triangles in Minimal Diameter Sets",
   "slug": "erdos-99",
   "description": "Must n points with minimum distance 1 and minimal diameter contain a unit equilateral triangle for large n? The n=4 square is a counterexample for small n. OPEN with $100/$50 prize.",
   "meta": {
-    "author": "Erdős (conjecture), Thue (optimal packing), Bezdek-Fodor (small cases)",
+    "author": "Erd\u0151s (conjecture), Thue (optimal packing), Bezdek-Fodor (small cases)",
     "sourceUrl": "https://erdosproblems.com/99",
     "date": "",
     "status": "axiomatized",
@@ -58,19 +58,19 @@
     ],
     "axiomCount": 1,
     "lineCount": 179,
-    "assumptions": "5 axioms: triangular_lattice_unit_distance, triangular_lattice_has_equilateral, thue_diameter_consequence, and 2 more. See Lean source for complete statements."
+    "assumptions": "1 axiom: case_n4_no_equilateral. 0 sorries."
   },
   "overview": {
-    "historicalContext": "Erdős Problem #99 is a deceptively natural question in discrete geometry that has resisted resolution since it was posed in the 1990s ([Er94b], [Er95], [Er97e]). The problem asks whether optimal point configurations — sets of n points with minimum pairwise distance 1 that minimize the enclosing diameter — must contain unit equilateral triangles when n is large enough.\n\nThe conjecture draws on Thue's classical theorem (1910) that the densest packing of unit circles in the plane is achieved by the triangular (hexagonal) lattice, with density π/(2√3) ≈ 0.9069. Since diameter-minimizing configurations must pack points efficiently, they should resemble circular regions of the triangular lattice, which is built entirely from unit equilateral triangles. Erdős went further, conjecturing that (1-o(1))n points of any optimal configuration lie exactly on the triangular lattice.\n\nRemarkably, Erdős himself seemed uncertain about the conjecture's truth. He wrote: 'I could not prove it but felt that it should not be hard. To my great surprise both B. H. Sendov and M. Simonovits doubted the truth of this conjecture.' The prize structure reinforces this uncertainty: $100 for a counterexample but only $50 for a proof. The n=4 case provides concrete evidence that small optimal configurations (a unit square) can avoid equilateral triangles entirely. Bezdek and Fodor (1999) analyzed optimal configurations for small n, finding that triangular lattice structure emerges gradually.",
-    "problemStatement": "**Problem Statement (Open)**\n\nLet $A \\subseteq \\mathbb{R}^2$ be a set of $n$ points with minimum pairwise distance $1$, chosen to minimize the diameter of $A$. For sufficiently large $n$, must $A$ contain three points forming a unit equilateral triangle?\n\n**Prize:** $100 for counterexample, $50 for proof\n\n**Known:** For $n = 4$, the unit square is optimal and contains no equilateral triangle. Erdős conjectured the stronger claim that $(1-o(1))n$ points must lie on the triangular lattice.",
+    "historicalContext": "Erd\u0151s Problem #99 is a deceptively natural question in discrete geometry that has resisted resolution since it was posed in the 1990s ([Er94b], [Er95], [Er97e]). The problem asks whether optimal point configurations \u2014 sets of n points with minimum pairwise distance 1 that minimize the enclosing diameter \u2014 must contain unit equilateral triangles when n is large enough.\n\nThe conjecture draws on Thue's classical theorem (1910) that the densest packing of unit circles in the plane is achieved by the triangular (hexagonal) lattice, with density \u03c0/(2\u221a3) \u2248 0.9069. Since diameter-minimizing configurations must pack points efficiently, they should resemble circular regions of the triangular lattice, which is built entirely from unit equilateral triangles. Erd\u0151s went further, conjecturing that (1-o(1))n points of any optimal configuration lie exactly on the triangular lattice.\n\nRemarkably, Erd\u0151s himself seemed uncertain about the conjecture's truth. He wrote: 'I could not prove it but felt that it should not be hard. To my great surprise both B. H. Sendov and M. Simonovits doubted the truth of this conjecture.' The prize structure reinforces this uncertainty: $100 for a counterexample but only $50 for a proof. The n=4 case provides concrete evidence that small optimal configurations (a unit square) can avoid equilateral triangles entirely. Bezdek and Fodor (1999) analyzed optimal configurations for small n, finding that triangular lattice structure emerges gradually.",
+    "problemStatement": "**Problem Statement (Open)**\n\nLet $A \\subseteq \\mathbb{R}^2$ be a set of $n$ points with minimum pairwise distance $1$, chosen to minimize the diameter of $A$. For sufficiently large $n$, must $A$ contain three points forming a unit equilateral triangle?\n\n**Prize:** $100 for counterexample, $50 for proof\n\n**Known:** For $n = 4$, the unit square is optimal and contains no equilateral triangle. Erd\u0151s conjectured the stronger claim that $(1-o(1))n$ points must lie on the triangular lattice.",
     "text": "Must n points with minimum distance 1 and minimal diameter contain a unit equilateral triangle for large n? The n=4 square is a counterexample for small n. OPEN with $100/$50 prize.",
-    "proofStrategy": "**Formalization Approach**\n\nThe formalization works in the Euclidean plane ℝ² = EuclideanSpace ℝ (Fin 2), defining distance, minimum pairwise distance, and diameter for finite point sets. The key definitions capture optimal configurations (minimum distance 1, minimal diameter) and unit equilateral triangles.\n\nThe triangular lattice is constructed explicitly with basis vectors (1, 0) and (1/2, √3/2). Two properties of the lattice are axiomatized: that adjacent points have unit distance, and that adjacent triples form equilateral triangles. Thue's theorem consequence — that optimal configurations resemble the lattice — is axiomatized since it requires deep results from the geometry of numbers.\n\nThe small cases n=3 (equilateral triangle forced) and n=4 (square avoids equilateral triangles) are axiomatized to capture the known boundary behavior. The summary theorem assembles the n=4 counterexample as the main concrete result.",
+    "proofStrategy": "**Formalization Approach**\n\nThe formalization works in the Euclidean plane \u211d\u00b2 = EuclideanSpace \u211d (Fin 2), defining distance, minimum pairwise distance, and diameter for finite point sets. The key definitions capture optimal configurations (minimum distance 1, minimal diameter) and unit equilateral triangles.\n\nThe triangular lattice is constructed explicitly with basis vectors (1, 0) and (1/2, \u221a3/2). Two properties of the lattice are axiomatized: that adjacent points have unit distance, and that adjacent triples form equilateral triangles. Thue's theorem consequence \u2014 that optimal configurations resemble the lattice \u2014 is axiomatized since it requires deep results from the geometry of numbers.\n\nThe small cases n=3 (equilateral triangle forced) and n=4 (square avoids equilateral triangles) are axiomatized to capture the known boundary behavior. The summary theorem assembles the n=4 counterexample as the main concrete result.",
     "keyInsights": [
-      "**Prize Asymmetry:** Erdős offered $100 for a counterexample but only $50 for a proof, suggesting he suspected the conjecture might be false",
+      "**Prize Asymmetry:** Erd\u0151s offered $100 for a counterexample but only $50 for a proof, suggesting he suspected the conjecture might be false",
       "**n=4 Square:** The unit square is an optimal 4-point configuration with no equilateral triangle, showing the conjecture fails for small n",
       "**Thue's Theorem:** Optimal 2D circle packing uses the triangular lattice, so diameter-minimizing sets should resemble it asymptotically",
       "**Gap Between Global and Local:** The subtlety is that 'approximately lattice-like' does not immediately imply 'contains lattice triangles'",
-      "**Expert Doubt:** Both Sendov and Simonovits doubted the conjecture, surprising Erdős himself"
+      "**Expert Doubt:** Both Sendov and Simonovits doubted the conjecture, surprising Erd\u0151s himself"
     ],
     "prerequisites": [
       "Combinatorics (counting, extremal problems)",
@@ -136,8 +136,8 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #99 asks whether diameter-minimizing n-point sets with minimum distance 1 must contain unit equilateral triangles for large n. The formalization axiomatizes the triangular lattice structure, Thue's packing consequence, and the key small cases (n=3 forced, n=4 avoids). The problem remains open.",
-    "implications": "**Theoretical Significance**: **Geometric Connections**\n\n1. **Packing Theory:** Tests whether optimal packings must exhibit local triangular lattice structure\n\n**2. Global vs Local:** Asks if global optimization (diameter) forces local structure (equilateral triangles)\n\n3. **Transition Behavior:** The n=4 square shows that non-lattice optimal configurations exist for small n, raising the question of when lattice structure becomes forced\n\n4. **Higher Dimensions:** Generalizations to optimal packings in ℝ^d remain unexplored.",
+    "summary": "Erd\u0151s Problem #99 asks whether diameter-minimizing n-point sets with minimum distance 1 must contain unit equilateral triangles for large n. The formalization axiomatizes the triangular lattice structure, Thue's packing consequence, and the key small cases (n=3 forced, n=4 avoids). The problem remains open.",
+    "implications": "**Theoretical Significance**: **Geometric Connections**\n\n1. **Packing Theory:** Tests whether optimal packings must exhibit local triangular lattice structure\n\n**2. Global vs Local:** Asks if global optimization (diameter) forces local structure (equilateral triangles)\n\n3. **Transition Behavior:** The n=4 square shows that non-lattice optimal configurations exist for small n, raising the question of when lattice structure becomes forced\n\n4. **Higher Dimensions:** Generalizations to optimal packings in \u211d^d remain unexplored.",
     "openQuestions": [
       "Prove or disprove the conjecture (main problem, prize unclaimed)",
       "What is the smallest n for which equilateral triangles are forced?",
@@ -171,17 +171,17 @@
     {
       "targetId": "erdos-1084",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: discrete-geometry, open, packing"
+      "description": "Related Erd\u0151s problem sharing themes: discrete-geometry, open, packing"
     },
     {
       "targetId": "erdos-103",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: open, packing"
+      "description": "Related Erd\u0151s problem sharing themes: open, packing"
     },
     {
       "targetId": "erdos-106",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: discrete-geometry, packing"
+      "description": "Related Erd\u0151s problem sharing themes: discrete-geometry, packing"
     }
   ],
   "references": [

--- a/src/data/proofs/erdos-994/meta.json
+++ b/src/data/proofs/erdos-994/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-994",
-  "title": "Erdős Problem #994: Khintchine's Equidistribution Conjecture",
+  "title": "Erd\u0151s Problem #994: Khintchine's Equidistribution Conjecture",
   "slug": "erdos-994",
-  "description": "For almost all α, is lim (1/n)∑1_{kα∈E} = λ(E) for ALL measurable E ⊆ (0,1)? DISPROVED: Marstrand (1970) showed this is FALSE. The quantifiers cannot be exchanged.",
+  "description": "For almost all \u03b1, is lim (1/n)\u22111_{k\u03b1\u2208E} = \u03bb(E) for ALL measurable E \u2286 (0,1)? DISPROVED: Marstrand (1970) showed this is FALSE. The quantifiers cannot be exchanged.",
   "meta": {
     "author": "Khintchine (1923, conjecture), Marstrand (1970, disproof)",
     "sourceUrl": "https://erdosproblems.com/994",
@@ -27,7 +27,7 @@
     "mathlibDependencies": [
       {
         "theorem": "MeasureTheory.Measure",
-        "description": "Lebesgue measure for λ(E)",
+        "description": "Lebesgue measure for \u03bb(E)",
         "module": "Mathlib.MeasureTheory.Measure.Lebesgue.Basic"
       },
       {
@@ -37,7 +37,7 @@
       }
     ],
     "originalContributions": [
-      "frac, fracSequence: fractional part {kα}",
+      "frac, fracSequence: fractional part {k\u03b1}",
       "indicator, countInE, empiricalFrequency: counting hits in E",
       "IsEquidistributed: limit definition",
       "weyl_theorem, WeylStatement: what IS true",
@@ -45,23 +45,23 @@
       "WeylOrder, KhintchineOrder: quantifier difference",
       "quantifier_exchange_fails: key insight",
       "marstrand_disproof, marstrand_construction: the counterexample",
-      "bad_set_exists: E can be constructed for each α",
+      "bad_set_exists: E can be constructed for each \u03b1",
       "weyl_equidistribution: intervals always work"
     ],
     "axiomCount": 2,
     "lineCount": 208,
-    "assumptions": "6 axioms: weyl_theorem, quantifier_exchange_fails, marstrand_disproof, and 3 more. See Lean source for complete statements."
+    "assumptions": "2 axioms: weyl_theorem, marstrand_disproof. 0 sorries."
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #994** concerns a conjecture of Aleksandr Khintchine from 1923, disproved by John Marstrand in 1970, about the equidistribution of fractional parts $\\{k\\alpha\\}$ in measurable subsets of $(0,1)$.\n\n**Khintchine's Original Work (1923):**\nAleksandr Yakovlevich Khintchine (1894–1959) was a Soviet mathematician who made foundational contributions to number theory, probability theory, and ergodic theory. In his 1923 paper 'Ein Satz über Kettenbrüche, mit arithmetischen Anwendungen' (A theorem on continued fractions, with arithmetic applications), he conjectured that for almost all real $\\alpha$, the sequence $\\{k\\alpha\\}_{k=1}^{\\infty}$ is equidistributed in every measurable subset $E \\subseteq (0,1)$ simultaneously. This was a natural strengthening of Hermann Weyl's celebrated equidistribution theorem (1916).\n\n**Weyl's Theorem (1916):**\nHermann Weyl proved that for any irrational $\\alpha$, the sequence $\\{k\\alpha\\}$ is equidistributed modulo 1 in the sense that $\\frac{1}{n}|\\{k \\leq n : \\{k\\alpha\\} \\in (a,b)\\}| \\to b - a$ for any interval $(a,b) \\subseteq (0,1)$. More generally, for any fixed measurable $E$, equidistribution holds for almost all $\\alpha$—but the exceptional null set depends on $E$.\n\n**Marstrand's Disproof (1970):**\nJohn Martin Marstrand (1928–2015), a British mathematician known for his work in geometric measure theory (including Marstrand's projection theorem), showed that Khintchine's conjecture is false. For any irrational $\\alpha$, one can construct a measurable set $E_\\alpha$ tailored to the continued fraction expansion of $\\alpha$ such that the sequence $\\{k\\alpha\\}$ fails to equidistribute in $E_\\alpha$. The key insight is that while each individual null set $N_E$ of exceptional $\\alpha$ has measure zero, the uncountable union $\\bigcup_E N_E$ over all measurable $E$ need not have measure zero.\n\n**The Quantifier Exchange:**\nThe heart of the problem is a quantifier exchange: Weyl's theorem gives $\\forall E,\\; \\forall^{\\text{a.e.}} \\alpha$, while Khintchine conjectured $\\forall^{\\text{a.e.}} \\alpha,\\; \\forall E$. Marstrand showed these are genuinely different—the exceptional null set cannot be made independent of $E$.",
+    "historicalContext": "**Erd\u0151s Problem #994** concerns a conjecture of Aleksandr Khintchine from 1923, disproved by John Marstrand in 1970, about the equidistribution of fractional parts $\\{k\\alpha\\}$ in measurable subsets of $(0,1)$.\n\n**Khintchine's Original Work (1923):**\nAleksandr Yakovlevich Khintchine (1894\u20131959) was a Soviet mathematician who made foundational contributions to number theory, probability theory, and ergodic theory. In his 1923 paper 'Ein Satz \u00fcber Kettenbr\u00fcche, mit arithmetischen Anwendungen' (A theorem on continued fractions, with arithmetic applications), he conjectured that for almost all real $\\alpha$, the sequence $\\{k\\alpha\\}_{k=1}^{\\infty}$ is equidistributed in every measurable subset $E \\subseteq (0,1)$ simultaneously. This was a natural strengthening of Hermann Weyl's celebrated equidistribution theorem (1916).\n\n**Weyl's Theorem (1916):**\nHermann Weyl proved that for any irrational $\\alpha$, the sequence $\\{k\\alpha\\}$ is equidistributed modulo 1 in the sense that $\\frac{1}{n}|\\{k \\leq n : \\{k\\alpha\\} \\in (a,b)\\}| \\to b - a$ for any interval $(a,b) \\subseteq (0,1)$. More generally, for any fixed measurable $E$, equidistribution holds for almost all $\\alpha$\u2014but the exceptional null set depends on $E$.\n\n**Marstrand's Disproof (1970):**\nJohn Martin Marstrand (1928\u20132015), a British mathematician known for his work in geometric measure theory (including Marstrand's projection theorem), showed that Khintchine's conjecture is false. For any irrational $\\alpha$, one can construct a measurable set $E_\\alpha$ tailored to the continued fraction expansion of $\\alpha$ such that the sequence $\\{k\\alpha\\}$ fails to equidistribute in $E_\\alpha$. The key insight is that while each individual null set $N_E$ of exceptional $\\alpha$ has measure zero, the uncountable union $\\bigcup_E N_E$ over all measurable $E$ need not have measure zero.\n\n**The Quantifier Exchange:**\nThe heart of the problem is a quantifier exchange: Weyl's theorem gives $\\forall E,\\; \\forall^{\\text{a.e.}} \\alpha$, while Khintchine conjectured $\\forall^{\\text{a.e.}} \\alpha,\\; \\forall E$. Marstrand showed these are genuinely different\u2014the exceptional null set cannot be made independent of $E$.",
     "problemStatement": "**Problem Statement (Disproved)**\n\nLet $E \\subseteq (0,1)$ be measurable with Lebesgue measure $\\lambda(E)$. Is it true that for almost all $\\alpha$:\n\n$$\\lim_{n \\to \\infty} \\frac{1}{n} \\sum_{k=1}^{n} \\mathbf{1}_{\\{k\\alpha\\} \\in E} = \\lambda(E)$$\n\nfor ALL measurable $E$ simultaneously?\n\n**Answer: NO** (Marstrand 1970)\n\nThe conjecture is FALSE. The quantifiers $\\forall E$ and $\\forall^{\\text{a.e.}} \\alpha$ cannot be exchanged. For every irrational $\\alpha$, there exists a measurable $E_\\alpha$ where equidistribution fails.",
-    "text": "For almost all α, is lim (1/n)∑1_{kα∈E} = λ(E) for ALL measurable E ⊆ (0,1)? DISPROVED: Marstrand (1970) showed this is FALSE. The quantifiers cannot be exchanged.",
-    "proofStrategy": "**Formalization Approach**\n\nThe Lean formalization carefully distinguishes between what is true and what is false:\n\n1. **Fractional Parts** (lines 44–56):\n   - `frac x = x - ⌊x⌋`: the fractional part, with proved bounds $0 \\leq \\{x\\} < 1$\n   - `fracSequence α k = \\{k\\alpha\\}`: the sequence studied by Weyl and Khintchine\n\n2. **Empirical Frequency** (lines 66–76):\n   - `countInE α E n`: counts $|\\{k \\leq n : \\{k\\alpha\\} \\in E\\}|$ using `Finset.filter`\n   - `empiricalFrequency α E n = \\text{countInE}(\\alpha, E, n) / n$\n   - `IsEquidistributed α E μ`: defined as `Tendsto` of empirical frequency to $\\mu$\n\n3. **Weyl's Theorem** (lines 82–96):\n   - Axiomatized: for fixed measurable $E \\subseteq (0,1)$, $\\forall^{\\text{a.e.}} \\alpha$, equidistribution holds\n   - `WeylStatement`: the proposition $\\forall E,\\; \\forall^{\\text{a.e.}} \\alpha$\n   - `weyl_is_true`: proved by applying the axiom\n\n4. **Khintchine's Conjecture** (lines 102–113):\n   - `KhintchineConjecture`: $\\forall^{\\text{a.e.}} \\alpha,\\; \\forall E$\n   - `KhintchineConjecture'`: equivalent formulation with explicit null set\n\n5. **Quantifier Analysis** (lines 123–132):\n   - `WeylOrder` vs `KhintchineOrder`: makes the quantifier difference explicit\n   - `quantifier_exchange_fails`: axiomatizes that the exchange is invalid\n\n6. **Marstrand's Disproof** (lines 138–152):\n   - `marstrand_disproof`: $\\neg$`KhintchineConjecture`\n   - `marstrand_construction`: existential witness\n   - `bad_set_exists`: for any irrational $\\alpha$, a bad $E$ can be constructed\n\n7. **Summary Theorems** (lines 209–220):\n   - `erdos_994`: the main result, proved from `marstrand_disproof`\n   - `weyl_vs_khintchine`: combines both directions",
+    "text": "For almost all \u03b1, is lim (1/n)\u22111_{k\u03b1\u2208E} = \u03bb(E) for ALL measurable E \u2286 (0,1)? DISPROVED: Marstrand (1970) showed this is FALSE. The quantifiers cannot be exchanged.",
+    "proofStrategy": "**Formalization Approach**\n\nThe Lean formalization carefully distinguishes between what is true and what is false:\n\n1. **Fractional Parts** (lines 44\u201356):\n   - `frac x = x - \u230ax\u230b`: the fractional part, with proved bounds $0 \\leq \\{x\\} < 1$\n   - `fracSequence \u03b1 k = \\{k\\alpha\\}`: the sequence studied by Weyl and Khintchine\n\n2. **Empirical Frequency** (lines 66\u201376):\n   - `countInE \u03b1 E n`: counts $|\\{k \\leq n : \\{k\\alpha\\} \\in E\\}|$ using `Finset.filter`\n   - `empiricalFrequency \u03b1 E n = \\text{countInE}(\\alpha, E, n) / n$\n   - `IsEquidistributed \u03b1 E \u03bc`: defined as `Tendsto` of empirical frequency to $\\mu$\n\n3. **Weyl's Theorem** (lines 82\u201396):\n   - Axiomatized: for fixed measurable $E \\subseteq (0,1)$, $\\forall^{\\text{a.e.}} \\alpha$, equidistribution holds\n   - `WeylStatement`: the proposition $\\forall E,\\; \\forall^{\\text{a.e.}} \\alpha$\n   - `weyl_is_true`: proved by applying the axiom\n\n4. **Khintchine's Conjecture** (lines 102\u2013113):\n   - `KhintchineConjecture`: $\\forall^{\\text{a.e.}} \\alpha,\\; \\forall E$\n   - `KhintchineConjecture'`: equivalent formulation with explicit null set\n\n5. **Quantifier Analysis** (lines 123\u2013132):\n   - `WeylOrder` vs `KhintchineOrder`: makes the quantifier difference explicit\n   - `quantifier_exchange_fails`: axiomatizes that the exchange is invalid\n\n6. **Marstrand's Disproof** (lines 138\u2013152):\n   - `marstrand_disproof`: $\\neg$`KhintchineConjecture`\n   - `marstrand_construction`: existential witness\n   - `bad_set_exists`: for any irrational $\\alpha$, a bad $E$ can be constructed\n\n7. **Summary Theorems** (lines 209\u2013220):\n   - `erdos_994`: the main result, proved from `marstrand_disproof`\n   - `weyl_vs_khintchine`: combines both directions",
     "keyInsights": [
-      "**The Quantifier Trap:** Weyl gives $\\forall E,\\; \\forall^{\\text{a.e.}} \\alpha$ (equidistribution), while Khintchine conjectured $\\forall^{\\text{a.e.}} \\alpha,\\; \\forall E$. These look similar but are genuinely different—the null set of exceptional $\\alpha$ depends on $E$ and cannot be uniformized",
-      "**Uncountable Union Failure:** Each measurable $E$ produces a null set $N_E$ of 'bad' $\\alpha$. While each $N_E$ has measure zero, the union $\\bigcup_E N_E$ over the uncountably many measurable $E$ can have positive measure—or even be all of $\\mathbb{R}$. This is why countable additivity of measure does not help",
+      "**The Quantifier Trap:** Weyl gives $\\forall E,\\; \\forall^{\\text{a.e.}} \\alpha$ (equidistribution), while Khintchine conjectured $\\forall^{\\text{a.e.}} \\alpha,\\; \\forall E$. These look similar but are genuinely different\u2014the null set of exceptional $\\alpha$ depends on $E$ and cannot be uniformized",
+      "**Uncountable Union Failure:** Each measurable $E$ produces a null set $N_E$ of 'bad' $\\alpha$. While each $N_E$ has measure zero, the union $\\bigcup_E N_E$ over the uncountably many measurable $E$ can have positive measure\u2014or even be all of $\\mathbb{R}$. This is why countable additivity of measure does not help",
       "**Continued Fraction Engineering:** Marstrand's construction exploits the continued fraction expansion $\\alpha = [a_0; a_1, a_2, \\ldots]$. By choosing $E$ to 'track' the specific convergents of $\\alpha$, one can make $\\{k\\alpha\\}$ systematically avoid $E$, breaking equidistribution",
-      "**Intervals vs. General Sets:** Weyl's original theorem shows equidistribution in intervals for ALL irrational $\\alpha$—no exceptional set at all. The failure only occurs for general measurable sets, highlighting how much harder the geometry of arbitrary sets is compared to intervals",
+      "**Intervals vs. General Sets:** Weyl's original theorem shows equidistribution in intervals for ALL irrational $\\alpha$\u2014no exceptional set at all. The failure only occurs for general measurable sets, highlighting how much harder the geometry of arbitrary sets is compared to intervals",
       "**Discrepancy Theory Connection:** The failure of Khintchine's conjecture is intimately related to discrepancy theory: the discrepancy $D_n(\\alpha, E) = |\\frac{1}{n}\\sum \\mathbf{1}_{\\{k\\alpha\\} \\in E} - \\lambda(E)|$ may not tend to zero for specially constructed $E$",
       "**A Template for Quantifier Failure:** This problem serves as a canonical example in analysis of why $\\forall x\\; \\forall^{\\text{a.e.}} y\\; P(x,y)$ does not imply $\\forall^{\\text{a.e.}} y\\; \\forall x\\; P(x,y)$, even when $P$ is 'nice' (equidistribution)"
     ],
@@ -84,16 +84,16 @@
       "title": "Fractional Parts and Indicator",
       "startLine": 40,
       "endLine": 61,
-      "summary": "Defines `frac x = x - ⌊x⌋` with proved bounds $0 \\leq \\{x\\} < 1$ (via `Int.floor_le` and `Int.sub_one_lt_floor`). Defines `fracSequence α k = \\{k\\alpha\\}$ and the indicator function for set membership.",
-      "mathContext": "Defines `frac x = x - ⌊x⌋` with proved bounds $0 \\leq \\{x\\} < 1$ (via `Int.floor_le` and `Int.sub_one_lt_floor`). Defines `fracSequence α k = \\{k\\alpha\\}$ and the indicator function for set membership."
+      "summary": "Defines `frac x = x - \u230ax\u230b` with proved bounds $0 \\leq \\{x\\} < 1$ (via `Int.floor_le` and `Int.sub_one_lt_floor`). Defines `fracSequence \u03b1 k = \\{k\\alpha\\}$ and the indicator function for set membership.",
+      "mathContext": "Defines `frac x = x - \u230ax\u230b` with proved bounds $0 \\leq \\{x\\} < 1$ (via `Int.floor_le` and `Int.sub_one_lt_floor`). Defines `fracSequence \u03b1 k = \\{k\\alpha\\}$ and the indicator function for set membership."
     },
     {
       "id": "counting-hits",
       "title": "Counting Hits and Empirical Frequency",
       "startLine": 62,
       "endLine": 77,
-      "summary": "Defines `countInE α E n` using `Finset.filter` to count $|\\{k \\leq n : \\{k\\alpha\\} \\in E\\}|$. Defines `empiricalFrequency` as this count divided by $n$, and `IsEquidistributed α E μ` as the `Tendsto` limit condition.",
-      "mathContext": "Defines `countInE α E n` using `Finset.filter` to count $|\\{k \\leq n : \\{k\\alpha\\} \\in E\\}|$. Defines `empiricalFrequency` as this count divided by $n$, and `IsEquidistributed α E μ` as the `Tendsto` limit condition."
+      "summary": "Defines `countInE \u03b1 E n` using `Finset.filter` to count $|\\{k \\leq n : \\{k\\alpha\\} \\in E\\}|$. Defines `empiricalFrequency` as this count divided by $n$, and `IsEquidistributed \u03b1 E \u03bc` as the `Tendsto` limit condition.",
+      "mathContext": "Defines `countInE \u03b1 E n` using `Finset.filter` to count $|\\{k \\leq n : \\{k\\alpha\\} \\in E\\}|$. Defines `empiricalFrequency` as this count divided by $n$, and `IsEquidistributed \u03b1 E \u03bc` as the `Tendsto` limit condition."
     },
     {
       "id": "weyl-theorem",
@@ -148,15 +148,15 @@
       "title": "Summary Theorems",
       "startLine": 192,
       "endLine": 208,
-      "summary": "Proves `erdos_994 : ¬KhintchineConjecture` from `marstrand_disproof`, `erdos_994_disproof` pairing the negative result with `weyl_is_true`, and `weyl_vs_khintchine` combining both directions into a single conjunction.",
-      "mathContext": "Proves `erdos_994 : ¬KhintchineConjecture` from `marstrand_disproof`, `erdos_994_disproof` pairing the negative result with `weyl_is_true`, and `weyl_vs_khintchine` combining both directions into a single conjunction."
+      "summary": "Proves `erdos_994 : \u00acKhintchineConjecture` from `marstrand_disproof`, `erdos_994_disproof` pairing the negative result with `weyl_is_true`, and `weyl_vs_khintchine` combining both directions into a single conjunction.",
+      "mathContext": "Proves `erdos_994 : \u00acKhintchineConjecture` from `marstrand_disproof`, `erdos_994_disproof` pairing the negative result with `weyl_is_true`, and `weyl_vs_khintchine` combining both directions into a single conjunction."
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #994 by carefully formalizing both what is true (Weyl's equidistribution theorem) and what is false (Khintchine's conjecture), making the quantifier difference explicit. The core definitions (`frac`, `fracSequence`, `empiricalFrequency`, `IsEquidistributed`) are fully formalized with two proved properties of the fractional part. Weyl's theorem and Marstrand's disproof are axiomatized. The summary theorems combine both results, and `bad_set_exists` captures the universal nature of the counterexample.",
-    "implications": "**Theoretical Significance**: **Connections and Implications**\n\n1. **Ergodic Theory:** The failure of Khintchine's conjecture reflects a fundamental limitation of pointwise ergodic theorems—the irrational rotation $x \\mapsto x + \\alpha$ is ergodic, but equidistribution in all measurable sets simultaneously is a strictly stronger condition than ergodicity\n\n2. **Continued Fractions and Diophantine Approximation:** Marstrand's construction depends on the Diophantine properties of $\\alpha$ encoded in its continued fraction expansion, connecting this problem to the metric theory of continued fractions\n\n**3. Discrepancy Theory:** The failure of equidistribution for some $E$ means the sequence $\\{k\\alpha\\}$ has unbounded discrepancy with respect to certain test sets, linking to the broader theory of uniform distribution modulo 1\n\n4. **Measure-Theoretic Subtleties:** This is a canonical example of why $\\forall x\\; \\forall^{\\text{a.e.}} y$ does not imply $\\forall^{\\text{a.e.}} y\\; \\forall x$—the uncountable union of null sets need not be null\n\n5. **Fourier Analysis:** Weyl's criterion connects equidistribution to the decay of exponential sums $\\sum e^{2\\pi i k \\alpha}$, placing this problem at the intersection of harmonic analysis and number theory.",
+    "summary": "This formalization captures Erd\u0151s Problem #994 by carefully formalizing both what is true (Weyl's equidistribution theorem) and what is false (Khintchine's conjecture), making the quantifier difference explicit. The core definitions (`frac`, `fracSequence`, `empiricalFrequency`, `IsEquidistributed`) are fully formalized with two proved properties of the fractional part. Weyl's theorem and Marstrand's disproof are axiomatized. The summary theorems combine both results, and `bad_set_exists` captures the universal nature of the counterexample.",
+    "implications": "**Theoretical Significance**: **Connections and Implications**\n\n1. **Ergodic Theory:** The failure of Khintchine's conjecture reflects a fundamental limitation of pointwise ergodic theorems\u2014the irrational rotation $x \\mapsto x + \\alpha$ is ergodic, but equidistribution in all measurable sets simultaneously is a strictly stronger condition than ergodicity\n\n2. **Continued Fractions and Diophantine Approximation:** Marstrand's construction depends on the Diophantine properties of $\\alpha$ encoded in its continued fraction expansion, connecting this problem to the metric theory of continued fractions\n\n**3. Discrepancy Theory:** The failure of equidistribution for some $E$ means the sequence $\\{k\\alpha\\}$ has unbounded discrepancy with respect to certain test sets, linking to the broader theory of uniform distribution modulo 1\n\n4. **Measure-Theoretic Subtleties:** This is a canonical example of why $\\forall x\\; \\forall^{\\text{a.e.}} y$ does not imply $\\forall^{\\text{a.e.}} y\\; \\forall x$\u2014the uncountable union of null sets need not be null\n\n5. **Fourier Analysis:** Weyl's criterion connects equidistribution to the decay of exponential sums $\\sum e^{2\\pi i k \\alpha}$, placing this problem at the intersection of harmonic analysis and number theory.",
     "openQuestions": [
-      "For which classes of measurable sets $E$ does a Khintchine-type statement hold? The problem is trivially true for intervals and finite unions of intervals—where exactly is the boundary?",
+      "For which classes of measurable sets $E$ does a Khintchine-type statement hold? The problem is trivially true for intervals and finite unions of intervals\u2014where exactly is the boundary?",
       "Can the 'bad set' $E_\\alpha$ in Marstrand's construction be taken to have any prescribed measure $\\lambda(E) \\in (0,1)$?",
       "What is the Hausdorff dimension of the set of $\\alpha$ for which a given $E$ fails equidistribution?",
       "Is there a quantitative version: for Marstrand's bad set, how far from $\\lambda(E)$ can the empirical frequency stay?",
@@ -187,17 +187,17 @@
     {
       "targetId": "erdos-990",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: analysis, discrepancy, equidistribution"
+      "description": "Related Erd\u0151s problem sharing themes: analysis, discrepancy, equidistribution"
     },
     {
       "targetId": "erdos-997",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: analysis, discrepancy, equidistribution"
+      "description": "Related Erd\u0151s problem sharing themes: analysis, discrepancy, equidistribution"
     },
     {
       "targetId": "erdos-998",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: analysis, discrepancy, equidistribution"
+      "description": "Related Erd\u0151s problem sharing themes: analysis, discrepancy, equidistribution"
     }
   ]
 }


### PR DESCRIPTION
## Fix

Corrects stale `assumptions` text in 10 gallery proof `meta.json` files.

## Changes

| Proof | Old count | New count |
|-------|-----------|-----------|
| erdos-1053 | 6 | 1 |
| erdos-1025 | 9 | 4 |
| erdos-1013 | 6 | 1 |
| erdos-994 | 6 | 2 |
| erdos-99 | 5 | 1 |
| erdos-989 | 6 | 2 |
| erdos-985 | 6 | 2 |
| erdos-973 | 8 | 4 |
| erdos-970 | 12 | 8 |
| erdos-966 | 10 | 6 |

---
Automated fix by lean-mechanic agent.