### PR TITLE
Prove 38 sorries across 5 Aristotle files (all sorry-free)

### DIFF
--- a/proofs/Proofs/Erdos1043Aristotle.lean
+++ b/proofs/Proofs/Erdos1043Aristotle.lean
@@ -23,17 +23,19 @@ namespace Erdos1043.Aristotle
 -/
 
 -- Aristotle target: 2 < 2.386 in ENNReal (norm_num)
-theorem two_lt_two_point_386 : (2 : ℝ≥0∞) < 2.386 := by sorry
+theorem two_lt_two_point_386 : (2 : ℝ≥0∞) < 2.386 := by norm_num
 
 -- Aristotle target: contradiction from ≥ 2.386 and ≤ 2 in ENNReal
 theorem ennreal_contradiction_2_386 (x : ℝ≥0∞)
-    (hge : (2.386 : ℝ≥0∞) ≤ x) (hle : x ≤ 2) : False := by sorry
+    (hge : (2.386 : ℝ≥0∞) ≤ x) (hle : x ≤ 2) : False := by
+  have : (2.386 : ℝ≥0∞) ≤ 2 := le_trans hge hle
+  exact absurd this (by norm_num)
 
 -- Aristotle target: 2 ≤ 3.3 in ENNReal
-theorem two_le_3_3 : (2 : ℝ≥0∞) ≤ 3.3 := by sorry
+theorem two_le_3_3 : (2 : ℝ≥0∞) ≤ 3.3 := by norm_num
 
 -- Aristotle target: 2.386 ≤ 3.3 in ENNReal
-theorem two_386_le_3_3 : (2.386 : ℝ≥0∞) ≤ 3.3 := by sorry
+theorem two_386_le_3_3 : (2.386 : ℝ≥0∞) ≤ 3.3 := by norm_num
 
 /-
   ## Section 2: iInf Bounds for min_projection_bounded
@@ -47,7 +49,8 @@ theorem two_386_le_3_3 : (2.386 : ℝ≥0∞) ≤ 3.3 := by sorry
 -- Aristotle target: iInf over a type ≤ any particular value
 -- (same as iInf_le, but explicit)
 theorem iInf_le_of_witness {α : Type*} [Nonempty α] (f : α → ℝ≥0∞)
-    (u : α) (b : ℝ≥0∞) (hu : f u ≤ b) : iInf f ≤ b := by sorry
+    (u : α) (b : ℝ≥0∞) (hu : f u ≤ b) : iInf f ≤ b :=
+  le_trans (iInf_le f u) hu
 
 /-
   ## Section 3: minWidth ≤ maxWidth
@@ -59,7 +62,9 @@ theorem iInf_le_of_witness {α : Type*} [Nonempty α] (f : α → ℝ≥0∞)
 
 -- Aristotle target: iInf ≤ iSup over same nonempty index type
 theorem iInf_le_iSup {α : Type*} [Nonempty α] (f : α → ℝ≥0∞) :
-    iInf f ≤ iSup f := by sorry
+    iInf f ≤ iSup f :=
+  let ⟨a⟩ := ‹Nonempty α›
+  le_trans (iInf_le f a) (le_iSup f a)
 
 /-
   ## Section 4: Measure Positivity
@@ -68,12 +73,12 @@ theorem iInf_le_iSup {α : Type*} [Nonempty α] (f : α → ℝ≥0∞) :
 -/
 
 -- Aristotle target: projection measure bound 0 < 2
-theorem zero_lt_two_ennreal : (0 : ℝ≥0∞) < 2 := by sorry
+theorem zero_lt_two_ennreal : (0 : ℝ≥0∞) < 2 := by norm_num
 
 -- Aristotle target: projection measure bound 0 < 3.3
-theorem zero_lt_3_3_ennreal : (0 : ℝ≥0∞) < 3.3 := by sorry
+theorem zero_lt_3_3_ennreal : (0 : ℝ≥0∞) < 3.3 := by norm_num
 
 -- Aristotle target: 0 < 2.386 in ENNReal
