### PR TITLE
Fix Lean proofs: remove false axioms for 5 resolved Erdős problems

### DIFF
--- a/proofs/Proofs/Erdos1091Problem.lean
+++ b/proofs/Proofs/Erdos1091Problem.lean
@@ -7,12 +7,18 @@ Must a K₄-free graph with χ(G) = 4 contain an odd cycle with at least two dia
 
 More generally, is there some f(r)→∞ such that every graph with χ ≥ 4,
 in which every subgraph on ≤r vertices has χ ≤ 3, contains an odd
-cycle with at least f(r) diagonals? This remains OPEN.
+cycle with at least f(r) diagonals?
+
+DISPROVED (Alexeev-Putterman-Sawhney-Sellke-Valiant 2026,
+arXiv:2604.06609): No. Explicit K₄-free 4-chromatic graphs Gₘ
+(caterpillars of pentagonal blocks, 20m+31 vertices) have every
+proper subgraph 2-degenerate yet every cycle has ≤ 10 chords.
 
 History:
 - Larson (1979): Proved one diagonal exists; proved Bollobás-Erdős conjecture
 - Voss (1982): Proved two diagonals are guaranteed
 - Pentagonal wheel shows three diagonals cannot be guaranteed
+- APSSV (2026): General f(r) question disproved
 
 Reference: https://erdosproblems.com/1091
 -/
@@ -163,6 +169,13 @@ def GeneralQuestion : Prop :=
       ∀ r : ℕ, IsLocallyColorable G r 3 →
         ∃ c : Cycle G, c.isOdd ∧ c.diagonalCount ≥ f r
 
+/-- DISPROVED: The general question is FALSE.
+    Alexeev-Putterman-Sawhney-Sellke-Valiant (2026, arXiv:2604.06609)
+    constructed explicit K₄-free 4-chromatic graphs where every proper
+    subgraph is 2-degenerate (hence 3-colorable) yet every cycle has
+    at most 10 chords. This means no f(r) → ∞ exists. -/
+axiom erdos_1091_general_disproof : ¬ GeneralQuestion
+
 /- ## Part 6: Related Results -/
 
 /-- Key insight: K₄-free graphs can still have high chromatic number -/
@@ -179,7 +192,7 @@ theorem K4_free_high_chi_possible :
 /-- **Erdős Problem #1091 Summary**:
     - First question (≥2 diagonals): SOLVED by Voss (1982)
     - Upper bound (not ≥3): Shown via pentagonal wheel counterexample
-    - General f(r) question: OPEN -/
+    - General f(r) question: DISPROVED (APSSV 2026) -/
 theorem erdos_1091_summary :
     -- Two diagonals guaranteed (Voss)
     (∀ (V : Type*) [Fintype V] [DecidableEq V] (G : SimpleGraph V),
@@ -188,8 +201,11 @@ theorem erdos_1091_summary :
     -- Three diagonals NOT guaranteed
     ¬ (∀ (V : Type*) [Fintype V] [DecidableEq V] (G : SimpleGraph V),
       IsK4Free G → chromaticNumber G ≥ 4 →
-      ∃ c : Cycle G, c.isOdd ∧ c.diagonalCount ≥ 3) :=
+      ∃ c : Cycle G, c.isOdd ∧ c.diagonalCount ≥ 3) ∧
+    -- General f(r) → ∞ question: DISPROVED
+    ¬ GeneralQuestion :=
   ⟨fun _ _ _ G hK4 hChi => voss_two_diagonals G hK4 hChi,
-   three_diagonals_not_guaranteed⟩
+   three_diagonals_not_guaranteed,
+   erdos_1091_general_disproof⟩
 
 end Erdos1091

--- a/proofs/Proofs/Erdos1141Problem.lean
+++ b/proofs/Proofs/Erdos1141Problem.lean
@@ -12,7 +12,13 @@ Known results:
 - No further terms exist below 10^10
 - ChatGPT-Tang proved the count in [1,N] is O(N^{1/2+o(1)})
 
