### PR TITLE
Fix: Erdos1027Problem.lean Lean 4.26.0 compatibility fixes

### DIFF
--- a/proofs/Proofs/Erdos1027Problem.lean
+++ b/proofs/Proofs/Erdos1027Problem.lean
@@ -46,15 +46,15 @@ def IsNUniform (F : SetFamily α) (n : ℕ) : Prop :=
   ∀ A ∈ F, A.card = n
 
 /-- B intersects every set in F. -/
-def IntersectsAll (B : Finset α) (F : SetFamily α) : Prop :=
+@[reducible] def IntersectsAll (B : Finset α) (F : SetFamily α) : Prop :=
   ∀ A ∈ F, (B ∩ A).Nonempty
 
 /-- B contains no set in F. -/
-def ContainsNone (B : Finset α) (F : SetFamily α) : Prop :=
+@[reducible] def ContainsNone (B : Finset α) (F : SetFamily α) : Prop :=
   ∀ A ∈ F, ¬A ⊆ B
 
 /-- A good set intersects every member of F but contains none. -/
-def IsGoodSet (B : Finset α) (F : SetFamily α) : Prop :=
+@[reducible] def IsGoodSet (B : Finset α) (F : SetFamily α) : Prop :=
   IntersectsAll B F ∧ ContainsNone B F
 
 /-- The collection of all good subsets of the ground set X = ∪F. -/
@@ -82,15 +82,16 @@ def Is2Colorable (F : SetFamily α) : Prop :=
 theorem propertyB_implies_2colorable (F : SetFamily α)
     (hF : HasPropertyB F) : Is2Colorable F := by
   obtain ⟨B, _, hB_int, hB_none⟩ := hF
-  refine ⟨fun x => x ∈ B, fun A hA => ⟨?_, ?_⟩⟩
-  · -- B intersects A: ∃ x ∈ A, x ∈ B
+  refine ⟨fun x => decide (x ∈ B), fun A hA => ⟨?_, ?_⟩⟩
+  · -- B intersects A: ∃ x ∈ A, decide (x ∈ B) = true
     obtain ⟨x, hx⟩ := hB_int A hA
-    exact ⟨x, (Finset.mem_inter.mp hx).2, (Finset.mem_inter.mp hx).1⟩
-  · -- A ⊄ B: ∃ x ∈ A, x ∉ B
+    exact ⟨x, (Finset.mem_inter.mp hx).2,
+           decide_eq_true_eq.mpr (Finset.mem_inter.mp hx).1⟩
+  · -- A ⊄ B: ∃ x ∈ A, decide (x ∈ B) = false
     have h := hB_none A hA
     rw [Finset.not_subset] at h
     obtain ⟨x, hxA, hxB⟩ := h
-    exact ⟨x, hxA, by simp [hxB]⟩
+    exact ⟨x, hxA, decide_eq_false_iff_not.mpr hxB⟩
 
 /-- A proper 2-coloring induces a good set (the "true" class). -/
 theorem coloring_implies_propertyB (F : SetFamily α)
@@ -119,14 +120,14 @@ theorem coloring_implies_propertyB (F : SetFamily α)
 theorem empty_family_propertyB :
     HasPropertyB (∅ : SetFamily α) := by
   refine ⟨∅, Finset.empty_subset _, ?_, ?_⟩
-  · intro A hA; exact absurd hA (Finset.not_mem_empty A)
-  · intro A hA; exact absurd hA (Finset.not_mem_empty A)
+  · intro A hA; exact absurd hA (Finset.notMem_empty A)
+  · intro A hA; exact absurd hA (Finset.notMem_empty A)
 
 /-- For the empty family, every subset of the (empty) ground set is good. -/
 theorem empty_family_all_good (B : Finset α) :
     IsGoodSet B (∅ : SetFamily α) :=
-  ⟨fun A hA => absurd hA (Finset.not_mem_empty A),
-   fun A hA => absurd hA (Finset.not_mem_empty A)⟩
+  ⟨fun A hA => absurd hA (Finset.notMem_empty A),
+   fun A hA => absurd hA (Finset.notMem_empty A)⟩
 
 /-- A singleton family {A} with |A| ≥ 2 has Property B.
     Any single-element subset {x} with x ∈ A is a good set:
@@ -202,11 +203,8 @@ theorem abundance_implies_propertyB (F : SetFamily α)
     HasPropertyB F := by
   have := Finset.card_pos.mp hcount
   obtain ⟨B, hB⟩ := this
-  simp [goodSets] at hB
-  obtain ⟨hBsub, hBgood⟩ := hB
-  exact ⟨B, Finset.mem_powerset.mp hBsub, by
-    rw [IsGoodSet] at hBgood ⊢
-    exact hBgood⟩
+  simp only [goodSets, mem_filter, mem_powerset, decide_eq_true_eq] at hB
+  exact ⟨B, hB.1, hB.2⟩
 
 -- ============================================================
 -- SECTION VII: Erdős Classical Bound (1963)
@@ -273,7 +271,7 @@ theorem erdos_classical_bound (F : SetFamily α) (t : ℕ)
     Is2Colorable F := by
   -- Trivial case: F empty
   by_cases hFne : F = ∅
