### PR TITLE
feat(aristotle): expand Erdos660 companion with 30 provable lemmas

### DIFF
--- a/proofs/Proofs/Erdos660Aristotle.lean
+++ b/proofs/Proofs/Erdos660Aristotle.lean
@@ -4,11 +4,13 @@
   See Erdos660Problem.lean for the main formalization.
 
   These lemmas provide building blocks for the distinct distances problem:
-  - Basic distance properties (positivity, symmetry)
+  - Basic distance properties (positivity, symmetry, zero distance)
   - Finset membership and cardinality helpers
   - Structural properties of pairwiseDistances
   - Trivial lower bound proof
-  - Specific geometric constructions (tetrahedron, cube, octahedron)
+  - Empty/singleton distance computations
+  - Product and image membership facts
+  - Monotonicity of distance sets
 -/
 import Mathlib
 
@@ -17,6 +19,7 @@ namespace Erdos660.Aristotle
 open Finset Set
 
 abbrev Point3D := EuclideanSpace ℝ (Fin 3)
+abbrev Point2D := EuclideanSpace ℝ (Fin 2)
 
 /-
   ## Section 1: Basic Distance Lemmas
@@ -30,9 +33,26 @@ lemma dist_pos_of_ne (p q : Point3D) (h : p ≠ q) : 0 < dist p q := by
 lemma dist_comm' (p q : Point3D) : dist p q = dist q p := by
   sorry
 
+/-- Distance from a point to itself is zero -/
+lemma dist_self' (p : Point3D) : dist p p = 0 := by
+  sorry
+
+/-- Distance is nonneg -/
+lemma dist_nonneg' (p q : Point3D) : 0 ≤ dist p q := by
+  sorry
+
+/-- If distance is zero then points are equal -/
+lemma eq_of_dist_zero (p q : Point3D) (h : dist p q = 0) : p = q := by
+  sorry
+
 /-- A Finset with card ≥ 2 has two distinct elements -/
 lemma has_two_elements (S : Finset Point3D) (h : S.card ≥ 2) :
     ∃ p ∈ S, ∃ q ∈ S, p ≠ q := by
+  sorry
+
+/-- If card ≥ 2, there exist two distinct elements -/
+lemma card_two_exists (S : Finset Point3D) (h : 2 ≤ S.card) :
+    ∃ a b : Point3D, a ∈ S ∧ b ∈ S ∧ a ≠ b := by
   sorry
 
 /-
@@ -45,15 +65,36 @@ noncomputable def pairwiseDistances (S : Finset Point3D) : Finset ℝ :=
 noncomputable def distinctDistances (S : Finset Point3D) : ℕ :=
   ((pairwiseDistances S).filter (· > 0)).card
 
-/-- A positive pairwise distance belongs to pairwiseDistances -/
+/-- Zero is in pairwiseDistances of a nonempty set (from dist p p = 0) -/
+lemma zero_mem_pairwiseDistances (S : Finset Point3D) (hne : S.Nonempty) :
+    (0 : ℝ) ∈ pairwiseDistances S := by
+  sorry
+
+/-- A pairwise distance belongs to pairwiseDistances -/
 lemma mem_pairwiseDistances (S : Finset Point3D) (p q : Point3D)
     (hp : p ∈ S) (hq : q ∈ S) : dist p q ∈ pairwiseDistances S := by
   sorry
 
-/-- If p ≠ q and both are in S, dist p q > 0 and in pairwiseDistances S -/
+/-- If p ≠ q and both are in S, dist p q > 0 -/
+lemma pos_dist_of_ne_mem (S : Finset Point3D) (p q : Point3D)
+    (hp : p ∈ S) (hq : q ∈ S) (hne : p ≠ q) : dist p q > 0 := by
+  sorry
+
+/-- If p ≠ q and both are in S, dist p q is in the filtered set -/
 lemma pos_dist_mem_filter (S : Finset Point3D) (p q : Point3D)
     (hp : p ∈ S) (hq : q ∈ S) (hne : p ≠ q) :
     dist p q ∈ (pairwiseDistances S).filter (· > 0) := by
+  sorry
+
+/-- pairwiseDistances consists of nonneg reals -/
+lemma pairwiseDistances_nonneg (S : Finset Point3D) (d : ℝ)
+    (hd : d ∈ pairwiseDistances S) : 0 ≤ d := by
+  sorry
+
+/-- The cardinality of filtered pairwiseDistances is positive if there is a pos distance -/
+lemma card_filter_pos_of_distinct (S : Finset Point3D) (p q : Point3D)
+    (hp : p ∈ S) (hq : q ∈ S) (hne : p ≠ q) :
+    0 < ((pairwiseDistances S).filter (· > 0)).card := by
   sorry
 
 /-
@@ -66,13 +107,8 @@ theorem trivial_lower_bound (S : Finset Point3D) (hn : S.card ≥ 2) :
   sorry
 
 /-
-  ## Section 4: Small Constructions
+  ## Section 4: Empty and Singleton Cases
 -/
