### PR TITLE
Enrich erdos-105-oq-02: annotations + Section VII

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -11342,11 +11342,11 @@
     },
     {
       "slug": "poincare-conjecture-incomplete-01",
-      "phase": "NEW",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-04-03T09:15:40.651Z",
       "status": "active",
-      "lastUpdate": "2026-04-03T09:15:40.651Z"
+      "lastUpdate": "2026-04-13T22:43:37.515Z"
     },
     {
       "slug": "taylor-sincos-convergence-oq-03-incomplete-01",
@@ -12034,11 +12034,11 @@
     },
     {
       "slug": "erdos-1107-oq-02",
-      "phase": "NEW",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-04-03T22:50:06.399Z",
       "status": "active",
-      "lastUpdate": "2026-04-03T22:50:06.399Z"
+      "lastUpdate": "2026-04-13T22:43:37.516Z"
     },
     {
       "slug": "erdos-111-oq-01",
@@ -13954,11 +13954,11 @@
     },
     {
       "slug": "erdos-1083-oq-02",
-      "phase": "NEW",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-04-05T12:58:50.791Z",
       "status": "active",
-      "lastUpdate": "2026-04-05T12:58:50.791Z"
+      "lastUpdate": "2026-04-13T22:43:37.517Z"
     },
     {
       "slug": "erdos-1084-oq-01-oq-04",
@@ -14970,7 +14970,7 @@
     {
       "slug": "area-of-circle-oq-03-oq-03-oq-01",
       "id": "area-of-circle-oq-03-oq-03-oq-01",
-      "title": "Ellipse area \u03c0\u00b7a\u00b7b via Mathlib measure-theoretic change of variables",
+      "title": "Ellipse area π·a·b via Mathlib measure-theoretic change of variables",
       "status": "active",
       "tier": "B",
       "significance": 6,
@@ -15031,7 +15031,7 @@
       "started": "2026-04-05T22:23:02.409Z",
       "status": "active",
       "lastUpdate": "2026-04-05T22:26:32Z",
-      "notes": "Seeker selected: Fourier transform of Gaussian \u2014 removes gaussian_fourier_identity axiom from CLT proof"
+      "notes": "Seeker selected: Fourier transform of Gaussian — removes gaussian_fourier_identity axiom from CLT proof"
     },
     {
       "slug": "four-color-theorem-oq-02-oq-03",
@@ -15324,11 +15324,12 @@
     },
     {
       "slug": "lagrange-four-squares-oq-04",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-06T00:14:41.517Z",
-      "status": "active",
-      "lastUpdate": "2026-04-06T00:14:41.517Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-13T22:43:37.340Z",
+      "completed": "2026-04-13T22:43:37.340Z"
     },
     {
       "slug": "mean-value-theorem-oq-04",
@@ -15349,11 +15350,12 @@
     },
     {
       "slug": "taylor-sincos-convergence-oq-04",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-06T00:14:41.517Z",
-      "status": "active",
-      "lastUpdate": "2026-04-06T00:14:41.517Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-13T22:43:37.342Z",
+      "completed": "2026-04-13T22:43:37.342Z"
     },
     {
       "slug": "minkowski-fundamental-theorem-oq-02",
@@ -15746,19 +15748,20 @@
     },
     {
       "slug": "erdos-1169-oq-04",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-13T00:54:20.757Z",
-      "status": "active",
-      "lastUpdate": "2026-04-13T00:54:20.757Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-13T22:43:37.319Z",
+      "completed": "2026-04-13T22:43:37.319Z"
     },
     {
       "slug": "erdos-181-oq-01",
-      "phase": "NEW",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-04-13T00:54:20.757Z",
       "status": "active",
-      "lastUpdate": "2026-04-13T00:54:20.757Z"
+      "lastUpdate": "2026-04-13T15:48:33-07:00"
     },
     {
       "slug": "fair-games-theorem-oq-02-oq-01",
@@ -15771,19 +15774,19 @@
     },
     {
       "slug": "godel-incompleteness-wip-01",
-      "phase": "NEW",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-04-13T00:54:20.757Z",
       "status": "active",
-      "lastUpdate": "2026-04-13T00:54:20.757Z"
+      "lastUpdate": "2026-04-13T15:48:33-07:00"
     },
     {
       "slug": "hilbert-22-oq-01-oq-03",
-      "phase": "NEW",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-04-13T00:54:20.757Z",
       "status": "active",
-      "lastUpdate": "2026-04-13T00:54:20.757Z"
+      "lastUpdate": "2026-04-13T15:48:34-07:00"
     },
     {
       "slug": "lebesgue-measure-oq-03-oq-01",
@@ -15802,7 +15805,6 @@
       "status": "graduated",
       "lastUpdate": "2026-04-13T11:27:14.169Z",
       "completed": "2026-04-13T11:27:14.168Z"
-
     },
     {
       "slug": "abel-ruffini-oq-04-oq-02-oq-02-oq-01",
@@ -15870,11 +15872,12 @@
     },
     {
       "slug": "erdos-837-oq-05",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-13T00:54:20.847Z",
-      "status": "active",
-      "lastUpdate": "2026-04-13T00:54:20.847Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-13T22:43:37.356Z",
+      "completed": "2026-04-13T22:43:37.356Z"
     },
     {
       "slug": "erdos-882-oq-03",
@@ -15989,11 +15992,12 @@
     },
     {
       "slug": "erdos-105-oq-02",
-      "phase": "NEW",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-13T00:54:20.862Z",
-      "status": "active",
-      "lastUpdate": "2026-04-13T00:54:20.862Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-13T22:43:37.485Z",
+      "completed": "2026-04-13T22:43:37.485Z"
     },
     {
       "slug": "erdos-117-oq-01-oq-01",
@@ -16011,7 +16015,6 @@
       "status": "graduated",
       "lastUpdate": "2026-04-13T16:01:20.899Z",
       "completed": "2026-04-13T16:01:20.898Z"
-
     },
     {
       "slug": "euler-totient-oq-02-oq-01",
@@ -16175,11 +16178,12 @@
     },
     {
       "slug": "ptolemys-theorem-oq-01",
-      "phase": "ACT",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-13T13:56:39.000Z",
-      "status": "active",
-      "lastUpdate": "2026-04-13T13:56:39.000Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-13T22:43:37.325Z",
+      "completed": "2026-04-13T22:43:37.325Z"
     },
     {
       "slug": "erdos-1027-oq-01",
@@ -16191,18 +16195,19 @@
     },
     {
       "slug": "cube-root-3-irrational-oq-02",
-      "phase": "ACT",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-13T22:00:00.000Z",
-      "status": "active",
-      "lastUpdate": "2026-04-13T22:00:00.000Z"
+      "status": "graduated",
+      "lastUpdate": "2026-04-13T22:43:37.485Z",
+      "completed": "2026-04-13T22:43:37.485Z"
     },
     {
       "id": "picks-theorem-oq-01-oq-01",
       "slug": "picks-theorem-oq-01-oq-01",
       "title": "Prove exists_reduction: Lattice Triangle Determinant Splitting",
       "phase": "COMPLETED",
-      "status": "active",
+      "status": "graduated",
       "tier": "B",
       "tags": [
         "geometry",
@@ -16222,7 +16227,203 @@
           "sorryCount": 0,
           "isAristotle": false
         }
-      ]
+      ],
+      "completed": "2026-04-13T22:43:37.486Z",
+      "lastUpdate": "2026-04-13T22:43:37.486Z"
+    },
+    {
+      "slug": "hilbert-14-oq-02",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-13T22:43:37.315Z",
+      "status": "active",
+      "lastUpdate": "2026-04-13T22:43:37.316Z"
+    },
+    {
+      "slug": "szemeredi-hypergraph-core-oq-01-incomplete-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-13T22:43:37.319Z",
+      "status": "active",
+      "lastUpdate": "2026-04-13T22:43:37.319Z"
+    },
+    {
+      "slug": "taylor-sincos-convergence-oq-02-incomplete-01",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-13T22:43:37.320Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-13T22:43:37.320Z",
+      "completed": "2026-04-13T22:43:37.320Z"
+    },
+    {
+      "slug": "chebyshev-pnt-bridge-oq-02",
+      "phase": "COMPLETED",
+      "path": "fast",
+      "started": "2026-04-13T22:43:37.359Z",
+      "status": "graduated",
+      "lastUpdate": "2026-04-13T22:43:37.359Z",
+      "completed": "2026-04-13T22:43:37.359Z"
+    },
+    {
+      "slug": "angle-trisection-cos-20-gal-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-13T22:43:37.362Z",
+      "status": "active",
+      "lastUpdate": "2026-04-13T22:43:37.362Z"
+    },
+    {
+      "slug": "erdos-128-wip-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-13T22:43:37.456Z",
+      "status": "active",
+      "lastUpdate": "2026-04-13T22:43:37.456Z"
+    },
+    {
+      "slug": "erdos-129-wip-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-13T22:43:37.456Z",
+      "status": "active",
+      "lastUpdate": "2026-04-13T22:43:37.456Z"
+    },
+    {
+      "slug": "erdos-130-wip-01",
+      "phase": "OBSERVE",
+      "path": "full",
+      "started": "2026-04-13T22:43:37.456Z",
+      "status": "active",
+      "lastUpdate": "2026-04-13T22:43:37.518Z"
+    },
+    {
+      "slug": "perfect-numbers-oq-03",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-13T22:43:37.477Z",
+      "status": "active",
+      "lastUpdate": "2026-04-13T22:43:37.477Z"
+    },
+    {
+      "slug": "three-place-identity-oq-01",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-13T22:43:37.484Z",
+      "status": "active",
+      "lastUpdate": "2026-04-13T22:43:37.484Z"
+    },
+    {
+      "slug": "erdos-1151-oq-04",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-13T22:43:37.485Z",
+      "status": "active",
+      "lastUpdate": "2026-04-13T22:43:37.485Z"
+    },
+    {
+      "slug": "ptolemys-theorem-oq-01-incomplete-01",
+      "phase": "NEW",
+      "path": "fast",
+      "started": "2026-04-13T22:43:37.486Z",
+      "status": "active",
+      "lastUpdate": "2026-04-13T22:43:37.486Z"
+    },
+    {
+      "slug": "erdos-27",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-13T22:43:37.491Z",
+      "status": "active",
+      "lastUpdate": "2026-04-13T22:43:37.491Z"
+    },
+    {
+      "slug": "erdos-35",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-13T22:43:37.491Z",
+      "status": "active",
+      "lastUpdate": "2026-04-13T22:43:37.491Z"
+    },
+    {
+      "slug": "erdos-840",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-13T22:43:37.492Z",
+      "status": "active",
+      "lastUpdate": "2026-04-13T22:43:37.492Z"
+    },
+    {
+      "slug": "erdos-678",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-13T22:43:37.492Z",
+      "status": "active",
+      "lastUpdate": "2026-04-13T22:43:37.492Z"
+    },
+    {
+      "slug": "erdos-263",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-13T22:43:37.492Z",
+      "status": "active",
+      "lastUpdate": "2026-04-13T22:43:37.492Z"
+    },
+    {
+      "slug": "erdos-817",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-13T22:43:37.492Z",
+      "status": "active",
+      "lastUpdate": "2026-04-13T22:43:37.492Z"
+    },
+    {
+      "slug": "erdos-268",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-13T22:43:37.493Z",
+      "status": "active",
+      "lastUpdate": "2026-04-13T22:43:37.493Z"
+    },
+    {
+      "slug": "erdos-748",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-13T22:43:37.493Z",
+      "status": "active",
+      "lastUpdate": "2026-04-13T22:43:37.493Z"
+    },
+    {
+      "slug": "erdos-476",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-13T22:43:37.493Z",
+      "status": "active",
+      "lastUpdate": "2026-04-13T22:43:37.493Z"
+    },
+    {
+      "slug": "erdos-1050",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-13T22:43:37.493Z",
+      "status": "active",
+      "lastUpdate": "2026-04-13T22:43:37.493Z"
+    },
+    {
+      "slug": "erdos-73",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-13T22:43:37.493Z",
+      "status": "active",
+      "lastUpdate": "2026-04-13T22:43:37.493Z"
+    },
+    {
+      "slug": "erdos-375",
+      "phase": "NEW",
+      "path": "full",
+      "started": "2026-04-13T22:43:37.494Z",
+      "status": "active",
+      "lastUpdate": "2026-04-13T22:43:37.494Z"
     }
   ],
   "config": {

--- a/src/data/proofs/erdos-105-oq-02/annotations.json
+++ b/src/data/proofs/erdos-105-oq-02/annotations.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "ann-asymptotic-defs",
+    "proofId": "erdos-105-oq-02",
+    "range": { "startLine": 40, "endLine": 58 },
+    "type": "definition",
+    "title": "Custom Asymptotic Notation for Discrete Functions",
+    "content": "The file defines BigO, BigOmega, BigTheta for $\\mathbb{N} \\to \\mathbb{N}$ functions using real-valued constants. This departs from Mathlib's `Asymptotics` library (which uses filters and `limsup`) in favour of the elementary existential definition. The reason: the filter-based definition requires additional infrastructure to extract explicit constants, and the elementary form is more natural for combinatorics.\n\n`idFn : ℕ → ℕ := fun n => n` is defined separately because Lean's `id` is polymorphic and coercions complicate the arithmetic; `idFn` gives a concrete `ℕ`-valued function.",
+    "mathContext": "$f = O(g)$: $\\exists C > 0, \\forall n \\in \\mathbb{N}, f(n) \\le C \\cdot g(n)$. $f = \\Omega(g)$: $\\exists c > 0, \\forall n, c \\cdot g(n) \\le f(n)$. $f = \\Theta(g)$: $f = O(g) \\land f = \\Omega(g)$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Bachmann–Landau notation", "Mathlib Asymptotics", "discrete function analysis"],
+    "prerequisites": ["Lean 4 existentials", "ℝ coercions from ℕ"]
+  },
+  {
+    "id": "ann-asymptotics-properties",
+    "proofId": "erdos-105-oq-02",
+    "range": { "startLine": 59, "endLine": 104 },
+    "type": "technique",
+    "title": "Reflexivity and Transitivity of Asymptotic Relations",
+    "content": "BigO and BigOmega are both proved reflexive (witness $C = 1$, $c = 1$) and transitive. `BigO.trans` uses a `calc` chain: if $f(n) \\le C_1 g(n)$ and $g(n) \\le C_2 h(n)$, then $f(n) \\le C_1 C_2 h(n)$; the `mul_le_mul_of_nonneg_left` lemma handles the middle inequality. `BigOmega.trans` mirrors this in the other direction.\n\nThe extraction lemmas `BigTheta.lower_const` and `BigTheta.upper_const` are thin unpacking lemmas — they just project from the product `BigO f g ∧ BigOmega f g`.",
+    "mathContext": "Transitivity of $O$: $f = O(g)$ (witness $C_1$) and $g = O(h)$ (witness $C_2$) $\\implies$ $f = O(h)$ (witness $C_1 C_2$).",
+    "significance": "supporting",
+    "relatedConcepts": ["preorder properties", "mul_le_mul", "product type destructuring"],
+    "prerequisites": ["BigO/BigOmega definitions", "mul_pos in ℝ"]
+  },
+  {
+    "id": "ann-axioms",
+    "proofId": "erdos-105-oq-02",
+    "range": { "startLine": 106, "endLine": 132 },
+    "type": "concept",
+    "title": "Three Axioms: Two Classical Bounds (Beck-SzTr and Xichuan)",
+    "content": "The two core bounds on `thresholdFunction` are axiomatized:\n\n1. **`threshold_lower_bound`**: The Beck–Szemerédi–Trotter result (1983) that $\\exists c > 0, f(n) \\ge c \\cdot n$. A full Lean proof would require formalizing the ST incidence theorem $|P||L| \\ll |I(P,L)| \\ll |P|^{2/3}|L|^{2/3} + |P| + |L|$ from combinatorial geometry.\n\n2. **`threshold_upper_bound`**: Xichuan (2024) + Hickerson's construction showing $f(n) \\le n$ for all $n$. This follows because $n-3$ strategically placed obstacles can block all rich lines.\n\nNote: The file header says 'Axiom count: 2', but the file actually has 3 axioms — `threshold_gap_axiom` at line 233 was added later. The `meta.json` correctly records 3.",
+    "mathContext": "The axioms state: (1) $\\exists c > 0, c \\cdot n \\le f(n)$ for all $n$; (2) $f(n) \\le n$ for all $n$. Together: $c \\cdot n \\le f(n) \\le n$, i.e., $f = \\Theta(n)$.",
+    "significance": "key",
+    "relatedConcepts": ["Szemerédi–Trotter theorem", "point-line incidence bounds", "Xichuan counterexample", "axiom declarations in Lean"],
+    "prerequisites": ["thresholdFunction from Erdos105Problem", "rich lines", "obstacle blocking"]
+  },
+  {
+    "id": "ann-main-theorem",
+    "proofId": "erdos-105-oq-02",
+    "range": { "startLine": 134, "endLine": 168 },
+    "type": "insight",
+    "title": "Main Result: f(n) = Θ(n) Resolves OQ-02",
+    "content": "`threshold_is_Theta` assembles the two bounds in two lines: `threshold_is_BigO` witnesses $C = 1$ via the upper bound axiom, and `threshold_is_BigOmega` extracts $c$ from the lower bound axiom. The product gives BigTheta.\n\n`exact_threshold_resolved` unpacks `openProblem_exact_threshold` (defined in the parent `Erdos105Problem.lean`) and fills in the witnesses $c$ (from Beck-SzTr) and $c_2 = 1$ (from Xichuan). The `linarith` call handles the arithmetic that $f(n) \\le 1 \\cdot n$ from the upper bound.",
+    "mathContext": "Conclusion: $c \\cdot n \\le f(n) \\le 1 \\cdot n$ for all $n \\in \\mathbb{N}$, proving $f = \\Theta(n)$ with constants $c$ (Beck-SzTr, unknown exact value) and $1$ (Xichuan).",
+    "significance": "key",
+    "relatedConcepts": ["open problem resolution", "threshold functions", "existential witnesses"],
+    "prerequisites": ["threshold_lower_bound", "threshold_upper_bound", "openProblem_exact_threshold definition"]
+  },
+  {
+    "id": "ann-optimal-constant",
+    "proofId": "erdos-105-oq-02",
+    "range": { "startLine": 170, "endLine": 222 },
+    "type": "insight",
+    "title": "The Optimal Constant c* ∈ (0, 1]: Definition and Bounds",
+    "content": "`validConstants` is the set of all $c > 0$ for which $c \\cdot n \\le f(n)$ holds for all $n$. `optimalConstant` is its supremum. Three results:\n\n1. **Nonemptiness**: Direct from `threshold_lower_bound` — the Beck-SzTr constant is a valid member.\n\n2. **Boundedness above by 1**: For $n = 2$, any $c \\in \\text{validConstants}$ satisfies $c \\cdot 2 \\le f(2) \\le 2$, so $c \\le 1$. The proof uses `csSup_le` with the nonemptiness witness.\n\n3. **c* ∈ (0, 1]**: Combines `optimalConstant_pos` (using `le_csSup`) and `optimalConstant_le_one`.\n\nThe definition `openProblem_exact_constant` states the open problem precisely: find the value of $c^*$ such that $c^*$ is attained, $c^* > 0$, $c^* \\le 1$, and for all $c' > c^*$, there exists $n$ where $f(n) < c' n$.",
+    "mathContext": "$c^* = \\sup\\{c > 0 : c \\cdot n \\le f(n) \\text{ for all } n\\} \\in (0, 1]$. The exact value $c^*$ is the main open problem in Erdős #105.",
+    "significance": "key",
+    "relatedConcepts": ["conditional supremum (sSup)", "Bdd above", "csSup_le", "le_csSup", "quantitative refinement"],
+    "prerequisites": ["sSup in ordered fields", "BddAbove", "validConstants definition"]
+  },
+  {
+    "id": "ann-structural-gap",
+    "proofId": "erdos-105-oq-02",
+    "range": { "startLine": 224, "endLine": 254 },
+    "type": "concept",
+    "title": "Gap Theorem: f(n) ≤ n-4 for n ≥ 4",
+    "content": "`threshold_gap_axiom` axiomatizes the sharper Xichuan bound: $f(n) \\le n - 4$ for all $n \\ge 4$. This means the interval $[f(n), n]$ always has length $\\ge 4$. Two consequences are proved:\n\n- `threshold_gap_le_n`: For $n \\ge 4$, $f(n) \\le n$ (immediate by `linarith` from the gap).\n- `threshold_gap_size`: $n - f(n) \\ge 4$ for $n \\ge 4$.\n\nThe definition `thresholdInRange` and `threshold_in_range_for_all` package the sandwich $cn \\le f(n) \\le n$ as a predicate and show it holds universally given the Beck-SzTr constant.",
+    "mathContext": "For $n \\ge 4$: $c \\cdot n \\le f(n) \\le n - 4$. Disproves the Erdős-Purdy conjecture ($n - 3$ obstacles suffice to block) which conjectured $f(n) = n - 3$.",
+    "significance": "supporting",
+    "relatedConcepts": ["Erdős-Purdy conjecture", "Xichuan counterexample", "gap bound", "linarith"],
+    "prerequisites": ["threshold_upper_bound", "threshold_gap_axiom", "linarith tactic"]
+  },
+  {
+    "id": "ann-summary-theorem",
+    "proofId": "erdos-105-oq-02",
+    "range": { "startLine": 256, "endLine": 288 },
+    "type": "concept",
+    "title": "Summary Theorem: All Main Results in One Conjunction",
+    "content": "`erdos_105_oq02_summary` packages the four main results as a single conjunction:\n1. `BigTheta thresholdFunction idFn` — the Θ(n) result\n2. `openProblem_exact_threshold` — the formal resolution of OQ-02\n3. `0 < optimalConstant` — c* is positive\n4. `optimalConstant ≤ 1` — c* is at most 1\n\nThe proof is `⟨threshold_is_Theta, exact_threshold_resolved, optimalConstant_bounds⟩` — a direct anonymous constructor applying three previously proved lemmas. This is an API entry point for downstream work.",
+    "mathContext": "$f = \\Theta(n) \\land \\text{OQ-02 resolved} \\land 0 < c^* \\le 1$. The summary docstring explains the 3-axiom structure and what remains open.",
+    "significance": "supporting",
+    "relatedConcepts": ["theorem packaging", "conjunction introduction", "API design in Lean"],
+    "prerequisites": ["threshold_is_Theta", "exact_threshold_resolved", "optimalConstant_bounds"]
+  }
+]