-theorem zero_lt_2_386_ennreal : (0 : ℝ≥0∞) < 2.386 := by sorry
+theorem zero_lt_2_386_ennreal : (0 : ℝ≥0∞) < 2.386 := by norm_num
 
 end Erdos1043.Aristotle

--- a/proofs/Proofs/Erdos260Aristotle.lean
+++ b/proofs/Proofs/Erdos260Aristotle.lean
@@ -30,7 +30,11 @@ theorem strictMono_nat_ge (f : ℕ → ℕ) (hf : StrictMono f) (n : ℕ) :
 
 -- Aristotle target: n / 2^n is summable over naturals
 theorem summable_nat_div_two_pow :
-    Summable (fun n : ℕ => (n : ℝ) / (2 : ℝ) ^ n) := by sorry
+    Summable (fun n : ℕ => (n : ℝ) / (2 : ℝ) ^ n) := by
+  -- n/2^n = n^1 * (1/2)^n; apply summable_pow_mul_geometric
+  have hsumm : Summable (fun n : ℕ => (n : ℝ) ^ 1 * ((1 : ℝ) / 2) ^ n) :=
+    summable_pow_mul_geometric_of_norm_lt_one 1 (by norm_num)
+  exact hsumm.congr (fun n => by rw [pow_one, one_div, inv_pow, div_eq_mul_inv])
 
 -- Aristotle target: 0 < 2^n for all natural n (in reals)
 theorem two_pow_pos (n : ℕ) : (0 : ℝ) < (2 : ℝ) ^ n := by positivity
@@ -46,7 +50,8 @@ theorem two_pow_mono {a n : ℕ} (h : n ≤ a) :
 
 -- Aristotle target: n/2^n -> 0 as n -> infinity
 theorem nat_div_two_pow_tendsto_zero :
-    Tendsto (fun n : ℕ => (n : ℝ) / (2 : ℝ) ^ n) atTop (nhds 0) := by sorry
+    Tendsto (fun n : ℕ => (n : ℝ) / (2 : ℝ) ^ n) atTop (nhds 0) :=
+  summable_nat_div_two_pow.tendsto_atTop_zero
 
 /-
   ## Section 2: Helpers for fastGrowth_of_gapsToInfinity

--- a/proofs/Proofs/Erdos73Aristotle.lean
+++ b/proofs/Proofs/Erdos73Aristotle.lean
@@ -40,16 +40,19 @@ def triangleGraph : SimpleGraph (Fin 3) where
 
 -- Aristotle target: adjacency in K₃ is exactly u ≠ v
 theorem triangleGraph_adj_iff (u v : Fin 3) :
-    triangleGraph.Adj u v ↔ u ≠ v := by sorry
+    triangleGraph.Adj u v ↔ u ≠ v := Iff.rfl
 
 -- Aristotle target: any two distinct vertices in Fin 3 are adjacent in K₃
 theorem triangleGraph_adj_of_ne (u v : Fin 3) (h : u ≠ v) :
-    triangleGraph.Adj u v := by sorry
+    triangleGraph.Adj u v := h
 
 -- Aristotle target: the only independent sets in K₃ are singletons and the empty set
 theorem triangleGraph_indep_set_card (S : Finset (Fin 3))
     (hS : IsIndependentSet triangleGraph S) :
-    S.card ≤ 1 := by sorry
+    S.card ≤ 1 := by
+  rw [Finset.card_le_one]
+  intro a ha b hb
+  exact of_not_not (hS a ha b hb)
 
 /-
   ## Section 2: K₂ Subgraph is Bipartite
@@ -61,13 +64,41 @@ theorem triangleGraph_indep_set_card (S : Finset (Fin 3))
 -- Aristotle target: {1, 2} partition as A = {{1}}, B = {{2}} is a bipartition
 -- The induced subgraph on {1, 2} in K₃ is bipartite
 theorem triangleGraph_on_two_vertices_bipartite :
