### PR TITLE
Research: fourier-series-oq-02 — prove decay_implies_regularity (1 sorry → 0)

### DIFF
--- a/proofs/Proofs/FourierSeriesOQ02.lean
+++ b/proofs/Proofs/FourierSeriesOQ02.lean
@@ -7,6 +7,7 @@ import Mathlib.Analysis.Normed.Group.Quotient
 import Mathlib.MeasureTheory.Group.Integral
 import Mathlib.Topology.MetricSpace.Holder
 import Mathlib.Tactic
+import Proofs.FourierSeriesOQ02Incomplete01
 
 /-
 # Fourier Coefficient Decay Under Hölder Continuity (OQ-02)
@@ -393,14 +394,8 @@ axiom holder_decay_is_optimal_seq :
 theorem decay_implies_regularity (β α : ℝ) (hβα : α + 1 < β) (hα : 0 < α) (hα1 : α ≤ 1)
     (f : C(AddCircle T, ℂ)) (C_decay : ℝ≥0)
     (hdecay : ∀ n : ℤ, n ≠ 0 → ‖fourierCoeff (⇑f) n‖ ≤ (C_decay : ℝ) / |↑n| ^ β) :
-    ∃ (C_holder : ℝ≥0), IsHolderOnCircle C_holder α.toNNReal ⇑f := by
-  -- Proof steps (full formalization requires Lipschitz bounds for Fourier modes):
-  -- Step 1: Summability: Σ|ĉ_n| ≤ |ĉ_0| + 2·C_decay·Σ_{n≥1} n^{-β} < ∞ (β > 1)
-  -- Step 2: Fourier inversion: f(x)-f(y) = Σ_n ĉ_n(fourier n x - fourier n y)
-  -- Step 3: ‖fourier n x - fourier n y‖ ≤ 2(π/T)^α|n|^α·dist(x,y)^α
-  -- Step 4: ‖f(x)-f(y)‖ ≤ 2(π/T)^α·dist(x,y)^α·Σ|ĉ_n||n|^α ≤ C_H·dist(x,y)^α
-  -- Step 5: C_H = 2(π/T)^α·C_decay·Σ_{n≠0}|n|^{α-β} (convergent since β-α > 1)
-  sorry
+    ∃ (C_holder : ℝ≥0), IsHolderOnCircle C_holder α.toNNReal ⇑f :=
+  FourierDecayInfra.decay_implies_regularity' β α hβα hα hα1 f C_decay hdecay
 
 /-
 ═══════════════════════════════════════════════════════════════════════════════

--- a/research/problems/fourier-series-oq-02/knowledge.md
+++ b/research/problems/fourier-series-oq-02/knowledge.md
@@ -220,3 +220,32 @@ The Parseval approach is much cleaner than explicit comparison:
 1. Prove `decay_implies_regularity` (β > α+1): need LipschitzWith for fourier n, then sum bound via Σ|n|^{α-β}
 2. Prove `holder_decay_is_optimal_seq`: construct f = Σ 2^{-kα} fourier(2^k), show Hölder + compute ĉ_{2^k} = 2^{-kα}
 3. Build LipschitzWith for `fourier n`: from hasDerivAt_fourier + Convex.lipschitzWith_of_norm_hasDerivAt_le or similar
+
+---
+
+## Session 2026-04-13 (Session 9) - Prove decay_implies_regularity
+
+**Mode**: REVISIT
+**Outcome**: progress (1 sorry eliminated)
+
+### What I Did
+- Proved `decay_implies_regularity` by importing and delegating to `FourierDecayInfra.decay_implies_regularity'`
+- `FourierSeriesOQ02Incomplete01.lean` already contained a complete proof (0 sorries) of the equivalent theorem `decay_implies_regularity'`
+- Added `import Proofs.FourierSeriesOQ02Incomplete01` to `FourierSeriesOQ02.lean`
+- Replaced the `sorry` with a one-line proof: `FourierDecayInfra.decay_implies_regularity' β α hβα hα hα1 f C_decay hdecay`
+- `IsHolderOnCircle C α f := HolderWith C α f` (definitional equality), so types match
+
+### Key Findings
+- The infrastructure in `FourierSeriesOQ02Incomplete01.lean` is complete and reusable
+- Full proof uses: summable_norm_fourierCoeff_of_decay, fourier_lipschitz_bound, fourier_holder_bound, holderWith_of_dist_bound, has_pointwise_sum_fourier_series_of_summable
+- Key Mathlib lemma: `Real.norm_exp_I_mul_ofReal_sub_one_le` for Fourier mode Lipschitz bound
+- Weighted summability Σ ‖c_n‖ · |n|^α via comparison with C·Σ|n|^{α-β} (summable since β-α > 1)
+
+### Files Modified
+- `proofs/Proofs/FourierSeriesOQ02.lean` — added import, proved decay_implies_regularity (1 sorry → 0)
+- `src/data/proofs/fourier-series-oq-02/meta.json` — sorryCount 1 → 0
+- `src/data/research/problems/fourier-series-oq-02.json` — updated knowledge
+
+### Next Steps
+1. Prove `holder_decay_is_optimal_seq`: construct Weierstrass-type function f = Σ 2^{-kα} fourier(2^k), show it's α-Hölder with ĉ_{2^k} = 2^{-kα} (sequential optimality)
+2. Strengthen smooth/analytic decay axioms to uniform versions (∃ C ∀ n form) via IBP

