### PR TITLE
fix(meta): correct fourier-series-oq-02 sorry count 3→1

### DIFF
--- a/src/data/proofs/fourier-series-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02/meta.json
@@ -19,7 +19,7 @@
       "open-question"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 1,
     "dateAdded": "2026-03-23",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [


### PR DESCRIPTION
## Fix

Correct the sorry count for fourier-series-oq-02 from 3 to 1 after two sorries were eliminated.

## Evidence

**Before**: `"sorries": 3`
**After**: `"sorries": 1`

---
Automated repair by lean-mechanic agent.