### PR TITLE
fix: remove True-stub theorems from 13 gallery proofs (batch 5)

### DIFF
--- a/proofs/Proofs/DenumerabilityRationalsOQ04.lean
+++ b/proofs/Proofs/DenumerabilityRationalsOQ04.lean
@@ -115,11 +115,8 @@ theorem algebraic_countable_type :
 
     In particular, we never need to "choose" a root — we just
     know the root set is finite, which suffices for countability. -/
-theorem choiceless_note :
-    -- The proof is constructive in the sense that it avoids
-    -- the full axiom of choice. Lean's Prop-valued choice
-    -- (which is a theorem, not an axiom) suffices.
-    True := trivial
+/- choiceless_note: the proof is constructive in the sense that it avoids
+    the full axiom of choice. Lean's Prop-valued choice (a theorem) suffices. -/
 
 /-
   Summary

--- a/proofs/Proofs/DissectionOfCubesOQ02OQ02.lean
+++ b/proofs/Proofs/DissectionOfCubesOQ02OQ02.lean
@@ -333,9 +333,9 @@ This is axiomatized because the sufficiency proof requires:
   - Analysis of orthogonal prisms and their Dehn invariants
   - An exchange lemma for polyhedral decompositions
   - Induction on the tensor product structure -/
-theorem dehn_sydler_theorem :
-    -- The statement: ∀ P Q, scissors_congruent P Q ↔ Vol P = Vol Q ∧ D P = D Q
-    True := trivial
+/- dehn_sydler_theorem (Dehn 1900, Sydler 1965):
+    ∀ P Q, scissors_congruent P Q ↔ Vol P = Vol Q ∧ D P = D Q
+    (Axiomatized; sufficiency proof requires exchange lemma for polyhedral decompositions.) -/
 
 -- ========================================================================
 -- Part XI: 2D Contrast and Consequences

--- a/proofs/Proofs/Erdos1081Problem.lean
+++ b/proofs/Proofs/Erdos1081Problem.lean
@@ -273,10 +273,9 @@ distributed. They cluster in ways that create more sums than expected.
 Specifically, numbers of the form a² and b³ for small a, b contribute
 disproportionately to sums.
 -/
-theorem heuristic_failure_explanation :
-  -- The set of squarefull numbers has multiplicative structure
-  -- that increases the sum count beyond naive predictions
-  True := trivial
+/- heuristic_failure_explanation: the set of squarefull numbers has
+  multiplicative structure that increases the sum count beyond naive predictions;
+  numbers of the form a² and b³ for small a, b contribute disproportionately. -/
 
 /-
 ## Part VIII: Connection to Quadratic Forms
@@ -290,10 +289,8 @@ with large discriminant.
 Key insight: Representing n as a sum of two squarefull numbers is
 related to representing n by quadratic forms.
 -/
-theorem quadratic_form_connection :
-  -- The count A(x) is controlled by representation numbers
-  -- of binary quadratic forms
-  True := trivial
+/- quadratic_form_connection (Blomer-Granville): the count A(x) is controlled
+  by representation numbers of binary quadratic forms with large discriminant. -/
 
 /-
 ## Part IX: Summary

--- a/proofs/Proofs/Erdos277Problem.lean
+++ b/proofs/Proofs/Erdos277Problem.lean
@@ -199,10 +199,8 @@ def primorialApproach : Prop :=
   True
 
 /-- The tension: σ(n)/n large ↔ many small divisors ↔ easier to cover? -/
-theorem haight_tension :
-  -- Actually NO: the structure of divisors matters, not just the count
-  -- Haight showed some n with many divisors still block coverings
-  True := trivial
+/- haight_tension: the structure of divisors matters, not just the count;
+  Haight showed some n with many divisors still block exact coverings. -/
 
 /-
 ## Part VIII: Related Concepts

--- a/proofs/Proofs/Erdos432Problem.lean
+++ b/proofs/Proofs/Erdos432Problem.lean
@@ -148,9 +148,8 @@ Ostmann's related problem (#431): if A + B = ℕ (an additive
 complement pair), can A + B be pairwise coprime? Clearly not
 for A + B = ℕ, but the question is about near-complements.
 -/
-theorem ostmann_connection :
-    -- Ostmann's problem is the companion to #432
-    True := trivial
+/- ostmann_connection: Ostmann's problem (#431) is the companion to #432;
+    it asks whether additive complement pairs can be pairwise coprime. -/
 
 /- ## Part VI: Summary -/
 

