### PR TITLE
Enrich batch: 8 gallery entries (enricher-2)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-03/meta.json
@@ -59,7 +59,7 @@
       "title": "Arithmetic and Harmonic Mean Instances",
       "startLine": 46,
       "endLine": 57,
-      "summary": "Two concrete theorems for pairs of positive reals: `powerMean_1_is_am` proves $M_1(a,b) = (a+b)/2$ (arithmetic mean), and `powerMean_neg1_is_hm` proves $M_{-1}(a,b) = 2ab/(a+b)$ (harmonic mean). Both have remaining sorries for finset normalization steps."
+      "summary": "Two concrete theorems for pairs of positive reals: `powerMean_1_is_am` proves $M_1(a,b) = (a+b)/2$ (arithmetic mean), and `powerMean_neg1_is_hm` proves $M_{-1}(a,b) = 2ab/(a+b)$ (harmonic mean). Both fully proved with 0 sorries."
     }
   ],
   "conclusion": {
@@ -128,11 +128,18 @@
     }
   ],
   "leanFile": {
+    "namespace": "AmgmOQ03OQ03",
     "axiomCount": 0,
     "lineCount": 65,
     "path": "Proofs/AmgmInequalityOQ03OQ03.lean",
     "sorries": 0,
     "theoremCount": 2,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset"
+    ]
   }
 }


### PR DESCRIPTION
Batch enrichment from enricher-2. All entries pass `pnpm build`. 8 entries enriched.

| Entry | Quality | Key Improvements |
|-------|---------|------------------|
| cauchy-schwarz-oq-02 | 97 | Fixed 3 incorrect import names, deepened historicalContext |
| taylor-sincos-convergence-oq-01 | 27 | **Complete rewrite** — wrong annotation schema, added sections/leanFile/openQuestions |
| abel-ruffini-oq-04-oq-02 | 98 | Full section coverage (was 32-120, now 1-154), 2 new annotations |
| amgm-inequality-oq-02-oq-03 | 98 | Added imports section, fixed `axioms: 0` vs `axiomCount: 2` conflict |
| angle-trisection-cos-20-gal-oq-01 | 98 | Added `leanFile` block, imports section |
| area-of-circle-oq-02 | 98 | Added imports section, completed leanFile with imports/opens |
| arithmetic-series-oq-02-oq-01-oq-01 | 98 | **Fixed stale annotation** claiming 2 sorries (file has 0), fixed cross-ref format |
| amgm-inequality-oq-03-oq-03 | 98 | Fixed stale sorry reference in section, completed leanFile |

**Common patterns fixed:**
- Missing section coverage for docstring/imports
- Missing `imports`/`opens`/`namespace` in `leanFile` blocks  
- Stale annotations not matching current Lean file state (sorry claims when file has 0 sorries)
- Non-standard cross-reference format (`id` instead of `targetId`)
- Factually incorrect import descriptions in annotations