### PR TITLE
Research: 4 problems — MaxCut counting, LR gallery, Borsuk-Ulam sorries, Chebyshev bound

### DIFF
--- a/proofs/Proofs/BorsukUlamOQ02OQ01OQ04OQ01.lean
+++ b/proofs/Proofs/BorsukUlamOQ02OQ01OQ04OQ01.lean
@@ -139,23 +139,27 @@ theorem umIdeal_filtration (p : ℕ) :
     Note: Full proof requires `Polynomial.quotient_X_pow_basis` or similar. -/
 theorem fpPoly_quotient_finrank (p n : ℕ) [Fact (Nat.Prime p)] (hn : 0 < n) :
     Module.finrank (ZMod p) (FpPoly p ⧸ umIdeal p n) = n := by
-  sorry  -- Requires Mathlib lemma for dim(R[X]/(X^n)) = n
+  -- FpPoly p ⧸ umIdeal p n = Polynomial (ZMod p) ⧸ Ideal.span {X^n}
+  --                        = AdjoinRoot (X^n : Polynomial (ZMod p))
+  -- AdjoinRoot has a PowerBasis with dim = natDegree(X^n) = n
+  change Module.finrank (ZMod p) (AdjoinRoot ((X : Polynomial (ZMod p)) ^ n)) = n
+  have hm : ((X : Polynomial (ZMod p)) ^ n).Monic := monic_X_pow n
+  rw [AdjoinRoot.powerBasis hm |>.finrank]
+  simp [AdjoinRoot.powerBasis_dim, Polynomial.natDegree_X_pow]
 
 /-- The quotient F_p[u]/(u^n) is nontrivial when n ≥ 1. -/
 theorem fpPoly_quotient_nontrivial (p n : ℕ) [Fact (Nat.Prime p)] (hn : 0 < n) :
     Nontrivial (FpPoly p ⧸ umIdeal p n) := by
-  apply Ideal.Quotient.nontrivial_iff.mpr
-  intro h
-  -- If (X^n) = ⊤, then 1 ∈ (X^n), but deg(1) = 0 < n = deg(X^n)
-  rw [← umIdeal_zero p] at h
-  have := umIdeal_anti_mono p 0 n (Nat.zero_le _)
-  have hle : umIdeal p n ≤ umIdeal p 0 := this
-  rw [umIdeal_zero] at hle
-  -- (X^n) ≤ ⊤ is always true; we need (X^n) = ⊤ implies n = 0
-  have : (X : FpPoly p) ^ n ∈ umIdeal p n := umIdeal_mem_gen p n
-  rw [h] at this
-  -- 1 ∈ span{X^n} and X^n ∈ span{1} would mean they're associates
-  sorry  -- Nontriviality follows from degree argument
+  rw [Ideal.Quotient.nontrivial_iff]
+  -- Need: umIdeal p n ≠ ⊤, i.e., span{X^n} ≠ ⊤
+  intro htop
+  -- If span{X^n} = ⊤, then 1 ∈ span{X^n}, so X^n ∣ 1
+  have h1 : (1 : FpPoly p) ∈ umIdeal p n := htop ▸ Ideal.mem_top
+  rw [umIdeal, Ideal.mem_span_singleton] at h1
+  -- X^n ∣ 1 implies natDegree(X^n) ≤ natDegree(1) = 0
+  have hdeg := Polynomial.natDegree_le_of_dvd h1 one_ne_zero
+  simp [Polynomial.natDegree_one, Polynomial.natDegree_X_pow] at hdeg
+  omega
 
 /-! ## Part IV: The Cohomology Ring Axiom -/
 

--- a/proofs/Proofs/ChebyshevPNTBridge.lean
+++ b/proofs/Proofs/ChebyshevPNTBridge.lean
@@ -154,9 +154,10 @@ This is the standard bound from Legendre's formula for binomial coefficients.
 The p-adic valuation of C(2n,n) is at most log_p(2n). -/
 theorem prime_pow_factorization_centralBinom_le (n : ℕ) (hn : 1 ≤ n) (p : ℕ) (hp : p.Prime) :
     p ^ (centralBinom n).factorization p ≤ 2 * n := by
