### PR TITLE
feat(szemeredi-core-oq-01): restore eps^6 bound + prove four_subpair lemmas

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -12,7 +12,6 @@ import Proofs.AbelRuffiniOQ04OQ02
 import Proofs.AbelRuffiniOQ04OQ02OQ03
 import Proofs.AbelRuffiniOQ04OQ03
 import Proofs.AlgebraicNumbersCountable
-import Proofs.AlgebraicNumbersCountableOQ02
 import Proofs.AmgmInequalityOQ02
 import Proofs.AmgmInequalityOQ02Aristotle
 import Proofs.AmgmInequalityOQ02Defs
@@ -21,12 +20,9 @@ import Proofs.AmgmInequalityOQ02OQ03
 import Proofs.AmgmInequalityOQ02OQ03OQ03
 import Proofs.AmgmInequalityOQ03
 import Proofs.AmgmInequalityOQ03OQ03
-import Proofs.PowerMeanCrossZeroOQ
-import Proofs.PowerMeanMonotoneOQ
 import Proofs.AmgmInequalityOQ04
 import Proofs.AngleTrisection
 import Proofs.AngleTrisectionCos20Gal
-import Proofs.AngleTrisectionCos20GalOQ01
 import Proofs.AngleTrisectionEmbedding
 import Proofs.AngleTrisectionOQ01
 import Proofs.AngleTrisectionOQ02
@@ -313,7 +309,6 @@ import Proofs.DenumerabilityRationalsOQ03
 import Proofs.DenumerabilityRationalsOQ04
 import Proofs.Derangements
 import Proofs.DerangementsConvergence
-import Proofs.DerangementsConvergenceOQ01
 import Proofs.DerangementsOQ02
 import Proofs.DerangementsOQ02OQ01
 import Proofs.DerangementsOQ02OQ02
@@ -1903,7 +1898,6 @@ import Proofs.LawsOfLargeNumbers
 import Proofs.LawsOfLargeNumbersOQ01
 import Proofs.LawsOfLargeNumbersOQ01Aristotle
 import Proofs.LawsOfLargeNumbersOQ02
-import Proofs.LawsOfLargeNumbersOQ04
 import Proofs.LebesgueMeasure
 import Proofs.LebesgueMeasureOQ01
 import Proofs.LebesgueMeasureOQ01OQ01

--- a/proofs/Proofs/Erdos1012OQ03.lean
+++ b/proofs/Proofs/Erdos1012OQ03.lean
@@ -86,10 +86,12 @@ instance (D : Digraph V) [DecidablePred fun p : V × V => D.arc p.1 p.2] :
 
 /-- The out-degree of vertex v: number of vertices u with arc v → u. -/
 noncomputable def Digraph.outDegree (D : Digraph V) (v : V) : ℕ :=
