### PR TITLE
fix: add Aristotle companion for Erdos1000OQ01 (factorial sum sorries)

### DIFF
--- a/proofs/Proofs/Erdos1000OQ01Aristotle.lean
+++ b/proofs/Proofs/Erdos1000OQ01Aristotle.lean
@@ -1,0 +1,48 @@
+/-
+  Aristotle targets for Erdős Problem #1000 OQ-01: Explicit Haight-type Sequences
+  Routine supporting lemmas for automated proof search.
+  See Erdos1000OQ01.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open question (characterization of Haight-type sequences)
+  - Routine factorial arithmetic: Σ (j+1)! < 2·k! for k ≥ 2
+  - Clean theorem statements with no definition sorries
+  - No axioms
+
+  Sorries targeted:
+  - sum_factorials_lt: (range k).sum (fun j => (j+1)!) < 2 * k! for k ≥ 2
+    Strategy: induction on k ≥ 2; base case norm_num; inductive step uses
+    Finset.sum_range_succ + Nat.factorial_succ + linarith.
+  - sum_factorials_pos: 0 < (range k).sum (fun j => (j+1)!) for k ≥ 1
+    Strategy: Finset.sum_pos + Nat.factorial_pos.
+-/
+import Mathlib
+
+open Finset Nat
+
+namespace Erdos1000OQ01Aristotle
+
+/-- Routine: Σ_{j=0}^{k-1} (j+1)! < 2 · k! for k ≥ 2.
+    The k! term dominates: all prior terms sum to less than k!.
+    Strategy: induction; base k=2 gives 1!+2!=3 < 2·2!=4 by norm_num;
+    inductive step: sum + (k+1)! < 2·k! + (k+1)·k! = (k+3)·k! < 2·(k+1)·k! = 2·(k+1)!
+    for k ≥ 2 since k+3 < 2k+2 iff k > 1. -/
+theorem sum_factorials_lt (k : ℕ) (hk : 2 ≤ k) :
+    (range k).sum (fun j => (j + 1).factorial) < 2 * k.factorial := by
+  sorry
+
+/-- Routine: The factorial sum is positive for k ≥ 1.
+    Each (j+1)! ≥ 1 and there is at least one term in the range.
+    Strategy: Finset.sum_pos with Nat.factorial_pos. -/
+theorem sum_factorials_pos (k : ℕ) (hk : 0 < k) :
+    0 < (range k).sum (fun j => (j + 1).factorial) := by
+  sorry
+
+/-- Routine: (range k).sum (fun j => (j+1)!) ≥ k for k ≥ 1.
+    Each term (j+1)! ≥ 1, and there are k terms.
+    Strategy: induction or Finset.sum_le_sum with le_factorial. -/
+theorem sum_factorials_ge_card (k : ℕ) :
+    k ≤ (range k).sum (fun j => (j + 1).factorial) := by
+  sorry
+
+end Erdos1000OQ01Aristotle


### PR DESCRIPTION
## Fix

Adds `Erdos1000OQ01Aristotle.lean` with 3 routine targets for Aristotle automated proof search.

## Evidence

**Before**: `Erdos1000OQ01.lean` has 2 code-level sorries blocking the proof that the factorial sequence is not Haight-type:
- `sum_factorials_lt`: Σ_{j<k} (j+1)! < 2·k! for k ≥ 2
- `factorialSeq_usedSum_le`: usedSum bounded by Σ (j+1)!

**After**: Companion exposes 3 routine inductive targets:
- `sum_factorials_lt`: direct induction target — base k=2 gives 1!+2!=3<4; inductive step via `Finset.sum_range_succ` + `Nat.factorial_succ` + linarith
- `sum_factorials_pos`: positivity via `Finset.sum_pos` + `Nat.factorial_pos`
- `sum_factorials_ge_card`: lower bound via term count, each factorial ≥ 1

Pre-submission checklist:
- [x] No `def ... := sorry` (definition sorries)
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections
- [x] No open conjectures

---
Automated fix by lean-mechanic agent.