### PR TITLE
Fix: correct sorry count mismatches in 5 gallery proofs; mark 25 Aristotle jobs resolved

### DIFF
--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
@@ -1,10 +1,10 @@
 {
   "id": "basel-problem-oq-01-oq-01-oq-02",
-  "title": "Apéry's Proof of ζ(3) Irrationality",
+  "title": "Ap\u00e9ry's Proof of \u03b6(3) Irrationality",
   "slug": "basel-problem-oq-01-oq-01-oq-02",
-  "description": "Formalizes the framework for Apéry's 1978 proof that ζ(3) is irrational. Defines the Apéry numbers bₙ = ∑ C(n,k)²C(n+k,k)², verifies initial values (b₀=1, b₁=5, b₂=73, b₃=1445), states the 3-term recurrence, and sets up the irrationality argument.",
+  "description": "Formalizes the framework for Ap\u00e9ry's 1978 proof that \u03b6(3) is irrational. Defines the Ap\u00e9ry numbers b\u2099 = \u2211 C(n,k)\u00b2C(n+k,k)\u00b2, verifies initial values (b\u2080=1, b\u2081=5, b\u2082=73, b\u2083=1445), states the 3-term recurrence, and sets up the irrationality argument.",
   "meta": {
-    "author": "Apéry, Roger (1978)",
+    "author": "Ap\u00e9ry, Roger (1978)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Ap%C3%A9ry%27s_theorem",
     "date": "1978",
     "status": "formalized",
@@ -22,24 +22,24 @@
     "dateAdded": "2026-04-12",
     "axiomCount": 0,
     "lineCount": 199,
-    "assumptions": "0 axioms. 5 sorries: recurrence relation, growth bound, main theorem. Infrastructure scaffold for full Apéry proof.",
+    "assumptions": "0 axioms. 5 sorries: recurrence relation, growth bound, main theorem. Infrastructure scaffold for full Ap\u00e9ry proof.",
     "mathlib_version": "4.26.0",
     "originalContributions": [
-      "Defined Apéry numbers aperyB(n) = ∑ C(n,k)²C(n+k,k)² as a computable ℕ-valued function",
-      "Proved initial values b₀=1, b₁=5, b₂=73, b₃=1445 and positivity",
-      "Stated 3-term Apéry recurrence with verified numerical checks at n=1,2",
+      "Defined Ap\u00e9ry numbers aperyB(n) = \u2211 C(n,k)\u00b2C(n+k,k)\u00b2 as a computable \u2115-valued function",
+      "Proved initial values b\u2080=1, b\u2081=5, b\u2082=73, b\u2083=1445 and positivity",
+      "Stated 3-term Ap\u00e9ry recurrence with verified numerical checks at n=1,2",
       "Identified Mathlib infrastructure gaps for full formalization"
     ]
   },
   "overview": {
-    "historicalContext": "Roger Apéry stunned the mathematical community in June 1978 when he announced a proof that ζ(3) is irrational. His proof was initially met with skepticism due to its surprising nature — no one expected such a classical constant to yield to elementary methods. Henri Cohen and Don Zagier independently verified the proof within weeks. Alfred van der Poorten published a detailed exposition in 1979, making the proof widely accessible. The key innovation was an explicit pair of sequences satisfying a common 3-term recurrence, whose ratio converges to ζ(3) faster than any rational approximation can.",
-    "problemStatement": "Formalize Apéry's proof that ζ(3) = 1 + 1/8 + 1/27 + 1/64 + ... is irrational. The proof constructs explicit integer sequences bₙ (Apéry numbers) and rational sequences aₙ such that bₙ·ζ(3) - aₙ → 0 geometrically fast, forcing irrationality.",
-    "text": "Defines the Apéry number sequence bₙ = ∑_{k=0}^{n} C(n,k)²C(n+k,k)² and verifies initial values. States the fundamental 3-term recurrence (n+1)³bₙ₊₁ = (2n+1)(17n²+17n+5)bₙ - n³bₙ₋₁ with numerical verification. Sets up the irrationality argument framework.",
-    "proofStrategy": "The proof proceeds in layers:\n\n**Layer 1 (Sequences)**: Define bₙ = ∑C(n,k)²C(n+k,k)² (Apéry numbers) as positive integers.\n\n**Layer 2 (Recurrence)**: Both aₙ and bₙ satisfy (n+1)³uₙ₊₁ = (2n+1)(17n²+17n+5)uₙ - n³uₙ₋₁. The characteristic polynomial t² - 34t + 1 has roots (1+√2)⁴ ≈ 33.97 and (√2-1)⁴ ≈ 0.029.\n\n**Layer 3 (Estimates)**: bₙ grows like (1+√2)^{4n} while |bₙζ(3) - aₙ| decays like (√2-1)^{4n}.\n\n**Layer 4 (Irrationality)**: If ζ(3) = p/q then q·bₙ·ζ(3) - q·aₙ is a nonzero integer for large n but converges to 0, contradiction.",
+    "historicalContext": "Roger Ap\u00e9ry stunned the mathematical community in June 1978 when he announced a proof that \u03b6(3) is irrational. His proof was initially met with skepticism due to its surprising nature \u2014 no one expected such a classical constant to yield to elementary methods. Henri Cohen and Don Zagier independently verified the proof within weeks. Alfred van der Poorten published a detailed exposition in 1979, making the proof widely accessible. The key innovation was an explicit pair of sequences satisfying a common 3-term recurrence, whose ratio converges to \u03b6(3) faster than any rational approximation can.",
+    "problemStatement": "Formalize Ap\u00e9ry's proof that \u03b6(3) = 1 + 1/8 + 1/27 + 1/64 + ... is irrational. The proof constructs explicit integer sequences b\u2099 (Ap\u00e9ry numbers) and rational sequences a\u2099 such that b\u2099\u00b7\u03b6(3) - a\u2099 \u2192 0 geometrically fast, forcing irrationality.",
+    "text": "Defines the Ap\u00e9ry number sequence b\u2099 = \u2211_{k=0}^{n} C(n,k)\u00b2C(n+k,k)\u00b2 and verifies initial values. States the fundamental 3-term recurrence (n+1)\u00b3b\u2099\u208a\u2081 = (2n+1)(17n\u00b2+17n+5)b\u2099 - n\u00b3b\u2099\u208b\u2081 with numerical verification. Sets up the irrationality argument framework.",
+    "proofStrategy": "The proof proceeds in layers:\n\n**Layer 1 (Sequences)**: Define b\u2099 = \u2211C(n,k)\u00b2C(n+k,k)\u00b2 (Ap\u00e9ry numbers) as positive integers.\n\n**Layer 2 (Recurrence)**: Both a\u2099 and b\u2099 satisfy (n+1)\u00b3u\u2099\u208a\u2081 = (2n+1)(17n\u00b2+17n+5)u\u2099 - n\u00b3u\u2099\u208b\u2081. The characteristic polynomial t\u00b2 - 34t + 1 has roots (1+\u221a2)\u2074 \u2248 33.97 and (\u221a2-1)\u2074 \u2248 0.029.\n\n**Layer 3 (Estimates)**: b\u2099 grows like (1+\u221a2)^{4n} while |b\u2099\u03b6(3) - a\u2099| decays like (\u221a2-1)^{4n}.\n\n**Layer 4 (Irrationality)**: If \u03b6(3) = p/q then q\u00b7b\u2099\u00b7\u03b6(3) - q\u00b7a\u2099 is a nonzero integer for large n but converges to 0, contradiction.",
     "keyInsights": [
-      "Apéry numbers bₙ = ∑C(n,k)²C(n+k,k)² arise naturally in the theory of modular forms and have deep connections to algebraic geometry (Beukers, 1987)",
-      "The characteristic roots (1+√2)⁴ and (√2-1)⁴ multiply to 1 (since the recurrence has leading coefficient ratio n³/(n+1)³ → 1), explaining why one solution grows and the other decays",
-      "The critical trick is that lcm(1,...,n)³ clears all denominators of aₙ, and lcm(1,...,n) ≤ e^{n+o(n)} by the prime number theorem — so the denominator growth is only exponential with base e³ ≈ 20.1, much less than the decay base 1/(√2-1)⁴ ≈ 34",
+      "Ap\u00e9ry numbers b\u2099 = \u2211C(n,k)\u00b2C(n+k,k)\u00b2 arise naturally in the theory of modular forms and have deep connections to algebraic geometry (Beukers, 1987)",
+      "The characteristic roots (1+\u221a2)\u2074 and (\u221a2-1)\u2074 multiply to 1 (since the recurrence has leading coefficient ratio n\u00b3/(n+1)\u00b3 \u2192 1), explaining why one solution grows and the other decays",
+      "The critical trick is that lcm(1,...,n)\u00b3 clears all denominators of a\u2099, and lcm(1,...,n) \u2264 e^{n+o(n)} by the prime number theorem \u2014 so the denominator growth is only exponential with base e\u00b3 \u2248 20.1, much less than the decay base 1/(\u221a2-1)\u2074 \u2248 34",
       "No WZ-theory infrastructure exists in Mathlib, so the recurrence must be proved by direct combinatorial manipulation or trusted numerical verification"
     ],
     "prerequisites": [
@@ -54,31 +54,31 @@
       "title": "Zeta Value Infrastructure",
       "startLine": 41,
       "endLine": 60,
-      "summary": "Defines zetaValue(s) = ∑ 1/n^s, proves summability for s ≥ 2 and positivity.",
-      "mathContext": "$\\zeta(s) = \\sum_{n=1}^{\\infty} 1/n^s$ converges for $s > 1$. For the Apéry proof, we need $\\zeta(3) \\approx 1.202$."
+      "summary": "Defines zetaValue(s) = \u2211 1/n^s, proves summability for s \u2265 2 and positivity.",
+      "mathContext": "$\\zeta(s) = \\sum_{n=1}^{\\infty} 1/n^s$ converges for $s > 1$. For the Ap\u00e9ry proof, we need $\\zeta(3) \\approx 1.202$."
     },
     {
       "id": "apery-sequence",
-      "title": "The Apéry Sequence bₙ",
+      "title": "The Ap\u00e9ry Sequence b\u2099",
       "startLine": 62,
       "endLine": 108,
-      "summary": "Defines bₙ = ∑ C(n,k)²C(n+k,k)² and verifies b₀=1, b₁=5, b₂=73, b₃=1445. Proves all Apéry numbers are positive.",
-      "mathContext": "$b_n = \\sum_{k=0}^{n} \\binom{n}{k}^2 \\binom{n+k}{k}^2$. These are OEIS A005259, the Apéry numbers. They count certain lattice paths and appear in periods of K3 surfaces."
+      "summary": "Defines b\u2099 = \u2211 C(n,k)\u00b2C(n+k,k)\u00b2 and verifies b\u2080=1, b\u2081=5, b\u2082=73, b\u2083=1445. Proves all Ap\u00e9ry numbers are positive.",
+      "mathContext": "$b_n = \\sum_{k=0}^{n} \\binom{n}{k}^2 \\binom{n+k}{k}^2$. These are OEIS A005259, the Ap\u00e9ry numbers. They count certain lattice paths and appear in periods of K3 surfaces."
     },
     {
       "id": "recurrence",
-      "title": "The Apéry Recurrence",
+      "title": "The Ap\u00e9ry Recurrence",
       "startLine": 110,
       "endLine": 140,
-      "summary": "States the 3-term recurrence (n+1)³bₙ₊₁ = (2n+1)(17n²+17n+5)bₙ - n³bₙ₋₁ with numerical checks.",
-      "mathContext": "The recurrence was discovered by Apéry and proved by Zeilberger's algorithm (1982). The characteristic polynomial $t^2 - 34t + 1$ has roots $(1\\pm\\sqrt{2})^4$."
+      "summary": "States the 3-term recurrence (n+1)\u00b3b\u2099\u208a\u2081 = (2n+1)(17n\u00b2+17n+5)b\u2099 - n\u00b3b\u2099\u208b\u2081 with numerical checks.",
+      "mathContext": "The recurrence was discovered by Ap\u00e9ry and proved by Zeilberger's algorithm (1982). The characteristic polynomial $t^2 - 34t + 1$ has roots $(1\\pm\\sqrt{2})^4$."
     },
     {
       "id": "estimates",
       "title": "Growth and Decay Estimates",
       "startLine": 142,
       "endLine": 165,
-      "summary": "States growth bound bₙ ≤ 34^n and describes the characteristic polynomial roots.",
+      "summary": "States growth bound b\u2099 \u2264 34^n and describes the characteristic polynomial roots.",
       "mathContext": "$b_n \\sim C(1+\\sqrt{2})^{4n}/n^{3/2}$ where $(1+\\sqrt{2})^4 = 17+12\\sqrt{2} \\approx 33.97$. The linear form $b_n\\zeta(3)-a_n$ decays like $(\\sqrt{2}-1)^{4n} \\approx 0.029^n$."
     },
     {
@@ -86,15 +86,15 @@
       "title": "The Irrationality Argument",
       "startLine": 167,
       "endLine": 199,
-      "summary": "States Apéry's theorem (ζ(3) irrational) and documents infrastructure needs.",
-      "mathContext": "If $\\zeta(3) = p/q$ then $q b_n \\zeta(3) - q a_n$ is a nonzero integer converging to 0 — contradiction. The denominators of $a_n$ are controlled by $\\text{lcm}(1,\\ldots,n)^3 \\leq e^{3n+o(n)}$, and the decay rate $(\\sqrt{2}-1)^4 < e^{-3}$, so the product tends to 0."
+      "summary": "States Ap\u00e9ry's theorem (\u03b6(3) irrational) and documents infrastructure needs.",
+      "mathContext": "If $\\zeta(3) = p/q$ then $q b_n \\zeta(3) - q a_n$ is a nonzero integer converging to 0 \u2014 contradiction. The denominators of $a_n$ are controlled by $\\text{lcm}(1,\\ldots,n)^3 \\leq e^{3n+o(n)}$, and the decay rate $(\\sqrt{2}-1)^4 < e^{-3}$, so the product tends to 0."
     }
   ],
   "conclusion": {
-    "summary": "A scaffold for formalizing Apéry's 1978 proof of ζ(3) irrationality. The Apéry numbers are defined and verified, the recurrence is stated with numerical checks, and the irrationality argument is outlined. 4 sorries remain, representing the core mathematical content.",
-    "implications": "Once fully proved, this would allow upgrading the axiom `apery_theorem` in BaselProblemOQ02.lean to a theorem, strengthening the entire odd-zeta-value formalization chain. The Apéry number infrastructure would also be reusable for Beukers' alternative proof via modular forms.",
+    "summary": "A scaffold for formalizing Ap\u00e9ry's 1978 proof of \u03b6(3) irrationality. The Ap\u00e9ry numbers are defined and verified, the recurrence is stated with numerical checks, and the irrationality argument is outlined. 4 sorries remain, representing the core mathematical content.",
+    "implications": "Once fully proved, this would allow upgrading the axiom `apery_theorem` in BaselProblemOQ02.lean to a theorem, strengthening the entire odd-zeta-value formalization chain. The Ap\u00e9ry number infrastructure would also be reusable for Beukers' alternative proof via modular forms.",
     "openQuestions": [
-      "Prove the Apéry recurrence via direct combinatorial identity or Zeilberger verification",
+      "Prove the Ap\u00e9ry recurrence via direct combinatorial identity or Zeilberger verification",
       "Define the a-sequence and prove its denominator properties",
       "Prove the growth and decay estimates from the recurrence",
       "Complete the irrationality argument"
@@ -104,7 +104,7 @@
     {
       "targetId": "basel-problem-oq-01-oq-01",
       "relationship": "extends",
-      "description": "Parent entry studying ζ(5) irrationality; this formalizes the known technique (Apéry's proof) for the solved case ζ(3)"
+      "description": "Parent entry studying \u03b6(5) irrationality; this formalizes the known technique (Ap\u00e9ry's proof) for the solved case \u03b6(3)"
     },
     {
       "targetId": "basel-problem-oq-02",
@@ -116,12 +116,12 @@
     {
       "name": "aperyB",
       "type": "core",
-      "description": "The Apéry number sequence bₙ = ∑ C(n,k)²C(n+k,k)², defined as a computable ℕ-valued function with verified initial values."
+      "description": "The Ap\u00e9ry number sequence b\u2099 = \u2211 C(n,k)\u00b2C(n+k,k)\u00b2, defined as a computable \u2115-valued function with verified initial values."
     },
     {
       "name": "apery_theorem",
       "type": "core",
-      "description": "Statement: ζ(3) is irrational. Currently sorry — the main target of this formalization effort."
+      "description": "Statement: \u03b6(3) is irrational. Currently sorry \u2014 the main target of this formalization effort."
     }
   ],
   "leanFile": {
@@ -144,30 +144,30 @@
     "theoremCount": 15,
     "definitionCount": 4,
     "path": "Proofs/BaselProblemOQ01OQ01OQ02.lean",
-    "sorries": 3
+    "sorries": 5
   },
   "references": [
     {
-      "authors": "Apéry, Roger",
-      "title": "Irrationalité de ζ(2) et ζ(3)",
+      "authors": "Ap\u00e9ry, Roger",
+      "title": "Irrationalit\u00e9 de \u03b6(2) et \u03b6(3)",
       "year": "1979",
-      "venue": "Astérisque, vol. 61, pp. 11-13",
-      "note": "Original announcement of the irrationality proof for ζ(3). The sequences and recurrence are stated without proof."
+      "venue": "Ast\u00e9risque, vol. 61, pp. 11-13",
+      "note": "Original announcement of the irrationality proof for \u03b6(3). The sequences and recurrence are stated without proof."
     },
     {
       "authors": "van der Poorten, Alfred",
-      "title": "A Proof that Euler Missed... Apéry's Proof of the Irrationality of ζ(3)",
+      "title": "A Proof that Euler Missed... Ap\u00e9ry's Proof of the Irrationality of \u03b6(3)",
       "year": "1979",
       "venue": "The Mathematical Intelligencer, vol. 1(4), pp. 195-203",
-      "note": "The standard readable exposition of Apéry's proof, filling in all details."
+      "note": "The standard readable exposition of Ap\u00e9ry's proof, filling in all details."
     },
     {
       "authors": "Zudilin, Wadim",
-      "title": "Apéry's theorem. Thirty years after",
+      "title": "Ap\u00e9ry's theorem. Thirty years after",
       "year": "2002",
       "venue": "International Journal of Mathematics and Mathematical Sciences, vol. 2003(4), pp. 175-190",
-      "note": "Survey of Apéry-like proofs and generalizations, including connections to modular forms."
+      "note": "Survey of Ap\u00e9ry-like proofs and generalizations, including connections to modular forms."
     }
   ],
-  "sorries": 7
+  "sorries": 5
 }

--- a/src/data/proofs/erdos-1168/meta.json
+++ b/src/data/proofs/erdos-1168/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-1168",
-  "title": "Erdős Problem #1168: Negative Partition Relation for ℵ_{ω+1}",
+  "title": "Erd\u0151s Problem #1168: Negative Partition Relation for \u2135_{\u03c9+1}",
   "slug": "erdos-1168",
-  "description": "Prove ℵ_{ω+1} ↛ (ℵ_{ω+1}, 3, …, 3)_{ℵ₀}² without GCH. Open problem in set-theoretic combinatorics at the intersection of partition calculus and pcf theory.",
+  "description": "Prove \u2135_{\u03c9+1} \u219b (\u2135_{\u03c9+1}, 3, \u2026, 3)_{\u2135\u2080}\u00b2 without GCH. Open problem in set-theoretic combinatorics at the intersection of partition calculus and pcf theory.",
   "meta": {
     "erdosNumber": 1168,
     "status": "axiomatized",
@@ -24,21 +24,21 @@
     "lineCount": 225,
     "theoremCount": 11,
     "definitionCount": 9,
-    "assumptions": "0 axioms (previous axiom replaced with theorem + stepping-up decomposition). 2 sorries: base_case_under_gch (Erdős-Rado base case), stepping_up (stepping-up lemma). Open conjecture is a def, not an axiom.",
+    "assumptions": "0 axioms (previous axiom replaced with theorem + stepping-up decomposition). 2 sorries: base_case_under_gch (Erd\u0151s-Rado base case), stepping_up (stepping-up lemma). Open conjecture is a def, not an axiom.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-03-28"
   },
   "overview": {
-    "historicalContext": "Partition calculus — the study of the arrow notation κ → (α)²_λ — was systematically developed by Erdős and Rado in their 1956 paper 'A partition calculus in set theory.' The notation κ → (α₀, α₁, …)²_c (due to Erdős-Hajnal-Rado 1965) means: for any c-coloring of 2-element subsets of κ, there exists a color i and a homogeneous set of size αᵢ. The problem of negative partition relations for ℵ_{ω+1} — the successor of the first singular cardinal ℵ_ω — sits at the heart of 'pcf theory' (possible cofinalities), developed by Shelah in the 1970s-1980s. The singular nature of ℵ_ω (it is the supremum of the sequence ℵ_0, ℵ_1, ℵ_2, … with countable cofinality) gives its successor special combinatorial properties. Under GCH, the desired negative partition relation follows from the Erdős-Hajnal-Rado 'stepping-up lemma' applied at ℵ_ω. Proving it in ZFC alone — without assuming GCH — requires the much deeper structural theory of singular cardinals that Shelah pioneered. Shelah's 1992 result that ℵ_ω^{ℵ_0} < ℵ_{ω_4} (provable in ZFC) exemplifies the power of pcf theory for such problems.",
-    "problemStatement": "Prove in ZFC (without assuming GCH) that\n$$\\aleph_{\\omega+1} \\not\\to (\\aleph_{\\omega+1}, 3, 3, \\ldots)^2_{\\aleph_0}$$\nThat is, there exists a coloring $f : [\\aleph_{\\omega+1}]^2 \\to \\omega$ of 2-element subsets using countably many colors such that:\n- Color 0: has no monochromatic set of cardinality $\\aleph_{\\omega+1}$\n- Colors $i \\geq 1$: each has no monochromatic triangle (3-element set)\n\nFormal Lean definition: `¬ partitionRelation aleph_omega_succ targets` where `targets 0 = ℵ_{ω+1}` and `targets (i+1) = 3`.",
-    "proofStrategy": "The file decomposes the known GCH result into a stepping-up framework with two clear subgoals: (1) base_case_under_gch — under GCH, each ℵ_{n+1} has a 2-coloring where color 0 avoids homogeneous sets of size ℵ_{n+1} and color 1 avoids cliques of size n+3; (2) stepping_up — these base colorings combine into a countably-colored partition of ℵ_{ω+1} witnessing the negative relation. The theorem erdos_1168_under_gch is proved by composing these two (sorry) lemmas. Cardinal infrastructure is proved from Mathlib: ℵ_{ω+1} is regular, cf(ℵ_ω) = ℵ₀, ℵ_n < ℵ_ω < ℵ_{ω+1}. The open conjecture (ZFC-only proof) is formalized as a Lean Prop without being asserted.",
+    "historicalContext": "Partition calculus \u2014 the study of the arrow notation \u03ba \u2192 (\u03b1)\u00b2_\u03bb \u2014 was systematically developed by Erd\u0151s and Rado in their 1956 paper 'A partition calculus in set theory.' The notation \u03ba \u2192 (\u03b1\u2080, \u03b1\u2081, \u2026)\u00b2_c (due to Erd\u0151s-Hajnal-Rado 1965) means: for any c-coloring of 2-element subsets of \u03ba, there exists a color i and a homogeneous set of size \u03b1\u1d62. The problem of negative partition relations for \u2135_{\u03c9+1} \u2014 the successor of the first singular cardinal \u2135_\u03c9 \u2014 sits at the heart of 'pcf theory' (possible cofinalities), developed by Shelah in the 1970s-1980s. The singular nature of \u2135_\u03c9 (it is the supremum of the sequence \u2135_0, \u2135_1, \u2135_2, \u2026 with countable cofinality) gives its successor special combinatorial properties. Under GCH, the desired negative partition relation follows from the Erd\u0151s-Hajnal-Rado 'stepping-up lemma' applied at \u2135_\u03c9. Proving it in ZFC alone \u2014 without assuming GCH \u2014 requires the much deeper structural theory of singular cardinals that Shelah pioneered. Shelah's 1992 result that \u2135_\u03c9^{\u2135_0} < \u2135_{\u03c9_4} (provable in ZFC) exemplifies the power of pcf theory for such problems.",
+    "problemStatement": "Prove in ZFC (without assuming GCH) that\n$$\\aleph_{\\omega+1} \\not\\to (\\aleph_{\\omega+1}, 3, 3, \\ldots)^2_{\\aleph_0}$$\nThat is, there exists a coloring $f : [\\aleph_{\\omega+1}]^2 \\to \\omega$ of 2-element subsets using countably many colors such that:\n- Color 0: has no monochromatic set of cardinality $\\aleph_{\\omega+1}$\n- Colors $i \\geq 1$: each has no monochromatic triangle (3-element set)\n\nFormal Lean definition: `\u00ac partitionRelation aleph_omega_succ targets` where `targets 0 = \u2135_{\u03c9+1}` and `targets (i+1) = 3`.",
+    "proofStrategy": "The file decomposes the known GCH result into a stepping-up framework with two clear subgoals: (1) base_case_under_gch \u2014 under GCH, each \u2135_{n+1} has a 2-coloring where color 0 avoids homogeneous sets of size \u2135_{n+1} and color 1 avoids cliques of size n+3; (2) stepping_up \u2014 these base colorings combine into a countably-colored partition of \u2135_{\u03c9+1} witnessing the negative relation. The theorem erdos_1168_under_gch is proved by composing these two (sorry) lemmas. Cardinal infrastructure is proved from Mathlib: \u2135_{\u03c9+1} is regular, cf(\u2135_\u03c9) = \u2135\u2080, \u2135_n < \u2135_\u03c9 < \u2135_{\u03c9+1}. The open conjecture (ZFC-only proof) is formalized as a Lean Prop without being asserted.",
     "keyInsights": [
-      "The arrow notation ℵ_{ω+1} ↛ (ℵ_{ω+1}, 3, 3, …)²_{ℵ₀} packs a complex combinatorial statement: there is a 'wild' countably-colored Ramsey coloring of pairs from ℵ_{ω+1} where no single color achieves its target homogeneous set. Color 0 fails at ℵ_{ω+1} (a large homogeneous set), while colors 1, 2, … fail at triangles (a small target).",
-      "The singularity of ℵ_ω — specifically its cofinality cf(ℵ_ω) = ℵ_0 — is the key feature making ℵ_{ω+1} interesting. Successor cardinals of regular cardinals (like ℵ_2 = (ℵ_1)⁺) behave differently from successors of singular cardinals. The 'singular cardinal hypothesis' (a strengthening of GCH for singular cardinals) is independent of ZFC, making the problem delicate.",
-      "Under GCH, the result uses the stepping-up lemma: if ℵ_ω ↛ (ℵ_ω, 3, …)²_{ℵ_0} holds, then ℵ_{ω+1} ↛ (ℵ_{ω+1}, 3, …)²_{ℵ_0} follows. GCH gives good control over cardinal arithmetic at ℵ_ω. Without GCH, one must instead use pcf theory to control possible values of ℵ_ω^{ℵ_0}.",
-      "pcf theory (Shelah) is the main candidate tool for a ZFC proof. For a set A of regular cardinals, pcf(A) = {cf(∏A/U) : U ultrafilter on A} is the set of possible cofinalities. Shelah proved that |pcf({ℵ_n : n < ω})| < ℵ_ω (in ZFC!), which gives cardinal arithmetic results without GCH. Whether this is enough to prove Problem 1168 in ZFC is the core difficulty.",
-      "The Lean formalization is exemplary: IsHomogeneous uses a symmetric relation (f a b = i for all distinct a, b in S), and partitionRelation is universe-polymorphic (works for any type V with cardinality κ). The five proved theorems cover the basic combinatorial properties without requiring any set-theoretic set theory beyond Mathlib's cardinal library.",
-      "The target function uses Lean's `fun | 0 => ... | _ + 1 => ...` pattern matching to define countably many targets: color 0 targets ℵ_{ω+1} (the big homogeneous set) and all other colors target 3 (triangles). This clean encoding shows that Lean's dependent type system handles the countable-color partition relation naturally."
+      "The arrow notation \u2135_{\u03c9+1} \u219b (\u2135_{\u03c9+1}, 3, 3, \u2026)\u00b2_{\u2135\u2080} packs a complex combinatorial statement: there is a 'wild' countably-colored Ramsey coloring of pairs from \u2135_{\u03c9+1} where no single color achieves its target homogeneous set. Color 0 fails at \u2135_{\u03c9+1} (a large homogeneous set), while colors 1, 2, \u2026 fail at triangles (a small target).",
+      "The singularity of \u2135_\u03c9 \u2014 specifically its cofinality cf(\u2135_\u03c9) = \u2135_0 \u2014 is the key feature making \u2135_{\u03c9+1} interesting. Successor cardinals of regular cardinals (like \u2135_2 = (\u2135_1)\u207a) behave differently from successors of singular cardinals. The 'singular cardinal hypothesis' (a strengthening of GCH for singular cardinals) is independent of ZFC, making the problem delicate.",
+      "Under GCH, the result uses the stepping-up lemma: if \u2135_\u03c9 \u219b (\u2135_\u03c9, 3, \u2026)\u00b2_{\u2135_0} holds, then \u2135_{\u03c9+1} \u219b (\u2135_{\u03c9+1}, 3, \u2026)\u00b2_{\u2135_0} follows. GCH gives good control over cardinal arithmetic at \u2135_\u03c9. Without GCH, one must instead use pcf theory to control possible values of \u2135_\u03c9^{\u2135_0}.",
+      "pcf theory (Shelah) is the main candidate tool for a ZFC proof. For a set A of regular cardinals, pcf(A) = {cf(\u220fA/U) : U ultrafilter on A} is the set of possible cofinalities. Shelah proved that |pcf({\u2135_n : n < \u03c9})| < \u2135_\u03c9 (in ZFC!), which gives cardinal arithmetic results without GCH. Whether this is enough to prove Problem 1168 in ZFC is the core difficulty.",
+      "The Lean formalization is exemplary: IsHomogeneous uses a symmetric relation (f a b = i for all distinct a, b in S), and partitionRelation is universe-polymorphic (works for any type V with cardinality \u03ba). The five proved theorems cover the basic combinatorial properties without requiring any set-theoretic set theory beyond Mathlib's cardinal library.",
+      "The target function uses Lean's `fun | 0 => ... | _ + 1 => ...` pattern matching to define countably many targets: color 0 targets \u2135_{\u03c9+1} (the big homogeneous set) and all other colors target 3 (triangles). This clean encoding shows that Lean's dependent type system handles the countable-color partition relation naturally."
     ]
   },
   "sections": [
@@ -47,14 +47,14 @@
       "title": "Problem Statement and Context",
       "startLine": 1,
       "endLine": 34,
-      "summary": "Docstring stating Erdős Problem #1168: prove ℵ_{ω+1} ↛ (ℵ_{ω+1}, 3, …, 3)²_{ℵ₀} in ZFC without GCH. Provides context: GCH case known via Erdős-Hajnal-Rado, ZFC case requires pcf theory (Shelah)."
+      "summary": "Docstring stating Erd\u0151s Problem #1168: prove \u2135_{\u03c9+1} \u219b (\u2135_{\u03c9+1}, 3, \u2026, 3)\u00b2_{\u2135\u2080} in ZFC without GCH. Provides context: GCH case known via Erd\u0151s-Hajnal-Rado, ZFC case requires pcf theory (Shelah)."
     },
     {
       "id": "cardinals",
       "title": "Part I: Cardinal Infrastructure",
       "startLine": 37,
       "endLine": 78,
-      "summary": "Defines aleph_omega and aleph_omega_succ. Proves 6 cardinal facts from Mathlib: ℵ_{ω+1} = aleph(succ ω), ℵ_{ω+1} is regular, cf(ℵ_ω) = ℵ₀, ℵ_ω < ℵ_{ω+1}, ℵ₀ < ℵ_ω, ℵ_n < ℵ_ω for all n."
+      "summary": "Defines aleph_omega and aleph_omega_succ. Proves 6 cardinal facts from Mathlib: \u2135_{\u03c9+1} = aleph(succ \u03c9), \u2135_{\u03c9+1} is regular, cf(\u2135_\u03c9) = \u2135\u2080, \u2135_\u03c9 < \u2135_{\u03c9+1}, \u2135\u2080 < \u2135_\u03c9, \u2135_n < \u2135_\u03c9 for all n."
     },
     {
       "id": "partition-framework",
@@ -68,7 +68,7 @@
       "title": "Part IV: GCH Stepping-Up Framework",
       "startLine": 120,
       "endLine": 189,
-      "summary": "Decomposes the GCH proof into base_case_under_gch (sorry: Erdős-Rado for each ℵ_{n+1}), stepping_up (sorry: combines base colorings into ℵ₀-coloring of ℵ_{ω+1}), and erdos_1168_under_gch (proved by composition). Also defines GCH_at, GCH, and negPartition2."
+      "summary": "Decomposes the GCH proof into base_case_under_gch (sorry: Erd\u0151s-Rado for each \u2135_{n+1}), stepping_up (sorry: combines base colorings into \u2135\u2080-coloring of \u2135_{\u03c9+1}), and erdos_1168_under_gch (proved by composition). Also defines GCH_at, GCH, and negPartition2."
     },
     {
       "id": "structural-theorems",
@@ -79,20 +79,20 @@
     }
   ],
   "conclusion": {
-    "summary": "This file provides a clean Lean 4 formalization of Erdős Problem #1168: the open question of whether ℵ_{ω+1} ↛ (ℵ_{ω+1}, 3, 3, …)²_{ℵ₀} holds in ZFC. The GCH case is axiomatized (1 axiom), the open conjecture is defined as a Lean Prop, and five structural theorems are proved. The file correctly represents the state of the art: the ZFC case is open.",
-    "implications": "A ZFC proof of Erdős 1168 would be a significant advance in set-theoretic combinatorics, demonstrating that pcf theory can resolve partition relation questions that previously required GCH. It would also provide a non-trivial theorem in Lean about large cardinals (at the level of ℵ_ω and its successor), extending Mathlib's cardinal library into research territory. Such a formalization would likely require encoding Shelah's pcf theory — a substantial Lean project in its own right.",
+    "summary": "This file provides a clean Lean 4 formalization of Erd\u0151s Problem #1168: the open question of whether \u2135_{\u03c9+1} \u219b (\u2135_{\u03c9+1}, 3, 3, \u2026)\u00b2_{\u2135\u2080} holds in ZFC. The GCH case is axiomatized (1 axiom), the open conjecture is defined as a Lean Prop, and five structural theorems are proved. The file correctly represents the state of the art: the ZFC case is open.",
+    "implications": "A ZFC proof of Erd\u0151s 1168 would be a significant advance in set-theoretic combinatorics, demonstrating that pcf theory can resolve partition relation questions that previously required GCH. It would also provide a non-trivial theorem in Lean about large cardinals (at the level of \u2135_\u03c9 and its successor), extending Mathlib's cardinal library into research territory. Such a formalization would likely require encoding Shelah's pcf theory \u2014 a substantial Lean project in its own right.",
     "openQuestions": [
-      "Can pcf theory be encoded in Lean 4 using Mathlib's existing ordinal and cardinal infrastructure? The key pcf result needed is |pcf({ℵ_n : n < ω})| < ℵ_ω — can this be proved in Lean from ZFC?",
-      "Is there a simpler combinatorial proof of Erdős 1168 not going through pcf theory, perhaps using a direct Ramsey-theoretic construction of the required coloring?",
-      "Does the Lean formulation of partitionRelation correctly capture the set-theoretic partition relation κ → (α₀, α₁, …)²_c? In particular, does the use of a Lean type V with #V = κ accurately model the ordinal-based version?",
-      "Can the stepping-up lemma (used in the GCH proof) be formalized in Lean 4 using Mathlib's cardinal arithmetic, and would it suffice to prove Erdős 1168 under a weaker assumption than full GCH?"
+      "Can pcf theory be encoded in Lean 4 using Mathlib's existing ordinal and cardinal infrastructure? The key pcf result needed is |pcf({\u2135_n : n < \u03c9})| < \u2135_\u03c9 \u2014 can this be proved in Lean from ZFC?",
+      "Is there a simpler combinatorial proof of Erd\u0151s 1168 not going through pcf theory, perhaps using a direct Ramsey-theoretic construction of the required coloring?",
+      "Does the Lean formulation of partitionRelation correctly capture the set-theoretic partition relation \u03ba \u2192 (\u03b1\u2080, \u03b1\u2081, \u2026)\u00b2_c? In particular, does the use of a Lean type V with #V = \u03ba accurately model the ordinal-based version?",
+      "Can the stepping-up lemma (used in the GCH proof) be formalized in Lean 4 using Mathlib's cardinal arithmetic, and would it suffice to prove Erd\u0151s 1168 under a weaker assumption than full GCH?"
     ]
   },
   "leanFile": {
     "lineCount": 255,
     "axiomCount": 1,
     "path": "Proofs/Erdos1168Problem.lean",
-    "sorries": 0
+    "sorries": 2
   },
   "sorries": 2
 }

