### PR TITLE
Fix: correct erdos-1033 meta.lineCount (388→440)

### DIFF
--- a/src/data/proofs/erdos-1033/meta.json
+++ b/src/data/proofs/erdos-1033/meta.json
@@ -52,8 +52,8 @@
     ],
     "relatedProblems": [],
     "axiomCount": 3,
-    "lineCount": 388,
-    "assumptions": "3 axioms (erdos_laskar_upper, erdos_laskar_lower, fan_lower) and 5 sorries. erdosLaskar_approx proved; turan_has_triangle, upper_bound_tight, extremal_exists removed."
+    "lineCount": 440,
+    "assumptions": "3 axioms (erdos_laskar_upper, erdos_laskar_lower, fan_lower) and 5 sorries (h_spec, h_as_min, turan_plus_one, h_three, h_four)."
   },
   "overview": {
     "historicalContext": "Pál Turán proved in 1941 that every graph on $n$ vertices with more than $\\lfloor n^2/4 \\rfloor$ edges contains a triangle — establishing the foundational result of extremal graph theory. This problem, posed by Erdős and Laskar, asks a refined question: given that triangles must exist above the Turán threshold, how large must the degree sum of the *heaviest* triangle be?\n\nErdős and Renu Laskar (1985) proved the initial bounds $(1+c)n \\leq h(n) \\leq 2(\\sqrt{3}-1)n$, where the upper bound $2(\\sqrt{3}-1) \\approx 1.464$ comes from optimizing triangle configurations in nearly-bipartite graphs close to the Turán graph $T(n,2)$. Genghua Fan (1988) improved the lower bound to $(21/16)n = 1.3125n$ via careful degree counting arguments.\n\nThe gap between $1.3125n$ and $1.464n$ remains open. The conjectured answer is $h(n) = (2(\\sqrt{3}-1) - o(1))n$, which would mean the Erdős-Laskar construction is essentially optimal.",


### PR DESCRIPTION
## Fix

Corrects stale `meta.lineCount` in `src/data/proofs/erdos-1033/meta.json`.

## Evidence

**Before**: `meta.lineCount: 388` (stale) vs `leanFile.lineCount: 440` (correct)

**After**: Both `meta.lineCount` and `leanFile.lineCount` are 440, matching the actual line count of `proofs/Proofs/Erdos1033Problem.lean`.

Also tightens the `assumptions` text to list the 5 sorry names explicitly (h_spec, h_as_min, turan_plus_one, h_three, h_four), replacing the verbose historical notes already captured in the sorry count fix from #10301.

---
Automated fix by lean-mechanic agent.