### PR TITLE
Fix: remove false conjunct from erdos-982 summary (sorries 4→3)

### DIFF
--- a/proofs/Proofs/Erdos982Problem.lean
+++ b/proofs/Proofs/Erdos982Problem.lean
@@ -324,14 +324,10 @@ The problem remains OPEN with significant progress but a substantial gap.
 -/
 theorem erdos_982_summary :
   (∀ n ≥ 3, guaranteedDistinctDistances n ≥ n / 3 + 1) ∧
-  (¬ ∀ n ≥ 3, guaranteedDistinctDistances n ≥ n / 2 → True) ∧  -- Conjecture unresolved
   strongerConjectureDisproved := by
-  refine ⟨?_, ?_, stronger_conjecture_is_false⟩
+  refine ⟨?_, stronger_conjecture_is_false⟩
   · intro n hn
     -- From Erdős-Fishburn
-    sorry
-  · simp only [not_forall, not_true_eq_false, exists_prop]
-    -- The conjecture is open (neither proved nor disproved)
     sorry
 
 end Erdos982

--- a/src/data/proofs/erdos-982/meta.json
+++ b/src/data/proofs/erdos-982/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 3,
     "erdosNumber": 982,
     "erdosUrl": "https://erdosproblems.com/982",
     "erdosProblemStatus": "open",
@@ -191,12 +191,12 @@
       "Set"
     ],
     "namespace": "Erdos982",
-    "lineCount": 337,
+    "lineCount": 333,
     "axiomCount": 4,
-    "theoremCount": 6,
+    "theoremCount": 5,
     "definitionCount": 8,
     "path": "Proofs/Erdos982Problem.lean",
-    "sorries": 4
+    "sorries": 3
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Remove 1 false conjunct from `erdos_982_summary` in `Erdos982Problem.lean`.

## Evidence

**Before**: 4 sorries, including 1 provably false claim:
- Second conjunct of `erdos_982_summary`: `¬ ∀ n ≥ 3, guaranteedDistinctDistances n ≥ n / 2 → True`
  - `P → True` is a tautology in Lean (anything implies True)
  - So `∀ n ≥ 3, P n → True` simplifies to `True`
  - Therefore the conjunct is `¬True = False` — unprovable without sorry
  - The comment even noted "Conjecture unresolved" but the Lean formulation was malformed

**After**: 3 sorries remaining (triangle_case, quadrilateral_case, first conjunct of erdos_982_summary — all mathematically valid but not yet formally proved). `erdos_982_summary` now correctly states: Erdős-Fishburn lower bound ∧ strongerConjectureDisproved.

---
Automated fix by lean-mechanic agent.