### PR TITLE
Fix: correct sorry count in dirichlets-theorem-oq-03 meta.json

### DIFF
--- a/src/data/proofs/dirichlets-theorem-oq-03/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-03/meta.json
@@ -18,11 +18,11 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "axiomCount": 2,
     "lineCount": 139,
     "theoremCount": 8,
-    "assumptions": "2 axioms: linnik_theorem (existence of c,L) and xylouris_bound (5 ∈ admissibleExponents). 2 sorries: two in leastPrimeInAP (existence of prime in AP — requires Dirichlet's theorem from parent) and linnikConstant_pos (lower bound argument).",
+    "assumptions": "2 axioms: linnik_theorem (existence of c,L) and xylouris_bound (5 ∈ admissibleExponents). 3 sorries: two in leastPrimeInAP (⟨sorry, sorry⟩ for witness and property of prime in AP) and one in linnikConstant_pos (lower bound argument).",
     "historicalContext": "Dirichlet proved in 1837 that there are infinitely many primes p ≡ a (mod q) for any coprime pair (a, q). The *quantitative* question — how large is the *first* such prime p(a, q)? — was answered by Linnik in 1944: p(a, q) ≤ c · q^L for absolute constants c and L. This L is the 'Linnik constant'. The history of bounding L spans decades: Pan Cheng-tung (1957) gave L ≤ 10000, Elliott-Halberstam (1966) reduced it to L ≤ 40, then Jutila (L ≤ 20), Chen (L ≤ 13.5), Wang (L ≤ 8), Heath-Brown (L ≤ 5.5, 1992), and finally Xylouris (L ≤ 5, 2011). Under the Generalized Riemann Hypothesis, L ≤ 2 + ε for any ε > 0. The unconditional conjecture is L = 1 + ε, or equivalently, linnikConstant = 1.",
     "problemStatement": "For coprime integers a, q with q ≥ 1, let p(a, q) denote the least prime p ≡ a (mod q).\n\n**Linnik's theorem** (1944): There exist absolute constants c > 0 and L > 0 such that\n$$p(a,q) \\leq c \\cdot q^L$$\nfor all coprime pairs (a, q).\n\nThe **Linnik constant** is:\n$$L^* = \\inf\\{ L > 0 : \\text{Linnik's theorem holds with exponent } L \\}.$$\n\n**Currently known**: 1 ≤ L* ≤ 5. Best unconditional bound: L* ≤ 5 (Xylouris 2011). Under GRH: L* ≤ 2 + ε. **Conjectured**: L* = 1.",
     "proofStrategy": "The formalization defines `leastPrimeInAP` via `Nat.find` (with sorry for the existence of a prime in each AP — this follows from Dirichlet's theorem, the parent entry). The `admissibleExponents` set collects all valid exponents, and `linnikConstant` is their infimum. Key proofs: (1) `heathBrown_bound` derives L ≤ 5.5 from Xylouris's L ≤ 5 by monotonicity of the bound in L; (2) `linnikConstant_le_5` follows from csInf_le applied to xylouris_bound; (3) `optimal_implies_le_one` uses a contradiction argument with δ = (L*-1)/2 — if L*>1 then 1+δ = (L*+1)/2 < L* would be admissible, contradicting L* being the infimum.",


### PR DESCRIPTION
## Summary

- **meta.sorries**: 2 → 3

The `leastPrimeInAP` definition uses `⟨sorry, sorry⟩` (2 sorry tokens for witness + property), and `linnikConstant_pos` has 1 sorry = 3 total. The `leanFile.sorries` field already correctly said 3.

## Test plan

- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)