### PR TITLE
feat: add Aristotle companion for central-limit-theorem-oq-02

### DIFF
--- a/proofs/Proofs/CentralLimitTheoremOQ02Aristotle.lean
+++ b/proofs/Proofs/CentralLimitTheoremOQ02Aristotle.lean
@@ -1,0 +1,136 @@
+/-
+  Aristotle targets for CentralLimitTheoremOQ02 (CLT for Dependent Variables)
+  Routine lemmas for automated proof search.
+  See CentralLimitTheoremOQ02.lean for the main formalization.
+
+  The 3 sorries are in:
+  1. `independent_implies_zero_mixing` (line 499): Show ⨆-of-zeros = 0
+     for alphaMixingCoeff when variables are independent.
+  2. `classical_clt_from_martingale` (line 532): Prove the Lindeberg condition
+     for i.i.d. sequences via dominated convergence for truncated moments.
+  3. `iid_satisfies_lyapunov` (line 549): Show Lyapunov sum → 0 via rpow decay
+     n^{-δ/2} → 0 for δ > 0.
+
+  ## Proof Strategies
+
+  TARGET 1 (`iSup_eq_zero_of_all_zero`):
+    Show ⨆ i, f i = 0 when all f i = 0 and the type is nonempty.
+    Strategy: ciSup_const (0) or:
+      apply le_antisymm
+      · exact ciSup_le (fun i => le_refl 0)
+      · exact le_ciSup_of_le ...
+
+  TARGET 2 (`independent_implies_zero_mixing`):
+    After simp on alphaMixingCoeff, show nested ⨆ = 0 using independence.
+    For each measurable A ∈ ℱ₁, B ∈ ℱ₂:
+      |μ(A∩B).toReal - μ(A).toReal · μ(B).toReal| = 0
+    Then the nested iSup of all-zero terms equals 0.
+    Strategy:
+      apply le_antisymm
+      · apply ciSup_le; intro A; apply ciSup_le; intro hA;
+        apply ciSup_le; intro B; apply ciSup_le; intro hB
+        have := hIndep k (n-1) A B hA (by rw [Nat.sub_add_cancel hn]; exact hB)
+        simp [this]
+      · exact le_ciSup_of_le ... (le_refl _)
+
+  TARGET 3 (`iid_satisfies_lyapunov`):
+    After simp, goal is:
+      Tendsto (fun n => ∑ k ∈ range n, ∫ |X_k/√n|^(2+δ)) atTop (nhds 0)
+    Key calculation: ∫ |X_k/√n|^(2+δ) = ∫ |X_k|^(2+δ) / (√n)^(2+δ)
+    Sum of n identical terms: n · E[|X₀|^(2+δ)] / n^((2+δ)/2) = E[...] / n^(δ/2)
+    Then use tendsto_rpow_atTop_nhds_zero_of_neg (or Filter.Tendsto.const_mul).
+    Strategy:
+      conv_lhs => ext n; simp_rw [Real.norm_eq_abs, ← Real.rpow_natCast, ...]
+      apply Filter.Tendsto.congr_dist
+      simp [mul_comm, ← Real.rpow_natCast]
+      apply tendsto_const_nhds.div_atTop
+      exact Filter.tendsto_rpow_atTop (by linarith)
+-/
+import Mathlib
+import Proofs.CentralLimitTheoremOQ02
+
+open MeasureTheory Filter CentralLimitTheoremOQ02
+
+namespace CentralLimitTheoremOQ02Aristotle
+
+variable {Ω : Type*} [MeasurableSpace Ω]
+
+/-
+TARGET 1 (pure order theory: nested iSup of zeros is 0)
+
+In any ConditionallyCompleteLinearOrder with Bot where the supremum is taken
+over a nonempty type, if all terms are ≤ 0 then the iSup = 0 (the bottom).
+
+This is the atomic ingredient for TARGET 2.
+
+Strategy:
+  apply le_antisymm
+  · exact ciSup_le (fun _ => le_refl 0)
+  · simp [iSup_const]
+  or simply: simp [iSup_const]
+-/
+theorem iSup_of_zero_eq_zero {α : Type*} [Nonempty α] :
+    (⨆ _ : α, (0 : ℝ)) = 0 := by
+  sorry
+
+/-
+TARGET 2 (independence → zero mixing coefficient)
+
+For independent variables, the alpha mixing coefficient is 0.
+
+Key: each term |μ(A∩B).toReal - μ(A).toReal · μ(B).toReal| = |0| = 0
+because independence gives μ(A∩B) = μ(A) * μ(B).
+
+Strategy:
+  simp only [alphaMixingCoeff]
+  apply le_antisymm _ (le_refl _)
+  apply ciSup_le; intro A
+  apply ciSup_le; intro hA
+  apply ciSup_le; intro B
+  apply ciSup_le; intro hB
+  have heq : μ (A ∩ B) = μ A * μ B :=
+    hIndep k (n - 1) A B hA (show @MeasurableSet Ω (σ_k (k + n)) B from by
+      convert hB using 2; omega)
+  simp [heq, ENNReal.toReal_mul]
+-/
+theorem independent_implies_zero_mixing
+    {μ : Measure Ω} [IsProbabilityMeasure μ]
+    (X : ℕ → Ω → ℝ) (σ_k : ℕ → MeasurableSpace Ω)
+    (hIndep : ∀ k n (A B : Set Ω),
+      @MeasurableSet Ω (σ_k k) A →
+      @MeasurableSet Ω (σ_k (k + n + 1)) B →
+      μ (A ∩ B) = μ A * μ B) :
+    ∀ k n, n ≥ 1 →
+      alphaMixingCoeff μ (σ_k k) (σ_k (k + n)) = 0 := by
+  sorry
+
+/-
+TARGET 3 (rpow decay: Lyapunov sum → 0 for i.i.d. sequences)
+
+After unfolding and simplifying, the Lyapunov sum equals
+  E[|X₀|^{2+δ}] / n^{δ/2}
+which tends to 0 because δ/2 > 0.
+
+Key steps:
+  - ∫ |X_k/√n|^{2+δ} = ∫ |X_k|^{2+δ} / n^{(2+δ)/2}
+  - Sum of n such terms = n · E[|X₀|^{2+δ}] / n^{(2+δ)/2} = E[...] / n^{δ/2}
+  - n^{δ/2} → ∞ (since δ/2 > 0), so the ratio → 0
+
+Strategy:
+  refine ⟨hδ, ?_⟩
+  simp only [MartingaleDiffArray.lyapunovSum, IIDSequence.toMDA]
+  have hC : ∫ ω, |S.X 0 ω| ^ (2 + δ) ∂μ ≥ 0 := integral_nonneg (fun _ => rpow_nonneg ...)
+  apply squeeze_zero (fun n => Finset.sum_nonneg ...) _
+  · intro n
+    -- bound by hC / n^{δ/2}
+    sorry
+  · exact (tendsto_rpow_atTop (by linarith : 0 < δ/2)).const_div_atTop hC
+-/
+theorem iid_satisfies_lyapunov
+    {μ : Measure Ω} [IsProbabilityMeasure μ]
+    (S : IIDSequence Ω μ) (δ : ℝ) (hδ : 0 < δ)
+    (hMoment : Integrable (fun ω => |S.X 0 ω| ^ (2 + δ)) μ) :
+    S.toMDA.lyapunovCondition δ := by
+  sorry
+
+end CentralLimitTheoremOQ02Aristotle


### PR DESCRIPTION
## Fix

Creates `CentralLimitTheoremOQ02Aristotle.lean` — an Aristotle companion file exposing 3 routine targets for automated proof search.

## Evidence

**Before**: `central-limit-theorem-oq-02` had 3 open sorries with no Aristotle companion file.

**After**: 3 focused targets for Aristotle:
1. `iSup_of_zero_eq_zero` — nested iSup of constant 0 over nonempty type = 0 (order theory API)
2. `independent_implies_zero_mixing` — alpha-mixing coefficient = 0 for independent variables (independence + iSup manipulation)
3. `iid_satisfies_lyapunov` — Lyapunov sum → 0 for i.i.d. sequences via n^{-δ/2} rpow decay

All 3 sorries are independent of the `martingale_clt` axiom in the main file. Completing them strengthens the formalization of the CLT for dependent random variables.

---
Automated fix by lean-mechanic agent.