### PR TITLE
feat(aristotle): add Aristotle companion for Erdős #629

### DIFF
--- a/proofs/Proofs/Erdos629Aristotle.lean
+++ b/proofs/Proofs/Erdos629Aristotle.lean
@@ -1,0 +1,112 @@
+/-
+  Aristotle targets for Erdos629 (List Chromatic Number of Bipartite Graphs)
+  Routine supporting lemmas for automated proof search.
+  See Erdos629Problem.lean for the main formalization.
+
+  These lemmas provide building blocks for list coloring analysis:
+  - IsBipartite structural helpers
+  - listChromaticNumber monotonicity and basic properties
+  - n(k) function arithmetic (bounds, monotonicity)
+  - Exponential growth helpers
+  - Complete bipartite graph properties
+-/
+import Mathlib
+
+open SimpleGraph Finset
+
+namespace Erdos629.Aristotle
+
+/-
+  ## Section 1: Bipartite Graph Helpers
+-/
+
+/-- A bipartite graph has chromatic number ≤ 2 -/
+lemma bipartite_chromatic_le_two {V : Type*} [Fintype V] [DecidableEq V]
+    (G : SimpleGraph V) [DecidableRel G.Adj]
+    (h : ∃ f : V → Bool, ∀ u v, G.Adj u v → f u ≠ f v) :
+    G.chromaticNumber ≤ 2 := by
+  sorry
+
+/-- A graph with no edges has chromatic number ≤ 1 -/
+lemma empty_graph_chromatic {V : Type*} [Fintype V] [DecidableEq V]
+    (G : SimpleGraph V) [DecidableRel G.Adj]
+    (h : ∀ u v : V, ¬G.Adj u v) : G.chromaticNumber ≤ 1 := by
+  sorry
+
+/-
+  ## Section 2: Exponential Bounds
+-/
+
+/-- 2^(k-1) < 2^k for k ≥ 1 -/
+lemma pow_pred_lt (k : ℕ) (hk : k ≥ 1) : 2 ^ (k - 1) < 2 ^ k := by
+  sorry
+
+/-- 2^k < k^2 * 2^(k+2) for k ≥ 1 -/
+lemma pow_lt_sq_pow (k : ℕ) (hk : k ≥ 1) : 2 ^ k < k ^ 2 * 2 ^ (k + 2) := by
+  sorry
+
+/-- k * n ≤ k^2 * 2^k when n ≤ k * 2^k -/
+lemma recursive_upper_bound_helper (k n : ℕ) (h : n ≤ k * 2 ^ k) :
+    k * n ≤ k ^ 2 * 2 ^ k := by
+  sorry
+
+/-- 2^k + k * 2^k = (k+1) * 2^k -/
+lemma pow_factor (k : ℕ) : 2 ^ k + k * 2 ^ k = (k + 1) * 2 ^ k := by
+  sorry
+
+/-- (k+1) * 2^k ≤ k^2 * 2^(k+2) for k ≥ 2 -/
+lemma k_plus_one_pow_le (k : ℕ) (hk : k ≥ 2) : (k + 1) * 2 ^ k ≤ k ^ 2 * 2 ^ (k + 2) := by
+  sorry
+
+/-
+  ## Section 3: Csínf / sInf Monotonicity
+-/
+
+/-- sInf of a subset is at least sInf of superset (for naturals) -/
+lemma sInf_mono_subset (S T : Set ℕ) (h : T ⊆ S) (hS : S.Nonempty) :
+    Nat.sInf S ≤ Nat.sInf T := by
+  sorry
+
+/-- n(k) is monotone: n(k₁) ≤ n(k₂) for k₁ ≤ k₂ -/
+lemma n_mono_helper (n : ℕ → ℕ) (hmono : ∀ k₁ k₂, k₁ ≤ k₂ → n k₁ ≤ n k₂)
+    (k : ℕ) : n k ≤ n (k + 2) := by
+  sorry
+
+/-
+  ## Section 4: Complete Bipartite Graph Properties
+-/
+
+/-- Complete bipartite graph K_{m,n} has m + n vertices -/
+lemma completeBipartite_card (m n : ℕ) :
+    Fintype.card (Fin m ⊕ Fin n) = m + n := by
+  sorry
+
+/-- K_{1,1} has 1 edge (it's just one edge) -/
+lemma K11_card_adj : ∀ (u v : Fin 1 ⊕ Fin 1),
+    (match u, v with
+    | Sum.inl _, Sum.inr _ => True
+    | Sum.inr _, Sum.inl _ => True
+    | _, _ => False) → u ≠ v := by
+  sorry
+
+/-- Sum.inl and Sum.inr are always different -/
+lemma inl_ne_inr {α β : Type*} (a : α) (b : β) : Sum.inl a ≠ (Sum.inr b : α ⊕ β) := by
+  sorry
+
+/-
+  ## Section 5: List Chromatic Ceiling
+-/
+
+/-- Nat.clog 2 n ≥ 1 for n ≥ 2 -/
+lemma clog_ge_one (n : ℕ) (hn : n ≥ 2) : Nat.clog 2 n ≥ 1 := by
+  sorry
+
+/-- Nat.clog 2 (2^k) = k -/
+lemma clog_pow_two (k : ℕ) : Nat.clog 2 (2 ^ k) = k := by
+  sorry
+
+/-- Nat.clog 2 n ≤ n for n ≥ 1 -/
+lemma clog_le_self (n : ℕ) (hn : n ≥ 1) : Nat.clog 2 n ≤ n := by
+  sorry
+
+end Erdos629.Aristotle


### PR DESCRIPTION
## Fix

Add Aristotle companion for Erdős #629 with routine supporting lemmas for automated proof search.

## Evidence

**Before**: No Aristotle companion file existed.
**After**: New companion file (`proofs/Proofs/Erdos629Aristotle.lean`) with 15 Aristotle targets covering bipartite graph helpers, exponential bounds, sInf monotonicity, complete bipartite graph properties, and list chromatic ceiling lemmas.

---
Automated repair by lean-mechanic agent.