### PR TITLE
Fix: sync stale leanFile.lineCount and axiomCount for 2 gallery proofs

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-04-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-04-oq-03/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 306,
+    "lineCount": 190,
     "assumptions": "0 sorries, 0 axioms. Fully machine-checked by Aristotle.",
     "originalContributions": [
       "Complete q-analog infrastructure: qNat, qFactorial, gaussianBinomial",
@@ -112,7 +112,7 @@
       "BigOperators"
     ],
     "namespace": "BinomialTheoremOQ04OQ03",
-    "lineCount": 306,
+    "lineCount": 190,
     "axiomCount": 0,
     "theoremCount": 17,
     "substantiveTheoremCount": 11,


### PR DESCRIPTION
## Fix

Update stale `leanFile.lineCount` and `leanFile.axiomCount` fields in 2 gallery meta.json files.

## Evidence

**feuerbachs-theorem-oq-02**:
- `leanFile.lineCount`: 350 → 665 (Lean file grew by 315 lines with recent proof additions)
- `leanFile.axiomCount`: 5 → 3 (2 axioms were proved; `meta.axiomCount` was already correctly 3)
- `meta.lineCount`: 350 → 665

**binomial-theorem-oq-04-oq-03**:
- `leanFile.lineCount`: 306 → 190 (file was refactored/trimmed by 116 lines)
- `meta.lineCount`: 306 → 190
- `axiomCount` and `sorries` remain 0 (correct, Aristotle-verified)

---
Automated fix by lean-mechanic agent.