### PR TITLE
Enrich 47 gallery entries: add mainTheorems (batch)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
@@ -299,6 +299,23 @@
       "The file contains 7 vestigial computational lemmas from earlier proof strategies (mod-13 facts, `closure_cycle_swap_eq_top`, etc.) that are no longer used in the main proof. Can these be removed or moved to a separate pedagogical file?"
     ]
   },
+  "mainTheorems": [
+    {
+      "name": "gal_eq_S5",
+      "type": "core",
+      "description": "The Galois group of x⁵ - 4x + 2 over ℚ is isomorphic to S₅, proved by eliminating all candidate orders except 120 via Sylow theory and discriminant analysis — the heart of the Abel-Ruffini concrete instance."
+    },
+    {
+      "name": "roots_not_solvable_by_rad",
+      "type": "core",
+      "description": "The roots of x⁵ - 4x + 2 cannot be expressed by radicals, concluded by the Galois bridge: solvableByRad.isSolvable' gives solvable Galois group ⟹ solvable by radicals, but Gal ≅ S₅ is not solvable."
+    },
+    {
+      "name": "p_irreducible",
+      "type": "supporting",
+      "description": "x⁵ - 4x + 2 is irreducible over ℚ, proved by Eisenstein's criterion at p = 2: all non-leading coefficients divisible by 2, constant term not divisible by 4."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib"

--- a/src/data/proofs/ballot-problem-oq-01-oq-04/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-04/meta.json
@@ -151,6 +151,23 @@
       "Can a q-analog of the Chung-Feller theorem be formalized, tracking the area under the path?"
     ]
   },
+  "mainTheorems": [
+    {
+      "name": "prepend_one_good_rotation",
+      "type": "core",
+      "description": "Applying the cycle lemma to a prepended balanced path shows exactly 1 of the 2n+1 cyclic rotations has all partial sums positive — the key structural fact for the Chung-Feller theorem."
+    },
+    {
+      "name": "prepend_mem_kCountedSequence",
+      "type": "core",
+      "description": "Prepending +1 to a balanced ±1 path of length 2n yields an element of kCountedSequence 1 (n+1) n, placing it within the cycle lemma's domain."
+    },
+    {
+      "name": "balanced_path_total",
+      "type": "supporting",
+      "description": "The counting identity C(2n,n) = Cₙ × (n+1) connects total balanced path count to Catalan numbers, showing any uniform (n+1)-partition yields exactly Cₙ members per type."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Proofs.BallotProblemOQ01",

--- a/src/data/proofs/basel-problem-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-02/meta.json
@@ -207,6 +207,23 @@
       "description": "Irrationality of √2 is the classical prototype for irrationality proofs — Apéry's proof of ζ(3) irrationality uses a far more sophisticated descendant of the same diophantine approximation tradition"
     }
   ],
+  "mainTheorems": [
+    {
+      "name": "zetaValue_two_transcendental",
+      "type": "core",
+      "description": "ζ(2) = π²/6 is transcendental, proved from the Lindemann axiom (π transcendental) via transcendental_pow_of_transcendental — the first machine-verified even-zeta transcendence result."
+    },
+    {
+      "name": "transcendental_pow_of_transcendental",
+      "type": "core",
+      "description": "If x is transcendental then x^n is transcendental for n ≥ 1, providing the algebraic backbone for deriving ζ(2) and ζ(4) transcendence from π transcendence."
+    },
+    {
+      "name": "even_odd_hierarchy",
+      "type": "supporting",
+      "description": "Structural implication chain connecting ζ(2) transcendence with the irrationality conjecture for odd zeta values, showing the transcendence conjecture implies all known partial results as corollaries."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.NumberTheory.ZetaValues",

--- a/src/data/proofs/bezout-identity-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01/meta.json
@@ -56,6 +56,23 @@
       "Connect extGcd to matrix arithmetic: the algorithm corresponds to unimodular 2×2 integer matrices"
     ]
   },
