### PR TITLE
Enrich: Nicomachus's Theorem + Taylor Convergence (add mathContext)

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-00/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-00/annotations.json
@@ -6,6 +6,7 @@
     "type": "technique",
     "title": "Induction Pattern: push_cast then linarith",
     "content": "The main theorem `sum_cubes_eq_triangular_sq` uses the same three-tactic induction pattern seen in `ArithmeticSeriesOQ04.lean` for `sum_powers_three`:\n\n1. `Finset.sum_Ico_succ_top` splits the sum: ∑_{k=1}^{n+1} k³ = ∑_{k=1}^{n} k³ + (n+1)³\n2. `push_cast` makes the ℕ → ℚ coercions explicit so arithmetic lemmas apply\n3. `linarith` closes the goal using the induction hypothesis\n\nThe `linarith` success here is surprising for a degree-4 identity — it works because after `push_cast`, the IH gives a linear constraint `∑k³ = (n(n+1)/2)²` that combines with the new term `(n+1)³` via the polynomial identity `(n(n+1)/2)² + (n+1)³ = ((n+1)(n+2)/2)²`. The `linarith` tactic can verify this by treating the monomials as atomic terms.",
+    "mathContext": "Inductive step: $\\sum_{k=1}^{n+1} k^3 = \\sum_{k=1}^{n} k^3 + (n+1)^3 = \\left(\\frac{n(n+1)}{2}\\right)^2 + (n+1)^3 = \\left(\\frac{(n+1)(n+2)}{2}\\right)^2$. The `push_cast` tactic coerces $\\mathbb{N} \\to \\mathbb{Q}$ so that `linarith` can verify the degree-4 polynomial identity.",
     "significance": "key",
     "relatedConcepts": ["induction", "push_cast", "linarith", "Finset.sum_Ico_succ_top"],
     "prerequisites": ["Finset.Ico", "BigOperators", "Nat.cast"]
@@ -17,6 +18,7 @@
     "type": "insight",
     "title": "The Beautiful Form: ∑k³ = (∑k)²",
     "content": "The theorem `sum_cubes_eq_sq_sum` states that ∑_{k=1}^n k³ = (∑_{k=1}^n k)². This follows immediately by combining two facts:\n1. ∑_{k=1}^n k³ = (n(n+1)/2)² (Nicomachus's theorem)\n2. ∑_{k=1}^n k = n(n+1)/2 (Gauss's formula)\n\nThe proof is just two `rw` steps: rewrite the Gauss sum, then Nicomachus's theorem. No computation needed once the two identities are established.\n\nThis form is arguably the most surprising: the same set {1, 2, ..., n} appears on both sides, but via completely different operations. The cube-and-sum coincides with the sum-and-square. This is genuinely non-obvious and is one reason Nicomachus's theorem has delighted mathematicians for 2000 years.",
+    "mathContext": "$\\sum_{k=1}^{n} k^3 = \\left(\\sum_{k=1}^{n} k\\right)^2$. The same sequence $\\{1, 2, \\ldots, n\\}$ yields the same result under two fundamentally different operations: cube-then-sum on the left, sum-then-square on the right.",
     "significance": "highlight",
     "relatedConcepts": ["Gauss sum", "triangular numbers", "figurate numbers", "power sums"],
     "prerequisites": ["gauss_sum_rat", "sum_cubes_eq_triangular_sq"]
@@ -28,6 +30,7 @@
     "type": "technique",
     "title": "Division-Free ℕ Form via ring",
     "content": "The theorem `sum_cubes_mul_four` avoids natural number division entirely by multiplying both sides by 4: `4 × ∑k³ = (n(n+1))²`.\n\nThe inductive step needs `ring` rather than `linarith` because the key algebraic identity\n  `(n(n+1))² + 4(n+1)³ = ((n+1)(n+2))²`\nis degree 4 and involves only polynomial multiplication (no division or subtraction). The `ring` tactic works in ℕ as a commutative *semiring* — it verifies polynomial identities without requiring additive inverses, as long as both sides have the same expansion with non-negative coefficients.\n\nExpanding: LHS = n⁴ + 6n³ + 13n² + 12n + 4 = RHS ✓",
+    "mathContext": "$4 \\times \\sum_{k=1}^{n} k^3 = (n(n+1))^2$ in $\\mathbb{N}$. The inductive identity $(n(n+1))^2 + 4(n+1)^3 = ((n+1)(n+2))^2$ expands to $n^4 + 6n^3 + 13n^2 + 12n + 4$ on both sides, verified by `ring` in the commutative semiring $\\mathbb{N}$.",
     "significance": "technique",
     "relatedConcepts": ["ring tactic", "commutative semiring", "natural number arithmetic", "division avoidance"],
     "prerequisites": ["Nat.mul_add", "ring"]
