### PR TITLE
chore: audit tracker — all 2000 proofs audited, 0 issues

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12065,6 +12065,42 @@
       "lastAudited": "2026-04-12T21:14:37Z",
       "result": "clean",
       "issues": []
+    },
+    "erdos-1008-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-12T22:39:43Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-606-oq-03-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-12T22:39:44Z",
+      "result": "clean",
+      "issues": []
+    },
+    "factor-remainder-nullstellensatz-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-12T22:39:44Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hilbert-10-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-12T22:39:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "schauder-fixed-point-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-12T22:39:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "wolstenholme-theorem-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-12T22:39:46Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {


### PR DESCRIPTION
## Summary

- Mark 6 newly audited proofs as clean in audit-tracker.json
- Gallery is now fully audited: **2000/2000 proofs, 0 issues, 0 critical**

Newly audited (all clean):
- erdos-1008-oq-04
- erdos-606-oq-03-oq-03
- factor-remainder-nullstellensatz-oq-02
- hilbert-10-oq-01
- schauder-fixed-point-oq-03-oq-01
- wolstenholme-theorem-oq-03

## Test plan

- [ ] `npx tsx scripts/auditor/find-targets.ts --stats` shows 0 unaudited

🤖 Generated with [Claude Code](https://claude.com/claude-code)