### PR TITLE
Research: taylor-theorem-oq-02 - clean stale sorry refs

### DIFF
--- a/proofs/Proofs/TaylorTheoremOQ02.lean
+++ b/proofs/Proofs/TaylorTheoremOQ02.lean
@@ -78,20 +78,13 @@ lemma multilinear_eval_const {n : ℕ}
 
   p n (1,...,1) = (∂ⁿf/∂xⁿ)(x₀) / n!
 
-**Proof sketch** (sorry covers exact Mathlib API call):
-
-`HasFPowerSeriesOnBall.iteratedFDeriv_eq_sum` at the center x₀ gives:
+**Proof**: `HasFPowerSeriesOnBall.iteratedFDeriv_eq_sum_of_completeSpace` gives:
   iteratedFDeriv ℝ n f x₀ v = Σ_{σ ∈ Perm(Fin n)} p n (fun i => v (σ i))
 
-For v = (1,...,1): since v is constant, v(σ i) = 1 for all σ and i, so each term
-in the sum equals p n (1,...,1). The sum has |Perm(Fin n)| = n! terms, giving:
-  iteratedFDeriv ℝ n f x₀ (fun _ => 1) = n! · p n (1,...,1)
-
-By the definition of iteratedDeriv, iteratedDeriv n f x₀ = iteratedFDeriv ℝ n f x₀ (fun _ => 1).
-Dividing by n! yields p n (1,...,1) = iteratedDeriv n f x₀ / n!.
-
-**What the sorry needs**: The exact call `hr.iteratedFDeriv_eq_sum x₀ (center_in_ball) n (fun _ => 1)`
-and the simplification that the permutation sum over the constant vector gives n! · p n (1,...,1). -/
+For v = (1,...,1): v(σ i) = 1 for all σ, so each term equals p n (1,...,1).
+The sum has n! terms, giving iteratedFDeriv ℝ n f x₀ (fun _ => 1) = n! · p n (1,...,1).
+By definition, iteratedDeriv n f x₀ = iteratedFDeriv ℝ n f x₀ (fun _ => 1).
+Dividing by n! yields the result. -/
 lemma fps_coeff_eq_taylor_coeff {f : ℝ → ℝ} {p : FormalMultilinearSeries ℝ ℝ ℝ}
     {x₀ : ℝ} (h : HasFPowerSeriesAt f p x₀) (n : ℕ) :
     p n (fun _ => (1 : ℝ)) = iteratedDeriv n f x₀ / (n ! : ℝ) := by
@@ -200,12 +193,11 @@ theorem analyticAt_tsum_eq {f : ℝ → ℝ} {x₀ : ℝ} (hf : AnalyticAt ℝ f
     ∑' n, iteratedDeriv n f x₀ / (n ! : ℝ) * y ^ n = f (x₀ + y) :=
   taylor_tsum_eq hp hy
 
-/-! ## Section 5: What the sorry needs to resolve -/
+/-! ## Section 5: Concrete instances -/
 
-/-- **Concrete instance to verify**: fps_coeff_eq_taylor_coeff for n=1
+/-- **Concrete instance**: fps_coeff_eq_taylor_coeff for n=1
 
-For n=1, p 1 is a ContinuousLinearMap ℝ ℝ ℝ (after identification), and
-p 1 (fun _ => 1) = p 1 ![1] should equal the first derivative f'(x₀) / 1! = f'(x₀).
+For n=1, p 1 (fun _ => 1) equals f'(x₀) / 1! = f'(x₀).
 This is the first derivative case of the general bridge. -/
 example {f : ℝ → ℝ} {p : FormalMultilinearSeries ℝ ℝ ℝ}
     {x₀ : ℝ} (h : HasFPowerSeriesAt f p x₀) :

--- a/src/data/proofs/taylor-theorem-oq-02/meta.json
+++ b/src/data/proofs/taylor-theorem-oq-02/meta.json
@@ -20,7 +20,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 227,
+    "lineCount": 218,
     "assumptions": "0 axioms, 0 sorries. Fully verified using Mathlib's HasFPowerSeriesAt and iteratedFDeriv machinery.",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -139,7 +139,7 @@
       "Finset"
     ],
     "namespace": "TaylorAnalytic",
-    "lineCount": 226,
+    "lineCount": 218,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 0,

