### PR TITLE
Research: erdos-684, erdos-695 — eliminate axiom, prove sorries

### DIFF
--- a/proofs/Proofs/Erdos684Problem.lean
+++ b/proofs/Proofs/Erdos684Problem.lean
@@ -123,8 +123,10 @@ def f_domain (n : ℕ) : Prop :=
 -- Property of f: at k = f(n), smooth part > n² (requires f_domain)
 -- BUG FIX: Previously stated for n ≥ 2, but the set is empty for small n (e.g., n = 2..9).
 -- When sInf ∅ = 0, binomialSmoothPart n 0 = 1 ≤ n², so the old axiom was false.
-axiom f_property (n : ℕ) (hn : f_domain n) :
-    binomialSmoothPart n (f n) > n^2
+-- PROVED: follows from Nat.sInf_mem — the infimum of a nonempty set of naturals is in the set.
+theorem f_property (n : ℕ) (hn : f_domain n) :
+    binomialSmoothPart n (f n) > n^2 :=
+  Nat.sInf_mem hn
 
 -- For sufficiently large n, f is well-defined (the set is nonempty).
 -- This follows from the fact that C(n,⌊n/2⌋) grows exponentially while n² is polynomial.

--- a/proofs/Proofs/Erdos695Problem.lean
+++ b/proofs/Proofs/Erdos695Problem.lean
@@ -83,7 +83,49 @@ def Question1 : Prop :=
 theorem question1_equiv :
     Question1 ↔ ∀ p : ℕ → ℕ, IsPrimeChain p →
       ∀ c : ℝ, c > 0 → ∃ k₀ : ℕ, ∀ k ≥ k₀, (p k : ℝ) > c ^ k := by
