### PR TITLE
fix: correct badge from 'original' to 'wip' for proofs with open sorries

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02/meta.json
@@ -15,7 +15,7 @@
       "impossibility"
     ],
     "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ01OQ02.lean",
-    "badge": "original",
+    "badge": "wip",
     "sorries": 5,
     "axiomCount": 0,
     "theoremCount": 10

--- a/src/data/proofs/arithmetic-series-oq-02-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-03/meta.json
@@ -14,7 +14,7 @@
       "f-vector",
       "binomial coefficients"
     ],
-    "badge": "original",
+    "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
     "lineCount": 145,

--- a/src/data/proofs/cantor-diagonalization-oq-04-oq-03/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-04-oq-03/meta.json
@@ -16,7 +16,7 @@
       "order-theory"
     ],
     "proofRepoPath": "Proofs/CantorDiagonalizationOQ04OQ03.lean",
-    "badge": "original",
+    "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
     "theoremCount": 10,


### PR DESCRIPTION
## Fix

Corrects `badge` field from `"original"` to `"wip"` for 3 gallery proofs where `status=formalized` but `badge=original`.

## Evidence

Per the axiom integrity policy: `badge=original` requires `status=verified` with 0 sorries and 0 axioms. These proofs have open sorries:

| Proof | Sorries | Previous badge | Fixed badge |
|-------|---------|----------------|-------------|
| `arithmetic-series-oq-02-oq-03` | 1 | `original` | `wip` |
| `cantor-diagonalization-oq-04-oq-03` | 1 | `original` | `wip` |
| `angle-trisection-oq-02-oq-01-oq-02` | 5 | `original` | `wip` |

**Before**: Gallery shows `original` badge implying full verification with 0 sorries.
**After**: Gallery shows `wip` badge accurately reflecting in-progress formalization.

---
Automated fix by lean-mechanic agent.