### PR TITLE
Fix: sync stale sorry counts in 11 gallery proofs

### DIFF
--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -13,10 +13,10 @@
       "tournaments"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 3,
     "axiomCount": 0,
     "lineCount": 1285,
-    "assumptions": "0 axioms. 1 sorry in Ghouila-Houri helper: ghouila_houri_cycle_extendable (cycle of length k < n → longer cycle under GH degree conditions). sc_degree_has_cycle (SC + high degree → initial directed cycle) is now fully proved via greedy path extension and back-arc argument. directed_hamiltonian_threshold is fully proved (0 sorries). Moon-Moser theorem and Rédei are also fully proved.",
+    "assumptions": "0 axioms. 1 sorry in Ghouila-Houri helper: ghouila_houri_cycle_extendable (cycle of length k < n → longer cycle under GH degree conditions). sc_degree_has_cycle (SC + high degree → initial directed cycle) is now fully proved via greedy path extension and back-arc argument. directed_hamiltonian_threshold is fully proved (3 sorries). Moon-Moser theorem and Rédei are also fully proved.",
     "dateAdded": "2026-03-30",
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Hamiltonian_path_problem#Directed_graphs",
@@ -125,7 +125,7 @@
     "namespace": "Erdos1012OQ03",
     "lineCount": 1285,
     "axiomCount": 0,
-    "sorries": 1,
+    "sorries": 3,
     "path": "Proofs/Erdos1012OQ03.lean",
     "theoremCount": 22,
     "definitionCount": 10

--- a/src/data/proofs/erdos-490/meta.json
+++ b/src/data/proofs/erdos-490/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 6,
     "erdosNumber": 490,
     "erdosUrl": "https://erdosproblems.com/490",
     "erdosProblemStatus": "solved",
@@ -71,7 +71,7 @@
     ],
     "axiomCount": 2,
     "lineCount": 282,
-    "assumptions": "2 axiom(s) and 3 sorry(s). See the Lean source for details."
+    "assumptions": "2 axiom(s) and 6 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "Erdős posed Problem #490 at the 1972 Number Theory Conference at the University of Colorado, asking for the maximum of $|A||B|$ when $A, B \\subseteq \\{1,\\ldots,N\\}$ have all products $ab$ distinct. The problem sits at the intersection of multiplicative number theory and extremal combinatorics.\n\nSzemerédi resolved the problem in 1976 in his paper \"On a problem of P. Erdős\" in the Journal of Number Theory, proving that $|A||B| \\ll N^2/\\log N$. His argument is a counting argument based on the divisor function: the total number of divisor pairs $(a,b)$ with $ab \\leq N^2$ is $\\sum_{n \\leq N^2} d(n) \\sim N^2 \\log N$, but the distinct products condition restricts each $n$ to contribute at most one pair, yielding the $\\log N$ savings.\n\nThe bound is sharp. The construction $A = [1, N/2]$ and $B = \\{p \\text{ prime} : N/2 < p \\leq N\\}$ achieves $|A||B| \\sim N^2/(4\\log N)$. The key insight is that primes $p > N/2$ cannot divide any integer $\\leq N/2$ (since $p > N/2 \\geq a$ for $a \\in A$), so $a_1 p_1 = a_2 p_2$ forces $p_1 = p_2$ by unique factorization, and then $a_1 = a_2$. By the prime number theorem, $|B| = \\pi(N) - \\pi(N/2) \\sim N/(2\\log N)$.\n\nErdős also posed the finer question: does $\\lim_{N\\to\\infty} \\max |A||B| \\cdot \\log N / N^2$ exist? Van Doorn observed that if the limit exists, it must be $\\geq 1$. This limit question remains open and connects to deep questions about the distribution of smooth numbers and the multiplicative structure of intervals.",
@@ -203,7 +203,7 @@
     "theoremCount": 10,
     "definitionCount": 15,
     "path": "Proofs/Erdos490Problem.lean",
-    "sorries": 3
+    "sorries": 6
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-607/meta.json
+++ b/src/data/proofs/erdos-607/meta.json
@@ -18,7 +18,7 @@
       "asymptotics"
     ],
     "badge": "axiom",
-    "sorries": 17,
+    "sorries": 20,
     "erdosNumber": 607,
     "erdosUrl": "https://erdosproblems.com/607",
     "erdosProblemStatus": "solved",
@@ -67,7 +67,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 203,
-    "assumptions": "1 axiom(s) and 17 sorry(s). See the Lean source for details.",
+    "assumptions": "1 axiom(s) and 20 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -212,7 +212,7 @@
     "theoremCount": 13,
     "definitionCount": 13,
     "path": "Proofs/Stubs/Erdos607Problem.lean",
-    "sorries": 17
+    "sorries": 20
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-610/meta.json
+++ b/src/data/proofs/erdos-610/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 11,
+    "sorries": 17,
     "erdosNumber": 610,
     "erdosUrl": "https://erdosproblems.com/610",
     "erdosProblemStatus": "open",
