### PR TITLE
Fix: sync root-level status/badge in 3 OQ proofs

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01/meta.json
@@ -185,7 +185,7 @@
     ]
   },
   "sorryCount": 0,
-  "status": "formalized",
+  "status": "verified",
   "badge": "original",
   "leanFile": {
     "imports": [

--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03/meta.json
@@ -5,7 +5,7 @@
   "description": "Extends quadratic reciprocity from the Legendre symbol (prime moduli) to the Jacobi symbol (composite odd moduli), formalizing the generalized reciprocity law J(m,n)·J(n,m) = (-1)^((m-1)/2·(n-1)/2) for coprime odd m,n.",
   "category": "number-theory",
   "status": "verified",
-  "badge": "mathlib",
+  "badge": "original",
   "difficulty": "intermediate",
   "leanFile": {
     "path": "Proofs/ElementaryQuadraticReciprocityOQ03.lean",

--- a/src/data/proofs/solution-of-cubic-oq-03-oq-03/meta.json
+++ b/src/data/proofs/solution-of-cubic-oq-03-oq-03/meta.json
@@ -5,7 +5,7 @@
   "description": "Proves that Ferrari's resolvent cubic for the quartic equation reduces to a depressed cubic solvable by Cardano's formula, completing the quartic-cubic-Cardano solution chain.",
   "category": "algebra",
   "status": "verified",
-  "badge": "mathlib",
+  "badge": "original",
   "difficulty": "intermediate",
   "leanFile": {
     "path": "Proofs/SolutionOfCubicOQ03OQ03.lean",


### PR DESCRIPTION
## Fix

Sync inconsistent root-level `status`/`badge` fields to match their authoritative `meta.meta` values in 3 OQ proofs.

## Evidence

**Before**:
- `cayley-hamilton-minpoly-oq-05-oq-01`: root `status: "formalized"`, meta `status: "verified"` (0 sorries, 0 axioms)
- `elementary-quadratic-reciprocity-oq-03`: root `badge: "mathlib"`, meta `badge: "original"`
- `solution-of-cubic-oq-03-oq-03`: root `badge: "mathlib"`, meta `badge: "original"`

**After**: All root-level fields match `meta.meta` values. Build passes.

---
Automated fix by lean-mechanic agent.