### PR TITLE
fix(meta): restore erdos-1000 Lean file and update stale meta.json

### DIFF
--- a/proofs/Proofs/Erdos1000Problem.lean
+++ b/proofs/Proofs/Erdos1000Problem.lean
@@ -1,1 +1,285 @@
-f31f3802-bfb3-439d-95f6-24d4a2aac7e9-output.lean
+/-
+Erdős Problem #1000: Diophantine Approximation and Generalized Totients
+
+Let A = {n₁ < n₂ < ⋯} be an infinite sequence of positive integers.
+Define φ_A(k) as the count of 1 ≤ m ≤ n_k such that the fraction m/n_k
+in lowest form has denominator different from all n_j where j < k.
+
+**Question**: Does there exist a sequence A such that
+  lim_{N→∞} (1/N) Σ_{k≤N} φ_A(k)/n_k = 0?
+
+**Status**: SOLVED
+**Answer**: YES (Haight) - contrary to Erdős' expectation
+
+**History**:
+- Cassels (1950): Introduced φ_A, proved liminf can equal 0
+- Erdős (1964): Proved limit of φ_A(k)/n_k cannot be 0
+- Erdős (1964): If liminf φ_A(k)/n_k = 0 then limsup = 1
+- Haight: Proved such a sequence exists, resolving the problem
+
+Reference: https://erdosproblems.com/1000
+-/
+
+import Mathlib.Data.Nat.Totient
+import Mathlib.Data.Nat.GCD.Basic
+import Mathlib.Data.Set.Finite.Basic
+import Mathlib.Order.Filter.AtTopBot.Basic
+import Mathlib.Topology.Instances.Real.Basic
+import Mathlib.Data.Real.Basic
+
+open Nat Set Filter
+
+namespace Erdos1000
+
+/-!
+## The Generalized Totient Function φ_A
+
+Given a strictly increasing sequence A = {n₁ < n₂ < ⋯} of positive integers,
+we define φ_A(k) to count integers m with a specific property related to
+reduced fractions and previous sequence elements.
+-/
+
+/--
+A strictly increasing sequence of positive integers.
+Represents A = {n₁ < n₂ < ⋯}.
+-/
+structure IncreasingSeq where
+  seq : ℕ → ℕ
+  pos : ∀ k, 0 < seq k
+  strict_mono : StrictMono seq
+
+/--
+For a fraction m/n in lowest form, the reduced denominator is n/gcd(m,n).
+Given m and n, this computes the denominator when m/n is reduced.
+-/
+def reducedDenom (m n : ℕ) : ℕ := n / Nat.gcd m n
+
+/--
+The generalized totient φ_A(k) counts integers 1 ≤ m ≤ n_k such that
+when m/n_k is written in lowest form, the denominator is not equal
+to any n_j for j < k.
+
+Equivalently: n_k / gcd(m, n_k) ≠ n_j for all 1 ≤ j < k.
+-/
+def phiA (A : IncreasingSeq) (k : ℕ) : ℕ :=
+  (Finset.filter (fun m =>
+    m ≥ 1 ∧ ∀ j < k, reducedDenom m (A.seq k) ≠ A.seq j
+  ) (Finset.range (A.seq k + 1))).card
+
+/-!
+## Basic Properties of φ_A
+
+The generalized totient satisfies φ_A(k) ≥ φ(n_k) always,
+with equality when A = ℕ (the natural numbers).
+-/
+
+/--
+φ_A(k) is always at least φ(n_k), the Euler totient.
+This is because any m coprime to n_k has reduced denominator n_k,
+which cannot equal any previous n_j (since the sequence is strictly increasing).
+-/
+theorem phiA_ge_totient (A : IncreasingSeq) (k : ℕ) (hk : k ≥ 1) :
+    φ (A.seq k) ≤ phiA A k := by
+  sorry
+
+/--
+The natural numbers as an increasing sequence.
+-/
+def naturalSeq : IncreasingSeq where
+  seq := fun n => n + 1
+  pos := fun k => Nat.succ_pos k
+  strict_mono := fun _ _ h => Nat.add_lt_add_right h 1
+
+/--
+When A = ℕ, we have φ_A(k) = φ(k) for all k.
+This is the baseline case.
+-/
+theorem phiA_naturals_eq_totient (k : ℕ) (hk : k ≥ 1) :
+    phiA naturalSeq k = φ (naturalSeq.seq k) := by
+  sorry
+
+/-!
+## The Average Density
+
+The main object of study is the Cesàro average of φ_A(k)/n_k.
+-/
+
+/--
+The density ratio for a single term: φ_A(k) / n_k.
+-/
+noncomputable def densityRatio (A : IncreasingSeq) (k : ℕ) : ℝ :=
+  (phiA A k : ℝ) / (A.seq k : ℝ)
+
+/--
+The Cesàro average of the density ratios up to N.
+-/
+noncomputable def cesaroAverage (A : IncreasingSeq) (N : ℕ) : ℝ :=
+  if N = 0 then 0
+  else (1 / N : ℝ) * (Finset.range N).sum (fun k => densityRatio A (k + 1))
+
+/-!
+## Cassels' Result (1950)
+
+Cassels introduced the study of φ_A and proved that the liminf
+of the Cesàro average can be 0 for appropriate sequences.
+
+This connects to Diophantine approximation: the divergence of
+Σ f(n_k)/k implies, for almost all α, that |α - m_k/n_k| < f(n_k)/n_k²
+for infinitely many k.
+-/
+
+/--
+Cassels (1950): There exist sequences A where the liminf of
+the Cesàro average equals 0.
+-/
+axiom cassels_liminf_zero :
+    ∃ A : IncreasingSeq,
+      Filter.liminf (fun N => cesaroAverage A N) atTop = 0
+
+/-!
+## Erdős' Results (1964)
+
+Erdős proved two key results about the behavior of φ_A(k)/n_k:
+
+1. The limit of individual terms φ_A(k)/n_k cannot be 0
+2. If liminf φ_A(k)/n_k = 0, then limsup φ_A(k)/n_k = 1
+-/
+
+/--
+Erdős (1964): For any sequence A, the limit of φ_A(k)/n_k as k→∞
+cannot be 0.
+-/
+axiom erdos_no_zero_limit (A : IncreasingSeq) :
+    ¬ Filter.Tendsto (densityRatio A) atTop (nhds 0)
+
+/--
+Erdős (1964): If liminf φ_A(k)/n_k = 0, then limsup φ_A(k)/n_k = 1.
+
+The proof uses the following argument:
+- If liminf = 0, then for any ε > 0, there are arbitrarily large k
+  with φ(n_k) < ε · n_k
+- This means there are arbitrarily large primes p dividing some n_i
+- If n_k is the first element divisible by p, then every m ≤ n_k
+  not divisible by p contributes to φ_A(k)
+- So φ_A(k)/n_k ≥ 1 - 1/p, which approaches 1 as p→∞
+-/
+axiom erdos_liminf_limsup (A : IncreasingSeq) :
+    Filter.liminf (densityRatio A) atTop = 0 →
+    Filter.limsup (densityRatio A) atTop = 1
+
+/-!
+## The Main Question
+
+Erdős believed that no sequence A could have the Cesàro average
+converge to 0. Haight proved him wrong.
+-/
+
+/--
+A sequence A has vanishing average if the Cesàro average
+of φ_A(k)/n_k tends to 0.
+-/
+def hasVanishingAverage (A : IncreasingSeq) : Prop :=
+  Filter.Tendsto (cesaroAverage A) atTop (nhds 0)
+
+/--
+The main question (Erdős): Does there exist a sequence A
+with vanishing average?
+
+Erdős conjectured NO. He was wrong.
+-/
+def erdos_1000_question : Prop :=
+  ∃ A : IncreasingSeq, hasVanishingAverage A
+
+/-!
+## Haight's Resolution
+
+Haight proved that such a sequence does exist, contrary to
+Erdős' expectation. This resolved Problem #1000.
+-/
+
+/--
+**Haight's Theorem**: There exists a sequence A such that the
+Cesàro average of φ_A(k)/n_k converges to 0.
+
+This answered Erdős' question in the affirmative and resolved
+Problem #1000.
+-/
+axiom haight_theorem : erdos_1000_question
+
+/--
+Erdős Problem #1000 is SOLVED.
+The answer is YES - such sequences exist.
+-/
+theorem erdos_1000_solved : erdos_1000_question := haight_theorem
+
+/-!
+## Connection to Metric Diophantine Approximation
+
+Cassels showed that the property
+  liminf (1/N) Σ_{k≤N} φ_A(k)/n_k > 0
+is equivalent to a fundamental divergence condition in metric theory:
+
+The divergence of Σ f(n_k)/k implies, for almost all real α,
+infinitely many approximations |α - m/n_k| < f(n_k)/n_k².
+
+This connects Problem #1000 to the Khinchin-Groshev theorem
+and the general theory of Diophantine approximation.
+-/
+
+/--
+The connection between φ_A and metric Diophantine approximation.
+This characterization is due to Cassels (1950).
+-/
+def cassels_characterization (A : IncreasingSeq) : Prop :=
+  Filter.liminf (cesaroAverage A) atTop > 0 ↔
+  -- The divergence condition for Diophantine approximation holds
+  True  -- Placeholder for the full statement
+
+/-!
+## Observations and Corollaries
+
+Haight's result shows that one can construct sequences where the
+"new denominators" become increasingly rare on average.
+
+Combined with Erdős' liminf/limsup result, this means:
+- The individual terms φ_A(k)/n_k oscillate between 0 and 1
+- But their average still tends to 0
+-/
+
+/--
+For Haight's sequence, densityRatio oscillates despite vanishing average.
+-/
+theorem haight_oscillation :
+    ∃ A : IncreasingSeq,
+      hasVanishingAverage A ∧
+      Filter.liminf (densityRatio A) atTop = 0 ∧
+      Filter.limsup (densityRatio A) atTop = 1 := by
+  obtain ⟨A, hA⟩ := haight_theorem
+  refine ⟨A, hA, ?_, ?_⟩
+  · -- The average tending to 0 implies liminf of terms is 0
+    sorry
+  · -- By Erdős' result, limsup must equal 1
+    sorry
+
+/-!
+## Summary
+
+This file formalizes Erdős Problem #1000 on generalized totient functions
+and Diophantine approximation.
+
+**The Question**: For infinite sequence A = {n₁ < n₂ < ⋯}, can
+  lim (1/N) Σ φ_A(k)/n_k = 0?
+
+**The Answer**: YES (Haight), contrary to Erdős' expectation.
+
+**Key Results**:
+- Cassels (1950): liminf can be 0
+- Erdős (1964): individual limit cannot be 0
+- Erdős (1964): liminf = 0 implies limsup = 1
+- Haight: Cesàro average can converge to 0
+
+**Connection**: The problem relates to metric Diophantine approximation
+and the Khinchin-Groshev theory of rational approximations.
+-/
+
+end Erdos1000

