### PR TITLE
Seeker: select pell-equation-oq-01-oq-04 — IsFundamental API exploration

### DIFF
--- a/research/problems/area-of-circle-oq-05-oq-03/problem.md
+++ b/research/problems/area-of-circle-oq-05-oq-03/problem.md
@@ -1,0 +1,93 @@
+# Problem: Fourier Transform of Gaussian in Lean 4 via Mathlib
+
+**Slug**: area-of-circle-oq-05-oq-03
+**Tier**: B | **Significance**: 7/10 | **Tractability**: 6/10
+**Category**: extension
+**Source**: gallery-gap
+**Status**: Active (OBSERVE)
+
+## Problem Statement
+
+### Formal Statement
+
+Prove that the Fourier transform of the standard Gaussian is another Gaussian:
+
+$$
+\int_{-\infty}^{\infty} e^{itx} \cdot \frac{e^{-x^2/2}}{\sqrt{2\pi}} \, dx = e^{-t^2/2}
+$$
+
+The exact Lean target from `CentralLimitTheorem.lean`:
+```lean
+axiom gaussian_fourier_identity (t : ℝ) :
+  ∫ x : ℝ, Complex.exp (Complex.I * ↑t * ↑x) ∂stdGaussian =
+  Complex.exp (-(↑t : ℂ)^2 / 2)
+```
+where `stdGaussian` is the standard Gaussian measure on ℝ.
+
+### Plain Language
+
+The Gaussian function is its own Fourier transform (up to normalization). This is the
+self-duality property of the Gaussian. Key computation: completing the square in
+$itx - x^2/2 = -\tfrac{1}{2}(x-it)^2 - t^2/2$, factoring out $e^{-t^2/2}$, then
+recognizing the remaining integral as the Gaussian integral $\sqrt{2\pi}$.
+
+## Why This Matters
+
+**Critical gap**: `proofs/Proofs/CentralLimitTheorem.lean` axiomatizes this identity.
+Proving it would eliminate the `gaussian_fourier_identity` axiom from the CLT proof,
+strengthening the gallery's `central-limit-theorem` entry.
+
+## Known Mathlib Lemmas to Investigate
+
+- `MeasureTheory.integral_gaussian_complex` — may exist in `Mathlib.Analysis.SpecialFunctions.Gaussian`
+- `Real.integral_gaussian` — `∫ x, exp (-b * x^2) = √(π / b)` for b > 0
+- `MeasureTheory.GaussianFourier` module or similar
+- `ProbabilityTheory.gaussianFourierTransform` — check if exists
+- `integral_comp_add_right`, `integral_comp_mul_right` — for contour-shift steps
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| area-of-circle-oq-05 | Parent: Gaussian integral ∫ e^{-x²} dx = √π |
+| area-of-circle-oq-05-oq-01 | Polar-coordinate proof of Gaussian integral (4 sorries) |
+| central-limit-theorem | Uses `gaussian_fourier_identity` as axiom — this would remove it |
+
+## Known Results
+
+- `gaussian_integral_eq_sqrt_pi` in `AreaOfCircleOQ05.lean`: ∫ e^{-x²} dx = √π
+- `Real.integral_gaussian` in Mathlib: ∫ x, exp (-b * x^2) = √(π / b)
+- The CLT proof uses the axiom at `CentralLimitTheorem.lean:100`
+
+## Approach Strategy
+
+**Primary**: Check if Mathlib already has a direct formalization:
+  - `Mathlib.Analysis.SpecialFunctions.Gaussian.FourierTransform` (may exist)
+  - `MeasureTheory.integral_mul_left` + completing-the-square algebraic manipulation
+
+**Fallback**: Prove directly:
+  1. Complete the square: $itx - x^2/2 = -(x-it)^2/2 - t^2/2$
+  2. Factor out $e^{-t^2/2}$
+  3. Shift integration variable $u = x - it$ (using `integral_comp_add_right`)
+  4. Apply Gaussian integral result to get $\sqrt{2\pi}$ normalization
+  5. Conclude
+
+## Metadata
+
+```yaml
+tags:
+  - analysis
+  - fourier
+  - gaussian
+  - mathlib
+  - central-limit-theorem
+related_proofs:
+  - area-of-circle-oq-05
+  - area-of-circle-oq-05-oq-01
+  - central-limit-theorem
+difficulty: medium
+source: gallery-gap
+tier: B
+significance: 7
+tractability: 6
+```

