### PR TITLE
Fix: sync leanFile.sorries for 37 gallery proofs (stale counts)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -303,7 +303,7 @@
     "lemmaCount": 0,
     "defCount": 3,
     "path": "Proofs/AmgmInequalityOQ02.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/angle-trisection-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02/meta.json
@@ -315,7 +315,7 @@
       }
     ],
     "path": "Proofs/AngleTrisectionOQ02.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -309,6 +309,6 @@
       }
     ],
     "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
-    "sorries": 1
+    "sorries": 0
   }
 }

--- a/src/data/proofs/bezout-identity-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01/meta.json
@@ -80,7 +80,7 @@
     "theoremCount": 10,
     "definitionCount": 4,
     "path": "Proofs/BezoutIdentityOQ01.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -686,7 +686,7 @@
     "theoremCount": 250,
     "definitionCount": 143,
     "path": "Proofs/BirchSwinnertonDyer.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
@@ -145,7 +145,7 @@
     "namespace": "BirthdayThreshold3",
     "lineCount": 420,
     "axiomCount": 1,
-    "sorries": 1,
+    "sorries": 0,
     "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
     "theoremCount": 19,
     "definitionCount": 3

--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01/meta.json
@@ -171,7 +171,7 @@
     "theoremCount": 11,
     "definitionCount": 6,
     "path": "Proofs/CantorDiagonalizationOQ03OQ01.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
@@ -202,7 +202,7 @@
     "theoremCount": 5,
     "definitionCount": 2,
     "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cevas-theorem-oq-01/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-01/meta.json
@@ -73,7 +73,7 @@
     "theoremCount": 39,
     "definitionCount": 20,
     "path": "Proofs/CevasTheoremOQ01.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/chinese-remainder-non-coprime-oq-03/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-03/meta.json
@@ -69,7 +69,7 @@
     "theoremCount": 13,
     "definitionCount": 0,
     "path": "Proofs/ChineseRemainderNonCoprimeOQ03.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/cramers-rule-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-03/meta.json
@@ -165,6 +165,6 @@
       }
     ],
     "path": "Proofs/CramersRuleOQ01OQ03.lean",
-    "sorries": 1
+    "sorries": 0
   }
 }

--- a/src/data/proofs/derangements-oq-02/meta.json
+++ b/src/data/proofs/derangements-oq-02/meta.json
@@ -180,7 +180,7 @@
     "theoremCount": 10,
     "definitionCount": 1,
     "path": "Proofs/DerangementsOQ02.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/descartes-rule-of-signs-oq-01/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-01/meta.json
@@ -168,7 +168,7 @@
     "theoremCount": 48,
     "definitionCount": 1,
     "path": "Proofs/DescartesRuleOfSignsOQ01.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/dirichlets-theorem-oq-02-oq-01/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02-oq-01/meta.json
@@ -212,6 +212,6 @@
     "lineCount": 366,
     "axiomCount": 4,
     "path": "Proofs/DirichletsTheoremOQ02OQ01.lean",
-    "sorries": 1
+    "sorries": 0
   }
 }

--- a/src/data/proofs/dirichlets-theorem-oq-02/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-02/meta.json
@@ -159,6 +159,6 @@
     "lineCount": 101,
     "path": "Proofs/DirichletsTheoremOQ02.lean",
     "axiomCount": 0,
-    "sorries": 1
+    "sorries": 0
   }
 }

--- a/src/data/proofs/dirichlets-theorem-oq-03/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-03/meta.json
@@ -79,7 +79,7 @@
       }
     ],
     "path": "Proofs/DirichletsTheoremOQ03.lean",