-  sorry
+  -- Helper: ((p k)^{1/k})^k = p k for k ≥ 1 (rpow identity)
+  have rpow_inv_pow (x : ℝ) (hx : 0 ≤ x) (k : ℕ) (hk : k ≠ 0) :
+      (x ^ ((1 : ℝ) / (k : ℝ))) ^ k = x := by
+    rw [← Real.rpow_natCast (x ^ _) k, ← Real.rpow_mul hx,
+        one_div, inv_mul_cancel₀ (Nat.cast_ne_zero.mpr hk), Real.rpow_one]
+  constructor
+  · -- (→) kthRoot tends to ∞ implies p_k > c^k eventually
+    intro hQ1 p hp c hc
+    have htend := hQ1 p hp
+    rw [Filter.tendsto_atTop_atTop] at htend
+    obtain ⟨k₀, hk₀⟩ := htend (c + 1)
+    refine ⟨max k₀ 1, fun k hk => ?_⟩
+    have hk1 : 1 ≤ k := by omega
+    have hkne : k ≠ 0 := by omega
+    have hpk_pos : (0 : ℝ) ≤ (p k : ℝ) := Nat.cast_nonneg _
+    -- kthRoot p k ≥ c + 1 > c
+    have hkth : c < kthRoot p k := by linarith [hk₀ k (by omega : k₀ ≤ k)]
+    -- c^k < (kthRoot p k)^k = p k
+    calc (c : ℝ) ^ k < (kthRoot p k) ^ k :=
+          pow_lt_pow_left hkth (le_of_lt hc) hkne
+      _ = (p k : ℝ) := by
+          exact rpow_inv_pow _ hpk_pos k hkne
+  · -- (←) p_k > c^k eventually implies kthRoot tends to ∞
+    intro h p hp
+    rw [Filter.tendsto_atTop_atTop]
+    intro b
+    obtain ⟨k₀, hk₀⟩ := h p hp (max b 1) (by positivity)
+    refine ⟨max k₀ 1, fun k hk => ?_⟩
+    have hkne : (k : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr (by omega)
+    have hpk_pos : (0 : ℝ) ≤ (p k : ℝ) := Nat.cast_nonneg _
+    -- p_k > (max b 1)^k, take k-th root
+    have hgt := hk₀ k (by omega)
+    unfold kthRoot
+    calc (p k : ℝ) ^ ((1 : ℝ) / (k : ℝ))
+        ≥ ((max b 1 : ℝ) ^ (k : ℕ)) ^ ((1 : ℝ) / (k : ℝ)) := by
+          apply Real.rpow_le_rpow (by positivity) (le_of_lt hgt)
+          positivity
+      _ = max b 1 := by
+          rw [← Real.rpow_natCast (max b 1 : ℝ) k,
+              ← Real.rpow_mul (by positivity : (0 : ℝ) ≤ max b 1),
+              show (↑k : ℝ) * ((1 : ℝ) / (k : ℝ)) = 1 from mul_one_div_cancel hkne,
+              Real.rpow_one]
+      _ ≥ b := le_max_left _ _
 
 -- Question 2: Can p_k ≤ exp(k (log k)^{1+o(1)})?
 def Question2 : Prop :=
@@ -116,8 +158,14 @@ Prime chains connect to OEIS A061092 and Cunningham chains.
 -/
 
 -- OEIS A061092: Smallest prime ≡ 1 (mod p_k) for k-th prime p_k
-def smallestPrimeCongruentOne (p : ℕ) (hp : p.Prime) : ℕ :=
-  Nat.find ⟨p + 1, sorry⟩  -- Existence by Dirichlet
+-- Existence by Dirichlet's theorem: gcd(1, p) = 1, so ∃ infinitely many primes ≡ 1 (mod p)
+noncomputable def smallestPrimeCongruentOne (p : ℕ) (hp : p.Prime) : ℕ :=
+  Nat.find (show ∃ q, q.Prime ∧ q % p = 1 from by
+    have hcop : Nat.Coprime 1 p := Nat.coprime_one_left p
+    obtain ⟨q, hq_prime, -, hq_mod⟩ := Nat.forall_exists_prime_gt_and_modEq hp.ne_zero hcop 0
+    refine ⟨q, hq_prime, ?_⟩
+    have := hq_mod  -- q ≡ 1 [MOD p] i.e. q % p = 1 % p
+    rwa [Nat.mod_eq_of_lt hp.one_lt] at this)
 
 -- Cunningham chain of the first kind: p, 2p+1, 4p+3, ...
 def IsCunninghamChainFirst (p : ℕ → ℕ) : Prop :=

--- a/src/data/proofs/erdos-684/meta.json
+++ b/src/data/proofs/erdos-684/meta.json
@@ -44,7 +44,7 @@
       "roughPart definition: remaining prime factors",
       "binomialSmoothPart definition: smooth part of C(n,k)",
       "f definition: min k with smooth part > n²",
-      "f_property axiom: smooth part exceeds n² at f(n)",
+      "f_property theorem: smooth part exceeds n² at f(n) (proved from Nat.sInf_mem)",
       "mahler_ineffective axiom: classical bound (ineffective)",
       "tang_exponent definition: 30/43",
       "tang_bound axiom: f(n) ≤ n^{30/43+o(1)}",
@@ -57,9 +57,9 @@
       "prime_binomial_structure theorem: p divides C(p,k)",
       "fGeneral definition: generalized problem"
     ],
-    "axiomCount": 3,
-    "lineCount": 399,
-    "assumptions": "6 axioms (soundness fix: was 5 but f_property was false for small n). Added f_domain_large and restricted f_property/erdos_684_statement to require f_domain. Remaining axioms: f_property, f_domain_large, mahler_ineffective, tang_bound, rh_conditional_bound, heuristic_conjecture."
+    "axiomCount": 2,
+    "lineCount": 401,
+    "assumptions": "2 axiom declarations: f_domain_large (for sufficiently large n, there exists k with smooth part > n²), mahler_ineffective (Mahler's classical bound: for fixed k₀ and ε>0, smooth part ≤ n^{1+ε} eventually). Former axiom f_property now proved from Nat.sInf_mem."
   },
   "overview": {
     "historicalContext": "Erdős posed this problem in [Er79d]. For binomial coefficient C(n,k), we decompose it as u·v where u is the k-smooth part (primes ≤ k) and v is the k-rough part (primes > k).\n\nThe function f(n) asks: how small can k be while still having the smooth part exceed n²?\n\nMahler's classical theorem gives an ineffective bound. Recent work by Tang & ChatGPT (2026) proved f(n) ≤ n^{30/43+o(1)}, with n^{2/3+o(1)} conditional on the Riemann Hypothesis.\n\nRemarkably, heuristic arguments by Sothanaphan & ChatGPT suggest f(n) ~ 2 log n for most n - vastly smaller than proven bounds!\n\nThe sequence f(n) is recorded in OEIS A392019.",
@@ -173,9 +173,9 @@
       "Finset"
     ],
     "namespace": "Erdos684",