+  "mainTheorems": [
+    {
+      "name": "extGcd_bezout",
+      "type": "core",
+      "description": "For any inputs a and b, the extended Euclidean algorithm satisfies a·x + b·y = g, proved by well-founded induction with the division algorithm closing the inductive step via linear_combination."
+    },
+    {
+      "name": "extGcd_gcd",
+      "type": "core",
+      "description": "The third component of extGcd equals Nat.gcd a b, establishing GCD correctness by chaining Nat.gcd_comm and Nat.gcd_rec identities."
+    },
+    {
+      "name": "bezout_via_extGcd",
+      "type": "supporting",
+      "description": "The classical existential Bézout identity ∃ x y, gcd(a,b) = a·x + b·y, derived using extGcdX and extGcdY as explicit computable witnesses."
+    }
+  ],
   "leanFile": {
     "namespace": "BezoutIdentityOQ01",
     "lineCount": 208,

--- a/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
@@ -117,6 +117,23 @@
       "The rational canonical form has been formalized in Coq (Cano-Dénès 2012) and Isabelle (Divasón-Thiemann 2016) — could a porting strategy from one of these reduce the estimated 1800-line effort?"
     ]
   },
+  "mainTheorems": [
+    {
+      "name": "aeval_companionMatrix",
+      "type": "core",
+      "description": "The companion matrix C(p) is annihilated by p: p(C(p)) = 0, proved via the orbit argument showing C(p)^k·e₀ = e_k for k < d and the last-column action."
+    },
+    {
+      "name": "charpoly_companionMatrix",
+      "type": "core",
+      "description": "The characteristic polynomial of C(p) equals p itself, confirming that companion matrices realize any monic polynomial as their own characteristic polynomial."
+    },
+    {
+      "name": "minpoly_companionMatrix",
+      "type": "supporting",
+      "description": "The minimal polynomial of C(p) equals p, establishing that companion matrices are non-derogatory — minpoly = charpoly — a key property for rational canonical form."
+    }
+  ],
   "crossReferences": [
     {
       "relationship": "Extends parent with concrete companion matrix construction",

--- a/src/data/proofs/cevas-theorem-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-02-oq-01-oq-03/meta.json
@@ -169,6 +169,23 @@
       "notes": "Chapter 4 covers Ceva's theorem and its applications to triangle centers; the division ratio interpretation BD/DC = \u03b2/\u03b1 is presented as the natural barycentric coordinate reading"
     }
   ],
+  "mainTheorems": [
+    {
+      "name": "weight_division_ratio",
+      "type": "core",
+      "description": "The main result: D = (α·B + β·C)/(α+β) satisfies BD/DC = β/α, giving the precise geometric interpretation of weight parameters in Ceva's theorem."
+    },
+    {
+      "name": "ceva_balance_iff_unit_product",
+      "type": "core",
+      "description": "The weight balance condition α_D·α_E·α_F = β_D·β_E·β_F is equivalent to the classical Ceva product (BD/DC)·(CE/EA)·(AF/FB) = 1, bridging the weight formulation to the original theorem."
+    },
+    {
+      "name": "weight_midpoint_iff_of_ne",
+      "type": "supporting",
+      "description": "D is the midpoint of BC if and only if α = β (when B ≠ C), characterizing the equal-weight case as the centroid configuration."
+    }
+  ],
   "leanFile": {
     "lineCount": 296,
     "path": "Proofs/CevasTheoremOQ02OQ01OQ03.lean",

--- a/src/data/proofs/cramers-rule-oq-02/meta.json
+++ b/src/data/proofs/cramers-rule-oq-02/meta.json
@@ -152,6 +152,23 @@
       "relationship": "Sibling extension: OQ-01 connects Cramer's Rule to Cayley-Hamilton theorem; OQ-02 analyzes its computational complexity."
     }
   ],
+  "mainTheorems": [
+    {
+      "name": "gauss_beats_cramer",
+      "type": "core",
+      "description": "For n ≥ 4, Gaussian elimination (n³ multiplications) is strictly faster than Cramer's rule ((n+1)·n·n! multiplications), proved from the key growth lemma n! > n²."
+    },
+    {
+      "name": "cramer_asymptotically_worse",
+      "type": "core",
+      "description": "For any constant K, there exists N such that for all n ≥ N, K·n³ < (n+1)·n·n! — the gap between Gaussian and Cramer grows super-polynomially without bound."
+    },
+    {
+      "name": "factorial_gt_sq",
+      "type": "supporting",
+      "description": "n! > n² for all n ≥ 4, proved by strong induction — the key growth lemma from which the entire complexity comparison follows via nlinarith."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.Data.Nat.Factorial.Basic",

--- a/src/data/proofs/desargues-theorem-oq-01/meta.json
+++ b/src/data/proofs/desargues-theorem-oq-01/meta.json
@@ -144,6 +144,23 @@
       "How does this relate to Pappus's theorem, which implies Desargues in characteristic ≠ 2?"
     ]
   },