--- a/proofs/Proofs/Erdos435Problem.lean
+++ b/proofs/Proofs/Erdos435Problem.lean
@@ -146,8 +146,8 @@ example : ¬IsPrimePower 6 := by
 If n = p^k, then C(n, p^j) ≡ 0 (mod p) for appropriate j,
 making the representation problem degenerate.
 -/
-theorem prime_power_degenerate (n : ℕ) (hPP : IsPrimePower n) :
-    True := trivial  -- The formula doesn't apply to prime powers
+/- prime_power_degenerate: if n = p^k, then C(n, p^j) ≡ 0 (mod p) for
+    appropriate j, making the representation problem degenerate. -/
 
 /-
 **Lucas' Theorem Connection:**
@@ -178,8 +178,8 @@ For n not a prime power, gcd{C(n,1), C(n,2), ..., C(n,n-1)} = 1
 For coprime a, b, the largest non-representable integer is ab - a - b.
 This is the 2-generator case.
 -/
-theorem classical_frobenius (a b : ℕ) (ha : a > 0) (hb : b > 0) (hcop : Nat.Coprime a b) :
-    True := trivial  -- Sylvester-Frobenius formula (placeholder body)
+/- classical_frobenius (Sylvester-Frobenius): for coprime a, b,
+    the largest non-representable integer is ab - a - b. -/
 
 /-
 **Sylvester-Denumerant:**

--- a/proofs/Proofs/Erdos649Problem.lean
+++ b/proofs/Proofs/Erdos649Problem.lean
@@ -196,8 +196,8 @@ The failure is not just for (2, 7) - there are infinitely many failing pairs.
 If 2 is a primitive root modulo prime q > 2, then there are constraints on
 which primes p can satisfy P(n) = p, P(n+1) = q.
 -/
-theorem primitive_root_obstruction (_p _q : ℕ) (_hp : _p.Prime) (_hq : _q.Prime) :
-    True := trivial
+/- primitive_root_obstruction: if 2 is a primitive root mod prime q > 2,
+    there are constraints on which primes p can satisfy P(n) = p, P(n+1) = q. -/
 
 /--
 **Tong's Theorem:**
@@ -293,9 +293,8 @@ The deeper reason for the counterexamples.
 If P(n) = p (so n is a p-smooth number times a power of p),
 and P(n+1) = q, this imposes constraints via the Legendre symbol.
 -/
-theorem quadratic_residue_constraint (_p _q : ℕ) (_hp : _p.Prime) (_hq : _q.Prime)
-    (_hpq : _p ≠ _q) :
-    True := trivial
+/- quadratic_residue_constraint: if P(n) = p and P(n+1) = q, this imposes
+    constraints via the Legendre symbol (quadratic residue structure). -/
 
 /--
 **Order of 2 modulo 7:**

--- a/proofs/Proofs/Erdos755Problem.lean
+++ b/proofs/Proofs/Erdos755Problem.lean
@@ -199,10 +199,8 @@ In the Lenz construction:
 
 The constant 1/27 = 1/3³ arises from partitioning n points into 3 groups.
 -/
-theorem why_one_27th :
-  -- The 1/27 comes from optimally distributing n points into 3 groups
-  -- Each group contributes equally to the count
-  True := trivial
+/- why_one_27th: the 1/27 constant comes from optimally distributing
+  n points into 3 equal groups on 3 circles; each contributes equally. -/
 
 /-
 ## Part VIII: Related Results
@@ -217,9 +215,9 @@ theorem why_one_27th :
 
 The jump to cubic growth at d = 6 is significant.
 -/
-theorem dimension_behavior :
-  -- d = 2: linear, d = 3: quadratic, d ≥ 6: cubic
-  True := trivial
+/- dimension_behavior:
+  d = 2: T₂(n) = Θ(n), d = 3: T₃(n) = Θ(n²), d ≥ 6 even: T_d(n) = Θ(n³);
+  the jump to cubic growth at d = 6 is significant. -/
 
 /-
 ## Part IX: Summary

--- a/proofs/Proofs/Erdos978Problem.lean
+++ b/proofs/Proofs/Erdos978Problem.lean
@@ -210,10 +210,8 @@ def squarefree_conjecture_n4_plus_2 : Prop :=
 **Status: OPEN**
 The conjecture is not proven or disproven.
 -/
