### PR TITLE
Fix: sync leanFile.sorries to meta.sorries for 2 proofs (double-sorry lines)

### DIFF
--- a/src/data/proofs/dirichlets-theorem-oq-03/meta.json
+++ b/src/data/proofs/dirichlets-theorem-oq-03/meta.json
@@ -79,7 +79,7 @@
       }
     ],
     "path": "Proofs/DirichletsTheoremOQ03.lean",
-    "sorries": 2
+    "sorries": 3
   },
   "overview": {
     "historicalContext": "Dirichlet proved in 1837 that there are infinitely many primes p ≡ a (mod q) for any coprime pair (a, q). The *quantitative* question — how large is the *first* such prime p(a, q)? — was answered by Linnik in 1944: p(a, q) ≤ c · q^L for absolute constants c and L. This L is the 'Linnik constant'. The history of bounding L spans decades: Pan Cheng-tung (1957) gave L ≤ 10000, Elliott-Halberstam (1966) reduced it to L ≤ 40, then Jutila (L ≤ 20), Chen (L ≤ 13.5), Wang (L ≤ 8), Heath-Brown (L ≤ 5.5, 1992), and finally Xylouris (L ≤ 5, 2011). Under the Generalized Riemann Hypothesis, L ≤ 2 + ε for any ε > 0. The unconditional conjecture is L = 1 + ε, or equivalently, linnikConstant = 1.",

--- a/src/data/proofs/erdos-138/meta.json
+++ b/src/data/proofs/erdos-138/meta.json
@@ -133,7 +133,7 @@
     "theoremCount": 3,
     "definitionCount": 8,
     "path": "Proofs/Stubs/Erdos138Problem.lean",
-    "sorries": 4
+    "sorries": 5
   },
   "references": [
     {


### PR DESCRIPTION
## Fix

Sync `leanFile.sorries` to match `meta.sorries` for 2 gallery proofs where the leanFile section was set to line count rather than sorry token count.

## Evidence

**dirichlets-theorem-oq-03**:
- Before: `leanFile.sorries: 2`
- After: `leanFile.sorries: 3`
- Reason: Line 34 contains `⟨sorry, sorry⟩ : ∃ p, p.Prime ∧ p ≡ a [MOD q]` — two sorry terms on one line. `meta.sorries: 3` was correct.

**erdos-138**:
- Before: `leanFile.sorries: 4`
- After: `leanFile.sorries: 5`
- Reason: Line 46 contains two `by sorry` expressions. `meta.sorries: 5` was correct.

In both cases the `meta.sorries` field already correctly counted sorry proof obligations (tokens). The `leanFile.sorries` was set to the number of sorry-containing lines by a prior sync script.

---
Automated fix by lean-mechanic agent.