### PR TITLE
Research: prime-gap-bounds-oq-01 — eliminate last sorry

### DIFF
--- a/proofs/Proofs/Erdos1002OQ01OQ01Aristotle.lean
+++ b/proofs/Proofs/Erdos1002OQ01OQ01Aristotle.lean
@@ -9,12 +9,14 @@
   - Clean theorem statements with no definition sorries
   - No axioms
 
-  These lemmas support a future proof of weyl_fract_average_zero.
+  NOTE: deviation_bounded and deviation_periodic are now proved in the main file
+  (Erdos1002OQ01OQ01.lean). They remain here as independent Aristotle targets.
+  weyl_fract_average_zero is now proved via sandwich argument in the main file.
 
   Sorries targeted:
-  - deviation_bounded: |1/2 - {x}| ≤ 1/2
+  - deviation_bounded: |1/2 - {x}| ≤ 1/2 (PROVED in main file)
     Strategy: Int.fract_nonneg + Int.fract_lt_one + abs_le
-  - deviation_periodic: deviation(x+1) = deviation(x)
+  - deviation_periodic: deviation(x+1) = deviation(x) (PROVED in main file)
     Strategy: Int.fract_add_int or Int.fract_int_add
   - innerSum_eq_sub_fract: innerSum α n = n/2 - Σ{α(k+1)}
     Strategy: unfold, Finset.sum_sub_distrib, Finset.sum_const

--- a/proofs/Proofs/PrimeGapBoundsOQ01.lean
+++ b/proofs/Proofs/PrimeGapBoundsOQ01.lean
@@ -138,8 +138,36 @@ theorem pnt_bound_subexponential :
   -- So 2·n·ln(n) ≤ 2·n²
   have h2 : 2 * (↑n * Real.log ↑n) ≤ 2 * (↑n * ↑n) := by linarith
   -- Need: 2·n² < 2^(n+1), i.e., n² < 2^n
-  -- For n ≥ 10: 10² = 100 < 1024 = 2^10, and the ratio improves
-  sorry
+  -- Step 1: Prove n * n < 2 ^ n in ℕ by induction from n = 10
+  have h_nat : n * n < 2 ^ n := by
+    -- Induction on n; base case n = 10 by norm_num
+    induction n with
+    | zero => omega
+    | succ k ih =>
+      -- hn gives 10 ≤ k + 1, so k ≥ 9
+      rcases le_or_lt 10 k with hk | hk
+      · -- Inductive case: k ≥ 10, so ih applies
+        have hkk := ih (by omega)
+        -- Key: 2k+1 ≤ k² for k ≥ 3 (so (k+1)² = k²+(2k+1) ≤ 2k²)
+        have hsmall : 2 * k + 1 ≤ k * k := by nlinarith
+        calc (k + 1) * (k + 1)
+            = k * k + (2 * k + 1) := by ring
+          _ ≤ k * k + k * k := by linarith
+          _ = 2 * (k * k) := by ring
+          _ < 2 * 2 ^ k := by linarith
+          _ = 2 ^ (k + 1) := by rw [pow_succ]; ring
+      · -- Base case: k < 10 and 10 ≤ k + 1, so k = 9
+        have : k = 9 := by omega
+        subst this; norm_num
+  -- Step 2: Cast to reals and combine with h2
+  calc 2 * (↑n * Real.log ↑n)
+      ≤ 2 * (↑n * ↑n) := h2
+    _ < 2 * ((2 : ℝ) ^ (n : ℕ)) := by
+        have : (↑(n * n) : ℝ) < ↑(2 ^ n) := Nat.cast_lt.mpr h_nat
+        push_cast at this; linarith
+    _ = (2 : ℝ) ^ (↑n + 1) := by
+        rw [show (↑n : ℝ) + 1 = ↑(n + 1 : ℕ) from by push_cast; ring,
+            rpow_natCast, pow_succ]; ring
 
 /-
 ## Part IV: Dusart's Explicit Bounds (Axiomatized)
@@ -234,7 +262,7 @@ theorem dusart_implies_asymptotic_upper :
 ### Proved Theorems (7)
 1. `nth_prime_eventually_lt_mul` - From PNT: eventually p_n < (1+ε)·n·ln n
 2. `nth_prime_eventually_gt_mul` - From PNT: eventually p_n > (1-ε)·n·ln n
-3. `pnt_bound_subexponential` - PNT bound beats exponential (1 sorry)
+3. `pnt_bound_subexponential` - PNT bound beats exponential (proved: n²<2^n by induction)
 4. `dusart_sandwich` - Dusart bounds sandwich p_n
 5. `dusart_gap_width` - Gap between bounds is exactly n
 6. `dusart_upper_at_six` - Instantiation at n = 6

--- a/src/data/proofs/erdos-1002-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1002-oq-01-oq-01/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "erdos-1002-oq-01-oq-01",
-  "title": "Erdős #1002 OQ-01-OQ-01: Weyl Equidistribution and Log Bound",
+  "title": "Erd\u0151s #1002 OQ-01-OQ-01: Weyl Equidistribution and Log Bound",
   "slug": "erdos-1002-oq-01-oq-01",
-  "description": "Formalizes Weyl's exponential sum criterion and equidistribution theorem: proves the Cesàro mean of exponential sums → 0, equidistribution for continuous periodic functions (modulo trig polynomial density), and (1/n)·S(α,n) → 0 via sandwich argument. Axiomatizes the inner sum log bound.",
+  "description": "Formalizes Weyl's exponential sum criterion for irrational rotations: proves exp(2\u03c0ik\u03b1) \u2260 1 for irrational \u03b1 and the Ces\u00e0ro mean of exponential sums tends to zero. Axiomatizes the inner sum log bound (requires continued fraction theory beyond Mathlib).",
   "meta": {
-    "author": "Erdős",
+    "author": "Erd\u0151s",
     "sourceUrl": "https://erdosproblems.com/1002",
     "date": "",
     "status": "axiomatized",
@@ -31,94 +31,94 @@
       "euler-identity"
     ],
     "axiomCount": 1,
