### PR TITLE
Enrich hurwitz-theorem-oq-03: add quaternion/octonion and 3D infrastructure coverage

### DIFF
--- a/src/data/proofs/hurwitz-theorem-oq-03/annotations.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03/annotations.json
@@ -48,6 +48,30 @@
     "prerequisites": ["Fin 4 → ℝ", "quaternion algebra", "ring tactic"]
   },
   {
+    "id": "ann-ht03-quaternion-connection",
+    "proofId": "hurwitz-theorem-oq-03",
+    "range": { "startLine": 217, "endLine": 297 },
+    "type": "technique",
+    "title": "Quaternion Connection and 8-Square (Octonion) Identity",
+    "content": "Part 5 connects to Mathlib's quaternion library: `quaternion_norm_mul` proves $|q_1 q_2|^2 = |q_1|^2 |q_2|^2$ via `Quaternion.normSq.map_mul`, providing an alternative proof of the 4-square identity using Mathlib's existing infrastructure. Part 6 handles the 8-square identity from octonion multiplication. The octonionic norm identity $|o_1 o_2| = |o_1| |o_2|$ gives an 8-square identity with each component being a sum of 8 signed products. The Cayley-Dickson doubling construction builds 𝕆 from ℍ via $(p,q)(r,s) = (pr - \\bar{s}q, sp + q\\bar{r})$ where $p,q,r,s \\in \\mathbb{H}$. The 8-square identity was first discovered by C.F. Degen in 1818, predating Cayley's octonions by 25 years.",
+    "mathContext": "Quaternion norm multiplicativity: $|q_1 q_2|^2 = |q_1|^2 |q_2|^2$ for $q_1, q_2 \\in \\mathbb{H}$. Cayley-Dickson doubling: $\\mathbb{O} = \\mathbb{H} \\oplus \\mathbb{H}$ with $(p,q)(r,s) = (pr - \\bar{s}q, sp + q\\bar{r})$. Degen's 8-square identity (1818): $(\\sum_{i=1}^8 x_i^2)(\\sum_{i=1}^8 y_i^2) = \\sum_{i=1}^8 z_i^2$ where each $z_i$ is bilinear in $x,y$.",
+    "significance": "key",
+    "relatedConcepts": ["Quaternion.normSq.map_mul", "Cayley-Dickson construction", "octonion multiplication", "Degen's 8-square identity"],
+    "prerequisites": ["quaternion algebra", "Mathlib Quaternion type", "norm multiplicativity"]
+  },
+  {
+    "id": "ann-ht03-helpers-infrastructure",
+    "proofId": "hurwitz-theorem-oq-03",
+    "range": { "startLine": 299, "endLine": 846 },
+    "type": "technique",
+    "title": "Inner Product and 3D Geometry Infrastructure for Impossibility Proof",
+    "content": "The largest section (548 lines) builds the supporting machinery for proving no 3-square identity exists. Defines `innerProd` on `Fin 3 → ℝ`, `stdBasis`, and `normSq` in terms of componentwise sums. Key lemmas include: (1) `orthogonality_constraint` — bilinearity of an NSquareIdentity forces orthogonal inputs to produce orthogonal outputs; (2) `inner_expansion_three` — any vector in ℝ³ expands as a linear combination of three orthonormal vectors; (3) `unit_ortho_two_eq_pm_third` — a unit vector orthogonal to two of three orthonormal basis vectors must equal ±(the third). These lemmas encode the finite-dimensional geometry that makes ℝ³ too small to support a normed composition algebra. The proof is essentially linear algebra: bilinearity forces images of basis vectors to be orthonormal, but ℝ³ has only 3 mutually orthogonal directions.",
+    "mathContext": "Key geometric fact: in $\\mathbb{R}^3$, any three mutually orthogonal unit vectors form a basis. If $B : \\mathbb{R}^3 \\times \\mathbb{R}^3 \\to \\mathbb{R}^3$ is bilinear with $\\|B(x,y)\\|^2 = \\|x\\|^2 \\|y\\|^2$, then the 9 vectors $B(e_i, e_j)$ must all be unit vectors ($\\|B(e_i,e_j)\\| = 1$) and the columns $\\{B(e_1,e_j), B(e_2,e_j), B(e_3,e_j)\\}$ must be orthonormal. But ℝ³ only has room for 3 mutually orthogonal directions, creating an overdetermined system.",
+    "significance": "supporting",
+    "relatedConcepts": ["innerProd", "stdBasis", "orthogonality_constraint", "inner_expansion_three", "unit_ortho_two_eq_pm_third", "Gram-Schmidt"],
+    "prerequisites": ["inner product spaces", "orthonormal bases in ℝ³", "linear independence"]
+  },
+  {
     "id": "ann-ht03-impossibility",
     "proofId": "hurwitz-theorem-oq-03",
     "range": { "startLine": 854, "endLine": 1226 },

--- a/src/data/proofs/hurwitz-theorem-oq-03/meta.json
+++ b/src/data/proofs/hurwitz-theorem-oq-03/meta.json
@@ -37,7 +37,7 @@
     ]
   },
   "overview": {
-    "historicalContext": "Hurwitz's theorem (1898) is one of the most beautiful results in algebra: it shows that the only normed division algebras over ℝ are the four classical ones — reals (ℝ), complex numbers (ℂ), quaternions (ℍ), and octonions (𝕆). Equivalently, the only n for which an n-square identity (sum of n squares times sum of n squares equals sum of n squares, with bilinear combinations) exists are n = 1, 2, 4, 8. Hamilton spent years trying to find a 3-dimensional normed algebra — Hurwitz's theorem explains why he failed.",
+    "historicalContext": "Hurwitz's theorem (1898) is one of the most beautiful results in algebra, connecting number theory, geometry, and topology. The story begins with Brahmagupta's identity (628 CE): $(a^2+b^2)(c^2+d^2) = (ac-bd)^2+(ad+bc)^2$, which shows products of sums of two squares are again sums of two squares — an algebraic reflection of norm multiplicativity in ℂ. Euler discovered the analogous 4-square identity in 1748, 95 years before Hamilton found quaternions (1843). The Cayley numbers (octonions, 1845) gave the 8-square case. Hamilton's fruitless 15-year search for a 3-dimensional 'triplet' algebra suggested no such thing existed, but it was Adolf Hurwitz who proved in 1898 that n-square identities with bilinear terms exist only for $n \\in \\{1,2,4,8\\}$. Hurwitz's original proof used what we now call Hurwitz matrices. The topological dimension of the result was revealed much later: Adams (1962) proved that $S^{n-1}$ admits $n-1$ linearly independent tangent vector fields iff $n \\in \\{1,2,4,8\\}$, connecting norm composition to the parallelizability of spheres. The connection to Bott periodicity and algebraic K-theory (with period 8) was discovered by Bott and Milnor in the same era.",
     "problemStatement": "For which values of n does there exist an identity (x₁²+⋯+xₙ²)(y₁²+⋯+yₙ²) = z₁²+⋯+zₙ² where each zᵢ is bilinear in the xⱼ and yₖ? Hurwitz's answer: only n ∈ {1, 2, 4, 8}.",
     "text": "An NSquareIdentity for n consists of n bilinear forms Bᵢ(x,y) such that ‖x‖²·‖y‖² = ‖B(x,y)‖². The theorem has two directions: (1) existence — for n=1,2,4,8, explicit identities are constructed using real multiplication, complex multiplication, quaternion multiplication, and octonion multiplication; (2) non-existence — for all other n, no such identity can exist. The existence direction is fully proved. The non-existence direction uses the axiom hurwitz_only_if, which captures the full Hurwitz theorem (requiring Clifford algebra theory).",
     "proofStrategy": "The 2-square identity is the Brahmagupta-Fibonacci identity: (x₁²+x₂²)(y₁²+y₂²) = (x₁y₁-x₂y₂)²+(x₁y₂+x₂y₁)². The 4-square identity uses Mathlib's Quaternion.normSq_mul: the norm of a quaternion product equals the product of norms. The 1-square identity is trivial. The 8-square identity for octonions is axiomatized (octonion multiplication in Lean 4 requires additional infrastructure). The non-existence proof for n=3 uses a structural argument about bilinear forms over ℝ³.",
@@ -83,10 +83,27 @@
     {
       "targetId": "lagrange-four-squares",
       "relationship": "related",
-      "description": "Lagrange's four-square theorem (every positive integer is a sum of 4 squares) follows from the 4-square identity"
+      "description": "Lagrange's four-square theorem (every positive integer is a sum of 4 squares) follows from the 4-square identity — if $a$ and $b$ are sums of 4 squares, so is $ab$, reducing the proof to primes."
+    },
+    {
+      "targetId": "euler-identity",
+      "relationship": "related",
+      "description": "Euler's identity $e^{ix} = \\cos(x) + i\\sin(x)$ arises from ℂ, the n=2 normed division algebra. Hurwitz's theorem explains why no analogous formula exists in dimension 3."
+    },
+    {
+      "targetId": "amgm-inequality",
+      "relationship": "related",
+      "description": "The AM-GM inequality uses properties of ℝ (the n=1 normed division algebra). Both results highlight the special algebraic structures of the four classical number systems."
     }
   ],
   "sections": [
+    {
+      "id": "docstring-imports",
+      "title": "Module Documentation and Imports",
+      "startLine": 1,
+      "endLine": 55,
+      "summary": "Extensive docstring covering the theorem statement, historical context (Brahmagupta through Adams), proof strategy for both directions, and connections to physics/topology. Imports full Mathlib for Quaternion, Fin, and linear algebra infrastructure."
+    },
     {
       "id": "definitions",
       "title": "Core Definitions: normSq and NSquareIdentity",


### PR DESCRIPTION
## Summary

Enrichment pass for `hurwitz-theorem-oq-03` (quality: 70, passes: 1 → 2).

**Annotations (7 → 9):**
- Quaternion connection + 8-square identity (lines 217-297): Degen's 1818 identity, Cayley-Dickson construction
- Inner product/3D geometry infrastructure (lines 299-846): the 548-line helper section for the impossibility proof

**Meta improvements:**
- Expanded historicalContext with Brahmagupta (628 CE), Euler's 4-square identity (1748), Cayley's octonions (1845), Adams's parallelizable spheres theorem (1962), and Bott-Milnor K-theory
- Added docstring/imports section (lines 1-55)
- Added 2 cross-references: euler-identity, amgm-inequality
- Deepened lagrange-four-squares cross-reference description

**Build:** `pnpm annotations:build` passes ✓