### PR TITLE
fix: audit taylor-sincos-convergence-oq-01 meta.json badge and counts

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12011,6 +12011,12 @@
       "lastAudited": "2026-04-06T00:33:16Z",
       "result": "clean",
       "issues": []
+    },
+    "taylor-sincos-convergence-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-06T04:54:49Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {

--- a/src/data/proofs/taylor-sincos-convergence-oq-01/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-01/meta.json
@@ -19,10 +19,10 @@
       "axiom-free"
     ],
     "proofRepoPath": "Proofs/TaylorSinCosConvergenceOQ01.lean",
-    "badge": "verified",
+    "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "None. This file has 0 axioms and 0 sorries. All results follow from Mathlib's taylor_mean_remainder_bound and the contDiff properties of sin and cos.",
+    "assumptions": "Core remainder bounds derived from Mathlib's taylor_mean_remainder_bound. 0 axioms, 0 sorries. Original contributions: parity lemmas, symmetry proofs, and connection of custom partial sums to Mathlib's taylorWithinEval.",
     "originalContributions": [
       "Proof of iteratedDeriv_sin_zero_even: all even-order derivatives of sin vanish at 0",
       "Proof of iteratedDeriv_cos_zero_odd: all odd-order derivatives of cos vanish at 0",
@@ -34,8 +34,8 @@
       "cos_taylor_remainder_bound': eliminates axiom, proved via taylor_mean_remainder_bound"
     ],
     "dateAdded": "2026-04-05",
-    "lineCount": 240,
-    "theoremCount": 10,
+    "lineCount": 238,
+    "theoremCount": 11,
     "definitionCount": 0,
     "mathlib_version": "4.26.0"
   },


### PR DESCRIPTION
## Summary

- **Badge**: `verified` → `mathlib` — core remainder bounds derived from Mathlib's `taylor_mean_remainder_bound` (Failure Mode 5: 0 sorries with Mathlib dependency)
- **theoremCount**: 10 → 11 (9 public + 2 private theorems)
- **lineCount**: 240 → 238

## Context

The proof is axiom-free and sorry-free, but obtains its main result (`sin_taylor_remainder_bound'`, `cos_taylor_remainder_bound'`) by applying Mathlib's Taylor remainder theorem. Per gallery Tier B classification, badge should be `mathlib`, not `verified`.

## Test plan

- [ ] `pnpm build` passes
- [ ] Gallery page renders correctly with `mathlib` badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)