### PR TITLE
Fix: descartes-rule-of-signs-oq-03 badge corrected (mathlib, not original)

### DIFF
--- a/src/data/proofs/descartes-rule-of-signs-oq-03/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-03/meta.json
@@ -15,7 +15,7 @@
       "cauchy-bound",
       "real-analysis"
     ],
-    "badge": "original",
+    "badge": "mathlib",
     "sorries": 0,
     "dateAdded": "2026-04-02",
     "axiomCount": 0,


### PR DESCRIPTION
## Summary

- Changes `"badge": "original"` to `"badge": "mathlib"` in `src/data/proofs/descartes-rule-of-signs-oq-03/meta.json`
- The entry's core results are direct Mathlib wrappers: `positive_root_count_bound` calls `p.roots_countP_pos_le_signVariations`, `all_roots_in_cauchy_interval` wraps `hr.norm_lt_cauchyBound`, and `descartes_upper_bound_via_mathlib` delegates to Mathlib directly
- The description text was already honest about Mathlib reliance ("via Mathlib's signVariations"), but the badge incorrectly claimed `original` (independent formalization)
- `status` remains `"verified"` — the proof has 0 sorries and 0 axioms; only the badge is corrected

## Test plan

- [ ] Confirm `meta.json` has `"badge": "mathlib"` and `"status": "verified"`
- [ ] Confirm no other fields were modified
- [ ] Verify gallery renders the corrected badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)