### PR TITLE
fix(meta): correct stale assumptions text for 10 gallery proofs (batch 33)

### DIFF
--- a/src/data/proofs/erdos-743/meta.json
+++ b/src/data/proofs/erdos-743/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-743",
-  "title": "Erdős Problem #743: Tree Packing Conjecture",
+  "title": "Erd\u0151s Problem #743: Tree Packing Conjecture",
   "slug": "erdos-743",
-  "description": "Can Kₙ always be decomposed as edge-disjoint union of trees T₂,...,Tₙ where Tₖ has k vertices? Known for stars/paths (1978), bounded degree (2019), and small/large trees. OPEN in full generality.",
+  "description": "Can K\u2099 always be decomposed as edge-disjoint union of trees T\u2082,...,T\u2099 where T\u2096 has k vertices? Known for stars/paths (1978), bounded degree (2019), and small/large trees. OPEN in full generality.",
   "meta": {
-    "author": "Gyárfás-Lehel (1978), Bollobás (1983), JKKO (2019), Janzer-Montgomery (2024)",
+    "author": "Gy\u00e1rf\u00e1s-Lehel (1978), Bollob\u00e1s (1983), JKKO (2019), Janzer-Montgomery (2024)",
     "sourceUrl": "https://erdosproblems.com/743",
     "date": "2024",
     "status": "axiomatized",
@@ -43,7 +43,7 @@
       "boundedDegreeCollection definition",
       "treePackingConjecture: formal statement of the open problem",
       "gyarfasLehel_stars and gyarfasLehel_starsPaths axioms (1978)",
-      "fishburn_small_n axiom: n ≤ 9 (1983)",
+      "fishburn_small_n axiom: n \u2264 9 (1983)",
       "bollobas_greedy axiom: small trees (1983)",
       "jkko_boundedDegree axiom: bounded degree (2019)",
       "allen_sublinearDegree axiom: cn/log n degree (2021)",
@@ -53,18 +53,18 @@
     ],
     "axiomCount": 8,
     "lineCount": 162,
