### PR TITLE
Fix: sync meta.lineCount for 15 gallery proofs (batch)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-02-oq-01-oq-03/meta.json
@@ -58,7 +58,7 @@
       "Proved thin shell concentration: 1 - (1-ε)^n → 1 for 0 < ε < 1"
     ],
     "axiomCount": 0,
-    "lineCount": 156,
+    "lineCount": 195,
     "assumptions": "None — fully verified from Mathlib",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/area-of-circle-oq-03-oq-02-oq-02-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02-oq-02-oq-01/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-04-12",
     "axiomCount": 0,
     "assumptions": "None. Proves new results from first principles using Mathlib's real analysis and integration libraries.",
-    "lineCount": 215,
+    "lineCount": 254,
     "theoremCount": 12,
     "definitionCount": 2,
     "originalContributions": [

--- a/src/data/proofs/arithmetic-series-oq-00/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-00/meta.json
@@ -20,7 +20,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 128,
+    "lineCount": 160,
     "assumptions": "0 axioms, 0 sorries. Elementary induction proof: no deep Mathlib dependencies beyond basic Finset sum lemmas and ring arithmetic.",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [

--- a/src/data/proofs/arithmetic-series-oq-04-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-04-oq-01/meta.json
@@ -20,7 +20,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 215,
+    "lineCount": 305,
     "assumptions": "0 axioms, 0 sorries. All theorems proved by induction with push_cast + linarith. Uses Mathlib only for Finset.sum_Ico_succ_top and push_cast.",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [

--- a/src/data/proofs/ballot-problem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "None. All axioms eliminated: fiber_card_uniform proved via fiberSwap bijection, uniformOn_fiber_transfer proved via cross-multiplication bijection showing |(MCS ∩ MSP)| · |CS| = |(CS ∩ SP)| · |MCS|.",
-    "lineCount": 934,
+    "lineCount": 1047,
     "theoremCount": 36,
     "definitionCount": 18,
     "originalContributions": [

--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-04-12",
     "axiomCount": 0,
     "assumptions": "None. Proved from first principles using Mathlib's Zsqrtd and EuclideanDomain infrastructure.",
-    "lineCount": 230,
+    "lineCount": 323,
     "theoremCount": 16,
     "definitionCount": 3,
     "originalContributions": [

--- a/src/data/proofs/erdos-1129-oq-02/meta.json
+++ b/src/data/proofs/erdos-1129-oq-02/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-04-12",
     "axiomCount": 0,
     "assumptions": "",
-    "lineCount": 220,
+    "lineCount": 260,
     "theoremCount": 15,
     "definitionCount": 6,
     "originalContributions": [

--- a/src/data/proofs/erdos-1168/meta.json
+++ b/src/data/proofs/erdos-1168/meta.json
@@ -21,7 +21,7 @@
     "erdosProblemStatus": "open",
     "badge": "formalized",
     "axiomCount": 0,
-    "lineCount": 225,
+    "lineCount": 255,
     "theoremCount": 11,
     "definitionCount": 9,
     "assumptions": "0 axioms (previous axiom replaced with theorem + stepping-up decomposition). 2 sorries: base_case_under_gch (Erd\u0151s-Rado base case), stepping_up (stepping-up lemma). Open conjecture is a def, not an axiom.",

--- a/src/data/proofs/erdos-406/meta.json
+++ b/src/data/proofs/erdos-406/meta.json
@@ -56,7 +56,7 @@
       "Proved digits01_iff_finset_sum_of_pow3: complete iff characterization HasOnlyDigits01Base3 n \u2194 \u2203 S, n = S.sum(3^\u00b7)"
     ],
     "axiomCount": 1,
-    "lineCount": 179,
+    "lineCount": 272,
     "assumptions": "1 axiom: saye_computation (Saye 2022 computational verification for n \u2264 5.9\u00d710\u00b2\u00b9, deep). ErdosProblem406 and variant are defs, not axioms."
   },
   "overview": {

--- a/src/data/proofs/erdos-622-oq-04/meta.json
+++ b/src/data/proofs/erdos-622-oq-04/meta.json
@@ -19,7 +19,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 180,
+    "lineCount": 215,
     "assumptions": "0 axioms, 0 sorries. All theorems fully proved from Mathlib.",
     "dateAdded": "2026-04-12",
     "mathlib_version": "4.26.0",

--- a/src/data/proofs/erdos-643/meta.json
+++ b/src/data/proofs/erdos-643/meta.json
@@ -49,7 +49,7 @@
       "Statement of Erdős-Rado Sunflower Lemma connection"
     ],
     "axiomCount": 3,
-    "lineCount": 1433,
+    "lineCount": 1403,
     "assumptions": "3 axiom(s) and 4 sorry(s)."
   },
   "overview": {
@@ -186,7 +186,7 @@
       "Classical"
     ],
     "namespace": "Harmonic.GeneralizeProofs",
-    "lineCount": 1402,
+    "lineCount": 1403,
     "axiomCount": 3,
     "theoremCount": 45,
     "definitionCount": 15,

--- a/src/data/proofs/pascals-hexagon/meta.json
+++ b/src/data/proofs/pascals-hexagon/meta.json
@@ -46,7 +46,7 @@
     ],
     "dateAdded": "2025-12-29",
     "leanFile": {
-      "lineCount": 712,
+      "lineCount": 767,
       "structures": 1,
       "axioms": 1,
       "theorems": 26,
@@ -54,7 +54,7 @@
       "instances": 0
     },
     "axiomCount": 1,
-    "lineCount": 712,
+    "lineCount": 767,
     "assumptions": "1 axiom (conic_implies_pascal_constraint). 0 sorries — all theorems proved.",
     "mathlib_version": "4.26.0"
   },

--- a/src/data/proofs/prime-gap-bounds-oq-01/meta.json
+++ b/src/data/proofs/prime-gap-bounds-oq-01/meta.json
@@ -57,7 +57,7 @@
     ],
     "dateAdded": "2026-04-12",
     "axiomCount": 3,
