### PR TITLE
Audit: fix randomized-maxcut-oq-04 (verified, 0 sorries) + mark 12 proofs audited

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12103,9 +12103,9 @@
       "issues": []
     },
     "chebyshev-pnt-bridge": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-12T23:05:48Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-04-13T00:50:38Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "erdos-622-oq-04": {
@@ -12127,10 +12127,70 @@
       "result": "clean"
     },
     "randomized-maxcut-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-12T23:55:51Z",
+      "lastAudited": "2026-04-13T00:50:38Z",
       "result": "issues-fixed"
+    },
+    "area-of-circle-oq-01-oq-02-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T00:50:38Z",
+      "result": "clean",
+      "issues": []
+    },
+    "arithmetic-series-oq-00": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T00:50:38Z",
+      "result": "clean",
+      "issues": []
+    },
+    "ballot-problem-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T00:50:38Z",
+      "result": "clean",
+      "issues": []
+    },
+    "binary-gcd-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T00:50:38Z",
+      "result": "clean",
+      "issues": []
+    },
+    "divisibility-rules-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T00:50:38Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hilbert-15-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T00:50:38Z",
+      "result": "clean",
+      "issues": []
+    },
+    "minkowski-fundamental-theorem-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T00:50:38Z",
+      "result": "clean",
+      "issues": []
+    },
+    "primitive-roots-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T00:50:38Z",
+      "result": "clean",
+      "issues": []
+    },
+    "taylor-theorem-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T00:50:38Z",
+      "result": "clean",
+      "issues": []
+    },
+    "vietas-formulas-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T00:50:38Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {

