### PR TITLE
Fix: erdos-1012-oq-03 axiomCount undercount (0→1) + status update

### DIFF
--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -4,7 +4,7 @@
   "slug": "erdos-1012-oq-03",
   "description": "Directed analogues of Hamiltonian cycle conditions: Ghouila-Houri, Moon-Moser, and Rédei theorems for digraphs and tournaments.",
   "meta": {
-    "status": "formalized",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos1012OQ03.lean",
     "tags": [
       "graph-theory",
@@ -12,11 +12,11 @@
       "hamiltonian-cycles",
       "tournaments"
     ],
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 1,
-    "axiomCount": 0,
-    "lineCount": 1929,
-    "assumptions": "1 sorry: path surgery in gh_cycle_extendable_small_k Case 2 (GH degree context). Previous all_neighbors_on_longest_cycle was FALSE — fixed. Rédei, Moon-Moser, directed_hamiltonian_threshold fully proved.",
+    "axiomCount": 1,
+    "lineCount": 1823,
+    "assumptions": "1 axiom: gh_longest_cycle_is_hamiltonian (path surgery step in Ghouila-Houri: given a longest directed cycle of length k < n in a strongly connected GH-degree digraph, SC routing constructs a longer cycle — standard result, technically involved). 1 sorry: sc_walk_to_simple_path (well-founded induction simplifying a walk to a simple path — infrastructure lemma for path surgery). Rédei, Moon-Moser, directed_hamiltonian_threshold fully proved.",
     "dateAdded": "2026-03-30",
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Hamiltonian_path_problem#Directed_graphs",
@@ -25,7 +25,7 @@
   "overview": {
     "historicalContext": "The theory of directed Hamiltonian cycles developed in the 1930s–1970s as a directed counterpart to the celebrated undirected results of Dirac (1952) and others. Rédei (1934) proved that every tournament (complete directed graph) has a Hamiltonian path — a result with a clean inductive proof via vertex insertion. Moon and Moser (1963) strengthened this: strongly connected tournaments always have Hamiltonian cycles, not just paths. Ghouila-Houri (1960) gave the directed analogue of Dirac's theorem: a strongly connected digraph in which every vertex has both in-degree and out-degree $\\geq n/2$ has a Hamiltonian cycle. Meyniel (1973) gave a weaker sufficient condition (sum of degrees $\\geq 2n-1$ for non-adjacent pairs), matching the degree-sum form of Ore's undirected theorem. Erdős Problem 1012 (undirected) asks about long cycle thresholds; this OQ explores the directed analogues.",
     "problemStatement": "For directed graphs: (1) What minimum degree condition on a strongly connected digraph guarantees a Hamiltonian cycle? (Ghouila-Houri, 1960: $\\delta^+(v) \\geq n/2$ and $\\delta^-(v) \\geq n/2$ for all $v$.) (2) Do all strongly connected tournaments have Hamiltonian cycles? (Moon-Moser, 1963: yes.) (3) Do all tournaments have Hamiltonian paths? (Rédei, 1934: yes.) (4) What arc-count threshold forces Hamiltonicity in a strongly connected digraph?",
-    "proofStrategy": "The file builds up from scratch: Digraph structure, degree definitions, Tournament and StronglyConnected predicates, Hamiltonian cycle/path definitions. Rédei's theorem is fully proved by induction: `tournament_path_insert` extends a Hamiltonian path by inserting a new vertex into an existing path (always possible in a tournament), and `tournament_full_path_list` builds the full path by induction; `list_path_to_hamiltonian` converts the list representation to the `Equiv`-based definition. Moon-Moser's theorem is now fully proved: `sc_tournament_has_cycle` (extract a simple cycle from a Hamiltonian path + SC walk), `tournament_cycle_non_insertable` (S⁺/S⁻ partition argument), `tournament_cycle_extendable` (cycle extension using SC contradiction), and `grow_cycle_to_hamiltonian` (well-founded induction growing any cycle to Hamiltonian). Ghouila-Houri and the arc threshold remain as sorries.",
+    "proofStrategy": "The file builds up from scratch: Digraph structure, degree definitions, Tournament and StronglyConnected predicates, Hamiltonian cycle/path definitions. Rédei's theorem is fully proved by induction: `tournament_path_insert` extends a Hamiltonian path by inserting a new vertex into an existing path (always possible in a tournament), and `tournament_full_path_list` builds the full path by induction; `list_path_to_hamiltonian` converts the list representation to the `Equiv`-based definition. Moon-Moser's theorem is now fully proved. Ghouila-Houri uses `gh_longest_cycle_is_hamiltonian` (axiom) for path surgery and `sc_walk_to_simple_path` (sorry: walk→simple-path helper). Arc threshold proved via probabilistic counting.",
     "keyInsights": [
       "Rédei's 1934 theorem (every tournament has a Hamiltonian path) has a beautiful constructive proof: start with a single vertex, and inductively insert each new vertex $v$ into the existing Hamiltonian path. Since $v$ beats some vertices and loses to others in the tournament, there always exists a position to insert $v$ maintaining the directed path property. This is formalized via `tournament_path_insert` — a pure induction argument.",
       "The Moon-Moser theorem requires strong connectivity, unlike Rédei's path result. The proof strategy is a 'longest cycle' argument: take a longest directed cycle $C$ in the tournament; if $|C| < n$, take a vertex $v \\notin C$; partition $C$ into $S^+ = \\{\\text{successors of } v \\text{ in } C\\}$ and $S^- = \\{\\text{predecessors of } v \\text{ in } C\\}$; strong connectivity forces the cycle to be extendable, contradicting maximality.",
@@ -86,7 +86,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Rédei (Hamiltonian path in tournaments), Moon-Moser (Hamiltonian cycles in SC tournaments), and directed_hamiltonian_threshold are fully proved. Ghouila-Houri's theorem has 1 sorry (gh_cycle_extendable_small_k: non-insertable case of cycle extension when k+1 < n). The 1694-line file is the most substantial directed Hamiltonicity formalization in this gallery.",
+    "summary": "Rédei (Hamiltonian path in tournaments), Moon-Moser (Hamiltonian cycles in SC tournaments), and directed_hamiltonian_threshold are fully proved. Ghouila-Houri uses 1 axiom (gh_longest_cycle_is_hamiltonian: path surgery step) and 1 sorry (sc_walk_to_simple_path: walk→simple-path infrastructure). The 1823-line file is the most substantial directed Hamiltonicity formalization in this gallery.",
     "implications": "Directed Hamiltonicity thresholds have applications beyond pure graph theory: tournament Hamiltonian paths correspond to linear extensions of partial orders, with applications to voting theory (ranking candidates) and scheduling. Rédei's theorem has a direct combinatorial interpretation: in any round-robin tournament, there exists a ranking of all players consistent with the match results (as a directed path). Moon-Moser's result shows that strongly connected tournaments (those where outcomes don't create a dominant clique) have circular Hamiltonian cycles — a stronger consistency property.",
     "openQuestions": [
       "Meyniel's condition (weaker than Ghouila-Houri: $\\delta^+(u) + \\delta^-(u) + \\delta^+(v) + \\delta^-(v) \\geq 2n-1$ for non-adjacent pairs) implies Hamiltonicity. Can this stronger result be formalized, or would it require substantially more tournament infrastructure?",
@@ -121,8 +121,8 @@
       "Finset"
     ],
     "namespace": "Erdos1012OQ03",
-    "lineCount": 1929,
-    "axiomCount": 0,
+    "lineCount": 1823,
+    "axiomCount": 1,
     "sorries": 1,
     "path": "Proofs/Erdos1012OQ03.lean",
     "theoremCount": 9,


### PR DESCRIPTION
## Fix

`erdos-1012-oq-03` (Directed Graph Hamiltonian Cycle Thresholds) has a `private axiom` declaration that was not reflected in meta.json.

## Evidence

**Before**:
- `axiomCount: 0` — incorrect, `private axiom gh_longest_cycle_is_hamiltonian` exists at line 530
- `status: "formalized"` — incorrect, should be `axiomatized` (has a stated axiom)
- `badge: "wip"` — incorrect, should be `axiom`
- `lineCount: 1929` — stale, actual is 1823

**After**:
- `axiomCount: 1` — correct
- `status: "axiomatized"` — correct
- `badge: "axiom"` — correct
- `lineCount: 1823` — correct
- `assumptions` updated to describe both the axiom and remaining sorry

The axiom covers the path surgery step in Ghouila-Houri (given a longest cycle of length k < n in a strongly connected GH-degree digraph, SC routing through off-cycle vertices constructs a longer cycle — mathematically standard but requires sc_walk_to_simple_path infrastructure which is still a sorry).

Replaces closed PR #10600.

---
Automated fix by lean-mechanic agent.