### PR TITLE
fix: sync stale sorry counts in 12 gallery proofs

### DIFF
--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -13,10 +13,10 @@
       "tournaments"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 3,
     "axiomCount": 0,
     "lineCount": 1285,
-    "assumptions": "0 axioms. 1 sorry in Ghouila-Houri helper: ghouila_houri_cycle_extendable (cycle of length k < n → longer cycle under GH degree conditions). sc_degree_has_cycle (SC + high degree → initial directed cycle) is now fully proved via greedy path extension and back-arc argument. directed_hamiltonian_threshold is fully proved (0 sorries). Moon-Moser theorem and Rédei are also fully proved.",
+    "assumptions": "0 axioms. 3 sorry(s) remain. See the Lean source for details.",
     "dateAdded": "2026-03-30",
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Hamiltonian_path_problem#Directed_graphs",
@@ -125,7 +125,7 @@
     "namespace": "Erdos1012OQ03",
     "lineCount": 1285,
     "axiomCount": 0,
-    "sorries": 1,
+    "sorries": 3,
     "path": "Proofs/Erdos1012OQ03.lean",
     "theoremCount": 22,
     "definitionCount": 10

--- a/src/data/proofs/erdos-490/meta.json
+++ b/src/data/proofs/erdos-490/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 6,
+    "sorries": 3,
     "erdosNumber": 490,
     "erdosUrl": "https://erdosproblems.com/490",
     "erdosProblemStatus": "solved",
@@ -71,7 +71,7 @@
     ],
     "axiomCount": 2,
     "lineCount": 282,
-    "assumptions": "6 axiom(s) and 6 sorry(s). See the Lean source for details."
+    "assumptions": "2 axiom(s) and 3 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "Erdős posed Problem #490 at the 1972 Number Theory Conference at the University of Colorado, asking for the maximum of $|A||B|$ when $A, B \\subseteq \\{1,\\ldots,N\\}$ have all products $ab$ distinct. The problem sits at the intersection of multiplicative number theory and extremal combinatorics.\n\nSzemerédi resolved the problem in 1976 in his paper \"On a problem of P. Erdős\" in the Journal of Number Theory, proving that $|A||B| \\ll N^2/\\log N$. His argument is a counting argument based on the divisor function: the total number of divisor pairs $(a,b)$ with $ab \\leq N^2$ is $\\sum_{n \\leq N^2} d(n) \\sim N^2 \\log N$, but the distinct products condition restricts each $n$ to contribute at most one pair, yielding the $\\log N$ savings.\n\nThe bound is sharp. The construction $A = [1, N/2]$ and $B = \\{p \\text{ prime} : N/2 < p \\leq N\\}$ achieves $|A||B| \\sim N^2/(4\\log N)$. The key insight is that primes $p > N/2$ cannot divide any integer $\\leq N/2$ (since $p > N/2 \\geq a$ for $a \\in A$), so $a_1 p_1 = a_2 p_2$ forces $p_1 = p_2$ by unique factorization, and then $a_1 = a_2$. By the prime number theorem, $|B| = \\pi(N) - \\pi(N/2) \\sim N/(2\\log N)$.\n\nErdős also posed the finer question: does $\\lim_{N\\to\\infty} \\max |A||B| \\cdot \\log N / N^2$ exist? Van Doorn observed that if the limit exists, it must be $\\geq 1$. This limit question remains open and connects to deep questions about the distribution of smooth numbers and the multiplicative structure of intervals.",
@@ -203,7 +203,7 @@
     "theoremCount": 10,
     "definitionCount": 15,
     "path": "Proofs/Erdos490Problem.lean",
-    "sorries": 6
+    "sorries": 3
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-607/meta.json
+++ b/src/data/proofs/erdos-607/meta.json
@@ -18,7 +18,7 @@
       "asymptotics"
     ],
     "badge": "axiom",
-    "sorries": 20,
+    "sorries": 17,
     "erdosNumber": 607,
     "erdosUrl": "https://erdosproblems.com/607",
     "erdosProblemStatus": "solved",
