### PR TITLE
fix: remove True-stub theorems from 13 gallery proofs (batch 6)

### DIFF
--- a/proofs/Proofs/DescartesRuleOfSignsOQ01OQ02.lean
+++ b/proofs/Proofs/DescartesRuleOfSignsOQ01OQ02.lean
@@ -261,11 +261,9 @@ Both are necessary; neither alone suffices.
 /-- **The answer**: Both components are needed. This encodes the structural
     fact that the parity proof decomposes into conjugate pairing (complex
     analysis) plus sign variation arithmetic (combinatorial algebra). -/
-theorem infrastructure_assessment :
-    -- The parity proof needs two independent ingredients:
-    -- 1. Non-real roots pair up (from complex conjugation)
-    -- 2. Sign variations change by correct parity under root extraction
-    -- Neither alone is sufficient.
-    True := trivial
+/- infrastructure_assessment: the parity proof needs two independent
+    ingredients: (1) non-real roots pair up (complex conjugation), and
+    (2) sign variations change by correct parity under root extraction.
+    Neither alone is sufficient. -/
 
 end DescartesRuleOfSignsOQ01OQ02

--- a/proofs/Proofs/Erdos1049Problem.lean
+++ b/proofs/Proofs/Erdos1049Problem.lean
@@ -263,10 +263,8 @@ theorem S_as_lambert (t : ℝ) (ht : t > 1) :
     S t = isLambertSeries (fun _ => 1) (1/t) := by
   sorry
 
-/-- Lambert series preserve arithmetic structure. -/
-theorem lambert_arithmetic_property :
-    -- Lambert series of arithmetic functions have special properties
-    True := trivial
+/- lambert_arithmetic_property: Lambert series of arithmetic functions
+    have special multiplicative properties. -/
 
 /-
 ## Part IX: Partial Results
@@ -274,15 +272,11 @@ theorem lambert_arithmetic_property :
 What is known towards Chowla's conjecture.
 -/
 
-/-- S(p/q) is irrational for certain p/q (partial results). -/
-theorem partial_rational_results :
-    -- Some specific rational values have been verified
-    True := trivial
+/- partial_rational_results: S(p/q) is irrational for certain p/q;
+    some specific rational values have been verified. -/
 
-/-- Linear independence results. -/
-theorem linear_independence_partial :
-    -- Partial results on linear independence of S values
-    True := trivial
+/- linear_independence_partial: partial results on linear independence
+    of S values at rational arguments. -/
 
 /-- Approximation bounds for S(t). -/
 theorem S_bounds (t : ℝ) (ht : t > 1) :

--- a/proofs/Proofs/Erdos1100ProblemProvable.lean
+++ b/proofs/Proofs/Erdos1100ProblemProvable.lean
@@ -178,10 +178,7 @@ def question1_almost_all_growth : Prop :=
         (fun n => (tauPerp n : ℝ) / (omega n) < M ∧ omega n > 0)
         (Finset.range x)).card / (x : ℝ) < ε
 
-/--
-**Status of Question 1: OPEN**
--/
-theorem question1_open : True := trivial
+/- Status of Question 1 (Erdős-Hall): OPEN -/
 
 /-
 ## Part IV: Question 2 - Upper Bound
@@ -206,10 +203,7 @@ theorem erdos_hall_max_lower_bound :
     ∀ ε > 0, ∃ X : ℕ, ∀ x : ℕ, x ≥ X →
       ∃ n : ℕ, n < x ∧ (tauPerp n : ℝ) > exp ((log (log x))^(2 - ε)) := by sorry
 
-/--
-**Status of Question 2: OPEN**
--/
-theorem question2_open : True := trivial
+/- Status of Question 2 (Erdős-Hall upper bound): OPEN -/
 
 /-
 ## Part V: Question 3 - Growth of g(k)
@@ -295,7 +289,8 @@ For n = p₁^a₁ · ... · p_k^a_k:
 
 The exponential bounds on g(k) show the structure is neither trivial nor chaotic.
 -/