-    "sorries": 3
+    "sorries": 2
   },
   "overview": {
     "historicalContext": "Dirichlet proved in 1837 that there are infinitely many primes p ≡ a (mod q) for any coprime pair (a, q). The *quantitative* question — how large is the *first* such prime p(a, q)? — was answered by Linnik in 1944: p(a, q) ≤ c · q^L for absolute constants c and L. This L is the 'Linnik constant'. The history of bounding L spans decades: Pan Cheng-tung (1957) gave L ≤ 10000, Elliott-Halberstam (1966) reduced it to L ≤ 40, then Jutila (L ≤ 20), Chen (L ≤ 13.5), Wang (L ≤ 8), Heath-Brown (L ≤ 5.5, 1992), and finally Xylouris (L ≤ 5, 2011). Under the Generalized Riemann Hypothesis, L ≤ 2 + ε for any ε > 0. The unconditional conjecture is L = 1 + ε, or equivalently, linnikConstant = 1.",

--- a/src/data/proofs/erdos-1006-oq-01/meta.json
+++ b/src/data/proofs/erdos-1006-oq-01/meta.json
@@ -118,7 +118,7 @@
     "theoremCount": 6,
     "definitionCount": 0,
     "path": "Proofs/Erdos1006OQ01.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1006-oq-02/meta.json
+++ b/src/data/proofs/erdos-1006-oq-02/meta.json
@@ -180,6 +180,6 @@
     "theoremCount": 17,
     "definitionCount": 8,
     "path": "Proofs/Erdos1006OQ02.lean",
-    "sorries": 1
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-103-oq-01/meta.json
+++ b/src/data/proofs/erdos-103-oq-01/meta.json
@@ -236,6 +236,6 @@
     "theoremCount": 23,
     "definitionCount": 14,
     "path": "Proofs/Erdos103OQ01.lean",
-    "sorries": 2
+    "sorries": 0
   }
 }

--- a/src/data/proofs/erdos-1084-oq-01/meta.json
+++ b/src/data/proofs/erdos-1084-oq-01/meta.json
@@ -164,7 +164,7 @@
     "sorryTheorems": 0,
     "definitionCount": 5,
     "path": "Proofs/Erdos1084OQ01.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/erdos-1138-oq-03/meta.json
+++ b/src/data/proofs/erdos-1138-oq-03/meta.json
@@ -180,7 +180,7 @@
     "theoremCount": 12,
     "definitionCount": 2,
     "path": "Proofs/Erdos1138OQ03.lean",
-    "sorries": 2
+    "sorries": 0
   },
   "references": [
     {

--- a/src/data/proofs/erdos-138/meta.json
+++ b/src/data/proofs/erdos-138/meta.json
@@ -133,7 +133,7 @@
     "theoremCount": 3,
     "definitionCount": 8,
     "path": "Proofs/Stubs/Erdos138Problem.lean",
-    "sorries": 5
+    "sorries": 4
   },
   "references": [
     {

--- a/src/data/proofs/euler-identity-oq-01-oq-01/meta.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-01/meta.json
@@ -218,7 +218,7 @@
       }
     ],
     "path": "Proofs/EulerIdentityOQ01OQ01.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/fair-games-theorem-oq-03/meta.json
+++ b/src/data/proofs/fair-games-theorem-oq-03/meta.json
@@ -36,7 +36,7 @@
     "theoremCount": 9,
     "definitionCount": 0,
     "path": "Proofs/FairGamesTheoremOQ03.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/fourier-series-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-incomplete-01/meta.json
@@ -29,7 +29,7 @@
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 0,
-    "sorries": 1
+    "sorries": 0
   },
   "meta": {
     "author": "Classical (Bernstein, Zygmund, Sobolev)",

--- a/src/data/proofs/hodge-conjecture/meta.json
+++ b/src/data/proofs/hodge-conjecture/meta.json
@@ -291,7 +291,7 @@
       "DirectSum"
     ],
     "path": "Proofs/HodgeConjecture.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -313,7 +313,7 @@
     "lineCount": 723,
     "path": "Proofs/InverseGaloisOQ01.lean",
     "axiomCount": 1,
-    "sorries": 1
+    "sorries": 2
   },
   "sorries": 1
 }

--- a/src/data/proofs/konigsberg-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-02/meta.json
@@ -68,7 +68,7 @@
     "theoremCount": 35,
     "definitionCount": 8,
     "path": "Proofs/KonigsbergOQ02.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/riemann-hypothesis/meta.json