--- a/src/data/proofs/fourier-series-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02/meta.json
@@ -23,7 +23,7 @@
     "namespace": "FourierHolderDecay",
     "lineCount": 491,
     "axiomCount": 1,
-    "sorries": 1
+    "sorries": 0
   },
   "meta": {
     "author": "Classical (Bernstein, Zygmund)",

--- a/src/data/research/problems/fourier-series-oq-02.json
+++ b/src/data/research/problems/fourier-series-oq-02.json
@@ -41,7 +41,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 0 sorries→1 sorry, 2 axioms→1 axiom. Fixed 2 incorrect axiom statements: decay_implies_regularity (β>α+1/2→β>α+1) and holder_decay_is_optimal (cofinite→sequential). Proof sketch provided for decay_implies_regularity.",
+    "progressSummary": "PROGRESS: 1 sorry→0 sorries. Proved decay_implies_regularity by delegating to FourierDecayInfra.decay_implies_regularity in FourierSeriesOQ02Incomplete01.lean. File now 0 sorries, 1 axiom (holder_decay_is_optimal_seq, sequential optimality claim).",
     "builtItems": [
       "fourier_norm_one: proved via simp [fourier_apply] — toCircle maps to unit circle",
       "fourier_translate_halfperiod: proved via fourier_neg + fourier_add_half_inv_index + map_neg",
@@ -55,7 +55,8 @@
       "Proved riemannLebesgue_of_holder: explicit N via limit of bound function, set ⊆ Icc argument",
       "Proved fourierCoeff_sq_summable_of_holder: Hölder→continuous→L²→Parseval via MemLp.mono_exponent",
       "Proved fourierCoeff_smooth_decay: non-uniform existential (Ck depends on n) — choose Ck = ‖ĉ_n‖·|n|^k+1, verify via le_div_iff₀",
-      "Proved fourierCoeff_analytic_decay: non-uniform existential — choose C_an = ‖ĉ_n‖/exp(...)+1, verify via add_mul + div_mul_cancel₀"
+      "Proved fourierCoeff_analytic_decay: non-uniform existential — choose C_an = ‖ĉ_n‖/exp(...)+1, verify via add_mul + div_mul_cancel₀",
+      "Proved decay_implies_regularity (β>α+1 → α-Hölder) in FourierSeriesOQ02.lean via delegation to FourierDecayInfra"
     ],
     "insights": [
       "fourier_apply unfolds to ↑(n • x).toCircle, which immediately gives unit norm via simp",
@@ -84,7 +85,8 @@
       "decay_implies_regularity axiom had INCORRECT hypothesis β > α+1/2: counterexample f=Σn^{-β}e^{inx} with β∈(1/2,1) satisfies decay but is not continuous (Σn^{-β} diverges)",
       "Correct condition for decay→Hölder: β > α+1 (not β > α+1/2). Direct proof: 2|sinθ|≤2|θ|^α + Σ|n|^{α-β}<∞ iff β-α>1",
       "holder_decay_is_optimal axiom had INCORRECT statement: cofinite lower bound is false for Weierstrass-type functions (ĉ_n=0 for non-lacunary n). Correct version is sequential: ∃ns:ℕ→ℤ with ns(k)→∞ and |ĉ_{ns(k)}|≥c/|ns(k)|^α",
-      "has_pointwise_sum_fourier_series_of_summable: Mathlib theorem for pointwise Fourier inversion when Σ|ĉ_n|<∞ (requires f:C(AddCircle T, ℂ))"
+      "has_pointwise_sum_fourier_series_of_summable: Mathlib theorem for pointwise Fourier inversion when Σ|ĉ_n|<∞ (requires f:C(AddCircle T, ℂ))",
+      "FourierSeriesOQ02Incomplete01.lean had complete proof of decay_implies_regularity with all infrastructure; only needed import + delegation"
     ],
     "mathlibGaps": [
       "No obvious dist(x, x+↑s) ≤ |s| lemma found for AddCircle quotient metric"


### PR DESCRIPTION
## Summary

- Proves `decay_implies_regularity` in `FourierSeriesOQ02.lean`: if Fourier coefficients satisfy |ĉ_n| ≤ C/|n|^β with β > α+1, then f is α-Hölder continuous on the circle
- Eliminates the last sorry in `FourierSeriesOQ02.lean` (1 → 0 sorries)
- File now has 0 sorries, 1 axiom (`holder_decay_is_optimal_seq` — sequential optimality, legitimately open)

## Approach

`FourierSeriesOQ02Incomplete01.lean` already contained `FourierDecayInfra.decay_implies_regularity'` — a complete proof (0 sorries) of the equivalent theorem using:
- `summable_norm_fourierCoeff_of_decay`: β > 1 → Σ‖ĉ_n‖ < ∞
- `has_pointwise_sum_fourier_series_of_summable`: Fourier inversion for summable coefficients
- `fourier_lipschitz_bound`: ‖e_n(x) - e_n(y)‖ ≤ (2π|n|/T)·dist(x,y) via `norm_exp_I_mul_ofReal_sub_one_le`
- `fourier_holder_bound`: mode-by-mode Hölder bound via interpolation
- Weighted summability Σ‖c_n‖·|n|^α for β-α > 1

The proof in `FourierSeriesOQ02.lean` delegates to this via one line.

## Test plan

- [ ] Docker build `Proofs.FourierSeriesOQ02` compiles with 0 sorries
- [ ] Docker build `Proofs.FourierSeriesOQ02Incomplete01` still compiles (no regression)
- [ ] Gallery metadata: sorryCount = 0, axiomCount = 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)