### PR TITLE
Audit: fix meta integrity + resolve tracker conflict + audit 5 proofs

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1849,10 +1849,10 @@
       "issues": []
     },
     "erdos-1012-oq-03": {
-      "auditCount": 10,
+      "auditCount": 11,
       "issues": [],
-      "lastAudited": "2026-04-13T01:00:46Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-04-13T01:17:31Z",
+      "result": "issues-found"
     },
     "erdos-1013": {
       "agentId": "auditor-cycle-20-batch",
@@ -11372,9 +11372,9 @@
       "issues": []
     },
     "fair-games-theorem-oq-03": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-04T23:23:29Z",
-      "result": "clean",
+      "auditCount": 3,
+      "lastAudited": "2026-04-13T01:21:11Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "arithmetic-series-oq-04": {
@@ -12122,15 +12122,15 @@
     },
     "area-of-circle-oq-03-oq-03-oq-02": {
       "auditCount": 1,
-      "issues": [],
-      "lastAudited": "2026-04-12T23:55:51Z",
-      "result": "clean"
+      "lastAudited": "2026-04-13T00:17:18Z",
+      "result": "clean",
+      "issues": []
     },
     "randomized-maxcut-oq-04": {
-      "auditCount": 3,
-      "issues": [],
-      "lastAudited": "2026-04-13T00:57:35Z",
-      "result": "issues-fixed"
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T00:17:48Z",
+      "result": "issues-fixed",
+      "issues": []
     },
     "area-of-circle-oq-01-oq-02-oq-01-oq-03": {
       "auditCount": 1,
@@ -12192,17 +12192,6 @@
       "result": "clean",
       "issues": []
     },
-<<<<<<< HEAD
-    "area-of-circle-oq-03-oq-03-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T00:17:18Z",
-      "result": "clean",
-      "issues": []
-    },
-    "randomized-maxcut-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-04-13T00:17:48Z",
-=======
     "angle-trisection-oq-02-oq-01-oq-02": {
       "auditCount": 1,
       "lastAudited": "2026-04-13T01:03:45Z",
@@ -12254,7 +12243,6 @@
     "leibniz-pi-oq-02": {
       "auditCount": 1,
       "lastAudited": "2026-04-13T01:03:45Z",
->>>>>>> 744a0ba1ac (Audit: fix meta.json integrity for 6 proofs, audit 12 total)
       "result": "clean",
       "issues": []
     }

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1921,9 +1921,9 @@
       "result": "clean"
     },
     "erdos-1018-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-13T01:24:21Z",
       "result": "clean"
     },
     "erdos-1019": {
@@ -2221,9 +2221,9 @@
       "result": "clean"
     },
     "erdos-1059-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-04-03T05:20:33Z",
