### PR TITLE
Research: perfect-numbers-oq-03 — prove necessity + factor congruence (0 sorries)

### DIFF
--- a/proofs/Proofs/PerfectNumbersOQ03.lean
+++ b/proofs/Proofs/PerfectNumbersOQ03.lean
@@ -80,23 +80,38 @@ lemma mersenne_dvd_of_dvd {a b : ℕ} (h : a ∣ b) : M a ∣ M b := by
 /-- **Mersenne prime necessity**: If 2^n - 1 is prime, then n is prime.
     Proof: If n = a * b with 1 < a, b < n, then M(a) | M(n) and 1 < M(a) < M(n),
     so M(n) is composite. -/
-theorem mersenne_prime_exp_prime {n : ℕ} (h : Nat.Prime (M n)) : Nat.Prime n := by
-  rcases Nat.eq_one_or_self_of_prime_of_dvd with _
-  -- Use contrapositive: if n is not prime and n > 1, then M(n) is not prime
+theorem mersenne_prime_exp_prime {n : ℕ} (hM : Nat.Prime (M n)) : Nat.Prime n := by
   by_contra hn
-  -- If n = 0: M(0) = 0, not prime
-  by_cases hn0 : n = 0
-  · simp [M, hn0] at h
-  -- If n = 1: M(1) = 1, not prime
-  by_cases hn1 : n = 1
-  · simp [M, hn1] at h
-  -- Otherwise n > 1 and not prime, so has a composite factor 1 < a < n
-  have hn2 : 2 ≤ n := by omega
-  have : ¬ Nat.Prime n := hn
-  obtain ⟨a, han, ha1, han2⟩ := Nat.exists_prime_and_dvd (by omega : n ≠ 1) |>.imp_left (fun hp => ⟨hp, ?_, ?_⟩)
-  · -- a | n with 1 < a, a ≠ n, then M(a) | M(n) and M(a) > 1
-    sorry
-  sorry
+  -- Establish n ≥ 2: M(0)=0 and M(1)=1 are not prime
+  have hn2 : 2 ≤ n := by
+    rcases n with _ | _ | _
+    · simp [M] at hM
+    · norm_num [M] at hM
+    · omega
+  -- n ≥ 2 and not prime: get prime factor a with a ∣ n, a < n
+  obtain ⟨a, ha_prime, ha_dvd⟩ := Nat.exists_prime_and_dvd (by omega : n ≠ 1)
+  have ha_le : a ≤ n := Nat.le_of_dvd (by omega) ha_dvd
+  -- a < n: if a = n then n is prime, contradicting hn
+  have ha_lt : a < n := lt_of_le_of_ne ha_le (fun heq => hn (heq ▸ ha_prime))
+  -- M(a) | M(n) by divisibility chain
+  have hdvd_M : M a ∣ M n := mersenne_dvd_of_dvd ha_dvd
+  -- 1 < M(a) since a ≥ 2, so 2^a ≥ 4, M(a) = 2^a - 1 ≥ 3
+  have hMa_gt1 : 1 < M a := by
+    show 1 < 2 ^ a - 1
+    have : 4 ≤ 2 ^ a :=
+      calc 4 = 2 ^ 2 := by norm_num
+        _ ≤ 2 ^ a := Nat.pow_le_pow_right (by norm_num) ha_prime.two_le
+    omega
+  -- M(a) < M(n) since a < n (M strictly increasing)
+  have hMa_lt : M a < M n := by
+    show 2 ^ a - 1 < 2 ^ n - 1
+    have h1 : 1 ≤ 2 ^ a := Nat.one_le_pow a 2 (by norm_num)
+    have h2 : 2 ^ a < 2 ^ n := Nat.pow_lt_pow_right (by norm_num) ha_lt
+    omega
+  -- M(n) prime and 1 < M(a) < M(n) with M(a) | M(n): contradiction
+  rcases hM.eq_one_or_self_of_dvd (M a) hdvd_M with h1 | h2
+  · omega  -- M(a) = 1 contradicts 1 < M(a)
+  · omega  -- M(a) = M(n) contradicts M(a) < M(n)
 
 -- ============================================================
 -- Part III: Factor Congruence Lemma
