### PR TITLE
Research: erdos-1002-oq-01-oq-01 — sandwich proof structure

### DIFF
--- a/proofs/Proofs/Erdos1002OQ01OQ01.lean
+++ b/proofs/Proofs/Erdos1002OQ01OQ01.lean
@@ -263,20 +263,139 @@ function deviation(x) = 1/2 - {x} follows by a sandwich argument:
 - Squeeze: innerSum/N → 0
 -/
 
+/-! ### Sandwich construction helpers
+
+The sandwich functions smooth out the jump discontinuity of `deviation` at integers.
+- `sandwichUpCore δ t = 1/2 - t + max(0, t-(1-δ))/δ`: on [1-δ, 1], interpolates
+  linearly from -1/2+δ to 1/2 (instead of jumping). Core(0) = Core(1) = 1/2.
+- `sandwichLoCore δ t = 1/2 - t - max(0, δ-t)/δ`: on [0, δ], interpolates
+  linearly from -1/2 to 1/2-δ (instead of jumping). Core(0) = Core(1) = -1/2.
+
+Composing with `Int.fract` yields continuous periodic functions because the
+endpoint condition (f(0) = f(1)) ensures the periodic extension is seamless. -/
+
+/-- Upper sandwich core: smoothly closes the upward jump of deviation at integers. -/
+private noncomputable def sandwichUpCore (δ : ℝ) (t : ℝ) : ℝ :=
+  1/2 - t + max 0 (t - (1 - δ)) / δ
+
+/-- Lower sandwich core: smoothly closes the downward approach at integers. -/
+private noncomputable def sandwichLoCore (δ : ℝ) (t : ℝ) : ℝ :=
+  1/2 - t - max 0 (δ - t) / δ
+
+private lemma sandwichUpCore_continuous (δ : ℝ) (hδ : 0 < δ) :
+    Continuous (sandwichUpCore δ) := by
+  unfold sandwichUpCore
+  exact ((continuous_const.sub continuous_id).add
+    ((continuous_const.max (continuous_id.sub continuous_const)).div
+      continuous_const (fun _ => hδ.ne')))
+
+private lemma sandwichLoCore_continuous (δ : ℝ) (hδ : 0 < δ) :
+    Continuous (sandwichLoCore δ) := by
+  unfold sandwichLoCore
+  exact ((continuous_const.sub continuous_id).sub
+    ((continuous_const.max (continuous_const.sub continuous_id)).div
+      continuous_const (fun _ => hδ.ne')))
+
+private lemma sandwichUpCore_endpoints (δ : ℝ) (hδ : 0 < δ) (hδ1 : δ ≤ 1) :
+    sandwichUpCore δ 0 = sandwichUpCore δ 1 := by
+  simp only [sandwichUpCore]
+  have h0 : max (0 : ℝ) (0 - (1 - δ)) = 0 := max_eq_left (by linarith)
+  have h1 : max (0 : ℝ) (1 - (1 - δ)) = δ := by
+    rw [show (1 : ℝ) - (1 - δ) = δ from by ring]; exact max_eq_right hδ.le
+  rw [h0, h1]; field_simp
+
+private lemma sandwichLoCore_endpoints (δ : ℝ) (hδ : 0 < δ) (hδ1 : δ ≤ 1) :
+    sandwichLoCore δ 0 = sandwichLoCore δ 1 := by
+  simp only [sandwichLoCore]
+  have h0 : max (0 : ℝ) (δ - 0) = δ := by rw [sub_zero]; exact max_eq_right hδ.le
+  have h1 : max (0 : ℝ) (δ - 1) = 0 := max_eq_left (by linarith)
+  rw [h0, h1]; field_simp
+
+/-- A continuous function composed with `Int.fract` is continuous, provided f(0) = f(1).
+    At non-integers, `Int.fract` is locally `x - ⌊x⌋` (continuous). At integers,
+    the endpoint condition ensures left limit f(1) = f(0) = right limit. -/
+private lemma continuous_comp_fract {f : ℝ → ℝ} (hf : Continuous f) (h01 : f 0 = f 1) :
+    Continuous (fun x => f (Int.fract x)) := by
+  rw [continuous_iff_continuousAt]
+  intro x
+  by_cases hfx : Int.fract x = 0
+  · -- x is an integer: f(fract(x)) = f(0)
+    -- Need: ∀ ε > 0, ∃ δ > 0, |y-x| < δ → |f(fract(y)) - f(0)| < ε
+    -- Key: fract(y) is near 0 (right of x) or near 1 (left of x), and f(0) = f(1)
+    sorry
+  · -- x is not an integer: fract is locally y ↦ y - ⌊x⌋, which is continuous
+    have hfr_pos : 0 < Int.fract x := lt_of_le_of_ne (Int.fract_nonneg x) (Ne.symm hfx)
+    -- f ∘ fract agrees with f ∘ (· - ⌊x⌋) in a neighborhood of x
+    have h_eq : (fun y => f (Int.fract y)) =ᶠ[nhds x] (fun y => f (y - ↑⌊x⌋)) := by
+      rw [Filter.eventuallyEq_iff_exists_mem]
+      refine ⟨Set.Ioo ↑⌊x⌋ (↑⌊x⌋ + 1),
+        IsOpen.mem_nhds isOpen_Ioo ⟨?_, Int.lt_floor_add_one x⟩, fun y hy => ?_⟩
+      · -- ⌊x⌋ < x because fract(x) > 0
+        have : Int.fract x = x - ↑⌊x⌋ := rfl
+        linarith
+      · -- On (⌊x⌋, ⌊x⌋+1), ⌊y⌋ = ⌊x⌋ so fract(y) = y - ⌊x⌋
+        congr 1
+        have hfloor_eq : ⌊y⌋ = ⌊x⌋ := by
+          apply le_antisymm
+          · -- ⌊y⌋ ≤ ⌊x⌋ from ⌊y⌋ ≤ y < ⌊x⌋+1
+            rw [← Int.lt_add_one_iff]
+            exact_mod_cast (Int.floor_le y).trans_lt hy.2
+          · -- ⌊x⌋ ≤ ⌊y⌋ from ⌊x⌋ ≤ y
+            exact Int.le_floor.mpr hy.1.le
+        simp [Int.fract, hfloor_eq]
+    exact h_eq.symm.continuousAt ((hf.comp (continuous_id.sub continuous_const)).continuousAt)
+
 /-- Continuous sandwich of the deviation function: for ε > 0, there exist
     continuous periodic g_lo ≤ deviation ≤ g_up with integrals near zero.
 
-    Construction: on [0, 1-δ], both equal deviation(x) = 1/2 - x.
-    Near x ≡ 0 (mod 1), where deviation jumps from -1/2 to 1/2,
-    g_up interpolates linearly upward (closing the gap from above)
-    and g_lo interpolates downward (closing from below). -/
+    Construction: `sandwichUpCore δ ∘ fract` and `sandwichLoCore δ ∘ fract` where
+    `δ = min(ε, 1/2)`. The core functions smooth the jump at integers by replacing
+    the discontinuous region with a linear interpolant. -/
 private lemma deviation_sandwich (ε : ℝ) (hε : 0 < ε) :
     ∃ (g_lo g_up : ℝ → ℝ),
       Continuous g_lo ∧ Continuous g_up ∧
       (∀ x, g_lo (x + 1) = g_lo x) ∧ (∀ x, g_up (x + 1) = g_up x) ∧
       (∀ x, g_lo x ≤ deviation x) ∧ (∀ x, deviation x ≤ g_up x) ∧
       (∫ x in (0 : ℝ)..1, g_up x ≤ ε) ∧ (-ε ≤ ∫ x in (0 : ℝ)..1, g_lo x) := by
-  sorry
+  -- Choose δ = min(ε, 1/2): small enough for integral bounds, large enough to be positive
+  set δ := min ε (1/2) with hδ_def
+  have hδ_pos : 0 < δ := lt_min hε (by norm_num)
+  have hδ_le_ε : δ ≤ ε := min_le_left _ _
+  have hδ_le_half : δ ≤ 1/2 := min_le_right _ _
+  have hδ_le_one : δ ≤ 1 := le_trans hδ_le_half (by norm_num)
+  -- The sandwich functions: core ∘ fract
+  refine ⟨fun x => sandwichLoCore δ (Int.fract x),
+          fun x => sandwichUpCore δ (Int.fract x), ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  -- 1. g_lo continuous
+  · exact continuous_comp_fract (sandwichLoCore_continuous δ hδ_pos)
+      (sandwichLoCore_endpoints δ hδ_pos hδ_le_one)
+  -- 2. g_up continuous
+  · exact continuous_comp_fract (sandwichUpCore_continuous δ hδ_pos)
+      (sandwichUpCore_endpoints δ hδ_pos hδ_le_one)
+  -- 3. g_lo periodic: fract(x+1) = fract(x)
+  · intro x
+    show sandwichLoCore δ (Int.fract (x + 1)) = sandwichLoCore δ (Int.fract x)
+    have : (x + 1 : ℝ) = x + ↑(1 : ℤ) := by push_cast; ring
+    rw [this, Int.fract_add_int]
+  -- 4. g_up periodic
+  · intro x
+    show sandwichUpCore δ (Int.fract (x + 1)) = sandwichUpCore δ (Int.fract x)
+    have : (x + 1 : ℝ) = x + ↑(1 : ℤ) := by push_cast; ring
+    rw [this, Int.fract_add_int]
+  -- 5. g_lo ≤ deviation (bump is nonneg, so subtracting it gives ≤)
+  · intro x
+    simp only [sandwichLoCore, deviation]
+    linarith [div_nonneg (le_max_left (0 : ℝ) (δ - Int.fract x)) hδ_pos.le]
+  -- 6. deviation ≤ g_up (bump is nonneg, so adding it gives ≥)
+  · intro x
+    simp only [sandwichUpCore, deviation]
+    linarith [div_nonneg (le_max_left (0 : ℝ) (Int.fract x - (1 - δ))) hδ_pos.le]
+  -- 7. ∫₀¹ g_up ≤ ε: integral of bump is δ/2 ≤ ε
+  · -- On [0,1], fract(x) = x a.e., so integral equals ∫₀¹ sandwichUpCore δ.
+    -- sandwichUpCore = deviation + bump_up, ∫deviation = 0, ∫bump_up = δ/2 ≤ ε.
+    sorry
+  -- 8. -ε ≤ ∫₀¹ g_lo: integral of bump is -δ/2 ≥ -ε
+  · sorry
 
 /-- **For irrational α, (1/n) · S(α,n) → 0.**
     Proof: sandwich deviation between continuous periodic bounds g_lo ≤ deviation ≤ g_up

--- a/src/data/proofs/erdos-1002-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1002-oq-01-oq-01/meta.json
@@ -18,7 +18,7 @@
       "weyl-criterion"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 4,
     "erdosNumber": 1002,
     "erdosUrl": "https://erdosproblems.com/1002",
     "erdosProblemStatus": "open",
@@ -31,8 +31,8 @@
       "euler-identity"
     ],
     "axiomCount": 1,
-    "lineCount": 312,
-    "assumptions": "One axiom: `innerSum_log_bound` — for badly approximable irrational α (bounded partial quotients), |S(α,n)| ≤ C·log n. This requires continued fraction theory not yet in Mathlib. Two sorries: `equidist_approx` (density of trig polynomials via span_fourier_closure_eq_top) and `deviation_sandwich` (piecewise linear continuous sandwich of the sawtooth function). Both main theorems (weyl_equidist_continuous, weyl_fract_average_zero) are proved modulo these helpers."
+    "lineCount": 479,
+    "assumptions": "One axiom: `innerSum_log_bound` — for badly approximable irrational α (bounded partial quotients), |S(α,n)| ≤ C·log n. This requires continued fraction theory not yet in Mathlib. Four sorries: `equidist_approx` (density of trig polynomials), `continuous_comp_fract` integer case (ε-δ at integer points), and two integral bounds for `deviation_sandwich` (routine computation: ∫₀¹ sandwichUpCore δ = δ/2 ≤ ε). The deviation_sandwich construction is proved structurally: sandwich functions defined, periodicity/pointwise bounds verified, non-integer continuity established. Both main theorems (weyl_equidist_continuous, weyl_fract_average_zero) are proved modulo these helpers."
   },
   "overview": {
     "historicalContext": "Hermann Weyl's 1916 paper 'Über die Gleichverteilung von Zahlen mod. Eins' (On the distribution of numbers mod one) is one of the foundational results of analytic number theory and ergodic theory. Weyl proved that for irrational α, the sequence {nα} of fractional parts is equidistributed modulo 1 — meaning any subinterval [a,b] ⊂ [0,1) contains exactly (b-a) fraction of the sequence in the long run. His key innovation was the exponential sum criterion: {nα} is equidistributed if and only if (1/N)Σ e^{2πiknα} → 0 for every nonzero integer k. This reduces equidistribution to estimates on exponential sums, which can be bounded by the geometry of the unit circle.\n\nThe connection to Erdős Problem #1002 comes through Kesten's 1960 theorem: the normalized inner sum (1/log n) S(α,n) = (1/log n) Σ_{k=1}^n (1/2 - {αk}) converges in distribution to a standard Cauchy distribution for badly approximable irrational α. The Cesàro mean result proved here (weyl_cesaro_zero) is the key ingredient showing that the unnormalized average (1/n) S(α,n) → 0, consistent with the 1/log n normalization in Kesten's theorem.\n\nWeyl's criterion has become a versatile tool throughout mathematics. It underlies the three-distance theorem (Steinhaus), the equidistribution of √n mod 1 (which Weyl's polynomial extension handles), and is the prototype for modern analytic approaches in ergodic theory. The exponential sum bound 2/‖r-1‖ proved in weyl_cesaro_bound is optimal — it cannot be improved without additional information about α.",
@@ -108,16 +108,16 @@
       "id": "fract-average",
       "title": "Fractional Part Average via Sandwich",
       "summary": "Proves weyl_fract_average_zero: (1/n)·S(α,n) → 0 for irrational α. Proof via continuous sandwich of the discontinuous deviation function: g_lo ≤ deviation ≤ g_up with small integrals, then apply weyl_equidist_continuous and squeeze. Modulo deviation_sandwich (construction of piecewise linear approximants).",
-      "startLine": 208,
-      "endLine": 275,
-      "mathContext": "The deviation function 1/2-{x} has a jump discontinuity at integers, so weyl_equidist_continuous cannot be applied directly. The sandwich construction smooths the discontinuity: on [0,1-δ] both bounds equal 1/2-x; on [1-δ,1] they interpolate linearly to close the gap, with ∫g_up = δ/2 → 0."
+      "startLine": 256,
+      "endLine": 399,
+      "mathContext": "The deviation function 1/2-{x} has a jump discontinuity at integers, so weyl_equidist_continuous cannot be applied directly. The sandwich construction defines sandwichUpCore and sandwichLoCore — piecewise-linear functions that smooth the jump by adding/subtracting a triangular bump near integers. Composing with Int.fract yields continuous periodic functions. The proof verifies periodicity (via Int.fract_add_int), pointwise bounds (bump ≥ 0), and continuity (via continuous_comp_fract for non-integer points; integer case requires ε-δ with left/right limits)."
     },
     {
       "id": "log-bound",
       "title": "Inner Sum Log Bound (axiom)",
       "summary": "Axiomatizes |S(α,n)| ≤ C·log n for badly approximable irrational α (HasBoundedPartialQuotients). Derives the bounded log-normalized form log_normalized_bounded as a consequence.",
-      "startLine": 277,
-      "endLine": 312,
+      "startLine": 444,
+      "endLine": 479,
       "mathContext": "Badly approximable numbers (also called numbers of bounded type) are those for which the continued fraction expansion has bounded partial quotients, equivalently ‖qα‖ ≥ C/q for all q ≥ 1. The log bound for S(α,n) is classical and essential for Kesten's 1960 central limit theorem for the inner sum."
     }
   ]

--- a/src/data/research/problems/erdos-1002-oq-01-oq-01.json
+++ b/src/data/research/problems/erdos-1002-oq-01-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved weyl_equidist_continuous (equidistribution for continuous periodic functions) and weyl_fract_average_zero (Cesaro average of deviation → 0) via ε-approximation + sandwich argument. Two helper sorries remain: equidist_approx (density of trig polynomials) and deviation_sandwich (piecewise linear continuous sandwich). File: 312 lines, 9 theorems (7 proved, 2 sorry), 1 axiom.",
+    "progressSummary": "PROGRESS: Proved deviation_sandwich structure (6/8 goals). Defined sandwichUpCore/sandwichLoCore, proved non-integer continuity of f∘fract, periodicity (via Int.fract_add_int), pointwise bounds (bump nonneg). File: 479 lines, 4 sorries (was 2), 1 axiom. Remaining: integer continuity of f∘fract (ε-δ), two integral bounds (routine computation).",
     "builtItems": [
       "irrational_exp_ne_one: exp(2πikα) ≠ 1 for irrational α, k ≠ 0 — Erdos1002OQ01OQ01.lean:46",
       "weyl_cesaro_bound: ‖Σ_{k<N} r^k‖ ≤ 2/‖r-1‖ for ‖r‖=1, r≠1 — Erdos1002OQ01OQ01.lean:77",
@@ -39,7 +39,11 @@
       "weyl_equidist_continuous: Weyl equidistribution for continuous periodic functions — proved via ε/3 triangle inequality from equidist_approx — Erdos1002OQ01OQ01.lean:157",
       "weyl_fract_average_zero: (1/n)·S(α,n) → 0 — proved via sandwich of deviation between continuous bounds + weyl_equidist_continuous + squeeze — Erdos1002OQ01OQ01.lean:237",
       "deviation_sandwich: continuous sandwich helper (sorry) for piecewise linear approximation of 1/2-{x} — Erdos1002OQ01OQ01.lean:225",
-      "equidist_approx: trig polynomial density helper (sorry) combining span_fourier_closure_eq_top + weyl_cesaro_zero — Erdos1002OQ01OQ01.lean:140"
+      "equidist_approx: trig polynomial density helper (sorry) combining span_fourier_closure_eq_top + weyl_cesaro_zero — Erdos1002OQ01OQ01.lean:140",
+      "sandwichUpCore: upper sandwich core function — Erdos1002OQ01OQ01.lean:278",
+      "sandwichLoCore: lower sandwich core function — Erdos1002OQ01OQ01.lean:282",
+      "continuous_comp_fract (non-integer case): f∘fract cts at non-integers via locally constant floor — Erdos1002OQ01OQ01.lean:326",
+      "deviation_sandwich (6/8 goals): periodicity, pointwise bounds, non-integer continuity proved — Erdos1002OQ01OQ01.lean:354"
     ],
     "insights": [
       "Weyl exponential sum criterion provable from Mathlib: exp(2πikα) ≠ 1 via exp_eq_one_iff, geometric sum bound via geom_sum_eq, Cesaro limit via squeeze_zero",
@@ -50,7 +54,11 @@
       "weyl_equidist_continuous proved by ε/3 argument: approximate g by trig poly h (equidist_approx), then |avg(g)-∫g| ≤ |avg(g)-avg(h)| + |avg(h)-∫h| + |∫h-∫g| < ε",
       "weyl_fract_average_zero proved by squeeze: continuous g_lo ≤ deviation ≤ g_up with small integrals, apply equidist to both, squeeze innerSum/n between their averages",
       "div_sub_div_eq_sub_div and Finset.sum_sub_distrib key for bounding average differences in Lean",
-      "abs_lt.mp decomposes |x| < ε into -ε < x and x < ε, useful for combining dist bounds with integral bounds via linarith"
+      "abs_lt.mp decomposes |x| < ε into -ε < x and x < ε, useful for combining dist bounds with integral bounds via linarith",
+      "Sandwich construction: sandwichUpCore δ t = 1/2-t+max(0,t-(1-δ))/δ has Core(0)=Core(1)=1/2, enabling continuous periodic extension via fract",
+      "Non-integer continuity of f∘fract: use EventuallyEq with Ioo(⌊x⌋,⌊x⌋+1) where floor is constant, show fract=id-const locally, apply ContinuousAt composition",
+      "Integer continuity of f∘fract: ε-δ proof using f cts at 0 (right approach) + f cts at 1 with f(0)=f(1) (left approach)",
+      "Integral bound approach: ∫₀¹ sandwichUpCore = ∫₀¹ deviation + ∫₀¹ bump = 0 + δ/2 ≤ ε. Can also bound bump ≤ 1 on support of measure δ."
     ],
     "mathlibGaps": [
       "Fourier series of sawtooth function 1/2-{x} = Σ sin(2πkx)/(πk) not in Mathlib — needed for weyl_fract_average_zero",
@@ -58,9 +66,9 @@
       "Continued fraction theory for Diophantine approximation bounds — needed for innerSum_log_bound"
     ],
     "nextSteps": [
-      "PRIORITY: Prove equidist_approx by lifting g to AddCircle 1 via span_fourier_closure_eq_top + weyl_cesaro_zero for each Fourier mode",
-      "Prove deviation_sandwich by constructing piecewise linear g_up/g_lo using if-then-else on Int.fract, prove continuity at breakpoints",
-      "Consider proving deviation_bounded, deviation_periodic, deviation_integral_zero in companion file to support deviation_sandwich"
+      "PRIORITY: Prove continuous_comp_fract integer case via ε-δ with f cts at 0 and f(0)=f(1) for left limits",
+      "Prove integral bounds: replace fract by id on [0,1] a.e., compute ∫₀¹ sandwichUpCore = δ/2 via integral splitting at 1-δ",
+      "equidist_approx: extract trig polynomial from span_fourier_closure_eq_top, show averages converge via linearity + weyl_cesaro_zero"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary
- Define `sandwichUpCore`/`sandwichLoCore`: piecewise-linear core functions that smooth the jump discontinuity of `deviation` at integers via triangular bumps (Core(0) = Core(1) ensures continuous periodic extension)
- Prove `continuous_comp_fract` (non-integer case): show `f ∘ Int.fract` is continuous at non-integers via `EventuallyEq` on `Ioo(⌊x⌋, ⌊x⌋+1)` where floor is constant
- Prove `deviation_sandwich` structure: 6 of 8 goals complete — periodicity, pointwise bounds (g_lo ≤ deviation ≤ g_up), continuity via helper lemmas
- File: 360→479 lines, 4 focused sorries (was 2 monolithic), 1 axiom (unchanged)

## Remaining sorries
1. `continuous_comp_fract` integer case — ε-δ proof using f continuous at 0 and f(0)=f(1) for left limits
2. Two `deviation_sandwich` integral bounds — routine: ∫₀¹ sandwichUpCore δ = δ/2 ≤ ε
3. `equidist_approx` — density of trig polynomials (unchanged from prior sessions)

## Test plan
- [ ] Docker build: `./proofs/scripts/docker-build.sh Proofs.Erdos1002OQ01OQ01`
- [ ] Gallery build: `pnpm build`
- [ ] Verify sorry count matches meta.json

🤖 Generated by researcher-7