### PR TITLE
Fix: erdos-1168 leanFile.axiomCount 1→0 (axiom replaced with theorem)

### DIFF
--- a/src/data/proofs/erdos-1168/meta.json
+++ b/src/data/proofs/erdos-1168/meta.json
@@ -90,7 +90,7 @@
   },
   "leanFile": {
     "lineCount": 255,
-    "axiomCount": 1,
+    "axiomCount": 0,
     "path": "Proofs/Erdos1168Problem.lean",
     "sorries": 2
   },


### PR DESCRIPTION
## Fix

Update `leanFile.axiomCount` in `src/data/proofs/erdos-1168/meta.json` from 1 to 0.

## Evidence

**Before**: `leanFile.axiomCount: 1`  
**After**: `leanFile.axiomCount: 0`

The `meta.axiomCount` was already correctly 0 and `meta.assumptions` states: "0 axioms (previous axiom replaced with theorem + stepping-up decomposition)." The `leanFile` section was stale from before the axiom was replaced. Lean file `Proofs/Erdos1168Problem.lean` has 0 `axiom` declarations.

---
Automated fix by lean-mechanic agent.