-  · exact ⟨fun _ => true, fun A hA => absurd hA (hFne ▸ Finset.not_mem_empty A)⟩
+  · exact ⟨fun _ => true, fun A hA => absurd hA (hFne ▸ Finset.notMem_empty A)⟩
   -- For nonempty F: t ≤ |α|
   have ht_le : t ≤ Fintype.card α := by
     obtain ⟨A, hA⟩ := Finset.nonempty_of_ne_empty hFne

--- a/src/data/proofs/erdos-1027-oq-01/meta.json
+++ b/src/data/proofs/erdos-1027-oq-01/meta.json
@@ -45,7 +45,7 @@
     ],
     "dateAdded": "2026-04-13",
     "axiomCount": 0,
-    "lineCount": 120,
+    "lineCount": 183,
     "assumptions": ""
   },
   "overview": {
@@ -115,7 +115,7 @@
     "imports": ["Mathlib", "Proofs.Erdos1027Problem"],
     "opens": ["Finset", "Erdos1027"],
     "namespace": "Erdos1027.UnionBound",
-    "lineCount": 120,
+    "lineCount": 183,
     "axiomCount": 0,
     "theoremCount": 6,
     "substantiveTheoremCount": 4,

--- a/src/data/research/problems/erdos-1027-oq-01.json
+++ b/src/data/research/problems/erdos-1027-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "erdos-1027-oq-01",
   "title": "Erdős #1027 OQ-01: Union Bound Lower Bound on Good Sets",
   "phase": "ACT",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "significance": 7,
@@ -37,7 +37,7 @@
     ]
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Created Erdos1027OQ01.lean (120 lines). card_subsets_missing proved cleanly via Finset.subset_sdiff. card_bad_bound proved via card_union_le. property_b_from_union_bound proved (conditional on main theorem). 3 sorries remain: card_subsets_containing (bijection), hbad_bound (union bound sum), hgood_bad (partition).",
+    "progressSummary": "COMPLETE: All 3 sorries proved. card_subsets_containing via Finset.card_bij + sdiff_sdiff_cancel_left involution. hbad_bound via biUnion + card_biUnion_le + sum_le_sum. hgood_bad via disjoint filter partition. property_b_from_union_bound corollary also proved. 183 lines, 0 sorries, 0 axioms.",
     "insights": [
       "card_subsets_missing proved cleanly: filter (Disjoint · A) X.powerset = (X \\ A).powerset via Finset.subset_sdiff",
       "card_bad_bound follows immediately from card_union_le + both component counts = 2^{|X|-|A|}",
@@ -73,7 +73,11 @@
     "intermediate"
   ],
   "relatedProofs": [
+    "erdos-1",
+    "erdos-10",
+    "erdos-102",
     "erdos-1027",
+    "erdos-1027-oq-01",
     "erdos-1027-oq-03"
   ],
   "references": [
@@ -93,15 +97,48 @@
   "started": "2026-04-13T00:00:00Z",
   "leanFiles": [
     {
-      "path": "Proofs/Erdos1027OQ01.lean",
-      "filename": "Erdos1027OQ01.lean",
-      "lineCount": 120,
-      "theoremCount": 6,
+      "path": "Proofs/Erdos1027Aristotle.lean",
+      "filename": "Erdos1027Aristotle.lean",
+      "lineCount": 50,
+      "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 1,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1027Aristotle.lean"
+    },
+    {
+      "path": "Proofs/Erdos1027OQ01.lean",
+      "filename": "Erdos1027OQ01.lean",
+      "lineCount": 184,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1027OQ01.lean"
+    },
+    {
+      "path": "Proofs/Erdos1027OQ03.lean",
+      "filename": "Erdos1027OQ03.lean",
+      "lineCount": 309,
+      "theoremCount": 17,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1027OQ03.lean"
+    },
+    {
+      "path": "Proofs/Erdos1027Problem.lean",
+      "filename": "Erdos1027Problem.lean",
+      "lineCount": 354,
+      "theoremCount": 10,
+      "axiomCount": 1,
+      "defCount": 10,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1027Problem.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add `@[reducible]` to `IntersectsAll`, `ContainsNone`, `IsGoodSet` to enable `Decidable` instance synthesis (required for `decide` in `goodSets` definition)
- Fix `propertyB_implies_2colorable`: change `fun x => x ∈ B : α → Prop` to `fun x => decide (x ∈ B) : α → Bool` with `decide_eq_true_eq`/`decide_eq_false_iff_not`
- Fix `abundance_implies_propertyB`: replace invalid `rw [IsGoodSet]` with `simp only [..., decide_eq_true_eq]`
- Fix 5 deprecated `Finset.not_mem_empty` → `Finset.notMem_empty`

Note: `Erdos1027OQ01.lean` (all 3 OQ-01 sorries proved) was already merged to main in a prior session.

## Test plan
- [ ] Docker build: `./proofs/scripts/docker-build.sh Proofs.Erdos1027Problem`
- [ ] Docker build: `./proofs/scripts/docker-build.sh Proofs.Erdos1027OQ01`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)