### PR TITLE
chore: mark stale Aristotle server jobs and submit 3 new batches

### DIFF
--- a/research/aristotle-jobs.json
+++ b/research/aristotle-jobs.json
@@ -3143,27 +3143,151 @@
       "file": "proofs/Proofs/SzemerediCore.lean",
       "problem_id": "szemeredicore",
       "submitted": "unknown",
-      "status": "completed",
-      "outcome": "No improvement (recovered from server)",
-      "notes": "Recovered from server at 2026-04-12T21:48:42Z. No sorry reduction."
+      "status": "integrated",
+      "outcome": "Already had 0 sorries",
+      "notes": "Recovered from server at 2026-04-12T21:48:42Z. No sorry reduction.",
+      "theorems_proved": 0
     },
     {
       "project_id": "d84928ca-f8b6-4834-8457-4d9879867aa3",
       "file": "proofs/Proofs/Erdos1012OQ03Aristotle.lean",
       "problem_id": "erdos-1012oq03",
       "submitted": "unknown",
-      "status": "completed",
-      "outcome": "No improvement (recovered from server)",
-      "notes": "Recovered from server at 2026-04-12T21:48:43Z. No sorry reduction."
+      "status": "integrated",
+      "outcome": "Already had 0 sorries",
+      "notes": "Recovered from server at 2026-04-12T21:48:43Z. No sorry reduction.",
+      "theorems_proved": 0
     },
     {
       "project_id": "73cf466b-e55c-4b03-a282-0ef698c26775",
       "file": "proofs/Proofs/Erdos1012Problem.lean",
       "problem_id": "erdos-1012",
       "submitted": "unknown",
-      "status": "completed",
-      "outcome": "No improvement (recovered from server)",
-      "notes": "Recovered from server at 2026-04-12T21:48:44Z. No sorry reduction."
+      "status": "integrated",
+      "outcome": "Already had 0 sorries",
+      "notes": "Recovered from server at 2026-04-12T21:48:44Z. No sorry reduction.",
+      "theorems_proved": 0
+    },
+    {
+      "project_id": "f8f2c54a-d0d8-4979-9dfd-8b8865a0c39b",
+      "file": "proofs/Proofs/Erdos501Aristotle.lean",
+      "problem_id": "erdos-501",
+      "submitted": "2026-04-13T05:50:44Z",
+      "status": "resolved_manually",
+      "outcome": "Erdos501Support companion - blocked by safety check (content already integrated); marked stale by mechanic"
+    },
+    {
+      "project_id": "d042c5c9-cad3-4a25-8b60-0d5efb9a4a2b",
+      "file": "proofs/Proofs/Erdos501Aristotle.lean",
+      "problem_id": "erdos-501",
+      "submitted": "2026-04-13T05:50:44Z",
+      "status": "resolved_manually",
+      "outcome": "Erdos501Support companion - blocked by safety check (content already integrated); marked stale by mechanic"
+    },
+    {
+      "project_id": "7d5f3c83-b6ea-4039-af69-5bc65a9463b6",
+      "file": "proofs/Proofs/Erdos501Aristotle.lean",
+      "problem_id": "erdos-501",
+      "submitted": "2026-04-13T05:50:44Z",
+      "status": "resolved_manually",
+      "outcome": "Erdos501Support companion - blocked by safety check (content already integrated); marked stale by mechanic"
+    },
+    {
+      "project_id": "27bef0da-21a7-4ddf-91ca-f71200abdd77",
+      "file": "proofs/Proofs/Erdos501Aristotle.lean",
+      "problem_id": "erdos-501",
+      "submitted": "2026-04-13T05:50:44Z",
+      "status": "resolved_manually",
+      "outcome": "Erdos501Support companion - blocked by safety check (content already integrated); marked stale by mechanic"
+    },
+    {
+      "project_id": "4d7b36aa-6764-4e28-8b4a-34460c38edaa",
+      "file": "proofs/Proofs/Erdos501Aristotle.lean",
+      "problem_id": "erdos-501",
+      "submitted": "2026-04-13T05:50:44Z",
+      "status": "resolved_manually",
+      "outcome": "Erdos501Support companion - blocked by safety check (content already integrated); marked stale by mechanic"
+    },
+    {
+      "project_id": "a85d3f5b-6bff-4b62-9fb9-5a1bd287c95a",
+      "file": "proofs/Proofs/Erdos501Aristotle.lean",
+      "problem_id": "erdos-501",
+      "submitted": "2026-04-13T05:50:44Z",
+      "status": "resolved_manually",
+      "outcome": "Erdos501Support companion - blocked by safety check (content already integrated); marked stale by mechanic"
+    },
+    {
+      "project_id": "1960629b-f89f-4f0d-817c-8a73aa164347",
+      "file": "proofs/Proofs/Erdos501Aristotle.lean",
+      "problem_id": "erdos-501",
+      "submitted": "2026-04-13T05:50:44Z",
+      "status": "resolved_manually",
+      "outcome": "Erdos501Support companion - blocked by safety check (content already integrated); marked stale by mechanic"
+    },
+    {
+      "project_id": "a71b9cea-ac8b-407d-8d27-dbcad7cca3c2",
+      "file": "proofs/Proofs/Erdos501Aristotle.lean",
+      "problem_id": "erdos-501",
+      "submitted": "2026-04-13T05:50:44Z",
+      "status": "resolved_manually",
+      "outcome": "Erdos501Support companion - blocked by safety check (content already integrated); marked stale by mechanic"
+    },
+    {
+      "project_id": "8100a08c-d9c7-4005-b83f-f6efb3ec50cc",
+      "file": "proofs/Proofs/Erdos501Aristotle.lean",
+      "problem_id": "erdos-501",
+      "submitted": "2026-04-13T05:50:44Z",
+      "status": "resolved_manually",
+      "outcome": "Erdos501Support companion - blocked by safety check (content already integrated); marked stale by mechanic"
+    },
+    {
+      "project_id": "fe810546-8de4-4da4-8912-d4fc97ea36f8",
+      "file": "proofs/Proofs/Erdos501Aristotle.lean",
+      "problem_id": "erdos-501",
+      "submitted": "2026-04-13T05:50:44Z",
+      "status": "resolved_manually",
+      "outcome": "Erdos501Support companion - blocked by safety check (content already integrated); marked stale by mechanic"
+    },
+    {
+      "project_id": "42383031-5f2f-4d2e-b208-318b27ec71a4",
+      "file": "proofs/Proofs/Erdos501Aristotle.lean",
+      "problem_id": "erdos-501",
+      "submitted": "2026-04-13T05:50:44Z",
+      "status": "resolved_manually",
+      "outcome": "Erdos501Support companion - blocked by safety check (content already integrated); marked stale by mechanic"
+    },
+    {
+      "project_id": "922bc1f1-a9a2-454e-aada-5d0ebd3ce8b7",
+      "file": "proofs/Proofs/AngleTrisectionOQ02OQ04OQ01Aristotle.lean",
+      "problem_id": "angletrisectionoq02oq04oq01",
+      "submitted": "2026-04-13T05:53:30Z",
+      "status": "submitted",
+      "preprocessed": true,
+      "preprocessing_log": "Converted 1 /-! docstrings to /-",
+      "companion_file": true,
+      "notes": "Companion file submission (T1)"
+    },
+    {
+      "project_id": "7c8f8cfc-9fdc-4a9c-9cb8-7988cfa233d3",
+      "file": "proofs/Proofs/CantorDiagonalizationOQ04OQ03Aristotle.lean",
+      "problem_id": "cantordiagonalizationoq04oq03",
+      "submitted": "2026-04-13T05:53:36Z",
+      "status": "submitted",
+      "preprocessed": true,
+      "preprocessing_log": "Converted 1 /-! docstrings to /-",
+      "companion_file": true,
+      "notes": "Companion file submission (T1)"
+    },
+    {
+      "project_id": "c1627f72-3dde-4952-96df-99fd324a16c6",
+      "file": "proofs/Proofs/Erdos1126OQ01Aristotle.lean",
+      "problem_id": "erdos-1126oq01",
+      "submitted": "2026-04-13T05:53:40Z",
+      "status": "submitted",
+      "preprocessed": false,
+      "preprocessing_log": null,
+      "companion_file": true,
+      "notes": "Companion file submission (T1)"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Marked 11 stale `Erdos501Support` server jobs as `resolved_manually` in `research/aristotle-jobs.json` — these were blocking the Aristotle submission pipeline because the safety guard correctly refused to overwrite `Erdos501Problem.lean` with companion file content
- Submitted 3 new Aristotle companion files for proof search:
  - `AngleTrisectionOQ02OQ04OQ01Aristotle` 
  - `CantorDiagonalizationOQ04OQ03Aristotle`
  - `Erdos1126OQ01Aristotle`

## Background

The `retrieve-integrate.sh` script found 11 completed server jobs that were untracked locally. All 11 were results for `Erdos501Support` companion content, but the recovery logic mapped them to `Erdos501Problem.lean` (via the "Erdős Problem #501" comment). The safety check correctly blocked the overwrite. The companion file `Erdos501Aristotle.lean` already has 0 code sorries so the results were stale; marking them as `resolved_manually` clears the pipeline.

## Test plan

- [x] `submit-batch.sh --dry-run` no longer reports "recovery pipeline may be broken"
- [x] 3 new Aristotle jobs successfully submitted (IDs in jobs file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)