-    "assumptions": "12 axiom(s) and 0 sorry(s). See the Lean source for details."
+    "assumptions": "8 axioms: TreeType, canPack, maxDegree, isStar, isPath, gyarfasLehel_starsPaths, fishburn_small_n, jkko_boundedDegree. 0 sorries."
   },
   "overview": {
-    "historicalContext": "The Tree Packing Conjecture was posed by Gyárfás and Lehel in 1978. It asks whether any collection of trees T₂, T₃, ..., Tₙ (where Tₖ has k vertices) can be packed edge-disjointly into the complete graph Kₙ. A necessary condition is that the total number of edges matches: Σ(k-1) = n(n-1)/2 = |E(Kₙ)|, and this is indeed satisfied. Gyárfás and Lehel proved the conjecture when all trees are stars and/or paths.\n\nThe problem attracted major attention over four decades. Fishburn (1983) verified small cases (n ≤ 9). Bollobás (1983) showed the smallest ⌊n/√2⌋ trees can always be packed greedily, handling roughly 70% of the collection. The breakthrough came with Joos, Kim, Kühn, and Osthus (2019), who proved the conjecture for bounded-degree tree collections using regularity methods. Allen et al. (2021) extended this to trees with max degree ≤ cn/log n.\n\nMost recently, Janzer and Montgomery (2024) proved that the largest cn trees can always be packed, complementing Bollobás's result for small trees. However, trees of intermediate size (roughly 0.7n to (1-c)n vertices) remain unresolved. The related Ringel Conjecture — decomposing K_{2n+1} into copies of a single tree — was proved by Montgomery, Pokrovskiy, and Sudakov (2021), but that result does not directly imply the tree packing conjecture.",
+    "historicalContext": "The Tree Packing Conjecture was posed by Gy\u00e1rf\u00e1s and Lehel in 1978. It asks whether any collection of trees T\u2082, T\u2083, ..., T\u2099 (where T\u2096 has k vertices) can be packed edge-disjointly into the complete graph K\u2099. A necessary condition is that the total number of edges matches: \u03a3(k-1) = n(n-1)/2 = |E(K\u2099)|, and this is indeed satisfied. Gy\u00e1rf\u00e1s and Lehel proved the conjecture when all trees are stars and/or paths.\n\nThe problem attracted major attention over four decades. Fishburn (1983) verified small cases (n \u2264 9). Bollob\u00e1s (1983) showed the smallest \u230an/\u221a2\u230b trees can always be packed greedily, handling roughly 70% of the collection. The breakthrough came with Joos, Kim, K\u00fchn, and Osthus (2019), who proved the conjecture for bounded-degree tree collections using regularity methods. Allen et al. (2021) extended this to trees with max degree \u2264 cn/log n.\n\nMost recently, Janzer and Montgomery (2024) proved that the largest cn trees can always be packed, complementing Bollob\u00e1s's result for small trees. However, trees of intermediate size (roughly 0.7n to (1-c)n vertices) remain unresolved. The related Ringel Conjecture \u2014 decomposing K_{2n+1} into copies of a single tree \u2014 was proved by Montgomery, Pokrovskiy, and Sudakov (2021), but that result does not directly imply the tree packing conjecture.",
     "problemStatement": "Let $T_2, T_3, \\ldots, T_n$ be trees where $T_k$ has $k$ vertices. Can $K_n$ always be decomposed as the edge-disjoint union of the $T_k$? The edge count $\\sum_{k=2}^{n}(k-1) = n(n-1)/2 = |E(K_n)|$ is a necessary condition that is satisfied. **Known cases:** stars/paths (1978), $n \\leq 9$ (1983), bounded degree (2019), max degree $\\leq cn/\\log n$ (2021). STATUS: OPEN.",
-    "text": "Can Kₙ always be decomposed as edge-disjoint union of trees T₂,...,Tₙ where Tₖ has k vertices? Known for stars/paths (1978), bounded degree (2019), and small/large trees. OPEN in full generality.",
-    "proofStrategy": "The formalization axiomatizes TreeType and canPack since full graph-theoretic tree and packing definitions require substantial infrastructure. Tree classifications (isStar, isPath, maxDegree) are axiomatized. The key partial results are stated as axioms with their precise quantitative forms. The summary theorem combines three major results (Fishburn, Gyárfás-Lehel, JKKO) into a single proved statement. Edge count verification uses a constructive proof via norm_num.",
+    "text": "Can K\u2099 always be decomposed as edge-disjoint union of trees T\u2082,...,T\u2099 where T\u2096 has k vertices? Known for stars/paths (1978), bounded degree (2019), and small/large trees. OPEN in full generality.",
+    "proofStrategy": "The formalization axiomatizes TreeType and canPack since full graph-theoretic tree and packing definitions require substantial infrastructure. Tree classifications (isStar, isPath, maxDegree) are axiomatized. The key partial results are stated as axioms with their precise quantitative forms. The summary theorem combines three major results (Fishburn, Gy\u00e1rf\u00e1s-Lehel, JKKO) into a single proved statement. Edge count verification uses a constructive proof via norm_num.",
     "keyInsights": [
-      "**Edge Count Match**: Σ(k-1) for k=2..n = n(n-1)/2 = |E(Kₙ)| — a necessary condition that holds",
+      "**Edge Count Match**: \u03a3(k-1) for k=2..n = n(n-1)/2 = |E(K\u2099)| \u2014 a necessary condition that holds",
       "**Stars/Paths Easy**: Simple tree types pack readily; complex branching creates challenges",
       "**Degree Matters**: Bounded degree trees (JKKO 2019) and sublinear degree (Allen 2021) are tractable",
-      "**Small + Large**: Bollobás packs the smallest ⌊n/√2⌋; Janzer-Montgomery packs the largest cn",
+      "**Small + Large**: Bollob\u00e1s packs the smallest \u230an/\u221a2\u230b; Janzer-Montgomery packs the largest cn",
       "**Middle Gap**: Trees of size roughly 0.7n to (1-c)n remain the hardest case"
     ],
     "prerequisites": [
@@ -100,7 +100,7 @@
     },
     {
       "id": "gyarfas-lehel",
-      "title": "Gyárfás-Lehel Results",
+      "title": "Gy\u00e1rf\u00e1s-Lehel Results",
       "startLine": 97,
       "endLine": 112,
       "summary": "Stars case and stars/paths case axioms",
@@ -140,7 +140,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #743 (Tree Packing Conjecture) asks whether Kₙ can be decomposed into trees T₂,...,Tₙ where Tₖ has k vertices. Major partial results span 46 years: Gyárfás-Lehel (1978, stars/paths), Fishburn (1983, n≤9), Bollobás (1983, small trees), JKKO (2019, bounded degree), Allen et al. (2021, sublinear degree), Janzer-Montgomery (2024, large trees). The full conjecture remains open.",
+    "summary": "Erd\u0151s Problem #743 (Tree Packing Conjecture) asks whether K\u2099 can be decomposed into trees T\u2082,...,T\u2099 where T\u2096 has k vertices. Major partial results span 46 years: Gy\u00e1rf\u00e1s-Lehel (1978, stars/paths), Fishburn (1983, n\u22649), Bollob\u00e1s (1983, small trees), JKKO (2019, bounded degree), Allen et al. (2021, sublinear degree), Janzer-Montgomery (2024, large trees). The full conjecture remains open.",
     "implications": "A positive resolution would be a landmark in graph decomposition theory. The techniques developed for partial results (regularity methods, probabilistic arguments, absorbing methods) have broader applications in extremal combinatorics.",
     "openQuestions": [
       "Prove the full Tree Packing Conjecture",
@@ -171,17 +171,17 @@
     {
       "targetId": "erdos-557",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, graph-theory, open, trees"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, graph-theory, open, trees"
     },
     {
       "targetId": "erdos-1014",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, graph-theory, open"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, graph-theory, open"
     },
     {
       "targetId": "erdos-1105",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, graph-theory, open"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, graph-theory, open"
     }
   ]
 }

--- a/src/data/proofs/erdos-744/meta.json
+++ b/src/data/proofs/erdos-744/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-744",
-  "title": "Erdős Problem #744: Critical Graphs and Bipartition",
+  "title": "Erd\u0151s Problem #744: Critical Graphs and Bipartition",
   "slug": "erdos-744",
-  "description": "Does f_k(n) tend to infinity, where f_k(n) is the minimum edges to delete from a k-chromatic critical graph on n vertices to make it bipartite? Disproved by Rödl and Tuza (1985): f_k(n) = C(k-1,2) for large n.",
+  "description": "Does f_k(n) tend to infinity, where f_k(n) is the minimum edges to delete from a k-chromatic critical graph on n vertices to make it bipartite? Disproved by R\u00f6dl and Tuza (1985): f_k(n) = C(k-1,2) for large n.",
   "meta": {
-    "author": "Rödl-Tuza (1985 disproof), Erdős-Hajnal-Szemerédi (1982 conjecture)",
+    "author": "R\u00f6dl-Tuza (1985 disproof), Erd\u0151s-Hajnal-Szemer\u00e9di (1982 conjecture)",
     "sourceUrl": "https://erdosproblems.com/744",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos744Problem.lean",
@@ -44,34 +44,34 @@
       "chromaticNumber axiom for graph coloring",
       "isKChromatic and isCritical definitions for critical graphs",
       "isBipartite definition via chromatic number",
-      "bipartite_iff_no_odd_cycle axiom (König characterization)",
+      "bipartite_iff_no_odd_cycle axiom (K\u00f6nig characterization)",
       "bipartitionNumber definition for edge deletion to bipartiteness",
       "f function: the f_k(n) function central to the problem",
       "f_3_equals_1 theorem: odd cycles need 1 edge removed",
-      "gallai_upper_bound axiom: O(√n) bound for k=4",
+      "gallai_upper_bound axiom: O(\u221an) bound for k=4",
       "lovasz_upper_bound axiom: generalized bound",
       "erdosOriginalConjecture and erdosLogConjecture definitions",
       "rodl_tuza_theorem axiom: the disproof, f_k(n) = C(k-1,2)",
       "f_4_eventually_3 and f_5_eventually_6 theorems",
       "complete_graph_edges theorem relating to binomial coefficients",
       "erdos_conjecture_false theorem: negation of the conjecture",
-      "f_k_formula theorem: general formula via Rödl-Tuza",
+      "f_k_formula theorem: general formula via R\u00f6dl-Tuza",
       "erdos_744_statement theorem: combined main result"
     ],
     "axiomCount": 2,
     "lineCount": 344,
-    "assumptions": "6 axiom(s) and 1 sorry (edge-deletion existence). See the Lean source for details."
+    "assumptions": "2 axioms: chromaticNumber, rodl_tuza_theorem. 1 sorries."
   },
   "overview": {
-    "historicalContext": "Erdős Problem #744 originates from a question posed by Erdős, Hajnal, and Szemerédi in the early 1980s (references [Er81] and [EHS82]). The problem concerns a fundamental question about the structure of k-chromatic critical graphs: how many edges must be removed to make such a graph bipartite? The function f_k(n) measures the minimum number of edge deletions needed across all k-critical graphs on n vertices.\n\nThe case k = 3 is trivial: the only 3-critical graphs are odd cycles, and removing any single edge yields a path (which is bipartite), so f_3(n) = 1. For k ≥ 4, early results were encouraging for the conjecture. Gallai (1968) established that f_4(n) ≤ O(√n), and Lovász extended this to f_k(n) ≤ O(n^{1-1/(k-2)}) for general k. Erdős and collaborators conjectured that f_k(n) → ∞ as n → ∞, and specifically asked whether f_4(n) grows at least as fast as log(n).\n\nIn a surprising turn, Rödl and Tuza disproved the conjecture entirely in 1985. They showed that for every fixed k ≥ 3, the function f_k(n) is eventually constant: f_k(n) = C(k-1, 2) = (k-1)(k-2)/2 for all sufficiently large n. This means the non-bipartiteness of large k-critical graphs is concentrated in a bounded substructure, regardless of the total graph size.",
-    "problemStatement": "Let $f_k(n)$ be the minimum number of edges whose deletion makes a $k$-chromatic critical graph on $n$ vertices bipartite.\n\nDoes $f_k(n) \\to \\infty$ as $n \\to \\infty$?\n\n**Answer:** NO.\n\n**Rödl-Tuza Theorem (1985):** For all $k \\geq 3$ and sufficiently large $n$:\n$$f_k(n) = \\binom{k-1}{2} = \\frac{(k-1)(k-2)}{2}$$\n\nThe function is eventually constant, not unbounded.",
-    "text": "Does f_k(n) tend to infinity, where f_k(n) is the minimum edges to delete from a k-chromatic critical graph on n vertices to make it bipartite? Disproved by Rödl and Tuza (1985): f_k(n) = C(k-1,2) for large n.",
-    "proofStrategy": "The formalization proceeds in ten parts:\n\n1. **Graph foundations:** We define SimpleGraph' with an adjacency predicate and axiomatize the chromatic number.\n\n2. **Critical graphs:** A graph is k-critical if χ(G) = k and removing any edge reduces the chromatic number. This captures the notion of \"minimal\" k-colorable graphs.\n\n3. **Bipartite characterization:** Bipartite graphs are defined as those with χ(G) ≤ 2, with an axiom connecting this to the absence of odd cycles.\n\n4. **The f_k function:** We define f_k(n) using the known values from Rödl-Tuza, which gives f_k(n) = (k-1)(k-2)/2 for k ≥ 4.\n\n5. **Disproof:** We state the original conjecture formally, axiomatize the Rödl-Tuza theorem, and derive that the conjecture is false. We also show specific instances like f_4 = 3 and f_5 = 6.",
+    "historicalContext": "Erd\u0151s Problem #744 originates from a question posed by Erd\u0151s, Hajnal, and Szemer\u00e9di in the early 1980s (references [Er81] and [EHS82]). The problem concerns a fundamental question about the structure of k-chromatic critical graphs: how many edges must be removed to make such a graph bipartite? The function f_k(n) measures the minimum number of edge deletions needed across all k-critical graphs on n vertices.\n\nThe case k = 3 is trivial: the only 3-critical graphs are odd cycles, and removing any single edge yields a path (which is bipartite), so f_3(n) = 1. For k \u2265 4, early results were encouraging for the conjecture. Gallai (1968) established that f_4(n) \u2264 O(\u221an), and Lov\u00e1sz extended this to f_k(n) \u2264 O(n^{1-1/(k-2)}) for general k. Erd\u0151s and collaborators conjectured that f_k(n) \u2192 \u221e as n \u2192 \u221e, and specifically asked whether f_4(n) grows at least as fast as log(n).\n\nIn a surprising turn, R\u00f6dl and Tuza disproved the conjecture entirely in 1985. They showed that for every fixed k \u2265 3, the function f_k(n) is eventually constant: f_k(n) = C(k-1, 2) = (k-1)(k-2)/2 for all sufficiently large n. This means the non-bipartiteness of large k-critical graphs is concentrated in a bounded substructure, regardless of the total graph size.",
+    "problemStatement": "Let $f_k(n)$ be the minimum number of edges whose deletion makes a $k$-chromatic critical graph on $n$ vertices bipartite.\n\nDoes $f_k(n) \\to \\infty$ as $n \\to \\infty$?\n\n**Answer:** NO.\n\n**R\u00f6dl-Tuza Theorem (1985):** For all $k \\geq 3$ and sufficiently large $n$:\n$$f_k(n) = \\binom{k-1}{2} = \\frac{(k-1)(k-2)}{2}$$\n\nThe function is eventually constant, not unbounded.",
+    "text": "Does f_k(n) tend to infinity, where f_k(n) is the minimum edges to delete from a k-chromatic critical graph on n vertices to make it bipartite? Disproved by R\u00f6dl and Tuza (1985): f_k(n) = C(k-1,2) for large n.",
+    "proofStrategy": "The formalization proceeds in ten parts:\n\n1. **Graph foundations:** We define SimpleGraph' with an adjacency predicate and axiomatize the chromatic number.\n\n2. **Critical graphs:** A graph is k-critical if \u03c7(G) = k and removing any edge reduces the chromatic number. This captures the notion of \"minimal\" k-colorable graphs.\n\n3. **Bipartite characterization:** Bipartite graphs are defined as those with \u03c7(G) \u2264 2, with an axiom connecting this to the absence of odd cycles.\n\n4. **The f_k function:** We define f_k(n) using the known values from R\u00f6dl-Tuza, which gives f_k(n) = (k-1)(k-2)/2 for k \u2265 4.\n\n5. **Disproof:** We state the original conjecture formally, axiomatize the R\u00f6dl-Tuza theorem, and derive that the conjecture is false. We also show specific instances like f_4 = 3 and f_5 = 6.",
     "keyInsights": [
       "**Critical Graph Structure:** A k-critical graph is one requiring exactly k colors, where every proper subgraph needs fewer. These are the 'minimal' examples of k-colorability.",
-      "**Odd Cycle Case (k=3):** The only 3-critical graphs are odd cycles. Removing one edge gives a path (bipartite), so f_3(n) = 1 — trivially bounded.",
-      "**Rödl-Tuza Surprise:** f_k(n) = C(k-1, 2) for large n. The non-bipartiteness doesn't spread as graphs grow; it stays concentrated in a clique of size k-1.",
-      "**Bounded vs. Unbounded:** Erdős expected f_k to grow without bound. The answer being a constant — the number of edges in K_{k-1} — was completely unexpected.",
+      "**Odd Cycle Case (k=3):** The only 3-critical graphs are odd cycles. Removing one edge gives a path (bipartite), so f_3(n) = 1 \u2014 trivially bounded.",
+      "**R\u00f6dl-Tuza Surprise:** f_k(n) = C(k-1, 2) for large n. The non-bipartiteness doesn't spread as graphs grow; it stays concentrated in a clique of size k-1.",
+      "**Bounded vs. Unbounded:** Erd\u0151s expected f_k to grow without bound. The answer being a constant \u2014 the number of edges in K_{k-1} \u2014 was completely unexpected.",
       "**Specific Values:** f_3 = 1, f_4 = 3, f_5 = 6, f_6 = 10, f_7 = 15, following the triangular number pattern C(k-1, 2)."
     ],
     "prerequisites": [
@@ -99,10 +99,10 @@
     {
       "id": "edge-deletion",
       "title": "Edge Deletion and f_k(n)",
-      "summary": "bipartitionNumber, f — the central function of the problem",
+      "summary": "bipartitionNumber, f \u2014 the central function of the problem",
       "startLine": 88,
       "endLine": 117,
-      "mathContext": "Mathematical content: bipartitionNumber, f — the central function of the problem"
+      "mathContext": "Mathematical content: bipartitionNumber, f \u2014 the central function of the problem"
     },
     {
       "id": "known-results",
@@ -115,14 +115,14 @@
     {
       "id": "original-conjecture",
       "title": "The Original Conjecture",
-      "summary": "erdosOriginalConjecture, erdosLogConjecture — what Erdős expected",
+      "summary": "erdosOriginalConjecture, erdosLogConjecture \u2014 what Erd\u0151s expected",
       "startLine": 155,
       "endLine": 178,
-      "mathContext": "Mathematical content: erdosOriginalConjecture, erdosLogConjecture — what Erdős expected"
+      "mathContext": "Mathematical content: erdosOriginalConjecture, erdosLogConjecture \u2014 what Erd\u0151s expected"
     },
     {
       "id": "rodl-tuza",
-      "title": "Rödl-Tuza Theorem (1985)",
+      "title": "R\u00f6dl-Tuza Theorem (1985)",
       "summary": "rodl_tuza_theorem axiom, f_4_eventually_3, f_5_eventually_6",
       "startLine": 179,
       "endLine": 221,
@@ -131,10 +131,10 @@
     {
       "id": "counterexample-structure",
       "title": "Why the Conjecture Was False",
-      "summary": "complete_graph_chromatic, complete_graph_edges — structural insight",
+      "summary": "complete_graph_chromatic, complete_graph_edges \u2014 structural insight",
       "startLine": 222,
       "endLine": 248,
-      "mathContext": "Mathematical content: complete_graph_chromatic, complete_graph_edges — structural insight"
+      "mathContext": "Mathematical content: complete_graph_chromatic, complete_graph_edges \u2014 structural insight"
     },
     {
       "id": "consequences",
@@ -147,27 +147,27 @@
     {
       "id": "complete-picture",
       "title": "The Complete Picture",
-      "summary": "f_k_table, f_k_formula — table and general formula",
+      "summary": "f_k_table, f_k_formula \u2014 table and general formula",
       "startLine": 281,
       "endLine": 301,
-      "mathContext": "Mathematical content: f_k_table, f_k_formula — table and general formula"
+      "mathContext": "Mathematical content: f_k_table, f_k_formula \u2014 table and general formula"
     },
     {
       "id": "status",
       "title": "Problem Status and Main Statement",
-      "summary": "erdos_744_status, erdos_744_statement — summary theorem",
+      "summary": "erdos_744_status, erdos_744_statement \u2014 summary theorem",
       "startLine": 302,
       "endLine": 342,
-      "mathContext": "Verified: erdos_744_status, erdos_744_statement — summary theorem"
+      "mathContext": "Verified: erdos_744_status, erdos_744_statement \u2014 summary theorem"
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #744 asked whether f_k(n) → ∞ as n → ∞, where f_k(n) measures the minimum edge deletions needed to make a k-critical graph bipartite. Rödl and Tuza disproved this in 1985, showing f_k(n) = C(k-1,2) = (k-1)(k-2)/2 for all sufficiently large n — a constant independent of the number of vertices.",
+    "summary": "Erd\u0151s Problem #744 asked whether f_k(n) \u2192 \u221e as n \u2192 \u221e, where f_k(n) measures the minimum edge deletions needed to make a k-critical graph bipartite. R\u00f6dl and Tuza disproved this in 1985, showing f_k(n) = C(k-1,2) = (k-1)(k-2)/2 for all sufficiently large n \u2014 a constant independent of the number of vertices.",
     "implications": "**Theoretical Significance**: The disproof reveals a striking structural property of k-chromatic critical graphs: their non-bipartiteness is concentrated in a bounded region isomorphic to a complete graph on k-1 vertices.\n\nNo matter how large the critical graph grows, the same fixed number of edge deletions suffices to make it bipartite. This challenges the intuition that larger graphs should have more 'spread out' coloring obstructions.",
     "openQuestions": [
-      "What is the exact threshold N₀(k) beyond which f_k(n) = C(k-1, 2)?",
+      "What is the exact threshold N\u2080(k) beyond which f_k(n) = C(k-1, 2)?",
       "Do similar bounded-parameter phenomena hold for other graph coloring variants?",
-      "Can the Rödl-Tuza result be extended to list-chromatic or fractional chromatic critical graphs?"
+      "Can the R\u00f6dl-Tuza result be extended to list-chromatic or fractional chromatic critical graphs?"
     ]
   },
   "leanFile": {
@@ -196,17 +196,17 @@
     {
       "targetId": "erdos-1032",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: chromatic-number, critical-graphs, graph-theory"
+      "description": "Related Erd\u0151s problem sharing themes: chromatic-number, critical-graphs, graph-theory"
     },
     {
       "targetId": "erdos-1067",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: chromatic-number, disproved, graph-theory"
+      "description": "Related Erd\u0151s problem sharing themes: chromatic-number, disproved, graph-theory"
     },
     {
       "targetId": "erdos-110",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: chromatic-number, disproved, graph-theory"
+      "description": "Related Erd\u0151s problem sharing themes: chromatic-number, disproved, graph-theory"
     }
   ]
 }

--- a/src/data/proofs/erdos-771/meta.json
+++ b/src/data/proofs/erdos-771/meta.json
@@ -80,7 +80,7 @@
     ],
     "axiomCount": 2,
     "lineCount": 244,
-    "assumptions": "6 axiom(s) and 7 sorry(s). See the Lean source for details."
+    "assumptions": "2 axioms: erdos_graham_lower_bound, alon_freiman_upper_bound. 7 sorries."
   },
   "overview": {
     "historicalContext": "**Erdos Problem #771: Subsets Avoiding a Given Sum**\n\n**The Problem:**\nGiven n, what is the largest set S subset {1,...,n} such that for ANY prescribed target m, no nonempty subset of S sums to m? The function f(n) measures this worst-case avoidance capacity. Erdos and Graham conjectured f(n) = (1/2+o(1))n/log n.\n\n**The Lower Bound (Erdos-Graham):**\nFor any target m, take S = {multiples of p in [n]} where p is the smallest prime not dividing m. Every subset sum of S is divisible by p, but m is not, so S avoids m. The size |S| = floor(n/p). By the prime number theorem, the smallest prime not dividing m is at most (2+o(1))log m, giving |S| >= (1/2+o(1))n/log n. Bertrand's postulate guarantees such a prime exists.\n\n**The Upper Bound (Alon-Freiman, 1988):**\nThe clever target: choose m = lcm{1,...,s} where s is maximal with m small enough. By PNT, lcm{1,...,s} ~ e^s. Any set S larger than (1/2+o(1))n/log n must contain a nonempty subset summing to some multiple of each integer in {1,...,s}, which forces a subset sum equal to m.\n\n**Resolution:**\nThe conjecture is TRUE: f(n) = (1/2+o(1))n/log n. The constant 1/2 comes from the prime number theorem: the density of primes near x is 1/log x, so the smallest prime not dividing any given m is about 2 log m.\n\n**The Lean formalization** has 7 sorries (characterization of f, prime multiples properties, special cases, leading constant convergence, and the final epsilon-delta bridge). The structural framework is complete with the key axioms for the lower and upper bounds.",
@@ -218,17 +218,17 @@
     {
       "targetId": "erdos-237",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: additive-combinatorics, primes, solved"
+      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, primes, solved"
     },
     {
       "targetId": "erdos-473",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: additive-combinatorics, primes, solved"
+      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, primes, solved"
     },
     {
       "targetId": "erdos-874",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: additive-combinatorics, solved, subset-sums"
+      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, solved, subset-sums"
     }
   ]
 }

--- a/src/data/proofs/erdos-773/meta.json
+++ b/src/data/proofs/erdos-773/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-773",
-  "title": "Erdős Problem #773: Sidon Subsets of Perfect Squares",
+  "title": "Erd\u0151s Problem #773: Sidon Subsets of Perfect Squares",
   "slug": "erdos-773",
-  "description": "What is the max size of a Sidon subset of {1², 2², ..., N²}? OPEN: Lower bound N^{2/3} (Lefmann-Thiele), upper bound N/(log N)^{1/4} (Alon-Erdős). Is it N^{1-o(1)}?",
+  "description": "What is the max size of a Sidon subset of {1\u00b2, 2\u00b2, ..., N\u00b2}? OPEN: Lower bound N^{2/3} (Lefmann-Thiele), upper bound N/(log N)^{1/4} (Alon-Erd\u0151s). Is it N^{1-o(1)}?",
   "meta": {
-    "author": "Alon-Erdős (1985), Lefmann-Thiele (1995)",
+    "author": "Alon-Erd\u0151s (1985), Lefmann-Thiele (1995)",
     "sourceUrl": "https://erdosproblems.com/773",
     "date": "1985",
     "status": "axiomatized",
@@ -34,15 +34,15 @@
     ],
     "axiomCount": 2,
     "lineCount": 236,
-    "assumptions": "6 axiom(s) and 0 sorry(s). See the Lean source for details."
+    "assumptions": "2 axioms: lower_bound, upper_bound. 0 sorries."
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #773 (Sidon Subsets of Squares)**\n\nSimon Sidon, a Hungarian mathematician and friend of Erdős, introduced B₂ sequences in 1932 while studying Fourier series: a set $A$ is *Sidon* if all pairwise sums $a + b$ ($a \\le b$, $a, b \\in A$) are distinct. Erdős and Turán (1941) proved the foundational result that the maximum Sidon subset of $\\{1, \\ldots, N\\}$ has size $\\sim \\sqrt{N}$, establishing a bridge between additive combinatorics and extremal set theory.\n\nProblem #773, posed by Alon and Erdős in 1985, restricts the Sidon question to perfect squares: how large can a Sidon subset of $\\{1^2, 2^2, \\ldots, N^2\\}$ be? The restriction to squares introduces number-theoretic constraints absent in the general setting — specifically, the sums $a^2 + b^2$ are governed by Fermat's theorem on sums of two squares and Landau's 1908 asymptotic for their counting function.\n\n**Key Results:**\n- **Alon–Erdős (1985):** Lower bound $N^{2/3 - o(1)}$ via probabilistic random selection; upper bound $N/(\\log N)^{1/4}$ using Landau's theorem\n- **Lefmann–Thiele (1995):** Refined the probabilistic argument to achieve $N^{2/3}$ without the $o(1)$ loss\n- **Landau (1908):** The count of integers $\\le N$ representable as sums of two squares is $\\sim c \\cdot N/\\sqrt{\\log N}$, where $c \\approx 0.7642$ is the Landau–Ramanujan constant\n\n**Status:** OPEN — the gap between $N^{2/3}$ and $N/(\\log N)^{1/4}$ remains one of the central open problems connecting additive combinatorics with analytic number theory.",
-    "problemStatement": "**Problem Statement (OPEN)**\n\nWhat is the size of the largest Sidon subset A ⊆ {1², 2², ..., N²}? Is it N^{1-o(1)}?\n\n**Known Bounds:**\n- Lower: |A| ≥ c·N^{2/3} (Lefmann-Thiele 1995)\n- Upper: |A| ≤ C·N/(log N)^{1/4} (Alon-Erdős 1985)\n\n**Key Question:** Is the true answer closer to N^{1-o(1)} or N^{2/3}?",
-    "text": "What is the max size of a Sidon subset of {1², 2², ..., N²}? OPEN: Lower bound N^{2/3} (Lefmann-Thiele), upper bound N/(log N)^{1/4} (Alon-Erdős). Is it N^{1-o(1)}?",
-    "proofStrategy": "**Formalization Approach**\n\nThe Lean file formalizes Erdős Problem #773 in nine parts, progressing from definitions through known results to open questions:\n\n1. **Sidon Sets (Parts I–II):** Defines `IsSidon` via the distinct-sums characterization and `IsSidonAlt` via the representation function. Introduces `squaresUpTo N` as the image of the squaring map on `Fin (N+1)`.\n\n2. **Extremal Function (Part III):** Defines $f(N)$ as the supremum of $|A|$ over all Sidon subsets $A \\subseteq \\{1^2, \\ldots, N^2\\}$, and states the main question: is $f(N) = N^{1-o(1)}$?\n\n3. **Axiomatized Bounds (Part IV):** States the Lefmann–Thiele lower bound $f(N) \\ge c \\cdot N^{2/3}$ and the Alon–Erdős upper bound $f(N) \\le C \\cdot N/(\\log N)^{1/4}$ as axioms, reflecting the deep analytic and probabilistic arguments behind them.\n\n4. **Landau's Theorem (Part V):** Formalizes the asymptotic $S(N) \\sim c \\cdot N/\\sqrt{\\log N}$ for the count of sums of two squares, which is the key number-theoretic input for the upper bound.\n\n5. **Proof Sketches (Parts VI–VII):** Axiomatizes the probabilistic construction (random subset with density $N^{-1/3}$) and the upper bound argument (Sidon constraint + Landau sparsity forces $|A|^2 \\le N^2/(\\log N)^{1/2}$).\n\n6. **Open Questions (Parts VIII–IX):** Formalizes `trueOrder` as the existence of a sharp exponent $\\alpha \\in [2/3, 1)$ and summarizes the problem status.",
+    "historicalContext": "**Erd\u0151s Problem #773 (Sidon Subsets of Squares)**\n\nSimon Sidon, a Hungarian mathematician and friend of Erd\u0151s, introduced B\u2082 sequences in 1932 while studying Fourier series: a set $A$ is *Sidon* if all pairwise sums $a + b$ ($a \\le b$, $a, b \\in A$) are distinct. Erd\u0151s and Tur\u00e1n (1941) proved the foundational result that the maximum Sidon subset of $\\{1, \\ldots, N\\}$ has size $\\sim \\sqrt{N}$, establishing a bridge between additive combinatorics and extremal set theory.\n\nProblem #773, posed by Alon and Erd\u0151s in 1985, restricts the Sidon question to perfect squares: how large can a Sidon subset of $\\{1^2, 2^2, \\ldots, N^2\\}$ be? The restriction to squares introduces number-theoretic constraints absent in the general setting \u2014 specifically, the sums $a^2 + b^2$ are governed by Fermat's theorem on sums of two squares and Landau's 1908 asymptotic for their counting function.\n\n**Key Results:**\n- **Alon\u2013Erd\u0151s (1985):** Lower bound $N^{2/3 - o(1)}$ via probabilistic random selection; upper bound $N/(\\log N)^{1/4}$ using Landau's theorem\n- **Lefmann\u2013Thiele (1995):** Refined the probabilistic argument to achieve $N^{2/3}$ without the $o(1)$ loss\n- **Landau (1908):** The count of integers $\\le N$ representable as sums of two squares is $\\sim c \\cdot N/\\sqrt{\\log N}$, where $c \\approx 0.7642$ is the Landau\u2013Ramanujan constant\n\n**Status:** OPEN \u2014 the gap between $N^{2/3}$ and $N/(\\log N)^{1/4}$ remains one of the central open problems connecting additive combinatorics with analytic number theory.",
+    "problemStatement": "**Problem Statement (OPEN)**\n\nWhat is the size of the largest Sidon subset A \u2286 {1\u00b2, 2\u00b2, ..., N\u00b2}? Is it N^{1-o(1)}?\n\n**Known Bounds:**\n- Lower: |A| \u2265 c\u00b7N^{2/3} (Lefmann-Thiele 1995)\n- Upper: |A| \u2264 C\u00b7N/(log N)^{1/4} (Alon-Erd\u0151s 1985)\n\n**Key Question:** Is the true answer closer to N^{1-o(1)} or N^{2/3}?",
+    "text": "What is the max size of a Sidon subset of {1\u00b2, 2\u00b2, ..., N\u00b2}? OPEN: Lower bound N^{2/3} (Lefmann-Thiele), upper bound N/(log N)^{1/4} (Alon-Erd\u0151s). Is it N^{1-o(1)}?",
+    "proofStrategy": "**Formalization Approach**\n\nThe Lean file formalizes Erd\u0151s Problem #773 in nine parts, progressing from definitions through known results to open questions:\n\n1. **Sidon Sets (Parts I\u2013II):** Defines `IsSidon` via the distinct-sums characterization and `IsSidonAlt` via the representation function. Introduces `squaresUpTo N` as the image of the squaring map on `Fin (N+1)`.\n\n2. **Extremal Function (Part III):** Defines $f(N)$ as the supremum of $|A|$ over all Sidon subsets $A \\subseteq \\{1^2, \\ldots, N^2\\}$, and states the main question: is $f(N) = N^{1-o(1)}$?\n\n3. **Axiomatized Bounds (Part IV):** States the Lefmann\u2013Thiele lower bound $f(N) \\ge c \\cdot N^{2/3}$ and the Alon\u2013Erd\u0151s upper bound $f(N) \\le C \\cdot N/(\\log N)^{1/4}$ as axioms, reflecting the deep analytic and probabilistic arguments behind them.\n\n4. **Landau's Theorem (Part V):** Formalizes the asymptotic $S(N) \\sim c \\cdot N/\\sqrt{\\log N}$ for the count of sums of two squares, which is the key number-theoretic input for the upper bound.\n\n5. **Proof Sketches (Parts VI\u2013VII):** Axiomatizes the probabilistic construction (random subset with density $N^{-1/3}$) and the upper bound argument (Sidon constraint + Landau sparsity forces $|A|^2 \\le N^2/(\\log N)^{1/2}$).\n\n6. **Open Questions (Parts VIII\u2013IX):** Formalizes `trueOrder` as the existence of a sharp exponent $\\alpha \\in [2/3, 1)$ and summarizes the problem status.",
     "keyInsights": [
-      "**Squares vs. general integers:** For general Sidon subsets of $\\{1, \\ldots, N\\}$, the maximum size is $\\sim \\sqrt{N}$ (Erdős–Turán 1941). Restricting to squares dramatically changes the landscape — the answer lies between $N^{2/3}$ and $N/(\\log N)^{1/4}$, far above $\\sqrt{N}$, suggesting that squares' additive structure is favorable for the Sidon condition.",
+      "**Squares vs. general integers:** For general Sidon subsets of $\\{1, \\ldots, N\\}$, the maximum size is $\\sim \\sqrt{N}$ (Erd\u0151s\u2013Tur\u00e1n 1941). Restricting to squares dramatically changes the landscape \u2014 the answer lies between $N^{2/3}$ and $N/(\\log N)^{1/4}$, far above $\\sqrt{N}$, suggesting that squares' additive structure is favorable for the Sidon condition.",
       "**Landau's theorem as the bottleneck:** The upper bound hinges on the fact that sums of two squares are sparse: only $\\sim N/\\sqrt{\\log N}$ integers up to $N$ are representable as $a^2 + b^2$. A Sidon set of $m$ squares produces $\\binom{m}{2}$ distinct sums, all of which must be sums of two squares, forcing $m^2 \\lesssim N^2/\\sqrt{\\log N}$.",
       "**Probabilistic method for the lower bound:** The $N^{2/3}$ lower bound uses a random subset: include each square independently with probability $p \\sim N^{-1/3}$. The expected number of Sidon-violating collisions is manageable, and a deletion argument yields a Sidon subset of size $\\sim N^{2/3}$.",
       "**Fermat's characterization underlies Landau:** Landau's theorem ultimately rests on Fermat's result that $n$ is a sum of two squares iff every prime $p \\equiv 3 \\pmod{4}$ appears to an even power in the factorization of $n$. This arithmetic constraint is what makes sums of two squares sparse.",
@@ -68,8 +68,8 @@
       "title": "Sidon Set Definitions",
       "startLine": 33,
       "endLine": 53,
-      "summary": "Defines `IsSidon` (distinct ordered pairwise sums) and `IsSidonAlt` (representation function ≤ 1). These capture the B₂ sequence property.",
-      "mathContext": "Defines `IsSidon` (distinct ordered pairwise sums) and `IsSidonAlt` (representation function $\\leq$ 1). These capture the B₂ sequence property."
+      "summary": "Defines `IsSidon` (distinct ordered pairwise sums) and `IsSidonAlt` (representation function \u2264 1). These capture the B\u2082 sequence property.",
+      "mathContext": "Defines `IsSidon` (distinct ordered pairwise sums) and `IsSidonAlt` (representation function $\\leq$ 1). These capture the B\u2082 sequence property."
     },
     {
       "id": "squares-and-f",
@@ -84,8 +84,8 @@
       "title": "Known Bounds",
       "startLine": 91,
       "endLine": 120,
-      "summary": "Axiomatizes the Lefmann–Thiele lower bound $f(N) \\ge c \\cdot N^{2/3}$ and the Alon–Erdős upper bound $f(N) \\le C \\cdot N/(\\log N)^{1/4}$. Combines them into `current_knowledge`.",
-      "mathContext": "Axiomatized: Axiomatizes the Lefmann–Thiele lower bound $f(N) \\ge c \\cdot N^{2/3}$ and the Alon–Erdős upper bound $f(N) \\le C \\cdot N/(\\log N)^{1/4}$. Combines them into `current_knowledge`."
+      "summary": "Axiomatizes the Lefmann\u2013Thiele lower bound $f(N) \\ge c \\cdot N^{2/3}$ and the Alon\u2013Erd\u0151s upper bound $f(N) \\le C \\cdot N/(\\log N)^{1/4}$. Combines them into `current_knowledge`.",
+      "mathContext": "Axiomatized: Axiomatizes the Lefmann\u2013Thiele lower bound $f(N) \\ge c \\cdot N^{2/3}$ and the Alon\u2013Erd\u0151s upper bound $f(N) \\le C \\cdot N/(\\log N)^{1/4}$. Combines them into `current_knowledge`."
     },
     {
       "id": "landau",
@@ -121,13 +121,13 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #773 in full: definitions of Sidon sets and the extremal function $f(N)$, axiomatized bounds $N^{2/3} \\le f(N) \\le N/(\\log N)^{1/4}$, Landau's theorem connecting the problem to analytic number theory, and sketches of both the probabilistic lower bound and the counting upper bound. The single sorry is on `squaresUpTo_card`, a routine injectivity lemma.",
-    "implications": "This problem sits at a remarkable crossroads of three mathematical areas: (1) **additive combinatorics** — the Sidon/B₂ condition is a fundamental object of study since Erdős–Turán 1941; (2) **analytic number theory** — Landau's 1908 theorem on sums of two squares provides the key counting constraint; and (3) **the probabilistic method** — the best lower bound comes from random selection, a technique pioneered by Erdős himself. Resolving the gap would likely require new ideas combining all three perspectives.",
+    "summary": "This formalization captures Erd\u0151s Problem #773 in full: definitions of Sidon sets and the extremal function $f(N)$, axiomatized bounds $N^{2/3} \\le f(N) \\le N/(\\log N)^{1/4}$, Landau's theorem connecting the problem to analytic number theory, and sketches of both the probabilistic lower bound and the counting upper bound. The single sorry is on `squaresUpTo_card`, a routine injectivity lemma.",
+    "implications": "This problem sits at a remarkable crossroads of three mathematical areas: (1) **additive combinatorics** \u2014 the Sidon/B\u2082 condition is a fundamental object of study since Erd\u0151s\u2013Tur\u00e1n 1941; (2) **analytic number theory** \u2014 Landau's 1908 theorem on sums of two squares provides the key counting constraint; and (3) **the probabilistic method** \u2014 the best lower bound comes from random selection, a technique pioneered by Erd\u0151s himself. Resolving the gap would likely require new ideas combining all three perspectives.",
     "openQuestions": [
       "Is $f(N) = N^{1-o(1)}$, or is the true exponent strictly less than 1? The answer determines whether the Sidon constraint on squares is 'essentially free.'",
-      "Can the $N^{2/3}$ lower bound be improved? The current proof uses no structure of squares beyond their count — exploiting the arithmetic of squares (e.g., quadratic residue structure) might yield better constructions.",
+      "Can the $N^{2/3}$ lower bound be improved? The current proof uses no structure of squares beyond their count \u2014 exploiting the arithmetic of squares (e.g., quadratic residue structure) might yield better constructions.",
       "Does an explicit (deterministic) Sidon subset of squares of size $\\gg N^{2/3}$ exist? All current constructions are probabilistic.",
-      "What is the role of the Landau–Ramanujan constant $c \\approx 0.7642$ in the precise asymptotics? Can the $(\\log N)^{1/4}$ factor in the upper bound be improved?"
+      "What is the role of the Landau\u2013Ramanujan constant $c \\approx 0.7642$ in the precise asymptotics? Can the $(\\log N)^{1/4}$ factor in the upper bound be improved?"
     ]
   },
   "leanFile": {
@@ -153,17 +153,17 @@
     {
       "targetId": "erdos-340",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory, open, sidon-sets"
+      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, number-theory, open, sidon-sets"
     },
     {
       "targetId": "erdos-782",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory, open, squares"
+      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, number-theory, open, squares"
     },
     {
       "targetId": "erdos-1148",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: additive-combinatorics, number-theory, open"
+      "description": "Related Erd\u0151s problem sharing themes: additive-combinatorics, number-theory, open"
     }
   ]
 }