@@ -67,7 +67,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 203,
-    "assumptions": "1 axiom(s) and 20 sorry(s). See the Lean source for details.",
+    "assumptions": "1 axiom(s) and 17 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -212,7 +212,7 @@
     "theoremCount": 13,
     "definitionCount": 13,
     "path": "Proofs/Stubs/Erdos607Problem.lean",
-    "sorries": 20
+    "sorries": 17
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-610/meta.json
+++ b/src/data/proofs/erdos-610/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 17,
+    "sorries": 11,
     "erdosNumber": 610,
     "erdosUrl": "https://erdosproblems.com/610",
     "erdosProblemStatus": "open",
@@ -89,13 +89,13 @@
     ],
     "axiomCount": 1,
     "lineCount": 222,
-    "assumptions": "1 axiom(s) and 17 sorries(s). See the Lean source for details."
+    "assumptions": "1 axiom(s) and 11 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Clique Transversals: Hitting Every Maximal Clique**\n\nA clique transversal is a set of vertices that intersects every maximal clique in a graph. The clique transversal number τ(G) — the minimum size of such a set — was introduced by Erdős, Gallai, and Tuza in the context of extremal graph theory.\n\n**The Erdős-Gallai-Tuza Bound**\n\nThe trio proved τ(G) ≤ n - √(2n) + O(1) for any n-vertex graph. The proof uses Turán's theorem on an auxiliary 'clique-intersection graph': vertices of G that share no maximal clique form an independent set of size ≥ √(2n), and removing this independent set leaves a transversal. The bound is constructive — the greedy algorithm finds such a transversal in polynomial time.\n\n**Near-Tightness**\n\nConstructions (Paley-type graphs, random graphs) achieve τ ≈ n - √(2n), showing the √(2n) coefficient is essentially correct. This means improving the bound requires new ideas, not just better analysis of existing arguments.\n\n**The Triangle-Free Connection**\n\nThe deep conjecture τ(G) ≤ n - f(n), where f(n) is the minimum independence number among triangle-free n-vertex graphs, would improve √(2n) to √(n log n). Kim's celebrated theorem (1995) establishes f(n) = Θ(√(n log n)) via the semi-random method (Rödl nibble), proving R(3,k) = Θ(k²/log k). The logarithmic improvement factor √(log n) represents a qualitative jump — the difference between constant and growing coefficients of √n.\n\n**Special Graph Classes**\n\nFor bipartite graphs, τ equals the vertex cover number (König's theorem). For chordal graphs, the clique tree structure enables polynomial computation. For perfect graphs, LP duality gives integrality. The general case remains the frontier.",
     "problemStatement": "**Definition:** τ(G) = minimum size of a set hitting every maximal clique.\n\n**Known:** τ(G) ≤ n - √(2n) + O(1) (Erdős-Gallai-Tuza)\n\n**Open Questions:**\n1. Is τ(G) ≤ n - ω(n)√n for some ω(n) → ∞?\n2. Is τ(G) ≤ n - c√(n log n) for some constant c > 0?\n\n**Conjecture:** τ(G) ≤ n - f(n) where f(n) = Θ(√(n log n)) is the triangle-free independence function.",
     "text": "For a graph G, let τ(G) be the minimum vertices hitting every maximal clique. Known: τ(G) ≤ n - √(2n) + O(1). Open: Can we improve to n - ω(n)√n or n - c√(n log n)?",
