### PR TITLE
Fix: sync stale lineCount metadata for 7 gallery proofs

### DIFF
--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -108,7 +108,7 @@
     "dateAdded": "2025-12-29",
     "millenniumProblem": "bsd",
     "proofRepoPath": "Proofs/BirchSwinnertonDyer.lean",
-    "lineCount": 7430,
+    "lineCount": 7409,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -681,7 +681,7 @@
       "ComplexConjugate"
     ],
     "namespace": "BirchSwinnertonDyer",
-    "lineCount": 7430,
+    "lineCount": 7409,
     "axiomCount": 19,
     "theoremCount": 250,
     "definitionCount": 143,

--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -15,8 +15,8 @@
     "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 1285,
-    "assumptions": "0 axioms. 2 sorries in Ghouila-Houri helper lemmas: sc_degree_has_cycle (SC + high degree → initial directed cycle) and ghouila_houri_cycle_extendable (cycle of length k < n → longer cycle). The main ghouila_houri theorem is proved by delegating to these helpers. directed_hamiltonian_threshold is fully proved (0 sorries). Moon-Moser theorem and Rédei are also fully proved.",
+    "lineCount": 1356,
+    "assumptions": "0 axioms. 1 sorry: ghouila_houri_cycle_extendable (cycle of length k < n → longer cycle). The main ghouila_houri theorem delegates to this helper. directed_hamiltonian_threshold, Moon-Moser theorem, and Rédei are all fully proved.",
     "dateAdded": "2026-03-30",
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Hamiltonian_path_problem#Directed_graphs",
@@ -93,7 +93,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Rédei's theorem (every tournament has a Hamiltonian path) is fully proved by induction via the tournament insertion lemma. Moon-Moser's theorem (every strongly connected tournament has a Hamiltonian cycle) is fully proved. directed_hamiltonian_threshold (arc count (n-1)² forces Hamiltonicity) is now fully proved via hamiltonian_of_few_missing_arcs, which was completed by proving the fiber counting lemma hBadFor_bound using Finset.orderIsoOfFin injections into Perm(Fin(n-2)). Only ghouila_houri remains as a sorry (1 sorry). The 1277-line file is the most substantial directed Hamiltonicity formalization in this gallery.",
+    "summary": "Rédei's theorem (every tournament has a Hamiltonian path) is fully proved by induction via the tournament insertion lemma. Moon-Moser's theorem (every strongly connected tournament has a Hamiltonian cycle) is fully proved. directed_hamiltonian_threshold (arc count (n-1)² forces Hamiltonicity) is now fully proved via hamiltonian_of_few_missing_arcs, which was completed by proving the fiber counting lemma hBadFor_bound using Finset.orderIsoOfFin injections into Perm(Fin(n-2)). Only ghouila_houri remains as a sorry (1 sorry). The 1356-line file is the most substantial directed Hamiltonicity formalization in this gallery.",
     "implications": "Directed Hamiltonicity thresholds have applications beyond pure graph theory: tournament Hamiltonian paths correspond to linear extensions of partial orders, with applications to voting theory (ranking candidates) and scheduling. Rédei's theorem has a direct combinatorial interpretation: in any round-robin tournament, there exists a ranking of all players consistent with the match results (as a directed path). Moon-Moser's result shows that strongly connected tournaments (those where outcomes don't create a dominant clique) have circular Hamiltonian cycles — a stronger consistency property.",
     "openQuestions": [
       "Can `ghouila_houri` be fully proved? It requires a longest-path argument tracking both in- and out-degrees (~200 lines), analogous to the undirected Dirac theorem. This is the only remaining sorry.",
@@ -162,9 +162,9 @@
       "Finset"
     ],
     "namespace": "Erdos1012OQ03",
-    "lineCount": 1285,
+    "lineCount": 1356,
     "axiomCount": 0,
-    "sorries": 2,
+    "sorries": 1,
     "path": "Proofs/Erdos1012OQ03.lean",
     "theoremCount": 22,
     "definitionCount": 10

--- a/src/data/proofs/erdos-279/meta.json
+++ b/src/data/proofs/erdos-279/meta.json
@@ -28,7 +28,7 @@
       }
     ],
     "axiomCount": 2,
-    "lineCount": 85,
+    "lineCount": 79,
     "originalContributions": [
       "Formal statement of Erdős Problem 279 as an existential over residue choices for prime moduli",
       "Generalization to arbitrary sets with prime-like density and log-log divergence conditions",
@@ -117,7 +117,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 85,
+    "lineCount": 79,
     "axiomCount": 2,
     "theoremCount": 1,
     "definitionCount": 6,

--- a/src/data/proofs/erdos-465/meta.json
+++ b/src/data/proofs/erdos-465/meta.json
@@ -87,7 +87,7 @@
       }
     ],
     "axiomCount": 3,
