### PR TITLE
Enrich Liu-Montgomery Sharp Cycle Length Constant

### DIFF
--- a/src/data/proofs/erdos-65-oq-03/annotations.json
+++ b/src/data/proofs/erdos-65-oq-03/annotations.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "ann-lm-harmonic-sums",
+    "proofId": "erdos-65-oq-03",
+    "range": { "startLine": 30, "endLine": 72 },
+    "type": "definition",
+    "title": "Partial Harmonic Sum Infrastructure",
+    "content": "Defines `partialHarmonic m` ($H(m) = \\sum_{j=1}^m 1/j$), `partialHarmonicFrom2`, and `evenHarmonic m` ($\\sum_{j=1}^m 1/(2j)$). The key algebraic identity `evenHarmonic_eq_half_harmonic` proves $\\sum_{j=1}^m 1/(2j) = \\frac{1}{2} H(m)$ by factoring out $1/2$. Also proves nonnegativity and monotonicity of $H(m)$. These sums are the building blocks for quantifying cycle reciprocal sums.",
+    "mathContext": "$H(m) = \\sum_{j=1}^{m} \\frac{1}{j}$, $\\sum_{j=1}^{m} \\frac{1}{2j} = \\frac{1}{2} H(m)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["harmonic series", "asymptotic growth", "Euler-Mascheroni constant"],
+    "prerequisites": ["Finset.sum", "positivity tactic"]
+  },
+  {
+    "id": "ann-lm-bipartite-cycles",
+    "proofId": "erdos-65-oq-03",
+    "range": { "startLine": 74, "endLine": 110 },
+    "type": "insight",
+    "title": "Bipartite Cycle Reciprocal Sum",
+    "content": "Defines `bipartiteCycleRecipSum r s` for $K_{r,s}$: the cycle lengths in a complete bipartite graph are exactly the even numbers $\\{4, 6, \\ldots, 2\\min(r,s)\\}$ (since bipartite graphs have no odd cycles). The reciprocal sum is $\\sum_{j=2}^{\\min(r,s)} 1/(2j) = \\frac{1}{2} \\sum_{j=2}^{\\min(r,s)} 1/j$. For $K_{m,m}$, this equals $\\frac{1}{2}(H(m) - 1)$, which is $\\sim \\frac{1}{2} \\log m$. This establishes the tightness example.",
+    "mathContext": "For $K_{m,m}$: $\\sum_{\\text{cycles}} \\frac{1}{|C|} = \\sum_{j=2}^{m} \\frac{1}{2j} = \\frac{1}{2}(H(m) - 1) \\sim \\frac{1}{2} \\ln m$.",
+    "significance": "key",
+    "relatedConcepts": ["complete bipartite graph", "even cycles", "extremal graph theory"],
+    "prerequisites": ["Finset.Ico", "min operation"]
+  },
+  {
+    "id": "ann-lm-liu-montgomery",
+    "proofId": "erdos-65-oq-03",
+    "range": { "startLine": 112, "endLine": 137 },
+    "type": "context",
+    "title": "Liu-Montgomery Theorem (Axiomatized)",
+    "content": "The main result axiomatized from Liu-Montgomery (JAMS 2023): for any graph $G$ with average degree $d \\ge 2$, the sum of reciprocals of distinct cycle lengths is $\\ge (1/2 - \\varepsilon) \\log d$ for sufficiently large $d$. Axiomatized because the proof is a deep 43-page argument using the regularity method, probabilistic techniques, and careful cycle-finding in expanding subgraphs. The formalization encodes cycles as injective sequences of vertices with adjacency around the cycle.",
+    "mathContext": "$\\sum_{i} \\frac{1}{a_i} \\ge \\left(\\frac{1}{2} - \\varepsilon\\right) \\log d$ for any $\\varepsilon > 0$ and sufficiently large $d$.",
+    "significance": "key",
+    "relatedConcepts": ["Szemerédi regularity lemma", "Gyárfás-Komlós-Szemerédi theorem", "cycle spectrum"],
+    "prerequisites": ["SimpleGraph", "average degree", "cycle definition"]
+  },
+  {
+    "id": "ann-lm-odd-even-decomposition",
+    "proofId": "erdos-65-oq-03",
+    "range": { "startLine": 139, "endLine": 181 },
+    "type": "technique",
+    "title": "Odd vs Even Cycle Decomposition",
+    "content": "Decomposes the reciprocal cycle sum into even and odd contributions. The even cycle sum $\\sum_{j=2}^m 1/(2j) = \\frac{1}{2} \\sum_{j=2}^m 1/j$ captures exactly the bipartite contribution. The key structural insight: bipartite graphs have *only* even cycles, so their reciprocal sum equals the even cycle sum. Non-bipartite graphs add strictly positive odd-cycle contributions ($1/k > 0$ for odd $k \\ge 3$), so they cannot have smaller reciprocal sums.",
+    "mathContext": "$\\sum \\frac{1}{|C|} = \\underbrace{\\sum_{\\text{even}} \\frac{1}{2j}}_{= \\frac{1}{2} \\sum 1/j} + \\underbrace{\\sum_{\\text{odd}} \\frac{1}{2j+1}}_{\\ge 0}$",
+    "significance": "key",
+    "relatedConcepts": ["bipartite graph characterization", "odd cycle parity", "chromatic number"],
+    "prerequisites": ["Finset.sum", "positivity"]
+  },
+  {
+    "id": "ann-lm-tightness",
+    "proofId": "erdos-65-oq-03",
+    "range": { "startLine": 183, "endLine": 228 },
+    "type": "insight",
+    "title": "Tightness: Why 1/2 Is the Sharp Constant",
+    "content": "Proves `sharp_constant_achieved`: the even harmonic sum is exactly $(1/2) H(m)$, confirming that the bipartite construction achieves constant $1/2$. Combined with `bipartite_is_even` (the $K_{m,m}$ cycle sum equals the even cycle sum) and `odd_cycle_increases_sum` (odd cycles add positive contributions), this proves that $1/2$ is tight. Concrete verifications: $H(4) = 25/12$, even harmonic for $m=4$ is $25/24$, and the cycle sum for $K_{4,4}$ from cycles $\\{4,6,8\\}$ is $13/24$.",
+    "mathContext": "The constant $1/2$ is achieved by $K_{m,m}$: $\\sum_{j=2}^{m} \\frac{1}{2j} = \\frac{1}{2}(H(m) - 1) \\sim \\frac{1}{2} \\ln m$.",
+    "significance": "key",
+    "relatedConcepts": ["extremal example", "tightness of bounds", "complete bipartite graph"],
+    "prerequisites": ["evenHarmonic_eq_half_harmonic", "bipartite_is_even"]
+  }
+]

