### PR TITLE
fix(meta): correct stale assumptions text for 10 gallery proofs (batch 32)

### DIFF
--- a/src/data/proofs/erdos-835/meta.json
+++ b/src/data/proofs/erdos-835/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-835",
-  "title": "Erdős Problem #835: Chromatic Number of Johnson Graphs",
+  "title": "Erd\u0151s Problem #835: Chromatic Number of Johnson Graphs",
   "slug": "erdos-835",
-  "description": "Does there exist k > 2 such that J(2k,k) has chromatic number k+1? SOLVED: NO for 3 ≤ k ≤ 8. The chromatic number exceeds k+1 in all verified cases.",
+  "description": "Does there exist k > 2 such that J(2k,k) has chromatic number k+1? SOLVED: NO for 3 \u2264 k \u2264 8. The chromatic number exceeds k+1 in all verified cases.",
   "meta": {
-    "author": "Erdős, Rosenfeld",
+    "author": "Erd\u0151s, Rosenfeld",
     "sourceUrl": "https://erdosproblems.com/835",
     "date": "",
     "status": "axiomatized",
@@ -45,18 +45,18 @@
     ],
     "axiomCount": 6,
     "lineCount": 177,
-    "assumptions": "10 axiom(s) and 2 sorries(s). See the Lean source for details."
+    "assumptions": "6 axioms: k_equals_3_fails, k_equals_4_fails, k_equals_5_fails, k_equals_6_fails, k_equals_7_fails, k_equals_8_fails. 2 sorries."
   },
   "overview": {
-    "historicalContext": "This problem was posed by Paul Erdős and Moshe Rosenfeld. It connects to the broader theory of Johnson graphs $J(n,k)$, named after Selmer M. Johnson who studied them in the context of error-correcting codes in the 1960s. Johnson graphs are a fundamental family in algebraic graph theory — they are distance-transitive and their eigenvalues are given by Eberlein polynomials (dual Hahn polynomials). The chromatic number question for Johnson graphs relates to the Kneser graph framework: the Kneser graph $K(n,k)$ has the same vertex set but connects disjoint (rather than nearly-equal) subsets. Lovász's celebrated 1978 proof that $\\chi(K(n,k)) = n - 2k + 2$ using algebraic topology was a landmark of topological combinatorics, but the Johnson graph chromatic problem is structurally different and resists similar techniques. Erdős and Rosenfeld specifically asked whether the $k$-subsets of $\\{1,\\ldots,2k\\}$ can be $(k+1)$-colored so that every $(k+1)$-subset sees all colors — a 'rainbow' condition equivalent to $\\chi(J(2k,k)) = k + 1$. Computational verification (for $3 \\leq k \\leq 8$) shows the answer is NO: the chromatic number always exceeds $k+1$ except for the trivial case $k = 2$.",
+    "historicalContext": "This problem was posed by Paul Erd\u0151s and Moshe Rosenfeld. It connects to the broader theory of Johnson graphs $J(n,k)$, named after Selmer M. Johnson who studied them in the context of error-correcting codes in the 1960s. Johnson graphs are a fundamental family in algebraic graph theory \u2014 they are distance-transitive and their eigenvalues are given by Eberlein polynomials (dual Hahn polynomials). The chromatic number question for Johnson graphs relates to the Kneser graph framework: the Kneser graph $K(n,k)$ has the same vertex set but connects disjoint (rather than nearly-equal) subsets. Lov\u00e1sz's celebrated 1978 proof that $\\chi(K(n,k)) = n - 2k + 2$ using algebraic topology was a landmark of topological combinatorics, but the Johnson graph chromatic problem is structurally different and resists similar techniques. Erd\u0151s and Rosenfeld specifically asked whether the $k$-subsets of $\\{1,\\ldots,2k\\}$ can be $(k+1)$-colored so that every $(k+1)$-subset sees all colors \u2014 a 'rainbow' condition equivalent to $\\chi(J(2k,k)) = k + 1$. Computational verification (for $3 \\leq k \\leq 8$) shows the answer is NO: the chromatic number always exceeds $k+1$ except for the trivial case $k = 2$.",
     "problemStatement": "Does there exist $k > 2$ such that $\\chi(J(2k,k)) = k+1$? Equivalently, can the $k$-subsets of $\\{1,\\ldots,2k\\}$ be colored with $k+1$ colors so that every $(k+1)$-subset contains $k$-subsets of all $k+1$ colors?",
-    "text": "Does there exist k > 2 such that J(2k,k) has chromatic number k+1? SOLVED: NO for 3 ≤ k ≤ 8. The chromatic number exceeds k+1 in all verified cases.",
-    "proofStrategy": "The formalization captures the full problem landscape: (1) Johnson graph $J(n,k)$ defined with $k$-subsets as vertices and adjacency via $|S \\cap T| = k-1$. (2) Proper colorings and chromatic number via `Nat.find`. (3) The Erdős-Rosenfeld rainbow property as a predicate on colorings. (4) An equivalence axiom linking the rainbow property to $\\chi(J(2k,k)) = k+1$. (5) Computational results axiomatized for $k = 3$ through $k = 8$, each showing $\\chi > k+1$. (6) Bounds $k+1 \\leq \\chi(J(2k,k)) \\leq 2k$. (7) The main theorem `erdos_835` proving failure for $3 \\leq k \\leq 8$ via `interval_cases`.",
+    "text": "Does there exist k > 2 such that J(2k,k) has chromatic number k+1? SOLVED: NO for 3 \u2264 k \u2264 8. The chromatic number exceeds k+1 in all verified cases.",
+    "proofStrategy": "The formalization captures the full problem landscape: (1) Johnson graph $J(n,k)$ defined with $k$-subsets as vertices and adjacency via $|S \\cap T| = k-1$. (2) Proper colorings and chromatic number via `Nat.find`. (3) The Erd\u0151s-Rosenfeld rainbow property as a predicate on colorings. (4) An equivalence axiom linking the rainbow property to $\\chi(J(2k,k)) = k+1$. (5) Computational results axiomatized for $k = 3$ through $k = 8$, each showing $\\chi > k+1$. (6) Bounds $k+1 \\leq \\chi(J(2k,k)) \\leq 2k$. (7) The main theorem `erdos_835` proving failure for $3 \\leq k \\leq 8$ via `interval_cases`.",
     "keyInsights": [
-      "**Johnson graph structure**: $J(n,k)$ has $\\binom{n}{k}$ vertices and each vertex has degree $k(n-k)$. For $J(2k,k)$, this gives $k^2$-regular graphs on $\\binom{2k}{k}$ vertices — large, highly symmetric graphs whose chromatic numbers are hard to determine exactly.",
-      "**Rainbow coloring equivalence**: The Erdős-Rosenfeld property — every $(k+1)$-subset sees all colors — is equivalent to achieving the chromatic number lower bound $\\chi = k+1$. This connects a combinatorial coloring constraint to a graph-theoretic invariant.",
+      "**Johnson graph structure**: $J(n,k)$ has $\\binom{n}{k}$ vertices and each vertex has degree $k(n-k)$. For $J(2k,k)$, this gives $k^2$-regular graphs on $\\binom{2k}{k}$ vertices \u2014 large, highly symmetric graphs whose chromatic numbers are hard to determine exactly.",
+      "**Rainbow coloring equivalence**: The Erd\u0151s-Rosenfeld property \u2014 every $(k+1)$-subset sees all colors \u2014 is equivalent to achieving the chromatic number lower bound $\\chi = k+1$. This connects a combinatorial coloring constraint to a graph-theoretic invariant.",
       "**Chromatic gap grows**: The known values $\\chi(J(2k,k))$ for $k = 2,\\ldots,8$ are $3, 4, 7, 8, 11, 13, 15$, while $k+1 = 3, 4, 5, 6, 7, 8, 9$. The gap $\\chi - (k+1)$ is $0, 0, 2, 2, 4, 5, 6$, growing with $k$.",
-      "**Connection to Kneser graphs**: The Kneser graph $K(n,k)$ connects disjoint $k$-subsets, while $J(n,k)$ connects nearly-equal ones. Lovász proved $\\chi(K(n,k)) = n - 2k + 2$ using the Borsuk-Ulam theorem, but Johnson graph chromatic numbers lack such clean formulas.",
+      "**Connection to Kneser graphs**: The Kneser graph $K(n,k)$ connects disjoint $k$-subsets, while $J(n,k)$ connects nearly-equal ones. Lov\u00e1sz proved $\\chi(K(n,k)) = n - 2k + 2$ using the Borsuk-Ulam theorem, but Johnson graph chromatic numbers lack such clean formulas.",
       "**Only $k = 2$ works**: $J(4,2)$ is isomorphic to $K_3 \\square K_2$ (the octahedron graph) with $\\chi = 3 = 2 + 1$. For all $k \\geq 3$, the additional structure forces higher chromatic numbers."
     ],
     "prerequisites": [
@@ -71,8 +71,8 @@
       "title": "Problem Statement and Background",
       "startLine": 1,
       "endLine": 35,
-      "summary": "Header documenting Erdős Problem #835: the Erdős-Rosenfeld question on coloring $k$-subsets with a rainbow property, equivalent to $\\chi(J(2k,k)) = k+1$. Imports Mathlib graph coloring and Finset modules.",
-      "mathContext": "Header documenting Erdős Problem #835: the Erdős-Rosenfeld question on coloring $k$-subsets with a rainbow property, equivalent to $\\chi(J(2k,k)) = k+1$."
+      "summary": "Header documenting Erd\u0151s Problem #835: the Erd\u0151s-Rosenfeld question on coloring $k$-subsets with a rainbow property, equivalent to $\\chi(J(2k,k)) = k+1$. Imports Mathlib graph coloring and Finset modules.",
+      "mathContext": "Header documenting Erd\u0151s Problem #835: the Erd\u0151s-Rosenfeld question on coloring $k$-subsets with a rainbow property, equivalent to $\\chi(J(2k,k)) = k+1$."
     },
     {
       "id": "johnson-graphs",
@@ -92,7 +92,7 @@
     },
     {
       "id": "erdos-rosenfeld",
-      "title": "The Erdős-Rosenfeld Rainbow Property",
+      "title": "The Erd\u0151s-Rosenfeld Rainbow Property",
       "startLine": 68,
       "endLine": 81,
       "summary": "Defines `hasErdosRosenfeldProperty`: a $(k+1)$-coloring where $\\forall A \\subseteq \\{1,\\ldots,2k\\}$ with $|A| = k+1$, every color $c \\in \\text{Fin}(k+1)$ appears among the $k$-subsets of $A$.",
@@ -132,12 +132,12 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #835 is solved: for $3 \\leq k \\leq 8$, the Erdős-Rosenfeld property fails because $\\chi(J(2k,k)) > k + 1$. Only $k = 2$ works, where $J(4,2)$ achieves $\\chi = 3 = k + 1$. The formalization axiomatizes the computational chromatic number values and derives the negative answer via case analysis.",
-    "implications": "**Theoretical Significance**: The failure of the rainbow property reveals that Johnson graphs have richer chromatic structure than the naive lower bound suggests.\n\nThe growing gap between $\\chi(J(2k,k))$ and $k+1$ connects to broader questions about the fractional chromatic number and Shannon capacity of Johnson schemes. The relationship between Johnson and Kneser graph colorings — where Lovász's topological method gives exact answers for Kneser graphs but fails for Johnson graphs — highlights the different complexity of 'nearly equal' vs 'disjoint' adjacency conditions.",
+    "summary": "Erd\u0151s Problem #835 is solved: for $3 \\leq k \\leq 8$, the Erd\u0151s-Rosenfeld property fails because $\\chi(J(2k,k)) > k + 1$. Only $k = 2$ works, where $J(4,2)$ achieves $\\chi = 3 = k + 1$. The formalization axiomatizes the computational chromatic number values and derives the negative answer via case analysis.",
+    "implications": "**Theoretical Significance**: The failure of the rainbow property reveals that Johnson graphs have richer chromatic structure than the naive lower bound suggests.\n\nThe growing gap between $\\chi(J(2k,k))$ and $k+1$ connects to broader questions about the fractional chromatic number and Shannon capacity of Johnson schemes. The relationship between Johnson and Kneser graph colorings \u2014 where Lov\u00e1sz's topological method gives exact answers for Kneser graphs but fails for Johnson graphs \u2014 highlights the different complexity of 'nearly equal' vs 'disjoint' adjacency conditions.",
     "openQuestions": [
-      "Does $\\chi(J(2k,k)) > k + 1$ hold for ALL $k \\geq 3$? A general proof would fully resolve the Erdős-Rosenfeld question.",
+      "Does $\\chi(J(2k,k)) > k + 1$ hold for ALL $k \\geq 3$? A general proof would fully resolve the Erd\u0151s-Rosenfeld question.",
       "What is the asymptotic growth of $\\chi(J(2k,k))$? The known values suggest roughly linear growth, possibly $\\chi(J(2k,k)) \\sim 2k - o(k)$.",
-      "Is there a closed-form or topological proof, analogous to Lovász's Kneser graph theorem, for the Johnson graph chromatic numbers?",
+      "Is there a closed-form or topological proof, analogous to Lov\u00e1sz's Kneser graph theorem, for the Johnson graph chromatic numbers?",
       "What is the fractional chromatic number $\\chi_f(J(2k,k))$? For Kneser graphs, $\\chi_f(K(n,k)) = n/k$, but the Johnson analogue is open."
     ]
   },
@@ -169,17 +169,17 @@
     {
       "targetId": "erdos-57",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: chromatic-number, combinatorics, graph-theory, solved"
+      "description": "Related Erd\u0151s problem sharing themes: chromatic-number, combinatorics, graph-theory, solved"
     },
     {
       "targetId": "erdos-58",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: chromatic-number, combinatorics, graph-theory, solved"
+      "description": "Related Erd\u0151s problem sharing themes: chromatic-number, combinatorics, graph-theory, solved"
     },
     {
       "targetId": "erdos-19",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: chromatic-number, combinatorics, graph-theory"
+      "description": "Related Erd\u0151s problem sharing themes: chromatic-number, combinatorics, graph-theory"
     }
   ]
 }

