### PR TITLE
Fix: hilbert-15-oq-02 True-stub theorems overclaim verified status

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12186,10 +12186,14 @@
       "issues": []
     },
     "hilbert-15-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-04-13T03:03:24Z",
-      "result": "clean",
-      "issues": []
+      "auditCount": 3,
+      "lastAudited": "2026-04-13T21:05:00Z",
+      "result": "issues-fixed",
+      "issues": [
+        "status verified->formalized (True stub theorems: lr_saturation_theorem, lr_positivity_in_P, lr_counting_sharp_P_complete prove True)",
+        "badge verified->wip",
+        "lineCount 360->506"
+      ]
     },
     "minkowski-fundamental-theorem-oq-02": {
       "auditCount": 1,
@@ -12502,6 +12506,12 @@
     "taylor-sincos-convergence-oq-04": {
       "auditCount": 1,
       "lastAudited": "2026-04-13T20:38:29Z",
+      "result": "clean",
+      "issues": []
+    },
+    "erdos-1027-oq-03": {
+      "auditCount": 2,
+      "lastAudited": "2026-04-13T20:42:50Z",
       "result": "clean",
       "issues": []
     }

--- a/src/data/proofs/hilbert-15-oq-02/meta.json
+++ b/src/data/proofs/hilbert-15-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius Research",
     "date": "2026",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/Hilbert15OQ02.lean",
     "tags": [
       "algebraic-geometry",
@@ -16,11 +16,11 @@
       "schubert-calculus",
       "research"
     ],
-    "badge": "verified",
+    "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 360,
-    "assumptions": "None. All 3 former axioms (saturation, positivity in P, #P-completeness) were vacuous (asserting True) and have been converted to theorems. All computational results verified via native_decide.",
+    "lineCount": 506,
+    "assumptions": "Three complexity-theoretic theorems (lr_saturation_theorem, lr_positivity_in_P, lr_counting_sharp_P_complete) prove `True` as explicit placeholders — the complexity theory formalism is not available in Lean/Mathlib. The 2-row LR coefficient computation (lrCoeff2) and full Gr(2,4) multiplication table are fully verified via native_decide.",
     "dateAdded": "2026-04-12",
     "mathlib_version": "4.26.0"
   },


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: `hilbert-15-oq-02` (Complexity of Littlewood-Richardson Coefficients)

**Problem**: Three key complexity-theoretic theorems prove `True` as explicit placeholders, yet the proof is publicly claimed as `status: verified`, `badge: verified`.

## Evidence

The Lean file (`Proofs/Hilbert15OQ02.lean`) states in a comment block:
> "The following results document the known complexity-theoretic facts about LR coefficients. Their formal content is **vacuous (asserting `True`)** because the actual complexity theory formalism is not available in Lean/Mathlib."

True-stub theorems:
- `lr_saturation_theorem`: `True := trivial`
- `lr_positivity_in_P`: `∃ poly_time_alg, True := ⟨fun _ _ _ => false, trivial⟩`
- `lr_counting_sharp_P_complete`: `∃ reduction, True := ⟨fun l => (l, l, l), trivial⟩`

## Fix Applied

| Field | Before | After |
|-------|--------|-------|
| `status` | `verified` | `formalized` |
| `badge` | `verified` | `wip` |
| `assumptions` | "None. All 3 former axioms... converted to theorems" | Explicitly names True-stub theorems |
| `lineCount` | 360 | 506 (correct) |

The 2-row LR coefficient computation and Gr(2,4) multiplication table remain fully verified — only the complexity-theoretic summary theorems are affected.

---
Discovered during gallery integrity audit (2026-04-13).