--- a/src/data/proofs/erdos-65-oq-03/meta.json
+++ b/src/data/proofs/erdos-65-oq-03/meta.json
@@ -19,10 +19,108 @@
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 1,
-    "lineCount": 267
+    "lineCount": 267,
+    "assumptions": "1 axiom: liu_montgomery_sharp — the (1/2 - o(1)) log d lower bound from Liu-Montgomery (JAMS 2023, 43 pages). All computational results (harmonic sums, bipartite cycle sums, tightness) fully verified.",
+    "originalContributions": [
+      "evenHarmonic_eq_half_harmonic: even harmonic sum equals half the full harmonic sum",
+      "bipartiteCycleRecipSum_eq_half_shifted: K_{m,m} cycle sum = (1/2)(H(m)-1)",
+      "sharp_constant_achieved: confirms 1/2 is the achieved constant",
+      "bipartite_is_even + odd_cycle_increases_sum: structural proof of tightness"
+    ]
   },
-  "sections": [],
+  "overview": {
+    "historicalContext": "Gyárfás, Komlós, and Szemerédi proved in the 1980s that graphs with high average degree contain cycles of many different lengths, with the sum of reciprocal cycle lengths growing at least logarithmically. The optimal constant in this bound remained open until Hong Liu and Richard Montgomery's 2023 paper in JAMS, where they proved the sharp constant is $1/2$: $\\sum 1/a_i \\ge (1/2 - o(1)) \\log d$. This file formalizes the tightness analysis, showing that complete bipartite graphs $K_{m,m}$ achieve exactly $(1/2)(H(m) - 1) \\sim (1/2) \\ln m$ because they have only even-length cycles.",
+    "problemStatement": "Formalize the sharp constant $1/2$ in the Gyárfás-Komlós-Szemerédi theorem and prove tightness via bipartite construction analysis.",
+    "proofStrategy": "The formalization develops harmonic sum infrastructure, then analyzes the cycle structure of $K_{m,m}$: its cycles have lengths $\\{4, 6, \\ldots, 2m\\}$, contributing $\\sum_{j=2}^m 1/(2j) = (1/2)(H(m) - 1)$. The tightness argument decomposes cycle sums into even and odd parts, showing bipartite graphs minimize the sum (having no odd-cycle contributions). The Liu-Montgomery lower bound is axiomatized from the published result.",
+    "keyInsights": [
+      "The constant 1/2 arises because complete bipartite graphs (the minimizers) have only even-length cycles 2j, contributing 1/(2j) = (1/2)(1/j)",
+      "Non-bipartite graphs have additional odd-cycle contributions (1/(2j+1) > 0), so they cannot achieve a smaller reciprocal sum",
+      "The decomposition into even and odd cycle sums reduces the tightness argument to a simple algebraic fact about harmonic numbers",
+      "The Liu-Montgomery lower bound matches the bipartite upper bound asymptotically, confirming 1/2 as sharp"
+    ]
+  },
+  "sections": [
+    {
+      "id": "harmonic-sums",
+      "title": "Part I: Partial Harmonic Sums",
+      "startLine": 30,
+      "endLine": 72,
+      "summary": "Defines H(m), even harmonic, shifted harmonic. Proves evenHarmonic = (1/2)H(m), nonnegativity, and monotonicity."
+    },
+    {
+      "id": "bipartite-cycles",
+      "title": "Part II: Complete Bipartite Graph Cycle Lengths",
+      "startLine": 74,
+      "endLine": 110,
+      "summary": "Defines bipartiteCycleRecipSum for K_{r,s}. Proves K_{m,m} sum = (1/2)(H(m)-1)."
+    },
+    {
+      "id": "sharp-constant",
+      "title": "Part III: The Sharp Constant (Axiomatized)",
+      "startLine": 112,
+      "endLine": 137,
+      "summary": "Liu-Montgomery theorem axiomatized: Σ 1/aᵢ ≥ (1/2 - ε) log d for sufficiently large d."
+    },
+    {
+      "id": "odd-even-analysis",
+      "title": "Part IV: Odd Cycle Analysis",
+      "startLine": 139,
+      "endLine": 181,
+      "summary": "Decomposes reciprocal sum into even and odd contributions. Proves odd cycles add strictly positive terms."
+    },
+    {
+      "id": "tightness",
+      "title": "Part V: Tightness of the 1/2 Constant",
+      "startLine": 183,
+      "endLine": 228,
+      "summary": "Proves bipartite graphs achieve the 1/2 constant and non-bipartite graphs cannot do better."
+    }
+  ],
+  "conclusion": {
+    "summary": "Formalizes the tightness analysis for the Liu-Montgomery sharp constant $1/2$ in the cycle reciprocal sum theorem. All computational results are fully verified; the Liu-Montgomery lower bound itself is axiomatized from the 43-page JAMS 2023 paper.",
+    "implications": "This verifies that the natural barrier for cycle reciprocal sums comes from bipartite graphs, connecting extremal graph theory to harmonic analysis. The even/odd decomposition technique is reusable for other cycle spectrum problems.",
+    "openQuestions": [
+      "Can the Liu-Montgomery lower bound be formalized, at least for special graph families?",
+      "What is the sharp constant for graphs of given girth (minimum cycle length)?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-65",
+      "relationship": "ancestor",
+      "description": "Root: Erdős problem 65 on cycle lengths in graphs"
+    }
+  ],
   "leanFile": {
-    "axiomCount": 1
-  }
+    "imports": ["Mathlib"],
+    "namespace": "Erdos65OQ03",
+    "lineCount": 267,
+    "axiomCount": 1,
+    "theoremCount": 12,
+    "definitionCount": 5,
+    "path": "Proofs/Erdos65OQ03.lean",
+    "sorries": 0
+  },
+  "mainTheorems": [
+    {
+      "name": "liu_montgomery_sharp",
+      "type": "core",
+      "description": "Liu-Montgomery theorem: Σ 1/aᵢ ≥ (1/2 - ε) log d (axiomatized)"
+    },
+    {
+      "name": "sharp_constant_achieved",
+      "type": "core",
+      "description": "The 1/2 constant is achieved by bipartite graphs"
+    },
+    {
+      "name": "evenHarmonic_eq_half_harmonic",
+      "type": "supporting",
+      "description": "Even harmonic = (1/2) · full harmonic"
+    },
+    {
+      "name": "bipartiteCycleRecipSum_eq_half_shifted",
+      "type": "supporting",
+      "description": "K_{m,m} cycle sum = (1/2)(H(m)-1)"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Enrichment pass for `erdos-65-oq-03` (quality 0 → enriched).

- Created `annotations.json` with 5 annotations covering harmonic sums, bipartite cycles, Liu-Montgomery theorem, odd/even decomposition, tightness
- Added full overview: historicalContext (GKS 1980s, Liu-Montgomery JAMS 2023), proofStrategy, 4 keyInsights
- Added 5 sections, conclusion with 2 open questions
- Added crossReferences, mainTheorems, leanFile details

Axiom integrity verified: 1 axiom (liu_montgomery_sharp), 0 sorries.

Note: Previous enrichments (7 proofs) were in PR #10338 which was merged/closed. This PR contains only the erdos-65-oq-03 enrichment.