### PR TITLE
fix: remove True-stub theorem from KummerTheoremOQ01

### DIFF
--- a/proofs/Proofs/KummerTheoremOQ01.lean
+++ b/proofs/Proofs/KummerTheoremOQ01.lean
@@ -98,11 +98,11 @@ theorem multinomial_triple (a b c : ℕ) :
   rw [← key]
   exact Nat.mul_div_cancel _ hpos
 
-/-- Kummer's theorem for multinomials (statement):
-    The p-adic valuation of C(n; k₁,...,kₘ) equals the total number
-    of carries when adding k₁, k₂, ..., kₘ in base p. -/
-theorem kummer_multinomial_statement (p : ℕ) (hp : Nat.Prime p) (ks : List ℕ) :
-    True := by  -- Statement placeholder
-  trivial
+/-
+  Kummer's theorem for multinomials (open formalization):
+  The p-adic valuation of C(n; k₁,...,kₘ) equals the total number
+  of carries when adding k₁, k₂, ..., kₘ in base p.
+  Full formalization requires base-p carry counting (not yet in Mathlib).
+-/
 
 end KummerMultinomial

--- a/src/data/proofs/kummer-theorem-oq-01/meta.json
+++ b/src/data/proofs/kummer-theorem-oq-01/meta.json
@@ -20,7 +20,7 @@
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. All theorems fully proved: multinomial_eq_prod_choose (via companion file KummerTheoremOQ01Aristotle.lean using reverseRecOn induction), multinomial_pair, multinomial_triple.",
     "lineCount": 108,
