### PR TITLE
Fix: correct stale leanFile.sorries in 3 gallery proofs

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-04/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-04/meta.json
@@ -17,7 +17,7 @@
       "game-theory"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "axioms": 1,
     "dateAdded": "2026-04-12",
     "dateUpdated": "2026-04-12",
@@ -25,7 +25,7 @@
     "lineCount": 368,
     "theoremCount": 12,
     "defCount": 2,
-    "assumptions": "1 axiom (scarf_approx_fixed_point — Scarf's n-dimensional algorithm via Sperner's lemma, with full proof sketch). 2 sorries (LSC/USC limit arguments in approx_fp_limit_1d, ~80 lines each, standard analysis).",
+    "assumptions": "1 axiom (scarf_approx_fixed_point — Scarf's n-dimensional algorithm via Sperner's lemma, with full proof sketch). 1 sorry (LSC/USC limit arguments in approx_fp_limit_1d via all_goals sorry, standard analysis).",
     "originalContributions": [
       "IsApproxFixedPoint: ε-approximate fixed point definition",
       "discrete_ivt_real: Discrete IVT for ℝ (PROVED by induction)",
@@ -143,6 +143,6 @@
     "axiomCount": 1,
     "theoremCount": 12,
     "definitionCount": 2,
-    "sorries": 2
+    "sorries": 1
   }
 }

--- a/src/data/proofs/erdos-1131/meta.json
+++ b/src/data/proofs/erdos-1131/meta.json
@@ -26,7 +26,7 @@
     "axiomCount": 1,
     "theoremCount": 31,
     "lineCount": 992,
-    "assumptions": "1 axiom: erdos_1131_conjecture (OPEN). 2 sorries: chebyshev_interp (Lagrange interpolation exactness for Chebyshev polynomials — needs polynomial uniqueness argument), chebyshev_sq_expansion (DCT Parseval identity — needs chebyshev_interp + bilinear expansion). Previously sorry lemmas now fully proved: dct_offdiag, integral_cos_substitution, integral_chebyshev_sq, chebyshev_integral_trace.",
+    "assumptions": "1 axiom: erdos_1131_conjecture (OPEN). 0 sorries — all supporting lemmas fully proved: chebyshev_interp, chebyshev_sq_expansion, dct_offdiag, integral_cos_substitution, integral_chebyshev_sq, chebyshev_integral_trace.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -203,7 +203,7 @@
     "axiomCount": 1,
     "theoremCount": 31,
     "definitionCount": 6,
-    "sorries": 2,
+    "sorries": 0,
     "path": "Proofs/Erdos1131Problem.lean"
   }
 }

--- a/src/data/proofs/stirling-formula-oq-01/meta.json
+++ b/src/data/proofs/stirling-formula-oq-01/meta.json
@@ -138,6 +138,6 @@
     "theoremCount": 8,
     "definitionCount": 2,
     "path": "Proofs/StirlingExpansion.lean",
-    "sorries": 2
+    "sorries": 1
   }
 }


### PR DESCRIPTION
## Fix

Correct stale `leanFile.sorries` counts in three gallery `meta.json` files where the Lean source was updated but the metadata was not synced.

## Evidence

| Proof | Field | Before | After | Reason |
|-------|-------|--------|-------|--------|
| `erdos-1131` | `leanFile.sorries` | 2 | 0 | Both sorries proved in #10299 (Lagrange exactness + DCT expansion) |
| `erdos-1131` | `meta.assumptions` | "2 sorries: ..." | "0 sorries — all ... fully proved" | Reflect proved status |
| `brouwer-fixed-point-oq-04-oq-04` | `leanFile.sorries` | 2 | 1 | `all_goals sorry` is 1 token closing 2 goals — fix over-count |
| `brouwer-fixed-point-oq-04-oq-04` | `meta.sorries` | 2 | 1 | Same correction |
| `brouwer-fixed-point-oq-04-oq-04` | `meta.assumptions` | "2 sorries ..." | "1 sorry ..." | Sync with corrected count |
| `stirling-formula-oq-01` | `leanFile.sorries` | 2 | 1 | Second sorry proved (noted in existing assumptions text) |

**Detection method**: systematic scan comparing `leanFile.sorries` in meta.json against actual `sorry` token count in Lean source (excluding comments).

---
Automated fix by lean-mechanic agent.