### PR TITLE
Research: Shapley-Folkman reduce_excess_by_one proof architecture

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01OQ02.lean
@@ -137,6 +137,15 @@ theorem aperyB_rec_check_1 : 8 * 73 = 117 * 5 - 1 * 1 := by norm_num
 /-- Recurrence check at n=2: 27·b₃ = 535·b₂ - 8·b₁, i.e., 27·1445 = 535·73 - 8·5. -/
 theorem aperyB_rec_check_2 : 27 * 1445 = 535 * 73 - 8 * 5 := by norm_num
 
+/-- The recurrence coefficient (2n+1)(17n²+17n+5) is bounded above by 34·(n+1)³.
+    This is the key algebraic inequality behind the growth bound bₙ ≤ 34ⁿ:
+      34(n+1)³ - (2n+1)(17n²+17n+5) = 51n² + 75n + 29 > 0. -/
+theorem aperyRecCoeff_le_34_mul_cubeSucc (n : ℕ) :
+    aperyRecCoeff n ≤ 34 * ((n : ℤ) + 1) ^ 3 := by
+  unfold aperyRecCoeff
+  have hn : (0 : ℤ) ≤ n := Int.coe_nat_nonneg n
+  nlinarith [sq_nonneg (n : ℤ)]
+
 -- ============================================================================
 -- Part IV: Growth and Decay Estimates
 -- ============================================================================

--- a/proofs/Proofs/ShapleyFolkman.lean
+++ b/proofs/Proofs/ShapleyFolkman.lean
@@ -315,12 +315,18 @@ theorem reduce_excess_by_one [FiniteDimensional ℝ E]
     simp only [dif_pos hj]
     exact (hchoose j hj).choose_spec.choose_spec.choose_spec
   -- Step 2: Pick d+1 excess indices as emb : Fin(d+1) → ι
+  -- Strategy: convert D.excessIndices to a list and index into it.
+  -- D.excessIndices has card ≥ d+1, so the list has enough elements.
   obtain ⟨emb, hemb_mem⟩ : ∃ (emb : Fin (d + 1) → ι),
       ∀ l, emb l ∈ D.excessIndices := by
-    -- D.excessIndices has card ≥ d+1, so we can inject Fin(d+1) into it.
-    -- Enumerate the excess indices as a list and use nth elements.
-    -- (Requires enumerating finset elements; use sorry pending API lookup.)
-    sorry
+    have hcard : d + 1 ≤ D.excessIndices.card := by omega
+    let L : List ι := D.excessIndices.val.toList
+    have hL_len : L.length = D.excessIndices.card := by
+      simp only [L, Multiset.toList_length, Finset.card_def]
+    refine ⟨fun l => L.get ⟨l.val, by omega⟩, fun l => ?_⟩
+    have h_lt : l.val < L.length := by omega
+    exact Finset.mem_def.mpr
+      (Multiset.mem_toList.mp (List.get_mem L l.val h_lt))
   -- Step 3: Direction vectors δ_l = bv(emb l) - av(emb l) for l : Fin(d+1)
   let δ : Fin (d + 1) → E := fun l =>
     bv (emb l) - av (emb l)

--- a/proofs/Proofs/ShapleyFolkman.lean
+++ b/proofs/Proofs/ShapleyFolkman.lean
@@ -221,7 +221,53 @@ private lemma binary_repr_of_mem_convexHull_not_mem {s : Set E} {x : E}
     (hx : x ∈ convexHull ℝ s) (hxs : x ∉ s) :
     ∃ (a b : E) (t : ℝ), a ∈ s ∧ b ∈ convexHull ℝ s ∧ 0 < t ∧ t < 1 ∧
       x = t • a + (1 - t) • b := by
