### PR TITLE
Fix: correct axiom count and line count in hilbert-21 meta.json

### DIFF
--- a/src/data/proofs/hilbert-21/meta.json
+++ b/src/data/proofs/hilbert-21/meta.json
@@ -36,9 +36,9 @@
     ],
     "dateAdded": "2025-12-29",
     "hilbertNumber": 21,
-    "axiomCount": 3,
-    "lineCount": 386,
-    "assumptions": "3 axioms: plemelj_theorem_irreducible, bolibrukh_counterexample, realization_criterion. No sorries.",
+    "axiomCount": 4,
+    "lineCount": 387,
+    "assumptions": "4 axioms: computeMonodromy (monodromy computation function), plemelj_theorem_irreducible, bolibrukh_counterexample, realization_criterion. No sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -149,8 +149,8 @@
     ],
     "opens": [],
     "namespace": "Hilbert21",
-    "lineCount": 386,
-    "axiomCount": 3,
+    "lineCount": 387,
+    "axiomCount": 4,
     "theoremCount": 4,
     "definitionCount": 5,
     "path": "Proofs/Hilbert21RiemannHilbert.lean",


### PR DESCRIPTION
## Summary

- **axiomCount**: 3 → 4 (was missing `computeMonodromy` noncomputable axiom at line 181)
- **lineCount**: 386 → 387 (actual file length)
- **assumptions**: now lists all 4 axioms including `computeMonodromy`

## Evidence

Verified against `proofs/Proofs/Hilbert21RiemannHilbert.lean`:
- 4 `axiom` declarations: `computeMonodromy`, `plemelj_theorem_irreducible`, `bolibrukh_counterexample`, `realization_criterion`
- 4 theorems, 5 definitions, 0 sorries
- 387 lines

## Test plan

- [ ] `pnpm build` passes
- [ ] Gallery page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)