### PR TITLE
Fix: correct stale leanFile.sorries in 2 gallery proofs

### DIFF
--- a/src/data/proofs/erdos-395-oq-01/meta.json
+++ b/src/data/proofs/erdos-395-oq-01/meta.json
@@ -29,7 +29,7 @@
       "Complex analysis and norms",
       "Probability on finite sets"
     ],
-    "assumptions": "2 axioms inherited from Erdos395Problem.lean: erdos_original_is_false, hjns_2024. 2 own axioms restored: counterexample_always_large (Carnielli-Carolino |sum| ≥ √2), extremal_example_tight (Θ(1/n) rate). 2 sorries: valid_constants_bddAbove, erdos_original_is_false_proved.",
+    "assumptions": "4 axioms: erdos_original_is_false and hjns_2024 inherited from Erdos395Problem.lean; counterexample_always_large (Carnielli-Carolino |sum| ≥ √2) and extremal_example_tight (Θ(1/n) rate) in this file. All sorries resolved.",
     "mathlib_version": "4.29.0",
     "originalContributions": [
       "Optimal constant c* defined via sSup",
@@ -117,6 +117,6 @@
     "axiomCount": 2,
     "lineCount": 161,
     "path": "Proofs/Erdos395OQ01.lean",
-    "sorries": 2
+    "sorries": 0
   }
 }

--- a/src/data/proofs/prime-gap-bounds-oq-01/meta.json
+++ b/src/data/proofs/prime-gap-bounds-oq-01/meta.json
@@ -189,7 +189,7 @@
     "theoremCount": 9,
     "definitionCount": 0,
     "path": "Proofs/PrimeGapBoundsOQ01.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "references": [
     {


### PR DESCRIPTION
## Fix

Two proofs had their sorries resolved but `leanFile.sorries` was never updated to reflect this.

## Evidence

| Proof | Field | Before | After | Actual (grep) |
|-------|-------|--------|-------|---------------|
| erdos-395-oq-01 | leanFile.sorries | 2 | 0 | 0 |
| prime-gap-bounds-oq-01 | leanFile.sorries | 1 | 0 | 0 |

Also updates `erdos-395-oq-01` assumptions text to remove stale sorry references (`valid_constants_bddAbove`, `erdos_original_is_false_proved`) and clarify the 4-axiom count (2 own + 2 inherited from parent proof).

Verified with `grep -c "^\s*sorry"` on `proofs/Proofs/Erdos395OQ01.lean` and `proofs/Proofs/PrimeGapBoundsOQ01.lean`.

---
Automated fix by lean-mechanic agent.