### PR TITLE
Enrich: Digital Root, Z[sqrt(-5)] UFD, Gaussian CharFn

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-03-oq-01/annotations.json
+++ b/src/data/proofs/lebesgue-measure-oq-03-oq-01/annotations.json
@@ -1,1 +1,62 @@
-[]
+[
+  {
+    "id": "ann-lm-oq03-archimedean",
+    "proofId": "lebesgue-measure-oq-03-oq-01",
+    "range": { "startLine": 37, "endLine": 64 },
+    "type": "technique",
+    "title": "ENNReal Archimedean Lemma",
+    "content": "Proves that if $N \\cdot c \\leq M$ for all $N \\in \\mathbb{N}$ and $M < \\top$, then $c = 0$ in $\\mathbb{R}_{\\geq 0}^{\\infty}$. The proof splits into $c = \\top$ (immediate contradiction with $N = 1$) and $0 < c < \\top$ (use `ENNReal.exists_nat_gt` to find $N > M/c$, then $M < N \\cdot c$, contradicting the bound). This is the measure-theoretic engine: it converts 'infinitely many equal contributions bounded by a finite sum' into 'each contribution is zero'.",
+    "mathContext": "In $\\mathbb{R}_{\\geq 0}^{\\infty}$: $\\forall N \\in \\mathbb{N},\\, N \\cdot c \\leq M < \\top \\implies c = 0$. Proof: if $c > 0$, then $N > M/c$ gives $N \\cdot c > M$, contradiction.",
+    "significance": "key",
+    "relatedConcepts": ["ENNReal arithmetic", "Archimedean property", "ENNReal.exists_nat_gt", "proof by contradiction"],
+    "prerequisites": ["ENNReal.pos_of_ne_zero", "ENNReal.div_lt_top", "ENNReal.div_mul_cancel₀"]
+  },
+  {
+    "id": "ann-lm-oq03-counting",
+    "proofId": "lebesgue-measure-oq-03-oq-01",
+    "range": { "startLine": 66, "endLine": 94 },
+    "type": "insight",
+    "title": "Counting Lemma: Infinitely Many Equal Disjoint Sets Force Measure Zero",
+    "content": "The heart of the impossibility proof. Given pairwise disjoint measurable sets $\\{f_n\\}$ with equal measure $\\mu(f_n) = \\mu(f_0)$, all contained in a set $S$ with $\\mu(S) < \\top$, then $\\mu(f_0) = 0$. The proof constructs a finite union $\\bigcup_{n < N} f_n \\subseteq S$ for each $N$, uses `measure_biUnion_finset` with pairwise disjointness to get $\\mu(\\bigcup) = N \\cdot \\mu(f_0)$, bounds by $\\mu(S)$, and applies the Archimedean lemma. The `calc` chain makes the argument transparent.",
+    "mathContext": "$\\mu(f_n) = c$ for all $n$, $f_n \\subseteq S$, $\\mu(S) < \\infty$, pairwise disjoint $\\implies N \\cdot c = \\sum_{n=0}^{N-1} \\mu(f_n) \\leq \\mu(S) < \\infty$ for all $N$, so $c = 0$.",
+    "significance": "key",
+    "relatedConcepts": ["measure_biUnion_finset", "PairwiseDisjoint", "countable additivity", "Finset.sum_const"],
+    "prerequisites": ["ennreal_const_le_finite_imp_zero", "measure_mono", "Finset.range"]
+  },
+  {
+    "id": "ann-lm-oq03-translation",
+    "proofId": "lebesgue-measure-oq-03-oq-01",
+    "range": { "startLine": 96, "endLine": 124 },
+    "type": "definition",
+    "title": "Translation Invariance and Equal Ball Measures",
+    "content": "Defines `IsTransInvariant μ` as $\\mu \\circ (\\cdot + v)^{-1} = \\mu$ for all $v$, then proves that translation-invariant measures assign equal measure to all balls of the same radius: $\\mu(B(x, r)) = \\mu(B(0, r))$. The proof translates by $-x$: the preimage of $B(0, r)$ under $(\\cdot + (-x))$ is $B(x, r)$. This is what makes the counting lemma applicable — all the orthonormal balls get the same measure.",
+    "mathContext": "$\\mu(B(x, r)) = \\mu(B(0, r))$ for any center $x$, since translating by $-x$ maps $B(x, r)$ to $B(0, r)$.",
+    "significance": "key",
+    "relatedConcepts": ["translation invariance", "Measure.map", "Borel measures", "Lebesgue measure property"],
+    "prerequisites": ["Measure.map_apply", "measurableSet_ball", "dist_eq_norm"]
+  },
+  {
+    "id": "ann-lm-oq03-orthoseq",
+    "proofId": "lebesgue-measure-oq-03-oq-01",
+    "range": { "startLine": 126, "endLine": 176 },
+    "type": "definition",
+    "title": "Orthonormal Sequence: Disjoint Balls in a Bounded Region",
+    "content": "Defines `OrthoSeq H` as a structure with a sequence of unit vectors that are pairwise orthogonal. Then proves two geometric facts: (1) $B(e_n, 1/3) \\subseteq B(0, 4/3)$ by the triangle inequality $\\|x\\| \\leq \\|x - e_n\\| + \\|e_n\\| < 1/3 + 1$, and (2) the balls are pairwise disjoint because $\\|e_m - e_n\\| = \\sqrt{2} > 2/3$ for distinct orthonormal vectors. The disjointness proof uses `orthonormal_dist` from the parent file to get the exact distance $\\sqrt{2}$.",
+    "mathContext": "$\\|e_m - e_n\\| = \\sqrt{2}$ for orthonormal $e_m, e_n$ ($m \\neq n$). Since $\\sqrt{2} > 2/3$, $B(e_m, 1/3) \\cap B(e_n, 1/3) = \\emptyset$. Each $B(e_n, 1/3) \\subseteq B(0, 4/3)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["orthonormal vectors", "Hilbert space geometry", "triangle inequality", "dist_triangle"],
+    "prerequisites": ["orthonormal_dist from parent file", "OrthoSeq structure", "Metric.ball"]
+  },
+  {
+    "id": "ann-lm-oq03-main",
+    "proofId": "lebesgue-measure-oq-03-oq-01",
+    "range": { "startLine": 178, "endLine": 217 },
+    "type": "insight",
+    "title": "Main Theorem: No Translation-Invariant Measure on Hilbert Space",
+    "content": "Combines all ingredients into the impossibility result: if $\\mu$ is translation-invariant with $\\mu(B(0, 4/3)) < \\top$ and $H$ admits an orthonormal sequence, then $\\mu(B(0, 1/3)) = 0$. The proof instantiates the counting lemma with $f_n = B(e_n, 1/3)$, $S = B(0, 4/3)$, supplying disjointness, containment, finite measure of $S$, and equal measures (from translation invariance). The corollary extends this to $\\mu(B(y, 1/3)) = 0$ for any center $y$ by another application of translation invariance. This means any locally finite, translation-invariant Borel measure on infinite-dimensional Hilbert space must be identically zero.",
+    "mathContext": "$\\mu(B(0, 1/3)) = 0$: apply counting lemma to $\\{B(e_n, 1/3)\\}_{n \\in \\mathbb{N}}$, which are pairwise disjoint, contained in $B(0, 4/3)$, and have equal measure $\\mu(B(0, 1/3))$ by translation invariance.",
+    "significance": "key",
+    "relatedConcepts": ["impossibility theorems", "infinite-dimensional analysis", "abstract Wiener spaces", "Gaussian measures"],
+    "prerequisites": ["zero_measure_of_infinite_disjoint", "trans_inv_ball_eq", "ortho_balls_disjoint", "ortho_ball_subset"]
+  }
+]


### PR DESCRIPTION
Enrichment pass for 3 gallery entries:

**divisibility-by-3-oq-03-oq-02** (Base-Parametrized Digital Root):
- Created 7 annotations (was empty), filled 6 sections (was empty), added conclusion

**fundamental-arithmetic-oq-02** (Failure of UFD in Z[sqrt(-5)]):
- Full enrichment: rewrote annotations from old format, added overview/sections/conclusion
- Fixes pre-existing build error (missing sections)

**central-limit-theorem-oq-01-oq-02-oq-01-oq-01** (Gaussian Characteristic Function):
- Created 6 annotations covering all parts (was empty)