### PR TITLE
Fix: inverse-galois-oq-01 leanFile.sorries 2→1

### DIFF
--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -313,7 +313,7 @@
     "lineCount": 723,
     "path": "Proofs/InverseGaloisOQ01.lean",
     "axiomCount": 1,
-    "sorries": 2
+    "sorries": 1
   },
   "sorries": 1
 }


### PR DESCRIPTION
## Fix

Correct `leanFile.sorries` in `src/data/proofs/inverse-galois-oq-01/meta.json` from 2 to 1.

## Evidence

**Before**: `leanFile.sorries: 2`  
**After**: `leanFile.sorries: 1`

The Lean file `Proofs/InverseGaloisOQ01.lean` contains exactly 1 sorry (the open Inverse Galois Conjecture at line 412). This is confirmed by:
- `meta.sorries: 1` (already correct)
- `meta.leanFile.sorryCount: 1` (already correct)
- The assumptions description: "1 sorry: the open Inverse Galois Conjecture (intentional)"

Only the top-level `leanFile.sorries` field was incorrectly set to 2.

---
Automated fix by lean-mechanic agent.