### PR TITLE
Research: BSD oq-03 — prove one_not_congruent as theorem (19→18 axioms)

### DIFF
--- a/proofs/Proofs/BirchSwinnertonDyer.lean
+++ b/proofs/Proofs/BirchSwinnertonDyer.lean
@@ -121,6 +121,16 @@ structure EllipticCurveQ where
   /-- The discriminant is nonzero (curve is smooth) -/
   discriminant_ne_zero : 4 * a^3 + 27 * b^2 ≠ 0
 
+/-- Extensionality for EllipticCurveQ: two curves are equal iff their coefficients agree.
+    The proof field is in Prop, so proof irrelevance handles it automatically. -/
+theorem EllipticCurveQ.ext {E1 E2 : EllipticCurveQ}
+    (ha : E1.a = E2.a) (hb : E1.b = E2.b) : E1 = E2 := by
+  obtain ⟨a1, b1, h1⟩ := E1
+  obtain ⟨a2, b2, h2⟩ := E2
+  simp only [EllipticCurveQ.a, EllipticCurveQ.b] at ha hb
+  subst ha; subst hb
+  exact congrArg (EllipticCurveQ.mk a1 b1) (proofIrrel h1 h2)
+
 /-- The discriminant Δ = -16(4a³ + 27b²) of an elliptic curve -/
 def discriminant (E : EllipticCurveQ) : ℚ :=
   -16 * (4 * E.a^3 + 27 * E.b^2)
@@ -842,11 +852,24 @@ Certain cases of the congruent number problem have been known for centuries.
 
     The smallest triangle has sides 35/12, 24/5, 337/60. -/
 
+/-- Helper: curveMinusX (y² = x³ - x) equals congruentNumberCurve 1 (y² = x³ - 1²·x).
+    Both have a = -1, b = 0 in short Weierstrass form. -/
+theorem curveMinusX_eq_congruent_one :
+    curveMinusX = congruentNumberCurve 1 (by norm_num) := by
+  apply EllipticCurveQ.ext
+  · simp [curveMinusX, congruentNumberCurve]; norm_num
+  · simp [curveMinusX, congruentNumberCurve]
+
 /-- 1 is NOT a congruent number (proved by Fermat using infinite descent).
 
-    This was one of Fermat's greatest achievements.
-    By BSD, rank(E₁) = 0 and L(E₁, 1) ≠ 0. -/
-axiom one_not_congruent : algebraicRank (congruentNumberCurve 1 (by norm_num)) = 0
+    This was one of Fermat's greatest achievements. Proved here from BSD:
+    curveMinusX = congruentNumberCurve 1, and curveMinusX_L_nonzero + BSD_rank_zero_axiom
+    give algebraicRank curveMinusX = 0. Converts axiom → theorem, reducing axiom count.
+
+    **AXIOM ELIMINATED**: previously `axiom one_not_congruent`. Now a theorem. -/
+theorem one_not_congruent : algebraicRank (congruentNumberCurve 1 (by norm_num)) = 0 := by
+  rw [← curveMinusX_eq_congruent_one]
+  exact (BSD_rank_zero_axiom curveMinusX curveMinusX_L_nonzero).1
 
 /-- 2 is NOT a congruent number (also proved by Fermat).
 

--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -2,7 +2,7 @@
   "id": "birch-swinnerton-dyer",
   "title": "Birch and Swinnerton-Dyer Conjecture",
   "slug": "birch-swinnerton-dyer",
