### PR TITLE
Fix: correct stale axiom/sorry counts in 9 gallery proof meta.json files

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9715,10 +9715,10 @@
       "result": "clean"
     },
     "hilbert-21": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-04-04T01:56:47Z",
-      "result": "clean"
+      "lastAudited": "2026-04-13T06:09:18Z",
+      "result": "issues-fixed"
     },
     "hilbert-22": {
       "agentId": "auditor-cycle-20-batch",
@@ -9829,9 +9829,9 @@
       "agentId": "lean-mechanic"
     },
     "inverse-galois": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-04-03T12:59:28Z",
+      "lastAudited": "2026-04-13T06:09:37Z",
       "result": "issues-fixed"
     },
     "inverse-galois-oq-01": {

--- a/src/data/proofs/buffons-needle-oq-02-oq-02/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02-oq-02/meta.json
@@ -228,7 +228,7 @@
     ],
     "namespace": "BuffonsNeedleOQ02OQ02",
     "lineCount": 376,
-    "axiomCount": 1,
+    "axiomCount": 2,
     "theoremCount": 15,
     "definitionCount": 4,
     "path": "Proofs/BuffonsNeedleOQ02OQ02.lean",

--- a/src/data/proofs/erdos-1126-oq-01/meta.json
+++ b/src/data/proofs/erdos-1126-oq-01/meta.json
@@ -64,9 +64,9 @@
       "log_of_mul_is_additive: Logarithmic reduction of multiplicative to additive equation (PROVED)"
     ],
     "dateAdded": "2026-03-24",
-    "axiomCount": 5,
+    "axiomCount": 7,
     "lineCount": 472,
-    "assumptions": "5 axioms: almost_multiplicative_stability, almost_jensen_stability, almost_derivation_stability, measurable_multiplicative_is_power, measurable_derivation_is_zero. 0 sorries."
+    "assumptions": "7 axioms: volume_preimage_double_null (measure-theoretic helper), ae_double_of_almost_jensen (Fubini section extraction), almost_multiplicative_stability, almost_jensen_stability, almost_derivation_stability, measurable_multiplicative_is_power, measurable_derivation_is_zero. 0 sorries."
   },
   "overview": {
     "historicalContext": "**Extending the de Bruijn-Jurkat Paradigm**\n\nThe de Bruijn-Jurkat theorem (1965-66) showed that almost additive functions can be corrected to truly additive functions a.e. This naturally raises the question: does the same stability hold for other fundamental functional equations?\n\n**The Key Equations:**\n1. **Multiplicative** (Cauchy exponential): $f(xy) = f(x)f(y)$ — characterizes exponentials and power functions\n2. **Jensen** (midpoint affinity): $f((x+y)/2) = (f(x)+f(y))/2$ — characterizes affine functions\n3. **Derivation** (Leibniz rule): $d(xy) = x \\cdot d(y) + y \\cdot d(x)$ — characterizes differentiation\n\n**Known Results:**\n- **Ger (1979)** showed stability holds for polynomial functional equations, which includes the derivation case\n- **Járai (2005)** gave a comprehensive treatment of regularity for functional equations in several variables\n- The multiplicative case reduces to the additive case via logarithms (for positive solutions)\n- The Jensen case is algebraically equivalent to the additive case modulo a constant",
@@ -185,7 +185,7 @@
     "path": "Proofs/Erdos1126OQ01Problem.lean",
     "filename": "Erdos1126OQ01Problem.lean",
     "lineCount": 472,
-    "axiomCount": 5,
+    "axiomCount": 7,
     "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-138/meta.json
+++ b/src/data/proofs/erdos-138/meta.json
@@ -37,14 +37,14 @@
       "Proof schema: main conjecture implies ExponentialDiverges"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 5,
     "erdosNumber": 138,
     "erdosUrl": "https://erdosproblems.com/138",
     "erdosProblemStatus": "open",
     "erdosPrizeValue": "$500",
     "axiomCount": 8,
     "lineCount": 176,
-    "assumptions": "8 axiom(s) and 4 sorries(s). Axioms encode mathematical hypotheses; sorries mark incomplete proofs.",
+    "assumptions": "8 axiom(s) and 5 sorry(s). Axioms encode mathematical hypotheses; sorries mark incomplete proofs.",
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -182,5 +182,5 @@
       "description": "Related Erdős problem sharing themes: arithmetic-progressions, combinatorics, ramsey-theory, van-der-waerden"
     }
   ],
-  "sorries": 4
+  "sorries": 5
 }

--- a/src/data/proofs/erdos-392/meta.json
+++ b/src/data/proofs/erdos-392/meta.json
@@ -181,7 +181,7 @@
     "theoremCount": 3,
     "definitionCount": 1,
     "path": "Proofs/Stubs/Erdos392Problem.lean",
