### PR TITLE
fix: correct sorry/badge mismatches in gallery audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12001,9 +12001,9 @@
       "issues": []
     },
     "erdos-1002-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-06T00:32:55Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-04-12T23:55:51Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "fourier-series-oq-02-incomplete-01": {
@@ -12113,6 +12113,24 @@
       "issues": [],
       "lastAudited": "2026-04-12T23:10:24Z",
       "result": "clean"
+    },
+    "brouwer-fixed-point-oq-04-oq-04": {
+      "auditCount": 2,
+      "issues": [],
+      "lastAudited": "2026-04-12T23:55:51Z",
+      "result": "clean"
+    },
+    "area-of-circle-oq-03-oq-03-oq-02": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-12T23:55:51Z",
+      "result": "clean"
+    },
+    "randomized-maxcut-oq-04": {
+      "auditCount": 1,
+      "issues": [],
+      "lastAudited": "2026-04-12T23:55:51Z",
+      "result": "issues-fixed"
     }
   },
   "erdos-1097-oq-01": {

--- a/src/data/proofs/erdos-1002-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1002-oq-01-oq-01/meta.json
@@ -18,7 +18,7 @@
       "weyl-criterion"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 1,
     "erdosNumber": 1002,
     "erdosUrl": "https://erdosproblems.com/1002",
     "erdosProblemStatus": "open",
@@ -31,8 +31,8 @@
       "euler-identity"
     ],
     "axiomCount": 1,
-    "lineCount": 479,
-    "assumptions": "One axiom: `innerSum_log_bound` — for badly approximable irrational α (bounded partial quotients), |S(α,n)| ≤ C·log n. This requires continued fraction theory not yet in Mathlib. Four sorries: `equidist_approx` (density of trig polynomials), `continuous_comp_fract` integer case (ε-δ at integer points), and two integral bounds for `deviation_sandwich` (routine computation: ∫₀¹ sandwichUpCore δ = δ/2 ≤ ε). The deviation_sandwich construction is proved structurally: sandwich functions defined, periodicity/pointwise bounds verified, non-integer continuity established. Both main theorems (weyl_equidist_continuous, weyl_fract_average_zero) are proved modulo these helpers."
+    "lineCount": 643,
+    "assumptions": "One axiom: `innerSum_log_bound` — for badly approximable irrational α (bounded partial quotients), |S(α,n)| ≤ C·log n. This requires continued fraction theory not yet in Mathlib. One sorry: `equidist_approx` (density of trig polynomials in L∞ — Stone-Weierstrass for periodic functions). Three previously open sorries (`continuous_comp_fract` integer case and two integral bounds for `deviation_sandwich`) are now fully proved. Both main theorems (weyl_equidist_continuous, weyl_fract_average_zero) are proved modulo equidist_approx."
   },
   "overview": {
     "historicalContext": "Hermann Weyl's 1916 paper 'Über die Gleichverteilung von Zahlen mod. Eins' (On the distribution of numbers mod one) is one of the foundational results of analytic number theory and ergodic theory. Weyl proved that for irrational α, the sequence {nα} of fractional parts is equidistributed modulo 1 — meaning any subinterval [a,b] ⊂ [0,1) contains exactly (b-a) fraction of the sequence in the long run. His key innovation was the exponential sum criterion: {nα} is equidistributed if and only if (1/N)Σ e^{2πiknα} → 0 for every nonzero integer k. This reduces equidistribution to estimates on exponential sums, which can be bounded by the geometry of the unit circle.\n\nThe connection to Erdős Problem #1002 comes through Kesten's 1960 theorem: the normalized inner sum (1/log n) S(α,n) = (1/log n) Σ_{k=1}^n (1/2 - {αk}) converges in distribution to a standard Cauchy distribution for badly approximable irrational α. The Cesàro mean result proved here (weyl_cesaro_zero) is the key ingredient showing that the unnormalized average (1/n) S(α,n) → 0, consistent with the 1/log n normalization in Kesten's theorem.\n\nWeyl's criterion has become a versatile tool throughout mathematics. It underlies the three-distance theorem (Steinhaus), the equidistribution of √n mod 1 (which Weyl's polynomial extension handles), and is the prototype for modern analytic approaches in ergodic theory. The exponential sum bound 2/‖r-1‖ proved in weyl_cesaro_bound is optimal — it cannot be improved without additional information about α.",

--- a/src/data/proofs/randomized-maxcut-oq-04/meta.json
+++ b/src/data/proofs/randomized-maxcut-oq-04/meta.json
@@ -14,7 +14,7 @@
       "derandomization"
     ],
     "proofRepoPath": "Proofs/RandomizedMaxcutOQ04.lean",
-    "badge": "original",
+    "badge": "wip",
     "sorries": 1,
     "originalContributions": [
       "greedyStep, greedyPartition: constructive greedy MaxCut algorithm in Lean 4",


### PR DESCRIPTION
## Summary

- **erdos-1002-oq-01-oq-01**: `sorries` 4→1 (researcher proved 3 of 4 goals), `lineCount` 479→643, updated assumptions text
- **randomized-maxcut-oq-04**: `badge` `original`→`wip` (1 sorry remains; `original` requires 0 sorries)

## Audit evidence

| Proof | Claim | Actual | Severity |
|-------|-------|--------|----------|
| erdos-1002-oq-01-oq-01 | sorries: 4 | grep shows 1 sorry keyword | HIGH |
| randomized-maxcut-oq-04 | badge: original | 1 sorry in file | HIGH |

Discovered during automated gallery integrity audit (2026-04-12).