### PR TITLE
Fix axiom undercounts in 4 Erdős proofs (APSSV 2026)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2467,10 +2467,10 @@
       "result": "clean"
     },
     "erdos-1091": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-04-03T21:57:30Z",
-      "result": "clean"
+      "lastAudited": "2026-04-12T20:48:17Z",
+      "result": "issues-fixed"
     },
     "erdos-1092": {
       "agentId": "auditor-cycle-20-batch",
@@ -8895,9 +8895,9 @@
     },
     "erdos-960": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:19:43Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-12T20:48:16Z",
+      "result": "issues-fixed"
     },
     "erdos-961": {
       "agentId": "auditor-cycle-20-batch",
@@ -9070,9 +9070,9 @@
     },
     "erdos-987": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:19:28Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-12T20:48:15Z",
+      "result": "issues-fixed"
     },
     "erdos-988": {
       "agentId": "auditor-cycle-20-batch",
@@ -9094,9 +9094,9 @@
     },
     "erdos-990": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:19:27Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-12T20:48:12Z",
+      "result": "issues-fixed"
     },
     "erdos-991": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-1091/meta.json
+++ b/src/data/proofs/erdos-1091/meta.json
@@ -59,9 +59,9 @@
       "erdos_1091_summary: verified combined result"
     ],
     "leanFile": {
-      "lineCount": 195,
+      "lineCount": 211,
       "structureCount": 2,
-      "axiomCount": 4,
+      "axiomCount": 5,
       "theoremCount": 4,
       "defCount": 8,
       "imports": [
@@ -72,9 +72,9 @@
       ]
     },
     "dateAdded": "2026-01-26",
-    "axiomCount": 4,
-    "lineCount": 195,
-    "assumptions": "4 axioms: voss_two_diagonals (Voss 1982 main result), pentagonal_wheel_K4_free, pentagonal_wheel_chi_4, pentagonal_wheel_max_2_diagonals. 0 sorries."
+    "axiomCount": 5,
+    "lineCount": 211,
+    "assumptions": "5 axioms: voss_two_diagonals (Voss 1982 main result), pentagonal_wheel_K4_free, pentagonal_wheel_chi_4, pentagonal_wheel_max_2_diagonals, erdos_1091_general_disproof (APSSV 2026 — general f(r)→∞ question is false). 0 sorries."
   },
   "overview": {
     "historicalContext": "Erdos Problem #1091 concerns the structure of odd cycles in graphs that are K4-free (contain no complete graph on 4 vertices) but have high chromatic number. The problem has its roots in the broader question of how clique-freeness constrains graph structure when the chromatic number is large.\n\nThe Bollobas-Erdos conjecture proposed that K4-free graphs without odd cycles having diagonals must have very restricted structure: they are bipartite, have a cut vertex, or have a low-degree vertex. Larson (1979) proved this conjecture and established that every K4-free graph with chi >= 4 must contain an odd cycle with at least one diagonal.\n\nVoss (1982) significantly strengthened Larson's result by proving that at least TWO diagonals are guaranteed. This answered the specific question of Problem #1091 affirmatively. The pentagonal wheel W5 (a 5-cycle with a central hub vertex) serves as an extremal counterexample: it is K4-free with chi = 4, but every odd cycle has at most 2 diagonals, showing that 3 diagonals cannot be universally guaranteed and making Voss's bound tight.\n\nThe problem connects to Mycielski's classical construction, which shows that triangle-free (and hence K4-free) graphs can have arbitrarily high chromatic number. The general open question asks whether there exists f(r) -> infinity such that graphs with chi >= 4 that are locally 3-colorable (every subgraph on <= r vertices has chi <= 3) must contain odd cycles with >= f(r) diagonals. This remains one of the open parts of the problem.",
@@ -192,8 +192,8 @@
     ],
     "opens": [],
     "namespace": "Erdos1091",