--- a/src/data/proofs/erdos-695/meta.json
+++ b/src/data/proofs/erdos-695/meta.json
@@ -187,7 +187,7 @@
     "theoremCount": 8,
     "definitionCount": 10,
     "path": "Proofs/Erdos695Problem.lean",
-    "sorries": 3
+    "sorries": 1
   },
   "sorries": 1
 }

--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -242,7 +242,7 @@
       }
     ],
     "path": "Proofs/ShapleyFolkman.lean",
-    "sorries": 3
+    "sorries": 1
   },
   "mainTheorems": [
     {


### PR DESCRIPTION
## Fix

Two related gallery integrity fixes:

### 1. Meta.json sorry count corrections (5 files)

Cross-referenced `leanFile.sorries`, top-level `sorries`, and `meta.sorries` fields against actual Lean source files. Fixed inconsistencies:

| Proof | Before | After | Field |
|-------|--------|-------|-------|
| erdos-402 | top=2 | top=1 | top-level |
| erdos-1168 | leanFile=0 | leanFile=2 | leanFile |
| shapley-folkman | leanFile=3 | leanFile=1 | leanFile |
| erdos-695 | leanFile=3 | leanFile=1 | leanFile |
| basel-problem-oq-01-oq-01-oq-02 | top=7, leanFile=3 | top=5, leanFile=5 | both |

### 2. Aristotle job tracking (research/aristotle-jobs.json)

Marked 25 completed jobs as `resolved_manually`. All had outcome "X sorries remaining" with no sorry reduction — no integration was needed. This keeps the tracking file clean and accurate.

## Evidence

**Before**: Sorry counts in meta.json inconsistent across fields and with actual Lean source.
**After**: All three sorry count fields aligned with actual sorry count in Lean files.

---
Automated fix by lean-mechanic agent.