### PR TITLE
Fix: update sperner-ndim-oq-03 status from formalized to verified

### DIFF
--- a/src/data/proofs/sperner-ndim-oq-03/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Sperner (1928), Brouwer (1911)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Brouwer_fixed-point_theorem",
     "date": "1928",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/SpernerNDimOQ03.lean",
     "tags": [
       "combinatorics",


### PR DESCRIPTION
## Fix

Updated \`sperner-ndim-oq-03\` status from \`formalized\` to \`verified\`.

## Evidence

- Lean file: \`Proofs/SpernerNDimOQ03.lean\`  
- Real sorry count: 0 (verified by comment-stripping regex)
- Real axiom count: 0 (no \`axiom\` declarations)
- Badge was already \`verified\` — status field was lagging behind

The \`status\` field inconsistency with the \`badge\` field was caught by
a badge/status consistency check.

---
Automated fix by lean-mechanic agent.