### PR TITLE
Enrich: 7 proofs — fix inaccuracies, standardize cross-refs

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01/annotations.json
@@ -27,7 +27,7 @@
     "id": "ann-bido-irred-iff-prime",
     "proofId": "bezout-identity-oq-02-oq-01-oq-01-oq-01",
     "range": { "startLine": 82, "endLine": 95 },
-    "type": "theorem",
+    "type": "concept",
     "title": "Irreducible ↔ Prime in ℤ[X,Y]: UFD Characterization",
     "content": "In any UFD, irreducible and prime are equivalent: p is irreducible (not a unit, and p = ab implies a or b is a unit) iff p is prime (p | ab implies p | a or p | b). This is proved via UniqueFactorizationMonoid.irreducible_iff_prime in Mathlib. The equivalence fails in general integral domains: in ℤ[√−5], the element 2 is irreducible but not prime (2 | (1+√−5)(1−√−5) = 6 but 2 ∤ 1±√−5). The UFD property is precisely the condition that makes irreducible = prime, enabling Euclid's lemma.",
     "mathContext": "In a UFD $R$: $p$ irreducible $\\Leftrightarrow$ $p$ prime. Non-UFD failure: in $\\mathbb{Z}[\\sqrt{-5}]$, $2$ is irreducible but $2 \\mid 6 = (1+\\sqrt{-5})(1-\\sqrt{-5})$ while $2 \\nmid (1\\pm\\sqrt{-5})$. In $\\mathbb{Z}[X,Y]$: Euclid's lemma holds by \\texttt{zxy\\_euclid\\_lemma}.",

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -59,8 +59,7 @@
       "Gauss's lemma for polynomial rings",
       "MvPolynomial (multivariate polynomial rings)",
       "Euler's prime/irreducible distinction"
-    ],
-    "mathlib_version": "4.26.0"
+    ]
   },
   "overview": {
     "historicalContext": "Gauss proved in Disquisitiones Arithmeticae (1801) that the product of two primitive polynomials over ℤ is primitive, which implies ℤ[X] is a UFD. The generalization to 'R UFD implies R[X] UFD' was made explicit by Kronecker (1882) and became standard in the work of Emmy Noether and Krull in the 1920s-30s, as they axiomatized ring theory. The inductive extension to multivariate rings ℤ[X₁,...,Xₙ] is immediate but foundational: these are the coordinate rings of affine n-space in algebraic geometry, and their UFD property underlies the geometric notion that hypersurfaces factor into irreducible components. Dedekind's recognition that ℤ[√−5] fails to be a UFD (with 6 = 2·3 = (1+√−5)(1−√−5)) motivated the development of ideal theory as a substitute for unique factorization — making the UFD property of polynomial rings a meaningful structural theorem rather than a vacuous definition. The Lean 4 formalization leverages Mathlib's typeclass system: the single instance Polynomial.uniqueFactorizationMonoid composes automatically to handle any finite iteration.",
@@ -125,24 +124,24 @@
   ],
   "crossReferences": [
     {
-      "id": "bezout-identity-oq-02-oq-01-oq-01",
-      "title": "R[X] is a UFD when R is a UFD (Gauss's Lemma)",
-      "relationship": "parent"
+      "targetId": "bezout-identity-oq-02-oq-01-oq-01",
+      "relationship": "parent",
+      "description": "R[X] is a UFD when R is a UFD (Gauss's Lemma) — the single-variable case that this file iterates"
     },
     {
-      "id": "bezout-identity-oq-02-oq-01",
-      "title": "Fundamental Theorem of Algebra: Euclid's Lemma for Polynomials",
-      "relationship": "foundational"
+      "targetId": "bezout-identity-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Euclid's Lemma for Polynomials — the prime divisibility property extended here to multivariate rings"
     },
     {
-      "id": "bezout-identity",
-      "title": "Bézout's Identity",
-      "relationship": "foundational"
+      "targetId": "bezout-identity",
+      "relationship": "ancestor",
+      "description": "Bézout's Identity — the root of this open question chain"
     },
     {
-      "id": "bezout-identity-oq-02",
-      "title": "Euclid's Lemma and Primality",
-      "relationship": "foundational"
+      "targetId": "bezout-identity-oq-02",
+      "relationship": "extends",
+      "description": "Euclid's Lemma and Primality — foundational prime/irreducible theory used in the UFD characterization"
     }
   ],
   "conclusion": {
@@ -191,6 +190,7 @@
     "namespace": "BezoutIdentityMultivarPoly",
     "lineCount": 127,
     "axiomCount": 0,
+    "sorries": 0,
     "theoremCount": 14,
     "definitionCount": 0
   }


### PR DESCRIPTION
## Summary

Accuracy-focused enrichment pass across 7 gallery entries. Primary themes: **correcting annotations that falsely claim sorries or fabricated imports**, standardizing cross-reference format, and metadata completeness.

### Fixed false sorry/import claims (3 entries)
- **Cauchy-Schwarz OQ-02**: Fixed ann-01 listing fabricated imports (MeanInequalitiesPow, etc.)
- **Power Mean Extreme Cases**: Fixed annotations falsely claiming sorries — both theorems fully proved
- **q-Vandermonde**: Fixed annotation falsely claiming "2 sorries" — proof fully verified

### Standardized cross-reference format (2 entries)
- **q-Vandermonde**: `{id, title}` → `{targetId, relationship, description}`
- **ℤ[X,Y] UFD**: Same format standardization

### Mathematical accuracy fixes
- **Vandermonde Falling Factorial**: Fixed 3 incorrect EGF references (`e^{nx}` → `(1+x)^n`)
- **Vandermonde via Binomial Theorem**: Added missing `implications` field, expanded cross-refs 2→7

### Metadata completeness (all entries)
- Added missing `leanFile` fields (imports, opens, namespace, sorries)
- Added missing sections, dateAdded, theoremCount/definitionCount
- Fixed section endLines and annotation ranges
- Deepened section summaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)