-  "description": "One of the seven Millennium Prize Problems ($1,000,000 Clay prize). The weak BSD conjecture states $\\text{rank}\\,E(\\mathbb{Q}) = \\text{ord}_{s=1} L(E,s)$, connecting the algebraic rank of an elliptic curve (from Mordell-Weil) with the analytic rank of its L-function. This 7422-line formalization in 70 parts covers the conjecture statement, proven cases (rank 0 via Kolyvagin, rank 1 via Gross-Zagier, CM via Coates-Wiles), Koblitz correspondence (fully proved in both directions), Selmer groups, Iwasawa theory, Tunnell's theorem, the Bloch-Kato generalization, modularity (Wiles-BCDT), arithmetic statistics (Bhargava-Shankar), and BSD verification for curves 37a and 389a.",
+  "description": "One of the seven Millennium Prize Problems ($1,000,000 Clay prize). The weak BSD conjecture states $\\text{rank}\\,E(\\mathbb{Q}) = \\text{ord}_{s=1} L(E,s)$, connecting the algebraic rank of an elliptic curve (from Mordell-Weil) with the analytic rank of its L-function. This 7432-line formalization in 70 parts covers the conjecture statement, proven cases (rank 0 via Kolyvagin, rank 1 via Gross-Zagier, CM via Coates-Wiles), Koblitz correspondence (fully proved in both directions), Selmer groups, Iwasawa theory, Tunnell's theorem, the Bloch-Kato generalization, modularity (Wiles-BCDT), arithmetic statistics (Bhargava-Shankar), and BSD verification for curves 37a and 389a.",
   "meta": {
     "author": "Birch & Swinnerton-Dyer (1965)",
     "date": "1965",
@@ -15,8 +15,8 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 19,
-    "assumptions": "19 axiom declarations encoding: (1) L-function analytic continuation and functional equation, (2) Hasse bound a_p^2 <= 4p, (3) BSD conjecture proven cases (Kolyvagin rank 0, Gross-Zagier+Kolyvagin rank 1), (4) parity conjecture (Dokchitsers), (5) L-values and ranks for specific curves, (6) Sha structure, (7) Elkies rank record, (8) Greenberg-Stevens theorem, (9) regulator positivity. Previously 21 axioms: BSD_CM_rank_zero was proved redundant (subsumed by Kolyvagin general result), gross_zagier_formula_detail was dead code (captured by GrossZagierData structure). 0 sorries: regulator_rank_one_is_height proved by constructing CanonicalHeight h with h.height x = R·x² and generator g = 1.",
+    "axiomCount": 18,
+    "assumptions": "18 axiom declarations encoding: (1) L-function analytic continuation and functional equation, (2) Hasse bound a_p^2 <= 4p, (3) BSD conjecture proven cases (Kolyvagin rank 0, Gross-Zagier+Kolyvagin rank 1), (4) parity conjecture (Dokchitsers), (5) L-values and ranks for specific curves, (6) Sha structure, (7) Elkies rank record, (8) Greenberg-Stevens theorem, (9) regulator positivity. Previously 21 axioms: BSD_CM_rank_zero proved redundant (subsumed by Kolyvagin general result), gross_zagier_formula_detail dead code, one_not_congruent proved as theorem from BSD_rank_zero_axiom + curveMinusX_L_nonzero (curveMinusX = congruentNumberCurve 1 by coefficient equality + EllipticCurveQ.ext). 0 sorries.",
     "mathlibDependencies": [
       {
         "theorem": "WeierstrassCurve",
@@ -50,10 +50,10 @@
       }
     ],
     "leanFile": {
-      "lineCount": 7430,
+      "lineCount": 7432,
       "structureCount": 92,
-      "axiomCount": 19,
-      "theoremCount": 251,
+      "axiomCount": 18,
+      "theoremCount": 253,
       "lemmaCount": 3,
       "defCount": 143,
       "imports": [
@@ -681,9 +681,9 @@
       "ComplexConjugate"
     ],
     "namespace": "BirchSwinnertonDyer",
-    "lineCount": 7409,
-    "axiomCount": 19,
-    "theoremCount": 250,
+    "lineCount": 7432,
+    "axiomCount": 18,
+    "theoremCount": 253,
     "definitionCount": 143,
     "path": "Proofs/BirchSwinnertonDyer.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

- **Problem**: birch-swinnerton-dyer-oq-03 (reduce BSD axiom count)
- **Change**: Convert `one_not_congruent` from axiom to theorem
- **Result**: Axiom count 19 → 18 (third reduction in this series: 21 → 20 → 19 → 18)
- **Build**: Verified with docker-build.sh (3085 jobs, no errors)

## Mathematical Content

The key insight: `curveMinusX` (y² = x³ - x, a = -1, b = 0) is definitionally the same
curve as `congruentNumberCurve 1` (a = -(1)² = -1, b = 0). Therefore:

```lean
theorem one_not_congruent : algebraicRank (congruentNumberCurve 1 (by norm_num)) = 0 := by
  rw [← curveMinusX_eq_congruent_one]
  exact (BSD_rank_zero_axiom curveMinusX curveMinusX_L_nonzero).1
```

This uses existing axioms `BSD_rank_zero_axiom` and `curveMinusX_L_nonzero` — no new
mathematical assumptions needed.

## Infrastructure Added

- `EllipticCurveQ.ext`: structural extensionality (a = a' ∧ b = b' → E = E'), proved via proof irrelevance for the `Prop`-valued `discriminant_ne_zero` field
- `curveMinusX_eq_congruent_one`: identity of the two curves

## Why two_not_congruent Remains an Axiom

No L-function non-vanishing axiom exists for `congruentNumberCurve 2` (a=-4, b=0).
Neither `curveJZero` nor `cremona11a1` match this curve. Would need a new axiom to prove it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)