### PR TITLE
Aristotle: companion file for CantorDiagonalizationOQ04OQ03

### DIFF
--- a/proofs/Proofs/CantorDiagonalizationOQ04OQ03Aristotle.lean
+++ b/proofs/Proofs/CantorDiagonalizationOQ04OQ03Aristotle.lean
@@ -1,0 +1,48 @@
+/-
+  Aristotle targets for CantorDiagonalizationOQ04OQ03
+  Routine supporting lemmas for automated proof search.
+  See CantorDiagonalizationOQ04OQ03.lean for the Lawvere-Kleene formalization.
+
+  Criteria for inclusion:
+  - Routine derivation from ω-continuity: monotonicity via a step chain
+  - The chain construction a, b, b, b, ... connects ω-continuity to monotonicity
+  - No axioms, no definition sorries, no open conjectures
+  - No /-! docstring sections (use /- instead)
+
+  Included targets (1):
+  - omega_continuous_monotone_ari: ω-continuous functions are monotone
+
+  Strategy: Given a ≤ b, build the ascending chain c(0) = a, c(n+1) = b.
+  Then ⨆ c = b (chain is eventually b), so by ω-continuity:
+    f b = f(⨆ c) = ⨆(f ∘ c) ≥ f(c 0) = f a.
+
+  NOT included:
+  - Lawvere fixed-point theorem (already proved in main file)
+  - Kleene fixed-point theorem (already proved in main file)
+  - Least fixed-point property (already proved in main file)
+-/
+import Mathlib
+import Proofs.CantorDiagonalizationOQ04OQ03
+
+namespace CantorDiagonalizationOQ04OQ03Aristotle
+
+open CantorDiagonalizationOQ04OQ03
+
+/-
+## ω-Continuity Implies Monotonicity
+
+Given a ≤ b, we need to show f a ≤ f b. The key is to use the step chain:
+  c n = if n = 0 then a else b
+
+This chain is ascending (a ≤ b, then constant) with supremum b.
+By ω-continuity: f(⨆ n, c n) = ⨆ n, f(c n)
+So: f b = ⨆ n, f(c n) ≥ f(c 0) = f a.
+-/
+
+/-- ω-continuous functions on complete lattices are monotone.
+    Proof: use the step chain c(0)=a, c(n+1)=b with sup=b and apply ω-continuity. -/
+theorem omega_continuous_monotone_ari {α : Type*} [CompleteLattice α] {f : α → α}
+    (hf : OmegaContinuous f) : Monotone f := by
+  sorry
+
+end CantorDiagonalizationOQ04OQ03Aristotle


### PR DESCRIPTION
## Fix

Creates Aristotle companion exposing the OmegaContinuous.monotone sorry for automated proof search in the Lawvere-Kleene fixed-point formalization.

## Evidence

**Target**: omega_continuous_monotone_ari - ω-continuous functions on complete lattices are monotone

**Proof strategy** (step chain):
Given a ≤ b, use chain c(0)=a, c(n+1)=b with sup=b. By ω-continuity:
f b = f(sup c) = sup(f c) ≥ f(c 0) = f a.

---
Automated fix by lean-mechanic agent.