-Status: OPEN (is the sequence infinite?)
+Status: SOLVED (Alexeev-Putterman-Sawhney-Sellke-Valiant 2026,
+arXiv:2604.06609). Answer: NO, only finitely many such n exist.
+More generally, for each fixed a ≥ 1, only finitely many n have
+n - ak² prime for all coprime k with ak² < n. Proof deduces this
+from Pollack's theorem (2017) on small prime quadratic residues.
+The result is ineffective (Siegel's theorem); computationally,
+1722 appears to be the largest good value for a=1.
 
 Reference: https://erdosproblems.com/1141
 -/
@@ -114,10 +120,12 @@ theorem good_ge4_even (n : ℕ) (hn : 4 ≤ n) (hg : IsErdos1141Good n) : 2 ∣ 
 
 -- ## The Open Conjecture
 
-/-- Erdős Problem #1141: Are there infinitely many n satisfying the property?
-    OPEN - this is the main unsolved question. -/
-axiom erdos_1141_infinitely_many :
-  ∀ N : ℕ, ∃ n : ℕ, N ≤ n ∧ IsErdos1141Good n
+/-- Erdős Problem #1141: SOLVED — only finitely many n satisfy the property.
+    Alexeev-Putterman-Sawhney-Sellke-Valiant (2026, arXiv:2604.06609) proved
+    this via Pollack's theorem on small prime quadratic residues.
+    The result is ineffective due to Siegel's theorem. -/
+axiom erdos_1141_finitely_many :
+  ∃ N : ℕ, ∀ n : ℕ, n ≥ N → ¬ IsErdos1141Good n
 
 -- ## Known Finite Results
 

--- a/proofs/Proofs/Erdos960Problem.lean
+++ b/proofs/Proofs/Erdos960Problem.lean
@@ -9,14 +9,18 @@ the threshold f_{r,k}(n) such that if there are ≥ f_{r,k}(n) ordinary
 lines, then there exist r points where all C(r,2) connecting lines
 are ordinary.
 
-Is f_{r,k}(n) = o(n²)? Is f_{r,k}(n) ≪ n?
+Erdős asked: Is f_{r,k}(n) = o(n²)? Is f_{r,k}(n) ≪ n?
 
-Turán's theorem gives: f_{r,k}(n) ≤ (1 - 1/(r-1)) · n²/2 + 1.
-
-Status: OPEN
+Status: DISPROVED (Alexeev-Putterman-Sawhney-Sellke-Valiant 2026,
+arXiv:2604.06609). For r ≥ 3, k ≥ 4, n ≥ 72:
+  F_{r,k}(n) ≥ n²/12 - 10n/3.
+The construction uses a cyclic subgroup of the real elliptic curve
+E: y² = x³ - x + 1; removing the zero residue class mod 7 yields
+a bipartite ordinary-line graph with Ω(n²) ordinary lines and no
+4 collinear points.
 
 Reference: https://erdosproblems.com/960
-Source: [Er84]
+Source: [Er84], [APSSV26]
 -/
 
 -- ## Part I: Point Configurations and Collinearity
@@ -91,9 +95,16 @@ def ErdosConjecture960_littleo (r k : ℕ) : Prop :=
 def ErdosConjecture960_linear (r k : ℕ) : Prop :=
   ∃ C : ℕ, ∀ n : ℕ, threshold r k n ≤ C * n
 
-/-- The little-o conjecture (axiomatized as OPEN). -/
-axiom erdos_960_littleo_conjecture : ∀ r k : ℕ, r ≥ 2 → k ≥ 2 →
-  ErdosConjecture960_littleo r k
+/-- DISPROVED: The little-o conjecture is FALSE.
+    Alexeev-Putterman-Sawhney-Sellke-Valiant (2026) showed
+    F_{r,k}(n) ≥ n²/12 - 10n/3 for r ≥ 3, k ≥ 4, n ≥ 72.
+    This means the threshold grows quadratically, not o(n²). -/
+axiom erdos_960_disproof : ∀ r k : ℕ, r ≥ 3 → k ≥ 4 →
+  ∀ n : ℕ, n ≥ 72 → (threshold r k n : ℚ) ≥ n * n / 12 - 10 * n / 3
+
+/-- The negation of the little-o conjecture follows from the quadratic lower bound. -/
+axiom erdos_960_littleo_false : ∀ r k : ℕ, r ≥ 3 → k ≥ 4 →
+  ¬ ErdosConjecture960_littleo r k
 
 -- ## Part VI: Turán Upper Bound
 
@@ -230,11 +241,11 @@ theorem linear_implies_littleo (r k : ℕ) (_hr : r ≥ 2) (_hk : k ≥ 2) :
 -- ## Summary
 
 /-- Erdős Problem #960: Summary
-    Combines the little-o conjecture, the Turán upper bound,
-    and the Sylvester-Gallai/Green-Tao ordinary line result. -/
+    The o(n²) conjecture is DISPROVED for r ≥ 3, k ≥ 4.
+    The r = 2 base case (threshold = 0) remains valid. -/
 theorem erdos_960_summary :
-    (∀ r k : ℕ, r ≥ 2 → k ≥ 2 → ErdosConjecture960_littleo r k) ∧
+    (∀ r k : ℕ, r ≥ 3 → k ≥ 4 → ¬ ErdosConjecture960_littleo r k) ∧
     (∀ k n : ℕ, k ≥ 2 → n ≥ 2 → threshold 2 k n = 0) :=
-  ⟨erdos_960_littleo_conjecture, fun k n hk hn => threshold_r2 k n hk hn⟩
+  ⟨erdos_960_littleo_false, fun k n hk hn => threshold_r2 k n hk hn⟩
 
 end Erdos960

--- a/proofs/Proofs/Erdos987Problem.lean
+++ b/proofs/Proofs/Erdos987Problem.lean
@@ -2,24 +2,28 @@
 Erdős Problem #987: Exponential Sums and Sequence Discrepancy
 
 Source: https://erdosproblems.com/987
-Status: PARTIALLY OPEN
+Status: SOLVED (Alexeev-Putterman-Sawhney-Sellke-Valiant 2026,
+arXiv:2604.06609)
 
 Statement:
 Let x₁, x₂, ... ∈ (0,1) be an infinite sequence and define:
-  Aₖ = limsup_{n→∞} |∑_{j≤n} e(kxⱼ)|
+  Aₖ = sup_{N≥1} |∑_{j<N} e(kxⱼ)|
 where e(x) = e^{2πix}.
 
 Questions:
-1. Is limsup_{k→∞} Aₖ = ∞?
-2. Is it possible for Aₖ = o(k)?
+1. Is limsup_{k→∞} Aₖ = ∞? YES (Erdős 1964)
+2. Is it possible for Aₖ = o(k)? YES (APSSV 2026)
 
 Known Results:
 - Erdős (1965): Aₖ ≫ log k infinitely often
 - Clunie (1967): Aₖ ≫ √k infinitely often; also ∃ sequences with Aₖ ≤ k ∀k
 - Tao: Independently proved Aₖ ≫ √k infinitely often
 - Liu (1969): With finitely many distinct points, Aₖ ≫ k^{1-ε} infinitely often
+- APSSV (2026): ∃ sequence with Aₖ ≪ √(k log k), resolving the o(k) question
 
-Open: Is Aₖ = o(k) possible?
+The construction is a randomized binary scrambling of the van der Corput
+sequence. Combined with Clunie's √k lower bound, the optimal growth rate
+is pinpointed up to a √(log k) factor.
 
 Reference: https://erdosproblems.com/987
 -/
@@ -157,14 +161,21 @@ def SublinearGrowth (x : ℕ → ℝ) : Prop :=
   Filter.Tendsto (fun k => A x k / k) Filter.atTop (nhds 0)
 
 /--
-**The Main Open Question:**
+**The Main Question (RESOLVED):**
 Is there a sequence x with InUnitInterval x such that Aₖ = o(k)?
 
-This question is asked in Erdős (1965) and repeated in Hayman (1974).
-It remains OPEN.
+This was asked by Erdős (1965) and repeated by Hayman (1974).
+RESOLVED YES by Alexeev-Putterman-Sawhney-Sellke-Valiant (2026):
+there exists a sequence with Aₖ ≪ √(k log k), which is o(k).
 -/
 def openQuestion : Prop :=
   ∃ x : ℕ → ℝ, InUnitInterval x ∧ SublinearGrowth x
+
+/-- SOLVED: The open question is TRUE.
+    Alexeev-Putterman-Sawhney-Sellke-Valiant (2026, arXiv:2604.06609)
+    constructed a randomized sequence achieving Aₖ ≪ √(k log k).
+    In fact, a stronger bound holds: sup_N |S_N(k)| ≪ √(k log k). -/
+axiom erdos_987_resolved : openQuestion
 
 /--
 **What We Know:**

--- a/proofs/Proofs/Erdos990Problem.lean
+++ b/proofs/Proofs/Erdos990Problem.lean
@@ -2,7 +2,8 @@
   Erdős Problem #990: Polynomial Root Distribution and the Erdős-Turán Inequality
 
   Source: https://erdosproblems.com/990
-  Status: OPEN (Sparse case conjectured, classical case proved)
+  Status: DISPROVED (Alexeev-Putterman-Sawhney-Sellke-Valiant 2026,
+  arXiv:2604.06609)
 
   Statement:
   Let f = a₀ + a₁x + ⋯ + aₐxᵈ ∈ ℂ[x] be a polynomial with roots z₁,...,zₐ
@@ -13,11 +14,15 @@
   where n is the number of nonzero coefficients and
   M = (|a₀| + ⋯ + |aₐ|)/√(|a₀||aₐ|)?
 
+  DISPROVED: Explicit lacunary polynomials with ν(f) = N+2 nonzero terms,
+  M(f) < 3, and a positive real root of multiplicity N+1 show that no
+  bound of order √(ν(f) log M(f)) can hold uniformly. Hayman's bound
+  discrepancy ≤ ν(f)-1 (1972) remains the best possible sparse bound.
+
   Background:
   - Erdős-Turán (1950): Proved the bound with n replaced by d (the degree)
-  - This asks: can we improve the bound for sparse polynomials?
-  - The "discrepancy" measures deviation from uniform distribution on the unit circle
-  - Applications: random matrix theory, numerical analysis, number theory
+  - APSSV (2026): Disproved the sparse strengthening
+  - Hayman (1972): discrepancy ≤ ν(f)-1 (best possible for sparse case)
 
   Tags: analysis, polynomials, equidistribution, discrepancy
 -/
@@ -183,9 +188,16 @@ theorem erdos_turan_known (d : ℕ) (p : ComplexPoly d) (hd : 0 < d)
     ∃ C : ℝ, C > 0 ∧ maxDiscrepancy d p ≤ C * Real.sqrt (d * Real.log (mahlerM d p hd)) :=
   erdos_turan_classical d p hd hp h0
 
+/-- DISPROVED: The sparse conjecture is FALSE.
+    Alexeev-Putterman-Sawhney-Sellke-Valiant (2026, arXiv:2604.06609)
+    constructed lacunary polynomials with ν(f) = N+2, M(f) < 3, and a
+    positive real root of multiplicity N+1, yielding discrepancy ≥ N+1/2
+    while √(ν(f) log M(f)) = O(√N). -/
+axiom erdos_990_sparse_disproof : ¬ sparseConjecture
+
 /-- Summary of Erdős Problem #990:
     The classical Erdős-Turán inequality with degree d is PROVED.
-    The sparse version (replacing d with n) remains OPEN. -/
+    The sparse strengthening (replacing d with ν(f)) is DISPROVED. -/
 theorem erdos_990_summary :
     ∃ C : ℝ, C > 0 ∧ ∀ (d : ℕ) (p : ComplexPoly d) (hd : 0 < d)
       (hp : p ⟨d, Nat.lt_succ_self d⟩ ≠ 0) (h0 : p 0 ≠ 0),


### PR DESCRIPTION
## Summary

- Removes two **provably false axioms** introduced before the OpenAI paper (arXiv:2604.06609) resolved these problems
- Adds new resolution axioms for all 5 problems
- Updates all docstrings with resolution status

### Critical fixes

| File | Old (FALSE) Axiom | New Axiom |
|------|-------------------|-----------|
| `Erdos960Problem.lean` | `erdos_960_littleo_conjecture` (o(n²) — disproved) | `erdos_960_disproof` + `erdos_960_littleo_false` |
| `Erdos1141Problem.lean` | `erdos_1141_infinitely_many` (infinitude — false) | `erdos_1141_finitely_many` |

### New resolution axioms

| File | New Axiom | Meaning |
|------|-----------|---------|
| `Erdos987Problem.lean` | `erdos_987_resolved` | Aₖ = o(k) IS achievable |
| `Erdos990Problem.lean` | `erdos_990_sparse_disproof` | Sparse Erdős-Turán is FALSE |
| `Erdos1091Problem.lean` | `erdos_1091_general_disproof` | f(r) → ∞ is FALSE |

### Axiom counts

| File | Before | After |
|------|--------|-------|
| Erdos960 | 1 (false!) | 2 |
| Erdos987 | 3 | 4 |
| Erdos990 | 3 | 4 |
| Erdos1091 | 4 | 5 |
| Erdos1141 | 1 (false!) | 1 |

## Test plan

- [ ] Docker build each file: `./proofs/scripts/docker-build.sh Proofs.Erdos{960,987,990,1091,1141}Problem`
- [ ] Verify no remaining references to the removed false axioms
- [ ] Update meta.json axiomCount fields to match (see companion PR #10232)

🤖 Generated with [Claude Code](https://claude.com/claude-code)