@@ -89,7 +89,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 222,
-    "assumptions": "1 axiom(s) and 11 sorry(s). See the Lean source for details."
+    "assumptions": "1 axiom(s) and 17 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Clique Transversals: Hitting Every Maximal Clique**\n\nA clique transversal is a set of vertices that intersects every maximal clique in a graph. The clique transversal number τ(G) — the minimum size of such a set — was introduced by Erdős, Gallai, and Tuza in the context of extremal graph theory.\n\n**The Erdős-Gallai-Tuza Bound**\n\nThe trio proved τ(G) ≤ n - √(2n) + O(1) for any n-vertex graph. The proof uses Turán's theorem on an auxiliary 'clique-intersection graph': vertices of G that share no maximal clique form an independent set of size ≥ √(2n), and removing this independent set leaves a transversal. The bound is constructive — the greedy algorithm finds such a transversal in polynomial time.\n\n**Near-Tightness**\n\nConstructions (Paley-type graphs, random graphs) achieve τ ≈ n - √(2n), showing the √(2n) coefficient is essentially correct. This means improving the bound requires new ideas, not just better analysis of existing arguments.\n\n**The Triangle-Free Connection**\n\nThe deep conjecture τ(G) ≤ n - f(n), where f(n) is the minimum independence number among triangle-free n-vertex graphs, would improve √(2n) to √(n log n). Kim's celebrated theorem (1995) establishes f(n) = Θ(√(n log n)) via the semi-random method (Rödl nibble), proving R(3,k) = Θ(k²/log k). The logarithmic improvement factor √(log n) represents a qualitative jump — the difference between constant and growing coefficients of √n.\n\n**Special Graph Classes**\n\nFor bipartite graphs, τ equals the vertex cover number (König's theorem). For chordal graphs, the clique tree structure enables polynomial computation. For perfect graphs, LP duality gives integrality. The general case remains the frontier.",
@@ -208,7 +208,7 @@
     "theoremCount": 13,
     "definitionCount": 16,
     "path": "Proofs/Stubs/Erdos610Problem.lean",
-    "sorries": 11
+    "sorries": 17
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-612/meta.json
+++ b/src/data/proofs/erdos-612/meta.json
@@ -19,7 +19,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 12,
+    "sorries": 16,
     "erdosNumber": 612,
     "erdosUrl": "https://erdosproblems.com/612",
     "erdosProblemStatus": "open",
@@ -51,7 +51,7 @@
     ],
     "axiomCount": 6,
     "lineCount": 268,
-    "assumptions": "6 axiom(s) and 12 sorry(s). See the Lean source for details.",
+    "assumptions": "6 axiom(s) and 16 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -179,7 +179,7 @@
     "theoremCount": 12,
     "definitionCount": 13,
     "path": "Proofs/Stubs/Erdos612Problem.lean",
-    "sorries": 12
+    "sorries": 16
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-627/meta.json
+++ b/src/data/proofs/erdos-627/meta.json
@@ -19,7 +19,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 13,
+    "sorries": 16,
     "erdosNumber": 627,
     "erdosUrl": "https://erdosproblems.com/627",
     "erdosProblemStatus": "open",
@@ -58,7 +58,7 @@
     ],
     "axiomCount": 8,
     "lineCount": 236,
-    "assumptions": "8 axiom(s) and 13 sorry(s).",
+    "assumptions": "8 axiom(s) and 16 sorry(s).",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -194,7 +194,7 @@
     "theoremCount": 13,
     "definitionCount": 14,
     "path": "Proofs/Stubs/Erdos627Problem.lean",
-    "sorries": 13
+    "sorries": 16
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-671/meta.json
+++ b/src/data/proofs/erdos-671/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 14,
+    "sorries": 23,
     "erdosNumber": 671,
     "erdosUrl": "https://erdosproblems.com/671",
     "erdosProblemStatus": "open",
@@ -64,7 +64,7 @@
     ],
     "axiomCount": 3,
     "lineCount": 249,
-    "assumptions": "3 axiom(s) and 14 sorry(s). See the Lean source for details."
+    "assumptions": "3 axiom(s) and 23 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Erdos Problem #671**\n\nThis is a deep problem in approximation theory about the relationship between the Lebesgue function and Lagrange interpolation convergence.\n\n**Key History:**\n- 1931: Bernstein proves lambda_n(x) diverges at some point for any interpolation scheme\n- 1980: Erdos and Vertesi prove that for any points, some continuous f has |L^n f(x)| -> infinity a.e.\n- Present: Questions 1 and 2 remain open with $250 prize\n\n**Mathematical Context:**\nThe Lebesgue function lambda_n(x) = sum |p_i^n(x)| controls interpolation error: the error is bounded by (1 + Lambda_n) times the best polynomial approximation. When Lambda_n grows, uniform convergence fails. The questions ask whether *pointwise* convergence can still occur when lambda_n diverges.",
@@ -148,7 +148,7 @@
     "axiomCount": 3,
     "theoremCount": 14,
     "definitionCount": 0,
-    "sorries": 14,
+    "sorries": 23,
     "path": "Proofs/Erdos671Problem.lean"
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-715/meta.json
+++ b/src/data/proofs/erdos-715/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "wip",
-    "sorries": 12,
+    "sorries": 15,
     "erdosNumber": 715,
     "erdosUrl": "https://erdosproblems.com/715",
     "erdosProblemStatus": "solved",
