### PR TITLE
fix: remove True-stub theorems from 2 gallery proofs (batch 9)

### DIFF
--- a/proofs/Proofs/Erdos1155OQ01OQ06.lean
+++ b/proofs/Proofs/Erdos1155OQ01OQ06.lean
@@ -6,5 +6,5 @@ Placeholder file. Full formalization pending (see researcher PR #9455).
 
 import Mathlib
 
--- Placeholder theorem stub
-theorem erdos1155_oq01_oq06_placeholder : True := trivial
+/- erdos1155_oq01_oq06_placeholder: stub for Erdős Problem #1155 OQ-01-OQ-06
+   (terminal graph structure). Full formalization pending. -/

--- a/proofs/Proofs/Erdos625Problem.lean
+++ b/proofs/Proofs/Erdos625Problem.lean
@@ -209,15 +209,11 @@ theorem perfect_graph_chromatic (G : SimpleGraph V) (hPerf : True) :  -- Perfect
     chromaticNumber G = cliqueNumber G := by
   sorry
 
-/-- Cochromatic number of complete bipartite K_{n,n}. -/
-theorem cochromatic_complete_bipartite (n : ℕ) :
-    True := by  -- ζ(K_{n,n}) = 2
-  trivial
+/- cochromatic_complete_bipartite: ζ(K_{n,n}) = 2 for complete bipartite graphs;
+   requires cochromatic number definition relative to graph structure. -/
 
-/-- Cochromatic number of path P_n. -/
-theorem cochromatic_path (n : ℕ) :
-    True := by  -- ζ(P_n) = ⌈n/2⌉
-  trivial
+/- cochromatic_path: ζ(P_n) = ⌈n/2⌉ for path graphs;
+   requires cochromatic number definition relative to path structure. -/
 
 /- ## Part XI: Upper Bounds on Difference -/
 


### PR DESCRIPTION
## Fix

Remove 3 True-stub theorem declarations from 2 gallery proofs, converting them to descriptive block comments. True-stub theorems (`: True := trivial`) are misleading — they appear valid but prove nothing mathematical.

## Changes

### `proofs/Proofs/Erdos625Problem.lean`
- Removed `cochromatic_complete_bipartite : True` — stub for ζ(K_{n,n}) = 2
- Removed `cochromatic_path : True` — stub for ζ(P_n) = ⌈n/2⌉
- Replaced with `/-...-/` block comments preserving the mathematical content

### `proofs/Proofs/Erdos1155OQ01OQ06.lean`
- Removed `erdos1155_oq01_oq06_placeholder : True := trivial` — placeholder stub
- Replaced with `/-...-/` block comment noting full formalization is pending

## Evidence

**Before**: 3 `theorem ... : True := trivial` declarations in 2 files

**After**: Block comments preserving the mathematical context; no `sorry` counts change (these used `trivial`)

---
Automated fix by lean-mechanic agent.