### PR TITLE
Seeker: select area-of-circle-oq-03-oq-03-oq-01 — ellipse area via measure-theoretic change of variables

### DIFF
--- a/research/problems/brouwer-fixed-point-oq-01-oq-01/knowledge.md
+++ b/research/problems/brouwer-fixed-point-oq-01-oq-01/knowledge.md
@@ -1,0 +1,32 @@
+# Knowledge Base: brouwer-fixed-point-oq-01-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+The goal is to prove the 2D Brouwer Fixed Point Theorem via Sperner's Lemma.
+Key fact: `SpernerNDim.lean` is already fully verified (0 axioms, 0 sorries).
+The main theorem to prove: every continuous `f : D² → D²` has a fixed point.
+
+The combinatorial proof strategy:
+1. Triangulate the standard 2-simplex with mesh size 1/n
+2. Color each vertex v by the index i where `(v - f(v))_i` is maximally positive
+3. Show this is a valid Sperner coloring (boundary vertices get boundary colors)
+4. Sperner → at least one fully-colored triangle exists at each level n
+5. Pick a point x_n from each fully-colored triangle
+6. Bolzano-Weierstrass: x_n has a convergent subsequence → limit x*
+7. Continuity: f(x*) = x*
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/brouwer-fixed-point-oq-01-oq-01/problem.md
+++ b/research/problems/brouwer-fixed-point-oq-01-oq-01/problem.md
@@ -1,0 +1,161 @@
+# Problem: Prove 2D Brouwer Fixed Point via Sperner's Lemma
+
+**Slug**: brouwer-fixed-point-oq-01-oq-01
+**Created**: 2026-04-05
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+The gallery entry `brouwer-fixed-point` axiomatizes the full n-dimensional Brouwer
+Fixed Point Theorem. The 2D case — every continuous function from the closed disk
+to itself has a fixed point — is the most geometrically intuitive instance and
+admits a combinatorial proof via Sperner's Lemma.
+
+The goal is to produce a fully-verified Lean 4 proof of the 2D Brouwer Fixed Point
+Theorem using the triangulation-based Sperner's Lemma approach, without axioms.
+
+Key steps:
+1. Triangulate the closed disk (standard 2-simplex)
+2. Apply Sperner's Lemma (already proved in `SpernerNDim.lean`)
+3. Extract a fixed-point sequence from the sequence of fully-colored simplices
+4. Use compactness to obtain a convergent subsequence
+5. Show the limit is a fixed point by continuity
+
+### Plain Language
+
+Given any continuous function `f : D² → D²` (from the closed unit disk to itself),
+there exists `x ∈ D²` with `f(x) = x`. The proof strategy:
+- Triangulate D² finely
+- Color vertices by which coordinate of `x - f(x)` is most negative (Sperner coloring)
+- Sperner's Lemma guarantees a fully-colored triangle exists
+- As mesh size → 0, these triangles shrink to a point — which must be a fixed point
+
+### Why This Matters
+
+This is one of the most elegant proofs in combinatorial topology: reducing a
+topological theorem to a purely combinatorial fact (Sperner's Lemma). Since
+`SpernerNDim.lean` is already fully verified, this proof can potentially achieve
+`badge: "original"` (0 axioms) rather than the current `badge: "axiom"` of the
+main `BrouwerFixedPoint.lean` entry. It also provides a verified bridge between
+the combinatorial Sperner infrastructure and classical topology.
+
+## Known Results
+
+### What's Already Proven in the Gallery
+
+- `SpernerNDim.lean` — n-dimensional Sperner's Lemma (VERIFIED, 0 axioms, 0 sorries)
+- `BrouwerFixedPointOQ01.lean` — 1D Brouwer via IVT (VERIFIED, 0 axioms)
+- `BrouwerFixedPoint.lean` — Full n-dim Brouwer (axiomatized, badge: "axiom")
+- Mathlib: `IsCompact.closedBall`, `Metric.closedBall`, `ContinuousMap`
+
+### What's Still Open
+
+- No `BrouwerFixedPointOQ01OQ01.lean` exists yet
+- The Sperner-to-Brouwer bridge for 2D is not formalized in this gallery
+- The compactness argument extracting a fixed point from approximations
+
+### Our Goal
+
+Prove: `theorem brouwer_2d : ∀ f : C(closedBall 0 1, closedBall 0 1), ∃ x, f x = x`
+
+Target: 0 axioms, 0 sorries — `badge: "original"`
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| `sperner-ndim` | Key ingredient: Sperner's Lemma is verified here |
+| `brouwer-fixed-point` | Parent proof (n-dim, axiomatized) |
+| `brouwer-fixed-point-oq-01` | 1D case via IVT (similar compactness limit argument) |
+| `brouwer-fixed-point-oq-01-oq-03` | Borsuk-Ulam via Brouwer (related equivalence chain) |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Direct Sperner triangulation of the 2-simplex**:
+   - The standard 2-simplex (triangle) is homeomorphic to D²
+   - Use `SpernerNDim` with d=2, N=n (refinement)
+   - Define Sperner coloring from `f(x) - x`: color vertex `v` by the index `i`
+     where `(v - f(v))_i = max_j (v - f(v))_j ≥ 0`
+   - Sperner guarantees a fully-colored 2-simplex at each level n
+   - Diagonal/compactness argument: subsequence converges by Bolzano-Weierstrass
+   - At the limit point, `f(x) = x` by continuity
+
+2. **Use existing Mathlib fixed-point results**:
+   - Check if Mathlib has `Continuous.fixedPoint` for compact convex sets
+   - `Mathlib.Topology.Algebra.Module.FiniteDimension` may have related results
+   - If Mathlib already has it, may just need `exact Mathlib.lemma_name`
+
+3. **Kakutani / Schauder approach** (overkill for 2D):
+   - Not recommended for this specific case
+
+### Key Difficulties
+
+- Bridging `SpernerNDim` (abstract triangulation) to the concrete disk requires
+  a homeomorphism from the standard 2-simplex to D²
+- The compactness argument needs `Metric.isCompact_closedBall` and sequential
+  compactness for ℝ²
+- Defining the Sperner coloring from `f` requires showing it satisfies the
+  boundary condition
+
+### What Would a Proof Need?
+
+- **Homeomorphism**: `Simplex 2 ≃ₜ closedBall (0 : ℝ²) 1`
+- **Sperner coloring from f**: A function `color_vertex : Vertex 2 N → Fin 3`
+  satisfying the Sperner boundary condition relative to `f`
+- **Approximation sequence**: `x_n ∈ simplex_n` with `‖x_n - f(x_n)‖ ≤ C/n`
+- **Limit argument**: `x_n` subconverges to `x*` with `f(x*) = x*`
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- The mathematical argument is classical and well-understood
+- `SpernerNDim.lean` is already verified — the hard part is done
+- The compactness argument is standard (sequential compactness of closed balls)
+- The main challenge: bridging abstract `SpernerNDim` structure to a concrete coloring
+  defined by `f` — requires careful instance construction
+- Risk: Lean 4 homeomorphism definitions for simplex ≃ disk may be verbose
+
+**Estimated Effort**: 3-5 researcher iterations
+
+## References
+
+### Mathlib
+- `Mathlib.Topology.MetricSpace.Basic` — `Metric.closedBall`, `isCompact_closedBall`
+- `Mathlib.Topology.Compactness.Compact` — `IsCompact`, sequential compactness
+- `Proofs.SpernerNDim` — n-dim Sperner's Lemma (fully verified)
+- `Mathlib.Analysis.InnerProductSpace.PiL2` — `EuclideanSpace`, `ℝ²`
+
+### Literature
+- Brouwer, L.E.J. (1911) — Original theorem
+- Cohen, D.I.A. (1967) — Combinatorial proof via Sperner
+- Su, F.E. (1999) — "Rental Harmony: Sperner's Lemma in Fair Division" — clear exposition
+
+## Metadata
+
+```yaml
+tags:
+  - topology
+  - combinatorics
+  - fixed-point-theory
+  - sperner
+  - compactness
+  - technique
+related_proofs:
+  - sperner-ndim
+  - brouwer-fixed-point
+  - brouwer-fixed-point-oq-01
+  - brouwer-fixed-point-oq-01-oq-03
+difficulty: medium
+source: gallery-gap
+created: 2026-04-05
+```
+
+**Significance**: 7/10
+**Tractability**: 6/10

--- a/research/problems/brouwer-fixed-point-oq-01-oq-01/state.md
+++ b/research/problems/brouwer-fixed-point-oq-01-oq-01/state.md
@@ -1,0 +1,30 @@
+# Research State: brouwer-fixed-point-oq-01-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-05T14:05:00-07:00
+**Iteration**: 1
+
+## Current Focus
+Prove 2D Brouwer Fixed Point Theorem via Sperner's Lemma using
+the already-verified SpernerNDim.lean as the key ingredient.
+
+## Active Approach
+Three-phase approach:
+1. Read SpernerNDim.lean to understand the abstract triangulation interface
+2. Define the Sperner coloring from f (color by which coordinate of x - f(x) is maximal)
+3. Build the compactness/limit argument to extract the fixed point
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+1. Read proofs/Proofs/SpernerNDim.lean — understand the main theorem interface
+2. Check if Mathlib has a 2D Brouwer proof already (`Continuous.fixedPoint` or similar)
+3. Look at BrouwerFixedPointOQ01.lean for the compactness pattern used in 1D

--- a/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-01/knowledge.md
+++ b/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-01/knowledge.md
@@ -1,0 +1,25 @@
+# Knowledge Base: cayley-hamilton-minpoly-oq-02-oq-02-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+The Rational Canonical Form (RCF) theorem states that two n×n matrices over a field F are similar if and only if they have identical invariant factor sequences. This is strictly stronger than sharing the same minimal polynomial (two matrices can share a minimal polynomial but have different invariant factor sequences and thus not be similar).
+
+Key example: The 3×3 matrices with characteristic polynomial (x-1)³ and minimal polynomial (x-1)² — one might have invariant factors [(x-1), (x-1)²] and another [(x-1)³], which are different despite potentially sharing the minimal polynomial.
+
+The proof strategy is via the Structure Theorem for finitely generated modules over the PID F[x].
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-01/literature/README.md
+++ b/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-01/literature/README.md
@@ -1,0 +1,20 @@
+# Literature for cayley-hamilton-minpoly-oq-02-oq-02-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+- `cayley-hamilton`: Foundation proof — matrix satisfies its characteristic polynomial
+- `cayley-hamilton-minpoly`: Minimal polynomial infrastructure
+- `cayley-hamilton-minpoly-oq-02`: Similar matrices have the same minimal polynomial
+
+## External References
+
+- Lang, *Algebra* Ch. XIV: Rational canonical form via modules over PID
+- Jacobson, *Basic Algebra I* §3.8: Invariant factor theorem
+- Mathlib4: `Mathlib.LinearAlgebra.Matrix.Charpoly` — characteristic polynomial
+- Mathlib4: `Mathlib.RingTheory.PrincipalIdealDomain` — PID structure theorem
+- Mathlib4: `Mathlib.LinearAlgebra.Matrix.DotProduct` — matrix infrastructure

--- a/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-01/problem.md
+++ b/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-01/problem.md
@@ -1,0 +1,107 @@
+# Problem: Rational Canonical Form Determines Similarity Class
+
+**Slug**: cayley-hamilton-minpoly-oq-02-oq-02-oq-01
+**Created**: 2026-04-05T00:00:00-07:00
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+A \sim B \iff \text{RCF}(A) = \text{RCF}(B)
+$$
+
+More precisely: two square matrices $A, B \in M_n(F)$ over a field $F$ are similar (there exists an invertible $P$ such that $B = PAP^{-1}$) if and only if they have the same rational canonical form — equivalently, the same list of invariant factors.
+
+### Plain Language
+
+The rational canonical form (RCF) provides a complete invariant for matrix similarity over any field. The minimal polynomial alone does NOT determine the similarity class (two matrices can share a minimal polynomial but differ in invariant factors), but the full sequence of invariant factors does.
+
+### Why This Matters
+
+This is a fundamental theorem of linear algebra. The RCF theorem:
+1. Gives a computable complete invariant for similarity (no field extension required, unlike JCF)
+2. Follows from the structure theorem for finitely generated modules over a PID
+3. Generalizes directly to linear operators on modules, not just vector spaces
+4. Is strictly stronger than the minimal polynomial characterization
+
+This is the "if" direction of the similarity characterization: same invariant factors implies similar matrices.
+
+## Known Results
+
+### What's Already Proven
+
+- `cayley-hamilton`: Every matrix satisfies its characteristic polynomial
+- `cayley-hamilton-minpoly`: The minimal polynomial divides the characteristic polynomial
+- `cayley-hamilton-minpoly-oq-02`: Similar matrices have identical minimal polynomials (the "only if" direction)
+- Mathlib: Structure theorem for finitely generated modules over a PID (`Module.torsion_over_pid` or similar)
+- Mathlib: `minpoly.dvd`, `Polynomial.degree_pos_of_root` — polynomial infrastructure
+- Mathlib: `Matrix.charpoly` — characteristic polynomial definition
+
+### What's Still Open
+
+- Formalization of the full RCF theorem in Lean: `A ~ B ↔ invariantFactors A = invariantFactors B`
+- The "if" direction: same invariant factors → constructing the conjugating matrix $P$
+- Connecting Mathlib's module-theoretic infrastructure to the matrix-theoretic statement
+- Showing that the invariant factors uniquely determine a matrix up to similarity
+
+### Our Goal
+
+Prove in Lean 4:
+
+```lean
+theorem similar_iff_eq_invariantFactors {F : Type*} [Field F] {n : ℕ}
+    (A B : Matrix (Fin n) (Fin n) F) :
+    Matrix.Similar A B ↔ invariantFactors A = invariantFactors B
+```
+
+or an equivalent formulation using the rational canonical form directly.
+
+## Mathematical Approach
+
+### Key Idea
+
+View $F^n$ as an $F[x]$-module via the action $x \cdot v = Av$. Two matrices $A, B$ are similar iff the corresponding $F[x]$-modules $M_A$ and $M_B$ are isomorphic. By the structure theorem for finitely generated torsion modules over the PID $F[x]$:
+
+$$
+M_A \cong \bigoplus_i F[x]/(f_i(x))
+$$
+
+where $f_1 \mid f_2 \mid \cdots \mid f_k$ are the invariant factors. The module isomorphism class is uniquely determined by these invariant factors.
+
+### Lean Strategy
+
+1. Define `Matrix.toModule` — the $F[x]$-module structure on $F^n$ induced by $A$
+2. Apply `Module.torsion_over_pid` (if it exists in Mathlib) to decompose
+3. Show that `Matrix.Similar A B ↔ Nonempty (LinearEquiv (F[x]) (toModule A) (toModule B))`
+4. Apply the uniqueness part of the structure theorem
+
+### Alternative: Direct Invariant Factor Approach
+
+If the module-theoretic path is too abstract, formalize via:
+1. Smith Normal Form of `(xI - A)` gives the invariant factors directly
+2. Two matrices have the same SNF of `(xI - A)` iff they are similar
+3. Mathlib might have `Matrix.smithNormalForm` available
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| cayley-hamilton | Foundation: matrix satisfies characteristic poly | charpoly evaluation |
+| cayley-hamilton-minpoly | Minimal polynomial infrastructure | minpoly, dvd relations |
+| cayley-hamilton-minpoly-oq-02 | Same proof family: similar → same minpoly | Matrix.Similar API |
+| cayley-hamilton-minpoly-oq-01 | Jordan canonical form (related canonical form) | JCF over algebraically closed fields |
+
+## Related Open Questions
+
+- `cayley-hamilton-minpoly-oq-02-oq-02-oq-02`: Jordan Normal Form over algebraically closed fields (complement approach)
+- `cayley-hamilton-minpoly-oq-01-oq-03`: Rational canonical form via companion matrix decomposition (direct construction approach)
+- `cayley-hamilton-minpoly-oq-02-oq-03`: Full similarity invariance of rational canonical form
+
+## Suggested First Steps
+
+1. **OBSERVE**: Search Mathlib for existing RCF infrastructure — `Matrix.toList_invariantFactors`, `Matrix.rationCanonicalForm`, or `Module.torsion_over_pid`
+2. **ORIENT**: Determine whether to go via Smith Normal Form of `(xI - A)` or via module theory
+3. **DECIDE**: If Mathlib has `Matrix.smithNormalForm`, use it; otherwise, formalize via the $F[x]$-module approach

--- a/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-01/state.md
+++ b/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-01/state.md
@@ -1,0 +1,16 @@
+# Research State: cayley-hamilton-minpoly-oq-02-oq-02-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-05T00:00:00-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0

--- a/research/problems/erdos-1132-oq-01/knowledge.md
+++ b/research/problems/erdos-1132-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: erdos-1132-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/erdos-1132-oq-01/literature/README.md
+++ b/research/problems/erdos-1132-oq-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for erdos-1132-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/erdos-1132-oq-01/problem.md
+++ b/research/problems/erdos-1132-oq-01/problem.md
@@ -1,0 +1,148 @@
+# Problem: Erdős #1132 OQ-01: Witness Points for Bernstein's Density Theorem
+
+**Slug**: erdos-1132-oq-01
+**Created**: 2026-04-05
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+For a node sequence $(x_1, x_2, \ldots) \subset [-1,1]$, define the $n$-th Lebesgue function:
+$$\Lambda_n(x) = \sum_{k=1}^n \left| \ell_k^{(n)}(x) \right|$$
+where $\ell_k^{(n)}$ are the Lagrange basis polynomials for nodes $x_1, \ldots, x_n$.
+
+**Bernstein's Theorem (1931, axiomatized)**: For any infinite node sequence, the set of
+"good points" (where $\Lambda_n(x)/\log n \to \infty$) is dense in $[-1,1]$.
+
+**OQ-01**: Can the `bernstein_density_theorem` or `erdos_max_theorem` axioms in
+`Erdos1132Problem.lean` be reduced via Lean formalization of the underlying classical analysis?
+
+More concretely: can we prove a version of Erdős's 1961 result (max of Lebesgue function
+> (2/π)log n - C) from Mathlib's polynomial and analysis infrastructure?
+
+### Plain Language
+
+The Lebesgue function measures how badly Lagrange interpolation can amplify errors. Bernstein
+(1931) showed that for ANY choice of interpolation nodes, the Lebesgue constant grows like
+log(n) at a dense set of points — you can't spread the badness out evenly.
+
+The parent proof (`erdos-1132`) axiomatizes this as `bernstein_density_theorem`. OQ-01 asks:
+can we formally construct a witness point and prove the divergence using Mathlib's analysis
+machinery? The axiom `erdos_max_theorem` (Erdős 1961: max of Lebesgue function > (2/π)log n)
+is a weaker but potentially more tractable starting point.
+
+### Why This Matters
+
+1. **Axiom reduction**: Reduces `axiomCount` of `erdos-1132` from 2 toward 0
+2. **Analysis infrastructure**: Tests Mathlib's polynomial + measure theory capabilities
+3. **Foundational**: Bernstein's theorem is a classical result; formalization would be
+   valuable for the wider Mathlib community (approximation theory gap)
+
+## Known Results
+
+### What's Already Proven (in gallery)
+
+- `lagrangeBasis_sum_eq_one` — partition of unity for Lagrange basis (proved in parent)
+- `lebesgueFunction_ge_one` — Lebesgue function ≥ 1 everywhere (proved in parent)
+- Equidistant nodes have exponentially growing Lebesgue constants (proved in parent)
+- `Lagrange.sum_basis` — Mathlib's Lagrange interpolation sum
+
+### What's Axiomatized
+
+- `bernstein_density_theorem` — density of "good" (diverging) points
+- `erdos_max_theorem` — max of Lebesgue function > (2/π)log(n) - 10
+
+### Our Goal
+
+Focus first on `erdos_max_theorem`: prove a version of Erdős's 1961 result that the maximum
+of the Lebesgue function over [-1,1] grows at least logarithmically. This is weaker than
+Bernstein's density result and may be formalizable using Chebyshev polynomial theory or
+orthogonality arguments in Lean 4.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `erdos-1132` | Parent proof with both axioms | Lagrange interpolation definitions |
+| `erdos-1129` | Optimal Lagrange interpolation nodes | Approximation theory |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Approach A: Prove `erdos_max_theorem` via orthogonality / Chebyshev**
+   - Lower bound on max Λ_n follows from the norm of the interpolation projector
+   - Chebyshev polynomials minimize max |ω(x)|; dual argument gives Λ_n lower bound
+   - Risk: Mathlib's Chebyshev / operator norm infrastructure may be insufficient
+
+2. **Approach B: Construct witness for equidistant nodes at x = 0**
+   - More concrete: prove Λ_n(0) → ∞ for equidistant nodes $x_k = -1 + 2k/(n-1)$
+   - Simpler target; avoids density argument; yields a constructive proof
+   - Could become a standalone gallery entry
+
+3. **Approach C: Formalize via L∞ projection norm argument**
+   - Use that the L∞ norm of the Lagrange interpolation operator grows like log n
+   - Follows from functional analysis (Banach-Steinhaus for Lagrange projectors)
+   - Risk: abstract functional analysis over C[-1,1] is not well-formalized in Mathlib
+
+### Key Difficulties
+
+- Mathlib has `Polynomial.lagrange` but limited analysis tools for bounding operator norms
+- The Lebesgue constant (sup over [-1,1]) requires `Real.iSup` machinery and continuity
+- Bernstein's proof uses classical analysis tools (uniform boundedness or direct estimates)
+
+### What Would a Proof Need?
+
+- Chebyshev polynomial properties: `Polynomial.Chebyshev.T`, orthogonality
+- `Finset.card_le_iff` style arguments for node counts
+- `Real.iSup_le` / `Real.le_iSup` for bounding the supremum
+- Possibly: `MeasureTheory.inner_le_iff` for L² orthogonality arguments
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- `erdos_max_theorem` (weaker: just the maximum, not density) more tractable
+- Mathlib has `Polynomial.lagrange`, `Polynomial.Chebyshev`, `Polynomial.eval`
+- Classical analysis proof (1961) uses elementary but involved Fourier/Chebyshev estimates
+- Lean 4 approximation theory is underdeveloped — likely requires new helper lemmas
+
+**Estimated Effort**:
+- Exploration (OBSERVE/ORIENT): 1-2 sessions
+- Approach B (concrete equidistant case): 2-3 sessions — most tractable path
+- Full `erdos_max_theorem` proof: 4-6 sessions
+
+## References
+
+### Papers
+- Bernstein, S.N. (1931) — Density theorem for Lagrange interpolation
+- Erdős, P. (1961) — Lower bound for Lebesgue constants: max Λ_n ≥ (2/π)log n - C
+- Cheney, E.W. "Introduction to Approximation Theory" — classical reference
+
+### Mathlib
+- `Mathlib.LinearAlgebra.Lagrange` — Lagrange interpolation definitions
+- `Mathlib.RingTheory.Polynomial.Chebyshev` — Chebyshev polynomial definitions
+- `Mathlib.Analysis.Normed.Group.Basic` — normed spaces for L∞ bounds
+- `Mathlib.Topology.ContinuousFunction.Polynomial` — polynomial eval continuity
+- `Mathlib.Analysis.SpecificLimits.Basic` — log growth estimates
+
+## Metadata
+
+```yaml
+tags:
+  - approximation-theory
+  - lagrange-interpolation
+  - lebesgue-function
+  - polynomial-theory
+  - analysis
+  - erdos
+related_proofs:
+  - erdos-1132
+  - erdos-1129
+difficulty: medium
+source: gallery-gap
+created: 2026-04-05
+```