-    "lineCount": 270,
+    "lineCount": 256,
     "assumptions": "3 axioms: sarkozy_1976, konyagin_2001, problem_466_lower_bound. Structure fields are object definitions, not assumptions."
   },
   "overview": {
@@ -184,7 +184,7 @@
       "Real"
     ],
     "namespace": "Erdos465",
-    "lineCount": 270,
+    "lineCount": 256,
     "axiomCount": 3,
     "theoremCount": 5,
     "definitionCount": 11,

--- a/src/data/proofs/erdos-478/meta.json
+++ b/src/data/proofs/erdos-478/meta.json
@@ -65,7 +65,7 @@
     ],
     "dateAdded": "2026-01-19",
     "axiomCount": 0,
-    "lineCount": 165,
+    "lineCount": 157,
     "assumptions": "4 axiom(s). Reduced from 10 by proving Wilson's theorem (Mathlib), factorial_residues_nonzero (p∤k!), factorial_as_multiplicative_walk (Nat.factorial_succ), klurman_munsch_average (placeholder → True), ratio_set_full (consecutive factorial ratios cover all nonzero residues), factorial_residue_sqrt_lower (|A_p|² ≥ p-1 via ratio-map surjectivity)."
   },
   "overview": {
@@ -171,7 +171,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 165,
+    "lineCount": 157,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 3,

--- a/src/data/proofs/erdos-776/meta.json
+++ b/src/data/proofs/erdos-776/meta.json
@@ -54,7 +54,7 @@
       "Proved n_not_in_antichain_sizes: size n excluded from antichain distinct sizes"
     ],
     "axiomCount": 3,
-    "lineCount": 391,
+    "lineCount": 385,
     "assumptions": "4 axioms: erdos_trotter_r1 (known, Griggs 1983), erdos_trotter_upper (known), erdos_trotter_achievable (known), erdos_776_threshold (OPEN conjecture). sperner_theorem is proved via Mathlib.",
     "mathlib_version": "4.26.0"
   },
@@ -166,7 +166,7 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 391,
+    "lineCount": 385,
     "axiomCount": 3,
     "theoremCount": 12,
     "definitionCount": 6,

--- a/src/data/proofs/four-color-theorem-oq-02/meta.json
+++ b/src/data/proofs/four-color-theorem-oq-02/meta.json
@@ -19,7 +19,7 @@
     "dateAdded": "2026-03-30",
     "axiomCount": 2,
     "assumptions": "2 axioms inherited from FourColorTheorem.lean: five_color_theorem_nonempty, four_color_theorem_axiom. 0 sorries.",
-    "lineCount": 93
+    "lineCount": 86
   },
   "crossReferences": [
     {
@@ -95,7 +95,7 @@
   },
   "leanFile": {
     "axiomCount": 0,
-    "lineCount": 93,
+    "lineCount": 86,
     "path": "Proofs/FourColorTheoremOQ02.lean",
     "sorries": 0
   }


### PR DESCRIPTION
## Fix

Corrects stale `lineCount` values in `meta.json` (both `meta.lineCount` and `leanFile.lineCount`) for 7 gallery proofs where files evolved after metadata was last recorded.

## Evidence

| Proof | Claimed | Actual | Delta |
|-------|---------|--------|-------|
| erdos-1012-oq-03 | 1285 | 1356 | +71 |
| birch-swinnerton-dyer | 7430 | 7409 | -21 |
| erdos-465 | 270 | 256 | -14 |
| erdos-478 | 165 | 157 | -8 |
| four-color-theorem-oq-02 | 93 | 86 | -7 |
| erdos-776 | 391 | 385 | -6 |
| erdos-279 | 85 | 79 | -6 |

**Additional fixes for erdos-1012-oq-03**:
- `leanFile.sorries`: 2 → 1 (only `ghouila_houri_cycle_extendable` has a sorry; `sc_degree_has_cycle` was completed)
- `meta.assumptions`: corrected "2 sorries" text to "1 sorry"
- `conclusion.summary`: corrected "1277-line file" to "1356-line file"

**Audit context**: `erdos-1012-oq-03` and `birch-swinnerton-dyer` were flagged in `audit-tracker.json` with `result: "issues-found"` but no recorded issue text. The lineCount discrepancies were likely what triggered these flags.

---
Automated fix by lean-mechanic agent.