-theorem structural_insight : True := trivial
+/- structural_insight: the exponential bounds on g(k) reflect that
+    consecutive divisors create intricate combinatorial constraints. -/
 
 /-
 ## Part VIII: Summary

--- a/proofs/Proofs/Erdos1165Problem.lean
+++ b/proofs/Proofs/Erdos1165Problem.lean
@@ -152,10 +152,11 @@ directly part of the problem statement.
     visit count is achieved at a unique site almost surely.
     This motivates the 2D question: in higher dimensions, the
     structure of favourite sites becomes more complex. -/
-theorem bass_griffin_1d_unique :
-  True := trivial  -- P(|F_1D(n)| = 1 for all large n) = 1
+/- bass_griffin_1d_unique (Bass-Griffin 1985): in 1D, for large n, the
+  maximum visit count is achieved at a unique site almost surely.
+  P(|F_1D(n)| = 1 for all large n) = 1. -/
 
-theorem bass_griffin_context : True := bass_griffin_1d_unique
+/- bass_griffin_context: the 1D uniqueness result motivates the 2D open question. -/
 
 /- ## Summary
 

--- a/proofs/Proofs/Erdos181Problem.lean
+++ b/proofs/Proofs/Erdos181Problem.lean
@@ -222,8 +222,8 @@ This question is OPEN. Note:
   so R(Q_n) / 2^n ≤ C · 2^{(1-c)n}, which still → ∞.
   The question remains unresolved.
 -/
-theorem erdos_sos_question_open :
-  True := trivial -- This question is genuinely OPEN; we do not assert either direction
+/- erdos_sos_question_open: whether R(Q_n)/2^n → ∞ is genuinely OPEN;
+  neither direction is currently proved. -/
 
 /-- The conjecture answers Erdős-Sós negatively: R(Q_n)/2^n is bounded. -/
 theorem conjecture_implies_bounded_ratio :

--- a/proofs/Proofs/Erdos321ProblemR1.lean
+++ b/proofs/Proofs/Erdos321ProblemR1.lean
@@ -63,17 +63,11 @@ theorem erdos_321_asymptotics :
     the content of the open problem. -/
 /- ## Observations -/
 
-/-- **Egyptian fraction connection**: The problem relates to
-    representations of rationals as sums of distinct unit fractions.
-    R(N) measures how many denominators from {1,...,N} can be used
-    while keeping all partial sums distinguishable. -/
-theorem egyptian_fraction_connection : True := trivial
+/- **Egyptian fraction connection**: R(N) measures how many denominators
+    from {1,...,N} can be used while keeping all partial sums distinguishable. -/
 
-/-- **Greedy construction**: A natural construction takes all n
-    with certain divisibility properties, ensuring subset sums
-    separate. The challenge is optimizing the selection criterion. -/
-theorem greedy_construction : True := trivial
+/- **Greedy construction**: a natural construction takes all n with
+    certain divisibility properties, ensuring subset sums separate. -/
 
-/-- **OEIS sequences**: Related sequences A384927 and A391592
-    track computed values of R(N) for small N. -/
-theorem oeis_sequences : True := trivial
+/- **OEIS sequences**: A384927 and A391592 track computed values
+    of R(N) for small N. -/

--- a/proofs/Proofs/Erdos396Problem.lean
+++ b/proofs/Proofs/Erdos396Problem.lean
@@ -53,16 +53,11 @@ theorem n_divides_rarely :
 /-- Pomerance: the set of n with (n−k) | C(2n, n) has upper density < 1/3.
     The measure-theoretic statement requires density infrastructure;
     the existential structure here is a placeholder. -/
-theorem pomerance_density_bound (k : ℕ) :
-  -- Upper density of {n : (n−k) | C(2n,n)} is less than 1/3
-  True := trivial
+/- pomerance_density_bound (Pomerance 2014): the upper density of
+  {n : (n−k) | C(2n,n)} is less than 1/3. -/
 
