### PR TITLE
Fix: correct stale lineCount in 5 gallery meta.json files

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02/meta.json
@@ -133,7 +133,7 @@
       "Equiv"
     ],
     "namespace": "AbelRuffiniOQ04OQ02OQ02",
-    "lineCount": 155,
+    "lineCount": 167,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 0,

--- a/src/data/proofs/erdos-1110/meta.json
+++ b/src/data/proofs/erdos-1110/meta.json
@@ -59,7 +59,7 @@
       "Connections to Problems #123, #845, #246"
     ],
     "axiomCount": 1,
-    "lineCount": 265,
+    "lineCount": 437,
     "assumptions": "1 axiom: erdos_lewin_theorem (Erdős-Lewin 1996: non-representable set is finite iff {p,q}={2,3}). The {2,3} case (case_2_3_all_representable) is now fully proved by strong induction."
   },
   "overview": {

--- a/src/data/proofs/erdos-314/meta.json
+++ b/src/data/proofs/erdos-314/meta.json
@@ -159,7 +159,7 @@
     ],
     "opens": [],
     "namespace": "Erdos314",
-    "lineCount": 222,
+    "lineCount": 239,
     "axiomCount": 5,
     "theoremCount": 9,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-395-oq-01/meta.json
+++ b/src/data/proofs/erdos-395-oq-01/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "open-question",
     "dateAdded": "2026-03-29",
     "axiomCount": 4,
-    "lineCount": 183,
+    "lineCount": 247,
     "prerequisites": [
       "Erdős Problem #395 parent formalization",
       "Complex analysis and norms",
@@ -115,7 +115,7 @@
   },
   "leanFile": {
     "axiomCount": 2,
-    "lineCount": 161,
+    "lineCount": 247,
     "path": "Proofs/Erdos395OQ01.lean",
     "sorries": 2
   }

--- a/src/data/proofs/stirling-formula-oq-01/meta.json
+++ b/src/data/proofs/stirling-formula-oq-01/meta.json
@@ -40,7 +40,7 @@
       "Path to axiom elimination: first correction implies stirling_error_bound_ge_2",
       "error_bound_from_correction: structured proof reducing axiom to first correction"
     ],
-    "lineCount": 190,
+    "lineCount": 207,
     "theoremCount": 9,
     "definitionCount": 2,
     "mathlib_version": "4.26.0"
@@ -133,7 +133,7 @@
       "Filter"
     ],
     "namespace": "StirlingExpansion",
-    "lineCount": 176,
+    "lineCount": 207,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 2,


### PR DESCRIPTION
## Fix

Corrects stale `lineCount` fields in 5 gallery `meta.json` files where the stored value diverged from the actual Lean source file.

## Evidence

| Proof | Field | Before | After | Actual (wc -l) |
|-------|-------|--------|-------|-----------------|
| abel-ruffini-oq-04-oq-02-oq-02 | leanFile.lineCount | 155 | 167 | 167 |
| erdos-1110 | meta.lineCount | 265 | 437 | 437 |
| erdos-314 | leanFile.lineCount | 222 | 239 | 239 |
| erdos-395-oq-01 | meta.lineCount | 183 | 247 | 247 |
| erdos-395-oq-01 | leanFile.lineCount | 161 | 247 | 247 |
| stirling-formula-oq-01 | meta.lineCount | 190 | 207 | 207 |
| stirling-formula-oq-01 | leanFile.lineCount | 176 | 207 | 207 |

All counts verified against `proofs/Proofs/*.lean` via `wc -l`.

---
Automated fix by lean-mechanic agent.