-    IsBipartite (triangleGraph.induce ({(0 : Fin 3)}ᶜ : Set (Fin 3))) := by sorry
+    IsBipartite (triangleGraph.induce ({(0 : Fin 3)}ᶜ : Set (Fin 3))) := by
+  -- The induced subgraph on {1, 2} is K₂; bipartition A = {1}, B = {2}
+  refine ⟨{⟨1, by decide⟩}, {⟨2, by decide⟩}, ?_, ?_, ?_, ?_⟩
+  · -- A ∪ B = univ
+    ext ⟨x, hx⟩
+    simp only [Set.mem_union, Set.mem_singleton_iff, Set.mem_univ, iff_true]
+    simp only [Set.mem_compl_iff, Set.mem_singleton_iff] at hx
+    fin_cases x <;> simp_all
+  · -- A ∩ B = ∅
+    ext ⟨x, hx⟩
+    simp only [Set.mem_inter_iff, Set.mem_singleton_iff, Set.mem_empty_iff_false, iff_false]
+    rintro ⟨h1, h2⟩
+    have := h1.symm.trans h2
+    exact absurd (congrArg Subtype.val this) (by decide)
+  · -- A is independent (singleton)
+    intro u hu v hv
+    simp only [Set.mem_singleton_iff] at hu hv
+    rw [hu, hv]
+    exact fun h => h rfl
+  · -- B is independent (singleton)
+    intro u hu v hv
+    simp only [Set.mem_singleton_iff] at hu hv
+    rw [hu, hv]
+    exact fun h => h rfl
 
 -- Aristotle target: K₃ is 1-almost-bipartite (remove vertex 0)
 -- isAlmostBipartite definition: ∃ S, S.card ≤ bound ∧ IsBipartite (G.induce Sᶜ)
 theorem K3_almost_bipartite_goal :
     ∃ S : Finset (Fin 3), S.card ≤ 1 ∧
-      IsBipartite (triangleGraph.induce (↑Sᶜ : Set (Fin 3))) := by sorry
+      IsBipartite (triangleGraph.induce (↑Sᶜ : Set (Fin 3))) := by
+  refine ⟨{0}, by simp, ?_⟩
+  convert triangleGraph_on_two_vertices_bipartite using 1
+  congr 1
+  ext x
+  simp [Finset.compl_eq_univ_sdiff]
 
 /-
   ## Section 3: Independence Arithmetic
@@ -76,17 +107,20 @@ theorem K3_almost_bipartite_goal :
 -/
 
 -- Aristotle target: 2 * m < 2 * m + 1 (odd cycles violate k=0 condition)
-theorem twice_lt_succ (m : ℕ) : 2 * m < 2 * m + 1 := by sorry
+theorem twice_lt_succ (m : ℕ) : 2 * m < 2 * m + 1 := by omega
 
 -- Aristotle target: for the strict condition, 2 * I.card ≥ S.card means I.card ≥ S.card / 2
 theorem strict_condition_card_bound (I S : Finset V)
     (hI : 2 * I.card ≥ S.card) :
-    I.card * 2 ≥ S.card := by sorry
+    I.card * 2 ≥ S.card := by omega
 
 -- Aristotle target: 3 vertices in K₃, max independent set has 1 vertex, so 2*1 < 3
 theorem K3_indep_bound_fails (S : Finset (Fin 3)) (hs : S = Finset.univ)
     (I : Finset (Fin 3)) (hI : IsIndependentSet triangleGraph I)
     (hIsub : I ⊆ S) :
-    ¬(2 * I.card ≥ S.card) := by sorry
+    ¬(2 * I.card ≥ S.card) := by
+  have hcard : S.card = 3 := by rw [hs]; decide
+  have hIcard := triangleGraph_indep_set_card I hI
+  omega
 
 end Erdos73Aristotle

--- a/proofs/Proofs/Erdos817Aristotle.lean
+++ b/proofs/Proofs/Erdos817Aristotle.lean
@@ -26,15 +26,48 @@ open Finset Filter Nat
 -- Aristotle target: set of cardinality < 3 is 3-AP-free
 -- If |S| < 3, there are no 3 distinct elements, so no 3-AP exists
 theorem apFree_of_card_lt_three (S : Finset ℕ) (hS : S.card < 3) :
