### PR TITLE
Fix: sync sorry counts for erdos-392 and shapley-folkman

### DIFF
--- a/src/data/proofs/erdos-392/meta.json
+++ b/src/data/proofs/erdos-392/meta.json
@@ -181,7 +181,7 @@
     "theoremCount": 3,
     "definitionCount": 1,
     "path": "Proofs/Stubs/Erdos392Problem.lean",
-    "sorries": 2
+    "sorries": 3
   },
   "crossReferences": [
     {

--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -16,7 +16,7 @@
       "intermediate"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 1,
     "mathlibDependencies": [
       {
         "theorem": "convexHull_eq_union",
@@ -252,5 +252,5 @@
       "leanType": "Decomposition S t x -> d.excessIndices.card <= Module.finrank R E"
     }
   ],
-  "sorries": 2
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

Correct stale `sorries` fields in two gallery proof meta.json files.

## Evidence

**erdos-392**:
- **Before**: `leanFile.sorries = 2` (top-level was already correctly 3)
- **After**: `leanFile.sorries = 3`
- **Reason**: Line 218 of `Proofs/Stubs/Erdos392Problem.lean` contains `⟨⟨1, by norm_num, by sorry⟩, ⟨1, by norm_num, by sorry⟩⟩` — two sorries on one line plus one at line 166 = 3 total. Previous fix (cbe6092c) updated only the top-level field but missed `leanFile.sorries`.

**shapley-folkman**:
- **Before**: `meta.sorries = 2`, top-level `sorries = 2` (leanFile.sorries = 1 was already correct)
- **After**: all three fields = 1
- **Reason**: File has exactly 1 sorry at line 351. Previous fix (cbe6092c) incorrectly set top-level to 2.

---
Automated fix by lean-mechanic agent.