### PR TITLE
fix(meta): correct lineCount and theoremCount in 6 gallery proofs

### DIFF
--- a/src/data/proofs/borsuk-ulam/meta.json
+++ b/src/data/proofs/borsuk-ulam/meta.json
@@ -269,7 +269,7 @@
       "Metric"
     ],
     "namespace": "BorsukUlam",
-    "lineCount": 264,
+    "lineCount": 267,
     "axiomCount": 1,
     "theoremCount": 9,
     "definitionCount": 6,

--- a/src/data/proofs/derangements-oq-02-oq-02/meta.json
+++ b/src/data/proofs/derangements-oq-02-oq-02/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
-    "lineCount": 250,
+    "lineCount": 249,
     "theoremCount": 13,
     "definitionCount": 0,
     "assumptions": "None.",
@@ -119,7 +119,7 @@
   ],
   "leanFile": {
     "namespace": "DerangementsOQ02OQ02",
-    "lineCount": 250,
+    "lineCount": 249,
     "axiomCount": 0,
     "theoremCount": 13,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -15,7 +15,7 @@
     "badge": "wip",
     "sorries": 2,
     "axiomCount": 0,
-    "lineCount": 1283,
+    "lineCount": 1285,
     "assumptions": "0 axioms. 2 sorries in Ghouila-Houri helper lemmas: sc_degree_has_cycle (SC + high degree → initial directed cycle) and ghouila_houri_cycle_extendable (cycle of length k < n → longer cycle). The main ghouila_houri theorem is proved by delegating to these helpers. directed_hamiltonian_threshold is fully proved (0 sorries). Moon-Moser theorem and Rédei are also fully proved.",
     "dateAdded": "2026-03-30",
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
@@ -123,11 +123,11 @@
       "Finset"
     ],
     "namespace": "Erdos1012OQ03",
-    "lineCount": 1283,
+    "lineCount": 1285,
     "axiomCount": 0,
     "sorries": 2,
     "path": "Proofs/Erdos1012OQ03.lean",
-    "theoremCount": 20,
+    "theoremCount": 22,
     "definitionCount": 10
   }
 }

--- a/src/data/proofs/erdos-1171/meta.json
+++ b/src/data/proofs/erdos-1171/meta.json
@@ -214,7 +214,7 @@
       "Ordinal"
     ],
     "namespace": "Erdos1171",
-    "lineCount": 433,
+    "lineCount": 445,
     "axiomCount": 2,
     "theoremCount": 22,
     "definitionCount": 8,

--- a/src/data/proofs/erdos-414/meta.json
+++ b/src/data/proofs/erdos-414/meta.json
@@ -51,7 +51,7 @@
     "assumptions": [
       "erdos_414_conjecture: ∀ m, n ≥ 1, ∃ i, j: h^i(m) = h^j(n) — all orbits eventually merge (main open question)"
     ],
-    "lineCount": 302
+    "lineCount": 301
   },
   "sections": [
     {
@@ -186,7 +186,7 @@
     ]
   },
   "leanFile": {
-    "lineCount": 302,
+    "lineCount": 301,
     "structureCount": 0,
     "axiomCount": 1,
     "theoremCount": 34,

--- a/src/data/proofs/erdos-625/meta.json
+++ b/src/data/proofs/erdos-625/meta.json
@@ -64,7 +64,7 @@
       "PrizeValue: $1000 (false) / $100 (true)"
     ],
     "axiomCount": 2,
-    "lineCount": 272,
+    "lineCount": 268,
     "assumptions": "2 axiom(s) and 20 sorry(s). See the Lean source for details."
   },
   "overview": {
@@ -144,9 +144,9 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 272,
+    "lineCount": 268,
     "axiomCount": 2,
-    "theoremCount": 22,
+    "theoremCount": 20,
     "definitionCount": 0,
     "sorries": 20,
     "path": "Proofs/Erdos625Problem.lean"


### PR DESCRIPTION
## Fix

Corrects stale `lineCount` and `theoremCount` values in 6 gallery `meta.json` files where the Lean source diverged from recorded metadata.

## Evidence

| Proof | Field | Before | After |
|-------|-------|--------|-------|
| erdos-1171 | lineCount | 433 | 445 |
| erdos-625 | lineCount | 272 | 268 |
| erdos-625 | theoremCount | 22 | 20 |
| borsuk-ulam | leanFile.lineCount | 264 | 267 |
| erdos-1012-oq-03 | lineCount | 1283 | 1285 |
| erdos-1012-oq-03 | theoremCount | 20 | 22 |
| erdos-414 | lineCount | 302 | 301 |
| derangements-oq-02-oq-02 | lineCount | 250 | 249 |

**Verification**: All counts confirmed by direct line counting (`wc -l`) and theorem/lemma declaration counting (including `private` declarations) on the current Lean source files.

---
Automated fix by lean-mechanic agent.