@@ -83,7 +83,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 209,
-    "assumptions": "No axioms. 12 sorry(s) remain in the formalization."
+    "assumptions": "No axioms. 15 sorry(s) remain in the formalization."
   },
   "overview": {
     "historicalContext": "This problem was posed by Berge and Sauer at the 6th Hungarian Combinatorial Colloquium (1976). It asks whether regular graphs of sufficient degree must contain regular subgraphs of smaller degree. Tashkinov (1982) gave the definitive answer: every 4-regular graph contains a 3-regular subgraph. This was strengthened by Alon, Friedland, and Kalai (1984), who showed that every 4-regular graph plus a single edge already contains a 3-regular subgraph, immediately implying the result for all r ≥ 5.\n\nThe threshold r = 4 is sharp: K₄ is 3-regular but has no proper 3-regular subgraph (removing any edge drops some degree below 3). The Petersen graph (10 vertices, 3-regular) is another minimal example. The general question — for which (r, k) pairs does every r-regular graph contain a k-regular subgraph? — remains an active research area for k ≥ 4.",
@@ -189,7 +189,7 @@
     "theoremCount": 13,
     "definitionCount": 10,
     "path": "Proofs/Stubs/Erdos715Problem.lean",
-    "sorries": 12
+    "sorries": 15
   },
   "references": [
     {

--- a/src/data/proofs/erdos-748/meta.json
+++ b/src/data/proofs/erdos-748/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 4,
     "erdosNumber": 748,
     "erdosUrl": "https://erdosproblems.com/748",
     "erdosProblemStatus": "solved",
@@ -182,7 +182,7 @@
     "theoremCount": 11,
     "definitionCount": 5,
     "path": "Proofs/Erdos748Problem.lean",
-    "sorries": 1
+    "sorries": 4
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-76/meta.json
+++ b/src/data/proofs/erdos-76/meta.json
@@ -18,7 +18,7 @@
       "extremal-combinatorics"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 4,
     "erdosNumber": 76,
     "erdosUrl": "https://erdosproblems.com/76",
     "erdosProblemStatus": "solved",
@@ -224,7 +224,7 @@
     "theoremCount": 5,
     "definitionCount": 15,
     "path": "Proofs/Stubs/Erdos76Problem.lean",
-    "sorries": 1
+    "sorries": 4
   },
   "references": [
     {

--- a/src/data/proofs/erdos-820/meta.json
+++ b/src/data/proofs/erdos-820/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 6,
     "erdosNumber": 820,
     "erdosUrl": "https://erdosproblems.com/820",
     "erdosProblemStatus": "open",
@@ -62,7 +62,7 @@
     ],
     "axiomCount": 3,
     "lineCount": 284,
-    "assumptions": "3 axiom(s) and 3 sorry(s). See the Lean source for details."
+    "assumptions": "3 axiom(s) and 6 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**The GCD Problem for Exponential Sequences**\n\nThis problem originates from Erdős's 1974 paper \"Remarks on some problems in number theory\" in Mathematica Balkanica. The core question studies when powers of different bases minus one are coprime.\n\n**The Function H(n)**\n\nDefine H(n) as the smallest l such that there exists k < l with gcd(k^n - 1, l^n - 1) = 1. This measures how \"rare\" coprimality is among these exponential expressions.\n\n**Computed Values**\n\nFor small n: H(1)=3, H(2)=3, H(3)=3, H(4)=6, H(5)=3, H(6)=18, H(7)=3, H(8)=6, H(9)=3, H(10)=12. The value H(n)=3 occurs frequently, corresponding to gcd(2^n-1, 3^n-1)=1.\n\n**Progress**\n\n1. **Erdős (1974):** Proved H(n) > exp(n^{c/(log log n)²}) for infinitely many n\n2. **van Doorn:** Improved to H(n) > exp(n^{c/log log n}) infinitely often\n3. **OEIS A263647:** Catalogues n where gcd(2^n-1, 3^n-1)=1\n\nThe main conjectures remain OPEN.",
@@ -204,7 +204,7 @@
     "theoremCount": 5,
     "definitionCount": 12,
     "path": "Proofs/Stubs/Erdos820Problem.lean",
-    "sorries": 3
+    "sorries": 6
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Correct meta.json sorry counts to match actual sorry occurrences in Lean source files (excluding block comments and line comments).

## Evidence

| Proof | Before | After |
|-------|--------|-------|
| erdos-1012-oq-03 | 1 | 3 |
| erdos-490 | 3 | 6 |
| erdos-607 | 17 | 20 |
| erdos-610 | 11 | 17 |
| erdos-612 | 12 | 16 |
| erdos-627 | 13 | 16 |
| erdos-671 | 14 | 23 |
| erdos-715 | 12 | 15 |
| erdos-748 | 1 | 4 |
| erdos-76 | 1 | 4 |
| erdos-820 | 3 | 6 |

All counts verified by parsing Lean files with comment-aware sorry counter. `pnpm build` passes.

---
Automated fix by lean-mechanic agent.