### PR TITLE
Research: erdos-1012-oq-03 GH path surgery proof strategy

### DIFF
--- a/src/data/research/problems/erdos-1012-oq-03.json
+++ b/src/data/research/problems/erdos-1012-oq-03.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ACT: Fixed ghouila_houri statement (floor→ceiling division bug). Restructured proof: main theorem proved via grow-cycle, 2 helper sorries remain (sc_degree_has_cycle, ghouila_houri_cycle_extendable).",
+    "progressSummary": "PROGRESS: Complete proof strategy documented; requires ~200 lines Lean infrastructure (last_exit_walk + first_entry_walk + vertex_disjoint minimality)",
     "builtItems": [
       "Digraph structure with loopless axiom",
       "In-degree, out-degree, tournament, strong connectivity definitions",
@@ -83,12 +83,15 @@
       "Directed path rotation (Dirac-style) does NOT work for directed graphs — cannot reverse path segments",
       "Grow-cycle approach is correct for directed GH: get initial cycle from SC, extend using degree conditions",
       "k=n-1 case is clean: |N⁺∩C|+|N⁻∩C| ≥ n+1 > n-1 forces insertability",
-      "k<n-1 case requires SC+S⁻/S⁺ partition argument (similar to tournament_cycle_extendable Case 2b)"
+      "k<n-1 case requires SC+S⁻/S⁺ partition argument (similar to tournament_cycle_extendable Case 2b)",
+      "Path surgery proof structure fully analyzed: requires (1) last_exit_walk lemma - extract sub-walk from SC walk starting at last set-contact vertex, (2) first_entry_walk lemma - dual, (3) vertex-disjoint minimality - Menger-style argument: if paths share off-cycle vertex u, shortcut to shorter paths with same endpoints; well-founded induction on |pathP|+|pathQ| gives vertex-disjoint paths with no l_max-internal vertices, (4) the resulting Nodup closed walk lmax_rot++pathP.tail++[w]++pathQ.init has length k_max+|P|+|Q|-1 ≥ k_max+3 and is a simple cycle contradicting h_max_bound. Total infrastructure needed: ~200 lines."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove sc_degree_has_cycle: SC + out-deg≥2 → directed cycle exists (pigeonhole on walks)",
-      "Prove ghouila_houri_cycle_extendable: key cases are k=n-1 (counting) and k<n-1 (SC partition)"
+      "Implement last_exit_walk (~40 lines): given walk from a∈S to v∉S, take sub-walk from last S-vertex; prove by List.findIdx on reversed walk",
+      "Implement first_entry_walk (~40 lines): symmetric",
+      "Implement vertex_disjoint_surgery (~80 lines): well-founded induction on |pathP|+|pathQ|, shortcut when paths share off-cycle vertex",
+      "Assemble into h_neighbors proof (~30 lines): apply three helpers, build closed walk, use h_max_bound for contradiction"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

- Analyzed the last remaining sorry in `Erdos1012OQ03.lean` (Ghouila-Houri theorem, Case k < n-1)
- Worked out the complete mathematical proof structure for the path surgery step
- Documented the full 4-step proof plan in the sorry comment and knowledge files

## Proof Strategy Discovered

The sorry proves `h_neighbors`: all in/out-neighbors of off-cycle vertex v lie on the longest cycle l_max. When a neighbor w ∉ l_max and D.arc v w exist, we build a simple cycle of length > k_max via:

1. **last_exit_walk** (~40 lines): SC walk → sub-walk from last l_max contact to v (internal vertices off l_max)
2. **first_entry_walk** (~40 lines): symmetric, from w to first l_max contact
3. **Vertex-disjoint minimality** (~80 lines): Menger-style — if paths share off-cycle vertex u, shortcut to shorter paths; Nat.strongRecOn on |P|+|Q|
4. **Closed walk construction** (~30 lines): Nodup walk W = lmax_rot++P.tail++[w]++Q.init, length ≥ k_max+3 > k_max, contradicts h_max_bound

Total implementation: ~190 lines to close the last sorry and complete `ghouila_houri`.

## Files Modified

- `proofs/Proofs/Erdos1012OQ03.lean` — sorry comment updated with complete proof plan
- `research/problems/erdos-1012-oq-03-incomplete-01/knowledge.md` — session 5 findings
- `src/data/research/problems/erdos-1012-oq-03.json` — knowledge updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)