### PR TITLE
Research: Apéry ζ(3) — recurrence proved + factorial denominator control

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -312,6 +312,7 @@ import Proofs.CevasTheoremOQ04
 import Proofs.CevasTheoremSinRatio
 import Proofs.ChebyshevBounds
 import Proofs.ChebyshevPNTBridge
+import Proofs.ChebyshevPNTBridgeOQ02
 import Proofs.ChineseRemainderConstructive
 import Proofs.ChineseRemainderConstructiveOQ03
 import Proofs.ChineseRemainderConstructiveOQ04

--- a/proofs/Proofs/BaselProblemOQ01OQ01OQ02.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01OQ02.lean
@@ -272,6 +272,18 @@ theorem aperyA_two : aperyA 2 = 351 / 4 := by
   simp only [aperyA]
   norm_num
 
+/-- The a-sequence satisfies the same 3-term recurrence as bₙ.
+    Proof: unfold definition, clear the (n+2)³ denominator via field_simp. -/
+private theorem aperyA_recurrence (n : ℕ) :
+    ((n + 2 : ℤ) : ℚ) ^ 3 * aperyA (n + 2) =
+    ((2 * (n + 1 : ℤ) + 1) * (17 * (n + 1 : ℤ) ^ 2 + 17 * (n + 1 : ℤ) + 5) : ℤ) *
+      aperyA (n + 1) -
+    ((n + 1 : ℤ) : ℚ) ^ 3 * aperyA n := by
+  simp only [aperyA]
+  have hne : ((n : ℚ) + 2) ^ 3 ≠ 0 := by positivity
+  push_cast
+  field_simp [hne]
+
 -- ============================================================================
 -- Part VII: Harmonic Numbers and Generalized Harmonic Sums
 -- ============================================================================
@@ -345,6 +357,13 @@ theorem lcmUpTo_pos (n : ℕ) (hn : 1 ≤ n) : 0 < lcmUpTo n := by
   have h1 : 1 ∣ (Finset.range n).lcm (· + 1) := Finset.dvd_lcm (Finset.mem_range.mpr (by omega))
   rw [h] at h1
   exact absurd h1 (by omega)
+
+/-- lcmUpTo is monotone under divisibility: m ≤ n → lcmUpTo m ∣ lcmUpTo n. -/
+theorem lcmUpTo_dvd {m n : ℕ} (hmn : m ≤ n) : lcmUpTo m ∣ lcmUpTo n := by
+  unfold lcmUpTo
+  apply Finset.lcm_dvd
+  intro i hi
+  exact Finset.dvd_lcm (Finset.range_mono hmn hi)
 
 /-- **Nair's bound (1982)**: lcm(1, 2, ..., n) ≤ 4^n.
     This elementary bound bypasses the prime number theorem for
@@ -576,5 +595,62 @@ theorem apery_irrationality_conditional
       _ = |(M : ℝ)| := by rw [hcast]
   -- Now: 1 ≤ |M| = d_{N₀} · |L_{N₀}| < 1 — contradiction
   linarith [heq ▸ hsmall]
