### PR TITLE
fix: correct sorry counts for 3 gallery entries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9622,10 +9622,10 @@
       "result": "clean"
     },
     "hilbert-13-oq-04": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-05T16:08:43Z",
-      "result": "clean"
+      "lastAudited": "2026-04-06T05:43:23Z",
+      "result": "issues-fixed"
     },
     "hilbert-14": {
       "agentId": "auditor-cycle-20-batch",
@@ -10485,10 +10485,10 @@
       "result": "clean"
     },
     "roth-theorem-k3-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-03T17:37:38Z",
-      "result": "clean"
+      "lastAudited": "2026-04-06T05:43:23Z",
+      "result": "issues-fixed"
     },
     "roth-theorem-k3-oq-02": {
       "auditCount": 2,
@@ -12007,9 +12007,9 @@
       "issues": []
     },
     "fourier-series-oq-02-incomplete-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-06T00:33:16Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-04-06T05:43:23Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "taylor-sincos-convergence-oq-01": {


### PR DESCRIPTION
## Summary

- **roth-theorem-k3-oq-01**: sorries 5→4 (`density_upper_bound_from_iteration` was removed)
- **hilbert-13-oq-04**: sorries 1→0 (`covDimLE_of_embedding` now fully proved)
- **fourier-series-oq-02-incomplete-01**: sorries 5→4 (`fourier_holder_bound` now proved)

## Context

All three entries had stale sorry counts in meta.json that didn't reflect recent proof progress. The Lean source files had fewer sorries than claimed due to theorems being proved or removed without updating the gallery metadata.

## Test plan

- [ ] `pnpm build` passes
- [ ] Gallery pages show correct sorry counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)