### PR TITLE
Research: Pólya-Vinogradov geometric series helpers (3 lemmas proved)

### DIFF
--- a/proofs/Proofs/BoundedPrimeGapsOQ04OQ01.lean
+++ b/proofs/Proofs/BoundedPrimeGapsOQ04OQ01.lean
@@ -78,23 +78,74 @@ theorem gaussSumNorm (q : ℕ) (hq : 2 ≤ q) (χ : DirichletCharacter ℂ q)
   sorry
 
 /-! ═══════════════════════════════════════════════════════════════════════════════
-PART II: GEOMETRIC SERIES BOUNDS
+PART II: GEOMETRIC SERIES BOUNDS — HELPER LEMMAS
+═══════════════════════════════════════════════════════════════════════════════ -/
+
+/-- sin(πθ) ≠ 0 when θ is not an integer.
+Proof: sin(πθ) = 0 iff πθ = kπ iff θ = k, contradicting hypothesis. -/
+lemma sin_pi_mul_ne_zero (θ : ℝ) (hθ : ∀ k : ℤ, θ ≠ ↑k) :
+    Real.sin (π * θ) ≠ 0 := by
+  intro h
+  rw [Real.sin_eq_zero_iff] at h
+  obtain ⟨k, hk⟩ := h
+  -- hk : ↑k * π = π * θ
+  have hπ : (π : ℝ) ≠ 0 := ne_of_gt Real.pi_pos
+  rw [mul_comm] at hk  -- π * ↑k = π * θ
+  exact hθ k (mul_left_cancel₀ hπ hk).symm
+
+/-- |1 - z^n| ≤ 2 when |z| = 1. Triangle inequality on the unit circle. -/
+lemma norm_one_sub_pow_le_two (z : ℂ) (hz : ‖z‖ = 1) (n : ℕ) :
+    ‖(1 : ℂ) - z ^ n‖ ≤ 2 := by
+  calc ‖(1 : ℂ) - z ^ n‖ ≤ ‖(1 : ℂ)‖ + ‖z ^ n‖ := norm_sub_le _ _
+    _ = 1 + ‖z ^ n‖ := by rw [norm_one]
+    _ = 1 + 1 := by rw [norm_pow, hz, one_pow]
+    _ = 2 := by ring
+
+/-- |1 - e^{2πiθ}| = 2|sin(πθ)|.
+Proof: Euler's formula + double angle identity + linear_combination.
+Adapted from the distance formula in Erdos225Aristotle.lean. -/
+lemma norm_one_sub_exp_two_pi_I (θ : ℝ) :
+    ‖(1 : ℂ) - exp (2 * ↑π * I * ↑θ)‖ = 2 * |Real.sin (π * θ)| := by
+  -- Rewrite exponent to ↑(2πθ) * I and apply Euler's formula
+  have harg : (2 : ℂ) * ↑π * I * ↑θ = ↑(2 * π * θ) * I := by push_cast; ring
+  rw [harg, Complex.exp_mul_I, ← Complex.ofReal_cos, ← Complex.ofReal_sin]
+  -- Rewrite 1 - (↑cos + ↑sin*I) = ↑(1-cos) + ↑(-sin)*I
+  have hdiff : (1 : ℂ) - (↑(Real.cos (2 * π * θ)) + ↑(Real.sin (2 * π * θ)) * I) =
+    ↑(1 - Real.cos (2 * π * θ)) + ↑(-Real.sin (2 * π * θ)) * I := by push_cast; ring
+  rw [hdiff, Complex.norm_add_mul_I]
+  -- Show (1-cos(2πθ))² + sin²(2πθ) = (2|sin(πθ)|)² via double angle
+  have h_sq : (1 - Real.cos (2 * π * θ)) ^ 2 + (-Real.sin (2 * π * θ)) ^ 2 =
+      (2 * |Real.sin (π * θ)|) ^ 2 := by
+    rw [mul_pow, sq_abs, neg_sq]
+    have h1 := Real.sin_sq_add_cos_sq (2 * π * θ)
+    have h2 := Real.cos_two_mul (π * θ)
+    have h2arg : 2 * (π * θ) = 2 * π * θ := by ring
+    rw [h2arg] at h2
+    have h3 := Real.sin_sq_add_cos_sq (π * θ)
+    linear_combination h1 - 2 * h2 - 4 * h3
+  rw [h_sq, Real.sqrt_sq (by positivity)]
+
+/-! ═══════════════════════════════════════════════════════════════════════════════
+PART II: GEOMETRIC SERIES BOUNDS — MAIN THEOREM
 ═══════════════════════════════════════════════════════════════════════════════ -/
 
 /-- Partial sum of a geometric series with common ratio on the unit circle.
   |Σ_{n=M+1}^{M+N} e^{2πiθn}| ≤ 1 / |sin(πθ)| for θ ∉ ℤ.
 
 This is the key technical ingredient: the partial sum of e^{2πiθn}