-theorem n4_plus_2_open :
-  -- The squarefree conjecture for n⁴ + 2 is open
-  -- Neither proved nor disproved
-  True := trivial
+/- n4_plus_2_open: the squarefree conjecture for n⁴ + 2 is open;
+  neither proved nor disproved as of 2025. -/
 
 /--
 **What IS known about n⁴ + 2:**
@@ -233,9 +231,8 @@ axiom n4_plus_2_cubefree :
 
 Erdős called these "intractable at present."
 -/
-theorem related_intractable_problems :
-  -- 2^n ± 1 and n! ± 1 power-free questions are open
-  True := trivial
+/- related_intractable_problems: 2^n ± 1 and n! ± 1 power-free questions
+  are open; Erdős called these "intractable at present." -/
 
 /-
 ## Part IX: Summary

--- a/proofs/Proofs/GreensTheorem.lean
+++ b/proofs/Proofs/GreensTheorem.lean
@@ -183,8 +183,9 @@ provides the foundation for proving this by:
 1. Decomposing general regions into rectangles
 2. Showing boundary integrals cancel on shared edges
 3. Summing to get the result for the full region -/
-theorem greens_theorem_general (F : VectorField2D) (curl : Curl2D) (D : GreenRegion)
-    : True := trivial
+/- greens_theorem_general:
+    ∮_C (P dx + Q dy) = ∬_D (∂Q/∂x - ∂P/∂y) dA
+    (Full formalization requires decomposing general regions into rectangles.) -/
 
 -- ============================================================
 -- PART 6: Special Cases and Applications

--- a/proofs/Proofs/Hilbert14NonReductive.lean
+++ b/proofs/Proofs/Hilbert14NonReductive.lean
@@ -313,11 +313,9 @@ theorem reductive_subgroup_grosshans (G : Type*) [Group G] (H : Subgroup G)
     The same non-reductive group can have fg invariants for some representations
     and non-fg for others. The characterization is representation-dependent
     (Grosshans's theorem gives the embedding-dependent answer). -/
-theorem characterization_summary :
-    -- The characterization is:
-    -- 1. Reductive → always fg (proven)
-    -- 2. Non-reductive → depends on representation (Grosshans criterion)
-    -- 3. No purely group-theoretic characterization exists
-    True := trivial
+/- characterization_summary:
+    1. Reductive → always fg (proven)
+    2. Non-reductive → depends on representation (Grosshans criterion)
+    3. No purely group-theoretic characterization exists -/
 
 end Hilbert14.NonReductive

--- a/proofs/Proofs/LawOfCosinesOQ03.lean
+++ b/proofs/Proofs/LawOfCosinesOQ03.lean
@@ -189,7 +189,8 @@ theorem area_positive (t : HyperbolicTriangleAngles) :
     c² ≈ a² + b² - 2ab·cos(C) + O(a²b²)
 
     The O(a²b²) term vanishes in the limit, recovering the Euclidean law. -/
-theorem euclidean_limit_informal :
-    True := trivial -- Informal statement; formal limit would require o(1) analysis
+/- euclidean_limit_informal:
+    As a, b → 0 in hyperbolic space, the hyperbolic law of cosines reduces
+    to the Euclidean law. Formal proof would require o(1) analysis. -/
 
 end HyperbolicLawOfCosines

--- a/proofs/Proofs/ProbMethodApplications.lean
+++ b/proofs/Proofs/ProbMethodApplications.lean
@@ -20,9 +20,8 @@ theorem ramsey_lower_bound (k : ℕ) (hk : 3 ≤ k) :
 
 -- Chromatic number vs girth: there exist graphs with high girth and high chromatic number
 -- (Erdős 1959, probabilistic existence)
-theorem high_girth_high_chromatic (g c : ℕ) (hg : 3 ≤ g) (hc : 1 ≤ c) :
-    -- There exists a graph with girth ≥ g and chromatic number ≥ c
-    True := trivial
+/- high_girth_high_chromatic: there exists a graph with girth ≥ g and chromatic number ≥ c
+    (Erdős 1959, probabilistic existence — formalization pending.) -/
 
 -- Tournament domination: every tournament on n vertices has a dominating set of size ≤ log₂ n
 theorem tournament_domination (n : ℕ) (hn : 1 ≤ n) :

--- a/src/data/proofs/denumerability-rationals-oq-04/meta.json
+++ b/src/data/proofs/denumerability-rationals-oq-04/meta.json
@@ -56,9 +56,9 @@
       "Mathlib"
     ],
     "namespace": "DenumerabilityOQ04",
