### PR TITLE
Fix: replace True-stub theorems in Erdos310Problem and BoundedPrimeGapsOQ01

### DIFF
--- a/proofs/Proofs/BoundedPrimeGapsOQ01.lean
+++ b/proofs/Proofs/BoundedPrimeGapsOQ01.lean
@@ -222,7 +222,7 @@ theorem admissible_2_tuple_min_diam (d : ℕ) (hd : 0 < d)
   exact not_admissible_0_1 hadm
 
 /-- {0, 2} achieves the minimum diameter of 2 (witness for optimality). -/
-theorem optimal_2_tuple_diameter : IsAdmissible {0, 2} ∧ True := ⟨admissible_twin, trivial⟩
+theorem optimal_2_tuple_diameter : IsAdmissible {0, 2} := admissible_twin
 
 /-- **Minimum diameter of admissible 3-tuple (with 0) is 6.**
 

--- a/proofs/Proofs/Erdos310Problem.lean
+++ b/proofs/Proofs/Erdos310Problem.lean
@@ -271,7 +271,7 @@ theorem erdos_310 : erdosGrahamConjecture := by
 /--
 The answer to Erdős's question is YES.
 -/
-theorem erdos_310_answer : ∃ _ : erdosGrahamConjecture, True := ⟨erdos_310, trivial⟩
+theorem erdos_310_answer : erdosGrahamConjecture := erdos_310
 
 /-
 ## Part X: Related Results


### PR DESCRIPTION
## Fix

Two theorems used `∧ True` / `∃ _ : P, True` patterns that are mathematically vacuous.

## Evidence

**BoundedPrimeGapsOQ01.lean**:
- Before: `theorem optimal_2_tuple_diameter : IsAdmissible {0, 2} ∧ True := ⟨admissible_twin, trivial⟩`
- After: `theorem optimal_2_tuple_diameter : IsAdmissible {0, 2} := admissible_twin`

**Erdos310Problem.lean**:
- Before: `theorem erdos_310_answer : ∃ _ : erdosGrahamConjecture, True := ⟨erdos_310, trivial⟩`
- After: `theorem erdos_310_answer : erdosGrahamConjecture := erdos_310`

Both theorems now state meaningful mathematical content. No metadata changes needed (same line count, same theorem count, types remain provable).

---
Automated fix by lean-mechanic agent.