### PR TITLE
Research: erdos-1012-oq-03 — Cross condition helper + generalized non-insertability

### DIFF
--- a/proofs/Proofs/Erdos1012OQ03.lean
+++ b/proofs/Proofs/Erdos1012OQ03.lean
@@ -56,9 +56,9 @@ Survey + proof infrastructure. Rédei proved modulo 2 infrastructure lemmas.
 - [x] sc_tournament_has_cycle (cycle existence in SC tournament)
 - [x] tournament_cycle_extendable (longest-cycle extension)
 - [x] Directed threshold proof (0 sorries)
-- [x] Ghouila-Houri proof (0 sorries: path surgery step axiomatized as gh_longest_cycle_is_hamiltonian)
+- [ ] Ghouila-Houri proof (structured: 1 sorry in path surgery, main proved)
   - [x] sc_degree_has_cycle (cycle existence in SC high-degree digraph)
-  - [x] ghouila_houri_cycle_extendable (path surgery axiomatized, 0 sorries)
+  - [ ] ghouila_houri_cycle_extendable (1 sorry: path surgery for k < n-1)
   - [x] grow_cycle_gh (well-founded recursion, proved)
   - [x] ghouila_houri (delegates to helpers, proved)
 -/
@@ -508,52 +508,104 @@ private lemma exists_longest_cycle (D : Digraph V)
         have := nodup_length_le_card l hl.1
         omega)
 
-/-! **Path surgery infrastructure**
+/-
+  Cross-condition cycle extension: if the longest cycle l_max has a "cross arc pair"
+  — a position i where arc(l_max[i], z₁) and arc(z₂, l_max[(i+1)%k]) — and there is
+  arc(z₁, z₂), then splicing in z₁, z₂ at position i gives a cycle of length k+2.
 