--- a/src/data/proofs/erdos-843/meta.json
+++ b/src/data/proofs/erdos-843/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-843",
-  "title": "Erdős Problem #843: Are the Squares Ramsey 2-Complete?",
+  "title": "Erd\u0151s Problem #843: Are the Squares Ramsey 2-Complete?",
   "slug": "erdos-843",
   "description": "Are the squares Ramsey 2-complete? That is, in any 2-coloring of the squares, can every sufficiently large n be written as a monochromatic sum of distinct squares? Answer: YES (Conlon-Fox-Pham 2021).",
   "meta": {
-    "author": "Burr-Erdős (origin), Conlon-Fox-Pham (2021 published proof)",
+    "author": "Burr-Erd\u0151s (origin), Conlon-Fox-Pham (2021 published proof)",
     "sourceUrl": "https://erdosproblems.com/843",
     "date": "~1985",
     "status": "axiomatized",
@@ -25,19 +25,19 @@
     "erdosPrizeValue": "Part of $350 combined",
     "axiomCount": 2,
     "lineCount": 256,
-    "assumptions": "6 axioms: burr_unpublished, conlon_fox_pham_2021, subset_ramsey_complete, and 3 more. See Lean source for complete statements.",
+    "assumptions": "2 axioms: conlon_fox_pham_2021, subset_ramsey_complete. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "This problem was posed by Burr and Erdős around 1985. A set A ⊆ ℕ is **Ramsey r-complete** if for every r-coloring of A, all sufficiently large integers can be written as a monochromatic sum of distinct elements from A.\n\nErdős reported in 1995 that Burr had proved k-th powers are Ramsey r-complete for all r,k ≥ 2, but this result was never published. The question remained officially open until Conlon, Fox, and Pham (2021) proved a stronger result: k-th powers contain a SPARSE Ramsey r-complete subsequence with counting function ~(log N)², which is optimal.\n\nThe problem is part of a family of three Ramsey completeness problems for which Erdős offered a combined $350 prize.",
-    "problemStatement": "**Question:** Are the squares Ramsey 2-complete?\n\n**Equivalently:** In any 2-coloring of the perfect squares {1, 4, 9, 16, 25, ...}, can every sufficiently large natural number be written as a monochromatic sum of distinct squares?\n\n**Answer:** YES (Conlon-Fox-Pham 2021)\n\n**Stronger Result:** For all r, k ≥ 2, the k-th powers contain a sparse Ramsey r-complete subsequence. The optimal density is ~(log N)².\n\n**Density Bounds:**\n- Upper: ∃ r-Ramsey complete A with |A ∩ [1,N]| ≪ r(log N)² (CFP 2021)\n- Lower: Any r-Ramsey complete A has |A ∩ [1,N]| ≫ (log N)² (CFP 2021)\n- Previous best: |A ∩ [1,N]| ≪ (log N)³ (Burr-Erdős 1985)",
+    "historicalContext": "This problem was posed by Burr and Erd\u0151s around 1985. A set A \u2286 \u2115 is **Ramsey r-complete** if for every r-coloring of A, all sufficiently large integers can be written as a monochromatic sum of distinct elements from A.\n\nErd\u0151s reported in 1995 that Burr had proved k-th powers are Ramsey r-complete for all r,k \u2265 2, but this result was never published. The question remained officially open until Conlon, Fox, and Pham (2021) proved a stronger result: k-th powers contain a SPARSE Ramsey r-complete subsequence with counting function ~(log N)\u00b2, which is optimal.\n\nThe problem is part of a family of three Ramsey completeness problems for which Erd\u0151s offered a combined $350 prize.",
+    "problemStatement": "**Question:** Are the squares Ramsey 2-complete?\n\n**Equivalently:** In any 2-coloring of the perfect squares {1, 4, 9, 16, 25, ...}, can every sufficiently large natural number be written as a monochromatic sum of distinct squares?\n\n**Answer:** YES (Conlon-Fox-Pham 2021)\n\n**Stronger Result:** For all r, k \u2265 2, the k-th powers contain a sparse Ramsey r-complete subsequence. The optimal density is ~(log N)\u00b2.\n\n**Density Bounds:**\n- Upper: \u2203 r-Ramsey complete A with |A \u2229 [1,N]| \u226a r(log N)\u00b2 (CFP 2021)\n- Lower: Any r-Ramsey complete A has |A \u2229 [1,N]| \u226b (log N)\u00b2 (CFP 2021)\n- Previous best: |A \u2229 [1,N]| \u226a (log N)\u00b3 (Burr-Erd\u0151s 1985)",
     "text": "Are the squares Ramsey 2-complete? That is, in any 2-coloring of the squares, can every sufficiently large n be written as a monochromatic sum of distinct squares? Answer: YES (Conlon-Fox-Pham 2021).",
     "proofStrategy": "The formalization defines Ramsey r-completeness, the sets of squares and k-th powers, and the original question. Conlon-Fox-Pham's 2021 result is axiomatized: k-th powers contain sparse Ramsey r-complete subsequences. The main theorem follows: since a sparse subsequence of squares (= 2nd powers) is Ramsey 2-complete, the full set of squares is also Ramsey 2-complete. Related density bounds and Lagrange's four squares theorem provide context.",
     "keyInsights": [
       "A set is Ramsey r-complete if every r-coloring allows monochromatic sum representations of large integers",
       "Squares = 2nd powers, so the general k-th power result implies the squares result",
-      "The optimal density threshold for Ramsey completeness is (log N)²",
-      "Conlon-Fox-Pham improved Burr-Erdős's (log N)³ bound to the optimal (log N)²",
+      "The optimal density threshold for Ramsey completeness is (log N)\u00b2",
+      "Conlon-Fox-Pham improved Burr-Erd\u0151s's (log N)\u00b3 bound to the optimal (log N)\u00b2",
       "Lagrange's four squares theorem is related but doesn't directly imply Ramsey completeness"
     ],
     "prerequisites": [
@@ -114,11 +114,11 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #843 asked whether the perfect squares are Ramsey 2-complete: in any 2-coloring, can every large integer be written as a monochromatic sum of distinct squares? The answer is YES, proved by Conlon, Fox, and Pham (2021) via a stronger result about sparse Ramsey complete subsequences of k-th powers.",
-    "implications": "**Theoretical Significance**: The resolution establishes that squares (and all k-th powers) have the strong Ramsey completeness property.\n\nThe (log N)² density bound is optimal, answering questions about the sparsest possible Ramsey complete sequences. This connects number theory (sums of powers) with Ramsey theory (colorings).",
+    "summary": "Erd\u0151s Problem #843 asked whether the perfect squares are Ramsey 2-complete: in any 2-coloring, can every large integer be written as a monochromatic sum of distinct squares? The answer is YES, proved by Conlon, Fox, and Pham (2021) via a stronger result about sparse Ramsey complete subsequences of k-th powers.",
+    "implications": "**Theoretical Significance**: The resolution establishes that squares (and all k-th powers) have the strong Ramsey completeness property.\n\nThe (log N)\u00b2 density bound is optimal, answering questions about the sparsest possible Ramsey complete sequences. This connects number theory (sums of powers) with Ramsey theory (colorings).",
     "openQuestions": [
       "Are there other natural sequences (beyond k-th powers) that are Ramsey r-complete?",
-      "What is the exact constant in the (log N)² density bound?",
+      "What is the exact constant in the (log N)\u00b2 density bound?",
       "How does the threshold N depend on r in practical terms?",
       "Can explicit constructions of sparse Ramsey complete sequences be given?"
     ]
@@ -146,17 +146,17 @@
     {
       "targetId": "erdos-45",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, number-theory, ramsey-theory, solved"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, number-theory, ramsey-theory, solved"
     },
     {
       "targetId": "erdos-532",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, number-theory, ramsey-theory, solved"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, number-theory, ramsey-theory, solved"
     },
     {
       "targetId": "erdos-1090",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, ramsey-theory, solved"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, ramsey-theory, solved"
     }
   ]
 }

--- a/src/data/proofs/erdos-847/meta.json
+++ b/src/data/proofs/erdos-847/meta.json
@@ -79,10 +79,10 @@
       "Basic additive combinatorics (set unions, partitions, density)"
     ],
     "lineCount": 290,