+
+-- ============================================================================
+-- Part XIII: Factorial Denominator Control
+-- ============================================================================
+
+/-- **Factorial denominator control**: (n!)³ · aₙ ∈ ℤ for all n.
+
+    This is a weaker but provable version of the true denominator control
+    (which uses lcm instead of factorial). The proof is by 2-step induction
+    using aperyA_recurrence:
+
+    Base cases: a₀ = 0, a₁ = 6.
+    Inductive step: From the recurrence
+      (n+2)³ · a_{n+2} = coeff · a_{n+1} - (n+1)³ · aₙ
+    we get
+      (n+2)!³ · a_{n+2} = coeff · (n+1)!³ · a_{n+1} - (n+1)^6 · n!³ · aₙ
+    If (n+1)!³ · a_{n+1} = m_{n+1} ∈ ℤ and n!³ · aₙ = mₙ ∈ ℤ, then the witness is
+      m_{n+2} = coeff · m_{n+1} - (n+1)^6 · mₙ. -/
+theorem denominator_control_factorial (n : ℕ) :
+    ∃ m : ℤ, ((n.factorial : ℚ) ^ 3) * aperyA n = m := by
+  suffices h : ∀ k : ℕ,
+      (∃ m : ℤ, ((k.factorial : ℚ) ^ 3) * aperyA k = m) ∧
+      (∃ m : ℤ, (((k + 1).factorial : ℚ) ^ 3) * aperyA (k + 1) = m) from (h n).1
+  intro k
+  induction k with
+  | zero => exact ⟨⟨0, by simp [aperyA]⟩, ⟨6, by simp [aperyA]⟩⟩
+  | succ j ih =>
+    obtain ⟨⟨mj, hmj⟩, ⟨mj1, hmj1⟩⟩ := ih
+    refine ⟨⟨mj1, hmj1⟩, ?_⟩
+    refine ⟨((2 * (j + 1 : ℤ) + 1) * (17 * (j + 1 : ℤ) ^ 2 + 17 * (j + 1 : ℤ) + 5)) * mj1 -
+        (j + 1 : ℤ) ^ 6 * mj, ?_⟩
+    have hfact2 : ((j + 2).factorial : ℚ) = (j + 2 : ℚ) * ((j + 1).factorial : ℚ) := by
+      have := Nat.factorial_succ (j + 1); push_cast [this]; ring
+    have hfact1 : ((j + 1).factorial : ℚ) = (j + 1 : ℚ) * (j.factorial : ℚ) := by
+      have := Nat.factorial_succ j; push_cast [this]; ring
+    have hrec := aperyA_recurrence j
+    calc ((j + 2).factorial : ℚ) ^ 3 * aperyA (j + 2)
+        = ((j + 1).factorial : ℚ) ^ 3 * (((j + 2 : ℤ) : ℚ) ^ 3 * aperyA (j + 2)) := by
+            rw [hfact2]; push_cast; ring
+      _ = ((j + 1).factorial : ℚ) ^ 3 *
+            (((2 * (j + 1 : ℤ) + 1) * (17 * (j + 1 : ℤ) ^ 2 + 17 * (j + 1 : ℤ) + 5) : ℤ) *
+              aperyA (j + 1) - ((j + 1 : ℤ) : ℚ) ^ 3 * aperyA j) := by rw [hrec]
+      _ = ((2 * (j + 1 : ℤ) + 1) * (17 * (j + 1 : ℤ) ^ 2 + 17 * (j + 1 : ℤ) + 5) : ℤ) *
+            (((j + 1).factorial : ℚ) ^ 3 * aperyA (j + 1)) -
+            ((j + 1 : ℤ) : ℚ) ^ 3 * (((j + 1).factorial : ℚ) ^ 3 * aperyA j) := by
+            push_cast; ring
+      _ = ((2 * (j + 1 : ℤ) + 1) * (17 * (j + 1 : ℤ) ^ 2 + 17 * (j + 1 : ℤ) + 5) : ℤ) *
+            (mj1 : ℚ) -
+            ((j + 1 : ℤ) : ℚ) ^ 3 * (((j + 1).factorial : ℚ) ^ 3 * aperyA j) := by rw [hmj1]
+      _ = ((2 * (j + 1 : ℤ) + 1) * (17 * (j + 1 : ℤ) ^ 2 + 17 * (j + 1 : ℤ) + 5) : ℤ) *
+            (mj1 : ℚ) -
+            (j + 1 : ℤ) ^ 6 * ((j.factorial : ℚ) ^ 3 * aperyA j) := by
+            rw [hfact1]; push_cast; ring
+      _ = ((2 * (j + 1 : ℤ) + 1) * (17 * (j + 1 : ℤ) ^ 2 + 17 * (j + 1 : ℤ) + 5) : ℤ) *
+            (mj1 : ℚ) - (j + 1 : ℤ) ^ 6 * (mj : ℚ) := by rw [hmj]
+      _ = ↑(((2 * (j + 1 : ℤ) + 1) * (17 * (j + 1 : ℤ) ^ 2 + 17 * (j + 1 : ℤ) + 5)) * mj1 -
+            (j + 1 : ℤ) ^ 6 * mj) := by push_cast; ring
 
 end AperyZetaThree

