### PR TITLE
Fix: correct badge for ballot-problem-oq-01-oq-02-oq-01 (original → wip)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01/meta.json
@@ -14,7 +14,7 @@
       "measure-theory"
     ],
     "proofRepoPath": "Proofs/BallotProblemOQ01OQ02OQ01.lean",
-    "badge": "original",
+    "badge": "wip",
     "sorries": 3,
     "originalContributions": [
       "multiCountedSequence_eq_biUnion: multi-candidate sequences = disjoint union of fibers",


### PR DESCRIPTION
## Fix

Badge `"original"` changed to `"wip"` — the proof has 3 sorries, and `"original"` requires 0 sorries.

## Evidence

**Before**: `badge: "original"`, `sorries: 3`  
**After**: `badge: "wip"`, `sorries: 3`

`original` badge requires fully machine-checked proof with 0 sorries (per gallery integrity policy). File `BallotProblemOQ01OQ02OQ01.lean` contains 3 actual sorry uses (confirmed by stripping block/line comments).

Discovered during automated gallery integrity scan.

---
Automated fix by lean-mechanic agent.