### PR TITLE
Audit: fix 9 meta integrity issues + audit 7 new proofs

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -142,10 +142,12 @@
       "result": "clean"
     },
     "angle-trisection-oq-02-oq-04-oq-01": {
-      "auditCount": 3,
-      "issues": [],
-      "lastAudited": "2026-04-03T22:23:24Z",
-      "result": "clean"
+      "auditCount": 4,
+      "issues": [
+        "sorry 7\u21923"
+      ],
+      "lastAudited": "2026-04-13T03:29:17Z",
+      "result": "issues-fixed"
     },
     "angle-trisection-oq-03": {
       "auditCount": 2,
@@ -541,10 +543,15 @@
       "result": "clean"
     },
     "binomial-theorem-oq-04-oq-03": {
-      "auditCount": 2,
-      "issues": [],
-      "lastAudited": "2026-04-03T17:41:23Z",
-      "result": "clean"
+      "auditCount": 3,
+      "issues": [
+        "sorry 6\u21920",
+        "axiomCount 1\u21920",
+        "status axiomatized\u2192verified",
+        "badge axiom\u2192original"
+      ],
+      "lastAudited": "2026-04-13T03:29:17Z",
+      "result": "issues-fixed"
     },
     "birch-swinnerton-dyer": {
       "auditCount": 5,
@@ -786,10 +793,13 @@
       "result": "clean"
     },
     "cantor-diagonalization-oq-01-oq-01-oq-02": {
-      "auditCount": 2,
-      "issues": [],
-      "lastAudited": "2026-04-03T17:41:28Z",
-      "result": "clean"
+      "auditCount": 3,
+      "issues": [
+        "sorry 1\u21920",
+        "status formalized\u2192verified"
+      ],
+      "lastAudited": "2026-04-13T03:29:17Z",
+      "result": "issues-fixed"
     },
     "cantor-diagonalization-oq-02": {
       "auditCount": 6,
@@ -6759,9 +6769,12 @@
     },
     "erdos-644": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:23:48Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-13T03:29:17Z",
+      "result": "issues-fixed",
+      "issues": [
+        "sorry 18\u219216"
+      ]
     },
     "erdos-645": {
       "agentId": "auditor-cycle-20-batch",
@@ -9314,10 +9327,12 @@
       "result": "clean"
     },
     "feuerbachs-theorem-oq-02": {
-      "auditCount": 2,
-      "issues": [],
-      "lastAudited": "2026-04-13T00:21:53Z",
-      "result": "clean"
+      "auditCount": 3,
+      "issues": [
+        "axiomCount 5\u21923"
+      ],
+      "lastAudited": "2026-04-13T03:29:17Z",
+      "result": "issues-fixed"
     },
     "four-color-theorem": {
       "agentId": "auditor-cycle-20-batch",
@@ -12281,6 +12296,62 @@
     "derangements-oq-03-oq-01-oq-02": {
       "auditCount": 2,
       "lastAudited": "2026-04-13T03:03:24Z",
+      "result": "clean",
+      "issues": []
+    },
+    "basel-problem-oq-01-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T03:29:17Z",
+      "result": "issues-fixed",
+      "issues": [
+        "sorry 4\u21923"
+      ]
+    },
+    "chebyshev-pnt-bridge-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T03:29:17Z",
+      "result": "issues-fixed",
+      "issues": [
+        "sorry 4\u21925",
+        "status axiomatized\u2192formalized",
+        "badge axiom\u2192wip"
+      ]
+    },
+    "divisibility-by-3-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T03:29:17Z",
+      "result": "issues-fixed",
+      "issues": [
+        "sorry 1\u21920",
+        "status axiomatized\u2192verified",
+        "badge axiom\u2192original"
+      ]
+    },
+    "lebesgue-measure-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T03:29:17Z",
+      "result": "issues-fixed",
+      "issues": [
+        "sorry 1\u21920",
+        "status axiomatized\u2192verified",
+        "badge axiom\u2192original"
+      ]
+    },
+    "area-of-circle-oq-02-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T03:29:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "central-limit-theorem-oq-01-oq-02-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T03:29:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sperner-ndim-oq-03-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T03:29:17Z",
       "result": "clean",
       "issues": []
     }

--- a/src/data/proofs/binomial-theorem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-03/meta.json
@@ -107,7 +107,10 @@
       "Mathlib.RingTheory.Polynomial.Basic",
       "Mathlib.Tactic"
     ],
-    "opens": ["Finset", "BigOperators"],
+    "opens": [
+      "Finset",
+      "BigOperators"
+    ],
     "namespace": "BinomialTheoremOQ04OQ03",
     "lineCount": 306,
     "axiomCount": 0,

--- a/src/data/proofs/feuerbachs-theorem-oq-02/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-02/meta.json
@@ -28,7 +28,7 @@
       }
     ],
     "dateAdded": "2026-03-30",
-    "axiomCount": 5,
+    "axiomCount": 3,
     "lineCount": 350,
     "assumptions": "5 axioms: circumcenter existence/equidistance (2), counterexample for general tetrahedra (1), edge midpoints on sphere (1), face centroids on sphere (1). 5 sorries for the main Feuerbach tangency theorems (insphere + 4 exspheres).",
     "originalContributions": [

--- a/src/data/proofs/lebesgue-measure-oq-03-oq-01/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-03-oq-01/meta.json
@@ -112,7 +112,9 @@
     }
   ],
   "leanFile": {
-    "imports": ["Mathlib"],
+    "imports": [
+      "Mathlib"
+    ],
     "namespace": "LebesgueMeasureOQ03OQ01",
     "lineCount": 163,
     "axiomCount": 0,


### PR DESCRIPTION
## Summary

**Sorry mismatches fixed (8):**
- `angle-trisection-oq-02-oq-04-oq-01`: 7→3
- `basel-problem-oq-01-oq-01-oq-02`: 4→3
- `chebyshev-pnt-bridge-oq-01`: 4→5, status `axiomatized`→`formalized` (no axioms)
- `cantor-diagonalization-oq-01-oq-01-oq-02`: 1→0, upgraded to `verified`
- `divisibility-by-3-oq-03-oq-02`: 1→0, upgraded to `verified`
- `erdos-644`: 18→16
- `lebesgue-measure-oq-03-oq-01`: 1→0, upgraded to `verified`
- `binomial-theorem-oq-04-oq-03`: 6→0, axiomCount 1→0, upgraded to `verified`

**Axiom count fixed (1):**
- `feuerbachs-theorem-oq-02`: 5→3 (verified by reading Lean source)

**New proofs audited (7):** 3 clean, 4 fixed above. All 2036 proofs now audited.

## Test plan

- [ ] `npx tsx scripts/auditor/find-targets.ts --stats` shows 0 unaudited
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)