### PR TITLE
Fix: erdos-606-oq-03-oq-03 sorry count corrected (0 sorries, 1 axiom)

### DIFF
--- a/src/data/proofs/erdos-606-oq-03-oq-03/meta.json
+++ b/src/data/proofs/erdos-606-oq-03-oq-03/meta.json
@@ -16,7 +16,7 @@
       "extremal-argument"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Real.sqrt",
@@ -150,7 +150,7 @@
     "theoremCount": 3,
     "definitionCount": 5,
     "path": "Proofs/Erdos606OQ03OQ03.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "references": [
     {
@@ -182,5 +182,5 @@
       "leanType": "(sorry) S.card ≥ 3 ∧ ¬AllCollinear S → HasOrdinaryLine S"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

- The Lean file `proofs/Proofs/Erdos606OQ03OQ03.lean` contains 0 sorries — the sorry in `sylvester_gallai` was resolved but `meta.json` was never updated to reflect this.
- Corrects all three sorry count fields from `1` to `0`: `meta.sorries`, `leanFile.sorries`, and the top-level `sorries`.
- The axiom count (1 for `kelly_distance_lemma`) and `axiomatized` status are unchanged.

## Test plan

- [ ] Confirm `grep -c "sorry" proofs/Proofs/Erdos606OQ03OQ03.lean` returns 0 (or only comments/strings)
- [ ] Confirm `meta.json` now has `"sorries": 0` in all three locations
- [ ] Confirm `axiomCount`, `status`, and `badge` are still `1`, `axiomatized`, and `axiom` respectively

🤖 Generated with [Claude Code](https://claude.com/claude-code)