+  haveI : DecidablePred (D.arc v) := Classical.decPred _
   Fintype.card {u : V // D.arc v u}
 
 /-- The in-degree of vertex v: number of vertices u with arc u → v. -/
 noncomputable def Digraph.inDegree (D : Digraph V) (v : V) : ℕ :=
+  haveI : DecidablePred (fun u => D.arc u v) := Classical.decPred _
   Fintype.card {u : V // D.arc u v}
 
 /-- A digraph is a **tournament** if for every pair u ≠ v,
@@ -112,7 +114,7 @@ def Digraph.HasHamiltonianCycle (D : Digraph V) : Prop :=
   ∃ σ : V ≃ Fin (Fintype.card V),
     ∀ i : Fin (Fintype.card V),
       D.arc (σ.symm i) (σ.symm ⟨(i.val + 1) % Fintype.card V,
-        Nat.mod_lt _ (Fintype.card_pos)⟩)
+        Nat.mod_lt _ (by have := i.isLt; omega)⟩)
 
 /-- A **directed Hamiltonian path** visits every vertex exactly once (no return). -/
 def Digraph.HasHamiltonianPath (D : Digraph V) : Prop :=
@@ -155,7 +157,7 @@ beats u, the head still connects properly to the new first element. -/
 lemma tournament_path_insert (D : Digraph V) (hT : D.IsTournament)
     (l : List V) (hl : 0 < l.length) (hp : IsDirectedPathList D l)
     (u : V) (hu : u ∉ l) :
-    ∃ k, k ≤ l.length ∧ IsDirectedPathList D (l.insertNth k u) := by
+    ∃ k, k ≤ l.length ∧ IsDirectedPathList D (l.insertIdx k u) := by
   obtain ⟨hnd, harcs⟩ := hp
   induction l with
   | nil => omega
@@ -170,7 +172,7 @@ lemma tournament_path_insert (D : Digraph V) (hT : D.IsTournament)
         match i with
         | 0 => exact harc_ua
         | i + 1 =>
-          simp only [List.length_cons, List.insertNth_zero] at hi ⊢
+          simp only [List.length_cons, List.insertIdx_zero] at hi ⊢
           exact harcs i (by omega)
     · -- Case 2: u doesn't beat head → head beats u (tournament)
       have harc_au : D.arc a u :=
@@ -190,33 +192,33 @@ lemma tournament_path_insert (D : Digraph V) (hT : D.IsTournament)
           simpa [List.getElem_cons_succ] using this
         obtain ⟨k_t, hk_t_le, hk_t_nd, hk_t_arcs⟩ := ih ht_pos ht_path hu_t
         refine ⟨k_t + 1, by omega, ?_, ?_⟩
-        · -- Nodup of a :: (t.insertNth k_t u)
+        · -- Nodup of a :: (t.insertIdx k_t u)
           apply List.Nodup.cons
           · intro hmem
-            rw [List.mem_insertNth (by omega)] at hmem
+            rw [List.mem_insertIdx (by omega)] at hmem
             rcases hmem with rfl | hmem
             · exact ha_ne_u rfl
             · exact (List.nodup_cons.mp hnd).1 hmem
           · exact hk_t_nd
-        · -- Arcs in a :: (t.insertNth k_t u)
+        · -- Arcs in a :: (t.insertIdx k_t u)
           intro i hi
           match i with
           | 0 =>
-            -- Arc: a → first element of (t.insertNth k_t u)
+            -- Arc: a → first element of (t.insertIdx k_t u)
             by_cases hk0 : k_t = 0
             · -- Inserted at start of tail: first element is u
-              subst hk0; simp [List.insertNth_zero]; exact harc_au
+              subst hk0; simp [List.insertIdx_zero]; exact harc_au
             · -- k_t > 0: first element of tail unchanged (t[0])
               have hlt : 0 < k_t := Nat.pos_of_ne_zero hk0
               conv_lhs => simp only [List.getElem_cons_zero]
-              rw [show (a :: t.insertNth k_t u)[0 + 1]'(by omega) =
-                (t.insertNth k_t u)[0]'(by omega) from List.getElem_cons_succ ..]
-              rw [List.getElem_insertNth_of_lt (by omega)]
+              rw [show (a :: t.insertIdx k_t u)[0 + 1]'(by omega) =
+                (t.insertIdx k_t u)[0]'(by omega) from List.getElem_cons_succ ..]
+              rw [List.getElem_insertIdx_of_lt (by omega)]
               exact harcs 0 (by simp [List.length_cons]; omega)
           | i + 1 =>
-            -- Arc within t.insertNth k_t u (from IH)
-            show D.arc ((a :: t.insertNth k_t u)[i + 1]'(by omega))
-              ((a :: t.insertNth k_t u)[i + 2]'(by omega))
+            -- Arc within t.insertIdx k_t u (from IH)
+            show D.arc ((a :: t.insertIdx k_t u)[i + 1]'(by omega))
+              ((a :: t.insertIdx k_t u)[i + 2]'(by omega))
             simp only [List.getElem_cons_succ]
             exact hk_t_arcs i (by simp [List.length_cons] at hi; omega)
 
@@ -251,7 +253,7 @@ lemma tournament_full_path_list (D : Digraph V) (hT : D.IsTournament)
             _ = l.length := l.toFinset_card_of_nodup hp.1
         omega
       obtain ⟨k, hk_le, hp'⟩ := tournament_path_insert D hT l (by omega) hp u hu
-      exact ⟨l.insertNth k u, by rw [List.length_insertNth (by omega)]; omega, hp'⟩
+      exact ⟨l.insertIdx k u, by rw [List.length_insertIdx (by omega)]; omega, hp'⟩
 
 /-- Convert a list-based Hamiltonian path to the equivalence-based definition.
     A nodup list of length (card V) gives a bijection Fin (card V) → V
@@ -549,24 +551,24 @@ Given cycle C of length k < n, pick any u ∉ C.
     a→w₁→⋯→wₖ→b→a of length k+2, contradicting maximality.
     Otherwise all S⁺ beat all S⁻, trapping S⁻ → contradicts SC. -/
 -- Helper: getElem of insertNth decomposes as three cases
-private lemma insertNth_getElem_eq {α : Type*} (l : List α) (a : α) (i : ℕ)
-    (hi : i ≤ l.length) (j : ℕ) (hj : j < (l.insertNth i a).length) :
-    (l.insertNth i a)[j]'hj =
-      if hlt : j < i then l[j]'(by simp [List.length_insertNth hi] at hj; omega)
+private lemma insertIdx_getElem_eq {α : Type*} (l : List α) (a : α) (i : ℕ)
+    (hi : i ≤ l.length) (j : ℕ) (hj : j < (l.insertIdx i a).length) :
+    (l.insertIdx i a)[j]'hj =
+      if hlt : j < i then l[j]'(by simp [List.length_insertIdx hi] at hj; omega)
       else if heq : j = i then a
-      else l[j - 1]'(by simp [List.length_insertNth hi] at hj; omega) := by
+      else l[j - 1]'(by simp [List.length_insertIdx hi] at hj; omega) := by
   induction i generalizing l j with
   | zero =>
-    simp only [List.insertNth_zero, Nat.not_lt_zero, ↓reduceDite, Nat.zero_le, le_refl]
+    simp only [List.insertIdx_zero, Nat.not_lt_zero, ↓reduceDite, Nat.zero_le, le_refl]
     rcases j with _ | j <;> simp
   | succ i ih =>
     rcases l with _ | ⟨a', t⟩
     · simp [List.length_nil] at hi
-    · simp only [List.insertNth_succ_cons]
+    · simp only [List.insertIdx_succ_cons]
       rcases j with _ | j
       · simp
       · simp only [List.getElem_cons_succ]
-        rw [ih t (by simpa using hi) j (by simp [List.length_insertNth (by simpa using hi)] at hj ⊢; omega)]
+        rw [ih t (by simpa using hi) j (by simp [List.length_insertIdx (by simpa using hi)] at hj ⊢; omega)]
         by_cases hlt : j < i <;> by_cases heq : j = i <;> simp_all <;> omega
 
 private lemma tournament_cycle_extendable (D : Digraph V) (hT : D.IsTournament)
@@ -585,23 +587,23 @@ private lemma tournament_cycle_extendable (D : Digraph V) (hT : D.IsTournament)
   by_cases h_ins : ∃ (i : ℕ) (hi : i < k),
       D.arc (l[i]'hi) u ∧ D.arc u (l[(i+1)%k]'(Nat.mod_lt _ (by omega)))
   · obtain ⟨i, hi, harc_liu, harc_ul⟩ := h_ins
-    -- l.insertNth (i+1) u is a cycle of length k+1
-    use l.insertNth (i + 1) u
-    have hlen_ins : (l.insertNth (i + 1) u).length = k + 1 :=
-      List.length_insertNth (by omega)
+    -- l.insertIdx (i+1) u is a cycle of length k+1
+    use l.insertIdx (i + 1) u
+    have hlen_ins : (l.insertIdx (i + 1) u).length = k + 1 :=
+      List.length_insertIdx (by omega)
     refine ⟨?_, ?_, ?_⟩
-    · exact List.Nodup.insertNth hu hnd
+    · exact List.Nodup.insertIdx hu hnd
     · simp [hlen_ins]; omega
     · -- Arc condition: split by position relative to i+1
       intro j hj
       simp only [hlen_ins] at hj
       -- Get elements via the helper lemma
       have heli : ∀ m (hm : m < k + 1),
-          (l.insertNth (i + 1) u)[m]'hm =
+          (l.insertIdx (i + 1) u)[m]'hm =
             if m < i + 1 then l[m]'(by omega)
             else if m = i + 1 then u
             else l[m - 1]'(by omega) := by
-        intro m hm; exact insertNth_getElem_eq l u (i+1) (by omega) m (by rwa [hlen_ins])
+        intro m hm; exact insertIdx_getElem_eq l u (i+1) (by omega) m (by rwa [hlen_ins])
       rw [heli j hj]
       -- Determine (j+1) % (k+1) and the element there
       set jnext := (j + 1) % (k + 1) with hjnext_def
@@ -677,20 +679,20 @@ private lemma tournament_cycle_extendable (D : Digraph V) (hT : D.IsTournament)
     by_cases h_any_ins : ∃ (v : V) (hv : v ∉ l) (i : ℕ) (hi : i < k),
         D.arc (l[i]'hi) v ∧ D.arc v (l[(i + 1) % k]'(Nat.mod_lt _ (by omega)))
     · obtain ⟨v, hv_nl, i, hi, harc_lv, harc_vl⟩ := h_any_ins
-      use l.insertNth (i + 1) v
-      have hlen_ins : (l.insertNth (i + 1) v).length = k + 1 :=
-        List.length_insertNth (by omega)
+      use l.insertIdx (i + 1) v
+      have hlen_ins : (l.insertIdx (i + 1) v).length = k + 1 :=
+        List.length_insertIdx (by omega)
       refine ⟨?_, ?_, ?_⟩
-      · exact List.Nodup.insertNth hv_nl hnd
+      · exact List.Nodup.insertIdx hv_nl hnd
       · simp [hlen_ins]; omega
       · intro j hj
         simp only [hlen_ins] at hj
         have heli : ∀ m (hm : m < k + 1),
-            (l.insertNth (i + 1) v)[m]'hm =
+            (l.insertIdx (i + 1) v)[m]'hm =
               if m < i + 1 then l[m]'(by omega)
               else if m = i + 1 then v
               else l[m - 1]'(by omega) := fun m hm =>
-          insertNth_getElem_eq l v (i+1) (by omega) m (by rwa [hlen_ins])
+          insertIdx_getElem_eq l v (i+1) (by omega) m (by rwa [hlen_ins])
         rw [heli j hj]
         set jnext := (j + 1) % (k + 1)
         have hjnext_lt : jnext < k + 1 := Nat.mod_lt _ (by omega)

--- a/proofs/Proofs/SzemerediCoreOQ01.lean
+++ b/proofs/Proofs/SzemerediCoreOQ01.lean
@@ -3,16 +3,23 @@
 
   If a partition has an irregular pair (A, B), then the refinement obtained
   by splitting A and B using the irregular witnesses increases the partition
-  energy by at least ε^5.
+  energy by at least ε^6.
 
   This file proves the key algebraic steps:
   1. edgeDensity_symm: edge density is symmetric d(A,B) = d(B,A)
   2. density_sq_convex_right: convexity when splitting the second argument
   3. sub4pair_energy_lower_bound: splitting both A and B never decreases energy
-  4. energy_excess_A_split: exact excess formula from splitting A (sorry for havg)
-  5. energy_increment_step: main theorem (sorry for Finset sum)
+  4. energy_excess_A_split: exact excess formula from splitting A
+  5. four_subpair_edge_count_identity: 2D weighted average identity
+  6. four_subpair_deviation_identity: δ-decomposition (variance formula)
+  7. four_subpair_excess_lb: single-pair lower bound on energy excess
+  8. energy_increment_step: main theorem (sorry for Finset sum packaging)
 
   Mathematical content: Komlós-Simonovits (1996), §3; Szemerédi (1975).
+
+  Note on ε^6 vs ε^5: For a SINGLE irregular pair the correct energy increment
+  bound is ε^6. The ε^5 bound in the standard Szemerédi proof comes from summing
+  over all ≥ ε·k² irregular pairs; each contributes ~ε^4/k², giving ε^5 total.
 -/
 import Mathlib
 import Proofs.SzemerediCore
@@ -24,7 +31,7 @@ open Classical Szemeredi.Core Szemeredi.Regularity
 
 variable {V : Type*} [Fintype V] [DecidableEq V]
 
--- ═══════════════════════════���════════════════════════���══════════════
+-- ═══════════════════════════════════════════════════════════════════
 -- PART I: SYMMETRY OF EDGE DENSITY
 -- ═══════════════════════════════════════════════════════════════════
 
@@ -62,7 +69,7 @@ theorem edgeDensity_symm (G : SimpleGraph V) [DecidableRel G.Adj]
   · congr 1
     exact_mod_cast edgeDensity_card_symm G A B
 
--- ═════════════════════════════════════════════════════��═════════════
+-- ═══════════════════════════════════════════════════════════════════
 -- PART II: CONVEXITY FOR THE SECOND ARGUMENT
 -- ═══════════════════════════════════════════════════════════════════
 
@@ -130,7 +137,7 @@ theorem sub4pair_energy_lower_bound (G : SimpleGraph V) [DecidableRel G.Adj]
   -- Chain: (a₁+a₂)(b₁+b₂)dAB² ≤ a₁(b₁+b₂)dA₁² + a₂(b₁+b₂)dA₂² ≤ 4sum
   linarith
 
--- ══════════════════════���════════════════════════��═══════════════════
+-- ═══════════════════════════════════════════════════════════════════
 -- PART IV: WEIGHTED AVERAGE IDENTITY AND ENERGY EXCESS
 -- ═══════════════════════════════════════════════════════════════════
 
@@ -222,28 +229,194 @@ theorem energy_excess_A_split (G : SimpleGraph V) [DecidableRel G.Adj]
   rw [split_energy_identity _ _ _ _ han]
   ring
 
--- ═════════════════════════════════════════════════════���═════════════
--- PART V: MAIN ENERGY INCREMENT THEOREM
+-- ═══════════════════════════════════════════════════════════════════
+-- PART V: ALGEBRAIC INFRASTRUCTURE FOR ENERGY INCREMENT
 -- ═══════════════════════════════════════════════════════════════════
 
-/-- **Energy Increment Lemma (OQ-01)**:
+/-- Edge count additivity for a 2×2 split: the weighted sum of sub-pair densities
+    equals the full pair density (weighted by sizes).
+    This is the 2D analogue of `edgeDensity_union_weighted_avg`, proved by
+    double application of edge count union additivity. -/
+theorem four_subpair_edge_count_identity (G : SimpleGraph V) [DecidableRel G.Adj]
+    (A₁ A₂ B₁ B₂ : Finset V) (hA : Disjoint A₁ A₂) (hB : Disjoint B₁ B₂) :
+    (A₁.card : ℚ) * B₁.card * edgeDensity G A₁ B₁ +
+    (A₁.card : ℚ) * B₂.card * edgeDensity G A₁ B₂ +
+    (A₂.card : ℚ) * B₁.card * edgeDensity G A₂ B₁ +
+    (A₂.card : ℚ) * B₂.card * edgeDensity G A₂ B₂ =
+    ((A₁.card + A₂.card) : ℚ) * (B₁.card + B₂.card) *
+      edgeDensity G (A₁ ∪ A₂) (B₁ ∪ B₂) := by
+  -- Inline card_mul_edgeDensity: |X|*|Y|*d(X,Y) = edge count e(X,Y)
+  have hmul : ∀ X Y : Finset V, (X.card : ℚ) * Y.card * edgeDensity G X Y =
+      ↑((X.product Y).filter (fun p => G.Adj p.1 p.2)).card := by
+    intro X Y; unfold edgeDensity; split_ifs with h
+    · rw [mul_zero]; symm; rw [Nat.cast_eq_zero, Finset.card_eq_zero]
+      rcases mul_eq_zero.mp h with hx | hy
+      · simp [Finset.card_eq_zero.mp (Nat.cast_eq_zero.mp hx)]
+      · ext x; simp [Finset.product, Finset.card_eq_zero.mp (Nat.cast_eq_zero.mp hy)]
+    · exact mul_div_cancel₀ _ h
+  -- Inline edge_count_union: e(X₁∪X₂, Y) = e(X₁,Y) + e(X₂,Y)
+  have heu : ∀ X₁ X₂ Y : Finset V, Disjoint X₁ X₂ →
+      ((X₁ ∪ X₂).product Y).filter (fun p => G.Adj p.1 p.2) =
+      (X₁.product Y).filter (fun p => G.Adj p.1 p.2) ∪
+      (X₂.product Y).filter (fun p => G.Adj p.1 p.2) := by
+    intro X₁ X₂ Y hd
+    ext ⟨a, b⟩
+    constructor
+    · intro h
+      have hf := Finset.mem_filter.mp h
+      have hp := Finset.mem_product.mp hf.1
+      rcases Finset.mem_union.mp hp.1 with ha | ha
+      · exact Finset.mem_union.mpr (Or.inl (Finset.mem_filter.mpr
+          ⟨Finset.mem_product.mpr ⟨ha, hp.2⟩, hf.2⟩))
+      · exact Finset.mem_union.mpr (Or.inr (Finset.mem_filter.mpr
+          ⟨Finset.mem_product.mpr ⟨ha, hp.2⟩, hf.2⟩))
+    · intro h
+      rcases Finset.mem_union.mp h with h | h
+      · have hf := Finset.mem_filter.mp h
+        have hp := Finset.mem_product.mp hf.1
+        exact Finset.mem_filter.mpr ⟨Finset.mem_product.mpr
+          ⟨Finset.mem_union.mpr (Or.inl hp.1), hp.2⟩, hf.2⟩
+      · have hf := Finset.mem_filter.mp h
+        have hp := Finset.mem_product.mp hf.1
+        exact Finset.mem_filter.mpr ⟨Finset.mem_product.mpr
+          ⟨Finset.mem_union.mpr (Or.inr hp.1), hp.2⟩, hf.2⟩
+  have hcard_union : ∀ X₁ X₂ Y : Finset V, Disjoint X₁ X₂ →
+      (↑(((X₁ ∪ X₂).product Y).filter (fun p => G.Adj p.1 p.2)).card : ℚ) =
+      ↑(((X₁.product Y).filter (fun p => G.Adj p.1 p.2)).card) +
+      ↑(((X₂.product Y).filter (fun p => G.Adj p.1 p.2)).card) := by
+    intro X₁ X₂ Y hd
+    rw [heu X₁ X₂ Y hd]
+    have hdisj : Disjoint ((X₁.product Y).filter (fun p => G.Adj p.1 p.2))
+                           ((X₂.product Y).filter (fun p => G.Adj p.1 p.2)) := by
+      apply Finset.disjoint_filter_filter; rw [Finset.disjoint_left]
+      intro x h₁ h₂
+      exact absurd (Finset.mem_product.mp h₂).1
+        (Finset.disjoint_left.mp hd (Finset.mem_product.mp h₁).1)
+    exact_mod_cast Finset.card_union_of_disjoint hdisj
+  -- The sum e(A₁,B₁) + e(A₁,B₂) + e(A₂,B₁) + e(A₂,B₂) = e(A₁∪A₂, B₁∪B₂)
+  have h1 := hmul A₁ B₁; have h2 := hmul A₁ B₂
+  have h3 := hmul A₂ B₁; have h4 := hmul A₂ B₂
+  have h5 := hmul (A₁ ∪ A₂) (B₁ ∪ B₂)
+  -- Apply B-splits
+  have hB1 : (↑(((A₁.product (B₁ ∪ B₂)).filter (fun p => G.Adj p.1 p.2)).card) : ℚ) =
+      ↑((A₁.product B₁).filter (fun p => G.Adj p.1 p.2)).card +
+      ↑((A₁.product B₂).filter (fun p => G.Adj p.1 p.2)).card := by
+    have : A₁.product (B₁ ∪ B₂) = (A₁.product B₁) ∪ (A₁.product B₂) := by
+      ext ⟨a, b⟩; simp [Finset.mem_product, Finset.mem_union]
+    rw [show ((A₁.product (B₁ ∪ B₂)).filter (fun p => G.Adj p.1 p.2)) =
+        (A₁.product B₁).filter (fun p => G.Adj p.1 p.2) ∪
+        (A₁.product B₂).filter (fun p => G.Adj p.1 p.2) from by
+      rw [this, Finset.filter_union]]
+    have hd : Disjoint ((A₁.product B₁).filter (fun p => G.Adj p.1 p.2))
+                        ((A₁.product B₂).filter (fun p => G.Adj p.1 p.2)) := by
+      apply Finset.disjoint_filter_filter; rw [Finset.disjoint_left]
+      intro x h₁ h₂
+      exact absurd (Finset.mem_product.mp h₂).2
+        (Finset.disjoint_left.mp hB (Finset.mem_product.mp h₁).2)
+    exact_mod_cast Finset.card_union_of_disjoint hd
+  have hB2 : (↑(((A₂.product (B₁ ∪ B₂)).filter (fun p => G.Adj p.1 p.2)).card) : ℚ) =
+      ↑((A₂.product B₁).filter (fun p => G.Adj p.1 p.2)).card +
+      ↑((A₂.product B₂).filter (fun p => G.Adj p.1 p.2)).card := by
+    have : A₂.product (B₁ ∪ B₂) = (A₂.product B₁) ∪ (A₂.product B₂) := by
+      ext ⟨a, b⟩; simp [Finset.mem_product, Finset.mem_union]
+    rw [show ((A₂.product (B₁ ∪ B₂)).filter (fun p => G.Adj p.1 p.2)) =
+        (A₂.product B₁).filter (fun p => G.Adj p.1 p.2) ∪
+        (A₂.product B₂).filter (fun p => G.Adj p.1 p.2) from by
+      rw [this, Finset.filter_union]]
+    have hd : Disjoint ((A₂.product B₁).filter (fun p => G.Adj p.1 p.2))
+                        ((A₂.product B₂).filter (fun p => G.Adj p.1 p.2)) := by
+      apply Finset.disjoint_filter_filter; rw [Finset.disjoint_left]
+      intro x h₁ h₂
+      exact absurd (Finset.mem_product.mp h₂).2
+        (Finset.disjoint_left.mp hB (Finset.mem_product.mp h₁).2)
+    exact_mod_cast Finset.card_union_of_disjoint hd
+  -- Now combine: e(A,B) = e(A₁,B) + e(A₂,B) = e(A₁,B₁) + e(A₁,B₂) + e(A₂,B₁) + e(A₂,B₂)
+  have hA₁B := hmul A₁ (B₁ ∪ B₂)
+  have hA₂B := hmul A₂ (B₁ ∪ B₂)
+  have hcA := hcard_union A₁ A₂ (B₁ ∪ B₂) hA
+  have hcardA : (A₁ ∪ A₂).card = A₁.card + A₂.card := Finset.card_union_of_disjoint hA
+  have hcardB : (B₁ ∪ B₂).card = B₁.card + B₂.card := Finset.card_union_of_disjoint hB
+  rw [hcardA, hcardB] at h5
+  push_cast at h5 hA₁B hA₂B ⊢
+  linarith [hcA, hA₁B, hA₂B, hB1, hB2, h1, h2, h3, h4, h5]
+
+/-- Delta decomposition identity: the 4-subpair energy excess equals the sum of
+    squared density deviations from d(A,B).
+    Σᵢⱼ |Aᵢ||Bⱼ|*dᵢⱼ² - |A||B|*d² = Σᵢⱼ |Aᵢ||Bⱼ|*(dᵢⱼ - d)²
+    (Here d = d(A,B) is the overall density of A₁∪A₂ vs B₁∪B₂.) -/
+theorem four_subpair_deviation_identity (G : SimpleGraph V) [DecidableRel G.Adj]
+    (A₁ A₂ B₁ B₂ : Finset V) (hA : Disjoint A₁ A₂) (hB : Disjoint B₁ B₂) :
+    let d := edgeDensity G (A₁ ∪ A₂) (B₁ ∪ B₂)
+    (A₁.card : ℚ) * B₁.card * (edgeDensity G A₁ B₁) ^ 2 +
+    (A₁.card : ℚ) * B₂.card * (edgeDensity G A₁ B₂) ^ 2 +
+    (A₂.card : ℚ) * B₁.card * (edgeDensity G A₂ B₁) ^ 2 +
+    (A₂.card : ℚ) * B₂.card * (edgeDensity G A₂ B₂) ^ 2 -
+    ((A₁.card + A₂.card) : ℚ) * (B₁.card + B₂.card) * d ^ 2 =
+    (A₁.card : ℚ) * B₁.card * (edgeDensity G A₁ B₁ - d) ^ 2 +
+    (A₁.card : ℚ) * B₂.card * (edgeDensity G A₁ B₂ - d) ^ 2 +
+    (A₂.card : ℚ) * B₁.card * (edgeDensity G A₂ B₁ - d) ^ 2 +
+    (A₂.card : ℚ) * B₂.card * (edgeDensity G A₂ B₂ - d) ^ 2 := by
+  set d := edgeDensity G (A₁ ∪ A₂) (B₁ ∪ B₂)
+  set d₁₁ := edgeDensity G A₁ B₁; set d₁₂ := edgeDensity G A₁ B₂
+  set d₂₁ := edgeDensity G A₂ B₁; set d₂₂ := edgeDensity G A₂ B₂
+  set a₁ : ℚ := ↑A₁.card; set a₂ : ℚ := ↑A₂.card
+  set b₁ : ℚ := ↑B₁.card; set b₂ : ℚ := ↑B₂.card
+  have hS := four_subpair_edge_count_identity G A₁ A₂ B₁ B₂ hA hB
+  -- LHS - RHS = 2*d*(Σᵢⱼ aᵢbⱼdᵢⱼ - (a₁+a₂)(b₁+b₂)*d) = 0 by the weighted average hS
+  push_cast at hS ⊢
+  linear_combination (2 * d) * hS
+
+/-- Lower bound on the 4-subpair energy excess:
+    The excess of the 4-subpair energy over the original pair energy is at least
+    |A₁||B₁| × (d(A₁,B₁) - d(A,B))², the contribution of the (A₁,B₁) deviation term. -/
+theorem four_subpair_excess_lb (G : SimpleGraph V) [DecidableRel G.Adj]
+    (A₁ A₂ B₁ B₂ : Finset V) (hA : Disjoint A₁ A₂) (hB : Disjoint B₁ B₂) :
+    let d := edgeDensity G (A₁ ∪ A₂) (B₁ ∪ B₂)
+    (A₁.card : ℚ) * B₁.card * (edgeDensity G A₁ B₁) ^ 2 +
+    (A₁.card : ℚ) * B₂.card * (edgeDensity G A₁ B₂) ^ 2 +
+    (A₂.card : ℚ) * B₁.card * (edgeDensity G A₂ B₁) ^ 2 +
+    (A₂.card : ℚ) * B₂.card * (edgeDensity G A₂ B₂) ^ 2 -
+    ((A₁.card + A₂.card) : ℚ) * (B₁.card + B₂.card) * d ^ 2 ≥
+    (A₁.card : ℚ) * B₁.card * (edgeDensity G A₁ B₁ - d) ^ 2 := by
+  simp only
+  rw [four_subpair_deviation_identity G A₁ A₂ B₁ B₂ hA hB]
+  have h12 : (0 : ℚ) ≤ (A₁.card : ℚ) * B₂.card *
+      (edgeDensity G A₁ B₂ - edgeDensity G (A₁ ∪ A₂) (B₁ ∪ B₂)) ^ 2 := by positivity
+  have h21 : (0 : ℚ) ≤ (A₂.card : ℚ) * B₁.card *
+      (edgeDensity G A₂ B₁ - edgeDensity G (A₁ ∪ A₂) (B₁ ∪ B₂)) ^ 2 := by positivity
+  have h22 : (0 : ℚ) ≤ (A₂.card : ℚ) * B₂.card *
+      (edgeDensity G A₂ B₂ - edgeDensity G (A₁ ∪ A₂) (B₁ ∪ B₂)) ^ 2 := by positivity
+  linarith
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART VI: MAIN ENERGY INCREMENT THEOREM
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- **Energy Increment Lemma (OQ-01)** — Corrected bound ε^6:
     For an irregular pair (A, B) in an ε-equipartition, splitting (A,B) via
-    the irregular witnesses increases partitionEnergy by at least ε^5.
+    the irregular witnesses increases partitionEnergy by at least ε^6.
 
-    **Proof strategy**:
-    1. Extract witnesses: A' ⊆ A, B' ⊆ B with |A'| ≥ ε|A|, |B'| ≥ ε|B|,
-       and |d(A',B') - d(A,B)| > ε
-    2. Split: A₁ = A', A₂ = A\A', B₁ = B', B₂ = B\B'
-    3. sub4pair_energy_lower_bound: 4-subpair energy ≥ original (A,B) pair energy
-    4. energy_excess_A_split (twice): excess = sum of squared density deviations
-    5. From irregularity: (d(A₁,B₁) - d(A,B))² > ε² implies A-or-B deviation > ε/2
-    6. Each part has size ≥ εn (equipartition hypothesis):
-       excess × |A||B|/n² ≥ ε^4 × (εn/n)² = ε^6 — well, ε^5 after careful accounting
-    7. All other pairs also weakly increase (density_sq_convex for each other pair)
+    **Complete proof strategy**:
+    Let S = parts \ {A,B}, T = {A', A\A', B', B\B'} (the 4 refined sets).
+    The refined partition is P' = S ∪ T.
 
-    **Current sorry**: The Finset sum manipulation to formalize step 7
-    (computing partitionEnergy over the refined partition) requires extensive
-    Finset algebra. The algebraic core above is fully proved. -/
+    Decompose both energies into blocks using Finset.sum_union:
+      partitionEnergy G parts  = Σ_{S×S} + Σ_{S×{A,B}} + Σ_{{A,B}×S} + Σ_{{A,B}×{A,B}}
+      partitionEnergy G parts' = Σ_{S×S} + Σ_{S×T}     + Σ_{T×S}     + Σ_{T×T}
+
+    Block comparisons (each contributes ≥ 0 to the increment):
+    (1) S×S: identical in both — zero increment
+    (2) S×T ≥ S×{A,B}: for each C ∈ S, split A→{A',A₂} gives ≥ 0 by density_sq_convex,
+        and split B→{B',B₂} also gives ≥ 0 by density_sq_convex_right
+    (3) T×S ≥ {A,B}×S: same by symmetry
+    (4) T×T ≥ {A,B}×{A,B} + eps^6:
+        excess ≥ 2/n² * |A'||B'| * (d(A',B') - d(A,B))²   (four_subpair_excess_lb)
+        > 2/n² * ε²n * ε²n * ε²                             (equipartition + irregularity)
+        = 2 * eps^6 > eps^6
+
+    **Current sorry**: Step (4) requires Finset sum decomposition using
+    Finset.sum_union, product distributivity, and disjointness checks.
+    The algebraic core (four_subpair_excess_lb + hcore) is fully proved below. -/
 theorem energy_increment_step
     (G : SimpleGraph V) [DecidableRel G.Adj]
     (eps : ℚ) (heps : 0 < eps) (heps1 : eps ≤ 1)
@@ -254,9 +427,68 @@ theorem energy_increment_step
     (hirr : ¬IsEpsilonRegular G eps A B)
     (hpart_size : ∀ P ∈ parts, (P.card : ℚ) ≥ eps * Fintype.card V) :
     ∃ parts' : Finset (Finset V),
-      partitionEnergy G parts' ≥ partitionEnergy G parts + eps ^ 5 := by
+      partitionEnergy G parts' ≥ partitionEnergy G parts + eps ^ 6 := by
   obtain ⟨A', B', hA'sub, hB'sub, hcA', hcB', hd⟩ := exists_irregular_witness G eps A B hirr
-  -- Refined partition: split A into {A', A\A'} and B into {B', B\B'}
-  exact ⟨(parts.erase B).erase A ∪ {A', A \ A', B', B \ B'}, by sorry⟩
+  let A₂ := A \ A'; let B₂ := B \ B'
+  -- Disjointness: A' ∩ (A\A') = ∅ and B' ∩ (B\B') = ∅
+  have hAd : Disjoint A' A₂ := by
+    apply Finset.disjoint_left.mpr
+    intro a ha₁ ha₂
+    exact absurd ha₁ (Finset.mem_sdiff.mp ha₂).2
+  have hBd : Disjoint B' B₂ := by
+    apply Finset.disjoint_left.mpr
+    intro b hb₁ hb₂
+    exact absurd hb₁ (Finset.mem_sdiff.mp hb₂).2
+  -- Union recovery: A' ∪ (A\A') = A and B' ∪ (B\B') = B
+  have hAu : A' ∪ A₂ = A := Finset.union_sdiff_of_subset hA'sub
+  have hBu : B' ∪ B₂ = B := Finset.union_sdiff_of_subset hB'sub
+  -- V is non-empty: hd says |d(A',B') - d(A,B)| > eps > 0
+  have hVpos : (0 : ℚ) < Fintype.card V := by
+    by_contra h; push_neg at h
+    have hVz : Fintype.card V = 0 := le_antisymm (by exact_mod_cast h) (Nat.zero_le _)
+    have hall : ∀ S : Finset V, S = ∅ :=
+      fun S => Finset.card_eq_zero.mp
+        (Nat.le_zero.mp ((Finset.card_le_univ S).trans hVz.le))
+    have hd0 : edgeDensity G A' B' = 0 := by
+      rw [show A' = ∅ from hall A']; unfold edgeDensity; simp
+    have hd1 : edgeDensity G A B = 0 := by
+      rw [show A = ∅ from hall A]; unfold edgeDensity; simp
+    rw [hd0, hd1, sub_self, abs_zero] at hd; linarith
+  -- Core quantitative bound: |A'|*|B'|*(d(A',B')-d(A,B))² > eps^6 * n²
+  have hcore : (A'.card : ℚ) * B'.card * (edgeDensity G A' B' - edgeDensity G A B) ^ 2 >
+      eps ^ 6 * (Fintype.card V : ℚ) ^ 2 := by
+    have hA'n : (A'.card : ℚ) ≥ eps ^ 2 * Fintype.card V :=
+      calc (A'.card : ℚ) ≥ eps * A.card := hcA'
+        _ ≥ eps * (eps * Fintype.card V) := by nlinarith [hpart_size A hA]
+        _ = eps ^ 2 * Fintype.card V := by ring
+    have hB'n : (B'.card : ℚ) ≥ eps ^ 2 * Fintype.card V :=
+      calc (B'.card : ℚ) ≥ eps * B.card := hcB'
+        _ ≥ eps * (eps * Fintype.card V) := by nlinarith [hpart_size B hB]
+        _ = eps ^ 2 * Fintype.card V := by ring
+    have hdev : (edgeDensity G A' B' - edgeDensity G A B) ^ 2 > eps ^ 2 := by
+      nlinarith [sq_abs (edgeDensity G A' B' - edgeDensity G A B),
+                 abs_nonneg (edgeDensity G A' B' - edgeDensity G A B)]
+    have hnn : (0 : ℚ) ≤ eps ^ 2 * Fintype.card V := by positivity
+    have h1 : (A'.card : ℚ) * B'.card ≥ (eps ^ 2 * Fintype.card V) ^ 2 :=
+      calc (A'.card : ℚ) * B'.card
+          ≥ eps ^ 2 * Fintype.card V * B'.card := by
+              nlinarith [Nat.cast_nonneg (α := ℚ) B'.card]
+        _ ≥ eps ^ 2 * Fintype.card V * (eps ^ 2 * Fintype.card V) := by nlinarith
+        _ = (eps ^ 2 * Fintype.card V) ^ 2 := by ring
+    have h2 : (0 : ℚ) < (eps ^ 2 * Fintype.card V) ^ 2 := by positivity
+    have hstep1 : (A'.card : ℚ) * B'.card * (edgeDensity G A' B' - edgeDensity G A B) ^ 2 ≥
+        (eps ^ 2 * Fintype.card V) ^ 2 *
+          (edgeDensity G A' B' - edgeDensity G A B) ^ 2 :=
+      mul_le_mul_of_nonneg_right h1 (sq_nonneg _)
+    have hstep2 : (eps ^ 2 * Fintype.card V) ^ 2 * (edgeDensity G A' B' - edgeDensity G A B) ^ 2 >
+        (eps ^ 2 * Fintype.card V) ^ 2 * eps ^ 2 :=
+      mul_lt_mul_of_pos_left hdev h2
+    have hstep3 : (eps ^ 2 * (Fintype.card V : ℚ)) ^ 2 * eps ^ 2 =
+        eps ^ 6 * (Fintype.card V : ℚ) ^ 2 := by ring
+    linarith
+  -- The refined partition P' = (parts \ {A,B}) ∪ {A', A\A', B', B\B'}
+  -- witnesses the energy increment.
+  exact ⟨(parts.erase B).erase A ∪ {A', A₂, B', B₂}, by
+    sorry⟩
 
 end Szemeredi.EnergyIncrement

--- a/proofs/Proofs/SzemerediCoreOQ01Aristotle.lean
+++ b/proofs/Proofs/SzemerediCoreOQ01Aristotle.lean
@@ -3,24 +3,32 @@
   Energy increment step — Finset.sum packaging for refined partition.
   See SzemerediCoreOQ01.lean for the main formalization.
 
-  Status: 1 sorry in energy_increment_step. This file exposes that sorry
-  as a standalone Aristotle target, plus two preparatory helper lemmas.
-
   Context: energy_increment_step proves that refining an ε-irregular pair
   (A,B) in a partition to {A', A\A', B', B\B'} increases partition energy ≥ eps^6.
-  All algebraic lemmas (sub4pair, deviation_identity, excess_lb) are proved.
-  The remaining sorry packages these via Finset.sum_union decomposition.
 
-  Aristotle targets (3):
-  1. partitionEnergy_mono: energy is monotone under partition Finset superset
-  2. partitionEnergy_term_nonneg: each sum term is nonneg (for monotonicity proof)
-  3. energy_increment_packaging_ari: main sorry — the sum packaging step
+  Infrastructure status (updated 2026-04-05):
+  - four_subpair_edge_count_identity: PROVED (= double weighted average)
+  - four_subpair_deviation_identity: PROVED (variance decomposition)
+  - four_subpair_excess_lb: PROVED (variance bound for cross-block)
+  - partitionEnergy_term_nonneg: PROVED (each term ≥ 0)
+  - partitionEnergy_mono: PROVED (monotone under superset) — THIS SESSION
+  - energy_increment_packaging_ari: sorry (Finset.sum_union decomposition)
 
-  Key tools:
-  - Finset.sum_le_sum_of_subset_of_nonneg (monotone subset sums)
-  - Finset.product_subset_product (product monotone in both args)
-  - sub4pair_energy_lower_bound (proved: 4-split ≥ 2-split energy)
-  - four_subpair_excess_lb (proved: excess ≥ A₁*B₁*(d₁₁-d)²)
+  Remaining sorry: package the algebraic lemmas into a Finset sum inequality.
+  The proof needs Finset.sum_union decomposition for:
+    (S ∪ T) ×ˢ (S ∪ T) = S×S ∪ S×T ∪ T×S ∪ T×T
+  vs
+    (S ∪ {A,B}) ×ˢ (S ∪ {A,B}) = S×S ∪ S×{A,B} ∪ {A,B}×S ∪ {A,B}×{A,B}
+
+  Block comparisons (all ≥ 0 or ≥ eps^6):
+  - S×S: identical
+  - S×T ≥ S×{A,B}: density_sq_convex per C ∈ S (splitting A→{A',A₂} and B→{B',B₂})
+  - T×S ≥ {A,B}×S: same by symmetry
+  - T×T ≥ {A,B}×{A,B} + eps^6:
+      A-self: sub4pair_energy_lower_bound ≥ 0
+      B-self: same ≥ 0
+      A×B cross: four_subpair_excess_lb + hcore → ≥ eps^6
+      B×A cross: symmetry → ≥ eps^6 (total ≥ 2*eps^6 ≥ eps^6)
 -/
 import Mathlib
 import Proofs.SzemerediCore
@@ -33,35 +41,34 @@ open Classical Szemeredi.Core Szemeredi.EnergyIncrement
 variable {V : Type*} [Fintype V] [DecidableEq V]
 
 -- ═══════════════════════════════════════════════════════════════════
--- PART I: HELPER LEMMAS
+-- PART I: MONOTONICITY LEMMAS (PROVED THIS SESSION)
 -- ═══════════════════════════════════════════════════════════════════
 
-/-- Each term in the partitionEnergy sum is non-negative.
-
-    `|P| * |Q| / n² * d(P,Q)²` is a product of non-negative factors:
-    - |P|, |Q| are Nat.cast so ≥ 0
-    - n² > 0 (or = 0 and we don't care)
-    - d(P,Q)² ≥ 0 by sq_nonneg -/
+/-- Each term in the partitionEnergy sum is non-negative. -/
 lemma partitionEnergy_term_nonneg (G : SimpleGraph V) [DecidableRel G.Adj]
     (P Q : Finset V) :
     0 ≤ (P.card : ℚ) * Q.card / (Fintype.card V : ℚ) ^ 2 *
-        (edgeDensity G P Q) ^ 2 := by
-  apply mul_nonneg
-  · apply div_nonneg _ (by positivity)
-    apply mul_nonneg <;> exact Nat.cast_nonneg _
-  · exact sq_nonneg _
+        (edgeDensity G P Q) ^ 2 :=
+  mul_nonneg (div_nonneg (mul_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _)) (by positivity))
+    (sq_nonneg _)
 
 /-- **partitionEnergy is monotone** under Finset superset.
-    If P ⊆ Q (as Finset of Finset V), then:
-      partitionEnergy G Q ≥ partitionEnergy G P
+    If P ⊆ Q (as Finset of Finset V), then partitionEnergy G Q ≥ partitionEnergy G P.
 
-    Proof: P × P ⊆ Q × Q (by Finset.product_subset_product).
-    Each term is non-negative (partitionEnergy_term_nonneg).
-    Apply Finset.sum_le_sum_of_subset_of_nonneg. -/
+    Proof: P ×ˢ P ⊆ Q ×ˢ Q by Finset.product_subset_product.
+    Each term is non-negative. Finset.sum_le_sum_of_subset_of_nonneg concludes. -/
 lemma partitionEnergy_mono (G : SimpleGraph V) [DecidableRel G.Adj]
     (P Q : Finset (Finset V)) (hPQ : P ⊆ Q) :
     partitionEnergy G Q ≥ partitionEnergy G P := by
-  sorry
+  unfold partitionEnergy; simp only
+  split_ifs with h
+  · exact le_refl 0
+  · apply Finset.sum_le_sum_of_subset_of_nonneg
+    · exact Finset.product_subset_product hPQ hPQ
+    · intro pq _ _
+      exact mul_nonneg
+        (div_nonneg (mul_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _)) (by positivity))
+        (sq_nonneg _)
 
 -- ═══════════════════════════════════════════════════════════════════
 -- PART II: MAIN ARISTOTLE TARGET
@@ -69,32 +76,30 @@ lemma partitionEnergy_mono (G : SimpleGraph V) [DecidableRel G.Adj]
 
 /-- **Energy increment packaging** — main Aristotle target.
 
-    Show that the refined partition `(parts\{A,B}) ∪ {A',A₂,B',B₂}`
+    Show that the refined partition `S ∪ {A',A₂,B',B₂}` (where S = parts\{A,B})
     has energy ≥ energy(parts) + eps^6.
 
-    Given context:
-    - S = parts.erase B |>.erase A  (all parts except A and B)
-    - T = {A', A₂, B', B₂} where A₂ = A\A', B₂ = B\B'
-    - A'∪A₂ = A, B'∪B₂ = B (from hAu, hBu)
-    - sub4pair: energy({A',A₂,B',B₂}) ≥ energy({A,B})  [proved lemma]
-    - hcore: A'.card * B'.card * dev² > eps^6 * n²      [proved in main]
-    - four_subpair_excess_lb: 4-term sum excess ≥ A₁B₁*(d₁₁-d)²  [proved]
+    Proof strategy: decompose both energies via Finset.sum_union:
+      energy(parts) = energy(S ∪ {A,B}) = S×S + S×{A,B} + {A,B}×S + {A,B}×{A,B}
+      energy(parts') = S×S + S×T + T×S + T×T
+    where T = {A',A₂,B',B₂}.
 
-    Proof strategy (Finset.sum_union decomposition):
-    1. parts = S ∪ {A,B} (as Finset of Finset V, with S ∩ {A,B} = ∅)
-    2. parts' = S ∪ T   (with S ∩ T = ∅)
-    3. Expand via Finset.sum_union: energy = S×S + S×{A,B} + {A,B}×S + {A,B}×{A,B}
-       and energy' = S×S + S×T + T×S + T×T
-    4. S×S: identical
-    5. S×T + T×S ≥ S×{A,B} + {A,B}×S: splitting A,B by density_sq_convex
-    6. T×T ≥ {A,B}×{A,B} + eps^6: from sub4pair + four_subpair_excess_lb + hcore
+    Show each block compares favorably:
+    (1) S×S: equal
+    (2) S×T ≥ S×{A,B}: density_sq_convex splits A→{A',A₂} and B→{B',B₂} for each C∈S
+    (3) T×S ≥ {A,B}×S: same by edgeDensity symmetry
+    (4) T×T ≥ {A,B}×{A,B} + eps^6:
+        - A-self and B-self blocks: sub4pair_energy_lower_bound (≥0 each)
+        - A×B cross: four_subpair_excess_lb + hcore → gain ≥ eps^6
+        - B×A cross: symmetry → another eps^6 (total ≥ 2*eps^6 ≥ eps^6)
 
-    Connection to eps^6:
-    four_subpair_excess_lb gives:
-      Σᵢⱼ Aᵢ*Bⱼ*dᵢⱼ² - A*B*d² ≥ A'.card*B'.card*(d(A',B')-d(A,B))²
-    And hcore gives: A'.card*B'.card*(d-d_AB)² > eps^6 * n²
-    Together: Σᵢⱼ Aᵢ*Bⱼ*dᵢⱼ²/n² > A*B*d²/n² + eps^6
-    Which is: (T×T block for cross-terms) > ({A}×{B} energy) + eps^6 -/
+    Key Lean challenge: disjointness of S and T for Finset.sum_union.
+    This requires A', A\A', B', B\B' ∉ S (the existing non-{A,B} parts).
+    In principle true if the witnesses are proper subsets, but the argument
+    depends on Finset.mem_erase and the definition of S.
+
+    NOTE: An additional hypothesis `hST_disj : Disjoint S T` would make this
+    straightforward. The current statement avoids it to match the main theorem. -/
 theorem energy_increment_packaging_ari
     (G : SimpleGraph V) [DecidableRel G.Adj]
     (eps : ℚ) (heps : 0 < eps) (heps1 : eps ≤ 1)
@@ -105,8 +110,9 @@ theorem energy_increment_packaging_ari
     (hA'sub : A' ⊆ A) (hB'sub : B' ⊆ B)
     (hAd : Disjoint A' (A \ A')) (hBd : Disjoint B' (B \ B'))
     (hAu : A' ∪ (A \ A') = A) (hBu : B' ∪ (B \ B') = B)
-    -- Core quantitative bound: enough excess for eps^6
-    -- (same as hcore in energy_increment_step: proved from irregularity + equipartition)
+    (hA'pos : 0 < A'.card) (hA₂pos : 0 < (A \ A').card)
+    (hB'pos : 0 < B'.card) (hB₂pos : 0 < (B \ B').card)
+    -- Core quantitative bound from irregularity + equipartition
     (hcore : (A'.card : ℚ) * B'.card *
              (edgeDensity G A' B' - edgeDensity G A B) ^ 2 >
              eps ^ 6 * (Fintype.card V : ℚ) ^ 2) :

--- a/research/aristotle-jobs.json
+++ b/research/aristotle-jobs.json
@@ -78,9 +78,9 @@
       "problem_id": "erdos-166",
       "submitted": "2026-01-15T08:27:18Z",
       "sorries": [
-        "theorem ramsey_one_left (t : \u2115) (ht : t \u2265 1) : R(1, t) = 1 := by",
-        "theorem ramsey_symmetric (s t : \u2115) : R(s, t) = R(t, s) := by",
-        "theorem ramsey_two_left (t : \u2115) (ht : t \u2265 2) : R(2, t) = t := by"
+        "theorem ramsey_one_left (t : ℕ) (ht : t ≥ 1) : R(1, t) = 1 := by",
+        "theorem ramsey_symmetric (s t : ℕ) : R(s, t) = R(t, s) := by",
+        "theorem ramsey_two_left (t : ℕ) (ht : t ≥ 2) : R(2, t) = t := by"
       ],
       "notes": "Ramsey R(4,k) lower bound - Mattheus-Verstraete 2023",
       "status": "integrated",
@@ -94,8 +94,8 @@
       "problem_id": "erdos-167",
       "submitted": "2026-01-15T08:27:20Z",
       "sorries": [
-        "theorem k4_tight : \u2203 (G : SimpleGraph (Fin 4)),",
-        "theorem k5_tight : \u2203 (G : SimpleGraph (Fin 5)),",
+        "theorem k4_tight : ∃ (G : SimpleGraph (Fin 4)),",
+        "theorem k5_tight : ∃ (G : SimpleGraph (Fin 5)),",
         "theorem trivial_bound (G : SimpleGraph V) :"
       ],
       "notes": "Tuza triangle covering conjecture",
@@ -110,10 +110,10 @@
       "problem_id": "erdos-168",
       "submitted": "2026-01-15T08:27:30Z",
       "sorries": [
-        "theorem better_construction (N : \u2115) :",
-        "theorem density_bounded (N : \u2115) (hN : N \u2265 1) :",
-        "theorem F_monotone (N : \u2115) : F N \u2264 F (N + 1) := by",
-        "theorem simple_lower_bound (N : \u2115) (hN : N \u2265 1) :"
+        "theorem better_construction (N : ℕ) :",
+        "theorem density_bounded (N : ℕ) (hN : N ≥ 1) :",
+        "theorem F_monotone (N : ℕ) : F N ≤ F (N + 1) := by",
+        "theorem simple_lower_bound (N : ℕ) (hN : N ≥ 1) :"
       ],
       "notes": "n 2n 3n free sets - GSW 1977",
       "status": "integrated",
@@ -128,7 +128,7 @@
       "submitted": "2026-01-15T08:27:35Z",
       "sorries": [
         "theorem chromatic_ge_clique {V : Type*} [Fintype V] (G : SimpleGraph V) :",
-        "theorem trivial_upper (n : \u2115) : maxChromaticSegments n \u2264 n := by"
+        "theorem trivial_upper (n : ℕ) : maxChromaticSegments n ≤ n := by"
       ],
       "notes": "Segment intersection chromatic - Pawlik 2014",
       "status": "integrated",
@@ -208,7 +208,7 @@
       "sorries": [
         ""
       ],
-      "notes": "Chromatic subgraphs - R\u00f6dl 1977",
+      "notes": "Chromatic subgraphs - Rödl 1977",
       "status": "integrated",
       "last_check": null,
       "integrated": "2026-01-16"
@@ -312,7 +312,7 @@
         "squarefree_double_odd",
         "squarefree_one"
       ],
-      "notes": "REVISIT: 9 axioms. Main conjectures OPEN. Supporting axioms HARD (Filaseta-Trifonov 1992, Pandey 2024, Erd\u0151s 1951, Granville 1998). Build verified.",
+      "notes": "REVISIT: 9 axioms. Main conjectures OPEN. Supporting axioms HARD (Filaseta-Trifonov 1992, Pandey 2024, Erdős 1951, Granville 1998). Build verified.",
       "status": "failed",
       "last_check": null,
       "outcome": "Aristotle failed to load environment. All sorries converted to axioms. No theorems proved.",
@@ -333,7 +333,7 @@
         "liu_montgomery",
         "penman_uncountable"
       ],
-      "notes": "REVISIT: 8 axioms. SOLVED (Liu-Montgomery 2020). Axioms include de Bruijn-Erd\u0151s, Bondy-Simonovits, high degree cycle results. Build verified.",
+      "notes": "REVISIT: 8 axioms. SOLVED (Liu-Montgomery 2020). Axioms include de Bruijn-Erdős, Bondy-Simonovits, high degree cycle results. Build verified.",
       "status": "failed",
       "last_check": null,
       "outcome": "Aristotle failed to load environment. Unexpected axioms added. No theorems proved.",
@@ -354,7 +354,7 @@
         "harborth_five",
         "kreisel_kurz_seven"
       ],
-      "notes": "REVISIT: 8 axioms. OPEN for general case, n=7 best known. Axioms include Anning-Erd\u0151s, Harborth n=5, Kreisel-Kurz n=7, GIP sparsity. Build verified.",
+      "notes": "REVISIT: 8 axioms. OPEN for general case, n=7 best known. Axioms include Anning-Erdős, Harborth n=5, Kreisel-Kurz n=7, GIP sparsity. Build verified.",
       "status": "failed",
       "last_check": null,
       "outcome": "Aristotle failed to load environment. No theorems proved - all axiomatized.",
@@ -368,8 +368,8 @@
       "sorries": [
         "kovac_tao_all_rationals",
         "stolarsky_conjecture_false",
-        "theorem harmonic_diverges : \u00acSummable (fun n : \u2115 => (1 : \u211d) / (n + 1)) := by",
-        "theorem sum_reciprocal_squares_summable : Summable (fun n : \u2115 => (1 : \u211d) / (n + 1)^2) := by"
+        "theorem harmonic_diverges : ¬Summable (fun n : ℕ => (1 : ℝ) / (n + 1)) := by",
+        "theorem sum_reciprocal_squares_summable : Summable (fun n : ℕ => (1 : ℝ) / (n + 1)^2) := by"
       ],
       "notes": "Standard convergence/divergence results for series",
       "status": "failed",
@@ -391,8 +391,8 @@
         "suk_bound",
         "theorem f_3_value : f 3 = 3 := by",
         "theorem f_4_lb : 4 < f 4 := by",
-        "theorem f_4_ub : f 4 \u2264 5 := by",
-        "theorem f_finite (n : \u2115) (hn : 3 \u2264 n) : (CardSet n).Nonempty := by",
+        "theorem f_4_ub : f 4 ≤ 5 := by",
+        "theorem f_finite (n : ℕ) (hn : 3 ≤ n) : (CardSet n).Nonempty := by",
         "theorem f_three_eq : f 3 = 3 := by"
       ],
       "notes": "5 sorries: Happy Ending Problem - f_3_value, f_4_lb, f_4_ub, f_finite, f_three_eq",
@@ -430,9 +430,9 @@
         "theorem example_binomial_square :",
         "theorem example_trinomial_square :",
         "theorem f_one : f 1 = 1 := by",
-        "theorem f_pos (k : \u2115) (hk : k \u2265 1) : f k \u2265 1 := by",
+        "theorem f_pos (k : ℕ) (hk : k ≥ 1) : f k ≥ 1 := by",
         "theorem f_two : f 2 = 3 := by",
-        "theorem general_divergence (n : \u2115) (hn : n \u2265 1) :",
+        "theorem general_divergence (n : ℕ) (hn : n ≥ 1) :",
         "theorem schinzel_lower_bound :",
         "theorem schinzel_zannier_improved :"
       ],
@@ -450,10 +450,10 @@
         "brownRodl_theorem",
         "erdos303_true",
         "theorem infinitely_many_solutions :",
-        "theorem monochromatic_iff_alt (\ud835\udcd2 : \u2124 \u2192 \u03b1) (a b c : \u2124) :",
-        "theorem unitFractionEq_iff_alt (a b c : \u2124) (ha : a \u2260 0) (hb : b \u2260 0) (hc : c \u2260 0) :"
+        "theorem monochromatic_iff_alt (𝓒 : ℤ → α) (a b c : ℤ) :",
+        "theorem unitFractionEq_iff_alt (a b c : ℤ) (ha : a ≠ 0) (hb : b ≠ 0) (hc : c ≠ 0) :"
       ],
-      "notes": "Monochromatic Unit Fraction Solutions - SOLVED (Brown-R\u00f6dl 1991)",
+      "notes": "Monochromatic Unit Fraction Solutions - SOLVED (Brown-Rödl 1991)",
       "status": "integrated",
       "last_check": null,
       "integrated": "2026-01-19",
@@ -532,7 +532,7 @@
       "status": "integrated",
       "original_sorries": 5,
       "solved_sorries": 3,
-      "notes": "Integrated from batch - 5\u21923 sorries"
+      "notes": "Integrated from batch - 5→3 sorries"
     },
     {
       "project_id": "e8c7f151-cf4a-4257-9ee1-cc564571ebff",
@@ -543,7 +543,7 @@
       "status": "integrated",
       "original_sorries": 3,
       "solved_sorries": 2,
-      "notes": "Integrated from batch - 3\u21922 sorries"
+      "notes": "Integrated from batch - 3→2 sorries"
     },
     {
       "project_id": "463fd6f9-3344-4387-82fe-0c9a02da0dec",
@@ -554,7 +554,7 @@
       "status": "integrated",
       "original_sorries": 2,
       "solved_sorries": 1,
-      "notes": "Integrated from batch - 2\u21921 sorries"
+      "notes": "Integrated from batch - 2→1 sorries"
     },
     {
       "project_id": "4d4f46e7-8d9e-49a3-8943-4c97ee8a241f",
@@ -565,7 +565,7 @@
       "status": "integrated",
       "original_sorries": 5,
       "solved_sorries": 1,
-      "notes": "Integrated from batch - 5\u21921 sorries"
+      "notes": "Integrated from batch - 5→1 sorries"
     },
     {
       "project_id": "254112df-e7b4-495b-8be3-2d2617d6d9e6",
@@ -576,7 +576,7 @@
       "status": "integrated",
       "original_sorries": 2,
       "solved_sorries": 1,
-      "notes": "Integrated from batch - 2\u21921 sorries"
+      "notes": "Integrated from batch - 2→1 sorries"
     },
     {
       "project_id": "a906ad36-22fc-4cc3-9c05-75bb1642dce8",
@@ -587,7 +587,7 @@
       "status": "integrated",
       "original_sorries": 3,
       "solved_sorries": 1,
-      "notes": "Integrated from batch - 3\u21921 sorries"
+      "notes": "Integrated from batch - 3→1 sorries"
     },
     {
       "project_id": "f5d0f273-819d-49bf-9021-01842b19bafa",
@@ -598,7 +598,7 @@
       "status": "integrated",
       "original_sorries": 5,
       "solved_sorries": 1,
-      "notes": "Integrated from batch - 5\u21921 sorries"
+      "notes": "Integrated from batch - 5→1 sorries"
     },
     {
       "project_id": "ca6f73f6-7352-477a-9749-0820bcfd35b4",
@@ -609,7 +609,7 @@
       "status": "integrated",
       "original_sorries": 3,
       "solved_sorries": 1,
-      "notes": "Integrated from batch - 3\u21921 sorries"
+      "notes": "Integrated from batch - 3→1 sorries"
     },
     {
       "project_id": "b01a17b8-e26e-43e4-be75-3aed52544d5f",
@@ -620,7 +620,7 @@
       "status": "integrated",
       "original_sorries": 4,
       "solved_sorries": 1,
-      "notes": "Integrated from batch - 4\u21921 sorries"
+      "notes": "Integrated from batch - 4→1 sorries"
     },
     {
       "project_id": "8942450f-e396-4846-97d7-20d51ef5dc57",
@@ -631,7 +631,7 @@
       "status": "integrated",
       "original_sorries": 3,
       "solved_sorries": 1,
-      "notes": "Integrated from batch - 3\u21921 sorries"
+      "notes": "Integrated from batch - 3→1 sorries"
     },
     {
       "project_id": "74278ca0-5769-438b-99fa-24efaa3f8ab9",
@@ -642,7 +642,7 @@
       "status": "integrated",
       "original_sorries": 4,
       "solved_sorries": 1,
-      "notes": "Integrated from batch - 4\u21921 sorries"
+      "notes": "Integrated from batch - 4→1 sorries"
     },
     {
       "project_id": "fc551401-f8db-40d2-9c00-d35b6708cb8e",
@@ -653,7 +653,7 @@
       "status": "integrated",
       "original_sorries": 3,
       "solved_sorries": 1,
-      "notes": "Integrated from batch - 3\u21921 sorries"
+      "notes": "Integrated from batch - 3→1 sorries"
     },
     {
       "project_id": "0981c660-3812-4596-b582-37bcd8147b2f",
@@ -664,7 +664,7 @@
       "status": "integrated",
       "original_sorries": 3,
       "solved_sorries": 1,
-      "notes": "Integrated from batch - 3\u21921 sorries"
+      "notes": "Integrated from batch - 3→1 sorries"
     },
     {
       "project_id": "07534fa5-cea1-4211-ac2e-66e3b86304f3",
@@ -675,7 +675,7 @@
       "status": "integrated",
       "original_sorries": 7,
       "solved_sorries": 1,
-      "notes": "Integrated from batch - 7\u21921 sorries"
+      "notes": "Integrated from batch - 7→1 sorries"
     },
     {
       "project_id": "b68219bf-f6f6-468d-aaf9-dee153ed25e4",
@@ -686,7 +686,7 @@
       "status": "integrated",
       "original_sorries": 3,
       "solved_sorries": 1,
-      "notes": "Integrated from batch - 3\u21921 sorries"
+      "notes": "Integrated from batch - 3→1 sorries"
     },
     {
       "project_id": "2c0deff5-83dc-45bd-a8dc-7d900c102ea5",
@@ -697,7 +697,7 @@
       "status": "integrated",
       "original_sorries": 3,
       "solved_sorries": 2,
-      "notes": "Integrated from batch - 3\u21922 sorries"
+      "notes": "Integrated from batch - 3→2 sorries"
     },
     {
       "project_id": "53ad8a5a-cb79-424d-a474-eb6a05318d2c",
@@ -708,7 +708,7 @@
       "status": "integrated",
       "original_sorries": 2,
       "solved_sorries": 1,
-      "notes": "Integrated from batch - 2\u21921 sorries"
+      "notes": "Integrated from batch - 2→1 sorries"
     },
     {
       "project_id": "ecfa895b-88ce-4432-aa19-9f0b5db1f88c",
@@ -719,7 +719,7 @@
       "status": "integrated",
       "original_sorries": 11,
       "solved_sorries": 6,
-      "notes": "Integrated from batch - 11\u21926 sorries"
+      "notes": "Integrated from batch - 11→6 sorries"
     },
     {
       "project_id": "5e879a4b-c313-4d93-ada9-41f2dcf2407c",
@@ -730,7 +730,7 @@
       "status": "integrated",
       "original_sorries": 1,
       "solved_sorries": 0,
-      "notes": "Integrated from batch - 1\u21920 sorries"
+      "notes": "Integrated from batch - 1→0 sorries"
     },
     {
       "project_id": "6bcac25f-2091-4639-a3d8-7ff2d53963c1",
@@ -2454,7 +2454,7 @@
       "preprocessing_log": null,
       "companion_file": true,
       "notes": "Companion file submission (T1)",
-      "outcome": "0 sorries remaining (companion file \u2014 merge into Erdos247Problem.lean)",
+      "outcome": "0 sorries remaining (companion file — merge into Erdos247Problem.lean)",
       "theorems_proved": 0
     },
     {
@@ -2989,7 +2989,7 @@
       "preprocessing_log": null,
       "companion_file": true,
       "notes": "Companion file submission (T1)",
-      "outcome": "1 sorries remaining (companion file \u2014 merge into Erdos1040Problem.lean)",
+      "outcome": "1 sorries remaining (companion file — merge into Erdos1040Problem.lean)",
       "theorems_proved": 3
     },
     {
@@ -3002,7 +3002,7 @@
       "preprocessing_log": null,
       "companion_file": true,
       "notes": "Companion file submission (T1)",
-      "outcome": "0 sorries remaining (companion file \u2014 merge into Erdos1OQ03Problem.lean)",
+      "outcome": "0 sorries remaining (companion file — merge into Erdos1OQ03Problem.lean)",
       "theorems_proved": 1
     },
     {
@@ -3113,6 +3113,18 @@
         "hpe_bound"
       ],
       "notes": "4 sorries: Gibbs+bimodal, Jensen, calculus monotonicity, Cauchy-Schwarz"
+    },
+    {
+      "project_id": "155eab6b-9546-4c3a-9923-8c4f21d15375",
+      "file": "proofs/Proofs/SzemerediCoreOQ01Aristotle.lean",
+      "problem_id": "szemeredi-core-oq-01",
+      "submitted": "2026-04-05T22:12:31Z",
+      "sorries": [
+        ""
+      ],
+      "notes": "End of session: energy_increment_packaging_ari sorry — Finset.sum_union decomposition for block energy comparison",
+      "status": "submitted",
+      "last_check": null
     }
   ]
 }

--- a/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/index.ts
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-02-oq-03-oq-01/index.ts
@@ -3,7 +3,7 @@ import metaJson from './meta.json'
 import annotationsJson from './annotations.json'
 import sourceRaw from '../../../../proofs/Proofs/ArithmeticSeriesOQ02OQ02OQ03OQ01.lean?raw'
 
-const meta = metaJson as unknown as {
+const meta = metaJson as {
   id: string
   title: string
   slug: string

--- a/src/data/proofs/spherical-law-of-sines/meta.json
+++ b/src/data/proofs/spherical-law-of-sines/meta.json
@@ -8,14 +8,7 @@
     "date": "2026-04-04",
     "status": "verified",
     "proofRepoPath": "Proofs/SphericalLawOfSines.lean",
-    "tags": [
-      "geometry",
-      "spherical-geometry",
-      "trigonometry",
-      "law-of-sines",
-      "non-euclidean-geometry",
-      "cross-product"
-    ],
+    "tags": ["geometry", "spherical-geometry", "trigonometry", "law-of-sines", "non-euclidean-geometry", "cross-product"],
     "badge": "original",
     "sorries": 0,
     "dateAdded": "2026-04-04",

--- a/src/data/research/problems/szemeredi-core-oq-01.json
+++ b/src/data/research/problems/szemeredi-core-oq-01.json
@@ -29,14 +29,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: All algebraic lemmas proved; partitionEnergy_mono proved; block decomposition strategy documented; one sorry remains (Finset sum packaging)",
+    "progressSummary": "PROGRESS: Restored eps^6 bound after regression; proved four_subpair_edge_count_identity, four_subpair_deviation_identity, four_subpair_excess_lb; partitionEnergy_mono proved; build clean with 1 sorry (Finset sum packaging for energy_increment_step)",
     "builtItems": [
       "edgeDensity_symm: d(A,B)=d(B,A) via swap bijection (SzemerediCoreOQ01.lean:49)",
       "density_sq_convex_right: convexity for second argument via edgeDensity_symm (SzemerediCoreOQ01.lean:63)",
       "sub4pair_energy_lower_bound: 4-subpair energy ≥ original pair (SzemerediCoreOQ01.lean:80)",
       "edgeDensity_union_weighted_avg: weighted average identity proved (SzemerediCoreOQ01.lean:139)",
       "energy_excess_A_split: exact excess = |A₁|·|A₂|/|A|·(d₁-d₂)² (SzemerediCoreOQ01.lean:209)",
-      "partitionEnergy_mono in SzemerediCoreOQ01Aristotle.lean: proved via Finset.sum_le_sum_of_subset_of_nonneg"
+      "partitionEnergy_mono in SzemerediCoreOQ01Aristotle.lean: proved via Finset.sum_le_sum_of_subset_of_nonneg",
+      "four_subpair_edge_count_identity: PROVED (SzemerediCoreOQ01.lean:~250) — distributes union over filter",
+      "four_subpair_deviation_identity: PROVED (SzemerediCoreOQ01.lean:~330) — variance decomposition via linear_combination",
+      "four_subpair_excess_lb: PROVED (SzemerediCoreOQ01.lean:~400) — variance lower bound via mul_lt_mul_of_pos_left"
     ],
     "insights": [
       "partitionEnergy uses n² normalization (n=total vertices), not k² (k=parts count)",
@@ -46,7 +49,10 @@
       "After set a₁ : ℚ := (A₁.card : ℚ), no further simp [show ...] needed as cast already done",
       "Correct energy increment bound for single irregular pair is eps^6 (not eps^5); eps^5 is for total over all irregular pairs",
       "Block decomposition strategy: S×S equal, S×T≥S×{A,B} by density_sq_convex, T×T≥{A,B}×{A,B}+eps^6 by four_subpair_excess_lb",
-      "Key Lean challenge: S∩T disjointness requires A-prime not in S, follows from hdisjoint + A-prime ⊂ A"
+      "Key Lean challenge: S∩T disjointness requires A-prime not in S, follows from hdisjoint + A-prime ⊂ A",
+      "Lean 4.26.0 API: after simp only [Finset.mem_union], rintro/rcases can fail with Quot.lift; fix with explicit Finset.mem_filter.mp / Finset.mem_product.mp / Finset.mem_union.mp",
+      "four_subpair_deviation_identity: linear_combination (2 * d) * hS closes variance decomposition directly without rw",
+      "hcore nlinarith failure: use mul_lt_mul_of_pos_left + ring normalization + linarith for cross-terms"
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -84,8 +90,8 @@
     {
       "path": "Proofs/SzemerediCoreOQ01.lean",
       "filename": "SzemerediCoreOQ01.lean",
-      "lineCount": 263,
-      "theoremCount": 10,
+      "lineCount": 494,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 1,


### PR DESCRIPTION
## Summary

- Restores `SzemerediCoreOQ01.lean` from 263-line regression (commit `8f949c53cb`) back to the correct 494-line version with `eps^6` energy increment bound
- Proves all algebraic infrastructure: `four_subpair_edge_count_identity`, `four_subpair_deviation_identity`, `four_subpair_excess_lb`
- `partitionEnergy_mono` proved in Aristotle companion file
- Build clean: only 1 `sorry` remains (Finset.sum packaging for block decomposition)
- Aristotle job `155eab6b` submitted for overnight processing of `energy_increment_packaging_ari`

## Key fixes applied for Lean 4.26.0 compatibility

- `Finset.mem_union` simp produces `Quot.lift` terms that `rintro/rcases` can't pattern-match — replaced with explicit `Finset.mem_filter.mp / Finset.mem_product.mp / Finset.mem_union.mp`
- `linear_combination (2 * d) * hS` closes variance decomposition without fragile `rw`
- `mul_lt_mul_of_pos_left` + `ring` + `linarith` for cross-term nonlinear bounds

## Test plan

- [x] `docker-build.sh Proofs.SzemerediCoreOQ01` succeeds
- [x] Only `warning: declaration uses 'sorry'` at line 420 (intended packaging sorry)
- [x] Aristotle job submitted for overnight

🤖 Generated with [Claude Code](https://claude.com/claude-code)