--- a/research/problems/basel-problem-oq-01-oq-01-oq-02/knowledge.md
+++ b/research/problems/basel-problem-oq-01-oq-01-oq-02/knowledge.md
@@ -84,3 +84,53 @@ The conditional theorem abstracts this away.
 2. Find stronger prime bound in Mathlib (PNT or Rosser-Schoenfeld)
 3. Prove denominator_control from a-sequence closed form
 4. Submit Aristotle companion for routine sub-lemmas
+
+---
+
+## Session 2026-04-13 (S2) — Recurrence Proved + Factorial Denominator Control
+
+**Mode**: REVISIT (RICH knowledge tier)
+**Outcome**: progress — proved 3 new theorems, 580 → 656 lines
+
+### What I Did
+
+Added Part XIII and helper theorems (580 → 656 lines):
+
+**aperyA_recurrence** (private, line ~285):
+- Proves the a-sequence satisfies the 3-term recurrence:
+  `(n+2)³·aₙ₊₂ = (2n+3)(17(n+1)²+17(n+1)+5)·aₙ₊₁ - (n+1)³·aₙ`
+- Proof: unfold `aperyA` definition, `push_cast` to normalize casts, `field_simp` cancels the `(n+2)³` denominator
+- Key insight: `push_cast` before `field_simp` was essential to unify cast types
+
+**lcmUpTo_dvd** (after `lcmUpTo_pos`):
+- Proves: `m ≤ n → lcmUpTo m ∣ lcmUpTo n`
+- Proof: `Finset.lcm_dvd` + `Finset.range_mono` — essentially a one-liner
+- Fills a gap in the divisibility infrastructure
+
+**denominator_control_factorial** (Part XIII, near end):
+- Proves: `∃ m : ℤ, (n!)³ · aperyA n = m`  (i.e., `(n!)³·aₙ ∈ ℤ`)
+- Proof: 2-step induction using `aperyA_recurrence`
+  - Base cases: n=0 (witness 0) and n=1 (witness 6)
+  - Inductive step: integer witness at n+2 is `coeff·m_{n+1} - (n+1)^6·m_n`
+  - Key calc: factor `(n+2)!³·a_{n+2}` = `(n+1)!³·((n+2)³·a_{n+2})`, use recurrence
+
+### Sorry Count: Still 4 (same sorries as before — new proved theorems added)
+
+1. `aperyB_recurrence`: b-recurrence — WZ theory required
+2. `apery_theorem`: Main theorem — needs denominator control + PNT
+3. `nair_lcm_bound`: lcm ≤ 4^n — Chebyshev/ballot-integral
+4. `denominator_control`: lcm³·aₙ ∈ ℤ — harder than factorial version
+
+### Key Insight: Factorial vs LCM Denominator Control
+
+`(n!)³·aₙ ∈ ℤ` is *weaker* than `lcm(1,...,n)³·aₙ ∈ ℤ` but proved cleanly.
+The factorial version doesn't help with irrationality (n! >> lcm), but demonstrates
+the inductive argument works. The lcm version requires `(n+2)³·lcm(n+1)³ | lcm(n+2)³`,
+which fails when `gcd(n+2, lcm(1,...,n+1)) > 1`.
+
+### Next Steps
+
+1. Prove `nair_lcm_bound`: Chebyshev ballot-integral approach
+2. Search for PNT or Rosser-Schoenfeld in Mathlib
+3. Prove `denominator_control` (lcm version) — the hard problem
+4. Prove `aperyB_recurrence` via WZ or direct combinatorics

