### PR TITLE
Audit: fix meta.json integrity for 6 proofs, audit 12 total

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02/meta.json
@@ -10,7 +10,7 @@
     "status": "formalized",
     "tags": ["geometry", "galois-theory", "constructibility", "impossibility"],
     "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ01OQ02.lean",
-    "badge": "original",
+    "badge": "wip",
     "sorries": 5,
     "axiomCount": 0,
     "theoremCount": 10

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1849,9 +1849,9 @@
       "issues": []
     },
     "erdos-1012-oq-03": {
-      "auditCount": 9,
+      "auditCount": 10,
       "issues": [],
-      "lastAudited": "2026-04-12T21:12:56Z",
+      "lastAudited": "2026-04-13T01:00:46Z",
       "result": "issues-fixed"
     },
     "erdos-1013": {
@@ -12103,8 +12103,8 @@
       "issues": []
     },
     "chebyshev-pnt-bridge": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-13T00:50:38Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-13T00:56:13Z",
       "result": "issues-fixed",
       "issues": []
     },
@@ -12127,9 +12127,9 @@
       "result": "clean"
     },
     "randomized-maxcut-oq-04": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-04-13T00:50:38Z",
+      "lastAudited": "2026-04-13T00:57:35Z",
       "result": "issues-fixed"
     },
     "area-of-circle-oq-01-oq-02-oq-01-oq-03": {
@@ -12192,6 +12192,7 @@
       "result": "clean",
       "issues": []
     },
+<<<<<<< HEAD
     "area-of-circle-oq-03-oq-03-oq-02": {
       "auditCount": 1,
       "lastAudited": "2026-04-13T00:17:18Z",
@@ -12201,6 +12202,59 @@
     "randomized-maxcut-oq-04": {
       "auditCount": 1,
       "lastAudited": "2026-04-13T00:17:48Z",
+=======
+    "angle-trisection-oq-02-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T01:03:45Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "cantor-diagonalization-oq-04-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T01:03:45Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "euler-totient-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T01:03:45Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "binomial-theorem-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T01:03:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-65-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T01:03:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "hilbert-20-oq-01-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T01:03:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "konigsberg-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T01:03:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "laws-of-large-numbers-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T01:03:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "leibniz-pi-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T01:03:45Z",
+>>>>>>> 744a0ba1ac (Audit: fix meta.json integrity for 6 proofs, audit 12 total)
       "result": "clean",
       "issues": []
     }

--- a/src/data/proofs/cantor-diagonalization-oq-04-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-04-oq-03/meta.json
@@ -16,7 +16,7 @@
       "order-theory"
     ],
     "proofRepoPath": "Proofs/CantorDiagonalizationOQ04OQ03.lean",
-    "badge": "original",
+    "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
     "theoremCount": 10,

--- a/src/data/proofs/chebyshev-pnt-bridge/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "None. All results fully verified from Mathlib.",
     "lineCount": 264,
-    "theoremCount": 10,
+    "theoremCount": 9,
     "definitionCount": 2,
     "originalContributions": [
       "Upper bound: (\u221an)^{\u03c0(n)-\u03c0(\u221an)} \u2264 4^n via primorial, fully proved from Mathlib",
@@ -61,7 +61,7 @@
       "title": "Module Documentation and Imports",
       "startLine": 1,
       "endLine": 31,
-      "description": "Documents the upper and lower bounds, connection to Chebyshev's 1852 result, and remaining sorries. Imports primorial, prime counting, central binomial, and ChebyshevBounds."
+      "description": "Documents the upper and lower bounds and connection to Chebyshev's 1852 result. Imports primorial, prime counting, central binomial, and ChebyshevBounds."
     },
     {
       "id": "sec-bridge-upper",
@@ -74,14 +74,14 @@
       "id": "sec-bridge-factorization",
       "title": "Factorization Bound (Key Lemma)",
       "startLine": 142,
-      "endLine": 172,
+      "endLine": 213,
       "description": "Proves the factorization bound p^{v_p(C(2n,n))} \u2264 2n via Mathlib's pow_factorization_choose_le, and C(2n,n) \u2264 (2n)^{\u03c0(2n)} via unique factorization and prime counting."
     },
     {
       "id": "sec-bridge-lower",
       "title": "Lower Bound on \u03c0(n)",
-      "startLine": 174,
-      "endLine": 224,
+      "startLine": 214,
+      "endLine": 264,
       "description": "Derives 4^n \u2264 (2n+1)\u00b7(2n)^{\u03c0(2n)} from the central binomial lower bound and factorization bound. Summary of asymptotic implications."
     }
   ],
