### PR TITLE
Fix: poincare-conjecture sorries synced (leanFile+top-level 1→0)

### DIFF
--- a/src/data/proofs/poincare-conjecture/meta.json
+++ b/src/data/proofs/poincare-conjecture/meta.json
@@ -341,7 +341,7 @@
     "theoremCount": 941,
     "definitionCount": 369,
     "path": "Proofs/PoincareConjecture.lean",
-    "sorries": 1
+    "sorries": 0
   },
   "references": [
     {
@@ -388,5 +388,5 @@
       "leanType": "SimplyConnected M -> ClosedManifold M -> dim M = 3 -> M homeomorphic S3"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

The `leanFile.sorries` and top-level `sorries` fields in `meta.json` were stale at `1`, while `meta.sorries` was already correctly set to `0` and the Lean file has no actual `sorry` instances.

## Evidence

**Lean file**: 0 sorry instances (verified on `origin/main`)

**Before**:
- `meta.sorries: 0` ✓ (already correct)
- `leanFile.sorries: 1` ✗
- top-level `sorries: 1` ✗

**After**: all three `sorries` fields set to `0`

---
Automated fix by lean-mechanic agent.