### PR TITLE
Fix: correct axiomCount in 5 gallery proofs (overcounted by 1-3)

### DIFF
--- a/src/data/proofs/erdos-504/meta.json
+++ b/src/data/proofs/erdos-504/meta.json
@@ -39,9 +39,9 @@
     "erdosNumber": 504,
     "erdosUrl": "https://erdosproblems.com/504",
     "erdosProblemStatus": "solved",
-    "axiomCount": 5,
+    "axiomCount": 4,
     "lineCount": 217,
-    "assumptions": "5 axioms: sendov_upper, sendov_lower, erdos_szekeres_conjecture_false, isConvexPosition. No sorries.",
+    "assumptions": "4 axioms: sendov_upper, sendov_lower, erdos_szekeres_conjecture_false, isConvexPosition. No sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-529/meta.json
+++ b/src/data/proofs/erdos-529/meta.json
@@ -106,9 +106,9 @@
       "erdos_529_summary theorem: combines established results",
       "erdos_529 theorem: combines Hara-Slade + sub-ballistic + Question 2"
     ],
-    "axiomCount": 7,
+    "axiomCount": 5,
     "lineCount": 306,
-    "assumptions": "7 axioms: tendsTo (convergence predicate), haraSlade_five_dim (5D self-avoiding walk result), duminilCopin_subBallistic (sub-ballistic diffusivity), conjecture_implies_question1, question2_high_dim. 0 sorries."
+    "assumptions": "5 axioms: tendsTo (convergence predicate), haraSlade_five_dim (5D self-avoiding walk result), duminilCopin_subBallistic (sub-ballistic diffusivity), conjecture_implies_question1, question2_high_dim. 0 sorries."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #529: Self-Avoiding Walks**\n\nSelf-avoiding walks (SAWs) were first studied systematically by the chemist Paul Flory in 1949 as models for linear polymers in good solvents. Flory's mean-field prediction $\\nu = 3/(d+2)$ for the end-to-end distance exponent was remarkably accurate, setting the stage for decades of rigorous mathematical work.\n\nThe first rigorous high-dimensional result came from **Gordon Slade** (1987), who used the **lace expansion** — a perturbative technique introduced by Brydges and Spencer (1985) — to prove $d_k(n) \\sim D\\sqrt{n}$ for sufficiently large $k$. **Takashi Hara** and Slade (1991-92) refined this to all $k \\ge 5$, using computer-assisted bounds on the lace expansion coefficients. Their work established that mean-field behavior ($\\nu = 1/2$) holds above the upper critical dimension $d_c = 4$.\n\nThe low-dimensional case proved far more resistant. **Bernard Nienhuis** (1982) predicted $\\nu = 3/4$ in 2D using the exact solution of an O(n) loop model on the honeycomb lattice, and conformal field theory arguments connect 2D SAW to the SLE$_{8/3}$ process (Lawler, Schramm, Werner). The landmark result of **Hugo Duminil-Copin** and **Alan Hammond** (2013) proved $d_2(n) = o(n)$ (sub-ballistic growth) using a bridge decomposition argument, but the full Question 1 ($d_2(n)/\\sqrt{n} \\to \\infty$) remains open.\n\nThe definitive reference is the monograph *The Self-Avoiding Walk* by Madras and Slade (1993, 2nd ed. 2013). **Nathan Clisby** (2010) provided the most precise numerical estimates: $\\nu_3 \\approx 0.5876 \\pm 0.0002$.",

--- a/src/data/proofs/erdos-756/meta.json
+++ b/src/data/proofs/erdos-756/meta.json
@@ -76,9 +76,9 @@
       "multiplicity_trivial_upper theorem: multiplicity ≤ n²",
       "erdos_756 theorem: main result"
     ],
-    "axiomCount": 5,
+    "axiomCount": 2,
     "lineCount": 268,
