### PR TITLE
fix: correct erdos-1040 meta.json sorry/line counts

### DIFF
--- a/src/data/proofs/erdos-1040/meta.json
+++ b/src/data/proofs/erdos-1040/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 1040,
     "erdosUrl": "https://erdosproblems.com/1040",
     "erdosProblemStatus": "open",
@@ -25,14 +25,14 @@
       1039
     ],
     "axiomCount": 4,
-    "assumptions": "4 axiom declarations: disc_diameter (disc capacity = radius), small_diameter_disc (qualitative disc containment for ρ < 1), lineSegment_muPosDeg_zero (EHP 1958 line segment case), disc_muPosDeg_zero (EHP 1958 disc case). 1 sorry in transfiniteDiameter_scale (scaling property). Previously axiomatized transfiniteDiameter_eq, lineSegment_diameter, erdos_netanyahu, lineSegment_determined, disc_determined were removed or proved.",
+    "assumptions": "4 axiom declarations: disc_diameter (disc capacity = radius), small_diameter_disc (qualitative disc containment for ρ < 1), lineSegment_muPosDeg_zero (EHP 1958 line segment case), disc_muPosDeg_zero (EHP 1958 disc case). 0 sorries (transfiniteDiameter_scale was commented out).",
     "prerequisites": [
       "Complex analysis: polynomial lemniscates and sublevel sets",
       "Potential theory: transfinite diameter and logarithmic capacity",
       "Measure theory: Lebesgue measure in the complex plane",
       "Approximation theory: Chebyshev polynomials and extremal polynomials"
     ],
-    "lineCount": 620,
+    "lineCount": 640,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -122,7 +122,7 @@
     {
       "id": "diameter-properties",
       "title": "Properties of Transfinite Diameter",
-      "summary": "Structural theorems for $\\rho$: monotonicity (sorry), non-negativity (PROVED), finite sets $\\rho = 0$ (sorry), and scaling (sorry). Non-negativity proved via nthDiameter_nonneg and le_csInf.",
+      "summary": "Structural theorems for $\\rho$: non-negativity (PROVED). Monotonicity, finite set degeneracy, and scaling are commented out. Non-negativity proved via nthDiameter_nonneg and le_csInf.",
       "startLine": 179,
       "endLine": 203,
       "mathContext": "$F \\subseteq G \\implies \\rho(F) \\leq \\rho(G)$; $\\rho(F) \\geq 0$; $|F| < \\infty \\implies \\rho(F) = 0$; $\\rho(cF) = |c|\\rho(F)$."
@@ -145,7 +145,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #1040 formalizes one of the fundamental open questions in the geometry of polynomial lemniscates: whether the infimum $\\mu(F)$ of sublevel set measures is determined by the transfinite diameter $\\rho(F)$. The Lean formalization builds a complete framework from the $n$-th diameter and Fekete point theory through to the two forms of the conjecture, axiomatizing the known results of EHP (1958) and the Erdős-Netanyahu (1973) quantitative bounds. 4 axiom declarations (disc capacity, disc containment, EHP known cases). 1 sorry remains in transfiniteDiameter_scale (scaling property of $\\rho$).",
+    "summary": "Erdős Problem #1040 formalizes one of the fundamental open questions in the geometry of polynomial lemniscates: whether the infimum $\\mu(F)$ of sublevel set measures is determined by the transfinite diameter $\\rho(F)$. The Lean formalization builds a complete framework from the $n$-th diameter and Fekete point theory through to the two forms of the conjecture, axiomatizing the known results of EHP (1958) and the Erdős-Netanyahu (1973) quantitative bounds. 4 axiom declarations (disc capacity, disc containment, EHP known cases). 0 sorries.",
     "implications": "1. **Potential Theory and Polynomial Geometry**: A positive resolution would establish that logarithmic capacity completely controls the measure-theoretic behavior of polynomial lemniscates, unifying capacity theory with the geometry of sublevel sets\n\n2. **Extremal Polynomial Theory**: Understanding $\\mu(F)$ requires identifying near-optimal polynomials for general sets, extending the role of Chebyshev polynomials (for intervals) and power functions (for discs) to arbitrary compact sets\n\n**3. Conformal Invariance**: Since $\\rho(F)$ is related to the conformal mapping radius of $\\mathbb{C} \\setminus F$, a positive answer would connect sublevel set area to conformal geometry\n\n4. **Connection to Problem #1039**: Problems 1039 and 1040 together ask about the inner structure (inscribed disc) and total size (area) of lemniscates — two complementary aspects of the same geometric question\n\n5. **Approximation Theory**: The problem has implications for polynomial approximation on compact sets, as sublevel set size controls the rate of polynomial convergence.",
     "openQuestions": [
       "Is $\\mu(F) = 0$ when $\\rho(F) \\geq 1$ for general closed infinite sets? (The main conjecture, open since 1958)",
@@ -230,13 +230,13 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 620,
+    "lineCount": 640,
     "axiomCount": 4,
     "theoremCount": 23,
     "substantiveTheoremCount": 19,
     "trivialSpecializations": 0,
     "definitionCount": 19,
     "path": "Proofs/Erdos1040Problem.lean",
-    "sorries": 1
+    "sorries": 0
   }
 }


### PR DESCRIPTION
## Summary
- Fixed sorry count: 1 → 0 (the `transfiniteDiameter_scale` sorry was commented out)
- Fixed line count: 620 → 640 (file grew since last audit)
- Updated assumptions text and conclusion to reflect 0 sorries

## Test plan
- [ ] Verify `pnpm build` passes
- [ ] Confirm auditor tracker clears the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)