--- a/research/problems/chebyshev-pnt-bridge-oq-02/knowledge.md
+++ b/research/problems/chebyshev-pnt-bridge-oq-02/knowledge.md
@@ -1,0 +1,39 @@
+# chebyshev-pnt-bridge-oq-02: Explicit PNT Bound from Chebyshev Power Bound
+
+**Problem**: Derive explicit real-valued bounds on π(x) from the Chebyshev integer power inequalities in ChebyshevBounds.lean and ChebyshevPNTBridge.lean.
+
+**Related gallery proofs**: `chebyshev-pnt-bridge`, `chebyshev-pnt-bridge-oq-01`, `chebyshev-bounds`
+
+---
+
+## Session 2026-04-13 (Session 1) - Gallery entry creation
+
+**Mode**: FRESH
+**Outcome**: completed
+
+### What I Did
+- Discovered `ChebyshevPNTBridgeOQ02.lean` already existed (168 lines, 0 sorries, 0 axioms) but had no gallery entry
+- Created gallery entry: `src/data/proofs/chebyshev-pnt-bridge-oq-02/` with meta.json, index.ts, annotations.json
+- Registered `import Proofs.ChebyshevPNTBridgeOQ02` in `proofs/Proofs.lean`
+- Updated candidate pool status to `completed`
+- Updated research problem JSON with COMPLETED phase and knowledge items
+
+### Key Findings
+- The Lean file proves 4 theorems:
+  1. `chebyshev_lower_log`: n·log(4) - log(2n+1) ≤ π(2n)·log(2n) (log form)
+  2. `chebyshev_lower_real`: (n·log(4)-log(2n+1))/log(2n) ≤ π(2n) (explicit lower bound)
+  3. `chebyshev_lower_pos`: the lower bound expression is positive (4^n > 2n+1 by induction)
+  4. `chebyshev_pi_interval`: two-sided sandwich with Erdos31PrimesDensity upper bound
+- Establishes π(x) = Θ(x/log x) with explicit Chebyshev constants [log(2), 2·log(4)]
+- Chains three prior files: ChebyshevBounds → ChebyshevPNTBridge + Erdos31PrimesDensity
+
+### Files Modified
+- `src/data/proofs/chebyshev-pnt-bridge-oq-02/meta.json` (created)
+- `src/data/proofs/chebyshev-pnt-bridge-oq-02/index.ts` (created)
+- `src/data/proofs/chebyshev-pnt-bridge-oq-02/annotations.json` (created)
+- `proofs/Proofs.lean` (added import)
+- `src/data/research/problems/chebyshev-pnt-bridge-oq-02.json` (updated to COMPLETED)
+- `.lean/state/candidate-pool.json` (status: completed)
+
+### Next Steps
+None - problem is COMPLETED.

--- a/research/problems/chebyshev-pnt-bridge-oq-02/problem.md
+++ b/research/problems/chebyshev-pnt-bridge-oq-02/problem.md
@@ -1,0 +1,46 @@
+# Problem: Explicit PNT Bound from Chebyshev Power Bound
+
+## Statement
+
+### Plain Language
+Derive explicit real-valued lower bounds on π(x) from Chebyshev's integer power inequalities (central binomial coefficient bounds), completing the analytic bridge to the Prime Number Theorem.
+
+### Formal Statement
+For all n ≥ 1:
+- `(n * log 4 - log (2n+1)) / log (2n) ≤ Nat.primeCounting (2 * n)`
+- Together with the upper bound: establishes π(x) = Θ(x/log x) with explicit constants [log 2, 2·log 4]
+
+## Classification
+
+```yaml
+tier: A
+significance: 7
+tractability: 7
+tags:
+  - seeker-selected
+  - number-theory
+  - prime-counting
+  - analytic-number-theory
+```
+
+**Significance**: 7/10
+**Tractability**: 7/10
+
+## Why This Matters
+
+1. **Completes the Chebyshev chain**: bridges integer inequalities (C(2n,n) bounds) to real-valued prime counting bounds
+2. **Explicit constants**: gives Chebyshev's [log(2), 2·log(4)] interval without any deep analytic machinery
+3. **Historical significance**: formalizes Chebyshev's 1852 result that π(x) = Θ(x/log x)
+
+## Related Gallery Proofs
+
+| Proof | Relevance |
+|-------|-----------|
+| chebyshev-bounds | Provides log_centralBinom_ge lemma |
+| chebyshev-pnt-bridge | Provides centralBinom_le_pow_primeCounting |
+| chebyshev-pnt-bridge-oq-01 | Sibling: factorization bound p^{v_p(C(2n,n))} ≤ 2n |
+
+## Status: COMPLETED
+
+Lean file `ChebyshevPNTBridgeOQ02.lean` exists with 0 sorries, 0 axioms.
+Gallery entry created: `src/data/proofs/chebyshev-pnt-bridge-oq-02/`.

