### PR TITLE
Audit: fix erdos-820 sorry count (3 → 6)

### DIFF
--- a/src/data/proofs/erdos-820/meta.json
+++ b/src/data/proofs/erdos-820/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 6,
     "erdosNumber": 820,
     "erdosUrl": "https://erdosproblems.com/820",
     "erdosProblemStatus": "open",
@@ -62,7 +62,7 @@
     ],
     "axiomCount": 3,
     "lineCount": 284,
-    "assumptions": "3 axiom(s) and 3 sorry(s). See the Lean source for details."
+    "assumptions": "3 axiom(s) and 6 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**The GCD Problem for Exponential Sequences**\n\nThis problem originates from Erdős's 1974 paper \"Remarks on some problems in number theory\" in Mathematica Balkanica. The core question studies when powers of different bases minus one are coprime.\n\n**The Function H(n)**\n\nDefine H(n) as the smallest l such that there exists k < l with gcd(k^n - 1, l^n - 1) = 1. This measures how \"rare\" coprimality is among these exponential expressions.\n\n**Computed Values**\n\nFor small n: H(1)=3, H(2)=3, H(3)=3, H(4)=6, H(5)=3, H(6)=18, H(7)=3, H(8)=6, H(9)=3, H(10)=12. The value H(n)=3 occurs frequently, corresponding to gcd(2^n-1, 3^n-1)=1.\n\n**Progress**\n\n1. **Erdős (1974):** Proved H(n) > exp(n^{c/(log log n)²}) for infinitely many n\n2. **van Doorn:** Improved to H(n) > exp(n^{c/log log n}) infinitely often\n3. **OEIS A263647:** Catalogues n where gcd(2^n-1, 3^n-1)=1\n\nThe main conjectures remain OPEN.",
@@ -204,7 +204,7 @@
     "theoremCount": 5,
     "definitionCount": 12,
     "path": "Proofs/Stubs/Erdos820Problem.lean",
-    "sorries": 3
+    "sorries": 6
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary

- Fix sorry count in `erdos-820/meta.json`: Lean source has 6 sorries but meta.json claimed 3
- Sorries: `H` def (L66), `H_eq_3_iff_2_3_coprime` (L97), `K` def (L192), `gcd_characterization` (L216), `h` def (L245), `H_le_h` (L254)
- Updated `meta.sorries`, `leanFile.sorries`, and `assumptions` text

## Evidence

**meta.json claimed**: 3 sorries
**Lean file shows**: 6 sorries (lines 66, 97, 192, 216, 245, 254)

## Test plan

- [ ] `pnpm build` passes
- [ ] Gallery page for erdos-820 shows correct sorry count

🤖 Generated with [Claude Code](https://claude.com/claude-code)