### PR TITLE
feat: symmetric channel capacity generalization (OQ 4)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -1827,6 +1827,7 @@ import Proofs.FactorRemainderTheoremOQ03
 import Proofs.FairGamesTheorem
 import Proofs.FairGamesTheoremOQ01
 import Proofs.FairGamesTheoremOQ02
+import Proofs.FairGamesTheoremOQ02OQ01
 import Proofs.FairGamesTheoremOQ03
 import Proofs.FairGamesTheoremOQ03Aristotle
 import Proofs.FermatTwoSquares

--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -117,6 +117,7 @@ import Proofs.BezoutIdentityOQ02OQ01OQ01
 import Proofs.BezoutIdentityOQ02OQ01OQ01OQ01
 import Proofs.BezoutIdentityOQ02OQ01OQ02
 import Proofs.BezoutIdentityOQ02OQ01OQ02OQ02
+import Proofs.BezoutIdentityOQ02OQ01OQ02OQ02OQ03
 import Proofs.BezoutIdentityOQ02OQ02
 import Proofs.BezoutIdentityOQ02OQ02OQ01
 import Proofs.BezoutIdentityOQ02OQ02OQ01OQ01

--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -292,6 +292,7 @@ import Proofs.CentralLimitTheoremOQ01
 import Proofs.CentralLimitTheoremOQ01OQ01
 import Proofs.CentralLimitTheoremOQ01OQ02
 import Proofs.CentralLimitTheoremOQ01OQ02OQ01
+import Proofs.CentralLimitTheoremOQ01OQ02OQ01OQ01
 import Proofs.CentralLimitTheoremOQ01OQ03
 import Proofs.CentralLimitTheoremOQ02
 import Proofs.CentralLimitTheoremOQ03

--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -65,6 +65,7 @@ import Proofs.AreaOfCircleOQ02
 import Proofs.AreaOfCircleOQ03OQ01
 import Proofs.AreaOfCircleOQ03OQ02
 import Proofs.AreaOfCircleOQ03OQ02OQ02
+import Proofs.AreaOfCircleOQ03OQ02OQ02OQ01
 import Proofs.AreaOfCircleOQ03OQ03
 import Proofs.AreaOfCircleOQ05
 import Proofs.AreaOfCircleOQ05OQ01

--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2141,6 +2141,7 @@ import Proofs.SchursTheorem
 import Proofs.SearchMathlib
 import Proofs.ShannonChannelCoding
 import Proofs.ShannonChannelCodingOQ02
+import Proofs.ShannonChannelCodingOQ02OQ04
 import Proofs.ShannonChannelCodingOQ02OQ01
 import Proofs.ShannonChannelCodingOQ02OQ01Aristotle
 import Proofs.ShannonChannelCodingOQ03

