### PR TITLE
fix(gallery): correct erdos-1033 sorry count and assumptions

### DIFF
--- a/src/data/proofs/erdos-1033/meta.json
+++ b/src/data/proofs/erdos-1033/meta.json
@@ -17,7 +17,7 @@
       "turan-theory"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 5,
     "erdosNumber": 1033,
     "erdosUrl": "https://erdosproblems.com/1033",
     "erdosProblemStatus": "open",
@@ -53,7 +53,7 @@
     "relatedProblems": [],
     "axiomCount": 3,
     "lineCount": 388,
-    "assumptions": "6 axioms (turan_has_triangle, erdos_laskar_upper, upper_bound_tight, erdos_laskar_lower, fan_lower, extremal_exists) and 7 sorries. erdosLaskar_approx now proved."
+    "assumptions": "3 axioms (erdos_laskar_upper, erdos_laskar_lower, fan_lower) and 5 sorries. erdosLaskar_approx proved; turan_has_triangle, upper_bound_tight, extremal_exists removed."
   },
   "overview": {
     "historicalContext": "Pál Turán proved in 1941 that every graph on $n$ vertices with more than $\\lfloor n^2/4 \\rfloor$ edges contains a triangle — establishing the foundational result of extremal graph theory. This problem, posed by Erdős and Laskar, asks a refined question: given that triangles must exist above the Turán threshold, how large must the degree sum of the *heaviest* triangle be?\n\nErdős and Renu Laskar (1985) proved the initial bounds $(1+c)n \\leq h(n) \\leq 2(\\sqrt{3}-1)n$, where the upper bound $2(\\sqrt{3}-1) \\approx 1.464$ comes from optimizing triangle configurations in nearly-bipartite graphs close to the Turán graph $T(n,2)$. Genghua Fan (1988) improved the lower bound to $(21/16)n = 1.3125n$ via careful degree counting arguments.\n\nThe gap between $1.3125n$ and $1.464n$ remains open. The conjectured answer is $h(n) = (2(\\sqrt{3}-1) - o(1))n$, which would mean the Erdős-Laskar construction is essentially optimal.",
@@ -303,11 +303,11 @@
       "Finset"
     ],
     "namespace": "Erdos1033",
-    "lineCount": 388,
+    "lineCount": 440,
     "axiomCount": 3,
     "theoremCount": 16,
     "definitionCount": 17,
-    "sorries": 7,
+    "sorries": 5,
     "path": "Proofs/Erdos1033Problem.lean"
   }
 }


### PR DESCRIPTION
## Summary
- Fix sorry count: 7 → 5 (matches actual Lean source)
- Fix assumptions text: listed 6 axioms but only 3 exist (`turan_has_triangle`, `upper_bound_tight`, `extremal_exists` were removed from the Lean file)
- Fix lineCount: 388 → 440

## Evidence
```
$ grep -n sorry proofs/Proofs/Erdos1033Problem.lean
113:  sorry    # h_spec
318:  sorry    # h_as_min
393:  sorry    # turan_plus_one
403:  sorry    # h_three
407:  sorry    # h_four

$ grep -n "^axiom " proofs/Proofs/Erdos1033Problem.lean
144:axiom erdos_laskar_upper
155:axiom erdos_laskar_lower
181:axiom fan_lower
```

## Test plan
- [ ] `pnpm build` passes with corrected meta.json
- [ ] Gallery page for erdos-1033 renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)