### PR TITLE
Audit: fix erdos-748 sorry count (1 → 4)

### DIFF
--- a/src/data/proofs/erdos-748/meta.json
+++ b/src/data/proofs/erdos-748/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 4,
     "erdosNumber": 748,
     "erdosUrl": "https://erdosproblems.com/748",
     "erdosProblemStatus": "solved",
@@ -60,7 +60,7 @@
     ],
     "axiomCount": 3,
     "lineCount": 279,
-    "assumptions": "3 axiom(s) and 1 sorry. See the Lean source for details."
+    "assumptions": "3 axiom(s) and 4 sorries. See the Lean source for details."
   },
   "overview": {
     "historicalContext": "Peter Cameron and Paul Erdős conjectured that the number $f(n)$ of sum-free subsets of $\\{1, \\ldots, n\\}$ satisfies $f(n) = 2^{(1+o(1))n/2}$, meaning the trivial lower bound from the upper half construction is essentially tight. The lower bound $f(n) \\ge 2^{\\lfloor n/2 \\rfloor}$ is elementary: any subset of $\\{\\lceil n/2 \\rceil, \\ldots, n\\}$ is sum-free since all pairwise sums exceed $n$. The conjecture was resolved independently by Ben Green (2004, Bull. London Math. Soc.) and Alexander Sapozhenko (2003, Dokl. Akad. Nauk). Green's proof introduced a proto-container argument: he showed that sum-free subsets are 'almost contained' in structured templates — either subsets of the upper half or subsets of odd numbers — and bounded the template count. This structural insight anticipated the Balogh-Morris-Samotij / Saxton-Thomason hypergraph container method (2015), one of the most powerful tools in modern combinatorics. More precisely, $f(n) \\sim c_n \\cdot 2^{n/2}$ where $c_n$ depends on the parity of $n$, reflecting the two dominant sum-free families (upper half for even $n$, odd numbers for odd $n$). The problem connects to Schur numbers in Ramsey theory and to the broader program of counting combinatorial structures avoiding prescribed patterns.",
@@ -182,7 +182,7 @@
     "theoremCount": 11,
     "definitionCount": 5,
     "path": "Proofs/Erdos748Problem.lean",
-    "sorries": 1
+    "sorries": 4
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary

- Fix sorry count in `erdos-748/meta.json`: Lean source has 4 sorries (`cameron_erdos_proved`, `f_1`, `f_2`, `f_3`) but meta.json claimed 1
- Updated `meta.sorries`, `leanFile.sorries`, and `assumptions` text

## Evidence

**meta.json claimed**: 1 sorry
**Lean file shows**: 4 sorries (lines 170, 240, 241, 242)

## Test plan

- [ ] `pnpm build` passes
- [ ] Gallery page for erdos-748 shows correct sorry count

🤖 Generated with [Claude Code](https://claude.com/claude-code)