### PR TITLE
fix: correct birthday-problem-oq-03-oq-01-oq-02 lineCount and theoremCount

### DIFF
--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
@@ -24,8 +24,8 @@
     "axiomCount": 1,
     "assumptions": "1 axiom: poisson_approx_birthday3 (Chen-Stein method: P(no triple) \u2192 exp(-C(n,3)/d\u00b2) as d \u2192 \u221e). All other theorems fully proved including choose3_mul_six (Pascal induction, 0 sorries).",
     "dateAdded": "2026-04-04",
-    "lineCount": 387,
-    "theoremCount": 18,
+    "lineCount": 420,
+    "theoremCount": 19,
     "definitionCount": 3,
     "originalContributions": [
       "asympThreshold: exact definition (6d\u00b2 ln 2)^{1/3} using Real.rpow",
@@ -132,7 +132,7 @@
       "title": "\u00a76. k=3 vs k=2 Threshold Comparison",
       "summary": "The k=3 threshold grows as d^{2/3} while the k=2 threshold grows as d^{1/2}; k=3 threshold exceeds k=2.",
       "startLine": 310,
-      "endLine": 387
+      "endLine": 420
     }
   ],
   "leanFile": {
@@ -143,11 +143,11 @@
       "Real"
     ],
     "namespace": "BirthdayThreshold3",
-    "lineCount": 387,
+    "lineCount": 420,
     "axiomCount": 1,
     "sorries": 0,
     "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
-    "theoremCount": 18,
+    "theoremCount": 19,
     "definitionCount": 3
   }
 }


### PR DESCRIPTION
## Fix

Corrects stale lineCount and theoremCount metadata in `birthday-problem-oq-03-oq-01-oq-02/meta.json`.

## Evidence

**Before**:
- `meta.lineCount: 387` / `leanFile.lineCount: 387`
- `meta.theoremCount: 18` / `leanFile.theoremCount: 18`
- `sections[k2-comparison].endLine: 387`

**After**:
- `meta.lineCount: 420` / `leanFile.lineCount: 420`
- `meta.theoremCount: 19` / `leanFile.theoremCount: 19`
- `sections[k2-comparison].endLine: 420`

The proof file `BirthdayProblemOQ03OQ01OQ02.lean` grew from 387 to 420 lines after `general_threshold_exponent` was added (lines 384-420: new theorem + summary comment + `#check` commands), but the metadata was not updated at the time of commit.

Verified: actual file line count is 420 (`wc -l` = 420), actual theorem/lemma count is 19 (grepped `^theorem` and `^lemma` declarations), no new sorries or axioms introduced.

---
Automated fix by lean-mechanic agent.