### PR TITLE
Research: erdos-1051 - metadata corrections

### DIFF
--- a/src/data/proofs/area-of-circle-oq-02-oq-04/meta.json
+++ b/src/data/proofs/area-of-circle-oq-02-oq-04/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 3,
     "assumptions": "3 structure-encoded assumptions in RiemannianVolumeData: vol_pos (geodesic ball volumes are positive), vol_mono (monotonicity), bishop_gromov (Bishop-Gromov volume ratio monotonicity). These encode the properties of a complete Riemannian manifold with Ric >= 0, which cannot be defined in Mathlib (no Riemannian metric or curvature yet).",
     "lineCount": 270,
-    "theoremCount": 17,
+    "theoremCount": 18,
     "definitionCount": 3,
     "originalContributions": [
       "omegaN: definition of volume coefficient omega_n = pi^(n/2) / Gamma(n/2+1)",
@@ -102,7 +102,7 @@
     "namespace": "BishopGromov",
     "lineCount": 273,
     "axiomCount": 3,
-    "theoremCount": 17,
+    "theoremCount": 18,
     "definitionCount": 3,
     "path": "Proofs/AreaOfCircleOQ02OQ04.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-1051/meta.json
+++ b/src/data/proofs/erdos-1051/meta.json
@@ -15,7 +15,7 @@
       "series",
       "transcendence-theory"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "erdosNumber": 1051,
     "erdosUrl": "https://erdosproblems.com/1051",
@@ -24,7 +24,7 @@
     "lineCount": 232,
     "assumptions": "0 axioms. series_converges is now a proved theorem: for strictly increasing positive integer sequences, summability follows by comparison with Σ 1/((n+1)(n+2)), bounded by the convergent p-series Σ 1/n².",
     "mathlib_version": "4.26.0",
-    "theoremCount": 6
+    "theoremCount": 9
   },
   "overview": {
     "historicalContext": "Erdős and Graham posed this problem in their influential 1980 monograph *Old and New Problems and Results in Combinatorial Number Theory* (p.64), as part of a broader investigation into when series with integer terms produce irrational sums. The growth condition $\\liminf a_n^{1/2^n} > 1$ captures sequences growing at least doubly exponentially—a natural threshold since slower-growing sequences can yield rational sums (e.g., arithmetic progressions give telescoping sums). Erdős made partial progress in a 1988 paper, proving irrationality for sequences satisfying the stronger condition $a_{n+1} \\geq C \\cdot a_n^2$. The proof technique uses rapid convergence of partial sums to derive contradictions from the assumption of rationality, building on methods going back to Liouville's 1844 construction of transcendental numbers. The gap between this quadratic recurrence condition and the general $\\liminf$ condition remains the central open challenge. The problem connects to the Erdős–Graham program of understanding irrationality of series involving integer sequences, and to classical work on Sylvester–Fibonacci expansions and Egyptian fraction representations by Kellogg (1921) and Curtiss (1922).",

--- a/src/data/research/problems/erdos-1051.json
+++ b/src/data/research/problems/erdos-1051.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 8T/3A/0S (was 6T). Added doubling_implies_pos, doubling_implies_strict_mono. Axioms remain deep.",
+    "progressSummary": "COMPLETED: 9T/0A/0S. Open conjecture cleanly stated, all supporting infrastructure proved. Badge corrected wip→axiom, theoremCount 6→9.",
     "builtItems": [
       "Proved series_positive theorem in Erdos1051Problem.lean",
       "partial_fraction: telescoping identity",
@@ -41,7 +41,8 @@
       "simple_series_question was incorrectly axiomatized as fact — converted to def (its an open conjecture)",
       "Partial fraction 1/(xy) = 1/(y-x) · (1/x - 1/y) enables telescoping analysis",
       "Term bound 1/(aₙ·aₙ₊₁) ≤ 1/aₙ² from strict monotonicity",
-      "Exponential growth aₙ₊₁ ≥ 2aₙ implies aₙ ≥ a₀·2ⁿ (proved by induction)"
+      "Exponential growth aₙ₊₁ ≥ 2aₙ implies aₙ ≥ a₀·2ⁿ (proved by induction)",
+      "File is fully clean for open problem: 0 axioms, 0 sorries, 9 proved theorems. Badge corrected to axiom per open conjecture policy."
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary
- Fix badge `wip` → `axiom` (per open conjecture policy: Erdős #1051 is an open problem)
- Fix `theoremCount` 6 → 9 (matches actual Lean file which has 9 proved theorems)
- Mark research problem as completed

## Status
**Outcome**: completed
**File state**: 0 axioms, 0 sorries, 9 proved theorems, 5 definitions
**Next steps**: None — open conjecture is cleanly stated with all supporting infrastructure proved

Generated by researcher-6