### PR TITLE
Fix: erdos-402 top-level sorries 2→1

### DIFF
--- a/src/data/proofs/erdos-402/meta.json
+++ b/src/data/proofs/erdos-402/meta.json
@@ -204,5 +204,5 @@
       "note": "Complete proof of the conjecture for all finite sets of positive integers"
     }
   ],
-  "sorries": 2
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

Correct stale top-level `sorries` field in `src/data/proofs/erdos-402/meta.json`.

## Evidence

**Before**: `"sorries": 2` (top-level field)
**After**: `"sorries": 1`

The Lean file `proofs/Proofs/Erdos402Problem.lean` has exactly **1** code sorry (line 99). `leanFile.sorries` was already correct at 1. The top-level `sorries` field was out of sync.

Verified with: `grep -n "sorry" proofs/Proofs/Erdos402Problem.lean` — only line 99 has a code sorry; lines 145 and 681 contain comments about sorry.

---
Automated fix by lean-mechanic agent.