-    "theoremCount": 4,
+    "theoremCount": 3,
     "definitionCount": 1,
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-03-30"
@@ -50,13 +50,13 @@
   "overview": {
     "historicalContext": "Ernst Kummer proved in 1852 that the highest power of a prime p dividing the binomial coefficient C(n, k) equals the number of carries when adding k and n-k in base p. This elegant theorem connects combinatorics (counting subsets) with the arithmetic of positional numeral systems. The result was rediscovered and generalized throughout the 20th century. The multinomial extension is a natural question: the multinomial coefficient C(n; k₁, k₂, ..., kₘ) counts the number of ways to partition n objects into groups of sizes k₁, ..., kₘ (with n = k₁ + ... + kₘ). The key insight is that multinomial coefficients factor as products of binomials via a telescoping decomposition: C(n; k₁,...,kₘ) = C(k₁+k₂, k₁) · C(k₁+k₂+k₃, k₁+k₂) · ... · C(n, n-kₘ). Applying Kummer's theorem to each factor and summing gives the total carry count when adding k₁, k₂, ..., kₘ successively in base p.",
     "problemStatement": "Can Kummer's theorem — $v_p\\binom{n}{k} = c(k, n-k; p)$ where $c$ counts base-$p$ carries — be extended to multinomial coefficients? That is, does $v_p\\binom{n}{k_1,\\ldots,k_m} = $ total carries when adding $k_1,\\ldots,k_m$ in base $p$? Answer: yes, via iterated binomial decomposition.",
-    "proofStrategy": "The file defines the multinomial coefficient as n! / (k₁! · ... · kₘ!) using `List.sum` and `List.prod`. The key identity `multinomial_eq_prod_choose` is now fully proved via companion file `KummerTheoremOQ01Aristotle.lean`, which uses backward list induction (`List.reverseRecOn`) with two key lemmas: `multinomial_append_singleton` (LHS step: appending k multiplies by C(sum+k,k)) and `rhs_append_singleton` (RHS step: the scanl/zip/tail/prod picks up factor C(sum+k,k)). The `zip_scanl_append_singleton` lemma (proved by generalizing the accumulator and induction on `ks`) is the key auxiliary result. `multinomial_pair` and `multinomial_triple` are proved via `Nat.choose_mul_factorial_mul_factorial`. `kummer_multinomial_statement` is a placeholder stub (returns `True`).",
+    "proofStrategy": "The file defines the multinomial coefficient as n! / (k₁! · ... · kₘ!) using `List.sum` and `List.prod`. The key identity `multinomial_eq_prod_choose` is now fully proved via companion file `KummerTheoremOQ01Aristotle.lean`, which uses backward list induction (`List.reverseRecOn`) with two key lemmas: `multinomial_append_singleton` (LHS step: appending k multiplies by C(sum+k,k)) and `rhs_append_singleton` (RHS step: the scanl/zip/tail/prod picks up factor C(sum+k,k)). The `zip_scanl_append_singleton` lemma (proved by generalizing the accumulator and induction on `ks`) is the key auxiliary result. `multinomial_pair` and `multinomial_triple` are proved via `Nat.choose_mul_factorial_mul_factorial`. The p-adic valuation statement (v_p of multinomial = total carries) is documented as a comment — full formalization requires base-p carry counting not yet in Mathlib.",
     "keyInsights": [
       "The iterated decomposition $\\binom{n}{k_1,\\ldots,k_m} = \\prod_{i=1}^{m} \\binom{k_1+\\cdots+k_i}{k_1+\\cdots+k_{i-1}}$ is the algebraic heart of the extension. Each factor is an ordinary binomial to which Kummer's theorem applies directly.",
       "Kummer's theorem for each binomial factor gives $v_p\\binom{k_1+\\cdots+k_i}{k_1+\\cdots+k_{i-1}} = c(k_i, k_1+\\cdots+k_{i-1}; p)$ — the carries when adding the $i$-th part to the running sum. Summing over all $i$ gives the total carries for adding all parts.",
       "The Lean definition uses `List.scanl (· + ·) 0` to compute running sums, then `zip`s with the original list to form the binomial argument pairs. This matches the mathematical telescoping exactly, but the general proof requires list induction on `ks`.",
       "The pair case `multinomial_pair` is trivially proved using `Nat.add_choose_eq`, confirming the definition is correct. The triple case requires the identity $(a+b+c)!/(a! \\cdot b! \\cdot c!) = (\\binom{a+b}{a})(\\binom{a+b+c}{a+b})$, proved up to the final factorial division.",
-      "The placeholder `kummer_multinomial_statement` returns `True` — a design choice to document the theorem statement without formalizing the full proof, which would require Kummer's theorem from Mathlib and a carry-counting formalism for base-p arithmetic."
+      "The p-adic valuation statement v_p(multinomial(ks)) = total carries is documented as a comment in the file. Full formalization requires a base-p carry-counting formalism not yet available in Mathlib."
     ]
   },
   "sections": [
@@ -93,19 +93,19 @@
       "mathContext": "Pair: $\\frac{(a+b)!}{a! b!} = \\binom{a+b}{a}$ via $\\binom{a+b}{a} \\cdot a! \\cdot b! = (a+b)!$. Triple: $\\frac{(a+b+c)!}{a! b! c!} = \\binom{a+b}{a} \\binom{a+b+c}{a+b}$ via two applications of the same identity."
     },
     {
-      "id": "statement-stub",
-      "title": "Kummer Multinomial Statement (Placeholder)",
+      "id": "valuation-comment",
+      "title": "Kummer Multinomial Valuation (Comment)",
       "startLine": 101,
       "endLine": 108,
-      "summary": "Placeholder `kummer_multinomial_statement` returning `True`. Documents the intended theorem: $v_p(\\text{multinomial}(ks)) = $ total carries when adding elements of $ks$ in base $p$. Not formalized because base-$p$ carry-counting is not yet in Mathlib.",
+      "summary": "Block comment documenting the open formalization: $v_p(\\text{multinomial}(ks)) = $ total carries when adding elements of $ks$ in base $p$. Stated as a comment rather than a theorem because base-$p$ carry-counting is not yet in Mathlib.",
       "mathContext": "$v_p\\binom{n}{k_1,\\ldots,k_m} = \\sum_{i=1}^{m-1} c(k_i, S_{i-1}; p)$ where $c(a,b;p)$ counts carries when adding $a$ and $b$ in base $p$"
     }
   ],
   "conclusion": {
-    "summary": "This file fully establishes the algebraic scaffolding for the multinomial extension of Kummer's theorem. All sorries have been eliminated: `multinomial_eq_prod_choose` is proved via backward list induction in companion file `KummerTheoremOQ01Aristotle.lean`, `multinomial_pair` and `multinomial_triple` are directly proved via `Nat.choose_mul_factorial_mul_factorial`. The main open remaining formalization is `kummer_multinomial_statement` (the p-adic valuation statement itself, currently a `True` stub).",
+    "summary": "This file fully establishes the algebraic scaffolding for the multinomial extension of Kummer's theorem. All sorries have been eliminated: `multinomial_eq_prod_choose` is proved via backward list induction in companion file `KummerTheoremOQ01Aristotle.lean`, `multinomial_pair` and `multinomial_triple` are directly proved via `Nat.choose_mul_factorial_mul_factorial`. The p-adic valuation statement (v_p of multinomial = total carries) is documented as a comment; full formalization awaits base-p carry counting in Mathlib.",
     "implications": "**Divisibility of multinomial coefficients**: Kummer's theorem for multinomials immediately gives a divisibility criterion: $p \\mid \\binom{n}{k_1,\\ldots,k_m}$ if and only if there is at least one carry when adding $k_1,\\ldots,k_m$ in base $p$. The coefficient is NOT divisible by $p$ precisely when $k_1,\\ldots,k_m$ are the base-$p$ digits of $n$ in some order — this generalizes Lucas' theorem to multiple parts.\n\n**Lucas' theorem and its multinomial extension**: Lucas' theorem states $\\binom{m}{n} \\equiv \\prod_i \\binom{m_i}{n_i} \\pmod{p}$ where $m_i, n_i$ are the base-$p$ digits of $m$ and $n$. The multinomial analog (Granville 1997) states $\\binom{n}{k_1,\\ldots,k_m} \\equiv \\prod_{\\text{digits}} \\binom{n_j}{k_{1,j},\\ldots,k_{m,j}} \\pmod{p}$, where the product is over digit positions. This is a direct consequence of the carry-count formula: zero carries means the digits don't interact.\n\n**Combinatorial identities**: The `multinomial_eq_prod_choose` identity is a generating function identity: it gives the coefficient of $x_1^{k_1} \\cdots x_m^{k_m}$ in $(x_1+\\cdots+x_m)^n$ as the telescoping product. This is used to prove the multinomial theorem, Vandermonde's identity (which is the $m=2$ case), and various symmetric function identities.\n\n**q-Analogs and Gaussian binomials**: The $q$-multinomial coefficient $\\binom{n}{k_1,\\ldots,k_m}_q$ (Gaussian multinomial) satisfies an analogous carry-count theorem at roots of unity. The iterated decomposition $\\binom{n}{k_1,\\ldots,k_m}_q = \\prod_i \\binom{S_i}{k_i}_q$ holds in the $q$-analog setting, connecting to the theory of quantum groups and $p$-divisibility of $q$-binomials.",
     "openQuestions": [
-      "Can `kummer_multinomial_statement` be formalized using Kummer's theorem from Mathlib? This would require a Lean formalism for base-p carries (not yet in Mathlib) and induction over the telescoping product.",
+      "Can the p-adic valuation statement be fully formalized using Kummer's theorem from Mathlib? This would require a Lean formalism for base-p carries (not yet in Mathlib) and induction over the telescoping product.",
       "Is there a q-analog? The q-binomial coefficient (Gaussian binomial) satisfies a Kummer-like theorem; the q-multinomial analog is less well-studied.",
       "Can `multinomial_eq_prod_choose` be made fully self-contained in the main file (without the companion import), using a more direct proof?",
       "Formalize the relationship between the multinomial carry-count and Lucas' theorem for multinomials: $\\binom{n}{k_1,\\ldots,k_m} \\equiv \\prod_j \\binom{n_j}{k_{1,j},\\ldots,k_{m,j}} \\pmod{p}$ where subscript $j$ denotes the $j$-th base-$p$ digit (Granville 1997)"
@@ -120,7 +120,7 @@
     "namespace": "KummerMultinomial",
     "axiomCount": 0,
     "lineCount": 108,
-    "theoremCount": 4,
+    "theoremCount": 3,
     "definitionCount": 1,
     "path": "Proofs/KummerTheoremOQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Remove misleading `kummer_multinomial_statement : True` from `KummerTheoremOQ01.lean` and replace with a block comment explaining the open formalization goal.

## Evidence

**Before**: `theorem kummer_multinomial_statement ... : True := by trivial` — a named theorem that proves only `True`, giving a false impression of formalized content.

**After**: Block comment documenting the open formalization (v_p of multinomial = total carries when adding parts in base p), noting that full formalization requires base-p carry counting not yet in Mathlib.

**Meta.json updates**:
- `theoremCount`: 4 → 3
- `proofStrategy`: removed stub mention
- `keyInsights`: removed "returns True" description
- `conclusion.summary`: removed "currently a True stub" text
- `sections`: renamed `statement-stub` → `valuation-comment` with accurate description

---
Automated fix by lean-mechanic agent.