### PR TITLE
Enrich Catalan Numbers and Central Binomial Coefficients

### DIFF
--- a/src/data/proofs/combinations-formula-oq-02/annotations.json
+++ b/src/data/proofs/combinations-formula-oq-02/annotations.json
@@ -1,1 +1,86 @@
-[]
+[
+  {
+    "id": "ann-catalan-def",
+    "proofId": "combinations-formula-oq-02",
+    "range": { "startLine": 42, "endLine": 43 },
+    "type": "definition",
+    "title": "Catalan Number Definition",
+    "content": "Defines $C_n = \\binom{2n}{n} - \\binom{2n}{n+1}$. This is equivalent to the more common formula $C_n = \\binom{2n}{n}/(n+1)$ (proved as `catalan_mul_succ`). The subtraction form is more natural for Lean's natural number arithmetic since it avoids division.",
+    "mathContext": "$C_n = \\binom{2n}{n} - \\binom{2n}{n+1} = \\frac{1}{n+1}\\binom{2n}{n}$",
+    "significance": "key",
+    "relatedConcepts": ["Catalan number", "central binomial coefficient", "Dyck path counting"],
+    "prerequisites": ["Nat.choose"]
+  },
+  {
+    "id": "ann-initial-values",
+    "proofId": "combinations-formula-oq-02",
+    "range": { "startLine": 46, "endLine": 72 },
+    "type": "context",
+    "title": "Initial Values C_0 through C_5",
+    "content": "Verifies $C_0 = 1, C_1 = 1, C_2 = 2, C_3 = 5, C_4 = 14, C_5 = 42$ using `norm_num` after simplification. These values match OEIS A000108 and serve as sanity checks for the definition.",
+    "mathContext": "$C_0 = 1,\\ C_1 = 1,\\ C_2 = 2,\\ C_3 = 5,\\ C_4 = 14,\\ C_5 = 42$",
+    "significance": "supporting",
+    "relatedConcepts": ["OEIS A000108", "computational verification"],
+    "prerequisites": ["catalan definition", "norm_num tactic"]
+  },
+  {
+    "id": "ann-absorption-identity",
+    "proofId": "combinations-formula-oq-02",
+    "range": { "startLine": 80, "endLine": 104 },
+    "type": "technique",
+    "title": "Absorption Identity for C(2n,n+1)",
+    "content": "Proves $\\binom{2n}{n+1}(n+1) = \\binom{2n}{n} \\cdot n$ using Mathlib's absorption identity `Nat.succ_mul_choose_eq` applied twice (with different parameters) and the symmetry $\\binom{2n+1}{n+1} = \\binom{2n+1}{n}$. This is the key auxiliary result for the fundamental Catalan identity.",
+    "mathContext": "$\\binom{2n}{n+1}(n+1) = \\binom{2n}{n} \\cdot n$, via absorption: $(m+1)\\binom{m}{k} = \\binom{m+1}{k+1}(k+1)$",
+    "significance": "key",
+    "relatedConcepts": ["absorption identity", "binomial coefficient symmetry", "Nat.succ_mul_choose_eq"],
+    "prerequisites": ["Nat.succ_mul_choose_eq", "Nat.choose_symm"]
+  },
+  {
+    "id": "ann-fundamental-identity",
+    "proofId": "combinations-formula-oq-02",
+    "range": { "startLine": 111, "endLine": 119 },
+    "type": "insight",
+    "title": "Fundamental Identity: C_n(n+1) = C(2n,n)",
+    "content": "Proves $C_n \\cdot (n+1) = \\binom{2n}{n}$. The proof expands $C_n = \\binom{2n}{n} - \\binom{2n}{n+1}$, distributes $(n+1)$, then uses $\\binom{2n}{n+1}(n+1) = \\binom{2n}{n} \\cdot n$ to get $\\binom{2n}{n}(n+1) - \\binom{2n}{n} \\cdot n = \\binom{2n}{n}$. This establishes the divisibility $C_n = \\binom{2n}{n}/(n+1)$.",
+    "mathContext": "$C_n(n+1) = [\\binom{2n}{n} - \\binom{2n}{n+1}](n+1) = \\binom{2n}{n}(n+1) - \\binom{2n}{n} \\cdot n = \\binom{2n}{n}$",
+    "significance": "key",
+    "relatedConcepts": ["divisibility of binomial coefficients", "Catalan formula"],
+    "prerequisites": ["choose_2n_succ", "Nat.sub_mul"]
+  },
+  {
+    "id": "ann-catalan-pos",
+    "proofId": "combinations-formula-oq-02",
+    "range": { "startLine": 122, "endLine": 129 },
+    "type": "technique",
+    "title": "Catalan Numbers Are Positive",
+    "content": "Proves $C_n > 0$ for all $n$ by contradiction: if $C_n = 0$ then $C_n(n+1) = 0$, but $C_n(n+1) = \\binom{2n}{n} > 0$ (since $n \\leq 2n$). Uses Mathlib's `Nat.choose_pos` to establish $\\binom{2n}{n} > 0$.",
+    "mathContext": "$C_n > 0$ since $C_n(n+1) = \\binom{2n}{n} > 0$ and $n+1 > 0$",
+    "significance": "supporting",
+    "relatedConcepts": ["positivity", "Nat.choose_pos"],
+    "prerequisites": ["catalan_mul_succ"]
+  },
+  {
+    "id": "ann-central-binom-bound",
+    "proofId": "combinations-formula-oq-02",
+    "range": { "startLine": 154, "endLine": 161 },
+    "type": "insight",
+    "title": "Central Binomial Coefficient Upper Bound: 4^n",
+    "content": "Proves $\\binom{2n}{n} \\leq 4^n$ via the chain $\\binom{2n}{n} \\leq \\sum_{k=0}^{2n} \\binom{2n}{k} = 2^{2n} = 4^n$. Uses `Finset.single_le_sum` (one term is at most the sum of non-negative terms) and `Nat.sum_range_choose` (binomial row sum equals $2^m$). The bound is tight: $\\binom{2n}{n} \\sim 4^n/\\sqrt{\\pi n}$ by Stirling.",
+    "mathContext": "$\\binom{2n}{n} \\leq \\sum_{k=0}^{2n} \\binom{2n}{k} = 2^{2n} = (2^2)^n = 4^n$",
+    "significance": "key",
+    "relatedConcepts": ["binomial row sum", "Nat.sum_range_choose", "Stirling approximation"],
+    "prerequisites": ["Finset.single_le_sum", "Nat.sum_range_choose", "pow_mul"]
+  },
+  {
+    "id": "ann-central-binom-lower",
+    "proofId": "combinations-formula-oq-02",
+    "range": { "startLine": 165, "endLine": 194 },
+    "type": "technique",
+    "title": "Central Binomial Lower Bound: 2^n",
+    "content": "Proves $\\binom{2n}{n} \\geq 2^n$ for $n \\geq 1$ by induction. The key step uses Pascal's identity $\\binom{2m+4}{m+2} = \\binom{2m+3}{m+1} + \\binom{2m+3}{m+2}$ and symmetry $\\binom{2m+3}{m+2} = \\binom{2m+3}{m+1}$ to get doubling: $\\binom{2(m+2)}{m+2} = 2\\binom{2m+3}{m+1}$. Monotonicity of $\\binom{\\cdot}{m+1}$ provides $\\binom{2m+3}{m+1} \\geq \\binom{2m+2}{m+1} = \\binom{2(m+1)}{m+1}$.",
+    "mathContext": "$\\binom{2(m+2)}{m+2} = 2\\binom{2m+3}{m+1} \\geq 2\\binom{2(m+1)}{m+1} \\geq 2 \\cdot 2^{m+1} = 2^{m+2}$",
+    "significance": "key",
+    "relatedConcepts": ["Pascal's identity", "binomial monotonicity", "induction"],
+    "prerequisites": ["Nat.choose_succ_succ", "Nat.choose_symm", "Nat.choose_le_choose"]
+  }
+]