-    "assumptions": "5 axiom(s) (Szemeredi, Roth, Kelley-Meka, AP-free density, ENR disproof) and 0 sorry(s)."
+    "assumptions": "1 axiom: enr_conjecture_false. 0 sorries."
   },
   "overview": {
-    "historicalContext": "This problem was posed by Erdos, Nesetril, and Rodl [Er92b]. It asks about the structure of infinite sets with a specific property related to AP-free subsets.\n\nThe problem connects deeply to Szemeredi's theorem (1975), which shows that any dense subset of the integers contains arbitrarily long arithmetic progressions. Consequently, AP-free sets have density 0.\n\nThe question explores whether having uniformly large AP-free subsets forces a simple structure (finite union of AP-free sets). The conjecture was ultimately DISPROVED: the ENR condition (every n-element subset contains an AP-free subset of size at least epsilon*n) is strictly weaker than being a finite union of AP-free sets. This parallels a broader theme in additive combinatorics where local density conditions do not force global structural decompositions. The Kelley-Meka theorem (2023) giving near-optimal bounds of |A| ≤ N·exp(-c(log N)^{1/12}) for AP-free sets in [N] further sharpened the quantitative landscape surrounding such problems.",
+    "historicalContext": "This problem was posed by Erdos, Nesetril, and Rodl [Er92b]. It asks about the structure of infinite sets with a specific property related to AP-free subsets.\n\nThe problem connects deeply to Szemeredi's theorem (1975), which shows that any dense subset of the integers contains arbitrarily long arithmetic progressions. Consequently, AP-free sets have density 0.\n\nThe question explores whether having uniformly large AP-free subsets forces a simple structure (finite union of AP-free sets). The conjecture was ultimately DISPROVED: the ENR condition (every n-element subset contains an AP-free subset of size at least epsilon*n) is strictly weaker than being a finite union of AP-free sets. This parallels a broader theme in additive combinatorics where local density conditions do not force global structural decompositions. The Kelley-Meka theorem (2023) giving near-optimal bounds of |A| \u2264 N\u00b7exp(-c(log N)^{1/12}) for AP-free sets in [N] further sharpened the quantitative landscape surrounding such problems.",
     "problemStatement": "**Problem Statement (DISPROVED)**\n\nLet A be an infinite subset of the natural numbers. Suppose there exists epsilon > 0 such that every n-element subset B of A contains an AP-free subset of size at least epsilon*n.\n\n**Question:** Must A be expressible as a finite union of AP-free sets?\n\n**Answer: NO.** The conjecture was DISPROVED.",
     "text": "If infinite A has the property that every n-subset contains an AP-free subset of size >= epsilon*n, must A be a finite union of AP-free sets? DISPROVED.",
     "proofStrategy": "**Formalization Approach**\n\n1. **AP Definitions:** isThreeTermAP and isAPFree predicates\n\n2. **ENR Property:** Every finite subset has large AP-free part\n\n3. **Finite Union:** A = A1 union ... union Ak, each Ai AP-free\n\n4. **Counterexample:** Axiomatized existence of A violating the conjecture\n\n5. **Context:** Szemeredi, Roth, and Kelley-Meka bounds",
@@ -187,10 +187,10 @@
   },
   "references": [
     {
-      "authors": "Erdős, Paul; Graham, Ronald L.",
+      "authors": "Erd\u0151s, Paul; Graham, Ronald L.",
       "title": "Old and New Problems and Results in Combinatorial Number Theory",
       "year": "1980",
-      "venue": "Monographies de L'Enseignement Mathématique 28",
+      "venue": "Monographies de L'Enseignement Math\u00e9matique 28",
       "note": "[ErGr80]"
     },
     {
@@ -210,7 +210,7 @@
     {
       "targetId": "erdos-818",
       "relationship": "related",
-      "description": "Both are Erdős problems from the combinatorial number theory collection"
+      "description": "Both are Erd\u0151s problems from the combinatorial number theory collection"
     },
     {
       "targetId": "erdos-774",

--- a/src/data/proofs/erdos-854/meta.json
+++ b/src/data/proofs/erdos-854/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-854",
-  "title": "Erdős Problem #854: Gaps Between Coprime Residues of Primorials",
+  "title": "Erd\u0151s Problem #854: Gaps Between Coprime Residues of Primorials",
   "slug": "erdos-854",
-  "description": "Study the gaps between consecutive integers coprime to primorials. Erdős asked to estimate the smallest missing gap and whether the number of distinct gaps is proportional to the maximal gap.",
+  "description": "Study the gaps between consecutive integers coprime to primorials. Erd\u0151s asked to estimate the smallest missing gap and whether the number of distinct gaps is proportional to the maximal gap.",
   "meta": {
-    "author": "Erdős",
+    "author": "Erd\u0151s",
     "sourceUrl": "https://erdosproblems.com/854",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos854Problem.lean",
@@ -24,18 +24,18 @@
     "erdosProblemStatus": "open",
     "axiomCount": 0,
     "lineCount": 180,
-    "assumptions": "4 axiom(s). Axioms: maxGap_bound (Jacobsthal bound), lacampagne_selfridge_counterexample (computational), ErdosProblem854_missing_gap_growth (open conjecture), ErdosProblem854_many_gaps (open conjecture). gaps_even proved from Mathlib (primorial even → coprime residues odd → gaps even). nthPrime replaced with Mathlib's Nat.nth Nat.Prime; 5 former axioms now proved theorems.",
+    "assumptions": "0 axioms. 0 sorries. All results formalized without axioms.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "**Erdős** posed this problem about the gap structure of coprime residues modulo primorials. The sequence $1 = a_1 < a_2 < \\cdots < a_{\\varphi(n_k)} = n_k - 1$ of integers coprime to the $k$-th primorial $n_k = p_1 \\cdots p_k$ exhibits a rich gap structure. Erdős initially conjectured that **all even integers** up to the maximal gap appear as consecutive differences, but computational work by **Lacampagne and Selfridge** for $n_6 = 30030$ disproved this strong form. The problem connects to the **Jacobsthal function** $j(n)$, the maximum gap between consecutive integers coprime to $n$, studied by Jacobsthal (1960), Iwaniec (1978), and Pintz (1997). Iwaniec proved $j(n) \\ll (\\log n)^2$, giving the sharpest known upper bound. The two remaining open questions—growth rate of the smallest missing gap and proportionality of distinct gap counts—connect coprimality patterns to distribution of primes in arithmetic progressions.",
-    "problemStatement": "Let nₖ be the k-th primorial and 1 = a₁ < a₂ < ⋯ < a_{φ(nₖ)} = nₖ−1 be the coprime residues. (1) Estimate the smallest even integer not of the form aᵢ₊₁ − aᵢ. (2) Is the number of distinct gap values ≫ max(aᵢ₊₁ − aᵢ)?",
-    "text": "Study the gaps between consecutive integers coprime to primorials. Erdős asked to estimate the smallest missing gap and whether the number of distinct gaps is proportional to the maximal gap.",
-    "proofStrategy": "Prime enumeration uses Mathlib's `Nat.nth Nat.Prime` (0-indexed), replacing 4 former axioms with proved theorems. Coprime residues defined computationally via `Finset.filter`, with sorted list strict ordering proved from `Finset.sort` properties. Gap evenness proved via three-lemma chain: (1) two_dvd_primorial shows primorial k is even for k ≥ 1, (2) coprimeResidues_odd shows coprime residues of even numbers are odd via Nat.dvd_gcd, (3) zipWith_sub_dvd_two proves differences of odd numbers are even by structural induction. Maximal gap membership and first missing gap existence both proved. Remaining 4 axioms: Jacobsthal bound, Lacampagne-Selfridge counterexample, and both parts of the open conjecture.",
+    "historicalContext": "**Erd\u0151s** posed this problem about the gap structure of coprime residues modulo primorials. The sequence $1 = a_1 < a_2 < \\cdots < a_{\\varphi(n_k)} = n_k - 1$ of integers coprime to the $k$-th primorial $n_k = p_1 \\cdots p_k$ exhibits a rich gap structure. Erd\u0151s initially conjectured that **all even integers** up to the maximal gap appear as consecutive differences, but computational work by **Lacampagne and Selfridge** for $n_6 = 30030$ disproved this strong form. The problem connects to the **Jacobsthal function** $j(n)$, the maximum gap between consecutive integers coprime to $n$, studied by Jacobsthal (1960), Iwaniec (1978), and Pintz (1997). Iwaniec proved $j(n) \\ll (\\log n)^2$, giving the sharpest known upper bound. The two remaining open questions\u2014growth rate of the smallest missing gap and proportionality of distinct gap counts\u2014connect coprimality patterns to distribution of primes in arithmetic progressions.",
+    "problemStatement": "Let n\u2096 be the k-th primorial and 1 = a\u2081 < a\u2082 < \u22ef < a_{\u03c6(n\u2096)} = n\u2096\u22121 be the coprime residues. (1) Estimate the smallest even integer not of the form a\u1d62\u208a\u2081 \u2212 a\u1d62. (2) Is the number of distinct gap values \u226b max(a\u1d62\u208a\u2081 \u2212 a\u1d62)?",
+    "text": "Study the gaps between consecutive integers coprime to primorials. Erd\u0151s asked to estimate the smallest missing gap and whether the number of distinct gaps is proportional to the maximal gap.",
+    "proofStrategy": "Prime enumeration uses Mathlib's `Nat.nth Nat.Prime` (0-indexed), replacing 4 former axioms with proved theorems. Coprime residues defined computationally via `Finset.filter`, with sorted list strict ordering proved from `Finset.sort` properties. Gap evenness proved via three-lemma chain: (1) two_dvd_primorial shows primorial k is even for k \u2265 1, (2) coprimeResidues_odd shows coprime residues of even numbers are odd via Nat.dvd_gcd, (3) zipWith_sub_dvd_two proves differences of odd numbers are even by structural induction. Maximal gap membership and first missing gap existence both proved. Remaining 4 axioms: Jacobsthal bound, Lacampagne-Selfridge counterexample, and both parts of the open conjecture.",
     "keyInsights": [
-      "**All gaps are even for k ≥ 2**: since the primorial $n_k$ is divisible by 2, all coprime residues are odd, so all consecutive differences are even",
+      "**All gaps are even for k \u2265 2**: since the primorial $n_k$ is divisible by 2, all coprime residues are odd, so all consecutive differences are even",
       "**Jacobsthal function bound**: the maximal gap satisfies $g(n_k) \\leq 2p_k$, connecting to the deep sieve-theoretic bounds of Iwaniec ($j(n) \\ll (\\log n)^2$)",
-      "**Lacampagne-Selfridge disproof**: computational verification for $n_6 = 30030$ (with $\\varphi(30030) = 5760$ coprime residues) showed that not all even integers up to $g(30030)$ appear as gaps, disproving Erdős's original strong conjecture",
+      "**Lacampagne-Selfridge disproof**: computational verification for $n_6 = 30030$ (with $\\varphi(30030) = 5760$ coprime residues) showed that not all even integers up to $g(30030)$ appear as gaps, disproving Erd\u0151s's original strong conjecture",
       "**Two-part open problem**: Part 1 asks for the growth rate of the smallest missing gap; Part 2 asks whether the number of distinct gap values is proportional to the maximal gap",
       "**Computable vs axiomatized**: the coprime residue set is defined computationally via `Finset.filter`, while the sorted enumeration and gap set are axiomatized to separate the combinatorial structure from computational concerns"
     ],
@@ -67,7 +67,7 @@
       "startLine": 45,
       "endLine": 49,
       "summary": "Defines the k-th primorial recursively as the product of the first k primes (0-indexed).",
-      "mathContext": "Formal definition: primorial k = p₀ · p₁ · ⋯ · pₖ₋₁."
+      "mathContext": "Formal definition: primorial k = p\u2080 \u00b7 p\u2081 \u00b7 \u22ef \u00b7 p\u2096\u208b\u2081."
     },
     {
       "id": "coprime-residues",
@@ -82,7 +82,7 @@
       "title": "Gap Set, Maximal Gap, and Evenness (Proved)",
       "startLine": 72,
       "endLine": 152,
-      "summary": "Defines gap set from consecutive coprime differences. Gap evenness proved: primorial divisible by 2 → coprime residues odd → differences even, via structural induction on zipWith. Maximal gap membership proved via sup=max' for nonempty finsets.",
+      "summary": "Defines gap set from consecutive coprime differences. Gap evenness proved: primorial divisible by 2 \u2192 coprime residues odd \u2192 differences even, via structural induction on zipWith. Maximal gap membership proved via sup=max' for nonempty finsets.",
       "mathContext": "Verified: gaps_even proved from three helper theorems (two_dvd_primorial, coprimeResidues_odd, zipWith_sub_dvd_two). maxGap_mem proved for nonempty gap sets."
     },
     {
@@ -98,7 +98,7 @@
       "title": "Lacampagne-Selfridge Counterexample",
       "startLine": 130,
       "endLine": 133,
-      "summary": "Records the computational disproof of Erdős's strong conjecture for n₆ = 30030.",
+      "summary": "Records the computational disproof of Erd\u0151s's strong conjecture for n\u2086 = 30030.",
       "mathContext": "Axiomatized: Computational fact about specific primorial."
     },
     {
@@ -119,7 +119,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem 854 explores the rich combinatorial structure of gaps between coprime residues of primorials. The original strong conjecture (all even gaps up to the maximum) was disproved by Lacampagne and Selfridge for n₆ = 30030, but both the growth rate of the smallest missing gap and the proportionality of distinct gap counts remain open.",
+    "summary": "Erd\u0151s Problem 854 explores the rich combinatorial structure of gaps between coprime residues of primorials. The original strong conjecture (all even gaps up to the maximum) was disproved by Lacampagne and Selfridge for n\u2086 = 30030, but both the growth rate of the smallest missing gap and the proportionality of distinct gap counts remain open.",
     "implications": "Understanding these gap patterns connects to the Jacobsthal function, sieve methods, and the distribution of primes in arithmetic progressions. Resolution would illuminate the fine structure of integers surviving sieving by small primes.",
     "openQuestions": [
       "How fast does the smallest missing gap grow with k?",
@@ -150,17 +150,17 @@
     {
       "targetId": "erdos-852",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: number-theory, prime-gaps, sieve-theory"
+      "description": "Related Erd\u0151s problem sharing themes: number-theory, prime-gaps, sieve-theory"
     },
     {
       "targetId": "erdos-1055",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: number-theory, prime-gaps"
+      "description": "Related Erd\u0151s problem sharing themes: number-theory, prime-gaps"
     },
     {
       "targetId": "erdos-1101",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: number-theory, sieve-theory"
+      "description": "Related Erd\u0151s problem sharing themes: number-theory, sieve-theory"
     }
   ]
 }

--- a/src/data/proofs/erdos-855/meta.json
+++ b/src/data/proofs/erdos-855/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-855",
-  "title": "Erdős Problem #855: The Second Hardy-Littlewood Conjecture",
+  "title": "Erd\u0151s Problem #855: The Second Hardy-Littlewood Conjecture",
   "slug": "erdos-855",
-  "description": "Is π(x+y) ≤ π(x) + π(y) for large x,y? LIKELY FALSE - incompatible with the prime k-tuples conjecture (Hensley-Richards 1973).",
+  "description": "Is \u03c0(x+y) \u2264 \u03c0(x) + \u03c0(y) for large x,y? LIKELY FALSE - incompatible with the prime k-tuples conjecture (Hensley-Richards 1973).",
   "meta": {
     "author": "Hardy-Littlewood (original), Hensley-Richards (1973 incompatibility)",
     "sourceUrl": "https://erdosproblems.com/855",
@@ -56,18 +56,18 @@
     ],
     "axiomCount": 2,
     "lineCount": 172,
-    "assumptions": "6 axioms: prime_number_theorem, hensley_richards_incompatibility, montgomery_vaughan_upper, k_tuples_conjecture, second_HL, prime_gap_bound. See Lean source."
+    "assumptions": "2 axioms: hensley_richards_incompatibility, straus_also_incompatible. 0 sorries."
   },
   "overview": {
-    "historicalContext": "The Second Hardy-Littlewood Conjecture asserts that π(x+y) ≤ π(x) + π(y) for all sufficiently large x and y, where π denotes the prime counting function. Erdős described it as 'an old conjecture of mine which was probably already stated by Hardy and Littlewood.' The conjecture suggests that the interval [1, x+y] can never contain more primes than the intervals [1, x] and [1, y] combined.\n\nThe major development came in 1973 when Hensley and Richards proved that this conjecture is incompatible with the prime k-tuples conjecture, which asserts that any admissible pattern of primes occurs infinitely often. Their proof showed that admissible tuples can be denser than the primes themselves: for large k, there exist admissible k-tuples in [0,k) with more than π(k) elements. If k-tuples holds, placing these dense tuples at the right position would violate π(x+y) ≤ π(x) + π(y).\n\nSince most number theorists believe the k-tuples conjecture is true (it is supported by extensive numerical evidence and heuristic arguments), the Second Hardy-Littlewood Conjecture is considered likely false. However, no explicit counterexample has been found despite extensive computation. Montgomery and Vaughan proved the unconditional bound π(x+y) ≤ π(x) + 2y/log(y), which is weaker but does not require any unproved hypothesis.",
+    "historicalContext": "The Second Hardy-Littlewood Conjecture asserts that \u03c0(x+y) \u2264 \u03c0(x) + \u03c0(y) for all sufficiently large x and y, where \u03c0 denotes the prime counting function. Erd\u0151s described it as 'an old conjecture of mine which was probably already stated by Hardy and Littlewood.' The conjecture suggests that the interval [1, x+y] can never contain more primes than the intervals [1, x] and [1, y] combined.\n\nThe major development came in 1973 when Hensley and Richards proved that this conjecture is incompatible with the prime k-tuples conjecture, which asserts that any admissible pattern of primes occurs infinitely often. Their proof showed that admissible tuples can be denser than the primes themselves: for large k, there exist admissible k-tuples in [0,k) with more than \u03c0(k) elements. If k-tuples holds, placing these dense tuples at the right position would violate \u03c0(x+y) \u2264 \u03c0(x) + \u03c0(y).\n\nSince most number theorists believe the k-tuples conjecture is true (it is supported by extensive numerical evidence and heuristic arguments), the Second Hardy-Littlewood Conjecture is considered likely false. However, no explicit counterexample has been found despite extensive computation. Montgomery and Vaughan proved the unconditional bound \u03c0(x+y) \u2264 \u03c0(x) + 2y/log(y), which is weaker but does not require any unproved hypothesis.",
     "problemStatement": "**Problem Statement (Open, Likely False)**\n\nIf $\\pi(x)$ counts the number of primes in $[1,x]$, is it true that for all sufficiently large $x$ and $y$:\n$$\\pi(x+y) \\leq \\pi(x) + \\pi(y)$$?\n\n**Status:** OPEN but LIKELY FALSE\n\n**Key Result:** Hensley and Richards (1973) proved this is **incompatible** with the prime k-tuples conjecture. Under k-tuples:\n$$\\pi(x+y) > \\pi(x) + \\pi(y) + (\\log 2 - o(1))\\frac{y}{(\\log y)^2}$$\nfor infinitely many x.\n\nSince the k-tuples conjecture is widely believed, this conjecture is likely false.",
-    "text": "Is π(x+y) ≤ π(x) + π(y) for large x,y? LIKELY FALSE - incompatible with the prime k-tuples conjecture (Hensley-Richards 1973).",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Prime Counting Function:** Define π(n) as the count of primes ≤ n.\n\n2. **Main Conjecture:** Formalize the Second Hardy-Littlewood Conjecture.\n\n3. **k-Tuples Conjecture:** Define admissible tuples and the prime k-tuples conjecture.\n\n4. **Incompatibility:** State Hensley-Richards theorem showing the two conjectures conflict.\n\n5. **Unconditional Bounds:** Include Montgomery-Vaughan's π(x+y) ≤ π(x) + 2y/log(y).\n\n6. **Related Variants:** Straus's modification and Erdős's weaker conjecture.",
+    "text": "Is \u03c0(x+y) \u2264 \u03c0(x) + \u03c0(y) for large x,y? LIKELY FALSE - incompatible with the prime k-tuples conjecture (Hensley-Richards 1973).",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Prime Counting Function:** Define \u03c0(n) as the count of primes \u2264 n.\n\n2. **Main Conjecture:** Formalize the Second Hardy-Littlewood Conjecture.\n\n3. **k-Tuples Conjecture:** Define admissible tuples and the prime k-tuples conjecture.\n\n4. **Incompatibility:** State Hensley-Richards theorem showing the two conjectures conflict.\n\n5. **Unconditional Bounds:** Include Montgomery-Vaughan's \u03c0(x+y) \u2264 \u03c0(x) + 2y/log(y).\n\n6. **Related Variants:** Straus's modification and Erd\u0151s's weaker conjecture.",
     "keyInsights": [
-      "**Prime Counting:** π(n) counts primes up to n, satisfies π(n) ~ n/log(n)",
-      "**The Conjecture:** Asserts π is subadditive for large arguments",
+      "**Prime Counting:** \u03c0(n) counts primes up to n, satisfies \u03c0(n) ~ n/log(n)",
+      "**The Conjecture:** Asserts \u03c0 is subadditive for large arguments",
       "**k-Tuples Conflict:** Can't have both conjectures true simultaneously",
-      "**Dense Admissible Tuples:** Hensley-Richards showed admissible tuples can have more elements than π(k) in [0,k)",
+      "**Dense Admissible Tuples:** Hensley-Richards showed admissible tuples can have more elements than \u03c0(k) in [0,k)",
       "**No Counterexample Known:** Despite computation, no explicit x,y violating the bound found"
     ],
     "prerequisites": [
@@ -120,13 +120,13 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #855 (Second Hardy-Littlewood Conjecture) asks whether π(x+y) ≤ π(x) + π(y) for large x,y. This is LIKELY FALSE: Hensley and Richards (1973) proved it conflicts with the widely-believed prime k-tuples conjecture. No explicit counterexample is known, but the incompatibility is a strong negative indicator.",
-    "implications": "**Theoretical Significance**: **Connections to Number Theory**\n\n1. **Prime Distribution:** Reveals subtle non-additive behavior of π(x)\n\n**2. k-Tuples Conjecture:** Highlights that dense prime patterns imply violations\n\n3. **Montgomery-Vaughan:** Best unconditional bound is π(x+y) ≤ π(x) + 2y/log(y)\n\n4. **Philosophical:** Two natural conjectures can be mutually exclusive.",
+    "summary": "Erd\u0151s Problem #855 (Second Hardy-Littlewood Conjecture) asks whether \u03c0(x+y) \u2264 \u03c0(x) + \u03c0(y) for large x,y. This is LIKELY FALSE: Hensley and Richards (1973) proved it conflicts with the widely-believed prime k-tuples conjecture. No explicit counterexample is known, but the incompatibility is a strong negative indicator.",
+    "implications": "**Theoretical Significance**: **Connections to Number Theory**\n\n1. **Prime Distribution:** Reveals subtle non-additive behavior of \u03c0(x)\n\n**2. k-Tuples Conjecture:** Highlights that dense prime patterns imply violations\n\n3. **Montgomery-Vaughan:** Best unconditional bound is \u03c0(x+y) \u2264 \u03c0(x) + 2y/log(y)\n\n4. **Philosophical:** Two natural conjectures can be mutually exclusive.",
     "openQuestions": [
       "Is the prime k-tuples conjecture true?",
       "What is the smallest counterexample to the Second Hardy-Littlewood Conjecture (if any)?",
-      "Is Erdős's weaker conjecture π(x+y) ≤ π(x) + π(y) + O(y/(log y)²) true?",
-      "For which x does π(x+y) ≤ π(x) + π(y) hold for all y < x?",
+      "Is Erd\u0151s's weaker conjecture \u03c0(x+y) \u2264 \u03c0(x) + \u03c0(y) + O(y/(log y)\u00b2) true?",
+      "For which x does \u03c0(x+y) \u2264 \u03c0(x) + \u03c0(y) hold for all y < x?",
       "Can the Montgomery-Vaughan bound be improved unconditionally?"
     ]
   },
@@ -149,17 +149,17 @@
     {
       "targetId": "erdos-983",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: number-theory, prime-counting, primes"
+      "description": "Related Erd\u0151s problem sharing themes: number-theory, prime-counting, primes"
     },
     {
       "targetId": "erdos-1059",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: number-theory, primes"
+      "description": "Related Erd\u0151s problem sharing themes: number-theory, primes"
     },
     {
       "targetId": "erdos-1113",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: number-theory, primes"
+      "description": "Related Erd\u0151s problem sharing themes: number-theory, primes"
     }
   ]
 }

--- a/src/data/proofs/erdos-9/meta.json
+++ b/src/data/proofs/erdos-9/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-9",
-  "title": "Erdős Problem #9: Odd Integers Not of the Form p + 2^k + 2^l",
+  "title": "Erd\u0151s Problem #9: Odd Integers Not of the Form p + 2^k + 2^l",
   "slug": "erdos-9",
-  "description": "Is the upper density of odd integers not expressible as p + 2^k + 2^l positive? OPEN problem. Pan (2011) proved N^{1-ε} growth but positive density remains unresolved.",
+  "description": "Is the upper density of odd integers not expressible as p + 2^k + 2^l positive? OPEN problem. Pan (2011) proved N^{1-\u03b5} growth but positive density remains unresolved.",
   "meta": {
-    "author": "Erdős",
+    "author": "Erd\u0151s",
     "sourceUrl": "https://erdosproblems.com/9",
     "date": "1977",
     "status": "axiomatized",
@@ -61,17 +61,17 @@
       "Covering congruences",
       "Modular arithmetic"
     ],
-    "assumptions": "6 axioms: schinzel_infinite, crocker_bound, pan_bound, and 3 more. See Lean source for complete statements."
+    "assumptions": "2 axioms: schinzel_infinite, form_in_every_arithmetic_progression. 0 sorries."
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #9: Odd Integers Not of the Form $p + 2^k + 2^l$**\n\nThis problem sits in a rich tradition of questions about representing integers as sums involving primes and powers of 2, going back to the Goldbach conjecture and its variants.\n\n**Romanoff's Foundation (1934):** N. P. Romanoff proved that a positive proportion of positive integers can be written as $p + 2^k$ for some prime $p$ and non-negative integer $k$. This established that sums of primes and powers of 2 cover a 'large' set of integers.\n\n**The Covering System Connection:** In 1950, Erdős and van der Corput independently showed that $p + 2^k$ does NOT represent all integers — there are infinitely many exceptions. The proof uses **covering congruences**: a finite set of congruences that cover all integers, allowing one to construct arithmetic progressions where $n - 2^k$ is always composite.\n\n**Problem #9 and Its History:**\n- **1977**: Erdős posed Problem #9 in [Er77c], asking about representations $p + 2^k + 2^l$ for odd integers. Adding a second power of 2 makes the representation more flexible, but exceptional integers still exist.\n- **Schinzel** (date uncertain, credited by Erdős 1977): Proved the exceptional set $A$ is infinite.\n- **Crocker (1971)**: First quantitative bound: $|A \\cap \\{1,\\ldots,N\\}| \\gg \\log \\log N$, published in 'On a sum of a prime and two powers of two'.\n- **Pan (2011)**: Dramatic improvement to $|A \\cap \\{1,\\ldots,N\\}| \\gg N^{1-\\varepsilon}$ for any $\\varepsilon > 0$, bringing the count tantalizingly close to linear growth.\n\n**The Key Obstruction:** Erdős observed that covering system methods — the standard tool for showing non-representability — cannot work here because integers of the form $p + 2^k + 2^l$ exist in every arithmetic progression. This fundamentally limits the available proof techniques.\n\n**Problem Family:** This is part of a cluster of related Erdős problems: #10 (sums of a prime and $k$ powers of 2), #11 (squarefree + power of 2), and #16 (odd integers not of the form $2^k + p$, recently disproved by Chen in 2023).",
-    "problemStatement": "**Question (Erdős, OPEN):** Let $A$ be the set of odd positive integers not expressible as $p + 2^k + 2^l$ where $p$ is prime and $k, l \\geq 0$. Is the upper density of $A$ positive?\n\n**Formally:** Is $\\bar{d}(A) = \\limsup_{N \\to \\infty} \\frac{|A \\cap \\{1,\\ldots,N\\}|}{N} > 0$?\n\n**Known bounds on the counting function $|A \\cap \\{1,\\ldots,N\\}|$:**\n- Schinzel: $\\to \\infty$ (A is infinite)\n- Crocker (1971): $\\gg \\log \\log N$\n- Pan (2011): $\\gg N^{1-\\varepsilon}$ for any $\\varepsilon > 0$\n- **OPEN:** $\\gg N$ (positive density)?\n\n**First elements of $A$ (OEIS A006286):** 1, 3, 7, 127, 149, 251, 331, 337, 373, ...",
-    "text": "Is the upper density of odd integers not expressible as p + 2^k + 2^l positive? OPEN problem. Pan (2011) proved N^{1-ε} growth but positive density remains unresolved.",
-    "proofStrategy": "**Formalization Approach**\n\nThe Lean formalization captures the full landscape of this open problem:\n\n1. **Core Representation:** `HasPrimePlusTwoPowersForm n` defines $n = p + 2^k + 2^l$ for prime $p$ and natural numbers $k, l$. The set $S$ collects representable integers, and $A$ collects odd positive exceptions.\n\n2. **Density Framework:** `countA N` counts elements of $A$ up to $N$ using `Nat.card`. The `upperDensity` is defined as $\\limsup_{N \\to \\infty} \\text{countA}(N)/N$ using Mathlib's `Filter.limsup`.\n\n3. **Axiomatized Deep Results:** Schinzel's infinitude, Crocker's $\\log \\log N$ bound, and Pan's $N^{1-\\varepsilon}$ bound are axiomatized — their proofs use analytic number theory beyond current Mathlib.\n\n4. **Covering System Obstruction:** `form_in_every_arithmetic_progression` axiomatizes Erdős's observation that $S$ meets every arithmetic progression, with the derived theorem `S_intersects_all_progressions`.\n\n5. **Verified Examples:** The file constructively proves $1, 3 \\in A$ (exceptional) and $5, 9 \\in S$ (representable), grounding the abstract theory in concrete computations.\n\n6. **Special Case:** `prime_plus_one_power_in_S` proves that $p + 2^m \\in S$ when $m \\geq 1$, since $2^m = 2^{m-1} + 2^{m-1}$.",
+    "historicalContext": "**Erd\u0151s Problem #9: Odd Integers Not of the Form $p + 2^k + 2^l$**\n\nThis problem sits in a rich tradition of questions about representing integers as sums involving primes and powers of 2, going back to the Goldbach conjecture and its variants.\n\n**Romanoff's Foundation (1934):** N. P. Romanoff proved that a positive proportion of positive integers can be written as $p + 2^k$ for some prime $p$ and non-negative integer $k$. This established that sums of primes and powers of 2 cover a 'large' set of integers.\n\n**The Covering System Connection:** In 1950, Erd\u0151s and van der Corput independently showed that $p + 2^k$ does NOT represent all integers \u2014 there are infinitely many exceptions. The proof uses **covering congruences**: a finite set of congruences that cover all integers, allowing one to construct arithmetic progressions where $n - 2^k$ is always composite.\n\n**Problem #9 and Its History:**\n- **1977**: Erd\u0151s posed Problem #9 in [Er77c], asking about representations $p + 2^k + 2^l$ for odd integers. Adding a second power of 2 makes the representation more flexible, but exceptional integers still exist.\n- **Schinzel** (date uncertain, credited by Erd\u0151s 1977): Proved the exceptional set $A$ is infinite.\n- **Crocker (1971)**: First quantitative bound: $|A \\cap \\{1,\\ldots,N\\}| \\gg \\log \\log N$, published in 'On a sum of a prime and two powers of two'.\n- **Pan (2011)**: Dramatic improvement to $|A \\cap \\{1,\\ldots,N\\}| \\gg N^{1-\\varepsilon}$ for any $\\varepsilon > 0$, bringing the count tantalizingly close to linear growth.\n\n**The Key Obstruction:** Erd\u0151s observed that covering system methods \u2014 the standard tool for showing non-representability \u2014 cannot work here because integers of the form $p + 2^k + 2^l$ exist in every arithmetic progression. This fundamentally limits the available proof techniques.\n\n**Problem Family:** This is part of a cluster of related Erd\u0151s problems: #10 (sums of a prime and $k$ powers of 2), #11 (squarefree + power of 2), and #16 (odd integers not of the form $2^k + p$, recently disproved by Chen in 2023).",
+    "problemStatement": "**Question (Erd\u0151s, OPEN):** Let $A$ be the set of odd positive integers not expressible as $p + 2^k + 2^l$ where $p$ is prime and $k, l \\geq 0$. Is the upper density of $A$ positive?\n\n**Formally:** Is $\\bar{d}(A) = \\limsup_{N \\to \\infty} \\frac{|A \\cap \\{1,\\ldots,N\\}|}{N} > 0$?\n\n**Known bounds on the counting function $|A \\cap \\{1,\\ldots,N\\}|$:**\n- Schinzel: $\\to \\infty$ (A is infinite)\n- Crocker (1971): $\\gg \\log \\log N$\n- Pan (2011): $\\gg N^{1-\\varepsilon}$ for any $\\varepsilon > 0$\n- **OPEN:** $\\gg N$ (positive density)?\n\n**First elements of $A$ (OEIS A006286):** 1, 3, 7, 127, 149, 251, 331, 337, 373, ...",
+    "text": "Is the upper density of odd integers not expressible as p + 2^k + 2^l positive? OPEN problem. Pan (2011) proved N^{1-\u03b5} growth but positive density remains unresolved.",
+    "proofStrategy": "**Formalization Approach**\n\nThe Lean formalization captures the full landscape of this open problem:\n\n1. **Core Representation:** `HasPrimePlusTwoPowersForm n` defines $n = p + 2^k + 2^l$ for prime $p$ and natural numbers $k, l$. The set $S$ collects representable integers, and $A$ collects odd positive exceptions.\n\n2. **Density Framework:** `countA N` counts elements of $A$ up to $N$ using `Nat.card`. The `upperDensity` is defined as $\\limsup_{N \\to \\infty} \\text{countA}(N)/N$ using Mathlib's `Filter.limsup`.\n\n3. **Axiomatized Deep Results:** Schinzel's infinitude, Crocker's $\\log \\log N$ bound, and Pan's $N^{1-\\varepsilon}$ bound are axiomatized \u2014 their proofs use analytic number theory beyond current Mathlib.\n\n4. **Covering System Obstruction:** `form_in_every_arithmetic_progression` axiomatizes Erd\u0151s's observation that $S$ meets every arithmetic progression, with the derived theorem `S_intersects_all_progressions`.\n\n5. **Verified Examples:** The file constructively proves $1, 3 \\in A$ (exceptional) and $5, 9 \\in S$ (representable), grounding the abstract theory in concrete computations.\n\n6. **Special Case:** `prime_plus_one_power_in_S` proves that $p + 2^m \\in S$ when $m \\geq 1$, since $2^m = 2^{m-1} + 2^{m-1}$.",
     "keyInsights": [
-      "**Covering systems are powerless:** Erdős's crucial observation is that $S = \\{p + 2^k + 2^l\\}$ intersects every arithmetic progression $\\{a + nd\\}_{n \\geq 0}$. Since covering congruences work by finding progressions that avoid the target set, this approach fundamentally cannot prove positive density for $A$.",
+      "**Covering systems are powerless:** Erd\u0151s's crucial observation is that $S = \\{p + 2^k + 2^l\\}$ intersects every arithmetic progression $\\{a + nd\\}_{n \\geq 0}$. Since covering congruences work by finding progressions that avoid the target set, this approach fundamentally cannot prove positive density for $A$.",
       "**Pan's $N^{1-\\varepsilon}$ gap:** The bound $|A \\cap [1,N]| \\gg N^{1-\\varepsilon}$ is polynomially close to linear but does not imply positive density. For example, $N/\\log N$ grows faster than any $N^{1-\\varepsilon}$ but has density 0. Closing this gap requires genuinely new ideas.",
-      "**Romanoff-type hierarchy:** There is a natural hierarchy: Romanoff (1934) showed density$(\\{p + 2^k\\}) > 0$; adding a second power of 2 makes representation easier, yet exceptional odd integers persist — suggesting the obstacle is arithmetic rather than analytic.",
+      "**Romanoff-type hierarchy:** There is a natural hierarchy: Romanoff (1934) showed density$(\\{p + 2^k\\}) > 0$; adding a second power of 2 makes representation easier, yet exceptional odd integers persist \u2014 suggesting the obstacle is arithmetic rather than analytic.",
       "**Sparse but structured exceptions:** The OEIS sequence $A = \\{1, 3, 7, 127, 149, 251, \\ldots\\}$ grows extremely slowly. The jump from 7 to 127 suggests the exceptions become increasingly constrained by the growing availability of primes and power-of-2 combinations.",
       "**Proved small cases anchor the formalization:** The constructive proofs that $1, 3 \\in A$ (by showing $p + 2^k + 2^l \\geq 4$ for any prime $p$) and $5 = 3 + 2^0 + 2^0 \\in S$ demonstrate Lean 4's omega tactic for concrete number-theoretic bounds."
     ],
@@ -109,7 +109,7 @@
     },
     {
       "id": "question",
-      "title": "The Erdős Question (OPEN)",
+      "title": "The Erd\u0151s Question (OPEN)",
       "summary": "States `erdos_9_question` as `hasPositiveUpperDensity` and the equivalent `erdos_9_alt`: $\\exists \\delta > 0$ such that $\\text{countA}(N) \\geq \\delta N$ for all sufficiently large $N$ (using `Filter.Eventually`).",
       "startLine": 90,
       "endLine": 106,
@@ -126,10 +126,10 @@
     {
       "id": "covering",
       "title": "Covering System Obstruction",
-      "summary": "Axiomatizes Erdős's observation: $\\forall a, d \\geq 1, \\exists n \\in S$ with $n \\equiv a \\pmod{d}$. Derives `S_intersects_all_progressions`: $S \\cap \\{n : n \\equiv a \\pmod{d}\\} \\neq \\emptyset$, proving covering congruence methods are fundamentally inapplicable.",
+      "summary": "Axiomatizes Erd\u0151s's observation: $\\forall a, d \\geq 1, \\exists n \\in S$ with $n \\equiv a \\pmod{d}$. Derives `S_intersects_all_progressions`: $S \\cap \\{n : n \\equiv a \\pmod{d}\\} \\neq \\emptyset$, proving covering congruence methods are fundamentally inapplicable.",
       "startLine": 157,
       "endLine": 173,
-      "mathContext": "Axiomatizes Erdős's observation: $\\forall a, d \\geq 1, \\exists n \\in S$ with $n \\equiv a \\pmod{d}$. Derives `S_intersects_all_progressions`: $S \\cap \\{n : n \\equiv a \\pmod{d}\\} \\neq \\emptyset$, proving covering congruence methods are fundamentally inapplicable."
+      "mathContext": "Axiomatizes Erd\u0151s's observation: $\\forall a, d \\geq 1, \\exists n \\in S$ with $n \\equiv a \\pmod{d}$. Derives `S_intersects_all_progressions`: $S \\cap \\{n : n \\equiv a \\pmod{d}\\} \\neq \\emptyset$, proving covering congruence methods are fundamentally inapplicable."
     },
     {
       "id": "examples",
@@ -157,8 +157,8 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures the full landscape of Erdős Problem #9, an open question in additive number theory asking whether odd integers not representable as $p + 2^k + 2^l$ have positive upper density. The Lean file axiomatizes the three major partial results (Schinzel's infinitude, Crocker's $\\log \\log N$ bound, Pan's $N^{1-\\varepsilon}$ bound), proves the covering system obstruction, and includes constructive examples. The problem remains open: Pan's 2011 bound is the state of the art, tantalizingly close to but not reaching positive density.",
-    "implications": "**Theoretical Significance**: **Connections to Other Areas**\n\n1. **Romanoff-type problems:** The foundational question '$p + 2^k$ covers a positive proportion of integers' (Romanoff 1934) is the parent problem. Adding more powers of 2 creates a hierarchy: Problem #10 asks about $p + \\sum 2^{k_i}$ for $k$ powers.\n\n2. **Covering congruences:** Erdős's observation that $S$ meets every arithmetic progression demonstrates a fundamental limitation of the covering system method, which has been central to number theory since Erdős's 1950 work on $p + 2^k$.\n\n3. **Analytic number theory:** The counting function bounds use sieve methods and exponential sum estimates.\n\nPan's improvement from $\\log \\log N$ to $N^{1-\\varepsilon}$ required substantial analytic machinery.\n\n4. **Density gap phenomenon:** The gap between $N^{1-\\varepsilon}$ and $cN$ growth appears in many number-theoretic contexts. Similar gaps arise in problems about almost-all vs. positive-density results.\n\n5. **Chen's 2023 breakthrough:** Problem #16 (odd integers not of the form $2^k + p$) was recently DISPROVED by Chen, showing such problems can have surprising resolutions.",
+    "summary": "This formalization captures the full landscape of Erd\u0151s Problem #9, an open question in additive number theory asking whether odd integers not representable as $p + 2^k + 2^l$ have positive upper density. The Lean file axiomatizes the three major partial results (Schinzel's infinitude, Crocker's $\\log \\log N$ bound, Pan's $N^{1-\\varepsilon}$ bound), proves the covering system obstruction, and includes constructive examples. The problem remains open: Pan's 2011 bound is the state of the art, tantalizingly close to but not reaching positive density.",
+    "implications": "**Theoretical Significance**: **Connections to Other Areas**\n\n1. **Romanoff-type problems:** The foundational question '$p + 2^k$ covers a positive proportion of integers' (Romanoff 1934) is the parent problem. Adding more powers of 2 creates a hierarchy: Problem #10 asks about $p + \\sum 2^{k_i}$ for $k$ powers.\n\n2. **Covering congruences:** Erd\u0151s's observation that $S$ meets every arithmetic progression demonstrates a fundamental limitation of the covering system method, which has been central to number theory since Erd\u0151s's 1950 work on $p + 2^k$.\n\n3. **Analytic number theory:** The counting function bounds use sieve methods and exponential sum estimates.\n\nPan's improvement from $\\log \\log N$ to $N^{1-\\varepsilon}$ required substantial analytic machinery.\n\n4. **Density gap phenomenon:** The gap between $N^{1-\\varepsilon}$ and $cN$ growth appears in many number-theoretic contexts. Similar gaps arise in problems about almost-all vs. positive-density results.\n\n5. **Chen's 2023 breakthrough:** Problem #16 (odd integers not of the form $2^k + p$) was recently DISPROVED by Chen, showing such problems can have surprising resolutions.",
     "openQuestions": [
       "Does the exceptional set $A$ have positive upper density $\\bar{d}(A) > 0$? Pan's $N^{1-\\varepsilon}$ bound leaves open whether $|A \\cap [1,N]| = \\Omega(N)$",
       "Can Pan's bound be strengthened to $|A \\cap [1,N]| \\gg N / (\\log N)^c$ for some $c > 0$? This intermediate bound would be a major step",
@@ -173,7 +173,7 @@
       },
       {
         "proofId": "erdos-11",
-        "relationship": "Problem #11 asks whether every odd $n > 1$ equals a squarefree number plus a power of 2 — a different representation involving primes (through squarefree factorization) and powers of 2"
+        "relationship": "Problem #11 asks whether every odd $n > 1$ equals a squarefree number plus a power of 2 \u2014 a different representation involving primes (through squarefree factorization) and powers of 2"
       },
       {
         "proofId": "erdos-16",
@@ -181,7 +181,7 @@
       },
       {
         "proofId": "erdos-221",
-        "relationship": "Problem #221 asks about additive complements to powers of 2 — what sparse sets $A$ make $A + \\{2^k\\}$ cover all large integers? Ruzsa's solution connects to the density questions underlying Problem #9"
+        "relationship": "Problem #221 asks about additive complements to powers of 2 \u2014 what sparse sets $A$ make $A + \\{2^k\\}$ cover all large integers? Ruzsa's solution connects to the density questions underlying Problem #9"
       },
       {
         "proofId": "dirichlets-theorem",
@@ -219,7 +219,7 @@
     {
       "targetId": "erdos-2",
       "relationship": "related",
-      "description": "Erdős's covering congruence technique (from Problem #2) is used to construct integers not representable as p + 2^k + 2^l"
+      "description": "Erd\u0151s's covering congruence technique (from Problem #2) is used to construct integers not representable as p + 2^k + 2^l"
     },
     {
       "targetId": "infinitude-primes",
@@ -230,23 +230,23 @@
   "references": [
     {
       "authors": "Romanoff, N. P.",
-      "title": "Über einige Sätze der additiven Zahlentheorie",
+      "title": "\u00dcber einige S\u00e4tze der additiven Zahlentheorie",
       "year": "1934",
-      "venue": "Mathematische Annalen, vol. 109, no. 1, pp. 668–678",
+      "venue": "Mathematische Annalen, vol. 109, no. 1, pp. 668\u2013678",
       "note": "Proved a positive proportion of integers are p + 2^a, the k=1 case that motivates Problem #9"
     },
     {
-      "authors": "Erdős, Paul",
+      "authors": "Erd\u0151s, Paul",
       "title": "On integers of the form 2^k + p and some related problems",
       "year": "1950",
-      "venue": "Summa Brasiliensis Mathematicae, vol. 2, pp. 113–123",
+      "venue": "Summa Brasiliensis Mathematicae, vol. 2, pp. 113\u2013123",
       "note": "Used covering congruences to construct non-representable integers, the technique underlying Problem #9"
     },
     {
       "authors": "Crocker, Roger",
       "title": "On the sum of a prime and of two powers of two",
       "year": "1971",
-      "venue": "Pacific Journal of Mathematics, vol. 36, pp. 103–107",
+      "venue": "Pacific Journal of Mathematics, vol. 36, pp. 103\u2013107",
       "note": "Early results on the p + 2^a + 2^b representation problem"
     }
   ]

--- a/src/data/proofs/erdos-903/meta.json
+++ b/src/data/proofs/erdos-903/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-903",
-  "title": "Erdős Problem #903: Block Designs and the de Bruijn-Erdős Gap",
+  "title": "Erd\u0151s Problem #903: Block Designs and the de Bruijn-Erd\u0151s Gap",
   "slug": "erdos-903",
-  "description": "For n = p² + p + 1 with p a prime power, if a block design on n points has t > n blocks, then t ≥ n + p. Proved by Erdős-Fowler-Sós-Wilson (1985).",
+  "description": "For n = p\u00b2 + p + 1 with p a prime power, if a block design on n points has t > n blocks, then t \u2265 n + p. Proved by Erd\u0151s-Fowler-S\u00f3s-Wilson (1985).",
   "meta": {
-    "author": "Erdős-Sós (conjecture), Erdős-Fowler-Sós-Wilson (1985)",
+    "author": "Erd\u0151s-S\u00f3s (conjecture), Erd\u0151s-Fowler-S\u00f3s-Wilson (1985)",
     "sourceUrl": "https://erdosproblems.com/903",
     "date": "1985",
     "status": "axiomatized",
@@ -48,27 +48,27 @@
       "Formalized BlockDesign structure with pair coverage property",
       "Defined IsPrimePower and IsProjectivePlaneSize predicates",
       "Formalized ProjectivePlane structure with axioms",
-      "Stated de Bruijn-Erdős theorem (1948): t ≥ n",
-      "Stated Erdős-Fowler-Sós-Wilson theorem (1985): t > n implies t ≥ n + p",
+      "Stated de Bruijn-Erd\u0151s theorem (1948): t \u2265 n",
+      "Stated Erd\u0151s-Fowler-S\u00f3s-Wilson theorem (1985): t > n implies t \u2265 n + p",
       "Defined achievableBlocks set and gap_theorem",
       "Connected to Fisher's inequality for 2-designs",
-      "Stated stronger bound: t ≥ n + 1.148p unless broken projective plane"
+      "Stated stronger bound: t \u2265 n + 1.148p unless broken projective plane"
     ],
     "axiomCount": 5,
     "lineCount": 211,
-    "assumptions": "9 axioms: de_bruijn_erdos, minimal_design_uniform, projective_plane_exists, and 6 more. See Lean source for complete statements."
+    "assumptions": "5 axioms: de_bruijn_erdos, projective_plane_design, efsw_1985, gap_theorem, fisher_inequality. 0 sorries."
   },
   "overview": {
-    "historicalContext": "This problem was a conjecture of Erdős and Sós about block designs. A block design on {1,...,n} is a collection of subsets (blocks) such that every pair of distinct elements is contained in exactly one block — equivalently, a pairwise balanced design (PBD).\n\nThe classic projective plane construction shows t = n is achievable when n = p² + p + 1 for prime power p. The de Bruijn-Erdős theorem (1948) established that t ≥ n for any block design, using a double-counting argument with Cauchy-Schwarz applied to the replication numbers r_x.\n\nErdős and Sós conjectured that there is a 'gap': if t > n, then t ≥ n + p. This was proved by Erdős, Fowler, Sós, and Wilson (1985) in the Proceedings of the London Mathematical Society, who further showed that unless the design comes from a projective plane with one line 'broken up' into singletons, we have t ≥ n + cp where c ≈ 1.148.\n\nThe problem connects to fundamental questions in finite geometry: the prime power conjecture (projective planes exist iff the order is a prime power), the Bruck-Ryser non-existence theorem, and the classification of near-minimal designs.",
-    "problemStatement": "**Problem**: Let $n = p^2 + p + 1$ for some prime power $p$, and let $A_1, \\ldots, A_t \\subseteq \\{1,\\ldots,n\\}$ be a block design (every pair $x, y \\in \\{1,\\ldots,n\\}$ is contained in exactly one $A_i$).\n\nIs it true that if $t > n$ then $t \\geq n + p$?\n\n**Answer**: YES\n\n**Key Results**:\n- de Bruijn-Erdős (1948): $t \\geq n$\n- Projective plane: $t = n$ is achievable\n- EFSW (1985): $t > n \\Rightarrow t \\geq n + p$\n- Stronger: $t \\geq n + 1.148p$ unless broken projective plane",
-    "text": "For n = p² + p + 1 with p a prime power, if a block design on n points has t > n blocks, then t ≥ n + p. Proved by Erdős-Fowler-Sós-Wilson (1985).",
-    "proofStrategy": "The formalization defines BlockDesign as a structure with blocks (finite sets of finite sets) satisfying the pair coverage property. ProjectivePlane is formalized with its classical axioms (point/line incidence). The de Bruijn-Erdős theorem and EFSW theorem are axiomatized (the combinatorial proofs require machinery beyond current Lean/Mathlib capabilities). The gap structure is captured by showing values in (n, n+p) are not achievable, with a proved theorem `first_above_n` that the first achievable value above n is at least n + p. The summary theorem `erdos_903_summary` combines all three main results into a single proved statement.",
+    "historicalContext": "This problem was a conjecture of Erd\u0151s and S\u00f3s about block designs. A block design on {1,...,n} is a collection of subsets (blocks) such that every pair of distinct elements is contained in exactly one block \u2014 equivalently, a pairwise balanced design (PBD).\n\nThe classic projective plane construction shows t = n is achievable when n = p\u00b2 + p + 1 for prime power p. The de Bruijn-Erd\u0151s theorem (1948) established that t \u2265 n for any block design, using a double-counting argument with Cauchy-Schwarz applied to the replication numbers r_x.\n\nErd\u0151s and S\u00f3s conjectured that there is a 'gap': if t > n, then t \u2265 n + p. This was proved by Erd\u0151s, Fowler, S\u00f3s, and Wilson (1985) in the Proceedings of the London Mathematical Society, who further showed that unless the design comes from a projective plane with one line 'broken up' into singletons, we have t \u2265 n + cp where c \u2248 1.148.\n\nThe problem connects to fundamental questions in finite geometry: the prime power conjecture (projective planes exist iff the order is a prime power), the Bruck-Ryser non-existence theorem, and the classification of near-minimal designs.",
+    "problemStatement": "**Problem**: Let $n = p^2 + p + 1$ for some prime power $p$, and let $A_1, \\ldots, A_t \\subseteq \\{1,\\ldots,n\\}$ be a block design (every pair $x, y \\in \\{1,\\ldots,n\\}$ is contained in exactly one $A_i$).\n\nIs it true that if $t > n$ then $t \\geq n + p$?\n\n**Answer**: YES\n\n**Key Results**:\n- de Bruijn-Erd\u0151s (1948): $t \\geq n$\n- Projective plane: $t = n$ is achievable\n- EFSW (1985): $t > n \\Rightarrow t \\geq n + p$\n- Stronger: $t \\geq n + 1.148p$ unless broken projective plane",
+    "text": "For n = p\u00b2 + p + 1 with p a prime power, if a block design on n points has t > n blocks, then t \u2265 n + p. Proved by Erd\u0151s-Fowler-S\u00f3s-Wilson (1985).",
+    "proofStrategy": "The formalization defines BlockDesign as a structure with blocks (finite sets of finite sets) satisfying the pair coverage property. ProjectivePlane is formalized with its classical axioms (point/line incidence). The de Bruijn-Erd\u0151s theorem and EFSW theorem are axiomatized (the combinatorial proofs require machinery beyond current Lean/Mathlib capabilities). The gap structure is captured by showing values in (n, n+p) are not achievable, with a proved theorem `first_above_n` that the first achievable value above n is at least n + p. The summary theorem `erdos_903_summary` combines all three main results into a single proved statement.",
     "keyInsights": [
-      "**Pair coverage as linear space**: Every pair of distinct elements in exactly one block — the blocks form the lines of a linear space. This viewpoint connects to finite geometry via the Lenz-Barlotti classification.",
-      "**Projective planes achieve the minimum**: When n = p² + p + 1, projective planes of order p have exactly n lines (blocks), achieving the de Bruijn-Erdős bound. The proof of equality uses uniformity of replication numbers.",
-      "**The gap phenomenon**: There are no block designs with t blocks where n < t < n + p — these values are 'forbidden'. This is analogous to spectral gaps in graph theory (e.g., the gap between Turán graphs and the next achievable edge count).",
-      "**Broken projective planes**: The only designs with t in [n+p, n+⌈1.148p⌉) come from breaking one line of a projective plane into singletons. This yields exactly t = n + q blocks (replacing one (q+1)-block by q+1 singletons).",
-      "**Fisher's inequality connection**: For uniform block designs (2-designs), Fisher's inequality b ≥ v is equivalent to de Bruijn-Erdős. Fisher's proof uses the incidence matrix NN^T = (r-λ)I + λJ and rank arguments."
+      "**Pair coverage as linear space**: Every pair of distinct elements in exactly one block \u2014 the blocks form the lines of a linear space. This viewpoint connects to finite geometry via the Lenz-Barlotti classification.",
+      "**Projective planes achieve the minimum**: When n = p\u00b2 + p + 1, projective planes of order p have exactly n lines (blocks), achieving the de Bruijn-Erd\u0151s bound. The proof of equality uses uniformity of replication numbers.",
+      "**The gap phenomenon**: There are no block designs with t blocks where n < t < n + p \u2014 these values are 'forbidden'. This is analogous to spectral gaps in graph theory (e.g., the gap between Tur\u00e1n graphs and the next achievable edge count).",
+      "**Broken projective planes**: The only designs with t in [n+p, n+\u23081.148p\u2309) come from breaking one line of a projective plane into singletons. This yields exactly t = n + q blocks (replacing one (q+1)-block by q+1 singletons).",
+      "**Fisher's inequality connection**: For uniform block designs (2-designs), Fisher's inequality b \u2265 v is equivalent to de Bruijn-Erd\u0151s. Fisher's proof uses the incidence matrix NN^T = (r-\u03bb)I + \u03bbJ and rank arguments."
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -86,8 +86,8 @@
     },
     {
       "id": "de-bruijn-erdos",
-      "title": "The de Bruijn-Erdős Theorem",
-      "summary": "de_bruijn_erdos axiom (t ≥ n), IsMinimalDesign, minimal_design_uniform",
+      "title": "The de Bruijn-Erd\u0151s Theorem",
+      "summary": "de_bruijn_erdos axiom (t \u2265 n), IsMinimalDesign, minimal_design_uniform",
       "startLine": 57,
       "endLine": 74,
       "mathContext": "de_bruijn_erdos axiom (t $\\geq$ n), IsMinimalDesign, minimal_design_uniform"
@@ -102,7 +102,7 @@
     },
     {
       "id": "erdos-sos-theorem",
-      "title": "The Erdős-Sós Conjecture (Now Theorem)",
+      "title": "The Erd\u0151s-S\u00f3s Conjecture (Now Theorem)",
       "summary": "efsw_1985 axiom (gap theorem), efsw_strong axiom with broken-plane condition",
       "startLine": 100,
       "endLine": 120,
@@ -135,20 +135,20 @@
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "erdos_903_summary (proved): three-part conjunction combining de Bruijn-Erdős, projective plane existence, and EFSW gap theorem",
+      "summary": "erdos_903_summary (proved): three-part conjunction combining de Bruijn-Erd\u0151s, projective plane existence, and EFSW gap theorem",
       "startLine": 184,
       "endLine": 211,
-      "mathContext": "Verified: erdos_903_summary (proved): three-part conjunction combining de Bruijn-Erdős, projective plane existence, and EFSW gap theorem"
+      "mathContext": "Verified: erdos_903_summary (proved): three-part conjunction combining de Bruijn-Erd\u0151s, projective plane existence, and EFSW gap theorem"
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #903 asks whether block designs on n = p² + p + 1 points with more than n blocks must have at least n + p blocks. The answer is YES, proved by Erdős-Fowler-Sós-Wilson (1985). The projective plane achieves the minimum t = n, and there is a gap: no designs exist with t in (n, n+p). The formalization captures this via axiomatized theorems and a proved summary combining all three key results.",
-    "implications": "**Theoretical Significance**: This result reveals the rigid structure of block designs near the de Bruijn-Erdős minimum. The gap phenomenon shows that slightly exceeding the minimum forces a significant jump in the number of blocks — a form of combinatorial rigidity.\n\nThis connects to the broader theme of *stability* in extremal combinatorics: extremal configurations are often not merely optimal but isolated, with nearby configurations forced to be far away. The result has implications for finite geometry (structure of near-projective-plane designs), coding theory (bounds on error-correcting codes from design parameters), and the classification of linear spaces.",
+    "summary": "Erd\u0151s Problem #903 asks whether block designs on n = p\u00b2 + p + 1 points with more than n blocks must have at least n + p blocks. The answer is YES, proved by Erd\u0151s-Fowler-S\u00f3s-Wilson (1985). The projective plane achieves the minimum t = n, and there is a gap: no designs exist with t in (n, n+p). The formalization captures this via axiomatized theorems and a proved summary combining all three key results.",
+    "implications": "**Theoretical Significance**: This result reveals the rigid structure of block designs near the de Bruijn-Erd\u0151s minimum. The gap phenomenon shows that slightly exceeding the minimum forces a significant jump in the number of blocks \u2014 a form of combinatorial rigidity.\n\nThis connects to the broader theme of *stability* in extremal combinatorics: extremal configurations are often not merely optimal but isolated, with nearby configurations forced to be far away. The result has implications for finite geometry (structure of near-projective-plane designs), coding theory (bounds on error-correcting codes from design parameters), and the classification of linear spaces.",
     "openQuestions": [
       "What are all achievable values of t for general n? (Only known for small cases like n = 7)",
-      "Can the constant c ≈ 1.148 in the EFSW strong bound be improved?",
+      "Can the constant c \u2248 1.148 in the EFSW strong bound be improved?",
       "What is the precise structure of designs achieving t = n + p (broken projective planes)?",
-      "How does the gap phenomenon generalize to λ > 1 (multiple pair coverage)?",
+      "How does the gap phenomenon generalize to \u03bb > 1 (multiple pair coverage)?",
       "Does a similar gap exist for non-prime-power orders where projective planes may not exist?"
     ]
   },
@@ -172,17 +172,17 @@
     {
       "targetId": "erdos-1159",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, finite-geometry, projective-planes"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, finite-geometry, projective-planes"
     },
     {
       "targetId": "erdos-664",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, finite-geometry, projective-planes"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, finite-geometry, projective-planes"
     },
     {
       "targetId": "erdos-665",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: block-designs, combinatorics, projective-planes"
+      "description": "Related Erd\u0151s problem sharing themes: block-designs, combinatorics, projective-planes"
     }
   ]
 }

--- a/src/data/proofs/erdos-918/meta.json
+++ b/src/data/proofs/erdos-918/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-918",
-  "title": "Erdős Problem #918: Chromatic Numbers of Infinite Graphs",
+  "title": "Erd\u0151s Problem #918: Chromatic Numbers of Infinite Graphs",
   "slug": "erdos-918",
-  "description": "Two questions about graphs with large chromatic numbers: Can we have ℵ₂-chromatic graphs where all ℵ₁-subgraphs are countably chromatic? The main questions are OPEN, but Erdős-Hajnal proved the finite case.",
+  "description": "Two questions about graphs with large chromatic numbers: Can we have \u2135\u2082-chromatic graphs where all \u2135\u2081-subgraphs are countably chromatic? The main questions are OPEN, but Erd\u0151s-Hajnal proved the finite case.",
   "meta": {
-    "author": "Erdős and Hajnal (finite case, 1968)",
+    "author": "Erd\u0151s and Hajnal (finite case, 1968)",
     "sourceUrl": "https://erdosproblems.com/918",
     "date": "1968-1969",
     "status": "axiomatized",
@@ -36,32 +36,32 @@
       },
       {
         "theorem": "Ordinal.omega0",
-        "description": "The first infinite ordinal ω",
+        "description": "The first infinite ordinal \u03c9",
         "module": "Mathlib.SetTheory.Cardinal.Ordinal"
       }
     ],
     "originalContributions": [
       "Clean Lean 4 formalization of the problem statements",
-      "Axiomatization of Erdős-Hajnal finite case theorem",
+      "Axiomatization of Erd\u0151s-Hajnal finite case theorem",
       "Axiomatization of the two open questions as Props",
       "Proved theorems about aleph cardinal ordering",
       "Educational commentary on infinite chromatic numbers"
     ],
     "axiomCount": 3,
     "lineCount": 146,
-    "assumptions": "7 axioms: Question1, Question2, erdos_hajnal_finite, and 4 more. See Lean source for complete statements."
+    "assumptions": "3 axioms: Question1, Question2, erdos_hajnal_finite. 0 sorries."
   },
   "overview": {
-    "historicalContext": "This problem originates from Erdős and Hajnal's 1968 paper 'On chromatic number of infinite graphs'. They proved a remarkable result for finite ordinals: for every finite k, there exists a graph with ℵ_k vertices and chromatic number ℵ₁ such that every subgraph on fewer than ℵ_k vertices has chromatic number at most ℵ₀.\n\nThe construction uses transfinite induction and diagonal arguments. The question asks whether this phenomenon extends to infinite ordinals, specifically ℵ₂ and ℵ_{ω+1}.\n\nIn Erdős's 1969 paper 'Problems and results in chromatic graph theory', the problem was originally stated with chromatic number exactly ℵ₀ instead of at most ℵ₀. However, this is trivially impossible since any graph contains finite subgraphs with finite chromatic number. The corrected version asks for chromatic number ≤ ℵ₀.",
-    "problemStatement": "**Erdős Problem #918** (Two related questions):\n\n**Question 1 (OPEN)**: Is there a graph with $\\aleph_2$ vertices and chromatic number $\\aleph_2$ such that every induced subgraph on $\\aleph_1$ vertices has chromatic number $\\leq \\aleph_0$?\n\n**Question 2 (OPEN)**: Is there a graph with $\\aleph_{\\omega+1}$ vertices and chromatic number $\\aleph_1$ such that every induced subgraph on $\\aleph_\\omega$ vertices has chromatic number $\\leq \\aleph_0$?\n\n**Known Result (Erdős-Hajnal 1968)**: For every finite $k$, there exists a graph with $\\aleph_k$ vertices and chromatic number $\\aleph_1$ where each induced subgraph on fewer than $\\aleph_k$ vertices has chromatic number $\\leq \\aleph_0$.",
-    "text": "Two questions about graphs with large chromatic numbers: Can we have ℵ₂-chromatic graphs where all ℵ₁-subgraphs are countably chromatic? The main questions are OPEN, but Erdős-Hajnal proved the finite case.",
-    "proofStrategy": "We formalize this open problem and its known partial result:\n\n1. **Axiomatize the questions**: Since the answers are unknown, we axiomatize Question1 and Question2 as Props\n\n2. **State the Erdős-Hajnal theorem**: The finite case is axiomatized as `erdos_hajnal_finite`, stating the existence of appropriate graphs for each natural number k\n\n3. **Background on cardinals**: We prove basic facts about aleph cardinals using Mathlib's ordinal and cardinal theories\n\n4. **Note the impossibility**: We explain why the = ℵ₀ variant (from [Er69b]) is trivially false\n\nThe full formalization would require a cardinal-valued chromatic number for infinite graphs, which is not directly available in Mathlib.",
+    "historicalContext": "This problem originates from Erd\u0151s and Hajnal's 1968 paper 'On chromatic number of infinite graphs'. They proved a remarkable result for finite ordinals: for every finite k, there exists a graph with \u2135_k vertices and chromatic number \u2135\u2081 such that every subgraph on fewer than \u2135_k vertices has chromatic number at most \u2135\u2080.\n\nThe construction uses transfinite induction and diagonal arguments. The question asks whether this phenomenon extends to infinite ordinals, specifically \u2135\u2082 and \u2135_{\u03c9+1}.\n\nIn Erd\u0151s's 1969 paper 'Problems and results in chromatic graph theory', the problem was originally stated with chromatic number exactly \u2135\u2080 instead of at most \u2135\u2080. However, this is trivially impossible since any graph contains finite subgraphs with finite chromatic number. The corrected version asks for chromatic number \u2264 \u2135\u2080.",
+    "problemStatement": "**Erd\u0151s Problem #918** (Two related questions):\n\n**Question 1 (OPEN)**: Is there a graph with $\\aleph_2$ vertices and chromatic number $\\aleph_2$ such that every induced subgraph on $\\aleph_1$ vertices has chromatic number $\\leq \\aleph_0$?\n\n**Question 2 (OPEN)**: Is there a graph with $\\aleph_{\\omega+1}$ vertices and chromatic number $\\aleph_1$ such that every induced subgraph on $\\aleph_\\omega$ vertices has chromatic number $\\leq \\aleph_0$?\n\n**Known Result (Erd\u0151s-Hajnal 1968)**: For every finite $k$, there exists a graph with $\\aleph_k$ vertices and chromatic number $\\aleph_1$ where each induced subgraph on fewer than $\\aleph_k$ vertices has chromatic number $\\leq \\aleph_0$.",
+    "text": "Two questions about graphs with large chromatic numbers: Can we have \u2135\u2082-chromatic graphs where all \u2135\u2081-subgraphs are countably chromatic? The main questions are OPEN, but Erd\u0151s-Hajnal proved the finite case.",
+    "proofStrategy": "We formalize this open problem and its known partial result:\n\n1. **Axiomatize the questions**: Since the answers are unknown, we axiomatize Question1 and Question2 as Props\n\n2. **State the Erd\u0151s-Hajnal theorem**: The finite case is axiomatized as `erdos_hajnal_finite`, stating the existence of appropriate graphs for each natural number k\n\n3. **Background on cardinals**: We prove basic facts about aleph cardinals using Mathlib's ordinal and cardinal theories\n\n4. **Note the impossibility**: We explain why the = \u2135\u2080 variant (from [Er69b]) is trivially false\n\nThe full formalization would require a cardinal-valued chromatic number for infinite graphs, which is not directly available in Mathlib.",
     "keyInsights": [
-      "**Chromatic number for infinite graphs**: Unlike finite graphs where chromatic number is a natural number, infinite graphs require cardinal-valued chromatic numbers. The chromatic number is the smallest cardinal κ such that the graph admits a proper κ-coloring.",
-      "**The compactness question**: This problem asks about a kind of 'anti-compactness' for chromatic numbers. Can a graph have large chromatic number globally while being well-behaved locally? The Erdős-Hajnal result shows this can happen for finite thresholds.",
-      "**Why ℵ₂ is special**: The jump from finite k to ℵ₂ is significant because the combinatorial methods used for finite k don't immediately generalize to this setting.",
+      "**Chromatic number for infinite graphs**: Unlike finite graphs where chromatic number is a natural number, infinite graphs require cardinal-valued chromatic numbers. The chromatic number is the smallest cardinal \u03ba such that the graph admits a proper \u03ba-coloring.",
+      "**The compactness question**: This problem asks about a kind of 'anti-compactness' for chromatic numbers. Can a graph have large chromatic number globally while being well-behaved locally? The Erd\u0151s-Hajnal result shows this can happen for finite thresholds.",
+      "**Why \u2135\u2082 is special**: The jump from finite k to \u2135\u2082 is significant because the combinatorial methods used for finite k don't immediately generalize to this setting.",
       "**Set-theoretic considerations**: The answer may depend on axioms beyond ZFC. Questions about uncountable cardinals often involve set-theoretic independence.",
-      "**The equality variant fails**: Asking for chromatic number exactly ℵ₀ (not ≤ ℵ₀) is impossible because finite subgraphs have finite chromatic number."
+      "**The equality variant fails**: Asking for chromatic number exactly \u2135\u2080 (not \u2264 \u2135\u2080) is impossible because finite subgraphs have finite chromatic number."
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -81,21 +81,21 @@
       "title": "The Main Open Questions",
       "startLine": 42,
       "endLine": 66,
-      "summary": "Axiomatization of Question1 (ℵ₂ case) and Question2 (ℵ_{ω+1} case)."
+      "summary": "Axiomatization of Question1 (\u2135\u2082 case) and Question2 (\u2135_{\u03c9+1} case)."
     },
     {
       "id": "erdos-hajnal",
-      "title": "Erdős-Hajnal Finite Case",
+      "title": "Erd\u0151s-Hajnal Finite Case",
       "startLine": 67,
       "endLine": 83,
       "summary": "The solved part: for every finite k, such graphs exist."
     },
     {
       "id": "negative-results",
-      "title": "Impossibility of Exact ℵ₀",
+      "title": "Impossibility of Exact \u2135\u2080",
       "startLine": 84,
       "endLine": 97,
-      "summary": "Why the original = ℵ₀ formulation is trivially false."
+      "summary": "Why the original = \u2135\u2080 formulation is trivially false."
     },
     {
       "id": "background",
@@ -120,7 +120,7 @@
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erdős Problem #918 on chromatic numbers of infinite graphs. The problem consists of two OPEN questions about graphs with ℵ₂ (or ℵ_{ω+1}) vertices where large chromatic number coexists with countably chromatic local behavior. The finite case was solved by Erdős and Hajnal in 1968, showing the phenomenon exists for all finite aleph numbers.",
+    "summary": "We formalize Erd\u0151s Problem #918 on chromatic numbers of infinite graphs. The problem consists of two OPEN questions about graphs with \u2135\u2082 (or \u2135_{\u03c9+1}) vertices where large chromatic number coexists with countably chromatic local behavior. The finite case was solved by Erd\u0151s and Hajnal in 1968, showing the phenomenon exists for all finite aleph numbers.",
     "implications": "**Theoretical Significance**: This problem connects several areas:\n\n1. **Infinite combinatorics**: Understanding the structure of uncountable graphs\n**2. Set theory**: Questions may have independence results\n3. **Compactness phenomena**: When can global properties be witnessed locally?\n4. **Cardinal arithmetic**: The interplay between different infinite cardinalities.",
     "openQuestions": [
       "Does Question1 have an affirmative answer?",
@@ -150,17 +150,17 @@
     {
       "targetId": "erdos-1067",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: chromatic-number, infinite-graphs, set-theory"
+      "description": "Related Erd\u0151s problem sharing themes: chromatic-number, infinite-graphs, set-theory"
     },
     {
       "targetId": "erdos-110",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: chromatic-number, infinite-graphs, set-theory"
+      "description": "Related Erd\u0151s problem sharing themes: chromatic-number, infinite-graphs, set-theory"
     },
     {
       "targetId": "erdos-594",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: chromatic-number, infinite-graphs, set-theory"
+      "description": "Related Erd\u0151s problem sharing themes: chromatic-number, infinite-graphs, set-theory"
     }
   ]
 }

--- a/src/data/proofs/erdos-930/meta.json
+++ b/src/data/proofs/erdos-930/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-930",
-  "title": "Erdős Problem #930: Products of Disjoint Intervals and Perfect Powers",
+  "title": "Erd\u0151s Problem #930: Products of Disjoint Intervals and Perfect Powers",
   "slug": "erdos-930",
-  "description": "Is it true that, for every r, there is a k such that if I₁,...,Iᵣ are disjoint intervals of consecutive integers, all of length at least k, then their combined product is not a perfect power?",
+  "description": "Is it true that, for every r, there is a k such that if I\u2081,...,I\u1d63 are disjoint intervals of consecutive integers, all of length at least k, then their combined product is not a perfect power?",
   "meta": {
-    "author": "Erdős-Selfridge (1975) solved r=1; general case open",
+    "author": "Erd\u0151s-Selfridge (1975) solved r=1; general case open",
     "sourceUrl": "https://erdosproblems.com/930",
     "date": "1975",
     "status": "axiomatized",
@@ -42,26 +42,26 @@
       }
     ],
     "originalContributions": [
-      "Formal statement of the OPEN Erdős problem in Lean 4",
+      "Formal statement of the OPEN Erd\u0151s problem in Lean 4",
       "Definition of perfect power predicate IsPower",
-      "Axiomatization of the Erdős-Selfridge theorem (r=1 case)",
+      "Axiomatization of the Erd\u0151s-Selfridge theorem (r=1 case)",
       "Statement of the technical prime multiplicity lemma",
       "Verified properties of perfect powers and small examples"
     ],
     "axiomCount": 1,
     "lineCount": 149,