@@ -39,6 +42,7 @@
     "type": "insight",
     "title": "The Algebraic Heart of Nicomachus's Theorem",
     "content": "The lemma `nicomachus_step` isolates the key algebraic identity:\n  (n(n+1)/2)² + (n+1)³ = ((n+1)(n+2)/2)²\n\nThis is proved in one line by `ring` over ℚ. It expresses the inductive content of the theorem: each time we extend the sum from n to n+1, the sum increases by (n+1)³, and the triangular square increases from T(n)² = (n(n+1)/2)² to T(n+1)² = ((n+1)(n+2)/2)².\n\nThe geometric interpretation: the gnomon for the (n+1)-th step has area (n+1)³, which exactly fills the L-shaped region between the n×n triangular square and the (n+1)×(n+1) triangular square.",
+    "mathContext": "$\\left(\\frac{n(n+1)}{2}\\right)^2 + (n+1)^3 = \\left(\\frac{(n+1)(n+2)}{2}\\right)^2$. Geometrically: the gnomon for step $n+1$ has area $(n+1)^3$, which exactly fills the L-shaped region from $T_n^2$ to $T_{n+1}^2$, where $T_n = n(n+1)/2$.",
     "significance": "key",
     "relatedConcepts": ["triangular numbers", "gnomon decomposition", "ring tactic"],
     "prerequisites": ["ring"]
@@ -50,6 +54,7 @@
     "type": "verification",
     "title": "Concrete Verification by native_decide",
     "content": "The partial sums ∑_{k=1}^n k³ are always perfect squares: 1, 9, 36, 100, 225, 441, 784, 1296, ... These are the squares of the triangular numbers 1, 3, 6, 10, 15, 21, 28, 36, ...\n\nFor n=10: ∑_{k=1}^{10} k³ = 3025 = 55² = (10·11/2)². This is verified by `native_decide`, which computes the sum directly. The `triangular_squares` theorem verifies all 8 cases simultaneously using a list computation.\n\nNote: `native_decide` compiles Lean code to native machine code and evaluates it, making it extremely fast for these concrete computations.",
+    "mathContext": "$\\sum_{k=1}^{10} k^3 = 1 + 8 + 27 + 64 + 125 + 216 + 343 + 512 + 729 + 1000 = 3025 = 55^2 = T_{10}^2$. The sequence of triangular numbers $T_n = 1, 3, 6, 10, 15, 21, 28, 36, \\ldots$ satisfies $T_n^2 = \\sum_{k=1}^n k^3$.",
     "significance": "supporting",
     "relatedConcepts": ["native_decide", "triangular numbers", "concrete computation"],
     "prerequisites": ["native_decide", "List.range", "List.map"]
@@ -61,6 +66,7 @@
     "type": "context",
     "title": "Nicomachus of Gerasa: 2000 Years of Mathematical Elegance",
     "content": "Nicomachus of Gerasa (c. 60–120 CE) was a Pythagorean philosopher from what is now Jerash, Jordan. His *Introductio Arithmetica* (Introduction to Arithmetic) was the standard arithmetic textbook in the Greco-Roman world for centuries, surviving through Boethius's Latin adaptation *De Institutione Arithmetica* (c. 500 CE).\n\nNicomachus described this identity by observing that:\n- The k-th cube k³ = sum of k consecutive odd numbers centered around k²\n  (e.g., 3³ = 27 = 7 + 9 + 11)\n- These consecutive odd blocks fit together as gnomons in a growing square\n- The partial sums form the sequence 1, 9, 36, 100, ... — perfect squares!\n\nThis visual insight predates modern algebraic notation by 1500 years and represents one of the earliest known *proofs without words*.",
+    "mathContext": "Nicomachus's observation: $k^3 = \\underbrace{(k^2 - k + 1) + (k^2 - k + 3) + \\cdots + (k^2 + k - 1)}_{k \\text{ consecutive odd numbers}}$. For example, $3^3 = 27 = 7 + 9 + 11$. These odd-number blocks fit together as L-shaped gnomons around a growing square of side $T_n = 1 + 2 + \\cdots + n$.",
     "significance": "context",
     "relatedConcepts": ["gnomon", "figurate numbers", "Pythagorean arithmetic", "proof without words"],
     "prerequisites": []