-    ∀ a d, d > 0 → ∃ i < 3, a + i * d ∉ (S : Set ℕ) := by sorry
+    ∀ a d, d > 0 → ∃ i < 3, a + i * d ∉ (S : Set ℕ) := by
+  intro a d hd
+  -- The 3 values a, a+d, a+2d are distinct (since d > 0)
+  -- S has < 3 elements, so at least one is missing
+  by_contra h
+  push_neg at h
+  have h0 := h 0 (by omega)
+  have h1 := h 1 (by omega)
+  have h2 := h 2 (by omega)
+  simp only [Finset.mem_coe, zero_mul, add_zero, one_mul, Nat.reduceMul] at h0 h1 h2
+  have hdistinct : ({a, a + d, a + 2 * d} : Finset ℕ).card = 3 := by
+    rw [Finset.card_insert_of_not_mem, Finset.card_insert_of_not_mem, Finset.card_singleton]
+    · simp; omega
+    · simp; omega
+  have hsub : ({a, a + d, a + 2 * d} : Finset ℕ) ⊆ S := by
+    intro x hx
+    simp only [Finset.mem_insert, Finset.mem_singleton] at hx
+    rcases hx with rfl | rfl | rfl <;> assumption
+  exact absurd (Finset.card_le_card hsub) (by omega)
 
 -- Aristotle target: {0, 1} contains no 3-term AP
 -- Only 2 elements, need 3 for an AP
-theorem apFree_zero_one : ∀ a d, d > 0 → ∃ i < 3, a + i * d ∉ ({0, 1} : Set ℕ) := by sorry
+theorem apFree_zero_one : ∀ a d, d > 0 → ∃ i < 3, a + i * d ∉ ({0, 1} : Set ℕ) := by
+  intro a d hd
+  -- If a ≥ 2, then a ∉ {0,1}
+  -- If a = 0, then a + 2d ≥ 2 so a + 2d ∉ {0,1}
+  -- If a = 1, then a + d ≥ 2 so a + d ∉ {0,1}
+  by_cases ha0 : a ≥ 2
+  · exact ⟨0, by omega, by simp [Set.mem_insert_iff]; omega⟩
+  · push_neg at ha0
+    interval_cases a
+    · exact ⟨2, by omega, by simp [Set.mem_insert_iff]; omega⟩
+    · exact ⟨1, by omega, by simp [Set.mem_insert_iff]; omega⟩
 
 -- Aristotle target: no 3-AP in a 2-element set of naturals
 theorem two_element_nat_set_apFree (x y : ℕ) (hxy : x ≠ y) :
-    ∀ a d, d > 0 → ∃ i < 3, a + i * d ∉ ({x, y} : Set ℕ) := by sorry
+    ∀ a d, d > 0 → ∃ i < 3, a + i * d ∉ ({x, y} : Set ℕ) := by
+  have hcard : ({x, y} : Finset ℕ).card < 3 := by
+    rw [Finset.card_insert_of_not_mem (by simp [hxy]), Finset.card_singleton]; omega
+  intro a d hd
+  obtain ⟨i, hi, hmem⟩ := apFree_of_card_lt_three {x, y} hcard a d hd
+  exact ⟨i, hi, by simpa using hmem⟩
 
 /-
   ## Section 2: Subset Sum Properties
@@ -49,15 +82,33 @@ def subsetSumsLocal (A : Finset ℕ) : Finset ℕ :=
 
 -- Aristotle target: subsetSums of singleton is {0, a}
 theorem subsetSums_singleton (a : ℕ) :