+  "mainTheorems": [
+    {
+      "name": "desargues_forward_K",
+      "type": "core",
+      "description": "The forward direction of Desargues's theorem over any CommRing K: if two triangles are perspective from a point then they are perspective from a line, proved via the master algebraic identity det(P,Q,R) = det(AA',BB',CC')·det(A,B,C)·det(A',B',C')."
+    },
+    {
+      "name": "desargues_converse_K",
+      "type": "core",
+      "description": "The converse direction over any IntegralDomain K with non-degeneracy: perspective from a line implies perspective from a point, using cancellation in an integral domain."
+    },
+    {
+      "name": "lagrange_cross_K",
+      "type": "supporting",
+      "description": "The Lagrange cross product identity (a×b)×(c×d) = det(a,b,d)·c − det(a,b,c)·d over any CommRing K, the key bridge expressing intersection points as linear combinations."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.LinearAlgebra.Matrix.Determinant.Basic",

--- a/src/data/proofs/erdos-103/meta.json
+++ b/src/data/proofs/erdos-103/meta.json
@@ -250,6 +250,23 @@
       "note": "Section 2.1 surveys minimum-diameter point configurations with unit separation; discusses h(n) and related questions"
     }
   ],
+  "mainTheorems": [
+    {
+      "name": "ErdosConjecture103",
+      "type": "core",
+      "description": "Formal definition of the main conjecture: h(n) → ∞ as n → ∞, where h(n) counts incongruent optimal point configurations minimizing diameter with unit minimum separation."
+    },
+    {
+      "name": "congruent_refl",
+      "type": "supporting",
+      "description": "Congruence of point configurations is reflexive — the identity isometry witnesses self-congruence, establishing the base property of the congruence equivalence relation."
+    },
+    {
+      "name": "WeakConjecture",
+      "type": "supporting",
+      "description": "The weaker form h(n) ≥ 2 for all sufficiently large n — even this much weaker version of the main conjecture remains open, illustrating the difficulty of the problem."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib"

--- a/src/data/proofs/erdos-164/meta.json
+++ b/src/data/proofs/erdos-164/meta.json
@@ -125,6 +125,23 @@
       "Are there quantitative stability results (if the sum is close to the maximum, must A be close to the primes)?"
     ]
   },
+  "mainTheorems": [
+    {
+      "name": "lichtman_theorem",
+      "type": "core",
+      "description": "Lichtman's 2023 theorem: for any primitive set A, the sum Σ 1/(n log n) satisfies primitiveSum A ≤ primeSum, i.e., primes uniquely maximize the sum among all primitive sets."
+    },
+    {
+      "name": "primes_primitive",
+      "type": "core",
+      "description": "The set of prime numbers forms a primitive set — no prime divides another — proved using Nat.Prime.eq_one_or_self_of_dvd from Mathlib."
+    },
+    {
+      "name": "erdos_164_main",
+      "type": "supporting",
+      "description": "The summary theorem combining Lichtman's maximality result with uniqueness: primes are the unique maximizer of Σ 1/(n log n) over all primitive sets."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.Data.Nat.Prime.Basic",

--- a/src/data/proofs/erdos-175/meta.json
+++ b/src/data/proofs/erdos-175/meta.json
@@ -176,6 +176,23 @@
       "What is the distribution of the \"champion prime\" $p_n = \\arg\\max_p v_p\\binom{2n}{n}$ — is it typically small or large?"
     ]
   },
