### PR TITLE
Fix: sync lineCount for 7 more gallery proofs

### DIFF
--- a/src/data/proofs/erdos-1107-oq-02/meta.json
+++ b/src/data/proofs/erdos-1107-oq-02/meta.json
@@ -29,7 +29,7 @@
       "Computational verification for all n up to 1000"
     ],
     "axiomCount": 1,
-    "lineCount": 140,
+    "lineCount": 156,
     "assumptions": "1 axiom: squareful_sum_threshold (every n ≥ 120 is a sum of 3 squareful numbers). Computationally verified up to 1000.",
     "theoremCount": 20
   },

--- a/src/data/proofs/erdos-1139/meta.json
+++ b/src/data/proofs/erdos-1139/meta.json
@@ -50,7 +50,7 @@
     ],
     "dateAdded": "2026-03-24",
     "axiomCount": 2,
-    "lineCount": 192,
+    "lineCount": 178,
     "assumptions": "2 axioms: erdos_1139 (the open conjecture), hardy_ramanujan_asymptotic (density estimate). 0 sorries."
   },
   "overview": {

--- a/src/data/proofs/erdos-360/meta.json
+++ b/src/data/proofs/erdos-360/meta.json
@@ -58,7 +58,7 @@
       "erdos_360_solved theorem: main result"
     ],
     "axiomCount": 4,
-    "lineCount": 187,
+    "lineCount": 170,
     "assumptions": "4 axiom(s) and 2 sorry(s). See the Lean source for details."
   },
   "overview": {

--- a/src/data/proofs/erdos-755/meta.json
+++ b/src/data/proofs/erdos-755/meta.json
@@ -55,7 +55,7 @@
       "erdos_755_summary: combined main results"
     ],
     "axiomCount": 1,
-    "lineCount": 259,
+    "lineCount": 272,
     "assumptions": "1 axiom: cdl_2025_main. 0 sorries."
   },
   "overview": {
@@ -165,7 +165,7 @@
       "Real"
     ],
     "namespace": "Erdos755",
-    "lineCount": 259,
+    "lineCount": 272,
     "axiomCount": 1,
     "theoremCount": 3,
     "definitionCount": 7,

--- a/src/data/proofs/minkowski-fundamental-theorem-oq-02/meta.json
+++ b/src/data/proofs/minkowski-fundamental-theorem-oq-02/meta.json
@@ -19,7 +19,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 113,
+    "lineCount": 130,
     "assumptions": "0 axioms, 0 sorries. All theorems are aliases of Mathlib results in Mathlib.NumberTheory.NumberField.ClassNumber and Mathlib.NumberTheory.NumberField.CanonicalEmbedding.ConvexBody.",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [

--- a/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
@@ -44,7 +44,7 @@
     ],
     "dateAdded": "2026-04-12",
     "axiomCount": 3,
-    "lineCount": 195,
+    "lineCount": 217,
     "prerequisites": [
       "Brouwer's fixed point theorem",
       "Compact metric spaces",

--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
@@ -40,7 +40,7 @@
     "assumptions": "1 axiom: import_shannon_entropy_blocked (placeholder for ShannonEntropy.lean compilation blocker). 0 sorries (fano_trivial_singleton now fully proved). The axiom will be eliminatable once ShannonEntropy.lean's strong_subadditivity proof is fixed.",
     "dateAdded": "2026-04-04",
     "axiomCount": 1,
-    "lineCount": 142,
+    "lineCount": 168,
     "prerequisites": [
       "Fano's inequality (OQ-03): H(X|Y) ≤ h(P_e) + P_e·log(|X|-1)",
       "Binary entropy function and concavity (OQ-04)",


### PR DESCRIPTION
## Fix

Batch sync of remaining stale `lineCount` fields discovered in gallery scan.

## Evidence

| Proof | Field(s) | Before | After |
|-------|---------|--------|-------|
| erdos-755 | meta + leanFile | 259 | 272 |
| shannon-channel-coding-oq-02-oq-01 | meta only | 142 | 168 |
| schauder-fixed-point-oq-03-oq-01 | meta only | 195 | 217 |
| minkowski-fundamental-theorem-oq-02 | meta only | 113 | 130 |
| erdos-360 | meta only | 187 | 170 (meta was too high) |
| erdos-1139 | meta only | 192 | 178 (meta was too high) |
| erdos-1107-oq-02 | meta only | 140 | 156 |

---
Automated fix by lean-mechanic agent.