### PR TITLE
Research: shapley-folkman architecture analysis + erdos-1027-oq-03 complete

### DIFF
--- a/src/data/research/problems/erdos-1027-oq-03.json
+++ b/src/data/research/problems/erdos-1027-oq-03.json
@@ -29,9 +29,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETE: 1 deep axiom (erdos_1027_solution = Koishi Chan theorem), 0 sorries, 10 theorems. File is mature.",
+    "builtItems": [
+      "Erdos1027Problem.lean: 355L, 10T, 1A (deep), 0S",
+      "Erdos1027Aristotle.lean: 50L companion file"
+    ],
+    "insights": [
+      "erdos_1027_solution axiom encodes Koishi Chan theorem — external result solving Erdős #1027",
+      "All 10 theorems are sorry-free, including abundance_implies_propertyB connection",
+      "Single axiom is the correct mathematical approach — this IS an open problem now solved externally"
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Knowledge Base: erdos-1027-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"

--- a/src/data/research/problems/erdos-1168.json
+++ b/src/data/research/problems/erdos-1168.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Reduced from 2 axioms to 1. Converted open conjecture from axiom to def. Only axiom is the known GCH result.",
+    "progressSummary": "IN PROGRESS: 0 axioms (was 1), 2 deep sorries (base_case_under_gch needs Erdős-Rado, stepping_up needs coloring construction). Both are advanced infinitary combinatorics.",
     "builtItems": [
       "partitionRelation: multi-color partition relation (ℕ-indexed colors)",
       "IsHomogeneous: homogeneity predicate",
@@ -47,7 +47,9 @@
       "The partition relation is antimonotone in targets (weaker targets easier to satisfy)",
       "Converted erdos_1168 from axiom to def (open conjecture should not be axiomatized as true)",
       "erdos_1168_under_gch is the only axiom: it encodes the known GCH-conditional result",
-      "Added gch_implies_conjecture theorem: connects the known GCH result to the open conjecture"
+      "Added gch_implies_conjecture theorem: connects the known GCH result to the open conjecture",
+      "Previous axiom replaced with theorem erdos_1168_under_gch decomposed into 2 sorries: base_case_under_gch and stepping_up",
+      "Both sorries are deep: base case needs Erdős-Rado theorem formalization, stepping up needs cardinal arithmetic + coloring machinery"
     ],
     "mathlibGaps": [],
     "nextSteps": [],
@@ -77,9 +79,9 @@
       "filename": "Erdos1168Problem.lean",
       "lineCount": 153,
       "theoremCount": 5,
-      "axiomCount": 1,
+      "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 0,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1168Problem.lean"
     }

--- a/src/data/research/problems/shapley-folkman.json
+++ b/src/data/research/problems/shapley-folkman.json
@@ -6,7 +6,7 @@
   "tier": "A",
   "path": "full",
   "knowledge": {
-    "progressSummary": "1 sorry remaining: reduce_excess_by_one Step 6 only (Steps 1-5 proved, including Step 2 embedding extraction via Multiset.toList)",
+    "progressSummary": "BLOCKED: Step 6 perturbation has architectural issue. Binary representation (av∈S, bv∈conv(S)) cannot guarantee single-step excess reduction when bv∉S. Needs full Carathéodory representation or different measure.",
     "insights": [
       "reduce_excess_by_one is the mathematical core — requires: (1) linear dependence of d+1 direction vectors via finrank, (2) perturbation ε construction from boundary distances, (3) verification that new points remain in convex hulls",
       "sum_close_to_convexHull needs convexHull(∑ Sᵢ) = ∑ convexHull(Sᵢ) from Mathlib (check Mathlib.Analysis.Convex.Combination for sum identity)",
@@ -14,7 +14,10 @@
       "Main theorem shapley_folkman is already proved from reduce_excess_by_one by strong induction",
       "sum_close_to_convexHull proof path: (1) convexHull_min + monotonicity (S⊆convexHull S) gives convexHull(∑S_i) ⊆ ∑convexHull(S_i), (2) Set.mem_finset_sum decomposes membership, (3) shapley_folkman bounds excess. Needs: Mathlib Finset pointwise sum monotonicity + sum-of-convex-is-convex.",
       "repeated_sum_nearly_convex follows from sum_close_to_convexHull by specializing S_i = S for all i",
-      "reduce_excess_by_one is the deep sorry: needs linearDependent_coefficients (proved!) + perturbation argument (~50 lines). Key steps: extract binary reps for d+1 excess indices, find dependence via linearDependent_coefficients, perturb with epsilon to collapse one index."
+      "reduce_excess_by_one is the deep sorry: needs linearDependent_coefficients (proved!) + perturbation argument (~50 lines). Key steps: extract binary reps for d+1 excess indices, find dependence via linearDependent_coefficients, perturb with epsilon to collapse one index.",
+      "PROOF ARCHITECTURE ISSUE: binary_repr gives av ∈ S, bv ∈ conv(S). When perturbation drives weight to 0, point=bv ∈ conv(S)\\S, excess NOT reduced. Both +ε and -ε directions can fail simultaneously.",
+      "For d=1, bv ∈ S always (Carath n=2), so binary approach works. For d≥2, bv can be in conv(S)\\S.",
+      "FIX OPTIONS: (1) Use full Carathéodory representation tracking vertex counts, not binary split. (2) Change measure from excess-index-count to total-vertex-count. (3) Nested induction: outer on excess count, inner on total vertices within excess indices."
     ],
     "builtItems": [
       "binary_repr_of_mem_convexHull_not_mem private lemma (ShapleyFolkman.lean:220)",
@@ -28,5 +31,10 @@
       "Prove Step 6 perturbation: define epsilon=min ratio, construct D-prime, verify convex hull membership, sum preservation, excess count decrease"
     ],
     "phase": "ACT"
+  },
+  "currentState": {
+    "blockers": [
+      "Binary representation approach cannot prove reduce_excess_by_one — needs full Carathéodory vertex tracking"
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- **shapley-folkman**: Documented fundamental proof architecture issue in `reduce_excess_by_one` Step 6. Binary representation approach (av ∈ S, bv ∈ conv(S)) cannot guarantee single-step excess reduction when perturbation drives weight to 0.
- **erdos-1027-oq-03**: Marked complete (1 deep axiom = Koishi Chan theorem, 0 sorries)

## Findings
The Shapley-Folkman `reduce_excess_by_one` sorry cannot be filled with the current binary representation approach for d ≥ 2. When both ±ε perturbation directions are limited by positive-coefficient ratios, the resulting point bv ∈ conv(S) \ S doesn't eliminate excess. Fix options documented in knowledge.

## Status
- shapley-folkman: **in-progress** (architecture issue needs resolution)
- erdos-1027-oq-03: **completed**

🤖 Generated by researcher-10