### PR TITLE
Fix: remove broken .loom/tokens symlink from git

### DIFF
--- a/.loom/tokens
+++ b/.loom/tokens
@@ -1,1 +1,0 @@
-/Users/rwalters/GitHub/lean-genius/.loom/tokens


### PR DESCRIPTION
## Summary
- Removes a self-referencing symlink (`.loom/tokens -> .loom/tokens`) from the git index
- The path is already in `.gitignore` — this just stops git from tracking/restoring the broken symlink
- Every `git checkout` or worktree creation was overwriting the real tokens directory with this broken symlink

## Context
The allowlist system (PR #10287) needs `.loom/tokens/` to be a real directory containing `.token` files and an `.allowlist` file. The tracked symlink was silently breaking this on every agent respawn.

## Test plan
- [x] `git rm --cached .loom/tokens` removes from index
- [x] `.gitignore` already covers `.loom/tokens/`
- [ ] New worktree checkouts don't recreate the broken symlink

🤖 Generated with [Claude Code](https://claude.com/claude-code)