### PR TITLE
Audit: fix meta integrity for 3 proofs, verify 2 clean

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "lean-genius researcher",
     "sourceUrl": "https://en.wikipedia.org/wiki/Cantor%27s_first_set_theory_article",
     "date": "2026-04-12",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/AlgebraicNumbersCountableOQ02OQ02.lean",
     "tags": [
       "set-theory",
@@ -17,7 +17,7 @@
       "nested-intervals",
       "constructive"
     ],
-    "badge": "wip",
+    "badge": "original",
     "sorries": 0,
     "dateAdded": "2026-04-12",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1849,10 +1849,10 @@
       "issues": []
     },
     "erdos-1012-oq-03": {
-      "auditCount": 11,
+      "auditCount": 12,
       "issues": [],
-      "lastAudited": "2026-04-13T01:17:31Z",
-      "result": "issues-found"
+      "lastAudited": "2026-04-13T02:03:23Z",
+      "result": "issues-fixed"
     },
     "erdos-1013": {
       "agentId": "auditor-cycle-20-batch",
@@ -4767,9 +4767,9 @@
     },
     "erdos-353": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:28:53Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-13T02:00:55Z",
+      "result": "issues-fixed"
     },
     "erdos-354": {
       "agentId": "auditor-cycle-20-batch",
@@ -12249,6 +12249,24 @@
     "erdos-1059-oq-01-oq-01": {
       "auditCount": 1,
       "lastAudited": "2026-04-13T01:23:58Z",
+      "result": "clean",
+      "issues": []
+    },
+    "algebraic-numbers-countable-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T02:04:28Z",
+      "result": "issues-fixed",
+      "issues": []
+    },
+    "kummer-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T02:05:43Z",
+      "result": "clean",
+      "issues": []
+    },
+    "subset-count-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T02:06:15Z",
       "result": "clean",
       "issues": []
     }

--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -4,7 +4,7 @@
   "slug": "erdos-1012-oq-03",
   "description": "Directed analogues of Hamiltonian cycle conditions: Ghouila-Houri, Moon-Moser, and Rédei theorems for digraphs and tournaments.",
   "meta": {
-    "status": "axiomatized",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Erdos1012OQ03.lean",
     "tags": [
       "graph-theory",
@@ -12,11 +12,11 @@
       "hamiltonian-cycles",
       "tournaments"
     ],
-    "badge": "axiom",
-    "sorries": 0,
-    "axiomCount": 1,
-    "lineCount": 1623,
-    "assumptions": "1 axiom: gh_cycle_extendable_small_k (Ghouila-Houri cycle extension for k+1 < n). Rédei, Moon-Moser, and directed_hamiltonian_threshold are fully proved. ghouila_houri depends on the axiom.",
+    "badge": "wip",
+    "sorries": 1,
+    "axiomCount": 0,
+    "lineCount": 1694,
+    "assumptions": "1 sorry in gh_cycle_extendable_small_k (Ghouila-Houri cycle extension, non-insertable case when k+1 < n). Rédei, Moon-Moser, and directed_hamiltonian_threshold are fully proved. ghouila_houri depends on the sorry.",
     "dateAdded": "2026-03-30",
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Hamiltonian_path_problem#Directed_graphs",
@@ -86,7 +86,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Rédei (Hamiltonian path in tournaments), Moon-Moser (Hamiltonian cycles in SC tournaments), and directed_hamiltonian_threshold are fully proved (0 sorries). Ghouila-Houri's theorem depends on 1 axiom (gh_cycle_extendable_small_k: cycle extension when k+1 < n). The 1623-line file is the most substantial directed Hamiltonicity formalization in this gallery.",
+    "summary": "Rédei (Hamiltonian path in tournaments), Moon-Moser (Hamiltonian cycles in SC tournaments), and directed_hamiltonian_threshold are fully proved. Ghouila-Houri's theorem has 1 sorry (gh_cycle_extendable_small_k: non-insertable case of cycle extension when k+1 < n). The 1694-line file is the most substantial directed Hamiltonicity formalization in this gallery.",
     "implications": "Directed Hamiltonicity thresholds have applications beyond pure graph theory: tournament Hamiltonian paths correspond to linear extensions of partial orders, with applications to voting theory (ranking candidates) and scheduling. Rédei's theorem has a direct combinatorial interpretation: in any round-robin tournament, there exists a ranking of all players consistent with the match results (as a directed path). Moon-Moser's result shows that strongly connected tournaments (those where outcomes don't create a dominant clique) have circular Hamiltonian cycles — a stronger consistency property.",
     "openQuestions": [
       "Meyniel's condition (weaker than Ghouila-Houri: $\\delta^+(u) + \\delta^-(u) + \\delta^+(v) + \\delta^-(v) \\geq 2n-1$ for non-adjacent pairs) implies Hamiltonicity. Can this stronger result be formalized, or would it require substantially more tournament infrastructure?",
@@ -121,9 +121,9 @@
       "Finset"
     ],
     "namespace": "Erdos1012OQ03",
-    "lineCount": 1623,
-    "axiomCount": 1,
-    "sorries": 0,
+    "lineCount": 1694,
+    "axiomCount": 0,
+    "sorries": 1,
     "path": "Proofs/Erdos1012OQ03.lean",
     "theoremCount": 9,
     "definitionCount": 9

--- a/src/data/proofs/erdos-353/meta.json
+++ b/src/data/proofs/erdos-353/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 353,
     "erdosUrl": "https://erdosproblems.com/353",
     "erdosProblemStatus": "solved",
@@ -52,8 +52,8 @@
       "Kovač-Predojević cyclic quadrilateral theorem"
     ],
     "axiomCount": 4,