@@ -102,7 +102,7 @@
     "lineCount": 264,
     "path": "Proofs/ChebyshevPNTBridge.lean",
     "axiomCount": 0,
-    "theoremCount": 10,
+    "theoremCount": 9,
     "definitionCount": 2,
     "sorries": 0,
     "imports": [

--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -4,7 +4,7 @@
   "slug": "erdos-1012-oq-03",
   "description": "Directed analogues of Hamiltonian cycle conditions: Ghouila-Houri, Moon-Moser, and Rédei theorems for digraphs and tournaments.",
   "meta": {
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos1012OQ03.lean",
     "tags": [
       "graph-theory",
@@ -12,11 +12,11 @@
       "hamiltonian-cycles",
       "tournaments"
     ],
-    "badge": "wip",
-    "sorries": 1,
+    "badge": "original",
+    "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 1285,
-    "assumptions": "0 axioms. 1 sorry in Ghouila-Houri helper: ghouila_houri_cycle_extendable (cycle of length k < n → longer cycle under GH degree conditions). sc_degree_has_cycle (SC + high degree → initial directed cycle) is now fully proved via greedy path extension and back-arc argument. directed_hamiltonian_threshold is fully proved (0 sorries). Moon-Moser theorem and Rédei are also fully proved.",
+    "lineCount": 1623,
+    "assumptions": "None. All four main theorems fully proved: Ghouila-Houri, Moon-Moser, Rédei, and directed Hamiltonian threshold. 0 sorries, 0 axioms.",
     "dateAdded": "2026-03-30",
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Hamiltonian_path_problem#Directed_graphs",
@@ -65,10 +65,10 @@
     },
     {
       "id": "part-iii-ghouila-houri",
-      "title": "Part III: Ghouila-Houri Theorem (Sorry)",
+      "title": "Part III: Ghouila-Houri Theorem",
       "startLine": 285,
-      "endLine": 301,
-      "summary": "States ghouila_houri: strongly connected digraph with δ⁺(v), δ⁻(v) ≥ n/2 for all v has a Hamiltonian cycle. Proof deferred (sorry). Requires longest-path argument (~200 lines, similar to undirected Dirac proof)."
+      "endLine": 758,
+      "summary": "Fully proves ghouila_houri: strongly connected digraph with δ⁺(v), δ⁻(v) ≥ n/2 for all v has a Hamiltonian cycle. Includes sc_degree_has_cycle (greedy path + back-arc), ghouila_houri_cycle_extendable (cycle extension under GH conditions), and grow_cycle_gh (well-founded recursion)."
     },
     {
       "id": "part-iv-moon-moser",
@@ -82,15 +82,13 @@
       "title": "Part V: Edge Threshold + Proof Roadmap",
       "startLine": 943,
       "endLine": 991,
-      "summary": "Defines arcCount. Proves directed_hamiltonian_threshold: (n-1)² < arcCount ∧ strongly connected → Hamiltonian cycle via probabilistic counting (hamiltonian_of_few_missing_arcs, perm_arc_bad_card_le). Only ghouila_houri remains as sorry. Closes with #check commands verifying all four main theorems."
+      "summary": "Defines arcCount. Proves directed_hamiltonian_threshold: (n-1)² < arcCount ∧ strongly connected → Hamiltonian cycle via probabilistic counting (hamiltonian_of_few_missing_arcs, perm_arc_bad_card_le). Closes with #check commands verifying all four main theorems."
     }
   ],
   "conclusion": {
-    "summary": "Rédei's theorem (every tournament has a Hamiltonian path) is fully proved by induction via the tournament insertion lemma. Moon-Moser's theorem (every strongly connected tournament has a Hamiltonian cycle) is fully proved. directed_hamiltonian_threshold (arc count (n-1)² forces Hamiltonicity) is now fully proved via hamiltonian_of_few_missing_arcs, which was completed by proving the fiber counting lemma hBadFor_bound using Finset.orderIsoOfFin injections into Perm(Fin(n-2)). Only ghouila_houri remains as a sorry (1 sorry). The 1277-line file is the most substantial directed Hamiltonicity formalization in this gallery.",
+    "summary": "All four main theorems fully proved (0 sorries, 0 axioms): Rédei's theorem (every tournament has a Hamiltonian path), Moon-Moser's theorem (strongly connected tournaments have Hamiltonian cycles), Ghouila-Houri's theorem (directed Dirac), and directed_hamiltonian_threshold (arc count (n-1)² forces Hamiltonicity). The 1623-line file is the most substantial directed Hamiltonicity formalization in this gallery.",
     "implications": "Directed Hamiltonicity thresholds have applications beyond pure graph theory: tournament Hamiltonian paths correspond to linear extensions of partial orders, with applications to voting theory (ranking candidates) and scheduling. Rédei's theorem has a direct combinatorial interpretation: in any round-robin tournament, there exists a ranking of all players consistent with the match results (as a directed path). Moon-Moser's result shows that strongly connected tournaments (those where outcomes don't create a dominant clique) have circular Hamiltonian cycles — a stronger consistency property.",
     "openQuestions": [
-      "Can `ghouila_houri` be fully proved? It requires a longest-path argument tracking both in- and out-degrees (~200 lines), analogous to the undirected Dirac theorem. This is the only remaining sorry.",
-      "Can Ghouila-Houri's theorem be fully formalized? The proof follows the Dirac argument for undirected graphs but requires tracking both in- and out-degrees. Is the analogous undirected Dirac theorem in Mathlib, and can the directed version be derived?",
       "Meyniel's condition (weaker than Ghouila-Houri: $\\delta^+(u) + \\delta^-(u) + \\delta^+(v) + \\delta^-(v) \\geq 2n-1$ for non-adjacent pairs) implies Hamiltonicity. Can this stronger result be formalized, or would it require substantially more tournament infrastructure?",
       "The arc threshold $(n-1)^2$ in `directed_hamiltonian_threshold` — is this the tight bound? What is the densest non-Hamiltonian strongly connected tournament on $n$ vertices, and can a tight threshold be proved in Lean?"
     ]
@@ -123,11 +121,11 @@
       "Finset"
     ],
     "namespace": "Erdos1012OQ03",
