### PR TITLE
Enrich Selberg Density Axiom Correction: add annotations

### DIFF
--- a/src/data/proofs/erdos-1059-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/erdos-1059-oq-02-oq-01/annotations.json
@@ -1,3 +1,88 @@
 {
-  "annotations": []
+  "annotations": [
+    {
+      "id": "ann-research-context",
+      "proofId": "erdos-1059-oq-02-oq-01",
+      "range": { "startLine": 1, "endLine": 42 },
+      "type": "context",
+      "title": "Bug Discovery: Off-by-One in Selberg Density Axiom",
+      "content": "This file documents a rare event in formal mathematics: discovering that a stated axiom is provably false. The `selberg_density_axiom` in the parent file claims that for $l \\ge 3$, the factorial interval $I(l) = (l!, (l+1)!]$ always contains a prime $p$ where every $p - k!$ (with $k! < p$) is composite. Exhaustive computation reveals this is false for $l = 3$: none of the 6 primes in $(6, 24]$ satisfy the condition. The correct threshold is $l \\ge 4$.",
+      "mathContext": "The predicate $\\text{AllFactorialSubtractionsComposite}(p)$ requires $p - k!$ to be composite and $\\ge 2$ for every $k$ with $k! < p$. For primes in $I(3) = (6, 24]$, the factorials $2! = 2$ and $3! = 6$ produce small subtractions that are often prime.",
+      "significance": "key",
+      "relatedConcepts": ["Selberg sieve", "factorial intervals", "counterexample to axiom", "off-by-one error"],
+      "prerequisites": ["prime number theory", "factorial arithmetic", "Erdős Problem 1059"]
+    },
+    {
+      "id": "ann-definition",
+      "proofId": "erdos-1059-oq-02-oq-01",
+      "range": { "startLine": 52, "endLine": 59 },
+      "type": "definition",
+      "title": "AllFactorialSubtractionsComposite Predicate",
+      "content": "Self-contained copy of the key predicate from the parent file. For a natural number $n$, `AllFactorialSubtractionsComposite(n)` holds if for every $k$ with $k! < n$, the difference $n - k!$ is both composite and at least 2. This is the central sieving condition for Erdős Problem #1059 — it identifies primes that are 'far' from every factorial in a specific multiplicative sense.",
+      "mathContext": "$\\text{AllFactorialSubtractionsComposite}(n) \\iff \\forall k \\in \\mathbb{N},\\; k! < n \\implies n - k! \\ge 2 \\land \\neg\\text{Prime}(n - k!)$",
+      "significance": "key",
+      "relatedConcepts": ["sieve condition", "factorial arithmetic", "composite numbers"],
+      "prerequisites": ["Nat.factorial", "Nat.Prime"]
+    },
+    {
+      "id": "ann-counterexample-failures",
+      "proofId": "erdos-1059-oq-02-oq-01",
+      "range": { "startLine": 61, "endLine": 91 },
+      "type": "insight",
+      "title": "Exhaustive Failure: All Primes in I(3) Fail",
+      "content": "Six individual failure theorems, one per prime in $I(3) = (6, 24]$. Each proof works by contradiction: assume the prime satisfies `AllFactorialSubtractionsComposite`, then exhibit a specific $k$ where $p - k!$ is prime. The witnessing primes reveal a pattern: subtracting $2! = 2$ gives $p - 2$ (prime for $p \\in \\{7, 13, 19\\}$), and subtracting $3! = 6$ gives $p - 6$ (prime for $p \\in \\{11, 17, 23\\}$). Since these two checks cover all 6 primes, the interval $I(3)$ has zero qualifying primes.",
+      "mathContext": "Failures: $7 - 2 = 5$ (prime), $11 - 6 = 5$ (prime), $13 - 2 = 11$ (prime), $17 - 6 = 11$ (prime), $19 - 2 = 17$ (prime), $23 - 6 = 17$ (prime). Note the residues are all small primes ($5, 11, 17$), reflecting that $I(3)$ is too small for the sieving condition to be satisfiable.",
+      "significance": "key",
+      "relatedConcepts": ["proof by contradiction", "absurd tactic", "norm_num", "exhaustive case analysis"],
+      "prerequisites": ["primality testing", "factorial computation"]
+    },
+    {
+      "id": "ann-witness-101",
+      "proofId": "erdos-1059-oq-02-oq-01",
+      "range": { "startLine": 92, "endLine": 123 },
+      "type": "technique",
+      "title": "Qualifying Prime Witness: p = 101",
+      "content": "Constructs the witness that $I(4) = (24, 120]$ does contain a qualifying prime. The prime $p = 101$ is verified in three steps: (1) `p101_prime` confirms primality via `norm_num`; (2) `p101_minus_24_composite` shows $101 - 4! = 77 = 7 \\times 11$ is composite; (3) `p101_qualifying` verifies all conditions. The proof of `p101_qualifying` first bounds $k \\le 4$ (since $5! = 120 > 101$), then uses `interval_cases` to split into cases $k \\in \\{0, 1, 2, 3, 4\\}$, each discharged by `norm_num`.",
+      "mathContext": "Verification: $101 - 0! = 100 = 4 \\times 25$ (composite), $101 - 1! = 100$ (same), $101 - 2! = 99 = 9 \\times 11$ (composite), $101 - 3! = 95 = 5 \\times 19$ (composite), $101 - 4! = 77 = 7 \\times 11$ (composite). Since $5! = 120 > 101$, no further checks are needed.",
+      "significance": "key",
+      "relatedConcepts": ["interval_cases tactic", "norm_num", "Nat.factorial_le_factorial", "explicit witness construction"],
+      "prerequisites": ["Lean 4 tactic mode", "primality and compositeness verification"]
+    },
+    {
+      "id": "ann-corrected-axiom",
+      "proofId": "erdos-1059-oq-02-oq-01",
+      "range": { "startLine": 125, "endLine": 140 },
+      "type": "concept",
+      "title": "Corrected Selberg Density Axiom",
+      "content": "The corrected axiom replaces $l \\ge 3$ with $l \\ge 4$. This is the only axiom in the file and represents a genuine mathematical assumption: for all $l \\ge 4$, the interval $(l!, (l+1)!]$ contains at least one qualifying prime. The case $l = 4$ is verified above ($p = 101$). The general case for $l \\ge 5$ would require the Brun-Titchmarsh inequality (prime counting in short intervals) and the Selberg $\\lambda^2$ sieve, neither of which are currently in Mathlib.",
+      "mathContext": "Brun-Titchmarsh: $\\pi(x+y) - \\pi(x) \\le \\frac{2y}{\\log y}$ for $y \\ge x^{0.525}$. Applied to $(l!, (l+1)!] = (l!, l! \\cdot (l+1)]$ with length $l! \\cdot l$, this gives enough primes in the interval for the sieving condition to be satisfiable when $l \\ge 4$.",
+      "significance": "key",
+      "relatedConcepts": ["axiom declaration", "Selberg sieve", "Brun-Titchmarsh inequality", "factorial interval density"],
+      "prerequisites": ["analytic number theory", "sieve methods"]
+    },
+    {
+      "id": "ann-main-theorem",
+      "proofId": "erdos-1059-oq-02-oq-01",
+      "range": { "startLine": 142, "endLine": 156 },
+      "type": "technique",
+      "title": "Infinitely Many Qualifying Primes",
+      "content": "The main theorem shows that for any $n$, there exists a qualifying prime $p > n$. The proof uses $l = n + 4$ (guaranteeing $l \\ge 4$) and applies the corrected axiom to obtain $p$ with $l! < p$. The chain $n < n + 4 \\le (n+4)! < p$ (using `Nat.self_le_factorial`) completes the bound. This is the same proof structure as in the parent file, just with the shifted threshold.",
+      "mathContext": "For any $n$: set $l = n + 4 \\ge 4$. By the corrected axiom, $\\exists p$ with $(n+4)! < p \\le (n+5)!$, $p$ prime, and $\\text{AllFactorialSubtractionsComposite}(p)$. Since $n < n + 4 \\le (n+4)! < p$, we have $p > n$.",
+      "significance": "key",
+      "relatedConcepts": ["Nat.self_le_factorial", "omega tactic", "existential elimination"],
+      "prerequisites": ["Lean 4 calc mode", "factorial bounds"]
+    },
+    {
+      "id": "ann-summary",
+      "proofId": "erdos-1059-oq-02-oq-01",
+      "range": { "startLine": 158, "endLine": 173 },
+      "type": "context",
+      "title": "Summary and Remaining Work",
+      "content": "Documents what has been formalized (bug discovery, counterexample, corrected axiom, main theorem) and what remains. The key open piece is proving the corrected density axiom for general $l \\ge 5$ without assuming it. This requires two components missing from Mathlib: the Brun-Titchmarsh inequality for prime counting in intervals, and Selberg's $\\lambda^2$ sieve for producing primes with specific residue properties. The Prime Number Theorem (which IS in Mathlib) provides the baseline density but is insufficient alone.",
+      "mathContext": "The proof gap: PNT gives $\\pi(x) \\sim x/\\log x$ but says nothing about primes avoiding specific residues mod factorials. The Selberg sieve provides the necessary refinement: it can sieve out primes $p$ where $p - k!$ is prime for any $k$, leaving qualifying primes.",
+      "significance": "context",
+      "relatedConcepts": ["Prime Number Theorem", "Mathlib gaps", "sieve methods", "future formalization targets"],
+      "prerequisites": ["analytic number theory overview"]
+    }
+  ]
 }

--- a/src/data/proofs/erdos-1059-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-1059-oq-02-oq-01/meta.json
@@ -68,7 +68,8 @@
       "title": "Definitions (Self-Contained Copy)",
       "startLine": 52,
       "endLine": 66,
-      "summary": "AllFactorialSubtractionsComposite: for all k with k! < n, n-k! is composite (≥2, not prime)."
+      "summary": "AllFactorialSubtractionsComposite: for all k with k! < n, n-k! is composite (≥2, not prime).",
+      "mathContext": "AllFactorialSubtractionsComposite(n) ≡ ∀ k, k! < n → ¬Prime(n - k!) ∧ n - k! ≥ 2. This is the sieving condition: primes 'far' from every factorial value."
     },
     {
       "id": "counterexample",


### PR DESCRIPTION
## Enrichment: erdos-1059-oq-02-oq-01

- Added 7 annotations with `mathContext`, `significance`, `relatedConcepts`, `prerequisites` (was empty)
- Added `mathContext` to definitions section in meta.json
- Covers: bug discovery context, definition, counterexample failures, witness p=101, corrected axiom, main theorem, summary