-    "proofStrategy": "**Formalization Structure**\n\nThe Lean file (223 lines, 17 sorries) has nine parts:\n\n1. **Cliques** (lines 32-44): IsClique, IsMaximalClique, maximalCliques via Finset.filter on univ\n\n2. **Transversal** (lines 46-67): IsCliqueTransversal, cliqueTransversalNumber via Finset.min' with existence proof using univ_is_transversal\n\n3. **Basic Properties** (lines 68-91): univ_is_transversal (PROVED), tau_le_card (sorry), tau_empty (sorry), tau_complete (sorry)\n\n4. **EGT Bound** (lines 92-102): ErdosGallaiTuzaBound definition, erdos_gallai_tuza axiom (∃ C, τ ≤ n - √(2n) + C)\n\n5. **Open Questions** (lines 103-117): Question1_OmegaImprovement with Filter.Tendsto, Question2_LogImprovement with c·√(n log n)\n\n6. **Independent Sets** (lines 118-138): IsIndependentSet, independenceNumber via Finset.max', IsTriangleFree, triangleFreeIndependence (def sorry)\n\n7. **Conjecture** (lines 139-156): ErdosGallaiTuzaConjecture, kim_triangle_free_independence axiom (Θ bounds), conjecture_implies_question2 (sorry)\n\n8. **Lower Bounds** (lines 157-169): NearTightConstruction via Filter.Frequently, egt_bound_tight (sorry)\n\n9. **Special Cases** (lines 170-223): Bipartite, chordal, perfect (all sorry), clique cover duality, main problem restatement\n\n**What is Proved vs Axiomatized**\n- **Proved**: univ_is_transversal, erdos_610_known (restatement)\n- **Axiomatized**: erdos_gallai_tuza, kim_triangle_free_independence\n- **Definition sorry**: triangleFreeIndependence, cliqueCoverNumber\n- **Sorry** (15 theorems): basic properties, implications, special cases, tightness",
+    "proofStrategy": "**Formalization Structure**\n\nThe Lean file (223 lines, 11 sorries) has nine parts:\n\n1. **Cliques** (lines 32-44): IsClique, IsMaximalClique, maximalCliques via Finset.filter on univ\n\n2. **Transversal** (lines 46-67): IsCliqueTransversal, cliqueTransversalNumber via Finset.min' with existence proof using univ_is_transversal\n\n3. **Basic Properties** (lines 68-91): univ_is_transversal (PROVED), tau_le_card (sorry), tau_empty (sorry), tau_complete (sorry)\n\n4. **EGT Bound** (lines 92-102): ErdosGallaiTuzaBound definition, erdos_gallai_tuza axiom (∃ C, τ ≤ n - √(2n) + C)\n\n5. **Open Questions** (lines 103-117): Question1_OmegaImprovement with Filter.Tendsto, Question2_LogImprovement with c·√(n log n)\n\n6. **Independent Sets** (lines 118-138): IsIndependentSet, independenceNumber via Finset.max', IsTriangleFree, triangleFreeIndependence (def sorry)\n\n7. **Conjecture** (lines 139-156): ErdosGallaiTuzaConjecture, kim_triangle_free_independence axiom (Θ bounds), conjecture_implies_question2 (sorry)\n\n8. **Lower Bounds** (lines 157-169): NearTightConstruction via Filter.Frequently, egt_bound_tight (sorry)\n\n9. **Special Cases** (lines 170-223): Bipartite, chordal, perfect (all sorry), clique cover duality, main problem restatement\n\n**What is Proved vs Axiomatized**\n- **Proved**: univ_is_transversal, erdos_610_known (restatement)\n- **Axiomatized**: erdos_gallai_tuza, kim_triangle_free_independence\n- **Definition sorry**: triangleFreeIndependence, cliqueCoverNumber\n- **Sorry** (15 theorems): basic properties, implications, special cases, tightness",
     "keyInsights": [
       "A clique transversal must hit every maximal clique — the minimum size τ(G) ranges from 1 (complete graph, one maximal clique) to n (empty graph, n singleton maximal cliques)",
       "The EGT bound τ ≤ n - √(2n) + O(1) uses Turán's theorem on an auxiliary graph: the independent set in the clique-intersection graph has size ≥ √(2n), and its complement is a transversal",
@@ -208,7 +208,7 @@
     "theoremCount": 13,
     "definitionCount": 16,
     "path": "Proofs/Stubs/Erdos610Problem.lean",
-    "sorries": 17
+    "sorries": 11
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-612/meta.json
+++ b/src/data/proofs/erdos-612/meta.json
@@ -19,7 +19,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 16,
+    "sorries": 12,
     "erdosNumber": 612,
     "erdosUrl": "https://erdosproblems.com/612",
     "erdosProblemStatus": "open",
@@ -51,7 +51,7 @@
     ],
     "axiomCount": 6,
     "lineCount": 268,
