### PR TITLE
Fix: sync leanFile.lineCount for shapley-folkman and erdos-109-oq-01

### DIFF
--- a/src/data/proofs/erdos-109-oq-01/meta.json
+++ b/src/data/proofs/erdos-109-oq-01/meta.json
@@ -58,7 +58,7 @@
   },
   "leanFile": {
     "namespace": "Erdos109OQ01",
-    "lineCount": 292,
+    "lineCount": 356,
     "axiomCount": 1,
     "theoremCount": 5,
     "definitionCount": 10,

--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -201,7 +201,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 350,
+    "lineCount": 461,
     "structureCount": 1,
     "axiomCount": 0,
     "theoremCount": 8,


### PR DESCRIPTION
## Fix

Update stale `leanFile.lineCount` in two gallery proof meta.json files.

## Evidence

**shapley-folkman**:
- **Before**: `leanFile.lineCount = 350`
- **After**: `leanFile.lineCount = 461`
- **Reason**: `ShapleyFolkman.lean` grew from 350 to 461 lines in PR #10499 (reduce_excess_by_one proof architecture); meta.json was not updated.

**erdos-109-oq-01**:
- **Before**: `leanFile.lineCount = 292`
- **After**: `leanFile.lineCount = 356`
- **Reason**: `Erdos109OQ01.lean` grew from 292 to 356 lines in PR #10485 (complete Erdős #1033 + Erdős #109 OQ-01); meta.json was not updated.

---
Automated fix by lean-mechanic agent.