### PR TITLE
Enrich Vandermonde Identity (falling factorial form)

### DIFF
--- a/research/problems/feuerbachs-theorem-defs-oq-02/knowledge.md
+++ b/research/problems/feuerbachs-theorem-defs-oq-02/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: feuerbachs-theorem-defs-oq-02
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/feuerbachs-theorem-defs-oq-02/literature/README.md
+++ b/research/problems/feuerbachs-theorem-defs-oq-02/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for feuerbachs-theorem-defs-oq-02
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/feuerbachs-theorem-defs-oq-02/problem.md
+++ b/research/problems/feuerbachs-theorem-defs-oq-02/problem.md
@@ -1,0 +1,131 @@
+# Problem: Nine-Point Circle Uniqueness
+
+**Slug**: feuerbachs-theorem-defs-oq-02
+**Created**: 2026-04-05T17:45:36-07:00
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+For any non-degenerate triangle ABC, the nine-point circle is the unique circle
+passing through the 9 special points: 3 side midpoints, 3 altitude feet, 3 Euler
+midpoints (vertex-to-orthocenter midpoints).
+
+More precisely: if a circle Γ passes through the midpoints of the three sides of
+triangle ABC, then Γ is the nine-point circle (center = midpoint(O, H), radius = R/2),
+because three non-collinear points uniquely determine a circle.
+
+### Plain Language
+
+The gallery proof (`feuerbachs-theorem-defs`) already establishes that all 9 special
+points lie on the nine-point circle. OQ-02 asks: prove the nine-point circle is the
+*only* circle with this property. This reduces to showing that at least 3 of the 9
+points are non-collinear, then applying the uniqueness theorem for circles through 3
+non-collinear points.
+
+### Why This Matters
+
+Uniqueness makes the nine-point circle a canonical geometric object rather than just
+a convenient one. Without uniqueness, "the nine-point circle" is just "a circle
+through these points." The uniqueness proof completes the definitional picture for
+Wiedijk #29 in the gallery.
+
+## Known Results
+
+### What's Already Proven
+
+- `feuerbachs-theorem-defs`: All 9 special points lie on the nine-point circle
+  (VERIFIED, 0 sorries)
+- `feuerbachs-theorem-oq-01`: Complete distance relations (VERIFIED)
+- Mathlib: Circumsphere/circumcenter uniqueness infrastructure exists
+
+### What's Still Open
+
+- That at least 3 of the 9 special points are non-collinear in a non-degenerate triangle
+- Formal statement of uniqueness in the coordinate framework used in FeuerbachsTheoremDefs
+
+### Our Goal
+
+Prove: for a non-degenerate triangle, the three side midpoints are non-collinear, so
+any circle through all 9 special points must be the nine-point circle.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| feuerbachs-theorem-defs | Infrastructure: 9 membership proofs, coordinate framework | Coordinate geometry, R^2 arithmetic |
+| feuerbachs-theorem | Main tangency theorem | Circle tangency in coordinates |
+| feuerbachs-theorem-oq-05 | Inversive geometry proof | Alternative proof framework |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Non-collinearity of midpoints**: The midpoints of the three sides of a
+   non-degenerate triangle are non-collinear. Prove this in coordinates (det ≠ 0
+   via the triangle area formula). Then invoke a Mathlib lemma that 3 non-collinear
+   points determine a unique sphere/circle.
+   - Why it might work: Direct coordinate computation.
+   - Risk: May need to find the right Mathlib API for circle uniqueness in the plane.
+
+2. **Equidistance system uniqueness**: Show that the system of equations (center
+   equidistant from 3 non-collinear points) has a unique solution. Since
+   FeuerbachsTheoremDefs already computes the nine-point center N = midpoint(O, H)
+   and radius R/2, this is a verification that the system has exactly one solution.
+   - Why it might work: Linear algebra — the perpendicular bisectors of 3 sides of
+     a non-degenerate triangle meet in exactly one point.
+   - Risk: May require extra linear algebra lemmas.
+
+### Key Difficulties
+
+- Finding the correct Mathlib API for "3 non-collinear points → unique circle"
+- The existing code uses coordinate geometry (not Mathlib's abstract EuclideanGeometry),
+  so abstract sphere uniqueness lemmas may need adaptation
+
+### What Would a Proof Need?
+
+- Key lemma: The three side midpoints of a non-degenerate triangle are non-collinear
+- Key theorem: Three non-collinear points lie on exactly one circle
+- Technical: Connecting FeuerbachsTheoremDefs' coordinate framework to Mathlib's API
+
+## Tractability Assessment
+
+**Difficulty**: Low-Medium
+
+**Justification**:
+- Mathematical content is straightforward (non-collinearity + circle uniqueness)
+- The existing coordinate infrastructure in FeuerbachsTheoremDefs is comprehensive
+- Main challenge is Mathlib API discovery
+- Should be achievable without sorries
+
+**Estimated Effort**:
+- Exploration: 1-2 hours (API search + non-collinearity proof sketch)
+- If tractable: 1-2 days
+
+## References
+
+### Mathlib
+- `Mathlib.Geometry.Euclidean.Sphere.Basic` — Sphere definitions
+- `Mathlib.Geometry.Euclidean.Circumcenter` — Circumcenter uniqueness
+- `EuclideanGeometry.circumsphere` — Abstract circumsphere
+
+## Metadata
+
+```yaml
+tags:
+  - geometry
+  - euclidean-geometry
+  - nine-point-circle
+  - feuerbach
+  - uniqueness
+  - triangle
+related_proofs:
+  - feuerbachs-theorem-defs
+  - feuerbachs-theorem
+  - feuerbachs-theorem-oq-01
+difficulty: low-medium
+source: gallery-gap
+created: 2026-04-05T17:45:36-07:00
+```

--- a/research/problems/feuerbachs-theorem-defs-oq-02/state.md
+++ b/research/problems/feuerbachs-theorem-defs-oq-02/state.md
@@ -1,0 +1,25 @@
+# Research State: feuerbachs-theorem-defs-oq-02
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-05T17:45:36-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/problems/mean-value-theorem-oq-04/selection-report.md
+++ b/research/problems/mean-value-theorem-oq-04/selection-report.md
@@ -1,0 +1,68 @@
+# Problem Selection Report
+
+**Date**: 2026-04-05
+**Mode**: SELECT
+**Pool Status**: 18 available, 512 in-progress, 1233 completed
+
+## Selected Problem
+
+- **ID**: mean-value-theorem-oq-04
+- **Name**: Cleanest formalization of FTC using mean value theorem structure
+- **Tier**: B
+- **Significance**: 7/10
+- **Tractability**: 7/10
+- **Knowledge Score**: 0 (EMPTY)
+- **Status**: available
+
+## Selection Rationale
+
+1. **Top composite score among quality-passing candidates**: Composite = 77 (EMPTY tier: 0 penalty + tractability×10=70 + significance=7). Equal with cube-root-2-irrational-oq-03 at 77, preferred due to domain diversity.
+2. **EMPTY knowledge tier**: No prior research on this problem — exploring it immediately is highest priority per the ranking algorithm.
+3. **Domain diversity**: Last 3 selections (mathematical-induction-oq-03, prime-gap-bounds-oq-03, euler-totient-oq-01-oq-02) were all number theory. This problem is real analysis — applying diversity penalty to number-theory candidates makes this the top pick.
+4. **Tractability 7**: The MVT→FTC connection is well-understood mathematically; the challenge is finding the cleanest Lean formalization path using Mathlib's existing analysis infrastructure.
+
+## Rejection Summary
+
+- **Candidates considered**: 18 available
+- **Candidates rejected**: 17
+  - `isosceles-triangle-oq-03` (score 85): Rejected — routine area formula derivation, one-off calculation with no theory-level implications.
+  - `cube-root-2-irrational-oq-03` (score 77): Rejected — algebraic number theory, same domain as recent selections (diversity penalty).
+  - `euler-identity-oq-01-oq-04` (score 76): Rejected — algebra/complex analysis, borderline diversity concern; dominated by mean-value-theorem-oq-04.
+  - `divisibility-rules-oq-03` (score 76): Rejected — number theory, diversity penalty.
+  - All other EMPTY candidates: Lower composite scores (66–68).
+  - `mathematical-induction-oq-03`, `feuerbachs-theorem-defs-oq-02` (WEAK tier): Penalized by knowledge tier (-1000).
+  - `prime-gap-bounds-oq-03` (RICH tier, 21 items): Penalized by knowledge tier (-3000).
+- **Confidence**: high (clear gap between top candidates; diversity constraint is decisive)
+
+## Related Gallery Proofs
+
+- `mean-value-theorem`: Base MVT formalization — the foundation this problem builds on
+- `fundamental-theorem-calculus`: Target theorem to be derived via MVT structure
+- `mean-value-theorem-oq-02`: Taylor's Theorem with Lagrange Remainder — sibling OQ using MVT
+- `mean-value-theorem-oq-03`: Vector-Valued Mean Value Inequality — related generalization
+- `fundamental-theorem-calculus-oq-01`: Lebesgue generalization of FTC — context for scope
+
+## Suggested First Steps
+
+1. **OBSERVE**: Survey Mathlib's `MeasureTheory.Integral.FundThmCalculus` and `Analysis.Calculus.MeanValue` — identify what already exists and what gap this problem fills.
+2. **ORIENT**: Determine which MVT variant (Lagrange, Cauchy, integral) provides the cleanest path to FTC Part 1 (antiderivative → integral) and Part 2 (integral → antiderivative).
+3. **DECIDE**: Select the approach — likely `intervalIntegral.integral_eq_sub_of_hasDerivAt` combined with MVT to give the cleanest structural proof.
+
+## Pool Summary After Selection
+
+| Status | Count |
+|--------|-------|
+| Available | 18 |
+| In Progress | 512 |
+| Completed | 1233 |
+| Surveyed | 0 |
+| Skipped | 0 |
+| Blocked | 1 |
+
+## Candidate Pool Health
+
+Pool has 18 available problems — above the replenishment threshold of 5. Pool depth is adequate.
+
+- Pool depth: **adequate**
+- Recommendation: Pool healthy; no immediate refresh needed
+- Next refresh recommended: When available count drops below 5

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03/annotations.json
@@ -2,14 +2,26 @@
   {
     "id": "ann-vandermonde-header",
     "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03",
-    "range": { "startLine": 1, "endLine": 31 },
+    "range": { "startLine": 1, "endLine": 25 },
     "type": "context",
     "title": "The Falling Factorial Vandermonde Identity",
-    "content": "The falling factorial (descending factorial) $n^{\\underline{r}} = n(n-1)\\cdots(n-r+1)$ counts ordered $r$-selections from $n$ items. The standard Vandermonde convolution $\\binom{m+n}{r} = \\sum_j \\binom{m}{j}\\binom{n}{r-j}$ lifts to the falling factorial form by multiplying by $r!$: each term $r! \\cdot \\binom{m}{j}\\binom{n}{r-j}$ becomes $\\binom{r}{j} \\cdot (m)^{\\underline{j}} \\cdot (n)^{\\underline{r-j}}$, the number of ordered $r$-tuples from $m+n$ items choosing $j$ from the first $m$ with $\\binom{r}{j}$ ways to place those positions. The proof imports `BinomialTheoremOQ03` for the standard Vandermonde and avoids broken parent files.",
+    "content": "The falling factorial (descending factorial) $n^{\\underline{r}} = n(n-1)\\cdots(n-r+1)$ counts ordered $r$-selections from $n$ items. The standard Vandermonde convolution $\\binom{m+n}{r} = \\sum_j \\binom{m}{j}\\binom{n}{r-j}$ lifts to the falling factorial form by multiplying by $r!$: each term $r! \\cdot \\binom{m}{j}\\binom{n}{r-j}$ becomes $\\binom{r}{j} \\cdot (m)^{\\underline{j}} \\cdot (n)^{\\underline{r-j}}$, the number of ordered $r$-tuples from $m+n$ items choosing $j$ from the first $m$ with $\\binom{r}{j}$ ways to place those positions. The docstring documents both the identity and the three-step proof strategy used in this file.",
     "mathContext": "$(m+n)^{\\underline{r}} = \\sum_{j=0}^{r} \\binom{r}{j} \\cdot m^{\\underline{j}} \\cdot n^{\\underline{r-j}}$, where $n^{\\underline{k}} = n(n-1)\\cdots(n-k+1) = k! \\binom{n}{k}$",
     "significance": "key",
     "relatedConcepts": ["falling factorial", "Vandermonde convolution", "ordered selections", "binomial coefficients"],
     "prerequisites": ["combinatorics", "binomial coefficients", "factorial notation"]
+  },
+  {
+    "id": "ann-imports-namespace",
+    "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03",
+    "range": { "startLine": 26, "endLine": 31 },
+    "type": "context",
+    "title": "Imports and Namespace Setup",
+    "content": "Imports Mathlib for core factorial and binomial coefficient lemmas (`Nat.descFactorial_eq_factorial_mul_choose`, `Nat.choose_mul_factorial_mul_factorial`), and `Proofs.BinomialTheoremOQ03` for the standard Vandermonde convolution `vandermonde_range`. Opens `Finset` for `range`, `sum_congr`, `mul_sum` and `BigOperators` for the `∑` notation. The `VandermondeDescFactorial` namespace scopes both lemmas to avoid name collisions. Notably, the proof avoids importing the broken parent files `ArithmeticSeriesOQ02OQ04.lean` and `ArithmeticSeriesOQ02OQ04OQ01.lean`, instead working directly with Mathlib's `Nat.descFactorial` API.",
+    "mathContext": "Provides access to $n^{\\underline{k}} = k! \\binom{n}{k}$ and $\\binom{m+n}{r} = \\sum_j \\binom{m}{j}\\binom{n}{r-j}$ as the two building blocks",
+    "significance": "context",
+    "relatedConcepts": ["Lean 4 imports", "namespace management", "BigOperators notation", "Mathlib API"],
+    "prerequisites": ["Lean 4 module system", "Mathlib organization"]
   },
   {
     "id": "ann-desc-factorial-conversion",

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03/meta.json
@@ -56,7 +56,7 @@
     "historicalContext": "Alexandre-Théophile Vandermonde presented his convolution identity $\\binom{m+n}{r} = \\sum_j \\binom{m}{j}\\binom{n}{r-j}$ in his 1772 paper 'Mémoire sur des irrationnelles de différents ordres avec une application au cercle' — though the result was anticipated by Chu Shih-Chieh in 1303 (the Chu-Vandermonde identity). Vandermonde's work focused on combinatorial manipulation of determinants, and his identity can be seen as a coefficient extraction from the identity $(1+x)^m(1+x)^n = (1+x)^{m+n}$ — matching coefficients of $x^r$ gives the convolution.\n\nThe falling factorial form $n^{\\underline{r}} = \\sum_j \\binom{r}{j} m^{\\underline{j}} n^{\\underline{r-j}}$ is natural in the umbral calculus and in the theory of finite differences, where falling factorials play the role that monomials play in ordinary calculus — they are the 'eigenfunctions' of the forward difference operator $\\Delta$. This form also connects to the formula for iterated differentiation: $(d/dx)^r x^n = n^{\\underline{r}} x^{n-r}$, showing how falling factorials encode derivative counts.\n\nIn computer science, this identity appears in the analysis of random binary search trees and in the computation of moments of hypergeometric distributions. Graham, Knuth, and Patashnik's *Concrete Mathematics* (1994) features the falling factorial Vandermonde as Table 174 and emphasizes its role as the 'natural' form of the identity. The Lean 4 formalization takes the algebraic route: derive the falling factorial form from the standard binomial form by the conversion $n^{\\underline{k}} = k! \\binom{n}{k}$.",
     "problemStatement": "Prove Vandermonde's identity in falling factorial form: $(m+n)^{\\underline{r}} = \\sum_{j=0}^{r} \\binom{r}{j} \\cdot m^{\\underline{j}} \\cdot n^{\\underline{r-j}}$, where $n^{\\underline{k}} = n(n-1)\\cdots(n-k+1)$ is the falling factorial. This generalizes the standard Vandermonde convolution $\\binom{m+n}{r} = \\sum_j \\binom{m}{j}\\binom{n}{r-j}$ by multiplying both sides by $r!$.",
     "text": "The falling (descending) factorial is descFactorial(n,k) = n*(n-1)*...*(n-k+1). It satisfies descFactorial(n,k) = k! * C(n,k) (Mathlib: Nat.descFactorial_eq_factorial_mul_choose). The proof converts the identity to the standard binomial form by substituting descFactorial = k!*C(n,k), applies vandermonde_range from BinomialTheoremOQ03, then verifies term equality using C(r,j)*j!*(r-j)! = r! from Nat.choose_mul_factorial_mul_factorial.",
-    "proofStrategy": "Convert descFactorials via simp_rw [Nat.descFactorial_eq_factorial_mul_choose], apply BinomialTheoremOQ03.vandermonde_range to rewrite C(m+n,r) as a sum, use Finset.mul_sum to distribute r!, then verify each term by ring + Nat.choose_mul_factorial_mul_factorial.",
+    "proofStrategy": "The proof proceeds in four clean steps. First, `simp_rw [Nat.descFactorial_eq_factorial_mul_choose]` converts every falling factorial $n^{\\underline{k}}$ to $k! \\cdot \\binom{n}{k}$, reducing the identity to a statement purely about binomial coefficients and factorials. Second, `vandermonde_range` from BinomialTheoremOQ03 rewrites $\\binom{m+n}{r}$ as $\\sum_j \\binom{m}{j}\\binom{n}{r-j}$, the standard Vandermonde convolution. Third, `Finset.mul_sum` distributes $r!$ into each summand. Finally, `Finset.sum_congr rfl` reduces the sum equality to the pointwise lemma `term_eq`, which proves $\\binom{r}{j} \\cdot j! \\cdot (r-j)! = r!$ via `ring` followed by `Nat.choose_mul_factorial_mul_factorial`. The factoring of the algebraic core into a separate `term_eq` lemma exemplifies the standard Lean 4 pattern for proving sum identities: reduce to term-level, then close by congruence.",
     "keyInsights": [
       "The identity descFactorial(n,k) = k! * C(n,k) (Nat.descFactorial_eq_factorial_mul_choose) converts between the two forms cleanly, enabling direct derivation from the standard Vandermonde.",
       "The key algebraic identity C(r,j)*j!*(r-j)! = r! (Nat.choose_mul_factorial_mul_factorial) makes each term comparison a single rewrite followed by ring, avoiding any case analysis.",
@@ -72,7 +72,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Vandermonde identity in falling factorial form proved cleanly from standard Vandermonde + descFactorial-choose conversion. 2 theorems, 0 sorries, 0 axioms, 78 lines.",
+    "summary": "A clean, self-contained formalization of the falling factorial Vandermonde identity $(m+n)^{\\underline{r}} = \\sum_j \\binom{r}{j} m^{\\underline{j}} n^{\\underline{r-j}}$, derived from the standard Vandermonde convolution via the conversion $n^{\\underline{k}} = k! \\binom{n}{k}$. The proof factors the algebraic core into a separate `term_eq` lemma, reducing the sum equality to pointwise term matching — a reusable pattern for Lean 4 sum identities. 2 theorems, 0 sorries, 0 axioms, 78 lines.",
     "implications": "**Generating Functions**: The falling factorial Vandermonde is the coefficient of $x^r/r!$ in the exponential generating function (EGF) product $(e^x)^m (e^x)^n = e^{(m+n)x}$. More precisely, the EGF of $n^{\\underline{r}}$ in $r$ is $(1+x)^n$ (using the EGF convention $\\sum_r n^{\\underline{r}} x^r/r! = e^{nx}$). The identity then says: [coefficient of $x^r/r!$] in $e^{mx} \\cdot e^{nx} = e^{(m+n)x}$ is $\\sum_j \\binom{r}{j} m^{\\underline{j}} n^{\\underline{r-j}}$, matching the LHS $(m+n)^{\\underline{r}}$. This is the generating function proof, complementing the algebraic proof here.\n\n**Umbral Calculus and Finite Differences**: In the umbral calculus (Rota-Roman school, 1970s), falling factorials $x^{\\underline{n}} = x(x-1)\\cdots(x-n+1)$ are the basic polynomial sequences associated with the forward difference operator $\\Delta f(x) = f(x+1) - f(x)$. The Vandermonde identity in falling factorial form is the binomial theorem for the shift operator: $(E^m E^n)^r = E^{(m+n)r}$ where $E$ is the shift. Every polynomial can be expanded in the falling factorial basis $\\{x^{\\underline{0}}, x^{\\underline{1}}, \\ldots\\}$ (analogous to the Taylor basis), and the falling factorial Vandermonde is exactly the product rule for this expansion.\n\n**Hypergeometric Distributions**: The identity underlies the hypergeometric distribution $P(X=k) = \\binom{m}{k}\\binom{n}{r-k}/\\binom{m+n}{r}$ (sampling without replacement from $m$ defective and $n$ good items). The Vandermonde identity in either form gives $\\sum_k P(X=k) = 1$ (the probabilities sum to 1). The falling factorial form converts this to a moment identity: $\\mathbb{E}[X^{\\underline{j}}] = m^{\\underline{j}} r^{\\underline{j}} / (m+n)^{\\underline{j}}$ (factorial moments of the hypergeometric distribution).\n\n**Analysis of Algorithms**: In the analysis of random binary search trees and randomized algorithms, the identity controls the count of distinct orderings of keys. In particular, descFactorial(n,r)/n! = (number of ways to choose r items with ordering from n) / (total orderings) = $\\binom{n}{r}$ gives the correct probability weight.",
     "openQuestions": [
       "Generalize to the polynomial identity (x+y)^{(r)} = ∑_j C(r,j)*x^{(j)}*y^{(r-j)} over any commutative ring",
@@ -131,6 +131,11 @@
       "targetId": "arithmetic-series-oq-02-oq-02",
       "relationship": "related",
       "description": "2D hockey stick via Vandermonde convolution — applies the same Vandermonde summation to simplicial number products"
+    },
+    {
+      "targetId": "binomial-theorem",
+      "relationship": "related",
+      "description": "The Binomial Theorem — foundational result whose coefficient matching $(1+x)^m(1+x)^n = (1+x)^{m+n}$ gives the Vandermonde convolution"
     }
   ],
   "references": [
@@ -153,12 +158,20 @@
   ],
   "sections": [
     {
-      "id": "sec-header",
-      "title": "Module Header and Imports",
+      "id": "sec-docstring",
+      "title": "Module Documentation",
       "startLine": 1,
-      "endLine": 31,
-      "summary": "Documents the falling factorial Vandermonde identity and proof strategy. Imports BinomialTheoremOQ03 for vandermonde_range and opens Finset and BigOperators for sum notation.",
+      "endLine": 25,
+      "summary": "Documents the falling factorial Vandermonde identity, its relationship to the standard Vandermonde convolution via the conversion $n^{\\underline{k}} = k! \\binom{n}{k}$, and the three-step proof strategy: convert descFactorials, apply vandermonde_range, verify terms via $\\binom{r}{j} j! (r-j)! = r!$.",
       "mathContext": "$(m+n)^{\\underline{r}} = \\sum_{j=0}^{r} \\binom{r}{j} m^{\\underline{j}} n^{\\underline{r-j}}$, derived from $\\binom{m+n}{r} = \\sum_j \\binom{m}{j}\\binom{n}{r-j}$ by multiplying by $r!$"
+    },
+    {
+      "id": "sec-imports",
+      "title": "Imports, Opens, and Namespace",
+      "startLine": 26,
+      "endLine": 31,
+      "summary": "Imports Mathlib for Nat.descFactorial, Nat.choose, and factorial lemmas. Imports Proofs.BinomialTheoremOQ03 for the standard Vandermonde convolution (vandermonde_range). Opens Finset and BigOperators for concise sum notation (∑ j ∈ ..., ...). The VandermondeDescFactorial namespace scopes both lemmas.",
+      "mathContext": "Requires $\\binom{m+n}{r} = \\sum_j \\binom{m}{j}\\binom{n}{r-j}$ from BinomialTheoremOQ03 and $n^{\\underline{k}} = k! \\binom{n}{k}$ from Mathlib"
     },
     {
       "id": "sec-term-eq",
@@ -169,11 +182,19 @@
       "mathContext": "$\\binom{r}{j} \\cdot j! \\cdot (r-j)! = r!$ (for $j \\leq r$) — the key factorial identity, equivalent to $\\binom{r}{j} = \\frac{r!}{j!(r-j)!}$"
     },
     {
-      "id": "sec-main-theorem",
-      "title": "Main Theorem: Vandermonde in Falling Factorial Form",
+      "id": "sec-theorem-statement",
+      "title": "Theorem Statement and Docstring",
       "startLine": 48,
+      "endLine": 62,
+      "summary": "Declares `vandermonde_descFactorial` with its docstring. The statement formalizes $(m+n)^{\\underline{r}} = \\sum_{j=0}^{r} \\binom{r}{j} m^{\\underline{j}} n^{\\underline{r-j}}$ using `Nat.descFactorial` and `Finset.range (r+1)`. Note that `Finset.range n = \\{0, \\ldots, n-1\\}`, so `r+1` is needed to include the $j = r$ term. The docstring documents the three-step proof strategy.",
+      "mathContext": "$(m+n)^{\\underline{r}} = \\sum_{j=0}^{r} \\binom{r}{j} \\cdot m^{\\underline{j}} \\cdot n^{\\underline{r-j}}$ for all $m, n, r \\in \\mathbb{N}$"
+    },
+    {
+      "id": "sec-main-proof",
+      "title": "Proof: Convert, Apply Vandermonde, Close by Congruence",
+      "startLine": 63,
       "endLine": 78,
-      "summary": "Proves vandermonde_descFactorial (lines 59-76). Four-step chain: (1) `simp_rw [Nat.descFactorial_eq_factorial_mul_choose]` converts descFactorials to k!*C(n,k) form under binders; (2) `vandermonde_range` rewrites C(m+n,r) as ∑_j C(m,j)*C(n,r-j); (3) `Finset.mul_sum` distributes r! into the sum; (4) `Finset.sum_congr rfl` + `term_eq` verifies each summand. The namespace `VandermondeDescFactorial` closes after the theorem.",
+      "summary": "Four-step proof: (1) `simp_rw [Nat.descFactorial_eq_factorial_mul_choose]` converts descFactorials to $k! \\binom{n}{k}$ form under binders; (2) `vandermonde_range` rewrites $\\binom{m+n}{r}$ as $\\sum_j \\binom{m}{j}\\binom{n}{r-j}$; (3) `Finset.mul_sum` distributes $r!$ into the sum; (4) `Finset.sum_congr rfl` + `term_eq` verifies each summand matches. The `end VandermondeDescFactorial` closes the namespace.",
       "mathContext": "$(m+n)^{\\underline{r}} = r! \\cdot \\binom{m+n}{r} = r! \\sum_j \\binom{m}{j}\\binom{n}{r-j} = \\sum_j \\binom{r}{j} m^{\\underline{j}} n^{\\underline{r-j}}$"
     }
   ]


### PR DESCRIPTION
## Summary

Enrichment pass for `arithmetic-series-oq-02-oq-04-oq-01-oq-03` (Vandermonde Identity in Falling Factorial Form).

**Quality improvements:**
- Expanded `proofStrategy` from a one-line summary to a detailed four-step description of the proof flow
- Split coarse sections into finer-grained subsections: docstring / imports / statement / proof
- Added annotation for the imports/namespace block explaining dependency choices and the avoidance of broken parent files
- Added `binomial-theorem` cross-reference (the foundational coefficient-matching argument underlying Vandermonde)
- Strengthened `conclusion.summary` with mathematical substance about the proof's reusable pattern
- Narrowed header annotation range to match the actual docstring boundary (1-25)

No Lean code changes. Build validates successfully.