-
-/-- A two-point set has exactly 1 distinct distance -/
-lemma two_point_one_distance (p q : Point3D) (hne : p ≠ q) :
-    distinctDistances {p, q} = 1 := by
-  sorry
 
 /-- Pairwise distances of an empty set is empty -/
 lemma pairwiseDistances_empty : pairwiseDistances (∅ : Finset Point3D) = ∅ := by
@@ -86,6 +122,82 @@ lemma pairwiseDistances_singleton (p : Point3D) :
 /-- A singleton has 0 distinct distances -/
 lemma distinctDistances_singleton (p : Point3D) :
     distinctDistances {p} = 0 := by
+  sorry
+
+/-- Distinct distances of empty set is 0 -/
+lemma distinctDistances_empty :
+    distinctDistances (∅ : Finset Point3D) = 0 := by
+  sorry
+
+/-
+  ## Section 5: Two-Point Configurations
+-/
+
+/-- A two-point set has exactly 1 distinct distance -/
+lemma two_point_one_distance (p q : Point3D) (hne : p ≠ q) :
+    distinctDistances {p, q} = 1 := by
+  sorry
+
+/-
+  ## Section 6: Finset and Cardinality Helpers
+-/
+
+/-- A Finset with card ≥ 1 is nonempty -/
+lemma card_pos_nonempty (S : Finset Point3D) (h : 0 < S.card) : S.Nonempty := by
+  sorry
+
+/-- If card ≥ 2 then card ≥ 1 -/
+lemma card_two_implies_one (S : Finset Point3D) (h : 2 ≤ S.card) : 1 ≤ S.card := by
+  sorry
+
+/-- filter of empty set (reals) is empty -/
+lemma filter_empty_pos : (∅ : Finset ℝ).filter (· > 0) = ∅ := by
+  sorry
+
+/-- Filtering {0} for positives gives empty -/
+lemma filter_zero_pos : ({0} : Finset ℝ).filter (· > 0) = ∅ := by
+  sorry
+
+/-- If a ≠ b then {a, b}.card = 2 (for ℝ) -/
+lemma card_pair_of_ne (a b : ℝ) (h : a ≠ b) : ({a, b} : Finset ℝ).card = 2 := by
+  sorry
+
+/-
+  ## Section 7: Distance Image Monotonicity
+-/
+
+/-- The image of the product under dist equals pairwiseDistances by definition -/
+lemma pairwiseDistances_eq_image (S : Finset Point3D) :
+    pairwiseDistances S = (S.product S).image (fun pq => dist pq.1 pq.2) := by
+  sorry
+
+/-- pairwiseDistances is monotone: if S ⊆ T then pairwiseDistances S ⊆ pairwiseDistances T -/
+lemma pairwiseDistances_mono (S T : Finset Point3D) (h : S ⊆ T) :
+    pairwiseDistances S ⊆ pairwiseDistances T := by
+  sorry
+
+/-- The filter is monotone with respect to subset -/
+lemma filter_mono_subset (S T : Finset ℝ) (h : S ⊆ T) :
+    S.filter (· > 0) ⊆ T.filter (· > 0) := by
+  sorry
+
+/-- distinctDistances is monotone -/
+lemma distinctDistances_mono (S T : Finset Point3D) (h : S ⊆ T) :
+    distinctDistances S ≤ distinctDistances T := by
+  sorry
+
+/-
+  ## Section 8: Product Membership Helpers
+-/
+
+/-- A pair (p, q) is in the product S ×ˢ S if both are in S -/
+lemma mem_product_of_mem (S : Finset Point3D) (p q : Point3D)
+    (hp : p ∈ S) (hq : q ∈ S) : (p, q) ∈ S.product S := by
+  sorry
+
+/-- The image of a nonempty finset is nonempty -/
+lemma image_nonempty_of_nonempty {α β : Type*} [DecidableEq β]
+    (S : Finset α) (f : α → β) (h : S.Nonempty) : (S.image f).Nonempty := by
   sorry
 
 end Erdos660.Aristotle


### PR DESCRIPTION
## Summary

- Expands `Erdos660Aristotle.lean` from 9 sorries to 30 Aristotle-provable theorem/lemma targets
- Adds coverage across 8 sections: basic distance properties, pairwiseDistances structure, trivial lower bound, empty/singleton cases, two-point configurations, cardinality helpers, monotonicity, and product membership
- Excludes all open conjectures (`erdos_660_conjecture`, `linear_lower_bound_conjecture`, `altman_convex_polygon_distances`, `guth_katz_distinct_distances`) and all `def` sorries per Aristotle guidelines
- No `/-!` sections, no `axiom` declarations, no `def ... := sorry`

## Test plan

- [ ] Verify no forbidden patterns: `def.*:= sorry`, `axiom`, `/-!`
- [ ] Confirm all 30 targets are `theorem` or `lemma` with `by sorry`
- [ ] Submit to Aristotle proof search for automated proving

🤖 Generated with [Claude Code](https://claude.com/claude-code)