### PR TITLE
Enrich 14 gallery entries to 100% quality (batch)

### DIFF
--- a/src/data/proofs/collatz-cycles/meta.json
+++ b/src/data/proofs/collatz-cycles/meta.json
@@ -112,6 +112,28 @@
   ],
   "crossReferences": [
   ],
+  "mainTheorems": [
+    {
+      "name": "collatz_no_fixpoint",
+      "type": "core",
+      "description": "No fixed points: collatz(n) = n implies n = 0"
+    },
+    {
+      "name": "collatz_no_two_cycle",
+      "type": "core",
+      "description": "No 2-cycles: collatz²(n) = n implies n = 0"
+    },
+    {
+      "name": "one_period_is_three",
+      "type": "core",
+      "description": "The orbit of 1 has minimal period 3: {1, 4, 2}"
+    },
+    {
+      "name": "small_numbers_reach_one",
+      "type": "supporting",
+      "description": "All n ∈ [1,20] reach 1 under iteration, verified by native_decide"
+    }
+  ],
   "leanFile": {
     "lineCount": 256,
     "path": "Proofs/CollatzCycles.lean",


### PR DESCRIPTION
## Batch enrichment: 14 gallery entries to 100% quality

### Current commit: collatz-cycles
- Added mainTheorems: collatz_no_fixpoint, collatz_no_two_cycle, one_period_is_three, small_numbers_reach_one

### All entries enriched in this session
1. taylor-sincos-convergence-oq-01 (q45→100)
2. binary-gcd (q98→100)
3. birthday-problem-oq-02-oq-01 (q98→100)
4. borsuk-ulam-oq-02-oq-01 (q98→100)
5. cantor-diag-oq-03-oq-01-incomplete-01 (q98→100)
6. cayley-hamilton-minpoly-oq-05-oq-01-oq-02 (q98→100)
7. chinese-remainder-constructive-oq-04-oq-03 (q98→100)
8. buffons-needle-oq-01-oq-01-oq-01 (q98→100)
9. derangements-oq-02-oq-02 (q98→100)
10. euler-totient-oq-01 (q98→100)
11. chinese-remainder-non-coprime-oq-03 (q98→100)
12. arithmetic-series-oq-02-oq-01-oq-01 (q98→100)
13. amgm-inequality-oq-03-oq-03 (already 100%, skipped)
14. collatz-cycles (q98→100)

### Verification
- `pnpm build` passes