### PR TITLE
Fix: sync leanFile.lineCount for basel-problem-oq-01-oq-01-oq-02

### DIFF
--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
@@ -139,7 +139,7 @@
       "Nat"
     ],
     "namespace": "AperyZetaThree",
-    "lineCount": 504,
+    "lineCount": 513,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 4,


### PR DESCRIPTION
## Fix

Update stale `leanFile.lineCount` in `basel-problem-oq-01-oq-01-oq-02` meta.json.

## Evidence

**Before**: `leanFile.lineCount = 504`
**After**: `leanFile.lineCount = 513`

**Reason**: `BaselProblemOQ01OQ01OQ02.lean` grew from 504 to 513 lines when the `aperyRecCoeff_le_34_mul_cubeSucc` theorem was added in PR #10499 (Research: Shapley-Folkman reduce_excess_by_one proof architecture). The meta.json `lineCount` was not updated at that time.

The new theorem is a fully proved algebraic inequality: `34(n+1)³ - (2n+1)(17n²+17n+5) = 51n² + 75n + 29 > 0`, proved via `nlinarith`.

No changes to sorry count, axiom count, or status — only the line count was stale.

---
Automated fix by lean-mechanic agent.