### PR TITLE
Fix: remove True-stub theorems from pythagorean-triples and erdos-625

### DIFF
--- a/proofs/Proofs/Erdos625Problem.lean
+++ b/proofs/Proofs/Erdos625Problem.lean
@@ -204,10 +204,10 @@ theorem cochromatic_concentration :
 
 /- ## Part X: Special Graph Classes -/
 
-/-- For perfect graphs, χ = ω, but cochromatic may differ. -/
-theorem perfect_graph_chromatic (G : SimpleGraph V) (hPerf : True) :  -- Perfect condition
-    chromaticNumber G = cliqueNumber G := by
-  sorry
+/- perfect_graph_chromatic: For perfect graphs, χ(G) = ω(G).
+   Requires a definition of "perfect graph" (every induced subgraph has χ = ω).
+   Not stated as a theorem because the perfectness hypothesis cannot be expressed
+   without defining the predicate. -/
 
 /- cochromatic_complete_bipartite: ζ(K_{n,n}) = 2 for complete bipartite graphs;
    requires cochromatic number definition relative to graph structure. -/

--- a/proofs/Proofs/PythagoreanTriples.lean
+++ b/proofs/Proofs/PythagoreanTriples.lean
@@ -53,12 +53,8 @@ namespace PythagoreanTriplesFormula
 
 A Pythagorean triple consists of three integers satisfying the Pythagorean equation. -/
 
-/-- A Pythagorean triple is three integers (x, y, z) satisfying x² + y² = z².
-
-This uses Mathlib's definition which works over any commutative monoid with squares. -/
-example : True := by
-  -- PythagoreanTriple (x y z : ℤ) : Prop
-  trivial
+/- A Pythagorean triple is three integers (x, y, z) satisfying x² + y² = z².
+   Mathlib definition: PythagoreanTriple (x y z : ℤ) : Prop -/
 
 /-- The basic equation: x * x + y * y = z * z -/
 example (x y z : ℤ) : PythagoreanTriple x y z ↔ x * x + y * y = z * z :=
@@ -69,18 +65,14 @@ example (x y z : ℤ) : PythagoreanTriple x y z ↔ x * x + y * y = z * z :=
 The key insight is that all Pythagorean triples can be expressed using the parametric
 formulas involving m and n. -/
 
-/-- **Primitive Classification**: A primitive Pythagorean triple is classified if it can
-be written in the form (m² - n², 2mn, m² + n²) or (2mn, m² - n², m² + n²) for coprime
-integers m, n with opposite parity. -/
-example : True := by
-  -- PythagoreanTriple.IsPrimitiveClassified
-  trivial
+/- **Primitive Classification**: A primitive Pythagorean triple is classified if it can
+   be written in the form (m² - n², 2mn, m² + n²) or (2mn, m² - n², m² + n²) for coprime
+   integers m, n with opposite parity.
+   Mathlib: PythagoreanTriple.IsPrimitiveClassified -/
 
-/-- **General Classification**: A Pythagorean triple is classified if it is a scalar
-multiple of a primitively classified triple. -/
-example : True := by
-  -- PythagoreanTriple.IsClassified
-  trivial
+/- **General Classification**: A Pythagorean triple is classified if it is a scalar
+   multiple of a primitively classified triple.
+   Mathlib: PythagoreanTriple.IsClassified -/
 
 /-! ## The Main Theorem: Every Primitive Triple Has This Form
 

--- a/src/data/proofs/erdos-625/meta.json
+++ b/src/data/proofs/erdos-625/meta.json
@@ -18,7 +18,7 @@
       "prize"
     ],
     "badge": "axiom",
-    "sorries": 20,
+    "sorries": 19,
     "erdosNumber": 625,
     "erdosUrl": "https://erdosproblems.com/625",
     "erdosProblemStatus": "open",
@@ -65,7 +65,7 @@
     ],
     "axiomCount": 2,
     "lineCount": 268,