--- a/proofs/Proofs/AreaOfCircleOQ03OQ02OQ02OQ01.lean
+++ b/proofs/Proofs/AreaOfCircleOQ03OQ02OQ02OQ01.lean
@@ -1,0 +1,254 @@
+import Mathlib
+import Proofs.AreaOfCircleOQ03OQ02OQ02
+
+/-
+# Generalized Dalzell Integral: Sharper Rational Bounds on π
+
+## Research Problem: area-of-circle-oq-03-oq-02-oq-02-oq-01
+
+**Open Question** (from AreaOfCircleOQ03OQ02OQ02): Can the generalized Dalzell integral
+∫₀¹ x^(4n)(1-x)^(4n)/(1+x²) dx be used to derive sharper rational bounds on π?
+
+**Answer**: Yes. This file proves the n=2 case:
+
+  ∫₀¹ x⁸(1-x)⁸/(1+x²) dx = 4π - 188684/15015
+
+Since the integral is positive (the integrand is nonneg on [0,1]), we get:
+
+  π > 47171/15015 ≈ 3.14156...
+
+Combined with the n=1 result π < 22/7 ≈ 3.14286 (from parent proof), we obtain:
+
+  **47171/15015 < π < 22/7**
+
+## Mathematical Content
+
+The key identity is:
+  x⁸(1-x)⁸ = (1+x²) · Q(x) + 16
+where Q(x) = x¹⁴ - 8x¹³ + 27x¹² - 48x¹¹ + 43x¹⁰ - 8x⁹ - 15x⁸ + 16x⁶ - 16x⁴ + 16x² - 16
+
+Dividing by (1+x²):
+  x⁸(1-x)⁸/(1+x²) = Q(x) + 16/(1+x²)
+
+Integrating from 0 to 1:
+  ∫₀¹ x⁸(1-x)⁸/(1+x²) dx = ∫₀¹ Q(x) dx + 16·arctan(1) = -188684/15015 + 4π
+
+## Connection to Parent Proofs
+
+- **AreaOfCircleOQ03OQ02OQ02**: Proves π < 22/7 via the n=1 Dalzell integral
+- **This file**: Proves π > 47171/15015 via the n=2 case, establishing a two-sided bound
+
+## Tags: pi, integral, rational-approximation, Dalzell, bounds
+-/
+
+namespace AreaOfCircleOQ03OQ02OQ02OQ01
+
+open Real MeasureTheory Set intervalIntegral
+
+-- ============================================================
+-- Part I: Polynomial Identity (Remainder = +16)
+-- ============================================================
+
+/-- The n=2 Dalzell polynomial identity.
+    When dividing x⁸(1-x)⁸ by (1+x²), the remainder is +16 (not -4 as for n=1).
+    This means the n=2 integral gives a LOWER bound on π. -/
+theorem dalzell2_polynomial_identity (x : ℝ) :
+    x ^ 8 * (1 - x) ^ 8 =
+    (1 + x ^ 2) * (x ^ 14 - 8 * x ^ 13 + 27 * x ^ 12 - 48 * x ^ 11 + 43 * x ^ 10 -
+      8 * x ^ 9 - 15 * x ^ 8 + 16 * x ^ 6 - 16 * x ^ 4 + 16 * x ^ 2 - 16) + 16 := by
+  ring
+
+/-- The n=2 Dalzell integrand decomposes as Q(x) + 16/(1+x²) -/
+theorem dalzell2_integrand_decomposition (x : ℝ) :
+    x ^ 8 * (1 - x) ^ 8 / (1 + x ^ 2) =
+    (x ^ 14 - 8 * x ^ 13 + 27 * x ^ 12 - 48 * x ^ 11 + 43 * x ^ 10 -
+      8 * x ^ 9 - 15 * x ^ 8 + 16 * x ^ 6 - 16 * x ^ 4 + 16 * x ^ 2 - 16) +
+    16 / (1 + x ^ 2) := by
+  have h : (1 : ℝ) + x ^ 2 ≠ 0 := by positivity
+  field_simp
+  ring
+
+-- ============================================================
+-- Part II: Positivity of the Integrand
+-- ============================================================
+
+/-- The n=2 Dalzell integrand is nonneg on [0,1] -/
+theorem dalzell2_integrand_nonneg {x : ℝ} (hx0 : 0 ≤ x) (hx1 : x ≤ 1) :
+    0 ≤ x ^ 8 * (1 - x) ^ 8 / (1 + x ^ 2) := by
+  apply div_nonneg
+  · apply mul_nonneg
+    · positivity
+    · apply pow_nonneg; linarith
+  · positivity
+
+/-- The n=2 Dalzell integrand is strictly positive on (0,1) -/
+theorem dalzell2_integrand_pos {x : ℝ} (hx0 : 0 < x) (hx1 : x < 1) :
+    0 < x ^ 8 * (1 - x) ^ 8 / (1 + x ^ 2) := by
+  apply div_pos
+  · apply mul_pos
+    · positivity
+    · apply pow_pos; linarith
+  · positivity
+
+-- ============================================================
+-- Part III: Antiderivative via FTC
+-- ============================================================
+
+/-- The antiderivative of the n=2 Dalzell integrand.
+    F₂(x) = x¹⁵/15 - 4x¹⁴/7 + 27x¹³/13 - 4x¹² + 43x¹¹/11
+            - 4x¹⁰/5 - 5x⁹/3 + 16x⁷/7 - 16x⁵/5 + 16x³/3 - 16x + 16·arctan(x) -/
+noncomputable def dalzell2Antideriv (x : ℝ) : ℝ :=
+  x ^ 15 / 15 - 4 * x ^ 14 / 7 + 27 * x ^ 13 / 13 - 4 * x ^ 12 + 43 * x ^ 11 / 11
+  - 4 * x ^ 10 / 5 - 5 * x ^ 9 / 3 + 16 * x ^ 7 / 7 - 16 * x ^ 5 / 5 + 16 * x ^ 3 / 3
+  - 16 * x + 16 * arctan x
+
+/-- The decomposed form of the integrand (antiderivative's derivative) -/
+noncomputable def dalzell2Decomposed (x : ℝ) : ℝ :=
+  x ^ 14 - 8 * x ^ 13 + 27 * x ^ 12 - 48 * x ^ 11 + 43 * x ^ 10 -
+  8 * x ^ 9 - 15 * x ^ 8 + 16 * x ^ 6 - 16 * x ^ 4 + 16 * x ^ 2 - 16 +
+  16 / (1 + x ^ 2)
+
+/-- F₂'(x) = dalzell2Decomposed(x): the antiderivative has the right derivative -/
+theorem hasDerivAt_dalzell2Antideriv (x : ℝ) :
+    HasDerivAt dalzell2Antideriv (dalzell2Decomposed x) x := by
+  unfold dalzell2Antideriv dalzell2Decomposed
+  have h15 : HasDerivAt (fun x : ℝ => x ^ 15 / 15) (x ^ 14) x := by
+    have := (hasDerivAt_pow 15 x).div_const (15 : ℝ)
+    convert this using 1; push_cast; ring
+  have h14 : HasDerivAt (fun x : ℝ => 4 * x ^ 14 / 7) (8 * x ^ 13) x := by
+    have := ((hasDerivAt_pow 14 x).const_mul 4).div_const (7 : ℝ)
+    convert this using 1; push_cast; ring
+  have h13 : HasDerivAt (fun x : ℝ => 27 * x ^ 13 / 13) (27 * x ^ 12) x := by
+    have := ((hasDerivAt_pow 13 x).const_mul 27).div_const (13 : ℝ)
+    convert this using 1; push_cast; ring
+  have h12 : HasDerivAt (fun x : ℝ => 4 * x ^ 12) (48 * x ^ 11) x := by
+    have := (hasDerivAt_pow 12 x).const_mul (4 : ℝ)
+    convert this using 1; push_cast; ring
+  have h11 : HasDerivAt (fun x : ℝ => 43 * x ^ 11 / 11) (43 * x ^ 10) x := by
+    have := ((hasDerivAt_pow 11 x).const_mul 43).div_const (11 : ℝ)
+    convert this using 1; push_cast; ring
+  have h10 : HasDerivAt (fun x : ℝ => 4 * x ^ 10 / 5) (8 * x ^ 9) x := by
+    have := ((hasDerivAt_pow 10 x).const_mul 4).div_const (5 : ℝ)
+    convert this using 1; push_cast; ring
+  have h9 : HasDerivAt (fun x : ℝ => 5 * x ^ 9 / 3) (15 * x ^ 8) x := by
+    have := ((hasDerivAt_pow 9 x).const_mul 5).div_const (3 : ℝ)
+    convert this using 1; push_cast; ring
+  have h7 : HasDerivAt (fun x : ℝ => 16 * x ^ 7 / 7) (16 * x ^ 6) x := by
+    have := ((hasDerivAt_pow 7 x).const_mul 16).div_const (7 : ℝ)
+    convert this using 1; push_cast; ring
+  have h5 : HasDerivAt (fun x : ℝ => 16 * x ^ 5 / 5) (16 * x ^ 4) x := by
+    have := ((hasDerivAt_pow 5 x).const_mul 16).div_const (5 : ℝ)
+    convert this using 1; push_cast; ring
+  have h3 : HasDerivAt (fun x : ℝ => 16 * x ^ 3 / 3) (16 * x ^ 2) x := by
+    have := ((hasDerivAt_pow 3 x).const_mul 16).div_const (3 : ℝ)
+    convert this using 1; push_cast; ring
+  have h1 : HasDerivAt (fun x : ℝ => 16 * x) (16 : ℝ) x := by
+    have := (hasDerivAt_id x).const_mul (16 : ℝ)
+    convert this using 1; simp
+  have ha : HasDerivAt (fun x : ℝ => 16 * arctan x) (16 / (1 + x ^ 2)) x := by
+    have := (hasDerivAt_arctan x).const_mul (16 : ℝ)
+    convert this using 1; ring
+  -- Chain all terms together (left-associative, matching the definition's parsing)
+  have hcomb :=
+    ((((((((((h15.sub h14).add h13).sub h12).add h11).sub h10).sub h9).add h7).sub h5).add h3).sub h1).add ha
+  convert hcomb using 1
+  · rfl
+  · ring
+
+/-- The decomposed integrand is continuous -/
+theorem continuous_dalzell2Decomposed : Continuous dalzell2Decomposed := by
+  unfold dalzell2Decomposed
+  fun_prop
+
+/-- F₂(0) = 0 -/
+theorem dalzell2Antideriv_zero : dalzell2Antideriv 0 = 0 := by
+  simp [dalzell2Antideriv]
+
+/-- F₂(1) = 4π - 188684/15015 -/
+theorem dalzell2Antideriv_one : dalzell2Antideriv 1 = 4 * Real.pi - 188684 / 15015 := by
+  unfold dalzell2Antideriv
+  rw [arctan_one]
+  ring
+
+/-- The integral of the decomposed form from 0 to 1 equals 4π - 188684/15015 -/
+theorem dalzell2_decomposed_integral :
+    ∫ x in (0 : ℝ)..1, dalzell2Decomposed x = 4 * Real.pi - 188684 / 15015 := by
+  have h_deriv : ∀ x ∈ uIcc (0 : ℝ) 1,
+      HasDerivAt dalzell2Antideriv (dalzell2Decomposed x) x :=
+    fun x _ => hasDerivAt_dalzell2Antideriv x
+  have h_int : IntervalIntegrable dalzell2Decomposed volume 0 1 :=
+    continuous_dalzell2Decomposed.intervalIntegrable 0 1
+  rw [integral_eq_sub_of_hasDerivAt h_deriv h_int,
+      dalzell2Antideriv_one, dalzell2Antideriv_zero, sub_zero]
+
+-- ============================================================
+-- Part IV: The n=2 Dalzell Integral Identity
+-- ============================================================
+
+/-- The n=2 integrand is continuous -/
+theorem continuous_dalzell2_integrand :
+    Continuous (fun x => x ^ 8 * (1 - x) ^ 8 / (1 + x ^ 2)) := by
+  apply Continuous.div
+  · exact (continuous_pow 8).mul ((continuous_const.sub continuous_id').pow 8)
+  · exact continuous_const.add (continuous_pow 2)
+  · intro x; positivity
+
+/-- The original integrand equals the decomposed form -/
+theorem dalzell2_integrand_eq_decomposed :
+    (fun x : ℝ => x ^ 8 * (1 - x) ^ 8 / (1 + x ^ 2)) = dalzell2Decomposed := by
+  ext x; exact dalzell2_integrand_decomposition x
+
+/-- **The n=2 Dalzell Integral Identity**:
+    ∫₀¹ x⁸(1-x)⁸/(1+x²) dx = 4π - 188684/15015 -/
+theorem dalzell2_integral :
+    ∫ x in (0 : ℝ)..1, x ^ 8 * (1 - x) ^ 8 / (1 + x ^ 2) =
+    4 * Real.pi - 188684 / 15015 := by
+  rw [show ∫ x in (0 : ℝ)..1, x ^ 8 * (1 - x) ^ 8 / (1 + x ^ 2) =
+      ∫ x in (0 : ℝ)..1, dalzell2Decomposed x from by
+    congr 1; exact dalzell2_integrand_eq_decomposed]
+  exact dalzell2_decomposed_integral
+
+-- ============================================================
+-- Part V: π > 47171/15015 from the Integral
+-- ============================================================
+
+/-- **Main Result**: π > 47171/15015 via the n=2 Dalzell integral.
+    The n=2 integral gives a LOWER bound (opposite direction from n=1).
+    The remainder for n=2 is +16 instead of -4, flipping the inequality. -/
+theorem pi_gt_lower_bound : (47171 : ℝ) / 15015 < Real.pi := by
+  have h_integral := dalzell2_integral
+  have h_pos : 0 < ∫ x in (0 : ℝ)..1, x ^ 8 * (1 - x) ^ 8 / (1 + x ^ 2) := by
+    apply integral_pos (by norm_num : (0 : ℝ) < 1)
+    · exact continuous_dalzell2_integrand.continuousOn
+    · intro x hx
+      exact dalzell2_integrand_nonneg (le_of_lt hx.1) hx.2
+    · exact ⟨1/2, mem_Icc.mpr ⟨by norm_num, by norm_num⟩,
+        dalzell2_integrand_pos (by norm_num) (by norm_num)⟩
+  linarith
+
+-- ============================================================
+-- Part VI: The Two-Sided Rational Sandwich for π
+-- ============================================================
+
+/-- **Fundamental Sandwich**: 47171/15015 < π < 22/7.
+    Combining the n=1 upper bound (from parent proof) with the n=2 lower bound.
+
+    This gives a rigorous two-sided rational approximation to π:
+    - Lower bound: 47171/15015 ≈ 3.14156...
+    - True value:  π           ≈ 3.14159...
+    - Upper bound: 22/7        ≈ 3.14286...
+
+    The Dalzell integral sequence provides increasingly tight bounds:
+    for larger n, the integrals ∫₀¹ x^(4n)(1-x)^(4n)/(1+x²) dx → 0,
+    yielding sharper rational approximations to π. -/
+theorem pi_rational_sandwich :
+    (47171 : ℝ) / 15015 < Real.pi ∧ Real.pi < 22 / 7 :=
+  ⟨pi_gt_lower_bound, AreaOfCircleOQ03OQ02OQ02.pi_lt_twentytwo_over_seven⟩
+
+/-- Explicit lower bound: π > 3.141556... -/
+theorem pi_gt_3141556 : (3141556 : ℝ) / 1000000 < Real.pi := by
+  have h1 := pi_gt_lower_bound
+  have h2 : (3141556 : ℝ) / 1000000 < 47171 / 15015 := by norm_num
+  linarith
+
+end AreaOfCircleOQ03OQ02OQ02OQ01

--- a/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean
+++ b/proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean
@@ -1,0 +1,323 @@
+import Mathlib
+import Proofs.BezoutIdentityOQ02OQ01OQ02OQ02
+
+/-
+# ℤ[√-2] as a Euclidean Domain: Inert Prime Classification
+
+## Research Problem: bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03
+
+**Open Question** (from BezoutIdentityOQ02OQ01OQ02OQ02): Can the inert prime technique
+be generalized to other Euclidean imaginary quadratic rings, such as ℤ[√-2]?
+
+**Answer**: Yes. This file establishes:
+
+1. **ℤ[√-2] is a Euclidean domain** with Euclidean function N(a+b√-2) = a² + 2b².
+   (The rounding error satisfies δ₁² + 2δ₂² ≤ 3/4 < 1.)
+
+2. **Inert prime classification**: A rational prime p is prime in ℤ[√-2] if and only if
+   p ≡ 5 or 7 (mod 8), i.e., the Legendre symbol (-2/p) = -1.
+
+## Mathematical Content
+
+**Why the Euclidean algorithm works**: For x/y in ℚ[√-2], round the re and im coordinates.
+The error δ = (δ₁, δ₂) with |δ₁|, |δ₂| ≤ 1/2 gives N(remainder) = N(y)·(δ₁² + 2δ₂²) ≤ 3N(y)/4 < N(y).
+
+**Why p ≡ 5 or 7 (mod 8) is inert**: If N(a) = p → a₀² + 2b₀² = p.
+But a² + 2b² mod 8 ∈ {0,1,2,3,4,6}, never 5 or 7.
+
+## Tags: number-theory, Gaussian-integers, Zsqrtd, inert-primes, Euclidean-domain
+-/
+
+namespace ZSqrtNegTwo
+
+open Zsqrtd Complex Real
+
+/-- ℤ[√-2] — the ring of integers of ℚ(√-2). -/
+abbrev ℤ√neg2 := Zsqrtd (-2 : ℤ)
+
+-- ============================================================
+-- Part I: Basic Norm Properties
+-- ============================================================
+
+/-- The norm N(a + b√-2) = a² + 2b² is always nonneg. -/
+theorem norm_nonneg (z : ℤ√neg2) : 0 ≤ Zsqrtd.norm z := by
+  simp only [Zsqrtd.norm]
+  nlinarith [sq_nonneg z.re, sq_nonneg z.im]
+
+/-- The norm is positive for nonzero elements (key for Euclidean algorithm). -/
+theorem norm_pos_of_ne_zero {z : ℤ√neg2} (hz : z ≠ 0) : 0 < Zsqrtd.norm z := by
+  rcases (norm_nonneg z).lt_or_eq with h | h
+  · exact h
+  · exfalso; apply hz
+    have hnn : Zsqrtd.norm z = 0 := h.symm
+    simp only [Zsqrtd.norm] at hnn
+    have hre : z.re = 0 := by nlinarith [sq_nonneg z.re, sq_nonneg z.im]
+    have him : z.im = 0 := by nlinarith [sq_nonneg z.re, sq_nonneg z.im]
+    exact Zsqrtd.ext hre him
+
+/-- Norm formula: N(a + b√-2) = a² + 2b². -/
+theorem norm_formula (z : ℤ√neg2) : Zsqrtd.norm z = z.re ^ 2 + 2 * z.im ^ 2 := by
+  simp [Zsqrtd.norm]; ring
+
+/-- Norm is nonneg (alternative formulation needed for natAbs). -/
+theorem norm_natAbs_cast (z : ℤ√neg2) : (z.norm.natAbs : ℤ) = z.norm :=
+  Int.natAbs_of_nonneg (norm_nonneg z)
+
+-- ============================================================
+-- Part II: Embedding into ℂ for Norm Computation
+-- ============================================================
+
+/-- The embedding ℤ[√-2] →+* ℂ sending √-2 ↦ i√2. -/
+noncomputable def toComplex : ℤ√neg2 →+* ℂ :=
+  Zsqrtd.lift ⟨Real.sqrt 2 * Complex.I,
+    by push_cast; rw [mul_pow, sq_sqrt (by norm_num : (2:ℝ) ≥ 0), I_sq]; ring⟩
+
+@[simp]
+theorem toComplex_apply (z : ℤ√neg2) :
+    toComplex z = z.re + z.im * (Real.sqrt 2 * Complex.I) := by
+  simp [toComplex, Zsqrtd.lift_apply]
+
+/-- The complex embedding is injective. -/
+theorem toComplex_injective : Function.Injective toComplex := by
+  intro x y h
+  simp only [toComplex_apply] at h
+  have hre : (x.re : ℂ) = y.re := by
+    have := congr_arg Complex.re h
+    simp at this; exact_mod_cast this
+  have him : (x.im : ℂ) = y.im := by
+    have := congr_arg Complex.im h
+    simp [Real.sqrt_ne_zero'] at this
+    have hsqrt2 : (Real.sqrt 2 : ℝ) ≠ 0 := Real.sqrt_ne_zero'.mpr (by norm_num)
+    have := mul_left_cancel₀ (ofReal_ne_zero.mpr hsqrt2) this
+    exact_mod_cast this
+  exact Zsqrtd.ext (by exact_mod_cast hre) (by exact_mod_cast him)
+
+/-- The Zsqrtd norm equals Complex.normSq ∘ toComplex. -/
+theorem norm_eq_normSq (z : ℤ√neg2) :
+    (z.norm : ℝ) = Complex.normSq (toComplex z) := by
+  simp [toComplex_apply, normSq_apply, Zsqrtd.norm,
+        sq_sqrt (show (2:ℝ) ≥ 0 by norm_num)]
+  push_cast; ring
+
+-- ============================================================
+-- Part III: Euclidean Division Algorithm
+-- ============================================================
+
+noncomputable instance : Div ℤ√neg2 :=
+  ⟨fun x y =>
+    let n := (Zsqrtd.norm y : ℚ)
+    let c := star y
+    ⟨round ((x * c).re / n : ℚ), round ((x * c).im / n : ℚ)⟩⟩
+
+noncomputable instance : Mod ℤ√neg2 :=
+  ⟨fun x y => x - y * (x / y)⟩
+
+theorem div_def (x y : ℤ√neg2) :
+    x / y = ⟨round ((x * star y).re / Zsqrtd.norm y : ℚ),
+             round ((x * star y).im / Zsqrtd.norm y : ℚ)⟩ := rfl
+
+theorem mod_def (x y : ℤ√neg2) : x % y = x - y * (x / y) := rfl
+
+-- ============================================================
+-- Part IV: The Key Norm Bound (3/4 rule)
+-- ============================================================
+
+/-- The exact complex quotient x/y decomposes as α + √2·β·I
+    where α = (x·ȳ).re / N(y) and β = (x·ȳ).im / N(y). -/
+private theorem toComplex_div_eq (x y : ℤ√neg2) (hy : y ≠ 0) :
+    (toComplex x / toComplex y : ℂ) =
+    (((x * star y).re : ℚ) / Zsqrtd.norm y : ℚ) +
+    Real.sqrt 2 * (((x * star y).im : ℚ) / Zsqrtd.norm y : ℚ) * Complex.I := by
+  have hy_ℂ : (toComplex y : ℂ) ≠ 0 := fun h => hy (toComplex_injective (by simp [h]))
+  have hN : (Zsqrtd.norm y : ℂ) ≠ 0 := by
+    exact_mod_cast (norm_pos_of_ne_zero hy).ne'
+  rw [div_eq_iff hy_ℂ]
+  apply Complex.ext
+  · simp only [mul_re, add_re, ofReal_re, mul_re, ofReal_re, I_re, mul_zero,
+               ofReal_im, I_im, mul_one, sub_zero, add_re, add_zero, toComplex_apply]
+    push_cast
+    have hN' : (Zsqrtd.norm y : ℝ) ≠ 0 := by exact_mod_cast (norm_pos_of_ne_zero hy).ne'
+    rw [Zsqrtd.norm]
+    simp [Zsqrtd.star_def, Zsqrtd.mul_def, mul_comm]
+    field_simp
+    ring
+  · simp only [mul_im, add_im, ofReal_im, mul_im, ofReal_re, I_im, mul_one,
+               ofReal_im, I_re, mul_zero, add_zero, zero_add, toComplex_apply]
+    push_cast
+    have hN' : (Zsqrtd.norm y : ℝ) ≠ 0 := by exact_mod_cast (norm_pos_of_ne_zero hy).ne'
+    rw [Zsqrtd.norm]
+    simp [Zsqrtd.star_def, Zsqrtd.mul_def, mul_comm]
+    field_simp
+    have h2 : Real.sqrt 2 ^ 2 = 2 := Real.sq_sqrt (by norm_num)
+    nlinarith [h2]
+
+/-- The rounded quotient in ℂ: round(α) + √2·round(β)·I. -/
+private theorem toComplex_quot_eq (x y : ℤ√neg2) :
+    (toComplex (x / y) : ℂ) =
+    (round ((x * star y).re / Zsqrtd.norm y : ℚ) : ℤ) +
+    Real.sqrt 2 * (round ((x * star y).im / Zsqrtd.norm y : ℚ) : ℤ) * Complex.I := by
+  simp [toComplex_apply, div_def]
+  push_cast; ring
+
+/-- **Key bound**: The rounding error has normSq ≤ 3/4 < 1. -/
+theorem normSq_div_sub_div_lt_one (x y : ℤ√neg2) (hy : y ≠ 0) :
+    Complex.normSq ((toComplex x / toComplex y : ℂ) - toComplex (x / y)) < 1 := by
+  set rα : ℚ := ((x * star y).re : ℚ) / Zsqrtd.norm y
+  set rβ : ℚ := ((x * star y).im : ℚ) / Zsqrtd.norm y
+  -- Express error as δα + √2·δβ·I where |δα|, |δβ| ≤ 1/2
+  have herr : (toComplex x / toComplex y : ℂ) - toComplex (x / y) =
+      (rα - round rα : ℚ) + Real.sqrt 2 * (rβ - round rβ : ℚ) * Complex.I := by
+    rw [toComplex_div_eq x y hy, toComplex_quot_eq]
+    push_cast; ring
+  rw [herr]
+  -- Compute normSq = (rα - round rα)² + 2*(rβ - round rβ)²
+  have hδα : |(rα - round rα : ℝ)| ≤ 1/2 := by
+    have := abs_sub_round rα
+    exact_mod_cast this
+  have hδβ : |(rβ - round rβ : ℝ)| ≤ 1/2 := by
+    have := abs_sub_round rβ
+    exact_mod_cast this
+  have h2 : Real.sqrt 2 ^ 2 = 2 := Real.sq_sqrt (by norm_num)
+  rw [normSq_apply]
+  simp only [add_re, ofReal_re, mul_re, ofReal_re, I_re, mul_zero, sub_zero,
+             ofReal_im, I_im, mul_one, add_im, ofReal_im, mul_im, ofReal_re, I_re, add_zero]
+  push_cast
+  nlinarith [sq_abs (rα - round rα : ℝ), sq_abs (rβ - round rβ : ℝ), h2,
+             sq_nonneg (rα - round rα : ℝ), sq_nonneg (rβ - round rβ : ℝ)]
+
+/-- **Key Result**: The remainder has strictly smaller norm. -/
+theorem norm_mod_lt (x : ℤ√neg2) {y : ℤ√neg2} (hy : y ≠ 0) :
+    (x % y).norm < y.norm := by
+  have hy_ℂ : (toComplex y : ℂ) ≠ 0 := fun h => hy (toComplex_injective (by simp [h]))
+  rw [mod_def]
+  apply_fun (Int.cast : ℤ → ℝ) using Int.cast_injective
+  rw [norm_eq_normSq, norm_eq_normSq]
+  calc Complex.normSq (toComplex (x - y * (x / y)))
+      = Complex.normSq (toComplex y * (toComplex x / toComplex y - toComplex (x / y))) := by
+        rw [map_sub, map_mul, mul_sub, mul_div_cancel₀ _ hy_ℂ]; ring
+    _ = Complex.normSq (toComplex y) *
+        Complex.normSq (toComplex x / toComplex y - toComplex (x / y)) := normSq_mul _ _
+    _ < Complex.normSq (toComplex y) * 1 :=
+        mul_lt_mul_of_pos_left (normSq_div_sub_div_lt_one x y hy) (normSq_pos.2 hy_ℂ)
+    _ = _ := mul_one _
+
+theorem norm_mod_lt_natAbs (x : ℤ√neg2) {y : ℤ√neg2} (hy : y ≠ 0) :
+    (x % y).norm.natAbs < y.norm.natAbs :=
+  Int.ofNat_lt.1 (by simpa [norm_natAbs_cast] using norm_mod_lt x hy)
+
+-- ============================================================
+-- Part V: ℤ[√-2] is a Euclidean Domain
+-- ============================================================
+
+/-- **ℤ[√-2] is a Euclidean Domain** with norm N(a+b√-2) = a² + 2b². -/
+noncomputable instance : EuclideanDomain ℤ√neg2 :=
+  { (inferInstance : CommRing ℤ√neg2), (inferInstance : Nontrivial ℤ√neg2) with
+    quotient := (· / ·)
+    remainder := (· % ·)
+    quotient_zero := fun a => by
+      simp [div_def, Zsqrtd.norm]
+    quotient_mul_add_remainder_eq := fun x y => by simp [mod_def]
+    r := fun a b => a.norm.natAbs < b.norm.natAbs
+    r_wellFounded := measure_wf (fun z => z.norm.natAbs)
+    remainder_lt := fun x {y} hy => norm_mod_lt_natAbs x hy
+    mul_left_not_lt := fun a b hb => by
+      simp only
+      rw [Zsqrtd.norm_mul, Int.natAbs_mul]
+      exact Nat.le_mul_of_pos_left _ (Nat.pos_of_ne_zero (fun h => by
+        simp only [Int.natAbs_eq_zero] at h
+        exact hb (Zsqrtd.norm_eq_zero_iff.mp h))) }
+
+-- Derive UFD from Euclidean domain
+instance : UniqueFactorizationMonoid ℤ√neg2 :=
+  EuclideanDomain.toUniqueFactorizationDomain
+
+-- ============================================================
+-- Part VI: Inert Prime Classification for ℤ[√-2]
+-- ============================================================
+
+/-- Squares mod 8 are {0,1,4}, so a² + 2b² mod 8 ∈ {0,1,2,3,4,6}, never 5 or 7. -/
+theorem no_sum_form_mod8 {p : ℕ} (hp5 : p % 8 = 5 ∨ p % 8 = 7) :
+    ∀ a b : ZMod 8, a ^ 2 + 2 * b ^ 2 ≠ (p : ZMod 8) := by
+  rcases hp5 with h | h <;>
+  · rw [show (p : ZMod 8) = ((p % 8 : ℕ) : ZMod 8) from by
+          simp [ZMod.natCast_eq_natCast_iff]
+        h]
+    decide
+
+/-- **Inert prime classification**: p ≡ 5 or 7 (mod 8) → p is prime in ℤ[√-2].
+    This is the condition (-2/p) = -1 (Legendre symbol). -/
+theorem inert_prime_neg2 (p : ℕ) [hp : Fact p.Prime]
+    (hmod : p % 8 = 5 ∨ p % 8 = 7) :
+    Prime ((p : ℤ) : ℤ√neg2) := by
+  have hprime := hp.out
+  rw [← UniqueFactorizationMonoid.irreducible_iff_prime]
+  have hnorm : ((p : ℤ) : ℤ√neg2).norm = (p : ℤ) ^ 2 := by
+    simp [Zsqrtd.norm]; push_cast; ring
+  refine ⟨fun hu => ?_, ?_⟩
+  · -- Not a unit: norm = p² ≥ 25 > 1
+    have h1 : ((p : ℤ) : ℤ√neg2).norm.natAbs = 1 :=
+      Zsqrtd.norm_eq_one_iff.mpr hu
+    simp only [hnorm, Int.natAbs_pow, Int.natAbs_natCast] at h1
+    nlinarith [hprime.two_le]
+  intro a b hab
+  -- norm(a) * norm(b) = p²
+  have hna_nn := norm_nonneg a
+  have hnb_nn := norm_nonneg b
+  have hfact : a.norm.natAbs * b.norm.natAbs = p ^ 2 := by
+    have hmul : (a * b).norm = a.norm * b.norm := Zsqrtd.norm_mul a b
+    have heq : (p : ℤ) ^ 2 = a.norm * b.norm := by rw [← hnorm, hab]; exact hmul
+    have ha_eq : a.norm = (a.norm.natAbs : ℤ) := (Int.natAbs_of_nonneg hna_nn).symm
+    have hb_eq : b.norm = (b.norm.natAbs : ℤ) := (Int.natAbs_of_nonneg hnb_nn).symm
+    exact_mod_cast (by linarith [ha_eq ▸ hb_eq ▸ heq] : (p : ℤ) ^ 2 =
+      (a.norm.natAbs : ℤ) * (b.norm.natAbs : ℤ)).symm
+  by_cases hau : a.norm.natAbs = 1
+  · left; exact Zsqrtd.norm_eq_one_iff.mp hau
+  by_cases hbu : b.norm.natAbs = 1
+  · right; exact Zsqrtd.norm_eq_one_iff.mp hbu
+  -- Both non-units: norm(a), norm(b) ≥ 2
+  exfalso
+  have ha2 : 2 ≤ a.norm.natAbs := by
+    rcases Nat.eq_zero_or_pos a.norm.natAbs with h0 | hpos
+    · simp [h0] at hfact; exact absurd hfact.symm (pow_pos hprime.pos 2).ne'
+    · omega
+  have hb2 : 2 ≤ b.norm.natAbs := by
+    rcases Nat.eq_zero_or_pos b.norm.natAbs with h0 | hpos
+    · simp [h0, Nat.mul_zero] at hfact; exact absurd hfact.symm (pow_pos hprime.pos 2).ne'
+    · omega
+  -- norm(a) must equal p
+  have hap : a.norm.natAbs = p := by
+    have hdvd : a.norm.natAbs ∣ p ^ 2 := ⟨b.norm.natAbs, hfact.symm⟩
+    rcases (Nat.dvd_prime_pow hprime).mp hdvd with ⟨k, hk_le, hk_eq⟩
+    interval_cases k
+    · simp at hk_eq; omega
+    · simpa using hk_eq
+    · -- k=2: a.norm.natAbs = p², forces b.norm.natAbs = 1
+      rw [hk_eq] at hfact
+      have hb1 := Nat.eq_of_mul_eq_mul_left (pow_pos hprime.pos 2)
+        (hfact.trans (mul_one (p ^ 2)).symm)
+      omega
+  -- norm(a) = p means a.re² + 2*a.im² = p
+  have hsum : a.re ^ 2 + 2 * a.im ^ 2 = (p : ℤ) := by
+    have ha_nat : a.norm = (p : ℤ) := by
+      rw [← Int.natAbs_of_nonneg hna_nn, hap]; simp
+    linarith [norm_formula a]
+  -- Cast to ZMod 8: a.re² + 2*a.im² ≡ p (mod 8)
+  have h8 : (a.re : ZMod 8) ^ 2 + 2 * (a.im : ZMod 8) ^ 2 = (p : ZMod 8) := by
+    have := congr_arg (Int.cast : ℤ → ZMod 8) hsum
+    push_cast at this ⊢; exact this
+  exact no_sum_form_mod8 hmod (a.re : ZMod 8) (a.im : ZMod 8) h8
+
+/-- **Concrete examples**: 5 and 7 are inert (prime) in ℤ[√-2]. -/
+theorem five_is_inert : Prime ((5 : ℤ) : ℤ√neg2) :=
+  inert_prime_neg2 5 (by norm_num) (by decide)
+
+theorem seven_is_inert : Prime ((7 : ℤ) : ℤ√neg2) :=
+  inert_prime_neg2 7 (by norm_num) (by decide)
+
+/-- **Splitting**: 3 = (1+√-2)·(1-√-2) since 1² + 2·1² = 3. -/
+theorem three_splits : (3 : ℤ√neg2) = ⟨1, 1⟩ * ⟨1, -1⟩ := by decide
+
+/-- **Ramification**: 2 = -(√-2)² since N(√-2) = 2. -/
+theorem two_ramifies : (2 : ℤ√neg2) = -(⟨0, 1⟩ : ℤ√neg2) ^ 2 := by decide
+
+end ZSqrtNegTwo

--- a/proofs/Proofs/FairGamesTheoremOQ02OQ01.lean
+++ b/proofs/Proofs/FairGamesTheoremOQ02OQ01.lean
@@ -1,0 +1,291 @@
+import Mathlib
+import Proofs.FairGamesTheoremOQ03
+
+/-!
+# Optional Stopping Theorem: Standalone Formalization
+
+## Research Problem: fair-games-theorem-oq-02-oq-01
+
+**Open Question** (from FairGamesTheoremOQ02): Can the Optional Stopping Theorem
+itself (not just the Gambler's Ruin formulas) be formalized in Lean 4? Doob's
+theorem requires a filtered probability space and integrability conditions —
+is Mathlib's probability library sufficient?
+
+**Answer**: Yes. This file gives the definitive answer: Doob's Optional Stopping
+Theorem is fully formalizable using Mathlib's probability infrastructure.
+
+## The Optional Stopping Theorem (Doob, 1953)
+
+Let (Ω, ℱ, P) be a probability space with filtration {ℱₙ}. Let {Xₙ} be a
+martingale adapted to {ℱₙ}, and let τ be a stopping time. Under appropriate
+integrability conditions, E[X_τ] = E[X_0].
+
+The main forms:
+1. **Bounded OST**: τ ≤ N (deterministic) → E[X_τ] = E[X_0]
+2. **Two stopping times**: τ ≤ σ ≤ N → E[X_τ] = E[X_σ]
+3. **Submartingale inequality**: τ ≤ σ ≤ N, f submartingale → E[f_τ] ≤ E[f_σ]
+
+## Mathlib Infrastructure
+
+The proof uses `Mathlib.Probability.Martingale.OptionalStopping`:
+- `Submartingale.expected_stoppedValue_mono`: the key monotonicity result
+- `Martingale.setIntegral_eq`: martingale expected value identity
+- `Martingale.ae_tendsto_limitProcess`: almost sure convergence
+
+## Connection to Parent Proofs
+
+- **FairGamesTheoremOQ02**: Gambler's Ruin formulas (derived algebraically)
+- **FairGamesTheoremOQ03**: Application theorems using Mathlib's martingale library
+- **This file**: Comprehensive formalization of the OST itself
+
+## Tags: probability, martingale, optional-stopping, doob, convergence
+-/
+
+noncomputable section
+
+open MeasureTheory MeasureTheory.Filtration
+
+namespace FairGamesOQ02OQ01
+
+-- ============================================================
+-- Part I: The Optional Stopping Theorem (Three Forms)
+-- ============================================================
+
+/-- **Doob's Optional Stopping Theorem** — Bounded Version.
+
+    For a martingale {Xₙ} adapted to filtration ℱ, and a bounded stopping time
+    τ ≤ N, the expected value of X at the stopping time equals the initial value:
+    E[X_τ] = E[X_0].
+
+    **Why τ ≤ N is needed**: Without boundedness, we need additional conditions
+    (e.g., uniform integrability, or L² boundedness). The bounded case is the
+    cleanest: just apply the submartingale/supermartingale squeeze.
+
+    **Mathlib proof**: Use `Submartingale.expected_stoppedValue_mono` for each
+    direction and conclude via `le_antisymm`.
+
+    Reference: J.L. Doob, "Stochastic Processes" (1953), Chapter VII. -/
+theorem doob_optional_stopping_theorem
+    {Ω : Type*} {m : MeasurableSpace Ω}
+    {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {ℱ : Filtration ℕ m}
+    (X : ℕ → Ω → ℝ) (hX : Martingale X ℱ μ)
+    (τ : Ω → ℕ∞) (hτ : IsStoppingTime ℱ τ)
+    (N : ℕ) (hτN : ∀ ω, τ ω ≤ N) :
+    ∫ ω, stoppedValue X τ ω ∂μ = ∫ ω, X 0 ω ∂μ :=
+  FairGamesOQ03.any_bounded_strategy_preserves_expectation X hX τ hτ N hτN
+
+/-- **OST — Submartingale Inequality**.
+
+    For a *submartingale* {Xₙ} (where E[X_{n+1} | ℱₙ] ≥ Xₙ), and bounded
+    stopping times τ ≤ σ ≤ N, the expected values are ordered:
+    E[X_τ] ≤ E[X_σ].
+
+    This is the weak version of OST: for a process that tends to increase on
+    average, stopping earlier gives a smaller or equal expected payoff. -/
+theorem doob_ost_submartingale
+    {Ω : Type*} {m : MeasurableSpace Ω}
+    {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {ℱ : Filtration ℕ m}
+    (X : ℕ → Ω → ℝ) (hX : Submartingale X ℱ μ)
+    (τ σ : Ω → ℕ∞)
+    (hτ : IsStoppingTime ℱ τ) (hσ : IsStoppingTime ℱ σ)
+    (hτσ : τ ≤ σ) (N : ℕ) (hσN : ∀ ω, σ ω ≤ N) :
+    ∫ ω, stoppedValue X τ ω ∂μ ≤ ∫ ω, stoppedValue X σ ω ∂μ :=
+  hX.expected_stoppedValue_mono hτ hσ hτσ hσN
+
+/-- **OST — Two Stopping Times**.
+
+    For a martingale {Xₙ} and bounded stopping times τ ≤ σ ≤ N:
+    E[X_τ] = E[X_σ].
+
+    This is the two-stopping-time version: any two bounded strategies applied
+    to the same martingale give the same expected outcome. -/
+theorem doob_ost_two_stopping_times
+    {Ω : Type*} {m : MeasurableSpace Ω}
+    {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {ℱ : Filtration ℕ m}
+    (X : ℕ → Ω → ℝ) (hX : Martingale X ℱ μ)
+    (τ σ : Ω → ℕ∞)
+    (hτ : IsStoppingTime ℱ τ) (hσ : IsStoppingTime ℱ σ)
+    (hτσ : τ ≤ σ) (N : ℕ) (hσN : ∀ ω, σ ω ≤ N) :
+    ∫ ω, stoppedValue X τ ω ∂μ = ∫ ω, stoppedValue X σ ω ∂μ :=
+  FairGamesOQ03.two_strategies_same_expectation X hX τ σ hτ hσ hτσ N hσN
+
+-- ============================================================
+-- Part II: The Martingale Convergence Theorem (Doob)
+-- ============================================================
+
+/-- **Doob's Martingale Convergence Theorem**.
+
+    A uniformly integrable martingale {Xₙ} converges almost surely to the
+    conditional expectation E[X_∞ | ℱ_∞], where ℱ_∞ = σ(⋃ₙ ℱₙ).
+
+    This is the heart of martingale theory: bounded martingales always converge.
+    The proof uses the upcrossing inequality (Doob's upcrossing lemma):
+    upcrossings of [a,b] before time N are bounded by (E[X_N⁺] - a)/(b-a).
+
+    In Mathlib: `Martingale.ae_tendsto_limitProcess` gives this for uniformly
+    integrable martingales (which includes all L∞-bounded ones). -/
+theorem doob_martingale_convergence
+    {Ω : Type*} {m : MeasurableSpace Ω}
+    {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {ℱ : Filtration ℕ m}
+    (X : ℕ → Ω → ℝ) (hX : Martingale X ℱ μ)
+    (hUI : UniformIntegrable X 1 μ) :
+    ∀ᵐ ω ∂μ, Filter.Tendsto (fun n => X n ω) Filter.atTop
+      (nhds (ℱ.limitProcess X μ ω)) :=
+  hX.ae_tendsto_limitProcess hUI
+
+-- ============================================================
+-- Part III: The "No Strategy" Corollary
+-- ============================================================
+
+/-- **No Profitable Betting Strategy in a Fair Game**.
+
+    In a fair game (martingale), no stopping time strategy can increase your
+    expected gain beyond the initial wealth.
+
+    This is the mathematical formalization of the "no free lunch" principle:
+    - Initial wealth: E[X_0]
+    - Wealth at stopping time τ: E[X_τ]
+    - OST: E[X_τ] = E[X_0]
+
+    Corollary: the expected return from any bounded strategy equals the
+    expected initial value.
+
+    This gives a rigorous proof that the Gambler's Ruin win probability
+    P(win) = k/N follows from E[X_τ] = X_0 = k (bounded OST) and
+    X_τ ∈ {0, N} (absorbing barriers). -/
+theorem no_profitable_stopping_strategy
+    {Ω : Type*} {m : MeasurableSpace Ω}
+    {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {ℱ : Filtration ℕ m}
+    (X : ℕ → Ω → ℝ) (hX : Martingale X ℱ μ)
+    (τ : Ω → ℕ∞) (hτ : IsStoppingTime ℱ τ)
+    (N : ℕ) (hτN : ∀ ω, τ ω ≤ N) :
+    ∫ ω, stoppedValue X τ ω ∂μ = ∫ ω, X 0 ω ∂μ :=
+  doob_optional_stopping_theorem X hX τ hτ N hτN
+
+-- ============================================================
+-- Part IV: Characterizations of Submartingales via OST
+-- ============================================================
+
+/-- **Submartingale Characterization via OST** (Doob's Theorem).
+
+    A process f is a submartingale if and only if stopped expectations are
+    monotone: for all stopping times τ ≤ σ ≤ N, E[f_τ] ≤ E[f_σ].
+
+    The (⇒) direction is `doob_ost_submartingale`.
+    The (⟸) direction is Mathlib's `submartingale_iff_expected_stoppedValue_mono`.
+    This iff characterization is the "submartingale via OST" theorem. -/
+theorem submartingale_iff_ost
+    {Ω : Type*} {m : MeasurableSpace Ω} {μ : Measure Ω}
+    [IsProbabilityMeasure μ]
+    {ℱ : Filtration ℕ m}
+    (f : ℕ → Ω → ℝ)
+    (hadapt : Adapted ℱ f)
+    (hint : ∀ n, Integrable (f n) μ) :
+    Submartingale f ℱ μ ↔
+    ∀ (τ π : Ω → ℕ∞), IsStoppingTime ℱ τ → IsStoppingTime ℱ π →
+      τ ≤ π → (∃ N : ℕ, ∀ ω, π ω ≤ N) →
+        ∫ ω, stoppedValue f τ ω ∂μ ≤ ∫ ω, stoppedValue f π ω ∂μ :=
+  submartingale_iff_expected_stoppedValue_mono hadapt hint
+
+-- ============================================================
+-- Part V: Doob's Maximal Inequality (Full Statement)
+-- ============================================================
+
+/-- **Doob's Maximal Inequality** — standalone version.
+
+    For a non-negative submartingale {Xₙ} and threshold λ > 0:
+    λ · P(max_{n≤N} Xₙ ≥ λ) ≤ E[X_N]
+
+    This is a key ingredient for almost-sure convergence (via Borel-Cantelli),
+    for the L^p maximal function bounds, and for the concentration inequalities.
+
+    In the Gambler's Ruin: the maximum wealth before ruin is bounded by
+    the initial wealth over win probability. -/
+theorem doob_maximal_inequality
+    {Ω : Type*} {m : MeasurableSpace Ω}
+    {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {ℱ : Filtration ℕ m}
+    (X : ℕ → Ω → ℝ) (hX : Submartingale X ℱ μ)
+    (hpos : ∀ n, 0 ≤ X n)
+    (N : ℕ) (λ : ℝ) (hλ : 0 < λ) :
+    λ * (μ {ω | ∃ n ≤ N, λ ≤ X n ω}).toReal ≤ ∫ ω, X N ω ∂μ :=
+  FairGamesOQ03.doobs_maximal_inequality X hX hpos N λ hλ
+
+-- ============================================================
+-- Part VI: Time-Invariance of Martingale Expectations
+-- ============================================================
+
+/-- **Martingale Expected Value is Time-Invariant**.
+
+    A martingale has constant expected value: E[X_n] = E[X_0] for all n.
+    This is a special case of OST with the constant stopping time τ = n.
+
+    This is the fundamental property that makes martingales model "fair games":
+    the expected wealth is always the same, regardless of how many steps
+    have been taken. -/
+theorem martingale_expected_value_constant
+    {Ω : Type*} {m : MeasurableSpace Ω}
+    {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {ℱ : Filtration ℕ m}
+    (X : ℕ → Ω → ℝ) (hX : Martingale X ℱ μ) (n : ℕ) :
+    ∫ ω, X n ω ∂μ = ∫ ω, X 0 ω ∂μ :=
+  FairGamesOQ03.martingale_time_invariance X hX n
+
+-- ============================================================
+-- Part VII: The "No Free Lunch" Summary Theorem
+-- ============================================================
+
+/-- **Summary Theorem: The Fundamental Theorem of Fair Games**.
+
+    In any fair game (martingale), no bounded stopping strategy can change
+    the expected outcome. The expected wealth at any bounded stopping time
+    equals the initial expected wealth.
+
+    This is the mathematical foundation behind:
+    - Efficient market hypothesis (no trading strategy beats the market)
+    - Casino mathematics (house edge = unfair game = supermartingale for player)
+    - Risk-neutral pricing in options theory (no arbitrage = martingale measure)
+    - The impossibility of "beating" fair roulette with any stopping rule
+
+    Conversely, a process where all bounded stopping strategies give the same
+    expected outcome is a martingale (the submartingale characterization in
+    `submartingale_iff_ost` gives both directions). -/
+theorem fundamental_theorem_fair_games
+    {Ω : Type*} {m : MeasurableSpace Ω}
+    {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {ℱ : Filtration ℕ m}
+    (X : ℕ → Ω → ℝ) (hX : Martingale X ℱ μ)
+    (τ : Ω → ℕ∞) (hτ : IsStoppingTime ℱ τ)
+    (N : ℕ) (hτN : ∀ ω, τ ω ≤ N) :
+    -- Stopping does not change the expected wealth:
+    ∫ ω, stoppedValue X τ ω ∂μ = ∫ ω, X 0 ω ∂μ :=
+  doob_optional_stopping_theorem X hX τ hτ N hτN
+
+/-- **The Converse: All Strategies Give Same Expectation → Martingale**.
+
+    If a process has the property that every bounded stopping time gives the
+    same expected value as the initial value, then the process is a submartingale.
+
+    This uses the submartingale characterization theorem:
+    `submartingale_iff_expected_stoppedValue_mono`. -/
+theorem all_strategies_equal_implies_submartingale
+    {Ω : Type*} {m : MeasurableSpace Ω} {μ : Measure Ω}
+    [IsProbabilityMeasure μ]
+    {ℱ : Filtration ℕ m}
+    (X : ℕ → Ω → ℝ)
+    (hadapt : Adapted ℱ X)
+    (hint : ∀ n, Integrable (X n) μ)
+    (h : ∀ (τ π : Ω → ℕ∞), IsStoppingTime ℱ τ → IsStoppingTime ℱ π →
+      τ ≤ π → (∃ N : ℕ, ∀ ω, π ω ≤ N) →
+        ∫ ω, stoppedValue X τ ω ∂μ ≤ ∫ ω, stoppedValue X π ω ∂μ) :
+    Submartingale X ℱ μ :=
+  FairGamesOQ03.submartingale_of_stoppedValue_mono_proved X hadapt hint h
+
+end FairGamesOQ02OQ01
+
+end

--- a/proofs/Proofs/ShannonChannelCodingOQ02OQ04.lean
+++ b/proofs/Proofs/ShannonChannelCodingOQ02OQ04.lean
@@ -1,0 +1,248 @@
+/-
+  Symmetric Channel Capacity: Generalization of BSC Proof
+
+  Open Question 04 (from ShannonChannelCodingOQ02):
+  "Extend to general symmetric channels beyond BSC"
+
+  A DMChannel W : α → β → ℝ is symmetric in the relevant sense when:
+  (1) Row symmetry: ∃ C : ℝ, ∀ x : α, ∑_y W(x,y)·log(W(x,y)) = C
+      (all rows have the same entropy sum, so H(Y|X=x) is constant in x)
+  (2) Doubly balanced: ∀ y : β, ∑_x W(x,y) = |α|/|β|
+      (uniform input → uniform output, achieving H(Y) = log|β|)
+  (3) Positive: W(x,y) > 0 for all x, y
+
+  Main result: channelCapacity ch = log|β| + C = log|β| - H(row)
+  where H(row) = -C ≥ 0 is the (common) entropy of any row of W.
+
+  This generalizes the BSC result (C = log 2 - h(p)) to arbitrary
+  finite input/output alphabets α, β.
+
+  Proof structure mirrors ShannonChannelCodingOQ02 (BSC case):
+  1. Uniform input distribution on general Fintype
+  2. Entropy of uniform distribution = log|α|
+  3. H(Y|X) = -C for any input distribution (row symmetry + W > 0)
+  4. Uniform input gives uniform output (doubly balanced)
+  5. Uniform MI = log|β| + C (achievability)
+  6. All MI ≤ log|β| + C (converse via chain rule)
+  7. Capacity = log|β| + C (main theorem)
+  8. BSC verification: BSC satisfies all hypotheses
+
+  Axioms: 4 (inherited from ShannonChannelCoding via import chain)
+  Sorries: 0
+  Theorems: 8
+-/
+import Mathlib
+import Proofs.ShannonChannelCoding
+import Proofs.ShannonChannelCodingOQ02
+
+open Real Finset InformationTheory InformationTheory.ChannelCoding
+
+namespace InformationTheory.ChannelCoding.SymmetricCapacity
+
+variable {α β : Type*} [Fintype α] [Fintype β] [DecidableEq α] [DecidableEq β]
+
+/-! ## Chain rule: MI = H(Y) - H(Y|X) (general version) -/
+
+/-- Mutual information equals output entropy minus conditional output entropy.
+    This is a restatement of the chain rule for general joint distributions. -/
+private theorem mi_eq_HY_sub_HYgivenX
+    {pXY : α × β → ℝ} (hp : ∀ xy, 0 ≤ pXY xy)
+    (hsum : ∑ xy : α × β, pXY xy = 1) :
+    mutualInformation pXY =
+    shannonEntropy (fun y => ∑ x : α, pXY (x, y)) -
+    conditionalEntropy (transposeJoint pXY) := by
+  rw [mutual_info_symm]
+  have hp' := transposeJoint_nonneg hp
+  have hsum' := transposeJoint_sum hsum
+  rw [chain_rule hp' hsum']
+  congr 1
+  ext y; simp [transposeJoint]
+
+/-! ## Uniform input distribution on a general Fintype -/
+
+/-- Uniform distribution on a nonempty Fintype: assigns weight 1/|α| to each element. -/
+noncomputable def uniformDist [Nonempty α] : InputDist α where
+  p := fun _ => 1 / (Fintype.card α : ℝ)
+  nonneg := fun _ => by positivity
+  sum_one := by
+    simp only [Finset.sum_const, Finset.card_univ, nsmul_eq_mul]
+    field_simp [(Nat.cast_pos.mpr Fintype.card_pos).ne']
+
+/-- Uniform distribution is strictly positive. -/
+lemma uniformDist_pos [Nonempty α] (x : α) : 0 < (uniformDist (α := α)).p x :=
+  div_pos one_pos (Nat.cast_pos.mpr Fintype.card_pos)
+
+/-! ## Entropy of the uniform distribution -/
+
+/-- Shannon entropy of the uniform distribution on α equals log|α|. -/
+theorem entropy_uniform_fintype [Nonempty α] :
+    shannonEntropy (uniformDist (α := α)).p = Real.log (Fintype.card α) := by
+  have hcard : (0 : ℝ) < Fintype.card α := Nat.cast_pos.mpr Fintype.card_pos
+  have hne : (1 : ℝ) / Fintype.card α ≠ 0 := div_ne_zero one_ne_zero hcard.ne'
+  simp only [shannonEntropy, uniformDist, if_neg hne,
+    Finset.sum_const, Finset.card_univ, nsmul_eq_mul]
+  -- After simp: -(↑|α| * (1/↑|α| * log(1/↑|α|))) = log ↑|α|
+  have h1 : (Fintype.card α : ℝ) * (1 / (Fintype.card α : ℝ) *
+      Real.log (1 / (Fintype.card α : ℝ))) = Real.log (1 / (Fintype.card α : ℝ)) := by
+    field_simp [hcard.ne']
+  rw [h1, show (1 : ℝ) / (Fintype.card α : ℝ) = ((Fintype.card α : ℝ))⁻¹ from one_div _,
+      Real.log_inv, neg_neg]
+
+/-! ## H(Y|X) = -C for symmetric channels -/
+
+/-- For a channel where all rows have the same entropy sum C and all transition
+    probabilities are positive, the conditional output entropy equals -C regardless
+    of the input distribution.
+
+    Proof: Unfold conditionalEntropy on transposeJoint(jointDist). The denominator
+    ∑_{y'} p(x)·W(x,y') = p(x) cancels. When p(x) = 0, terms vanish. When p(x) > 0,
+    simplification gives p(x)·W(x,y)·log(W(x,y)). Summing: ∑_x p(x)·∑_y W(x,y)·log(W(x,y))
+    = ∑_x p(x)·C = C, so the conditional entropy is -C. -/
+theorem sym_conditional_output_entropy
+    (ch : DMChannel α β) (inp : InputDist α)
+    (hW : ∀ x y, 0 < ch.W x y)
+    {C : ℝ} (hrow : ∀ x : α, ∑ y : β, ch.W x y * Real.log (ch.W x y) = C) :
+    conditionalEntropy (transposeJoint (jointDist ch inp)) = -C := by
+  unfold conditionalEntropy transposeJoint jointDist
+  dsimp only
+  -- Denominator for each input x: ∑_{y':β} p(x)·W(x,y') = p(x)
+  have hden : ∀ x : α, ∑ y' : β, inp.p x * ch.W x y' = inp.p x :=
+    fun x => by rw [← Finset.mul_sum, ch.sum_one, mul_one]
+  -- Simplify each term: two cases (p(x) = 0 or p(x) > 0)
+  have hterm : ∀ (y : β) (x : α),
+      (if inp.p x * ch.W x y = 0 then (0 : ℝ)
+       else inp.p x * ch.W x y *
+         Real.log (inp.p x * ch.W x y / (∑ y' : β, inp.p x * ch.W x y'))) =
+      inp.p x * (ch.W x y * Real.log (ch.W x y)) := by
+    intro y x
+    rcases (inp.nonneg x).eq_or_gt with ha | ha
+    · simp [ha.symm]
+    · have hne : inp.p x * ch.W x y ≠ 0 := (mul_pos ha (hW x y)).ne'
+      rw [if_neg hne, hden x, mul_div_cancel_left₀ _ ha.ne']
+      ring
+  simp_rw [hterm]
+  rw [Finset.sum_comm]
+  simp_rw [← Finset.mul_sum, hrow]
+  congr 1
+  rw [← Finset.sum_mul, inp.sum_one, one_mul]
+
+/-! ## Doubly balanced: uniform input → uniform output -/
+
+/-- For a doubly balanced channel (column sums = |α|/|β|), the uniform input
+    distribution produces a uniform output distribution with weight 1/|β|. -/
+lemma sym_uniform_ymarg [Nonempty α]
+    (ch : DMChannel α β)
+    (hbal : ∀ y : β, ∑ x : α, ch.W x y = (Fintype.card α : ℝ) / Fintype.card β)
+    (y : β) :
+    ∑ x : α, jointDist ch (uniformDist (α := α)) (x, y) = 1 / Fintype.card β := by
+  simp only [jointDist, uniformDist]
+  rw [← Finset.mul_sum, hbal y]
+  have hα : (Fintype.card α : ℝ) ≠ 0 := (Nat.cast_pos.mpr Fintype.card_pos).ne'
+  field_simp [hα]
+
+/-! ## Mutual information for uniform input -/
+
+/-- For a symmetric channel, the uniform input achieves MI = log|β| + C.
+    This is the achievability direction: uniform input gives H(Y) = log|β|
+    (doubly balanced) and H(Y|X) = -C (row symmetry). -/
+theorem sym_uniform_mi [Nonempty α] [Nonempty β]
+    (ch : DMChannel α β)
+    (hW : ∀ x y, 0 < ch.W x y)
+    {C : ℝ} (hrow : ∀ x : α, ∑ y : β, ch.W x y * Real.log (ch.W x y) = C)
+    (hbal : ∀ y : β, ∑ x : α, ch.W x y = (Fintype.card α : ℝ) / Fintype.card β) :
+    channelMI ch (uniformDist (α := α)) = Real.log (Fintype.card β) + C := by
+  unfold channelMI
+  have hjoint_nn : ∀ xy, 0 ≤ jointDist ch (uniformDist (α := α)) xy :=
+    fun xy => le_of_lt (mul_pos (uniformDist_pos xy.1) (hW xy.1 xy.2))
+  have hjoint_sum := jointDist_sum_one ch (uniformDist (α := α))
+  rw [mi_eq_HY_sub_HYgivenX hjoint_nn hjoint_sum]
+  rw [sym_conditional_output_entropy ch (uniformDist (α := α)) hW hrow]
+  -- Y-marginal under uniform input is uniform (by doubly balanced)
+  have hymarg : (fun y => ∑ x : α, jointDist ch (uniformDist (α := α)) (x, y)) =
+      fun _ : β => (1 : ℝ) / Fintype.card β :=
+    funext (sym_uniform_ymarg ch hbal)
+  rw [hymarg]
+  -- Entropy of uniform distribution on β = log|β|
+  have heq : (fun (_ : β) => (1 : ℝ) / Fintype.card β) = (uniformDist (α := β)).p := rfl
+  rw [heq, entropy_uniform_fintype (α := β)]
+  ring
+
+/-! ## MI upper bound for all inputs -/
+
+/-- For a symmetric channel, MI(X;Y) ≤ log|β| + C for all input distributions.
+    Proof: MI = H(Y) - H(Y|X) = H(Y) + C ≤ log|β| + C by entropy maximality. -/
+theorem sym_mi_le
+    (ch : DMChannel α β) (inp : InputDist α)
+    (hW : ∀ x y, 0 < ch.W x y)
+    {C : ℝ} (hrow : ∀ x : α, ∑ y : β, ch.W x y * Real.log (ch.W x y) = C) :
+    channelMI ch inp ≤ Real.log (Fintype.card β) + C := by
+  unfold channelMI
+  have hjoint_nn : ∀ xy, 0 ≤ jointDist ch inp xy :=
+    fun xy => mul_nonneg (inp.nonneg xy.1) (le_of_lt (hW xy.1 xy.2))
+  have hjoint_sum := jointDist_sum_one ch inp
+  rw [mi_eq_HY_sub_HYgivenX hjoint_nn hjoint_sum,
+      sym_conditional_output_entropy ch inp hW hrow]
+  -- Suffices: H(Y-marginal) ≤ log|β|
+  have hymarg_nn : ∀ y : β, 0 ≤ ∑ x, jointDist ch inp (x, y) :=
+    fun y => Finset.sum_nonneg (fun x _ => hjoint_nn (x, y))
+  have hymarg_sum : ∑ y : β, (∑ x, jointDist ch inp (x, y)) = 1 := by
+    rw [Finset.sum_comm, ← Fintype.sum_prod_type]; exact hjoint_sum
+  linarith [entropy_le_log_card hymarg_nn hymarg_sum]
+
+/-! ## Main theorem: Symmetric channel capacity -/
+
+/-- **Symmetric Channel Capacity Theorem**.
+    For a channel that is row-symmetric (all rows have the same entropy C)
+    and doubly balanced (uniform input → uniform output) with positive
+    transition probabilities, the channel capacity equals log|β| + C.
+
+    Upper bound: For all inputs, MI ≤ H(Y) + C ≤ log|β| + C (chain rule + entropy bound).
+    Achievability: Uniform input achieves MI = log|β| + C (by double balance + row symmetry).
+
+    Setting C = -h(p) and α = β = Bool recovers the BSC capacity log 2 - h(p). -/
+theorem sym_channel_capacity [Nonempty α] [Nonempty β]
+    (ch : DMChannel α β)
+    (hW : ∀ x y, 0 < ch.W x y)
+    {C : ℝ} (hrow : ∀ x : α, ∑ y : β, ch.W x y * Real.log (ch.W x y) = C)
+    (hbal : ∀ y : β, ∑ x : α, ch.W x y = (Fintype.card α : ℝ) / Fintype.card β) :
+    channelCapacity ch = Real.log (Fintype.card β) + C := by
+  unfold channelCapacity
+  apply le_antisymm
+  · -- Upper bound: sSup ≤ log|β| + C
+    apply csSup_le
+    · exact ⟨_, uniformDist (α := α), rfl⟩
+    · rintro r ⟨inp, rfl⟩
+      exact sym_mi_le ch inp hW hrow
+  · -- Lower bound: log|β| + C ≤ sSup (achieved by uniform input)
+    apply le_csSup
+    · -- BddAbove: each MI ≤ log|β| ≤ log|β| + ... (use log|β| as upper bound)
+      exact ⟨Real.log (Fintype.card β), fun _ ⟨inp, hr⟩ => hr ▸ channelMI_le_log_card ch inp⟩
+    · exact ⟨uniformDist (α := α), sym_uniform_mi ch hW hrow hbal⟩
+
+/-! ## Examples: BSC satisfies the hypotheses -/
+
+/-- The BSC satisfies the row symmetry hypothesis with C = p·log(p) + (1-p)·log(1-p). -/
+theorem bsc_row_symmetric {p : ℝ} (hp0 : 0 < p) (hp1 : p < 1) :
+    ∀ x : Bool, ∑ y : Bool, (bsc p (le_of_lt hp0) (le_of_lt hp1)).W x y *
+      Real.log ((bsc p (le_of_lt hp0) (le_of_lt hp1)).W x y) =
+    p * Real.log p + (1 - p) * Real.log (1 - p) := by
+  intro x; simp only [Fintype.sum_bool, bsc]; cases x <;> simp <;> ring
+
+/-- BSC is doubly balanced: column sums = |Bool|/|Bool| = 1. -/
+theorem bsc_doubly_balanced {p : ℝ} (hp0 : 0 < p) (hp1 : p < 1) :
+    ∀ y : Bool, ∑ x : Bool, (bsc p (le_of_lt hp0) (le_of_lt hp1)).W x y =
+    (Fintype.card Bool : ℝ) / Fintype.card Bool := by
+  intro y; simp only [Fintype.sum_bool, bsc, Fintype.card_bool, Nat.cast_ofNat]
+  cases y <;> simp <;> ring
+
+/-- BSC capacity recovered from the symmetric channel theorem:
+    C(BSC(p)) = log 2 + (p·log p + (1-p)·log(1-p)) = log 2 - h(p). -/
+theorem bsc_capacity_from_symmetric {p : ℝ} (hp0 : 0 < p) (hp1 : p < 1) :
+    channelCapacity (bsc p (le_of_lt hp0) (le_of_lt hp1)) =
+    Real.log 2 + (p * Real.log p + (1 - p) * Real.log (1 - p)) :=
+  sym_channel_capacity (bsc p (le_of_lt hp0) (le_of_lt hp1))
+    (fun x y => by simp only [bsc]; split_ifs <;> linarith)
+    (bsc_row_symmetric hp0 hp1)
+    (bsc_doubly_balanced hp0 hp1)
+
+end InformationTheory.ChannelCoding.SymmetricCapacity

--- a/src/data/proofs/area-of-circle-oq-03-oq-02-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02-oq-02-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-remainder-sign",
+    "proofId": "area-of-circle-oq-03-oq-02-oq-02-oq-01",
+    "range": { "startLine": 41, "endLine": 65 },
+    "type": "insight",
+    "title": "The Remainder Sign Flips the Bound Direction",
+    "content": "The key algebraic fact is that when dividing x^(4n)(1-x)^(4n) by (1+x²), the remainder (a constant) alternates in sign with n:\n\n- n=1: remainder = (1-i)^4 = -4 → integral = r - π > 0 → π < r (upper bound)\n- n=2: remainder = (1-i)^8 = 16 → integral = 4π - r > 0 → π > r/4 (lower bound)\n- n=3: remainder = (1-i)^12 = -64 → integral = r - 16π > 0 → π < r/16 (upper bound)\n\nThis alternating pattern means successive Dalzell integrals give alternating upper/lower bounds, converging to π from both sides.\n\nThe remainder is computed by evaluating x^(4n)(1-x)^(4n) at the root of (1+x²), i.e., at x = i (the imaginary unit): i^(4n) = 1 and (1-i)^(4n) depends on n.",
+    "mathContext": "The polynomial remainder theorem: when P(x) = (x²+1)Q(x) + (ax+b), evaluating at x=i gives P(i) = ai + b. For x^(4n)(1-x)^(4n), the value at x=i is i^(4n)(1-i)^(4n) = (1-i)^(4n). Since (1-i)^4 = -4, we get the pattern: n=1 → -4, n=2 → 16, n=3 → -64, n=4 → 256. The imaginary part is always 0 (the polynomial has real coefficients), so the remainder is a real constant.",
+    "significance": "key",
+    "relatedConcepts": ["polynomial remainder theorem", "complex roots", "alternating bounds"],
+    "prerequisites": ["complex number evaluation of real polynomials", "remainder theorem"]
+  },
+  {
+    "id": "ann-antideriv-computation",
+    "proofId": "area-of-circle-oq-03-oq-02-oq-02-oq-01",
+    "range": { "startLine": 88, "endLine": 140 },
+    "type": "technique",
+    "title": "Term-by-Term HasDerivAt Chain for Degree-14 Antiderivative",
+    "content": "The antiderivative F₂ has 12 terms (a degree-14 polynomial plus 16·arctan). The proof constructs F₂' = dalzell2Decomposed via a chain of 11 HasDerivAt compositions:\n\n```lean\nhave hcomb := ((((((((((h15.sub h14).add h13).sub h12).add h11)\n  .sub h10).sub h9).add h7).sub h5).add h3).sub h1).add ha\n```\n\nThis follows the same pattern as the parent proof's 5-term chain, just extended. Each term's derivative is proved using `hasDerivAt_pow`, `.const_mul`, `.div_const`, and `hasDerivAt_arctan`, with `convert ... using 1; push_cast; ring` to normalize the derivative value.\n\nThe chain works because Lean's `HasDerivAt.sub` and `HasDerivAt.add` compose left-associatively, matching the left-associative parsing of arithmetic expressions in Lean.",
+    "mathContext": "The antiderivative F₂(x) = x¹⁵/15 - 4x¹⁴/7 + 27x¹³/13 - 4x¹² + 43x¹¹/11 - 4x¹⁰/5 - 5x⁹/3 + 16x⁷/7 - 16x⁵/5 + 16x³/3 - 16x + 16·arctan(x). Note x⁷ and x⁵ and x³ terms come from integrating the even-only polynomial Q (which has no odd-degree terms except via the polynomial itself).",
+    "significance": "supporting",
+    "relatedConcepts": ["HasDerivAt", "intervalIntegral", "arctan_one"],
+    "prerequisites": ["Mathlib derivative API", "HasDerivAt composition rules"]
+  },
+  {
+    "id": "ann-ftc-evaluation",
+    "proofId": "area-of-circle-oq-03-oq-02-oq-02-oq-01",
+    "range": { "startLine": 141, "endLine": 172 },
+    "type": "technique",
+    "title": "FTC via F₂(1) - F₂(0): Exact Rational + π Computation",
+    "content": "The integral value 4π - 188684/15015 comes from:\n\n  F₂(1) - F₂(0) = (1/15 - 4/7 + 27/13 - 4 + 43/11 - 4/5 - 5/3 + 16/7 - 16/5 + 16/3 - 16 + 4π) - 0\n\nThe rational sum over LCM(15,7,13,11,3) = 15015:\n  (1001 + 25740 + 31185 - 60060 + 58695 - 12012 - 25025 + 34320 - 48048 + 80080 - 240240) / 15015\n  = -188684 / 15015\n\nThe arctan term: 16·arctan(1) = 16·(π/4) = 4π (by `arctan_one`).\n\nIn Lean: after `rw [arctan_one]`, the `ring` tactic verifies F₂(1) = 4π - 188684/15015 by computing the rational arithmetic automatically.",
+    "mathContext": "The fraction -188684/15015 is in lowest terms (GCD = 1). The bound it gives: π > 47171/15015 ≈ 3.14156 vs π ≈ 3.14159. The integral itself is approximately 4π - 188684/15015 ≈ 4×3.14159 - 12.56637 ≈ 0.0000023, a tiny positive number confirming the integrand is very small.",
+    "significance": "supporting",
+    "relatedConcepts": ["arctan_one", "integral_eq_sub_of_hasDerivAt", "FTC"],
+    "prerequisites": ["Real.arctan_one = π/4", "rational arithmetic", "FTC in Mathlib"]
+  },
+  {
+    "id": "ann-lower-bound",
+    "proofId": "area-of-circle-oq-03-oq-02-oq-02-oq-01",
+    "range": { "startLine": 197, "endLine": 213 },
+    "type": "insight",
+    "title": "π > 47171/15015: Lower Bound from Integral Positivity",
+    "content": "The lower bound proof follows directly from two facts:\n1. ∫₀¹ x⁸(1-x)⁸/(1+x²) dx = 4π - 188684/15015 (integral identity)\n2. ∫₀¹ x⁸(1-x)⁸/(1+x²) dx > 0 (integrand is positive on (0,1))\n\nCombining: 4π - 188684/15015 > 0 → π > 188684/60060 = 47171/15015.\n\nThe `linarith` tactic closes this after establishing the two facts. The positivity comes from `integral_pos`, which requires:\n- ContinuousOn on [0,1]\n- Nonneg everywhere on [0,1]\n- Strictly positive at some interior point (x=1/2 is the witness)\n\nThis is the opposite direction from the parent proof's conclusion π < 22/7, which used the same integral_pos approach but with the n=1 integral equaling 22/7 - π > 0.",
+    "mathContext": "The key contrast with n=1: the n=1 integral = 22/7 - π > 0 gives an UPPER bound (22/7 > π). The n=2 integral = 4π - 188684/15015 > 0 gives a LOWER bound (π > 47171/15015). The remainder's sign flips the direction of the bound.",
+    "significance": "key",
+    "relatedConcepts": ["integral_pos", "pi_gt_lower_bound", "linarith"],
+    "prerequisites": ["integral positivity in Mathlib", "Dalzell integral identity"]
+  },
+  {
+    "id": "ann-sandwich",
+    "proofId": "area-of-circle-oq-03-oq-02-oq-02-oq-01",
+    "range": { "startLine": 215, "endLine": 250 },
+    "type": "concept",
+    "title": "Two-Sided Rational Sandwich: 47171/15015 < π < 22/7",
+    "content": "pi_rational_sandwich packages the two bounds into a conjunction:\n\n  47171/15015 < π   (n=2 lower bound, this file)\n  π < 22/7           (n=1 upper bound, from parent AreaOfCircleOQ03OQ02OQ02)\n\nNumerically: 3.14156... < π < 3.14286...\n\nThis gives π correct to 4 decimal places (π = 3.1415...) using only rational approximations. The Dalzell method provides a purely analytic (integration-based) proof that π is approximately 3.14159 without computing more than two specific rational approximations.\n\nThe convergence pattern for higher n:\n- n=1: π < 22/7 ≈ 3.14286 (error ≈ 0.00126)\n- n=2: π > 47171/15015 ≈ 3.14156 (error ≈ 0.00003)\n- n=3: π < q₃ (tighter upper bound)\n- n=4: π > q₄ (tighter lower bound)\n\nThe bounds converge to π since ∫₀¹ x^(4n)(1-x)^(4n)/(1+x²) dx → 0.",
+    "mathContext": "Archimedes' method (inscribed/circumscribed polygons) gave 223/71 < π < 22/7. This Dalzell method gives a comparable lower bound via integration theory, with the same upper bound 22/7 from Dalzell n=1. The lower bound 47171/15015 ≈ 3.14156 is weaker than Archimedes' 223/71 ≈ 3.14085... wait, 223/71 ≈ 3.14085, which is actually less accurate. The Dalzell lower bound 47171/15015 is much tighter.",
+    "significance": "key",
+    "relatedConcepts": ["pi_lt_twentytwo_over_seven", "Archimedes bounds", "rational approximations to π"],
+    "prerequisites": ["Parent proof AreaOfCircleOQ03OQ02OQ02", "Dalzell lower bound"]
+  },
+  {
+    "id": "ann-convergence",
+    "proofId": "area-of-circle-oq-03-oq-02-oq-02-oq-01",
+    "range": { "startLine": 1, "endLine": 40 },
+    "type": "concept",
+    "title": "The Dalzell Sequence: Alternating Upper/Lower Bounds on π",
+    "content": "The Dalzell integral sequence Iₙ = ∫₀¹ x^(4n)(1-x)^(4n)/(1+x²) dx satisfies:\n\n1. Iₙ > 0 for all n (integrand is nonneg and strictly positive somewhere)\n2. Iₙ → 0 as n → ∞ (since x^(4n)(1-x)^(4n) → 0 pointwise)\n3. Iₙ = aₙ·π - bₙ for explicit rationals aₙ, bₙ (from polynomial long division)\n\nFrom (1) and (3): aₙ·π > bₙ (if aₙ > 0) or aₙ·π < bₙ (if aₙ < 0).\n\nFor n=1: a₁ = -1 (from remainder -4 → ∫16/(1+x²) = -arctan terms = -π), I₁ = 22/7 - π → π < 22/7\nFor n=2: a₂ = 4 (from remainder +16 → 4π term), I₂ = 4π - 188684/15015 → π > 47171/15015\n\nFrom (2): bₙ/aₙ → π, giving increasingly precise rational approximations.\n\nThis file formally verifies the n=2 case, answering the open question from the parent proof affirmatively.",
+    "mathContext": "The sequence (bₙ/aₙ) converges to π at rate O(1/16^n) approximately (since max{x^4(1-x)^4} = (1/4)^4·(1/4)^4/(5/4) = (1/4)^8/(5/4), and scaling by n). This is slow convergence compared to e.g. the Gauss-Legendre algorithm, but the proof is elementary and elegant.",
+    "significance": "key",
+    "relatedConcepts": ["convergence to π", "alternating series", "Dalzell 1944"],
+    "prerequisites": ["Dalzell 1944 original paper", "basic real analysis"]
+  }
+]

--- a/src/data/proofs/area-of-circle-oq-03-oq-02-oq-02-oq-01/index.ts
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02-oq-02-oq-01/index.ts
@@ -1,0 +1,38 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/AreaOfCircleOQ03OQ02OQ02OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const areaOfCircleOQ03OQ02OQ02OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections ?? [],
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const areaOfCircleOQ03OQ02OQ02OQ01Annotations: Annotation[] =
+  annotationsJson as unknown as Annotation[]
+
+export const areaOfCircleOQ03OQ02OQ02OQ01Data: ProofData = {
+  proof: areaOfCircleOQ03OQ02OQ02OQ01Proof,
+  annotations: areaOfCircleOQ03OQ02OQ02OQ01Annotations,
+  tacticStates: [],
+}

--- a/src/data/proofs/area-of-circle-oq-03-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02-oq-02-oq-01/meta.json
@@ -1,0 +1,125 @@
+{
+  "id": "area-of-circle-oq-03-oq-02-oq-02-oq-01",
+  "title": "Generalized Dalzell Integral: π > 47171/15015",
+  "slug": "area-of-circle-oq-03-oq-02-oq-02-oq-01",
+  "description": "Proves that π > 47171/15015 ≈ 3.14156 using the n=2 Dalzell integral ∫₀¹ x⁸(1-x)⁸/(1+x²) dx = 4π - 188684/15015. Combined with the n=1 result π < 22/7, establishes the two-sided rational sandwich 47171/15015 < π < 22/7.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-04-12",
+    "status": "verified",
+    "proofRepoPath": "Proofs/AreaOfCircleOQ03OQ02OQ02OQ01.lean",
+    "tags": [
+      "pi",
+      "integral",
+      "rational-approximation",
+      "Dalzell",
+      "bounds"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-04-12",
+    "axiomCount": 0,
+    "assumptions": "None. Proves new results from first principles using Mathlib's real analysis and integration libraries.",
+    "lineCount": 215,
+    "theoremCount": 12,
+    "definitionCount": 2,
+    "originalContributions": [
+      "dalzell2_polynomial_identity: x⁸(1-x)⁸ = (1+x²)·Q(x) + 16 (remainder +16, opposite sign from n=1)",
+      "dalzell2_integral: ∫₀¹ x⁸(1-x)⁸/(1+x²) dx = 4π - 188684/15015",
+      "pi_gt_lower_bound: π > 47171/15015 ≈ 3.14156...",
+      "pi_rational_sandwich: 47171/15015 < π < 22/7 (two-sided rational bound)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Dalzell (1944) proved that ∫₀¹ x⁴(1-x)⁴/(1+x²) dx = 22/7 - π, giving a clean proof that π < 22/7. The generalized Dalzell integrals ∫₀¹ x^(4n)(1-x)^(4n)/(1+x²) dx for n ≥ 1 provide a sequence of increasingly tight rational bounds on π. The n=1 case gives an upper bound (remainder = -4, flipped sign means 22/7 > π). The n=2 case gives a lower bound (remainder = +16, reversed inequality means π > 47171/15015).\n\nThe key algebraic insight is that x^(4n)(1-x)^(4n)|_{x=i} = i^(4n)(1-i)^(4n) = 1·(1-i)^(4n). For n=1: (1-i)^4 = -4, remainder = -4. For n=2: (1-i)^8 = 16, remainder = +16. The sign alternates, giving alternating upper/lower bounds that converge to π.",
+    "problemStatement": "Can the generalized Dalzell integral ∫₀¹ x^(4n)(1-x)^(4n)/(1+x²) dx be used to derive sharper rational bounds on π? Specifically, what does the n=2 case give?",
+    "text": "**Answer**: Yes. The n=2 Dalzell integral gives:\n\n  ∫₀¹ x⁸(1-x)⁸/(1+x²) dx = 4π - 188684/15015\n\nSince the integrand is nonneg on [0,1] and strictly positive on (0,1), the integral is strictly positive:\n\n  4π - 188684/15015 > 0 ⟹ π > 47171/15015 ≈ 3.14156...\n\nCombined with the n=1 bound π < 22/7 ≈ 3.14286, we get the two-sided rational sandwich:\n\n  **47171/15015 < π < 22/7**\n\nThe key identity is x⁸(1-x)⁸ = (1+x²)·Q(x) + 16, where Q is the degree-14 polynomial x¹⁴ - 8x¹³ + 27x¹² - 48x¹¹ + 43x¹⁰ - 8x⁹ - 15x⁸ + 16x⁶ - 16x⁴ + 16x² - 16. The remainder +16 (vs -4 for n=1) flips the direction of the inequality.",
+    "proofStrategy": "1. Prove the polynomial identity x⁸(1-x)⁸ = (1+x²)·Q(x) + 16 by `ring`. 2. Decompose the integrand: x⁸(1-x)⁸/(1+x²) = Q(x) + 16/(1+x²). 3. Define antiderivative F₂(x) = x¹⁵/15 - 4x¹⁴/7 + 27x¹³/13 - 4x¹² + 43x¹¹/11 - 4x¹⁰/5 - 5x⁹/3 + 16x⁷/7 - 16x⁵/5 + 16x³/3 - 16x + 16·arctan(x). 4. Prove HasDerivAt F₂ = decomposed integrand using term-by-term derivatives and HasDerivAt chains. 5. Apply FTC: ∫₀¹ = F₂(1) - F₂(0) = (4π - 188684/15015) - 0. 6. Conclude from positivity of integral that π > 47171/15015.",
+    "keyInsights": [
+      "The remainder when dividing x^(4n)(1-x)^(4n) by (1+x²) alternates in sign: n=1 gives -4, n=2 gives +16. This is because (1-i)^(4n)|_{x=i} = (1-i)^(4n), and (1-i)^4 = -4, (1-i)^8 = 16.",
+      "The remainder sign determines the direction of the bound: negative remainder → π < q (upper bound), positive remainder → π > q (lower bound).",
+      "The antiderivative F₂ integrates the full decomposed form Q(x) + 16/(1+x²), with F₂(0) = 0 and F₂(1) = -188684/15015 + 4π (after arctan_one = π/4).",
+      "The two bounds together: 47171/15015 ≈ 3.14156 < π < 22/7 ≈ 3.14286, giving π to 4 correct decimal places.",
+      "The Dalzell sequence converges: as n → ∞, ∫₀¹ x^(4n)(1-x)^(4n)/(1+x²) dx → 0 since max{x^(4n)(1-x)^(4n)} → 0, giving arbitrarily tight rational bounds on π."
+    ],
+    "prerequisites": [
+      "Real analysis: HasDerivAt, intervalIntegral, arctan_one",
+      "Mathlib: integral_pos, integral_eq_sub_of_hasDerivAt",
+      "Parent proof: AreaOfCircleOQ03OQ02OQ02 (π < 22/7)"
+    ]
+  },
+  "conclusion": {
+    "summary": "The n=2 Dalzell integral proves π > 47171/15015. Combined with the n=1 bound π < 22/7 (from the parent proof), we obtain the two-sided rational sandwich 47171/15015 < π < 22/7, locating π to 4 correct decimal places using only rational arithmetic and calculus.",
+    "implications": "The Dalzell integral sequence provides a purely analytic (no number theory) method for computing rational bounds on π. Each pair (n=2k-1, n=2k) gives an upper and lower bound converging to π. This is an elementary alternative to the Leibniz/Gregory formula and Machin-type formulas for computing π to arbitrary precision.",
+    "openQuestions": [
+      "Can the n=3 Dalzell integral be evaluated? The remainder when dividing x¹²(1-x)¹²  by (1+x²) is (1-i)^12 = (-2i)^6/(-2i)^0... let me compute: (1-i)^4 = -4, (1-i)^8 = 16, (1-i)^12 = (1-i)^8 · (1-i)^4 = 16 · (-4) = -64. So n=3 gives remainder -64 and an upper bound π < q₃ for some rational q₃ < 22/7.",
+      "Can the general formula ∫₀¹ x^(4n)(1-x)^(4n)/(1+x²) dx = aₙπ - bₙ be derived in Lean for all n, where aₙ and bₙ are explicit rationals? This would require induction on the polynomial long division.",
+      "Can this approach extend to ∫₀¹ x^m(1-x)^n/(1+x²) dx for general m, n, giving a complete theory of integral representations of π?"
+    ]
+  },
+  "leanFile": {
+    "namespace": "AreaOfCircleOQ03OQ02OQ02OQ01",
+    "lineCount": 215,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 2,
+    "path": "Proofs/AreaOfCircleOQ03OQ02OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "area-of-circle-oq-03-oq-02-oq-02",
+      "relationship": "extends",
+      "description": "Parent proof: proves π < 22/7 via n=1 Dalzell integral; this proof provides the complementary lower bound"
+    },
+    {
+      "targetId": "area-of-circle-oq-03-oq-02",
+      "relationship": "related",
+      "description": "Grandparent: area-of-circle rational bounds chain"
+    }
+  ],
+  "sections": [
+    {
+      "id": "sec-polynomial",
+      "title": "Part I: Polynomial Identity",
+      "startLine": 41,
+      "endLine": 65,
+      "summary": "Proves x⁸(1-x)⁸ = (1+x²)·Q(x) + 16 by `ring`. The remainder +16 (vs -4 for n=1) is the key difference that flips the bound direction."
+    },
+    {
+      "id": "sec-positivity",
+      "title": "Part II: Positivity of the Integrand",
+      "startLine": 67,
+      "endLine": 86,
+      "summary": "Shows x⁸(1-x)⁸/(1+x²) ≥ 0 on [0,1] and > 0 on (0,1). Required for applying integral_pos."
+    },
+    {
+      "id": "sec-antideriv",
+      "title": "Part III: Antiderivative via FTC",
+      "startLine": 88,
+      "endLine": 172,
+      "summary": "Defines F₂ and proves F₂'= decomposed integrand using term-by-term HasDerivAt chain. F₂(0)=0, F₂(1)=4π-188684/15015. FTC gives the integral value."
+    },
+    {
+      "id": "sec-integral",
+      "title": "Part IV: Integral Identity",
+      "startLine": 174,
+      "endLine": 195,
+      "summary": "Proves ∫₀¹ x⁸(1-x)⁸/(1+x²) dx = 4π - 188684/15015 by combining the antiderivative FTC with integrand decomposition."
+    },
+    {
+      "id": "sec-bound",
+      "title": "Part V: Lower Bound on π",
+      "startLine": 197,
+      "endLine": 213,
+      "summary": "Derives π > 47171/15015 from positivity of the integral. Uses integral_pos for strictness."
+    },
+    {
+      "id": "sec-sandwich",
+      "title": "Part VI: Two-Sided Rational Sandwich",
+      "startLine": 215,
+      "endLine": 250,
+      "summary": "Combines n=1 (π < 22/7) and n=2 (π > 47171/15015) bounds to give 47171/15015 < π < 22/7."
+    }
+  ]
+}

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03/annotations.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-euclidean-bound",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03",
+    "range": { "startLine": 122, "endLine": 165 },
+    "type": "insight",
+    "title": "The 3/4 Bound: Why ℤ[√-2] Has a Larger Rounding Error Than ℤ[i]",
+    "content": "In ℤ[i], the rounding error is bounded by 1/2 + 1/2 = 1/2. In ℤ[√-2], the bound is 3/4:\n\n  normSq(δα + √2·δβ·I) = δα² + (√2·δβ)² = δα² + 2δβ² ≤ (1/2)² + 2·(1/2)² = 3/4\n\nThe difference comes from the complex embedding. In ℤ[i]: error = δα + δβ·I.\nIn ℤ[√-2]: error = δα + (√2·δβ)·I, where the imaginary part is scaled by √2.\n\nBoth bounds are < 1, so the Euclidean algorithm terminates. The key insight is that the complex embedding for Zsqrtd(-2) sends z.im to z.im·√2·I, introducing the extra factor of √2 in the imaginary error.",
+    "mathContext": "The general pattern: for ℤ[√d] with d < 0, the Euclidean bound is (1/4) + |d|/4 = (1+|d|)/4. For d=-1: (1+1)/4 = 1/2. For d=-2: (1+2)/4 = 3/4. For d=-3 (ℤ[ω]): need |d| = 1 in the ring of integers, giving bound (1+1)/4 = 1/2. The bound must be < 1 for the Euclidean algorithm to terminate.",
+    "significance": "key",
+    "relatedConcepts": ["Complex.normSq", "abs_sub_round", "Euclidean bound"],
+    "prerequisites": ["Zsqrtd complex embedding", "rounding error analysis"]
+  },
+  {
+    "id": "ann-mod8-impossibility",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03",
+    "range": { "startLine": 192, "endLine": 215 },
+    "type": "technique",
+    "title": "Mod-8 Impossibility via decide: a² + 2b² ∉ {5, 7} (mod 8)",
+    "content": "The key fact is that a² + 2b² mod 8 can never be 5 or 7. Proof by exhaustive check:\n\nSquares mod 8: 0²=0, 1²=1, 2²=4, 3²=1, 4²=0, 5²=1, 6²=4, 7²=1 → {0,1,4}\n2·(squares mod 8): 2·{0,1,4} = {0,2,8≡0} → {0,2,4} (accounting for carries)\n\nAll values of a²+2b² mod 8: {0+0, 0+2, 0+4, 1+0, 1+2, 1+4, 4+0, 4+2, 4+4}\n= {0, 2, 4, 1, 3, 5? no: 1+4=5, wait...}\n\nActual computation: a²+2b² mod 8 ∈ {0,1,2,3,4,6} — never 5 or 7.\n\nThe `decide` tactic verifies this by checking all 64 pairs (a,b) ∈ ZMod 8 × ZMod 8.",
+    "mathContext": "This is equivalent to the Legendre symbol (-2/p) = -1 for p ≡ 5 or 7 (mod 8). The Legendre symbol factorizes as (-2/p) = (-1/p)·(2/p). By quadratic reciprocity: (-1/p) = (-1)^((p-1)/2), (2/p) = (-1)^((p²-1)/8). Their product is -1 precisely when p ≡ 5 or 7 (mod 8).",
+    "significance": "key",
+    "relatedConcepts": ["ZMod", "decide", "Legendre symbol", "quadratic reciprocity"],
+    "prerequisites": ["ZMod arithmetic", "Legendre symbol (-2/p)"]
+  },
+  {
+    "id": "ann-inert-proof-structure",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03",
+    "range": { "startLine": 215, "endLine": 265 },
+    "type": "technique",
+    "title": "Inert Prime Proof: Norm Factorization Argument",
+    "content": "The proof that p ≡ 5 or 7 (mod 8) is prime in ℤ[√-2] follows this structure:\n\n1. **Not a unit**: N(p) = p² ≥ 25, but units have norm 1.\n2. **Irreducible**: If p = a·b with neither unit, then:\n   - N(a)·N(b) = N(p) = p² (norm is multiplicative)\n   - N(a), N(b) ≥ 2 (non-units have norm ≥ 2)\n   - Since p is prime, N(a) ∈ {p, p²} (divisors of p² ≥ 2 are p or p²)\n   - If N(a) = p², then N(b) = 1, contradicting b non-unit\n   - So N(a) = p, meaning a.re² + 2·a.im² = p\n3. **Contradiction**: This is impossible mod 8 by `no_sum_form_mod8`.\n\nThe key Mathlib lemma used: `Nat.dvd_prime_pow` classifies divisors of p^n as {1, p, p², ..., pⁿ}.",
+    "mathContext": "The norm argument exploits that p is rational prime (so p² has exactly three divisors: 1, p, p²). This is the classic argument for classifying primes in rings of integers of number fields. The same structure works for ℤ[i] (mod 4 impossibility) and would work for ℤ[√-11], etc.",
+    "significance": "key",
+    "relatedConcepts": ["Nat.dvd_prime_pow", "interval_cases", "norm multiplicativity"],
+    "prerequisites": ["Prime factorization in ℤ", "Zsqrtd.norm_mul", "Zsqrtd.norm_eq_one_iff"]
+  },
+  {
+    "id": "ann-splitting-examples",
+    "proofId": "bezout-identity-oq-02-oq-01-oq-02-oq-22-oq-03",
+    "range": { "startLine": 265, "endLine": 285 },
+    "type": "concept",
+    "title": "Prime Behavior in ℤ[√-2]: Three Cases",
+    "content": "Rational primes exhibit three behaviors in ℤ[√-2]:\n\n**Inert** (p ≡ 5 or 7 mod 8): p stays prime. Examples: 5, 7, 13, 23.\nFormal proof: p = 5 (5 % 8 = 5 ✓), p = 7 (7 % 8 = 7 ✓).\n\n**Split** (p ≡ 1 or 3 mod 8, p ≠ 2): p = π·π̄ where N(π) = p.\nExample: 3 = (1+√-2)·(1-√-2). Verification: N(1+√-2) = 1+2 = 3 ✓.\n\n**Ramified** (p = 2): 2 = -(√-2)². Only 2 ramifies in ℤ[√-2].\nVerification: -(√-2)² = -(−2) = 2 ✓.\n\nAll three cases are verified by `decide` since ℤ[√-2] elements are represented as pairs.",
+    "mathContext": "The classification follows from (-2/p): split when (-2/p)=1 (p≡1,3 mod 8), inert when (-2/p)=-1 (p≡5,7 mod 8), ramified when p|(-2) (p=2). This is the standard decomposition of rational primes in rings of integers of quadratic fields.",
+    "significance": "supporting",
+    "relatedConcepts": ["prime splitting", "ramification", "Legendre symbol"],
+    "prerequisites": ["algebraic number theory basics", "Dedekind's theorem on prime splitting"]
+  }
+]

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03/index.ts
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03/index.ts
@@ -1,0 +1,38 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const bezoutIdentityOQ02OQ01OQ02OQ02OQ03Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections ?? [],
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const bezoutIdentityOQ02OQ01OQ02OQ02OQ03Annotations: Annotation[] =
+  annotationsJson as unknown as Annotation[]
+
+export const bezoutIdentityOQ02OQ01OQ02OQ02OQ03Data: ProofData = {
+  proof: bezoutIdentityOQ02OQ01OQ02OQ02OQ03Proof,
+  annotations: bezoutIdentityOQ02OQ01OQ02OQ02OQ03Annotations,
+  tacticStates: [],
+}

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03/meta.json
@@ -1,0 +1,121 @@
+{
+  "id": "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03",
+  "title": "ℤ[√-2] as a Euclidean Domain: Inert Prime Classification",
+  "slug": "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03",
+  "description": "Generalizes the inert prime technique from ℤ[i] to ℤ[√-2]. Proves ℤ[√-2] is a Euclidean domain (rounding error bounded by 3/4 < 1) and classifies inert primes: p is prime in ℤ[√-2] iff p ≡ 5 or 7 (mod 8), the condition (-2/p) = -1.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-04-12",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
+    "tags": [
+      "number-theory",
+      "Euclidean-domain",
+      "Zsqrtd",
+      "inert-primes",
+      "Legendre-symbol"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-04-12",
+    "axiomCount": 0,
+    "assumptions": "None. Proved from first principles using Mathlib's Zsqrtd and EuclideanDomain infrastructure.",
+    "lineCount": 230,
+    "theoremCount": 16,
+    "definitionCount": 3,
+    "originalContributions": [
+      "norm_pos_of_ne_zero: N(z) > 0 for z ≠ 0 in ℤ[√-2] (key for Euclidean algorithm)",
+      "normSq_div_sub_div_lt_one: rounding error has normSq ≤ 3/4 < 1 (tighter than ℤ[i]'s 1/2)",
+      "EuclideanDomain instance for ℤ[√-2] = Zsqrtd(-2)",
+      "inert_prime_neg2: p ≡ 5 or 7 (mod 8) → p prime in ℤ[√-2]",
+      "no_sum_form_mod8: a² + 2b² mod 8 ∈ {0,1,2,3,4,6} (not 5 or 7)"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The ring ℤ[√-2] is one of the five imaginary quadratic rings that are Euclidean domains (the others being ℤ[i], ℤ[√-3], ℤ[√-7], ℤ[√-11]). Its Euclidean property was established classically by Dedekind. The inert prime classification follows from the theory of the Legendre symbol: (-2/p) = (-1/p)·(2/p) = -1 iff p ≡ 5 or 7 (mod 8).",
+    "problemStatement": "Can the inert prime technique used for ℤ[i] (classifying primes p ≡ 3 mod 4) be generalized to ℤ[√-2]?",
+    "text": "**Answer**: Yes. For ℤ[√-2]:\n\n1. **Euclidean Domain**: The norm N(a+b√-2) = a²+2b² is a Euclidean function. The rounding error in the division algorithm satisfies δ₁² + 2δ₂² ≤ (1/2)² + 2(1/2)² = 3/4 < 1 (compared to ℤ[i]'s 1/4 + 1/4 = 1/2 < 1).\n\n2. **Inert Prime Classification**: A rational prime p is prime in ℤ[√-2] iff p ≡ 5 or 7 (mod 8). This is the condition (-2/p) = -1 for the Legendre symbol.\n\n**The mod-8 impossibility**: If N(a) = p, then a₀² + 2b₀² ≡ p (mod 8). Since squares mod 8 are {0,1,4}, the possible values of a²+2b² mod 8 are {0,1,2,3,4,6} — never 5 or 7.",
+    "proofStrategy": "1. Prove N(z) > 0 for z ≠ 0 (since N = a²+2b² ≥ 0 and = 0 only for z=0). 2. Embed ℤ[√-2] into ℂ via √-2 ↦ i√2. 3. Show the error ε = (exact quotient) - (rounded quotient) satisfies normSq(ε) ≤ 3/4 < 1 using |δα|,|δβ| ≤ 1/2. 4. Derive EuclideanDomain → UFD. 5. In a UFD, irreducible = prime. 6. Show p ≡ 5 or 7 (mod 8) is irreducible by the mod-8 impossibility argument.",
+    "keyInsights": [
+      "The Euclidean bound for ℤ[√-2] is 3/4 (not 1/2 as in ℤ[i]) because the imaginary part scales by √2 in the complex embedding, giving normSq(δα + √2·δβ·I) = δα² + 2δβ².",
+      "The inert prime condition p ≡ 5 or 7 (mod 8) corresponds to (-2/p) = -1, preventing p from being a norm in ℤ[√-2].",
+      "The `decide` tactic can verify `no_sum_form_mod8` by exhaustive check of ZMod 8 (64 cases).",
+      "The proof structure mirrors BezoutIdentityOQ02OQ01OQ02OQ02 (Gaussian integers) almost exactly, with norm a²+2b² replacing a²+b² and mod 8 replacing mod 4.",
+      "3 splits (3 = (1+√-2)(1-√-2)), 2 ramifies (2 = -(√-2)²), and 5,7 are inert — exemplifying all three behaviors."
+    ],
+    "prerequisites": [
+      "BezoutIdentityOQ02OQ01OQ02OQ02: Gaussian integers inert prime classification",
+      "Mathlib: Zsqrtd, EuclideanDomain, Complex.normSq",
+      "Number theory: Legendre symbol, quadratic reciprocity"
+    ]
+  },
+  "conclusion": {
+    "summary": "ℤ[√-2] is a Euclidean domain with the 3/4 rounding bound, and rational primes p ≡ 5 or 7 (mod 8) are inert (prime) in this ring. This generalizes the ℤ[i] inert prime classification (p ≡ 3 mod 4) to a new ring.",
+    "implications": "The technique generalizes to all five Euclidean imaginary quadratic rings. Each has its own Euclidean bound and inert prime condition determined by the Legendre symbol. The unified framework is: p is inert in ℤ[√d] iff d is not a square mod p.",
+    "openQuestions": [
+      "Can this be further generalized to ℤ[√-3], ℤ[√-7], and ℤ[√-11] (the other Euclidean imaginary quadratic rings)? These would require the ring of integers ℤ[ω] for d = -3 and similar.",
+      "Can we formalize the full prime classification in ℤ[√-2] (not just the inert direction): characterizing split primes (p ≡ 1 or 3 mod 8) and ramified primes (p = 2)?",
+      "Can the Euclidean domain proof be generalized to a parameterized family Zsqrtd(d) for d ∈ {-1,-2,-3,-7,-11} with a uniform bound?"
+    ]
+  },
+  "leanFile": {
+    "namespace": "ZSqrtNegTwo",
+    "lineCount": 230,
+    "axiomCount": 0,
+    "theoremCount": 16,
+    "definitionCount": 3,
+    "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "bezout-identity-oq-02-oq-01-oq-02-oq-02",
+      "relationship": "extends",
+      "description": "Parent proof: Gaussian integers ℤ[i] inert prime classification (p ≡ 3 mod 4)"
+    }
+  ],
+  "sections": [
+    {
+      "id": "sec-norm",
+      "title": "Part I: Basic Norm Properties",
+      "startLine": 38,
+      "endLine": 65,
+      "summary": "Norm N(a+b√-2) = a²+2b² is nonneg, positive for nonzero elements, and the formula. natAbs connection for EuclideanDomain."
+    },
+    {
+      "id": "sec-embedding",
+      "title": "Part II: Complex Embedding",
+      "startLine": 67,
+      "endLine": 95,
+      "summary": "toComplex : ℤ[√-2] →+* ℂ via √-2 ↦ i√2. Injective. Norm equals Complex.normSq ∘ toComplex."
+    },
+    {
+      "id": "sec-division",
+      "title": "Part III: Division Algorithm",
+      "startLine": 97,
+      "endLine": 120,
+      "summary": "Div and Mod instances. Division rounds the rational quotient coordinates."
+    },
+    {
+      "id": "sec-bound",
+      "title": "Part IV: 3/4 Norm Bound",
+      "startLine": 122,
+      "endLine": 165,
+      "summary": "Key bound: normSq(error) ≤ 3/4 < 1. Error = δα + √2·δβ·I with |δα|,|δβ| ≤ 1/2. normSq = δα²+2δβ² ≤ 3/4."
+    },
+    {
+      "id": "sec-euclidean",
+      "title": "Part V: Euclidean Domain",
+      "startLine": 167,
+      "endLine": 190,
+      "summary": "EuclideanDomain instance, UniqueFactorizationMonoid derivation."
+    },
+    {
+      "id": "sec-inert",
+      "title": "Part VI: Inert Prime Classification",
+      "startLine": 192,
+      "endLine": 230,
+      "summary": "no_sum_form_mod8 (decide), inert_prime_neg2 for p ≡ 5 or 7 (mod 8), concrete examples 5 and 7."
+    }
+  ]
+}

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-02-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-02-oq-01-oq-01/annotations.json
@@ -1,1 +1,50 @@
-[]
+[
+  {
+    "id": "ann-product-formula",
+    "proofId": "central-limit-theorem-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 86, "endLine": 103 },
+    "type": "technique",
+    "title": "Product Formula: The Algebraic Heart of the CLT",
+    "content": "The product formula\n  φ_{μ₁,σ₁²}(t) · φ_{μ₂,σ₂²}(t) = φ_{μ₁+μ₂,σ₁²+σ₂²}(t)\nis a one-line consequence of exp(a)·exp(b) = exp(a+b):\n\n  exp(iμ₁t - σ₁²t²/2) · exp(iμ₂t - σ₂²t²/2)\n  = exp((iμ₁t - σ₁²t²/2) + (iμ₂t - σ₂²t²/2))\n  = exp(i(μ₁+μ₂)t - (σ₁²+σ₂²)t²/2)\n  = φ_{μ₁+μ₂,σ₁²+σ₂²}(t)\n\nThis encodes the fundamental fact: X₁ ~ N(μ₁,σ₁²) and X₂ ~ N(μ₂,σ₂²) independent implies X₁+X₂ ~ N(μ₁+μ₂,σ₁²+σ₂²). The power formula `gaussianCharFn_pow` follows by induction on this product.",
+    "mathContext": "The characteristic function φ_X(t) = E[e^{itX}] transforms convolution (sum of independent r.v.) into pointwise multiplication. The Gaussian distribution is a fixed point of this multiplication structure: the family {N(μ,σ²)} is closed under convolution, with parameters adding. This is the algebraic core of the CLT.",
+    "significance": "key",
+    "relatedConcepts": ["characteristic function", "convolution", "Gaussian stability"],
+    "prerequisites": ["Complex.exp_add", "Gaussian definition"]
+  },
+  {
+    "id": "ann-modulus-decay",
+    "proofId": "central-limit-theorem-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 58, "endLine": 77 },
+    "type": "insight",
+    "title": "|φ(t)| = exp(-σ²t²/2): Mean Affects Phase Only",
+    "content": "The modulus computation reveals a key structural fact:\n  |φ_{μ,σ²}(t)| = |exp(iμt - σ²t²/2)|\n                = exp(Re(iμt - σ²t²/2))\n                = exp(-σ²t²/2)\n\nThe mean μ appears only in the imaginary part iμt of the exponent — it oscillates but doesn't decay. Only σ² controls the decay rate.\n\nConsequences:\n• |φ(t)| = 1 iff σ² = 0 (degenerate/point mass)\n• For σ² > 0: |φ(t)| < 1 for all t ≠ 0\n• The decay exp(-σ²t²/2) is integrable over ℝ → Lévy's inversion theorem applies",
+    "mathContext": "For any z ∈ ℂ: |e^z| = e^{Re(z)}. The real part of the Gaussian exponent is -σ²t²/2 regardless of μ. This Gaussian envelope in frequency space is dual to the Gaussian density in physical space — the Fourier transform of e^{-σ²x²/2} is e^{-t²/(2σ²)}.",
+    "significance": "key",
+    "relatedConcepts": ["Complex.abs_exp", "Gaussian envelope", "Lévy inversion"],
+    "prerequisites": ["Complex.abs_exp", "Real.exp_lt_exp_of_lt"]
+  },
+  {
+    "id": "ann-clt-stability",
+    "proofId": "central-limit-theorem-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 165, "endLine": 176 },
+    "type": "insight",
+    "title": "CLT Gaussian Stability: Sₙ/√n ~ N(0,1) from Char Fn Algebra",
+    "content": "The CLT stability theorem in 10 lines:\n\nIf X₁,...,Xₙ are iid N(0,1), then Sₙ = X₁+...+Xₙ ~ N(0,n) by the product formula.\nThe characteristic function of Sₙ/√n at t is the char fn of Sₙ at t/√n:\n  φ_{0,n}(t/√n) = exp(-n·(t/√n)²/2) = exp(-n·t²/(2n)) = exp(-t²/2) = φ_{0,1}(t)\n\nSo Sₙ/√n has the same characteristic function as N(0,1) — hence the same distribution.\n\nThe Lean proof uses `Real.sq_sqrt` to justify √n² = n for natural n, then `field_simp` and `nlinarith` for the algebraic simplification.",
+    "mathContext": "This is the Gaussian case of the CLT, where the limit distribution is Gaussian precisely because Gaussians are closed under convolution and scaling. The general CLT (non-Gaussian iid) requires Lévy's continuity theorem — pointwise convergence of char fns implies weak convergence. This theorem provides the base case and demonstrates the proof strategy.",
+    "significance": "key",
+    "relatedConcepts": ["CLT", "weak convergence", "Gaussian stability", "characteristic function"],
+    "prerequisites": ["gaussianCharFn_pow", "Real.sq_sqrt", "Gaussian scaling"]
+  },
+  {
+    "id": "ann-conjugate-symmetry",
+    "proofId": "central-limit-theorem-oq-01-oq-02-oq-01-oq-01",
+    "range": { "startLine": 111, "endLine": 123 },
+    "type": "concept",
+    "title": "Conjugate Symmetry: φ(-t) = conj(φ(t)) ↔ Real Distribution",
+    "content": "For any real-valued random variable X:\n  E[e^{-itX}] = E[conj(e^{itX})] = conj(E[e^{itX}])\n\nSo φ(-t) = conj(φ(t)) is equivalent to X being real-valued.\n\nFor the Gaussian: φ_{μ,σ²}(-t) = exp(-iμt - σ²t²/2) = conj(exp(iμt - σ²t²/2)) = conj(φ_{μ,σ²}(t)).\n\nSpecial case: for μ = 0 (centered), φ(t) = exp(-σ²t²/2) is real and positive — its imaginary part is 0. This is proved in `gaussianCharFn_real_of_centered`.",
+    "mathContext": "The conjugate symmetry condition is a necessary criterion for characteristic functions of real distributions. The Gaussian satisfies it because the density (2πσ²)^{-1/2} e^{-(x-μ)²/(2σ²)} is real-valued. In Lean, this is proved via `Complex.star_def` and coordinate computations.",
+    "significance": "supporting",
+    "relatedConcepts": ["conjugate symmetry", "real distribution", "Fourier transform"],
+    "prerequisites": ["Complex.star_def", "characteristic function definition"]
+  }
+]

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -19,7 +19,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 170,
+    "lineCount": 176,
     "assumptions": "0 axioms, 0 sorries. All properties proved from Complex.exp algebra.",
     "dateAdded": "2026-04-12",
     "mathlib_version": "4.26.0",
@@ -131,7 +131,7 @@
   "leanFile": {
     "imports": ["Mathlib"],
     "namespace": "CentralLimitTheoremOQ01OQ02OQ01OQ01",
-    "lineCount": 170,
+    "lineCount": 176,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 2,

--- a/src/data/proofs/fair-games-theorem-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/fair-games-theorem-oq-02-oq-01/annotations.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "ann-ost-bounded",
+    "proofId": "fair-games-theorem-oq-02-oq-01",
+    "range": { "startLine": 68, "endLine": 84 },
+    "type": "technique",
+    "title": "Bounded OST: The Clean Canonical Statement",
+    "content": "doob_optional_stopping_theorem gives the bounded Optional Stopping Theorem in its cleanest form: for martingale X and bounded stopping time τ ≤ N, E[X_τ] = E[X_0]. The proof delegates entirely to FairGamesOQ03.any_bounded_strategy_preserves_expectation, which in turn uses the submartingale/supermartingale sandwich argument: apply expected_stoppedValue_mono twice (for X and -X), get E[X_0] ≤ E[X_τ] and E[X_τ] ≤ E[X_0], conclude by antisymmetry.\n\nThe key hypothesis τ : Ω → ℕ∞ (not τ : Ω → ℕ) is the Mathlib 4.26 convention. The ℕ∞ type allows τ(ω) = ⊤ (never stop), which is mathematically natural and required for the characterization theorem.",
+    "mathContext": "The bounded OST is the foundation of all more advanced results. The bound τ ≤ N is necessary without additional integrability conditions. Doob (1953) also proved the L¹ version (τ < ∞ a.s., E[τ] < ∞, uniform integrability) and the L^p version (p > 1 gives better control). The bounded version is the safest and most general for finite-time applications.",
+    "significance": "key",
+    "relatedConcepts": ["Submartingale.expected_stoppedValue_mono", "IsStoppingTime", "stoppedValue", "Martingale"],
+    "prerequisites": ["Martingale in Lean 4", "IsStoppingTime with ℕ∞", "stoppedValue"]
+  },
+  {
+    "id": "ann-submartingale-inequality",
+    "proofId": "fair-games-theorem-oq-02-oq-01",
+    "range": { "startLine": 86, "endLine": 102 },
+    "type": "technique",
+    "title": "Submartingale OST: Expected Values Are Ordered",
+    "content": "doob_ost_submartingale gives the submartingale version: for a *submartingale* X (where E[X_{n+1} | ℱₙ] ≥ Xₙ, a process that tends to increase) and bounded τ ≤ σ ≤ N: E[X_τ] ≤ E[X_σ]. Stopping earlier gives a smaller or equal expected payoff.\n\nThis is a direct application of Mathlib's `Submartingale.expected_stoppedValue_mono`. The hypothesis τ ≤ σ (pointwise for all ω) is the essential condition — you must commit to stopping the earlier strategy before the later one.\n\nApplications: (1) Gambler with house edge (submartingale for the house) — the casino's expected profit is non-decreasing with time. (2) Asset prices under no-arbitrage measure — stopping earlier in a favorable process reduces the expected gain.",
+    "mathContext": "The submartingale OST is the 'half' of the full OST. For a martingale X, both X and -X are submartingales, giving E[X_τ] ≤ E[X_σ] and E[-X_τ] ≤ E[-X_σ] (i.e., E[X_σ] ≤ E[X_τ]), hence E[X_τ] = E[X_σ]. The submartingale version is important independently for one-sided stopping problems.",
+    "significance": "key",
+    "relatedConcepts": ["Submartingale", "expected_stoppedValue_mono", "pairwise bounded stopping times"],
+    "prerequisites": ["Submartingale definition", "conditional expectation", "IsStoppingTime"]
+  },
+  {
+    "id": "ann-convergence",
+    "proofId": "fair-games-theorem-oq-02-oq-01",
+    "range": { "startLine": 122, "endLine": 148 },
+    "type": "insight",
+    "title": "Doob's Martingale Convergence: a.s. Limits via Mathlib",
+    "content": "doob_martingale_convergence uses `Martingale.ae_tendsto_limitProcess` from Mathlib. The hypothesis is UniformIntegrable X 1 μ (uniform integrability in L¹), which is stronger than just supₙ E|Xₙ| < ∞ but implied by, e.g., L∞-boundedness.\n\nThe conclusion is that Xₙ(ω) → ℱ.limitProcess X μ ω for almost every ω. The limit `limitProcess` is the Mathlib-defined limit of the martingale, which in nice cases equals E[X_∞ | ℱ_∞].\n\nThe upcrossing inequality (Doob's lemma): if a martingale makes many upcrossings of [a,b] before time N, then E[Xₙ⁺] is large. Formally: E[U_N([a,b])] ≤ (E[Xₙ⁺] + |a|)/(b-a). Since E[Xₙ⁺] is bounded (by L¹-boundedness), the expected upcrossings are bounded, and by Monotone Convergence, upcrossings are finite a.s., forcing convergence.",
+    "mathContext": "Doob's convergence theorem is equivalent to the upcrossing inequality via the following: a sequence of real numbers diverges iff it makes infinitely many upcrossings of some rational interval [a,b]. The upcrossing inequality bounds E[U_N([a,b])], and by MCT the total upcrossings are finite a.s., hence convergence holds a.s. Mathlib's proof follows this approach.",
+    "significance": "key",
+    "relatedConcepts": ["UniformIntegrable", "limitProcess", "ae_tendsto_limitProcess", "upcrossing inequality"],
+    "prerequisites": ["uniform integrability", "Filtration.limitProcess", "almost sure convergence"]
+  },
+  {
+    "id": "ann-submartingale-iff",
+    "proofId": "fair-games-theorem-oq-02-oq-01",
+    "range": { "startLine": 170, "endLine": 202 },
+    "type": "insight",
+    "title": "Submartingale Characterization: Local ↔ Global OST Condition",
+    "content": "submartingale_iff_ost gives the fundamental equivalence: f is a submartingale iff for all bounded stopping times τ ≤ σ, E[f_τ] ≤ E[f_σ]. This is a deep theorem connecting:\n- **Local condition**: E[f_{n+1} | ℱₙ] ≥ fₙ (definition of submartingale)\n- **Global condition**: stopped expectations are monotone (optional stopping)\n\nThe iff uses Mathlib's `submartingale_iff_expected_stoppedValue_mono`. The (⇒) direction is the OST. The (⟸) direction: if stopped expectations are monotone, then in particular for τ = n and σ = n+1 (constant stopping times), E[f_n] ≤ E[f_{n+1}], which combined with adaptedness gives the submartingale condition.\n\nThis theorem shows OST is not just a consequence of the martingale property — it's an equivalent characterization.",
+    "mathContext": "The equivalence `Submartingale ↔ stopped expectations monotone` is Doob's characterization theorem. For martingales, both directions give equality: the martingale property ↔ all bounded stopping strategies give the same expected outcome. This is the 'optimal stopping theory' formulation of the martingale property, connecting it to decision theory.",
+    "significance": "key",
+    "relatedConcepts": ["submartingale_iff_expected_stoppedValue_mono", "Adapted", "Integrable", "conditional expectation"],
+    "prerequisites": ["submartingale definition", "Mathlib's submartingale_iff theorem", "IsStoppingTime"]
+  },
+  {
+    "id": "ann-maximal-ineq",
+    "proofId": "fair-games-theorem-oq-02-oq-01",
+    "range": { "startLine": 205, "endLine": 225 },
+    "type": "technique",
+    "title": "Doob's Maximal Inequality: λP(max ≥ λ) ≤ E[X_N]",
+    "content": "doob_maximal_inequality bounds the probability of the running maximum exceeding a threshold: λ · P(∃ n ≤ N, Xₙ ≥ λ) ≤ E[X_N]. For a non-negative submartingale, the expected value at time N controls how often the process can be large before time N.\n\nProof idea: Let τ = min{n : Xₙ ≥ λ} (if no such n, τ = N). Then E[Xₙ] ≥ E[X_τ] ≥ λ · P(τ < N) = λ · P(∃ n < N, Xₙ ≥ λ). The inequality E[X_N] ≥ E[X_τ] uses the submartingale OST.\n\nApplications: (1) Azuma-Hoeffding (via exponential martingale trick); (2) L² convergence of martingales; (3) Doob's L^p inequality (E[max_n Xₙ^p] ≤ (p/(p-1))^p E[X_∞^p] for p > 1).",
+    "mathContext": "Doob's maximal inequality is fundamental to almost-sure convergence (via Borel-Cantelli on exceedance events), to L^p bounds on the maximal function, and to the theory of Hardy-Littlewood maximal functions. In Lean, the proof delegates to Mathlib's `maximal_ineq` (in ENNReal/NNReal), converted to the real-valued form.",
+    "significance": "supporting",
+    "relatedConcepts": ["maximal_ineq", "Submartingale", "running maximum", "Borel-Cantelli lemma"],
+    "prerequisites": ["non-negative submartingale", "Measure.toReal", "ENNReal to real conversion"]
+  },
+  {
+    "id": "ann-no-strategy",
+    "proofId": "fair-games-theorem-oq-02-oq-01",
+    "range": { "startLine": 152, "endLine": 169 },
+    "type": "concept",
+    "title": "No Profitable Strategy: The Mathematical Basis of Market Efficiency",
+    "content": "no_profitable_stopping_strategy restates the bounded OST as an economic principle: in a fair game (martingale), no bounded stopping rule can increase your expected wealth above the initial value. This is the mathematical foundation of: (1) Efficient Market Hypothesis — if prices are a martingale, no trading strategy (stopping rule for when to buy/sell) can earn above-market expected returns; (2) Casino mathematics — fair games have zero expected profit regardless of betting strategy; (3) No-arbitrage in options theory — risk-neutral prices are martingales, so no portfolio strategy earns risk-free profit above the risk-free rate.\n\nThe theorem is trivially proved (it's just the OST) but its economic interpretation is profound: the mathematical structure of martingales exactly captures the 'no free lunch' principle.",
+    "mathContext": "The connection between martingales and 'no free lunch' was formalized by Harrison-Kreps (1979) and Delbaen-Schachermayer (1994) in the Fundamental Theorem of Asset Pricing: a market has no arbitrage if and only if there exists an equivalent martingale measure. Doob's OST is the main technical tool in proving this correspondence.",
+    "significance": "key",
+    "relatedConcepts": ["Efficient Market Hypothesis", "no-arbitrage", "Fair Games Theorem", "risk-neutral pricing"],
+    "prerequisites": ["Martingale interpretation as fair game", "OST", "economic interpretation of stochastic processes"]
+  }
+]

--- a/src/data/proofs/fair-games-theorem-oq-02-oq-01/index.ts
+++ b/src/data/proofs/fair-games-theorem-oq-02-oq-01/index.ts
@@ -1,0 +1,38 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+import sourceRaw from '../../../../proofs/Proofs/FairGamesTheoremOQ02OQ01.lean?raw'
+
+const meta = metaJson as unknown as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+export const fairGamesTheoremOQ02OQ01Proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  sections: meta.sections ?? [],
+  source: sourceRaw,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const fairGamesTheoremOQ02OQ01Annotations: Annotation[] =
+  annotationsJson as unknown as Annotation[]
+
+export const fairGamesTheoremOQ02OQ01Data: ProofData = {
+  proof: fairGamesTheoremOQ02OQ01Proof,
+  annotations: fairGamesTheoremOQ02OQ01Annotations,
+  tacticStates: [],
+}

--- a/src/data/proofs/fair-games-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/fair-games-theorem-oq-02-oq-01/meta.json
@@ -1,0 +1,148 @@
+{
+  "id": "fair-games-theorem-oq-02-oq-01",
+  "title": "Doob's Optional Stopping Theorem: Standalone Formalization",
+  "slug": "fair-games-theorem-oq-02-oq-01",
+  "description": "Comprehensive formalization of Doob's Optional Stopping Theorem (1953) using Mathlib's probability library. Proves three forms of OST (bounded, submartingale inequality, two stopping times), the martingale convergence theorem, the submartingale characterization via OST, and Doob's maximal inequality. Answers the open question from FairGamesTheoremOQ02: Yes, Mathlib's martingale library is sufficient for a complete OST formalization. 10 theorems, 0 sorries, 291 lines.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-04-12",
+    "status": "verified",
+    "proofRepoPath": "Proofs/FairGamesTheoremOQ02OQ01.lean",
+    "tags": [
+      "probability",
+      "martingale",
+      "optional-stopping",
+      "doob",
+      "convergence",
+      "stochastic-processes"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "dateAdded": "2026-04-12",
+    "axiomCount": 0,
+    "assumptions": "None. Delegates to FairGamesTheoremOQ03.lean (which is fully verified) and Mathlib's martingale library.",
+    "lineCount": 291,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "originalContributions": [
+      "doob_optional_stopping_theorem: clean standalone statement of the bounded OST",
+      "doob_ost_submartingale: submartingale inequality version (E[f_τ] ≤ E[f_σ])",
+      "doob_ost_two_stopping_times: two stopping times version (E[f_τ] = E[f_σ])",
+      "doob_martingale_convergence: Doob's martingale convergence theorem (a.s.)",
+      "no_profitable_stopping_strategy: no bounded strategy increases expected wealth",
+      "submartingale_iff_ost: submartingale iff stopped expectations are monotone",
+      "doob_maximal_inequality: λP(max ≥ λ) ≤ E[X_N] for non-negative submartingales",
+      "martingale_expected_value_constant: E[X_n] = E[X_0] (time invariance)",
+      "fundamental_theorem_fair_games: no bounded strategy changes expected outcome",
+      "all_strategies_equal_implies_submartingale: converse characterization"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Joseph Doob proved the Optional Stopping Theorem in his seminal 1953 book 'Stochastic Processes' (Chapter VII). The theorem formalizes the intuition that in a fair game (martingale), no clever strategy for choosing when to stop can improve expected outcomes. This mathematical principle underlies: the efficient market hypothesis in finance, the impossibility of guaranteed profit systems in casino gambling, the risk-neutral pricing formula in options theory, and the no-arbitrage condition in modern financial mathematics.\n\nThe OST was the centerpiece of Doob's martingale theory, which transformed probability theory in the 1950s. The theorem connects three fundamental ideas: filtrations (information revealed over time), stopping times (decision rules based on available information), and martingales (fair processes). Together they provide the mathematical framework for 'rational decision-making under uncertainty' that is foundational to modern probability and mathematical finance.",
+    "problemStatement": "Can Doob's Optional Stopping Theorem be fully formalized in Lean 4 using Mathlib's probability library? Does Mathlib have sufficient infrastructure for filtered probability spaces, stopping times, and martingale integrals?",
+    "text": "**Answer**: Yes. Mathlib's probability library (Mathlib.Probability.Martingale) provides complete infrastructure for the Optional Stopping Theorem. This file gives a comprehensive formalization:\n\n**Three forms of the OST:**\n1. **Bounded OST**: For martingale {Xₙ} and stopping time τ ≤ N: E[X_τ] = E[X_0]. Proved via submartingale/supermartingale sandwich using Mathlib's `Submartingale.expected_stoppedValue_mono`.\n\n2. **Submartingale OST**: For submartingale {Xₙ} and τ ≤ σ ≤ N: E[X_τ] ≤ E[X_σ]. This is the key monotonicity result.\n\n3. **Two Stopping Times**: For martingale {Xₙ} and τ ≤ σ ≤ N: E[X_τ] = E[X_σ]. Any two bounded strategies have the same expected outcome.\n\n**Convergence**: Doob's convergence theorem — uniformly integrable martingales converge almost surely to a limit. Uses Mathlib's `Martingale.ae_tendsto_limitProcess`.\n\n**Characterization**: Submartingale iff stopped expectations are monotone. This iff characterization (Mathlib's `submartingale_iff_expected_stoppedValue_mono`) is fundamental: it connects the 'local' martingale condition to the 'global' optimal stopping property.\n\n**Maximal inequality**: Doob's inequality λP(max ≥ λ) ≤ E[X_N], used in proving convergence and concentration bounds.",
+    "proofStrategy": "All theorems delegate to either FairGamesTheoremOQ03.lean (which proves the key applications from Mathlib's core) or directly to Mathlib lemmas. The file serves as a clean, gallery-oriented wrapper that exposes the OST in its canonical forms with comprehensive documentation.",
+    "keyInsights": [
+      "Mathlib's martingale library (Mathlib.Probability.Martingale.OptionalStopping) provides all necessary infrastructure: Filtration, IsStoppingTime, stoppedValue, Martingale/Submartingale typeclasses.",
+      "The key Mathlib theorem is Submartingale.expected_stoppedValue_mono: E[f_τ] ≤ E[f_σ] for τ ≤ σ ≤ N. The martingale OST follows by applying this to f and -f.",
+      "The submartingale iff characterization (submartingale_iff_expected_stoppedValue_mono) gives a clean two-sided statement connecting local and global properties.",
+      "Mathlib 4.26 uses τ : Ω → ℕ∞ for stopping times (not τ : Ω → ℕ). The ℕ∞ type handles possibly-infinite stopping times correctly.",
+      "The convergence theorem (ae_tendsto_limitProcess) requires uniform integrability rather than just L¹-boundedness — a key refinement over the naive statement.",
+      "The proof that 'no profitable stopping strategy exists' is immediate: it's just the bounded OST restated for emphasis. The mathematical content is entirely in Mathlib's lemmas."
+    ],
+    "prerequisites": [
+      "Filtered probability spaces: Filtration, MeasurableSpace, Measure, IsProbabilityMeasure",
+      "Stopping times: IsStoppingTime, isStoppingTime_const",
+      "Martingale theory: Martingale, Submartingale, stoppedValue",
+      "Integration: integral, Integrable, UniformIntegrable",
+      "Parent proofs: FairGamesTheoremOQ03.lean (Applications), FairGamesTheoremOQ02.lean (Gambler's Ruin)"
+    ]
+  },
+  "conclusion": {
+    "summary": "Doob's Optional Stopping Theorem fully formalized: 3 forms of OST, martingale convergence, submartingale characterization, maximal inequality, and fundamental no-strategy theorem. All 10 theorems proved with 0 sorries, 0 axioms. Mathlib 4.26's probability library is fully sufficient for the complete OST formalization.",
+    "implications": "This file closes the open question from FairGamesTheoremOQ02: Mathlib's martingale library is indeed sufficient for a complete OST formalization. The infrastructure — filtrations, stopping times, stoppedValue, submartingale_iff_expected_stoppedValue_mono — covers all standard forms of the theorem. The convergence theorem and maximal inequality are also available, making Mathlib ready for advanced martingale-based probability theory.",
+    "openQuestions": [
+      "Wald's identity: If X_n = ∑_{i≤n} Y_i with E[Y_i] = μ and E[τ] < ∞, then E[X_τ] = μ E[τ]. Can this be proved using Mathlib's integration tools?",
+      "Azuma-Hoeffding inequality: For a martingale with bounded differences |X_n - X_{n-1}| ≤ c_n, P(X_τ - X_0 ≥ t) ≤ exp(-2t²/∑c_n²). Not yet in Mathlib — can it be built from the existing infrastructure?",
+      "Martingale Central Limit Theorem: Under appropriate conditions, (X_n - X_0)/√n → N(0,σ²) in distribution. Formalize the conditions and proof using Mathlib's CLT infrastructure.",
+      "Doob's h-transform: Given a harmonic function h > 0, the process h(X_n)/h(X_0) is a martingale. Formalize this conditioning technique for Markov chains."
+    ]
+  },
+  "leanFile": {
+    "namespace": "FairGamesOQ02OQ01",
+    "lineCount": 291,
+    "axiomCount": 0,
+    "theoremCount": 10,
+    "definitionCount": 0,
+    "path": "Proofs/FairGamesTheoremOQ02OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "fair-games-theorem-oq-02",
+      "relationship": "extends",
+      "description": "Gambler's Ruin computations; this file provides the abstract OST that justifies those formulas"
+    },
+    {
+      "targetId": "fair-games-theorem-oq-03",
+      "relationship": "related",
+      "description": "Application theorems for martingales; this file wraps those applications in canonical OST form"
+    },
+    {
+      "targetId": "fair-games-theorem",
+      "relationship": "extends",
+      "description": "Base proof with Fair Games definitions and OST statement"
+    }
+  ],
+  "sections": [
+    {
+      "id": "sec-imports",
+      "title": "Imports and Module Header",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Imports Mathlib and FairGamesTheoremOQ03. Module header explains the open question, the mathematical content, Mathlib infrastructure, and connections to parent proofs."
+    },
+    {
+      "id": "sec-ost-three-forms",
+      "title": "Part I: OST — Three Forms",
+      "startLine": 48,
+      "endLine": 118,
+      "summary": "Three canonical forms: (1) doob_optional_stopping_theorem — bounded OST, E[X_τ] = E[X_0]; (2) doob_ost_submartingale — submartingale inequality E[f_τ] ≤ E[f_σ]; (3) doob_ost_two_stopping_times — two stopping times E[f_τ] = E[f_σ]."
+    },
+    {
+      "id": "sec-convergence",
+      "title": "Part II: Martingale Convergence Theorem",
+      "startLine": 119,
+      "endLine": 149,
+      "summary": "doob_martingale_convergence: uniformly integrable martingales converge almost surely to their limit process. Uses Mathlib's ae_tendsto_limitProcess."
+    },
+    {
+      "id": "sec-no-strategy",
+      "title": "Part III: No Profitable Strategy",
+      "startLine": 150,
+      "endLine": 169,
+      "summary": "no_profitable_stopping_strategy: restates OST as the economic principle — no bounded stopping strategy increases expected wealth in a fair game."
+    },
+    {
+      "id": "sec-characterization",
+      "title": "Part IV: Submartingale Characterization",
+      "startLine": 170,
+      "endLine": 204,
+      "summary": "submartingale_iff_ost: submartingale iff E[f_τ] ≤ E[f_σ] for all bounded τ ≤ σ. The iff version of the OST via Mathlib's submartingale_iff_expected_stoppedValue_mono."
+    },
+    {
+      "id": "sec-maximal",
+      "title": "Part V: Doob's Maximal Inequality",
+      "startLine": 205,
+      "endLine": 225,
+      "summary": "doob_maximal_inequality: λP(max_{n≤N} X_n ≥ λ) ≤ E[X_N] for non-negative submartingales. Delegates to OQ03's conversion from Mathlib's NNReal form."
+    },
+    {
+      "id": "sec-summary",
+      "title": "Part VI: Summary Theorems",
+      "startLine": 226,
+      "endLine": 291,
+      "summary": "martingale_expected_value_constant: E[X_n] = E[X_0] for all n. fundamental_theorem_fair_games: the definitive no-strategy result. all_strategies_equal_implies_submartingale: the converse characterization."
+    }
+  ]
+}

--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-04/annotations.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-04/annotations.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "ann-row-symmetry",
+    "proofId": "shannon-channel-coding-oq-02-oq-04",
+    "range": { "startLine": 91, "endLine": 127 },
+    "type": "technique",
+    "title": "H(Y|X) = -C: The Key Computation for Row-Symmetric Channels",
+    "content": "The core computation generalizing the BSC conditional entropy proof:\n\nFor input x with p(x) > 0:\n  Term = p(x)·W(x,y)·log(p(x)·W(x,y) / p(x))  [denominator = ∑_{y'} p(x)·W(x,y') = p(x)]\n       = p(x)·W(x,y)·log(W(x,y))               [p(x) cancels]\n\nFor input x with p(x) = 0:\n  Term = 0 (by the if-then-else in conditionalEntropy)\n\nSumming over all (y,x):\n  ∑_y ∑_x term = ∑_x p(x) · ∑_y W(x,y)·log(W(x,y))\n               = ∑_x p(x) · C                    [by row symmetry]\n               = C · ∑_x p(x) = C               [since ∑_x p(x) = 1]\n\nConditional entropy = -(C) = -C.\n\nKey: This works for ANY input distribution, even degenerate ones, because zero-probability inputs contribute 0 to both sides.",
+    "mathContext": "This generalizes the BSC computation where the constant C = p·log(p) + (1-p)·log(1-p). For a general row-symmetric channel, C = ∑_y W(x₀,y)·log(W(x₀,y)) for any fixed x₀. The condition C = const is equivalent to: all rows of the channel matrix have equal Shannon entropy H(row x) = -C.",
+    "significance": "key",
+    "relatedConcepts": ["conditionalEntropy", "transposeJoint", "row symmetry"],
+    "prerequisites": ["channel joint distribution", "conditionalEntropy definition"]
+  },
+  {
+    "id": "ann-doubly-balanced",
+    "proofId": "shannon-channel-coding-oq-02-oq-04",
+    "range": { "startLine": 129, "endLine": 141 },
+    "type": "concept",
+    "title": "Doubly Balanced Condition: Uniform Input → Uniform Output",
+    "content": "A channel is doubly balanced if all column sums are equal:\n  ∀ y : β, ∑_x W(x,y) = |α|/|β|\n\nWith uniform input (p(x) = 1/|α|):\n  P(Y=y) = ∑_x p(x)·W(x,y) = (1/|α|) · ∑_x W(x,y) = (1/|α|) · (|α|/|β|) = 1/|β|\n\nSo the output is uniform on β, giving H(Y) = log|β|.\n\nFor BSC (α = β = Bool): column sums = p + (1-p) = 1 = |Bool|/|Bool|. ✓\nFor q-ary symmetric channel: each output appears with probability 1/q from each input, so column sums = |α|/q = |α|/|β|. ✓\n\nThe doubly balanced condition is STRONGER than row symmetry alone. It ensures the maximum entropy H(Y) = log|β| is actually achieved by the uniform input.",
+    "mathContext": "A doubly stochastic matrix (where both row sums and column sums equal 1, with |α| = |β|) satisfies the doubly balanced condition with |α|/|β| = 1. The BSC is doubly stochastic. For general |α| ≠ |β|, the condition ∑_x W(x,y) = |α|/|β| is the natural analog.",
+    "significance": "key",
+    "relatedConcepts": ["doubly stochastic matrix", "maximum entropy", "uniform distribution"],
+    "prerequisites": ["channel marginal distributions", "entropy maximization"]
+  },
+  {
+    "id": "ann-capacity-formula",
+    "proofId": "shannon-channel-coding-oq-02-oq-04",
+    "range": { "startLine": 192, "endLine": 220 },
+    "type": "insight",
+    "title": "Capacity = log|β| + C = log|β| - H(row): The General Formula",
+    "content": "The main theorem:\n  C(W) = log|β| - H(row) = log|β| + C\n  where C = ∑_y W(x,y)·log(W(x,y)) ≤ 0 (negative entropy)\n  and H(row) = -C ≥ 0 (row entropy)\n\nSpecial cases:\n• BSC(p): |β|=2, C = p·log p + (1-p)·log(1-p) → C = log 2 - h(p)\n• Binary erasure channel (BEC): |β|=3 (0, 1, ε), rows [1-ε, 0, ε] and [0, 1-ε, ε]\n  C = (1-ε)log(1-ε) + ε·log(ε) → capacity = log 2 + C = (1-ε)·log 2\n• q-ary symmetric channel: each entry = (1-p)/(q-1) or p, capacity = log(q) - h(p) - p·log(q-1)\n\nThe formula captures the fundamental tradeoff: higher row entropy (more uncertainty about Y given X) means lower capacity.",
+    "mathContext": "The formula C = log|β| - H(row) follows directly from C = H(Y) - H(Y|X) = log|β| - (-C). The row entropy H(row) = -C ≥ 0 is bounded by log|β| (entropy ≤ log of alphabet), so C(W) = log|β| - H(row) ≥ 0. The capacity equals 0 when H(row) = log|β|, i.e., when rows are uniform (maximum noise).",
+    "significance": "key",
+    "relatedConcepts": ["channel capacity", "H(Y|X) = H(row)", "entropy bound"],
+    "prerequisites": ["BSC capacity", "chain rule MI = H(Y) - H(Y|X)"]
+  },
+  {
+    "id": "ann-bsc-recovery",
+    "proofId": "shannon-channel-coding-oq-02-oq-04",
+    "range": { "startLine": 222, "endLine": 247 },
+    "type": "concept",
+    "title": "BSC Recovered from the General Theorem",
+    "content": "The BSC satisfies both hypotheses:\n\n1. Row symmetry (bsc_row_symmetric): For BSC(p) with x : Bool:\n   ∑_{y:Bool} W(x,y)·log(W(x,y)) = p·log(p) + (1-p)·log(1-p) (same for all x)\n   Proof: cases x; simp; ring — both true and false give the same sum.\n\n2. Doubly balanced (bsc_doubly_balanced): Column sums = |Bool|/|Bool| = 2/2 = 1\n   ∑_{x:Bool} W(x,y) = (1-p) + p = 1 for both y = true and y = false.\n\nThen bsc_capacity_from_symmetric applies sym_channel_capacity to recover:\n  C(BSC(p)) = log 2 + (p·log p + (1-p)·log(1-p)) = log 2 - h(p)\n\nThis provides an ALTERNATIVE proof of the BSC capacity from the more general theorem, complementing the direct proof in ShannonChannelCodingOQ02.",
+    "mathContext": "The two proofs of BSC capacity (direct via ShannonChannelCodingOQ02, and via general symmetric channel) are both valid. The general theorem gives more conceptual clarity: the capacity formula follows from the structural properties (row symmetry + doubly balanced), not from the specifics of the binary alphabet.",
+    "significance": "supporting",
+    "relatedConcepts": ["BSC capacity", "bsc_row_symmetric", "bsc_doubly_balanced"],
+    "prerequisites": ["BSC definition", "symmetric channel conditions"]
+  }
+]

--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-04/index.ts
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-04/index.ts
@@ -1,0 +1,46 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+
+// Type assertion for JSON import
+const meta = metaJson as {
+  id: string
+  title: string
+  slug: string
+  description: string
+  meta: ProofMeta
+  sections: ProofSection[]
+  overview?: ProofOverview
+  conclusion?: ProofConclusion
+  crossReferences?: CrossReference[]
+}
+
+// Import the Lean source file
+const leanSource = () => import('../../../../proofs/Proofs/ShannonChannelCodingOQ02OQ04.lean?raw')
+
+export const proof: Proof = {
+  id: meta.id,
+  title: meta.title,
+  slug: meta.slug,
+  description: meta.description,
+  meta: meta.meta,
+  source: '', // Loaded dynamically
+  sections: meta.sections,
+  overview: meta.overview,
+  conclusion: meta.conclusion,
+  crossReferences: meta.crossReferences,
+}
+
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+
+export const proofData: ProofData = {
+  proof,
+  annotations,
+}
+
+export async function getProofSource(): Promise<string> {
+  const module = await leanSource()
+  return module.default
+}
+
+export default proofData

--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-04/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-04/meta.json
@@ -1,0 +1,151 @@
+{
+  "id": "shannon-channel-coding-oq-02-oq-04",
+  "title": "Symmetric Channel Capacity: Generalization Beyond BSC",
+  "slug": "shannon-channel-coding-oq-02-oq-04",
+  "description": "Generalizes the BSC capacity proof to arbitrary symmetric channels. Proves that for a channel where all rows have the same entropy sum C and uniform input produces uniform output (doubly balanced), the capacity equals log|β| + C = log|β| - H(row). Recovers the BSC result as a special case.",
+  "meta": {
+    "author": "Claude Shannon (1948), formalized in Lean 4",
+    "date": "1948",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/ShannonChannelCodingOQ02OQ04.lean",
+    "tags": [
+      "information-theory",
+      "channel-capacity",
+      "symmetric-channels",
+      "generalization",
+      "coding-theory"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "dateAdded": "2026-04-12",
+    "axiomCount": 4,
+    "assumptions": "4 axioms inherited from ShannonChannelCoding.lean via import chain. 0 sorries. 0 new axioms introduced.",
+    "lineCount": 249,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "originalContributions": [
+      "uniformDist: uniform distribution on any nonempty Fintype as an InputDist",
+      "entropy_uniform_fintype: H(uniform on α) = log|α| (generalizes entropy_uniform_bool)",
+      "sym_conditional_output_entropy: H(Y|X) = -C for row-symmetric channels, any input distribution",
+      "sym_uniform_ymarg: doubly balanced + uniform input → uniform output",
+      "sym_uniform_mi: achievability MI = log|β| + C for uniform input",
+      "sym_mi_le: converse MI ≤ log|β| + C for all inputs (via chain rule)",
+      "sym_channel_capacity: capacity = log|β| + C (main theorem)",
+      "BSC verification: bsc_row_symmetric, bsc_doubly_balanced, bsc_capacity_from_symmetric"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Shannon (1948) identified symmetric channels as a natural class for which the capacity formula has a closed form. A channel is symmetric (in the relevant sense) when all rows of the transition matrix are permutations of each other (ensuring H(Y|X) is constant) and all columns are proportional (ensuring uniform input maximizes H(Y)). Shannon showed the capacity is C = log|β| - H(row), achieved by the uniform input distribution. The BSC is the simplest example: α = β = {0,1}, rows [p, 1-p] and [1-p, p], giving C = log 2 - h(p).",
+    "problemStatement": "**Symmetric Channel Capacity**: For a DMChannel W : α → β where:\n(1) Row symmetry: ∃ C, ∀ x, ∑_y W(x,y)·log(W(x,y)) = C\n(2) Doubly balanced: ∀ y, ∑_x W(x,y) = |α|/|β|\n(3) Positive: W(x,y) > 0 for all x, y\n\nThe channel capacity equals $C(W) = \\log|\\beta| + C = \\log|\\beta| - H(\\text{row})$.",
+    "text": "**Answer**: The capacity formula `channelCapacity ch = log|β| + C` holds for symmetric channels satisfying the three conditions.\n\n**Proof structure**:\n1. **Achievability**: Uniform input gives H(Y) = log|β| (by doubly balanced condition) and H(Y|X) = -C (by row symmetry). So MI(uniform) = H(Y) - H(Y|X) = log|β| + C.\n\n2. **Converse**: For any input distribution, MI = H(Y) - H(Y|X) = H(Y) + C ≤ log|β| + C (since H(Y) ≤ log|β|).\n\n3. **Capacity**: The supremum equals the maximum achieved value log|β| + C.\n\n**BSC recovery**: Setting α = β = Bool, C = p·log(p) + (1-p)·log(1-p) = -h(p), we recover C(BSC(p)) = log 2 - h(p).",
+    "proofStrategy": "1. Prove H(Y|X) = -C for any input distribution using the row symmetry hypothesis.\n   Key step: each conditional entropy term simplifies to inp.p(x)·(ch.W(x,y)·log(ch.W(x,y))), and summing over x gives C.\n2. Prove uniform input → uniform output via the doubly balanced condition.\n3. Compute MI(uniform) = H(Y) - H(Y|X) = log|β| - (-C) = log|β| + C.\n4. Bound MI ≤ log|β| + C for all inputs via the chain rule and entropy maximality.\n5. Conclude capacity = log|β| + C.",
+    "keyInsights": [
+      "H(Y|X) = -C holds for ALL input distributions (not just positive ones), because zero-probability input terms contribute 0 to the conditional entropy.",
+      "The row symmetry condition is minimal: it only requires that all rows have the same entropy sum C = ∑_y W(x,y)·log(W(x,y)), not that rows are permutations of each other.",
+      "The doubly balanced condition ∑_x W(x,y) = |α|/|β| ensures uniform input → uniform output, giving H(Y) = log|β|.",
+      "BSC is doubly stochastic (column sums = 1 = |Bool|/|Bool|), satisfying the doubly balanced condition with |α|/|β| = 2/2 = 1.",
+      "The capacity formula log|β| + C generalizes to BSC as log 2 + (p·log p + (1-p)·log(1-p)) = log 2 - h(p)."
+    ],
+    "prerequisites": [
+      "BSC Capacity Proof (ShannonChannelCodingOQ02): parent proof providing the chain rule and BSC infrastructure",
+      "Shannon entropy and mutual information (ShannonEntropy.lean)",
+      "Discrete memoryless channel and channel capacity (ShannonChannelCoding.lean)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "chain-rule",
+      "title": "Chain Rule: MI = H(Y) - H(Y|X)",
+      "startLine": 44,
+      "endLine": 59,
+      "summary": "Private lemma: MI = H(Y) - H(Y|X) for general joint distributions. Re-proves the BSCCapacity version for use in this namespace."
+    },
+    {
+      "id": "uniform-dist",
+      "title": "Uniform Distribution on General Fintype",
+      "startLine": 61,
+      "endLine": 73,
+      "summary": "uniformDist: InputDist with p(x) = 1/|α| for all x. Proves positivity."
+    },
+    {
+      "id": "uniform-entropy",
+      "title": "Entropy of Uniform Distribution = log|α|",
+      "startLine": 75,
+      "endLine": 89,
+      "summary": "entropy_uniform_fintype: H(uniform on α) = log|α|. Generalizes entropy_uniform_bool from the BSC proof."
+    },
+    {
+      "id": "conditional-entropy",
+      "title": "H(Y|X) = -C for Row-Symmetric Channels",
+      "startLine": 91,
+      "endLine": 127,
+      "summary": "sym_conditional_output_entropy: For any input distribution, H(Y|X) = -C. Works even for degenerate (non-positive) inputs."
+    },
+    {
+      "id": "uniform-ymarg",
+      "title": "Doubly Balanced: Uniform → Uniform Output",
+      "startLine": 129,
+      "endLine": 141,
+      "summary": "sym_uniform_ymarg: Doubly balanced condition implies uniform input gives 1/|β| output marginal."
+    },
+    {
+      "id": "achievability",
+      "title": "Achievability: Uniform MI = log|β| + C",
+      "startLine": 143,
+      "endLine": 168,
+      "summary": "sym_uniform_mi: The uniform input distribution achieves mutual information = log|β| + C."
+    },
+    {
+      "id": "converse",
+      "title": "Converse: All MI ≤ log|β| + C",
+      "startLine": 170,
+      "endLine": 190,
+      "summary": "sym_mi_le: For all input distributions, MI ≤ log|β| + C via chain rule + entropy bound."
+    },
+    {
+      "id": "capacity",
+      "title": "Symmetric Channel Capacity Theorem",
+      "startLine": 192,
+      "endLine": 220,
+      "summary": "sym_channel_capacity: capacity = log|β| + C. Follows from achievability and converse."
+    },
+    {
+      "id": "bsc-verification",
+      "title": "BSC as a Symmetric Channel",
+      "startLine": 222,
+      "endLine": 247,
+      "summary": "Verifies BSC satisfies row symmetry and doubly balanced conditions. Recovers C(BSC(p)) = log 2 - h(p) from the general theorem."
+    }
+  ],
+  "conclusion": {
+    "summary": "The symmetric channel capacity formula C(W) = log|β| - H(row) is proved from first principles for channels satisfying row symmetry and the doubly balanced condition. The BSC is verified as a special case, recovering log 2 - h(p). This closes OQ 4 from the BSC capacity proof.",
+    "implications": "The proof demonstrates that the key structural properties of BSC (constant row entropy and doubly balanced columns) are the mathematical essence behind the capacity formula, not the binary alphabet. The same technique applies to q-ary symmetric channels, erasure channels over larger alphabets, and other structured channels.",
+    "openQuestions": [
+      "Remove the positivity assumption W(x,y) > 0: can the theorem extend to channels with zero-probability transitions?",
+      "Extend to the general case without the doubly balanced condition: characterize capacity for channels where only row symmetry holds.",
+      "Formalize the q-ary symmetric channel (|α| = |β| = q, each off-diagonal entry = p/(q-1)) as a concrete example of the general theorem.",
+      "Connect to the Blahut-Arimoto algorithm: show it converges to the uniform distribution for symmetric channels."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "shannon-channel-coding-oq-02",
+      "relationship": "extends",
+      "description": "Parent proof: BSC capacity log 2 - h(p), which this generalizes to arbitrary symmetric channels"
+    },
+    {
+      "targetId": "shannon-channel-coding",
+      "relationship": "uses",
+      "description": "Core channel coding infrastructure: DMChannel, InputDist, channelCapacity"
+    }
+  ],
+  "leanFile": {
+    "namespace": "InformationTheory.ChannelCoding.SymmetricCapacity",
+    "lineCount": 249,
+    "axiomCount": 4,
+    "theoremCount": 8,
+    "definitionCount": 1,
+    "path": "Proofs/ShannonChannelCodingOQ02OQ04.lean",
+    "sorries": 0
+  }
+}


### PR DESCRIPTION
## Summary

Proves the symmetric channel capacity formula `C(W) = log|β| + C` for any DMChannel satisfying:
- **Row symmetry**: all rows have the same entropy sum `C = ∑_y W(x,y)·log(W(x,y))`
- **Doubly balanced**: uniform input → uniform output (`∑_x W(x,y) = |α|/|β|`)
- **Positive**: `W(x,y) > 0` for all x, y

The formula `log|β| + C = log|β| - H(row)` generalizes the BSC capacity `log 2 - h(p)` to arbitrary finite input/output alphabets. BSC is verified as a special case.

**Addresses**: OQ 4 from `shannon-channel-coding-oq-02` ("Extend to general symmetric channels beyond BSC")

## Key contributions

- `uniformDist`: uniform `InputDist` on any nonempty `Fintype` (generalizes `uniformBool`)
- `entropy_uniform_fintype`: `H(uniform on α) = log|α|` (generalizes `entropy_uniform_bool`)
- `sym_conditional_output_entropy`: `H(Y|X) = -C` for **any** input distribution (row symmetry + W > 0)
- `sym_mi_le`: `MI ≤ log|β| + C` for all inputs (chain rule + entropy bound)
- `sym_channel_capacity`: main capacity theorem
- `bsc_capacity_from_symmetric`: BSC as special case → recovers `log 2 - h(p)`

**New file**: `Proofs/ShannonChannelCodingOQ02OQ04.lean` (249 lines, 8 theorems, 0 sorries, 4 inherited axioms)
**Gallery**: `shannon-channel-coding-oq-02-oq-04`

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.ShannonChannelCodingOQ02OQ04` compiles successfully
- [ ] BSC verification: `bsc_capacity_from_symmetric` recovers `log 2 - h(p)`
- [ ] Gallery page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)