### PR TITLE
Enrich: 5 proofs (Digital Root, Z[sqrt(-5)], Gaussian, Lebesgue, Liu-Montgomery)

### DIFF
--- a/src/data/proofs/erdos-65-oq-03/meta.json
+++ b/src/data/proofs/erdos-65-oq-03/meta.json
@@ -19,10 +19,97 @@
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 1,
-    "lineCount": 267
+    "lineCount": 267,
+    "assumptions": "1 axiom: Liu-Montgomery theorem (JAMS 2023) — the main bound on reciprocal cycle sums. This is a deep 43-page result using regularity and probabilistic methods.",
+    "originalContributions": [
+      "Partial harmonic sum infrastructure with key algebraic identities",
+      "Bipartite cycle reciprocal sum formula for K_{m,m}",
+      "Even/odd cycle decomposition for reciprocal sums",
+      "Tightness proof: bipartite construction achieves constant 1/2",
+      "Concrete numerical verifications for small cases"
+    ]
   },
-  "sections": [],
+  "overview": {
+    "historicalContext": "Erdős (1975) conjectured that graphs with large average degree must contain many distinct cycle lengths. Gyárfás, Komlós, and Szemerédi (1984) proved that the number of distinct cycle lengths is $\\Omega(\\log d)$, and conjectured that the sum of reciprocal cycle lengths is at least $(1/2 - o(1)) \\log d$. Liu and Montgomery resolved this conjecture in a landmark paper published in the Journal of the AMS (2023), proving the sharp constant $1/2$ using the regularity method, expander-based cycle-finding, and probabilistic techniques in a 43-page tour de force.",
+    "problemStatement": "What is the sharp constant $c$ such that every graph with average degree $d$ has $\\sum 1/|C_i| \\geq (c - o(1)) \\log d$? The answer is $c = 1/2$, achieved by complete bipartite graphs $K_{m,m}$.",
+    "proofStrategy": "The tightness proof proceeds in two parts: (1) The bipartite construction: $K_{m,m}$ has cycle lengths exactly $\\{4, 6, \\ldots, 2m\\}$, giving reciprocal sum $\\sum_{j=2}^m 1/(2j) = (1/2)(H(m) - 1) \\sim (1/2) \\ln m$. (2) The even/odd decomposition: bipartite graphs have only even cycles, and adding odd cycles can only increase the sum, so $1/2$ is tight from above.",
+    "keyInsights": [
+      "The constant 1/2 comes from the even harmonic series: bipartite graphs contribute only even cycle lengths, and Σ 1/(2j) = (1/2) Σ 1/j",
+      "Complete bipartite graphs K_{m,m} are the extremal family: they have average degree m and exactly the even cycle lengths {4,6,...,2m}",
+      "The Liu-Montgomery theorem is axiomatized because its proof requires deep tools (regularity lemma, expanders, probabilistic method) spanning 43 pages",
+      "Odd cycles only increase the reciprocal sum, so non-bipartite graphs cannot be extremal"
+    ],
+    "prerequisites": [
+      "Graph theory: SimpleGraph, average degree, cycles",
+      "Harmonic numbers and their asymptotic growth",
+      "Complete bipartite graphs"
+    ]
+  },
+  "sections": [
+    {
+      "id": "harmonic-sums",
+      "title": "Partial Harmonic Sum Infrastructure",
+      "startLine": 30,
+      "endLine": 72,
+      "summary": "Defines partial harmonic sums H(m), even harmonic sums, and proves the identity Σ 1/(2j) = (1/2)H(m).",
+      "mathContext": "H(m) = Σ_{j=1}^m 1/j. Even harmonic: Σ_{j=1}^m 1/(2j) = (1/2)H(m)."
+    },
+    {
+      "id": "bipartite-cycles",
+      "title": "Bipartite Cycle Reciprocal Sum",
+      "startLine": 74,
+      "endLine": 110,
+      "summary": "Defines the cycle reciprocal sum for K_{r,s}: even cycle lengths {4,6,...,2min(r,s)}, sum = (1/2)(H(m) - 1) for K_{m,m}.",
+      "mathContext": "Cycle lengths in K_{m,m}: {4,6,...,2m}. Sum: Σ_{j=2}^m 1/(2j) = (1/2)(H(m) - 1)."
+    },
+    {
+      "id": "liu-montgomery",
+      "title": "Liu-Montgomery Theorem (Axiomatized)",
+      "startLine": 112,
+      "endLine": 137,
+      "summary": "States the Liu-Montgomery bound as an axiom: for average degree d ≥ 2, the reciprocal cycle sum is ≥ (1/2 - ε) log d for large d.",
+      "mathContext": "Σ 1/|C_i| ≥ (1/2 - ε) log d for any ε > 0 and d sufficiently large (JAMS 2023)."
+    },
+    {
+      "id": "decomposition",
+      "title": "Odd vs Even Cycle Decomposition",
+      "startLine": 139,
+      "endLine": 181,
+      "summary": "Decomposes the cycle reciprocal sum into even and odd contributions. Bipartite graphs have only even cycles; odd cycles add strictly positive contributions.",
+      "mathContext": "Σ 1/|C| = Σ_{even} 1/(2j) + Σ_{odd} 1/(2j+1), with Σ_{odd} ≥ 0."
+    },
+    {
+      "id": "tightness",
+      "title": "Tightness: Why 1/2 Is Sharp",
+      "startLine": 183,
+      "endLine": 267,
+      "summary": "Proves that the bipartite construction achieves constant 1/2, with concrete verifications for K_{4,4}.",
+      "mathContext": "K_{m,m} gives Σ 1/|C| = (1/2)(H(m) - 1) ~ (1/2) ln m, achieving the constant 1/2."
+    }
+  ],
+  "conclusion": {
+    "summary": "Formalizes the sharp constant 1/2 in the Erdős cycle length problem: the sum of reciprocal cycle lengths in graphs with average degree d is at least (1/2 - o(1)) log d, and this is tight via K_{m,m}. The Liu-Montgomery theorem (JAMS 2023) is axiomatized; the tightness argument and harmonic sum infrastructure are fully proved.",
+    "implications": "This resolves a conjecture from extremal graph theory that stood open for nearly 40 years. The result shows that bipartite graphs are extremal for the cycle reciprocal sum, giving a clean characterization of which graphs have the fewest distinct cycle lengths relative to their density.",
+    "openQuestions": [
+      "Can the Liu-Montgomery theorem be fully proved in Lean, including the regularity lemma and expander-based cycle-finding?",
+      "What is the exact minimum reciprocal cycle sum for graphs with n vertices and m edges?",
+      "Does an analogous result hold for directed graphs or hypergraphs?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "erdos-65",
+      "relationship": "parent-problem",
+      "description": "Parent Erdős problem #65 on cycle lengths in graphs with large average degree"
+    }
+  ],
   "leanFile": {
-    "axiomCount": 1
+    "imports": ["Mathlib", "Proofs.LebesgueMeasureOQ03"],
+    "namespace": "Erdos65OQ03",
+    "lineCount": 267,
+    "axiomCount": 1,
+    "theoremCount": 15,
+    "definitionCount": 5,
+    "sorries": 0
   }
 }


### PR DESCRIPTION
Enrichment batch for 5 gallery entries:

- **divisibility-by-3-oq-03-oq-02** — 7 annotations, 6 sections, conclusion (all new)
- **fundamental-arithmetic-oq-02** — Full enrichment from quality 0, fixes build error
- **central-limit-theorem-oq-01-oq-02-oq-01-oq-01** — 6 annotations (was empty)
- **lebesgue-measure-oq-03-oq-01** — 5 annotations (was empty)
- **erdos-65-oq-03** — 5 sections, overview, conclusion (was missing)