--- a/research/problems/area-of-circle-oq-05-oq-03/state.md
+++ b/research/problems/area-of-circle-oq-05-oq-03/state.md
@@ -1,0 +1,45 @@
+# Research State: area-of-circle-oq-05-oq-03
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-05T22:13:23.854Z
+**Iteration**: 1
+
+## Current Focus
+
+Prove the Gaussian Fourier transform identity:
+  ∫ x : ℝ, Complex.exp (I * t * x) ∂stdGaussian = Complex.exp (-t² / 2)
+
+This is currently axiomatized in `CentralLimitTheorem.lean`. Proving it would
+remove the `gaussian_fourier_identity` axiom from the CLT formalization.
+
+## Active Approach
+
+Mathlib search strategy (primary):
+1. Check `Mathlib.Analysis.SpecialFunctions.Gaussian` for complex Fourier results
+2. Search for `integral_gaussian_complex`, `GaussianFourier`, or `charFun_gaussianReal`
+3. If found directly, wrap in a short proof connecting to our `stdGaussian` measure
+4. If not found, use completing-the-square approach with `integral_comp_add_right`
+
+## Key Mathlib Lemmas to Check
+
+- `MeasureTheory.integral_gaussian_complex` in Mathlib.Analysis.SpecialFunctions.Gaussian
+- `ProbabilityTheory.charFun_gaussianReal` or similar characteristic function API
+- `Real.integral_gaussian`: ∫ x, exp (-b * x^2) = √(π / b)
+- `Complex.exp_add` and algebraic completing-the-square
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+
+1. Search Mathlib for `gaussian.*fourier`, `fourier.*gaussian`, `charFun.*gaussian`
+2. Read `CentralLimitTheorem.lean` lines 95-120 for exact type of axiom to replace
+3. Check `AreaOfCircleOQ05.lean` for Mathlib imports already available
+4. Try connecting existing `integral_gaussian` to the complex-exponential form

--- a/research/registry.json
+++ b/research/registry.json
@@ -15051,7 +15051,8 @@
       "path": "fast",
       "started": "2026-04-05T22:23:02.409Z",
       "status": "active",
-      "lastUpdate": "2026-04-05T22:23:02.430Z"
+      "lastUpdate": "2026-04-05T22:23:02.430Z",
+      "selected_at": "2026-04-05T22:32:41Z"
     }
   ],
   "config": {

--- a/research/registry.json
+++ b/research/registry.json
@@ -3271,11 +3271,11 @@
     },
     {
       "slug": "erdos-871",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "fast",
       "started": "2026-01-23T08:04:56.547Z",
-      "status": "active",
-      "lastUpdate": "2026-04-05T20:35:25.000Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T22:23:02.279Z",
       "completed": "2026-03-23T22:48:57.683Z"
     },
     {
@@ -14074,11 +14074,11 @@
     },
     {
       "slug": "erdos-279-oq-04",
-      "phase": "NEW",
+      "phase": "OBSERVE",
       "path": "fast",
       "started": "2026-04-05T14:51:46.137Z",
       "status": "active",
-      "lastUpdate": "2026-04-05T14:51:46.137Z"
+      "lastUpdate": "2026-04-05T22:23:02.427Z"
     },
     {
       "slug": "erdos-286-oq-01",
@@ -14939,6 +14939,119 @@
       ],
       "source": "gallery-gap",
       "parentProof": "area-of-circle-oq-03-oq-03"
+    },
+    {
+      "slug": "abel-ruffini-oq-04-oq-07-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T22:23:02.408Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T22:23:02.408Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-03-oq-03-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T22:23:02.409Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T22:23:02.409Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-03-oq-03-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T22:23:02.409Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T22:23:02.409Z"
+    },
+    {
+      "slug": "area-of-circle-oq-03-oq-03-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T22:23:02.409Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T22:23:02.409Z"
+    },
+    {
+      "slug": "area-of-circle-oq-05-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T22:23:02.409Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T22:26:32Z",
+      "notes": "Seeker selected: Fourier transform of Gaussian \u2014 removes gaussian_fourier_identity axiom from CLT proof"
+    },
+    {
+      "slug": "four-color-theorem-oq-02-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T22:23:02.409Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T22:23:02.409Z"
+    },
+    {
+      "slug": "gelfond-schneider-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T22:23:02.409Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T22:23:02.409Z"
+    },
+    {
+      "slug": "hilbert-3-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T22:23:02.409Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T22:23:02.409Z"
+    },
+    {
+      "slug": "hilbert-4-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T22:23:02.409Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T22:23:02.409Z"
+    },
+    {
+      "slug": "hilbert-5-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T22:23:02.409Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T22:23:02.409Z"
+    },
+    {
+      "slug": "hilbert-9-reciprocity-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T22:23:02.409Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T22:23:02.409Z"
+    },
+    {
+      "slug": "pell-equation-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T22:23:02.409Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T22:23:02.409Z"
+    },
+    {
+      "slug": "ramseys-theorem-oq-04-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T22:23:02.409Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T22:23:02.409Z"
+    },
+    {
+      "slug": "pell-equation-oq-01-oq-04",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-05T22:23:02.409Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T22:23:02.430Z"
     }
   ],
   "config": {


### PR DESCRIPTION
## Summary

- Selects `pell-equation-oq-01-oq-04` as the next research problem (composite score 75)
- Also includes prior seeker selection of `area-of-circle-oq-05-oq-03` (Fourier transform of Gaussian, score 67)
- Applied diversity penalty to skip 3 consecutive area-of-circle selections

## Problem Selected

**pell-equation-oq-01-oq-04** — Use IsFundamental from Mathlib Pell namespace to simplify pellNorm proof
- Tier C | Significance 5/10 | Tractability 7/10
- Workspace initialized at OBSERVE phase, 0 attempts
- Explores whether `Pell.IsFundamental.one_lt_x` can replace manual `calc` in `pellNorm_pos_of_pos`

🤖 Generated with [Claude Code](https://claude.com/claude-code)