### PR TITLE
Seeker: select infinitude-primes-4k1-oq-01 — Fermat sums of two squares

### DIFF
--- a/research/problems/infinitude-primes-4k1-oq-01/knowledge.md
+++ b/research/problems/infinitude-primes-4k1-oq-01/knowledge.md
@@ -1,0 +1,21 @@
+# Knowledge Base: infinitude-primes-4k1-oq-01
+
+Insights accumulated during research on this problem.
+
+---
+
+## Problem Understanding
+
+[Initial observations about the problem will be recorded here]
+
+---
+
+## Insights
+
+[Insights from research attempts will be accumulated here]
+
+---
+
+## Dead Ends
+
+[Approaches known not to work will be documented here]

--- a/research/problems/infinitude-primes-4k1-oq-01/literature/README.md
+++ b/research/problems/infinitude-primes-4k1-oq-01/literature/README.md
@@ -1,0 +1,14 @@
+# Literature for infinitude-primes-4k1-oq-01
+
+This directory contains:
+- Related papers and their summaries
+- Links to relevant Mathlib documentation
+- References to similar problems and their solutions
+
+## Related Gallery Proofs
+
+[List proofs from src/data/proofs/ that relate to this problem]
+
+## External References
+
+[Papers, books, online resources]

--- a/research/problems/infinitude-primes-4k1-oq-01/problem.md
+++ b/research/problems/infinitude-primes-4k1-oq-01/problem.md
@@ -1,0 +1,126 @@
+# Problem: Fermat's Theorem on Sums of Two Squares
+
+**Slug**: infinitude-primes-4k1-oq-01
+**Created**: 2026-04-12T14:53:27-07:00
+**Status**: Active
+**Source**: gallery-gap
+
+## Problem Statement
+
+### Formal Statement
+
+$$
+p \text{ is an odd prime} \implies \bigl(p \equiv 1 \pmod{4} \iff \exists\, a\, b \in \mathbb{N},\; p = a^2 + b^2\bigr)
+$$
+
+### Plain Language
+
+Fermat's theorem on sums of two squares states that an odd prime $p$ can be written as a sum of two perfect squares if and only if $p \equiv 1 \pmod{4}$. This is one of the most elegant characterizations in elementary number theory.
+
+The existing gallery proof (`infinitude-primes-4k1`) already uses the forward direction implicitly — via Mathlib's `mod_four_ne_three_of_dvd_isSquare_neg_one` — to show there are infinitely many such primes. The open question asks: can we formalize the full equivalence as a standalone theorem using `Mathlib.NumberTheory.SumTwoSquares`?
+
+### Why This Matters
+
+- Fermat's two-squares theorem is a cornerstone result connecting quadratic residues, Gaussian integers, and prime decomposition
+- The gallery already has the infinitude proof that depends on one direction; making the full characterization explicit adds significant mathematical depth
+- Mathlib likely has the pieces (`Nat.Prime.sq_add_sq` or similar) — the question is how cleanly we can assemble them
+
+## Known Results
+
+### What's Already Proven
+
+- `InfinitudePrimes4k1.lean`: Infinitely many primes ≡ 1 (mod 4), using `mod_four_ne_three_of_dvd_isSquare_neg_one` — `proofs/Proofs/InfinitudePrimes4k1.lean`
+- `Mathlib.NumberTheory.SumTwoSquares`: Contains Nat.Prime representations as sums of two squares
+- `ZMod.isSquare_neg_one_iff`: Characterization of when -1 is a quadratic residue
+
+### What's Still Open
+
+- Full formalization of the biconditional: p ≡ 1 (mod 4) ⟺ p = a² + b²
+- Connection to Gaussian integer factorization (p splits in ℤ[i] iff p ≡ 1 mod 4)
+- Explicit witness extraction: given p ≡ 1 (mod 4), compute (a, b)
+
+### Our Goal
+
+Formalize the complete Fermat two-squares characterization as a Lean theorem, connecting it to the existing infinitude proof as a strengthening. The result should cleanly state the biconditional and leverage Mathlib's infrastructure rather than rebuilding from scratch.
+
+## Related Gallery Proofs
+
+| Proof | Relevance | Techniques |
+|-------|-----------|------------|
+| infinitude-primes-4k1 | Source proof, uses one direction | Euler's criterion, ZMod, factorial construction |
+| pythagorean-theorem | Sum of squares context | Inner product geometry |
+| fundamental-theorem-arithmetic | Prime factorization | Nat.Prime, Unique factorization |
+| quadratic-reciprocity (if exists) | Quadratic residues | Legendre symbol |
+
+## Initial Thoughts
+
+### Potential Approaches
+
+1. **Direct Mathlib wrapper**: Check if `Mathlib.NumberTheory.SumTwoSquares` already contains `Nat.Prime.sq_add_sq` or equivalent, and write a clean pedagogical wrapper
+   - Why it might work: Mathlib is comprehensive for classical number theory
+   - Risk: The API may not expose the biconditional directly
+
+2. **Gaussian integers path**: Factor p in ℤ[i]. If p ≡ 1 (mod 4), then p = (a + bi)(a - bi) = a² + b². Use `Mathlib.NumberTheory.Zsqrtd` or `GaussianInt`
+   - Why it might work: Conceptually clean and connects to algebraic number theory
+   - Risk: Gaussian integer infrastructure may have gaps
+
+3. **Descent argument**: Fermat's original proof via infinite descent — if p ≡ 1 mod 4, find x with x² ≡ -1 mod p, then use the descent to reduce x² + 1 = mp to m = 1
+   - Why it might work: Elementary, no heavy machinery
+   - Risk: Descent proofs can be tricky in Lean
+
+### Key Difficulties
+
+- Identifying which Mathlib theorems give the biconditional most directly
+- The "only if" direction (p = a² + b² implies p ≡ 1 mod 4) is easy: squares mod 4 are 0 or 1, so a² + b² mod 4 ∈ {0, 1, 2}
+- The "if" direction (p ≡ 1 mod 4 implies p = a² + b²) is the deep part
+
+### What Would a Proof Need?
+
+- Key lemma 1: If p ≡ 3 (mod 4), then p cannot be a sum of two squares
+- Key lemma 2: If p ≡ 1 (mod 4), then p is a sum of two squares (the hard direction)
+- Technical: Navigate Mathlib's SumTwoSquares API, possibly GaussianInt
+
+## Tractability Assessment
+
+**Difficulty**: Low to Medium
+
+**Justification**:
+- Mathlib explicitly imports `NumberTheory.SumTwoSquares` in the existing proof
+- The result is classical and well-known — Mathlib almost certainly has it
+- The main work is finding the right API and writing clean wrappers
+- The "if" direction may already be `Nat.Prime.sq_add_sq` or similar
+
+**Estimated Effort**:
+- Exploration: 1-2 hours (survey Mathlib's SumTwoSquares)
+- If Mathlib has it: 2-4 hours (write clean formalization)
+- If Mathlib gaps exist: 1-2 days (fill in supporting lemmas)
+
+## References
+
+### Papers
+- Fermat, letter to Mersenne, 1640 — original claim (no proof published)
+- Euler, 1749 — first published proof
+- Zagier, "A one-sentence proof", American Mathematical Monthly, 1990 — famous elegant proof
+
+### Mathlib
+- `Mathlib.NumberTheory.SumTwoSquares` — key infrastructure
+- `Mathlib.NumberTheory.Zsqrtd.GaussianInt` — Gaussian integers
+- `Mathlib.Data.ZMod.Basic` — modular arithmetic
+- `Mathlib.NumberTheory.LegendreSymbol` — quadratic residues
+
+## Metadata
+
+```yaml
+tags:
+  - number-theory
+  - quadratic-residues
+  - sums-of-squares
+  - primes
+related_proofs:
+  - infinitude-primes-4k1
+  - fundamental-theorem-arithmetic
+  - pythagorean-theorem
+difficulty: low-medium
+source: gallery-gap
+created: 2026-04-12T14:53:27-07:00
+```

--- a/research/problems/infinitude-primes-4k1-oq-01/selection-report.md
+++ b/research/problems/infinitude-primes-4k1-oq-01/selection-report.md
@@ -1,0 +1,86 @@
+# Problem Selection Report
+
+**Date**: 2026-04-12
+**Mode**: SELECT
+**Pool Status**: 17 available, 1233 in-progress, 556 completed, 3 graduated, 2 blocked
+
+## Selected Problem
+
+- **ID**: infinitude-primes-4k1-oq-01
+- **Name**: Fermat's theorem on sums of two squares (p ≡ 1 mod 4 ⟺ p = a² + b²)
+- **Tier**: B
+- **Significance**: 7/10
+- **Tractability**: 8/10
+- **Knowledge Score**: 0 (EMPTY)
+- **Status**: available
+
+## Selection Rationale
+
+1. **Highest composite score among unselected candidates**: Composite = 87 =
+   (tractability 8 × 10) + significance 7, tied with erdos-729-oq-02 (also 87).
+   erdos-729-oq-02 was rejected because it was already selected twice in previous
+   seeker runs (commits e0296b9b, e1d3e85e). This problem has never been selected.
+
+2. **EMPTY knowledge tier**: No research has been done on this problem. Per the
+   algorithm, EMPTY-tier problems have highest priority (knowledge_tier=0).
+
+3. **High tractability (8/10)**: Mathlib's `NumberTheory.SumTwoSquares` module is
+   already imported by the gallery proof. The infrastructure likely exists — the
+   main work is assembling a clean biconditional statement. Well-suited for
+   autonomous research.
+
+4. **Diversity maintained**: Last 3 selections were number theory (×2) and geometry.
+   Not all same domain — no diversity penalty applies. This problem is number theory
+   but adds quadratic-residue/algebraic-number-theory flavor distinct from the
+   arithmetic series and p-adic valuation selections.
+
+## Rejection Summary
+
+- **Candidates considered**: 17
+- **Candidates rejected**: 16
+  - `erdos-729-oq-02` (score 87): rejected — already selected twice in previous runs
+  - `erdos-1168-oq-04` (score 77): lower composite score
+  - `erdos-166-oq-04` (score 77): lower composite score
+  - `erdos-998-oq-02` (score 77): lower composite score
+  - `erdos-998-oq-04` (score 77): lower composite score
+  - `mean-value-theorem-oq-04` (score 77): already selected (commit 09d5fda2)
+  - `abel-ruffini-oq-04-oq-02-oq-02-oq-01` (score 76): lower score
+  - `erdos-729-oq-04` (score 76): lower score, same problem family as rejected top
+  - Remaining 8 candidates: composite scores 67 or below
+- **Confidence**: high — clear score separation (87 vs 77 for runner-up)
+
+## Related Gallery Proofs
+
+- `infinitude-primes-4k1`: Source proof — uses one direction of Fermat's theorem via Euler's criterion
+- `fundamental-theorem-arithmetic`: Prime factorization infrastructure
+- `pythagorean-theorem`: Sum of squares geometric context
+
+## Suggested First Steps
+
+1. **OBSERVE**: Survey `Mathlib.NumberTheory.SumTwoSquares` — look for `Nat.Prime.sq_add_sq`,
+   `Int.sq_add_sq_of_sq_add_sq`, or similar. Check if the biconditional already exists.
+
+2. **ORIENT**: Read `proofs/Proofs/InfinitudePrimes4k1.lean` (already done in selection).
+   Map which Mathlib lemmas are used and which could bridge to the full characterization.
+   Check `GaussianInt` for the Gaussian integer factorization approach.
+
+3. **DECIDE**: If Mathlib has the forward direction as a theorem, write a clean wrapper.
+   If not, determine whether the Gaussian integer path or descent path is more tractable.
+
+## Pool Summary After Selection
+
+| Status | Count |
+|--------|-------|
+| Available | 17 |
+| In Progress | 1233 |
+| Completed | 556 |
+| Graduated | 3 |
+| Blocked | 2 |
+
+## Candidate Pool Health
+
+Pool has 17 available problems — above the 15-problem threshold. However, the `.lean/state/candidate-pool.json` was found to be stale (showed 19 available, database had only 1 truly available before sync to `research/candidate-pool.json`). The stale pool file at `.lean/state/` should be updated to match the synced database.
+
+- **Pool depth**: adequate (17 available, threshold 15)
+- **Recommendation**: Pool healthy. Monitor for claims reducing available count below 15.
+- **Next refresh recommended**: When available drops below 12

--- a/research/problems/infinitude-primes-4k1-oq-01/state.md
+++ b/research/problems/infinitude-primes-4k1-oq-01/state.md
@@ -1,0 +1,25 @@
+# Research State: infinitude-primes-4k1-oq-01
+
+## Current State
+**Phase**: OBSERVE
+**Path**: full
+**Since**: 2026-04-12T14:53:27-07:00
+**Iteration**: 1
+
+## Current Focus
+Initial problem understanding. Read problem.md and gather context.
+
+## Active Approach
+None yet.
+
+## Attempt Count
+- Total attempts: 0
+- Current approach attempts: 0
+- Approaches tried: 0
+
+## Blockers
+None.
+
+## Next Action
+Read problem.md thoroughly and acquire full context.
+Then move to ORIENT phase to explore literature and related proofs.

--- a/research/registry.json
+++ b/research/registry.json
@@ -14944,7 +14944,7 @@
     {
       "slug": "area-of-circle-oq-03-oq-03-oq-01",
       "id": "area-of-circle-oq-03-oq-03-oq-01",
-      "title": "Ellipse area π·a·b via Mathlib measure-theoretic change of variables",
+      "title": "Ellipse area \u03c0\u00b7a\u00b7b via Mathlib measure-theoretic change of variables",
       "status": "active",
       "tier": "B",
       "significance": 6,
@@ -15004,7 +15004,7 @@
       "started": "2026-04-05T22:23:02.409Z",
       "status": "active",
       "lastUpdate": "2026-04-05T22:26:32Z",
-      "notes": "Seeker selected: Fourier transform of Gaussian — removes gaussian_fourier_identity axiom from CLT proof"
+      "notes": "Seeker selected: Fourier transform of Gaussian \u2014 removes gaussian_fourier_identity axiom from CLT proof"
     },
     {
       "slug": "four-color-theorem-oq-02-oq-03",


### PR DESCRIPTION
## Summary

- Select **infinitude-primes-4k1-oq-01** — Fermat's theorem on sums of two squares: p ≡ 1 (mod 4) ⟺ p = a² + b²
- Composite score 87 (significance 7, tractability 8, EMPTY knowledge tier) — highest unselected candidate
- Gallery proof `infinitude-primes-4k1` already verified (0 sorries, 0 axioms), uses `Mathlib.NumberTheory.SumTwoSquares`
- Pool status: 17 available (threshold 15), pool healthy

## Selection rationale

Tied at 87 with erdos-729-oq-02, which was rejected as a repeat selection (selected 2x previously). Diversity check passed — last 3 selections covered number theory (×2) and geometry, no domain monopoly. High tractability (8/10) because Mathlib's SumTwoSquares infrastructure is already imported by the gallery proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)