-    "lineCount": 399,
-    "axiomCount": 3,
-    "theoremCount": 11,
+    "lineCount": 401,
+    "axiomCount": 2,
+    "theoremCount": 12,
     "definitionCount": 10,
     "path": "Proofs/Erdos684Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-695/meta.json
+++ b/src/data/proofs/erdos-695/meta.json
@@ -17,7 +17,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 1,
     "erdosNumber": 695,
     "erdosUrl": "https://erdosproblems.com/695",
     "erdosProblemStatus": "open",
@@ -66,8 +66,8 @@
       "Asymptotic notation (big-O, little-o)",
       "Lean 4 / Mathlib (Filter.Tendsto, Asymptotics.IsLittleO, Nat.Prime)"
     ],
-    "lineCount": 251,
-    "assumptions": "1 axiom: small_prime_conjecture. 3 sorries."
+    "lineCount": 299,
+    "assumptions": "1 axiom: small_prime_conjecture (conjectured). 1 sorry: conjecture_implies_question2. Proved question1_equiv (rpow/tendsto equivalence) and fixed smallestPrimeCongruentOne (Dirichlet's theorem from Mathlib)."
   },
   "overview": {
     "historicalContext": "Erd\u0151s posed this problem in 1979 [Er79e]. Prime chains arise from the multiplicative structure of cyclic groups: if p_{i+1} \u2261 1 (mod p_i), then Z/p_{i+1}Z contains a cyclic subgroup of order p_i.\n\nFord, Konyagin, and Luca [FKL10] conducted an extensive study of prime chain growth, establishing various bounds. The problem connects to Linnik's theorem on the least prime in arithmetic progressions.\n\nRelated: OEIS A061092, Cunningham chains. Cunningham chains, studied by A.J.C. Cunningham in 1881, are special prime chains of the form p, 2p+1, 4p+3, ... where each term is 2\u00b7(previous term)+1; these satisfy the divisibility condition and are the subject of longstanding conjectures about their unbounded length. Linnik's theorem (1944) guarantees the existence of primes in arithmetic progressions, and its quantitative form (Linnik's constant L, conjectured to equal 2) directly controls the greedy construction of prime chains.",
@@ -182,7 +182,7 @@
       "Real"
     ],
     "namespace": "Erdos695",
-    "lineCount": 251,
+    "lineCount": 299,
     "axiomCount": 1,
     "theoremCount": 8,
     "definitionCount": 10,