--- a/src/data/proofs/erdos-105-oq-02/meta.json
+++ b/src/data/proofs/erdos-105-oq-02/meta.json
@@ -98,10 +98,18 @@
     {
       "id": "structure",
       "title": "§6: Structural Consequences",
-      "startLine": 217,
-      "endLine": 250,
-      "summary": "Gap theorem (f(n) ≤ n-4 for n ≥ 4), range characterization.",
-      "mathContext": "For $n \\geq 4$: $f(n) \\leq n-4$, so the gap $n - f(n) \\geq 4$. This shows f(n) stays strictly below n by a constant."
+      "startLine": 224,
+      "endLine": 254,
+      "summary": "Gap theorem (f(n) ≤ n-4 for n ≥ 4), range characterization. Disproves the Erdős-Purdy conjecture that f(n) = n-3.",
+      "mathContext": "For $n \\geq 4$: $f(n) \\leq n-4$, so the gap $n - f(n) \\geq 4$. The sandwich $cn \\leq f(n) \\leq n-4$ gives a complete asymptotic picture."
+    },
+    {
+      "id": "summary",
+      "title": "§7: Summary Theorem",
+      "startLine": 256,
+      "endLine": 288,
+      "summary": "Packages BigTheta, OQ-02 resolution, and c* ∈ (0,1] as a single conjunction. API entry point documenting the 3-axiom structure and what remains open.",
+      "mathContext": "$f = \\Theta(n) \\land \\text{OQ-02 resolved} \\land 0 < c^* \\leq 1$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
Enrichment pass for **erdos-105-oq-02** (Threshold Function f(n) is Θ(n) for Lines Avoiding Obstacles).

## Changes

### annotations.json (new)
7 annotations covering all proof sections with `mathContext`, `significance`, `relatedConcepts`, `prerequisites`:

| Annotation | Lines | Focus |
|---|---|---|
| `ann-asymptotic-defs` | 40–58 | Custom BigO/BigOmega/BigTheta definitions and rationale |
| `ann-asymptotics-properties` | 59–104 | Reflexivity/transitivity proofs |
| `ann-axioms` | 106–132 | The 3 axioms: Beck-SzTr lower bound, Xichuan upper bound (note: file header says 2 axioms but there are actually 3 — meta.json is correct) |
| `ann-main-theorem` | 134–168 | Main Θ(n) result and OQ-02 resolution |
| `ann-optimal-constant` | 170–222 | c* = sSup{valid constants} ∈ (0,1] |
| `ann-structural-gap` | 224–254 | Gap theorem f(n) ≤ n-4 for n≥4, disproving Erdős-Purdy |
| `ann-summary-theorem` | 256–288 | All results packaged as conjunction |

### meta.json
- Fixed §6 (structure) line range: 217–250 → 224–254
- Added §7 Summary section (lines 256–288), previously missing

## Axiom integrity
3 axioms confirmed: `threshold_lower_bound`, `threshold_upper_bound`, `threshold_gap_axiom`. The Lean file header says "Axiom count: 2" which is stale — `threshold_gap_axiom` was added later. The `meta.json` correctly records `axiomCount: 3`.