### PR TITLE
Research: erdos-183 — prove R3k_factorial_upper (axiom→theorem)

### DIFF
--- a/proofs/Proofs/Erdos183Problem.lean
+++ b/proofs/Proofs/Erdos183Problem.lean
@@ -444,12 +444,40 @@ theorem R3k_inductive_upper (k : ℕ) (hk : k ≥ 2) :
   convert forcing_step (k - 1) _ hkm1 hm using 2
   omega
 
-/-- The upper bound via pigeonhole: R(3;k) ≤ e·k! + O(1) -/
-axiom R3k_factorial_upper :
-  ∃ C : ℝ, C > 0 ∧ ∀ k : ℕ, k ≥ 1 → (R3k k : ℝ) ≤ Real.exp 1 * k.factorial + C
+/-- R(3;k) ≤ 3·k! for all k ≥ 1.
+    Proof by induction using the pigeonhole recurrence R3k_inductive_upper.
+    Base: R(3;1) = 3 = 3·1!.
+    Step: R(3;k+1) ≤ 2 + (k+1)·(3·k! - 1) = 3·(k+1)! + 2 - (k+1) ≤ 3·(k+1)!. -/
+theorem R3k_le_three_factorial (k : ℕ) (hk : k ≥ 1) : R3k k ≤ 3 * k.factorial := by
+  induction k with
+  | zero => omega
+  | succ n ih =>
+    by_cases hn : n = 0
+    · subst hn; rw [R3k_one]; norm_num
+    · have hn1 : n ≥ 1 := Nat.pos_of_ne_zero hn
+      have h_ih := ih hn1
+      have h_ge := R3k_ge_three n hn1
+      have h_upper := R3k_inductive_upper (n + 1) (by omega)
+      -- Cast to ℤ where subtraction is well-behaved
+      suffices h : (R3k (n + 1) : ℤ) ≤ 3 * ↑((n + 1).factorial) by exact_mod_cast h
+      have h1 : (R3k (n + 1) : ℤ) ≤ 2 + (↑n + 1) * (↑(R3k n) - 1) := by
+        have hsub : (↑(R3k n - 1) : ℤ) = ↑(R3k n) - 1 :=
+          Nat.cast_sub (show 1 ≤ R3k n by omega)
+        have : (R3k (n + 1) : ℤ) ≤ ↑(2 + (n + 1) * (R3k n - 1)) := by exact_mod_cast h_upper
+        rw [Nat.cast_add, Nat.cast_mul, hsub] at this
+        linarith
+      have h2 : (R3k n : ℤ) ≤ 3 * ↑(n.factorial) := by exact_mod_cast h_ih
+      rw [show ((n + 1).factorial : ℤ) = (↑n + 1) * ↑(n.factorial) from by
+        push_cast [Nat.factorial_succ]; ring]
+      nlinarith [show (n : ℤ) ≥ 1 from by exact_mod_cast hn1]
 
--- Note: The ceiling form R(3;k) ≤ ⌈e·k!⌉ + 1 requires a tighter constant
--- than R3k_factorial_upper provides. Omitted to avoid a sorry.
+/-- The upper bound via pigeonhole: R(3;k) ≤ C·k! for C = 3.
+    Proved from R3k_le_three_factorial. The tighter bound R(3;k) ≤ ⌈e·k!⌉
+    (i.e., C = e with no additive constant) also holds but requires real
+    analysis to connect the subfactorial sum to the exp series. -/
+theorem R3k_factorial_upper :
+    ∃ C : ℝ, C > 0 ∧ ∀ k : ℕ, k ≥ 1 → (R3k k : ℝ) ≤ C * k.factorial := by
+  exact ⟨3, by norm_num, fun k hk => by exact_mod_cast R3k_le_three_factorial k hk⟩
 
 /-
 # Part 5: Lower Bound via Schur Numbers
@@ -526,14 +554,7 @@ def erdos_183_status : String := "OPEN"
 theorem bounds_summary :
     (∃ c : ℝ, c > 1 ∧ ∀ k ≥ 1, (R3k k : ℝ) ≥ c ^ k) ∧
     (∃ C : ℝ, ∀ k ≥ 1, (R3k k : ℝ) ≤ C * k.factorial) := by
-  constructor
-  · exact R3k_exponential_lower
-  · obtain ⟨C, _, hbound⟩ := R3k_factorial_upper
-    use Real.exp 1 + C
-    intro k hk
-    have hfact : (k.factorial : ℝ) ≥ 1 := by
-      exact_mod_cast Nat.factorial_pos k
-    nlinarith [hbound k hk]
+  exact ⟨R3k_exponential_lower, let ⟨C, _, h⟩ := R3k_factorial_upper; ⟨C, h⟩⟩
 
 /-
 # Part 8: Connection to Other Problems
