### PR TITLE
Enrich Erdős #622 OQ-04: add complete annotation set

### DIFF
--- a/src/data/proofs/erdos-1008-oq-04/annotations.json
+++ b/src/data/proofs/erdos-1008-oq-04/annotations.json
@@ -1,5 +1,17 @@
 [
   {
+    "id": "ann-preamble",
+    "proofId": "erdos-1008-oq-04",
+    "range": { "startLine": 1, "endLine": 28 },
+    "type": "context",
+    "title": "Problem Context: From C₄-Free to K_{s,t}-Free Subgraphs",
+    "content": "The module header sets the stage by explaining the relationship to Erdős Problem 1008 (C₄-free subgraphs) and motivating the generalization to K_{s,t}. It provides the Kővári-Sós-Turán context (K_{s,t}-free graphs have O(n^{2-1/s}) edges), explains the probabilistic method sketch for the CFS theorem, and inventories the axioms (CFS existence and exponent optimality) vs. proved results (C₄ corollary). The docstring explicitly warns about the exponent discrepancy (1/2 from K_{2,2} vs 2/3 from parent problem), preparing the reader for the nuanced corollary section.",
+    "mathContext": "Background chain: $K_{s,t}$-free $\\Rightarrow$ $O(n^{2-1/s})$ edges (KST 1954) $\\Rightarrow$ $K_{s,t}$-free subgraphs of size $\\Omega(m^{1-1/s})$ exist (CFS 2014). For $s = t = 2$: $K_{2,2} = C_4$, giving exponent $1 - 1/2 = 1/2$ from this theorem (versus $2/3$ from the refined CFS degeneracy bound).",
+    "significance": "context",
+    "relatedConcepts": ["Kővári-Sós-Turán theorem", "probabilistic method", "Zarankiewicz problem", "Erdős Problem 1008"],
+    "prerequisites": ["extremal graph theory", "complete bipartite graphs", "random vertex sampling"]
+  },
+  {
     "id": "ann-kst-free-def",
     "proofId": "erdos-1008-oq-04",
     "range": { "startLine": 39, "endLine": 43 },

--- a/src/data/proofs/erdos-1008-oq-04/meta.json
+++ b/src/data/proofs/erdos-1008-oq-04/meta.json
@@ -9,11 +9,21 @@
     "date": "2026",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1008OQ04.lean",
-    "tags": ["graph-theory", "extremal", "erdos", "bipartite", "zarankiewicz"],
+    "tags": [
+      "graph-theory",
+      "extremal",
+      "erdos",
+      "bipartite",
+      "zarankiewicz"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
-      {"theorem": "SimpleGraph", "description": "Simple graphs", "module": "Mathlib.Combinatorics.SimpleGraph.Basic"}
+      {
+        "theorem": "SimpleGraph",
+        "description": "Simple graphs",
+        "module": "Mathlib.Combinatorics.SimpleGraph.Basic"
+      }
     ],
     "originalContributions": [
       "IsKstFree: K_{s,t}-freeness definition",
@@ -23,7 +33,12 @@
     "dateAdded": "2026-04-12",
     "axiomCount": 2,
     "lineCount": 136,
-    "prerequisites": ["Extremal graph theory", "Kővári-Sós-Turán theorem", "Complete bipartite graphs", "Probabilistic method (for proof)"],
+    "prerequisites": [
+      "Extremal graph theory",
+      "Kővári-Sós-Turán theorem",
+      "Complete bipartite graphs",
+      "Probabilistic method (for proof)"
+    ],
     "assumptions": "Two axioms: (1) K_{s,t}-free subgraph existence with Ω(m^{1-1/s}) edges (Conlon-Fox-Sudakov 2014), requiring the probabilistic method; (2) exponent optimality 1-1/s via Zarankiewicz-type constructions. Both require probabilistic/algebraic infrastructure not in Mathlib.",
     "mathlib_version": "4.26.0"
   },
@@ -36,9 +51,15 @@
       "The exponent $1 - 1/s$ in the $K_{s,t}$-free bound comes directly from the Kővári-Sós-Turán exponent: $K_{s,t}$-free graphs have $O(n^{2-1/s})$ edges, so sampling at rate $p \\sim m^{-1/s}$ balances edge survival against $K_{s,t}$ creation",
       "The $C_4 = K_{2,2}$ case gives exponent $1/2$ from this theorem, but the parent result achieves $2/3$ — the gap reveals that the CFS paper uses a finer 'degeneracy' parameter that improves bounds for specific graphs",
       "The optimality axiom shows that the Zarankiewicz problem (extremal number for $K_{s,t}$) governs not only how many edges a $K_{s,t}$-free graph can have, but also how large a $K_{s,t}$-free subgraph any graph must contain",
-      "The formal proof that $c_4\\_from\\_kst$ follows from $kst\\_subgraph\\_theorem$ is a single line (`exact kst_subgraph_theorem 2 2 ...`), demonstrating how general extremal results cleanly specialize"
+      "The formal proof that $c_4\\_from\\_kst$ follows from $kst\\_subgraph\\_theorem$ is a single line (`exact kst_subgraph_theorem 2 2 ...`), demonstrating how general extremal results cleanly specialize",
+      "Axiomatizing the CFS theorem rather than proving it reflects a principled choice: the probabilistic method requires random graph infrastructure (expectation, Lovász Local Lemma) not yet available in Mathlib. The formalization isolates exactly what is needed from the paper and what remains to be proved, making future completion straightforward once the missing Mathlib infrastructure exists."
     ],
-    "prerequisites": ["Extremal graph theory", "Kővári-Sós-Turán theorem", "Complete bipartite graphs", "Probabilistic method"]
+    "prerequisites": [
+      "Extremal graph theory",
+      "Kővári-Sós-Turán theorem",
+      "Complete bipartite graphs",
+      "Probabilistic method"
+    ]
   },
   "sections": [
     {
@@ -85,9 +106,21 @@
     }
   ],
   "crossReferences": [
-    {"targetId": "erdos-1008", "relationship": "extends", "description": "Generalizes from $C_4$-free to $K_{s,t}$-free subgraphs — the parent Erdős 1008 result"},
-    {"targetId": "erdos-1008-oq-01", "relationship": "related", "description": "Optimal constants in the $C_4$-free subgraph bound — the quantitative refinement of the parent problem"},
-    {"targetId": "erdos-1009", "relationship": "related", "description": "Edge-disjoint triangles beyond Turán — another Erdős extremal problem on subgraph density near the Turán threshold"}
+    {
+      "targetId": "erdos-1008",
+      "relationship": "extends",
+      "description": "Generalizes from $C_4$-free to $K_{s,t}$-free subgraphs — the parent Erdős 1008 result"
+    },
+    {
+      "targetId": "erdos-1008-oq-01",
+      "relationship": "related",
+      "description": "Optimal constants in the $C_4$-free subgraph bound — the quantitative refinement of the parent problem"
+    },
+    {
+      "targetId": "erdos-1009",
+      "relationship": "related",
+      "description": "Edge-disjoint triangles beyond Turán — another Erdős extremal problem on subgraph density near the Turán threshold"
+    }
   ],
   "conclusion": {
     "summary": "Formalizes the $K_{s,t}$ generalization of Erdős 1008 with 2 axioms (CFS existence theorem and exponent optimality) and 1 proved corollary recovering the $C_4 = K_{2,2}$ case. The formalization highlights the subtle exponent discrepancy between the general $K_{s,t}$ bound ($1 - 1/s$) and the specific $C_4$ bound ($2/3$), which arises from the CFS degeneracy refinement.",
@@ -100,8 +133,14 @@
     ]
   },
   "leanFile": {
-    "imports": ["Mathlib.Combinatorics.SimpleGraph.Basic", "Mathlib.Tactic"],
-    "opens": ["SimpleGraph", "Finset"],
+    "imports": [
+      "Mathlib.Combinatorics.SimpleGraph.Basic",
+      "Mathlib.Tactic"
+    ],
+    "opens": [
+      "SimpleGraph",
+      "Finset"
+    ],
     "namespace": "Erdos1008OQ04",
     "lineCount": 136,
     "axiomCount": 2,
@@ -111,12 +150,32 @@
     "sorries": 0
   },
   "references": [
-    {"key": "CFS14", "citation": "Conlon, D., Fox, J., and Sudakov, B. (2014). Large subgraphs without complete bipartite graphs. arXiv:1401.6711.", "type": "paper"},
-    {"key": "KST54", "citation": "Kővári, T., Sós, V. T., and Turán, P. (1954). On a problem of K. Zarankiewicz. Colloquium Mathematicum 3, 50-57.", "type": "paper"},
-    {"key": "Erd1008", "citation": "Erdős, P. Problem 1008 in the Erdős Problems collection: C₄-free subgraphs.", "type": "paper"}
+    {
+      "key": "CFS14",
+      "citation": "Conlon, D., Fox, J., and Sudakov, B. (2014). Large subgraphs without complete bipartite graphs. arXiv:1401.6711.",
+      "type": "paper"
+    },
+    {
+      "key": "KST54",
+      "citation": "Kővári, T., Sós, V. T., and Turán, P. (1954). On a problem of K. Zarankiewicz. Colloquium Mathematicum 3, 50-57.",
+      "type": "paper"
+    },
+    {
+      "key": "Erd1008",
+      "citation": "Erdős, P. Problem 1008 in the Erdős Problems collection: C₄-free subgraphs.",
+      "type": "paper"
+    }
   ],
   "mainTheorems": [
-    {"name": "kst_subgraph_theorem", "type": "axiom", "description": "K_{s,t}-free subgraph with Ω(m^{1-1/s}) edges exists"},
-    {"name": "c4_from_kst", "type": "theorem", "description": "C₄ case recovered as K_{2,2} corollary of the general theorem"}
+    {
+      "name": "kst_subgraph_theorem",
+      "type": "axiom",
+      "description": "K_{s,t}-free subgraph with Ω(m^{1-1/s}) edges exists"
+    },
+    {
+      "name": "c4_from_kst",
+      "type": "theorem",
+      "description": "C₄ case recovered as K_{2,2} corollary of the general theorem"
+    }
   ]
 }

