### PR TITLE
fix(meta): correct stale assumptions text for 10 gallery proofs (batch 34)

### DIFF
--- a/src/data/proofs/erdos-666/meta.json
+++ b/src/data/proofs/erdos-666/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-666",
-  "title": "Erdős Problem #666: C₆ in Hypercube Subgraphs",
+  "title": "Erd\u0151s Problem #666: C\u2086 in Hypercube Subgraphs",
   "slug": "erdos-666",
-  "description": "Does every ε-dense subgraph of the n-hypercube Qₙ contain C₆? Answer: NO. Chung (1992) and Brouwer-Dejter-Thomassen (1993) showed Qₙ can be 4-partitioned into C₆-free subgraphs.",
+  "description": "Does every \u03b5-dense subgraph of the n-hypercube Q\u2099 contain C\u2086? Answer: NO. Chung (1992) and Brouwer-Dejter-Thomassen (1993) showed Q\u2099 can be 4-partitioned into C\u2086-free subgraphs.",
   "meta": {
     "author": "Chung (1992 disproof), Brouwer-Dejter-Thomassen (1993), Conder (1993)",
     "sourceUrl": "https://erdosproblems.com/666",
@@ -43,50 +43,50 @@
     ],
     "originalContributions": [
       "Hypercube definition via XOR popcount: vertices adjacent iff differ in exactly one bit",
-      "hypercubeVertices: |V(Qₙ)| = 2ⁿ",
-      "hypercubeEdges: |E(Qₙ)| = n·2ⁿ⁻¹",
-      "hypercube_regular axiom: Qₙ is n-regular",
+      "hypercubeVertices: |V(Q\u2099)| = 2\u207f",
+      "hypercubeEdges: |E(Q\u2099)| = n\u00b72\u207f\u207b\u00b9",
+      "hypercube_regular axiom: Q\u2099 is n-regular",
       "HasCycle definition: injective sequence with cyclic adjacency",
       "HasC4, HasC6, HasC2k cycle predicates",
-      "EpsilonDenseSubgraph: subgraph with ε-fraction of edges",
+      "EpsilonDenseSubgraph: subgraph with \u03b5-fraction of edges",
       "ErdosConjecture: original (disproved) conjecture",
       "erdos_conjecture_false theorem: main disproof",
-      "chung_1992 axiom: 4-partition into C₆-free subgraphs",
+      "chung_1992 axiom: 4-partition into C\u2086-free subgraphs",
       "brouwer_dejter_thomassen_1993 axiom: independent 4-coloring",
       "conder_1993 axiom: improved 3-coloring",
       "GeneralizedConjecture: open question for C_{2k}"
     ],
     "axiomCount": 1,
     "lineCount": 270,
-    "assumptions": "5 axiom(s) and 1 sorry(s). See the Lean source for details."
+    "assumptions": "1 axiom: chung_1992. 1 sorries."
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #666**\n\nErdős posed this problem in 1991, asking whether dense subgraphs of the n-dimensional hypercube must contain 6-cycles. The hypercube Qₙ has 2ⁿ vertices (binary strings of length n) and n·2ⁿ⁻¹ edges (vertices adjacent iff they differ in exactly one coordinate).\n\n**Resolution (1992-1993):**\nThe answer is NO, disproved independently by two groups:\n- **Chung (1992):** Constructed an explicit 4-partition of Qₙ's edges into C₆-free subgraphs\n- **Brouwer-Dejter-Thomassen (1993):** Independent 4-coloring construction avoiding C₄ and C₆\n\n**Further Improvement:**\nConder (1993) showed that only 3 colors suffice - the edges of Qₙ can be 3-colored with no monochromatic C₄ or C₆. This means subgraphs with 1/3 of all edges need not contain C₆.",
-    "problemStatement": "**Problem Statement (Disproved)**\n\nLet Qₙ be the n-dimensional hypercube (2ⁿ vertices, n·2ⁿ⁻¹ edges).\n\n**Conjecture:** For every ε > 0, if n is sufficiently large, every subgraph of Qₙ with ≥ ε·n·2ⁿ⁻¹ edges contains C₆.\n\n**Answer:** NO\n\n**Counterexamples:**\n- ε = 1/4: Chung's 4-partition (1992)\n- ε = 1/3: Conder's 3-coloring (1993)\n\n**Generalized Conjecture (OPEN):** For C_{2k}, ∃ c > 0 and aₖ < 1 such that ≥ c·n^{aₖ}·2ⁿ edges forces C_{2k}, with aₖ → 0 as k → ∞.",
-    "text": "Does every ε-dense subgraph of the n-hypercube Qₙ contain C₆? Answer: NO. Chung (1992) and Brouwer-Dejter-Thomassen (1993) showed Qₙ can be 4-partitioned into C₆-free subgraphs.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Hypercube Definition:** Qₙ defined via XOR popcount - vertices in Fin(2ⁿ) are adjacent iff their XOR has exactly one 1-bit (Hamming distance 1)\n\n2. **Cycle Definitions:**\n   - HasCycle G k: injective k-sequence with cyclic adjacency\n   - HasC4, HasC6, HasC2k: specific even cycle predicates\n\n3. **Density:**\n   - EpsilonDenseSubgraph: at least ε·n·2ⁿ⁻¹ edges\n\n4. **Main Results:**\n   - ErdosConjecture: the (false) original conjecture\n   - erdos_conjecture_false: theorem showing it's false\n   - chung_1992 axiom: 4-partition exists\n   - conder_1993 axiom: 3-coloring exists\n\n5. **Why Axioms:** The partition constructions are combinatorial and not in Mathlib",
+    "historicalContext": "**Erd\u0151s Problem #666**\n\nErd\u0151s posed this problem in 1991, asking whether dense subgraphs of the n-dimensional hypercube must contain 6-cycles. The hypercube Q\u2099 has 2\u207f vertices (binary strings of length n) and n\u00b72\u207f\u207b\u00b9 edges (vertices adjacent iff they differ in exactly one coordinate).\n\n**Resolution (1992-1993):**\nThe answer is NO, disproved independently by two groups:\n- **Chung (1992):** Constructed an explicit 4-partition of Q\u2099's edges into C\u2086-free subgraphs\n- **Brouwer-Dejter-Thomassen (1993):** Independent 4-coloring construction avoiding C\u2084 and C\u2086\n\n**Further Improvement:**\nConder (1993) showed that only 3 colors suffice - the edges of Q\u2099 can be 3-colored with no monochromatic C\u2084 or C\u2086. This means subgraphs with 1/3 of all edges need not contain C\u2086.",
+    "problemStatement": "**Problem Statement (Disproved)**\n\nLet Q\u2099 be the n-dimensional hypercube (2\u207f vertices, n\u00b72\u207f\u207b\u00b9 edges).\n\n**Conjecture:** For every \u03b5 > 0, if n is sufficiently large, every subgraph of Q\u2099 with \u2265 \u03b5\u00b7n\u00b72\u207f\u207b\u00b9 edges contains C\u2086.\n\n**Answer:** NO\n\n**Counterexamples:**\n- \u03b5 = 1/4: Chung's 4-partition (1992)\n- \u03b5 = 1/3: Conder's 3-coloring (1993)\n\n**Generalized Conjecture (OPEN):** For C_{2k}, \u2203 c > 0 and a\u2096 < 1 such that \u2265 c\u00b7n^{a\u2096}\u00b72\u207f edges forces C_{2k}, with a\u2096 \u2192 0 as k \u2192 \u221e.",
+    "text": "Does every \u03b5-dense subgraph of the n-hypercube Q\u2099 contain C\u2086? Answer: NO. Chung (1992) and Brouwer-Dejter-Thomassen (1993) showed Q\u2099 can be 4-partitioned into C\u2086-free subgraphs.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Hypercube Definition:** Q\u2099 defined via XOR popcount - vertices in Fin(2\u207f) are adjacent iff their XOR has exactly one 1-bit (Hamming distance 1)\n\n2. **Cycle Definitions:**\n   - HasCycle G k: injective k-sequence with cyclic adjacency\n   - HasC4, HasC6, HasC2k: specific even cycle predicates\n\n3. **Density:**\n   - EpsilonDenseSubgraph: at least \u03b5\u00b7n\u00b72\u207f\u207b\u00b9 edges\n\n4. **Main Results:**\n   - ErdosConjecture: the (false) original conjecture\n   - erdos_conjecture_false: theorem showing it's false\n   - chung_1992 axiom: 4-partition exists\n   - conder_1993 axiom: 3-coloring exists\n\n5. **Why Axioms:** The partition constructions are combinatorial and not in Mathlib",
     "keyInsights": [
-      "**Hypercube Structure:** Qₙ vertices are binary strings, adjacent iff Hamming distance = 1",
-      "**Size:** |V| = 2ⁿ, |E| = n·2ⁿ⁻¹, degree = n (n-regular)",
-      "**Chung's Partition (1992):** Qₙ edges split into 4 C₆-free parts, each with ~1/4 of edges",
-      "**Conder's Improvement (1993):** Only 3 colors needed - even denser C₆-free subgraphs exist",
-      "**The Disproof:** ε = 1/4 (or 1/3) counterexamples refute the conjecture",
-      "**Open Generalization:** For C_{2k}, what density threshold aₖ forces the cycle?"
+      "**Hypercube Structure:** Q\u2099 vertices are binary strings, adjacent iff Hamming distance = 1",
+      "**Size:** |V| = 2\u207f, |E| = n\u00b72\u207f\u207b\u00b9, degree = n (n-regular)",
+      "**Chung's Partition (1992):** Q\u2099 edges split into 4 C\u2086-free parts, each with ~1/4 of edges",
+      "**Conder's Improvement (1993):** Only 3 colors needed - even denser C\u2086-free subgraphs exist",
+      "**The Disproof:** \u03b5 = 1/4 (or 1/3) counterexamples refute the conjecture",
+      "**Open Generalization:** For C_{2k}, what density threshold a\u2096 forces the cycle?"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
       "Graph theory (vertices, edges, colorings)",
-      "Extremal graph theory (Turán-type problems)"
+      "Extremal graph theory (Tur\u00e1n-type problems)"
     ]
   },
   "sections": [
     {
       "id": "hypercube",
       "title": "Hypercube Graph",
-      "summary": "Definition of Qₙ via XOR, vertices, edges, regularity",
+      "summary": "Definition of Q\u2099 via XOR, vertices, edges, regularity",
       "startLine": 36,
       "endLine": 68,
-      "mathContext": "Formal definition: Definition of Qₙ via XOR, vertices, edges, regularity"
+      "mathContext": "Formal definition: Definition of Q\u2099 via XOR, vertices, edges, regularity"
     },
     {
       "id": "cycles",
@@ -106,7 +106,7 @@
     },
     {
       "id": "conjecture",
-      "title": "Erdős's Conjecture (Disproved)",
+      "title": "Erd\u0151s's Conjecture (Disproved)",
       "summary": "ErdosConjecture, erdos_conjecture_false",
       "startLine": 119,
       "endLine": 141,
@@ -115,10 +115,10 @@
     {
       "id": "chung",
       "title": "Chung's Result (1992)",
-      "summary": "4-partition into C₆-free subgraphs",
+      "summary": "4-partition into C\u2086-free subgraphs",
       "startLine": 142,
       "endLine": 175,
-      "mathContext": "Mathematical content: 4-partition into C₆-free subgraphs"
+      "mathContext": "Mathematical content: 4-partition into C\u2086-free subgraphs"
     },
     {
       "id": "bdt",
@@ -131,10 +131,10 @@
     {
       "id": "conder",
       "title": "Conder's Improvement (1993)",
-      "summary": "3-coloring, ε = 1/3 counterexample",
+      "summary": "3-coloring, \u03b5 = 1/3 counterexample",
       "startLine": 199,
       "endLine": 232,
-      "mathContext": "Mathematical content: 3-coloring, ε = 1/3 counterexample"
+      "mathContext": "Mathematical content: 3-coloring, \u03b5 = 1/3 counterexample"
     },
     {
       "id": "generalized",
@@ -146,12 +146,12 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #666 asked whether ε-dense hypercube subgraphs must contain C₆. The answer is NO: Chung (1992) and Brouwer-Dejter-Thomassen (1993) independently showed Qₙ can be 4-partitioned into C₆-free subgraphs. Conder (1993) improved this to 3 colors.",
-    "implications": "The result shows the hypercube has surprising structure allowing sparse cycle-free subgraphs. This connects to Ramsey-Turán problems in hypercubes and extremal graph theory in structured graphs.",
+    "summary": "Erd\u0151s Problem #666 asked whether \u03b5-dense hypercube subgraphs must contain C\u2086. The answer is NO: Chung (1992) and Brouwer-Dejter-Thomassen (1993) independently showed Q\u2099 can be 4-partitioned into C\u2086-free subgraphs. Conder (1993) improved this to 3 colors.",
+    "implications": "The result shows the hypercube has surprising structure allowing sparse cycle-free subgraphs. This connects to Ramsey-Tur\u00e1n problems in hypercubes and extremal graph theory in structured graphs.",
     "openQuestions": [
-      "What is the minimum number of colors to avoid monochromatic C₆ in Qₙ?",
+      "What is the minimum number of colors to avoid monochromatic C\u2086 in Q\u2099?",
       "For C_{2k}, what density threshold forces the cycle?",
-      "Does aₖ → 0 as k → ∞ in the generalized conjecture?"
+      "Does a\u2096 \u2192 0 as k \u2192 \u221e in the generalized conjecture?"
     ]
   },
   "leanFile": {
@@ -176,17 +176,17 @@
     {
       "targetId": "erdos-1080",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: cycles, disproved, extremal-graph-theory, graph-theory"
+      "description": "Related Erd\u0151s problem sharing themes: cycles, disproved, extremal-graph-theory, graph-theory"
     },
     {
       "targetId": "erdos-1035",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: extremal-graph-theory, graph-theory, hypercube"
+      "description": "Related Erd\u0151s problem sharing themes: extremal-graph-theory, graph-theory, hypercube"
     },
     {
       "targetId": "erdos-147",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: disproved, extremal-graph-theory, graph-theory"
+      "description": "Related Erd\u0151s problem sharing themes: disproved, extremal-graph-theory, graph-theory"
     }
   ]
 }

--- a/src/data/proofs/erdos-669/meta.json
+++ b/src/data/proofs/erdos-669/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-669",
-  "title": "Erdős Problem #669: k-Point Lines and the Orchard Problem",
+  "title": "Erd\u0151s Problem #669: k-Point Lines and the Orchard Problem",
   "slug": "erdos-669",
-  "description": "Estimate f_k(n) (lines through exactly k points) and F_k(n) (lines through at least k points) for n-point sets in R². For k=3, the Orchard Problem: f_3(n) = F_3(n) = n²/6 - O(n) (Burr-Grünbaum-Sloane 1974). General k remains open.",
+  "description": "Estimate f_k(n) (lines through exactly k points) and F_k(n) (lines through at least k points) for n-point sets in R\u00b2. For k=3, the Orchard Problem: f_3(n) = F_3(n) = n\u00b2/6 - O(n) (Burr-Gr\u00fcnbaum-Sloane 1974). General k remains open.",
   "meta": {
-    "author": "Burr-Grünbaum-Sloane (1974, k=3 case)",
+    "author": "Burr-Gr\u00fcnbaum-Sloane (1974, k=3 case)",
     "sourceUrl": "https://erdosproblems.com/669",
     "date": "1974",
     "status": "axiomatized",
@@ -55,20 +55,20 @@
     ],
     "axiomCount": 1,
     "lineCount": 128,
-    "assumptions": "5 axioms: burr_grunbaum_sloane, k3_limit, trivial_upper_bound, and 2 more. See Lean source for complete statements."
+    "assumptions": "1 axiom: k3_limit. 0 sorries."
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #669** concerns the maximum number of lines determined by point configurations in the plane, measured by how many points lie on each line. Two functions are studied: f_k(n) counts lines through exactly k points, while F_k(n) counts lines through at least k points. The problem asks for the asymptotic behavior of both as n grows.\n\nThe most celebrated special case is the **Orchard Problem** (k=3), which goes back to Sylvester in the 19th century: how many 3-point lines can n points determine? Burr, Grünbaum, and Sloane resolved this in their 1974 paper, proving that both f_3(n) and F_3(n) equal n²/6 up to an O(n) error term. Their proof uses elegant constructions from finite projective planes.\n\nFor general k, a trivial upper bound comes from double counting: each line with ≥ k points accounts for at least C(k,2) point-pairs, and there are only C(n,2) pairs total. This gives F_k(n) ≤ C(n,2)/C(k,2), or asymptotically F_k(n)/n² ≤ 1/(k(k-1)). Whether this bound is tight for all k remains an open problem. The conjecture is that lim f_k(n)/n² = lim F_k(n)/n² = 1/(k(k-1)) for all k ≥ 2.",
+    "historicalContext": "**Erd\u0151s Problem #669** concerns the maximum number of lines determined by point configurations in the plane, measured by how many points lie on each line. Two functions are studied: f_k(n) counts lines through exactly k points, while F_k(n) counts lines through at least k points. The problem asks for the asymptotic behavior of both as n grows.\n\nThe most celebrated special case is the **Orchard Problem** (k=3), which goes back to Sylvester in the 19th century: how many 3-point lines can n points determine? Burr, Gr\u00fcnbaum, and Sloane resolved this in their 1974 paper, proving that both f_3(n) and F_3(n) equal n\u00b2/6 up to an O(n) error term. Their proof uses elegant constructions from finite projective planes.\n\nFor general k, a trivial upper bound comes from double counting: each line with \u2265 k points accounts for at least C(k,2) point-pairs, and there are only C(n,2) pairs total. This gives F_k(n) \u2264 C(n,2)/C(k,2), or asymptotically F_k(n)/n\u00b2 \u2264 1/(k(k-1)). Whether this bound is tight for all k remains an open problem. The conjecture is that lim f_k(n)/n\u00b2 = lim F_k(n)/n\u00b2 = 1/(k(k-1)) for all k \u2265 2.",
     "problemStatement": "**Problem Statement (Open)**\n\nLet $f_k(n)$ = maximum number of lines through exactly $k$ points of any $n$-point set in $\\mathbb{R}^2$.\nLet $F_k(n)$ = maximum number of lines through at least $k$ points.\n\n**Determine:** $\\lim_{n \\to \\infty} f_k(n)/n^2$ and $\\lim_{n \\to \\infty} F_k(n)/n^2$.\n\n**Known:**\n- $k=2$: $f_2(n) = F_2(n) = \\binom{n}{2}$\n- $k=3$ (Orchard Problem): $f_3(n) = F_3(n) = n^2/6 - O(n)$ (SOLVED, BGS 1974)\n- Upper bound: $F_k(n) \\leq \\binom{n}{2}/\\binom{k}{2}$\n\n**Conjecture:** Both limits equal $\\frac{1}{k(k-1)}$ for all $k \\geq 2$.",
-    "text": "Estimate f_k(n) (lines through exactly k points) and F_k(n) (lines through at least k points) for n-point sets in R². For k=3, the Orchard Problem: f_3(n) = F_3(n) = n²/6 - O(n) (Burr-Grünbaum-Sloane 1974). General k remains open.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Geometry:** Define Point (R²), Line (ax+by=c), OnLine, pointsOnLine.\n2. **Counting Functions:** Define f_k (exactly k) and F_k (at least k) using sSup.\n3. **Orchard Problem:** Axiomatize the BGS theorem for k=3 with explicit error bounds.\n4. **Limits:** State the k=3 asymptotic limit as 1/6.\n5. **Upper Bounds:** Axiomatize the trivial bound F_k ≤ C(n,2)/C(k,2).\n6. **Conjecture:** Define the 1/(k(k-1)) conjecture; prove it holds for k=3.\n7. **Summary:** The k=3 case is fully proved from axioms.",
+    "text": "Estimate f_k(n) (lines through exactly k points) and F_k(n) (lines through at least k points) for n-point sets in R\u00b2. For k=3, the Orchard Problem: f_3(n) = F_3(n) = n\u00b2/6 - O(n) (Burr-Gr\u00fcnbaum-Sloane 1974). General k remains open.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Geometry:** Define Point (R\u00b2), Line (ax+by=c), OnLine, pointsOnLine.\n2. **Counting Functions:** Define f_k (exactly k) and F_k (at least k) using sSup.\n3. **Orchard Problem:** Axiomatize the BGS theorem for k=3 with explicit error bounds.\n4. **Limits:** State the k=3 asymptotic limit as 1/6.\n5. **Upper Bounds:** Axiomatize the trivial bound F_k \u2264 C(n,2)/C(k,2).\n6. **Conjecture:** Define the 1/(k(k-1)) conjecture; prove it holds for k=3.\n7. **Summary:** The k=3 case is fully proved from axioms.",
     "keyInsights": [
       "**The Orchard Problem:** Sylvester's classical question of how many 3-point lines n points can determine, solved by BGS (1974).",
       "**Two Functions:** f_k counts 'exactly k' lines while F_k counts 'at least k' - they agree asymptotically for k=3.",
-      "**Double Counting Bound:** F_k(n) ≤ C(n,2)/C(k,2) from the pigeonhole principle on point-pairs.",
-      "**k=3 Limit:** Both f_3(n)/n² and F_3(n)/n² tend to 1/6 as n → ∞.",
+      "**Double Counting Bound:** F_k(n) \u2264 C(n,2)/C(k,2) from the pigeonhole principle on point-pairs.",
+      "**k=3 Limit:** Both f_3(n)/n\u00b2 and F_3(n)/n\u00b2 tend to 1/6 as n \u2192 \u221e.",
       "**Projective Plane Constructions:** Optimal configurations for k=3 come from points of PG(2,q).",
-      "**General k Open:** Whether the limit equals 1/(k(k-1)) for k ≥ 4 remains one of the main open questions in discrete geometry."
+      "**General k Open:** Whether the limit equals 1/(k(k-1)) for k \u2265 4 remains one of the main open questions in discrete geometry."
     ],
     "prerequisites": [
       "Combinatorics (counting, extremal problems)",
@@ -120,11 +120,11 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #669 asks for the asymptotic behavior of f_k(n) (exactly k-point lines) and F_k(n) (at least k-point lines). The k=3 case is the famous Orchard Problem, solved by Burr-Grünbaum-Sloane (1974): both functions equal n²/6 - O(n). The general conjecture is that both limits equal 1/(k(k-1)).",
-    "implications": "The Orchard Problem connects to fundamental questions in discrete geometry and combinatorics. Optimal configurations relate to finite projective planes, and the counting functions connect to the Szemerédi-Trotter incidence theorem.",
+    "summary": "Erd\u0151s Problem #669 asks for the asymptotic behavior of f_k(n) (exactly k-point lines) and F_k(n) (at least k-point lines). The k=3 case is the famous Orchard Problem, solved by Burr-Gr\u00fcnbaum-Sloane (1974): both functions equal n\u00b2/6 - O(n). The general conjecture is that both limits equal 1/(k(k-1)).",
+    "implications": "The Orchard Problem connects to fundamental questions in discrete geometry and combinatorics. Optimal configurations relate to finite projective planes, and the counting functions connect to the Szemer\u00e9di-Trotter incidence theorem.",
     "openQuestions": [
-      "Is lim f_k(n)/n² = 1/(k(k-1)) for all k ≥ 4?",
-      "Is lim F_k(n)/n² = 1/(k(k-1)) for all k ≥ 4?",
+      "Is lim f_k(n)/n\u00b2 = 1/(k(k-1)) for all k \u2265 4?",
+      "Is lim F_k(n)/n\u00b2 = 1/(k(k-1)) for all k \u2265 4?",
       "What point configurations achieve the maximum for general k?",
       "How does the problem generalize to higher dimensions?"
     ]
@@ -153,7 +153,7 @@
   "references": [
     {
       "key": "BGS74",
-      "citation": "Burr, S.A., Grünbaum, B., Sloane, N.J.A., The orchard problem, Geom. Dedicata 2 (1974), 397-424",
+      "citation": "Burr, S.A., Gr\u00fcnbaum, B., Sloane, N.J.A., The orchard problem, Geom. Dedicata 2 (1974), 397-424",
       "type": "paper"
     }
   ],
@@ -161,12 +161,12 @@
     {
       "targetId": "erdos-588",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: discrete-geometry, incidences, point-line"
+      "description": "Related Erd\u0151s problem sharing themes: discrete-geometry, incidences, point-line"
     },
     {
       "targetId": "erdos-104",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: discrete-geometry, incidences"
+      "description": "Related Erd\u0151s problem sharing themes: discrete-geometry, incidences"
     }
   ]
 }

--- a/src/data/proofs/erdos-676/meta.json
+++ b/src/data/proofs/erdos-676/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-676",
-  "title": "Erdős Problem #676: Representations ap² + b with p Prime",
+  "title": "Erd\u0151s Problem #676: Representations ap\u00b2 + b with p Prime",
   "slug": "erdos-676",
-  "description": "Is every sufficiently large integer expressible as ap² + b for some prime p, integer a >= 1, and 0 <= b < p?",
+  "description": "Is every sufficiently large integer expressible as ap\u00b2 + b for some prime p, integer a >= 1, and 0 <= b < p?",
   "meta": {
-    "author": "Erdős",
+    "author": "Erd\u0151s",
     "sourceUrl": "https://erdosproblems.com/676",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos676Problem.lean",
@@ -59,12 +59,12 @@
     ],
     "axiomCount": 1,
     "lineCount": 225,
-    "assumptions": "5 axioms: brun_selberg_bound, density_one, selfridge_wagstaff_conjecture, and 2 more. See Lean source for complete statements."
+    "assumptions": "1 axiom: density_one. 0 sorries."
   },
   "overview": {
     "historicalContext": "Erdos posed this problem in 1979 [Er79], [Er79d]. The question asks whether every sufficiently large integer can be written as ap^2 + b where p is prime, a >= 1, and 0 <= b < p.\n\nThe sieve of Eratosthenes shows that 'almost all' integers have this representation, and the Brun-Selberg sieve gives that exceptions in [1,x] are at most x/(log x)^c for some c > 0.\n\nErdos himself believed it 'rather unlikely' that all large integers would satisfy this condition. Selfridge and Wagstaff's computer searches (without the prime restriction) suggested infinitely many exceptions even in the general case.\n\nRelated questions include the behavior of the minimal coefficient c_n and whether c_n < n^{o(1)}.",
     "problemStatement": "**Problem Statement (OPEN)**\n\nIs every sufficiently large integer expressible as ap^2 + b for some prime p, integer a >= 1, and 0 <= b < p?\n\nEquivalently: Are there only finitely many integers that cannot be represented in this form?\n\n**Background:**\n- The sieve of Eratosthenes shows 'almost all' integers are representable\n- Brun-Selberg sieve: exceptions in [1,x] are << x/(log x)^c\n- Erdos believed positive answer 'rather unlikely'",
-    "text": "Is every sufficiently large integer expressible as ap² + b for some prime p, integer a >= 1, and 0 <= b < p?",
+    "text": "Is every sufficiently large integer expressible as ap\u00b2 + b for some prime p, integer a >= 1, and 0 <= b < p?",
     "proofStrategy": "**Formalization Approach**\n\n1. **Representation:** Define HasRepresentation(n, a, p, b) as n = a*p^2 + b with p prime, a >= 1, b < p\n\n2. **Conjecture:** ErdosConjecture676 states exists N such that all n >= N are representable\n\n3. **Density Results:** Axiomatize Brun-Selberg bound and density 1\n\n4. **Examples:** Prove specific numbers are representable\n\n5. **Variants:** Formalize the general case and minimal coefficient questions",
     "keyInsights": [
       "**Density 1:** Almost all integers are representable - exceptions are very sparse",
@@ -176,17 +176,17 @@
     {
       "targetId": "erdos-369",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: number-theory, open, sieve-methods"
+      "description": "Related Erd\u0151s problem sharing themes: number-theory, open, sieve-methods"
     },
     {
       "targetId": "erdos-976",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: number-theory, open, sieve-methods"
+      "description": "Related Erd\u0151s problem sharing themes: number-theory, open, sieve-methods"
     },
     {
       "targetId": "erdos-1053",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: number-theory, open"
+      "description": "Related Erd\u0151s problem sharing themes: number-theory, open"
     }
   ]
 }