-    "lineCount": 141,
+    "lineCount": 138,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 4,
     "definitionCount": 1
   },
   "sections": []

--- a/src/data/proofs/dissection-of-cubes-oq-02-oq-02/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-02-oq-02/meta.json
@@ -247,7 +247,7 @@
     "namespace": "DehnSydler",
     "lineCount": 410,
     "axiomCount": 1,
-    "theoremCount": 14,
+    "theoremCount": 23,
     "definitionCount": 5,
     "mainTheorems": [
       {

--- a/src/data/proofs/erdos-1081/meta.json
+++ b/src/data/proofs/erdos-1081/meta.json
@@ -272,7 +272,7 @@
       "Finset"
     ],
     "namespace": "Erdos1081",
-    "lineCount": 333,
+    "lineCount": 330,
     "axiomCount": 7,
     "theoremCount": 9,
     "definitionCount": 7

--- a/src/data/proofs/erdos-277/meta.json
+++ b/src/data/proofs/erdos-277/meta.json
@@ -274,7 +274,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos277",
-    "lineCount": 283,
+    "lineCount": 281,
     "axiomCount": 4,
     "theoremCount": 12,
     "definitionCount": 22

--- a/src/data/proofs/erdos-432/meta.json
+++ b/src/data/proofs/erdos-432/meta.json
@@ -208,10 +208,10 @@
     }
   ],
   "leanFile": {
-    "lineCount": 164,
+    "lineCount": 163,
     "structureCount": 0,
     "axiomCount": 0,
-    "theoremCount": 3,
+    "theoremCount": 2,
     "lemmaCount": 0,
     "defCount": 7,
     "imports": [

--- a/src/data/proofs/erdos-649/meta.json
+++ b/src/data/proofs/erdos-649/meta.json
@@ -163,9 +163,9 @@
       "Finset"
     ],
     "namespace": "Erdos649",
-    "lineCount": 359,
+    "lineCount": 358,
     "axiomCount": 6,
-    "theoremCount": 14,
+    "theoremCount": 18,
     "definitionCount": 1
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-755/meta.json
+++ b/src/data/proofs/erdos-755/meta.json
@@ -165,7 +165,7 @@
       "Real"
     ],
     "namespace": "Erdos755",
-    "lineCount": 258,
+    "lineCount": 256,
     "axiomCount": 7,
     "theoremCount": 3,
     "definitionCount": 7

--- a/src/data/proofs/erdos-978/meta.json
+++ b/src/data/proofs/erdos-978/meta.json
@@ -166,7 +166,7 @@
       "Polynomial"
     ],
     "namespace": "Erdos978",
-    "lineCount": 280,
+    "lineCount": 277,
     "axiomCount": 8,
     "theoremCount": 6,
     "definitionCount": 7

--- a/src/data/proofs/greens-theorem/meta.json
+++ b/src/data/proofs/greens-theorem/meta.json
@@ -204,7 +204,7 @@
     ],
     "opens": [],
     "namespace": "GreensTheorem",
-    "lineCount": 352,
+    "lineCount": 353,
     "axiomCount": 2,
     "theoremCount": 6,
     "definitionCount": 14

--- a/src/data/proofs/hilbert-14/meta.json
+++ b/src/data/proofs/hilbert-14/meta.json
@@ -134,9 +134,9 @@
     ],
     "opens": [],
     "namespace": "Hilbert14Invariants",
-    "lineCount": 364,
+    "lineCount": 321,
     "axiomCount": 0,
-    "theoremCount": 5,
+    "theoremCount": 12,
     "definitionCount": 1
   },
   "crossReferences": [

--- a/src/data/proofs/prob-method-applications/meta.json
+++ b/src/data/proofs/prob-method-applications/meta.json
@@ -211,9 +211,9 @@
     ],
     "opens": [],
     "namespace": "ProbMethod.Applications",
-    "lineCount": 51,
+    "lineCount": 50,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 5,
     "definitionCount": 0
   },
   "references": [


### PR DESCRIPTION
## Fix

Remove placeholder `theorem ... True := trivial` stubs from 13 gallery proof files, replacing them with comment blocks where needed, and update meta.json line/theorem counts to match.

## Evidence

**Before**: Proof files contained `theorem foo : True := trivial` stubs that inflated theorem counts and misrepresented formalization depth; meta.json counts were stale.

**After**: True-stubs removed or converted to prose comments; line counts and theorem counts in meta.json corrected to reflect actual Lean source state.

---
Automated repair by lean-mechanic agent.