### PR TITLE
Fix: sync lineCount fields for 4 gallery proofs

### DIFF
--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
@@ -21,7 +21,7 @@
     "sorries": 4,
     "dateAdded": "2026-04-12",
     "axiomCount": 0,
-    "lineCount": 199,
+    "lineCount": 580,
     "assumptions": "0 axioms. 4 sorries: recurrence relation, growth bound, main theorem. Infrastructure scaffold for full Ap\u00e9ry proof.",
     "mathlib_version": "4.26.0",
     "originalContributions": [
@@ -139,7 +139,7 @@
       "Nat"
     ],
     "namespace": "AperyZetaThree",
-    "lineCount": 513,
+    "lineCount": 580,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 4,

--- a/src/data/proofs/feuerbachs-theorem-oq-02/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-02/meta.json
@@ -29,7 +29,7 @@
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 3,
-    "lineCount": 350,
+    "lineCount": 665,
     "assumptions": "3 axioms: feuerbach_3d_fails_general (Feuerbach tangency fails for general tetrahedra — counterexample), edge_midpoints_on_sphere (edge midpoints of orthocentric tetrahedra lie on the 24-point sphere), face_centroids_on_sphere (face centroids lie on the 24-point sphere). The 2 circumcenter axioms (existence and equidistance) were proved in code via Cramer's rule. 5 sorries for the main Feuerbach tangency theorems (insphere + 4 exspheres).",
     "originalContributions": [
       "Complete 3D coordinate geometry infrastructure for tetrahedra in Lean 4",
@@ -146,7 +146,7 @@
       "Real"
     ],
     "namespace": "FeuerbachsTheoremOQ02",
-    "lineCount": 350,
+    "lineCount": 665,
     "axiomCount": 3,
     "theoremCount": 10,
     "substantiveTheoremCount": 6,

--- a/src/data/proofs/p-vs-np/meta.json
+++ b/src/data/proofs/p-vs-np/meta.json
@@ -39,7 +39,7 @@
     ],
     "dateAdded": "2025-12-29",
     "millenniumProblem": "p-vs-np",
-    "lineCount": 2462,
+    "lineCount": 6370,
     "mathlib_version": "4.26.0"
   },
   "leanFile": {

--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -61,7 +61,7 @@
       "Caratheodory's theorem (points in convex hull need at most d+1 vertices)",
       "Affine independence and dimension"
     ],
-    "lineCount": 318,
+    "lineCount": 490,
     "mathlib_version": "4.26.0",
     "leanFile": {
       "imports": [
@@ -79,7 +79,7 @@
         "Pointwise"
       ],
       "namespace": "ShapleyFolkman",
-      "lineCount": 318,
+      "lineCount": 490,
       "axiomCount": 0,
       "theoremCount": 6,
       "definitionCount": 2
@@ -201,7 +201,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 460,
+    "lineCount": 490,
     "structureCount": 1,
     "axiomCount": 0,
     "theoremCount": 8,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` fields in `meta.json` to match actual Lean source file sizes.

## Evidence

| Proof | Field | Before | After |
|-------|-------|--------|-------|
| `p-vs-np` | `meta.lineCount` | 2462 | 6370 |
| `feuerbachs-theorem-oq-02` | `meta.lineCount` | 350 | 665 |
| `feuerbachs-theorem-oq-02` | `leanFile.lineCount` | 350 | 665 |
| `basel-problem-oq-01-oq-01-oq-02` | `meta.lineCount` | 199 | 580 |
| `basel-problem-oq-01-oq-01-oq-02` | `leanFile.lineCount` | 513 | 580 |
| `shapley-folkman` | `meta.lineCount` | 318 | 490 |
| `shapley-folkman` | `meta.leanFile.lineCount` | 318 | 490 |
| `shapley-folkman` | `leanFile.lineCount` | 460 | 490 |

The `p-vs-np` mismatch (2462 vs 6370) was caused by a stale lineCount from `PvsNP.lean` being retained after the file was refactored into the larger `PNPBarriersUnified.lean`. The `leanFile` section already had the correct value (6370).

---
Automated fix by lean-mechanic agent.