### PR TITLE
Research: erdos-462 fix + erdos-1040 fix + HN7 + bertrand sorries

### DIFF
--- a/proofs/Proofs/Erdos1040Aristotle.lean
+++ b/proofs/Proofs/Erdos1040Aristotle.lean
@@ -114,26 +114,85 @@ These are needed to fill sorries in Erdos1040Problem.lean.
 -/
 
 /-- When G is bounded, the nthDiameter value set is BddAbove.
-    Key: each |pts i - pts j| ≤ diam(G), so the product is bounded,
-    and rpow with exponent 2/(n*(n-1)) gives ≤ diam(G).
-    Uses: Metric.isBounded_iff, Finset.prod_le_prod, Real.rpow_le_rpow -/
+    Each |pts i - pts j| ≤ diam(G), so the product ≤ (diam G + 1)^(n*n).
+    For n ≤ 1 the rpow exponent is 0 giving value 1.
+    For n ≥ 2 the exponent ≤ 1 so rpow ≤ product ≤ (diam G + 1)^(n*n).
+    Proof adapted from Erdos1040Problem.lean transfiniteDiameter_mono_of_bounded. -/
 theorem nthDiameter_bddAbove_of_bounded (G : Set ℂ) (hG : Bornology.IsBounded G) (n : ℕ) :
     BddAbove {(∏ i : Fin n, ∏ j in Finset.Iio i,
       Complex.abs (pts i - pts j)) ^ (2 / (n * (n - 1) : ℝ)) |
-      pts : Fin n → ℂ // ∀ i, pts i ∈ G} := by sorry
+      pts : Fin n → ℂ // ∀ i, pts i ∈ G} := by
+  refine ⟨(Metric.diam G + 1) ^ (n * n), ?_⟩
+  rintro _ ⟨⟨pts, hpts⟩, rfl⟩
+  have hD1 : (1 : ℝ) ≤ Metric.diam G + 1 := by linarith [Metric.diam_nonneg (s := G)]
+  -- Each factor: |pts i - pts j| ≤ diam G + 1
+  have hfac : ∀ i j : Fin n, Complex.abs (pts i - pts j) ≤ Metric.diam G + 1 := by
+    intro i j
+    have h1 : Complex.abs (pts i - pts j) = dist (pts i) (pts j) := by
+      rw [← Complex.dist_eq]
+    rw [h1]; linarith [Metric.dist_le_diam_of_mem hG (hpts i) (hpts j)]
+  -- Product ≤ (diam G + 1)^(n*n)
+  have hprod_le : ∏ i : Fin n, ∏ j in Finset.Iio i,
+      Complex.abs (pts i - pts j) ≤ (Metric.diam G + 1) ^ (n * n) := by
+    calc ∏ i : Fin n, ∏ j in Finset.Iio i, Complex.abs (pts i - pts j)
+        ≤ ∏ i : Fin n, (Metric.diam G + 1) ^ (Finset.Iio i).card := by
+          apply Finset.prod_le_prod
+          · intro i _; exact Finset.prod_nonneg fun j _ => Complex.abs.nonneg _
+          · intro i _
+            have : ∏ j in Finset.Iio i, Complex.abs (pts i - pts j) ≤
+                ∏ _j in Finset.Iio i, (Metric.diam G + 1) :=
+              Finset.prod_le_prod (fun j _ => Complex.abs.nonneg _) (fun j _ => hfac i j)
+            rwa [Finset.prod_const] at this
+      _ = (Metric.diam G + 1) ^ ∑ i : Fin n, (Finset.Iio i).card :=
+          Finset.prod_pow_eq_pow_sum Finset.univ _ _
+      _ ≤ (Metric.diam G + 1) ^ (n * n) := by
+          apply pow_le_pow_right₀ hD1
+          calc ∑ i : Fin n, (Finset.Iio i).card
+              ≤ ∑ _i : Fin n, n :=
+                Finset.sum_le_sum fun i _ =>
+                  (Finset.card_le_card (Finset.subset_univ _)).trans_eq (Finset.card_fin n)
+            _ = n * n := by simp [Finset.sum_const, Finset.card_univ, Fintype.card_fin, mul_comm]
+  -- Apply rpow bound
+  have hprod_nn : 0 ≤ ∏ i : Fin n, ∏ j in Finset.Iio i, Complex.abs (pts i - pts j) :=
+    Finset.prod_nonneg fun i _ => Finset.prod_nonneg fun j _ => Complex.abs.nonneg _
+  rcases le_or_gt n 1 with hn1 | hn2
+  · -- n ≤ 1: exponent = 0, value = 1 ≤ (D+1)^(n*n)
+    have he0 : (2 : ℝ) / ((↑n : ℝ) * ((↑n : ℝ) - 1)) = 0 := by
+      have : n = 0 ∨ n = 1 := by omega; rcases this with rfl | rfl <;> norm_num
+    rw [he0, Real.rpow_zero]; exact one_le_pow₀ hD1
+  · -- n ≥ 2: exponent ∈ (0, 1], so product^e ≤ max(product, 1) ≤ (D+1)^(n*n)
+    have he_le : (2 : ℝ) / ((↑n : ℝ) * ((↑n : ℝ) - 1)) ≤ 1 := by
+      rw [div_le_one (by positivity)]
+      have h1 : (2 : ℝ) ≤ ↑n := by exact_mod_cast hn2
+      nlinarith [show (1 : ℝ) ≤ (↑n : ℝ) - 1 by linarith]
+    rcases le_or_gt (∏ i : Fin n, ∏ j in Finset.Iio i, Complex.abs (pts i - pts j)) 1
+      with hle1 | hgt1
+    · exact (Real.rpow_le_one hprod_nn hle1 (by positivity)).trans (one_le_pow₀ hD1)
+    · exact (Real.rpow_le_rpow_of_exponent_le (le_of_lt hgt1) he_le).trans
+        (Real.rpow_one _ ▸ hprod_le)
 
-/-- Scaling: nthDiameter(c·F, n) = |c| · nthDiameter(F, n).
-    Proof: |c·x - c·y| = |c|·|x-y|, factor |c|^(n*(n-1)/2) out of product,
-    rpow simplifies exponent to give |c|^1 = |c|. Then factor |c| out of sSup.
-    Uses: Complex.abs.map_mul, Finset.prod_mul_distrib, Real.mul_rpow -/
-theorem nthDiameter_scale (F : Set ℂ) (c : ℂ) (n : ℕ) :
+/-- **Scaling: nthDiameter(c·F, n) = |c| · nthDiameter(F, n).**
+
+**FALSE for n ≤ 1**: When n = 0 or n = 1, the inner product over `Finset.Iio i`
+is empty, giving product = 1. The exponent is 2/(n*(n-1)) = 2/0 = 0, so
+`1 ^ 0 = 1` regardless of F or c. Thus `nthDiameter(cF, n) = 1` but
+`|c| * nthDiameter(F, n) = |c| * 1 = |c| ≠ 1` for |c| ≠ 1.
+
+The correct statement requires `n ≥ 2`. -/
+theorem nthDiameter_scale (F : Set ℂ) (c : ℂ) (n : ℕ) (hn : n ≥ 2) :
     nthDiameter ((fun z => c * z) '' F) n = Complex.abs c * nthDiameter F n := by sorry
 
-/-- Scaling property of transfinite diameter: ρ(cF) = |c|·ρ(F).
-    Follows from nthDiameter_scale and pulling constant out of iInf.
-    Uses: nthDiameter_scale, Real.iInf_mul_of_nonneg (or similar) -/
-theorem transfiniteDiameter_scale (F : Set ℂ) (c : ℂ) (hc : c ≠ 0) :
-    transfiniteDiameter ((fun z => c * z) '' F) =
-    Complex.abs c * transfiniteDiameter F := by sorry
+/-- **Scaling of transfinite diameter — FALSE with inf-over-all-n definition.**
+
+The `transfiniteDiameter` definition uses `⨅ n : ℕ, nthDiameter F n`. Since
+`nthDiameter F 0 = nthDiameter F 1 = 1` for all F, the inf is clamped at ≤ 1.
+For sets with true transfinite diameter > 1 (e.g., disc of radius 2), scaling
+by c with `|c| < 1` gives `transfiniteDiameter(cF) = 1 ≠ |c| * 1`.
+
+Fix: define transfiniteDiameter as `⨅ n ≥ 2, nthDiameter F n` or use
+`Filter.liminf`. See `transfiniteDiameter'` in Erdos1040Problem.lean. -/
+-- theorem transfiniteDiameter_scale (F : Set ℂ) (c : ℂ) (hc : c ≠ 0) :
+--     transfiniteDiameter ((fun z => c * z) '' F) =
+--     Complex.abs c * transfiniteDiameter F := by sorry
 
 end Erdos1040

--- a/proofs/Proofs/Erdos1040Problem.lean
+++ b/proofs/Proofs/Erdos1040Problem.lean
@@ -424,11 +424,31 @@ theorem finite_diameter_zero (F : Set ℂ) (hF : F.Finite) :
       _ = 0 := nthDiameter_eq_zero_of_finite F hF n₀ (by omega) (by omega)
   · exact (transfiniteDiameter_nonneg F).le
 
-/-- Scaling property. -/
-theorem transfiniteDiameter_scale (F : Set ℂ) (c : ℂ) (hc : c ≠ 0) :
-    transfiniteDiameter ((fun z => c * z) '' F) =
-    ‖c‖ * transfiniteDiameter F := by
-  sorry
+/-- **Scaling property — FALSE as stated.**
+
+The current `transfiniteDiameter` definition uses `⨅ n : ℕ, nthDiameter F n`
+(inf over ALL n ≥ 0). Since `nthDiameter F 0 = nthDiameter F 1 = 1` for
+any `F` (empty product with exponent 2/0 = 0 gives 1^0 = 1), the inf is
+clamped at ≤ 1.
+
+**Counterexample**: Let F = closed disc of radius 2 centered at 0, c = 1/2.
+- `nthDiameter F n → 2` as `n → ∞` (transfinite diameter of disc = radius)
+- `transfiniteDiameter F = ⨅ n, nthDiameter F n = 1` (clamped by n=0,1)
+- `transfiniteDiameter (cF) = 1` (clamped by n=0,1)
+- `‖c‖ * transfiniteDiameter F = 0.5 * 1 = 0.5 ≠ 1`
+
+**Fix**: Use `transfiniteDiameter'` (Filter.liminf, line 44) or restrict the inf
+to `n ≥ 2`. The standard mathematical definition is `lim_{n→∞} δ_n(F)`, which
+equals `inf_{n≥2} δ_n(F)` by Fekete's subadditivity. The n=0,1 artifacts do not
+affect the correct definition.
+
+For Erdős #1040 specifically, the interesting regime is `ρ(F) < 1`, where the
+current definition is correct (the inf over n ≥ 2 is < 1, dominating the
+n=0,1 value of 1). -/
+-- theorem transfiniteDiameter_scale (F : Set ℂ) (c : ℂ) (hc : c ≠ 0) :
+--     transfiniteDiameter ((fun z => c * z) '' F) =
+--     ‖c‖ * transfiniteDiameter F := by
+--   sorry
 
 /-
 ## Properties of μ

--- a/proofs/Proofs/Erdos462Problem.lean
+++ b/proofs/Proofs/Erdos462Problem.lean
@@ -5,8 +5,11 @@ Let `p(n)` denote the least prime factor of `n`. There exists `c > 0`
 such that `∑_{n<x, n composite} p(n)/n ~ c · x^{1/2} / (log x)²`.
 
 Does there exist `C > 0` such that
-`∑_{x ≤ n ≤ x + C·x^{1/2}·(log x)²} p(n)/n ≫ 1`
+`∑_{x ≤ n ≤ x + C·x^{1/2}·(log x)², n composite} p(n)/n ≫ 1`
 for all sufficiently large `x`?
+
+Note: the sum must be restricted to composites. For primes, `p(n)/n = 1`,
+so the unrestricted sum is trivially large from primes alone.
 
 *Reference:* [erdosproblems.com/462](https://www.erdosproblems.com/462),
 Erdős–Graham (1980), p. 92.
@@ -52,6 +55,15 @@ noncomputable def intervalSum (a b : ℕ) : ℝ :=
     (Finset.Icc a b).sum fun n =>
       (leastPrimeFactor n : ℝ) / (n : ℝ)
 
+/-- Sum of `p(n)/n` over composites in an interval `{a, …, b}`.
+This is the correct summand for Erdős #462: the conjecture concerns
+the *composite* contribution only, since primes contribute `p(n)/n = 1`
+each, making the unrestricted sum trivially large. -/
+noncomputable def compositeIntervalSum (a b : ℕ) : ℝ :=
+    (Finset.Icc a b).sum fun n =>
+      if n.Prime then 0
+      else (leastPrimeFactor n : ℝ) / (n : ℝ)
+
 /- ## Known asymptotics -/
 
 /-- There exists `c > 0` such that `∑_{n<x, composite} p(n)/n ~ c·√x/(log x)²`.
@@ -64,14 +76,18 @@ axiom compositeSum_asymptotic :
 
 /- ## Main conjecture -/
 
-/-- Erdős Problem 462: There exists `C > 0` such that the sum
-`∑_{x ≤ n ≤ x + C·√x·(log x)²} p(n)/n` is bounded below by
-an absolute constant for all large `x`. -/
+/-- Erdős Problem 462: There exists `C > 0` such that the *composite*
+sum `∑_{x ≤ n ≤ x + C·√x·(log x)², n composite} p(n)/n` is bounded
+below by an absolute constant for all large `x`.
+
+N.B. The sum is restricted to composites: for primes `p(n)/n = 1`,
+so the unrestricted `intervalSum` would be trivially `≫ 1` from the
+prime contribution alone (~`C√x·log x` primes in the interval). -/
 def ErdosProblem462 : Prop :=
     ∃ C : ℝ, 0 < C ∧
       ∃ δ : ℝ, 0 < δ ∧
         ∃ x₀ : ℕ, ∀ x : ℕ, x₀ ≤ x →
-          δ ≤ intervalSum x ⌊(x : ℝ) + C * (x : ℝ) ^ (1/2 : ℝ) * (Real.log x) ^ 2⌋₊
+          δ ≤ compositeIntervalSum x ⌊(x : ℝ) + C * (x : ℝ) ^ (1/2 : ℝ) * (Real.log x) ^ 2⌋₊
 
 /- ## Basic properties -/
 
@@ -173,3 +189,71 @@ theorem intervalSum_split (a m b : ℕ) (ham : a ≤ m + 1) (hmb : m + 1 ≤ b) 
   have hunion : Finset.Icc a m ∪ Finset.Icc (m + 1) b = Finset.Icc a b := by
     ext n; simp only [Finset.mem_Icc, Finset.mem_union]; omega
   rw [← hunion, Finset.sum_union hdisj]
+
+/- ## Composite interval sum properties -/
+
+/-- The composite interval sum is non-negative. -/
+theorem compositeIntervalSum_nonneg (a b : ℕ) : 0 ≤ compositeIntervalSum a b := by
+  unfold compositeIntervalSum
+  apply Finset.sum_nonneg
+  intro n _
+  split_ifs with h
+  · exact le_refl 0
+  · exact div_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _)
+
+/-- The composite interval sum is at most the full interval sum. -/
+theorem compositeIntervalSum_le_intervalSum (a b : ℕ) :
+    compositeIntervalSum a b ≤ intervalSum a b := by
+  unfold compositeIntervalSum intervalSum
+  apply Finset.sum_le_sum
+  intro n _
+  split_ifs with h
+  · exact div_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _)
+  · exact le_refl _
+
+/-- Enlarging the interval increases the composite sum. -/
+theorem compositeIntervalSum_mono {a₁ b₁ a₂ b₂ : ℕ}
+    (ha : a₂ ≤ a₁) (hb : b₁ ≤ b₂) :
+    compositeIntervalSum a₁ b₁ ≤ compositeIntervalSum a₂ b₂ := by
+  unfold compositeIntervalSum
+  apply Finset.sum_le_sum_of_subset_of_nonneg
+  · intro n hn; simp only [Finset.mem_Icc] at *; omega
+  · intro n _ _
+    split_ifs with h
+    · exact le_refl 0
+    · exact div_nonneg (Nat.cast_nonneg _) (Nat.cast_nonneg _)
+
+/-- Splitting a composite interval sum at a midpoint. -/
+theorem compositeIntervalSum_split (a m b : ℕ)
+    (ham : a ≤ m + 1) (hmb : m + 1 ≤ b) :
+    compositeIntervalSum a b =
+      compositeIntervalSum a m + compositeIntervalSum (m + 1) b := by
+  unfold compositeIntervalSum
+  have hdisj : Disjoint (Finset.Icc a m) (Finset.Icc (m + 1) b) := by
+    rw [Finset.disjoint_left]
+    intro n hn₁ hn₂; simp only [Finset.mem_Icc] at *; omega
+  have hunion : Finset.Icc a m ∪ Finset.Icc (m + 1) b = Finset.Icc a b := by
+    ext n; simp only [Finset.mem_Icc, Finset.mem_union]; omega
+  rw [← hunion, Finset.sum_union hdisj]
+
+/-- The composite interval sum over `[a, b]` equals
+`compositeSum (b + 1) - compositeSum a` when `a ≥ 2`. -/
+theorem compositeIntervalSum_eq_compositeSum_sub (a b : ℕ)
+    (ha : 2 ≤ a) (hab : a ≤ b + 1) :
+    compositeIntervalSum a b = compositeSum (b + 1) - compositeSum a := by
+  unfold compositeIntervalSum compositeSum
+  have hsub : (b + 1 - 1) = b := by omega
+  rw [hsub]
+  have hunion : Finset.Icc 2 (a - 1) ∪ Finset.Icc a b = Finset.Icc 2 b := by
+    ext n; simp only [Finset.mem_Icc, Finset.mem_union]; omega
+  have hdisj : Disjoint (Finset.Icc 2 (a - 1)) (Finset.Icc a b) := by
+    rw [Finset.disjoint_left]
+    intro n hn₁ hn₂; simp only [Finset.mem_Icc] at *; omega
+  have hkey : (Finset.Icc 2 b).sum (fun n =>
+      if n.Prime then (0 : ℝ) else (leastPrimeFactor n : ℝ) / (n : ℝ)) =
+    (Finset.Icc 2 (a - 1)).sum (fun n =>
+      if n.Prime then (0 : ℝ) else (leastPrimeFactor n : ℝ) / (n : ℝ)) +
+    (Finset.Icc a b).sum (fun n =>
+      if n.Prime then (0 : ℝ) else (leastPrimeFactor n : ℝ) / (n : ℝ)) := by
+    rw [← hunion, Finset.sum_union hdisj]
+  linarith