-    subsetSumsLocal {a} = {0, a} := by sorry
+    subsetSumsLocal {a} = {0, a} := by
+  unfold subsetSumsLocal
+  ext x
+  simp only [Finset.mem_image, Finset.mem_powerset, Finset.mem_insert, Finset.mem_singleton]
+  constructor
+  · rintro ⟨B, hB, rfl⟩
+    have : B = ∅ ∨ B = {a} := by
+      rcases Finset.eq_empty_or_nonempty B with rfl | ⟨b, hb⟩
+      · left; rfl
+      · right; ext y; simp only [Finset.mem_singleton]
+        exact ⟨fun hy => (Finset.mem_singleton.mp (hB hy)), fun hy => hy ▸ hb⟩
+    rcases this with rfl | rfl <;> simp
+  · rintro (rfl | rfl)
+    · exact ⟨∅, Finset.empty_subset _, by simp⟩
+    · exact ⟨{a}, Finset.Subset.refl _, by simp⟩
 
 -- Aristotle target: subsetSums of singleton has cardinality 2 (when a ≠ 0)
 theorem card_subsetSums_singleton (a : ℕ) (ha : a ≠ 0) :
-    (subsetSumsLocal {a}).card = 2 := by sorry
+    (subsetSumsLocal {a}).card = 2 := by
+  rw [subsetSums_singleton]
+  rw [Finset.card_insert_of_not_mem (by simp [ha]), Finset.card_singleton]
 
 -- Aristotle target: subsetSums of singleton has cardinality ≤ 2
 theorem card_subsetSums_singleton_le (a : ℕ) :
-    (subsetSumsLocal {a}).card ≤ 2 := by sorry
+    (subsetSumsLocal {a}).card ≤ 2 := by
+  rw [subsetSums_singleton]
+  exact le_trans (Finset.card_insert_le 0 {a}) (by simp)
 
 /-
   ## Section 3: Icc Cardinality Bounds
@@ -67,16 +118,19 @@ theorem card_subsetSums_singleton_le (a : ℕ) :
 -/
 
 -- Aristotle target: |Icc 1 N| = N
-theorem card_Icc_one (N : ℕ) : (Finset.Icc 1 N).card = N := by sorry
+theorem card_Icc_one (N : ℕ) : (Finset.Icc 1 N).card = N := by
+  simp [Nat.card_Icc]
 
 -- Aristotle target: if A ⊆ Icc 1 N then |A| ≤ N
 theorem subset_Icc_card_le (A : Finset ℕ) (N : ℕ) (hA : A ⊆ Finset.Icc 1 N) :
-    A.card ≤ N := by sorry
+    A.card ≤ N := by
+  calc A.card ≤ (Finset.Icc 1 N).card := Finset.card_le_card hA
+    _ = N := card_Icc_one N
 
 -- Aristotle target: N ≥ n when some A ⊆ Icc 1 N has |A| = n
 theorem Icc_contains_n_elements (A : Finset ℕ) (n N : ℕ)
     (hA : A ⊆ Finset.Icc 1 N) (hn : A.card = n) :
-    N ≥ n := by sorry
+    N ≥ n := hn ▸ subset_Icc_card_le A N hA
 
 /-
   ## Section 4: Powers of 3 are in Icc 1 (3^n)
@@ -86,13 +140,16 @@ theorem Icc_contains_n_elements (A : Finset ℕ) (n N : ℕ)
 -/
 
 -- Aristotle target: 3^i ≥ 1 for all i (so powers of 3 are in Icc 1 ...)
-theorem three_pow_pos (i : ℕ) : 0 < 3^i := by sorry
+theorem three_pow_pos (i : ℕ) : 0 < 3^i := by positivity
 
 -- Aristotle target: 3^i ≤ 3^n for i < n
-theorem three_pow_le_pow (i n : ℕ) (hi : i < n) : 3^i ≤ 3^n := by sorry
+theorem three_pow_le_pow (i n : ℕ) (hi : i < n) : 3^i ≤ 3^n :=
+  Nat.pow_le_pow_right (by norm_num) hi.le
 
 -- Aristotle target: 3^i ∈ Finset.Icc 1 (3^n) for i < n
 theorem three_pow_mem_Icc (i n : ℕ) (hi : i < n) :
-    3^i ∈ Finset.Icc 1 (3^n) := by sorry
+    3^i ∈ Finset.Icc 1 (3^n) := by
+  simp only [Finset.mem_Icc]
+  exact ⟨three_pow_pos i, three_pow_le_pow i n hi⟩
 
 end Erdos817Aristotle

