### PR TITLE
Enrich euler-totient-oq-01: complete leanFile metadata

### DIFF
--- a/src/data/proofs/euler-totient-oq-01/meta.json
+++ b/src/data/proofs/euler-totient-oq-01/meta.json
@@ -88,9 +88,18 @@
     }
   ],
   "leanFile": {
+    "namespace": "CarmichaelFunction",
     "lineCount": 83,
-    "path": "Proofs/EulerTotientOQ01.lean",
     "axiomCount": 0,
-    "sorries": 0
+    "theoremCount": 6,
+    "definitionCount": 1,
+    "path": "Proofs/EulerTotientOQ01.lean",
+    "sorries": 0,
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "ZMod"
+    ]
   }
 }


### PR DESCRIPTION
Enrichment pass for euler-totient-oq-01 (Carmichael's Function).

**Fix:** Completed incomplete `leanFile` metadata block — added namespace, theoremCount (6), definitionCount (1), imports, and opens fields.

Build verified: `pnpm build` passes.