-    "assumptions": "6 axiom(s) and 16 sorry(s). See the Lean source for details.",
+    "assumptions": "6 axiom(s) and 12 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -179,7 +179,7 @@
     "theoremCount": 12,
     "definitionCount": 13,
     "path": "Proofs/Stubs/Erdos612Problem.lean",
-    "sorries": 16
+    "sorries": 12
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-627/meta.json
+++ b/src/data/proofs/erdos-627/meta.json
@@ -19,7 +19,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 16,
+    "sorries": 13,
     "erdosNumber": 627,
     "erdosUrl": "https://erdosproblems.com/627",
     "erdosProblemStatus": "open",
@@ -58,7 +58,7 @@
     ],
     "axiomCount": 8,
     "lineCount": 236,
-    "assumptions": "8 axiom(s) and 16 sorries(s).",
+    "assumptions": "8 axiom(s) and 13 sorry(s).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -194,7 +194,7 @@
     "theoremCount": 13,
     "definitionCount": 14,
     "path": "Proofs/Stubs/Erdos627Problem.lean",
-    "sorries": 16
+    "sorries": 13
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-671/meta.json
+++ b/src/data/proofs/erdos-671/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 23,
+    "sorries": 14,
     "erdosNumber": 671,
     "erdosUrl": "https://erdosproblems.com/671",
     "erdosProblemStatus": "open",
@@ -64,7 +64,7 @@
     ],
     "axiomCount": 3,
     "lineCount": 249,
-    "assumptions": "3 axiom(s) and 23 sorry(s). See the Lean source for details."
+    "assumptions": "3 axiom(s) and 14 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Erdos Problem #671**\n\nThis is a deep problem in approximation theory about the relationship between the Lebesgue function and Lagrange interpolation convergence.\n\n**Key History:**\n- 1931: Bernstein proves lambda_n(x) diverges at some point for any interpolation scheme\n- 1980: Erdos and Vertesi prove that for any points, some continuous f has |L^n f(x)| -> infinity a.e.\n- Present: Questions 1 and 2 remain open with $250 prize\n\n**Mathematical Context:**\nThe Lebesgue function lambda_n(x) = sum |p_i^n(x)| controls interpolation error: the error is bounded by (1 + Lambda_n) times the best polynomial approximation. When Lambda_n grows, uniform convergence fails. The questions ask whether *pointwise* convergence can still occur when lambda_n diverges.",
@@ -148,7 +148,7 @@
     "axiomCount": 3,
     "theoremCount": 14,
     "definitionCount": 0,
-    "sorries": 23,
+    "sorries": 14,
     "path": "Proofs/Erdos671Problem.lean"
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-715/meta.json
+++ b/src/data/proofs/erdos-715/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "wip",
-    "sorries": 15,
+    "sorries": 12,
     "erdosNumber": 715,
     "erdosUrl": "https://erdosproblems.com/715",
     "erdosProblemStatus": "solved",
