### PR TITLE
Fix: sync leanFile.axiomCount to 0 for 2 fully-verified proofs

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02/meta.json
@@ -69,7 +69,7 @@
   "leanFile": {
     "namespace": "MultiBallot",
     "lineCount": 1047,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "theoremCount": 37,
     "definitionCount": 18,
     "path": "Proofs/BallotProblemOQ01OQ02.lean",

--- a/src/data/proofs/erdos-875/meta.json
+++ b/src/data/proofs/erdos-875/meta.json
@@ -147,8 +147,8 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 142,
-    "axiomCount": 4,
+    "lineCount": 212,
+    "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 7
   },


### PR DESCRIPTION
## Fix

Update stale `leanFile.axiomCount` fields in 2 gallery meta.json files where all axioms have been eliminated but the leanFile section was not updated.

## Evidence

**ballot-problem-oq-01-oq-02**:
- Before: `leanFile.axiomCount: 1`
- After: `leanFile.axiomCount: 0`
- Evidence: `meta.axiomCount: 0`, assumptions say "None. All axioms eliminated: fiber_card_uniform proved via fiberSwap bijection..."

**erdos-875**:
- Before: `leanFile.axiomCount: 4`, `leanFile.lineCount: 142`
- After: `leanFile.axiomCount: 0`, `leanFile.lineCount: 212`
- Evidence: `meta.axiomCount: 0`, assumptions say "No axioms, no sorries. All theorems fully proved..."

Both proofs correctly claim `status: "verified"` — the leanFile section was simply stale.

---
Automated fix by lean-mechanic agent.