### PR TITLE
fix: add Aristotle companion for Erdos512Problem (Littlewood L1 bound)

### DIFF
--- a/proofs/Proofs/Erdos512Aristotle.lean
+++ b/proofs/Proofs/Erdos512Aristotle.lean
@@ -1,0 +1,59 @@
+/-
+  Aristotle targets for Erdos512Problem (Littlewood's Conjecture on Exponential Sums)
+  Routine integration bound lemmas for automated proof search.
+  See Erdos512Problem.lean for the main formalization.
+
+  Two sorries remain in the main file:
+  1. `L1norm_upper_bound` (line 104): ∫₀¹ |∑_{n∈A} e(nθ)| dθ ≤ |A|
+  2. `L2_norm` (line 167): ∫₀¹ |∑_{n∈A} e(nθ)|² dθ = |A|
+
+  TARGET 1 is most tractable.
+  TARGET 2 (Parseval) is harder and left as secondary target.
+
+  Proof strategy for `L1norm_upper_bound`:
+    `expSum_bound` is already proved: ∀ θ, expSumNorm A θ ≤ A.card.
+    1. Continuity: expSumNorm A is continuous (finite sum of continuous functions
+       composed with Complex.abs). Uses: Complex.continuous_abs, continuous_finset_sum.
+    2. Integrability: ContinuousOn.integrableOn_Icc on [0,1].
+    3. Integral bound: setIntegral_mono_on + expSum_bound as pointwise bound.
+    4. Constant integral: ∫₀¹ A.card dθ = A.card (volume [0,1] = 1).
+       Uses: setIntegral_const, Real.volume_Icc, smul_eq_mul.
+-/
+import Mathlib
+import Proofs.Erdos512Problem
+
+open Real Complex MeasureTheory MeasureTheory.Measure Erdos512
+
+namespace Erdos512Aristotle
+
+/-
+TARGET 1 (most tractable)
+Continuity of the exponential sum modulus.
+
+expTwoPiI (n * θ) is continuous in θ for each n.
+The sum over the finite set A is a finite sum of continuous functions.
+Complex.abs is continuous. So the composition is continuous.
+
+Uses: Complex.continuous_abs, Continuous.comp, continuous_finset_sum,
+      Complex.continuous_exp, Continuous.mul_const, continuous_ofReal
+-/
+theorem expSumNorm_continuous (A : Finset ℤ) : Continuous (expSumNorm A) := by
+  sorry
+
+/-
+TARGET 2 (depends on Target 1)
+L1 norm upper bound: ∫₀¹ expSumNorm A θ dθ ≤ A.card.
+
+Strategy:
+  1. hcont := expSumNorm_continuous A
+  2. hbdd : ∀ θ ∈ Icc 0 1, expSumNorm A θ ≤ A.card  -- from expSum_bound
+  3. hint : IntegrableOn (expSumNorm A) (Icc 0 1)    -- from continuity
+  4. hcint : IntegrableOn (fun _ => A.card) (Icc 0 1) -- integrableOn_const
+  5. setIntegral_mono_on hint hcint measurableSet_Icc hbdd
+  6. setIntegral_const + smul_eq_mul + Real.volume_Icc → = A.card
+-/
+theorem L1norm_le_card (A : Finset ℤ) :
+    ∫ θ in Set.Icc (0 : ℝ) 1, expSumNorm A θ ≤ A.card := by
+  sorry
+
+end Erdos512Aristotle


### PR DESCRIPTION
## Fix

Add `Erdos512Aristotle.lean` Aristotle companion for the 2 remaining sorries in `Erdos512Problem.lean` (Littlewood's conjecture on exponential sums).

## Targets

**Target 1** (`expSumNorm_continuous`): `Continuous (expSumNorm A)`
- `expTwoPiI (n * θ)` is continuous in θ for each n
- Finite sum of continuous functions composed with `Complex.abs`
- Uses: `Complex.continuous_abs`, `continuous_finset_sum`, `Complex.continuous_exp`

**Target 2** (`L1norm_le_card`): `∫ θ in Icc 0 1, expSumNorm A θ ≤ A.card`
- `expSum_bound` (already proved in main file) gives the pointwise bound
- Continuity → integrability on [0,1]
- `setIntegral_mono_on` + `setIntegral_const` + `Real.volume_Icc`

## Evidence

**Before**: `L1norm_upper_bound` and `L2_norm` both sorry in main file; no companion
**After**: 2 tractable stepping-stone lemmas exposed for Aristotle proof search

---
Automated fix by lean-mechanic agent.