+  "mainTheorems": [
+    {
+      "name": "granville_ramare_1996",
+      "type": "core",
+      "description": "The main theorem axiomatizing Granville-Ramaré's 1996 result: C(2n,n) is not squarefree for all n ≥ 5, completing the solution to Erdős's problem."
+    },
+    {
+      "name": "c_10_5_not_squarefree",
+      "type": "supporting",
+      "description": "Concrete verified instance: C(10,5) = 252 = 2²·3²·7 is not squarefree, proved by norm_num as a machine-checked small case."
+    },
+    {
+      "name": "sander_1992_f_unbounded",
+      "type": "supporting",
+      "description": "Sander's 1992 result that f(n) = max_p v_p(C(2n,n)) tends to infinity, establishing that the prime power exponents of central binomial coefficients grow without bound."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib"

--- a/src/data/proofs/erdos-195/meta.json
+++ b/src/data/proofs/erdos-195/meta.json
@@ -145,6 +145,23 @@
       "What is the answer for other groups (e.g., ℤ²)?"
     ]
   },
+  "mainTheorems": [
+    {
+      "name": "adenwalla_2022",
+      "type": "core",
+      "description": "Adenwalla's 2022 result: there exists a permutation of ℤ that avoids all 5-term monotone arithmetic progressions, establishing k ≤ 4 as the best known upper bound."
+    },
+    {
+      "name": "erdos_195_summary",
+      "type": "core",
+      "description": "Combined theorem packaging the full state of knowledge: 3 ≤ k ≤ 4 where k is the largest integer such that every permutation of ℤ contains a k-term monotone arithmetic progression."
+    },
+    {
+      "name": "adenwalla_implies_geneson",
+      "type": "supporting",
+      "description": "Proved theorem: Adenwalla's bound (k ≤ 4) implies Geneson's earlier bound (k ≤ 5), showing the logical relationship between successive upper bound improvements."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.Data.Nat.Basic",

--- a/src/data/proofs/erdos-22/meta.json
+++ b/src/data/proofs/erdos-22/meta.json
@@ -136,6 +136,23 @@
       "Can the polylogarithmic independence bound be improved further?"
     ]
   },
+  "mainTheorems": [
+    {
+      "name": "conjecture_resolved",
+      "type": "core",
+      "description": "Fully proved theorem deriving the Bollobás-Erdős conjecture from the Fox-Loh-Zhao axiom: K₄-free graphs on n vertices can have ≥ n²/8 edges with independence number ≤ εn, for any ε > 0 and large n."
+    },
+    {
+      "name": "fox_loh_zhao_2015",
+      "type": "core",
+      "description": "Axiomatized Fox-Loh-Zhao 2015 result: there exist K₄-free graphs with ≥ n²/8 edges and independence number only O((log log n)^{3/2}/(log n)^{1/2}·n), far smaller than any linear εn."
+    },
+    {
+      "name": "erdos_22_summary",
+      "type": "supporting",
+      "description": "Summary theorem combining the Ramsey-Turán density ρ₄ = 1/4, the resolved conjecture, and the polylogarithmic independence bound into a single statement of the full result."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib"

--- a/src/data/proofs/erdos-284/meta.json
+++ b/src/data/proofs/erdos-284/meta.json
@@ -143,6 +143,23 @@
       "Extension to representations of other rationals p/q"
     ]
   },
+  "mainTheorems": [
+    {
+      "name": "f_asymptotic",
+      "type": "core",
+      "description": "The asymptotic formula f(k) = (1+o(1))·k/(e-1): for any ε > 0 there exists K such that (1-ε)k/(e-1) ≤ f(k) ≤ (1+ε)k/(e-1) for all k ≥ K, combining the upper bound and Croot's lower bound."
+    },
+    {
+      "name": "croot_2001",
+      "type": "core",
+      "description": "Croot's 2001 constructive theorem: for any N > 1 there exist distinct integers in (N, eN] whose reciprocals sum to exactly 1, establishing the lower bound f(k) ≥ (1-o(1))·k/(e-1)."
+    },
+    {
+      "name": "erdos_284_summary",
+      "type": "supporting",
+      "description": "Summary theorem combining both bounds into the definitive resolution of Erdős Problem #284: f(k) = (1+o(1))·k/(e-1) where the constant 1/(e-1) arises from the integral ∫₁ᵉ 1/x dx = 1."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.Data.Nat.Basic",

--- a/src/data/proofs/erdos-633/meta.json
+++ b/src/data/proofs/erdos-633/meta.json
@@ -128,6 +128,23 @@
       "Are there square-only triangles not in Soifer's family (sides √p, √q, √r)?"
     ]
   },