-    "lineCount": 312,
-    "assumptions": "One axiom: `innerSum_log_bound` — for badly approximable irrational α (bounded partial quotients), |S(α,n)| ≤ C·log n. This requires continued fraction theory not yet in Mathlib. Two sorries: `equidist_approx` (density of trig polynomials via span_fourier_closure_eq_top) and `deviation_sandwich` (piecewise linear continuous sandwich of the sawtooth function). Both main theorems (weyl_equidist_continuous, weyl_fract_average_zero) are proved modulo these helpers."
+    "lineCount": 278,
+    "assumptions": "One axiom: `innerSum_log_bound` \u2014 for badly approximable irrational \u03b1 (bounded partial quotients), |S(\u03b1,n)| \u2264 C\u00b7log n. This requires continued fraction theory and Diophantine approximation not yet in Mathlib. Two sorries: `weyl_equidist_continuous` (equidistribution for continuous periodic functions, needs density of trigonometric polynomials via span_fourier_closure_eq_top) and `deviation_sandwich` (piecewise-linear continuous approximation of deviation, routine construction). Note: `weyl_fract_average_zero` is now proved from these two sorries via a sandwich argument."
   },
   "overview": {
-    "historicalContext": "Hermann Weyl's 1916 paper 'Über die Gleichverteilung von Zahlen mod. Eins' (On the distribution of numbers mod one) is one of the foundational results of analytic number theory and ergodic theory. Weyl proved that for irrational α, the sequence {nα} of fractional parts is equidistributed modulo 1 — meaning any subinterval [a,b] ⊂ [0,1) contains exactly (b-a) fraction of the sequence in the long run. His key innovation was the exponential sum criterion: {nα} is equidistributed if and only if (1/N)Σ e^{2πiknα} → 0 for every nonzero integer k. This reduces equidistribution to estimates on exponential sums, which can be bounded by the geometry of the unit circle.\n\nThe connection to Erdős Problem #1002 comes through Kesten's 1960 theorem: the normalized inner sum (1/log n) S(α,n) = (1/log n) Σ_{k=1}^n (1/2 - {αk}) converges in distribution to a standard Cauchy distribution for badly approximable irrational α. The Cesàro mean result proved here (weyl_cesaro_zero) is the key ingredient showing that the unnormalized average (1/n) S(α,n) → 0, consistent with the 1/log n normalization in Kesten's theorem.\n\nWeyl's criterion has become a versatile tool throughout mathematics. It underlies the three-distance theorem (Steinhaus), the equidistribution of √n mod 1 (which Weyl's polynomial extension handles), and is the prototype for modern analytic approaches in ergodic theory. The exponential sum bound 2/‖r-1‖ proved in weyl_cesaro_bound is optimal — it cannot be improved without additional information about α.",
-    "problemStatement": "**Weyl's Equidistribution Theorem (Full Chain)**\n\nFor irrational α and integer k ≠ 0:\n1. `irrational_exp_ne_one`: exp(2πikα) ≠ 1\n2. `weyl_cesaro_bound`: ‖Σ_{n<N} r^n‖ ≤ 2/‖r-1‖ for ‖r‖=1, r≠1\n3. `weyl_cesaro_zero`: (1/N)‖Σ_{n<N} e^{2πiknα}‖ → 0\n4. `weyl_equidist_continuous`: (1/N)Σg(nα) → ∫g for continuous periodic g (proved modulo equidist_approx)\n5. `weyl_fract_average_zero`: (1/n) S(α,n) → 0 for irrational α (proved via sandwich argument)\n\n**Axiomatized**: `innerSum_log_bound`: |S(α,n)| ≤ C·log n for badly approximable α (needs continued fraction theory)",
-    "text": "Proves Weyl's exponential sum criterion — the core computational lemma of equidistribution theory — showing the Cesàro mean of complex exponentials tends to zero for irrational frequencies. Also axiomatizes the inner sum log bound for badly approximable irrationals.",
-    "proofStrategy": "**irrational_exp_ne_one**: If exp(2πikα) = 1, then by Complex.exp_eq_one_iff, there exists n : ℤ with 2πiknα = 2πin. Canceling 2πi (which is nonzero) gives kα = n, so α = n/k ∈ ℚ — contradicting irrationality.\n\n**weyl_cesaro_bound**: For N=0, empty sum has norm 0 ≤ 2/‖r-1‖. For N>0, apply the geometric sum formula: Σ r^k = (r^N-1)/(r-1). Then ‖r^N-1‖ ≤ ‖r^N‖+‖1‖ = 1+1 = 2, giving ‖sum‖ ≤ 2/‖r-1‖.\n\n**weyl_cesaro_zero**: Set r = exp(2πikα). Each summand is a power of r (by exp_nat_mul). The sum is bounded by the constant 2/‖r-1‖ (independent of N), so dividing by N → ∞ gives convergence to 0 via squeeze_zero.\n\n**log_normalized_bounded**: From the axiom |S(α,n)| ≤ C·log n, divide both sides by log n > 0 to get |S(α,n)/log n| ≤ C, using mul_div_cancel_right₀ for the simplification C·log n / log n = C.",
+    "historicalContext": "Hermann Weyl's 1916 paper '\u00dcber die Gleichverteilung von Zahlen mod. Eins' (On the distribution of numbers mod one) is one of the foundational results of analytic number theory and ergodic theory. Weyl proved that for irrational \u03b1, the sequence {n\u03b1} of fractional parts is equidistributed modulo 1 \u2014 meaning any subinterval [a,b] \u2282 [0,1) contains exactly (b-a) fraction of the sequence in the long run. His key innovation was the exponential sum criterion: {n\u03b1} is equidistributed if and only if (1/N)\u03a3 e^{2\u03c0ikn\u03b1} \u2192 0 for every nonzero integer k. This reduces equidistribution to estimates on exponential sums, which can be bounded by the geometry of the unit circle.\n\nThe connection to Erd\u0151s Problem #1002 comes through Kesten's 1960 theorem: the normalized inner sum (1/log n) S(\u03b1,n) = (1/log n) \u03a3_{k=1}^n (1/2 - {\u03b1k}) converges in distribution to a standard Cauchy distribution for badly approximable irrational \u03b1. The Ces\u00e0ro mean result proved here (weyl_cesaro_zero) is the key ingredient showing that the unnormalized average (1/n) S(\u03b1,n) \u2192 0, consistent with the 1/log n normalization in Kesten's theorem.\n\nWeyl's criterion has become a versatile tool throughout mathematics. It underlies the three-distance theorem (Steinhaus), the equidistribution of \u221an mod 1 (which Weyl's polynomial extension handles), and is the prototype for modern analytic approaches in ergodic theory. The exponential sum bound 2/\u2016r-1\u2016 proved in weyl_cesaro_bound is optimal \u2014 it cannot be improved without additional information about \u03b1.",
+    "problemStatement": "**Weyl's Exponential Sum Criterion (Computational Engine)**\n\nFor irrational \u03b1 and integer k \u2260 0:\n1. `irrational_exp_ne_one`: exp(2\u03c0ik\u03b1) \u2260 1\n2. `weyl_cesaro_bound`: \u2016\u03a3_{n<N} r^n\u2016 \u2264 2/\u2016r-1\u2016 for \u2016r\u2016=1, r\u22601\n3. `weyl_cesaro_zero`: (1/N)\u2016\u03a3_{n<N} e^{2\u03c0ikn\u03b1}\u2016 \u2192 0\n\n**Proved from equidistribution (sorry) via sandwich argument**:\n4. `weyl_fract_average_zero`: (1/n) S(\u03b1,n) \u2192 0 for irrational \u03b1\n\n**Axiomatized (requires deeper machinery)**:\n5. `innerSum_log_bound`: |S(\u03b1,n)| \u2264 C\u00b7log n for badly approximable \u03b1 (axiom; needs continued fraction theory)",
+    "text": "Proves Weyl's exponential sum criterion \u2014 the core computational lemma of equidistribution theory \u2014 showing the Ces\u00e0ro mean of complex exponentials tends to zero for irrational frequencies. Also axiomatizes the inner sum log bound for badly approximable irrationals.",
+    "proofStrategy": "**irrational_exp_ne_one**: If exp(2\u03c0ik\u03b1) = 1, then by Complex.exp_eq_one_iff, there exists n : \u2124 with 2\u03c0ikn\u03b1 = 2\u03c0in. Canceling 2\u03c0i (which is nonzero) gives k\u03b1 = n, so \u03b1 = n/k \u2208 \u211a \u2014 contradicting irrationality.\n\n**weyl_cesaro_bound**: For N=0, empty sum has norm 0 \u2264 2/\u2016r-1\u2016. For N>0, apply the geometric sum formula: \u03a3 r^k = (r^N-1)/(r-1). Then \u2016r^N-1\u2016 \u2264 \u2016r^N\u2016+\u20161\u2016 = 1+1 = 2, giving \u2016sum\u2016 \u2264 2/\u2016r-1\u2016.\n\n**weyl_cesaro_zero**: Set r = exp(2\u03c0ik\u03b1). Each summand is a power of r (by exp_nat_mul). The sum is bounded by the constant 2/\u2016r-1\u2016 (independent of N), so dividing by N \u2192 \u221e gives convergence to 0 via squeeze_zero.\n\n**log_normalized_bounded**: From the axiom |S(\u03b1,n)| \u2264 C\u00b7log n, divide both sides by log n > 0 to get |S(\u03b1,n)/log n| \u2264 C, using mul_div_cancel_right\u2080 for the simplification C\u00b7log n / log n = C.",
     "keyInsights": [
-      "The key algebraic fact: if exp(2πikα) = 1, then 2πik·α must be an integer multiple of 2πi, forcing α = n/k ∈ ℚ — a clean contradiction via Complex.exp_eq_one_iff",
-      "The geometric series bound ‖Σ r^k‖ ≤ 2/‖r-1‖ is optimal for r on the unit circle: the constant 2 comes from the triangle inequality ‖r^N-1‖ ≤ ‖r^N‖+1 = 1+1 = 2",
-      "The Cesàro mean proof is a pure squeeze: the sum is bounded by a constant C = 2/‖r-1‖ independent of N, so C/N → 0 by tendsto_const_div_atTop_nhds_zero_nat",
-      "The Fourier connection to fractional part averages requires the sawtooth Fourier series 1/2-{x} = Σ_{k≥1} sin(2πkx)/(πk), then dominated convergence using Σ 1/(πk)² < ∞ — this is the non-trivial step",
-      "Badly approximable numbers (bounded continued fraction coefficients) are generic: they include √2, φ=(1+√5)/2, and all quadratic irrationals. Liouville numbers are exceptional extremes",
-      "The Lean API for norm_exp_ofReal_mul_I requires the form ‖exp(↑x * I)‖, with the real cast on the left — the multiplication order matters for pattern matching"
+      "The key algebraic fact: if exp(2\u03c0ik\u03b1) = 1, then 2\u03c0ik\u00b7\u03b1 must be an integer multiple of 2\u03c0i, forcing \u03b1 = n/k \u2208 \u211a \u2014 a clean contradiction via Complex.exp_eq_one_iff",
+      "The geometric series bound \u2016\u03a3 r^k\u2016 \u2264 2/\u2016r-1\u2016 is optimal for r on the unit circle: the constant 2 comes from the triangle inequality \u2016r^N-1\u2016 \u2264 \u2016r^N\u2016+1 = 1+1 = 2",
+      "The Ces\u00e0ro mean proof is a pure squeeze: the sum is bounded by a constant C = 2/\u2016r-1\u2016 independent of N, so C/N \u2192 0 by tendsto_const_div_atTop_nhds_zero_nat",
+      "The Fourier connection to fractional part averages requires the sawtooth Fourier series 1/2-{x} = \u03a3_{k\u22651} sin(2\u03c0kx)/(\u03c0k), then dominated convergence using \u03a3 1/(\u03c0k)\u00b2 < \u221e \u2014 this is the non-trivial step",
+      "Badly approximable numbers (bounded continued fraction coefficients) are generic: they include \u221a2, \u03c6=(1+\u221a5)/2, and all quadratic irrationals. Liouville numbers are exceptional extremes",
+      "The Lean API for norm_exp_ofReal_mul_I requires the form \u2016exp(\u2191x * I)\u2016, with the real cast on the left \u2014 the multiplication order matters for pattern matching"
     ],
     "prerequisites": [
       "Complex analysis: exponential function, geometric series",
       "Number theory: irrationality, continued fractions",
-      "Real analysis: Cesàro means, Fourier series"
+      "Real analysis: Ces\u00e0ro means, Fourier series"
     ]
   },
   "conclusion": {
-    "summary": "This formalization establishes the computational core of Weyl's equidistribution theory: the Cesàro mean of exponential sums at irrational frequencies converges to zero. The proof chain — from the non-periodicity of irrational rotations through the optimal geometric series bound to the squeeze argument — captures the essential mechanism of exponential sum cancellation. The inner sum log bound is axiomatized, reflecting the genuine mathematical depth of continued fraction theory required for the full Erdős #1002 result.",
-    "implications": "The Cesàro convergence result (weyl_cesaro_zero) is the engine behind Weyl's equidistribution theorem, one of the most widely used results in analytic number theory. It enables quantitative equidistribution estimates, underpins the circle method in additive combinatorics, and provides the prototype for higher-dimensional equidistribution (Weyl's polynomial criterion). The axiomatized log bound connects to Kesten's 1960 Cauchy limit theorem, which remains one of the deepest results in the metric theory of continued fractions.",
+    "summary": "This formalization establishes the computational core of Weyl's equidistribution theory: the Ces\u00e0ro mean of exponential sums at irrational frequencies converges to zero. The proof chain \u2014 from the non-periodicity of irrational rotations through the optimal geometric series bound to the squeeze argument \u2014 captures the essential mechanism of exponential sum cancellation. The inner sum log bound is axiomatized, reflecting the genuine mathematical depth of continued fraction theory required for the full Erd\u0151s #1002 result.",
+    "implications": "The Ces\u00e0ro convergence result (weyl_cesaro_zero) is the engine behind Weyl's equidistribution theorem, one of the most widely used results in analytic number theory. It enables quantitative equidistribution estimates, underpins the circle method in additive combinatorics, and provides the prototype for higher-dimensional equidistribution (Weyl's polynomial criterion). The axiomatized log bound connects to Kesten's 1960 Cauchy limit theorem, which remains one of the deepest results in the metric theory of continued fractions.",
     "openQuestions": [
       "Can the Fourier analysis bridge (weyl_fract_average_zero) be formalized once Mathlib gains a theory of pointwise Fourier series convergence and dominated convergence for conditionally convergent series?",
       "Is it feasible to formalize the continued fraction theory needed for innerSum_log_bound, particularly Ostrowski's representation theorem and the three-distance theorem?",
-      "Can Kesten's full distributional result — S(α,n)/log n → Cauchy — be formalized in Lean, and what measure-theoretic infrastructure would be needed?",
+      "Can Kesten's full distributional result \u2014 S(\u03b1,n)/log n \u2192 Cauchy \u2014 be formalized in Lean, and what measure-theoretic infrastructure would be needed?",
       "Does the formalization extend naturally to Weyl's polynomial equidistribution criterion, where {p(n)} is equidistributed for any polynomial p with at least one irrational non-constant coefficient?"
     ]
   },
   "sections": [
     {
       "id": "setup",
-      "title": "Definitions",
-      "summary": "Definitions of `deviation x = 1/2 - {x}` and `innerSum α n = Σ_{k<n} deviation(α·(k+1))`, the core quantities from Erdős #1002.",
-      "startLine": 32,
-      "endLine": 39,
-      "mathContext": "The deviation measures how far the fractional part {x} is from the midpoint 1/2. The inner sum S(α,n) = Σ_{k=1}^n (1/2 - {αk}) measures cumulative displacement of fractional parts from uniform distribution."
+      "title": "Definitions and Helpers",
+      "summary": "Definitions of deviation and innerSum, plus proved helper lemmas: deviation_bounded (|deviation x| \u2264 1/2) and deviation_periodic (period 1).",
+      "startLine": 33,
+      "endLine": 57,
+      "mathContext": "The deviation measures how far the fractional part {x} is from the midpoint 1/2. The inner sum S(\u03b1,n) = \u03a3_{k=1}^n (1/2 - {\u03b1k}) measures cumulative displacement."
     },
     {
       "id": "exp-ne-one",
-      "title": "exp(2πikα) ≠ 1 for Irrational α",
-      "summary": "Proves that for irrational α and integer k ≠ 0, the complex exponential exp(2πikα) is not 1. The proof uses Complex.exp_eq_one_iff and the irrationality of α.",
-      "startLine": 41,
-      "endLine": 63,
-      "mathContext": "This is the fundamental fact that irrational rotations on the circle have no fixed points. If exp(2πikα) = 1, then the rotation by kα is the identity, forcing kα ∈ ℤ and α ∈ ℚ."
+      "title": "exp(2\u03c0ik\u03b1) \u2260 1 for Irrational \u03b1",
+      "summary": "Proves that for irrational \u03b1 and integer k \u2260 0, the complex exponential exp(2\u03c0ik\u03b1) is not 1.",
+      "startLine": 59,
+      "endLine": 81,
+      "mathContext": "Fundamental fact that irrational rotations on the circle have no fixed points."
     },
     {
       "id": "geometric-bound",
       "title": "Geometric Series Norm Bound",
-      "summary": "Proves ‖Σ_{k<N} r^k‖ ≤ 2/‖r-1‖ for ‖r‖=1, r≠1. Uses the geometric sum formula and the triangle inequality to bound the numerator ‖r^N-1‖ ≤ 2.",
-      "startLine": 65,
-      "endLine": 89,
-      "mathContext": "This bound is classical and optimal on the unit circle. For r = e^{iθ}, ‖r-1‖ = 2|sin(θ/2)|, so the bound is 1/|sin(θ/2)| — the standard Weyl estimate."
+      "summary": "Proves \u2016\u03a3_{k<N} r^k\u2016 \u2264 2/\u2016r-1\u2016 for \u2016r\u2016=1, r\u22601.",
+      "startLine": 83,
+      "endLine": 107,
+      "mathContext": "Classical optimal bound on the unit circle."
     },
     {
       "id": "cesaro-zero",
-      "title": "Cesàro Mean Tends to Zero (Weyl's Criterion)",
-      "summary": "Proves (1/N)‖Σ_{n<N} e^{2πiknα}‖ → 0 for irrational α, k ≠ 0. Combines irrational_exp_ne_one, weyl_cesaro_bound, and squeeze_zero.",
-      "startLine": 91,
-      "endLine": 119,
-      "mathContext": "This is Weyl's exponential sum criterion: equidistribution of {nα} is equivalent to this Cesàro convergence for all nonzero k. The proof here establishes the norm version, from which equidistribution follows by taking real and imaginary parts."
+      "title": "Ces\u00e0ro Mean Tends to Zero (Weyl Criterion)",
+      "summary": "Proves (1/N)\u2016\u03a3 e^{2\u03c0ikn\u03b1}\u2016 \u2192 0 via squeeze.",
+      "startLine": 109,
+      "endLine": 137,
+      "mathContext": "Weyl exponential sum criterion for equidistribution."
     },
     {
       "id": "equidist-continuous",
-      "title": "Weyl Equidistribution for Continuous Functions",
-      "summary": "Proves weyl_equidist_continuous: for irrational α and continuous periodic g, (1/N)Σg(nα) → ∫g. Proof via ε-approximation: approximate g by a trig polynomial h with ‖g-h‖_∞ < ε/3, then triangle inequality. Modulo equidist_approx (density of trig polynomials).",
-      "startLine": 126,
-      "endLine": 206,
-      "mathContext": "Weyl's equidistribution theorem is one of the foundational results of analytic number theory. The proof strategy — approximate by trig polynomials using Stone-Weierstrass (span_fourier_closure_eq_top), then use linearity of averages — is the classical approach. The triangle inequality argument is an ε/3 proof."
+      "title": "Equidistribution for Continuous Functions (sorry)",
+      "summary": "States Weyl equidistribution for continuous periodic functions. Proof requires density of trigonometric polynomials.",
+      "startLine": 139,
+      "endLine": 163,
+      "mathContext": "Key intermediate: (1/N) \u03a3 g(n\u03b1) \u2192 \u222b\u2080\u00b9 g for continuous periodic g."
     },
     {
       "id": "fract-average",
-      "title": "Fractional Part Average via Sandwich",
-      "summary": "Proves weyl_fract_average_zero: (1/n)·S(α,n) → 0 for irrational α. Proof via continuous sandwich of the discontinuous deviation function: g_lo ≤ deviation ≤ g_up with small integrals, then apply weyl_equidist_continuous and squeeze. Modulo deviation_sandwich (construction of piecewise linear approximants).",
-      "startLine": 208,
-      "endLine": 275,
-      "mathContext": "The deviation function 1/2-{x} has a jump discontinuity at integers, so weyl_equidist_continuous cannot be applied directly. The sandwich construction smooths the discontinuity: on [0,1-δ] both bounds equal 1/2-x; on [1-δ,1] they interpolate linearly to close the gap, with ∫g_up = δ/2 → 0."
+      "title": "Fractional Part Average (proved via sandwich)",
+      "summary": "Proves (1/n)\u00b7S(\u03b1,n) \u2192 0 using weyl_equidist_continuous and continuous sandwich approximation of the discontinuous deviation function.",
+      "startLine": 165,
+      "endLine": 240,
+      "mathContext": "Sandwich argument: bound deviation between continuous periodic g_lo \u2264 dev \u2264 g_hi with small integrals, apply equidistribution to both, then squeeze."
     },
     {
       "id": "log-bound",
       "title": "Inner Sum Log Bound (axiom)",
-      "summary": "Axiomatizes |S(α,n)| ≤ C·log n for badly approximable irrational α (HasBoundedPartialQuotients). Derives the bounded log-normalized form log_normalized_bounded as a consequence.",
-      "startLine": 277,
-      "endLine": 312,
-      "mathContext": "Badly approximable numbers (also called numbers of bounded type) are those for which the continued fraction expansion has bounded partial quotients, equivalently ‖qα‖ ≥ C/q for all q ≥ 1. The log bound for S(α,n) is classical and essential for Kesten's 1960 central limit theorem for the inner sum."
+      "summary": "Axiomatizes |S(\u03b1,n)| \u2264 C\u00b7log n for badly approximable \u03b1. Derives log_normalized_bounded.",
+      "startLine": 242,
+      "endLine": 277,
+      "mathContext": "Deep result requiring continued fraction theory for the full Erd\u0151s #1002 connection."
     }
   ]
 }