-    "lineCount": 195,
-    "axiomCount": 4,
+    "lineCount": 211,
+    "axiomCount": 5,
     "theoremCount": 4,
     "definitionCount": 8,
     "path": "Proofs/Erdos1091Problem.lean",

--- a/src/data/proofs/erdos-960/meta.json
+++ b/src/data/proofs/erdos-960/meta.json
@@ -36,9 +36,9 @@
       "ordinary_pairs_count (proved): r*(r-1) ordered ordinary pairs",
       "erdos_960_summary (proved): combines conjecture with r=2 case"
     ],
-    "axiomCount": 1,
-    "lineCount": 240,
-    "assumptions": "1 axiom (erdos_960_littleo_conjecture: the main open conjecture), 0 sorries. Previously 3 axioms — removed 2 unused axioms (turan_upper_bound, green_tao_ordinary_lines).",
+    "axiomCount": 2,
+    "lineCount": 251,
+    "assumptions": "2 axioms: erdos_960_disproof (APSSV 2026 — quadratic lower bound F ≥ n²/12 - 10n/3 for r≥3, k≥4), erdos_960_littleo_false (negation of little-o conjecture). 0 sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -160,8 +160,8 @@
     ],
     "opens": [],
     "namespace": "Erdos960",
-    "lineCount": 240,
-    "axiomCount": 1,
+    "lineCount": 251,
+    "axiomCount": 2,
     "theoremCount": 7,
     "definitionCount": 8,
     "path": "Proofs/Erdos960Problem.lean",

--- a/src/data/proofs/erdos-987/meta.json
+++ b/src/data/proofs/erdos-987/meta.json
@@ -56,9 +56,9 @@
       "openQuestion: is Aₖ = o(k) achievable?",
       "erdos_987 theorem: main summary"
     ],
-    "axiomCount": 3,
-    "lineCount": 234,
-    "assumptions": "3 axioms: clunie_sqrt_bound, clunie_upper_construction, erdos_987_unbounded. 0 sorries."
+    "axiomCount": 4,
+    "lineCount": 245,
+    "assumptions": "4 axioms: clunie_sqrt_bound, clunie_upper_construction, erdos_987_unbounded, erdos_987_resolved (APSSV 2026 — Aₖ = o(k) is achievable). 0 sorries."
   },
   "overview": {
     "historicalContext": "Erdős Problem #987 concerns the behavior of exponential sums over arbitrary sequences in (0,1). Given a sequence x₁, x₂, ... ∈ (0,1), define Aₖ = limsup_{n→∞} |∑_{j≤n} e(kxⱼ)| where e(x) = e^{2πix}. The problem asks two questions: is limsup Aₖ = ∞, and can Aₖ = o(k)? This appeared as Problem 7.21 in Hayman's 'Research problems in function theory' (1974).\n\nThe problem traces back to Erdős's work on exponential sums in the mid-1960s. In 1964, he observed that the supremum of partial sums must be unbounded — an 'easy' consequence of the fact that for any finite collection of reals, sufficiently large k makes all kxⱼ mod 1 cluster near 0 (by Dirichlet's principle), forcing alignment of the unit vectors e(kxⱼ). In 1965, he gave a 'very easy' quantitative proof that Aₖ ≫ log k infinitely often.\n\nThe major breakthrough came from J.G. Clunie in 1967, who proved two complementary results: (1) Aₖ ≫ √k for infinitely many k, using a second-moment argument based on the orthogonality of characters, and (2) there exist sequences with Aₖ ≤ k for all k, showing the trivial linear upper bound is essentially tight. Terence Tao independently found a proof of the √k lower bound. Liu (1969) showed that for sequences with finitely many distinct values, the bound improves dramatically to Aₖ ≫ k^{1-ε}.\n\nThe problem remains partially open. The first question (limsup Aₖ = ∞) is resolved affirmatively, but the second — whether Aₖ = o(k) is achievable — remains open after more than 60 years. The gap between the √k lower bound and the O(k) upper bound is a fundamental question connecting exponential sum theory to discrepancy, equidistribution, and additive combinatorics.",
@@ -92,8 +92,8 @@
       "Filter"
     ],
     "namespace": "Erdos987",