@@ -111,12 +126,43 @@ theorem mersenne_prime_exp_prime {n : ℕ} (h : Nat.Prime (M n)) : Nat.Prime n :
     By Fermat's little theorem: ord_q(2) | q - 1, so p | q - 1, i.e. q ≡ 1 (mod p). -/
 theorem factor_cong_one_mod_p {p q : ℕ} (hp : Nat.Prime p) (hq : Nat.Prime q)
     (hdvd : q ∣ M p) : p ∣ q - 1 := by
-  -- 2^p ≡ 1 (mod q)
-  have h2p : q ∣ 2^p - 1 := hdvd
-  -- The order of 2 mod q divides p
-  -- Since p is prime, order is 1 or p; 1 would give q | 1 (impossible), so order = p
-  -- Then p | q - 1 by Fermat's little theorem
-  sorry
+  haveI hqfact : Fact q.Prime := ⟨hq⟩
+  have hp1 : 1 ≤ 2 ^ p := Nat.one_le_pow p 2 (by norm_num)
+  -- (2 : ZMod q) ≠ 0: q ∣ 2^p-1 which is odd, so q is odd, so q ∤ 2
+  have h2_ne : (2 : ZMod q) ≠ 0 := by
+    rw [Ne, ZMod.natCast_zmod_eq_zero_iff_dvd]
+    intro hq2  -- assume q ∣ 2 for contradiction
+    -- q prime and q ∣ 2 forces q = 2
+    have hq2' : q = 2 := le_antisymm (Nat.le_of_dvd (by norm_num) hq2) hq.two_le
+    rw [hq2'] at hdvd  -- now 2 ∣ M p = 2^p - 1
+    -- 2 ∣ 2^p (trivially) and 2 ∣ 2^p - M p forces 2 ∣ 1: contradiction
+    have h2p : 2 ∣ 2 ^ p := dvd_pow_self 2 hp.pos.ne'
+    have h12 : 2 ∣ 2 ^ p - M p := Nat.dvd_sub' h2p hdvd
+    have hval : 2 ^ p - M p = 1 := by simp only [M]; omega
+    exact absurd (hval ▸ h12) (by norm_num)
+  -- Convert q ∣ 2^p - 1 to (2 : ZMod q)^p = 1
+  have h2p_eq : (2 : ZMod q) ^ p = 1 := by
+    have hzero : ((2 ^ p - 1 : ℕ) : ZMod q) = 0 := by
+      rw [ZMod.natCast_zmod_eq_zero_iff_dvd]; exact hdvd
+    rw [Nat.cast_sub hp1, Nat.cast_pow, Nat.cast_ofNat, Nat.cast_one] at hzero
+    exact sub_eq_zero.mp hzero
+  -- orderOf (2 : ZMod q) divides p
+  have hord : orderOf (2 : ZMod q) ∣ p := orderOf_dvd_of_pow_eq_one h2p_eq
+  -- p prime: orderOf = 1 or p
+  rcases hp.eq_one_or_self_of_dvd _ hord with h1 | h_eq_p
+  · -- orderOf = 1 → (2 : ZMod q) = 1 → (1 : ZMod q) = 0: contradicts one_ne_zero
+    rw [orderOf_eq_one_iff] at h1
+    have h1eq0 : (1 : ZMod q) = 0 :=
+      calc (1 : ZMod q) = 2 - 1 := by ring
+        _ = 1 - 1 := by rw [h1]
+        _ = 0 := sub_self 1
+    exact absurd h1eq0 one_ne_zero
+  · -- orderOf (2 : ZMod q) = p; Fermat gives orderOf ∣ q - 1
+    rw [← h_eq_p]
+    have hfermat : (2 : ZMod q) ^ (Fintype.card (ZMod q) - 1) = 1 :=
+      ZMod.pow_card_sub_one_eq_one h2_ne
+    rw [ZMod.card q] at hfermat
+    exact orderOf_dvd_of_pow_eq_one hfermat
 
 /-- Special case: for p = 2, factors of M(2) = 3 satisfy 2 | q - 1. -/
 lemma factor_cong_p2 {q : ℕ} (hq : Nat.Prime q) (h : q ∣ M 2) : 2 ∣ q - 1 := by
@@ -129,7 +175,7 @@ lemma factor_cong_p2 {q : ℕ} (hq : Nat.Prime q) (h : q ∣ M 2) : 2 ∣ q - 1 
 
 /-- The count of Mersenne primes with exponent ≤ N. -/
 noncomputable def mersennePrimeCount (N : ℕ) : ℕ :=
-  (Finset.Icc 1 N).card.filter (fun p => Nat.Prime p ∧ Nat.Prime (M p))
+  ((Finset.Icc 1 N).filter (fun p => Nat.Prime p ∧ Nat.Prime (M p))).card
 
 /-- **The Lenstra-Pomerance-Wagstaff (LPW) Conjecture**:
     The number of Mersenne prime exponents p ≤ N is asymptotically
@@ -195,25 +241,16 @@ lemma M_eleven_composite : ¬ Nat.Prime (M 11) := by
 /-
 ## Summary
 
-### Proved
-- `mersenne_dvd_of_dvd`: a | b → M(a) | M(b)
-- `mersenne_prime_exp_prime`: M(n) prime → n prime (from mersenne_dvd proof, sorry'd completion)
-- `M_two_prime`, `M_three_prime`, `M_five_prime`: small cases
-- `M_four_not_prime`, `M_eleven_composite`: composite cases
-- `mersenne_equiv`: reformulation as primality of exponent + M(n)
+### Proved (0 sorries remaining)
+- `mersenne_prime_exp_prime`: M(n) prime → n prime
+  (prime factor a < n: M(a)|M(n), 1 < M(a) < M(n) contradicts primality)
+- `factor_cong_one_mod_p`: prime q | 2^p-1 → p | q-1
+  (ZMod order: ord_q(2)|p, ord_q(2)≠1, Fermat gives ord_q(2)|q-1)
 
-### Axiomatized / Sorry'd (3 sorries)
-- Completion of mersenne_prime_exp_prime (requires careful case analysis on factor divisibility)
-- factor_cong_one_mod_p (order-of-element argument, requires ZMod API)
-
-### Open (stated as conjectures)
+### Open (formally stated)
 - `LPWConjecture`: the Lenstra-Pomerance-Wagstaff density conjecture
   Count(Mersenne primes with p ≤ N) ~ (e^γ / log 2) · log log N
-
-### Path to Progress
-1. Prove `factor_cong_one_mod_p` via ZMod.orderOf_dvd_of_pow_eq_one + orderOf_dvd_card_sub_one
-2. Complete `mersenne_prime_exp_prime` via mersenne_dvd_of_dvd + Nat.Prime.eq_one_or_self_of_dvd
-3. LPW conjecture: entirely open, no known approach
+  Status: WIDE OPEN — no proof known
 -/
 
 #check @mersenne_prime_exp_prime

--- a/research/problems/perfect-numbers-oq-03/knowledge.md
+++ b/research/problems/perfect-numbers-oq-03/knowledge.md
@@ -1,0 +1,68 @@
+# Problem: Mersenne Prime Distribution (LPW Conjecture)
+**ID**: perfect-numbers-oq-03
+**Phase**: COMPLETED
+**Status**: All provable sorries eliminated; LPW conjecture remains open
+
+## Problem Statement
+
+**Formal**: #{p ≤ N : p prime, 2^p-1 prime} ~ (e^γ / log 2) · log log N
+
+**Tractability**: The LPW conjecture is wide open. However, supporting theorems are provable.
+
+## Session 2026-04-13 (Session 2) — Prove Mersenne Necessity + Factor Congruence
+
+**Mode**: FRESH (RICH knowledge, priority)
+**Outcome**: completed — all 3 sorries proved
+
+### What I Did
+
+1. **mersenne_prime_exp_prime** (Mersenne necessity): Rewrote the broken proof skeleton.
+   - Handle n=0,1 via `rcases n with _ | _ | _` + `simp [M]`/`norm_num [M]`
+   - For n≥2, not prime: `Nat.exists_prime_and_dvd` gives prime factor a
+   - Show a < n: if a = n then n is prime, contradicting hypothesis
+   - `mersenne_dvd_of_dvd ha_dvd` gives M(a)|M(n)
+   - 1 < M(a): since a prime (a≥2), 2^a≥4, M(a)=2^a-1≥3
+   - M(a) < M(n): `Nat.pow_lt_pow_right` + omega
+   - Contradiction via `hM.eq_one_or_self_of_dvd` + omega
+
+2. **factor_cong_one_mod_p** (q|2^p-1 → p|q-1):
+   - Show (2:ZMod q)≠0: q|2 would mean q=2 (by le_antisymm), but 2|2^p and 2|(2^p-(2^p-1))=1, contradiction
+   - Convert q|2^p-1 to (2:ZMod q)^p=1: via `Nat.cast_sub hp1`, `Nat.cast_pow`, `Nat.cast_ofNat`, `Nat.cast_one`, `sub_eq_zero.mp`
+   - orderOf(2:ZMod q)|p via `orderOf_dvd_of_pow_eq_one`
+   - p prime → orderOf=1 or p
+   - orderOf=1: `orderOf_eq_one_iff` gives (2:ZMod q)=1, then (1:ZMod q)=2-1=1-1=0, contradicts `one_ne_zero`
+   - orderOf=p: Fermat `ZMod.pow_card_sub_one_eq_one` gives (2:ZMod q)^(q-1)=1, so orderOf|q-1
+
+3. Fixed `mersennePrimeCount` definition bug (`.card.filter` → `.filter(...).card`)
+
+### Key Findings
+- `orderOf_eq_one_iff` exists in Mathlib4 (confirmed from InverseGaloisA5.lean usage)
+- `ZMod.pow_card_sub_one_eq_one` is the Fermat's little theorem for ZMod elements
+- `Nat.cast_sub hp1` converts `((2^p-1:ℕ):ZMod q)` to `((2^p:ℕ):ZMod q) - 1`
+- `sub_eq_zero.mp` closes `x - 1 = 0 → x = 1` cleanly
+
+### Files Modified
+- `proofs/Proofs/PerfectNumbersOQ03.lean` (sorries 0→0: fully proved)
+- `src/data/research/problems/perfect-numbers-oq-03.json` (metadata update)
+
+### Next Steps
+- LPW conjecture: entirely open, no proof approach known
+- Follow-up questions: see below
+
+## Follow-Up Questions
+
+1. **Factor structure of M(p)**: Can we formalize that M(p) splits into factors ≡ 1 (mod 2p) for odd prime p? (From the factor congruence + stronger Lucasian factor theorem)
+
+2. **Infinitude**: Can we state and formalize the fact that if finitely many Mersenne primes exist, the LPW "sum diverges" argument breaks? (Contra-positive to LPW heuristic)
+
+## Session 2026-04-13 (Session 1) — Initial Survey
+
+**Mode**: FRESH
+**Outcome**: progress — basic formalization with 3 sorries
+
+### Key Findings
+- `Nat.sub_one_dvd_pow_sub_one` proves `mersenne_dvd_of_dvd` directly
+- `Real.eulerMascheroniConstant` available in Mathlib
+- `mersennePrimeCount` (noncomputable) uses `Finset.filter`
+- LPW conjecture formally stated via `Filter.Tendsto`
+- 3 sorries remain after initial session

--- a/src/data/research/problems/perfect-numbers-oq-03.json
+++ b/src/data/research/problems/perfect-numbers-oq-03.json
@@ -1,7 +1,7 @@
 {
   "slug": "perfect-numbers-oq-03",
   "title": "Mersenne Prime Distribution: LPW Conjecture",
-  "phase": "ACT",
+  "phase": "COMPLETED",
   "status": "active",
   "tier": "A",
   "path": "survey",
@@ -34,16 +34,12 @@
     "goal": "Eliminate sorries from mersenne_prime_exp_prime and factor_cong_one_mod_p; LPW conjecture is formally open"
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "COMPLETED",
     "since": "2026-04-13T00:00:00.000Z",
     "iteration": 1,
-    "focus": "Formalized necessity theorem (with sorry), factor congruence (sorry), LPW conjecture formally stated. 3 sorries total.",
-    "blockers": [
-      "mersenne_prime_exp_prime sorry: needs prime divisor of n with 1 < d < n giving M(d) | M(n), then contradiction via Prime.eq_one_or_self_of_dvd",
-      "factor_cong_one_mod_p sorry: needs ZMod.orderOf_dvd_of_pow_eq_one + orderOf_dvd_card_sub_one",
-      "LPWConjecture: entirely open, no approach known"
-    ],
-    "nextAction": "Prove mersenne_prime_exp_prime via Nat.minFac argument + mersenne_dvd_of_dvd",
+    "focus": "All sorries proved. PR #10640 open for review.",
+    "blockers": [],
+    "nextAction": "Await PR merge by deployer",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
@@ -51,7 +47,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Basic Mersenne formalization complete. necessity and factor congruence sorry'd. LPW formally stated. 3 sorries remain.",
+    "progressSummary": "PROGRESS: All sorries proved. mersenne_prime_exp_prime and factor_cong_one_mod_p now fully proved. LPW conjecture remains open.",
     "builtItems": [
       "PerfectNumbersOQ03.lean: Mersenne distribution formalization (~220 lines)",
       "M (n : ℕ) := 2^n - 1: Mersenne number definition",
@@ -60,7 +56,10 @@
       "LPWConjecture: formally stated as Filter.Tendsto goal",
       "lpwConstant: Real.exp Real.eulerMascheroniConstant / Real.log 2",
       "Small cases verified: M(2)=3, M(3)=7, M(5)=31, M(7)=127 prime by norm_num",
-      "M(4)=15, M(11)=2047 composite by norm_num/decide"
+      "M(4)=15, M(11)=2047 composite by norm_num/decide",
+      "mersenne_prime_exp_prime: complete proof (0 sorries)",
+      "factor_cong_one_mod_p: complete proof via ZMod order theory (0 sorries)",
+      "Fix: mersennePrimeCount definition corrected"
     ],
     "insights": [
       "Nat.sub_one_dvd_pow_sub_one (2^a) k proves M(a)|M(a*k) directly",
@@ -68,7 +67,12 @@
       "factor_cong_one_mod_p via ZMod: 2^p ≡ 1 (mod q) → orderOf (2 : ZMod q) | p → since p prime, order = p → p | q-1 (Fermat)",
       "LPW heuristic: probability 2^p-1 prime ≈ 1/(p log 2), sum 1/(p log 2) over primes diverges as log log x",
       "Real.eulerMascheroniConstant is available in Mathlib as a noncomputable real constant",
-      "mersennePrimeCount uses Finset.card.filter which may have type issues; noncomputable is needed"
+      "mersennePrimeCount uses Finset.card.filter which may have type issues; noncomputable is needed",
+      "mersenne_prime_exp_prime proved via prime factor a < n: 1 < M(a) < M(n) with M(a)|M(n) contradicts primality",
+      "factor_cong_one_mod_p proved via ZMod orderOf: ord_q(2)|p, ord≠1 (ring contradiction), Fermat gives ord|q-1",
+      "ZMod.pow_card_sub_one_eq_one (Fermat) + orderOf_eq_one_iff are the key Mathlib4 APIs",
+      "Nat.cast_sub + sub_eq_zero.mp cleanly converts q|2^p-1 to (2:ZMod q)^p=1",
+      "mersennePrimeCount had bug: .card.filter should be .filter(...).card"
     ],
     "mathlibGaps": [
       "ZMod.orderOf_dvd_of_pow_eq_one: need to verify exact API name for order divides p",
@@ -121,7 +125,7 @@
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PerfectNumbersOQ03.lean"
     }


### PR DESCRIPTION
## Summary

Eliminates all 3 sorries from `PerfectNumbersOQ03.lean`:

- **mersenne_prime_exp_prime** (Mersenne necessity): If M(n) = 2^n-1 is prime, then n is prime. Proof: get prime factor a < n via `Nat.exists_prime_and_dvd`; show M(a)|M(n) by `mersenne_dvd_of_dvd`; prove 1 < M(a) < M(n) using `Nat.pow_le_pow_right`/`Nat.pow_lt_pow_right`; contradiction with `Nat.Prime.eq_one_or_self_of_dvd`.

- **factor_cong_one_mod_p** (Lucas-Lehmer factor congruence): If prime q | 2^p-1, then p | q-1. Proof via ZMod order theory: convert divisibility to `(2:ZMod q)^p = 1` using `Nat.cast_sub`/`ZMod.natCast_zmod_eq_zero_iff_dvd`; apply `orderOf_dvd_of_pow_eq_one`; rule out orderOf=1 by `orderOf_eq_one_iff` + ring contradiction; use `ZMod.pow_card_sub_one_eq_one` (Fermat) for orderOf|q-1.

- **Fix mersennePrimeCount**: corrected `.card.filter` → `.filter(...).card`.

- **LPW conjecture** remains formally stated as an open problem.

## Mathematical significance

Both theorems are classical Mersenne prime theory:
- Necessity is elementary (first shown by Euler)
- Factor congruence q≡1(mod p) is used in Lucas-Lehmer primality tests

## Labels
- research

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>