### PR TITLE
fix(build): apply 'as unknown as' cast to 3 more index.ts files missing sections

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02/index.ts
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02/index.ts
@@ -4,7 +4,7 @@ import annotationsJson from './annotations.json'
 import tacticStatesJson from './tacticStates.json'
 import sourceRaw from '../../../../proofs/Proofs/CantorDiagonalizationOQ01OQ01OQ02.lean?raw'
 
-const meta = metaJson as {
+const meta = metaJson as unknown as {
   id: string
   title: string
   slug: string

--- a/src/data/proofs/erdos-1179-oq-01/index.ts
+++ b/src/data/proofs/erdos-1179-oq-01/index.ts
@@ -2,7 +2,7 @@ import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOvervi
 import metaJson from './meta.json'
 
 // Type assertion for JSON import
-const meta = metaJson as {
+const meta = metaJson as unknown as {
   id: string
   title: string
   slug: string

--- a/src/data/proofs/erdos-848-oq-01/index.ts
+++ b/src/data/proofs/erdos-848-oq-01/index.ts
@@ -1,7 +1,7 @@
 import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
 import metaJson from './meta.json'
 
-const meta = metaJson as {
+const meta = metaJson as unknown as {
   id: string; title: string; slug: string; description: string
   meta: ProofMeta; sections: ProofSection[]
   overview?: ProofOverview; conclusion?: ProofConclusion


### PR DESCRIPTION
## Summary

- Extends the fix from #10425 to 3 additional `index.ts` files that had the same TS2352 error
- `cantor-diagonalization-oq-01-oq-01-oq-02`, `erdos-1179-oq-01`, and `erdos-848-oq-01` all had `metaJson as { ... sections: ProofSection[] }` without the `unknown` intermediate cast
- These were caught during the deployer's build run (build failed after merging #10426)

## Test plan

- [ ] `pnpm build` succeeds without TS2352 errors on affected files

🤖 Generated with [Claude Code](https://claude.com/claude-code)