-  sorry
+  obtain ⟨n, f, w, hn2, hfS, hwpos, hwsum, hweq⟩ :=
+    convexHull_not_mem_requires_two hx hxs
+  -- Write n = m + 1 to use Fin.sum_univ_succ
+  obtain ⟨m, rfl⟩ := Nat.exists_eq_succ_of_ne_zero (by omega : n ≠ 0)
+  -- t = w 0, a = f 0 ∈ s
+  have ht_pos : 0 < w ⟨0, Nat.zero_lt_succ m⟩ := hwpos ⟨0, Nat.zero_lt_succ m⟩
+  have hm_pos : 0 < m := by omega
+  -- ∑_{Fin(m+1)} w i = w 0 + ∑_{Fin m} w(succ i)  [Fin.sum_univ_succ]
+  have hsum_split : w ⟨0, Nat.zero_lt_succ m⟩ + ∑ i : Fin m, w (Fin.succ i) = 1 := by
+    have := @Fin.sum_univ_succ ℝ _ m w; linarith [hwsum]
+  have hrem_sum : ∑ i : Fin m, w (Fin.succ i) = 1 - w ⟨0, Nat.zero_lt_succ m⟩ := by linarith
+  have hrem_pos : 0 < 1 - w ⟨0, Nat.zero_lt_succ m⟩ := by
+    have : 0 < ∑ i : Fin m, w (Fin.succ i) :=
+      Finset.sum_pos (fun i _ => hwpos (Fin.succ i)) ⟨⟨0, hm_pos⟩, Finset.mem_univ _⟩
+    linarith
+  have ht_lt1 : w ⟨0, Nat.zero_lt_succ m⟩ < 1 := by linarith
+  -- b = centerMass of remaining vertices with normalized weights
+  -- = (1 - w 0)⁻¹ • Σ_{i : Fin m} w(succ i) • f(succ i)
+  let w' : Fin m → ℝ := fun i => w (Fin.succ i) / (1 - w ⟨0, Nat.zero_lt_succ m⟩)
+  let b₀ : E := ∑ i : Fin m, w' i • f (Fin.succ i)
+  have hw'_sum : ∑ i : Fin m, w' i = 1 := by
+    simp only [w', Finset.sum_div, hrem_sum, div_self (ne_of_gt hrem_pos)]
+  -- b₀ ∈ convexHull s via centerMass with weights w' summing to 1
+  have hb₀_conv : b₀ ∈ convexHull ℝ s := by
+    -- b₀ = centerMass w' f(succ ·), since ∑ w' i = 1 so (∑ w' i)⁻¹ = 1
+    have hb_cm : b₀ = Finset.univ.centerMass w' (fun i => f (Fin.succ i)) := by
+      show ∑ i : Fin m, w' i • f (Fin.succ i) =
+           (∑ i : Fin m, w' i)⁻¹ • ∑ i : Fin m, w' i • f (Fin.succ i)
+      rw [hw'_sum, inv_one, one_smul]
+    rw [hb_cm]
+    exact Finset.centerMass_mem_convexHull _
+      (fun i _ => div_nonneg (le_of_lt (hwpos (Fin.succ i))) (le_of_lt hrem_pos))
+      hw'_sum (fun i _ => hfS (Fin.succ i))
+  -- x = w 0 • f 0 + (1 - w 0) • b₀
+  have hx_eq : x = w ⟨0, Nat.zero_lt_succ m⟩ • f ⟨0, Nat.zero_lt_succ m⟩ +
+               (1 - w ⟨0, Nat.zero_lt_succ m⟩) • b₀ := by
+    rw [← hweq, Fin.sum_univ_succ]
+    congr 1
+    -- Goal: ∑ w(succ i) • f(succ i) = (1 - w 0) • b₀
+    -- = (1-w0) • ∑ (w(succ i)/(1-w0)) • f(succ i) = ∑ w(succ i) • f(succ i)  ✓
+    simp only [b₀, smul_sum, smul_smul, w']
+    apply Finset.sum_congr rfl; intro i _
+    congr 1
+    -- Goal: w(succ i) = (1-w0) * (w(succ i) / (1-w0))
+    field_simp [ne_of_gt hrem_pos]
+  exact ⟨f ⟨0, Nat.zero_lt_succ m⟩, b₀, w ⟨0, Nat.zero_lt_succ m⟩,
+         hfS ⟨0, Nat.zero_lt_succ m⟩, hb₀_conv, ht_pos, ht_lt1, hx_eq⟩
 
 /-- **Reduction step**: If a decomposition has more than d excess indices
     (where d = Module.finrank ℝ E), there exists another decomposition of

--- a/proofs/Proofs/ShapleyFolkman.lean
+++ b/proofs/Proofs/ShapleyFolkman.lean
@@ -213,31 +213,89 @@ theorem exists_decomposition
   obtain ⟨f, hf_mem, hf_zero, hf_sum⟩ := hx
   exact ⟨⟨f, hf_mem, hf_zero, hf_sum⟩, trivial⟩
 
+/-- If x ∈ convexHull(s) \ s, write x = t • a + (1-t) • b with a ∈ s,
+    b ∈ convexHull(s), t ∈ (0,1).
+    Proof: take a = first Carathéodory vertex (in s), t = its weight (∈ (0,1) since n ≥ 2),
+    b = renormalized convex combination of remaining vertices (in convexHull s). -/
+private lemma binary_repr_of_mem_convexHull_not_mem {s : Set E} {x : E}
+    (hx : x ∈ convexHull ℝ s) (hxs : x ∉ s) :
+    ∃ (a b : E) (t : ℝ), a ∈ s ∧ b ∈ convexHull ℝ s ∧ 0 < t ∧ t < 1 ∧
+      x = t • a + (1 - t) • b := by
+  sorry
+
 /-- **Reduction step**: If a decomposition has more than d excess indices
     (where d = Module.finrank ℝ E), there exists another decomposition of
     the same point with strictly fewer excess indices.
 
-    This is the core of the Shapley-Folkman proof. The argument uses:
-    - Binary representations from convexHull_not_mem_requires_two
-    - Linear dependence of d+1 direction vectors in d-dimensional space
-    - A perturbation that collapses one excess index to an original point
-
-    Proof sketch:
-    1. Pick d+1 excess indices i₁,...,i_{d+1}
-    2. For each iₘ: point(iₘ) = tₘ·aₘ + (1-tₘ)·bₘ, aₘ bₘ ∈ S(iₘ), 0 < tₘ < 1
-    3. Let δₘ = bₘ - aₘ. By Fintype.linearIndependent_iff + dim bound:
-       ∃ c : Fin(d+1) → ℝ, ∑ cₘ·δₘ = 0, ∃ m, cₘ ≠ 0
-    4. Set ε = argmin over m of |boundary_distance(m)/cₘ| (only m with cₘ ≠ 0)
-    5. New point: point'(iₘ) = point(iₘ) + ε·cₘ·δₘ = aₘ + (1-tₘ+ε·cₘ)·δₘ
-    6. For the minimizing m: point'(iₘ) = aₘ ∈ S(iₘ) or bₘ ∈ S(iₘ)
-    7. ∑ point'(i) = ∑ point(i) + ε·∑ cₘ·δₘ = x + 0 = x  ✓
-    8. All point'(i) ∈ conv(S i) since they're still convex combinations  ✓ -/
+    Proof strategy:
+    1. For each excess j: write point j = s_j • a_j + (1-s_j) • b_j,
+       a_j ∈ S j, b_j ∈ conv(S j), s_j ∈ (0,1)  [binary_repr_of_mem_convexHull_not_mem]
+    2. Pick d+1 excess indices emb : Fin(d+1) → ι; direction vectors δ_l = b_l - a_l
+    3. Linear dependence (d+1 vecs in d-dim): Σ c_l • δ_l = 0, normalize so ∃ l, c_l < 0
+    4. ε = min { (1-s_l)/(-c_l) : c_l < 0 } ∩ { s_l/c_l : c_l > 0 } > 0
+    5. Perturb: point'(emb l) = (s_l - ε·c_l)·a_l + (1-s_l+ε·c_l)·b_l
+       - Still in conv(S l) since weights ≥ 0 sum to 1
+       - Sum preserved: Σ perturbation = ε · Σ c_l · δ_l = 0
+       - At minimizing lmin (c_lmin < 0): b-weight = 0, point' = a_lmin ∈ S(emb lmin)
+       - excessIndices strictly decreases -/
 theorem reduce_excess_by_one [FiniteDimensional ℝ E]
     {ι : Type*} [DecidableEq ι] {S : ι → Set E} {t : Finset ι}
     (hne : ∀ i ∈ t, (S i).Nonempty)
     {x : E} (D : Decomposition S t x)
     (hexcess : Module.finrank ℝ E < D.excessIndices.card) :
     ∃ D' : Decomposition S t x, D'.excessIndices.card < D.excessIndices.card := by
+  classical
+  set d := Module.finrank ℝ E with hd_def
+  -- Step 1: Binary representation data for excess indices
+  -- For each j ∈ excessIndices: av j ∈ S j, bv j ∈ conv(S j), sv j ∈ (0,1),
+  --   D.point j = sv j • av j + (1 - sv j) • bv j
+  obtain ⟨av, bv, sv, hrepr⟩ :
+      ∃ (av bv : ι → E) (sv : ι → ℝ), ∀ j ∈ D.excessIndices,
+        av j ∈ S j ∧ bv j ∈ convexHull ℝ (S j) ∧ 0 < sv j ∧ sv j < 1 ∧
+        D.point j = sv j • av j + (1 - sv j) • bv j := by
+    have hchoose : ∀ j ∈ D.excessIndices, ∃ (a b : E) (s : ℝ),
+        a ∈ S j ∧ b ∈ convexHull ℝ (S j) ∧ 0 < s ∧ s < 1 ∧
+        D.point j = s • a + (1 - s) • b := fun j hj => by
+      simp only [Decomposition.excessIndices, Finset.mem_filter] at hj
+      exact binary_repr_of_mem_convexHull_not_mem (D.mem_convexHull j hj.1) hj.2
+    -- Use Classical.choice to get the functions
+    refine ⟨fun j => if h : j ∈ D.excessIndices then
+                      (hchoose j h).choose else 0,
+            fun j => if h : j ∈ D.excessIndices then
+                      (hchoose j h).choose_spec.choose else 0,
+            fun j => if h : j ∈ D.excessIndices then
+                      (hchoose j h).choose_spec.choose_spec.choose else 0,
+            fun j hj => ?_⟩
+    simp only [dif_pos hj]
+    exact (hchoose j hj).choose_spec.choose_spec.choose_spec
+  -- Step 2: Pick d+1 excess indices as emb : Fin(d+1) → ι
+  obtain ⟨emb, hemb_mem⟩ : ∃ (emb : Fin (d + 1) → ι),
+      ∀ l, emb l ∈ D.excessIndices := by
+    -- D.excessIndices has card ≥ d+1, so we can inject Fin(d+1) into it.
+    -- Enumerate the excess indices as a list and use nth elements.
+    -- (Requires enumerating finset elements; use sorry pending API lookup.)
+    sorry
+  -- Step 3: Direction vectors δ_l = bv(emb l) - av(emb l) for l : Fin(d+1)
+  let δ : Fin (d + 1) → E := fun l =>
+    bv (emb l) - av (emb l)
+  -- Step 4: Linear dependence: c : Fin(d+1) → ℝ, ∃ l₀ with c l₀ ≠ 0, Σ c_l • δ_l = 0
+  obtain ⟨c, ⟨l₀, hl₀ne⟩, hcδ⟩ := linearDependent_coefficients (by omega : d < d + 1) δ
+  -- Step 5: Normalize so some coefficient is negative (negate c if needed)
+  obtain ⟨c', lneg, hlneg, hc'δ⟩ : ∃ (c' : Fin (d + 1) → ℝ) (lneg : Fin (d + 1)),
+      c' lneg < 0 ∧ ∑ l, c' l • δ l = 0 := by
+    rcases lt_trichotomy (c l₀) 0 with h | rfl | h
+    · exact ⟨c, l₀, h, hcδ⟩
+    · exact absurd rfl hl₀ne
+    · refine ⟨fun l => -(c l), l₀, by linarith, ?_⟩
+      have : ∑ l : Fin (d + 1), -(c l) • δ l = -(∑ l : Fin (d + 1), c l • δ l) := by
+        simp [neg_smul, Finset.sum_neg_distrib]
+      rw [this, hcδ, neg_zero]
+  -- Step 6: Perturbation construction
+  -- ε = min { (1 - sv(emb l)) / (-c' l) : c' l < 0 } ∩ { sv(emb l) / c' l : c' l > 0 }
+  -- point'(emb l) = (sv_l - ε·c'_l)·av_l + (1-sv_l+ε·c'_l)·bv_l
+  -- At lmin with c' lmin < 0 and minimizing (1-sv_lmin)/(-c' lmin):
+  --   b-weight 1-sv_lmin + ε·c' lmin = 0 → point' = av_lmin ∈ S(emb lmin) → excess decreases
+  -- Sum preserved: Σ_l ε·c'_l·δ_l = ε·(Σ c'_l·δ_l) = ε·0 = 0
   sorry
 
 /-

--- a/research/problems/shapley-folkman/knowledge.md
+++ b/research/problems/shapley-folkman/knowledge.md
@@ -11,7 +11,32 @@ of N sets in ℝ^d can be decomposed so that at most d summands come from convex
 rather than the original sets.
 
 Current status: `shapley_folkman`, `sum_close_to_convexHull`, `repeated_sum_nearly_convex`
-all proved (0 sorries). Only `reduce_excess_by_one` remains.
+all proved (0 sorries). `reduce_excess_by_one` has 1 sorry remaining (Step 6 perturbation).
+
+---
+
+## Session 2026-04-13 (Session 3) — Embedding Extraction Fixed
+
+**Mode**: REVISIT
+**Outcome**: Step 2 proved — embedding extraction via Multiset.toList
+
+### What I Did
+- Replaced Step 2 sorry with list-based proof: convert `D.excessIndices.val` to a `List`
+  via `Multiset.toList`, then index with `List.get`. Membership follows from
+  `Multiset.mem_toList.mp (List.get_mem ...)`.
+- Key lemmas: `Multiset.toList_length` (list length = multiset card), `List.get_mem`,
+  `Multiset.mem_toList`, `Finset.mem_def`
+
+### Sorrys Remaining
+1. Step 6 (perturbation construction) — the only remaining sorry
+
+### Files Modified
+- `proofs/Proofs/ShapleyFolkman.lean` lines 317-328: replaced Step 2 sorry
+
+### Next Steps
+1. Prove Step 6: define ε = min { (1-sv_l)/(-c'_l) : c'_l < 0 }, construct D',
+   verify convex hull membership (weights in [0,1] summing to 1), sum preservation,
+   and excess count decrease (lmin index has b-weight hitting 0)
 
 ---
 

--- a/research/problems/shapley-folkman/knowledge.md
+++ b/research/problems/shapley-folkman/knowledge.md
@@ -6,16 +6,113 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+The Shapley-Folkman Lemma states: any point in the convex hull of a Minkowski sum
+of N sets in ℝ^d can be decomposed so that at most d summands come from convex hulls
+rather than the original sets.
+
+Current status: `shapley_folkman`, `sum_close_to_convexHull`, `repeated_sum_nearly_convex`
+all proved (0 sorries). Only `reduce_excess_by_one` remains.
+
+---
+
+## Session 2026-04-13 (Session 2) — Proof Architecture for reduce_excess_by_one
+
+**Mode**: FRESH
+**Outcome**: proof architecture progress — 1 sorry → 2 sorrys + 1 proved sub-step
+
+### What I Did
+- Replaced the single sorry in `reduce_excess_by_one` with a full proof structure
+- Added `binary_repr_of_mem_convexHull_not_mem` private lemma (with sorry)
+- Wrote Steps 1-5 of the perturbation proof with only Step 6 (the construction) remaining sorry
+- Step 5 (sign normalization of linear dependence coefficients) is **actually proved**
+
+### Proof Architecture
+
+The proof proceeds as:
+
+1. **Binary reps** (sorry → `binary_repr_of_mem_convexHull_not_mem`):
+   For each excess j: `D.point j = s_j • a_j + (1-s_j) • b_j` with
+   `a_j ∈ S j`, `b_j ∈ conv(S j)`, `s_j ∈ (0,1)`.
+   Construction: take first Carathéodory vertex as `a_j`, renormalized sum of rest as `b_j`.
+
+2. **Embedding** (sorry):
+   Extract `emb : Fin(d+1) → ι` with all images in `excessIndices`.
+   (Requires finset enumeration API — `orderEmbOfCardLE` needs LinearOrder on ι;
+   need alternative like `Finset.exists_subset_card_le` + list enumeration.)
+
+3. **Direction vectors**: `δ_l = bv(emb l) - av(emb l)` — explicit, no sorry.
+
+4. **Linear dependence**: `linearDependent_coefficients` gives `c`, nonzero, `Σ c_l • δ_l = 0` — proved.
+
+5. **Sign normalization** (PROVED):
+   Negate c if `c l₀ > 0`. Either way get `c'` with `c' lneg < 0`, `Σ c'_l • δ_l = 0`.
+   Key: `∑ -(c l) • δ l = -(∑ c l • δ l) = 0` via `Finset.sum_neg_distrib`.
+
+6. **Perturbation construction** (sorry):
+   `ε = min { (1-s_l)/(-c'_l) : c'_l < 0 } ∩ { s_l/c'_l : c'_l > 0 } > 0`
+   `point'(emb l) = (s_l - ε·c'_l)·a_l + (1-s_l+ε·c'_l)·b_l`
+   At minimizing lmin (with `c'_lmin < 0`): b-weight hits 0 → `point' = a_lmin ∈ S(emb lmin)`
+   Sum preserved since `Σ c'_l·δ_l = 0`.
+
+### Key Findings
+- Sign normalization (step 5) is provable and IS proved in the file
+- `binary_repr` construction: take `a = f 0 ∈ s`, `t = w 0 ∈ (0,1)` (since `n ≥ 2` and weights positive),
+  `b = (1-t)^{-1} • Σ_{k≥1} w_k • f_k ∈ conv(s)`. Then `x = t•a + (1-t)•b`.
+- Embedding extraction: need `∃ emb : Fin(d+1) → ι, ∀ l, emb l ∈ S` from `S.card ≥ d+1`.
+  Mathlib approach: `Finset.exists_subset_card_le` gives a subset J of size d+1, then
+  `J.orderIsoOfFin rfl` enumerates J (requires LinearOrder — workaround: use subtype).
+- Step 6 D' construction: needs to define modified `point` function, prove convex hull membership,
+  sum equality, and count excess decrease. This is the main work remaining.
+
+### Files Modified
+- `proofs/Proofs/ShapleyFolkman.lean` (lines 216-300):
+  - Added `binary_repr_of_mem_convexHull_not_mem` (1 sorry)
+  - Rewrote `reduce_excess_by_one` with 3 sorrys (was 1), steps 3-5 proved
+
+### Next Steps
+
+1. **Prove `binary_repr_of_mem_convexHull_not_mem`**:
+   - Use `convexHull_not_mem_requires_two` to get n≥2 points
+   - `a = f 0`, `t = w 0`, `b = (1-t)⁻¹ • Σ_{k≥1} w_k • f_k`
+   - Need: `b ∈ convexHull s` (convex combo of s-points), `w 0 < 1` (since `w 1 > 0`),
+     `x = t•a + (1-t)•b` (algebraic identity after Finset sum manipulation)
+
+2. **Fix embedding extraction** (Step 2):
+   - Use `Finset.card_le_iff_exists_subset` to get a subset J of size d+1
+   - Then enumerate J via coercion to a Fintype subtype
+
+3. **Prove Step 6 (perturbation construction)**:
+   - This is the hard sorry. Needs: min of finite positive set, new Decomposition struct,
+     convexHull membership via convex combination argument, sum preservation, excess count
+
+---
+
+## Session 2026-04-12 (Session 1) — Prior progress
+
+**Outcome**: `sum_close_to_convexHull` and `repeated_sum_nearly_convex` proved. Only
+`reduce_excess_by_one` remains as a sorry.
+
+### Key Findings (Session 1)
+- `reduce_excess_by_one` is the mathematical core
+- `linearDependent_coefficients` proved (lines 194-205)
+- `shapley_folkman` proved from `reduce_excess_by_one` by induction
+- `convexHull_not_mem_requires_two` proved (lines 105-157)
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- `reduce_excess_by_one` proof works by DIRECT excess decrease (not M-induction).
+  Key: choose c with a negative entry, then ε makes the b-weight hit 0, collapsing
+  the excess index to a_lmin ∈ S j. No induction on vertex count needed.
+- `sum_close_to_convexHull` depends on `Set.mem_finset_sum` (Mathlib) and `convexHull_min`.
+- Binary representation: general n-point Carathéodory rep → binary rep via first-vertex extraction.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- "Toward a single point" perturbation: doesn't preserve convex hull membership for negative coefficients
+- M-induction (induct on total vertex count): correct but more complex than needed
+- Direct proof without binary reps: linearDependent_coefficients needs direction vectors,
+  which requires reducing n-point reps to 2-point reps first

--- a/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Added Apéry a-sequence, harmonic numbers, lcm infrastructure, linear form definition. File now 350 lines, 20 theorems, 9 defs, 6 sorries (up from 4 — added Nair bound and denominator control). Critical path dependencies now clear.",
+    "progressSummary": "PROGRESS: Added aperyRecCoeff_le_34_mul_cubeSucc (proved). 6 sorries remain but key algebraic bound now established.",
     "builtItems": [
       "Created proofs/Proofs/BaselProblemOQ01OQ01OQ02.lean (199 lines)",
       "Defined aperyB: ℕ → ℕ (Apéry number sequence)",
@@ -42,7 +42,8 @@
       "Defined harmonicNumber, genHarmonicNumber (H_n and H_n^{(s)})",
       "Defined lcmUpTo and stated nair_lcm_bound (sorry)",
       "Defined linearForm: bₙ·ζ(3) - aₙ",
-      "Stated denominator_control: lcm³·aₙ ∈ ℤ (sorry)"
+      "Stated denominator_control: lcm³·aₙ ∈ ℤ (sorry)",
+      "Proved aperyRecCoeff_le_34_mul_cubeSucc: (2n+1)(17n^2+17n+5) ≤ 34*(n+1)^3 by nlinarith (BaselProblemOQ01OQ01OQ02.lean)"
     ],
     "insights": [
       "Apéry numbers bₙ = ∑ C(n,k)²C(n+k,k)² computable as ℕ in Lean via Finset.sum",
@@ -54,7 +55,8 @@
       "a-sequence satisfies same recurrence as b-sequence with a₀=0, a₁=6",
       "lcm bound lcm(1,...,n) ≤ 4^n (Nair 1982) bypasses PNT for denominator control",
       "Critical path: recurrence → growth → decay + denominator control → irrationality",
-      "Harmonic numbers H_n and generalized H_n^{(s)} needed for a-sequence closed form"
+      "Harmonic numbers H_n and generalized H_n^{(s)} needed for a-sequence closed form",
+      "aperyRecCoeff_le_34_mul_cubeSucc proves the key algebraic inequality: 34(n+1)^3 - (2n+1)(17n^2+17n+5) = 51n^2+75n+29 > 0. This enables bounding b_{n+1} ≤ 34*b_n from the recurrence."
     ],
     "mathlibGaps": [],
     "nextSteps": [

--- a/src/data/research/problems/shapley-folkman.json
+++ b/src/data/research/problems/shapley-folkman.json
@@ -1,12 +1,12 @@
 {
   "slug": "shapley-folkman",
   "title": "Shapley-Folkman Lemma",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
   "knowledge": {
-    "progressSummary": "3 sorries: reduce_excess_by_one (deep), sum_close_to_convexHull (from shapley_folkman + Minkowski sum identity), repeated_sum_nearly_convex (specialization). Corollary proofs need Mathlib pointwise sum lemmas.",
+    "progressSummary": "1 sorry remaining: reduce_excess_by_one Step 6 (perturbation construction). Steps 1-5 structure proved. Corollaries all proved.",
     "insights": [
       "reduce_excess_by_one is the mathematical core — requires: (1) linear dependence of d+1 direction vectors via finrank, (2) perturbation ε construction from boundary distances, (3) verification that new points remain in convex hulls",
       "sum_close_to_convexHull needs convexHull(∑ Sᵢ) = ∑ convexHull(Sᵢ) from Mathlib (check Mathlib.Analysis.Convex.Combination for sum identity)",
@@ -16,11 +16,18 @@
       "repeated_sum_nearly_convex follows from sum_close_to_convexHull by specializing S_i = S for all i",
       "reduce_excess_by_one is the deep sorry: needs linearDependent_coefficients (proved!) + perturbation argument (~50 lines). Key steps: extract binary reps for d+1 excess indices, find dependence via linearDependent_coefficients, perturb with epsilon to collapse one index."
     ],
-    "builtItems": [],
+    "builtItems": [
+      "binary_repr_of_mem_convexHull_not_mem private lemma (ShapleyFolkman.lean:220)",
+      "reduce_excess_by_one Steps 1-5 proof structure (lines 247-300)",
+      "Sign normalization of linear dependence coefficients (proved)",
+      "Direction vectors and linear dependence extraction (proved)"
+    ],
     "mathlibGaps": [],
     "nextSteps": [
-      "reduce_excess_by_one: extract d+1 excess indices, form δ vectors, find kernel element via Module.finrank, compute ε from min |boundary/coeff|",
-      "Check if Mathlib has convexHull_sum or similar for Minkowski sum identity (needed for corollaries)"
-    ]
+      "Prove binary_repr_of_mem_convexHull_not_mem from convexHull_not_mem_requires_two",
+      "Fix embedding extraction: use Finset.exists_subset_card_le + subtype instead of orderEmbOfCardLE",
+      "Prove Step 6 perturbation: define epsilon=min ratio, construct D-prime, verify properties"
+    ],
+    "phase": "ACT"
   }
 }

--- a/src/data/research/problems/shapley-folkman.json
+++ b/src/data/research/problems/shapley-folkman.json
@@ -6,7 +6,7 @@
   "tier": "A",
   "path": "full",
   "knowledge": {
-    "progressSummary": "1 sorry remaining: reduce_excess_by_one Step 6 (perturbation construction). Steps 1-5 structure proved. Corollaries all proved.",
+    "progressSummary": "1 sorry remaining: reduce_excess_by_one Step 6 only (Steps 1-5 proved, including Step 2 embedding extraction via Multiset.toList)",
     "insights": [
       "reduce_excess_by_one is the mathematical core — requires: (1) linear dependence of d+1 direction vectors via finrank, (2) perturbation ε construction from boundary distances, (3) verification that new points remain in convex hulls",
       "sum_close_to_convexHull needs convexHull(∑ Sᵢ) = ∑ convexHull(Sᵢ) from Mathlib (check Mathlib.Analysis.Convex.Combination for sum identity)",
@@ -20,13 +20,12 @@
       "binary_repr_of_mem_convexHull_not_mem private lemma (ShapleyFolkman.lean:220)",
       "reduce_excess_by_one Steps 1-5 proof structure (lines 247-300)",
       "Sign normalization of linear dependence coefficients (proved)",
-      "Direction vectors and linear dependence extraction (proved)"
+      "Direction vectors and linear dependence extraction (proved)",
+      "Fixed embedding extraction Step 2 via Multiset.toList list enumeration (ShapleyFolkman.lean:317-328)"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove binary_repr_of_mem_convexHull_not_mem from convexHull_not_mem_requires_two",
-      "Fix embedding extraction: use Finset.exists_subset_card_le + subtype instead of orderEmbOfCardLE",
-      "Prove Step 6 perturbation: define epsilon=min ratio, construct D-prime, verify properties"
+      "Prove Step 6 perturbation: define epsilon=min ratio, construct D-prime, verify convex hull membership, sum preservation, excess count decrease"
     ],
     "phase": "ACT"
   }


### PR DESCRIPTION
## Summary

- **ShapleyFolkman**: Reduce `reduce_excess_by_one` from 2 sorrys to 1
  - Step 2 (embedding extraction): proved via `Multiset.toList` — convert excess index finset to list, index with `List.get`, membership by `Multiset.mem_toList`
  - Steps 1,3,4,5 remain proved; only Step 6 (perturbation construction) is the remaining sorry
- **Basel (Apéry ζ(3))**: Added `aperyRecCoeff_le_34_mul_cubeSucc` — proves `(2n+1)(17n²+17n+5) ≤ 34*(n+1)³` by `nlinarith`, the algebraic engine behind the growth bound `bₙ ≤ 34ⁿ`

## Remaining Work

- `reduce_excess_by_one` Step 6: define ε = min { (1-s_l)/(-c_l) : c_l < 0 }, construct D', verify weights ∈ [0,1] sum to 1, sum preservation, excess count decrease at lmin

## Test plan
- [ ] Docker build Proofs.ShapleyFolkman to verify compilation
- [ ] Docker build Proofs.BaselProblemOQ01OQ01OQ02 to verify compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)