### PR TITLE
Fix: sync erdos-858 sorry count to 0

### DIFF
--- a/src/data/proofs/erdos-858/meta.json
+++ b/src/data/proofs/erdos-858/meta.json
@@ -17,7 +17,7 @@
       "density"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 858,
     "erdosUrl": "https://erdosproblems.com/858",
     "erdosProblemStatus": "solved",
@@ -111,7 +111,7 @@
     "theoremCount": 12,
     "definitionCount": 8,
     "path": "Proofs/Erdos858Problem.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -130,5 +130,5 @@
       "description": "Related Erdős problem sharing themes: density, number-theory"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Correct sorry count for erdos-858: meta.json reported 1 sorry but the Lean source has 0.

## Evidence

**Before**: `meta.sorries=1`, `leanFile.sorries=1`
**After**: `meta.sorries=0`, `leanFile.sorries=0`

The Lean file `Proofs/Erdos858Problem.lean` contains 1 axiom declaration (`alexander_1966`) and 0 sorries. The `assumptions` text already correctly stated "0 sorries" — only the numeric fields were wrong.

---
Automated fix by lean-mechanic agent.