### PR TITLE
Enrich: Hall's Theorem, Vandermonde, Kummer Multinomial, König Cofinality

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -13780,7 +13780,9 @@
       "path": "fast",
       "started": "2026-04-05T12:05:44.541Z",
       "status": "active",
-      "lastUpdate": "2026-04-05T17:20:37.384Z"
+      "lastUpdate": "2026-04-05T21:00:00.000Z",
+      "seeker_selected": "2026-04-05T21:00:00.000Z",
+      "selection_rationale": "Highest composite score (78): EMPTY knowledge, tractability 7, significance 8. Three concrete axioms with clear Mathlib paths."
     },
     {
       "slug": "taylor-theorem-oq-03-oq-01",
@@ -14610,11 +14612,11 @@
     },
     {
       "slug": "inclusion-exclusion-oq-02",
-      "phase": "NEW",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-04-05T17:20:37.366Z",
       "status": "active",
-      "lastUpdate": "2026-04-05T17:20:37.366Z"
+      "lastUpdate": "2026-04-05T21:36:08.623Z"
     },
     {
       "slug": "inverse-galois-oq-03",
@@ -14868,11 +14870,11 @@
     },
     {
       "slug": "brouwer-fixed-point-oq-01-oq-01",
-      "phase": "NEW",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-04-05T20:58:27.566Z",
       "status": "active",
-      "lastUpdate": "2026-04-05T20:58:27.566Z"
+      "lastUpdate": "2026-04-05T21:36:08.624Z"
     },
     {
       "slug": "cantor-diagonalization-oq-01-oq-01-oq-03",

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03/annotations.json
@@ -72,6 +72,18 @@
     "prerequisites": ["generating functions", "formal power series", "finite difference calculus"]
   },
   {
+    "id": "ann-theorem-statement",
+    "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03",
+    "range": { "startLine": 48, "endLine": 62 },
+    "type": "definition",
+    "title": "Theorem Statement: Falling Factorial Vandermonde",
+    "content": "The theorem `vandermonde_descFactorial` formalizes $(m+n)^{\\underline{r}} = \\sum_{j=0}^{r} \\binom{r}{j} m^{\\underline{j}} n^{\\underline{r-j}}$ for all natural numbers $m, n, r$. The Lean statement uses `Nat.descFactorial` for the falling factorial and `Finset.range (r+1)` for the summation index $j \\in \\{0, \\ldots, r\\}$. Note the Lean sum is `∑ j ∈ Finset.range (r + 1)` rather than `∑ j ∈ Finset.range r` because `Finset.range n = {0, ..., n-1}`, so we need `r+1` to include $j = r$. The docstring (lines 52-58) documents the three-step proof strategy: convert via `descFactorial_eq_factorial_mul_choose`, apply `vandermonde_range`, verify terms via `term_eq`.",
+    "mathContext": "$(m+n)^{\\underline{r}} = \\sum_{j=0}^{r} \\binom{r}{j} \\cdot m^{\\underline{j}} \\cdot n^{\\underline{r-j}}$ for all $m, n, r \\in \\mathbb{N}$",
+    "significance": "key",
+    "relatedConcepts": ["Nat.descFactorial", "Finset.range", "theorem statement", "falling factorial"],
+    "prerequisites": ["falling factorials", "Finset.sum", "Lean 4 theorem syntax"]
+  },
+  {
     "id": "ann-simp-rw-vs-rw",
     "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03",
     "range": { "startLine": 64, "endLine": 64 },

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03/meta.json
@@ -121,6 +121,16 @@
       "targetId": "combinations-formula",
       "relationship": "related",
       "description": "Formula for C(n,k) — foundational identity underlying the descFactorial-choose conversion"
+    },
+    {
+      "targetId": "arithmetic-series-oq-02-oq-04",
+      "relationship": "related",
+      "description": "Rising factorial identity S_k(n)·k! = (n+1)^{\\overline{k}} — the ascending factorial dual of descFactorial = k!·C(n,k)"
+    },
+    {
+      "targetId": "arithmetic-series-oq-02-oq-02",
+      "relationship": "related",
+      "description": "2D hockey stick via Vandermonde convolution — applies the same Vandermonde summation to simplicial number products"
     }
   ],
   "sections": [

--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "cantor-diagonalization-oq-01-oq-01-oq-02",
-  "title": "K\u00f6nig's Constraint from Mathlib's Cofinality API",
+  "title": "König's Constraint from Mathlib's Cofinality API",
   "slug": "cantor-diagonalization-oq-01-oq-01-oq-02",
-  "description": "Proves K\u00f6nig's cofinality constraint (cf(2^\u2135\u2080) > \u2135\u2080) directly from Mathlib's Cardinal.lt_cof_power. Shows which alephs are excluded as possible values for the continuum (\u2135_\u03c9, etc.) and which are permitted (all successor alephs).",
+  "description": "Proves König's cofinality constraint (cf(2^ℵ₀) > ℵ₀) directly from Mathlib's Cardinal.lt_cof_power. Shows which alephs are excluded as possible values for the continuum (ℵ_ω, etc.) and which are permitted (all successor alephs).",
   "leanFile": {
     "path": "Proofs/CantorDiagonalizationOQ01OQ01OQ02.lean",
     "imports": [
@@ -14,15 +14,18 @@
       "Proofs.ContinuumHypothesis"
     ],
     "opens": [
-      "Cardinal"
+      "Cardinal",
+      "ContinuumHypothesis"
     ],
     "namespace": "CantorDiagOQ01OQ01OQ02",
     "lineCount": 255,
     "axiomCount": 0,
-    "sorries": 0
+    "sorries": 0,
+    "theoremCount": 15,
+    "definitionCount": 0
   },
   "meta": {
-    "author": "K\u00f6nig (1905), Easton (1970)",
+    "author": "König (1905), Easton (1970)",
     "sourceUrl": "https://en.wikipedia.org/wiki/K%C3%B6nig%27s_theorem_(set_theory)",
     "date": "1905",
     "status": "verified",
@@ -42,12 +45,12 @@
     "mathlibDependencies": [
       {
         "theorem": "Cardinal.lt_cof_power",
-        "description": "K\u00f6nig's theorem: cf(\u03ba^\u03bb) > \u03bb for infinite \u03bb and \u03ba > 1",
+        "description": "König's theorem: cf(κ^λ) > λ for infinite λ and κ > 1",
         "module": "Mathlib.SetTheory.Cardinal.Cofinality"
       },
       {
         "theorem": "Cardinal.cof_aleph",
-        "description": "Cofinality of limit alephs (e.g., cf(\u2135_\u03c9) = \u03c9)",
+        "description": "Cofinality of limit alephs (e.g., cf(ℵ_ω) = ω)",
         "module": "Mathlib.SetTheory.Cardinal.Cofinality"
       },
       {
@@ -57,43 +60,43 @@
       },
       {
         "theorem": "Cardinal.isRegular_aleph_one",
-        "description": "\u2135\u2081 is regular",
+        "description": "ℵ₁ is regular",
         "module": "Mathlib.SetTheory.Cardinal.Cofinality"
       }
     ],
     "originalContributions": [
-      "konig_cofinality: cf(2^\u2135\u2080) > \u2135\u2080 proved from Cardinal.lt_cof_power",
-      "konig_general: cf(\u03ba^\u2135\u2080) > \u2135\u2080 for any \u03ba > 1",
-      "continuum_ne_aleph_omega: 2^\u2135\u2080 \u2260 \u2135_\u03c9 from K\u00f6nig + cofinality computation",
-      "continuum_ne_singular: 2^\u2135\u2080 cannot equal any cardinal with cf \u2264 \u2135\u2080",
-      "regular_satisfies_konig: all regular uncountable cardinals satisfy K\u00f6nig",
-      "aleph_succ_satisfies_konig: every \u2135_{\u03b1+1} satisfies K\u00f6nig",
-      "zfc_constraints_on_continuum: complete 2-part constraint (Cantor + K\u00f6nig)",
-      "smallest_excluded_is_aleph_omega: \u2135_\u03c9 is first excluded value"
+      "konig_cofinality: cf(2^ℵ₀) > ℵ₀ proved from Cardinal.lt_cof_power",
+      "konig_general: cf(κ^ℵ₀) > ℵ₀ for any κ > 1",
+      "continuum_ne_aleph_omega: 2^ℵ₀ ≠ ℵ_ω from König + cofinality computation",
+      "continuum_ne_singular: 2^ℵ₀ cannot equal any cardinal with cf ≤ ℵ₀",
+      "regular_satisfies_konig: all regular uncountable cardinals satisfy König",
+      "aleph_succ_satisfies_konig: every ℵ_{α+1} satisfies König",
+      "zfc_constraints_on_continuum: complete 2-part constraint (Cantor + König)",
+      "smallest_excluded_is_aleph_omega: ℵ_ω is first excluded value"
     ],
     "axiomCount": 0,
     "lineCount": 255,
     "assumptions": "0 axioms, 0 sorries. Core result (konig_cofinality) derived from Mathlib's Cardinal.lt_cof_power. All other results built on Mathlib cofinality API."
   },
   "overview": {
-    "historicalContext": "**K\u00f6nig's Theorem and the Continuum Problem**\n\n- **1905**: Julius K\u00f6nig proved his inequality on sums and products of cardinals\n- **1940-1963**: G\u00f6del and Cohen showed CH is independent of ZFC\n- **1970**: Easton proved K\u00f6nig's constraint is the ONLY ZFC constraint on 2^\u2135\u2080\n- **Present**: Mathlib formalizes K\u00f6nig's theorem as Cardinal.lt_cof_power\n\nK\u00f6nig's constraint is the strongest thing ZFC can say about the size of the continuum beyond Cantor's basic bound \u2135\u2081 \u2264 2^\u2135\u2080.",
-    "problemStatement": "**Question**: Can K\u00f6nig's cofinality constraint \u2014 cf(2^\u2135\u2080) > \u2135\u2080 \u2014 be proved from Mathlib's cofinality API?\n\n**Answer**: Yes. `Cardinal.lt_cof_power` from `Mathlib.SetTheory.Cardinal.Cofinality` directly proves cf(\u03ba^\u03bb) > \u03bb for infinite \u03bb and \u03ba > 1. Setting \u03ba = 2, \u03bb = \u2135\u2080 gives the result immediately.",
-    "proofStrategy": "1. Apply Cardinal.lt_cof_power with \u03ba=2, \u03bb=\u2135\u2080 to get cf(2^\u2135\u2080) > \u2135\u2080\n2. Compute cf(\u2135_\u03c9) = \u2135\u2080 via Cardinal.cof_aleph to show 2^\u2135\u2080 \u2260 \u2135_\u03c9\n3. Show all successor alephs are regular via Cardinal.isRegular_aleph_succ\n4. Classify: regular uncountable cardinals satisfy K\u00f6nig, singular ones don't",
+    "historicalContext": "**König's Theorem and the Continuum Problem**\n\n- **1905**: Julius König proved his inequality on sums and products of cardinals\n- **1940-1963**: Gödel and Cohen showed CH is independent of ZFC\n- **1970**: Easton proved König's constraint is the ONLY ZFC constraint on 2^ℵ₀\n- **Present**: Mathlib formalizes König's theorem as Cardinal.lt_cof_power\n\nKönig's constraint is the strongest thing ZFC can say about the size of the continuum beyond Cantor's basic bound ℵ₁ ≤ 2^ℵ₀.",
+    "problemStatement": "**Question**: Can König's cofinality constraint — cf(2^ℵ₀) > ℵ₀ — be proved from Mathlib's cofinality API?\n\n**Answer**: Yes. `Cardinal.lt_cof_power` from `Mathlib.SetTheory.Cardinal.Cofinality` directly proves cf(κ^λ) > λ for infinite λ and κ > 1. Setting κ = 2, λ = ℵ₀ gives the result immediately.",
+    "proofStrategy": "1. Apply Cardinal.lt_cof_power with κ=2, λ=ℵ₀ to get cf(2^ℵ₀) > ℵ₀\n2. Compute cf(ℵ_ω) = ℵ₀ via Cardinal.cof_aleph to show 2^ℵ₀ ≠ ℵ_ω\n3. Show all successor alephs are regular via Cardinal.isRegular_aleph_succ\n4. Classify: regular uncountable cardinals satisfy König, singular ones don't",
     "keyInsights": [
       "**One line of Mathlib suffices**: `Cardinal.lt_cof_power le_rfl (by norm_num)` proves the core constraint. What was axiomatized in the parent file is a direct Mathlib theorem.",
-      "**K\u00f6nig partitions the alephs**: Among infinite cardinals, K\u00f6nig divides them into permitted (regular: \u2135\u2081, \u2135\u2082, ..., \u2135_{\u03c9\u2081}, ...) and excluded (singular of countable cofinality: \u2135_\u03c9, \u2135_{\u03c9\u00b72}, \u2135_{\u03c9\u00b2}, ...).",
-      "**Easton completes the picture**: K\u00f6nig is necessary AND sufficient. Every regular uncountable cardinal is consistently the value of 2^\u2135\u2080 (Easton 1970). So the complete answer is: 2^\u2135\u2080 \u2208 {\u2135_\u03b1 : cf(\u2135_\u03b1) > \u2135\u2080}.",
-      "**\u2135_\u03c9 is the first gap**: The sequence \u2135\u2081, \u2135\u2082, \u2135\u2083, ... are all permitted. \u2135_\u03c9 is the first excluded value. This makes \u03c9 a natural dividing line.",
-      "**General K\u00f6nig is uniform**: The proof works for any \u03ba^\u2135\u2080 with \u03ba > 1, not just 2^\u2135\u2080. The cofinality constraint is intrinsic to cardinal exponentiation."
+      "**König partitions the alephs**: Among infinite cardinals, König divides them into permitted (regular: ℵ₁, ℵ₂, ..., ℵ_{ω₁}, ...) and excluded (singular of countable cofinality: ℵ_ω, ℵ_{ω·2}, ℵ_{ω²}, ...).",
+      "**Easton completes the picture**: König is necessary AND sufficient. Every regular uncountable cardinal is consistently the value of 2^ℵ₀ (Easton 1970). So the complete answer is: 2^ℵ₀ ∈ {ℵ_α : cf(ℵ_α) > ℵ₀}.",
+      "**ℵ_ω is the first gap**: The sequence ℵ₁, ℵ₂, ℵ₃, ... are all permitted. ℵ_ω is the first excluded value. This makes ω a natural dividing line.",
+      "**General König is uniform**: The proof works for any κ^ℵ₀ with κ > 1, not just 2^ℵ₀. The cofinality constraint is intrinsic to cardinal exponentiation."
     ],
     "prerequisites": [
       "Cardinal arithmetic (aleph hierarchy)",
       "Cofinality (regular vs singular cardinals)",
-      "Cantor's theorem (\u2135\u2080 < 2^\u2135\u2080)",
+      "Cantor's theorem (ℵ₀ < 2^ℵ₀)",
       "Successor cardinals and limit cardinals"
     ],
     "furtherWork": [
-      "Formalize Easton's theorem (requires forcing): every regular uncountable cardinal is consistently 2^\u2135\u2080",
+      "Formalize Easton's theorem (requires forcing): every regular uncountable cardinal is consistently 2^ℵ₀",
       "Extend König's constraint to the generalized continuum function 2^κ for arbitrary infinite κ",
       "Formalize Shelah's pcf theory for tighter bounds on singular cardinal arithmetic"
     ]
@@ -104,55 +107,63 @@
       "title": "Module Header and Imports",
       "startLine": 1,
       "endLine": 47,
-      "summary": "Imports Mathlib's Cardinal, Ordinal, Cofinality, and SuccPred modules plus the local ContinuumHypothesis file. The docstring frames the open question: can K\u00f6nig's constraint (cf(2^\u2135\u2080) > \u2135\u2080) be proved directly from Mathlib's cofinality API? Introduces the K\u00f6nig-Easton framework for constraining the continuum.",
-      "mathContext": "K\u00f6nig's constraint: $\\text{cf}(2^{\\aleph_0}) > \\aleph_0$. Combined with Easton's theorem (1970): the permitted values for $2^{\\aleph_0}$ are exactly the regular uncountable cardinals $\\geq \\aleph_1$."
+      "summary": "Imports Mathlib's Cardinal, Ordinal, Cofinality, and SuccPred modules plus the local ContinuumHypothesis file. The docstring frames the open question: can König's constraint (cf(2^ℵ₀) > ℵ₀) be proved directly from Mathlib's cofinality API? Introduces the König-Easton framework for constraining the continuum.",
+      "mathContext": "König's constraint: $\\text{cf}(2^{\\aleph_0}) > \\aleph_0$. Combined with Easton's theorem (1970): the permitted values for $2^{\\aleph_0}$ are exactly the regular uncountable cardinals $\\geq \\aleph_1$."
     },
     {
       "id": "konig-constraint",
-      "title": "K\u00f6nig's Cofinality Constraint",
+      "title": "König's Cofinality Constraint",
       "startLine": 48,
-      "endLine": 67,
-      "summary": "Proves cf(2^\u2135\u2080) > \u2135\u2080 from Mathlib's `Cardinal.lt_cof_power` and generalizes to cf(\u03ba^\u2135\u2080) > \u2135\u2080 for any \u03ba > 1.",
-      "mathContext": "K\u00f6nig's theorem (1905) on cardinal products: $\\sum_i \\kappa_i < \\prod_i \\lambda_i$ when $\\kappa_i < \\lambda_i$. The cofinality version says $\\text{cf}(\\kappa^\\lambda) > \\lambda$ for infinite $\\lambda$, $\\kappa > 1$."
+      "endLine": 75,
+      "summary": "Proves cf(2^ℵ₀) > ℵ₀ from Mathlib’s Cardinal.lt_cof_power (konig_cofinality, lines 67–69) and generalizes to cf(κ^ℵ₀) > ℵ₀ for any κ > 1 (konig_general, lines 73–75). Both are one-line proofs delegating directly to Mathlib.",
+      "mathContext": "König's theorem (1905) on cardinal products: $\\sum_i \\kappa_i < \\prod_i \\lambda_i$ when $\\kappa_i < \\lambda_i$. The cofinality version says $\\text{cf}(\\kappa^\\lambda) > \\lambda$ for infinite $\\lambda$, $\\kappa > 1$."
     },
     {
       "id": "cofinality-computations",
       "title": "Cofinality of Specific Alephs",
-      "startLine": 73,
-      "endLine": 116,
-      "summary": "Computes cofinalities using Mathlib: \u2135\u2081, \u2135\u2082 are regular (successor alephs always are), \u2135_\u03c9 is singular with cf = \u2135\u2080.",
+      "startLine": 77,
+      "endLine": 117,
+      "summary": "Computes cofinalities using Mathlib: ℵ₁, ℵ₂ are regular (successor alephs always are), ℵ_ω is singular with cf = ℵ₀. Also proves aleph_omega_not_regular (lines 109–117) as a direct consequence.",
       "mathContext": "A cardinal $\\kappa$ is **regular** if $\\text{cf}(\\kappa) = \\kappa$, **singular** otherwise. All successor alephs $\\aleph_{\\alpha+1}$ are regular. The first singular aleph is $\\aleph_\\omega = \\sup_n \\aleph_n$."
     },
     {
       "id": "excluded-values",
-      "title": "Excluded Values for 2^\u2135\u2080",
-      "startLine": 122,
-      "endLine": 146,
-      "summary": "Proves 2^\u2135\u2080 \u2260 \u2135_\u03c9 and more generally 2^\u2135\u2080 \u2260 any cardinal with cf \u2264 \u2135\u2080.",
-      "mathContext": "If $2^{\\aleph_0} = \\kappa$ and $\\text{cf}(\\kappa) \\leq \\aleph_0$, then $\\text{cf}(2^{\\aleph_0}) \\leq \\aleph_0$, contradicting K\u00f6nig. So singular cardinals of countable cofinality are excluded."
+      "title": "Excluded Values for 2^ℵ₀",
+      "startLine": 119,
+      "endLine": 148,
+      "summary": "Proves 2^ℵ₀ ≠ ℵ_ω and more generally 2^ℵ₀ ≠ any cardinal with cf ≤ ℵ₀.",
+      "mathContext": "If $2^{\\aleph_0} = \\kappa$ and $\\text{cf}(\\kappa) \\leq \\aleph_0$, then $\\text{cf}(2^{\\aleph_0}) \\leq \\aleph_0$, contradicting König. So singular cardinals of countable cofinality are excluded."
     },
     {
       "id": "permitted-values",
-      "title": "Permitted Values for 2^\u2135\u2080",
-      "startLine": 152,
-      "endLine": 195,
-      "summary": "Shows every regular uncountable cardinal satisfies K\u00f6nig. All successor alephs \u2135_{\u03b1+1} are permitted, with \u2135\u2081 (CH) and \u2135\u2082 (PFA) as specific examples.",
-      "mathContext": "Easton (1970): for any regular $\\kappa \\geq \\aleph_1$, $\\text{Con}(\\text{ZFC}) \\to \\text{Con}(\\text{ZFC} + 2^{\\aleph_0} = \\kappa)$. So K\u00f6nig's constraint is necessary AND sufficient."
+      "title": "Permitted Values for 2^ℵ₀",
+      "startLine": 149,
+      "endLine": 193,
+      "summary": "Shows every regular uncountable cardinal satisfies König. All successor alephs ℵ_{α+1} are permitted, with ℵ₁ (CH) and ℵ₂ (PFA) as specific examples.",
+      "mathContext": "Easton (1970): for any regular $\\kappa \\geq \\aleph_1$, $\\text{Con}(\\text{ZFC}) \\to \\text{Con}(\\text{ZFC} + 2^{\\aleph_0} = \\kappa)$. So König's constraint is necessary AND sufficient."
     },
     {
       "id": "complete-picture",
       "title": "The Complete Picture",
-      "startLine": 201,
-      "endLine": 232,
-      "summary": "Combines Cantor's lower bound (\u2135\u2081 \u2264 2^\u2135\u2080) with K\u00f6nig's constraint (cf(2^\u2135\u2080) > \u2135\u2080) as the complete set of ZFC constraints. Shows \u2135_\u03c9 is the first excluded value.",
-      "mathContext": "The complete ZFC-provable information about $2^{\\aleph_0}$: (1) $\\aleph_1 \\leq 2^{\\aleph_0}$ (Cantor), (2) $\\text{cf}(2^{\\aleph_0}) > \\aleph_0$ (K\u00f6nig). These are the ONLY constraints (Easton)."
+      "startLine": 194,
+      "endLine": 241,
+      "summary": "Combines Cantor's lower bound (ℵ₁ ≤ 2^ℵ₀) with König's constraint (cf(2^ℵ₀) > ℵ₀) as the complete set of ZFC constraints. Shows ℵ_ω is the first excluded value.",
+      "mathContext": "The complete ZFC-provable information about $2^{\\aleph_0}$: (1) $\\aleph_1 \\leq 2^{\\aleph_0}$ (Cantor), (2) $\\text{cf}(2^{\\aleph_0}) > \\aleph_0$ (König). These are the ONLY constraints (Easton)."
+    },
+    {
+      "id": "verification",
+      "title": "Type Verification",
+      "startLine": 242,
+      "endLine": 255,
+      "summary": "#check commands verify the types of all key theorems (konig_cofinality, konig_general, continuum_ne_aleph_omega, continuum_ne_singular, regular_satisfies_konig, zfc_constraints_on_continuum, smallest_excluded_is_aleph_omega). Closes the CantorDiagOQ01OQ01OQ02 namespace.",
+      "mathContext": "Lean 4 #check outputs the type signature of each theorem, confirming the formalization matches the intended mathematical statements."
     }
   ],
   "crossReferences": [
     {
       "targetId": "cantor-diagonalization-oq-01-oq-01",
       "relationship": "answers",
-      "description": "Directly answers OQ-02 from the parent: K\u00f6nig's constraint CAN be proved from Mathlib's cofinality API, eliminating the axiom."
+      "description": "Directly answers OQ-02 from the parent: König's constraint CAN be proved from Mathlib's cofinality API, eliminating the axiom."
     },
     {
       "targetId": "cantor-diagonalization-oq-01",
@@ -162,26 +173,26 @@
     {
       "targetId": "cantor-diagonalization",
       "relationship": "foundational",
-      "description": "Cantor's diagonal argument proves \u2135\u2080 < 2^\u2135\u2080. K\u00f6nig's constraint is the next step: which values > \u2135\u2080 are possible?"
+      "description": "Cantor's diagonal argument proves ℵ₀ < 2^ℵ₀. König's constraint is the next step: which values > ℵ₀ are possible?"
     },
     {
       "targetId": "continuum-hypothesis",
       "relationship": "related",
-      "description": "The continuum hypothesis asserts 2^\u2135\u2080 = \u2135\u2081. K\u00f6nig's constraint shows this is the minimal permitted value."
+      "description": "The continuum hypothesis asserts 2^ℵ₀ = ℵ₁. König's constraint shows this is the minimal permitted value."
     }
   ],
   "conclusion": {
-    "summary": "K\u00f6nig's cofinality constraint is proved from Mathlib with 0 axioms: Cardinal.lt_cof_power directly yields cf(2^\u2135\u2080) > \u2135\u2080. This rules out \u2135_\u03c9 and all singular cardinals of countable cofinality. All successor alephs (\u2135\u2081, \u2135\u2082, ...) satisfy K\u00f6nig and are consistent values for 2^\u2135\u2080 by Easton's theorem.",
+    "summary": "König's cofinality constraint is proved from Mathlib with 0 axioms: Cardinal.lt_cof_power directly yields cf(2^ℵ₀) > ℵ₀. This rules out ℵ_ω and all singular cardinals of countable cofinality. All successor alephs (ℵ₁, ℵ₂, ...) satisfy König and are consistent values for 2^ℵ₀ by Easton's theorem.",
     "implications": "The parent file's KonigConstraint definition can now be proved as a theorem, not stated as an axiom. This eliminates one of the axiomatic assumptions in the CH independence formalization chain.",
     "openQuestions": [
       "Can Shelah's pcf theory constraints on singular cardinal arithmetic be formalized in Lean?",
-      "What happens at higher levels: can cf(2^{\u2135_\u03b1}) > \u2135_\u03b1 be uniformly proved for all \u03b1?",
+      "What happens at higher levels: can cf(2^{ℵ_α}) > ℵ_α be uniformly proved for all α?",
       "Can the permitted/excluded classification be extended to inaccessible and Mahlo cardinals, and what forcing axioms (PFA, MM) pin down the continuum to specific values?"
     ]
   },
   "references": [
     {
-      "authors": "K\u00f6nig, Julius",
+      "authors": "König, Julius",
       "title": "Zum Kontinuumproblem",
       "year": "1905",
       "venue": "Mathematische Annalen 60, 177-180"
@@ -197,20 +208,20 @@
     {
       "name": "konig_cofinality",
       "type": "core",
-      "description": "K\u00f6nig's constraint: cf(2^\u2135\u2080) > \u2135\u2080",
-      "leanType": "\u2135\u2080 < ((2 : Cardinal) ^ \u2135\u2080).ord.cof.card"
+      "description": "König's constraint: cf(2^ℵ₀) > ℵ₀",
+      "leanType": "ℵ₀ < ((2 : Cardinal) ^ ℵ₀).ord.cof.card"
     },
     {
       "name": "continuum_ne_aleph_omega",
       "type": "key",
-      "description": "2^\u2135\u2080 \u2260 \u2135_\u03c9 (first excluded value)",
-      "leanType": "(2 : Cardinal) ^ \u2135\u2080 \u2260 Cardinal.aleph \u03c9"
+      "description": "2^ℵ₀ ≠ ℵ_ω (first excluded value)",
+      "leanType": "(2 : Cardinal) ^ ℵ₀ ≠ Cardinal.aleph ω"
     },
     {
       "name": "zfc_constraints_on_continuum",
       "type": "key",
-      "description": "Complete ZFC constraints: \u2135\u2081 \u2264 2^\u2135\u2080 \u2227 cf(2^\u2135\u2080) > \u2135\u2080",
-      "leanType": "Cardinal.aleph 1 \u2264 2 ^ \u2135\u2080 \u2227 \u2135\u2080 < (2 ^ \u2135\u2080).ord.cof.card"
+      "description": "Complete ZFC constraints: ℵ₁ ≤ 2^ℵ₀ ∧ cf(2^ℵ₀) > ℵ₀",
+      "leanType": "Cardinal.aleph 1 ≤ 2 ^ ℵ₀ ∧ ℵ₀ < (2 ^ ℵ₀).ord.cof.card"
     }
   ]
 }

--- a/src/data/proofs/kummer-theorem-oq-01/meta.json
+++ b/src/data/proofs/kummer-theorem-oq-01/meta.json
@@ -62,27 +62,43 @@
   "sections": [
     {
       "id": "setup",
-      "title": "Module Header and Mathematical Overview",
+      "title": "Module Header, Imports, and Overview",
       "startLine": 1,
-      "endLine": 22,
-      "summary": "Imports Mathlib and provides a detailed docstring explaining the open question (can Kummer's theorem extend to multinomials?), the iterated binomial decomposition identity, and the key results to be proved.",
-      "mathContext": "The open question: given prime $p$ and parts $k_1,\\ldots,k_m$ with $k_1+\\cdots+k_m = n$, is $v_p\\binom{n}{k_1,\\ldots,k_m}$ = total carries when adding $k_1,\\ldots,k_m$ in base $p$? Answer: yes, via the telescoping identity $\\binom{n}{k_1,\\ldots,k_m} = \\prod_{i=1}^{m} \\binom{S_i}{k_i}$ where $S_i = k_1+\\cdots+k_i$, and Kummer's theorem applied to each factor."
+      "endLine": 31,
+      "summary": "Imports Mathlib and the Aristotle companion file. Docstring (lines 4-27) explains the open question, the iterated binomial decomposition answer, and lists the three key results. Opens namespace `KummerMultinomial` and `Nat` for unqualified access to factorial/choose.",
+      "mathContext": "The open question: given prime $p$ and parts $k_1,\\ldots,k_m$ with $\\sum k_i = n$, is $v_p\\binom{n}{k_1,\\ldots,k_m}$ = total carries when adding $k_1,\\ldots,k_m$ in base $p$? Answer: yes, via $\\binom{n}{k_1,\\ldots,k_m} = \\prod_{i=1}^{m} \\binom{S_i}{k_i}$ and Kummer's theorem on each factor."
     },
     {
       "id": "definition",
       "title": "Multinomial Coefficient Definition",
-      "startLine": 24,
-      "endLine": 33,
-      "summary": "Defines `multinomial (ks : List ℕ) : ℕ` as `(ks.sum).factorial / (ks.map Nat.factorial).prod` — i.e., n! / (k₁! · k₂! · ... · kₘ!). Marked `noncomputable` due to natural number division.",
-      "mathContext": "`multinomial ks = (ks.sum).factorial / (ks.map Nat.factorial).prod` — i.e., $\\binom{n}{k_1,\\ldots,k_m} = n!/\\prod k_i!$ where $n = \\sum k_i$. The `noncomputable` annotation is necessary because `Nat.div` for factorials is not decidably computable (classical division). The pair case `multinomial [a,b] = choose (a+b) a` is the key sanity check."
+      "startLine": 33,
+      "endLine": 36,
+      "summary": "Defines `multinomial (ks : List ℕ) : ℕ` as `(ks.sum).factorial / (ks.map Nat.factorial).prod`. Marked `noncomputable` since Lean's kernel does not evaluate natural number division with classical logic.",
+      "mathContext": "$\\binom{n}{k_1,\\ldots,k_m} = \\frac{n!}{k_1! \\cdot k_2! \\cdots k_m!}$ where $n = \\sum k_i$"
     },
     {
-      "id": "decomposition",
-      "title": "Binomial Factorization and Pair/Triple Cases",
-      "startLine": 35,
+      "id": "iterated-decomposition",
+      "title": "Iterated Binomial Decomposition",
+      "startLine": 38,
+      "endLine": 50,
+      "summary": "Proves `multinomial_eq_prod_choose`: the multinomial factors as a product of binomials indexed by running sums via `scanl/zip/tail/map`. Delegates to the Aristotle companion file which uses `List.reverseRecOn` backward induction.",
+      "mathContext": "$\\binom{n}{k_1,\\ldots,k_m} = \\prod_{i=1}^{m} \\binom{S_i}{k_i}$ where $S_i = \\sum_{j=1}^{i} k_j$. Lean encodes this as `(scanl (+) 0 ks).zip(ks).tail.map(fun (acc,k) => choose (acc+k) k).prod`."
+    },
+    {
+      "id": "pair-triple",
+      "title": "Pair and Triple Cases",
+      "startLine": 52,
+      "endLine": 99,
+      "summary": "Proves `multinomial_pair`: $\\binom{a+b}{a,b} = \\binom{a+b}{a}$ and `multinomial_triple`: $\\binom{a+b+c}{a,b,c} = \\binom{a+b}{a} \\cdot \\binom{a+b+c}{a+b}$. Both use `Nat.choose_mul_factorial_mul_factorial` via calc blocks to chain factorial identities, then `Nat.mul_div_cancel` to conclude.",
+      "mathContext": "Pair: $\\frac{(a+b)!}{a! b!} = \\binom{a+b}{a}$ via $\\binom{a+b}{a} \\cdot a! \\cdot b! = (a+b)!$. Triple: $\\frac{(a+b+c)!}{a! b! c!} = \\binom{a+b}{a} \\binom{a+b+c}{a+b}$ via two applications of the same identity."
+    },
+    {
+      "id": "statement-stub",
+      "title": "Kummer Multinomial Statement (Placeholder)",
+      "startLine": 101,
       "endLine": 108,
-      "summary": "Four theorems: `multinomial_eq_prod_choose` (general decomposition, proved via Aristotle companion), `multinomial_pair` (proved via `Nat.choose_mul_factorial_mul_factorial`), `multinomial_triple` (proved via two factorial chains), `kummer_multinomial_statement` (p-adic valuation, stub returning True).",
-      "mathContext": "`multinomial_eq_prod_choose`: $\\text{multinomial}(k_1,\\ldots,k_m) = \\prod_{i=1}^{m} \\binom{S_i}{k_i}$ where $S_i = \\sum_{j \\le i} k_j$. Lean uses `List.scanl (·+·) 0` for running sums, `List.zip` for pairing, `List.prod` for the product. `multinomial_pair`: $\\text{multinomial}([a,b]) = \\binom{a+b}{a}$ via `Nat.choose_mul_factorial_mul_factorial`. `multinomial_triple`: $\\text{multinomial}([a,b,c]) = \\binom{a+b}{a} \\cdot \\binom{a+b+c}{a+b}$ via two factorial chains."
+      "summary": "Placeholder `kummer_multinomial_statement` returning `True`. Documents the intended theorem: $v_p(\\text{multinomial}(ks)) = $ total carries when adding elements of $ks$ in base $p$. Not formalized because base-$p$ carry-counting is not yet in Mathlib.",
+      "mathContext": "$v_p\\binom{n}{k_1,\\ldots,k_m} = \\sum_{i=1}^{m-1} c(k_i, S_{i-1}; p)$ where $c(a,b;p)$ counts carries when adding $a$ and $b$ in base $p$"
     }
   ],
   "conclusion": {
@@ -100,6 +116,7 @@
       "Mathlib",
       "Proofs.KummerTheoremOQ01Aristotle"
     ],
+    "opens": ["Nat"],
     "namespace": "KummerMultinomial",
     "axiomCount": 0,
     "lineCount": 108,

--- a/src/data/proofs/lagrange-theorem-oq-03/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-03/meta.json
@@ -253,6 +253,11 @@
       "targetId": "euler-totient",
       "relationship": "related",
       "description": "Euler's totient function phi(n) counts units in Z/nZ, and Euler's theorem a^phi(n) = 1 (mod n) follows from Lagrange's theorem applied to (Z/nZ)*. Hall's coprimality condition gcd(|H|, [G:H]) = 1 generalizes the coprimality central to Euler's totient theory."
+    },
+    {
+      "targetId": "primitive-roots",
+      "relationship": "related",
+      "description": "Primitive root existence for primes follows from the cyclic structure of (Z/pZ)*, whose order p-1 is constrained by Lagrange; Hall's theorem generalizes this order theory to solvable groups"
     }
   ]
 }


### PR DESCRIPTION
Enrichment passes on feature/enricher-2 branch:

1. **Hall's Theorem** (`halls-theorem`): Added cross-reference to primitive-roots proof
2. **Vandermonde Falling Factorial** (`arithmetic-series-oq-02-oq-04-oq-01-oq-03`): Added cross-references to rising factorial identity and 2D hockey stick, plus annotation for theorem statement block
3. **Kummer Multinomial OQ-01** (`kummer-theorem-oq-01`): Fixed sections with correct non-overlapping line ranges, split monolithic section into 3 focused sections, added missing `opens` field
4. **König Cofinality OQ-02** (`cantor-diagonalization-oq-01-oq-01-oq-02`): Fixed section line ranges to eliminate gaps, added verification section, fixed leanFile.opens (added ContinuumHypothesis), added theoremCount/definitionCount