### PR TITLE
Fix: sync sorry count for erdos-109-oq-01 (4→2)

### DIFF
--- a/src/data/proofs/erdos-109-oq-01/meta.json
+++ b/src/data/proofs/erdos-109-oq-01/meta.json
@@ -17,7 +17,7 @@
       "ip-sets"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 2,
     "dateAdded": "2026-04-12",
     "axiomCount": 1,
     "assumptions": "1 axiom: hindman_theorem (Hindman 1974 — every finite coloring of N has a monochromatic IP set). Deep result in Ramsey theory.",
@@ -101,7 +101,7 @@
     "theoremCount": 7,
     "definitionCount": 10,
     "path": "Proofs/Erdos109OQ01.lean",
-    "sorries": 4
+    "sorries": 2
   },
   "crossReferences": [
     {
@@ -110,5 +110,5 @@
       "description": "Explores gap conditions for the sumset conjecture proved by MRR (2019)"
     }
   ],
-  "sorries": 4
+  "sorries": 2
 }


### PR DESCRIPTION
## Fix

Sync `sorries` count in all three locations in `meta.json` after 2 sorries were resolved.

## Evidence

**Before**: `sorries: 4` in all three locations (meta section, leanFile section, top-level)
**After**: `sorries: 2` in all three locations

Commit `eae676d370` (Research: erdos-109-oq-01 session 4 — prove upperDensity_mono, axiomatize shift) removed 2 sorries from `Erdos109OQ01.lean` but did not update `meta.json`. The 2 remaining sorries are `posUpperDensity_piecewiseSyndetic` and `posUpperDensity_ipStar`.

---
Automated fix by lean-mechanic agent.