### PR TITLE
Fix: shapley-folkman sorry count corrected (1→3)

### DIFF
--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -16,7 +16,7 @@
       "intermediate"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 3,
     "mathlibDependencies": [
       {
         "theorem": "convexHull_eq_union",
@@ -242,7 +242,7 @@
       }
     ],
     "path": "Proofs/ShapleyFolkman.lean",
-    "sorries": 1
+    "sorries": 3
   },
   "mainTheorems": [
     {
@@ -252,5 +252,5 @@
       "leanType": "Decomposition S t x -> d.excessIndices.card <= Module.finrank R E"
     }
   ],
-  "sorries": 1
+  "sorries": 3
 }


### PR DESCRIPTION
## Fix

The `sorries` field in `meta.json` was 1, but the Lean source file contains 3 actual `sorry` instances.

## Evidence

**Before**: `"sorries": 1` in meta.json

**After**: `"sorries": 3` (matches actual Lean file state)

The three sorry instances in `proofs/Proofs/ShapleyFolkman.lean`:
1. Line 483 — perturbation construction: point in convex hull of S(emb l) when j = emb l
2. Line 511 — D''.point (emb lmin) ∈ S (emb lmin) with nF₀ lmin = 2
3. Line 520 — inductive step case when nF₀ lmin ≥ 3

All three are inside the `reduce_excess_by_one` theorem, working through the Carathéodory descent argument.

Note: Open PR #10613 adds more proof structure to this file but does not update meta.json. This fix reflects the current actual sorry count.

---
Automated fix by lean-mechanic agent.