### PR TITLE
chore: sync research registry

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -11660,11 +11660,12 @@
     },
     {
       "slug": "erdos-727-incomplete-01",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "fast",
       "started": "2026-04-03T15:38:25.652Z",
-      "status": "active",
-      "lastUpdate": "2026-04-03T15:38:25.666Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-13T10:38:16.804Z",
+      "completed": "2026-04-13T10:38:16.802Z"
     },
     {
       "slug": "erdos-565-incomplete-01",


### PR DESCRIPTION
Auto-sync of research/registry.json by deployer agent.

- Updates registry with latest listing counts and metadata
- Generated during deploy cycle on 2026-04-13

🤖 Generated by Deployer