--- a/proofs/Proofs/Erdos877Aristotle.lean
+++ b/proofs/Proofs/Erdos877Aristotle.lean
@@ -28,15 +28,15 @@ def isSumFree (A : Finset ℕ) : Prop :=
 
 -- Aristotle target: sum of two odd naturals is even (norm_num / omega)
 theorem odd_add_odd_even (b c : ℕ) (hb : b % 2 = 1) (hc : c % 2 = 1) :
-    (b + c) % 2 = 0 := by sorry
+    (b + c) % 2 = 0 := by omega
 
 -- Aristotle target: odd ≠ sum of two odds (follows from parity)
 theorem odd_ne_sum_of_two_odds (a b c : ℕ)
     (ha : a % 2 = 1) (hb : b % 2 = 1) (hc : c % 2 = 1) :
-    a ≠ b + c := by sorry
+    a ≠ b + c := by omega
 
 -- Aristotle target: 0 is not odd (trivial)
-theorem zero_not_odd : (0 : ℕ) % 2 ≠ 1 := by sorry
+theorem zero_not_odd : (0 : ℕ) % 2 ≠ 1 := by omega
 
 /-
   ## Section 2: The Odd Filter is Sum-Free
@@ -47,16 +47,32 @@ theorem zero_not_odd : (0 : ℕ) % 2 ≠ 1 := by sorry
 
 -- Aristotle target: the filter of odd numbers in range(n+1) is sum-free
 theorem isSumFree_odd_filter (n : ℕ) :
-    isSumFree (Finset.filter (fun x => x % 2 = 1) (Finset.range (n + 1))) := by sorry
+    isSumFree (Finset.filter (fun x => x % 2 = 1) (Finset.range (n + 1))) := by
+  intro a b c ha hb hc
+  simp only [Finset.mem_filter] at ha hb hc
+  exact odd_ne_sum_of_two_odds a b c ha.2 hb.2 hc.2
 
 -- Aristotle target: odd filter is a subset of range(n+1)
 theorem odd_filter_subset_range (n : ℕ) :
-    Finset.filter (fun x => x % 2 = 1) (Finset.range (n + 1)) ⊆ Finset.range (n + 1) := by sorry
+    Finset.filter (fun x => x % 2 = 1) (Finset.range (n + 1)) ⊆ Finset.range (n + 1) :=
+  Finset.filter_subset _ _
 
 -- Aristotle target: odd filter has cardinality ≥ n / 2
 -- Proof sketch: odds in {0,...,n} number ⌈(n+1)/2⌉ = (n+1)/2 ≥ n/2
 theorem odd_filter_card_ge_half (n : ℕ) :
-    (Finset.filter (fun x => x % 2 = 1) (Finset.range (n + 1))).card ≥ n / 2 := by sorry
+    (Finset.filter (fun x => x % 2 = 1) (Finset.range (n + 1))).card ≥ n / 2 := by
+  -- Injection k ↦ 2k+1 maps {0,...,n/2-1} into the odd numbers in {0,...,n}
+  calc (Finset.filter (fun x => x % 2 = 1) (Finset.range (n + 1))).card
+      ≥ (Finset.image (fun k => 2 * k + 1) (Finset.range (n / 2))).card := by
+        apply Finset.card_le_card
+        intro x hx
+        simp only [Finset.mem_image, Finset.mem_range] at hx
+        obtain ⟨k, hk, rfl⟩ := hx
+        simp only [Finset.mem_filter, Finset.mem_range]
+        exact ⟨by omega, by omega⟩
+    _ = (Finset.range (n / 2)).card := by
+        rw [Finset.card_image_of_injective _ (fun a b h => by omega)]
+    _ = n / 2 := Finset.card_range _
 
 /-
   ## Section 3: Existence of a Large Sum-Free Subset
@@ -70,7 +86,8 @@ theorem odd_filter_card_ge_half (n : ℕ) :
 theorem odds_construction_goal (n : ℕ) : ∃ A : Finset ℕ,
     A ⊆ Finset.range (n + 1) ∧
     isSumFree A ∧
