### PR TITLE
Fix sorry counts in 13 gallery proofs

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -19,7 +19,7 @@
       "elementary-symmetric-polynomials"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Real.geom_mean_le_arith_mean_weighted",

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -53,10 +53,10 @@
       "result": "clean"
     },
     "amgm-inequality-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T17:03:24Z",
-      "result": "clean"
+      "lastAudited": "2026-04-05T23:15:07Z",
+      "result": "issues-fixed"
     },
     "amgm-inequality-oq-02-oq-03": {
       "auditCount": 5,
@@ -1432,10 +1432,10 @@
       "result": "clean"
     },
     "descartes-rule-of-signs-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-03T22:10:54Z",
-      "result": "clean"
+      "lastAudited": "2026-04-05T23:15:07Z",
+      "result": "issues-fixed"
     },
     "descartes-rule-of-signs-oq-01-oq-01": {
       "auditCount": 2,
@@ -1500,11 +1500,11 @@
       "result": "clean"
     },
     "dirichlets-theorem-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "sorry mismatch corrected in meta.json"
       ],
-      "lastAudited": "2026-04-03T09:06:15Z",
+      "lastAudited": "2026-04-05T23:15:07Z",
       "result": "issues-fixed"
     },
     "dissection-of-cubes": {
@@ -1763,10 +1763,10 @@
       "result": "clean"
     },
     "erdos-1006-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-03T21:47:53Z",
-      "result": "clean"
+      "lastAudited": "2026-04-05T23:15:07Z",
+      "result": "issues-fixed"
     },
     "erdos-1006-oq-02-oq-03": {
       "auditCount": 6,
@@ -2821,10 +2821,10 @@
       "result": "clean"
     },
     "erdos-1137": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T17:31:46Z",
-      "result": "clean"
+      "lastAudited": "2026-04-05T23:15:07Z",
+      "result": "issues-fixed"
     },
     "erdos-1138": {
       "auditCount": 3,
@@ -2833,10 +2833,10 @@
       "result": "issues-fixed"
     },
     "erdos-1138-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T17:31:45Z",
-      "result": "clean"
+      "lastAudited": "2026-04-05T23:15:07Z",
+      "result": "issues-fixed"
     },
     "erdos-1139": {
       "auditCount": 3,
@@ -3271,11 +3271,11 @@
       "result": "clean"
     },
     "erdos-138": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [
         "sorry mismatch corrected in meta.json"
       ],
-      "lastAudited": "2026-04-03T09:06:15Z",
+      "lastAudited": "2026-04-05T23:15:07Z",
       "result": "issues-fixed"
     },
     "erdos-139": {
@@ -5024,11 +5024,11 @@
       "result": "issues-fixed"
     },
     "erdos-392": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "sorry mismatch corrected in meta.json"
       ],
-      "lastAudited": "2026-04-03T09:06:15Z",
+      "lastAudited": "2026-04-05T23:15:07Z",
       "result": "issues-fixed"
     },
     "erdos-393": {
@@ -6453,10 +6453,10 @@
       "result": "issues-fixed"
     },
     "erdos-60": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T17:31:34Z",
-      "result": "clean"
+      "lastAudited": "2026-04-05T23:15:07Z",
+      "result": "issues-fixed"
     },
     "erdos-600": {
       "agentId": "auditor-cycle-20-batch",
@@ -6645,11 +6645,11 @@
       "result": "clean"
     },
     "erdos-628": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "sorry mismatch corrected in meta.json"
       ],
-      "lastAudited": "2026-04-03T09:06:15Z",
+      "lastAudited": "2026-04-05T23:11:31Z",
       "result": "issues-fixed"
     },
     "erdos-629": {
@@ -7873,10 +7873,10 @@
       "result": "issues-fixed"
     },
     "erdos-809": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-04-03T17:31:05Z",
-      "result": "clean"
+      "lastAudited": "2026-04-05T23:15:07Z",
+      "result": "issues-fixed"
     },
     "erdos-81": {
       "agentId": "auditor-cycle-20-batch",
@@ -9750,10 +9750,10 @@
       "result": "clean"
     },
     "hodge-conjecture": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-05T16:11:52Z",
-      "result": "clean"
+      "lastAudited": "2026-04-05T23:15:08Z",
+      "result": "issues-fixed"
     },
     "hurwitz-theorem": {
       "agentId": "auditor-cycle-20-batch",
@@ -10509,10 +10509,10 @@
       "result": "clean"
     },
     "schauder-fixed-point": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T16:58:00Z",
-      "result": "clean"
+      "lastAudited": "2026-04-05T23:15:07Z",
+      "result": "issues-fixed"
     },
     "schauder-fixed-point-oq-01": {
       "auditCount": 5,

--- a/src/data/proofs/descartes-rule-of-signs-oq-01/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01/meta.json
@@ -20,7 +20,7 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.roots_countP_pos_le_signVariations",

--- a/src/data/proofs/dirichlets-theorem-oq-03/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-03/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "axiomCount": 2,
     "lineCount": 139,
     "theoremCount": 8,
@@ -79,7 +79,7 @@
       }
     ],
     "path": "Proofs/DirichletsTheoremOQ03.lean",