-    "assumptions": "2 axiom(s) and 20 sorry(s). See the Lean source for details."
+    "assumptions": "2 axiom(s) and 19 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #625**\n\nProposed by Erdős and Gimbel at a random graph conference in Poznań, Poland (1989). The cochromatic number generalizes proper coloring by allowing color classes to induce either complete graphs (cliques) or empty graphs (independent sets).\n\n**Prize Structure:**\nErdős offered $100 for a proof that χ - ζ → ∞ almost surely, and $1000 for a proof of the opposite. He later remarked to Gimbel that \"$1000 was perhaps too much\" - suggesting he believed the affirmative answer is correct.\n\n**Recent Progress (2024):**\nHeckel and independently Steiner proved that χ(G) - ζ(G) is unbounded with high probability. Heckel further conjectured χ - ζ ≈ n/(log n)³ and proved χ - ζ ≥ n^{1-ε} for roughly 95% of all n. Despite this progress, the main question remains OPEN.",
@@ -146,9 +146,9 @@
     "namespace": null,
     "lineCount": 268,
     "axiomCount": 2,
-    "theoremCount": 20,
+    "theoremCount": 19,
     "definitionCount": 0,
-    "sorries": 20,
+    "sorries": 19,
     "path": "Proofs/Erdos625Problem.lean"
   },
   "crossReferences": [

--- a/src/data/proofs/pythagorean-triples/meta.json
+++ b/src/data/proofs/pythagorean-triples/meta.json
@@ -48,7 +48,7 @@
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 23,
     "axiomCount": 0,
-    "lineCount": 268,
+    "lineCount": 260,
     "assumptions": "0 axioms, 0 sorries. Core classification theorem derived from Mathlib's PythagoreanTriple module (isPrimitiveClassified_of_coprime, classified).",
     "mathlib_version": "4.26.0"
   },
@@ -82,63 +82,63 @@
       "id": "predicate",
       "title": "The Pythagorean Triple Predicate",
       "startLine": 50,
