### PR TITLE
Research: erdos-353, erdos-470, surveys + pool cleanup

### DIFF
--- a/proofs/Proofs/Erdos353Aristotle.lean
+++ b/proofs/Proofs/Erdos353Aristotle.lean
@@ -25,6 +25,16 @@ theorem volume_preimage_smul_eq_top (c : ℝ) (hc : c ≠ 0)
     (A : Set (EuclideanSpace ℝ (Fin 2)))
     (hA : MeasurableSet A) (hvol : volume A = ⊤) :
     volume ((fun x => c • x) ⁻¹' A) = ⊤ := by
-  sorry
+  -- Rewrite preimage as c⁻¹ • A
+  have h_eq : (fun x : EuclideanSpace ℝ (Fin 2) => c • x) ⁻¹' A = c⁻¹ • A := by
+    ext x
+    simp only [Set.mem_smul_set, Set.mem_preimage]
+    constructor
+    · intro h; exact ⟨c • x, h, inv_smul_smul₀ hc x⟩
+    · rintro ⟨a, ha, rfl⟩; rwa [smul_inv_smul₀ hc]
+  rw [h_eq, MeasureTheory.Measure.addHaar_smul volume c⁻¹ A, hvol]
+  have h_pos : (0 : ℝ≥0∞) < ENNReal.ofReal |c⁻¹| ^ FiniteDimensional.finrank ℝ (EuclideanSpace ℝ (Fin 2)) :=
+    pow_pos (ENNReal.ofReal_pos.mpr (abs_pos.mpr (inv_ne_zero.mpr hc))) _
+  simp [ENNReal.mul_top, h_pos.ne']
 
 end Erdos353Aristotle

--- a/proofs/Proofs/Erdos470Problem.lean
+++ b/proofs/Proofs/Erdos470Problem.lean
@@ -362,122 +362,85 @@ theorem odd_weird_gt_4725 (n : ℕ) (hw : IsWeird n) (hodd : Odd n) : 4725 < n :
   · exact absurd hw.1 (no_odd_abundant_4096_to_4725 n h4095 hlt hodd)
   · exact absurd (heq ▸ forty725_semiperfect) hw.2
 
-/-
-## Extending the Odd Weird Bound
-
-The odd abundant numbers (OEIS A005231) begin: 945, 1575, 2205, 2835, ...
-Each is semiperfect, with no odd abundant numbers in between.
-We push the lower bound for odd weird numbers to >2835.
--/
-
 /--
-836 = 4 × 11 × 19 is the second weird number (after 70).
+5355 = 3² × 5 × 7 × 17 is semiperfect.
 -/
-theorem weird_836 : IsWeird 836 := by
-  constructor
-  · unfold IsAbundant sigma; native_decide
-  · intro ⟨S, hS_sub, hS_sum⟩
-    have : ∀ T ∈ (836 : ℕ).properDivisors.powerset, T.sum id ≠ 836 := by native_decide
-    exact this S (Finset.mem_powerset.mpr hS_sub) hS_sum
-
-/--
-1575 = 3² × 5² × 7 is the second smallest odd abundant number
-and is pseudoperfect.
--/
-theorem one575_semiperfect : IsPseudoperfect 1575 := by
-  have : ∃ S ∈ (1575 : ℕ).properDivisors.powerset, S.sum id = 1575 := by native_decide
+theorem fifty355_semiperfect : IsPseudoperfect 5355 := by
+  have : ∃ S ∈ (5355 : ℕ).properDivisors.powerset, S.sum id = 5355 := by native_decide
   exact let ⟨S, hmem, hsum⟩ := this; ⟨S, Finset.mem_powerset.mp hmem, hsum⟩
 
 /--
-No odd number strictly between 945 and 1575 is abundant.
+No odd number in (4725, 5355) is abundant.
 -/
-theorem no_odd_abundant_945_to_1575 (n : ℕ) (h1 : 945 < n) (h2 : n < 1575)
+theorem no_odd_abundant_4726_to_5355 (n : ℕ) (hn1 : 4725 < n) (hn2 : n < 5355)
     (hodd : Odd n) : ¬IsAbundant n := by
-  have h : ∀ m ∈ Finset.range 1575, 945 < m → Odd m → ¬IsAbundant m := by native_decide
-  exact h n (Finset.mem_range.mpr h2) h1 hodd
+  have h : ∀ m ∈ Finset.Icc 4726 5354, Odd m → ¬IsAbundant m := by native_decide
+  exact h n (Finset.mem_Icc.mpr ⟨hn1, by omega⟩) hodd
 
 /--
-No odd number up to 1575 is weird.
+Any odd weird number must exceed 5355.
 -/
-theorem no_odd_weird_to_1575 (n : ℕ) (hn : n ≤ 1575) (hodd : Odd n) : ¬IsWeird n := by
-  rcases le_or_lt n 945 with h | h
-  · rcases Nat.eq_or_lt_of_le h with heq | hlt
-    · subst heq; exact nine45_not_weird
-    · exact fun hw => absurd hw.1 (no_odd_abundant_below_945 n hlt hodd)
-  · rcases Nat.eq_or_lt_of_le hn with heq | hlt
-    · subst heq; exact fun hw => absurd one575_semiperfect hw.2
-    · exact fun hw => absurd hw.1 (no_odd_abundant_945_to_1575 n h hlt hodd)
+theorem odd_weird_gt_5355 (n : ℕ) (hw : IsWeird n) (hodd : Odd n) : 5355 < n := by
+  have h4725 := odd_weird_gt_4725 n hw hodd
+  by_contra hle
+  push_neg at hle
+  rcases Nat.lt_or_eq_of_le hle with hlt | heq
+  · exact absurd hw.1 (no_odd_abundant_4726_to_5355 n h4725 hlt hodd)
+  · exact absurd (heq ▸ fifty355_semiperfect) hw.2
 
 /--
-Any odd weird number exceeds 1575.
+5775 = 3 × 5² × 7 × 11 is semiperfect.
 -/
-theorem odd_weird_gt_1575 (n : ℕ) (hw : IsWeird n) (hodd : Odd n) : 1575 < n := by
-  by_contra h; push_neg at h; exact absurd hw (no_odd_weird_to_1575 n h hodd)
-
-/--
-2205 = 3² × 5 × 7² is the third smallest odd abundant number
-and is pseudoperfect.
--/
-theorem two205_semiperfect : IsPseudoperfect 2205 := by
-  have : ∃ S ∈ (2205 : ℕ).properDivisors.powerset, S.sum id = 2205 := by native_decide
+theorem fifty775_semiperfect : IsPseudoperfect 5775 := by
+  have : ∃ S ∈ (5775 : ℕ).properDivisors.powerset, S.sum id = 5775 := by native_decide
   exact let ⟨S, hmem, hsum⟩ := this; ⟨S, Finset.mem_powerset.mp hmem, hsum⟩
 
 /--
-No odd number strictly between 1575 and 2205 is abundant.
+No odd number in (5355, 5775) is abundant.
 -/
-theorem no_odd_abundant_1575_to_2205 (n : ℕ) (h1 : 1575 < n) (h2 : n < 2205)
+theorem no_odd_abundant_5356_to_5775 (n : ℕ) (hn1 : 5355 < n) (hn2 : n < 5775)
     (hodd : Odd n) : ¬IsAbundant n := by
-  have h : ∀ m ∈ Finset.range 2205, 1575 < m → Odd m → ¬IsAbundant m := by native_decide
-  exact h n (Finset.mem_range.mpr h2) h1 hodd
+  have h : ∀ m ∈ Finset.Icc 5356 5774, Odd m → ¬IsAbundant m := by native_decide
+  exact h n (Finset.mem_Icc.mpr ⟨hn1, by omega⟩) hodd
 
 /--
-No odd number up to 2205 is weird.
+Any odd weird number must exceed 5775.
 -/
-theorem no_odd_weird_to_2205 (n : ℕ) (hn : n ≤ 2205) (hodd : Odd n) : ¬IsWeird n := by
-  rcases le_or_lt n 1575 with h | h
-  · exact no_odd_weird_to_1575 n h hodd
-  · rcases Nat.eq_or_lt_of_le hn with heq | hlt
-    · subst heq; exact fun hw => absurd two205_semiperfect hw.2
-    · exact fun hw => absurd hw.1 (no_odd_abundant_1575_to_2205 n h hlt hodd)
+theorem odd_weird_gt_5775 (n : ℕ) (hw : IsWeird n) (hodd : Odd n) : 5775 < n := by
+  have h5355 := odd_weird_gt_5355 n hw hodd
+  by_contra hle
+  push_neg at hle
+  rcases Nat.lt_or_eq_of_le hle with hlt | heq
+  · exact absurd hw.1 (no_odd_abundant_5356_to_5775 n h5355 hlt hodd)
+  · exact absurd (heq ▸ fifty775_semiperfect) hw.2
 
 /--
-Any odd weird number exceeds 2205.
+5985 = 3² × 5 × 7 × 19 is semiperfect.
 -/
-theorem odd_weird_gt_2205 (n : ℕ) (hw : IsWeird n) (hodd : Odd n) : 2205 < n := by
-  by_contra h; push_neg at h; exact absurd hw (no_odd_weird_to_2205 n h hodd)
-
-/--
-2835 = 3⁴ × 5 × 7 is the fourth smallest odd abundant number
-and is pseudoperfect.
--/
-theorem two835_semiperfect : IsPseudoperfect 2835 := by
-  have : ∃ S ∈ (2835 : ℕ).properDivisors.powerset, S.sum id = 2835 := by native_decide
+theorem fifty985_semiperfect : IsPseudoperfect 5985 := by
+  have : ∃ S ∈ (5985 : ℕ).properDivisors.powerset, S.sum id = 5985 := by native_decide
   exact let ⟨S, hmem, hsum⟩ := this; ⟨S, Finset.mem_powerset.mp hmem, hsum⟩
 
 /--
-No odd number strictly between 2205 and 2835 is abundant.
+No odd number in (5775, 5985) is abundant.
 -/
-theorem no_odd_abundant_2205_to_2835 (n : ℕ) (h1 : 2205 < n) (h2 : n < 2835)
+theorem no_odd_abundant_5776_to_5985 (n : ℕ) (hn1 : 5775 < n) (hn2 : n < 5985)
     (hodd : Odd n) : ¬IsAbundant n := by
-  have h : ∀ m ∈ Finset.range 2835, 2205 < m → Odd m → ¬IsAbundant m := by native_decide
-  exact h n (Finset.mem_range.mpr h2) h1 hodd
+  have h : ∀ m ∈ Finset.Icc 5776 5984, Odd m → ¬IsAbundant m := by native_decide
+  exact h n (Finset.mem_Icc.mpr ⟨hn1, by omega⟩) hodd
 
 /--
-No odd number up to 2835 is weird.
+Any odd weird number must exceed 5985, covering the first ten odd abundant
+numbers (945, 1575, 2205, 2835, 3465, 4095, 4725, 5355, 5775, 5985) — all
+verified semiperfect.
 -/
-theorem no_odd_weird_to_2835 (n : ℕ) (hn : n ≤ 2835) (hodd : Odd n) : ¬IsWeird n := by
-  rcases le_or_lt n 2205 with h | h
-  · exact no_odd_weird_to_2205 n h hodd
-  · rcases Nat.eq_or_lt_of_le hn with heq | hlt
-    · subst heq; exact fun hw => absurd two835_semiperfect hw.2
-    · exact fun hw => absurd hw.1 (no_odd_abundant_2205_to_2835 n h hlt hodd)
-
-/--
-Any odd weird number exceeds 2835, covering the first four odd abundant
-numbers (945, 1575, 2205, 2835) — all verified semiperfect.
--/
-theorem odd_weird_gt_2835 (n : ℕ) (hw : IsWeird n) (hodd : Odd n) : 2835 < n := by
-  by_contra h; push_neg at h; exact absurd hw (no_odd_weird_to_2835 n h hodd)
+theorem odd_weird_gt_5985 (n : ℕ) (hw : IsWeird n) (hodd : Odd n) : 5985 < n := by
+  have h5775 := odd_weird_gt_5775 n hw hodd
+  by_contra hle
+  push_neg at hle
+  rcases Nat.lt_or_eq_of_le hle with hlt | heq
+  · exact absurd hw.1 (no_odd_abundant_5776_to_5985 n h5775 hlt hodd)
+  · exact absurd (heq ▸ fifty985_semiperfect) hw.2
 
 /-
 ## Computational Bounds on Odd Weird Numbers
@@ -608,7 +571,7 @@ noncomputable def abundancyIndex (n : ℕ) : ℚ := sigma n / n
 Key established results:
 1. 70 is the smallest weird number, 836 is the second
 2. 70 is primitive weird
-3. Any odd weird exceeds 4725 (first 7 odd abundants verified semiperfect)
+3. Any odd weird exceeds 5985 (first 10 odd abundants verified semiperfect)
 4. Weird numbers have positive density (Benkoski-Erdős)
 5. Melfi's conditional infinitude of primitive weirds
 -/
@@ -620,11 +583,11 @@ theorem erdos_470 :
     (IsWeird 70 ∧ ∀ n < 70, ¬IsWeird n) ∧
     IsWeird 836 ∧
     IsPrimitiveWeird 70 ∧
-    (∀ n, IsWeird n → Odd n → 4725 < n) ∧
+    (∀ n, IsWeird n → Odd n → 5985 < n) ∧
     (∃ c > 0, ∀ᶠ N in Filter.atTop, (↑((WeirdSet ∩ {n | n ≤ N}).ncard) : ℝ) / N ≥ c) ∧
     ((∀ᶠ n in Filter.atTop, (primeGap n : ℝ) < Real.sqrt (nthPrime n) / 10) →
       PrimitiveWeirdSet.Infinite) :=
   ⟨smallest_weird_is_70, weird_836, seventy_is_primitive_weird,
-   odd_weird_gt_4725, benkoski_erdos_density, melfi_conditional⟩
+   odd_weird_gt_5985, benkoski_erdos_density, melfi_conditional⟩
 
 end Erdos470

--- a/src/data/proofs/erdos-470/meta.json
+++ b/src/data/proofs/erdos-470/meta.json
@@ -64,7 +64,7 @@
       "erdos_470 summary theorem combining key results"
     ],
     "axiomCount": 3,
-    "lineCount": 630,
+    "lineCount": 593,
     "assumptions": "3 axioms: liddy_riedl_6_primes (odd weird has ≥6 prime divisors), melfi_conditional (prime gap hypothesis implies infinitely many primitive weirds), benkoski_erdos_density (weird numbers have positive density). All deep results; no routine axioms remain."
   },
   "overview": {
@@ -161,7 +161,7 @@
       "Set"
     ],
     "namespace": "Erdos470",
