### PR TITLE
Enrich: Multinomial Marginals — add implications, cross-refs

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-02/annotations.json
@@ -70,5 +70,17 @@
     "significance": "context",
     "relatedConcepts": ["Bernoulli distribution", "binomial distribution", "Bool as index set", "symmetry in probability"],
     "prerequisites": ["bernoulli_marginal_pgf", "Finset.sum_pair", "Bool.false_ne_true", "simpa tactic"]
+  },
+  {
+    "id": "ann-binomial-marginal-summary",
+    "proofId": "binomial-theorem-oq-02-oq-01-oq-02",
+    "range": { "startLine": 318, "endLine": 337 },
+    "type": "insight",
+    "title": "Summary: The Multinomial Marginal Theorem",
+    "content": "The closing summary consolidates the file's two complementary proofs of the same result. The PGF approach (`multinomial_marginal_pgf`) is algebraically elegant — one application of the multinomial theorem with a strategically chosen indicator weight function. The direct PMF approach (`multinomial_marginal_pmf`) is combinatorially explicit — an explicit bijection between filtered antidiagonal elements and a smaller antidiagonal, factoring the multinomial coefficient via `Nat.multinomial_insert`. Both routes confirm that marginal distributions of the multinomial are binomial, answering the open question affirmatively. The PGF approach generalizes more readily (to moment calculations, joint distributions, and limiting theorems), while the direct approach gives the precise combinatorial mechanism.",
+    "mathContext": "Two proofs of the same identity: $P(X_{i_0} = j) = \\binom{n}{j} p_{i_0}^j (1-p_{i_0})^{n-j}$. PGF route: $E[t^{X_{i_0}}] = (p_{i_0} t + (1-p_{i_0}))^n$ matches the binomial PGF, so distributions agree. Direct route: sum over $k$ with $k(i_0)=j$, factor $\\binom{n}{k} = \\binom{n}{j}\\binom{n-j}{\\text{rest}}$, apply multinomial theorem on remaining components.",
+    "significance": "supporting",
+    "relatedConcepts": ["PGF uniqueness", "coefficient extraction", "combinatorial bijection", "proof methodology comparison"],
+    "prerequisites": ["multinomial_marginal_pgf", "multinomial_marginal_pmf", "all preceding sections"]
   }
 ]

--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-02/meta.json
@@ -41,8 +41,8 @@
       "id": "module-docstring",
       "title": "Module Overview and Proof Strategy",
       "startLine": 1,
-      "endLine": 44,
-      "summary": "Explains the open question (marginals of multinomial are binomial?), the PGF proof strategy (choose g(i) = t if i=i₀ else 1), and the Mathlib dependencies (Finset.sum_pow_eq_sum_piAntidiag, Finset.prod_eq_single, Finset.sum_ite_eq'). Also includes imports."
+      "endLine": 48,
+      "summary": "Explains the open question (marginals of multinomial are binomial?), the PGF proof strategy (choose g(i) = t if i=i₀ else 1), and the Mathlib dependencies (Finset.sum_pow_eq_sum_piAntidiag, Finset.prod_eq_single, Finset.sum_ite_eq'). Also includes four imports and opens BigOperators."
     },
     {
       "id": "setup",
@@ -82,8 +82,11 @@
   ],
   "conclusion": {
     "summary": "The main result `multinomial_marginal_pgf` proves that the PGF of each marginal of the multinomial distribution equals the Binomial PGF. Additionally, `multinomial_marginal_pmf` directly proves the PMF formula P(X_{i₀}=j) = C(n,j)·p(i₀)^j·(1−p(i₀))^(n−j) via an explicit bijection and Nat.multinomial_insert. All 10 theorems fully machine-verified, 0 sorries.",
+    "implications": "The marginal-is-binomial result is foundational in statistics: it justifies treating each category of a multinomial experiment as an independent success/failure trial when only one category is of interest. This is used routinely in goodness-of-fit tests (chi-squared), confidence intervals for proportions, and the derivation of the multinomial's covariance structure Cov(Xᵢ,Xⱼ) = -npᵢpⱼ (which follows from knowing the marginals). The PGF method exemplified here generalizes to any compound distribution whose PGF factors — a principle underlying the Poisson limit theorem and branching processes.",
     "openQuestions": [
-      "Can the proof be extended to show joint independence of disjoint subsets of multinomial components?"
+      "Can the proof be extended to show joint independence of disjoint subsets of multinomial components? Specifically, if S₁∪S₂⊂{1,...,k} are disjoint, is (∑_{i∈S₁}Xᵢ, ∑_{i∈S₂}Xᵢ) jointly multinomial on the collapsed categories?",
+      "Formalize the multinomial covariance: Cov(Xᵢ,Xⱼ) = -npᵢpⱼ for i≠j, derivable from this marginal result plus E[Xᵢ]=npᵢ and E[XᵢXⱼ] via the joint PGF",
+      "Prove the Poisson limit: as n→∞ and pᵢ→0 with npᵢ→λᵢ, the multinomial converges to independent Poisson(λᵢ) components — the infinite-dimensional analogue of the marginal binomial result"
     ]
   },
   "leanFile": {
@@ -118,6 +121,21 @@
       "id": "binomial-theorem",
       "relation": "ancestor",
       "description": "The original binomial theorem"
+    },
+    {
+      "id": "binomial-theorem-oq-02-oq-02",
+      "relation": "sibling",
+      "description": "Vandermonde's identity via the binomial theorem — another combinatorial identity derived from the same multinomial framework"
+    },
+    {
+      "id": "binomial-theorem-oq-02-oq-03",
+      "relation": "sibling",
+      "description": "q-Multinomial coefficients — a q-analogue generalization of the multinomial coefficients used here"
+    },
+    {
+      "id": "central-limit-theorem",
+      "relation": "related",
+      "description": "Central Limit Theorem — the marginal binomial Xᵢ ∼ Bin(n,pᵢ) proved here converges to Normal(npᵢ, npᵢ(1-pᵢ)) by CLT as n→∞"
     }
   ]
 }


### PR DESCRIPTION
## Enrichment pass for binomial-theorem-oq-02-oq-01-oq-02

**Additions:**
- `conclusion.implications`: statistical applications (chi-squared, covariance structure), PGF generality (Poisson limit, branching processes)
- Expanded `openQuestions` from 1 to 3: joint independence, multinomial covariance, Poisson limit
- 3 cross-references: Vandermonde identity, q-multinomial coefficients, Central Limit Theorem
- Summary annotation (lines 318-337) comparing PGF vs direct PMF proof approaches
- Fixed section gap: extended module-docstring section to cover lines 1-48

🤖 Generated with [Claude Code](https://claude.com/claude-code)