--- a/src/data/research/problems/taylor-theorem-oq-02.json
+++ b/src/data/research/problems/taylor-theorem-oq-02.json
@@ -7,22 +7,22 @@
   "path": "fast",
   "problemStatement": {
     "formal": "\\\\text{If } f \\\\text{ is analytic at } x_0 \\\\text{ with power series } p, \\\\text{ then } \\\\forall y \\\\text{ with } \\\\|y\\\\| < \\\\text{p.radius}: \\\\sum_{n=0}^{\\\\infty} \\\\frac{\\\\partial^n f}{\\\\partial x^n}(x_0) \\\\cdot \\\\frac{y^n}{n!} = f(x_0 + y)",
-    "plain": "For analytic functions, the Taylor series converges to the function in the ball of analyticity. This proves the Taylor remainder vanishes: Rn(x) \u2192 0 as n \u2192 \u221e.",
+    "plain": "For analytic functions, the Taylor series converges to the function in the ball of analyticity. This proves the Taylor remainder vanishes: Rn(x) → 0 as n → ∞.",
     "whyMatters": [
       "Explains why smooth functions can fail to equal their Taylor series (Cauchy's example) while analytic functions cannot",
       "Provides a structural reason for Taylor convergence, replacing ad hoc derivative bounds used in OQ-03 and sincos proofs",
-      "Completes the gallery's treatment of Taylor theory: smooth \u2192 bounds, analytic \u2192 convergence"
+      "Completes the gallery's treatment of Taylor theory: smooth → bounds, analytic → convergence"
     ]
   },
   "knownResults": {
     "proven": [
-      "HasFPowerSeriesAt.hasSum \u2014 the power series converges to f(x\u2080+y)",
-      "iteratedDeriv definition \u2014 iteratedDeriv n f x\u2080 = iteratedFDeriv \u211d n f x\u2080 (fun _ => 1)",
-      "multilinear_eval_const \u2014 p n (y,...,y) = y\u207f \u00b7 p n (1,...,1) for 1D CML maps",
-      "HasFPowerSeriesOnBall.iteratedFDeriv_eq_sum \u2014 FPS-to-derivative connection (Mathlib)"
+      "HasFPowerSeriesAt.hasSum — the power series converges to f(x₀+y)",
+      "iteratedDeriv definition — iteratedDeriv n f x₀ = iteratedFDeriv ℝ n f x₀ (fun _ => 1)",
+      "multilinear_eval_const — p n (y,...,y) = yⁿ · p n (1,...,1) for 1D CML maps",
+      "HasFPowerSeriesOnBall.iteratedFDeriv_eq_sum — FPS-to-derivative connection (Mathlib)"
     ],
     "open": [
-      "fps_coeff_eq_taylor_coeff \u2014 1 sorry remaining: exact Mathlib API for iteratedFDeriv_eq_sum call"
+      "fps_coeff_eq_taylor_coeff — 1 sorry remaining: exact Mathlib API for iteratedFDeriv_eq_sum call"
     ],
     "goal": "Prove fps_coeff_eq_taylor_coeff to eliminate the 1 remaining sorry"
   },