--- a/src/data/research/problems/erdos-684.json
+++ b/src/data/research/problems/erdos-684.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Fixed critical soundness bug — f_property axiom was false for small n. Added f_domain guard. Axiom count 5→6 but formalization is now correct.",
+    "progressSummary": "PROGRESS: Proved f_property axiom from Nat.sInf_mem (axioms 3→2). Remaining axioms f_domain_large and mahler_ineffective are deep results.",
     "builtItems": [
       "Proved smoothPart_dvd via prod_pow_factorization_dvd helper (Finset induction + coprimality)",
       "Proved f_lower_bound theorem from f_property axiom",
@@ -43,7 +43,8 @@
       "f_domain_large axiom (f is well-defined for sufficiently large n)",
       "Fixed f_property axiom (now requires f_domain instead of n≥2)",
       "Fixed f_lower_bound theorem (now requires f_domain)",
-      "Fixed erdos_684_statement theorem (now requires f_domain)"
+      "Fixed erdos_684_statement theorem (now requires f_domain)",
+      "Proved f_property from Nat.sInf_mem, reducing axiom count 3→2"
     ],
     "insights": [
       "smoothPart_dvd proved: product of p^(factorization p) for primes p ≤ k divides m, via coprimality of distinct prime powers and Finset induction",
@@ -56,13 +57,13 @@
       "CRITICAL BUG: f_property axiom was FALSE for small n (n=2..~9). The set {k | smoothPart > n²} is empty for small n because binomial coefficients are too small.",
       "Example: n=5, max smoothPart across all k is 2 (from C(5,2)=10), far below n²=25. So sInf ∅ = 0 and f_property claims 1 > 25, which is false.",
       "Fix: Added f_domain predicate (set nonemptiness) and f_domain_large axiom. Changed f_property, f_lower_bound, erdos_684_statement to require f_domain.",
-      "Axiom count 5→6 but formalization is now SOUND. The old version was unsound from a false axiom."
+      "Axiom count 5→6 but formalization is now SOUND. The old version was unsound from a false axiom.",
+      "f_property axiom eliminated: proved from Nat.sInf_mem (sInf of nonempty set of naturals is in the set)"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Determine exact threshold for f_domain (smallest n where set is nonempty)",
-      "Consider merging f_domain_large into mahler_ineffective (Mahler implies nonemptiness for large n)",
-      "Explore if any of the remaining axioms can be reduced"
+      "f_domain_large might be provable via central binomial coefficient growth analysis (C(n,n/2) ~ 2^n/√n)",
+      "mahler_ineffective is Mahler 1961 - deep analytic number theory, unlikely provable from Mathlib"
     ],
     "markdown": "# Erdős #684 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nFor $0\\leq k\\leq n$ write\\[\\binom{n}{k} = uv\\]where the only primes dividing $u$ are in $[2,k]$ and the only primes dividing $v$ are in $(k,n]$.\n\nLet $f(n)$ be the smallest $k$ such that $u>n^2$. Give bounds for $f(n)$.\n\n\n\nA classical theorem of Mahler states that for any $\\epsilon>0$ and integers $k$ and $l$ then, writing\\[(n+1)\\cdots (n+k) = ab\\]where the only primes dividing $a$ are $\\leq l$ and the only primes dividing $b$ are $>l$, we have $a < n^{1+\\epsilon}$ for all sufficiently large (depending on $\\epsilon,k,l$) $n$.\n\nMahler's theorem implies $f(n)\\to \\infty$ as $n\\to \\infty$, but is ineffective, and so gives no bounds on the growth of $f(n)$.\n\nOne can similarly ask for estimates on the smallest integer $f(n,k)$ such that if $m$ is the factor of $\\binom{n}{k}$ containing all primes $\\leq f(n,k)$ then $m > n^2$.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #683\n- Problem #685\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er79d\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-14*\n"
   },

