### PR TITLE
Fix: sync lineCount for 7 proofs where meta==lf both stale

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-04-oq-01/meta.json
@@ -47,7 +47,7 @@
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 311,
+    "lineCount": 334,
     "assumptions": "No axioms. 3 sorries for deep theorems requiring Mathlib API glue.",
     "originalContributions": [
       "Proper inductive definition of QuadraticTower replacing the alias TowerCriterion = DegreeCriterion",
@@ -164,7 +164,7 @@
       "FiniteDimensional"
     ],
     "namespace": "AngleTrisectionOQ02OQ04OQ01",
-    "lineCount": 311,
+    "lineCount": 334,
     "axiomCount": 0,
     "theoremCount": 12,
     "substantiveTheoremCount": 8,

--- a/src/data/proofs/bounded-prime-gaps-oq-04-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-04-oq-01/meta.json
@@ -18,7 +18,7 @@
     "badge": "wip",
     "sorries": 4,
     "axiomCount": 0,
-    "lineCount": 212,
+    "lineCount": 263,
     "assumptions": "0 axioms. 4 sorries (Gauss sum norm, geometric series bound, cotangent sum, PV inequality). Theorem statements and proof strategy documented.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0"
@@ -100,7 +100,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 212,
+    "lineCount": 263,
     "path": "Proofs/BoundedPrimeGapsOQ04OQ01.lean",
     "axiomCount": 0,
     "sorries": 4

--- a/src/data/proofs/erdos-1027-oq-03/meta.json
+++ b/src/data/proofs/erdos-1027-oq-03/meta.json
@@ -24,7 +24,7 @@
     "mathlib_version": "4.29.0",
     "axiomCount": 0,
     "assumptions": "No axioms. All 17 theorems proved from Mathlib and the existing LLL infrastructure (LovaszLocalLemma.lean). No dependency on axiomatized results.",
-    "lineCount": 245,
+    "lineCount": 308,
     "relatedProblems": [
       {
         "id": "erdos-1027",
@@ -141,7 +141,7 @@
       "ProbMethod.LovaszLocal"
     ],
     "namespace": "Erdos1027.Constructive",
-    "lineCount": 245,
+    "lineCount": 308,
     "axiomCount": 0,
     "theoremCount": 17,
     "definitionCount": 5,

--- a/src/data/proofs/erdos-105-oq-02/meta.json
+++ b/src/data/proofs/erdos-105-oq-02/meta.json
@@ -19,7 +19,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 3,
-    "lineCount": 220,
+    "lineCount": 288,
     "assumptions": "3 axioms: threshold_lower_bound (Beck-SzTr 1983), threshold_upper_bound (Xichuan 2024 + Hickerson), threshold_gap_axiom (Xichuan 2024). All are established mathematical results.",
     "dateAdded": "2026-04-13",
     "mathlib_version": "4.26.0",
@@ -147,7 +147,7 @@
   "leanFile": {
     "imports": ["Proofs.Erdos105Problem", "Mathlib"],
     "namespace": "Erdos105OQ02",
-    "lineCount": 220,
+    "lineCount": 288,
     "axiomCount": 3,
     "theoremCount": 15,
     "definitionCount": 6,

--- a/src/data/proofs/erdos-858/meta.json
+++ b/src/data/proofs/erdos-858/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/858",
     "erdosProblemStatus": "solved",
     "axiomCount": 1,
-    "lineCount": 328,
+    "lineCount": 348,
     "assumptions": "1 axiom: alexander_1966. 0 sorries.",
     "mathlib_version": "4.26.0"
   },
@@ -106,7 +106,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos858",
-    "lineCount": 328,
+    "lineCount": 348,
     "axiomCount": 1,
     "theoremCount": 12,
     "definitionCount": 8,

--- a/src/data/proofs/ptolemys-theorem-oq-01/meta.json
+++ b/src/data/proofs/ptolemys-theorem-oq-01/meta.json
@@ -45,7 +45,7 @@
     ],
     "dateAdded": "2026-04-13",
     "axiomCount": 0,
-    "lineCount": 270,
+    "lineCount": 201,
     "assumptions": "2 sorries remain: (1) unit_star_eq_inv — the algebraic step that z * conj z = normSq z = 1 implies conj z = z⁻¹ (needs exact Mathlib API: Complex.mul_conj); (2) ptolemy_ratio_pos_of_ccw — the trig positivity argument that all four half-angle sine factors are negative for CCW-ordered points (needs the half-angle formula for Complex.exp differences)."
   },
   "overview": {
@@ -141,7 +141,7 @@
     ],
     "opens": ["Complex"],
     "namespace": null,
-    "lineCount": 270,
+    "lineCount": 201,
     "axiomCount": 0,
     "theoremCount": 8,
     "substantiveTheoremCount": 5,

--- a/src/data/proofs/taylor-sincos-convergence-oq-04/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-04/meta.json
@@ -30,7 +30,7 @@
       "Optimality: C = 1 is the minimum possible bound constant (sin/cos achieve it)"
     ],
     "dateAdded": "2026-04-13",
-    "lineCount": 257,
+    "lineCount": 329,
     "theoremCount": 16,
     "definitionCount": 1,
     "mathlibDependencies": [
@@ -199,7 +199,7 @@
       "Real"
     ],
     "namespace": "TaylorBoundedDerivConvergence",
-    "lineCount": 257,
+    "lineCount": 329,
     "axiomCount": 0,
     "theoremCount": 16,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Batch sync of `lineCount` fields where both `meta.lineCount` and `leanFile.lineCount` agreed with each other but disagreed with the actual Lean file size.

## Evidence

| Proof | Old (both) | Actual |
|-------|-----------|--------|
| taylor-sincos-convergence-oq-04 | 257 | 329 |
| ptolemys-theorem-oq-01 | 270 | 201 (file shrank after cleanup) |
| erdos-105-oq-02 | 220 | 288 |
| erdos-1027-oq-03 | 245 | 308 |
| bounded-prime-gaps-oq-04-oq-01 | 212 | 263 |
| angle-trisection-oq-02-oq-04-oq-01 | 311 | 334 |
| erdos-858 | 328 | 348 |

---
Automated fix by lean-mechanic agent.