--- a/research/problems/erdos-1132-oq-01/state.md
+++ b/research/problems/erdos-1132-oq-01/state.md
@@ -1,0 +1,37 @@
+# Research State: erdos-1132-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-05T13:26:15-07:00
+**Iteration**: 1
+
+## Current Focus
+
+Axiom reduction: the parent proof `erdos-1132` axiomatizes two classical results from
+approximation theory: `bernstein_density_theorem` (Bernstein 1931) and `erdos_max_theorem`
+(Erdős 1961). Primary target: prove `erdos_max_theorem` — that the maximum of the Lebesgue
+function Λ_n over [-1,1] exceeds (2/π)log(n) - C for some constant C.
+
+## Active Approach
+
+Seeker-selected: Explore Mathlib's polynomial and analysis infrastructure for Lagrange
+interpolation and Chebyshev polynomials. Assess whether a proof of `erdos_max_theorem`
+is feasible via Chebyshev orthogonality or a concrete equidistant-nodes calculation.
+Most tractable entry point: show Λ_n diverges at a specific point for equidistant nodes.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+
+1. Read `proofs/Proofs/Erdos1132Problem.lean` in full — understand existing definitions
+   (`lebesgueFunction`, `lebesgueConstant`, `InfiniteNodeSequence`, `denseGoodPoints`)
+2. Search Mathlib for Chebyshev polynomial tools: `Polynomial.Chebyshev.T`, orthogonality
+3. Search Mathlib for `Real.iSup` machinery needed for the Lebesgue constant supremum
+4. Assess Approach B (equidistant nodes, concrete Λ_n(0) calculation) as quickest win