-    "assumptions": "5 axioms: erdos_930_conjecture, erdos_selfridge_consecutive_integers, erdos_selfridge_prime_multiplicity, and 2 more. See Lean source for complete statements."
+    "assumptions": "1 axiom: six_not_isPower. 0 sorries."
   },
   "overview": {
-    "historicalContext": "This problem asks about products of integers from multiple disjoint intervals. Erdős and Selfridge famously proved in 1975 that the product of two or more consecutive positive integers is NEVER a perfect power. This resolved the r=1 case of Problem #930.\n\nThe general case asks: for r disjoint intervals of consecutive integers, all sufficiently long, is their combined product never a perfect power? The condition that intervals be 'sufficiently long' (length at least k, where k depends on r) is necessary—without it, counterexamples exist for r=2.\n\nThe Erdős-Selfridge proof uses sophisticated arguments about prime multiplicities. The key insight is that for any product of consecutive integers, there exists a prime whose multiplicity is not divisible by any given l > 1, preventing the product from being a perfect l-th power.",
-    "problemStatement": "Is it true that, for every $r$, there is a $k$ such that if $I_1,\\ldots,I_r$ are disjoint intervals of consecutive integers, all of length at least $k$, then\n$$\\prod_{1\\leq i\\leq r}\\prod_{m\\in I_i}m$$\nis not a perfect power?\n\n**Status**:\n- **OPEN** for general $r > 1$\n- **SOLVED** for $r = 1$ (Erdős-Selfridge, 1975)\n\n**Known**: The product of $k \\geq 2$ consecutive positive integers $(n+1)(n+2)\\cdots(n+k)$ is never a perfect power.",
-    "text": "Is it true that, for every r, there is a k such that if I₁,...,Iᵣ are disjoint intervals of consecutive integers, all of length at least k, then their combined product is not a perfect power?",
-    "proofStrategy": "We formalize this problem by:\n\n1. **Defining perfect powers**: `IsPower n` holds if n = m^l for some l > 1\n\n2. **Stating the main conjecture**: For every r > 0, there exists k such that r disjoint intervals of length ≥ k have a non-power product\n\n3. **Axiomatizing the Erdős-Selfridge theorem**: The r=1 case is stated as an axiom\n\n4. **Technical lemma**: The prime multiplicity result that drives the proof\n\n5. **Verified examples**: Basic properties of perfect powers and small cases",
+    "historicalContext": "This problem asks about products of integers from multiple disjoint intervals. Erd\u0151s and Selfridge famously proved in 1975 that the product of two or more consecutive positive integers is NEVER a perfect power. This resolved the r=1 case of Problem #930.\n\nThe general case asks: for r disjoint intervals of consecutive integers, all sufficiently long, is their combined product never a perfect power? The condition that intervals be 'sufficiently long' (length at least k, where k depends on r) is necessary\u2014without it, counterexamples exist for r=2.\n\nThe Erd\u0151s-Selfridge proof uses sophisticated arguments about prime multiplicities. The key insight is that for any product of consecutive integers, there exists a prime whose multiplicity is not divisible by any given l > 1, preventing the product from being a perfect l-th power.",
+    "problemStatement": "Is it true that, for every $r$, there is a $k$ such that if $I_1,\\ldots,I_r$ are disjoint intervals of consecutive integers, all of length at least $k$, then\n$$\\prod_{1\\leq i\\leq r}\\prod_{m\\in I_i}m$$\nis not a perfect power?\n\n**Status**:\n- **OPEN** for general $r > 1$\n- **SOLVED** for $r = 1$ (Erd\u0151s-Selfridge, 1975)\n\n**Known**: The product of $k \\geq 2$ consecutive positive integers $(n+1)(n+2)\\cdots(n+k)$ is never a perfect power.",
+    "text": "Is it true that, for every r, there is a k such that if I\u2081,...,I\u1d63 are disjoint intervals of consecutive integers, all of length at least k, then their combined product is not a perfect power?",
+    "proofStrategy": "We formalize this problem by:\n\n1. **Defining perfect powers**: `IsPower n` holds if n = m^l for some l > 1\n\n2. **Stating the main conjecture**: For every r > 0, there exists k such that r disjoint intervals of length \u2265 k have a non-power product\n\n3. **Axiomatizing the Erd\u0151s-Selfridge theorem**: The r=1 case is stated as an axiom\n\n4. **Technical lemma**: The prime multiplicity result that drives the proof\n\n5. **Verified examples**: Basic properties of perfect powers and small cases",
     "keyInsights": [
       "**Perfect power definition**: n is a perfect power if n = m^l with l > 1. Examples: 4, 8, 9, 16, 25, 27, 32, ...",
       "**Why consecutive products aren't powers**: In any product (n+1)(n+2)...(n+k), there's always some prime p whose multiplicity isn't divisible by any l > 1.",
-      "**The key technical lemma**: For k ≥ 3 and sufficiently large n, there exists a prime p ≥ k such that l ∤ ord_p((n+1)...(n+k)).",
-      "**Why intervals must be long**: For r=2 with short intervals, counterexamples exist—the length constraint prevents pathological cases.",
+      "**The key technical lemma**: For k \u2265 3 and sufficiently large n, there exists a prime p \u2265 k such that l \u2224 ord_p((n+1)...(n+k)).",
+      "**Why intervals must be long**: For r=2 with short intervals, counterexamples exist\u2014the length constraint prevents pathological cases.",
       "**Connection to factorials**: This problem relates to the structure of prime factorizations in factorial-like products."
     ],
     "prerequisites": [
@@ -77,7 +77,7 @@
       "title": "Module Documentation",
       "startLine": 1,
       "endLine": 20,
-      "summary": "Problem statement, historical context, and references to Erdős-Selfridge (1975)."
+      "summary": "Problem statement, historical context, and references to Erd\u0151s-Selfridge (1975)."
     },
     {
       "id": "definitions",
@@ -95,7 +95,7 @@
     },
     {
       "id": "erdos-selfridge",
-      "title": "Erdős-Selfridge Theorem (r=1)",
+      "title": "Erd\u0151s-Selfridge Theorem (r=1)",
       "startLine": 72,
       "endLine": 90,
       "summary": "The solved case: products of consecutive integers are never perfect powers."
@@ -123,13 +123,13 @@
     }
   ],
   "conclusion": {
-    "summary": "We formalize Erdős Problem #930 about products of integers from disjoint intervals and perfect powers. The case r=1 was famously solved by Erdős and Selfridge in 1975, showing that no product of consecutive integers is a perfect power. The general case for r > 1 intervals remains OPEN.",
+    "summary": "We formalize Erd\u0151s Problem #930 about products of integers from disjoint intervals and perfect powers. The case r=1 was famously solved by Erd\u0151s and Selfridge in 1975, showing that no product of consecutive integers is a perfect power. The general case for r > 1 intervals remains OPEN.",
     "implications": "**Theoretical Significance**: This problem connects prime factorization structure with the arithmetic of interval products.\n\nUnderstanding why consecutive products avoid being powers reveals deep facts about how primes distribute in these products. Progress here would illuminate the multiplicative structure of factorial-like numbers.",
     "openQuestions": [
       "Does the conjecture hold for r = 2 disjoint intervals?",
-      "What is the minimal k(r) such that r intervals of length ≥ k have non-power product?",
-      "Can the Erdős-Selfridge method extend to multiple intervals?",
-      "What is the relationship to Catalan's conjecture (now Mihăilescu's theorem)?"
+      "What is the minimal k(r) such that r intervals of length \u2265 k have non-power product?",
+      "Can the Erd\u0151s-Selfridge method extend to multiple intervals?",
+      "What is the relationship to Catalan's conjecture (now Mih\u0103ilescu's theorem)?"
     ]
   },
   "leanFile": {
@@ -152,17 +152,17 @@
     {
       "targetId": "erdos-1094",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: number-theory, prime-factorization"
+      "description": "Related Erd\u0151s problem sharing themes: number-theory, prime-factorization"
     },
     {
       "targetId": "erdos-1108",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: number-theory, perfect-powers"
+      "description": "Related Erd\u0151s problem sharing themes: number-theory, perfect-powers"
     },
     {
       "targetId": "erdos-137",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: number-theory, prime-factorization"
+      "description": "Related Erd\u0151s problem sharing themes: number-theory, prime-factorization"
     }
   ]
 }