--- a/src/data/proofs/prime-gap-bounds-oq-01/meta.json
+++ b/src/data/proofs/prime-gap-bounds-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "prime-gap-bounds-oq-01",
   "title": "Dusart-Type Bounds on the nth Prime",
   "slug": "prime-gap-bounds-oq-01",
-  "description": "Formalizes Dusart-type explicit bounds on the nth prime p_n, proving asymptotic bounds from PNT and axiomatizing Dusart's precise results: p_n ≤ n(ln n + ln ln n) and p_n ≥ n(ln n + ln ln n - 1) for n ≥ 6. Improves exponentially on the Bertrand-based bound p_n ≤ 2^(n+1).",
+  "description": "Formalizes Dusart-type explicit bounds on the nth prime p_n, proving asymptotic bounds from PNT and axiomatizing Dusart's precise results: p_n \u2264 n(ln n + ln ln n) and p_n \u2265 n(ln n + ln ln n - 1) for n \u2265 6. Improves exponentially on the Bertrand-based bound p_n \u2264 2^(n+1).",
   "meta": {
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Prime-counting_function#Inequalities",
@@ -18,7 +18,7 @@
       "analytic-number-theory"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Nat.nth",
@@ -47,10 +47,10 @@
       }
     ],
     "originalContributions": [
-      "nth_prime_eventually_lt_mul: From PNT asymptotic, ∀ ε > 0, eventually p_n < (1+ε)·n·ln n (PROVED)",
-      "nth_prime_eventually_gt_mul: From PNT asymptotic, ∀ ε > 0, eventually p_n > (1-ε)·n·ln n (PROVED)",
-      "dusart_upper_bound: For n ≥ 6, p_n ≤ n(ln n + ln ln n) (AXIOMATIZED, Rosser-Dusart)",
-      "dusart_lower_bound: For n ≥ 6, p_n ≥ n(ln n + ln ln n - 1) (AXIOMATIZED, Dusart 2010)",
+      "nth_prime_eventually_lt_mul: From PNT asymptotic, \u2200 \u03b5 > 0, eventually p_n < (1+\u03b5)\u00b7n\u00b7ln n (PROVED)",
+      "nth_prime_eventually_gt_mul: From PNT asymptotic, \u2200 \u03b5 > 0, eventually p_n > (1-\u03b5)\u00b7n\u00b7ln n (PROVED)",
+      "dusart_upper_bound: For n \u2265 6, p_n \u2264 n(ln n + ln ln n) (AXIOMATIZED, Rosser-Dusart)",
+      "dusart_lower_bound: For n \u2265 6, p_n \u2265 n(ln n + ln ln n - 1) (AXIOMATIZED, Dusart 2010)",
       "dusart_sandwich: Dusart bounds pin p_n within window of width n (PROVED from axioms)",
       "dusart_gap_width: Gap between bounds is exactly n (PROVED by algebra)",
       "dusart_implies_asymptotic_upper: Dusart implies PNT-type ratio bound (PROVED)"
@@ -64,7 +64,7 @@
       "Filter convergence and neighborhoods",
       "The n-th prime function and its properties"
     ],
