### PR TITLE
Aristotle: companion file for LeibnizPiOQ02

### DIFF
--- a/proofs/Proofs/LeibnizPiOQ02Aristotle.lean
+++ b/proofs/Proofs/LeibnizPiOQ02Aristotle.lean
@@ -1,0 +1,99 @@
+/-
+  Aristotle targets for LeibnizPiOQ02
+  Routine supporting lemmas for automated proof search.
+  See LeibnizPiOQ02.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the deep Fourier analysis result (dirichlet_beta_three — requires Fourier)
+  - NOT theorems depending on the axiom eta_zeta_relation (dirichlet_eta_two)
+  - NOT numerical bounds on infinite sums (catalan_bounds — too complex for Aristotle)
+  - Convergence theorems accessible via Mathlib's alternating series results
+  - No axioms, no definition sorries, no open conjectures
+  - No /-! docstring sections (use /- instead)
+
+  Included targets (5):
+  - alternating_harmonic_series_ari: altHarmonicPartialSum → log 2
+  - dirichlet_beta_one_ari: dirichletBetaPartialSum 1 → π/4
+  - dirichlet_eta_one_ari: dirichletEtaPartialSum 1 → log 2
+  - catalan_series_convergent_ari: dirichletBetaPartialSum 2 → G (Catalan's constant)
+  - leibniz_error_bound_ari: |β_n(1) - π/4| ≤ 1/(2n+1)
+
+  NOT included:
+  - dirichlet_beta_three: requires Fourier analysis of x² on [-π,π]
+  - dirichlet_eta_two: depends on axiom eta_zeta_relation
+  - catalan_bounds: numerical bounds on infinite sums (0.91 < G < 0.92)
+  - catalan_pos: requires convergence result that is also sorry
+-/
+import Mathlib
+import Proofs.LeibnizPiOQ02
+
+namespace LeibnizPiOQ02Aristotle
+
+open LeibnizPiOQ02 Finset BigOperators Filter Real Topology
+
+/-
+## Section 1: Alternating Harmonic Series
+
+The alternating harmonic series Σ (-1)^k/(k+1) converges to ln(2).
+Mathlib provides this via Real.hasSum_pow_div_log_of_abs_lt_one (the Taylor
+series of -ln(1-x)) evaluated at x = -1 in the limit sense, or directly
+via lemmas about the Dirichlet eta function.
+-/
+
+/-- The alternating harmonic partial sums converge to ln 2. -/
+theorem alternating_harmonic_series_ari :
+    Tendsto LeibnizPiOQ02.altHarmonicPartialSum atTop (nhds (Real.log 2)) := by
+  sorry
+
+/-
+## Section 2: Leibniz Formula (β(1) = π/4)
+
+The Leibniz formula connects our dirichletBetaPartialSum at s=1 to π/4.
+Mathlib has Real.tendsto_sum_pi_div_four for the Leibniz series.
+-/
+
+/-- The Dirichlet beta partial sums at s=1 converge to π/4. -/
+theorem dirichlet_beta_one_ari :
+    Tendsto (LeibnizPiOQ02.dirichletBetaPartialSum 1) atTop (nhds (π / 4)) := by
+  sorry
+
+/-
+## Section 3: Dirichlet Eta at s=1 (η(1) = ln 2)
+
+The Dirichlet eta partial sums at s=1 compute the same series as the
+alternating harmonic series; they differ only in index packaging.
+-/
+
+/-- The Dirichlet eta partial sums at s=1 converge to ln 2. -/
+theorem dirichlet_eta_one_ari :
+    Tendsto (LeibnizPiOQ02.dirichletEtaPartialSum 1) atTop (nhds (Real.log 2)) := by
+  sorry
+
+/-
+## Section 4: Catalan's Constant Series Convergence
+
+The Dirichlet beta partial sums at s=2 converge to Catalan's constant G,
+defined as ∑' n, (-1)^n/(2n+1)^2. The alternating series test applies
+since 1/(2n+1)^2 is positive, decreasing, and tends to 0.
+-/
+
+/-- The Dirichlet beta partial sums at s=2 converge to Catalan's constant. -/
+theorem catalan_series_convergent_ari :
+    Tendsto (LeibnizPiOQ02.dirichletBetaPartialSum 2) atTop
+      (nhds LeibnizPiOQ02.catalansConstant) := by
+  sorry
+
+/-
+## Section 5: Leibniz Error Bound
+
+The alternating series estimation theorem bounds the truncation error
+of the Leibniz series: the n-th partial sum approximates π/4 with
+error at most the (n+1)-th term = 1/(2n+1).
+-/
+
+/-- The Leibniz series partial sums satisfy the alternating series error bound. -/
+theorem leibniz_error_bound_ari (n : ℕ) (hn : 0 < n) :
+    |LeibnizPiOQ02.dirichletBetaPartialSum 1 n - π / 4| ≤ 1 / (2 * n + 1 : ℝ) := by
+  sorry
+
+end LeibnizPiOQ02Aristotle


### PR DESCRIPTION
## Fix

Create Aristotle companion file for LeibnizPiOQ02 (9 sorries, no prior companion).

## Evidence

**Before**: LeibnizPiOQ02.lean has 9 theorem sorries with no Aristotle companion file for automated proof search.

**After**: LeibnizPiOQ02Aristotle.lean exposes 5 routine convergence targets:
1. `alternating_harmonic_series_ari` — altHarmonicPartialSum → log 2
2. `dirichlet_beta_one_ari` — dirichletBetaPartialSum 1 → π/4 (Leibniz formula)
3. `dirichlet_eta_one_ari` — dirichletEtaPartialSum 1 → log 2
4. `catalan_series_convergent_ari` — dirichletBetaPartialSum 2 → Catalan's constant
5. `leibniz_error_bound_ari` — alternating series error bound for Leibniz

**Excluded** (not Aristotle-suitable):
- `dirichlet_beta_three`: requires Fourier analysis
- `dirichlet_eta_two`: depends on axiom `eta_zeta_relation`
- `catalan_bounds`: numerical bounds on infinite tsum
- `catalan_pos`: requires convergence result that is also sorry

## Checklist
- [x] No `def ... := sorry`
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections
- [x] No open conjectures

---
Automated fix by lean-mechanic agent.