--- a/src/data/proofs/erdos-1000/meta.json
+++ b/src/data/proofs/erdos-1000/meta.json
@@ -7,7 +7,7 @@
     "author": "J.W.S. Cassels, Paul Erdős, J.A. Haight",
     "sourceUrl": "https://erdosproblems.com/1000",
     "date": "1950-1964",
-    "status": "pending",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1000Problem.lean",
     "tags": [
       "erdos",
@@ -16,14 +16,14 @@
       "totient-function",
       "cesaro-averages"
     ],
-    "badge": "wip",
-    "sorries": 0,
+    "badge": "axiom",
+    "sorries": 4,
     "erdosNumber": 1000,
     "erdosUrl": "https://erdosproblems.com/1000",
     "erdosProblemStatus": "solved",
-    "axiomCount": 0,
-    "lineCount": 1,
-    "assumptions": "Lean file corrupted (contains Aristotle job UUID reference instead of code). Previous status was \"formalized\".",
+    "axiomCount": 4,
+    "lineCount": 285,
+    "assumptions": "cassels_liminf_zero (Cassels' liminf=0 construction), erdos_no_zero_limit (individual limit cannot be 0), erdos_liminf_limsup (liminf=0 implies limsup=1 dichotomy), haight_theorem (vanishing-average sequences exist)",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -51,79 +51,79 @@
       "title": "Imports and Setup",
       "summary": "Module imports for Nat.GCD, Finset, real casts, and filter limits",
       "startLine": 1,