+  "mainTheorems": [
+    {
+      "name": "universal_square_dissection",
+      "type": "core",
+      "description": "Every triangle can be dissected into k² congruent copies for any k ≥ 1, by subdividing each side into k equal segments and connecting corresponding points — the universal lower bound on achievable dissection counts."
+    },
+    {
+      "name": "erdos_633_classification",
+      "type": "core",
+      "description": "Formal statement of the open classification problem: characterize all triangles T such that any dissection of T into n congruent triangles requires n to be a perfect square."
+    },
+    {
+      "name": "similar_dissection_complete",
+      "type": "supporting",
+      "description": "Characterization of square-only triangles in the similar (not congruent) case, contrasting with the open congruent case that is the subject of Erdős's $25 prize."
+    }
+  ],
   "leanFile": {
     "imports": [],
     "opens": [],

--- a/src/data/proofs/erdos-820/meta.json
+++ b/src/data/proofs/erdos-820/meta.json
@@ -169,6 +169,23 @@
       "Connection to the Artin primitive root conjecture"
     ]
   },
+  "mainTheorems": [
+    {
+      "name": "erdos820Conjecture1",
+      "type": "core",
+      "description": "The main open conjecture: H(n) = 3 for infinitely many n, equivalently gcd(2^n - 1, 3^n - 1) = 1 for infinitely many n — the simplest instance of coprimality in exponential sequences."
+    },
+    {
+      "name": "van_doorn_lower_bound",
+      "type": "core",
+      "description": "Van Doorn's improvement of Erdős's 1974 bound: H(n) > exp(n^{c/log log n}) for infinitely many n, establishing the best known lower bound on the growth of H(n)."
+    },
+    {
+      "name": "erdos_820_summary",
+      "type": "supporting",
+      "description": "Summary theorem combining the main conjecture, known bounds, and the connection to Problem #770, giving a complete picture of the current state of knowledge."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.Data.Nat.GCD.Basic",

--- a/src/data/proofs/erdos-908/meta.json
+++ b/src/data/proofs/erdos-908/meta.json
@@ -158,6 +158,23 @@
       "What is the relationship between the rigid component and invariant measures in ergodic theory? Can the decomposition be interpreted dynamically?"
     ]
   },
+  "mainTheorems": [
+    {
+      "name": "laczkovich_decomposition",
+      "type": "core",
+      "description": "Laczkovich's 1980 theorem: every function f : ℝ → ℝ with measurable differences decomposes as f = g + h + r where g is continuous, h is additive, and r is rigid (a.e. translation-invariant). This resolves the de Bruijn-Erdős conjecture."
+    },
+    {
+      "name": "additive_zero",
+      "type": "supporting",
+      "description": "Verified theorem: any additive function h satisfies h(0) = 0, proved directly from the functional equation h(x+y) = h(x) + h(y) by setting x = y = 0."
+    },
+    {
+      "name": "erdos_908_summary",
+      "type": "supporting",
+      "description": "Comprehensive summary theorem combining the decomposition theorem with verification that continuous and additive functions have measurable differences, and that measurable f forces h = 0 in the decomposition."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.MeasureTheory.Function.AEMeasurableOrder",

--- a/src/data/proofs/feuerbachs-theorem-oq-05/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-05/meta.json
@@ -124,6 +124,23 @@
       "description": "Ptolemy's theorem is proved via inversive geometry — inversion maps circles to lines in both theorems; the technique is the same"
     }
   ],
+  "mainTheorems": [
+    {
+      "name": "feuerbach_inversive_parallel_lines",
+      "type": "core",
+      "description": "Under inversion at the Feuerbach point F, the nine-point circle and the incircle map to parallel lines — the geometric core of the inversive proof strategy, establishing that ∃ λ ≠ 0, N-F = λ·(I-F)."
+    },
+    {
+      "name": "circle_to_line",
+      "type": "core",
+      "description": "The Circle-to-Line theorem: inversion at a point O on a circle maps the circle to a line, proved via the algebraic identity |PO|² = 2(P-O)·(C-O) for any P on the circle."
+    },
+    {
+      "name": "feuerbachPoint_on_ninePointCircle",
+      "type": "supporting",
+      "description": "The Feuerbach point lies on the nine-point circle (dist2(N,F) = R₉), proved from the explicit coordinate definition F = N + (R₉/d)·(I-N) where d = R₉ - r."
+    }
+  ],
   "leanFile": {
     "namespace": "FeuerbachsTheoremOQ05",
     "lineCount": 266,

--- a/src/data/proofs/hilbert-17-oq-01/meta.json
+++ b/src/data/proofs/hilbert-17-oq-01/meta.json
@@ -137,6 +137,23 @@
       "description": "Hilbert's classification of when PSD = polynomial-SOS"
     }
   ],