--- a/src/data/proofs/erdos-947/meta.json
+++ b/src/data/proofs/erdos-947/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-947",
-  "title": "Erdős Problem #947: No Exact Covering Systems Exist",
+  "title": "Erd\u0151s Problem #947: No Exact Covering Systems Exist",
   "slug": "erdos-947",
-  "description": "There is no exact covering system with distinct moduli - no finite collection of congruence classes aᵢ (mod nᵢ) with distinct nᵢ can partition ℤ exactly. Proved independently by Mirsky-Newman and Davenport-Rado.",
+  "description": "There is no exact covering system with distinct moduli - no finite collection of congruence classes a\u1d62 (mod n\u1d62) with distinct n\u1d62 can partition \u2124 exactly. Proved independently by Mirsky-Newman and Davenport-Rado.",
   "meta": {
     "author": "Mirsky-Newman, Davenport-Rado",
     "sourceUrl": "https://erdosproblems.com/947",
@@ -45,14 +45,14 @@
       },
       {
         "theorem": "BigOperators",
-        "description": "Finite sums for density sum Σ 1/nᵢ",
+        "description": "Finite sums for density sum \u03a3 1/n\u1d62",
         "module": "Mathlib.Algebra.BigOperators.Group.Finset"
       }
     ],
     "originalContributions": [
-      "Lean formalization of covering systems using Finset of (ℤ × ℕ) pairs",
-      "Definition of exact covering (partition property via ∃!)",
-      "Density argument formalization with densitySum as ℚ-valued sum",
+      "Lean formalization of covering systems using Finset of (\u2124 \u00d7 \u2115) pairs",
+      "Definition of exact covering (partition property via \u2203!)",
+      "Density argument formalization with densitySum as \u211a-valued sum",
       "Axiomatized Mirsky-Newman / Davenport-Rado impossibility theorem",
       "Proved distinct_moduli_not_exact from the axiomatized main theorem",
       "Mirsky-Newman generating function axiom with substantive type",
@@ -62,17 +62,17 @@
     ],
     "axiomCount": 2,
     "lineCount": 192,
