### PR TITLE
Aristotle: create companion file for Erdos933Problem

### DIFF
--- a/proofs/Proofs/Erdos933ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos933ProblemAristotle.lean
@@ -1,0 +1,54 @@
+/-
+  Aristotle targets for Erdos933Problem
+  Routine supporting lemmas for automated proof search.
+  See Erdos933Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT steinerberger_gives_large_smooth (deep analytic argument)
+  - NOT steinerberger_proof (axiom — Aristotle skips)
+  - Factorization additivity lemmas: power of prime p in n*(n+1)
+    equals sum of powers in n and n+1 (from Nat.factorization_mul)
+  - No axioms, no definition sorries, no open conjectures
+  - No /-! docstring sections (use /- instead)
+
+  Included targets (2):
+  - power2_consecutive_ari: v_2(n*(n+1)) = v_2(n) + v_2(n+1)
+  - power3_consecutive_ari: v_3(n*(n+1)) = v_3(n) + v_3(n+1)
+
+  NOT included:
+  - steinerberger_proof: axiom (Aristotle skips)
+  - steinerberger_gives_large_smooth: requires analytic estimates
+-/
+import Mathlib
+import Proofs.Erdos933Problem
+
+namespace Erdos933ProblemAristotle
+
+open Erdos933 Nat
+
+/-
+## Factorization Additivity for Consecutive Products
+
+The key tool is Nat.factorization_mul: for m, n > 0,
+  (m * n).factorization = m.factorization + n.factorization
+
+as Finsupps of prime exponents, so evaluating at any prime p gives
+  v_p(m * n) = v_p(m) + v_p(n).
+
+For n = 0, factorization 0 = 0 and n*(n+1) = 0, so both sides are 0.
+For n > 0, n+1 > 0 always, so Nat.factorization_mul applies.
+-/
+
+/-- The 2-adic valuation of n*(n+1) equals the sum of 2-adic valuations of n and n+1. -/
+theorem power2_consecutive_ari (n : ℕ) :
+    (n * (n + 1)).factorization 2 =
+      n.factorization 2 + (n + 1).factorization 2 := by
+  sorry
+
+/-- The 3-adic valuation of n*(n+1) equals the sum of 3-adic valuations of n and n+1. -/
+theorem power3_consecutive_ari (n : ℕ) :
+    (n * (n + 1)).factorization 3 =
+      n.factorization 3 + (n + 1).factorization 3 := by
+  sorry
+
+end Erdos933ProblemAristotle


### PR DESCRIPTION
## Fix

Creates Aristotle companion file for `Erdos933Problem` (Erdős #933: Smooth Part of Consecutive Products) exposing 2 factorization sorries for automated proof search.

## Targets

**power2_consecutive_ari**: v₂(n·(n+1)) = v₂(n) + v₂(n+1)

**power3_consecutive_ari**: v₃(n·(n+1)) = v₃(n) + v₃(n+1)

**Proof strategy**: Both follow from `Nat.factorization_mul`: for m, n > 0, (m*n).factorization = m.factorization + n.factorization as Finsupps. Evaluating at any prime p gives the result. For n = 0: both sides are 0. For n > 0: n+1 > 0 always, apply `Nat.factorization_mul`.

## Excluded (correctly)

- `steinerberger_proof`: `axiom` — Aristotle skips axioms
- `steinerberger_gives_large_smooth`: deep analytic argument about c·n·log(n)

## Validation

- No `def ... := sorry` (definition sorries)
- No `axiom` declarations
- No `theorem ... : True` placeholders
- No `/-!` docstring sections

---
Automated fix by lean-mechanic agent.