@@ -83,7 +83,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 209,
-    "assumptions": "No axioms. 15 sorries(s) remain in the formalization."
+    "assumptions": "No axioms. 12 sorry(s) remain in the formalization."
   },
   "overview": {
     "historicalContext": "This problem was posed by Berge and Sauer at the 6th Hungarian Combinatorial Colloquium (1976). It asks whether regular graphs of sufficient degree must contain regular subgraphs of smaller degree. Tashkinov (1982) gave the definitive answer: every 4-regular graph contains a 3-regular subgraph. This was strengthened by Alon, Friedland, and Kalai (1984), who showed that every 4-regular graph plus a single edge already contains a 3-regular subgraph, immediately implying the result for all r ≥ 5.\n\nThe threshold r = 4 is sharp: K₄ is 3-regular but has no proper 3-regular subgraph (removing any edge drops some degree below 3). The Petersen graph (10 vertices, 3-regular) is another minimal example. The general question — for which (r, k) pairs does every r-regular graph contain a k-regular subgraph? — remains an active research area for k ≥ 4.",
@@ -189,7 +189,7 @@
     "theoremCount": 13,
     "definitionCount": 10,
     "path": "Proofs/Stubs/Erdos715Problem.lean",
-    "sorries": 15
+    "sorries": 12
   },
   "references": [
     {

--- a/src/data/proofs/erdos-748/meta.json
+++ b/src/data/proofs/erdos-748/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 1,
     "erdosNumber": 748,
     "erdosUrl": "https://erdosproblems.com/748",
     "erdosProblemStatus": "solved",
@@ -60,7 +60,7 @@
     ],
     "axiomCount": 3,
     "lineCount": 279,
-    "assumptions": "6 axiom(s) and 4 sorry(s). See the Lean source for details."
+    "assumptions": "3 axiom(s) and 1 sorry. See the Lean source for details."
   },
   "overview": {
     "historicalContext": "Peter Cameron and Paul Erdős conjectured that the number $f(n)$ of sum-free subsets of $\\{1, \\ldots, n\\}$ satisfies $f(n) = 2^{(1+o(1))n/2}$, meaning the trivial lower bound from the upper half construction is essentially tight. The lower bound $f(n) \\ge 2^{\\lfloor n/2 \\rfloor}$ is elementary: any subset of $\\{\\lceil n/2 \\rceil, \\ldots, n\\}$ is sum-free since all pairwise sums exceed $n$. The conjecture was resolved independently by Ben Green (2004, Bull. London Math. Soc.) and Alexander Sapozhenko (2003, Dokl. Akad. Nauk). Green's proof introduced a proto-container argument: he showed that sum-free subsets are 'almost contained' in structured templates — either subsets of the upper half or subsets of odd numbers — and bounded the template count. This structural insight anticipated the Balogh-Morris-Samotij / Saxton-Thomason hypergraph container method (2015), one of the most powerful tools in modern combinatorics. More precisely, $f(n) \\sim c_n \\cdot 2^{n/2}$ where $c_n$ depends on the parity of $n$, reflecting the two dominant sum-free families (upper half for even $n$, odd numbers for odd $n$). The problem connects to Schur numbers in Ramsey theory and to the broader program of counting combinatorial structures avoiding prescribed patterns.",
@@ -182,7 +182,7 @@
     "theoremCount": 11,
     "definitionCount": 5,
     "path": "Proofs/Erdos748Problem.lean",
-    "sorries": 4
+    "sorries": 1
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-76/meta.json
+++ b/src/data/proofs/erdos-76/meta.json
@@ -18,7 +18,7 @@
       "extremal-combinatorics"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 1,
     "erdosNumber": 76,
     "erdosUrl": "https://erdosproblems.com/76",
     "erdosProblemStatus": "solved",
@@ -92,7 +92,7 @@
     ],
     "axiomCount": 2,
     "lineCount": 246,
