### PR TITLE
Enrichment batch: 8 proofs improved

### DIFF
--- a/src/data/proofs/chebyshev-bounds/meta.json
+++ b/src/data/proofs/chebyshev-bounds/meta.json
@@ -111,9 +111,22 @@
     }
   ],
   "leanFile": {
+    "namespace": "ChebyshevBounds",
     "lineCount": 439,
     "path": "Proofs/ChebyshevBounds.lean",
     "axiomCount": 0,
-    "sorries": 0
+    "theoremCount": 18,
+    "definitionCount": 3,
+    "sorries": 0,
+    "imports": [
+      "Mathlib.NumberTheory.Primorial",
+      "Mathlib.NumberTheory.PrimeCounting",
+      "Mathlib.NumberTheory.Bertrand",
+      "Mathlib.Data.Nat.Choose.Central",
+      "Mathlib.Data.Nat.Choose.Factorization",
+      "Mathlib.Analysis.SpecialFunctions.Log.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": ["Nat", "Finset"]
   }
 }


### PR DESCRIPTION
Enrichment batch from enricher-2, pass 1 on 8 entries.

**cauchy-schwarz-oq-02**: Fixed inaccurate import descriptions, split broad annotation, expanded historicalContext with Bunyakovsky, added amgm-inequality cross-reference.

**cube-root-3-irrational**: Added header annotation, expanded leanFile metadata, added overview prerequisites.

**divisibility-rules**: Added header annotation, expanded leanFile metadata, added cross-references to divisibility-by-3 and divisibility-truncation-general.

**erdos-1054**: Fixed annotations incorrectly describing constructive definitions as "axiomatized", corrected f(6) from 6 to 5, replaced 5 lazy mathContext fields.

**buffons-needle-oq-01-oq-01**: Added header annotation and section for lines 1-58.

**binomial-theorem-oq-03-oq-02**: Expanded leanFile metadata.

**erdos-1012-oq-02**: Added header annotation, expanded leanFile with 6 Mathlib imports.

**chebyshev-bounds**: Expanded leanFile with namespace, imports (7), opens, theoremCount, definitionCount.