### PR TITLE
Fix: sorry count corrections for erdos-1033, erdos-392, shapley-folkman

### DIFF
--- a/src/data/proofs/erdos-1033/meta.json
+++ b/src/data/proofs/erdos-1033/meta.json
@@ -17,7 +17,7 @@
       "turan-theory"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 0,
     "erdosNumber": 1033,
     "erdosUrl": "https://erdosproblems.com/1033",
     "erdosProblemStatus": "open",
@@ -52,7 +52,7 @@
     ],
     "relatedProblems": [],
     "axiomCount": 3,
-    "lineCount": 514,
+    "lineCount": 1016,
     "assumptions": "3 axioms (erdos_laskar_upper, erdos_laskar_lower, fan_lower) and 3 sorries (h_as_min, turan_plus_one, h_four). h_spec was proved. Note: erdos_laskar_upper and fan_lower axioms are too strong for small n (asymptotic results stated as universal)."
   },
   "overview": {
@@ -303,12 +303,12 @@
       "Finset"
     ],
     "namespace": "Erdos1033",
-    "lineCount": 722,
+    "lineCount": 1016,
     "axiomCount": 3,
     "theoremCount": 16,
     "definitionCount": 17,
-    "sorries": 3,
+    "sorries": 0,
     "path": "Proofs/Erdos1033Problem.lean"
   },
-  "sorries": 3
+  "sorries": 0
 }

--- a/src/data/proofs/erdos-392/meta.json
+++ b/src/data/proofs/erdos-392/meta.json
@@ -17,7 +17,7 @@
       "number-theory"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "erdosNumber": 392,
     "erdosUrl": "https://erdosproblems.com/392",
     "erdosProblemStatus": "solved",
@@ -200,5 +200,5 @@
       "description": "Related Erdős problem sharing themes: factorial, number-theory"
     }
   ],
-  "sorries": 2
+  "sorries": 3
 }

--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -16,7 +16,7 @@
       "intermediate"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 2,
     "mathlibDependencies": [
       {
         "theorem": "convexHull_eq_union",
@@ -252,5 +252,5 @@
       "leanType": "Decomposition S t x -> d.excessIndices.card <= Module.finrank R E"
     }
   ],
-  "sorries": 1
+  "sorries": 2
 }


### PR DESCRIPTION
## Fix

Three sorry count corrections found via systematic gallery integrity scan.

## Evidence

### erdos-1033
**Before**: `sorries: 3` (all fields), `lineCount: 514/722`
**After**: `sorries: 0`, `lineCount: 1016`
- `proofs/Proofs/Erdos1033Problem.lean` has **0** `sorry` occurrences
- File grew to 1016 lines (sorries were replaced by proper proofs or converted to 3 `axiom` declarations which remain)
- Status stays `axiomatized` (correct: 3 axioms declared)

### erdos-392 (stub)
**Before**: `sorries: 2`
**After**: `sorries: 3`
- `proofs/Proofs/Stubs/Erdos392Problem.lean` line 218: `⟨⟨1, by norm_num, by sorry⟩, ⟨1, by norm_num, by sorry⟩⟩` — 2 sorries on one line plus line 166 = 3 total

### shapley-folkman
**Before**: `sorries: 1`
**After**: `sorries: 2`
- Line 323: `sorry` (embedding injection proof)
- Line 345: `sorry` (convex combination adjustment)
- Both are actual code sorries, not comments

---
Automated fix by lean-mechanic agent.