### PR TITLE
Aristotle: create companion files for Erdos57Problem and Erdos207Problem

### DIFF
--- a/proofs/Proofs/Erdos207ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos207ProblemAristotle.lean
@@ -1,0 +1,53 @@
+/-
+  Aristotle targets for Erdos207Problem
+  Routine supporting lemmas for automated proof search.
+  See Erdos207Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT erdos207Conjecture: existential (Aristotle cannot construct STS)
+  - NOT girth_3_iff_pasch_free: complex combinatorial equivalence
+  - Girth ≥ 2 for any Steiner triple system: provable from STS uniqueness
+  - No axioms, no definition sorries, no open conjectures
+  - No /-! docstring sections (use /- instead)
+
+  Included targets (1):
+  - sts_has_girth_at_least_2_ari: every STS has girth ≥ 2
+
+  NOT included:
+  - erdos207Conjecture: requires existence of high-girth STS (Aristotle skips)
+  - girth_3_iff_pasch_free: needs full Pasch configuration analysis
+-/
+import Mathlib
+import Proofs.Erdos207Problem
+
+namespace Erdos207ProblemAristotle
+
+open Erdos207 Finset
+
+/-
+## Section: Girth ≥ 2 for Steiner Triple Systems
+
+HasGirthAtLeast H 2 says: for any S ⊆ H.edges with S.card = 2,
+the union of the two edges (vertexSpan S) has ≥ 5 vertices.
+
+Key argument:
+- Two distinct edges e₁, e₂ in a STS each have 3 vertices
+- If they shared ≥ 2 vertices a, b, the STS property ∃! triple through {a,b}
+  would force e₁ = e₂, contradicting distinctness
+- So they share ≤ 1 vertex: |e₁ ∪ e₂| ≥ 3 + 3 - 1 = 5
+
+Key Mathlib lemmas:
+- Finset.card_eq_two: S.card = 2 ↔ ∃ a b, a ≠ b ∧ S = {a, b}
+- Finset.card_union_add_card_inter: |A ∪ B| + |A ∩ B| = |A| + |B|
+- Finset.biUnion_pair: ({e₁, e₂}.biUnion id) = e₁ ∪ e₂
+-/
+
+/-- Every Steiner triple system has girth at least 2.
+    Any two distinct edges share at most 1 vertex (by the unique-triple property),
+    so their union has at least 3 + 3 - 1 = 5 vertices. -/
+theorem sts_has_girth_at_least_2_ari {V : Type*} [Fintype V] [DecidableEq V]
+    (H : Hypergraph3 V) (hSTS : IsSteinerTripleSystem H) :
+    HasGirthAtLeast H 2 := by
+  sorry
+
+end Erdos207ProblemAristotle

--- a/proofs/Proofs/Erdos57ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos57ProblemAristotle.lean
@@ -1,0 +1,66 @@
+/-
+  Aristotle targets for Erdos57Problem
+  Routine supporting lemmas for automated proof search.
+  See Erdos57Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT erdos_57: axiom (main Liu-Montgomery result, Aristotle skips)
+  - NOT UpperDensityConjecture / HalfDensityConjecture: open conjectures
+  - Bipartite characterization lemmas, classical graph theory
+  - No axioms, no definition sorries, no open conjectures
+  - No /-! docstring sections (use /- instead)
+
+  Included targets (2):
+  - colorable_two_no_odd_cycles_ari: IsColorable G 2 → oddCycleLengths G = ∅
+  - bipartite_iff_no_odd_cycles_ari: G.IsBipartite ↔ oddCycleLengths G = ∅
+
+  NOT included:
+  - erdos_57: axiom (Aristotle skips)
+  - UpperDensityConjecture, HalfDensityConjecture: open conjectures
+-/
+import Mathlib
+import Proofs.Erdos57Problem
+
+namespace Erdos57ProblemAristotle
+
+open Erdos57 SimpleGraph
+
+/-
+## Section 1: 2-Colorable Graphs Have No Odd Cycles
+
+A proper 2-coloring f : V → Fin 2 assigns colors 0 or 1 to vertices.
+Adjacent vertices get different colors, so colors strictly alternate along edges.
+Any closed walk of odd length would require f(start) = f(start) + 1 (mod 2),
+a contradiction. Hence no odd cycles exist.
+
+Key Mathlib lemmas:
+- SimpleGraph.Walk.IsCycle.three_le_length
+- Fin 2 arithmetic: exactly two values, swapping is the only color change
+-/
+
+/-- 2-colorable graphs have no odd cycles.
+    A proper 2-coloring makes colors alternate along walks; odd closed walks
+    require the start vertex to have two different colors. -/
+theorem colorable_two_no_odd_cycles_ari {V : Type*} (G : SimpleGraph V)
+    (h : IsColorable G 2) : oddCycleLengths G = ∅ := by
+  sorry
+
+/-
+## Section 2: Bipartite Iff No Odd Cycles
+
+In Mathlib, G.IsBipartite ↔ G.Colorable 2 ↔ no odd cycles.
+The local oddCycleLengths G collects lengths of all odd cycles.
+IsBipartite means the vertex set can be 2-partitioned with all edges crossing.
+
+Key Mathlib lemmas:
+- SimpleGraph.IsBipartite iff 2-colorable
+- Odd cycles prevent 2-colorability (parity argument)
+- 2-colorable graphs have only even-length cycles
+-/
+
+/-- A graph is bipartite iff it has no odd cycles. -/
+theorem bipartite_iff_no_odd_cycles_ari {V : Type*} (G : SimpleGraph V) :
+    G.IsBipartite ↔ oddCycleLengths G = ∅ := by
+  sorry
+
+end Erdos57ProblemAristotle


### PR DESCRIPTION
## Fix

Create Aristotle companion files exposing 3 theorem sorries for automated proof search.

## Targets

### Erdos57Problem (odd cycle characterization):
- **`colorable_two_no_odd_cycles_ari`**: `IsColorable G 2 → oddCycleLengths G = ∅`
  — A proper 2-coloring alternates colors along edges; any odd closed walk would force `f(start) ≠ f(start)`.
- **`bipartite_iff_no_odd_cycles_ari`**: `G.IsBipartite ↔ oddCycleLengths G = ∅`
  — Standard bipartite characterization: 2-colorable ↔ no odd cycles.

### Erdos207Problem (high-girth Steiner triple systems):
- **`sts_has_girth_at_least_2_ari`**: every STS has `HasGirthAtLeast H 2`
  — Two distinct STS edges share ≤ 1 vertex (by unique-triple property), so their union spans ≥ 5 vertices.

## Evidence

**Before**: These theorem sorries were not exposed for Aristotle proof search.
**After**: 3 targets available in companion files, following Aristotle inclusion criteria.

---
Automated fix by lean-mechanic agent.