### PR TITLE
fix: remove embedded True stubs from erdos-770 and erdos-926

### DIFF
--- a/proofs/Proofs/Erdos770Problem.lean
+++ b/proofs/Proofs/Erdos770Problem.lean
@@ -202,14 +202,11 @@ theorem h_gt_3_at_11 : gcdPowerSeq 11 3 ≠ 1 := by native_decide
 
 -- ## The three open questions (axiomatized)
 
-/-- **Q1 (OPEN)**: Does the density of integers n with h(n) = p
-    exist for every prime p?
-    NOTE: As stated, this is trivially true (δ = 0 works).
-    The intended statement should involve an actual density computation. -/
-theorem erdos_770_density_exists :
-    ∀ p : ℕ, Nat.Prime p →
-      ∃ δ : ℝ, δ ≥ 0 ∧ True :=
-  fun _ _ => ⟨0, le_refl _, trivial⟩
+/-
+  **Q1 (OPEN)**: Does the density δ_p of integers n with h(n) = p
+  exist for every prime p? Full formalization requires natural density
+  analysis in Lean — not yet available in Mathlib for this specific h(n).
+-/
 
 /-- **Q2 (OPEN)**: Is h(n) unbounded? Specifically, does
     lim inf h(n) = ∞? -/

--- a/proofs/Proofs/Erdos926Problem.lean
+++ b/proofs/Proofs/Erdos926Problem.lean
@@ -211,12 +211,12 @@ Alternative approach using hypergraph containers.
 ## Part X: Main Results Summary
 -/
 
-/--
-**Erdős Problem #926: Summary**
+/-
+**Erdős Problem #926: Summary (open formalization)**
 
 Question: Is ex(n; H_k) ≪_k n^(3/2) for k ≥ 4?
 
-Answer: YES
+Answer: YES (Füredi 1991, Alon-Krivelevich-Sudakov 2003)
 
 Timeline:
 - 1971: Erdős poses the problem, claims k = 3 case
@@ -224,12 +224,10 @@ Timeline:
 - 2003: Alon-Krivelevich-Sudakov improve to k · n^(3/2)
 
 The lower bound n^(3/2) is trivial (H_k contains C_4).
+
+Full formalization requires the probabilistic method and dependent random choice,
+not yet available in Mathlib.
 -/
-theorem erdos_926_summary :
-    True ∧  -- ex(n; H_k) ≪_k n^(3/2) for k ≥ 4
-    True ∧  -- Lower bound n^(3/2) is tight
-    True    -- Problem is a special case of 2-degenerate conjecture
-  := ⟨trivial, trivial, trivial⟩
 
 /- erdos_926_order: The order of magnitude is n^(3/2) for all k ≥ 3. -/
 

--- a/src/data/proofs/erdos-770/meta.json
+++ b/src/data/proofs/erdos-770/meta.json
@@ -56,8 +56,8 @@
       "Bridge lemma zmod_pow_eq_one_of_dvd: converts nat divisibility to ZMod equality"
     ],
     "axiomCount": 0,
-    "lineCount": 498,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "lineCount": 495,
+    "assumptions": "None. 77 theorems fully verified with 0 axioms and 0 sorries. The open density question (Q1) is stated as a comment only.",
     "mathlib_version": "4.26.0"
   },
   "sections": [
@@ -197,9 +197,9 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 498,
+    "lineCount": 495,
     "axiomCount": 0,
-    "theoremCount": 78,
+    "theoremCount": 77,
     "definitionCount": 2,
     "path": "Proofs/Erdos770Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-926/meta.json
+++ b/src/data/proofs/erdos-926/meta.json
@@ -21,8 +21,8 @@
     "erdosUrl": "https://erdosproblems.com/926",
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
-    "lineCount": 237,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "lineCount": 235,
+    "assumptions": "None. 3 theorems fully verified with 0 axioms and 0 sorries (numerical examples via native_decide). Main result (ex(n; H_k) ≪ n^(3/2)) documented as a comment; full formalization requires probabilistic method not in Mathlib.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -146,9 +146,9 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos926",
-    "lineCount": 237,
+    "lineCount": 235,
     "axiomCount": 0,
-    "theoremCount": 4,
+    "theoremCount": 3,
     "definitionCount": 3,
     "path": "Proofs/Erdos926Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Two gallery entries with `status: verified` had embedded True stubs that appeared to prove mathematical content but were vacuously trivial.

## Evidence

**erdos-770** (`Erdos770Problem.lean`):
- Before: `theorem erdos_770_density_exists : ∀ p prime, ∃ δ ≥ 0, True := fun _ _ => ⟨0, trivial⟩`
- After: Block comment explaining the open density formalization goal

**erdos-926** (`Erdos926Problem.lean`):
- Before: `theorem erdos_926_summary : True ∧ True ∧ True := ⟨trivial, trivial, trivial⟩`
- After: Block comment documenting the solved result (Füredi 1991, AKS 2003) and why full formalization needs probabilistic method

**meta.json updates**:
- `erdos-770`: `lineCount` 498→495, `leanFile.theoremCount` 78→77, updated assumptions
- `erdos-926`: `lineCount` 237→235, `leanFile.theoremCount` 4→3, updated assumptions

---
Automated fix by lean-mechanic agent.