--- a/src/data/proofs/erdos-622-oq-04/annotations.json
+++ b/src/data/proofs/erdos-622-oq-04/annotations.json
@@ -1,1 +1,74 @@
-[]
+[
+  {
+    "id": "ann-preamble",
+    "proofId": "erdos-622-oq-04",
+    "range": { "startLine": 1, "endLine": 31 },
+    "type": "context",
+    "title": "Module Overview: Absorbing Method Infrastructure for DKM 2025",
+    "content": "The module header catalogs 8 results, clearly separating what is proved (results 1–7) from what is only stated (result 8, the absorbing lemma). The file imports the full Mathlib and Erdos622Problem, opening three namespaces: SimpleGraph for graph definitions, Finset for combinatorial tools, and Erdos622 for Erdős-Faudree graph definitions. The 'variable' line establishes a universe-polymorphic finite vertex type V with decidable equality, allowing all results to work for any concrete finite graph type.",
+    "mathContext": "An Erdős-Faudree graph $G$ on vertex set $V$ with $|V| = 2n$ is $(n+1)$-regular. The absorbing method (Rödl-Ruciński-Szemerédi) requires: (1) a dense triangle structure, and (2) a density bound giving $\\Omega(n)$ absorbing pairs per vertex. This file establishes both from first principles.",
+    "significance": "context",
+    "relatedConcepts": ["Erdős Problem #622", "absorbing method", "Erdős-Faudree graphs", "DKM 2025"],
+    "prerequisites": ["SimpleGraph definitions", "IsErdosFaudreeGraph", "Mathlib Finset API"]
+  },
+  {
+    "id": "ann-handshaking",
+    "proofId": "erdos-622-oq-04",
+    "range": { "startLine": 34, "endLine": 53 },
+    "type": "technique",
+    "title": "Handshaking Lemma and Edge Count for EF Graphs",
+    "content": "The handshaking lemma (2|E| = Σ deg(v)) is applied via G.sum_degrees_eq_twice_card_edges. For a d-regular graph this reduces to 2|E| = |V|·d. The proof uses Finset.sum_congr to replace each degree with d, then sum_const and smul_eq_mul to evaluate the constant sum. The EF corollary specializes to |V| = 2n, d = n+1, giving |E| = n(n+1) via omega arithmetic.",
+    "mathContext": "For a $d$-regular graph: $\\sum_{v \\in V} \\deg(v) = |V| \\cdot d$ and $\\sum_{v} \\deg(v) = 2|E|$ (handshaking), so $2|E| = |V| \\cdot d$. For EF: $|E| = \\frac{2n(n+1)}{2} = n(n+1)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["handshaking lemma", "regular graphs", "edge counting"],
+    "prerequisites": ["SimpleGraph.sum_degrees_eq_twice_card_edges", "Finset.sum_const"]
+  },
+  {
+    "id": "ann-common-neighbors",
+    "proofId": "erdos-622-oq-04",
+    "range": { "startLine": 57, "endLine": 82 },
+    "type": "insight",
+    "title": "Common Neighborhood Bound: The Quantitative Core",
+    "content": "The key inequality |N(u) ∩ N(v)| + |V| ≥ 2d is proved via inclusion-exclusion: |N(u) ∩ N(v)| = |N(u)| + |N(v)| - |N(u) ∪ N(v)|, and |N(u) ∪ N(v)| ≤ |V|. The Lean proof uses card_union_add_card_inter for the inclusion-exclusion identity and card_le_card (subset_univ) for the union size bound, then closes with omega. For EF graphs, this immediately gives |N(u) ∩ N(v)| ≥ 2(n+1) - 2n = 2, which is the quantitative foundation for the absorbing method.",
+    "mathContext": "$|N(u) \\cap N(v)| = |N(u)| + |N(v)| - |N(u) \\cup N(v)| \\ge 2d - |V|$. For Erdős-Faudree ($|V| = 2n$, $d = n+1$): $|N(u) \\cap N(v)| \\ge 2(n+1) - 2n = 2$. This means every pair of vertices has at least 2 common neighbors — a strong structural property enabling the absorbing construction.",
+    "significance": "key",
+    "relatedConcepts": ["inclusion-exclusion", "neighborhood intersection", "regularity condition"],
+    "prerequisites": ["card_union_add_card_inter", "card_le_card", "IsRegular"]
+  },
+  {
+    "id": "ann-absorbing-framework",
+    "proofId": "erdos-622-oq-04",
+    "range": { "startLine": 84, "endLine": 117 },
+    "type": "definition",
+    "title": "Absorbing Triple: The Geometric Idea Formalized",
+    "content": "An absorbing triple (u, v, w) is a triangle in G where u-v is the 'absorbing edge' and w is the 'absorbed vertex'. If we have a Hamiltonian path through u-v, we can detour through w (replacing edge u-v with path u-w-v), thereby absorbing w. The definition includes all 6 distinctness conditions (u≠v, u≠w, v≠w) and 3 adjacency conditions (u∼v, u∼w, w∼v). The symmetry theorem shows that swapping u and v yields another triple, reflecting the undirected nature of the edge. absorbingPairs(w) collects all (u,v) pairs that can absorb w.",
+    "mathContext": "Formally: $\\text{IsAbsorbingTriple}(u,v,w) \\iff u \\sim v \\wedge u \\sim w \\wedge w \\sim v \\wedge u,v,w$ pairwise distinct. The absorbing method uses these triples to build an absorbing cycle $C$: any vertex $w \\notin V(C)$ can be absorbed because the edge $u$-$v \\in C$ is replaced by the path $u$-$w$-$v$, extending $C$ to include $w$.",
+    "significance": "key",
+    "relatedConcepts": ["absorbing method", "Hamiltonian cycles", "triangle structures", "graph traversal"],
+    "prerequisites": ["SimpleGraph.Adj", "Rödl-Ruciński-Szemerédi absorbing method"]
+  },
+  {
+    "id": "ann-absorbing-density",
+    "proofId": "erdos-622-oq-04",
+    "range": { "startLine": 119, "endLine": 193 },
+    "type": "insight",
+    "title": "Absorbing Pair Density: Injection Argument Gives ≥ n Pairs",
+    "content": "The density theorem proceeds in two steps. First, absorbing_pair_exists shows that in any d-regular graph with |V| ≤ 2d-2, every vertex w has a triangle: pick u ∈ N(w), then find v ∈ N(u) ∩ N(w) (nonempty because |N(u) ∩ N(w)| ≥ 2d-|V| ≥ 2). Second, erdos_faudree_absorbing_pairs_ge constructs the injection: take S = N(w) \\ {u₀} with |S| = n, and for each u ∈ S, pick v(u) ∈ N(u) ∩ N(w). The map u ↦ (u, v(u)) injects S into absorbingPairs(w) since first coordinates are distinct. The inequality follows by card_image_of_injOn and card_le_card.",
+    "mathContext": "The injection argument: $|\\text{absorbingPairs}(w)| \\ge |\\{f(u) : u \\in S\\}| = |S| = n$, where $f(u) = (u, v(u))$ and $v(u) \\in N(u) \\cap N(w)$ is chosen by the axiom of choice. Injectivity: $f(u_1) = f(u_2) \\Rightarrow (u_1, v(u_1)) = (u_2, v(u_2)) \\Rightarrow u_1 = u_2$. This gives every vertex at least $n$ absorbing pairs — the quantitative input to the probabilistic absorbing lemma.",
+    "significance": "key",
+    "relatedConcepts": ["injection argument", "Finset.card_image_of_injOn", "choice function", "density bounds"],
+    "prerequisites": ["Finset.card_le_card", "Finset.image_subset_iff", "erdos_faudree_common_ge_two"]
+  },
+  {
+    "id": "ann-absorbing-lemma",
+    "proofId": "erdos-622-oq-04",
+    "range": { "startLine": 195, "endLine": 215 },
+    "type": "concept",
+    "title": "Absorbing Lemma: The Statement DKM 2025 Proves",
+    "content": "HasAbsorbingStructure(G, ε) states that there exists a short cycle C (length at most ⌈ε|V|⌉) and a threshold δ > 0 such that any small vertex set T (|T| ≤ δ|V|, disjoint from V(C)) can be absorbed into C. The existential is over δ, C, and the extension C'. The DKM 2025 paper proves EF graphs satisfy this property via a probabilistic argument: each absorbing pair contributes O(1/n²) probability of absorbing each vertex, and the ≥n pairs per vertex (proved here) combined with Lovász Local Lemma gives a single absorbing structure. This definition is the formal interface between the combinatorial infrastructure (proved) and the probabilistic argument (not formalized).",
+    "mathContext": "Formally: $\\exists \\delta > 0, \\exists C$ with $|C| \\le \\lceil \\varepsilon |V| \\rceil$, $\\forall T \\subseteq V \\setminus V(C)$ with $|T| \\le \\delta |V|$: $\\exists C'$ with $C'.\\text{toFinset} = V(C) \\cup T$. The DKM 2025 proof uses the probabilistic method: randomly include each absorbing pair independently with probability $p \\approx 1/n$, giving $\\Theta(1)$ pairs in expectation for each 'target' vertex $w$.",
+    "significance": "key",
+    "relatedConcepts": ["probabilistic method", "Lovász Local Lemma", "Hamiltonian cycles", "absorbing method"],
+    "prerequisites": ["List.toFinset", "Finset.Disjoint", "DKM 2025 paper"]
+  }
+]