-    "lineCount": 630,
+    "lineCount": 593,
     "axiomCount": 3,
     "theoremCount": 46,
     "definitionCount": 14,

--- a/src/data/research/problems/erdos-1002-oq-01-oq-01.json
+++ b/src/data/research/problems/erdos-1002-oq-01-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 3 sorries eliminated (4→1). Proved continuous_comp_fract integer case via ε-δ with floor manipulation. Proved both integral bounds via fract→id replacement, integral decomposition (linear + bump), and monotone bounding. Only equidist_approx sorry remains (Fourier density connection).",
+    "progressSummary": "1 sorry: equidist_approx (Fourier density on AddCircle 1). Needs Mathlib Fourier/Stone-Weierstrass integration. All other theorems proved.",
     "builtItems": [
       "irrational_exp_ne_one: exp(2πikα) ≠ 1 for irrational α, k ≠ 0 — Erdos1002OQ01OQ01.lean:46",
       "weyl_cesaro_bound: ‖Σ_{k<N} r^k‖ ≤ 2/‖r-1‖ for ‖r‖=1, r≠1 — Erdos1002OQ01OQ01.lean:77",
@@ -67,7 +67,9 @@
       "Integral bounds: decompose sandwichUpCore = (1/2-x) + max(0,x-(1-δ))/δ. First part integrates to 0, second part bounded by δ via integral_mono + measure of support",
       "equidist_approx requires bridging span_fourier_closure_eq_top (AddCircle) to concrete ℝ→ℝ periodic. Three possible approaches: (1) Stone-Weierstrass on AddCircle + lift, (2) Erdős-Turán inequality for step function approach, (3) Fejér kernel. All require substantial Mathlib API work.",
       "Decomposition path: split into trig_poly_density (sorry, pure approx theory) + trig_poly_cesaro_converges (provable from weyl_cesaro_re/im_zero). The cesaro convergence part uses shift factoring: Σ exp(2πij α(n+1)) = exp(2πijα) · Σ exp(2πijαn)",
-      "innerSum_log_bound axiom genuinely requires continued fraction / discrepancy theory not in Mathlib"
+      "innerSum_log_bound axiom genuinely requires continued fraction / discrepancy theory not in Mathlib",
+      "equidist_approx sorry requires: (1) lift g:ℝ→ℝ periodic to f:AddCircle 1→ℝ, (2) apply Mathlib FourierBasis density (Stone-Weierstrass), (3) for each Fourier mode use weyl_cesaro_zero, (4) linearity + triangle inequality. Key Mathlib dep: span_fourier_closure_eq_top on AddCircle.",
+      "Mathlib.Analysis.Fourier.AddCircle has Fourier coefficient infrastructure. Need to verify span_fourier_closure_eq_top or equivalent exists."
     ],
     "mathlibGaps": [
       "Fourier series of sawtooth function 1/2-{x} = Σ sin(2πkx)/(πk) not in Mathlib — needed for weyl_fract_average_zero",

--- a/src/data/research/problems/erdos-1012-oq-03-incomplete-01.json
+++ b/src/data/research/problems/erdos-1012-oq-03-incomplete-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Converted axiom gh_cycle_extendable_small_k to theorem. Proved the insertable sub-case (any non-cycle vertex directly insertable → cycle extension). 0 axioms, 1 sorry remaining (non-insertable case: longest-cycle + SC routing argument).",
+    "progressSummary": "1 sorry remains: gh_cycle_extendable_small_k Case 2 (non-insertable). Needs longest-cycle + SC path surgery (~100+ lines). Case 1 (insertable) is proved.",
     "builtItems": [
       "Proved list_path_to_hamiltonian via Equiv.ofBijective in Erdos1012OQ03.lean:246-277",
       "Key insight: nodup list of full length gives bijection, arc condition transfers directly",
@@ -62,7 +62,9 @@
       "Key insight for counting: Finset.eq_of_subset_of_card_le shows l.toFinset = univ\\{v} from cardinality matching",
       "Finset.card_le_card_of_injOn (mapping first, then injectivity) with Finset.mem_coe for Set/Finset bridge",
       "The insertable case of GH cycle extension for k<n-1 uses the same insertion construction as k=n-1: insert vertex w at position i+1 in cycle list, verify arcs via insertIdx_getElem_eq decomposition into 5 sub-cases",
-      "Converting from axiom to theorem-with-sorry eliminates the axiom from the file, improving the mathematical status (axiomatized → formalized)"
+      "Converting from axiom to theorem-with-sorry eliminates the axiom from the file, improving the mathematical status (axiomatized → formalized)",
+      "The sorry at line 579 is Case 2 (non-insertable) of gh_cycle_extendable_small_k. Requires: (1) longest-cycle selection, (2) prove no off-cycle arcs via SC path surgery, (3) degree counting → contradiction. Estimated ~100+ lines.",
+      "Infrastructure in place: Digraph, IsStronglyConnected, arc/outDegree/inDegree, IsDirectedCycleList, insertability proofs. Case 1 (insertable) is fully proved."
     ],
     "mathlibGaps": [],
     "nextSteps": [

--- a/src/data/research/problems/erdos-1160.json
+++ b/src/data/research/problems/erdos-1160.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Reduced axioms 11→10. Merged numGroups_pq_dvd + numGroups_pq_ndvd into single numGroups_pq axiom. Added numGroups_prime_cube (g(p³)=5 for all primes), derived numGroups_eight as theorem.",
+    "progressSummary": "SURVEYED: 10 axioms confirmed deep (group classification). No further elimination possible. File complete for m≤4. Extending to m=5 needs 6 new value axioms.",
     "builtItems": [
       "Created Erdos1160Problem.lean with numGroups axiomatization",
       "Proved erdos_1160_equiv (two formulations equivalent)",
@@ -87,7 +87,10 @@
       "Only g(12)=5 and g(16)=14 required new specific value axioms for m=4 case",
       "numGroups_pq: combined pq classification into single axiom (if q|(p-1) then 2 else 1), derived pq_dvd and pq_ndvd as theorems",
       "numGroups_prime_cube: g(p³)=5 for all primes p (well-known classification) — subsumes numGroups_eight",
-      "Remaining 10 axioms are all deep (group theory classification) or structural (function definition) — none are Mathlib-routine"
+      "Remaining 10 axioms are all deep (group theory classification) or structural (function definition) — none are Mathlib-routine",
+      "Confirmed: all 10 axioms are deep group theory. numGroups itself must be axiomatized (Lean/Mathlib has no group enumeration). Specific values (g(12)=5, g(16)=14) not derivable from structural axioms.",
+      "Extending to m=5 (n≤32) would need 6 new axioms: g(18)=5, g(20)=5, g(24)=15, g(28)=4, g(30)=4, g(32)=51. Values n ≤ 32 that ARE derivable: primes, p², pq, p³ — covers 22/32 values.",
+      "Generalization opportunity: replace individual value axioms with structural ones (g(p²q), g(p⁴)) to cover more values per axiom. But formulas are case-dependent."
     ],
     "mathlibGaps": [],
     "nextSteps": [],

--- a/src/data/research/problems/erdos-151.json
+++ b/src/data/research/problems/erdos-151.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Fixed proof bug in erdos_151_triangle_free (omega could not derive I.card ≤ n from H(n) ≤ I.card + H(n) ≤ n). Strengthened triangleFreeIndep_spec to include I.card ≤ n. Removed unused triangleFreeIndep_le axiom. 12→11 axioms.",
+    "progressSummary": "SURVEYED: 11 axioms are structural (abstract graph API + deep Ramsey). No routine axioms to eliminate. Path forward: refactor to Mathlib SimpleGraph (~500+ lines).",
     "builtItems": [
       "Removed axiom IsClique (line 34, never used)",
       "Removed axiom cliqueTransversal_spec (line 59-60, never used)",
@@ -48,10 +48,18 @@
       "Further axiom reduction possible: refactoring to use Mathlib SimpleGraph would eliminate the 4 graph predicate axioms and enable proving complement_of_indep_is_transversal and triangleFreeIndep_le",
       "Bug: omega cannot prove I.card ≤ n from H(n) ≤ I.card and H(n) ≤ n (counterexample: H=0, I=100, n=5)",
       "Fix: include I.card ≤ n in triangleFreeIndep_spec output (any independent set in n-vertex graph has ≤ n elements)",
-      "Remaining 11 axioms are either deep (Ramsey, complement transversal, easy bound) or definitional (graph concepts)"
+      "Remaining 11 axioms are either deep (Ramsey, complement transversal, easy bound) or definitional (graph concepts)",
+      "All 11 axioms are structural: 6 are abstract graph API (vertexCount, IsMaximalClique, etc.), 3 are deep Ramsey-theoretic, 2 are structural lemmas. None are routine Mathlib-provable.",
+      "Refactoring to Mathlib SimpleGraph API would eliminate 6-8 axioms but requires ~500+ line rewrite",
+      "complement_of_indep_is_transversal is provable in principle but needs concrete vertex set representation",
+      "clique_transversal_easy_bound follows for triangle-free from existing theorems; general case needs Ramsey bound on alpha(G)"
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "Major refactoring: rewrite using Mathlib SimpleGraph V, Fintype V — would eliminate 6+ axioms",
+      "After refactoring: triangleFreeIndep_spec and triangleFreeIndep_sqrt still need axiomatization (deep Ramsey)",
+      "complement_of_indep_is_transversal becomes provable after refactoring"
+    ],
     "markdown": "# Erdős #151 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nFor a graph $G$ let $\\tau(G)$ denote the minimal number of vertices that include at least one from each maximal clique of $G$ on at least two vertices (sometimes called the clique transversal number).\n\nLet $H(n)$ be maximal such that every triangle-free graph on $n$ vertices contains an independent set on $H(n)$ vertices.\n\nIf $G$ is a graph on $n$ vertices then is\\[\\tau(G)\\leq n-H(n)?\\]\n\n\n\nIt is easy to see that $\\tau(G) \\leq n-\\sqrt{n}$. Note also that if $G$ is triangle-free then trivially $\\tau(G)\\leq n-H(n)$.\n\nThis is listed in \\cite{Er88} as a problem of Erd\\H{o}s and Gallai, who were unable to make progress even assuming $G$ is $K_4$-free. There Erd\\H{o}s remarked that this conjecture is 'perhaps completely wrongheaded'.\n\nIt later appeared as Problem 1 in \\cite{EGT92}.\n\nThe general behaviour of $\\tau(G)$ is the subject of [610].\n\n\n\n\nReferences\n\n\n[EGT92] Erd\\H{o}s, Paul and Gallai, Tibor and Tuza, Zsolt, Covering the cliques of a graph with vertices. Discrete Math. (1992), 279-289.\n\n[Er88] Erd\\H{o}s, P, Problems and results in combinatorial analysis and graph theory. Discrete Math. (1988), 81-92.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #610\n- Problem #150\n- Problem #152\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er88\n- EGT92\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-12*\n"
   },
   "tags": [

--- a/src/data/research/problems/erdos-353-incomplete-01.json
+++ b/src/data/research/problems/erdos-353-incomplete-01.json
@@ -29,20 +29,22 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: All sorries filled. Proved hasInfiniteMeasure_inv_smul using Haar measure scaling formula (addHaar_smul). File now has 0 sorries, 4 axioms (deep extremal geometry results).",
+    "progressSummary": "COMPLETED: Proved companion file sorry. Fixed meta.json (0 sorries, 4 deep axioms). All Lean files sorry-free.",
     "builtItems": [
       "Proved scaling_property modulo measure scaling sorry in Erdos353Problem.lean",
       "Created Erdos353Aristotle.lean companion file for remaining sorry",
       "Proved inv_smul_set_eq_preimage: preimage characterization of scaled sets",
       "Proved isIsoscelesTriangle_smul: scaling preserves isosceles property",
       "Proved triangleArea_smul_eq: area scales by c² under vertex scaling",
-      "SORRY FILLED: hasInfiniteMeasure_inv_smul — proved via addHaar_smul + ENNReal.mul_top. volume(c⁻¹•A) = |c⁻¹|^n * ⊤ = ⊤ when c≠0."
+      "SORRY FILLED: hasInfiniteMeasure_inv_smul — proved via addHaar_smul + ENNReal.mul_top. volume(c⁻¹•A) = |c⁻¹|^n * ⊤ = ⊤ when c≠0.",
+      "Proved volume_preimage_smul_eq_top in Erdos353Aristotle.lean (0 sorries remaining in companion)"
     ],
     "insights": [
       "scaling_property theorem proved via scaling argument: scale A by 1/√t, apply Koizumi for area 1, scale back to get area t",
       "Only remaining sorry is measure-theoretic: volume of preimage under scaling by c ≠ 0",
       "Proved 4 helper lemmas: inv_smul_set_eq_preimage, hasInfiniteMeasure_inv_smul (with sorry), isIsoscelesTriangle_smul, triangleArea_smul_eq",
-      "Haar measure scaling: volume(r•S) = |r|^finrank * volume(S) via MeasureTheory.Measure.addHaar_smul. For preimage: use inv_smul_set_eq_preimage then addHaar_smul."
+      "Haar measure scaling: volume(r•S) = |r|^finrank * volume(S) via MeasureTheory.Measure.addHaar_smul. For preimage: use inv_smul_set_eq_preimage then addHaar_smul.",
+      "Companion file sorry was already solved by technique in main file — direct proof via addHaar_smul"
     ],
     "mathlibGaps": [],
     "nextSteps": [],

--- a/src/data/research/problems/erdos-825-oq-03.json
+++ b/src/data/research/problems/erdos-825-oq-03.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Extended odd weird bound from >2835 to >4725. Cleaned up duplicate definitions. 3 deep axioms remain unchanged.",
+    "progressSummary": "PROGRESS: Extended odd weird bound from >4725 to >5985 (10 odd abundants verified). Removed ~115 lines of duplicate code fixing compilation. 3 deep axioms remain.",
     "builtItems": [
       "Decidable instances for IsPseudoperfect and IsWeird in Erdos470Problem.lean:70-78",
       "Proved no_weird_below_70 (was axiom) via native_decide in Erdos470Problem.lean:108-110",
@@ -47,7 +47,11 @@
       "thirty465_semiperfect + no_odd_abundant_2836_to_3465 + odd_weird_gt_3465: bound >3465",
       "forty95_semiperfect + no_odd_abundant_3466_to_4095 + odd_weird_gt_4095: bound >4095",
       "forty725_semiperfect + no_odd_abundant_4096_to_4725 + odd_weird_gt_4725: bound >4725",
-      "Cleaned up file: removed duplicate theorem definitions that prevented compilation"
+      "Cleaned up file: removed duplicate theorem definitions that prevented compilation",
+      "fifty355_semiperfect + no_odd_abundant_4726_to_5355 + odd_weird_gt_5355: bound >5355",
+      "fifty775_semiperfect + no_odd_abundant_5356_to_5775 + odd_weird_gt_5775: bound >5775",
+      "fifty985_semiperfect + no_odd_abundant_5776_to_5985 + odd_weird_gt_5985: bound >5985",
+      "Removed duplicate theorem section (lines 365-480 from prior sessions) preventing compilation"
     ],
     "insights": [
       "IsPseudoperfect is decidable by enumerating subsets of properDivisors.powerset",
@@ -62,12 +66,16 @@
       "3465 = 3^2 * 5 * 7 * 11 is the fifth smallest odd abundant; semiperfect (native_decide)",
       "4095 = 3^2 * 5 * 7 * 13 is the sixth smallest odd abundant; semiperfect (native_decide)",
       "4725 = 3^3 * 5^2 * 7 is the seventh smallest odd abundant; semiperfect (native_decide)",
-      "All odd abundant numbers through 4725 have 23 or fewer proper divisors - powerset search feasible"
+      "All odd abundant numbers through 4725 have 23 or fewer proper divisors - powerset search feasible",
+      "5355 = 3² × 5 × 7 × 17 is the 8th odd abundant, semiperfect (native_decide)",
+      "5775 = 3 × 5² × 7 × 11 is the 9th odd abundant, semiperfect (native_decide)",
+      "5985 = 3² × 5 × 7 × 19 is the 10th odd abundant, semiperfect (native_decide)",
+      "File had duplicate declarations from prior sessions causing compilation errors — cleaned up"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Next odd abundant: 5355 = 3^2 * 5 * 7 * 17 (check semiperfectness and gap)",
-      "Then 5775 = 3 * 5^2 * 7 * 11, then 5985 = 3^2 * 5 * 7 * 19",
+      "Next odd abundant: 6435 = 3² × 5 × 11 × 13 (check semiperfectness)",
+      "Then 6615 = 3³ × 5 × 7² then 6825 = 3 × 5² × 7 × 13",
       "3 remaining axioms (Liddy-Riedl, Melfi, Benkoski-Erdos) are deep results, not provable"
     ]
   },

--- a/src/data/research/problems/newton-inductive-step-oq-01.json
+++ b/src/data/research/problems/newton-inductive-step-oq-01.json
@@ -29,13 +29,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEYED: 2 sorries, 0 axioms. newton_inequality_binomial is weaker form, newton_inequality_means is the true Newton inequality. Binomial form CANNOT imply means form. Both need Cauchy-Schwarz inductive proofs.",
+    "progressSummary": "SURVEYED: 1 sorry remains (newton_inequality_binomial). Proof requires Cauchy-Schwarz induction ~100+ lines. Aristotle companion already queued. Detailed proof strategy documented.",
     "builtItems": [],
     "insights": [
       "newton_inequality_binomial (C(n,k)²·e_k²≥C(k-1)C(k+1)·e_{k-1}e_{k+1}) is WEAKER than newton_inequality_means (ē_k²≥ē_{k-1}ē_{k+1}) — cannot derive one from the other",
       "The means form is the true Newton inequality. The binomial form is not used anywhere in the file.",
       "Both proofs require induction on list length with Cauchy-Schwarz on the recurrence esymm(x::xs) k = esymm xs k + x·esymm xs (k-1)",
-      "maclaurin_first_step and amgm_from_newton both depend on newton_inequality_means (not binomial form)"
+      "maclaurin_first_step and amgm_from_newton both depend on newton_inequality_means (not binomial form)",
+      "newton_inequality_binomial inductive step requires: expand F_k²-F_{k-1}·F_{k+1} via recurrence, group into (E_k²-E_{k-1}·E_{k+1}) + x·(cross terms) + x²·(E_{k-1}²-E_{k-2}·E_k), apply IH at k and k-1, bound cross terms using esymm_nonneg",
+      "Estimated ~100-150 lines of careful algebra in Lean 4. Not tractable in single session.",
+      "Alternative approach: prove for means form directly using α_k + β_k = 1 decomposition from Pascal rule"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
Multi-problem research session with 5 commits across 2 proofs completed, 1 bound extended, and 3 surveys.

### Code Changes

**erdos-353** (Geometric Configurations in Sets of Infinite Measure)
- Proved `volume_preimage_smul_eq_top` in `Erdos353Aristotle.lean` via `addHaar_smul` (1→0 sorries)
- Fixed meta.json: corrected sorry count (1→0) and stale assumptions string

**erdos-470** (Odd Weird Numbers)
- Removed ~115 lines of duplicate theorem declarations preventing compilation
- Extended odd weird lower bound from >4725 to >5985 (3 new steps: 5355, 5775, 5985)
- All 10 odd abundant numbers through 5985 verified semiperfect via `native_decide`
- Updated summary theorem to reference new bound

### Surveys (Knowledge Updates Only)

- **erdos-151**: 11 axioms are structural (abstract graph API + Ramsey). Refactoring to Mathlib SimpleGraph needed.
- **newton-inductive-step-oq-01**: Documented proof strategy for Cauchy-Schwarz induction (~100+ lines)
- **erdos-1160**: Confirmed all 10 axioms deep (group classification). Extension to m=5 needs 6 new value axioms.

### Pool Maintenance
- Updated ~15 stale already-completed problems to "completed" status in candidate pool

## Status
- **erdos-353**: completed
- **erdos-470**: progress (bound 4725→5985)
- **erdos-151, newton-oq-01, erdos-1160**: surveyed

🤖 Generated by researcher-7

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>