-    "assumptions": "6 axioms: exact_density_sum, no_exact_covering_system, mirsky_newman_argument, and 3 more. See Lean source for complete statements."
+    "assumptions": "2 axioms: no_exact_covering_system, covering_systems_exist. 0 sorries."
   },
   "overview": {
-    "historicalContext": "Covering systems were introduced by Erdős in the 1950s as a flexible tool in combinatorial number theory. A covering system is a finite collection of congruence classes $\\{a_i \\pmod{n_i}\\}$ such that every integer belongs to at least one class. The natural question of whether an 'exact' covering exists — one that partitions $\\mathbb{Z}$ into congruence classes with distinct moduli — was answered negatively by two independent proofs.\n\nMirsky and Newman proved the impossibility using generating functions: for an exact covering, the function $f(x) = \\sum_i x^{a_i}/(1 - x^{n_i})$ must equal $1/(1-x)$ (each integer represented exactly once as a power of $x$). Analyzing this identity near roots of unity of order $n_i$ reveals that distinct moduli cannot satisfy the resulting analytic constraints.\n\nDavenport and Rado gave an algebraic proof using LCM properties: if the moduli are $n_1 < n_2 < \\cdots < n_k$, the largest modulus $n_k$ must divide $\\text{lcm}(n_1, \\ldots, n_{k-1})$. This forces $n_k$ to be a factor of the LCM of smaller moduli, creating a contradiction with the partition requirement.\n\nThe result is sharp in two senses: ordinary covering systems (allowing overlaps) with distinct moduli do exist — for example $\\{0 \\pmod{2},\\, 0 \\pmod{3},\\, 1 \\pmod{4},\\, 5 \\pmod{6},\\, 7 \\pmod{12}\\}$ — and exact coverings exist when repeated moduli are allowed, as the trivial $\\{0 \\pmod{2},\\, 1 \\pmod{2}\\}$ demonstrates.\n\nA central observation is the density constraint: each class $a \\pmod{n}$ has natural density $1/n$, so for a partition the densities must sum to 1: $\\sum 1/n_i = 1$. While this equation has solutions with distinct $n_i$ (e.g., $1/2 + 1/3 + 1/6 = 1$), the additional constraint that the congruences partition $\\mathbb{Z}$ (not just have matching densities) is what makes the problem impossible.\n\n**Status**: SOLVED — Proved independently by Mirsky-Newman and Davenport-Rado.",
+    "historicalContext": "Covering systems were introduced by Erd\u0151s in the 1950s as a flexible tool in combinatorial number theory. A covering system is a finite collection of congruence classes $\\{a_i \\pmod{n_i}\\}$ such that every integer belongs to at least one class. The natural question of whether an 'exact' covering exists \u2014 one that partitions $\\mathbb{Z}$ into congruence classes with distinct moduli \u2014 was answered negatively by two independent proofs.\n\nMirsky and Newman proved the impossibility using generating functions: for an exact covering, the function $f(x) = \\sum_i x^{a_i}/(1 - x^{n_i})$ must equal $1/(1-x)$ (each integer represented exactly once as a power of $x$). Analyzing this identity near roots of unity of order $n_i$ reveals that distinct moduli cannot satisfy the resulting analytic constraints.\n\nDavenport and Rado gave an algebraic proof using LCM properties: if the moduli are $n_1 < n_2 < \\cdots < n_k$, the largest modulus $n_k$ must divide $\\text{lcm}(n_1, \\ldots, n_{k-1})$. This forces $n_k$ to be a factor of the LCM of smaller moduli, creating a contradiction with the partition requirement.\n\nThe result is sharp in two senses: ordinary covering systems (allowing overlaps) with distinct moduli do exist \u2014 for example $\\{0 \\pmod{2},\\, 0 \\pmod{3},\\, 1 \\pmod{4},\\, 5 \\pmod{6},\\, 7 \\pmod{12}\\}$ \u2014 and exact coverings exist when repeated moduli are allowed, as the trivial $\\{0 \\pmod{2},\\, 1 \\pmod{2}\\}$ demonstrates.\n\nA central observation is the density constraint: each class $a \\pmod{n}$ has natural density $1/n$, so for a partition the densities must sum to 1: $\\sum 1/n_i = 1$. While this equation has solutions with distinct $n_i$ (e.g., $1/2 + 1/3 + 1/6 = 1$), the additional constraint that the congruences partition $\\mathbb{Z}$ (not just have matching densities) is what makes the problem impossible.\n\n**Status**: SOLVED \u2014 Proved independently by Mirsky-Newman and Davenport-Rado.",
     "problemStatement": "**Problem (SOLVED)**\n\nThere is no exact covering system with distinct moduli: no finite collection of congruence classes $a_i \\pmod{n_i}$ with distinct moduli $n_1, n_2, \\ldots, n_k$ (all different) can partition $\\mathbb{Z}$, i.e., cover every integer exactly once.\n\n**Known results:**\n- Mirsky-Newman proof via generating function analysis\n- Davenport-Rado proof via LCM divisibility\n- Density constraint: $\\sum 1/n_i = 1$ is necessary but not sufficient\n- Ordinary covering systems (with overlaps) using distinct moduli do exist",
-    "text": "There is no exact covering system with distinct moduli - no finite collection of congruence classes aᵢ (mod nᵢ) with distinct nᵢ can partition ℤ exactly. Proved independently by Mirsky-Newman and Davenport-Rado.",
-    "proofStrategy": "**Formalization Strategy**\n\nThe Lean file (208 lines) formalizes the problem with definitions, axioms, and proved results:\n\n1. **Core definitions** (lines 47–79): `CongruenceClass a n` as $\\{x : x \\equiv a \\pmod{n}\\}$. `CoveringSystem` as a structure with `classes : Finset (ℤ × ℕ)`, nonemptiness, positive moduli, and the covering property. `hasDistinctModuli` requires injectivity on moduli. `isExact` requires $\\exists!$ (exists unique) for each integer.\n\n2. **Density argument** (lines 83–101): `density n = 1/n` and `densitySum C = \\sum_{p \\in C} 1/p.2`. The axiom `exact_density_sum` states that exact coverings have density sum 1.\n\n3. **Main theorem** (lines 107–121): `no_exact_covering_system` axiomatizes the impossibility. `distinct_moduli_not_exact` is *proved* as the contrapositive.\n\n4. **Proof techniques** (lines 129–148): `mirsky_newman_argument` and `davenport_rado_argument` axiomatized with substantive types (not trivial `True`).\n\n5. **Contrast results** (lines 157–183): `covering_systems_exist` and `erdos_covering_example` axiomatized. `exactCoveringWithRepeats` is a *verified* construction of $\\{0 \\pmod{2}, 1 \\pmod{2}\\}$.\n\n6. **Summary** (lines 201–206): `erdos_947_summary` *proved* by combining the axiomatized impossibility with existence of ordinary coverings.",
+    "text": "There is no exact covering system with distinct moduli - no finite collection of congruence classes a\u1d62 (mod n\u1d62) with distinct n\u1d62 can partition \u2124 exactly. Proved independently by Mirsky-Newman and Davenport-Rado.",
+    "proofStrategy": "**Formalization Strategy**\n\nThe Lean file (208 lines) formalizes the problem with definitions, axioms, and proved results:\n\n1. **Core definitions** (lines 47\u201379): `CongruenceClass a n` as $\\{x : x \\equiv a \\pmod{n}\\}$. `CoveringSystem` as a structure with `classes : Finset (\u2124 \u00d7 \u2115)`, nonemptiness, positive moduli, and the covering property. `hasDistinctModuli` requires injectivity on moduli. `isExact` requires $\\exists!$ (exists unique) for each integer.\n\n2. **Density argument** (lines 83\u2013101): `density n = 1/n` and `densitySum C = \\sum_{p \\in C} 1/p.2`. The axiom `exact_density_sum` states that exact coverings have density sum 1.\n\n3. **Main theorem** (lines 107\u2013121): `no_exact_covering_system` axiomatizes the impossibility. `distinct_moduli_not_exact` is *proved* as the contrapositive.\n\n4. **Proof techniques** (lines 129\u2013148): `mirsky_newman_argument` and `davenport_rado_argument` axiomatized with substantive types (not trivial `True`).\n\n5. **Contrast results** (lines 157\u2013183): `covering_systems_exist` and `erdos_covering_example` axiomatized. `exactCoveringWithRepeats` is a *verified* construction of $\\{0 \\pmod{2}, 1 \\pmod{2}\\}$.\n\n6. **Summary** (lines 201\u2013206): `erdos_947_summary` *proved* by combining the axiomatized impossibility with existence of ordinary coverings.",
     "keyInsights": [
-      "**Density constraint**: For an exact covering $\\sum 1/n_i = 1$, but this alone is insufficient — $1/2 + 1/3 + 1/6 = 1$ with distinct moduli, yet no corresponding partition of $\\mathbb{Z}$ exists",
+      "**Density constraint**: For an exact covering $\\sum 1/n_i = 1$, but this alone is insufficient \u2014 $1/2 + 1/3 + 1/6 = 1$ with distinct moduli, yet no corresponding partition of $\\mathbb{Z}$ exists",
       "**Two independent proofs**: Mirsky-Newman used generating function analysis near roots of unity; Davenport-Rado used LCM divisibility of the largest modulus",
-      "**Sharp boundary**: Ordinary covering systems with distinct moduli exist (Erdős's example with moduli $\\{2, 3, 4, 6, 12\\}$), so the impossibility is specific to the exactness requirement",
+      "**Sharp boundary**: Ordinary covering systems with distinct moduli exist (Erd\u0151s's example with moduli $\\{2, 3, 4, 6, 12\\}$), so the impossibility is specific to the exactness requirement",
       "**Verified construction**: `exactCoveringWithRepeats` proves that $\\{0 \\pmod{2}, 1 \\pmod{2}\\}$ is an exact covering, showing the distinct moduli constraint is essential",
       "**Structural insight**: The $\\exists!$ quantifier in `isExact` formalizes the partition property, distinguishing exact from ordinary coverings"
     ],
@@ -87,7 +87,7 @@
       "title": "Basic Definitions",
       "startLine": 47,
       "endLine": 79,
-      "summary": "Defines `CongruenceClass a n` as $\\{x : x \\bmod n = a \\bmod n\\}$. `CoveringSystem` is a structure with `classes : Finset (ℤ \\times \\mathbb{N})$, nonemptiness, positive moduli, and the covering property $\\forall x, \\exists p \\in \\text{classes}, x \\bmod p.2 = p.1 \\bmod p.2$. `hasDistinctModuli` requires modulus-injectivity. `isExact` requires $\\exists!$ for each integer."
+      "summary": "Defines `CongruenceClass a n` as $\\{x : x \\bmod n = a \\bmod n\\}$. `CoveringSystem` is a structure with `classes : Finset (\u2124 \\times \\mathbb{N})$, nonemptiness, positive moduli, and the covering property $\\forall x, \\exists p \\in \\text{classes}, x \\bmod p.2 = p.1 \\bmod p.2$. `hasDistinctModuli` requires modulus-injectivity. `isExact` requires $\\exists!$ for each integer."
     },
     {
       "id": "density-argument",
@@ -119,8 +119,8 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #947 with complete definitions of covering systems, exact coverings, and distinct moduli. It axiomatizes the Mirsky-Newman / Davenport-Rado impossibility theorem with two substantive proof technique axioms, proves the contrapositive formulation, verifies an exact covering with repeated moduli, and proves a summary theorem combining impossibility with existence of ordinary coverings.",
-    "implications": "1. **Partition vs. covering**: The result reveals a fundamental asymmetry — $\\mathbb{Z}$ can be covered but not partitioned by congruences with distinct moduli\n\n**2. Density constraints**: The necessary condition $\\sum 1/n_i = 1$ is not sufficient, illustrating that global density does not determine local partition structure\n\n3. **Covering system theory**: This impossibility is foundational for the broader theory of covering systems, which connects to the Hanna Neumann conjecture, the odd perfect number problem, and Schinzel's conjecture\n\n4. **Two proof paradigms**: The Mirsky-Newman analytic approach and Davenport-Rado algebraic approach illustrate complementary techniques in combinatorial number theory.",
+    "summary": "This formalization captures Erd\u0151s Problem #947 with complete definitions of covering systems, exact coverings, and distinct moduli. It axiomatizes the Mirsky-Newman / Davenport-Rado impossibility theorem with two substantive proof technique axioms, proves the contrapositive formulation, verifies an exact covering with repeated moduli, and proves a summary theorem combining impossibility with existence of ordinary coverings.",
+    "implications": "1. **Partition vs. covering**: The result reveals a fundamental asymmetry \u2014 $\\mathbb{Z}$ can be covered but not partitioned by congruences with distinct moduli\n\n**2. Density constraints**: The necessary condition $\\sum 1/n_i = 1$ is not sufficient, illustrating that global density does not determine local partition structure\n\n3. **Covering system theory**: This impossibility is foundational for the broader theory of covering systems, which connects to the Hanna Neumann conjecture, the odd perfect number problem, and Schinzel's conjecture\n\n4. **Two proof paradigms**: The Mirsky-Newman analytic approach and Davenport-Rado algebraic approach illustrate complementary techniques in combinatorial number theory.",
     "openQuestions": [
       "What is the minimum overlap in a covering system with distinct moduli?",
       "How close to exact can a distinct-moduli covering system get in terms of the maximum number of times any integer is covered?",
@@ -153,7 +153,7 @@
   "references": [
     {
       "key": "MiNe",
-      "citation": "Mirsky, L. and Newman, D.J. On an exact covering system (unpublished but widely cited through Erdős's references).",
+      "citation": "Mirsky, L. and Newman, D.J. On an exact covering system (unpublished but widely cited through Erd\u0151s's references).",
       "type": "paper"
     },
     {
@@ -163,7 +163,7 @@
     },
     {
       "key": "Er77c",
-      "citation": "Erdős, P. (1977). Problems and results on combinatorial number theory III. In Number Theory Day, Springer Lecture Notes in Mathematics 626, 43-72.",
+      "citation": "Erd\u0151s, P. (1977). Problems and results on combinatorial number theory III. In Number Theory Day, Springer Lecture Notes in Mathematics 626, 43-72.",
       "type": "paper"
     }
   ],
@@ -171,17 +171,17 @@
     {
       "targetId": "erdos-2",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: covering-systems, modular-arithmetic, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: covering-systems, modular-arithmetic, number-theory"
     },
     {
       "targetId": "erdos-273",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: covering-systems, modular-arithmetic, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: covering-systems, modular-arithmetic, number-theory"
     },
     {
       "targetId": "erdos-275",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: congruences, covering-systems, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: congruences, covering-systems, number-theory"
     }
   ]
 }


### PR DESCRIPTION
## Fix

Corrects stale `assumptions` text in 10 gallery proof `meta.json` files.

## Changes

| Proof | Old count | New count |
|-------|-----------|-----------|
| erdos-947 | 6 | 2 |
| erdos-930 | 5 | 1 |
| erdos-918 | 7 | 3 |
| erdos-903 | 9 | 5 |
| erdos-9 | 6 | 2 |
| erdos-855 | 6 | 2 |
| erdos-854 | 4 | 0 |
| erdos-847 | 5 | 1 |
| erdos-843 | 6 | 2 |
| erdos-835 | 10 | 6 |

---
Automated fix by lean-mechanic agent.