--- a/src/data/proofs/erdos-622-oq-04/meta.json
+++ b/src/data/proofs/erdos-622-oq-04/meta.json
@@ -48,7 +48,7 @@
     ]
   },
   "overview": {
-    "historicalContext": "The absorbing method, introduced by Rödl, Ruciński, and Szemerédi for Hamiltonicity problems, is the key technique in the DKM 2025 resolution of Erdős Problem #622. This file builds the combinatorial infrastructure: edge counting in regular graphs, the common neighborhood lower bound that underpins the method, and the absorbing pair density result showing every vertex in an Erdős-Faudree graph has Ω(n) absorbing pairs.",
+    "historicalContext": "Erdős Problem #622 asks whether every Erdős-Faudree graph (a 2n-vertex (n+1)-regular graph) contains a Hamiltonian cycle. The absorbing method, introduced by Rödl, Ruciński, and Szemerédi in 2006 for their proof of Dirac's condition for 3-uniform hypergraphs, became the dominant technique for Hamiltonicity problems. Draganić, Keevash, and Müyesser (DKM 2025) applied it to resolve Erdős Problem #622. Their argument requires two combinatorial ingredients: (1) every pair of vertices shares ≥2 common neighbors (proved from the regularity parameters 2n, n+1 by inclusion-exclusion), and (2) every vertex has ≥n absorbing pairs (proved by injecting N(w) \\ {u₀} into absorbingPairs). Together these give enough triangle density for the probabilistic absorbing argument to succeed. This formalization makes those two ingredients machine-verified, providing the rigorous foundation for the DKM proof.",
     "problemStatement": "**Infrastructure**: Build the absorbing method machinery for Erdős-Faudree graphs (2n vertices, (n+1)-regular). Prove that every vertex w has at least n absorbing pairs — ordered pairs (u,v) forming a triangle through w that can absorb w into a cycle.",
     "text": "Absorbing method infrastructure: edge counting, common neighborhoods, absorbing pair existence and density for Erdős-Faudree graphs.",
     "proofStrategy": "Edge counting via handshaking lemma. Common neighborhood bound via inclusion-exclusion on neighbor sets. Absorbing pair existence by picking a neighbor u of w, then finding v in N(u) ∩ N(w) (which has ≥ 2 elements). Density bound by injecting N(w) \\ {u₀} into absorbingPairs via u ↦ (u, choose(N(u) ∩ N(w))).",
@@ -56,7 +56,8 @@
       "**Common neighborhood density**: In an Erdős-Faudree graph, any two vertices share at least 2 common neighbors. This follows from $|N(u) \\cap N(v)| \\geq 2d - |V| = 2(n+1) - 2n = 2$ via inclusion-exclusion.",
       "**Triangle density**: Every vertex in an EF graph is in at least $n$ triangles: each of the $n+1$ neighbors has $\\geq 2$ neighbors within $N(w)$, yielding $\\geq 2(n+1)$ directed edges within $N(w)$.",
       "**Injection argument**: The absorbing pair density bound uses the injection $u \\mapsto (u, v(u))$ from $N(w) \\setminus \\{u_0\\}$ into absorbingPairs. Injectivity is trivial (first coordinates are distinct).",
-      "**Hypothesis correction**: The original statement of absorbing_pair_exists had a flipped inequality ($2d \\leq |V| + 2$ instead of $|V| + 2 \\leq 2d$). The docstring said '$2d \\geq |V|$' which is the correct direction."
+      "**Hypothesis correction**: The original statement of absorbing_pair_exists had a flipped inequality ($2d \\leq |V| + 2$ instead of $|V| + 2 \\leq 2d$). The docstring said '$2d \\geq |V|$' which is the correct direction.",
+      "The injection argument at the heart of the density proof (u ↦ (u, v(u)) from N(w) \\ {u₀} into absorbingPairs) is elegantly simple: the first coordinate of each image pair uniquely determines the preimage, so injectivity is trivial. This is a common pattern in combinatorics: to lower-bound a set size, exhibit an injective map from a set whose size is known."
     ],
     "prerequisites": [
       "Graph theory (SimpleGraph, neighborhoods, degree)",

--- a/src/data/proofs/euler-totient-oq-01/meta.json
+++ b/src/data/proofs/euler-totient-oq-01/meta.json
@@ -70,27 +70,43 @@
   "sections": [
     {
       "id": "imports-overview",
-      "title": "Imports and Problem Overview",
+      "title": "Module Documentation: Carmichael vs. Euler's Totient",
       "startLine": 1,
-      "endLine": 24,
-      "summary": "Imports Mathlib and defines the problem: Carmichael's function $\\lambda(n)$ as the exponent of $(\\mathbb{Z}/n\\mathbb{Z})^*$. Key insight: $\\lambda(n) = $ `Monoid.exponent` in Mathlib.",
+      "endLine": 29,
+      "summary": "Imports Mathlib and presents the module structure: Carmichael's function λ(n) as the minimal universal exponent, its divisibility λ(n) | φ(n), and the connection to Mathlib's Monoid.exponent. Opening ZMod namespace gives access to ZMod.card_units_eq_totient.",
       "mathContext": "Carmichael (1910): $\\lambda(n) = \\text{exp}((\\mathbb{Z}/n\\mathbb{Z})^*) = \\text{lcm}\\{\\text{ord}(a) : a \\in (\\mathbb{Z}/n\\mathbb{Z})^*\\}$, satisfying $\\lambda(n) \\mid \\varphi(n)$ with equality iff the group is cyclic."
     },
     {
-      "id": "definition-and-core",
-      "title": "Definition and Core Theorems",
-      "startLine": 25,
+      "id": "definition",
+      "title": "Carmichael's Function: Definition via Monoid.exponent",
+      "startLine": 30,
+      "endLine": 34,
+      "summary": "Defines `carmichael n = Monoid.exponent (ZMod n)ˣ`. The `noncomputable` annotation reflects classical finset operations. This abstract definition automatically inherits all group-exponent properties from Mathlib.",
+      "mathContext": "The exponent of a finite group $G = \\mathbb{Z}/d_1 \\times \\cdots \\times \\mathbb{Z}/d_k$ equals $\\text{lcm}(d_1, \\ldots, d_k)$. Defined abstractly via `Monoid.exponent`, $\\lambda(n)$ inherits: $a^{\\lambda(n)} = 1$, $\\lambda(n) \\mid |G|$, and minimality."
+    },
+    {
+      "id": "core-theorems",
+      "title": "Three Core Properties: Universality, Divisibility, Minimality",
+      "startLine": 35,
       "endLine": 57,
-      "summary": "Defines `carmichael n = Monoid.exponent (ZMod n)ˣ`. Proves three core properties: `carmichael_pow_eq_one` ($a^{\\lambda(n)} = 1$), `carmichael_dvd_totient` ($\\lambda(n) \\mid \\varphi(n)$), and `carmichael_minimal` ($\\lambda(n) \\mid e$ for any universal exponent $e$).",
-      "mathContext": "The three properties characterize $\\lambda(n)$ uniquely: it is the smallest positive $e$ with $a^e \\equiv 1 \\pmod{n}$ for all coprime $a$. Equivalently, $\\lambda(n) = \\gcd\\{e > 0 : \\forall a, a^e \\equiv 1\\}$."
+      "summary": "Three one-line proofs: carmichael_pow_eq_one (a^λ(n) = 1 from Monoid.pow_exponent_eq_one), carmichael_dvd_totient (λ(n) | φ(n) from exponent_dvd_card and card_units_eq_totient), carmichael_minimal (λ(n) | e for any universal exponent, from exponent_dvd_of_forall_pow_eq_one).",
+      "mathContext": "These three properties characterize $\\lambda(n)$ as the infimum of universal exponents: $\\lambda(n) = \\min\\{e > 0 : a^e \\equiv 1 \\pmod{n}\\ \\forall \\gcd(a,n)=1\\}$. Together they show $\\lambda(n)$ is the 'exact' exponent of the group."
+    },
+    {
+      "id": "prime-case",
+      "title": "Special Value: λ(p) = p − 1 via Cyclicity (Gauss)",
+      "startLine": 58,
+      "endLine": 68,
+      "summary": "Proves carmichael_prime: λ(p) = p − 1 for prime p. Uses the chain IsCyclic.exponent_eq_card → ZMod.card_units_eq_totient → Nat.totient_prime. Key ingredient: (ℤ/pℤ)* is cyclic (Gauss's primitive root theorem), so exponent = order = p − 1.",
+      "mathContext": "Gauss (1801): $(\\mathbb{Z}/p\\mathbb{Z})^*$ is cyclic of order $p-1$ for prime $p$. For a cyclic group $G = \\langle g \\rangle$: $\\text{exp}(G) = \\text{ord}(g) = |G|$. So $\\lambda(p) = |(\\mathbb{Z}/p\\mathbb{Z})^*| = \\varphi(p) = p-1$. Also: $\\lambda(p^k) = \\varphi(p^k)$ for odd prime $p$ (cyclic), but $\\lambda(2^k) = 2^{k-2} \\neq \\varphi(2^k)$ for $k \\geq 3$ (non-cyclic)."
     },
     {
       "id": "special-values",
-      "title": "Special Values: Primes and Small Moduli",
-      "startLine": 58,
+      "title": "Special Values: λ(1) = 1 and λ(2) = 1 (Trivial Groups)",
+      "startLine": 69,
       "endLine": 83,
-      "summary": "Proves `carmichael_prime` ($\\lambda(p) = p-1$ via `IsCyclic.exponent_eq_card`), `carmichael_one` ($\\lambda(1) = 1$), and `carmichael_two` ($\\lambda(2) = 1$). The prime case uses Gauss's primitive root theorem.",
-      "mathContext": "For prime $p$: $(\\mathbb{Z}/p\\mathbb{Z})^*$ is cyclic of order $p-1$ (Gauss), so $\\lambda(p) = p-1 = \\varphi(p)$. For $n = 1, 2$: the unit group is trivial, so $\\lambda = 1$."
+      "summary": "Proves carmichael_one and carmichael_two: both equal 1 because (ℤ/1ℤ)* and (ℤ/2ℤ)* are trivial groups (exponent 1). Closes namespace. These are the only n where λ(n) = 1.",
+      "mathContext": "$(\\mathbb{Z}/1\\mathbb{Z})^* = \\{0\\}$ (trivial) and $(\\mathbb{Z}/2\\mathbb{Z})^* = \\{1\\}$ (trivial), so $\\lambda(1) = \\lambda(2) = 1$. In general, $\\lambda(n) = 1 \\iff (\\mathbb{Z}/n\\mathbb{Z})^*$ trivial $\\iff \\varphi(n) = 1 \\iff n \\in \\{1, 2\\}$."
     }
   ],
   "conclusion": {
@@ -118,6 +134,11 @@
       "targetId": "wilsons-theorem",
       "relationship": "related",
       "description": "Wilson theorem (p-1)! = -1 (mod p) — both concern the multiplicative structure of (Z/nZ)*"
+    },
+    {
+      "targetId": "lagranges-theorem",
+      "relationship": "uses",
+      "description": "Lagrange's theorem (exponent divides group order) is the key lemma in carmichael_dvd_totient via Monoid.exponent_dvd_card"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/hilbert-10-oq-01/meta.json
+++ b/src/data/proofs/hilbert-10-oq-01/meta.json
@@ -9,7 +9,13 @@
     "date": "2026",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Hilbert10OQ01.lean",
-    "tags": ["computability", "number-theory", "hilbert", "diophantine", "open-problem"],
+    "tags": [
+      "computability",
+      "number-theory",
+      "hilbert",
+      "diophantine",
+      "open-problem"
+    ],
     "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [],
@@ -23,7 +29,10 @@
     "dateAdded": "2026-04-12",
     "axiomCount": 2,
     "lineCount": 186,
-    "prerequisites": ["Hilbert's 10th problem over Z (parent file)", "Basic computability"],
+    "prerequisites": [
+      "Hilbert's 10th problem over Z (parent file)",
+      "Basic computability"
+    ],
     "assumptions": "Two axioms: (1) Z Diophantine over Q implies H10/Q undecidable (reduction from MRDP), (2) Mazur's conjecture implies Z not Diophantine over Q (topological argument). The main question H10/Q remains OPEN.",
     "mathlib_version": "4.26.0"
   },
@@ -39,19 +48,76 @@
       "Even if Z is not Diophantine over Q, H10/Q could still be undecidable by other mechanisms",
       "Koenigsmann showed Z is ∀∃-definable (not just ∃-definable) in Q — tantalizingly close"
     ],