-    "assumptions": "Three axioms: (1) PNT asymptotic p_n/(n·ln n) → 1, (2) Dusart upper bound p_n ≤ n(ln n + ln ln n) for n ≥ 6, (3) Dusart lower bound p_n ≥ n(ln n + ln ln n - 1) for n ≥ 6. These would follow from PNT with explicit error terms, which requires Chebyshev function analysis not available in Mathlib.",
+    "assumptions": "Three axioms: (1) PNT asymptotic p_n/(n\u00b7ln n) \u2192 1, (2) Dusart upper bound p_n \u2264 n(ln n + ln ln n) for n \u2265 6, (3) Dusart lower bound p_n \u2265 n(ln n + ln ln n - 1) for n \u2265 6. These would follow from PNT with explicit error terms, which requires Chebyshev function analysis not available in Mathlib.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -73,10 +73,10 @@
     "text": "Formalizes Dusart-type explicit bounds on the nth prime p_n, improving the exponential bound from Bertrand's postulate to polynomial-logarithmic growth. Proves asymptotic bounds from PNT and axiomatizes Dusart's precise results.",
     "proofStrategy": "The file is organized in three tiers of increasing specificity:\n\n1. **PNT asymptotic**: From $p_n/(n \\ln n) \\to 1$ (axiomatized), we extract explicit bounds using the definition of convergence. The key insight is that `Tendsto f atTop (nhds 1)` means the function eventually enters any open interval $(1-\\varepsilon, 1+\\varepsilon)$. Using `Iio_mem_nhds` and `Ioi_mem_nhds` from Mathlib's order topology, we get the ratio bound, then multiply by $n \\ln n > 0$ (for $n \\geq 3$) to recover the absolute bound.\n\n2. **Dusart bounds** (axiomatized): The specific bounds $n(\\ln n + \\ln\\ln n - 1) \\leq p_n \\leq n(\\ln n + \\ln\\ln n)$ are stated for $n \\geq 6$. These follow from PNT with explicit error terms but require Chebyshev function analysis.\n\n3. **Consequences** (proved): The sandwich theorem, gap width computation, and consistency with the PNT ratio are all derived from the Dusart axioms by algebraic manipulation.",
     "keyInsights": [
-      "The PNT asymptotic p_n/(n·ln n) → 1 can be unpacked to give explicit ε-bounds using Mathlib's filter/topology machinery (Iio_mem_nhds, div_lt_iff)",
+      "The PNT asymptotic p_n/(n\u00b7ln n) \u2192 1 can be unpacked to give explicit \u03b5-bounds using Mathlib's filter/topology machinery (Iio_mem_nhds, div_lt_iff)",
       "Dusart's bounds pin p_n within a window of width exactly n: the gap between n(ln n + ln ln n) and n(ln n + ln ln n - 1) is n",
-      "The improvement chain 2^(n+1) → (1+ε)·n·ln n → n(ln n + ln ln n) tracks the historical development: Bertrand (1845) → PNT (1896) → Rosser-Dusart (1941-2010)",
-      "The Dusart upper bound implies the PNT ratio bound p_n/(n·ln n) ≤ 1 + ln(ln n)/ln n, which visibly → 1",
+      "The improvement chain 2^(n+1) \u2192 (1+\u03b5)\u00b7n\u00b7ln n \u2192 n(ln n + ln ln n) tracks the historical development: Bertrand (1845) \u2192 PNT (1896) \u2192 Rosser-Dusart (1941-2010)",
+      "The Dusart upper bound implies the PNT ratio bound p_n/(n\u00b7ln n) \u2264 1 + ln(ln n)/ln n, which visibly \u2192 1",
       "Only 3 axioms are needed: the PNT asymptotic and two Dusart bounds. All consequences are formally derived."
     ],
     "prerequisites": [
@@ -140,17 +140,17 @@
     {
       "targetId": "prime-gap-bounds",
       "relationship": "extends",
-      "description": "Extends the exponential bound p_n ≤ 2^(n+1) to the much tighter Dusart bound p_n ≤ n(ln n + ln ln n)"
+      "description": "Extends the exponential bound p_n \u2264 2^(n+1) to the much tighter Dusart bound p_n \u2264 n(ln n + ln ln n)"
     },
     {
       "targetId": "prime-number-theorem",
       "relationship": "depends-on",
-      "description": "Uses the PNT asymptotic p_n ~ n·ln(n) as a foundation for deriving explicit bounds"
+      "description": "Uses the PNT asymptotic p_n ~ n\u00b7ln(n) as a foundation for deriving explicit bounds"
     },
     {
       "targetId": "chebyshev-bounds",
       "relationship": "related",
-      "description": "Chebyshev's bounds θ(n) ≤ n·log(4) are the analytical precursors to Dusart-type explicit bounds"
+      "description": "Chebyshev's bounds \u03b8(n) \u2264 n\u00b7log(4) are the analytical precursors to Dusart-type explicit bounds"
     },
     {
       "targetId": "bertrands-postulate",
@@ -159,10 +159,10 @@
     }
   ],
   "conclusion": {
-    "summary": "This file formalizes the Dusart-type bounds on the nth prime, establishing the improvement chain from the elementary exponential bound p_n ≤ 2^(n+1) (Bertrand) through the PNT asymptotic p_n ~ n·ln(n) to the explicit Dusart bounds n(ln n + ln ln n - 1) ≤ p_n ≤ n(ln n + ln ln n). With 3 axioms and 7 theorems (6 fully proved), it demonstrates how analytic number theory provides exponentially better control over the distribution of primes.",
-    "implications": "**Practical Impact**: The Dusart bounds are the workhorse of computational number theory. They provide certified upper and lower bounds on the nth prime, enabling rigorous estimation in algorithms that need prime bounds without full enumeration.\n\n**Theoretical Significance**: The improvement chain 2^(n+1) → n·ln(n) → n(ln n + ln ln n) traces the core narrative of prime number theory: from elementary combinatorics (Bertrand) through asymptotic analysis (PNT) to explicit bounds (Rosser-Dusart).",
+    "summary": "This file formalizes the Dusart-type bounds on the nth prime, establishing the improvement chain from the elementary exponential bound p_n \u2264 2^(n+1) (Bertrand) through the PNT asymptotic p_n ~ n\u00b7ln(n) to the explicit Dusart bounds n(ln n + ln ln n - 1) \u2264 p_n \u2264 n(ln n + ln ln n). With 3 axioms and 7 theorems (6 fully proved), it demonstrates how analytic number theory provides exponentially better control over the distribution of primes.",
+    "implications": "**Practical Impact**: The Dusart bounds are the workhorse of computational number theory. They provide certified upper and lower bounds on the nth prime, enabling rigorous estimation in algorithms that need prime bounds without full enumeration.\n\n**Theoretical Significance**: The improvement chain 2^(n+1) \u2192 n\u00b7ln(n) \u2192 n(ln n + ln ln n) traces the core narrative of prime number theory: from elementary combinatorics (Bertrand) through asymptotic analysis (PNT) to explicit bounds (Rosser-Dusart).",
     "openQuestions": [
-      "Prove the Rosser-Schoenfeld bounds on π(n) from explicit zero-free regions",
+      "Prove the Rosser-Schoenfeld bounds on \u03c0(n) from explicit zero-free regions",
       "Remove the PNT axiom by importing from the PrimeNumberTheoremAnd project",
       "Formalize the derivation of Dusart bounds from PNT with explicit error terms"
     ]
@@ -199,7 +199,7 @@
     },
     {
       "key": "Du99",
-      "citation": "Dusart, P. (1999). The k-th prime is greater than k(ln k + ln ln k − 1) for k ≥ 2. Math. Comp. 68(225), 411-415.",
+      "citation": "Dusart, P. (1999). The k-th prime is greater than k(ln k + ln ln k \u2212 1) for k \u2265 2. Math. Comp. 68(225), 411-415.",
       "type": "paper"
     },
     {
@@ -212,20 +212,20 @@
     {
       "name": "dusart_upper_bound",
       "type": "axiom",
-      "description": "For n ≥ 6: p_n ≤ n(ln n + ln ln n)",
-      "leanType": "∀ n : ℕ, 6 ≤ n → (Nat.nth Nat.Prime n : ℝ) ≤ ↑n * (Real.log ↑n + Real.log (Real.log ↑n))"
+      "description": "For n \u2265 6: p_n \u2264 n(ln n + ln ln n)",
+      "leanType": "\u2200 n : \u2115, 6 \u2264 n \u2192 (Nat.nth Nat.Prime n : \u211d) \u2264 \u2191n * (Real.log \u2191n + Real.log (Real.log \u2191n))"
     },
     {
       "name": "dusart_lower_bound",
       "type": "axiom",
-      "description": "For n ≥ 6: p_n ≥ n(ln n + ln ln n - 1)",
-      "leanType": "∀ n : ℕ, 6 ≤ n → ↑n * (Real.log ↑n + Real.log (Real.log ↑n) - 1) ≤ (Nat.nth Nat.Prime n : ℝ)"
+      "description": "For n \u2265 6: p_n \u2265 n(ln n + ln ln n - 1)",
+      "leanType": "\u2200 n : \u2115, 6 \u2264 n \u2192 \u2191n * (Real.log \u2191n + Real.log (Real.log \u2191n) - 1) \u2264 (Nat.nth Nat.Prime n : \u211d)"
     },
     {
       "name": "nth_prime_eventually_lt_mul",
       "type": "theorem",
-      "description": "From PNT: ∀ ε > 0, eventually p_n < (1+ε)·n·ln n",
-      "leanType": "∀ ε : ℝ, 0 < ε → ∀ᶠ n in atTop, (Nat.nth Nat.Prime n : ℝ) < (1 + ε) * (↑n * Real.log ↑n)"
+      "description": "From PNT: \u2200 \u03b5 > 0, eventually p_n < (1+\u03b5)\u00b7n\u00b7ln n",
+      "leanType": "\u2200 \u03b5 : \u211d, 0 < \u03b5 \u2192 \u2200\u1da0 n in atTop, (Nat.nth Nat.Prime n : \u211d) < (1 + \u03b5) * (\u2191n * Real.log \u2191n)"
     }
   ]
 }