--- a/src/data/proofs/combinations-formula-oq-02/meta.json
+++ b/src/data/proofs/combinations-formula-oq-02/meta.json
@@ -41,9 +41,11 @@
     "problemStatement": "Formalize the connection between binomial coefficients and Catalan numbers. Define C_n, prove initial values, establish the identity C_n(n+1) = C(2n,n), prove the 4^n upper bound, and state the Catalan convolution.",
     "proofStrategy": "**Part I**: Define catalan(n) = C(2n,n) - C(2n,n+1) and verify C_0 through C_5 by norm_num.\n\n**Part II**: State the fundamental identity catalan_mul_succ and the auxiliary choose_2n_succ.\n\n**Part III**: Define centralBinom and prove centralBinom_le_four_pow using the binomial row sum C(2n,0)+...+C(2n,2n) = 2^{2n} = 4^n.\n\n**Part IV**: Derive catalan_le_four_pow from the central binomial bound.\n\n**Parts V-VI**: Value tables and the convolution identity (stated with sorry).",
     "keyInsights": [
-      "**C(2n,n) <= 4^n via row sum**: The proof uses the identity sum_k C(m,k) = 2^m from Mathlib (Nat.sum_range_choose), then notes C(2n,n) is at most the full sum.",
-      "**Catalan = ballot path count**: C_n = C(2n,n) - C(2n,n+1) is the reflection principle formula for counting Dyck paths (paths that stay non-negative).",
-      "**Convolution encodes recursive decomposition**: C_{n+1} = sum C_k C_{n-k} corresponds to choosing the position of the 'outermost' operation in a bracketed expression."
+      "$\\binom{2n}{n} \\leq 4^n$ via the binomial row sum: $\\binom{2n}{n} \\leq \\sum_k \\binom{2n}{k} = 2^{2n} = 4^n$. This uses Mathlib's `Nat.sum_range_choose` and Finset.single_le_sum. The bound is tight up to a $\\sqrt{n}$ factor (Stirling gives $\\binom{2n}{n} \\sim 4^n / \\sqrt{\\pi n}$).",
+      "The Catalan formula $C_n = \\binom{2n}{n} - \\binom{2n}{n+1}$ is the reflection principle: lattice paths from $(0,0)$ to $(2n,0)$ that stay non-negative minus those that go below the $x$-axis. The 'bad' paths are in bijection with all paths to $(2n,-2)$, which are counted by $\\binom{2n}{n+1}$.",
+      "The fundamental identity $C_n(n+1) = \\binom{2n}{n}$ is proved via the absorption identity $\\binom{m+1}{k+1}(k+1) = (m+1)\\binom{m}{k}$ and symmetry $\\binom{2n+1}{n+1} = \\binom{2n+1}{n}$. The cancellation of $(n+1)$ terms gives the clean factorization.",
+      "The convolution $C_{n+1} = \\sum_{k=0}^n C_k C_{n-k}$ encodes the recursive decomposition: in any bracketed expression, the outermost operation splits the remaining $n$ factors into two groups of sizes $k$ and $n-k$, each counted by a Catalan number.",
+      "The lower bound $\\binom{2n}{n} \\geq 2^n$ (for $n \\geq 1$) is proved by induction using Pascal's identity and the symmetry $\\binom{2m+3}{m+2} = \\binom{2m+3}{m+1}$, giving $\\binom{2m+4}{m+2} = 2\\binom{2m+3}{m+1}$. Combined with the $4^n$ upper bound, this pins down the exponential growth rate."
     ]
   },
   "sections": [
@@ -93,13 +95,23 @@
   "crossReferences": [
     {
       "targetId": "combinations-formula",
-      "relationship": "extends",
-      "description": "Connects binomial coefficients to Catalan numbers"
+      "relationship": "parent",
+      "description": "Parent entry on the binomial coefficient formula, which this extends to Catalan numbers"
     },
     {
       "targetId": "ballot-problem-oq-03",
       "relationship": "related",
-      "description": "BallotProblemOQ03 also defines Catalan numbers (Cn) and proves catalan_formula"
+      "description": "Also defines Catalan numbers and proves the catalan_formula; both connect lattice paths to ballot sequences"
+    },
+    {
+      "targetId": "binomial-theorem-oq-02-oq-01-oq-01",
+      "relationship": "related",
+      "description": "Binomial theorem extensions that use the same row-sum identity $\\sum_k \\binom{m}{k} = 2^m$"
+    },
+    {
+      "targetId": "chebyshev-pnt-bridge-oq-01",
+      "relationship": "related",
+      "description": "Also uses central binomial coefficient bounds $\\binom{2n}{n} \\leq 4^n$ for prime distribution estimates"
     }
   ],
   "sorries": 1


### PR DESCRIPTION
## Enrichment pass for combinations-formula-oq-02

**meta.json:**
- Expanded `keyInsights` from 3 to 5 with LaTeX and proof technique details
- Expanded `crossReferences` from 2 to 4 (binomial theorem, Chebyshev bridge)

**annotations.json:**
- Populated with 7 deep annotations (was empty `[]`)
- Covers Catalan definition, initial values, absorption identity, fundamental identity, positivity, 4^n upper bound, and 2^n lower bound
- All include `mathContext`, `significance`, `relatedConcepts`, `prerequisites`

Build verified: `pnpm build` passes cleanly.