--- a/research/problems/erdos-871/knowledge.md
+++ b/research/problems/erdos-871/knowledge.md
@@ -1,0 +1,32 @@
+# Knowledge: Erdős #871 — Partitioning Additive Bases of Order 2
+
+## Current Status
+
+3 axioms in `Erdos871Problem.lean`:
+1. `erdos_nathanson_1989` — Fixed-threshold counterexample (Acta Arithmetica LII, 1989)
+2. `erdos_nathanson_positive` — Partition possible under log-growth condition
+3. `larsen_construction_blocking` — Blocking property of Larsen 2026 construction
+
+## Key Insight
+
+Larsen (2026) disproved Erdős's conjecture by constructing a basis A with r_A(n) → ∞
+but A cannot be partitioned into two additive bases. The proof uses a "blocking property":
+the construction is dense enough to be a basis but not decomposable.
+
+## Reduction Targets (Priority Order)
+
+### 1. `larsen_construction_blocking` (PRIMARY)
+- Constructive argument: A = ∪_{k} B_k where each block B_k blocks all potential partitions
+- May be formalizable via explicit density/greedy construction
+- Mathlib target: `Mathlib.Combinatorics.Additive` — check for sumset/density infrastructure
+
+### 2. `erdos_nathanson_positive` (SECONDARY)
+- log-growth condition: if r_A(n) > c·log n for c > (log 4/3)⁻¹ ≈ 3.48, partition IS possible
+- May use Mathlib entropy/counting lemmas
+
+## Mathlib Resources to Survey
+
+- `Mathlib.Combinatorics.Additive.Salem` — Salem-Spencer structure
+- `Mathlib.Combinatorics.Additive.Behrend` — density constructions
+- `Mathlib.Data.Set.Card` — cardinality infrastructure
+- Sumset API: `Finset.sumset`, `Set.IsSumFree`