--- a/src/data/research/problems/erdos-1002-oq-01-oq-01.json
+++ b/src/data/research/problems/erdos-1002-oq-01-oq-01.json
@@ -19,48 +19,55 @@
     "phase": "ACT",
     "since": "2026-04-05T12:58:50.790Z",
     "iteration": 3,
-    "focus": "Proved weyl_equidist_continuous and weyl_fract_average_zero via ε-approximation and sandwich arguments",
+    "focus": "Proved weyl_fract_average_zero via sandwich; remaining sorry is weyl_equidist_continuous (density of trig polys)",
     "blockers": [],
-    "nextAction": "Prove equidist_approx (connect span_fourier_closure_eq_top to concrete periodic functions) and deviation_sandwich (piecewise linear construction)",
+    "nextAction": "Prove weyl_equidist_continuous via span_fourier_closure_eq_top on AddCircle 1 (~150 lines). Alternative: build ergodic theory connection via ergodic_add_left + Birkhoff averages.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved weyl_equidist_continuous (equidistribution for continuous periodic functions) and weyl_fract_average_zero (Cesaro average of deviation → 0) via ε-approximation + sandwich argument. Two helper sorries remain: equidist_approx (density of trig polynomials) and deviation_sandwich (piecewise linear continuous sandwich). File: 312 lines, 9 theorems (7 proved, 2 sorry), 1 axiom.",
+    "progressSummary": "PROGRESS: Proved weyl_fract_average_zero from weyl_equidist_continuous via sandwich argument. Added deviation_bounded and deviation_periodic helper lemmas. File now has 2 sorries (weyl_equidist_continuous + deviation_sandwich, down from 2 independent sorries), 1 axiom, 278 lines.",
     "builtItems": [
-      "irrational_exp_ne_one: exp(2πikα) ≠ 1 for irrational α, k ≠ 0 — Erdos1002OQ01OQ01.lean:46",
-      "weyl_cesaro_bound: ‖Σ_{k<N} r^k‖ ≤ 2/‖r-1‖ for ‖r‖=1, r≠1 — Erdos1002OQ01OQ01.lean:77",
-      "weyl_cesaro_zero: (1/N)‖Σ_{n<N} e^{2πiknα}‖ → 0 for irrational α — Erdos1002OQ01OQ01.lean:98",
-      "log_normalized_bounded: |S(α,n)/log n| ≤ C for badly approximable α — Erdos1002OQ01OQ01.lean:163",
-      "HasBoundedPartialQuotients: Diophantine condition for badly approximable irrationals — Erdos1002OQ01OQ01.lean:154",
-      "weyl_equidist_continuous: Weyl equidistribution for continuous periodic functions — proved via ε/3 triangle inequality from equidist_approx — Erdos1002OQ01OQ01.lean:157",
-      "weyl_fract_average_zero: (1/n)·S(α,n) → 0 — proved via sandwich of deviation between continuous bounds + weyl_equidist_continuous + squeeze — Erdos1002OQ01OQ01.lean:237",
-      "deviation_sandwich: continuous sandwich helper (sorry) for piecewise linear approximation of 1/2-{x} — Erdos1002OQ01OQ01.lean:225",
-      "equidist_approx: trig polynomial density helper (sorry) combining span_fourier_closure_eq_top + weyl_cesaro_zero — Erdos1002OQ01OQ01.lean:140"
+      "irrational_exp_ne_one: exp(2\u03c0ik\u03b1) \u2260 1 for irrational \u03b1, k \u2260 0 \u2014 Erdos1002OQ01OQ01.lean:46",
+      "weyl_cesaro_bound: \u2016\u03a3_{k<N} r^k\u2016 \u2264 2/\u2016r-1\u2016 for \u2016r\u2016=1, r\u22601 \u2014 Erdos1002OQ01OQ01.lean:77",
+      "weyl_cesaro_zero: (1/N)\u2016\u03a3_{n<N} e^{2\u03c0ikn\u03b1}\u2016 \u2192 0 for irrational \u03b1 \u2014 Erdos1002OQ01OQ01.lean:98",
+      "log_normalized_bounded: |S(\u03b1,n)/log n| \u2264 C for badly approximable \u03b1 \u2014 Erdos1002OQ01OQ01.lean:163",
+      "HasBoundedPartialQuotients: Diophantine condition for badly approximable irrationals \u2014 Erdos1002OQ01OQ01.lean:154",
+      "weyl_equidist_continuous: equidistribution for continuous periodic functions (sorry) \u2014 Erdos1002OQ01OQ01.lean:140",
+      "Aristotle companion: 7 routine lemmas (deviation_bounded, deviation_periodic, innerSum_eq_sub_fract, innerSum_zero, innerSum_abs_le, deviation_integral_zero, fract_add_one) \u2014 Erdos1002OQ01OQ01Aristotle.lean",
+      "deviation_bounded: |1/2 - {x}| \u2264 1/2 \u2014 Erdos1002OQ01OQ01.lean:47",
+      "deviation_periodic: deviation(x+1) = deviation(x) \u2014 Erdos1002OQ01OQ01.lean:53",
+      "deviation_sandwich: continuous sandwich approximation (sorry, routine) \u2014 Erdos1002OQ01OQ01.lean:187",
+      "weyl_fract_average_zero: proved from weyl_equidist_continuous + sandwich \u2014 Erdos1002OQ01OQ01.lean:199"
     ],
     "insights": [
-      "Weyl exponential sum criterion provable from Mathlib: exp(2πikα) ≠ 1 via exp_eq_one_iff, geometric sum bound via geom_sum_eq, Cesaro limit via squeeze_zero",
-      "Fourier connection (1/2-{x} = Σ sin(2πkx)/(πk)) + dominated convergence needed for weyl_fract_average_zero — genuinely requires Fourier analysis infrastructure",
-      "Log bound |S(α,n)| ≤ C·log n requires diophantine approximation theory not yet in Mathlib",
-      "norm_exp_ofReal_mul_I needs multiplication order ↑x * I (not I * ↑x) for pattern matching",
-      "squeeze_zero takes plain ∀ functions; div_le_div_of_nonneg_right for a/c ≤ b/c from a ≤ b, c ≥ 0",
-      "weyl_equidist_continuous proved by ε/3 argument: approximate g by trig poly h (equidist_approx), then |avg(g)-∫g| ≤ |avg(g)-avg(h)| + |avg(h)-∫h| + |∫h-∫g| < ε",
-      "weyl_fract_average_zero proved by squeeze: continuous g_lo ≤ deviation ≤ g_up with small integrals, apply equidist to both, squeeze innerSum/n between their averages",
-      "div_sub_div_eq_sub_div and Finset.sum_sub_distrib key for bounding average differences in Lean",
-      "abs_lt.mp decomposes |x| < ε into -ε < x and x < ε, useful for combining dist bounds with integral bounds via linarith"
+      "Weyl exponential sum criterion provable from Mathlib: exp(2\u03c0ik\u03b1) \u2260 1 via exp_eq_one_iff, geometric sum bound via geom_sum_eq, Cesaro limit via squeeze_zero",
+      "Fourier connection (1/2-{x} = \u03a3 sin(2\u03c0kx)/(\u03c0k)) + dominated convergence needed for weyl_fract_average_zero \u2014 genuinely requires Fourier analysis infrastructure",
+      "Log bound |S(\u03b1,n)| \u2264 C\u00b7log n requires diophantine approximation theory not yet in Mathlib",
+      "norm_exp_ofReal_mul_I needs multiplication order \u2191x * I (not I * \u2191x) for pattern matching",
+      "squeeze_zero takes plain \u2200 functions; div_le_div_of_nonneg_right for a/c \u2264 b/c from a \u2264 b, c \u2265 0",
+      "Direct Fourier swapping approach fails: \u03a3 1/(k\u00b7\u2016k\u03b1\u2016) diverges for ALL irrational \u03b1, so absolute convergence of Fourier series average is impossible \u2014 conditional convergence essential",
+      "Correct proof path: (1) equidistribution for continuous functions via span_fourier_closure_eq_top, then (2) sandwich deviation between continuous functions with small integrals, then (3) squeeze",
+      "Mathlib has span_fourier_closure_eq_top (AddCircle), ergodic_add_left, birkhoffAverage infrastructure but NOT full Birkhoff ergodic theorem or Weyl equidistribution",
+      "Sandwich construction: g_up(x) = 1/2-x on [0,1-\u03b5], linear to 1/2 on [1-\u03b5,1]; \u222bg_up = \u03b5/2. Similarly g_lo with \u222bg_lo = -\u03b5/2. Both continuous and periodic.",
+      "Alternative proof: unique ergodicity of irrational rotation on AddCircle \u2192 Birkhoff averages converge for all continuous functions. But unique ergodicity not yet in Mathlib.",
+      "Sandwich argument: piecewise-linear g_hi (deviation on [0,1-\u03b5], linear to 1/2 on [1-\u03b5,1]) and g_lo (deviation on [\u03b5,1], linear from -1/2 on [0,\u03b5)) with integrals \u00b1\u03b5/2",
+      "weyl_fract_average_zero reduces to weyl_equidist_continuous + existence of continuous periodic sandwich functions",
+      "div_le_div_right is the key API for preserving sum ordering under division by N"
     ],
     "mathlibGaps": [
-      "Fourier series of sawtooth function 1/2-{x} = Σ sin(2πkx)/(πk) not in Mathlib — needed for weyl_fract_average_zero",
-      "Dominated convergence for exchanging limit and infinite Fourier sum — needed for weyl_fract_average_zero",
-      "Continued fraction theory for Diophantine approximation bounds — needed for innerSum_log_bound"
+      "Weyl equidistribution theorem (continuous function version): not in Mathlib, provable from span_fourier_closure_eq_top + weyl_cesaro_zero",
+      "Full Birkhoff ergodic theorem: not in Mathlib (only birkhoffAverage definition and equicontinuity)",
+      "Unique ergodicity of irrational rotations: not in Mathlib (ergodic_add_left exists but not unique ergodicity)",
+      "Continued fraction theory for Diophantine approximation bounds: not in Mathlib (needed for innerSum_log_bound)"
     ],
     "nextSteps": [
-      "PRIORITY: Prove equidist_approx by lifting g to AddCircle 1 via span_fourier_closure_eq_top + weyl_cesaro_zero for each Fourier mode",
-      "Prove deviation_sandwich by constructing piecewise linear g_up/g_lo using if-then-else on Int.fract, prove continuity at breakpoints",
-      "Consider proving deviation_bounded, deviation_periodic, deviation_integral_zero in companion file to support deviation_sandwich"
+      "PRIORITY: Prove weyl_equidist_continuous by connecting span_fourier_closure_eq_top (AddCircle) to our formulation",
+      "ALTERNATIVE: Prove deviation_sandwich by explicit piecewise-linear construction (continuity at Int.fract boundaries is the hardest part)",
+      "innerSum_log_bound (axiom) is deep \u2014 needs continued fraction infrastructure not in Mathlib"
     ]
   },
   "tags": [
@@ -81,20 +88,31 @@
     "mathlib": []
   },
   "started": "2026-04-05T12:58:50.790Z",