+      "lastAudited": "2026-04-13T01:24:09Z",
       "result": "clean"
     },
     "erdos-1059-oq-05": {
@@ -12243,6 +12243,12 @@
     "leibniz-pi-oq-02": {
       "auditCount": 1,
       "lastAudited": "2026-04-13T01:03:45Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1059-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T01:23:58Z",
       "result": "clean",
       "issues": []
     }

--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -4,7 +4,7 @@
   "slug": "erdos-1012-oq-03",
   "description": "Directed analogues of Hamiltonian cycle conditions: Ghouila-Houri, Moon-Moser, and Rédei theorems for digraphs and tournaments.",
   "meta": {
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1012OQ03.lean",
     "tags": [
       "graph-theory",
@@ -12,11 +12,11 @@
       "hamiltonian-cycles",
       "tournaments"
     ],
-    "badge": "original",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 1623,
-    "assumptions": "None. All four main theorems fully proved: Ghouila-Houri, Moon-Moser, Rédei, and directed Hamiltonian threshold. 0 sorries, 0 axioms.",
+    "assumptions": "1 axiom: gh_cycle_extendable_small_k (Ghouila-Houri cycle extension for k+1 < n). Rédei, Moon-Moser, and directed_hamiltonian_threshold are fully proved. ghouila_houri depends on the axiom.",
     "dateAdded": "2026-03-30",
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Hamiltonian_path_problem#Directed_graphs",
@@ -86,7 +86,7 @@
     }
   ],
   "conclusion": {
-    "summary": "All four main theorems fully proved (0 sorries, 0 axioms): Rédei's theorem (every tournament has a Hamiltonian path), Moon-Moser's theorem (strongly connected tournaments have Hamiltonian cycles), Ghouila-Houri's theorem (directed Dirac), and directed_hamiltonian_threshold (arc count (n-1)² forces Hamiltonicity). The 1623-line file is the most substantial directed Hamiltonicity formalization in this gallery.",
+    "summary": "Rédei (Hamiltonian path in tournaments), Moon-Moser (Hamiltonian cycles in SC tournaments), and directed_hamiltonian_threshold are fully proved (0 sorries). Ghouila-Houri's theorem depends on 1 axiom (gh_cycle_extendable_small_k: cycle extension when k+1 < n). The 1623-line file is the most substantial directed Hamiltonicity formalization in this gallery.",
     "implications": "Directed Hamiltonicity thresholds have applications beyond pure graph theory: tournament Hamiltonian paths correspond to linear extensions of partial orders, with applications to voting theory (ranking candidates) and scheduling. Rédei's theorem has a direct combinatorial interpretation: in any round-robin tournament, there exists a ranking of all players consistent with the match results (as a directed path). Moon-Moser's result shows that strongly connected tournaments (those where outcomes don't create a dominant clique) have circular Hamiltonian cycles — a stronger consistency property.",
     "openQuestions": [
       "Meyniel's condition (weaker than Ghouila-Houri: $\\delta^+(u) + \\delta^-(u) + \\delta^+(v) + \\delta^-(v) \\geq 2n-1$ for non-adjacent pairs) implies Hamiltonicity. Can this stronger result be formalized, or would it require substantially more tournament infrastructure?",
@@ -122,7 +122,7 @@
     ],
     "namespace": "Erdos1012OQ03",
     "lineCount": 1623,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "sorries": 0,
     "path": "Proofs/Erdos1012OQ03.lean",
     "theoremCount": 9,

--- a/src/data/proofs/fair-games-theorem-oq-03/meta.json
+++ b/src/data/proofs/fair-games-theorem-oq-03/meta.json
@@ -17,10 +17,10 @@
       "wiedijk-100"
     ],
     "badge": "wip",
-    "sorries": 4,
+    "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 290,
-    "assumptions": "4 sorries: any_bounded_strategy_preserves_expectation, two_strategies_same_expectation, risk_neutral_pricing_neutrality (pending WithTop.untopA simp API in Mathlib 4.26.0), doobs_maximal_inequality (pending NNReal-to-real conversion of Mathlib maximal_ineq). Note: FairGamesTheorem.lean has pre-existing build failures in Mathlib 4.26.0 due to IsStoppingTime API change from τ:Ω→ι to τ:Ω→WithTop ι.",
+    "lineCount": 317,
+    "assumptions": "1 sorry: doobs_maximal_inequality (pending NNReal-to-real conversion of Mathlib maximal_ineq). 8 theorems fully proved including any_bounded_strategy_preserves_expectation, two_strategies_same_expectation, and risk_neutral_pricing_neutrality.",
     "mathlib_version": "4.26.0"
   },
   "leanFile": {
@@ -31,12 +31,12 @@
       "MeasureTheory"
     ],
     "namespace": "FairGamesOQ03",
-    "lineCount": 290,
+    "lineCount": 317,
     "axiomCount": 0,
     "theoremCount": 9,
     "definitionCount": 0,
     "path": "Proofs/FairGamesTheoremOQ03.lean",
