### PR TITLE
Fix: sync sorry/axiom counts for erdos-858, erdos-211, inverse-galois

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3799,9 +3799,9 @@
     },
     "erdos-211": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T17:11:03Z",
-      "result": "clean"
+      "auditCount": 3,
+      "lastAudited": "2026-04-13T16:07:24Z",
+      "result": "issues-fixed"
     },
     "erdos-212": {
       "agentId": "auditor-cycle-20-batch",
@@ -8218,8 +8218,8 @@
     },
     "erdos-858": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 2,
-      "lastAudited": "2026-04-03T10:17:33Z",
+      "auditCount": 3,
+      "lastAudited": "2026-04-13T16:07:23Z",
       "result": "issues-fixed"
     },
     "erdos-859": {
@@ -9829,9 +9829,9 @@
       "agentId": "lean-mechanic"
     },
     "inverse-galois": {
-      "auditCount": 7,
+      "auditCount": 8,
       "issues": [],
-      "lastAudited": "2026-04-13T06:09:37Z",
+      "lastAudited": "2026-04-13T16:07:25Z",
       "result": "issues-fixed"
     },
     "inverse-galois-oq-01": {
@@ -12352,6 +12352,96 @@
     "sperner-ndim-oq-03-oq-01": {
       "auditCount": 1,
       "lastAudited": "2026-04-13T03:29:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "area-of-circle-oq-03-oq-02-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T16:10:16Z",
+      "result": "clean",
+      "issues": []
+    },
+    "arithmetic-series-oq-02-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T16:10:16Z",
+      "result": "clean",
+      "issues": []
+    },
+    "bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T16:10:16Z",
+      "result": "clean",
+      "issues": []
+    },
+    "buffons-needle-oq-01-oq-01-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T16:10:16Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T16:10:16Z",
+      "result": "clean",
+      "issues": []
+    },
+    "chinese-remainder-non-coprime-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T16:10:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "combinations-formula-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T16:10:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "denumerability-rationals-oq-02-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T16:10:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-109-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T16:10:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1129-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T16:10:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-327-oq-01-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T16:10:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "fair-games-theorem-oq-02-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T16:10:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "partition-theorem-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T16:10:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "shannon-channel-coding-oq-02-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T16:10:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "sophie-germain-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T16:10:17Z",
       "result": "clean",
       "issues": []
     }

--- a/src/data/proofs/erdos-211/meta.json
+++ b/src/data/proofs/erdos-211/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 211,
     "erdosUrl": "https://erdosproblems.com/211",
     "erdosProblemStatus": "solved",
@@ -50,13 +50,13 @@
     ],
     "axiomCount": 10,
     "lineCount": 243,