--- a/src/data/proofs/erdos-692/meta.json
+++ b/src/data/proofs/erdos-692/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-692",
-  "title": "Erdős Problem #692: Unimodularity of Divisor Density",
+  "title": "Erd\u0151s Problem #692: Unimodularity of Divisor Density",
   "slug": "erdos-692",
-  "description": "Let δ₁(n,m) be the density of integers with exactly one divisor in (n,m). Is δ₁(n,m) unimodal for m > n+1? DISPROVED by Cambie (2025) with explicit counterexamples showing superpolynomially many local maxima.",
+  "description": "Let \u03b4\u2081(n,m) be the density of integers with exactly one divisor in (n,m). Is \u03b4\u2081(n,m) unimodal for m > n+1? DISPROVED by Cambie (2025) with explicit counterexamples showing superpolynomially many local maxima.",
   "meta": {
-    "author": "Erdős, Ford, Cambie",
+    "author": "Erd\u0151s, Ford, Cambie",
     "sourceUrl": "https://erdosproblems.com/692",
     "date": "2025",
     "status": "axiomatized",
@@ -44,10 +44,10 @@
     "originalContributions": [
       "divisorsInInterval: count divisors in (n,m)",
       "countWithOneDivisor: count integers with exactly one divisor",
-      "delta1: density function δ₁(n,m) via limsup",
+      "delta1: density function \u03b4\u2081(n,m) via limsup",
       "IsUnimodal: definition of unimodal sequence",
-      "erdosUnimodalityQuestion: Erdős's original question",
-      "erdos_delta1_bound axiom: Erdős's upper bound",
+      "erdosUnimodalityQuestion: Erd\u0151s's original question",
+      "erdos_delta1_bound axiom: Erd\u0151s's upper bound",
       "ford_2008_bounds axiom: Ford's sharper bounds",
       "cambie_n3_values axiom: counterexample values",
       "cambie_n3_not_unimodal axiom: disproof for n=3",
@@ -56,19 +56,19 @@
     ],
     "axiomCount": 3,
     "lineCount": 281,
-    "assumptions": "7 axioms: erdos_delta1_bound, ford_2008_bounds, cambie_n3_values, and 4 more. See Lean source for complete statements."
+    "assumptions": "3 axioms: erdos_delta1_bound, cambie_disproves_unimodality, cambie_n3_not_unimodal. 0 sorries."
   },
   "overview": {
-    "historicalContext": "This problem concerns the density $\\delta_1(n,m)$ of integers with exactly one divisor in the open interval $(n,m)$, and whether this density is unimodal as a function of $m$.\n\n**Erdős (1986):** Posed the unimodality question at the Oberwolfach Number Theory conference. He proved the quantitative bound $\\delta_1(n,m) \\leq 1/(\\log n)^c$ for some $c > 0$, showing the density decays as $n$ grows. The bound follows from the Hardy-Ramanujan observation that a typical integer $k$ has about $\\log \\log k$ prime factors, so its divisors are spread out and having exactly one in a short interval requires special multiplicative structure.\n\n**Ford (2008):** Kevin Ford's landmark paper 'The distribution of integers with a divisor in a given interval' (Annals of Mathematics, 2008) gave precise asymptotics for the related function $H(x,y,z) = \\#\\{n \\leq x : \\exists d \\mid n,\\; y < d < z\\}$. Ford proved $H(x,y,z) \\asymp x \\cdot \\delta(u)$ where $u = \\log z / \\log y$ and $\\delta(u)$ involves the Dickman function $\\rho(u)$. This resolved Problem #446 and provided the foundational framework for studying $\\delta_1$.\n\n**Cambie (2025):** Stijn Cambie disproved unimodality with an elegant computational counterexample. For $n = 3$, he computed $\\delta_1(3,6) \\approx 0.35$, $\\delta_1(3,7) \\approx 0.33$, $\\delta_1(3,8) \\approx 0.3619$ via inclusion-exclusion over divisibility conditions, showing a decrease-then-increase pattern that violates any unimodal shape. He further proved the dramatically stronger result that the number of local maxima grows superpolynomially in $M$, driven by the prime counting function $\\pi(m) - \\pi(n) \\sim m/\\log m$.",
-    "problemStatement": "**Problem Statement (Disproved)**\n\nLet $\\delta_1(n,m)$ be the density of integers with exactly one divisor in $(n,m)$.\n\n**Original Question (Erdős 1986):**\nIs $\\delta_1(n,m)$ unimodal for $m > n + 1$? That is, does it increase then decrease?\n\n**Answer: NO**\n\n**Cambie's Counterexample (2025):**\nFor $n = 3$:\n- $\\delta_1(3,6) = 0.35$\n- $\\delta_1(3,7) \\approx 0.33$\n- $\\delta_1(3,8) \\approx 0.3619$\n\nThe sequence **decreases then increases**, refuting unimodality.\n\n**Stronger Result:** The sequence has superpolynomially many local maxima.",
-    "text": "Let δ₁(n,m) be the density of integers with exactly one divisor in (n,m). Is δ₁(n,m) unimodal for m > n+1? DISPROVED by Cambie (2025) with explicit counterexamples showing superpolynomially many local maxima.",
-    "proofStrategy": "**Formalization Architecture**\n\n1. **Core Definitions (lines 49–79):** `divisorsInInterval` counts $|\\mathcal{D}(k) \\cap (n,m)|$ via `Finset.filter` on `Nat.divisors`. `countWithOneDivisor` counts integers $k \\leq N$ with exactly one such divisor. `delta1` defines $\\delta_1(n,m) = \\limsup_{N \\to \\infty} \\frac{\\text{count}(N,n,m)}{N}$ using `Filter.limsup` over `Filter.atTop`.\n\n2. **Historical Bounds (lines 87–111):** Erdős's bound $\\delta_1(n,m) \\leq 1/(\\log n)^c$ and Ford's 2008 sharper bounds are axiomatized, encoding the quantitative decay.\n\n3. **Unimodality Framework (lines 119–134):** `IsUnimodal` formalizes the definition (non-decreasing to peak, non-increasing after). `erdosUnimodalityQuestion` asks whether $\\delta_1(n,\\cdot)$ satisfies this.\n\n4. **Cambie's Disproof (lines 142–175):** Axiomatized counterexample values for $n=3$, the negation of unimodality for $n=2,3$, and the universal negation.\n\n5. **Superpolynomial Oscillation (lines 187–213):** `SuperpolynomialGrowth` captures $g(n) = \\omega(n^k)$ for all $k$, and `cambie_superpolynomial_maxima` asserts this for the local maxima count.\n\n6. **Synthesis (lines 277–295):** `erdos_692` combines the bound with the disproof via `constructor`.",
+    "historicalContext": "This problem concerns the density $\\delta_1(n,m)$ of integers with exactly one divisor in the open interval $(n,m)$, and whether this density is unimodal as a function of $m$.\n\n**Erd\u0151s (1986):** Posed the unimodality question at the Oberwolfach Number Theory conference. He proved the quantitative bound $\\delta_1(n,m) \\leq 1/(\\log n)^c$ for some $c > 0$, showing the density decays as $n$ grows. The bound follows from the Hardy-Ramanujan observation that a typical integer $k$ has about $\\log \\log k$ prime factors, so its divisors are spread out and having exactly one in a short interval requires special multiplicative structure.\n\n**Ford (2008):** Kevin Ford's landmark paper 'The distribution of integers with a divisor in a given interval' (Annals of Mathematics, 2008) gave precise asymptotics for the related function $H(x,y,z) = \\#\\{n \\leq x : \\exists d \\mid n,\\; y < d < z\\}$. Ford proved $H(x,y,z) \\asymp x \\cdot \\delta(u)$ where $u = \\log z / \\log y$ and $\\delta(u)$ involves the Dickman function $\\rho(u)$. This resolved Problem #446 and provided the foundational framework for studying $\\delta_1$.\n\n**Cambie (2025):** Stijn Cambie disproved unimodality with an elegant computational counterexample. For $n = 3$, he computed $\\delta_1(3,6) \\approx 0.35$, $\\delta_1(3,7) \\approx 0.33$, $\\delta_1(3,8) \\approx 0.3619$ via inclusion-exclusion over divisibility conditions, showing a decrease-then-increase pattern that violates any unimodal shape. He further proved the dramatically stronger result that the number of local maxima grows superpolynomially in $M$, driven by the prime counting function $\\pi(m) - \\pi(n) \\sim m/\\log m$.",
+    "problemStatement": "**Problem Statement (Disproved)**\n\nLet $\\delta_1(n,m)$ be the density of integers with exactly one divisor in $(n,m)$.\n\n**Original Question (Erd\u0151s 1986):**\nIs $\\delta_1(n,m)$ unimodal for $m > n + 1$? That is, does it increase then decrease?\n\n**Answer: NO**\n\n**Cambie's Counterexample (2025):**\nFor $n = 3$:\n- $\\delta_1(3,6) = 0.35$\n- $\\delta_1(3,7) \\approx 0.33$\n- $\\delta_1(3,8) \\approx 0.3619$\n\nThe sequence **decreases then increases**, refuting unimodality.\n\n**Stronger Result:** The sequence has superpolynomially many local maxima.",
+    "text": "Let \u03b4\u2081(n,m) be the density of integers with exactly one divisor in (n,m). Is \u03b4\u2081(n,m) unimodal for m > n+1? DISPROVED by Cambie (2025) with explicit counterexamples showing superpolynomially many local maxima.",
+    "proofStrategy": "**Formalization Architecture**\n\n1. **Core Definitions (lines 49\u201379):** `divisorsInInterval` counts $|\\mathcal{D}(k) \\cap (n,m)|$ via `Finset.filter` on `Nat.divisors`. `countWithOneDivisor` counts integers $k \\leq N$ with exactly one such divisor. `delta1` defines $\\delta_1(n,m) = \\limsup_{N \\to \\infty} \\frac{\\text{count}(N,n,m)}{N}$ using `Filter.limsup` over `Filter.atTop`.\n\n2. **Historical Bounds (lines 87\u2013111):** Erd\u0151s's bound $\\delta_1(n,m) \\leq 1/(\\log n)^c$ and Ford's 2008 sharper bounds are axiomatized, encoding the quantitative decay.\n\n3. **Unimodality Framework (lines 119\u2013134):** `IsUnimodal` formalizes the definition (non-decreasing to peak, non-increasing after). `erdosUnimodalityQuestion` asks whether $\\delta_1(n,\\cdot)$ satisfies this.\n\n4. **Cambie's Disproof (lines 142\u2013175):** Axiomatized counterexample values for $n=3$, the negation of unimodality for $n=2,3$, and the universal negation.\n\n5. **Superpolynomial Oscillation (lines 187\u2013213):** `SuperpolynomialGrowth` captures $g(n) = \\omega(n^k)$ for all $k$, and `cambie_superpolynomial_maxima` asserts this for the local maxima count.\n\n6. **Synthesis (lines 277\u2013295):** `erdos_692` combines the bound with the disproof via `constructor`.",
     "keyInsights": [
       "**Minimal Counterexample at $n = 3$:** The density values $\\delta_1(3,6) > \\delta_1(3,7) < \\delta_1(3,8)$ show non-monotonicity at the smallest non-trivial $n$, computed via inclusion-exclusion over divisibility by 4, 5, and 20",
-      "**Prime Boundary Oscillation Mechanism:** When $m$ passes through a prime $p$, multiples of $p$ gain a new divisor in $(n,m)$: those with zero divisors before contribute positively to $\\delta_1$, while those with exactly one contribute negatively — the net effect oscillates with local prime structure",
-      "**Superpolynomial Growth of Local Maxima:** Not just occasional non-monotonicity — the count of local maxima of $\\delta_1(n,\\cdot)$ up to $M$ grows faster than any polynomial in $M$, driven by $\\pi(M) \\sim M/\\log M$",
+      "**Prime Boundary Oscillation Mechanism:** When $m$ passes through a prime $p$, multiples of $p$ gain a new divisor in $(n,m)$: those with zero divisors before contribute positively to $\\delta_1$, while those with exactly one contribute negatively \u2014 the net effect oscillates with local prime structure",
+      "**Superpolynomial Growth of Local Maxima:** Not just occasional non-monotonicity \u2014 the count of local maxima of $\\delta_1(n,\\cdot)$ up to $M$ grows faster than any polynomial in $M$, driven by $\\pi(M) \\sim M/\\log M$",
       "**Ford's Framework Underpins the Analysis:** Ford's 2008 Annals result $H(x,y,z) \\asymp x \\cdot \\delta(\\log z/\\log y)$ via the Dickman function gives the 'at least one divisor' density; the 'exactly one' variant $\\delta_1$ oscillates more due to inclusion-exclusion cancellation",
-      "**39-Year Resolution (1986–2025):** Erdős's Oberwolfach question survived nearly four decades, suggesting the community expected unimodality to hold — Cambie's computational approach overturned this intuition"
+      "**39-Year Resolution (1986\u20132025):** Erd\u0151s's Oberwolfach question survived nearly four decades, suggesting the community expected unimodality to hold \u2014 Cambie's computational approach overturned this intuition"
     ],
     "prerequisites": [
       "Divisor function and divisor distribution in intervals",
@@ -87,7 +87,7 @@
     {
       "targetId": "erdos-690",
       "relationship": "parallel",
-      "description": "Parallel unimodality question for $k$-th prime factor density $d_k(p)$, also resolved by Cambie (2025): YES for $k \\leq 3$, NO for $4 \\leq k \\leq 20$ — contrasting answer to #692's universal NO"
+      "description": "Parallel unimodality question for $k$-th prime factor density $d_k(p)$, also resolved by Cambie (2025): YES for $k \\leq 3$, NO for $4 \\leq k \\leq 20$ \u2014 contrasting answer to #692's universal NO"
     },
     {
       "targetId": "erdos-693",
@@ -120,7 +120,7 @@
       "summary": "Defines `divisorsInInterval(k, n, m) = |\\mathcal{D}(k) \\cap (n,m)|$ via `Finset.filter` and `hasExactlyOneDivisor` for the exactness predicate",
       "startLine": 49,
       "endLine": 62,
-      "mathContext": "$d_k(n,m) = |\\\\{d : d \\\\mid k,; n < d < m\\\\}|$ — count of divisors of $k$ in the open interval $(n,m)$."
+      "mathContext": "$d_k(n,m) = |\\\\{d : d \\\\mid k,; n < d < m\\\\}|$ \u2014 count of divisors of $k$ in the open interval $(n,m)$."
     },
     {
       "id": "counting-density",
@@ -128,12 +128,12 @@
       "summary": "Defines `countWithOneDivisor(N, n, m)` counting integers $k \\leq N$ with one divisor in $(n,m)$, and `delta1(n,m) = \\limsup_{N \\to \\infty} \\text{count}/N$ via `Filter.limsup`",
       "startLine": 63,
       "endLine": 79,
-      "mathContext": "$\\\\delta_1(n,m) = \\\\lim_{N \\\\to \\\\infty} \\\\frac{1}{N} |\\\\{k \\\\leq N : d_k(n,m) = 1\\\\}|$ — density of integers with exactly one divisor in $(n,m)$."
+      "mathContext": "$\\\\delta_1(n,m) = \\\\lim_{N \\\\to \\\\infty} \\\\frac{1}{N} |\\\\{k \\\\leq N : d_k(n,m) = 1\\\\}|$ \u2014 density of integers with exactly one divisor in $(n,m)$."
     },
     {
       "id": "erdos-bound",
-      "title": "Erdős's Upper Bound",
-      "summary": "Axiomatizes $\\forall n \\geq 2,\\; \\exists c > 0,\\; \\delta_1(n,m) \\leq 1/(\\log n)^c$ — Erdős's 1986 quantitative decay bound, uniform in $m$",
+      "title": "Erd\u0151s's Upper Bound",
+      "summary": "Axiomatizes $\\forall n \\geq 2,\\; \\exists c > 0,\\; \\delta_1(n,m) \\leq 1/(\\log n)^c$ \u2014 Erd\u0151s's 1986 quantitative decay bound, uniform in $m$",
       "startLine": 87,
       "endLine": 94,
       "mathContext": "Erdos: $\\\\forall n \\\\geq 2$, $\\\\exists c > 0$: $\\\\delta_1(n,m) \\\\leq 1 - c$ for all $m > n+1$. Not all integers have a divisor in $(n,m)$."
@@ -141,14 +141,14 @@
     {
       "id": "ford-bounds",
       "title": "Ford's Sharper Bounds (2008)",
-      "summary": "Axiomatizes Ford's regime-dependent bounds on $\\delta_1(n,m)$ from his Annals paper, refining Erdős's estimate using $H(x,y,z) \\asymp x \\cdot \\delta(\\log z / \\log y)$",
+      "summary": "Axiomatizes Ford's regime-dependent bounds on $\\delta_1(n,m)$ from his Annals paper, refining Erd\u0151s's estimate using $H(x,y,z) \\asymp x \\cdot \\delta(\\log z / \\log y)$",
       "startLine": 102,
       "endLine": 111,
       "mathContext": "Ford: regime-dependent bounds on $\\\\delta_1(n,m)$ from his work on the distribution of divisors."
     },
     {
       "id": "unimodality-definition",
-      "title": "Unimodality and Erdős's Question",
+      "title": "Unimodality and Erd\u0151s's Question",
       "summary": "Defines `IsUnimodal f start` (non-decreasing to peak, non-increasing after) and `erdosUnimodalityQuestion n`: is $m \\mapsto \\delta_1(n,m)$ unimodal for $m > n+1$?",
       "startLine": 119,
       "endLine": 134,
@@ -157,7 +157,7 @@
     {
       "id": "cambie-counterexample",
       "title": "Cambie's Counterexample Values ($n = 3$)",
-      "summary": "Axiomatizes $\\delta_1(3,6) > 0.34$, $\\delta_1(3,7) < 0.34$, $\\delta_1(3,8) > 0.36$ — the decrease-then-increase pattern computed via inclusion-exclusion over divisibility by 4, 5, and 20",
+      "summary": "Axiomatizes $\\delta_1(3,6) > 0.34$, $\\delta_1(3,7) < 0.34$, $\\delta_1(3,8) > 0.36$ \u2014 the decrease-then-increase pattern computed via inclusion-exclusion over divisibility by 4, 5, and 20",
       "startLine": 142,
       "endLine": 158,
       "mathContext": "Cambie (2025): $\\\\delta_1(3,6) > 0.34 > \\\\delta_1(3,7) < 0.34 < \\\\delta_1(3,8)$. Non-monotone! Disproves unimodality for $n=3$."
@@ -181,7 +181,7 @@
     {
       "id": "superpolynomial-maxima",
       "title": "Superpolynomially Many Local Maxima",
-      "summary": "Axiomatizes that for fixed $n \\geq 2$, the count of local maxima of $\\delta_1(n,\\cdot)$ up to $M$ grows superpolynomially — driven by $\\pi(M) \\sim M/\\log M$",
+      "summary": "Axiomatizes that for fixed $n \\geq 2$, the count of local maxima of $\\delta_1(n,\\cdot)$ up to $M$ grows superpolynomially \u2014 driven by $\\pi(M) \\sim M/\\log M$",
       "startLine": 209,
       "endLine": 213,
       "mathContext": "For fixed $n \\\\geq 2$: the number of local maxima of $m \\\\mapsto \\\\delta_1(n,m)$ for $m \\\\leq M$ grows super-polynomially in $M$. Wild oscillation."
@@ -204,13 +204,13 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #692 is DISPROVED. The density $\\delta_1(n,m)$ of integers with exactly one divisor in $(n,m)$ is NOT unimodal in $m$. Cambie (2025) provided explicit counterexamples for $n = 2, 3$ and proved the dramatically stronger result that the number of local maxima grows superpolynomially. The formalization encodes Erdős's 1986 bound, Ford's 2008 refinements, and Cambie's complete resolution, combining them in the summary theorem `erdos_692`.",
-    "implications": "**Theoretical Significance**: **Number-Theoretic Significance**\n\n1. **Divisor Distribution Complexity:** The oscillatory behavior of $\\delta_1$ reveals that divisor counts in intervals have far more intricate structure than the smooth decay suggested by Erdős's bound\n\n**2. Prime Boundary Effects:** Each prime $p$ entering the interval $(n,m)$ creates a discontinuity in $\\delta_1$, with the net effect depending on local divisor statistics — a phenomenon invisible to averaged bounds\n\n3. **Resolution of Problem #446 Context:** Ford's Annals framework for the 'at least one divisor' function $H(x,y,z)$ was necessary but insufficient — the 'exactly one' restriction via inclusion-exclusion introduces additional oscillation\n\n4. **Parallel to Problem #690:** Cambie's simultaneous resolution of the $k$-th prime factor density unimodality question (YES for $k \\leq 3$, NO for $k \\geq 4$) shows both expected and unexpected behavior can coexist in closely related problems.",
+    "summary": "Erd\u0151s Problem #692 is DISPROVED. The density $\\delta_1(n,m)$ of integers with exactly one divisor in $(n,m)$ is NOT unimodal in $m$. Cambie (2025) provided explicit counterexamples for $n = 2, 3$ and proved the dramatically stronger result that the number of local maxima grows superpolynomially. The formalization encodes Erd\u0151s's 1986 bound, Ford's 2008 refinements, and Cambie's complete resolution, combining them in the summary theorem `erdos_692`.",
+    "implications": "**Theoretical Significance**: **Number-Theoretic Significance**\n\n1. **Divisor Distribution Complexity:** The oscillatory behavior of $\\delta_1$ reveals that divisor counts in intervals have far more intricate structure than the smooth decay suggested by Erd\u0151s's bound\n\n**2. Prime Boundary Effects:** Each prime $p$ entering the interval $(n,m)$ creates a discontinuity in $\\delta_1$, with the net effect depending on local divisor statistics \u2014 a phenomenon invisible to averaged bounds\n\n3. **Resolution of Problem #446 Context:** Ford's Annals framework for the 'at least one divisor' function $H(x,y,z)$ was necessary but insufficient \u2014 the 'exactly one' restriction via inclusion-exclusion introduces additional oscillation\n\n4. **Parallel to Problem #690:** Cambie's simultaneous resolution of the $k$-th prime factor density unimodality question (YES for $k \\leq 3$, NO for $k \\geq 4$) shows both expected and unexpected behavior can coexist in closely related problems.",
     "openQuestions": [
-      "What is the exact growth rate of the number of local maxima of δ₁(n,·) up to M — is it comparable to π(M)?",
-      "For which n (if any) does δ₁(n,m) exhibit 'approximate' unimodality in the sense that oscillations become negligible relative to the main trend?",
+      "What is the exact growth rate of the number of local maxima of \u03b4\u2081(n,\u00b7) up to M \u2014 is it comparable to \u03c0(M)?",
+      "For which n (if any) does \u03b4\u2081(n,m) exhibit 'approximate' unimodality in the sense that oscillations become negligible relative to the main trend?",
       "Can the prime boundary oscillation mechanism be made quantitative enough to predict the exact locations of local maxima?",
-      "What is the analog of Cambie's result for the 'at least k divisors' density δ_k(n,m) with k ≥ 2?"
+      "What is the analog of Cambie's result for the 'at least k divisors' density \u03b4_k(n,m) with k \u2265 2?"
     ]
   },
   "leanFile": {

--- a/src/data/proofs/erdos-695/meta.json
+++ b/src/data/proofs/erdos-695/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-695",
-  "title": "Erdős Problem #695: Prime Chain Growth",
+  "title": "Erd\u0151s Problem #695: Prime Chain Growth",
   "slug": "erdos-695",
-  "description": "Let p₁ < p₂ < ⋯ be primes with p_{i+1} ≡ 1 (mod p_i). Is lim p_k^{1/k} = ∞? Can p_k ≤ exp(k(log k)^{1+o(1)})?",
+  "description": "Let p\u2081 < p\u2082 < \u22ef be primes with p_{i+1} \u2261 1 (mod p_i). Is lim p_k^{1/k} = \u221e? Can p_k \u2264 exp(k(log k)^{1+o(1)})?",
   "meta": {
-    "author": "Erdős",
+    "author": "Erd\u0151s",
     "sourceUrl": "https://erdosproblems.com/695",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos695Problem.lean",
@@ -45,18 +45,18 @@
       }
     ],
     "originalContributions": [
-      "IsPrimeChain definition: strictly increasing primes with p_{i+1} ≡ 1 (mod p_i)",
+      "IsPrimeChain definition: strictly increasing primes with p_{i+1} \u2261 1 (mod p_i)",
       "ChainDivisibility definition: p_i | (p_{i+1} - 1)",
       "chain_equiv theorem: equivalence of definitions",
       "kthRoot definition: p_k^{1/k}",
-      "Question1 definition: does p_k^{1/k} → ∞?",
-      "Question2 definition: can p_k ≤ exp(k(log k)^{1+o(1)})?",
+      "Question1 definition: does p_k^{1/k} \u2192 \u221e?",
+      "Question2 definition: can p_k \u2264 exp(k(log k)^{1+o(1)})?",
       "linnik_bound axiom: least prime in AP bound",
       "greedy_doubly_exponential axiom: greedy gives exp(exp(O(k)))",
       "small_prime_conjecture axiom: conjectured polynomial bound",
       "IsCunninghamChainFirst definition: 2p+1 chains",
       "fkl_analysis axiom: Ford-Konyagin-Luca results",
-      "exponential_lower_bound axiom: p_k ≥ c^k"
+      "exponential_lower_bound axiom: p_k \u2265 c^k"
     ],
     "axiomCount": 1,
     "prerequisites": [
@@ -67,17 +67,17 @@
       "Lean 4 / Mathlib (Filter.Tendsto, Asymptotics.IsLittleO, Nat.Prime)"
     ],
     "lineCount": 251,
-    "assumptions": "5 axioms (linnik_bound, greedy_chain_exists, greedy_doubly_exponential, small_prime_conjecture, fkl_analysis) and 3 sorries. exponential_lower_bound proved from chain_step_ge (p₀+1 even for odd p₀)."
+    "assumptions": "1 axiom: small_prime_conjecture. 3 sorries."
   },
   "overview": {
-    "historicalContext": "Erdős posed this problem in 1979 [Er79e]. Prime chains arise from the multiplicative structure of cyclic groups: if p_{i+1} ≡ 1 (mod p_i), then Z/p_{i+1}Z contains a cyclic subgroup of order p_i.\n\nFord, Konyagin, and Luca [FKL10] conducted an extensive study of prime chain growth, establishing various bounds. The problem connects to Linnik's theorem on the least prime in arithmetic progressions.\n\nRelated: OEIS A061092, Cunningham chains. Cunningham chains, studied by A.J.C. Cunningham in 1881, are special prime chains of the form p, 2p+1, 4p+3, ... where each term is 2·(previous term)+1; these satisfy the divisibility condition and are the subject of longstanding conjectures about their unbounded length. Linnik's theorem (1944) guarantees the existence of primes in arithmetic progressions, and its quantitative form (Linnik's constant L, conjectured to equal 2) directly controls the greedy construction of prime chains.",
+    "historicalContext": "Erd\u0151s posed this problem in 1979 [Er79e]. Prime chains arise from the multiplicative structure of cyclic groups: if p_{i+1} \u2261 1 (mod p_i), then Z/p_{i+1}Z contains a cyclic subgroup of order p_i.\n\nFord, Konyagin, and Luca [FKL10] conducted an extensive study of prime chain growth, establishing various bounds. The problem connects to Linnik's theorem on the least prime in arithmetic progressions.\n\nRelated: OEIS A061092, Cunningham chains. Cunningham chains, studied by A.J.C. Cunningham in 1881, are special prime chains of the form p, 2p+1, 4p+3, ... where each term is 2\u00b7(previous term)+1; these satisfy the divisibility condition and are the subject of longstanding conjectures about their unbounded length. Linnik's theorem (1944) guarantees the existence of primes in arithmetic progressions, and its quantitative form (Linnik's constant L, conjectured to equal 2) directly controls the greedy construction of prime chains.",
     "problemStatement": "**Problem Statement (OPEN)**\n\nLet $p_1 < p_2 < \\cdots$ be a sequence of primes where $p_{i+1} \\equiv 1 \\pmod{p_i}$.\n\n**Question 1:** Is it true that $\\lim_{k \\to \\infty} p_k^{1/k} = \\infty$?\n\n**Question 2:** Does there exist such a sequence with $p_k \\leq \\exp(k(\\log k)^{1+o(1)})$?\n\nBoth questions remain OPEN.",
-    "text": "Let p₁ < p₂ < ⋯ be primes with p_{i+1} ≡ 1 (mod p_i). Is lim p_k^{1/k} = ∞? Can p_k ≤ exp(k(log k)^{1+o(1)})?",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Prime Chains:** IsPrimeChain(p) := StrictMono p ∧ all primes ∧ p_{i+1} % p_i = 1\n\n2. **Growth Questions:** Question1 (k-th root → ∞) and Question2 (sub-doubly-exponential)\n\n3. **Known Bounds:** Axiomatize Linnik's theorem, greedy algorithm bounds, FKL analysis\n\n4. **Related Structures:** Cunningham chains as special prime chains\n\n5. **Formal Statements:** Precise Tendsto formulation from formal-conjectures",
+    "text": "Let p\u2081 < p\u2082 < \u22ef be primes with p_{i+1} \u2261 1 (mod p_i). Is lim p_k^{1/k} = \u221e? Can p_k \u2264 exp(k(log k)^{1+o(1)})?",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Prime Chains:** IsPrimeChain(p) := StrictMono p \u2227 all primes \u2227 p_{i+1} % p_i = 1\n\n2. **Growth Questions:** Question1 (k-th root \u2192 \u221e) and Question2 (sub-doubly-exponential)\n\n3. **Known Bounds:** Axiomatize Linnik's theorem, greedy algorithm bounds, FKL analysis\n\n4. **Related Structures:** Cunningham chains as special prime chains\n\n5. **Formal Statements:** Precise Tendsto formulation from formal-conjectures",
     "keyInsights": [
-      "**Greedy Bound:** Using Linnik's theorem, greedy gives p_k ≤ exp(exp(O(k)))",
-      "**Conjectural Improvement:** If least prime ≡ 1 (mod p) is O(p(log p)^C), get desired bound",
-      "**Exponential Lower:** Any prime chain grows at least exponentially: p_k ≥ c^k",
+      "**Greedy Bound:** Using Linnik's theorem, greedy gives p_k \u2264 exp(exp(O(k)))",
+      "**Conjectural Improvement:** If least prime \u2261 1 (mod p) is O(p(log p)^C), get desired bound",
+      "**Exponential Lower:** Any prime chain grows at least exponentially: p_k \u2265 c^k",
       "**Cunningham Chains:** p, 2p+1, 4p+3,... are prime chains when all terms are prime",
       "**Gap:** Large gap between known lower (c^k) and upper (exp(exp(Ck))) bounds"
     ],
@@ -141,19 +141,19 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #695 asks two questions about prime chains (sequences p_i where p_{i+1} ≡ 1 (mod p_i)): does p_k^{1/k} → ∞, and can p_k grow as slowly as exp(k(log k)^{1+o(1)})? Both questions are OPEN.",
+    "summary": "Erd\u0151s Problem #695 asks two questions about prime chains (sequences p_i where p_{i+1} \u2261 1 (mod p_i)): does p_k^{1/k} \u2192 \u221e, and can p_k grow as slowly as exp(k(log k)^{1+o(1)})? Both questions are OPEN.",
     "implications": "Understanding prime chain growth would illuminate the distribution of primes in arithmetic progressions and the structure of multiplicative groups modulo primes.",
     "openQuestions": [
-      "Does every prime chain have p_k^{1/k} → ∞?",
+      "Does every prime chain have p_k^{1/k} \u2192 \u221e?",
       "Can we improve on the greedy doubly-exponential bound?",
       "Is the small prime conjecture true?",
-      "What is the longest prime chain with p_k ≤ n?",
+      "What is the longest prime chain with p_k \u2264 n?",
       "Are there prime chains with p_k = exp(k^{1+o(1)})?"
     ]
   },
   "references": [
     {
-      "authors": "Erdős, Paul; Pomerance, Carl",
+      "authors": "Erd\u0151s, Paul; Pomerance, Carl",
       "title": "On the largest prime factors of n and n+1",
       "year": "1978",
       "venue": "Aequationes Math. 17, pp. 311-321",

--- a/src/data/proofs/erdos-710/meta.json
+++ b/src/data/proofs/erdos-710/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-710",
-  "title": "Erdős Problem #710: Minimal Interval for Divisibility Matching",
+  "title": "Erd\u0151s Problem #710: Minimal Interval for Divisibility Matching",
   "slug": "erdos-710",
-  "description": "Let f(n) be minimal such that in (n, n+f(n)) there exist distinct integers a₁,...,aₙ with k|aₖ for all k. Obtain an asymptotic formula for f(n). Known bounds differ by √(log log n) factor; exact asymptotics remain OPEN.",
+  "description": "Let f(n) be minimal such that in (n, n+f(n)) there exist distinct integers a\u2081,...,a\u2099 with k|a\u2096 for all k. Obtain an asymptotic formula for f(n). Known bounds differ by \u221a(log log n) factor; exact asymptotics remain OPEN.",
   "meta": {
-    "author": "Erdős, Pomerance (bounds 1980), Open (asymptotics)",
+    "author": "Erd\u0151s, Pomerance (bounds 1980), Open (asymptotics)",
     "sourceUrl": "https://erdosproblems.com/710",
     "date": "1980",
     "status": "axiomatized",
@@ -52,9 +52,9 @@
       "IntervalAdmitsSelection definition: existence of valid selection",
       "minimalIntervalLength definition: the function f(n)",
       "multiplesInInterval definition: counting multiples",
-      "erdos_pomerance_lower_bound axiom: (2/√e + o(1))n√(log n / log log n)",
-      "erdos_pomerance_upper_bound axiom: (1.7398... + o(1))n√(log n)",
-      "bounds_gap axiom: factor of √(log log n) between bounds",
+      "erdos_pomerance_lower_bound axiom: (2/\u221ae + o(1))n\u221a(log n / log log n)",
+      "erdos_pomerance_upper_bound axiom: (1.7398... + o(1))n\u221a(log n)",
+      "bounds_gap axiom: factor of \u221a(log log n) between bounds",
       "erdos_710_open axiom: asymptotic formula exists",
       "Small examples for n = 1, 2, 3",
       "smallest_multiple_bound theorem: greedy algorithm insight",
@@ -62,19 +62,19 @@
     ],
     "axiomCount": 3,
     "lineCount": 320,
-    "assumptions": "7 axioms: selection_exists_large, multiples_sparse, erdos_pomerance_lower_bound, and 4 more. See Lean source for complete statements."
+    "assumptions": "3 axioms: selection_exists_large, erdos_pomerance_lower_bound, erdos_pomerance_upper_bound. 0 sorries."
   },
   "overview": {
-    "historicalContext": "**Erdős Problem #710**\n\nThis problem concerns the minimal interval length needed for divisibility matching, a combinatorial problem at the intersection of number theory and extremal combinatorics.\n\n**Key History:**\n- Erdős and Pomerance (1980): Established upper and lower bounds in \"Matching the natural numbers up to n with distinct multiples of another interval\"\n- Erdős [Er92c] (1992): \"Some of my forgotten problems in number theory\" - offered 2000 rupees prize\n- The problem remains OPEN - exact asymptotics unknown\n\n**Mathematical Setting:**\n- Given n, we seek distinct integers a₁,...,aₙ in a short interval starting at n\n- The k-th integer must be divisible by k\n- f(n) = minimal interval length for this to be possible\n- The challenge is finding the precise asymptotic growth rate of f(n)",
-    "problemStatement": "**Problem Statement (OPEN)**\n\nLet f(n) be minimal such that in (n, n+f(n)) there exist distinct integers a₁,...,aₙ with k | aₖ for all 1 ≤ k ≤ n.\n\nObtain an asymptotic formula for f(n).\n\n**Known Bounds (Erdős-Pomerance 1980):**\n- Lower: (2/√e + o(1)) · n · √(log n / log log n) ≈ 1.213 · n · √(log n / log log n)\n- Upper: (1.7398... + o(1)) · n · √(log n)\n\n**Gap:** The bounds differ by a factor of √(log log n), which grows very slowly but is unbounded.\n\n**Prize:** Erdős offered 2000 rupees (~$78 in 1992) for an asymptotic formula.",
-    "text": "Let f(n) be minimal such that in (n, n+f(n)) there exist distinct integers a₁,...,aₙ with k|aₖ for all k. Obtain an asymptotic formula for f(n). Known bounds differ by √(log log n) factor; exact asymptotics remain OPEN.",
-    "proofStrategy": "**Formalization Approach**\n\n1. **Core Definitions:** Define IsValidSelection (divisibility matching), IntervalAdmitsSelection, and minimalIntervalLength f(n)\n\n2. **Counting Functions:** Define multiplesInInterval to count multiples of d in an interval\n\n3. **Known Bounds:** Axiomatize the Erdős-Pomerance upper and lower bounds\n\n4. **Bounds Gap:** Show the gap is √(log log n)\n\n5. **Open Problem:** Axiomatize existence of exact asymptotic\n\n6. **Examples:** Verify divisibility matching for n = 1, 2, 3\n\n7. **Heuristics:** Analyze why the constraint for large k is critical",
+    "historicalContext": "**Erd\u0151s Problem #710**\n\nThis problem concerns the minimal interval length needed for divisibility matching, a combinatorial problem at the intersection of number theory and extremal combinatorics.\n\n**Key History:**\n- Erd\u0151s and Pomerance (1980): Established upper and lower bounds in \"Matching the natural numbers up to n with distinct multiples of another interval\"\n- Erd\u0151s [Er92c] (1992): \"Some of my forgotten problems in number theory\" - offered 2000 rupees prize\n- The problem remains OPEN - exact asymptotics unknown\n\n**Mathematical Setting:**\n- Given n, we seek distinct integers a\u2081,...,a\u2099 in a short interval starting at n\n- The k-th integer must be divisible by k\n- f(n) = minimal interval length for this to be possible\n- The challenge is finding the precise asymptotic growth rate of f(n)",
+    "problemStatement": "**Problem Statement (OPEN)**\n\nLet f(n) be minimal such that in (n, n+f(n)) there exist distinct integers a\u2081,...,a\u2099 with k | a\u2096 for all 1 \u2264 k \u2264 n.\n\nObtain an asymptotic formula for f(n).\n\n**Known Bounds (Erd\u0151s-Pomerance 1980):**\n- Lower: (2/\u221ae + o(1)) \u00b7 n \u00b7 \u221a(log n / log log n) \u2248 1.213 \u00b7 n \u00b7 \u221a(log n / log log n)\n- Upper: (1.7398... + o(1)) \u00b7 n \u00b7 \u221a(log n)\n\n**Gap:** The bounds differ by a factor of \u221a(log log n), which grows very slowly but is unbounded.\n\n**Prize:** Erd\u0151s offered 2000 rupees (~$78 in 1992) for an asymptotic formula.",
+    "text": "Let f(n) be minimal such that in (n, n+f(n)) there exist distinct integers a\u2081,...,a\u2099 with k|a\u2096 for all k. Obtain an asymptotic formula for f(n). Known bounds differ by \u221a(log log n) factor; exact asymptotics remain OPEN.",
+    "proofStrategy": "**Formalization Approach**\n\n1. **Core Definitions:** Define IsValidSelection (divisibility matching), IntervalAdmitsSelection, and minimalIntervalLength f(n)\n\n2. **Counting Functions:** Define multiplesInInterval to count multiples of d in an interval\n\n3. **Known Bounds:** Axiomatize the Erd\u0151s-Pomerance upper and lower bounds\n\n4. **Bounds Gap:** Show the gap is \u221a(log log n)\n\n5. **Open Problem:** Axiomatize existence of exact asymptotic\n\n6. **Examples:** Verify divisibility matching for n = 1, 2, 3\n\n7. **Heuristics:** Analyze why the constraint for large k is critical",
     "keyInsights": [
       "**Divisibility Constraint:** The k-th integer must be divisible by k, making large k the hardest constraint (fewest multiples in any interval)",
-      "**Bounds Gap:** The √(log log n) gap between upper and lower bounds is the key mystery",
-      "**Critical k:** For slot n, we need a multiple of n in the interval, requiring L ≈ n as a minimum",
+      "**Bounds Gap:** The \u221a(log log n) gap between upper and lower bounds is the key mystery",
+      "**Critical k:** For slot n, we need a multiple of n in the interval, requiring L \u2248 n as a minimum",
       "**Greedy Approach:** Assigning smallest available multiples gives upper bound but is not optimal",
-      "**Prize Problem:** This is one of Erdős's \"forgotten problems\" with a modest prize attached",
+      "**Prize Problem:** This is one of Erd\u0151s's \"forgotten problems\" with a modest prize attached",
       "**Related Problem:** See also #711 for a connected question"
     ],
     "prerequisites": [
@@ -150,12 +150,12 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #710 asks for an asymptotic formula for f(n), the minimal interval length needed for divisibility matching. Erdős and Pomerance (1980) established bounds that differ by a factor of √(log log n). The exact asymptotics remain open, with a prize of 2000 rupees offered by Erdős. The formalization defines the key concepts, axiomatizes the known bounds, and verifies the setup with small examples.",
-    "implications": "**Theoretical Significance**: **Number-Theoretic Connections**\n\n1. **Divisibility Structure:** The distribution of multiples in intervals is central to the problem\n\n2. **Extremal Combinatorics:** Finding optimal matchings with divisibility constraints\n\n**3. Asymptotic Analysis:** The √(log n) vs √(log n / log log n) question is delicate\n\n4. **Algorithmic Aspects:** Greedy algorithms give bounds but not optimal solutions\n\n5. **Prize Problems:** Part of Erdős's legacy of encouraging research with cash prizes.",
+    "summary": "Erd\u0151s Problem #710 asks for an asymptotic formula for f(n), the minimal interval length needed for divisibility matching. Erd\u0151s and Pomerance (1980) established bounds that differ by a factor of \u221a(log log n). The exact asymptotics remain open, with a prize of 2000 rupees offered by Erd\u0151s. The formalization defines the key concepts, axiomatizes the known bounds, and verifies the setup with small examples.",
+    "implications": "**Theoretical Significance**: **Number-Theoretic Connections**\n\n1. **Divisibility Structure:** The distribution of multiples in intervals is central to the problem\n\n2. **Extremal Combinatorics:** Finding optimal matchings with divisibility constraints\n\n**3. Asymptotic Analysis:** The \u221a(log n) vs \u221a(log n / log log n) question is delicate\n\n4. **Algorithmic Aspects:** Greedy algorithms give bounds but not optimal solutions\n\n5. **Prize Problems:** Part of Erd\u0151s's legacy of encouraging research with cash prizes.",
     "openQuestions": [
       "What is the exact asymptotic formula for f(n)?",
-      "Is the upper bound tight: f(n) ~ C·n·√(log n)?",
-      "Is the lower bound tight: f(n) ~ C·n·√(log n / log log n)?",
+      "Is the upper bound tight: f(n) ~ C\u00b7n\u00b7\u221a(log n)?",
+      "Is the lower bound tight: f(n) ~ C\u00b7n\u00b7\u221a(log n / log log n)?",
       "Is there a polynomial-time algorithm to compute f(n) exactly?",
       "What is the connection to Problem #711?"
     ]
@@ -184,17 +184,17 @@
     {
       "targetId": "erdos-711",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: asymptotic-analysis, combinatorics, divisibility, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: asymptotic-analysis, combinatorics, divisibility, number-theory"
     },
     {
       "targetId": "erdos-1005",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: asymptotic-analysis, combinatorics, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: asymptotic-analysis, combinatorics, number-theory"
     },
     {
       "targetId": "erdos-13",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, divisibility, number-theory"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, divisibility, number-theory"
     }
   ]
 }

--- a/src/data/proofs/erdos-713/meta.json
+++ b/src/data/proofs/erdos-713/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-713",
-  "title": "Erdős Problem #713: Rational Exponents for Bipartite Turán Numbers",
+  "title": "Erd\u0151s Problem #713: Rational Exponents for Bipartite Tur\u00e1n Numbers",
   "slug": "erdos-713",
-  "description": "Does ex(n; G) ~ c·n^α for every bipartite G? Must α be rational? Original conjecture (α ∈ {1+1/k, 2-1/k}) disproved by Erdős-Simonovits (1970). Main questions remain OPEN. Prize: $500.",
+  "description": "Does ex(n; G) ~ c\u00b7n^\u03b1 for every bipartite G? Must \u03b1 be rational? Original conjecture (\u03b1 \u2208 {1+1/k, 2-1/k}) disproved by Erd\u0151s-Simonovits (1970). Main questions remain OPEN. Prize: $500.",
   "meta": {
-    "author": "Erdős-Simonovits (problem), various partial results",
+    "author": "Erd\u0151s-Simonovits (problem), various partial results",
     "sourceUrl": "https://erdosproblems.com/713",
     "date": "",
     "status": "axiomatized",
@@ -47,31 +47,31 @@
       "isBipartite definition: 2-colorable graphs",
       "isGFree definition: subgraph-free",
       "extremalNumber axiom: ex(n; G)",
-      "hasPowerLawGrowth definition: ex ~ cn^α",
-      "hasPowerLawOrder definition: ex ≍ n^α",
+      "hasPowerLawGrowth definition: ex ~ cn^\u03b1",
+      "hasPowerLawOrder definition: ex \u224d n^\u03b1",
       "erdos713StrongQuestion, erdos713WeakQuestion, erdos713RationalQuestion",
       "kovari_sos_turan axiom: upper bound O(n^{2-1/s})",
-      "complete_bipartite_lower axiom: lower bound Ω(n^{2-1/s})",
+      "complete_bipartite_lower axiom: lower bound \u03a9(n^{2-1/s})",
       "complete_bipartite_exponent theorem: rational for K_{s,t}",
       "erdosOriginalConjecture definition and erdos_simonovits_counterexample",
-      "frankl_furedi_hypergraph axiom: hypergraph counterexample for k ≥ 5",
+      "frankl_furedi_hypergraph axiom: hypergraph counterexample for k \u2265 5",
       "erdos_713 summary theorem"
     ],
     "axiomCount": 2,
     "lineCount": 195,
-    "assumptions": "6 axioms: extremalNumber, extremalNumber_bound, kovari_sos_turan, and 3 more. See Lean source for complete statements."
+    "assumptions": "2 axioms: extremalNumber, erdos_simonovits_counterexample. 0 sorries."
   },
   "overview": {
-    "historicalContext": "Erdős Problem #713 asks fundamental questions about the extremal number ex(n; G) for bipartite graphs G, where ex(n; G) is the maximum number of edges in an n-vertex G-free graph. For non-bipartite G, the Erdős-Stone-Simonovits theorem determines ex(n; G) up to lower-order terms. For bipartite G, we only know ex(n; G) = o(n²), and the precise growth rate is the subject of this problem.\n\nErdős initially conjectured (1967) that for every bipartite G, the exponent α in ex(n; G) ~ cn^α always has the restricted form 1+1/k or 2-1/k for integer k ≥ 2. This was natural given that ex(n; K_{s,t}) has exponent 2-1/s by the Kővári-Sós-Turán theorem. However, Erdős and Simonovits (1970) disproved this restricted form, finding bipartite graphs with other exponents.\n\nThe broader questions remain open and carry a $500 prize: Does every bipartite graph have a well-defined power-law exponent? Must such exponents be rational? Frankl-Füredi (1987) showed the analogous statement fails for k-uniform hypergraphs with k ≥ 5, and Füredi-Gerbner (2021) extended this to all k ≥ 5, but the graph case remains unresolved.",
-    "problemStatement": "**Problem Statement (OPEN)**\n\n1. Does there exist α ∈ [1,2) and c > 0 such that ex(n; G) ~ c·n^α for every bipartite G?\n\n2. Does ex(n; G) ≍ n^α for some α?\n\n3. Must α be rational?\n\n**Known:**\n- Original conjecture α ∈ {1+1/k, 2-1/k} is FALSE\n- For K_{s,t}: α = 2 - 1/s (rational)\n- Hypergraph version fails for k ≥ 5\n\n**Prize:** $500 (still open)",
-    "text": "Does ex(n; G) ~ c·n^α for every bipartite G? Must α be rational? Original conjecture (α ∈ {1+1/k, 2-1/k}) disproved by Erdős-Simonovits (1970). Main questions remain OPEN. Prize: $500.",
+    "historicalContext": "Erd\u0151s Problem #713 asks fundamental questions about the extremal number ex(n; G) for bipartite graphs G, where ex(n; G) is the maximum number of edges in an n-vertex G-free graph. For non-bipartite G, the Erd\u0151s-Stone-Simonovits theorem determines ex(n; G) up to lower-order terms. For bipartite G, we only know ex(n; G) = o(n\u00b2), and the precise growth rate is the subject of this problem.\n\nErd\u0151s initially conjectured (1967) that for every bipartite G, the exponent \u03b1 in ex(n; G) ~ cn^\u03b1 always has the restricted form 1+1/k or 2-1/k for integer k \u2265 2. This was natural given that ex(n; K_{s,t}) has exponent 2-1/s by the K\u0151v\u00e1ri-S\u00f3s-Tur\u00e1n theorem. However, Erd\u0151s and Simonovits (1970) disproved this restricted form, finding bipartite graphs with other exponents.\n\nThe broader questions remain open and carry a $500 prize: Does every bipartite graph have a well-defined power-law exponent? Must such exponents be rational? Frankl-F\u00fcredi (1987) showed the analogous statement fails for k-uniform hypergraphs with k \u2265 5, and F\u00fcredi-Gerbner (2021) extended this to all k \u2265 5, but the graph case remains unresolved.",
+    "problemStatement": "**Problem Statement (OPEN)**\n\n1. Does there exist \u03b1 \u2208 [1,2) and c > 0 such that ex(n; G) ~ c\u00b7n^\u03b1 for every bipartite G?\n\n2. Does ex(n; G) \u224d n^\u03b1 for some \u03b1?\n\n3. Must \u03b1 be rational?\n\n**Known:**\n- Original conjecture \u03b1 \u2208 {1+1/k, 2-1/k} is FALSE\n- For K_{s,t}: \u03b1 = 2 - 1/s (rational)\n- Hypergraph version fails for k \u2265 5\n\n**Prize:** $500 (still open)",
+    "text": "Does ex(n; G) ~ c\u00b7n^\u03b1 for every bipartite G? Must \u03b1 be rational? Original conjecture (\u03b1 \u2208 {1+1/k, 2-1/k}) disproved by Erd\u0151s-Simonovits (1970). Main questions remain OPEN. Prize: $500.",
     "proofStrategy": "**Formalization Approach**\n\n1. **Bipartite Graphs:** isBipartite definition\n\n2. **Extremal Number:** extremalNumber axiom for ex(n; G)\n\n3. **Growth Conditions:** hasPowerLawGrowth and hasPowerLawOrder\n\n4. **Key Results:**\n   - kovari_sos_turan: upper bound O(n^{2-1/s})\n   - erdos_simonovits_counterexample: original conjecture false\n   - frankl_furedi_hypergraph_counterexample: hypergraph fails",
     "keyInsights": [
-      "**Bipartite is Special:** For non-bipartite G, Erdős-Stone-Simonovits gives exact answer",
+      "**Bipartite is Special:** For non-bipartite G, Erd\u0151s-Stone-Simonovits gives exact answer",
       "**K_{s,t} is Understood:** Exponent 2-1/s is rational",
-      "**Original Form Failed:** α not restricted to {1+1/k, 2-1/k}",
-      "**Hypergraph Counterexample:** For k ≥ 5, no clean exponent exists",
-      "**Still Open:** Main questions about existence and rationality of α",
+      "**Original Form Failed:** \u03b1 not restricted to {1+1/k, 2-1/k}",
+      "**Hypergraph Counterexample:** For k \u2265 5, no clean exponent exists",
+      "**Still Open:** Main questions about existence and rationality of \u03b1",
       "**$500 Prize:** Reflects difficulty and importance"
     ],
     "prerequisites": [
@@ -115,26 +115,26 @@
     {
       "id": "known-results",
       "title": "Known Results",
-      "summary": "Kővári-Sós-Turán, complete bipartite bounds and exponent",
+      "summary": "K\u0151v\u00e1ri-S\u00f3s-Tur\u00e1n, complete bipartite bounds and exponent",
       "startLine": 124,
       "endLine": 151,
-      "mathContext": "Bound: Kővári-Sós-Turán, complete bipartite bounds and exponent"
+      "mathContext": "Bound: K\u0151v\u00e1ri-S\u00f3s-Tur\u00e1n, complete bipartite bounds and exponent"
     },
     {
       "id": "original-conjecture",
-      "title": "Erdős's Original Conjecture (Disproved)",
-      "summary": "erdosOriginalConjecture definition and Erdős-Simonovits counterexample",
+      "title": "Erd\u0151s's Original Conjecture (Disproved)",
+      "summary": "erdosOriginalConjecture definition and Erd\u0151s-Simonovits counterexample",
       "startLine": 152,
       "endLine": 169,
-      "mathContext": "Formal definition: erdosOriginalConjecture definition and Erdős-Simonovits counterexample"
+      "mathContext": "Formal definition: erdosOriginalConjecture definition and Erd\u0151s-Simonovits counterexample"
     },
     {
       "id": "hypergraph",
       "title": "Hypergraph Counterexamples",
-      "summary": "Frankl-Füredi-Gerbner results for k ≥ 5",
+      "summary": "Frankl-F\u00fcredi-Gerbner results for k \u2265 5",
       "startLine": 170,
       "endLine": 187,
-      "mathContext": "Frankl-Füredi-Gerbner results for k $\\geq$ 5"
+      "mathContext": "Frankl-F\u00fcredi-Gerbner results for k $\\geq$ 5"
     },
     {
       "id": "summary",
@@ -146,12 +146,12 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #713 asks fundamental questions about extremal numbers of bipartite graphs: Does ex(n; G) have power-law growth cn^α? Is α always rational? The original conjecture (α ∈ {1+1/k, 2-1/k}) was disproved by Erdős-Simonovits (1970). The main questions remain OPEN with a $500 prize.",
-    "implications": "**Theoretical Significance**: **Connections and Impact**\n\n1. **Extremal Graph Theory:** Fundamental question about bipartite Turán numbers\n\n2. **Zarankiewicz Problem:** K_{s,t} case is a major special case\n\n**3. Hypergraph Theory:** Frankl-Füredi showed the statement fails for k ≥ 5\n\n4. **Turán Density:** Bipartite graphs have zero Turán density\n\n5. **Analytic Combinatorics:** Connects to asymptotic enumeration.",
+    "summary": "Erd\u0151s Problem #713 asks fundamental questions about extremal numbers of bipartite graphs: Does ex(n; G) have power-law growth cn^\u03b1? Is \u03b1 always rational? The original conjecture (\u03b1 \u2208 {1+1/k, 2-1/k}) was disproved by Erd\u0151s-Simonovits (1970). The main questions remain OPEN with a $500 prize.",
+    "implications": "**Theoretical Significance**: **Connections and Impact**\n\n1. **Extremal Graph Theory:** Fundamental question about bipartite Tur\u00e1n numbers\n\n2. **Zarankiewicz Problem:** K_{s,t} case is a major special case\n\n**3. Hypergraph Theory:** Frankl-F\u00fcredi showed the statement fails for k \u2265 5\n\n4. **Tur\u00e1n Density:** Bipartite graphs have zero Tur\u00e1n density\n\n5. **Analytic Combinatorics:** Connects to asymptotic enumeration.",
     "openQuestions": [
-      "Does ex(n; G) ~ cn^α for all bipartite G?",
-      "Does ex(n; G) ≍ n^α for all bipartite G?",
-      "Is α always rational when it exists?",
+      "Does ex(n; G) ~ cn^\u03b1 for all bipartite G?",
+      "Does ex(n; G) \u224d n^\u03b1 for all bipartite G?",
+      "Is \u03b1 always rational when it exists?",
       "Resolve hypergraph case for k = 3, 4",
       "Find explicit counterexample or prove existence"
     ]
@@ -180,17 +180,17 @@
     {
       "targetId": "erdos-1021",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: bipartite-graphs, extremal-combinatorics, graph-theory"
+      "description": "Related Erd\u0151s problem sharing themes: bipartite-graphs, extremal-combinatorics, graph-theory"
     },
     {
       "targetId": "erdos-111",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: bipartite-graphs, graph-theory, open"
+      "description": "Related Erd\u0151s problem sharing themes: bipartite-graphs, graph-theory, open"
     },
     {
       "targetId": "erdos-23",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: bipartite-graphs, extremal-combinatorics, graph-theory"
+      "description": "Related Erd\u0151s problem sharing themes: bipartite-graphs, extremal-combinatorics, graph-theory"
     }
   ]
 }

--- a/src/data/proofs/erdos-72/meta.json
+++ b/src/data/proofs/erdos-72/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-72",
-  "title": "Erdős Problem #72: Unavoidable Cycle Lengths",
+  "title": "Erd\u0151s Problem #72: Unavoidable Cycle Lengths",
   "slug": "erdos-72",
-  "description": "Given a sparse set A of natural numbers and sufficiently high average degree, must every large graph contain a cycle whose length is in A? This $100 problem was solved affirmatively, with Liu and Montgomery's 2020 result contradicting Erdős's original intuition about powers of 2.",
+  "description": "Given a sparse set A of natural numbers and sufficiently high average degree, must every large graph contain a cycle whose length is in A? This $100 problem was solved affirmatively, with Liu and Montgomery's 2020 result contradicting Erd\u0151s's original intuition about powers of 2.",
   "meta": {
-    "author": "Verstraëte (2005), Liu & Montgomery (2020)",
+    "author": "Verstra\u00ebte (2005), Liu & Montgomery (2020)",
     "sourceUrl": "https://erdosproblems.com/72",
     "date": "2020",
     "status": "axiomatized",
@@ -28,7 +28,7 @@
     "relatedProblems": [
       {
         "id": "erdos-71",
-        "relationship": "Bollobás's result on arithmetic progressions (referenced in problem statement)"
+        "relationship": "Bollob\u00e1s's result on arithmetic progressions (referenced in problem statement)"
       }
     ],
     "mathlibDependencies": [
@@ -67,26 +67,26 @@
       "verstraete_existence: non-constructive solution axiom",
       "liu_montgomery_powers_of_two: powers of 2 are unavoidable",
       "erdos_72_solved: combining Liu-Montgomery with density-zero for the solution",
-      "erdos_was_wrong: formal refutation of Erdős's belief",
-      "powersOfTwo_all_even: evenness property (proved for k ≥ 1)",
+      "erdos_was_wrong: formal refutation of Erd\u0151s's belief",
+      "powersOfTwo_all_even: evenness property (proved for k \u2265 1)",
       "optimalThreshold, liu_montgomery_explicit_bound: quantitative bounds",
       "liu_montgomery_general: general theorem for logarithmic-growth even sets"
     ],
     "axiomCount": 1,
     "lineCount": 221,
-    "assumptions": "5 axiom(s) and 3 sorry(s). See the Lean source for details."
+    "assumptions": "1 axiom: liu_montgomery_powers_of_two. 3 sorries."
   },
   "overview": {
-    "historicalContext": "**The Quest for Unavoidable Cycle Lengths**\n\nErdős posed this $100 problem asking whether there exists a 'sparse' set A ⊂ ℕ (density 0) such that any sufficiently dense graph must contain a cycle with length in A. This connects extremal graph theory to number-theoretic properties of cycle length sets.\n\n**Key Historical Developments:**\n\n- **1977**: Bollobás proved the result for infinite arithmetic progressions containing even numbers\n- **2005**: Verstraëte gave a non-constructive existence proof for such a set A\n- **2020**: Liu and Montgomery proved the surprising result that A can be the powers of 2, directly contradicting Erdős's stated belief\n\n**Why Erdős Was Wrong**: Erdős was 'almost certain' that powers of 2 would not work, expecting that forcing specific cycle lengths would require average degree growing with graph size. Liu and Montgomery showed a constant threshold suffices.",
-    "problemStatement": "**Problem Statement**\n\nIs there a set A ⊂ ℕ of density 0 and a constant c > 0 such that every graph on sufficiently many vertices with average degree ≥ c contains a cycle whose length is in A?\n\n**Clarification**: The set A must have density 0, meaning |A ∩ [1,n]|/n → 0 as n → ∞. The constant c must be independent of the graph size.\n\n**Answer**: YES. Multiple constructions exist:\n- Any infinite arithmetic progression with even numbers works (Bollobás 1977)\n- Powers of 2 work (Liu & Montgomery 2020)\n- More generally, any slowly-growing set of even numbers works",
-    "text": "Given a sparse set A of natural numbers and sufficiently high average degree, must every large graph contain a cycle whose length is in A? This $100 problem was solved affirmatively, with Liu and Montgomery's 2020 result contradicting Erdős's original intuition about powers of 2.",
-    "proofStrategy": "**Proof Approach (Liu-Montgomery 2020)**\n\nThe Liu-Montgomery proof for powers of 2 uses sophisticated techniques from extremal combinatorics:\n\n1. **Regularity Methods**: Apply variants of Szemerédi's regularity lemma to decompose the graph into structured pieces\n\n2. **Cycle Detection**: Within regular pairs, analyze path structures to force cycles of specific lengths\n\n3. **Density Arguments**: Show that high average degree propagates through the regular decomposition, ensuring enough structure for cycle existence\n\n4. **Powers of 2 Property**: Exploit that powers of 2 are well-spaced enough that one must appear as a cycle length\n\n**Key Insight**: The sparsity of powers of 2 (only O(log n) values up to n) is counterbalanced by the structural richness that high average degree provides.",
+    "historicalContext": "**The Quest for Unavoidable Cycle Lengths**\n\nErd\u0151s posed this $100 problem asking whether there exists a 'sparse' set A \u2282 \u2115 (density 0) such that any sufficiently dense graph must contain a cycle with length in A. This connects extremal graph theory to number-theoretic properties of cycle length sets.\n\n**Key Historical Developments:**\n\n- **1977**: Bollob\u00e1s proved the result for infinite arithmetic progressions containing even numbers\n- **2005**: Verstra\u00ebte gave a non-constructive existence proof for such a set A\n- **2020**: Liu and Montgomery proved the surprising result that A can be the powers of 2, directly contradicting Erd\u0151s's stated belief\n\n**Why Erd\u0151s Was Wrong**: Erd\u0151s was 'almost certain' that powers of 2 would not work, expecting that forcing specific cycle lengths would require average degree growing with graph size. Liu and Montgomery showed a constant threshold suffices.",
+    "problemStatement": "**Problem Statement**\n\nIs there a set A \u2282 \u2115 of density 0 and a constant c > 0 such that every graph on sufficiently many vertices with average degree \u2265 c contains a cycle whose length is in A?\n\n**Clarification**: The set A must have density 0, meaning |A \u2229 [1,n]|/n \u2192 0 as n \u2192 \u221e. The constant c must be independent of the graph size.\n\n**Answer**: YES. Multiple constructions exist:\n- Any infinite arithmetic progression with even numbers works (Bollob\u00e1s 1977)\n- Powers of 2 work (Liu & Montgomery 2020)\n- More generally, any slowly-growing set of even numbers works",
+    "text": "Given a sparse set A of natural numbers and sufficiently high average degree, must every large graph contain a cycle whose length is in A? This $100 problem was solved affirmatively, with Liu and Montgomery's 2020 result contradicting Erd\u0151s's original intuition about powers of 2.",
+    "proofStrategy": "**Proof Approach (Liu-Montgomery 2020)**\n\nThe Liu-Montgomery proof for powers of 2 uses sophisticated techniques from extremal combinatorics:\n\n1. **Regularity Methods**: Apply variants of Szemer\u00e9di's regularity lemma to decompose the graph into structured pieces\n\n2. **Cycle Detection**: Within regular pairs, analyze path structures to force cycles of specific lengths\n\n3. **Density Arguments**: Show that high average degree propagates through the regular decomposition, ensuring enough structure for cycle existence\n\n4. **Powers of 2 Property**: Exploit that powers of 2 are well-spaced enough that one must appear as a cycle length\n\n**Key Insight**: The sparsity of powers of 2 (only O(log n) values up to n) is counterbalanced by the structural richness that high average degree provides.",
     "keyInsights": [
       "Dense graphs force structural patterns that include specific cycle lengths",
       "The density 0 condition on A is crucial - A cannot be too 'thin' (like primes) or too 'thick'",
-      "Powers of 2 work despite Erdős's intuition, showing even number sets with sub-polynomial growth suffice",
+      "Powers of 2 work despite Erd\u0151s's intuition, showing even number sets with sub-polynomial growth suffice",
       "The problem connects extremal graph theory to number-theoretic properties of integer sets",
-      "Non-constructive proofs (Verstraëte) preceded constructive ones (Liu-Montgomery)"
+      "Non-constructive proofs (Verstra\u00ebte) preceded constructive ones (Liu-Montgomery)"
     ],
     "prerequisites": [
       "Graph theory (vertices, edges, colorings)",
@@ -124,24 +124,24 @@
       "title": "The Main Problem",
       "startLine": 99,
       "endLine": 109,
-      "summary": "Erdős Problem #72: existence of density-0 unavoidable sets",
-      "mathContext": "Mathematical content: Erdős Problem #72: existence of density-0 unavoidable sets"
+      "summary": "Erd\u0151s Problem #72: existence of density-0 unavoidable sets",
+      "mathContext": "Mathematical content: Erd\u0151s Problem #72: existence of density-0 unavoidable sets"
     },
     {
       "id": "known-results",
       "title": "Known Results",
       "startLine": 110,
       "endLine": 141,
-      "summary": "Bollobás (1977), Verstraëte (2005), Liu-Montgomery (2020) as axioms",
-      "mathContext": "Axiomatized: Bollobás (1977), Verstraëte (2005), Liu-Montgomery (2020) as axioms"
+      "summary": "Bollob\u00e1s (1977), Verstra\u00ebte (2005), Liu-Montgomery (2020) as axioms",
+      "mathContext": "Axiomatized: Bollob\u00e1s (1977), Verstra\u00ebte (2005), Liu-Montgomery (2020) as axioms"
     },
     {
       "id": "erdos-wrong",
-      "title": "Erdős's Error",
+      "title": "Erd\u0151s's Error",
       "startLine": 142,
       "endLine": 153,
-      "summary": "Liu-Montgomery refuted Erdős's belief that powers of 2 wouldn't work",
-      "mathContext": "Mathematical content: Liu-Montgomery refuted Erdős's belief that powers of 2 wouldn't work"
+      "summary": "Liu-Montgomery refuted Erd\u0151s's belief that powers of 2 wouldn't work",
+      "mathContext": "Mathematical content: Liu-Montgomery refuted Erd\u0151s's belief that powers of 2 wouldn't work"
     },
     {
       "id": "other-sets",
@@ -196,7 +196,7 @@
         "Hong Liu",
         "Richard Montgomery"
       ],
-      "title": "A proof of Mader's conjecture on large clique subdivisions in C₄-free graphs",
+      "title": "A proof of Mader's conjecture on large clique subdivisions in C\u2084-free graphs",
       "year": "2017",
       "note": "Foundation for the Liu-Montgomery cycle length work",
       "venue": "Journal of the London Mathematical Society"
@@ -206,51 +206,51 @@
         "Hong Liu",
         "Richard Montgomery"
       ],
-      "title": "A solution to Erdős and Hajnal's odd cycle problem",
+      "title": "A solution to Erd\u0151s and Hajnal's odd cycle problem",
       "year": "2023",
       "doi": "10.1090/jams/1009",
-      "note": "Proves powers of 2 are unavoidable cycle lengths, directly resolving Erdős Problem #72 and refuting Erdős's intuition",
+      "note": "Proves powers of 2 are unavoidable cycle lengths, directly resolving Erd\u0151s Problem #72 and refuting Erd\u0151s's intuition",
       "venue": "Journal of the American Mathematical Society"
     },
     {
       "authors": [
-        "Jacques Verstraëte"
+        "Jacques Verstra\u00ebte"
       ],
       "title": "Unavoidable cycle lengths in graphs",
       "volume": 49,
       "year": "2005",
-      "pages": "151–167",
+      "pages": "151\u2013167",
       "note": "Non-constructive proof that a density-0 unavoidable set exists, the first positive answer to Problem #72",
       "venue": "Journal of Graph Theory"
     },
     {
       "authors": [
-        "Béla Bollobás"
+        "B\u00e9la Bollob\u00e1s"
       ],
       "title": "Cycles modulo k",
       "volume": 9,
       "year": "1977",
-      "pages": "97–98",
+      "pages": "97\u201398",
       "note": "Shows every infinite arithmetic progression containing even numbers is an unavoidable cycle length set",
       "venue": "Bulletin of the London Mathematical Society"
     },
     {
       "authors": [
-        "Endre Szemerédi"
+        "Endre Szemer\u00e9di"
       ],
       "title": "Regular partitions of graphs",
       "year": "1978",
-      "pages": "399–401",
+      "pages": "399\u2013401",
       "note": "The regularity lemma used as a key tool in the Liu-Montgomery proof strategy",
-      "venue": "Problèmes Combinatoires et Théorie des Graphes (Colloques Internationaux CNRS)"
+      "venue": "Probl\u00e8mes Combinatoires et Th\u00e9orie des Graphes (Colloques Internationaux CNRS)"
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #72 asked whether sparse sets of natural numbers can serve as 'unavoidable' cycle length sets in dense graphs. The answer is yes, proved non-constructively by Verstraëte (2005) and constructively for powers of 2 by Liu and Montgomery (2020). This contradicted Erdős's belief that powers of 2 would not work.",
-    "implications": "1. **Extremal Graph Theory**: Demonstrates that high average degree forces rich cycle structure with specific length properties\n\n**2. Erdős's Intuition**: A rare case where Erdős's mathematical intuition was definitively wrong, showing the depth of the problem\n\n3. **Number Theory Connection**: Links graph density to number-theoretic properties of integer sets\n\n4. **Algorithmic Implications**: Suggests efficient cycle-finding algorithms in dense graphs may target specific length classes.",
+    "summary": "Erd\u0151s Problem #72 asked whether sparse sets of natural numbers can serve as 'unavoidable' cycle length sets in dense graphs. The answer is yes, proved non-constructively by Verstra\u00ebte (2005) and constructively for powers of 2 by Liu and Montgomery (2020). This contradicted Erd\u0151s's belief that powers of 2 would not work.",
+    "implications": "1. **Extremal Graph Theory**: Demonstrates that high average degree forces rich cycle structure with specific length properties\n\n**2. Erd\u0151s's Intuition**: A rare case where Erd\u0151s's mathematical intuition was definitively wrong, showing the depth of the problem\n\n3. **Number Theory Connection**: Links graph density to number-theoretic properties of integer sets\n\n4. **Algorithmic Implications**: Suggests efficient cycle-finding algorithms in dense graphs may target specific length classes.",
     "openQuestions": [
       "What is the optimal constant c for powers of 2?",
-      "Which other density-0 sets work? What about perfect squares or {p±1 : p prime}?",
+      "Which other density-0 sets work? What about perfect squares or {p\u00b11 : p prime}?",
       "Can the proof be made algorithmic - given a dense graph, efficiently find a cycle of length 2^k?",
       "What happens for directed graphs or hypergraphs?",
       "Full Lean formalization of the Liu-Montgomery argument"

--- a/src/data/proofs/erdos-720/meta.json
+++ b/src/data/proofs/erdos-720/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-720",
-  "title": "Erdős Problem #720: Size Ramsey Numbers of Paths and Cycles",
+  "title": "Erd\u0151s Problem #720: Size Ramsey Numbers of Paths and Cycles",
   "slug": "erdos-720",
-  "description": "Let R̂(G) denote the size Ramsey number. Does R̂(Pₙ)/n → ∞ and R̂(Pₙ)/n² → 0? Does R̂(Cₙ) = o(n²)? SOLVED: Beck (1983) proved R̂(Pₙ) ≪ n and R̂(Cₙ) ≪ n — both are LINEAR in n!",
+  "description": "Let R\u0302(G) denote the size Ramsey number. Does R\u0302(P\u2099)/n \u2192 \u221e and R\u0302(P\u2099)/n\u00b2 \u2192 0? Does R\u0302(C\u2099) = o(n\u00b2)? SOLVED: Beck (1983) proved R\u0302(P\u2099) \u226a n and R\u0302(C\u2099) \u226a n \u2014 both are LINEAR in n!",
   "meta": {
-    "author": "Erdős-Faudree-Rousseau-Schelp (1978), Beck (1983)",
+    "author": "Erd\u0151s-Faudree-Rousseau-Schelp (1978), Beck (1983)",
     "sourceUrl": "https://erdosproblems.com/720",
     "date": "1978",
     "status": "axiomatized",
@@ -60,50 +60,50 @@
       "sizeRamseyNumber via Nat.find as minimal m with Ramsey property",
       "ErdosQuestion720a/b/c: original questions as Filter.Tendsto propositions",
       "beck_path_theorem, beck_cycle_theorem: linear upper bounds (axioms)",
-      "dudek_pralat_bound: improved constant R̂(Pₙ) ≤ 900n",
-      "path_lower_bound, cycle_lower_bound: matching Ω(n) lower bounds",
-      "pathIsLinear, cycleIsLinear: Θ(n) characterization definitions",
-      "answer_720a/b/c: answers to Erdős's questions",
-      "erdos_720_beck: proved pathIsLinear ∧ cycleIsLinear from axioms"
+      "dudek_pralat_bound: improved constant R\u0302(P\u2099) \u2264 900n",
+      "path_lower_bound, cycle_lower_bound: matching \u03a9(n) lower bounds",
+      "pathIsLinear, cycleIsLinear: \u0398(n) characterization definitions",
+      "answer_720a/b/c: answers to Erd\u0151s's questions",
+      "erdos_720_beck: proved pathIsLinear \u2227 cycleIsLinear from axioms"
     ],
     "relatedProblems": [
       {
         "id": "erdos-76",
         "relationship": "thematic",
-        "description": "Monochromatic triangle packing in 2-colored $K_n$ — another Ramsey-theoretic problem counting substructures under colorings"
+        "description": "Monochromatic triangle packing in 2-colored $K_n$ \u2014 another Ramsey-theoretic problem counting substructures under colorings"
       },
       {
         "id": "erdos-719",
         "relationship": "companion",
-        "description": "Hypergraph decomposition into cliques — adjacent problem number studying decomposition in Ramsey/Turán framework"
+        "description": "Hypergraph decomposition into cliques \u2014 adjacent problem number studying decomposition in Ramsey/Tur\u00e1n framework"
       },
       {
         "id": "erdos-746",
         "relationship": "thematic",
-        "description": "Ramsey numbers and coloring problems — part of the broader Ramsey theory cluster in the Erdős collection"
+        "description": "Ramsey numbers and coloring problems \u2014 part of the broader Ramsey theory cluster in the Erd\u0151s collection"
       },
       {
         "id": "erdos-648",
         "relationship": "thematic",
-        "description": "Extremal combinatorics on sequences — shares the theme of sharp asymptotic characterization ($\\Theta(n)$ vs $o(n^2)$)"
+        "description": "Extremal combinatorics on sequences \u2014 shares the theme of sharp asymptotic characterization ($\\Theta(n)$ vs $o(n^2)$)"
       }
     ],
     "axiomCount": 8,
     "lineCount": 257,
-    "assumptions": "12 axioms: path_edges, cycle_edges, complete_graph_ramsey, and 9 more. See Lean source for complete statements."
+    "assumptions": "8 axioms: complete_graph_ramsey, beck_path_theorem, beck_cycle_theorem, path_lower_bound, cycle_lower_bound, answer_720a, answer_720b, answer_720c. 0 sorries."
   },
   "overview": {
-    "historicalContext": "**Origins: Erdős, Faudree, Rousseau, and Schelp (1978)**\n\nThe size Ramsey number $\\hat{R}(G)$ was introduced by Erdős, Faudree, Rousseau, and Schelp in 1978 as a refinement of the classical Ramsey number. While $R(G)$ counts the minimum number of **vertices** in a host graph that forces a monochromatic copy of $G$, $\\hat{R}(G)$ counts the minimum number of **edges**. This distinction is profound: for the complete graph $K_n$, both $R(K_n)$ and $\\hat{R}(K_n)$ grow exponentially, but for sparse graphs the behavior diverges dramatically.\n\n**Erdős's Three Questions**\n\nErdős posed three questions about the path $P_n$ and cycle $C_n$, offering $\\$100$ for their resolution:\n(a) Does $\\hat{R}(P_n)/n \\to \\infty$? — Is the growth superlinear?\n(b) Does $\\hat{R}(P_n)/n^2 \\to 0$? — Is the growth subquadratic?\n(c) Does $\\hat{R}(C_n) = o(n^2)$? — Same for cycles?\n\nErdős expected $\\hat{R}(P_n)$ to grow superlinearly but subquadratically, a regime that seemed natural given that the ordinary Ramsey number $R(P_n) = 2n - 1$ (Gerencsér and Gyárfás, 1967) is exactly linear.\n\n**Beck's $\\$100$ Breakthrough (1983)**\n\nJózsef Beck stunned the combinatorics community by proving $\\hat{R}(P_n) = O(n)$ and $\\hat{R}(C_n) = O(n)$ — both are **linear** in $n$. This overshot Erdős's expectations: question (a) received a **negative** answer (the ratio is bounded, not divergent), while questions (b) and (c) received positive answers for a far stronger reason than anticipated. Beck's proof uses the probabilistic method: he constructs a random graph $H$ with $O(n)$ edges and shows that any 2-coloring of $H$ must contain a long monochromatic path, using a sophisticated expansion argument.\n\n**Refinements: Dudek-Prałat and the Constant Gap**\n\nDudek and Prałat (2017) improved Beck's upper bound constant to $\\hat{R}(P_n) \\le 900n$. The current best lower bound is $\\hat{R}(P_n) \\ge (3.75 - o(1))n$, leaving a factor of 240 between upper and lower bounds. Determining the true constant is one of the main open problems in size Ramsey theory. The result generalizes: Friedman and Pippenger (1987) proved linear size Ramsey numbers for bounded-degree trees, and Kohayakawa, Rödl, Schacht, and Szemerédi (2011) extended this to all bounded-degree graphs (Problem #559).",
-    "problemStatement": "**Problem Statement (SOLVED)**\n\nLet $\\hat{R}(G)$ denote the **size Ramsey number**: the minimal number of edges $m$ such that there exists a graph $H$ with $m$ edges where any 2-coloring of the edges of $H$ contains a monochromatic copy of $G$.\n\n**Questions:**\n(a) Does $\\hat{R}(P_n)/n \\to \\infty$?\n(b) Does $\\hat{R}(P_n)/n^2 \\to 0$?\n(c) Does $\\hat{R}(C_n) = o(n^2)$?\n\n**Answers (Beck 1983):**\n(a) **NO** — $\\hat{R}(P_n)/n$ is bounded (in fact $\\hat{R}(P_n) \\le cn$), so the ratio does not diverge\n(b) **YES** — since $\\hat{R}(P_n) = O(n)$, we have $\\hat{R}(P_n)/n^2 \\le c/n \\to 0$, much stronger than $o(n^2)$\n(c) **YES** — since $\\hat{R}(C_n) = O(n)$, we have $\\hat{R}(C_n)/n^2 \\to 0$, in fact $\\hat{R}(C_n) = \\Theta(n)$",
-    "text": "Let R̂(G) denote the size Ramsey number. Does R̂(Pₙ)/n → ∞ and R̂(Pₙ)/n² → 0? Does R̂(Cₙ) = o(n²)? SOLVED: Beck (1983) proved R̂(Pₙ) ≪ n and R̂(Cₙ) ≪ n — both are LINEAR in n!",
-    "proofStrategy": "**Formalization Strategy**\n\n1. **Graph model**: `GraphOnN n = SimpleGraph (Fin n)` with `numEdges` counting ordered-pair edges\n2. **Path and cycle graphs**: `PathGraph n` with adjacency $|i - j| = 1$; `CycleGraph n` extending with wrap-around edge $\\{0, n-1\\}$\n3. **Coloring framework**: `EdgeColoring G` as functions from edges to `Fin 2`, `IsMonochromatic` for uniform coloring, `ContainsMonochromaticCopy` for the Ramsey property\n4. **Size Ramsey number**: `sizeRamseyNumber n G` defined via `Nat.find` as the minimum $m$ such that some $H$ with $m$ edges has the Ramsey property for $G$\n5. **Erdős's questions**: `ErdosQuestion720a/b/c` formalized as `Filter.Tendsto` propositions with `atTop` and `nhds 0`\n6. **Beck's theorem**: Axiomatized as $\\exists c > 0, \\forall n \\ge 2, \\hat{R}(P_n) \\le cn$ (and similarly for cycles)\n7. **Lower bounds**: Axiomatized matching $\\Omega(n)$ bounds; `pathIsLinear` and `cycleIsLinear` define the $\\Theta(n)$ characterization\n8. **Summary theorems**: `erdos_720` proves questions (b) and (c); `erdos_720_main` packages all three answers; `erdos_720_beck` derives `pathIsLinear ∧ cycleIsLinear` from the axiomatized bounds via `obtain`",
+    "historicalContext": "**Origins: Erd\u0151s, Faudree, Rousseau, and Schelp (1978)**\n\nThe size Ramsey number $\\hat{R}(G)$ was introduced by Erd\u0151s, Faudree, Rousseau, and Schelp in 1978 as a refinement of the classical Ramsey number. While $R(G)$ counts the minimum number of **vertices** in a host graph that forces a monochromatic copy of $G$, $\\hat{R}(G)$ counts the minimum number of **edges**. This distinction is profound: for the complete graph $K_n$, both $R(K_n)$ and $\\hat{R}(K_n)$ grow exponentially, but for sparse graphs the behavior diverges dramatically.\n\n**Erd\u0151s's Three Questions**\n\nErd\u0151s posed three questions about the path $P_n$ and cycle $C_n$, offering $\\$100$ for their resolution:\n(a) Does $\\hat{R}(P_n)/n \\to \\infty$? \u2014 Is the growth superlinear?\n(b) Does $\\hat{R}(P_n)/n^2 \\to 0$? \u2014 Is the growth subquadratic?\n(c) Does $\\hat{R}(C_n) = o(n^2)$? \u2014 Same for cycles?\n\nErd\u0151s expected $\\hat{R}(P_n)$ to grow superlinearly but subquadratically, a regime that seemed natural given that the ordinary Ramsey number $R(P_n) = 2n - 1$ (Gerencs\u00e9r and Gy\u00e1rf\u00e1s, 1967) is exactly linear.\n\n**Beck's $\\$100$ Breakthrough (1983)**\n\nJ\u00f3zsef Beck stunned the combinatorics community by proving $\\hat{R}(P_n) = O(n)$ and $\\hat{R}(C_n) = O(n)$ \u2014 both are **linear** in $n$. This overshot Erd\u0151s's expectations: question (a) received a **negative** answer (the ratio is bounded, not divergent), while questions (b) and (c) received positive answers for a far stronger reason than anticipated. Beck's proof uses the probabilistic method: he constructs a random graph $H$ with $O(n)$ edges and shows that any 2-coloring of $H$ must contain a long monochromatic path, using a sophisticated expansion argument.\n\n**Refinements: Dudek-Pra\u0142at and the Constant Gap**\n\nDudek and Pra\u0142at (2017) improved Beck's upper bound constant to $\\hat{R}(P_n) \\le 900n$. The current best lower bound is $\\hat{R}(P_n) \\ge (3.75 - o(1))n$, leaving a factor of 240 between upper and lower bounds. Determining the true constant is one of the main open problems in size Ramsey theory. The result generalizes: Friedman and Pippenger (1987) proved linear size Ramsey numbers for bounded-degree trees, and Kohayakawa, R\u00f6dl, Schacht, and Szemer\u00e9di (2011) extended this to all bounded-degree graphs (Problem #559).",
+    "problemStatement": "**Problem Statement (SOLVED)**\n\nLet $\\hat{R}(G)$ denote the **size Ramsey number**: the minimal number of edges $m$ such that there exists a graph $H$ with $m$ edges where any 2-coloring of the edges of $H$ contains a monochromatic copy of $G$.\n\n**Questions:**\n(a) Does $\\hat{R}(P_n)/n \\to \\infty$?\n(b) Does $\\hat{R}(P_n)/n^2 \\to 0$?\n(c) Does $\\hat{R}(C_n) = o(n^2)$?\n\n**Answers (Beck 1983):**\n(a) **NO** \u2014 $\\hat{R}(P_n)/n$ is bounded (in fact $\\hat{R}(P_n) \\le cn$), so the ratio does not diverge\n(b) **YES** \u2014 since $\\hat{R}(P_n) = O(n)$, we have $\\hat{R}(P_n)/n^2 \\le c/n \\to 0$, much stronger than $o(n^2)$\n(c) **YES** \u2014 since $\\hat{R}(C_n) = O(n)$, we have $\\hat{R}(C_n)/n^2 \\to 0$, in fact $\\hat{R}(C_n) = \\Theta(n)$",
+    "text": "Let R\u0302(G) denote the size Ramsey number. Does R\u0302(P\u2099)/n \u2192 \u221e and R\u0302(P\u2099)/n\u00b2 \u2192 0? Does R\u0302(C\u2099) = o(n\u00b2)? SOLVED: Beck (1983) proved R\u0302(P\u2099) \u226a n and R\u0302(C\u2099) \u226a n \u2014 both are LINEAR in n!",
+    "proofStrategy": "**Formalization Strategy**\n\n1. **Graph model**: `GraphOnN n = SimpleGraph (Fin n)` with `numEdges` counting ordered-pair edges\n2. **Path and cycle graphs**: `PathGraph n` with adjacency $|i - j| = 1$; `CycleGraph n` extending with wrap-around edge $\\{0, n-1\\}$\n3. **Coloring framework**: `EdgeColoring G` as functions from edges to `Fin 2`, `IsMonochromatic` for uniform coloring, `ContainsMonochromaticCopy` for the Ramsey property\n4. **Size Ramsey number**: `sizeRamseyNumber n G` defined via `Nat.find` as the minimum $m$ such that some $H$ with $m$ edges has the Ramsey property for $G$\n5. **Erd\u0151s's questions**: `ErdosQuestion720a/b/c` formalized as `Filter.Tendsto` propositions with `atTop` and `nhds 0`\n6. **Beck's theorem**: Axiomatized as $\\exists c > 0, \\forall n \\ge 2, \\hat{R}(P_n) \\le cn$ (and similarly for cycles)\n7. **Lower bounds**: Axiomatized matching $\\Omega(n)$ bounds; `pathIsLinear` and `cycleIsLinear` define the $\\Theta(n)$ characterization\n8. **Summary theorems**: `erdos_720` proves questions (b) and (c); `erdos_720_main` packages all three answers; `erdos_720_beck` derives `pathIsLinear \u2227 cycleIsLinear` from the axiomatized bounds via `obtain`",
     "keyInsights": [
-      "**Surprise negative answer**: Erdős expected $\\hat{R}(P_n)/n \\to \\infty$, but Beck showed the ratio is bounded — one of the rare cases where an Erdős problem overshot the conjecture in both directions",
+      "**Surprise negative answer**: Erd\u0151s expected $\\hat{R}(P_n)/n \\to \\infty$, but Beck showed the ratio is bounded \u2014 one of the rare cases where an Erd\u0151s problem overshot the conjecture in both directions",
       "**Probabilistic method**: Beck's proof constructs a random graph $H$ with $O(n)$ edges and shows via expansion properties that any 2-coloring forces a long monochromatic path",
-      "**Ordinary vs size Ramsey**: The ordinary Ramsey number $R(P_n) = 2n - 1$ is exact (Gerencsér-Gyárfás 1967), but the size Ramsey constant in $\\hat{R}(P_n) = \\Theta(n)$ remains unknown — current bounds span a factor of 240",
-      "**Generalization hierarchy**: Paths $\\subset$ trees $\\subset$ bounded-degree graphs all have linear size Ramsey numbers, proved by Beck (1983), Friedman-Pippenger (1987), and Kohayakawa-Rödl-Schacht-Szemerédi (2011) respectively",
+      "**Ordinary vs size Ramsey**: The ordinary Ramsey number $R(P_n) = 2n - 1$ is exact (Gerencs\u00e9r-Gy\u00e1rf\u00e1s 1967), but the size Ramsey constant in $\\hat{R}(P_n) = \\Theta(n)$ remains unknown \u2014 current bounds span a factor of 240",
+      "**Generalization hierarchy**: Paths $\\subset$ trees $\\subset$ bounded-degree graphs all have linear size Ramsey numbers, proved by Beck (1983), Friedman-Pippenger (1987), and Kohayakawa-R\u00f6dl-Schacht-Szemer\u00e9di (2011) respectively",
       "**Nat.find for minimum**: The size Ramsey number is defined as the minimum $m$ with the Ramsey property, using `Nat.find` with the complete graph $K_n$ providing an existence witness",
-      "**Filter.Tendsto formalization**: Erdős's asymptotic questions are precisely captured by `Tendsto f atTop atTop` (divergence) and `Tendsto f atTop (nhds 0)` (convergence to zero)"
+      "**Filter.Tendsto formalization**: Erd\u0151s's asymptotic questions are precisely captured by `Tendsto f atTop atTop` (divergence) and `Tendsto f atTop (nhds 0)` (convergence to zero)"
     ],
     "prerequisites": [
       "**Graph theory fundamentals**: Simple graphs, edges, vertices, subgraphs, and graph homomorphisms. The definitions of paths $P_n$ (vertices $\\{0, \\ldots, n-1\\}$ with edges $\\{i, i+1\\}$) and cycles $C_n$ (path plus wrap-around edge $\\{0, n-1\\}$).",
@@ -139,50 +139,50 @@
     },
     {
       "id": "erdos-questions",
-      "title": "Erdős's Three Questions",
+      "title": "Erd\u0151s's Three Questions",
       "startLine": 105,
       "endLine": 128,
-      "summary": "Defines `sizeRamseyPath n` and `sizeRamseyCycle n` as specializations. Formalizes Erdős's questions: (a) $\\hat{R}(P_n)/n \\to \\infty$ via `Tendsto ... atTop atTop`, (b) $\\hat{R}(P_n)/n^2 \\to 0$ via `Tendsto ... atTop (nhds 0)`, (c) $\\hat{R}(C_n)/n^2 \\to 0$ similarly.",
-      "mathContext": "Defines `sizeRamseyPath n` and `sizeRamseyCycle n` as specializations. Formalizes Erdős's questions: (a) $\\hat{R}(P_n)/n \\to \\infty$ via `Tendsto ... atTop atTop`, (b) $\\hat{R}(P_n)/n^2 \\to 0$ via `Tendsto ... atTop (nhds 0)`, (c) $\\hat{R}(C_n)/n^2 \\to 0$ similarly."
+      "summary": "Defines `sizeRamseyPath n` and `sizeRamseyCycle n` as specializations. Formalizes Erd\u0151s's questions: (a) $\\hat{R}(P_n)/n \\to \\infty$ via `Tendsto ... atTop atTop`, (b) $\\hat{R}(P_n)/n^2 \\to 0$ via `Tendsto ... atTop (nhds 0)`, (c) $\\hat{R}(C_n)/n^2 \\to 0$ similarly.",
+      "mathContext": "Defines `sizeRamseyPath n` and `sizeRamseyCycle n` as specializations. Formalizes Erd\u0151s's questions: (a) $\\hat{R}(P_n)/n \\to \\infty$ via `Tendsto ... atTop atTop`, (b) $\\hat{R}(P_n)/n^2 \\to 0$ via `Tendsto ... atTop (nhds 0)`, (c) $\\hat{R}(C_n)/n^2 \\to 0$ similarly."
     },
     {
       "id": "beck-theorem",
-      "title": "Beck's Theorem (1983) and Dudek-Prałat Improvement",
+      "title": "Beck's Theorem (1983) and Dudek-Pra\u0142at Improvement",
       "startLine": 129,
       "endLine": 153,
-      "summary": "Axiomatizes Beck's $\\$100$-prize result: $\\exists c > 0,\\, \\forall n \\ge 2,\\, \\hat{R}(P_n) \\le cn$ and $\\hat{R}(C_n) \\le c'n$. Defines `beckPathConstant = 900` from Dudek-Prałat (2017) and axiomatizes $\\hat{R}(P_n) \\le 900n$.",
-      "mathContext": "Axiomatizes Beck's $\\$100$-prize result: $\\exists c > 0,\\, \\forall n \\ge 2,\\, \\hat{R}(P_n) \\le cn$ and $\\hat{R}(C_n) \\le c'n$. Defines `beckPathConstant = 900` from Dudek-Prałat (2017) and axiomatizes $\\hat{R}(P_n) \\le 900n$."
+      "summary": "Axiomatizes Beck's $\\$100$-prize result: $\\exists c > 0,\\, \\forall n \\ge 2,\\, \\hat{R}(P_n) \\le cn$ and $\\hat{R}(C_n) \\le c'n$. Defines `beckPathConstant = 900` from Dudek-Pra\u0142at (2017) and axiomatizes $\\hat{R}(P_n) \\le 900n$.",
+      "mathContext": "Axiomatizes Beck's $\\$100$-prize result: $\\exists c > 0,\\, \\forall n \\ge 2,\\, \\hat{R}(P_n) \\le cn$ and $\\hat{R}(C_n) \\le c'n$. Defines `beckPathConstant = 900` from Dudek-Pra\u0142at (2017) and axiomatizes $\\hat{R}(P_n) \\le 900n$."
     },
     {
       "id": "lower-bounds",
       "title": "Lower Bounds and $\\Theta(n)$ Characterization",
       "startLine": 154,
       "endLine": 178,
-      "summary": "Axiomatizes matching lower bounds $\\hat{R}(P_n) \\ge cn$ and $\\hat{R}(C_n) \\ge c'n$. Defines `pathIsLinear` and `cycleIsLinear` as $\\exists c_1, c_2 > 0$ bounding $\\hat{R}$ from both sides — the $\\Theta(n)$ characterization. Current gap: $3.75n \\le \\hat{R}(P_n) \\le 900n$.",
-      "mathContext": "Axiomatizes matching lower bounds $\\hat{R}(P_n) \\ge cn$ and $\\hat{R}(C_n) \\ge c'n$. Defines `pathIsLinear` and `cycleIsLinear` as $\\exists c_1, c_2 > 0$ bounding $\\hat{R}$ from both sides — the $\\Theta(n)$ characterization. Current gap: $3.75n \\le \\hat{R}(P_n) \\le 900n$."
+      "summary": "Axiomatizes matching lower bounds $\\hat{R}(P_n) \\ge cn$ and $\\hat{R}(C_n) \\ge c'n$. Defines `pathIsLinear` and `cycleIsLinear` as $\\exists c_1, c_2 > 0$ bounding $\\hat{R}$ from both sides \u2014 the $\\Theta(n)$ characterization. Current gap: $3.75n \\le \\hat{R}(P_n) \\le 900n$.",
+      "mathContext": "Axiomatizes matching lower bounds $\\hat{R}(P_n) \\ge cn$ and $\\hat{R}(C_n) \\ge c'n$. Defines `pathIsLinear` and `cycleIsLinear` as $\\exists c_1, c_2 > 0$ bounding $\\hat{R}$ from both sides \u2014 the $\\Theta(n)$ characterization. Current gap: $3.75n \\le \\hat{R}(P_n) \\le 900n$."
     },
     {
       "id": "answers",
-      "title": "Answers to Erdős's Questions",
+      "title": "Answers to Erd\u0151s's Questions",
       "startLine": 179,
       "endLine": 195,
-      "summary": "Axiomatizes the three answers: (a) $\\neg$`ErdosQuestion720a` — NO, $\\hat{R}(P_n)/n$ is bounded; (b) `ErdosQuestion720b` — YES, $\\hat{R}(P_n)/n^2 \\to 0$; (c) `ErdosQuestion720c` — YES, $\\hat{R}(C_n)/n^2 \\to 0$.",
-      "mathContext": "Axiomatizes the three answers: (a) $\\neg$`ErdosQuestion720a` — NO, $\\hat{R}(P_n)/n$ is bounded; (b) `ErdosQuestion720b` — YES, $\\hat{R}(P_n)/n^2 \\to 0$; (c) `ErdosQuestion720c` — YES, $\\hat{R}(C_n)/n^2 \\to 0$."
+      "summary": "Axiomatizes the three answers: (a) $\\neg$`ErdosQuestion720a` \u2014 NO, $\\hat{R}(P_n)/n$ is bounded; (b) `ErdosQuestion720b` \u2014 YES, $\\hat{R}(P_n)/n^2 \\to 0$; (c) `ErdosQuestion720c` \u2014 YES, $\\hat{R}(C_n)/n^2 \\to 0$.",
+      "mathContext": "Axiomatizes the three answers: (a) $\\neg$`ErdosQuestion720a` \u2014 NO, $\\hat{R}(P_n)/n$ is bounded; (b) `ErdosQuestion720b` \u2014 YES, $\\hat{R}(P_n)/n^2 \\to 0$; (c) `ErdosQuestion720c` \u2014 YES, $\\hat{R}(C_n)/n^2 \\to 0$."
     },
     {
       "id": "linear-bound-context",
       "title": "The Surprising Linear Bound",
       "startLine": 196,
       "endLine": 212,
-      "summary": "Context propositions `beckSurprise` and `ramseyComparison` contrasting size vs ordinary Ramsey: $R(P_n) = 2n - 1$ is exact (Gerencsér-Gyárfás), but $\\hat{R}(P_n) = \\Theta(n)$ has a factor-240 gap in the constant.",
-      "mathContext": "Context propositions `beckSurprise` and `ramseyComparison` contrasting size vs ordinary Ramsey: $R(P_n) = 2n - 1$ is exact (Gerencsér-Gyárfás), but $\\hat{R}(P_n) = \\Theta(n)$ has a factor-240 gap in the constant."
+      "summary": "Context propositions `beckSurprise` and `ramseyComparison` contrasting size vs ordinary Ramsey: $R(P_n) = 2n - 1$ is exact (Gerencs\u00e9r-Gy\u00e1rf\u00e1s), but $\\hat{R}(P_n) = \\Theta(n)$ has a factor-240 gap in the constant.",
+      "mathContext": "Context propositions `beckSurprise` and `ramseyComparison` contrasting size vs ordinary Ramsey: $R(P_n) = 2n - 1$ is exact (Gerencs\u00e9r-Gy\u00e1rf\u00e1s), but $\\hat{R}(P_n) = \\Theta(n)$ has a factor-240 gap in the constant."
     },
     {
       "id": "related-results",
       "title": "Related Results and Generalizations",
       "startLine": 213,
       "endLine": 234,
-      "summary": "Axiomatizes linear size Ramsey for bounded-degree trees (Friedman-Pippenger 1987). Notes connection to Problem #559 on bounded-degree graphs (Kohayakawa-Rödl-Schacht-Szemerédi). States that the exact constant in $\\hat{R}(P_n) = \\Theta(n)$ remains open.",
+      "summary": "Axiomatizes linear size Ramsey for bounded-degree trees (Friedman-Pippenger 1987). Notes connection to Problem #559 on bounded-degree graphs (Kohayakawa-R\u00f6dl-Schacht-Szemer\u00e9di). States that the exact constant in $\\hat{R}(P_n) = \\Theta(n)$ remains open.",
       "mathContext": "Axiomatizes linear size Ramsey for bounded-degree trees (Friedman-Pippenger 1987). States that the exact constant in $\\hat{R}(P_n) = \\Theta(n)$ remains open."
     },
     {
@@ -190,18 +190,18 @@
       "title": "Summary Theorems",
       "startLine": 235,
       "endLine": 257,
-      "summary": "Three proved results: `erdos_720` derives $\\hat{R}(P_n)/n^2 \\to 0 \\wedge \\hat{R}(C_n)/n^2 \\to 0$; `erdos_720_main` packages all three answers; `erdos_720_beck` proves `pathIsLinear ∧ cycleIsLinear` by combining upper and lower bound axioms via `obtain`.",
-      "mathContext": "Three proved results: `erdos_720` derives $\\hat{R}(P_n)/n^2 \\to 0 \\wedge \\hat{R}(C_n)/n^2 \\to 0$; `erdos_720_main` packages all three answers; `erdos_720_beck` proves `pathIsLinear ∧ cycleIsLinear` by combining upper and lower bound axioms via `obtain`."
+      "summary": "Three proved results: `erdos_720` derives $\\hat{R}(P_n)/n^2 \\to 0 \\wedge \\hat{R}(C_n)/n^2 \\to 0$; `erdos_720_main` packages all three answers; `erdos_720_beck` proves `pathIsLinear \u2227 cycleIsLinear` by combining upper and lower bound axioms via `obtain`.",
+      "mathContext": "Three proved results: `erdos_720` derives $\\hat{R}(P_n)/n^2 \\to 0 \\wedge \\hat{R}(C_n)/n^2 \\to 0$; `erdos_720_main` packages all three answers; `erdos_720_beck` proves `pathIsLinear \u2227 cycleIsLinear` by combining upper and lower bound axioms via `obtain`."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #720 is completely SOLVED. Beck (1983) proved both $\\hat{R}(P_n)$ and $\\hat{R}(C_n)$ are $\\Theta(n)$ — linear in $n$ — winning Erdős's $\\$100$ prize. This was far stronger than expected: the ratio $\\hat{R}(P_n)/n$ is bounded rather than divergent. The formalization captures the complete solution with 0 sorries: definitions, three questions as Filter.Tendsto propositions, Beck's bounds as axioms, matching lower bounds, and three summary theorems including `erdos_720_beck` proving the $\\Theta(n)$ characterization from axioms.",
-    "implications": "**Theoretical Significance**: **Connections and Significance**\n\n1. **Foundational for size Ramsey theory**: Beck's result established that sparse graphs (paths, cycles) can have sparse Ramsey hosts, launching a research program that culminated in the resolution of Problem #559 for all bounded-degree graphs\n**2. Probabilistic method showcase**: Beck's proof is a landmark application of the probabilistic method — random graphs with $O(n)$ edges have the Ramsey property via expansion\n3. **Generalization hierarchy**: Paths $\\to$ trees (Friedman-Pippenger 1987) $\\to$ bounded-degree graphs (KRSS 2011) — each step required fundamentally new techniques\n4. **Connection to Problem #76**: Both problems study monochromatic substructures under 2-colorings, but #720 asks about edges of the host while #76 asks about packing in the complete graph.",
+    "summary": "Erd\u0151s Problem #720 is completely SOLVED. Beck (1983) proved both $\\hat{R}(P_n)$ and $\\hat{R}(C_n)$ are $\\Theta(n)$ \u2014 linear in $n$ \u2014 winning Erd\u0151s's $\\$100$ prize. This was far stronger than expected: the ratio $\\hat{R}(P_n)/n$ is bounded rather than divergent. The formalization captures the complete solution with 0 sorries: definitions, three questions as Filter.Tendsto propositions, Beck's bounds as axioms, matching lower bounds, and three summary theorems including `erdos_720_beck` proving the $\\Theta(n)$ characterization from axioms.",
+    "implications": "**Theoretical Significance**: **Connections and Significance**\n\n1. **Foundational for size Ramsey theory**: Beck's result established that sparse graphs (paths, cycles) can have sparse Ramsey hosts, launching a research program that culminated in the resolution of Problem #559 for all bounded-degree graphs\n**2. Probabilistic method showcase**: Beck's proof is a landmark application of the probabilistic method \u2014 random graphs with $O(n)$ edges have the Ramsey property via expansion\n3. **Generalization hierarchy**: Paths $\\to$ trees (Friedman-Pippenger 1987) $\\to$ bounded-degree graphs (KRSS 2011) \u2014 each step required fundamentally new techniques\n4. **Connection to Problem #76**: Both problems study monochromatic substructures under 2-colorings, but #720 asks about edges of the host while #76 asks about packing in the complete graph.",
     "openQuestions": [
-      "Determine the exact constant $c$ in $\\hat{R}(P_n) \\sim cn$ — current bounds $3.75 \\le c \\le 900$ leave a factor-240 gap",
+      "Determine the exact constant $c$ in $\\hat{R}(P_n) \\sim cn$ \u2014 current bounds $3.75 \\le c \\le 900$ leave a factor-240 gap",
       "Is there a constructive (non-probabilistic) proof that $\\hat{R}(P_n) = O(n)$, or is randomness essential?",
-      "Improve the lower bound beyond $3.75n$ — this would require new coloring constructions of sparse graphs",
-      "Determine the size Ramsey number of the hypercube $Q_n$ — conjectured linear but known only to be polynomial"
+      "Improve the lower bound beyond $3.75n$ \u2014 this would require new coloring constructions of sparse graphs",
+      "Determine the size Ramsey number of the hypercube $Q_n$ \u2014 conjectured linear but known only to be polynomial"
     ]
   },
   "leanFile": {
@@ -227,37 +227,37 @@
   "references": [
     {
       "key": "EFRS1978",
-      "citation": "Erdős, P., Faudree, R.J., Rousseau, C.C., Schelp, R.H. (1978). The size Ramsey number. Periodica Mathematica Hungarica 9, 145–161.",
+      "citation": "Erd\u0151s, P., Faudree, R.J., Rousseau, C.C., Schelp, R.H. (1978). The size Ramsey number. Periodica Mathematica Hungarica 9, 145\u2013161.",
       "type": "paper"
     },
     {
       "key": "Be1983",
-      "citation": "Beck, J. (1983). On size Ramsey number of paths, trees, and circuits I. Journal of Graph Theory 7, 115–129.",
+      "citation": "Beck, J. (1983). On size Ramsey number of paths, trees, and circuits I. Journal of Graph Theory 7, 115\u2013129.",
       "type": "paper"
     },
     {
       "key": "DP2017",
-      "citation": "Dudek, A., Prałat, P. (2017). An alternative proof of the linearity of the size-Ramsey number of paths. Combinatorics, Probability and Computing 24, 551–555.",
+      "citation": "Dudek, A., Pra\u0142at, P. (2017). An alternative proof of the linearity of the size-Ramsey number of paths. Combinatorics, Probability and Computing 24, 551\u2013555.",
       "type": "paper"
     },
     {
       "key": "FP1987",
-      "citation": "Friedman, J., Pippenger, N. (1987). Expanding graphs contain all small trees. Combinatorica 7, 71–76.",
+      "citation": "Friedman, J., Pippenger, N. (1987). Expanding graphs contain all small trees. Combinatorica 7, 71\u201376.",
       "type": "paper"
     },
     {
       "key": "GG1967",
-      "citation": "Gerencsér, L., Gyárfás, A. (1967). On Ramsey-type problems. Annales Universitatis Scientiarum Budapestinensis 10, 167–170.",
+      "citation": "Gerencs\u00e9r, L., Gy\u00e1rf\u00e1s, A. (1967). On Ramsey-type problems. Annales Universitatis Scientiarum Budapestinensis 10, 167\u2013170.",
       "type": "paper"
     },
     {
       "key": "KRSS2011",
-      "citation": "Kohayakawa, Y., Rödl, V., Schacht, M., Szemerédi, E. (2011). Sparse partition universal graphs for graphs of bounded degree. Advances in Mathematics 226, 5041–5065.",
+      "citation": "Kohayakawa, Y., R\u00f6dl, V., Schacht, M., Szemer\u00e9di, E. (2011). Sparse partition universal graphs for graphs of bounded degree. Advances in Mathematics 226, 5041\u20135065.",
       "type": "paper"
     },
     {
       "key": "ErdosProblems",
-      "citation": "Erdős Problems. Problem #720.",
+      "citation": "Erd\u0151s Problems. Problem #720.",
       "type": "website"
     }
   ],

--- a/src/data/proofs/erdos-734/meta.json
+++ b/src/data/proofs/erdos-734/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-734",
-  "title": "Erdős Problem #734: Pairwise Balanced Block Designs with Bounded Frequencies",
+  "title": "Erd\u0151s Problem #734: Pairwise Balanced Block Designs with Bounded Frequencies",
   "slug": "erdos-734",
-  "description": "Find a non-trivial PBD where all block sizes have O(n^{1/2}) frequency. OPEN. de Bruijn-Erdős (1948) implies some size must have high frequency on average.",
+  "description": "Find a non-trivial PBD where all block sizes have O(n^{1/2}) frequency. OPEN. de Bruijn-Erd\u0151s (1948) implies some size must have high frequency on average.",
   "meta": {
-    "author": "de Bruijn-Erdős (1948 lower bound), Erdős (1981 problem)",
+    "author": "de Bruijn-Erd\u0151s (1948 lower bound), Erd\u0151s (1981 problem)",
     "sourceUrl": "https://erdosproblems.com/734",
     "date": "1981",
     "status": "axiomatized",
@@ -54,25 +54,25 @@
       "blockSizesPresent: image of block cardinalities",
       "hasSquareRootBound: the O(n^{1/2}) frequency condition",
       "erdos734Question: formal statement of the open problem",
-      "deBruijn_erdos: m ≥ n axiom for non-trivial PBDs",
+      "deBruijn_erdos: m \u2265 n axiom for non-trivial PBDs",
       "pair_count: pair counting identity (axiomatized)",
-      "erdos_734_summary: combining de Bruijn-Erdős and projective plane existence"
+      "erdos_734_summary: combining de Bruijn-Erd\u0151s and projective plane existence"
     ],
     "axiomCount": 2,
     "lineCount": 206,
-    "assumptions": "6 axioms: deBruijn_erdos, some_size_frequent, projective_plane_exists, and 3 more. See Lean source for complete statements."
+    "assumptions": "2 axioms: deBruijn_erdos, projective_plane_exists. 0 sorries."
   },
   "overview": {
-    "historicalContext": "Erdős posed Problem #734 in his 1981 paper 'On the combinatorial problems which I would most like to see solved.' He asked whether, for all large n, there exists a non-trivial pairwise balanced block design (PBD) on n points where every block size t appears in at most O(n^{1/2}) blocks. Erdős wrote that this would 'probably not be very difficult to prove' but admitted he had been unsuccessful.\n\nThe foundational result for this problem is the de Bruijn-Erdős theorem (1948), which states that any non-trivial PBD on n points has at least n blocks. By a pigeonhole argument, since block sizes range from 2 to n, at least one size must appear with frequency proportional to √n. The question is whether ALL sizes can be kept at this threshold simultaneously.\n\nClassical constructions like projective and affine planes fail the frequency condition because they have uniform block size — all blocks are the same size, concentrating frequency in a single value. No construction achieving the O(√n) bound for all sizes is known, and the problem remains open. It connects to broader questions in combinatorial design theory about how block sizes can be distributed in balanced structures.",
-    "problemStatement": "**Problem Statement (Open)**\n\nFind, for all large n, a non-trivial pairwise balanced block design A₁,...,Aₘ ⊆ {1,...,n} such that for all t, there are O(n^{1/2}) many blocks of size t.\n\n**Status: OPEN**\n\nKnown constructions (projective and affine planes) have uniform block size, which fails this criterion.",
-    "text": "Find a non-trivial PBD where all block sizes have O(n^{1/2}) frequency. OPEN. de Bruijn-Erdős (1948) implies some size must have high frequency on average.",
-    "proofStrategy": "The formalization defines PBD as a structure with pair coverage and non-emptiness, along with block size counting and the O(√n) frequency condition. The de Bruijn-Erdős lower bound and projective/affine plane existence are axiomatized. The pair counting identity is axiomatized. The summary theorem combines de Bruijn-Erdős with projective plane existence, with no trivial placeholders.",
+    "historicalContext": "Erd\u0151s posed Problem #734 in his 1981 paper 'On the combinatorial problems which I would most like to see solved.' He asked whether, for all large n, there exists a non-trivial pairwise balanced block design (PBD) on n points where every block size t appears in at most O(n^{1/2}) blocks. Erd\u0151s wrote that this would 'probably not be very difficult to prove' but admitted he had been unsuccessful.\n\nThe foundational result for this problem is the de Bruijn-Erd\u0151s theorem (1948), which states that any non-trivial PBD on n points has at least n blocks. By a pigeonhole argument, since block sizes range from 2 to n, at least one size must appear with frequency proportional to \u221an. The question is whether ALL sizes can be kept at this threshold simultaneously.\n\nClassical constructions like projective and affine planes fail the frequency condition because they have uniform block size \u2014 all blocks are the same size, concentrating frequency in a single value. No construction achieving the O(\u221an) bound for all sizes is known, and the problem remains open. It connects to broader questions in combinatorial design theory about how block sizes can be distributed in balanced structures.",
+    "problemStatement": "**Problem Statement (Open)**\n\nFind, for all large n, a non-trivial pairwise balanced block design A\u2081,...,A\u2098 \u2286 {1,...,n} such that for all t, there are O(n^{1/2}) many blocks of size t.\n\n**Status: OPEN**\n\nKnown constructions (projective and affine planes) have uniform block size, which fails this criterion.",
+    "text": "Find a non-trivial PBD where all block sizes have O(n^{1/2}) frequency. OPEN. de Bruijn-Erd\u0151s (1948) implies some size must have high frequency on average.",
+    "proofStrategy": "The formalization defines PBD as a structure with pair coverage and non-emptiness, along with block size counting and the O(\u221an) frequency condition. The de Bruijn-Erd\u0151s lower bound and projective/affine plane existence are axiomatized. The pair counting identity is axiomatized. The summary theorem combines de Bruijn-Erd\u0151s with projective plane existence, with no trivial placeholders.",
     "keyInsights": [
-      "**de Bruijn-Erdős Bound:** Any non-trivial PBD on n points has at least n blocks",
-      "**Pigeonhole Consequence:** With ≥ n blocks and ≤ n-1 possible sizes, some size must have multiple blocks",
-      "**Classical Constructions Fail:** Projective planes have uniform block size, giving one size with ≫ √n blocks",
+      "**de Bruijn-Erd\u0151s Bound:** Any non-trivial PBD on n points has at least n blocks",
+      "**Pigeonhole Consequence:** With \u2265 n blocks and \u2264 n-1 possible sizes, some size must have multiple blocks",
+      "**Classical Constructions Fail:** Projective planes have uniform block size, giving one size with \u226b \u221an blocks",
       "**Spreading Challenge:** Need to find designs where sizes are spread out evenly",
-      "**Erdős's Expectation:** He thought this would be 'not very difficult' yet remained unsolved"
+      "**Erd\u0151s's Expectation:** He thought this would be 'not very difficult' yet remained unsolved"
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -98,7 +98,7 @@
     },
     {
       "id": "de-bruijn-erdos",
-      "title": "de Bruijn-Erdős Theorem",
+      "title": "de Bruijn-Erd\u0151s Theorem",
       "summary": "deBruijn_erdos and some_size_frequent axioms",
       "startLine": 98,
       "endLine": 119,
@@ -106,7 +106,7 @@
     },
     {
       "id": "erdos-question",
-      "title": "The Erdős Question",
+      "title": "The Erd\u0151s Question",
       "summary": "hasSquareRootBound, erdos734Question definitions",
       "startLine": 120,
       "endLine": 139,
@@ -139,14 +139,14 @@
     {
       "id": "summary",
       "title": "Summary",
-      "summary": "erdos_734_summary combining de Bruijn-Erdős and projective planes",
+      "summary": "erdos_734_summary combining de Bruijn-Erd\u0151s and projective planes",
       "startLine": 191,
       "endLine": 206,
-      "mathContext": "Mathematical content: erdos_734_summary combining de Bruijn-Erdős and projective planes"
+      "mathContext": "Mathematical content: erdos_734_summary combining de Bruijn-Erd\u0151s and projective planes"
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #734 asks whether there exist non-trivial pairwise balanced block designs where every block size appears in O(n^{1/2}) blocks. The problem remains OPEN. de Bruijn-Erdős (1948) showed m ≥ n for any PBD, implying some averaging constraint, but no construction achieving the bound is known. Classical constructions like projective planes fail because they have uniform block size.",
+    "summary": "Erd\u0151s Problem #734 asks whether there exist non-trivial pairwise balanced block designs where every block size appears in O(n^{1/2}) blocks. The problem remains OPEN. de Bruijn-Erd\u0151s (1948) showed m \u2265 n for any PBD, implying some averaging constraint, but no construction achieving the bound is known. Classical constructions like projective planes fail because they have uniform block size.",
     "implications": "Resolution would advance combinatorial design theory by showing whether block sizes can be distributed uniformly in balanced structures. New construction techniques beyond classical designs would likely be needed.",
     "openQuestions": [
       "Does such a PBD exist for ANY n > 2?",
@@ -180,17 +180,17 @@
     {
       "targetId": "erdos-665",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: block-designs, combinatorics, design-theory, open"
+      "description": "Related Erd\u0151s problem sharing themes: block-designs, combinatorics, design-theory, open"
     },
     {
       "targetId": "erdos-722",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: block-designs, combinatorics, design-theory"
+      "description": "Related Erd\u0151s problem sharing themes: block-designs, combinatorics, design-theory"
     },
     {
       "targetId": "erdos-1014",
       "relationship": "related",
-      "description": "Related Erdős problem sharing themes: combinatorics, open"
+      "description": "Related Erd\u0151s problem sharing themes: combinatorics, open"
     }
   ]
 }


### PR DESCRIPTION
## Fix

Corrects stale `assumptions` text in 10 gallery proof `meta.json` files.

## Changes

| Proof | Old count | New count |
|-------|-----------|-----------|
| erdos-734 | 6 | 2 |
| erdos-720 | 12 | 8 |
| erdos-72 | 5 | 1 |
| erdos-713 | 6 | 2 |
| erdos-710 | 7 | 3 |
| erdos-695 | 5 | 1 |
| erdos-692 | 7 | 3 |
| erdos-676 | 5 | 1 |
| erdos-669 | 5 | 1 |
| erdos-666 | 5 | 1 |

---
Automated fix by lean-mechanic agent.