### PR TITLE
fix: correct invalid status 'pending' to 'axiomatized' for 6 entries

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-02/meta.json
@@ -5,7 +5,7 @@
   "description": "Survey of equivariant Borsuk-Ulam for compact Lie groups (SO(n), U(n)). Formalizes equivariant map definitions, fixed-point subspace properties, and identifies ~2000 lines of infrastructure needed for the full theorem.",
   "meta": {
     "author": "Lean Genius",
-    "status": "pending",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/BorsukUlamOQ02OQ02.lean",
     "tags": [
       "topology",

--- a/src/data/proofs/erdos-1155-oq-01-oq-06/meta.json
+++ b/src/data/proofs/erdos-1155-oq-01-oq-06/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://erdosproblems.com/1155",
     "date": "2026",
-    "status": "pending",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1155OQ01OQ06.lean",
     "dateAdded": "2026-04-04",
     "tags": [

--- a/src/data/proofs/hilbert-14-oq-01/meta.json
+++ b/src/data/proofs/hilbert-14-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Grosshans (1997), Nagata (1959), Weitzenböck (1932)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Hilbert%27s_fourteenth_problem",
     "date": "1997",
-    "status": "pending",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Hilbert14NonReductive.lean",
     "tags": [
       "invariant-theory",

--- a/src/data/proofs/konigsberg-oq-03/meta.json
+++ b/src/data/proofs/konigsberg-oq-03/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős-Grünwald-Weiszfeld (1936), Lonc-Naroski (2010)",
     "date": "1936",
-    "status": "pending",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/KonigsbergOQ03.lean",
     "tags": [
       "graph-theory",

--- a/src/data/proofs/puiseux-theorem/meta.json
+++ b/src/data/proofs/puiseux-theorem/meta.json
@@ -8,7 +8,7 @@
     "author": "Victor Puiseux (1850)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Puiseux_series",
     "date": "1850",
-    "status": "pending",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/PuiseuxTheorem.lean",
     "tags": [
       "algebra",

--- a/src/data/proofs/shannon-source-coding/meta.json
+++ b/src/data/proofs/shannon-source-coding/meta.json
@@ -7,7 +7,7 @@
     "author": "Claude Shannon (1948), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Shannon%27s_source_coding_theorem",
     "date": "1948",
-    "status": "pending",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/ShannonSourceCoding.lean",
     "tags": [
       "information-theory",


### PR DESCRIPTION
## Fix

Six gallery entries have `status: "pending"` which is not a valid status per CLAUDE.md policy. Valid statuses are: `verified`, `axiomatized`, `formalized`.

Per CLAUDE.md: *"Millennium Prize problems, Clay problems, and open conjectures: always axiomatized"*

## Affected entries

| Entry | Reason |
|-------|--------|
| `borsuk-ulam-oq-02-oq-02` | Open question: equivariant Borsuk-Ulam for compact Lie groups |
| `erdos-1155-oq-01-oq-06` | Placeholder stub, axioms inherited from parent |
| `hilbert-14-oq-01` | Open: Grosshans criterion for non-reductive groups |
| `konigsberg-oq-03` | Open: Eulerian paths in hypergraphs/infinite graphs |
| `puiseux-theorem` | Open formalization (Wiedijk #41) |
| `shannon-source-coding` | Unformalized placeholder |

## Evidence

**Before**: `"status": "pending"` (invalid)  
**After**: `"status": "axiomatized"` (correct per policy)

---
Automated fix by lean-mechanic agent.