### PR TITLE
Enrich Apéry's Proof of ζ(3) Irrationality

### DIFF
--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-zeta-def",
+    "proofId": "basel-problem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 46, "endLine": 46 },
+    "type": "definition",
+    "title": "Zeta Value Definition",
+    "content": "Defines $\\zeta(s) = \\sum_{n=1}^{\\infty} 1/n^s$ as a `tsum` over $\\mathbb{N}$. For Apéry's proof, the target is $\\zeta(3) = 1 + 1/8 + 1/27 + 1/64 + \\cdots \\approx 1.202$. The irrationality of $\\zeta(3)$ was open for over 200 years before Apéry's breakthrough.",
+    "mathContext": "$\\zeta(s) = \\sum_{n=1}^{\\infty} \\frac{1}{n^s}$",
+    "significance": "key",
+    "relatedConcepts": ["Riemann zeta function", "p-series", "tsum"],
+    "prerequisites": ["tsum", "Real.summable_nat_rpow_inv"]
+  },
+  {
+    "id": "ann-summability",
+    "proofId": "basel-problem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 49, "endLine": 54 },
+    "type": "technique",
+    "title": "Summability of the Zeta Series",
+    "content": "Proves $\\sum 1/n^s$ converges for $s \\geq 2$ using Mathlib's `Real.summable_nat_rpow_inv`, which states that the real-power series $\\sum 1/n^p$ converges iff $p > 1$. The conversion between natural and real exponents requires a `convert` step.",
+    "mathContext": "$\\sum_{n=1}^{\\infty} 1/n^s$ converges for $s \\geq 2$ (in fact for $s > 1$)",
+    "significance": "supporting",
+    "relatedConcepts": ["p-series test", "summability", "Real.summable_nat_rpow_inv"],
+    "prerequisites": ["Summable", "Real.summable_nat_rpow_inv"]
+  },
+  {
+    "id": "ann-apery-numbers",
+    "proofId": "basel-problem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 71, "endLine": 72 },
+    "type": "definition",
+    "title": "The Apéry Number Sequence",
+    "content": "Defines $b_n = \\sum_{k=0}^{n} \\binom{n}{k}^2 \\binom{n+k}{k}^2$ as a computable natural number. These are the Apéry numbers (OEIS A005259), which arise in the theory of modular forms, K3 surfaces, and Picard-Fuchs equations. The double-squared binomial product ensures all terms are positive integers.",
+    "mathContext": "$b_n = \\sum_{k=0}^{n} \\binom{n}{k}^2 \\binom{n+k}{k}^2$",
+    "significance": "key",
+    "relatedConcepts": ["Apéry numbers", "OEIS A005259", "modular forms", "K3 surfaces"],
+    "prerequisites": ["Nat.choose", "Finset.sum"]
+  },
+  {
+    "id": "ann-initial-values",
+    "proofId": "basel-problem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 75, "endLine": 91 },
+    "type": "context",
+    "title": "Verified Initial Values",
+    "content": "Computes $b_0 = 1$, $b_1 = 5$, $b_2 = 73$, $b_3 = 1445$ using `norm_num`. These match OEIS A005259 and the values in Apéry's original paper. The rapid growth ($1, 5, 73, 1445, \\ldots$) foreshadows the exponential growth rate $(1+\\sqrt{2})^4 \\approx 33.97$.",
+    "mathContext": "$b_0 = 1,\\ b_1 = 5,\\ b_2 = 73,\\ b_3 = 1445$",
+    "significance": "supporting",
+    "relatedConcepts": ["computational verification", "OEIS A005259"],
+    "prerequisites": ["aperyB definition", "norm_num"]
+  },
+  {
+    "id": "ann-positivity",
+    "proofId": "basel-problem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 94, "endLine": 101 },
+    "type": "technique",
+    "title": "Apéry Numbers Are Positive",
+    "content": "Proves $b_n > 0$ for all $n$ using `Finset.sum_pos`: each term $\\binom{n}{k}^2 \\binom{n+k}{k}^2$ is a product of squares of positive integers (binomial coefficients $\\binom{n}{k} > 0$ for $k \\leq n$), and the sum has at least one term ($k = 0$). Positivity is essential for the irrationality argument.",
+    "mathContext": "$b_n > 0$ since each $\\binom{n}{k}^2 \\binom{n+k}{k}^2 > 0$",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.sum_pos", "Nat.choose_pos", "pow_ne_zero"],
+    "prerequisites": ["Finset.sum_pos", "Nat.choose_pos"]
+  },
+  {
+    "id": "ann-recurrence",
+    "proofId": "basel-problem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 110, "endLine": 111 },
+    "type": "concept",
+    "title": "The Apéry Recurrence Coefficient",
+    "content": "Defines the coefficient $(2n+1)(17n^2+17n+5)$ appearing in the 3-term Apéry recurrence $(n+1)^3 u_{n+1} = (2n+1)(17n^2+17n+5) u_n - n^3 u_{n-1}$. This recurrence was discovered by Apéry and proved by Zeilberger's creative telescoping algorithm (1982). Its characteristic polynomial $t^2 - 34t + 1$ has roots $(1 \\pm \\sqrt{2})^4$.",
+    "mathContext": "$(n+1)^3 u_{n+1} = (2n+1)(17n^2+17n+5) u_n - n^3 u_{n-1}$",
+    "significance": "key",
+    "relatedConcepts": ["three-term recurrence", "Zeilberger algorithm", "characteristic polynomial"],
+    "prerequisites": ["polynomial arithmetic"]
+  },
+  {
+    "id": "ann-irrationality",
+    "proofId": "basel-problem-oq-01-oq-01-oq-02",
+    "range": { "startLine": 167, "endLine": 199 },
+    "type": "insight",
+    "title": "The Irrationality Argument",
+    "content": "The final step: if $\\zeta(3) = p/q$ then $q b_n \\zeta(3) - q a_n$ is a nonzero integer for large $n$ that converges to 0 — contradiction. The key estimates are: $b_n$ grows like $(1+\\sqrt{2})^{4n}$, $|b_n \\zeta(3) - a_n|$ decays like $(\\sqrt{2}-1)^{4n} \\approx 0.029^n$, and $\\text{lcm}(1,\\ldots,n)^3 \\leq e^{3n}$ controls the denominators of $a_n$. Since $(\\sqrt{2}-1)^4 \\cdot e^3 < 1$, the product tends to 0.",
+    "mathContext": "$|q b_n \\zeta(3) - q a_n| \\to 0$ but $q b_n \\zeta(3) - q a_n \\in \\mathbb{Z} \\setminus \\{0\\}$ for large $n$ — contradiction",
+    "significance": "key",
+    "relatedConcepts": ["irrationality proof", "Diophantine approximation", "linear forms in zeta values"],
+    "prerequisites": ["growth/decay estimates", "lcm denominator control", "Apéry recurrence"]
+  }
+]

--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/index.ts
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/index.ts
@@ -1,0 +1,10 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+const meta = metaJson as unknown as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+const leanSource = () => import('../../../../proofs/Proofs/BaselProblemOQ01OQ01OQ02.lean?raw')
+export const proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: '', overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const proofData: ProofData = { proof, annotations }
+export async function getProofSource(): Promise<string> { const m = await leanSource(); return m.default }
+export default proofData


### PR DESCRIPTION
## Enrichment pass for basel-problem-oq-01-oq-01-oq-02

**annotations.json (new):**
- 7 deep annotations covering zeta definition, summability, Apéry number definition, initial values, positivity, recurrence coefficient, and irrationality argument
- All include `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`

**index.ts (new):**
- Gallery integration module

Build verified: `pnpm build` passes cleanly.