--- a/research/problems/chebyshev-pnt-bridge-oq-02/state.md
+++ b/research/problems/chebyshev-pnt-bridge-oq-02/state.md
@@ -1,0 +1,16 @@
+# Current State
+
+**Phase**: COMPLETED
+**Since**: 2026-04-13
+
+## Summary
+
+Lean file `proofs/Proofs/ChebyshevPNTBridgeOQ02.lean` (168 lines, 0 sorries, 0 axioms) contains all proofs.
+Gallery entry `src/data/proofs/chebyshev-pnt-bridge-oq-02/` created with meta.json, index.ts, annotations.json.
+
+## Key Results
+
+- `chebyshev_lower_log`: n·log(4) - log(2n+1) ≤ π(2n)·log(2n)
+- `chebyshev_lower_real`: (n·log(4)-log(2n+1))/log(2n) ≤ π(2n)
+- `chebyshev_lower_pos`: 0 < n·log(4) - log(2n+1) for n ≥ 1
+- `chebyshev_pi_interval`: two-sided sandwich for π(2n)

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-02/annotations.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-02/annotations.json
@@ -1,0 +1,104 @@
+[
+  {
+    "id": "ann-lower-bound-log",
+    "proofId": "chebyshev-pnt-bridge-oq-02",
+    "range": { "startLine": 57, "endLine": 78 },
+    "type": "theorem",
+    "title": "Lower Bound in Log Form",
+    "content": "The main new result: for $n \\geq 1$, $n \\cdot \\log 4 - \\log(2n+1) \\leq \\pi(2n) \\cdot \\log(2n)$. The proof chains two previously proved integer inequalities via `Real.log_le_log`: first $n \\cdot \\log 4 - \\log(2n+1) \\leq \\log \\binom{2n}{n}$ (from `ChebyshevBounds.log_centralBinom_ge`), then $\\log \\binom{2n}{n} \\leq \\pi(2n) \\cdot \\log(2n)$ (from `ChebyshevPNTBridge.centralBinom_le_pow_primeCounting` via `Real.log_pow`).",
+    "mathContext": "Chain: $n\\log 4 - \\log(2n+1) \\leq \\log\\binom{2n}{n} \\leq \\log(2n)^{\\pi(2n)} = \\pi(2n)\\cdot\\log(2n)$. The first inequality is the log-form Chebyshev lower bound; the second uses monotonicity of $\\log$ and $\\log(a^b) = b\\log a$.",
+    "significance": "key",
+    "prerequisites": [
+      "Real.log_le_log (monotonicity)",
+      "Real.log_pow",
+      "ChebyshevBounds.log_centralBinom_ge",
+      "ChebyshevPNTBridge.centralBinom_le_pow_primeCounting"
+    ],
+    "relatedConcepts": [
+      "Chebyshev's lower bound",
+      "prime counting function",
+      "central binomial coefficient",
+      "logarithm monotonicity"
+    ]
+  },
+  {
+    "id": "ann-lower-bound-divided",
+    "proofId": "chebyshev-pnt-bridge-oq-02",
+    "range": { "startLine": 83, "endLine": 98 },
+    "type": "theorem",
+    "title": "Explicit Lower Bound on π(2n)",
+    "content": "Divides the log-form inequality by $\\log(2n) > 0$ to get a direct lower bound on $\\pi(2n)$: $(n\\log 4 - \\log(2n+1))/\\log(2n) \\leq \\pi(2n)$. For large $n$, the left side $\\sim n\\log 4/\\log(2n) \\sim \\log(2) \\cdot 2n/\\log(2n) = \\log(2) \\cdot x/\\log x$, recovering Chebyshev's constant $\\log 2 \\approx 0.693$.",
+    "mathContext": "Divide $n\\log 4 - \\log(2n+1) \\leq \\pi(2n)\\cdot\\log(2n)$ by $\\log(2n) > 0$ (using `Real.log_pos` since $2n > 1$). As $n \\to \\infty$: $(n\\log 4 - \\log(2n+1))/\\log(2n) \\to n\\log 4/\\log(2n) = \\frac{1}{2} \\cdot \\frac{2n\\log 4}{\\log(2n)} \\sim \\frac{\\log 4}{2} \\cdot \\frac{x}{\\log x} = \\log 2 \\cdot \\frac{x}{\\log x}$.",
+    "significance": "key",
+    "prerequisites": [
+      "Real.log_pos",
+      "div_le_iff₀",
+      "chebyshev_lower_log"
+    ],
+    "relatedConcepts": [
+      "prime counting lower bound",
+      "Chebyshev's constant log(2)",
+      "analytic number theory",
+      "asymptotic analysis"
+    ]
+  },
+  {
+    "id": "ann-positivity",
+    "proofId": "chebyshev-pnt-bridge-oq-02",
+    "range": { "startLine": 104, "endLine": 126 },
+    "type": "theorem",
+    "title": "The Lower Bound Is Non-Vacuous",
+    "content": "Proves that $n \\cdot \\log 4 - \\log(2n+1) > 0$ for all $n \\geq 1$, i.e., $4^n > 2n+1$. This is a clean induction: base case $4 > 3$ (n=1), and inductively $4^{n+1} = 4 \\cdot 4^n > 4(2n+1) = 8n+4 > 2(n+1)+1 = 2n+3$ for $n \\geq 0$. Without this lemma, the divided-form lower bound could be negative (vacuous).",
+    "mathContext": "Claim: $4^n > 2n+1$ for $n \\geq 1$. Equivalently, $n\\log 4 > \\log(2n+1)$, so the lower bound expression is positive. The exponential $4^n$ grows much faster than the linear $2n+1$; the induction argument is tight at $n=1$ (4 vs. 3) and quickly becomes trivial.",
+    "significance": "supporting",
+    "prerequisites": [
+      "Nat.pow induction",
+      "Real.log_lt_log",
+      "Real.log_pow"
+    ],
+    "relatedConcepts": [
+      "exponential vs linear growth",
+      "non-vacuous lower bounds",
+      "induction on natural numbers"
+    ]
+  },
+  {
+    "id": "ann-pi-interval",
+    "proofId": "chebyshev-pnt-bridge-oq-02",
+    "range": { "startLine": 132, "endLine": 150 },
+    "type": "theorem",
+    "title": "Two-Sided Chebyshev Sandwich",
+    "content": "The main synthesis theorem: for $n \\geq 2$, $\\pi(2n)$ is sandwiched by $$\\frac{n\\log 4 - \\log(2n+1)}{\\log(2n)} \\leq \\pi(2n) \\leq \\frac{2(2n)\\log 4}{\\log(2n)} + \\sqrt{2n} + 1.$$ The lower bound is the new result of this file; the upper bound is `Erdos31PrimesDensity.primeCounting_le_chebyshev`. Together they establish $\\pi(x) = \\Theta(x/\\log x)$ with explicit constants $\\log 2 \\approx 0.693$ and $2\\log 4 \\approx 2.773$.",
+    "mathContext": "Chebyshev (1852) actually proved the tighter interval $[0.921, 1.106]$ around the PNT constant 1. Our elementary bounds give $[\\log 2, 2\\log 4] = [0.693, 2.773]$, which is wider but sufficient to establish $\\pi(x) = \\Theta(x/\\log x)$. Chebyshev's exact constants required his refined estimates of $\\psi(x) = \\sum_{p^k \\leq x} \\log p$ using the primorial.",
+    "significance": "key",
+    "prerequisites": [
+      "chebyshev_lower_real",
+      "Erdos31PrimesDensity.primeCounting_le_chebyshev"
+    ],
+    "relatedConcepts": [
+      "Chebyshev's theorem",
+      "Prime Number Theorem",
+      "asymptotic prime counting",
+      "Bertrand's postulate"
+    ]
+  },
+  {
+    "id": "ann-numerical",
+    "proofId": "chebyshev-pnt-bridge-oq-02",
+    "range": { "startLine": 154, "endLine": 168 },
+    "type": "technique",
+    "title": "Numerical Verification via native_decide",
+    "content": "Verifies $\\pi(2)=1$, $\\pi(10)=4$, $\\pi(20)=8$, $\\pi(100)=25$, $\\pi(1000)=168$ using `native_decide`. These certify exact prime counting values up to 1000, confirming that $\\pi(1000) = 168$ is consistent with the Chebyshev bounds (lower bound ≈ 103, upper bound ≈ 207 at $n=500$).",
+    "mathContext": "The well-known values: primes up to 10 are {2,3,5,7} (π(10)=4); up to 100 there are 25 primes (π(100)=25); up to 1000 there are 168 primes (π(1000)=168). These match the asymptotic $x/\\log x$ approximation: $1000/\\log(1000) \\approx 144.8$, and the true value 168 is within the Chebyshev factor.",
+    "significance": "context",
+    "prerequisites": [
+      "Nat.primeCounting",
+      "native_decide tactic"
+    ],
+    "relatedConcepts": [
+      "prime counting function values",
+      "native_decide certified computation",
+      "prime number theorem numerics"
+    ]
+  }
+]

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-02/index.ts
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-02/index.ts
@@ -1,0 +1,10 @@
+import type { Proof, Annotation, ProofData, ProofMeta, ProofSection, ProofOverview, ProofConclusion, CrossReference } from '@/types/proof'
+import metaJson from './meta.json'
+import annotationsJson from './annotations.json'
+const meta = metaJson as { id: string; title: string; slug: string; description: string; meta: ProofMeta; sections: ProofSection[]; overview?: ProofOverview; conclusion?: ProofConclusion; crossReferences?: CrossReference[] }
+const leanSource = () => import('../../../../proofs/Proofs/ChebyshevPNTBridgeOQ02.lean?raw')
+export const proof: Proof = { id: meta.id, title: meta.title, slug: meta.slug, description: meta.description, meta: meta.meta, sections: meta.sections, source: '', overview: meta.overview, conclusion: meta.conclusion, crossReferences: meta.crossReferences }
+export const annotations: Annotation[] = annotationsJson as unknown as Annotation[]
+export const proofData: ProofData = { proof, annotations }
+export async function getProofSource(): Promise<string> { const module = await leanSource(); return module.default }
+export default proofData

