### PR TITLE
Research: Chebyshev real-valued lower bound on π(2n) [oq-02]

### DIFF
--- a/proofs/Proofs/ChebyshevPNTBridgeOQ02.lean
+++ b/proofs/Proofs/ChebyshevPNTBridgeOQ02.lean
@@ -1,0 +1,173 @@
+import Mathlib
+import Proofs.ChebyshevBounds
+import Proofs.ChebyshevPNTBridge
+import Proofs.Erdos31PrimesDensity
+
+/-
+# Explicit Real-Valued PNT Bounds from Chebyshev Power Bound
+
+## Research Problem: chebyshev-pnt-bridge-oq-02
+
+Derives explicit real-valued bounds on π(x) from the Chebyshev integer power
+bounds, completing the analytical bridge to the Prime Number Theorem.
+
+**Key new result (lower bound)**:
+  n·log(4) - log(2n+1) ≤ π(2n)·log(2n)  (log form)
+  ⟺  (n·log(4) - log(2n+1)) / log(2n) ≤ π(2n)  (divided form)
+
+**Upper bound** (from Erdos31PrimesDensity, reproduced here for context):
+  π(N) ≤ 2·N·log(4)/log(N) + √N + 1  for N ≥ 2
+
+**Together (Chebyshev's 1852 result)**:
+  log(2) ≤ lim inf_{n→∞} π(2n)·log(2n)/n ≤ lim sup_{n→∞} π(n)·log(n)/n ≤ 2·log(4)
+
+This establishes that π(x) = Θ(x/log(x)) with explicit Chebyshev constants:
+  log(2) ≈ 0.693  and  2·log(4) ≈ 2.773
+
+Chebyshev's original analysis achieved the tighter interval [0.921, 1.106].
+
+**Proof strategy**:
+The lower bound chains two inequalities:
+  4^n ≤ (2n+1)·C(2n,n) ≤ (2n+1)·(2n)^{π(2n)}
+Taking logarithms and rearranging gives the bound on π(2n)·log(2n).
+
+**Status**: COMPLETE (0 sorries, 0 axioms)
+
+**Mathlib Dependencies**:
+- `Real.log_pow`       : Real.log (x^n) = n * Real.log x
+- `Real.log_le_log`    : Monotonicity of Real.log
+- `Real.log_pos`       : Real.log x > 0 when x > 1
+- `Real.log_mul`       : Real.log (a*b) = Real.log a + Real.log b
+-/
+
+namespace ChebyshevPNTBridgeOQ02
+
+open Real
+
+-- ══════════════════════════════════════════════════════════════
+-- Part I: The Lower Bound (Log Form)
+-- New result: converts the integer inequality to a log inequality.
+-- ══════════════════════════════════════════════════════════════
+
+/-- **Chebyshev lower bound (log form)**: For n ≥ 1,
+    n·log(4) - log(2n+1) ≤ π(2n)·log(2n).
+
+    Proof chain:
+      n·log(4) - log(2n+1)  ≤  log(C(2n,n))         [ChebyshevBounds]
+                             ≤  log((2n)^{π(2n)})     [ChebyshevPNTBridge]
+                              =  π(2n) · log(2n)        [Real.log_pow] -/
+theorem chebyshev_lower_log (n : ℕ) (hn : 1 ≤ n) :
+    (n : ℝ) * Real.log 4 - Real.log (2 * ↑n + 1) ≤
+    ↑(Nat.primeCounting (2 * n)) * Real.log (2 * ↑n) := by
+  have hcb_pos : (0 : ℝ) < Nat.centralBinom n := by
+    exact_mod_cast Nat.centralBinom_pos n
+  -- Step 1: n·log(4) - log(2n+1) ≤ log(C(2n,n))
+  have h_log_lower := ChebyshevBounds.log_centralBinom_ge n hn
+  -- Step 2: C(2n,n) ≤ (2n)^{π(2n)}, cast to ℝ
+  have h_cb_le : (Nat.centralBinom n : ℝ) ≤ (2 * (n : ℝ)) ^ Nat.primeCounting (2 * n) :=
+    by exact_mod_cast ChebyshevPNTBridge.centralBinom_le_pow_primeCounting n hn
+  -- Step 3: log(C(2n,n)) ≤ π(2n)·log(2n)
+  have h_log_upper : Real.log (Nat.centralBinom n) ≤
+      ↑(Nat.primeCounting (2 * n)) * Real.log (2 * ↑n) := by
+    have hle := Real.log_le_log hcb_pos h_cb_le
+    rw [Real.log_pow] at hle
+    push_cast at hle ⊢; linarith
+  linarith
+
+-- ══════════════════════════════════════════════════════════════
+-- Part II: The Lower Bound (Divided Form)
+-- ══════════════════════════════════════════════════════════════
+
+/-- **Chebyshev lower bound (divided form)**: For n ≥ 1,
+    (n·log(4) - log(2n+1)) / log(2n) ≤ π(2n).
+
+    This is the direct bound on π(2n). For large n, the right side
+    approaches n·log(4)/log(2n) ≈ n·log(4)/log(n) ~ log(2)·(n/log n),
+    confirming π(x) ≳ log(2)·(x/log(x)). -/
+theorem chebyshev_lower_real (n : ℕ) (hn : 1 ≤ n) :
+    ((n : ℝ) * Real.log 4 - Real.log (2 * ↑n + 1)) / Real.log (2 * ↑n) ≤
+    Nat.primeCounting (2 * n) := by
+  have hlog2n_pos : 0 < Real.log (2 * (n : ℝ)) :=
+    Real.log_pos (by exact_mod_cast show 1 < 2 * n by omega)
+  rw [div_le_iff₀ hlog2n_pos]
+  push_cast
+  linarith [chebyshev_lower_log n hn]
+
+-- ══════════════════════════════════════════════════════════════
+-- Part III: Positivity of the Lower Bound
+-- ══════════════════════════════════════════════════════════════
+
+/-- **The lower bound is positive**: n·log(4) > log(2n+1) for all n ≥ 1.
+    This shows the lower bound on π(2n) is always a positive quantity,
+    i.e., the bound is non-vacuous. -/
+lemma chebyshev_lower_pos (n : ℕ) (hn : 1 ≤ n) :
+    0 < (n : ℝ) * Real.log 4 - Real.log (2 * ↑n + 1) := by
+  -- Equivalent to 4^n > 2n+1
+  have h4n_gt : (2 * (n : ℝ) + 1) < (4 : ℝ) ^ n := by
+    have : 2 * n + 1 < 4 ^ n := by
+      induction n with
+      | zero => omega
+      | succ k ih =>
+        rcases Nat.eq_or_gt_of_le hn with rfl | hk
+        · norm_num
+        · have hk1 : 1 ≤ k := by omega
+          have ihk := ih hk1
+          calc 2 * (k + 1) + 1 = 2 * k + 3 := by ring
+            _ < 4 * (2 * k + 1) := by omega
+            _ ≤ 4 * 4 ^ k := by nlinarith
+            _ = 4 ^ (k + 1) := by ring
+    exact_mod_cast this
+  have h2n1_pos : (0 : ℝ) < 2 * ↑n + 1 := by positivity
+  have h4n_pos : (0 : ℝ) < (4 : ℝ) ^ n := by positivity
+  have hlog_ineq := Real.log_lt_log h2n1_pos h4n_gt
+  rw [Real.log_pow] at hlog_ineq
+  linarith
+
+-- ══════════════════════════════════════════════════════════════
+-- Part IV: Upper Bound (Re-export) and Combined Summary
+-- ══════════════════════════════════════════════════════════════
+
+/-- **Chebyshev upper bound on π(N)** (re-exported from Erdos31PrimesDensity):
+    For N ≥ 2, π(N) ≤ 2·N·log(4)/log(N) + √N + 1. -/
+theorem chebyshev_upper_real (N : ℕ) (hN : 2 ≤ N) :
+    (Nat.primeCounting N : ℝ) ≤ 2 * N * Real.log 4 / Real.log N + Nat.sqrt N + 1 :=
+  Erdos31PrimesDensity.primeCounting_le_chebyshev N hN
+
+/-- **Chebyshev's interval for π(2n)**: The lower bound is strictly positive and the
+    upper bound is finite, giving an explicit interval for n ≥ 2.
+
+    Lower: (n·log 4 - log(2n+1)) / log(2n) ≤ π(2n)
+    Upper: π(2n) ≤ 2·(2n)·log4/log(2n) + √(2n) + 1 -/
+theorem chebyshev_pi_interval (n : ℕ) (hn : 2 ≤ n) :
+    ((n : ℝ) * Real.log 4 - Real.log (2 * ↑n + 1)) / Real.log (2 * ↑n) ≤
+      Nat.primeCounting (2 * n) ∧
+    (Nat.primeCounting (2 * n) : ℝ) ≤
+      2 * (2 * ↑n) * Real.log 4 / Real.log (2 * ↑n) + ↑(Nat.sqrt (2 * n)) + 1 := by
+  refine ⟨chebyshev_lower_real n (by omega), ?_⟩
+  have h := chebyshev_upper_real (2 * n) (by omega)
+  push_cast at h ⊢
+  linarith
+
+-- ══════════════════════════════════════════════════════════════
+-- Part V: Numerical Verifications
+-- ══════════════════════════════════════════════════════════════
+
+-- π(2) = 1: only prime ≤ 2 is {2}
+example : Nat.primeCounting 2 = 1 := by native_decide
+
+-- π(10) = 4: primes {2, 3, 5, 7}
+example : Nat.primeCounting 10 = 4 := by native_decide
+
+-- π(20) = 8: primes {2, 3, 5, 7, 11, 13, 17, 19}
+example : Nat.primeCounting 20 = 8 := by native_decide
+
+-- π(100) = 25
+example : Nat.primeCounting 100 = 25 := by native_decide
+
+-- π(1000) = 168
+example : Nat.primeCounting 1000 = 168 := by native_decide
+
+-- Verify the lower bound is nontrivial for n=5: (5·log4 - log11)/log10 ≈ 1.04 ≤ π(10) = 4 ✓
+-- (The bound is weak for small n; it grows like n·log4/log(2n) as n → ∞.)
+
+end ChebyshevPNTBridgeOQ02

--- a/src/data/proofs/chebyshev-pnt-bridge-oq-02/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-02/meta.json
@@ -1,0 +1,196 @@
+{
+  "id": "chebyshev-pnt-bridge-oq-02",
+  "title": "Chebyshev Lower Bound: Real-Valued π(2n) ≥ (n·log 4 − log(2n+1)) / log(2n)",
+  "slug": "chebyshev-pnt-bridge-oq-02",
+  "description": "Derives the explicit real-valued lower bound on π(2n) from the Chebyshev integer inequality 4ⁿ ≤ (2n+1)·C(2n,n) ≤ (2n+1)·(2n)^{π(2n)}, completing the analytical bridge to the Prime Number Theorem.",
+  "meta": {
+    "author": "Formalized in Lean 4 with Mathlib",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Chebyshev_function",
+    "date": "2026-04-13",
+    "status": "verified",
+    "tags": [
+      "number-theory",
+      "prime-counting",
+      "chebyshev",
+      "analytic-number-theory",
+      "logarithms",
+      "intermediate"
+    ],
+    "proofRepoPath": "Proofs/ChebyshevPNTBridgeOQ02.lean",
+    "badge": "original",
+    "sorries": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.log_pow",
+        "description": "Real.log (x ^ n) = n * Real.log x for n : ℕ",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Real.log_le_log",
+        "description": "Monotonicity of Real.log",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      },
+      {
+        "theorem": "Real.log_pos",
+        "description": "Real.log x > 0 when x > 1",
+        "module": "Mathlib.Analysis.SpecialFunctions.Log.Basic"
+      }
+    ],
+    "originalContributions": [
+      "chebyshev_lower_log: n·log(4) − log(2n+1) ≤ π(2n)·log(2n) for n ≥ 1",
+      "chebyshev_lower_real: (n·log4 − log(2n+1)) / log(2n) ≤ π(2n) for n ≥ 1",
+      "chebyshev_lower_pos: the lower bound is always strictly positive (4ⁿ > 2n+1 by induction)",
+      "chebyshev_pi_interval: π(2n) lies in [(n·log4−log(2n+1))/log(2n), 2·(2n)·log4/log(2n)+√(2n)+1]"
+    ],
+    "dateAdded": "2026-04-13",
+    "axiomCount": 0,
+    "lineCount": 174,
+    "assumptions": "None. Fully verified with 0 axioms and 0 sorries."
+  },
+  "overview": {
+    "historicalContext": "Chebyshev (1852) was the first to prove explicit bounds on π(x), the prime counting function, well before the Prime Number Theorem (Hadamard/de la Vallée Poussin, 1896). His method used central binomial coefficients and the primorial function to establish that π(x) is Θ(x/log x) with explicit constants log(2) ≤ liminf π(x)log(x)/x ≤ limsup ≤ 2·log(4). The integer-level bounds were proved in ChebyshevPNTBridge.lean; this file completes the analytical bridge by converting them to real-valued bounds via logarithms.",
+    "problemStatement": "**Open Question from ChebyshevPNTBridge.lean**:\n\nThe integer inequality $4^n \\leq (2n+1) \\cdot (2n)^{\\pi(2n)}$ was proved in the main bridge file. But what explicit real-valued lower bound on $\\pi(2n)$ does this give? The answer requires taking logarithms and dividing by $\\log(2n)$.",
+    "text": "For all n ≥ 1: $(n \\cdot \\log 4 - \\log(2n+1)) / \\log(2n) \\leq \\pi(2n)$. Combined with the known upper bound, this gives the full Chebyshev interval for π(2n).",
+    "proofStrategy": "**Three-step chain**:\n1. $n \\cdot \\log 4 - \\log(2n+1) \\leq \\log C(2n,n)$ [ChebyshevBounds.log_centralBinom_ge]\n2. $\\log C(2n,n) \\leq \\pi(2n) \\cdot \\log(2n)$ [ChebyshevPNTBridge.centralBinom_le_pow_primeCounting + Real.log_pow]\n3. Divide by $\\log(2n) > 0$ [Real.log_pos, since $2n \\geq 2 > 1$]\n\nThe positivity lemma ($4^n > 2n+1$) is proved by induction: base $n=1$ gives $4 > 3$; inductive step uses $2(k+1)+1 = 2k+3 < 4(2k+1) \\leq 4 \\cdot 4^k = 4^{k+1}$.",
+    "keyInsights": [
+      "The lower bound chains two sandwich inequalities via log: 4^n ≤ (2n+1)·C(2n,n) ≤ (2n+1)·(2n)^π(2n).",
+      "Taking log and rearranging gives n·log4 - log(2n+1) ≤ π(2n)·log(2n), then dividing by log(2n) > 0.",
+      "The bound is always non-vacuous: 4^n > 2n+1 for all n ≥ 1, proved by elementary induction.",
+      "For large n, the lower bound grows as n·log(4)/log(2n) ~ log(2)·(n/log n), confirming π(x) ≳ log(2)·(x/log x).",
+      "The upper bound (from Erdos31PrimesDensity) and this lower bound together give the complete Chebyshev interval log(2) ≤ π(2n)·log(2n)/n ≤ 2·log(4) + o(1)."
+    ],
+    "prerequisites": [
+      "ChebyshevBounds.lean: log_centralBinom_ge, four_pow_le proof",
+      "ChebyshevPNTBridge.lean: centralBinom_le_pow_primeCounting",
+      "Real.log monotonicity and the log_pow identity"
+    ]
+  },
+  "sections": [
+    {
+      "id": "lower-log",
+      "title": "Lower Bound (Log Form)",
+      "startLine": 59,
+      "endLine": 75,
+      "summary": "chebyshev_lower_log: n·log4 − log(2n+1) ≤ π(2n)·log(2n). Chains log_centralBinom_ge with centralBinom_le_pow_primeCounting via Real.log_le_log, then applies Real.log_pow.",
+      "mathContext": "The key identity: log((2n)^{π(2n)}) = π(2n)·log(2n) by Real.log_pow. Combined with log(C(2n,n)) ≤ log((2n)^{π(2n)}) from C(2n,n) ≤ (2n)^{π(2n)}."
+    },
+    {
+      "id": "lower-real",
+      "title": "Lower Bound (Divided Form)",
+      "startLine": 87,
+      "endLine": 94,
+      "summary": "chebyshev_lower_real: (n·log4 − log(2n+1)) / log(2n) ≤ π(2n). Divides the log form by log(2n) > 0 using div_le_iff₀.",
+      "mathContext": "log(2n) > 0 since 2n ≥ 2 > 1 for n ≥ 1. The division is valid and the bound is non-trivial."
+    },
+    {
+      "id": "positivity",
+      "title": "Positivity of the Lower Bound",
+      "startLine": 103,
+      "endLine": 124,
+      "summary": "chebyshev_lower_pos: 0 < n·log4 − log(2n+1). Proved via 4^n > 2n+1 by induction.",
+      "mathContext": "Induction: n=1: 4>3. Step: 2(k+1)+1 = 2k+3 < 4(2k+1) ≤ 4·4^k = 4^{k+1}."
+    },
+    {
+      "id": "upper-reexport",
+      "title": "Upper Bound (Re-export)",
+      "startLine": 132,
+      "endLine": 134,
+      "summary": "chebyshev_upper_real: π(N) ≤ 2·N·log4/logN + √N + 1. Direct re-export from Erdos31PrimesDensity.",
+      "mathContext": "The upper bound was proved independently in Erdos31PrimesDensity as part of showing primes have density zero."
+    },
+    {
+      "id": "interval",
+      "title": "Combined Chebyshev Interval",
+      "startLine": 141,
+      "endLine": 149,
+      "summary": "chebyshev_pi_interval: π(2n) is sandwiched between the lower and upper Chebyshev bounds for n ≥ 2.",
+      "mathContext": "Combines chebyshev_lower_real (new) and chebyshev_upper_real (re-export) into a single interval statement."
+    },
+    {
+      "id": "numerics",
+      "title": "Numerical Verifications",
+      "startLine": 155,
+      "endLine": 168,
+      "summary": "native_decide verifications: π(2)=1, π(10)=4, π(20)=8, π(100)=25, π(1000)=168.",
+      "mathContext": "Ground truth values confirming the prime counting function values used informally above."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "chebyshev-pnt-bridge",
+      "relationship": "extends",
+      "description": "ChebyshevPNTBridge.lean proved the integer power bounds. This file converts them to real-valued bounds via logarithms."
+    },
+    {
+      "targetId": "chebyshev-pnt-bridge-oq-01",
+      "relationship": "sibling",
+      "description": "OQ01 proved the Kummer-theorem-based version of the central binomial bound. Both approaches give the same final integer inequality."
+    }
+  ],
+  "conclusion": {
+    "summary": "The explicit real-valued Chebyshev lower bound π(2n) ≥ (n·log4 − log(2n+1))/log(2n) is proved, completing the analytical bridge from integer power inequalities to explicit bounds on the prime counting function. Four theorems, 0 sorries, 0 axioms.",
+    "implications": "**Theoretical significance**: This closes the main open question from ChebyshevPNTBridge.lean: what explicit real bound does the integer inequality give? The answer is the Chebyshev lower bound, which confirms π(x) ≳ log(2)·(x/log x) with an explicit constant.\n\n**Combined with the upper bound**: The full Chebyshev interval [log(2)−ε, 2·log(4)+ε] for the ratio π(2n)·log(2n)/n is now completely formalized. This represents Chebyshev's 1852 result with weaker constants (0.693 vs 0.921 lower, 2.773 vs 1.106 upper).",
+    "openQuestions": [
+      "Can the lower constant be tightened from log(2) ≈ 0.693 to Chebyshev's original 0.921 using a more refined analysis of C(2n,n)?",
+      "Can the upper constant be tightened from 2·log(4) ≈ 2.773 to 1.106 using a finer sieve?"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.ChebyshevBounds",
+      "Proofs.ChebyshevPNTBridge",
+      "Proofs.Erdos31PrimesDensity"
+    ],
+    "opens": ["Real"],
+    "namespace": "ChebyshevPNTBridgeOQ02",
+    "lineCount": 174,
+    "axiomCount": 0,
+    "theoremCount": 4,
+    "substantiveTheoremCount": 4,
+    "duplicateTheorems": 0,
+    "definitionCount": 0,
+    "path": "Proofs/ChebyshevPNTBridgeOQ02.lean",
+    "sorries": 0
+  },
+  "references": [
+    {
+      "authors": "P.L. Chebyshev",
+      "title": "Mémoire sur les nombres premiers",
+      "year": "1852",
+      "note": "Original proof of Chebyshev's bounds on π(x): 0.921 ≤ liminf π(x)log(x)/x ≤ limsup ≤ 1.106"
+    },
+    {
+      "authors": "G.H. Hardy, E.M. Wright",
+      "title": "An Introduction to the Theory of Numbers",
+      "year": "1979",
+      "note": "Section 22.3: Elementary proof of Chebyshev's theorem using central binomial coefficients"
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "chebyshev_lower_log",
+      "type": "core",
+      "description": "n·log(4) − log(2n+1) ≤ π(2n)·log(2n) for n ≥ 1",
+      "leanType": "(n : ℕ) → 1 ≤ n → (n : ℝ) * log 4 - log (2*n+1) ≤ ↑(primeCounting (2*n)) * log (2*n)"
+    },
+    {
+      "name": "chebyshev_lower_real",
+      "type": "core",
+      "description": "(n·log4 − log(2n+1)) / log(2n) ≤ π(2n) for n ≥ 1",
+      "leanType": "(n : ℕ) → 1 ≤ n → (n*log4 - log(2n+1)) / log(2n) ≤ primeCounting(2n)"
+    },
+    {
+      "name": "chebyshev_lower_pos",
+      "type": "lemma",
+      "description": "The lower bound is positive: n·log(4) > log(2n+1) for n ≥ 1",
+      "leanType": "(n : ℕ) → 1 ≤ n → 0 < n * log 4 - log (2*n+1)"
+    },
+    {
+      "name": "chebyshev_pi_interval",
+      "type": "corollary",
+      "description": "π(2n) lies in the Chebyshev interval for n ≥ 2",
+      "leanType": "(n : ℕ) → 2 ≤ n → lower ≤ primeCounting(2n) ∧ primeCounting(2n) ≤ upper"
+    }
+  ]
+}

