### PR TITLE
fix: remove True-stub theorems from 7 gallery proofs (batch 10)

### DIFF
--- a/proofs/Proofs/Erdos279Problem.lean
+++ b/proofs/Proofs/Erdos279Problem.lean
@@ -37,12 +37,6 @@ def CoversEventually (a : ResidueChoice) (k : ℕ) : Prop :=
 
 /- ## Known Results for Small k -/
 
-/-- For k = 1 or k = 2: any set A with divergent Σ 1/n can cover
-    all sufficiently large integers (placeholder — conclusion is True) -/
-theorem small_k_covers :
-  ∀ k : ℕ, k ≤ 2 → True := by
-  intros; trivial
-
 /- ## Density Conditions for Generalization -/
 
 /-- A set A ⊆ ℕ has counting function ≫ N/log N -/

--- a/proofs/Proofs/Erdos465Problem.lean
+++ b/proofs/Proofs/Erdos465Problem.lean
@@ -172,12 +172,6 @@ theorem second_conjecture_holds : SecondConjecture := by
 ## Part 5: Comparison of Bounds
 -/
 
-/-- The Sárközy bound is weaker than Konyagin's -/
-theorem sarkozy_weaker_than_konyagin :
-    KonyaginBound → SarkozyBound → True := by
-  intro _ _
-  trivial
-
 /-
 ## Part 6: Lower Bounds (Problem #466)
 -/
@@ -190,14 +184,6 @@ def LowerBound : Prop :=
 
 /-- Problem #466: Lower bounds for N(X, δ) -/
 axiom problem_466_lower_bound : LowerBound
-
-/-- Optimality: The exponent 1/2 is tight -/
-theorem exponent_optimal :
-    KonyaginBound ∧ LowerBound →
-    -- N(X, δ) ≈ X^{1/2} (up to constants depending on δ)
-    True := by
-  intro _
-  trivial
 
 /-
 ## Part 7: Related Techniques

--- a/proofs/Proofs/Erdos478Problem.lean
+++ b/proofs/Proofs/Erdos478Problem.lean
@@ -154,12 +154,4 @@ theorem factorial_as_multiplicative_walk (p : ℕ) [Fact (Nat.Prime p)] :
 
 /- ## Average Results -/
 
-/-- Klurman–Munsch (2017): On average over primes p ≤ x,
-    the factorial residue count is (1 - 1/e + o(1)) · p.
-    (The precise statement is not formalized; this is a placeholder.) -/
-theorem klurman_munsch_average :
-    ∀ ε : ℝ, ε > 0 → ∃ X₀ : ℝ, X₀ > 0 ∧
-      ∀ x : ℝ, x > X₀ → True :=
-  fun _ _ => ⟨1, one_pos, fun _ _ => trivial⟩
-
 end Erdos478

--- a/proofs/Proofs/Erdos776Problem.lean
+++ b/proofs/Proofs/Erdos776Problem.lean
@@ -182,12 +182,6 @@ theorem size_variety_tradeoff (n r : ℕ) (hr : r ≥ 1) :
     _ = r * (distinctSizes F).card := by
         rw [Finset.sum_const, mul_comm]; simp [smul_eq_mul]
 
-/-- For size k, the number of k-element subsets of {1,...,n} is C(n,k).
-    The multiplicity constraint r requires C(n,k) ≥ r for each used size k. -/
-theorem size_availability (n r k : ℕ) (hk : k ≤ n) :
-  Nat.choose n k ≥ r → True := by
-  intro; trivial
-
 /- ## Structural Lemmas for Axiom Elimination
 
 These lemmas decompose the path toward proving the known-result axioms

--- a/proofs/Proofs/Erdos969Problem.lean
+++ b/proofs/Proofs/Erdos969Problem.lean
@@ -222,8 +222,4 @@ theorem erdos_969_summary :
 /-- The main open question: is E(x) ≍ x^(1/4)? -/
 def erdos_969_open_problem : Prop := errorTermConjecture
 
-/-- The Riemann Hypothesis would follow from resolving this problem -/
-theorem rh_follows_from_conjecture : errorTermConjecture → True :=
-  fun _ => trivial
-
 end Erdos969