+++ b/src/data/proofs/riemann-hypothesis/meta.json
@@ -323,7 +323,7 @@
     "theoremCount": 363,
     "definitionCount": 38,
     "path": "Proofs/RiemannHypothesis.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/schauder-fixed-point-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-01/meta.json
@@ -181,6 +181,6 @@
       "Finset"
     ],
     "path": "Proofs/SchauderFixedPointOQ01.lean",
-    "sorries": 2
+    "sorries": 0
   }
 }

--- a/src/data/proofs/schauder-fixed-point/meta.json
+++ b/src/data/proofs/schauder-fixed-point/meta.json
@@ -245,7 +245,7 @@
       "Filter"
     ],
     "path": "Proofs/SchauderFixedPoint.lean",
-    "sorries": 2
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
@@ -149,7 +149,7 @@
     "namespace": "FanoFromConditionalEntropy",
     "lineCount": 142,
     "axiomCount": 1,
-    "sorries": 1,
+    "sorries": 0,
     "path": "Proofs/ShannonChannelCodingOQ02OQ01.lean",
     "theoremCount": 3,
     "definitionCount": 0

--- a/src/data/proofs/shannon-entropy-oq-01/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-01/meta.json
@@ -119,6 +119,6 @@
     "theoremCount": 14,
     "definitionCount": 3,
     "path": "Proofs/ShannonEntropyOQ01.lean",
-    "sorries": 1
+    "sorries": 0
   }
 }

--- a/src/data/proofs/sum-of-divisors/meta.json
+++ b/src/data/proofs/sum-of-divisors/meta.json
@@ -64,7 +64,7 @@
     "namespace": "SumOfDivisors",
     "lineCount": 549,
     "axiomCount": 0,
-    "sorries": 1,
+    "sorries": 0,
     "theoremCount": 81,
     "definitionCount": 4,
     "path": "Proofs/SumOfDivisors.lean"

--- a/src/data/proofs/taylor-theorem-oq-02/meta.json
+++ b/src/data/proofs/taylor-theorem-oq-02/meta.json
@@ -176,7 +176,7 @@
       }
     ],
     "path": "Proofs/TaylorTheoremOQ02.lean",
-    "sorries": 3
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/wilsons-theorem-oq-01/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-01/meta.json
@@ -73,7 +73,7 @@
     "theoremCount": 35,
     "definitionCount": 9,
     "path": "Proofs/WilsonsTheoremOQ01.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {

--- a/src/data/proofs/wilsons-theorem-oq-02/meta.json
+++ b/src/data/proofs/wilsons-theorem-oq-02/meta.json
@@ -72,7 +72,7 @@
     "theoremCount": 21,
     "definitionCount": 8,
     "path": "Proofs/WilsonsTheoremOQ02.lean",
-    "sorries": 3
+    "sorries": 0
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Batch correction of `leanFile.sorries` across 37 gallery proof `meta.json` files. In each case, the actual Lean source file had fewer sorry tactics than recorded in `leanFile.sorries`. All occurrences of "sorry" in these files were in comments/documentation, not actual sorry tactics.

## Summary

- **35 proofs**: corrected to 0 (were 1-3)
- **dirichlets-theorem-oq-03**: 3→2 (has 2 actual sorries)
- **erdos-138**: 5→4 (has 4 actual sorries)
- **inverse-galois-oq-01**: 1→2 (had undercounted — actually 2 sorries)

## Methodology

Cross-referenced `leanFile.sorries` against actual sorry tactic count using comment-aware parsing (excludes `--` line comments and `/-...-/` block comments). Only `leanFile.sorries` was updated; `meta.sorries`, `status`, and `badge` were already correct in all cases.

**Before**: leanFile.sorries overstated (or understated for inverse-galois-oq-01).
**After**: leanFile.sorries matches actual sorry tactic count in the Lean file.

---
Automated fix by lean-mechanic agent.