-/-- Pomerance: the set of n with ∏(n+i) | C(2n, n) for i=1..k has density 1.
-    The measure-theoretic statement requires density infrastructure;
-    the existential structure here is a placeholder. -/
-theorem pomerance_ascending_density (k : ℕ) :
-  -- {n : ascFactorial(n+1, k) | C(2n,n)} has asymptotic density 1
-  True := trivial
+/- pomerance_ascending_density (Pomerance 2014): the set of n with
+  ∏(n+i) | C(2n, n) for i=1..k has asymptotic density 1. -/
 
 /- ## The Erdős–Graham Conjecture -/
 

--- a/proofs/Proofs/Erdos515Problem.lean
+++ b/proofs/Proofs/Erdos515Problem.lean
@@ -184,8 +184,8 @@ axiom lewis_rossi_weitsman_1984 : UniversalQuestion
 The Lewis-Rossi-Weitsman result actually holds for e^u where u is any
 subharmonic function, not just u = log|f| for entire f.
 -/
-theorem lrw_subharmonic_version :
-  True := trivial  -- Placeholder for more general statement
+/- lrw_subharmonic_version: the Lewis-Rossi-Weitsman (1984) result holds
+  for e^u where u is any subharmonic function, not just u = log|f|. -/
 
 /-
 ## Part VII: Why This is Surprising

--- a/proofs/Proofs/Erdos575Problem.lean
+++ b/proofs/Proofs/Erdos575Problem.lean
@@ -71,19 +71,17 @@ The exact order is typically a fractional power of n. -/
 
 /-- ex(n; F) ≤ ex(n; G) for any G ∈ F: excluding more graphs can
 only reduce the extremal function. -/
-theorem exFamily_le_member :
-  -- Adding more forbidden graphs reduces the maximum edge count
-  True := trivial
+/- exFamily_le_member: ex(n; F) ≤ ex(n; G) for any G ∈ F;
+  adding more forbidden graphs reduces the maximum edge count. -/
 
 /-- If F contains a bipartite graph, then ex(n; F) = o(n²):
 the family extremal function is subquadratic. -/
-theorem family_with_bipartite_subquadratic :
-  -- Follows from the Kővári–Sós–Turán bound on the bipartite member
-  True := trivial
+/- family_with_bipartite_subquadratic: if F contains a bipartite graph,
+  then ex(n; F) = o(n²) — follows from Kővári–Sós–Turán bound. -/
 
 /-- The conjecture implies that for families with a bipartite member,
 the asymptotic behavior of ex(n; F) is controlled by a single
 bipartite graph in the family. -/
