### PR TITLE
Fix: sync lineCount for erdos-1002-oq-01-oq-01 (643→705)

### DIFF
--- a/src/data/proofs/erdos-1002-oq-01-oq-01/meta.json
+++ b/src/data/proofs/erdos-1002-oq-01-oq-01/meta.json
@@ -31,7 +31,7 @@
       "euler-identity"
     ],
     "axiomCount": 1,
-    "lineCount": 643,
+    "lineCount": 705,
     "assumptions": "One axiom: `innerSum_log_bound` — for badly approximable irrational α (bounded partial quotients), |S(α,n)| ≤ C·log n. This requires continued fraction theory not yet in Mathlib. One sorry: `equidist_approx` (density of trig polynomials in L∞ — Stone-Weierstrass for periodic functions). Three previously open sorries (`continuous_comp_fract` integer case and two integral bounds for `deviation_sandwich`) are now fully proved. Both main theorems (weyl_equidist_continuous, weyl_fract_average_zero) are proved modulo equidist_approx."
   },
   "overview": {


### PR DESCRIPTION
## Fix

`meta.lineCount` was stale; actual `Erdos1002OQ01OQ01.lean` has 705 lines.

**Before**: 643
**After**: 705

---
Automated fix by lean-mechanic agent.