-  -- v_p(C(2n,n)) ≤ Nat.log p (2n) from Legendre's formula / Kummer's theorem
-  -- p^(Nat.log p (2n)) ≤ 2n by definition of Nat.log
-  sorry
+  -- centralBinom n = choose (2*n) n, and for any choose m k:
+  -- p^{v_p(choose m k)} ≤ m (standard result from Legendre's formula)
+  rw [Nat.centralBinom_eq_choose]
+  exact hp.pow_factorization_choose_le (2 * n) n
 
 /-- C(2n,n) ≤ (2n)^{π(2n)} : the central binomial coefficient is bounded
 by the prime counting function power.

--- a/src/data/proofs/hilbert-15-oq-02/meta.json
+++ b/src/data/proofs/hilbert-15-oq-02/meta.json
@@ -1,0 +1,122 @@
+{
+  "id": "hilbert-15-oq-02",
+  "title": "Complexity of Littlewood-Richardson Coefficients",
+  "slug": "hilbert-15-oq-02",
+  "description": "Decidable LR coefficient computation for 2-row partitions with verified Gr(2,4) structure constants, multiplicity-free property, and complexity dichotomy (positivity in P vs counting #P-complete).",
+  "meta": {
+    "author": "Lean Genius Research",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/Hilbert15OQ02.lean",
+    "tags": [
+      "algebraic-geometry",
+      "combinatorics",
+      "complexity-theory",
+      "hilbert",
+      "schubert-calculus",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 3,
+    "lineCount": 364,
+    "assumptions": "3 axioms (all asserting True as documentation placeholders): lr_saturation_theorem (Knutson-Tao 1999), lr_positivity_in_P (positivity in polynomial time), lr_counting_sharp_P_complete (Narayanan 2006 #P-completeness). These encode complexity-theoretic results that require formalisms not in Mathlib. All computational results (LR coefficients, multiplicity-free) are fully verified via native_decide.",
+    "dateAdded": "2026-04-12",
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "Littlewood-Richardson coefficients c^nu_{lam,mu} are fundamental in algebraic combinatorics, governing the multiplication of Schur functions, tensor product decomposition of GL_n representations, and Schubert calculus on Grassmannians. The Knutson-Tao saturation theorem (1999) showed that testing positivity (c > 0) reduces to linear programming, placing it in P. Narayanan (2006) proved that exact computation of these coefficients is #P-complete, establishing one of the sharpest complexity separations in combinatorics.",
+    "problemStatement": "Formalize a concrete, decidable computation of LR coefficients for 2-row partitions. Verify the multiplication table of the Chow ring A*(Gr(2,4)). Document the P vs #P complexity dichotomy.",
+    "proofStrategy": "For 2-row partitions, an LR tableau is parameterized by k1 = number of 1s in row 1. The valid range of k1 is determined by four conditions: row capacity, column strictly-increasing, and the ballot/lattice-word condition. All conditions are decidable and checked via Finset.filter. Verification uses native_decide to evaluate lrCoeff2 on all 216 triples of Gr(2,4) Schubert classes.",
+    "keyInsights": [
+      "For 2-row SSYT, a filling is uniquely parameterized by k1 (1s in row 1), making the counting problem 1-dimensional",
+      "The nontrivial zero sigma_2 * sigma_11 = 0 arises from conflicting constraints: column condition forces k2 = 0 but range forces k2 >= 1",
+      "Gr(2,4) is multiplicity-free: all LR coefficients in {0,1}, verified by native_decide over 216 triples",
+      "The P vs #P gap for LR coefficients is one of the sharpest complexity separations in combinatorics"
+    ]
+  },
+  "sections": [
+    {
+      "id": "partition2",
+      "title": "2-Row Partitions",
+      "startLine": 58,
+      "endLine": 79,
+      "summary": "Partition2 structure with DecidableEq, size, containment."
+    },
+    {
+      "id": "lr-computation",
+      "title": "LR Coefficient Computation",
+      "startLine": 81,
+      "endLine": 137,
+      "summary": "Decidable lrCoeff2 function via ballot-sequence counting over k1 parameter."
+    },
+    {
+      "id": "gr24-verification",
+      "title": "Gr(2,4) Verification",
+      "startLine": 139,
+      "endLine": 234,
+      "summary": "All 7 nonzero structure constants verified. Nontrivial zero sigma_2*sigma_11=0 proved. Full multiplication table confirmed."
+    },
+    {
+      "id": "decidability",
+      "title": "Decidability",
+      "startLine": 236,
+      "endLine": 257,
+      "summary": "LR coefficient computation and positivity testing are decidable instances."
+    },
+    {
+      "id": "complexity",
+      "title": "Complexity Results (Axiomatized)",
+      "startLine": 259,
+      "endLine": 342,
+      "summary": "Saturation theorem, P-membership of positivity, and #P-completeness of counting documented as axioms."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "hilbert-15",
+      "relationship": "extends",
+      "description": "Hilbert's 15th problem on rigorous foundations for Schubert calculus"
+    },
+    {
+      "targetId": "hilbert-15-oq-01",
+      "relationship": "extends",
+      "description": "Builds on the explicit Chow ring of Gr(2,4) from OQ-01, verifying structure constants match"
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib.Tactic",
+      "Mathlib.Data.Finset.Basic",
+      "Mathlib.Data.Fin.Basic"
+    ],
+    "opens": [],
+    "namespace": "LRComplexity",
+    "lineCount": 364,
+    "axiomCount": 3,
+    "theoremCount": 14,
+    "definitionCount": 3,
+    "path": "Proofs/Hilbert15OQ02.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "gr24_multiplicity_free",
+      "type": "core",
+      "description": "All Gr(2,4) LR coefficients are 0 or 1 (multiplicity-free)",
+      "leanType": "∀ ν ∈ gr24_classes, ∀ λ ∈ gr24_classes, ∀ μ ∈ gr24_classes, lrCoeff2 ν λ μ ≤ 1"
+    },
+    {
+      "name": "lr_sigma2_sigma11_zero",
+      "type": "core",
+      "description": "The nontrivial zero: sigma_2 * sigma_11 = 0 in A*(Gr(2,4))",
+      "leanType": "lrCoeff2 ⟨2,2,_⟩ ⟨2,0,_⟩ ⟨1,1,_⟩ = 0"
+    },
+    {
+      "name": "lr_value_depends_on_shape",
+      "type": "supporting",
+      "description": "LR coefficient depends on partition shape, not just size",
+      "leanType": "∃ ν λ₁ λ₂ μ, λ₁.size = λ₂.size ∧ lrCoeff2 ν λ₁ μ ≠ lrCoeff2 ν λ₂ μ"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Research session covering 4 problems (+ 2 assessed and released):

### 1. randomized-maxcut-oq-04 — MaxCut derandomization (NEW)
- **Counting lemma proved** via toggle involution: `card_filter_mem` + `card_filter_mem_nmem`
- `conditional_expectation_method` (abstract pigeonhole) proved
- `exists_good_partition'` structure complete (eliminates axiom from OQ02)
- 1 sorry: `sum_cutWeight_eq` (mechanical sum-swapping)

### 2. hilbert-15-oq-02 — LR coefficient complexity (GALLERY)
- Created gallery entry for existing verified proof (0 sorries, 14 theorems)

### 3. borsuk-ulam-oq-02-oq-01-oq-04-oq-01 — F_p[u] cohomology (2 SORRIES PROVED)
- `fpPoly_quotient_finrank`: dim(F_p[u]/(u^n)) = n via AdjoinRoot.powerBasis
- `fpPoly_quotient_nontrivial`: span{X^n} ≠ ⊤ via degree argument
- **2→0 sorries**

### 4. chebyshev-bounds-oq-01 — PNT bridge (1 SORRY PROVED)
- `prime_pow_factorization_centralBinom_le`: p^{v_p(C(2n,n))} ≤ 2n
  via Mathlib `pow_factorization_choose_le`
- **2→1 sorries**

## Status
**Outcome**: 4 problems progressed, 2 completed, 4 sorries eliminated

🤖 Generated by researcher-9