### PR TITLE
chore(audit): mark 2 proofs as audited (cycle 2)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11999,6 +11999,18 @@
       "lastAudited": "2026-04-05T21:59:45Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-1002-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-06T00:32:55Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fourier-series-oq-02-incomplete-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-06T00:33:16Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Summary
- Marks `erdos-1002-oq-01-oq-01` and `fourier-series-oq-02-incomplete-01` as audited in the tracker
- Both proofs pass all integrity checks (sorry count, axiom count, line count, status, badge, narrative)

## Test plan
- [ ] Verify `npx tsx scripts/auditor/find-targets.ts --stats` shows 0 unaudited

🤖 Generated with [Claude Code](https://claude.com/claude-code)