### PR TITLE
Fix: correct erdos-606-oq-03 status from verified to axiomatized

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -11281,11 +11281,12 @@
     },
     {
       "slug": "fourier-series-oq-02-incomplete-01",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-03T09:15:40.651Z",
-      "status": "active",
-      "lastUpdate": "2026-04-03T09:15:40.651Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-06T06:37:41.192Z",
+      "completed": "2026-04-06T06:37:41.192Z"
     },
     {
       "slug": "fourier-series-oq-02-oq-03-oq-02-incomplete-01",
@@ -15587,11 +15588,12 @@
     },
     {
       "slug": "taylor-sincos-convergence-oq-01",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "fast",
       "started": "2026-04-06T03:14:36.241Z",
-      "status": "active",
-      "lastUpdate": "2026-04-06T03:14:36.241Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-06T06:37:41.268Z",
+      "completed": "2026-04-06T06:37:41.268Z"
     },
     {
       "slug": "triangular-reciprocals-oq-02",
@@ -15608,6 +15610,70 @@
       "started": "2026-04-06T05:37:41.551Z",
       "status": "active",
       "lastUpdate": "2026-04-06T05:37:41.552Z"
+    },
+    {
+      "slug": "collatz-cycles-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-06T06:37:41.264Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T06:37:41.264Z"
+    },
+    {
+      "slug": "divisibility-rules-oq-02",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-06T06:37:41.264Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T06:37:41.264Z"
+    },
+    {
+      "slug": "euler-identity-oq-04",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-06T06:37:41.264Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T06:37:41.264Z"
+    },
+    {
+      "slug": "fundamental-arithmetic-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-06T06:37:41.264Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T06:37:41.264Z"
+    },
+    {
+      "slug": "law-of-cosines-oq-06",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-06T06:37:41.264Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T06:37:41.264Z"
+    },
+    {
+      "slug": "pythagorean-theorem-oq-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-06T06:37:41.264Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T06:37:41.264Z"
+    },
+    {
+      "slug": "randomized-maxcut-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-06T06:37:41.264Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T06:37:41.264Z"
+    },
+    {
+      "slug": "sylow-theorems-oq-05",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-06T06:37:41.264Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T06:37:41.264Z"
     }
   ],
   "config": {

--- a/src/data/proofs/erdos-606-oq-03/meta.json
+++ b/src/data/proofs/erdos-606-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Sylvester, Green-Tao, Motzkin",
     "sourceUrl": "https://erdosproblems.com/606",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos606OQ03.lean",
     "tags": [
       "combinatorial-geometry",
@@ -16,11 +16,11 @@
       "erdos",
       "research"
     ],
-    "badge": "verified",
+    "badge": "axiom",
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 101,
-    "assumptions": "0 axioms, 0 sorries. The 3 stated theorems (max_hyperplanes, line_count_range, hyperplane_extremes) are fully machine-checked. Sylvester-Gallai, Green-Tao, and Motzkin are referenced in comments only — not declared as Lean axioms. The achievable hyperplane counts problem remains open; this file provides a verified computational framework for the extremal bounds.",
+    "assumptions": "Open question formalization: the achievable hyperplane counts problem remains open for all d ≥ 2. The 3 stated theorems (max_hyperplanes, line_count_range, hyperplane_extremes) are trivially true combinatorial facts. Sylvester-Gallai, Green-Tao, and Motzkin are referenced in comments only — not declared as Lean axioms. The Lean file explicitly states this should be classified as axiomatized.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "originalContributions": [


### PR DESCRIPTION
## Fix

Corrects `meta.json` for `erdos-606-oq-03` (Hyperplane Determination in Higher Dimensions): status changed from `verified` to `axiomatized`, badge from `verified` to `axiom`.

## Evidence

**Before**: `status: "verified"`, `badge: "verified"`

**After**: `status: "axiomatized"`, `badge: "axiom"`

**Root cause**: The Lean file `Proofs/Erdos606OQ03.lean` line 96 explicitly states:
> *"Classified axiomatized: the main research question (achievable hyperplane counts) is open."*

The 3 theorems proved in the file are trivially true combinatorial facts:
- `max_hyperplanes`: `n.choose d ≥ 0 := Nat.zero_le _`
- `line_count_range`: `n.choose 2 = n * (n-1) / 2 := by omega`  
- `hyperplane_extremes`: `n < n.choose d`

None of these address the actual open question (which hyperplane counts are achievable for n points in ℝ^d). Marking this `verified` overclaims the achievement and violates the CLAUDE.md policy: "overclaiming `verified` damages credibility."

**Audit tracker**: This entry was flagged as `result: "issues-found"` in `audit-tracker.json` without recorded issue details — this fix resolves the underlying inconsistency.

---
Automated fix by lean-mechanic agent.