-    "sorries": 3
+    "sorries": 2
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-504/meta.json
+++ b/src/data/proofs/erdos-504/meta.json
@@ -16,7 +16,7 @@
     ],
     "namespace": "Erdos504",
     "lineCount": 217,
-    "axiomCount": 4,
+    "axiomCount": 5,
     "theoremCount": 1,
     "definitionCount": 5,
     "path": "Proofs/Erdos504Problem.lean",
@@ -39,9 +39,9 @@
     "erdosNumber": 504,
     "erdosUrl": "https://erdosproblems.com/504",
     "erdosProblemStatus": "solved",
-    "axiomCount": 4,
+    "axiomCount": 5,
     "lineCount": 217,
-    "assumptions": "4 axioms: sendov_upper, sendov_lower, erdos_szekeres_conjecture_false, isConvexPosition. No sorries.",
+    "assumptions": "5 axioms: maxAngleInSet (maximum angle function), sendov_upper, sendov_lower, erdos_szekeres_conjecture_false, isConvexPosition. No sorries.",
     "mathlib_version": "4.26.0"
   },
   "overview": {

--- a/src/data/proofs/erdos-529/meta.json
+++ b/src/data/proofs/erdos-529/meta.json
@@ -106,9 +106,9 @@
       "erdos_529_summary theorem: combines established results",
       "erdos_529 theorem: combines Hara-Slade + sub-ballistic + Question 2"
     ],
-    "axiomCount": 5,
+    "axiomCount": 7,
     "lineCount": 306,
-    "assumptions": "5 axioms: tendsTo (convergence predicate), haraSlade_five_dim (5D self-avoiding walk result), duminilCopin_subBallistic (sub-ballistic diffusivity), conjecture_implies_question1, question2_high_dim. 0 sorries."
+    "assumptions": "7 axioms: endToEndDistance (end-to-end distance function), expectedEndDistance (expected distance function), tendsTo (convergence predicate), haraSlade_five_dim (5D self-avoiding walk result), duminilCopin_subBallistic (sub-ballistic diffusivity), conjecture_implies_question1, question2_high_dim. 0 sorries."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #529: Self-Avoiding Walks**\n\nSelf-avoiding walks (SAWs) were first studied systematically by the chemist Paul Flory in 1949 as models for linear polymers in good solvents. Flory's mean-field prediction $\\nu = 3/(d+2)$ for the end-to-end distance exponent was remarkably accurate, setting the stage for decades of rigorous mathematical work.\n\nThe first rigorous high-dimensional result came from **Gordon Slade** (1987), who used the **lace expansion** — a perturbative technique introduced by Brydges and Spencer (1985) — to prove $d_k(n) \\sim D\\sqrt{n}$ for sufficiently large $k$. **Takashi Hara** and Slade (1991-92) refined this to all $k \\ge 5$, using computer-assisted bounds on the lace expansion coefficients. Their work established that mean-field behavior ($\\nu = 1/2$) holds above the upper critical dimension $d_c = 4$.\n\nThe low-dimensional case proved far more resistant. **Bernard Nienhuis** (1982) predicted $\\nu = 3/4$ in 2D using the exact solution of an O(n) loop model on the honeycomb lattice, and conformal field theory arguments connect 2D SAW to the SLE$_{8/3}$ process (Lawler, Schramm, Werner). The landmark result of **Hugo Duminil-Copin** and **Alan Hammond** (2013) proved $d_2(n) = o(n)$ (sub-ballistic growth) using a bridge decomposition argument, but the full Question 1 ($d_2(n)/\\sqrt{n} \\to \\infty$) remains open.\n\nThe definitive reference is the monograph *The Self-Avoiding Walk* by Madras and Slade (1993, 2nd ed. 2013). **Nathan Clisby** (2010) provided the most precise numerical estimates: $\\nu_3 \\approx 0.5876 \\pm 0.0002$.",
@@ -225,7 +225,7 @@
     ],
     "namespace": "Erdos529",
     "lineCount": 306,
-    "axiomCount": 5,
+    "axiomCount": 7,
     "theoremCount": 6,
     "definitionCount": 5,
     "path": "Proofs/Erdos529Problem.lean",

--- a/src/data/proofs/erdos-628/meta.json
+++ b/src/data/proofs/erdos-628/meta.json
@@ -217,7 +217,7 @@
     "theoremCount": 10,
     "definitionCount": 12,
     "path": "Proofs/Stubs/Erdos628Problem.lean",
-    "sorries": 12
+    "sorries": 11
   },
   "sorries": 11
 }