-    "assumptions": "10 axiom(s) and 1 sorry(s). See the Lean source for details."
+    "assumptions": "10 axiom(s) and 0 sorry(s). See the Lean source for details."
   },
   "overview": {
     "historicalContext": "**Erdős Problem #211: Lines Formed by Points in the Plane**\n\nThis problem sits at the heart of combinatorial incidence geometry, asking how bounded collinearity forces many determined lines.\n\n**Origins and Context:**\nThe study of incidences between points and lines has roots in classical geometry (Sylvester 1893, Gallai 1944), but the quantitative theory began with Erdős in the 1960s-70s. Problem #211 was posed by Erdős as part of his systematic investigation of extremal problems in discrete geometry, with a $100 prize attached.\n\n**The Two Independent Solutions (1983):**\n- **József Beck** proved the result in 'On the lattice property of the plane and some problems of Dirac, Motzkin, and Erdős in combinatorial geometry' (Combinatorica, 1983). His approach introduced the now-famous *Beck dichotomy*: either many points are collinear, or many lines are formed. The proof uses double counting and the Cauchy-Schwarz inequality.\n- **Endre Szemerédi and William T. Trotter** independently proved the result in 'Extremal problems in discrete geometry' (Combinatorica, 1983). Their approach established the Szemerédi-Trotter incidence theorem $I(P,L) = O(m^{2/3}n^{2/3} + m + n)$, from which the Erdős bound follows as a corollary. The original proof used a cell decomposition; László Székely gave a simpler proof via the crossing number inequality in 1997.\n\n**The Optimal Constant:**\nErdős further speculated that the bound could be sharpened to $\\geq (1+o(1))kn/6$ lines, with the constant $1/6$ being best possible. This constant arises from Steiner-type configurations where every line contains exactly 3 points, yielding $\\binom{n}{2}/3 \\approx n^2/6$ lines. Burr, Grünbaum, and Sloane constructed explicit extremal configurations.\n\n**Legacy:**\nThe Szemerédi-Trotter theorem became one of the most widely-used tools in combinatorial geometry, with applications to sum-product estimates (Elekes 1997), distinct distances (Guth-Katz 2015), and additive combinatorics. The crossing number technique has been called the most useful application of graph theory to geometry.",
     "problemStatement": "**Problem Statement (Solved)**\n\nLet $1 \\leq k < n$. Given $n$ points in $\\mathbb{R}^2$ with at most $n-k$ on any line, prove there are $\\Omega(kn)$ lines containing at least two points.\n\n**Special Case:** For $2n$ points with at most $n$ collinear, there are $\\Omega(n^2)$ such lines.\n\n**Answer:** YES (Beck 1983, Szemerédi-Trotter 1983)\n\n**Prize:** $100 (awarded)\n\n**Refined Bound:** Erdős speculated $\\geq (1+o(1))kn/6$ lines, which is tight.",
     "text": "For n points with at most n-k collinear (1≤k<n), there are Ω(kn) lines through ≥2 points. SOLVED by Beck and Szemerédi-Trotter (1983).",
-    "proofStrategy": "**Formalization Strategy: Axiomatic Framework for Incidence Geometry**\n\nThe formalization takes a top-down approach, axiomatizing the deep analytic and probabilistic results while building the combinatorial framework constructively.\n\n1. **Geometric Foundation (Lines 34-76):** Points in $\\mathbb{R}^2$, lines via point-direction pairs, collinearity via affine combinations, and counting functions `numLines` and `maxCollinear`. These definitions are constructive where possible.\n\n2. **Main Result as Axiom (Lines 96-112):** The Beck-Szemerédi-Trotter bound $|\\mathcal{L}(P)| = \\Omega(kn)$ is axiomatized because the proof requires either (a) Beck's double-counting + Cauchy-Schwarz argument or (b) the Szemerédi-Trotter theorem, both of which involve analytic techniques not yet in Mathlib's discrete geometry.\n\n3. **Beck's Dichotomy (Lines 118-137):** Axiomatized separately as it is a key structural lemma with independent applications. The quantitative version parameterizes the trade-off between collinearity and line count.\n\n4. **Szemerédi-Trotter Infrastructure (Lines 139-165):** The incidence function, the $O(m^{2/3}n^{2/3} + m + n)$ bound, and the rich lines corollary are axiomatized as a suite of tools. The incidence definition uses `sorry` because the full counting requires measurability arguments.\n\n5. **Extremal Analysis (Lines 167-217):** The refined $1/6$ conjecture is stated as a Lean `Prop`, with supporting axioms for extremal configurations (Burr-Grünbaum-Sloane, Füredi-Palásti) and the crossing number inequality that powers Székely's proof.\n\n6. **Final Theorem (Lines 237-241):** The `erdos_211` theorem delegates to the main axiom, providing a clean interface for the solved Erdős problem.",
+    "proofStrategy": "**Formalization Strategy: Axiomatic Framework for Incidence Geometry**\n\nThe formalization takes a top-down approach, axiomatizing the deep analytic and probabilistic results while building the combinatorial framework constructively.\n\n1. **Geometric Foundation (Lines 34-76):** Points in $\\mathbb{R}^2$, lines via point-direction pairs, collinearity via affine combinations, and counting functions `numLines` and `maxCollinear`. These definitions are constructive where possible.\n\n2. **Main Result as Axiom (Lines 96-112):** The Beck-Szemerédi-Trotter bound $|\\mathcal{L}(P)| = \\Omega(kn)$ is axiomatized because the proof requires either (a) Beck's double-counting + Cauchy-Schwarz argument or (b) the Szemerédi-Trotter theorem, both of which involve analytic techniques not yet in Mathlib's discrete geometry.\n\n3. **Beck's Dichotomy (Lines 118-137):** Axiomatized separately as it is a key structural lemma with independent applications. The quantitative version parameterizes the trade-off between collinearity and line count.\n\n4. **Szemerédi-Trotter Infrastructure (Lines 139-165):** The incidence function, the $O(m^{2/3}n^{2/3} + m + n)$ bound, and the rich lines corollary are axiomatized as a suite of tools. The incidence function is axiomatized as part of the Szemerédi-Trotter toolkit.\n\n5. **Extremal Analysis (Lines 167-217):** The refined $1/6$ conjecture is stated as a Lean `Prop`, with supporting axioms for extremal configurations (Burr-Grünbaum-Sloane, Füredi-Palásti) and the crossing number inequality that powers Székely's proof.\n\n6. **Final Theorem (Lines 237-241):** The `erdos_211` theorem delegates to the main axiom, providing a clean interface for the solved Erdős problem.",
     "keyInsights": [
       "**Beck's Dichotomy as Paradigm:** The either-or structure (many collinear OR many lines) is an instance of a broader phenomenon in extremal combinatorics: structural dichotomies that reduce problems to case analysis. This pattern appears in Ramsey theory, regularity lemmas, and the Balog-Szemerédi-Gowers theorem.",
       "**Szemerédi-Trotter as Universal Tool:** The incidence bound $I(P,L) = O(m^{2/3}n^{2/3} + m + n)$ is tight and has become the Swiss army knife of discrete geometry. Elekes (1997) used it to prove sum-product estimates; Pach and Sharir extended it to curves; Guth and Katz (2015) used a polynomial partitioning generalization to resolve Erdős's distinct distances problem.",
@@ -145,7 +145,7 @@
     "theoremCount": 1,
     "definitionCount": 7,
     "path": "Proofs/Stubs/Erdos211Problem.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -179,5 +179,5 @@
       "note": "Incidence geometry foundations relevant to combinatorial geometry problems"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }

--- a/src/data/proofs/erdos-858/meta.json
+++ b/src/data/proofs/erdos-858/meta.json
@@ -17,7 +17,7 @@
       "density"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 858,
     "erdosUrl": "https://erdosproblems.com/858",
     "erdosProblemStatus": "solved",
@@ -111,7 +111,7 @@
     "theoremCount": 12,
     "definitionCount": 8,
     "path": "Proofs/Erdos858Problem.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "crossReferences": [
     {
@@ -130,5 +130,5 @@
       "description": "Related Erdős problem sharing themes: density, number-theory"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -40,7 +40,7 @@
       "theoremCount": 105,
       "lemmaCount": 1,
       "defCount": 1,
-      "axiomCount": 4,
+      "axiomCount": 5,
       "sorryCount": 0,
       "imports": [
         "Mathlib.NumberTheory.Cyclotomic.Basic",

--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -281,7 +281,7 @@
     ],
     "namespace": "InverseGaloisProblem",
     "lineCount": 1882,
-    "axiomCount": 4,
+    "axiomCount": 5,
     "theoremCount": 106,
     "definitionCount": 1,
     "path": "Proofs/InverseGalois.lean",


### PR DESCRIPTION
## Summary

- **erdos-858**: `sorries` 1→0 (Lean file has 0 sorries, only 1 axiom)
- **erdos-211**: `sorries` 1→0 (Lean file has 0 sorries), fixed stale proofStrategy text that incorrectly mentioned `sorry`
- **inverse-galois**: `leanFile.axiomCount` 4→5 (5th axiom `three_dvd_gal_card` is in InverseGaloisA5.lean, consistent with top-level `axiomCount: 5`)
- Audited 15 previously unaudited proofs — all clean

## Test plan

- [ ] Verify `npx tsx scripts/auditor/find-targets.ts --issues` shows 0 issues
- [ ] Verify `npx tsx scripts/auditor/find-targets.ts --stats` shows 0 unaudited

🤖 Generated with [Claude Code](https://claude.com/claude-code)