### PR TITLE
Fix: erdos-109-oq-01 recount — 3 sorries, 1 axiom (upperDensity_shift converted from axiom to sorry)

### DIFF
--- a/src/data/proofs/erdos-109-oq-01/meta.json
+++ b/src/data/proofs/erdos-109-oq-01/meta.json
@@ -17,10 +17,10 @@
       "ip-sets"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "dateAdded": "2026-04-12",
-    "axiomCount": 2,
-    "assumptions": "2 axioms: (1) upperDensity_shift — shift invariance of upper density (standard result, limsup boundary argument); (2) hindman_theorem — every finite coloring of N has a monochromatic IP set (Hindman 1974, deep Ramsey theory). 2 sorries: posUpperDensity_piecewiseSyndetic and posUpperDensity_ipStar (both require ergodic theory).",
+    "axiomCount": 1,
+    "assumptions": "1 axiom: hindman_theorem — every finite coloring of N has a monochromatic IP set (Hindman 1974). 3 sorries: posUpperDensity_piecewiseSyndetic (positive density → piecewise syndetic, requires pigeonhole), upperDensity_shift (shift invariance of upper density, requires Filter.limsup API), posUpperDensity_ipStar (positive density → IP*, requires Furstenberg-Katznelson).",
     "lineCount": 406,
     "theoremCount": 7,
     "definitionCount": 10,
@@ -97,11 +97,11 @@
   "leanFile": {
     "namespace": "Erdos109OQ01",
     "lineCount": 406,
-    "axiomCount": 2,
+    "axiomCount": 1,
     "theoremCount": 7,
     "definitionCount": 10,
     "path": "Proofs/Erdos109OQ01.lean",
-    "sorries": 2
+    "sorries": 3
   },
   "crossReferences": [
     {
@@ -110,5 +110,5 @@
       "description": "Explores gap conditions for the sumset conjecture proved by MRR (2019)"
     }
   ],
-  "sorries": 2
+  "sorries": 3
 }


### PR DESCRIPTION
## Summary

- `upperDensity_shift` was converted from an `axiom` declaration to a `lemma ... := by sorry` in `Proofs/Erdos109OQ01.lean`
- This reduces axiomCount from 2 to 1 (only `hindman_theorem` remains as a true axiom)
- This raises sorryCount from 2 to 3 (`posUpperDensity_piecewiseSyndetic`, `upperDensity_shift`, `posUpperDensity_ipStar`)
- Updated `meta.json` fields: `meta.sorries`, `meta.axiomCount`, `meta.assumptions`, `leanFile.sorries`, `leanFile.axiomCount`, and top-level `sorries`
- Status (`axiomatized`) and badge (`axiom`) unchanged — the proof still has a genuine axiom (`hindman_theorem`)

## Test plan

- [ ] Verify `proofs/Proofs/Erdos109OQ01.lean` on main has exactly 1 axiom (`hindman_theorem` at line ~181) and 3 sorries (lines 70, 125, 198)
- [ ] Confirm `meta.json` now matches: `sorries=3`, `axiomCount=1`
- [ ] Confirm `status` and `badge` remain `axiomatized` / `axiom`

🤖 Generated with [Claude Code](https://claude.com/claude-code)