### PR TITLE
fix(meta): correct sorry counts in 13 gallery proofs after batch PR regressions

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -19,7 +19,7 @@
       "elementary-symmetric-polynomials"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Real.geom_mean_le_arith_mean_weighted",

--- a/src/data/proofs/descartes-rule-of-signs-oq-01/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01/meta.json
@@ -20,7 +20,7 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.roots_countP_pos_le_signVariations",

--- a/src/data/proofs/dirichlets-theorem-oq-03/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-03/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "axiomCount": 2,
     "lineCount": 139,
     "theoremCount": 8,
@@ -79,7 +79,7 @@
       }
     ],
     "path": "Proofs/DirichletsTheoremOQ03.lean",
-    "sorries": 2
+    "sorries": 3
   },
   "overview": {
     "historicalContext": "Dirichlet proved in 1837 that there are infinitely many primes p ≡ a (mod q) for any coprime pair (a, q). The *quantitative* question — how large is the *first* such prime p(a, q)? — was answered by Linnik in 1944: p(a, q) ≤ c · q^L for absolute constants c and L. This L is the 'Linnik constant'. The history of bounding L spans decades: Pan Cheng-tung (1957) gave L ≤ 10000, Elliott-Halberstam (1966) reduced it to L ≤ 40, then Jutila (L ≤ 20), Chen (L ≤ 13.5), Wang (L ≤ 8), Heath-Brown (L ≤ 5.5, 1992), and finally Xylouris (L ≤ 5, 2011). Under the Generalized Riemann Hypothesis, L ≤ 2 + ε for any ε > 0. The unconditional conjecture is L = 1 + ε, or equivalently, linnikConstant = 1.",

--- a/src/data/proofs/erdos-1006-oq-02/meta.json
+++ b/src/data/proofs/erdos-1006-oq-02/meta.json
@@ -20,7 +20,7 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "SimpleGraph.chromaticNumber",

--- a/src/data/proofs/erdos-1137/meta.json
+++ b/src/data/proofs/erdos-1137/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 1137,
     "erdosUrl": "https://erdosproblems.com/1137",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-1138-oq-03/meta.json
+++ b/src/data/proofs/erdos-1138-oq-03/meta.json
@@ -18,7 +18,7 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Nat.bertrand",

--- a/src/data/proofs/erdos-138/meta.json
+++ b/src/data/proofs/erdos-138/meta.json
@@ -37,7 +37,7 @@
       "Proof schema: main conjecture implies ExponentialDiverges"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 5,
     "erdosNumber": 138,
     "erdosUrl": "https://erdosproblems.com/138",
     "erdosProblemStatus": "open",
@@ -133,7 +133,7 @@
     "theoremCount": 3,
     "definitionCount": 8,
     "path": "Proofs/Stubs/Erdos138Problem.lean",
-    "sorries": 4
+    "sorries": 5
   },
   "references": [
     {

--- a/src/data/proofs/erdos-392/meta.json
+++ b/src/data/proofs/erdos-392/meta.json
@@ -17,7 +17,7 @@
       "number-theory"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "erdosNumber": 392,
     "erdosUrl": "https://erdosproblems.com/392",
     "erdosProblemStatus": "solved",
@@ -181,7 +181,7 @@
     "theoremCount": 3,
     "definitionCount": 1,
     "path": "Proofs/Stubs/Erdos392Problem.lean",
-    "sorries": 2
+    "sorries": 3
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-60/meta.json
+++ b/src/data/proofs/erdos-60/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 60,
     "erdosUrl": "https://erdosproblems.com/60",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/erdos-628/meta.json
+++ b/src/data/proofs/erdos-628/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 11,
+    "sorries": 12,
     "erdosNumber": 628,
     "erdosUrl": "https://erdosproblems.com/628",
     "erdosProblemStatus": "open",
@@ -217,6 +217,6 @@
     "theoremCount": 10,
     "definitionCount": 12,
     "path": "Proofs/Stubs/Erdos628Problem.lean",
-    "sorries": 11
+    "sorries": 12
   }
 }

--- a/src/data/proofs/erdos-809/meta.json
+++ b/src/data/proofs/erdos-809/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 809,
     "erdosUrl": "https://erdosproblems.com/809",
     "erdosProblemStatus": "open",

--- a/src/data/proofs/hodge-conjecture/meta.json
+++ b/src/data/proofs/hodge-conjecture/meta.json
@@ -14,7 +14,7 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 49,
     "assumptions": "49 axiom declarations (down from 101) encoding Hodge structures, known cases (Lefschetz 1,1, abelian varieties, K3, top codimension), categorical operations, motives, p-adic Hodge theory, counterexamples (Atiyah-Hirzebruch, Voisin, Totaro), and related conjectures. 3 unused axioms removed (tateTwist, tateStructure, deligne_cycle_class). The Hodge Conjecture itself remains open. 0 sorries remain.",
     "mathlibDependencies": [],

--- a/src/data/proofs/schauder-fixed-point/meta.json
+++ b/src/data/proofs/schauder-fixed-point/meta.json
@@ -15,7 +15,7 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "ContractingWith.fixedPoint",


### PR DESCRIPTION
## Fix

Correct sorry count regressions introduced by two recent batch PRs.

## Evidence

### PR #10065 regression (9 proofs): sorries set too high

Batch PR #10065 used line-based sorry counting that included comment mentions of "sorry". Result: 9 proofs with 0 actual sorries had meta.json sorries set to 1-3.

| Proof | Was | Set | Actual |
|-------|-----|-----|--------|
| amgm-inequality-oq-02 | 0 | 1 | 0 |
| descartes-rule-of-signs-oq-01 | 0 | 1 | 0 |
| erdos-1006-oq-02 | 0 | 1 | 0 |
| erdos-1137 | 0 | 1 | 0 |
| erdos-1138-oq-03 | 0 | 3 | 0 |
| erdos-60 | 0 | 1 | 0 |
| erdos-809 | 0 | 1 | 0 |
| hodge-conjecture | 0 | 1 | 0 |
| schauder-fixed-point | 0 | 2 | 0 |

### PR #10109 regression (4 proofs): sorries set too low

PR #10109 used per-line counting rather than per-token counting. Lines with two `sorry` tokens were undercounted by 1.

| Proof | Was | Set | Actual | Multi-sorry line |
|-------|-----|-----|--------|------------------|
| dirichlets-theorem-oq-03 | 3 | 2 | 3 | line 34: `⟨sorry, sorry⟩` |
| erdos-138 | 5 | 4 | 5 | line 46: two `by sorry` |
| erdos-392 | 3 | 2 | 3 | line 218: two `by sorry` |
| erdos-628 | 12 | 11 | 12 | line 209: two sorry'd type annotations |

All 13 fixes verified by comment-aware token counting (excludes `--` and `/- -/` comments).

---
Automated fix by lean-mechanic agent.