--- a/proofs/Proofs/FourColorTheoremOQ02.lean
+++ b/proofs/Proofs/FourColorTheoremOQ02.lean
@@ -51,13 +51,6 @@ def IsUnavoidable (S : Finset Configuration) : Prop :=
 
 /-- The Robertson-Sanders-Seymour-Thomas unavoidable set has 633 configurations. -/
 /-- Appel-Haken's original set had 1936 (later 1476) configurations. -/
-/-- No configuration of ring size ≤ 3 is needed.
-    The Birkhoff diamond (ring size 6) was the first reducible
-    configuration found (1913). -/
-theorem small_ring_not_needed :
-    ∀ C : Configuration, C.ringSize ≤ 3 → True :=
-  fun _ _ => trivial
-
 /-- The Birkhoff diamond has ring size 6 and is reducible. -/
 def birkhoffDiamond : Configuration where
   ringSize := 6

--- a/proofs/Proofs/KroneckersJugendtraum.lean
+++ b/proofs/Proofs/KroneckersJugendtraum.lean
@@ -284,11 +284,6 @@ def Hilberts12thProblem : Prop :=
       True -- Full statement is not formalizable without specifying
            -- what "explicit analytic function" means
 
-/-- The problem is solved for ℚ (by Kronecker-Weber) -/
-theorem hilbert12_solved_for_rationals : KroneckerWeberTheorem → True := by
-  intro _
-  trivial
-
 /-- The problem is solved for imaginary quadratic fields (by CM theory) -/
 theorem hilbert12_solved_for_imaginary_quadratic :
     ∀ (K : Type*) [Field K] [Algebra ℚ K],

--- a/src/data/proofs/erdos-279/meta.json
+++ b/src/data/proofs/erdos-279/meta.json
@@ -119,7 +119,7 @@
     "namespace": null,
     "lineCount": 85,
     "axiomCount": 2,
-    "theoremCount": 2,
+    "theoremCount": 1,
     "definitionCount": 6,
     "path": "Proofs/Erdos279Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-465/meta.json
+++ b/src/data/proofs/erdos-465/meta.json
@@ -186,7 +186,7 @@
     "namespace": "Erdos465",
     "lineCount": 270,
     "axiomCount": 3,
-    "theoremCount": 7,
+    "theoremCount": 5,
     "definitionCount": 11,
     "path": "Proofs/Erdos465Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-478/meta.json
+++ b/src/data/proofs/erdos-478/meta.json
@@ -173,7 +173,7 @@
     "namespace": null,
     "lineCount": 165,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 5,
     "definitionCount": 3,
     "path": "Proofs/Erdos478Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-776/meta.json
+++ b/src/data/proofs/erdos-776/meta.json
@@ -168,7 +168,7 @@
     "namespace": null,
     "lineCount": 391,
     "axiomCount": 3,
-    "theoremCount": 13,
+    "theoremCount": 12,
     "definitionCount": 6,
     "path": "Proofs/Erdos776Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-969/meta.json
+++ b/src/data/proofs/erdos-969/meta.json
@@ -154,7 +154,7 @@
     "namespace": "Erdos969",
     "lineCount": 229,
     "axiomCount": 2,
-    "theoremCount": 13,
+    "theoremCount": 12,
     "definitionCount": 7,
     "path": "Proofs/Erdos969Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Remove placeholder `theorem ... → True := trivial` stubs from 7 gallery proof files and update meta.json theorem counts to match.

## Evidence

**Before**: Proof files contained `theorem foo : HypothesisName → True := trivial` stubs that inflate theorem counts and misrepresent formalization depth.

**After**: True-stubs removed; theoremCount in meta.json corrected to reflect actual non-stub theorems in each Lean file.

## Files Changed

| File | Stubs Removed | theoremCount |
|------|--------------|--------------|
| `Erdos279Problem.lean` | `small_k_covers` | 2 → 1 |
| `Erdos465Problem.lean` | `sarkozy_weaker_than_konyagin`, `exponent_optimal` | 7 → 5 |
| `Erdos478Problem.lean` | `klurman_munsch_average` | 6 → 5 |
| `Erdos776Problem.lean` | `size_availability` | 13 → 12 |
| `Erdos969Problem.lean` | `rh_follows_from_conjecture` | 13 → 12 |
| `KroneckersJugendtraum.lean` | `hilbert12_solved_for_rationals` | (no count in meta) |
| `FourColorTheoremOQ02.lean` | `small_ring_not_needed` | (no count in meta) |

---
Automated repair by lean-mechanic agent.