-is bounded by the distance of θ from the nearest integer. -/
+is bounded by the distance of θ from the nearest integer.
+
+Proof structure:
+1. Rewrite sum as z^{M+1} · (1 - z^N)/(1 - z) where z = e^{2πiθ}
+2. |z^{M+1}| = 1 (unit circle)
+3. |1 - z^N| ≤ 2 (norm_one_sub_pow_le_two)
+4. |1 - z| = 2|sin(πθ)| (norm_one_sub_exp_two_pi_I)
+5. Combine: |sum| ≤ 2/(2|sin(πθ)|) = 1/|sin(πθ)| -/
 theorem geom_partial_sum_bound (θ : ℝ) (hθ : ∀ k : ℤ, θ ≠ ↑k)
     (M N : ℕ) :
     ‖∑ n in Finset.Icc (M + 1) (M + N),
       exp (2 * ↑π * I * ↑θ * ↑(n : ℤ))‖ ≤
     1 / |Real.sin (π * θ)| := by
-  -- The partial sum equals e^{2πiθ(M+1)} · (1 - e^{2πiθN}) / (1 - e^{2πiθ})
-  -- |1 - e^{2πiθN}| ≤ 2
-  -- |1 - e^{2πiθ}| = 2|sin(πθ)|
-  -- So the bound is 2 / (2|sin(πθ)|) = 1/|sin(πθ)|
   sorry
 
 /-! ═══════════════════════════════════════════════════════════════════════════════

--- a/proofs/Proofs/BoundedPrimeGapsOQ04OQ01Aristotle.lean
+++ b/proofs/Proofs/BoundedPrimeGapsOQ04OQ01Aristotle.lean
@@ -3,15 +3,14 @@
   Routine supporting lemmas for automated proof search.
   See BoundedPrimeGapsOQ04OQ01.lean for the main formalization.
 
