### PR TITLE
Enrich: Vandermonde's Identity — add implications, cross-refs, setup annotation

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-02/annotations.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-02/annotations.json
@@ -12,6 +12,18 @@
     "prerequisites": ["binomial theorem", "Finset.antidiagonal definition", "formal power series multiplication"]
   },
   {
+    "id": "ann-vdm-setup",
+    "proofId": "binomial-theorem-oq-02-oq-02",
+    "range": { "startLine": 29, "endLine": 43 },
+    "type": "context",
+    "title": "Setup: Single Mathlib Import and Namespace",
+    "content": "The file uses `import Mathlib` — a monolithic import that brings in the entire Mathlib library. While this is heavier than targeted imports, it is the idiomatic approach for combinatorics proofs that draw on a narrow API surface (`Nat.add_choose_eq`, `Nat.sum_range_choose`, `Nat.choose_succ_succ`) spread across multiple modules. `open Finset Nat` brings `antidiagonal`, `range`, `choose`, and `sum_range_choose` into scope without qualification. The namespace `VandermondeMult` scopes all 11 theorems.",
+    "mathContext": "The key Mathlib API: `Nat.add_choose_eq m n r : (m+n).choose r = ∑ ij ∈ antidiagonal r, m.choose ij.1 * n.choose ij.2` and `Nat.sum_range_choose n : ∑ k ∈ range (n+1), n.choose k = 2^n`. The `antidiagonal r` set $\\{(i,j) \\in \\mathbb{N}^2 : i+j=r\\}$ is the discrete convolution support.",
+    "significance": "context",
+    "relatedConcepts": ["Mathlib import strategy", "Finset.antidiagonal", "Nat.choose", "namespace scoping"],
+    "prerequisites": ["Lean 4 import system", "Mathlib library"]
+  },
+  {
     "id": "ann-vdm-core",
     "proofId": "binomial-theorem-oq-02-oq-02",
     "range": { "startLine": 44, "endLine": 71 },

--- a/src/data/proofs/binomial-theorem-oq-02-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-02/meta.json
@@ -107,6 +107,7 @@
   ],
   "conclusion": {
     "summary": "Vandermonde's identity is derived from the binomial theorem, extending the parent's multinomial formalization. 11 theorems, 0 axioms, 0 sorries.",
+    "implications": "Vandermonde's identity is the engine behind many combinatorial arguments: it powers the convolution identities for generating functions, underlies the Chu-Vandermonde identity in hypergeometric series, and provides the algebraic backbone for lattice path counting (the self-convolution C(2n,n) = Σ C(n,k)² counts NE lattice paths). The triple Vandermonde opens the path to the full multinomial convolution, central to partition theory and symmetric function theory. The formalization validates that Mathlib's antidiagonal API cleanly supports convolution-style combinatorial identities.",
     "openQuestions": [
       "Can the q-Vandermonde identity ∑ q^{k(r-k)} C(m,k)_q · C(n,r-k)_q = C(m+n,r)_q be formalized using Mathlib's `GaussianBinomial`? This counts k-dimensional subspaces of an (r)-dimensional subspace chosen from m- and n-dimensional spaces over 𝔽_q.",
       "The hockey-stick identity C(r,r) + C(r+1,r) + … + C(n,r) = C(n+1,r+1) follows from Vandermonde by a telescoping argument. Can it be derived from the existing formalization using `Finset.sum_range_succ` and `vandermonde` directly?",
@@ -146,7 +147,17 @@
     {
       "targetId": "binomial-theorem",
       "relationship": "related",
-      "description": "Root binomial theorem formalization."
+      "description": "Root binomial theorem formalization — the first layer of the three-layer chain that culminates in Vandermonde."
+    },
+    {
+      "targetId": "ballot-problem",
+      "relationship": "related",
+      "description": "Ballot problem — uses lattice path counting where the self-convolution C(2n,n) = Σ C(n,k)² (proved here) counts the total paths"
+    },
+    {
+      "targetId": "pascals-hexagon",
+      "relationship": "related",
+      "description": "Pascal's hexagon theorem — another structural property of Pascal's triangle; this file derives Pascal's rule from Vandermonde"
     }
   ]
 }


### PR DESCRIPTION
Enrichment pass for binomial-theorem-oq-02-oq-02. Quality improvements:

- **Added missing `conclusion.implications`** covering convolution algebra, Chu-Vandermonde, lattice path counting, multinomial connections
- **Added 2 cross-references**: ballot-problem (lattice paths/C(2n,n)), pascals-hexagon (Pascal's triangle structure)
- **Added annotation** `ann-vdm-setup` covering import/namespace lines 29-43 (previously uncovered)
- Expanded binomial-theorem cross-ref description

🤖 Generated with [Claude Code](https://claude.com/claude-code)