### PR TITLE
Fix: sync leanFile.sorries for erdos-727 and basel-problem

### DIFF
--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
@@ -18,11 +18,11 @@
       "research"
     ],
     "badge": "formalized",
-    "sorries": 5,
+    "sorries": 4,
     "dateAdded": "2026-04-12",
     "axiomCount": 0,
     "lineCount": 199,
-    "assumptions": "0 axioms. 5 sorries: recurrence relation, growth bound, main theorem. Infrastructure scaffold for full Ap\u00e9ry proof.",
+    "assumptions": "0 axioms. 4 sorries: recurrence relation, growth bound, main theorem. Infrastructure scaffold for full Ap\u00e9ry proof.",
     "mathlib_version": "4.26.0",
     "originalContributions": [
       "Defined Ap\u00e9ry numbers aperyB(n) = \u2211 C(n,k)\u00b2C(n+k,k)\u00b2 as a computable \u2115-valued function",
@@ -144,7 +144,7 @@
     "theoremCount": 15,
     "definitionCount": 4,
     "path": "Proofs/BaselProblemOQ01OQ01OQ02.lean",
-    "sorries": 5
+    "sorries": 4
   },
   "references": [
     {
@@ -169,5 +169,5 @@
       "note": "Survey of Ap\u00e9ry-like proofs and generalizations, including connections to modular forms."
     }
   ],
-  "sorries": 5
+  "sorries": 4
 }

--- a/src/data/proofs/erdos-727/meta.json
+++ b/src/data/proofs/erdos-727/meta.json
@@ -19,7 +19,7 @@
       "partially-solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 727,
     "erdosUrl": "https://erdosproblems.com/727",
     "erdosProblemStatus": "open",
@@ -58,7 +58,7 @@
     ],
     "axiomCount": 3,
     "lineCount": 285,
-    "assumptions": "5 axiom(s) and 1 sorry(s). See the Lean source for details."
+    "assumptions": "3 axioms: balakran_theorem (Balakran 1929, k=1 case), egrs_theorem (EGRS variant for k≥2), erdos_factorial_bound (Erdős 1968 bound). 0 sorries."
   },
   "overview": {
     "historicalContext": "Erdős Problem #727 was posed by Erdős, Graham, Ruzsa, and Straus in their 1975 paper 'On the prime factors of C(2n,n)'. The problem asks about the divisibility of (2n)! by squared factorials.\n\n**Key results**:\n- **Balakran (1929)**: Solved the k=1 case, proving ((n+1)!)² | (2n)! for infinitely many n. This is equivalent to (n+1)² dividing the central binomial coefficient C(2n,n).\n- **Classical**: (n+1) | C(2n,n) for ALL n (this defines the Catalan numbers).\n- **EGRS (1975)**: Proved a weaker variant: (n+k)!(n+1)! | (2n)! for infinitely many n, for any k ≥ 2.\n\nThe main question for k ≥ 2 remains **OPEN** even for k = 2.",
@@ -180,7 +180,7 @@
     "theoremCount": 7,
     "definitionCount": 9,
     "path": "Proofs/Erdos727Problem.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -204,5 +204,5 @@
       "description": "Unique factorization underlies the divisibility analysis"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary
- **erdos-727**: `sorries` 1→0 (sorry was resolved in Lean source, meta.json stale). Updated `assumptions` text to accurately reflect 3 axioms (was incorrectly stating "5 axiom(s) and 1 sorry(s)").
- **basel-problem-oq-01-oq-01-oq-02**: `sorries` 5→4 (one sorry resolved in Lean source, meta.json stale).

## Test plan
- [ ] `pnpm build` passes
- [ ] Gallery pages for erdos-727 and basel-problem-oq-01-oq-01-oq-02 render correctly

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)