-    "lineCount": 438,
-    "assumptions": "8 axiom(s) and 1 sorry(s). See the Lean source for details."
+    "lineCount": 445,
+    "assumptions": "4 axiom(s): Koizumi's three main theorems (isosceles trapezoid, isosceles triangle, right triangle) and Kovač-Predojević cyclic quadrilateral theorem are stated as axioms."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #353**\n\nThis problem explores what geometric configurations must appear in sets of infinite measure in the plane.\n\n**Key History:**\n- Erdős-Mauldin (unpublished): Claimed true for trapezoids\n- Kovač (2023): Proved trapezoids work; showed parallelograms can fail\n- Kovač-Predojević (2024): Proved cyclic quadrilaterals; congruent sides counterexample\n- Koizumi (2025): Complete resolution for isosceles trapezoids, triangles, and right triangles\n\n**Mathematical Setting:**\nThe problem connects geometric measure theory with combinatorial geometry. Infinite measure ensures sufficient point density to guarantee configurations.",
@@ -151,7 +151,7 @@
       "summary": "Main results and status theorem",
       "startLine": 338,
       "endLine": 362,
-      "mathContext": "Verified: Main results and status theorem"
+      "mathContext": "Main results and status theorem (axiomatized)"
     }
   ],
   "conclusion": {
@@ -176,12 +176,12 @@
       "Set"
     ],
     "namespace": "Erdos353",
-    "lineCount": 438,
+    "lineCount": 445,
     "axiomCount": 4,
     "theoremCount": 4,
     "definitionCount": 14,
     "path": "Proofs/Erdos353Problem.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary

Gallery integrity audit batch — fixes 3 proofs with incorrect metadata, verifies 2 clean.

### Issues Fixed

- **erdos-353**: `sorries: 1` → `0` (no sorries in Lean file), `assumptions` field claimed "8 axiom(s) and 1 sorry(s)" but file has 4 axioms and 0 sorries. Fixed assumptions text and line count.
- **erdos-1012-oq-03**: Commit #10357 eliminated the `gh_cycle_extendable_small_k` axiom (replaced with theorem + sorry) but meta.json was not updated. Fixed: `axiomCount: 1` → `0`, `sorries: 0` → `1`, `status: axiomatized` → `formalized`, `badge: axiom` → `wip`, updated assumptions and conclusion text.
- **algebraic-numbers-countable-oq-02-oq-02**: Fully proved (0 sorries, 0 axioms) but labeled as `formalized`/`wip`. Fixed: `status: formalized` → `verified`, `badge: wip` → `original`.

### Clean Audits

- **kummer-theorem-oq-01-oq-01**: 0 sorries, 0 axioms, badge `mathlib` — all correct
- **subset-count-oq-02-oq-01**: 0 sorries, 0 axioms, badge `mathlib` — all correct

## Test plan

- [ ] `pnpm build` passes with updated meta.json files
- [ ] No gallery rendering issues from status/badge changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)