--- a/src/data/proofs/erdos-778/meta.json
+++ b/src/data/proofs/erdos-778/meta.json
@@ -1,6 +1,6 @@
 {
   "id": "erdos-778",
-  "title": "Erdős Problem #778: Clique-Building Games on Complete Graphs",
+  "title": "Erd\u0151s Problem #778: Clique-Building Games on Complete Graphs",
   "slug": "erdos-778",
   "description": "Alice and Bob alternate coloring edges of K_n (red/blue). Alice wins if her largest red clique exceeds any blue clique. Does Bob have a winning strategy for n >= 3? OPEN. Malekshahian-Spiro (2024) proved Bob wins with density >= 3/4.",
   "meta": {
@@ -59,20 +59,20 @@
     ],
     "axiomCount": 2,
     "lineCount": 219,
-    "assumptions": "6 axioms: playGame, malekshahian_spiro_density_clique, malekshahian_spiro_alice_n_bob_n123, and 3 more. See Lean source for complete statements."
+    "assumptions": "2 axioms: playGame, malekshahian_spiro_alice_n_bob_n123. 0 sorries."
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #778: Clique-Building Games on Complete Graphs**\n\nThis problem, posed by Erdős (referenced in Gu83), concerns competitive edge-coloring games on complete graphs — a topic at the intersection of combinatorial game theory and Ramsey theory.\n\n**Three Game Variants:**\nAlice and Bob alternate coloring edges of K_n red (Alice) and blue (Bob), with Alice going first. Variant 1 (Clique Game): Alice wins if her largest red clique exceeds Bob's largest blue clique. Variant 2 (Modified Game): Bob colors 2 edges per turn; he wins if his largest clique strictly exceeds Alice's. Variant 3 (Degree Game): Alice wins if the maximum degree in the red subgraph exceeds that of the blue.\n\n**Erdős's Belief:** Erdős conjectured that Bob should always have a winning strategy in the clique game for n ≥ 3, reflecting the general principle that the second player often has a structural advantage in such games.\n\n**Recent Progress:** Malekshahian and Spiro (arXiv:2410.18304, 2024) proved significant partial results. For the clique game, they showed Bob wins for a set of n with natural density at least 3/4, and that if Alice ever wins at some n, then Bob wins at the next three values n+1, n+2, n+3. For the degree game, Bob wins with density at least 2/3, with a similar recovery property over two consecutive values. These results strongly support Erdős's conjecture but the complete answer remains open.",
+    "historicalContext": "**Erd\u0151s Problem #778: Clique-Building Games on Complete Graphs**\n\nThis problem, posed by Erd\u0151s (referenced in Gu83), concerns competitive edge-coloring games on complete graphs \u2014 a topic at the intersection of combinatorial game theory and Ramsey theory.\n\n**Three Game Variants:**\nAlice and Bob alternate coloring edges of K_n red (Alice) and blue (Bob), with Alice going first. Variant 1 (Clique Game): Alice wins if her largest red clique exceeds Bob's largest blue clique. Variant 2 (Modified Game): Bob colors 2 edges per turn; he wins if his largest clique strictly exceeds Alice's. Variant 3 (Degree Game): Alice wins if the maximum degree in the red subgraph exceeds that of the blue.\n\n**Erd\u0151s's Belief:** Erd\u0151s conjectured that Bob should always have a winning strategy in the clique game for n \u2265 3, reflecting the general principle that the second player often has a structural advantage in such games.\n\n**Recent Progress:** Malekshahian and Spiro (arXiv:2410.18304, 2024) proved significant partial results. For the clique game, they showed Bob wins for a set of n with natural density at least 3/4, and that if Alice ever wins at some n, then Bob wins at the next three values n+1, n+2, n+3. For the degree game, Bob wins with density at least 2/3, with a similar recovery property over two consecutive values. These results strongly support Erd\u0151s's conjecture but the complete answer remains open.",
     "problemStatement": "**Problem Statement (OPEN)**\n\nAlice and Bob play on $K_n$, alternating coloring edges red (Alice) and blue (Bob). Alice goes first.\n\n**Questions:**\n1. Does Bob have a winning strategy for $n \\geq 3$? (Main question)\n2. Modified: Bob colors 2 edges per turn. Does Bob win for $n > 3$?\n3. Degree variant: Who wins when comparing maximum degrees?\n\n**Known (Malekshahian-Spiro 2024):**\n- Clique game: Bob wins with density $\\geq 3/4$\n- If Alice wins at $n$, Bob wins at $n+1, n+2, n+3$\n- Degree game: Bob wins with density $\\geq 2/3$",
     "text": "Alice and Bob alternate coloring edges of K_n (red/blue). Alice wins if her largest red clique exceeds any blue clique. Does Bob have a winning strategy for n >= 3? OPEN. Malekshahian-Spiro (2024) proved Bob wins with density >= 3/4.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Game State:** A structure with symmetric edge coloring and diagonal constraints, not just a bare function — this ensures the state is mathematically well-formed.\n\n2. **Colored Subgraphs:** Red and blue subgraphs defined as SimpleGraph instances with symmetry proofs that use the GameState's symmetry invariant.\n\n3. **Clique Predicate:** Uses Mathlib's IsClique to define when a graph contains a k-clique, avoiding custom definitions.\n\n4. **Strategy Framework:** Strategies as functions from state to edge choice, with playGame axiomatized (the game tree is finite by K_n having finitely many edges, so a final state always exists).\n\n5. **Key Theorem:** alice_no_four_consecutive is proved directly from the Malekshahian-Spiro axiom via a contradiction argument — if Alice wins at n and n+1, the Malekshahian-Spiro result gives Bob a winning strategy at n+1, contradicting Alice's strategy there.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Game State:** A structure with symmetric edge coloring and diagonal constraints, not just a bare function \u2014 this ensures the state is mathematically well-formed.\n\n2. **Colored Subgraphs:** Red and blue subgraphs defined as SimpleGraph instances with symmetry proofs that use the GameState's symmetry invariant.\n\n3. **Clique Predicate:** Uses Mathlib's IsClique to define when a graph contains a k-clique, avoiding custom definitions.\n\n4. **Strategy Framework:** Strategies as functions from state to edge choice, with playGame axiomatized (the game tree is finite by K_n having finitely many edges, so a final state always exists).\n\n5. **Key Theorem:** alice_no_four_consecutive is proved directly from the Malekshahian-Spiro axiom via a contradiction argument \u2014 if Alice wins at n and n+1, the Malekshahian-Spiro result gives Bob a winning strategy at n+1, contradicting Alice's strategy there.",
     "keyInsights": [
       "**Density Result:** Bob wins the clique game for at least 3/4 of all n (Malekshahian-Spiro 2024)",
-      "**Recovery Property:** If Alice wins at n, Bob recovers and wins the next 3 consecutive values — this is the key structural constraint",
+      "**Recovery Property:** If Alice wins at n, Bob recovers and wins the next 3 consecutive values \u2014 this is the key structural constraint",
       "**No Four in a Row:** Alice cannot win 4 consecutive values, proved by contradiction using the recovery property",
-      "**Zermelo's Theorem:** The game is determined — either Alice or Bob has a winning strategy for each n (finite perfect-information game)",
+      "**Zermelo's Theorem:** The game is determined \u2014 either Alice or Bob has a winning strategy for each n (finite perfect-information game)",
       "**Connection to Ramsey Theory:** Finding monochromatic cliques in edge-colored K_n parallels Ramsey number problems",
-      "**Open Gap:** Whether Bob wins for ALL n ≥ 3 remains the central open question, despite the high-density results"
+      "**Open Gap:** Whether Bob wins for ALL n \u2265 3 remains the central open question, despite the high-density results"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -122,7 +122,7 @@
     },
     {
       "id": "conjecture-and-results",
-      "title": "Erdős's Conjecture and Known Results",
+      "title": "Erd\u0151s's Conjecture and Known Results",
       "summary": "ErdosConjecture, Malekshahian-Spiro density and periodicity axioms",
       "startLine": 150,
       "endLine": 181,
@@ -146,8 +146,8 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #778 asks about clique-building games on K_n. The main question — does Bob always win for n ≥ 3? — remains OPEN. Malekshahian-Spiro (2024) proved significant partial results: Bob wins with density ≥ 3/4, and if Alice ever wins at n, Bob wins at n+1, n+2, n+3. We prove that Alice cannot win 4 consecutive values.",
-    "implications": "**Theoretical Significance**: **Combinatorial Game Theory Connections**\n\n1. **Ramsey Theory:** The game is about building monochromatic structures in edge-colorings, paralleling Ramsey number problems\n\n**2. Zermelo's Theorem:** The game is finite and has perfect information, so it is determined — one player always has a winning strategy\n\n3. **Density Methods:** The Malekshahian-Spiro results use asymptotic density to measure how often Bob wins, a technique from analytic combinatorics\n\n4. **Second Player Advantage:** Bob's structural advantage from responding to Alice's moves is central to Erdős's conjecture.",
+    "summary": "Erd\u0151s Problem #778 asks about clique-building games on K_n. The main question \u2014 does Bob always win for n \u2265 3? \u2014 remains OPEN. Malekshahian-Spiro (2024) proved significant partial results: Bob wins with density \u2265 3/4, and if Alice ever wins at n, Bob wins at n+1, n+2, n+3. We prove that Alice cannot win 4 consecutive values.",
+    "implications": "**Theoretical Significance**: **Combinatorial Game Theory Connections**\n\n1. **Ramsey Theory:** The game is about building monochromatic structures in edge-colorings, paralleling Ramsey number problems\n\n**2. Zermelo's Theorem:** The game is finite and has perfect information, so it is determined \u2014 one player always has a winning strategy\n\n3. **Density Methods:** The Malekshahian-Spiro results use asymptotic density to measure how often Bob wins, a technique from analytic combinatorics\n\n4. **Second Player Advantage:** Bob's structural advantage from responding to Alice's moves is central to Erd\u0151s's conjecture.",
     "openQuestions": [
       "Does Bob have a winning strategy for ALL n >= 3? (Main open question)",
       "Does Bob have a winning strategy for the modified game when n > 3?",
@@ -179,17 +179,17 @@
     {
       "targetId": "erdos-136",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: graph-coloring, ramsey-theory"
+      "description": "Related Erd\u0151s problem sharing themes: graph-coloring, ramsey-theory"
     },
     {
       "targetId": "erdos-191",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: graph-coloring, ramsey-theory"
+      "description": "Related Erd\u0151s problem sharing themes: graph-coloring, ramsey-theory"
     },
     {
       "targetId": "erdos-553",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: graph-coloring, ramsey-theory"
+      "description": "Related Erd\u0151s problem sharing themes: graph-coloring, ramsey-theory"
     }
   ]
 }

--- a/src/data/proofs/erdos-790/meta.json
+++ b/src/data/proofs/erdos-790/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-790",
-  "title": "Erdős Problem #790: Maximum Sum-Free Subsequences",
+  "title": "Erd\u0151s Problem #790: Maximum Sum-Free Subsequences",
   "slug": "erdos-790",
-  "description": "Let l(n) be the maximum size of a guaranteed sum-free subset of any n-element integer set. Known bounds: √(n log n / log log n) ≤ l(n) ≤ n / log n (CKS 1975). Main conjecture: l(n) ≥ n^{1-o(1)}. OPEN.",
+  "description": "Let l(n) be the maximum size of a guaranteed sum-free subset of any n-element integer set. Known bounds: \u221a(n log n / log log n) \u2264 l(n) \u2264 n / log n (CKS 1975). Main conjecture: l(n) \u2265 n^{1-o(1)}. OPEN.",
   "meta": {
-    "author": "Choi-Komlós-Szemerédi (1975)",
+    "author": "Choi-Koml\u00f3s-Szemer\u00e9di (1975)",
     "sourceUrl": "https://erdosproblems.com/790",
     "date": "1975",
     "status": "axiomatized",
@@ -42,33 +42,33 @@
       }
     ],
     "originalContributions": [
-      "IsSumFree definition: no element equals sum of ≥2 distinct others",
+      "IsSumFree definition: no element equals sum of \u22652 distinct others",
       "classicalSumFree definition: no a + b = c (stronger condition)",
       "l(n) axiom: extremal function for guaranteed sum-free subsets",
-      "l_characterization: every n-set has sum-free subset of size ≥ l(n)",
+      "l_characterization: every n-set has sum-free subset of size \u2265 l(n)",
       "l_optimal: l(n) is the best such bound",
-      "erdos_lower_bound: l(n) ≥ √(n/2)",
-      "choi_improvement: l(n) > (1+c)√n",
-      "cks_lower_bound: l(n) ≥ c√(n log n / log log n)",
-      "cks_upper_bound: l(n) ≤ Cn/log n",
-      "cks_conjecture: l(n) ≥ n^{1-o(1)} (OPEN)",
+      "erdos_lower_bound: l(n) \u2265 \u221a(n/2)",
+      "choi_improvement: l(n) > (1+c)\u221an",
+      "cks_lower_bound: l(n) \u2265 c\u221a(n log n / log log n)",
+      "cks_upper_bound: l(n) \u2264 Cn/log n",
+      "cks_conjecture: l(n) \u2265 n^{1-o(1)} (OPEN)",
       "cks_bounds and erdos_790_summary theorems"
     ],
     "axiomCount": 5,
     "lineCount": 129,
