### PR TITLE
Fix line count for fourier-series-oq-02-incomplete-01

### DIFF
--- a/src/data/proofs/fourier-series-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-incomplete-01/meta.json
@@ -25,7 +25,7 @@
       "Finset"
     ],
     "namespace": "FourierDecayInfra",
-    "lineCount": 240,
+    "lineCount": 242,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 0,
@@ -78,7 +78,7 @@
       "Clear dependency graph: Lipschitz -> Holder bound -> main theorem"
     ],
     "axiomCount": 0,
-    "lineCount": 240,
+    "lineCount": 242,
     "assumptions": "5 sorry(s): fourier_lipschitz_bound, fourier_holder_bound, summable_norm_fourierCoeff_of_decay, holderWith_of_dist_bound, decay_implies_regularity'"
   },
   "overview": {


### PR DESCRIPTION
## Summary
- Corrected lineCount in fourier-series-oq-02-incomplete-01 meta.json: 240→242

## Test plan
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)