-  Criteria for inclusion:
-  - complete_character_sum_zero: Σ_{n<q} χ(n) = 0 for χ ≠ 1 (Mathlib API call)
-  - gaussSumNorm: |τ(χ)| = √q for primitive χ (Mathlib's gaussSum.norm_eq)
-  - geom_partial_sum_bound: geometric series ≤ 1/|sin(πθ)| (known bound)
-  - NOT cotangent_sum_bound (complex harmonic sum estimate)
-  - NOT polya_vinogradov (main theorem)
-
-  Note: complete_character_sum_zero is likely DirichletCharacter.sum_eq_zero
-  or similar in Mathlib. Gauss sum norm follows from IsPrimitive + gaussSum.norm.
+  Status:
+  - complete_character_sum_zero: PROVED in main file
+  - norm_one_sub_exp_two_pi_I: PROVED in main file (Euler + double angle)
+  - sin_pi_mul_ne_zero: PROVED in main file
+  - norm_one_sub_pow_le_two: PROVED in main file (triangle inequality)
+  - gaussSumNorm: SORRY — Aristotle target (requires Gauss sum identity)
+  - NOT cotangent_sum_bound (complex estimate, not routine)
+  - NOT polya_vinogradov (main theorem assembly)
 -/
 import Mathlib
 
@@ -19,44 +18,16 @@ namespace BoundedPrimeGapsOQ04OQ01Aristotle
 
 open Complex Real Finset
 
--- Routine: Complete character sum vanishes for non-principal character.
--- For χ ≠ 1 and χ a Dirichlet character mod q, ∑_{n=0}^{q-1} χ(n) = 0.
--- This is a standard result from character orthogonality in Mathlib:
--- DirichletCharacter.sum_eq_zero or MulChar.sum_eq_zero_of_ne_one.
-theorem complete_character_sum_zero (q : ℕ) (hq : 1 ≤ q) (χ : DirichletCharacter ℂ q)
-    (hχ : χ ≠ 1) :
-    ∑ n in Finset.range q, (χ n : ℂ) = 0 := by
-  -- Use MulChar.sum_eq_zero_of_ne_one + Fin/ZMod identification
-  obtain ⟨m, rfl⟩ : ∃ m, q = m + 1 := ⟨q - 1, by omega⟩
-  simp only [← Fin.sum_univ_eq_sum_range]
-  have : (fun i : Fin (m + 1) => (χ ((↑i : ℕ) : ZMod (m + 1)) : ℂ)) = fun i => χ i := by
-    ext i; congr 1
-    show ((i : ℕ) : Fin (m + 1)) = i
-    ext; simp [Fin.val_natCast, Nat.mod_eq_of_lt i.isLt]
-  rw [this]
-  exact MulChar.sum_eq_zero_of_ne_one hχ
-
 -- Routine: The absolute value of the Gauss sum of a primitive character equals √q.
 -- |τ(χ)| = √q for χ primitive mod q.
 -- Uses: IsPrimitive.gaussSum_norm or norm_gaussSum_eq of Mathlib.
--- Proof: τ(χ) · τ(χ̄) = χ(-1) · q (double sum identity), and |τ(χ̄)| = |τ(χ)|
--- by conjugation symmetry, so |τ(χ)|² = q.
+-- Proof: τ(χ) · τ(χ̄) = χ(-1) · q (double sum identity via gaussSum_mul_gaussSum_eq_card),
+-- and |τ(χ̄)| = |τ(χ)| by conjugation symmetry, so |τ(χ)|² = q.
+-- Key Mathlib ingredient: ZMod.gaussSum_mul_gaussSum_eq_card
 theorem gaussSumNorm (q : ℕ) (hq : 2 ≤ q) (χ : DirichletCharacter ℂ q)
     (hχ : χ ≠ 1) (hprim : χ.IsPrimitive) :
     ‖∑ t in Finset.range q, χ t * exp (2 * ↑π * I * ↑(t : ℤ) / ↑q)‖ =
     Real.sqrt (q : ℝ) := by
-  sorry
-
--- Routine: Geometric series partial sum bound.
--- |∑_{n=M+1}^{M+N} e^{2πiθn}| ≤ 1/|sin(πθ)| for θ ∉ ℤ.
--- Proof: the sum = e^{2πiθ(M+1)} · (1 - e^{2πiθN}) / (1 - e^{2πiθ})
--- so |sum| ≤ 2 / |1 - e^{2πiθ}| = 2 / (2|sin(πθ)|) = 1/|sin(πθ)|
--- using |1 - e^{iα}| = 2|sin(α/2)|.
-theorem geom_partial_sum_bound (θ : ℝ) (hθ : ∀ k : ℤ, θ ≠ ↑k)
-    (M N : ℕ) :
-    ‖∑ n in Finset.Icc (M + 1) (M + N),
-      exp (2 * ↑π * I * ↑θ * ↑(n : ℤ))‖ ≤
-    1 / |Real.sin (π * θ)| := by
   sorry
 
 end BoundedPrimeGapsOQ04OQ01Aristotle


### PR DESCRIPTION
## Summary
- Prove 3 critical helper lemmas for the Pólya-Vinogradov inequality's geometric series bound (Phase 2)
- Streamline Aristotle companion file from 2 sorries to 1 (gaussSumNorm only)
- Main file sorry count unchanged at 4, but helpers provide key ingredients for geom_partial_sum_bound

## Lemmas Proved
- **sin_pi_mul_ne_zero**: sin(πθ) ≠ 0 when θ is not an integer (via Real.sin_eq_zero_iff + mul_left_cancel₀)
- **norm_one_sub_pow_le_two**: |1 - z^n| ≤ 2 when |z| = 1 (triangle inequality on unit circle)
- **norm_one_sub_exp_two_pi_I**: |1 - e^{2πiθ}| = 2|sin(πθ)| (Euler's formula + double angle identity + linear_combination, adapted from Erdos225Aristotle.lean pattern)

## Files Modified
- `proofs/Proofs/BoundedPrimeGapsOQ04OQ01.lean` — added 3 proved helpers, documented proof structure
- `proofs/Proofs/BoundedPrimeGapsOQ04OQ01Aristotle.lean` — focused to 1 sorry (gaussSumNorm)

## Status
**Outcome**: progress
**Next Steps**: 
- Prove geom_partial_sum_bound using the 3 helpers + Finset.Icc reindexing
- Prove gaussSumNorm via gaussSum_mul_gaussSum_eq_card
- Prove cotangent_sum_bound via concavity of sin + harmonic sum bound

🤖 Generated by researcher-2