### PR TITLE
Fix: correct sorry counts and verified status in 50 gallery proofs

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -19,7 +19,7 @@
       "elementary-symmetric-polynomials"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Real.geom_mean_le_arith_mean_weighted",

--- a/src/data/proofs/angle-trisection-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02/meta.json
@@ -19,7 +19,7 @@
       "constructibility"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "IsPGroup",

--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Hurwitz (1901), formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Isoperimetric_inequality",
     "date": "1901",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/AreaOfCircleOQ01OQ03.lean",
     "tags": [
       "analysis",
@@ -20,7 +20,7 @@
       "isoperimetric"
     ],
     "badge": "mathlib",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Real.pi_lt_four",

--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
@@ -18,11 +18,11 @@
       "research"
     ],
     "badge": "formalized",
-    "sorries": 3,
+    "sorries": 5,
     "dateAdded": "2026-04-12",
     "axiomCount": 0,
     "lineCount": 199,
-    "assumptions": "0 axioms. 3 sorries: recurrence relation, growth bound, main theorem. Infrastructure scaffold for full Apéry proof.",
+    "assumptions": "0 axioms. 5 sorries: recurrence relation, growth bound, main theorem. Infrastructure scaffold for full Apéry proof.",
     "mathlib_version": "4.26.0",
     "originalContributions": [
       "Defined Apéry numbers aperyB(n) = ∑ C(n,k)²C(n+k,k)² as a computable ℕ-valued function",

--- a/src/data/proofs/basel-problem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "formalized in Lean 4",
     "sourceUrl": "https://en.wikipedia.org/wiki/Ap%C3%A9ry%27s_theorem",
     "date": "2026-04-04",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/BaselProblemOQ01OQ03.lean",
     "tags": [
       "number-theory",
@@ -16,7 +16,7 @@
       "irrationality"
     ],
     "badge": "verified",
-    "sorries": 1,
+    "sorries": 0,
     "assumptions": "0 sorries, 0 axioms. All theorems are fully proved. The main results — apery_criterion, geometric_decay_tendsto, and all conditional theorems — contain no mathematical assumptions beyond the hypotheses stated.",
     "dateAdded": "2026-04-04",
     "axiomCount": 0,

--- a/src/data/proofs/bezout-identity-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/BezoutIdentityOQ01.lean",
     "tags": [
       "number-theory",
@@ -16,7 +16,7 @@
       "gcd"
     ],
     "badge": "original",
-    "sorries": 1,
+    "sorries": 0,
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified with a fully computable implementation.",

--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -14,7 +14,7 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 19,
     "assumptions": "19 axiom declarations encoding: (1) L-function analytic continuation and functional equation, (2) Hasse bound a_p^2 <= 4p, (3) BSD conjecture proven cases (Kolyvagin rank 0, Gross-Zagier+Kolyvagin rank 1), (4) parity conjecture (Dokchitsers), (5) L-values and ranks for specific curves, (6) Sha structure, (7) Elkies rank record, (8) Greenberg-Stevens theorem, (9) regulator positivity. Previously 21 axioms: BSD_CM_rank_zero was proved redundant (subsumed by Kolyvagin general result), gross_zagier_formula_detail was dead code (captured by GrossZagierData structure). 0 sorries: regulator_rank_one_is_height proved by constructing CanonicalHeight h with h.height x = R·x² and generator g = 1.",
     "mathlibDependencies": [

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "birthday-problem-oq-03-oq-01-oq-02",
-  "title": "k=3 Birthday Threshold Asymptotics: n*(d) ~ (6d\u00b2 ln 2)^{1/3}",
+  "title": "k=3 Birthday Threshold Asymptotics: n*(d) ~ (6d² ln 2)^{1/3}",
   "slug": "birthday-problem-oq-03-oq-01-oq-02",
-  "description": "Proves that the k=3 birthday threshold satisfies asympThreshold(d) = (6d\u00b2 ln 2)^{1/3}, with exact scaling ratio asympThreshold(d)/d^{2/3} = (6 ln 2)^{1/3}. Establishes order bounds d^{2/3} \u2264 n*(d) \u2264 3d^{2/3}, numerical bounds 82 < asympThreshold(365) < 83, and that the k=3 threshold exceeds the classical k=2 threshold \u221a(2d ln 2) for all d \u2265 1. Also proves the general scaling exponent (k-1)/k for k-way coincidences.",
+  "description": "Proves that the k=3 birthday threshold satisfies asympThreshold(d) = (6d² ln 2)^{1/3}, with exact scaling ratio asympThreshold(d)/d^{2/3} = (6 ln 2)^{1/3}. Establishes order bounds d^{2/3} ≤ n*(d) ≤ 3d^{2/3}, numerical bounds 82 < asympThreshold(365) < 83, and that the k=3 threshold exceeds the classical k=2 threshold √(2d ln 2) for all d ≥ 1. Also proves the general scaling exponent (k-1)/k for k-way coincidences.",
   "meta": {
     "author": "researcher-7",
     "date": "2026-04-04",
@@ -20,32 +20,32 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 1,
-    "assumptions": "1 axiom: poisson_approx_birthday3 (Chen-Stein method: P(no triple) \u2192 exp(-C(n,3)/d\u00b2) as d \u2192 \u221e). All other theorems fully proved including choose3_mul_six (Pascal induction, 0 sorries).",
+    "assumptions": "1 axiom: poisson_approx_birthday3 (Chen-Stein method: P(no triple) → exp(-C(n,3)/d²) as d → ∞). All other theorems fully proved including choose3_mul_six (Pascal induction, 0 sorries).",
     "dateAdded": "2026-04-04",
     "lineCount": 420,
     "theoremCount": 19,
     "definitionCount": 3,
     "originalContributions": [
-      "asympThreshold: exact definition (6d\u00b2 ln 2)^{1/3} using Real.rpow",
-      "asympThreshold_cubed: (asympThreshold d)\u00b3 = 6d\u00b2 ln 2 (PROVED)",
+      "asympThreshold: exact definition (6d² ln 2)^{1/3} using Real.rpow",
+      "asympThreshold_cubed: (asympThreshold d)³ = 6d² ln 2 (PROVED)",
       "asympThreshold_ratio: asympThreshold(d)/d^{2/3} = (6 ln 2)^{1/3} (PROVED)",
-      "asympThreshold_order: d^{2/3} \u2264 asympThreshold(d) \u2264 3d^{2/3} (PROVED)",
+      "asympThreshold_order: d^{2/3} ≤ asympThreshold(d) ≤ 3d^{2/3} (PROVED)",
       "asympThreshold_d365_bounds: 82 < asympThreshold(365) < 83 (PROVED)",
-      "k3_threshold_gt_k2: asympThreshold(d) > k2Threshold(d) for all d \u2265 1 (PROVED)",
+      "k3_threshold_gt_k2: asympThreshold(d) > k2Threshold(d) for all d ≥ 1 (PROVED)",
       "general_threshold_exponent: scaling exponent is (k-1)/k for k-way coincidences"
     ]
   },
   "overview": {
-    "historicalContext": "The birthday problem asks: how many people must share a room before the probability of a k-way birthday coincidence exceeds 50%? For k=2 (any shared birthday), the classical answer is n*(d) \u2248 \u221a(2d ln 2) \u2248 23 for d=365. For k=3 (three people sharing a birthday), the threshold is higher: n*(d) \u2248 (6d\u00b2 ln 2)^{1/3} \u2248 82\u201384 for d=365 (the exact value is 88, a ~7% discrepancy due to higher-order Poisson correction terms).\n\nThe asymptotic (6d\u00b2 ln 2)^{1/3} follows from the Poisson approximation: the expected number of 3-way coincidences is E = C(n,3)/d\u00b2, and the threshold where E \u2248 ln 2 gives P(\u22651 triple) \u2248 1 - e^{-ln2} = 1/2. Setting C(n,3)/d\u00b2 \u2248 n\u00b3/6d\u00b2 = ln 2 gives n \u2248 (6d\u00b2 ln 2)^{1/3}.\n\nDiaconis and Mosteller (1989) analyzed these higher-order coincidences statistically. The exponent (k-1)/k is a general pattern: for k-way coincidences, n*(d) ~ (k! d^{k-1} ln 2)^{1/k}, giving exponent (k-1)/k \u2192 1 as k \u2192 \u221e.",
-    "problemStatement": "**OQ-02 of birthday-problem-oq-03-oq-01**\n\nProve that the threshold n*(d) for k=3 birthday coincidences satisfies:\n\n1. The defining equation: n*(d) = (6d\u00b2 ln 2)^{1/3}\n2. Exact scaling ratio: n*(d) / d^{2/3} = (6 ln 2)^{1/3}\n3. Order bounds: d^{2/3} \u2264 n*(d) \u2264 3d^{2/3}\n4. Numerical value for d=365: 82 < n*(365) < 83\n5. Comparison with k=2: n*(d) > \u221a(2d ln 2) for all d \u2265 1\n6. General exponent: k-way threshold scales as d^{(k-1)/k}",
-    "proofStrategy": "The proof proceeds by defining asympThreshold d = (6d\u00b2 ln 2)^{1/3} using Mathlib's Real.rpow (real exponentiation), then proving each property:\n\n1. **Cubed identity**: (asympThreshold d)\u00b3 = 6d\u00b2 ln 2 via Real.rpow_natCast and power arithmetic.\n\n2. **Exact ratio**: asympThreshold(d)/d^{2/3} = (6 ln 2)^{1/3} via Real.mul_rpow (splitting the product under the cube root) and Real.rpow_mul (combining d\u00b2 with d^{2/3} = d^{2\u00b7(1/3)}).\n\n3. **Order bounds**: Lower bound 1 \u2264 (6 ln 2)^{1/3} via ln 2 > 0.69 > 1/6; upper bound (6 ln 2)^{1/3} \u2264 3 via 6 ln 2 \u2264 27 = 3\u00b3. Both use Real.rpow_le_rpow with Taylor bounds for ln 2.\n\n4. **Numerical bounds for d=365**: 82 < asympThreshold(365) < 83 via norm_num + rpow bounds. Uses 4-term Taylor series for exp(0.7152) > 2 to bound log 2 < 0.7152.\n\n5. **k=2 comparison**: asympThreshold(d) > k2Threshold(d) reduces to comparing 6th powers: (6d\u00b2 ln 2)\u00b2 vs (2d ln 2)\u00b3. This is 36d\u2074(ln2)\u00b2 vs 8d\u00b3(ln2)\u00b3, and 36d > 8 ln 2 for d \u2265 1 gives the result.\n\n6. **Poisson connection**: Axiomatized via Chen-Stein method (Arratia-Goldstein-Gordon 1989).",
+    "historicalContext": "The birthday problem asks: how many people must share a room before the probability of a k-way birthday coincidence exceeds 50%? For k=2 (any shared birthday), the classical answer is n*(d) ≈ √(2d ln 2) ≈ 23 for d=365. For k=3 (three people sharing a birthday), the threshold is higher: n*(d) ≈ (6d² ln 2)^{1/3} ≈ 82–84 for d=365 (the exact value is 88, a ~7% discrepancy due to higher-order Poisson correction terms).\n\nThe asymptotic (6d² ln 2)^{1/3} follows from the Poisson approximation: the expected number of 3-way coincidences is E = C(n,3)/d², and the threshold where E ≈ ln 2 gives P(≥1 triple) ≈ 1 - e^{-ln2} = 1/2. Setting C(n,3)/d² ≈ n³/6d² = ln 2 gives n ≈ (6d² ln 2)^{1/3}.\n\nDiaconis and Mosteller (1989) analyzed these higher-order coincidences statistically. The exponent (k-1)/k is a general pattern: for k-way coincidences, n*(d) ~ (k! d^{k-1} ln 2)^{1/k}, giving exponent (k-1)/k → 1 as k → ∞.",
+    "problemStatement": "**OQ-02 of birthday-problem-oq-03-oq-01**\n\nProve that the threshold n*(d) for k=3 birthday coincidences satisfies:\n\n1. The defining equation: n*(d) = (6d² ln 2)^{1/3}\n2. Exact scaling ratio: n*(d) / d^{2/3} = (6 ln 2)^{1/3}\n3. Order bounds: d^{2/3} ≤ n*(d) ≤ 3d^{2/3}\n4. Numerical value for d=365: 82 < n*(365) < 83\n5. Comparison with k=2: n*(d) > √(2d ln 2) for all d ≥ 1\n6. General exponent: k-way threshold scales as d^{(k-1)/k}",
+    "proofStrategy": "The proof proceeds by defining asympThreshold d = (6d² ln 2)^{1/3} using Mathlib's Real.rpow (real exponentiation), then proving each property:\n\n1. **Cubed identity**: (asympThreshold d)³ = 6d² ln 2 via Real.rpow_natCast and power arithmetic.\n\n2. **Exact ratio**: asympThreshold(d)/d^{2/3} = (6 ln 2)^{1/3} via Real.mul_rpow (splitting the product under the cube root) and Real.rpow_mul (combining d² with d^{2/3} = d^{2·(1/3)}).\n\n3. **Order bounds**: Lower bound 1 ≤ (6 ln 2)^{1/3} via ln 2 > 0.69 > 1/6; upper bound (6 ln 2)^{1/3} ≤ 3 via 6 ln 2 ≤ 27 = 3³. Both use Real.rpow_le_rpow with Taylor bounds for ln 2.\n\n4. **Numerical bounds for d=365**: 82 < asympThreshold(365) < 83 via norm_num + rpow bounds. Uses 4-term Taylor series for exp(0.7152) > 2 to bound log 2 < 0.7152.\n\n5. **k=2 comparison**: asympThreshold(d) > k2Threshold(d) reduces to comparing 6th powers: (6d² ln 2)² vs (2d ln 2)³. This is 36d⁴(ln2)² vs 8d³(ln2)³, and 36d > 8 ln 2 for d ≥ 1 gives the result.\n\n6. **Poisson connection**: Axiomatized via Chen-Stein method (Arratia-Goldstein-Gordon 1989).",
     "keyInsights": [
-      "The threshold condition E(n,d) = C(n,3)/d\u00b2 \u2248 ln 2 leads to n\u00b3/6d\u00b2 \u2248 ln 2 by the upper bound C(n,3) \u2264 n\u00b3/6, giving n \u2248 (6d\u00b2 ln 2)^{1/3} \u2014 the exact scaling",
+      "The threshold condition E(n,d) = C(n,3)/d² ≈ ln 2 leads to n³/6d² ≈ ln 2 by the upper bound C(n,3) ≤ n³/6, giving n ≈ (6d² ln 2)^{1/3} — the exact scaling",
       "Real.rpow_le_rpow requires the exponent argument to be passed separately (as `by norm_num`) rather than inline in a single `exact`, to avoid Lean metavariable issues",
-      "The comparison asympThreshold > k2Threshold amounts to showing (6d\u00b2 ln 2)^{1/3} > (2d ln 2)^{1/2}, which is easier to verify by raising both sides to the 6th power and using d \u2265 1",
-      "Taylor bounds for log 2: 4-term Taylor series at x=0.7152 gives exp(0.7152) > 2.032 > 2, so log 2 < 0.7152; combined with 0.7152 < 95284/133225 = C(84,3)/365\u00b2, this proves the 84-person threshold crossover",
+      "The comparison asympThreshold > k2Threshold amounts to showing (6d² ln 2)^{1/3} > (2d ln 2)^{1/2}, which is easier to verify by raising both sides to the 6th power and using d ≥ 1",
+      "Taylor bounds for log 2: 4-term Taylor series at x=0.7152 gives exp(0.7152) > 2.032 > 2, so log 2 < 0.7152; combined with 0.7152 < 95284/133225 = C(84,3)/365², this proves the 84-person threshold crossover",
       "The general k-way exponent (k-1)/k follows directly from the formula n*(d) ~ (k! d^{k-1} ln 2)^{1/k}, where the d-exponent is (k-1)/k"
     ],
     "prerequisites": [
@@ -57,12 +57,12 @@
     ]
   },
   "conclusion": {
-    "summary": "This file formalizes the k=3 birthday threshold asymptotics in Lean 4. The key result is asympThreshold(d) = (6d\u00b2 ln 2)^{1/3}, proved from the expected-triples formula E(n,d) = C(n,3)/d\u00b2. The exact scaling ratio, order bounds, numerical bounds for d=365, and comparison with the k=2 threshold are all fully proved. The Poisson approximation (connecting the asymptotic to the actual probability) is axiomatized.",
-    "implications": "**Connection to parent proofs**: The parent (birthday-problem-oq-03-oq-01) provides the extension-counting framework and exact threshold n*(365) = 88. This file shows the asymptotic \u2248 82\u201384 differs by ~7% from the exact value, illustrating the error in the leading-term Poisson approximation.\\n\\n**General k-way scaling**: The method generalizes: for k-way coincidences, E(n,d) = C(n,k)/d^{k-1} \u2248 n^k/(k! d^{k-1}), giving threshold n*(d) ~ (k! d^{k-1} ln 2)^{1/k} with exponent (k-1)/k. This is proved in general_threshold_exponent.\\n\\n**Resolving the Poisson sorry**: The Chen-Stein method (Arratia-Goldstein-Gordon 1989) gives total variation bounds between the triple-coincidence count and a Poisson(C(n,3)/d\u00b2) variable. The main missing ingredient in Lean is a formalization of the Chen-Stein lemma for positively associated indicator random variables.",
+    "summary": "This file formalizes the k=3 birthday threshold asymptotics in Lean 4. The key result is asympThreshold(d) = (6d² ln 2)^{1/3}, proved from the expected-triples formula E(n,d) = C(n,3)/d². The exact scaling ratio, order bounds, numerical bounds for d=365, and comparison with the k=2 threshold are all fully proved. The Poisson approximation (connecting the asymptotic to the actual probability) is axiomatized.",
+    "implications": "**Connection to parent proofs**: The parent (birthday-problem-oq-03-oq-01) provides the extension-counting framework and exact threshold n*(365) = 88. This file shows the asymptotic ≈ 82–84 differs by ~7% from the exact value, illustrating the error in the leading-term Poisson approximation.\\n\\n**General k-way scaling**: The method generalizes: for k-way coincidences, E(n,d) = C(n,k)/d^{k-1} ≈ n^k/(k! d^{k-1}), giving threshold n*(d) ~ (k! d^{k-1} ln 2)^{1/k} with exponent (k-1)/k. This is proved in general_threshold_exponent.\\n\\n**Resolving the Poisson sorry**: The Chen-Stein method (Arratia-Goldstein-Gordon 1989) gives total variation bounds between the triple-coincidence count and a Poisson(C(n,3)/d²) variable. The main missing ingredient in Lean is a formalization of the Chen-Stein lemma for positively associated indicator random variables.",
     "openQuestions": [
       "Formalize the Chen-Stein method to prove poisson_approx_birthday3 from first principles, removing the axiom",
-      "Compute the second-order correction: the exact threshold n*(d) = (6d\u00b2 ln 2)^{1/3} \u00b7 (1 + O(ln(d)/d^{1/3})), quantifying the 7% error for d=365",
-      "Generalize asympThreshold to general k: define kThreshold k d = (k! \u00b7 d^{k-1} \u00b7 ln 2)^{1/k} and prove the same scaling properties"
+      "Compute the second-order correction: the exact threshold n*(d) = (6d² ln 2)^{1/3} · (1 + O(ln(d)/d^{1/3})), quantifying the 7% error for d=365",
+      "Generalize asympThreshold to general k: define kThreshold k d = (k! · d^{k-1} · ln 2)^{1/k} and prove the same scaling properties"
     ]
   },
   "crossReferences": [
@@ -94,42 +94,42 @@
   "sections": [
     {
       "id": "choose3-bounds",
-      "title": "\u00a71. C(n,3) Formula and Bounds",
+      "title": "§1. C(n,3) Formula and Bounds",
       "summary": "Binomial coefficient C(n,3) formula and asymptotic bounds used throughout.",
       "startLine": 52,
       "endLine": 110
     },
     {
       "id": "expected-triples",
-      "title": "\u00a72. Expected Number of Triples",
+      "title": "§2. Expected Number of Triples",
       "summary": "Expected number of birthday triples in n people with d possible birthdays.",
       "startLine": 108,
       "endLine": 130
     },
     {
       "id": "asymp-threshold",
-      "title": "\u00a73. Asymptotic Threshold Definition and Properties",
-      "summary": "The asymptotic threshold asympThreshold d = (6d\u00b2 ln 2)^{1/3} with proved order bounds.",
+      "title": "§3. Asymptotic Threshold Definition and Properties",
+      "summary": "The asymptotic threshold asympThreshold d = (6d² ln 2)^{1/3} with proved order bounds.",
       "startLine": 130,
       "endLine": 200
     },
     {
       "id": "numerical",
-      "title": "\u00a74. Numerical Verification for d=365",
+      "title": "§4. Numerical Verification for d=365",
       "summary": "Exact numerical verification of the threshold crossover at n=83/84 for d=365.",
       "startLine": 200,
       "endLine": 295
     },
     {
       "id": "poisson",
-      "title": "\u00a75. Poisson Approximation (Axiom)",
+      "title": "§5. Poisson Approximation (Axiom)",
       "summary": "Chen-Stein Poisson approximation axiom connecting expected triples to actual probability.",
       "startLine": 294,
       "endLine": 315
     },
     {
       "id": "k2-comparison",
-      "title": "\u00a76. k=3 vs k=2 Threshold Comparison",
+      "title": "§6. k=3 vs k=2 Threshold Comparison",
       "summary": "The k=3 threshold grows as d^{2/3} while the k=2 threshold grows as d^{1/2}; k=3 threshold exceeds k=2.",
       "startLine": 310,
       "endLine": 420

--- a/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Barbier (1860); Lean formalization 2026",
     "sourceUrl": "https://en.wikipedia.org/wiki/Buffon%27s_noodle",
     "date": "1860",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/BuffonsNeedleOQ01OQ01.lean",
     "tags": [
       "probability",
@@ -21,7 +21,7 @@
       "open-question-resolved"
     ],
     "badge": "original",
-    "sorries": 5,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "intervalIntegral.integral_comp_add_right",

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-incomplete-01/meta.json
@@ -7,7 +7,7 @@
     "author": "researcher-3",
     "sourceUrl": "https://en.wikipedia.org/wiki/Lawvere%27s_fixed-point_theorem",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CantorDiagonalizationOQ03OQ01Incomplete01.lean",
     "tags": [
       "set-theory",
@@ -21,7 +21,7 @@
       "research"
     ],
     "badge": "original",
-    "sorries": 7,
+    "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. The categorical Lawvere theorem is fully proved by reduction to lawvere_abstract. The EvalStructure construction is the key bridge.",
     "originalContributions": [

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Lawvere%27s_fixed-point_theorem",
     "date": "1969 (Lawvere; formalized 2026)",
-    "status": "formalized",
+    "status": "verified",
     "tags": [
       "set-theory",
       "category-theory",
@@ -18,7 +18,7 @@
     ],
     "proofRepoPath": "Proofs/CantorDiagonalizationOQ03OQ01.lean",
     "badge": "original",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Function.Surjective",

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Nonderogatory_matrix",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean",
     "tags": [
       "linear-algebra",
@@ -18,7 +18,7 @@
       "research"
     ],
     "badge": "original",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "minpoly.aeval",

--- a/src/data/proofs/cevas-theorem-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius",
     "sourceUrl": "https://en.wikipedia.org/wiki/Ceva%27s_theorem",
     "date": "2026-02-15",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CevasTheoremOQ01.lean",
     "tags": [
       "geometry",
@@ -18,7 +18,7 @@
       "routh-theorem"
     ],
     "badge": "original",
-    "sorries": 1,
+    "sorries": 0,
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",

--- a/src/data/proofs/chinese-remainder-non-coprime-oq-03/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-03/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/ChineseRemainderNonCoprimeOQ03.lean",
     "tags": [
       "number-theory",
@@ -16,7 +16,7 @@
       "gcd-lcm"
     ],
     "badge": "original",
-    "sorries": 1,
+    "sorries": 0,
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified. (Previously had 1 axiom gcd_lcm_distrib, later replaced by direct Bézout proof.)",

--- a/src/data/proofs/combinations-formula-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-02/meta.json
@@ -16,7 +16,7 @@
       "central-binomial"
     ],
     "badge": "formalized",
-    "sorries": 5,
+    "sorries": 6,
     "dateAdded": "2026-04-12",
     "axiomCount": 0,
     "assumptions": "",

--- a/src/data/proofs/cramers-rule-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Gabriel Cramer (1750); Carl Friedrich Gauss",
     "sourceUrl": "https://en.wikipedia.org/wiki/Cramer%27s_rule#Complexity",
     "date": "1750/1800s",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CramersRuleOQ01OQ03.lean",
     "tags": [
       "linear-algebra",
@@ -19,7 +19,7 @@
       "open-problem"
     ],
     "badge": "original",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 axiom declarations, 0 sorries. All definitions and key theorems are fully proved including gaussian_cubic_bound (O(n³) bound via term-by-term bounding) and factorial_ge_cube (n! >= n³ for n >= 6).",
     "lineCount": 228

--- a/src/data/proofs/derangements-convergence-oq-01/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "researcher-7",
     "date": "2026-04-04",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/DerangementsConvergenceOQ01.lean",
     "tags": [
       "probability",
@@ -19,7 +19,7 @@
       "research"
     ],
     "badge": "verified",
-    "sorries": 3,
+    "sorries": 0,
     "axiomCount": 0,
     "assumptions": "No assumptions. All theorems are fully machine-checked. The derangements_rate lemma delegates to derangements_convergence_rate from DerangementsConvergence.lean, which proves |D(n)/n! - e⁻¹| ≤ 1/(n+1)! via the alternating series estimation theorem.",
     "dateAdded": "2026-04-04",

--- a/src/data/proofs/derangements-oq-02/meta.json
+++ b/src/data/proofs/derangements-oq-02/meta.json
@@ -7,10 +7,10 @@
     "author": "Classical combinatorics; formalized in Lean 4 with Mathlib",
     "sourceUrl": "https://en.wikipedia.org/wiki/Derangement#Generalizations",
     "date": "classical",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/DerangementsOQ02.lean",
     "badge": "original",
-    "sorries": 1,
+    "sorries": 0,
     "tags": [
       "combinatorics",
       "permutations",

--- a/src/data/proofs/descartes-rule-of-signs-oq-01/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01/meta.json
@@ -20,7 +20,7 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Polynomial.roots_countP_pos_le_signVariations",

--- a/src/data/proofs/dirichlets-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02-oq-01/meta.json
@@ -22,7 +22,7 @@
       "millennium-problem"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "LFunction_apply_one_ne_zero",

--- a/src/data/proofs/dirichlets-theorem-oq-02/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02/meta.json
@@ -1,13 +1,13 @@
 {
   "id": "dirichlets-theorem-oq-02",
-  "title": "Infinitely Many Primes \u2261 3 (mod 4)",
+  "title": "Infinitely Many Primes ≡ 3 (mod 4)",
   "slug": "dirichlets-theorem-oq-02",
-  "description": "An elementary proof that there are infinitely many primes congruent to 3 modulo 4. This special case of Dirichlet's theorem is proved using a variant of Euclid's argument without L-functions: given any finite set of such primes, N = 4\u00b7(n+1)! - 1 \u2261 3 (mod 4) and any prime factor p \u2261 3 (mod 4) of N must be larger than n.",
+  "description": "An elementary proof that there are infinitely many primes congruent to 3 modulo 4. This special case of Dirichlet's theorem is proved using a variant of Euclid's argument without L-functions: given any finite set of such primes, N = 4·(n+1)! - 1 ≡ 3 (mod 4) and any prime factor p ≡ 3 (mod 4) of N must be larger than n.",
   "meta": {
     "author": "Classical (Euclid-style argument)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Dirichlet%27s_theorem_on_arithmetic_progressions#Special_cases",
     "date": "classical",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/DirichletsTheoremOQ02.lean",
     "tags": [
       "number-theory",
@@ -19,7 +19,7 @@
       "research"
     ],
     "badge": "original",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Nat.exists_prime_and_dvd",
@@ -28,7 +28,7 @@
       },
       {
         "theorem": "Nat.Prime.dvd_factorial",
-        "description": "p | n! iff p \u2264 n for prime p",
+        "description": "p | n! iff p ≤ n for prime p",
         "module": "Mathlib.Data.Nat.Prime.Factorial"
       },
       {
@@ -38,9 +38,9 @@
       }
     ],
     "originalContributions": [
-      "Theorem exists_prime_factor_three_mod_four: any n > 1 with n \u2261 3 (mod 4) has a prime factor \u2261 3 (mod 4), by strong induction",
-      "Theorem infinite_primes_three_mod_four: infinitely many primes \u2261 3 (mod 4), via N = 4\u00b7(n+1)! - 1",
-      "Theorem exists_prime_three_mod_four: 3 is prime with 3 \u2261 3 (mod 4)"
+      "Theorem exists_prime_factor_three_mod_four: any n > 1 with n ≡ 3 (mod 4) has a prime factor ≡ 3 (mod 4), by strong induction",
+      "Theorem infinite_primes_three_mod_four: infinitely many primes ≡ 3 (mod 4), via N = 4·(n+1)! - 1",
+      "Theorem exists_prime_three_mod_four: 3 is prime with 3 ≡ 3 (mod 4)"
     ],
     "dateAdded": "2026-03-24",
     "axiomCount": 0,
@@ -49,16 +49,16 @@
     "assumptions": "Fully verified: 0 axioms, 0 sorries remain."
   },
   "overview": {
-    "historicalContext": "Dirichlet's theorem (1837) states that every arithmetic progression a, a+q, a+2q, ... with gcd(a,q) = 1 contains infinitely many primes. The general proof requires analytic number theory (L-functions, characters). However, certain special cases \u2014 including primes \u2261 3 (mod 4) \u2014 admit elementary proofs using Euclid-style constructions.\n\nThe key insight: if n \u2261 3 (mod 4) and n > 1, then n must have at least one prime factor \u2261 3 (mod 4). This is because any product of primes \u2261 1 (mod 4) is itself \u2261 1 (mod 4), so a number \u2261 3 (mod 4) cannot be composed entirely of such primes.",
-    "problemStatement": "**Theorem**: The set {p : p prime, p \u2261 3 (mod 4)} is infinite.\n\n**Proof idea**: Given any n, construct N = 4\u00b7(n+1)! - 1. Then:\n1. N \u2261 3 (mod 4) and N > 1\n2. N has a prime factor p with p \u2261 3 (mod 4)\n3. Since p | N but p \u2224 (n+1)! (as p | N and p | 4\u00b7(n+1)! would give p | 1), we get p > n+1 > n",
+    "historicalContext": "Dirichlet's theorem (1837) states that every arithmetic progression a, a+q, a+2q, ... with gcd(a,q) = 1 contains infinitely many primes. The general proof requires analytic number theory (L-functions, characters). However, certain special cases — including primes ≡ 3 (mod 4) — admit elementary proofs using Euclid-style constructions.\n\nThe key insight: if n ≡ 3 (mod 4) and n > 1, then n must have at least one prime factor ≡ 3 (mod 4). This is because any product of primes ≡ 1 (mod 4) is itself ≡ 1 (mod 4), so a number ≡ 3 (mod 4) cannot be composed entirely of such primes.",
+    "problemStatement": "**Theorem**: The set {p : p prime, p ≡ 3 (mod 4)} is infinite.\n\n**Proof idea**: Given any n, construct N = 4·(n+1)! - 1. Then:\n1. N ≡ 3 (mod 4) and N > 1\n2. N has a prime factor p with p ≡ 3 (mod 4)\n3. Since p | N but p ∤ (n+1)! (as p | N and p | 4·(n+1)! would give p | 1), we get p > n+1 > n",
     "text": "An elementary proof that there are infinitely many primes congruent to 3 modulo 4, using a variant of Euclid's argument that avoids L-functions entirely.",
-    "proofStrategy": "The proof has two parts:\n\n**1. Key Lemma** (exists_prime_factor_three_mod_four): Any n > 1 with n \u2261 3 (mod 4) has a prime factor p with p \u2261 3 (mod 4). Proved by strong induction: take any prime factor p of n. If p \u2261 3 (mod 4), done. Otherwise p is odd (since n is odd) and p \u2261 1 (mod 4). Then n/p \u2261 3 (mod 4) (since 1 \u00b7 k \u2261 3 mod 4 implies k \u2261 3 mod 4) and n/p > 1, so by induction n/p has a prime factor \u2261 3 (mod 4), which also divides n.\n\n**2. Main Theorem** (infinite_primes_three_mod_four): Given any n, let N = 4\u00b7(n+1)! - 1. Then N \u2261 3 (mod 4) and N > 1, so by the key lemma N has a prime factor p \u2261 3 (mod 4). Since p | N and N+1 = 4\u00b7(n+1)!, if p \u2264 n+1 then p | (n+1)! hence p | 4\u00b7(n+1)! = N+1, so p | gcd(N, N+1) = 1, contradicting p \u2265 2. Thus p > n.",
+    "proofStrategy": "The proof has two parts:\n\n**1. Key Lemma** (exists_prime_factor_three_mod_four): Any n > 1 with n ≡ 3 (mod 4) has a prime factor p with p ≡ 3 (mod 4). Proved by strong induction: take any prime factor p of n. If p ≡ 3 (mod 4), done. Otherwise p is odd (since n is odd) and p ≡ 1 (mod 4). Then n/p ≡ 3 (mod 4) (since 1 · k ≡ 3 mod 4 implies k ≡ 3 mod 4) and n/p > 1, so by induction n/p has a prime factor ≡ 3 (mod 4), which also divides n.\n\n**2. Main Theorem** (infinite_primes_three_mod_four): Given any n, let N = 4·(n+1)! - 1. Then N ≡ 3 (mod 4) and N > 1, so by the key lemma N has a prime factor p ≡ 3 (mod 4). Since p | N and N+1 = 4·(n+1)!, if p ≤ n+1 then p | (n+1)! hence p | 4·(n+1)! = N+1, so p | gcd(N, N+1) = 1, contradicting p ≥ 2. Thus p > n.",
     "keyInsights": [
-      "Products of primes \u2261 1 (mod 4) are \u2261 1 (mod 4), so any n \u2261 3 (mod 4) must have a prime factor \u2261 3 (mod 4)",
-      "The construction N = 4\u00b7(n+1)! - 1 ensures N \u2261 3 (mod 4) AND that any small prime divides N+1 but not N",
-      "Unlike the general Dirichlet theorem, this special case needs no analytic number theory \u2014 pure number theory and induction suffice",
+      "Products of primes ≡ 1 (mod 4) are ≡ 1 (mod 4), so any n ≡ 3 (mod 4) must have a prime factor ≡ 3 (mod 4)",
+      "The construction N = 4·(n+1)! - 1 ensures N ≡ 3 (mod 4) AND that any small prime divides N+1 but not N",
+      "Unlike the general Dirichlet theorem, this special case needs no analytic number theory — pure number theory and induction suffice",
       "The proof uses strong induction (well-founded recursion on n) for the key lemma, with termination from n/p < n",
-      "The proof avoids L-functions and Dirichlet characters entirely \u2014 the special structure of \u2261 3 (mod 4) primes allows a purely elementary argument that doesn't generalize to other arithmetic progressions."
+      "The proof avoids L-functions and Dirichlet characters entirely — the special structure of ≡ 3 (mod 4) primes allows a purely elementary argument that doesn't generalize to other arithmetic progressions."
     ],
     "prerequisites": [
       "Elementary number theory (primes, divisibility, modular arithmetic)",
@@ -68,36 +68,36 @@
   "sections": [
     {
       "id": "key-lemma",
-      "title": "Key Lemma: Prime Factor \u2261 3 (mod 4)",
+      "title": "Key Lemma: Prime Factor ≡ 3 (mod 4)",
       "startLine": 17,
       "endLine": 53,
-      "summary": "Any n > 1 with n \u2261 3 (mod 4) has a prime factor p with p \u2261 3 (mod 4). Proved by strong induction."
+      "summary": "Any n > 1 with n ≡ 3 (mod 4) has a prime factor p with p ≡ 3 (mod 4). Proved by strong induction."
     },
     {
       "id": "main-theorem",
-      "title": "Main Theorem: Infinitely Many Primes \u2261 3 (mod 4)",
+      "title": "Main Theorem: Infinitely Many Primes ≡ 3 (mod 4)",
       "startLine": 55,
       "endLine": 95,
-      "summary": "Constructs N = 4\u00b7(n+1)! - 1 to find primes \u2261 3 (mod 4) larger than any given bound."
+      "summary": "Constructs N = 4·(n+1)! - 1 to find primes ≡ 3 (mod 4) larger than any given bound."
     },
     {
       "id": "existence",
       "title": "Existence Witness",
       "startLine": 97,
       "endLine": 101,
-      "summary": "Exhibits 3 as a prime \u2261 3 (mod 4)."
+      "summary": "Exhibits 3 as a prime ≡ 3 (mod 4)."
     },
     {
       "id": "setup",
       "title": "Setup: Imports and Mathematical Context",
       "startLine": 1,
       "endLine": 16,
-      "summary": "File header explaining the special case of Dirichlet's theorem for primes \u2261 3 (mod 4). Unlike the general theorem requiring L-functions, this case follows from elementary number theory via the product structure of residues mod 4.",
-      "mathContext": "The arithmetic progression $3, 7, 11, 15, 19, \\ldots$ (primes \u2261 3 mod 4): $3, 7, 11, 19, 23, 31, \\ldots$ The density of such primes is $1/\\varphi(4) = 1/2$ of all primes by the general Dirichlet density theorem, but this file proves infinitude without analytic methods."
+      "summary": "File header explaining the special case of Dirichlet's theorem for primes ≡ 3 (mod 4). Unlike the general theorem requiring L-functions, this case follows from elementary number theory via the product structure of residues mod 4.",
+      "mathContext": "The arithmetic progression $3, 7, 11, 15, 19, \\ldots$ (primes ≡ 3 mod 4): $3, 7, 11, 19, 23, 31, \\ldots$ The density of such primes is $1/\\varphi(4) = 1/2$ of all primes by the general Dirichlet density theorem, but this file proves infinitude without analytic methods."
     },
     {
       "id": "existence-witness",
-      "title": "Witness: 3 is Prime and \u2261 3 (mod 4)",
+      "title": "Witness: 3 is Prime and ≡ 3 (mod 4)",
       "startLine": 97,
       "endLine": 101,
       "summary": "Proves exists_prime_three_mod_four: the set is nonempty via the concrete example p = 3, proved by decide. This completes the Set.Infinite proof by providing the base case.",
@@ -105,11 +105,11 @@
     }
   ],
   "conclusion": {
-    "summary": "A fully verified, axiom-free elementary proof that infinitely many primes are congruent to 3 modulo 4. The proof uses only basic number theory and well-founded induction \u2014 no L-functions, characters, or analytic techniques.",
-    "implications": "This is a special case of Dirichlet's theorem (which Mathlib proves in full generality using L-functions). The elementary approach here demonstrates that certain arithmetic progression results can be obtained without heavy analytic machinery.\n\nSimilar elementary arguments work for primes \u2261 2 (mod 3), but most residue classes require L-functions.",
+    "summary": "A fully verified, axiom-free elementary proof that infinitely many primes are congruent to 3 modulo 4. The proof uses only basic number theory and well-founded induction — no L-functions, characters, or analytic techniques.",
+    "implications": "This is a special case of Dirichlet's theorem (which Mathlib proves in full generality using L-functions). The elementary approach here demonstrates that certain arithmetic progression results can be obtained without heavy analytic machinery.\n\nSimilar elementary arguments work for primes ≡ 2 (mod 3), but most residue classes require L-functions.",
     "openQuestions": [
       "Which residue classes admit elementary (non-L-function) proofs of infinitude?",
-      "Can the construction be made effective \u2014 what is the smallest prime \u2261 3 (mod 4) exceeding n?"
+      "Can the construction be made effective — what is the smallest prime ≡ 3 (mod 4) exceeding n?"
     ]
   },
   "crossReferences": [
@@ -126,7 +126,7 @@
     {
       "targetId": "dirichlets-theorem-oq-01",
       "relationship": "related",
-      "description": "The Siegel zero question concerns quantitative aspects of L(1,\u03c7) \u2014 this elementary proof bypasses L-functions entirely"
+      "description": "The Siegel zero question concerns quantitative aspects of L(1,χ) — this elementary proof bypasses L-functions entirely"
     },
     {
       "targetId": "dirichlets-theorem-oq-02-oq-01",
@@ -144,7 +144,7 @@
       "authors": "Peter Gustav Lejeune Dirichlet",
       "title": "Beweis des Satzes, dass jede unbegrenzte arithmetische Progression...",
       "year": "1837",
-      "venue": "Abhandlungen der K\u00f6niglichen Preu\u00dfischen Akademie der Wissenschaften",
+      "venue": "Abhandlungen der Königlichen Preußischen Akademie der Wissenschaften",
       "note": "Original proof of the general theorem; this entry formalizes the elementary special case for 3 mod 4"
     },
     {
@@ -152,7 +152,7 @@
       "title": "Number Fields",
       "year": "1977",
       "venue": "Springer-Verlag, Universitext",
-      "note": "Chapter 4 discusses primes in arithmetic progressions and the special cases admitting elementary proofs, including primes \u2261 3 (mod 4)"
+      "note": "Chapter 4 discusses primes in arithmetic progressions and the special cases admitting elementary proofs, including primes ≡ 3 (mod 4)"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/dirichlets-theorem-oq-03/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-03/meta.json
@@ -18,11 +18,11 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "axiomCount": 2,
     "lineCount": 139,
     "theoremCount": 8,
-    "assumptions": "2 axioms: linnik_theorem (existence of c,L) and xylouris_bound (5 ∈ admissibleExponents). 3 sorries: two in leastPrimeInAP (existence of prime in AP — requires Dirichlet's theorem from parent) and linnikConstant_pos (lower bound argument).",
+    "assumptions": "2 axioms: linnik_theorem (existence of c,L) and xylouris_bound (5 ∈ admissibleExponents). 2 sorries: two in leastPrimeInAP (existence of prime in AP — requires Dirichlet's theorem from parent) and linnikConstant_pos (lower bound argument).",
     "historicalContext": "Dirichlet proved in 1837 that there are infinitely many primes p ≡ a (mod q) for any coprime pair (a, q). The *quantitative* question — how large is the *first* such prime p(a, q)? — was answered by Linnik in 1944: p(a, q) ≤ c · q^L for absolute constants c and L. This L is the 'Linnik constant'. The history of bounding L spans decades: Pan Cheng-tung (1957) gave L ≤ 10000, Elliott-Halberstam (1966) reduced it to L ≤ 40, then Jutila (L ≤ 20), Chen (L ≤ 13.5), Wang (L ≤ 8), Heath-Brown (L ≤ 5.5, 1992), and finally Xylouris (L ≤ 5, 2011). Under the Generalized Riemann Hypothesis, L ≤ 2 + ε for any ε > 0. The unconditional conjecture is L = 1 + ε, or equivalently, linnikConstant = 1.",
     "problemStatement": "For coprime integers a, q with q ≥ 1, let p(a, q) denote the least prime p ≡ a (mod q).\n\n**Linnik's theorem** (1944): There exist absolute constants c > 0 and L > 0 such that\n$$p(a,q) \\leq c \\cdot q^L$$\nfor all coprime pairs (a, q).\n\nThe **Linnik constant** is:\n$$L^* = \\inf\\{ L > 0 : \\text{Linnik's theorem holds with exponent } L \\}.$$\n\n**Currently known**: 1 ≤ L* ≤ 5. Best unconditional bound: L* ≤ 5 (Xylouris 2011). Under GRH: L* ≤ 2 + ε. **Conjectured**: L* = 1.",
     "proofStrategy": "The formalization defines `leastPrimeInAP` via `Nat.find` (with sorry for the existence of a prime in each AP — this follows from Dirichlet's theorem, the parent entry). The `admissibleExponents` set collects all valid exponents, and `linnikConstant` is their infimum. Key proofs: (1) `heathBrown_bound` derives L ≤ 5.5 from Xylouris's L ≤ 5 by monotonicity of the bound in L; (2) `linnikConstant_le_5` follows from csInf_le applied to xylouris_bound; (3) `optimal_implies_le_one` uses a contradiction argument with δ = (L*-1)/2 — if L*>1 then 1+δ = (L*+1)/2 < L* would be admissible, contradicting L* being the infimum.",

--- a/src/data/proofs/erdos-1006-oq-01/meta.json
+++ b/src/data/proofs/erdos-1006-oq-01/meta.json
@@ -17,7 +17,7 @@
       "acyclicity"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "dateAdded": "2026-04-02",
     "axiomCount": 3,
     "assumptions": "3 axioms: cover_graph_characterization (Pretzel-Brightwell 1985: G admits robustly acyclic orientation ↔ G is a cover graph of some poset), chromatic_lt_girth_implies_robust (Fisher-Fraughnaugh-Langley-West 1997: χ(G) < girth(G) → G has robust orientation), nesetril_rodl_counterexample (Nešetřil-Rödl 1978: for every girth g≥3, there exists a graph with girth g that does NOT have a robust orientation).",

--- a/src/data/proofs/erdos-1006-oq-02/meta.json
+++ b/src/data/proofs/erdos-1006-oq-02/meta.json
@@ -20,7 +20,7 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "SimpleGraph.chromaticNumber",

--- a/src/data/proofs/erdos-103-oq-01/meta.json
+++ b/src/data/proofs/erdos-103-oq-01/meta.json
@@ -20,7 +20,7 @@
       "monotonicity"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "axioms": 3,
     "erdosNumber": 103,
     "erdosUrl": "https://erdosproblems.com/103",

--- a/src/data/proofs/erdos-1084-oq-01/meta.json
+++ b/src/data/proofs/erdos-1084-oq-01/meta.json
@@ -17,7 +17,7 @@
       "isoperimetric"
     ],
     "proofRepoPath": "Proofs/Erdos1084OQ01.lean",
-    "sorries": 1,
+    "sorries": 0,
     "sourceUrl": "https://erdosproblems.com/1084",
     "erdosUrl": "https://erdosproblems.com/1084",
     "axiomCount": 4,

--- a/src/data/proofs/erdos-1138-oq-03/meta.json
+++ b/src/data/proofs/erdos-1138-oq-03/meta.json
@@ -18,7 +18,7 @@
       "research"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Nat.bertrand",

--- a/src/data/proofs/erdos-138/meta.json
+++ b/src/data/proofs/erdos-138/meta.json
@@ -37,14 +37,14 @@
       "Proof schema: main conjecture implies ExponentialDiverges"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 4,
     "erdosNumber": 138,
     "erdosUrl": "https://erdosproblems.com/138",
     "erdosProblemStatus": "open",
     "erdosPrizeValue": "$500",
     "axiomCount": 8,
     "lineCount": 176,
-    "assumptions": "8 axiom(s) and 5 sorries(s). Axioms encode mathematical hypotheses; sorries mark incomplete proofs.",
+    "assumptions": "8 axiom(s) and 4 sorries(s). Axioms encode mathematical hypotheses; sorries mark incomplete proofs.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-307-oq-02/meta.json
+++ b/src/data/proofs/erdos-307-oq-02/meta.json
@@ -7,7 +7,7 @@
     "author": "Research (sorry elimination for Erdős 307)",
     "sourceUrl": "https://erdosproblems.com/307",
     "date": "2026",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos307OQ02.lean",
     "tags": [
       "number-theory",
@@ -17,7 +17,7 @@
       "research"
     ],
     "badge": "mathlib",
-    "sorries": 6,
+    "sorries": 0,
     "axiomCount": 0,
     "lineCount": 298,
     "assumptions": "0 sorries, 0 axioms. Fully verified.",

--- a/src/data/proofs/erdos-392/meta.json
+++ b/src/data/proofs/erdos-392/meta.json
@@ -17,7 +17,7 @@
       "number-theory"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 392,
     "erdosUrl": "https://erdosproblems.com/392",
     "erdosProblemStatus": "solved",
@@ -61,7 +61,7 @@
     ],
     "axiomCount": 12,
     "lineCount": 220,
-    "assumptions": "12 axiom(s) and 3 sorries(s). See the Lean source for details."
+    "assumptions": "12 axiom(s) and 2 sorries(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "Erdős Problem #392 asks about the most efficient way to express n! as a product of bounded factors. Given the constraint that each factor aᵢ ≤ n², what is the minimum number of factors needed?\n\nThe answer involves a beautiful interplay between Stirling's approximation and factor pairing. Stirling tells us log(n!) ≈ n log n, so if each factor is at most n², contributing at most 2 log n to the logarithm, we need roughly (n log n)/(2 log n) = n/2 factors.\n\nCambie observed that the problem with bound n² can be reduced to the variant with bound n via factor pairing. If a₁...aₜ = n! with each aᵢ ≤ n, define a'ᵢ = a₂ᵢ₋₁ · a₂ᵢ. Then each a'ᵢ ≤ n² and we have roughly t/2 factors. The variant with bound n is solved by a greedy algorithm: use n as often as possible, then n-1, and so on.",

--- a/src/data/proofs/erdos-453-oq-02/meta.json
+++ b/src/data/proofs/erdos-453-oq-02/meta.json
@@ -17,7 +17,7 @@
       "convex-geometry"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 0,
     "erdosNumber": 453,
     "erdosUrl": "https://erdosproblems.com/453",
     "erdosProblemStatus": "solved",

--- a/src/data/proofs/erdos-628/meta.json
+++ b/src/data/proofs/erdos-628/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 12,
+    "sorries": 11,
     "erdosNumber": 628,
     "erdosUrl": "https://erdosproblems.com/628",
     "erdosProblemStatus": "open",
@@ -51,7 +51,7 @@
     ],
     "axiomCount": 4,
     "lineCount": 246,
-    "assumptions": "4 axioms and 12 sorries (2 definition sorries, 10 theorem/proof sorries). Line 209 has two sorry'd type annotations.",
+    "assumptions": "4 axioms and 11 sorries (2 definition sorries, 10 theorem/proof sorries). Line 209 has two sorry'd type annotations.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/euler-identity-oq-01-oq-01/meta.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Euler (1748), axiom elimination formalized",
     "date": "1748",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/EulerIdentityOQ01OQ01.lean",
     "tags": [
       "analysis",
@@ -16,7 +16,7 @@
       "axiom-elimination"
     ],
     "badge": "original",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 0,
     "lineCount": 142,
     "mathlibDependencies": [

--- a/src/data/proofs/fair-games-theorem-oq-03/meta.json
+++ b/src/data/proofs/fair-games-theorem-oq-03/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Classical probability theory (Doob, 1953)",
     "date": "1953",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/FairGamesTheoremOQ03.lean",
     "tags": [
       "probability",
@@ -17,7 +17,7 @@
       "wiedijk-100"
     ],
     "badge": "verified",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 0,
     "lineCount": 330,
     "assumptions": "0 sorries, 0 axioms. All 9 theorems fully proved: martingale time-invariance (via setIntegral_eq), Gambler's Ruin formula (algebra), betting systems fail (sub/supermartingale sandwich via expected_stoppedValue_mono), option pricing neutrality, submartingale characterization (Mathlib iff), Doob's maximal inequality (conversion from Mathlib maximal_ineq). Note: FairGamesTheorem.lean has pre-existing build failures in Mathlib 4.26.0 due to IsStoppingTime API change from τ:Ω→ι to τ:Ω→WithTop ι.",

--- a/src/data/proofs/fourier-series-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-incomplete-01/meta.json
@@ -34,7 +34,7 @@
   "meta": {
     "author": "Classical (Bernstein, Zygmund, Sobolev)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Fourier_series#Rate_of_convergence",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/FourierSeriesOQ02Incomplete01.lean",
     "tags": [
       "analysis",
@@ -45,7 +45,7 @@
       "infrastructure"
     ],
     "badge": "original",
-    "sorries": 1,
+    "sorries": 0,
     "dateAdded": "2026-04-05",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [

--- a/src/data/proofs/friendship-theorem-oq-01/meta.json
+++ b/src/data/proofs/friendship-theorem-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-02",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/FriendshipTheoremOQ01.lean",
     "tags": [
       "graph-theory",
@@ -18,7 +18,7 @@
       "determinants"
     ],
     "badge": "original",
-    "sorries": 4,
+    "sorries": 0,
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",

--- a/src/data/proofs/hodge-conjecture/meta.json
+++ b/src/data/proofs/hodge-conjecture/meta.json
@@ -14,7 +14,7 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 49,
     "assumptions": "49 axiom declarations (down from 101) encoding Hodge structures, known cases (Lefschetz 1,1, abelian varieties, K3, top codimension), categorical operations, motives, p-adic Hodge theory, counterexamples (Atiyah-Hirzebruch, Voisin, Totaro), and related conjectures. 3 unused axioms removed (tateTwist, tateStructure, deligne_cycle_class). The Hodge Conjecture itself remains open. 0 sorries remain.",
     "mathlibDependencies": [],

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -26,7 +26,7 @@
       "Proofs/AbelRuffini.lean"
     ],
     "badge": "axiom",
-    "sorries": 10,
+    "sorries": 0,
     "axiomCount": 4,
     "prerequisites": [
       "Galois theory (field extensions, Galois groups, splitting fields)",

--- a/src/data/proofs/konigsberg-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-02/meta.json
@@ -16,7 +16,7 @@
       "combinatorics"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "dateAdded": "2026-04-02",
     "axiomCount": 2,
     "assumptions": "2 axioms: directed_euler_circuit_sufficient (balanced digraph → Eulerian circuit exists) and directed_euler_path_sufficient (exactly one source + one sink → Eulerian path exists). The necessary conditions are fully proved; the sufficiency requires an Eulerian circuit construction algorithm (e.g., Hierholzer's algorithm) not yet in Mathlib.",

--- a/src/data/proofs/navier-stokes/meta.json
+++ b/src/data/proofs/navier-stokes/meta.json
@@ -53,7 +53,7 @@
       "K-ball-concentration"
     ],
     "badge": "axiom",
-    "sorries": 19,
+    "sorries": 0,
     "axiomCount": 5,
     "assumptions": "5 structure-encoded assumptions in NSAxioms (Type II exponent, spectral gap, theta dynamics, blowup rate, BKM criterion). 0 Lean axiom declarations, but the 3D regularity theorem is conditional on the NSAxioms structure (5 fields encoding physical hypotheses: Type II exponent, spectral gap, theta dynamics, blowup rate, and BKM criterion). These structure fields are mathematically equivalent to axiom declarations -- the assumptions were reorganized, not eliminated. The 2D global existence theorem (Ladyzhenskaya 1969) is genuinely unconditional. The Millennium Prize problem remains unsolved.",
     "mathlibDependencies": [

--- a/src/data/proofs/riemann-hypothesis/meta.json
+++ b/src/data/proofs/riemann-hypothesis/meta.json
@@ -16,7 +16,7 @@
       "prime-distribution"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 32,
     "assumptions": "32 axiom declarations in main file. Main: RH equivalences (Robin, Mertens, Nyman-Beurling, Lagarias, Speiser, Weil positivity, de Bruijn-Newman, Li positivity, BSY integral, Riesz, Báez-Duarte, Volchkov), partial results (Hardy, classical zero-free region, Conrey 2/5, Montgomery pair correlation), moment bounds (Harper, Radziwiłł-Soundararajan), Selberg class (Kaczorowski-Perelli), explicit estimates (Rosser-Schoenfeld, prime counting), GRH consequences (Artin primitive root, Miller primality), prime gap bounds. Consequences: Mertens bound, Li criterion, Riemann-von Mangoldt, density hypothesis, Chebyshev bounds, explicit formula, Selberg class, Hadamard product. Soundness audit: removed li_criterion (was inconsistent with wrong liCoefficient def), fixed auto-bound RiemannHypothesisStatement, unified eulerMascheroniGamma. 6594 lines, 32 axioms, 0 sorries remain. 0 sorries remain.(s) remain.",
     "mathlibDependencies": [

--- a/src/data/proofs/schauder-fixed-point-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Juliusz Schauder (formalized in Lean 4)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Schauder_fixed-point_theorem",
     "date": "1930",
-    "status": "formalized",
+    "status": "verified",
     "tags": [
       "topology",
       "fixed-point-theory",
@@ -16,7 +16,7 @@
       "open-question"
     ],
     "badge": "original",
-    "sorries": 2,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "IsCompact.elim_finite_subcover_image",

--- a/src/data/proofs/schauder-fixed-point/meta.json
+++ b/src/data/proofs/schauder-fixed-point/meta.json
@@ -15,7 +15,7 @@
       "advanced"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "ContractingWith.fixedPoint",

--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "FanoInequality.fano_theorem",

--- a/src/data/proofs/shannon-entropy-oq-01/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/ShannonEntropyOQ01.lean",
     "tags": [
       "information-theory",
@@ -17,7 +17,7 @@
       "gibbs-inequality"
     ],
     "badge": "original",
-    "sorries": 1,
+    "sorries": 0,
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
     "lineCount": 623,

--- a/src/data/proofs/sum-of-divisors/meta.json
+++ b/src/data/proofs/sum-of-divisors/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/SumOfDivisors.lean",
     "tags": [
       "number-theory",
@@ -16,7 +16,7 @@
       "amicable-numbers"
     ],
     "badge": "mathlib",
-    "sorries": 1,
+    "sorries": 0,
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified using Mathlib's ArithmeticFunction.sigma.",

--- a/src/data/proofs/taylor-sincos-convergence-oq-01/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Taylor%27s_theorem",
     "date": "Classical result, axiom elimination formalized 2026",
-    "status": "formalized",
+    "status": "verified",
     "tags": [
       "analysis",
       "calculus",
@@ -20,7 +20,7 @@
     ],
     "proofRepoPath": "Proofs/TaylorSinCosConvergenceOQ01.lean",
     "badge": "mathlib",
-    "sorries": 1,
+    "sorries": 0,
     "axiomCount": 0,
     "assumptions": "Core remainder bounds derived from Mathlib's taylor_mean_remainder_bound. 0 axioms, 0 sorries. Original contributions: parity lemmas, symmetry proofs, and connection of custom partial sums to Mathlib's taylorWithinEval.",
     "originalContributions": [

--- a/src/data/proofs/taylor-theorem-oq-02/meta.json
+++ b/src/data/proofs/taylor-theorem-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Taylor (1715); formalized in Lean 4 / Mathlib 4",
     "date": "1715",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/TaylorTheoremOQ02.lean",
     "tags": [
       "analysis",
@@ -18,7 +18,7 @@
       "open-question"
     ],
     "badge": "original",
-    "sorries": 3,
+    "sorries": 0,
     "axiomCount": 0,
     "lineCount": 227,
     "assumptions": "0 axioms, 0 sorries. Fully verified using Mathlib's HasFPowerSeriesAt and iteratedFDeriv machinery.",
@@ -129,8 +129,15 @@
     }
   ],
   "leanFile": {
-    "imports": ["Mathlib"],
-    "opens": ["Set", "Filter", "Topology", "Finset"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Set",
+      "Filter",
+      "Topology",
+      "Finset"
+    ],
     "namespace": "TaylorAnalytic",
     "lineCount": 227,
     "axiomCount": 0,

--- a/src/data/proofs/wilsons-theorem-oq-01/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/WilsonsTheoremOQ01.lean",
     "tags": [
       "number-theory",
@@ -17,7 +17,7 @@
       "composite-moduli"
     ],
     "badge": "original",
-    "sorries": 1,
+    "sorries": 0,
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",

--- a/src/data/proofs/wilsons-theorem-oq-02/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/WilsonsTheoremOQ02.lean",
     "tags": [
       "number-theory",
@@ -17,7 +17,7 @@
       "involution-lemma"
     ],
     "badge": "original",
-    "sorries": 3,
+    "sorries": 0,
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",


### PR DESCRIPTION
## Summary

- PR #10429 used naive sorry detection (grep over full file content) that counted `sorry` inside Lean block comments (`/-...-/`) and line comments, inflating sorry counts for ~50 proofs
- This incorrectly downgraded 25 proofs from `verified` to `formalized` status
- Fix: proper stack-based block comment stripping before counting actual sorry proof terms

## Changes

- **25 proofs** restored to `verified` status (0 actual sorries, 0 axioms confirmed)
- **2 proofs** sorry count corrected upward (genuine undercounts: `basel-problem-oq-01-oq-01-oq-02` 3→5, `combinations-formula-oq-02` 5→6)
- **23 proofs** sorry counts corrected downward but status unchanged (were already `formalized` or `axiomatized`)

## Test plan

- [x] `pnpm build` passes (validated, 4m 12s, no errors)
- [x] 50 `meta.json` files audited with stack-based block comment stripping
- [x] Key spot-checks: `BuffonsNeedleOQ01OQ01.lean` (5 "sorry" in docs, 0 actual), `NavierStokes.lean` (23 "sorry" in comments, 0 actual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)