### PR TITLE
feat: Aristotle companion file for erdos-109-oq-01

### DIFF
--- a/proofs/Proofs/Erdos109OQ01Aristotle.lean
+++ b/proofs/Proofs/Erdos109OQ01Aristotle.lean
@@ -1,0 +1,45 @@
+/-
+  Aristotle targets for Erdos109OQ01
+  Routine supporting lemmas for automated proof search.
+  See Erdos109OQ01.lean for the main formalization.
+
+  Targets:
+  - syndetic_infinite: A syndetic set is infinite
+    Key: for every n, the gap condition gives m ∈ S with m ≥ n+1,
+    so S is unbounded above, hence infinite (Set.infinite_of_not_bddAbove).
+  - syndetic_nonempty: Immediate from gap condition at n=0.
+  - thick_nonempty: Immediate from run condition at g=0.
+
+  Not targeted (too deep for automated search):
+  - posUpperDensity_piecewiseSyndetic: requires ergodic theory
+  - sumset_density_constraint: requires density comparison
+  - posUpperDensity_contains_IP: requires Hindman's theorem
+  - ip_set_sumset_structure: requires FS set construction
+-/
+import Mathlib
+
+namespace Erdos109OQ01
+
+/-- A set S ⊆ ℕ is syndetic if the gaps between consecutive elements are bounded. -/
+def IsSyndetic (S : Set ℕ) : Prop :=
+  ∃ g : ℕ, ∀ n : ℕ, ∃ m ∈ S, n ≤ m ∧ m ≤ n + g
+
+/-- A set S ⊆ ℕ is thick if it contains arbitrarily long runs. -/
+def IsThick (S : Set ℕ) : Prop :=
+  ∀ g : ℕ, ∃ n : ℕ, ∀ m : ℕ, n ≤ m → m ≤ n + g → m ∈ S
+
+/-- A syndetic set is nonempty. -/
+theorem syndetic_nonempty (S : Set ℕ) (hS : IsSyndetic S) : S.Nonempty := by
+  sorry
+
+/-- A thick set is nonempty. -/
+theorem thick_nonempty (S : Set ℕ) (hS : IsThick S) : S.Nonempty := by
+  sorry
+
+/-- Syndetic sets are infinite.
+    Key: for every n, the syndetic gap condition gives m ∈ S with m ≥ n+1,
+    so S is not bounded above, hence infinite. -/
+theorem syndetic_infinite (S : Set ℕ) (hS : IsSyndetic S) : S.Infinite := by
+  sorry
+
+end Erdos109OQ01


### PR DESCRIPTION
## Summary

- Creates `Erdos109OQ01Aristotle.lean` with 3 routine lemma targets for Aristotle automated proof search
- Targets: `syndetic_infinite`, `syndetic_nonempty`, `thick_nonempty`
- These are supporting lemmas for the 5 sorry-bearing theorems in `Erdos109OQ01.lean`

## Aristotle Targets

| Theorem | Strategy |
|---------|----------|
| `syndetic_nonempty` | Gap condition at n=0 gives an element |
| `thick_nonempty` | Run condition at g=0 gives an element |
| `syndetic_infinite` | S unbounded (from gap condition) → `Set.infinite_of_not_bddAbove` |

## Out of scope (too deep)

- `posUpperDensity_piecewiseSyndetic`: ergodic theory
- `sumset_density_constraint`: density comparison argument
- `posUpperDensity_contains_IP`: requires axiomatized Hindman's theorem
- `ip_set_sumset_structure`: FS set structure construction

## Test plan

- [x] Pre-submission checklist: no def-sorries, no axiom decls, no True theorems, no `/-!` sections
- [x] 3 theorem-body sorries (all Aristotle-eligible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)