-      "endLine": 1,
+      "endLine": 30,
       "mathContext": "Module imports for Nat.GCD, Finset, real casts, and filter limits"
     },
     {
       "id": "generalized-totient",
       "title": "The Generalized Totient φ_A",
       "summary": "IncreasingSeq, reducedDenom, and φ_A definitions",
-      "startLine": 1,
-      "endLine": 1,
+      "startLine": 31,
+      "endLine": 72,
       "mathContext": "IncreasingSeq, reducedDenom, and φ_A definitions"
     },
     {
       "id": "basic-properties",
       "title": "Basic Properties",
       "summary": "φ_A(k) ≥ φ(n_k) bound and naturalSeq baseline",
-      "startLine": 1,
-      "endLine": 1,
+      "startLine": 74,
+      "endLine": 100,
       "mathContext": "φ_A(k) ≥ φ(n_k) bound and naturalSeq baseline"
     },
     {
       "id": "average-density",
       "title": "Average Density",
       "summary": "Density ratio ρ_A(k) = φ_A(k)/n_k and Cesàro average C_A(N)",
-      "startLine": 1,
-      "endLine": 1,
+      "startLine": 102,
+      "endLine": 125,
       "mathContext": "Density ratio ρ_A(k) = φ_A(k)/n_k and Cesàro average C_A(N)"
     },
     {
       "id": "cassels-result",
       "title": "Cassels' Result (1950)",
       "summary": "Liminf of Cesàro average can be 0; Diophantine approximation connection",
-      "startLine": 1,
-      "endLine": 1,
+      "startLine": 127,
+      "endLine": 140,
       "mathContext": "Liminf of Cesàro average can be 0; Diophantine approximation connection"
     },
     {
       "id": "erdos-results",
       "title": "Erdős' Results (1964)",
       "summary": "No-zero-limit theorem and liminf/limsup dichotomy",
-      "startLine": 1,
-      "endLine": 1,
+      "startLine": 142,
+      "endLine": 177,
       "mathContext": "No-zero-limit theorem and liminf/limsup dichotomy"
     },
     {
       "id": "main-question",
       "title": "The Main Question",
       "summary": "VanishingAverage predicate and Erdős' conjecture",
-      "startLine": 1,
-      "endLine": 1,
+      "startLine": 179,
+      "endLine": 203,
       "mathContext": "VanishingAverage predicate and Erdős' conjecture"
     },
     {
       "id": "haight-resolution",
       "title": "Haight's Resolution",
       "summary": "Haight's theorem: vanishing-average sequences exist (SOLVED)",
-      "startLine": 1,
-      "endLine": 1,
+      "startLine": 205,
+      "endLine": 220,
       "mathContext": "Haight's theorem: vanishing-average sequences exist (SOLVED)"
     },
     {
       "id": "diophantine-connection",
       "title": "Connection to Diophantine Approximation",
       "summary": "Cassels' characterization via Khinchin-Groshev theory",
-      "startLine": 1,
-      "endLine": 1,
+      "startLine": 222,
+      "endLine": 245,
       "mathContext": "Cassels' characterization via Khinchin-Groshev theory"
     },
     {
       "id": "observations",
       "title": "Observations and Corollaries",
       "summary": "Haight oscillation: vanishing average with maximal oscillation",
-      "startLine": 1,
-      "endLine": 1,
+      "startLine": 247,
+      "endLine": 285,
       "mathContext": "Haight oscillation: vanishing average with maximal oscillation"
     }
   ],
