### PR TITLE
Fix: shapley-folkman sorry count corrected (1→3) + lineCount synced

### DIFF
--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -16,7 +16,7 @@
       "intermediate"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 3,
     "mathlibDependencies": [
       {
         "theorem": "convexHull_eq_union",
@@ -61,7 +61,7 @@
       "Caratheodory's theorem (points in convex hull need at most d+1 vertices)",
       "Affine independence and dimension"
     ],
-    "lineCount": 490,
+    "lineCount": 629,
     "mathlib_version": "4.26.0",
     "leanFile": {
       "imports": [
@@ -79,7 +79,7 @@
         "Pointwise"
       ],
       "namespace": "ShapleyFolkman",
-      "lineCount": 490,
+      "lineCount": 629,
       "axiomCount": 0,
       "theoremCount": 6,
       "definitionCount": 2
@@ -201,7 +201,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 490,
+    "lineCount": 629,
     "structureCount": 1,
     "axiomCount": 0,
     "theoremCount": 8,
@@ -242,7 +242,7 @@
       }
     ],
     "path": "Proofs/ShapleyFolkman.lean",
-    "sorries": 1
+    "sorries": 3
   },
   "mainTheorems": [
     {
@@ -252,5 +252,5 @@
       "leanType": "Decomposition S t x -> d.excessIndices.card <= Module.finrank R E"
     }
   ],
-  "sorries": 1
+  "sorries": 3
 }


### PR DESCRIPTION
## Fix

Corrects the sorry count and lineCount metadata for `shapley-folkman`.

## Evidence

**Before**:
- `sorries: 1` (in meta, leanFile, and top-level) — incorrect
- `lineCount: 490` (all locations) — stale

**After**:
- `sorries: 3` — matches actual 3 `sorry` statements in `proofs/Proofs/ShapleyFolkman.lean` (lines 483, 511, 520)
- `lineCount: 629` — matches actual line count

The `badge: "wip"` and `status: "formalized"` are already correct for a proof with remaining sorries and no axioms.

---
Automated fix by lean-mechanic agent. Closes auditor finding: `shapley-folkman` sorry mismatch (claims 1, actual 3).