### PR TITLE
fix(meta): correct theoremCount in 16 gallery proofs

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
@@ -309,7 +309,7 @@
     "namespace": "AbelRuffiniOQ04OQ01",
     "lineCount": 1498,
     "axiomCount": 0,
-    "theoremCount": 81,
+    "theoremCount": 64,
     "definitionCount": 6,
     "mainTheorems": [
       {

--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-04/meta.json
@@ -69,7 +69,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/AmgmInequalityOQ03OQ02OQ04.lean",
-    "theoremCount": 2,
+    "theoremCount": 6,
     "definitionCount": 1
   },
   "crossReferences": [

--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01/meta.json
@@ -225,7 +225,7 @@
     "namespace": "NDimVolumeIntegral",
     "lineCount": 290,
     "axiomCount": 0,
-    "theoremCount": 25,
+    "theoremCount": 26,
     "definitionCount": 3,
     "path": "Proofs/AreaOfCircleOq01Oq02Oq01.lean",
     "sorries": 0

--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -683,7 +683,7 @@
     "namespace": "BirchSwinnertonDyer",
     "lineCount": 7430,
     "axiomCount": 19,
-    "theoremCount": 254,
+    "theoremCount": 253,
     "definitionCount": 143,
     "path": "Proofs/BirchSwinnertonDyer.lean",
     "sorries": 0

--- a/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-02-oq-02/meta.json
@@ -22,7 +22,7 @@
     "lineCount": 406,
     "axiomCount": 0,
     "sorries": 0,
-    "theoremCount": 12,
+    "theoremCount": 13,
     "definitionCount": 0
   },
   "meta": {

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-02-oq-01/meta.json
@@ -151,7 +151,7 @@
     "namespace": "CentralLimitTheoremOQ01OQ02OQ01",
     "lineCount": 112,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 0,
     "path": "Proofs/CentralLimitTheoremOQ01OQ02OQ01.lean",
     "sorries": 0

--- a/src/data/proofs/cramers-rule/meta.json
+++ b/src/data/proofs/cramers-rule/meta.json
@@ -208,7 +208,7 @@
     "namespace": "CramersRule",
     "lineCount": 161,
     "axiomCount": 0,
-    "theoremCount": 10,
+    "theoremCount": 9,
     "definitionCount": 0,
     "path": "Proofs/CramersRule.lean",
     "sorries": 0

--- a/src/data/proofs/divisibility-by-three-oq-01-oq-02/meta.json
+++ b/src/data/proofs/divisibility-by-three-oq-01-oq-02/meta.json
@@ -84,7 +84,7 @@
     "namespace": "DivisibilityByThreeOQ01OQ02",
     "lineCount": 200,
     "axiomCount": 0,
-    "theoremCount": 14,
+    "theoremCount": 13,
     "definitionCount": 1,
     "path": "Proofs/DivisibilityByThreeOQ01OQ02.lean",
     "sorries": 1

--- a/src/data/proofs/erdos-1008/meta.json
+++ b/src/data/proofs/erdos-1008/meta.json
@@ -133,7 +133,7 @@
     "namespace": "Erdos1008",
     "lineCount": 698,
     "axiomCount": 1,
-    "theoremCount": 26,
+    "theoremCount": 27,
     "definitionCount": 8,
     "path": "Proofs/Erdos1008Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-1059-oq-01/meta.json
+++ b/src/data/proofs/erdos-1059-oq-01/meta.json
@@ -191,7 +191,7 @@
     "opens": [],
     "structureCount": 0,
     "axiomCount": 1,
-    "theoremCount": 32,
+    "theoremCount": 35,
     "substantiveTheoremCount": 11,
     "computationalVerifications": 14,
     "lemmaCount": 3,

--- a/src/data/proofs/erdos-1100/meta.json
+++ b/src/data/proofs/erdos-1100/meta.json
@@ -241,7 +241,7 @@
     "namespace": "Erdos1100",
     "lineCount": 328,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 10,
     "definitionCount": 7,
     "mainTheorems": [
       {

--- a/src/data/proofs/erdos-647/meta.json
+++ b/src/data/proofs/erdos-647/meta.json
@@ -150,7 +150,7 @@
     "namespace": "Erdos647",
     "lineCount": 324,
     "axiomCount": 1,
-    "theoremCount": 25,
+    "theoremCount": 26,
     "definitionCount": 11,
     "path": "Proofs/Erdos647Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-892/meta.json
+++ b/src/data/proofs/erdos-892/meta.json
@@ -183,7 +183,7 @@
     "namespace": null,
     "lineCount": 318,
     "axiomCount": 1,
-    "theoremCount": 6,
+    "theoremCount": 7,
     "definitionCount": 6,
     "path": "Proofs/Erdos892Problem.lean",
     "sorries": 2

--- a/src/data/proofs/godel-incompleteness/meta.json
+++ b/src/data/proofs/godel-incompleteness/meta.json
@@ -270,7 +270,7 @@
     "lineCount": 437,
     "structureCount": 1,
     "axiomCount": 0,
-    "theoremCount": 9,
+    "theoremCount": 10,
     "lemmaCount": 0,
     "defCount": 12,
     "imports": [

--- a/src/data/proofs/shannon-channel-coding-oq-03/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-03/meta.json
@@ -191,7 +191,7 @@
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/ShannonChannelCodingOQ03.lean",
-    "theoremCount": 8,
+    "theoremCount": 10,
     "definitionCount": 4
   },
   "references": [

--- a/src/data/proofs/yang-mills/meta.json
+++ b/src/data/proofs/yang-mills/meta.json
@@ -197,7 +197,7 @@
     "namespace": "YangMillsMassGap",
     "lineCount": 48,
     "axiomCount": 16,
-    "theoremCount": 1787,
+    "theoremCount": 1806,
     "definitionCount": 260,
     "path": "Proofs/YangMillsMassGap.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Re-counted `theorem`/`lemma`/`proposition`/`corollary` declarations in 16 Lean source files (stripping block and line comments before counting) and corrected the `leanFile.theoremCount` metadata fields that had drifted from reality.

## Evidence

| Proof | Before | After | Notes |
|-------|--------|-------|-------|
| abel-ruffini-oq-04-oq-01 | 81 | 64 | over-counted |
| amgm-inequality-oq-03-oq-02-oq-04 | 2 | 6 | under-counted private lemmas |
| area-of-circle-oq-01-oq-02-oq-01 | 25 | 26 | off by one |
| birch-swinnerton-dyer | 254 | 253 | off by one |
| cauchy-schwarz-integral-oq-02-oq-02 | 12 | 13 | off by one |
| central-limit-theorem-oq-01-oq-02-01 | 7 | 8 | off by one |
| cramers-rule | 10 | 9 | off by one |
| divisibility-by-three-oq-01-oq-02 | 14 | 13 | off by one |
| erdos-1008 | 26 | 27 | off by one |
| erdos-1059-oq-01 | 32 | 35 | under-counted |
| erdos-1100 | 6 | 10 | excluded private lemmas |
| erdos-647 | 25 | 26 | off by one |
| erdos-892 | 6 | 7 | off by one |
| godel-incompleteness | 9 | 10 | off by one |
| shannon-channel-coding-oq-03 | 8 | 10 | under-counted |
| yang-mills | 1787 | 1806 | now sums all 4 sub-modules (Core+Classical+Quantum+Exploration) |

**Counting methodology**: stripped block comments (`/-...-/`) and line comments (`--...`), then matched `^(?:private\s+)?(?:theorem|lemma|proposition|corollary)[ \t]`.

---
Automated fix by lean-mechanic agent.