### PR TITLE
Fix: remove True-stub theorems from 4 gallery proofs (batch A)

### DIFF
--- a/proofs/Proofs/Erdos476Problem.lean
+++ b/proofs/Proofs/Erdos476Problem.lean
@@ -203,9 +203,10 @@ If f(x₁,...,xₙ) is a polynomial over a field and the coefficient of
 x₁^{d₁}...xₙ^{dₙ} is nonzero where ∑dᵢ = deg(f), then for sets Aᵢ
 with |Aᵢ| > dᵢ, there exist aᵢ ∈ Aᵢ with f(a₁,...,aₙ) ≠ 0.
 -/
-theorem combinatorial_nullstellensatz :
-    ∀ (n : ℕ) (f : (Fin n → ZMod p) → ZMod p),
-      True := fun _ _ => trivial
+/- combinatorial_nullstellensatz: Alon's Combinatorial Nullstellensatz (1999).
+   If f(x₁,...,xₙ) has nonzero coefficient for x₁^{d₁}···xₙ^{dₙ} with ∑dᵢ = deg(f),
+   and |Aᵢ| > dᵢ, then ∃ aᵢ ∈ Aᵢ with f(a₁,...,aₙ) ≠ 0. Formalizing requires
+   polynomial rings over fields in full generality, not just ZMod p. -/
 
 /--
 **ANR Proof (1995):**

--- a/proofs/Proofs/Erdos523Problem.lean
+++ b/proofs/Proofs/Erdos523Problem.lean
@@ -102,13 +102,10 @@ def ErdosQuestion523 : Prop :=
 ## Part V: Halász's Theorem
 -/
 
-/-- **Halász's Theorem (1973):**
-    The answer is YES with C = 1. -/
-theorem halasz_theorem :
-  ∀ ε : ℝ, ε > 0 →
-    -- With probability tending to 1 as n → ∞:
-    -- |maxModulus s / √(n log n) - 1| < ε
-    True := fun _ _ => trivial
+/- halasz_theorem: Halász's theorem (1973) states that for a random degree-n polynomial
+   with ±1 coefficients, the maximum modulus s satisfies |s / √(n log n) - 1| < ε
+   with probability tending to 1 as n → ∞ (C = 1 is optimal). Formalizing this
+   requires a probabilistic framework and complex analysis for the maximum modulus. -/
 
 /-- The optimal constant is C = 1. -/
 def halaszConstant : ℝ := 1

--- a/proofs/Proofs/Erdos763Problem.lean
+++ b/proofs/Proofs/Erdos763Problem.lean
@@ -226,11 +226,10 @@ sums of k elements from A?
 
 The Erdős-Fuchs theorem extends to this case.
 -/
-theorem erdos_fuchs_k_fold :
-  ∀ (k : ℕ), k ≥ 2 →
-  ∀ (A : Set ℕ), A.Infinite →
-  ∀ (c : ℝ), c > 0 →
-  True := fun _ _ _ _ _ _ => trivial  -- Statement would involve k-fold representation function
+/- erdos_fuchs_k_fold: The Erdős-Fuchs theorem for k-fold sums (k ≥ 2).
+   For any infinite A ⊆ ℕ, the k-fold representation function r_k(n) = |{(a₁,...,aₖ) ∈ Aᵏ : a₁+...+aₖ=n}|
+   cannot be asymptotically close to a constant c > 0 (it must deviate by Ω(n^{-1/4}(log n)^{-1/2})).
+   Formalizing this requires defining r_k and stating the precise oscillation bound. -/
 
 /--
 **Connection to Waring's Problem:**

--- a/proofs/Proofs/Erdos969Problem.lean
+++ b/proofs/Proofs/Erdos969Problem.lean
@@ -159,10 +159,10 @@ The error term is intimately connected to the Riemann Hypothesis.
 If E(x) ≪ x^(1/4), then the Riemann Hypothesis follows!
 -/
 
-/-- RH follows from E(x) ≪ x^(1/4 + ε) for all ε > 0 -/
-theorem rh_from_error_bound :
-  (∀ ε > 0, ∃ C : ℝ, C > 0 ∧ ∀ x : ℝ, x ≥ 1 → |E(x)| ≤ C * x^(1/4 + ε)) →
-  True := fun _ => trivial
+/- rh_from_error_bound: RH follows from E(x) ≪ x^(1/4 + ε) for all ε > 0.
+   The Riemann Hypothesis is equivalent to E(x) = O(x^(1/4 + ε)). Proving the
+   implication requires connecting the error bound to the zero-free region of ζ(s).
+   This is a deep analytic number theory result that cannot be formalized as a trivial implication. -/
 
 /-- Under RH, Liu (2016): E(x) ≪ x^(11/35 + o(1)) -/
 /-- The exponent 11/35 ≈ 0.314 vs conjectured 1/4 = 0.25 -/

--- a/src/data/proofs/erdos-476/meta.json
+++ b/src/data/proofs/erdos-476/meta.json
@@ -181,7 +181,7 @@
     "namespace": "Erdos476",
     "lineCount": 290,
     "axiomCount": 2,
-    "theoremCount": 10,
+    "theoremCount": 9,
     "definitionCount": 4,
     "path": "Proofs/Erdos476Problem.lean",
     "sorries": 4

--- a/src/data/proofs/erdos-523/meta.json
+++ b/src/data/proofs/erdos-523/meta.json
@@ -203,7 +203,7 @@
     "namespace": "Erdos523",
     "lineCount": 241,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 6,
     "definitionCount": 21,
     "path": "Proofs/Erdos523Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-763/meta.json
+++ b/src/data/proofs/erdos-763/meta.json
@@ -174,7 +174,7 @@
     "namespace": "Erdos763",
     "lineCount": 273,
     "axiomCount": 2,
-    "theoremCount": 5,
+    "theoremCount": 4,
     "definitionCount": 9,
     "path": "Proofs/Erdos763Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-969/meta.json
+++ b/src/data/proofs/erdos-969/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/969",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
-    "lineCount": 229,
+    "lineCount": 225,
     "assumptions": "2 axioms: elementary_upper_bound, evelyn_linfoot_lower_bound. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
@@ -152,9 +152,9 @@
       "Filter"
     ],
     "namespace": "Erdos969",
-    "lineCount": 229,
+    "lineCount": 225,
     "axiomCount": 2,
-    "theoremCount": 12,
+    "theoremCount": 11,
     "definitionCount": 7,
     "path": "Proofs/Erdos969Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Four gallery proof files contained vacuous `theorem X : ... → True := fun _ => trivial` patterns — theorems that prove `True` but claim to formalize deep mathematical content.

## Evidence

| File | Theorem | Replaced with |
|------|---------|---------------|
| Erdos476Problem.lean | `combinatorial_nullstellensatz` | Block comment: requires polynomial rings over fields in full generality |
| Erdos523Problem.lean | `halasz_theorem` | Block comment: requires probabilistic framework and complex analysis |
| Erdos763Problem.lean | `erdos_fuchs_k_fold` | Block comment: requires k-fold representation function definition |
| Erdos969Problem.lean | `rh_from_error_bound` | Block comment: connecting E(x) to RH via zero-free region is non-trivial |

## Metadata updates

- `theoremCount` decremented by 1 for each file (theorem removed)
- `erdos-969/meta.json`: `lineCount` corrected 229 → 225 (actual file length was already 225)

---
Automated fix by lean-mechanic agent.