### PR TITLE
Enrich: Fourier Decay Converse + Collatz Stopping Time

### DIFF
--- a/src/data/proofs/collatz-structured-oq-03/meta.json
+++ b/src/data/proofs/collatz-structured-oq-03/meta.json
@@ -101,13 +101,56 @@
     {
       "targetId": "collatz-structured",
       "relationship": "extends",
-      "description": "Parent proof establishes basic Collatz formalization; this OQ focuses on the asymptotic behavior of the average stopping time."
+      "description": "Parent proof establishes basic Collatz formalization (verification for structured values like powers of 2); this OQ focuses on the asymptotic behavior of the average stopping time."
+    },
+    {
+      "targetId": "collatz-cycles",
+      "relationship": "related",
+      "description": "Proves structural constraints on Collatz cycles (no fixed points, no 2-cycles, unique cycle through 1). The non-existence of small cycles is a prerequisite for the stopping time being well-defined for most inputs."
+    },
+    {
+      "targetId": "collatz-structured-oq-02",
+      "relationship": "related",
+      "description": "Proves non-existence of small cycles and derives algebraic bounds on cycle length. The halving constraint 2^M > 3^j connects to the log(4/3) constant appearing in the heuristic stopping time."
+    },
+    {
+      "targetId": "collatz-structured-oq-02-oq-01",
+      "relationship": "related",
+      "description": "Extends k-cycle exclusion via case analysis and axiomatizes the Eliahou (1993) bound (period > 17 billion). Complements this entry's density-based approach with algebraic cycle exclusion."
+    }
+  ],
+  "references": [
+    {
+      "text": "Terras, R. (1976). A stopping time problem on the positive integers. Acta Arithmetica, 30(3), 241-252.",
+      "url": "https://en.wikipedia.org/wiki/Collatz_conjecture#Stopping_time"
+    },
+    {
+      "text": "Lagarias, J. C. (1985). The 3x+1 problem and its generalizations. American Mathematical Monthly, 92(1), 3-23.",
+      "url": "https://en.wikipedia.org/wiki/Collatz_conjecture"
+    },
+    {
+      "text": "Krasikov, I. & Lagarias, J. C. (2003). Bounds for the 3x+1 problem using difference inequalities. Acta Arithmetica, 109(3), 237-258.",
+      "url": "https://en.wikipedia.org/wiki/Collatz_conjecture#Rigorous_results"
+    },
+    {
+      "text": "Tao, T. (2019). Almost all orbits of the Collatz map attain almost bounded values. arXiv:1909.03562.",
+      "url": "https://en.wikipedia.org/wiki/Collatz_conjecture#In_2019,_Terence_Tao"
     }
   ],
   "leanFile": {
-    "lineCount": 149,
     "path": "Proofs/CollatzStructuredOQ03.lean",
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Nat",
+      "Finset"
+    ],
+    "namespace": "CollatzStoppingTime",
+    "lineCount": 149,
     "axiomCount": 1,
+    "theoremCount": 2,
+    "definitionCount": 10,
     "sorries": 0
   }
 }


### PR DESCRIPTION
## Enrichment pass — 2 entries

### 1. fourier-series-oq-02-incomplete-01 (quality: 38 → enriched)
- Created `annotations.json` with 12 annotations covering all sections, each with `mathContext`, `significance`, `relatedConcepts`, and `prerequisites`
- Expanded `historicalContext` with Bernstein (1914), Zygmund (1935), Sobolev (1938), Nikol'skii (1951), Katznelson (1968)
- Expanded `keyInsights` from 3 to 5
- Added 4 new cross-references
- Enriched all 7 sections with detailed summaries and LaTeX `mathContext`
- Deepened conclusion with bidirectional characterization implications

### 2. collatz-structured-oq-03 (quality: 0 → enriched)
- Added 4 references: Terras (1976), Lagarias (1985), Krasikov-Lagarias (2003), Tao (2019)
- Added 3 new cross-references to collatz-cycles, collatz-structured-oq-02, collatz-structured-oq-02-oq-01
- Completed `leanFile` section with imports, opens, namespace, theoremCount, definitionCount