--- a/src/data/research/problems/erdos-695.json
+++ b/src/data/research/problems/erdos-695.json
@@ -29,21 +29,27 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Proved exponential_lower_bound axiom (6A→5A). p(k) ≥ 2^k for any prime chain, via chain_step_ge: for odd prime p₀, q≡1(mod p₀) implies q≥2p₀+1.",
+    "progressSummary": "PROGRESS: Eliminated 2 of 3 sorries. Proved question1_equiv (rpow/tendsto equivalence) and fixed smallestPrimeCongruentOne (Dirichlet). 1 sorry remains (conjecture_implies_question2 — iterative asymptotic argument).",
     "builtItems": [
       "Proved: chain_step_ge — q ≡ 1 (mod p₀) implies q ≥ 2p₀+1 for odd prime p₀",
       "Proved: exponential_lower_bound — p(k) ≥ 2^k for any prime chain (was axiom)",
-      "Updated: meta.json axiomCount 6→5, lineCount 203→259"
+      "Updated: meta.json axiomCount 6→5, lineCount 203→259",
+      "Proved question1_equiv: rpow/tendsto equivalence for prime chain growth (eliminated sorry)",
+      "Fixed smallestPrimeCongruentOne: replaced sorry with Dirichlet theorem from Mathlib (eliminated sorry)"
     ],
     "insights": [
       "Key insight: for odd prime p₀, p₀+1 is even and ≥4, so not prime — forces q/p₀ ≥ 2",
       "chain_step_ge: q ≡ 1 (mod p₀) with p₀ ≥ 3 prime implies q ≥ 2p₀+1",
       "Exponential bound: p(k) ≥ 2^k by induction using chain_step_ge for k ≥ 1",
       "Remaining 5 axioms: 4 deep results (Linnik, FKL, greedy bounds) + 1 conjecture (small prime)",
-      "3 sorries: question1_equiv (tendsto equivalence), conjecture_implies_question2, smallestPrimeCongruentOne (Dirichlet)"
+      "3 sorries: question1_equiv (tendsto equivalence), conjecture_implies_question2, smallestPrimeCongruentOne (Dirichlet)",
+      "question1_equiv: Tendsto kthRoot atTop atTop ↔ p_k > c^k eventually. Proved via rpow_inv_pow helper (rpow identity for k-th root), pow_lt_pow_left for monotonicity, and rpow_le_rpow for the backward direction.",
+      "smallestPrimeCongruentOne: Nat.forall_exists_prime_gt_and_modEq (Mathlib Dirichlet theorem) provides existence of primes ≡ 1 (mod p). Nat.mod_eq_of_lt hp.one_lt simplifies 1 % p = 1."
     ],
     "mathlibGaps": [],
-    "nextSteps": [],
+    "nextSteps": [
+      "conjecture_implies_question2 sorry requires iterative growth estimate: if next prime ≤ p·(log p)^C then p_k ≤ exp(k(log k)^{1+o(1)})"
+    ],
     "markdown": "# Erdős #695 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $p_1<p_2<\\cdots$ be a sequence of primes such that $p_{i+1}\\equiv 1\\pmod{p_i}$. Is it true that\\[\\lim_k p_k^{1/k}=\\infty?\\]Does there exist such a sequence with\\[p_k \\leq \\exp(k(\\log k)^{1+o(1)})?\\]\n\n\n\nSuch a sequence is sometimes called a prime chain.\n\nIf we take the obvious 'greedy' chain with $2=p_1$ and $p_{i+1}$ is the smallest prime $\\equiv 1\\pmod{p_i}$ then Linnik's theorem implies that this sequence grows like\\[p_k \\leq e^{e^{O(k)}}.\\]It is conjectured that, for any prime $p$, there is a prime $p'\\leq p(\\log p)^{O(1)}$ which is congruent to $1\\pmod{p}$, which would imply this sequence grows like\\[p_k\\leq \\exp(k(\\log k)^{1+o(1)}).\\]An extensive study of the growth of finite prime chains was carried out by Ford, Konyagin, and Luca \\cite{FKL10}.\n\nSee also [696].\n\n\n\n\nReferences\n\n\n[FKL10] Ford, Kevin and Konyagin, Sergei V. and Luca, Florian, Prime chains and {P}ratt trees. Geom. Funct. Anal. (2010), 1231--1258.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #696\n- Problem #694\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er79e\n- FKL10\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-14*\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary
Two research problems improved in this session.

### erdos-684: Smooth Parts of Binomial Coefficients
- Proved `f_property` axiom from `Nat.sInf_mem` (infimum of nonempty set of naturals is in the set)
- **Axiom delta**: 3 → 2 (-1)
- Remaining axioms: `f_domain_large`, `mahler_ineffective` (both deep results)

### erdos-695: Prime Chain Growth
- Proved `question1_equiv`: kthRoot→∞ iff p_k > c^k for all c > 0 eventually
- Fixed `smallestPrimeCongruentOne`: replaced false witness with Dirichlet's theorem from Mathlib
- **Sorry delta**: 3 → 1 (-2)
- Remaining sorry: `conjecture_implies_question2` (iterative asymptotic argument)

## Status
**Outcome**: progress on both problems

🤖 Generated by researcher-8