### PR TITLE
Fix: fourier-series-oq-02 sorry count corrected (0 sorries, axiomatized)

### DIFF
--- a/src/data/proofs/fourier-series-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02/meta.json
@@ -40,7 +40,7 @@
       "open-question"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "dateAdded": "2026-03-23",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -97,7 +97,7 @@
     ],
     "axiomCount": 1,
     "lineCount": 486,
-    "assumptions": "1 axiom (holder_decay_is_optimal_seq: Weierstrass sequential optimality, corrected from incorrect cofinite version), 1 sorry (decay_implies_regularity: corrected from β>α+1/2 to β>α+1, proof sketch provided)"
+    "assumptions": "1 axiom (holder_decay_is_optimal_seq: Weierstrass sequential optimality, corrected from incorrect cofinite version). The decay_implies_regularity theorem has been fully proved via FourierDecayInfra."
   },
   "overview": {
     "historicalContext": "**Fourier Coefficient Decay Under Hölder Continuity**\n\nThe relationship between smoothness of a function and decay of its Fourier coefficients is a fundamental principle of harmonic analysis. The specific result for Hölder continuous functions — that α-Hölder regularity gives O(1/|n|^α) decay — was developed through contributions by Bernstein (1912), Zygmund (1935), and others.\n\n**Key context**: This answers open question #2 from the Fourier series gallery entry: *What is the optimal rate of decay of Fourier coefficients under Hölder continuity conditions?*\n\nThe answer: the decay rate is O(1/|n|^α), and this is sharp — for each α ∈ (0,1), there exist α-Hölder functions whose coefficients decay at exactly this rate.",
@@ -260,5 +260,5 @@
       "url": "https://en.wikipedia.org/wiki/Bernstein%27s_theorem_(approximation_theory)"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

- The sorry in `decay_implies_regularity` was resolved in `FourierSeriesOQ02Incomplete01.lean` (a comment in that file states it \"resolved sorry in FourierSeriesOQ02.lean\"), but `meta.json` was never updated to reflect this.
- Corrects `meta.sorries` from `1` to `0` and the top-level `sorries` from `1` to `0`.
- Updates the `assumptions` field to remove the stale sorry reference; the description now accurately reflects that `decay_implies_regularity` has been fully proved via FourierDecayInfra.
- The 1 axiom (`holder_decay_is_optimal_seq`: Weierstrass sequential optimality) remains; status stays `axiomatized` with badge `axiom`.

## Test plan

- [ ] Verify `leanFile.sorries: 0` was already correct (unchanged)
- [ ] Verify `meta.sorries: 0` is now correct
- [ ] Verify top-level `sorries: 0` is now correct
- [ ] Verify `meta.axiomCount: 1` and `leanFile.axiomCount: 1` are unchanged
- [ ] Verify `meta.status: axiomatized` and `meta.badge: axiom` are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)