### PR TITLE
fix: add Aristotle companion for CentralLimitTheoremOQ03OQ01

### DIFF
--- a/proofs/Proofs/CentralLimitTheoremOQ03OQ01Aristotle.lean
+++ b/proofs/Proofs/CentralLimitTheoremOQ03OQ01Aristotle.lean
@@ -1,0 +1,84 @@
+/-
+  Aristotle targets for CentralLimitTheoremOQ03OQ01 (Gaussian domain of attraction)
+  Routine lemmas for automated proof search.
+  See CentralLimitTheoremOQ03OQ01.lean for the main formalization.
+
+  The 1 sorry in the main file is in `gaussian_family_in_domain`, which proves
+  that exp(-c·t²) (a Gaussian characteristic function) lies in the domain of
+  the standard Gaussian attractor.
+
+  After `simp only [Complex.ofReal_neg, Complex.ofReal_mul]`, the goal is:
+    Filter.Tendsto
+      (fun n => (Complex.exp (↑(-(c * (t / √(c*n))²)))) ^ n)
+      Filter.atTop (nhds (Complex.exp (↑(-t²))))
+
+  Proof strategy:
+
+  KEY INSIGHT: The sequence is eventually constant.
+  For n ≥ 1 with c > 0:
+    c * (t / √(c·n))² = c · t²/(c·n) = t²/n
+  So:
+    (exp(-(t²/n)))^n = exp(n · (-(t²/n))) = exp(-t²)    [by Complex.exp_nat_mul]
+  The sequence equals exp(-t²) for ALL n ≥ 1, so tendsto_const_nhds applies.
+
+  Targets:
+  1. `exp_exponent_eq`: c * (t / √(c·n))² = t²/n  (algebra, field_simp + ring)
+  2. `gaussian_exp_pow_eq`: (exp(-(c*(t/√(cn))²)))^n = exp(-t²)  (exp_nat_mul + 1)
+  3. `gaussian_tendsto`: Tendsto (fun n => ...) atTop (nhds (exp(-t²)))  (const + congr')
+-/
+import Mathlib
+import Proofs.CentralLimitTheoremOQ03OQ01
+
+open Real Complex Filter CentralLimitTheoremOQ03OQ01
+
+namespace CentralLimitTheoremOQ03OQ01Aristotle
+
+/-
+TARGET 1 (most tractable: pure algebra)
+The exponent simplifies: c * (t / √(c*n))² = t²/n for c > 0, n ≥ 1.
+
+Strategy:
+  have hsqrt : Real.sqrt (c * n) ^ 2 = c * n := Real.sq_sqrt (by positivity)
+  field_simp [hsqrt, (show (n : ℝ) ≠ 0 from Nat.cast_ne_zero.mpr (Nat.one_le_iff_ne_zero.mp hn))]
+  ring
+-/
+theorem exp_exponent_eq (c t : ℝ) (hc : 0 < c) (n : ℕ) (hn : 1 ≤ n) :
+    c * (t / Real.sqrt (c * (n : ℝ))) ^ 2 = t ^ 2 / (n : ℝ) := by
+  sorry
+
+/-
+TARGET 2
+The n-th power of the characteristic function equals exp(-t²) for n ≥ 1, c > 0.
+
+(Complex.exp (↑(-(c * (t / √(c·n))²))))^n = Complex.exp (↑(-t²))
+
+Strategy:
+  rw [← Complex.exp_nat_mul]
+  congr 1
+  push_cast
+  rw [show c * (t / Real.sqrt (c * (n : ℝ))) ^ 2 = t ^ 2 / n from exp_exponent_eq c t hc n hn]
+  field_simp
+  ring
+-/
+theorem gaussian_exp_pow_eq (c t : ℝ) (hc : 0 < c) (n : ℕ) (hn : 1 ≤ n) :
+    (Complex.exp (↑(-(c * (t / Real.sqrt (c * (n : ℝ))) ^ 2)))) ^ n =
+    Complex.exp (↑(-(t ^ 2 : ℝ))) := by
+  sorry
+
+/-
+TARGET 3 (main target, depends on 2)
+The Tendsto conclusion: the sequence is eventually constant at exp(-t²).
+
+Strategy:
+  apply Filter.Tendsto.congr' tendsto_const_nhds
+  apply Filter.eventually_atTop.mpr
+  exact ⟨1, fun n hn => (gaussian_exp_pow_eq c t hc n hn).symm⟩
+-/
+theorem gaussian_tendsto (c t : ℝ) (hc : 0 < c) :
+    Filter.Tendsto
+      (fun n : ℕ => (Complex.exp (↑(-(c * (t / Real.sqrt (c * (n : ℝ))) ^ 2)))) ^ n)
+      Filter.atTop
+      (nhds (Complex.exp (↑(-(t ^ 2 : ℝ))))) := by
+  sorry
+
+end CentralLimitTheoremOQ03OQ01Aristotle


### PR DESCRIPTION
## Fix

Adds Aristotle companion file for the `gaussian_family_in_domain` sorry in `CentralLimitTheoremOQ03OQ01.lean`.

## Evidence

**Before**: `gaussian_family_in_domain` has 1 sorry (after `simp only [Complex.ofReal_neg, Complex.ofReal_mul]`) with no companion file.

**After**: Three targeted lemmas expose the tractable algebraic steps for Aristotle:
1. `exp_exponent_eq`: `c * (t / √(c·n))² = t²/n` — pure algebra via `field_simp + ring`
2. `gaussian_exp_pow_eq`: the n-th power equality via `Complex.exp_nat_mul` + target 1
3. `gaussian_tendsto`: `Tendsto ... atTop (nhds (exp(-t²)))` via `tendsto_const_nhds` + eventually-constant argument

**Key insight**: The sequence `(exp(-c*(t/√(cn))²))^n` equals `exp(-t²)` for ALL `n ≥ 1` (constant!), so `tendsto_const_nhds` applies via `Filter.Tendsto.congr'` with `Filter.eventually_atTop`.

---
Automated fix by lean-mechanic agent.