### PR TITLE
Enrich 2 proofs: erdos-130-wip-01 annotations + taylor-sincos-convergence-oq-04 reformat

### DIFF
--- a/src/data/proofs/taylor-sincos-convergence-oq-04/annotations.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-04/annotations.json
@@ -1,108 +1,110 @@
-{
-  "annotations": [
-    {
-      "lineStart": 57,
-      "lineEnd": 62,
-      "type": "definition",
-      "label": "taylorPartialSum",
-      "content": "The general Taylor partial sum $T_n^f(x) = \\sum_{k=0}^{n} \\frac{f^{(k)}(0)}{k!} x^k$. This single definition generalizes both sinPartialSum and cosPartialSum from the parent proof. The key property: it only depends on derivatives at 0 and powers of $x$, making it function-agnostic.",
-      "significance": "core"
-    },
-    {
-      "lineStart": 64,
-      "lineEnd": 70,
-      "type": "theorem",
-      "label": "Agreement with parent",
-      "content": "taylorPartialSum applied to $\\sin$ (resp. $\\cos$) is **definitionally equal** to sinPartialSum (resp. cosPartialSum). The proof is `rfl` — no computation needed. This confirms the general definition correctly captures the specific cases.",
-      "significance": "supporting"
-    },
-    {
-      "lineStart": 81,
-      "lineEnd": 86,
-      "type": "theorem",
-      "label": "iteratedDerivWithin = iteratedDeriv",
-      "content": "For $C^\\infty$ functions, the restriction of derivatives to a subset agrees with the unrestricted derivative, provided the subset has the unique differentiation property. This is the key bridge between our clean definition (using `iteratedDeriv`) and Mathlib's Taylor machinery (using `iteratedDerivWithin`).",
-      "significance": "supporting"
-    },
-    {
-      "lineStart": 88,
-      "lineEnd": 97,
-      "type": "theorem",
-      "label": "Bridge to Mathlib (x > 0)",
-      "content": "For $x > 0$: $T_n^f(x) = $ `taylorWithinEval` $f$ $n$ $[0,x]$ $0$ $x$. The proof unfolds both definitions and shows term-by-term equality using the iteratedDerivWithin = iteratedDeriv bridge. This only works for $x > 0$ because we need $[0,x]$ to be a non-degenerate interval for `uniqueDiffOn_Icc`.",
-      "significance": "key"
-    },
-    {
-      "lineStart": 106,
-      "lineEnd": 121,
-      "type": "theorem",
-      "label": "Remainder bound (x > 0)",
-      "content": "**Fully proved**: $\\|f(x) - T_n^f(x)\\| \\leq C \\cdot \\frac{x^{n+1}}{n!}$ for $x > 0$. The proof chains: (1) bridge to `taylorWithinEval`, (2) apply `taylor_mean_remainder_bound` with the uniform derivative bound $C$, (3) simplify $x - 0 = x$. This is the general version of OQ-01's `sin_remainder_pos`.",
-      "significance": "key"
-    },
-    {
-      "lineStart": 123,
-      "lineEnd": 135,
-      "type": "axiom",
-      "label": "General remainder bound (axiom)",
-      "content": "**Axiom**: $\\|f(x) - T_n^f(x)\\| \\leq C \\cdot \\frac{|x|^{n+1}}{n!}$ for all $x \\in \\mathbb{R}$. The $x > 0$ case is proved above. The $x = 0$ case is trivial. The $x < 0$ case would use the reflection $g(t) = f(-t)$: since $g$ also has derivatives bounded by $C$, the $x > 0$ bound for $g$ at $-x > 0$ gives the bound for $f$ at $x < 0$. The missing ingredient is `iteratedDeriv n (f \\circ \\text{neg}) = (-1)^n \\cdot (\\text{iteratedDeriv}\\, n\\, f) \\circ \\text{neg}`.",
-      "significance": "core"
-    },
-    {
-      "lineStart": 143,
-      "lineEnd": 149,
-      "type": "theorem",
-      "label": "pow/factorial → 0",
-      "content": "$\\frac{|x|^n}{n!} \\to 0$ for any $x \\in \\mathbb{R}$. This is the fundamental asymptotic: factorials grow faster than any geometric sequence. Derived from Mathlib's `summable_pow_div_factorial` — if a series converges, its terms tend to 0.",
-      "significance": "supporting"
-    },
-    {
-      "lineStart": 151,
-      "lineEnd": 157,
-      "type": "theorem",
-      "label": "C·remainder → 0",
-      "content": "$C \\cdot \\frac{|x|^{n+1}}{n!} = C|x| \\cdot \\frac{|x|^n}{n!} \\to 0$. A constant times a null sequence is null. The `ring` tactic handles the algebraic rearrangement.",
-      "significance": "supporting"
-    },
-    {
-      "lineStart": 159,
-      "lineEnd": 167,
-      "type": "theorem",
-      "label": "Remainder → 0",
-      "content": "$f(x) - T_n^f(x) \\to 0$ by the squeeze theorem: $\\|f(x) - T_n^f(x)\\| \\leq C|x|^{n+1}/n! \\to 0$. The `squeeze_zero_norm'` tactic does the heavy lifting — it requires an upper bound that tends to 0.",
-      "significance": "key"
-    },
-    {
-      "lineStart": 169,
-      "lineEnd": 183,
-      "type": "theorem",
-      "label": "Main Convergence Theorem",
-      "content": "**MAIN RESULT**: $T_n^f(x) \\to f(x)$ for all $x$. Proof: from $f(x) - T_n^f(x) \\to 0$, subtract from $f(x)$: $f(x) - (f(x) - T_n^f(x)) = T_n^f(x) \\to f(x) - 0 = f(x)$. This is the same algebraic manipulation used in the parent proof for sinPartialSum_tendsto.",
-      "significance": "core"
-    },
-    {
-      "lineStart": 189,
-      "lineEnd": 196,
-      "type": "theorem",
-      "label": "T_n(0) = f(0)",
-      "content": "The Taylor polynomial at 0 evaluated at 0 returns $f(0)$: all terms with $k \\geq 1$ contain $0^k = 0$. The $k = 0$ term is $f^{(0)}(0) \\cdot 0^0/0! = f(0) \\cdot 1/1 = f(0)$. Uses `Finset.sum_eq_single` to isolate the $k = 0$ term.",
-      "significance": "supporting"
-    },
-    {
-      "lineStart": 204,
-      "lineEnd": 228,
-      "type": "theorem",
-      "label": "Sin/Cos as instances",
-      "content": "**Instantiation**: $\\sin$ and $\\cos$ satisfy the hypotheses with $C = 1$ (ContDiff and derivative bound from the parent proof). Therefore `taylorPartialSum_tendsto` applied with $C = 1$ recovers the parent's `sinPartialSum_tendsto` and `cosPartialSum_tendsto`. This demonstrates the general theorem truly generalizes the specific results.",
-      "significance": "core"
-    },
-    {
-      "lineStart": 234,
-      "lineEnd": 248,
-      "type": "theorem",
-      "label": "Optimality of C = 1",
-      "content": "For $C > 1$ and $x \\neq 0$: $\\frac{|x|^{n+1}}{n!} < \\frac{C|x|^{n+1}}{n!}$. This means $\\sin$ and $\\cos$ achieve the tightest possible remainder bound in this framework — no non-constant function can do better. The proof uses positivity of $|x|^{n+1}$ and the inequality $1 < C$.",
-      "significance": "supporting"
-    }
-  ]
-}
+[
+  {
+    "id": "ann-taylor-general-def",
+    "proofId": "taylor-sincos-convergence-oq-04",
+    "range": { "startLine": 57, "endLine": 74 },
+    "type": "definition",
+    "title": "General Taylor Partial Sum and Agreement with Sin/Cos",
+    "content": "`taylorPartialSum f n x` defines the n-th Taylor polynomial of any function f at 0, evaluated at x. The two follow-on theorems `taylorPartialSum_sin_eq` and `taylorPartialSum_cos_eq` show it agrees definitionally (`rfl`) with the parent proof's `sinPartialSum` and `cosPartialSum`. Since the proofs are `rfl`, no rewriting is needed — the definitions are literally the same expression.",
+    "mathContext": "$T_n^f(x) = \\sum_{k=0}^{n} \\frac{f^{(k)}(0)}{k!} x^k$. For $f = \\sin$: $T_n^{\\sin}(x) = \\sum_{k=0}^{n} \\frac{\\sin^{(k)}(0)}{k!} x^k = \\text{sinPartialSum}(n, x)$.",
+    "significance": "key",
+    "relatedConcepts": ["Taylor polynomials", "iteratedDeriv", "generalization principle", "noncomputable definitions"],
+    "prerequisites": ["iterated derivatives in Lean", "Finset.sum", "parent proof TaylorSinCosConvergence"]
+  },
+  {
+    "id": "ann-mathlib-bridge",
+    "proofId": "taylor-sincos-convergence-oq-04",
+    "range": { "startLine": 76, "endLine": 98 },
+    "type": "technique",
+    "title": "Bridging to Mathlib: iteratedDerivWithin = iteratedDeriv on UniqueDiffOn Sets",
+    "content": "Mathlib's `taylor_mean_remainder_bound` uses `taylorWithinEval` which is defined via `iteratedDerivWithin` (restricted derivatives). Our definition uses `iteratedDeriv` (global derivatives). The lemma `iteratedDerivWithin_eq_of_contDiff` bridges the two: for $C^\\infty$ functions on a set with the unique differentiation property, they agree.\n\n`taylorPartialSum_eq_taylorWithinEval` instantiates this bridge for $x > 0$ using `Icc 0 x`, which satisfies `uniqueDiffOn_Icc hx`. The term-by-term comparison uses `Finset.sum_congr` and `smul_eq_mul` to reconcile Mathlib's multiplication convention (smul for reals) with our multiplication.",
+    "mathContext": "For $x > 0$ and $f \\in C^\\infty(\\mathbb{R})$: $T_n^f(x) = \\text{taylorWithinEval}(f, n, [0,x], 0, x)$. The set $[0,x]$ is required to be non-degenerate ($x > 0$) for `uniqueDiffOn_Icc`.",
+    "significance": "supporting",
+    "relatedConcepts": ["iteratedDerivWithin", "UniqueDiffOn", "taylorWithinEval", "Icc set"],
+    "prerequisites": ["ContDiff in Lean", "unique differentiation property", "Mathlib Analysis.Calculus.Taylor"]
+  },
+  {
+    "id": "ann-remainder-bound-pos",
+    "proofId": "taylor-sincos-convergence-oq-04",
+    "range": { "startLine": 100, "endLine": 122 },
+    "type": "technique",
+    "title": "Remainder Bound for x > 0: Applying taylor_mean_remainder_bound",
+    "content": "`remainder_bound_pos` proves $\\|f(x) - T_n^f(x)\\| \\le C \\cdot x^{n+1}/n!$ for $x > 0$ by a two-step `calc`: first rewrite using the bridge theorem, then apply Mathlib's `taylor_mean_remainder_bound`. The latter requires a pointwise derivative bound in `iteratedDerivWithin`, which we supply by composing with `iteratedDerivWithin_eq_of_contDiff` and the hypothesis `hbound`. The final `ring` step simplifies `(x - 0)^{n+1}` to `x^{n+1}`.",
+    "mathContext": "$\\|f(x) - T_n^f(x)\\| \\le C \\cdot (x-0)^{n+1}/n! = C \\cdot x^{n+1}/n!$ for $x > 0$, using the Lagrange form of the Taylor remainder.",
+    "significance": "key",
+    "relatedConcepts": ["Lagrange remainder", "taylor_mean_remainder_bound", "ContDiffOn", "calc tactic"],
+    "prerequisites": ["taylorPartialSum_eq_taylorWithinEval", "Mathlib.Analysis.Calculus.Taylor"]
+  },
+  {
+    "id": "ann-general-remainder-bound",
+    "proofId": "taylor-sincos-convergence-oq-04",
+    "range": { "startLine": 124, "endLine": 162 },
+    "type": "insight",
+    "title": "General Remainder Bound: Fully Proved via Reflection (0 Axioms)",
+    "content": "`general_taylor_remainder_bound` extends the remainder bound to all $x \\in \\mathbb{R}$ using case analysis via `lt_trichotomy`:\n\n- **x > 0**: Direct application of `remainder_bound_pos`.\n- **x = 0**: Trivial since $T_n^f(0) = f(0)$ (using `taylorPartialSum_at_zero`).\n- **x < 0**: The reflection $g(t) = f(-t)$ satisfies $g \\in C^\\infty$ and $\\|g^{(n)}(y)\\| = |(-1)^n| \\cdot \\|f^{(n)}(-y)\\| = \\|f^{(n)}(-y)\\| \\le C$ by `iteratedDeriv_comp_neg`. Apply `remainder_bound_pos` to $g$ at $-x > 0$, then use `hgx : g(-x) = f(x)` and `hts : taylorPartialSum g n (-x) = taylorPartialSum f n x` (via $(-1)^k(-x)^k = x^k$).\n\nThis theorem is **fully proved** in the current version (0 axioms). An earlier version axiomatized the $x < 0$ case pending `iteratedDeriv_comp_neg`.",
+    "mathContext": "$\\|f(x) - T_n^f(x)\\| \\le C \\cdot |x|^{n+1}/n!$ for all $x \\in \\mathbb{R}$. The key identity: $(\\!-1)^k \\cdot (-x)^k = x^k$ makes the Taylor sum symmetric under $x \\mapsto -x$ modulo the reflection.",
+    "significance": "key",
+    "relatedConcepts": ["iteratedDeriv_comp_neg", "reflection principle", "absolute value", "lt_trichotomy"],
+    "prerequisites": ["remainder_bound_pos", "taylorPartialSum_at_zero", "Mathlib.Analysis.Calculus.IteratedDeriv.Lemmas"]
+  },
+  {
+    "id": "ann-convergence-squeeze",
+    "proofId": "taylor-sincos-convergence-oq-04",
+    "range": { "startLine": 164, "endLine": 212 },
+    "type": "technique",
+    "title": "Convergence via Squeeze: |x|^n/n! → 0 and Main Theorem",
+    "content": "The convergence argument has three steps:\n\n1. **`pow_div_factorial_tendsto`**: $|x|^n/n! \\to 0$ follows from Mathlib's `summable_pow_div_factorial` (if $\\sum |x|^n/n!$ converges, its terms go to 0). The `.congr` adjusts the `‖x‖` vs `|x|` convention.\n\n2. **`C_remainder_tendsto`**: $C|x|^{n+1}/n! = C|x| \\cdot |x|^n/n! \\to 0$ by `const_mul` applied to the previous limit.\n\n3. **`taylor_remainder_tendsto`**: $f(x) - T_n^f(x) \\to 0$ by `squeeze_zero_norm'` with the remainder bound as the squeezing function.\n\n4. **`taylorPartialSum_tendsto`**: From $f(x) - T_n^f(x) \\to 0$, deduce $T_n^f(x) = f(x) - (f(x) - T_n^f(x)) \\to f(x) - 0 = f(x)$ using `const_sub`.",
+    "mathContext": "$\\frac{|x|^n}{n!} \\to 0 \\implies C \\cdot \\frac{|x|^{n+1}}{n!} \\to 0 \\implies \\|f(x) - T_n^f(x)\\| \\to 0 \\implies T_n^f(x) \\to f(x)$.",
+    "significance": "key",
+    "relatedConcepts": ["squeeze theorem", "squeeze_zero_norm'", "summable_pow_div_factorial", "const_sub filter tendsto"],
+    "prerequisites": ["general_taylor_remainder_bound", "C_remainder_tendsto", "Filter.Tendsto in Mathlib"]
+  },
+  {
+    "id": "ann-value-at-zero",
+    "proofId": "taylor-sincos-convergence-oq-04",
+    "range": { "startLine": 214, "endLine": 225 },
+    "type": "technique",
+    "title": "Taylor Polynomial at Zero: T_n(0) = f(0)",
+    "content": "`taylorPartialSum_at_zero` proves $T_n^f(0) = f(0)$ by isolating the $k=0$ term using `Finset.sum_eq_single`. All terms with $k \\ge 1$ contain $0^k = 0$ (proved by `zero_pow hk` where `hk : k ≠ 0`), so only the $k=0$ term survives: $f^{(0)}(0) \\cdot 0^0/0! = f(0) \\cdot 1/1 = f(0)$. The `iteratedDeriv_zero` lemma confirms $f^{(0)} = f$.",
+    "mathContext": "$T_n^f(0) = \\sum_{k=0}^{n} \\frac{f^{(k)}(0)}{k!} 0^k = \\frac{f(0)}{0!} 0^0 = f(0)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Finset.sum_eq_single", "zero_pow", "iteratedDeriv_zero"],
+    "prerequisites": ["taylorPartialSum definition", "Finset.sum manipulation in Lean"]
+  },
+  {
+    "id": "ann-sin-cos-instances",
+    "proofId": "taylor-sincos-convergence-oq-04",
+    "range": { "startLine": 227, "endLine": 251 },
+    "type": "concept",
+    "title": "Sin and Cos as Optimal Instances (C = 1)",
+    "content": "The general theorem is instantiated for sin and cos with bound $C = 1$. The derivative bounds `sin_deriv_bound` and `cos_deriv_bound` are thin wrappers over the parent proof's `norm_iteratedDeriv_sin_le` and `norm_iteratedDeriv_cos_le`, which prove $\\|\\sin^{(n)}(x)\\| \\le 1$ using the period-4 structure of sin derivatives.\n\n`sin_taylorPartialSum_tendsto` and `cos_taylorPartialSum_tendsto` recover the parent's results as one-line applications of `taylorPartialSum_tendsto` with explicit parameters. This demonstrates the general theorem truly subsumes the specific cases — no new proof work needed.",
+    "mathContext": "$\\|\\sin^{(n)}(x)\\| \\le 1$ and $\\|\\cos^{(n)}(x)\\| \\le 1$ for all $n, x$ $\\implies$ $T_n^{\\sin}(x) \\to \\sin(x)$ and $T_n^{\\cos}(x) \\to \\cos(x)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["ContDiff_sin", "ContDiff_cos", "norm_iteratedDeriv_sin_le", "instance specialization"],
+    "prerequisites": ["parent proof TaylorSinCosConvergence", "taylorPartialSum_tendsto"]
+  },
+  {
+    "id": "ann-remainder-optimality",
+    "proofId": "taylor-sincos-convergence-oq-04",
+    "range": { "startLine": 253, "endLine": 275 },
+    "type": "insight",
+    "title": "Optimality of C = 1: Sin/Cos Achieve the Tightest Bound",
+    "content": "`unit_bound_optimal` proves that for $C > 1$ and $x \\ne 0$, the remainder $C|x|^{n+1}/n!$ strictly exceeds the $C=1$ bound $|x|^{n+1}/n!$. The proof uses `div_lt_div_of_pos_right` and `mul_lt_mul_of_pos_right`. Together with `smaller_bound_tighter` (monotonicity: smaller $C$ gives smaller bound), this establishes that sin and cos, with $C = 1$, occupy the minimum-bound position in the framework.",
+    "mathContext": "For $C > 1$, $x \\ne 0$: $\\frac{|x|^{n+1}}{n!} < \\frac{C|x|^{n+1}}{n!}$. Monotonicity: $C_1 \\le C_2 \\implies \\frac{C_1|x|^{n+1}}{n!} \\le \\frac{C_2|x|^{n+1}}{n!}$.",
+    "significance": "supporting",
+    "relatedConcepts": ["optimality in approximation theory", "div_lt_div", "Bernstein's theorem"],
+    "prerequisites": ["abs_pos", "pow_pos", "general_taylor_remainder_bound"]
+  },
+  {
+    "id": "ann-linear-combo-bound",
+    "proofId": "taylor-sincos-convergence-oq-04",
+    "range": { "startLine": 277, "endLine": 308 },
+    "type": "technique",
+    "title": "Section VIII: Derivative Bound for Linear Combinations a·sin + b·cos",
+    "content": "`linear_combo_bound` proves $\\|\\partial^n(a\\sin + b\\cos)(x)\\| \\le |a| + |b|$ using the linearity of `iteratedDeriv`. The proof rewrites $a\\sin + b\\cos = a \\cdot \\text{sin} + b \\cdot \\text{cos}$ as a sum of scalar multiples (using `smul_eq_mul`), then applies `iteratedDeriv_add` and `iteratedDeriv_const_smul` to decompose. A `calc` chain applies the triangle inequality, norm-of-product identity, and the individual bounds $\\|\\sin^{(n)}\\| \\le 1$, $\\|\\cos^{(n)}\\| \\le 1$, followed by `gcongr` and `ring`.\n\nThis makes the general theorem immediately applicable to all trigonometric polynomials: any finite combination $\\sum_k (a_k \\sin + b_k \\cos)$ has derivative bound $\\sum_k (|a_k| + |b_k|)$.",
+    "mathContext": "$\\|\\partial^n(a\\sin + b\\cos)(x)\\| \\le |a| \\cdot \\|\\sin^{(n)}(x)\\| + |b| \\cdot \\|\\cos^{(n)}(x)\\| \\le |a| + |b|$. The triangle inequality: $\\|u + v\\| \\le \\|u\\| + \\|v\\|$.",
+    "significance": "supporting",
+    "relatedConcepts": ["iteratedDeriv_add", "iteratedDeriv_const_smul", "norm_add_le", "trigonometric polynomials", "Bernstein's theorem"],
+    "prerequisites": ["sin_deriv_bound", "cos_deriv_bound", "ContDiffAt.const_smul"]
+  }
+]