--- a/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Added aperyRecCoeff_le_34_mul_cubeSucc (proved). 6 sorries remain but key algebraic bound now established.",
+    "progressSummary": "PROGRESS: 656 lines, 4 sorries remain (b-recurrence/WZ, nair_lcm_bound, denominator_control lcm version, apery_theorem). New: aperyA_recurrence proved, lcmUpTo_dvd proved, denominator_control_factorial proved.",
     "builtItems": [
       "Created proofs/Proofs/BaselProblemOQ01OQ01OQ02.lean (199 lines)",
       "Defined aperyB: ℕ → ℕ (Apéry number sequence)",
@@ -43,7 +43,10 @@
       "Defined lcmUpTo and stated nair_lcm_bound (sorry)",
       "Defined linearForm: bₙ·ζ(3) - aₙ",
       "Stated denominator_control: lcm³·aₙ ∈ ℤ (sorry)",
-      "Proved aperyRecCoeff_le_34_mul_cubeSucc: (2n+1)(17n^2+17n+5) ≤ 34*(n+1)^3 by nlinarith (BaselProblemOQ01OQ01OQ02.lean)"
+      "Proved aperyRecCoeff_le_34_mul_cubeSucc: (2n+1)(17n^2+17n+5) ≤ 34*(n+1)^3 by nlinarith (BaselProblemOQ01OQ01OQ02.lean)",
+      "aperyA_recurrence (private): a-sequence satisfies 3-term recurrence, BaselProblemOQ01OQ01OQ02.lean",
+      "lcmUpTo_dvd: m ≤ n → lcmUpTo m ∣ lcmUpTo n, BaselProblemOQ01OQ01OQ02.lean",
+      "denominator_control_factorial: (n!)³·aperyA n ∈ ℤ for all n, by 2-step induction, BaselProblemOQ01OQ01OQ02.lean"
     ],
     "insights": [
       "Apéry numbers bₙ = ∑ C(n,k)²C(n+k,k)² computable as ℕ in Lean via Finset.sum",
@@ -56,7 +59,11 @@
       "lcm bound lcm(1,...,n) ≤ 4^n (Nair 1982) bypasses PNT for denominator control",
       "Critical path: recurrence → growth → decay + denominator control → irrationality",
       "Harmonic numbers H_n and generalized H_n^{(s)} needed for a-sequence closed form",
-      "aperyRecCoeff_le_34_mul_cubeSucc proves the key algebraic inequality: 34(n+1)^3 - (2n+1)(17n^2+17n+5) = 51n^2+75n+29 > 0. This enables bounding b_{n+1} ≤ 34*b_n from the recurrence."
+      "aperyRecCoeff_le_34_mul_cubeSucc proves the key algebraic inequality: 34(n+1)^3 - (2n+1)(17n^2+17n+5) = 51n^2+75n+29 > 0. This enables bounding b_{n+1} ≤ 34*b_n from the recurrence.",
+      "factorial denominator control is provable by 2-step induction on the recurrence; lcm version is harder",
+      "push_cast before field_simp is essential when cast types mix ℤ and ℚ in recurrence proofs",
+      "lcmUpTo_dvd follows immediately from Finset.lcm_dvd + Finset.range_mono",
+      "PNT (lcm ~ eⁿ) is needed for unconditional irrationality; Nair (lcm ≤ 4ⁿ) is insufficient"
     ],
     "mathlibGaps": [],
     "nextSteps": [

--- a/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02.json
@@ -65,7 +65,12 @@
       "lcmUpTo_dvd follows immediately from Finset.lcm_dvd + Finset.range_mono",
       "PNT (lcm ~ eⁿ) is needed for unconditional irrationality; Nair (lcm ≤ 4ⁿ) is insufficient"
     ],