-    "assumptions": "3 axiom(s) and 4 sorries(s). See the Lean source for details."
+    "assumptions": "2 axiom(s) and 1 sorry. See the Lean source for details."
   },
   "overview": {
     "historicalContext": "Ramsey's theorem (1930) guarantees that any 2-coloring of $K_6$ contains a monochromatic triangle, since $R(3,3) = 6$. This qualitative existence result naturally leads to quantitative questions: how many monochromatic triangles must appear, and how many can be packed edge-disjointly?\n\nErdős, Faudree, and Ordman posed Problem #76: in any 2-coloring of $K_n$, what is the minimum number of edge-disjoint monochromatic triangles? They conjectured the answer is $(1 + o(1)) n^2/12$, achieved by the balanced bipartition coloring — partition $[n]$ into two equal halves, color within-half edges blue and between-half edges red. The red graph $K_{n/2, n/2}$ is bipartite (triangle-free), and each blue clique $K_{n/2}$ packs $\\approx (n/2)(n/2-1)/6 \\approx n^2/24$ edge-disjoint triangles via Steiner triple systems (Kirkman 1847). Two halves yield $n^2/12$ total.\n\nThe conjecture was confirmed by Vytautas Gruslys and Shoham Letzter in their 2020 Combinatorica paper. Their proof applies a variant of the Szemerédi regularity lemma (1978) to decompose the 2-colored $K_n$ into structured regular pairs, then uses a greedy-absorption method to build the packing. They also established a stability result: any coloring achieving the bound must be close to the balanced bipartition (up to isomorphism).\n\nThe problem connects Ramsey theory (existence of monochromatic subgraphs), extremal graph theory (extremal constructions and stability), packing theory (edge-disjointness constraints), and design theory (Steiner triple systems for optimal packings).",
@@ -224,7 +224,7 @@
     "theoremCount": 5,
     "definitionCount": 15,
     "path": "Proofs/Stubs/Erdos76Problem.lean",
-    "sorries": 4
+    "sorries": 1
   },
   "references": [
     {

--- a/src/data/proofs/erdos-820/meta.json
+++ b/src/data/proofs/erdos-820/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 6,
+    "sorries": 3,
     "erdosNumber": 820,
     "erdosUrl": "https://erdosproblems.com/820",
     "erdosProblemStatus": "open",
@@ -62,7 +62,7 @@
     ],
     "axiomCount": 3,
     "lineCount": 284,
-    "assumptions": "3 axiom(s) and 6 sorries(s). See the Lean source for details."
+    "assumptions": "3 axiom(s) and 3 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**The GCD Problem for Exponential Sequences**\n\nThis problem originates from Erdős's 1974 paper \"Remarks on some problems in number theory\" in Mathematica Balkanica. The core question studies when powers of different bases minus one are coprime.\n\n**The Function H(n)**\n\nDefine H(n) as the smallest l such that there exists k < l with gcd(k^n - 1, l^n - 1) = 1. This measures how \"rare\" coprimality is among these exponential expressions.\n\n**Computed Values**\n\nFor small n: H(1)=3, H(2)=3, H(3)=3, H(4)=6, H(5)=3, H(6)=18, H(7)=3, H(8)=6, H(9)=3, H(10)=12. The value H(n)=3 occurs frequently, corresponding to gcd(2^n-1, 3^n-1)=1.\n\n**Progress**\n\n1. **Erdős (1974):** Proved H(n) > exp(n^{c/(log log n)²}) for infinitely many n\n2. **van Doorn:** Improved to H(n) > exp(n^{c/log log n}) infinitely often\n3. **OEIS A263647:** Catalogues n where gcd(2^n-1, 3^n-1)=1\n\nThe main conjectures remain OPEN.",
@@ -204,7 +204,7 @@
     "theoremCount": 5,
     "definitionCount": 12,
     "path": "Proofs/Stubs/Erdos820Problem.lean",
-    "sorries": 6
+    "sorries": 3
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Update meta.json sorry counts to match actual Lean source files. Sorries were removed by research agents but metadata was not updated.

## Evidence

| Proof | Before | After |
|-------|--------|-------|
| erdos-671 | 23 | 14 |
| erdos-610 | 17 | 11 |
| erdos-612 | 16 | 12 |
| erdos-627 | 16 | 13 |
| erdos-607 | 20 | 17 |
| erdos-715 | 15 | 12 |
| erdos-820 | 6 | 3 |
| erdos-76 | 4 | 1 |
| erdos-748 | 4 | 1 |
| erdos-490 | 6 | 3 |
| erdos-1012-oq-03 | 1 | 3 |

---
Automated fix by lean-mechanic agent.