+  "mainTheorems": [
+    {
+      "name": "two_sos_closed_under_mul",
+      "type": "core",
+      "description": "Product closure: the product of two 2-SOS polynomials is again 2-SOS, proved via the Brahmagupta-Fibonacci identity (a²+b²)(c²+d²) = (ac-bd)² + (ad+bc)² — one line of ring in Lean."
+    },
+    {
+      "name": "brahmagupta_fibonacci_poly",
+      "type": "core",
+      "description": "The Brahmagupta-Fibonacci identity in polynomial form: (p²+q²)(r²+s²) = (pr-qs)² + (ps+qr)², the algebraic engine explaining why 2 squares suffice for univariate PSD polynomials."
+    },
+    {
+      "name": "sos_monotone",
+      "type": "supporting",
+      "description": "SOS monotonicity: if p is k-SOS then p is m-SOS for any m ≥ k, proved by padding with 0² terms via Fin.cons 0 and induction on Nat.le."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib.Data.Real.Basic",

--- a/src/data/proofs/sperner-ndim/meta.json
+++ b/src/data/proofs/sperner-ndim/meta.json
@@ -187,6 +187,23 @@
       "note": "Elementary proof of Sperner's lemma via door-counting parity"
     }
   ],
+  "mainTheorems": [
+    {
+      "name": "sperner_parity",
+      "type": "core",
+      "description": "The Sperner Parity Theorem: the number of fully-colored simplices has the same parity as the number of boundary doors on face d (mod 2), proved unconditionally via door-counting with interior pairing and boundary analysis."
+    },
+    {
+      "name": "sperner_ndim",
+      "type": "core",
+      "description": "The main n-dimensional Sperner's lemma: if boundary doors on face d are odd then a fully-colored simplex exists, proved for any abstract triangulation satisfying the SpernerTriangulation axioms."
+    },
+    {
+      "name": "even_card_fpf_invol",
+      "type": "supporting",
+      "description": "A fixed-point-free involution on a finite set has even cardinality, proved by strong induction — the abstract principle underlying interior door pairing that makes the parity argument work."
+    }
+  ],
   "leanFile": {
     "imports": [
       "Mathlib"


### PR DESCRIPTION
## Batch enrichment: add mainTheorems to 47 gallery entries

### Batch 1-3 (27 entries) — previous pushes
derangements-oq-03-oq-02, abel-ruffini-galois-extensions, algebraic-numbers-countable, algebraic-numbers-countable-oq-02, amgm-inequality-oq-02, amgm-inequality-oq-02-oq-01, ballot-problem-oq-01, ballot-problem-oq-03, bertrands-postulate-oq-03-oq-04, binomial-theorem-oq-04, birthday-problem-oq-03, cauchy-schwarz-oq-04-oq-01, derangements-convergence-oq-01, derangements-oq-02-oq-01, derangements-oq-03-oq-01, erdos-1079, erdos-1162, fourier-series-oq-02-incomplete-01, gcd-algorithm-oq-01-oq-03, geometric-series-oq-02-oq-05, inclusion-exclusion-oq-01, law-of-cosines-oq-01, law-of-cosines-oq-03, law-of-cosines-oq-04, navier-stokes-oq-01, navier-stokes-oq-02

### Batch 4 (20 entries) — current commit
ballot-problem-oq-01-oq-04, basel-problem-oq-02, bezout-identity-oq-01, cayley-hamilton-reduction-oq-02-oq-01, cevas-theorem-oq-02-oq-01-oq-03, cramers-rule-oq-02, desargues-theorem-oq-01, erdos-103, erdos-164, erdos-175, erdos-195, erdos-22, erdos-284, erdos-633, erdos-820, erdos-908, feuerbachs-theorem-oq-05, hilbert-17-oq-01, sperner-ndim, abel-ruffini-oq-04-oq-01

### Verification
- `pnpm build` passes for all changes