--- a/src/data/proofs/taylor-theorem-oq-02/annotations.json
+++ b/src/data/proofs/taylor-theorem-oq-02/annotations.json
@@ -6,6 +6,7 @@
     "type": "insight",
     "title": "The FPS-to-Taylor Bridge",
     "content": "The core challenge is connecting two different representations of the same function:\n\n- **Mathlib's FPS representation**: `HasSum (fun n => p n (fun _ => y)) (f (x₀+y))` where p n is a degree-n continuous multilinear map ℝⁿ → ℝ\n- **Classical Taylor form**: `HasSum (fun n => iteratedDeriv n f x₀ / n! * y^n) (f (x₀+y))` where each term is a scalar\n\nThe bridge has two steps:\n1. **Multilinearity**: `m(y,...,y) = y^n · m(1,...,1)` (extracting the `y^n` factor)\n2. **Permutation symmetry**: `iteratedFDeriv = Σ_{σ} p n (v ∘ σ)` for constant v becomes `iteratedFDeriv = n! · p n (1,...,1)` (identifying the `1/n!` denominator)\n\nThe factor `n!` appears naturally: the permutation group Perm(Fin n) has exactly n! elements, and each permutation of a constant vector gives the same value.",
+    "mathContext": "Bridge from $\\text{HasSum}(n \\mapsto p_n(y, \\ldots, y),\\, f(x_0 + y))$ to $\\text{HasSum}\\left(n \\mapsto \\frac{f^{(n)}(x_0)}{n!} y^n,\\, f(x_0 + y)\\right)$. Step 1: multilinearity gives $p_n(y,\\ldots,y) = y^n \\cdot p_n(1,\\ldots,1)$. Step 2: permutation symmetry gives $f^{(n)}(x_0) = n! \\cdot p_n(1,\\ldots,1)$, so $p_n(1,\\ldots,1) = f^{(n)}(x_0)/n!$.",
     "significance": "key",
     "relatedConcepts": ["HasFPowerSeriesAt", "iteratedFDeriv", "FormalMultilinearSeries", "Perm"],
     "prerequisites": ["taylor-theorem", "HasFPowerSeriesAt"]
@@ -17,6 +18,7 @@
     "type": "technique",
     "title": "Fintype.card_perm = n! — The Permutation Count",
     "content": "The proof uses `Fintype.card_perm` to rewrite `|Perm (Fin n)| = n!`. This is the key step that introduces the `n!` denominator in the Taylor series.\n\nThe proof chain:\n```\nFinset.sum_const  →  nsmul_eq_mul  →  Fintype.card_perm\n```\n\nSpecifically:\n- `Finset.sum_const`: sum of constant c over S = |S| • c\n- `Finset.card_univ`: |Finset.univ| = Fintype.card\n- `Fintype.card_perm`: Fintype.card (Perm (Fin n)) = n!\n- `nsmul_eq_mul`: converts ℕ-scalar multiplication to ring multiplication\n\nThis is a clean and general argument — it does not need any special properties of the particular function f.",
+    "mathContext": "$f^{(n)}(x_0) = \\sum_{\\sigma \\in S_n} p_n(e_{\\sigma(1)}, \\ldots, e_{\\sigma(n)})$. For constant vectors $v = (1, \\ldots, 1)$, every permutation gives the same value, so $f^{(n)}(x_0) = |S_n| \\cdot p_n(1,\\ldots,1) = n! \\cdot p_n(1,\\ldots,1)$, using $|\\text{Perm}(\\text{Fin}\\, n)| = n!$.",
     "significance": "technique",
     "relatedConcepts": ["Fintype.card_perm", "nsmul_eq_mul", "Finset.sum_const", "permutation group"],
     "prerequisites": ["HasFPowerSeriesOnBall.iteratedFDeriv_eq_sum_of_completeSpace"]
@@ -28,6 +30,7 @@
     "type": "insight",
     "title": "Why Smoothness Fails: The Cauchy Example",
     "content": "The module docstring highlights the sharp boundary between smooth and analytic functions:\n\n**Cauchy's example**: f(x) = exp(-1/x²) for x ≠ 0, f(0) = 0.\n\nThis function is C^∞ at 0 — every derivative exists and equals 0 at x=0. So the Taylor series at 0 is identically 0. But f(x) ≠ 0 for x ≠ 0, so the Taylor series **fails** to converge to f anywhere except at the expansion point.\n\nThe Taylor remainder Rₙ(x) = f(x) - 0 = f(x) **does not converge to 0** — it stays at f(x) forever!\n\nThis example shows that the O(hⁿ) bound from Taylor's theorem (gallery: taylor-theorem) does NOT imply Rₙ → 0. Something more is needed — namely, **analyticity** (convergence of the power series).",