--- a/src/data/proofs/erdos-756/meta.json
+++ b/src/data/proofs/erdos-756/meta.json
@@ -76,9 +76,9 @@
       "multiplicity_trivial_upper theorem: multiplicity ≤ n²",
       "erdos_756 theorem: main result"
     ],
-    "axiomCount": 2,
+    "axiomCount": 5,
     "lineCount": 268,
-    "assumptions": "2 axioms: hopf_pannwitz (largest distance multiplicity ≤ n), bhowmick_main (⌊n/4⌋ rich distances for large n). No sorries."
+    "assumptions": "5 axioms: hopf_pannwitz (largest distance multiplicity ≤ n), bhowmick_main (⌊n/4⌋ rich distances for large n), squareGrid (square grid construction), regularPolygon (regular polygon construction), latticeInDisk (lattice points in disk). No sorries."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #756: Rich Distances in the Plane**\n\nThis problem, asked by Erdős and Pach, concerns distance multiplicities in finite point sets in the plane.\n\n**Historical Timeline:**\n- **1934:** Hopf and Pannwitz proved the largest distance among n points occurs at most n times (this is tight for regular polygons)\n- **Erdős-Pach:** Asked whether ALL other distances can have multiplicity > n (the \"strong\" form)\n- **2024:** Bhowmick answered affirmatively with an explicit construction achieving ⌊n/4⌋ rich distances\n- **2025:** Clemen, Dumitrescu, and Liu studied the square grid, finding superpolynomial richness\n\n**The Surprise:**\nDespite the classical Hopf-Pannwitz constraint on the largest distance, Bhowmick showed that MANY distances can be \"rich\" (occurring more than n times). The phenomenon is even stronger on structured sets like square grids.",
@@ -223,7 +223,7 @@
     ],
     "namespace": "Erdos756",
     "lineCount": 268,
-    "axiomCount": 2,
+    "axiomCount": 5,
     "theoremCount": 8,
     "definitionCount": 15,
     "path": "Proofs/Erdos756Problem.lean",

--- a/src/data/proofs/erdos-96/meta.json
+++ b/src/data/proofs/erdos-96/meta.json
@@ -55,9 +55,9 @@
       "erdos_96_summary: proved conjunction of bounds"
     ],
     "dateAdded": "2026-01-19",
-    "axiomCount": 2,
+    "axiomCount": 3,
     "lineCount": 285,
-    "assumptions": "2 axioms: furedi_bound, edelsbrunner_hajnal_construction. No sorries."
+    "assumptions": "3 axioms: cyclicOrder (cyclic vertex ordering), furedi_bound, edelsbrunner_hajnal_construction. No sorries."
   },
   "overview": {
     "historicalContext": "Erdős and Moser conjectured that a convex n-gon has O(n) unit distance pairs. Despite progress from O(n log n) bounds (Füredi 1990, Aggarwal 2015), the conjecture remains open. The Edelsbrunner-Hajnal (1991) lower bound of 2n - 7 suggests the Erdős-Fishburn conjecture of exactly 2n may be tight. The unit distance problem for general point sets (Erdős Problem #89, 1946) asks for the maximum number of unit distance pairs among n points in the plane, with best known bounds Ω(n^{1+c/log log n}) and O(n^{4/3}). The convex restriction dramatically simplifies the problem: in a convex polygon, each distance can appear at most twice on each side, giving much sharper bounds.",
@@ -150,7 +150,7 @@
     ],
     "namespace": "Erdos96",
     "lineCount": 285,
-    "axiomCount": 2,
+    "axiomCount": 3,
     "theoremCount": 2,
     "definitionCount": 10,
     "path": "Proofs/Erdos96Problem.lean",


### PR DESCRIPTION
## Summary

Batch audit fix for 9 proofs with axiom undercount or sorry mismatch issues.

**Axiom undercounts** (noncomputable axioms and construction axioms were not counted):
- **erdos-96**: 2 → 3 (missing `cyclicOrder`)
- **erdos-756**: 2 → 5 (missing `squareGrid`, `regularPolygon`, `latticeInDisk`)
- **erdos-529**: 5 → 7 (missing `endToEndDistance`, `expectedEndDistance`)
- **erdos-504**: 4 → 5 (missing `maxAngleInSet`)
- **erdos-1126-oq-01**: 5 → 7 (missing `volume_preimage_double_null`, `ae_double_of_almost_jensen`)
- **buffons-needle-oq-02-oq-02**: `leanFile.axiomCount` 1 → 2

**Sorry count mismatches**:
- **erdos-628**: `leanFile.sorries` 12 → 11
- **erdos-392**: `leanFile.sorries` 3 → 2
- **erdos-138**: `meta.sorries` 4 → 5

## Test plan

- [ ] `pnpm build` passes
- [ ] Gallery pages render correctly with updated counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)