--- a/src/data/proofs/taylor-sincos-convergence-oq-04/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-04/meta.json
@@ -122,10 +122,18 @@
     {
       "id": "remainder-comparison",
       "title": "Section VII: Remainder Comparison",
-      "startLine": 230,
-      "endLine": 252,
+      "startLine": 253,
+      "endLine": 275,
       "summary": "Proves C = 1 gives the tightest possible remainder in this framework: for C > 1 the bound is strictly larger. Shows smaller C gives tighter bounds (monotonicity).",
       "mathContext": "For $x \\neq 0$ and $C > 1$: $\\frac{|x|^{n+1}}{n!} < \\frac{C \\cdot |x|^{n+1}}{n!}$."
+    },
+    {
+      "id": "linear-combinations",
+      "title": "Section VIII: Linear Combinations",
+      "startLine": 277,
+      "endLine": 309,
+      "summary": "Proves that any linear combination a·sin + b·cos has all derivatives bounded by |a| + |b|, extending the framework to all trigonometric polynomials. Uses iteratedDeriv_add and iteratedDeriv_const_smul to decompose the derivative.",
+      "mathContext": "$\\|\\partial^n(a\\sin + b\\cos)(x)\\| \\le |a| + |b|$ via the triangle inequality and the bounds $\\|\\sin^{(n)}\\|, \\|\\cos^{(n)}\\| \\le 1$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for two proofs.

## erdos-130-wip-01: Anning–Erdős Finiteness Bound

**annotations.json (new)** — 9 annotations covering all 7 proof parts with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`. Includes header/imports, x-coord rationality, triangle-inequality bound, y-linearity, scale identity, quadratic constraint, count, algebraic core summary, and finiteness corollary.

**meta.json** — Fixed `count` section line range (168–195 → 146–163), added `algebraic-core` (Part VI, 165–189) and `finiteness` (Part VII, 191–201) sections.

## taylor-sincos-convergence-oq-04: Taylor Convergence for Bounded Derivatives

**annotations.json (rewritten)** — Converted from non-standard `{"annotations": [...]}` wrapper format to required top-level array. Added `id`, `proofId`, `range`, `mathContext`, `relatedConcepts`, `prerequisites` to all 8 annotations. Fixed all line numbers to match the current Lean source.

Key fix: previous annotation marked `general_taylor_remainder_bound` as an `axiom`, but the current Lean file fully proves it via `iteratedDeriv_comp_neg` (0 axioms). Annotation updated to reflect this.

**New annotation** for Section VIII (`linear_combo_bound`, lines 277–308) which was missing from the original annotations.

**meta.json** — Added Section VIII (linear combinations, lines 277–309); corrected Section VII line range from 230–252 to 253–275.

## Axiom integrity
- erdos-130-wip-01: 0 axioms confirmed, `status: "verified"` correct.
- taylor-sincos-convergence-oq-04: 0 local axioms. Header notes "+2 inherited from parent TaylorSinCosConvergence.lean" — these are parent-file axioms not declared in this file.