### PR TITLE
fix(lean): close unclosed docstrings hiding axioms in 4 Erdős proofs

### DIFF
--- a/proofs/Proofs/Erdos15Problem.lean
+++ b/proofs/Proofs/Erdos15Problem.lean
@@ -73,7 +73,7 @@ def AlternatingPrimeSeriesConverges : Prop :=
 The Prime Number Theorem tells us p_n ~ n log n.
 -/
 
-/-- The Prime Number Theorem: p_n / (n log n) → 1 as n → ∞.
+/-- The Prime Number Theorem: p_n / (n log n) → 1 as n → ∞. -/
 
 /-- Consequence: n / p_n ~ 1 / log n → 0.
 
@@ -81,7 +81,7 @@ The Prime Number Theorem tells us p_n ~ n log n.
 axiom terms_tend_to_zero :
     Tendsto (fun n : ℕ => (n : ℝ) / (nthPrime n : ℝ)) atTop (𝓝 0)
 
-/-- The terms of our series go to zero.
+/-- The terms of our series go to zero. -/
 
 /-
 ## The Alternating Series Test
@@ -122,7 +122,7 @@ def HardyLittlewoodConjecture : Prop :=
     (∀ p : ℕ, p.Prime → (Finset.univ.image h).image (· % p) ≠ Finset.range p) →
     ∀ N : ℕ, ∃ n > N, ∀ i : Fin k, (n + h i).Prime
 
-/-- Tao's Theorem (2023): Assuming Hardy-Littlewood, the series converges.
+/-- Tao's Theorem (2023): Assuming Hardy-Littlewood, the series converges. -/
 
 /-
 ## Related Series (Erdős's Conjectures)
@@ -149,9 +149,9 @@ def ErdosGapConjecture2 : Prop :=
     (fun N => ∑ n ∈ Finset.Icc 1 N, (-1 : ℝ)^n / primeGap n)
     atTop (𝓝 L)
 
-/-- Zhang's Theorem (2014): There are infinitely many prime gaps ≤ 70,000,000.
+/-- Zhang's Theorem (2014): There are infinitely many prime gaps ≤ 70,000,000. -/
 
-/-- Consequence of Zhang: Erdős's second conjecture is true.
+/-- Consequence of Zhang: Erdős's second conjecture is true. -/
 
 /-
 ## Why This Problem is Hard
@@ -169,7 +169,7 @@ The difficulty stems from the irregular distribution of primes.
    as the answer depends on the infinite tail behavior.
 -/
 
-/-- The problem cannot be resolved by computing finitely many terms.
+/-- The problem cannot be resolved by computing finitely many terms. -/
 
 /-
 ## Absolute Convergence
@@ -177,7 +177,7 @@ The difficulty stems from the irregular distribution of primes.
 Note that the series does NOT converge absolutely.
 -/
 
-/-- The series Σ n/p_n diverges (no absolute convergence).
+/-- The series Σ n/p_n diverges (no absolute convergence). -/
 
 /-
 ## Numerical Evidence
@@ -186,7 +186,7 @@ Computational evidence suggests the partial sums oscillate around a value
 near -1, but this cannot prove convergence.
 -/
 
-/-- Empirical observation: partial sums appear to oscillate around ≈ -1.
+/-- Empirical observation: partial sums appear to oscillate around ≈ -1. -/
 
 /-
 ## Summary

--- a/proofs/Proofs/Erdos231Problem.lean
+++ b/proofs/Proofs/Erdos231Problem.lean
@@ -127,8 +127,10 @@ def erdos_231_question (k : ℕ) : Prop :=
 The key result: infinite abelian-square-free strings exist over 4 letters.
 -/
 
-/-- Keränen (1992): There exists an infinite sequence over 4 letters
+/-
+Keränen (1992): There exists an infinite sequence over 4 letters
     with no abelian squares.
+-/
 
 /-- The Keränen morphism (85 letters per symbol) that generates
     abelian-square-free words. -/

--- a/proofs/Proofs/Erdos297Problem.lean
+++ b/proofs/Proofs/Erdos297Problem.lean
@@ -131,8 +131,10 @@ The first proof that c < 1, establishing egyptianCount(N) ≤ 2^{0.93N}.
 /-- Steinerberger's constant: the exponent 0.93 from his upper bound. -/
 def steinerbergerConstant : ℝ := 0.93
 
-/-- **Steinerberger (2024, arXiv:2403.17041):**
+/-
+**Steinerberger (2024, arXiv:2403.17041):**
     The Egyptian count satisfies egyptianCount(N) ≤ 2^{0.93N} for all sufficiently large N.
+-/
 
 /-
 ## Part 6: Liu-Sawhney's Full Asymptotic (April 2024)
@@ -172,9 +174,11 @@ Independent proof of the same asymptotic, plus generalization to arbitrary targe
 noncomputable def egyptianCountTarget (N : ℕ) (x : ℚ) : ℕ :=
   ((subsets N).filter (fun A => harmonicSum A = x ∧ 0 ∉ A)).card
 
-/-- **Conlon et al. generalization:**
+/-
+**Conlon et al. generalization:**
     For any rational x > 0, there exists a constant c_x ∈ (0, 1) such that
     egyptianCountTarget(N, x) = 2^{(c_x + o(1))N}.
+-/
 
 /-
 ## Part 8: The 2017 MathOverflow Precedent
@@ -192,8 +196,10 @@ noncomputable def egyptianCountLeq (N : ℕ) : ℕ :=
 The constraint Σ 1/n = 1 exactly is very restrictive.
 -/
 
-/-- **Heuristic:** For a random subset of {1,...,N}, the expected harmonic sum is
+/-
+**Heuristic:** For a random subset of {1,...,N}, the expected harmonic sum is
     E[Σ 1/n] ≈ (1/2) · H_N ≈ (log N)/2, which grows without bound.
+-/
 
 /-
 ## Part 10: Main Results

--- a/proofs/Proofs/Erdos657Problem.lean
+++ b/proofs/Proofs/Erdos657Problem.lean
@@ -150,9 +150,11 @@ noncomputable def numDifferences (A : Finset ℝ) : ℕ :=
 ## Part VIII: Straus's High-Dimensional Construction
 -/
 
-/-- **Straus's Observation:**
+/-
+**Straus's Observation:**
     If 2^k ≥ n, there exist n points in ℝ^k with no isosceles triangle
     that determine at most n-1 distinct distances.
+-/
 
 /-
 ## Part IX: Known Examples


### PR DESCRIPTION
## Fix

Close unclosed Lean docstring comments (`/--` without closing `-/`) in 4 Erdős proof files. Unclosed docstrings were absorbing subsequent `axiom` declarations, hiding them from axiom counts.

## Evidence

**Before**: Erdos15Problem.lean, Erdos231Problem.lean, Erdos297Problem.lean, and Erdos657Problem.lean contained `/-- ... ` docstrings without closing `-/`, which caused subsequent `axiom` statements to be treated as part of the docstring and not parsed as real axiom declarations
**After**: All affected docstrings are properly closed with `-/`; axioms are now visible to the Lean parser and correctly counted

---
Automated repair by lean-mechanic agent.