### PR TITLE
Aristotle: create companion file for LawsOfLargeNumbersOQ03

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ03Aristotle.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ03Aristotle.lean
@@ -1,0 +1,48 @@
+/-
+  Aristotle targets for LawsOfLargeNumbersOQ03
+  Routine supporting lemmas for automated proof search.
+  See LawsOfLargeNumbersOQ03.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the Birkhoff ergodic theorem (axiom — deep functional analysis)
+  - NOT the mean ergodic theorem (axiom — Hilbert space methods)
+  - NOT the maximal ergodic lemma (axiom — sunrise lemma)
+  - Only the mixing → ergodic implication (theorem sorry, standard argument)
+  - No axioms, no definition sorries, no open conjectures
+  - No /-! docstring sections (use /- instead)
+
+  Included targets (1):
+  - mixing_implies_ergodic_ari: IsMixing T μ → Ergodic T μ
+
+  NOT included:
+  - birkhoff_ergodic_theorem: axiom (deep, Aristotle skips)
+  - birkhoff_ergodic_constant: axiom (deep, Aristotle skips)
+  - maximal_ergodic_lemma: axiom (deep, Aristotle skips)
+  - vonNeumann_mean_ergodic: axiom (deep, Aristotle skips)
+-/
+import Mathlib
+import Proofs.LawsOfLargeNumbersOQ03
+
+namespace LawsOfLargeNumbersOQ03Aristotle
+
+open LawsOfLargeNumbersOQ03 MeasureTheory MeasurableSpace Filter Topology
+
+/-
+## Mixing Implies Ergodic
+
+Proof strategy: Let A be a T-invariant measurable set (T⁻¹A = A, hence T^[n]⁻¹A = A).
+By IsMixing, μ(A ∩ T^[n]⁻¹A) → μ(A) * μ(A).
+But A is invariant, so T^[n]⁻¹A = A, and A ∩ A = A, so μ(A ∩ T^[n]⁻¹A) = μ(A) constantly.
+The limit of a constant sequence μ(A) equals μ(A)² = μ(A) * μ(A).
+Thus μ(A) = μ(A)², which means μ(A) * (1 - μ(A)) = 0, so μ(A) = 0 or μ(A) = 1.
+Since μ is a probability measure, μ(Set.univ) = 1, so μ(A) ∈ {0, μ Set.univ}.
+-/
+
+/-- Mixing implies ergodic: invariant sets have measure 0 or 1.
+    Proof: for T-invariant A, IsMixing gives μ(A) = μ(A)², so μ(A) ∈ {0,1}. -/
+theorem mixing_implies_ergodic_ari {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
+    (T : Ω → Ω) (hT : MeasurePreserving T μ μ) (hTm : Measurable T)
+    [IsProbabilityMeasure μ] (hmix : IsMixing T μ) : Ergodic T μ := by
+  sorry
+
+end LawsOfLargeNumbersOQ03Aristotle


### PR DESCRIPTION
## Fix

Creates Aristotle companion file for `LawsOfLargeNumbersOQ03` exposing the `mixing_implies_ergodic` sorry for automated proof search.

## Evidence

**Target**: `mixing_implies_ergodic_ari` — IsMixing T μ → Ergodic T μ

**Proof strategy**: For T-invariant A, IsMixing gives μ(A ∩ T^[n]⁻¹A) → μ(A)². Since A is invariant, T^[n]⁻¹A = A so the sequence is constant at μ(A), giving μ(A) = μ(A)², hence μ(A) ∈ {0,1}.

**Excluded** (correctly): 4 axioms (`birkhoff_ergodic_theorem`, `birkhoff_ergodic_constant`, `maximal_ergodic_lemma`, `vonNeumann_mean_ergodic`) — Aristotle skips axioms.

## Validation

- No `def ... := sorry` (definition sorries)
- No `axiom` declarations
- No `theorem ... : True` placeholders
- No `/-!` docstring sections

---
Automated fix by lean-mechanic agent.