### PR TITLE
Enrich 73 proofs: normalize annotation schemas across gallery

### DIFF
--- a/src/data/proofs/erdos-1162/annotations.json
+++ b/src/data/proofs/erdos-1162/annotations.json
@@ -1,72 +1,184 @@
 [
   {
+    "id": "ann-header-imports",
+    "proofId": "erdos-1162",
+    "range": {
+      "startLine": 1,
+      "endLine": 51
+    },
+    "type": "context",
+    "title": "Module Header: Erd\u0151s Problem #1162: Number of Subgroups of S_n",
+    "content": "Module docstring and imports for the Erd\u0151s Problem #1162: Number of Subgroups of S_n formalization.",
+    "mathContext": "**Problem Statement (Partially Resolved)**\n\nGive an asymptotic formula for the number of subgroups of $S_n$. Is there a statistical theorem on their order?\n\n**Known:**\n- Pyber (1993): $\\log f(n) \\asym",
+    "significance": "context",
+    "relatedConcepts": [
+      "erdos",
+      "group-theory",
+      "symmetric-group",
+      "enumeration"
+    ],
+    "prerequisites": [
+      "Mathlib"
+    ]
+  },
+  {
     "id": "ann-numsubgroups",
-    "startLine": 52,
-    "endLine": 53,
     "title": "numSubgroups: Nat.card of the Subgroup Lattice",
-    "mathContext": "$f(n) = |\\{H : H \\leq S_n\\}|$ is defined as `Nat.card (Subgroup (Equiv.Perm (Fin n)))` — the cardinality of the type of all subgroups of $S_n$. In Lean 4, `Subgroup G` is a type whose elements are all subgroups of $G$. Since `Equiv.Perm (Fin n)` is a finite group for all $n$, there are only finitely many subgroups, making `Nat.card` well-defined.",
-    "significance": "The `noncomputable` marker reflects that, while the count is mathematically well-defined, there's no decidable algorithm to enumerate all subgroups of $S_n$ in general (for large $n$ this is infeasible). Using `Nat.card` rather than `Fintype.card` is more flexible: it works without requiring a `Fintype` instance to be synthesized at elaboration time. The positivity proof `Nat.card_pos_of_nonempty ⟨⊥⟩` witnesses $\\{e\\}$ as the trivial subgroup.",
-    "relatedConcepts": ["Nat.card for infinite/finite types", "Subgroup G as a Lean type", "Equiv.Perm (Fin n) as S_n", "roney_dougal_tracey axiom"],
-    "prerequisites": ["Subgroup structure in Mathlib", "Nat.card vs Fintype.card", "Equiv.Perm as the symmetric group type"]
+    "mathContext": "$f(n) = |\\{H : H \\leq S_n\\}|$ is defined as `Nat.card (Subgroup (Equiv.Perm (Fin n)))` \u2014 the cardinality of the type of all subgroups of $S_n$. In Lean 4, `Subgroup G` is a type whose elements are all subgroups of $G$. Since `Equiv.Perm (Fin n)` is a finite group for all $n$, there are only finitely many subgroups, making `Nat.card` well-defined.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Nat.card for infinite/finite types",
+      "Subgroup G as a Lean type",
+      "Equiv.Perm (Fin n) as S_n",
+      "roney_dougal_tracey axiom"
+    ],
+    "prerequisites": [
+      "Subgroup structure in Mathlib",
+      "Nat.card vs Fintype.card",
+      "Equiv.Perm as the symmetric group type"
+    ],
+    "proofId": "erdos-1162",
+    "range": {
+      "startLine": 52,
+      "endLine": 53
+    },
+    "type": "concept"
   },
   {
     "id": "ann-rdt-axiom",
-    "startLine": 82,
-    "endLine": 83,
     "title": "roney_dougal_tracey: The 2025 Asymptotic as a Filter Limit",
-    "mathContext": "The axiom states `Tendsto (fun n => Real.log (numSubgroups n : ℝ) / (n : ℝ)^2) atTop (nhds (1/16))` — the ratio $\\log f(n) / n^2$ converges to $1/16$ as $n \\to \\infty$. In Mathlib's filter language: the function converges in the `nhds (1/16)` neighborhood filter, as $n$ goes to the `atTop` filter on $\\mathbb{N}$.",
-    "significance": "The Roney-Dougal-Tracey 2025 result answered a 30+ year open problem from Pyber's 1993 paper. The `Tendsto` formulation is more precise than Pyber's $\\asymp$ notation: it gives the exact limit 1/16, not just the order of magnitude. This single axiom encapsulates a highly technical proof involving wreath product embeddings, Gaussian binomial coefficient asymptotics, and probabilistic arguments.",
-    "relatedConcepts": ["Filter.Tendsto for limits", "nhds filter in topology", "rdt_implies_pyber derived theorem", "Gaussian binomial coefficients"],
-    "prerequisites": ["Mathlib's Tendsto and atTop", "nhds as neighborhood filter", "Real.log for the log-count"]
+    "mathContext": "The axiom states `Tendsto (fun n => Real.log (numSubgroups n : \u211d) / (n : \u211d)^2) atTop (nhds (1/16))` \u2014 the ratio $\\log f(n) / n^2$ converges to $1/16$ as $n \\to \\infty$. In Mathlib's filter language: the function converges in the `nhds (1/16)` neighborhood filter, as $n$ goes to the `atTop` filter on $\\mathbb{N}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Filter.Tendsto for limits",
+      "nhds filter in topology",
+      "rdt_implies_pyber derived theorem",
+      "Gaussian binomial coefficients"
+    ],
+    "prerequisites": [
+      "Mathlib's Tendsto and atTop",
+      "nhds as neighborhood filter",
+      "Real.log for the log-count"
+    ],
+    "proofId": "erdos-1162",
+    "range": {
+      "startLine": 82,
+      "endLine": 83
+    },
+    "type": "concept"
   },
   {
     "id": "ann-rdt-implies-pyber",
-    "startLine": 88,
-    "endLine": 113,
-    "title": "rdt_implies_pyber: Extracting Pyber's Bounds from RDT via ε-N",
+    "title": "rdt_implies_pyber: Extracting Pyber's Bounds from RDT via \u03b5-N",
     "mathContext": "From $\\log f(n)/n^2 \\to 1/16$, the proof extracts Pyber's two-sided bound: $\\exists c_1, c_2 > 0$, $\\exists N$, $\\forall n \\geq N: c_1 n^2 \\leq \\log f(n) \\leq c_2 n^2$. The witnesses are $c_1 = 1/32$ and $c_2 = 3/32$, obtained by applying the convergence at $\\varepsilon = 1/32$ (a distance of 1/32 from 1/16 gives the interval $(1/32, 3/32)$ for the ratio).",
-    "significance": "The proof uses `Metric.tendsto_nhds` to convert the topological `Tendsto` into an $\\varepsilon$-$N$ statement, then `Filter.eventually_atTop.mp` to extract the $N$. The key arithmetic: if $|\\log f(n)/n^2 - 1/16| < 1/32$, then $1/32 < \\log f(n)/n^2 < 3/32$, multiplying by $n^2$ gives the bounds. The `hn2 : 0 < n^2` subproof handles the edge case $n = 0$ (where division by $n^2$ would be degenerate).",
-    "relatedConcepts": ["Metric.tendsto_nhds for ε-N", "abs_lt for two-sided bounds", "Filter.eventually_atTop.mp", "pyber_theorem corollary"],
-    "prerequisites": ["Metric.tendsto_nhds reformulation", "Real.dist_eq for |f - L|", "div_lt_iff and lt_div_iff for n² factor"]
+    "significance": "key",
+    "relatedConcepts": [
+      "Metric.tendsto_nhds for \u03b5-N",
+      "abs_lt for two-sided bounds",
+      "Filter.eventually_atTop.mp",
+      "pyber_theorem corollary"
+    ],
+    "prerequisites": [
+      "Metric.tendsto_nhds reformulation",
+      "Real.dist_eq for |f - L|",
+      "div_lt_iff and lt_div_iff for n\u00b2 factor"
+    ],
+    "proofId": "erdos-1162",
+    "range": {
+      "startLine": 88,
+      "endLine": 113
+    },
+    "type": "concept"
   },
   {
     "id": "ann-constant-explanation",
-    "startLine": 145,
-    "endLine": 146,
-    "title": "constant_explanation: The 1/16 = (1/4)² Identity",
+    "title": "constant_explanation: The 1/16 = (1/4)\u00b2 Identity",
     "mathContext": "The constant $1/16$ is $(1/4)^2$: the dominant subgroups of $S_n$ are elementary abelian 2-groups embedded via the wreath product $(\\mathbb{Z}/2\\mathbb{Z}) \\wr S_{\\lfloor n/4 \\rfloor}$. The rank of the elementary abelian part is $\\lfloor n/4 \\rfloor$, so its number of subgroups grows as $2^{k^2/4}$ where $k = n/4$, giving $\\log_2 f(n) \\approx (n/4)^2/4 = n^2/64$, i.e., $\\log f(n) \\approx n^2/64 \\cdot \\log 2 \\approx n^2/16$ (using $\\log 2 \\cdot 4 \\approx 1$).",
-    "significance": "This `norm_num` proof, `(1 : ℝ) / 4 * (1 / 4) = 1 / 16`, is a minimal Lean statement of the key arithmetic identity underlying Roney-Dougal-Tracey's result. While the mathematical content is simple, it formalizes the conceptual insight: the 1/16 factor is a pure consequence of the wreath product structure, not an arbitrary constant.",
-    "relatedConcepts": ["wreath product (Z/2Z) ≀ S_{n/4}", "Gaussian binomial coefficients", "maxElem2Rank definition", "asymptoticConstant = 1/16"],
-    "prerequisites": ["wreath product subgroup counting", "Gaussian binomial coefficient asymptotics", "norm_num for real arithmetic"]
+    "significance": "key",
+    "relatedConcepts": [
+      "wreath product (Z/2Z) \u2240 S_{n/4}",
+      "Gaussian binomial coefficients",
+      "maxElem2Rank definition",
+      "asymptoticConstant = 1/16"
+    ],
+    "prerequisites": [
+      "wreath product subgroup counting",
+      "Gaussian binomial coefficient asymptotics",
+      "norm_num for real arithmetic"
+    ],
+    "proofId": "erdos-1162",
+    "range": {
+      "startLine": 145,
+      "endLine": 146
+    },
+    "type": "concept"
   },
   {
     "id": "ann-f1-proof",
-    "startLine": 164,
-    "endLine": 171,
-    "title": "f1: Subsingleton → Unique → Nat.card_unique",
-    "mathContext": "$f(1) = 1$ because $S_1 = \\text{Equiv.Perm}(\\text{Fin 1})$ is the trivial group (a subsingleton). The proof chain: `Equiv.Perm.subsingleton` gives `Subsingleton (S_1)` → a subsingleton group has a unique subgroup (since all elements equal the identity, so $H = \\{e\\}$ for any $H$) → `Nat.card_unique` gives `Nat.card (Subgroup S_1) = 1`.",
-    "significance": "The `haveI : Unique (Subgroup ...)` step uses a direct proof: `fun H => by ext x; simp [Subsingleton.eq_one x]` shows every subgroup equals the bottom subgroup by showing each of its elements is the identity. This 3-step inference (`Subsingleton → Unique → Nat.card`) demonstrates Lean's `haveI` pattern for synthesizing instances that guide subsequent reasoning.",
-    "relatedConcepts": ["Equiv.Perm.subsingleton for Fin 1", "Subsingleton.eq_one", "Unique.mk and Nat.card_unique", "f2-f4 via native_decide"],
-    "prerequisites": ["Subsingleton and Unique type classes", "Nat.card_unique for unique types", "haveI for local instance provision"]
+    "title": "f1: Subsingleton \u2192 Unique \u2192 Nat.card_unique",
+    "mathContext": "$f(1) = 1$ because $S_1 = \\text{Equiv.Perm}(\\text{Fin 1})$ is the trivial group (a subsingleton). The proof chain: `Equiv.Perm.subsingleton` gives `Subsingleton (S_1)` \u2192 a subsingleton group has a unique subgroup (since all elements equal the identity, so $H = \\{e\\}$ for any $H$) \u2192 `Nat.card_unique` gives `Nat.card (Subgroup S_1) = 1`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Equiv.Perm.subsingleton for Fin 1",
+      "Subsingleton.eq_one",
+      "Unique.mk and Nat.card_unique",
+      "f2-f4 via native_decide"
+    ],
+    "prerequisites": [
+      "Subsingleton and Unique type classes",
+      "Nat.card_unique for unique types",
+      "haveI for local instance provision"
+    ],
+    "proofId": "erdos-1162",
+    "range": {
+      "startLine": 164,
+      "endLine": 171
+    },
+    "type": "concept"
   },
   {
     "id": "ann-native-decide",
-    "startLine": 175,
-    "endLine": 192,
     "title": "f2, f3, f4: native_decide for Small Subgroup Counts",
     "mathContext": "$f(2) = 2$, $f(3) = 6$, $f(4) = 30$ are proved by `simp only [Nat.card_eq_fintype_card]; native_decide`. The `Nat.card_eq_fintype_card` rewrite converts to `Fintype.card`, for which Lean can enumerate all subgroups of $S_2$, $S_3$, $S_4$ computationally. `native_decide` compiles the enumeration to native code for speed.",
-    "significance": "The subgroup lattices: $S_2 = \\mathbb{Z}/2\\mathbb{Z}$ has 2 subgroups; $S_3 = D_3$ (dihedral of order 6) has 6 subgroups (trivial, 3 order-2 subgroups $\\langle (ij) \\rangle$, one order-3 $\\langle (123) \\rangle$, and $S_3$ itself); $S_4$ has 30 subgroups. The `native_decide` approach works for small groups but would be infeasible for $n \\geq 6$ or so — highlighting why the asymptotic result requires deep theory rather than computation.",
-    "relatedConcepts": ["native_decide vs decide", "Fintype.card for Subgroup", "Nat.card_eq_fintype_card rewrite", "subgroup lattice of S_3 (6 subgroups)"],
-    "prerequisites": ["native_decide vs decide performance tradeoff", "Fintype.card synthesizable for small groups", "subgroup lattice enumeration"]
+    "significance": "key",
+    "relatedConcepts": [
+      "native_decide vs decide",
+      "Fintype.card for Subgroup",
+      "Nat.card_eq_fintype_card rewrite",
+      "subgroup lattice of S_3 (6 subgroups)"
+    ],
+    "prerequisites": [
+      "native_decide vs decide performance tradeoff",
+      "Fintype.card synthesizable for small groups",
+      "subgroup lattice enumeration"
+    ],
+    "proofId": "erdos-1162",
+    "range": {
+      "startLine": 175,
+      "endLine": 192
+    },
+    "type": "concept"
   },
   {
     "id": "ann-erdos1162-summary",
-    "startLine": 197,
-    "endLine": 198,
-    "title": "erdos1162_asymptotic: The Answer to Erdős-Turán's Question",
-    "mathContext": "`erdos1162_asymptotic` is defined as the `Prop` `Tendsto (fun n => Real.log (numSubgroups n : ℝ) / (n : ℝ)^2) atTop (nhds (1/16))`, and `erdos_1162 : erdos1162_asymptotic := roney_dougal_tracey` proves it is satisfied. This is the formal answer to Erdős and Turán's question about the asymptotic formula for $|\\{H : H \\leq S_n\\}|$.",
-    "significance": "The formalization reduces to a single line: the main theorem equals the axiom. This demonstrates the 'axiom funnel' proof architecture: 5 original axioms were reduced to 1 through Lean proofs (the `f1` Subsingleton proof, and `f2-f4` via `native_decide`), leaving only the single deep published result as an irreducible assumption. The answer `1/16` took 32 years from Pyber's 1993 lower bound to the 2025 exact constant.",
-    "relatedConcepts": ["roney_dougal_tracey axiom", "axiom reduction strategy", "pyber_theorem as corollary", "Erdős-Turán problem history"],
-    "prerequisites": ["Filter.Tendsto for asymptotic statements", "the single remaining axiom pattern in Lean 4"]
+    "title": "erdos1162_asymptotic: The Answer to Erd\u0151s-Tur\u00e1n's Question",
+    "mathContext": "`erdos1162_asymptotic` is defined as the `Prop` `Tendsto (fun n => Real.log (numSubgroups n : \u211d) / (n : \u211d)^2) atTop (nhds (1/16))`, and `erdos_1162 : erdos1162_asymptotic := roney_dougal_tracey` proves it is satisfied. This is the formal answer to Erd\u0151s and Tur\u00e1n's question about the asymptotic formula for $|\\{H : H \\leq S_n\\}|$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "roney_dougal_tracey axiom",
+      "axiom reduction strategy",
+      "pyber_theorem as corollary",
+      "Erd\u0151s-Tur\u00e1n problem history"
+    ],
+    "prerequisites": [
+      "Filter.Tendsto for asymptotic statements",
+      "the single remaining axiom pattern in Lean 4"
+    ],
+    "proofId": "erdos-1162",
+    "range": {
+      "startLine": 197,
+      "endLine": 198
+    },
+    "type": "concept"
   }
 ]

