### PR TITLE
Fix: feuerbachs-theorem-oq-02 leanFile.axiomCount 5→3

### DIFF
--- a/src/data/proofs/feuerbachs-theorem-oq-02/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-02/meta.json
@@ -147,7 +147,7 @@
     ],
     "namespace": "FeuerbachsTheoremOQ02",
     "lineCount": 350,
-    "axiomCount": 5,
+    "axiomCount": 3,
     "theoremCount": 10,
     "substantiveTheoremCount": 6,
     "duplicateTheorems": 0,


### PR DESCRIPTION
## Fix

Correct stale `leanFile.axiomCount` in `src/data/proofs/feuerbachs-theorem-oq-02/meta.json`.

## Evidence

**Before**: `leanFile.axiomCount: 5`
**After**: `leanFile.axiomCount: 3`

The Lean file `proofs/Proofs/FeuerbachsTheoremOQ02.lean` has exactly **3** `^axiom` declarations:
- `feuerbach_3d_fails_general` (line 588)
- `edge_midpoints_on_sphere` (line 602)
- `face_centroids_on_sphere` (line 618)

The 2 circumcenter axioms (circumcenter existence and equidistance) were proved directly in code via Cramer's rule. The `meta.axiomCount` field was already correctly updated to 3; the `leanFile.axiomCount` field was missed.

---
Automated fix by lean-mechanic agent.