### PR TITLE
Enrich: BU Dimension Formula — fix leanFile schema, field names

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01/meta.json
@@ -20,7 +20,7 @@
     "axiomCount": 1,
     "lineCount": 138,
     "theoremCount": 9,
-    "defCount": 1,
+    "definitionCount": 1,
     "assumptions": "1 axiom: buDim_le_formula (the open conjecture: buDim(n,d) ≤ max_{p|n} buDim(p,d)). Lower bound direction proved from buDim_mono in parent file. Specific cases n=4,6,9 proved. buDim function and known results axiomatized in parent file BorsukUlamOQ02OQ01.lean.",
     "mathlib_version": "4.26.0"
   },
@@ -132,5 +132,16 @@
       "note": "Comprehensive reference for equivariant Borsuk-Ulam theory"
     }
   ],
-  "leanFile": "Proofs/BorsukUlamOQ02OQ01OQ01.lean"
+  "leanFile": {
+    "imports": [
+      "Proofs.BorsukUlamOQ02OQ01"
+    ],
+    "namespace": "BorsukUlamOQ02OQ01OQ01",
+    "lineCount": 138,
+    "axiomCount": 1,
+    "theoremCount": 9,
+    "definitionCount": 1,
+    "path": "Proofs/BorsukUlamOQ02OQ01OQ01.lean",
+    "sorries": 0
+  }
 }


### PR DESCRIPTION
## Summary
- Fixed `leanFile` from bare string to proper object with imports, lineCount, axiomCount, theoremCount, definitionCount, path, sorries
- Fixed `defCount` → `definitionCount` for schema consistency

## Test plan
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)