### PR TITLE
Fix: shapley-folkman sorry count corrected (3 sorries, not 1)

### DIFF
--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -16,7 +16,7 @@
       "intermediate"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 3,
     "mathlibDependencies": [
       {
         "theorem": "convexHull_eq_union",
@@ -61,7 +61,7 @@
       "Caratheodory's theorem (points in convex hull need at most d+1 vertices)",
       "Affine independence and dimension"
     ],
-    "lineCount": 490,
+    "lineCount": 629,
     "mathlib_version": "4.26.0",
     "leanFile": {
       "imports": [
@@ -79,7 +79,7 @@
         "Pointwise"
       ],
       "namespace": "ShapleyFolkman",
-      "lineCount": 490,
+      "lineCount": 629,
       "axiomCount": 0,
       "theoremCount": 6,
       "definitionCount": 2
@@ -201,7 +201,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 490,
+    "lineCount": 629,
     "structureCount": 1,
     "axiomCount": 0,
     "theoremCount": 8,
@@ -242,7 +242,7 @@
       }
     ],
     "path": "Proofs/ShapleyFolkman.lean",
-    "sorries": 1
+    "sorries": 3
   },
   "mainTheorems": [
     {
@@ -252,5 +252,5 @@
       "leanType": "Decomposition S t x -> d.excessIndices.card <= Module.finrank R E"
     }
   ],
-  "sorries": 1
+  "sorries": 3
 }


### PR DESCRIPTION
## Summary

- **Mismatch**: `meta.json` claimed `sorries: 1` and `lineCount: 490`, but the actual Lean source (`proofs/Proofs/ShapleyFolkman.lean`) has 3 sorries and 629 lines
- **Root cause**: Commit `25860e8ac1` added the `reduce_excess_by_one` theorem with 3 sorries (at lines 483, 511, 520) and grew the file to 629 lines, but `meta.json` was not updated at that time
- **Fix**: Updated all 6 affected fields in `src/data/proofs/shapley-folkman/meta.json` to reflect the actual state of the Lean source

### Fields corrected

| Field | Old | New |
|-------|-----|-----|
| `meta.sorries` | 1 | 3 |
| `meta.lineCount` | 490 | 629 |
| `meta.leanFile.lineCount` | 490 | 629 |
| `leanFile.lineCount` | 490 | 629 |
| `leanFile.sorries` | 1 | 3 |
| `sorries` (top-level) | 1 | 3 |

## Test plan

- [x] Verified `grep -n "sorry" proofs/Proofs/ShapleyFolkman.lean | wc -l` returns 3
- [x] Verified `wc -l proofs/Proofs/ShapleyFolkman.lean` returns 629
- [x] All 6 fields in meta.json updated consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)