-    "sorries": 4
+    "sorries": 1
   },
   "crossReferences": [
     {
@@ -53,13 +53,13 @@
   "overview": {
     "historicalContext": "The Optional Stopping Theorem was proved by Joseph Doob in 1953 and forms the cornerstone of modern martingale theory. Doob's martingale theory unified previously disparate results in probability: the ballot problem (Bertrand 1887), the ruin probability formula (Laplace 1812), and sequential hypothesis testing (Wald 1947) all become special cases of one theorem: if you stop a martingale at a bounded stopping time, the expected value is unchanged from the start.\n\nIn Lean 4 / Mathlib 4.26.0, the stopping time API was updated to use τ : Ω → WithTop ℕ (extended naturals ℕ∞) instead of τ : Ω → ℕ. This represents a conceptually richer formalization — ⊤ represents 'never stop', which is the correct mathematical type — but breaks code written against the older API. This file navigates that API change, documenting the workarounds and the four theorems that remain as sorries pending stabilization of the stoppedValue/WithTop.untopA simp lemmas.",
     "problemStatement": "The main FairGamesTheorem.lean file contained several application theorems left as trivial placeholders (returning `(1:ℕ)+1=2` or `True`). Can these be given substantive, mathematically meaningful proofs? Additionally, can the single axiom in the main file be eliminated using Mathlib's bidirectional characterization theorem?",
-    "proofStrategy": "Standalone file (no import of FairGamesTheorem). Each stub is given a proper mathematical statement and proof. The Gambler's Ruin formula is derived algebraically from the fair game condition. Martingale time-invariance uses Martingale.setIntegral_eq directly. The submartingale characterization axiom is proved using submartingale_iff_expected_stoppedValue_mono. Four theorems remain as sorry pending Mathlib 4.26.0 stoppedValue/untopA simp API resolution.",
+    "proofStrategy": "Standalone file (no import of FairGamesTheorem). Each stub is given a proper mathematical statement and proof. The Gambler's Ruin formula is derived algebraically from the fair game condition. Martingale time-invariance uses Martingale.setIntegral_eq directly. The submartingale characterization axiom is proved using submartingale_iff_expected_stoppedValue_mono. The betting system failure theorem uses a sub/supermartingale sandwich argument. Only doobs_maximal_inequality remains as a sorry.",
     "keyInsights": [
       "Martingale time-invariance (E[f_n] = E[f_0]) is proved via Martingale.setIntegral_eq with s=Set.univ — a clean path that avoids stopping time machinery entirely.",
       "The Gambler's Ruin probability formula P(win) = W₀/(W₀+a) is a pure algebraic consequence of E[final wealth] = initial wealth. Once the fair game property is established, the stochastic problem reduces to a linear equation solved by rw [eq_div_iff] and linarith.",
       "The submartingale characterization axiom in FairGamesTheorem.lean is directly eliminated: rw [submartingale_iff_expected_stoppedValue_mono hadapt hint] rewrites the goal, then exact h closes it in one step.",
       "Mathlib 4.26.0 changed IsStoppingTime from τ:Ω→ι to τ:Ω→WithTop ι. This is a breaking change affecting FairGamesTheorem.lean. The OQ03 file is standalone and uses the correct τ:Ω→ℕ∞ type.",
-      "Doob's maximal inequality and three stopping-time theorems remain as honest sorries. The stoppedValue unfolding via WithTop.untopA requires identifying the correct Mathlib 4.26.0 simp lemmas."
+      "The three stopping-time theorems (any_bounded_strategy_preserves_expectation, two_strategies_same_expectation, risk_neutral_pricing_neutrality) are now fully proved via sub/supermartingale sandwich. Only doobs_maximal_inequality remains as a sorry (NNReal-to-real conversion from Mathlib's maximal_ineq)."
     ]
   },
   "sections": [
@@ -104,18 +104,18 @@
     {
       "id": "betting-systems-fail",
       "title": "Part III: Betting Systems Fail",
-      "description": "Any bounded stopping strategy preserves the expected value (sorry — pending stoppedValue API)",
+      "description": "Any bounded stopping strategy preserves the expected value (proved via sub/supermartingale sandwich)",
       "theorems": [
         {
           "name": "any_bounded_strategy_preserves_expectation",
           "statement": "∫ ω, stoppedValue f τ ω ∂μ = ∫ ω, f 0 ω ∂μ",
-          "status": "sorry",
+          "status": "proved",
           "description": "No bounded stopping strategy can improve expected returns"
         },
         {
           "name": "two_strategies_same_expectation",
           "statement": "∫ ω, stoppedValue f τ ω ∂μ = ∫ ω, stoppedValue f π ω ∂μ for τ ≤ π",
-          "status": "sorry",
+          "status": "proved",
           "description": "Two bounded strategies yield equal expected payoffs"
         }
       ]
@@ -123,12 +123,12 @@
     {
       "id": "option-pricing",
       "title": "Part IV: Option Pricing Neutrality",
-      "description": "Risk-neutral pricing: exercise timing preserves expected payoff (sorry — pending stoppedValue API)",
+      "description": "Risk-neutral pricing: exercise timing preserves expected payoff (proved — delegates to Optional Stopping)",
       "theorems": [
         {
           "name": "risk_neutral_pricing_neutrality",
           "statement": "∫ ω, stoppedValue f τ ω ∂μ = ∫ ω, f 0 ω ∂μ",
-          "status": "sorry",
+          "status": "proved",
           "description": "Under risk-neutral measure, exercise timing doesn't matter"
         }
       ]
@@ -161,10 +161,10 @@
     }
   ],
   "conclusion": {
-    "summary": "This file demonstrates that the Optional Stopping Theorem's main application theorems can be formalized with 0 axioms. The algebraic Gambler's Ruin formula shows the theorem's power: a result requiring careful stochastic analysis reduces to solving a linear equation. The submartingale characterization axiom from the parent file is fully eliminated. Four theorems remain as honest sorries pending Mathlib 4.26.0 stoppedValue/WithTop.untopA simp API stabilization.",
+    "summary": "This file demonstrates that the Optional Stopping Theorem's main application theorems can be formalized with 0 axioms. 8 of 9 theorems are fully proved, including the Gambler's Ruin formula, martingale time-invariance, betting system failure (via sub/supermartingale sandwich), and the submartingale characterization (eliminating the parent file's axiom). Only doobs_maximal_inequality remains as a sorry (pending NNReal-to-real conversion).",
     "implications": "The Gambler's Ruin formalization illustrates a general pattern: once a stochastic invariant (E[f_τ] = E[f_0]) is established, the application reduces to pure algebra. This separation of concerns — stochastic argument once, algebraic consequence forever — makes formal verification tractable for complex probabilistic arguments. The martingale time-invariance proof via setIntegral_eq with s=Set.univ shows that Mathlib's measure theory API is rich enough to bypass complex stopping-time machinery when simpler paths exist.",
     "openQuestions": [
-      "Can the 4 sorry'd theorems be proved once Mathlib stabilizes WithTop.untopD/untopA simp lemmas for stoppedValue?",
+      "Can doobs_maximal_inequality be proved once Mathlib stabilizes NNReal-to-real conversion for maximal_ineq?",
       "Can the continuous-time version (Doob's Optional Stopping for Brownian motion) be formalized using Mathlib's continuous-time martingale infrastructure?",
       "Can Wald's identity (E[S_τ] = E[X₁] · E[τ] for random sums stopped at τ) be derived as a corollary of martingale_time_invariance?"
     ]


### PR DESCRIPTION
## Summary

- **erdos-1012-oq-03**: `verified` → `axiomatized`, `axiomCount` 0→1 (has `private axiom gh_cycle_extendable_small_k` at line 500). Supersedes PR #10358.
- **fair-games-theorem-oq-03**: `sorries` 4→1 (3 theorems now fully proved: `any_bounded_strategy_preserves_expectation`, `two_strategies_same_expectation`, `risk_neutral_pricing_neutrality`; only `doobs_maximal_inequality` remains sorry)
- **audit-tracker.json**: Resolved merge conflict markers introduced by PR #10352 (JSON was invalid on main)
- **3 proofs audited clean**: erdos-1059-oq-01-oq-01, erdos-1059-oq-03, erdos-1018-oq-04

## Test plan

- [ ] `python3 -c "import json; json.load(open('src/data/proofs/audit-tracker.json'))"` passes
- [ ] `pnpm build` succeeds
- [ ] erdos-1012-oq-03 meta.json shows status=axiomatized, badge=axiom, axiomCount=1
- [ ] fair-games-theorem-oq-03 meta.json shows sorries=1

🤖 Generated with [Claude Code](https://claude.com/claude-code)