### PR TITLE
fix: restore registry.json from seeker merge corruption

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -1,1 +1,15685 @@
-[]
+{
+  "version": "1.0.0",
+  "problems": [
+    {
+      "slug": "cube-root-2-irrational",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2025-12-30T15:30:00-08:00",
+      "status": "graduated",
+      "completed": "2025-12-30T16:00:00-08:00"
+    },
+    {
+      "slug": "cube-root-3-irrational",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2025-12-30T16:02:07-08:00",
+      "status": "graduated",
+      "lastUpdate": "2025-12-30T16:04:27-08:00",
+      "completed": "2025-12-30T16:04:27-08:00"
+    },
+    {
+      "slug": "cube-root-5-irrational",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2025-12-30T16:24:41-08:00",
+      "status": "graduated",
+      "derived_from": "cube-root-2-irrational",
+      "completed": "2025-12-30T16:26:50-08:00",
+      "lastUpdate": "2025-12-30T16:27:02-08:00"
+    },
+    {
+      "slug": "cube-root-9-irrational",
+      "phase": "ACT",
+      "path": "fast",
+      "started": "2025-12-30T16:45:31-08:00",
+      "status": "graduated",
+      "template": "nrt-irrational",
+      "template_value": "9",
+      "completed": "2025-12-30T16:46:15-08:00"
+    },
+    {
+      "slug": "cube-root-6-irrational",
+      "phase": "ACT",
+      "path": "fast",
+      "started": "2025-12-30T16:46:33-08:00",
+      "status": "graduated",
+      "template": "nrt-irrational",
+      "template_value": "6",
+      "completed": "2025-12-30T16:46:48-08:00"
+    },
+    {
+      "slug": "cube-root-7-irrational",
+      "phase": "ACT",
+      "path": "fast",
+      "started": "2025-12-30T16:46:33-08:00",
+      "status": "graduated",
+      "template": "nrt-irrational",
+      "template_value": "7",
+      "completed": "2025-12-30T16:46:54-08:00"
+    },
+    {
+      "slug": "cube-root-10-irrational",
+      "phase": "ACT",
+      "path": "fast",
+      "started": "2025-12-30T16:46:33-08:00",
+      "status": "graduated",
+      "template": "nrt-irrational",
+      "template_value": "10",
+      "completed": "2025-12-30T16:47:00-08:00"
+    },
+    {
+      "slug": "hurwitz-three-square-impossibility",
+      "phase": "ORIENT",
+      "path": "full",
+      "started": "2025-12-30T16:59:27-08:00",
+      "status": "graduated",
+      "lastUpdate": "2025-12-30T17:01:35-08:00",
+      "completed": "2025-12-30T23:58:14-08:00"
+    },
+    {
+      "slug": "fourth-root-2-irrational",
+      "phase": "ACT",
+      "path": "fast",
+      "started": "2025-12-31T00:00:13-08:00",
+      "status": "active",
+      "template": "nrt-irrational",
+      "template_value": "2"
+    },
+    {
+      "slug": "sqrt2-plus-sqrt3-irrational",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2025-12-31T11:10:20-08:00",
+      "status": "graduated",
+      "lastUpdate": "2026-01-01T06:38:29.515Z",
+      "completed": "2025-12-31T14:30:00-08:00"
+    },
+    {
+      "slug": "weak-goldbach",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2025-12-31T12:09:11-08:00",
+      "status": "graduated",
+      "lastUpdate": "2026-01-01T19:54:13.469Z",
+      "completed": "2026-01-01T19:54:13.468Z"
+    },
+    {
+      "slug": "twin-prime-special",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2025-12-31T16:00:00-08:00",
+      "status": "graduated",
+      "completed": "2025-12-31T17:00:00-08:00"
+    },
+    {
+      "slug": "prime-gaps-explicit",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2025-12-31T16:00:00-08:00",
+      "status": "graduated",
+      "completed": "2025-12-31T17:00:00-08:00"
+    },
+    {
+      "slug": "collatz-structured",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2025-12-31T16:00:00-08:00",
+      "status": "graduated",
+      "completed": "2025-12-31T17:00:00-08:00"
+    },
+    {
+      "slug": "szemeredi-theorem",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2025-12-31T16:00:00-08:00",
+      "status": "graduated",
+      "completed": "2025-12-31T17:00:00-08:00"
+    },
+    {
+      "slug": "pnp-barriers",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2025-12-31T00:00:00-08:00",
+      "status": "graduated",
+      "lastUpdate": "2026-03-15T19:52:05.293Z",
+      "completed": "2026-03-15T19:52:05.293Z"
+    },
+    {
+      "slug": "rh-consequences",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2025-12-31T00:00:00-08:00",
+      "status": "graduated",
+      "lastUpdate": "2026-01-01T06:38:29.517Z",
+      "completed": "2025-12-31T20:00:00-08:00"
+    },
+    {
+      "slug": "legendre-partial",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2025-12-31T14:00:00-08:00",
+      "status": "graduated",
+      "completed": "2025-12-31T15:00:00-08:00"
+    },
+    {
+      "slug": "sophie-germain-structure",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2025-12-31T14:00:00-08:00",
+      "status": "graduated",
+      "completed": "2025-12-31T15:00:00-08:00"
+    },
+    {
+      "slug": "chinese-remainder-constructive",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2025-12-31T14:00:00-08:00",
+      "status": "graduated",
+      "completed": "2025-12-31T15:00:00-08:00"
+    },
+    {
+      "slug": "wolstenholme-theorem",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2025-12-31T14:00:00-08:00",
+      "status": "graduated",
+      "completed": "2025-12-31T15:00:00-08:00"
+    },
+    {
+      "slug": "kummer-theorem",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2025-12-31T14:00:00-08:00",
+      "status": "graduated",
+      "completed": "2025-12-31T15:00:00-08:00"
+    },
+    {
+      "slug": "primitive-roots-count",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2025-12-31T14:00:00-08:00",
+      "status": "graduated",
+      "completed": "2025-12-31T15:00:00-08:00"
+    },
+    {
+      "slug": "bounded-prime-gaps",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-01T05:32:39.472Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T16:23:16.609Z",
+      "completed": "2026-02-07T00:59:53.359Z"
+    },
+    {
+      "slug": "2d-navier-stokes",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-01T05:32:39.476Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T16:23:16.610Z",
+      "completed": "2026-02-07T00:59:53.358Z"
+    },
+    {
+      "slug": "hurwitz-impossibility",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-01-01T05:32:39.476Z",
+      "status": "graduated",
+      "lastUpdate": "2026-01-02T00:51:36.379Z",
+      "completed": "2026-01-02T00:51:36.379Z"
+    },
+    {
+      "slug": "infinitude-primes-4k1",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-01-01T05:32:39.477Z",
+      "status": "graduated",
+      "lastUpdate": "2026-01-02T00:51:36.380Z",
+      "completed": "2026-01-02T00:51:36.380Z"
+    },
+    {
+      "slug": "infinitude-primes-4k3",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-01-01T05:32:39.477Z",
+      "status": "graduated",
+      "lastUpdate": "2026-01-02T00:51:36.380Z",
+      "completed": "2026-01-02T00:51:36.380Z"
+    },
+    {
+      "slug": "sum-of-divisors",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-01-01T05:32:39.478Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T16:23:16.663Z",
+      "completed": "2026-02-11T05:41:00.789Z"
+    },
+    {
+      "slug": "mobius-inversion",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-01-01T05:32:39.478Z",
+      "status": "graduated",
+      "lastUpdate": "2026-01-02T00:51:36.380Z",
+      "completed": "2026-01-02T00:51:36.380Z"
+    },
+    {
+      "slug": "prime-counting-bounds",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-01T05:32:39.479Z",
+      "status": "graduated",
+      "lastUpdate": "2026-01-02T00:51:36.380Z",
+      "completed": "2026-01-02T00:51:36.380Z"
+    },
+    {
+      "slug": "vietas-formulas",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-01-01T05:32:39.479Z",
+      "status": "graduated",
+      "lastUpdate": "2026-01-01T05:32:39.479Z",
+      "completed": "2026-01-01T05:32:39.479Z"
+    },
+    {
+      "slug": "frobenius-two-coprime",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-01-01T05:32:39.480Z",
+      "status": "graduated",
+      "lastUpdate": "2026-01-02T00:51:36.381Z",
+      "completed": "2026-01-02T00:51:36.381Z"
+    },
+    {
+      "slug": "ramsey-lower-bounds",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-01-01T19:54:13.472Z",
+      "status": "graduated",
+      "lastUpdate": "2026-01-01T19:54:13.472Z",
+      "completed": "2026-01-01T19:54:13.472Z"
+    },
+    {
+      "slug": "three-squares-theorem",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-01T19:54:13.472Z",
+      "status": "graduated",
+      "lastUpdate": "2026-01-13T16:22:40.288Z",
+      "completed": "2026-01-13T16:22:40.281Z"
+    },
+    {
+      "slug": "schur-theorem",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-01-01T19:54:13.473Z",
+      "status": "graduated",
+      "lastUpdate": "2026-01-01T19:54:13.473Z",
+      "completed": "2026-01-01T19:54:13.473Z"
+    },
+    {
+      "slug": "burnside-counting",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-01-01T19:54:13.473Z",
+      "status": "graduated",
+      "lastUpdate": "2026-01-01T21:40:23.911Z",
+      "completed": "2026-01-01T21:40:23.910Z"
+    },
+    {
+      "slug": "erdos-ko-rado",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-01T19:54:13.473Z",
+      "status": "graduated",
+      "lastUpdate": "2026-01-01T21:40:23.912Z",
+      "completed": "2026-01-01T21:40:23.912Z"
+    },
+    {
+      "slug": "riemann-hypothesis",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-01T21:55:27.885Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T16:23:16.609Z",
+      "completed": "2026-03-15T17:29:13.116Z"
+    },
+    {
+      "slug": "birch-swinnerton-dyer",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-01T21:55:27.886Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T16:23:16.609Z",
+      "completed": "2026-02-11T05:41:00.786Z"
+    },
+    {
+      "slug": "hodge-conjecture",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-01T21:55:27.887Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T16:23:16.609Z",
+      "completed": "2026-03-16T16:51:32.259Z"
+    },
+    {
+      "slug": "yang-mills-mass-gap",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-01T21:55:27.887Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T16:11:01.209Z",
+      "completed": "2026-03-13T17:50:22.123Z"
+    },
+    {
+      "slug": "poincare-conjecture",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-01T21:55:27.887Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T17:47:49.955Z",
+      "completed": "2026-03-15T22:28:57.349Z"
+    },
+    {
+      "slug": "navier-stokes-existence",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-01T21:55:27.888Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T16:23:16.609Z",
+      "completed": "2026-02-11T05:41:00.787Z"
+    },
+    {
+      "slug": "p-vs-np",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-01T21:55:27.888Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T16:23:16.607Z",
+      "completed": "2026-03-21T19:47:15.949Z"
+    },
+    {
+      "slug": "erdos-728-factorial-divisibility",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-01-10T18:59:46.679Z",
+      "status": "graduated",
+      "lastUpdate": "2026-01-10T18:59:46.679Z",
+      "completed": "2026-01-10T18:59:46.679Z"
+    },
+    {
+      "slug": "erdos-5",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T03:31:00.704Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.763Z",
+      "completed": "2026-03-24T15:15:41.763Z"
+    },
+    {
+      "slug": "erdos-10",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T04:04:26.047Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T16:23:55.773Z",
+      "completed": "2026-03-24T16:23:55.773Z"
+    },
+    {
+      "slug": "erdos-14",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T04:14:29.013Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.780Z",
+      "completed": "2026-03-24T15:15:41.780Z"
+    },
+    {
+      "slug": "erdos-25",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T04:34:21.348Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.761Z",
+      "completed": "2026-03-24T15:15:41.761Z"
+    },
+    {
+      "slug": "erdos-28",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T06:42:02.929Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.781Z",
+      "completed": "2026-03-24T15:15:41.781Z"
+    },
+    {
+      "slug": "erdos-36",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T06:58:30.838Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T23:43:21.722Z",
+      "completed": "2026-03-26T23:43:21.722Z"
+    },
+    {
+      "slug": "erdos-40",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T06:58:30.838Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.762Z",
+      "completed": "2026-03-24T15:15:41.762Z"
+    },
+    {
+      "slug": "erdos-42",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T06:58:30.839Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T23:43:21.714Z",
+      "completed": "2026-03-26T23:43:21.714Z"
+    },
+    {
+      "slug": "erdos-43",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T06:58:30.839Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T20:28:03.660Z",
+      "completed": "2026-03-23T20:28:03.659Z"
+    },
+    {
+      "slug": "erdos-44",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T06:58:30.839Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T22:32:23.135Z",
+      "completed": "2026-03-22T22:32:23.134Z"
+    },
+    {
+      "slug": "erdos-68",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T07:49:42.862Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.788Z",
+      "completed": "2026-03-24T15:15:41.788Z"
+    },
+    {
+      "slug": "erdos-75",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T07:49:42.862Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T23:43:21.723Z",
+      "completed": "2026-03-26T23:43:21.723Z"
+    },
+    {
+      "slug": "erdos-340-greedy-sidon",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T09:10:09.147Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T16:23:16.610Z",
+      "completed": "2026-03-22T16:23:16.610Z"
+    },
+    {
+      "slug": "erdos-5-prime-gaps",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T09:10:09.148Z",
+      "status": "graduated",
+      "lastUpdate": "2026-01-13T16:22:40.291Z",
+      "completed": "2026-01-13T16:22:40.291Z"
+    },
+    {
+      "slug": "erdos-10-prime-powers-of-2",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T09:10:09.148Z",
+      "status": "graduated",
+      "lastUpdate": "2026-01-13T16:22:40.291Z",
+      "completed": "2026-01-13T16:22:40.291Z"
+    },
+    {
+      "slug": "erdos-14-unique-sums",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T09:10:09.148Z",
+      "status": "graduated",
+      "lastUpdate": "2026-01-13T16:22:40.291Z",
+      "completed": "2026-01-13T16:22:40.291Z"
+    },
+    {
+      "slug": "erdos-25-number-theory",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T09:10:09.149Z",
+      "status": "graduated",
+      "lastUpdate": "2026-01-13T16:22:40.291Z",
+      "completed": "2026-01-13T16:22:40.291Z"
+    },
+    {
+      "slug": "erdos-28-additive-bases",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T09:10:09.149Z",
+      "status": "graduated",
+      "lastUpdate": "2026-01-13T16:22:40.291Z",
+      "completed": "2026-01-13T16:22:40.291Z"
+    },
+    {
+      "slug": "erdos-151",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T09:56:05.234Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.780Z",
+      "completed": "2026-03-24T15:15:41.780Z"
+    },
+    {
+      "slug": "erdos-152",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T09:56:05.235Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T00:05:33.406Z",
+      "completed": "2026-03-27T00:05:33.406Z"
+    },
+    {
+      "slug": "erdos-153",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T09:56:05.235Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T01:39:43.294Z",
+      "completed": "2026-03-28T01:39:43.294Z"
+    },
+    {
+      "slug": "erdos-155",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T09:56:05.235Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T23:50:23.948Z",
+      "completed": "2026-03-26T23:50:23.948Z"
+    },
+    {
+      "slug": "erdos-156",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T09:56:05.235Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.780Z",
+      "completed": "2026-03-24T15:15:41.780Z"
+    },
+    {
+      "slug": "erdos-159",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T09:56:05.236Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.780Z",
+      "completed": "2026-03-24T15:15:41.780Z"
+    },
+    {
+      "slug": "erdos-160",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T09:56:05.236Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T00:05:33.437Z",
+      "completed": "2026-03-27T00:05:33.437Z"
+    },
+    {
+      "slug": "erdos-162",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T09:56:05.236Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T20:50:15.386Z",
+      "completed": "2026-03-23T20:50:15.386Z"
+    },
+    {
+      "slug": "erdos-180",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T10:00:45.598Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T16:23:55.804Z",
+      "completed": "2026-03-24T16:23:55.804Z"
+    },
+    {
+      "slug": "erdos-181",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T10:00:45.598Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T06:04:02.050Z",
+      "completed": "2026-03-28T06:04:02.050Z"
+    },
+    {
+      "slug": "erdos-183",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T10:00:45.598Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T00:05:33.437Z",
+      "completed": "2026-03-27T00:05:33.437Z"
+    },
+    {
+      "slug": "erdos-200",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T10:06:12.675Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T00:41:59.387Z",
+      "completed": "2026-03-27T00:41:59.387Z"
+    },
+    {
+      "slug": "erdos-201",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T10:06:12.675Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T06:36:47.429Z",
+      "completed": "2026-03-28T06:36:47.429Z"
+    },
+    {
+      "slug": "erdos-190",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T16:01:50.836Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T00:05:33.437Z",
+      "completed": "2026-03-27T00:05:33.437Z"
+    },
+    {
+      "slug": "erdos-193",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T16:01:50.836Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T00:48:19.217Z",
+      "completed": "2026-03-27T00:48:19.216Z"
+    },
+    {
+      "slug": "erdos-196",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T16:01:50.837Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:26:46.997Z",
+      "completed": "2026-03-24T15:26:46.996Z"
+    },
+    {
+      "slug": "erdos-197",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T16:01:50.837Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.760Z",
+      "completed": "2026-03-24T15:15:41.760Z"
+    },
+    {
+      "slug": "erdos-203",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T16:01:50.837Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T01:05:50.584Z",
+      "completed": "2026-03-28T01:05:50.584Z"
+    },
+    {
+      "slug": "erdos-218",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T16:05:28.188Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.780Z",
+      "completed": "2026-03-24T15:15:41.780Z"
+    },
+    {
+      "slug": "erdos-234",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T16:08:36.613Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.760Z",
+      "completed": "2026-03-24T15:15:41.760Z"
+    },
+    {
+      "slug": "erdos-238",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T16:08:36.613Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.761Z",
+      "completed": "2026-03-24T15:15:41.761Z"
+    },
+    {
+      "slug": "erdos-241",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T16:21:33.088Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.781Z",
+      "completed": "2026-03-24T15:15:41.781Z"
+    },
+    {
+      "slug": "erdos-249",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T22:27:32.550Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.761Z",
+      "completed": "2026-03-24T15:15:41.761Z"
+    },
+    {
+      "slug": "erdos-261",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T22:30:27.389Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T01:39:43.327Z",
+      "completed": "2026-03-28T01:39:43.327Z"
+    },
+    {
+      "slug": "erdos-265",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T22:30:27.389Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T20:23:29.860Z",
+      "completed": "2026-03-26T20:23:29.860Z"
+    },
+    {
+      "slug": "erdos-269",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T22:30:27.390Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.781Z",
+      "completed": "2026-03-24T15:15:41.781Z"
+    },
+    {
+      "slug": "erdos-273",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T22:33:22.718Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.761Z",
+      "completed": "2026-03-24T15:15:41.761Z"
+    },
+    {
+      "slug": "erdos-276",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T22:33:22.719Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.781Z",
+      "completed": "2026-03-24T15:15:41.781Z"
+    },
+    {
+      "slug": "erdos-278",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T22:33:22.719Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T22:48:57.714Z",
+      "completed": "2026-03-23T22:48:57.714Z"
+    },
+    {
+      "slug": "erdos-279",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T22:33:22.719Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T01:39:43.328Z",
+      "completed": "2026-03-28T01:39:43.328Z"
+    },
+    {
+      "slug": "erdos-281",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T22:33:22.720Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T22:54:44.554Z",
+      "completed": "2026-03-24T22:54:44.553Z"
+    },
+    {
+      "slug": "erdos-282",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T22:33:22.720Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:26:47.028Z",
+      "completed": "2026-03-24T15:26:47.028Z"
+    },
+    {
+      "slug": "erdos-288",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T22:42:54.055Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T00:41:59.387Z",
+      "completed": "2026-03-27T00:41:59.387Z"
+    },
+    {
+      "slug": "erdos-289",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T22:42:54.055Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T10:37:57.640Z",
+      "completed": "2026-03-27T10:37:57.640Z"
+    },
+    {
+      "slug": "erdos-301",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T23:48:29.416Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T03:15:47.280Z",
+      "completed": "2026-03-24T03:15:47.279Z"
+    },
+    {
+      "slug": "erdos-311",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T23:51:53.284Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T00:05:33.407Z",
+      "completed": "2026-03-27T00:05:33.407Z"
+    },
+    {
+      "slug": "erdos-313",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T23:51:53.284Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T02:01:49.427Z",
+      "completed": "2026-03-24T02:01:49.426Z"
+    },
+    {
+      "slug": "erdos-317",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T23:51:53.285Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T23:05:29.570Z",
+      "completed": "2026-03-26T23:05:29.570Z"
+    },
+    {
+      "slug": "erdos-319",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T23:51:53.285Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T10:47:28.036Z",
+      "completed": "2026-03-27T10:47:28.036Z"
+    },
+    {
+      "slug": "erdos-312",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T23:55:09.603Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.761Z",
+      "completed": "2026-03-24T15:15:41.761Z"
+    },
+    {
+      "slug": "erdos-321",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T23:55:09.603Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.781Z",
+      "completed": "2026-03-24T15:15:41.781Z"
+    },
+    {
+      "slug": "erdos-323",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T23:55:09.603Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T06:36:47.432Z",
+      "completed": "2026-03-28T06:36:47.432Z"
+    },
+    {
+      "slug": "erdos-324",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T23:55:09.604Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.761Z",
+      "completed": "2026-03-24T15:15:41.761Z"
+    },
+    {
+      "slug": "erdos-327",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T23:55:09.604Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T04:30:45.854Z",
+      "completed": "2026-03-23T04:30:45.854Z"
+    },
+    {
+      "slug": "erdos-330",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T23:55:09.604Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T17:16:50.982Z",
+      "completed": "2026-03-24T17:16:50.982Z"
+    },
+    {
+      "slug": "erdos-332",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-12T23:55:09.604Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T07:57:24.332Z",
+      "completed": "2026-03-28T07:57:24.332Z"
+    },
+    {
+      "slug": "erdos-335",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T00:04:50.018Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T21:01:07.110Z",
+      "completed": "2026-03-23T21:01:07.109Z"
+    },
+    {
+      "slug": "erdos-341",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T00:04:50.019Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T14:26:12.482Z",
+      "completed": "2026-03-27T14:26:12.482Z"
+    },
+    {
+      "slug": "erdos-342",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T00:04:50.019Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.782Z",
+      "completed": "2026-03-24T15:15:41.782Z"
+    },
+    {
+      "slug": "erdos-345",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T00:53:52.153Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.782Z",
+      "completed": "2026-03-24T15:15:41.782Z"
+    },
+    {
+      "slug": "erdos-346",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T00:53:52.153Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T16:23:55.807Z",
+      "completed": "2026-03-24T16:23:55.807Z"
+    },
+    {
+      "slug": "erdos-347",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T00:53:52.153Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.762Z",
+      "completed": "2026-03-24T15:15:41.762Z"
+    },
+    {
+      "slug": "erdos-349",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T00:53:52.154Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.782Z",
+      "completed": "2026-03-24T15:15:41.782Z"
+    },
+    {
+      "slug": "erdos-358",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T00:53:52.154Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.782Z",
+      "completed": "2026-03-24T15:15:41.782Z"
+    },
+    {
+      "slug": "erdos-348",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T00:56:39.043Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.782Z",
+      "completed": "2026-03-24T15:15:41.782Z"
+    },
+    {
+      "slug": "erdos-361",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T00:56:39.043Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T20:50:15.351Z",
+      "completed": "2026-03-23T20:50:15.351Z"
+    },
+    {
+      "slug": "erdos-369",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T00:56:39.044Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T01:05:50.585Z",
+      "completed": "2026-03-28T01:05:50.585Z"
+    },
+    {
+      "slug": "erdos-367",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T00:59:36.242Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.782Z",
+      "completed": "2026-03-24T15:15:41.782Z"
+    },
+    {
+      "slug": "erdos-374",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T00:59:36.242Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T01:39:43.328Z",
+      "completed": "2026-03-28T01:39:43.328Z"
+    },
+    {
+      "slug": "erdos-380",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T00:59:36.242Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T10:37:57.640Z",
+      "completed": "2026-03-27T10:37:57.640Z"
+    },
+    {
+      "slug": "erdos-382",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T00:59:36.242Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T23:16:32.849Z",
+      "completed": "2026-03-24T23:16:32.849Z"
+    },
+    {
+      "slug": "erdos-383",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T00:59:36.243Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T10:37:57.599Z",
+      "completed": "2026-03-27T10:37:57.599Z"
+    },
+    {
+      "slug": "erdos-385",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T00:59:36.243Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.783Z",
+      "completed": "2026-03-24T15:15:41.783Z"
+    },
+    {
+      "slug": "erdos-386",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T00:59:36.244Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T00:41:59.416Z",
+      "completed": "2026-03-27T00:41:59.416Z"
+    },
+    {
+      "slug": "erdos-389",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T01:10:23.917Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:26:47.030Z",
+      "completed": "2026-03-24T15:26:47.030Z"
+    },
+    {
+      "slug": "erdos-390",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T01:10:23.917Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.783Z",
+      "completed": "2026-03-24T15:15:41.783Z"
+    },
+    {
+      "slug": "erdos-388",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T02:35:40.568Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.762Z",
+      "completed": "2026-03-24T15:15:41.762Z"
+    },
+    {
+      "slug": "erdos-396",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T02:35:40.568Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T00:48:19.218Z",
+      "completed": "2026-03-27T00:48:19.218Z"
+    },
+    {
+      "slug": "erdos-400",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T02:35:40.569Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T16:00:27.149Z",
+      "completed": "2026-03-24T16:00:27.149Z"
+    },
+    {
+      "slug": "erdos-404",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T02:35:40.569Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T01:39:43.328Z",
+      "completed": "2026-03-28T01:39:43.328Z"
+    },
+    {
+      "slug": "erdos-406",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T02:35:40.574Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T01:39:43.328Z",
+      "completed": "2026-03-28T01:39:43.328Z"
+    },
+    {
+      "slug": "erdos-409",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T02:38:27.586Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.784Z",
+      "completed": "2026-03-24T15:15:41.784Z"
+    },
+    {
+      "slug": "erdos-410",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T02:38:27.587Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T10:37:57.607Z",
+      "completed": "2026-03-27T10:37:57.607Z"
+    },
+    {
+      "slug": "erdos-411",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T02:38:27.587Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T17:16:51.006Z",
+      "completed": "2026-03-24T17:16:51.006Z"
+    },
+    {
+      "slug": "erdos-414",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T02:38:27.587Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T02:01:49.429Z",
+      "completed": "2026-03-24T02:01:49.429Z"
+    },
+    {
+      "slug": "erdos-417",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T02:38:27.587Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T01:39:43.329Z",
+      "completed": "2026-03-28T01:39:43.329Z"
+    },
+    {
+      "slug": "erdos-421",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T02:38:27.587Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T05:53:20.752Z",
+      "completed": "2026-03-28T05:53:20.751Z"
+    },
+    {
+      "slug": "erdos-413",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T02:41:06.675Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T22:15:18.940Z",
+      "completed": "2026-03-23T22:15:18.939Z"
+    },
+    {
+      "slug": "erdos-422",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T02:41:06.676Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T23:43:21.714Z",
+      "completed": "2026-03-26T23:43:21.714Z"
+    },
+    {
+      "slug": "erdos-423",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T02:41:06.676Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T16:00:27.150Z",
+      "completed": "2026-03-24T16:00:27.150Z"
+    },
+    {
+      "slug": "erdos-424",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T02:41:06.676Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T16:23:55.809Z",
+      "completed": "2026-03-24T16:23:55.809Z"
+    },
+    {
+      "slug": "erdos-428",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T02:41:06.676Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.762Z",
+      "completed": "2026-03-24T15:15:41.762Z"
+    },
+    {
+      "slug": "erdos-430",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T02:41:06.677Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.784Z",
+      "completed": "2026-03-24T15:15:41.784Z"
+    },
+    {
+      "slug": "erdos-432",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T02:41:06.677Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T10:37:57.607Z",
+      "completed": "2026-03-27T10:37:57.607Z"
+    },
+    {
+      "slug": "erdos-477",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T03:37:39.478Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.763Z",
+      "completed": "2026-03-24T15:15:41.763Z"
+    },
+    {
+      "slug": "erdos-478",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T03:37:39.479Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.785Z",
+      "completed": "2026-03-24T15:15:41.785Z"
+    },
+    {
+      "slug": "erdos-483",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T03:37:39.479Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.785Z",
+      "completed": "2026-03-24T15:15:41.785Z"
+    },
+    {
+      "slug": "erdos-488",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T03:37:39.479Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.785Z",
+      "completed": "2026-03-24T15:15:41.785Z"
+    },
+    {
+      "slug": "erdos-450",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T04:11:10.511Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T06:36:47.433Z",
+      "completed": "2026-03-28T06:36:47.433Z"
+    },
+    {
+      "slug": "erdos-451",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T04:11:10.511Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T00:41:59.417Z",
+      "completed": "2026-03-27T00:41:59.417Z"
+    },
+    {
+      "slug": "erdos-456",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T04:11:10.511Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T06:52:50.218Z",
+      "completed": "2026-03-28T06:52:50.218Z"
+    },
+    {
+      "slug": "erdos-457",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T04:11:10.512Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.784Z",
+      "completed": "2026-03-24T15:15:41.784Z"
+    },
+    {
+      "slug": "erdos-460",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T04:11:10.512Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T10:37:57.635Z",
+      "completed": "2026-03-27T10:37:57.635Z"
+    },
+    {
+      "slug": "erdos-461",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T04:11:10.512Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T06:36:47.387Z",
+      "completed": "2026-03-28T06:36:47.387Z"
+    },
+    {
+      "slug": "erdos-462",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T04:11:10.512Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T20:50:15.353Z",
+      "completed": "2026-03-23T20:50:15.353Z"
+    },
+    {
+      "slug": "erdos-463",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T04:11:10.513Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.784Z",
+      "completed": "2026-03-24T15:15:41.784Z"
+    },
+    {
+      "slug": "erdos-467",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T04:11:10.513Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.784Z",
+      "completed": "2026-03-24T15:15:41.784Z"
+    },
+    {
+      "slug": "erdos-468",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T04:11:10.513Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:26:47.000Z",
+      "completed": "2026-03-24T15:26:47.000Z"
+    },
+    {
+      "slug": "erdos-469",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T04:11:10.513Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T01:39:43.329Z",
+      "completed": "2026-03-28T01:39:43.329Z"
+    },
+    {
+      "slug": "erdos-472",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T04:11:10.513Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T00:31:22.450Z",
+      "completed": "2026-03-24T00:31:22.450Z"
+    },
+    {
+      "slug": "erdos-513",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T04:39:49.622Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.785Z",
+      "completed": "2026-03-24T15:15:41.785Z"
+    },
+    {
+      "slug": "erdos-524",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T04:39:49.622Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T10:37:57.610Z",
+      "completed": "2026-03-27T10:37:57.610Z"
+    },
+    {
+      "slug": "erdos-530",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T04:39:49.623Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.785Z",
+      "completed": "2026-03-24T15:15:41.785Z"
+    },
+    {
+      "slug": "erdos-533",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T04:39:49.623Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T01:05:50.586Z",
+      "completed": "2026-03-28T01:05:50.586Z"
+    },
+    {
+      "slug": "erdos-536",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T04:39:49.623Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.785Z",
+      "completed": "2026-03-24T15:15:41.785Z"
+    },
+    {
+      "slug": "erdos-538",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T04:39:49.623Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T01:55:24.811Z",
+      "completed": "2026-03-23T01:55:24.810Z"
+    },
+    {
+      "slug": "erdos-544",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T06:07:05.459Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.763Z",
+      "completed": "2026-03-24T15:15:41.763Z"
+    },
+    {
+      "slug": "erdos-635",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T17:14:37.756Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T01:39:43.329Z",
+      "completed": "2026-03-28T01:39:43.329Z"
+    },
+    {
+      "slug": "erdos-638",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T17:14:37.756Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.786Z",
+      "completed": "2026-03-24T15:15:41.786Z"
+    },
+    {
+      "slug": "erdos-640",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T17:14:37.756Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T20:23:29.862Z",
+      "completed": "2026-03-26T20:23:29.862Z"
+    },
+    {
+      "slug": "erdos-602",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T18:05:31.779Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T16:00:27.151Z",
+      "completed": "2026-03-24T16:00:27.151Z"
+    },
+    {
+      "slug": "erdos-603",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T18:05:31.780Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T00:15:21.320Z",
+      "completed": "2026-03-24T00:15:21.319Z"
+    },
+    {
+      "slug": "erdos-614",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T18:05:31.780Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T20:33:42.002Z",
+      "completed": "2026-03-27T20:33:42.001Z"
+    },
+    {
+      "slug": "erdos-654",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T18:22:04.304Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T03:15:47.317Z",
+      "completed": "2026-03-24T03:15:47.317Z"
+    },
+    {
+      "slug": "erdos-655",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T18:22:04.304Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T01:39:43.330Z",
+      "completed": "2026-03-28T01:39:43.330Z"
+    },
+    {
+      "slug": "erdos-661",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T18:22:04.304Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T19:07:51.811Z",
+      "completed": "2026-03-27T19:07:51.811Z"
+    },
+    {
+      "slug": "erdos-662",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T18:22:04.304Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T10:37:57.614Z",
+      "completed": "2026-03-27T10:37:57.614Z"
+    },
+    {
+      "slug": "erdos-663",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T18:22:04.304Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T01:39:43.330Z",
+      "completed": "2026-03-28T01:39:43.330Z"
+    },
+    {
+      "slug": "erdos-667",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T18:22:04.305Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.787Z",
+      "completed": "2026-03-24T15:15:41.787Z"
+    },
+    {
+      "slug": "erdos-668",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-13T18:22:04.305Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-25T05:52:08.645Z",
+      "completed": "2026-03-25T05:52:08.645Z"
+    },
+    {
+      "slug": "erdos-675",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-14T18:07:47.343Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T10:37:57.643Z",
+      "completed": "2026-03-27T10:37:57.643Z"
+    },
+    {
+      "slug": "erdos-676",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-14T18:07:47.344Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T06:36:47.428Z",
+      "completed": "2026-03-28T06:36:47.428Z"
+    },
+    {
+      "slug": "erdos-677",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-14T18:07:47.344Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T00:41:59.419Z",
+      "completed": "2026-03-27T00:41:59.419Z"
+    },
+    {
+      "slug": "erdos-680",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-14T18:07:47.345Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.788Z",
+      "completed": "2026-03-24T15:15:41.788Z"
+    },
+    {
+      "slug": "erdos-681",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-14T19:46:33.194Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T16:00:27.129Z",
+      "completed": "2026-03-24T16:00:27.128Z"
+    },
+    {
+      "slug": "erdos-684",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-14T19:46:33.195Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T17:41:59.029Z",
+      "completed": "2026-03-24T17:41:59.029Z"
+    },
+    {
+      "slug": "erdos-685",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-14T19:46:33.201Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.788Z",
+      "completed": "2026-03-24T15:15:41.788Z"
+    },
+    {
+      "slug": "erdos-686",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-14T19:46:33.202Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:35:06.951Z",
+      "completed": "2026-03-24T15:35:06.950Z"
+    },
+    {
+      "slug": "erdos-687",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-14T19:46:33.202Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T06:36:47.439Z",
+      "completed": "2026-03-28T06:36:47.439Z"
+    },
+    {
+      "slug": "erdos-688",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-14T19:46:33.202Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.788Z",
+      "completed": "2026-03-24T15:15:41.788Z"
+    },
+    {
+      "slug": "erdos-689",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-14T19:46:33.202Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T23:16:32.856Z",
+      "completed": "2026-03-24T23:16:32.856Z"
+    },
+    {
+      "slug": "erdos-690",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-14T19:46:33.203Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T10:37:57.643Z",
+      "completed": "2026-03-27T10:37:57.643Z"
+    },
+    {
+      "slug": "erdos-691",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-14T19:54:27.711Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T16:23:55.813Z",
+      "completed": "2026-03-24T16:23:55.813Z"
+    },
+    {
+      "slug": "erdos-693",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-14T19:54:27.712Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T10:37:57.595Z",
+      "completed": "2026-03-27T10:37:57.595Z"
+    },
+    {
+      "slug": "erdos-695",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-14T19:54:27.713Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T17:16:51.012Z",
+      "completed": "2026-03-24T17:16:51.012Z"
+    },
+    {
+      "slug": "erdos-700",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-14T21:07:11.724Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.788Z",
+      "completed": "2026-03-24T15:15:41.788Z"
+    },
+    {
+      "slug": "erdos-705",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-14T21:07:11.724Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T01:05:50.587Z",
+      "completed": "2026-03-28T01:05:50.587Z"
+    },
+    {
+      "slug": "erdos-706",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-14T21:11:01.534Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T01:39:43.331Z",
+      "completed": "2026-03-28T01:39:43.331Z"
+    },
+    {
+      "slug": "erdos-719",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-14T21:21:40.197Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T07:57:24.312Z",
+      "completed": "2026-03-28T07:57:24.311Z"
+    },
+    {
+      "slug": "erdos-726",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-14T21:29:39.409Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T05:53:20.776Z",
+      "completed": "2026-03-28T05:53:20.776Z"
+    },
+    {
+      "slug": "erdos-730",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-14T21:29:39.410Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T00:41:59.420Z",
+      "completed": "2026-03-27T00:41:59.420Z"
+    },
+    {
+      "slug": "erdos-731",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-14T21:29:39.410Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.789Z",
+      "completed": "2026-03-24T15:15:41.789Z"
+    },
+    {
+      "slug": "erdos-738",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-14T21:33:35.591Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T04:43:29.534Z",
+      "completed": "2026-03-23T04:43:29.533Z"
+    },
+    {
+      "slug": "erdos-741",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-14T21:33:35.592Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T16:23:55.814Z",
+      "completed": "2026-03-24T16:23:55.814Z"
+    },
+    {
+      "slug": "erdos-31",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-14T00:00:00.000Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T19:02:33.939Z",
+      "completed": "2026-03-27T19:02:33.938Z"
+    },
+    {
+      "slug": "erdos-749",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T08:18:33.645Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T05:02:49.854Z",
+      "completed": "2026-03-28T05:02:49.853Z"
+    },
+    {
+      "slug": "erdos-750",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T08:18:33.645Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T10:37:57.643Z",
+      "completed": "2026-03-27T10:37:57.643Z"
+    },
+    {
+      "slug": "erdos-761",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T08:25:36.657Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T06:52:50.206Z",
+      "completed": "2026-03-28T06:52:50.205Z"
+    },
+    {
+      "slug": "erdos-768",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T08:32:32.167Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.789Z",
+      "completed": "2026-03-24T15:15:41.789Z"
+    },
+    {
+      "slug": "erdos-770",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T08:32:32.167Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T07:57:24.332Z",
+      "completed": "2026-03-28T07:57:24.332Z"
+    },
+    {
+      "slug": "erdos-776",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T08:39:26.858Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T00:05:33.442Z",
+      "completed": "2026-03-27T00:05:33.442Z"
+    },
+    {
+      "slug": "erdos-782",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T08:39:26.859Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.789Z",
+      "completed": "2026-03-24T15:15:41.789Z"
+    },
+    {
+      "slug": "erdos-783",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T08:39:26.859Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.789Z",
+      "completed": "2026-03-24T15:15:41.789Z"
+    },
+    {
+      "slug": "erdos-792",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T08:46:37.713Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.789Z",
+      "completed": "2026-03-24T15:15:41.789Z"
+    },
+    {
+      "slug": "erdos-810",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T09:32:29.767Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:26:47.002Z",
+      "completed": "2026-03-24T15:26:47.002Z"
+    },
+    {
+      "slug": "erdos-825",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T09:39:18.200Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T16:23:55.815Z",
+      "completed": "2026-03-24T16:23:55.815Z"
+    },
+    {
+      "slug": "erdos-826",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T09:39:18.200Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T23:43:21.714Z",
+      "completed": "2026-03-26T23:43:21.714Z"
+    },
+    {
+      "slug": "erdos-827",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T09:39:18.200Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T06:36:47.427Z",
+      "completed": "2026-03-28T06:36:47.427Z"
+    },
+    {
+      "slug": "erdos-828",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T09:39:18.200Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T00:48:59.887Z",
+      "completed": "2026-03-24T00:48:59.887Z"
+    },
+    {
+      "slug": "erdos-831",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T09:46:19.704Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T05:53:20.753Z",
+      "completed": "2026-03-28T05:53:20.753Z"
+    },
+    {
+      "slug": "erdos-837",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T09:46:19.704Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T16:23:55.815Z",
+      "completed": "2026-03-24T16:23:55.815Z"
+    },
+    {
+      "slug": "erdos-839",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T09:46:19.704Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.789Z",
+      "completed": "2026-03-24T15:15:41.789Z"
+    },
+    {
+      "slug": "erdos-846",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T10:25:45.155Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T00:41:59.390Z",
+      "completed": "2026-03-27T00:41:59.390Z"
+    },
+    {
+      "slug": "erdos-847",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T10:25:45.155Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.789Z",
+      "completed": "2026-03-24T15:15:41.789Z"
+    },
+    {
+      "slug": "erdos-848",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T10:25:45.155Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T21:55:15.588Z",
+      "completed": "2026-03-23T21:55:15.588Z"
+    },
+    {
+      "slug": "erdos-850",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T10:25:45.155Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:26:47.040Z",
+      "completed": "2026-03-24T15:26:47.040Z"
+    },
+    {
+      "slug": "erdos-852",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T10:25:45.156Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T05:17:00.076Z",
+      "completed": "2026-03-24T05:17:00.076Z"
+    },
+    {
+      "slug": "erdos-853",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T10:25:45.156Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.789Z",
+      "completed": "2026-03-24T15:15:41.789Z"
+    },
+    {
+      "slug": "erdos-854",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T10:25:45.156Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T23:05:29.578Z",
+      "completed": "2026-03-26T23:05:29.578Z"
+    },
+    {
+      "slug": "erdos-863",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T10:32:49.761Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T19:07:51.813Z",
+      "completed": "2026-03-27T19:07:51.813Z"
+    },
+    {
+      "slug": "erdos-864",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T10:32:49.761Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T01:39:43.331Z",
+      "completed": "2026-03-28T01:39:43.331Z"
+    },
+    {
+      "slug": "erdos-875",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T10:46:46.306Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T23:43:21.724Z",
+      "completed": "2026-03-26T23:43:21.724Z"
+    },
+    {
+      "slug": "erdos-881",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T10:46:46.306Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.765Z",
+      "completed": "2026-03-24T15:15:41.765Z"
+    },
+    {
+      "slug": "erdos-884",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T10:46:46.306Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.765Z",
+      "completed": "2026-03-24T15:15:41.765Z"
+    },
+    {
+      "slug": "erdos-889",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T10:57:29.901Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T00:41:59.420Z",
+      "completed": "2026-03-27T00:41:59.420Z"
+    },
+    {
+      "slug": "erdos-890",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T10:57:29.901Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.790Z",
+      "completed": "2026-03-24T15:15:41.790Z"
+    },
+    {
+      "slug": "erdos-891",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T10:57:29.901Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:26:47.041Z",
+      "completed": "2026-03-24T15:26:47.041Z"
+    },
+    {
+      "slug": "erdos-892",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T11:22:53.228Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T22:54:44.563Z",
+      "completed": "2026-03-24T22:54:44.563Z"
+    },
+    {
+      "slug": "erdos-893",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T11:22:53.229Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T06:36:47.428Z",
+      "completed": "2026-03-28T06:36:47.428Z"
+    },
+    {
+      "slug": "erdos-896",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T11:22:53.229Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T04:30:45.865Z",
+      "completed": "2026-03-23T04:30:45.865Z"
+    },
+    {
+      "slug": "erdos-911",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T11:29:51.028Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T19:07:51.776Z",
+      "completed": "2026-03-27T19:07:51.776Z"
+    },
+    {
+      "slug": "erdos-913",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T11:36:40.863Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T01:39:43.332Z",
+      "completed": "2026-03-28T01:39:43.332Z"
+    },
+    {
+      "slug": "erdos-919",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T11:36:40.863Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.791Z",
+      "completed": "2026-03-24T15:15:41.791Z"
+    },
+    {
+      "slug": "erdos-929",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T11:43:50.650Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T16:00:27.156Z",
+      "completed": "2026-03-24T16:00:27.156Z"
+    },
+    {
+      "slug": "erdos-931",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T11:43:50.650Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.791Z",
+      "completed": "2026-03-24T15:15:41.791Z"
+    },
+    {
+      "slug": "erdos-932",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T11:43:50.650Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T02:40:09.410Z",
+      "completed": "2026-03-24T02:40:09.409Z"
+    },
+    {
+      "slug": "erdos-935",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T11:50:52.409Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T01:39:43.332Z",
+      "completed": "2026-03-28T01:39:43.332Z"
+    },
+    {
+      "slug": "erdos-936",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T11:50:52.409Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.791Z",
+      "completed": "2026-03-24T15:15:41.791Z"
+    },
+    {
+      "slug": "erdos-938",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T11:50:52.409Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T23:27:55.485Z",
+      "completed": "2026-03-23T23:27:55.484Z"
+    },
+    {
+      "slug": "erdos-949",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T12:22:36.006Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T17:16:51.016Z",
+      "completed": "2026-03-24T17:16:51.016Z"
+    },
+    {
+      "slug": "erdos-950",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T12:22:36.006Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T04:17:09.482Z",
+      "completed": "2026-03-24T04:17:09.482Z"
+    },
+    {
+      "slug": "erdos-951",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T12:22:36.006Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T10:37:57.645Z",
+      "completed": "2026-03-27T10:37:57.645Z"
+    },
+    {
+      "slug": "erdos-952",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T12:22:36.006Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T05:53:20.790Z",
+      "completed": "2026-03-28T05:53:20.790Z"
+    },
+    {
+      "slug": "erdos-953",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T12:22:36.007Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.791Z",
+      "completed": "2026-03-24T15:15:41.791Z"
+    },
+    {
+      "slug": "erdos-943",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T12:29:39.917Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T00:05:33.410Z",
+      "completed": "2026-03-27T00:05:33.410Z"
+    },
+    {
+      "slug": "erdos-948",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T12:29:39.917Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T16:23:55.817Z",
+      "completed": "2026-03-24T16:23:55.817Z"
+    },
+    {
+      "slug": "erdos-954",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T12:29:39.917Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T23:43:21.724Z",
+      "completed": "2026-03-26T23:43:21.724Z"
+    },
+    {
+      "slug": "erdos-959",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T12:36:36.407Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T00:41:59.421Z",
+      "completed": "2026-03-27T00:41:59.421Z"
+    },
+    {
+      "slug": "erdos-960",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T12:36:36.408Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T21:49:34.109Z",
+      "completed": "2026-03-24T21:49:34.108Z"
+    },
+    {
+      "slug": "erdos-963",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T12:36:36.408Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.792Z",
+      "completed": "2026-03-24T15:15:41.792Z"
+    },
+    {
+      "slug": "erdos-1013",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T13:36:13.714Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:26:47.022Z",
+      "completed": "2026-03-24T15:26:47.022Z"
+    },
+    {
+      "slug": "erdos-1014",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T13:43:13.293Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T00:05:33.400Z",
+      "completed": "2026-03-27T00:05:33.399Z"
+    },
+    {
+      "slug": "erdos-1016",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T13:43:13.294Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.777Z",
+      "completed": "2026-03-24T15:15:41.777Z"
+    },
+    {
+      "slug": "erdos-1032",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T13:50:22.421Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T01:39:43.325Z",
+      "completed": "2026-03-28T01:39:43.325Z"
+    },
+    {
+      "slug": "erdos-1035",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T13:59:18.137Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.778Z",
+      "completed": "2026-03-24T15:15:41.778Z"
+    },
+    {
+      "slug": "erdos-1051",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T14:24:45.358Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.750Z",
+      "completed": "2026-03-24T15:15:41.750Z"
+    },
+    {
+      "slug": "erdos-1052",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T14:31:40.057Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.778Z",
+      "completed": "2026-03-24T15:15:41.778Z"
+    },
+    {
+      "slug": "erdos-1053",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T14:31:40.057Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T00:41:59.414Z",
+      "completed": "2026-03-27T00:41:59.414Z"
+    },
+    {
+      "slug": "erdos-1055",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T14:31:40.058Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T04:30:45.849Z",
+      "completed": "2026-03-23T04:30:45.848Z"
+    },
+    {
+      "slug": "erdos-1056",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T14:31:40.058Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.778Z",
+      "completed": "2026-03-24T15:15:41.778Z"
+    },
+    {
+      "slug": "erdos-1059",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T14:31:40.058Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:26:47.023Z",
+      "completed": "2026-03-24T15:26:47.023Z"
+    },
+    {
+      "slug": "erdos-1060",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T14:31:40.058Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T23:10:36.805Z",
+      "completed": "2026-03-26T23:10:36.804Z"
+    },
+    {
+      "slug": "erdos-1061",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T14:31:40.058Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T01:39:43.288Z",
+      "completed": "2026-03-28T01:39:43.288Z"
+    },
+    {
+      "slug": "erdos-1062",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T14:38:41.571Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T01:39:43.326Z",
+      "completed": "2026-03-28T01:39:43.326Z"
+    },
+    {
+      "slug": "erdos-1063",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T14:38:41.571Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:26:47.024Z",
+      "completed": "2026-03-24T15:26:47.024Z"
+    },
+    {
+      "slug": "erdos-1065",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T14:38:41.571Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.751Z",
+      "completed": "2026-03-24T15:15:41.751Z"
+    },
+    {
+      "slug": "erdos-1068",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T14:38:41.571Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.751Z",
+      "completed": "2026-03-24T15:15:41.751Z"
+    },
+    {
+      "slug": "erdos-1071",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T14:38:41.571Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T17:16:51.000Z",
+      "completed": "2026-03-24T17:16:51.000Z"
+    },
+    {
+      "slug": "erdos-1072",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T14:38:41.572Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.778Z",
+      "completed": "2026-03-24T15:15:41.778Z"
+    },
+    {
+      "slug": "erdos-1073",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T14:45:40.351Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T03:15:47.309Z",
+      "completed": "2026-03-24T03:15:47.309Z"
+    },
+    {
+      "slug": "erdos-1084",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T14:52:37.979Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.778Z",
+      "completed": "2026-03-24T15:15:41.778Z"
+    },
+    {
+      "slug": "erdos-1092",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T14:52:37.979Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T01:05:50.583Z",
+      "completed": "2026-03-28T01:05:50.582Z"
+    },
+    {
+      "slug": "erdos-1093",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T14:52:37.979Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T06:36:47.428Z",
+      "completed": "2026-03-28T06:36:47.428Z"
+    },
+    {
+      "slug": "erdos-1103",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T15:24:14.877Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T05:03:37.723Z",
+      "completed": "2026-03-23T05:03:37.723Z"
+    },
+    {
+      "slug": "erdos-1104",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T15:24:14.877Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T16:23:55.803Z",
+      "completed": "2026-03-24T16:23:55.803Z"
+    },
+    {
+      "slug": "erdos-1094",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T15:31:24.881Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T01:39:43.326Z",
+      "completed": "2026-03-28T01:39:43.326Z"
+    },
+    {
+      "slug": "erdos-1097",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T15:31:24.882Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T00:41:59.414Z",
+      "completed": "2026-03-27T00:41:59.414Z"
+    },
+    {
+      "slug": "erdos-1105",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T15:31:24.882Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T16:23:55.803Z",
+      "completed": "2026-03-24T16:23:55.803Z"
+    },
+    {
+      "slug": "erdos-1117",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T15:38:27.860Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.779Z",
+      "completed": "2026-03-24T15:15:41.779Z"
+    },
+    {
+      "slug": "erdos-1120",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T15:45:30.818Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T10:47:28.035Z",
+      "completed": "2026-03-27T10:47:28.035Z"
+    },
+    {
+      "slug": "erdos-1130",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T15:52:59.262Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T10:37:57.639Z",
+      "completed": "2026-03-27T10:37:57.639Z"
+    },
+    {
+      "slug": "erdos-1135",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T15:52:59.262Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.779Z",
+      "completed": "2026-03-24T15:15:41.779Z"
+    },
+    {
+      "slug": "erdos-1136",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T15:52:59.262Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T23:50:23.943Z",
+      "completed": "2026-03-26T23:50:23.942Z"
+    },
+    {
+      "slug": "erdos-1137",
+      "phase": "ACT",
+      "path": "full",
+      "started": "2026-01-15T15:52:59.263Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T12:00:16-07:00",
+      "completed": "2026-03-24T05:17:00.048Z"
+    },
+    {
+      "slug": "erdos-1138",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T15:52:59.263Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.751Z",
+      "completed": "2026-03-24T15:15:41.751Z"
+    },
+    {
+      "slug": "erdos-1140",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:10:18.694Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T17:16:50.972Z",
+      "completed": "2026-03-24T17:16:50.971Z"
+    },
+    {
+      "slug": "erdos-1141",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:10:18.694Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T00:31:22.437Z",
+      "completed": "2026-03-24T00:31:22.436Z"
+    },
+    {
+      "slug": "erdos-1148",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:24:55.486Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.753Z",
+      "completed": "2026-03-24T15:15:41.753Z"
+    },
+    {
+      "slug": "erdos-1149",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:24:55.487Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.753Z",
+      "completed": "2026-03-24T15:15:41.753Z"
+    },
+    {
+      "slug": "erdos-1150",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:24:55.487Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T05:17:00.056Z",
+      "completed": "2026-03-24T05:17:00.056Z"
+    },
+    {
+      "slug": "erdos-1151",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:24:55.487Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T15:33:02.024Z",
+      "completed": "2026-03-28T15:33:02.024Z"
+    },
+    {
+      "slug": "erdos-1142",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:41:04.199Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T10:37:57.600Z",
+      "completed": "2026-03-27T10:37:57.600Z"
+    },
+    {
+      "slug": "erdos-1143",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:41:04.200Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T23:16:32.808Z",
+      "completed": "2026-03-24T23:16:32.808Z"
+    },
+    {
+      "slug": "erdos-1144",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:41:04.200Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T07:57:24.320Z",
+      "completed": "2026-03-28T07:57:24.320Z"
+    },
+    {
+      "slug": "erdos-1145",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:41:04.200Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.752Z",
+      "completed": "2026-03-24T15:15:41.752Z"
+    },
+    {
+      "slug": "erdos-1146",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:41:04.200Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.752Z",
+      "completed": "2026-03-24T15:15:41.752Z"
+    },
+    {
+      "slug": "erdos-1147",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:46:42.683Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T16:23:55.776Z",
+      "completed": "2026-03-24T16:23:55.776Z"
+    },
+    {
+      "slug": "erdos-1152",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:46:42.683Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T15:33:02.020Z",
+      "completed": "2026-03-28T15:33:02.020Z"
+    },
+    {
+      "slug": "erdos-1153",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:46:42.683Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T23:43:21.713Z",
+      "completed": "2026-03-26T23:43:21.712Z"
+    },
+    {
+      "slug": "erdos-1154",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:46:42.683Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T15:33:02.024Z",
+      "completed": "2026-03-28T15:33:02.024Z"
+    },
+    {
+      "slug": "erdos-1155",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:46:42.684Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T05:17:00.057Z",
+      "completed": "2026-03-24T05:17:00.057Z"
+    },
+    {
+      "slug": "erdos-1156",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:46:42.684Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T13:53:13.357Z",
+      "completed": "2026-03-28T13:53:13.357Z"
+    },
+    {
+      "slug": "erdos-1157",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:46:42.684Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T01:39:43.290Z",
+      "completed": "2026-03-28T01:39:43.290Z"
+    },
+    {
+      "slug": "erdos-1158",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:46:42.684Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T04:17:09.428Z",
+      "completed": "2026-03-24T04:17:09.428Z"
+    },
+    {
+      "slug": "erdos-1159",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:46:42.684Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.755Z",
+      "completed": "2026-03-24T15:15:41.755Z"
+    },
+    {
+      "slug": "erdos-1160",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:46:42.685Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.755Z",
+      "completed": "2026-03-24T15:15:41.755Z"
+    },
+    {
+      "slug": "erdos-1161",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:53:51.157Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T05:03:37.685Z",
+      "completed": "2026-03-23T05:03:37.684Z"
+    },
+    {
+      "slug": "erdos-1162",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:53:51.157Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T09:59:36.890Z",
+      "completed": "2026-03-28T09:59:36.889Z"
+    },
+    {
+      "slug": "erdos-1163",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:53:51.157Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T15:33:02.021Z",
+      "completed": "2026-03-28T15:33:02.021Z"
+    },
+    {
+      "slug": "erdos-1164",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:53:51.157Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T07:57:24.321Z",
+      "completed": "2026-03-28T07:57:24.321Z"
+    },
+    {
+      "slug": "erdos-1165",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:53:51.158Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.755Z",
+      "completed": "2026-03-24T15:15:41.755Z"
+    },
+    {
+      "slug": "erdos-1166",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:53:51.158Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.756Z",
+      "completed": "2026-03-24T15:15:41.756Z"
+    },
+    {
+      "slug": "erdos-1167",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:53:51.159Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T00:41:59.381Z",
+      "completed": "2026-03-27T00:41:59.380Z"
+    },
+    {
+      "slug": "erdos-1168",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:53:51.159Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T11:52:48.734Z",
+      "completed": "2026-03-28T11:52:48.733Z"
+    },
+    {
+      "slug": "erdos-1169",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:53:51.159Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T23:43:21.713Z",
+      "completed": "2026-03-26T23:43:21.713Z"
+    },
+    {
+      "slug": "erdos-1170",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T16:53:51.159Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.756Z",
+      "completed": "2026-03-24T15:15:41.756Z"
+    },
+    {
+      "slug": "erdos-1171",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T17:01:06.707Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.756Z",
+      "completed": "2026-03-24T15:15:41.756Z"
+    },
+    {
+      "slug": "erdos-1172",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T17:01:06.708Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.756Z",
+      "completed": "2026-03-24T15:15:41.756Z"
+    },
+    {
+      "slug": "erdos-1173",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T17:01:06.708Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.756Z",
+      "completed": "2026-03-24T15:15:41.756Z"
+    },
+    {
+      "slug": "erdos-1174",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T17:01:06.708Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T17:16:50.977Z",
+      "completed": "2026-03-24T17:16:50.977Z"
+    },
+    {
+      "slug": "erdos-1175",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T17:01:06.708Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T16:23:55.780Z",
+      "completed": "2026-03-24T16:23:55.780Z"
+    },
+    {
+      "slug": "erdos-1176",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T17:01:06.709Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T10:37:57.603Z",
+      "completed": "2026-03-27T10:37:57.603Z"
+    },
+    {
+      "slug": "erdos-1177",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T17:01:06.709Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T17:41:58.906Z",
+      "completed": "2026-03-24T17:41:58.905Z"
+    },
+    {
+      "slug": "erdos-1178",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T17:01:06.709Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T10:03:26.433Z",
+      "completed": "2026-03-28T10:03:26.433Z"
+    },
+    {
+      "slug": "erdos-1179",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T17:01:06.709Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T08:09:52.859Z",
+      "completed": "2026-03-28T08:09:52.859Z"
+    },
+    {
+      "slug": "erdos-1180",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-15T17:01:06.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T13:53:13.358Z",
+      "completed": "2026-03-28T13:53:13.358Z"
+    },
+    {
+      "slug": "erdos-1183",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-16T08:44:15.246Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T14:53:07.118Z",
+      "completed": "2026-03-28T14:53:07.117Z"
+    },
+    {
+      "slug": "erdos-1184",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-16T08:44:15.246Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T15:33:02.021Z",
+      "completed": "2026-03-28T15:33:02.021Z"
+    },
+    {
+      "slug": "erdos-1185",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-16T08:44:15.247Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T15:33:02.025Z",
+      "completed": "2026-03-28T15:33:02.025Z"
+    },
+    {
+      "slug": "erdos-1186",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-16T08:44:15.247Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T15:33:02.021Z",
+      "completed": "2026-03-28T15:33:02.021Z"
+    },
+    {
+      "slug": "erdos-1187",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-16T08:44:15.247Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T15:33:02.021Z",
+      "completed": "2026-03-28T15:33:02.021Z"
+    },
+    {
+      "slug": "erdos-1188",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-16T08:44:15.247Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T15:33:02.025Z",
+      "completed": "2026-03-28T15:33:02.025Z"
+    },
+    {
+      "slug": "erdos-1189",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-16T08:44:15.248Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T15:33:02.022Z",
+      "completed": "2026-03-28T15:33:02.022Z"
+    },
+    {
+      "slug": "erdos-1190",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-16T08:44:15.248Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T15:33:02.022Z",
+      "completed": "2026-03-28T15:33:02.022Z"
+    },
+    {
+      "slug": "erdos-1191",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-16T08:44:15.248Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T15:33:02.021Z",
+      "completed": "2026-03-28T15:33:02.021Z"
+    },
+    {
+      "slug": "erdos-1192",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-16T08:44:15.249Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T15:33:02.022Z",
+      "completed": "2026-03-28T15:33:02.022Z"
+    },
+    {
+      "slug": "erdos-1193",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-16T08:44:15.249Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T15:33:02.025Z",
+      "completed": "2026-03-28T15:33:02.025Z"
+    },
+    {
+      "slug": "erdos-1194",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-16T08:44:15.249Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T15:33:02.022Z",
+      "completed": "2026-03-28T15:33:02.022Z"
+    },
+    {
+      "slug": "erdos-1195",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-16T08:44:15.250Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T15:33:02.025Z",
+      "completed": "2026-03-28T15:33:02.025Z"
+    },
+    {
+      "slug": "erdos-1196",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-16T08:44:15.250Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T15:33:02.025Z",
+      "completed": "2026-03-28T15:33:02.025Z"
+    },
+    {
+      "slug": "erdos-1197",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-16T08:44:15.250Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T15:33:02.022Z",
+      "completed": "2026-03-28T15:33:02.022Z"
+    },
+    {
+      "slug": "erdos-1198",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-16T08:44:15.251Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T15:33:02.026Z",
+      "completed": "2026-03-28T15:33:02.026Z"
+    },
+    {
+      "slug": "erdos-1199",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-16T08:44:15.251Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T15:33:02.020Z",
+      "completed": "2026-03-28T15:33:02.019Z"
+    },
+    {
+      "slug": "erdos-1200",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-16T08:44:15.251Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T15:33:02.026Z",
+      "completed": "2026-03-28T15:33:02.026Z"
+    },
+    {
+      "slug": "erdos-100",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-23T08:04:56.538Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T20:50:15.339Z",
+      "completed": "2026-03-23T20:50:15.338Z"
+    },
+    {
+      "slug": "erdos-109",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-01-23T08:04:56.540Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T16:23:55.774Z",
+      "completed": "2026-03-24T16:23:55.774Z"
+    },
+    {
+      "slug": "erdos-12",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-01-23T08:04:56.542Z",
+      "status": "active",
+      "lastUpdate": "2026-03-13T07:52:17.061Z"
+    },
+    {
+      "slug": "erdos-205",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-01-23T08:04:56.542Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T03:51:07.518Z",
+      "completed": "2026-03-24T03:51:07.517Z"
+    },
+    {
+      "slug": "erdos-401",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-01-23T08:04:56.544Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T06:36:47.433Z",
+      "completed": "2026-03-28T06:36:47.433Z"
+    },
+    {
+      "slug": "erdos-547",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-01-23T08:04:56.545Z",
+      "status": "active",
+      "lastUpdate": "2026-03-13T07:52:17.061Z"
+    },
+    {
+      "slug": "erdos-871",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-01-23T08:04:56.547Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T22:23:02.279Z",
+      "completed": "2026-03-23T22:48:57.683Z"
+    },
+    {
+      "slug": "abel-ruffini-galois-extensions",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-27T22:18:02.331Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-07T00:59:53.359Z",
+      "completed": "2026-02-07T00:59:53.359Z"
+    },
+    {
+      "slug": "erdos-1057",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-27T22:18:02.332Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-07T00:59:53.361Z",
+      "completed": "2026-02-07T00:59:53.361Z"
+    },
+    {
+      "slug": "erdos-1109",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-27T22:18:02.332Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-13T07:22:26.134Z",
+      "completed": "2026-02-13T07:22:26.134Z"
+    },
+    {
+      "slug": "erdos-185",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-01-27T22:18:02.333Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-08T06:49:51.839Z",
+      "completed": "2026-02-08T06:49:51.839Z"
+    },
+    {
+      "slug": "erdos-285",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-27T22:18:02.333Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-11T05:41:00.788Z",
+      "completed": "2026-02-11T05:41:00.788Z"
+    },
+    {
+      "slug": "erdos-291",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-27T22:18:02.333Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-11T05:41:00.788Z",
+      "completed": "2026-02-11T05:41:00.788Z"
+    },
+    {
+      "slug": "erdos-436",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-27T22:18:02.333Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-07T00:59:53.378Z",
+      "completed": "2026-02-07T00:59:53.378Z"
+    },
+    {
+      "slug": "ramsey-r4k-extensions",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-01-27T22:18:02.334Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-07T00:59:53.389Z",
+      "completed": "2026-02-07T00:59:53.389Z"
+    },
+    {
+      "slug": "sum-of-kth-powers",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-01-27T22:18:02.334Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-08T06:11:43.708Z",
+      "completed": "2026-02-08T06:11:43.708Z"
+    },
+    {
+      "slug": "unit-distance-independence",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-01-27T22:18:02.334Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-08T06:11:43.709Z",
+      "completed": "2026-02-08T06:11:43.709Z"
+    },
+    {
+      "slug": "erdos-1139",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-08T00:55:03.569Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.751Z",
+      "completed": "2026-03-24T15:15:41.751Z"
+    },
+    {
+      "slug": "erdos-1181",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-08T00:55:03.569Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.757Z",
+      "completed": "2026-03-24T15:15:41.757Z"
+    },
+    {
+      "slug": "erdos-1182",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-08T00:55:03.569Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T10:47:28.000Z",
+      "completed": "2026-03-27T10:47:27.999Z"
+    },
+    {
+      "slug": "arithmetic-series-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-08T06:11:43.708Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-08T06:11:43.708Z",
+      "completed": "2026-02-08T06:11:43.708Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-08T06:11:43.709Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-08T17:19:55.975Z",
+      "completed": "2026-02-08T17:19:55.974Z"
+    },
+    {
+      "slug": "angle-trisection-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-08T06:11:43.709Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-08T08:02:45.183Z",
+      "completed": "2026-02-08T08:02:45.183Z"
+    },
+    {
+      "slug": "area-of-circle-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-08T06:11:43.709Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-09T23:59:13.856Z",
+      "completed": "2026-02-09T23:59:13.856Z"
+    },
+    {
+      "slug": "ballot-problem-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-08T06:11:43.709Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-15T01:15:34.171Z",
+      "completed": "2026-02-15T01:15:34.170Z"
+    },
+    {
+      "slug": "bezout-identity-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-08T06:11:43.709Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-13T07:22:26.133Z",
+      "completed": "2026-02-13T07:22:26.133Z"
+    },
+    {
+      "slug": "birthday-problem-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-08T06:11:43.709Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-09T23:59:13.857Z",
+      "completed": "2026-02-09T23:59:13.857Z"
+    },
+    {
+      "slug": "borsuk-ulam-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-08T06:11:43.709Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-08T06:49:51.838Z",
+      "completed": "2026-02-08T06:49:51.837Z"
+    },
+    {
+      "slug": "brouwer-fixed-point-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-08T06:11:43.709Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-11T04:38:25.646Z",
+      "completed": "2026-02-11T04:38:25.645Z"
+    },
+    {
+      "slug": "cayley-hamilton-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-08T06:11:43.709Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-13T07:22:26.134Z",
+      "completed": "2026-02-13T07:22:26.134Z"
+    },
+    {
+      "slug": "cayley-hamilton-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-11T05:41:00.788Z",
+      "completed": "2026-02-11T05:41:00.788Z"
+    },
+    {
+      "slug": "cevas-theorem-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-15T01:15:34.172Z",
+      "completed": "2026-02-15T01:15:34.172Z"
+    },
+    {
+      "slug": "cevas-theorem-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-09T23:59:13.857Z",
+      "completed": "2026-02-09T23:59:13.857Z"
+    },
+    {
+      "slug": "chinese-remainder-constructive-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-13T07:22:26.134Z",
+      "completed": "2026-02-13T07:22:26.134Z"
+    },
+    {
+      "slug": "combinations-formula-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-09T23:59:13.857Z",
+      "completed": "2026-02-09T23:59:13.857Z"
+    },
+    {
+      "slug": "denumerability-rationals-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-11T04:38:25.646Z",
+      "completed": "2026-02-11T04:38:25.646Z"
+    },
+    {
+      "slug": "descartes-rule-of-signs-oq-03",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-13T07:22:26.134Z",
+      "completed": "2026-02-13T07:22:26.134Z"
+    },
+    {
+      "slug": "divisibility-by-3-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-11T05:41:00.788Z",
+      "completed": "2026-02-11T05:41:00.788Z"
+    },
+    {
+      "slug": "erdos-1006-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-09T23:59:13.857Z",
+      "completed": "2026-02-09T23:59:13.857Z"
+    },
+    {
+      "slug": "erdos-101",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-13T07:22:26.134Z",
+      "completed": "2026-02-13T07:22:26.134Z"
+    },
+    {
+      "slug": "erdos-1012",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-09T23:59:13.857Z",
+      "completed": "2026-02-09T23:59:13.857Z"
+    },
+    {
+      "slug": "erdos-1012-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-08T08:35:28.158Z",
+      "completed": "2026-02-08T08:35:28.157Z"
+    },
+    {
+      "slug": "erdos-1023-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-11T04:38:25.646Z",
+      "completed": "2026-02-11T04:38:25.646Z"
+    },
+    {
+      "slug": "erdos-1054",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-15T01:15:34.174Z",
+      "completed": "2026-02-15T01:15:34.174Z"
+    },
+    {
+      "slug": "erdos-1054-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-10T18:07:05.001Z",
+      "completed": "2026-02-10T18:07:05.000Z"
+    },
+    {
+      "slug": "erdos-1082-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-09T23:59:13.857Z",
+      "completed": "2026-02-09T23:59:13.857Z"
+    },
+    {
+      "slug": "friendship-theorem-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-11T05:41:00.788Z",
+      "completed": "2026-02-11T05:41:00.788Z"
+    },
+    {
+      "slug": "gcd-algorithm-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-15T01:15:34.175Z",
+      "completed": "2026-02-15T01:15:34.175Z"
+    },
+    {
+      "slug": "geometric-series-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-13T07:22:26.135Z",
+      "completed": "2026-02-13T07:22:26.135Z"
+    },
+    {
+      "slug": "harmonic-divergence-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-15T01:15:34.175Z",
+      "completed": "2026-02-15T01:15:34.175Z"
+    },
+    {
+      "slug": "inclusion-exclusion-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-09T23:59:13.858Z",
+      "completed": "2026-02-09T23:59:13.858Z"
+    },
+    {
+      "slug": "konigsberg-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-13T07:22:26.135Z",
+      "completed": "2026-02-13T07:22:26.135Z"
+    },
+    {
+      "slug": "lagrange-four-squares",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-09T23:59:13.858Z",
+      "completed": "2026-02-09T23:59:13.858Z"
+    },
+    {
+      "slug": "lagrange-four-squares-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-13T07:22:26.135Z",
+      "completed": "2026-02-13T07:22:26.135Z"
+    },
+    {
+      "slug": "law-of-cosines-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-09T23:59:13.858Z",
+      "completed": "2026-02-09T23:59:13.858Z"
+    },
+    {
+      "slug": "pythagorean-theorem-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-21T18:51:26.156Z",
+      "completed": "2026-02-21T18:51:26.156Z"
+    },
+    {
+      "slug": "quadratic-reciprocity-elementary",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-13T07:22:26.135Z",
+      "completed": "2026-02-13T07:22:26.135Z"
+    },
+    {
+      "slug": "sqrt2-irrational-oq-03",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-08T07:34:07.912Z",
+      "completed": "2026-02-08T07:34:07.912Z"
+    },
+    {
+      "slug": "stirling-formula-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-09T23:59:13.858Z",
+      "completed": "2026-02-09T23:59:13.858Z"
+    },
+    {
+      "slug": "wilsons-generalization",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-13T07:22:26.135Z",
+      "completed": "2026-02-13T07:22:26.135Z"
+    },
+    {
+      "slug": "wilsons-theorem-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-13T07:22:26.135Z",
+      "completed": "2026-02-13T07:22:26.135Z"
+    },
+    {
+      "slug": "birthday-problem-oq-04",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-08T06:11:43.710Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-13T07:22:26.135Z",
+      "completed": "2026-02-13T07:22:26.135Z"
+    },
+    {
+      "slug": "cauchy-schwarz-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-11T07:03:36.101Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-15T01:15:34.172Z",
+      "completed": "2026-02-15T01:15:34.172Z"
+    },
+    {
+      "slug": "derangements-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-11T07:03:36.101Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-15T01:15:34.173Z",
+      "completed": "2026-02-15T01:15:34.173Z"
+    },
+    {
+      "slug": "euler-polyhedral-formula-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-11T07:03:36.101Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-15T01:15:34.175Z",
+      "completed": "2026-02-15T01:15:34.175Z"
+    },
+    {
+      "slug": "bertrands-postulate-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-21T18:51:26.153Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-23T05:42:29.517Z",
+      "completed": "2026-02-23T05:42:29.516Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-21T18:51:26.154Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-24T08:35:25.046Z",
+      "completed": "2026-02-24T08:35:25.046Z"
+    },
+    {
+      "slug": "bezout-identity-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-21T18:51:26.155Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-21T22:20:44.359Z",
+      "completed": "2026-02-21T22:20:44.358Z"
+    },
+    {
+      "slug": "bezout-identity-oq-03",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-21T18:51:26.155Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-21T19:21:07.131Z",
+      "completed": "2026-02-21T19:21:07.131Z"
+    },
+    {
+      "slug": "binomial-theorem-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-21T18:51:26.155Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-24T08:35:25.046Z",
+      "completed": "2026-02-24T08:35:25.046Z"
+    },
+    {
+      "slug": "abel-ruffini-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-21T19:21:07.129Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T21:17:21.387Z",
+      "completed": "2026-03-21T21:17:21.387Z"
+    },
+    {
+      "slug": "area-of-circle-oq-01-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-21T19:21:07.130Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-24T05:02:41.701Z",
+      "completed": "2026-02-24T05:02:41.700Z"
+    },
+    {
+      "slug": "ballot-problem-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-21T19:21:07.130Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-24T08:35:25.046Z",
+      "completed": "2026-02-24T08:35:25.046Z"
+    },
+    {
+      "slug": "basel-problem-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-21T19:21:07.130Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-24T08:35:25.046Z",
+      "completed": "2026-02-24T08:35:25.046Z"
+    },
+    {
+      "slug": "buffons-needle-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-21T19:21:07.131Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-12T17:29:54.442Z",
+      "completed": "2026-03-12T17:29:54.442Z"
+    },
+    {
+      "slug": "cantor-diagonalization-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-21T19:21:07.131Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-23T05:42:29.517Z",
+      "completed": "2026-02-23T05:42:29.517Z"
+    },
+    {
+      "slug": "cantors-theorem-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-21T19:21:07.131Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-24T05:02:41.701Z",
+      "completed": "2026-02-24T05:02:41.701Z"
+    },
+    {
+      "slug": "cauchy-schwarz-integral-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-21T19:21:07.131Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-23T05:42:29.518Z",
+      "completed": "2026-02-23T05:42:29.518Z"
+    },
+    {
+      "slug": "cayley-hamilton-minpoly-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-21T19:21:07.131Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-24T08:35:25.047Z",
+      "completed": "2026-02-24T08:35:25.047Z"
+    },
+    {
+      "slug": "cayley-hamilton-reduction-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-21T19:21:07.132Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-24T08:35:25.047Z",
+      "completed": "2026-02-24T08:35:25.047Z"
+    },
+    {
+      "slug": "central-limit-theorem-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-21T19:21:07.132Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-24T05:02:41.701Z",
+      "completed": "2026-02-24T05:02:41.701Z"
+    },
+    {
+      "slug": "chinese-remainder-non-coprime-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-21T19:21:07.132Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-24T08:35:25.047Z",
+      "completed": "2026-02-24T08:35:25.047Z"
+    },
+    {
+      "slug": "continuum-hypothesis-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-21T19:21:07.133Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-23T05:42:29.518Z",
+      "completed": "2026-02-23T05:42:29.518Z"
+    },
+    {
+      "slug": "cramers-rule-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-21T19:21:07.133Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-24T05:02:41.701Z",
+      "completed": "2026-02-24T05:02:41.701Z"
+    },
+    {
+      "slug": "de-moivre-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-21T19:21:07.133Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-24T08:35:25.047Z",
+      "completed": "2026-02-24T08:35:25.047Z"
+    },
+    {
+      "slug": "desargues-theorem-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-21T19:21:07.134Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-24T08:35:25.047Z",
+      "completed": "2026-02-24T08:35:25.047Z"
+    },
+    {
+      "slug": "dirichlets-theorem-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-21T19:21:07.134Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-06T06:42:42.096Z",
+      "completed": "2026-03-06T06:42:42.096Z"
+    },
+    {
+      "slug": "dissection-of-cubes-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-21T19:21:07.134Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-24T05:02:41.701Z",
+      "completed": "2026-02-24T05:02:41.701Z"
+    },
+    {
+      "slug": "divisibility-by-3-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-21T19:21:07.134Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-21T22:20:44.360Z",
+      "completed": "2026-02-21T22:20:44.360Z"
+    },
+    {
+      "slug": "e-transcendental-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-21T19:21:07.134Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-06T06:42:42.096Z",
+      "completed": "2026-03-06T06:42:42.096Z"
+    },
+    {
+      "slug": "abel-ruffini-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-24T08:35:25.045Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-24T08:35:25.046Z",
+      "completed": "2026-02-24T08:35:25.046Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-24T08:35:25.046Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-25T19:36:59.224Z",
+      "completed": "2026-02-25T19:36:59.223Z"
+    },
+    {
+      "slug": "angle-trisection-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-24T08:35:25.046Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-25T19:36:59.224Z",
+      "completed": "2026-02-25T19:36:59.224Z"
+    },
+    {
+      "slug": "area-of-circle-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-24T08:35:25.046Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-24T08:35:25.046Z",
+      "completed": "2026-02-24T08:35:25.046Z"
+    },
+    {
+      "slug": "ballot-problem-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-24T08:35:25.046Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-25T19:36:59.224Z",
+      "completed": "2026-02-25T19:36:59.224Z"
+    },
+    {
+      "slug": "borsuk-ulam-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-24T08:35:25.046Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-25T19:36:59.225Z",
+      "completed": "2026-02-25T19:36:59.225Z"
+    },
+    {
+      "slug": "cauchy-schwarz-integral-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-24T08:35:25.046Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-25T19:36:59.225Z",
+      "completed": "2026-02-25T19:36:59.225Z"
+    },
+    {
+      "slug": "cauchy-schwarz-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-24T08:35:25.047Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-24T08:35:25.047Z",
+      "completed": "2026-02-24T08:35:25.047Z"
+    },
+    {
+      "slug": "erdos-1006-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-24T08:35:25.047Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-25T19:36:59.227Z",
+      "completed": "2026-02-25T19:36:59.227Z"
+    },
+    {
+      "slug": "laws-of-large-numbers-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-24T08:35:25.048Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-25T19:36:59.227Z",
+      "completed": "2026-02-25T19:36:59.227Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-03-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-25T19:36:59.224Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-06T07:22:46.058Z",
+      "completed": "2026-03-06T07:22:46.057Z"
+    },
+    {
+      "slug": "angle-trisection-oq-02-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-25T19:36:59.224Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-25T19:36:59.224Z",
+      "completed": "2026-02-25T19:36:59.224Z"
+    },
+    {
+      "slug": "area-of-circle-oq-01-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-25T19:36:59.224Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-13T06:21:52.594Z",
+      "completed": "2026-03-13T06:21:52.594Z"
+    },
+    {
+      "slug": "bezout-identity-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-25T19:36:59.225Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-25T19:36:59.225Z",
+      "completed": "2026-02-25T19:36:59.225Z"
+    },
+    {
+      "slug": "bezout-identity-oq-02-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-25T19:36:59.225Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-25T19:36:59.225Z",
+      "completed": "2026-02-25T19:36:59.225Z"
+    },
+    {
+      "slug": "binomial-theorem-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-25T19:36:59.225Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-25T19:36:59.225Z",
+      "completed": "2026-02-25T19:36:59.225Z"
+    },
+    {
+      "slug": "borsuk-ulam-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-25T19:36:59.225Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T19:47:15.961Z",
+      "completed": "2026-03-21T19:47:15.961Z"
+    },
+    {
+      "slug": "bounded-prime-gaps-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-25T19:36:59.225Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-25T19:36:59.225Z",
+      "completed": "2026-02-25T19:36:59.225Z"
+    },
+    {
+      "slug": "bounded-prime-gaps-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-25T19:36:59.225Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-26T21:45:55.132Z",
+      "completed": "2026-02-26T21:45:55.132Z"
+    },
+    {
+      "slug": "brouwer-fixed-point-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-25T19:36:59.225Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-25T19:36:59.225Z",
+      "completed": "2026-02-25T19:36:59.225Z"
+    },
+    {
+      "slug": "buffons-needle-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-25T19:36:59.225Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-07T18:02:01.175Z",
+      "completed": "2026-03-07T18:02:01.175Z"
+    },
+    {
+      "slug": "cantor-diagonalization-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-25T19:36:59.225Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-12T17:29:54.443Z",
+      "completed": "2026-03-12T17:29:54.443Z"
+    },
+    {
+      "slug": "cauchy-schwarz-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-25T19:36:59.225Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-26T18:10:25.579Z",
+      "completed": "2026-02-26T18:10:25.579Z"
+    },
+    {
+      "slug": "cayley-hamilton-minpoly-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-25T19:36:59.225Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-25T19:36:59.225Z",
+      "completed": "2026-02-25T19:36:59.225Z"
+    },
+    {
+      "slug": "cevas-theorem-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-25T19:36:59.226Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-25T19:36:59.226Z",
+      "completed": "2026-02-25T19:36:59.226Z"
+    },
+    {
+      "slug": "derangements-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-25T19:36:59.226Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-25T19:36:59.226Z",
+      "completed": "2026-02-25T19:36:59.226Z"
+    },
+    {
+      "slug": "descartes-rule-of-signs-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-25T19:36:59.226Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-07T18:02:01.176Z",
+      "completed": "2026-03-07T18:02:01.176Z"
+    },
+    {
+      "slug": "erdos-1006-oq-02-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-25T19:36:59.227Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-25T19:36:59.227Z",
+      "completed": "2026-02-25T19:36:59.227Z"
+    },
+    {
+      "slug": "greens-theorem-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-25T19:36:59.227Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-25T19:36:59.227Z",
+      "completed": "2026-02-25T19:36:59.227Z"
+    },
+    {
+      "slug": "area-of-circle-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-26T17:08:50.304Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-26T18:10:25.577Z",
+      "completed": "2026-02-26T18:10:25.576Z"
+    },
+    {
+      "slug": "arithmetic-series-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-26T17:08:50.304Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-26T17:08:50.304Z",
+      "completed": "2026-02-26T17:08:50.304Z"
+    },
+    {
+      "slug": "ballot-problem-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-26T17:08:50.304Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T19:47:15.958Z",
+      "completed": "2026-03-21T19:47:15.958Z"
+    },
+    {
+      "slug": "bezout-identity-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-26T17:08:50.305Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-26T17:08:50.305Z",
+      "completed": "2026-02-26T17:08:50.305Z"
+    },
+    {
+      "slug": "binomial-theorem-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-26T17:08:50.305Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-12T07:36:01.954Z",
+      "completed": "2026-03-12T07:36:01.954Z"
+    },
+    {
+      "slug": "binomial-theorem-oq-04",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-26T17:08:50.305Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-26T21:45:55.132Z",
+      "completed": "2026-02-26T21:45:55.131Z"
+    },
+    {
+      "slug": "buffons-needle-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-26T17:08:50.305Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-26T17:08:50.305Z",
+      "completed": "2026-02-26T17:08:50.305Z"
+    },
+    {
+      "slug": "cantors-theorem-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-26T17:08:50.305Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-06T06:42:42.095Z",
+      "completed": "2026-03-06T06:42:42.095Z"
+    },
+    {
+      "slug": "cevas-theorem-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-26T17:08:50.305Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-26T22:16:20.677Z",
+      "completed": "2026-02-26T22:16:20.676Z"
+    },
+    {
+      "slug": "cramers-rule-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-26T17:08:50.305Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-26T21:45:55.133Z",
+      "completed": "2026-02-26T21:45:55.133Z"
+    },
+    {
+      "slug": "de-moivre-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-26T17:08:50.306Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-12T17:29:54.447Z",
+      "completed": "2026-03-12T17:29:54.447Z"
+    },
+    {
+      "slug": "de-moivre-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-26T17:08:50.306Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-13T03:56:04.582Z",
+      "completed": "2026-03-13T03:56:04.582Z"
+    },
+    {
+      "slug": "derangements-oq-03",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-02-26T17:08:50.306Z",
+      "status": "graduated",
+      "lastUpdate": "2026-02-26T18:10:25.580Z",
+      "completed": "2026-02-26T18:10:25.580Z"
+    },
+    {
+      "slug": "desargues-theorem-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-26T17:08:50.306Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-06T06:42:42.096Z",
+      "completed": "2026-03-06T06:42:42.096Z"
+    },
+    {
+      "slug": "greens-theorem-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-02-26T17:08:50.306Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-06T06:42:42.096Z",
+      "completed": "2026-03-06T06:42:42.096Z"
+    },
+    {
+      "slug": "bezout-identity-oq-02-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-06T06:42:42.090Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-12T07:36:01.954Z",
+      "completed": "2026-03-12T07:36:01.954Z"
+    },
+    {
+      "slug": "brouwer-fixed-point-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-06T06:42:42.092Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-12T17:29:54.442Z",
+      "completed": "2026-03-12T17:29:54.442Z"
+    },
+    {
+      "slug": "cauchy-schwarz-integral-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-06T06:42:42.095Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-12T17:29:54.444Z",
+      "completed": "2026-03-12T17:29:54.444Z"
+    },
+    {
+      "slug": "central-limit-theorem-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-06T06:42:42.095Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-06T06:42:42.095Z",
+      "completed": "2026-03-06T06:42:42.095Z"
+    },
+    {
+      "slug": "euler-polyhedral-formula-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-06T06:42:42.096Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-06T07:22:46.060Z",
+      "completed": "2026-03-06T07:22:46.060Z"
+    },
+    {
+      "slug": "euler-polyhedral-formula-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-06T06:42:42.096Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-13T03:56:04.585Z",
+      "completed": "2026-03-13T03:56:04.585Z"
+    },
+    {
+      "slug": "lebesgue-measure-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-06T06:42:42.097Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-07T18:02:01.177Z",
+      "completed": "2026-03-07T18:02:01.177Z"
+    },
+    {
+      "slug": "schauder-fixed-point-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-06T06:42:42.097Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-07T18:02:01.177Z",
+      "completed": "2026-03-07T18:02:01.177Z"
+    },
+    {
+      "slug": "angle-trisection-oq-02-oq-03-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-07T18:02:01.174Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-17T05:34:02.800Z",
+      "completed": "2026-03-17T05:34:02.800Z"
+    },
+    {
+      "slug": "area-of-circle-oq-01-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-07T18:02:01.174Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-12T07:36:01.954Z",
+      "completed": "2026-03-12T07:36:01.953Z"
+    },
+    {
+      "slug": "bezout-identity-oq-03-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-07T18:02:01.175Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-12T07:36:01.954Z",
+      "completed": "2026-03-12T07:36:01.954Z"
+    },
+    {
+      "slug": "borsuk-ulam-oq-03-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-07T18:02:01.175Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-12T06:03:39.245Z",
+      "completed": "2026-03-12T06:03:39.244Z"
+    },
+    {
+      "slug": "borsuk-ulam-oq-03-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-07T18:02:01.175Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T19:47:15.961Z",
+      "completed": "2026-03-21T19:47:15.961Z"
+    },
+    {
+      "slug": "cauchy-schwarz-integral-oq-01-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-07T18:02:01.175Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-12T17:29:54.444Z",
+      "completed": "2026-03-12T17:29:54.444Z"
+    },
+    {
+      "slug": "cauchy-schwarz-integral-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-07T18:02:01.175Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-12T07:36:01.955Z",
+      "completed": "2026-03-12T07:36:01.955Z"
+    },
+    {
+      "slug": "cauchy-schwarz-oq-03-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-07T18:02:01.175Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-12T17:29:54.444Z",
+      "completed": "2026-03-12T17:29:54.444Z"
+    },
+    {
+      "slug": "cayley-hamilton-minpoly-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-07T18:02:01.176Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-12T17:29:54.445Z",
+      "completed": "2026-03-12T17:29:54.445Z"
+    },
+    {
+      "slug": "central-limit-theorem-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-07T18:02:01.176Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-12T17:29:54.445Z",
+      "completed": "2026-03-12T17:29:54.445Z"
+    },
+    {
+      "slug": "central-limit-theorem-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-07T18:02:01.176Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-07T18:02:01.176Z",
+      "completed": "2026-03-07T18:02:01.176Z"
+    },
+    {
+      "slug": "cevas-theorem-oq-02-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-07T18:02:01.176Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-13T07:52:17.038Z",
+      "completed": "2026-03-13T07:52:17.037Z"
+    },
+    {
+      "slug": "chinese-remainder-non-coprime-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-07T18:02:01.176Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-12T07:36:01.955Z",
+      "completed": "2026-03-12T07:36:01.955Z"
+    },
+    {
+      "slug": "derangements-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-07T18:02:01.176Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-12T17:29:54.447Z",
+      "completed": "2026-03-12T17:29:54.447Z"
+    },
+    {
+      "slug": "erdos-1007-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-07T18:02:01.176Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T19:47:15.971Z",
+      "completed": "2026-03-21T19:47:15.971Z"
+    },
+    {
+      "slug": "erdos-1124-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-07T18:02:01.177Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-12T17:29:54.449Z",
+      "completed": "2026-03-12T17:29:54.449Z"
+    },
+    {
+      "slug": "erdos-1138-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-07T18:02:01.177Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-12T17:29:54.449Z",
+      "completed": "2026-03-12T17:29:54.449Z"
+    },
+    {
+      "slug": "erdos-1155-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-07T18:02:01.177Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-12T17:29:54.449Z",
+      "completed": "2026-03-12T17:29:54.449Z"
+    },
+    {
+      "slug": "euler-polyhedral-formula-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-07T18:02:01.177Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-12T17:29:54.450Z",
+      "completed": "2026-03-12T17:29:54.450Z"
+    },
+    {
+      "slug": "fourier-series-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-07T18:02:01.177Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-07T18:02:01.177Z",
+      "completed": "2026-03-07T18:02:01.177Z"
+    },
+    {
+      "slug": "konigsberg-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-07T18:02:01.177Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-07T18:02:01.177Z",
+      "completed": "2026-03-07T18:02:01.177Z"
+    },
+    {
+      "slug": "lebesgue-measure-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-07T18:02:01.177Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-07T18:02:01.177Z",
+      "completed": "2026-03-07T18:02:01.177Z"
+    },
+    {
+      "slug": "mean-value-theorem-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-07T18:02:01.177Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-12T07:36:01.957Z",
+      "completed": "2026-03-12T07:36:01.957Z"
+    },
+    {
+      "slug": "picks-theorem-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-07T18:02:01.177Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-12T17:29:54.452Z",
+      "completed": "2026-03-12T17:29:54.452Z"
+    },
+    {
+      "slug": "desargues-theorem-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-12T05:34:54.573Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-13T06:21:52.604Z",
+      "completed": "2026-03-13T06:21:52.604Z"
+    },
+    {
+      "slug": "elementary-quadratic-reciprocity-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-12T05:34:54.573Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-12T17:29:54.448Z",
+      "completed": "2026-03-12T17:29:54.448Z"
+    },
+    {
+      "slug": "fair-games-theorem-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-12T05:34:54.574Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-12T07:36:01.956Z",
+      "completed": "2026-03-12T07:36:01.956Z"
+    },
+    {
+      "slug": "feuerbachs-theorem-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-12T05:34:54.574Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-14T16:25:43.539Z",
+      "completed": "2026-03-14T16:25:43.539Z"
+    },
+    {
+      "slug": "hilbert-19-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-12T05:34:54.574Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-13T03:56:04.587Z",
+      "completed": "2026-03-13T03:56:04.587Z"
+    },
+    {
+      "slug": "lagrange-theorem-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-12T05:34:54.574Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-12T17:29:54.451Z",
+      "completed": "2026-03-12T17:29:54.451Z"
+    },
+    {
+      "slug": "leibniz-pi-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-12T05:34:54.574Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-13T06:21:52.608Z",
+      "completed": "2026-03-13T06:21:52.608Z"
+    },
+    {
+      "slug": "nth-root-irrational-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-12T05:34:54.574Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-13T06:21:52.608Z",
+      "completed": "2026-03-13T06:21:52.608Z"
+    },
+    {
+      "slug": "parallel-postulate-independence-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-12T05:34:54.574Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-12T17:29:54.451Z",
+      "completed": "2026-03-12T17:29:54.451Z"
+    },
+    {
+      "slug": "partition-theorem-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-12T05:34:54.574Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-15T19:52:05.292Z",
+      "completed": "2026-03-15T19:52:05.292Z"
+    },
+    {
+      "slug": "pythagorean-triples-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-12T05:34:54.574Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-15T19:52:05.293Z",
+      "completed": "2026-03-15T19:52:05.293Z"
+    },
+    {
+      "slug": "randomized-maxcut-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-12T05:34:54.574Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-13T03:56:04.589Z",
+      "completed": "2026-03-13T03:56:04.589Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-02-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-13T03:56:04.572Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-17T05:34:02.800Z",
+      "completed": "2026-03-17T05:34:02.799Z"
+    },
+    {
+      "slug": "ballot-problem-oq-01-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-13T03:56:04.574Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T19:47:15.958Z",
+      "completed": "2026-03-21T19:47:15.958Z"
+    },
+    {
+      "slug": "bezout-identity-oq-03-oq-01-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-13T03:56:04.575Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T19:47:15.959Z",
+      "completed": "2026-03-21T19:47:15.959Z"
+    },
+    {
+      "slug": "euler-polyhedral-formula-oq-01-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-13T03:56:04.585Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-13T05:04:31.044Z",
+      "completed": "2026-03-13T05:04:31.044Z"
+    },
+    {
+      "slug": "angle-trisection-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-14T19:01:45.290Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-18T15:53:06.870Z",
+      "completed": "2026-03-18T15:53:06.869Z"
+    },
+    {
+      "slug": "cauchy-schwarz-oq-04",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-14T19:01:45.297Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T19:47:15.964Z",
+      "completed": "2026-03-21T19:47:15.964Z"
+    },
+    {
+      "slug": "combinations-formula-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-14T19:01:45.300Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-18T23:57:01.187Z",
+      "completed": "2026-03-18T23:57:01.187Z"
+    },
+    {
+      "slug": "cramers-rule-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-14T19:01:45.300Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T19:47:15.968Z",
+      "completed": "2026-03-21T19:47:15.968Z"
+    },
+    {
+      "slug": "fermat-two-squares-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-15T02:30:10.387Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T19:47:15.973Z",
+      "completed": "2026-03-21T19:47:15.973Z"
+    },
+    {
+      "slug": "cayley-hamilton-minpoly-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-15T12:11:41.202Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T19:47:15.966Z",
+      "completed": "2026-03-21T19:47:15.966Z"
+    },
+    {
+      "slug": "dissection-of-cubes-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-15T12:11:41.205Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T18:11:22.545Z",
+      "completed": "2026-03-21T18:11:22.545Z"
+    },
+    {
+      "slug": "euler-totient-oq-04",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-15T12:11:41.207Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-18T23:57:01.193Z",
+      "completed": "2026-03-18T23:57:01.193Z"
+    },
+    {
+      "slug": "friendship-theorem-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-15T12:11:41.208Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T21:17:21.406Z",
+      "completed": "2026-03-21T21:17:21.406Z"
+    },
+    {
+      "slug": "gcd-algorithm-oq-01-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-15T12:11:41.208Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-18T15:53:06.873Z",
+      "completed": "2026-03-18T15:53:06.873Z"
+    },
+    {
+      "slug": "area-of-circle-oq-03-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-17T22:03:36.897Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T19:47:15.958Z",
+      "completed": "2026-03-21T19:47:15.958Z"
+    },
+    {
+      "slug": "binomial-theorem-oq-04-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-17T22:03:36.898Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T19:47:15.960Z",
+      "completed": "2026-03-21T19:47:15.960Z"
+    },
+    {
+      "slug": "divisibility-truncation-general-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-17T22:03:36.907Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-18T23:57:01.190Z",
+      "completed": "2026-03-18T23:57:01.190Z"
+    },
+    {
+      "slug": "elementary-quadratic-reciprocity-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-17T22:03:36.908Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T19:47:15.971Z",
+      "completed": "2026-03-21T19:47:15.971Z"
+    },
+    {
+      "slug": "erdos-1012-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-17T22:03:36.908Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-19T00:56:58.249Z",
+      "completed": "2026-03-19T00:56:58.249Z"
+    },
+    {
+      "slug": "erdos-131-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-19T08:13:01.827Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T19:47:15.950Z",
+      "completed": "2026-03-21T19:47:15.950Z"
+    },
+    {
+      "slug": "erdos-247-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-19T08:13:01.828Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T22:25:46.939Z",
+      "completed": "2026-03-21T22:25:46.939Z"
+    },
+    {
+      "slug": "erdos-177-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-19T08:13:01.845Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T19:47:15.972Z",
+      "completed": "2026-03-21T19:47:15.972Z"
+    },
+    {
+      "slug": "intermediate-value-theorem-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-19T08:13:01.847Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T19:47:15.975Z",
+      "completed": "2026-03-21T19:47:15.974Z"
+    },
+    {
+      "slug": "triangular-reciprocals-oq-03",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-19T08:13:01.850Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T19:47:15.977Z",
+      "completed": "2026-03-21T19:47:15.977Z"
+    },
+    {
+      "slug": "area-of-circle-oq-03-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-21T17:10:19.183Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T01:43:26.796Z",
+      "completed": "2026-03-22T01:43:26.795Z"
+    },
+    {
+      "slug": "bounded-prime-gaps-oq-03-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-21T17:10:19.184Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T03:22:54.641Z",
+      "completed": "2026-03-22T03:22:54.640Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-03-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-21T17:10:19.187Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T23:10:37.813Z",
+      "completed": "2026-03-21T23:10:37.813Z"
+    },
+    {
+      "slug": "angle-trisection-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-21T17:10:19.188Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T13:56:35.421Z",
+      "completed": "2026-03-22T13:56:35.421Z"
+    },
+    {
+      "slug": "arithmetic-series-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-21T17:10:19.190Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T02:26:15.524Z",
+      "completed": "2026-03-22T02:26:15.523Z"
+    },
+    {
+      "slug": "ballot-problem-oq-03-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-21T17:10:19.190Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T13:56:35.423Z",
+      "completed": "2026-03-22T13:56:35.423Z"
+    },
+    {
+      "slug": "bezout-identity-oq-02-oq-02-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-21T17:10:19.191Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T03:25:45.578Z",
+      "completed": "2026-03-22T03:25:45.578Z"
+    },
+    {
+      "slug": "bezout-identity-oq-03-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-21T17:10:19.191Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T23:10:37.817Z",
+      "completed": "2026-03-21T23:10:37.817Z"
+    },
+    {
+      "slug": "binomial-theorem-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-21T17:10:19.191Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T03:25:45.578Z",
+      "completed": "2026-03-22T03:25:45.578Z"
+    },
+    {
+      "slug": "binomial-theorem-oq-04-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-21T17:10:19.192Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T03:25:45.579Z",
+      "completed": "2026-03-22T03:25:45.579Z"
+    },
+    {
+      "slug": "borsuk-ulam-oq-03-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-21T17:10:19.192Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T10:45:34.763Z",
+      "completed": "2026-03-22T10:45:34.762Z"
+    },
+    {
+      "slug": "brouwer-fixed-point-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-21T17:10:19.192Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T00:45:41.601Z",
+      "completed": "2026-03-23T00:45:41.600Z"
+    },
+    {
+      "slug": "buffons-needle-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-21T17:10:19.193Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T13:56:35.426Z",
+      "completed": "2026-03-22T13:56:35.426Z"
+    },
+    {
+      "slug": "cantor-diagonalization-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-21T17:10:19.193Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T03:22:54.651Z",
+      "completed": "2026-03-22T03:22:54.651Z"
+    },
+    {
+      "slug": "cauchy-schwarz-integral-oq-01-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-21T17:10:19.194Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T03:22:54.651Z",
+      "completed": "2026-03-22T03:22:54.651Z"
+    },
+    {
+      "slug": "cauchy-schwarz-integral-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-21T17:10:19.194Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T13:56:35.427Z",
+      "completed": "2026-03-22T13:56:35.427Z"
+    },
+    {
+      "slug": "cauchy-schwarz-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-21T17:10:19.194Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T03:25:45.582Z",
+      "completed": "2026-03-22T03:25:45.582Z"
+    },
+    {
+      "slug": "cayley-hamilton-minpoly-oq-02-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-21T17:10:19.196Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T22:10:40.327Z",
+      "completed": "2026-03-22T22:10:40.327Z"
+    },
+    {
+      "slug": "central-limit-theorem-oq-01-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-21T17:10:19.196Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T03:25:45.583Z",
+      "completed": "2026-03-22T03:25:45.583Z"
+    },
+    {
+      "slug": "cevas-theorem-oq-02-oq-01-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-21T17:10:19.197Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T10:45:34.767Z",
+      "completed": "2026-03-22T10:45:34.767Z"
+    },
+    {
+      "slug": "pac-learning-bounds",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-21T20:11:02.346Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T23:10:37.807Z",
+      "completed": "2026-03-21T23:10:37.806Z"
+    },
+    {
+      "slug": "prob-method-expectation",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-21T20:11:02.346Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T21:17:21.382Z",
+      "completed": "2026-03-21T21:17:21.381Z"
+    },
+    {
+      "slug": "prob-method-lovasz-local",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-21T20:11:02.346Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T23:10:37.808Z",
+      "completed": "2026-03-21T23:10:37.808Z"
+    },
+    {
+      "slug": "shannon-entropy",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-21T20:11:02.346Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T22:25:46.937Z",
+      "completed": "2026-03-21T22:25:46.937Z"
+    },
+    {
+      "slug": "prob-method-alteration",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-21T20:11:02.346Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T21:57:07.469Z",
+      "completed": "2026-03-21T21:57:07.468Z"
+    },
+    {
+      "slug": "prob-method-second-moment",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-21T20:11:02.346Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T21:57:07.469Z",
+      "completed": "2026-03-21T21:57:07.469Z"
+    },
+    {
+      "slug": "shannon-channel-coding",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-21T20:11:02.346Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T21:57:07.469Z",
+      "completed": "2026-03-21T21:57:07.469Z"
+    },
+    {
+      "slug": "shannon-source-coding",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-21T20:11:02.346Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T21:57:07.470Z",
+      "completed": "2026-03-21T21:57:07.470Z"
+    },
+    {
+      "slug": "prob-method-applications",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-21T20:11:02.346Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-21T21:57:07.470Z",
+      "completed": "2026-03-21T21:57:07.470Z"
+    },
+    {
+      "slug": "area-of-circle-oq-01-oq-02-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-21T23:44:26.669Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T15:46:48.335Z",
+      "completed": "2026-03-22T15:46:48.335Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-21T23:44:26.674Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T03:25:45.576Z",
+      "completed": "2026-03-22T03:25:45.576Z"
+    },
+    {
+      "slug": "arithmetic-series-oq-02-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-21T23:44:26.677Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T13:56:35.423Z",
+      "completed": "2026-03-22T13:56:35.423Z"
+    },
+    {
+      "slug": "ballot-problem-oq-03-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-21T23:44:26.678Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T11:58:53.302Z",
+      "completed": "2026-03-22T11:58:53.301Z"
+    },
+    {
+      "slug": "abel-ruffini-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-22T03:02:07.189Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T12:52:40.604Z",
+      "completed": "2026-03-22T12:52:40.604Z"
+    },
+    {
+      "slug": "birthday-problem-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-22T03:02:07.195Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T13:56:35.425Z",
+      "completed": "2026-03-22T13:56:35.425Z"
+    },
+    {
+      "slug": "cayley-hamilton-minpoly-oq-05",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-03-22T03:02:07.201Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T15:12:17-07:00",
+      "completed": "2026-03-22T12:47:35.471Z"
+    },
+    {
+      "slug": "chinese-remainder-non-coprime-oq-03",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-22T03:02:07.203Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T18:10:49.477Z",
+      "completed": "2026-03-22T18:10:49.477Z"
+    },
+    {
+      "slug": "dissection-of-cubes-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-22T03:02:07.207Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T10:45:34.770Z",
+      "completed": "2026-03-22T10:45:34.770Z"
+    },
+    {
+      "slug": "fundamental-theorem-calculus-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-22T03:02:07.210Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T10:45:34.772Z",
+      "completed": "2026-03-22T10:45:34.772Z"
+    },
+    {
+      "slug": "intermediate-value-theorem-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-22T03:02:07.212Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T03:28:22.851Z",
+      "completed": "2026-03-22T03:28:22.851Z"
+    },
+    {
+      "slug": "divisibility-by-3-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-22T04:19:59.477Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T13:56:35.432Z",
+      "completed": "2026-03-22T13:56:35.432Z"
+    },
+    {
+      "slug": "law-of-cosines-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-22T04:19:59.477Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T13:56:35.435Z",
+      "completed": "2026-03-22T13:56:35.435Z"
+    },
+    {
+      "slug": "denumerability-rationals-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-22T04:19:59.477Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T13:56:35.430Z",
+      "completed": "2026-03-22T13:56:35.430Z"
+    },
+    {
+      "slug": "cayley-hamilton-reduction-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-22T04:19:59.477Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T16:11:01.290Z",
+      "completed": "2026-03-22T16:11:01.289Z"
+    },
+    {
+      "slug": "elementary-quadratic-reciprocity-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-22T04:19:59.477Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T09:45:43.578Z",
+      "completed": "2026-03-23T09:45:43.578Z"
+    },
+    {
+      "slug": "inclusion-exclusion-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-22T04:19:59.477Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T10:45:34.772Z",
+      "completed": "2026-03-22T10:45:34.772Z"
+    },
+    {
+      "slug": "roth-theorem-k3",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-22T07:19:45.046Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T05:17:00.028Z",
+      "completed": "2026-03-24T05:17:00.027Z"
+    },
+    {
+      "slug": "szemeredi-full",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-22T07:19:45.046Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T06:36:47.386Z",
+      "completed": "2026-03-28T06:36:47.386Z"
+    },
+    {
+      "slug": "szemeredi-regularity",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-22T07:19:45.046Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T02:21:50.681Z",
+      "completed": "2026-03-23T02:21:50.681Z"
+    },
+    {
+      "slug": "szemeredi-counting",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-22T07:19:45.047Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T07:21:10.437Z",
+      "completed": "2026-03-23T07:21:10.435Z"
+    },
+    {
+      "slug": "arithmetic-series-oq-02-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-22T07:19:45.054Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T13:56:35.423Z",
+      "completed": "2026-03-22T13:56:35.423Z"
+    },
+    {
+      "slug": "bezout-identity-oq-03-oq-01-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-22T07:19:45.056Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T13:56:35.424Z",
+      "completed": "2026-03-22T13:56:35.424Z"
+    },
+    {
+      "slug": "cauchy-schwarz-oq-04-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-22T07:19:45.060Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-22T12:47:35.470Z",
+      "completed": "2026-03-22T12:47:35.470Z"
+    },
+    {
+      "slug": "shannon-channel-coding-oq-04",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-22T16:23:16.628Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T08:19:33.454Z",
+      "completed": "2026-03-23T08:19:33.453Z"
+    },
+    {
+      "slug": "shannon-source-coding-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-22T16:23:16.628Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T09:45:43.504Z",
+      "completed": "2026-03-23T09:45:43.503Z"
+    },
+    {
+      "slug": "sylow-theorems-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-22T16:23:16.628Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-25T05:52:08.618Z",
+      "completed": "2026-03-25T05:52:08.617Z"
+    },
+    {
+      "slug": "schroeder-bernstein-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-22T16:23:16.662Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T11:18:59.801Z",
+      "completed": "2026-03-23T11:18:59.800Z"
+    },
+    {
+      "slug": "solution-of-cubic-oq-03",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-22T16:23:16.662Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T07:21:10.510Z",
+      "completed": "2026-03-23T07:21:10.510Z"
+    },
+    {
+      "slug": "sqrt2-from-axioms-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-22T16:23:16.662Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T07:21:10.510Z",
+      "completed": "2026-03-23T07:21:10.510Z"
+    },
+    {
+      "slug": "sum-of-kth-powers-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-22T16:23:16.662Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T20:28:03.673Z",
+      "completed": "2026-03-23T20:28:03.673Z"
+    },
+    {
+      "slug": "taylor-theorem-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-22T16:23:16.662Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T13:45:40.709Z",
+      "completed": "2026-03-23T13:45:40.709Z"
+    },
+    {
+      "slug": "triangle-inequality-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-22T16:23:16.662Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T08:19:33.498Z",
+      "completed": "2026-03-23T08:19:33.498Z"
+    },
+    {
+      "slug": "vietas-formulas-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-22T16:23:16.662Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T09:45:43.580Z",
+      "completed": "2026-03-23T09:45:43.580Z"
+    },
+    {
+      "slug": "wolstenholme-theorem-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-22T16:23:16.662Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T14:21:05.221Z",
+      "completed": "2026-03-23T14:21:05.220Z"
+    },
+    {
+      "slug": "chinese-remainder-constructive-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-22T15:12:20-07:00",
+      "status": "graduated",
+      "completed": "2026-03-23T09:45:43.576Z",
+      "lastUpdate": "2026-03-23T09:45:43.576Z"
+    },
+    {
+      "slug": "birthday-problem-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-22T15:12:20-07:00",
+      "status": "graduated",
+      "completed": "2026-03-23T10:45:52.031Z",
+      "lastUpdate": "2026-03-23T10:45:52.032Z"
+    },
+    {
+      "slug": "fourier-series-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-22T15:12:20-07:00",
+      "status": "graduated",
+      "completed": "2026-03-24T03:44:12.957Z",
+      "lastUpdate": "2026-03-24T03:44:12.958Z"
+    },
+    {
+      "slug": "cayley-hamilton-minpoly-oq-05-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-22T22:32:23.161Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T09:45:43.575Z",
+      "completed": "2026-03-23T09:45:43.575Z"
+    },
+    {
+      "slug": "leibniz-pi-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-22T22:32:23.162Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T08:19:33.497Z",
+      "completed": "2026-03-23T08:19:33.497Z"
+    },
+    {
+      "slug": "abel-ruffini-oq-05",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-23T00:45:41.641Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T16:23:55.817Z",
+      "completed": "2026-03-24T16:23:55.817Z"
+    },
+    {
+      "slug": "angle-trisection-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-23T00:45:41.641Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T06:36:47.429Z",
+      "completed": "2026-03-28T06:36:47.429Z"
+    },
+    {
+      "slug": "basel-problem-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-23T00:45:41.641Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.792Z",
+      "completed": "2026-03-24T15:15:41.792Z"
+    },
+    {
+      "slug": "borsuk-ulam-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-23T00:45:41.642Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T19:07:51.805Z",
+      "completed": "2026-03-27T19:07:51.805Z"
+    },
+    {
+      "slug": "buffons-needle-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-23T00:45:41.642Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T16:20:58.347Z",
+      "completed": "2026-03-28T16:20:58.346Z"
+    },
+    {
+      "slug": "cantor-diagonalization-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-23T00:45:41.642Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T01:39:43.324Z",
+      "completed": "2026-03-28T01:39:43.324Z"
+    },
+    {
+      "slug": "cantors-theorem-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-23T00:45:41.642Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T08:19:33.495Z",
+      "completed": "2026-03-23T08:19:33.495Z"
+    },
+    {
+      "slug": "cayley-hamilton-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-23T00:45:41.642Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T16:23:55.818Z",
+      "completed": "2026-03-24T16:23:55.818Z"
+    },
+    {
+      "slug": "cayley-hamilton-reduction-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-23T00:45:41.642Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T10:37:57.638Z",
+      "completed": "2026-03-27T10:37:57.638Z"
+    },
+    {
+      "slug": "central-limit-theorem-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-23T00:45:41.642Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.793Z",
+      "completed": "2026-03-24T15:15:41.793Z"
+    },
+    {
+      "slug": "cevas-theorem-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-23T00:45:41.642Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T06:36:47.430Z",
+      "completed": "2026-03-28T06:36:47.430Z"
+    },
+    {
+      "slug": "chinese-remainder-constructive-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-23T00:45:41.642Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:26:47.045Z",
+      "completed": "2026-03-24T15:26:47.045Z"
+    },
+    {
+      "slug": "chinese-remainder-non-coprime-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-23T00:45:41.642Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T13:58:59.385Z",
+      "completed": "2026-03-23T13:58:59.384Z"
+    },
+    {
+      "slug": "collatz-structured-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-23T00:45:41.642Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-23T20:28:03.672Z",
+      "completed": "2026-03-23T20:28:03.672Z"
+    },
+    {
+      "slug": "continuum-hypothesis-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-23T00:45:41.642Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T10:37:57.611Z",
+      "completed": "2026-03-27T10:37:57.611Z"
+    },
+    {
+      "slug": "ballot-problem-oq-01-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-23T17:46:34.537Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T22:16:39.846Z",
+      "completed": "2026-03-24T22:16:39.846Z"
+    },
+    {
+      "slug": "binomial-theorem-oq-03-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-23T17:46:34.538Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-25T05:52:08.651Z",
+      "completed": "2026-03-25T05:52:08.651Z"
+    },
+    {
+      "slug": "dissection-of-cubes-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-23T17:46:34.541Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T16:23:55.819Z",
+      "completed": "2026-03-24T16:23:55.819Z"
+    },
+    {
+      "slug": "dissection-of-cubes-oq-02-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-23T17:46:34.541Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-25T08:15:49.456Z",
+      "completed": "2026-03-25T08:15:49.456Z"
+    },
+    {
+      "slug": "fundamental-theorem-algebra-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-23T17:46:34.542Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T22:16:39.850Z",
+      "completed": "2026-03-24T22:16:39.850Z"
+    },
+    {
+      "slug": "abel-ruffini-oq-04-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.815Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-25T14:20:17.454Z",
+      "completed": "2026-03-25T14:20:17.453Z"
+    },
+    {
+      "slug": "brouwer-fixed-point-oq-04",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.817Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T20:30:46-07:00",
+      "completed": "2026-03-24T22:16:39.808Z"
+    },
+    {
+      "slug": "continuum-hypothesis-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.817Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T18:43:45-07:00",
+      "completed": "2026-03-24T15:15:41.765Z"
+    },
+    {
+      "slug": "cramers-rule-oq-03",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.817Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T21:05:08-07:00",
+      "completed": "2026-03-24T22:16:39.808Z"
+    },
+    {
+      "slug": "descartes-rule-of-signs-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.817Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T23:28:27.383Z",
+      "completed": "2026-03-24T23:28:27.382Z"
+    },
+    {
+      "slug": "dirichlets-theorem-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.817Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T20:23:29.848Z",
+      "completed": "2026-03-26T20:23:29.847Z"
+    },
+    {
+      "slug": "divisibility-by-3-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.818Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.765Z",
+      "completed": "2026-03-24T15:15:41.765Z"
+    },
+    {
+      "slug": "cayley-hamilton-minpoly-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.896Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.792Z",
+      "completed": "2026-03-24T15:15:41.792Z"
+    },
+    {
+      "slug": "e-transcendental-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.899Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T16:23:55.819Z",
+      "completed": "2026-03-24T16:23:55.819Z"
+    },
+    {
+      "slug": "erdos-1000-wip-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.900Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T00:09:28.700Z",
+      "completed": "2026-03-27T00:09:28.699Z"
+    },
+    {
+      "slug": "erdos-1002-wip-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.900Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.793Z",
+      "completed": "2026-03-24T15:15:41.793Z"
+    },
+    {
+      "slug": "erdos-1004-wip-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.900Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T23:05:29.552Z",
+      "completed": "2026-03-26T23:05:29.551Z"
+    },
+    {
+      "slug": "erdos-1007-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.901Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.793Z",
+      "completed": "2026-03-24T15:15:41.793Z"
+    },
+    {
+      "slug": "erdos-1008-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.901Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T22:16:39.849Z",
+      "completed": "2026-03-24T22:16:39.849Z"
+    },
+    {
+      "slug": "erdos-1009-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.901Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T06:47:22.112Z",
+      "completed": "2026-03-28T06:47:22.111Z"
+    },
+    {
+      "slug": "erdos-1010-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.901Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.793Z",
+      "completed": "2026-03-24T15:15:41.793Z"
+    },
+    {
+      "slug": "erdos-1010-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.901Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:26:47.045Z",
+      "completed": "2026-03-24T15:26:47.045Z"
+    },
+    {
+      "slug": "erdos-1014-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.902Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-25T05:52:08.654Z",
+      "completed": "2026-03-25T05:52:08.654Z"
+    },
+    {
+      "slug": "erdos-1015-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.902Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-25T15:54:36.277Z",
+      "completed": "2026-03-25T15:54:36.277Z"
+    },
+    {
+      "slug": "erdos-1017-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.902Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T19:54:12.812Z",
+      "completed": "2026-03-26T19:54:12.812Z"
+    },
+    {
+      "slug": "erdos-1019-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.902Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T22:04:50-07:00",
+      "completed": "2026-03-24T15:15:41.794Z"
+    },
+    {
+      "slug": "erdos-102-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.903Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T05:53:20.773Z",
+      "completed": "2026-03-28T05:53:20.773Z"
+    },
+    {
+      "slug": "erdos-1020-oq-05",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.903Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:26:47.045Z",
+      "completed": "2026-03-24T15:26:47.045Z"
+    },
+    {
+      "slug": "erdos-103-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.903Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T22:54:44.568Z",
+      "completed": "2026-03-24T22:54:44.568Z"
+    },
+    {
+      "slug": "erdos-1032-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.903Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T06:36:47.431Z",
+      "completed": "2026-03-28T06:36:47.431Z"
+    },
+    {
+      "slug": "erdos-1047-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.903Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.794Z",
+      "completed": "2026-03-24T15:15:41.794Z"
+    },
+    {
+      "slug": "erdos-1063-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.903Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.794Z",
+      "completed": "2026-03-24T15:15:41.794Z"
+    },
+    {
+      "slug": "erdos-1071-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.904Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T16:23:55.819Z",
+      "completed": "2026-03-24T16:23:55.819Z"
+    },
+    {
+      "slug": "erdos-1084-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.904Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T23:05:29.554Z",
+      "completed": "2026-03-26T23:05:29.554Z"
+    },
+    {
+      "slug": "erdos-1089-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.904Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T22:54:44.568Z",
+      "completed": "2026-03-24T22:54:44.568Z"
+    },
+    {
+      "slug": "erdos-1095-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.904Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.794Z",
+      "completed": "2026-03-24T15:15:41.794Z"
+    },
+    {
+      "slug": "erdos-1096-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.904Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.794Z",
+      "completed": "2026-03-24T15:15:41.794Z"
+    },
+    {
+      "slug": "erdos-1099-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.905Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-25T13:15:36.931Z",
+      "completed": "2026-03-25T13:15:36.931Z"
+    },
+    {
+      "slug": "erdos-1108-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.905Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.794Z",
+      "completed": "2026-03-24T15:15:41.794Z"
+    },
+    {
+      "slug": "erdos-1109-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.905Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.794Z",
+      "completed": "2026-03-24T15:15:41.794Z"
+    },
+    {
+      "slug": "erdos-1116-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.905Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T06:04:02.051Z",
+      "completed": "2026-03-28T06:04:02.051Z"
+    },
+    {
+      "slug": "erdos-1126-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.906Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:26:47.045Z",
+      "completed": "2026-03-24T15:26:47.045Z"
+    },
+    {
+      "slug": "erdos-1129-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.906Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T22:16:39.850Z",
+      "completed": "2026-03-24T22:16:39.850Z"
+    },
+    {
+      "slug": "erdos-113-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.906Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T23:43:21.722Z",
+      "completed": "2026-03-26T23:43:21.722Z"
+    },
+    {
+      "slug": "erdos-1131-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.907Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-25T04:49:06.998Z",
+      "completed": "2026-03-25T04:49:06.997Z"
+    },
+    {
+      "slug": "erdos-1132-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.907Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T13:26:15-07:00",
+      "completed": "2026-03-24T16:23:55.819Z"
+    },
+    {
+      "slug": "erdos-1179-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.907Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T23:43:21.716Z",
+      "completed": "2026-03-26T23:43:21.716Z"
+    },
+    {
+      "slug": "erdos-118-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.907Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.794Z",
+      "completed": "2026-03-24T15:15:41.794Z"
+    },
+    {
+      "slug": "erdos-490-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.907Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-24T15:15:41.794Z",
+      "completed": "2026-03-24T15:15:41.794Z"
+    },
+    {
+      "slug": "inverse-galois-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-24T00:48:59.908Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-25T05:52:08.655Z",
+      "completed": "2026-03-25T05:52:08.655Z"
+    },
+    {
+      "slug": "taylor-sincos-convergence",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-26T19:54:12.789Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T19:54:12.789Z",
+      "completed": "2026-03-26T19:54:12.789Z"
+    },
+    {
+      "slug": "abel-ruffini-oq-04-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-26T20:00:24.428Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T10:37:57.635Z",
+      "completed": "2026-03-27T10:37:57.635Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-02-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-26T20:00:24.430Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T06:36:47.429Z",
+      "completed": "2026-03-28T06:36:47.429Z"
+    },
+    {
+      "slug": "angle-trisection-oq-05",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-26T20:00:24.430Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T14:26:12.478Z",
+      "completed": "2026-03-27T14:26:12.477Z"
+    },
+    {
+      "slug": "area-of-circle-oq-01-oq-02-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-26T20:00:24.430Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T00:41:59.423Z",
+      "completed": "2026-03-27T00:41:59.423Z"
+    },
+    {
+      "slug": "arithmetic-series-oq-02-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-26T20:00:24.430Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-26T23:43:21.725Z",
+      "completed": "2026-03-26T23:43:21.725Z"
+    },
+    {
+      "slug": "ballot-problem-oq-01-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-26T20:00:24.430Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T06:36:47.429Z",
+      "completed": "2026-03-28T06:36:47.429Z"
+    },
+    {
+      "slug": "basel-problem-oq-05",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-26T20:00:24.431Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T06:36:47.429Z",
+      "completed": "2026-03-28T06:36:47.429Z"
+    },
+    {
+      "slug": "bertrands-postulate-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-26T20:00:24.431Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T06:36:47.430Z",
+      "completed": "2026-03-28T06:36:47.430Z"
+    },
+    {
+      "slug": "bezout-identity-oq-02-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-26T20:00:24.431Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T06:36:47.430Z",
+      "completed": "2026-03-28T06:36:47.430Z"
+    },
+    {
+      "slug": "binomial-theorem-oq-01-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-26T20:00:24.431Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T01:39:43.324Z",
+      "completed": "2026-03-28T01:39:43.324Z"
+    },
+    {
+      "slug": "birthday-problem-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-26T20:00:24.431Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T06:36:47.430Z",
+      "completed": "2026-03-28T06:36:47.430Z"
+    },
+    {
+      "slug": "borsuk-ulam-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-26T20:00:24.432Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T06:36:47.430Z",
+      "completed": "2026-03-28T06:36:47.430Z"
+    },
+    {
+      "slug": "bounded-prime-gaps-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-26T20:00:24.432Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T01:39:43.324Z",
+      "completed": "2026-03-28T01:39:43.324Z"
+    },
+    {
+      "slug": "brouwer-fixed-point-oq-02-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-26T20:00:24.432Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T06:36:47.430Z",
+      "completed": "2026-03-28T06:36:47.430Z"
+    },
+    {
+      "slug": "buffons-needle-oq-01-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-26T20:00:24.432Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T00:41:59.423Z",
+      "completed": "2026-03-27T00:41:59.423Z"
+    },
+    {
+      "slug": "cantor-diagonalization-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-26T20:00:24.432Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T05:11:50.238Z",
+      "completed": "2026-03-28T05:11:50.237Z"
+    },
+    {
+      "slug": "cantors-theorem-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-26T20:00:24.432Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T00:41:59.424Z",
+      "completed": "2026-03-27T00:41:59.424Z"
+    },
+    {
+      "slug": "cauchy-schwarz-integral-oq-01-oq-01-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-26T20:00:24.432Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T00:41:59.424Z",
+      "completed": "2026-03-27T00:41:59.424Z"
+    },
+    {
+      "slug": "cauchy-schwarz-oq-01-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-26T20:00:24.433Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T10:04:39.175Z",
+      "completed": "2026-03-27T10:04:39.175Z"
+    },
+    {
+      "slug": "cayley-hamilton-minpoly-oq-02-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-26T20:00:24.433Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-27T10:04:39.174Z",
+      "completed": "2026-03-27T10:04:39.173Z"
+    },
+    {
+      "slug": "borsuk-ulam-oq-04-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T14:26:43.164Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T15:33:02.060Z",
+      "completed": "2026-03-28T15:33:02.060Z"
+    },
+    {
+      "slug": "continuum-hypothesis-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T14:26:43.165Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T15:33:02.060Z",
+      "completed": "2026-03-28T15:33:02.060Z"
+    },
+    {
+      "slug": "erdos-1-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T14:26:43.165Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T15:00:38.424Z",
+      "completed": "2026-03-28T15:00:38.423Z"
+    },
+    {
+      "slug": "erdos-1014-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T14:26:43.165Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T15:00:38.424Z",
+      "completed": "2026-03-28T15:00:38.424Z"
+    },
+    {
+      "slug": "erdos-1098-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T14:26:43.165Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T15:33:02.042Z",
+      "completed": "2026-03-28T15:33:02.042Z"
+    },
+    {
+      "slug": "erdos-1135-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T14:26:43.165Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T15:33:02.062Z",
+      "completed": "2026-03-28T15:33:02.062Z"
+    },
+    {
+      "slug": "erdos-1144-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T14:26:43.165Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T15:33:02.062Z",
+      "completed": "2026-03-28T15:33:02.062Z"
+    },
+    {
+      "slug": "erdos-362-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T14:26:43.165Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T14:57:46.850Z",
+      "completed": "2026-03-28T14:57:46.849Z"
+    },
+    {
+      "slug": "godel-incompleteness-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T14:26:43.165Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T15:33:02.065Z",
+      "completed": "2026-03-28T15:33:02.065Z"
+    },
+    {
+      "slug": "hilbert-20-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T14:26:43.165Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T14:53:07.164Z",
+      "completed": "2026-03-28T14:53:07.164Z"
+    },
+    {
+      "slug": "erdos-171-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T17:58:20.618Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T20:12:32.487Z",
+      "completed": "2026-03-28T20:12:32.487Z"
+    },
+    {
+      "slug": "erdos-249-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T17:58:20.620Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T18:48:10.894Z",
+      "completed": "2026-03-28T18:48:10.894Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-03-oq-01-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T17:58:20.658Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T18:52:46.258Z",
+      "completed": "2026-03-28T18:52:46.257Z"
+    },
+    {
+      "slug": "area-of-circle-oq-01-oq-03-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T17:58:20.659Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T18:52:46.258Z",
+      "completed": "2026-03-28T18:52:46.258Z"
+    },
+    {
+      "slug": "binomial-theorem-oq-01-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T17:58:20.659Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T19:26:08.344Z",
+      "completed": "2026-03-28T19:26:08.344Z"
+    },
+    {
+      "slug": "buffons-needle-oq-01-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T17:58:20.659Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T18:48:10.930Z",
+      "completed": "2026-03-28T18:48:10.930Z"
+    },
+    {
+      "slug": "cantor-diagonalization-oq-02-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T17:58:20.660Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T18:45:08.463Z",
+      "completed": "2026-03-28T18:45:08.462Z"
+    },
+    {
+      "slug": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-28T17:58:20.660Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T19:26:08.345Z",
+      "completed": "2026-03-28T19:26:08.345Z"
+    },
+    {
+      "slug": "cayley-hamilton-minpoly-oq-05-oq-01-wip-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T17:58:20.660Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T19:26:08.345Z",
+      "completed": "2026-03-28T19:26:08.345Z"
+    },
+    {
+      "slug": "dirichlets-theorem-oq-02-wip-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T17:58:20.660Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T18:52:46.260Z",
+      "completed": "2026-03-28T18:52:46.260Z"
+    },
+    {
+      "slug": "erdos-1005-wip-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T17:58:20.660Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T19:26:08.346Z",
+      "completed": "2026-03-28T19:26:08.346Z"
+    },
+    {
+      "slug": "erdos-1014-oq-02-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T17:58:20.661Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T18:37:51.515Z",
+      "completed": "2026-03-28T18:37:51.514Z"
+    },
+    {
+      "slug": "erdos-1022-wip-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T17:58:20.661Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T20:23:06.054Z",
+      "completed": "2026-03-28T20:23:06.053Z"
+    },
+    {
+      "slug": "erdos-483-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T17:58:20.661Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T18:33:36.406Z",
+      "completed": "2026-03-28T18:33:36.405Z"
+    },
+    {
+      "slug": "fourier-series-oq-02-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T17:58:20.661Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T19:26:08.352Z",
+      "completed": "2026-03-28T19:26:08.352Z"
+    },
+    {
+      "slug": "isoperimetric-theorem-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T17:58:20.661Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T20:00:18.334Z",
+      "completed": "2026-03-28T20:00:18.334Z"
+    },
+    {
+      "slug": "kummer-theorem-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T17:58:20.661Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T19:26:08.352Z",
+      "completed": "2026-03-28T19:26:08.352Z"
+    },
+    {
+      "slug": "platonic-solids-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T17:58:20.661Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T18:52:46.266Z",
+      "completed": "2026-03-28T18:52:46.266Z"
+    },
+    {
+      "slug": "subset-count-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T17:58:20.662Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T18:52:46.266Z",
+      "completed": "2026-03-28T18:52:46.266Z"
+    },
+    {
+      "slug": "wolstenholme-theorem-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T17:58:20.662Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T18:35:46.501Z",
+      "completed": "2026-03-28T18:35:46.500Z"
+    },
+    {
+      "slug": "erdos-1022",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T10:58:21-07:00",
+      "status": "graduated",
+      "completed": "2026-03-28T18:52:46.269Z",
+      "lastUpdate": "2026-03-28T18:52:46.269Z"
+    },
+    {
+      "slug": "cayley-hamilton-minpoly-oq-05-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T19:26:08.356Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T21:52:46.541Z",
+      "completed": "2026-03-28T21:52:46.541Z"
+    },
+    {
+      "slug": "cayley-hamilton-minpoly-oq-05-oq-01-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T19:26:08.356Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T19:26:08.356Z",
+      "completed": "2026-03-28T19:26:08.356Z"
+    },
+    {
+      "slug": "cayley-hamilton-minpoly-oq-05-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T19:26:08.356Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T20:00:18.316Z",
+      "completed": "2026-03-28T20:00:18.315Z"
+    },
+    {
+      "slug": "elementary-quadratic-reciprocity-oq-03-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T19:26:08.356Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T19:26:08.356Z",
+      "completed": "2026-03-28T19:26:08.356Z"
+    },
+    {
+      "slug": "elementary-quadratic-reciprocity-oq-03-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T19:26:08.357Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T19:26:08.357Z",
+      "completed": "2026-03-28T19:26:08.357Z"
+    },
+    {
+      "slug": "solution-of-cubic-oq-03-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T19:26:08.357Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T20:19:55.241Z",
+      "completed": "2026-03-28T20:19:55.241Z"
+    },
+    {
+      "slug": "solution-of-cubic-oq-03-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T19:26:08.357Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T19:26:08.357Z",
+      "completed": "2026-03-28T19:26:08.357Z"
+    },
+    {
+      "slug": "erdos-1030-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T19:26:08.357Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T20:30:09.794Z",
+      "completed": "2026-03-28T20:30:09.794Z"
+    },
+    {
+      "slug": "erdos-1080-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T19:26:08.357Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T20:31:56.657Z",
+      "completed": "2026-03-28T20:31:56.657Z"
+    },
+    {
+      "slug": "erdos-1166-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T19:26:08.357Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T20:35:27.561Z",
+      "completed": "2026-03-28T20:35:27.560Z"
+    },
+    {
+      "slug": "erdos-131-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T19:26:08.358Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T20:30:09.796Z",
+      "completed": "2026-03-28T20:30:09.796Z"
+    },
+    {
+      "slug": "erdos-165-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T19:26:08.358Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T20:25:08.008Z",
+      "completed": "2026-03-28T20:25:08.008Z"
+    },
+    {
+      "slug": "erdos-202-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T19:26:08.358Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T20:33:40.977Z",
+      "completed": "2026-03-28T20:33:40.977Z"
+    },
+    {
+      "slug": "erdos-260-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T19:26:08.358Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T20:31:56.659Z",
+      "completed": "2026-03-28T20:31:56.659Z"
+    },
+    {
+      "slug": "erdos-263-wip-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T19:26:08.358Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T21:52:46.570Z",
+      "completed": "2026-03-28T21:52:46.570Z"
+    },
+    {
+      "slug": "erdos-338-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T19:26:08.358Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T20:00:18.333Z",
+      "completed": "2026-03-28T20:00:18.333Z"
+    },
+    {
+      "slug": "erdos-363-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T19:26:08.358Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T19:58:11.347Z",
+      "completed": "2026-03-28T19:58:11.347Z"
+    },
+    {
+      "slug": "erdos-402-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T19:26:08.359Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T20:23:06.058Z",
+      "completed": "2026-03-28T20:23:06.058Z"
+    },
+    {
+      "slug": "erdos-402-wip-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T19:26:08.359Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T20:06:39.056Z",
+      "completed": "2026-03-28T20:06:39.055Z"
+    },
+    {
+      "slug": "inverse-galois-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T19:26:08.359Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T19:26:08.359Z",
+      "completed": "2026-03-28T19:26:08.359Z"
+    },
+    {
+      "slug": "cayley-hamilton-minpoly-oq-05-oq-01-oq-02-wip-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T19:58:11.305Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T20:12:32.490Z",
+      "completed": "2026-03-28T20:12:32.490Z"
+    },
+    {
+      "slug": "cayley-hamilton-minpoly-oq-05-oq-01-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T19:58:11.305Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T21:52:46.548Z",
+      "completed": "2026-03-28T21:52:46.548Z"
+    },
+    {
+      "slug": "cayley-hamilton-minpoly-oq-05-oq-01-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T19:58:11.305Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T21:52:46.543Z",
+      "completed": "2026-03-28T21:52:46.543Z"
+    },
+    {
+      "slug": "elementary-quadratic-reciprocity-oq-03-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T19:58:11.305Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T20:12:32.490Z",
+      "completed": "2026-03-28T20:12:32.490Z"
+    },
+    {
+      "slug": "elementary-quadratic-reciprocity-oq-03-oq-01-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T19:58:11.305Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T20:12:32.491Z",
+      "completed": "2026-03-28T20:12:32.491Z"
+    },
+    {
+      "slug": "elementary-quadratic-reciprocity-oq-03-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T19:58:11.305Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T20:12:32.491Z",
+      "completed": "2026-03-28T20:12:32.491Z"
+    },
+    {
+      "slug": "solution-of-cubic-oq-03-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T19:58:11.305Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T20:12:32.491Z",
+      "completed": "2026-03-28T20:12:32.491Z"
+    },
+    {
+      "slug": "solution-of-cubic-oq-03-oq-05",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T19:58:11.305Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T20:12:32.491Z",
+      "completed": "2026-03-28T20:12:32.491Z"
+    },
+    {
+      "slug": "erdos-45-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T19:58:11.352Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T20:06:39.087Z",
+      "completed": "2026-03-28T20:06:39.087Z"
+    },
+    {
+      "slug": "erdos-465-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T19:58:11.352Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T20:00:18.335Z",
+      "completed": "2026-03-28T20:00:18.335Z"
+    },
+    {
+      "slug": "erdos-1098-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T21:52:46.572Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T21:52:46.572Z",
+      "completed": "2026-03-28T21:52:46.572Z"
+    },
+    {
+      "slug": "fair-games-theorem-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T21:52:46.572Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T21:52:46.572Z",
+      "completed": "2026-03-28T21:52:46.572Z"
+    },
+    {
+      "slug": "lagrange-theorem-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T21:52:46.575Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T21:52:46.575Z",
+      "completed": "2026-03-28T21:52:46.575Z"
+    },
+    {
+      "slug": "erdos-1095-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T21:52:46.581Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T21:52:46.581Z",
+      "completed": "2026-03-28T21:52:46.581Z"
+    },
+    {
+      "slug": "area-of-circle-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T21:52:46.599Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T21:52:46.599Z",
+      "completed": "2026-03-28T21:52:46.599Z"
+    },
+    {
+      "slug": "chinese-remainder-constructive-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T21:52:46.600Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T21:52:46.600Z",
+      "completed": "2026-03-28T21:52:46.600Z"
+    },
+    {
+      "slug": "descartes-rule-of-signs-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T21:52:46.600Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T21:52:46.600Z",
+      "completed": "2026-03-28T21:52:46.600Z"
+    },
+    {
+      "slug": "erdos-1008-wip-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T21:52:46.600Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T21:52:46.600Z",
+      "completed": "2026-03-28T21:52:46.600Z"
+    },
+    {
+      "slug": "erdos-1027-wip-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T21:52:46.600Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T21:52:46.600Z",
+      "completed": "2026-03-28T21:52:46.600Z"
+    },
+    {
+      "slug": "erdos-103-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T21:52:46.600Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T21:52:46.600Z",
+      "completed": "2026-03-28T21:52:46.600Z"
+    },
+    {
+      "slug": "erdos-104-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T21:52:46.600Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T21:52:46.600Z",
+      "completed": "2026-03-28T21:52:46.600Z"
+    },
+    {
+      "slug": "erdos-107-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T21:52:46.600Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T22:27:17.977Z",
+      "completed": "2026-03-28T22:27:17.977Z"
+    },
+    {
+      "slug": "erdos-225-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T21:52:46.602Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T21:52:46.602Z",
+      "completed": "2026-03-28T21:52:46.602Z"
+    },
+    {
+      "slug": "erdos-485-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T21:52:46.603Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T21:52:46.603Z",
+      "completed": "2026-03-28T21:52:46.603Z"
+    },
+    {
+      "slug": "erdos-501-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T21:52:46.603Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T22:27:17.980Z",
+      "completed": "2026-03-28T22:27:17.980Z"
+    },
+    {
+      "slug": "four-color-theorem-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T21:52:46.606Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T22:27:17.982Z",
+      "completed": "2026-03-28T22:27:17.982Z"
+    },
+    {
+      "slug": "lebesgue-measure-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T21:52:46.606Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T21:52:46.606Z",
+      "completed": "2026-03-28T21:52:46.606Z"
+    },
+    {
+      "slug": "shannon-channel-coding-wip-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T21:52:46.606Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T23:32:03.136Z",
+      "completed": "2026-03-28T23:32:03.135Z"
+    },
+    {
+      "slug": "shapley-folkman-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T21:52:46.606Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T21:52:46.606Z",
+      "completed": "2026-03-28T21:52:46.606Z"
+    },
+    {
+      "slug": "yang-mills-2d-wip-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T21:52:46.607Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-28T21:52:46.607Z",
+      "completed": "2026-03-28T21:52:46.607Z"
+    },
+    {
+      "slug": "abel-ruffini-oq-04-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T22:57:01.593Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T00:52:49.299Z",
+      "completed": "2026-03-29T00:52:49.299Z"
+    },
+    {
+      "slug": "angle-trisection-oq-02-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T22:57:01.594Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T00:52:49.266Z",
+      "completed": "2026-03-29T00:52:49.266Z"
+    },
+    {
+      "slug": "area-of-circle-oq-03-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T22:57:01.594Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T00:52:49.267Z",
+      "completed": "2026-03-29T00:52:49.267Z"
+    },
+    {
+      "slug": "bezout-identity-oq-03-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T22:57:01.594Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T00:52:49.271Z",
+      "completed": "2026-03-29T00:52:49.271Z"
+    },
+    {
+      "slug": "binomial-theorem-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T22:57:01.594Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T00:52:49.264Z",
+      "completed": "2026-03-29T00:52:49.264Z"
+    },
+    {
+      "slug": "borsuk-ulam-oq-02-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T22:57:01.594Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T00:52:49.270Z",
+      "completed": "2026-03-29T00:52:49.270Z"
+    },
+    {
+      "slug": "cantor-diagonalization-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T22:57:01.594Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T00:52:49.278Z",
+      "completed": "2026-03-29T00:52:49.278Z"
+    },
+    {
+      "slug": "cantors-theorem-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T22:57:01.594Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T00:52:49.303Z",
+      "completed": "2026-03-29T00:52:49.303Z"
+    },
+    {
+      "slug": "cauchy-schwarz-integral-oq-02-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T22:57:01.594Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T00:52:49.303Z",
+      "completed": "2026-03-29T00:52:49.303Z"
+    },
+    {
+      "slug": "cauchy-schwarz-oq-01-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T22:57:01.594Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T00:52:49.303Z",
+      "completed": "2026-03-29T00:52:49.303Z"
+    },
+    {
+      "slug": "cayley-hamilton-minpoly-oq-02-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T22:57:01.595Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T00:52:49.300Z",
+      "completed": "2026-03-29T00:52:49.300Z"
+    },
+    {
+      "slug": "central-limit-theorem-oq-01-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T22:57:01.595Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T00:52:49.273Z",
+      "completed": "2026-03-29T00:52:49.273Z"
+    },
+    {
+      "slug": "cramers-rule-oq-01-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T22:57:01.595Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T01:53:38.152Z",
+      "completed": "2026-03-29T01:53:38.151Z"
+    },
+    {
+      "slug": "descartes-rule-of-signs-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T22:57:01.595Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T00:52:49.268Z",
+      "completed": "2026-03-29T00:52:49.268Z"
+    },
+    {
+      "slug": "erdos-1007-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T22:57:01.595Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T00:52:49.303Z",
+      "completed": "2026-03-29T00:52:49.303Z"
+    },
+    {
+      "slug": "euler-polyhedral-formula-oq-01-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T22:57:01.595Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T00:52:49.271Z",
+      "completed": "2026-03-29T00:52:49.271Z"
+    },
+    {
+      "slug": "fourier-series-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-28T22:57:01.595Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T00:52:49.268Z",
+      "completed": "2026-03-29T00:52:49.268Z"
+    },
+    {
+      "slug": "borsuk-ulam-oq-02-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T04:28:18.926Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T08:38:19.285Z",
+      "completed": "2026-03-29T08:38:19.285Z"
+    },
+    {
+      "slug": "bounded-prime-gaps-oq-04-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T04:28:18.926Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T05:38:13.050Z",
+      "completed": "2026-03-29T05:38:13.049Z"
+    },
+    {
+      "slug": "roth-theorem-k3-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T04:28:18.926Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T07:10:03.190Z",
+      "completed": "2026-03-29T07:10:03.190Z"
+    },
+    {
+      "slug": "descartes-rule-of-signs-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T04:28:18.977Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T05:52:18.619Z",
+      "completed": "2026-03-29T05:52:18.619Z"
+    },
+    {
+      "slug": "elementary-quadratic-reciprocity-oq-03-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-29T04:28:18.977Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T08:13:35.968Z",
+      "completed": "2026-03-29T08:13:35.968Z"
+    },
+    {
+      "slug": "euler-identity-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-29T04:28:18.977Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T05:38:13.102Z",
+      "completed": "2026-03-29T05:38:13.102Z"
+    },
+    {
+      "slug": "fourier-series-oq-02-oq-03-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T04:28:18.977Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T08:13:35.971Z",
+      "completed": "2026-03-29T08:13:35.971Z"
+    },
+    {
+      "slug": "friendship-theorem-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T04:28:18.978Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T07:10:03.257Z",
+      "completed": "2026-03-29T07:10:03.257Z"
+    },
+    {
+      "slug": "greens-theorem-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T04:28:18.978Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T06:25:16.590Z",
+      "completed": "2026-03-29T06:25:16.590Z"
+    },
+    {
+      "slug": "kummer-theorem-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T04:28:18.978Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T09:55:19.200Z",
+      "completed": "2026-03-29T09:55:19.200Z"
+    },
+    {
+      "slug": "laws-of-large-numbers-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T04:28:18.978Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T06:25:16.601Z",
+      "completed": "2026-03-29T06:25:16.601Z"
+    },
+    {
+      "slug": "platonic-solids-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T04:28:18.978Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T05:48:17.240Z",
+      "completed": "2026-03-29T05:48:17.240Z"
+    },
+    {
+      "slug": "prob-method-expectation-oq-03",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-29T04:28:18.978Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T09:20:37.021Z",
+      "completed": "2026-03-29T09:20:37.021Z"
+    },
+    {
+      "slug": "shannon-source-coding-oq-05",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T04:28:18.978Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T08:13:35.981Z",
+      "completed": "2026-03-29T08:13:35.981Z"
+    },
+    {
+      "slug": "stirling-formula-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T04:28:18.978Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T05:38:13.103Z",
+      "completed": "2026-03-29T05:38:13.103Z"
+    },
+    {
+      "slug": "vietas-formulas-oq-03-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T04:28:18.978Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T05:52:18.610Z",
+      "completed": "2026-03-29T05:52:18.609Z"
+    },
+    {
+      "slug": "chinese-remainder-constructive-oq-04-oq-03",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-29T04:28:18.979Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T08:13:36.007Z",
+      "completed": "2026-03-29T08:13:36.007Z"
+    },
+    {
+      "slug": "divisibility-by-3-oq-04-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-29T04:28:18.979Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T06:25:16.635Z",
+      "completed": "2026-03-29T06:25:16.635Z"
+    },
+    {
+      "slug": "triangular-reciprocals-oq-03-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-29T04:28:18.979Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T05:52:18.622Z",
+      "completed": "2026-03-29T05:52:18.622Z"
+    },
+    {
+      "slug": "erdos-70-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T13:00:51.260Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T13:20:23.632Z",
+      "completed": "2026-03-29T13:20:23.632Z"
+    },
+    {
+      "slug": "erdos-485-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T13:00:51.309Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T13:34:14.224Z",
+      "completed": "2026-03-29T13:34:14.224Z"
+    },
+    {
+      "slug": "cramers-rule-oq-01-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T13:00:51.316Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T13:26:46.536Z",
+      "completed": "2026-03-29T13:26:46.536Z"
+    },
+    {
+      "slug": "erdos-106-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T13:00:51.316Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T13:12:28.950Z",
+      "completed": "2026-03-29T13:12:28.949Z"
+    },
+    {
+      "slug": "erdos-114-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T13:00:51.316Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T13:17:33.508Z",
+      "completed": "2026-03-29T13:17:33.507Z"
+    },
+    {
+      "slug": "erdos-115-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T13:00:51.316Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T13:24:38.238Z",
+      "completed": "2026-03-29T13:24:38.237Z"
+    },
+    {
+      "slug": "erdos-117-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T13:00:51.316Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T16:17:18.555Z",
+      "completed": "2026-03-29T16:17:18.555Z"
+    },
+    {
+      "slug": "erdos-19-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T13:00:51.316Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T13:14:54.075Z",
+      "completed": "2026-03-29T13:14:54.074Z"
+    },
+    {
+      "slug": "erdos-2-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T13:00:51.316Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T13:12:28.950Z",
+      "completed": "2026-03-29T13:12:28.950Z"
+    },
+    {
+      "slug": "erdos-232-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T13:00:51.316Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T13:36:18.023Z",
+      "completed": "2026-03-29T13:36:18.023Z"
+    },
+    {
+      "slug": "erdos-395-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T13:00:51.316Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T13:24:38.239Z",
+      "completed": "2026-03-29T13:24:38.239Z"
+    },
+    {
+      "slug": "erdos-8-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T13:00:51.316Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T13:20:23.684Z",
+      "completed": "2026-03-29T13:20:23.684Z"
+    },
+    {
+      "slug": "erdos-909-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T13:00:51.316Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T13:22:27.006Z",
+      "completed": "2026-03-29T13:22:27.006Z"
+    },
+    {
+      "slug": "erdos-94-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T13:00:51.316Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T13:22:27.006Z",
+      "completed": "2026-03-29T13:22:27.006Z"
+    },
+    {
+      "slug": "geometric-series-oq-02-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T13:00:51.316Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T13:22:27.006Z",
+      "completed": "2026-03-29T13:22:27.006Z"
+    },
+    {
+      "slug": "erdos-1022-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T14:32:06.054Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T16:17:18.531Z",
+      "completed": "2026-03-29T16:17:18.531Z"
+    },
+    {
+      "slug": "fundamental-theorem-algebra-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T14:32:06.055Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T16:17:18.524Z",
+      "completed": "2026-03-29T16:17:18.524Z"
+    },
+    {
+      "slug": "fundamental-theorem-calculus-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T14:32:06.055Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T16:17:18.526Z",
+      "completed": "2026-03-29T16:17:18.526Z"
+    },
+    {
+      "slug": "geometric-series-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T14:32:06.055Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T16:17:18.520Z",
+      "completed": "2026-03-29T16:17:18.520Z"
+    },
+    {
+      "slug": "sylow-theorems-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T14:32:06.056Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T16:17:18.519Z",
+      "completed": "2026-03-29T16:17:18.518Z"
+    },
+    {
+      "slug": "collatz-structured-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T14:32:06.110Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T16:17:18.573Z",
+      "completed": "2026-03-29T16:17:18.573Z"
+    },
+    {
+      "slug": "dirichlets-theorem-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T14:32:06.110Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T16:17:18.567Z",
+      "completed": "2026-03-29T16:17:18.567Z"
+    },
+    {
+      "slug": "erdos-1002-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T14:32:06.111Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T16:17:18.546Z",
+      "completed": "2026-03-29T16:17:18.546Z"
+    },
+    {
+      "slug": "erdos-1021-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T14:32:06.111Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T16:17:18.578Z",
+      "completed": "2026-03-29T16:17:18.578Z"
+    },
+    {
+      "slug": "erdos-1027-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-29T14:32:06.111Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T16:47:23.718Z",
+      "completed": "2026-03-29T16:47:23.718Z"
+    },
+    {
+      "slug": "erdos-1031-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T14:32:06.111Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T16:17:18.539Z",
+      "completed": "2026-03-29T16:17:18.539Z"
+    },
+    {
+      "slug": "erdos-1036-wip-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T14:32:06.111Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T16:17:18.585Z",
+      "completed": "2026-03-29T16:17:18.585Z"
+    },
+    {
+      "slug": "erdos-1039-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T14:32:06.111Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T16:17:18.553Z",
+      "completed": "2026-03-29T16:17:18.553Z"
+    },
+    {
+      "slug": "erdos-1040-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T14:32:06.111Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T16:17:18.580Z",
+      "completed": "2026-03-29T16:17:18.580Z"
+    },
+    {
+      "slug": "erdos-1042-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T14:32:06.112Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T16:17:18.556Z",
+      "completed": "2026-03-29T16:17:18.556Z"
+    },
+    {
+      "slug": "erdos-1070-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-29T14:32:06.112Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T16:17:18.576Z",
+      "completed": "2026-03-29T16:17:18.576Z"
+    },
+    {
+      "slug": "factor-remainder-theorem-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-29T14:32:06.112Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T16:17:18.558Z",
+      "completed": "2026-03-29T16:17:18.558Z"
+    },
+    {
+      "slug": "lagrange-theorem-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-29T14:32:06.112Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T16:17:18.573Z",
+      "completed": "2026-03-29T16:17:18.573Z"
+    },
+    {
+      "slug": "divisibility-by-3-oq-03",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-29T14:32:06.114Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T16:17:18.587Z",
+      "completed": "2026-03-29T16:17:18.587Z"
+    },
+    {
+      "slug": "general-quartic-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T14:32:06.114Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T16:17:18.589Z",
+      "completed": "2026-03-29T16:17:18.589Z"
+    },
+    {
+      "slug": "erdos-1097-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-29T18:32:39.273Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T18:32:39.273Z",
+      "completed": "2026-03-29T18:32:39.273Z"
+    },
+    {
+      "slug": "collatz-structured-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T18:32:39.303Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T18:37:00.573Z",
+      "completed": "2026-03-29T18:37:00.572Z"
+    },
+    {
+      "slug": "dissection-of-cubes-oq-06",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T18:32:39.304Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T18:37:00.573Z",
+      "completed": "2026-03-29T18:37:00.573Z"
+    },
+    {
+      "slug": "euler-identity-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T18:32:39.304Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T18:37:00.573Z",
+      "completed": "2026-03-29T18:37:00.573Z"
+    },
+    {
+      "slug": "factor-remainder-theorem-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T18:32:39.304Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T18:37:00.573Z",
+      "completed": "2026-03-29T18:37:00.573Z"
+    },
+    {
+      "slug": "fermat-two-squares-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T18:32:39.304Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T18:37:00.574Z",
+      "completed": "2026-03-29T18:37:00.574Z"
+    },
+    {
+      "slug": "fermat-two-squares-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T18:32:39.305Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T18:37:00.574Z",
+      "completed": "2026-03-29T18:37:00.574Z"
+    },
+    {
+      "slug": "fundamental-theorem-algebra-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T18:32:39.305Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T18:37:00.574Z",
+      "completed": "2026-03-29T18:37:00.574Z"
+    },
+    {
+      "slug": "fundamental-theorem-algebra-oq-05",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T18:32:39.305Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T18:37:00.574Z",
+      "completed": "2026-03-29T18:37:00.574Z"
+    },
+    {
+      "slug": "geometric-series-oq-05",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T18:32:39.305Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T18:37:00.575Z",
+      "completed": "2026-03-29T18:37:00.575Z"
+    },
+    {
+      "slug": "hermite-lindemann-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T18:32:39.305Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T18:37:00.575Z",
+      "completed": "2026-03-29T18:37:00.575Z"
+    },
+    {
+      "slug": "hilbert-16-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T18:32:39.305Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T18:37:00.575Z",
+      "completed": "2026-03-29T18:37:00.575Z"
+    },
+    {
+      "slug": "hilbert-21-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T18:32:39.306Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T18:37:00.575Z",
+      "completed": "2026-03-29T18:37:00.575Z"
+    },
+    {
+      "slug": "hilbert-21-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T18:32:39.306Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T18:37:00.575Z",
+      "completed": "2026-03-29T18:37:00.575Z"
+    },
+    {
+      "slug": "infinitude-primes-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T18:32:39.306Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T18:37:00.575Z",
+      "completed": "2026-03-29T18:37:00.575Z"
+    },
+    {
+      "slug": "infinitude-primes-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T18:32:39.306Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T18:37:00.575Z",
+      "completed": "2026-03-29T18:37:00.575Z"
+    },
+    {
+      "slug": "lagrange-theorem-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T18:32:39.306Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T18:37:00.575Z",
+      "completed": "2026-03-29T18:37:00.575Z"
+    },
+    {
+      "slug": "law-of-cosines-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T18:32:39.306Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T18:37:00.575Z",
+      "completed": "2026-03-29T18:37:00.575Z"
+    },
+    {
+      "slug": "law-of-cosines-oq-05",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T18:32:39.306Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T18:37:00.575Z",
+      "completed": "2026-03-29T18:37:00.575Z"
+    },
+    {
+      "slug": "mathematical-induction-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T18:32:39.307Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T18:37:00.575Z",
+      "completed": "2026-03-29T18:37:00.575Z"
+    },
+    {
+      "slug": "mathematical-induction-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T18:32:39.307Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T18:37:00.575Z",
+      "completed": "2026-03-29T18:37:00.575Z"
+    },
+    {
+      "slug": "erdos-327-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-29T19:00:31.147Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-29T19:00:31.147Z",
+      "completed": "2026-03-29T19:00:31.147Z"
+    },
+    {
+      "slug": "erdos-1027-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T01:04:30.787Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T04:50:51.686Z",
+      "completed": "2026-03-30T04:50:51.686Z"
+    },
+    {
+      "slug": "erdos-1037-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T01:04:30.788Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T04:50:51.671Z",
+      "completed": "2026-03-30T04:50:51.671Z"
+    },
+    {
+      "slug": "erdos-1040-oq-05",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T01:04:30.788Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T10:25:10.054Z",
+      "completed": "2026-03-30T10:25:10.054Z"
+    },
+    {
+      "slug": "erdos-105-oq-05",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T01:04:30.788Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T03:38:37.957Z",
+      "completed": "2026-03-30T03:38:37.957Z"
+    },
+    {
+      "slug": "fundamental-theorem-calculus-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T01:04:30.789Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T03:38:37.954Z",
+      "completed": "2026-03-30T03:38:37.953Z"
+    },
+    {
+      "slug": "hilbert-14-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T01:04:30.789Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T03:38:37.956Z",
+      "completed": "2026-03-30T03:38:37.956Z"
+    },
+    {
+      "slug": "infinitude-primes-oq-03",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T01:04:30.789Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T04:50:51.675Z",
+      "completed": "2026-03-30T04:50:51.675Z"
+    },
+    {
+      "slug": "mathematical-induction-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T01:04:30.789Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T03:38:37.959Z",
+      "completed": "2026-03-30T03:38:37.959Z"
+    },
+    {
+      "slug": "pac-learning-bounds-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T01:04:30.789Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T04:50:51.668Z",
+      "completed": "2026-03-30T04:50:51.667Z"
+    },
+    {
+      "slug": "schauder-fixed-point-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T01:04:30.789Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T04:50:51.686Z",
+      "completed": "2026-03-30T04:50:51.686Z"
+    },
+    {
+      "slug": "shannon-entropy-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T01:04:30.790Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T03:38:37.954Z",
+      "completed": "2026-03-30T03:38:37.954Z"
+    },
+    {
+      "slug": "wilsons-theorem-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T01:04:30.790Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T02:40:17.040Z",
+      "completed": "2026-03-30T02:40:17.032Z"
+    },
+    {
+      "slug": "erdos-1019-oq-04",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T01:04:30.838Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T05:20:48.835Z",
+      "completed": "2026-03-30T05:20:48.835Z"
+    },
+    {
+      "slug": "picks-theorem-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T01:04:30.838Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T04:53:46.328Z",
+      "completed": "2026-03-30T04:53:46.328Z"
+    },
+    {
+      "slug": "prob-method-second-moment-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T01:04:30.838Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T02:40:17.829Z",
+      "completed": "2026-03-30T02:40:17.829Z"
+    },
+    {
+      "slug": "ptolemys-theorem-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T01:04:30.838Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T04:50:51.693Z",
+      "completed": "2026-03-30T04:50:51.693Z"
+    },
+    {
+      "slug": "roth-theorem-k3-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T01:04:30.839Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T02:13:21.187Z",
+      "completed": "2026-03-30T02:13:21.187Z"
+    },
+    {
+      "slug": "szemeredi-theorem-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T01:04:30.839Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T01:39:17.029Z",
+      "completed": "2026-03-30T01:39:17.029Z"
+    },
+    {
+      "slug": "taylor-sincos-convergence-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T01:04:30.839Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:36:05.001Z",
+      "completed": "2026-03-30T06:36:05.001Z"
+    },
+    {
+      "slug": "three-place-identity-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T01:04:30.839Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:06:23.639Z",
+      "completed": "2026-03-30T06:06:23.639Z"
+    },
+    {
+      "slug": "erdos-1-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T02:13:21.170Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:36:04.962Z",
+      "completed": "2026-03-30T06:36:04.961Z"
+    },
+    {
+      "slug": "factor-remainder-theorem-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T02:13:21.170Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T04:59:40.667Z",
+      "completed": "2026-03-30T04:59:40.666Z"
+    },
+    {
+      "slug": "morleys-theorem-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T02:13:21.170Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T08:24:39.130Z",
+      "completed": "2026-03-30T08:24:39.130Z"
+    },
+    {
+      "slug": "ramseys-theorem-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T02:13:21.170Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T05:20:48.808Z",
+      "completed": "2026-03-30T05:20:48.808Z"
+    },
+    {
+      "slug": "denumerability-rationals-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T02:13:21.212Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:36:05.000Z",
+      "completed": "2026-03-30T06:36:05.000Z"
+    },
+    {
+      "slug": "gcd-algorithm-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T02:13:21.213Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:50:26.409Z",
+      "completed": "2026-03-30T06:50:26.409Z"
+    },
+    {
+      "slug": "greens-theorem-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T02:13:21.213Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T04:50:51.698Z",
+      "completed": "2026-03-30T04:50:51.698Z"
+    },
+    {
+      "slug": "harmonic-divergence-oq-04",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T02:13:21.213Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T03:38:38.012Z",
+      "completed": "2026-03-30T03:38:38.012Z"
+    },
+    {
+      "slug": "lagrange-theorem-oq-05",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T02:13:21.213Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T03:38:38.013Z",
+      "completed": "2026-03-30T03:38:38.013Z"
+    },
+    {
+      "slug": "law-of-cosines-oq-04",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T02:13:21.213Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:36:05.001Z",
+      "completed": "2026-03-30T06:36:05.001Z"
+    },
+    {
+      "slug": "mean-value-theorem-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T02:13:21.213Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T04:59:40.724Z",
+      "completed": "2026-03-30T04:59:40.724Z"
+    },
+    {
+      "slug": "partition-theorem-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T02:13:21.213Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T04:59:40.724Z",
+      "completed": "2026-03-30T04:59:40.724Z"
+    },
+    {
+      "slug": "puiseux-theorem-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T02:13:21.213Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T05:20:48.851Z",
+      "completed": "2026-03-30T05:20:48.851Z"
+    },
+    {
+      "slug": "pythagorean-triples-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T02:13:21.213Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T05:54:30.464Z",
+      "completed": "2026-03-30T05:54:30.464Z"
+    },
+    {
+      "slug": "quadratic-reciprocity-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T02:13:21.213Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T04:50:51.730Z",
+      "completed": "2026-03-30T04:50:51.730Z"
+    },
+    {
+      "slug": "schroeder-bernstein-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T02:13:21.213Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T08:38:57.337Z",
+      "completed": "2026-03-30T08:38:57.337Z"
+    },
+    {
+      "slug": "triangular-reciprocals-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T02:13:21.213Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:36:05.001Z",
+      "completed": "2026-03-30T06:36:05.001Z"
+    },
+    {
+      "slug": "sqrt2-irrational-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T02:13:21.214Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T04:50:51.733Z",
+      "completed": "2026-03-30T04:50:51.733Z"
+    },
+    {
+      "slug": "abel-ruffini-oq-04-oq-06",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T04:50:51.686Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T05:20:48.819Z",
+      "completed": "2026-03-30T05:20:48.819Z"
+    },
+    {
+      "slug": "basel-problem-oq-05-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T04:50:51.686Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T08:24:39.134Z",
+      "completed": "2026-03-30T08:24:39.134Z"
+    },
+    {
+      "slug": "roth-theorem-k3-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T04:50:51.686Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:03:08.378Z",
+      "completed": "2026-03-30T06:03:08.377Z"
+    },
+    {
+      "slug": "shannon-entropy-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T04:50:51.686Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:06:23.599Z",
+      "completed": "2026-03-30T06:06:23.599Z"
+    },
+    {
+      "slug": "sum-of-kth-powers-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T04:50:51.686Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:36:04.962Z",
+      "completed": "2026-03-30T06:36:04.962Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-03-oq-03",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T04:50:51.731Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:36:05.000Z",
+      "completed": "2026-03-30T06:36:05.000Z"
+    },
+    {
+      "slug": "angle-trisection-oq-02-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T04:50:51.731Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T05:54:30.464Z",
+      "completed": "2026-03-30T05:54:30.463Z"
+    },
+    {
+      "slug": "arithmetic-series-oq-02-oq-02-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T04:50:51.731Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T05:27:37.772Z",
+      "completed": "2026-03-30T05:27:37.772Z"
+    },
+    {
+      "slug": "borsuk-ulam-oq-02-oq-01-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T04:50:51.731Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T05:54:30.464Z",
+      "completed": "2026-03-30T05:54:30.464Z"
+    },
+    {
+      "slug": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T04:50:51.731Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T05:54:30.464Z",
+      "completed": "2026-03-30T05:54:30.464Z"
+    },
+    {
+      "slug": "erdos-1018-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T04:50:51.731Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T05:54:30.464Z",
+      "completed": "2026-03-30T05:54:30.464Z"
+    },
+    {
+      "slug": "erdos-110-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T04:50:51.731Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T05:08:53.622Z",
+      "completed": "2026-03-30T05:08:53.622Z"
+    },
+    {
+      "slug": "erdos-606-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T04:50:51.731Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:36:05.001Z",
+      "completed": "2026-03-30T06:36:05.001Z"
+    },
+    {
+      "slug": "erdos-989-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T04:50:51.731Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T05:20:48.858Z",
+      "completed": "2026-03-30T05:20:48.858Z"
+    },
+    {
+      "slug": "lhopital-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T04:50:51.731Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T05:27:37.772Z",
+      "completed": "2026-03-30T05:27:37.772Z"
+    },
+    {
+      "slug": "mean-value-theorem-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T04:50:51.732Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T07:38:47.828Z",
+      "completed": "2026-03-30T07:38:47.828Z"
+    },
+    {
+      "slug": "prob-method-expectation-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T04:50:51.732Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:36:05.001Z",
+      "completed": "2026-03-30T06:36:05.001Z"
+    },
+    {
+      "slug": "prob-method-second-moment-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T04:50:51.732Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T04:59:40.727Z",
+      "completed": "2026-03-30T04:59:40.727Z"
+    },
+    {
+      "slug": "sqrt2-examples-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T04:50:51.732Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T05:35:33.338Z",
+      "completed": "2026-03-30T05:35:33.338Z"
+    },
+    {
+      "slug": "subset-count-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T04:50:51.733Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:17:07.925Z",
+      "completed": "2026-03-30T06:17:07.925Z"
+    },
+    {
+      "slug": "erdos-780-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T05:04:39.264Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T05:38:44.201Z",
+      "completed": "2026-03-30T05:38:44.200Z"
+    },
+    {
+      "slug": "hermite-lindemann-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T05:04:39.265Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T05:38:44.201Z",
+      "completed": "2026-03-30T05:38:44.201Z"
+    },
+    {
+      "slug": "erdos-152-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T05:04:39.280Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:06:23.610Z",
+      "completed": "2026-03-30T06:06:23.610Z"
+    },
+    {
+      "slug": "erdos-307-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T05:04:39.311Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:17:07.924Z",
+      "completed": "2026-03-30T06:17:07.924Z"
+    },
+    {
+      "slug": "erdos-453-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T05:04:39.312Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T08:52:08.755Z",
+      "completed": "2026-03-30T08:52:08.755Z"
+    },
+    {
+      "slug": "herons-formula-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T05:04:39.312Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:17:07.924Z",
+      "completed": "2026-03-30T06:17:07.924Z"
+    },
+    {
+      "slug": "brouwer-fixed-point-oq-04-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T06:03:08.378Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:17:07.914Z",
+      "completed": "2026-03-30T06:17:07.913Z"
+    },
+    {
+      "slug": "fermats-last-theorem-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T06:03:08.378Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:36:04.962Z",
+      "completed": "2026-03-30T06:36:04.962Z"
+    },
+    {
+      "slug": "four-color-theorem-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T06:03:08.378Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:17:07.914Z",
+      "completed": "2026-03-30T06:17:07.914Z"
+    },
+    {
+      "slug": "hilbert-13-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T06:03:08.378Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:50:26.393Z",
+      "completed": "2026-03-30T06:50:26.392Z"
+    },
+    {
+      "slug": "hilbert-22-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T06:03:08.378Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:36:04.962Z",
+      "completed": "2026-03-30T06:36:04.962Z"
+    },
+    {
+      "slug": "motivic-flag-maps-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T06:03:08.378Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:50:26.393Z",
+      "completed": "2026-03-30T06:50:26.393Z"
+    },
+    {
+      "slug": "szemeredi-core-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T06:03:08.378Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T11:14:34.871Z",
+      "completed": "2026-03-30T11:14:34.870Z"
+    },
+    {
+      "slug": "yang-mills-2d-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T06:03:08.378Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:17:07.914Z",
+      "completed": "2026-03-30T06:17:07.914Z"
+    },
+    {
+      "slug": "de-moivre-oq-03-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T06:03:08.389Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:36:05.001Z",
+      "completed": "2026-03-30T06:36:05.001Z"
+    },
+    {
+      "slug": "erdos-1066-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T06:03:08.389Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:36:05.001Z",
+      "completed": "2026-03-30T06:36:05.001Z"
+    },
+    {
+      "slug": "erdos-1118-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T06:03:08.389Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:36:05.002Z",
+      "completed": "2026-03-30T06:36:05.002Z"
+    },
+    {
+      "slug": "erdos-525-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T06:03:08.389Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:36:05.002Z",
+      "completed": "2026-03-30T06:36:05.002Z"
+    },
+    {
+      "slug": "factor-remainder-nullstellensatz-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T06:03:08.389Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:17:07.925Z",
+      "completed": "2026-03-30T06:17:07.925Z"
+    },
+    {
+      "slug": "fourier-series-oq-04",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T06:03:08.389Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:17:07.925Z",
+      "completed": "2026-03-30T06:17:07.925Z"
+    },
+    {
+      "slug": "intermediate-value-theorem-oq-03",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T06:03:08.389Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:36:05.002Z",
+      "completed": "2026-03-30T06:36:05.002Z"
+    },
+    {
+      "slug": "konigsberg-oq-03",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T06:03:08.389Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:17:07.925Z",
+      "completed": "2026-03-30T06:17:07.925Z"
+    },
+    {
+      "slug": "lebesgue-measure-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T06:03:08.389Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:36:05.002Z",
+      "completed": "2026-03-30T06:36:05.002Z"
+    },
+    {
+      "slug": "randomized-maxcut-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T06:03:08.389Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:36:05.003Z",
+      "completed": "2026-03-30T06:36:05.003Z"
+    },
+    {
+      "slug": "schauder-fixed-point-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T06:03:08.389Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T06:36:05.003Z",
+      "completed": "2026-03-30T06:36:05.003Z"
+    },
+    {
+      "slug": "sperner-ndim-oq-03",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T06:03:08.390Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T12:11:39.101Z",
+      "completed": "2026-03-30T12:11:39.101Z"
+    },
+    {
+      "slug": "feuerbachs-theorem-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T23:39:44-07:00",
+      "status": "graduated",
+      "completed": "2026-03-30T08:52:08.759Z",
+      "lastUpdate": "2026-03-30T08:52:08.759Z"
+    },
+    {
+      "slug": "furstenberg-correspondence-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T23:39:50-07:00",
+      "status": "graduated",
+      "completed": "2026-03-30T10:25:10.095Z",
+      "lastUpdate": "2026-03-30T10:25:10.095Z"
+    },
+    {
+      "slug": "hilbert-15-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T23:39:50-07:00",
+      "status": "graduated",
+      "completed": "2026-03-30T12:11:39.045Z",
+      "lastUpdate": "2026-03-30T12:11:39.046Z"
+    },
+    {
+      "slug": "hurwitz-theorem-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T23:39:50-07:00",
+      "status": "graduated",
+      "completed": "2026-03-30T08:52:08.758Z",
+      "lastUpdate": "2026-03-30T08:52:08.758Z"
+    },
+    {
+      "slug": "inverse-galois-oq-06",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T23:39:50-07:00",
+      "status": "graduated",
+      "completed": "2026-03-30T08:52:08.749Z",
+      "lastUpdate": "2026-03-30T08:52:08.749Z"
+    },
+    {
+      "slug": "minkowski-theorem-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T23:39:50-07:00",
+      "status": "graduated",
+      "completed": "2026-03-30T10:25:10.081Z",
+      "lastUpdate": "2026-03-30T10:25:10.081Z"
+    },
+    {
+      "slug": "pascals-hexagon-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T23:39:50-07:00",
+      "status": "graduated",
+      "completed": "2026-03-30T09:24:56.478Z",
+      "lastUpdate": "2026-03-30T09:24:56.478Z"
+    },
+    {
+      "slug": "pi-transcendental-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T23:39:50-07:00",
+      "status": "graduated",
+      "completed": "2026-03-30T11:05:50.319Z",
+      "lastUpdate": "2026-03-30T11:05:50.319Z"
+    },
+    {
+      "slug": "erdos-29-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T23:39:50-07:00",
+      "status": "graduated",
+      "completed": "2026-03-30T12:11:39.076Z",
+      "lastUpdate": "2026-03-30T12:11:39.076Z"
+    },
+    {
+      "slug": "erdos-43-oq-05",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T23:39:51-07:00",
+      "status": "graduated",
+      "completed": "2026-03-30T10:31:26.946Z",
+      "lastUpdate": "2026-03-30T10:31:26.947Z"
+    },
+    {
+      "slug": "erdos-453-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T23:39:51-07:00",
+      "status": "graduated",
+      "completed": "2026-03-30T08:52:08.752Z",
+      "lastUpdate": "2026-03-30T08:52:08.752Z"
+    },
+    {
+      "slug": "erdos-59-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T23:39:51-07:00",
+      "status": "graduated",
+      "completed": "2026-03-30T10:25:10.091Z",
+      "lastUpdate": "2026-03-30T10:25:10.091Z"
+    },
+    {
+      "slug": "erdos-648-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T23:39:51-07:00",
+      "status": "graduated",
+      "completed": "2026-03-30T08:52:08.759Z",
+      "lastUpdate": "2026-03-30T08:52:08.759Z"
+    },
+    {
+      "slug": "erdos-1015-oq-05",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T23:39:51-07:00",
+      "status": "graduated",
+      "completed": "2026-03-30T08:52:08.753Z",
+      "lastUpdate": "2026-03-30T08:52:08.753Z"
+    },
+    {
+      "slug": "erdos-1126-oq-01-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-29T23:39:51-07:00",
+      "status": "graduated",
+      "completed": "2026-03-30T11:05:50.277Z",
+      "lastUpdate": "2026-03-30T11:05:50.277Z"
+    },
+    {
+      "slug": "ballot-problem-oq-03-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T08:52:08.739Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T11:05:50.272Z",
+      "completed": "2026-03-30T11:05:50.271Z"
+    },
+    {
+      "slug": "bounded-prime-gaps-oq-04-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T08:52:08.740Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T11:05:50.272Z",
+      "completed": "2026-03-30T11:05:50.272Z"
+    },
+    {
+      "slug": "central-limit-theorem-oq-03-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T08:52:08.740Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T11:05:50.272Z",
+      "completed": "2026-03-30T11:05:50.272Z"
+    },
+    {
+      "slug": "erdos-1-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T08:52:08.740Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T11:26:01.134Z",
+      "completed": "2026-03-30T11:26:01.134Z"
+    },
+    {
+      "slug": "erdos-100-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T08:52:08.740Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T12:11:39.057Z",
+      "completed": "2026-03-30T12:11:39.057Z"
+    },
+    {
+      "slug": "motivic-flag-maps-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T08:52:08.752Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T10:25:10.084Z",
+      "completed": "2026-03-30T10:25:10.084Z"
+    },
+    {
+      "slug": "furstenberg-correspondence-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T08:52:08.755Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T10:25:10.095Z",
+      "completed": "2026-03-30T10:25:10.095Z"
+    },
+    {
+      "slug": "erdos-1007-oq-05",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T08:52:08.779Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T09:24:56.482Z",
+      "completed": "2026-03-30T09:24:56.482Z"
+    },
+    {
+      "slug": "erdos-1134-oq-04",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T08:52:08.779Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T12:11:39.102Z",
+      "completed": "2026-03-30T12:11:39.102Z"
+    },
+    {
+      "slug": "erdos-114-oq-04",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T08:52:08.779Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T11:05:50.318Z",
+      "completed": "2026-03-30T11:05:50.318Z"
+    },
+    {
+      "slug": "erdos-951-oq-05",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T08:52:08.780Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T11:05:50.319Z",
+      "completed": "2026-03-30T11:05:50.319Z"
+    },
+    {
+      "slug": "lhopital-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T08:52:08.780Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T11:05:50.294Z",
+      "completed": "2026-03-30T11:05:50.294Z"
+    },
+    {
+      "slug": "prime-reciprocal-divergence-oq-03",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T08:52:08.780Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T11:05:50.311Z",
+      "completed": "2026-03-30T11:05:50.311Z"
+    },
+    {
+      "slug": "abel-ruffini-oq-04-oq-02-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T08:52:08.781Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T11:05:50.316Z",
+      "completed": "2026-03-30T11:05:50.316Z"
+    },
+    {
+      "slug": "angle-trisection-oq-05-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T08:52:08.781Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T11:05:50.316Z",
+      "completed": "2026-03-30T11:05:50.316Z"
+    },
+    {
+      "slug": "area-of-circle-oq-01-oq-02-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T08:52:08.781Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T12:11:39.075Z",
+      "completed": "2026-03-30T12:11:39.075Z"
+    },
+    {
+      "slug": "basel-problem-oq-05-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T08:52:08.781Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T11:05:50.317Z",
+      "completed": "2026-03-30T11:05:50.317Z"
+    },
+    {
+      "slug": "bezout-identity-oq-04-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T08:52:08.782Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T11:05:50.317Z",
+      "completed": "2026-03-30T11:05:50.317Z"
+    },
+    {
+      "slug": "binomial-theorem-oq-02-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T08:52:08.782Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T11:05:50.317Z",
+      "completed": "2026-03-30T11:05:50.317Z"
+    },
+    {
+      "slug": "birthday-problem-oq-03-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T08:52:08.782Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T11:05:50.317Z",
+      "completed": "2026-03-30T11:05:50.317Z"
+    },
+    {
+      "slug": "buffons-needle-oq-02-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T08:52:08.782Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T11:26:01.184Z",
+      "completed": "2026-03-30T11:26:01.184Z"
+    },
+    {
+      "slug": "cantor-diagonalization-oq-03-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T08:52:08.782Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T11:05:50.317Z",
+      "completed": "2026-03-30T11:05:50.317Z"
+    },
+    {
+      "slug": "cauchy-schwarz-oq-03-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T08:52:08.782Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T11:05:50.317Z",
+      "completed": "2026-03-30T11:05:50.317Z"
+    },
+    {
+      "slug": "cayley-hamilton-reduction-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T08:52:08.782Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T11:05:50.317Z",
+      "completed": "2026-03-30T11:05:50.317Z"
+    },
+    {
+      "slug": "erdos-1006-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T08:52:08.782Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T11:26:01.185Z",
+      "completed": "2026-03-30T11:26:01.184Z"
+    },
+    {
+      "slug": "erdos-1012-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T08:52:08.782Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T11:14:34.913Z",
+      "completed": "2026-03-30T11:14:34.913Z"
+    },
+    {
+      "slug": "hilbert-17-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T12:11:39.058Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T12:34:39.083Z",
+      "completed": "2026-03-30T12:34:39.082Z"
+    },
+    {
+      "slug": "binary-gcd-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T12:11:39.111Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T12:34:39.129Z",
+      "completed": "2026-03-30T12:34:39.129Z"
+    },
+    {
+      "slug": "e-transcendental-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T12:11:39.112Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T12:34:39.129Z",
+      "completed": "2026-03-30T12:34:39.129Z"
+    },
+    {
+      "slug": "erdos-1003-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T12:11:39.112Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T12:34:39.129Z",
+      "completed": "2026-03-30T12:34:39.129Z"
+    },
+    {
+      "slug": "fundamental-arithmetic-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T12:11:39.112Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T12:11:39.112Z",
+      "completed": "2026-03-30T12:11:39.112Z"
+    },
+    {
+      "slug": "herons-formula-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T12:11:39.112Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T12:34:39.130Z",
+      "completed": "2026-03-30T12:34:39.130Z"
+    },
+    {
+      "slug": "isoperimetric-theorem-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T12:11:39.112Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T12:11:39.112Z",
+      "completed": "2026-03-30T12:11:39.112Z"
+    },
+    {
+      "slug": "liouville-theorem-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T12:11:39.112Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T13:07:48.588Z",
+      "completed": "2026-03-30T13:07:48.587Z"
+    },
+    {
+      "slug": "napoleons-theorem-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T12:11:39.112Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T12:34:39.131Z",
+      "completed": "2026-03-30T12:34:39.131Z"
+    },
+    {
+      "slug": "newton-inductive-step-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T12:11:39.112Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T12:11:39.112Z",
+      "completed": "2026-03-30T12:11:39.112Z"
+    },
+    {
+      "slug": "pell-equation-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T12:11:39.112Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T12:14:24.136Z",
+      "completed": "2026-03-30T12:14:24.136Z"
+    },
+    {
+      "slug": "quadratic-reciprocity-algorithm-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T12:11:39.112Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T13:14:35.211Z",
+      "completed": "2026-03-30T13:14:35.211Z"
+    },
+    {
+      "slug": "knights-tour-oblique-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T12:11:39.114Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T12:34:39.133Z",
+      "completed": "2026-03-30T12:34:39.133Z"
+    },
+    {
+      "slug": "angle-trisection-oq-02-oq-01-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T13:07:48.617Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T14:51:23.369Z",
+      "completed": "2026-03-30T14:51:23.369Z"
+    },
+    {
+      "slug": "angle-trisection-oq-02-oq-04-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T13:07:48.617Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T14:51:23.369Z",
+      "completed": "2026-03-30T14:51:23.369Z"
+    },
+    {
+      "slug": "bezout-identity-oq-02-oq-01-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T13:07:48.617Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T14:14:09.298Z",
+      "completed": "2026-03-30T14:14:09.298Z"
+    },
+    {
+      "slug": "bezout-identity-oq-04-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T13:07:48.618Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T14:14:09.272Z",
+      "completed": "2026-03-30T14:14:09.272Z"
+    },
+    {
+      "slug": "binomial-theorem-oq-02-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T13:07:48.618Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T14:51:23.370Z",
+      "completed": "2026-03-30T14:51:23.370Z"
+    },
+    {
+      "slug": "binomial-theorem-oq-04-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T13:07:48.618Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T14:51:23.370Z",
+      "completed": "2026-03-30T14:51:23.370Z"
+    },
+    {
+      "slug": "borsuk-ulam-oq-02-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T13:07:48.618Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T14:14:09.298Z",
+      "completed": "2026-03-30T14:14:09.298Z"
+    },
+    {
+      "slug": "cantor-diagonalization-oq-01-oq-01-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T13:07:48.619Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T14:51:23.370Z",
+      "completed": "2026-03-30T14:51:23.370Z"
+    },
+    {
+      "slug": "cantor-diagonalization-oq-04-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T13:07:48.619Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T14:51:23.370Z",
+      "completed": "2026-03-30T14:51:23.370Z"
+    },
+    {
+      "slug": "erdos-65-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T13:07:48.619Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T14:51:23.359Z",
+      "completed": "2026-03-30T14:51:23.359Z"
+    },
+    {
+      "slug": "fundamental-theorem-calculus-oq-01-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T13:07:48.619Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T13:52:05.691Z",
+      "completed": "2026-03-30T13:52:05.690Z"
+    },
+    {
+      "slug": "greens-theorem-oq-01-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T13:07:48.620Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T13:52:05.691Z",
+      "completed": "2026-03-30T13:52:05.691Z"
+    },
+    {
+      "slug": "hilbert-20-oq-01-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T13:07:48.620Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T16:00:07.443Z",
+      "completed": "2026-03-30T16:00:07.443Z"
+    },
+    {
+      "slug": "pac-learning-bounds-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T13:07:48.620Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T14:51:23.362Z",
+      "completed": "2026-03-30T14:51:23.362Z"
+    },
+    {
+      "slug": "shannon-channel-coding-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T13:07:48.620Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T13:52:05.693Z",
+      "completed": "2026-03-30T13:52:05.693Z"
+    },
+    {
+      "slug": "euler-totient-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T13:52:05.694Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T14:14:09.302Z",
+      "completed": "2026-03-30T14:14:09.302Z"
+    },
+    {
+      "slug": "feuerbachs-theorem-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T13:52:05.694Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T14:14:09.303Z",
+      "completed": "2026-03-30T14:14:09.303Z"
+    },
+    {
+      "slug": "fundamental-arithmetic-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T13:52:05.694Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T14:14:09.303Z",
+      "completed": "2026-03-30T14:14:09.303Z"
+    },
+    {
+      "slug": "konigsberg-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T13:52:05.694Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T14:51:23.372Z",
+      "completed": "2026-03-30T14:51:23.372Z"
+    },
+    {
+      "slug": "kummer-theorem-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T13:52:05.694Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T14:14:09.304Z",
+      "completed": "2026-03-30T14:14:09.304Z"
+    },
+    {
+      "slug": "laws-of-large-numbers-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T13:52:05.694Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T14:14:09.304Z",
+      "completed": "2026-03-30T14:14:09.304Z"
+    },
+    {
+      "slug": "leibniz-pi-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T13:52:05.694Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T14:51:23.373Z",
+      "completed": "2026-03-30T14:51:23.373Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T16:34:54.910Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T17:47:49.973Z",
+      "completed": "2026-03-30T17:47:49.973Z"
+    },
+    {
+      "slug": "basel-problem-oq-01-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T16:34:54.911Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.841Z",
+      "completed": "2026-03-30T19:13:14.840Z"
+    },
+    {
+      "slug": "dirichlets-theorem-oq-03-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T16:34:54.911Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T06:46:59.068Z",
+      "completed": "2026-04-03T06:46:59.067Z"
+    },
+    {
+      "slug": "area-of-circle-oq-05",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T16:34:54.970Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T17:47:50.007Z",
+      "completed": "2026-03-30T17:47:50.007Z"
+    },
+    {
+      "slug": "dissection-of-cubes-oq-05",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T16:34:54.971Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T02:53:26.430Z",
+      "completed": "2026-04-03T02:53:26.430Z"
+    },
+    {
+      "slug": "erdos-10-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T16:34:54.971Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T07:37:00.128Z",
+      "completed": "2026-04-03T07:37:00.128Z"
+    },
+    {
+      "slug": "erdos-1000-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-30T16:34:54.971Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T16:34:54.971Z"
+    },
+    {
+      "slug": "erdos-1001-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T16:34:54.971Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T20:14:08.551Z",
+      "completed": "2026-03-30T20:14:08.550Z"
+    },
+    {
+      "slug": "erdos-1008-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T16:34:54.971Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T17:47:50.010Z",
+      "completed": "2026-03-30T17:47:50.010Z"
+    },
+    {
+      "slug": "erdos-101-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-30T16:34:54.971Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T16:34:54.971Z"
+    },
+    {
+      "slug": "erdos-1011-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-30T16:34:54.971Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T16:34:54.971Z"
+    },
+    {
+      "slug": "erdos-1012-oq-03-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-03-30T16:34:54.972Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T00:38:42.403Z"
+    },
+    {
+      "slug": "erdos-1018-oq-04-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T16:34:54.972Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T07:37:00.128Z",
+      "completed": "2026-04-03T07:37:00.128Z"
+    },
+    {
+      "slug": "erdos-1034-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T16:34:54.972Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T17:47:50.010Z",
+      "completed": "2026-03-30T17:47:50.010Z"
+    },
+    {
+      "slug": "erdos-1036-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T16:34:54.972Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T20:25:54.858Z",
+      "completed": "2026-03-30T20:25:54.858Z"
+    },
+    {
+      "slug": "erdos-1039-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-30T16:34:54.972Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T16:34:54.972Z"
+    },
+    {
+      "slug": "quadratic-reciprocity-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T16:34:54.972Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T17:47:50.013Z",
+      "completed": "2026-03-30T17:47:50.013Z"
+    },
+    {
+      "slug": "wilsons-theorem-oq-04",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T16:34:54.972Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T17:47:49.996Z",
+      "completed": "2026-03-30T17:47:49.996Z"
+    },
+    {
+      "slug": "divisibility-truncation-general-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T16:34:54.975Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T18:27:56.399Z",
+      "completed": "2026-03-30T18:27:56.399Z"
+    },
+    {
+      "slug": "erdos-1026-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T16:34:54.975Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.906Z",
+      "completed": "2026-03-30T19:13:14.906Z"
+    },
+    {
+      "slug": "erdos-1022-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T17:47:50.026Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T02:53:26.469Z",
+      "completed": "2026-04-03T02:53:26.469Z"
+    },
+    {
+      "slug": "erdos-1059-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T17:47:50.026Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T05:22:30.417Z",
+      "completed": "2026-04-05T05:22:30.417Z"
+    },
+    {
+      "slug": "erdos-1100-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T17:47:50.026Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T20:25:54.859Z",
+      "completed": "2026-03-30T20:25:54.859Z"
+    },
+    {
+      "slug": "erdos-29-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T17:47:50.026Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.897Z",
+      "completed": "2026-03-30T19:13:14.897Z"
+    },
+    {
+      "slug": "erdos-445-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T17:47:50.026Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T02:53:26.472Z",
+      "completed": "2026-04-03T02:53:26.472Z"
+    },
+    {
+      "slug": "erdos-52-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-30T17:47:50.026Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T17:47:50.026Z"
+    },
+    {
+      "slug": "erdos-659-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-30T17:47:50.026Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T17:47:50.026Z"
+    },
+    {
+      "slug": "erdos-69-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T17:47:50.026Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.898Z",
+      "completed": "2026-03-30T19:13:14.898Z"
+    },
+    {
+      "slug": "erdos-825-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T17:47:50.026Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T20:14:08.556Z",
+      "completed": "2026-03-30T20:14:08.556Z"
+    },
+    {
+      "slug": "hilbert-21-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T17:47:50.026Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.899Z",
+      "completed": "2026-03-30T19:13:14.899Z"
+    },
+    {
+      "slug": "infinitude-primes-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-30T17:47:50.026Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T17:47:50.026Z"
+    },
+    {
+      "slug": "mathematical-induction-oq-05",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T17:47:50.026Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T18:27:56.395Z",
+      "completed": "2026-03-30T18:27:56.394Z"
+    },
+    {
+      "slug": "prob-method-alteration-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T17:47:50.026Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T20:09:18.414Z",
+      "completed": "2026-04-04T20:09:18.414Z"
+    },
+    {
+      "slug": "product-of-segments-of-chords-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T17:47:50.026Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T04:43:04.856Z",
+      "completed": "2026-04-03T04:43:04.856Z"
+    },
+    {
+      "slug": "pythagorean-theorem-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-30T17:47:50.026Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T17:47:50.026Z"
+    },
+    {
+      "slug": "shannon-entropy-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T17:47:50.026Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T20:39:10.677Z",
+      "completed": "2026-04-03T20:39:10.677Z"
+    },
+    {
+      "slug": "shannon-source-coding-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T17:47:50.026Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.901Z",
+      "completed": "2026-03-30T19:13:14.901Z"
+    },
+    {
+      "slug": "sum-of-kth-powers-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T17:47:50.026Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T10:50:50.304Z",
+      "completed": "2026-04-03T10:50:50.304Z"
+    },
+    {
+      "slug": "sylow-theorems-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T17:47:50.026Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T22:03:16.527Z",
+      "completed": "2026-03-30T22:03:16.526Z"
+    },
+    {
+      "slug": "triangle-inequality-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T17:47:50.026Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T12:58:50.696Z",
+      "completed": "2026-04-05T12:58:50.696Z"
+    },
+    {
+      "slug": "arithmetic-series-oq-02-oq-02-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T18:27:56.397Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.893Z",
+      "completed": "2026-03-30T19:13:14.893Z"
+    },
+    {
+      "slug": "basel-problem-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T18:27:56.397Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.893Z",
+      "completed": "2026-03-30T19:13:14.893Z"
+    },
+    {
+      "slug": "birthday-problem-oq-02-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T18:27:56.397Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:56.355Z",
+      "completed": "2026-03-30T19:13:56.354Z"
+    },
+    {
+      "slug": "bounded-prime-gaps-oq-04-oq-01-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-03-30T18:27:56.397Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T18:27:56.408Z"
+    },
+    {
+      "slug": "brouwer-fixed-point-oq-02-oq-02-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-03-30T18:27:56.397Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T18:27:56.408Z"
+    },
+    {
+      "slug": "cantors-theorem-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T18:27:56.397Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:38.180Z",
+      "completed": "2026-03-30T19:13:38.179Z"
+    },
+    {
+      "slug": "cayley-hamilton-reduction-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T18:27:56.397Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.894Z",
+      "completed": "2026-03-30T19:13:14.894Z"
+    },
+    {
+      "slug": "cevas-theorem-oq-02-oq-04",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-03-30T18:27:56.397Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T18:27:56.409Z"
+    },
+    {
+      "slug": "collatz-structured-oq-02-oq-02",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-03-30T18:27:56.397Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T18:27:56.409Z"
+    },
+    {
+      "slug": "continuum-hypothesis-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T18:27:56.397Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.894Z",
+      "completed": "2026-03-30T19:13:14.894Z"
+    },
+    {
+      "slug": "derangements-oq-03-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T18:27:56.397Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.894Z",
+      "completed": "2026-03-30T19:13:14.894Z"
+    },
+    {
+      "slug": "erdos-1-oq-02-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-03-30T18:27:56.397Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T18:27:56.410Z"
+    },
+    {
+      "slug": "erdos-100-oq-01-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-03-30T18:27:56.397Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T18:27:56.411Z"
+    },
+    {
+      "slug": "erdos-1001-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T18:27:56.397Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T04:46:33.151Z",
+      "completed": "2026-04-03T04:46:33.151Z"
+    },
+    {
+      "slug": "erdos-1006-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T18:27:56.397Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T05:14:05.856Z",
+      "completed": "2026-04-03T05:14:05.856Z"
+    },
+    {
+      "slug": "erdos-1040-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-03-30T18:27:56.397Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T18:27:56.411Z"
+    },
+    {
+      "slug": "erdos-106-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T18:27:56.397Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.897Z",
+      "completed": "2026-03-30T19:13:14.897Z"
+    },
+    {
+      "slug": "erdos-1066-oq-04-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-03-30T18:27:56.397Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T18:27:56.412Z"
+    },
+    {
+      "slug": "erdos-1098-oq-04",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-03-30T18:27:56.397Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T18:27:56.412Z"
+    },
+    {
+      "slug": "fundamental-theorem-algebra-oq-04-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T18:27:56.397Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:38.181Z",
+      "completed": "2026-03-30T19:13:38.181Z"
+    },
+    {
+      "slug": "basel-problem-oq-01-oq-02",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-03-30T18:39:05.244Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T18:39:05.257Z"
+    },
+    {
+      "slug": "birthday-problem-oq-03-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T18:39:05.245Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.902Z",
+      "completed": "2026-03-30T19:13:14.902Z"
+    },
+    {
+      "slug": "cayley-hamilton-reduction-oq-01-oq-02",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-03-30T18:39:05.245Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T18:39:05.258Z"
+    },
+    {
+      "slug": "collatz-structured-oq-02-oq-03",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-03-30T18:39:05.245Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T18:39:05.258Z"
+    },
+    {
+      "slug": "cramers-rule-oq-02-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-03-30T18:39:05.245Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T18:39:05.259Z"
+    },
+    {
+      "slug": "de-moivre-oq-01-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T18:39:05.245Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T21:46:38.052Z",
+      "completed": "2026-03-30T21:46:38.052Z"
+    },
+    {
+      "slug": "derangements-oq-03-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T18:39:05.245Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T06:46:59.151Z",
+      "completed": "2026-04-03T06:46:59.151Z"
+    },
+    {
+      "slug": "descartes-rule-of-signs-oq-01-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T18:39:05.245Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.903Z",
+      "completed": "2026-03-30T19:13:14.903Z"
+    },
+    {
+      "slug": "dissection-of-cubes-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T18:39:05.245Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T08:51:33.842Z",
+      "completed": "2026-04-03T08:51:33.842Z"
+    },
+    {
+      "slug": "erdos-1-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T18:39:05.245Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:39:40.866Z",
+      "completed": "2026-03-30T19:39:40.866Z"
+    },
+    {
+      "slug": "erdos-1001-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T18:39:05.245Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T06:46:59.151Z",
+      "completed": "2026-04-03T06:46:59.151Z"
+    },
+    {
+      "slug": "erdos-1006-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T18:39:05.245Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.904Z",
+      "completed": "2026-03-30T19:13:14.904Z"
+    },
+    {
+      "slug": "erdos-1039-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T18:39:05.245Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.904Z",
+      "completed": "2026-03-30T19:13:14.904Z"
+    },
+    {
+      "slug": "erdos-106-oq-02-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T18:39:05.245Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T20:34:17.571Z",
+      "completed": "2026-03-30T20:34:17.570Z"
+    },
+    {
+      "slug": "erdos-1087-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T18:39:05.245Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.904Z",
+      "completed": "2026-03-30T19:13:14.904Z"
+    },
+    {
+      "slug": "erdos-109-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-03-30T18:39:05.245Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T18:39:05.261Z"
+    },
+    {
+      "slug": "erdos-1098-oq-01-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-03-30T18:39:05.245Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T18:39:05.261Z"
+    },
+    {
+      "slug": "erdos-1129-oq-02",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-03-30T18:39:05.245Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T18:39:05.261Z"
+    },
+    {
+      "slug": "erdos-268-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T18:39:05.245Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T19:13:14.904Z",
+      "completed": "2026-03-30T19:13:14.904Z"
+    },
+    {
+      "slug": "euler-polyhedral-formula-oq-02-oq-02",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-03-30T18:39:05.245Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T18:39:05.262Z"
+    },
+    {
+      "slug": "geometric-series-oq-02-oq-05",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T18:39:05.245Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T04:43:04.851Z",
+      "completed": "2026-04-03T04:43:04.850Z"
+    },
+    {
+      "slug": "hilbert-9-reciprocity-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-03-30T18:39:05.245Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T18:39:05.263Z"
+    },
+    {
+      "slug": "shannon-channel-coding-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-03-30T18:39:05.245Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T18:39:05.263Z"
+    },
+    {
+      "slug": "yang-mills-2d-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T18:39:05.245Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T08:51:33.768Z",
+      "completed": "2026-04-03T08:51:33.768Z"
+    },
+    {
+      "slug": "yang-mills-transfer-matrix-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T18:39:05.245Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T20:14:08.561Z",
+      "completed": "2026-03-30T20:14:08.561Z"
+    },
+    {
+      "slug": "abel-ruffini-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-30T19:39:40.875Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T19:39:40.875Z"
+    },
+    {
+      "slug": "abel-ruffini-oq-04-oq-07",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T19:39:40.876Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T03:40:16.605Z",
+      "completed": "2026-04-04T03:40:16.604Z"
+    },
+    {
+      "slug": "abel-ruffini-oq-06",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-30T19:39:40.876Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T19:39:40.876Z"
+    },
+    {
+      "slug": "angle-trisection-oq-02-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T19:39:40.876Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T05:48:10.126Z",
+      "completed": "2026-04-03T05:48:10.125Z"
+    },
+    {
+      "slug": "area-of-circle-oq-01-oq-03-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T19:39:40.876Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T08:51:33.793Z",
+      "completed": "2026-04-03T08:51:33.793Z"
+    },
+    {
+      "slug": "area-of-circle-oq-01-oq-03-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T19:39:40.877Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T15:38:25.573Z",
+      "completed": "2026-04-03T15:38:25.572Z"
+    },
+    {
+      "slug": "area-of-circle-oq-03-oq-02-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T19:39:40.877Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T21:46:38.062Z",
+      "completed": "2026-03-30T21:46:38.062Z"
+    },
+    {
+      "slug": "ballot-problem-oq-01-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T19:39:40.877Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T20:14:08.562Z",
+      "completed": "2026-03-30T20:14:08.562Z"
+    },
+    {
+      "slug": "ballot-problem-oq-01-oq-01-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T19:39:40.877Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T21:46:38.048Z",
+      "completed": "2026-03-30T21:46:38.048Z"
+    },
+    {
+      "slug": "birch-swinnerton-dyer-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T19:39:40.877Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T07:37:00.127Z",
+      "completed": "2026-04-03T07:37:00.126Z"
+    },
+    {
+      "slug": "birch-swinnerton-dyer-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T19:39:40.878Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T20:34:17.579Z",
+      "completed": "2026-03-30T20:34:17.579Z"
+    },
+    {
+      "slug": "birch-swinnerton-dyer-oq-06",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-30T19:39:40.878Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T19:39:40.878Z"
+    },
+    {
+      "slug": "erdos-1059-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-30T19:39:40.878Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T19:39:40.878Z"
+    },
+    {
+      "slug": "erdos-1059-oq-03",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T19:39:40.878Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T20:25:54.866Z",
+      "completed": "2026-03-30T20:25:54.866Z"
+    },
+    {
+      "slug": "erdos-1059-oq-05",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T19:39:40.878Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T21:13:16.751Z",
+      "completed": "2026-03-30T21:13:16.751Z"
+    },
+    {
+      "slug": "erdos-1065-oq-05",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T19:39:40.878Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T20:34:17.580Z",
+      "completed": "2026-03-30T20:34:17.580Z"
+    },
+    {
+      "slug": "erdos-1065-oq-06",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T19:39:40.879Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T04:43:04.855Z",
+      "completed": "2026-04-03T04:43:04.855Z"
+    },
+    {
+      "slug": "erdos-1155-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T19:39:40.879Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T08:51:33.791Z",
+      "completed": "2026-04-03T08:51:33.791Z"
+    },
+    {
+      "slug": "erdos-1155-oq-01-oq-06",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-30T19:39:40.879Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T19:39:40.879Z"
+    },
+    {
+      "slug": "erdos-1155-oq-01-oq-07",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T19:39:40.879Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T21:13:16.752Z",
+      "completed": "2026-03-30T21:13:16.752Z"
+    },
+    {
+      "slug": "erdos-156-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T19:39:40.881Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T20:14:08.566Z",
+      "completed": "2026-03-30T20:14:08.566Z"
+    },
+    {
+      "slug": "erdos-156-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T19:39:40.882Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T03:38:30.636Z",
+      "completed": "2026-04-03T03:38:30.635Z"
+    },
+    {
+      "slug": "sperner-ndim-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-30T21:13:16.686Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T21:13:16.686Z"
+    },
+    {
+      "slug": "binary-gcd-oq-01-oq-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-03-30T21:13:16.757Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T21:13:16.757Z"
+    },
+    {
+      "slug": "erdos-1002-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-30T21:13:16.757Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T21:13:16.757Z"
+    },
+    {
+      "slug": "erdos-1003-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-30T21:13:16.757Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T21:13:16.757Z"
+    },
+    {
+      "slug": "erdos-1009-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T21:13:16.757Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T18:04:06.922Z",
+      "completed": "2026-04-03T18:04:06.921Z"
+    },
+    {
+      "slug": "harmonic-divergence-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T21:13:16.758Z",
+      "status": "graduated",
+      "lastUpdate": "2026-03-30T21:46:38.101Z",
+      "completed": "2026-03-30T21:46:38.101Z"
+    },
+    {
+      "slug": "minkowski-theorem-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T21:13:16.758Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T08:51:33.770Z",
+      "completed": "2026-04-03T08:51:33.770Z"
+    },
+    {
+      "slug": "hilbert-10-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-30T21:46:38.028Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T21:46:38.028Z"
+    },
+    {
+      "slug": "inverse-galois-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T21:46:38.029Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T02:53:26.409Z",
+      "completed": "2026-04-03T02:53:26.409Z"
+    },
+    {
+      "slug": "erdos-1004-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-30T21:46:38.105Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T21:46:38.105Z"
+    },
+    {
+      "slug": "erdos-1005-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-30T21:46:38.105Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T21:46:38.105Z"
+    },
+    {
+      "slug": "erdos-1013-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-30T21:46:38.105Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T21:46:38.105Z"
+    },
+    {
+      "slug": "erdos-1020-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-30T21:46:38.106Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T21:46:38.106Z"
+    },
+    {
+      "slug": "erdos-1021-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T21:46:38.106Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T07:37:00.129Z",
+      "completed": "2026-04-03T07:37:00.129Z"
+    },
+    {
+      "slug": "erdos-1023-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-30T21:46:38.106Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T21:46:38.106Z"
+    },
+    {
+      "slug": "erdos-1029-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-30T21:46:38.106Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T21:46:38.106Z"
+    },
+    {
+      "slug": "feuerbachs-theorem-oq-05",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T21:46:38.106Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T05:48:10.145Z",
+      "completed": "2026-04-03T05:48:10.145Z"
+    },
+    {
+      "slug": "gcd-algorithm-oq-03",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-03-30T21:46:38.106Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T21:46:38.106Z"
+    },
+    {
+      "slug": "greens-theorem-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T21:46:38.106Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T09:22:55.410Z",
+      "completed": "2026-04-04T09:22:55.410Z"
+    },
+    {
+      "slug": "herons-formula-oq-03",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-03-30T21:46:38.107Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T04:02:48.850Z",
+      "completed": "2026-04-03T04:02:48.849Z"
+    },
+    {
+      "slug": "hilbert-11-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-03-30T21:46:38.107Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T11:25:13.703Z",
+      "completed": "2026-04-03T11:25:13.703Z"
+    },
+    {
+      "slug": "hilbert-15-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-03-30T21:46:38.107Z",
+      "status": "active",
+      "lastUpdate": "2026-03-30T21:46:38.107Z"
+    },
+    {
+      "slug": "erdos-1008-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T02:53:26.476Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T02:53:26.476Z"
+    },
+    {
+      "slug": "erdos-1014-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T02:53:26.476Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T02:53:26.476Z"
+    },
+    {
+      "slug": "euler-totient-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-03T02:53:26.476Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T02:53:26.476Z",
+      "completed": "2026-04-03T02:53:26.476Z"
+    },
+    {
+      "slug": "feuerbachs-theorem-defs-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T02:53:26.476Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T08:40:57.045Z",
+      "completed": "2026-04-04T08:40:57.044Z"
+    },
+    {
+      "slug": "furstenberg-correspondence-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T02:53:26.476Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T02:53:26.476Z"
+    },
+    {
+      "slug": "hilbert-13-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T02:53:26.476Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T02:53:26.476Z"
+    },
+    {
+      "slug": "hilbert-17-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T02:53:26.476Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T02:53:26.476Z"
+    },
+    {
+      "slug": "inverse-galois-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T02:53:26.476Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T02:53:26.476Z"
+    },
+    {
+      "slug": "lagrange-four-squares-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T02:53:26.476Z",
+      "status": "blocked",
+      "lastUpdate": "2026-04-03T04:43:04.856Z"
+    },
+    {
+      "slug": "laws-of-large-numbers-oq-04",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T02:53:26.476Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T02:53:26.487Z"
+    },
+    {
+      "slug": "leibniz-pi-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T02:53:26.476Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T17:20:37.306Z",
+      "completed": "2026-04-05T17:20:37.306Z"
+    },
+    {
+      "slug": "liouville-theorem-oq-02",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T02:53:26.476Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T02:53:26.487Z"
+    },
+    {
+      "slug": "morleys-theorem-oq-02",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T02:53:26.476Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T02:53:26.488Z"
+    },
+    {
+      "slug": "newton-inductive-step-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T02:53:26.476Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T04:02:48.852Z",
+      "completed": "2026-04-03T04:02:48.852Z"
+    },
+    {
+      "slug": "isosceles-triangle-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-03T02:53:26.479Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T07:37:00.134Z",
+      "completed": "2026-04-03T07:37:00.134Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-02-oq-03-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-03T02:57:02.768Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T04:43:04.856Z",
+      "completed": "2026-04-03T04:43:04.856Z"
+    },
+    {
+      "slug": "arithmetic-series-oq-02-oq-04-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-03T02:57:02.769Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T04:46:33.164Z",
+      "completed": "2026-04-03T04:46:33.164Z"
+    },
+    {
+      "slug": "ballot-problem-oq-01-oq-04-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T02:57:02.769Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T20:39:10.631Z",
+      "completed": "2026-04-03T20:39:10.631Z"
+    },
+    {
+      "slug": "bezout-identity-oq-02-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T02:57:02.770Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T07:37:00.132Z",
+      "completed": "2026-04-03T07:37:00.132Z"
+    },
+    {
+      "slug": "binary-gcd-oq-01-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-03T02:57:02.770Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T05:48:10.152Z",
+      "completed": "2026-04-03T05:48:10.152Z"
+    },
+    {
+      "slug": "binomial-theorem-oq-02-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T02:57:02.770Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T08:51:33.836Z",
+      "completed": "2026-04-03T08:51:33.836Z"
+    },
+    {
+      "slug": "buffons-needle-oq-01-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-03T02:57:02.770Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T06:46:59.163Z",
+      "completed": "2026-04-03T06:46:59.163Z"
+    },
+    {
+      "slug": "cauchy-schwarz-integral-oq-02-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-03T02:57:02.770Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T05:14:05.872Z",
+      "completed": "2026-04-03T05:14:05.872Z"
+    },
+    {
+      "slug": "cauchy-schwarz-oq-01-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T02:57:02.770Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T04:43:04.857Z",
+      "completed": "2026-04-03T04:43:04.857Z"
+    },
+    {
+      "slug": "cevas-theorem-oq-02-oq-01-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T02:57:02.771Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T09:22:55.393Z",
+      "completed": "2026-04-04T09:22:55.392Z"
+    },
+    {
+      "slug": "chinese-remainder-constructive-oq-04-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T02:57:02.771Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T05:14:05.872Z",
+      "completed": "2026-04-03T05:14:05.872Z"
+    },
+    {
+      "slug": "collatz-structured-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T02:57:02.771Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T08:12:38.795Z",
+      "completed": "2026-04-03T08:12:38.794Z"
+    },
+    {
+      "slug": "cramers-rule-oq-01-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T02:57:02.771Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T02:57:02.771Z"
+    },
+    {
+      "slug": "de-moivre-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T02:57:02.771Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T06:46:59.164Z",
+      "completed": "2026-04-03T06:46:59.164Z"
+    },
+    {
+      "slug": "derangements-oq-02-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T02:57:02.771Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T07:37:00.132Z",
+      "completed": "2026-04-03T07:37:00.132Z"
+    },
+    {
+      "slug": "descartes-rule-of-signs-oq-01-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T02:57:02.771Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T02:57:02.771Z"
+    },
+    {
+      "slug": "erdos-308-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T02:57:02.772Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T02:57:02.772Z"
+    },
+    {
+      "slug": "erdos-746-oq-04",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-03T02:57:02.772Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T04:43:04.857Z",
+      "completed": "2026-04-03T04:43:04.857Z"
+    },
+    {
+      "slug": "sperner-ndim-oq-03-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T02:57:02.772Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T05:14:05.874Z",
+      "completed": "2026-04-03T05:14:05.874Z"
+    },
+    {
+      "slug": "birthday-problem-oq-03-oq-01-oq-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-03T02:57:02.773Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T02:57:02.773Z"
+    },
+    {
+      "slug": "brouwer-fixed-point-oq-04-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T05:14:05.877Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T05:14:05.980Z"
+    },
+    {
+      "slug": "fundamental-theorem-calculus-oq-04",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-03T05:14:05.877Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T06:46:59.167Z",
+      "completed": "2026-04-03T06:46:59.167Z"
+    },
+    {
+      "slug": "cayley-hamilton-minpoly-oq-02-oq-02-oq-02",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T05:14:05.877Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T05:14:05.982Z"
+    },
+    {
+      "slug": "elementary-quadratic-reciprocity-oq-03-oq-01-oq-01-oq-04",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-03T05:14:05.877Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T06:46:59.167Z",
+      "completed": "2026-04-03T06:46:59.167Z"
+    },
+    {
+      "slug": "ballot-problem-oq-02-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-03T05:14:05.877Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T07:37:00.134Z",
+      "completed": "2026-04-03T07:37:00.134Z"
+    },
+    {
+      "slug": "cantor-diagonalization-oq-03-oq-01-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T05:48:10.158Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T05:48:10.171Z"
+    },
+    {
+      "slug": "central-limit-theorem-oq-02-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T05:48:10.158Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T05:48:10.171Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-03-oq-03-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T07:37:00.135Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T20:20:51-07:00",
+      "completed": "2026-04-03T10:50:50.304Z"
+    },
+    {
+      "slug": "bezout-identity-oq-04-oq-01-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T07:37:00.135Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:12:38.890Z"
+    },
+    {
+      "slug": "erdos-1036-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T07:37:00.135Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T05:40:44.459Z",
+      "completed": "2026-04-04T05:40:44.459Z"
+    },
+    {
+      "slug": "erdos-156-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T00:52:22-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "erdos-157-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T00:52:26-07:00",
+      "status": "graduated",
+      "completed": "2026-04-04T05:15:05.846Z",
+      "lastUpdate": "2026-04-04T05:15:05.846Z"
+    },
+    {
+      "slug": "erdos-138-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T00:52:26-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "erdos-139-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T00:52:26-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "cayley-hamilton-reduction-oq-02-oq-01-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T08:12:38.856Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:12:38.891Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-02-oq-03-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T08:12:38.872Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T11:25:13.741Z",
+      "completed": "2026-04-03T11:25:13.741Z"
+    },
+    {
+      "slug": "area-of-circle-oq-05-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T08:12:38.873Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:12:38.873Z"
+    },
+    {
+      "slug": "ballot-problem-oq-01-oq-01-wip-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T08:12:38.873Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T08:51:33.834Z",
+      "completed": "2026-04-03T08:51:33.834Z"
+    },
+    {
+      "slug": "binomial-theorem-oq-03-oq-02-oq-03",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-03T08:12:38.873Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T08:58:43.752Z",
+      "completed": "2026-04-05T08:58:43.752Z"
+    },
+    {
+      "slug": "dissection-of-cubes-oq-03-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T08:12:38.874Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:12:38.874Z"
+    },
+    {
+      "slug": "erdos-1-oq-03-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T08:12:38.874Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:12:38.874Z"
+    },
+    {
+      "slug": "erdos-1065-oq-05-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T08:12:38.874Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T09:22:55.401Z",
+      "completed": "2026-04-04T09:22:55.401Z"
+    },
+    {
+      "slug": "erdos-1090-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T08:12:38.874Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:12:38.874Z"
+    },
+    {
+      "slug": "erdos-1100-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T08:12:38.874Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:12:38.874Z"
+    },
+    {
+      "slug": "erdos-1126-oq-01-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T08:12:38.874Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T10:50:50.295Z",
+      "completed": "2026-04-03T10:50:50.294Z"
+    },
+    {
+      "slug": "erdos-1131-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T08:12:38.874Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:12:38.874Z"
+    },
+    {
+      "slug": "erdos-117-oq-01-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T08:12:38.874Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:12:38.874Z"
+    },
+    {
+      "slug": "erdos-748-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T08:51:33.758Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:51:33.932Z"
+    },
+    {
+      "slug": "erdos-3-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T08:51:33.760Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:51:33.932Z"
+    },
+    {
+      "slug": "erdos-10-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-03T08:51:33.848Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:51:33.933Z"
+    },
+    {
+      "slug": "erdos-1065-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-03T08:51:33.863Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:51:33.933Z"
+    },
+    {
+      "slug": "erdos-175-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T08:51:33.875Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:51:33.933Z"
+    },
+    {
+      "slug": "erdos-191-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-03T08:51:33.875Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:51:33.934Z"
+    },
+    {
+      "slug": "erdos-433-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-03T08:51:33.876Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T01:13:43.699Z",
+      "completed": "2026-04-04T01:13:43.699Z"
+    },
+    {
+      "slug": "erdos-728-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T08:51:33.880Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:51:33.934Z"
+    },
+    {
+      "slug": "cayley-hamilton-minpoly-oq-04-backward-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T08:51:33.912Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:51:33.912Z"
+    },
+    {
+      "slug": "erdos-214-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T08:51:33.912Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:51:33.934Z"
+    },
+    {
+      "slug": "erdos-290-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T08:51:33.912Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T17:22:58.989Z",
+      "completed": "2026-04-04T17:22:58.989Z"
+    },
+    {
+      "slug": "erdos-305-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T08:51:33.912Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:51:33.935Z"
+    },
+    {
+      "slug": "erdos-32-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T08:51:33.912Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:51:33.935Z"
+    },
+    {
+      "slug": "erdos-353-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T08:51:33.912Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:51:33.936Z"
+    },
+    {
+      "slug": "erdos-4-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T08:51:33.913Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:51:33.913Z"
+    },
+    {
+      "slug": "erdos-448-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T08:51:33.913Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T20:09:18.404Z",
+      "completed": "2026-04-04T20:09:18.404Z"
+    },
+    {
+      "slug": "erdos-511-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T08:51:33.913Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T05:40:44.444Z",
+      "completed": "2026-04-04T05:40:44.443Z"
+    },
+    {
+      "slug": "erdos-516-incomplete-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-03T08:51:33.913Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:51:33.913Z"
+    },
+    {
+      "slug": "erdos-519-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T08:51:33.913Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T10:50:50.297Z",
+      "completed": "2026-04-03T10:50:50.297Z"
+    },
+    {
+      "slug": "erdos-564-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T08:51:33.913Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T08:51:33.913Z"
+    },
+    {
+      "slug": "erdos-10-oq-01-incomplete-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-03T09:15:40.650Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T09:15:40.651Z"
+    },
+    {
+      "slug": "erdos-1018-oq-04-incomplete-01-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T09:15:40.651Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T09:15:40.651Z"
+    },
+    {
+      "slug": "erdos-1021-oq-01-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T09:15:40.651Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T09:15:40.651Z"
+    },
+    {
+      "slug": "erdos-395-oq-01-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T09:15:40.651Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T09:15:40.651Z"
+    },
+    {
+      "slug": "erdos-94-oq-02-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T09:15:40.651Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T09:15:40.651Z"
+    },
+    {
+      "slug": "fourier-series-oq-02-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T09:15:40.651Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-06T06:37:41.192Z",
+      "completed": "2026-04-06T06:37:41.192Z"
+    },
+    {
+      "slug": "fourier-series-oq-02-oq-03-oq-02-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T09:15:40.651Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T09:15:40.651Z"
+    },
+    {
+      "slug": "inverse-galois-oq-02-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T09:15:40.651Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T09:15:40.651Z"
+    },
+    {
+      "slug": "kummer-theorem-oq-01-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T09:15:40.651Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T22:44:23.278Z",
+      "completed": "2026-04-03T22:44:23.278Z"
+    },
+    {
+      "slug": "lhopital-oq-02-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T09:15:40.651Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T09:15:40.651Z"
+    },
+    {
+      "slug": "newton-inductive-step-oq-01-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T09:15:40.651Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T09:15:40.651Z"
+    },
+    {
+      "slug": "poincare-conjecture-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T09:15:40.651Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T09:15:40.651Z"
+    },
+    {
+      "slug": "taylor-sincos-convergence-oq-03-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T09:15:40.651Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T09:15:40.651Z"
+    },
+    {
+      "slug": "shannon-entropy-oq-03-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-03T10:50:50.309Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T10:50:50.323Z"
+    },
+    {
+      "slug": "sum-of-kth-powers-oq-04-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-03T10:50:50.309Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T10:50:50.309Z",
+      "completed": "2026-04-03T10:50:50.309Z"
+    },
+    {
+      "slug": "fundamental-theorem-calculus-oq-01-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T10:50:50.309Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T10:50:50.323Z"
+    },
+    {
+      "slug": "stirling-formula-oq-01-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T10:50:50.309Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T10:50:50.323Z"
+    },
+    {
+      "slug": "cauchy-schwarz-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T10:50:50.309Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T14:55:31.525Z",
+      "completed": "2026-04-03T14:55:31.525Z"
+    },
+    {
+      "slug": "fundamental-theorem-calculus-oq-02-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T10:50:50.309Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T10:50:50.324Z"
+    },
+    {
+      "slug": "cayley-hamilton-oq-01-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T10:50:50.309Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T10:50:50.324Z"
+    },
+    {
+      "slug": "roth-theorem-k3-oq-02-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T10:50:50.309Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T10:50:50.324Z"
+    },
+    {
+      "slug": "roth-theorem-k3-oq-03-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T10:50:50.309Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T10:50:50.324Z"
+    },
+    {
+      "slug": "roth-theorem-k3-oq-01-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T10:50:50.309Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T10:50:50.325Z"
+    },
+    {
+      "slug": "erdos-307-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T04:51:14-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "erdos-604-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T04:51:14-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "erdos-69-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T12:22:59.000Z",
+      "status": "graduated",
+      "completed": "2026-04-03T20:39:10.594Z",
+      "lastUpdate": "2026-04-03T20:39:10.595Z"
+    },
+    {
+      "slug": "erdos-647-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T12:22:59.000Z",
+      "status": "active"
+    },
+    {
+      "slug": "erdos-659-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T12:22:59.000Z",
+      "status": "active"
+    },
+    {
+      "slug": "erdos-666-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T12:22:59.000Z",
+      "status": "active"
+    },
+    {
+      "slug": "erdos-746-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T12:22:59.000Z",
+      "status": "graduated",
+      "completed": "2026-04-04T02:39:17.793Z",
+      "lastUpdate": "2026-04-04T02:39:17.794Z"
+    },
+    {
+      "slug": "erdos-755-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T12:22:59.000Z",
+      "status": "active"
+    },
+    {
+      "slug": "erdos-858-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T12:22:59.000Z",
+      "status": "active"
+    },
+    {
+      "slug": "erdos-991-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T12:22:59.000Z",
+      "status": "graduated",
+      "completed": "2026-04-04T13:46:53.916Z",
+      "lastUpdate": "2026-04-04T13:46:53.917Z"
+    },
+    {
+      "slug": "erdos-614-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T12:22:59.000Z",
+      "status": "active"
+    },
+    {
+      "slug": "erdos-703-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T12:22:59.000Z",
+      "status": "active"
+    },
+    {
+      "slug": "erdos-740-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T12:22:59.000Z",
+      "status": "active"
+    },
+    {
+      "slug": "mean-value-theorem-oq-02-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T12:22:59.000Z",
+      "status": "active"
+    },
+    {
+      "slug": "ramseys-theorem-oq-04-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T12:22:59.000Z",
+      "status": "active"
+    },
+    {
+      "slug": "pythagorean-triples-oq-02-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T12:22:59.000Z",
+      "status": "active"
+    },
+    {
+      "slug": "erdos-176-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T13:04:09.628Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T13:04:09.629Z"
+    },
+    {
+      "slug": "erdos-204-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T13:04:09.629Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T05:22:30.406Z",
+      "completed": "2026-04-05T05:22:30.406Z"
+    },
+    {
+      "slug": "erdos-220-wip-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T13:04:09.629Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T13:04:09.629Z"
+    },
+    {
+      "slug": "prime-number-theorem-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T13:04:09.630Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T13:04:09.630Z"
+    },
+    {
+      "slug": "hilbert-17-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T13:04:09.708Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T13:04:09.708Z"
+    },
+    {
+      "slug": "prime-gap-bounds-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T13:04:09.710Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T13:04:09.710Z"
+    },
+    {
+      "slug": "prime-gap-bounds-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T13:04:09.710Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T13:04:09.710Z"
+    },
+    {
+      "slug": "prime-reciprocal-divergence-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T13:04:09.710Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T13:04:09.710Z"
+    },
+    {
+      "slug": "partition-theorem-oq-04",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-03T13:04:09.713Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T09:42:46.934Z",
+      "completed": "2026-04-04T09:42:46.934Z"
+    },
+    {
+      "slug": "binary-gcd-oq-02",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-03T13:04:09.716Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T13:04:09.716Z"
+    },
+    {
+      "slug": "ramanujan-sum-fallacy-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T13:04:09.716Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T13:04:09.716Z"
+    },
+    {
+      "slug": "burnside-counting-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T07:05:01-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "erdos-727-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-03T15:38:25.652Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T15:38:25.666Z"
+    },
+    {
+      "slug": "erdos-565-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-03T15:38:25.652Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T15:38:25.667Z"
+    },
+    {
+      "slug": "erdos-ko-rado-oq-01",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-03T15:38:25.652Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T15:38:25.667Z"
+    },
+    {
+      "slug": "erdos-224-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T15:38:25.652Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-03T22:44:23.286Z",
+      "completed": "2026-04-03T22:44:23.286Z"
+    },
+    {
+      "slug": "erdos-869-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T15:38:25.652Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T15:38:25.667Z"
+    },
+    {
+      "slug": "cauchy-schwarz-integral-oq-04",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T15:38:25.652Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T15:38:25.668Z"
+    },
+    {
+      "slug": "erdos-314-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T15:38:25.652Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T15:38:25.668Z"
+    },
+    {
+      "slug": "erdos-160-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T15:38:25.652Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T15:38:25.668Z"
+    },
+    {
+      "slug": "erdos-207-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T15:38:25.652Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T15:38:25.668Z"
+    },
+    {
+      "slug": "triangle-inequality-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T15:38:25.652Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T15:38:25.668Z"
+    },
+    {
+      "slug": "erdos-744-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T15:38:25.652Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T15:38:25.668Z"
+    },
+    {
+      "slug": "burnside-counting-oq-02",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-03T15:38:25.652Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T15:38:25.669Z"
+    },
+    {
+      "slug": "abel-ruffini-galois-extensions-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T22:44:23.249Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:44:23.358Z"
+    },
+    {
+      "slug": "elementary-quadratic-reciprocity-oq-01-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T22:44:23.250Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:44:23.358Z"
+    },
+    {
+      "slug": "szemeredi-core-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T22:44:23.253Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-06T01:37:02.105Z",
+      "completed": "2026-04-06T01:37:02.105Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-02-oq-01-oq-01",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-03T22:44:23.314Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:44:23.358Z"
+    },
+    {
+      "slug": "angle-trisection-oq-01-oq-03",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-03T22:44:23.314Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:44:23.359Z"
+    },
+    {
+      "slug": "borsuk-ulam-oq-02-oq-04",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T22:44:23.316Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:44:23.359Z"
+    },
+    {
+      "slug": "buffons-needle-oq-01-oq-01-oq-02",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T22:44:23.317Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:44:23.359Z"
+    },
+    {
+      "slug": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T22:44:23.317Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:44:23.359Z"
+    },
+    {
+      "slug": "cayley-hamilton-minpoly-oq-01-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T22:44:23.317Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:44:23.360Z"
+    },
+    {
+      "slug": "central-limit-theorem-oq-01-oq-04",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T22:44:23.318Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:44:23.360Z"
+    },
+    {
+      "slug": "chinese-remainder-constructive-oq-03-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T22:44:23.318Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:44:23.360Z"
+    },
+    {
+      "slug": "descartes-rule-of-signs-oq-01-oq-04",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-03T22:44:23.320Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:44:23.360Z"
+    },
+    {
+      "slug": "euler-identity-oq-02",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T22:44:23.330Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:44:23.361Z"
+    },
+    {
+      "slug": "shannon-channel-coding-oq-03",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-03T22:44:23.338Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T21:14:29.543Z",
+      "completed": "2026-04-05T21:14:29.542Z"
+    },
+    {
+      "slug": "abel-ruffini-galois-extensions-oq-02",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-03T22:44:23.339Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.383Z"
+    },
+    {
+      "slug": "abel-ruffini-galois-extensions-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T22:44:23.339Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:44:23.339Z"
+    },
+    {
+      "slug": "arithmetic-series-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T22:44:23.339Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:44:23.339Z"
+    },
+    {
+      "slug": "arithmetic-series-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T22:44:23.339Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T03:40:16.612Z",
+      "completed": "2026-04-04T03:40:16.612Z"
+    },
+    {
+      "slug": "burnside-counting-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T22:44:23.339Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T16:22:26.368Z",
+      "completed": "2026-04-04T16:22:26.368Z"
+    },
+    {
+      "slug": "burnside-counting-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T22:44:23.339Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:44:23.339Z"
+    },
+    {
+      "slug": "combinations-formula-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T22:44:23.339Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:44:23.339Z"
+    },
+    {
+      "slug": "desargues-theorem-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T22:44:23.339Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:44:23.339Z"
+    },
+    {
+      "slug": "erdos-736-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T22:44:23.339Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:44:23.339Z"
+    },
+    {
+      "slug": "erdos-815-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T22:44:23.339Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T00:38:42.369Z",
+      "completed": "2026-04-04T00:38:42.369Z"
+    },
+    {
+      "slug": "erdos-986-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T22:44:23.339Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T01:13:43.714Z",
+      "completed": "2026-04-04T01:13:43.714Z"
+    },
+    {
+      "slug": "erdos-ko-rado-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T22:44:23.339Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:44:23.339Z"
+    },
+    {
+      "slug": "erdos-ko-rado-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T22:44:23.339Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:44:23.339Z"
+    },
+    {
+      "slug": "triangle-inequality-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T22:44:23.339Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T23:05:52.609Z",
+      "completed": "2026-04-04T23:05:52.608Z"
+    },
+    {
+      "slug": "binomial-theorem-oq-02-oq-04",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-03T22:44:23.341Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:44:23.362Z"
+    },
+    {
+      "slug": "denumerability-rationals-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T22:50:06.381Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:50:06.381Z"
+    },
+    {
+      "slug": "erdos-11-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T22:50:06.398Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:50:06.398Z"
+    },
+    {
+      "slug": "erdos-1100-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T22:50:06.399Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:50:06.399Z"
+    },
+    {
+      "slug": "erdos-1101-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T22:50:06.399Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:50:06.399Z"
+    },
+    {
+      "slug": "erdos-1107-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T22:50:06.399Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:50:06.399Z"
+    },
+    {
+      "slug": "erdos-111-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T22:50:06.399Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:50:06.399Z"
+    },
+    {
+      "slug": "erdos-1110-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T22:50:06.399Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:50:06.399Z"
+    },
+    {
+      "slug": "euler-totient-oq-03",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-03T22:50:06.443Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:50:06.443Z"
+    },
+    {
+      "slug": "fair-games-theorem-oq-03",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-03T22:50:06.443Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T03:40:16.681Z",
+      "completed": "2026-04-04T03:40:16.681Z"
+    },
+    {
+      "slug": "gcd-algorithm-oq-05",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T22:50:06.447Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:50:06.447Z"
+    },
+    {
+      "slug": "herons-formula-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-03T22:50:06.448Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T17:48:51.795Z",
+      "completed": "2026-04-04T17:48:51.793Z"
+    },
+    {
+      "slug": "hilbert-10-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-03T22:50:06.448Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T22:50:06.448Z"
+    },
+    {
+      "slug": "erdos-660",
+      "phase": "ARISTOTLE",
+      "path": "full",
+      "started": "2026-04-03T23:00:00.000Z",
+      "status": "active",
+      "lastUpdate": "2026-04-03T23:00:00.000Z",
+      "notes": "Aristotle companion created: Erdos660Aristotle.lean (10 supporting lemmas for distinct distances lower bound)"
+    },
+    {
+      "slug": "basel-problem-oq-01-oq-01-oq-02",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.862Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T05:15:05.980Z"
+    },
+    {
+      "slug": "cayley-hamilton-minpoly-oq-01-oq-02",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.862Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T05:15:05.980Z"
+    },
+    {
+      "slug": "hilbert-13-oq-04-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.864Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T05:15:05.981Z"
+    },
+    {
+      "slug": "shannon-source-coding-oq-06",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.865Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T05:15:05.981Z"
+    },
+    {
+      "slug": "basel-problem-oq-01-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.865Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T20:09:18.322Z",
+      "completed": "2026-04-04T20:09:18.321Z"
+    },
+    {
+      "slug": "brouwer-fixed-point-oq-01-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.866Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T09:42:46.920Z",
+      "completed": "2026-04-04T09:42:46.919Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-04-oq-04",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.928Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T05:15:05.981Z"
+    },
+    {
+      "slug": "angle-trisection-oq-01-oq-04",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.928Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T05:15:05.981Z"
+    },
+    {
+      "slug": "area-of-circle-oq-03-oq-02-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.928Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T05:15:05.982Z"
+    },
+    {
+      "slug": "ballot-problem-oq-01-oq-02-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.929Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T05:15:05.982Z"
+    },
+    {
+      "slug": "basel-problem-oq-04",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.929Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T05:15:05.982Z"
+    },
+    {
+      "slug": "borsuk-ulam-oq-02-oq-01-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.930Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T05:15:05.982Z"
+    },
+    {
+      "slug": "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.932Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T23:54:07.822Z",
+      "completed": "2026-04-04T23:54:07.821Z"
+    },
+    {
+      "slug": "cube-root-2-irrational-oq-01",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-04T05:15:05.934Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T05:15:05.983Z"
+    },
+    {
+      "slug": "cube-root-3-irrational-oq-01",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-04T05:15:05.934Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T05:15:05.983Z"
+    },
+    {
+      "slug": "cube-root-3-irrational-oq-03",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.934Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T05:15:05.983Z"
+    },
+    {
+      "slug": "erdos-100-oq-04",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.936Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T05:15:05.984Z"
+    },
+    {
+      "slug": "erdos-1004-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.937Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T09:22:55.398Z",
+      "completed": "2026-04-04T09:22:55.398Z"
+    },
+    {
+      "slug": "erdos-1027-oq-03",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.938Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T05:15:05.984Z"
+    },
+    {
+      "slug": "erdos-211-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.940Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T05:15:05.985Z"
+    },
+    {
+      "slug": "fermat-two-squares-oq-01-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.946Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T05:15:05.985Z"
+    },
+    {
+      "slug": "friendship-theorem-oq-01-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.947Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T05:15:05.985Z"
+    },
+    {
+      "slug": "inverse-galois-oq-01-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.949Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T05:15:05.986Z"
+    },
+    {
+      "slug": "solution-of-cubic-oq-03-oq-04",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-04T05:15:05.954Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T05:15:05.986Z"
+    },
+    {
+      "slug": "vietas-formulas-oq-03-oq-05",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.954Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T23:54:07.843Z",
+      "completed": "2026-04-04T23:54:07.843Z"
+    },
+    {
+      "slug": "wilsons-theorem-oq-02-oq-02",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-04T05:15:05.954Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T05:15:05.986Z"
+    },
+    {
+      "slug": "wilsons-theorem-oq-04-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-04T05:15:05.954Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T17:48:51.805Z",
+      "completed": "2026-04-04T17:48:51.805Z"
+    },
+    {
+      "slug": "abel-ruffini-oq-04-oq-01-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.954Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T05:15:05.954Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-03-oq-02-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.955Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T17:57:43.066Z",
+      "completed": "2026-04-05T17:57:43.066Z"
+    },
+    {
+      "slug": "angle-trisection-oq-02-oq-03-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.955Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T05:15:05.955Z"
+    },
+    {
+      "slug": "area-of-circle-oq-01-oq-02-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.955Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T11:46:56.107Z",
+      "completed": "2026-04-04T11:46:56.107Z"
+    },
+    {
+      "slug": "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.955Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T01:23:27.203Z",
+      "completed": "2026-04-05T01:23:27.203Z"
+    },
+    {
+      "slug": "arithmetic-series-oq-02-oq-02-oq-03-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.955Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T05:15:05.955Z"
+    },
+    {
+      "slug": "arithmetic-series-oq-02-oq-02-oq-03-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.955Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T05:15:05.955Z"
+    },
+    {
+      "slug": "ballot-problem-oq-01-oq-02-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.956Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T21:07:53.430Z",
+      "completed": "2026-04-04T21:07:53.429Z"
+    },
+    {
+      "slug": "bertrands-postulate-oq-03-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.956Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T09:42:47.003Z",
+      "completed": "2026-04-04T09:42:47.003Z"
+    },
+    {
+      "slug": "bezout-identity-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-04T05:15:05.956Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T07:40:01.899Z",
+      "completed": "2026-04-04T07:40:01.899Z"
+    },
+    {
+      "slug": "binary-gcd-oq-01-oq-03",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-04T05:15:05.956Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T08:40:57.057Z",
+      "completed": "2026-04-04T08:40:57.057Z"
+    },
+    {
+      "slug": "binomial-theorem-oq-02-oq-01-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.956Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T14:46:55.468Z",
+      "completed": "2026-04-04T14:46:55.467Z"
+    },
+    {
+      "slug": "birthday-problem-oq-03-oq-01-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.956Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T00:20:29.182Z",
+      "completed": "2026-04-05T00:20:29.182Z"
+    },
+    {
+      "slug": "borsuk-ulam-oq-02-oq-01-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.957Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T05:15:05.957Z"
+    },
+    {
+      "slug": "buffons-needle-oq-01-oq-01-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.957Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T05:15:05.957Z"
+    },
+    {
+      "slug": "cramers-rule-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.957Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T13:24:55.526Z",
+      "completed": "2026-04-04T13:24:55.526Z"
+    },
+    {
+      "slug": "descartes-rule-oq-01-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.957Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T05:15:05.957Z"
+    },
+    {
+      "slug": "erdos-606-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.957Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T05:15:05.957Z"
+    },
+    {
+      "slug": "erdos-678-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.957Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T09:22:55.439Z"
+    },
+    {
+      "slug": "erdos-793-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.958Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T09:42:47.004Z",
+      "completed": "2026-04-04T09:42:47.004Z"
+    },
+    {
+      "slug": "erdos-895-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-04T05:15:05.958Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T05:15:05.958Z"
+    },
+    {
+      "slug": "konigsberg-oq-03-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T09:42:47.007Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T09:42:47.022Z"
+    },
+    {
+      "slug": "konigsberg-oq-03-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-04T09:42:47.007Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T17:22:59.010Z",
+      "completed": "2026-04-04T17:22:59.010Z"
+    },
+    {
+      "slug": "konigsberg-oq-03-wip-01",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-04T09:42:47.007Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T09:42:47.023Z"
+    },
+    {
+      "slug": "cantor-diagonalization-oq-02-oq-03-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-04T09:42:47.007Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T22:29:37.263Z",
+      "completed": "2026-04-04T22:29:37.262Z"
+    },
+    {
+      "slug": "cantor-diagonalization-oq-03-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-04T09:42:47.007Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T16:46:53.625Z",
+      "completed": "2026-04-04T16:46:53.624Z"
+    },
+    {
+      "slug": "cantor-diagonalization-oq-03-oq-01-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-04T09:42:47.007Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T20:09:18.423Z",
+      "completed": "2026-04-04T20:09:18.423Z"
+    },
+    {
+      "slug": "cantor-diagonalization-oq-03-oq-01-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-04T09:42:47.007Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T20:09:18.424Z",
+      "completed": "2026-04-04T20:09:18.424Z"
+    },
+    {
+      "slug": "euler-polyhedral-formula-oq-02-oq-01-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T09:42:47.007Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T09:42:47.023Z"
+    },
+    {
+      "slug": "euler-polyhedral-formula-oq-02-oq-01-wip-01",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-04T09:42:47.007Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T09:42:47.023Z"
+    },
+    {
+      "slug": "inverse-galois-oq-06-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-04T09:42:47.007Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T05:22:30.394Z",
+      "completed": "2026-04-05T05:22:30.394Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-04-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-04T09:42:47.007Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T23:05:52.616Z",
+      "completed": "2026-04-04T23:05:52.616Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-04-oq-03",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T09:42:47.007Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T09:42:47.024Z"
+    },
+    {
+      "slug": "bounded-prime-gaps-oq-03-oq-01-oq-04",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-04T09:42:47.007Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T20:09:18.425Z",
+      "completed": "2026-04-04T20:09:18.425Z"
+    },
+    {
+      "slug": "bezout-identity-oq-03-oq-04-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-04T09:42:47.007Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T17:22:59.012Z",
+      "completed": "2026-04-04T17:22:59.012Z"
+    },
+    {
+      "slug": "bezout-identity-oq-02-oq-01-oq-02-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-04T09:42:47.007Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-04T20:09:18.425Z",
+      "completed": "2026-04-04T20:09:18.425Z"
+    },
+    {
+      "slug": "buffons-needle-oq-01-oq-02-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T09:42:47.007Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T09:42:47.024Z"
+    },
+    {
+      "slug": "dissection-of-cubes-oq-01-oq-01-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T09:42:47.007Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T09:42:47.024Z"
+    },
+    {
+      "slug": "erdos-165-oq-05",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-04T09:42:47.007Z",
+      "status": "active",
+      "lastUpdate": "2026-04-04T09:42:47.024Z"
+    },
+    {
+      "slug": "chebyshev-bounds-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T17:22:10-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "lovasz-local-lemma-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T17:22:10-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "sylow-theorem-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T17:22:10-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "algebraic-numbers-countable-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T17:22:10-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "navier-stokes-oq-01-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T17:22:10-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "szemeredi-hypergraph-core-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-04T17:22:10-07:00",
+      "status": "graduated",
+      "completed": "2026-04-05T05:22:30.411Z",
+      "lastUpdate": "2026-04-05T05:22:30.411Z"
+    },
+    {
+      "slug": "minkowski-fundamental-theorem-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T17:22:10-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "cevas-theorem-non-euclidean-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T17:22:10-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "ballot-problem-oq-03-oq-01-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T17:22:11-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "bezout-identity-oq-02-oq-01-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-04T17:22:11-07:00",
+      "status": "graduated",
+      "completed": "2026-04-05T03:20:31.659Z",
+      "lastUpdate": "2026-04-05T03:20:31.659Z"
+    },
+    {
+      "slug": "area-of-circle-oq-02-oq-04",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T17:22:16-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "derangements-convergence-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-04T17:22:16-07:00",
+      "status": "graduated",
+      "completed": "2026-04-05T01:23:27.252Z",
+      "lastUpdate": "2026-04-05T01:23:27.252Z"
+    },
+    {
+      "slug": "spherical-law-of-cosines-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-04T17:22:16-07:00",
+      "status": "graduated",
+      "completed": "2026-04-05T05:22:30.497Z",
+      "lastUpdate": "2026-04-05T05:22:30.497Z"
+    },
+    {
+      "slug": "ptolemys-complex-proof-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-04T17:22:17-07:00",
+      "status": "graduated",
+      "completed": "2026-04-05T03:59:25.464Z",
+      "lastUpdate": "2026-04-05T03:59:25.464Z"
+    },
+    {
+      "slug": "subset-count-multiset-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-04T17:22:17-07:00",
+      "status": "graduated",
+      "completed": "2026-04-05T02:27:27.079Z",
+      "lastUpdate": "2026-04-05T02:27:27.085Z"
+    },
+    {
+      "slug": "collatz-cycles-oq-02",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T17:22:17-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "amgm-inequality-oq-03-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-04T17:22:17-07:00",
+      "status": "graduated",
+      "completed": "2026-04-05T03:59:25.456Z",
+      "lastUpdate": "2026-04-05T03:59:25.457Z"
+    },
+    {
+      "slug": "angle-trisection-oq-03-oq-03",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T17:22:17-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "divisibility-rules-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T17:22:17-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "triangle-angle-sum-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-04T17:22:17-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "fair-games-theorem-oq-03-incomplete-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T03:59:25.465Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T03:59:25.480Z"
+    },
+    {
+      "slug": "divisibility-by-three-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-05T03:59:25.465Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T05:22:30.503Z",
+      "completed": "2026-04-05T05:22:30.503Z"
+    },
+    {
+      "slug": "sylow-theorem-oq-04-oq-03",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T03:59:25.465Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T03:59:25.481Z"
+    },
+    {
+      "slug": "angle-trisection-cos-20-gal-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-05T03:59:25.465Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T05:22:30.503Z",
+      "completed": "2026-04-05T05:22:30.503Z"
+    },
+    {
+      "slug": "gelfond-schneider-oq-04",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T03:59:25.465Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T03:59:25.481Z"
+    },
+    {
+      "slug": "divisibility-rules-oq-01-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-05T03:59:25.465Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T06:00:06.532Z",
+      "completed": "2026-04-05T06:00:06.532Z"
+    },
+    {
+      "slug": "russell-1-plus-1-oq-01",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-05T03:59:25.465Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T03:59:25.481Z"
+    },
+    {
+      "slug": "newton-inductive-step-oq-01-oq-02",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T03:59:25.465Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T03:59:25.481Z"
+    },
+    {
+      "slug": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-05T03:59:25.465Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T06:00:06.529Z",
+      "completed": "2026-04-05T06:00:06.529Z"
+    },
+    {
+      "slug": "hilbert-10-oq-03",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T03:59:25.465Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.383Z"
+    },
+    {
+      "slug": "cayley-hamilton-minpoly-oq-01-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-05T03:59:25.465Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T10:20:12.872Z",
+      "completed": "2026-04-05T10:20:12.872Z"
+    },
+    {
+      "slug": "borsuk-ulam-oq-02-oq-01-oq-03",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T03:59:25.465Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.383Z"
+    },
+    {
+      "slug": "euler-identity-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-05T03:59:25.465Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T05:22:30.505Z",
+      "completed": "2026-04-05T05:22:30.505Z"
+    },
+    {
+      "slug": "shannon-channel-coding-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-05T03:59:25.465Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T06:26:48.458Z",
+      "completed": "2026-04-05T06:26:48.458Z"
+    },
+    {
+      "slug": "elementary-quadratic-reciprocity-oq-01-oq-03",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T03:59:25.465Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T03:59:25.465Z"
+    },
+    {
+      "slug": "cevas-theorem-non-euclidean-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T03:59:25.465Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T03:59:25.465Z"
+    },
+    {
+      "slug": "binomial-theorem-oq-02-oq-01-oq-03",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T03:59:25.465Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T03:59:25.465Z"
+    },
+    {
+      "slug": "central-limit-theorem-oq-01-oq-01-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T03:59:25.465Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T03:59:25.465Z"
+    },
+    {
+      "slug": "abel-ruffini-oq-04-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T03:59:25.465Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T03:59:25.465Z"
+    },
+    {
+      "slug": "dissection-of-cubes-oq-01-oq-02",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T03:59:25.465Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T03:59:25.465Z"
+    },
+    {
+      "slug": "algebraic-numbers-countable-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-05T03:59:25.465Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T06:00:06.494Z",
+      "completed": "2026-04-05T06:00:06.494Z"
+    },
+    {
+      "slug": "erdos-10-wip-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T03:59:25.465Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T03:59:25.465Z"
+    },
+    {
+      "slug": "erdos-1016-wip-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T03:59:25.465Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T03:59:25.465Z"
+    },
+    {
+      "slug": "area-of-circle-oq-01-oq-02-oq-01-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T06:00:06.438Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T06:00:06.439Z"
+    },
+    {
+      "slug": "brouwer-fixed-point-oq-01-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-05T06:00:06.439Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T12:58:50.656Z",
+      "completed": "2026-04-05T12:58:50.656Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-02-oq-03-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T06:00:06.528Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T06:00:06.528Z"
+    },
+    {
+      "slug": "arithmetic-series-oq-02-oq-01-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-05T06:00:06.528Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T18:48:59.276Z",
+      "completed": "2026-04-05T18:48:59.275Z"
+    },
+    {
+      "slug": "ballot-problem-oq-01-oq-04-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T06:00:06.528Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T06:00:06.528Z"
+    },
+    {
+      "slug": "bertrands-postulate-oq-03-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-05T06:00:06.529Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T12:05:44.500Z",
+      "completed": "2026-04-05T12:05:44.500Z"
+    },
+    {
+      "slug": "bezout-identity-oq-02-oq-01-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T06:00:06.529Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T06:00:06.529Z"
+    },
+    {
+      "slug": "binary-gcd-oq-01-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T06:00:06.529Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T06:00:06.529Z"
+    },
+    {
+      "slug": "birthday-problem-oq-02-oq-01-oq-01",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-05T06:00:06.529Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.383Z"
+    },
+    {
+      "slug": "buffons-needle-oq-01-oq-01-oq-05",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T06:00:06.529Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T06:00:06.529Z"
+    },
+    {
+      "slug": "burnside-counting-oq-03-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-05T06:00:06.529Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T08:58:43.210Z",
+      "completed": "2026-04-05T08:58:43.210Z"
+    },
+    {
+      "slug": "central-limit-theorem-oq-01-oq-01-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T06:00:06.529Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T06:00:06.529Z"
+    },
+    {
+      "slug": "cevas-theorem-oq-01-oq-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T06:00:06.529Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T06:00:06.529Z"
+    },
+    {
+      "slug": "chebyshev-bounds-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T06:00:06.529Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T06:00:06.529Z"
+    },
+    {
+      "slug": "chinese-remainder-constructive-oq-03-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T06:00:06.529Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T06:00:06.529Z"
+    },
+    {
+      "slug": "bounded-prime-gaps-oq-04-oq-01-wip-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T08:58:42.097Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T08:58:42.099Z"
+    },
+    {
+      "slug": "abel-ruffini-oq-04-oq-02-oq-03-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T08:58:42.316Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T08:58:42.316Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-02-oq-03-oq-03-oq-01",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-05T08:58:43.673Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T08:58:44.751Z"
+    },
+    {
+      "slug": "angle-trisection-oq-04-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T08:58:43.687Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T08:58:43.687Z"
+    },
+    {
+      "slug": "arithmetic-series-oq-02-oq-04-oq-01-oq-03",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-05T08:58:43.702Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T14:51:46.062Z",
+      "completed": "2026-04-05T14:51:46.062Z"
+    },
+    {
+      "slug": "arithmetic-series-oq-04-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T08:58:43.702Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T08:58:43.702Z"
+    },
+    {
+      "slug": "ballot-problem-oq-02-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T08:58:43.705Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T08:58:43.705Z"
+    },
+    {
+      "slug": "bezout-identity-oq-02-oq-02-oq-01-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T08:58:43.719Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T08:58:43.720Z"
+    },
+    {
+      "slug": "cantor-diagonalization-oq-03-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T08:58:43.775Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T08:58:43.775Z"
+    },
+    {
+      "slug": "cayley-hamilton-reduction-oq-02-oq-01-wip-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T08:58:43.798Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T08:58:43.798Z"
+    },
+    {
+      "slug": "elementary-quadratic-reciprocity-oq-03-oq-02-wip-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T08:58:43.841Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T08:58:43.841Z"
+    },
+    {
+      "slug": "erdos-1018-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T08:58:43.885Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T08:58:43.886Z"
+    },
+    {
+      "slug": "lhopital-oq-02-wip-01",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-05T08:58:44.240Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.383Z"
+    },
+    {
+      "slug": "shannon-channel-coding-oq-04-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-05T08:58:44.306Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T19:11:40.978Z",
+      "completed": "2026-04-05T19:11:40.977Z"
+    },
+    {
+      "slug": "taylor-sincos-convergence-oq-03-wip-01",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-05T08:58:44.332Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.383Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-02-oq-01-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T08:58:44.358Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T08:58:44.358Z"
+    },
+    {
+      "slug": "angle-trisection-oq-02-oq-01-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T08:58:44.358Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T08:58:44.358Z"
+    },
+    {
+      "slug": "area-of-circle-oq-02-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T08:58:44.359Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T08:58:44.359Z"
+    },
+    {
+      "slug": "arithmetic-series-oq-04-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T08:58:44.359Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T08:58:44.359Z"
+    },
+    {
+      "slug": "ballot-problem-oq-02-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T08:58:44.359Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T08:58:44.359Z"
+    },
+    {
+      "slug": "basel-problem-oq-05-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T08:58:44.359Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T08:58:44.359Z"
+    },
+    {
+      "slug": "bezout-identity-oq-02-oq-02-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T08:58:44.359Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T08:58:44.359Z"
+    },
+    {
+      "slug": "borsuk-ulam-oq-02-oq-01-oq-04-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T08:58:44.359Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T08:58:44.359Z"
+    },
+    {
+      "slug": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T08:58:44.360Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T08:58:44.360Z"
+    },
+    {
+      "slug": "cauchy-schwarz-oq-01-oq-02-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T08:58:44.360Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T08:58:44.360Z"
+    },
+    {
+      "slug": "de-moivre-oq-03-oq-01-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T08:58:44.360Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T08:58:44.360Z"
+    },
+    {
+      "slug": "erdos-1007-oq-05-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T08:58:44.360Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T08:58:44.360Z"
+    },
+    {
+      "slug": "roth-theorem-k3-oq-03-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T08:58:44.360Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T08:58:44.360Z"
+    },
+    {
+      "slug": "shannon-channel-coding-oq-02-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T08:58:44.360Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T08:58:44.360Z"
+    },
+    {
+      "slug": "algebraic-numbers-countable-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T10:20:12.865Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T10:20:12.866Z"
+    },
+    {
+      "slug": "basel-problem-oq-01-oq-05",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T10:20:12.866Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T10:20:12.866Z"
+    },
+    {
+      "slug": "cauchy-schwarz-oq-01-oq-05",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T10:20:12.866Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T10:20:12.866Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-02-oq-03-oq-03-oq-04",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T10:20:12.918Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T10:20:12.971Z"
+    },
+    {
+      "slug": "abel-ruffini-oq-04-oq-01-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T10:20:12.954Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T10:20:12.954Z"
+    },
+    {
+      "slug": "angle-trisection-cos-20-gal-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T10:20:12.954Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T10:20:12.954Z"
+    },
+    {
+      "slug": "area-of-circle-oq-01-oq-02-oq-01-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T10:20:12.954Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T10:20:12.954Z"
+    },
+    {
+      "slug": "arithmetic-series-oq-02-oq-02-oq-01-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T10:20:12.954Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T10:20:12.954Z"
+    },
+    {
+      "slug": "ballot-problem-oq-02-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T10:20:12.954Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T10:20:12.954Z"
+    },
+    {
+      "slug": "bezout-identity-oq-02-oq-01-oq-01-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T10:20:12.954Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T10:20:12.954Z"
+    },
+    {
+      "slug": "binomial-theorem-oq-02-oq-01-oq-02-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T10:20:12.954Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T10:20:12.954Z"
+    },
+    {
+      "slug": "birthday-problem-oq-02-oq-01-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T10:20:12.954Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T10:20:12.954Z"
+    },
+    {
+      "slug": "brouwer-fixed-point-oq-01-oq-02-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T10:20:12.954Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T10:20:12.954Z"
+    },
+    {
+      "slug": "buffons-needle-oq-01-oq-01-oq-01-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T10:20:12.954Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T10:20:12.954Z"
+    },
+    {
+      "slug": "binary-gcd-oq-01-oq-04-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T10:20:12.958Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.384Z"
+    },
+    {
+      "slug": "combinations-formula-oq-01-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T03:20:16-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "arithmetic-series-oq-04-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.419Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.420Z"
+    },
+    {
+      "slug": "bounded-prime-gaps-oq-04-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.421Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.421Z"
+    },
+    {
+      "slug": "e-transcendental-oq-01-oq-01-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.434Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.434Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-03-oq-02-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.495Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.495Z"
+    },
+    {
+      "slug": "angle-trisection-oq-02-oq-02-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.496Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.496Z"
+    },
+    {
+      "slug": "area-of-circle-oq-02-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.497Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.497Z"
+    },
+    {
+      "slug": "ballot-problem-oq-03-oq-02-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.499Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.499Z"
+    },
+    {
+      "slug": "bezout-identity-oq-02-oq-02-oq-01-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.501Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.501Z"
+    },
+    {
+      "slug": "binomial-theorem-oq-03-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.503Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.503Z"
+    },
+    {
+      "slug": "buffons-needle-oq-01-oq-01-oq-01-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.504Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.504Z"
+    },
+    {
+      "slug": "cayley-hamilton-minpoly-oq-01-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.505Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.505Z"
+    },
+    {
+      "slug": "central-limit-theorem-oq-01-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-05T12:05:44.507Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T12:58:50.690Z",
+      "completed": "2026-04-05T12:58:50.690Z"
+    },
+    {
+      "slug": "cevas-theorem-oq-01-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.507Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.507Z"
+    },
+    {
+      "slug": "cramers-rule-oq-01-oq-02-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.509Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.509Z"
+    },
+    {
+      "slug": "derangements-oq-02-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.510Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.510Z"
+    },
+    {
+      "slug": "descartes-rule-of-signs-oq-01-oq-01-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.510Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.510Z"
+    },
+    {
+      "slug": "erdos-1059-oq-02-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.516Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.516Z"
+    },
+    {
+      "slug": "fourier-series-oq-01-oq-02",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.529Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.384Z"
+    },
+    {
+      "slug": "geometric-series-oq-01-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.531Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.531Z"
+    },
+    {
+      "slug": "greens-theorem-oq-01-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.531Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.531Z"
+    },
+    {
+      "slug": "lebesgue-measure-oq-01-oq-02",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.533Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.563Z"
+    },
+    {
+      "slug": "solution-of-cubic-oq-01",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-05T12:05:44.539Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.563Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-02-oq-05",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.541Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.541Z"
+    },
+    {
+      "slug": "bezout-identity-oq-04-oq-01-oq-03",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-05T12:05:44.541Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.384Z"
+    },
+    {
+      "slug": "birthday-problem-oq-03-oq-01-oq-01-oq-03",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T12:05:44.541Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.541Z"
+    },
+    {
+      "slug": "brouwer-fixed-point-oq-01-oq-02-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.541Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.541Z"
+    },
+    {
+      "slug": "brouwer-fixed-point-oq-04-oq-03-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.541Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.541Z"
+    },
+    {
+      "slug": "buffons-needle-oq-02-oq-02-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.541Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.541Z"
+    },
+    {
+      "slug": "cantor-diagonalization-oq-02-oq-03-oq-02-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.541Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.384Z"
+    },
+    {
+      "slug": "cauchy-schwarz-integral-oq-01-oq-02-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.541Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.541Z"
+    },
+    {
+      "slug": "collatz-structured-oq-03-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.541Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.541Z"
+    },
+    {
+      "slug": "dirichlets-theorem-oq-03-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.541Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.384Z"
+    },
+    {
+      "slug": "e-transcendental-oq-03-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.541Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.541Z"
+    },
+    {
+      "slug": "erdos-100-oq-02-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.541Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.541Z"
+    },
+    {
+      "slug": "erdos-1012-oq-02-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.541Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.541Z"
+    },
+    {
+      "slug": "erdos-1023-oq-01-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.541Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.541Z"
+    },
+    {
+      "slug": "erdos-1023-oq-01-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.541Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.541Z"
+    },
+    {
+      "slug": "isoperimetric-theorem-oq-01-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.541Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.541Z"
+    },
+    {
+      "slug": "minkowski-theorem-oq-02-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-05T12:05:44.541Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-06T00:14:41.505Z",
+      "seeker_selected": "2026-04-05T21:00:00.000Z",
+      "selection_rationale": "Highest composite score (78): EMPTY knowledge, tractability 7, significance 8. Three concrete axioms with clear Mathlib paths.",
+      "completed": "2026-04-06T00:14:41.505Z"
+    },
+    {
+      "slug": "taylor-theorem-oq-03-oq-01",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-05T12:05:44.541Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.564Z"
+    },
+    {
+      "slug": "binary-gcd-oq-01-oq-04-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:05:44.544Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:05:44.544Z"
+    },
+    {
+      "slug": "hilbert-3-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:58:50.676Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.676Z"
+    },
+    {
+      "slug": "solution-of-cubic-oq-03-oq-01-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:58:50.678Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.678Z"
+    },
+    {
+      "slug": "erdos-1033-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:58:50.767Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.767Z"
+    },
+    {
+      "slug": "erdos-179-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:58:50.770Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.770Z"
+    },
+    {
+      "slug": "erdos-490-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:58:50.773Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.773Z"
+    },
+    {
+      "slug": "hilbert-3-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:58:50.781Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.781Z"
+    },
+    {
+      "slug": "erdos-1-oq-02-oq-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T12:58:50.789Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.789Z"
+    },
+    {
+      "slug": "erdos-1002-oq-01-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:58:50.790Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.790Z"
+    },
+    {
+      "slug": "erdos-1012-oq-01-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:58:50.790Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.790Z"
+    },
+    {
+      "slug": "erdos-1015-oq-05-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:58:50.790Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.790Z"
+    },
+    {
+      "slug": "erdos-1054-oq-01-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:58:50.790Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.790Z"
+    },
+    {
+      "slug": "erdos-1057-oq-04",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T12:58:50.790Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.790Z"
+    },
+    {
+      "slug": "erdos-1059-oq-01-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:58:50.790Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.790Z"
+    },
+    {
+      "slug": "erdos-1065-oq-05-oq-01",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-05T12:58:50.791Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.817Z"
+    },
+    {
+      "slug": "erdos-1083-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:58:50.791Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.791Z"
+    },
+    {
+      "slug": "erdos-1084-oq-01-oq-04",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T12:58:50.791Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.791Z"
+    },
+    {
+      "slug": "erdos-1098-oq-01-oq-03",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T12:58:50.791Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.791Z"
+    },
+    {
+      "slug": "erdos-1138-oq-03-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T12:58:50.791Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.791Z"
+    },
+    {
+      "slug": "erdos-1146-oq-04",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T12:58:50.791Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.791Z"
+    },
+    {
+      "slug": "erdos-1168-oq-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T12:58:50.791Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:58:50.791Z"
+    },
+    {
+      "slug": "yang-mills-lattice-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:45.975Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:45.975Z"
+    },
+    {
+      "slug": "erdos-12-wip-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.027Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.027Z"
+    },
+    {
+      "slug": "hilbert-23-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.027Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.027Z"
+    },
+    {
+      "slug": "kepler-conjecture-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.027Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.027Z"
+    },
+    {
+      "slug": "kroneckers-jugendtraum-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.027Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.027Z"
+    },
+    {
+      "slug": "perfect-numbers-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.027Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.027Z"
+    },
+    {
+      "slug": "twin-primes-special-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.027Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.027Z"
+    },
+    {
+      "slug": "erdos-1012-oq-03-oq-02",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.128Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.128Z"
+    },
+    {
+      "slug": "erdos-1018-oq-04-incomplete-01-oq-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.129Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.129Z"
+    },
+    {
+      "slug": "erdos-1066-oq-04-oq-03",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.132Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.132Z"
+    },
+    {
+      "slug": "erdos-1179-oq-01-oq-02",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.135Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.135Z"
+    },
+    {
+      "slug": "erdos-129-oq-04",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.135Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.135Z"
+    },
+    {
+      "slug": "erdos-247-oq-01-oq-02",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.137Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.137Z"
+    },
+    {
+      "slug": "erdos-277-oq-02",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.137Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.137Z"
+    },
+    {
+      "slug": "erdos-279-oq-04",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.137Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-06T00:14:41.400Z",
+      "completed": "2026-04-06T00:14:41.399Z"
+    },
+    {
+      "slug": "erdos-286-oq-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.137Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.137Z"
+    },
+    {
+      "slug": "erdos-307-oq-02-oq-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.139Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.139Z"
+    },
+    {
+      "slug": "erdos-357-oq-04",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.140Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.140Z"
+    },
+    {
+      "slug": "erdos-396-oq-04",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.140Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.140Z"
+    },
+    {
+      "slug": "erdos-435-oq-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.141Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.141Z"
+    },
+    {
+      "slug": "erdos-453-oq-02-oq-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.141Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.141Z"
+    },
+    {
+      "slug": "erdos-458-oq-02",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.141Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.141Z"
+    },
+    {
+      "slug": "erdos-458-oq-05",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.141Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.141Z"
+    },
+    {
+      "slug": "erdos-57-oq-04",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.142Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.142Z"
+    },
+    {
+      "slug": "erdos-606-oq-03-oq-03",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.143Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.185Z"
+    },
+    {
+      "slug": "erdos-622-oq-04",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.143Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.143Z"
+    },
+    {
+      "slug": "erdos-659-oq-05",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.144Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.144Z"
+    },
+    {
+      "slug": "erdos-770-oq-04",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.146Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.146Z"
+    },
+    {
+      "slug": "erdos-799-oq-05",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.146Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.146Z"
+    },
+    {
+      "slug": "erdos-823-oq-05",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.147Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.147Z"
+    },
+    {
+      "slug": "erdos-841-oq-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.147Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.147Z"
+    },
+    {
+      "slug": "erdos-909-oq-01-oq-02",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T14:51:46.148Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.148Z"
+    },
+    {
+      "slug": "erdos-1038-wip-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.162Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.162Z"
+    },
+    {
+      "slug": "erdos-1074-wip-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.162Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.162Z"
+    },
+    {
+      "slug": "erdos-1077-wip-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.162Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.162Z"
+    },
+    {
+      "slug": "erdos-112-wip-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.162Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.162Z"
+    },
+    {
+      "slug": "erdos-227-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.162Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.162Z"
+    },
+    {
+      "slug": "erdos-230-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.162Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.162Z"
+    },
+    {
+      "slug": "erdos-240-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.162Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.162Z"
+    },
+    {
+      "slug": "erdos-309-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.162Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.162Z"
+    },
+    {
+      "slug": "erdos-318-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.162Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.162Z"
+    },
+    {
+      "slug": "halting-problem-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.162Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.162Z"
+    },
+    {
+      "slug": "sophie-germain-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.162Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.162Z"
+    },
+    {
+      "slug": "spherical-law-of-sines-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.162Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.186Z"
+    },
+    {
+      "slug": "primitive-roots-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T14:51:46.167Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T14:51:46.167Z"
+    },
+    {
+      "slug": "angle-trisection",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T15:06:35.167Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T15:06:35.168Z"
+    },
+    {
+      "slug": "borsuk-ulam",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T15:06:35.168Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T15:06:35.168Z"
+    },
+    {
+      "slug": "dissection-of-cubes",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T15:06:35.168Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.385Z"
+    },
+    {
+      "slug": "erdos-1085",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T15:06:35.168Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T15:06:35.168Z"
+    },
+    {
+      "slug": "erdos-1069",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T15:06:35.169Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.385Z"
+    },
+    {
+      "slug": "erdos-1027",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T15:06:35.169Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T15:06:35.169Z"
+    },
+    {
+      "slug": "erdos-1026",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T15:06:35.169Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T15:06:35.169Z"
+    },
+    {
+      "slug": "erdos-1008",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-05T15:06:35.169Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T17:20:37.339Z",
+      "completed": "2026-04-05T17:20:37.339Z"
+    },
+    {
+      "slug": "erdos-1131",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T15:06:35.169Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T15:06:35.169Z"
+    },
+    {
+      "slug": "burnside-counting-oq-03-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T15:44:05.091Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T15:44:05.092Z"
+    },
+    {
+      "slug": "cayley-hamilton-minpoly-oq-02-oq-02-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T15:44:05.093Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T20:08:48.027Z"
+    },
+    {
+      "slug": "cevas-theorem-non-euclidean-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T15:44:05.093Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T15:44:05.093Z"
+    },
+    {
+      "slug": "bezout-identity-oq-02-oq-01-oq-02-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T15:44:05.093Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T15:44:05.093Z"
+    },
+    {
+      "slug": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T15:44:05.093Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T15:44:05.093Z"
+    },
+    {
+      "slug": "birthday-problem-oq-03-oq-01-oq-01-oq-05",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T15:44:05.093Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T15:44:05.093Z"
+    },
+    {
+      "slug": "furstenberg-correspondence",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T17:20:37.273Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.273Z"
+    },
+    {
+      "slug": "hermite-lindemann",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T17:20:37.273Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.273Z"
+    },
+    {
+      "slug": "navier-stokes-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T17:20:37.275Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.275Z"
+    },
+    {
+      "slug": "navier-stokes-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T17:20:37.275Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.275Z"
+    },
+    {
+      "slug": "geometric-series-oq-03",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-05T17:20:37.276Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T17:57:42.954Z",
+      "completed": "2026-04-05T17:57:42.953Z"
+    },
+    {
+      "slug": "godel-incompleteness-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T17:20:37.277Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.277Z"
+    },
+    {
+      "slug": "szemeredi-regularity-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T17:20:37.277Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.277Z"
+    },
+    {
+      "slug": "unit-distance-independence-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T17:20:37.277Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.277Z"
+    },
+    {
+      "slug": "e-transcendental",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T17:20:37.337Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.337Z"
+    },
+    {
+      "slug": "elementary-quadratic-reciprocity",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-05T17:20:37.337Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.386Z"
+    },
+    {
+      "slug": "erdos-1021",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T17:20:37.340Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.340Z"
+    },
+    {
+      "slug": "erdos-1059-oq-04",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T17:20:37.341Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.341Z"
+    },
+    {
+      "slug": "euler-polyhedral-formula",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T17:20:37.356Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.387Z"
+    },
+    {
+      "slug": "greens-theorem",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T17:20:37.358Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.358Z"
+    },
+    {
+      "slug": "sylow-theorem-oq-04",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T17:20:37.365Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.365Z"
+    },
+    {
+      "slug": "chebyshev-bounds-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T17:20:37.366Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.366Z"
+    },
+    {
+      "slug": "derangements-convergence-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T17:20:37.366Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.366Z"
+    },
+    {
+      "slug": "factor-remainder-theorem-oq-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T17:20:37.366Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.366Z"
+    },
+    {
+      "slug": "fermat-two-squares-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T17:20:37.366Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.366Z"
+    },
+    {
+      "slug": "fundamental-theorem-algebra-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T17:20:37.366Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.366Z"
+    },
+    {
+      "slug": "gcd-algorithm-oq-04",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T17:20:37.366Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.366Z"
+    },
+    {
+      "slug": "inclusion-exclusion-oq-02",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T17:20:37.366Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T21:36:08.623Z"
+    },
+    {
+      "slug": "inverse-galois-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T17:20:37.366Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.366Z"
+    },
+    {
+      "slug": "taylor-sincos-convergence-oq-02",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-05T17:20:37.366Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T12:22:14-07:00"
+    },
+    {
+      "slug": "taylor-theorem-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T17:20:37.366Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.366Z"
+    },
+    {
+      "slug": "vietas-formulas-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T17:20:37.366Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T17:20:37.366Z"
+    },
+    {
+      "slug": "wilsons-theorem-oq-03",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-05T17:20:37.366Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T18:48:59.352Z",
+      "completed": "2026-04-05T18:48:59.352Z"
+    },
+    {
+      "slug": "angle-trisection-oq-01-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T19:47:48.519Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T19:47:48.519Z"
+    },
+    {
+      "slug": "abel-ruffini-oq-04-oq-02-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T19:47:48.662Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T19:47:48.662Z"
+    },
+    {
+      "slug": "algebraic-numbers-countable-oq-02-oq-01",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-05T19:47:48.662Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T19:47:48.697Z"
+    },
+    {
+      "slug": "algebraic-numbers-countable-oq-02-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T19:47:48.662Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T19:47:48.662Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-03-oq-01-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T19:47:48.662Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T19:47:48.662Z"
+    },
+    {
+      "slug": "area-of-circle-oq-05-oq-01",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-05T19:47:48.662Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-05T20:08:48.003Z",
+      "completed": "2026-04-05T20:08:48.002Z"
+    },
+    {
+      "slug": "ballot-problem-oq-01-oq-03",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T19:47:48.662Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T19:47:48.662Z"
+    },
+    {
+      "slug": "cantors-theorem-oq-02-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T19:47:48.662Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T19:47:48.662Z"
+    },
+    {
+      "slug": "descartes-rule-of-signs-oq-02-oq-01-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T19:47:48.662Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T19:47:48.662Z"
+    },
+    {
+      "slug": "harmonic-divergence-oq-01-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T19:47:48.662Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T19:47:48.662Z"
+    },
+    {
+      "slug": "inverse-galois-oq-06-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T19:47:48.662Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T19:47:48.662Z"
+    },
+    {
+      "slug": "schauder-fixed-point-oq-03-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T19:47:48.662Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T19:47:48.662Z"
+    },
+    {
+      "slug": "arithmetic-series-oq-02-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T19:47:48.667Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T19:47:48.667Z"
+    },
+    {
+      "slug": "divisibility-by-three-oq-01-oq-02",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-05T19:47:48.667Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T20:58:27.588Z"
+    },
+    {
+      "slug": "cayley-hamilton-minpoly-oq-02-oq-02-oq-01",
+      "title": "Rational Canonical Form Determines Similarity Class",
+      "status": "active",
+      "tier": "A",
+      "significance": 8,
+      "tractability": 5,
+      "phase": "OBSERVE",
+      "created": "2026-04-05T00:00:00-07:00",
+      "tags": [
+        "linear-algebra",
+        "canonical-forms",
+        "module-theory",
+        "seeker-selected"
+      ],
+      "source": "gallery-gap",
+      "parentProof": "cayley-hamilton-minpoly"
+    },
+    {
+      "slug": "shapley-folkman",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T13:10:59-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "burnside-counting-oq-03-oq-03",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T13:40:39-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "bounded-prime-gaps-oq-01-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T20:58:27.451Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T20:58:27.452Z"
+    },
+    {
+      "slug": "abel-ruffini-oq-04-oq-01-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T20:58:27.566Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T20:58:27.566Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-02-oq-03-oq-03-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T20:58:27.566Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T20:58:27.566Z"
+    },
+    {
+      "slug": "angle-trisection-oq-02-oq-02-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T20:58:27.566Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T20:58:27.566Z"
+    },
+    {
+      "slug": "area-of-circle-oq-01-oq-02-oq-02-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T20:58:27.566Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T20:58:27.566Z"
+    },
+    {
+      "slug": "arithmetic-series-oq-02-oq-01-oq-01-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T20:58:27.566Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T20:58:27.566Z"
+    },
+    {
+      "slug": "ballot-problem-oq-01-oq-02-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T20:58:27.566Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T20:58:27.566Z"
+    },
+    {
+      "slug": "bezout-identity-oq-02-oq-02-oq-01-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T20:58:27.566Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T20:58:27.566Z"
+    },
+    {
+      "slug": "brouwer-fixed-point-oq-01-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T20:58:27.566Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T21:36:08.624Z"
+    },
+    {
+      "slug": "cantor-diagonalization-oq-01-oq-01-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T20:58:27.567Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T20:58:27.567Z"
+    },
+    {
+      "slug": "binary-gcd-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T20:58:27.571Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T20:58:27.571Z"
+    },
+    {
+      "slug": "birthday-problem-oq-02-oq-01-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T20:58:27.571Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T20:58:27.571Z"
+    },
+    {
+      "slug": "solution-of-cubic-oq-02",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T21:14:29.669Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T21:14:29.733Z"
+    },
+    {
+      "slug": "spherical-law-of-sines-oq-02",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T21:14:29.669Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T21:14:29.734Z"
+    },
+    {
+      "slug": "area-of-circle-oq-03-oq-03-oq-01",
+      "id": "area-of-circle-oq-03-oq-03-oq-01",
+      "title": "Ellipse area π·a·b via Mathlib measure-theoretic change of variables",
+      "status": "active",
+      "tier": "B",
+      "significance": 6,
+      "tractability": 7,
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-05T22:13:23.853Z",
+      "lastUpdate": "2026-04-05T22:13:23.876Z",
+      "seekerSelected": "2026-04-05T22:13:23.876Z",
+      "compositeScore": 76,
+      "tags": [
+        "geometry",
+        "measure-theory",
+        "change-of-variables",
+        "ellipse",
+        "mathlib-formalization"
+      ],
+      "source": "gallery-gap",
+      "parentProof": "area-of-circle-oq-03-oq-03"
+    },
+    {
+      "slug": "abel-ruffini-oq-04-oq-07-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T22:23:02.408Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T22:23:02.408Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-03-oq-03-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T22:23:02.409Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T22:23:02.409Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-03-oq-03-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T22:23:02.409Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T22:23:02.409Z"
+    },
+    {
+      "slug": "area-of-circle-oq-03-oq-03-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T22:23:02.409Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T22:23:02.409Z"
+    },
+    {
+      "slug": "area-of-circle-oq-05-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T22:23:02.409Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T22:26:32Z",
+      "notes": "Seeker selected: Fourier transform of Gaussian — removes gaussian_fourier_identity axiom from CLT proof"
+    },
+    {
+      "slug": "four-color-theorem-oq-02-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T22:23:02.409Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T22:23:02.409Z"
+    },
+    {
+      "slug": "gelfond-schneider-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T22:23:02.409Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T22:23:02.409Z"
+    },
+    {
+      "slug": "hilbert-3-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T22:23:02.409Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T22:23:02.409Z"
+    },
+    {
+      "slug": "hilbert-4-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T22:23:02.409Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T22:23:02.409Z"
+    },
+    {
+      "slug": "hilbert-5-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T22:23:02.409Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T22:23:02.409Z"
+    },
+    {
+      "slug": "hilbert-9-reciprocity-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T22:23:02.409Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T22:23:02.409Z"
+    },
+    {
+      "slug": "pell-equation-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T22:23:02.409Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T22:23:02.409Z"
+    },
+    {
+      "slug": "ramseys-theorem-oq-04-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T22:23:02.409Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T22:23:02.409Z"
+    },
+    {
+      "slug": "pell-equation-oq-01-oq-04",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-05T22:23:02.409Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T22:23:02.430Z",
+      "selected_at": "2026-04-05T22:32:41Z"
+    },
+    {
+      "slug": "inclusion-exclusion-oq-01-oq-02",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T16:12:31-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "cayley-hamilton-minpoly-oq-04-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T23:28:46.361Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T23:28:46.362Z"
+    },
+    {
+      "slug": "central-limit-theorem-oq-01-oq-02-oq-01-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T23:28:46.362Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T23:28:46.362Z"
+    },
+    {
+      "slug": "euler-identity-oq-01-oq-02",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T23:28:46.362Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T23:28:46.362Z"
+    },
+    {
+      "slug": "euler-identity-oq-01-oq-03",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T23:28:46.362Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T23:28:46.362Z"
+    },
+    {
+      "slug": "euler-polyhedral-formula-oq-01-oq-01-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T23:28:46.362Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T23:28:46.362Z"
+    },
+    {
+      "slug": "euler-polyhedral-formula-oq-01-oq-02-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T23:28:46.362Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T23:28:46.362Z"
+    },
+    {
+      "slug": "euler-totient-oq-01-oq-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T23:28:46.363Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T23:28:46.363Z"
+    },
+    {
+      "slug": "inclusion-exclusion-oq-01-oq-03",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T23:28:46.363Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T23:28:46.363Z"
+    },
+    {
+      "slug": "prime-gap-bounds-oq-03",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-05T23:28:46.363Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T00:18:24.501Z"
+    },
+    {
+      "slug": "quadratic-reciprocity-algorithm-oq-02",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T23:28:46.363Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T23:28:46.363Z"
+    },
+    {
+      "slug": "stirling-formula-oq-01-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T23:28:46.363Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T23:28:46.363Z"
+    },
+    {
+      "slug": "stirling-formula-oq-02-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-05T23:28:46.363Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T23:28:46.363Z"
+    },
+    {
+      "slug": "euler-totient-oq-01-oq-02",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T23:28:46.369Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T23:28:46.369Z"
+    },
+    {
+      "slug": "euler-totient-oq-01-oq-03",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-05T23:28:46.369Z",
+      "status": "active",
+      "lastUpdate": "2026-04-05T23:28:46.369Z"
+    },
+    {
+      "slug": "binomial-theorem-oq-04-oq-04",
+      "phase": "COMPLETED",
+      "path": "full",
+      "started": "2026-04-06T00:14:41.514Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-06T01:14:00.391Z",
+      "completed": "2026-04-06T01:14:00.391Z"
+    },
+    {
+      "slug": "cauchy-schwarz-integral-oq-02-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-06T00:14:41.515Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T00:14:41.515Z"
+    },
+    {
+      "slug": "central-limit-theorem-oq-02-oq-02",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-06T00:14:41.515Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T00:14:41.547Z"
+    },
+    {
+      "slug": "central-limit-theorem-oq-02-oq-03",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-06T00:14:41.515Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T00:14:41.515Z"
+    },
+    {
+      "slug": "derangements-convergence-oq-03",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-06T00:14:41.515Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T00:14:41.548Z"
+    },
+    {
+      "slug": "euler-identity-oq-01-oq-04",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-06T00:14:41.516Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T00:14:41.516Z"
+    },
+    {
+      "slug": "fundamental-theorem-algebra-oq-04-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-06T00:14:41.516Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T00:14:41.516Z"
+    },
+    {
+      "slug": "fundamental-theorem-algebra-oq-04-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-06T00:14:41.516Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T00:14:41.516Z"
+    },
+    {
+      "slug": "gcd-algorithm-oq-01-oq-04",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-06T00:14:41.516Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T00:14:41.516Z"
+    },
+    {
+      "slug": "intermediate-value-theorem-oq-01-oq-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-06T00:14:41.516Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T00:14:41.516Z"
+    },
+    {
+      "slug": "intermediate-value-theorem-oq-02-oq-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-06T00:14:41.516Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T00:14:41.516Z"
+    },
+    {
+      "slug": "lagrange-four-squares-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-06T00:14:41.517Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T00:14:41.517Z"
+    },
+    {
+      "slug": "lagrange-four-squares-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-06T00:14:41.517Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T00:14:41.517Z"
+    },
+    {
+      "slug": "mean-value-theorem-oq-04",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-06T00:14:41.517Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T00:14:41.517Z"
+    },
+    {
+      "slug": "sylow-theorem-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-06T00:14:41.517Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T00:14:41.517Z"
+    },
+    {
+      "slug": "taylor-sincos-convergence-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-06T00:14:41.517Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T00:14:41.517Z"
+    },
+    {
+      "slug": "minkowski-fundamental-theorem-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-06T01:14:00.442Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T01:14:00.442Z"
+    },
+    {
+      "slug": "cevas-theorem-non-euclidean-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-06T01:14:00.442Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T01:14:00.442Z"
+    },
+    {
+      "slug": "cube-root-2-irrational-oq-03",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-06T01:14:00.442Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-06T01:37:02.282Z",
+      "completed": "2026-04-06T01:37:02.282Z"
+    },
+    {
+      "slug": "divisibility-rules-oq-03",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-06T01:14:00.443Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-06T02:37:06.628Z",
+      "completed": "2026-04-06T02:37:06.627Z"
+    },
+    {
+      "slug": "feuerbachs-theorem-defs-oq-02",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-06T01:14:00.443Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T01:14:00.465Z"
+    },
+    {
+      "slug": "hilbert-13-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-06T01:14:00.443Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T01:14:00.443Z"
+    },
+    {
+      "slug": "hilbert-17-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-06T01:14:00.443Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T01:14:00.443Z"
+    },
+    {
+      "slug": "knights-tour-oblique-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-06T01:14:00.443Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T01:14:00.443Z"
+    },
+    {
+      "slug": "lovasz-local-lemma-oq-02",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-06T01:14:00.443Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T02:37:06.650Z"
+    },
+    {
+      "slug": "lovasz-local-lemma-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-06T01:14:00.443Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T01:14:00.443Z"
+    },
+    {
+      "slug": "mathematical-induction-oq-03",
+      "phase": "OBSERVE",
+      "path": "fast",
+      "started": "2026-04-06T01:14:00.444Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T01:14:00.465Z"
+    },
+    {
+      "slug": "roth-theorem-k3-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-06T01:14:00.444Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T01:14:00.444Z"
+    },
+    {
+      "slug": "szemeredi-core-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-06T01:14:00.444Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T01:14:00.444Z"
+    },
+    {
+      "slug": "szemeredi-counting-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-06T01:14:00.444Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T01:14:00.444Z"
+    },
+    {
+      "slug": "isosceles-triangle-oq-03",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-06T01:14:00.444Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-06T03:14:36.240Z",
+      "completed": "2026-04-06T03:14:36.240Z"
+    },
+    {
+      "slug": "amgm-inequality-oq-03-oq-01-oq-02",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T20:06:18-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "abel-ruffini-oq-04-oq-02-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T20:06:18-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "angle-trisection-oq-04-oq-02",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T20:06:18-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "quadratic-reciprocity-oq-04",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T20:06:18-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "basel-problem-oq-01-oq-01-oq-03",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T20:06:18-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "borsuk-ulam-oq-02-oq-01-oq-01-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T20:06:18-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "erdos-1006-oq-01-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T20:06:18-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "cauchy-schwarz-oq-01-oq-01-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T20:06:18-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "cayley-hamilton-oq-01-oq-02",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T20:06:18-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "birch-swinnerton-dyer-oq-06-oq-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T20:06:19-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "buffons-needle-oq-01-oq-01-oq-04",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-05T20:06:19-07:00",
+      "status": "active"
+    },
+    {
+      "slug": "brouwer-fixed-point-oq-04-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-06T03:14:36.234Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T03:14:36.235Z"
+    },
+    {
+      "slug": "buffons-needle-oq-01-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-06T03:14:36.235Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T03:14:36.235Z"
+    },
+    {
+      "slug": "erdos-ko-rado-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-06T03:14:36.235Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T03:14:36.235Z"
+    },
+    {
+      "slug": "erdos-szekeres-oq-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-06T03:14:36.235Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T03:14:36.235Z"
+    },
+    {
+      "slug": "factor-remainder-nullstellensatz-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-06T03:14:36.235Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T03:14:36.235Z"
+    },
+    {
+      "slug": "szemeredi-theorem-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-06T03:14:36.235Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T03:14:36.235Z"
+    },
+    {
+      "slug": "taylor-theorem-oq-02",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-06T03:14:36.235Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T03:14:36.235Z"
+    },
+    {
+      "slug": "unit-distance-independence-oq-02",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-06T03:14:36.235Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T03:14:36.235Z"
+    },
+    {
+      "slug": "vietas-formulas-oq-02",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-06T03:14:36.235Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T03:14:36.235Z"
+    },
+    {
+      "slug": "wolstenholme-theorem-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-06T03:14:36.235Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T03:14:36.235Z"
+    },
+    {
+      "slug": "taylor-sincos-convergence-oq-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-06T03:14:36.241Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-06T06:37:41.268Z",
+      "completed": "2026-04-06T06:37:41.268Z"
+    },
+    {
+      "slug": "triangular-reciprocals-oq-02",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-06T03:14:36.241Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T03:14:36.241Z"
+    },
+    {
+      "slug": "arithmetic-series-oq-00",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-06T05:37:41.551Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T05:37:41.552Z"
+    },
+    {
+      "slug": "collatz-cycles-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-06T06:37:41.264Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T06:37:41.264Z"
+    },
+    {
+      "slug": "divisibility-rules-oq-02",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-06T06:37:41.264Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T06:37:41.264Z"
+    },
+    {
+      "slug": "euler-identity-oq-04",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-06T06:37:41.264Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T06:37:41.264Z"
+    },
+    {
+      "slug": "fundamental-arithmetic-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-06T06:37:41.264Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T06:37:41.264Z"
+    },
+    {
+      "slug": "law-of-cosines-oq-06",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-06T06:37:41.264Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T06:37:41.264Z"
+    },
+    {
+      "slug": "pythagorean-theorem-oq-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-06T06:37:41.264Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T06:37:41.264Z"
+    },
+    {
+      "slug": "randomized-maxcut-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-06T06:37:41.264Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T06:37:41.264Z"
+    },
+    {
+      "slug": "sylow-theorems-oq-05",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-06T06:37:41.264Z",
+      "status": "active",
+      "lastUpdate": "2026-04-06T06:37:41.264Z"
+    }
+  ],
+  "config": {
+    "maxActiveProblemsPerAgent": 1,
+    "oodaTimeoutMinutes": 60,
+    "attemptsBeforePivot": 5
+  },
+  "lastUpdated": "2026-04-05T12:51:54.779144"
+}


### PR DESCRIPTION
## Summary
- Restores `research/registry.json` from its corrupted state (empty array `[]`) back to the proper dict format with 1806 problems
- Corruption was introduced during the seeker PR #10122 rebase, which used a JSON merge script that didn't understand the registry's `{version, problems, config}` structure

## Test plan
- [ ] `pnpm build` succeeds (the `sync-data.ts` script reads `registry.problems.length`)
- [ ] Registry contains 1806 problems

🤖 Generated with [Claude Code](https://claude.com/claude-code)