### PR TITLE
Audit: batch fix sorry/axiom counts in 9 gallery proofs

### DIFF
--- a/src/data/proofs/erdos-395-oq-01/meta.json
+++ b/src/data/proofs/erdos-395-oq-01/meta.json
@@ -114,7 +114,7 @@
     ]
   },
   "leanFile": {
-    "axiomCount": 0,
+    "axiomCount": 2,
     "lineCount": 161,
     "path": "Proofs/Erdos395OQ01.lean",
     "sorries": 2


### PR DESCRIPTION
## Summary

Batch fix for sorry/axiom count mismatches detected by `find-targets.ts`:

| Proof | Field | Old | New |
|-------|-------|-----|-----|
| erdos-715 | sorries | 12 | 15 |
| erdos-627 | sorries | 13 | 16 |
| erdos-610 | sorries | 11 | 17 |
| erdos-612 | sorries | 12 | 16 |
| erdos-607 | sorries | 17 | 20 |
| erdos-671 | sorries | 14 | 23 |
| bounded-prime-gaps-oq-04-oq-01 | sorries | 5 | 4 (overclaimed) |
| fourier-series-oq-02-incomplete-01 | sorries | 1 | 0 (all proved) |
| erdos-395-oq-01 | leanFile.axiomCount | 0 | 2 |

**Root cause**: initial meta.json generation counted only theorem-level `by sorry` and missed sorries in `Nat.find` existence proofs, multi-sorry theorems, and definition proof obligations.

## Test plan

- [ ] `pnpm build` passes
- [ ] `npx tsx scripts/auditor/find-targets.ts --issues` shows reduced issue count

🤖 Generated with [Claude Code](https://claude.com/claude-code)