--- a/research/problems/gcd-algorithm-oq-04/problem.md
+++ b/research/problems/gcd-algorithm-oq-04/problem.md
@@ -1,0 +1,46 @@
+# Problem: Unifying EuclideanDomain GCD with GCDMonoid Normalization
+
+## Statement
+
+### Plain Language
+Show that in Lean 4/Mathlib, the GCD computed via `EuclideanDomain` (using the Euclidean algorithm) coincides with the `GCDMonoid` normalized GCD. Establish that the `EuclideanDomain` instance for `ℤ` (or a general Euclidean domain) gives a `GCDMonoid` structure where `gcd` satisfies the universal divisibility property and the normalization condition, and that these two algebraic hierarchies are coherent for concrete types like `ℕ` and `ℤ`.
+
+### Formal Statement
+$$
+\forall \alpha\ [\text{EuclideanDomain}\ \alpha]\ (a\ b : \alpha),\quad
+\gcd_{\text{Euclid}}(a, b) \sim \gcd_{\text{GCDMonoid}}(a, b)
+$$
+where $\sim$ denotes association (unit multiple), and both divide each other.
+
+## Classification
+
+```yaml
+tier: B
+significance: 6
+tractability: 7
+tags:
+  - algebra
+  - lean-mathlib
+  - gcd
+  - type-theory
+  - typeclass-coherence
+  - seeker-selected
+```
+
+**Significance**: 6/10 — Fills a real gap in Mathlib's algebraic hierarchy coherence; used downstream in any formal number theory that switches between `EuclideanDomain` and `GCDMonoid` APIs.
+
+**Tractability**: 7/10 — Both structures exist in Mathlib; the main challenge is navigating typeclass instances and normalization conditions.
+
+## Why This Matters
+
+1. **Typeclass coherence** — Mathlib has two overlapping GCD abstractions; a formal bridge prevents API mismatches in downstream proofs
+2. **Normalization** — `GCDMonoid` requires a canonical representative; `EuclideanDomain.gcd` is not automatically normalized (e.g., `gcd` in `ℤ` can be negative)
+3. **Practical formalization** — Number theory proofs often need to switch between polynomial rings (via `EuclideanDomain`) and integers (via `GCDMonoid`); coherence theorems enable this
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| gcd-algorithm | Parent proof: Euclidean GCD algorithm formalized |
+| gcd-algorithm-oq-01 | Related: extended Euclidean / Bézout context |
+| gcd-algorithm-oq-02 | Related: Binary GCD (Stein's algorithm) |

--- a/research/problems/gcd-algorithm-oq-04/state.md
+++ b/research/problems/gcd-algorithm-oq-04/state.md
@@ -1,0 +1,27 @@
+# Current State
+
+**Phase**: NEW
+**Since**: 2026-04-05T17:02:54.915Z
+**Iteration**: 1
+
+## Current Focus
+
+Initial exploration of the problem.
+
+## Active Approach
+
+None yet.
+
+## Blockers
+
+None.
+
+## Next Action
+
+Begin problem exploration.
+
+## Attempt Counts
+
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0

--- a/research/problems/inclusion-exclusion-oq-02/knowledge.md
+++ b/research/problems/inclusion-exclusion-oq-02/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: inclusion-exclusion-oq-02
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/inclusion-exclusion-oq-02/literature/README.md
+++ b/research/problems/inclusion-exclusion-oq-02/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for inclusion-exclusion-oq-02
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/inclusion-exclusion-oq-02/problem.md
+++ b/research/problems/inclusion-exclusion-oq-02/problem.md
@@ -1,0 +1,159 @@
+# Problem: Möbius Inversion on Boolean Lattice
+
+**Slug**: inclusion-exclusion-oq-02
+**Created**: 2026-04-05
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\text{If } g(S) = \sum_{T \subseteq S} f(T), \text{ then } f(S) = \sum_{T \subseteq S} (-1)^{|S \setminus T|} g(T)
+$$
+
+For all functions f, g : 2^[n] → ℤ satisfying the above "zeta transform" relation.
+
+### Plain Language
+
+The Möbius inversion formula on the Boolean lattice (power set ordered by inclusion)
+says: if you can write g in terms of f by summing over all subsets, you can recover f
+from g by the alternating signed sum. This is the precise algebraic reason why
+inclusion-exclusion works.
+
+In Lean:
+```lean
+theorem mobius_inversion_boolean_lattice {α : Type*} [DecidableEq α]
+    (f g : Finset α → ℤ) (S : Finset α)
+    (h : ∀ T, g T = ∑ U ∈ T.powerset, f U) :
+    f S = ∑ T ∈ S.powerset, (-1 : ℤ) ^ (S.card - T.card) * g T
+```
+
+### Why This Matters
+
+The Möbius inversion formula on the Boolean lattice is the algebraic backbone of
+inclusion-exclusion: it explains *why* the alternating signs work. This fills a
+conceptual gap between the gallery's concrete IE proofs (`inclusion-exclusion`,
+`inclusion-exclusion-oq-01`) and their lattice-theoretic foundation.
+
+The Boolean lattice Möbius function μ(A, B) = (-1)^{|B\A|} (for A ⊆ B) is the
+simplest instance of Möbius inversion on posets (Rota 1964). Proving it from first
+principles in Lean connects the combinatorial and algebraic perspectives.
+
+## Classification
+
+```yaml
+tier: B
+significance: 7
+tractability: 6
+tags:
+  - combinatorics
+  - algebra
+  - mobius-inversion
+  - lattice-theory
+  - inclusion-exclusion
+  - seeker-selected
+```
+
+**Significance**: 7/10 — Foundational algebraic result explaining inclusion-exclusion;
+connects the concrete gallery proofs to abstract Möbius theory.
+
+**Tractability**: 6/10 — The proof is inductive over subsets. Mathlib has `Finset.sum_powerset`
+and related tools. The key step is showing the double sum telescopes. Likely 1-2 sessions.
+
+## Known Gallery Context
+
+### What's Already Proved
+
+- **`inclusion-exclusion`** (verified/mathlib): 2-set and 3-set IE formula, symmetric difference
+- **`inclusion-exclusion-oq-01`** (verified): Euler's totient, surjection counting, derangement formula, Stirling/Bell numbers via IE
+- **`InclusionExclusionOQ03.lean`**: Uses `Finset.sum_comm'` and `Finset.mem_powerset` for more advanced IE arguments
+
+### What's Still Open (OQ-02 Goal)
+
+- The *abstract* Möbius inversion theorem for the Boolean lattice
+- The connection: IE = Möbius inversion specialized to 2^[n]
+- Possibly: the incidence algebra interpretation (if Mathlib has `IncidenceAlgebra`)
+
+## Proof Approach
+
+### Approach 1: Direct Induction on |S| (Most Tractable)
+
+Induct on |S|. For the base case |S| = 0, both sides equal f(∅). For the inductive step,
+expand g(T) using the hypothesis and exchange the order of summation.
+
+Key step (double sum telescoping):
+```
+∑_{T⊆S} (-1)^{|S\T|} g(T)
+  = ∑_{T⊆S} (-1)^{|S\T|} ∑_{U⊆T} f(U)
+  = ∑_{U⊆S} f(U) · ∑_{T: U⊆T⊆S} (-1)^{|S\T|}
+```
+
+The inner sum `∑_{T: U⊆T⊆S} (-1)^{|S\T|}` = [S = U] (1 if S = U, 0 otherwise).
+This is the key combinatorial identity: `∑_{k=0}^n (-1)^k C(n,k) = [n=0]`.
+
+In Lean, this uses:
+- `Finset.sum_comm` to swap order of summation
+- `Finset.sum_powerset_insert` or `Finset.sum_powerset`
+- The alternating binomial identity `∑ (-1)^k C(n,k) = 0` for n ≥ 1 (already in `InclusionExclusionOQ01.lean`)
+
+### Approach 2: Via Mathlib's Incidence Algebra
+
+Mathlib4 has `Algebra.IncidenceAlgebra` (`Mathlib.Algebra.IncidenceAlgebra.Basic`).
+The Möbius function `mobiusAlgebra` for `Finset` ordered by inclusion might give a
+one-line proof. Check `LocallyFiniteOrder` instance for `Finset`.
+
+Look for: `MobiusInversion`, `zeta_mul_mobius`, `LocallyFiniteOrder (Finset α)`
+
+### Approach 3: Explicit Witness for Boolean Lattice
+
+Define the Möbius function for Boolean lattice directly:
+```lean
+def boolMobius (S T : Finset α) : ℤ :=
+  if T ⊆ S then (-1 : ℤ) ^ (S.card - T.card) else 0
+```
+Then prove the defining property: `∑_T boolMobius S T = [S = ∅]`.
+
+### Key Difficulties
+
+- **Sum swapping**: Lean's `Finset.sum_comm` requires careful type setup when
+  the inner sum's domain depends on the outer variable.
+- **Powerset of powerset**: Need to show `{T | U ⊆ T ⊆ S}` is `(S \ U).powerset.image (· ∪ U)`.
+- **Alternating binomial vanishing**: `∑ k : Fin (n+1), (-1)^k.val * C(n, k.val) = 0` for n ≥ 1.
+  This is `InclusionExclusionOQ01.alternating_binomial_sum` if it's in the gallery.
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| `inclusion-exclusion` | Base proof: 2-set and 3-set IE formula |
+| `inclusion-exclusion-oq-01` | Applications: this result generalizes the IE principle used there |
+| `InclusionExclusionOQ03.lean` | Uses powerset sum techniques relevant here |
+
+## References
+
+### Papers
+- Rota, G.-C. (1964). "On the foundations of combinatorial theory I. Theory of Möbius functions." *Zeitschrift für Wahrscheinlichkeitstheorie*, 2(4), 340–368.
+
+### Mathlib
+- `Algebra.IncidenceAlgebra.Basic` — Abstract Möbius inversion (check if Boolean lattice instance exists)
+- `Mathlib.Data.Finset.Powerset` — `Finset.sum_powerset`, `Finset.mem_powerset`
+- `Mathlib.Data.Finset.Lattice.Basic` — Finset lattice operations
+- `Finset.sum_comm` — Key for swapping summation order
+
+## Metadata
+
+```yaml
+tags:
+  - combinatorics
+  - mobius-inversion
+  - boolean-lattice
+  - inclusion-exclusion
+  - lattice-theory
+related_proofs:
+  - inclusion-exclusion
+  - inclusion-exclusion-oq-01
+difficulty: medium
+source: gallery-gap
+```

