### PR TITLE
Fix: remove false theorems from erdos-360 (sorries 5→2)

### DIFF
--- a/proofs/Proofs/Stubs/Erdos360Problem.lean
+++ b/proofs/Proofs/Stubs/Erdos360Problem.lean
@@ -142,11 +142,6 @@ For small n, we can compute f(n) directly.
 theorem f_2 : f 2 = 1 := by
   sorry -- Requires showing {1} is 2-sum-free and optimal
 
-/-- f(3) = 1: {1, 2} is 3-sum-free (1 + 2 = 3, but we need DISTINCT elements in a subset,
-and {1,2} is the whole set, so trivially satisfied by taking single elements). -/
-theorem f_3 : f 3 = 1 := by
-  sorry -- {1,2} works: subsets are ∅, {1}, {2}, {1,2} with sums 0, 1, 2, 3
-
 /-- f(4) = 2: Need 2 classes because {1,3} sums to 4. -/
 theorem f_4 : f 4 = 2 := by
   sorry -- Partition into {1, 2} and {3}, for example
@@ -163,25 +158,13 @@ The factor (log log n)^{2/3} in the denominator reflects deep structure from
 analytic number theory and probabilistic combinatorics.
 -/
 
-/-- The main result: Problem #360 is solved. -/
+/-- The main result: Problem #360 is solved. Exact order: f(n) ≍ n^{1/3}·(n/φ(n)) / ((log n)^{1/3}·(log log n)^{2/3}). -/
 theorem erdos_360_solved :
     ∃ c₁ c₂ : ℝ, c₁ > 0 ∧ c₂ > 0 ∧
     ∀ n : ℕ, n ≥ 10 →
-      c₁ * (n : ℝ)^(1/3 : ℝ) / (Real.log n)^(1/3 : ℝ) ≤ f n ∧
-      (f n : ℝ) ≤ c₂ * (n : ℝ)^(1/3 : ℝ) / (Real.log n)^(1/3 : ℝ) :=
-  conlon_fox_pham_2021.imp fun c₁ ⟨c₂, h⟩ => ⟨c₂, by
-    obtain ⟨hc₁, hc₂, hbounds⟩ := h
-    refine ⟨hc₁, hc₂, fun n hn => ?_⟩
-    obtain ⟨lb, ub⟩ := hbounds n hn
-    constructor
-    · calc c₁ * (n : ℝ)^(1/3 : ℝ) / (Real.log n)^(1/3 : ℝ)
-        ≤ c₁ * (n : ℝ)^(1/3 : ℝ) * (n / Nat.totient n) / ((Real.log n)^(1/3 : ℝ) * (Real.log (Real.log n))^(2/3 : ℝ)) := by
-          sorry -- n/φ(n) ≥ 1 and (log log n)^{2/3} ≥ 1 for n ≥ 10
-        _ ≤ f n := lb
-    · calc (f n : ℝ)
-        ≤ c₂ * (n : ℝ)^(1/3 : ℝ) * (n / Nat.totient n) / ((Real.log n)^(1/3 : ℝ) * (Real.log (Real.log n))^(2/3 : ℝ)) := ub
-        _ ≤ c₂ * (n : ℝ)^(1/3 : ℝ) / (Real.log n)^(1/3 : ℝ) := by
-          sorry -- This bound is not always true, simplified statement
-  ⟩
+      let φn := Nat.totient n
+      c₁ * (n : ℝ)^(1/3 : ℝ) * (n / φn) / ((Real.log n)^(1/3 : ℝ) * (Real.log (Real.log n))^(2/3 : ℝ)) ≤ f n ∧
+      (f n : ℝ) ≤ c₂ * (n : ℝ)^(1/3 : ℝ) * (n / φn) / ((Real.log n)^(1/3 : ℝ) * (Real.log (Real.log n))^(2/3 : ℝ)) :=
+  conlon_fox_pham_2021
 
 end Erdos360

--- a/src/data/proofs/erdos-360/meta.json
+++ b/src/data/proofs/erdos-360/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 2,
     "erdosNumber": 360,
     "erdosUrl": "https://erdosproblems.com/360",
     "erdosProblemStatus": "solved",
@@ -59,7 +59,7 @@
     ],
     "axiomCount": 4,
     "lineCount": 187,
-    "assumptions": "4 axiom(s) and 5 sorry(s). See the Lean source for details."
+    "assumptions": "4 axiom(s) and 2 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #360**\n\nThis problem asks about partitioning integers to avoid subset sums, a fundamental question in additive combinatorics with connections to Ramsey theory.\n\n**Key History:**\n- Erdős and Graham (1980): Original problem in \"Old and new problems and results in combinatorial number theory\"\n- Alon-Erdős (1996): Proved f(n) = n^{1/3+o(1)}, establishing cube-root growth\n- Vu (2007): Improved lower bound to n^{1/3}/log n\n- Conlon-Fox-Pham (2021): Determined exact order up to constants\n\n**Mathematical Setting:**\nGiven n, we want to partition {1,2,...,n-1} into the minimum number of classes such that no class contains distinct elements summing to n. This is a Ramsey-type problem about avoiding specific additive structures.",
@@ -170,10 +170,10 @@
     "namespace": "Erdos360",
     "lineCount": 187,
     "axiomCount": 4,
-    "theoremCount": 5,
+    "theoremCount": 4,
     "definitionCount": 4,
     "path": "Proofs/Stubs/Erdos360Problem.lean",
-    "sorries": 5
+    "sorries": 2
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Remove 1 mathematically false theorem and 2 false calc steps from `Erdos360Problem.lean`.

## Evidence

**Before**: 5 sorries in `erdos-360`, including 3 false claims:
- `f_3 : f 3 = 1` — FALSE: `IsNSumFree 3 {1,2}` fails because the subset `{1,2} ⊆ {1,2}` sums to 3 = n. So f(3) = 2, not 1.
- `erdos_360_solved` line 179 sorry: Claims `c₁·n^{1/3}/(log n)^{1/3} ≤ c₁·n^{1/3}·(n/φ(n))/((log n)^{1/3}·(log log n)^{2/3})` — requires `(log log n)^{2/3} ≤ n/φ(n)`, which fails for prime n (where n/φ(n) ≈ 1)
- `erdos_360_solved` line 184 sorry: Even self-annotated "This bound is not always true, simplified statement"

**After**: 2 sorries remaining (`f_2`, `f_4` — genuinely unproved small case computations). `erdos_360_solved` restated to directly match the `conlon_fox_pham_2021` axiom (exact n/φ(n) formula), making it sorry-free.

---
Automated fix by lean-mechanic agent.