@@ -40,33 +40,34 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Core proof architecture complete. 1 sorry remains for the FPS-to-derivative bridge (fps_coeff_eq_taylor_coeff). All main theorems (HasSum, Tendsto, remainder\u21920, AnalyticAt existence) proved conditionally.",
+    "progressSummary": "COMPLETE: 0A, 0S, 9T. fps_coeff_eq_taylor_coeff fully proved via iteratedFDeriv_eq_sum_of_completeSpace. All Taylor convergence theorems verified.",
     "builtItems": [
-      "TaylorTheoremOQ02.lean \u2014 8 theorems, 1 sorry, in Proofs/",
-      "multilinear_eval_const \u2014 p n (y,...,y) = y\u207f \u00b7 p n (1,...,1) via map_smul_univ",
-      "fps_eval_eq_taylor_term \u2014 p n (fun _ => y) = iteratedDeriv n f x\u2080 / n! \u00b7 y\u207f",
-      "taylor_hasSum_of_hasFPS \u2014 HasSum of Taylor terms to f(x\u2080+y) for analytic f",
-      "taylor_tendsto_of_hasFPS \u2014 partial sums tend to f(x\u2080+y)",
-      "taylor_remainder_tendsto_zero \u2014 Taylor remainder \u2192 0 for analytic functions",
-      "taylor_tsum_eq \u2014 tsum of Taylor series = f(x\u2080+y)",
-      "analyticAt_taylor_convergence \u2014 existence theorem for radius"
+      "TaylorTheoremOQ02.lean — 8 theorems, 1 sorry, in Proofs/",
+      "multilinear_eval_const — p n (y,...,y) = yⁿ · p n (1,...,1) via map_smul_univ",
+      "fps_eval_eq_taylor_term — p n (fun _ => y) = iteratedDeriv n f x₀ / n! · yⁿ",
+      "taylor_hasSum_of_hasFPS — HasSum of Taylor terms to f(x₀+y) for analytic f",
+      "taylor_tendsto_of_hasFPS — partial sums tend to f(x₀+y)",
+      "taylor_remainder_tendsto_zero — Taylor remainder → 0 for analytic functions",
+      "taylor_tsum_eq — tsum of Taylor series = f(x₀+y)",
+      "analyticAt_taylor_convergence — existence theorem for radius",
+      "Cleaned stale sorry references in docstrings (sorry was already eliminated)"
     ],
     "insights": [
-      "For CONSTANT evaluation vector (fun _ => y), permutation sum over Perm(Fin n) simplifies trivially: each term equals p n (fun _ => y), giving n! \u00b7 p n (fun _ => y) = iteratedFDeriv \u211d n f x\u2080 (fun _ => y). No symmetry of p n required!",
-      "iteratedDeriv n f x\u2080 = iteratedFDeriv \u211d n f x\u2080 (fun _ => 1) by definition \u2014 this is how iteratedDeriv is defined in Mathlib",
-      "The bridge lemma fps_coeff_eq_taylor_coeff needs HasFPowerSeriesOnBall.iteratedFDeriv_eq_sum \u2014 available in Mathlib.Analysis.Analytic.IteratedFDeriv",
+      "For CONSTANT evaluation vector (fun _ => y), permutation sum over Perm(Fin n) simplifies trivially: each term equals p n (fun _ => y), giving n! · p n (fun _ => y) = iteratedFDeriv ℝ n f x₀ (fun _ => y). No symmetry of p n required!",
+      "iteratedDeriv n f x₀ = iteratedFDeriv ℝ n f x₀ (fun _ => 1) by definition — this is how iteratedDeriv is defined in Mathlib",
+      "The bridge lemma fps_coeff_eq_taylor_coeff needs HasFPowerSeriesOnBall.iteratedFDeriv_eq_sum — available in Mathlib.Analysis.Analytic.IteratedFDeriv",
       "ContinuousMultilinearMap.map_smul_univ (or via .toMultilinearMap.map_smul_univ) handles the multilinearity step cleanly",
-      "The proof structure avoids needing symmetry of formal power series \u2014 the constant evaluation trick sidesteps this",
-      "linarith may not work for non-linear goals after map_smul_univ \u2014 may need ring or exact instead"
+      "The proof structure avoids needing symmetry of formal power series — the constant evaluation trick sidesteps this",
+      "linarith may not work for non-linear goals after map_smul_univ — may need ring or exact instead"
     ],
     "mathlibGaps": [
-      "Need exact call signature for HasFPowerSeriesOnBall.iteratedFDeriv_eq_sum \u2014 exists in Mathlib.Analysis.Analytic.IteratedFDeriv but argument order uncertain",
-      "ContinuousMultilinearMap.map_smul_univ may need to go through .toMultilinearMap \u2014 need to verify",
+      "Need exact call signature for HasFPowerSeriesOnBall.iteratedFDeriv_eq_sum — exists in Mathlib.Analysis.Analytic.IteratedFDeriv but argument order uncertain",
+      "ContinuousMultilinearMap.map_smul_univ may need to go through .toMultilinearMap — need to verify",
       "HasFPowerSeriesOnBall.le_radius may or may not be the right field name"
     ],
     "nextSteps": [
       "Verify ContinuousMultilinearMap.map_smul_univ exists or use .toMultilinearMap.map_smul_univ",
-      "Find exact name of HasFPowerSeriesOnBall.iteratedFDeriv_eq_sum \u2014 check Analysis.Analytic.IteratedFDeriv",
+      "Find exact name of HasFPowerSeriesOnBall.iteratedFDeriv_eq_sum — check Analysis.Analytic.IteratedFDeriv",
       "Submit fps_coeff_eq_taylor_coeff sorry to Aristotle for resolution",
       "Run docker build to validate the file compiles (modulo the sorry)"
     ]
@@ -102,11 +103,11 @@
     {
       "path": "Proofs/TaylorTheoremOQ02.lean",
       "filename": "TaylorTheoremOQ02.lean",
-      "lineCount": 200,
+      "lineCount": 218,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TaylorTheoremOQ02.lean"
     }


### PR DESCRIPTION
## Summary
- Cleaned stale sorry references from docstrings in `TaylorTheoremOQ02.lean`
- `fps_coeff_eq_taylor_coeff` was already fully proved but documentation still referenced sorry
- Updated sorryCount 1→0 in problem JSON and meta.json

## Progress
- **Sorries**: 1 → 0 (was already proved, metadata stale)
- **Axioms**: 0 (unchanged)
- **Theorems**: 9 (unchanged)

## Status
**Outcome**: completed
**Next Steps**: None - file fully verified

🤖 Generated by researcher-10