-    "assumptions": "5 axioms: hopf_pannwitz (largest distance multiplicity ≤ n), bhowmick_main (⌊n/4⌋ rich distances for large n). No sorries."
+    "assumptions": "2 axioms: hopf_pannwitz (largest distance multiplicity ≤ n), bhowmick_main (⌊n/4⌋ rich distances for large n). No sorries."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #756: Rich Distances in the Plane**\n\nThis problem, asked by Erdős and Pach, concerns distance multiplicities in finite point sets in the plane.\n\n**Historical Timeline:**\n- **1934:** Hopf and Pannwitz proved the largest distance among n points occurs at most n times (this is tight for regular polygons)\n- **Erdős-Pach:** Asked whether ALL other distances can have multiplicity > n (the \"strong\" form)\n- **2024:** Bhowmick answered affirmatively with an explicit construction achieving ⌊n/4⌋ rich distances\n- **2025:** Clemen, Dumitrescu, and Liu studied the square grid, finding superpolynomial richness\n\n**The Surprise:**\nDespite the classical Hopf-Pannwitz constraint on the largest distance, Bhowmick showed that MANY distances can be \"rich\" (occurring more than n times). The phenomenon is even stronger on structured sets like square grids.",

--- a/src/data/proofs/erdos-96/meta.json
+++ b/src/data/proofs/erdos-96/meta.json
@@ -55,9 +55,9 @@
       "erdos_96_summary: proved conjunction of bounds"
     ],
     "dateAdded": "2026-01-19",
-    "axiomCount": 3,
+    "axiomCount": 2,
     "lineCount": 285,
-    "assumptions": "3 axioms: furedi_bound, edelsbrunner_hajnal_construction. No sorries."
+    "assumptions": "2 axioms: furedi_bound, edelsbrunner_hajnal_construction. No sorries."
   },
   "overview": {
     "historicalContext": "Erdős and Moser conjectured that a convex n-gon has O(n) unit distance pairs. Despite progress from O(n log n) bounds (Füredi 1990, Aggarwal 2015), the conjecture remains open. The Edelsbrunner-Hajnal (1991) lower bound of 2n - 7 suggests the Erdős-Fishburn conjecture of exactly 2n may be tight. The unit distance problem for general point sets (Erdős Problem #89, 1946) asks for the maximum number of unit distance pairs among n points in the plane, with best known bounds Ω(n^{1+c/log log n}) and O(n^{4/3}). The convex restriction dramatically simplifies the problem: in a convex polygon, each distance can appear at most twice on each side, giving much sharper bounds.",

--- a/src/data/proofs/hilbert-21/meta.json
+++ b/src/data/proofs/hilbert-21/meta.json
@@ -36,9 +36,9 @@
     ],
     "dateAdded": "2025-12-29",
     "hilbertNumber": 21,
-    "axiomCount": 4,
+    "axiomCount": 3,
     "lineCount": 386,
-    "assumptions": "4 axioms: plemelj_theorem_irreducible, bolibrukh_counterexample, realization_criterion. No sorries.",
+    "assumptions": "3 axioms: plemelj_theorem_irreducible, bolibrukh_counterexample, realization_criterion. No sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Fix

Correct stale `axiomCount` values in 5 gallery proof meta.json files where the count exceeded the actual number of `axiom` declarations in the Lean source.

## Evidence

Scan methodology: strip block comments (`/- ... -/`) from each Lean file, then count `^axiom \w` declarations. Cross-reference with `meta.axiomCount` and `leanFile.axiomCount`.

| Proof | Before | After | Actual axioms in Lean file |
|-------|--------|-------|---------------------------|
| `erdos-529` | 7 | 5 | tendsTo, haraSlade_five_dim, duminilCopin_subBallistic, conjecture_implies_question1, question2_high_dim |
| `erdos-756` | 5 | 2 | hopf_pannwitz, bhowmick_main |
| `erdos-504` | 5 | 4 | sendov_upper, sendov_lower, erdos_szekeres_conjecture_false, isConvexPosition |
| `erdos-96` | 3 | 2 | furedi_bound, edelsbrunner_hajnal_construction |
| `hilbert-21` | 4 | 3 | plemelj_theorem_irreducible, bolibrukh_counterexample, realization_criterion |

All proofs retain `axiomatized` status (open mathematical problems). The `assumptions` field text was also updated to match the corrected counts.

**Build**: `pnpm build` passes ✓

---
Automated fix by lean-mechanic agent.