--- a/research/problems/inclusion-exclusion-oq-02/state.md
+++ b/research/problems/inclusion-exclusion-oq-02/state.md
@@ -1,0 +1,25 @@
+# Research State: inclusion-exclusion-oq-02
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-05T12:11:17-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/shapley-folkman/knowledge.md
+++ b/research/problems/shapley-folkman/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: shapley-folkman
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/shapley-folkman/literature/README.md
+++ b/research/problems/shapley-folkman/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for shapley-folkman
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/shapley-folkman/problem.md
+++ b/research/problems/shapley-folkman/problem.md
@@ -1,0 +1,115 @@
+# Problem: Shapley-Folkman Lemma — Complete the Lean Formalization
+
+**Slug**: shapley-folkman
+**Created**: 2026-04-05T13:14:12-07:00
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+\text{For sets } S_i \subseteq \mathbb{R}^d, \text{ any } x \in \operatorname{conv}\!\left(\sum_{i \in I} S_i\right)
+\text{ has a decomposition with at most } d \text{ summands in } \operatorname{conv}(S_i) \setminus S_i.
+$$
+
+### Plain Language
+
+A point in the convex hull of a Minkowski sum can always be expressed as a sum where
+almost all summands come from the original (non-convexified) sets. Only $d$ summands
+need to come from convex hulls rather than the original sets, regardless of how many
+sets are summed.
+
+### Why This Matters
+
+The Shapley-Folkman lemma underpins existence of approximate equilibria in large economies
+with non-convex preferences (Arrow-Debreu theory), nearly-convex optimization, and
+combinatorial geometry. The gallery formalization (Proofs/ShapleyFolkman.lean) has the main
+theorem proved but 3 sorries remain: `reduce_excess_by_one` (core step), `sum_close_to_convexHull`
+(corollary), and `repeated_sum_nearly_convex` (corollary).
+
+## Known Results
+
+### What's Already Proven
+
+- `convexHull_not_mem_requires_two`, `excess_vertices_affine_dependent`, `linearDependent_coefficients`
+- `exists_decomposition` — initial decomposition from convHull membership
+- `shapley_folkman` (main theorem) — proved by induction using `reduce_excess_by_one` as sorry
+
+### What's Still Open
+
+1. **`reduce_excess_by_one`** (line 241): affine dependence → remove one excess index (Carathéodory-style)
+2. **`sum_close_to_convexHull`** (line 304): corollary from `x ∈ convexHull ℝ (∑ Sᵢ)`
+3. **`repeated_sum_nearly_convex`** (line 316): n-fold Minkowski sum corollary
+
+### Our Goal
+
+Fill all 3 sorries in `Proofs/ShapleyFolkman.lean`. Corollaries #2 and #3 should follow
+from the main theorem. `reduce_excess_by_one` is the hard core step.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| `shapley-folkman` | The formalization itself | Convex analysis, finrank, affine independence |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Aristotle first on corollaries**: `sum_close_to_convexHull` and `repeated_sum_nearly_convex`
+   may be auto-provable since they follow from `shapley_folkman` + membership rewrites.
+
+2. **Manual `reduce_excess_by_one`**: find λ s.t. ∑ λᵢ = 0, ∑ λᵢfᵢ = 0 with some λᵢ ≠ 0
+   (from `linearDependent_coefficients`). Perturb f by t·λ until one component hits ∂Sᵢ.
+
+3. **Mathlib Carathéodory**: check if `Convex.caratheodory` or similar can close `reduce_excess_by_one`.
+
+### Key Difficulties
+
+- `reduce_excess_by_one` needs explicit construction of the perturbed decomposition
+- Must show perturbed point stays in convHull(Sᵢ) throughout
+
+### What Would a Proof Need?
+
+- `AffineIndependent` and affine dependence theory from Mathlib
+- `Module.finrank` bounds and FiniteDimensional infrastructure
+- Linear algebra: finding t∗ where perturbed component hits boundary
+
+## Tractability Assessment
+
+**Difficulty**: Medium
+
+**Justification**:
+- Two corollaries are likely low-effort (structural follows from main theorem)
+- Core step requires careful algebra but the mathematical structure is clear
+- Mathlib has all prerequisites (FiniteDimensional, convexHull, AffineIndependent)
+- Aristotle is an explicit goal per the gallery openQuestions
+
+## References
+
+### Papers
+- Shapley & Shubik (1966) — "Quasi-cores in a monetary economy with nonconvex preferences"
+- Starr (1969) — "Quasi-equilibria in markets with non-convex preferences"
+
+### Mathlib
+- `Mathlib.Analysis.Convex.Hull` — convexHull and basic properties
+- `Mathlib.LinearAlgebra.AffineSpace.Independent` — AffineIndependent
+- `Mathlib.LinearAlgebra.FiniteDimensional` — Module.finrank
+
+## Metadata
+
+```yaml
+tags:
+  - convex-analysis
+  - economics
+  - formalization
+  - aristotle-candidate
+  - mathlib-target
+related_proofs:
+  - shapley-folkman
+difficulty: medium
+source: gallery-gap
+created: 2026-04-05T13:14:12-07:00
+```