@@ -177,12 +177,19 @@
     }
   ],
   "leanFile": {
-    "imports": [],
-    "opens": [],
-    "namespace": null,
-    "lineCount": 1,
-    "axiomCount": 0,
-    "theoremCount": 0,
-    "definitionCount": 0
+    "imports": [
+      "Mathlib.Data.Nat.Totient",
+      "Mathlib.Data.Nat.GCD.Basic",
+      "Mathlib.Data.Set.Finite.Basic",
+      "Mathlib.Order.Filter.AtTopBot.Basic",
+      "Mathlib.Topology.Instances.Real.Basic",
+      "Mathlib.Data.Real.Basic"
+    ],
+    "opens": ["Nat", "Set", "Filter"],
+    "namespace": "Erdos1000",
+    "lineCount": 285,
+    "axiomCount": 4,
+    "theoremCount": 4,
+    "definitionCount": 8
   }
 }


### PR DESCRIPTION
## Fix

Restore erdos-1000 Lean proof file (was corrupted with a UUID reference) and update meta.json to reflect the actual 285-line formalization with 4 axioms and 4 sorries.

## Evidence

**Before**: `Erdos1000Problem.lean` contained only a single UUID string (`f31f3802-bfb3-439d-95f6-24d4a2aac7e9-output.lean`); meta.json reported `lineCount: 1`, `axiomCount: 0`, `sorries: 0`, `badge: "wip"`, `status: "pending"`, all section ranges `1–1`
**After**: Full 285-line Lean formalization with proper structure (IncreasingSeq, phiA, Cassels/Erdős/Haight results); meta.json reports `lineCount: 285`, `axiomCount: 4`, `sorries: 4`, `badge: "axiom"`, `status: "formalized"`, correct section line ranges

---
Automated repair by lean-mechanic agent.