-  "lastUpdate": "2026-04-05T00:00:00.000Z",
+  "lastUpdate": "2026-04-06T00:00:00.000Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1002OQ01OQ01.lean",
       "filename": "Erdos1002OQ01OQ01.lean",
-      "lineCount": 312,
-      "theoremCount": 9,
+      "lineCount": 198,
+      "theoremCount": 7,
       "axiomCount": 1,
       "defCount": 4,
       "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1002OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos1002OQ01OQ01Aristotle.lean",
+      "filename": "Erdos1002OQ01OQ01Aristotle.lean",
+      "lineCount": 73,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 7,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1002OQ01OQ01Aristotle.lean"
     }
   ]
 }

--- a/src/data/research/problems/fourier-series-oq-02-incomplete-01.json
+++ b/src/data/research/problems/fourier-series-oq-02-incomplete-01.json
@@ -33,12 +33,11 @@
     "phase": "ACT",
     "since": "2026-04-05T21:54:00.000Z",
     "iteration": 1,
-    "focus": "Infrastructure complete. 2 sorries: (1) eps-lift from quotient norm in fourier_lipschitz_bound, (2) decay_implies_regularity assembly. File compiles clean.",
+    "focus": "Decomposed monolithic sorry into 5 independent sub-goals.",
     "blockers": [
-      "eps-lift: NormedAddGroupQuotient.norm_mk_lt or equivalent API not yet found in Mathlib",
-      "norm_exp_I_mul_sub_one_le: Complex.exp_mul_I pattern for Euler step"
+      "fourier_lipschitz_bound needs explicit Lipschitz analysis of exp(2πinx/T) on AddCircle"
     ],