-theorem single_graph_controls :
-  -- This is the precise content of Erdős Problem #575
-  True := trivial
+/- single_graph_controls: for families with a bipartite member,
+  the asymptotic behavior of ex(n; F) is controlled by a single
+  bipartite graph in the family (Erdős Problem #575 conjecture). -/

--- a/proofs/Proofs/Erdos606OQ03.lean
+++ b/proofs/Proofs/Erdos606OQ03.lean
@@ -37,9 +37,8 @@ theorem max_hyperplanes (n d : ℕ) (hd : d ≥ 1) :
 
 /-- In general position (no d+1 points on a hyperplane),
     n points determine exactly C(n,d) hyperplanes. -/
-theorem general_position_count (n d : ℕ) :
-    -- exactly C(n,d) hyperplanes for n points in general position
-    True := trivial
+/- general_position_count: n points in general position (no d+1 on a
+    hyperplane) determine exactly C(n,d) hyperplanes. -/
 
 -- ============================================================
 -- Part II: The Sylvester-Gallai Theorem

--- a/proofs/Proofs/Erdos698Problem.lean
+++ b/proofs/Proofs/Erdos698Problem.lean
@@ -241,17 +241,11 @@ The GCD of binomial coefficients relates to:
 The largest power of prime p dividing C(m+n, m) equals
 the number of carries in adding m and n in base p.
 -/
-theorem kummer_theorem (p m n : ℕ) (hp : p.Prime) :
-  -- The p-adic valuation relates to carry count (placeholder)
-  True := trivial
+/- kummer_theorem: the largest power of prime p dividing C(m+n, m)
+  equals the number of carries in adding m and n in base p. -/
 
-/--
-**Lucas' Theorem:**
-C(m, n) mod p can be computed from base-p digits of m and n.
--/
-theorem lucas_theorem (p m n : ℕ) (hp : p.Prime) :
-  -- Modular reduction of binomial coefficients (placeholder)
-  True := trivial
+/- **Lucas' Theorem:** C(m, n) mod p can be computed from the
+  base-p digits of m and n (modular reduction of binomial coefficients). -/
 
 /-
 ## Part IX: Summary

--- a/proofs/Proofs/LebesgueMeasureOQ03.lean
+++ b/proofs/Proofs/LebesgueMeasureOQ03.lean
@@ -97,10 +97,8 @@ theorem orthonormal_balls_disjoint :
     This → 0 as n → ∞, showing that "most of the volume
     concentrates near the surface" — a preview of the
     infinite-dimensional pathology. -/
-theorem ball_volume_vanishes :
-    -- The volume of the unit ball in ℝⁿ tends to 0 as n → ∞
-    -- (This is provable from the Gamma function asymptotics)
-    True := trivial
+/- ball_volume_vanishes: the volume of the unit ball in ℝⁿ tends to 0
+    as n → ∞ (provable from Gamma function asymptotics). -/
 
 /-- The concentration of measure phenomenon:
     In high dimensions, a Lipschitz function on the sphere Sⁿ⁻¹
@@ -108,8 +106,8 @@ theorem ball_volume_vanishes :
 
     This is a quantitative version of "no translation-invariant
     measure exists": translations spread mass too thin. -/
-theorem concentration_sketch :
-    True := trivial
+/- concentration_sketch: in high dimensions, a Lipschitz function on
+    the sphere Sⁿ⁻¹ is approximately constant on most of the sphere. -/
 
 /-
   Summary

--- a/proofs/Proofs/PACLearning.lean
+++ b/proofs/Proofs/PACLearning.lean
@@ -94,11 +94,9 @@ theorem pac_sample_complexity (d : ℕ) (ε δ : ℝ) (hd : 0 < d)
 -- PART IV: FUNDAMENTAL THEOREM (PLACEHOLDER)
 -- ═══════════════════════════════════════════════════════════════════
 
-/-- Fundamental theorem of statistical learning:
+/- Fundamental theorem of statistical learning:
     A hypothesis class is PAC learnable iff it has finite VC dimension.
-    Placeholder: requires formalizing the PAC learning model, uniform
-    convergence, and the full equivalence chain. -/
-theorem fundamental_theorem_stat_learning {α : Type*} (H : Set (Set α)) :
-    True := trivial
+    (Requires formalizing the PAC learning model, uniform convergence,
+    and the full equivalence chain.) -/
 
 end LearningTheory

--- a/src/data/proofs/descartes-rule-of-signs-oq-01-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01-oq-02/meta.json
@@ -47,7 +47,7 @@
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 1,
-    "lineCount": 271,
+    "lineCount": 269,
     "prerequisites": [
       "Descartes' Rule of Signs (upper bound from Mathlib)",
       "Complex conjugate root theorem",
@@ -159,9 +159,9 @@
     ],
     "opens": [],
     "namespace": "DescartesRuleOfSignsOQ01OQ02",
-    "lineCount": 271,
+    "lineCount": 269,
     "axiomCount": 1,
-    "theoremCount": 10,
+    "theoremCount": 9,
     "definitionCount": 0,
     "mainTheorems": [
       {

--- a/src/data/proofs/erdos-1049/meta.json
+++ b/src/data/proofs/erdos-1049/meta.json
@@ -73,7 +73,7 @@
       "Infinite series convergence (tsum)",
       "p-adic analysis (for understanding Erdős's proof technique)"
     ],
-    "lineCount": 327
+    "lineCount": 321
   },
   "overview": {
     "historicalContext": "The study of arithmetic properties of the series S(t) = sum 1/(t^n - 1) originates in classical analytic number theory. The series naturally arises as a Lambert series with constant coefficients, connecting it to the divisor function tau(n) via the identity S(t) = sum tau(n)/t^n. In 1948, Paul Erdos published 'On arithmetical properties of Lambert series' in the Journal of the Indian Mathematical Society, proving that S(t) is irrational whenever t is an integer >= 2. His proof used careful analysis of the p-adic structure of partial sums. Sarvadaman Chowla conjectured that the irrationality should hold for all rational t > 1, not just integers. This conjecture remains open and connects to broader questions about Lambert series, transcendence theory, and the Erdos-Borwein constant E = S(2) ~ 1.606695. The problem appears as #1049 in the Erdos problems collection and is closely related to #1048 (Lambert series generalizations) and #1050 (related irrationality questions).",
@@ -276,9 +276,9 @@
       "Real"
     ],
     "namespace": null,
-    "lineCount": 327,
+    "lineCount": 321,
     "axiomCount": 2,
-    "theoremCount": 26,
+    "theoremCount": 23,
     "substantiveTheoremCount": 22,
     "trivialSpecializations": 0,
     "definitionCount": 12

--- a/src/data/proofs/erdos-1100/meta.json
+++ b/src/data/proofs/erdos-1100/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/1100",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 335,
+    "lineCount": 330,
     "assumptions": "0 axiom(s) and 3 sorry(s). Deep results (tau_perp_lower_bound, erdos_hall_max_lower_bound, erdos_simonovits_bounds) remain as sorries.",
     "mathlib_version": "4.26.0"
   },