-    A.card ≥ n / 2 := by sorry
+    A.card ≥ n / 2 :=
+  ⟨_, odd_filter_subset_range n, isSumFree_odd_filter n, odd_filter_card_ge_half n⟩
 
 /-
   ## Section 4: Sum-Free Maximality Helpers
@@ -81,7 +98,11 @@ theorem odds_construction_goal (n : ℕ) : ∃ A : Finset ℕ,
 
 -- Aristotle target: ¬isSumFree A implies existence of a violating triple
 theorem not_isSumFree_triple (A : Finset ℕ) (h : ¬isSumFree A) :
-    ∃ a b c : ℕ, a ∈ A ∧ b ∈ A ∧ c ∈ A ∧ a = b + c := by sorry
+    ∃ a b c : ℕ, a ∈ A ∧ b ∈ A ∧ c ∈ A ∧ a = b + c := by
+  unfold isSumFree at h
+  push_neg at h
+  obtain ⟨a, b, c, ha, hb, hc, heq⟩ := h
+  exact ⟨a, b, c, ha, hb, hc, heq⟩
 
 -- Aristotle target: if A is sum-free and insert x A is not, then x is in the triple
 -- (since A itself has no sum triple, the new element x must appear)
@@ -91,6 +112,17 @@ theorem insert_breaks_sum_free_via_x (A : Finset ℕ) (x : ℕ)
     (hAx : ¬isSumFree (insert x A)) :
     ∃ a b c : ℕ,
       a ∈ insert x A ∧ b ∈ insert x A ∧ c ∈ insert x A ∧ a = b + c ∧
-      (a = x ∨ b = x ∨ c = x) := by sorry
+      (a = x ∨ b = x ∨ c = x) := by
+  obtain ⟨a, b, c, ha, hb, hc, heq⟩ := not_isSumFree_triple _ hAx
+  refine ⟨a, b, c, ha, hb, hc, heq, ?_⟩
+  -- At least one of a, b, c must be x; otherwise all three are in A,
+  -- contradicting that A is sum-free
+  by_contra hall
+  push_neg at hall
+  obtain ⟨hax, hbx, hcx⟩ := hall
+  have ha' : a ∈ A := by simp only [Finset.mem_insert] at ha; exact ha.resolve_left hax
+  have hb' : b ∈ A := by simp only [Finset.mem_insert] at hb; exact hb.resolve_left hbx
+  have hc' : c ∈ A := by simp only [Finset.mem_insert] at hc; exact hc.resolve_left hcx
+  exact hA a b c ha' hb' hc' heq
 
 end Erdos877Aristotle


### PR DESCRIPTION
## Summary

### Commit 1: 38 sorries proved (5 files now sorry-free)
- **Erdos73Aristotle** (8→0): K₃ adjacency, independence (card ≤ 1), bipartite K₂ subgraph, almost-bipartite goal, arithmetic bounds
- **Erdos1043Aristotle** (9→0): ENNReal comparisons (norm_num), iInf ≤ value witness, iInf ≤ iSup, positivity facts
- **Erdos260Aristotle** (2→0): n/2^n summable (via summable_pow_mul_geometric), n/2^n → 0 (from summability)
- **Erdos817Aristotle** (12→0): AP-free small sets (card < 3, pigeonhole), subset sum singleton, Icc cardinality, powers of 3
- **Erdos877Aristotle** (9→0): Sum-free parity (odd+odd=even), odd filter construction, cardinality ≥ n/2 (injection), maximality

### Commit 2: 3 more sorries + 31 unused axioms removed
- **Erdos608ProblemAristotle** (3→0): c = (2+√2)/16 bounds via nlinarith + √2²=2
- 31 unused axioms removed across 7 files (Erdos1001OQ03, Hilbert6, Hilbert19, Erdos848, Erdos335, Erdos25, Erdos14)

**Total: 41 sorries eliminated, 6 files now sorry-free, 31 axioms removed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)