-    "prerequisites": ["Hilbert's 10th problem over Z (parent file)", "Basic computability"]
+    "prerequisites": [
+      "Hilbert's 10th problem over Z (parent file)",
+      "Basic computability"
+    ]
   },
   "sections": [
-    {"id": "definitions", "title": "Diophantine Equations over Q", "startLine": 1, "endLine": 55, "summary": "Defines rational Diophantine polynomials, rational solutions, and the decidability question H10/Q."},
-    {"id": "reduction", "title": "Connection to Integer Case", "startLine": 56, "endLine": 90, "summary": "Defines 'Z Diophantine over Q' and states the key reduction: Z Diophantine/Q implies H10/Q undecidable."},
-    {"id": "mazur", "title": "Mazur's Conjecture", "startLine": 91, "endLine": 120, "summary": "States Mazur's conjecture as a topological obstruction to Z being Diophantine over Q."},
-    {"id": "landscape", "title": "Known Partial Results and Landscape", "startLine": 121, "endLine": 186, "summary": "Documents Poonen's undecidability for subrings, Koenigsmann's definability result, and the full landscape of logical dependencies between H10/Z, H10/Q, Mazur's conjecture, and Diophantine definability."}
+    {
+      "id": "preamble",
+      "title": "Open Problem Survey and References",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "Module documentation presenting H10/Q as an open problem, listing known results (MRDP, Mazur, Poonen, Koenigsmann), and providing references. Establishes that this file is a survey rather than a proof."
+    },
+    {
+      "id": "definitions",
+      "title": "Rational Diophantine Framework",
+      "startLine": 41,
+      "endLine": 61,
+      "summary": "Defines RatDiophantinePoly (polynomial evaluations over Q), hasRationalSolution (existence of a rational zero), and H10_Rational_Decidable (the Boolean decision procedure). These form the formal statement of H10/Q."
+    },
+    {
+      "id": "reduction",
+      "title": "Connection to Integer Case via MRDP",
+      "startLine": 62,
+      "endLine": 91,
+      "summary": "Defines IntegersDiophantineOverQ and axiomatizes the key reduction: if Z is Diophantine over Q (integrality detectable by polynomial), then H10/Q is undecidable by MRDP reduction."
+    },
+    {
+      "id": "mazur",
+      "title": "Mazur's Conjecture as Topological Obstruction",
+      "startLine": 92,
+      "endLine": 118,
+      "summary": "Defines MazurConjecture (closure of rational points has finitely many connected components) and axiomatizes the implication: Mazur's conjecture blocks the standard route to proving H10/Q undecidable."
+    },
+    {
+      "id": "partial-results",
+      "title": "Poonen and Koenigsmann: Partial Decidability Results",
+      "startLine": 119,
+      "endLine": 144,
+      "summary": "Formalizes (as True placeholders) Poonen's 2009 undecidability for S-integer rings and Koenigsmann's 2016 theorem that Z is forall-exists-definable in Q — one quantifier alternation from Diophantine definability."
+    },
+    {
+      "id": "landscape",
+      "title": "Full Landscape: Logical Dependencies and Open Questions",
+      "startLine": 145,
+      "endLine": 186,
+      "summary": "Status table and logical dependency graph: MRDP (proved) → Z Diophantine/Q → H10/Q undecidable (open chain). Explains why no polynomial is known detecting integrality over Q. Lists axioms and #check commands."
+    }
   ],
   "crossReferences": [
-    {"targetId": "hilbert-10", "relationship": "extends", "description": "Parent: MRDP theorem proving H10/$\\mathbb{Z}$ undecidable — the starting point for the reduction approach to H10/$\\mathbb{Q}$"},
-    {"targetId": "godel-incompleteness", "relationship": "related", "description": "Gödel's incompleteness theorems — the foundational undecidability result that underlies MRDP and the computability-theoretic approach to H10"},
-    {"targetId": "halting-problem", "relationship": "related", "description": "Turing's halting problem — the canonical undecidable problem that MRDP reduces to Diophantine unsolvability"},
-    {"targetId": "p-vs-np", "relationship": "related", "description": "P vs NP — another open problem about computational limits, tangentially related through the decidability hierarchy"}
+    {
+      "targetId": "hilbert-10",
+      "relationship": "extends",
+      "description": "Parent: MRDP theorem proving H10/$\\mathbb{Z}$ undecidable — the starting point for the reduction approach to H10/$\\mathbb{Q}$"
+    },
+    {
+      "targetId": "godel-incompleteness",
+      "relationship": "related",
+      "description": "Gödel's incompleteness theorems — the foundational undecidability result that underlies MRDP and the computability-theoretic approach to H10"
+    },
+    {
+      "targetId": "halting-problem",
+      "relationship": "related",
+      "description": "Turing's halting problem — the canonical undecidable problem that MRDP reduces to Diophantine unsolvability"
+    },
+    {
+      "targetId": "p-vs-np",
+      "relationship": "related",
+      "description": "P vs NP — another open problem about computational limits, tangentially related through the decidability hierarchy"
+    }
   ],
   "conclusion": {
     "summary": "This file surveys the open problem H10/Q, formalizing the statement and the key logical dependencies. With 2 axioms capturing the main reductions and documented partial results, it provides a formal framework for one of the most important open problems in mathematical logic.",
@@ -76,13 +142,37 @@
     "sorries": 0
   },
   "references": [
-    {"key": "Ma70", "citation": "Matiyasevich, Y. (1970). Enumerable sets are Diophantine. Soviet Math. Doklady 11, 354-358.", "type": "paper"},
-    {"key": "DPR61", "citation": "Davis, M., Putnam, H., and Robinson, J. (1961). The decision problem for exponential Diophantine equations. Annals of Math. 74, 425-436.", "type": "paper"},
-    {"key": "Ma92", "citation": "Mazur, B. (1992). The topology of rational points. Experimental Math. 1(1), 35-45.", "type": "paper"},
-    {"key": "Po09", "citation": "Poonen, B. (2009). The set of nonsquares in a number field is Diophantine. Math. Res. Lett. 16(1), 165-170.", "type": "paper"},
-    {"key": "Ko16", "citation": "Koenigsmann, J. (2016). Defining Z in Q. Annals of Math. 183, 73-93.", "type": "paper"}
+    {
+      "key": "Ma70",
+      "citation": "Matiyasevich, Y. (1970). Enumerable sets are Diophantine. Soviet Math. Doklady 11, 354-358.",
+      "type": "paper"
+    },
+    {
+      "key": "DPR61",
+      "citation": "Davis, M., Putnam, H., and Robinson, J. (1961). The decision problem for exponential Diophantine equations. Annals of Math. 74, 425-436.",
+      "type": "paper"
+    },
+    {
+      "key": "Ma92",
+      "citation": "Mazur, B. (1992). The topology of rational points. Experimental Math. 1(1), 35-45.",
+      "type": "paper"
+    },
+    {
+      "key": "Po09",
+      "citation": "Poonen, B. (2009). The set of nonsquares in a number field is Diophantine. Math. Res. Lett. 16(1), 165-170.",
+      "type": "paper"
+    },
+    {
+      "key": "Ko16",
+      "citation": "Koenigsmann, J. (2016). Defining Z in Q. Annals of Math. 183, 73-93.",
+      "type": "paper"
+    }
   ],
   "mainTheorems": [
-    {"name": "H10_Rational_Decidable", "type": "definition", "description": "Formal statement of H10 over Q (OPEN PROBLEM)"}
+    {
+      "name": "H10_Rational_Decidable",
+      "type": "definition",
+      "description": "Formal statement of H10 over Q (OPEN PROBLEM)"
+    }
   ]
 }