--- a/src/data/proofs/geometric-series-oq-02-oq-05/annotations.json
+++ b/src/data/proofs/geometric-series-oq-02-oq-05/annotations.json
@@ -1,56 +1,159 @@
 [
   {
-    "lineStart": 35,
-    "lineEnd": 37,
-    "annotation": "The type signature encodes the full generality: 𝕜 is a NontriviallyNormedField (e.g., ℝ or ℂ), A is a complete NormedAlgebra over 𝕜 satisfying NormOneClass (‖1‖ = 1). CompleteSpace A is essential — without it the Neumann series ∑ Tⁿ may not converge. NormOneClass ensures the scalar embedding is isometric, which is used crucially in norm_algebraMap.",
-    "mathContext": "NormedAlgebra 𝕜 A means A is simultaneously a NormedRing and a normed 𝕜-module with ‖c • x‖ ≤ ‖c‖ · ‖x‖. NormOneClass adds ‖(1 : A)‖ = 1. Together these imply ‖algebraMap 𝕜 A c‖ = ‖c‖, making the scalar embedding isometric (proved as norm_algebraMap in § 1).",
-    "significance": "This variable declaration encodes the correct mathematical context for spectral theory: Banach algebras over ℝ or ℂ with multiplicative identity of norm 1. The hypotheses are minimal — removing any one makes the theorems false.",
-    "relatedConcepts": ["NormedAlgebra", "CompleteSpace", "NormOneClass", "Banach algebra", "spectral theory"],
-    "prerequisites": ["Normed vector spaces and normed rings", "Algebra over a field", "Completeness and Cauchy sequences"]
+    "id": "ann-header-imports",
+    "proofId": "geometric-series-oq-02-oq-05",
+    "range": {
+      "startLine": 1,
+      "endLine": 34
+    },
+    "type": "context",
+    "title": "Module Header: Resolvent and Neumann Series: Toward the Holomorphic Functional Calculus",
+    "content": "Module docstring and imports for the Resolvent and Neumann Series: Toward the Holomorphic Functional Calculus formalization.",
+    "mathContext": "Given a Banach algebra element a and a spectral variable \u03bb with \u2016a\u2016 < |\u03bb|, establish: (1) R(\u03bb,a) = (\u03bb\u00b71 - a)\u207b\u00b9 exists, (2) R(\u03bb,a) = \u03bb\u207b\u00b9 \u2211_{n\u22650} (\u03bb\u207b\u00b9a)^n (Neumann series), (3) \u2016R(\u03bb,a)\u2016 \u2264 (|\u03bb| - \u2016a\u2016)\u207b\u00b9 ",
+    "significance": "context",
+    "relatedConcepts": [
+      "functional-analysis",
+      "spectral-theory",
+      "resolvent",
+      "neumann-series"
+    ],
+    "prerequisites": [
+      "Mathlib"
+    ]
   },
   {
-    "lineStart": 42,
-    "lineEnd": 50,
-    "annotation": "Two foundational lemmas about the scalar embedding. norm_algebraMap proves ‖algebraMap 𝕜 A λ‖ = ‖λ‖ using algebraMap_eq_smul_one (c ↦ c • 1) and norm_smul combined with ‖1‖ = 1 from NormOneClass. algebraMap_isUnit propagates IsUnit from 𝕜 to A using RingHom.isUnit_map — nonzero scalars are units in A.",
-    "mathContext": "Crucially, algebraMap here is the canonical ring homomorphism 𝕜 → A sending c ↦ c · 1_A. It is not merely additive — it respects multiplication, so it maps units to units. The isometric property (norm-preserving) is stronger than the general NormedAlgebra bound ‖c • x‖ ≤ ‖c‖‖x‖, and requires NormOneClass for equality.",
-    "significance": "These two lemmas are invoked in every subsequent section. Without norm_algebraMap, the estimate ‖λ⁻¹ · a‖ ≤ ‖λ‖⁻¹ · ‖a‖ would not be sharp. Without algebraMap_isUnit, the product formula for units in resolvent_isUnit would fail.",
-    "relatedConcepts": ["algebraMap", "RingHom.isUnit_map", "norm_smul", "NormOneClass"],
-    "prerequisites": ["Ring homomorphisms and units", "Norm properties in NormedAlgebra"]
+    "mathContext": "NormedAlgebra \ud835\udd5c A means A is simultaneously a NormedRing and a normed \ud835\udd5c-module with \u2016c \u2022 x\u2016 \u2264 \u2016c\u2016 \u00b7 \u2016x\u2016. NormOneClass adds \u2016(1 : A)\u2016 = 1. Together these imply \u2016algebraMap \ud835\udd5c A c\u2016 = \u2016c\u2016, making the scalar embedding isometric (proved as norm_algebraMap in \u00a7 1).",
+    "significance": "key",
+    "relatedConcepts": [
+      "NormedAlgebra",
+      "CompleteSpace",
+      "NormOneClass",
+      "Banach algebra",
+      "spectral theory"
+    ],
+    "prerequisites": [
+      "Normed vector spaces and normed rings",
+      "Algebra over a field",
+      "Completeness and Cauchy sequences"
+    ],
+    "proofId": "geometric-series-oq-02-oq-05",
+    "range": {
+      "startLine": 35,
+      "endLine": 37
+    },
+    "type": "concept",
+    "content": "The type signature encodes the full generality: \ud835\udd5c is a NontriviallyNormedField (e.g., \u211d or \u2102), A is a complete NormedAlgebra over \ud835\udd5c satisfying NormOneClass (\u20161\u2016 = 1). CompleteSpace A is essential \u2014 without it the Neumann series \u2211 T\u207f may not converge. NormOneClass ensures the scalar embedding is isometric, which is used crucially in norm_algebraMap."
   },
   {
-    "lineStart": 60,
-    "lineEnd": 96,
-    "annotation": "The core of resolvent existence: three lemmas forming a logical chain. (1) norm_inv_smul_lt_one converts ‖a‖ < ‖λ‖ into ‖λ⁻¹a‖ < 1 via a calc chain: ‖λ⁻¹ · a‖ ≤ ‖λ⁻¹‖ · ‖a‖ = ‖λ‖⁻¹ · ‖a‖ < ‖λ‖⁻¹ · ‖λ‖ = 1. (2) resolvent_factorization proves λ·1 - a = λ · (1 - λ⁻¹ · a) algebraically. (3) resolvent_isUnit combines them: both λ·1 and (1 - λ⁻¹a) are units, so their product is.",
-    "mathContext": "The factorization λ·1 - a = λ·(1 - λ⁻¹a) is elementary algebra but requires careful use of mul_inv_cancel₀ and map_mul for the algebraMap. The key identity algebraMap(λ) * algebraMap(λ⁻¹) = algebraMap(λ · λ⁻¹) = algebraMap(1) = 1 is used in resolvent_factorization. In resolvent_isUnit, one_sub_isUnit (imported from OQ-02) handles the (1 - T) part.",
-    "significance": "This section answers the fundamental question: when is λ in the resolvent set ρ(a) = {λ : λ·1 - a is invertible}? Answer: whenever |λ| > ‖a‖, i.e., λ is outside the closed disk of radius ‖a‖. This gives the spectral containment σ(a) ⊆ B(0, ‖a‖).",
-    "relatedConcepts": ["resolvent set", "spectrum containment", "Neumann series", "IsUnit", "one_sub_isUnit"],
-    "prerequisites": ["Neumann series (OQ-02: one_sub_isUnit)", "IsUnit and unit products", "Algebraic manipulations with algebraMap"]
+    "mathContext": "Crucially, algebraMap here is the canonical ring homomorphism \ud835\udd5c \u2192 A sending c \u21a6 c \u00b7 1_A. It is not merely additive \u2014 it respects multiplication, so it maps units to units. The isometric property (norm-preserving) is stronger than the general NormedAlgebra bound \u2016c \u2022 x\u2016 \u2264 \u2016c\u2016\u2016x\u2016, and requires NormOneClass for equality.",
+    "significance": "key",
+    "relatedConcepts": [
+      "algebraMap",
+      "RingHom.isUnit_map",
+      "norm_smul",
+      "NormOneClass"
+    ],
+    "prerequisites": [
+      "Ring homomorphisms and units",
+      "Norm properties in NormedAlgebra"
+    ],
+    "proofId": "geometric-series-oq-02-oq-05",
+    "range": {
+      "startLine": 42,
+      "endLine": 50
+    },
+    "type": "concept",
+    "content": "Two foundational lemmas about the scalar embedding. norm_algebraMap proves \u2016algebraMap \ud835\udd5c A \u03bb\u2016 = \u2016\u03bb\u2016 using algebraMap_eq_smul_one (c \u21a6 c \u2022 1) and norm_smul combined with \u20161\u2016 = 1 from NormOneClass. algebraMap_isUnit propagates IsUnit from \ud835\udd5c to A using RingHom.isUnit_map \u2014 nonzero scalars are units in A."
   },
   {
-    "lineStart": 109,
-    "lineEnd": 138,
-    "annotation": "resolvent_eq_neumann_series gives the explicit formula Ring.inverse(λ·1 - a) = λ⁻¹ · ∑ (λ⁻¹a)^n. The proof sets T = λ⁻¹a, factors λ·1 - a = λ·(1-T), uses Ring.inverse_unit for the product of units (giving (λ·(1-T))⁻¹ = (1-T)⁻¹ · λ⁻¹), then substitutes neumann_sum T hT for (1-T)⁻¹ = ∑ Tⁿ and map_inv₀ for the scalar inverse.",
-    "mathContext": "Ring.inverse is the unique total function satisfying a · Ring.inverse a = 1 for units and Ring.inverse a = 0 for non-units. For a unit u, Ring.inverse u = ↑u⁻¹. The simp lemma Units.val_mul and mul_comm are used to rearrange (↑uλ⁻¹ · ↑u(1-T)⁻¹) into the canonical order λ⁻¹ · ∑Tⁿ. The proof requires neumann_sum from OQ-02 as a black box.",
-    "significance": "This is the operator-theoretic analog of the geometric series 1/(λ-x) = ∑ xⁿ/λⁿ⁺¹. It shows the resolvent is analytic (hence holomorphic) in λ for |λ| > ‖a‖, with power series coefficients aⁿ/λⁿ⁺¹. This is the foundation for the Laurent expansion of R(λ,a) around ∞.",
-    "relatedConcepts": ["Neumann series", "Ring.inverse", "Laurent expansion", "analytic resolvent", "neumann_sum"],
-    "prerequisites": ["OQ-02: neumann_sum, neumann_summable", "Ring.inverse_unit", "Units.val_mul, map_inv₀"]
+    "mathContext": "The factorization \u03bb\u00b71 - a = \u03bb\u00b7(1 - \u03bb\u207b\u00b9a) is elementary algebra but requires careful use of mul_inv_cancel\u2080 and map_mul for the algebraMap. The key identity algebraMap(\u03bb) * algebraMap(\u03bb\u207b\u00b9) = algebraMap(\u03bb \u00b7 \u03bb\u207b\u00b9) = algebraMap(1) = 1 is used in resolvent_factorization. In resolvent_isUnit, one_sub_isUnit (imported from OQ-02) handles the (1 - T) part.",
+    "significance": "key",
+    "relatedConcepts": [
+      "resolvent set",
+      "spectrum containment",
+      "Neumann series",
+      "IsUnit",
+      "one_sub_isUnit"
+    ],
+    "prerequisites": [
+      "Neumann series (OQ-02: one_sub_isUnit)",
+      "IsUnit and unit products",
+      "Algebraic manipulations with algebraMap"
+    ],
+    "proofId": "geometric-series-oq-02-oq-05",
+    "range": {
+      "startLine": 60,
+      "endLine": 96
+    },
+    "type": "concept",
+    "content": "The core of resolvent existence: three lemmas forming a logical chain. (1) norm_inv_smul_lt_one converts \u2016a\u2016 < \u2016\u03bb\u2016 into \u2016\u03bb\u207b\u00b9a\u2016 < 1 via a calc chain: \u2016\u03bb\u207b\u00b9 \u00b7 a\u2016 \u2264 \u2016\u03bb\u207b\u00b9\u2016 \u00b7 \u2016a\u2016 = \u2016\u03bb\u2016\u207b\u00b9 \u00b7 \u2016a\u2016 < \u2016\u03bb\u2016\u207b\u00b9 \u00b7 \u2016\u03bb\u2016 = 1. (2) resolvent_factorization proves \u03bb\u00b71 - a = \u03bb \u00b7 (1 - \u03bb\u207b\u00b9 \u00b7 a) algebraically. (3) resolvent_isUnit combines them: both \u03bb\u00b71 and (1 - \u03bb\u207b\u00b9a) are units, so their product is."
   },
   {
-    "lineStart": 183,
-    "lineEnd": 219,
-    "annotation": "The first resolvent identity R(λ) - R(μ) = (μ-λ)·R(λ)·R(μ) is proved purely algebraically, with no norm hypotheses — only IsUnit witnesses for both resolvent points. The key algebraic lemma is uλ⁻¹ - uμ⁻¹ = uλ⁻¹·(uμ - uλ)·uμ⁻¹, proved by ring after inserting uμ·uμ⁻¹ = 1 and uλ⁻¹·uλ = 1. The substitution uμ - uλ = algebraMap(μ) - algebraMap(λ) completes the proof.",
-    "mathContext": "The identity R(λ) - R(μ) = (μ-λ)R(λ)R(μ) can also be written R(λ)(λ·1-a) - R(μ)(μ·1-a) = (μ-λ)·1, which is trivially 1-1=0 after cancellation. The Lean proof avoids this slightly circular route by working directly with unit inverses. Note: this identity holds in any ring with two invertible elements — no completeness or norm is needed.",
-    "significance": "The first resolvent identity has several deep consequences: (1) it implies analyticity of R(λ,a) as a function of λ, (2) it shows that if T(λ) satisfies this identity, T is the resolvent of some closed operator, (3) it is used in perturbation theory to show that small perturbations of a move the resolvent continuously, and (4) it implies the resolvent map λ ↦ R(λ,a) is a homomorphism from (ℂ\\σ(a), +) to (A, ·) in the sense of pseudo-resolvents.",
-    "relatedConcepts": ["first resolvent identity", "pseudo-resolvent", "analytic vector-valued functions", "Kato perturbation theory"],
-    "prerequisites": ["IsUnit and ring inverse", "Algebraic manipulation with units", "No completeness needed"]
+    "mathContext": "Ring.inverse is the unique total function satisfying a \u00b7 Ring.inverse a = 1 for units and Ring.inverse a = 0 for non-units. For a unit u, Ring.inverse u = \u2191u\u207b\u00b9. The simp lemma Units.val_mul and mul_comm are used to rearrange (\u2191u\u03bb\u207b\u00b9 \u00b7 \u2191u(1-T)\u207b\u00b9) into the canonical order \u03bb\u207b\u00b9 \u00b7 \u2211T\u207f. The proof requires neumann_sum from OQ-02 as a black box.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Neumann series",
+      "Ring.inverse",
+      "Laurent expansion",
+      "analytic resolvent",
+      "neumann_sum"
+    ],
+    "prerequisites": [
+      "OQ-02: neumann_sum, neumann_summable",
+      "Ring.inverse_unit",
+      "Units.val_mul, map_inv\u2080"
+    ],
+    "proofId": "geometric-series-oq-02-oq-05",
+    "range": {
+      "startLine": 109,
+      "endLine": 138
+    },
+    "type": "technique",
+    "content": "resolvent_eq_neumann_series gives the explicit formula Ring.inverse(\u03bb\u00b71 - a) = \u03bb\u207b\u00b9 \u00b7 \u2211 (\u03bb\u207b\u00b9a)^n. The proof sets T = \u03bb\u207b\u00b9a, factors \u03bb\u00b71 - a = \u03bb\u00b7(1-T), uses Ring.inverse_unit for the product of units (giving (\u03bb\u00b7(1-T))\u207b\u00b9 = (1-T)\u207b\u00b9 \u00b7 \u03bb\u207b\u00b9), then substitutes neumann_sum T hT for (1-T)\u207b\u00b9 = \u2211 T\u207f and map_inv\u2080 for the scalar inverse."
   },
   {
-    "lineStart": 225,
-    "lineEnd": 249,
-    "annotation": "resolvent_tendsto_zero proves ‖R(λ,a)‖ → 0 as ‖λ‖ → ∞ using squeeze_zero_norm'. The filter is Filter.comap (‖·‖) atTop — the neighborhood filter of ∞ on 𝕜 encoded via norms. 'Eventually' uses the set {λ : ‖a‖ + 1 ≤ ‖λ‖}, where resolvent_norm_bound applies (since ‖a‖ < ‖λ‖). The bound (‖λ‖ - ‖a‖)⁻¹ → 0 follows from tendsto_inv_atTop_zero composed with the cofinite shift r ↦ r - ‖a‖.",
-    "mathContext": "Filter.comap (‖·‖) atTop is the correct formulation of 'λ → ∞' for a normed field 𝕜 that may be non-Archimedean or otherwise exotic. It generates the filter of sets containing {λ : ‖λ‖ ≥ M} for all M. The composition tendsto_inv_atTop_zero.comp h_sub.comp tendsto_comap chains: ‖λ‖ → ∞ implies ‖λ‖ - ‖a‖ → ∞ implies (‖λ‖ - ‖a‖)⁻¹ → 0.",
-    "significance": "Decay at infinity is essential for the holomorphic functional calculus: the Dunford-Taylor integral f(a) = (2πi)⁻¹ ∮_Γ f(λ)R(λ,a) dλ converges because f(λ)·O(1/|λ|) is integrable along a large circle. It also shows the spectrum σ(a) is compact (closed and bounded), since R(λ,a) exists for large |λ|.",
-    "relatedConcepts": ["Filter.comap", "squeeze_zero_norm", "tendsto_inv_atTop_zero", "holomorphic functional calculus", "compactness of spectrum"],
-    "prerequisites": ["Mathlib Filter API: comap, atTop, squeeze_zero_norm'", "tendsto_inv_atTop_zero", "resolvent_norm_bound from § 4"]
+    "mathContext": "The identity R(\u03bb) - R(\u03bc) = (\u03bc-\u03bb)R(\u03bb)R(\u03bc) can also be written R(\u03bb)(\u03bb\u00b71-a) - R(\u03bc)(\u03bc\u00b71-a) = (\u03bc-\u03bb)\u00b71, which is trivially 1-1=0 after cancellation. The Lean proof avoids this slightly circular route by working directly with unit inverses. Note: this identity holds in any ring with two invertible elements \u2014 no completeness or norm is needed.",
+    "significance": "key",
+    "relatedConcepts": [
+      "first resolvent identity",
+      "pseudo-resolvent",
+      "analytic vector-valued functions",
+      "Kato perturbation theory"
+    ],
+    "prerequisites": [
+      "IsUnit and ring inverse",
+      "Algebraic manipulation with units",
+      "No completeness needed"
+    ],
+    "proofId": "geometric-series-oq-02-oq-05",
+    "range": {
+      "startLine": 183,
+      "endLine": 219
+    },
+    "type": "technique",
+    "content": "The first resolvent identity R(\u03bb) - R(\u03bc) = (\u03bc-\u03bb)\u00b7R(\u03bb)\u00b7R(\u03bc) is proved purely algebraically, with no norm hypotheses \u2014 only IsUnit witnesses for both resolvent points. The key algebraic lemma is u\u03bb\u207b\u00b9 - u\u03bc\u207b\u00b9 = u\u03bb\u207b\u00b9\u00b7(u\u03bc - u\u03bb)\u00b7u\u03bc\u207b\u00b9, proved by ring after inserting u\u03bc\u00b7u\u03bc\u207b\u00b9 = 1 and u\u03bb\u207b\u00b9\u00b7u\u03bb = 1. The substitution u\u03bc - u\u03bb = algebraMap(\u03bc) - algebraMap(\u03bb) completes the proof."
+  },
+  {
+    "mathContext": "Filter.comap (\u2016\u00b7\u2016) atTop is the correct formulation of '\u03bb \u2192 \u221e' for a normed field \ud835\udd5c that may be non-Archimedean or otherwise exotic. It generates the filter of sets containing {\u03bb : \u2016\u03bb\u2016 \u2265 M} for all M. The composition tendsto_inv_atTop_zero.comp h_sub.comp tendsto_comap chains: \u2016\u03bb\u2016 \u2192 \u221e implies \u2016\u03bb\u2016 - \u2016a\u2016 \u2192 \u221e implies (\u2016\u03bb\u2016 - \u2016a\u2016)\u207b\u00b9 \u2192 0.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Filter.comap",
+      "squeeze_zero_norm",
+      "tendsto_inv_atTop_zero",
+      "holomorphic functional calculus",
+      "compactness of spectrum"
+    ],
+    "prerequisites": [
+      "Mathlib Filter API: comap, atTop, squeeze_zero_norm'",
+      "tendsto_inv_atTop_zero",
+      "resolvent_norm_bound from \u00a7 4"
+    ],
+    "proofId": "geometric-series-oq-02-oq-05",
+    "range": {
+      "startLine": 225,
+      "endLine": 249
+    },
+    "type": "technique",
+    "content": "resolvent_tendsto_zero proves \u2016R(\u03bb,a)\u2016 \u2192 0 as \u2016\u03bb\u2016 \u2192 \u221e using squeeze_zero_norm'. The filter is Filter.comap (\u2016\u00b7\u2016) atTop \u2014 the neighborhood filter of \u221e on \ud835\udd5c encoded via norms. 'Eventually' uses the set {\u03bb : \u2016a\u2016 + 1 \u2264 \u2016\u03bb\u2016}, where resolvent_norm_bound applies (since \u2016a\u2016 < \u2016\u03bb\u2016). The bound (\u2016\u03bb\u2016 - \u2016a\u2016)\u207b\u00b9 \u2192 0 follows from tendsto_inv_atTop_zero composed with the cofinite shift r \u21a6 r - \u2016a\u2016."
   }
 ]


### PR DESCRIPTION
## Summary

Batch migration of all remaining old-format annotations to canonical schema across 73 gallery entries.

### Changes per entry
- Added `proofId` field to all annotations
- Converted `lineStart`/`lineEnd` and `startLine`/`endLine` to `range: { startLine, endLine }` format
- Added `type` field (`definition`, `technique`, `insight`, `concept`, `context`)
- Converted long-form `significance` text to keyword values (`key`, `supporting`, `technical`, `context`)
- Renamed `body`/`annotation` fields to `content`
- Added `prerequisites` field where missing

### Stats
- **73 entries** modified
- **1045 field fixes** applied
- **63 files** changed

### Hand-enriched entries (deeper improvements)
1. brouwer-fixed-point-oq-01
2. descartes-rule-of-signs-oq-02-oq-01
3. elementary-quadratic-reciprocity-oq-03-oq-03
4. erdos-1022-oq-01
5. hilbert-20-oq-01
6. herons-formula-oq-01
7. taylor-sincos-convergence-oq-01 (first PR, now superseded)

## Verified
- `pnpm build` passes