### PR TITLE
Enrich Chebyshev-PNT Bridge: Explicit Bounds on pi(x)

### DIFF
--- a/src/data/proofs/chebyshev-pnt-bridge/annotations.json
+++ b/src/data/proofs/chebyshev-pnt-bridge/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-bridge-interval-primes",
+    "proofId": "chebyshev-pnt-bridge",
+    "range": { "startLine": 42, "endLine": 68 },
+    "type": "definition",
+    "title": "Counting and Multiplying Primes in Intervals",
+    "content": "Defines numPrimesAbove(m, n) as the cardinality of primes in the half-open interval (m, n], implemented as the filter of Nat.Prime over Ico(m+1, n+1). Proves this equals π(n) - π(m) by decomposing range(n+1) into range(m+1) ∪ Ico(m+1, n+1) and using disjointness. Also defines prodPrimesAbove as the product of these primes. These are the key building blocks for the upper bound.",
+    "mathContext": "numPrimesAbove$(m, n) = |\\{p : m < p \\le n, p \\text{ prime}\\}| = \\pi(n) - \\pi(m)$. The proof splits $\\{0, \\ldots, n\\}$ into $\\{0, \\ldots, m\\} \\sqcup (m, n]$ and counts primes in each piece.",
+    "significance": "supporting",
+    "relatedConcepts": ["prime counting function", "Finset.Ico", "Finset.filter"],
+    "prerequisites": ["Nat.primeCounting", "count_eq_card_filter_range"]
+  },
+  {
+    "id": "ann-bridge-primorial-dvd",
+    "proofId": "chebyshev-pnt-bridge",
+    "range": { "startLine": 70, "endLine": 88 },
+    "type": "technique",
+    "title": "Product of Interval Primes Divides Primorial",
+    "content": "Every prime p in (m, n] divides primorial(n) = ∏{q ≤ n, q prime} q, since p ≤ n and p is prime. The product of all such primes therefore divides primorial(n) by Finset.prod_primes_dvd. This divisibility is the link between the interval prime product and the 4^n bound: since primorial(n) ≤ 4^n (from Mathlib), any divisor of primorial(n) is also ≤ 4^n.",
+    "mathContext": "$\\prod_{m < p \\le n, p\\text{ prime}} p \\;|\\; n\\# \\;|\\; 4^n$. Here $n\\# = \\text{primorial}(n)$ and the bound $n\\# \\le 4^n$ is a classical result provable by induction.",
+    "significance": "key",
+    "relatedConcepts": ["primorial", "divisibility chain", "Finset.prod_primes_dvd"],
+    "prerequisites": ["primorial_le_4_pow", "dvd_prod_of_mem"]
+  },
+  {
+    "id": "ann-bridge-upper",
+    "proofId": "chebyshev-pnt-bridge",
+    "range": { "startLine": 90, "endLine": 119 },
+    "type": "insight",
+    "title": "Upper Bound: (√n)^{π(n)−π(√n)} ≤ 4^n",
+    "content": "The main upper bound: every prime p in (√n, n] exceeds √n, so their product is at least (√n)^k where k = π(n) - π(√n). Since this product divides primorial(n) ≤ 4^n, we get (√n)^k ≤ 4^n. Taking logarithms: k ≤ 2n·log(4)/log(n), giving π(n) ≤ √n + 2·log(4)·n/log(n). The proof uses ChebyshevBounds.pow_le_of_prod_primes_dvd from the parent file — a general lemma that if b^k divides a product ≤ M with all factors > b, then b^k ≤ M.",
+    "mathContext": "$(\\sqrt{n})^{\\pi(n) - \\pi(\\sqrt{n})} \\le \\prod_{\\sqrt{n} < p \\le n} p \\le n\\# \\le 4^n$. Taking logs: $(\\pi(n) - \\pi(\\sqrt{n})) \\cdot \\frac{\\log n}{2} \\le n \\log 4$, so $\\pi(n) \\le \\sqrt{n} + \\frac{2n \\log 4}{\\log n}$.",
+    "significance": "key",
+    "relatedConcepts": ["Chebyshev upper bound", "primorial bound", "prime interval counting"],
+    "prerequisites": ["pow_le_of_prod_primes_dvd", "primorial_le_4_pow"]
+  },
+  {
+    "id": "ann-bridge-trivial",
+    "proofId": "chebyshev-pnt-bridge",
+    "range": { "startLine": 121, "endLine": 140 },
+    "type": "technique",
+    "title": "Trivial Bound π(m) ≤ m",
+    "content": "Proves that π(m) ≤ m by observing that 0 is not prime: the primes in {0, ..., m} form a subset of {1, ..., m}, which has cardinality m. The proof filters out 0 from range(m+1) using erase, then applies card_filter_le. This bound is used to absorb the π(√n) term in the upper bound.",
+    "mathContext": "$\\pi(m) = |\\{p \\le m : p \\text{ prime}\\}| \\le |\\{1, \\ldots, m\\}| = m$, since 0 is not prime.",
+    "significance": "supporting",
+    "relatedConcepts": ["counting argument", "card_filter_le", "card_erase"],
+    "prerequisites": ["Nat.Prime.ne_zero", "card_erase_of_mem"]
+  },
+  {
+    "id": "ann-bridge-factorization",
+    "proofId": "chebyshev-pnt-bridge",
+    "range": { "startLine": 152, "endLine": 172 },
+    "type": "concept",
+    "title": "Factorization Bound and Central Binomial Estimate",
+    "content": "Two key lemmas (both with sorry): (1) p^{v_p(C(2n,n))} ≤ 2n for any prime p — this follows from Kummer's theorem (v_p counts carries in base-p addition) or equivalently from Legendre's formula with the observation that each floor term contributes 0 or 1. (2) C(2n,n) ≤ (2n)^{π(2n)} — the factorization of C(2n,n) has at most π(2n) prime factors, each contributing at most 2n. These are the remaining obstacles to a fully verified proof.",
+    "mathContext": "Kummer's theorem: $v_p\\binom{2n}{n}$ equals the number of carries when adding $n + n$ in base $p$, which is at most $\\lfloor \\log_p(2n) \\rfloor$. Hence $p^{v_p} \\le p^{\\lfloor \\log_p(2n) \\rfloor} \\le 2n$.",
+    "significance": "key",
+    "relatedConcepts": ["Kummer's theorem", "Legendre's formula", "p-adic valuation"],
+    "prerequisites": ["centralBinom", "Nat.factorization", "Nat.log"]
+  },
+  {
+    "id": "ann-bridge-lower",
+    "proofId": "chebyshev-pnt-bridge",
+    "range": { "startLine": 186, "endLine": 195 },
+    "type": "insight",
+    "title": "Lower Bound: 4^n ≤ (2n+1)·(2n)^{π(2n)}",
+    "content": "The lower bound on π(2n) chains: 4^n ≤ (2n+1)·C(2n,n) (from ChebyshevBounds, the well-known central binomial lower bound) and C(2n,n) ≤ (2n)^{π(2n)} (the factorization bound). Taking logarithms: π(2n) ≥ (n·log(4) - log(2n+1))/log(2n) ∼ log(2)·n/log(n). This establishes π(x) = Ω(x/log(x)).",
+    "mathContext": "$4^n \\le (2n+1) \\cdot \\binom{2n}{n} \\le (2n+1) \\cdot (2n)^{\\pi(2n)}$. Taking logs: $\\pi(2n) \\ge \\frac{n \\log 4 - \\log(2n+1)}{\\log(2n)} \\to \\log 2 \\approx 0.693$ as $n \\to \\infty$.",
+    "significance": "key",
+    "relatedConcepts": ["central binomial coefficient", "Chebyshev lower bound", "asymptotic analysis"],
+    "prerequisites": ["centralBinom_ge_four_pow_div", "centralBinom_le_pow_primeCounting"]
+  }
+]

