### PR TITLE
Fix: add missing implications field to 4 proof conclusions

### DIFF
--- a/src/data/proofs/basel-problem-oq-04/meta.json
+++ b/src/data/proofs/basel-problem-oq-04/meta.json
@@ -65,7 +65,8 @@
   ],
   "conclusion": {
     "summary": "A fully verified proof that ∏_p (1-p⁻²)⁻¹ = π²/6, combining the Euler product formula with the Basel identity. Zero axioms, zero sorries.",
-    "openQuestions": []
+    "openQuestions": [],
+    "implications": "Connects Euler's product formula to the zeta function, establishing a foundational bridge between analytic and algebraic number theory."
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1083-oq-02/meta.json
+++ b/src/data/proofs/erdos-1083-oq-02/meta.json
@@ -84,12 +84,9 @@
   "conclusion": {
     "summary": "We formalize the state of Erdős #1083, proving that the Solymosi-Vu bound leaves a gap of exactly 2/(d(d+2)) from the conjectured truth. No approach is known to eliminate this gap.",
     "openQuestions": [
-      {
-        "question": "Can the SV exponent be improved for specific small d (e.g., d=3 or d=4)?",
-        "difficulty": "hard",
-        "relatedWork": "For d=2, Guth-Katz (2015) solved the problem completely."
-      }
-    ]
+      "Can the SV exponent be improved for specific small d (e.g., d=3 or d=4)?"
+    ],
+    "implications": "Quantifies the gap between the best known sum-product bound and the conjectured optimal, highlighting the remaining challenge in additive combinatorics."
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1107-oq-02/meta.json
+++ b/src/data/proofs/erdos-1107-oq-02/meta.json
@@ -86,17 +86,10 @@
   "conclusion": {
     "summary": "We determine the exact threshold N=120 for Heath-Brown's squareful sum theorem and identify all six exceptions. The result is verified computationally up to 1000.",
     "openQuestions": [
-      {
-        "question": "What is the threshold for r=3? Is every n ≥ N₃ a sum of ≤ 4 cubeful numbers?",
-        "difficulty": "hard",
-        "relatedWork": "No effective bounds known for r ≥ 3"
-      },
-      {
-        "question": "Can the threshold 120 be proved without exhaustive computation, using only the structure of squareful numbers?",
-        "difficulty": "medium",
-        "relatedWork": "Would require understanding the additive structure of squareful numbers modulo small numbers"
-      }
-    ]
+      "What is the threshold for r=3? Is every n ≥ N₃ a sum of ≤ 4 cubeful numbers?",
+      "Can the threshold 120 be proved without exhaustive computation, using only the structure of squareful numbers?"
+    ],
+    "implications": "Makes Heath-Brown's squareful sum theorem effective with an explicit threshold N=120, providing a template for effectivizing other asymptotic results in additive number theory."
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-837-oq-05/meta.json
+++ b/src/data/proofs/erdos-837-oq-05/meta.json
@@ -83,7 +83,8 @@
       "Prove zero_is_jump using a supersaturation argument",
       "Formalize the subhypergraph relation properly using typed hypergraph structures",
       "What is A_3? (Erdős #837, open)"
-    ]
+    ],
+    "implications": "Strengthens the density jump framework using filter-based limits, enabling finer analysis of graph density thresholds."
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary
- Adds missing `implications` field to `ProofConclusion` in 4 gallery proofs that were breaking the build
- Normalizes `openQuestions` from object format to `string[]` per type definition
- Affected proofs: basel-problem-oq-04, erdos-1083-oq-02, erdos-837-oq-05, erdos-1107-oq-02

## Test plan
- [ ] `pnpm build` passes without TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)