### PR TITLE
Fix: remove broken proofs/.lake symlink crashing Docker

### DIFF
--- a/proofs/.lake
+++ b/proofs/.lake
@@ -1,1 +1,0 @@
-/Users/rwalters/GitHub/lean-genius/proofs/.lake


### PR DESCRIPTION
## Summary
- Removes a self-referencing symlink (`proofs/.lake -> proofs/.lake`) from the git index
- This broken symlink causes Docker to crash with "too many levels of symbolic links" when traversing the build context
- Same fix pattern as #10556 (`.loom/tokens` symlink)

## Test plan
- [ ] Docker builds no longer crash with symlink errors
- [ ] `proofs/.lake` is in `.gitignore` so won't be re-tracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)