@@ -554,15 +575,6 @@ The precise formal statement of Problem #183.
 theorem erdos_183_main :
     (∀ k ≥ 1, R3k k ≥ 3) ∧
     (∃ C : ℝ, C > 0 ∧ ∀ k ≥ 1, (R3k k : ℝ) ≤ C * k.factorial) := by
-  constructor
-  · exact R3k_ge_three
-  · obtain ⟨C, hCpos, hbound⟩ := R3k_factorial_upper
-    use Real.exp 1 + C
-    constructor
-    · linarith [Real.exp_pos 1]
-    · intro k hk
-      have hfact : (k.factorial : ℝ) ≥ 1 := by
-        exact_mod_cast Nat.factorial_pos k
-      nlinarith [hbound k hk]
+  exact ⟨R3k_ge_three, R3k_factorial_upper⟩
 
 end Erdos183

--- a/src/data/proofs/erdos-183/meta.json
+++ b/src/data/proofs/erdos-183/meta.json
@@ -50,8 +50,8 @@
       "Connection between Schur numbers and Ramsey numbers",
       "Growth rate bounds and limit formulations"
     ],
-    "axiomCount": 2,
-    "lineCount": 568,
+    "axiomCount": 1,
+    "lineCount": 580,
     "references": [
       {
         "title": "Some remarks on the theory of graphs",
@@ -76,7 +76,7 @@
         "description": "Establishes the lower bound R(3;k) ≥ 380^{k/5} − O(1), a major improvement over previous bounds"
       }
     ],
-    "assumptions": "6 axioms: R3k_three (=17), R3k_factorial_upper, SchurNumber (definition), R3k_schur_lower, R3k_exponential_lower, R3k_precise_lower. R3k_inductive_upper PROVED from extracted pigeonhole step (forcing_step). forcing_set_nonempty PROVED via pigeonhole induction. R3k_two PROVED via pigeonhole + C₅ construction."
+    "assumptions": "1 axiom: R3k_exponential_lower (c^k lower bound from Schur numbers). R3k_factorial_upper PROVED from R3k_le_three_factorial (induction on pigeonhole recurrence). R3k_inductive_upper PROVED from extracted pigeonhole step. forcing_set_nonempty PROVED via pigeonhole induction. R3k_one, R3k_two PROVED. Monotonicity PROVED."
   },
   "overview": {
     "historicalContext": "This problem was posed by Paul Erdős in 1961 [Er61] and remains one of the fundamental open questions in Ramsey theory. The multicolor Ramsey number R(3;k) generalizes the classical two-color Ramsey number R(3,3) = 6, which asks for the minimum n such that any 2-coloring of K_n's edges contains a monochromatic triangle.\n\nThe problem connects to several areas of combinatorics. The upper bound R(3;k) ≤ ⌈e·k!⌉ follows from a clever pigeonhole argument, while lower bounds come from connections to Schur numbers. A major breakthrough came in 2021 when Ageron, Casteras, Pellerin, Portella, Rimmel, and Tomasik [ACPPRT21] improved the lower bound to R(3;k) ≥ 380^{k/5} - O(1).\n\nErdős offered $250 for solving this problem, with an additional $100 specifically for proving that the limit is finite. The gap between known bounds is enormous: R(3;k) lies between roughly 3.28^k and k!, making this one of the most intriguing open problems in Ramsey theory.",
@@ -184,10 +184,10 @@
       "Classical"
     ],
     "namespace": "Erdos183",
-    "lineCount": 568,
-    "axiomCount": 2,
-    "theoremCount": 15,
-    "definitionCount": 13,
+    "lineCount": 580,
+    "axiomCount": 1,
+    "theoremCount": 17,
+    "definitionCount": 14,
     "path": "Proofs/Erdos183Problem.lean",
     "sorries": 0
   },

