### PR TITLE
Fix: erdos-109-oq-01 corrected (sorries 2→1, axiomCount 2→3)

### DIFF
--- a/src/data/proofs/erdos-109-oq-01/meta.json
+++ b/src/data/proofs/erdos-109-oq-01/meta.json
@@ -17,10 +17,10 @@
       "ip-sets"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 1,
     "dateAdded": "2026-04-12",
-    "axiomCount": 2,
-    "assumptions": "2 axioms: (1) upperDensity_shift — shift invariance of upper density (standard result, limsup boundary argument); (2) hindman_theorem — every finite coloring of N has a monochromatic IP set (Hindman 1974, deep Ramsey theory). 2 sorries: posUpperDensity_piecewiseSyndetic and posUpperDensity_ipStar (both require ergodic theory).",
+    "axiomCount": 3,
+    "assumptions": "3 axioms: (1) posUpperDensity_piecewiseSyndetic — positive density implies piecewise syndetic (standard result); (2) hindman_theorem — every finite coloring of N has a monochromatic IP set (Hindman 1974, deep Ramsey theory); (3) posUpperDensity_ipStar — positive density implies IP* (requires IP Szemerédi theorem). 1 sorry: upperDensity_shift (shift invariance of upper density, standard limsup argument).",
     "lineCount": 406,
     "theoremCount": 7,
     "definitionCount": 10,
@@ -97,11 +97,11 @@
   "leanFile": {
     "namespace": "Erdos109OQ01",
     "lineCount": 406,
-    "axiomCount": 2,
+    "axiomCount": 3,
     "theoremCount": 7,
     "definitionCount": 10,
     "path": "Proofs/Erdos109OQ01.lean",
-    "sorries": 2
+    "sorries": 1
   },
   "crossReferences": [
     {
@@ -110,5 +110,5 @@
       "description": "Explores gap conditions for the sumset conjecture proved by MRR (2019)"
     }
   ],
-  "sorries": 2
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

The Lean file `Erdos109OQ01.lean` was restructured in PR #10599, converting two `theorem ... := by sorry` into explicit `axiom` declarations. The `meta.json` was not updated to reflect these changes.

## Evidence

**Current Lean file state** (verified on `origin/main`):
- **3 axiom declarations**:
  1. `posUpperDensity_piecewiseSyndetic` (positive density → piecewise syndetic)
  2. `hindman_theorem` (Hindman 1974 — monochromatic IP set)
  3. `posUpperDensity_ipStar` (positive density → IP*, IP Szemerédi theorem)
- **1 sorry**: `upperDensity_shift` (shift invariance of upper density)

**Before**: `sorries: 2, axiomCount: 2`

**After**: `sorries: 1, axiomCount: 3`

Also updated the `assumptions` text to accurately describe all 3 axioms and the 1 remaining sorry.

Note: Supersedes PR #10623 which was filed against an older version where these were still sorry-theorems rather than axiom declarations.

---
Automated fix by lean-mechanic agent.