@@ -239,9 +239,9 @@
       "Finset"
     ],
     "namespace": "Erdos1100",
-    "lineCount": 335,
+    "lineCount": 330,
     "axiomCount": 0,
-    "theoremCount": 13,
+    "theoremCount": 10,
     "definitionCount": 7,
     "mainTheorems": [
       {

--- a/src/data/proofs/erdos-1165/meta.json
+++ b/src/data/proofs/erdos-1165/meta.json
@@ -20,7 +20,7 @@
     "erdosUrl": "https://erdosproblems.com/1165",
     "erdosProblemStatus": "solved",
     "axiomCount": 7,
-    "lineCount": 182,
+    "lineCount": 183,
     "assumptions": "8 axioms: VisitCount and FavouriteSites (random walk infrastructure), prob_favourite_count_io with bounds (probability events), toth_favourite_sites_geq_4 (Tóth 2001), hao_li_okada_zheng_three_favourite_sites (Hao et al. 2024), bass_griffin_1d_unique (background). All theorems fully proved from axioms (0 sorries).",
     "mathlib_version": "4.26.0"
   },
@@ -170,9 +170,9 @@
       "MeasureTheory"
     ],
     "namespace": "Erdos1165",
-    "lineCount": 182,
+    "lineCount": 183,
     "axiomCount": 7,
-    "theoremCount": 5,
+    "theoremCount": 3,
     "definitionCount": 2,
     "sorryCount": 0
   }

--- a/src/data/proofs/erdos-181/meta.json
+++ b/src/data/proofs/erdos-181/meta.json
@@ -158,7 +158,7 @@
     "namespace": "Erdos181",
     "lineCount": 382,
     "axiomCount": 3,