-    "mathlibGaps": [],
+    "mathlibGaps": [
+      "Mathlib has primorial_le_four_pow (primorial ≤ 4^n) but NOT lcmUpTo ≤ 4^n directly",
+      "Mathlib has primorial_add_dvd: primorial(m+n) | primorial(m) * C(m+n,m) for n ≤ m",
+      "lcmUpTo n = ∏_{k≥1} primorial(⌊n^{1/k}⌋) but this product approach gives weaker bound 4^{2n} not 4^n",
+      "nair_lcm_bound needs either PNT/Chebyshev or a clever ballot-integral argument not yet available"
+    ],
     "nextSteps": [
       "Prove aperyB_recurrence by combinatorial identity expansion",
       "Define the a-sequence with harmonic number coefficients",


### PR DESCRIPTION
## Summary

- Proved `aperyA_recurrence`: the Apéry a-sequence satisfies the same 3-term recurrence as the b-sequence, by unfolding the recursive definition and using `push_cast` + `field_simp` to cancel the `(n+2)³` denominator
- Proved `lcmUpTo_dvd`: `m ≤ n → lcmUpTo m ∣ lcmUpTo n`, via `Finset.lcm_dvd` + `Finset.range_mono`
- Proved `denominator_control_factorial`: `(n!)³·aₙ ∈ ℤ` for all n, by 2-step induction using the recurrence with explicit integer witnesses
- Updated metadata: lineCount 580→656, originalContributions, progressSummary
- Added session notes to knowledge.md documenting factorial vs. lcm denominator control distinction

The 4 existing sorries remain (b-recurrence requires WZ-theory, nair_lcm_bound, denominator_control/lcm-version, apery_theorem).

## Test plan

- [ ] Verify `./proofs/scripts/docker-build.sh Proofs.BaselProblemOQ01OQ01OQ02` compiles
- [ ] Confirm sorry count is still 4 (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)