-    "lineCount": 1285,
+    "lineCount": 1623,
     "axiomCount": 0,
-    "sorries": 1,
+    "sorries": 0,
     "path": "Proofs/Erdos1012OQ03.lean",
-    "theoremCount": 22,
-    "definitionCount": 10
+    "theoremCount": 9,
+    "definitionCount": 9
   }
 }

--- a/src/data/proofs/euler-totient-oq-02-oq-01/meta.json
+++ b/src/data/proofs/euler-totient-oq-02-oq-01/meta.json
@@ -16,7 +16,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. All results from Mathlib's Nat.totient API and Finsupp infrastructure.",
-    "lineCount": 203,
+    "lineCount": 207,
     "theoremCount": 10,
     "definitionCount": 0,
     "mathlib_version": "4.26.0",
@@ -133,7 +133,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 203,
+    "lineCount": 207,
     "path": "Proofs/EulerTotientOQ02OQ01.lean",
     "axiomCount": 0,
     "sorries": 0

--- a/src/data/proofs/randomized-maxcut-oq-04/meta.json
+++ b/src/data/proofs/randomized-maxcut-oq-04/meta.json
@@ -60,7 +60,7 @@
       "title": "Part III: Deterministic Existence",
       "startLine": 88,
       "endLine": 113,
-      "summary": "exists_good_partition': the main theorem showing the greedy partition achieves >= W/2. Has 1 sorry for the inductive fold assembly.",
+      "summary": "exists_good_partition': the main theorem showing the greedy partition achieves >= W/2. Fully proved via inductive fold assembly.",
       "mathContext": "$\\text{cutWeight}(G, S_{\\text{greedy}}) = \\sum_k \\text{contribution}(k) \\geq \\sum_k \\frac{w_{\\text{in}}(k) + w_{\\text{out}}(k)}{2} = \\frac{W}{2}$."
     },
     {
@@ -100,8 +100,8 @@
     "namespace": "MaxCutDerandomization",
     "lineCount": 401,
     "axiomCount": 0,
-    "theoremCount": 5,
-    "definitionCount": 5,
+    "theoremCount": 10,
+    "definitionCount": 4,
     "path": "Proofs/RandomizedMaxcutOQ04.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

- **erdos-1012-oq-03**: upgrade formalized/wip → verified/original — all 4 theorems (Ghouila-Houri, Moon-Moser, Rédei, directed Hamiltonian threshold) are now fully proved with 0 sorries
- **chebyshev-pnt-bridge**: fix theoremCount (10→9), update section line ranges for expanded file
- **randomized-maxcut-oq-04**: fix theoremCount (5→10), definitionCount (5→4), remove stale sorry reference
- **angle-trisection-oq-02-oq-01-oq-02**: fix badge original→wip (has 5 sorries)
- **cantor-diagonalization-oq-04-oq-03**: fix badge original→wip (has 1 sorry)
- **euler-totient-oq-02-oq-01**: fix lineCount (203→207)

## Test plan

- [ ] Verify `pnpm build` succeeds with updated meta.json files
- [ ] Check that gallery pages render correctly for all 6 modified proofs

🤖 Generated with [Claude Code](https://claude.com/claude-code)