-    "assumptions": "9 axioms: l, l_characterization, l_optimal, and 6 more. See Lean source for complete statements."
+    "assumptions": "5 axioms: l, cks_lower_bound, cks_upper_bound, question1_affirmative, question2_answered. 0 sorries."
   },
   "overview": {
-    "historicalContext": "Erdős Problem #790 concerns the extremal function l(n) for sum-free subsequences. The problem appeared in Erdős's 1965 survey \"Extremal problems in number theory,\" where he claimed to have a complicated proof that l(n) = o(n) but by 1973 reported \"difficulties in reconstructing\" it. This is one of the rare cases where Erdős lost track of one of his own proofs.\n\nThe definitive work was done by Choi, Komlós, and Szemerédi in their 1975 Trans. Amer. Math. Soc. paper \"On sum-free subsequences.\" They proved both the best known lower bound l(n) ≥ c√(n log n / log log n) and the upper bound l(n) ≤ Cn/log n. This confirmed l(n) = o(n) rigorously and answered Erdős's main questions, but left a large gap between the bounds.\n\nThe notion of \"sum-free\" here is weaker than the classical definition: rather than forbidding a + b = c, it forbids a₁ = a₂ + ⋯ + aᵣ for any r ≥ 2 distinct elements. This weaker condition means more sets qualify as sum-free. Choi, Komlós, and Szemerédi conjectured l(n) ≥ n^{1-o(1)}, suggesting l(n) is nearly linear. This conjecture remains open and represents the central question.",
+    "historicalContext": "Erd\u0151s Problem #790 concerns the extremal function l(n) for sum-free subsequences. The problem appeared in Erd\u0151s's 1965 survey \"Extremal problems in number theory,\" where he claimed to have a complicated proof that l(n) = o(n) but by 1973 reported \"difficulties in reconstructing\" it. This is one of the rare cases where Erd\u0151s lost track of one of his own proofs.\n\nThe definitive work was done by Choi, Koml\u00f3s, and Szemer\u00e9di in their 1975 Trans. Amer. Math. Soc. paper \"On sum-free subsequences.\" They proved both the best known lower bound l(n) \u2265 c\u221a(n log n / log log n) and the upper bound l(n) \u2264 Cn/log n. This confirmed l(n) = o(n) rigorously and answered Erd\u0151s's main questions, but left a large gap between the bounds.\n\nThe notion of \"sum-free\" here is weaker than the classical definition: rather than forbidding a + b = c, it forbids a\u2081 = a\u2082 + \u22ef + a\u1d63 for any r \u2265 2 distinct elements. This weaker condition means more sets qualify as sum-free. Choi, Koml\u00f3s, and Szemer\u00e9di conjectured l(n) \u2265 n^{1-o(1)}, suggesting l(n) is nearly linear. This conjecture remains open and represents the central question.",
     "problemStatement": "Let $l(n)$ be maximal such that for any $A \\subseteq \\mathbb{Z}$ with $|A| = n$, there exists a sum-free $B \\subseteq A$ with $|B| \\geq l(n)$. Here sum-free means no element equals a sum of $\\geq 2$ distinct other elements. **Known bounds:** $\\sqrt{n \\log n / \\log\\log n} \\ll l(n) \\ll n / \\log n$ (CKS 1975). **Questions:** (1) Does $l(n)/\\sqrt{n} \\to \\infty$? YES. (2) Is $l(n) < n^{1-c}$ for some $c > 0$? YES. **CKS Conjecture:** $l(n) \\geq n^{1-o(1)}$. STATUS: OPEN.",
-    "text": "Let l(n) be the maximum size of a guaranteed sum-free subset of any n-element integer set. Known bounds: √(n log n / log log n) ≤ l(n) ≤ n / log n (CKS 1975). Main conjecture: l(n) ≥ n^{1-o(1)}. OPEN.",
-    "proofStrategy": "The formalization defines IsSumFree as the weak sum-free condition (no element is a sum of ≥2 distinct others) and classicalSumFree as the stronger classical condition (no a + b = c). The extremal function l(n) is axiomatized with characterization and optimality axioms. Three progressive lower bounds are stated (Erdős, Choi, CKS), followed by the CKS upper bound. The main questions are formalized as propositions and answered by axioms referencing the CKS bounds. Two theorems are proved: cks_bounds (combining both bounds) and erdos_790_summary (answering both questions).",
+    "text": "Let l(n) be the maximum size of a guaranteed sum-free subset of any n-element integer set. Known bounds: \u221a(n log n / log log n) \u2264 l(n) \u2264 n / log n (CKS 1975). Main conjecture: l(n) \u2265 n^{1-o(1)}. OPEN.",
+    "proofStrategy": "The formalization defines IsSumFree as the weak sum-free condition (no element is a sum of \u22652 distinct others) and classicalSumFree as the stronger classical condition (no a + b = c). The extremal function l(n) is axiomatized with characterization and optimality axioms. Three progressive lower bounds are stated (Erd\u0151s, Choi, CKS), followed by the CKS upper bound. The main questions are formalized as propositions and answered by axioms referencing the CKS bounds. Two theorems are proved: cks_bounds (combining both bounds) and erdos_790_summary (answering both questions).",
     "keyInsights": [
-      "**Weak vs Classical Sum-Free**: No a = a₂ + ⋯ + aᵣ (r ≥ 2) is weaker than no a + b = c",
-      "**Huge Gap**: Current bounds span √(n log n / log log n) to n/log n — roughly n^{1/2+ε} to n^{1-ε}",
-      "**Both Questions Answered**: CKS bounds settle l(n)/√n → ∞ and l(n) < n^{1-c}",
-      "**CKS Conjecture (OPEN)**: l(n) ≥ n^{1-o(1)} would mean l(n) is nearly linear",
-      "**Erdős's Lost Proof**: He claimed l(n) = o(n) in 1965 but couldn't reconstruct it by 1973",
+      "**Weak vs Classical Sum-Free**: No a = a\u2082 + \u22ef + a\u1d63 (r \u2265 2) is weaker than no a + b = c",
+      "**Huge Gap**: Current bounds span \u221a(n log n / log log n) to n/log n \u2014 roughly n^{1/2+\u03b5} to n^{1-\u03b5}",
+      "**Both Questions Answered**: CKS bounds settle l(n)/\u221an \u2192 \u221e and l(n) < n^{1-c}",
+      "**CKS Conjecture (OPEN)**: l(n) \u2265 n^{1-o(1)} would mean l(n) is nearly linear",
+      "**Erd\u0151s's Lost Proof**: He claimed l(n) = o(n) in 1965 but couldn't reconstruct it by 1973",
       "**Probabilistic Methods**: Lower bound constructions use random or greedy selection"
     ],
     "prerequisites": [
@@ -98,14 +98,14 @@
       "title": "Lower Bounds",
       "startLine": 65,
       "endLine": 85,
-      "summary": "Erdős, Choi, and CKS lower bounds"
+      "summary": "Erd\u0151s, Choi, and CKS lower bounds"
     },
     {
       "id": "upper-bound",
       "title": "Upper Bound",
       "startLine": 86,
       "endLine": 94,
-      "summary": "CKS upper bound l(n) ≤ Cn/log n"
+      "summary": "CKS upper bound l(n) \u2264 Cn/log n"
     },
     {
       "id": "main-questions",
@@ -123,10 +123,10 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #790 asks for the extremal function l(n) — the maximum guaranteed sum-free subset size in any n-element integer set. Choi-Komlós-Szemerédi (1975) proved √(n log n / log log n) ≤ l(n) ≤ n/log n, answering both of Erdős's questions (l(n)/√n → ∞ and l(n) < n^{1-c}). The CKS conjecture l(n) ≥ n^{1-o(1)} remains OPEN.",
+    "summary": "Erd\u0151s Problem #790 asks for the extremal function l(n) \u2014 the maximum guaranteed sum-free subset size in any n-element integer set. Choi-Koml\u00f3s-Szemer\u00e9di (1975) proved \u221a(n log n / log log n) \u2264 l(n) \u2264 n/log n, answering both of Erd\u0151s's questions (l(n)/\u221an \u2192 \u221e and l(n) < n^{1-c}). The CKS conjecture l(n) \u2265 n^{1-o(1)} remains OPEN.",
     "implications": "Closing the gap between the lower and upper bounds would resolve a fundamental question in additive combinatorics about the size of guaranteed sum-free structures. The problem connects to Ramsey theory, the probabilistic method, and Schur numbers.",
     "openQuestions": [
-      "Is l(n) ≥ n^{1-o(1)}? (CKS Conjecture)",
+      "Is l(n) \u2265 n^{1-o(1)}? (CKS Conjecture)",
       "Can the n/log n upper bound be improved?",
       "What is the correct asymptotic for l(n)?",
       "What happens for sum-free sets in Z/mZ instead of Z?"
@@ -156,17 +156,17 @@
     {
       "targetId": "erdos-857",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, extremal-combinatorics, open"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, extremal-combinatorics, open"
     },
     {
       "targetId": "erdos-1014",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, open"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, open"
     },
     {
       "targetId": "erdos-1023",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, extremal-combinatorics"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, extremal-combinatorics"
     }
   ]
 }

--- a/src/data/proofs/erdos-808/meta.json
+++ b/src/data/proofs/erdos-808/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-808",
   "title": "Graph-Restricted Sum-Product Bounds",
   "slug": "erdos-808",
-  "description": "Graph version of sum-product: with n^{1+c} edges, is max(|A+_G A|, |A·_G A|) ≥ n^{1+c-ε}? DISPROVED by Alon-Ruzsa-Solymosi (2020). Counterexample: n^{5/3} edges give only n^{4/3} outputs. Positive result: max ≥ m^{3/2}/n^{7/4}.",
+  "description": "Graph version of sum-product: with n^{1+c} edges, is max(|A+_G A|, |A\u00b7_G A|) \u2265 n^{1+c-\u03b5}? DISPROVED by Alon-Ruzsa-Solymosi (2020). Counterexample: n^{5/3} edges give only n^{4/3} outputs. Positive result: max \u2265 m^{3/2}/n^{7/4}.",
   "meta": {
     "author": "Alon, Ruzsa, Solymosi (2020)",
     "sourceUrl": "https://erdosproblems.com/808",
@@ -46,27 +46,27 @@
     ],
     "originalContributions": [
       "Lean formalization of graph-restricted sumsets and product sets",
-      "Formal statement of the (false) Erdős-Szemerédi graph conjecture",
+      "Formal statement of the (false) Erd\u0151s-Szemer\u00e9di graph conjecture",
       "Axiomatized ARS counterexample construction",
-      "Positive lower bound: max ≥ m^{3/2}n^{-7/4}",
+      "Positive lower bound: max \u2265 m^{3/2}n^{-7/4}",
       "Connection to classical sum-product conjecture"
     ],
     "dateAdded": "2026-01-19",
     "axiomCount": 2,
-    "assumptions": "6 axiom declarations: erdos_808_false (conjecture disproved), ars_counterexample (n^{5/3} edges give n^{4/3} outputs), ars_positive_bound (m^{3/2}/n^{7/4} lower bound), complete_graph_case (reduces to classical conjecture), construction_idea (arithmetic structure exploited), arithmetic_structure (AP sumset bound)",
+    "assumptions": "2 axioms: erdos_808_false, ars_positive_bound. 0 sorries.",
     "lineCount": 211
   },
   "overview": {
-    "historicalContext": "This problem generalizes the famous Erdős-Szemerédi sum-product conjecture to graph-restricted settings. Alon, Ruzsa, and Solymosi (2020) showed the natural generalization fails, but proved a weaker positive bound. The classical Erdős-Szemerédi sum-product conjecture (1983) asserts that for any finite set A of real numbers, max(|A+A|, |A·A|) ≥ |A|^{2−ε}, capturing the heuristic that a set cannot simultaneously have small sumset and small product set. The graph-restricted variant, proposed by Erdős and Szemerédi, asks whether restricting sums and products to edges of a dense graph preserves this expansion. The ARS (2020) counterexample, using sets with strong multiplicative structure and a carefully chosen bipartite graph, showed that graph sparsity can be exploited to defeat expansion, settling the conjecture negatively.",
-    "problemStatement": "If A ⊂ ℕ with |A| = n and graph G on A has ≥ n^{1+c} edges, is max(|A +_G A|, |A ·_G A|) ≥ n^{1+c-ε}? Here A +_G A = {a+b : (a,b) ∈ G}.",
-    "text": "Graph version of sum-product: with n^{1+c} edges, is max(|A+_G A|, |A·_G A|) ≥ n^{1+c-ε}? DISPROVED by Alon-Ruzsa-Solymosi (2020). Counterexample: n^{5/3} edges give only n^{4/3} outputs. Positive result: max ≥ m^{3/2}/n^{7/4}.",
+    "historicalContext": "This problem generalizes the famous Erd\u0151s-Szemer\u00e9di sum-product conjecture to graph-restricted settings. Alon, Ruzsa, and Solymosi (2020) showed the natural generalization fails, but proved a weaker positive bound. The classical Erd\u0151s-Szemer\u00e9di sum-product conjecture (1983) asserts that for any finite set A of real numbers, max(|A+A|, |A\u00b7A|) \u2265 |A|^{2\u2212\u03b5}, capturing the heuristic that a set cannot simultaneously have small sumset and small product set. The graph-restricted variant, proposed by Erd\u0151s and Szemer\u00e9di, asks whether restricting sums and products to edges of a dense graph preserves this expansion. The ARS (2020) counterexample, using sets with strong multiplicative structure and a carefully chosen bipartite graph, showed that graph sparsity can be exploited to defeat expansion, settling the conjecture negatively.",
+    "problemStatement": "If A \u2282 \u2115 with |A| = n and graph G on A has \u2265 n^{1+c} edges, is max(|A +_G A|, |A \u00b7_G A|) \u2265 n^{1+c-\u03b5}? Here A +_G A = {a+b : (a,b) \u2208 G}.",
+    "text": "Graph version of sum-product: with n^{1+c} edges, is max(|A+_G A|, |A\u00b7_G A|) \u2265 n^{1+c-\u03b5}? DISPROVED by Alon-Ruzsa-Solymosi (2020). Counterexample: n^{5/3} edges give only n^{4/3} outputs. Positive result: max \u2265 m^{3/2}/n^{7/4}.",
     "proofStrategy": "ARS constructed sets with arithmetic structure where many edges (n^{5/3}) produce few distinct sums/products (n^{4/3}). They also proved a positive lower bound using different techniques.",
     "keyInsights": [
       "The conjecture is FALSE: n^{5/3} edges can yield only n^{4/3} outputs, an exponent gap of 1/3",
-      "Arithmetic structure (like APs with |A+A| ≤ 2|A|-1) allows many edges without many new sums",
-      "Positive result: max(|A+_G A|, |A·_G A|) ≥ c · m^{3/2} · n^{-7/4} still guarantees some expansion",
+      "Arithmetic structure (like APs with |A+A| \u2264 2|A|-1) allows many edges without many new sums",
+      "Positive result: max(|A+_G A|, |A\u00b7_G A|) \u2265 c \u00b7 m^{3/2} \u00b7 n^{-7/4} still guarantees some expansion",
       "Graph structure fundamentally changes sum-product behavior: sparse graphs defeat expansion that complete graphs guarantee",
-      "The complete graph case reduces to the classical Erdős-Szemerédi conjecture (Problem 52), which remains open — sparsity is the essential obstruction"
+      "The complete graph case reduces to the classical Erd\u0151s-Szemer\u00e9di conjecture (Problem 52), which remains open \u2014 sparsity is the essential obstruction"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -81,7 +81,7 @@
       "startLine": 1,
       "endLine": 49,
       "summary": "Module docstring documenting the problem statement, background, and references; 4 Mathlib imports covering required modules; `open` declarations (Finset); namespace `Erdos808`",
-      "mathContext": "Graph version of Erdős-Szemerédi sum-product: for a graph $G$ on $A$ with $n^{1+c}$ edges, is $\\max(|A +_G A|, |A \\cdot_G A|) \\geq n^{1+c-\\varepsilon}$? DISPROVED by Alon-Ruzsa-Solymosi (2020); positive result: $\\max \\geq m^{3/2} n^{-7/4}$."
+      "mathContext": "Graph version of Erd\u0151s-Szemer\u00e9di sum-product: for a graph $G$ on $A$ with $n^{1+c}$ edges, is $\\max(|A +_G A|, |A \\cdot_G A|) \\geq n^{1+c-\\varepsilon}$? DISPROVED by Alon-Ruzsa-Solymosi (2020); positive result: $\\max \\geq m^{3/2} n^{-7/4}$."
     },
     {
       "id": "basic-definitions",
@@ -96,15 +96,15 @@
       "title": "The Original Conjecture (DISPROVED)",
       "startLine": 83,
       "endLine": 105,
-      "summary": "Statement of the false Erdős-Szemerédi graph conjecture",
-      "mathContext": "$|E(G)| \\ge n^{1+c} \\implies \\max(|A +_G A|, |A \\cdot_G A|) \\ge n^{1+c-\\varepsilon}$. Conjectured generalization of the Erdős-Szemerédi sum-product phenomenon to sparse graphs. DISPROVED."
+      "summary": "Statement of the false Erd\u0151s-Szemer\u00e9di graph conjecture",
+      "mathContext": "$|E(G)| \\ge n^{1+c} \\implies \\max(|A +_G A|, |A \\cdot_G A|) \\ge n^{1+c-\\varepsilon}$. Conjectured generalization of the Erd\u0151s-Szemer\u00e9di sum-product phenomenon to sparse graphs. DISPROVED."
     },
     {
       "id": "counterexample",
       "title": "The Counterexample",
       "startLine": 106,
       "endLine": 134,
-      "summary": "ARS counterexample: n^{5/3} edges → n^{4/3} outputs",
+      "summary": "ARS counterexample: n^{5/3} edges \u2192 n^{4/3} outputs",
       "mathContext": "$\\exists A, G: |E(G)| \\approx n^{5/3},\\, \\max(|A +_G A|, |A \\cdot_G A|) \\approx n^{4/3}$. Alon-Ruzsa-Solymosi (2020): exponent gap $5/3 - 4/3 = 1/3$ refutes the conjecture."
     },
     {
@@ -112,7 +112,7 @@
       "title": "The Positive Result",
       "startLine": 135,
       "endLine": 159,
-      "summary": "ARS positive bound: max ≥ m^{3/2}/n^{7/4}",
+      "summary": "ARS positive bound: max \u2265 m^{3/2}/n^{7/4}",
       "mathContext": "$\\max(|A +_G A|, |A \\cdot_G A|) \\ge c \\cdot m^{3/2} \\cdot n^{-7/4}$ where $m = |E(G)|$, $n = |A|$. ARS positive bound: more edges do guarantee more outputs."
     },
     {
@@ -141,7 +141,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #808 is DISPROVED. The graph-restricted sum-product conjecture fails: n^{5/3} edges can produce only n^{4/3} outputs. However, ARS proved a positive bound: max(|A+_G A|, |A·_G A|) ≥ m^{3/2}/n^{7/4}.",
+    "summary": "Erd\u0151s Problem #808 is DISPROVED. The graph-restricted sum-product conjecture fails: n^{5/3} edges can produce only n^{4/3} outputs. However, ARS proved a positive bound: max(|A+_G A|, |A\u00b7_G A|) \u2265 m^{3/2}/n^{7/4}.",
     "implications": "Graph structure fundamentally changes sum-product phenomena. Sparse graphs can exploit arithmetic structure to avoid expansion, unlike complete graphs.",
     "openQuestions": [
       "What is the optimal lower bound in terms of m and n?",
@@ -171,17 +171,17 @@
     {
       "targetId": "erdos-1067",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: disproved, graph-theory"
+      "description": "Related Erd\u0151s problem sharing themes: disproved, graph-theory"
     },
     {
       "targetId": "erdos-1080",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: disproved, graph-theory"
+      "description": "Related Erd\u0151s problem sharing themes: disproved, graph-theory"
     },
     {
       "targetId": "erdos-110",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: disproved, graph-theory"
+      "description": "Related Erd\u0151s problem sharing themes: disproved, graph-theory"
     }
   ]
 }

--- a/src/data/proofs/erdos-81/meta.json
+++ b/src/data/proofs/erdos-81/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-81",
-  "title": "Erdős Problem #81: Clique Partitions of Chordal Graphs",
+  "title": "Erd\u0151s Problem #81: Clique Partitions of Chordal Graphs",
   "slug": "erdos-81",
-  "description": "Can every chordal graph (no induced cycles > 3) have its edges partitioned into n²/6 + O(n) cliques? The extremal split graph K_{n/3} ∪ 2n/3 isolated vertices requires ≈ n²/6 cliques, while the Erdős-Ordman-Zalcstein upper bound gives (1/4 − ε)n². The gap factor of ~1.5 remains open.",
+  "description": "Can every chordal graph (no induced cycles > 3) have its edges partitioned into n\u00b2/6 + O(n) cliques? The extremal split graph K_{n/3} \u222a 2n/3 isolated vertices requires \u2248 n\u00b2/6 cliques, while the Erd\u0151s-Ordman-Zalcstein upper bound gives (1/4 \u2212 \u03b5)n\u00b2. The gap factor of ~1.5 remains open.",
   "meta": {
-    "author": "Erdős, Ordman & Zalcstein (1993)",
+    "author": "Erd\u0151s, Ordman & Zalcstein (1993)",
     "sourceUrl": "https://erdosproblems.com/81",
     "date": "1993",
     "status": "axiomatized",
@@ -52,21 +52,21 @@
     ],
     "axiomCount": 4,
     "lineCount": 290,
-    "assumptions": "8 axioms: split_is_chordal, extremal_construction_exists, erdos_ordman_zalcstein, and 5 more. See Lean source for complete statements.",
+    "assumptions": "4 axioms: split_is_chordal, extremal_construction_exists, erdos_ordman_zalcstein, peo_gives_clique_partition. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "A chordal graph is one with no induced cycles of length greater than 3, equivalently every cycle of length 4 or more has a chord. These graphs arise naturally in sparse matrix computations, database theory, and phylogenetics. Erdős, Ordman, and Zalcstein asked in 1993 how efficiently the edges of a chordal graph on n vertices can be partitioned into cliques, conjecturing that n²/6 + O(n) cliques always suffice.\n\nThe lower bound comes from an explicit extremal construction: take K_{n/3} and 2n/3 isolated vertices, connecting every K_{n/3} vertex to every isolated vertex. This split graph requires approximately n²/6 cliques because the bipartite edges between the clique and independent set cannot be efficiently grouped. Erdős, Ordman, and Zalcstein proved the upper bound that (1/4 - ε)n² cliques always suffice for some small ε > 0. Chen, Erdős, and Ordman (1994) improved this to 3n²/16 + O(n) for the special case of split graphs.\n\nThe gap between the upper bound coefficient 1/4 and the conjectured coefficient 1/6 (a factor of approximately 1.5) remains open. Chordal graphs are characterized by having a perfect elimination ordering (Dirac 1961, Fulkerson-Gross 1965), which gives a polynomial-time recognition algorithm and a greedy clique partition that is a 2-approximation, but the optimal coefficient for clique partitions remains unknown.",
-    "problemStatement": "**Problem Statement**\n\nLet G be a chordal graph on n vertices (no induced cycles of length > 3). Can the edges of G be partitioned into n²/6 + O(n) many cliques?\n\n**Key Definitions**:\n- **Chordal graph**: Every cycle of length ≥ 4 has a chord\n- **Clique partition**: Partition of edges into complete subgraphs\n- **Split graph**: Vertices partition into a clique and independent set (special case of chordal)\n\n**Known Results**:\n- Lower bound: n²/6 + O(n) is sometimes necessary (extremal construction)\n- Upper bound: (1/4 − ε)n² cliques suffice (Erdős-Ordman-Zalcstein)\n- Split graphs: 3n²/16 + O(n) cliques suffice (Chen-Erdős-Ordman)\n\n**Status**: OPEN",
-    "text": "Can every chordal graph (no induced cycles > 3) have its edges partitioned into n²/6 + O(n) cliques? The extremal split graph K_{n/3} ∪ 2n/3 isolated vertices requires ≈ n²/6 cliques, while the Erdős-Ordman-Zalcstein upper bound gives (1/4 − ε)n². The gap factor of ~1.5 remains open.",
-    "proofStrategy": "**Approach and Known Techniques**\n\n**Upper Bound Strategy** (lines 153–167):\n1. Use the perfect elimination ordering (chordal ↔ PEO, line 246)\n2. The PEO-based greedy algorithm gives a 2-approximation (line 259)\n3. The Erdős-Ordman-Zalcstein bound of (1/4 − ε)n² (line 158) uses structural analysis beyond greedy\n\n**Lower Bound Construction** (lines 129–147):\n1. Take K_{n/3} (complete graph on n/3 vertices)\n2. Add 2n/3 isolated vertices and connect all K_{n/3} vertices to all isolated vertices\n3. This split graph (line 132) requires ≈ n²/6 cliques\n4. The `lower_bound` theorem (line 140) derives the chordal lower bound from the split graph construction via `split_is_chordal`\n\n**The Gap** (lines 190–206):\nCurrent upper bound coefficient 1/4 vs conjectured 1/6, a factor of 3/2. Closing this requires either:\n- Better structural analysis of chordal clique partitions, or\n- A counterexample exceeding n²/6 + O(n)\n\n**Main Theorems** (lines 309–333):\n- `erdos_81_summary`: combines the lower bound and gap analysis\n- `erdos_81`: combines the upper bound and PEO 2-approximation for any chordal graph",
+    "historicalContext": "A chordal graph is one with no induced cycles of length greater than 3, equivalently every cycle of length 4 or more has a chord. These graphs arise naturally in sparse matrix computations, database theory, and phylogenetics. Erd\u0151s, Ordman, and Zalcstein asked in 1993 how efficiently the edges of a chordal graph on n vertices can be partitioned into cliques, conjecturing that n\u00b2/6 + O(n) cliques always suffice.\n\nThe lower bound comes from an explicit extremal construction: take K_{n/3} and 2n/3 isolated vertices, connecting every K_{n/3} vertex to every isolated vertex. This split graph requires approximately n\u00b2/6 cliques because the bipartite edges between the clique and independent set cannot be efficiently grouped. Erd\u0151s, Ordman, and Zalcstein proved the upper bound that (1/4 - \u03b5)n\u00b2 cliques always suffice for some small \u03b5 > 0. Chen, Erd\u0151s, and Ordman (1994) improved this to 3n\u00b2/16 + O(n) for the special case of split graphs.\n\nThe gap between the upper bound coefficient 1/4 and the conjectured coefficient 1/6 (a factor of approximately 1.5) remains open. Chordal graphs are characterized by having a perfect elimination ordering (Dirac 1961, Fulkerson-Gross 1965), which gives a polynomial-time recognition algorithm and a greedy clique partition that is a 2-approximation, but the optimal coefficient for clique partitions remains unknown.",
+    "problemStatement": "**Problem Statement**\n\nLet G be a chordal graph on n vertices (no induced cycles of length > 3). Can the edges of G be partitioned into n\u00b2/6 + O(n) many cliques?\n\n**Key Definitions**:\n- **Chordal graph**: Every cycle of length \u2265 4 has a chord\n- **Clique partition**: Partition of edges into complete subgraphs\n- **Split graph**: Vertices partition into a clique and independent set (special case of chordal)\n\n**Known Results**:\n- Lower bound: n\u00b2/6 + O(n) is sometimes necessary (extremal construction)\n- Upper bound: (1/4 \u2212 \u03b5)n\u00b2 cliques suffice (Erd\u0151s-Ordman-Zalcstein)\n- Split graphs: 3n\u00b2/16 + O(n) cliques suffice (Chen-Erd\u0151s-Ordman)\n\n**Status**: OPEN",
+    "text": "Can every chordal graph (no induced cycles > 3) have its edges partitioned into n\u00b2/6 + O(n) cliques? The extremal split graph K_{n/3} \u222a 2n/3 isolated vertices requires \u2248 n\u00b2/6 cliques, while the Erd\u0151s-Ordman-Zalcstein upper bound gives (1/4 \u2212 \u03b5)n\u00b2. The gap factor of ~1.5 remains open.",
+    "proofStrategy": "**Approach and Known Techniques**\n\n**Upper Bound Strategy** (lines 153\u2013167):\n1. Use the perfect elimination ordering (chordal \u2194 PEO, line 246)\n2. The PEO-based greedy algorithm gives a 2-approximation (line 259)\n3. The Erd\u0151s-Ordman-Zalcstein bound of (1/4 \u2212 \u03b5)n\u00b2 (line 158) uses structural analysis beyond greedy\n\n**Lower Bound Construction** (lines 129\u2013147):\n1. Take K_{n/3} (complete graph on n/3 vertices)\n2. Add 2n/3 isolated vertices and connect all K_{n/3} vertices to all isolated vertices\n3. This split graph (line 132) requires \u2248 n\u00b2/6 cliques\n4. The `lower_bound` theorem (line 140) derives the chordal lower bound from the split graph construction via `split_is_chordal`\n\n**The Gap** (lines 190\u2013206):\nCurrent upper bound coefficient 1/4 vs conjectured 1/6, a factor of 3/2. Closing this requires either:\n- Better structural analysis of chordal clique partitions, or\n- A counterexample exceeding n\u00b2/6 + O(n)\n\n**Main Theorems** (lines 309\u2013333):\n- `erdos_81_summary`: combines the lower bound and gap analysis\n- `erdos_81`: combines the upper bound and PEO 2-approximation for any chordal graph",
     "keyInsights": [
-      "Chordal graphs have perfect elimination orderings — vertices can be removed one at a time keeping the graph chordal (Dirac 1961)",
-      "Split graphs (clique + independent set) are a key special case; the Chen-Erdős-Ordman bound of 3n²/16 is between the conjectured 1/6 and known 1/4",
+      "Chordal graphs have perfect elimination orderings \u2014 vertices can be removed one at a time keeping the graph chordal (Dirac 1961)",
+      "Split graphs (clique + independent set) are a key special case; the Chen-Erd\u0151s-Ordman bound of 3n\u00b2/16 is between the conjectured 1/6 and known 1/4",
       "The extremal construction is itself a split graph, suggesting split graphs may be the hardest case for clique partitions",
-      "The gap between (1/4 − ε)n² and n²/6 is the core open question — a factor of ~1.5 in the leading coefficient",
+      "The gap between (1/4 \u2212 \u03b5)n\u00b2 and n\u00b2/6 is the core open question \u2014 a factor of ~1.5 in the leading coefficient",
       "The PEO-based greedy algorithm gives a 2-approximation for clique partition number, but optimal partitioning remains open algorithmically",
-      "The O(n) term handles boundary effects — the leading coefficient (1/6 vs 1/4) is the key question"
+      "The O(n) term handles boundary effects \u2014 the leading coefficient (1/6 vs 1/4) is the key question"
     ],
     "prerequisites": [
       "Graph theory (vertices, edges, colorings)",
@@ -95,32 +95,32 @@
       "title": "Extremal Construction",
       "startLine": 120,
       "endLine": 148,
-      "summary": "The lower bound construction: K_{n/3} + 2n/3 isolated vertices requires ≥ n²/6 cliques",
-      "mathContext": "The lower bound construction: K_{n/3} + 2n/3 isolated vertices requires $\\geq$ n²/6 cliques"
+      "summary": "The lower bound construction: K_{n/3} + 2n/3 isolated vertices requires \u2265 n\u00b2/6 cliques",
+      "mathContext": "The lower bound construction: K_{n/3} + 2n/3 isolated vertices requires $\\geq$ n\u00b2/6 cliques"
     },
     {
       "id": "upper-bounds",
       "title": "Known Upper Bounds",
       "startLine": 149,
       "endLine": 168,
-      "summary": "Erdős-Ordman-Zalcstein (1/4 − ε)n² and Chen-Erdős-Ordman 3n²/16 + O(n) for split graphs",
-      "mathContext": "Erdős-Ordman-Zalcstein (1/4 − ε)n² and Chen-Erdős-Ordman 3n²/16 + $O(n)$ for split graphs"
+      "summary": "Erd\u0151s-Ordman-Zalcstein (1/4 \u2212 \u03b5)n\u00b2 and Chen-Erd\u0151s-Ordman 3n\u00b2/16 + O(n) for split graphs",
+      "mathContext": "Erd\u0151s-Ordman-Zalcstein (1/4 \u2212 \u03b5)n\u00b2 and Chen-Erd\u0151s-Ordman 3n\u00b2/16 + $O(n)$ for split graphs"
     },
     {
       "id": "conjecture",
       "title": "The Main Conjecture and Gap",
       "startLine": 169,
       "endLine": 196,
-      "summary": "The open conjecture (n²/6 + O(n)) and gap analysis",
-      "mathContext": "The open conjecture (n²/6 + $O(n)$) and gap analysis"
+      "summary": "The open conjecture (n\u00b2/6 + O(n)) and gap analysis",
+      "mathContext": "The open conjecture (n\u00b2/6 + $O(n)$) and gap analysis"
     },
     {
       "id": "peo",
       "title": "Perfect Elimination Ordering",
       "startLine": 197,
       "endLine": 227,
-      "summary": "Simplicial vertices, PEO definition, and the chordal ↔ PEO characterization",
-      "mathContext": "Formal definition: Simplicial vertices, PEO definition, and the chordal ↔ PEO characterization"
+      "summary": "Simplicial vertices, PEO definition, and the chordal \u2194 PEO characterization",
+      "mathContext": "Formal definition: Simplicial vertices, PEO definition, and the chordal \u2194 PEO characterization"
     },
     {
       "id": "computational",
@@ -148,12 +148,12 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #81 asks whether every chordal graph on n vertices can have its edges partitioned into n²/6 + O(n) cliques. The extremal split graph K_{n/3} + 2n/3 isolated vertices achieves the lower bound n²/6. The Erdős-Ordman-Zalcstein upper bound is (1/4 − ε)n², leaving a gap factor of ~1.5 in the leading coefficient. The Chen-Erdős-Ordman bound of 3n²/16 for split graphs is a partial result. The problem remains OPEN.",
-    "implications": "1. **Structural Graph Theory**: Connects chordal graph structure to edge partition complexity; a resolution would reveal which structural property of chordal graphs limits clique partition efficiency\n\n**2. Split Graphs as Extremal**: The 3n²/16 result for split graphs and the fact that the extremal construction is split suggest these are the hardest case\n\n3. **Perfect Elimination**: The PEO characterization of chordal graphs is central — the 2-approximation via greedy PEO shows the structure helps, but optimal exploitation remains open\n\n4. **Applications**: Chordal graphs appear in sparse matrix factorization (fill-in minimization), constraint satisfaction (arc consistency), and database theory (acyclic schemas).",
+    "summary": "Erd\u0151s Problem #81 asks whether every chordal graph on n vertices can have its edges partitioned into n\u00b2/6 + O(n) cliques. The extremal split graph K_{n/3} + 2n/3 isolated vertices achieves the lower bound n\u00b2/6. The Erd\u0151s-Ordman-Zalcstein upper bound is (1/4 \u2212 \u03b5)n\u00b2, leaving a gap factor of ~1.5 in the leading coefficient. The Chen-Erd\u0151s-Ordman bound of 3n\u00b2/16 for split graphs is a partial result. The problem remains OPEN.",
+    "implications": "1. **Structural Graph Theory**: Connects chordal graph structure to edge partition complexity; a resolution would reveal which structural property of chordal graphs limits clique partition efficiency\n\n**2. Split Graphs as Extremal**: The 3n\u00b2/16 result for split graphs and the fact that the extremal construction is split suggest these are the hardest case\n\n3. **Perfect Elimination**: The PEO characterization of chordal graphs is central \u2014 the 2-approximation via greedy PEO shows the structure helps, but optimal exploitation remains open\n\n4. **Applications**: Chordal graphs appear in sparse matrix factorization (fill-in minimization), constraint satisfaction (arc consistency), and database theory (acyclic schemas).",
     "openQuestions": [
-      "Can the upper bound be improved from (1/4 − ε)n² to n²/6 + O(n)?",
+      "Can the upper bound be improved from (1/4 \u2212 \u03b5)n\u00b2 to n\u00b2/6 + O(n)?",
       "Are split graphs the hardest case for clique partitions among chordal graphs?",
-      "What is the exact optimal coefficient for split graphs — is 3/16 tight?",
+      "What is the exact optimal coefficient for split graphs \u2014 is 3/16 tight?",
       "Is there a polynomial-time algorithm to find optimal clique partitions of chordal graphs?",
       "How does the clique partition number relate to other chordal graph parameters (treewidth, clique number)?"
     ]
@@ -187,14 +187,14 @@
     {
       "targetId": "ramseys-theorem",
       "relationship": "related",
-      "description": "Both concern structural properties of graphs — Ramsey theory guarantees unavoidable substructures, connecting to the structural constraints studied here"
+      "description": "Both concern structural properties of graphs \u2014 Ramsey theory guarantees unavoidable substructures, connecting to the structural constraints studied here"
     }
   ],
   "references": [
     {
       "key": "Er62",
       "authors": [
-        "P. Erdős"
+        "P. Erd\u0151s"
       ],
       "title": "On cliques in graphs",
       "venue": "Israel Journal of Mathematics",

--- a/src/data/proofs/erdos-812/meta.json
+++ b/src/data/proofs/erdos-812/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-812",
-  "title": "Erdős Problem #812: Growth of Consecutive Ramsey Numbers",
+  "title": "Erd\u0151s Problem #812: Growth of Consecutive Ramsey Numbers",
   "slug": "erdos-812",
-  "description": "Two questions about Ramsey number growth: (1) Is R(n+1)/R(n) ≥ 1+c for some c > 0? (2) Is R(n+1) - R(n) ≫ n²? Both questions remain OPEN. Best known: R(n+1) - R(n) ≥ 4n - 8 (Burr-Erdős-Faudree-Schelp 1989).",
+  "description": "Two questions about Ramsey number growth: (1) Is R(n+1)/R(n) \u2265 1+c for some c > 0? (2) Is R(n+1) - R(n) \u226b n\u00b2? Both questions remain OPEN. Best known: R(n+1) - R(n) \u2265 4n - 8 (Burr-Erd\u0151s-Faudree-Schelp 1989).",
   "meta": {
-    "author": "Erdős, Burr, Faudree, Schelp",
+    "author": "Erd\u0151s, Burr, Faudree, Schelp",
     "sourceUrl": "https://erdosproblems.com/812",
     "date": "1989-1991",
     "status": "axiomatized",
@@ -46,13 +46,13 @@
       "R axiom: the diagonal Ramsey number",
       "R_basic: R(1)=1, R(2)=2, strict increasing",
       "R_known_values: R(3)=6, R(4)=18",
-      "ramsey_bounds axiom: 2^{n/2} ≤ R(n) ≤ 4^n/√n",
+      "ramsey_bounds axiom: 2^{n/2} \u2264 R(n) \u2264 4^n/\u221an",
       "ratio_conjecture and quadratic_difference_conjecture definitions",
-      "BEFS_theorem axiom: R(n+1) - R(n) ≥ 4n - 8",
+      "BEFS_theorem axiom: R(n+1) - R(n) \u2265 4n - 8",
       "problem_165_bound axiom: two-step almost-quadratic bound",
       "ratio_implies_exponential: logical consequence",
       "Computational verifications for small n (6 examples proved by norm_num)",
-      "erdos_812_summary: conjunction proved by exact ⟨BEFS_theorem, problem_165_bound⟩"
+      "erdos_812_summary: conjunction proved by exact \u27e8BEFS_theorem, problem_165_bound\u27e9"
     ],
     "relatedProblems": [
       "erdos-165",
@@ -66,16 +66,16 @@
     ],
     "axiomCount": 3,
     "lineCount": 157,
-    "assumptions": "7 axioms: R, R_basic, R_known_values, and 4 more. See Lean source for complete statements."
+    "assumptions": "3 axioms: R, BEFS_theorem, problem_165_bound. 0 sorries."
   },
   "overview": {
-    "historicalContext": "**Consecutive Ramsey Number Growth: From Erdős-Szekeres to the BEFS Linear Bound**\n\nThe diagonal Ramsey number $R(n)$ — the minimum $N$ such that any 2-coloring of $K_N$ contains a monochromatic $K_n$ — is one of the most mysterious quantities in combinatorics. Since Erdős and Szekeres (1935) proved $R(n) \\leq \\binom{2n-2}{n-1} < 4^n$ and Erdős (1947) proved $R(n) \\geq 2^{n/2}$ using the probabilistic method (the founding result of probabilistic combinatorics), the exponential base has remained unknown: $\\sqrt{2} \\leq \\alpha \\leq 4$ where $R(n) \\sim \\alpha^n$.\n\n**Problem #812 (Erdős, 1991)** asks two questions about the *consecutive* growth of $R(n)$:\n1. **Ratio conjecture**: Is $R(n+1)/R(n) \\geq 1 + c$ for some absolute $c > 0$?\n2. **Quadratic difference conjecture**: Is $R(n+1) - R(n) \\gg n^2$?\n\n**The BEFS Linear Bound (1989)**: Burr, Erdős, Faudree, and Schelp proved the best known result: $R(n+1) - R(n) \\geq 4n - 8$ for $n \\geq 2$. Their proof analyzes critical colorings — 2-colorings of $K_{R(n)-1}$ with no monochromatic $K_n$ — and shows that extending to $K_{R(n+1)-1}$ requires adding at least $4n - 8$ vertices. The bound is tight at $n = 3$: $R(4) - R(3) = 18 - 6 = 12 \\geq 4 \\cdot 3 - 8 = 4$.\n\n**The Two-Step Gap (Problem #165)**: For the *two-step* difference $R(n+2) - R(n)$, much more is known. Using $R(n+2) \\geq R(n) + R(3, R(n) - 1) - 1$ and the asymptotic $R(3, k) \\sim k^2/(2\\log k)$ (Kim 1995 for lower bound, Shearer 1983 for upper), one obtains $R(n+2) - R(n) \\gg n^{2-o(1)}$. This tantalizingly shows that quadratic growth is achievable with a two-step gap but remains unproved for one step.\n\n**Known Exact Values**: $R(3) = 6$ (Ramsey 1930), $R(4) = 18$ (Greenwood-Gleason 1955), $43 \\leq R(5) \\leq 46$ (McKay-Radziszowski 1995, Angeltveit-McKay 2024). Erdős's famous aliens quote captures the difficulty: *'If aliens demanded $R(5)$, we could marshal our best minds... but if they asked for $R(6)$, we should just surrender.'*\n\n**Recent Progress**: In 2023, Campos, Griffiths, Morris, and Sahasrabudhe proved $R(n) \\leq (4 - \\varepsilon)^n$ for some small $\\varepsilon > 0$, the first improvement to the Erdős-Szekeres upper bound in nearly 90 years. This breakthrough suggests that the exponential base may indeed be closer to $\\sqrt{2}$ than to $4$, but says nothing about consecutive differences.",
-    "problemStatement": "**Problem Statement (OPEN)**\n\nLet $R(n)$ denote the diagonal Ramsey number.\n\n**Question 1 (Ratio):** Is it true that $R(n+1)/R(n) \\geq 1 + c$ for some constant $c > 0$ and all sufficiently large $n$?\n\n**Question 2 (Quadratic Difference):** Is it true that $R(n+1) - R(n) \\gg n^2$?\n\n**Best Known:** $R(n+1) - R(n) \\geq 4n - 8$ for $n \\geq 2$ (Burr-Erdős-Faudree-Schelp 1989).\n\n**Status:** Both questions remain completely open.",
-    "text": "Two questions about Ramsey number growth: (1) Is R(n+1)/R(n) ≥ 1+c for some c > 0? (2) Is R(n+1) - R(n) ≫ n²? Both questions remain OPEN. Best known: R(n+1) - R(n) ≥ 4n - 8 (Burr-Erdős-Faudree-Schelp 1989).",
-    "proofStrategy": "**Formalization Strategy**\n\n1. **Axiomatized Ramsey Number**: $R(n)$ is declared as an axiom $R : \\mathbb{N} \\to \\mathbb{N}$ with basic properties ($R(1) = 1$, $R(2) = 2$, strict monotonicity) and known values ($R(3) = 6$, $R(4) = 18$).\n\n2. **Classical Bounds**: Axiomatizes $2^{n/2} \\leq R(n) \\leq 4^n/\\sqrt{n}$ (Erdős 1947 + Erdős-Szekeres 1935).\n\n3. **Formal Conjectures**: Defines `ratio_conjecture` and `quadratic_difference_conjecture` as `Prop` values.\n\n4. **Known Results**: Axiomatizes the BEFS linear bound and the Problem #165 two-step bound. The two-step bound uses a subpolynomial correction factor formalized as $f : \\mathbb{N} \\to \\mathbb{R}$ with $f(n) \\leq n^\\varepsilon$ eventually.\n\n5. **Logical Consequence**: Axiomatizes that the ratio conjecture implies exponential growth via telescoping.\n\n6. **Computational Verifications**: Six `norm_num` examples verify ratios and BEFS bounds for small $n$.\n\n7. **Summary Theorem**: A **verified proof** `erdos_812_summary` packages BEFS and the two-step bound as a conjunction.",
+    "historicalContext": "**Consecutive Ramsey Number Growth: From Erd\u0151s-Szekeres to the BEFS Linear Bound**\n\nThe diagonal Ramsey number $R(n)$ \u2014 the minimum $N$ such that any 2-coloring of $K_N$ contains a monochromatic $K_n$ \u2014 is one of the most mysterious quantities in combinatorics. Since Erd\u0151s and Szekeres (1935) proved $R(n) \\leq \\binom{2n-2}{n-1} < 4^n$ and Erd\u0151s (1947) proved $R(n) \\geq 2^{n/2}$ using the probabilistic method (the founding result of probabilistic combinatorics), the exponential base has remained unknown: $\\sqrt{2} \\leq \\alpha \\leq 4$ where $R(n) \\sim \\alpha^n$.\n\n**Problem #812 (Erd\u0151s, 1991)** asks two questions about the *consecutive* growth of $R(n)$:\n1. **Ratio conjecture**: Is $R(n+1)/R(n) \\geq 1 + c$ for some absolute $c > 0$?\n2. **Quadratic difference conjecture**: Is $R(n+1) - R(n) \\gg n^2$?\n\n**The BEFS Linear Bound (1989)**: Burr, Erd\u0151s, Faudree, and Schelp proved the best known result: $R(n+1) - R(n) \\geq 4n - 8$ for $n \\geq 2$. Their proof analyzes critical colorings \u2014 2-colorings of $K_{R(n)-1}$ with no monochromatic $K_n$ \u2014 and shows that extending to $K_{R(n+1)-1}$ requires adding at least $4n - 8$ vertices. The bound is tight at $n = 3$: $R(4) - R(3) = 18 - 6 = 12 \\geq 4 \\cdot 3 - 8 = 4$.\n\n**The Two-Step Gap (Problem #165)**: For the *two-step* difference $R(n+2) - R(n)$, much more is known. Using $R(n+2) \\geq R(n) + R(3, R(n) - 1) - 1$ and the asymptotic $R(3, k) \\sim k^2/(2\\log k)$ (Kim 1995 for lower bound, Shearer 1983 for upper), one obtains $R(n+2) - R(n) \\gg n^{2-o(1)}$. This tantalizingly shows that quadratic growth is achievable with a two-step gap but remains unproved for one step.\n\n**Known Exact Values**: $R(3) = 6$ (Ramsey 1930), $R(4) = 18$ (Greenwood-Gleason 1955), $43 \\leq R(5) \\leq 46$ (McKay-Radziszowski 1995, Angeltveit-McKay 2024). Erd\u0151s's famous aliens quote captures the difficulty: *'If aliens demanded $R(5)$, we could marshal our best minds... but if they asked for $R(6)$, we should just surrender.'*\n\n**Recent Progress**: In 2023, Campos, Griffiths, Morris, and Sahasrabudhe proved $R(n) \\leq (4 - \\varepsilon)^n$ for some small $\\varepsilon > 0$, the first improvement to the Erd\u0151s-Szekeres upper bound in nearly 90 years. This breakthrough suggests that the exponential base may indeed be closer to $\\sqrt{2}$ than to $4$, but says nothing about consecutive differences.",
+    "problemStatement": "**Problem Statement (OPEN)**\n\nLet $R(n)$ denote the diagonal Ramsey number.\n\n**Question 1 (Ratio):** Is it true that $R(n+1)/R(n) \\geq 1 + c$ for some constant $c > 0$ and all sufficiently large $n$?\n\n**Question 2 (Quadratic Difference):** Is it true that $R(n+1) - R(n) \\gg n^2$?\n\n**Best Known:** $R(n+1) - R(n) \\geq 4n - 8$ for $n \\geq 2$ (Burr-Erd\u0151s-Faudree-Schelp 1989).\n\n**Status:** Both questions remain completely open.",
+    "text": "Two questions about Ramsey number growth: (1) Is R(n+1)/R(n) \u2265 1+c for some c > 0? (2) Is R(n+1) - R(n) \u226b n\u00b2? Both questions remain OPEN. Best known: R(n+1) - R(n) \u2265 4n - 8 (Burr-Erd\u0151s-Faudree-Schelp 1989).",
+    "proofStrategy": "**Formalization Strategy**\n\n1. **Axiomatized Ramsey Number**: $R(n)$ is declared as an axiom $R : \\mathbb{N} \\to \\mathbb{N}$ with basic properties ($R(1) = 1$, $R(2) = 2$, strict monotonicity) and known values ($R(3) = 6$, $R(4) = 18$).\n\n2. **Classical Bounds**: Axiomatizes $2^{n/2} \\leq R(n) \\leq 4^n/\\sqrt{n}$ (Erd\u0151s 1947 + Erd\u0151s-Szekeres 1935).\n\n3. **Formal Conjectures**: Defines `ratio_conjecture` and `quadratic_difference_conjecture` as `Prop` values.\n\n4. **Known Results**: Axiomatizes the BEFS linear bound and the Problem #165 two-step bound. The two-step bound uses a subpolynomial correction factor formalized as $f : \\mathbb{N} \\to \\mathbb{R}$ with $f(n) \\leq n^\\varepsilon$ eventually.\n\n5. **Logical Consequence**: Axiomatizes that the ratio conjecture implies exponential growth via telescoping.\n\n6. **Computational Verifications**: Six `norm_num` examples verify ratios and BEFS bounds for small $n$.\n\n7. **Summary Theorem**: A **verified proof** `erdos_812_summary` packages BEFS and the two-step bound as a conjunction.",
     "keyInsights": [
-      "**Linear vs quadratic gap**: The BEFS bound $R(n+1) - R(n) \\geq 4n - 8$ is linear, while the conjectured growth is quadratic ($\\gg n^2$). Bridging this gap — from $O(n)$ to $O(n^2)$ — would be a major advance in Ramsey theory, equivalent to understanding the local behavior of an exponentially growing function",
-      "**Two-step vs one-step**: The two-step difference $R(n+2) - R(n) \\gg n^{2-o(1)}$ is almost quadratic, but the one-step difference is only known to be linear. This asymmetry suggests that $R(n)$ may have an oscillatory or irregular local structure that 'smooths out' over two steps — a phenomenon not captured by any current model",
+      "**Linear vs quadratic gap**: The BEFS bound $R(n+1) - R(n) \\geq 4n - 8$ is linear, while the conjectured growth is quadratic ($\\gg n^2$). Bridging this gap \u2014 from $O(n)$ to $O(n^2)$ \u2014 would be a major advance in Ramsey theory, equivalent to understanding the local behavior of an exponentially growing function",
+      "**Two-step vs one-step**: The two-step difference $R(n+2) - R(n) \\gg n^{2-o(1)}$ is almost quadratic, but the one-step difference is only known to be linear. This asymmetry suggests that $R(n)$ may have an oscillatory or irregular local structure that 'smooths out' over two steps \u2014 a phenomenon not captured by any current model",
       "**Ratio conjecture and exponential base**: If $R(n+1)/R(n) \\geq 1 + c$, then $R(n) \\geq R(3) \\cdot (1+c)^{n-3}$, pinning down the exponential base $\\alpha \\geq 1 + c$. Currently $\\alpha \\in [\\sqrt{2}, 4-\\varepsilon]$ (CGMS 2023), and determining $\\alpha$ is arguably the central problem of Ramsey theory",
       "**Small cases are misleading**: $R(3)/R(2) = R(4)/R(3) = 3$, both suggesting $c \\approx 2$. But with only two non-trivial exact values known, this pattern may break for $R(5)/R(4)$. The ratio could vary wildly for small $n$ before stabilizing (if it stabilizes at all)",
       "**Connection to the 2023 breakthrough**: Campos-Griffiths-Morris-Sahasrabudhe proved $R(n) \\leq (4-\\varepsilon)^n$, the first upper bound improvement in 90 years. This affects the possible range of the ratio limit but does not directly address consecutive differences, leaving Problem #812 untouched"
@@ -109,8 +109,8 @@
       "title": "Known Values and Classical Bounds",
       "startLine": 55,
       "endLine": 66,
-      "summary": "Axiomatizes $R(3) = 6$, $R(4) = 18$, and the classical bounds $2^{n/2} \\leq R(n) \\leq 4^n/\\sqrt{n}$ (Erdős 1947 + Erdős-Szekeres 1935).",
-      "mathContext": "Axiomatizes $R(3) = 6$, $R(4) = 18$, and the classical bounds $$$2^{{n/2}$}$ \\leq R(n) \\leq $4^{n}$/\\sqrt{n}$ (Erdős 1947 + Erdős-Szekeres 1935)."
+      "summary": "Axiomatizes $R(3) = 6$, $R(4) = 18$, and the classical bounds $2^{n/2} \\leq R(n) \\leq 4^n/\\sqrt{n}$ (Erd\u0151s 1947 + Erd\u0151s-Szekeres 1935).",
+      "mathContext": "Axiomatizes $R(3) = 6$, $R(4) = 18$, and the classical bounds $$$2^{{n/2}$}$ \\leq R(n) \\leq $4^{n}$/\\sqrt{n}$ (Erd\u0151s 1947 + Erd\u0151s-Szekeres 1935)."
     },
     {
       "id": "main-questions",
@@ -125,8 +125,8 @@
       "title": "BEFS Linear Bound (1989)",
       "startLine": 95,
       "endLine": 96,
-      "summary": "Axiomatizes the Burr-Erdős-Faudree-Schelp theorem: $R(n+1) - R(n) \\geq 4n - 8$ for all $n \\geq 2$. The best known lower bound on consecutive differences.",
-      "mathContext": "Verified: Axiomatizes the Burr-Erdős-Faudree-Schelp theorem: $R(n+1) - R(n) \\geq 4n - 8$ for all $n \\geq 2$. The best known lower bound on consecutive differences."
+      "summary": "Axiomatizes the Burr-Erd\u0151s-Faudree-Schelp theorem: $R(n+1) - R(n) \\geq 4n - 8$ for all $n \\geq 2$. The best known lower bound on consecutive differences.",
+      "mathContext": "Verified: Axiomatizes the Burr-Erd\u0151s-Faudree-Schelp theorem: $R(n+1) - R(n) \\geq 4n - 8$ for all $n \\geq 2$. The best known lower bound on consecutive differences."
     },
     {
       "id": "twostep",
@@ -154,8 +154,8 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures the full structure of Erdős Problem #812 on consecutive Ramsey number growth. It axiomatizes the diagonal Ramsey number $R(n)$ with basic properties and known values, defines the two open conjectures (ratio bound and quadratic difference), presents the best known results (BEFS linear bound and Problem #165 two-step bound), derives the logical consequence of the ratio conjecture, verifies bounds computationally for small $n$, and packages the known results in a verified summary theorem.",
-    "implications": "**Theoretical Significance**: **Ramsey Theory Significance**\n\n1. **Central Open Problem**: Determining the growth rate of $R(n)$ is one of the most important problems in combinatorics. Problem #812's two questions would each represent significant progress: the ratio conjecture pins down the exponential base, while the quadratic conjecture closes the gap between $O(n)$ and $O(n^2)$ consecutive differences.\n\n2. **BEFS Bound in Context**: The $4n - 8$ bound has stood as the best result for over 35 years.\n\nIt was proved in the same era as Alon's subdivided graph theorem (Problem #800) and reflects the combinatorial depth of critical coloring arguments.\n\n3. **Connection to Upper Bound Improvements**: The 2023 result $R(n) \\leq (4 - \\varepsilon)^n$ by Campos-Griffiths-Morris-Sahasrabudhe is the biggest advance in Ramsey theory in decades. If the exponential base $\\alpha$ can be determined more precisely, the consecutive ratios $R(n+1)/R(n) \\to \\alpha$ would follow.\n\n4. **Probabilistic Method Limitations**: Both conjectures resist current probabilistic techniques because they require *lower bounds* on Ramsey numbers (which need explicit constructions) rather than upper bounds (which the probabilistic method excels at).\n\n5. **Formal Verification**: The file demonstrates how open problems can be meaningfully formalized: defining conjectures as `Prop`, axiomatizing partial results, proving logical consequences, and verifying computational evidence — all while making the status of each component explicit.",
+    "summary": "This formalization captures the full structure of Erd\u0151s Problem #812 on consecutive Ramsey number growth. It axiomatizes the diagonal Ramsey number $R(n)$ with basic properties and known values, defines the two open conjectures (ratio bound and quadratic difference), presents the best known results (BEFS linear bound and Problem #165 two-step bound), derives the logical consequence of the ratio conjecture, verifies bounds computationally for small $n$, and packages the known results in a verified summary theorem.",
+    "implications": "**Theoretical Significance**: **Ramsey Theory Significance**\n\n1. **Central Open Problem**: Determining the growth rate of $R(n)$ is one of the most important problems in combinatorics. Problem #812's two questions would each represent significant progress: the ratio conjecture pins down the exponential base, while the quadratic conjecture closes the gap between $O(n)$ and $O(n^2)$ consecutive differences.\n\n2. **BEFS Bound in Context**: The $4n - 8$ bound has stood as the best result for over 35 years.\n\nIt was proved in the same era as Alon's subdivided graph theorem (Problem #800) and reflects the combinatorial depth of critical coloring arguments.\n\n3. **Connection to Upper Bound Improvements**: The 2023 result $R(n) \\leq (4 - \\varepsilon)^n$ by Campos-Griffiths-Morris-Sahasrabudhe is the biggest advance in Ramsey theory in decades. If the exponential base $\\alpha$ can be determined more precisely, the consecutive ratios $R(n+1)/R(n) \\to \\alpha$ would follow.\n\n4. **Probabilistic Method Limitations**: Both conjectures resist current probabilistic techniques because they require *lower bounds* on Ramsey numbers (which need explicit constructions) rather than upper bounds (which the probabilistic method excels at).\n\n5. **Formal Verification**: The file demonstrates how open problems can be meaningfully formalized: defining conjectures as `Prop`, axiomatizing partial results, proving logical consequences, and verifying computational evidence \u2014 all while making the status of each component explicit.",
     "openQuestions": [
       "Is $R(n+1)/R(n) \\geq 1 + c$ for some absolute $c > 0$? Even proving $R(n+1)/R(n) \\to \\infty$ (that the ratio is unbounded) would be a breakthrough.",
       "Is $R(n+1) - R(n) \\gg n^2$? Can the BEFS linear bound $4n - 8$ be improved to $n^{1+\\delta}$ for any $\\delta > 0$?",
@@ -183,17 +183,17 @@
     {
       "targetId": "erdos-165",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, graph-theory, probabilistic-method, ramsey-theory"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, graph-theory, probabilistic-method, ramsey-theory"
     },
     {
       "targetId": "erdos-166",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, graph-theory, probabilistic-method, ramsey-theory"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, graph-theory, probabilistic-method, ramsey-theory"
     },
     {
       "targetId": "erdos-1014",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, graph-theory, ramsey-theory"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, graph-theory, ramsey-theory"
     }
   ]
 }

--- a/src/data/proofs/erdos-816/meta.json
+++ b/src/data/proofs/erdos-816/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-816",
-  "title": "Erdős Problem #816: Equal-Degree Vertices and Paths of Length 3",
+  "title": "Erd\u0151s Problem #816: Equal-Degree Vertices and Paths of Length 3",
   "slug": "erdos-816",
-  "description": "Let G be a graph with 2n+1 vertices and n² + n + 1 edges. Must G contain two vertices of the same degree joined by a path of length 3? YES - proved by Chen-Ma (2025).",
+  "description": "Let G be a graph with 2n+1 vertices and n\u00b2 + n + 1 edges. Must G contain two vertices of the same degree joined by a path of length 3? YES - proved by Chen-Ma (2025).",
   "meta": {
     "author": "Chen and Ma (2025)",
     "sourceUrl": "https://erdosproblems.com/816",
@@ -59,30 +59,30 @@
       "hasPath3_symm: symmetry theorem (constructive proof)",
       "sameDegree: equal degree predicate",
       "hasEqualDegreePath3Pair: main property",
-      "satisfiesEH816: Erdős-Hajnal condition",
+      "satisfiesEH816: Erd\u0151s-Hajnal condition",
       "satisfiesWeakerEH816: Chen-Ma weaker condition",
       "isCompleteBipartite: K_{n,n+1} characterization",
       "K_counterexample: threshold tightness",
       "chen_ma_theorem: 2025 main result",
-      "erdos_816_for_large_n: corollary for n ≥ 600",
+      "erdos_816_for_large_n: corollary for n \u2265 600",
       "erdos_816_full: complete answer",
       "pigeonhole_degrees: degree pigeonhole axiom"
     ],
     "axiomCount": 1,
     "lineCount": 206,
-    "assumptions": "5 axioms: K_counterexample, chen_ma_theorem, erdos_816_for_large_n, and 2 more. See Lean source for complete statements."
+    "assumptions": "1 axiom: erdos_816_full. 0 sorries."
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #816: Equal-Degree Paths**\n\nThis problem was posed by Erdős and Hajnal and concerns the interplay between degree sequences and path connectivity in graphs.\n\n**The Question:**\nGiven enough edges, must a graph contain two vertices of the same degree that are connected by a path of length 3?\n\n**Key Insight:**\nThe complete bipartite graph K_{n,n+1} has exactly n² + n edges and fails this property: vertices of equal degree are in the same part, but paths of length 3 between same-part vertices don't exist (paths alternate between parts).\n\n**Resolution:**\nChen and Ma (2025, arXiv:2503.19569) proved that one additional edge (n² + n + 1 total) forces the property. They proved the stronger result that for n ≥ 600, even n² + n edges suffice except for K_{n,n+1}.",
+    "historicalContext": "**Erd\u0151s Problem #816: Equal-Degree Paths**\n\nThis problem was posed by Erd\u0151s and Hajnal and concerns the interplay between degree sequences and path connectivity in graphs.\n\n**The Question:**\nGiven enough edges, must a graph contain two vertices of the same degree that are connected by a path of length 3?\n\n**Key Insight:**\nThe complete bipartite graph K_{n,n+1} has exactly n\u00b2 + n edges and fails this property: vertices of equal degree are in the same part, but paths of length 3 between same-part vertices don't exist (paths alternate between parts).\n\n**Resolution:**\nChen and Ma (2025, arXiv:2503.19569) proved that one additional edge (n\u00b2 + n + 1 total) forces the property. They proved the stronger result that for n \u2265 600, even n\u00b2 + n edges suffice except for K_{n,n+1}.",
     "problemStatement": "**Problem Statement**\n\nLet $G$ be a graph with $2n+1$ vertices and $n^2 + n + 1$ edges.\n\n**Question:** Must $G$ contain two vertices of the same degree which are joined by a path of length 3?\n\n**Answer:** YES\n\n**Threshold:** The complete bipartite graph $K_{n,n+1}$ has exactly $n^2 + n$ edges and fails this property, showing the threshold is tight.\n\n**Stronger Result (Chen-Ma 2025):**\nFor $n \\geq 600$, all graphs with $2n+1$ vertices and at least $n^2 + n$ edges contain such a pair, except $K_{n,n+1}$.",
-    "text": "Let G be a graph with 2n+1 vertices and n² + n + 1 edges. Must G contain two vertices of the same degree joined by a path of length 3? YES - proved by Chen-Ma (2025).",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Graph Basics:** Define vertex count, edge count, and degree using Mathlib's SimpleGraph\n\n2. **Path of Length 3:** Define hasPath3 with a constructive symmetry proof\n\n3. **Equal-Degree Pair:** Define sameDegree and hasEqualDegreePath3Pair\n\n4. **Conditions:** Define the Erdős-Hajnal and weaker Chen-Ma conditions\n\n5. **Counterexample:** Define complete bipartite graph and state it fails with n² + n edges\n\n6. **Chen-Ma Theorem:** Axiomatize the 2025 result for n ≥ 600\n\n7. **Main Result:** State the full answer as an axiom",
+    "text": "Let G be a graph with 2n+1 vertices and n\u00b2 + n + 1 edges. Must G contain two vertices of the same degree joined by a path of length 3? YES - proved by Chen-Ma (2025).",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Graph Basics:** Define vertex count, edge count, and degree using Mathlib's SimpleGraph\n\n2. **Path of Length 3:** Define hasPath3 with a constructive symmetry proof\n\n3. **Equal-Degree Pair:** Define sameDegree and hasEqualDegreePath3Pair\n\n4. **Conditions:** Define the Erd\u0151s-Hajnal and weaker Chen-Ma conditions\n\n5. **Counterexample:** Define complete bipartite graph and state it fails with n\u00b2 + n edges\n\n6. **Chen-Ma Theorem:** Axiomatize the 2025 result for n \u2265 600\n\n7. **Main Result:** State the full answer as an axiom",
     "keyInsights": [
-      "**K_{n,n+1} as Extremal Graph:** The complete bipartite graph K_{n,n+1} is the unique extremal example—it has exactly n² + n edges and fails the property.",
+      "**K_{n,n+1} as Extremal Graph:** The complete bipartite graph K_{n,n+1} is the unique extremal example\u2014it has exactly n\u00b2 + n edges and fails the property.",
       "**Why K_{n,n+1} Fails:** In K_{n,n+1}, one part has degree n+1, the other has degree n. Same-degree vertices are in the same part, but paths of length 3 between them don't exist since paths alternate parts.",
-      "**Edge Threshold:** Adding one edge beyond K_{n,n+1} (to n² + n + 1) breaks the bipartite obstruction and forces the equal-degree path-3 pair.",
-      "**Path Length 3 is Natural:** Path length 3 creates the tension with bipartite structure—it traverses both parts and returns, unlike paths of length 1 or 2.",
-      "**Very Recent Result:** Chen-Ma's 2025 paper (arXiv:2503.19569) resolves a decades-old Erdős-Hajnal problem with a stronger characterization."
+      "**Edge Threshold:** Adding one edge beyond K_{n,n+1} (to n\u00b2 + n + 1) breaks the bipartite obstruction and forces the equal-degree path-3 pair.",
+      "**Path Length 3 is Natural:** Path length 3 creates the tension with bipartite structure\u2014it traverses both parts and returns, unlike paths of length 1 or 2.",
+      "**Very Recent Result:** Chen-Ma's 2025 paper (arXiv:2503.19569) resolves a decades-old Erd\u0151s-Hajnal problem with a stronger characterization."
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -116,7 +116,7 @@
     },
     {
       "id": "conditions",
-      "title": "The Erdős-Hajnal Condition",
+      "title": "The Erd\u0151s-Hajnal Condition",
       "summary": "satisfiesEH816, satisfiesWeakerEH816",
       "startLine": 104,
       "endLine": 123,
@@ -156,11 +156,11 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #816 asks whether graphs with 2n+1 vertices and n² + n + 1 edges must contain equal-degree vertices joined by a path of length 3. The answer is YES, proved by Chen and Ma in 2025. The complete bipartite graph K_{n,n+1} (with n² + n edges) is the unique obstruction.",
-    "implications": "**Theoretical Significance**: **Connections to Other Areas**\n\n1. **Turán-type Problems:** This is a Turán problem for the 'equal-degree path-3' property\n\n2. **Extremal Graph Theory:** K_{n,n+1} emerges as the unique extremal graph\n\n**3. Degree Sequences:** Connects degree distributions to path structure\n\n4. **Bipartite Structure:** The bipartite obstruction explains why K_{n,n+1} is special\n\n5. **Recent Progress:** One of the most recently solved Erdős problems (2025).",
+    "summary": "Erd\u0151s Problem #816 asks whether graphs with 2n+1 vertices and n\u00b2 + n + 1 edges must contain equal-degree vertices joined by a path of length 3. The answer is YES, proved by Chen and Ma in 2025. The complete bipartite graph K_{n,n+1} (with n\u00b2 + n edges) is the unique obstruction.",
+    "implications": "**Theoretical Significance**: **Connections to Other Areas**\n\n1. **Tur\u00e1n-type Problems:** This is a Tur\u00e1n problem for the 'equal-degree path-3' property\n\n2. **Extremal Graph Theory:** K_{n,n+1} emerges as the unique extremal graph\n\n**3. Degree Sequences:** Connects degree distributions to path structure\n\n4. **Bipartite Structure:** The bipartite obstruction explains why K_{n,n+1} is special\n\n5. **Recent Progress:** One of the most recently solved Erd\u0151s problems (2025).",
     "openQuestions": [
-      "Remove the n ≥ 600 restriction from Chen-Ma's stronger result",
-      "Characterize graphs with n² + n edges that contain equal-degree path-3 pairs",
+      "Remove the n \u2265 600 restriction from Chen-Ma's stronger result",
+      "Characterize graphs with n\u00b2 + n edges that contain equal-degree path-3 pairs",
       "Generalize to paths of other lengths",
       "Study analogous problems for directed graphs",
       "Explore algorithmic aspects: efficiently finding such pairs"
@@ -189,17 +189,17 @@
     {
       "targetId": "erdos-1021",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: bipartite-graphs, graph-theory, turan-type"
+      "description": "Related Erd\u0151s problem sharing themes: bipartite-graphs, graph-theory, turan-type"
     },
     {
       "targetId": "erdos-1079",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: extremal-graphs, graph-theory, solved"
+      "description": "Related Erd\u0151s problem sharing themes: extremal-graphs, graph-theory, solved"
     },
     {
       "targetId": "erdos-581",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: bipartite-graphs, graph-theory, solved"
+      "description": "Related Erd\u0151s problem sharing themes: bipartite-graphs, graph-theory, solved"
     }
   ]
 }


### PR DESCRIPTION
## Fix

Corrects stale `assumptions` text in 10 gallery proof `meta.json` files.

## Changes

| Proof | Old count | New count |
|-------|-----------|-----------|
| erdos-816 | 5 | 1 |
| erdos-812 | 7 | 3 |
| erdos-81 | 8 | 4 |
| erdos-808 | 6 | 2 |
| erdos-790 | 9 | 5 |
| erdos-778 | 6 | 2 |
| erdos-773 | 6 | 2 |
| erdos-771 | 6 | 2 |
| erdos-744 | 6 | 2 |
| erdos-743 | 12 | 8 |

---
Automated fix by lean-mechanic agent.