--- a/src/data/proofs/randomized-maxcut-oq-04/meta.json
+++ b/src/data/proofs/randomized-maxcut-oq-04/meta.json
@@ -4,9 +4,9 @@
   "slug": "randomized-maxcut-oq-04",
   "description": "Formalizes the method of conditional expectations for MaxCut: a deterministic greedy algorithm that processes vertices in order, always choosing the side that maximizes cut weight to placed vertices, achieving cut weight at least W/2.",
   "meta": {
-    "author": "Erd\u0151s (1965), Sahni-Gonzalez (1976), formalized in Lean 4",
+    "author": "Erdős (1965), Sahni-Gonzalez (1976), formalized in Lean 4",
     "date": "1965",
-    "status": "formalized",
+    "status": "verified",
     "tags": [
       "algorithms",
       "approximation",
@@ -14,8 +14,8 @@
       "derandomization"
     ],
     "proofRepoPath": "Proofs/RandomizedMaxcutOQ04.lean",
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "original",
+    "sorries": 0,
     "originalContributions": [
       "greedyStep, greedyPartition: constructive greedy MaxCut algorithm in Lean 4",
       "max_ge_avg: max(a,b) >= (a+b)/2 for nonneg reals",
@@ -24,11 +24,11 @@
     ],
     "dateAdded": "2026-04-12",
     "axiomCount": 0,
-    "lineCount": 198,
-    "assumptions": "1 sorry: inductive assembly connecting greedyPartition to cutWeight via fold state bookkeeping"
+    "lineCount": 401,
+    "assumptions": "No remaining sorries. All theorems fully proved: max_ge_avg, greedyContrib_ge_half, conditional_expectation_method, card_filter_mem, card_filter_mem_nmem, sum_cutWeight_eq, exists_good_partition'."
   },
   "overview": {
-    "historicalContext": "The probabilistic method shows that a random partition of a graph cuts at least half the total edge weight in expectation. The method of conditional expectations (Spencer 1987, based on ideas from Erd\u0151s 1965 and Sahni-Gonzalez 1976) converts this into a deterministic algorithm: process vertices in order, and for each vertex choose the side that maintains the conditional expectation above W/2. For MaxCut, this simplifies to a greedy algorithm: put each vertex on the side opposite to where it has more edge weight.",
+    "historicalContext": "The probabilistic method shows that a random partition of a graph cuts at least half the total edge weight in expectation. The method of conditional expectations (Spencer 1987, based on ideas from Erdős 1965 and Sahni-Gonzalez 1976) converts this into a deterministic algorithm: process vertices in order, and for each vertex choose the side that maintains the conditional expectation above W/2. For MaxCut, this simplifies to a greedy algorithm: put each vertex on the side opposite to where it has more edge weight.",
     "problemStatement": "Constructively prove that for any weighted graph, there exists a partition cutting at least half the total edge weight (the exists_good_partition axiom from RandomizedMaxcutOQ02.lean).",
     "proofStrategy": "Define a greedy algorithm that processes vertices in order. For each vertex k with the current partition S of vertices 0..k-1, the vertex is placed in S if the weight to S-complement exceeds the weight to S (maximizing cut contribution). The key inequality max(a,b) >= (a+b)/2 shows each vertex contributes at least half its total edge weight to already-placed vertices. Summing gives total cut >= W/2.",
     "keyInsights": [
@@ -85,7 +85,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Formalizes the method of conditional expectations for MaxCut derandomization. Defines a constructive greedy algorithm, proves the key inequality max(a,b)>=(a+b)/2, and proves the abstract conditional expectations principle. 1 sorry remains for the inductive fold assembly. 0 axioms, 5 theorems, 170 lines.",
+    "summary": "0 sorries, 0 axioms. Fully proved via the method of conditional expectations (averaging argument). 401 lines.",
     "implications": "The method of conditional expectations is one of the most important derandomization techniques in combinatorics and algorithms. This formalization demonstrates the pattern: probabilistic existence -> greedy algorithm -> deterministic guarantee. The same technique applies to MAX-SAT (Johnson 1974), coloring, and many other optimization problems.",
     "openQuestions": [
       "Can the Goemans-Williamson SDP relaxation (0.878-approximation) be formalized in Lean 4?",
@@ -98,18 +98,18 @@
       "Mathlib"
     ],
     "namespace": "MaxCutDerandomization",
-    "lineCount": 198,
+    "lineCount": 401,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 5,
     "path": "Proofs/RandomizedMaxcutOQ04.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "mainTheorems": [
     {
       "name": "exists_good_partition'",
       "type": "core",
-      "description": "Constructive proof of MaxCut 1/2-approximation via greedy algorithm (1 sorry)"
+      "description": "Constructive proof of MaxCut 1/2-approximation via greedy algorithm"
     },
     {
       "name": "conditional_expectation_method",


### PR DESCRIPTION
## Summary

- **Fix**: `randomized-maxcut-oq-04/meta.json` — sorry count 1→0, status `formalized`→`verified`, badge `wip`→`original`. The Lean file (`RandomizedMaxcutOQ04.lean`) is fully proved with 0 sorries and 0 axioms via the method of conditional expectations averaging argument.
- **Tracker**: 10 proofs marked clean (first audit pass), 2 marked issues-fixed

## Issues Fixed

### randomized-maxcut-oq-04 (HIGH severity)
- **meta.json claimed**: `sorries: 1`, `status: formalized`, `badge: wip`
- **Lean file has**: 0 sorries, 0 axioms — Lean comment at bottom says "0 sorries, 0 axioms. Fully proved."
- The sorry was for an "inductive fold assembly" that was resolved by switching to an averaging argument

## 10 Proofs Audited (Clean)
All matched their meta.json claims — 0 sorries, correct badges:
- `area-of-circle-oq-01-oq-02-oq-01-oq-03` (verified/mathlib)
- `arithmetic-series-oq-00` (verified/original)
- `ballot-problem-oq-01-oq-02-oq-01` (formalized/wip, 3 sorries matches)
- `binary-gcd-oq-03` (verified/original)
- `divisibility-rules-oq-02` (verified/verified)
- `hilbert-15-oq-02` (axiomatized/axiom, 3 axioms)
- `minkowski-fundamental-theorem-oq-02` (verified/mathlib)
- `primitive-roots-oq-02` (verified/original)
- `taylor-theorem-oq-02` (verified/original, "sorry" only in comments)
- `vietas-formulas-oq-02` (verified/original)

## Related
- PR #10340: fix `chebyshev-pnt-bridge` sorry count 2→1

## Test plan
- [x] Verified Lean file for each audited proof
- [x] Confirmed sorry counts, axiom counts, True-stub checks
- [x] Audit tracker updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)