-    "theoremCount": 11,
+    "theoremCount": 18,
     "definitionCount": 2
   },
   "references": [

--- a/src/data/proofs/erdos-321/meta.json
+++ b/src/data/proofs/erdos-321/meta.json
@@ -22,7 +22,7 @@
     "badge": "axiom",
     "proofRepoPath": "Proofs/Erdos321Problem.lean",
     "mathlib_version": "4.26.0",
-    "lineCount": 155,
+    "lineCount": 73,
     "mathlibDependencies": [
       {
         "theorem": "Finset.sup",
@@ -160,9 +160,9 @@
     }
   ],
   "leanFile": {
-    "lineCount": 155,
+    "lineCount": 73,
     "axiomCount": 3,
-    "theoremCount": 6,
+    "theoremCount": 1,
     "definitionCount": 3,
     "imports": [
       "Mathlib.Data.Finset.Basic",

--- a/src/data/proofs/erdos-396/meta.json
+++ b/src/data/proofs/erdos-396/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/396",
     "erdosProblemStatus": "open",
     "axiomCount": 5,
-    "lineCount": 79,
+    "lineCount": 74,
     "assumptions": "9 axioms: catalan_divisibility, n_divides_rarely, pomerance_single_factor, and 6 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
@@ -114,9 +114,9 @@
       "Nat"
     ],
     "namespace": null,
-    "lineCount": 79,
+    "lineCount": 74,
     "axiomCount": 7,
-    "theoremCount": 0,
+    "theoremCount": 2,
     "definitionCount": 0
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-575/meta.json
+++ b/src/data/proofs/erdos-575/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/575",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "lineCount": 89,
+    "lineCount": 87,
     "assumptions": "6 axioms: erdos_575_conjecture, erdos_stone_simonovits, bipartite_subquadratic, and 3 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0"
   },
@@ -100,9 +100,9 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 89,
+    "lineCount": 87,
     "axiomCount": 6,
-    "theoremCount": 1,
+    "theoremCount": 0,
     "definitionCount": 3
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-606-oq-03/meta.json
+++ b/src/data/proofs/erdos-606-oq-03/meta.json
@@ -19,7 +19,7 @@
     "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 98,
+    "lineCount": 97,
     "assumptions": "0 axioms, 0 sorries. WARNING: general_position_count proves True (placeholder). Sylvester-Gallai, Green-Tao, and Motzkin are mentioned in comments but not axiomatized.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
@@ -45,9 +45,9 @@
       "Mathlib"
     ],
     "namespace": "Erdos606OQ03",
-    "lineCount": 98,
+    "lineCount": 97,
     "axiomCount": 0,
-    "theoremCount": 4,
+    "theoremCount": 3,
     "definitionCount": 0
   },
   "sections": []

--- a/src/data/proofs/erdos-698/meta.json
+++ b/src/data/proofs/erdos-698/meta.json
@@ -74,7 +74,7 @@
       "p-adic valuations (Kummer's theorem)",
       "Modular arithmetic (Lucas' theorem)"
     ],
-    "lineCount": 289,
+    "lineCount": 283,
     "assumptions": "8 axiom(s), 0 sorry(s). bergmanH_unbounded and erdos698_answer fully proved; axioms encode deep results (Erdős-Szekeres, Bergman, Kummer, Lucas)."
   },
   "overview": {
@@ -218,9 +218,9 @@
       "Nat"
     ],
     "namespace": "Erdos698",
-    "lineCount": 289,
+    "lineCount": 283,
     "axiomCount": 8,
-    "theoremCount": 7,
+    "theoremCount": 5,
     "definitionCount": 6
   }
 }

--- a/src/data/proofs/lebesgue-measure-oq-03/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-03/meta.json
@@ -17,7 +17,7 @@
     "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 132,
+    "lineCount": 130,
     "assumptions": "0 axioms, 0 sorries. 2 True-stub placeholder theorems (ball_volume_vanishes, concentration_sketch). Orthonormal separation and framework theorems fully proved.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
@@ -73,9 +73,9 @@
       "Mathlib"
     ],
     "namespace": "LebesgueMeasureOQ03",
-    "lineCount": 132,
+    "lineCount": 130,
     "axiomCount": 3,
-    "theoremCount": 4,
+    "theoremCount": 2,
     "definitionCount": 0
   }
 }


### PR DESCRIPTION
## Fix

Remove placeholder `theorem ... True := trivial` stubs from 13 gallery proof files and update meta.json theorem counts to match the corrected Lean source.

## Evidence

**Before**: Proof files contained `theorem foo : True := trivial` stubs that inflated theorem counts and misrepresented formalization depth; meta.json theoremCount values were stale.

**After**: True-stubs removed; theoremCount in meta.json corrected to reflect actual non-stub theorems in each Lean file.

---
Automated repair by lean-mechanic agent.