### PR TITLE
Enrich 3 proofs: Thin Shell, LLN Ergodic, Resolvent Neumann

### DIFF
--- a/src/data/proofs/geometric-series-oq-02-oq-05/annotations.json
+++ b/src/data/proofs/geometric-series-oq-02-oq-05/annotations.json
@@ -2,158 +2,85 @@
   {
     "id": "ann-header-imports",
     "proofId": "geometric-series-oq-02-oq-05",
-    "range": {
-      "startLine": 1,
-      "endLine": 34
-    },
+    "range": { "startLine": 1, "endLine": 34 },
     "type": "context",
-    "title": "Module Header: Resolvent and Neumann Series: Toward the Holomorphic Functional Calculus",
-    "content": "Module docstring and imports for the Resolvent and Neumann Series: Toward the Holomorphic Functional Calculus formalization.",
-    "mathContext": "Given a Banach algebra element a and a spectral variable \u03bb with \u2016a\u2016 < |\u03bb|, establish: (1) R(\u03bb,a) = (\u03bb\u00b71 - a)\u207b\u00b9 exists, (2) R(\u03bb,a) = \u03bb\u207b\u00b9 \u2211_{n\u22650} (\u03bb\u207b\u00b9a)^n (Neumann series), (3) \u2016R(\u03bb,a)\u2016 \u2264 (|\u03bb| - \u2016a\u2016)\u207b\u00b9 ",
+    "title": "Module Header and Problem Statement",
+    "content": "Module docstring and imports for the Resolvent and Neumann Series formalization. Sets up the bridge from the Neumann series (OQ-02) to spectral theory and the holomorphic functional calculus.",
+    "mathContext": "Given a Banach algebra element $a$ and spectral variable $\\lambda$ with $\\|a\\| < |\\lambda|$: (1) $R(\\lambda,a) = (\\lambda \\cdot 1 - a)^{-1}$ exists, (2) $R(\\lambda,a) = \\lambda^{-1} \\sum_{n \\geq 0} (\\lambda^{-1}a)^n$, (3) $\\|R(\\lambda,a)\\| \\leq (|\\lambda| - \\|a\\|)^{-1}$",
     "significance": "context",
-    "relatedConcepts": [
-      "functional-analysis",
-      "spectral-theory",
-      "resolvent",
-      "neumann-series"
-    ],
-    "prerequisites": [
-      "Mathlib"
-    ]
+    "relatedConcepts": ["functional analysis", "spectral theory", "resolvent", "Neumann series"],
+    "prerequisites": ["Mathlib", "GeometricSeriesOQ02"]
   },
   {
-    "mathContext": "NormedAlgebra \ud835\udd5c A means A is simultaneously a NormedRing and a normed \ud835\udd5c-module with \u2016c \u2022 x\u2016 \u2264 \u2016c\u2016 \u00b7 \u2016x\u2016. NormOneClass adds \u2016(1 : A)\u2016 = 1. Together these imply \u2016algebraMap \ud835\udd5c A c\u2016 = \u2016c\u2016, making the scalar embedding isometric (proved as norm_algebraMap in \u00a7 1).",
-    "significance": "key",
-    "relatedConcepts": [
-      "NormedAlgebra",
-      "CompleteSpace",
-      "NormOneClass",
-      "Banach algebra",
-      "spectral theory"
-    ],
-    "prerequisites": [
-      "Normed vector spaces and normed rings",
-      "Algebra over a field",
-      "Completeness and Cauchy sequences"
-    ],
+    "id": "ann-banach-algebra-setup",
     "proofId": "geometric-series-oq-02-oq-05",
-    "range": {
-      "startLine": 35,
-      "endLine": 37
-    },
+    "range": { "startLine": 35, "endLine": 37 },
     "type": "concept",
-    "content": "The type signature encodes the full generality: \ud835\udd5c is a NontriviallyNormedField (e.g., \u211d or \u2102), A is a complete NormedAlgebra over \ud835\udd5c satisfying NormOneClass (\u20161\u2016 = 1). CompleteSpace A is essential \u2014 without it the Neumann series \u2211 T\u207f may not converge. NormOneClass ensures the scalar embedding is isometric, which is used crucially in norm_algebraMap."
+    "title": "Banach Algebra Type Signature",
+    "content": "The type signature encodes the full generality: $\\mathbb{K}$ is a NontriviallyNormedField (e.g., $\\mathbb{R}$ or $\\mathbb{C}$), $A$ is a complete NormedAlgebra over $\\mathbb{K}$ satisfying NormOneClass ($\\|1\\| = 1$). CompleteSpace $A$ is essential for Neumann series convergence. NormOneClass ensures the scalar embedding is isometric.",
+    "mathContext": "NormedAlgebra $\\mathbb{K}$ $A$ with $\\|c \\cdot x\\| \\leq \\|c\\| \\cdot \\|x\\|$ and $\\|1_A\\| = 1$, implying $\\|\\text{algebraMap}(c)\\| = \\|c\\|$",
+    "significance": "key",
+    "relatedConcepts": ["NormedAlgebra", "CompleteSpace", "NormOneClass", "Banach algebra", "spectral theory"],
+    "prerequisites": ["Normed vector spaces and normed rings", "Algebra over a field", "Completeness"]
   },
   {
-    "mathContext": "Crucially, algebraMap here is the canonical ring homomorphism \ud835\udd5c \u2192 A sending c \u21a6 c \u00b7 1_A. It is not merely additive \u2014 it respects multiplication, so it maps units to units. The isometric property (norm-preserving) is stronger than the general NormedAlgebra bound \u2016c \u2022 x\u2016 \u2264 \u2016c\u2016\u2016x\u2016, and requires NormOneClass for equality.",
-    "significance": "key",
-    "relatedConcepts": [
-      "algebraMap",
-      "RingHom.isUnit_map",
-      "norm_smul",
-      "NormOneClass"
-    ],
-    "prerequisites": [
-      "Ring homomorphisms and units",
-      "Norm properties in NormedAlgebra"
-    ],
+    "id": "ann-scalar-embedding",
     "proofId": "geometric-series-oq-02-oq-05",
-    "range": {
-      "startLine": 42,
-      "endLine": 50
-    },
+    "range": { "startLine": 42, "endLine": 50 },
     "type": "concept",
-    "content": "Two foundational lemmas about the scalar embedding. norm_algebraMap proves \u2016algebraMap \ud835\udd5c A \u03bb\u2016 = \u2016\u03bb\u2016 using algebraMap_eq_smul_one (c \u21a6 c \u2022 1) and norm_smul combined with \u20161\u2016 = 1 from NormOneClass. algebraMap_isUnit propagates IsUnit from \ud835\udd5c to A using RingHom.isUnit_map \u2014 nonzero scalars are units in A."
+    "title": "Scalar Embedding: Isometry and Units",
+    "content": "Two foundational lemmas: norm_algebraMap proves $\\|\\text{algebraMap}(\\lambda)\\| = \\|\\lambda\\|$ via algebraMap_eq_smul_one and $\\|1\\| = 1$. algebraMap_isUnit propagates IsUnit from $\\mathbb{K}$ to $A$ via RingHom.isUnit_map. These ensure nonzero scalars embed isometrically as units.",
+    "mathContext": "$\\|\\text{algebraMap}_{\\mathbb{K} \\to A}(\\lambda)\\| = \\|\\lambda\\|$ and $\\lambda \\neq 0 \\implies \\text{algebraMap}(\\lambda)$ is a unit in $A$",
+    "significance": "key",
+    "relatedConcepts": ["algebraMap", "RingHom.isUnit_map", "norm_smul", "NormOneClass"],
+    "prerequisites": ["Ring homomorphisms and units", "Norm properties in NormedAlgebra"]
   },
   {
-    "mathContext": "The factorization \u03bb\u00b71 - a = \u03bb\u00b7(1 - \u03bb\u207b\u00b9a) is elementary algebra but requires careful use of mul_inv_cancel\u2080 and map_mul for the algebraMap. The key identity algebraMap(\u03bb) * algebraMap(\u03bb\u207b\u00b9) = algebraMap(\u03bb \u00b7 \u03bb\u207b\u00b9) = algebraMap(1) = 1 is used in resolvent_factorization. In resolvent_isUnit, one_sub_isUnit (imported from OQ-02) handles the (1 - T) part.",
-    "significance": "key",
-    "relatedConcepts": [
-      "resolvent set",
-      "spectrum containment",
-      "Neumann series",
-      "IsUnit",
-      "one_sub_isUnit"
-    ],
-    "prerequisites": [
-      "Neumann series (OQ-02: one_sub_isUnit)",
-      "IsUnit and unit products",
-      "Algebraic manipulations with algebraMap"
-    ],
+    "id": "ann-resolvent-existence",
     "proofId": "geometric-series-oq-02-oq-05",
-    "range": {
-      "startLine": 60,
-      "endLine": 96
-    },
-    "type": "concept",
-    "content": "The core of resolvent existence: three lemmas forming a logical chain. (1) norm_inv_smul_lt_one converts \u2016a\u2016 < \u2016\u03bb\u2016 into \u2016\u03bb\u207b\u00b9a\u2016 < 1 via a calc chain: \u2016\u03bb\u207b\u00b9 \u00b7 a\u2016 \u2264 \u2016\u03bb\u207b\u00b9\u2016 \u00b7 \u2016a\u2016 = \u2016\u03bb\u2016\u207b\u00b9 \u00b7 \u2016a\u2016 < \u2016\u03bb\u2016\u207b\u00b9 \u00b7 \u2016\u03bb\u2016 = 1. (2) resolvent_factorization proves \u03bb\u00b71 - a = \u03bb \u00b7 (1 - \u03bb\u207b\u00b9 \u00b7 a) algebraically. (3) resolvent_isUnit combines them: both \u03bb\u00b71 and (1 - \u03bb\u207b\u00b9a) are units, so their product is."
-  },
-  {
-    "mathContext": "Ring.inverse is the unique total function satisfying a \u00b7 Ring.inverse a = 1 for units and Ring.inverse a = 0 for non-units. For a unit u, Ring.inverse u = \u2191u\u207b\u00b9. The simp lemma Units.val_mul and mul_comm are used to rearrange (\u2191u\u03bb\u207b\u00b9 \u00b7 \u2191u(1-T)\u207b\u00b9) into the canonical order \u03bb\u207b\u00b9 \u00b7 \u2211T\u207f. The proof requires neumann_sum from OQ-02 as a black box.",
-    "significance": "key",
-    "relatedConcepts": [
-      "Neumann series",
-      "Ring.inverse",
-      "Laurent expansion",
-      "analytic resolvent",
-      "neumann_sum"
-    ],
-    "prerequisites": [
-      "OQ-02: neumann_sum, neumann_summable",
-      "Ring.inverse_unit",
-      "Units.val_mul, map_inv\u2080"
-    ],
-    "proofId": "geometric-series-oq-02-oq-05",
-    "range": {
-      "startLine": 109,
-      "endLine": 138
-    },
+    "range": { "startLine": 60, "endLine": 96 },
     "type": "technique",
-    "content": "resolvent_eq_neumann_series gives the explicit formula Ring.inverse(\u03bb\u00b71 - a) = \u03bb\u207b\u00b9 \u00b7 \u2211 (\u03bb\u207b\u00b9a)^n. The proof sets T = \u03bb\u207b\u00b9a, factors \u03bb\u00b71 - a = \u03bb\u00b7(1-T), uses Ring.inverse_unit for the product of units (giving (\u03bb\u00b7(1-T))\u207b\u00b9 = (1-T)\u207b\u00b9 \u00b7 \u03bb\u207b\u00b9), then substitutes neumann_sum T hT for (1-T)\u207b\u00b9 = \u2211 T\u207f and map_inv\u2080 for the scalar inverse."
+    "title": "Resolvent Existence via Neumann Factorization",
+    "content": "The core of resolvent existence: three lemmas forming a logical chain. (1) norm_inv_smul_lt_one converts $\\|a\\| < \\|\\lambda\\|$ into $\\|\\lambda^{-1}a\\| < 1$ via submultiplicativity. (2) resolvent_factorization proves $\\lambda \\cdot 1 - a = \\lambda \\cdot (1 - \\lambda^{-1}a)$ algebraically using mul_inv_cancel and map_mul. (3) resolvent_isUnit combines these: both $\\lambda \\cdot 1$ and $(1 - \\lambda^{-1}a)$ are units (the latter via one_sub_isUnit from OQ-02), so their product is invertible.",
+    "mathContext": "$\\lambda \\cdot 1 - a = \\lambda \\cdot (1 - \\lambda^{-1}a)$. Since $\\|\\lambda^{-1}a\\| < 1$, both factors are units, so $\\lambda \\cdot 1 - a$ is invertible.",
+    "significance": "key",
+    "relatedConcepts": ["resolvent set", "spectrum containment", "Neumann series", "IsUnit", "one_sub_isUnit"],
+    "prerequisites": ["Neumann series (OQ-02: one_sub_isUnit)", "IsUnit and unit products"]
   },
   {
-    "mathContext": "The identity R(\u03bb) - R(\u03bc) = (\u03bc-\u03bb)R(\u03bb)R(\u03bc) can also be written R(\u03bb)(\u03bb\u00b71-a) - R(\u03bc)(\u03bc\u00b71-a) = (\u03bc-\u03bb)\u00b71, which is trivially 1-1=0 after cancellation. The Lean proof avoids this slightly circular route by working directly with unit inverses. Note: this identity holds in any ring with two invertible elements \u2014 no completeness or norm is needed.",
-    "significance": "key",
-    "relatedConcepts": [
-      "first resolvent identity",
-      "pseudo-resolvent",
-      "analytic vector-valued functions",
-      "Kato perturbation theory"
-    ],
-    "prerequisites": [
-      "IsUnit and ring inverse",
-      "Algebraic manipulation with units",
-      "No completeness needed"
-    ],
+    "id": "ann-neumann-series-repr",
     "proofId": "geometric-series-oq-02-oq-05",
-    "range": {
-      "startLine": 183,
-      "endLine": 219
-    },
+    "range": { "startLine": 109, "endLine": 138 },
     "type": "technique",
-    "content": "The first resolvent identity R(\u03bb) - R(\u03bc) = (\u03bc-\u03bb)\u00b7R(\u03bb)\u00b7R(\u03bc) is proved purely algebraically, with no norm hypotheses \u2014 only IsUnit witnesses for both resolvent points. The key algebraic lemma is u\u03bb\u207b\u00b9 - u\u03bc\u207b\u00b9 = u\u03bb\u207b\u00b9\u00b7(u\u03bc - u\u03bb)\u00b7u\u03bc\u207b\u00b9, proved by ring after inserting u\u03bc\u00b7u\u03bc\u207b\u00b9 = 1 and u\u03bb\u207b\u00b9\u00b7u\u03bb = 1. The substitution u\u03bc - u\u03bb = algebraMap(\u03bc) - algebraMap(\u03bb) completes the proof."
+    "title": "Neumann Series Representation of the Resolvent",
+    "content": "Gives the explicit formula $R(\\lambda,a) = \\lambda^{-1} \\sum_{n \\geq 0} (\\lambda^{-1}a)^n$. The proof sets $T = \\lambda^{-1}a$, factors $\\lambda \\cdot 1 - a = \\lambda \\cdot (1-T)$, applies Ring.inverse_unit for products of units, then substitutes neumann_sum from OQ-02 for $(1-T)^{-1} = \\sum T^n$ and map_inv for the scalar inverse.",
+    "mathContext": "$R(\\lambda,a) = \\text{Ring.inverse}(\\lambda \\cdot 1 - a) = \\lambda^{-1} \\sum_{n=0}^{\\infty} (\\lambda^{-1}a)^n$",
+    "significance": "key",
+    "relatedConcepts": ["Neumann series", "Ring.inverse", "Laurent expansion", "analytic resolvent"],
+    "prerequisites": ["OQ-02: neumann_sum, neumann_summable", "Ring.inverse_unit"]
   },
   {
-    "mathContext": "Filter.comap (\u2016\u00b7\u2016) atTop is the correct formulation of '\u03bb \u2192 \u221e' for a normed field \ud835\udd5c that may be non-Archimedean or otherwise exotic. It generates the filter of sets containing {\u03bb : \u2016\u03bb\u2016 \u2265 M} for all M. The composition tendsto_inv_atTop_zero.comp h_sub.comp tendsto_comap chains: \u2016\u03bb\u2016 \u2192 \u221e implies \u2016\u03bb\u2016 - \u2016a\u2016 \u2192 \u221e implies (\u2016\u03bb\u2016 - \u2016a\u2016)\u207b\u00b9 \u2192 0.",
-    "significance": "key",
-    "relatedConcepts": [
-      "Filter.comap",
-      "squeeze_zero_norm",
-      "tendsto_inv_atTop_zero",
-      "holomorphic functional calculus",
-      "compactness of spectrum"
-    ],
-    "prerequisites": [
-      "Mathlib Filter API: comap, atTop, squeeze_zero_norm'",
-      "tendsto_inv_atTop_zero",
-      "resolvent_norm_bound from \u00a7 4"
-    ],
+    "id": "ann-first-resolvent-identity",
     "proofId": "geometric-series-oq-02-oq-05",
-    "range": {
-      "startLine": 225,
-      "endLine": 249
-    },
+    "range": { "startLine": 183, "endLine": 219 },
+    "type": "insight",
+    "title": "First Resolvent Identity (Purely Algebraic)",
+    "content": "Proves $R(\\lambda) - R(\\mu) = (\\mu - \\lambda) R(\\lambda) R(\\mu)$ purely algebraically, with no norm hypotheses. The key lemma is $u_\\lambda^{-1} - u_\\mu^{-1} = u_\\lambda^{-1} (u_\\mu - u_\\lambda) u_\\mu^{-1}$, proved by ring after inserting $u_\\mu u_\\mu^{-1} = 1$. This identity holds in any ring with two invertible elements, and is central to Kato's perturbation theory.",
+    "mathContext": "$R(\\lambda) - R(\\mu) = (\\mu - \\lambda) R(\\lambda) R(\\mu)$ for any two resolvent points $\\lambda, \\mu$",
+    "significance": "key",
+    "relatedConcepts": ["first resolvent identity", "pseudo-resolvent", "Kato perturbation theory"],
+    "prerequisites": ["IsUnit and ring inverse", "Algebraic manipulation with units"]
+  },
+  {
+    "id": "ann-resolvent-vanishes",
+    "proofId": "geometric-series-oq-02-oq-05",
+    "range": { "startLine": 225, "endLine": 249 },
     "type": "technique",
-    "content": "resolvent_tendsto_zero proves \u2016R(\u03bb,a)\u2016 \u2192 0 as \u2016\u03bb\u2016 \u2192 \u221e using squeeze_zero_norm'. The filter is Filter.comap (\u2016\u00b7\u2016) atTop \u2014 the neighborhood filter of \u221e on \ud835\udd5c encoded via norms. 'Eventually' uses the set {\u03bb : \u2016a\u2016 + 1 \u2264 \u2016\u03bb\u2016}, where resolvent_norm_bound applies (since \u2016a\u2016 < \u2016\u03bb\u2016). The bound (\u2016\u03bb\u2016 - \u2016a\u2016)\u207b\u00b9 \u2192 0 follows from tendsto_inv_atTop_zero composed with the cofinite shift r \u21a6 r - \u2016a\u2016."
+    "title": "Resolvent Vanishes at Infinity",
+    "content": "Proves $\\|R(\\lambda,a)\\| \\to 0$ as $\\|\\lambda\\| \\to \\infty$ using squeeze_zero_norm'. The filter $\\text{comap}(\\|\\cdot\\|, \\text{atTop})$ encodes $\\lambda \\to \\infty$ for general normed fields. The bound $(\\|\\lambda\\| - \\|a\\|)^{-1} \\to 0$ follows from tendsto_inv_atTop_zero composed with the shift $r \\mapsto r - \\|a\\|$. Essential for contour integration in the holomorphic functional calculus.",
+    "mathContext": "$\\|R(\\lambda,a)\\| \\to 0$ as $|\\lambda| \\to \\infty$, via $\\|R(\\lambda,a)\\| \\leq (|\\lambda| - \\|a\\|)^{-1} \\to 0$",
+    "significance": "key",
+    "relatedConcepts": ["Filter.comap", "squeeze_zero_norm", "tendsto_inv_atTop_zero", "holomorphic functional calculus"],
+    "prerequisites": ["Filter API: comap, atTop", "resolvent_norm_bound"]
   }
 ]


### PR DESCRIPTION
## Summary

Enrichment batch covering 3 gallery proof entries.

### 1. area-of-circle-oq-01-oq-02-oq-01-oq-03 (Thin Shell Limit)
- Created `annotations.json` with 9 annotations covering all 195 lines
- Expanded historicalContext with Schläfli (1852), Lévy (1922), Bellman (1957)
- Added 3rd open question on peak dimension

### 2. laws-of-large-numbers-oq-03 (LLN Ergodic Theory)  
- Created `annotations.json` with 13 annotations covering all 375 lines
- Expanded historicalContext with Boltzmann (1871), von Neumann (1932), Hopf (1954)
- Added 3 missing sections: maximal ergodic lemma, von Neumann theorem, mixing/hierarchy
- Added cross-reference to prob-method-expectation

### 3. geometric-series-oq-02-oq-05 (Resolvent Neumann Series)
- Fixed all 7 annotations: added missing `id` and `title` fields
- Converted mathContext to proper LaTeX notation
- Standardized annotation structure