### PR TITLE
feat: Aristotle companion file for arithmetic-series-oq-02-oq-03 (Euler characteristic)

### DIFF
--- a/proofs/Proofs/ArithmeticSeriesOQ02OQ03Aristotle.lean
+++ b/proofs/Proofs/ArithmeticSeriesOQ02OQ03Aristotle.lean
@@ -1,0 +1,34 @@
+/-
+  Aristotle targets for ArithmeticSeriesOQ02OQ03 (Simplicial Face Counts)
+  Routine supporting lemma for automated proof search.
+  See ArithmeticSeriesOQ02OQ03.lean for the main formalization.
+
+  Target:
+  - euler_characteristic_ari: Euler characteristic of k-simplex = 1
+    (alternating sum of face counts)
+
+  Proof strategy:
+  The key identity is ∑_{j=0}^{k} (-1)^j C(k+1, j+1) = 1.
+  Reindex i = j + 1: the sum becomes -∑_{i=1}^{k+1} (-1)^i C(k+1, i).
+  Use Int.alternating_sum_range_choose (k+1): ∑_{i=0}^{k+2} (-1)^i C(k+1,i) = 0
+  for k+1 ≥ 1. Extract the i=0 term (= 1) to get the result.
+-/
+import Mathlib
+
+open Finset BigOperators
+
+namespace ArithmeticSeriesOQ02OQ03.Aristotle
+
+/-- **Euler characteristic of Δ^k is 1** (Aristotle target).
+
+    χ(Δ^k) = ∑_{j=0}^{k} (-1)^j f_j = 1, where f_j = C(k+1, j+1).
+
+    Proof: ∑_{j=0}^k (-1)^j C(k+1, j+1) = 1.
+    Reindex (i = j+1): ∑_{i=1}^{k+1} (-1)^{i-1} C(k+1, i) = 1.
+    Use the alternating binomial identity ∑_{i=0}^{k+1} (-1)^i C(k+1,i) = 0
+    (for k+1 ≥ 1), then extract the i=0 term. -/
+theorem euler_characteristic_ari (k : ℕ) :
+    ∑ j ∈ range (k + 1), (-1 : ℤ) ^ j * (Nat.choose (k + 1) (j + 1) : ℤ) = 1 := by
+  sorry
+
+end ArithmeticSeriesOQ02OQ03.Aristotle


### PR DESCRIPTION
## Fix

Creates ArithmeticSeriesOQ02OQ03Aristotle.lean with 1 Aristotle target for the simplicial face counts proof.

## Evidence

**Target**: euler_characteristic_ari — Euler characteristic of k-simplex = 1.

∑_{j=0}^{k} (-1)^j · C(k+1, j+1) = 1

**Before**: The euler_characteristic theorem in ArithmeticSeriesOQ02OQ03.lean has a sorry.

**After**: Companion file exposes the theorem as a standalone lemma with proof strategy (reindex + alternating binomial identity from Mathlib).

---
Automated fix by lean-mechanic agent.