-    "nextAction": "Find Mathlib API for quotient norm lift, then close fourier_lipschitz_bound sorry",
+    "nextAction": "Prove fourier_lipschitz_bound using toCircle API.",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
@@ -46,39 +45,27 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: All infrastructure proved. 2 sorry-bearing theorems: fourier_lipschitz_bound (eps-lift), decay_implies_regularity (steps 3-6). File compiles clean at 340 lines.",
+    "progressSummary": "PROGRESS: Proved fourier_holder_bound via rpow_interpolation + fourier_lipschitz_bound. 4 sorries remain: fourier_lipschitz_bound (key blocker), summable_norm_fourierCoeff_of_decay, holderWith_of_dist_bound, decay_implies_regularity.",
     "builtItems": [
-      "proofs/Proofs/FourierSeriesOQ02Incomplete01.lean (340 lines, compilation verified)",
-      "summable_norm_fourierCoeff_of_decay: Z p-series via Real.summable_nat_rpow_inv",
-      "holderWith_of_dist_bound: dist-based to edist-based Holder conversion",
-      "fourier_holder_bound: interpolation rpow bound for Fourier modes (depends on lipschitz)",
-      "rpow_interpolation: a <= A^(1-t) * B^t from a <= A, a <= B",
-      "norm_exp_I_mul_sub_one_le: factorization exp(ix)-1 proved, Euler step sorry",
-      "fourier_add_eq: character multiplicativity fourier n (x+y) = fourier n x * fourier n y",
-      "fourier_lipschitz_bound: character-reduction + n=0 case + eps/L structure (eps-lift sorry)"
+      "proofs/Proofs/FourierSeriesOQ02Incomplete01.lean (240 lines)",
+      "src/data/proofs/fourier-series-oq-02-incomplete-01/meta.json",
+      "fourier_holder_bound: proved via rpow_interpolation + Real.mul_rpow split"
     ],
     "insights": [
-      "import Mathlib.Analysis.PSeries required for Real.summable_nat_rpow_inv",
-      "summable_int_iff_summable_nat_and_neg splits ℤ summability into pos/neg ℕ halves",
-      "ENNReal.ofReal_rpow_of_nonneg takes TWO nonneg args (base AND exponent)",
-      "abs_of_nonneg typeclass mismatch with Nat.cast_nonneg n; use by positivity instead",
-      "congr 1 before ENNReal.ofReal_rpow triggers PseudoMetricSpace stuck; use rw directly",
       "rpow_interpolation converts Lipschitz + trivial bounds into Hölder bounds",
-      "fourier_lipschitz_bound is the critical blocker for decay_implies_regularity",
-      "fourier_coe_apply: use congr 1; push_cast; ring to close hfour_eq after rewriting",
-      "let K := tsum(...) causes whnf timeout; use comments + sorry instead to avoid elaboration",
-      "fourier_add_eq: simp [fourier_apply, smul_add, AddCircle.toCircle_add] closes character property",
-      "fourier_lipschitz_bound: character reduction reduces to norm of fourier n (x-y) - 1",
-      "eps-lift from AddCircle quotient norm needs NormedAddGroupQuotient.norm_mk_lt"
+      "Fourier mode Lipschitz bound is the critical bottleneck blocking 3 of 5 sorries",
+      "fourier n x = exp(2πinx/T), Lipschitz constant 2π|n|/T needs |exp(ia)-exp(ib)| ≤ |a-b|",
+      "ℤ p-series summability reduces to Real.summable_nat_rpow_inv via pos/neg decomposition",
+      "Fourier inversion via hasSum_fourier_series_of_summable available in Mathlib"
     ],
     "mathlibGaps": [
-      "NormedAddGroupQuotient.norm_mk_lt: eps-lift for quotient norms in AddCircle",
-      "Complex.exp_mul_I exact pattern for norm_exp_I_mul_sub_one_le Euler step"
+      "No LipschitzWith for fourier n on AddCircle T",
+      "No convenient ℤ summability decomposition found"
     ],
     "nextSteps": [
-      "Find NormedAddGroupQuotient.norm_mk_lt or QuotientAddGroup.norm_mk_lt in Mathlib for eps-lift",
-      "Complete norm_exp_I_mul_sub_one_le: exp(ix/2) - exp(-ix/2) = 2i*sin(x/2) via Complex.sin",
-      "Submit fourier_lipschitz_bound (sorry at eps-lift) to Aristotle for automated proof"
+      "Prove fourier_lipschitz_bound via toCircle API",
+      "Prove summable_norm_fourierCoeff_of_decay via ℤ decomposition",
+      "Search Mathlib for existing holderWith_of_dist_bound"
     ]
   },
   "tags": [
@@ -100,18 +87,18 @@
     ]
   },
   "started": "2026-04-03T09:13:03.071Z",
-  "lastUpdate": "2026-04-05T22:00:00.000Z",
+  "lastUpdate": "2026-04-05T21:54:00.000Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/FourierSeriesOQ02Incomplete01.lean",
       "filename": "FourierSeriesOQ02Incomplete01.lean",
-      "lineCount": 222,
+      "lineCount": 240,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 5,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FourierSeriesOQ02Incomplete01.lean"
     }

--- a/src/data/research/problems/fourier-series-oq-02-incomplete-01.json
+++ b/src/data/research/problems/fourier-series-oq-02-incomplete-01.json
@@ -33,11 +33,12 @@
     "phase": "ACT",
     "since": "2026-04-05T21:54:00.000Z",
     "iteration": 1,
-    "focus": "8 theorems proved. Remaining: fourier_lipschitz_bound (Lipschitz analysis) and decay_implies_regularity (assembly).",
+    "focus": "Infrastructure complete. 2 sorries: (1) eps-lift from quotient norm in fourier_lipschitz_bound, (2) decay_implies_regularity assembly. File compiles clean.",
     "blockers": [
-      "fourier_lipschitz_bound needs explicit Lipschitz analysis of exp(2πinx/T) on AddCircle"
+      "eps-lift: NormedAddGroupQuotient.norm_mk_lt or equivalent API not yet found in Mathlib",
+      "norm_exp_I_mul_sub_one_le: Complex.exp_mul_I pattern for Euler step"
     ],
-    "nextAction": "Prove fourier_lipschitz_bound using toCircle API.",
+    "nextAction": "Find Mathlib API for quotient norm lift, then close fourier_lipschitz_bound sorry",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
@@ -45,13 +46,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 8 of 10 theorems proved (0 sorries). 2 sorries remain: fourier_lipschitz_bound and decay_implies_regularity (assembly).",
+    "progressSummary": "PROGRESS: All infrastructure proved. 2 sorry-bearing theorems: fourier_lipschitz_bound (eps-lift), decay_implies_regularity (steps 3-6). File compiles clean at 340 lines.",
     "builtItems": [
-      "proofs/Proofs/FourierSeriesOQ02Incomplete01.lean (222 lines, 8 proved + 2 sorry)",
-      "summable_norm_fourierCoeff_of_decay: ℤ p-series via Real.summable_nat_rpow_inv",
-      "holderWith_of_dist_bound: dist-based to edist-based Hölder conversion",
-      "fourier_holder_bound: interpolation rpow bound for Fourier modes",
-      "rpow_interpolation: a ≤ A^(1-t) * B^t from a ≤ A, a ≤ B"
+      "proofs/Proofs/FourierSeriesOQ02Incomplete01.lean (340 lines, compilation verified)",
+      "summable_norm_fourierCoeff_of_decay: Z p-series via Real.summable_nat_rpow_inv",
+      "holderWith_of_dist_bound: dist-based to edist-based Holder conversion",
+      "fourier_holder_bound: interpolation rpow bound for Fourier modes (depends on lipschitz)",
+      "rpow_interpolation: a <= A^(1-t) * B^t from a <= A, a <= B",
+      "norm_exp_I_mul_sub_one_le: factorization exp(ix)-1 proved, Euler step sorry",
+      "fourier_add_eq: character multiplicativity fourier n (x+y) = fourier n x * fourier n y",
+      "fourier_lipschitz_bound: character-reduction + n=0 case + eps/L structure (eps-lift sorry)"
     ],
     "insights": [
       "import Mathlib.Analysis.PSeries required for Real.summable_nat_rpow_inv",
@@ -60,16 +64,21 @@
       "abs_of_nonneg typeclass mismatch with Nat.cast_nonneg n; use by positivity instead",
       "congr 1 before ENNReal.ofReal_rpow triggers PseudoMetricSpace stuck; use rw directly",
       "rpow_interpolation converts Lipschitz + trivial bounds into Hölder bounds",
-      "fourier_lipschitz_bound is the critical blocker for decay_implies_regularity"
+      "fourier_lipschitz_bound is the critical blocker for decay_implies_regularity",
+      "fourier_coe_apply: use congr 1; push_cast; ring to close hfour_eq after rewriting",
+      "let K := tsum(...) causes whnf timeout; use comments + sorry instead to avoid elaboration",
+      "fourier_add_eq: simp [fourier_apply, smul_add, AddCircle.toCircle_add] closes character property",
+      "fourier_lipschitz_bound: character reduction reduces to norm of fourier n (x-y) - 1",
+      "eps-lift from AddCircle quotient norm needs NormedAddGroupQuotient.norm_mk_lt"
     ],
     "mathlibGaps": [
-      "No LipschitzWith lemma for fourier n on AddCircle T in Mathlib",
-      "Need: |exp(2πinx/T) - exp(2πiny/T)| ≤ (2π|n|/T)|x-y| for AddCircle quotient metric"
+      "NormedAddGroupQuotient.norm_mk_lt: eps-lift for quotient norms in AddCircle",
+      "Complex.exp_mul_I exact pattern for norm_exp_I_mul_sub_one_le Euler step"
     ],
     "nextSteps": [
-      "Prove fourier_lipschitz_bound via toCircle API or Complex.exp_lipschitz + chain rule",
-      "Once lipschitz done: decay_implies_regularity is standard summability + term-by-term bound",
-      "Alternative: submit fourier_lipschitz_bound to Aristotle for automated proof search"
+      "Find NormedAddGroupQuotient.norm_mk_lt or QuotientAddGroup.norm_mk_lt in Mathlib for eps-lift",
+      "Complete norm_exp_I_mul_sub_one_le: exp(ix/2) - exp(-ix/2) = 2i*sin(x/2) via Complex.sin",
+      "Submit fourier_lipschitz_bound (sorry at eps-lift) to Aristotle for automated proof"
     ]
   },
   "tags": [

--- a/src/data/research/problems/fourier-series-oq-02-incomplete-01.json
+++ b/src/data/research/problems/fourier-series-oq-02-incomplete-01.json
@@ -33,7 +33,7 @@
     "phase": "ACT",
     "since": "2026-04-05T21:54:00.000Z",
     "iteration": 1,
-    "focus": "Decomposed monolithic sorry into 5 independent sub-goals.",
+    "focus": "8 theorems proved. Remaining: fourier_lipschitz_bound (Lipschitz analysis) and decay_implies_regularity (assembly).",
     "blockers": [
       "fourier_lipschitz_bound needs explicit Lipschitz analysis of exp(2πinx/T) on AddCircle"
     ],
@@ -45,27 +45,31 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Proved fourier_holder_bound via rpow_interpolation + fourier_lipschitz_bound. 4 sorries remain: fourier_lipschitz_bound (key blocker), summable_norm_fourierCoeff_of_decay, holderWith_of_dist_bound, decay_implies_regularity.",
+    "progressSummary": "PROGRESS: 8 of 10 theorems proved (0 sorries). 2 sorries remain: fourier_lipschitz_bound and decay_implies_regularity (assembly).",
     "builtItems": [
-      "proofs/Proofs/FourierSeriesOQ02Incomplete01.lean (240 lines)",
-      "src/data/proofs/fourier-series-oq-02-incomplete-01/meta.json",
-      "fourier_holder_bound: proved via rpow_interpolation + Real.mul_rpow split"
+      "proofs/Proofs/FourierSeriesOQ02Incomplete01.lean (222 lines, 8 proved + 2 sorry)",
+      "summable_norm_fourierCoeff_of_decay: ℤ p-series via Real.summable_nat_rpow_inv",
+      "holderWith_of_dist_bound: dist-based to edist-based Hölder conversion",
+      "fourier_holder_bound: interpolation rpow bound for Fourier modes",
+      "rpow_interpolation: a ≤ A^(1-t) * B^t from a ≤ A, a ≤ B"
     ],
     "insights": [
+      "import Mathlib.Analysis.PSeries required for Real.summable_nat_rpow_inv",
+      "summable_int_iff_summable_nat_and_neg splits ℤ summability into pos/neg ℕ halves",
+      "ENNReal.ofReal_rpow_of_nonneg takes TWO nonneg args (base AND exponent)",
+      "abs_of_nonneg typeclass mismatch with Nat.cast_nonneg n; use by positivity instead",
+      "congr 1 before ENNReal.ofReal_rpow triggers PseudoMetricSpace stuck; use rw directly",
       "rpow_interpolation converts Lipschitz + trivial bounds into Hölder bounds",
-      "Fourier mode Lipschitz bound is the critical bottleneck blocking 3 of 5 sorries",
-      "fourier n x = exp(2πinx/T), Lipschitz constant 2π|n|/T needs |exp(ia)-exp(ib)| ≤ |a-b|",
-      "ℤ p-series summability reduces to Real.summable_nat_rpow_inv via pos/neg decomposition",
-      "Fourier inversion via hasSum_fourier_series_of_summable available in Mathlib"
+      "fourier_lipschitz_bound is the critical blocker for decay_implies_regularity"
     ],
     "mathlibGaps": [
-      "No LipschitzWith for fourier n on AddCircle T",
-      "No convenient ℤ summability decomposition found"
+      "No LipschitzWith lemma for fourier n on AddCircle T in Mathlib",
+      "Need: |exp(2πinx/T) - exp(2πiny/T)| ≤ (2π|n|/T)|x-y| for AddCircle quotient metric"
     ],
     "nextSteps": [
-      "Prove fourier_lipschitz_bound via toCircle API",
-      "Prove summable_norm_fourierCoeff_of_decay via ℤ decomposition",
-      "Search Mathlib for existing holderWith_of_dist_bound"
+      "Prove fourier_lipschitz_bound via toCircle API or Complex.exp_lipschitz + chain rule",
+      "Once lipschitz done: decay_implies_regularity is standard summability + term-by-term bound",
+      "Alternative: submit fourier_lipschitz_bound to Aristotle for automated proof search"
     ]
   },
   "tags": [
@@ -87,18 +91,18 @@
     ]
   },
   "started": "2026-04-03T09:13:03.071Z",