-    "lineCount": 211,
+    "lineCount": 288,
     "prerequisites": [
       "Prime Number Theorem (axiomatized)",
       "Properties of the natural logarithm",

--- a/src/data/proofs/primitive-roots-oq-02/meta.json
+++ b/src/data/proofs/primitive-roots-oq-02/meta.json
@@ -19,7 +19,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 170,
+    "lineCount": 224,
     "assumptions": "0 axioms, 0 sorries. Fully verified using Mathlib's group theory and number theory machinery.",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [

--- a/src/data/proofs/stirling-formula/meta.json
+++ b/src/data/proofs/stirling-formula/meta.json
@@ -43,7 +43,7 @@
     ],
     "dateAdded": "2025-12-27",
     "axiomCount": 0,
-    "lineCount": 497,
+    "lineCount": 640,
     "prerequisites": [
       "Real analysis: limits, asymptotic equivalence (~), sequences",
       "Factorials and the Gamma function: n! = Γ(n+1)",


### PR DESCRIPTION
## Fix

Batch sync of stale `meta.lineCount` fields. In each case `leanFile.lineCount` matched the actual file, while `meta.lineCount` was out of date.

## Evidence

| Proof | Before | After |
|-------|--------|-------|
| stirling-formula | 497 | 640 |
| ballot-problem-oq-01-oq-02 | 934 | 1047 |
| erdos-406 | 179 | 272 |
| bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03 | 230 | 323 |
| arithmetic-series-oq-04-oq-01 | 215 | 305 |
| prime-gap-bounds-oq-01 | 211 | 288 |
| pascals-hexagon | 712 | 767 (both meta sections) |
| primitive-roots-oq-02 | 170 | 224 |
| erdos-1129-oq-02 | 220 | 260 |
| area-of-circle-oq-03-oq-02-oq-02-oq-01 | 215 | 254 |
| area-of-circle-oq-01-oq-02-oq-01-oq-03 | 156 | 195 |
| erdos-622-oq-04 | 180 | 215 |
| arithmetic-series-oq-00 | 128 | 160 |
| erdos-643 | 1433 | 1403 (also fixed lf: 1402→1403) |
| erdos-1168 | 225 | 255 |

---
Automated fix by lean-mechanic agent.