--- a/research/problems/taylor-theorem-oq-02/selection-report.md
+++ b/research/problems/taylor-theorem-oq-02/selection-report.md
@@ -1,0 +1,111 @@
+# Problem Selection Report
+
+**Date**: 2026-04-05
+**Mode**: SELECT
+**Pool Status**: 15 available, 533 in-progress, 1238 completed
+
+## Selected Problem
+
+- **ID**: taylor-theorem-oq-02
+- **Name**: Characterize Taylor remainder interaction with Lean analytic function API
+- **Tier**: B
+- **Significance**: 6/10
+- **Tractability**: 7/10
+- **Knowledge Score**: 0 (EMPTY)
+- **Status**: available
+
+## Selection Rationale
+
+1. **Highest composite score among fresh candidates (76)**: EMPTY knowledge tier (0 items)
+   combined with tractability 7 gives the top score among uninitiated problems.
+2. **Domain diversity**: Recent selections were combinatorics (burnside-counting-oq-01),
+   graph coloring (unit-distance-independence-oq-02), and algebra (vietas-formulas-oq-02).
+   Analysis is underrepresented — this rebalances the pipeline.
+3. **Tractability 7 is strong for autonomous research**: The Lean Mathlib `Analysis.Calculus.Taylor`
+   module is well-documented. The analytic function API (`AnalyticOn`, `HasFPowerSeriesAt`) is
+   mature. The gap between "Taylor polynomial remainder → 0" and "analytic iff Taylor series
+   converges" is a meaningful but bridgeable step, not an open conjecture.
+
+## Rejection Summary
+
+- **Candidates considered**: 15 available
+- **Candidates rejected**: 14
+  - `triangular-reciprocals-oq-02` (score 75): C tier, significance 5 — below quality bar
+  - `factor-remainder-nullstellensatz-oq-02` (score 67): Good but lower tractability (6)
+  - `buffons-needle-oq-01-oq-04` (score 66): Geometry/probability, significance 6
+  - `wolstenholme-theorem-oq-03` (score 66): Number theory, significance 6
+  - `erdos-ko-rado-oq-04` (score 57): Tractability 5, significance 7 — harder for autonomous research
+  - `brouwer-fixed-point-oq-04-oq-04` (score 56): Constructive content extraction is subtle
+  - `szemeredi-theorem-oq-01` (score 48): Significance 8 but tractability 4 — too hard solo
+  - `prime-gap-bounds-oq-03` (score -1923): MODERATE knowledge (11 items), lower priority
+  - Already-initialized (skip re-selecting): `euler-identity-oq-01-oq-04`,
+    `unit-distance-independence-oq-02`, `vietas-formulas-oq-02`, `erdos-szekeres-oq-01`,
+    `mean-value-theorem-oq-04`, `taylor-sincos-convergence-oq-01`
+- **Confidence**: medium (score spread between top 2 is modest: 76 vs 75, but tier difference justifies)
+
+## Related Gallery Proofs
+
+- `taylor-theorem`: Parent proof (Wiedijk #35) — verified, 0 sorries. Provides
+  `taylor_lagrange_remainder`, `taylor_cauchy_remainder`, `taylor_remainder_bound`. OQ-02
+  asks what happens when f is analytic (not just smooth).
+- `taylor-theorem-oq-03`: Taylor series convergence of `exp` via Cauchy remainder —
+  verified with mathlib badge. Shows the blueprint: use Cauchy form, bound remainder,
+  take limit. OQ-02 generalizes this to arbitrary analytic functions.
+- `taylor-sincos-convergence`: Related — convergence of sin/cos Taylor series.
+  Provides `sinPartialSum` infrastructure that may inform analytic API patterns.
+
+## The Core Problem
+
+The Taylor theorem proof uses `taylor_mean_remainder_lagrange`/`_cauchy` from
+`Mathlib.Analysis.Calculus.Taylor`. These give: for some ξ,
+```
+f(x) = Tₙ(x) + Rₙ(x)
+```
+where Rₙ depends on `iteratedDeriv f (n+1) ξ`.
+
+The **analytic function API** in Mathlib uses:
+- `AnalyticOn ℝ f s` — f has a convergent power series at every point in s
+- `HasFPowerSeriesAt f p x` — f equals its power series p at x
+- `HasFPowerSeriesOnBall f p x r` — convergence on a ball
+
+**OQ-02 asks**: Can we connect these? Specifically:
+1. If `AnalyticOn ℝ f s`, does the Taylor remainder `Rₙ(x) → 0` as n → ∞?
+2. Can we express `taylorWithinEval` in terms of `FormalMultilinearSeries`?
+3. Is there a Mathlib lemma like `AnalyticAt.hasFPowerSeriesAt` that we can bridge to?
+
+## Suggested First Steps
+
+1. **OBSERVE**: Search Mathlib for bridging lemmas — look for `AnalyticOn.taylor`,
+   `hasFPowerSeriesAt_iff`, and whether `iteratedDeriv` connects to `FormalMultilinearSeries`.
+   Check `Mathlib.Analysis.Analytic.Basic` and `Mathlib.Analysis.Calculus.Taylor`.
+2. **ORIENT via Scout**: Survey how `taylor-theorem-oq-03` (exp convergence) bridges
+   Cauchy remainder to convergence — this is the template. Check if that proof uses
+   `AnalyticOn` or only smoothness + derivative bounds.
+3. **DECIDE**: Formulate a concrete theorem statement, e.g.:
+   ```lean
+   theorem analytic_taylor_remainder_tendsto {f : ℝ → ℝ} {x₀ : ℝ}
+       (hf : AnalyticAt ℝ f x₀) (x : ℝ) :
+       Filter.Tendsto (fun n => f x - taylorWithinEval f n (Set.univ) x₀ x)
+         Filter.atTop (nhds 0)
+   ```
+   Or alternatively find the Mathlib theorem that already says this and write a
+   wrapper that makes it accessible from the Taylor proof context.
+
+## Pool Summary After Selection
+
+| Status | Count |
+|--------|-------|
+| Available | 15 |
+| In Progress | 533 |
+| Completed | 1238 |
+| Blocked | 1 |
+| **Total** | **~1787** |
+
+## Candidate Pool Health
+
+Pool depth is adequate (15 available). No replenishment needed immediately.
+
+- Pool depth: **adequate**
+- Recommendation: Pool healthy — 15 available problems span analysis, algebra,
+  combinatorics, number theory, topology, and probability.
+- Next refresh recommended: When available count drops below 5

--- a/research/problems/vietas-formulas-oq-02/selection-report.md
+++ b/research/problems/vietas-formulas-oq-02/selection-report.md
@@ -1,0 +1,79 @@
+# Problem Selection Report
+
+**Date**: 2026-04-05
+**Mode**: SELECT
+**Pool Status**: 15 available, 533 in-progress, 1238 completed
+
+## Selected Problem
+
+- **ID**: vietas-formulas-oq-02
+- **Name**: Formalize multivariate analogues of Vieta's formulas
+- **Tier**: B
+- **Significance**: 6/10
+- **Tractability**: 7/10
+- **Knowledge Score**: 0 (EMPTY)
+- **Status**: available
+
+## Selection Rationale
+
+1. **Top composite score among unselected candidates**: Composite = 76 (EMPTY tier: 0 penalty + tractability×10=70 + significance=6). Higher-scoring problems (unit-distance-independence-oq-02 score 78, mean-value-theorem-oq-04 score 77, euler-identity-oq-01-oq-04 score 76, erdos-szekeres-oq-01 score 76) were all initialized in prior seeker runs on this branch or main.
+
+2. **EMPTY knowledge tier**: No prior research accumulated in this workspace — fresh territory for the Researcher to explore.
+
+3. **Domain diversity**: Algebra/polynomial theory, distinct from recent selections (burnside-counting: group theory/combinatorics; unit-distance: graph coloring; mean-value: analysis; lhopital: analysis). Avoids the combinatorics/analysis concentration of the last 4 selections.
+
+4. **Strong gallery infrastructure**: `VietasFormulas.lean` provides a fully verified base (0 sorries, 0 axioms, 179 lines) with `vieta_formula_quadratic` and `coeff_eq_esymm_roots_of_card`. The multivariate extension builds directly on `Mathlib.RingTheory.Polynomial.Vieta` and `Mathlib.RingTheory.MvPolynomial.Basic`.
+
+5. **Substantive mathematics**: Multivariate Vieta connects to several deep areas — resultants, discriminants, symmetric function theory in multiple variables, and the theory of algebraic varieties. The gallery's own open question list names this: "What are the analogous formulas for multivariate polynomials?"
+
+## Rejection Summary
+
+- **Candidates considered**: 15 available
+- **Candidates rejected**: 14
+  - unit-distance-independence-oq-02 (score 78): already initialized in seeker commit 83e3f74152 on this branch
+  - mean-value-theorem-oq-04 (score 77): already selected on main (#10163)
+  - euler-identity-oq-01-oq-04 (score 76): already initialized with selection-report.md today
+  - erdos-szekeres-oq-01 (score 76): already selected on main (#10161)
+  - taylor-theorem-oq-02 (score 76): tied with vietas-formulas-oq-02; vietas selected for stronger mathematical depth vs. Lean API exploration framing
+  - taylor-sincos-convergence-oq-01 (score 75): C-tier, analysis domain
+  - triangular-reciprocals-oq-02 (score 75): C-tier, analysis/number theory
+  - factor-remainder-nullstellensatz-oq-02 (score 67): lower score, combinatorics domain
+  - buffons-needle-oq-01-oq-04 (score 66): lower score, probability domain
+  - erdos-ko-rado-oq-04 (score 57): combinatorics domain (diversity penalty)
+  - brouwer-fixed-point-oq-04-oq-04 (score 56): lower score, topology domain
+  - szemeredi-theorem-oq-01 (score 48): sig=8 but tractability=4 (low tractability penalty)
+  - prime-gap-bounds-oq-03 (score -1923): MODERATE knowledge tier (93-line knowledge.md), large negative penalty
+  - wolstenholme-theorem-oq-03 (score -1934): MODERATE knowledge tier (45-line knowledge.md)
+- **Confidence**: medium (tight score cluster among EMPTY candidates; diversity filter was the tiebreaker)
+
+## Related Gallery Proofs
+
+- `vietas-formulas`: Direct parent — quadratic and degree-n univariate Vieta's formulas, fully verified (0 sorries, 0 axioms). Provides `vieta_formula_quadratic`, `coeff_eq_esymm_roots_of_card`.
+- `vietas-formulas-oq-03`: Extended Vieta work in gallery (OQ-03 direction)
+- `sum-of-kth-powers`: Closely related — Newton's identities connect power sums Σrᵢᵏ to elementary symmetric polynomials (exactly Vieta's relations)
+- `cayley-hamilton`: Trace and determinant as Vieta-type relations for characteristic polynomials
+- `fundamental-theorem-algebra`: Guarantees exactly n roots (with multiplicity) for degree-n polynomials
+
+## Suggested First Steps
+
+1. **OBSERVE**: Read `proofs/Proofs/VietasFormulas.lean` to understand the base infrastructure. Check what `Mathlib.RingTheory.MvPolynomial.Basic` and `Mathlib.RingTheory.Polynomial.Vieta` provide for multivariate symmetric functions (`MvPolynomial.esymm`, `MvPolynomial.esymmAlgEquiv`).
+
+2. **ORIENT**: Clarify the mathematical target — "multivariate analogues of Vieta's formulas" could mean: (a) Vieta's formulas for a polynomial in one variable over a polynomial ring (parametric family), (b) resultant-based relations between roots of two polynomials in two variables, or (c) symmetric polynomial identities in `MvPolynomial`. Scout `Mathlib4` for `MvPolynomial.esymm` and `MvPolynomial.IsSymmetric`.
+
+3. **DECIDE**: Target the most tractable interpretation: likely (a) or (c). The Newton identity generalization (`p_k = Σ e_j * p_{k-j}` for multiple variable sets) has Mathlib support and directly extends the gallery's `sum-of-kth-powers` connection. Formulate a concrete theorem statement before diving into tactics.
+
+## Pool Summary After Selection
+
+| Status | Count |
+|--------|-------|
+| Available | 15 |
+| In Progress | 533 |
+| Completed | 1238 |
+| Blocked | 2 |
+| **Total** | **1787** |
+
+## Candidate Pool Health
+
+- **Pool depth**: adequate (15 available problems, all with initialized workspaces)
+- **Recommendation**: Pool is healthy for now. If Researchers exhaust the 15 available candidates, trigger a replenishment run to add fresh problems from the gallery (currently ~1787 total, most in-progress).
+- **Next refresh recommended**: When available drops below 5

--- a/src/data/proofs/erdos-462/meta.json
+++ b/src/data/proofs/erdos-462/meta.json
@@ -23,7 +23,7 @@
     "erdosUrl": "https://erdosproblems.com/462",
     "erdosProblemStatus": "open",
     "dateAdded": "2026-01-15",
-    "dateUpdated": "2026-03-28",
+    "dateUpdated": "2026-04-05",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
       {
@@ -44,15 +44,16 @@
     ],
     "originalContributions": [
       "leastPrimeFactor definition via Nat.minFac with proved primality, divisibility, and minimality theorems",
-      "Separate compositeSum (filtering primes) and intervalSum (full interval) for distinct analytical roles",
+      "Separate compositeSum (filtering primes), intervalSum (full interval), and compositeIntervalSum (composites in interval) for distinct analytical roles",
       "Two-sided Θ-bound for compositeSum axiomatized with existential constants",
-      "Formal statement of ErdosProblem462 with Nat floor for the interval endpoint",
+      "Corrected ErdosProblem462 using compositeIntervalSum: original intervalSum included primes (p(n)/n = 1 each), making conjecture trivially true",
       "Basic properties: p(p) = p for primes, p(n) ≥ 2, p(n) ≤ √n for composites",
-      "Structural lemmas: p(n) ≤ n, p(n) = 2 for even n, p(n)/n ≤ 1, interval sum monotonicity/splitting/singleton"
+      "Structural lemmas: p(n) ≤ n, p(n) = 2 for even n, p(n)/n ≤ 1, interval sum monotonicity/splitting/singleton",
+      "compositeIntervalSum_eq_compositeSum_sub: connects interval sum to global sum difference, bridging axiom to conjecture"
     ],
     "axiomCount": 1,
     "assumptions": "1 axiom: compositeSum_asymptotic (deep analytic number theory: Θ(√x/(log x)²) two-sided bound for composite least-prime-factor sum, Alladi–Erdős 1977)",
-    "lineCount": 175
+    "lineCount": 259
   },
   "leanFile": {
     "path": "Proofs/Erdos462Problem.lean",
@@ -61,10 +62,10 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 175,
+    "lineCount": 259,
     "axiomCount": 1,
-    "theoremCount": 15,
-    "definitionCount": 4,
+    "theoremCount": 20,
+    "definitionCount": 5,
     "sorries": 0
   },
   "crossReferences": [
@@ -93,7 +94,7 @@
     "historicalContext": "This problem appears in Erdős and Graham's 1980 monograph 'Old and New Problems and Results in Combinatorial Number Theory' (p. 92). It concerns the distribution of the least prime factor function p(n) weighted by 1/n over short intervals.\n\nThe global asymptotic Σ_{n < x, n composite} p(n)/n ~ c · √x/(log x)² was established by Alladi and Erdős (1977) using the connection between p(n) and smooth number distribution. The key observation is that p(n) = q precisely when q is the smallest prime dividing n. Partial summation over the Dickman-de Bruijn ρ-function yields the √x/(log x)² growth rate.\n\nThe natural interval scale is √x(log x)²: since the global sum grows as √x/(log x)², dividing [1, x] into intervals of length √x(log x)² gives √x/(log x)² intervals, each capturing Θ(1) on average. The conjecture asks whether this average behavior holds uniformly.\n\nThis is analogous to the prime number theorem in short intervals: Huxley (1972) showed π(x+h) - π(x) ~ h/log x for h = x^{7/12}. Problem #462 asks a similar equidistribution question for the least prime factor sum, where the relevant scale is much larger (√x(log x)² vs x^θ), suggesting the problem may be more tractable.",
     "problemStatement": "Does there exist $C > 0$ such that $\\sum_{x \\leq n \\leq x + C\\sqrt{x}(\\log x)^2} p(n)/n \\gg 1$ for all large $x$?",
     "text": "Let $p(n)$ be the least prime factor of $n$. The sum $\\sum_{n < x,\\, n \\text{ composite}} p(n)/n \\sim c \\cdot \\sqrt{x}/(\\log x)^2$. Does a short interval of length $C\\sqrt{x}(\\log x)^2$ capture a bounded fraction of this sum?",
-    "proofStrategy": "The formalization defines leastPrimeFactor via Nat.minFac with sentinel 0 for n ≤ 1. Three properties are axiomatized: primality, divisibility, and minimality. Two sum functions serve distinct roles: compositeSum filters primes, while intervalSum sums over all integers. The known global asymptotic is axiomatized as a two-sided Θ-bound. The main conjecture ErdosProblem462 uses Nat floor ⌊·⌋₊ to convert the real endpoint to a natural number.",
+    "proofStrategy": "The formalization defines leastPrimeFactor via Nat.minFac with sentinel 0 for n ≤ 1. Three sum functions serve distinct roles: compositeSum accumulates over all composites up to x, intervalSum sums over all integers in an interval, and compositeIntervalSum restricts to composites in an interval. The key structural result compositeIntervalSum_eq_compositeSum_sub connects the short-interval composite sum to the cumulative sum difference, bridging the axiom to the conjecture. ErdosProblem462 uses compositeIntervalSum (not intervalSum) because primes contribute p(n)/n = 1 each, making the unrestricted sum trivially large.",
     "keyInsights": [
       "The global sum Σ p(n)/n over composites grows as √x/(log x)², so intervals of length √x(log x)² are the natural scale — each captures Θ(1) on average",
       "The conjecture asks whether every interval of the natural scale captures Ω(1) contribution, with no anomalously empty intervals",
@@ -126,8 +127,8 @@
       "id": "sums",
       "title": "Sums Involving Least Prime Factor",
       "startLine": 42,
-      "endLine": 54,
-      "summary": "compositeSum (filtering primes) and intervalSum (full interval)"
+      "endLine": 62,
+      "summary": "compositeSum (filtering primes), intervalSum (full interval), and compositeIntervalSum (composites in interval)"
     },
     {
       "id": "asymptotics",
@@ -153,9 +154,16 @@
     {
       "id": "structural-properties",
       "title": "Additional Structural Properties",
-      "startLine": 130,
-      "endLine": 175,
+      "startLine": 143,
+      "endLine": 191,
       "summary": "p(n) ≤ n, p(n) = 2 for even n, p(n)/n ≤ 1 bound, interval sum monotonicity, singleton evaluation, and interval splitting — all proved from Mathlib"
+    },
+    {
+      "id": "composite-interval-properties",
+      "title": "Composite Interval Sum Properties",
+      "startLine": 192,
+      "endLine": 259,
+      "summary": "compositeIntervalSum: non-negativity, comparison with intervalSum, monotonicity, splitting, and the key bridge compositeIntervalSum_eq_compositeSum_sub connecting the short interval sum to the global cumulative sum difference — all proved from Mathlib"
     }
   ],
   "conclusion": {

--- a/src/data/research/problems/erdos-1040-oq-05.json
+++ b/src/data/research/problems/erdos-1040-oq-05.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SORRY ELIMINATION: Proved nthDiameter_eq_zero_of_finite via pigeonhole (3→2 sorries)",
+    "progressSummary": "FALSE THEOREM FIXED: transfiniteDiameter_scale removed (counterexample documented). Proved nthDiameter_bddAbove_of_bounded. Main file: 0S (was 1 false sorry). Aristotle: 1S (was 3). 4A unchanged.",
     "builtItems": [
       "Proved mu_mono: anti-monotonicity of μ (F ⊆ G → mu G ≤ mu F) via iInf_mono in Erdos1040Problem.lean:209-215",
       "Removed problem_open axiom (8→7 axioms): was ¬(P ∨ ¬P), inconsistent with classical logic",
@@ -57,7 +57,12 @@
       "Proved lineSegment_determined trivially (axiom→theorem): ⟨fun _ => muPosDeg F, rfl⟩",
       "Proved disc_determined trivially (axiom→theorem): same pattern",
       "Proved muPosDeg_pos_of_small_diameter via small_diameter_disc + Complex.volume_ball + Metric.ball_subset_ball",
-      "nthDiameter_eq_zero_of_finite: proved via pigeonhole + Finset.prod_eq_zero + zero_rpow (was sorry)"
+      "nthDiameter_eq_zero_of_finite: proved via pigeonhole + Finset.prod_eq_zero + zero_rpow (was sorry)",
+      {
+        "name": "nthDiameter_bddAbove_of_bounded",
+        "type": "theorem",
+        "description": "BddAbove for nthDiameter value set when G bounded (Aristotle file)"
+      }
     ],
     "insights": [
       "The problem_open axiom (¬(P ∨ ¬P)) was inconsistent — it negates classical excluded middle. Removed to fix axiom system.",
@@ -84,12 +89,16 @@
       "Remaining 2 sorries: BddAbove for monotonicity (line 297), transfiniteDiameter_scale (line 400)",
       "7 axioms remain — all are deep published results (transfinite diameter theory, EHP 1958, Erdős-Netanyahu 1973)",
       "BddAbove sorry (line 284): extract D from IsBounded G, bound each distance factor by D, product by D^(n*(n-1)/2), then rpow with e<=1 gives bound max(D^(n*(n-1)/2), 1). Needs Metric.isBounded API.",
-      "transfiniteDiameter_scale sorry (line 387): FALSE for n<=1 (rpow exponent 2/0=0 gives 1, not |c|*1). Proof strategy: show nthDiameter(cF, n) = |c| * nthDiameter(F, n) for n>=2, then pull |c| from iInf over n>=2 (n=0,1 dont affect inf since they equal 1)."
+      "transfiniteDiameter_scale sorry (line 387): FALSE for n<=1 (rpow exponent 2/0=0 gives 1, not |c|*1). Proof strategy: show nthDiameter(cF, n) = |c| * nthDiameter(F, n) for n>=2, then pull |c| from iInf over n>=2 (n=0,1 dont affect inf since they equal 1).",
+      "CRITICAL: transfiniteDiameter_scale is FALSE with inf-over-all-n definition. nthDiameter F 0 = nthDiameter F 1 = 1 (empty product, rpow 2/0=0). Clamps inf at 1. Counterexample: disc radius 2, c=1/2.",
+      "nthDiameter_scale also FALSE for n≤1 by same mechanism. Must require n≥2.",
+      "nthDiameter_bddAbove_of_bounded proved: diam G bounds each factor, product ≤ (diam G+1)^(n²), rpow case analysis for n≤1 vs n≥2"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "BddAbove sorry: use Metric.isBounded_iff.mp hG to extract diameter D, bound Finset product by D^(n choose 2), rpow mono for exponent in [0,1]",
-      "transfiniteDiameter_scale: prove nthDiameter_scale for n>=2 via Complex.abs_mul + Finset.prod scaling + rpow_mul, then use iInf on n>=2"
+      "Fix transfiniteDiameter definition to use ⨅ n ≥ 2 or Filter.liminf (transfiniteDiameter')",
+      "Prove nthDiameter_scale for n ≥ 2 (Aristotle file, 1 remaining sorry)",
+      "Pre-existing Mathlib compilation errors still need mechanic repair"
     ]
   },
   "tags": [

--- a/src/data/research/problems/erdos-462.json
+++ b/src/data/research/problems/erdos-462.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Added 6 structural lemmas (15T total). 1 deep axiom remains (compositeSum_asymptotic).",
+    "progressSummary": "PROGRESS: Fixed formalization bug in ErdosProblem462 (was trivially true via primes). Added compositeIntervalSum + 5 structural theorems (20T total). 1 deep axiom remains.",
     "builtItems": [
       "Proved leastPrimeFactor_prime via Nat.minFac_prime",
       "Proved leastPrimeFactor_dvd via Nat.minFac_dvd",
@@ -45,14 +45,22 @@
       "leastPrimeFactor_div_le_one: p(n)/n ≤ 1 for n ≥ 2",
       "intervalSum_mono: enlarging interval increases sum",
       "intervalSum_singleton: singleton interval evaluation",
-      "intervalSum_split: splitting interval sum at a midpoint"
+      "intervalSum_split: splitting interval sum at a midpoint",
+      "compositeIntervalSum: sum of p(n)/n over composites in [a,b] (corrected domain for ErdosProblem462)",
+      "compositeIntervalSum_nonneg: proved non-negativity",
+      "compositeIntervalSum_le_intervalSum: composite sum ≤ full sum",
+      "compositeIntervalSum_mono: monotonicity under interval enlargement",
+      "compositeIntervalSum_split: interval decomposition at midpoint",
+      "compositeIntervalSum_eq_compositeSum_sub: key bridge from interval to cumulative sum"
     ],
     "insights": [
       "All minFac axioms follow trivially from Mathlib: unfold leastPrimeFactor, simp away the ≤1 guard, then apply the Nat.minFac lemma",
       "sqrt proof: minFac²≤n (Nat.minFac_sq_le_self) → sqrt(minFac²)≤sqrt(n) (Real.sqrt_le_sqrt) → minFac≤sqrt(n) (Real.sqrt_sq)",
       "leastPrimeFactor_le_self follows from divisibility: p(n) | n implies p(n) ≤ n",
       "leastPrimeFactor_even: squeeze between ge_two and le(2,prime_two,heven)",
-      "intervalSum_split via Finset.sum_union + Icc decomposition at midpoint"
+      "intervalSum_split via Finset.sum_union + Icc decomposition at midpoint",
+      "CRITICAL BUG FIXED: ErdosProblem462 was using intervalSum (all integers), which includes primes where p(n)/n = 1. By PNT, ~C√x·log(x) primes in the interval make the unrestricted sum trivially → ∞. Corrected to compositeIntervalSum.",
+      "compositeIntervalSum_eq_compositeSum_sub bridges the interval conjecture to the global asymptotic: short interval composite sum = compositeSum(b+1) - compositeSum(a)"
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -81,10 +89,10 @@
     {
       "path": "Proofs/Erdos462Problem.lean",
       "filename": "Erdos462Problem.lean",
-      "lineCount": 175,
-      "theoremCount": 15,
+      "lineCount": 259,
+      "theoremCount": 20,
       "axiomCount": 1,
-      "defCount": 4,
+      "defCount": 5,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos462Problem.lean"


### PR DESCRIPTION
## Summary

### erdos-462: Fix formalization bug
- `ErdosProblem462` used `intervalSum` (all integers), trivially true. Fixed to `compositeIntervalSum`.
- Added 5 structural theorems + bridge `compositeIntervalSum_eq_compositeSum_sub`

### erdos-1040-oq-05: Fix false theorem + prove BddAbove
- `transfiniteDiameter_scale` was FALSE (inf-over-all-n clamps at 1). Documented.
- Proved `nthDiameter_bddAbove_of_bounded` in Aristotle file

### unit-distance-independence-oq-02: Hadwiger-Nelson 7-coloring
- New `UnitDistanceHN7.lean`: hex coloring proof structure, 3 geometric sorries
- Would eliminate `hadwiger_nelson_upper_bound` axiom from parent

### bertrands-postulate-oq-04: Proved limit algebra
- Eliminated both sorries in `long_interval_density_from_pnt`
- Tendsto.mul for PNT×log-ratio, Tendsto.sub for linear combination
- File now 0 sorries (was 2), 1 axiom (RH-conditional)

## Test plan
- [ ] `./proofs/scripts/docker-build.sh Proofs.Erdos462Problem`
- [ ] `./proofs/scripts/docker-build.sh Proofs.BertrandsPostulateOQ03OQ04`
- [ ] `./proofs/scripts/docker-build.sh Proofs.UnitDistanceHN7`

🤖 Generated by researcher-7