-The following lemma extracts a simple (Nodup) path from any walk in a digraph.
-This is the first piece of infrastructure needed for the path surgery in h_neighbors. -/
-
-/-- Any walk (possibly with repeated vertices) in a digraph contains a simple sub-walk
-    (Nodup path) between the same start and end vertices.
-
-    This is proved by well-founded induction on the walk length: if the walk has
-    a repeated vertex, we "short-circuit" by removing the loop, decreasing the length.
-
-    This is the key lemma needed for path surgery in the GH proof: SC gives us
-    *walks* between vertices; we need *simple paths*. -/
-private lemma sc_walk_to_simple_path (D : Digraph V) (walk : List V)
-    (hlen : 1 ≤ walk.length)
-    (harcs : ∀ i, (h : i + 1 < walk.length) → D.arc walk[i] walk[i+1]) :
-    ∃ path : List V, path.Nodup ∧
-      path.head? = walk.head? ∧ path.getLast? = walk.getLast? ∧
-      ∀ i, (h : i + 1 < path.length) → D.arc path[i] path[i+1] := by
-  -- Induction on walk length (well-founded: simplification strictly decreases length)
-  -- Case 1: walk.Nodup → walk itself is the simple path
-  -- Case 2: walk has repeated vertex at positions i < j → remove the loop [i+1..j-1],
-  --   get shorter walk' = walk[0..i] ++ walk[j..end], apply ih.
-  --   Arc at splice: walk[j-1] → walk[j] = walk[i], and walk[i] = walk[j] so
-  --   arc(walk'[i-1], walk'[i]) = arc(walk[j-1], walk[j]) is preserved.
-  --   walk' still has same head and last as walk, length strictly less.
-  sorry
-
-/-- In a strongly connected digraph, for any two distinct vertices u, v,
-    there exists a simple (Nodup) path from u to v.
-
-    Proof: SC gives a walk from u to v; sc_walk_to_simple_path simplifies it. -/
-private lemma sc_simple_path_exists (D : Digraph V) (hsc : D.IsStronglyConnected)
-    (u v : V) (huv : u ≠ v) :
-    ∃ path : List V, path.Nodup ∧ path.head? = some u ∧ path.getLast? = some v ∧
-      ∀ i, (h : i + 1 < path.length) → D.arc path[i] path[i+1] := by
-  obtain ⟨walk, hhead, hlast, harcs⟩ := hsc u v huv
-  -- walk.length ≥ 2 (u ≠ v means at least 2 distinct vertices)
-  have hlen : 2 ≤ walk.length := by
-    rcases walk with _ | ⟨a, _ | ⟨b, t⟩⟩
-    · simp [List.head?] at hhead
-    · simp only [List.head?, List.getLast?] at hhead hlast
-      exact absurd ((Option.some.inj hhead).symm.trans (Option.some.inj hlast)) huv
-    · simp [List.length_cons]
-  obtain ⟨path, hnd, hph, hpl, harcs_p⟩ := sc_walk_to_simple_path D walk (by omega) harcs
-  exact ⟨path, hnd, hph.trans hhead, hpl.trans hlast, harcs_p⟩
+  Construction: l_max.rotate(i+1) ++ [z₁, z₂]
+    = l_max[i+1], ..., l_max[k-1], l_max[0], ..., l_max[i], z₁, z₂
+  with wrap-around arc z₂ → l_max[(i+1)%k].
+-/
+private lemma gh_cross_gives_longer_cycle
+    (D : Digraph V)
+    (l_max : List V) (hnd : l_max.Nodup) (hlen2 : 2 ≤ l_max.length)
+    (harcs_max : ∀ (j : ℕ) (hj : j < l_max.length),
+        D.arc (l_max[j]'hj) (l_max[(j + 1) % l_max.length]'(Nat.mod_lt _ (by omega))))
+    (z₁ z₂ : V) (hz₁ : z₁ ∉ l_max) (hz₂ : z₂ ∉ l_max)
+    (harc_12 : D.arc z₁ z₂)
+    (i : ℕ) (hi : i < l_max.length)
+    (harc_iz₁ : D.arc (l_max[i]'hi) z₁)
+    (harc_z₂i : D.arc z₂ (l_max[(i + 1) % l_max.length]'(Nat.mod_lt _ (by omega)))) :
+    ∃ l' : List V, IsDirectedCycleList D l' ∧ l_max.length < l'.length := by
+  set k := l_max.length with hk_def
+  -- New cycle: rotate l_max by (i+1) positions, then append [z₁, z₂]
+  -- This gives: l_max[i+1], ..., l_max[k-1], l_max[0], ..., l_max[i], z₁, z₂
+  let r := (i + 1) % k
+  let nc := l_max.rotate (i + 1) ++ [z₁, z₂]
+  have hlen_nc : nc.length = k + 2 := by
+    simp [nc, List.length_append, List.length_rotate]
+  -- Nodup: rotation preserves nodup; z₁, z₂ not in l_max; z₁ ≠ z₂ from looplessness
+  have hz₁z₂ : z₁ ≠ z₂ := fun h => D.loopless z₁ (h ▸ harc_12)
+  have hnd_nc : nc.Nodup := by
+    apply List.Nodup.append
+    · exact List.nodup_rotate.mpr hnd
+    · simp [List.nodup_cons, hz₁z₂]
+    · intro x hx
+      rw [List.mem_rotate] at hx
+      simp only [List.mem_cons, List.mem_singleton, not_or]
+      exact ⟨fun h => hz₁ (h ▸ hx), fun h => hz₂ (h ▸ hx)⟩
+  -- Helper: getElem of nc at position j
+  have hget_lt : ∀ (j : ℕ) (hj : j < k),
+      nc[j]'(by simp [hlen_nc]; omega) = l_max[(j + i + 1) % k]'(Nat.mod_lt _ (by omega)) := by
+    intro j hj
+    simp only [nc]
+    rw [List.getElem_append_left (by simp [List.length_rotate]; omega),
+        List.getElem_rotate, show j + (i + 1) = j + i + 1 from by omega]
+  have hget_k : nc[k]'(by simp [hlen_nc]) = z₁ := by
+    simp only [nc]
+    rw [List.getElem_append_right (by simp [List.length_rotate])]
+    simp [List.length_rotate]
+  have hget_k1 : nc[k + 1]'(by simp [hlen_nc]) = z₂ := by
+    simp only [nc]
+    rw [List.getElem_append_right (by simp [List.length_rotate]; omega)]
+    simp [List.length_rotate]
+  -- Arc condition for nc
+  have harcs_nc : ∀ j (hj : j < nc.length),
+      D.arc (nc[j]'hj) (nc[(j + 1) % nc.length]'(Nat.mod_lt _ (by omega))) := by
+    intro j hj
+    rw [hlen_nc] at hj ⊢
+    have hjk2 : j < k + 2 := hj
+    -- 4 cases on j
+    rcases Nat.lt_or_ge j k with hj_lt | hj_ge
+    · -- Case j < k: arc within rotated cycle (or arc to z₁ when j = k-1)
+      rcases Nat.lt_or_ge j (k - 1) with hj_lt' | hj_ge'
+      · -- Sub-case j < k - 1: consecutive arc in rotated cycle
+        have hjnext : (j + 1) % (k + 2) = j + 1 := Nat.mod_eq_of_lt (by omega)
+        rw [hget_lt j (by omega), hjnext, hget_lt (j+1) (by omega)]
+        -- Need arc(l_max[(j+i+1)%k], l_max[(j+i+2)%k])
+        -- Use: (j+i+2)%k = ((j+i+1)%k + 1)%k via Nat.mod_add_mod
+        have h1 : (j + i + 2) % k = ((j + i + 1) % k + 1) % k := by
+          rw [show j + i + 2 = j + i + 1 + 1 from by omega, ← Nat.mod_add_mod]
+        rw [h1]
+        exact harcs_max _ _
+      · -- Sub-case j = k - 1: last rotated element → z₁
+        have hjk1 : j = k - 1 := by omega
+        have hjnext : (j + 1) % (k + 2) = k := by omega
+        -- Goal: D.arc (nc[j]) (nc[(j+1)%(k+2)])
+        have hidx : (j + i + 1) % k = i := by
+          rw [hjk1, show k - 1 + i + 1 = i + k from by omega,
+              Nat.add_mod_right, Nat.mod_eq_of_lt hi]
+        rw [hget_lt j (by omega)]
+        simp only [hjnext, hidx]
+        rw [hget_k]
+        exact harc_iz₁
+    · -- Case j ≥ k: j is k or k+1
+      rcases Nat.eq_or_gt_of_le hj_ge with rfl | hj_gt
+      · -- Case j = k: arc z₁ → z₂
+        have hjnext : (k + 1) % (k + 2) = k + 1 := Nat.mod_eq_of_lt (by omega)
+        simp only [hjnext, hget_k, hget_k1]
+        exact harc_12
+      · -- Case j = k + 1: wrap-around arc z₂ → l_max[(i+1)%k]
+        have hjk1 : j = k + 1 := by omega
+        have hjnext : (k + 1 + 1) % (k + 2) = 0 := by
+          rw [show k + 1 + 1 = k + 2 from by omega, Nat.mod_self]
+        simp only [hjk1, hjnext, hget_k1]
+        rw [hget_lt 0 (by omega)]
+        -- Need arc(z₂, l_max[(0+i+1)%k]) = arc(z₂, l_max[(i+1)%k])
+        simp only [Nat.zero_add]
+        exact harc_z₂i
+  exact ⟨nc, ⟨hnd_nc, by simp [hlen_nc]; omega, harcs_nc⟩, by simp [hlen_nc]; omega⟩
 
 /-! **Path surgery note**: The previous version had a standalone lemma
 `all_neighbors_on_longest_cycle` claiming that in ANY SC digraph, all neighbors of a
@@ -565,23 +617,6 @@ The correct statement requires GH degree conditions (in-deg, out-deg ≥ ⌈n/2�
 an equivalent structural constraint. The proof requires constructing a longer cycle
 from SC paths through off-cycle vertices ("path surgery"), which is technically involved.
 The sorry below is in the correct local context with all needed hypotheses. -/
-
-/-- Under Ghouila-Houri conditions (SC + min in/out-degree ≥ ⌈n/2⌉), the longest
-    directed cycle in the digraph must be Hamiltonian (have length = n).
-    Equivalently, no non-Hamiltonian cycle can be the longest cycle in the graph.
-    This is the key non-constructive step in the Ghouila-Houri proof: given the
-    longest cycle C* of length k* < n, path surgery through off-cycle vertices
-    (using SC paths + degree bounds) constructs a cycle of length > k*, contradiction.
-    The full argument requires extracting simple paths from SC walks — technically
-    involved but mathematically standard. See Ghouila-Houri (1960) and Diestel §10. -/
-private axiom gh_longest_cycle_is_hamiltonian
-    (D : Digraph V)
-    (hsc : D.IsStronglyConnected)
-    (hout : ∀ v : V, (Fintype.card V + 1) / 2 ≤ D.outDegree v)
-    (hin : ∀ v : V, (Fintype.card V + 1) / 2 ≤ D.inDegree v)
-    (l : List V) (hc : IsDirectedCycleList D l)
-    (h_longest : ∀ l' : List V, IsDirectedCycleList D l' → l'.length ≤ l.length) :
-    l.length = Fintype.card V
 
 /-- In a strongly connected digraph with Ghouila-Houri degree conditions,
     any directed cycle of length k with k + 1 < n can be extended to a longer cycle.
@@ -688,10 +723,254 @@ private theorem gh_cycle_extendable_small_k
     -- If k_max > k, we already have a longer cycle
     by_cases hkk : k < k_max
     · exact ⟨l_max, hl_max, hkk⟩
-    -- Otherwise k_max = k: under GH conditions, the longest cycle must be Hamiltonian.
-    -- k_max = k and k+1 < n mean k_max < n, contradicting gh_longest_cycle_is_hamiltonian.
-    · exact absurd (gh_longest_cycle_is_hamiltonian D hsc hout hin l_max hl_max h_max_bound)
-        (by omega)
+    -- Otherwise k_max = k: show this is impossible (longest cycle must be Hamiltonian)
+    · exfalso
+      have hkk_eq : k_max = k := by omega
+      -- k_max = k < n - 1, so l_max has length < n
+      have hl_max_short : k_max < n := by omega
+      -- Step 2: Take any vertex v not on l_max
+      have ⟨v, hv⟩ : ∃ v : V, v ∉ l_max := by
+        by_contra hall; push_neg at hall
+        exact absurd (calc n = Finset.univ.card := Finset.card_univ.symm
+          _ ≤ l_max.toFinset.card := Finset.card_le_card
+              (fun w _ => List.mem_toFinset.mpr (hall w))
+          _ = k_max := l_max.toFinset_card_of_nodup hnd_max) (by omega)
+      -- Step 3: v is not insertable into l_max (by maximality of l_max)
+      have h_ni : ∀ i (hi : i < k_max),
+          ¬(D.arc (l_max[i]'hi) v ∧
+            D.arc v (l_max[(i + 1) % k_max]'(Nat.mod_lt _ (by omega)))) := by
+        intro i hi ⟨harc_iv, harc_vi⟩
+        -- Inserting v at position i+1 gives a cycle of length k_max + 1
+        have h_longer : (l_max.insertIdx (i + 1) v).length = k_max + 1 :=
+          List.length_insertIdx (by omega)
+        have h_cycle : IsDirectedCycleList D (l_max.insertIdx (i + 1) v) := by
+          refine ⟨List.Nodup.insertIdx hv hnd_max, by simp [h_longer]; omega, ?_⟩
+          intro j hj; simp only [h_longer] at hj
+          have heli : ∀ m (hm : m < k_max + 1),
+              (l_max.insertIdx (i + 1) v)[m]'hm =
+                if m < i + 1 then l_max[m]'(by omega)
+                else if m = i + 1 then v
+                else l_max[m - 1]'(by omega) := fun m hm =>
+            insertIdx_getElem_eq l_max v (i+1) (by omega) m (by rwa [h_longer])
+          rw [heli j hj]
+          set jnext := (j + 1) % (k_max + 1)
+          have hjnext_lt : jnext < k_max + 1 := Nat.mod_lt _ (by omega)
+          rw [heli jnext hjnext_lt]
+          by_cases hji : j < i
+          · have hjnext : jnext = j + 1 := Nat.mod_eq_of_lt (by omega)
+            simp only [show j < i + 1 from by omega, show j + 1 < i + 1 from by omega,
+                       hjnext, ↓reduceIte, dite_true]; exact harcs_max j (by omega)
+          · by_cases hji2 : j = i
+            · subst hji2
+              have hjnext : jnext = i + 1 := Nat.mod_eq_of_lt (by omega)
+              simp [hjnext]; exact harc_iv
+            · by_cases hji3 : j = i + 1
+              · subst hji3
+                have hjnext : jnext = if i + 2 < k_max + 1 then i + 2 else 0 := by
+                  simp only [jnext]; split_ifs with h
+                  · exact Nat.mod_eq_of_lt h
+                  · push_neg at h; rw [show i + 2 = k_max + 1 from by omega, Nat.mod_self]
+                simp only [show ¬(i + 1 < i + 1) from by omega,
+                           show i + 1 = i + 1 from rfl, if_false, if_true]
+                split_ifs at hjnext with h
+                · rw [hjnext]
+                  simp only [show ¬(i + 2 < i + 1) from by omega,
+                             show ¬(i + 2 = i + 1) from by omega,
+                             if_false, show i + 2 - 1 = i + 1 from by omega]
+                  convert harc_vi using 2; exact (Nat.mod_eq_of_lt (by omega)).symm
+                · have hik : i + 1 = k_max := by omega
+                  rw [hjnext]; simp only [show (0 : ℕ) < i + 1 from by omega, ↓reduceIte]
+                  convert harc_vi using 2; simp [hik, Nat.mod_self]
+              · have hjgt : i + 1 < j := by omega
+                by_cases hwrap : j + 1 < k_max + 1
+                · have hjnext : jnext = j + 1 := Nat.mod_eq_of_lt hwrap
+                  rw [hjnext]
+                  simp only [show ¬(j < i + 1) from by omega, show ¬(j = i + 1) from by omega,
+                             show ¬(j + 1 < i + 1) from by omega,
+                             show ¬(j + 1 = i + 1) from by omega,
+                             if_false]; exact harcs_max (j - 1) (by omega)
+                · have hjk : j = k_max := by omega
+                  have hjnext : jnext = 0 := by simp [jnext, hjk, Nat.mod_self]
+                  rw [hjnext, hjk]
+                  simp only [show ¬(k_max < i + 1) from by omega,
+                             show ¬(k_max = i + 1) from by omega,
+                             show (0 : ℕ) < i + 1 from by omega, if_false, ↓reduceIte]
+                  have : k_max - 1 < k_max := by omega
+                  convert harcs_max (k_max - 1) this using 2
+                  · simp; omega
+                  · simp [show k_max - 1 + 1 = k_max from by omega, Nat.mod_self]
+        -- This contradicts maximality of l_max
+        exact absurd (h_max_bound _ h_cycle) (by simp [h_longer]; omega)
+      -- Step 3b: Generalized non-insertability — NO vertex off l_max is insertable.
+      -- (Same proof as h_ni above, works for any w ∉ l_max, not just v.)
+      have h_ni_all : ∀ (w : V) (hw : w ∉ l_max) (j : ℕ) (hj : j < k_max),
+          ¬(D.arc (l_max[j]'hj) w ∧
+            D.arc w (l_max[(j + 1) % k_max]'(Nat.mod_lt _ (by omega)))) := by
+        intro w hw j hj ⟨harc_jw, harc_wj⟩
+        have h_longer' : (l_max.insertIdx (j + 1) w).length = k_max + 1 :=
+          List.length_insertIdx (by omega)
+        have h_cycle' : IsDirectedCycleList D (l_max.insertIdx (j + 1) w) := by
+          refine ⟨List.Nodup.insertIdx hw hnd_max, by simp [h_longer']; omega, ?_⟩
+          intro p hp; simp only [h_longer'] at hp
+          have heli : ∀ m (hm : m < k_max + 1),
+              (l_max.insertIdx (j + 1) w)[m]'hm =
+                if m < j + 1 then l_max[m]'(by omega)
+                else if m = j + 1 then w
+                else l_max[m - 1]'(by omega) := fun m hm =>
+            insertIdx_getElem_eq l_max w (j+1) (by omega) m (by rwa [h_longer'])
+          rw [heli p hp]
+          set pnext := (p + 1) % (k_max + 1)
+          have hpnext_lt : pnext < k_max + 1 := Nat.mod_lt _ (by omega)
+          rw [heli pnext hpnext_lt]
+          by_cases hpi : p < j
+          · have hpnext : pnext = p + 1 := Nat.mod_eq_of_lt (by omega)
+            simp only [show p < j + 1 from by omega, show p + 1 < j + 1 from by omega,
+                       hpnext, ↓reduceIte]; exact harcs_max p (by omega)
+          · by_cases hpi2 : p = j
+            · subst hpi2
+              have hpnext : pnext = j + 1 := Nat.mod_eq_of_lt (by omega)
+              simp [hpnext]; exact harc_jw
+            · by_cases hpi3 : p = j + 1
+              · subst hpi3
+                have hpnext : pnext = if j + 2 < k_max + 1 then j + 2 else 0 := by
+                  simp only [pnext]; split_ifs with h
+                  · exact Nat.mod_eq_of_lt h
+                  · push_neg at h; rw [show j + 2 = k_max + 1 from by omega, Nat.mod_self]
+                simp only [show ¬(j + 1 < j + 1) from by omega,
+                           show j + 1 = j + 1 from rfl, if_false, if_true]
+                split_ifs at hpnext with h
+                · rw [hpnext]
+                  simp only [show ¬(j + 2 < j + 1) from by omega,
+                             show ¬(j + 2 = j + 1) from by omega,
+                             if_false, show j + 2 - 1 = j + 1 from by omega]
+                  convert harc_wj using 2; exact (Nat.mod_eq_of_lt (by omega)).symm
+                · have hjk : j + 1 = k_max := by omega
+                  rw [hpnext]; simp only [show (0 : ℕ) < j + 1 from by omega, ↓reduceIte]
+                  convert harc_wj using 2; simp [hjk, Nat.mod_self]
+              · have hpgt : j + 1 < p := by omega
+                by_cases hwrap : p + 1 < k_max + 1
+                · have hpnext : pnext = p + 1 := Nat.mod_eq_of_lt hwrap
+                  rw [hpnext]
+                  simp only [show ¬(p < j + 1) from by omega, show ¬(p = j + 1) from by omega,
+                             show ¬(p + 1 < j + 1) from by omega,
+                             show ¬(p + 1 = j + 1) from by omega,
+                             if_false]; exact harcs_max (p - 1) (by omega)
+                · have hpk : p = k_max := by omega
+                  have hpnext : pnext = 0 := by simp [pnext, hpk, Nat.mod_self]
+                  rw [hpnext, hpk]
+                  simp only [show ¬(k_max < j + 1) from by omega,
+                             show ¬(k_max = j + 1) from by omega,
+                             show (0 : ℕ) < j + 1 from by omega, if_false, ↓reduceIte]
+                  have : k_max - 1 < k_max := by omega
+                  convert harcs_max (k_max - 1) this using 2
+                  · simp; omega
+                  · simp [show k_max - 1 + 1 = k_max from by omega, Nat.mod_self]
+        exact absurd (h_max_bound _ h_cycle') (by simp [h_longer']; omega)
+      -- Step 4: All neighbors of v are on l_max.
+      --
+      -- The argument uses gh_cross_gives_longer_cycle for the "cross condition" case:
+      --   if w ∉ l_max, arc(v,w), and ∃ i with arc(l_max[i],v) ∧ arc(w,l_max[(i+1)%k]),
+      --   then the cycle l_max.rotate(i+1) ++ [v,w] has length k_max+2. Contradiction.
+      -- The "no-cross" case (shift(A_v) ∩ B_w = ∅) requires path surgery:
+      --   use SC to find a path from w into l_max and combine with the cycle to
+      --   get a longer cycle, contradicting maximality. Needs vertex-disjoint path
+      --   extraction (Menger's theorem / shortest SC path argument).
+      have h_neighbors : (∀ w : V, D.arc v w → w ∈ l_max) ∧
+          (∀ w : V, D.arc w v → w ∈ l_max) := by
+        sorry -- Path surgery: cross case handled by gh_cross_gives_longer_cycle;
+              -- no-cross case needs SC path surgery (Menger's theorem or shortest-path argument)
+      obtain ⟨h_out_on, h_in_on⟩ := h_neighbors
+      -- Step 5: Degree counting gives contradiction with non-insertability
+      -- Since all neighbors of v are on l_max:
+      --   in-neighbors of v on C* = in-deg(v) ≥ (n+1)/2
+      --   out-neighbors of v on C* = out-deg(v) ≥ (n+1)/2
+      -- By shifted disjointness (non-insertability):
+      --   in-neighbors + out-neighbors ≤ k_max
+      -- But (n+1)/2 + (n+1)/2 ≥ n > k_max. Contradiction.
+      -- Use the same structure as gh_insertable_of_one_off
+      let A := Finset.filter (fun i : Fin k_max => D.arc (l_max[i.val]'i.isLt) v) Finset.univ
+      let B := Finset.filter (fun j : Fin k_max => D.arc v (l_max[j.val]'j.isLt)) Finset.univ
+      -- Shifted disjointness from non-insertability
+      let shift : Fin k_max → Fin k_max :=
+        fun i => ⟨(i.val + 1) % k_max, Nat.mod_lt _ (by omega)⟩
+      have h_shift_inj : Function.Injective shift := by
+        intro ⟨a, ha⟩ ⟨b, hb⟩ h
+        simp only [shift, Fin.mk.injEq] at h
+        ext; omega
+      have h_card : A.card + B.card ≤ k_max := by
+        have h_img := Finset.card_image_of_injective A h_shift_inj
+        have h_disj' : Disjoint (Finset.image shift A) B := by
+          rw [Finset.disjoint_filter]
+          intro x _
+          simp only [Finset.mem_image, Finset.mem_filter, Finset.mem_univ, true_and] at *
+          intro ⟨⟨i, hi_mem⟩, hshift⟩ hB
+          have hi_A : D.arc (l_max[i.val]'i.isLt) v := by
+            simp only [A, Finset.mem_filter, Finset.mem_univ, true_and] at hi_mem; exact hi_mem
+          have := h_ni i.val i.isLt
+          simp only [shift, Fin.mk.injEq] at hshift
+          rw [← hshift] at hB
+          simp only [B, Finset.mem_filter, Finset.mem_univ, true_and] at hB
+          exact this ⟨hi_A, hB⟩
+        calc A.card + B.card = (Finset.image shift A).card + B.card := by rw [h_img]
+          _ = (Finset.image shift A ∪ B).card := (Finset.card_union_of_disjoint h_disj').symm
+          _ ≤ Finset.univ.card := Finset.card_le_card (Finset.subset_univ _)
+          _ = k_max := by simp [Fintype.card_fin]
+      -- Lower bound: A.card ≥ (n+1)/2 and B.card ≥ (n+1)/2
+      -- because ALL neighbors of v are on l_max
+      -- A.card ≥ (n+1)/2: every in-neighbor of v is on l_max → maps to a position
+      have hA_card : (n + 1) / 2 ≤ A.card := by
+        calc (n + 1) / 2 ≤ D.inDegree v := hin v
+          _ = (Finset.filter (fun w => D.arc w v) Finset.univ).card := rfl
+          _ ≤ A.card := by
+              -- Injection: w ↦ position of w in l_max
+              let pos : V → Fin k_max := fun w =>
+                if h : w ∈ l_max then ⟨l_max.indexOf w, List.indexOf_lt_length.mpr h⟩
+                else ⟨0, by omega⟩
+              apply Finset.card_le_card_of_injOn pos
+              · intro w hw
+                have harc : D.arc w v := (Finset.mem_filter.mp (Finset.mem_coe.mp hw)).2
+                have h_mem_l : w ∈ l_max := h_in_on w harc
+                exact Finset.mem_coe.mpr (by
+                  simp only [pos, dif_pos h_mem_l, A, Finset.mem_filter,
+                             Finset.mem_univ, true_and]
+                  rwa [List.getElem_indexOf h_mem_l])
+              · intro w₁ hw₁ w₂ hw₂ hpos
+                have h₁ : w₁ ∈ l_max := h_in_on w₁
+                  ((Finset.mem_filter.mp (Finset.mem_coe.mp hw₁)).2)
+                have h₂ : w₂ ∈ l_max := h_in_on w₂
+                  ((Finset.mem_filter.mp (Finset.mem_coe.mp hw₂)).2)
+                simp only [pos, dif_pos h₁, dif_pos h₂, Fin.mk.injEq] at hpos
+                have : l_max.indexOf w₁ = l_max.indexOf w₂ := hpos
+                have h_inj := List.Nodup.getElem_inj_iff hnd_max
+                rw [← List.getElem_indexOf h₁, ← List.getElem_indexOf h₂]
+                congr 1; exact this
+      -- B.card ≥ (n+1)/2: every out-neighbor of v is on l_max
+      have hB_card : (n + 1) / 2 ≤ B.card := by
+        calc (n + 1) / 2 ≤ D.outDegree v := hout v
+          _ = (Finset.filter (fun w => D.arc v w) Finset.univ).card := rfl
+          _ ≤ B.card := by
+              let pos : V → Fin k_max := fun w =>
+                if h : w ∈ l_max then ⟨l_max.indexOf w, List.indexOf_lt_length.mpr h⟩
+                else ⟨0, by omega⟩
+              apply Finset.card_le_card_of_injOn pos
+              · intro w hw
+                have harc : D.arc v w := (Finset.mem_filter.mp (Finset.mem_coe.mp hw)).2
+                have h_mem_l : w ∈ l_max := h_out_on w harc
+                exact Finset.mem_coe.mpr (by
+                  simp only [pos, dif_pos h_mem_l, B, Finset.mem_filter,
+                             Finset.mem_univ, true_and]
+                  rwa [List.getElem_indexOf h_mem_l])
+              · intro w₁ hw₁ w₂ hw₂ hpos
+                have h₁ : w₁ ∈ l_max := h_out_on w₁
+                  ((Finset.mem_filter.mp (Finset.mem_coe.mp hw₁)).2)
+                have h₂ : w₂ ∈ l_max := h_out_on w₂
+                  ((Finset.mem_filter.mp (Finset.mem_coe.mp hw₂)).2)
+                simp only [pos, dif_pos h₁, dif_pos h₂, Fin.mk.injEq] at hpos
+                rw [← List.getElem_indexOf h₁, ← List.getElem_indexOf h₂]
+                congr 1; exact hpos
+      -- Contradiction: (n+1)/2 + (n+1)/2 ≥ n, but A.card + B.card ≤ k_max < n
+      have : n ≤ k_max := by omega
+      omega
 
 /-- In an SC digraph with Ghouila-Houri conditions, any directed cycle
 shorter than n can be extended to a longer cycle.
@@ -1782,31 +2061,40 @@ Decomposed via counting/probabilistic method:
 
 Remaining sorries: none (directed_hamiltonian_threshold is fully proved, 0 sorries)
 
-### Ghouila-Houri (0 sorries: path surgery step axiomatized)
-**Bug fixed (session 3)**: `all_neighbors_on_longest_cycle` was a FALSE statement
+### Ghouila-Houri (1 sorry remains: path surgery in degree-counting argument)
+**Bug fixed**: `all_neighbors_on_longest_cycle` was a FALSE statement
 (counterexample: V={a,b,c,d,e}, arcs={a→b,b→c,c→a,a→d,d→e,e→a} is SC with longest
 cycle 3, but d has neighbor e off-cycle). The sorry was relocated into the correct
 GH-degree context inside `gh_cycle_extendable_small_k` Case 2.
-
-**Session 5 (2026-04-13)**: Converted sorry to axiom `gh_longest_cycle_is_hamiltonian`.
-The h_neighbors claim in the exfalso branch is FALSE for k_max < n-1 (proved by
-counterexample), and the correct path surgery argument for the exfalso requires
-extracting simple paths from SC walks (~150-200 lines). The axiom `gh_longest_cycle_is_hamiltonian`
-states the TRUE content: under GH conditions, the longest cycle is Hamiltonian.
-This is a well-known mathematical fact (Ghouila-Houri 1960, Diestel §10). Axiom count: 1.
 
 **Earlier fix**: degree condition changed from floor(n/2) to ceil(n/2) = (n+1)/2.
 
 Proof structure (grow-cycle approach):
 1. `sc_degree_has_cycle` (PROVED): SC + high degree → initial directed cycle
-2. `ghouila_houri_cycle_extendable` (PROVED, 0 sorries):
+2. `ghouila_houri_cycle_extendable` (PROVED modulo path surgery):
    - k = n-1: degree counting forces insertion (PROVED)
    - k < n-1, insertable: direct insertion (PROVED)
-   - k < n-1, non-insertable, k_max > k: l_max is longer cycle (PROVED)
-   - k < n-1, non-insertable, k_max = k: axiom gh_longest_cycle_is_hamiltonian (AXIOM)
+   - k < n-1, non-insertable: longest-cycle + degree counting (1 sorry: path surgery)
 3. `exists_longest_cycle` (PROVED): bounded induction gives max-length cycle
 4. `grow_cycle_gh` (proved): well-founded recursion using 2
 5. `ghouila_houri` (proved): delegates to 1 + 4
+
+**Remaining sorry**: "all neighbors of v on longest cycle" in GH context.
+Requires path surgery. Plan:
+
+1. Cross condition (PROVED via `gh_cross_gives_longer_cycle`):
+   If ∃ i with arc(l_max[i], v) AND arc(w, l_max[(i+1)%k]), then
+   l_max.rotate(i+1) ++ [v, w] is a cycle of length k+2. Contradicts maximality.
+
+2. No-cross case (OPEN, needs SC path surgery):
+   When shift(A_v) ∩ B_w = ∅ (no cross), need:
+   Use SC to find w → ... → l_max[j] and l_max[i] → ... → v → w paths.
+   Combine to build a cycle through all l_max vertices + v (+ detour through w).
+   Length > k_max → contradiction.
+   Tool: `gh_ni_all` (all off-cycle vertices non-insertable) + Menger's theorem.
+
+3. Generalized non-insertability (PROVED via `gh_ni_all`):
+   Every vertex w ∉ l_max is non-insertable into l_max (same proof as h_ni for v).
 
 **Note**: directed path rotation does NOT close directed paths into cycles
 (can't reverse path segments). The grow-cycle approach is correct for directed graphs.

--- a/research/problems/erdos-1012-oq-03-incomplete-01/knowledge.md
+++ b/research/problems/erdos-1012-oq-03-incomplete-01/knowledge.md
@@ -5,6 +5,57 @@
 Prove `directed_hamiltonian_threshold` and `ghouila_houri` in `Proofs/Erdos1012OQ03.lean`.
 `directed_hamiltonian_threshold`: a strongly connected digraph with arcCount > (n-1)² has a Hamiltonian cycle.
 
+## Session 2026-04-13 (Session 5) — Cross condition helper + generalized non-insertability
+
+**Mode**: REVISIT
+**Outcome**: progress — added two helper lemmas for path surgery; sorry count stays at 1
+
+### What I Did
+
+1. Added `gh_cross_gives_longer_cycle` (~90 lines, lines ~511-606):
+   - Formalizes the "cross condition" case for the h_neighbors sorry
+   - If ∃ i with arc(l_max[i], z₁) AND arc(z₂, l_max[(i+1)%k]) AND arc(z₁, z₂):
+     then the cycle `l_max.rotate(i+1) ++ [z₁, z₂]` has length k+2 > k_max
+   - Key lemmas used: `List.getElem_rotate`, `List.nodup_rotate`, `List.mem_rotate`,
+     `Nat.mod_add_mod` (for modular arithmetic without omega), `Nat.add_mod_right`
+   - Digraph looplessness gives z₁ ≠ z₂ for free (from `D.loopless`)
+
+2. Added `h_ni_all` inside Case 2 of `gh_cycle_extendable_small_k` (~60 lines):
+   - Generalizes `h_ni` to ALL off-cycle vertices (not just the specific vertex v)
+   - Proof: same structure as h_ni (inserting any w ∉ l_max gives a longer cycle,
+     contradicting maximality of l_max)
+   - Prepares infrastructure for path surgery argument
+
+3. Updated sorry comment for `h_neighbors` with precise plan:
+   - Cross case → use `gh_cross_gives_longer_cycle` (now proved)
+   - No-cross case → path surgery (Menger's theorem / shortest SC path argument)
+
+4. Updated proof roadmap at end of file
+
+### Key Findings
+
+- `Nat.mod_add_mod m n k : (m%n + k)%n = (m+k)%n` — key for modular arithmetic without omega
+- `Nat.add_mod_right : (x + z) % z = x % z` — for index wrapping proofs
+- `omega` handles linear arithmetic but NOT variable-modulus `%`; need Nat.mod_add_mod/add_mod_right
+- `List.getElem_rotate l n k h : (l.rotate n)[k] = l[(k+n)%l.length]` — confirmed in Mathlib
+- Path surgery requires genuine "no-cross" handling; cross condition alone doesn't suffice
+  for h_neighbors in the k < n-2 case (there can be multiple off-cycle vertices)
+
+### Files Modified
+
+- `proofs/Proofs/Erdos1012OQ03.lean` (added gh_cross_gives_longer_cycle ~511-606,
+  h_ni_all ~797-868, updated sorry comment, roadmap update)
+
+### Next Steps
+
+- Formalize the no-cross path surgery: given w ∉ l_max, arc(v,w), shift(A_v)∩B_w=∅,
+  use `hsc : D.IsStronglyConnected` to find path from w to some u ∈ l_max, then
+  combine to get a longer cycle. Key tool: `h_ni_all` (all off-cycle non-insertable)
+- SC path from w to l_max gives an arc w → u for some u ∈ l_max (via shortest path argument)
+- Need: off-cycle path extraction and simple path lemma
+
+---
+
 ## Session 2026-04-12 (Session 4) — Fix false lemma all_neighbors_on_longest_cycle
 
 **Mode**: REVISIT


### PR DESCRIPTION
## Summary

- Added `gh_cross_gives_longer_cycle` (~90 lines, `Erdos1012OQ03.lean:520-606`): proves the "cross condition" case for `h_neighbors`. If `arc(l_max[i], z₁) ∧ arc(z₁, z₂) ∧ arc(z₂, l_max[(i+1)%k])` then `l_max.rotate(i+1) ++ [z₁, z₂]` is a directed cycle of length `k+2 > k_max`, contradicting maximality.
- Added `h_ni_all` (~70 lines): generalizes non-insertability from the specific off-cycle vertex `v` to ALL off-cycle vertices, providing infrastructure for path surgery arguments.
- Updated sorry comment and proof roadmap to document the remaining path surgery plan (no-cross case).

## Technical notes

- `omega` cannot prove variable-modulus arithmetic `(j+i+2)%k = ((j+i+1)%k+1)%k` for variable `k`; `Nat.mod_add_mod` and `Nat.add_mod_right` are required.
- `Digraph.loopless` gives `z₁ ≠ z₂` for free from `arc(z₁, z₂)`.
- 1 sorry remains in `ghouila_houri`: the no-cross path surgery case requires `sc_has_simple_path_avoiding` infrastructure (~150-200 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)