--- a/src/data/proofs/chebyshev-pnt-bridge/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-04-12",
     "axiomCount": 0,
     "assumptions": "Two sorries remain for the factorization bound: p^{v_p(C(2n,n))} \u2264 2n. Once proved, all results become fully verified.",
-    "lineCount": 220,
+    "lineCount": 224,
     "theoremCount": 10,
     "definitionCount": 2,
     "originalContributions": [
@@ -38,7 +38,8 @@
     "keyInsights": [
       "The upper bound reuses pow_le_of_prod_primes_dvd from ChebyshevBounds with the primorial instead of the central binomial",
       "The factorization bound p^{v_p(C(2n,n))} \u2264 2n follows from Kummer's theorem: v_p = #{carries adding n+n in base p} \u2264 log_p(2n), and p^{log_p(2n)} \u2264 2n",
-      "These bounds are weaker than Chebyshev's original 0.921 and 1.106 but are fully constructive from Mathlib primitives"
+      "These bounds are weaker than Chebyshev's original 0.921 and 1.106 but are fully constructive from Mathlib primitives",
+      "The trivial bound π(m) ≤ m (excluding 0 from the prime filter) absorbs the π(√n) term in the upper bound — a simple but essential ingredient for the final asymptotic"
     ],
     "prerequisites": [
       "Chebyshev bounds (ChebyshevBounds.lean)",
@@ -57,24 +58,31 @@
   },
   "sections": [
     {
+      "id": "sec-preamble",
+      "title": "Module Documentation and Imports",
+      "startLine": 1,
+      "endLine": 31,
+      "description": "Documents the upper and lower bounds, connection to Chebyshev's 1852 result, and remaining sorries. Imports primorial, prime counting, central binomial, and ChebyshevBounds."
+    },
+    {
       "id": "sec-bridge-upper",
       "title": "Upper Bound via Primorial",
-      "startLine": 29,
-      "endLine": 119,
+      "startLine": 33,
+      "endLine": 140,
       "description": "Defines numPrimesAbove and prodPrimesAbove for counting/multiplying primes in intervals. Proves the product of primes in (\u221an, n] divides primorial(n). Main result: (\u221an)^{\u03c0(n)-\u03c0(\u221an)} \u2264 4^n."
     },
     {
       "id": "sec-bridge-factorization",
       "title": "Factorization Bound (Key Lemma)",
-      "startLine": 131,
-      "endLine": 165,
+      "startLine": 142,
+      "endLine": 172,
       "description": "States the factorization bound p^{v_p(C(2n,n))} \u2264 2n and C(2n,n) \u2264 (2n)^{\u03c0(2n)}. Both have sorry pending proof via Kummer's theorem."
     },
     {
       "id": "sec-bridge-lower",
       "title": "Lower Bound on \u03c0(n)",
-      "startLine": 167,
-      "endLine": 220,
+      "startLine": 174,
+      "endLine": 224,
       "description": "Derives 4^n \u2264 (2n+1)\u00b7(2n)^{\u03c0(2n)} from the central binomial lower bound and factorization bound. Summary of asymptotic implications."
     }
   ],
@@ -92,7 +100,7 @@
   ],
   "leanFile": {
     "namespace": "ChebyshevPNTBridge",
-    "lineCount": 220,
+    "lineCount": 224,
     "path": "Proofs/ChebyshevPNTBridge.lean",
     "axiomCount": 0,
     "theoremCount": 10,


### PR DESCRIPTION
Enrichment pass for chebyshev-pnt-bridge.

**Improvements:**
- Added 6 annotations with mathContext, significance, relatedConcepts covering all major sections
- Added 4th keyInsight on the trivial bound π(m) ≤ m
- Added preamble section, fixed section line ranges for full 224-line coverage
- Fixed lineCount 220 → 224

Quality: 34 → ~80 (from empty annotations to full coverage)