### PR TITLE
Fix: gallery audit batch (badge correction + tracker completion)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12444,6 +12444,18 @@
       "lastAudited": "2026-04-13T16:10:17Z",
       "result": "clean",
       "issues": []
+    },
+    "amgm-inequality-oq-02-oq-01-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T20:30:52Z",
+      "result": "clean",
+      "issues": []
+    },
+    "basel-problem-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T20:33:48Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12456,6 +12456,54 @@
       "lastAudited": "2026-04-13T20:33:48Z",
       "result": "issues-fixed",
       "issues": []
+    },
+    "cauchy-schwarz-oq-01-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T20:34:51Z",
+      "result": "clean",
+      "issues": []
+    },
+    "cevas-theorem-non-euclidean-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T20:35:23Z",
+      "result": "clean",
+      "issues": []
+    },
+    "chinese-remainder-non-coprime-oq-01-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T20:35:43Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1083-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T20:36:17Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1107-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T20:36:46Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-837-oq-05": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T20:37:47Z",
+      "result": "clean",
+      "issues": []
+    },
+    "lagrange-four-squares-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T20:38:12Z",
+      "result": "clean",
+      "issues": []
+    },
+    "taylor-sincos-convergence-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-04-13T20:38:29Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "erdos-1097-oq-01": {

--- a/src/data/proofs/basel-problem-oq-04/meta.json
+++ b/src/data/proofs/basel-problem-oq-04/meta.json
@@ -16,16 +16,43 @@
       "primes",
       "basel-problem"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-04-13",
+    "mathlibDependencies": [
+      {
+        "theorem": "riemannZeta_eulerProduct_tprod",
+        "description": "∏_p (1-p^{-s})⁻¹ = ζ(s) as a tprod for Re(s) > 1",
+        "module": "Mathlib.NumberTheory.EulerProduct.DirichletLSeries"
+      },
+      {
+        "theorem": "riemannZeta_eulerProduct_hasProd",
+        "description": "HasProd form of the Euler product for ζ(s)",
+        "module": "Mathlib.NumberTheory.EulerProduct.DirichletLSeries"
+      },
+      {
+        "theorem": "riemannZeta_eulerProduct",
+        "description": "Tendsto form of the Euler product for ζ(s)",
+        "module": "Mathlib.NumberTheory.EulerProduct.DirichletLSeries"
+      },
+      {
+        "theorem": "riemannZeta_two",
+        "description": "ζ(2) = π²/6",
+        "module": "Mathlib.NumberTheory.LSeries.HurwitzZetaValues"
+      },
+      {
+        "theorem": "hasSum_zeta_two",
+        "description": "∑ 1/n² = π²/6 as a HasSum",
+        "module": "Mathlib.NumberTheory.ZetaValues"
+      }
+    ],
     "originalContributions": [
-      "Euler product ∏_p (1-p⁻²)⁻¹ = π²/6 by combining two Mathlib theorems",
-      "Three equivalent formulations: tprod, HasProd, and Tendsto versions"
+      "Bridge connecting Mathlib's Euler product and Basel identity in three formulations (tprod, HasProd, Tendsto)",
+      "two_re_gt_one: trivial helper that Re(2) > 1, needed for Euler product convergence hypothesis"
     ],
     "axiomCount": 0,
-    "lineCount": 100,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "lineCount": 107,
+    "assumptions": "None. 0 axioms, 0 sorries. Core results (Euler product and ζ(2) = π²/6) are from Mathlib.",
     "theoremCount": 5
   },
   "overview": {


### PR DESCRIPTION
## Summary

Audit of all 10 previously unaudited gallery proofs. Gallery is now 100% audited (2061/2061).

### Issue Fixed

**`basel-problem-oq-04`**: Badge was `original` but this is a Mathlib bridge proof. The Lean file docstring explicitly states "Both results are in Mathlib." Fixed:
- Badge: `original` → `mathlib`
- Added `mathlibDependencies` (5 Mathlib theorems: `riemannZeta_eulerProduct_tprod`, `riemannZeta_two`, etc.)
- `lineCount` corrected: 100 → 107
- `assumptions` updated to note Mathlib reliance
- `originalContributions` reworded accurately

### Clean Audits (9 proofs)

- `amgm-inequality-oq-02-oq-01-oq-02`: 0 sorries, 0 axioms, original badge ✓
- `cauchy-schwarz-oq-01-oq-01-oq-01`: 0 sorries, 0 axioms, independently proved ✓
- `cevas-theorem-non-euclidean-oq-02`: 0 sorries, 0 axioms, independently proved ✓
- `chinese-remainder-non-coprime-oq-01-oq-01`: 0 sorries, 0 axioms, original badge ✓
- `erdos-1083-oq-02`: 0 sorries, 5 axioms, axiomatized/axiom badge ✓
- `erdos-1107-oq-02`: 0 sorries, 1 axiom, axiomatized/axiom badge ✓
- `erdos-837-oq-05`: 1 sorry, 1 axiom, axiomatized/axiom badge ✓ (True placeholder present but status correctly reflects non-verified state)
- `lagrange-four-squares-oq-04`: 0 sorries, 1 axiom, axiomatized/axiom badge ✓
- `taylor-sincos-convergence-oq-04`: 1 sorry, 1 axiom, axiomatized/axiom badge ✓

## Test plan

- [ ] Verify `basel-problem-oq-04` gallery page shows `mathlib` badge
- [ ] Verify audit tracker shows 2061/2061 audited

🤖 Generated with [Claude Code](https://claude.com/claude-code)