### PR TITLE
feat: Aristotle companion for chebyshev-pnt-bridge-oq-01

### DIFF
--- a/proofs/Proofs/ChebyshevPNTBridgeOQ01Aristotle.lean
+++ b/proofs/Proofs/ChebyshevPNTBridgeOQ01Aristotle.lean
@@ -1,0 +1,45 @@
+/-
+  Aristotle targets for ChebyshevPNTBridgeOQ01 (Factorization Bound for C(2n,n))
+  Routine supporting lemmas for automated proof search.
+  See ChebyshevPNTBridgeOQ01.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open conjecture
+  - Known result likely in Mathlib (central binomial bounds, Legendre formula)
+  - Clean theorem statement with no definition sorries
+  - No axioms (use theorem ... := by sorry instead)
+
+  Targets:
+  1. central_binom_lower_ari: C(2n,n) * (2n+1) ≥ 4^n
+     Proof: Sum of all C(2n,k) = 4^n (by Nat.sum_range_choose), and C(2n,n) is
+     the maximum term (by symmetry: C(2n,k) = C(2n,2n-k), and the central term
+     is largest). So 4^n = ∑_k C(2n,k) ≤ (2n+1) * C(2n,n).
+
+  2. legendre_val_ari: v_p(n!) = ∑_{i≥1} ⌊n/p^i⌋
+     Mathlib has Nat.factorization_factorial or Nat.Prime.factorization_factorial_eq.
+-/
+import Mathlib
+
+open Nat Finset BigOperators
+
+namespace ChebyshevPNTBridgeOQ01.Aristotle
+
+/-- **Central binomial lower bound** (Aristotle target):
+    (2n+1) * C(2n,n) ≥ 4^n.
+
+    Proof: ∑_{k=0}^{2n} C(2n,k) = 2^(2n) = 4^n by Nat.sum_range_choose.
+    The central term C(2n,n) is the maximum, so:
+    4^n = ∑_{k} C(2n,k) ≤ (2n+1) * C(2n,n). -/
+theorem central_binom_lower_ari (n : ℕ) :
+    (2 * n + 1) * Nat.choose (2 * n) n ≥ 4 ^ n := by
+  sorry
+
+/-- The p-adic valuation of C(2n,n) satisfies:
+    v_p(C(2n,n)) = v_p((2n)!) - 2 * v_p(n!)
+    and equals ∑_{i≥1} (⌊2n/p^i⌋ - 2⌊n/p^i⌋). -/
+theorem central_binom_factorization_eq (p n : ℕ) (hp : Nat.Prime p) :
+    ((2 * n).choose n).factorization p =
+    ((2 * n).factorization p) - 2 * (n.factorization p) := by
+  sorry
+
+end ChebyshevPNTBridgeOQ01.Aristotle


### PR DESCRIPTION
## Summary

- Adds `ChebyshevPNTBridgeOQ01Aristotle.lean` with 2 Aristotle proof targets
- `central_binom_lower_ari`: (2n+1) · C(2n,n) ≥ 4^n — needed for Chebyshev's lower bound on π(x)
- `central_binom_factorization_eq`: v_p(C(2n,n)) = v_p((2n)!) - 2·v_p(n!) — Legendre formula consequence

## Proof strategies

1. `central_binom_lower_ari`: Sum all C(2n,k) = 4^n via `Nat.sum_range_choose`; C(2n,n) is the maximum among the 2n+1 terms
2. `central_binom_factorization_eq`: Direct from `Nat.choose_factorization` or `Finsupp.sub` on factorizations

These support the main theorem `prime_pow_val_central_binom_le` which proves p^{v_p(C(2n,n))} ≤ 2n (a key ingredient in Bertrand's postulate / Chebyshev's method).

## Test plan

- [x] Companion file follows Aristotle format (no definition sorries, no axioms)
- [x] Theorem statements are clean and match the `ChebyshevPNTBridgeOQ01.lean` proof goals

🤖 Generated with [Claude Code](https://claude.com/claude-code)