-    "lineCount": 234,
-    "axiomCount": 3,
+    "lineCount": 245,
+    "axiomCount": 4,
     "theoremCount": 2,
     "definitionCount": 6,
     "path": "Proofs/Erdos987Problem.lean",

--- a/src/data/proofs/erdos-990/meta.json
+++ b/src/data/proofs/erdos-990/meta.json
@@ -65,9 +65,9 @@
       "sharp_erdos_turan axiom: optimal constant exists",
       "erdelyi_one_sided axiom: one-sided improvement"
     ],
-    "axiomCount": 3,
-    "lineCount": 195,
-    "assumptions": "3 axioms: rootSet (polynomial root set — axiomatized construction), erdos_turan_classical (Erdős-Turán 1950 — discrepancy ≤ C·√(d·log M(p))), erdos_turan_explicit_constant (explicit constant C holds uniformly). 0 sorries."
+    "axiomCount": 4,
+    "lineCount": 207,
+    "assumptions": "4 axioms: rootSet (polynomial root set — axiomatized construction), erdos_turan_classical (Erdős-Turán 1950 — discrepancy ≤ C·√(d·log M(p))), erdos_turan_explicit_constant (explicit constant C holds uniformly), erdos_990_sparse_disproof (APSSV 2026 — sparse conjecture is false). 0 sorries."
   },
   "overview": {
     "historicalContext": "Erdős Problem #990 concerns the angular distribution of polynomial roots, a fundamental topic connecting complex analysis, number theory, and probability.\n\nThe Erdős-Turán inequality (1950) was the first quantitative result on polynomial root equidistribution. It bounds the *star discrepancy* — the worst-case deviation of root counts from uniform distribution in any angular sector — by O(√(d log M)), where d is the degree and M is a coefficient-based normalization factor.\n\nGanelius (1954) improved the explicit constant to C ≤ 8. Mignotte (1992) made further improvements. After 70 years, the *sharp* constant was determined by Soundararajan (2019), who connected the problem to Hilbert transforms, and Steinerberger et al. (2021).\n\nThe open question asks whether the degree d can be replaced by the sparsity n (number of nonzero coefficients). The motivating example is x^d - 1: degree d but only n = 2 nonzero terms, with perfectly equidistributed roots. This connects to the broader theory of lacunary polynomials and sparse representations in analysis.",
@@ -179,8 +179,8 @@
       "Polynomial"
     ],
     "namespace": "Erdos990",
-    "lineCount": 195,
-    "axiomCount": 3,
+    "lineCount": 207,
+    "axiomCount": 4,
     "theoremCount": 3,
     "definitionCount": 11,
     "path": "Proofs/Erdos990Problem.lean",


### PR DESCRIPTION
## Summary

- Fix axiomCount mismatches in 4 gallery proofs that gained disproof axioms from arXiv:2604.06609 (Alexeev-Putterman-Sawhney-Sellke-Valiant 2026)
- Update `axiomCount`, `lineCount`, and `assumptions` fields in both `meta` and `leanFile` sections
- **erdos-990**: 3→4 axioms (missing `erdos_990_sparse_disproof`)
- **erdos-987**: 3→4 axioms (missing `erdos_987_resolved`)
- **erdos-960**: 1→2 axioms (missing `erdos_960_disproof`, `erdos_960_littleo_false`)
- **erdos-1091**: 4→5 axioms (missing `erdos_1091_general_disproof`)

## Test plan

- [ ] Verify `pnpm build` passes
- [ ] Confirm axiomCount matches `grep -c "^axiom "` for each Lean file
- [ ] Check audit tracker clears these 4 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)