### PR TITLE
Fix: sync erdos-211 sorry count to 0

### DIFF
--- a/src/data/proofs/erdos-211/meta.json
+++ b/src/data/proofs/erdos-211/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 211,
     "erdosUrl": "https://erdosproblems.com/211",
     "erdosProblemStatus": "solved",
@@ -50,7 +50,7 @@
     ],
     "axiomCount": 10,
     "lineCount": 243,
-    "assumptions": "10 axiom(s) and 1 sorry(s). See the Lean source for details."
+    "assumptions": "10 axiom(s) and 0 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #211: Lines Formed by Points in the Plane**\n\nThis problem sits at the heart of combinatorial incidence geometry, asking how bounded collinearity forces many determined lines.\n\n**Origins and Context:**\nThe study of incidences between points and lines has roots in classical geometry (Sylvester 1893, Gallai 1944), but the quantitative theory began with Erdős in the 1960s-70s. Problem #211 was posed by Erdős as part of his systematic investigation of extremal problems in discrete geometry, with a $100 prize attached.\n\n**The Two Independent Solutions (1983):**\n- **József Beck** proved the result in 'On the lattice property of the plane and some problems of Dirac, Motzkin, and Erdős in combinatorial geometry' (Combinatorica, 1983). His approach introduced the now-famous *Beck dichotomy*: either many points are collinear, or many lines are formed. The proof uses double counting and the Cauchy-Schwarz inequality.\n- **Endre Szemerédi and William T. Trotter** independently proved the result in 'Extremal problems in discrete geometry' (Combinatorica, 1983). Their approach established the Szemerédi-Trotter incidence theorem $I(P,L) = O(m^{2/3}n^{2/3} + m + n)$, from which the Erdős bound follows as a corollary. The original proof used a cell decomposition; László Székely gave a simpler proof via the crossing number inequality in 1997.\n\n**The Optimal Constant:**\nErdős further speculated that the bound could be sharpened to $\\geq (1+o(1))kn/6$ lines, with the constant $1/6$ being best possible. This constant arises from Steiner-type configurations where every line contains exactly 3 points, yielding $\\binom{n}{2}/3 \\approx n^2/6$ lines. Burr, Grünbaum, and Sloane constructed explicit extremal configurations.\n\n**Legacy:**\nThe Szemerédi-Trotter theorem became one of the most widely-used tools in combinatorial geometry, with applications to sum-product estimates (Elekes 1997), distinct distances (Guth-Katz 2015), and additive combinatorics. The crossing number technique has been called the most useful application of graph theory to geometry.",
@@ -145,7 +145,7 @@
     "theoremCount": 1,
     "definitionCount": 7,
     "path": "Proofs/Stubs/Erdos211Problem.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -179,5 +179,5 @@
       "note": "Incidence geometry foundations relevant to combinatorial geometry problems"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Correct sorry count for erdos-211: meta.json reported 1 sorry but the Lean source has 0.

## Evidence

**Before**: `meta.sorries=1`, `leanFile.sorries=1`, `assumptions="10 axiom(s) and 1 sorry(s)"`
**After**: `meta.sorries=0`, `leanFile.sorries=0`, `assumptions="10 axiom(s) and 0 sorry(s)"`

The Lean file `Proofs/Stubs/Erdos211Problem.lean` contains 10 axiom declarations and 0 sorries (verified by grep).

---
Automated fix by lean-mechanic agent.