+    "mathContext": "Cauchy's function $f(x) = e^{-1/x^2}$ (with $f(0) = 0$) satisfies $f^{(n)}(0) = 0$ for all $n$, so its Taylor series at 0 is $\\sum 0 \\cdot x^n = 0$. But $f(x) > 0$ for $x \\neq 0$, so $R_n(x) = f(x) \\not\\to 0$. The function is $C^\\infty$ but not analytic at 0: smoothness ($\\forall n, f^{(n)}$ exists) $\\not\\Rightarrow$ analyticity ($\\sum f^{(n)}(x_0) y^n/n!$ converges to $f$).",
     "significance": "highlight",
     "relatedConcepts": ["smooth functions", "analytic functions", "Cauchy example", "exp(-1/x²)"],
     "prerequisites": ["taylor-theorem", "HasFPowerSeriesAt"]
@@ -39,6 +42,7 @@
     "type": "technique",
     "title": "HasSum.congr — One-Line Main Theorem",
     "content": "With the bridge lemma in hand, the main convergence theorem `taylor_hasSum_of_hasFPS` reduces to a single line:\n\n```lean\n(h.hasSum hy).congr fun n => (fps_eval_eq_taylor_term h n y).symm\n```\n\nThis is the standard Mathlib pattern:\n1. Start with `h.hasSum hy : HasSum (fun n => p n (fun _ => y)) (f (x₀+y))`\n2. Apply `.congr` with the bridge lemma (reversed) to rewrite each term\n3. Get `HasSum (fun n => iteratedDeriv n f x₀ / n! * y^n) (f (x₀+y))`\n\nThe elegance: once you have the right bridge lemma, the proof is trivial.",
+    "mathContext": "$\\text{HasSum}\\left(n \\mapsto \\frac{f^{(n)}(x_0)}{n!} y^n,\\; f(x_0 + y)\\right)$ for $\\|y\\| < r$, where $r$ is the radius of analyticity. The proof: `HasSum.congr` rewrites $p_n(y,\\ldots,y) \\to \\frac{f^{(n)}(x_0)}{n!} y^n$ term-by-term using the bridge lemma.",
     "significance": "technique",
     "relatedConcepts": ["HasSum.congr", "HasFPowerSeriesAt.hasSum", "fps_eval_eq_taylor_term"],
     "prerequisites": ["HasSum"]
@@ -50,6 +54,7 @@
     "type": "insight",
     "title": "Structural vs Ad Hoc: Comparison with OQ-03",
     "content": "This proof (OQ-02) and the companion (OQ-03) both prove Taylor convergence, but with different scope and method:\n\n**OQ-03** (taylor-theorem-oq-03): Proves Taylor convergence for exp(x) specifically.\n- Uses explicit derivative bounds: `iteratedDeriv n exp x₀ = exp x₀` by induction\n- Uses summability of `‖x‖^n/n!` to bound the error\n- Constructive, gives explicit error bounds (|e - S_n(1)| ≤ 3/n!)\n\n**OQ-02** (this file): Proves Taylor convergence for ALL analytic functions.\n- Uses the structural definition: analytic ≡ HasFPowerSeriesAt\n- No explicit derivative computation needed\n- No error bounds, but covers the full generality\n\nThe relationship: OQ-02's result explains WHY exp's Taylor series converges (exp is analytic). OQ-03's result gives HOW FAST it converges (explicit bound). Both perspectives are valuable.",
+    "mathContext": "OQ-02 proves: $f$ analytic at $x_0 \\implies \\sum_{n=0}^{\\infty} \\frac{f^{(n)}(x_0)}{n!} y^n = f(x_0 + y)$ for $\\|y\\| < r$. OQ-03 proves: $\\left|e - \\sum_{k=0}^{n} \\frac{1}{k!}\\right| \\leq \\frac{3}{(n+1)!}$ with explicit error bounds. OQ-02 is general (all analytic $f$); OQ-03 is specific ($f = \\exp$) but quantitative.",
     "significance": "supporting",
     "relatedConcepts": ["HasFPowerSeriesAt", "AnalyticAt", "exp convergence", "taylor-theorem-oq-03"],
     "prerequisites": ["taylor-theorem-oq-03"]


### PR DESCRIPTION
## Summary

### 1. `arithmetic-series-oq-00` — Nicomachus's Theorem (0/6 → 6/6 mathContext)
- Added LaTeX `mathContext` to all 6 annotations
- Key formulas: ∑k³ = (n(n+1)/2)², gnomon decomposition k³ = k consecutive odds, division-free form 4∑k³ = (n(n+1))²

### 2. `taylor-theorem-oq-02` — Taylor Series Convergence (0/5 → 5/5 mathContext)
- Added LaTeX `mathContext` to all 5 annotations
- Key formulas: FPS-to-Taylor bridge via multilinearity + permutation counting, Cauchy's smooth-but-not-analytic counterexample, HasSum.congr proof

## Verification

- `pnpm build` passes for both entries