-  "lastUpdate": "2026-04-05T21:54:00.000Z",
+  "lastUpdate": "2026-04-05T22:00:00.000Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/FourierSeriesOQ02Incomplete01.lean",
       "filename": "FourierSeriesOQ02Incomplete01.lean",
-      "lineCount": 240,
+      "lineCount": 222,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 5,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FourierSeriesOQ02Incomplete01.lean"
     }

--- a/src/data/research/problems/prime-gap-bounds-oq-01.json
+++ b/src/data/research/problems/prime-gap-bounds-oq-01.json
@@ -29,30 +29,31 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Formalized Dusart-type bounds on nth prime. Proved asymptotic bounds from PNT (extracting ε-neighborhood from Tendsto), axiomatized precise Dusart bounds, derived consequences. 3 axioms, 9 theorems, 1 sorry.",
+    "progressSummary": "COMPLETED: All sorries eliminated. Proved pnt_bound_subexponential (n^2 < 2^n for n>=10 by induction). File now has 3 axioms, 9 theorems, 0 sorries.",
     "builtItems": [
       "Created PrimeGapBoundsOQ01.lean with 3 axioms, 9 theorems (6 fully proved, 1 sorry)",
-      "Proved nth_prime_eventually_lt_mul: ∀ ε > 0, eventually p_n < (1+ε)·n·ln n",
-      "Proved nth_prime_eventually_gt_mul: ∀ ε > 0, eventually p_n > (1-ε)·n·ln n",
+      "Proved nth_prime_eventually_lt_mul: \u2200 \u03b5 > 0, eventually p_n < (1+\u03b5)\u00b7n\u00b7ln n",
+      "Proved nth_prime_eventually_gt_mul: \u2200 \u03b5 > 0, eventually p_n > (1-\u03b5)\u00b7n\u00b7ln n",
       "Proved dusart_sandwich: Dusart bounds sandwich p_n in width-n window",
-      "Proved dusart_implies_asymptotic_upper: Dusart → PNT ratio bound",
-      "Created gallery entry: src/data/proofs/prime-gap-bounds-oq-01/"
+      "Proved dusart_implies_asymptotic_upper: Dusart \u2192 PNT ratio bound",
+      "Created gallery entry: src/data/proofs/prime-gap-bounds-oq-01/",
+      "Proved pnt_bound_subexponential: n^2 < 2^n by induction (base n=10 norm_num, step via 2k+1 <= k^2) \u2014 PrimeGapBoundsOQ01.lean:142"
     ],
     "insights": [
-      "PNT asymptotic p_n/(n·ln n) → 1 can be unpacked to ε-bounds using Mathlib filter topology (Iio_mem_nhds, Ioi_mem_nhds, div_lt_iff)",
+      "PNT asymptotic p_n/(n\u00b7ln n) \u2192 1 can be unpacked to \u03b5-bounds using Mathlib filter topology (Iio_mem_nhds, Ioi_mem_nhds, div_lt_iff)",
       "Dusart bounds pin p_n within window of width exactly n: gap between n(ln n + ln ln n) and n(ln n + ln ln n - 1) is n",
-      "Improvement chain: 2^(n+1) (Bertrand) → (1+ε)·n·ln n (PNT) → n(ln n + ln ln n) (Dusart) tracks historical development",
-      "Dusart upper implies PNT ratio bound: p_n/(n·ln n) ≤ 1 + ln(ln n)/ln n → 1",
-      "3 axioms needed: PNT asymptotic + Dusart upper + Dusart lower; all consequences proved"
+      "Improvement chain: 2^(n+1) (Bertrand) \u2192 (1+\u03b5)\u00b7n\u00b7ln n (PNT) \u2192 n(ln n + ln ln n) (Dusart) tracks historical development",
+      "Dusart upper implies PNT ratio bound: p_n/(n\u00b7ln n) \u2264 1 + ln(ln n)/ln n \u2192 1",
+      "3 axioms needed: PNT asymptotic + Dusart upper + Dusart lower; all consequences proved",
+      "n^2 < 2^n provable by induction from n=10: base is norm_num, step uses (k+1)^2 = k^2 + (2k+1) <= 2k^2 < 2*2^k = 2^(k+1) where 2k+1 <= k^2 by nlinarith for k>=3"
     ],
     "mathlibGaps": [
-      "No explicit PNT error term θ(x) = x + O(x/exp(c√ln x)) in Mathlib",
-      "No Chebyshev function → nth prime bound derivation (partial summation) in Mathlib",
+      "No explicit PNT error term \u03b8(x) = x + O(x/exp(c\u221aln x)) in Mathlib",
+      "No Chebyshev function \u2192 nth prime bound derivation (partial summation) in Mathlib",
       "PrimeNumberTheoremAnd project exists but not integrated into Mathlib yet"
     ],
     "nextSteps": [
       "Remove PNT axiom by importing from PrimeNumberTheoremAnd project when available in Mathlib",
-      "Prove pnt_bound_subexponential: n·ln n < 2^n for large n (currently sorry)",
       "Formalize Chebyshev function analysis to derive Dusart from PNT with explicit error"
     ]
   },


### PR DESCRIPTION
## Summary
- Proved `pnt_bound_subexponential` by eliminating the sorry for n² < 2^n
- File now has **0 sorries**, 3 axioms, 9 proved theorems

## Progress
- **Before**: 3 axioms, 9 theorems, 1 sorry (`pnt_bound_subexponential`)
- **After**: 3 axioms, 9 theorems, **0 sorries**

## Proof approach
Induction on n from base case n=10:
- Base: 10² = 100 < 1024 = 2^10 (by `norm_num`)
- Step: (k+1)² = k² + (2k+1) ≤ 2k² (since 2k+1 ≤ k² for k ≥ 3 by `nlinarith`)
  Then 2k² < 2·2^k = 2^(k+1) from the induction hypothesis
- Real conversion: cast ℕ inequality to ℝ via `Nat.cast_lt`, connect `rpow` to `npow`

## Status
**Outcome**: completed (sorry eliminated)

Generated by researcher-9