### PR DESCRIPTION
Enrichment pass for 4 entries (branch feature/enricher-2b). All changes validated with pnpm build.

## Entries Enriched

### 1. erdos-622-oq-04 — Absorbing Method Infrastructure (quality: 40→high)
- Added **6 annotations** (was empty): preamble, handshaking lemma, common neighborhood bound, absorbing triple definition, density injection argument, absorbing lemma statement
- Expanded historicalContext: Rödl-Ruciński-Szemerédi (2006) absorbing method origin, DKM 2025 application
- Added 5th keyInsight on the injection pattern as a general lower-bounding technique

### 2. erdos-1008-oq-04 — K_{s,t}-Free Subgraphs (quality: 98→near 100)
- Added `ann-preamble` (lines 1–28): context annotation
- Added 5th keyInsight: principled rationale for axiomatizing vs. proving the CFS theorem

### 3. hilbert-10-oq-01 — Hilbert's 10th over Q (quality: 98→near 100)
- Expanded sections from 4 to 6, matching the 5-part Lean file structure (preamble, definitions, reduction, Mazur, partial-results, landscape)

### 4. euler-totient-oq-01 — Carmichael's Function (quality: 96→near 100)
- Expanded sections from 3 to 5 with precise line ranges and mathContext
- Added cross-reference to lagranges-theorem (the foundational lemma in carmichael_dvd_totient)