### PR TITLE
fix: correct sorry counts for 3 gallery entries

### DIFF
--- a/src/data/proofs/fourier-series-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-incomplete-01/meta.json
@@ -25,11 +25,11 @@
       "Finset"
     ],
     "namespace": "FourierDecayInfra",
-    "lineCount": 242,
+    "lineCount": 280,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 0,
-    "sorries": 5
+    "sorries": 4
   },
   "meta": {
     "author": "Classical (Bernstein, Zygmund, Sobolev)",
@@ -46,7 +46,7 @@
       "open-question"
     ],
     "badge": "formalized",
-    "sorries": 5,
+    "sorries": 4,
     "dateAdded": "2026-04-05",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -78,8 +78,8 @@
       "Clear dependency graph: Lipschitz -> Holder bound -> main theorem"
     ],
     "axiomCount": 0,
-    "lineCount": 242,
-    "assumptions": "5 sorry(s): fourier_lipschitz_bound, fourier_holder_bound, summable_norm_fourierCoeff_of_decay, holderWith_of_dist_bound, decay_implies_regularity'"
+    "lineCount": 280,
+    "assumptions": "4 sorry(s): fourier_lipschitz_bound (last step: quotient_dist_le), summable_norm_fourierCoeff_of_decay, holderWith_of_dist_bound, decay_implies_regularity'. (fourier_holder_bound now fully proved via rpow_interpolation.)"
   },
   "overview": {
     "historicalContext": "The relationship between smoothness and Fourier decay is one of the oldest themes in harmonic analysis. Bernstein (1914) proved the forward direction: if f is alpha-Holder continuous on the circle, then its Fourier coefficients satisfy ||c_n|| = O(1/|n|^alpha). This was sharpened by Zygmund (1935) in his monumental 'Trigonometric Series', where he systematically developed the theory of smoothness spaces (Lipschitz, Zygmund, Besov) and their Fourier-analytic characterizations. The partial converse -- fast decay implies regularity -- requires a loss of one derivative, reflecting the Sobolev embedding theorem: H^s(T) embeds into C^alpha(T) only when s > alpha + 1/2. The interpolation technique used here has roots in the Riesz-Thorin interpolation theorem (M. Riesz 1926, Thorin 1938), though the specific rpow interpolation lemma is a simpler pointwise version. The condition beta > alpha + 1 (rather than beta > alpha) is sharp: the Sobolev embedding on the circle S^1 requires spending one full derivative -- half for L^2-to-C^0 passage and half for summability margin. This sharpness was understood by the 1950s through the work of Nikolsky and Besov on embedding theorems for function spaces on compact groups.",

--- a/src/data/proofs/hilbert-13-oq-04/meta.json
+++ b/src/data/proofs/hilbert-13-oq-04/meta.json
@@ -20,9 +20,9 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 6,
-    "assumptions": "6 axioms: unitCube_covDimLE, unitCube_covDim_lower_bound (dimension of [0,1]^n), ostrand_separating_maps (Ostrand 1965), generalized_kolmogorov_arnold (generalized KA theorem), sternfeld_characterization (Sternfeld 1985), superposition_2n_plus_1_sharp (optimality of 2n+1). 1 sorry: covDimLE_of_embedding (dimension monotonicity under continuous injection).",
+    "assumptions": "6 axioms: unitCube_covDimLE, unitCube_covDim_lower_bound (dimension of [0,1]^n), ostrand_separating_maps (Ostrand 1965), generalized_kolmogorov_arnold (generalized KA theorem), sternfeld_characterization (Sternfeld 1985), superposition_2n_plus_1_sharp (optimality of 2n+1). 0 sorries (covDimLE_of_embedding now fully proved).",
     "dateAdded": "2026-03-30",
     "hilbertNumber": 13,
     "mathlibDependencies": [
@@ -60,7 +60,7 @@
       "Continuous function spaces"
     ],
     "mathlib_version": "4.26.0",
-    "lineCount": 406,
+    "lineCount": 443,
     "relatedProblems": [
       {
         "id": "hilbert-13",
@@ -162,8 +162,8 @@
     "path": "Proofs/Hilbert13GeneralSpaces.lean",
     "filename": "Hilbert13GeneralSpaces.lean",
     "axiomCount": 6,
-    "sorries": 1,
-    "lineCount": 406
+    "sorries": 0,
+    "lineCount": 443
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/roth-theorem-k3-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-01/meta.json
@@ -17,9 +17,9 @@
       "roth-number"
     ],
     "badge": "wip",
-    "sorries": 5,
+    "sorries": 4,
     "axiomCount": 0,
-    "assumptions": "0 axioms. 5 sorries: density_upper_bound_from_iteration (density iteration needs M ≥ N^c), roth_quantitative_upper_bound, behrend_lower_bound, bloom_sisask_bound, kelley_meka_upper_bound.",
+    "assumptions": "0 axioms. 4 sorries: roth_quantitative_upper_bound, behrend_lower_bound, bloom_sisask_bound, kelley_meka_upper_bound. (density_upper_bound_from_iteration was removed — the claim r₃(N) ≤ 10√N is false for large N.)",
     "dateAdded": "2026-03-29",
     "mathlibDependencies": [
       {
@@ -50,7 +50,7 @@
       "Proof of max_iterations_bound: density increment iteration count ≤ ⌊100/δ²⌋",
       "Formal statements of 4 quantitative bounds: Roth, Behrend, Bloom-Sisask, Kelley-Meka"
     ],
-    "lineCount": 242,
+    "lineCount": 234,
     "theoremCount": 19,
     "definitionCount": 2,
     "mathlib_version": "4.26.0"
@@ -107,7 +107,7 @@
       "title": "Part II: Density Increment Iteration Bound",
       "startLine": 139,
       "endLine": 183,
-      "summary": "max_iterations_bound: after >⌊100/δ²⌋ density increments of δ²/100, density exceeds 1 (proved). iterations_before_contradiction (proved). density_upper_bound_from_iteration: 1 sorry — blocked by missing modulus decay bound M≥N^c.",
+      "summary": "max_iterations_bound: after >⌊100/δ²⌋ density increments of δ²/100, density exceeds 1 (proved). iterations_before_contradiction (proved). density_upper_bound_from_iteration was removed — the claim r₃(N) ≤ 10√N is false for large N (Behrend gives r₃(N) >> √N). 0 sorries.",
       "mathContext": "If $\\delta_k = \\delta + k\\delta^2/100 > 1$ then $k > \\lfloor 100/\\delta^2\\rfloor$. The sorry: density increment gives $M < N$ but no lower bound on $M$; need $M \\geq N^c$ (Roth uses $M\\geq N^{2/3}$) to count iterations."
     },
     {
@@ -175,11 +175,11 @@
       "Finset"
     ],
     "namespace": "Szemeredi.Roth.Quantitative",
-    "lineCount": 242,
+    "lineCount": 234,
     "axiomCount": 0,
     "theoremCount": 19,
     "definitionCount": 2,
     "path": "Proofs/RothTheoremQuantitative.lean",
-    "sorries": 5
+    "sorries": 4
   }
 }


### PR DESCRIPTION
## Summary

- **roth-theorem-k3-oq-01**: sorries 5→4 (`density_upper_bound_from_iteration` removed as mathematically false — Behrend gives r₃(N) >> √N), lineCount 242→234
- **hilbert-13-oq-04**: sorries 1→0 (`covDimLE_of_embedding` now fully proved), lineCount 406→443
- **fourier-series-oq-02-incomplete-01**: sorries 5→4 (`fourier_holder_bound` proved via rpow_interpolation), lineCount 242→280

## Test plan

- [x] All three meta.json files are valid JSON
- [x] Sorry counts verified by `grep -c '\bsorry\b'` against Lean source files
- [x] Line counts verified by `wc -l` against Lean source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)