-    "sorries": 2
+    "sorries": 3
   },
   "overview": {
     "historicalContext": "Dirichlet proved in 1837 that there are infinitely many primes p ≡ a (mod q) for any coprime pair (a, q). The *quantitative* question — how large is the *first* such prime p(a, q)? — was answered by Linnik in 1944: p(a, q) ≤ c · q^L for absolute constants c and L. This L is the 'Linnik constant'. The history of bounding L spans decades: Pan Cheng-tung (1957) gave L ≤ 10000, Elliott-Halberstam (1966) reduced it to L ≤ 40, then Jutila (L ≤ 20), Chen (L ≤ 13.5), Wang (L ≤ 8), Heath-Brown (L ≤ 5.5, 1992), and finally Xylouris (L ≤ 5, 2011). Under the Generalized Riemann Hypothesis, L ≤ 2 + ε for any ε > 0. The unconditional conjecture is L = 1 + ε, or equivalently, linnikConstant = 1.",

--- a/src/data/proofs/erdos-1006-oq-02/meta.json
+++ b/src/data/proofs/erdos-1006-oq-02/meta.json
@@ -20,7 +20,7 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "SimpleGraph.chromaticNumber",

--- a/src/data/proofs/erdos-1137/meta.json
+++ b/src/data/proofs/erdos-1137/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 1137,
     "erdosUrl": "https://erdosproblems.com/1137",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-1138-oq-03/meta.json
+++ b/src/data/proofs/erdos-1138-oq-03/meta.json
@@ -18,7 +18,7 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Nat.bertrand",

--- a/src/data/proofs/erdos-138/meta.json
+++ b/src/data/proofs/erdos-138/meta.json
@@ -37,7 +37,7 @@
       "Proof schema: main conjecture implies ExponentialDiverges"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 5,
     "erdosNumber": 138,
     "erdosUrl": "https://erdosproblems.com/138",
     "erdosProblemStatus": "open",
@@ -133,7 +133,7 @@
     "theoremCount": 3,
     "definitionCount": 8,
     "path": "Proofs/Stubs/Erdos138Problem.lean",
-    "sorries": 4
+    "sorries": 5
   },
   "references": [
     {

--- a/src/data/proofs/erdos-392/meta.json
+++ b/src/data/proofs/erdos-392/meta.json
@@ -17,7 +17,7 @@
       "number-theory"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "erdosNumber": 392,
     "erdosUrl": "https://erdosproblems.com/392",
     "erdosProblemStatus": "solved",
@@ -181,7 +181,7 @@
     "theoremCount": 3,
     "definitionCount": 1,
     "path": "Proofs/Stubs/Erdos392Problem.lean",
-    "sorries": 2
+    "sorries": 3
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-60/meta.json
+++ b/src/data/proofs/erdos-60/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 60,
     "erdosUrl": "https://erdosproblems.com/60",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-628/meta.json
+++ b/src/data/proofs/erdos-628/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 11,
+    "sorries": 12,
     "erdosNumber": 628,
     "erdosUrl": "https://erdosproblems.com/628",
     "erdosProblemStatus": "open",
@@ -217,6 +217,6 @@
     "theoremCount": 10,
     "definitionCount": 12,
     "path": "Proofs/Stubs/Erdos628Problem.lean",
-    "sorries": 11
+    "sorries": 12
   }
 }

--- a/src/data/proofs/erdos-809/meta.json
+++ b/src/data/proofs/erdos-809/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 809,
     "erdosUrl": "https://erdosproblems.com/809",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/hodge-conjecture/meta.json
+++ b/src/data/proofs/hodge-conjecture/meta.json
@@ -14,7 +14,7 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 49,
     "assumptions": "49 axiom declarations (down from 101) encoding Hodge structures, known cases (Lefschetz 1,1, abelian varieties, K3, top codimension), categorical operations, motives, p-adic Hodge theory, counterexamples (Atiyah-Hirzebruch, Voisin, Totaro), and related conjectures. 3 unused axioms removed (tateTwist, tateStructure, deligne_cycle_class). The Hodge Conjecture itself remains open. 0 sorries remain.",
     "mathlibDependencies": [],

--- a/src/data/proofs/schauder-fixed-point/meta.json
+++ b/src/data/proofs/schauder-fixed-point/meta.json
@@ -15,7 +15,7 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "ContractingWith.fixedPoint",


### PR DESCRIPTION
## Summary
- Corrected sorry counts in 13 gallery proof meta.json files found during audit sweep
- 4 undercounts: `erdos-628`, `erdos-392`, `erdos-138`, `dirichlets-theorem-oq-03` had same-line double sorry tokens missed by line-counting (`grep -c`)
- 9 overcounts: `schauder-fixed-point`, `amgm-inequality-oq-02`, `erdos-809`, `erdos-60`, `erdos-1138-oq-03`, `erdos-1137`, `erdos-1006-oq-02`, `descartes-rule-of-signs-oq-01`, `hodge-conjecture` had sorries resolved (by Aristotle/researchers) but `meta.sorries` not updated
- Audit tracker updated for all 13 proofs
- Gallery issue count: 12 → 0

## Test plan
- [ ] `pnpm build` passes
- [ ] `npx tsx scripts/auditor/find-targets.ts --stats` shows 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)