### PR TITLE
Refactor: account allowlist replaces single-pin

### DIFF
--- a/.claude/commands/lean.md
+++ b/.claude/commands/lean.md
@@ -64,13 +64,15 @@ Or for a one-shot Claude subagent (independent of the daemon pool), use the Agen
 ./scripts/lean/launch.sh wake [type]
 ```
 
-## Account Pinning
+## Account Allowlist
 
-Check/change which OAuth account agents use:
+Control which OAuth accounts agents use:
 ```bash
-./scripts/agents/pin-account.sh status    # Show current pin
-./scripts/agents/pin-account.sh pin <name> # Pin to account (partial match OK)
-./scripts/agents/pin-account.sh unpin      # Resume load balancing
+./scripts/agents/pin-account.sh status                  # Show current state
+./scripts/agents/pin-account.sh allow agent-6 agent-7   # Only use these accounts
+./scripts/agents/pin-account.sh add agent-8             # Add to allowlist
+./scripts/agents/pin-account.sh remove agent-6          # Remove from allowlist
+./scripts/agents/pin-account.sh reset                   # Use all accounts (default)
 ```
 
 ## Quick Reference

--- a/scripts/agents/claude-wrapper.sh
+++ b/scripts/agents/claude-wrapper.sh
@@ -35,46 +35,47 @@ unset CLAUDECODE 2>/dev/null || true
 # Load long-lived OAuth token for autonomous agent sessions.
 # Supports multiple accounts via .loom/tokens/*.token files (load balancing).
 # Falls back to CLAUDE_CODE_OAUTH_TOKEN in .env for single-account setups.
+#
+# Account filtering:
+#   .loom/tokens/.allowlist — one account name per line; only these accounts are used.
+#   If absent, all .token files are eligible.
 if [[ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
     _repo_root="${REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
     _tokens_dir="$_repo_root/.loom/tokens"
 
     if [[ -d "$_tokens_dir" ]] && ls "$_tokens_dir"/*.token &>/dev/null; then
-        _token_files=("$_tokens_dir"/*.token)
-        _count=${#_token_files[@]}
-        _pin_file="$_tokens_dir/.pinned"
+        _allowlist_file="$_tokens_dir/.allowlist"
 
-        if [[ -f "$_pin_file" ]]; then
-            # Pinned mode: use the specified account
-            _pinned_acct=$(tr -d '[:space:]' < "$_pin_file")
-            _selected="$_tokens_dir/${_pinned_acct}.token"
-            if [[ -f "$_selected" ]]; then
-                _token=$(tr -d '[:space:]' < "$_selected")
-                if [[ -n "$_token" ]]; then
-                    export CLAUDE_CODE_OAUTH_TOKEN="$_token"
-                    echo "[wrapper] Using PINNED account: $_pinned_acct" >&2
+        # Build eligible token list (filtered by allowlist if present)
+        _eligible_tokens=()
+        if [[ -f "$_allowlist_file" ]]; then
+            while IFS= read -r _name || [[ -n "$_name" ]]; do
+                _name=$(echo "$_name" | tr -d '[:space:]')
+                [[ -z "$_name" || "$_name" == \#* ]] && continue
+                if [[ -f "$_tokens_dir/${_name}.token" ]]; then
+                    _eligible_tokens+=("$_tokens_dir/${_name}.token")
+                else
+                    echo "[wrapper] WARNING: allowlisted account '$_name' has no token file, skipping" >&2
                 fi
-            else
-                echo "[wrapper] WARNING: pinned account '$_pinned_acct' not found, falling back to random" >&2
-                _idx=$(( RANDOM % _count ))
-                _selected="${_token_files[$_idx]}"
-                _token=$(tr -d '[:space:]' < "$_selected")
-                if [[ -n "$_token" ]]; then
-                    export CLAUDE_CODE_OAUTH_TOKEN="$_token"
-                    _acct=$(basename "$_selected" .token)
-                    echo "[wrapper] Using OAuth account: $_acct (${_count} available)" >&2
-                fi
+            done < "$_allowlist_file"
+            if [[ ${#_eligible_tokens[@]} -eq 0 ]]; then
+                echo "[wrapper] WARNING: allowlist is empty or all entries invalid, falling back to all accounts" >&2
+                _eligible_tokens=("$_tokens_dir"/*.token)
             fi
+            _mode="allowlist"
         else
-            # Default: multi-account load balancing via random selection
-            _idx=$(( RANDOM % _count ))
-            _selected="${_token_files[$_idx]}"
-            _token=$(tr -d '[:space:]' < "$_selected")
-            if [[ -n "$_token" ]]; then
-                export CLAUDE_CODE_OAUTH_TOKEN="$_token"
-                _acct=$(basename "$_selected" .token)
-                echo "[wrapper] Using OAuth account: $_acct (${_count} available)" >&2
-            fi
+            _eligible_tokens=("$_tokens_dir"/*.token)
+            _mode="all"
+        fi
+
+        _count=${#_eligible_tokens[@]}
+        _idx=$(( RANDOM % _count ))
+        _selected="${_eligible_tokens[$_idx]}"
+        _token=$(tr -d '[:space:]' < "$_selected")
+        if [[ -n "$_token" ]]; then
+            export CLAUDE_CODE_OAUTH_TOKEN="$_token"
+            _acct=$(basename "$_selected" .token)
+            echo "[wrapper] Using OAuth account: $_acct (${_count} eligible, mode: ${_mode})" >&2
         fi
     else
         # Fallback: single token from .env
@@ -349,7 +350,27 @@ is_token_bad() {
     [[ -f "$_bad_tokens_file" ]] && grep -q " $token_name " "$_bad_tokens_file" 2>/dev/null
 }
 
-# Try rotating to a working token (skip bad ones)
+# Build the list of eligible tokens (respecting allowlist)
+_get_eligible_tokens() {
+    local _repo_root="${REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+    local _tokens_dir="$_repo_root/.loom/tokens"
+    local _allowlist_file="$_tokens_dir/.allowlist"
+
+    _eligible_rotation_tokens=()
+    if [[ -f "$_allowlist_file" ]]; then
+        while IFS= read -r _name || [[ -n "$_name" ]]; do
+            _name=$(echo "$_name" | tr -d '[:space:]')
+            [[ -z "$_name" || "$_name" == \#* ]] && continue
+            [[ -f "$_tokens_dir/${_name}.token" ]] && _eligible_rotation_tokens+=("$_tokens_dir/${_name}.token")
+        done < "$_allowlist_file"
+    fi
+    # Fall back to all tokens if allowlist empty/missing
+    if [[ ${#_eligible_rotation_tokens[@]} -eq 0 ]]; then
+        _eligible_rotation_tokens=("$_tokens_dir"/*.token)
+    fi
+}
+
+# Try rotating to a working token (skip bad ones, respect allowlist)
 rotate_to_working_token() {
     local _repo_root="${REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
     local _tokens_dir="$_repo_root/.loom/tokens"
@@ -358,40 +379,13 @@ rotate_to_working_token() {
         return 1
     fi
 
-    # If pinned, don't rotate — unless we've failed too many times
-    local _pin_file="$_tokens_dir/.pinned"
-    local _pin_fail_file="$_tokens_dir/.pin-exhaust-count"
-    local _pin_exhaust_limit=5
-    if [[ -f "$_pin_file" ]]; then
-        local _pinned_acct
-        _pinned_acct=$(tr -d '[:space:]' < "$_pin_file")
-
-        # Track consecutive exhaustion failures while pinned
-        local _pin_fails=0
-        if [[ -f "$_pin_fail_file" ]]; then
-            _pin_fails=$(tr -d '[:space:]' < "$_pin_fail_file")
-            _pin_fails=${_pin_fails:-0}
-        fi
-        _pin_fails=$((_pin_fails + 1))
-        echo "$_pin_fails" > "$_pin_fail_file"
-
-        if [[ $_pin_fails -ge $_pin_exhaust_limit ]]; then
-            log_warn "Account pinned to $_pinned_acct exhausted after $_pin_fails attempts — auto-unpinning to allow rotation"
-            rm -f "$_pin_file" "$_pin_fail_file"
-            # Fall through to normal rotation below
-        else
-            log_warn "Account pinned to $_pinned_acct — not rotating (attempt $_pin_fails/$_pin_exhaust_limit, will backoff instead)"
-            return 1
-        fi
-    fi
-
-    local _token_files=("$_tokens_dir"/*.token)
-    local _count=${#_token_files[@]}
+    _get_eligible_tokens
+    local _count=${#_eligible_rotation_tokens[@]}
     local _tried=0
 
     while [[ $_tried -lt $_count ]]; do
         local _idx=$(( RANDOM % _count ))
-        local _selected="${_token_files[$_idx]}"
+        local _selected="${_eligible_rotation_tokens[$_idx]}"
         local _acct
         _acct=$(basename "$_selected" .token)
 
@@ -410,7 +404,7 @@ rotate_to_working_token() {
         _tried=$((_tried + 1))
     done
 
-    log_error "All $_count tokens are marked bad or empty"
+    log_error "All $_count eligible tokens are marked bad or empty"
     return 1
 }
 

--- a/scripts/agents/pin-account.sh
+++ b/scripts/agents/pin-account.sh
@@ -1,18 +1,23 @@
 #!/bin/bash
 #
-# pin-account.sh - Pin all agents to a specific OAuth account
+# pin-account.sh - Manage the account allowlist for agent token selection
 #
-# When pinned, all claude-wrapper.sh invocations use the pinned account
-# instead of random load balancing. Useful when you want to burn through
-# a specific account's quota or debug account-specific issues.
+# When an allowlist is active, agents load-balance only across listed accounts.
+# When no allowlist exists, all .token files are eligible (default).
 #
 # Usage:
-#   ./scripts/agents/pin-account.sh pin robb-integratedplasmonics
-#   ./scripts/agents/pin-account.sh unpin
-#   ./scripts/agents/pin-account.sh status
-#   ./scripts/agents/pin-account.sh list
+#   ./scripts/agents/pin-account.sh allow agent-6 agent-7   # Set allowlist
+#   ./scripts/agents/pin-account.sh add agent-8              # Add to allowlist
+#   ./scripts/agents/pin-account.sh remove agent-8           # Remove from allowlist
+#   ./scripts/agents/pin-account.sh reset                    # Remove allowlist (use all)
+#   ./scripts/agents/pin-account.sh status                   # Show current state
+#   ./scripts/agents/pin-account.sh list                     # List all accounts
 #
-# The pin is stored in .loom/tokens/.pinned (contains token filename stem).
+# Legacy compatibility:
+#   ./scripts/agents/pin-account.sh pin <name>   # Same as: allow <name>
+#   ./scripts/agents/pin-account.sh unpin        # Same as: reset
+#
+# The allowlist is stored in .loom/tokens/.allowlist (one account per line).
 # New agents pick it up immediately; running agents pick it up on next cycle.
 #
 
@@ -20,27 +25,41 @@ set -euo pipefail
 
 REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
 TOKENS_DIR="$REPO_ROOT/.loom/tokens"
-PIN_FILE="$TOKENS_DIR/.pinned"
+ALLOWLIST_FILE="$TOKENS_DIR/.allowlist"
+# Legacy pin file — removed on any allowlist operation
+LEGACY_PIN_FILE="$TOKENS_DIR/.pinned"
 
 usage() {
     cat <<'EOF'
-Usage: pin-account.sh <command> [account-name]
+Usage: pin-account.sh <command> [accounts...]
 
 Commands:
-  pin <name>   Pin all agents to the named account
-  unpin        Remove pin (resume load balancing)
-  status       Show current pin status
-  list         List available accounts
+  allow <name...>   Set allowlist to exactly these accounts
+  add <name...>     Add account(s) to existing allowlist
+  remove <name...>  Remove account(s) from allowlist
+  reset             Remove allowlist (all accounts eligible)
+  status            Show current allowlist and account state
+  list              List all available accounts
+
+  pin <name>        Legacy: same as "allow <name>"
+  unpin             Legacy: same as "reset"
 
 Account names are token file stems (without .token extension).
-Partial matches are supported: "robb-int" matches "robb-integratedplasmonics".
+Partial matches are supported: "agent-6" matches "agent-6-rwalters".
 
 Examples:
-  pin-account.sh pin robb-integratedplasmonics
-  pin-account.sh pin robb-int          # partial match
-  pin-account.sh pin agent0            # partial match
-  pin-account.sh unpin
+  pin-account.sh allow agent-6 agent-7     # Only use these two
+  pin-account.sh add agent-8               # Add a third
+  pin-account.sh remove agent-6            # Drop one
+  pin-account.sh reset                     # Back to all accounts
 EOF
+}
+
+cleanup_legacy() {
+    if [[ -f "$LEGACY_PIN_FILE" ]]; then
+        rm -f "$LEGACY_PIN_FILE" "$TOKENS_DIR/.pin-exhaust-count"
+        echo "  (removed legacy .pinned file)"
+    fi
 }
 
 list_accounts() {
@@ -49,21 +68,33 @@ list_accounts() {
         return 1
     fi
 
-    local pinned=""
-    if [[ -f "$PIN_FILE" ]]; then
-        pinned=$(cat "$PIN_FILE")
+    local allowlisted=()
+    if [[ -f "$ALLOWLIST_FILE" ]]; then
+        while IFS= read -r name || [[ -n "$name" ]]; do
+            name=$(echo "$name" | tr -d '[:space:]')
+            [[ -z "$name" || "$name" == \#* ]] && continue
+            allowlisted+=("$name")
+        done < "$ALLOWLIST_FILE"
     fi
 
     echo "Available accounts:"
     for f in "$TOKENS_DIR"/*.token; do
         local name
         name=$(basename "$f" .token)
-        if [[ "$name" == "$pinned" ]]; then
-            echo "  * $name  (PINNED)"
-        else
-            echo "    $name"
-        fi
+        local marker="  "
+        for a in "${allowlisted[@]+"${allowlisted[@]}"}"; do
+            if [[ "$a" == "$name" ]]; then
+                marker="* "
+                break
+            fi
+        done
+        echo "  ${marker}${name}"
     done
+
+    if [[ ${#allowlisted[@]} -gt 0 ]]; then
+        echo ""
+        echo "  * = in allowlist"
+    fi
 }
 
 resolve_account() {
@@ -74,7 +105,6 @@ resolve_account() {
         local name
         name=$(basename "$f" .token)
         if [[ "$name" == "$query" ]]; then
-            # Exact match
             echo "$name"
             return 0
         fi
@@ -98,48 +128,148 @@ resolve_account() {
     fi
 }
 
-cmd_pin() {
+cmd_allow() {
     if [[ $# -lt 1 ]]; then
-        echo "Error: pin requires an account name" >&2
+        echo "Error: allow requires at least one account name" >&2
         usage >&2
         return 1
     fi
 
-    local account
-    account=$(resolve_account "$1") || return 1
+    local resolved=()
+    for name in "$@"; do
+        local acct
+        acct=$(resolve_account "$name") || return 1
+        resolved+=("$acct")
+    done
 
-    local token_file="$TOKENS_DIR/${account}.token"
-    if [[ ! -f "$token_file" ]]; then
-        echo "Error: token file not found: $token_file" >&2
+    mkdir -p "$TOKENS_DIR"
+    printf '%s\n' "${resolved[@]}" > "$ALLOWLIST_FILE"
+    cleanup_legacy
+
+    echo "Allowlist set to ${#resolved[@]} account(s):"
+    for acct in "${resolved[@]}"; do
+        echo "  $acct"
+    done
+    echo ""
+    echo "New agents will use only these accounts."
+    echo "Running agents pick this up on next cycle."
+    echo "To reset: $(basename "$0") reset"
+}
+
+cmd_add() {
+    if [[ $# -lt 1 ]]; then
+        echo "Error: add requires at least one account name" >&2
         return 1
     fi
 
-    echo "$account" > "$PIN_FILE"
-    echo "Pinned all agents to: $account"
-    echo "New agent invocations will use this account immediately."
-    echo "Running agents will pick it up on their next cycle."
-    echo ""
-    echo "To unpin: $(basename "$0") unpin"
+    # Load existing
+    local existing=()
+    if [[ -f "$ALLOWLIST_FILE" ]]; then
+        while IFS= read -r name || [[ -n "$name" ]]; do
+            name=$(echo "$name" | tr -d '[:space:]')
+            [[ -z "$name" || "$name" == \#* ]] && continue
+            existing+=("$name")
+        done < "$ALLOWLIST_FILE"
+    fi
+
+    local added=()
+    for name in "$@"; do
+        local acct
+        acct=$(resolve_account "$name") || return 1
+        # Check for duplicates
+        local dup=false
+        for e in "${existing[@]+"${existing[@]}"}"; do
+            [[ "$e" == "$acct" ]] && dup=true && break
+        done
+        if $dup; then
+            echo "  $acct already in allowlist, skipping"
+        else
+            existing+=("$acct")
+            added+=("$acct")
+        fi
+    done
+
+    if [[ ${#added[@]} -eq 0 ]]; then
+        echo "No new accounts added."
+        return 0
+    fi
+
+    mkdir -p "$TOKENS_DIR"
+    printf '%s\n' "${existing[@]}" > "$ALLOWLIST_FILE"
+    cleanup_legacy
+
+    echo "Added ${#added[@]} account(s) to allowlist:"
+    for acct in "${added[@]}"; do
+        echo "  + $acct"
+    done
+    echo "Allowlist now has ${#existing[@]} account(s)."
 }
 
-cmd_unpin() {
-    if [[ -f "$PIN_FILE" ]]; then
-        local was
-        was=$(cat "$PIN_FILE")
-        rm -f "$PIN_FILE"
-        echo "Unpinned (was: $was). Agents will resume load balancing."
+cmd_remove() {
+    if [[ $# -lt 1 ]]; then
+        echo "Error: remove requires at least one account name" >&2
+        return 1
+    fi
+
+    if [[ ! -f "$ALLOWLIST_FILE" ]]; then
+        echo "No allowlist active — nothing to remove from." >&2
+        return 1
+    fi
+
+    local to_remove=()
+    for name in "$@"; do
+        local acct
+        acct=$(resolve_account "$name") || return 1
+        to_remove+=("$acct")
+    done
+
+    local remaining=()
+    while IFS= read -r name || [[ -n "$name" ]]; do
+        name=$(echo "$name" | tr -d '[:space:]')
+        [[ -z "$name" || "$name" == \#* ]] && continue
+        local keep=true
+        for r in "${to_remove[@]}"; do
+            [[ "$r" == "$name" ]] && keep=false && break
+        done
+        $keep && remaining+=("$name")
+    done < "$ALLOWLIST_FILE"
+
+    if [[ ${#remaining[@]} -eq 0 ]]; then
+        rm -f "$ALLOWLIST_FILE"
+        echo "Allowlist is now empty — removed it. All accounts are eligible."
     else
-        echo "No account is currently pinned."
+        printf '%s\n' "${remaining[@]}" > "$ALLOWLIST_FILE"
+        echo "Removed ${#to_remove[@]} account(s). Allowlist now has ${#remaining[@]}:"
+        for acct in "${remaining[@]}"; do
+            echo "  $acct"
+        done
     fi
 }
 
-cmd_status() {
-    if [[ -f "$PIN_FILE" ]]; then
-        local pinned
-        pinned=$(cat "$PIN_FILE")
-        echo "Pinned to: $pinned"
+cmd_reset() {
+    if [[ -f "$ALLOWLIST_FILE" ]]; then
+        rm -f "$ALLOWLIST_FILE"
+        echo "Allowlist removed. All accounts are now eligible."
     else
-        echo "No pin active — agents are load-balancing across all accounts."
+        echo "No allowlist was active."
+    fi
+    cleanup_legacy
+}
+
+cmd_status() {
+    if [[ -f "$ALLOWLIST_FILE" ]]; then
+        local count=0
+        echo "Allowlist active:"
+        while IFS= read -r name || [[ -n "$name" ]]; do
+            name=$(echo "$name" | tr -d '[:space:]')
+            [[ -z "$name" || "$name" == \#* ]] && continue
+            echo "  * $name"
+            count=$((count + 1))
+        done < "$ALLOWLIST_FILE"
+        echo ""
+        echo "$count account(s) in allowlist."
+    else
+        echo "No allowlist active — agents load-balance across all accounts."
     fi
     echo ""
     list_accounts
@@ -147,12 +277,29 @@ cmd_status() {
 
 # Main
 case "${1:-}" in
-    pin)
+    allow)
         shift
-        cmd_pin "$@"
+        cmd_allow "$@"
+        ;;
+    add)
+        shift
+        cmd_add "$@"
+        ;;
+    remove)
+        shift
+        cmd_remove "$@"
+        ;;
+    reset)
+        cmd_reset
+        ;;
+    pin)
+        # Legacy: pin = allow single account
+        shift
+        cmd_allow "$@"
         ;;
     unpin)
-        cmd_unpin
+        # Legacy: unpin = reset
+        cmd_reset
         ;;
     status|"")
         cmd_status


### PR DESCRIPTION
## Summary
- Replaces the single-account `.pinned` mechanism with a multi-account `.allowlist` file
- When `.allowlist` exists, agents load-balance only across listed accounts
- When absent, all accounts are eligible (unchanged default behavior)
- New CLI commands: `allow`, `add`, `remove`, `reset` (legacy `pin`/`unpin` still work)
- Token rotation also respects the allowlist, removing the old pin-exhaust counter logic

## Motivation
Need to restrict agents to specific accounts (e.g., agent-6 and agent-7) to manage token spend. The old system only supported pinning to a single account.

## Test plan
- [ ] `pin-account.sh allow agent-6 agent-7` creates `.allowlist` with both entries
- [ ] `pin-account.sh add agent-8` appends without duplicating
- [ ] `pin-account.sh remove agent-6` removes one entry
- [ ] `pin-account.sh reset` deletes the allowlist file
- [ ] `pin-account.sh status` shows current state
- [ ] Wrapper log shows `mode: allowlist` when allowlist active, `mode: all` when not
- [ ] Legacy `pin`/`unpin` commands still work (mapped to `allow`/`reset`)
- [ ] Token rotation respects allowlist boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)