### PR TITLE
Fix: erdos-109-oq-01 sorry count corrected (2→3)

### DIFF
--- a/src/data/proofs/erdos-109-oq-01/meta.json
+++ b/src/data/proofs/erdos-109-oq-01/meta.json
@@ -17,10 +17,10 @@
       "ip-sets"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 3,
     "dateAdded": "2026-04-12",
     "axiomCount": 2,
-    "assumptions": "2 axioms: (1) upperDensity_shift — shift invariance of upper density (standard result, limsup boundary argument); (2) hindman_theorem — every finite coloring of N has a monochromatic IP set (Hindman 1974, deep Ramsey theory). 2 sorries: posUpperDensity_piecewiseSyndetic and posUpperDensity_ipStar (both require ergodic theory).",
+    "assumptions": "1 axiom: hindman_theorem — every finite coloring of N has a monochromatic IP set (Hindman 1974, deep Ramsey theory). 3 sorries: (1) posUpperDensity_piecewiseSyndetic (positive density → piecewise syndetic, requires ergodic theory); (2) upperDensity_shift (shift invariance of upper density, standard limsup argument); (3) posUpperDensity_ipStar (positive density → IP*, requires IP Szemerédi theorem).",
     "lineCount": 406,
     "theoremCount": 7,
     "definitionCount": 10,
@@ -101,7 +101,7 @@
     "theoremCount": 7,
     "definitionCount": 10,
     "path": "Proofs/Erdos109OQ01.lean",
-    "sorries": 2
+    "sorries": 3
   },
   "crossReferences": [
     {
@@ -110,5 +110,5 @@
       "description": "Explores gap conditions for the sumset conjecture proved by MRR (2019)"
     }
   ],
-  "sorries": 2
+  "sorries": 3
 }


### PR DESCRIPTION
## Fix

The `sorries` field in `meta.json` was 2, but the Lean source file contains 3 actual `sorry` instances.

## Evidence

**Before**: `"sorries": 2` in meta.json

**After**: `"sorries": 3` (matches Lean file)

The three sorry instances in `proofs/Proofs/Erdos109OQ01.lean`:
1. `posUpperDensity_piecewiseSyndetic` (line 70) — positive density → piecewise syndetic
2. `upperDensity_shift` (line 125) — shift invariance of upper density
3. `posUpperDensity_ipStar` (line 198) — positive density → IP*

The file's own bottom comment confirms: `## Sorries: 3 (density→PS, shift invariance, density→IP*)`.

The `assumptions` text was also updated to accurately list all 3 sorries and clarify the single axiom declaration. `axiomCount` is unchanged at 2 (as set by #10612).

---
Automated fix by lean-mechanic agent.