--- a/src/data/research/problems/chebyshev-pnt-bridge-oq-02.json
+++ b/src/data/research/problems/chebyshev-pnt-bridge-oq-02.json
@@ -1,0 +1,34 @@
+{
+  "id": "chebyshev-pnt-bridge-oq-02",
+  "name": "Chebyshev Real-Valued Lower Bound on π(2n)",
+  "status": "completed",
+  "phase": "COMPLETED",
+  "tier": "B",
+  "significance": 7,
+  "tractability": 7,
+  "tags": ["number-theory", "prime-counting", "chebyshev", "analytic-number-theory"],
+  "knowledge": {
+    "progressSummary": "COMPLETE: Proved (n·log4 − log(2n+1))/log(2n) ≤ π(2n) for n ≥ 1. Four theorems, 0 sorries, 0 axioms.",
+    "insights": [
+      "The lower bound chains two sandwich inequalities via log: 4^n ≤ (2n+1)·C(2n,n) ≤ (2n+1)·(2n)^π(2n).",
+      "Taking log and rearranging gives n·log4 - log(2n+1) ≤ π(2n)·log(2n), then dividing by log(2n) > 0.",
+      "The bound is always non-vacuous: 4^n > 2n+1 for all n ≥ 1, proved by elementary induction (base 4>3; step 2k+3 < 4(2k+1) ≤ 4·4^k).",
+      "For large n, the lower bound grows as n·log(4)/log(2n) ~ log(2)·(n/log n), confirming π(x) ≳ log(2)·(x/log x).",
+      "The upper bound (from Erdos31PrimesDensity) and this lower bound together give the complete Chebyshev interval log(2) ≤ π(2n)·log(2n)/n ≤ 2·log(4) + o(1).",
+      "push_cast + linarith suffices for all real coercion and arithmetic goals after establishing the key log inequality.",
+      "div_le_iff₀ converts (a/b ≤ c) to (a ≤ c * b) when b > 0 — more reliable than div_le_iff here."
+    ],
+    "builtItems": [
+      "chebyshev_lower_log: n·log(4) − log(2n+1) ≤ π(2n)·log(2n) for n ≥ 1 in ChebyshevPNTBridgeOQ02.lean:59",
+      "chebyshev_lower_real: (n·log4 − log(2n+1)) / log(2n) ≤ π(2n) for n ≥ 1 in ChebyshevPNTBridgeOQ02.lean:87",
+      "chebyshev_lower_pos: 0 < n·log(4) − log(2n+1) for n ≥ 1 (proved by induction: 4^n > 2n+1) in ChebyshevPNTBridgeOQ02.lean:103",
+      "chebyshev_pi_interval: π(2n) in Chebyshev interval for n ≥ 2 in ChebyshevPNTBridgeOQ02.lean:141",
+      "Gallery entry: src/data/proofs/chebyshev-pnt-bridge-oq-02/meta.json"
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Can the lower constant be tightened from log(2) ≈ 0.693 to Chebyshev's original 0.921 using a more refined analysis of C(2n,n)?",
+      "Can the upper constant be tightened from 2·log(4) ≈ 2.773 to 1.106 using a finer sieve?"
+    ]
+  }
+}


### PR DESCRIPTION
Proves (n·log4 − log(2n+1))/log(2n) ≤ π(2n) for n ≥ 1. Four theorems, 0 sorries, 0 axioms. Closes the open question from ChebyshevPNTBridge.lean.