-      "endLine": 66,
+      "endLine": 62,
       "summary": "Introduces Mathlib's PythagoreanTriple predicate and verifies it unfolds to x * x + y * y = z * z via Iff.rfl.",
       "mathContext": "Defines the predicate $\\texttt{PythagoreanTriple}(x, y, z) \\iff x^2 + y^2 = z^2$ over $\\mathbb{Z}$ and verifies definitional unfolding via $\\texttt{Iff.rfl}$."
     },
     {
       "id": "parametric-formula",
       "title": "Parametric Formula Classification",
-      "startLine": 67,
-      "endLine": 84,
+      "startLine": 63,
+      "endLine": 76,
       "summary": "Documents IsPrimitiveClassified and IsClassified structures from Mathlib that formalize what it means for a triple to match the parametric form.",
       "mathContext": "Describes the $\\texttt{IsPrimitiveClassified}$ structure: $\\exists\\, m > n > 0$ with $\\gcd(m,n) = 1$, $2 \\mid (m - n)$, such that $(a,b,c) = (m^2-n^2,\\, 2mn,\\, m^2+n^2)$ (up to sign/swap). The $\\texttt{IsClassified}$ structure adds a scalar factor $k$."
     },
     {
       "id": "main-theorems",
       "title": "Main Classification Theorems",
-      "startLine": 85,
-      "endLine": 114,
+      "startLine": 77,
+      "endLine": 106,
       "summary": "The central results: primitive_triples_are_classified (every coprime triple has parametric form) and all_triples_are_classified (every triple is a scaled parametric triple).",
       "mathContext": "Proves two key theorems: (1) $\\gcd(a,b) = 1 \\wedge a^2+b^2=c^2 \\implies \\texttt{IsPrimitiveClassified}(a,b,c)$, and (2) $a^2+b^2=c^2 \\implies \\exists\\, k,\\, \\texttt{IsPrimitiveClassified}(a/k,\\, b/k,\\, c/k)$, i.e., every triple is $k \\cdot (m^2-n^2,\\, 2mn,\\, m^2+n^2)$."
     },
     {
       "id": "verification",
       "title": "Algebraic Verification",
-      "startLine": 115,
-      "endLine": 134,
+      "startLine": 107,
+      "endLine": 126,
       "summary": "Proves the converse direction: the parametric formula always produces valid triples, verified via the ring tactic for both orderings of legs.",
       "mathContext": "Proves the polynomial identity $(m^2 - n^2)^2 + (2mn)^2 = (m^2 + n^2)^2$ via the $\\texttt{ring}$ tactic, confirming that the parametric formula always produces valid triples for any $m, n \\in \\mathbb{Z}$."
     },
     {
       "id": "examples",
       "title": "Classical Examples",
-      "startLine": 135,
-      "endLine": 193,
+      "startLine": 127,
+      "endLine": 185,
       "summary": "Verifies five classical Pythagorean triples: (3,4,5), (5,12,13), (8,15,17), (7,24,25), (20,21,29) with their corresponding (m,n) parameters.",
       "mathContext": "Verifies $3^2+4^2=5^2$ with $(m,n)=(2,1)$, $5^2+12^2=13^2$ with $(m,n)=(3,2)$, $8^2+15^2=17^2$ with $(m,n)=(4,1)$, $7^2+24^2=25^2$ with $(m,n)=(4,3)$, and $20^2+21^2=29^2$ with $(m,n)=(5,2)$ via $\\texttt{norm\\_num}$."
     },
     {
       "id": "properties",
       "title": "Properties of Pythagorean Triples",
-      "startLine": 194,
-      "endLine": 210,
+      "startLine": 186,
+      "endLine": 202,
       "summary": "Proves structural properties: symmetry of legs, the trivial (0,0,0) triple, and the parity constraint that primitive triples have one even and one odd leg.",
       "mathContext": "Proves: (1) $a^2+b^2=c^2 \\iff b^2+a^2=c^2$ (symmetry), (2) $0^2+0^2=0^2$ (trivial triple), and (3) $\\gcd(a,b)=1 \\wedge a^2+b^2=c^2 \\implies 2 \\mid a \\oplus 2 \\mid b$ (exactly one leg is even)."
     },
     {
       "id": "geometric",
       "title": "Unit Circle Parametrization",
-      "startLine": 211,
-      "endLine": 240,
+      "startLine": 203,
+      "endLine": 232,
       "summary": "Extended documentation explaining the geometric derivation of the formula via stereographic projection from (-1,0) on the unit circle, with full algebraic verification.",
       "mathContext": "Derives the parametric formula geometrically: a line through $(-1, 0)$ with rational slope $t = n/m$ meets the unit circle $x^2+y^2=1$ at the rational point $\\left(\\frac{m^2-n^2}{m^2+n^2},\\, \\frac{2mn}{m^2+n^2}\\right)$. Clearing denominators yields the integer parametrization."
     },
     {
       "id": "scaling",
       "title": "Non-primitive Triples and Summary",
-      "startLine": 241,
-      "endLine": 268,
+      "startLine": 233,
+      "endLine": 260,
       "summary": "Demonstrates that scaling preserves the Pythagorean property with examples (6,8,10) = 2×(3,4,5) and (9,12,15) = 3×(3,4,5), completing the classification.",
       "mathContext": "Proves that if $a^2+b^2=c^2$ then $(ka)^2+(kb)^2=(kc)^2$ for any $k \\in \\mathbb{Z}$, with examples: $(6,8,10) = 2 \\cdot (3,4,5)$ and $(9,12,15) = 3 \\cdot (3,4,5)$. This completes the reduction of the general case to the primitive case."
     }
@@ -186,7 +186,7 @@
     ],
     "opens": [],
     "namespace": "PythagoreanTriplesFormula",
-    "lineCount": 268,
+    "lineCount": 260,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Remove True-stub theorems from 2 gallery proofs and update metadata to match.

## Evidence

**Before**: 
- `PythagoreanTriples.lean` had 3 `example : True := by trivial` stubs serving as placeholders for Mathlib definitions
- `Erdos625Problem.lean` had `theorem perfect_graph_chromatic` with a meaningless `hPerf : True` hypothesis (no perfect graph predicate defined)

**After**: 
- True-stubs replaced with descriptive comments referencing the actual Mathlib definitions
- `erdos-625/meta.json`: theoremCount 20→19, sorries 20→19
- `pythagorean-triples/meta.json`: lineCount 268→260, section line ranges corrected

---
Automated fix by lean-mechanic agent.