--- a/research/problems/shapley-folkman/state.md
+++ b/research/problems/shapley-folkman/state.md
@@ -1,0 +1,25 @@
+# Research State: shapley-folkman
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-05T13:14:12-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/wilsons-theorem-oq-03/state.md
+++ b/research/problems/wilsons-theorem-oq-03/state.md
@@ -4,10 +4,16 @@
 **Phase**: OBSERVE
 **Path**: full
 **Since**: 2026-04-05T10:02:39-07:00
+**Last Selected**: 2026-04-05T17:00:00-07:00
 **Iteration**: 1
 
 ## Current Focus
 Initial problem understanding. Read problem.md and gather context.
+
+**Seeker note (re-selection)**: Highest-scoring available candidate (composite 77:
+tractability=7, significance=7, EMPTY knowledge). Workspace fully initialized —
+begin OBSERVE immediately. Key API targets: `Nat.factorization_factorial`,
+`padicValNat`, `ZMod.wilsons_lemma`.
 
 ## Active Approach
 None yet.

--- a/research/registry.json
+++ b/research/registry.json
@@ -6196,11 +6196,11 @@
     },
     {
       "slug": "erdos-1132-oq-01",
-      "phase": "COMPLETED",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-03-24T00:48:59.907Z",
       "status": "graduated",
-      "lastUpdate": "2026-03-24T16:23:55.819Z",
+      "lastUpdate": "2026-04-05T13:26:15-07:00",
       "completed": "2026-03-24T16:23:55.819Z"
     },
     {

--- a/research/registry.json
+++ b/research/registry.json
@@ -14913,6 +14913,30 @@
       "started": "2026-04-05T21:14:29.669Z",
       "status": "active",
       "lastUpdate": "2026-04-05T21:14:29.734Z"
+    },
+    {
+      "slug": "area-of-circle-oq-03-oq-03-oq-01",
+      "id": "area-of-circle-oq-03-oq-03-oq-01",
+      "title": "Ellipse area \u03c0\u00b7a\u00b7b via Mathlib measure-theoretic change of variables",
+      "status": "active",
+      "tier": "B",
+      "significance": 6,
+      "tractability": 7,
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-05T22:13:23.853Z",
+      "lastUpdate": "2026-04-05T22:13:23.876Z",
+      "seekerSelected": "2026-04-05T22:13:23.876Z",
+      "compositeScore": 76,
+      "tags": [
+        "geometry",
+        "measure-theory",
+        "change-of-variables",
+        "ellipse",
+        "mathlib-formalization"
+      ],
+      "source": "gallery-gap",
+      "parentProof": "area-of-circle-oq-03-oq-03"
     }
   ],
   "config": {

--- a/research/registry.json
+++ b/research/registry.json
@@ -3271,11 +3271,11 @@
     },
     {
       "slug": "erdos-871",
-      "phase": "COMPLETED",
+      "phase": "OBSERVE",
       "path": "fast",
       "started": "2026-01-23T08:04:56.547Z",
-      "status": "graduated",
-      "lastUpdate": "2026-03-23T22:48:57.683Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T20:35:25.000Z",
       "completed": "2026-03-23T22:48:57.683Z"
     },
     {


### PR DESCRIPTION
## Selected Problem

**ID**: area-of-circle-oq-03-oq-03-oq-01
**Name**: Ellipse area π·a·b via Mathlib measure-theoretic change of variables
**Tier**: B | **Significance**: 6/10 | **Tractability**: 7/10
**Knowledge**: EMPTY | **Composite Score**: 76

## Selection Rationale

- Highest composite score (76) in pool of 16 available candidates
- Highest tractability (7/10) — concrete Mathlib strategy via `map_linearMap`
- Parent proof `AreaOfCircleOQ03OQ03` uses a ring tautology for ellipse area; this formalizes it properly
- Domain diversity: geometry/analysis vs. recent number-theory and topology selections

## Approach

The linear map T(x,y) = (ax, by) has det T = a·b. By the measure-theoretic change of variables:
```
vol(ellipse a b) = vol(T(unit_disk)) = |det T| · vol(unit_disk) = ab · π
```

Key Mathlib lemmas: `MeasureTheory.Measure.map_linearMap`, `Real.volume_ball`

## Runner-up

pell-equation-oq-01-oq-04 (score 75, tract=7, sig=5) — 1-point margin

## Pool Summary

| Status | Count |
|--------|-------|
| Available | 16 |
| In Progress | 6 |
| Completed | 1231 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)