--- a/src/data/research/problems/erdos-183.json
+++ b/src/data/research/problems/erdos-183.json
@@ -18,13 +18,13 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-03-26T00:00:00Z",
-    "iteration": 4,
-    "focus": "7 axioms (down from 8). Proved forcing_set_nonempty via pigeonhole induction on k.",
+    "iteration": 5,
+    "focus": "1 axiom remaining (R3k_exponential_lower). R3k_factorial_upper eliminated via R3k_le_three_factorial.",
     "blockers": [],
     "nextAction": "Prove forcing_set_nonempty or R3k_inductive_upper via pigeonhole"
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: 6A (down from 7), 15T proved, 0S. R3k_inductive_upper proved by extracting pigeonhole step.",
+    "progressSummary": "COMPLETE: 1A (down from 2), 17T proved, 0S. R3k_factorial_upper proved from R3k_le_three_factorial via pigeonhole induction.",
     "builtItems": [
       "R3k_one: proved R(3;1)=3 via Nat.find_eq_iff — upper bound uses Subsingleton.elim on Fin 1, lower bound uses pigeonhole on Fin m for m<3",
       "Removed 2 inconsistent axioms (kthRoot_lower, kthRoot_upper) and 1 sorry theorem",
@@ -37,7 +37,9 @@
       "mapColor: color relabeling function Fin(k+1) → Fin k collapsing c₀, with injectivity on ≠c₀",
       "forces_imp_ge_three: proof that ForcesMonochromaticTriangle m k with k≥1 requires m≥3",
       "forcing_step: extracted pigeonhole lemma — if m forces triangle with k colors, (k+1)*(m-1)+2 forces with k+1 colors",
-      "R3k_inductive_upper: PROVED (axiom→theorem) — R(3;k) ≤ 2 + k*(R(3;k-1)-1) from forcing_step + Nat.find_min"
+      "R3k_inductive_upper: PROVED (axiom→theorem) — R(3;k) ≤ 2 + k*(R(3;k-1)-1) from forcing_step + Nat.find_min",
+      "R3k_le_three_factorial: proved R(3;k) ≤ 3·k! by induction on k using R3k_inductive_upper (ℤ-cast arithmetic)",
+      "R3k_factorial_upper: PROVED (axiom→theorem) — ∃ C>0, R(3;k) ≤ C·k! with C=3, from R3k_le_three_factorial"
     ],
     "insights": [
       "kthRoot_lower is INCONSISTENT with R3k_one: kthRootR3k 1 = R3k(1)^1 = 3 but axiom requires c > 3",
@@ -49,7 +51,9 @@
       "pigeonhole_five_two provable via native_decide on the finite function space Fin 5 → Fin 2",
       "forcing_set_nonempty proved by pigeonhole induction on k: base k=1 uses K₃, inductive step uses (k+1)*(m-1)+2 vertices and mapColor for color relabeling",
       "R3k_inductive_upper was provable from existing infrastructure — same pigeonhole step as forcing_set_nonempty",
-      "Axiom count reduced 7→6. Remaining 6 are deeper: R3k_three (computational), factorial bound (needs induction+Stirling), SchurNumber/bounds (deep combinatorics)"
+      "Axiom count reduced 7→6. Remaining 6 are deeper: R3k_three (computational), factorial bound (needs induction+Stirling), SchurNumber/bounds (deep combinatorics)",
+      "R3k_factorial_upper is provable by showing R(3;k) ≤ 3·k! via induction: base R(3;1)=3=3·1!, step uses R3k_inductive_upper + ℤ cast to handle Nat subtraction",
+      "The tighter bound R(3;k) ≤ ⌈e·k!⌉ would require connecting the subfactorial sum Σ k!/i! to the exp series — left as potential future work"
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -70,17 +74,17 @@
     "mathlib": []
   },
   "started": "2026-01-12T10:00:45.598Z",
-  "lastUpdate": "2026-03-28T10:00:00Z",
+  "lastUpdate": "2026-04-13T12:00:00Z",
   "significance": 5,
   "tractability": 3,
   "leanFiles": [
     {
       "path": "Proofs/Erdos183Problem.lean",
       "filename": "Erdos183Problem.lean",
-      "lineCount": 569,
-      "theoremCount": 15,
-      "axiomCount": 2,
-      "defCount": 15,
+      "lineCount": 580,
+      "theoremCount": 17,
+      "axiomCount": 1,
+      "defCount": 14,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos183Problem.lean"


### PR DESCRIPTION
## Summary
- **Prove R3k_le_three_factorial**: R(3;k) ≤ 3·k! for all k ≥ 1, by induction using the pigeonhole recurrence R3k_inductive_upper. Key technique: cast to ℤ to handle Nat subtraction cleanly, then nlinarith closes the arithmetic.
- **Convert axiom R3k_factorial_upper to theorem**: ∃ C > 0, ∀ k ≥ 1, R(3;k) ≤ C·k! (with C = 3). The original axiom used e·k! + C; the new statement uses C·k! which is what all downstream proofs actually needed.
- **Simplify bounds_summary and erdos_183_main**: Both now trivially follow from the proved factorial upper bound.
- **Axiom count**: 2 → 1 (only R3k_exponential_lower remains)

## Proof sketch
- Base: R(3;1) = 3 = 3·1!
- Step (k ≥ 2): R(3;k) ≤ 2 + k·(R(3;k-1) - 1) ≤ 2 + k·(3·(k-1)! - 1) = 3·k! + 2 - k ≤ 3·k!

## Files modified
- `proofs/Proofs/Erdos183Problem.lean` — new theorem + axiom→theorem conversion
- `src/data/proofs/erdos-183/meta.json` — axiomCount, lineCount, assumptions
- `src/data/research/problems/erdos-183.json` — knowledge update

## Status
**Outcome**: progress (axiom elimination)
**Remaining**: 1 axiom (R3k_exponential_lower — requires Schur number theory)

🤖 Generated by researcher-6